### PR TITLE
fix(chat): support native reasoning for vllm by bypassing go-openai limitations

### DIFF
--- a/internal/models/chat/provider_chat.go
+++ b/internal/models/chat/provider_chat.go
@@ -78,5 +78,6 @@ func (c *GenericChat) customizeRequest(req *openai.ChatCompletionRequest, opts *
 	req.ChatTemplateKwargs = map[string]interface{}{
 		"enable_thinking": thinking,
 	}
-	return nil, false // 使用标准请求（已修改）
+
+	return req, true
 }

--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -477,7 +477,7 @@ func (c *RemoteAPIChat) processStream(ctx context.Context, stream *openai.ChatCo
 		}
 
 		if len(response.Choices) > 0 {
-			c.processStreamDelta(ctx, &response.Choices[0], state, streamChan)
+			c.processStreamDelta(ctx, &response.Choices[0], state, streamChan, response.Choices[0].Delta.ReasoningContent)
 		}
 	}
 }
@@ -522,14 +522,39 @@ func (c *RemoteAPIChat) processRawHTTPStream(ctx context.Context, resp *http.Res
 			continue
 		}
 
-		var streamResp openai.ChatCompletionStreamResponse
+		// 使用局部结构体进行一次性解析，同时捕捉标准字段和 vLLM 的 reasoning 字段，避免性能损失
+		var streamResp struct {
+			openai.ChatCompletionStreamResponse
+			Choices []struct {
+				Index int `json:"index"`
+				Delta struct {
+					openai.ChatCompletionStreamChoiceDelta
+					Reasoning string `json:"reasoning,omitempty"`
+				} `json:"delta"`
+				FinishReason openai.FinishReason `json:"finish_reason"`
+			} `json:"choices"`
+		}
+
 		if err := json.Unmarshal(event.Data, &streamResp); err != nil {
 			logger.Errorf(ctx, "Failed to parse stream response: %v", err)
 			continue
 		}
 
 		if len(streamResp.Choices) > 0 {
-			c.processStreamDelta(ctx, &streamResp.Choices[0], state, streamChan)
+			choice := streamResp.Choices[0]
+			// 统一获取逻辑（支持标准和 vLLM 两种路径）
+			reasoning := choice.Delta.Reasoning
+			if reasoning == "" {
+				reasoning = choice.Delta.ReasoningContent
+			}
+
+			// 构造一个标准 SDK 兼容的 choice 对象传给下游，保证现有逻辑完全不动
+			sdkChoice := openai.ChatCompletionStreamChoice{
+				Index:        choice.Index,
+				Delta:        choice.Delta.ChatCompletionStreamChoiceDelta,
+				FinishReason: choice.FinishReason,
+			}
+			c.processStreamDelta(ctx, &sdkChoice, state, streamChan, reasoning)
 		}
 	}
 }
@@ -570,7 +595,7 @@ func (s *streamState) buildOrderedToolCalls() []types.LLMToolCall {
 }
 
 // processStreamDelta 处理流式响应的单个 delta
-func (c *RemoteAPIChat) processStreamDelta(ctx context.Context, choice *openai.ChatCompletionStreamChoice, state *streamState, streamChan chan types.StreamResponse) {
+func (c *RemoteAPIChat) processStreamDelta(ctx context.Context, choice *openai.ChatCompletionStreamChoice, state *streamState, streamChan chan types.StreamResponse, reasoningContent string) {
 	delta := choice.Delta
 	isDone := string(choice.FinishReason) != ""
 
@@ -580,11 +605,11 @@ func (c *RemoteAPIChat) processStreamDelta(ctx context.Context, choice *openai.C
 	}
 
 	// 发送思考内容（ReasoningContent，支持 DeepSeek 等模型）
-	if delta.ReasoningContent != "" {
+	if reasoningContent != "" {
 		state.hasThinking = true
 		streamChan <- types.StreamResponse{
 			ResponseType: types.ResponseTypeThinking,
-			Content:      delta.ReasoningContent,
+			Content:      reasoningContent,
 			Done:         false,
 		}
 	}


### PR DESCRIPTION
## 描述 (Description)
针对 新版本vLLM 推理型模型（如glm5等），增加了对原生推理字段 `reasoning` 的支持。

由于项目依赖的 **`github.com/sashabaranov/go-openai` 库长时间未维护**，无法及时收录推理型模型产生的非标准字段（如 `reasoning`），导致在标准 SDK 解析路径下该字段会被直接丢弃。为了解决这一局限性，本 PR 对vLLM的请求逻辑进行了调整：
1.  将 vLLM 供应商的解析路径切换至原始 HTTP 路径 (`useRawHTTP = true`)。
2.  利用已有的 [processRawHTTPStream](cci:1://file:///e:/Code/WeKnora/internal/models/chat/remote_api.go:484:0-559:1) 手动解析逻辑，精准捕捉并分发 `reasoning` 和 `reasoning_content` 增量，确保思考过程能在 UI 界面正常渲染。

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [ ] 📚 文档更新 (Documentation update)
- [x] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [ ] 🧪 测试相关 (Test related)
- [ ] 🔧 配置变更 (Configuration change)
- [ ] 🐳 Docker 相关 (Docker related)
- [x] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)
- [x] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [ ] 其他 (Other): <!-- 请说明 -->

## 测试 (Testing)
- [x] 手动测试 (Manual testing)
- [x] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 启动支持推理输出的 vLLM 服务端glm5模型。
2. 开启“思考模式”并提问，观察前端是否能正常流式展示模型的思考逻辑。

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 相关文档已更新
- [x] 变更不会产生新的警告
- [x] 破坏性变更已在描述中明确说明




## 数据库迁移 (Database Migration)
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
无

## 部署说明 (Deployment Notes)
无

## 其他信息 (Additional Information)
本次修改仅针对 [GenericChat](cci:2://file:///e:/Code/WeKnora/internal/models/chat/provider_chat.go:47:0-49:1) (vLLM) 生效，不会影响其他已适配特定厂商（如阿里云、腾讯云）的模型路径，保证了系统的整体稳定性。