### PR TITLE
fix(tenant): prevent api_key encryption loss on tenant settings update

### DIFF
--- a/internal/application/repository/tenant.go
+++ b/internal/application/repository/tenant.go
@@ -3,10 +3,12 @@ package repository
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/Tencent/WeKnora/internal/utils"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -93,9 +95,28 @@ func (r *tenantRepository) SearchTenants(ctx context.Context, keyword string, te
 	return tenants, total, nil
 }
 
-// UpdateTenant updates tenant
+// UpdateTenant updates tenant.
+// Handles api_key carefully because db.Updates() does not trigger the BeforeSave
+// GORM hook. Without this guard, AfterFind-decrypted plaintext would silently
+// overwrite the encrypted value in the database.
+//
+// Strategy:
+//   - enc:v1:… (pre-encrypted by CreateTenant / UpdateAPIKey): write as-is.
+//   - plaintext (decrypted by AfterFind): blank it so GORM skips the column.
+//   - SYSTEM_AES_KEY not set: write as-is (encryption disabled).
+//
+// The caller's in-memory struct is always restored after the write.
 func (r *tenantRepository) UpdateTenant(ctx context.Context, tenant *types.Tenant) error {
-	return r.db.WithContext(ctx).Model(&types.Tenant{}).Where("id = ?", tenant.ID).Updates(tenant).Error
+	origAPIKey := tenant.APIKey
+	if key := utils.GetAESKey(); key != nil && tenant.APIKey != "" &&
+		!strings.HasPrefix(tenant.APIKey, utils.EncPrefix) {
+		// Plaintext from AfterFind — do not write back; let the DB keep its
+		// existing encrypted value untouched.
+		tenant.APIKey = ""
+	}
+	err := r.db.WithContext(ctx).Model(&types.Tenant{}).Where("id = ?", tenant.ID).Updates(tenant).Error
+	tenant.APIKey = origAPIKey
+	return err
 }
 
 // DeleteTenant deletes tenant

--- a/internal/application/repository/tenant_test.go
+++ b/internal/application/repository/tenant_test.go
@@ -1,0 +1,168 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const testAESKey = "01234567890123456789012345678901" // 32 bytes
+
+// setupTestDB creates an in-memory SQLite database with tenant table.
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.Tenant{}))
+	return db
+}
+
+// insertTenantRaw inserts a tenant row with the given api_key value directly,
+// bypassing GORM hooks, to simulate an already-encrypted row in the DB.
+func insertTenantRaw(t *testing.T, db *gorm.DB, id uint64, apiKey string) {
+	t.Helper()
+	now := time.Now()
+	err := db.Exec(
+		"INSERT INTO tenants (id, name, api_key, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+		id, "test-tenant", apiKey, "active", now, now,
+	).Error
+	require.NoError(t, err)
+}
+
+// readAPIKeyRaw reads the raw api_key value from the database, bypassing GORM hooks.
+func readAPIKeyRaw(t *testing.T, db *gorm.DB, id uint64) string {
+	t.Helper()
+	var apiKey string
+	err := db.Raw("SELECT api_key FROM tenants WHERE id = ?", id).Scan(&apiKey).Error
+	require.NoError(t, err)
+	return apiKey
+}
+
+func TestUpdateTenant_PreservesEncryptedAPIKey(t *testing.T) {
+	t.Setenv("SYSTEM_AES_KEY", testAESKey)
+
+	db := setupTestDB(t)
+	key := utils.GetAESKey()
+	require.NotNil(t, key)
+
+	// Encrypt a known api_key and insert it directly into the DB.
+	originalPlaintext := "sk-my-secret-api-key"
+	encrypted, err := utils.EncryptAESGCM(originalPlaintext, key)
+	require.NoError(t, err)
+	insertTenantRaw(t, db, 1, encrypted)
+
+	// Verify the raw DB value is encrypted.
+	rawBefore := readAPIKeyRaw(t, db, 1)
+	assert.True(t, isEncrypted(rawBefore), "api_key should be encrypted in DB before update")
+
+	// Simulate what happens in the application:
+	// 1. Load tenant (AfterFind decrypts api_key)
+	var tenant types.Tenant
+	require.NoError(t, db.First(&tenant, 1).Error)
+	assert.Equal(t, originalPlaintext, tenant.APIKey, "AfterFind should decrypt api_key")
+
+	// 2. Modify a non-key field (simulating a config update via UpdateTenantKV)
+	tenant.Description = "updated description"
+
+	// 3. Save via repository's UpdateTenant
+	repo := NewTenantRepository(db)
+	require.NoError(t, repo.UpdateTenant(context.Background(), &tenant))
+
+	// 4. Verify: raw DB value must still be encrypted AND unchanged (no unnecessary re-encryption)
+	rawAfter := readAPIKeyRaw(t, db, 1)
+	assert.True(t, isEncrypted(rawAfter), "api_key must remain encrypted in DB after update")
+	assert.Equal(t, rawBefore, rawAfter, "api_key column should not be touched when only other fields change")
+
+	// 5. Verify: the in-memory struct should still have the decrypted value
+	assert.Equal(t, originalPlaintext, tenant.APIKey, "caller's struct should retain decrypted value")
+
+	// 6. Verify: round-trip — re-read from DB and decrypt
+	var reloaded types.Tenant
+	require.NoError(t, db.First(&reloaded, 1).Error)
+	assert.Equal(t, originalPlaintext, reloaded.APIKey, "re-loaded api_key should decrypt correctly")
+	assert.Equal(t, "updated description", reloaded.Description, "description should be updated")
+}
+
+func TestUpdateTenant_PreEncryptedAPIKeyIsWritten(t *testing.T) {
+	t.Setenv("SYSTEM_AES_KEY", testAESKey)
+
+	db := setupTestDB(t)
+	key := utils.GetAESKey()
+	require.NotNil(t, key)
+
+	// Insert a tenant with an initial encrypted api_key.
+	initialEncrypted, err := utils.EncryptAESGCM("sk-old-key", key)
+	require.NoError(t, err)
+	insertTenantRaw(t, db, 4, initialEncrypted)
+
+	// Simulate CreateTenant / UpdateAPIKey path:
+	// The service layer manually encrypts BEFORE calling repo.UpdateTenant.
+	newEncrypted, err := utils.EncryptAESGCM("sk-new-key", key)
+	require.NoError(t, err)
+
+	tenant := &types.Tenant{ID: 4, APIKey: newEncrypted}
+	repo := NewTenantRepository(db)
+	require.NoError(t, repo.UpdateTenant(context.Background(), tenant))
+
+	// The pre-encrypted value should be written to DB as-is.
+	rawAfter := readAPIKeyRaw(t, db, 4)
+	assert.Equal(t, newEncrypted, rawAfter, "pre-encrypted api_key should be written to DB")
+
+	// Round-trip: decrypt should yield the new key.
+	var reloaded types.Tenant
+	require.NoError(t, db.First(&reloaded, 4).Error)
+	assert.Equal(t, "sk-new-key", reloaded.APIKey)
+}
+
+func TestUpdateTenant_LegacyPlaintextNotOverwritten(t *testing.T) {
+	t.Setenv("SYSTEM_AES_KEY", testAESKey)
+
+	db := setupTestDB(t)
+
+	// Insert a tenant with a plaintext api_key (legacy row, pre-encryption era).
+	insertTenantRaw(t, db, 2, "sk-legacy-plaintext-key")
+
+	// Load tenant — AfterFind returns plaintext as-is (no enc:v1: prefix).
+	var tenant types.Tenant
+	require.NoError(t, db.First(&tenant, 2).Error)
+	assert.Equal(t, "sk-legacy-plaintext-key", tenant.APIKey)
+
+	// Update a non-key field via repository.
+	tenant.Description = "migrated"
+	repo := NewTenantRepository(db)
+	require.NoError(t, repo.UpdateTenant(context.Background(), &tenant))
+
+	// Legacy plaintext should NOT be overwritten — the column should remain untouched.
+	rawAfter := readAPIKeyRaw(t, db, 2)
+	assert.Equal(t, "sk-legacy-plaintext-key", rawAfter, "legacy plaintext api_key should remain untouched")
+}
+
+func TestUpdateTenant_NoEncryptionWithoutAESKey(t *testing.T) {
+	t.Setenv("SYSTEM_AES_KEY", "")
+
+	db := setupTestDB(t)
+	insertTenantRaw(t, db, 3, "sk-no-encryption")
+
+	var tenant types.Tenant
+	require.NoError(t, db.First(&tenant, 3).Error)
+	assert.Equal(t, "sk-no-encryption", tenant.APIKey)
+
+	tenant.Description = "no key env"
+	repo := NewTenantRepository(db)
+	require.NoError(t, repo.UpdateTenant(context.Background(), &tenant))
+
+	// Without SYSTEM_AES_KEY, api_key should remain as-is (no guard needed).
+	rawAfter := readAPIKeyRaw(t, db, 3)
+	assert.Equal(t, "sk-no-encryption", rawAfter)
+}
+
+func isEncrypted(s string) bool {
+	return len(s) > len(utils.EncPrefix) && s[:len(utils.EncPrefix)] == utils.EncPrefix
+}

--- a/internal/utils/crypto_test.go
+++ b/internal/utils/crypto_test.go
@@ -1,0 +1,95 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testAESKey = "01234567890123456789012345678901" // 32 bytes
+
+func TestEncryptAESGCM(t *testing.T) {
+	key := []byte(testAESKey)
+
+	t.Run("encrypts plaintext with enc:v1: prefix", func(t *testing.T) {
+		encrypted, err := EncryptAESGCM("sk-secret-key", key)
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(encrypted, EncPrefix))
+		assert.NotEqual(t, "sk-secret-key", encrypted)
+	})
+
+	t.Run("returns empty string as-is", func(t *testing.T) {
+		encrypted, err := EncryptAESGCM("", key)
+		require.NoError(t, err)
+		assert.Equal(t, "", encrypted)
+	})
+
+	t.Run("returns already encrypted string as-is (idempotent)", func(t *testing.T) {
+		first, err := EncryptAESGCM("sk-secret-key", key)
+		require.NoError(t, err)
+
+		second, err := EncryptAESGCM(first, key)
+		require.NoError(t, err)
+		assert.Equal(t, first, second, "re-encrypting should be a no-op")
+	})
+
+	t.Run("returns plaintext when key is nil", func(t *testing.T) {
+		encrypted, err := EncryptAESGCM("sk-secret-key", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "sk-secret-key", encrypted)
+	})
+}
+
+func TestDecryptAESGCM(t *testing.T) {
+	key := []byte(testAESKey)
+
+	t.Run("round-trip encrypt then decrypt", func(t *testing.T) {
+		original := "sk-my-secret-api-key"
+		encrypted, err := EncryptAESGCM(original, key)
+		require.NoError(t, err)
+
+		decrypted, err := DecryptAESGCM(encrypted, key)
+		require.NoError(t, err)
+		assert.Equal(t, original, decrypted)
+	})
+
+	t.Run("returns legacy plaintext as-is (no enc:v1: prefix)", func(t *testing.T) {
+		decrypted, err := DecryptAESGCM("sk-legacy-plaintext", key)
+		require.NoError(t, err)
+		assert.Equal(t, "sk-legacy-plaintext", decrypted)
+	})
+
+	t.Run("returns empty string as-is", func(t *testing.T) {
+		decrypted, err := DecryptAESGCM("", key)
+		require.NoError(t, err)
+		assert.Equal(t, "", decrypted)
+	})
+
+	t.Run("returns as-is when key is nil", func(t *testing.T) {
+		decrypted, err := DecryptAESGCM("enc:v1:something", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "enc:v1:something", decrypted)
+	})
+}
+
+func TestGetAESKey(t *testing.T) {
+	t.Run("returns key when SYSTEM_AES_KEY is 32 bytes", func(t *testing.T) {
+		t.Setenv("SYSTEM_AES_KEY", testAESKey)
+		key := GetAESKey()
+		assert.Equal(t, []byte(testAESKey), key)
+	})
+
+	t.Run("returns nil when SYSTEM_AES_KEY is not set", func(t *testing.T) {
+		t.Setenv("SYSTEM_AES_KEY", "")
+		key := GetAESKey()
+		assert.Nil(t, key)
+	})
+
+	t.Run("returns nil when SYSTEM_AES_KEY is wrong length", func(t *testing.T) {
+		t.Setenv("SYSTEM_AES_KEY", "too-short")
+		key := GetAESKey()
+		assert.Nil(t, key)
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #798

When a tenant setting is updated via `PUT /tenants/kv/{key}` (e.g., `retrieval-config`, `parser-engine-config`, `storage-engine-config`), the encrypted `api_key` is silently reverted to plaintext in the database.

**Root cause**: `tenantRepository.UpdateTenant()` uses `db.Updates()` which does not trigger GORM's `BeforeSave` hook. The `AfterFind` hook decrypts `enc:v1:...` → `sk-...` in the Go struct, and `Updates()` writes the plaintext back.

The existing codebase already handles this in `CreateTenant` and `UpdateAPIKey` with manual `EncryptAESGCM` calls and the comment _"because db.Updates() does not trigger BeforeSave hook"_, but the general `UpdateTenant` path was missing this treatment.

## Changes

Guard the repository's `UpdateTenant` to prevent writing AfterFind-decrypted plaintext back to the database:

- **`enc:v1:…` (pre-encrypted by CreateTenant / UpdateAPIKey)**: written as-is
- **plaintext (decrypted by AfterFind)**: blanked so GORM skips the column — the existing encrypted value in the DB remains untouched
- **SYSTEM_AES_KEY not set**: written as-is (encryption disabled)

The caller's in-memory struct is always restored after the write.

**Note**: `ModelParameters` JSONB encryption is not affected — its `Value()` method (implementing `driver.Valuer`) is correctly called by GORM during `Updates()`.

## Files changed

| File | Change |
|------|--------|
| `internal/application/repository/tenant.go` | Guard `UpdateTenant` to skip plaintext api_key writes |
| `internal/application/repository/tenant_test.go` | 4 test scenarios with SQLite in-memory DB |
| `internal/utils/crypto_test.go` | Unit tests for `EncryptAESGCM`, `DecryptAESGCM`, `GetAESKey` |

## Test plan

- [x] Unit tests: `go test ./internal/utils/ -run "TestEncrypt|TestDecrypt|TestGetAESKey"` — 11 PASS
- [x] Repository tests: `go test ./internal/application/repository/ -run TestUpdateTenant` — 4 PASS
- [x] Build: `go build ./...` — OK
- [x] E2E: Started dev server (`docker-compose.dev.yml` + `go run`), created new tenant, updated `retrieval-config`, verified DB `api_key` column stays `enc:v1:...` and **unchanged** (no unnecessary re-encryption)