### PR TITLE
fix: use explicit localhost for docreader health probes

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -150,7 +150,7 @@ services:
       - MINERU_ENDPOINT=${MINERU_ENDPOINT:-}
       - MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-}
     healthcheck:
-      test: ["CMD", "grpc_health_probe", "-addr=:50051"]
+      test: ["CMD", "grpc_health_probe", "-addr=localhost:50051"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,7 +171,7 @@ services:
       - DOCREADER_IMAGE_OUTPUT_DIR=/tmp/docreader
       - MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-}
     healthcheck:
-      test: ["CMD", "grpc_health_probe", "-addr=:50051"]
+      test: ["CMD", "grpc_health_probe", "-addr=localhost:50051"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docreader/README.md
+++ b/docreader/README.md
@@ -229,7 +229,7 @@ DocReader 服务配置了健康检查：
 
 ```yaml
 healthcheck:
-  test: ["CMD", "grpc_health_probe", "-addr=:50051"]
+  test: ["CMD", "grpc_health_probe", "-addr=localhost:50051"]
   interval: 30s
   timeout: 10s
   retries: 3

--- a/helm/templates/docreader.yaml
+++ b/helm/templates/docreader.yaml
@@ -55,7 +55,7 @@ spec:
             exec:
               command:
                 - grpc_health_probe
-                - -addr=:50051
+                - -addr=localhost:50051
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
@@ -64,7 +64,7 @@ spec:
             exec:
               command:
                 - grpc_health_probe
-                - -addr=:50051
+                - -addr=localhost:50051
             initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 3


### PR DESCRIPTION
## Summary
- replace `grpc_health_probe -addr=:50051` with `grpc_health_probe -addr=localhost:50051` in docker compose and Helm docreader probes
- update the docreader README example to match the runtime configuration

## Why
On Ubuntu/WSL2, the docreader service can start normally and serve gRPC requests, but the probe target `:50051` may still fail with `failed to connect service ":50051"`.
Using `localhost:50051` keeps the probe explicit and avoids false unhealthy results that block `app` startup via `depends_on: condition: service_healthy`.

## Verification
- `grpc_health_probe -addr=:50051` failed inside the docreader container
- `grpc_health_probe -addr=localhost:50051` returned `SERVING`
- docreader `ListEngines` and `Read` gRPC calls succeeded
- after the change, `WeKnora-docreader` became healthy and `app`/`frontend` started normally