### PR TITLE
fix(chat): exclude ChatTemplateKwargs for OpenAI API

### DIFF
--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -204,8 +204,13 @@ func (c *RemoteAPIChat) buildChatCompletionRequest(messages []Message,
 		}
 	}
 
-	req.ChatTemplateKwargs = map[string]interface{}{
-		"enable_thinking": thinking,
+	// ChatTemplateKwargs is only supported by custom backends like vLLM.
+	// Official APIs (OpenAI, Aliyun, Zhipu, etc.) do not support this parameter
+	// and will return 400 Bad Request if it's included.
+	if c.provider == provider.ProviderGeneric {
+		req.ChatTemplateKwargs = map[string]interface{}{
+			"enable_thinking": thinking,
+		}
 	}
 
 	// Log LLM request for debugging


### PR DESCRIPTION
## Summary
- OpenAI 모델 연결 테스트 시 `chat_template_kwargs` 파라미터로 인한 400 Bad Request 에러 수정
- `ChatTemplateKwargs`를 `ProviderGeneric`(vLLM 등 커스텀 백엔드)인 경우에만 포함하도록 조건부 처리 추가

## Problem
OpenAI API 연결 테스트 시 다음 에러 발생:
```
status: 400 Bad Request
message: Unrecognized request argument supplied: chat_template_kwargs
```

## Solution
`ChatTemplateKwargs` 파라미터는 vLLM 같은 커스텀 백엔드에서만 지원되므로, `ProviderGeneric`인 경우에만 요청에 포함하도록 수정했다.

## Test Plan
- [x] OpenAI 모델(gpt-4.1) 연결 테스트 정상 동작 확인
- [x] 빌드 성공 확인