### PR TITLE
fix(knowledge-base): restore hover feedback on selected list rows

### DIFF
--- a/frontend/src/views/knowledge/components/DocumentListView.vue
+++ b/frontend/src/views/knowledge/components/DocumentListView.vue
@@ -325,7 +325,13 @@ const handleAction = (action: 'edit' | 'reparse' | 'move' | 'delete', item: Know
     background: var(--td-brand-color-1, #f2f5fc);
     box-shadow: inset 3px 0 0 var(--td-brand-color, #0052d9);
 
-    &:hover { background: var(--td-brand-color-light, #e8eefc); }
+    // brand-color-light alias maps back to brand-color-1, so a plain
+    // var() swap produces no visible hover delta. Mix in a touch of
+    // brand-color so the hover state is perceptible in both light and
+    // dark themes without falling back to the saturated brand-color-2.
+    &:hover {
+      background: color-mix(in srgb, var(--td-brand-color-1) 75%, var(--td-brand-color));
+    }
   }
 
   &:hover .row-more-btn,


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
<!-- 请简要描述这个 PR 的目的和变更内容 -->
  前一轮列表视图色调优化（PR #1075）把选中行的 hover 背景设为
  \`var(--td-brand-color-light)\`，theme.css 里 \`--td-brand-color-light\`
  alias 到 \`--td-brand-color-1\`，和静态选中态背景同色——hover
  没有任何视觉反馈，用户失去了"这一行可点击/可操作"的提示。

 优化没来得及在merge前提交，这里新增一个follow-up PR ，并增加在浅色/深色模式的适配

## 变更类型 (Type of Change)
<!-- 请选择适用的类型，删除其他选项 -->
- [x] 🐛 Bug 修复 (Bug fix)
- [x] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
<!-- 请选择受影响的组件，删除其他选项 -->
- [x] 前端界面 (Frontend UI)

## 测试 (Testing)
<!-- 请描述如何测试这些变更 -->
- [ ] 单元测试 (Unit tests)
- [x] 集成测试 (Integration tests)
- [ ] 手动测试 (Manual testing)
- [x] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
  1. 切到任一文档型知识库（非 FAQ / Wiki），用 toolbar 切到列表视图。
  2. 点击任意一行的复选框选中该行（行底色变浅绿，左侧出现深绿 accent bar）。
  3. 鼠标移入/移出已选中行：背景应有可见的颜色加深（轻微但能感觉到），鼠标移
  开恢复静态选中色；同时验证未选中行 hover 仍是中性灰、不受影响；如果配置了
  dark mode，切到 dark 重复一遍，hover 反馈同样可感知。

## 检查清单 (Checklist)
<!-- 请确保完成以下检查项 -->
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
<!-- 如果此 PR 解决了某个 issue，请使用 "Fixes #123" 或 "Closes #123" 的格式 -->
Fixes #

## 截图/录屏 (Screenshots/Recordings)
<!-- 如果是前端 UI 变更，请提供截图或录屏 -->
修复前：选中行 hover 无可见变化
<img width="1392" height="731" alt="Screenshot 2026-04-29 at 12 23 29" src="https://github.com/user-attachments/assets/264477a2-01be-4031-9aa8-d6e49dc6de32" />


修复后：选中行 hover 可见加深
浅色模式
<img width="1392" height="731" alt="Screenshot 2026-04-29 at 13 29 42" src="https://github.com/user-attachments/assets/2e46ee48-7289-4a41-a06a-c769e6dba389" />
<img width="1392" height="731" alt="Screenshot 2026-04-29 at 13 29 20" src="https://github.com/user-attachments/assets/1794e886-3061-4306-bf46-f079ab939aab" />
深色模式
<img width="1392" height="731" alt="Screenshot 2026-04-29 at 13 42 20" src="https://github.com/user-attachments/assets/296ee7dd-573b-42b1-adca-67bd3012a0f9" />
<img width="1392" height="731" alt="Screenshot 2026-04-29 at 13 42 30" src="https://github.com/user-attachments/assets/0c750831-c0c3-4574-b96a-55ccaec690f5" />


## 数据库迁移 (Database Migration)
<!-- 如果涉及数据库变更，请说明 -->
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
<!-- 如果涉及配置变更，请说明需要更新的配置项 -->
 无对应 issue。本 PR 是 #1075 合并后的 follow-up：选中行 hover
  无视觉反馈的回归修复。

## 部署说明 (Deployment Notes)
<!-- 如果有特殊的部署要求，请说明 -->

## 其他信息 (Additional Information)
<!-- 任何其他需要说明的信息 -->