### PR TITLE
fix(search): align rerank priority between Execute and rerankResults

### DIFF
--- a/internal/agent/tools/knowledge_search.go
+++ b/internal/agent/tools/knowledge_search.go
@@ -299,7 +299,7 @@ func (t *KnowledgeSearchTool) Execute(ctx context.Context, args json.RawMessage)
 	deduplicatedBeforeRerank := t.deduplicateResults(allResults)
 
 	// Apply ReRank if model is configured
-	// Prefer chatModel (LLM-based reranking) over rerankModel if both are available
+	// Prefer rerankModel; fall back to chatModel (LLM-based reranking) if unavailable
 	// Use first query for reranking (or combine all queries if needed)
 	rerankQuery := ""
 	if len(queries) > 0 {
@@ -313,26 +313,9 @@ func (t *KnowledgeSearchTool) Execute(ctx context.Context, args json.RawMessage)
 	// Variable to hold results through reranking and MMR stages
 	var filteredResults []*searchResultWithMeta
 
-	if t.chatModel != nil && len(deduplicatedBeforeRerank) > 0 && rerankQuery != "" {
-		logger.Infof(
-			ctx,
-			"[Tool][KnowledgeSearch] Applying LLM-based rerank with model: %s, input: %d results, queries: %v",
-			t.chatModel.GetModelName(),
-			len(deduplicatedBeforeRerank),
-			queries,
-		)
-		rerankedResults, err := t.rerankResults(ctx, rerankQuery, deduplicatedBeforeRerank)
-		if err != nil {
-			logger.Warnf(ctx, "[Tool][KnowledgeSearch] LLM rerank failed, using original results: %v", err)
-			filteredResults = deduplicatedBeforeRerank
-		} else {
-			filteredResults = rerankedResults
-			logger.Infof(ctx, "[Tool][KnowledgeSearch] LLM rerank completed successfully: %d results",
-				len(filteredResults))
-		}
-	} else if t.rerankModel != nil && len(deduplicatedBeforeRerank) > 0 && rerankQuery != "" {
-		logger.Infof(ctx, "[Tool][KnowledgeSearch] Applying rerank with model: %s, input: %d results, queries: %v",
-			t.rerankModel.GetModelName(), len(deduplicatedBeforeRerank), queries)
+	if (t.rerankModel != nil || t.chatModel != nil) && len(deduplicatedBeforeRerank) > 0 && rerankQuery != "" {
+		logger.Infof(ctx, "[Tool][KnowledgeSearch] Applying rerank, input: %d results, queries: %v",
+			len(deduplicatedBeforeRerank), queries)
 		rerankedResults, err := t.rerankResults(ctx, rerankQuery, deduplicatedBeforeRerank)
 		if err != nil {
 			logger.Warnf(ctx, "[Tool][KnowledgeSearch] Rerank failed, using original results: %v", err)
@@ -343,7 +326,7 @@ func (t *KnowledgeSearchTool) Execute(ctx context.Context, args json.RawMessage)
 				len(filteredResults))
 		}
 	} else {
-		// No reranking, use deduplicated results
+		// No reranking model available, use deduplicated results
 		filteredResults = deduplicatedBeforeRerank
 	}
 


### PR DESCRIPTION
## Summary
- `Execute` 外层 if/else 声称优先用 chatModel，但两个分支都调用 `rerankResults`，而 `rerankResults` 内部优先用 rerankModel —— 优先级矛盾，外层分支成了死代码
- 合并为单一条件分支，模型选择逻辑统一由 `rerankResults` 内部处理：rerankModel → chatModel → 原始结果
- 注释对齐实际行为

## Test plan
- [ ] 仅 rerankModel 配置时：走 `rerankWithModel`
- [ ] 仅 chatModel 配置时：走 `rerankWithLLM`
- [ ] 两者都配置时：先 rerankModel，失败后 fallback chatModel
- [ ] 两者都未配置时：直接使用原始结果