### PR TITLE
fix: duckdb spatial extension not found error

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -645,6 +645,12 @@ func NewDuckDB() (*sql.DB, error) {
 		return nil, fmt.Errorf("failed to open duckdb: %w", err)
 	}
 
+	// Try to install and load spatial extension
+	installSQL := "INSTALL spatial;"
+	if _, err := sqlDB.ExecContext(context.Background(), installSQL); err != nil {
+		logger.Warnf(context.Background(), "[DuckDB] Failed to install spatial extension: %v", err)
+	}
+
 	// Try to load spatial extension
 	loadSQL := "LOAD spatial;"
 	if _, err := sqlDB.ExecContext(context.Background(), loadSQL); err != nil {


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
修复 DuckDB 无法加载 spatial 插件的问题。

```
WARNING[2026-02-09 16:51:57.541] [] container.go:668[NewDuckDB] | [DuckDB] Failed to load spatial extension: IO Error: Extension "/Users/dounx/.duckdb/extensions/v1.4.3/osx_arm64/spatial.duckdb_extension" not found.
Extension "spatial" is an existing extension.
```

## 变更类型 (Type of Change)
- [x]  后端 API (Backend API)

## 测试 (Testing)
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 全新启动一个 make dev-start
2. 启动 make dev-app

预期不报 Failed to load spatial extension 警告。

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明