### PR TITLE
feat: upgrade MiniMax models from M2.1 to M2.7

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2128,7 +2128,7 @@ export default {
         },
         minimax: {
           label: 'MiniMax',
-          description: 'MiniMax-M2.1, MiniMax-M2.1-lightning, etc.',
+          description: 'MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, etc.',
         },
         mimo: {
           label: 'MiMo',
@@ -2172,7 +2172,7 @@ export default {
         },
         novita: {
           label: "Novita AI",
-          description: "moonshotai/kimi-k2.5, zai-org/glm-5, minimax/minimax-m2.5, qwen/qwen3-embedding-0.6b, etc.",
+          description: "moonshotai/kimi-k2.5, zai-org/glm-5, minimax/minimax-m2.7, qwen/qwen3-embedding-0.6b, etc.",
         },
       },
     },

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -1592,7 +1592,7 @@ export default {
         },
         minimax: {
           label: "MiniMax",
-          description: "MiniMax-M2.1, MiniMax-M2.1-lightning 등",
+          description: "MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5 등",
         },
         mimo: {
           label: "MiMo",
@@ -1636,7 +1636,7 @@ export default {
         },
         novita: {
           label: "Novita AI",
-          description: "moonshotai/kimi-k2.5, zai-org/glm-5, minimax/minimax-m2.5, qwen/qwen3-embedding-0.6b 등",
+          description: "moonshotai/kimi-k2.5, zai-org/glm-5, minimax/minimax-m2.7, qwen/qwen3-embedding-0.6b 등",
         },
       },
     },

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -1430,7 +1430,7 @@ export default {
         },
         minimax: {
           label: 'MiniMax',
-          description: 'MiniMax-M2.1, MiniMax-M2.1-lightning, etc.'
+          description: 'MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, etc.'
         },
         mimo: {
           label: 'MiMo',
@@ -1474,7 +1474,7 @@ export default {
         },
         novita: {
           label: "Novita AI",
-          description: "moonshotai/kimi-k2.5, zai-org/glm-5, minimax/minimax-m2.5, qwen/qwen3-embedding-0.6b, etc.",
+          description: "moonshotai/kimi-k2.5, zai-org/glm-5, minimax/minimax-m2.7, qwen/qwen3-embedding-0.6b, etc.",
         },
       }
     },

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1581,7 +1581,7 @@ export default {
         },
         minimax: {
           label: "MiniMax",
-          description: "MiniMax-M2.1, MiniMax-M2.1-lightning 等",
+          description: "MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5 等",
         },
         mimo: {
           label: "小米 MiMo",
@@ -1625,7 +1625,7 @@ export default {
         },
         novita: {
             label: "Novita AI",
-            description: "moonshotai/kimi-k2.5, zai-org/glm-5, minimax/minimax-m2.5, qwen/qwen3-embedding-0.6b 等",
+            description: "moonshotai/kimi-k2.5, zai-org/glm-5, minimax/minimax-m2.7, qwen/qwen3-embedding-0.6b 等",
         },
       },
     },

--- a/internal/models/provider/minimax.go
+++ b/internal/models/provider/minimax.go
@@ -25,7 +25,7 @@ func (p *MiniMaxProvider) Info() ProviderInfo {
 	return ProviderInfo{
 		Name:        ProviderMiniMax,
 		DisplayName: "MiniMax",
-		Description: "MiniMax-M2.1, MiniMax-M2.1-lightning, etc.",
+		Description: "MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, etc.",
 		DefaultURLs: map[types.ModelType]string{
 			types.ModelTypeKnowledgeQA: MiniMaxCNBaseURL,
 		},

--- a/internal/models/provider/novita.go
+++ b/internal/models/provider/novita.go
@@ -23,7 +23,7 @@ func (p *NovitaProvider) Info() ProviderInfo {
 	return ProviderInfo{
 		Name:        ProviderNovita,
 		DisplayName: "Novita AI",
-		Description: "moonshotai/kimi-k2.5, zai-org/glm-5, minimax/minimax-m2.5, qwen/qwen3-embedding-0.6b, etc.",
+		Description: "moonshotai/kimi-k2.5, zai-org/glm-5, minimax/minimax-m2.7, qwen/qwen3-embedding-0.6b, etc.",
 		DefaultURLs: map[types.ModelType]string{
 			types.ModelTypeKnowledgeQA: NovitaOpenAIBaseURL,
 			types.ModelTypeEmbedding:   NovitaOpenAIBaseURL,

--- a/internal/models/provider/provider_test.go
+++ b/internal/models/provider/provider_test.go
@@ -128,6 +128,46 @@ func TestAliyunModelDetection(t *testing.T) {
 	})
 }
 
+func TestMiniMaxProviderValidation(t *testing.T) {
+	p := &MiniMaxProvider{}
+
+	t.Run("valid config", func(t *testing.T) {
+		config := &Config{
+			APIKey:    "test-key",
+			ModelName: "MiniMax-M2.7",
+		}
+		err := p.ValidateConfig(config)
+		assert.NoError(t, err)
+	})
+
+	t.Run("missing API key", func(t *testing.T) {
+		config := &Config{
+			ModelName: "MiniMax-M2.7",
+		}
+		err := p.ValidateConfig(config)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "API key")
+	})
+
+	t.Run("missing model name", func(t *testing.T) {
+		config := &Config{
+			APIKey: "test-key",
+		}
+		err := p.ValidateConfig(config)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "model name")
+	})
+
+	t.Run("info", func(t *testing.T) {
+		info := p.Info()
+		assert.Equal(t, ProviderMiniMax, info.Name)
+		assert.Equal(t, "MiniMax", info.DisplayName)
+		assert.Contains(t, info.ModelTypes, types.ModelTypeKnowledgeQA)
+		assert.True(t, info.RequiresAuth)
+		assert.Contains(t, info.Description, "M2.7")
+	})
+}
+
 func TestZhipuProviderValidation(t *testing.T) {
 	p := &ZhipuProvider{}
 


### PR DESCRIPTION
## Summary

Upgrade MiniMax model references from the legacy M2.1/M2.1-lightning to the latest M2.7/M2.7-highspeed across the provider definition, i18n locales, and Novita AI cross-reference.

MiniMax-M2.7 is the latest flagship model (1M context, 1.6x faster), superseding M2.5 and the older M2.1 series.

### Changes

- **internal/models/provider/minimax.go** - update provider description to MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5
- **internal/models/provider/novita.go** - update Novita MiniMax model reference from minimax-m2.5 to minimax-m2.7
- **frontend/src/i18n/locales/{en-US,zh-CN,ko-KR,ru-RU}.ts** - update MiniMax description strings in all 4 locales
- **internal/models/provider/provider_test.go** - add TestMiniMaxProviderValidation covering config validation, info metadata, and M2.7 description assertion

## Test Plan

- [x] go test ./internal/models/provider/... - all existing + new tests pass
- [ ] Verify MiniMax provider shows updated model names in the frontend model selector