### PR TITLE
fix: add OpenRouter embedding provider support

### DIFF
--- a/frontend/src/components/ModelEditorDialog.vue
+++ b/frontend/src/components/ModelEditorDialog.vue
@@ -341,9 +341,12 @@ const fallbackProviderOptions = computed(() => [
   { 
     value: 'openrouter', 
     label: t('model.editor.providers.openrouter.label'), 
-    defaultUrls: { chat: 'https://openrouter.ai/api/v1' },
+    defaultUrls: {
+      chat: 'https://openrouter.ai/api/v1',
+      embedding: 'https://openrouter.ai/api/v1'
+    },
     description: t('model.editor.providers.openrouter.description'),
-    modelTypes: ['chat']
+    modelTypes: ['chat', 'embedding']
   },
   { 
     value: 'siliconflow', 
@@ -1608,4 +1611,3 @@ const handleOverlayMouseUp = () => {
   }
 }
 </style>
-

--- a/internal/models/provider/openrouter.go
+++ b/internal/models/provider/openrouter.go
@@ -25,10 +25,12 @@ func (p *OpenRouterProvider) Info() ProviderInfo {
 		Description: "openai/gpt-5.2-chat, google/gemini-3-flash-preview, etc.",
 		DefaultURLs: map[types.ModelType]string{
 			types.ModelTypeKnowledgeQA: OpenRouterBaseURL,
+			types.ModelTypeEmbedding:   OpenRouterBaseURL,
 			types.ModelTypeVLLM:        OpenRouterBaseURL,
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeEmbedding,
 			types.ModelTypeVLLM,
 		},
 		RequiresAuth: true,

--- a/internal/models/provider/provider_test.go
+++ b/internal/models/provider/provider_test.go
@@ -169,4 +169,20 @@ func TestListByModelType(t *testing.T) {
 		}
 		assert.True(t, found, "Aliyun should support rerank")
 	})
+
+	t.Run("embedding models include openrouter", func(t *testing.T) {
+		providers := ListByModelType(types.ModelTypeEmbedding)
+		assert.NotEmpty(t, providers)
+
+		found := false
+		for _, p := range providers {
+			if p.Name == ProviderOpenRouter {
+				found = true
+				assert.Equal(t, OpenRouterBaseURL, p.GetDefaultURL(types.ModelTypeEmbedding))
+				break
+			}
+		}
+
+		assert.True(t, found, "OpenRouter should support embedding")
+	})
 }


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
添加 Embedding 供应商支持 OpenRouter。

例如：https://openrouter.ai/google/gemini-embedding-001

## 变更类型 (Type of Change)
- [x] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
- [x] 前端界面 (Frontend UI)

## 测试 (Testing)
- [x] 单元测试 (Unit tests)
- [x] 手动测试 (Manual testing)

### 测试步骤 (Test Steps)
1. 页面上新增 Embedding 模型，选择 OpenRouter 作为供应商。
2. 输入模型名 google/gemini-embedding-001 & API Key
3. 测试 & 保存

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [ ] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明


## 截图/录屏 (Screenshots/Recordings)
<img width="1204" height="1672" alt="image" src="https://github.com/user-attachments/assets/bc5e1c6a-3c79-4a48-a612-d7e87674e130" />