### PR TITLE
fix(chat): stop button behavior and input layout fixes

### DIFF
--- a/frontend/src/components/IMChannelPanel.vue
+++ b/frontend/src/components/IMChannelPanel.vue
@@ -19,7 +19,7 @@
 
       <div v-else class="channels-list">
         <div v-for="channel in channels" :key="channel.id" class="channel-item">
-          <div class="channel-info">
+          <div class="channel-item-header">
             <div class="channel-info-top">
               <div class="channel-main">
                 <span class="platform-badge" :class="channel.platform">
@@ -28,6 +28,28 @@
                 <span class="channel-name">{{ channel.name || $t('agentEditor.im.unnamed') }}</span>
               </div>
             </div>
+            <div class="channel-actions">
+              <t-switch
+                :value="channel.enabled"
+                size="small"
+                @change="handleToggle(channel)"
+              />
+              <t-dropdown
+                trigger="click"
+                placement="bottom-right"
+                :options="[
+                  { content: $t('common.edit'), value: 'edit', onClick: () => editChannel(channel) },
+                  { content: $t('common.delete'), value: 'delete', theme: 'error' }
+                ]"
+                @click="(data) => data.value === 'delete' && handleDelete(channel.id)"
+              >
+                <t-button variant="text" theme="default" size="small">
+                  <t-icon name="more" />
+                </t-button>
+              </t-dropdown>
+            </div>
+          </div>
+          <div class="channel-info">
             <div class="channel-meta">
               <span class="meta-tag">
                 <t-icon name="link" class="meta-icon" />
@@ -50,21 +72,6 @@
               </t-button>
             </div>
           </div>
-          <div class="channel-actions">
-            <t-switch
-              :value="channel.enabled"
-              size="small"
-              @change="handleToggle(channel)"
-            />
-            <t-button variant="text" theme="default" size="small" @click="editChannel(channel)">
-              <t-icon name="edit" />
-            </t-button>
-            <t-popconfirm :content="$t('agentEditor.im.deleteConfirm')" @confirm="handleDelete(channel.id)">
-              <t-button variant="text" theme="danger" size="small">
-                <t-icon name="delete" />
-              </t-button>
-            </t-popconfirm>
-          </div>
         </div>
       </div>
     </div>
@@ -75,29 +82,43 @@
       {{ $t('agentEditor.im.addChannel') }}
     </t-button>
 
-    <!-- Create/Edit dialog -->
-    <t-dialog
+    <!-- Create/Edit drawer -->
+    <t-drawer
       v-model:visible="showCreateDialog"
       :header="editingChannel ? $t('agentEditor.im.editChannel') : $t('agentEditor.im.addChannel')"
       :confirm-btn="$t('common.save')"
       :cancel-btn="$t('common.cancel')"
       @confirm="handleSave"
       @close="resetForm"
-      width="560px"
+      size="560px"
     >
-      <div class="dialog-form">
+      <div class="drawer-form">
         <!-- Platform -->
         <div class="form-item">
           <label class="form-label">{{ $t('agentEditor.im.platform') }}</label>
-          <t-radio-group v-model="formData.platform" :disabled="!!editingChannel" @change="onPlatformChange">
-            <t-radio-button value="wecom">{{ $t('agentEditor.im.wecom') }}</t-radio-button>
-            <t-radio-button value="feishu">{{ $t('agentEditor.im.feishu') }}</t-radio-button>
-            <t-radio-button value="slack">{{ $t('agentEditor.im.slack') }}</t-radio-button>
-            <t-radio-button value="telegram">{{ $t('agentEditor.im.telegram') }}</t-radio-button>
-            <t-radio-button value="dingtalk">{{ $t('agentEditor.im.dingtalk') }}</t-radio-button>
-            <t-radio-button value="mattermost">{{ $t('agentEditor.im.mattermost') }}</t-radio-button>
-            <t-radio-button value="wechat">{{ $t('agentEditor.im.wechat') }}</t-radio-button>
-          </t-radio-group>
+          <t-select v-model="formData.platform" :disabled="!!editingChannel" @change="onPlatformChange">
+            <t-option value="wecom" :label="$t('agentEditor.im.wecom')">
+              <span class="platform-badge wecom" style="margin-right: 8px;">{{ $t('agentEditor.im.wecom') }}</span>
+            </t-option>
+            <t-option value="feishu" :label="$t('agentEditor.im.feishu')">
+              <span class="platform-badge feishu" style="margin-right: 8px;">{{ $t('agentEditor.im.feishu') }}</span>
+            </t-option>
+            <t-option value="slack" :label="$t('agentEditor.im.slack')">
+              <span class="platform-badge slack" style="margin-right: 8px;">{{ $t('agentEditor.im.slack') }}</span>
+            </t-option>
+            <t-option value="telegram" :label="$t('agentEditor.im.telegram')">
+              <span class="platform-badge telegram" style="margin-right: 8px;">{{ $t('agentEditor.im.telegram') }}</span>
+            </t-option>
+            <t-option value="dingtalk" :label="$t('agentEditor.im.dingtalk')">
+              <span class="platform-badge dingtalk" style="margin-right: 8px;">{{ $t('agentEditor.im.dingtalk') }}</span>
+            </t-option>
+            <t-option value="mattermost" :label="$t('agentEditor.im.mattermost')">
+              <span class="platform-badge mattermost" style="margin-right: 8px;">{{ $t('agentEditor.im.mattermost') }}</span>
+            </t-option>
+            <t-option value="wechat" :label="$t('agentEditor.im.wechat')">
+              <span class="platform-badge wechat" style="margin-right: 8px;">{{ $t('agentEditor.im.wechat') }}</span>
+            </t-option>
+          </t-select>
         </div>
 
         <!-- Name -->
@@ -394,7 +415,7 @@
           </div>
         </template>
       </div>
-    </t-dialog>
+    </t-drawer>
   </div>
 </template>
 
@@ -766,27 +787,35 @@ onUnmounted(() => {
 }
 
 .channels-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
   max-height: 400px;
   overflow-y: auto;
 }
 
 .channel-item {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-  padding: 14px 16px;
-  background: var(--td-bg-color-secondarycontainer);
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  background: var(--td-bg-color-container);
   border: 1px solid var(--td-component-stroke);
   border-radius: 8px;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  transition: all 0.2s cubic-bezier(0.38, 0, 0.24, 1);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 
   &:hover {
-    border-color: var(--td-brand-color-focus);
+    border-color: var(--td-brand-color);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   }
+}
+
+.channel-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
 }
 
 .channel-info {
@@ -924,7 +953,7 @@ onUnmounted(() => {
   }
 }
 
-.dialog-form {
+.drawer-form {
   display: flex;
   flex-direction: column;
   gap: 16px;

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -209,7 +209,7 @@
           >
                <div v-html="renderMarkdownContent(event.content)"></div>
           </div>
-          <div v-if="event.done" class="answer-toolbar">
+          <div v-if="event.done && event.content && event.content.trim()" class="answer-toolbar">
             <t-button size="small" variant="outline" shape="round" @click.stop="handleCopyAnswer(event)" :title="$t('agent.copy')">
               <t-icon name="copy" />
             </t-button>
@@ -894,6 +894,19 @@ const finalContent = computed(() => {
     return { type: 'answer' };
   }
 
+  // Do NOT fall back to re-rendering the last thinking event when the
+  // intermediate-steps tree already shows it — that would duplicate the
+  // thinking card below the tree. The fallback is only meaningful for
+  // legacy conversations where the tree is absent. Also skip for
+  // user-stopped conversations which have no final answer to fall back to.
+  if (shouldShowCollapsedSteps.value) {
+    return null;
+  }
+  const wasStopped = stream.some((e: any) => e.type === 'stop');
+  if (wasStopped) {
+    return null;
+  }
+
   // Fallback: if no answer content (legacy path or LLM didn't call final_answer),
   // use last thinking as final content
   const thinkingEvents = stream.filter((e: any) => e.type === 'thinking' && e.content && e.content.trim());
@@ -1069,6 +1082,14 @@ const displayEvents = computed(() => {
   const answerEvents = result.filter((e: any) => e.type === 'answer');
   if (answerEvents.length > 0) {
     return answerEvents;
+  }
+
+  // If the intermediate-steps tree is active, all thinking/tool_call events
+  // are already rendered there. Showing anything else here would duplicate
+  // them. This covers both the user-stopped case and any completion path
+  // that didn't produce an answer event.
+  if (shouldShowCollapsedSteps.value) {
+    return [];
   }
 
   // Fallback: if no answer events, show last thinking (legacy compatibility)

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -380,15 +380,14 @@ const reconstructEventStreamFromSteps = (agentSteps, messageContent, isCompleted
         if (isFallback) answerEvent.is_fallback = true;
         events.push(answerEvent);
     } else if (isCompleted) {
-        // 如果消息已完成但 content 为空（Agent 模式常见情况），添加一个空的 answer 事件标记完成
-        // 这样可以确保 isConversationDone 返回 true，不显示 loading-indicator
-        const answerEvent = {
-            type: 'answer',
-            content: '',
-            done: true
-        };
-        if (isFallback) answerEvent.is_fallback = true;
-        events.push(answerEvent);
+        // 消息已完成但 content 为空：说明是"停止时尚未产出最终答案"的场景。
+        // Push 一个 stop 事件，让 AgentStreamDisplay 的 isConversationDone 返回 true，
+        // 但不产生 answer 内容，也就不会渲染最终答案的 toolbar。与实时 stop 分支保持一致。
+        events.push({
+            type: 'stop',
+            timestamp: Date.now(),
+            reason: 'user_requested'
+        });
     }
     
     return events;
@@ -435,11 +434,9 @@ const handleMsgList = async (data, isScrollType = false, newScrollHeight) => {
             }
         }
         
-        // 只给非Agent模式的空内容已完成消息设置默认错误消息
-        // Agent模式的消息内容在agent_steps中，content为空是正常的
-        if (item.is_completed && !item.content && !item.isAgentMode) {
-            item.content = t('chat.cannotAnswer');
-        }
+        // 非 Agent 模式下若 content 为空（例如用户停止时尚未产出任何文字），
+        // 保持为空；botmsg.vue 会因 hasActualContent=false 不渲染内容区和 toolbar。
+        // 此前这里会兜底为 "chat.cannotAnswer"，会让停止场景显示误导性文案并出现复制按钮。
         messagesList.unshift(item);
         if (isFirstEnter.value) {
             scrollToBottom(true);
@@ -725,7 +722,25 @@ onChunk((data) => {
     
     // 原有的知识库 QA 处理逻辑（非 Agent 模式）
     // answer 内容中可能包含 <think>...</think> 标签
-    
+
+    // 非 Agent 模式下的 stop 事件：只更新状态，不把后端附带的 "Generation stopped by user"
+    // 文案拼进 content，保留用户点停止时已经流式输出的内容不变。
+    if (data.response_type === 'stop') {
+        console.log('[Stop Event] Non-agent generation stopped');
+        const stoppedMessage = messagesList.findLast((item) => {
+            if (item.request_id === data.id) return true;
+            return item.id === data.id;
+        });
+        if (stoppedMessage) {
+            stoppedMessage.is_completed = true;
+        }
+        loading.value = false;
+        isReplying.value = false;
+        fullContent.value = '';
+        currentAssistantMessageId.value = '';
+        return;
+    }
+
     // 检查消息是否已经完成，如果已完成则忽略后续的完成事件（防止空内容覆盖）
     const existingMessage = messagesList.findLast((item) => {
         if (item.request_id === data.id) {

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -1234,6 +1234,11 @@ onBeforeRouteUpdate((to, from, next) => {
     padding: 20px;
     box-sizing: border-box;
     flex: 1;
+    // The parent .platform-route-outlet is a flex column with min-height:0
+    // and overflow:hidden — we also need min-height:0 here so that our
+    // own flex:1 child (.chat_scroll_box) can shrink below its content
+    // height and scroll instead of pushing .input-container out of view.
+    min-height: 0;
     position: relative;
     display: flex;
     flex-direction: column;
@@ -1272,6 +1277,12 @@ onBeforeRouteUpdate((to, from, next) => {
 
 .chat_scroll_box {
     flex: 1;
+    // Without min-height: 0, a flex-column child defaults to min-height: auto
+    // and expands to fit all inner content. When there are many messages,
+    // that pushes .input-container out of the viewport. Clamping min-height
+    // to 0 lets overflow-y: auto take effect so the messages scroll inside
+    // this box instead of stretching it.
+    min-height: 0;
     width: 100%;
     overflow-y: auto;
 
@@ -1372,6 +1383,9 @@ onBeforeRouteUpdate((to, from, next) => {
 
 .input-container {
     min-height: 115px;
+    // Keep the input visible when messages overflow: without flex-shrink: 0
+    // a tall .chat_scroll_box can squeeze this container down to 0 height.
+    flex-shrink: 0;
     margin: 16px auto 4px;
     width: 100%;
     max-width: 800px;

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -353,6 +353,24 @@ func (e *AgentEngine) executeLoop(
 	common.PipelineInfo(ctx, "Agent", "loop_start", map[string]interface{}{
 		"max_iterations": e.config.MaxIterations,
 	})
+
+	// Guarantee exactly-one EventAgentComplete emission on every exit path
+	// (normal finish, ctx cancel observed at the loop head, or iteration error
+	// bubbling up while ctx was cancelled). The emission triggers
+	// agent_stream_handler.handleComplete, which is where state.RoundSteps
+	// (thinking + tool_call history) gets written onto assistantMessage.AgentSteps
+	// so it can be persisted by the caller's defer. Use WithoutCancel so a
+	// cancelled ctx does not short-circuit the emit on the stop path.
+	completionEmitted := false
+	emitCompletion := func() {
+		if completionEmitted {
+			return
+		}
+		completionEmitted = true
+		e.emitCompletionEvent(context.WithoutCancel(ctx), state, sessionID, messageID, startTime)
+	}
+	defer emitCompletion()
+
 	emptyRetries := 0
 	consecutiveSameContent := 0
 	lastResponseContent := ""
@@ -393,13 +411,15 @@ loop:
 		}
 	}
 
-	// If loop finished without final answer, generate one
-	if !state.IsComplete {
+	// If loop finished without final answer, generate one — but skip this
+	// when the context was cancelled (user pressed stop). In that case the
+	// fallback LLM call would fail on the already-cancelled ctx and set
+	// state.FinalAnswer to the generic "Sorry, I was unable to generate a
+	// complete answer." message, which then leaks to the UI as the final
+	// answer for a conversation the user deliberately stopped.
+	if !state.IsComplete && ctx.Err() == nil {
 		e.handleMaxIterations(ctx, query, state, sessionID)
 	}
-
-	// Emit completion event
-	e.emitCompletionEvent(ctx, state, sessionID, messageID, startTime)
 
 	return state, nil
 }
@@ -552,6 +572,25 @@ func (e *AgentEngine) runReActIteration(
 		Thought:   response.Content,
 		ToolCalls: make([]types.ToolCall, 0),
 		Timestamp: time.Now(),
+	}
+
+	// If the request was cancelled while the LLM was streaming (e.g. the
+	// user pressed "stop"), the stream driver still returns a usable
+	// response (partial content / finish_reason="stop" / no tool calls).
+	// Do NOT let analyzeResponse treat that partial thinking text as the
+	// final answer — it would pollute Message.Content with mid-stream
+	// thinking and show up as a duplicate card next to the intermediate-
+	// steps tree. Preserve the partial thinking as an AgentStep and break
+	// out of the loop without marking state.IsComplete. executeLoop's
+	// deferred emitCompletionEvent will persist the step onto
+	// Message.AgentSteps so it still appears in the tree on refresh.
+	if ctx.Err() != nil {
+		logger.Warnf(ctx, "[Agent][Round-%d] Context cancelled during LLM call; preserving partial step",
+			round)
+		if step.Thought != "" || len(step.ToolCalls) > 0 {
+			state.RoundSteps = append(state.RoundSteps, step)
+		}
+		return iterOutcomeBreak, nil
 	}
 
 	// 2. Analyze: Check for stop conditions (natural stop or final_answer tool)

--- a/internal/handler/session/helpers.go
+++ b/internal/handler/session/helpers.go
@@ -213,9 +213,13 @@ func (h *Handler) setupStopEventHandler(
 	eventBus.On(event.EventStop, func(ctx context.Context, evt event.Event) error {
 		logger.Infof(ctx, "Received stop event, cancelling async operations for session: %s", sessionID)
 		cancel()
-		assistantMessage.Content = "用户停止了本次对话"
-		// Use session's tenant for message update (ctx may have effectiveTenantID when using shared agent)
-		updateCtx := context.WithValue(ctx, types.TenantIDContextKey, sessionTenantID)
+		// Preserve whatever has been streamed so far; do not overwrite Content.
+		// Use session's tenant for message update (ctx may have effectiveTenantID when using shared agent).
+		// Use WithoutCancel so the GORM UPDATE survives the upcoming ctx.Done triggered by cancel()/client disconnect.
+		updateCtx := context.WithValue(
+			context.WithoutCancel(ctx),
+			types.TenantIDContextKey, sessionTenantID,
+		)
 		h.completeAssistantMessage(updateCtx, assistantMessage, "") // empty query: stopped conversations are not indexed
 		return nil
 	})

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -615,7 +615,15 @@ func (h *Handler) executeQA(reqCtx *qaRequestContext, mode qaMode, generateTitle
 			}
 			// Agent mode: complete the assistant message in defer (normal mode does it via event handler)
 			if mode == qaModeAgent {
-				updateCtx := context.WithValue(streamCtx.asyncCtx, types.TenantIDContextKey, reqCtx.session.TenantID)
+				// Use WithoutCancel so a user-triggered stop (which cancels
+				// asyncCtx) doesn't also cancel the GORM UPDATE that persists
+				// AgentSteps/Content. Without this, cancelled-ctx makes
+				// GORM skip the write and the agent's intermediate steps
+				// (thinking / tool_call history) are lost on page refresh.
+				updateCtx := context.WithValue(
+					context.WithoutCancel(streamCtx.asyncCtx),
+					types.TenantIDContextKey, reqCtx.session.TenantID,
+				)
 				h.completeAssistantMessage(updateCtx, streamCtx.assistantMessage, reqCtx.query)
 				logger.Infof(streamCtx.asyncCtx, "Agent QA service completed for session: %s", sessionID)
 			}


### PR DESCRIPTION
## Summary
- Fix the "stop" button so it no longer overwrites the assistant message with ‟用户停止了本次对话", preserves already-streamed content, and persists Agent intermediate steps to `Message.AgentSteps` so they survive a page refresh.
- When the user stops while the LLM is mid-thinking (no tool calls yet), the in-flight thinking no longer leaks into `Message.Content`; we skip `analyzeResponse` on a cancelled ctx and also skip the max-iterations fallback that would otherwise emit "Sorry, I was unable to generate a complete answer."
- UI: don't render a duplicate "思考" card below the steps tree on stopped/legacy-fallback paths; hide the copy/notes toolbar when the answer is empty; don't show the "cannotAnswer" placeholder for non-Agent empty content.
- Chat layout: fix a flexbox min-height trap so the input box stays visible when a conversation is long; previously the scroll container was stretched by its content, pushing the input out of view and breaking scrolling.
- Also includes an IM channel panel UX refactor (drawer + card grid) that was batched into the same branch.

## Test plan
- [x] Non-Agent: stop mid-stream → already-streamed chars preserved; copy/notes visible
- [x] Non-Agent: stop before any content → bubble empty, no toolbar, no placeholder
- [x] Agent: stop during thinking → tree shows the partial thinking step, no duplicate card below, no "Sorry…" fallback answer
- [x] Agent: stop during tool call → tree shows thinking + tool_call; refresh the page and the same state is restored
- [x] Chat with many messages: page doesn't scroll away the input; internal scroll inside the message list works