### PR TITLE
fix: use typed context key instead of string literal- Add UserContext…

### DIFF
--- a/internal/application/service/user.go
+++ b/internal/application/service/user.go
@@ -419,7 +419,7 @@ func (s *userService) RevokeToken(ctx context.Context, tokenString string) error
 
 // GetCurrentUser gets current user from context
 func (s *userService) GetCurrentUser(ctx context.Context) (*types.User, error) {
-	user, ok := ctx.Value("user").(*types.User)
+	user, ok := ctx.Value(types.UserContextKey).(*types.User)
 	if !ok {
 		return nil, errors.New("user not found in context")
 	}

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -130,14 +130,14 @@ func Auth(
 				// 存储用户和租户信息到上下文
 				c.Set(types.TenantIDContextKey.String(), targetTenantID)
 				c.Set(types.TenantInfoContextKey.String(), tenant)
-				c.Set("user", user)
+				c.Set(types.UserContextKey.String(), user)
 				c.Request = c.Request.WithContext(
 					context.WithValue(
 						context.WithValue(
 							context.WithValue(c.Request.Context(), types.TenantIDContextKey, targetTenantID),
 							types.TenantInfoContextKey, tenant,
 						),
-						"user", user,
+						types.UserContextKey, user,
 					),
 				)
 				c.Next()

--- a/internal/types/const.go
+++ b/internal/types/const.go
@@ -12,6 +12,8 @@ const (
 	RequestIDContextKey ContextKey = "RequestID"
 	// LoggerContextKey is the context key for logger
 	LoggerContextKey ContextKey = "Logger"
+	// UserContextKey is the context key for user information
+	UserContextKey ContextKey = "User"
 )
 
 // String returns the string representation of the context key


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
修复 staticcheck SA1029 警告：不应使用内置类型 string 作为 context key。

在 `auth.go` middleware 中，原来使用裸字符串 `"user"` 作为 context key。
根据 Go 最佳实践，应该使用自定义类型来避免潜在的 key 冲突。

本 PR：
1. 在 `types/const.go` 中添加类型安全的 `UserContextKey` 常量（复用现有的 `ContextKey` 类型）
2. 在 `middleware/auth.go` 中使用 `types.UserContextKey` 替换裸字符串 `"user"`
3. 同步更新 `service/user.go` 中读取 context 的代码，确保一致性

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)

## 测试 (Testing)
- [x] 手动测试 (Manual testing)

### 测试步骤 (Test Steps)
1. 运行 `go build ./...` - 编译通过
2. 运行 `staticcheck ./... | grep SA1029` - 无输出，确认警告已修复
3. 运行 `go test ./...` - 测试通过

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明


## 数据库迁移 (Database Migration)
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
无

## 部署说明 (Deployment Notes)
无特殊要求，正常部署即可。

## 其他信息 (Additional Information)

### 修改的文件
| 文件 | 变更说明 |
|------|---------|
| `internal/types/const.go` | 添加 `UserContextKey` 常量 |
| `internal/middleware/auth.go` | 使用 `types.UserContextKey` 替换 `"user"` |
| `internal/application/service/user.go` | 使用 `types.UserContextKey` 替换 `"user"` |

### 参考资料
此修复遵循 Go 官方文档关于 context key 的最佳实践：
- [Go context.WithValue 文档](https://pkg.go.dev/context#WithValue)
- [staticcheck SA1029 说明](https://staticcheck.io/docs/checks#SA1029)

> The provided key should be comparable and should not be of type string 
> or any other built-in type to avoid collisions between packages using context.
