### PR TITLE
fix(files): fall back to global file service when tenant storage config is unavailable

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -33,6 +33,7 @@ type RouterParams struct {
 	dig.In
 
 	Config                   *config.Config
+	FileService              interfaces.FileService
 	UserService              interfaces.UserService
 	KBService                interfaces.KnowledgeBaseService
 	KnowledgeService         interfaces.KnowledgeService
@@ -118,7 +119,7 @@ func NewRouter(params RouterParams) *gin.Engine {
 	r.Use(middleware.Auth(params.TenantService, params.UserService, params.Config))
 
 	// 文件服务：统一代理本地/MinIO/COS/TOS存储后端（需要认证）
-	serveFiles(r)
+	serveFiles(r, params.FileService)
 
 	// 添加OpenTelemetry追踪中间件
 	// r.Use(middleware.TracingMiddleware())
@@ -729,7 +730,11 @@ func serveFrontendStatic(r *gin.Engine) {
 //
 // Route:
 //   - /files?file_path=<provider://...>
-func serveFiles(r *gin.Engine) {
+type getRouteRegistrar interface {
+	GET(string, ...gin.HandlerFunc) gin.IRoutes
+}
+
+func serveFiles(r getRouteRegistrar, globalFileService interfaces.FileService) {
 	baseDir := os.Getenv("LOCAL_STORAGE_BASE_DIR")
 	if baseDir == "" {
 		baseDir = "/data/files"
@@ -762,11 +767,31 @@ func serveFiles(r *gin.Engine) {
 			return
 		}
 
-		fileSvc, resolvedProvider, err := filesvc.NewFileServiceFromStorageConfig(provider, tenant.StorageEngineConfig, absDir)
+		var (
+			fileSvc          interfaces.FileService
+			resolvedProvider string
+			err              error
+		)
+
+		if tenant.StorageEngineConfig != nil {
+			fileSvc, resolvedProvider, err = filesvc.NewFileServiceFromStorageConfig(provider, tenant.StorageEngineConfig, absDir)
+		} else {
+			err = http.ErrMissingFile
+		}
 		if err != nil {
-			logger.Warnf(context.Background(), "[Router] /files resolve file service failed: tenant_id=%d provider=%s err=%v", tenant.ID, provider, err)
-			c.Status(http.StatusBadRequest)
-			return
+			globalStorageType := strings.ToLower(strings.TrimSpace(os.Getenv("STORAGE_TYPE")))
+			if globalStorageType == "" {
+				globalStorageType = "local"
+			}
+			if provider == globalStorageType && globalFileService != nil {
+				logger.Warnf(context.Background(), "[Router] /files tenant storage config missing or invalid, fallback to global file service: tenant_id=%d provider=%s err=%v", tenant.ID, provider, err)
+				fileSvc = globalFileService
+				resolvedProvider = globalStorageType
+			} else {
+				logger.Warnf(context.Background(), "[Router] /files resolve file service failed without fallback: tenant_id=%d provider=%s global_storage_type=%s err=%v", tenant.ID, provider, globalStorageType, err)
+				c.Status(http.StatusBadRequest)
+				return
+			}
 		}
 
 		reader, err := fileSvc.GetFile(c.Request.Context(), filePath)

--- a/internal/router/router_files_test.go
+++ b/internal/router/router_files_test.go
@@ -1,0 +1,104 @@
+package router
+
+import (
+	"context"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+var _ interfaces.FileService = (*stubFileService)(nil)
+
+type stubFileService struct {
+	getFile func(ctx context.Context, filePath string) (io.ReadCloser, error)
+}
+
+func (s *stubFileService) CheckConnectivity(ctx context.Context) error {
+	return nil
+}
+
+func (s *stubFileService) SaveFile(ctx context.Context, file *multipart.FileHeader, tenantID uint64, knowledgeID string) (string, error) {
+	panic("unexpected call to SaveFile")
+}
+
+func (s *stubFileService) SaveBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error) {
+	panic("unexpected call to SaveBytes")
+}
+
+func (s *stubFileService) GetFile(ctx context.Context, filePath string) (io.ReadCloser, error) {
+	if s.getFile == nil {
+		panic("unexpected call to GetFile")
+	}
+	return s.getFile(ctx, filePath)
+}
+
+func (s *stubFileService) GetFileURL(ctx context.Context, filePath string) (string, error) {
+	panic("unexpected call to GetFileURL")
+}
+
+func (s *stubFileService) DeleteFile(ctx context.Context, filePath string) error {
+	panic("unexpected call to DeleteFile")
+}
+
+func TestServeFilesFallsBackToGlobalFileService(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("STORAGE_TYPE", "local")
+
+	engine := gin.New()
+	var requestedPath string
+	serveFiles(engine, &stubFileService{
+		getFile: func(ctx context.Context, filePath string) (io.ReadCloser, error) {
+			requestedPath = filePath
+			return io.NopCloser(strings.NewReader("fallback-body")), nil
+		},
+	})
+
+	filePath := "local://docs/example.txt"
+	req := httptest.NewRequest(http.MethodGet, "/files?file_path="+url.QueryEscape(filePath), nil)
+	req = req.WithContext(context.WithValue(req.Context(), types.TenantInfoContextKey, &types.Tenant{ID: 42}))
+
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, req)
+
+	if got, want := recorder.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	if requestedPath != filePath {
+		t.Fatalf("requested path = %q, want %q", requestedPath, filePath)
+	}
+	if body := recorder.Body.String(); body != "fallback-body" {
+		t.Fatalf("body = %q, want %q", body, "fallback-body")
+	}
+}
+
+func TestServeFilesDoesNotFallbackWhenProviderDoesNotMatchGlobalStorage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("STORAGE_TYPE", "minio")
+
+	engine := gin.New()
+	serveFiles(engine, &stubFileService{
+		getFile: func(ctx context.Context, filePath string) (io.ReadCloser, error) {
+			t.Fatalf("GetFile should not be called for mismatched provider, got %q", filePath)
+			return nil, nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/files?file_path="+url.QueryEscape("local://docs/example.txt"), nil)
+	req = req.WithContext(context.WithValue(req.Context(), types.TenantInfoContextKey, &types.Tenant{ID: 42}))
+
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, req)
+
+	if got, want := recorder.Code, http.StatusBadRequest; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds a safe fallback for `/files` when a tenant does not have a storage engine configuration, but the requested provider matches the globally configured storage backend.

## Changes

- inject the global file service into the router
- keep the existing tenant-specific storage resolution path when tenant storage config is present
- fall back to the global file service when tenant storage config is missing or unavailable and the provider matches `STORAGE_TYPE`
- keep returning `400` when no safe fallback is available
- add focused router tests for fallback and non-fallback behavior

## Why

In some deployments, `/files` requests may still be valid even when tenant storage configuration is missing. Without a fallback, those requests fail even though the global storage backend is correctly configured and available.

## Testing

- added focused router tests for:
  - successful fallback to the global file service
  - rejection when the requested provider does not match the global storage backend
- full `go test` was not completed in my environment because dependency downloads from `proxy.golang.org` timed out

## Notes

- this PR only keeps the generic `/files` fallback behavior
- deployment-specific or company-specific storage changes are not included
