### PR TITLE
feat(frontend): add LLM call timeout for agents

### DIFF
--- a/frontend/src/api/agent/index.ts
+++ b/frontend/src/api/agent/index.ts
@@ -23,9 +23,11 @@ export interface CustomAgentConfig {
   rerank_model_id?: string;         // ReRank 模型 ID
   temperature?: number;
   max_completion_tokens?: number;   // 最大生成token数（普通模式）
+  thinking?: boolean;                      // 是否启用思考模式（支持扩展思考的模型）
 
   // ===== Agent模式设置 =====
   max_iterations?: number;          // 最大迭代次数
+  llm_call_timeout?: number;        // LLM调用超时时间（秒）
   allowed_tools?: string[];         // 允许的工具
   reflection_enabled?: boolean;     // 是否启用反思
   // MCP服务选择模式：all=全部启用的MCP服务, selected=指定服务, none=不使用MCP

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -3664,6 +3664,12 @@ export default {
       selectDesc: 'Select MCP services to enable',
       selectPlaceholder: 'Select MCP services',
     },
+    llmCallTimeout: {
+      label: "LLM Call Timeout",
+      desc: "Maximum waiting time for a single LLM call (seconds). Call will be terminated if this time is exceeded",
+      hint: "0 means unlimited wait (not recommended)",
+      placeholder: "Enter seconds, recommended range 60-600",
+    },
     imageUpload: {
       navLabel: 'Multimodal',
       sectionTitle: 'Multimodal Configuration',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -3662,6 +3662,12 @@ export default {
       selectDesc: "选择要启用的 MCP 服务",
       selectPlaceholder: "选择 MCP 服务",
     },
+    llmCallTimeout: {
+      label: "LLM 调用超时",
+      desc: "单次 LLM 调用的最大等待时间（秒），超过此时间后调用将被中止",
+      hint: "0 表示无限等待（不推荐）",
+      placeholder: "输入秒数，建议范围 60-600",
+    },
     imageUpload: {
       navLabel: "多模态",
       sectionTitle: "多模态配置",

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -748,6 +748,25 @@
                       </div>
                     </div>
 
+                    <!-- LLM 调用超时时间 -->
+                    <div class="setting-row">
+                      <div class="setting-info">
+                        <label>{{ $t('agentEditor.llmCallTimeout.label') }}</label>
+                        <p class="desc">{{ $t('agentEditor.llmCallTimeout.desc') }}</p>
+                        <p class="desc-hint">{{ $t('agentEditor.llmCallTimeout.hint') }}</p>
+                      </div>
+                      <div class="setting-control">
+                        <t-input-number 
+                          v-model="formData.config.llm_call_timeout" 
+                          :min="0" 
+                          :max="600" 
+                          theme="column"
+                          :placeholder="$t('agentEditor.llmCallTimeout.placeholder')"
+                          clearable
+                        />
+                      </div>
+                    </div>
+
                     <!-- MCP 服务选择 -->
                     <div class="setting-row">
                       <div class="setting-info">
@@ -1797,6 +1816,7 @@ const defaultFormData = {
     thinking: false, // 默认禁用思考模式
     // Agent模式设置
     max_iterations: 10,
+    llm_call_timeout: 120,  // 120 seconds
     allowed_tools: [] as string[],
     reflection_enabled: false,
     // MCP 服务设置


### PR DESCRIPTION
Adds configurable LLM call timeout in the agent editor (API types, i18n, AgentEditorModal).

Cherry-picked from internal work; targets clean review vs `main`.