### PR TITLE
fix: respect global default storage engine when creating knowledge base (#772)

### DIFF
--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
@@ -348,7 +348,7 @@ const initFormData = (type: 'document' | 'faq' = 'document') => {
       parentChunkSize: 4096,
       childChunkSize: 384
     },
-    storageProvider: 'local' as string,
+    storageProvider: '' as string,
     multimodalConfig: {
       enabled: false,
       vllmModelId: ''


### PR DESCRIPTION
## Summary
- Changed the default `storageProvider` in `initFormData()` from hardcoded `'local'` to empty string `''`
- This allows `KBStorageSettings.vue` to properly apply the global default storage engine configuration (e.g., minio)

## Root Cause
`KnowledgeBaseEditorModal.vue` hardcoded `storageProvider: 'local'` in `initFormData()`. The child component `KBStorageSettings` tried to apply the global default, but since the value was already `'local'` (not empty), the global config was never applied.

Fixes #772