### PR TITLE
fix: correct PostgreSQL dollar-quoting syntax in migration 000017

### DIFF
--- a/migrations/versioned/000017_mcp_builtin.down.sql
+++ b/migrations/versioned/000017_mcp_builtin.down.sql
@@ -2,7 +2,7 @@
 -- Migration 000017 DOWN: Remove is_builtin from mcp_services
 -- ============================================================================
 
-DO $ BEGIN RAISE NOTICE '[Migration 000017 DOWN] Removing is_builtin column from mcp_services...'; END $;
+DO $$ BEGIN RAISE NOTICE '[Migration 000017 DOWN] Removing is_builtin column from mcp_services...'; END $$;
 
 -- Drop index
 DROP INDEX IF EXISTS idx_mcp_services_is_builtin;
@@ -11,4 +11,4 @@ DROP INDEX IF EXISTS idx_mcp_services_is_builtin;
 ALTER TABLE mcp_services
 DROP COLUMN IF EXISTS is_builtin;
 
-DO $ BEGIN RAISE NOTICE '[Migration 000017 DOWN] is_builtin column removed from mcp_services'; END $;
+DO $$ BEGIN RAISE NOTICE '[Migration 000017 DOWN] is_builtin column removed from mcp_services'; END $$;

--- a/migrations/versioned/000017_mcp_builtin.up.sql
+++ b/migrations/versioned/000017_mcp_builtin.up.sql
@@ -2,10 +2,10 @@
 -- Migration 000017: Add is_builtin support for MCP services
 -- ============================================================================
 
-DO $ BEGIN RAISE NOTICE '[Migration 000017] Adding is_builtin column to mcp_services...'; END $;
+DO $$ BEGIN RAISE NOTICE '[Migration 000017] Adding is_builtin column to mcp_services...'; END $$;
 
 -- Add is_builtin column to mcp_services
 ALTER TABLE mcp_services ADD COLUMN IF NOT EXISTS is_builtin BOOLEAN NOT NULL DEFAULT false;
 CREATE INDEX IF NOT EXISTS idx_mcp_services_is_builtin ON mcp_services(is_builtin);
 
-DO $ BEGIN RAISE NOTICE '[Migration 000017] is_builtin column added to mcp_services'; END $;
+DO $$ BEGIN RAISE NOTICE '[Migration 000017] is_builtin column added to mcp_services'; END $$;


### PR DESCRIPTION
## 描述 (Description)

Migration 000017 中 `DO $ BEGIN ... END $;` 使用了无效的 PostgreSQL 语法，
正确的 dollar-quote 分隔符应为 `$$`。该问题导致应用启动时数据库迁移失败，
报错：`pq: syntax error at or near "$"`

## 变更类型 (Type of Change)

- [x] 🐛 Bug 修复 (Bug fix)

## 影响范围 (Scope)

- [x] 数据库 (Database)

## 测试 (Testing)

- [x] 手动测试 (Manual testing)

## 检查清单 (Checklist)

- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [x] 变更不会产生新的警告

## 数据库迁移 (Database Migration)

- [x] 需要数据库迁移

修复现有迁移文件的语法错误，未新增迁移。
如数据库已处于 dirty state，需先执行：
`migrate force 16` 回退到上一版本，再重新运行迁移。