### PR TITLE
fix: correctly extract host from completion_url by handling both v1 and non-v1 endpoints

### DIFF
--- a/docreader/parser/caption.py
+++ b/docreader/parser/caption.py
@@ -238,7 +238,8 @@ class Caption:
         """Call Ollama API for image captioning using base64 encoded image data."""
 
         # Extract host URL by removing the chat completions endpoint
-        host = self.completion_url.replace("/v1/chat/completions", "")
+        # Handle both "/v1/chat/completions" and "/chat/completions" patterns
+        host = self.completion_url.replace("/v1/chat/completions", "").replace("/chat/completions", "")
 
         # Initialize Ollama client with host and timeout
         client = ollama.Client(


### PR DESCRIPTION
…nd non-v1 endpoints

# Pull Request

## 描述 (Description)
<!-- 请简要描述这个 PR 的目的和变更内容 -->

## 变更类型 (Type of Change)
<!-- 请选择适用的类型，删除其他选项 -->
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [ ] 📚 文档更新 (Documentation update)
- [ ] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [ ] 🧪 测试相关 (Test related)
- [ ] 🔧 配置变更 (Configuration change)
- [ ] 🐳 Docker 相关 (Docker related)
- [ ] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
<!-- 请选择受影响的组件，删除其他选项 -->
- [ ] 后端 API (Backend API)
- [ ] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [x] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [ ] 其他 (Other): <!-- 请说明 -->

## 测试 (Testing)
<!-- 请描述如何测试这些变更 -->
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 高级设置中多模态使用本地ollama进行视觉解析。
2. 上传图片文件，或者world pdf中有图片的文档，Document Reader Service 出现404异常
3. 调试发现 修改 `completion_ur` 的格式是 'http://192.168.187.166:11434/chat/completions'，`host = self.completion_url.replace("/v1/chat/completions", "") `这种替换没有替换成功。导致后面调用服务404
4. 修改为 ` host = self.completion_url.replace("/v1/chat/completions", "").replace("/chat/completions", "")` 重复上面步骤，文档和图片皆涂提取成功。

## 检查清单 (Checklist)
<!-- 请确保完成以下检查项 -->
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [x] 相关文档已更新
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常
- [x] 新功能和变更已更新到相关文档
- [x] 破坏性变更已在描述中明确说明


## 截图/录屏 (Screenshots/Recordings)
<img width="1528" height="523" alt="image" src="https://github.com/user-attachments/assets/35398999-c893-4215-9b0e-6cb870d4e8ae" />


## 数据库迁移 (Database Migration)
<!-- 如果涉及数据库变更，请说明 -->
- [x] 需要数据库迁移
- [x] 不需要数据库迁移

