### PR TITLE
refactor(chat): simplify temperature option handling in chat request builders (#793)

### DIFF
--- a/internal/models/chat/ollama.go
+++ b/internal/models/chat/ollama.go
@@ -93,9 +93,7 @@ func (c *OllamaChat) buildChatRequest(messages []Message, opts *ChatOptions, isS
 
 	// 添加可选参数
 	if opts != nil {
-		if opts.Temperature > 0 {
-			chatReq.Options["temperature"] = opts.Temperature
-		}
+		chatReq.Options["temperature"] = opts.Temperature
 		if opts.TopP > 0 {
 			chatReq.Options["top_p"] = opts.TopP
 		}

--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -177,9 +177,7 @@ func (c *RemoteAPIChat) BuildChatCompletionRequest(messages []Message, opts *Cha
 	}
 
 	if opts != nil {
-		if opts.Temperature > 0 {
-			req.Temperature = float32(opts.Temperature)
-		}
+		req.Temperature = float32(opts.Temperature)
 		if opts.TopP > 0 {
 			req.TopP = float32(opts.TopP)
 		}


### PR DESCRIPTION


- Streamlined the handling of the temperature option in both OllamaChat and RemoteAPIChat by removing unnecessary conditional checks.
- Ensured that the temperature value is directly assigned when options are provided, improving code clarity and reducing complexity.

fix #793 
