### PR TITLE
fix(secrets): prevent masked placeholders from overwriting real crede…

### DIFF
--- a/internal/application/service/mcp_service.go
+++ b/internal/application/service/mcp_service.go
@@ -69,6 +69,11 @@ func (s *mcpServiceService) GetMCPServiceByID(
 		return nil, fmt.Errorf("MCP service not found")
 	}
 
+	// Redact sensitive credentials before returning (mirrors ListMCPServices).
+	// Previously GetMCPServiceByID returned plaintext credentials while List
+	// redacted them, creating an inconsistency (see issue #988).
+	service.MaskSensitiveData()
+
 	return service, nil
 }
 
@@ -173,7 +178,17 @@ func (s *mcpServiceService) UpdateMCPService(ctx context.Context, service *types
 			existing.Headers = service.Headers
 		}
 		if service.AuthConfig != nil {
-			existing.AuthConfig = service.AuthConfig
+			// Preserve existing credentials when the incoming value is the redacted
+			// placeholder or empty — this prevents the UI from silently overwriting
+			// real secrets with masked display values (see issue #988).
+			if existing.AuthConfig == nil {
+				existing.AuthConfig = service.AuthConfig
+			} else {
+				existing.AuthConfig.APIKey = types.PreserveIfRedacted(service.AuthConfig.APIKey, existing.AuthConfig.APIKey)
+				existing.AuthConfig.Token = types.PreserveIfRedacted(service.AuthConfig.Token, existing.AuthConfig.Token)
+				// Copy non-secret fields unconditionally.
+				existing.AuthConfig.AuthType = service.AuthConfig.AuthType
+			}
 		}
 		if service.AdvancedConfig != nil {
 			existing.AdvancedConfig = service.AdvancedConfig

--- a/internal/types/mcp.go
+++ b/internal/types/mcp.go
@@ -206,14 +206,16 @@ func GetDefaultAdvancedConfig() *MCPAdvancedConfig {
 	}
 }
 
-// MaskSensitiveData masks sensitive information in the MCP service for display
+// MaskSensitiveData redacts sensitive credentials in the MCP service for API
+// responses. The fixed RedactedSecretPlaceholder ("***") is used so that
+// callers can reliably detect it with IsRedactedOrEmpty / PreserveIfRedacted.
 func (m *MCPService) MaskSensitiveData() {
 	if m.AuthConfig != nil {
 		if m.AuthConfig.APIKey != "" {
-			m.AuthConfig.APIKey = maskString(m.AuthConfig.APIKey)
+			m.AuthConfig.APIKey = RedactedSecretPlaceholder
 		}
 		if m.AuthConfig.Token != "" {
-			m.AuthConfig.Token = maskString(m.AuthConfig.Token)
+			m.AuthConfig.Token = RedactedSecretPlaceholder
 		}
 	}
 }
@@ -233,7 +235,10 @@ func (m *MCPService) HideSensitiveInfo() *MCPService {
 	return &copy
 }
 
-// maskString masks a string, showing only first 4 and last 4 characters
+// maskString is retained for any callers not yet migrated to RedactedSecretPlaceholder.
+// Prefer RedactedSecretPlaceholder for new code — it leaks zero entropy.
+//
+// Deprecated: use RedactedSecretPlaceholder instead.
 func maskString(s string) string {
 	if len(s) <= 8 {
 		return "****"

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -1,0 +1,29 @@
+package types
+
+// RedactedSecretPlaceholder is the fixed placeholder returned in API responses
+// whenever a sensitive field (API key, token, password, etc.) is set.
+// This constant value is intentionally short and unambiguous so that callers
+// can reliably detect it with IsRedactedOrEmpty.
+const RedactedSecretPlaceholder = "***"
+
+// IsRedactedOrEmpty reports whether s is either the empty string or the
+// canonical redacted placeholder. Use this to decide whether an incoming
+// update request field should be treated as "no change".
+func IsRedactedOrEmpty(s string) bool {
+	return s == "" || s == RedactedSecretPlaceholder
+}
+
+// PreserveIfRedacted returns existing when incoming is empty or the redacted
+// placeholder, otherwise it returns incoming. This implements the "preserve by
+// default, replace on explicit input" pattern for secret fields in Update
+// handlers.
+//
+// Usage in a service Update method:
+//
+//	existing.AuthConfig.APIKey = PreserveIfRedacted(req.AuthConfig.APIKey, existing.AuthConfig.APIKey)
+func PreserveIfRedacted(incoming, existing string) string {
+	if IsRedactedOrEmpty(incoming) {
+		return existing
+	}
+	return incoming
+}

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -1,0 +1,45 @@
+package types
+
+import "testing"
+
+func TestIsRedactedOrEmpty(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"", true},
+		{RedactedSecretPlaceholder, true},
+		{"real-secret-value", false},
+		{"abc****xyz", false}, // old leaky maskString format — not treated as placeholder
+		{" ", false},
+	}
+	for _, c := range cases {
+		got := IsRedactedOrEmpty(c.input)
+		if got != c.want {
+			t.Errorf("IsRedactedOrEmpty(%q) = %v, want %v", c.input, got, c.want)
+		}
+	}
+}
+
+func TestPreserveIfRedacted(t *testing.T) {
+	const existing = "original-secret"
+	cases := []struct {
+		incoming string
+		want     string
+	}{
+		// empty → preserve
+		{"", existing},
+		// placeholder → preserve
+		{RedactedSecretPlaceholder, existing},
+		// real value → replace
+		{"new-secret", "new-secret"},
+		// whitespace is treated as a real (if odd) value → replace
+		{" ", " "},
+	}
+	for _, c := range cases {
+		got := PreserveIfRedacted(c.incoming, existing)
+		if got != c.want {
+			t.Errorf("PreserveIfRedacted(%q, %q) = %q, want %q", c.incoming, existing, got, c.want)
+		}
+	}
+}

--- a/internal/types/vectorstore.go
+++ b/internal/types/vectorstore.go
@@ -184,14 +184,16 @@ func (c ConnectionConfig) GetEndpoint() string {
 	return ""
 }
 
-// MaskSensitiveFields returns a copy with Password and APIKey masked.
+// MaskSensitiveFields returns a copy with Password and APIKey replaced by the
+// canonical RedactedSecretPlaceholder so that callers can detect them with
+// IsRedactedOrEmpty / PreserveIfRedacted.
 func (c ConnectionConfig) MaskSensitiveFields() ConnectionConfig {
 	masked := c
 	if masked.Password != "" {
-		masked.Password = "***"
+		masked.Password = RedactedSecretPlaceholder
 	}
 	if masked.APIKey != "" {
-		masked.APIKey = "***"
+		masked.APIKey = RedactedSecretPlaceholder
 	}
 	return masked
 }


### PR DESCRIPTION
## 描述 (Description)

Closes #988

When editing any resource that holds credentials (MCP service, Model,
WebSearchProvider, DataSource) the UI pre-fills form fields with the masked
display value (e.g. `abc****xyz`). On save, that placeholder was sent back
verbatim and the Update handler wrote it to the database, silently destroying
the real credential.

Additionally, `GetMCPServiceByID` returned plaintext secrets while
`ListMCPServices` redacted them, leaking credentials via the single-item GET
endpoint.

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)
- [x] 🧪 测试相关 (Test related)
- [x] 🎨 代码重构 (Code refactoring)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)
- [x] MCP 服务器 (MCP Server)

## Changes

### `internal/types/secret.go` (new)
Introduces shared primitives used by all resource Update paths:
- `RedactedSecretPlaceholder = "***"` (fixed, leaks zero entropy)
- `IsRedactedOrEmpty(s)` — true for `""` and the placeholder
- `PreserveIfRedacted(incoming, existing)` — preserve when redacted/empty, replace otherwise

### `internal/types/secret_test.go` (new)
Unit tests for `IsRedactedOrEmpty` and `PreserveIfRedacted` covering empty,
placeholder, real value, and whitespace inputs.

### `internal/types/mcp.go`
- `MaskSensitiveData()` now uses `RedactedSecretPlaceholder` instead of the
  leaky `maskString` format (`first4****last4` exposed 8 chars of entropy)
- `maskString()` marked Deprecated with a note to prefer the constant

### `internal/types/vectorstore.go`
- `MaskSensitiveFields()` now uses `RedactedSecretPlaceholder` for consistency
  with the new shared constant (was already using `"***"` inline)

### `internal/application/service/mcp_service.go`
- `UpdateMCPService`: field-level merge for `AuthConfig.APIKey` and
  `AuthConfig.Token` using `PreserveIfRedacted`; non-secret `AuthType` is
  still copied unconditionally
- `GetMCPServiceByID`: call `MaskSensitiveData()` before returning, fixing
  the inconsistency with `ListMCPServices`

## Scope

This PR covers the MCP service fully. The same `PreserveIfRedacted` pattern
should be applied to `Model`, `WebSearchProvider`, and `DataSource` in
follow-up PRs — the helper is now available in `internal/types`.

## 测试 (Testing)
- [x] 单元测试 (Unit tests)
- [x] 手动测试 (Manual testing)
- [x] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. Create an MCP service with a real bearer token via API
2. Open the edit dialog in the UI, toggle `enabled` off then on (do not touch the token field), click Save
3. Verify the database still contains the original token (not `***`)
4. Run `go test ./internal/types/...` — all tests pass
5. Call `GET /mcp/:id` — verify response contains `***` instead of plaintext secret

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常

## 相关 Issue
Closes #988

## 数据库迁移 (Database Migration)
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
无

## 部署说明 (Deployment Notes)
无特殊部署要求，向后兼容。