### PR TITLE
chore(security): upgrade Alpine final image 3.17  to 3.23

### DIFF
--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -45,7 +45,7 @@ RUN --mount=type=cache,target=/go/pkg/mod make build-prod
 RUN --mount=type=cache,target=/go/pkg/mod cp -r /go/pkg/mod/github.com/yanyiwu/ /app/yanyiwu/
 
 # Final stage
-FROM alpine:3.17
+FROM alpine:3.23
 
 WORKDIR /app
 


### PR DESCRIPTION
## Base Image Update

Updated the final base image from **Alpine 3.17 → Alpine 3.23**.

Alpine **3.17 is EOL**, and upgrading resolves multiple security issues:

- **3 Critical vulnerabilities**
- **4 High vulnerabilities**
- **4 Medium vulnerabilities**

### Screenshots

<img width="830" height="91" alt="Screenshot from 2025-12-11 23-04-00" src="https://github.com/user-attachments/assets/0851f082-e34f-4673-83e3-18a33e1ab4e4" />

<img width="934" height="270" alt="Screenshot from 2025-12-11 23-07-04" src="https://github.com/user-attachments/assets/5d5bffe1-f275-43d3-9eff-89d506bd979d" />
