### PR TITLE
feat: correct data analysis errors using fileService.

### DIFF
--- a/internal/agent/tools/data_analysis.go
+++ b/internal/agent/tools/data_analysis.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
 	"io"
 	"os"
 	"strings"
@@ -40,25 +41,31 @@ type DataAnalysisInput struct {
 
 type DataAnalysisTool struct {
 	BaseTool
-	knowledgeService interfaces.KnowledgeService
-	fileService      interfaces.FileService
-	db               *sql.DB
-	sessionID        string
-	createdTables    []string // Track tables created in this session
+	knowledgeBaseService interfaces.KnowledgeBaseService
+	knowledgeService     interfaces.KnowledgeService
+	fileService          interfaces.FileService
+	tenantService        interfaces.TenantService
+	db                   *sql.DB
+	sessionID            string
+	createdTables        []string // Track tables created in this session
 }
 
 func NewDataAnalysisTool(
+	knowledgeBaseService interfaces.KnowledgeBaseService,
 	knowledgeService interfaces.KnowledgeService,
+	tenantService interfaces.TenantService,
 	fileService interfaces.FileService,
 	db *sql.DB,
 	sessionID string,
 ) *DataAnalysisTool {
 	return &DataAnalysisTool{
-		BaseTool:         dataAnalysisTool,
-		knowledgeService: knowledgeService,
-		fileService:      fileService,
-		db:               db,
-		sessionID:        sessionID,
+		BaseTool:             dataAnalysisTool,
+		knowledgeBaseService: knowledgeBaseService,
+		knowledgeService:     knowledgeService,
+		fileService:          fileService,
+		tenantService:        tenantService,
+		db:                   db,
+		sessionID:            sessionID,
 	}
 }
 
@@ -497,7 +504,7 @@ func (t *DataAnalysisTool) LoadFromKnowledge(ctx context.Context, knowledge *typ
 func (t *DataAnalysisTool) materializeKnowledgeFile(ctx context.Context, knowledge *types.Knowledge) (string, func(), error) {
 	noop := func() {}
 
-	reader, err := t.fileService.GetFile(ctx, knowledge.FilePath)
+	reader, err := t.resolveFileServiceForKnowledge(ctx, knowledge).GetFile(ctx, knowledge.FilePath)
 	if err != nil {
 		return "", noop, fmt.Errorf("failed to open file for knowledge '%s': %w", knowledge.ID, err)
 	}
@@ -652,4 +659,80 @@ func (t *TableSchema) Description() string {
 	}
 
 	return builder.String()
+}
+
+// resolveFileServiceForKnowledge resolves a provider-specific FileService based on the knowledge file path.
+// It falls back to the injected default service when provider/config cannot be resolved.
+func (t *DataAnalysisTool) resolveFileServiceForKnowledge(ctx context.Context, knowledge *types.Knowledge) interfaces.FileService {
+	if knowledge == nil {
+		logger.Warnf(ctx, "[Tool][DataAnalysis][storage] fallback default: session_id=%s reason=knowledge_nil", t.sessionID)
+		return t.fileService
+	}
+
+	kbID := strings.TrimSpace(knowledge.KnowledgeBaseID)
+	var kb *types.KnowledgeBase
+	if t.knowledgeBaseService != nil && kbID != "" {
+		var err error
+		kb, err = t.knowledgeBaseService.GetKnowledgeBaseByID(ctx, kbID)
+		if err != nil {
+			logger.Warnf(ctx, "[Tool][DataAnalysis][storage] get kb failed, fallback default: session_id=%s knowledge_id=%s kb_id=%s err=%v",
+				t.sessionID, knowledge.ID, kbID, err)
+			return t.fileService
+		}
+	}
+	if kb == nil && kbID != "" {
+		logger.Infof(ctx, "[Tool][DataAnalysis][storage] kb not found, fallback default: session_id=%s knowledge_id=%s kb_id=%s",
+			t.sessionID, knowledge.ID, kbID)
+		return t.fileService
+	}
+
+	provider := ""
+	if kb != nil {
+		provider = kb.GetStorageProvider()
+	}
+	tenant, _ := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
+	if tenant == nil {
+		tenantID := uint64(0)
+		if tid, ok := ctx.Value(types.TenantIDContextKey).(uint64); ok {
+			tenantID = tid
+		}
+		if tenantID == 0 && kb != nil {
+			tenantID = knowledge.TenantID
+		}
+		if tenantID > 0 && t.tenantService != nil {
+			resolvedTenant, err := t.tenantService.GetTenantByID(ctx, tenantID)
+			if err != nil {
+				logger.Warnf(ctx, "[Tool][DataAnalysis][storage] get tenant failed: session_id=%s knowledge_id=%s kb_id=%s tenant_id=%d err=%v",
+					t.sessionID, knowledge.ID, kbID, tenantID, err)
+			} else if resolvedTenant != nil {
+				tenant = resolvedTenant
+				logger.Infof(ctx, "[Tool][DataAnalysis][storage] resolved tenant from service: session_id=%s knowledge_id=%s kb_id=%s tenant_id=%d",
+					t.sessionID, knowledge.ID, kbID, tenantID)
+			}
+		}
+	}
+	if provider == "" && tenant != nil && tenant.StorageEngineConfig != nil {
+		provider = strings.ToLower(strings.TrimSpace(tenant.StorageEngineConfig.DefaultProvider))
+	}
+
+	if provider == "" || tenant == nil || tenant.StorageEngineConfig == nil {
+		hasTenantStorageConfig := tenant != nil && tenant.StorageEngineConfig != nil
+		logger.Infof(ctx, "[Tool][DataAnalysis][storage] fallback default: session_id=%s knowledge_id=%s kb_id=%s provider=%q tenant_cfg=%t",
+			t.sessionID, knowledge.ID, kbID, provider, hasTenantStorageConfig)
+		return t.fileService
+	}
+
+	storageConfig := tenant.StorageEngineConfig
+	baseDir := strings.TrimSpace(os.Getenv("LOCAL_STORAGE_BASE_DIR"))
+
+	resolvedSvc, resolvedProvider, err := filesvc.NewFileServiceFromStorageConfig(provider, storageConfig, baseDir)
+	if err != nil {
+		logger.Warnf(ctx, "[Tool][DataAnalysis][storage] create file service failed, fallback default: session_id=%s knowledge_id=%s kb_id=%s provider=%s err=%v",
+			t.sessionID, knowledge.ID, kbID, provider, err)
+		return t.fileService
+	}
+
+	logger.Infof(ctx, "[Tool][DataAnalysis][storage] resolved file service: session_id=%s knowledge_id=%s kb_id=%s provider=%s",
+		t.sessionID, knowledge.ID, kbID, resolvedProvider)
+	return resolvedSvc
 }

--- a/internal/application/service/agent_service.go
+++ b/internal/application/service/agent_service.go
@@ -58,6 +58,7 @@ type agentService struct {
 	duckdb                *sql.DB
 	webSearchStateService interfaces.WebSearchStateService
 	wikiPageService       interfaces.WikiPageService
+	tenantService         interfaces.TenantService
 }
 
 // NewAgentService creates a new agent service
@@ -76,6 +77,7 @@ func NewAgentService(
 	duckdb *sql.DB,
 	webSearchStateService interfaces.WebSearchStateService,
 	wikiPageService interfaces.WikiPageService,
+	tenantService interfaces.TenantService,
 ) interfaces.AgentService {
 	return &agentService{
 		cfg:                   cfg,
@@ -92,6 +94,7 @@ func NewAgentService(
 		duckdb:                duckdb,
 		webSearchStateService: webSearchStateService,
 		wikiPageService:       wikiPageService,
+		tenantService:         tenantService,
 	}
 }
 
@@ -544,7 +547,7 @@ func (s *agentService) registerTools(
 			logger.Infof(ctx, "Registered web_fetch tool for session: %s", sessionID)
 
 		case tools.ToolDataAnalysis:
-			toolToRegister = tools.NewDataAnalysisTool(s.knowledgeService, s.fileService, s.duckdb, sessionID)
+			toolToRegister = tools.NewDataAnalysisTool(s.knowledgeBaseService, s.knowledgeService, s.tenantService, s.fileService, s.duckdb, sessionID)
 			logger.Infof(ctx, "Registered data_analysis tool for session: %s", sessionID)
 
 		case tools.ToolDataSchema:

--- a/internal/application/service/chat_pipeline/data_analysis.go
+++ b/internal/application/service/chat_pipeline/data_analysis.go
@@ -17,27 +17,33 @@ import (
 )
 
 type PluginDataAnalysis struct {
-	modelService     interfaces.ModelService
-	knowledgeService interfaces.KnowledgeService
-	fileService      interfaces.FileService
-	chunkRepo        interfaces.ChunkRepository
-	db               *sql.DB
+	modelService         interfaces.ModelService
+	knowledgeBaseService interfaces.KnowledgeBaseService
+	knowledgeService     interfaces.KnowledgeService
+	fileService          interfaces.FileService
+	chunkRepo            interfaces.ChunkRepository
+	tenantService        interfaces.TenantService
+	db                   *sql.DB
 }
 
 func NewPluginDataAnalysis(
 	eventManager *EventManager,
 	modelService interfaces.ModelService,
+	knowledgeBaseService interfaces.KnowledgeBaseService,
 	knowledgeService interfaces.KnowledgeService,
 	fileService interfaces.FileService,
 	chunkRepo interfaces.ChunkRepository,
+	tenantService interfaces.TenantService,
 	db *sql.DB,
 ) *PluginDataAnalysis {
 	p := &PluginDataAnalysis{
-		modelService:     modelService,
-		knowledgeService: knowledgeService,
-		fileService:      fileService,
-		chunkRepo:        chunkRepo,
-		db:               db,
+		modelService:         modelService,
+		knowledgeBaseService: knowledgeBaseService,
+		knowledgeService:     knowledgeService,
+		fileService:          fileService,
+		chunkRepo:            chunkRepo,
+		tenantService:        tenantService,
+		db:                   db,
 	}
 	eventManager.Register(p)
 	return p
@@ -83,7 +89,7 @@ func (p *PluginDataAnalysis) OnEvent(
 	}
 
 	// Initialize DataAnalysisTool
-	tool := tools.NewDataAnalysisTool(p.knowledgeService, p.fileService, p.db, chatManage.SessionID)
+	tool := tools.NewDataAnalysisTool(p.knowledgeBaseService, p.knowledgeService, p.tenantService, p.fileService, p.db, chatManage.SessionID)
 	defer tool.Cleanup(ctx)
 
 	// Load data into DuckDB
@@ -136,11 +142,11 @@ Return your response in the specified JSON format.`, chatManage.Query, knowledge
 	// 5. Store result
 	// Create a new SearchResult for the analysis output
 	analysisResult := &types.SearchResult{
-		ID:                "analysis_" + knowledge.ID,
-		Content:           toolResult.Output,
-		Score:             1.0,
-		MatchType:         types.MatchTypeDataAnalysis,
-		KnowledgeID:       knowledge.ID,
+		ID:                   "analysis_" + knowledge.ID,
+		Content:              toolResult.Output,
+		Score:                1.0,
+		MatchType:            types.MatchTypeDataAnalysis,
+		KnowledgeID:          knowledge.ID,
 		KnowledgeTitle:       knowledge.Title,
 		KnowledgeFilename:    knowledge.FileName,
 		KnowledgeDescription: knowledge.Description,

--- a/internal/application/service/extract.go
+++ b/internal/application/service/extract.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/Tencent/WeKnora/internal/agent/tools"
-	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
 	chatpipeline "github.com/Tencent/WeKnora/internal/application/service/chat_pipeline"
+	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
 	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -252,18 +252,20 @@ type DataTableSummaryPayload struct {
 
 // DataTableSummaryService is a service for extracting tables
 type DataTableSummaryService struct {
-	modelService     interfaces.ModelService
-	knowledgeService interfaces.KnowledgeService
-	fileService      interfaces.FileService
-	chunkService     interfaces.ChunkService
-	tenantService    interfaces.TenantService
-	retrieveEngine   interfaces.RetrieveEngineRegistry
-	sqlDB            *sql.DB
+	modelService         interfaces.ModelService
+	knowledgeBaseService interfaces.KnowledgeBaseService
+	knowledgeService     interfaces.KnowledgeService
+	fileService          interfaces.FileService
+	chunkService         interfaces.ChunkService
+	tenantService        interfaces.TenantService
+	retrieveEngine       interfaces.RetrieveEngineRegistry
+	sqlDB                *sql.DB
 }
 
 // NewDataTableSummaryService creates a new DataTableSummaryService
 func NewDataTableSummaryService(
 	modelService interfaces.ModelService,
+	knowledgeBaseService interfaces.KnowledgeBaseService,
 	knowledgeService interfaces.KnowledgeService,
 	fileService interfaces.FileService,
 	chunkService interfaces.ChunkService,
@@ -272,13 +274,14 @@ func NewDataTableSummaryService(
 	sqlDB *sql.DB,
 ) interfaces.TaskHandler {
 	return &DataTableSummaryService{
-		modelService:     modelService,
-		knowledgeService: knowledgeService,
-		fileService:      fileService,
-		chunkService:     chunkService,
-		tenantService:    tenantService,
-		retrieveEngine:   retrieveEngine,
-		sqlDB:            sqlDB,
+		modelService:         modelService,
+		knowledgeBaseService: knowledgeBaseService,
+		knowledgeService:     knowledgeService,
+		fileService:          fileService,
+		chunkService:         chunkService,
+		tenantService:        tenantService,
+		retrieveEngine:       retrieveEngine,
+		sqlDB:                sqlDB,
 	}
 }
 
@@ -421,7 +424,7 @@ func (s *DataTableSummaryService) processTableData(ctx context.Context, resource
 	// 创建DuckDB会话并加载数据
 	sessionID := fmt.Sprintf("table_summary_%s", resources.knowledge.ID)
 	fileSvc := s.resolveFileServiceForKnowledge(ctx, resources)
-	duckdbTool := tools.NewDataAnalysisTool(s.knowledgeService, fileSvc, s.sqlDB, sessionID)
+	duckdbTool := tools.NewDataAnalysisTool(s.knowledgeBaseService, s.knowledgeService, s.tenantService, fileSvc, s.sqlDB, sessionID)
 	defer duckdbTool.Cleanup(ctx)
 
 	// 使用knowledge.ID作为表名，根据文件类型自动加载数据


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
本 PR 主要修复 `data_analysis` 在多存储场景下读取知识库文件时的错误行为，避免始终使用默认 `fileService` 导致的数据加载失败。  
核心改动是为 `DataAnalysisTool` 增加对 `KnowledgeBaseService` 与 `TenantService` 的依赖注入，并基于知识库/租户存储配置动态解析对应的 `FileService`，在解析失败时安全回退到默认实现并输出清晰日志。  
同时同步更新了 `agent_service`、`chat_pipeline/data_analysis`、`extract` 等调用链构造参数，确保数据分析与表格摘要流程在不同存储 provider 下行为一致。

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [ ] 📚 文档更新 (Documentation update)
- [x] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [ ] 🧪 测试相关 (Test related)
- [ ] 🔧 配置变更 (Configuration change)
- [ ] 🐳 Docker 相关 (Docker related)
- [ ] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)
- [ ] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [x] 配置文件 (Configuration)
- [x] 其他 (Other): `internal/agent/tools` 与 `application/service` 数据分析调用链

## 测试 (Testing)
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [x] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 准备至少两种存储 provider（如本地 + 对象存储）对应的知识库与租户配置，导入可用于 `data_analysis` 的表格/结构化数据文件。  
2. 触发 `data_analysis` 与 `table_summary` 相关流程，确认 DuckDB 能正常加载知识文件并返回分析结果。  
3. 在日志中确认 provider 解析、回退逻辑与错误信息符合预期（包括 provider 缺失、tenant 缺失、构建 file service 失败等场景）。

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
[Fixes #](https://github.com/Tencent/WeKnora/issues/1040)

## 截图/录屏 (Screenshots/Recordings)
local修改符合预期：
<img width="1763" height="1021" alt="image" src="https://github.com/user-attachments/assets/eaa305ec-49c3-459f-b3e5-990b3027496e" />

## 数据库迁移 (Database Migration)
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
本 PR 不新增配置项，但会读取并依赖已有租户存储配置与 `LOCAL_STORAGE_BASE_DIR` 来构建 provider-specific `FileService`。请确保部署环境中相关配置已正确设置。

## 部署说明 (Deployment Notes)
后端服务常规发布即可，无需数据库迁移。建议发布后重点观察 `data_analysis` 相关日志，确认在多租户/多 provider 场景下文件解析稳定。

## 其他信息 (Additional Information)
对应提交：`5e5b52486fa47219111be7b34e2e96ca2beebc86`