### PR TITLE
fix(im): strip <kb> and <web> citation tags before sending to IM 

### DIFF
--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/textproto"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -41,6 +42,16 @@ const (
 	// This prevents API rate-limiting while keeping perceived latency low.
 	streamFlushInterval = 300 * time.Millisecond
 )
+
+// imCitationTagRe matches inline citation tags produced by the agent pipeline.
+// These tags are rendered as interactive UI in the web frontend but are meaningless
+// in IM platforms, so they must be stripped before sending.
+var imCitationTagRe = regexp.MustCompile(`<(?:kb|web)\b[^>]*/?>`)
+
+// stripIMCitationTags removes <kb .../> and <web .../> inline citation tags from s.
+func stripIMCitationTags(s string) string {
+	return imCitationTagRe.ReplaceAllString(s, "")
+}
 
 const (
 	// wsLeaderTTL is the TTL for the Redis key used for WebSocket leader election.
@@ -1650,7 +1661,7 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 		bufMu.Unlock()
 
 		if chunk != "" {
-			if err := streamer.SendStreamChunk(ctx, msg, streamID, chunk); err != nil {
+			if err := streamer.SendStreamChunk(ctx, msg, streamID, stripIMCitationTags(chunk)); err != nil {
 				logger.Warnf(ctx, "[IM] SendStreamChunk failed: %v", err)
 			}
 		}
@@ -1858,14 +1869,16 @@ func (s *Service) runQA(ctx context.Context, session *types.Session, query strin
 		answer = "抱歉，我暂时无法回答这个问题。"
 	}
 
-	// Update assistant message with the final answer content
+	// Update assistant message with the full answer (including citation tags for web rendering).
 	assistantMsg.Content = answer
 	assistantMsg.IsCompleted = true
 	if err := s.messageService.UpdateMessage(ctx, assistantMsg); err != nil {
 		logger.Warnf(ctx, "[IM] Failed to update assistant message: %v", err)
 	}
 
-	return answer, nil
+	// Strip citation tags before returning to the IM adapter — IM platforms cannot
+	// render <kb .../> / <web .../> and would display them as raw text.
+	return stripIMCitationTags(answer), nil
 }
 
 // ── CRUD operations for IM channels ──


### PR DESCRIPTION
# Pull Request
对接 IM 集成时，Agent 管道产生的内联引用标签 `<kb doc="..." chunk_id="..." />` 和 `<web url="..." title="..." />` 会原样输出到 IM 端，用户看到大量无法解析的原始标签，影响回答质量。

本 PR 在 IM 服务层发送前剥离这些标签，同时保留数据库中的原始内容供 Web 前端正常渲染引用 UI。

## 描述 (Description)
<!-- 请简要描述这个 PR 的目的和变更内容 -->

## 变更类型 (Type of Change)
<!-- 请选择适用的类型，删除其他选项 -->
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [ ] 📚 文档更新 (Documentation update)
- [ ] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [ ] 🧪 测试相关 (Test related)
- [ ] 🔧 配置变更 (Configuration change)
- [ ] 🐳 Docker 相关 (Docker related)
- [ ] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
<!-- 请选择受影响的组件，删除其他选项 -->
- [ ] 后端 API (Backend API)
- [ ] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [x] 其他 (Other): IM 集成服务 (`internal/im/service.go`)

## 测试 (Testing)
<!-- 请描述如何测试这些变更 -->
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 配置任意 IM 渠道（企业微信/飞书/Slack 等）并绑定一个关联知识库的 Agent
2. 在 IM 端提问，触发知识库引用的回答
3. 确认回答中不再出现 `<kb .../>` 或 `<web .../>` 原始标签
4. 在 Web 端查看同一会话的历史记录，确认引用 UI 仍正常渲染

## 检查清单 (Checklist)
<!-- 请确保完成以下检查项 -->
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
<!-- 如果此 PR 解决了某个 issue，请使用 "Fixes #123" 或 "Closes #123" 的格式 -->
Fixes #945

## 截图/录屏 (Screenshots/Recordings)
<!-- 如果是前端 UI 变更，请提供截图或录屏 -->

## 数据库迁移 (Database Migration)
<!-- 如果涉及数据库变更，请说明 -->
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
<!-- 如果涉及配置变更，请说明需要更新的配置项 -->

## 部署说明 (Deployment Notes)
<!-- 如果有特殊的部署要求，请说明 -->

## 其他信息 (Additional Information)
<!-- 任何其他需要说明的信息 -->
- 改动仅涉及 `internal/im/service.go` 一个文件，影响范围限定在 IM 发送链路
- 流式路径（`flush` → `SendStreamChunk`）和非流式路径（`runQA` return）均已处理
- 后续可考虑将引用标签转为末尾参考来源列表（如 `[1] 文档A`），为 IM 用户保留来源信息 , 或者针对每个IM平台做特定的富文本渲染