### PR TITLE
feat(MCP): MCP服务端添加使用文件创建知识的功能

### DIFF
--- a/mcp-server/weknora_mcp_server.py
+++ b/mcp-server/weknora_mcp_server.py
@@ -305,6 +305,19 @@ async def handle_list_tools() -> list[types.Tool]:
         
         # Knowledge Management
         types.Tool(
+            name="create_knowledge_from_file",
+            description="Create knowledge from a local file on the server filesystem",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "kb_id": {"type": "string", "description": "Knowledge base ID"},
+                    "file_path": {"type": "string", "description": "Absolute path to the local file on the server"},
+                    "enable_multimodel": {"type": "boolean", "description": "Enable multimodal processing", "default": True}
+                },
+                "required": ["kb_id", "file_path"]
+            }
+        ),
+        types.Tool(
             name="create_knowledge_from_url",
             description="Create knowledge from URL",
             inputSchema={
@@ -537,6 +550,12 @@ async def handle_call_tool(
             result = client.hybrid_search(args["kb_id"], args["query"], config)
         
         # Knowledge Management
+        elif name == "create_knowledge_from_file":
+            result = client.create_knowledge_from_file(
+                args["kb_id"],
+                args["file_path"],
+                args.get("enable_multimodel", True)
+            )
         elif name == "create_knowledge_from_url":
             result = client.create_knowledge_from_url(
                 args["kb_id"],


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
在MCP服务端中添加通过文件创建知识的功能

## 变更类型 (Type of Change)
- [ ] ✨ 新功能 (New feature)

## 影响范围 (Scope)
- [ ] MCP 服务器 (MCP Server)

## 测试 (Testing)
- [ ] 手动测试 (Manual testing)

### 测试步骤 (Test Steps)
1. 在MCP客户端中使用Prompt：“把 /path/to/file/knowldege.txt 这个文件添加到名为的Test知识库中”
2. 观察到Test知识库中出现了knowledge.txt

## 检查清单 (Checklist)
<!-- 请确保完成以下检查项 -->
- [ ] 代码遵循项目的编码规范
- [ ] 已进行自我代码审查
- [ ] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [ ] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 数据库迁移 (Database Migration)
- [ ] 不需要数据库迁移