### PR TITLE
fix(agent-share): don't require rerank model for wiki-only agents

### DIFF
--- a/internal/application/service/agent_share.go
+++ b/internal/application/service/agent_share.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Tencent/WeKnora/internal/agent/tools"
 	"github.com/Tencent/WeKnora/internal/application/repository"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
@@ -19,8 +20,34 @@ var (
 	ErrAgentNotFoundForShare   = errors.New("agent not found")
 	ErrNotAgentOwner           = errors.New("only agent owner can share")
 	ErrOrgRoleCannotShareAgent = errors.New("only editors and admins can share agents to this organization")
-	ErrAgentNotConfigured      = errors.New("agent is not fully configured (missing required chat model or rerank model when using knowledge bases)")
+	ErrAgentNotConfigured      = errors.New("agent is not fully configured (missing required chat model, or rerank model when the knowledge_search tool is enabled)")
 )
+
+// agentRequiresRerankModel returns true when the agent's configured tools
+// will actually invoke the reranker at runtime. This mirrors the runtime
+// check in session_agent_qa.go: only `knowledge_search` uses the reranker.
+// Wiki-first agents (wiki_search / wiki_read_page / …) never call it and
+// therefore don't need a rerank model configured, even when knowledge bases
+// are attached.
+//
+// When AllowedTools is empty the runtime falls back to
+// tools.DefaultAllowedTools(), which includes knowledge_search, so we treat
+// that case as requiring the reranker.
+func agentRequiresRerankModel(agent *types.CustomAgent) bool {
+	if agent == nil {
+		return false
+	}
+	allowed := agent.Config.AllowedTools
+	if len(allowed) == 0 {
+		allowed = tools.DefaultAllowedTools()
+	}
+	for _, t := range allowed {
+		if t == tools.ToolKnowledgeSearch {
+			return true
+		}
+	}
+	return false
+}
 
 // agentShareService implements AgentShareService interface
 type agentShareService struct {
@@ -60,12 +87,14 @@ func (s *agentShareService) ShareAgent(ctx context.Context, agentID string, orgI
 		return nil, ErrNotAgentOwner
 	}
 
-	// Require agent to be fully configured before sharing (same rules as for conversation)
+	// Require agent to be fully configured before sharing (same rules as for
+	// conversation — see session_agent_qa.go). Rerank model is only required
+	// when the `knowledge_search` tool is enabled; Wiki-only agents
+	// (wiki_search / wiki_read_page) don't call the reranker at runtime.
 	if agent.Config.ModelID == "" {
 		return nil, ErrAgentNotConfigured
 	}
-	usesKB := agent.Config.KBSelectionMode != "none" || len(agent.Config.KnowledgeBases) > 0
-	if usesKB && agent.Config.RerankModelID == "" {
+	if agentRequiresRerankModel(agent) && agent.Config.RerankModelID == "" {
 		return nil, ErrAgentNotConfigured
 	}
 

--- a/internal/handler/organization.go
+++ b/internal/handler/organization.go
@@ -1262,7 +1262,7 @@ func (h *OrganizationHandler) ShareAgent(c *gin.Context) {
 			return
 		}
 		if errors.Is(err, service.ErrAgentNotConfigured) {
-			c.Error(apperrors.NewValidationError("Agent is not fully configured. Please set the chat model and, if using knowledge bases, the rerank model in agent settings."))
+			c.Error(apperrors.NewValidationError("Agent is not fully configured. Please set the chat model, and set the rerank model if the knowledge_search tool is enabled in agent settings."))
 			return
 		}
 		c.Error(apperrors.NewForbiddenError("Permission denied or invalid operation"))


### PR DESCRIPTION
## Summary

Sharing a Wiki-type custom agent to a space currently fails with:

> Agent is not fully configured. Please set the chat model and, if using knowledge bases, the rerank model in agent settings.

even though a Wiki agent only uses `wiki_search` / `wiki_read_page` / `wiki_read_source_doc` / … and never invokes the reranker at runtime. The share-time validation in `agent_share.go` was too coarse — it required `rerank_model_id` whenever any KB was attached.

This PR aligns the share-time check with the runtime check in `session_agent_qa.go`:

- Rerank model is only required when `knowledge_search` is in `allowed_tools` (or when `allowed_tools` is empty and the runtime falls back to `tools.DefaultAllowedTools()`, which contains `knowledge_search`).
- Wiki-only agents (preset `wiki-qa` and any custom agent whose tools don't include `knowledge_search`) can now be shared without a rerank model configured.
- Hybrid / RAG agents still enforce the requirement, unchanged.
- Handler error message updated to match the new rule.

## Changes

- `internal/application/service/agent_share.go`
  - New helper `agentRequiresRerankModel(agent)` mirroring the `session_agent_qa.go` runtime gate.
  - `ShareAgent` replaces the `usesKB && RerankModelID == ""` check with `agentRequiresRerankModel(agent) && RerankModelID == ""`.
  - `ErrAgentNotConfigured` text clarified.
- `internal/handler/organization.go`
  - User-facing validation error updated to "…set the rerank model if the `knowledge_search` tool is enabled…".

## Test plan

- [ ] Create a Wiki Q&A agent (preset `wiki-qa`, tools = `wiki_search`, `wiki_read_page`, `wiki_read_source_doc`, `wiki_flag_issue`, `final_answer`), bind a Wiki-enabled KB, leave rerank model empty → share to space succeeds.
- [ ] Create a RAG Q&A agent with `knowledge_search` enabled and no rerank model → share fails with the updated error message.
- [ ] Create a Hybrid agent (`knowledge_search` + `wiki_search`) with rerank configured → share succeeds.
- [ ] Existing share flow for fully configured RAG agents keeps working.