### PR TITLE
fix(stream): use io.EOF instead of errors.New("EOF") in SSEReader

### DIFF
--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -546,7 +546,20 @@ func (c *RemoteAPIChat) processRawHTTPStream(ctx context.Context, resp *http.Res
 	for {
 		event, err := reader.ReadEvent()
 		if err != nil {
-			if err != io.EOF {
+			if err == io.EOF {
+				// 部分模型不发送 [DONE] 标记，直接关闭连接，视为正常结束
+				if state.usage != nil {
+					logger.Infof(ctx, "[LLM Usage] model=%s, prompt_tokens=%d, completion_tokens=%d, total_tokens=%d",
+						c.modelName, state.usage.PromptTokens, state.usage.CompletionTokens, state.usage.TotalTokens)
+				}
+				streamChan <- types.StreamResponse{
+					ResponseType: types.ResponseTypeAnswer,
+					Content:      "",
+					Done:         true,
+					ToolCalls:    state.buildOrderedToolCalls(),
+					Usage:        state.usage,
+				}
+			} else {
 				logger.Errorf(ctx, "Stream read error: %v", err)
 				streamChan <- types.StreamResponse{
 					ResponseType: types.ResponseTypeError,

--- a/internal/models/chat/sse_reader.go
+++ b/internal/models/chat/sse_reader.go
@@ -2,7 +2,6 @@ package chat
 
 import (
 	"bufio"
-	"errors"
 	"io"
 	"strings"
 )
@@ -55,5 +54,5 @@ func (r *SSEReader) ReadEvent() (*SSEEvent, error) {
 		return nil, err
 	}
 
-	return nil, errors.New("EOF")
+	return nil, io.EOF
 }


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
<!-- 请简要描述这个 PR 的目的和变更内容 -->
`SSEReader.ReadEvent()` 在流正常结束时返回 `errors.New("EOF")` 而非 `io.EOF`，导致 `processRawHTTPStream` 中 `err != io.EOF` 判断为 true，将正常的流结束误报为错误，产生 ERROR 日志并向前端发送错误响应。

修复：
- `SSEReader`：`errors.New("EOF")` → `io.EOF`，符合 Go 标准库惯例
- `processRawHTTPStream`：EOF 时发送正常 done 响应（与同文件 processStream（第 500-521 行）的模式一致），兼容不发送 `[DONE]` 标记的模型

## 变更类型 (Type of Change)
<!-- 请选择适用的类型，删除其他选项 -->
- [x] 🐛 Bug 修复 (Bug fix)

## 影响范围 (Scope)
<!-- 请选择受影响的组件，删除其他选项 -->
- [x] 后端 API (Backend API)

## 测试 (Testing)
<!-- 请描述如何测试这些变更 -->
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 使用知识库问答功能发起一次对话
2. 等待模型流式回答完成
3. 检查后端日志，确认不再出现 `Stream read error: EOF` 的 ERROR 日志
4. 确认前端正常收到完整回答和 usage 数据

## 检查清单 (Checklist)
<!-- 请确保完成以下检查项 -->
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
<!-- 如果此 PR 解决了某个 issue，请使用 "Fixes #123" 或 "Closes #123" 的格式 -->
Fixes #860

## 截图/录屏 (Screenshots/Recordings)
<!-- 如果是前端 UI 变更，请提供截图或录屏 -->

## 数据库迁移 (Database Migration)
<!-- 如果涉及数据库变更，请说明 -->
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
<!-- 如果涉及配置变更，请说明需要更新的配置项 -->

## 部署说明 (Deployment Notes)
<!-- 如果有特殊的部署要求，请说明 -->

## 其他信息 (Additional Information)
<!-- 任何其他需要说明的信息 -->