### PR TITLE
fix: cleanup conversation context stored in Redis

### DIFF
--- a/internal/application/service/session.go
+++ b/internal/application/service/session.go
@@ -203,6 +203,11 @@ func (s *sessionService) DeleteSession(ctx context.Context, id string) error {
 		logger.Warnf(ctx, "Failed to cleanup temporary KB for session %s: %v", id, err)
 	}
 
+	// Cleanup conversation context stored in Redis for this session
+	if err := s.sessionStorage.Delete(ctx, id); err != nil {
+		logger.Warnf(ctx, "Failed to cleanup conversation context for session %s: %v", id, err)
+	}
+
 	// Delete session from repository
 	err := s.sessionRepo.Delete(ctx, tenantID, id)
 	if err != nil {


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
<!-- 请简要描述这个 PR 的目的和变更内容 -->

修复 DeleteSession方法在删除会话时遗漏清理 Redis 中存储的对话上下文数据的问题


原有的 DeleteSession方法只执行了两个清理步骤：
1.清理网络搜索产生的临时知识库状态 (tempkb:{sessionID})
2.删除数据库中的会话记录
但忽略了存储在 Redis 中的多轮对话上下文数据 (context:{sessionID})，导致删除会话后 Redis 中残留无用数据。

变更文件：internal/application/service/session.go，仅影响 DeleteSession API

## 变更类型 (Type of Change)
<!-- 请选择适用的类型，删除其他选项 -->
- [x] 🐛 Bug 修复 (Bug fix)

## 影响范围 (Scope)
<!-- 请选择受影响的组件，删除其他选项 -->
- [x] 后端 API (Backend API)
- [x] 数据库 (Database)

## 测试 (Testing)
<!-- 请描述如何测试这些变更 -->
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [x] API 测试 (API testing)

### 测试步骤 (Test Steps)
1.创建会话并进行多轮对话
2.使用 redis-cli KEYS "context:*" 确认上下文数据存在
3.调用删除会话 API
4.确认 Redis 中对应的 context:{sessionID} 已被清理

## 检查清单 (Checklist)
<!-- 请确保完成以下检查项 -->
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [x] 相关文档已更新
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常
- [x] 新功能和变更已更新到相关文档
- [x] 破坏性变更已在描述中明确说明

## 相关 Issue
<!-- 如果此 PR 解决了某个 issue，请使用 "Fixes #123" 或 "Closes #123" 的格式 -->
Fixes #576

## 截图/录屏 (Screenshots/Recordings)
<!-- 如果是前端 UI 变更，请提供截图或录屏 -->
NULL
## 数据库迁移 (Database Migration)
<!-- 如果涉及数据库变更，请说明 -->
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
<!-- 如果涉及配置变更，请说明需要更新的配置项 -->
NULL
## 部署说明 (Deployment Notes)
<!-- 如果有特殊的部署要求，请说明 -->
NULL
## 其他信息 (Additional Information)
<!-- 任何其他需要说明的信息 -->
NULL