### PR TITLE
fix(embedding): remove hardcoded TruncatePromptTokens in BatchEmbed

### DIFF
--- a/internal/models/embedding/weknoracloud.go
+++ b/internal/models/embedding/weknoracloud.go
@@ -78,7 +78,7 @@ func (e *WeKnoraCloudEmbedder) Embed(ctx context.Context, text string) ([]float3
 }
 
 func (e *WeKnoraCloudEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
-	reqBody := weKnoraCloudEmbedRequest{Model: e.effectiveModelName(), Input: texts, TruncatePromptTokens: 512}
+	reqBody := weKnoraCloudEmbedRequest{Model: e.effectiveModelName(), Input: texts}
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("weknoracloud embedder: marshal: %w", err)


### PR DESCRIPTION
## Summary

- **移除 `WeKnoraCloudEmbedder.BatchEmbed` 中硬编码的 `TruncatePromptTokens: 512` 参数**，使 API 使用其默认截断行为，避免对较长输入文本进行意外截断。

## 变更内容

`internal/models/embedding/weknoracloud.go`:
- `BatchEmbed` 构造请求体时不再传入 `TruncatePromptTokens: 512`，与 `Embed` 方法保持一致。

## 动机

之前 `BatchEmbed` 强制将 prompt token 截断为 512，这可能导致较长文本的 embedding 结果不完整。移除该限制后，由服务端决定是否截断及截断长度，行为更合理。

## Test plan

- [ ] 验证 `BatchEmbed` 对长文本（>512 tokens）能正确返回完整 embedding
- [ ] 验证 `BatchEmbed` 对短文本行为无变化
- [ ] 确认 `Embed` 和 `BatchEmbed` 行为一致