### PR TITLE
fix(frontend): polish KB list sticky header, batch bar, and card checkbox

### DIFF
--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -3824,20 +3824,23 @@ async function createNewSession(value: string): Promise<void> {
   cursor: pointer;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 
-  /* 初始态略可见，悬停/多选/已选时再强调，避免「凭空多一列」的突兀感 */
+  /* 默认折叠不占位，悬停/多选/已选时展开，避免非选择态左侧错位 */
   .card-nav-check {
     flex-shrink: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 22px;
+    width: 0;
     height: 29px;
-    opacity: 0.4;
-    transition: opacity 0.2s ease;
+    margin-right: 0;
+    opacity: 0;
+    overflow: hidden;
+    transition: width 0.2s ease, margin-right 0.2s ease, opacity 0.2s ease;
     cursor: pointer;
 
-    &.active,
-    &:focus-within {
+    &.active {
+      width: 22px;
+      margin-right: 8px;
       opacity: 1;
     }
 
@@ -3869,6 +3872,8 @@ async function createNewSession(value: string): Promise<void> {
 
   &:hover .card-nav-check,
   &.has-selection .card-nav-check {
+    width: 22px;
+    margin-right: 8px;
     opacity: 1;
   }
 
@@ -3908,7 +3913,7 @@ async function createNewSession(value: string): Promise<void> {
     flex-shrink: 0;
     display: flex;
     align-items: flex-start;
-    gap: 8px;
+    gap: 0;
     margin-bottom: 8px;
   }
 
@@ -3926,6 +3931,7 @@ async function createNewSession(value: string): Promise<void> {
     font-size: 15px;
     font-weight: 600;
     letter-spacing: 0.01em;
+    margin-right: 8px;
   }
 
   .more-wrap {

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -3024,6 +3024,7 @@ async function createNewSession(value: string): Promise<void> {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  position: relative; /* 作为批量工具栏悬浮的定位上下文 */
 }
 
 .doc-filter-bar {
@@ -3137,10 +3138,21 @@ async function createNewSession(value: string): Promise<void> {
   }
 }
 
-/* 批量条在滚动区外，始终贴主内容列底部，不随列表高度在列内上下漂移 */
+/* 批量条悬浮在滚动区底部，不挤占列表高度 */
 .doc-batch-bar-anchor {
-  flex-shrink: 0;
-  padding-top: 4px;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 12px;
+  z-index: 6;
+  display: flex;
+  justify-content: center;
+  padding: 0 16px;
+  pointer-events: none;
+
+  & > * {
+    pointer-events: auto;
+  }
 }
 
 // Header 样式（无底部分割线，留更多空间给下方内容区）

--- a/frontend/src/views/knowledge/components/DocumentBatchBar.vue
+++ b/frontend/src/views/knowledge/components/DocumentBatchBar.vue
@@ -61,7 +61,7 @@ const { t } = useI18n();
   background: var(--td-bg-color-container);
   border: 1px solid var(--td-component-stroke);
   border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
 }
 
 .batch-bar-left {

--- a/frontend/src/views/knowledge/components/DocumentListView.vue
+++ b/frontend/src/views/knowledge/components/DocumentListView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { formatFileSize, getFileIcon } from '@/utils/files';
 
@@ -124,6 +124,25 @@ const onMoreVisible = (id: string, visible: boolean) => {
   moreOpen.value = visible ? id : null;
 };
 
+// 吸顶检测：哨兵离开视口说明 header 已吸附在滚动容器顶部
+const stickySentinel = ref<HTMLElement | null>(null);
+const headerStuck = ref(false);
+let stickyObserver: IntersectionObserver | null = null;
+onMounted(() => {
+  if (!stickySentinel.value || typeof IntersectionObserver === 'undefined') return;
+  stickyObserver = new IntersectionObserver(
+    (entries) => {
+      headerStuck.value = !entries[0].isIntersecting;
+    },
+    { threshold: 0 },
+  );
+  stickyObserver.observe(stickySentinel.value);
+});
+onBeforeUnmount(() => {
+  stickyObserver?.disconnect();
+  stickyObserver = null;
+});
+
 const handleAction = (action: 'edit' | 'reparse' | 'move' | 'delete', item: KnowledgeItem) => {
   moreOpen.value = null;
   item.isMore = false;
@@ -134,7 +153,8 @@ const handleAction = (action: 'edit' | 'reparse' | 'move' | 'delete', item: Know
 
 <template>
   <div class="doc-list-view" :class="{ 'is-loading': loading }">
-    <div class="doc-list-header" role="row">
+    <div ref="stickySentinel" class="doc-list-sticky-sentinel" aria-hidden="true"></div>
+    <div class="doc-list-header" :class="{ 'is-stuck': headerStuck }" role="row">
       <div class="cell cell-check" role="columnheader" @click.stop>
         <t-checkbox
           class="doc-list-check"
@@ -305,6 +325,14 @@ const handleAction = (action: 'edit' | 'reparse' | 'move' | 'delete', item: Know
   padding: 0 16px;
 }
 
+.doc-list-sticky-sentinel {
+  height: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  pointer-events: none;
+}
+
 .doc-list-header {
   position: sticky;
   top: 0;
@@ -318,6 +346,12 @@ const handleAction = (action: 'edit' | 'reparse' | 'move' | 'delete', item: Know
   border-bottom: 1px solid var(--td-component-stroke);
   border-radius: 8px 8px 0 0;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  transition: border-radius 0.15s ease, box-shadow 0.2s ease;
+
+  &.is-stuck {
+    border-radius: 0;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+  }
 }
 
 .doc-list-body {


### PR DESCRIPTION
## Summary
- Polish the knowledge base document list: keep the header/toolbar sticky and float the batch action bar so multi-select stays usable when the list is long.
- In card/grid mode, hide the per-card checkbox by default and expand it on hover, when any card is selected, or when this card itself is selected — avoids the "ghost column" that misaligned titles after multi-select was added.
- Drop `:focus-within` on the checkbox wrapper so that clearing a selection collapses the checkbox instead of getting stuck visible due to retained input focus.

## Test plan
- [ ] Open a knowledge base detail page in card/grid view (`/platform/knowledge-bases/:id`): the checkboxes are invisible by default, titles align flush with the card's left padding.
- [ ] Hover a card: its checkbox slides in; title shifts right smoothly.
- [ ] Select a card via its checkbox: all cards show their checkbox (batch mode visible).
- [ ] Uncheck the selection and move the mouse away: checkboxes collapse, no stuck/visible checkbox on the previously selected card.
- [ ] Scroll a long list: header and toolbar remain sticky; batch bar floats correctly when selections exist.