### PR TITLE
refactor: remove mineru_api_base_url from ParserEngineConfig and related components

### DIFF
--- a/frontend/src/api/system/index.ts
+++ b/frontend/src/api/system/index.ts
@@ -127,7 +127,6 @@ export interface ParserEngineConfig {
   docreader_transport?: string
   mineru_endpoint?: string
   mineru_api_key?: string
-  mineru_api_base_url?: string
   // MinerU 自建参数
   mineru_model?: string
   mineru_enable_formula?: boolean | null

--- a/frontend/src/views/settings/ParserEngineSettings.vue
+++ b/frontend/src/views/settings/ParserEngineSettings.vue
@@ -142,14 +142,6 @@
               />
             </div>
             <div class="form-field">
-              <label>API 地址</label>
-              <t-input
-                v-model="config.mineru_api_base_url"
-                placeholder="默认 https://mineru.net/api/v4"
-                clearable
-              />
-            </div>
-            <div class="form-field">
               <label>Model Version</label>
               <t-select v-model="config.mineru_cloud_model" placeholder="默认 pipeline" clearable>
                 <t-option value="pipeline" label="pipeline" />
@@ -215,7 +207,6 @@ const DEFAULT_PARSER_CONFIG: ParserEngineConfig = {
   docreader_transport: 'grpc',
   mineru_endpoint: '',
   mineru_api_key: '',
-  mineru_api_base_url: 'https://mineru.net/api/v4',
   mineru_model: 'pipeline',
   mineru_enable_formula: true,
   mineru_enable_table: true,
@@ -298,7 +289,6 @@ async function loadConfig() {
       docreader_transport: data?.docreader_transport ?? DEFAULT_PARSER_CONFIG.docreader_transport ?? 'grpc',
       mineru_endpoint: data?.mineru_endpoint ?? DEFAULT_PARSER_CONFIG.mineru_endpoint ?? '',
       mineru_api_key: data?.mineru_api_key ?? DEFAULT_PARSER_CONFIG.mineru_api_key ?? '',
-      mineru_api_base_url: data?.mineru_api_base_url ?? DEFAULT_PARSER_CONFIG.mineru_api_base_url ?? '',
       mineru_model: data?.mineru_model ?? DEFAULT_PARSER_CONFIG.mineru_model ?? '',
       mineru_enable_formula: data?.mineru_enable_formula ?? DEFAULT_PARSER_CONFIG.mineru_enable_formula ?? true,
       mineru_enable_table: data?.mineru_enable_table ?? DEFAULT_PARSER_CONFIG.mineru_enable_table ?? true,
@@ -328,7 +318,6 @@ function buildConfigPayload(): ParserEngineConfig {
     docreader_transport: (config.value.docreader_transport ?? 'grpc').trim() || 'grpc',
     mineru_endpoint: config.value.mineru_endpoint?.trim() ?? '',
     mineru_api_key: config.value.mineru_api_key?.trim() ?? '',
-    mineru_api_base_url: config.value.mineru_api_base_url?.trim() ?? '',
     mineru_model: config.value.mineru_model?.trim() ?? '',
     mineru_enable_formula: config.value.mineru_enable_formula,
     mineru_enable_table: config.value.mineru_enable_table,
@@ -469,12 +458,12 @@ onMounted(loadAll)
 .engine-doc-link {
   margin-left: auto;
   font-size: 12px;
-  color: #999;
+  color: var(--td-brand-color, #0052d9);
   text-decoration: none;
   white-space: nowrap;
 
   &:hover {
-    color: var(--td-brand-color, #0052d9);
+    opacity: 0.8;
   }
 }
 

--- a/internal/infrastructure/docparser/engine_registry.go
+++ b/internal/infrastructure/docparser/engine_registry.go
@@ -41,8 +41,10 @@ const SimpleEngineName = "simple"
 
 type simpleEngine struct{}
 
-func (e *simpleEngine) Name() string        { return SimpleEngineName }
-func (e *simpleEngine) Description() string { return "简单格式 & 图片解析（无需外部服务）" }
+func (e *simpleEngine) Name() string { return SimpleEngineName }
+func (e *simpleEngine) Description() string {
+	return "简单格式 & 图片解析（无需外部服务）"
+}
 func (e *simpleEngine) FileTypes(_ bool) []string {
 	return []string{"md", "markdown", "txt", "csv", "jpg", "jpeg", "png", "gif", "bmp", "tiff", "webp"}
 }
@@ -85,7 +87,7 @@ func (e *mineruCloudEngine) CheckAvailable(_ bool, overrides map[string]string) 
 	if apiKey == "" {
 		return false, "未配置 MinerU API Key"
 	}
-	return PingMinerUCloud(apiKey, overrides["mineru_api_base_url"])
+	return PingMinerUCloud(apiKey)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/infrastructure/docparser/mineru_cloud_converter.go
+++ b/internal/infrastructure/docparser/mineru_cloud_converter.go
@@ -29,9 +29,9 @@ const (
 // MinerUCloudReader calls the MinerU Cloud API (mineru.net) to read/convert documents.
 // Flow: POST /file-urls/batch → PUT file → poll GET /extract-results/batch/{batch_id}.
 type MinerUCloudReader struct {
-	apiKey       string
-	baseURL      string
-	model        string
+	apiKey        string
+	baseURL       string
+	model         string
 	formulaEnable bool
 	tableEnable   bool
 	ocrEnable     bool
@@ -40,14 +40,9 @@ type MinerUCloudReader struct {
 
 // NewMinerUCloudReader creates a reader from ParserEngineOverrides.
 func NewMinerUCloudReader(overrides map[string]string) *MinerUCloudReader {
-	baseURL := strings.TrimRight(stringOr(overrides["mineru_api_base_url"], defaultBaseURL), "/")
-	if safe, reason := utils.IsSSRFSafeURL(baseURL); !safe {
-		logger.Printf("WARN: [MinerUCloud] baseURL rejected by SSRF check (%s), falling back to default", reason)
-		baseURL = defaultBaseURL
-	}
 	return &MinerUCloudReader{
 		apiKey:        strings.TrimSpace(overrides["mineru_api_key"]),
-		baseURL:       baseURL,
+		baseURL:       defaultBaseURL,
 		model:         stringOr(overrides["mineru_cloud_model"], "pipeline"),
 		formulaEnable: parseBoolOr(overrides["mineru_cloud_enable_formula"], true),
 		tableEnable:   parseBoolOr(overrides["mineru_cloud_enable_table"], true),
@@ -481,24 +476,14 @@ func readZipEntryBytes(f *zip.File) ([]byte, error) {
 	return io.ReadAll(rc)
 }
 
-// logCloudResponseStructure is now unified in helpers.go as logResponseStructure("MinerUCloud", ...)
-
 // PingMinerUCloud checks if the MinerU Cloud API is reachable with the given API key.
-func PingMinerUCloud(apiKey, baseURL string) (bool, string) {
+func PingMinerUCloud(apiKey string) (bool, string) {
 	apiKey = strings.TrimSpace(apiKey)
-	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
 	if apiKey == "" {
 		return false, "未配置 MinerU Cloud API Key"
 	}
-	if baseURL == "" {
-		baseURL = defaultBaseURL
-	}
 
-	targetURL := baseURL + "/file-urls/batch"
-	if safe, reason := utils.IsSSRFSafeURL(targetURL); !safe {
-		return false, fmt.Sprintf("baseURL 不安全: %s", reason)
-	}
-
+	targetURL := defaultBaseURL + "/file-urls/batch"
 	payload := []byte(`{"files":[],"model_version":"pipeline"}`)
 	req, err := http.NewRequest(http.MethodPost, targetURL, bytes.NewReader(payload))
 	if err != nil {
@@ -522,5 +507,3 @@ func PingMinerUCloud(apiKey, baseURL string) (bool, string) {
 	}
 	return true, ""
 }
-
-// firstNonEmpty, sleepCtx are defined in helpers.go

--- a/internal/types/tenant.go
+++ b/internal/types/tenant.go
@@ -202,10 +202,9 @@ func (c *ConversationConfig) Scan(value interface{}) error {
 // ParserEngineConfig holds tenant-level overrides for document parser engines (e.g. MinerU endpoint, API key).
 // These values take precedence over environment variables when parsing documents.
 type ParserEngineConfig struct {
-	DocReaderAddr    string `json:"docreader_addr"`      // 文档解析服务地址
-	MinerUEndpoint   string `json:"mineru_endpoint"`     // MinerU 自建服务端点
-	MinerUAPIKey     string `json:"mineru_api_key"`      // MinerU 云 API Key
-	MinerUAPIBaseURL string `json:"mineru_api_base_url"` // MinerU 云 API Base URL（可选）
+	DocReaderAddr  string `json:"docreader_addr"`  // 文档解析服务地址
+	MinerUEndpoint string `json:"mineru_endpoint"` // MinerU 自建服务端点
+	MinerUAPIKey   string `json:"mineru_api_key"`  // MinerU 云 API Key
 
 	// MinerU 自建解析参数
 	MinerUModel         string `json:"mineru_model,omitempty"` // backend: pipeline, vlm-*, hybrid-*
@@ -223,7 +222,7 @@ type ParserEngineConfig struct {
 }
 
 // ToOverridesMap returns a map suitable for ParserEngineOverrides in parse requests.
-// Keys are snake_case (mineru_endpoint, mineru_api_key, mineru_api_base_url).
+// Keys are snake_case (mineru_endpoint, mineru_api_key, etc.).
 func (c *ParserEngineConfig) ToOverridesMap() map[string]string {
 	if c == nil {
 		return nil
@@ -234,9 +233,6 @@ func (c *ParserEngineConfig) ToOverridesMap() map[string]string {
 	}
 	if c.MinerUAPIKey != "" {
 		m["mineru_api_key"] = c.MinerUAPIKey
-	}
-	if c.MinerUAPIBaseURL != "" {
-		m["mineru_api_base_url"] = c.MinerUAPIBaseURL
 	}
 	if c.MinerUModel != "" {
 		m["mineru_model"] = c.MinerUModel

--- a/migrations/versioned/000013_engine_configs.up.sql
+++ b/migrations/versioned/000013_engine_configs.up.sql
@@ -2,7 +2,7 @@
 DO $$ BEGIN RAISE NOTICE '[Migration 000013] Adding engine config columns to tenants'; END $$;
 
 ALTER TABLE tenants ADD COLUMN IF NOT EXISTS parser_engine_config JSONB DEFAULT NULL;
-COMMENT ON COLUMN tenants.parser_engine_config IS 'Parser engine overrides (mineru_endpoint, mineru_api_key, mineru_api_base_url); takes precedence over env when parsing';
+COMMENT ON COLUMN tenants.parser_engine_config IS 'Parser engine overrides (mineru_endpoint, mineru_api_key, etc.); takes precedence over env when parsing';
 
 ALTER TABLE tenants ADD COLUMN IF NOT EXISTS storage_engine_config JSONB DEFAULT NULL;
 COMMENT ON COLUMN tenants.storage_engine_config IS 'Storage engine parameters for Local, MinIO, COS; used for document/file storage and docreader';


### PR DESCRIPTION

- Eliminated the `mineru_api_base_url` field from the `ParserEngineConfig` interface and its usage across the application, simplifying the configuration structure.
- Updated the `ParserEngineSettings` view to remove the corresponding input field, enhancing the user interface.
- Adjusted the `PingMinerUCloud` function to no longer require the base URL parameter, defaulting to a predefined value instead.
- Modified database migration comments to reflect the removal of the base URL from the configuration.

These changes streamline the configuration process for the MinerU Cloud integration, improving clarity and reducing potential misconfigurations.
