### PR TITLE
fix(web_fetch): use ValidateURLForSSRF instead of removed IsSSRFSafeURL

### DIFF
--- a/internal/infrastructure/web_fetch/fetcher.go
+++ b/internal/infrastructure/web_fetch/fetcher.go
@@ -31,8 +31,8 @@ func FetchURLContent(ctx context.Context, rawURL string) (string, error) {
 	}
 
 	// SSRF validation
-	if safe, reason := utils.IsSSRFSafeURL(rawURL); !safe {
-		return "", fmt.Errorf("URL rejected: %s", reason)
+	if err := utils.ValidateURLForSSRF(rawURL); err != nil {
+		return "", fmt.Errorf("URL rejected: %w", err)
 	}
 
 	u, err := url.Parse(rawURL)


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
<!-- 请简要描述这个 PR 的目的和变更内容 -->
PR（#858）的`web_fetch/fetcher.go` 中调用了前面的PR（#856）刚移除的exported 函数 `utils.IsSSRFSafeURL`，导致编译失败。将其替换为统一的公开 API `utils.ValidateURLForSSRF`。

背景：`util.IsSSRFSafeURL` 已被更新为内部函数，所有外部调用方应统一使用 `ValidateURLForSSRF`，该函数额外支持白名单跳过和 scheme 自动补全
原因是已有的 isSSRFSafeURL 是严格模式——直接封杀所有 IP 地址，不看白名单。如果外部直接调它，白名单就形同虚设了

## 变更类型 (Type of Change)
<!-- 请选择适用的类型，删除其他选项 -->
- [x] 🐛 Bug 修复 (Bug fix)

## 影响范围 (Scope)
<!-- 请选择受影响的组件，删除其他选项 -->
- [x] 后端 API (Backend API)

## 测试 (Testing)
<!-- 请描述如何测试这些变更 -->
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. `docker compose build app` 验证编译通过
2. 调用 web fetch 相关接口，验证 SSRF 校验正常工作

## 检查清单 (Checklist)
<!-- 请确保完成以下检查项 -->
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [ ] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
<!-- 如果此 PR 解决了某个 issue，请使用 "Fixes #123" 或 "Closes #123" 的格式 -->
Fixes #

## 截图/录屏 (Screenshots/Recordings)
<!-- 如果是前端 UI 变更，请提供截图或录屏 -->

## 数据库迁移 (Database Migration)
<!-- 如果涉及数据库变更，请说明 -->
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
<!-- 如果涉及配置变更，请说明需要更新的配置项 -->

## 部署说明 (Deployment Notes)
<!-- 如果有特殊的部署要求，请说明 -->

## 其他信息 (Additional Information)
<!-- 任何其他需要说明的信息 -->