### PR TITLE
refactor: unsupported type types.StorageConfig, a struct

### DIFF
--- a/internal/types/knowledgebase.go
+++ b/internal/types/knowledgebase.go
@@ -84,7 +84,7 @@ type StorageConfig struct {
 	Provider string `yaml:"provider" json:"provider"`
 }
 
-func (c *StorageConfig) Value() (driver.Value, error) {
+func (c StorageConfig) Value() (driver.Value, error) {
 	return json.Marshal(c)
 }
 


### PR DESCRIPTION
将 StorageConfig.Value() 接收者改为值类型