### PR TITLE
fix(auth): move OIDC callback results to one-time exchange tickets

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -6,7 +6,7 @@ import { MessagePlugin } from 'tdesign-vue-next'
 import ManualKnowledgeEditor from '@/components/manual-knowledge-editor.vue'
 import { useAuthStore } from '@/stores/auth'
 import { useSettingsStore } from '@/stores/settings'
-import { getCurrentUser } from '@/api/auth'
+import { exchangeOIDCCallbackTicket, getCurrentUser } from '@/api/auth'
 
 // TDesign locale configs
 import enUSConfig from 'tdesign-vue-next/esm/locale/en_US'
@@ -95,9 +95,10 @@ const handleGlobalOIDCCallback = async () => {
   const params = new URLSearchParams(hash)
   const oidcError = params.get('oidc_error')
   const oidcErrorDescription = params.get('oidc_error_description')
+  const oidcCallbackTicket = params.get('oidc_callback_ticket')
   const oidcResult = params.get('oidc_result')
 
-  if (!oidcError && !oidcResult) return
+  if (!oidcError && !oidcCallbackTicket && !oidcResult) return
 
   if (oidcError) {
     clearOIDCCallbackState('/login')
@@ -107,14 +108,18 @@ const handleGlobalOIDCCallback = async () => {
   }
 
   try {
-    if (!oidcResult) {
+    let response: any
+
+    if (oidcCallbackTicket) {
+      response = await exchangeOIDCCallbackTicket(oidcCallbackTicket)
+    } else if (oidcResult) {
+      response = decodeOIDCResult(oidcResult)
+    } else {
       clearOIDCCallbackState('/login')
       await router.replace('/login')
       MessagePlugin.error('OIDC login failed')
       return
     }
-
-    const response = decodeOIDCResult(oidcResult)
     if (response.success) {
       clearOIDCCallbackState('/')
       MessagePlugin.success('Login successful')

--- a/frontend/src/api/auth/index.ts
+++ b/frontend/src/api/auth/index.ts
@@ -39,6 +39,10 @@ export interface LoginResponse {
   refresh_token?: string
 }
 
+export interface OIDCCallbackResponse extends LoginResponse {
+  is_new_user?: boolean
+}
+
 export interface OIDCAuthURLResponse {
   success: boolean
   authorization_url?: string
@@ -51,6 +55,10 @@ export interface OIDCConfigResponse {
   enabled: boolean
   provider_display_name?: string
   message?: string
+}
+
+export interface OIDCCallbackExchangeRequest {
+  ticket: string
 }
 
 // 用户注册接口
@@ -170,6 +178,18 @@ export async function getOIDCConfig(): Promise<OIDCConfigResponse> {
     return {
       success: false,
       enabled: false,
+      message: error.message || t('error.auth.loginFailed')
+    }
+  }
+}
+
+export async function exchangeOIDCCallbackTicket(ticket: string): Promise<OIDCCallbackResponse> {
+  try {
+    const response = await post('/api/v1/auth/oidc/callback/exchange', { ticket } as OIDCCallbackExchangeRequest)
+    return response as unknown as OIDCCallbackResponse
+  } catch (error: any) {
+    return {
+      success: false,
       message: error.message || t('error.auth.loginFailed')
     }
   }

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/errors"
@@ -23,9 +24,10 @@ import (
 // Provides functionality for user registration, login, logout, and token management
 // through the REST API endpoints
 type AuthHandler struct {
-	userService   interfaces.UserService
-	tenantService interfaces.TenantService
-	configInfo    *config.Config
+	userService     interfaces.UserService
+	tenantService   interfaces.TenantService
+	configInfo      *config.Config
+	oidcTicketStore oidcCallbackTicketStore
 }
 
 // NewAuthHandler creates a new auth handler instance with the provided services
@@ -35,11 +37,12 @@ type AuthHandler struct {
 //
 // Returns a pointer to the newly created AuthHandler
 func NewAuthHandler(configInfo *config.Config,
-	userService interfaces.UserService, tenantService interfaces.TenantService) *AuthHandler {
+	userService interfaces.UserService, tenantService interfaces.TenantService, redisClient *redis.Client) *AuthHandler {
 	return &AuthHandler{
-		configInfo:    configInfo,
-		userService:   userService,
-		tenantService: tenantService,
+		configInfo:      configInfo,
+		userService:     userService,
+		tenantService:   tenantService,
+		oidcTicketStore: newOIDCCallbackTicketStore(redisClient),
 	}
 }
 
@@ -265,14 +268,14 @@ func (h *AuthHandler) OIDCRedirectCallback(c *gin.Context) {
 		return
 	}
 
-	payload, err := encodeOIDCCallbackPayload(resp)
+	ticket, err := h.oidcTicketStore.Save(ctx, resp)
 	if err != nil {
-		logger.Errorf(ctx, "Failed to encode OIDC callback payload: %v", err)
-		c.Redirect(http.StatusFound, frontendRedirectURI+"#oidc_error="+urlQueryEscape("payload_encode_failed"))
+		logger.Errorf(ctx, "Failed to persist OIDC callback ticket: %v", err)
+		c.Redirect(http.StatusFound, frontendRedirectURI+"#oidc_error="+urlQueryEscape("callback_ticket_store_failed"))
 		return
 	}
 
-	c.Redirect(http.StatusFound, frontendRedirectURI+"#oidc_result="+urlQueryEscape(payload))
+	c.Redirect(http.StatusFound, frontendRedirectURI+"#oidc_callback_ticket="+urlQueryEscape(ticket))
 }
 
 func encodeOIDCCallbackPayload(resp *types.OIDCCallbackResponse) (string, error) {
@@ -314,6 +317,48 @@ func urlQueryEscape(value string) string {
 		"?", "%3F",
 	)
 	return replacer.Replace(value)
+}
+
+// ExchangeOIDCCallbackTicket godoc
+// @Summary      Exchange OIDC callback ticket
+// @Description  Exchanges a one-time OIDC callback ticket for the stored OIDC login result
+// @Tags         认证
+// @Accept       json
+// @Produce      json
+// @Param        request  body      types.OIDCCallbackExchangeRequest  true  "OIDC callback ticket"
+// @Success      200      {object}  types.OIDCCallbackResponse
+// @Failure      400      {object}  errors.AppError  "请求参数错误"
+// @Failure      410      {object}  types.OIDCCallbackResponse  "ticket invalid or expired"
+// @Router       /auth/oidc/callback/exchange [post]
+func (h *AuthHandler) ExchangeOIDCCallbackTicket(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	var req types.OIDCCallbackExchangeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		appErr := errors.NewValidationError("Invalid OIDC callback ticket request").WithDetails(err.Error())
+		c.Error(appErr)
+		return
+	}
+
+	resp, err := h.oidcTicketStore.Consume(ctx, req.Ticket)
+	if err != nil {
+		if err == errOIDCCallbackTicketNotFound {
+			c.JSON(http.StatusGone, &types.OIDCCallbackResponse{
+				Success: false,
+				Message: err.Error(),
+			})
+			return
+		}
+
+		logger.Errorf(ctx, "Failed to exchange OIDC callback ticket: %v", err)
+		c.JSON(http.StatusInternalServerError, &types.OIDCCallbackResponse{
+			Success: false,
+			Message: "Failed to exchange OIDC callback ticket",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
 }
 
 // Logout godoc

--- a/internal/handler/auth_oidc_test.go
+++ b/internal/handler/auth_oidc_test.go
@@ -1,0 +1,248 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestOIDCRedirectCallbackUsesTicketRedirect(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := newOIDCCallbackTicketStore(nil)
+	handler := &AuthHandler{
+		userService: &testUserService{
+			loginWithOIDC: func(ctx context.Context, code, redirectURI string) (*types.OIDCCallbackResponse, error) {
+				if code != "auth-code" {
+					t.Fatalf("code = %q, want %q", code, "auth-code")
+				}
+				return &types.OIDCCallbackResponse{
+					Success:      true,
+					Token:        "access-token",
+					RefreshToken: "refresh-token",
+				}, nil
+			},
+		},
+		oidcTicketStore: store,
+	}
+
+	state := mustEncodeOIDCState(t, &oidcStatePayload{
+		Nonce:       "nonce",
+		RedirectURI: "https://kb.uimpcloud.com/api/v1/auth/oidc/callback",
+	})
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/callback?code=auth-code&state="+url.QueryEscape(state), nil)
+
+	handler.OIDCRedirectCallback(ctx)
+
+	if got, want := recorder.Code, http.StatusFound; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+
+	location := recorder.Header().Get("Location")
+	if !strings.HasPrefix(location, "/#oidc_callback_ticket=") {
+		t.Fatalf("Location = %q, want oidc_callback_ticket redirect", location)
+	}
+	if strings.Contains(location, "oidc_result=") {
+		t.Fatalf("Location = %q, should not contain legacy oidc_result", location)
+	}
+
+	ticket := strings.TrimPrefix(location, "/#oidc_callback_ticket=")
+	resp, err := store.Consume(context.Background(), ticket)
+	if err != nil {
+		t.Fatalf("Consume() error = %v", err)
+	}
+	if got, want := resp.Token, "access-token"; got != want {
+		t.Fatalf("stored token = %q, want %q", got, want)
+	}
+}
+
+func TestExchangeOIDCCallbackTicketSingleUse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := newOIDCCallbackTicketStore(nil)
+	ticket, err := store.Save(context.Background(), &types.OIDCCallbackResponse{
+		Success:      true,
+		Token:        "access-token",
+		RefreshToken: "refresh-token",
+	})
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	handler := &AuthHandler{oidcTicketStore: store}
+
+	first := performOIDCTicketExchange(t, handler, ticket)
+	if got, want := first.Code, http.StatusOK; got != want {
+		t.Fatalf("first exchange status = %d, want %d", got, want)
+	}
+
+	var successResp types.OIDCCallbackResponse
+	if err := json.Unmarshal(first.Body.Bytes(), &successResp); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if !successResp.Success || successResp.Token != "access-token" {
+		t.Fatalf("first exchange body = %+v, want success with token", successResp)
+	}
+
+	second := performOIDCTicketExchange(t, handler, ticket)
+	if got, want := second.Code, http.StatusGone; got != want {
+		t.Fatalf("second exchange status = %d, want %d", got, want)
+	}
+
+	var goneResp types.OIDCCallbackResponse
+	if err := json.Unmarshal(second.Body.Bytes(), &goneResp); err != nil {
+		t.Fatalf("json.Unmarshal() second error = %v", err)
+	}
+	if goneResp.Success {
+		t.Fatalf("second exchange success = true, want false")
+	}
+}
+
+func TestExchangeOIDCCallbackTicketExpired(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	now := time.Now()
+	store := &redisOIDCCallbackTicketStore{
+		fallback: &memoryOIDCCallbackTicketStore{
+			entries: make(map[string]memoryOIDCCallbackTicketEntry),
+			ttl:     time.Minute,
+			now:     func() time.Time { return now },
+		},
+	}
+
+	ticket, err := store.Save(context.Background(), &types.OIDCCallbackResponse{
+		Success: true,
+		Token:   "access-token",
+	})
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	now = now.Add(2 * time.Minute)
+
+	handler := &AuthHandler{oidcTicketStore: store}
+	recorder := performOIDCTicketExchange(t, handler, ticket)
+	if got, want := recorder.Code, http.StatusGone; got != want {
+		t.Fatalf("expired exchange status = %d, want %d", got, want)
+	}
+}
+
+func performOIDCTicketExchange(t *testing.T, handler *AuthHandler, ticket string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body, err := json.Marshal(&types.OIDCCallbackExchangeRequest{Ticket: ticket})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/v1/auth/oidc/callback/exchange", bytes.NewReader(body))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	handler.ExchangeOIDCCallbackTicket(ctx)
+	return recorder
+}
+
+func mustEncodeOIDCState(t *testing.T, payload *oidcStatePayload) string {
+	t.Helper()
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+type testUserService struct {
+	loginWithOIDC func(ctx context.Context, code, redirectURI string) (*types.OIDCCallbackResponse, error)
+}
+
+func (s *testUserService) Register(ctx context.Context, req *types.RegisterRequest) (*types.User, error) {
+	panic("unexpected call to Register")
+}
+
+func (s *testUserService) Login(ctx context.Context, req *types.LoginRequest) (*types.LoginResponse, error) {
+	panic("unexpected call to Login")
+}
+
+func (s *testUserService) GetOIDCAuthorizationURL(ctx context.Context, redirectURI string) (*types.OIDCAuthURLResponse, error) {
+	panic("unexpected call to GetOIDCAuthorizationURL")
+}
+
+func (s *testUserService) LoginWithOIDC(ctx context.Context, code, redirectURI string) (*types.OIDCCallbackResponse, error) {
+	if s.loginWithOIDC == nil {
+		panic("unexpected call to LoginWithOIDC")
+	}
+	return s.loginWithOIDC(ctx, code, redirectURI)
+}
+
+func (s *testUserService) GetUserByID(ctx context.Context, id string) (*types.User, error) {
+	panic("unexpected call to GetUserByID")
+}
+
+func (s *testUserService) GetUserByEmail(ctx context.Context, email string) (*types.User, error) {
+	panic("unexpected call to GetUserByEmail")
+}
+
+func (s *testUserService) GetUserByUsername(ctx context.Context, username string) (*types.User, error) {
+	panic("unexpected call to GetUserByUsername")
+}
+
+func (s *testUserService) GetUserByTenantID(ctx context.Context, tenantID uint64) (*types.User, error) {
+	panic("unexpected call to GetUserByTenantID")
+}
+
+func (s *testUserService) UpdateUser(ctx context.Context, user *types.User) error {
+	panic("unexpected call to UpdateUser")
+}
+
+func (s *testUserService) DeleteUser(ctx context.Context, id string) error {
+	panic("unexpected call to DeleteUser")
+}
+
+func (s *testUserService) ChangePassword(ctx context.Context, userID string, oldPassword, newPassword string) error {
+	panic("unexpected call to ChangePassword")
+}
+
+func (s *testUserService) ValidatePassword(ctx context.Context, userID string, password string) error {
+	panic("unexpected call to ValidatePassword")
+}
+
+func (s *testUserService) GenerateTokens(ctx context.Context, user *types.User) (accessToken, refreshToken string, err error) {
+	panic("unexpected call to GenerateTokens")
+}
+
+func (s *testUserService) ValidateToken(ctx context.Context, token string) (*types.User, error) {
+	panic("unexpected call to ValidateToken")
+}
+
+func (s *testUserService) RefreshToken(ctx context.Context, refreshToken string) (accessToken, newRefreshToken string, err error) {
+	panic("unexpected call to RefreshToken")
+}
+
+func (s *testUserService) RevokeToken(ctx context.Context, token string) error {
+	panic("unexpected call to RevokeToken")
+}
+
+func (s *testUserService) GetCurrentUser(ctx context.Context) (*types.User, error) {
+	panic("unexpected call to GetCurrentUser")
+}
+
+func (s *testUserService) SearchUsers(ctx context.Context, query string, limit int) ([]*types.User, error) {
+	panic("unexpected call to SearchUsers")
+}

--- a/internal/handler/oidc_ticket_store.go
+++ b/internal/handler/oidc_ticket_store.go
@@ -1,0 +1,185 @@
+package handler
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+const (
+	oidcCallbackTicketTTL         = 5 * time.Minute
+	oidcCallbackTicketBytes       = 32
+	oidcCallbackTicketRedisPrefix = "auth:oidc:callback:"
+)
+
+var errOIDCCallbackTicketNotFound = errors.New("OIDC callback ticket is invalid or expired")
+
+type oidcCallbackTicketStore interface {
+	Save(ctx context.Context, resp *types.OIDCCallbackResponse) (string, error)
+	Consume(ctx context.Context, ticket string) (*types.OIDCCallbackResponse, error)
+}
+
+func newOIDCCallbackTicketStore(redisClient *redis.Client) oidcCallbackTicketStore {
+	return &redisOIDCCallbackTicketStore{
+		redisClient: redisClient,
+		fallback: &memoryOIDCCallbackTicketStore{
+			entries: make(map[string]memoryOIDCCallbackTicketEntry),
+			ttl:     oidcCallbackTicketTTL,
+			now:     time.Now,
+		},
+	}
+}
+
+type redisOIDCCallbackTicketStore struct {
+	redisClient *redis.Client
+	fallback    *memoryOIDCCallbackTicketStore
+}
+
+func (s *redisOIDCCallbackTicketStore) Save(ctx context.Context, resp *types.OIDCCallbackResponse) (string, error) {
+	payload, err := json.Marshal(resp)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode OIDC callback response: %w", err)
+	}
+
+	ticket, err := generateOIDCCallbackTicket()
+	if err != nil {
+		return "", fmt.Errorf("failed to generate OIDC callback ticket: %w", err)
+	}
+
+	if s.redisClient != nil {
+		if err := s.redisClient.Set(ctx, s.redisKey(ticket), payload, oidcCallbackTicketTTL).Err(); err == nil {
+			return ticket, nil
+		} else {
+			logger.Warnf(ctx, "OIDC callback ticket Redis store unavailable, falling back to in-memory store: %v", err)
+		}
+	}
+
+	if err := s.fallback.SavePayload(ticket, payload); err != nil {
+		return "", err
+	}
+
+	return ticket, nil
+}
+
+func (s *redisOIDCCallbackTicketStore) Consume(ctx context.Context, ticket string) (*types.OIDCCallbackResponse, error) {
+	ticket = strings.TrimSpace(ticket)
+	if ticket == "" {
+		return nil, errOIDCCallbackTicketNotFound
+	}
+
+	if s.redisClient != nil {
+		payload, err := s.redisClient.GetDel(ctx, s.redisKey(ticket)).Bytes()
+		switch {
+		case err == nil:
+			return decodeOIDCCallbackTicketPayload(payload)
+		case errors.Is(err, redis.Nil):
+		default:
+			logger.Warnf(ctx, "OIDC callback ticket Redis consume failed, trying in-memory fallback: %v", err)
+			if payload, ok, fallbackErr := s.fallback.ConsumePayload(ticket); fallbackErr == nil && ok {
+				return decodeOIDCCallbackTicketPayload(payload)
+			}
+			return nil, fmt.Errorf("failed to consume OIDC callback ticket: %w", err)
+		}
+	}
+
+	payload, ok, err := s.fallback.ConsumePayload(ticket)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, errOIDCCallbackTicketNotFound
+	}
+
+	return decodeOIDCCallbackTicketPayload(payload)
+}
+
+func (s *redisOIDCCallbackTicketStore) redisKey(ticket string) string {
+	return oidcCallbackTicketRedisPrefix + ticket
+}
+
+type memoryOIDCCallbackTicketStore struct {
+	mu      sync.Mutex
+	entries map[string]memoryOIDCCallbackTicketEntry
+	ttl     time.Duration
+	now     func() time.Time
+}
+
+type memoryOIDCCallbackTicketEntry struct {
+	payload   []byte
+	expiresAt time.Time
+}
+
+func (s *memoryOIDCCallbackTicketStore) SavePayload(ticket string, payload []byte) error {
+	if s == nil {
+		return errors.New("OIDC callback ticket store is not initialized")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	s.cleanupExpiredLocked(now)
+	s.entries[ticket] = memoryOIDCCallbackTicketEntry{
+		payload:   append([]byte(nil), payload...),
+		expiresAt: now.Add(s.ttl),
+	}
+	return nil
+}
+
+func (s *memoryOIDCCallbackTicketStore) ConsumePayload(ticket string) ([]byte, bool, error) {
+	if s == nil {
+		return nil, false, errors.New("OIDC callback ticket store is not initialized")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	s.cleanupExpiredLocked(now)
+
+	entry, ok := s.entries[ticket]
+	if !ok {
+		return nil, false, nil
+	}
+	delete(s.entries, ticket)
+	if !entry.expiresAt.After(now) {
+		return nil, false, nil
+	}
+
+	return append([]byte(nil), entry.payload...), true, nil
+}
+
+func (s *memoryOIDCCallbackTicketStore) cleanupExpiredLocked(now time.Time) {
+	for ticket, entry := range s.entries {
+		if !entry.expiresAt.After(now) {
+			delete(s.entries, ticket)
+		}
+	}
+}
+
+func decodeOIDCCallbackTicketPayload(payload []byte) (*types.OIDCCallbackResponse, error) {
+	var resp types.OIDCCallbackResponse
+	if err := json.Unmarshal(payload, &resp); err != nil {
+		return nil, fmt.Errorf("failed to decode OIDC callback response: %w", err)
+	}
+	return &resp, nil
+}
+
+func generateOIDCCallbackTicket() (string, error) {
+	buffer := make([]byte, oidcCallbackTicketBytes)
+	if _, err := rand.Read(buffer); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buffer), nil
+}

--- a/internal/handler/oidc_ticket_store_test.go
+++ b/internal/handler/oidc_ticket_store_test.go
@@ -1,0 +1,78 @@
+package handler
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestMemoryOIDCCallbackTicketStoreConsumeOnce(t *testing.T) {
+	now := time.Now()
+	store := &memoryOIDCCallbackTicketStore{
+		entries: make(map[string]memoryOIDCCallbackTicketEntry),
+		ttl:     time.Minute,
+		now:     func() time.Time { return now },
+	}
+
+	payload, err := json.Marshal(&types.OIDCCallbackResponse{
+		Success:      true,
+		Token:        "access-token",
+		RefreshToken: "refresh-token",
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	if err := store.SavePayload("ticket-1", payload); err != nil {
+		t.Fatalf("SavePayload() error = %v", err)
+	}
+
+	got, ok, err := store.ConsumePayload("ticket-1")
+	if err != nil {
+		t.Fatalf("ConsumePayload() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("ConsumePayload() ok = false, want true")
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("ConsumePayload() payload = %q, want %q", string(got), string(payload))
+	}
+
+	_, ok, err = store.ConsumePayload("ticket-1")
+	if err != nil {
+		t.Fatalf("ConsumePayload() second call error = %v", err)
+	}
+	if ok {
+		t.Fatalf("ConsumePayload() second call ok = true, want false")
+	}
+}
+
+func TestMemoryOIDCCallbackTicketStoreExpires(t *testing.T) {
+	now := time.Now()
+	store := &memoryOIDCCallbackTicketStore{
+		entries: make(map[string]memoryOIDCCallbackTicketEntry),
+		ttl:     time.Minute,
+		now:     func() time.Time { return now },
+	}
+
+	payload, err := json.Marshal(&types.OIDCCallbackResponse{Success: true, Token: "access-token"})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	if err := store.SavePayload("ticket-1", payload); err != nil {
+		t.Fatalf("SavePayload() error = %v", err)
+	}
+
+	now = now.Add(2 * time.Minute)
+
+	_, ok, err = store.ConsumePayload("ticket-1")
+	if err != nil {
+		t.Fatalf("ConsumePayload() error = %v", err)
+	}
+	if ok {
+		t.Fatalf("ConsumePayload() ok = true, want false for expired ticket")
+	}
+}

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -19,14 +19,15 @@ import (
 
 // 无需认证的API列表
 var noAuthAPI = map[string][]string{
-	"/health":                    {"GET"},
-	"/api/v1/auth/register":      {"POST"},
-	"/api/v1/auth/login":         {"POST"},
-	"/api/v1/auth/auto-setup":    {"POST"},
-	"/api/v1/auth/oidc/config":   {"GET"},
-	"/api/v1/auth/oidc/url":      {"GET"},
-	"/api/v1/auth/oidc/callback": {"GET"},
-	"/api/v1/auth/refresh":       {"POST"},
+	"/health":                             {"GET"},
+	"/api/v1/auth/register":               {"POST"},
+	"/api/v1/auth/login":                  {"POST"},
+	"/api/v1/auth/auto-setup":             {"POST"},
+	"/api/v1/auth/oidc/config":            {"GET"},
+	"/api/v1/auth/oidc/url":               {"GET"},
+	"/api/v1/auth/oidc/callback":          {"GET"},
+	"/api/v1/auth/oidc/callback/exchange": {"POST"},
+	"/api/v1/auth/refresh":                {"POST"},
 }
 
 // 检查请求是否在无需认证的API列表中

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -415,6 +415,7 @@ func RegisterAuthRoutes(r *gin.RouterGroup, handler *handler.AuthHandler) {
 	r.GET("/auth/oidc/config", handler.GetOIDCConfig)
 	r.GET("/auth/oidc/url", handler.GetOIDCAuthorizationURL)
 	r.GET("/auth/oidc/callback", handler.OIDCRedirectCallback)
+	r.POST("/auth/oidc/callback/exchange", handler.ExchangeOIDCCallbackTicket)
 	r.POST("/auth/refresh", handler.RefreshToken)
 	r.GET("/auth/validate", handler.ValidateToken)
 	r.POST("/auth/logout", handler.Logout)

--- a/internal/types/user.go
+++ b/internal/types/user.go
@@ -87,6 +87,10 @@ type OIDCCallbackResponse struct {
 	IsNewUser    bool    `json:"is_new_user,omitempty"`
 }
 
+type OIDCCallbackExchangeRequest struct {
+	Ticket string `json:"ticket" binding:"required"`
+}
+
 type OIDCUserInfo struct {
 	Subject  string                 `json:"subject,omitempty"`
 	Username string                 `json:"username,omitempty"`


### PR DESCRIPTION
## Summary

This PR moves OIDC callback results out of the browser URL fragment and into a one-time server-side exchange ticket.

## Changes

- store OIDC callback results server-side with a short TTL
- add `POST /api/v1/auth/oidc/callback/exchange`
- redirect the frontend with `oidc_callback_ticket` instead of serialized `oidc_result`
- keep frontend compatibility with the legacy `oidc_result` flow
- add focused tests for single-use and expiry behavior

## Why

OIDC callback payloads may contain tokens or sensitive login state. Returning the full result in the URL fragment is brittle and unnecessarily exposes that data in the browser.

## Testing

- added focused handler/store tests for redirect, single-use exchange, and expiry
- full `go test` was not completed in my environment because dependency downloads from `proxy.golang.org` timed out

## Notes

- this PR does not include deployment-specific or company-specific changes
