### PR TITLE
chore: 将 PostgreSQL 镜像版本更新为 v0.18.9-pg17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
     restart: unless-stopped
   # 修改的PostgreSQL配置
   postgres:
-    image: paradedb/paradedb:latest
+    image: paradedb/paradedb:v0.18.9-pg17
     container_name: WeKnora-postgres
     ports:
       - "${DB_PORT}:5432"


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
paradedb 常发生不兼容更新，固定 paradedb 版本为线上稳定版本v0.18.9-pg17，兼容过去数据

## 变更类型 (Type of Change)
- [ ] 🐳 Docker 相关 (Docker related)

## 影响范围 (Scope)
- [ ] 数据库 (Database)

## 测试 (Testing)
- [ ] 手动测试 (Manual testing)