### PR TITLE
feat(preview): add localized document fullscreen toggle

### DIFF
--- a/frontend/src/components/document-preview.vue
+++ b/frontend/src/components/document-preview.vue
@@ -1,6 +1,6 @@
 // @ts-nocheck
 <script setup lang="ts">
-import { ref, shallowRef, watch, onUnmounted, nextTick, defineAsyncComponent } from 'vue';
+import { ref, shallowRef, watch, onUnmounted, nextTick, defineAsyncComponent, onMounted } from 'vue';
 import { previewKnowledgeFile } from '@/api/knowledge-base/index';
 import { MessagePlugin } from 'tdesign-vue-next';
 import hljs from 'highlight.js';
@@ -31,6 +31,32 @@ const docxContainer = ref<HTMLElement | null>(null);
 const imageNaturalWidth = ref(0);
 const imageNaturalHeight = ref(0);
 let loadedForId = '';
+
+const isFullscreen = ref(false);
+const previewContainerRef = ref<HTMLElement | null>(null);
+
+function toggleFullscreen() {
+  if (!document.fullscreenElement) {
+    if (previewContainerRef.value?.requestFullscreen) {
+      previewContainerRef.value.requestFullscreen().catch((err: any) => {
+        console.error(`Error attempting to enable fullscreen: ${err.message}`);
+      });
+    }
+  } else {
+    if (document.exitFullscreen) {
+      document.exitFullscreen();
+    }
+  }
+}
+
+function handleFullscreenChange() {
+  isFullscreen.value = !!document.fullscreenElement;
+}
+
+onMounted(() => {
+  document.addEventListener('fullscreenchange', handleFullscreenChange);
+});
+
 
 const fileTypeMap: Record<string, typeof previewType.value> = {};
 ['pdf'].forEach(t => fileTypeMap[t] = 'pdf');
@@ -296,12 +322,24 @@ watch(
 );
 
 onUnmounted(() => {
+  document.removeEventListener('fullscreenchange', handleFullscreenChange);
   cleanup();
 });
 </script>
 
 <template>
-  <div class="document-preview">
+  <div ref="previewContainerRef" class="document-preview" :class="{ 'is-fullscreen': isFullscreen }">
+    <!-- Toolbar -->
+    <div class="preview-toolbar" v-if="!loading && !error && previewType !== 'unsupported'">
+      <t-space size="small">
+        <t-tooltip :content="isFullscreen ? $t('preview.exitFullscreen') : $t('preview.fullscreen')" placement="bottom">
+          <t-button theme="default" variant="text" shape="square" @click="toggleFullscreen">
+            <template #icon><t-icon :name="isFullscreen ? 'fullscreen-exit' : 'fullscreen'" /></template>
+          </t-button>
+        </t-tooltip>
+      </t-space>
+    </div>
+
     <!-- Loading -->
     <div v-if="loading" class="preview-loading">
       <t-loading size="medium" />
@@ -397,6 +435,51 @@ onUnmounted(() => {
 
 .document-preview {
   min-height: 200px;
+  position: relative;
+}
+
+.is-fullscreen {
+  background: var(--td-bg-color-container);
+  padding: 0;
+  overflow-y: auto;
+  z-index: 1000;
+
+  .preview-container {
+    max-height: 100vh;
+  }
+
+  .preview-pdf, .preview-pptx {
+    height: 100vh;
+  }
+
+  .preview-docx {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    .docx-container {
+      max-height: 100vh;
+      height: 100%;
+      flex: 1;
+    }
+  }
+}
+
+.preview-toolbar {
+  position: absolute;
+  top: 8px;
+  right: 24px;
+  z-index: 10;
+  background: var(--td-bg-color-container);
+  border: 1px solid var(--td-component-border);
+  border-radius: var(--td-radius-default);
+  box-shadow: var(--td-shadow-1);
+  padding: 4px;
+  opacity: 0.6;
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 1;
+  }
 }
 
 // ── States ──

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2981,6 +2981,8 @@ export default {
     retry: 'Retry',
     unsupported: 'This file type does not support online preview',
     unsupportedHint: 'Please download and open with a local application',
+    fullscreen: 'Fullscreen',
+    exitFullscreen: 'Exit Fullscreen',
   },
   knowledgeSearch: {
     title: 'Search',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -3049,6 +3049,8 @@ export default {
     retry: '재시도',
     unsupported: '이 파일 유형은 온라인 미리보기를 지원하지 않습니다',
     unsupportedHint: '파일을 다운로드하여 로컬 앱으로 열어주세요',
+    fullscreen: '전체 화면',
+    exitFullscreen: '전체 화면 종료',
   },
   knowledgeSearch: {
     title: '검색',

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -2580,7 +2580,9 @@ export default {
     loadFailed: 'Не удалось загрузить предпросмотр документа',
     retry: 'Повторить',
     unsupported: 'Этот тип файла не поддерживает онлайн-просмотр',
-    unsupportedHint: 'Скачайте файл и откройте локально'
+    unsupportedHint: 'Скачайте файл и откройте локально',
+    fullscreen: 'Полноэкранный режим',
+    exitFullscreen: 'Выйти из полноэкранного режима',
   },
   knowledgeSearch: {
     title: 'Поиск',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2978,6 +2978,8 @@ export default {
     retry: "重试",
     unsupported: "该文件类型暂不支持在线预览",
     unsupportedHint: "请下载文件后使用本地应用查看",
+    fullscreen: "全屏预览",
+    exitFullscreen: "退出全屏",
   },
   knowledgeSearch: {
     title: "搜索",


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
此功能为文档预览组件新增了原生的局部全屏切换功能，对文档查看的优化。

## 变更类型 (Type of Change)
- [x] ✨ 新功能 (New feature)
- [x] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
- [x] 前端界面 (Frontend UI)

## 测试 (Testing)
- [x] 手动测试 (Manual testing)
- [x] 前端测试 (Frontend testing)

### 测试步骤 (Test Steps)
1. 在前端页面预览任意支持的文档格式（PDF, Docx）。
2. 点击预览框右上角的“全屏”按钮，确认容器能够顺利铺满全屏。
3. 对于 DOCX 文档，由于新增了弹性高度，确保其全屏时能够充分占据屏幕的垂直空间，底部不会再出现巨大的纯色留白。
4. 再次点击“退出全屏”，确认能正确回退到原始显示状态。
5. 切换系统的多语言设置（zh-CN, en-US, ko-KR, ru-RU），检查悬浮按钮的“全屏/退出全屏”文案提示是否能跟随当前语言进行国际化切换。

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常



## 数据库迁移 (Database Migration)
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
无

## 部署说明 (Deployment Notes)
无

