### PR TITLE
fix: improve auth error messages and unify username validation length

### DIFF
--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -87,7 +87,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 	user, err := h.userService.Register(ctx, &req)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to register user: %v", err)
-		appErr := errors.NewBadRequestError("Registration failed").WithDetails(err.Error())
+		appErr := errors.NewBadRequestError(err.Error())
 		c.Error(appErr)
 		return
 	}

--- a/internal/types/user.go
+++ b/internal/types/user.go
@@ -66,7 +66,7 @@ type LoginRequest struct {
 
 // RegisterRequest represents a registration request
 type RegisterRequest struct {
-	Username string `json:"username" binding:"required,min=3,max=50"`
+	Username string `json:"username" binding:"required,min=2,max=50"`
 	Email    string `json:"email"    binding:"required,email"`
 	Password string `json:"password" binding:"required,min=6"`
 }


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
本项目修复了注册过程中由于前后端校验不一致导致的用户困惑，并优化了注册失败相关的错误反馈处理。
1. **对齐逻辑**：将后端用户名最小长度从 3 修正为 2，确保与前端校验规则完全一致，消除了前端校验通过但后端拦截的问题。
2. **注册优化**：当注册失败（如邮箱或用户名重复）时，后端现在会返回具体的业务错误信息到 `message` 字段，使前端能够显示直观的错误原因。

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)
- [x] 🎨 代码重构 (Code refactoring)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)

## 测试 (Testing)
- [x] 手动测试 (Manual testing)

### 测试步骤 (Test Steps)
1. **注册测试**：使用已有的邮箱注册，确认前端弹窗显示 "user with this email already exists"。
2. **校验测试**：输入长度为 2 的用户名，确认可以成功提交且不再触发后端 `min=3` 的校验错误。


## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [x] 相关文档已更新
- [x] 变更不会产生新的警告
- [x] 不需要数据库迁移

## 相关 Issue
Fixes #

## 数据库迁移 (Database Migration)
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
不需要

## 部署说明 (Deployment Notes)
无特殊要求

## 其他信息 (Additional Information)
本次改动主要是提升用户注册时体验以及对前后端校验不一致的bug修复。
