### PR TITLE
fix: update doc-content.vue renderer to marked v5+ token API

### DIFF
--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -172,7 +172,7 @@ const checkImage = (url) => {
     img.src = url;
   });
 };
-renderer.image = function (href: string, title: string | null, text: string) {
+renderer.image = function ({href, title, text}) {
   if (!isValidImageURL(href)) {
     return `<p>${t('error.invalidImageLink')}</p>`;
   }
@@ -185,7 +185,7 @@ renderer.image = function (href: string, title: string | null, text: string) {
 };
 
 // 自定义代码块渲染器，只显示语言标签
-renderer.code = function (text: string, lang?: string) {
+renderer.code = function ({text, lang}) {
   // Mermaid 图表处理
   if (lang === 'mermaid') {
     // 生成唯一ID


### PR DESCRIPTION
## Summary

Fixes #828

`doc-content.vue` (Knowledge Base document detail viewer) still uses the marked v4 renderer API signatures (`renderer.image(href, title, text)` and `renderer.code(text, lang)`), while the project has upgraded to marked v17. This causes markdown images to render with truncated URLs and code blocks to break in the KB document view.

Commit `5c0b265` (fix: marked usage errors) fixed the same issue in `botmsg.vue`, `mermaidShared.ts`, and `document-preview.vue`, but missed `doc-content.vue`.

## Changes

- `renderer.image(href, title, text)` → `renderer.image({href, title, text})` — migrate to v5+ token object destructuring
- `renderer.code(text, lang)` → `renderer.code({text, lang})` — migrate to v5+ token object destructuring

## Test plan

- [x] Build: `npm run build` — OK (Node 22, vite v7.2.2)
- [x] Type check: `vue-tsc --noEmit` — OK
- [x] E2E: Knowledge Base → document card click → images render correctly with full URLs
- [x] E2E: Code blocks (including Mermaid) render correctly in document detail view
- [x] Regression: Chat view (`botmsg.vue`) image rendering unaffected

## Related

- `5c0b265` fix: marked usage errors — same fix applied to other components, `doc-content.vue` was missed