### PR TITLE
feat: Make search parameters configurable in HybridSearch

### DIFF
--- a/internal/types/search.go
+++ b/internal/types/search.go
@@ -50,10 +50,10 @@ type SearchResult struct {
 
 // SearchParams represents the search parameters
 type SearchParams struct {
-	QueryText        string
-	VectorThreshold  float64
-	KeywordThreshold float64
-	MatchCount       int
+	QueryText        string  `json:"query_text"`
+	VectorThreshold  float64 `json:"vector_threshold"`
+	KeywordThreshold float64 `json:"keyword_threshold"`
+	MatchCount       int     `json:"match_count"`
 }
 
 // Value implements the driver.Valuer interface, used to convert SearchResult to database value


### PR DESCRIPTION
Problem: The HybridSearch function used hardcoded values for search parameters, making it inflexible and difficult to maintain.

Solution: The search parameters are now configurable and can be passed in the request body.


Impact: This change improves the flexibility and usability of the HybridSearch function, allowing for dynamic adjustment of search parameters without code modification. This also improves code quality and maintainability.