### PR TITLE
fix: allow temperature 0, default if negative

### DIFF
--- a/internal/application/service/session_qa_helpers.go
+++ b/internal/application/service/session_qa_helpers.go
@@ -118,7 +118,7 @@ func (s *sessionService) applyAgentOverridesToChatManage(
 		cm.SummaryConfig.ContextTemplate = customAgent.Config.ContextTemplate
 		logger.Infof(ctx, "Using custom agent's context_template")
 	}
-	if customAgent.Config.Temperature > 0 {
+	if customAgent.Config.Temperature >= 0 {
 		cm.SummaryConfig.Temperature = customAgent.Config.Temperature
 		logger.Infof(ctx, "Using custom agent's temperature: %f", customAgent.Config.Temperature)
 	}

--- a/internal/handler/session/helpers.go
+++ b/internal/handler/session/helpers.go
@@ -286,7 +286,7 @@ func (h *Handler) createDefaultSummaryConfig(ctx context.Context) *types.Summary
 		if tenant.ConversationConfig.ContextTemplate != "" {
 			cfg.ContextTemplate = tenant.ConversationConfig.ContextTemplate
 		}
-		if tenant.ConversationConfig.Temperature > 0 {
+		if tenant.ConversationConfig.Temperature >= 0 {
 			cfg.Temperature = tenant.ConversationConfig.Temperature
 		}
 		if tenant.ConversationConfig.MaxCompletionTokens > 0 {
@@ -344,7 +344,7 @@ func (h *Handler) fillSummaryConfigDefaults(ctx context.Context, config *types.S
 	if config.ContextTemplate == "" {
 		config.ContextTemplate = defaultContextTemplate
 	}
-	if config.Temperature == 0 {
+	if config.Temperature < 0 {
 		config.Temperature = defaultTemperature
 	}
 	if config.MaxCompletionTokens == 0 {

--- a/internal/types/custom_agent.go
+++ b/internal/types/custom_agent.go
@@ -211,7 +211,7 @@ func (a *CustomAgent) EnsureDefaults() {
 	if a == nil {
 		return
 	}
-	if a.Config.Temperature == 0 {
+	if a.Config.Temperature < 0 {
 		a.Config.Temperature = 0.7
 	}
 	if a.Config.MaxIterations == 0 {


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
修复了在前端设置 LLM 温度（Temperature）为 `0` 时，后端会自动将其重置为默认值 `0.7` 的问题。原因在于后端逻辑中错误地将 `0` 视为空或无效值。现已修改逻辑，仅在温度为负数（非法值）时才回退默认值，完全支持 `0` 作为合法的确定性输出参数。

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [ ] 📚 文档更新 (Documentation update)
- [ ] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [ ] 🧪 测试相关 (Test related)
- [ ] 🔧 配置变更 (Configuration change)
- [ ] 🐳 Docker 相关 (Docker related)
- [ ] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)
- [ ] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [ ] 其他 (Other): <!-- 请说明 -->

## 测试 (Testing)
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 在智能体编辑器中，将“温度”参数拖动至 `0`。
2. 点击“保存”或“确定”。
3. 刷新页面或重新打开对话，确认温度值持久保持为 `0`，且对话时后端日志显示的温度参数为 `0.000000`。
4. 验证租户全局配置中的温度设置为 `0` 也能正确生效。

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
Fixes # (无)

## 截图/录屏 (Screenshots/Recordings)
(无)

## 数据库迁移 (Database Migration)
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
(无)

## 部署说明 (Deployment Notes)
(无)

## 其他信息 (Additional Information)
涉及修改的文件包括：
- [internal/types/custom_agent.go](cci:7://file:///Users/kirei/Code/WeKnora/internal/types/custom_agent.go:0:0-0:0): 修正 [EnsureDefaults](cci:1://file:///Users/kirei/Code/WeKnora/internal/types/custom_agent.go:208:0-252:1) 默认值填充逻辑。
- [internal/application/service/session_qa_helpers.go](cci:7://file:///Users/kirei/Code/WeKnora/internal/application/service/session_qa_helpers.go:0:0-0:0): 修正应用智能体配置覆盖时的判断条件。
- [internal/handler/session/helpers.go](cci:7://file:///Users/kirei/Code/WeKnora/internal/handler/session/helpers.go:0:0-0:0): 修正会话摘要配置默认填充逻辑。