### PR TITLE
fix(frontend): hide upload mask when drag leaves window

### DIFF
--- a/frontend/src/views/platform/index.vue
+++ b/frontend/src/views/platform/index.vue
@@ -27,6 +27,9 @@ let ismask = ref(false)
 let uploadInput = ref();
 const { t } = useI18n();
 
+// 用于跟踪拖拽进入/离开的计数器，解决子元素触发 dragleave 的问题
+let dragCounter = 0;
+
 // 获取当前知识库ID
 const getCurrentKbId = (): string | null => {
     return (route.params as any)?.kbId as string || null
@@ -60,6 +63,7 @@ const checkKnowledgeBaseInitialization = async (): Promise<boolean> => {
 // 全局拖拽事件处理
 const handleGlobalDragEnter = (event: DragEvent) => {
     event.preventDefault();
+    dragCounter++;
     if (event.dataTransfer) {
         event.dataTransfer.effectAllowed = 'all';
     }
@@ -71,11 +75,19 @@ const handleGlobalDragOver = (event: DragEvent) => {
     if (event.dataTransfer) {
         event.dataTransfer.dropEffect = 'copy';
     }
-    ismask.value = true;
+}
+
+const handleGlobalDragLeave = (event: DragEvent) => {
+    event.preventDefault();
+    dragCounter--;
+    if (dragCounter === 0) {
+        ismask.value = false;
+    }
 }
 
 const handleGlobalDrop = async (event: DragEvent) => {
     event.preventDefault();
+    dragCounter = 0;
     ismask.value = false;
     
     const DataTransferFiles = event.dataTransfer?.files ? Array.from(event.dataTransfer.files) : [];
@@ -104,6 +116,7 @@ const handleGlobalDrop = async (event: DragEvent) => {
 onMounted(() => {
     document.addEventListener('dragenter', handleGlobalDragEnter, true);
     document.addEventListener('dragover', handleGlobalDragOver, true);
+    document.addEventListener('dragleave', handleGlobalDragLeave, true);
     document.addEventListener('drop', handleGlobalDrop, true);
 });
 
@@ -111,7 +124,9 @@ onMounted(() => {
 onUnmounted(() => {
     document.removeEventListener('dragenter', handleGlobalDragEnter, true);
     document.removeEventListener('dragover', handleGlobalDragOver, true);
+    document.removeEventListener('dragleave', handleGlobalDragLeave, true);
     document.removeEventListener('drop', handleGlobalDrop, true);
+    dragCounter = 0;
 });
 </script>
 <style lang="less">


### PR DESCRIPTION
## 描述 (Description)
修复了文件拖拽上传时，遮罩层（Upload Mask）在离开浏览器窗口或在嵌套元素间移动时无法正确消失的问题。 引入了 dragCounter 计数器机制，确保只有当真正离开浏览器视口时才隐藏遮罩，避免了因子元素冒泡触发 dragleave 导致的闪烁。

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)
- [x] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
- [x] 前端界面 (Frontend UI)

## 测试 (Testing)
- [x] 手动测试 (Manual testing)
- [x] 前端测试 (Frontend testing)

## 测试步骤 (Test Steps)
- 将文件拖入浏览器窗口，验证上传遮罩正常显示。
- 将文件拖出浏览器窗口边缘，验证遮罩正常消失。
- 释放文件（Drop）或取消拖拽，验证计数器重置且遮罩消失。

检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效