### PR TITLE
refactor:重构了start_all.sh启动脚本和docker构建文件，适配新版本docke compose和centos9str…

### DIFF
--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -4,7 +4,8 @@ FROM golang:1.24-alpine AS builder
 WORKDIR /app
 
 # Install dependencies
-RUN apk add --no-cache git build-base
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories && \
+    apk add --no-cache git build-base
 
 # 通过构建参数接收敏感信息
 ARG GOPRIVATE_ARG

--- a/docker/Dockerfile.docreader
+++ b/docker/Dockerfile.docreader
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
     zlib1g-dev \
     libpq-dev \
     libffi-dev \
-    libgl1-mesa-glx \
+    libgl1 \
     libglib2.0-0 \
     wget \
     antiword \
@@ -31,7 +31,7 @@ RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.19
 COPY services/docreader/requirements.txt .
 
 # 安装依赖
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip cache purge && pip install --no-cache-dir -r requirements.txt
 
 # 预下载 PP-OCRv5 模型
 RUN mkdir -p /root/.paddlex/official_models
@@ -69,7 +69,7 @@ RUN apt-get update && apt-get install -y \
     libpq5 \
     wget \
     gnupg \
-    libgl1-mesa-glx \
+    libgl1 \
     libglib2.0-0 \
     antiword \
     supervisor \
@@ -127,7 +127,7 @@ COPY --from=builder /root/.paddlex/official_models /root/.paddlex/official_model
 
 # 安装 Playwright 浏览器
 RUN python -m playwright install webkit
-RUN python -m playwright install-deps webkit
+#RUN python -m playwright install-deps webkit
 
 COPY --from=builder /app/src /app/src
 


### PR DESCRIPTION
#解决问题

在 CentOS 9 Stream 系统上部署本项目时，由于网络环境和软件版本更新，遇到了以下几个问题导致无法成功启动：
1.  `docker-compose` 命令与新版 Docker 不兼容。
2.  多个 Dockerfile 在构建时因网络问题或软件包名过时而失败。
3.  Playwright 的依赖安装脚本在新系统中失效。

修改

为了解决这些问题，我对以下文件进行了重构和修复：
- scripts/start_all.sh: 将所有 `docker-compose` 命令更新为新版的 `docker compose` 语法。
- Dockerfile.app: 添加了国内镜像源，解决了 `apk add` 失败的问题。
- Dockerfile.docreader: 修正了多个过时的 `apt-get` 软件包名称，并清除了 `pip` 的损坏缓存，注释掉了失效的 `playwright install-deps` 命令。

这些修改使得项目能够在新版的 CentOS 9 Stream + Docker 环境下顺利构建和运行。