### PR TITLE
refactor(postgres): optimize vector retrieval and HNSW settings

### DIFF
--- a/internal/agent/prompts.go
+++ b/internal/agent/prompts.go
@@ -105,79 +105,74 @@ func AvailablePlaceholders() []PlaceholderDefinition {
 	return result
 }
 
-// formatKnowledgeBaseList formats knowledge base information for the prompt
+// formatKnowledgeBaseList formats knowledge base information as XML for the prompt
 func formatKnowledgeBaseList(kbInfos []*KnowledgeBaseInfo) string {
 	if len(kbInfos) == 0 {
-		return "None"
+		return "<knowledge_bases />"
 	}
 
-	var builder strings.Builder
-	builder.WriteString("\nThe following knowledge bases have been selected by the user for this conversation. ")
-	builder.WriteString("You should search within these knowledge bases to find relevant information.\n\n")
-	for i, kb := range kbInfos {
-		// Display knowledge base name and ID
-		builder.WriteString(fmt.Sprintf("%d. **%s** (knowledge_base_id: `%s`)\n", i+1, kb.Name, kb.ID))
-
-		// Display knowledge base type
+	var b strings.Builder
+	b.WriteString("<knowledge_bases>\n")
+	for _, kb := range kbInfos {
 		kbType := kb.Type
 		if kbType == "" {
-			kbType = "document" // Default type
+			kbType = "document"
 		}
-		builder.WriteString(fmt.Sprintf("   - Type: %s\n", kbType))
-
+		b.WriteString(fmt.Sprintf("<knowledge_base id=\"%s\" name=\"%s\" type=\"%s\" doc_count=\"%d\">\n",
+			kb.ID, kb.Name, kbType, kb.DocCount))
 		if kb.Description != "" {
-			builder.WriteString(fmt.Sprintf("   - Description: %s\n", kb.Description))
+			b.WriteString(fmt.Sprintf("<description>%s</description>\n", kb.Description))
 		}
-		builder.WriteString(fmt.Sprintf("   - Document count: %d\n", kb.DocCount))
 
-		// Display recent documents if available
-		// For FAQ type knowledge bases, adjust the display format
 		if len(kb.RecentDocs) > 0 {
 			if kbType == "faq" {
-				// FAQ knowledge base: show Q&A pairs in a more compact format
-				builder.WriteString("   - Recent FAQ entries:\n\n")
-				builder.WriteString("     | # | Question  | Answers | Chunk ID | Knowledge ID | Created At |\n")
-				builder.WriteString("     |---|-------------------|---------|----------|--------------|------------|\n")
+				b.WriteString("<faq_entries>\n")
 				for j, doc := range kb.RecentDocs {
-					if j >= 10 { // Limit to 10 documents
+					if j >= 10 {
 						break
 					}
 					question := doc.FAQStandardQuestion
 					if question == "" {
 						question = doc.FileName
 					}
-					answers := "-"
+					b.WriteString(fmt.Sprintf("<faq chunk_id=\"%s\" knowledge_id=\"%s\" created_at=\"%s\">\n",
+						doc.ChunkID, doc.KnowledgeID, doc.CreatedAt))
+					b.WriteString(fmt.Sprintf("<question>%s</question>\n", question))
 					if len(doc.FAQAnswers) > 0 {
-						answers = strings.Join(doc.FAQAnswers, " | ")
+						for _, ans := range doc.FAQAnswers {
+							b.WriteString(fmt.Sprintf("<answer>%s</answer>\n", ans))
+						}
 					}
-					builder.WriteString(fmt.Sprintf("     | %d | %s | %s | `%s` | `%s` | %s |\n",
-						j+1, question, answers, doc.ChunkID, doc.KnowledgeID, doc.CreatedAt))
+					b.WriteString("</faq>\n")
 				}
+				b.WriteString("</faq_entries>\n")
 			} else {
-				// Document knowledge base: show documents in standard format
-				builder.WriteString("   - Recently added documents:\n\n")
-				builder.WriteString("     | # | Document Name | Type | Created At | Knowledge ID | File Size | Summary |\n")
-				builder.WriteString("     |---|---------------|------|------------|--------------|----------|---------|\n")
+				b.WriteString("<recent_documents>\n")
 				for j, doc := range kb.RecentDocs {
-					if j >= 10 { // Limit to 10 documents
+					if j >= 10 {
 						break
 					}
 					docName := doc.Title
 					if docName == "" {
 						docName = doc.FileName
 					}
-					// Format file size
 					fileSize := formatFileSize(doc.FileSize)
-					summary := formatDocSummary(doc.Description, 120)
-					builder.WriteString(fmt.Sprintf("     | %d | %s | %s | %s | `%s` | %s | %s |\n",
-						j+1, docName, doc.Type, doc.CreatedAt, doc.KnowledgeID, fileSize, summary))
+					b.WriteString(fmt.Sprintf("<document knowledge_id=\"%s\" type=\"%s\" file_size=\"%s\" created_at=\"%s\">\n",
+						doc.KnowledgeID, doc.Type, fileSize, doc.CreatedAt))
+					b.WriteString(fmt.Sprintf("<name>%s</name>\n", docName))
+					if doc.Description != "" {
+						summary := formatDocSummary(doc.Description, 120)
+						b.WriteString(fmt.Sprintf("<summary>%s</summary>\n", summary))
+					}
+					b.WriteString("</document>\n")
 				}
+				b.WriteString("</recent_documents>\n")
 			}
-			builder.WriteString("\n")
 		}
-		builder.WriteString("\n")
+		b.WriteString("</knowledge_base>\n")
 	}
-	return builder.String()
+	b.WriteString("</knowledge_bases>")
+	return b.String()
 }
 
 // renderPromptPlaceholders renders placeholders in the prompt template

--- a/internal/agent/tools/grep_chunks.go
+++ b/internal/agent/tools/grep_chunks.go
@@ -374,7 +374,7 @@ func (t *GrepChunksTool) searchChunks(
 	return results, int64(len(results)), nil
 }
 
-// formatOutput formats the search results for display (grep-style output)
+// formatOutput formats the search results as XML
 func (t *GrepChunksTool) formatOutput(
 	ctx context.Context,
 	results []knowledgeAggregation,
@@ -382,46 +382,37 @@ func (t *GrepChunksTool) formatOutput(
 	patterns []string,
 	countOnly bool,
 ) string {
-	var output strings.Builder
+	var b strings.Builder
 
-	// If count_only mode, just return the count
 	if countOnly {
-		output.WriteString(fmt.Sprintf("%d\n", totalCount))
-		return output.String()
+		b.WriteString(fmt.Sprintf("<grep_results count=\"%d\" />\n", totalCount))
+		return b.String()
 	}
 
-	// Show search info
-	if len(patterns) == 1 {
-		output.WriteString(fmt.Sprintf("Pattern: '%s' (case-insensitive)\n", patterns[0]))
-	} else {
-		output.WriteString(fmt.Sprintf("Patterns (%d): %v (case-insensitive, OR logic)\n", len(patterns), patterns))
+	b.WriteString(fmt.Sprintf("<grep_results match_count=\"%d\">\n", len(results)))
+	for _, p := range patterns {
+		b.WriteString(fmt.Sprintf("<pattern>%s</pattern>\n", p))
 	}
-	output.WriteString(fmt.Sprintf("Matches: %d knowledge item(s)\n\n", len(results)))
 
 	if len(results) == 0 {
-		output.WriteString("No matches found.\n")
-		return output.String()
+		b.WriteString("</grep_results>")
+		return b.String()
 	}
 
-	for idx, result := range results {
-		var patternSummaries []string
+	for _, result := range results {
+		b.WriteString(fmt.Sprintf("<match knowledge_id=\"%s\" title=\"%s\" chunk_hits=\"%d\" chunk_total=\"%d\">\n",
+			result.KnowledgeID, result.KnowledgeTitle, result.ChunkHitCount, result.TotalChunkCount))
 		for _, pattern := range patterns {
 			count := result.PatternCounts[pattern]
-			patternSummaries = append(patternSummaries, fmt.Sprintf("%s=%d", pattern, count))
+			if count > 0 {
+				b.WriteString(fmt.Sprintf("<pattern_hit pattern=\"%s\" count=\"%d\" />\n", pattern, count))
+			}
 		}
-
-		output.WriteString(
-			fmt.Sprintf("%d) knowledge_id=%s | title=%s | chunk_hits=%d | chunk_total=%d | pattern_hits=[%s]\n",
-				idx+1,
-				result.KnowledgeID,
-				result.KnowledgeTitle,
-				result.ChunkHitCount,
-				result.TotalChunkCount,
-				strings.Join(patternSummaries, ", "),
-			),
-		)
+		b.WriteString("</match>\n")
 	}
-	return output.String()
+
+	b.WriteString("</grep_results>")
+	return b.String()
 }
 
 type knowledgeAggregation struct {

--- a/internal/agent/tools/knowledge_search.go
+++ b/internal/agent/tools/knowledge_search.go
@@ -395,6 +395,21 @@ func (t *KnowledgeSearchTool) Execute(ctx context.Context, args json.RawMessage)
 		}
 	}
 
+	// Enrich image info for search results (lazy-loaded from child image chunks)
+	if t.chunkService != nil && len(deduplicatedResults) > 0 {
+		byTenant := make(map[uint64][]*types.SearchResult)
+		for _, r := range deduplicatedResults {
+			tid := t.searchTargets.GetTenantIDForKB(r.KnowledgeBaseID)
+			if tid == 0 {
+				continue
+			}
+			byTenant[tid] = append(byTenant[tid], r.SearchResult)
+		}
+		for tid, batch := range byTenant {
+			searchutil.EnrichSearchResultsImageInfo(ctx, t.chunkService.GetRepository(), tid, batch)
+		}
+	}
+
 	// Build output
 	logger.Infof(ctx, "[Tool][KnowledgeSearch] Formatting output with %d final results", len(deduplicatedResults))
 	result, err := t.formatOutput(ctx, deduplicatedResults, kbIDs, queries)
@@ -1065,144 +1080,106 @@ func (t *KnowledgeSearchTool) formatOutput(
 		}, nil
 	}
 
-	// Build output header
-	output := "=== Search Results ===\n"
-	output += fmt.Sprintf("Found %d relevant results", len(results))
-	output += "\n\n"
-
 	// Count results by KB
 	kbCounts := make(map[string]int)
 	for _, r := range results {
 		kbCounts[r.KnowledgeID]++
 	}
 
-	output += "Knowledge Base Coverage:\n"
-	for kbID, count := range kbCounts {
-		output += fmt.Sprintf("  - %s: %d results\n", kbID, count)
-	}
-	output += "\n=== Detailed Results ===\n\n"
+	// Format individual results as XML
+	var ob strings.Builder
+	ob.WriteString(fmt.Sprintf("<search_results count=\"%d\">\n", len(results)))
 
-	// Format individual results
 	formattedResults := make([]map[string]interface{}, 0, len(results))
-	currentKB := ""
 
 	faqMetadataCache := make(map[string]*types.FAQChunkMetadata)
 
-	// Track chunks per knowledge for statistics
-	knowledgeChunkMap := make(map[string]map[int]bool) // knowledge_id -> set of chunk_index
-	knowledgeTotalMap := make(map[string]int64)        // knowledge_id -> total chunks
-	knowledgeTitleMap := make(map[string]string)       // knowledge_id -> title
+	knowledgeChunkMap := make(map[string]map[int]bool)
+	knowledgeTotalMap := make(map[string]int64)
+	knowledgeTitleMap := make(map[string]string)
 
 	for i, result := range results {
 		var faqMeta *types.FAQChunkMetadata
 		if result.KnowledgeBaseType == types.KnowledgeBaseTypeFAQ {
 			meta, err := t.getFAQMetadata(ctx, result.ID, faqMetadataCache)
 			if err != nil {
-				logger.Warnf(
-					ctx,
-					"[Tool][KnowledgeSearch] Failed to load FAQ metadata for chunk %s: %v",
-					result.ID,
-					err,
-				)
+				logger.Warnf(ctx, "[Tool][KnowledgeSearch] Failed to load FAQ metadata for chunk %s: %v", result.ID, err)
 			} else {
 				faqMeta = meta
 			}
 		}
 
-		// Track chunk indices per knowledge
 		if knowledgeChunkMap[result.KnowledgeID] == nil {
 			knowledgeChunkMap[result.KnowledgeID] = make(map[int]bool)
 		}
 		knowledgeChunkMap[result.KnowledgeID][result.ChunkIndex] = true
 		knowledgeTitleMap[result.KnowledgeID] = result.KnowledgeTitle
 
-		// Group by knowledge base
-		if result.KnowledgeID != currentKB {
-			currentKB = result.KnowledgeID
-			if i > 0 {
-				output += "\n"
-			}
-			output += fmt.Sprintf("[Source Document: %s]\n", result.KnowledgeTitle)
-
-			// Get total chunk count for this knowledge (cache it)
-			// Use KB's tenant_id from searchTargets to support cross-tenant shared KB
-			if _, exists := knowledgeTotalMap[result.KnowledgeID]; !exists {
-				// Get tenant_id from searchTargets using the KB ID from the result
-				effectiveTenantID := t.searchTargets.GetTenantIDForKB(result.KnowledgeBaseID)
-				if effectiveTenantID == 0 {
-					logger.Warnf(ctx, "[Tool][KnowledgeSearch] KB %s not found in searchTargets, skipping chunk count", result.KnowledgeBaseID)
+		// Cache total chunk count per knowledge
+		if _, exists := knowledgeTotalMap[result.KnowledgeID]; !exists {
+			effectiveTenantID := t.searchTargets.GetTenantIDForKB(result.KnowledgeBaseID)
+			if effectiveTenantID == 0 {
+				logger.Warnf(ctx, "[Tool][KnowledgeSearch] KB %s not found in searchTargets, skipping chunk count", result.KnowledgeBaseID)
+				knowledgeTotalMap[result.KnowledgeID] = 0
+			} else {
+				_, total, err := t.chunkService.GetRepository().ListPagedChunksByKnowledgeID(ctx,
+					effectiveTenantID, result.KnowledgeID,
+					&types.Pagination{Page: 1, PageSize: 1},
+					[]types.ChunkType{types.ChunkTypeText}, "", "", "", "", "",
+				)
+				if err != nil {
+					logger.Warnf(ctx, "[Tool][KnowledgeSearch] Failed to get total chunks for knowledge %s: %v", result.KnowledgeID, err)
 					knowledgeTotalMap[result.KnowledgeID] = 0
 				} else {
-					_, total, err := t.chunkService.GetRepository().ListPagedChunksByKnowledgeID(ctx,
-						effectiveTenantID, result.KnowledgeID,
-						&types.Pagination{Page: 1, PageSize: 1},
-						[]types.ChunkType{types.ChunkTypeText}, "", "", "", "", "",
-					)
-					if err != nil {
-						logger.Warnf(
-							ctx,
-							"[Tool][KnowledgeSearch] Failed to get total chunks for knowledge %s: %v",
-							result.KnowledgeID,
-							err,
-						)
-						knowledgeTotalMap[result.KnowledgeID] = 0
-					} else {
-						knowledgeTotalMap[result.KnowledgeID] = total
-					}
+					knowledgeTotalMap[result.KnowledgeID] = total
 				}
 			}
 		}
 
-		// relevanceLevel := GetRelevanceLevel(result.Score)
-		output += fmt.Sprintf("\nResult #%d:\n", i+1)
-		output += fmt.Sprintf(
-			"  [chunk_id: %s][chunk_index: %d]\nContent: %s\n",
-			result.ID,
-			result.ChunkIndex,
-			result.Content,
-		)
+		ob.WriteString(fmt.Sprintf("<result id=\"%d\" chunk_id=\"%s\" chunk_index=\"%d\" knowledge_id=\"%s\" source=\"%s\">\n",
+			i+1, result.ID, result.ChunkIndex, result.KnowledgeID, result.KnowledgeTitle))
+		ob.WriteString(fmt.Sprintf("<content>%s</content>\n", result.Content))
 
-		// 解析并输出关联的图片信息
 		if result.ImageInfo != "" {
 			var imageInfos []types.ImageInfo
 			if err := json.Unmarshal([]byte(result.ImageInfo), &imageInfos); err == nil && len(imageInfos) > 0 {
-				output += fmt.Sprintf("  Related Images (%d):\n", len(imageInfos))
-				for imgIdx, img := range imageInfos {
-					output += fmt.Sprintf("    Image %d:\n", imgIdx+1)
-					if img.URL != "" {
-						output += fmt.Sprintf("      URL: %s\n", img.URL)
-					}
+				for _, img := range imageInfos {
+					ob.WriteString(fmt.Sprintf("<image url=\"%s\">\n", img.URL))
 					if img.Caption != "" {
-						output += fmt.Sprintf("      Caption: %s\n", img.Caption)
+						ob.WriteString(fmt.Sprintf("<image_caption>%s</image_caption>\n", img.Caption))
 					}
 					if img.OCRText != "" {
-						output += fmt.Sprintf("      OCR Text: %s\n", img.OCRText)
+						ob.WriteString(fmt.Sprintf("<image_ocr>%s</image_ocr>\n", img.OCRText))
 					}
+					ob.WriteString("</image>\n")
 				}
 			}
 		}
 
 		if faqMeta != nil {
+			ob.WriteString("<faq>\n")
 			if faqMeta.StandardQuestion != "" {
-				output += fmt.Sprintf("  FAQ Standard Question: %s\n", faqMeta.StandardQuestion)
+				ob.WriteString(fmt.Sprintf("<question>%s</question>\n", faqMeta.StandardQuestion))
 			}
 			if len(faqMeta.SimilarQuestions) > 0 {
-				output += fmt.Sprintf("  FAQ Similar Questions: %s\n", strings.Join(faqMeta.SimilarQuestions, "; "))
-			}
-			if len(faqMeta.Answers) > 0 {
-				output += "  FAQ Answers:\n"
-				for ansIdx, ans := range faqMeta.Answers {
-					output += fmt.Sprintf("    Answer Choice %d: %s\n", ansIdx+1, ans)
+				for _, sq := range faqMeta.SimilarQuestions {
+					ob.WriteString(fmt.Sprintf("<similar_question>%s</similar_question>\n", sq))
 				}
 			}
+			if len(faqMeta.Answers) > 0 {
+				for _, ans := range faqMeta.Answers {
+					ob.WriteString(fmt.Sprintf("<answer>%s</answer>\n", ans))
+				}
+			}
+			ob.WriteString("</faq>\n")
 		}
 
+		ob.WriteString("</result>\n")
+
 		formattedResults = append(formattedResults, map[string]interface{}{
-			"result_index": i + 1,
-			"chunk_id":     result.ID,
-			"content":      result.Content,
-			// "score":        result.Score,
-			// "relevance_level":     relevanceLevel,
+			"result_index":        i + 1,
+			"chunk_id":            result.ID,
+			"content":             result.Content,
 			"knowledge_id":        result.KnowledgeID,
 			"knowledge_title":     result.KnowledgeTitle,
 			"match_type":          result.MatchType,
@@ -1213,11 +1190,9 @@ func (t *KnowledgeSearchTool) formatOutput(
 
 		last := formattedResults[len(formattedResults)-1]
 
-		// 添加图片信息到结构化数据
 		if result.ImageInfo != "" {
 			var imageInfos []types.ImageInfo
 			if err := json.Unmarshal([]byte(result.ImageInfo), &imageInfos); err == nil && len(imageInfos) > 0 {
-				// 构建简化的图片信息列表
 				imageList := make([]map[string]string, 0, len(imageInfos))
 				for _, img := range imageInfos {
 					imgData := make(map[string]string)
@@ -1253,36 +1228,23 @@ func (t *KnowledgeSearchTool) formatOutput(
 		}
 	}
 
-	// Add statistics and recommendations for each knowledge
-	output += "\n=== Retrieval Statistics ===\n\n"
+	// Retrieval statistics
+	ob.WriteString("<retrieval_statistics>\n")
 	for knowledgeID, retrievedChunks := range knowledgeChunkMap {
 		totalChunks := knowledgeTotalMap[knowledgeID]
 		retrievedCount := len(retrievedChunks)
 		title := knowledgeTitleMap[knowledgeID]
-
 		if totalChunks > 0 {
-			percentage := float64(retrievedCount) / float64(totalChunks) * 100
 			remaining := totalChunks - int64(retrievedCount)
-
-			output += fmt.Sprintf("Document: %s (%s)\n", title, knowledgeID)
-			output += fmt.Sprintf("  Total Chunks: %d\n", totalChunks)
-			output += fmt.Sprintf("  Retrieved: %d (%.1f%%)\n", retrievedCount, percentage)
-			output += fmt.Sprintf("  Remaining: %d\n", remaining)
-
+			percentage := float64(retrievedCount) / float64(totalChunks) * 100
+			ob.WriteString(fmt.Sprintf("<document_stat knowledge_id=\"%s\" title=\"%s\" total_chunks=\"%d\" retrieved=\"%d\" remaining=\"%d\" coverage=\"%.1f%%\" />\n",
+				knowledgeID, title, totalChunks, retrievedCount, remaining, percentage))
 		}
 	}
+	ob.WriteString("</retrieval_statistics>\n")
+	ob.WriteString("</search_results>")
 
-	// // Add usage guidance
-	// output += "\n\n=== Usage Guidelines ===\n"
-	// output += "- High relevance (>=0.8): directly usable for answering\n"
-	// output += "- Medium relevance (0.6-0.8): use as supplementary reference\n"
-	// output += "- Low relevance (<0.6): use with caution, may not be accurate\n"
-	// if totalBeforeFilter > len(results) {
-	// 	output += "- Results below threshold have been automatically filtered\n"
-	// }
-	// output += "- Full content is already included in search results above\n"
-	// output += "- Results are deduplicated across knowledge bases and sorted by relevance\n"
-	// output += "- Use list_knowledge_chunks to expand context if needed\n"
+	output := ob.String()
 
 	data := map[string]interface{}{
 		"knowledge_base_ids": kbsToSearch,

--- a/internal/agent/tools/list_knowledge_chunks.go
+++ b/internal/agent/tools/list_knowledge_chunks.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Tencent/WeKnora/internal/searchutil"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 )
@@ -160,6 +161,22 @@ func (t *ListKnowledgeChunksTool) Execute(ctx context.Context, args json.RawMess
 	totalChunks := total
 	fetched := len(chunks)
 
+	// Enrich image info from child image chunks (lazy loading)
+	if fetched > 0 {
+		chunkIDs := make([]string, 0, fetched)
+		for _, c := range chunks {
+			chunkIDs = append(chunkIDs, c.ID)
+		}
+		infoMap := searchutil.CollectImageInfoByChunkIDs(ctx, t.chunkService.GetRepository(), effectiveTenantID, chunkIDs)
+		for _, c := range chunks {
+			if c.ImageInfo == "" {
+				if merged, ok := infoMap[c.ID]; ok {
+					c.ImageInfo = merged
+				}
+			}
+		}
+	}
+
 	knowledgeTitle := t.lookupKnowledgeTitle(ctx, knowledgeID)
 
 	output := t.buildOutput(knowledgeID, knowledgeTitle, totalChunks, fetched, chunks)
@@ -236,7 +253,7 @@ func (t *ListKnowledgeChunksTool) lookupKnowledgeTitle(ctx context.Context, know
 	return strings.TrimSpace(knowledge.Title)
 }
 
-// buildOutput builds the output for the list knowledge chunks tool
+// buildOutput builds the output as XML for the list knowledge chunks tool
 func (t *ListKnowledgeChunksTool) buildOutput(
 	knowledgeID string,
 	knowledgeTitle string,
@@ -244,65 +261,54 @@ func (t *ListKnowledgeChunksTool) buildOutput(
 	fetched int,
 	chunks []*types.Chunk,
 ) string {
-	builder := &strings.Builder{}
-	builder.WriteString("=== Knowledge Document Chunks ===\n\n")
+	var b strings.Builder
 
+	titleAttr := ""
 	if knowledgeTitle != "" {
-		fmt.Fprintf(builder, "Document: %s (%s)\n", knowledgeTitle, knowledgeID)
-	} else {
-		fmt.Fprintf(builder, "Document ID: %s\n", knowledgeID)
+		titleAttr = fmt.Sprintf(" title=\"%s\"", knowledgeTitle)
 	}
-	fmt.Fprintf(builder, "Total chunks: %d\n", total)
+	fmt.Fprintf(&b, "<knowledge_chunks knowledge_id=\"%s\"%s total=\"%d\" fetched=\"%d\">\n",
+		knowledgeID, titleAttr, total, fetched)
 
 	if fetched == 0 {
-		builder.WriteString("No chunks found. Please confirm the document has been parsed.\n")
-		if total > 0 {
-			builder.WriteString("Document exists but the current page is empty. Please check pagination parameters.\n")
-		}
-		return builder.String()
+		b.WriteString("</knowledge_chunks>")
+		return b.String()
 	}
-	fmt.Fprintf(
-		builder,
-		"Fetched: %d chunks, range: %d - %d\n\n",
-		fetched,
-		chunks[0].ChunkIndex,
-		chunks[len(chunks)-1].ChunkIndex,
-	)
 
-	builder.WriteString("=== Chunk Content Preview ===\n\n")
-	for idx, c := range chunks {
-		fmt.Fprintf(builder, "Chunk #%d (Index %d)\n", idx+1, c.ChunkIndex+1)
-		fmt.Fprintf(builder, "  chunk_id: %s\n", c.ID)
-		fmt.Fprintf(builder, "  Type: %s\n", c.ChunkType)
-		fmt.Fprintf(builder, "  Content: %s\n", summarizeContent(c.Content))
+	for _, c := range chunks {
+		fmt.Fprintf(&b, "<chunk chunk_id=\"%s\" chunk_index=\"%d\" type=\"%s\">\n",
+			c.ID, c.ChunkIndex, c.ChunkType)
+		fmt.Fprintf(&b, "<content>%s</content>\n", summarizeContent(c.Content))
 
-		// Output associated image information
 		if c.ImageInfo != "" {
 			var imageInfos []types.ImageInfo
 			if err := json.Unmarshal([]byte(c.ImageInfo), &imageInfos); err == nil && len(imageInfos) > 0 {
-				fmt.Fprintf(builder, "  Associated images (%d):\n", len(imageInfos))
-				for imgIdx, img := range imageInfos {
-					fmt.Fprintf(builder, "    Image %d:\n", imgIdx+1)
+				for _, img := range imageInfos {
 					if img.URL != "" {
-						fmt.Fprintf(builder, "      URL: %s\n", img.URL)
+						fmt.Fprintf(&b, "<image url=\"%s\">\n", img.URL)
+					} else {
+						b.WriteString("<image>\n")
 					}
 					if img.Caption != "" {
-						fmt.Fprintf(builder, "      Caption: %s\n", img.Caption)
+						fmt.Fprintf(&b, "<image_caption>%s</image_caption>\n", img.Caption)
 					}
 					if img.OCRText != "" {
-						fmt.Fprintf(builder, "      OCR Text: %s\n", img.OCRText)
+						fmt.Fprintf(&b, "<image_ocr>%s</image_ocr>\n", img.OCRText)
 					}
+					b.WriteString("</image>\n")
 				}
 			}
 		}
-		builder.WriteString("\n")
+
+		b.WriteString("</chunk>\n")
 	}
 
 	if int64(fetched) < total {
-		builder.WriteString("Note: The document has more chunks. Adjust offset or make multiple calls to retrieve all content.\n")
+		fmt.Fprintf(&b, "<pagination remaining=\"%d\" />\n", int64(total)-int64(fetched))
 	}
 
-	return builder.String()
+	b.WriteString("</knowledge_chunks>")
+	return b.String()
 }
 
 // summarizeContent summarizes the content of a chunk

--- a/internal/application/repository/retriever/postgres/repository.go
+++ b/internal/application/repository/retriever/postgres/repository.go
@@ -193,13 +193,13 @@ func (g *pgRepository) KeywordsRetrieve(ctx context.Context,
 			Values: common.ToInterfaceSlice(params.TagIDs),
 		})
 	}
-	
+
 	// Use ParadeDB's ||| operator for matching any token
 	conds = append(conds, clause.Expr{
 		SQL:  "content ||| ?",
 		Vars: []interface{}{params.Query},
 	})
-	
+
 	// Filter by is_enabled = true or NULL (NULL means enabled for historical data)
 	conds = append(conds, clause.Expr{
 		SQL:  "(is_enabled IS NULL OR is_enabled = ?)",
@@ -340,22 +340,36 @@ func (g *pgRepository) VectorRetrieve(ctx context.Context,
 		whereClause = "WHERE " + strings.Join(whereParts, " AND ")
 	}
 
-	// Expand TopK to get more candidates before threshold filtering
+	// Expand TopK to get more candidates before threshold filtering.
+	//
+	// HNSW requires `ef_search >= LIMIT`, and a very large LIMIT (e.g. 1000)
+	// forces HNSW to walk a near-exhaustive portion of the graph, often making
+	// it slower than a sequential scan and pushing the planner to pick Seq Scan
+	// even when an index exists. 200 is a good sweet spot: it gives enough
+	// headroom for threshold/filter post-processing without ballooning ef_search.
 	expandedTopK := params.TopK * 2
 	if expandedTopK < 100 {
 		expandedTopK = 100 // Minimum 100 candidates
 	}
-	if expandedTopK > 1000 {
-		expandedTopK = 1000 // Maximum 1000 candidates
+	if expandedTopK > 200 {
+		expandedTopK = 200 // Maximum 200 candidates (keeps HNSW efficient)
 	}
 	if expandedTopK < params.TopK {
 		expandedTopK = params.TopK // Ensure subquery limit is at least final limit
 	}
 
-	// Optimized query: Use subquery to calculate distance once
-	// Strategy: Use ORDER BY with vector distance to leverage HNSW index,
-	// then filter by threshold in outer query
-	// This allows PostgreSQL to use HNSW index efficiently
+	// Optimized query: Use subquery to calculate distance once.
+	//
+	// IMPORTANT: The HNSW index in this project is built on the EXPRESSION
+	//   (embedding::halfvec(<dim>)) halfvec_cosine_ops
+	// because the `embedding` column itself is `halfvec` without a fixed dimension
+	// (so the table can store multiple embedding sizes such as 798 / 3584 / ...).
+	//
+	// pgvector requires the ORDER BY expression to match the indexed expression
+	// EXACTLY, otherwise the planner falls back to a sequential scan. The
+	// `embedding::halfvec(%d)` cast on both sides of `<=>` is therefore NOT
+	// redundant — it is the only way to make the HNSW index get used at all.
+	// See: pgvector issues #702, #835 and ParadeDB "indexing-expressions" docs.
 	subqueryLimitParam := len(allVars) + 1
 	thresholdParam := len(allVars) + 2
 	finalLimitParam := len(allVars) + 3
@@ -367,24 +381,66 @@ func (g *pgRepository) VectorRetrieve(ctx context.Context,
 		FROM (
 			SELECT 
 				id, content, source_id, source_type, chunk_id, knowledge_id, knowledge_base_id, tag_id,
-				embedding <=> $1::halfvec as distance
+				embedding::halfvec(%[1]d) <=> $1::halfvec(%[1]d) as distance
 			FROM embeddings
-			%s
-			ORDER BY embedding <=> $1::halfvec
-			LIMIT $%d
+			%[2]s
+			ORDER BY embedding::halfvec(%[1]d) <=> $1::halfvec(%[1]d)
+			LIMIT $%[3]d
 		) AS candidates
-		WHERE distance <= $%d
+		WHERE distance <= $%[4]d
 		ORDER BY distance ASC
-		LIMIT $%d
-	`, whereClause, subqueryLimitParam, thresholdParam, finalLimitParam)
+		LIMIT $%[5]d
+	`, dimension, whereClause, subqueryLimitParam, thresholdParam, finalLimitParam)
 
 	allVars = append(allVars, expandedTopK)       // LIMIT in subquery
 	allVars = append(allVars, 1-params.Threshold) // Distance threshold
 	allVars = append(allVars, params.TopK)        // Final LIMIT
 
+	// HNSW's `ef_search` defaults to 40, which is much smaller than our
+	// `expandedTopK` budget (up to 1000). Without raising it, HNSW would only
+	// return ~40 candidates per scan and our outer threshold/filter step would
+	// silently lose recall. `SET LOCAL` requires a transaction so we wrap the
+	// query in one. We never write inside this transaction, so the cost is
+	// negligible.
+	efSearch := expandedTopK
+	if efSearch < 40 {
+		efSearch = 40
+	}
+
 	var embeddingDBList []pgVectorWithScore
 
-	err := g.db.WithContext(ctx).Raw(querySQL, allVars...).Scan(&embeddingDBList).Error
+	err := g.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec(fmt.Sprintf("SET LOCAL hnsw.ef_search = %d", efSearch)).Error; err != nil {
+			// Treat as non-fatal: pgvector should always expose this GUC, but if
+			// for any reason it does not we still want the query to run (just
+			// with default recall). We must rollback first because a failed
+			// statement aborts the transaction in PostgreSQL.
+			logger.GetLogger(ctx).Warnf("[Postgres] Failed to set hnsw.ef_search=%d: %v", efSearch, err)
+			return err
+		}
+		// pgvector >= 0.8 supports iterative scan, which keeps pulling more
+		// candidates from HNSW until the post-filter (knowledge_base_id /
+		// knowledge_id / tag_id / is_enabled) yields enough rows. Without it,
+		// HNSW returns at most ef_search candidates and the outer filter may
+		// silently lose recall when the filter is selective.
+		// Best-effort: ignore failure on older pgvector versions.
+		if err := tx.Exec("SET LOCAL hnsw.iterative_scan = strict_order").Error; err != nil {
+			logger.GetLogger(ctx).Debugf("[Postgres] hnsw.iterative_scan not available: %v", err)
+			// abort transaction and let the fallback path below handle it.
+			return err
+		}
+		return tx.Raw(querySQL, allVars...).Scan(&embeddingDBList).Error
+	})
+
+	// Fallback: if the transaction failed because of an unsupported GUC (e.g.
+	// older pgvector that doesn't have hnsw.ef_search or hnsw.iterative_scan),
+	// retry the query without the SETs so we still return results.
+	if err != nil && len(embeddingDBList) == 0 &&
+		(strings.Contains(err.Error(), "hnsw.ef_search") ||
+			strings.Contains(err.Error(), "hnsw.iterative_scan")) {
+		logger.GetLogger(ctx).Warnf("[Postgres] Retrying vector query without HNSW GUC overrides: %v", err)
+		err = g.db.WithContext(ctx).Raw(querySQL, allVars...).Scan(&embeddingDBList).Error
+	}
 
 	if err == gorm.ErrRecordNotFound {
 		logger.GetLogger(ctx).Warnf("[Postgres] No vector matches found that meet threshold %.4f", params.Threshold)

--- a/internal/application/service/chat_pipeline/merge_overlap.go
+++ b/internal/application/service/chat_pipeline/merge_overlap.go
@@ -30,10 +30,36 @@ func (p *PluginMerge) mergeOverlappingChunks(
 			continue
 		}
 
-		// Partial overlap: append the non-overlapping suffix
+		// Partial overlap: append the non-overlapping suffix.
+		//
+		// Offset math assumes len([]rune(Content)) == EndAt-StartAt, but a
+		// few upstream paths break that invariant:
+		//   - Parent-child chunker prepends table headers, so Content may be
+		//     longer than EndAt-StartAt.
+		//   - Legacy data / mixed chunk sources may carry EndAt-StartAt that
+		//     exceed the actual rune length of Content.
+		// We clamp offset into [0, len(contentRunes)] so the merge degrades
+		// gracefully instead of panicking with a negative slice bound.
 		if chunks[i].EndAt > lastChunk.EndAt {
 			contentRunes := []rune(chunks[i].Content)
-			offset := len(contentRunes) - (chunks[i].EndAt - lastChunk.EndAt)
+			suffixLen := chunks[i].EndAt - lastChunk.EndAt
+			offset := len(contentRunes) - suffixLen
+			if offset < 0 || offset > len(contentRunes) {
+				pipelineWarn(ctx, "Merge", "overlap_offset_clamp", map[string]interface{}{
+					"knowledge_id":    knowledgeID,
+					"chunk_id":        chunks[i].ID,
+					"content_runes":   len(contentRunes),
+					"chunk_start":     chunks[i].StartAt,
+					"chunk_end":       chunks[i].EndAt,
+					"last_end":        lastChunk.EndAt,
+					"computed_offset": offset,
+				})
+				if offset < 0 {
+					offset = 0
+				} else {
+					offset = len(contentRunes)
+				}
+			}
 			lastChunk.Content = lastChunk.Content + string(contentRunes[offset:])
 			lastChunk.EndAt = chunks[i].EndAt
 			lastChunk.SubChunkID = append(lastChunk.SubChunkID, chunks[i].ID)

--- a/internal/application/service/knowledgebase_search.go
+++ b/internal/application/service/knowledgebase_search.go
@@ -114,8 +114,8 @@ func (s *knowledgeBaseService) HybridSearch(ctx context.Context,
 	// Use 5x over-retrieval to ensure sufficient candidates for RRF fusion and reranking.
 	// Scale proportionally when searching multiple KBs to maintain per-KB recall quality.
 	matchCount := max(params.MatchCount*5, 50) * len(searchKBIDs)
-	if matchCount > 1000 {
-		matchCount = 1000
+	if matchCount > 500 {
+		matchCount = 500
 	}
 
 	// Build retrieval parameters for vector and keyword engines


### PR DESCRIPTION
- Adjusted the expanded TopK limit to a maximum of 200 candidates to enhance HNSW efficiency.
- Updated the vector retrieval query to ensure the ORDER BY expression matches the indexed expression, improving index usage.
- Implemented local settings for HNSW's ef_search and iterative_scan within a transaction to optimize candidate retrieval.
- Added fallback logic to handle unsupported GUCs gracefully, ensuring query execution continues even with older pgvector versions.
