### PR TITLE
Fix/docreader protoc offline whitelist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -63,9 +63,9 @@ test/data/mswag.txt
 
 # 大的归档/压缩包
 packages/protoc-*.zip
-!packages/protoc-3.19.4-linux-x86_64.zip
-!packages/protoc-3.19.4-linux-aarch_64.zip
-!packages/protoc-3.19.4-linux-arm.zip
+!packages/protoc-*-linux-x86_64.zip
+!packages/protoc-*-linux-aarch_64.zip
+!packages/protoc-*-linux-arm.zip
 
 # 本地测试脚本
 configure-ollama.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -63,6 +63,9 @@ test/data/mswag.txt
 
 # 大的归档/压缩包
 packages/protoc-*.zip
+!packages/protoc-3.19.4-linux-x86_64.zip
+!packages/protoc-3.19.4-linux-aarch_64.zip
+!packages/protoc-3.19.4-linux-arm.zip
 
 # 本地测试脚本
 configure-ollama.sh

--- a/docker/Dockerfile.docreader
+++ b/docker/Dockerfile.docreader
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y \
 # 检查是否存在本地protoc安装包，如果存在则离线安装，否则在线安装
 ARG TARGETARCH
 COPY packages/ /app/packages/
+RUN ls -lah /app/packages/
 # 兼容 BuildKit 和传统构建：如果 TARGETARCH 为空，使用 uname 检测
 RUN if [ -z "$TARGETARCH" ]; then \
         case $(uname -m) in \


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
修复了在使用 Docker 构建 `docreader` 服务时，由于项目根目录下的 `.dockerignore` 中全局排除了 `packages/protoc-*.zip`，导致即使本地存在离线 protoc 安装包也无法进入构建上下文，从而在内网或无代理环境下强制回退到在线下载并因证书问题构建失败的 Bug。

1. 在 `.dockerignore` 中添加了白名单规则 ，确保离线包可以正常进入 Docker context。
2. 在 `docker/Dockerfile.docreader` 中追加了 `RUN ls -lah /app/packages/` 命令，便于在构建日志中直观确认离线依赖包是否被正确加载。

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [ ] 📚 文档更新 (Documentation update)
- [ ] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [ ] 🧪 测试相关 (Test related)
- [ ] 🔧 配置变更 (Configuration change)
- [x] 🐳 Docker 相关 (Docker related)
- [ ] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
- [ ] 后端 API (Backend API)
- [ ] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [x] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [x] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [ ] 其他 (Other): 

## 测试 (Testing)
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 在项目根目录下手动创建 `packages` 目录，并放入对应的 protoc 离线包
2. 断开网络连接或在纯无代理网络环境下。
3. 在项目根目录执行构建命令：`docker build -t weknora-docreader-test -f docker/Dockerfile.docreader .`
4. 观察构建日志，确认能够在 Step 8 中看到 `RUN ls -lah /app/packages/` 正常输出了 protoc 包详情。

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
Fixes #1030

## 截图/录屏 (Screenshots/Recordings)
无

## 数据库迁移 (Database Migration)
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
无。

## 部署说明 (Deployment Notes)
无特殊部署要求。离线用户只需要按照对应文档进行操作即可。

## 其他信息 (Additional Information)
无。