### PR TITLE
feat(router): implement auto-setup failure handling for Lite edition

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -5,6 +5,15 @@ import { autoSetup } from '@/api/auth'
 
 /** Lite /桌面 WebView 硬刷新时可能只打开 `/`，用 session 记住上次页面以便恢复 */
 const LITE_LAST_PATH_KEY = 'weknora_lite_last_path'
+const AUTO_SETUP_FAILED_KEY = 'weknora_auto_setup_failed'
+
+function shouldTryAutoSetup() {
+  return localStorage.getItem(AUTO_SETUP_FAILED_KEY) !== 'true'
+}
+
+function markAutoSetupFailed() {
+  localStorage.setItem(AUTO_SETUP_FAILED_KEY, 'true')
+}
 
 function isLiteEdition(authStore: ReturnType<typeof useAuthStore>) {
   return authStore.isLiteMode || localStorage.getItem('weknora_lite_mode') === 'true'
@@ -188,8 +197,7 @@ router.beforeEach(async (to, from, next) => {
   // 检查用户认证状态
   if (to.meta.requiresAuth !== false) {
     if (!authStore.isLoggedIn) {
-      // Lite 版：尝试自动初始化（仅一次），成功则跳过登录页
-      if (!autoSetupAttempted) {
+      if (!autoSetupAttempted && shouldTryAutoSetup()) {
         autoSetupAttempted = true
         try {
           const response = await autoSetup()
@@ -198,9 +206,11 @@ router.beforeEach(async (to, from, next) => {
             authStore.setLiteMode(true)
             next(to.fullPath)
             return
+          } else {
+            markAutoSetupFailed()
           }
         } catch {
-          // auto-setup 不可用（非 lite 版本），走正常登录流程
+          markAutoSetupFailed()
         }
       }
       next('/login')

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -64,7 +64,13 @@ instance.interceptors.request.use(
 // Token刷新标志，防止多个请求同时刷新token
 let isRefreshing = false;
 let failedQueue: Array<{ resolve: Function; reject: Function }> = [];
-let hasRedirectedOn401 = false;
+
+const PUBLIC_AUTH_PATHS = ['/auth/auto-setup', '/auth/login', '/auth/register', '/auth/oidc/'];
+
+function isPublicAuthRequest(url?: string): boolean {
+  if (!url) return false;
+  return PUBLIC_AUTH_PATHS.some(p => url.includes(p));
+}
 
 // 处理队列中的请求
 const processQueue = (error: any, token: string | null = null) => {
@@ -78,6 +84,12 @@ const processQueue = (error: any, token: string | null = null) => {
   
   failedQueue = [];
 };
+
+function redirectToLogin() {
+  if (typeof window === 'undefined') return;
+  if (window.location.pathname === '/login') return;
+  window.location.href = '/login';
+}
 
 instance.interceptors.response.use(
   (response) => {
@@ -96,10 +108,10 @@ instance.interceptors.response.use(
       return Promise.reject({ message: t('error.networkError') });
     }
     
-    // 如果是登录接口的401，直接返回错误以便页面展示toast，不做跳转
-    if (error.response.status === 401 && originalRequest?.url?.includes('/auth/login')) {
+    // 公开接口（auto-setup / login / register / oidc）的 401 不走 refresh 逻辑，直接返回错误
+    if (error.response.status === 401 && isPublicAuthRequest(originalRequest?.url)) {
       const { status, data } = error.response;
-      return Promise.reject({ status, message: (typeof data === 'object' ? data?.message : data) || t('error.invalidCredentials') });
+      return Promise.reject({ status, message: (typeof data === 'object' ? (data?.error?.message || data?.message) : data) || t('error.invalidCredentials') });
     }
 
     // 如果是401错误且不是刷新token的请求，尝试刷新token
@@ -153,11 +165,7 @@ instance.interceptors.response.use(
           
           processQueue(refreshError, null);
           
-          // 跳转到登录页
-          if (!hasRedirectedOn401 && typeof window !== 'undefined') {
-            hasRedirectedOn401 = true;
-            window.location.href = '/login';
-          }
+          redirectToLogin();
           
           return Promise.reject(refreshError);
         } finally {
@@ -169,10 +177,7 @@ instance.interceptors.response.use(
         localStorage.removeItem('weknora_user');
         localStorage.removeItem('weknora_tenant');
         
-        if (!hasRedirectedOn401 && typeof window !== 'undefined') {
-          hasRedirectedOn401 = true;
-          window.location.href = '/login';
-        }
+        redirectToLogin();
         
         return Promise.reject({ message: t('error.pleaseRelogin') });
       }

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -675,15 +675,20 @@ onMounted(async () => {
     return
   }
 
-  try {
-    const response = await autoSetup()
-    if (response.success) {
-      authStore.setLiteMode(true)
-      await persistLoginResponse(response)
-      return
+  const AUTO_SETUP_FAILED_KEY = 'weknora_auto_setup_failed'
+  if (localStorage.getItem(AUTO_SETUP_FAILED_KEY) !== 'true') {
+    try {
+      const response = await autoSetup()
+      if (response.success) {
+        authStore.setLiteMode(true)
+        await persistLoginResponse(response)
+        return
+      } else {
+        localStorage.setItem(AUTO_SETUP_FAILED_KEY, 'true')
+      }
+    } catch {
+      localStorage.setItem(AUTO_SETUP_FAILED_KEY, 'true')
     }
-  } catch {
-    // auto-setup not available (standard edition) — show normal login form
   }
 
   loadOIDCConfig()


### PR DESCRIPTION
- Added logic to track auto-setup failures using localStorage, preventing repeated attempts if the setup fails.
- Updated the router's authentication flow to conditionally attempt auto-setup based on the failure status.
- Enhanced the login component to check for auto-setup failure before attempting the setup process.

This update improves the user experience by ensuring that failed auto-setup attempts do not lead to repeated failures during login.
