### PR TITLE
fix(elasticsearch): restore ".keyword" suffix for Terms queries on ID fields

### DIFF
--- a/internal/application/repository/retriever/elasticsearch/structs.go
+++ b/internal/application/repository/retriever/elasticsearch/structs.go
@@ -7,40 +7,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 )
 
-// VectorEmbedding defines the Elasticsearch document structure for vector embeddings.
-//
-// Expected index mapping (all ID fields must be "keyword" type, not "text"):
-//
-//	{
-//	  "settings": {
-//	    "analysis": {
-//	      "analyzer": {
-//	        "ik_max_word": { "type": "custom", "tokenizer": "ik_max_word" },
-//	        "ik_smart":    { "type": "custom", "tokenizer": "ik_smart" }
-//	      }
-//	    }
-//	  },
-//	  "mappings": {
-//	    "dynamic_templates": [
-//	      { "strings": { "match_mapping_type": "string", "mapping": { "type": "keyword" } } }
-//	    ],
-//	    "properties": {
-//	      "content":           { "type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart" },
-//	      "chunk_id":          { "type": "keyword" },
-//	      "knowledge_id":      { "type": "keyword" },
-//	      "knowledge_base_id": { "type": "keyword" },
-//	      "source_id":         { "type": "keyword" },
-//	      "tag_id":            { "type": "keyword" },
-//	      "source_type":       { "type": "long" },
-//	      "is_enabled":        { "type": "boolean" },
-//	      "is_recommended":    { "type": "boolean" },
-//	      "embedding":         { "type": "dense_vector", "dims": "<model_dims>" }
-//	    }
-//	  }
-//	}
-//
-// IMPORTANT: Do NOT use ".keyword" suffix in queries for ID fields (e.g. use "chunk_id", not
-// "chunk_id.keyword"), because these fields are already "keyword" type without a ".keyword" sub-field.
+// VectorEmbedding defines the Elasticsearch document structure for vector embeddings
 type VectorEmbedding struct {
 	Content         string    `json:"content"           gorm:"column:content;not null"`     // Text content of the chunk
 	SourceID        string    `json:"source_id"         gorm:"column:source_id;not null"`   // ID of the source document

--- a/internal/application/repository/retriever/elasticsearch/v7/repository.go
+++ b/internal/application/repository/retriever/elasticsearch/v7/repository.go
@@ -288,19 +288,19 @@ func (e *elasticsearchRepository) countBulkErrors(ctx context.Context,
 
 // DeleteByChunkIDList Delete indices by chunk ID list
 func (e *elasticsearchRepository) DeleteByChunkIDList(ctx context.Context, chunkIDList []string, dimension int, knowledgeType string) error {
-	return e.deleteByFieldList(ctx, "chunk_id", chunkIDList)
+	return e.deleteByFieldList(ctx, "chunk_id.keyword", chunkIDList)
 }
 
 // DeleteBySourceIDList Delete indices by source ID list
 func (e *elasticsearchRepository) DeleteBySourceIDList(ctx context.Context, sourceIDList []string, dimension int, knowledgeType string) error {
-	return e.deleteByFieldList(ctx, "source_id", sourceIDList)
+	return e.deleteByFieldList(ctx, "source_id.keyword", sourceIDList)
 }
 
 // DeleteByKnowledgeIDList Delete indices by knowledge ID list
 func (e *elasticsearchRepository) DeleteByKnowledgeIDList(ctx context.Context,
 	knowledgeIDList []string, dimension int, knowledgeType string,
 ) error {
-	return e.deleteByFieldList(ctx, "knowledge_id", knowledgeIDList)
+	return e.deleteByFieldList(ctx, "knowledge_id.keyword", knowledgeIDList)
 }
 
 // deleteByFieldList Delete documents by field value list
@@ -368,14 +368,14 @@ func (e *elasticsearchRepository) getBaseConds(params typesLocal.RetrieveParams)
 	if len(params.KnowledgeBaseIDs) > 0 {
 		must = append(must, map[string]interface{}{
 			"terms": map[string]interface{}{
-				"knowledge_base_id": params.KnowledgeBaseIDs,
+				"knowledge_base_id.keyword": params.KnowledgeBaseIDs,
 			},
 		})
 	}
 	if len(params.KnowledgeIDs) > 0 {
 		must = append(must, map[string]interface{}{
 			"terms": map[string]interface{}{
-				"knowledge_id": params.KnowledgeIDs,
+				"knowledge_id.keyword": params.KnowledgeIDs,
 			},
 		})
 	}
@@ -383,7 +383,7 @@ func (e *elasticsearchRepository) getBaseConds(params typesLocal.RetrieveParams)
 	if len(params.TagIDs) > 0 {
 		must = append(must, map[string]interface{}{
 			"terms": map[string]interface{}{
-				"tag_id": params.TagIDs,
+				"tag_id.keyword": params.TagIDs,
 			},
 		})
 	}
@@ -400,14 +400,14 @@ func (e *elasticsearchRepository) getBaseConds(params typesLocal.RetrieveParams)
 	if len(params.ExcludeKnowledgeIDs) > 0 {
 		mustNot = append(mustNot, map[string]interface{}{
 			"terms": map[string]interface{}{
-				"knowledge_id": params.ExcludeKnowledgeIDs,
+				"knowledge_id.keyword": params.ExcludeKnowledgeIDs,
 			},
 		})
 	}
 	if len(params.ExcludeChunkIDs) > 0 {
 		mustNot = append(mustNot, map[string]interface{}{
 			"terms": map[string]interface{}{
-				"chunk_id": params.ExcludeChunkIDs,
+				"chunk_id.keyword": params.ExcludeChunkIDs,
 			},
 		})
 	}
@@ -1185,7 +1185,7 @@ func (e *elasticsearchRepository) BatchUpdateChunkEnabledStatus(
 		query := map[string]interface{}{
 			"query": map[string]interface{}{
 				"terms": map[string]interface{}{
-					"chunk_id": enabledChunkIDs,
+					"chunk_id.keyword": enabledChunkIDs,
 				},
 			},
 			"script": map[string]interface{}{
@@ -1220,7 +1220,7 @@ func (e *elasticsearchRepository) BatchUpdateChunkEnabledStatus(
 		query := map[string]interface{}{
 			"query": map[string]interface{}{
 				"terms": map[string]interface{}{
-					"chunk_id": disabledChunkIDs,
+					"chunk_id.keyword": disabledChunkIDs,
 				},
 			},
 			"script": map[string]interface{}{
@@ -1278,7 +1278,7 @@ func (e *elasticsearchRepository) BatchUpdateChunkTagID(
 		query := map[string]interface{}{
 			"query": map[string]interface{}{
 				"terms": map[string]interface{}{
-					"chunk_id": chunkIDs,
+					"chunk_id.keyword": chunkIDs,
 				},
 			},
 			"script": map[string]interface{}{

--- a/internal/application/repository/retriever/elasticsearch/v8/repository.go
+++ b/internal/application/repository/retriever/elasticsearch/v8/repository.go
@@ -175,7 +175,7 @@ func (e *elasticsearchRepository) DeleteByChunkIDList(ctx context.Context, chunk
 	log.Infof("[Elasticsearch] Deleting indices by chunk IDs, count: %d", len(chunkIDList))
 	// Use DeleteByQuery to delete all documents matching the chunk IDs
 	_, err := e.client.DeleteByQuery(e.index).Query(&types.Query{
-		Terms: &types.TermsQuery{TermsQuery: map[string]types.TermsQueryField{"chunk_id": chunkIDList}},
+		Terms: &types.TermsQuery{TermsQuery: map[string]types.TermsQueryField{"chunk_id.keyword": chunkIDList}},
 	}).Do(ctx)
 	if err != nil {
 		log.Errorf("[Elasticsearch] Failed to delete by chunk IDs: %v", err)
@@ -198,7 +198,7 @@ func (e *elasticsearchRepository) DeleteBySourceIDList(ctx context.Context, sour
 	log.Infof("[Elasticsearch] Deleting indices by source IDs, count: %d", len(sourceIDList))
 	// Use DeleteByQuery to delete all documents matching the source IDs
 	_, err := e.client.DeleteByQuery(e.index).Query(&types.Query{
-		Terms: &types.TermsQuery{TermsQuery: map[string]types.TermsQueryField{"source_id": sourceIDList}},
+		Terms: &types.TermsQuery{TermsQuery: map[string]types.TermsQueryField{"source_id.keyword": sourceIDList}},
 	}).Do(ctx)
 	if err != nil {
 		log.Errorf("[Elasticsearch] Failed to delete by source IDs: %v", err)
@@ -223,7 +223,7 @@ func (e *elasticsearchRepository) DeleteByKnowledgeIDList(ctx context.Context,
 	log.Infof("[Elasticsearch] Deleting indices by knowledge IDs, count: %d", len(knowledgeIDList))
 	// Use DeleteByQuery to delete all documents matching the knowledge IDs
 	_, err := e.client.DeleteByQuery(e.index).Query(&types.Query{
-		Terms: &types.TermsQuery{TermsQuery: map[string]types.TermsQueryField{"knowledge_id": knowledgeIDList}},
+		Terms: &types.TermsQuery{TermsQuery: map[string]types.TermsQueryField{"knowledge_id.keyword": knowledgeIDList}},
 	}).Do(ctx)
 	if err != nil {
 		log.Errorf("[Elasticsearch] Failed to delete by knowledge IDs: %v", err)
@@ -247,14 +247,14 @@ func (e *elasticsearchRepository) getBaseConds(params typesLocal.RetrieveParams)
 	if len(params.KnowledgeBaseIDs) > 0 {
 		must = append(must, types.Query{Terms: &types.TermsQuery{
 			TermsQuery: map[string]types.TermsQueryField{
-				"knowledge_base_id": params.KnowledgeBaseIDs,
+				"knowledge_base_id.keyword": params.KnowledgeBaseIDs,
 			},
 		}})
 	}
 	if len(params.KnowledgeIDs) > 0 {
 		must = append(must, types.Query{Terms: &types.TermsQuery{
 			TermsQuery: map[string]types.TermsQueryField{
-				"knowledge_id": params.KnowledgeIDs,
+				"knowledge_id.keyword": params.KnowledgeIDs,
 			},
 		}})
 	}
@@ -262,7 +262,7 @@ func (e *elasticsearchRepository) getBaseConds(params typesLocal.RetrieveParams)
 	if len(params.TagIDs) > 0 {
 		must = append(must, types.Query{Terms: &types.TermsQuery{
 			TermsQuery: map[string]types.TermsQueryField{
-				"tag_id": params.TagIDs,
+				"tag_id.keyword": params.TagIDs,
 			},
 		}})
 	}
@@ -275,12 +275,12 @@ func (e *elasticsearchRepository) getBaseConds(params typesLocal.RetrieveParams)
 	}})
 	if len(params.ExcludeKnowledgeIDs) > 0 {
 		mustNot = append(mustNot, types.Query{Terms: &types.TermsQuery{
-			TermsQuery: map[string]types.TermsQueryField{"knowledge_id": params.ExcludeKnowledgeIDs},
+			TermsQuery: map[string]types.TermsQueryField{"knowledge_id.keyword": params.ExcludeKnowledgeIDs},
 		}})
 	}
 	if len(params.ExcludeChunkIDs) > 0 {
 		mustNot = append(mustNot, types.Query{Terms: &types.TermsQuery{
-			TermsQuery: map[string]types.TermsQueryField{"chunk_id": params.ExcludeChunkIDs},
+			TermsQuery: map[string]types.TermsQueryField{"chunk_id.keyword": params.ExcludeChunkIDs},
 		}})
 	}
 	return []types.Query{{Bool: &types.BoolQuery{Must: must, MustNot: mustNot}}}
@@ -642,7 +642,7 @@ func (e *elasticsearchRepository) BatchUpdateChunkEnabledStatus(
 			Must: []types.Query{
 				{Terms: &types.TermsQuery{
 					TermsQuery: map[string]types.TermsQueryField{
-						"chunk_id": enabledChunkIDs,
+						"chunk_id.keyword": enabledChunkIDs,
 					},
 				}},
 			},
@@ -668,7 +668,7 @@ func (e *elasticsearchRepository) BatchUpdateChunkEnabledStatus(
 			Must: []types.Query{
 				{Terms: &types.TermsQuery{
 					TermsQuery: map[string]types.TermsQueryField{
-						"chunk_id": disabledChunkIDs,
+						"chunk_id.keyword": disabledChunkIDs,
 					},
 				}},
 			},
@@ -717,7 +717,7 @@ func (e *elasticsearchRepository) BatchUpdateChunkTagID(
 			Must: []types.Query{
 				{Terms: &types.TermsQuery{
 					TermsQuery: map[string]types.TermsQueryField{
-						"chunk_id": chunkIDs,
+						"chunk_id.keyword": chunkIDs,
 					},
 				}},
 			},


### PR DESCRIPTION
## Overview

Revert commit `3daaabf` which removed the `.keyword` suffix from all `Terms` queries in both v7 and v8 Elasticsearch repositories.

The commit assumed that index mappings would be changed to `keyword` type via `dynamic_templates`, but `createIndexIfNotExists()` creates indexes **without any explicit mapping**. The "expected mapping" was only documented as a code comment in `structs.go` — never implemented. As a result, all indexes (both new and existing) use Elasticsearch's default dynamic mapping where ID fields are `text` type with a `.keyword` sub-field, making every `Terms` query silently match 0 documents.

This causes **silent failures** across delete, filter, and update operations — all report success while affecting nothing.

## Why

**Backward compatibility must be a first-class concern when changing index mapping assumptions.**

Elasticsearch index mappings are immutable once a field is indexed — you cannot change a `text` field to `keyword` without reindexing. Any code change that assumes a different mapping **must** ship with an actual migration path (reindex script, index template, or `dynamic_templates` in `createIndexIfNotExists`). Without that, the change is a breaking regression for every existing deployment.

This is especially critical for a system where the vector database holds expensive embeddings. Users upgrading to a new version reasonably expect their existing indexes to keep working. A version update should never silently break delete, search filtering, and chunk management across the entire knowledge base.

The original `.keyword` suffix is the correct approach because it works universally:
- **Existing indexes** (default dynamic mapping): `text` + `.keyword` sub-field → `.keyword` resolves to the sub-field
- **Future indexes with explicit `keyword` mapping**: accessing `.keyword` on a `keyword`-typed field is a harmless no-op

If we want to move toward explicit `keyword` mappings in the future, we'd likely need to introduce an **index schema version** — so that the application can detect the mapping version of each index and branch query logic accordingly (e.g., use `.keyword` suffix for v1 indexes, omit it for v2 indexes with native `keyword` fields). This would allow a graceful migration without breaking existing deployments.

## Changes

This is a clean `git revert 3daaabf` — no conflicts, zero commits have touched these files since.

- `elasticsearch/v8/repository.go` — restore `.keyword` suffix in 11 `Terms` query locations
- `elasticsearch/v7/repository.go` — restore `.keyword` suffix in 11 `Terms` query locations
- `elasticsearch/structs.go` — remove unimplemented "expected mapping" comment that incorrectly warns against using `.keyword`

## Related

- Issue: #873
- Root cause commit: `3daaabf`