### PR TITLE
feat(security): add AES-256-GCM encryption for API keys at rest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,9 @@ AUTO_RECOVER_DIRTY=true
 
 TENANT_AES_KEY=weknorarag-api-key-secret-secret
 
+# AES-256 密钥，用于数据库中 API Key 等敏感字段的落盘加密（必须为32字节）
+SYSTEM_AES_KEY=weknora-system-aes-key-32bytes!!
+
 # 是否开启知识图谱构建和检索（构建阶段需调用大模型，耗时较长）
 ENABLE_GRAPH_RAG=false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ services:
       - NEO4J_USERNAME=${NEO4J_USERNAME:-neo4j}
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:-password}
       - TENANT_AES_KEY=${TENANT_AES_KEY:-}
+      - SYSTEM_AES_KEY=${SYSTEM_AES_KEY:-}
       - CONCURRENCY_POOL_SIZE=${CONCURRENCY_POOL_SIZE:-5}
       - JWT_SECRET=${JWT_SECRET:-}
       # File size limit (in MB)

--- a/helm/templates/app.yaml
+++ b/helm/templates/app.yaml
@@ -104,6 +104,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "weknora.secretName" . }}
                   key: TENANT_AES_KEY
+            - name: SYSTEM_AES_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "weknora.secretName" . }}
+                  key: SYSTEM_AES_KEY
             # Retrieval & Storage
             - name: RETRIEVE_DRIVER
               value: {{ .Values.app.env.RETRIEVE_DRIVER | quote }}

--- a/helm/templates/secrets.yaml
+++ b/helm/templates/secrets.yaml
@@ -30,6 +30,7 @@ stringData:
   # Application secrets
   JWT_SECRET: {{ required "secrets.jwtSecret is required" .Values.secrets.jwtSecret | quote }}
   TENANT_AES_KEY: {{ .Values.secrets.tenantAesKey | default (randAlphaNum 32) | quote }}
+  SYSTEM_AES_KEY: {{ .Values.secrets.systemAesKey | default (randAlphaNum 32) | quote }}
   {{- if .Values.neo4j.enabled }}
   # Neo4j credentials (for GraphRAG)
   NEO4J_USERNAME: {{ .Values.neo4j.username | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -394,9 +394,11 @@ secrets:
   jwtSecret: ""
   # -- Tenant AES encryption key
   tenantAesKey: ""
+  # -- System AES-256 key for database API key encryption (32 bytes)
+  systemAesKey: ""
 
   # -- Use existing secret instead of creating one
-  # The secret must contain keys: DB_USER, DB_PASSWORD, DB_NAME, REDIS_USERNAME, REDIS_PASSWORD, JWT_SECRET, TENANT_AES_KEY
+  # The secret must contain keys: DB_USER, DB_PASSWORD, DB_NAME, REDIS_USERNAME, REDIS_PASSWORD, JWT_SECRET, TENANT_AES_KEY, SYSTEM_AES_KEY
   existingSecret: ""
 
 # -----------------------------------------------------------------------------

--- a/internal/application/service/tenant.go
+++ b/internal/application/service/tenant.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/Tencent/WeKnora/internal/utils"
 )
 
 var apiKeySecret = func() []byte {
@@ -67,6 +68,14 @@ func (s *tenantService) CreateTenant(ctx context.Context, tenant *types.Tenant) 
 
 	logger.Infof(ctx, "Tenant created successfully, ID: %d, generating official API Key", tenant.ID)
 	tenant.APIKey = s.generateApiKey(tenant.ID)
+
+	// Manually encrypt APIKey before update, because db.Updates() does not trigger BeforeSave hook
+	if key := utils.GetAESKey(); key != nil && tenant.APIKey != "" {
+		if encrypted, err := utils.EncryptAESGCM(tenant.APIKey, key); err == nil {
+			tenant.APIKey = encrypted
+		}
+	}
+
 	if err := s.repo.UpdateTenant(ctx, tenant); err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"tenant_id":   tenant.ID,
@@ -195,6 +204,13 @@ func (s *tenantService) UpdateAPIKey(ctx context.Context, id uint64) (string, er
 
 	logger.Infof(ctx, "Generating new API Key for tenant, ID: %d", id)
 	tenant.APIKey = s.generateApiKey(tenant.ID)
+
+	// Manually encrypt APIKey before update, because db.Updates() does not trigger BeforeSave hook
+	if key := utils.GetAESKey(); key != nil && tenant.APIKey != "" {
+		if encrypted, err := utils.EncryptAESGCM(tenant.APIKey, key); err == nil {
+			tenant.APIKey = encrypted
+		}
+	}
 
 	if err := s.repo.UpdateTenant(ctx, tenant); err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{

--- a/internal/types/model.go
+++ b/internal/types/model.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/Tencent/WeKnora/internal/utils"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
@@ -94,12 +95,19 @@ type Model struct {
 	DeletedAt gorm.DeletedAt `yaml:"deleted_at"  json:"deleted_at"  gorm:"index"`
 }
 
-// Value implements the driver.Valuer interface, used to convert ModelParameters to database value
+// Value implements the driver.Valuer interface, used to convert ModelParameters to database value.
+// Encrypts APIKey before persisting to database (value receiver = no memory pollution).
 func (c ModelParameters) Value() (driver.Value, error) {
+	if key := utils.GetAESKey(); key != nil && c.APIKey != "" {
+		if encrypted, err := utils.EncryptAESGCM(c.APIKey, key); err == nil {
+			c.APIKey = encrypted
+		}
+	}
 	return json.Marshal(c)
 }
 
-// Scan implements the sql.Scanner interface, used to convert database value to ModelParameters
+// Scan implements the sql.Scanner interface, used to convert database value to ModelParameters.
+// Decrypts APIKey after loading from database; legacy plaintext is returned as-is.
 func (c *ModelParameters) Scan(value interface{}) error {
 	if value == nil {
 		return nil
@@ -108,7 +116,15 @@ func (c *ModelParameters) Scan(value interface{}) error {
 	if !ok {
 		return nil
 	}
-	return json.Unmarshal(b, c)
+	if err := json.Unmarshal(b, c); err != nil {
+		return err
+	}
+	if key := utils.GetAESKey(); key != nil && c.APIKey != "" {
+		if decrypted, err := utils.DecryptAESGCM(c.APIKey, key); err == nil {
+			c.APIKey = decrypted
+		}
+	}
+	return nil
 }
 
 // BeforeCreate is a GORM hook that runs before creating a new model record

--- a/internal/types/tenant.go
+++ b/internal/types/tenant.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Tencent/WeKnora/internal/utils"
 	"gorm.io/gorm"
 )
 
@@ -123,6 +124,28 @@ func (t *Tenant) GetEffectiveEngines() []RetrieverEngineParams {
 func (t *Tenant) BeforeCreate(tx *gorm.DB) error {
 	if t.RetrieverEngines.Engines == nil {
 		t.RetrieverEngines.Engines = []RetrieverEngineParams{}
+	}
+	return nil
+}
+
+// BeforeSave encrypts APIKey before persisting to database.
+// Uses tx.Statement.SetColumn to avoid polluting the in-memory struct.
+func (t *Tenant) BeforeSave(tx *gorm.DB) error {
+	if key := utils.GetAESKey(); key != nil && t.APIKey != "" {
+		if encrypted, err := utils.EncryptAESGCM(t.APIKey, key); err == nil {
+			tx.Statement.SetColumn("api_key", encrypted)
+		}
+	}
+	return nil
+}
+
+// AfterFind decrypts APIKey after loading from database.
+// Legacy plaintext (without enc:v1: prefix) is returned as-is.
+func (t *Tenant) AfterFind(tx *gorm.DB) error {
+	if key := utils.GetAESKey(); key != nil && t.APIKey != "" {
+		if decrypted, err := utils.DecryptAESGCM(t.APIKey, key); err == nil {
+			t.APIKey = decrypted
+		}
 	}
 	return nil
 }

--- a/internal/utils/crypto.go
+++ b/internal/utils/crypto.go
@@ -1,0 +1,89 @@
+package utils
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"io"
+	"os"
+	"strings"
+)
+
+// EncPrefix marks a string as AES-256-GCM encrypted
+const EncPrefix = "enc:v1:"
+
+// GetAESKey reads the 32-byte AES key from SYSTEM_AES_KEY env.
+// Returns nil if not set or not exactly 32 bytes.
+func GetAESKey() []byte {
+	key := []byte(os.Getenv("SYSTEM_AES_KEY"))
+	if len(key) == 32 {
+		return key
+	}
+	return nil
+}
+
+// EncryptAESGCM encrypts plaintext with AES-256-GCM.
+// Returns the original string if empty, already encrypted, or key is nil.
+func EncryptAESGCM(plaintext string, key []byte) (string, error) {
+	if plaintext == "" || key == nil {
+		return plaintext, nil
+	}
+	if strings.HasPrefix(plaintext, EncPrefix) {
+		return plaintext, nil
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, aesgcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+
+	ciphertext := aesgcm.Seal(nil, nonce, []byte(plaintext), nil)
+	combined := append(nonce, ciphertext...)
+	return EncPrefix + base64.RawURLEncoding.EncodeToString(combined), nil
+}
+
+// DecryptAESGCM decrypts an AES-256-GCM encrypted string.
+// If the string lacks the enc:v1: prefix, it's treated as legacy plaintext and returned as-is.
+func DecryptAESGCM(encrypted string, key []byte) (string, error) {
+	if encrypted == "" || key == nil {
+		return encrypted, nil
+	}
+	if !strings.HasPrefix(encrypted, EncPrefix) {
+		return encrypted, nil
+	}
+
+	data, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(encrypted, EncPrefix))
+	if err != nil {
+		return "", err
+	}
+	if len(data) < 12 {
+		return "", errors.New("invalid encrypted data: too short")
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonce, ciphertext := data[:aesgcm.NonceSize()], data[aesgcm.NonceSize():]
+	plaintext, err := aesgcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(plaintext), nil
+}

--- a/migrations/mysql/00-init-db.sql
+++ b/migrations/mysql/00-init-db.sql
@@ -10,7 +10,7 @@ CREATE TABLE tenants (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     description TEXT,
-    api_key VARCHAR(64) NOT NULL,
+    api_key VARCHAR(256) NOT NULL,
     retriever_engines JSON NOT NULL,
     status VARCHAR(50) DEFAULT 'active',
     business VARCHAR(255) NOT NULL,

--- a/migrations/paradedb/00-init-db.sql
+++ b/migrations/paradedb/00-init-db.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS tenants (
     id SERIAL PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     description TEXT,
-    api_key VARCHAR(64) NOT NULL,
+    api_key VARCHAR(256) NOT NULL,
     retriever_engines JSONB NOT NULL DEFAULT '[]',
     status VARCHAR(50) DEFAULT 'active',
     business VARCHAR(255) NOT NULL,

--- a/migrations/sqlite/000000_init.up.sql
+++ b/migrations/sqlite/000000_init.up.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS tenants (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name VARCHAR(255) NOT NULL,
     description TEXT,
-    api_key VARCHAR(64) NOT NULL,
+    api_key VARCHAR(256) NOT NULL,
     retriever_engines TEXT NOT NULL DEFAULT '[]',
     status VARCHAR(50) DEFAULT 'active',
     business VARCHAR(255) NOT NULL,

--- a/migrations/versioned/000017_mcp_builtin.down.sql
+++ b/migrations/versioned/000017_mcp_builtin.down.sql
@@ -2,7 +2,7 @@
 -- Migration 000017 DOWN: Remove is_builtin from mcp_services
 -- ============================================================================
 
-DO $ BEGIN RAISE NOTICE '[Migration 000017 DOWN] Removing is_builtin column from mcp_services...'; END $;
+DO $$ BEGIN RAISE NOTICE '[Migration 000017 DOWN] Removing is_builtin column from mcp_services...'; END $$;
 
 -- Drop index
 DROP INDEX IF EXISTS idx_mcp_services_is_builtin;
@@ -11,4 +11,4 @@ DROP INDEX IF EXISTS idx_mcp_services_is_builtin;
 ALTER TABLE mcp_services
 DROP COLUMN IF EXISTS is_builtin;
 
-DO $ BEGIN RAISE NOTICE '[Migration 000017 DOWN] is_builtin column removed from mcp_services'; END $;
+DO $$ BEGIN RAISE NOTICE '[Migration 000017 DOWN] is_builtin column removed from mcp_services'; END $$;

--- a/migrations/versioned/000017_mcp_builtin.up.sql
+++ b/migrations/versioned/000017_mcp_builtin.up.sql
@@ -2,10 +2,10 @@
 -- Migration 000017: Add is_builtin support for MCP services
 -- ============================================================================
 
-DO $ BEGIN RAISE NOTICE '[Migration 000017] Adding is_builtin column to mcp_services...'; END $;
+DO $$ BEGIN RAISE NOTICE '[Migration 000017] Adding is_builtin column to mcp_services...'; END $$;
 
 -- Add is_builtin column to mcp_services
 ALTER TABLE mcp_services ADD COLUMN IF NOT EXISTS is_builtin BOOLEAN NOT NULL DEFAULT false;
 CREATE INDEX IF NOT EXISTS idx_mcp_services_is_builtin ON mcp_services(is_builtin);
 
-DO $ BEGIN RAISE NOTICE '[Migration 000017] is_builtin column added to mcp_services'; END $;
+DO $$ BEGIN RAISE NOTICE '[Migration 000017] is_builtin column added to mcp_services'; END $$;

--- a/migrations/versioned/000018_extend_tenant_api_key.down.sql
+++ b/migrations/versioned/000018_extend_tenant_api_key.down.sql
@@ -1,0 +1,2 @@
+-- Migration 000018 DOWN: Revert tenant api_key column to varchar(64)
+ALTER TABLE tenants ALTER COLUMN api_key TYPE varchar(64);

--- a/migrations/versioned/000018_extend_tenant_api_key.up.sql
+++ b/migrations/versioned/000018_extend_tenant_api_key.up.sql
@@ -1,0 +1,2 @@
+-- Migration 000018: Extend tenant api_key column to support encrypted values
+ALTER TABLE tenants ALTER COLUMN api_key TYPE varchar(256);


### PR DESCRIPTION
# Pull Request

## 描述 (Description)

为数据库中存储的 API Key 等敏感字段增加 AES-256-GCM 落盘加密能力。通过环境变量 `SYSTEM_AES_KEY`（32 字节）控制开关，未配置时保持明文兼容；已有明文数据在读取时原样返回，写入时自动加密（`enc:v1:` 前缀标识密文版本）。

主要变更：
- 新增 `internal/utils/crypto.go`，提供 AES-256-GCM 加解密工具函数
- Tenant API Key：通过 GORM `BeforeSave`/`AfterFind` 钩子自动加解密；`CreateTenant`/`UpdateAPIKey` 中因使用 `db.Updates()` 不触发钩子，增加手动加密逻辑
- Model API Key：在 `ModelParameters` 的 `Value()`/`Scan()` 中加解密
- `api_key` 字段从 `varchar(64)` 扩展到 `varchar(256)` 以容纳密文长度
- 修复 migration 000017 中 PL/pgSQL dollar-quoting 语法错误（`$` → `$$`）

## 变更类型 (Type of Change)

- [x] ✨ 新功能 (New feature)
- [x] 🐛 Bug 修复 (Bug fix)
- [x] 🔧 配置变更 (Configuration change)
- [x] 🐳 Docker 相关 (Docker related)

## 影响范围 (Scope)

- [x] 后端 API (Backend API)
- [x] 数据库 (Database)
- [x] Docker 配置 (Docker Configuration)
- [x] 配置文件 (Configuration)

## 测试 (Testing)

- [x] 手动测试 (Manual testing)
- [x] API 测试 (API testing)

### 测试步骤 (Test Steps)

1. 设置环境变量 `SYSTEM_AES_KEY` 为 32 字节字符串
2. 创建 Tenant，检查数据库中 `api_key` 字段是否以 `enc:v1:` 开头
3. 通过 API 获取 Tenant，确认返回的是解密后的明文 API Key
4. 创建/更新 Model 并配置 API Key，验证数据库中 `parameters` JSON 内的 `api_key` 已加密
5. 不设置 `SYSTEM_AES_KEY`，验证系统正常运行且数据保持明文

## 检查清单 (Checklist)

- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [x] 变更不会产生新的警告
- [x] 新功能和变更已更新到相关文档

## 数据库迁移 (Database Migration)

- [x] 需要数据库迁移

新增 migration 000018：将 `tenants.api_key` 从 `varchar(64)` 扩展为 `varchar(256)`。同时更新了 MySQL、ParadeDB、SQLite 的初始化 SQL。

## 配置变更 (Configuration Changes)

新增环境变量 `SYSTEM_AES_KEY`：
- `.env.example` 中增加说明和默认值
- `docker-compose.yml` 中透传该变量
- Helm chart 中增加 `secrets.systemAesKey` 配置项，并通过 Secret 挂载

## 部署说明 (Deployment Notes)

- 部署前需配置 `SYSTEM_AES_KEY` 环境变量（必须为 32 字节），不配置则加密功能不生效，系统正常运行
- 需执行 migration 000018 扩展 `api_key` 字段长度
- 已有明文数据无需手动迁移，下次写入时会自动加密