### PR TITLE
feat(knowledge): resolve remote images in file upload path

### DIFF
--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -7576,7 +7576,20 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 			convertResult.MarkdownContent = updatedMarkdown
 		}
 		storedImages = images
-		logger.Infof(ctx, "Resolved %d images for knowledge %s", len(storedImages), knowledge.ID)
+
+		// Resolve remote http(s) images (e.g. markdown external URLs) → download + upload to storage.
+		// ResolveAndStore handles inline bytes and base64; ResolveRemoteImages handles http/https URLs.
+		updatedContent, remoteImages, remoteErr := s.imageResolver.ResolveRemoteImages(ctx, convertResult.MarkdownContent, fileSvc, tenantID)
+		if remoteErr != nil {
+			logger.Warnf(ctx, "Remote image resolution partially failed: %v", remoteErr)
+		}
+		if len(remoteImages) > 0 {
+			logger.Infof(ctx, "Resolved %d remote images for knowledge %s", len(remoteImages), knowledge.ID)
+			convertResult.MarkdownContent = updatedContent
+			storedImages = append(storedImages, remoteImages...)
+		}
+
+		logger.Infof(ctx, "Resolved %d total images for knowledge %s", len(storedImages), knowledge.ID)
 	}
 
 	// Step 3: Split into chunks using Go chunker


### PR DESCRIPTION
Closes #841

## Overview

Markdown files with external image URLs (`![](https://...)`) uploaded to a VLM-enabled Knowledge Base are not processed by the multimodal pipeline. The file upload path (`ProcessDocument`) only calls `ResolveAndStore()`, which explicitly skips `http://`/`https://` URLs. This PR adds a `ResolveRemoteImages()` call to match the existing manual processing path behavior.

## Why

This regression was introduced during the Python→Go migration (WeKnora Lite, `397689d`). The original Python `base_parser.py` handled external image download in `process_chunks_images()`. When image processing moved to Go, `ResolveRemoteImages()` was implemented (`3450ed5`) but only connected to the manual input path — the file upload path was missed.

## Changes

**`internal/application/service/knowledge.go`** (1 file, +14/-1):
- Add `ResolveRemoteImages()` call after `ResolveAndStore()` in `ProcessDocument()` Step 2
- Follows the same pattern as `triggerManualProcessing()` (variable naming, log-then-assign order)
- Appends remote stored images to `storedImages` so `enqueueImageMultimodalTasks()` picks them up for VLM OCR + Caption

No new functions, packages, or dependencies. `ResolveRemoteImages()` already has SSRF-safe HTTP client, icon filtering, 10MB size limit, 30 image count limit, and 15s per-image timeout.

## Core

Single change point — review `internal/application/service/knowledge.go` L7578-7591.

## Test Plan

- [x] Build: `go build ./...` passes
- [x] Existing tests: `go test ./internal/infrastructure/docparser/...` — all `ResolveRemoteImages` tests pass (SSRF blocking, non-image content type, provider scheme skip, no-images, server errors)
- [x] E2E: Upload markdown file with external image URLs to VLM-enabled KB → verify images are downloaded, stored with `provider://` URLs, and VLM OCR/Caption chunks are created
- [x] E2E: Upload markdown file with inaccessible image URLs (404, auth-required) → verify graceful degradation (original URL preserved, no crash)
- [x] Regression: Existing PDF/DOCX image processing unchanged
- [x] Regression: Manual input path image processing unchanged

## Notes

- Download failure is graceful: original URL is preserved in markdown, no VLM task enqueued for that image
- `ResolveAndStore()` already handles `ResolveDataURIImages()` internally, so base64 images in uploaded markdown files are already covered