### PR TITLE
fix(zhipu): correct Embedding BaseURL to match API structure

### DIFF
--- a/internal/models/provider/zhipu.go
+++ b/internal/models/provider/zhipu.go
@@ -10,7 +10,7 @@ const (
 	// ZhipuChatBaseURL 智谱 AI Chat 的默认 BaseURL
 	ZhipuChatBaseURL = "https://open.bigmodel.cn/api/paas/v4"
 	// ZhipuEmbeddingBaseURL 智谱 AI Embedding 的默认 BaseURL
-	ZhipuEmbeddingBaseURL = "https://open.bigmodel.cn/api/paas/v4/embeddings"
+	ZhipuEmbeddingBaseURL = "https://open.bigmodel.cn/api/paas/v4"
 	// ZhipuRerankBaseURL 智谱 AI Rerank 的默认 BaseURL
 	ZhipuRerankBaseURL = "https://open.bigmodel.cn/api/paas/v4/rerank"
 )


### PR DESCRIPTION
  # Pull Request                                                                                                                                                                                            
  ## 描述 (Description)                                                                                                                                                                                  
  
  修复智谱 AI Embedding BaseURL 配置错误。
  
  当前 `ZhipuEmbeddingBaseURL` 常量包含了 `/embeddings` 后缀，但 `OpenAIEmbedder` 实现会自动在 baseURL 后追加 `/embeddings`（见 `internal/models/embedding/openai.go:99`），导致最终请求 URL 变成        
  `/v4/embeddings/embeddings`，造成 API 调用失败。

  此 PR 移除了常量中的 `/embeddings` 后缀，使其与 `ZhipuChatBaseURL` 和 `ZhipuRerankBaseURL` 的模式保持一致。

  **修复前：**
  - 常量值：`https://open.bigmodel.cn/api/paas/v4/embeddings`
  - 实际请求：`https://open.bigmodel.cn/api/paas/v4/embeddings/embeddings` ❌

  **修复后：**
  - 常量值：`https://open.bigmodel.cn/api/paas/v4`
  - 实际请求：`https://open.bigmodel.cn/api/paas/v4/embeddings` ✅

  ## 变更类型 (Type of Change)

  - [x] 🐛 Bug 修复 (Bug fix)

  ## 影响范围 (Scope)

  - [x] 后端 API (Backend API)

  ## 测试 (Testing)

  - [ ] 单元测试 (Unit tests)
  - [ ] 集成测试 (Integration tests)
  - [x] 手动测试 (Manual testing)
  - [x] API 测试 (API testing)

  ### 测试步骤 (Test Steps)
  1. 配置智谱 AI Embedding 模型
  2. 调用 Embedding API 生成文本向量
  3. 验证 API 请求成功且返回正确的向量数据
  4. 确认请求日志中的 URL 为 `https://open.bigmodel.cn/api/paas/v4/embeddings`

  ## 检查清单 (Checklist)

  - [x] 代码遵循项目的编码规范
  - [x] 已进行自我代码审查
  - [x] 代码变更已添加适当的注释
  - [x] 相关文档已更新
  - [x] 变更不会产生新的警告
  - [ ] 已添加测试用例证明修复有效或功能正常
  - [x] 新功能和变更已更新到相关文档
  - [x] 破坏性变更已在描述中明确说明

  ## 相关 Issue

  Fixes #

  ## 截图/录屏 (Screenshots/Recordings)

  N/A

  ## 数据库迁移 (Database Migration)

  - [ ] 需要数据库迁移
  - [x] 不需要数据库迁移

  ## 配置变更 (Configuration Changes)

  无需配置变更。此修复仅更正常量值，对现有配置无影响。

  ## 部署说明 (Deployment Notes)

  无特殊部署要求，直接部署即可。建议部署后验证智谱 Embedding API 功能正常。

  ## 其他信息 (Additional Information)

  此问题影响所有使用智谱 AI Embedding 功能的用户。修复后 Embedding API 将能够正常工作。

  相关代码位置：
  - 常量定义：`internal/models/provider/zhipu.go:13`
  - URL 拼接逻辑：`internal/models/embedding/openai.go:99`