### PR TITLE
fix(docparser): preserve standalone image uploads from icon filter

### DIFF
--- a/internal/infrastructure/docparser/builtin_converter.go
+++ b/internal/infrastructure/docparser/builtin_converter.go
@@ -98,6 +98,7 @@ func imageToResult(fileName string, data []byte) *types.ReadResult {
 				OriginalRef: safeRef,
 				MimeType:    mime,
 				ImageData:   data,
+				IsOriginal:  true,
 			},
 		},
 	}
@@ -170,6 +171,7 @@ func ensureOriginalImageRef(req *types.ReadRequest, mdContent string, imageRefs 
 		OriginalRef: refPath,
 		MimeType:    mime,
 		ImageData:   req.FileContent,
+		IsOriginal:  true,
 	})
 
 	return mdContent, imageRefs

--- a/internal/infrastructure/docparser/image_resolver.go
+++ b/internal/infrastructure/docparser/image_resolver.go
@@ -126,8 +126,11 @@ func (r *ImageResolver) ResolveAndStore(
 			continue
 		}
 
-		// Filter out small icons and decorative images
-		if isIconImage(ref.ImageData) {
+		// Filter out small icons and decorative images. Skip the filter
+		// when the reference is the originally uploaded file itself, so
+		// that a standalone image upload is never silently dropped even
+		// if its dimensions are below the icon threshold.
+		if !ref.IsOriginal && isIconImage(ref.ImageData) {
 			// Remove the image reference from markdown entirely
 			markdown = markdown[:m[0]] + markdown[m[1]:]
 			continue

--- a/internal/types/docparser.go
+++ b/internal/types/docparser.go
@@ -31,6 +31,11 @@ type ImageRef struct {
 	MimeType    string
 	StorageKey  string
 	ImageData   []byte // inline image bytes (universal fallback for cross-machine deployments)
+	// IsOriginal marks references that point to the originally uploaded file
+	// itself (e.g. when the user uploads a standalone image). Such references
+	// must not be dropped by the icon/size filter — otherwise a small image
+	// upload would be silently discarded before multimodal processing.
+	IsOriginal bool
 }
 
 // ParserEngineInfo describes a registered parser engine.


### PR DESCRIPTION
## 描述 (Description)

当用户上传的原始文件本身就是一张图片时，多模态处理链路上的 icon 过滤会把尺寸小于 64×64（或字节数小于 512B）的图片当作图标丢弃，导致小尺寸的整张原图在进入 OCR/Caption 之前就被静默删除。

本 PR 给 `types.ImageRef` 增加 `IsOriginal` 标记：
- `SimpleFormatReader.imageToResult`（Go 原生处理纯图片上传）和 `ensureOriginalImageRef`（MinerU / MinerU Cloud 处理纯图片上传时补回的原图引用）在构造 `ImageRef` 时设置 `IsOriginal: true`。
- `ResolveAndStore` 在执行 `isIconImage` 过滤前先判断 `ref.IsOriginal`，为 true 时跳过过滤。

文档解析过程中从 PDF/Docx/HTML 等内嵌抽取出的图片仍保持原行为（默认 `IsOriginal=false`，继续走 icon 过滤）。

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)

## 测试 (Testing)
- [x] 单元测试 (Unit tests)

### 测试步骤 (Test Steps)
1. `go build ./...`
2. `go test ./internal/infrastructure/docparser/ -run Image -count=1`
3. 上传一张小尺寸图片（例如 32×32），确认其能进入多模态 OCR/Caption 处理而不被过滤。

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [x] 变更不会产生新的警告

## 相关 Issue
Fixes #

## 数据库迁移 (Database Migration)
- [x] 不需要数据库迁移