### PR TITLE
Refactor: Replace MD5 with SHA-256 for hashing

### DIFF
--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -2,7 +2,7 @@ package service
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -1326,7 +1326,7 @@ func (s *knowledgeService) GetKnowledgeBatch(ctx context.Context,
 	return s.repo.GetKnowledgeBatch(ctx, tenantID, ids)
 }
 
-// calculateFileHash calculates MD5 hash of a file
+// calculateFileHash calculates SHA256 hash of a file
 func calculateFileHash(file *multipart.FileHeader) (string, error) {
 	f, err := file.Open()
 	if err != nil {
@@ -1334,7 +1334,7 @@ func calculateFileHash(file *multipart.FileHeader) (string, error) {
 	}
 	defer f.Close()
 
-	h := md5.New()
+	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
 		return "", err
 	}
@@ -1348,7 +1348,7 @@ func calculateFileHash(file *multipart.FileHeader) (string, error) {
 }
 
 func calculateStr(strList ...string) string {
-	h := md5.New()
+	h := sha256.New()
 	input := strings.Join(strList, "")
 	h.Write([]byte(input))
 	return hex.EncodeToString(h.Sum(nil))


### PR DESCRIPTION
  This PR replaces the MD5 hashing algorithm with SHA-256 in
  internal/application/service/knowledge.go.

  Motivation:

  MD5 is cryptographically broken and should not be used for hashing, even for
  non-security-critical purposes like deduplication. SHA-256 is a more secure and robust hashing
  algorithm.

  Changes:

   * Updated the import statement from crypto/md5 to crypto/sha256.
   * Modified calculateFileHash to use sha256.New() instead of md5.New().
   * Modified calculateStr to use sha256.New() instead of md5.New().

  This change improves the security and robustness of the application by using a stronger
  hashing algorithm.