### PR TITLE
fix: replace standard log with structured logger in main and recovery middleware

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,7 +25,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -36,16 +35,13 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/container"
+	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/runtime"
 	"github.com/Tencent/WeKnora/internal/tracing"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 )
 
 func main() {
-	// Set log format with request ID
-	log.SetFlags(log.LstdFlags | log.Lmicroseconds | log.Lshortfile)
-	log.SetOutput(os.Stdout)
-
 	// Set Gin mode
 	if os.Getenv("GIN_MODE") == "release" {
 		gin.SetMode(gin.ReleaseMode)
@@ -87,29 +83,29 @@ func main() {
 		signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 		go func() {
 			sig := <-signals
-			log.Printf("Received signal: %v, starting server shutdown...", sig)
+			logger.Infof(context.Background(), "Received signal: %v, starting server shutdown...", sig)
 
 			// Create a context with timeout for server shutdown
 			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer shutdownCancel()
 
 			if err := server.Shutdown(shutdownCtx); err != nil {
-				log.Fatalf("Server forced to shutdown: %v", err)
+				logger.Fatalf(context.Background(), "Server forced to shutdown: %v", err)
 			}
 
 			// Clean up all registered resources
-			log.Println("Cleaning up resources...")
+			logger.Info(context.Background(), "Cleaning up resources...")
 			errs := resourceCleaner.Cleanup(cleanupCtx)
 			if len(errs) > 0 {
-				log.Printf("Errors occurred during resource cleanup: %v", errs)
+				logger.Errorf(context.Background(), "Errors occurred during resource cleanup: %v", errs)
 			}
 
-			log.Println("Server has exited")
+			logger.Info(context.Background(), "Server has exited")
 			done()
 		}()
 
 		// Start server
-		log.Printf("Server is running at %s:%d", cfg.Server.Host, cfg.Server.Port)
+		logger.Infof(context.Background(), "Server is running at %s:%d", cfg.Server.Host, cfg.Server.Port)
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			return fmt.Errorf("failed to start server: %v", err)
 		}
@@ -119,6 +115,6 @@ func main() {
 		return nil
 	})
 	if err != nil {
-		log.Fatalf("Failed to run application: %v", err)
+		logger.Fatalf(context.Background(), "Failed to run application: %v", err)
 	}
 }


### PR DESCRIPTION
## 📝 Summary

This PR continues the migration to structured logging by replacing the standard Go log package usage with the project's structured logger system.

## 🔧 Changes

### 1. cmd/server/main.go
- Replaced `log.SetFlags` and `log.SetOutput` with structured logger (no longer needed)
- Replaced `log.Printf` with `logger.Infof` for server startup message
- Replaced `log.Println` with `logger.Info` for cleanup messages
- Replaced `log.Fatalf` with `logger.Fatalf` for fatal errors
- Replaced `log.Printf` with `logger.Errorf` for cleanup errors

### 2. internal/middleware/recovery.go
- Replaced `log.Printf` with `logger.ErrorWithFields` for panic logging
- Added request ID to panic logs for better debugging
- Added stacktrace as a structured field
- Uses proper context from request

## ✅ Benefits

- **Consistent logging**: All application logs now use the structured logger
- **Better debugging**: Panic logs include request ID and stacktrace as structured fields
- **Proper integration**: Logs respect the project's logging configuration
- **Easier log analysis**: Structured logs can be parsed and analyzed more effectively

## 🧪 Testing

- Changes are minimal and focused on logging only
- No functional changes to application behavior
- The structured logger is already used throughout the codebase

## 📋 Checklist

- [x] Code follows project conventions
- [x] No breaking changes
- [x] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>