### PR TITLE
修改MinIO endpoint 中错误地包含 http:// 或 https:// 前缀时的提示信息

### DIFF
--- a/internal/handler/system.go
+++ b/internal/handler/system.go
@@ -613,6 +613,8 @@ var cosFieldPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$`)
 func sanitizeStorageCheckError(err error) string {
 	msg := err.Error()
 	switch {
+	case strings.Contains(msg, "Endpoint url cannot have fully qualified paths"):
+		return "Endpoint 地址格式错误：请去除 http:// 或 https:// 前缀，只填写域名或 IP 地址和端口（例如：minio.example.com:9000）"
 	case strings.Contains(msg, "no such host"):
 		return "DNS 解析失败，请检查地址是否正确"
 	case strings.Contains(msg, "connection refused"):


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
<!-- 请简要描述这个 PR 的目的和变更内容 -->
当用户在 MinIO endpoint 中错误地包含 http:// 或 https:// 前缀时，原错误提示 '连接失败，请检查配置参数是否正确' 不够清晰。现在会明确提示用户去除协议前缀，只填写域名/IP和端口。

## 变更类型 (Type of Change)
<!-- 请选择适用的类型，删除其他选项 -->
- [x] ⚡ 提示信息优化 (Message improvement)

## 影响范围 (Scope)
<!-- 请选择受影响的组件，删除其他选项 -->
- [x] 后端 API (Backend API)

## 测试 (Testing)
<!-- 请描述如何测试这些变更 -->
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 配置存储引擎为minio，URL填写以http开头
2. 点测试连接
3. 查看提示信息

## 检查清单 (Checklist)
<!-- 请确保完成以下检查项 -->
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [x] 相关文档已更新
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常
- [x] 新功能和变更已更新到相关文档
- [x] 破坏性变更已在描述中明确说明

## 相关 Issue
<!-- 如果此 PR 解决了某个 issue，请使用 "Fixes #123" 或 "Closes #123" 的格式 -->
Fixes #

## 截图/录屏 (Screenshots/Recordings)
<!-- 如果是前端 UI 变更，请提供截图或录屏 -->
修改前：
<img width="640" height="629" alt="image" src="https://github.com/user-attachments/assets/2e2aba5b-9a54-429a-81b5-7d254a9dd783" />

修改后：
<img width="659" height="642" alt="image" src="https://github.com/user-attachments/assets/0387bead-70fe-4d0a-aed3-49ac559ad3db" />

## 数据库迁移 (Database Migration)
<!-- 如果涉及数据库变更，请说明 -->
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
<!-- 如果涉及配置变更，请说明需要更新的配置项 -->

## 部署说明 (Deployment Notes)
<!-- 如果有特殊的部署要求，请说明 -->

## 其他信息 (Additional Information)
<!-- 任何其他需要说明的信息 -->