### PR TITLE
feat(knowledge): Enhance delete functionality with success callback

### DIFF
--- a/frontend/src/hooks/useKnowledgeBase.ts
+++ b/frontend/src/hooks/useKnowledgeBase.ts
@@ -63,20 +63,27 @@ export default function (knowledgeBaseId?: string) {
       })
       .catch(() => {});
   };
-  const delKnowledge = (index: number, item: any) => {
+  const delKnowledge = (index: number, item: any, onSuccess?: () => void) => {
     cardList.value[index].isMore = false;
     moreIndex.value = -1;
-    delKnowledgeDetails(item.id)
+    return delKnowledgeDetails(item.id)
       .then((result: any) => {
         if (result.success) {
           MessagePlugin.info("知识删除成功！");
-          getKnowled();
+          if (onSuccess) {
+            onSuccess();
+          } else {
+            getKnowled();
+          }
+          return true;
         } else {
           MessagePlugin.error("知识删除失败！");
+          return false;
         }
       })
       .catch(() => {
         MessagePlugin.error("知识删除失败！");
+        return false;
       });
   };
   const openMore = (index: number) => {

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -866,7 +866,11 @@ const getDoc = (page: number) => {
 
 const delCardConfirm = () => {
   delDialog.value = false;
-  delKnowledge(knowledgeIndex.value, knowledge.value);
+  delKnowledge(knowledgeIndex.value, knowledge.value, () => {
+    // 删除成功后刷新文档列表和分类数量
+    loadKnowledgeFiles(kbId.value);
+    loadTags(kbId.value);
+  });
 };
 
 // 处理知识库编辑成功后的回调


### PR DESCRIPTION
- Updated the delKnowledge function to accept an optional onSuccess callback for post-deletion actions.
- Modified the delCardConfirm function to refresh the document list and tag counts upon successful deletion.

close #517 