### PR TITLE
docs: 补充env.example的REDIS_ADDR字段

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,8 @@ DB_PASSWORD=postgres123!@#
 DB_NAME=WeKnora
 
 # 如果使用 redis 作为流处理后端，需要配置以下参数
+# Redis地址，例如 /localhost
+REDIS_ADDR=your_redis_addr
 # Redis端口，默认为6379
 REDIS_PORT=6379
 


### PR DESCRIPTION
补充字段：# Redis地址，例如 /localhost
REDIS_ADDR=your_redis_addr