### PR TITLE
Optimization Code

### DIFF
--- a/docker/Dockerfile.docreader
+++ b/docker/Dockerfile.docreader
@@ -25,11 +25,24 @@ RUN apt-get update && apt-get install -y \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 
-# 安装 protoc
-RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip && \
-    unzip protoc-3.19.4-linux-x86_64.zip -d /usr/local && \
-    chmod +x /usr/local/bin/protoc && \
-    rm protoc-3.19.4-linux-x86_64.zip
+# 检查是否存在本地protoc安装包，如果存在则离线安装，否则在线安装,其他安装包按需求添加
+COPY packages/ /app/packages/
+RUN echo "检查本地protoc安装包..." && \
+    if [ -f "/app/packages/protoc-3.19.4-linux-x86_64.zip" ]; then \
+        echo "发现本地protoc安装包，将进行离线安装"; \
+        # 离线安装：使用本地包（精确路径避免歧义）
+        cp /app/packages/protoc-*.zip /app/ && \
+        unzip -o /app/protoc-*.zip -d /usr/local && \
+        chmod +x /usr/local/bin/protoc && \
+        rm -f /app/protoc-*.zip; \
+    else \
+        echo "未发现本地protoc安装包，将进行在线安装"; \
+        # 在线安装：从网络下载
+        curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip && \
+        unzip -o protoc-3.19.4-linux-x86_64.zip -d /usr/local && \
+        chmod +x /usr/local/bin/protoc && \
+        rm -f protoc-3.19.4-linux-x86_64.zip; \
+    fi
 
 # 复制依赖文件
 COPY services/docreader/requirements.txt .

--- a/services/docreader/requirements.txt
+++ b/services/docreader/requirements.txt
@@ -22,6 +22,7 @@ textract
 antiword
 openai
 ollama
+pdfplumber
 
 --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/cpu/
 paddlepaddle==3.0.0

--- a/services/docreader/src/parser/ocr_engine.py
+++ b/services/docreader/src/parser/ocr_engine.py
@@ -36,6 +36,8 @@ class PaddleOCRBackend(OCRBackend):
             from paddleocr import PaddleOCR
             # Default OCR configuration
             ocr_config = {
+                "text_det_limit_type": "max",  # Change from 'min' to 'max'
+                "text_det_limit_side_len": 960,  # A standard and safe limit for the longest side
                 "use_doc_orientation_classify": False,  # Do not use document image orientation classification
                 "use_doc_unwarping": False,  # Do not use document unwarping
                 "use_textline_orientation": False,  # Do not use textline orientation classification
@@ -43,8 +45,6 @@ class PaddleOCRBackend(OCRBackend):
                 "text_detection_model_name": "PP-OCRv5_server_det",
                 "text_recognition_model_dir": "/root/.paddlex/official_models/PP-OCRv5_server_rec_infer",
                 "text_detection_model_dir": "/root/.paddlex/official_models/PP-OCRv5_server_det_infer",
-                "text_det_limit_type": "min",  # Limit by short side
-                "text_det_limit_side_len": 736,  # Limit side length to 736
                 "text_det_thresh": 0.3,  # Text detection pixel threshold
                 "text_det_box_thresh": 0.6,  # Text detection box threshold
                 "text_det_unclip_ratio": 1.5,  # Text detection expansion ratio

--- a/services/docreader/src/parser/pdf_parser.py
+++ b/services/docreader/src/parser/pdf_parser.py
@@ -82,3 +82,10 @@ class PDFParser(BaseParser):
         except Exception as e:
             logger.error(f"Failed to parse PDF document: {str(e)}")
             return ""
+        finally:
+            if os.path.exists(temp_pdf_path):
+                try:
+                    os.remove(temp_pdf_path)
+                    logger.info(f"Temporary file cleaned up: {temp_pdf_path}")
+                except OSError as e:
+                    logger.error(f"Error removing temporary file {temp_pdf_path}: {e}")


### PR DESCRIPTION
1. 解决在构建文档镜像中出现timeout问题
2. 修改ocr文本检测的边长度限制类型为max ，在实际测试中发现当出现长条图像时，在开启并发的情况下，会出现内存错误。[参考链接](https://aistudio.baidu.com/modelsdetail/28601l)
4. 在兼容现有chunk逻辑的基础上，优化paf_parser.py，支持表格识别。