### PR TITLE
fix(chat): exclude ChatTemplateKwargs for OpenAI API

### DIFF
--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -204,8 +204,13 @@ func (c *RemoteAPIChat) buildChatCompletionRequest(messages []Message,
 		}
 	}
 
-	req.ChatTemplateKwargs = map[string]interface{}{
-		"enable_thinking": thinking,
+	// ChatTemplateKwargs is only supported by custom backends like vLLM.
+	// Official APIs (OpenAI, Aliyun, Zhipu, etc.) do not support this parameter
+	// and will return 400 Bad Request if it's included.
+	if c.provider == provider.ProviderGeneric {
+		req.ChatTemplateKwargs = map[string]interface{}{
+			"enable_thinking": thinking,
+		}
 	}
 
 	// Log LLM request for debugging


### PR DESCRIPTION
## Summary
- Fix 400 Bad Request error caused by `chat_template_kwargs` parameter when testing OpenAI model connection
- Conditionally include `ChatTemplateKwargs` only for `ProviderGeneric` (custom backends like vLLM)

## Problem
When testing OpenAI API connection, the following error occurs:
```
status: 400 Bad Request
message: Unrecognized request argument supplied: chat_template_kwargs
```

## Solution
The `ChatTemplateKwargs` parameter is only supported by custom backends like vLLM. This change modifies the code to include this parameter only when the provider is `ProviderGeneric`.

## Test Plan
- [x] Verified OpenAI model (gpt-4.1) connection test works correctly
- [x] Build succeeded