### PR TITLE
fix(migrations): correct migration numbers and remove broken trigger

### DIFF
--- a/migrations/versioned/000029_datasource_tables.up.sql
+++ b/migrations/versioned/000029_datasource_tables.up.sql
@@ -1,6 +1,6 @@
--- Migration: 000028_datasource_tables
+-- Migration: 000029_datasource_tables
 -- Description: Create data_sources and sync_logs tables for external data source management
-DO $$ BEGIN RAISE NOTICE '[Migration 000028] Creating data_sources and sync_logs tables'; END $$;
+DO $$ BEGIN RAISE NOTICE '[Migration 000029] Creating data_sources and sync_logs tables'; END $$;
 
 -- Create data_sources table for managing external data source configurations
 CREATE TABLE IF NOT EXISTS data_sources (
@@ -57,4 +57,4 @@ CREATE INDEX IF NOT EXISTS idx_sync_logs_status ON sync_logs (status);
 CREATE INDEX IF NOT EXISTS idx_sync_logs_started_at ON sync_logs (started_at);
 
 
-DO $$ BEGIN RAISE NOTICE '[Migration 000028] data_sources and sync_logs tables created successfully'; END $$;
+DO $$ BEGIN RAISE NOTICE '[Migration 000029] data_sources and sync_logs tables created successfully'; END $$;

--- a/migrations/versioned/000030_web_search_providers.up.sql
+++ b/migrations/versioned/000030_web_search_providers.up.sql
@@ -1,6 +1,6 @@
--- Migration: 000029_web_search_providers
+-- Migration: 000030_web_search_providers
 -- Description: Create web_search_providers table for tenant-specific search engine configurations
-DO $$ BEGIN RAISE NOTICE '[Migration 000029] Creating web_search_providers table'; END $$;
+DO $$ BEGIN RAISE NOTICE '[Migration 000030] Creating web_search_providers table'; END $$;
 
 -- Create web_search_providers table for managing tenant search engine configurations
 -- Each row represents a configured search provider instance (e.g., "Production Bing", "Test Google")
@@ -22,10 +22,4 @@ CREATE INDEX IF NOT EXISTS idx_web_search_providers_tenant_id ON web_search_prov
 CREATE INDEX IF NOT EXISTS idx_web_search_providers_provider ON web_search_providers (provider);
 CREATE INDEX IF NOT EXISTS idx_web_search_providers_deleted_at ON web_search_providers (deleted_at);
 
--- Auto-update updated_at column (reuses the function from migration 000028)
-CREATE TRIGGER trg_web_search_providers_updated_at
-    BEFORE UPDATE ON web_search_providers
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
-
-DO $$ BEGIN RAISE NOTICE '[Migration 000029] web_search_providers table created successfully'; END $$;
+DO $$ BEGIN RAISE NOTICE '[Migration 000030] web_search_providers table created successfully'; END $$;

--- a/migrations/versioned/000031_add_asr_config.up.sql
+++ b/migrations/versioned/000031_add_asr_config.up.sql
@@ -1,10 +1,10 @@
--- Migration: 000025_add_asr_config
+-- Migration: 000031_add_asr_config
 -- Description: Add asr_config column to knowledge_bases for ASR (Automatic Speech Recognition) configuration.
 -- ASR config stores the model ID and language settings for audio transcription.
-DO $$ BEGIN RAISE NOTICE '[Migration 000025] Adding asr_config column to knowledge_bases'; END $$;
+DO $$ BEGIN RAISE NOTICE '[Migration 000031] Adding asr_config column to knowledge_bases'; END $$;
 
 ALTER TABLE knowledge_bases ADD COLUMN IF NOT EXISTS asr_config JSONB;
 
 COMMENT ON COLUMN knowledge_bases.asr_config IS 'ASR (Automatic Speech Recognition) configuration: {"enabled": bool, "model_id": string, "language": string}';
 
-DO $$ BEGIN RAISE NOTICE '[Migration 000025] asr_config column added successfully'; END $$;
+DO $$ BEGIN RAISE NOTICE '[Migration 000031] asr_config column added successfully'; END $$;


### PR DESCRIPTION
Migration 000029 and 000030 had off-by-one numbering in comments/notices. Also removed update_updated_at_column() trigger from 000030 as the function is never defined and no other table uses this pattern.

# Pull Request

## 描述 (Description)
<!-- 请简要描述这个 PR 的目的和变更内容 -->
000030_web_search_providers.up.sql中触发器引用了不存在的函数update_updated_at_column()，导致执行数据库迁移时报错。此PR移除了该sql中的触发器，并且修复了sql中编号不一致的问题。

## 变更类型 (Type of Change)
<!-- 请选择适用的类型，删除其他选项 -->
- [x] 🐛 Bug 修复 (Bug fix)

## 影响范围 (Scope)
<!-- 请选择受影响的组件，删除其他选项 -->
- [x] 数据库 (Database)

## 测试 (Testing)
<!-- 请描述如何测试这些变更 -->
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 启动app
2. 查看日志，发现迁移数据时报错，update_updated_at_column函数不存在
3. 

## 检查清单 (Checklist)
<!-- 请确保完成以下检查项 -->
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [x] 相关文档已更新
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常
- [x] 新功能和变更已更新到相关文档
- [x] 破坏性变更已在描述中明确说明

## 相关 Issue
<!-- 如果此 PR 解决了某个 issue，请使用 "Fixes #123" 或 "Closes #123" 的格式 -->
Fixes #

## 截图/录屏 (Screenshots/Recordings)
<!-- 如果是前端 UI 变更，请提供截图或录屏 -->

## 数据库迁移 (Database Migration)
<!-- 如果涉及数据库变更，请说明 -->
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
<!-- 如果涉及配置变更，请说明需要更新的配置项 -->

## 部署说明 (Deployment Notes)
<!-- 如果有特殊的部署要求，请说明 -->

## 其他信息 (Additional Information)
<!-- 任何其他需要说明的信息 -->