### PR TITLE
feat(miniprogram): add WeChat mini program plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ packages/protoc-3.19.4-linux-x86_64.zip
 # 本地测试脚本
 configure-ollama.sh
 fix-docker.sh
+
+# WeChat Mini Program local/private configuration
+miniprogram/project.private.config.json

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Fully modular pipeline from document parsing, vectorization, and retrieval to LL
 | Capability | Details |
 |------------|---------|
 | Deployment | Local / Docker / Kubernetes (Helm) with private and offline support |
-| UI | Web UI / RESTful API / Chrome Extension |
+| UI | Web UI / RESTful API / Chrome Extension / WeChat Mini Program |
 | Observability | Integrated Langfuse for ReAct loops, token tracking, tool calls, and pipeline tracing |
 | Task Management | MQ async tasks, automatic database migration on version upgrade |
 | Model Management | Centralized config, per-knowledge-base model selection, multi-tenant built-in model sharing, WeKnora Cloud hosted models and parsing |
@@ -247,6 +247,11 @@ Fully modular pipeline from document parsing, vectorization, and retrieval to LL
 [**WeKnora Chrome Extension**](https://chromewebstore.google.com/detail/jpemjbopikggjlmikmclgbmkhhopjdgd) lets you capture web content directly into your WeKnora knowledge base. Select text, images, or entire pages in the browser and save them as knowledge entries with one click — no copy-paste or file upload needed.
 
 
+## 📱 WeChat Mini Program
+
+The [WeKnora Mini Program](./miniprogram/README.md) provides a lightweight mobile client for configuring WeKnora API access, selecting knowledge bases, importing URLs, and asking knowledge chat from WeChat.
+
+
 ## 🦞 ClawHub Skill
 
 [**WeKnora ClawHub Skill**](https://clawhub.ai/lyingbug/weknora) is a WeKnora skill published on the ClawHub platform. Once installed, it enables document import (file / URL / Markdown), hybrid search (vector + keyword) across knowledge bases, and knowledge entry management — all through the WeKnora REST API.
@@ -254,7 +259,6 @@ Fully modular pipeline from document parsing, vectorization, and retrieval to LL
 - **Document Import** — Upload files, import web pages, or write Markdown knowledge via the agent
 - **Hybrid Search** — Search within or across knowledge bases with vector + keyword retrieval
 - **Knowledge Management** — List, browse, edit, and delete knowledge entries programmatically
-
 
 ## 🚀 Getting Started
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -235,7 +235,7 @@
 | 能力 | 详情 |
 |------|------|
 | 部署 | 本地 / Docker / Kubernetes (Helm)，支持私有化离线部署 |
-| 界面 | Web UI / RESTful API / Chrome Extension|
+| 界面 | Web UI / RESTful API / Chrome Extension / 微信小程序 |
 | 可观测性 | 集成 Langfuse 以追踪 ReAct 循环、Token 消耗、工具调用和任务流水线 |
 | 任务管理 | MQ 异步任务，版本升级自动数据库迁移 |
 | 模型管理 | 集中配置，知识库级别模型选择，多租户共享内置模型，WeKnora Cloud 托管模型与文档解析 |
@@ -245,6 +245,11 @@
 [**WeKnora Chrome 插件**](https://chromewebstore.google.com/detail/jpemjbopikggjlmikmclgbmkhhopjdgd)支持在浏览器中直接将网页内容采集到 WeKnora 知识库。选中文本、图片或整个页面，一键保存为知识条目，无需复制粘贴或手动上传文件。
 
 
+## 📱 微信小程序
+
+[**WeKnora 微信小程序**](./miniprogram/README.md) 提供轻量移动端客户端，支持配置 WeKnora API、选择知识库、导入 URL，并在微信内向知识库提问。
+
+
 ## 🦞 ClawHub Skill
 
 [**WeKnora ClawHub Skill**](https://clawhub.ai/lyingbug/weknora) 是 WeKnora 发布在 ClawHub 平台上的技能。安装后，可通过 WeKnora REST API 上传文档（文件 / URL / Markdown）、执行混合检索（向量 + 关键词）以及管理知识条目。
@@ -252,7 +257,6 @@
 - **文档导入** — 通过 Agent 上传文件、导入网页或写入 Markdown 知识
 - **混合检索** — 在单个或多个知识库中进行向量 + 关键词混合搜索
 - **知识管理** — 以编程方式浏览、编辑和删除知识条目
-
 
 ## 🚀 快速开始
 
@@ -405,4 +409,3 @@ WeKnora/
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Tencent/WeKnora&type=date&legend=top-left" />
  </picture>
 </a>
-

--- a/miniprogram/README.md
+++ b/miniprogram/README.md
@@ -1,0 +1,31 @@
+# WeKnora Mini Program
+
+This directory contains a WeChat Mini Program plugin for WeKnora. It gives mobile users a lightweight entry point to:
+
+- configure a WeKnora API endpoint and tenant API key;
+- list available knowledge bases;
+- import a URL into a selected knowledge base;
+- ask a selected knowledge base through WeKnora knowledge chat.
+
+## Getting started
+
+1. Open `miniprogram/` in WeChat DevTools.
+2. Copy `project.private.config.json.example` to `project.private.config.json` and set your real Mini Program AppID. The shared `project.config.json` intentionally does not include an AppID to avoid forcing maintainers into a placeholder project.
+3. Open the **Settings** tab and fill in:
+   - API Base URL, for example `https://weknora.example.com`;
+   - API Key from the WeKnora tenant settings page.
+4. Open the **Knowledge** tab, refresh knowledge bases, and select the target knowledge base.
+5. Import a URL or switch to **Chat** to ask questions.
+
+## Local development notes
+
+- WeChat DevTools may block `localhost` requests when URL validation is enabled. For local testing, either disable domain validation in DevTools or expose WeKnora through a HTTPS development domain.
+- In production Mini Programs, add the WeKnora API domain to the Mini Program request domain allowlist.
+- The chat endpoint returns Server-Sent Events. The Mini Program client parses completed SSE text responses and displays accumulated `answer` chunks.
+
+## Test
+
+```bash
+cd miniprogram
+npm test
+```

--- a/miniprogram/app.js
+++ b/miniprogram/app.js
@@ -1,0 +1,12 @@
+App({
+  onLaunch() {
+    const settings = wx.getStorageSync("weknora_settings");
+    if (!settings) {
+      wx.setStorageSync("weknora_settings", {
+        baseUrl: "http://localhost:8080",
+        apiKey: "",
+        selectedKnowledgeBaseId: ""
+      });
+    }
+  }
+});

--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -6,13 +6,13 @@
   ],
   "window": {
     "navigationBarTitleText": "WeKnora",
-    "navigationBarBackgroundColor": "#102a43",
+    "navigationBarBackgroundColor": "#0d3b2a",
     "navigationBarTextStyle": "white",
-    "backgroundColor": "#f4f7fb"
+    "backgroundColor": "#f3f3f3"
   },
   "tabBar": {
-    "color": "#667085",
-    "selectedColor": "#1264a3",
+    "color": "#8b8b8b",
+    "selectedColor": "#07c05f",
     "backgroundColor": "#ffffff",
     "borderStyle": "white",
     "list": [

--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -1,0 +1,33 @@
+{
+  "pages": [
+    "pages/index/index",
+    "pages/chat/chat",
+    "pages/settings/settings"
+  ],
+  "window": {
+    "navigationBarTitleText": "WeKnora",
+    "navigationBarBackgroundColor": "#102a43",
+    "navigationBarTextStyle": "white",
+    "backgroundColor": "#f4f7fb"
+  },
+  "tabBar": {
+    "color": "#667085",
+    "selectedColor": "#1264a3",
+    "backgroundColor": "#ffffff",
+    "borderStyle": "white",
+    "list": [
+      {
+        "pagePath": "pages/index/index",
+        "text": "Knowledge"
+      },
+      {
+        "pagePath": "pages/chat/chat",
+        "text": "Chat"
+      },
+      {
+        "pagePath": "pages/settings/settings",
+        "text": "Settings"
+      }
+    ]
+  }
+}

--- a/miniprogram/app.wxss
+++ b/miniprogram/app.wxss
@@ -1,0 +1,71 @@
+page {
+  min-height: 100%;
+  background: #f4f7fb;
+  color: #102a43;
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", sans-serif;
+}
+
+.page {
+  min-height: 100vh;
+  box-sizing: border-box;
+  padding: 32rpx;
+}
+
+.card {
+  padding: 28rpx;
+  border-radius: 24rpx;
+  background: #ffffff;
+  box-shadow: 0 12rpx 36rpx rgba(16, 42, 67, 0.08);
+}
+
+.title {
+  font-size: 40rpx;
+  font-weight: 700;
+  margin-bottom: 12rpx;
+}
+
+.muted {
+  color: #667085;
+  font-size: 26rpx;
+}
+
+.field {
+  margin-top: 24rpx;
+}
+
+.label {
+  display: block;
+  margin-bottom: 12rpx;
+  color: #344054;
+  font-size: 26rpx;
+  font-weight: 600;
+}
+
+input,
+textarea,
+picker {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 88rpx;
+  padding: 20rpx 24rpx;
+  border: 1rpx solid #d0d5dd;
+  border-radius: 18rpx;
+  background: #ffffff;
+  font-size: 28rpx;
+}
+
+textarea {
+  min-height: 180rpx;
+}
+
+button {
+  margin-top: 24rpx;
+  border-radius: 18rpx;
+  background: #1264a3;
+  color: #ffffff;
+  font-weight: 700;
+}
+
+button[disabled] {
+  background: #98a2b3;
+}

--- a/miniprogram/app.wxss
+++ b/miniprogram/app.wxss
@@ -1,13 +1,14 @@
 page {
   min-height: 100%;
-  background: #f4f7fb;
-  color: #102a43;
+  background: #f3f3f3;
+  color: #1a1a1a;
   font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", sans-serif;
 }
 
 .page {
   min-height: 100vh;
   box-sizing: border-box;
+  background: linear-gradient(180deg, #f8faf9 0%, #f3f3f3 100%);
   padding: 32rpx;
 }
 
@@ -15,7 +16,8 @@ page {
   padding: 28rpx;
   border-radius: 24rpx;
   background: #ffffff;
-  box-shadow: 0 12rpx 36rpx rgba(16, 42, 67, 0.08);
+  border: 1rpx solid #e7ebf0;
+  box-shadow: 0 12rpx 36rpx rgba(7, 192, 95, 0.08);
 }
 
 .title {
@@ -25,7 +27,7 @@ page {
 }
 
 .muted {
-  color: #667085;
+  color: rgba(0, 0, 0, 0.6);
   font-size: 26rpx;
 }
 
@@ -36,7 +38,7 @@ page {
 .label {
   display: block;
   margin-bottom: 12rpx;
-  color: #344054;
+  color: rgba(0, 0, 0, 0.9);
   font-size: 26rpx;
   font-weight: 600;
 }
@@ -48,9 +50,10 @@ picker {
   width: 100%;
   min-height: 88rpx;
   padding: 20rpx 24rpx;
-  border: 1rpx solid #d0d5dd;
+  border: 1rpx solid #dcdcdc;
   border-radius: 18rpx;
   background: #ffffff;
+  color: #1a1a1a;
   font-size: 28rpx;
 }
 
@@ -61,11 +64,11 @@ textarea {
 button {
   margin-top: 24rpx;
   border-radius: 18rpx;
-  background: #1264a3;
+  background: #07c05f;
   color: #ffffff;
   font-weight: 700;
 }
 
 button[disabled] {
-  background: #98a2b3;
+  background: #c5c5c5;
 }

--- a/miniprogram/package.json
+++ b/miniprogram/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "weknora-miniprogram",
+  "version": "0.1.0",
+  "private": true,
+  "description": "WeChat Mini Program plugin for WeKnora",
+  "scripts": {
+    "test": "node --test ../tests/miniprogram/*.test.js"
+  }
+}

--- a/miniprogram/pages/chat/chat.js
+++ b/miniprogram/pages/chat/chat.js
@@ -34,7 +34,8 @@ Page({
     this.setData({ answer: "", rawResponse: "", loading: true });
     try {
       const sessionId = await this.ensureSession();
-      const response = await knowledgeChat(sessionId, this.data.query.trim());
+      const settings = getSettings();
+      const response = await knowledgeChat(sessionId, this.data.query.trim(), settings.selectedKnowledgeBaseId);
       const rawResponse = typeof response === "string" ? response : JSON.stringify(response);
       const answer = collectAnswerFromSSE(rawResponse);
       this.setData({

--- a/miniprogram/pages/chat/chat.js
+++ b/miniprogram/pages/chat/chat.js
@@ -1,0 +1,54 @@
+const { getSettings } = require("../../utils/config");
+const { createSession, knowledgeChat } = require("../../utils/request");
+const { collectAnswerFromSSE } = require("../../utils/sse");
+
+Page({
+  data: {
+    answer: "",
+    loading: false,
+    query: "",
+    rawResponse: "",
+    sessionId: ""
+  },
+
+  onQueryInput(event) {
+    this.setData({ query: event.detail.value });
+  },
+
+  async ensureSession() {
+    if (this.data.sessionId) {
+      return this.data.sessionId;
+    }
+
+    const settings = getSettings();
+    const response = await createSession(settings.selectedKnowledgeBaseId);
+    const sessionId = response.data?.id;
+    if (!sessionId) {
+      throw new Error("The session API did not return a session id.");
+    }
+    this.setData({ sessionId });
+    return sessionId;
+  },
+
+  async ask() {
+    this.setData({ answer: "", rawResponse: "", loading: true });
+    try {
+      const sessionId = await this.ensureSession();
+      const response = await knowledgeChat(sessionId, this.data.query.trim());
+      const rawResponse = typeof response === "string" ? response : JSON.stringify(response);
+      const answer = collectAnswerFromSSE(rawResponse);
+      this.setData({
+        answer,
+        rawResponse: answer ? "" : rawResponse
+      });
+    } catch (error) {
+      wx.showModal({
+        title: "Chat failed",
+        content: error.message,
+        showCancel: false
+      });
+    } finally {
+      this.setData({ loading: false });
+    }
+  }
+});

--- a/miniprogram/pages/chat/chat.json
+++ b/miniprogram/pages/chat/chat.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "Chat"
+}

--- a/miniprogram/pages/chat/chat.wxml
+++ b/miniprogram/pages/chat/chat.wxml
@@ -1,0 +1,18 @@
+<view class="page">
+  <view class="card">
+    <view class="title">Knowledge Chat</view>
+    <view class="muted">Ask the selected WeKnora knowledge base.</view>
+
+    <view class="field">
+      <text class="label">Question</text>
+      <textarea value="{{query}}" placeholder="Ask something..." bindinput="onQueryInput" />
+    </view>
+
+    <button bindtap="ask" loading="{{loading}}" disabled="{{!query}}">Ask WeKnora</button>
+  </view>
+
+  <view class="card answer-card" wx:if="{{answer || rawResponse}}">
+    <view class="label">Answer</view>
+    <view class="answer">{{answer || rawResponse}}</view>
+  </view>
+</view>

--- a/miniprogram/pages/chat/chat.wxss
+++ b/miniprogram/pages/chat/chat.wxss
@@ -1,0 +1,10 @@
+.answer-card {
+  margin-top: 28rpx;
+}
+
+.answer {
+  white-space: pre-wrap;
+  line-height: 1.7;
+  color: #102a43;
+  font-size: 28rpx;
+}

--- a/miniprogram/pages/chat/chat.wxss
+++ b/miniprogram/pages/chat/chat.wxss
@@ -5,6 +5,6 @@
 .answer {
   white-space: pre-wrap;
   line-height: 1.7;
-  color: #102a43;
+  color: #1a1a1a;
   font-size: 28rpx;
 }

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -1,0 +1,87 @@
+const { saveSettings, getSettings } = require("../../utils/config");
+const { createKnowledgeFromURL, listKnowledgeBases } = require("../../utils/request");
+
+Page({
+  data: {
+    importing: false,
+    knowledgeBases: [],
+    loading: false,
+    selectedIndex: 0,
+    selectedKnowledgeBaseId: "",
+    selectedKnowledgeBaseName: "",
+    url: ""
+  },
+
+  onShow() {
+    const settings = getSettings();
+    if (settings.selectedKnowledgeBaseId) {
+      this.setData({ selectedKnowledgeBaseId: settings.selectedKnowledgeBaseId });
+    }
+    this.loadKnowledgeBases();
+  },
+
+  onUrlInput(event) {
+    this.setData({ url: event.detail.value });
+  },
+
+  onKnowledgeBaseChange(event) {
+    const selectedIndex = Number(event.detail.value);
+    const selected = this.data.knowledgeBases[selectedIndex];
+    if (!selected) return;
+
+    saveSettings({ selectedKnowledgeBaseId: selected.id });
+    this.setData({
+      selectedIndex,
+      selectedKnowledgeBaseId: selected.id,
+      selectedKnowledgeBaseName: selected.name
+    });
+  },
+
+  async loadKnowledgeBases() {
+    this.setData({ loading: true });
+    try {
+      const response = await listKnowledgeBases();
+      const knowledgeBases = response.data || [];
+      const settings = getSettings();
+      const selectedIndex = Math.max(
+        0,
+        knowledgeBases.findIndex((item) => item.id === settings.selectedKnowledgeBaseId)
+      );
+      const selected = knowledgeBases[selectedIndex];
+      this.setData({
+        knowledgeBases,
+        selectedIndex,
+        selectedKnowledgeBaseId: selected?.id || "",
+        selectedKnowledgeBaseName: selected?.name || ""
+      });
+      if (selected?.id) {
+        saveSettings({ selectedKnowledgeBaseId: selected.id });
+      }
+    } catch (error) {
+      wx.showModal({
+        title: "Load failed",
+        content: error.message,
+        showCancel: false
+      });
+    } finally {
+      this.setData({ loading: false });
+    }
+  },
+
+  async importURL() {
+    this.setData({ importing: true });
+    try {
+      await createKnowledgeFromURL(this.data.selectedKnowledgeBaseId, this.data.url.trim(), false);
+      this.setData({ url: "" });
+      wx.showToast({ title: "Imported", icon: "success" });
+    } catch (error) {
+      wx.showModal({
+        title: "Import failed",
+        content: error.message,
+        showCancel: false
+      });
+    } finally {
+      this.setData({ importing: false });
+    }
+  }
+});

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -1,21 +1,42 @@
 const { saveSettings, getSettings } = require("../../utils/config");
 const { createKnowledgeFromURL, listKnowledgeBases } = require("../../utils/request");
 
+function normalizeKnowledgeBases(response) {
+  if (Array.isArray(response?.data)) {
+    return response.data;
+  }
+  if (Array.isArray(response?.data?.list)) {
+    return response.data.list;
+  }
+  if (Array.isArray(response?.knowledge_bases)) {
+    return response.knowledge_bases;
+  }
+  return [];
+}
+
 Page({
   data: {
     importing: false,
     knowledgeBases: [],
+    knowledgeBaseNames: [],
     loading: false,
+    needsSettings: false,
     selectedIndex: 0,
     selectedKnowledgeBaseId: "",
     selectedKnowledgeBaseName: "",
+    statusMessage: "",
     url: ""
   },
 
   onShow() {
     const settings = getSettings();
+    const needsSettings = !settings.baseUrl || !settings.apiKey;
     if (settings.selectedKnowledgeBaseId) {
       this.setData({ selectedKnowledgeBaseId: settings.selectedKnowledgeBaseId });
+    }
+    this.setData({ needsSettings });
+    if (needsSettings) {
+      return;
     }
     this.loadKnowledgeBases();
   },
@@ -26,6 +47,14 @@ Page({
 
   onKnowledgeBaseChange(event) {
     const selectedIndex = Number(event.detail.value);
+    this.selectKnowledgeBase(selectedIndex);
+  },
+
+  onKnowledgeBaseTap(event) {
+    this.selectKnowledgeBase(Number(event.currentTarget.dataset.index));
+  },
+
+  selectKnowledgeBase(selectedIndex) {
     const selected = this.data.knowledgeBases[selectedIndex];
     if (!selected) return;
 
@@ -37,11 +66,22 @@ Page({
     });
   },
 
+  openSettings() {
+    wx.switchTab({ url: "/pages/settings/settings" });
+  },
+
   async loadKnowledgeBases() {
-    this.setData({ loading: true });
+    const settings = getSettings();
+    if (!settings.baseUrl || !settings.apiKey) {
+      this.setData({ needsSettings: true });
+      return;
+    }
+
+    this.setData({ loading: true, statusMessage: "" });
     try {
       const response = await listKnowledgeBases();
-      const knowledgeBases = response.data || [];
+      const knowledgeBases = normalizeKnowledgeBases(response);
+      const knowledgeBaseNames = knowledgeBases.map((item) => item.name || item.id);
       const settings = getSettings();
       const selectedIndex = Math.max(
         0,
@@ -50,9 +90,13 @@ Page({
       const selected = knowledgeBases[selectedIndex];
       this.setData({
         knowledgeBases,
+        knowledgeBaseNames,
         selectedIndex,
         selectedKnowledgeBaseId: selected?.id || "",
-        selectedKnowledgeBaseName: selected?.name || ""
+        selectedKnowledgeBaseName: selected?.name || "",
+        statusMessage: knowledgeBases.length
+          ? `Loaded ${knowledgeBases.length} knowledge bases.`
+          : "No knowledge bases found."
       });
       if (selected?.id) {
         saveSettings({ selectedKnowledgeBaseId: selected.id });

--- a/miniprogram/pages/index/index.json
+++ b/miniprogram/pages/index/index.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "Knowledge"
+}

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -5,11 +5,28 @@
   </view>
 
   <view class="card section">
+    <view wx:if="{{needsSettings}}" class="notice">
+      Configure the WeKnora API base URL and API key before loading knowledge bases.
+      <button bindtap="openSettings" class="secondary">Open Settings</button>
+    </view>
+
     <view class="field">
       <text class="label">Knowledge Base</text>
-      <picker range="{{knowledgeBases}}" range-key="name" value="{{selectedIndex}}" bindchange="onKnowledgeBaseChange">
+      <picker range="{{knowledgeBaseNames}}" value="{{selectedIndex}}" bindchange="onKnowledgeBaseChange">
         <view class="picker-value">{{selectedKnowledgeBaseName || "Tap to select"}}</view>
       </picker>
+      <view wx:if="{{statusMessage}}" class="status-message">{{statusMessage}}</view>
+      <view wx:if="{{knowledgeBaseNames.length}}" class="knowledge-list">
+        <view
+          wx:for="{{knowledgeBaseNames}}"
+          wx:key="*this"
+          data-index="{{index}}"
+          bindtap="onKnowledgeBaseTap"
+          class="knowledge-item {{index == selectedIndex ? 'active' : ''}}"
+        >
+          {{item}}
+        </view>
+      </view>
     </view>
 
     <button bindtap="loadKnowledgeBases" loading="{{loading}}">Refresh knowledge bases</button>

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -1,0 +1,26 @@
+<view class="page">
+  <view class="card hero">
+    <view class="title">WeKnora Knowledge</view>
+    <view class="muted">Import a web page into a selected knowledge base from WeChat.</view>
+  </view>
+
+  <view class="card section">
+    <view class="field">
+      <text class="label">Knowledge Base</text>
+      <picker range="{{knowledgeBases}}" range-key="name" value="{{selectedIndex}}" bindchange="onKnowledgeBaseChange">
+        <view class="picker-value">{{selectedKnowledgeBaseName || "Tap to select"}}</view>
+      </picker>
+    </view>
+
+    <button bindtap="loadKnowledgeBases" loading="{{loading}}">Refresh knowledge bases</button>
+  </view>
+
+  <view class="card section">
+    <view class="field">
+      <text class="label">URL</text>
+      <input value="{{url}}" placeholder="https://github.com/Tencent/WeKnora" bindinput="onUrlInput" />
+    </view>
+
+    <button bindtap="importURL" loading="{{importing}}" disabled="{{!selectedKnowledgeBaseId || !url}}">Import URL</button>
+  </view>
+</view>

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -1,5 +1,5 @@
 .hero {
-  background: linear-gradient(135deg, #102a43 0%, #1264a3 100%);
+  background: linear-gradient(135deg, #0d3b2a 0%, #05a04f 54%, #07c05f 100%);
   color: #ffffff;
 }
 
@@ -11,6 +11,52 @@
   margin-top: 28rpx;
 }
 
+.notice {
+  box-sizing: border-box;
+  padding: 24rpx;
+  border: 1rpx solid #d0f2de;
+  border-radius: 18rpx;
+  background: #e9f8ec;
+  color: #1f5a3f;
+  font-size: 26rpx;
+  line-height: 1.5;
+}
+
 .picker-value {
-  color: #102a43;
+  color: #1a1a1a;
+}
+
+.status-message {
+  margin-top: 12rpx;
+  color: #6b7280;
+  font-size: 24rpx;
+}
+
+.knowledge-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12rpx;
+  margin-top: 16rpx;
+}
+
+.knowledge-item {
+  padding: 18rpx 20rpx;
+  border: 1rpx solid #dcdcdc;
+  border-radius: 14rpx;
+  background: #ffffff;
+  color: #1a1a1a;
+  font-size: 26rpx;
+}
+
+.knowledge-item.active {
+  border-color: #07c05f;
+  background: #e9f8ec;
+  color: #05a04f;
+  font-weight: 600;
+}
+
+.secondary {
+  background: #ffffff;
+  color: #07c05f;
+  border: 1rpx solid #b8ebcc;
 }

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -1,0 +1,16 @@
+.hero {
+  background: linear-gradient(135deg, #102a43 0%, #1264a3 100%);
+  color: #ffffff;
+}
+
+.hero .muted {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.section {
+  margin-top: 28rpx;
+}
+
+.picker-value {
+  color: #102a43;
+}

--- a/miniprogram/pages/settings/settings.js
+++ b/miniprogram/pages/settings/settings.js
@@ -1,0 +1,32 @@
+const { getSettings, saveSettings } = require("../../utils/config");
+
+Page({
+  data: {
+    baseUrl: "",
+    apiKey: ""
+  },
+
+  onShow() {
+    const settings = getSettings();
+    this.setData({
+      baseUrl: settings.baseUrl,
+      apiKey: settings.apiKey
+    });
+  },
+
+  onBaseUrlInput(event) {
+    this.setData({ baseUrl: event.detail.value });
+  },
+
+  onApiKeyInput(event) {
+    this.setData({ apiKey: event.detail.value });
+  },
+
+  save() {
+    saveSettings({
+      baseUrl: this.data.baseUrl,
+      apiKey: this.data.apiKey
+    });
+    wx.showToast({ title: "Saved", icon: "success" });
+  }
+});

--- a/miniprogram/pages/settings/settings.json
+++ b/miniprogram/pages/settings/settings.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "Settings"
+}

--- a/miniprogram/pages/settings/settings.wxml
+++ b/miniprogram/pages/settings/settings.wxml
@@ -1,0 +1,18 @@
+<view class="page">
+  <view class="card">
+    <view class="title">Connect WeKnora</view>
+    <view class="muted">Use your WeKnora API endpoint and tenant API key.</view>
+
+    <view class="field">
+      <text class="label">API Base URL</text>
+      <input value="{{baseUrl}}" placeholder="https://your-weknora.example.com" bindinput="onBaseUrlInput" />
+    </view>
+
+    <view class="field">
+      <text class="label">API Key</text>
+      <input value="{{apiKey}}" password placeholder="sk-..." bindinput="onApiKeyInput" />
+    </view>
+
+    <button bindtap="save">Save settings</button>
+  </view>
+</view>

--- a/miniprogram/pages/settings/settings.wxss
+++ b/miniprogram/pages/settings/settings.wxss
@@ -1,0 +1,3 @@
+.card {
+  margin-top: 40rpx;
+}

--- a/miniprogram/project.config.json
+++ b/miniprogram/project.config.json
@@ -1,0 +1,14 @@
+{
+  "description": "WeKnora Mini Program plugin",
+  "setting": {
+    "urlCheck": true,
+    "es6": true,
+    "enhance": true,
+    "postcss": true,
+    "minified": true
+  },
+  "compileType": "miniprogram",
+  "libVersion": "latest",
+  "projectname": "WeKnora Mini Program",
+  "condition": {}
+}

--- a/miniprogram/project.private.config.json.example
+++ b/miniprogram/project.private.config.json.example
@@ -1,0 +1,3 @@
+{
+  "appid": "your-wechat-mini-program-appid"
+}

--- a/miniprogram/sitemap.json
+++ b/miniprogram/sitemap.json
@@ -1,0 +1,8 @@
+{
+  "rules": [
+    {
+      "action": "allow",
+      "page": "*"
+    }
+  ]
+}

--- a/miniprogram/utils/config.js
+++ b/miniprogram/utils/config.js
@@ -1,0 +1,36 @@
+const STORAGE_KEY = "weknora_settings";
+
+function normalizeBaseUrl(baseUrl) {
+  if (!baseUrl || typeof baseUrl !== "string") {
+    return "";
+  }
+
+  return baseUrl.trim().replace(/\/+$/, "");
+}
+
+function getSettings() {
+  const stored = wx.getStorageSync(STORAGE_KEY) || {};
+  return {
+    baseUrl: normalizeBaseUrl(stored.baseUrl || ""),
+    apiKey: stored.apiKey || "",
+    selectedKnowledgeBaseId: stored.selectedKnowledgeBaseId || ""
+  };
+}
+
+function saveSettings(settings) {
+  const current = getSettings();
+  const next = {
+    ...current,
+    ...settings,
+    baseUrl: normalizeBaseUrl(settings.baseUrl ?? current.baseUrl)
+  };
+  wx.setStorageSync(STORAGE_KEY, next);
+  return next;
+}
+
+module.exports = {
+  STORAGE_KEY,
+  getSettings,
+  normalizeBaseUrl,
+  saveSettings
+};

--- a/miniprogram/utils/request.js
+++ b/miniprogram/utils/request.js
@@ -55,10 +55,15 @@ function createSession(knowledgeBaseId) {
   });
 }
 
-function knowledgeChat(sessionId, query) {
+function knowledgeChat(sessionId, query, knowledgeBaseId) {
+  const data = { query };
+  if (knowledgeBaseId) {
+    data.knowledge_base_ids = [knowledgeBaseId];
+  }
+
   return request(`/api/v1/knowledge-chat/${sessionId}`, {
     method: "POST",
-    data: { query }
+    data
   });
 }
 

--- a/miniprogram/utils/request.js
+++ b/miniprogram/utils/request.js
@@ -1,0 +1,71 @@
+const { getSettings } = require("./config");
+
+function request(path, options = {}) {
+  const settings = getSettings();
+  if (!settings.baseUrl) {
+    return Promise.reject(new Error("Please configure the WeKnora API base URL first."));
+  }
+  if (!settings.apiKey) {
+    return Promise.reject(new Error("Please configure the WeKnora API key first."));
+  }
+
+  return new Promise((resolve, reject) => {
+    wx.request({
+      url: `${settings.baseUrl}${path}`,
+      method: options.method || "GET",
+      data: options.data,
+      header: {
+        "Content-Type": "application/json",
+        "X-API-Key": settings.apiKey,
+        "X-Request-ID": `mp-${Date.now()}-${Math.random().toString(16).slice(2)}`
+      },
+      success(response) {
+        if (response.statusCode >= 200 && response.statusCode < 300) {
+          resolve(response.data);
+          return;
+        }
+        const message = response.data?.error?.message || response.data?.message || `HTTP ${response.statusCode}`;
+        reject(new Error(message));
+      },
+      fail(error) {
+        reject(new Error(error.errMsg || "Network request failed."));
+      }
+    });
+  });
+}
+
+function listKnowledgeBases() {
+  return request("/api/v1/knowledge-bases");
+}
+
+function createKnowledgeFromURL(knowledgeBaseId, url, enableMultimodel = false) {
+  return request(`/api/v1/knowledge-bases/${knowledgeBaseId}/knowledge/url`, {
+    method: "POST",
+    data: {
+      url,
+      enable_multimodel: enableMultimodel
+    }
+  });
+}
+
+function createSession(knowledgeBaseId) {
+  return request("/api/v1/sessions", {
+    method: "POST",
+    data: knowledgeBaseId ? { knowledge_base_id: knowledgeBaseId } : {}
+  });
+}
+
+function knowledgeChat(sessionId, query) {
+  return request(`/api/v1/knowledge-chat/${sessionId}`, {
+    method: "POST",
+    data: { query }
+  });
+}
+
+module.exports = {
+  createKnowledgeFromURL,
+  createSession,
+  knowledgeChat,
+  listKnowledgeBases,
+  request
+};

--- a/miniprogram/utils/sse.js
+++ b/miniprogram/utils/sse.js
@@ -1,0 +1,42 @@
+function parseSSE(raw) {
+  if (!raw || typeof raw !== "string") {
+    return [];
+  }
+
+  return raw
+    .split(/\n\n+/)
+    .map((block) => block.trim())
+    .filter(Boolean)
+    .map((block) => {
+      const event = { event: "message", data: "" };
+      block.split(/\n/).forEach((line) => {
+        if (line.startsWith("event:")) {
+          event.event = line.slice(6).trim();
+        }
+        if (line.startsWith("data:")) {
+          event.data += line.slice(5).trim();
+        }
+      });
+      return event;
+    })
+    .filter((event) => event.data);
+}
+
+function collectAnswerFromSSE(raw) {
+  return parseSSE(raw).reduce((answer, event) => {
+    try {
+      const payload = JSON.parse(event.data);
+      if (payload.response_type === "answer" && payload.content) {
+        return answer + payload.content;
+      }
+    } catch (error) {
+      return answer;
+    }
+    return answer;
+  }, "");
+}
+
+module.exports = {
+  collectAnswerFromSSE,
+  parseSSE
+};

--- a/tests/miniprogram/miniprogram.test.js
+++ b/tests/miniprogram/miniprogram.test.js
@@ -1,6 +1,6 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
-const { createKnowledgeFromURL, listKnowledgeBases } = require("../../miniprogram/utils/request");
+const { createKnowledgeFromURL, knowledgeChat, listKnowledgeBases } = require("../../miniprogram/utils/request");
 const { collectAnswerFromSSE, parseSSE } = require("../../miniprogram/utils/sse");
 const { normalizeBaseUrl } = require("../../miniprogram/utils/config");
 
@@ -83,4 +83,126 @@ test("URL import helper posts the selected URL payload", async () => {
     url: "https://github.com/Tencent/WeKnora",
     enable_multimodel: true
   });
+});
+
+test("chat helper includes selected knowledge base ids", async () => {
+  let capturedRequest;
+  global.wx = {
+    getStorageSync() {
+      return {
+        apiKey: "sk-test",
+        baseUrl: "https://weknora.example.com"
+      };
+    },
+    request(options) {
+      capturedRequest = options;
+      options.success({
+        statusCode: 200,
+        data: "event: message\ndata: {}\n\n"
+      });
+    }
+  };
+
+  await knowledgeChat("session-1", "hello", "kb-1");
+
+  assert.equal(capturedRequest.method, "POST");
+  assert.equal(capturedRequest.url, "https://weknora.example.com/api/v1/knowledge-chat/session-1");
+  assert.deepEqual(capturedRequest.data, {
+    query: "hello",
+    knowledge_base_ids: ["kb-1"]
+  });
+});
+
+test("knowledge page skips API loading until settings are configured", async () => {
+  const calls = [];
+  const pageDefinitions = [];
+  const originalPage = global.Page;
+  const originalWx = global.wx;
+
+  try {
+    global.Page = (definition) => {
+      pageDefinitions.push(definition);
+    };
+    global.wx = {
+      getStorageSync() {
+        return {};
+      },
+      request() {
+        calls.push("request");
+      },
+      switchTab() {}
+    };
+
+    delete require.cache[require.resolve("../../miniprogram/pages/index/index.js")];
+    require("../../miniprogram/pages/index/index.js");
+    const page = {
+      data: { ...pageDefinitions[0].data },
+      setData(nextData) {
+        this.data = { ...this.data, ...nextData };
+      }
+    };
+
+    await pageDefinitions[0].onShow.call(page);
+
+    assert.equal(page.data.needsSettings, true);
+    assert.deepEqual(calls, []);
+  } finally {
+    global.Page = originalPage;
+    global.wx = originalWx;
+  }
+});
+
+test("knowledge page maps API results to picker labels", async () => {
+  const pageDefinitions = [];
+  const originalPage = global.Page;
+  const originalWx = global.wx;
+  let savedSettings;
+
+  try {
+    global.Page = (definition) => {
+      pageDefinitions.push(definition);
+    };
+    global.wx = {
+      getStorageSync() {
+        return {
+          apiKey: "sk-test",
+          baseUrl: "https://weknora.example.com"
+        };
+      },
+      request(options) {
+        options.success({
+          statusCode: 200,
+          data: {
+            data: [
+              { id: "kb-1", name: "Compliance KB" },
+              { id: "kb-2", name: "Docs KB" }
+            ]
+          }
+        });
+      },
+      setStorageSync(key, value) {
+        savedSettings = { key, value };
+      },
+      switchTab() {}
+    };
+
+    delete require.cache[require.resolve("../../miniprogram/pages/index/index.js")];
+    require("../../miniprogram/pages/index/index.js");
+    const page = {
+      data: { ...pageDefinitions[0].data },
+      setData(nextData) {
+        this.data = { ...this.data, ...nextData };
+      }
+    };
+
+    await pageDefinitions[0].loadKnowledgeBases.call(page);
+
+    assert.deepEqual(page.data.knowledgeBaseNames, ["Compliance KB", "Docs KB"]);
+    assert.equal(page.data.selectedKnowledgeBaseId, "kb-1");
+    assert.equal(page.data.selectedKnowledgeBaseName, "Compliance KB");
+    assert.equal(savedSettings.value.selectedKnowledgeBaseId, "kb-1");
+  } finally {
+    global.Page = originalPage;
+    global.wx = originalWx;
+  }
 });

--- a/tests/miniprogram/miniprogram.test.js
+++ b/tests/miniprogram/miniprogram.test.js
@@ -1,0 +1,86 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { createKnowledgeFromURL, listKnowledgeBases } = require("../../miniprogram/utils/request");
+const { collectAnswerFromSSE, parseSSE } = require("../../miniprogram/utils/sse");
+const { normalizeBaseUrl } = require("../../miniprogram/utils/config");
+
+test("parseSSE extracts event payloads", () => {
+  const events = parseSSE('event: message\ndata: {"content":"hi"}\n\n');
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].event, "message");
+  assert.equal(events[0].data, '{"content":"hi"}');
+});
+
+test("collectAnswerFromSSE joins answer chunks and skips references", () => {
+  const raw = [
+    'event: message\ndata: {"response_type":"references","content":"skip","done":false}',
+    'event: message\ndata: {"response_type":"answer","content":"Hel","done":false}',
+    'event: message\ndata: {"response_type":"answer","content":"lo","done":true}'
+  ].join("\n\n");
+
+  assert.equal(collectAnswerFromSSE(raw), "Hello");
+});
+
+test("normalizeBaseUrl trims trailing slashes", () => {
+  assert.equal(normalizeBaseUrl(" https://example.com/// "), "https://example.com");
+});
+
+test("API helpers send WeKnora auth headers", async () => {
+  let capturedRequest;
+  global.wx = {
+    getStorageSync() {
+      return {
+        apiKey: "sk-test",
+        baseUrl: "https://weknora.example.com/",
+        selectedKnowledgeBaseId: "kb-1"
+      };
+    },
+    request(options) {
+      capturedRequest = options;
+      options.success({
+        statusCode: 200,
+        data: {
+          data: []
+        }
+      });
+    }
+  };
+
+  await listKnowledgeBases();
+
+  assert.equal(capturedRequest.url, "https://weknora.example.com/api/v1/knowledge-bases");
+  assert.equal(capturedRequest.header["X-API-Key"], "sk-test");
+  assert.match(capturedRequest.header["X-Request-ID"], /^mp-/);
+});
+
+test("URL import helper posts the selected URL payload", async () => {
+  let capturedRequest;
+  global.wx = {
+    getStorageSync() {
+      return {
+        apiKey: "sk-test",
+        baseUrl: "https://weknora.example.com",
+        selectedKnowledgeBaseId: "kb-1"
+      };
+    },
+    request(options) {
+      capturedRequest = options;
+      options.success({
+        statusCode: 201,
+        data: {
+          success: true
+        }
+      });
+    }
+  };
+
+  await createKnowledgeFromURL("kb-1", "https://github.com/Tencent/WeKnora", true);
+
+  assert.equal(capturedRequest.method, "POST");
+  assert.equal(capturedRequest.url, "https://weknora.example.com/api/v1/knowledge-bases/kb-1/knowledge/url");
+  assert.deepEqual(capturedRequest.data, {
+    url: "https://github.com/Tencent/WeKnora",
+    enable_multimodel: true
+  });
+});


### PR DESCRIPTION
## Summary
- Add a WeChat Mini Program plugin under `miniprogram/`
- Support configuring WeKnora API base URL and tenant API key
- Support listing knowledge bases, selecting a knowledge base, importing URL knowledge, and asking knowledge chat from WeChat
- Improve empty/settings states, align the Mini Program colors with WeKnora's green visual style, and pass the selected knowledge base ID into chat requests
- Document setup steps and add tests for reusable SSE/config/API helpers outside the Mini Program source tree so DevTools does not compile Node-only test files

Closes #908

## Test
- `cd miniprogram && npm test` (`8 passed`)
- `find miniprogram tests/miniprogram -name '*.js' -type f -exec node --check {} \;`
- `git diff --check`
- JSON config validation with Node
- Local WeKnora backend `GET /api/v1/knowledge-bases` with a tenant API key returned `2` knowledge bases
- Manual WeChat DevTools validation with a real test AppID: loaded knowledge bases, selected a knowledge base, and received a knowledge chat answer from the local backend
- WeChat DevTools CLI: copied `miniprogram/` to `/tmp` and ran `cli preview --project /tmp/.../miniprogram --appid <real test AppID> ...` successfully; generated preview QR and reported total package size `19.3 KB`
