### PR TITLE
fix(docreader): remove default 100-page limit for DOCX parsing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -386,9 +386,9 @@ DOCREADER_ADDR=docreader:50051
 # Docreader 连接方式
 DOCREADER_TRANSPORT=grpc
 
-# Docreader 中 DOCX 解析的最大页数，默认 100
-# 用于限制超大 Word 文档的解析开销；超过页数的内容将不会继续解析
-# DOCREADER_DOCX_MAX_PAGES=100
+# Docreader 中 DOCX 解析的最大页数，默认 0（不限制）
+# 设为正整数（如 500）可限制超大 Word 文档的解析开销；超过页数的内容将不会继续解析
+# DOCREADER_DOCX_MAX_PAGES=0
 
 # 如果使用Weaviate作为向量存储，需要配置以下参数
 # 注意：容器内访问请使用 service:port（不要用 localhost，也不要用宿主机映射端口）

--- a/docreader/config.py
+++ b/docreader/config.py
@@ -73,7 +73,7 @@ def load_config() -> DocReaderConfig:
         * 1024
     )
     grpc_port = _get_int(["DOCREADER_GRPC_PORT", "PORT"], 50051)
-    docx_max_pages = _get_int(["DOCREADER_DOCX_MAX_PAGES"], 100)
+    docx_max_pages = _get_int(["DOCREADER_DOCX_MAX_PAGES"], 0)
 
     external_http_proxy = _get_str(
         ["DOCREADER_EXTERNAL_HTTP_PROXY", "EXTERNAL_HTTP_PROXY"], ""

--- a/docreader/parser/docx_parser.py
+++ b/docreader/parser/docx_parser.py
@@ -97,6 +97,8 @@ class DocxParser(BaseParser):
         """
         super().__init__(**kwargs)
         self.max_pages = CONFIG.docx_max_pages if max_pages is None else max_pages
+        if self.max_pages <= 0:
+            self.max_pages = 100000  # no limit (matches Docx.__call__ default)
         logger.info(f"DocxParser initialized with max_pages={self.max_pages}")
 
     def parse_into_text(self, content: bytes) -> DocumentModel:


### PR DESCRIPTION
## Summary

- Change `DOCREADER_DOCX_MAX_PAGES` default from `100` to `0` (no limit), so large DOCX documents are fully parsed instead of being silently truncated at 100 pages (~1000 chunks)
- Treat `0` / negative values as "no limit" in `DocxParser` by converting to `100000` (the `Docx` class's existing no-limit sentinel)
- Update `.env.example` comment to document the new default

## Background

Users uploading books or long documents found that chunks were always capped at ~1000 fragments regardless of document length. Root cause: the default 100-page limit in the DOCX parser, combined with the default 512-char chunk size, produces at most ~1000 chunks. Content beyond page 100 was silently discarded.

PR #884 made this configurable via env var but kept the default at 100. This PR removes the cap by default. Operators who need a limit can still set `DOCREADER_DOCX_MAX_PAGES=500` (or any positive integer).

## Test plan

- [ ] Start docreader with no `DOCREADER_DOCX_MAX_PAGES` set → log shows `max_pages=100000`
- [ ] Set `DOCREADER_DOCX_MAX_PAGES=200` → log shows `max_pages=200`
- [ ] Upload a DOCX longer than 100 pages → chunks exceed 1000 if document content warrants it

Fixes #719