### PR TITLE
feat: support customizable LLM call timeout via env and agent config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -265,6 +265,12 @@ WEKNORA_SANDBOX_TIMEOUT=60
 # 自定义 Sandbox Docker 镜像
 WEKNORA_SANDBOX_DOCKER_IMAGE=wechatopenai/weknora-sandbox:latest
 
+# ========== Agent 配置 ==========
+# 智能体大模型调用默认超时时间（秒），默认 120
+# 对于复杂的推理行为，建议调大此值（如 300 或 600）
+# 注：此值为全局默认值。若单个智能体在数据库中配置了独立的 llm_call_timeout，则以智能体配置为准（优先级更高）。
+# WEKNORA_AGENT_LLM_TIMEOUT=300
+
 # APK 镜像源设置（可选）
 APK_MIRROR_ARG=mirrors.tencent.com
 

--- a/internal/application/service/session_agent_qa.go
+++ b/internal/application/service/session_agent_qa.go
@@ -219,6 +219,12 @@ func (s *sessionService) buildAgentConfig(
 		MCPServices:                 customAgent.Config.MCPServices,
 		Thinking:                    customAgent.Config.Thinking,
 		RetrieveKBOnlyWhenMentioned: customAgent.Config.RetrieveKBOnlyWhenMentioned,
+		LLMCallTimeout:              customAgent.Config.LLMCallTimeout,
+	}
+
+	// Falls back to global configuration if no specific timeout is set for the agent.
+	if agentConfig.LLMCallTimeout == 0 && s.cfg.Agent != nil && s.cfg.Agent.LLMCallTimeout > 0 {
+		agentConfig.LLMCallTimeout = s.cfg.Agent.LLMCallTimeout
 	}
 
 	// Configure skills based on CustomAgentConfig

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,14 @@ type Config struct {
 	WebSearch       *WebSearchConfig       `yaml:"web_search"       json:"web_search"`
 	PromptTemplates *PromptTemplatesConfig `yaml:"prompt_templates" json:"prompt_templates"`
 	IM              *IMConfig              `yaml:"im"               json:"im"`
+	Agent           *AgentConfig           `yaml:"agent"            json:"agent"`
+}
+
+// AgentConfig represents the global agent settings.
+type AgentConfig struct {
+	// LLMCallTimeout is the default timeout for a single LLM call in seconds.
+	// Default: 120 (standard agents) or 300 (can be overridden by Env).
+	LLMCallTimeout int `yaml:"llm_call_timeout" json:"llm_call_timeout"`
 }
 
 // IMConfig configures the IM integration service.
@@ -408,6 +416,7 @@ func LoadConfig() (*Config, error) {
 
 	// Validate configuration values
 	applyOIDCEnvOverrides(&cfg)
+	applyAgentEnvOverrides(&cfg)
 
 	if err := ValidateConfig(&cfg); err != nil {
 		return nil, err
@@ -532,6 +541,20 @@ func applyOIDCEnvOverrides(cfg *Config) {
 	}
 	if cfg.OIDCAuth.DiscoveryURL == "" && cfg.OIDCAuth.IssuerURL != "" {
 		cfg.OIDCAuth.DiscoveryURL = strings.TrimRight(cfg.OIDCAuth.IssuerURL, "/") + "/.well-known/openid-configuration"
+	}
+}
+
+func applyAgentEnvOverrides(cfg *Config) {
+	if cfg.Agent == nil {
+		cfg.Agent = &AgentConfig{}
+	}
+	if value := strings.TrimSpace(os.Getenv("WEKNORA_AGENT_LLM_TIMEOUT")); value != "" {
+		if timeout, err := time.ParseDuration(value); err == nil {
+			cfg.Agent.LLMCallTimeout = int(timeout.Seconds())
+		} else if sec, err := time.ParseDuration(value + "s"); err == nil {
+			// Handle case where user just provides a number like "300"
+			cfg.Agent.LLMCallTimeout = int(sec.Seconds())
+		}
 	}
 }
 

--- a/internal/types/custom_agent.go
+++ b/internal/types/custom_agent.go
@@ -91,6 +91,8 @@ type CustomAgentConfig struct {
 	// ===== Agent Mode Settings =====
 	// Maximum iterations for ReAct loop (only for agent type)
 	MaxIterations int `yaml:"max_iterations" json:"max_iterations"`
+	// Timeout for a single LLM call in seconds (0 = use global default)
+	LLMCallTimeout int `yaml:"llm_call_timeout" json:"llm_call_timeout,omitempty"`
 	// Allowed tools (only for agent type)
 	AllowedTools []string `yaml:"allowed_tools" json:"allowed_tools"`
 	// MCP service selection mode: "all" = all enabled MCP services, "selected" = specific services, "none" = no MCP


### PR DESCRIPTION
## 描述 (Description)

引入了对智能体（Agent）LLM 调用超时的多级自定义支持。

此前 LLM 调用超时硬编码为 120s，用户无法通过配置调整。对于需要较长推理时间的深度思考模型（如 GLM5 ），用户无法自行调优该值。

**主要变更内容：**
1. **全局默认值控制**：新增环境变量 `WEKNORA_AGENT_LLM_TIMEOUT`，允许通过 `.env` 文件快速调整所有 Agent 的默认超时时间。
2. **智能体独立配置**：在 `CustomAgentConfig` 结构中增加了 `llm_call_timeout` 字段，支持在数据库层面为特定智能体设置独立的超时限制。
3. **配置优先级链路**：`智能体特定配置 > 环境变量全局默认值 > 系统硬编码默认值 (120s)`。
4. **文档更新**：同步更新了 `.env.example`，增加了配置项说明及优先级注释。

## 变更类型 (Type of Change)
- [x] ✨ 新功能 (New feature)
- [x] 🔧 配置变更 (Configuration change)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)
- [x] 配置文件 (Configuration)

## 测试 (Testing)
- [x] 手动测试 (Manual testing)
- [x] API 测试 (API testing)



## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [x] 相关文档已更新
- [x] 变更不会产生新的警告

## 数据库迁移 (Database Migration)
- [x] 不需要数据库迁移（仅在 JSON 字段中增加可选 key，无需显式迁移 Schema）

## 配置变更 (Configuration Changes)
新增环境变量：`WEKNORA_AGENT_LLM_TIMEOUT`（单位：秒，也支持 Go `time.Duration` 格式如 `300s`、`5m`）
