### PR TITLE
fix(crypto): fail loudly when encrypted DB fields cannot be decrypted

### DIFF
--- a/internal/types/model.go
+++ b/internal/types/model.go
@@ -3,6 +3,7 @@ package types
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/Tencent/WeKnora/internal/utils"
@@ -139,18 +140,16 @@ func (c *ModelParameters) Scan(value interface{}) error {
 	if err := json.Unmarshal(b, c); err != nil {
 		return err
 	}
-	if key := utils.GetAESKey(); key != nil {
-		if c.APIKey != "" {
-			if decrypted, err := utils.DecryptAESGCM(c.APIKey, key); err == nil {
-				c.APIKey = decrypted
-			}
-		}
-		if c.AppSecret != "" {
-			if decrypted, err := utils.DecryptAESGCM(c.AppSecret, key); err == nil {
-				c.AppSecret = decrypted
-			}
-		}
+	apiKey, err := utils.DecryptStoredSecret(c.APIKey)
+	if err != nil {
+		return fmt.Errorf("decrypt model parameters api_key: %w", err)
 	}
+	c.APIKey = apiKey
+	appSecret, err := utils.DecryptStoredSecret(c.AppSecret)
+	if err != nil {
+		return fmt.Errorf("decrypt model parameters app_secret: %w", err)
+	}
+	c.AppSecret = appSecret
 	return nil
 }
 

--- a/internal/types/tenant.go
+++ b/internal/types/tenant.go
@@ -150,13 +150,16 @@ func (t *Tenant) BeforeSave(tx *gorm.DB) error {
 }
 
 // AfterFind decrypts APIKey after loading from database.
-// Legacy plaintext (without enc:v1: prefix) is returned as-is.
+// Legacy plaintext (without enc:v1: prefix) is returned as-is. When the value
+// is encrypted but SYSTEM_AES_KEY is missing/rotated and the data cannot be
+// decrypted, the error is propagated so the read fails loudly instead of
+// returning ciphertext to callers.
 func (t *Tenant) AfterFind(tx *gorm.DB) error {
-	if key := utils.GetAESKey(); key != nil && t.APIKey != "" {
-		if decrypted, err := utils.DecryptAESGCM(t.APIKey, key); err == nil {
-			t.APIKey = decrypted
-		}
+	decrypted, err := utils.DecryptStoredSecret(t.APIKey)
+	if err != nil {
+		return fmt.Errorf("decrypt tenants.api_key (id=%d): %w", t.ID, err)
 	}
+	t.APIKey = decrypted
 	return nil
 }
 
@@ -299,12 +302,12 @@ func (c *CredentialsConfig) Scan(value interface{}) error {
 	if err := json.Unmarshal(b, c); err != nil {
 		return err
 	}
-	if c.WeKnoraCloud != nil && c.WeKnoraCloud.AppSecret != "" {
-		if key := utils.GetAESKey(); key != nil {
-			if decrypted, err := utils.DecryptAESGCM(c.WeKnoraCloud.AppSecret, key); err == nil {
-				c.WeKnoraCloud.AppSecret = decrypted
-			}
+	if c.WeKnoraCloud != nil {
+		decrypted, err := utils.DecryptStoredSecret(c.WeKnoraCloud.AppSecret)
+		if err != nil {
+			return fmt.Errorf("decrypt tenant credentials we_knora_cloud.app_secret: %w", err)
 		}
+		c.WeKnoraCloud.AppSecret = decrypted
 	}
 	return nil
 }

--- a/internal/types/vectorstore.go
+++ b/internal/types/vectorstore.go
@@ -151,18 +151,16 @@ func (c *ConnectionConfig) Scan(value interface{}) error {
 	if err := json.Unmarshal(b, c); err != nil {
 		return err
 	}
-	if key := utils.GetAESKey(); key != nil {
-		if c.Password != "" {
-			if decrypted, err := utils.DecryptAESGCM(c.Password, key); err == nil {
-				c.Password = decrypted
-			}
-		}
-		if c.APIKey != "" {
-			if decrypted, err := utils.DecryptAESGCM(c.APIKey, key); err == nil {
-				c.APIKey = decrypted
-			}
-		}
+	password, err := utils.DecryptStoredSecret(c.Password)
+	if err != nil {
+		return fmt.Errorf("decrypt vector store connection password: %w", err)
 	}
+	c.Password = password
+	apiKey, err := utils.DecryptStoredSecret(c.APIKey)
+	if err != nil {
+		return fmt.Errorf("decrypt vector store connection api_key: %w", err)
+	}
+	c.APIKey = apiKey
 	return nil
 }
 

--- a/internal/types/web_search_provider.go
+++ b/internal/types/web_search_provider.go
@@ -3,6 +3,7 @@ package types
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/Tencent/WeKnora/internal/utils"
@@ -101,11 +102,11 @@ func (p *WebSearchProviderParameters) Scan(value interface{}) error {
 	if err := json.Unmarshal(b, p); err != nil {
 		return err
 	}
-	if key := utils.GetAESKey(); key != nil && p.APIKey != "" {
-		if decrypted, err := utils.DecryptAESGCM(p.APIKey, key); err == nil {
-			p.APIKey = decrypted
-		}
+	apiKey, err := utils.DecryptStoredSecret(p.APIKey)
+	if err != nil {
+		return fmt.Errorf("decrypt web search provider api_key: %w", err)
 	}
+	p.APIKey = apiKey
 	return nil
 }
 

--- a/internal/utils/crypto.go
+++ b/internal/utils/crypto.go
@@ -53,6 +53,13 @@ func EncryptAESGCM(plaintext string, key []byte) (string, error) {
 	return EncPrefix + base64.RawURLEncoding.EncodeToString(combined), nil
 }
 
+// ErrEncryptedDataMissingKey is returned by DecryptStoredSecret when the value
+// carries the enc:v1: prefix but no AES key is available to decrypt it. This
+// signals an operator misconfiguration (typically a rotated or unset
+// SYSTEM_AES_KEY) and must propagate so the system fails loudly instead of
+// silently using ciphertext as a credential.
+var ErrEncryptedDataMissingKey = errors.New("encrypted data found but SYSTEM_AES_KEY is not set or has wrong length")
+
 // DecryptAESGCM decrypts an AES-256-GCM encrypted string.
 // If the string lacks the enc:v1: prefix, it's treated as legacy plaintext and returned as-is.
 func DecryptAESGCM(encrypted string, key []byte) (string, error) {
@@ -86,4 +93,37 @@ func DecryptAESGCM(encrypted string, key []byte) (string, error) {
 		return "", err
 	}
 	return string(plaintext), nil
+}
+
+// DecryptStoredSecret decrypts a value loaded from the database with strict
+// error propagation. Use this from GORM Scan/AfterFind hooks for any field that
+// stores AES-encrypted secrets (API keys, passwords, app secrets).
+//
+// Behaviour:
+//   - empty input -> empty output, no error.
+//   - no enc:v1: prefix -> returned as-is (legacy plaintext column), no error.
+//   - has enc:v1: prefix and SYSTEM_AES_KEY is missing or wrong length ->
+//     returns ErrEncryptedDataMissingKey. Callers MUST propagate this so the
+//     load fails loudly instead of silently surfacing ciphertext as a credential.
+//   - has enc:v1: prefix and key is set -> decrypts, returns any decryption
+//     error verbatim (e.g. base64 decode failure, GCM auth tag mismatch from a
+//     rotated key).
+//
+// The previous lenient pattern (`if decrypted, err := ...; err == nil { ... }`)
+// hid the rotated-key case and caused the encrypted ciphertext to be sent
+// upstream as the actual API key, surfacing as 401/403 from third-party
+// vendors. Always prefer this helper over calling DecryptAESGCM directly when
+// loading from the database.
+func DecryptStoredSecret(encrypted string) (string, error) {
+	if encrypted == "" {
+		return "", nil
+	}
+	if !strings.HasPrefix(encrypted, EncPrefix) {
+		return encrypted, nil
+	}
+	key := GetAESKey()
+	if key == nil {
+		return "", ErrEncryptedDataMissingKey
+	}
+	return DecryptAESGCM(encrypted, key)
 }

--- a/internal/utils/crypto_test.go
+++ b/internal/utils/crypto_test.go
@@ -74,6 +74,70 @@ func TestDecryptAESGCM(t *testing.T) {
 	})
 }
 
+func TestDecryptStoredSecret(t *testing.T) {
+	t.Run("returns empty string as-is", func(t *testing.T) {
+		t.Setenv("SYSTEM_AES_KEY", testAESKey)
+		out, err := DecryptStoredSecret("")
+		require.NoError(t, err)
+		assert.Equal(t, "", out)
+	})
+
+	t.Run("legacy plaintext (no enc:v1: prefix) returned as-is", func(t *testing.T) {
+		t.Setenv("SYSTEM_AES_KEY", testAESKey)
+		out, err := DecryptStoredSecret("sk-legacy-plaintext")
+		require.NoError(t, err)
+		assert.Equal(t, "sk-legacy-plaintext", out)
+	})
+
+	t.Run("legacy plaintext is returned even when key is unset", func(t *testing.T) {
+		t.Setenv("SYSTEM_AES_KEY", "")
+		out, err := DecryptStoredSecret("sk-legacy-plaintext")
+		require.NoError(t, err)
+		assert.Equal(t, "sk-legacy-plaintext", out)
+	})
+
+	t.Run("round-trip with valid key", func(t *testing.T) {
+		t.Setenv("SYSTEM_AES_KEY", testAESKey)
+		encrypted, err := EncryptAESGCM("sk-secret", []byte(testAESKey))
+		require.NoError(t, err)
+
+		out, err := DecryptStoredSecret(encrypted)
+		require.NoError(t, err)
+		assert.Equal(t, "sk-secret", out)
+	})
+
+	t.Run("encrypted value with missing key returns ErrEncryptedDataMissingKey", func(t *testing.T) {
+		encrypted, err := EncryptAESGCM("sk-secret", []byte(testAESKey))
+		require.NoError(t, err)
+
+		t.Setenv("SYSTEM_AES_KEY", "")
+		out, err := DecryptStoredSecret(encrypted)
+		require.ErrorIs(t, err, ErrEncryptedDataMissingKey)
+		assert.Equal(t, "", out, "ciphertext must NOT leak when decryption is impossible")
+	})
+
+	t.Run("encrypted value with wrong-length key returns ErrEncryptedDataMissingKey", func(t *testing.T) {
+		encrypted, err := EncryptAESGCM("sk-secret", []byte(testAESKey))
+		require.NoError(t, err)
+
+		t.Setenv("SYSTEM_AES_KEY", "too-short")
+		out, err := DecryptStoredSecret(encrypted)
+		require.ErrorIs(t, err, ErrEncryptedDataMissingKey)
+		assert.Equal(t, "", out)
+	})
+
+	t.Run("encrypted value with rotated key returns auth-tag error", func(t *testing.T) {
+		encrypted, err := EncryptAESGCM("sk-secret", []byte(testAESKey))
+		require.NoError(t, err)
+
+		t.Setenv("SYSTEM_AES_KEY", "abcdefghijklmnopqrstuvwxyz123456")
+		out, err := DecryptStoredSecret(encrypted)
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, ErrEncryptedDataMissingKey, "should be a real auth failure, not the missing-key sentinel")
+		assert.Equal(t, "", out, "ciphertext must NOT leak when decryption fails")
+	})
+}
+
 func TestGetAESKey(t *testing.T) {
 	t.Run("returns key when SYSTEM_AES_KEY is 32 bytes", func(t *testing.T) {
 		t.Setenv("SYSTEM_AES_KEY", testAESKey)


### PR DESCRIPTION
## Background

While investigating a user report ("a model stops working once we mark
it as built-in, but adding the same config as a new model still
works") we re-walked the AES-256-GCM encryption path that secures
\`tenants.api_key\`, \`models.parameters.api_key\`/\`app_secret\`,
\`vector_store_connections.password\`/\`api_key\`,
\`web_search_providers.api_key\`, and \`tenants.we_knora_cloud.app_secret\`.

Every \`Scan\` / \`AfterFind\` hook used the same lenient pattern:

\`\`\`go
if decrypted, err := utils.DecryptAESGCM(c.APIKey, key); err == nil {
    c.APIKey = decrypted
}
\`\`\`

When \`SYSTEM_AES_KEY\` is missing, rotated, or the wrong length, the
GCM auth-tag failure is **swallowed** and the in-memory struct keeps
the original \`enc:v1:...\` ciphertext. The application then
forwards that ciphertext upstream as the actual credential. Two real
consequences:

1. **Looks like a transient vendor outage.** OpenAI / DeepSeek / etc.
   reject the request with 401/403/SignatureDoesNotMatch and the user
   sees "model can't be used" with no actionable error in our logs.
2. **Customer credential ciphertext leaks.** Each failed request
   pushes a fragment of an encrypted customer secret into the third
   party's access log, where we have no control over retention.

The companion bug in #1087 (Helm \`randAlphaNum\` rotating
\`SYSTEM_AES_KEY\` on every \`helm upgrade\`) makes this state extremely
easy to fall into in production.

## Change

Introduce \`utils.DecryptStoredSecret\` with strict semantics designed
for the GORM load path:

| Input | Behaviour |
| --- | --- |
| empty | \`\"\", nil\` |
| no \`enc:v1:\` prefix | returned as-is, \`nil\` (legacy plaintext rows) |
| has prefix, key missing/wrong length | \`ErrEncryptedDataMissingKey\` |
| has prefix, key set, decrypt fails | underlying error (e.g. GCM auth) |
| has prefix, key set, decrypt succeeds | plaintext, \`nil\` |

On any error path the helper returns \`\"\"\` so ciphertext can never
leak into the in-memory struct.

Five \`Scan\` / \`AfterFind\` sites now use it and propagate the wrapped
error including the originating column for log triage:

- \`Tenant.AfterFind\` -> \`tenants.api_key\`
- \`CredentialsConfig.Scan\` -> \`tenants.we_knora_cloud.app_secret\`
- \`ModelParameters.Scan\` -> \`models.parameters.api_key\`, \`.app_secret\`
- \`ConnectionConfig.Scan\` -> \`vector_store_connections.password\`, \`.api_key\`
- \`WebSearchProviderParameters.Scan\` -> \`web_search_providers.api_key\`

\`DecryptAESGCM\` itself is unchanged so existing test cases
documenting the lenient API (round-trip, legacy plaintext, key=nil
passthrough) keep passing.

## Behaviour change for operators

This is a **breaking behaviour change** for any deployment whose DB
holds ciphertext that the current process cannot decrypt:

- Before: model invocations / vector reads / web searches silently
  fail upstream with a confusing third-party 401/403.
- After: \`gorm.Find\` / \`Scan\` returns
  \`decrypt models.parameters.api_key: encrypted data found but
  SYSTEM_AES_KEY is not set or has wrong length\`, the call surfaces
  the error to the API client, and nothing is sent to the vendor.

Operators have two recovery paths (same as #1087 / #1089):

1. Restore the original \`SYSTEM_AES_KEY\` value (e.g. from a Secret
   backup, ArgoCD revision history, or older replica) and pin it via
   \`secrets.systemAesKey\`.
2. Rotate every affected encrypted field: API keys, model provider
   credentials, vector store credentials, web-search provider keys,
   and \`WeKnoraCloud.AppSecret\`.

A release-note callout is recommended.

## Tests

Added table-driven coverage in \`internal/utils/crypto_test.go\` for
empty input, legacy plaintext, round-trip, missing key, wrong-length
key, and rotated key. The non-trivial cases explicitly assert that
ciphertext is **not** returned to the caller on any error path.

## Test plan

- [x] \`go test ./internal/utils/... ./internal/types/...\`
- [x] \`go test ./internal/application/repository/ -run Tenant\`
- [x] \`go build ./...\`
- [x] Manual: with a tenant + model whose secrets are encrypted under
      key A, set \`SYSTEM_AES_KEY\` to key B (or unset it), confirm the
      next chat request returns a clear decrypt error rather than a
      vendor 401.