### PR TITLE
fix: prevent API key ciphertext (enc:v1:...) from leaking to the UI

### DIFF
--- a/helm/templates/secrets.yaml
+++ b/helm/templates/secrets.yaml
@@ -11,10 +11,30 @@ IMPORTANT: For production deployments, use one of these approaches:
 4. Provide an existing secret via secrets.existingSecret
 */}}
 {{- if not .Values.secrets.existingSecret }}
+{{/*
+Reuse the previously generated random keys on upgrade. Without this lookup,
+randAlphaNum would re-roll on every `helm upgrade` and rotate SYSTEM_AES_KEY /
+TENANT_AES_KEY, making any data encrypted with the old key unreadable
+(e.g. tenants.api_key would surface as enc:v1:... in the UI).
+*/}}
+{{- $secretName := include "weknora.secretName" . }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- $existingTenantKey := "" }}
+{{- $existingSystemKey := "" }}
+{{- if and $existing $existing.data }}
+  {{- if index $existing.data "TENANT_AES_KEY" }}
+    {{- $existingTenantKey = index $existing.data "TENANT_AES_KEY" | b64dec }}
+  {{- end }}
+  {{- if index $existing.data "SYSTEM_AES_KEY" }}
+    {{- $existingSystemKey = index $existing.data "SYSTEM_AES_KEY" | b64dec }}
+  {{- end }}
+{{- end }}
+{{- $tenantAesKey := .Values.secrets.tenantAesKey | default $existingTenantKey | default (randAlphaNum 32) }}
+{{- $systemAesKey := .Values.secrets.systemAesKey | default $existingSystemKey | default (randAlphaNum 32) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "weknora.secretName" . }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "weknora.labels" . | nindent 4 }}
@@ -29,8 +49,8 @@ stringData:
   REDIS_PASSWORD: {{ required "secrets.redisPassword is required" .Values.secrets.redisPassword | quote }}
   # Application secrets
   JWT_SECRET: {{ required "secrets.jwtSecret is required" .Values.secrets.jwtSecret | quote }}
-  TENANT_AES_KEY: {{ .Values.secrets.tenantAesKey | default (randAlphaNum 32) | quote }}
-  SYSTEM_AES_KEY: {{ .Values.secrets.systemAesKey | default (randAlphaNum 32) | quote }}
+  TENANT_AES_KEY: {{ $tenantAesKey | quote }}
+  SYSTEM_AES_KEY: {{ $systemAesKey | quote }}
   {{- if .Values.neo4j.enabled }}
   # Neo4j credentials (for GraphRAG)
   NEO4J_USERNAME: {{ .Values.neo4j.username | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -392,9 +392,20 @@ secrets:
   redisPassword: ""
   # -- JWT signing secret (REQUIRED: change in production)
   jwtSecret: ""
-  # -- Tenant AES encryption key
+  # -- Tenant AES encryption key (32 bytes).
+  # STRONGLY RECOMMENDED to set this explicitly in production.
+  # If left empty, a random 32-char value is generated on first install and
+  # reused on subsequent `helm upgrade` via Secret lookup. However, if the
+  # Secret is ever deleted/recreated (e.g. namespace recreated, GitOps prune,
+  # cluster rebuilt) a new random value will be generated and any data
+  # encrypted with the old key becomes UNRECOVERABLE.
   tenantAesKey: ""
-  # -- System AES-256 key for database API key encryption (32 bytes)
+  # -- System AES-256 key for database field encryption (must be exactly 32 bytes).
+  # Encrypts: tenants.api_key, model API keys, vector store credentials,
+  # web search provider keys, WeKnoraCloud.AppSecret.
+  # STRONGLY RECOMMENDED to set this explicitly in production. Same caveat as
+  # tenantAesKey: losing this key makes all encrypted fields unreadable
+  # (the UI will display ciphertext like "enc:v1:..." instead of plaintext).
   systemAesKey: ""
 
   # -- Use existing secret instead of creating one

--- a/internal/application/service/tenant.go
+++ b/internal/application/service/tenant.go
@@ -75,7 +75,8 @@ func (s *tenantService) CreateTenant(ctx context.Context, tenant *types.Tenant) 
 	}
 
 	logger.Infof(ctx, "Tenant created successfully, ID: %d, generating official API Key", tenant.ID)
-	tenant.APIKey = s.generateApiKey(tenant.ID)
+	plaintextAPIKey := s.generateApiKey(tenant.ID)
+	tenant.APIKey = plaintextAPIKey
 
 	// Manually encrypt APIKey before update, because db.Updates() does not trigger BeforeSave hook
 	if key := utils.GetAESKey(); key != nil && tenant.APIKey != "" {
@@ -91,6 +92,9 @@ func (s *tenantService) CreateTenant(ctx context.Context, tenant *types.Tenant) 
 		})
 		return nil, err
 	}
+
+	// Restore plaintext for the response so callers don't see enc:v1: ciphertext.
+	tenant.APIKey = plaintextAPIKey
 
 	logger.Infof(ctx, "Tenant creation and update completed, ID: %d, name: %s", tenant.ID, tenant.Name)
 	return tenant, nil
@@ -218,7 +222,8 @@ func (s *tenantService) UpdateAPIKey(ctx context.Context, id uint64) (string, er
 	}
 
 	logger.Infof(ctx, "Generating new API Key for tenant, ID: %d", id)
-	tenant.APIKey = s.generateApiKey(tenant.ID)
+	plaintextAPIKey := s.generateApiKey(tenant.ID)
+	tenant.APIKey = plaintextAPIKey
 
 	// Manually encrypt APIKey before update, because db.Updates() does not trigger BeforeSave hook
 	if key := utils.GetAESKey(); key != nil && tenant.APIKey != "" {
@@ -235,7 +240,7 @@ func (s *tenantService) UpdateAPIKey(ctx context.Context, id uint64) (string, er
 	}
 
 	logger.Infof(ctx, "Tenant API Key updated successfully, ID: %d", id)
-	return tenant.APIKey, nil
+	return plaintextAPIKey, nil
 }
 
 // generateApiKey generates a secure API key for tenant authentication


### PR DESCRIPTION
## Background

Users reported that the **API 信息 → API Key** field in the tenant
settings UI sometimes displays an `enc:v1:...` value (the AES-256-GCM
ciphertext) instead of the expected `sk-...` plaintext. Investigation
surfaced two independent bugs that can each cause this symptom.

## Bug 1 — Helm rotates `SYSTEM_AES_KEY` on every upgrade

`helm/templates/secrets.yaml` rendered the Secret with:

```yaml
TENANT_AES_KEY: {{ .Values.secrets.tenantAesKey | default (randAlphaNum 32) | quote }}
SYSTEM_AES_KEY: {{ .Values.secrets.systemAesKey | default (randAlphaNum 32) | quote }}
```

`randAlphaNum` is re-evaluated on every render, so any `helm upgrade`
without an explicit `secrets.systemAesKey` rotated the encryption key
in-place. After the rollout, the App pod tried to decrypt fields
that had been encrypted with the previous key — `aesgcm.Open` fails,
and the GORM `AfterFind` hook keeps the original ciphertext on the
struct. The UI then renders `enc:v1:...`.

The same issue affects every field that goes through
`utils.DecryptAESGCM`: `tenants.api_key`, model API keys, vector
store credentials, `web_search_provider.api_key`, and
`WeKnoraCloud.AppSecret`.

### Fix

Use Helm's `lookup` to reuse the keys that already exist in the
Secret on subsequent renders, falling back to `randAlphaNum` only on
first install. Also clarified the production guidance and recovery
caveat in `values.yaml`.

## Bug 2 — `CreateTenant` / `UpdateAPIKey` return the ciphertext

Both service methods generated a fresh `sk-...` key, then overwrote
`tenant.APIKey` with the AES-encrypted form so that
`repo.UpdateTenant` (which uses `db.Updates()` and bypasses
`BeforeSave`) would persist the encrypted column. The post-write
return value was the same field — i.e., the ciphertext was handed
back to the HTTP handler, so the user saw `enc:v1:...` immediately
after pressing **Generate / Reset**, even when `SYSTEM_AES_KEY` was
configured correctly.

### Fix

Stash the plaintext in a local variable, encrypt only the value
written to the DB, and return the plaintext. Reads via
`GetTenantByID` continue to rely on the `AfterFind` hook for
transparent decryption, so the persisted state is unchanged.

## Recovery for existing deployments hit by Bug 1

Operators whose deployments have already rotated `SYSTEM_AES_KEY` need
to either:

1. Restore the previous key value (e.g. from a Secret backup, ArgoCD
   revision history, or `kubectl get secret -o yaml` from an older
   replica) and pin it via `secrets.systemAesKey`, or
2. Reset every encrypted field for affected tenants — API keys,
   model provider credentials, vector store credentials, web search
   provider keys, and `WeKnoraCloud.AppSecret`.

## Test plan

- [ ] `make fmt && make lint && make test`
- [ ] `helm template ./helm --set secrets.dbPassword=x --set secrets.redisPassword=x --set secrets.jwtSecret=x` — confirm `SYSTEM_AES_KEY` / `TENANT_AES_KEY` get random values on the first render.
- [ ] Install on a kind/minikube cluster, then `helm upgrade` (no overrides); confirm the Secret keeps the original `SYSTEM_AES_KEY` instead of rotating.
- [ ] Generate a fresh API key via the UI / `POST /api/v1/tenants/:id/api-key`; confirm the response and UI show `sk-...`, while the DB column starts with `enc:v1:`.
- [ ] Refresh the tenant detail page; confirm the previously persisted key still decrypts to `sk-...`.