### PR TITLE
fix: guard pg_search update with skip_embedding

### DIFF
--- a/migrations/versioned/000008_migrate_untagged_faq.up.sql
+++ b/migrations/versioned/000008_migrate_untagged_faq.up.sql
@@ -1,6 +1,14 @@
 -- Migration: Create "未分类" tag for each knowledge base that has untagged entries
 -- and update chunks, knowledges, and embeddings to reference the new tag
-ALTER EXTENSION pg_search UPDATE;
+DO $$
+BEGIN
+    IF current_setting('app.skip_embedding', true) = 'true' THEN
+        RAISE NOTICE 'Skipping pg_search update (app.skip_embedding=true)';
+        RETURN;
+    END IF;
+
+    ALTER EXTENSION pg_search UPDATE;
+END $$;
 
 DO $$
 DECLARE

--- a/migrations/versioned/000011_pg_search_update.up.sql
+++ b/migrations/versioned/000011_pg_search_update.up.sql
@@ -1,4 +1,12 @@
 -- Migration 000011: Update pg_search extension to latest version
 -- Equivalent to: psql -c 'ALTER EXTENSION pg_search UPDATE;'
 
-ALTER EXTENSION pg_search UPDATE;
+DO $$
+BEGIN
+    IF current_setting('app.skip_embedding', true) = 'true' THEN
+        RAISE NOTICE 'Skipping pg_search update (app.skip_embedding=true)';
+        RETURN;
+    END IF;
+
+    ALTER EXTENSION pg_search UPDATE;
+END $$;


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
skip_embedding 需要应用于以下两个迁移，不然 Postgres 会报错。

* 000008_migrate_untagged_faq.up.sql
* 000011_pg_search_update.up.sql

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)

## 影响范围 (Scope)
- [x] 数据库 (Database)

## 测试 (Testing)
- [x] 手动测试 (Manual testing)

### 测试步骤 (Test Steps)
1. 设置 RETRIEVE_DRIVER 为非 postgres
2. 使用 postgres 镜像
3. 跑迁移

预期不报错。

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [ ] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明