### PR TITLE
fix(im): remove pipeline-level timeout that kills multi-round agent reasoning

### DIFF
--- a/internal/agent/think.go
+++ b/internal/agent/think.go
@@ -19,6 +19,7 @@ type streamLLMResult struct {
 	ToolCalls    []types.LLMToolCall
 	Usage        *types.TokenUsage
 	FinishReason string // actual finish_reason from LLM (captured from last stream chunk)
+	StreamError  string // error message from stream (e.g., timeout), kept separate from Content
 }
 
 // streamLLMToEventBus streams LLM response through EventBus (generic method)
@@ -51,6 +52,14 @@ func (e *AgentEngine) streamLLMToEventBus(
 			firstChunkTime = time.Now()
 		}
 		responseTypeCounts[string(chunk.ResponseType)]++
+
+		// Capture error messages from the stream (e.g., "context deadline exceeded")
+		// but do NOT append them to result.Content — they would leak to the user
+		// as if they were part of the LLM answer.
+		if chunk.ResponseType == types.ResponseTypeError {
+			result.StreamError = chunk.Content
+			continue
+		}
 
 		if chunk.Content != "" {
 			isExtracted := chunk.Data != nil && chunk.Data["source"] != nil
@@ -85,6 +94,12 @@ func (e *AgentEngine) streamLLMToEventBus(
 		"stream_duration=%dms, type_distribution=%v",
 		chunkCount, len(result.Content), len(result.ToolCalls),
 		streamDuration.Milliseconds(), responseTypeCounts)
+
+	// If the stream produced an error and no usable content/tool calls,
+	// surface it as a Go error so the caller can retry or degrade gracefully.
+	if result.StreamError != "" && result.Content == "" && len(result.ToolCalls) == 0 {
+		return result, fmt.Errorf("LLM stream error: %s", result.StreamError)
+	}
 
 	return result, nil
 }

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -28,8 +28,6 @@ import (
 )
 
 const (
-	// qaTimeout is the maximum time to wait for the QA pipeline to complete.
-	qaTimeout = 120 * time.Second
 	// dedupTTL is how long processed message IDs are retained.
 	dedupTTL = 5 * time.Minute
 	// dedupCleanupInterval is how often the dedup map is cleaned.
@@ -646,7 +644,7 @@ func (s *Service) storeInflightMapping(ctx context.Context, userKey, sessionID, 
 		return
 	}
 	val := sessionID + ":" + messageID
-	if err := s.redis.Set(ctx, RedisKeyInflight+userKey, val, qaTimeout+30*time.Second).Err(); err != nil {
+	if err := s.redis.Set(ctx, RedisKeyInflight+userKey, val, 10*time.Minute).Err(); err != nil {
 		logger.Warnf(ctx, "[IM] Failed to store inflight mapping: %v", err)
 	}
 }
@@ -1451,7 +1449,9 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 	}
 
 	// Prepare the QA pipeline
-	qaCtx, qaCancel := context.WithTimeout(ctx, qaTimeout)
+	// No total deadline: each agent round has its own LLMCallTimeout (default 120s).
+	// A hard pipeline deadline would kill multi-round agent reasoning prematurely.
+	qaCtx, qaCancel := context.WithCancel(ctx)
 	defer qaCancel()
 
 	eventBus := event.NewEventBus()
@@ -1748,8 +1748,9 @@ func (s *Service) fallbackNonStream(ctx context.Context, msg *IncomingMessage, s
 
 // runQA executes the WeKnora QA pipeline and returns the full answer text.
 func (s *Service) runQA(ctx context.Context, session *types.Session, query string, customAgent *types.CustomAgent, kbIDs []string, userKey string, quote *QuotedMessage) (string, error) {
-	// Add timeout to prevent indefinite blocking
-	ctx, cancel := context.WithTimeout(ctx, qaTimeout)
+	// Cancellable context (no hard deadline): each agent round has its own
+	// LLMCallTimeout. The context can still be cancelled by /stop.
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	eventBus := event.NewEventBus()
@@ -1855,18 +1856,18 @@ func (s *Service) runQA(ctx context.Context, session *types.Session, query strin
 		}
 	}()
 
-	// Wait for completion or timeout
+	// Wait for completion or cancellation (e.g., /stop)
 	select {
 	case <-done:
 	case <-ctx.Done():
 		// Mark assistant message as completed to avoid dangling incomplete records
-		assistantMsg.Content = "抱歉，回答超时，请稍后再试。"
+		assistantMsg.Content = "抱歉，回答已被取消。"
 		assistantMsg.IsCompleted = true
 		// Use a fresh context since the original is cancelled
 		if updateErr := s.messageService.UpdateMessage(context.WithoutCancel(ctx), assistantMsg); updateErr != nil {
-			logger.Warnf(ctx, "[IM] Failed to update timed-out assistant message: %v", updateErr)
+			logger.Warnf(ctx, "[IM] Failed to update cancelled assistant message: %v", updateErr)
 		}
-		return "", fmt.Errorf("QA timed out after %v", qaTimeout)
+		return "", fmt.Errorf("QA cancelled: %w", ctx.Err())
 	}
 
 	answerMu.Lock()


### PR DESCRIPTION
## Summary

Fixes #1000, also fixes #1046 (error message leak).

IM 服务对整个 QA pipeline 加了 120s 硬超时 (`qaTimeout`)。多轮 ReAct agent 推理很容易超过这个时间——第 8 轮时 parent context 到期，LLM stream 被 cancel，`"context deadline exceeded"` 错误消息泄漏给用户作为最终回答。

- **移除 pipeline 级总超时**：`handleMessageStream` 和 `runQA` 中的 `context.WithTimeout(ctx, qaTimeout)` 改为 `context.WithCancel(ctx)`，与 Web 模式一致。每轮 agent 仍有独立的 `LLMCallTimeout`（默认 120s/轮）控制。
- **修复错误消息泄漏**：`streamLLMToEventBus` 中 `ResponseTypeError` 类型的 chunk 不再拼入 `result.Content`，改为记录在 `StreamError` 字段，仅在无有效内容时作为 Go error 返回。
- **调整 Redis inflight TTL**：从 `qaTimeout+30s`（150s）调大到 10 分钟，匹配多轮推理的实际耗时。
- **删除** `qaTimeout` 常量。

## Test plan

- [ ] `go build ./internal/im/ ./internal/agent/` 编译通过
- [ ] `go test ./internal/im/ ./internal/agent/` 测试通过
- [ ] IM Agent 模式多轮推理（>8 轮）不再被总超时中断
- [ ] LLM 单轮超时（`LLMCallTimeout`）仍然生效，不会无限挂起
- [ ] `/stop` 命令仍然可以取消正在进行的推理
- [ ] LLM stream 错误不再泄漏为用户可见内容