### PR TITLE
fix: remove limit/offset from required in list_knowledge_chunks JSON Schema

### DIFF
--- a/internal/agent/tools/list_knowledge_chunks.go
+++ b/internal/agent/tools/list_knowledge_chunks.go
@@ -52,7 +52,7 @@ Full chunk content with chunk_id, chunk_index, and content text.`,
       "minimum": 0
     }
   },
-  "required": ["knowledge_id", "limit", "offset"]
+  "required": ["knowledge_id"]
 }`),
 }
 


### PR DESCRIPTION
## Problem

Closes #1003

`list_knowledge_chunks.go:54` declares `limit` and `offset` as `required` in the JSON Schema, but both parameters are optional with sensible defaults (`limit=20`, `offset=0`).

This forces MCP/LLM clients to always provide `limit` and `offset` when calling `list_knowledge_chunks`, breaking the expected usage pattern where clients call the tool with only `knowledge_id`.

## Root Cause

```json
// Before (incorrect)
"required": ["knowledge_id", "limit", "offset"]
```

The implementation already handles missing values gracefully:
```go
chunkLimit := 20
if input.Limit > 0 {
    chunkLimit = input.Limit
}
offset := 0
if input.Offset > 0 {
    offset = input.Offset
}
```

## Fix

Remove `limit` and `offset` from the `required` array — only `knowledge_id` is truly required.

```json
// After (correct)
"required": ["knowledge_id"]
```

## Before / After

| Field | Before | After |
|-------|--------|-------|
| `knowledge_id` | required ✅ | required ✅ |
| `limit` | required ❌ | optional ✅ (default: 20) |
| `offset` | required ❌ | optional ✅ (default: 0) |

No behavior change in the implementation — only the schema declaration is corrected to match the actual semantics.