### PR TITLE
fix(wiki): queue JSON handling and failed ingest operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ frontend/chrome-extension/
 WeKnora-Chrome-Extension
 packages/protoc-3.19.4-linux-x86_64.zip
 
+Claude.md
+
 # 本地测试脚本
 configure-ollama.sh
 fix-docker.sh

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -299,6 +299,8 @@ func (s *wikiIngestService) peekPendingList(ctx context.Context, kbID string) ([
 		var op WikiPendingOp
 		if err := json.Unmarshal([]byte(item), &op); err == nil {
 			ops = append(ops, op)
+		} else {
+			logger.Warnf(ctx, "wiki ingest: failed to unmarshal pending op: %v, raw_item: %.100s", err, item)
 		}
 	}
 
@@ -320,7 +322,7 @@ func (s *wikiIngestService) peekPendingList(ctx context.Context, kbID string) ([
 		unique = append(unique, reversedUnique[i])
 	}
 
-	return unique, len(result)
+	return unique, len(ops)
 }
 
 // trimPendingList removes the first `count` items from the Redis pending list.

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -322,7 +322,7 @@ func (s *wikiIngestService) peekPendingList(ctx context.Context, kbID string) ([
 		unique = append(unique, reversedUnique[i])
 	}
 
-	return unique, len(ops)
+	return unique, len(result)
 }
 
 // trimPendingList removes the first `count` items from the Redis pending list.
@@ -333,6 +333,28 @@ func (s *wikiIngestService) trimPendingList(ctx context.Context, kbID string, co
 	pendingKey := wikiPendingKeyPrefix + kbID
 	if err := s.redisClient.LTrim(ctx, pendingKey, int64(count), -1).Err(); err != nil {
 		logger.Warnf(ctx, "wiki ingest: failed to trim pending list: %v", err)
+	}
+}
+
+// requeueFailedOps appends failed operations back to the pending list so they
+// are retried in the next follow-up batch. Called after trimPendingList has
+// already removed the consumed batch head.
+func (s *wikiIngestService) requeueFailedOps(ctx context.Context, kbID string, ops []WikiPendingOp) {
+	if s.redisClient == nil {
+		return
+	}
+	pendingKey := wikiPendingKeyPrefix + kbID
+	for _, op := range ops {
+		data, err := json.Marshal(op)
+		if err != nil {
+			logger.Warnf(ctx, "wiki ingest: failed to marshal op for requeue: %v", err)
+			continue
+		}
+		if err := s.redisClient.RPush(ctx, pendingKey, string(data)).Err(); err != nil {
+			logger.Warnf(ctx, "wiki ingest: failed to requeue op %s: %v", op.KnowledgeID, err)
+			continue
+		}
+		logger.Infof(ctx, "wiki ingest: re-queued failed op %s (%s) for retry", op.KnowledgeID, op.DocTitle)
 	}
 }
 

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -228,6 +228,7 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 
 	// 1. MAP PHASE (Parallel extraction and generation of updates)
 	var mapMu sync.Mutex
+	var failedOps []WikiPendingOp
 	slugUpdates := make(map[string][]SlugUpdate)
 	var docResults []*docIngestResult
 	var retractChangeDesc strings.Builder
@@ -310,6 +311,7 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 			if err != nil {
 				mapMu.Lock()
 				ingestFailed++
+				failedOps = append(failedOps, op)
 				mapMu.Unlock()
 				logger.Warnf(mapCtx, "wiki ingest: failed to map knowledge %s: %v", op.KnowledgeID, err)
 				return nil // Don't fail the whole batch
@@ -412,6 +414,13 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 	}
 
 	s.trimPendingList(ctx, payload.KnowledgeBaseID, peekedCount)
+
+	// Re-enqueue failed ops so they get retried in the next follow-up batch.
+	// This must happen after trim: trim removes the consumed batch head, then
+	// requeue appends the failed items to the tail for a future attempt.
+	if len(failedOps) > 0 {
+		s.requeueFailedOps(ctx, payload.KnowledgeBaseID, failedOps)
+	}
 
 	logger.Infof(ctx, "wiki ingest: batch completed for KB %s, %d ops, %d pages affected", payload.KnowledgeBaseID, len(pendingOps), len(allPagesAffected))
 


### PR DESCRIPTION
## Summary
- Fix silent data loss when Redis queue payloads contain malformed JSON (`wiki_ingest.go`, `.gitignore` tweak if any).
- Improve handling of failed wiki ingest operations (`wiki_ingest.go`, `wiki_ingest_batch.go`).

## Notes
Two commits preserved in chronological order. Independent of other PRs in this split.