### PR TITLE
fix: resolve tool name duplication in streaming tool calls

### DIFF
--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -780,7 +780,11 @@ func (c *RemoteAPIChat) processToolCallsDelta(ctx context.Context, toolCalls []o
 			toolCallEntry.Type = string(tc.Type)
 		}
 		if tc.Function.Name != "" {
-			toolCallEntry.Function.Name += tc.Function.Name
+			// 防御性校验：解决部分供应商（如vLLM Ascend等）在每个流 Chunk 中重复发送完整工具名的问题。
+			// 如果当前已存名字与新收到名字一致，则视为冗余重复，不进行叠加。
+			if toolCallEntry.Function.Name != tc.Function.Name {
+				toolCallEntry.Function.Name += tc.Function.Name
+			}
 		}
 
 		argsUpdated := false


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
修复了在流式输出（Streaming）过程中，由于部分模型供应商的模型（如 **vLLM Ascend**的glm5、qwen3.5）在每一个流式分包（Chunk）中重复返回函数名称，导致解析器错误地将名称进行字符串叠加（例如将 `thinking` 错误拼接为 `thinkingthinking`）的 Bug。

**变更内容：**
在 `internal/models/chat/remote_api.go` 的 `processToolCallsDelta` 函数中增加了一个冗余名称校验逻辑。如果当前已收到的名称与新收到的 Delta 名称一致，则视为重复包，不再进行 `+=` 叠加。

## 变更类型 (Type of Change)
<!-- 请选择适用的类型，删除其他选项 -->
- [x] 🐛 Bug 修复 (Bug fix)
- [x] ⚡ 性能优化 (Performance improvement)

## 影响范围 (Scope)
<!-- 请选择受影响的组件，删除其他选项 -->
- [x] 后端 API (Backend API)

## 测试 (Testing)
<!-- 请描述如何测试这些变更 -->
- [x] API 测试 (API testing)
- [x] 手动测试 (Manual testing)

### 测试步骤 (Test Steps)
1. 使用 vLLM (Ascend 算力/模型) 或阿里云 DashScope 接入 Agent 智能推理模式。
2. 触发模型产生长文本思考内容（调用 `thinking` 工具）。
3. 观察后端日志，解析出的工具名应始终为 `thinking`，不再出现 `thinkingthinking` 导致的 404 错误。
4. 验证其他工具（如 `knowledge_search`）在分段发送（如 `knowledge_` + `search`）的情况下依然能正确拼接。

## 检查清单 (Checklist)
<!-- 请确保完成以下检查项 -->
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [x] 变更不会产生新的警告
- [x] 已手动验证修复有效



## 数据库迁移 (Database Migration)
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
无

## 部署说明 (Deployment Notes)
重新编译后端服务后生效。

## 其他信息 (Additional Information)
此修复不仅解决了 `thinking` 工具的问题，也增强了系统对非标准 OpenAI 协议实现（重复发送字段名）的鲁棒性。

---
