### PR TITLE
fix(knowledge): delete extracted images from storage when knowledge is removed

### DIFF
--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -425,6 +425,20 @@ func (r *chunkRepository) DeleteChunksByKnowledgeID(ctx context.Context, tenantI
 	).Delete(&types.Chunk{}).Error
 }
 
+// ListImageInfoByKnowledgeIDs returns non-empty image_info values for the given knowledge IDs.
+// No chunk_type filter — collects from text, image_ocr, and image_caption chunks.
+func (r *chunkRepository) ListImageInfoByKnowledgeIDs(
+	ctx context.Context, tenantID uint64, knowledgeIDs []string,
+) ([]interfaces.ChunkImageInfo, error) {
+	var results []interfaces.ChunkImageInfo
+	err := r.db.WithContext(ctx).
+		Model(&types.Chunk{}).
+		Select("knowledge_id, image_info").
+		Where("tenant_id = ? AND knowledge_id IN ? AND image_info != ''", tenantID, knowledgeIDs).
+		Scan(&results).Error
+	return results, err
+}
+
 // DeleteByKnowledgeList deletes all chunks for a knowledge list
 func (r *chunkRepository) DeleteByKnowledgeList(ctx context.Context, tenantID uint64, knowledgeIDs []string) error {
 	return r.db.WithContext(ctx).Where(

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -1059,6 +1059,46 @@ func (s *knowledgeService) ListPagedKnowledgeByKnowledgeBaseID(ctx context.Conte
 	return types.NewPageResult(total, page, knowledges), nil
 }
 
+// collectImageURLs extracts unique provider:// image URLs from image_info JSON strings.
+func collectImageURLs(ctx context.Context, imageInfos []string) []string {
+	seen := make(map[string]struct{})
+	var urls []string
+	for _, info := range imageInfos {
+		if info == "" {
+			continue
+		}
+		var images []*types.ImageInfo
+		if err := json.Unmarshal([]byte(info), &images); err != nil {
+			logger.Warnf(ctx, "Failed to parse image_info JSON: %v", err)
+			continue
+		}
+		for _, img := range images {
+			if img.URL != "" {
+				if _, exists := seen[img.URL]; !exists {
+					seen[img.URL] = struct{}{}
+					urls = append(urls, img.URL)
+				}
+			}
+		}
+	}
+	return urls
+}
+
+// deleteExtractedImages deletes all extracted image files from storage.
+// Standalone function — callable from both knowledgeService and knowledgeBaseService.
+// Errors are logged but do not fail the overall deletion.
+func deleteExtractedImages(ctx context.Context, fileSvc interfaces.FileService, imageURLs []string) {
+	if len(imageURLs) == 0 {
+		return
+	}
+	logger.Infof(ctx, "Deleting %d extracted images", len(imageURLs))
+	for _, url := range imageURLs {
+		if err := fileSvc.DeleteFile(ctx, url); err != nil {
+			logger.Errorf(ctx, "Failed to delete extracted image %s: %v", url, err)
+		}
+	}
+}
+
 // DeleteKnowledge deletes a knowledge entry and all related resources
 func (s *knowledgeService) DeleteKnowledge(ctx context.Context, id string) error {
 	// Get the knowledge entry
@@ -1082,6 +1122,18 @@ func (s *knowledgeService) DeleteKnowledge(ctx context.Context, id string) error
 	// Resolve file service for this KB before spawning goroutines
 	kb, _ := s.kbService.GetKnowledgeBaseByID(ctx, knowledge.KnowledgeBaseID)
 	kbFileSvc := s.resolveFileService(ctx, kb)
+
+	// Collect image URLs before chunks are deleted (ImageInfo references are lost after deletion)
+	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
+	chunkImageInfos, err := s.chunkService.GetRepository().ListImageInfoByKnowledgeIDs(ctx, tenantID, []string{id})
+	if err != nil {
+		logger.Errorf(ctx, "Failed to collect image URLs for cleanup: %v", err)
+	}
+	var imageInfoStrs []string
+	for _, ci := range chunkImageInfos {
+		imageInfoStrs = append(imageInfoStrs, ci.ImageInfo)
+	}
+	imageURLs := collectImageURLs(ctx, imageInfoStrs)
 
 	wg := errgroup.Group{}
 	// Delete knowledge embeddings from vector store
@@ -1116,13 +1168,14 @@ func (s *knowledgeService) DeleteKnowledge(ctx context.Context, id string) error
 		return nil
 	})
 
-	// Delete the physical file if it exists
+	// Delete the physical file and extracted images if they exist
 	wg.Go(func() error {
 		if knowledge.FilePath != "" {
 			if err := kbFileSvc.DeleteFile(ctx, knowledge.FilePath); err != nil {
 				logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge delete file failed")
 			}
 		}
+		deleteExtractedImages(ctx, kbFileSvc, imageURLs)
 		tenantInfo := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
 		tenantInfo.StorageUsed -= knowledge.StorageSize
 		if err := s.tenantRepo.AdjustStorageUsed(ctx, tenantInfo.ID, -knowledge.StorageSize); err != nil {
@@ -1181,6 +1234,25 @@ func (s *knowledgeService) DeleteKnowledgeList(ctx context.Context, ids []string
 		}
 	}
 
+	// Collect image URLs before chunks are deleted
+	chunkImageInfos, err := s.chunkService.GetRepository().ListImageInfoByKnowledgeIDs(ctx, tenantInfo.ID, ids)
+	if err != nil {
+		logger.Errorf(ctx, "Failed to collect image URLs for batch cleanup: %v", err)
+	}
+	knowledgeToKB := make(map[string]string)
+	for _, k := range knowledgeList {
+		knowledgeToKB[k.ID] = k.KnowledgeBaseID
+	}
+	kbImageInfos := make(map[string][]string) // kbID → []imageInfo JSON
+	for _, ci := range chunkImageInfos {
+		kbID := knowledgeToKB[ci.KnowledgeID]
+		kbImageInfos[kbID] = append(kbImageInfos[kbID], ci.ImageInfo)
+	}
+	kbImageURLs := make(map[string][]string) // kbID → []imageURL (deduplicated)
+	for kbID, infos := range kbImageInfos {
+		kbImageURLs[kbID] = collectImageURLs(ctx, infos)
+	}
+
 	wg := errgroup.Group{}
 	// 2. Delete knowledge embeddings from vector store
 	wg.Go(func() error {
@@ -1228,7 +1300,7 @@ func (s *knowledgeService) DeleteKnowledgeList(ctx context.Context, ids []string
 		return nil
 	})
 
-	// 4. Delete the physical file if it exists
+	// 4. Delete the physical file and extracted images if they exist
 	wg.Go(func() error {
 		storageAdjust := int64(0)
 		for _, knowledge := range knowledgeList {
@@ -1239,6 +1311,15 @@ func (s *knowledgeService) DeleteKnowledgeList(ctx context.Context, ids []string
 				}
 			}
 			storageAdjust -= knowledge.StorageSize
+		}
+		// Delete extracted images per KB
+		for kbID, urls := range kbImageURLs {
+			fSvc := kbFileServices[kbID]
+			if fSvc == nil {
+				logger.Warnf(ctx, "No file service for KB %s, skipping %d image deletions", kbID, len(urls))
+				continue
+			}
+			deleteExtractedImages(ctx, fSvc, urls)
 		}
 		tenantInfo.StorageUsed += storageAdjust
 		if err := s.tenantRepo.AdjustStorageUsed(ctx, tenantInfo.ID, storageAdjust); err != nil {
@@ -6995,10 +7076,27 @@ func (s *knowledgeService) cleanupKnowledgeResources(ctx context.Context, knowle
 		}
 	}
 
+	// Collect image URLs before chunks are deleted
+	kb, _ := s.kbService.GetKnowledgeBaseByID(ctx, knowledge.KnowledgeBaseID)
+	fileSvc := s.resolveFileService(ctx, kb)
+	chunkImageInfos, imgErr := s.chunkService.GetRepository().ListImageInfoByKnowledgeIDs(ctx, tenantInfo.ID, []string{knowledge.ID})
+	if imgErr != nil {
+		logger.GetLogger(ctx).WithField("error", imgErr).Error("Failed to collect image URLs for cleanup")
+		cleanupErr = errors.Join(cleanupErr, imgErr)
+	}
+	var imageInfoStrs []string
+	for _, ci := range chunkImageInfos {
+		imageInfoStrs = append(imageInfoStrs, ci.ImageInfo)
+	}
+	imageURLs := collectImageURLs(ctx, imageInfoStrs)
+
 	if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
 		logger.GetLogger(ctx).WithField("error", err).Error("Failed to delete manual knowledge chunks")
 		cleanupErr = errors.Join(cleanupErr, err)
 	}
+
+	// Delete extracted images after chunks are deleted
+	deleteExtractedImages(ctx, fileSvc, imageURLs)
 
 	namespace := types.NameSpace{KnowledgeBase: knowledge.KnowledgeBaseID, Knowledge: knowledge.ID}
 	if err := s.graphEngine.DelGraph(ctx, []types.NameSpace{namespace}); err != nil {

--- a/internal/application/service/knowledge_image_cleanup_test.go
+++ b/internal/application/service/knowledge_image_cleanup_test.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCollectImageURLs(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		imageInfos []string
+		wantURLs   []string
+	}{
+		{
+			name:       "empty input",
+			imageInfos: nil,
+			wantURLs:   nil,
+		},
+		{
+			name:       "empty strings",
+			imageInfos: []string{"", ""},
+			wantURLs:   nil,
+		},
+		{
+			name: "single image",
+			imageInfos: []string{
+				`[{"url":"s3://bucket/prefix/123/exports/abc.png","original_url":"https://example.com/img.png"}]`,
+			},
+			wantURLs: []string{"s3://bucket/prefix/123/exports/abc.png"},
+		},
+		{
+			name: "multiple images in one chunk",
+			imageInfos: []string{
+				`[{"url":"s3://bucket/a.png"},{"url":"s3://bucket/b.png"}]`,
+			},
+			wantURLs: []string{"s3://bucket/a.png", "s3://bucket/b.png"},
+		},
+		{
+			name: "dedup across chunks — parent and child share same URL",
+			imageInfos: []string{
+				`[{"url":"s3://bucket/same.png"}]`,
+				`[{"url":"s3://bucket/same.png"}]`,
+				`[{"url":"s3://bucket/other.png"}]`,
+			},
+			wantURLs: []string{"s3://bucket/same.png", "s3://bucket/other.png"},
+		},
+		{
+			name: "skip empty URL field",
+			imageInfos: []string{
+				`[{"url":"","original_url":"https://example.com/img.png"}]`,
+			},
+			wantURLs: nil,
+		},
+		{
+			name: "invalid JSON — skipped with no panic",
+			imageInfos: []string{
+				`not valid json`,
+				`[{"url":"s3://bucket/valid.png"}]`,
+			},
+			wantURLs: []string{"s3://bucket/valid.png"},
+		},
+		{
+			name: "mixed providers",
+			imageInfos: []string{
+				`[{"url":"s3://bucket/img1.png"}]`,
+				`[{"url":"minio://bucket/img2.jpg"}]`,
+				`[{"url":"local://data/img3.webp"}]`,
+			},
+			wantURLs: []string{
+				"s3://bucket/img1.png",
+				"minio://bucket/img2.jpg",
+				"local://data/img3.webp",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := collectImageURLs(ctx, tt.imageInfos)
+
+			if len(got) != len(tt.wantURLs) {
+				t.Fatalf("collectImageURLs() returned %d URLs, want %d\ngot:  %v\nwant: %v",
+					len(got), len(tt.wantURLs), got, tt.wantURLs)
+			}
+			for i, url := range got {
+				if url != tt.wantURLs[i] {
+					t.Errorf("collectImageURLs()[%d] = %q, want %q", i, url, tt.wantURLs[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/application/service/knowledgebase.go
+++ b/internal/application/service/knowledgebase.go
@@ -453,6 +453,17 @@ func (s *knowledgeBaseService) ProcessKBDelete(ctx context.Context, t *asynq.Tas
 			}
 		}
 
+		// Collect image URLs before chunks are deleted
+		chunkImageInfos, imgErr := s.chunkRepo.ListImageInfoByKnowledgeIDs(ctx, tenantID, knowledgeIDs)
+		if imgErr != nil {
+			logger.Warnf(ctx, "Failed to collect image URLs for KB delete: %v", imgErr)
+		}
+		var imageInfoStrs []string
+		for _, ci := range chunkImageInfos {
+			imageInfoStrs = append(imageInfoStrs, ci.ImageInfo)
+		}
+		imageURLs := collectImageURLs(ctx, imageInfoStrs)
+
 		// Delete all chunks
 		logger.Infof(ctx, "Deleting all chunks in knowledge base")
 		for _, knowledgeID := range knowledgeIDs {
@@ -461,8 +472,8 @@ func (s *knowledgeBaseService) ProcessKBDelete(ctx context.Context, t *asynq.Tas
 			}
 		}
 
-		// Delete physical files and adjust storage
-		logger.Infof(ctx, "Deleting physical files")
+		// Delete physical files, extracted images, and adjust storage
+		logger.Infof(ctx, "Deleting physical files and extracted images")
 		storageAdjust := int64(0)
 		for _, knowledge := range knowledgeList {
 			if knowledge.FilePath != "" {
@@ -472,6 +483,7 @@ func (s *knowledgeBaseService) ProcessKBDelete(ctx context.Context, t *asynq.Tas
 			}
 			storageAdjust -= knowledge.StorageSize
 		}
+		deleteExtractedImages(ctx, s.fileSvc, imageURLs)
 		if storageAdjust != 0 {
 			if err := s.tenantRepo.AdjustStorageUsed(ctx, tenantID, storageAdjust); err != nil {
 				logger.Warnf(ctx, "Failed to adjust tenant storage: %v", err)

--- a/internal/types/interfaces/chunk.go
+++ b/internal/types/interfaces/chunk.go
@@ -6,6 +6,12 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 )
 
+// ChunkImageInfo holds (knowledge_id, image_info) pairs for image cleanup before chunk deletion.
+type ChunkImageInfo struct {
+	KnowledgeID string `gorm:"column:knowledge_id"`
+	ImageInfo   string `gorm:"column:image_info"`
+}
+
 // ChunkRepository defines the interface for chunk repository operations
 type ChunkRepository interface {
 	// CreateChunks creates chunks
@@ -58,6 +64,8 @@ type ChunkRepository interface {
 	DeleteChunksByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) error
 	// DeleteByKnowledgeList deletes all chunks for a knowledge list
 	DeleteByKnowledgeList(ctx context.Context, tenantID uint64, knowledgeIDs []string) error
+	// ListImageInfoByKnowledgeIDs returns non-empty (knowledge_id, image_info) pairs for image cleanup.
+	ListImageInfoByKnowledgeIDs(ctx context.Context, tenantID uint64, knowledgeIDs []string) ([]ChunkImageInfo, error)
 	// MoveChunksByKnowledgeID updates knowledge_base_id for all chunks of a knowledge item
 	MoveChunksByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string, targetKBID string) error
 	// DeleteChunksByTagID deletes all chunks with the specified tag ID


### PR DESCRIPTION
## Overview

Fix orphaned storage files caused by extracted images not being deleted when knowledge documents are removed. Previously, only the original uploaded file (`knowledge.FilePath`) was deleted — images extracted by the builtin parser via `ImageResolver` were never cleaned up.

## Why

The builtin parser extracts images from documents and stores them as individual files (e.g., `s3://bucket/prefix/{tenantID}/exports/{uuid}.png`). Image URLs are referenced in `chunk.ImageInfo` JSON. When chunks are deleted during knowledge removal, these references are lost but the storage objects remain — causing indefinite orphan file accumulation across all storage providers (S3, MinIO, COS, TOS, local).

A new repository method (`ListImageInfoByKnowledgeIDs`) is needed because the existing `ListChunksByKnowledgeID` filters `chunk_type = 'text'`, which misses `image_ocr` and `image_caption` chunks that also carry `ImageInfo`. Parent text chunks and child image chunks can share the same `ImageInfo.URL` (via `updateParentChunkImageInfo`), so URL deduplication is required to avoid redundant delete calls.

## Changes

**`internal/types/interfaces/chunk.go`**
- Add `ChunkImageInfo` struct — holds `(knowledge_id, image_info)` pairs for image cleanup
- Add `ListImageInfoByKnowledgeIDs` to `ChunkRepository` interface

**`internal/application/repository/chunk.go`**
- Implement `ListImageInfoByKnowledgeIDs` — SELECT `knowledge_id, image_info` with no `chunk_type` filter, `image_info != ''`

**`internal/application/service/knowledge.go`**
- Add `collectImageURLs(ctx, imageInfos)` — parse ImageInfo JSON, extract URLs, deduplicate via `seen` map, log JSON parse errors
- Add `deleteExtractedImages(ctx, fileSvc, imageURLs)` — standalone best-effort deletion with count logging and error logging
- `DeleteKnowledge`: collect image URLs before errgroup, delete in file goroutine
- `DeleteKnowledgeList`: bulk collect with KB-level fileSvc mapping + nil guard
- `cleanupKnowledgeResources`: collect before chunk deletion, delete after

**`internal/application/service/knowledgebase.go`**
- `ProcessKBDelete`: collect image URLs before chunk deletion loop, delete after file cleanup

**`internal/application/service/knowledge_image_cleanup_test.go`**
- 8 table-driven tests for `collectImageURLs`: empty input, single/multiple images, dedup across chunks, empty URL skip, invalid JSON handling, mixed providers

## Related

- Issue: #879