### PR TITLE
IsModelAvailable误判导致反复频繁调用pull模型接口

### DIFF
--- a/internal/handler/initialization.go
+++ b/internal/handler/initialization.go
@@ -556,11 +556,7 @@ func (h *InitializationHandler) CheckOllamaModels(c *gin.Context) {
 
 	// 检查每个模型是否存在
 	for _, modelName := range req.Models {
-		checkModelName := modelName
-		if !strings.Contains(modelName, ":") {
-			checkModelName = modelName + ":latest"
-		}
-		available, err := h.ollamaService.IsModelAvailable(ctx, checkModelName)
+		available, err := h.ollamaService.IsModelAvailable(ctx, modelName)
 		if err != nil {
 			logger.ErrorWithFields(ctx, err, map[string]interface{}{
 				"model_name": modelName,

--- a/internal/models/utils/ollama/ollama.go
+++ b/internal/models/utils/ollama/ollama.go
@@ -107,9 +107,14 @@ func (s *OllamaService) IsModelAvailable(ctx context.Context, modelName string) 
 		return false, fmt.Errorf("failed to get model list: %w", err)
 	}
 
+	// If no version is specified for the model, add ":latest" by default
+	checkModelName := modelName
+	if !strings.Contains(modelName, ":") {
+		checkModelName = modelName + ":latest"
+	}
 	// Check if model is in the list
 	for _, model := range listResp.Models {
-		if model.Name == modelName {
+		if model.Name == checkModelName {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
问题：查看日志发现文本向量化前判断bge-m3模型是否可用时，即使本地早已下载了模型，代码还是会每次都频繁调用pull模型接口，无形中拉长了处理逻辑时间
原因：文本向量化时，IsModelAvailable误判导致反复调用pull模型接口，而/api/v1/initialization/ollama/models/check接口有正确判断逻辑
解决方法：将各个判断模型是否可用的逻辑和接口/api/v1/initialization/ollama/models/check的逻辑统一：对于没有指定版本的模型，默认添加":latest"，避免误判导致反复频繁调用pull模型接口

## 变更类型 (Type of Change)
- [ ] 🐛 Bug 修复 (Bug fix)

## 影响范围 (Scope)
- [ ] 后端 API (Backend API)

## 测试 (Testing)
<!-- 请描述如何测试这些变更 -->
- [ ] 手动测试 (Manual testing)

### 测试步骤 (Test Steps)
1. 新建知识库时，Embedding 嵌入模型配置，模型来源选择Ollama (本地)，模型名称输入bge-m3，输入栏右侧图标显示校验通过
2. 新建完成后，上传知识，未修复时观察日志中上传的处理逻辑，会发现反复调用pull模型接口，但是模型是校验通过在本地可用的
3. 修复后观察日志中上传的处理逻辑，没有反复调用pull模型接口了
4. 各个调用了IsModelAvailable的功能接口应该都没有此问题了

## 检查清单 (Checklist)
<!-- 请确保完成以下检查项 -->
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [x] 相关文档已更新
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常
- [x] 新功能和变更已更新到相关文档
- [x] 破坏性变更已在描述中明确说明
