### PR TITLE
fix: docreader add monkey patch for docx parse error

### DIFF
--- a/docreader/parser/docx_parser.py
+++ b/docreader/parser/docx_parser.py
@@ -11,9 +11,10 @@ from io import BytesIO
 from multiprocessing import Manager
 from typing import Any, Dict, List, Optional, Tuple
 
+
+# patch from https://github.com/python-openxml/python-docx/issues/1105#issuecomment-1298075246
 from docx.opc.pkgreader import _SerializedRelationships, _SerializedRelationship
 from docx.opc.oxml import parse_xml
-
 
 def load_from_xml_v2(baseURI, rels_item_xml):
     """
@@ -29,7 +30,6 @@ def load_from_xml_v2(baseURI, rels_item_xml):
                 continue
             srels._srels.append(_SerializedRelationship(baseURI, rel_elm))
     return srels
-
 
 _SerializedRelationships.load_from_xml = load_from_xml_v2
 


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
上传特定docsx文件时docsreader报错 KeyError: "There is no item named 'word/NULL' in the archive"
报错类似这个 https://github.com/python-openxml/python-docx/issues/797
这个issue里提到了另一个issue里提供的解决方法 https://github.com/python-openxml/python-docx/issues/1105#issuecomment-1298075246
并且后者的issue提交者提供了一个有问题的文件可供测试
本PR完全使用issue中提到的monkey patch代码，经测试可以正常解析有问题的文件。

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)


## 影响范围 (Scope)
- [x] 文档解析服务 (Document Reader Service)


## 测试 (Testing)
- [x] 手动测试 (Manual testing)


### 测试步骤 (Test Steps)
1. 导入https://github.com/python-openxml/python-docx/issues/1105#issue-1282134399 提到的 [WordHasSomeProblem.docx](https://github.com/python-openxml/python-docx/files/8966092/WordHasSomeProblem.docx) 文件，并导入知识库
2. 观察导入结果和docreader日志

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [x] 相关文档已更新
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常
- [x] 新功能和变更已更新到相关文档
- [x] 破坏性变更已在描述中明确说明

## 相关 Issue
Fixes #861

## 截图/录屏 (Screenshots/Recordings)
<!-- 如果是前端 UI 变更，请提供截图或录屏 -->

## 数据库迁移 (Database Migration)
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
<!-- 如果涉及配置变更，请说明需要更新的配置项 -->

## 部署说明 (Deployment Notes)
<!-- 如果有特殊的部署要求，请说明 -->

## 其他信息 (Additional Information)
<!-- 任何其他需要说明的信息 -->