### PR TITLE
feat: expose builtin parser engine in settings

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -3012,6 +3012,10 @@ export default {
       fileTypeText: 'Plain Text',
       fileTypeImage: 'Images',
       engines: {
+        builtin: {
+          name: 'Built-in',
+          desc: 'DocReader built-in parser engine (docx/pdf/xlsx and other complex formats)',
+        },
         simple: {
           name: 'Simple',
           desc: 'Simple format & image parsing (no external service required)',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -3069,6 +3069,10 @@ export default {
       fileTypeText: '일반 텍스트',
       fileTypeImage: '이미지',
       engines: {
+        builtin: {
+          name: '내장',
+          desc: 'DocReader 내장 파서 엔진 (docx/pdf/xlsx 등 복잡한 형식)',
+        },
         simple: {
           name: 'Simple',
           desc: '간단한 형식 및 이미지 파싱 (외부 서비스 불필요)',

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -2679,6 +2679,10 @@ export default {
       fileTypeText: 'Текстовые файлы',
       fileTypeImage: 'Изображения',
       engines: {
+        builtin: {
+          name: 'Встроенный',
+          desc: 'Встроенный парсер DocReader (docx/pdf/xlsx и другие сложные форматы)',
+        },
         simple: {
           name: 'Simple',
           desc: 'Простой формат и анализ изображений (внешний сервис не требуется)',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -3010,6 +3010,10 @@ export default {
       fileTypeText: "纯文本",
       fileTypeImage: "图片",
       engines: {
+        builtin: {
+          name: "内置",
+          desc: "DocReader 内置解析引擎（docx/pdf/xlsx 等复杂格式）",
+        },
         simple: {
           name: "Simple",
           desc: "简单格式 & 图片解析（无需外部服务）",

--- a/frontend/src/views/settings/ParserEngineSettings.vue
+++ b/frontend/src/views/settings/ParserEngineSettings.vue
@@ -26,18 +26,26 @@
       </div>
 
       <template v-else>
-        <!-- DocReader 未连接时显示占位 -->
+        <!-- 当后端未返回 builtin 引擎项时，仍展示 DocReader 状态卡片 -->
         <div v-if="!hasBuiltinEngine" class="engine-item first" data-model-type="builtin">
           <div class="engine-item-header">
             <div class="engine-title-row">
               <h3>builtin</h3>
-              <t-tag theme="danger" variant="light" size="small">{{ $t('settings.parser.disconnected') }}</t-tag>
+              <t-tag
+                :theme="connected ? 'success' : 'danger'"
+                variant="light"
+                size="small"
+              >{{ connected ? $t('settings.parser.connected') : $t('settings.parser.disconnected') }}</t-tag>
             </div>
             <p>{{ $t('settings.parser.builtinDesc') }}</p>
           </div>
           <div class="docreader-inline">
             <div class="status-line">
-              <t-tag theme="danger" variant="light" size="small">{{ $t('settings.parser.disconnected') }}</t-tag>
+              <t-tag
+                :theme="connected ? 'success' : 'danger'"
+                variant="light"
+                size="small"
+              >{{ connected ? $t('settings.parser.connected') : $t('settings.parser.disconnected') }}</t-tag>
               <t-tag theme="default" variant="light" size="small">{{ docreaderTransport === 'http' ? 'HTTP' : 'gRPC' }}</t-tag>
               <span v-if="docreaderAddrEnv" class="env-hint">{{ $t('settings.parser.currentAddr') }}: {{ docreaderAddrEnv }}</span>
             </div>
@@ -55,7 +63,7 @@
         >
           <div class="engine-item-header">
             <div class="engine-title-row">
-              <h3>{{ engine.Name }}</h3>
+              <h3>{{ getEngineDisplayName(engine.Name) }}</h3>
               <t-tag v-if="engine.Available" theme="success" variant="light" size="small">{{ $t('settings.parser.available') }}</t-tag>
               <t-tooltip v-else-if="engine.UnavailableReason" :content="engine.UnavailableReason" placement="top">
                 <t-tag theme="danger" variant="light" size="small" class="tag-with-tooltip">{{ $t('settings.parser.unavailable') }}</t-tag>
@@ -69,7 +77,7 @@
                 class="engine-doc-link"
               >{{ engineDocLabel(engine.Name) }} ↗</a>
             </div>
-            <p>{{ engine.Description }}</p>
+            <p>{{ getEngineDisplayDesc(engine.Name, engine.Description) }}</p>
           </div>
 
           <!-- builtin: DocReader 连接信息 -->
@@ -266,6 +274,18 @@ function engineDocLink(name: string): string | undefined {
 
 function engineDocLabel(_name: string): string {
   return t('settings.parser.docs')
+}
+
+function getEngineDisplayName(engineName: string): string {
+  const key = `kbSettings.parser.engines.${engineName}.name`
+  const translated = t(key)
+  return translated !== key ? translated : engineName
+}
+
+function getEngineDisplayDesc(engineName: string, fallback: string): string {
+  const key = `kbSettings.parser.engines.${engineName}.desc`
+  const translated = t(key)
+  return translated !== key ? translated : fallback
 }
 
 async function loadEngines() {

--- a/internal/infrastructure/docparser/engine_registry.go
+++ b/internal/infrastructure/docparser/engine_registry.go
@@ -25,9 +25,30 @@ func RegisterEngine(e EngineRegistration) {
 }
 
 func init() {
+	RegisterEngine(&builtinEngine{})
 	RegisterEngine(&simpleEngine{})
 	RegisterEngine(&mineruEngine{})
 	RegisterEngine(&mineruCloudEngine{})
+}
+
+// ---------------------------------------------------------------------------
+// builtin — DocReader-backed parser for complex document formats.
+// ---------------------------------------------------------------------------
+
+type builtinEngine struct{}
+
+func (e *builtinEngine) Name() string { return "builtin" }
+func (e *builtinEngine) Description() string {
+	return "DocReader built-in parser engine"
+}
+func (e *builtinEngine) FileTypes(_ bool) []string {
+	return []string{"docx", "doc", "pdf", "md", "markdown", "xlsx", "xls", "jpg", "jpeg", "png", "gif", "bmp", "tiff", "webp"}
+}
+func (e *builtinEngine) CheckAvailable(docreaderConnected bool, _ map[string]string) (bool, string) {
+	if docreaderConnected {
+		return true, ""
+	}
+	return false, "DocReader service not connected"
 }
 
 // SimpleEngineName is the engine name for Go-native simple format handling.


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
修复默认配置下 `builtin` 解析引擎未在页面上显示的问题。

本次修复包含：
- 后端补充注册 `builtin` 解析引擎，确保接口能够返回该引擎信息
- 前端在未返回 `builtin` 引擎项时，仍展示其状态卡片
- 补充 `builtin` 引擎的多语言名称和描述，统一页面展示文案

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)
- [x] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [ ] 其他 (Other): 

## 测试 (Testing)
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [x] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 启动系统并保持默认解析引擎配置
2. 打开 Settings 页面中的 Parser Engine 配置区域
3. 确认页面能够显示 `builtin` 引擎状态卡片，并正确展示连接状态、描述及多语言文案

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [ ] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
Fixes #

## 截图/录屏 (Screenshots/Recordings)
<img width="1806" height="1400" alt="image" src="https://github.com/user-attachments/assets/5e1ac15a-c820-4706-9416-947e4506dc6a" />

<img width="2190" height="1470" alt="image" src="https://github.com/user-attachments/assets/a5be48d1-9d46-4f09-addb-0e0f71272bd2" />

## 数据库迁移 (Database Migration)
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
无新增配置项。

## 部署说明 (Deployment Notes)
无特殊部署要求。

## 其他信息 (Additional Information)
本次变更不涉及数据库结构和外部接口协议变更，主要为引擎注册补全及前端展示修复。
