### PR TITLE
fix: use milvus result set length for empty search results

### DIFF
--- a/internal/application/repository/retriever/milvus/repository.go
+++ b/internal/application/repository/retriever/milvus/repository.go
@@ -1000,7 +1000,11 @@ func convertResultSet(resultSet []client.ResultSet) ([]*MilvusVectorEmbeddingWit
 		return results, scores, nil
 	}
 	set := resultSet[0]
-	resultLen := set.Fields[0].Len()
+	resultLen := set.Len()
+	if resultLen == 0 {
+		return results, scores, nil
+	}
+
 	for _, score := range set.Scores {
 		scores = append(scores, float64(score))
 	}


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
修复 Milvus 在空结果时的 Panic 的问题。

Milvus 在关键词检索 0 命中时会返回一个合法的 ResultSet：ResultCount=0, Fields=[], Scores=[], Err=nil。

当前代码错误地用 set.Fields[0].Len() 获取结果长度，导致在无命中场景下触发 index out of range panic。

```
panic: runtime error: index out of range [0] with length 0

goroutine 933 [running]:
github.com/Tencent/WeKnora/internal/application/repository/retriever/milvus.convertResultSet({0xc001ccf680?, 0x7f7e700?, 0xc00148b3e0?})
	/app/internal/application/repository/retriever/milvus/repository.go:1003 +0x113f
github.com/Tencent/WeKnora/internal/application/repository/retriever/milvus.(*milvusRepository).KeywordsRetrieve(0xc0000191d0, {0x7f7e700, 0xc00148b3e0}, {{0xc0015200b6, 0x6}, {0x0, 0x0, 0x0}, {0xc001be4008, 0x21, ...}, ...})
	/app/internal/application/repository/retriever/milvus/repository.go:745 +0x6f6
github.com/Tencent/WeKnora/internal/application/repository/retriever/milvus.(*milvusRepository).Retrieve(0xc0000191d0, {0x7f7e700, 0xc00148b3e0}, {{0xc0015200b6, 0x6}, {0x0, 0x0, 0x0}, {0xc001be4008, 0x21, ...}, ...})
	/app/internal/application/repository/retriever/milvus/repository.go:624 +0x197
github.com/Tencent/WeKnora/internal/application/service/retriever.(*KeywordsVectorHybridRetrieveEngineService).Retrieve(0xfabdeb?, {0x7f7e700?, 0xc00148b3e0?}, {{0xc0015200b6, 0x6}, {0x0, 0x0, 0x0}, {0xc001be4008, 0x21, ...}, ...})
	/app/internal/application/service/retriever/keywords_vector_hybrid_indexer.go:40 +0x5f
github.com/Tencent/WeKnora/internal/application/service/retriever.(*CompositeRetrieveEngine).Retrieve.func1({0x7f7e700, 0xc00148b3e0}, {{0xc0015200b6, 0x6}, {0x0, 0x0, 0x0}, {0xc001be4008, 0x21, 0x47}, ...}, ...)
	/app/internal/application/service/retriever/composite.go:45 +0x263
github.com/Tencent/WeKnora/internal/application/service/retriever.concurrentRetrieve.func1()
	/app/internal/application/service/retriever/composite.go:148 +0xbc
created by github.com/Tencent/WeKnora/internal/application/service/retriever.concurrentRetrieve in goroutine 931
	/app/internal/application/service/retriever/composite.go:146 +0xdc
```

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)
- [ ] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [ ] 其他 (Other): <!-- 请说明 -->

## 测试 (Testing)
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 使用 Milvus 作为存储
2. 使用搜索页面

预期不报错

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明