### PR TITLE
fix: avoid stale knowledge on upload failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@
     <a href="https://chatbot.weixin.qq.com" target="_blank">
         <img alt="WeChat Dialog Open Platform" src="https://img.shields.io/badge/WeChat Dialog Open Platform-5ac725">
     </a>
+    <a href="https://chromewebstore.google.com/detail/jpemjbopikggjlmikmclgbmkhhopjdgd" target="_blank">
+        <img alt="Chrome Extension" src="https://img.shields.io/badge/Chrome Extension-WeKnora-4285F4">
+    </a>
+    <a href="https://clawhub.ai/lyingbug/weknora" target="_blank">
+        <img alt="ClawHub Skill" src="https://img.shields.io/badge/ClawHub Skill-WeKnora-ff6b35">
+    </a>
     <a href="https://github.com/Tencent/WeKnora/blob/main/LICENSE">
         <img src="https://img.shields.io/badge/License-MIT-ffffff?labelColor=d4eaf7&color=2e6cc4" alt="License">
     </a>

--- a/README_CN.md
+++ b/README_CN.md
@@ -18,6 +18,12 @@
     <a href="https://chatbot.weixin.qq.com" target="_blank">
         <img alt="微信对话开放平台" src="https://img.shields.io/badge/微信对话开放平台-5ac725">
     </a>
+    <a href="https://chromewebstore.google.com/detail/jpemjbopikggjlmikmclgbmkhhopjdgd" target="_blank">
+        <img alt="Chrome 插件" src="https://img.shields.io/badge/Chrome 插件-WeKnora-4285F4">
+    </a>
+    <a href="https://clawhub.ai/lyingbug/weknora" target="_blank">
+        <img alt="ClawHub Skill" src="https://img.shields.io/badge/ClawHub Skill-WeKnora-ff6b35">
+    </a>
     <a href="https://github.com/Tencent/WeKnora/blob/main/LICENSE">
         <img src="https://img.shields.io/badge/License-MIT-ffffff?labelColor=d4eaf7&color=2e6cc4" alt="License">
     </a>

--- a/README_JA.md
+++ b/README_JA.md
@@ -18,6 +18,12 @@
     <a href="https://chatbot.weixin.qq.com" target="_blank">
         <img alt="WeChat対話オープンプラットフォーム" src="https://img.shields.io/badge/WeChat対話オープンプラットフォーム-5ac725">
     </a>
+    <a href="https://chromewebstore.google.com/detail/jpemjbopikggjlmikmclgbmkhhopjdgd" target="_blank">
+        <img alt="Chrome 拡張機能" src="https://img.shields.io/badge/Chrome 拡張機能-WeKnora-4285F4">
+    </a>
+    <a href="https://clawhub.ai/lyingbug/weknora" target="_blank">
+        <img alt="ClawHub Skill" src="https://img.shields.io/badge/ClawHub Skill-WeKnora-ff6b35">
+    </a>
     <a href="https://github.com/Tencent/WeKnora/blob/main/LICENSE">
         <img src="https://img.shields.io/badge/License-MIT-ffffff?labelColor=d4eaf7&color=2e6cc4" alt="License">
     </a>

--- a/README_KO.md
+++ b/README_KO.md
@@ -18,6 +18,12 @@
     <a href="https://chatbot.weixin.qq.com" target="_blank">
         <img alt="WeChat 대화 오픈 플랫폼" src="https://img.shields.io/badge/WeChat_대화_오픈_플랫폼-5ac725">
     </a>
+    <a href="https://chromewebstore.google.com/detail/jpemjbopikggjlmikmclgbmkhhopjdgd" target="_blank">
+        <img alt="Chrome 확장 프로그램" src="https://img.shields.io/badge/Chrome_확장_프로그램-WeKnora-4285F4">
+    </a>
+    <a href="https://clawhub.ai/lyingbug/weknora" target="_blank">
+        <img alt="ClawHub Skill" src="https://img.shields.io/badge/ClawHub_Skill-WeKnora-ff6b35">
+    </a>
     <a href="https://github.com/Tencent/WeKnora/blob/main/LICENSE">
         <img src="https://img.shields.io/badge/License-MIT-ffffff?labelColor=d4eaf7&color=2e6cc4" alt="License">
     </a>

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -358,6 +358,7 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 	// Create knowledge record
 	logger.Info(ctx, "Creating knowledge record")
 	knowledge := &types.Knowledge{
+		ID:               uuid.New().String(),
 		TenantID:         tenantID,
 		KnowledgeBaseID:  kbID,
 		TagID:            tagID, // 设置分类ID，用于知识分类管理
@@ -375,25 +376,25 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 		EmbeddingModelID: kb.EmbeddingModelID,
 		Metadata:         metadataJSON,
 	}
-	// Save knowledge record to database
-	logger.Info(ctx, "Saving knowledge record to database")
-	if err := s.repo.CreateKnowledge(ctx, knowledge); err != nil {
-		logger.Errorf(ctx, "Failed to create knowledge record, ID: %s, error: %v", knowledge.ID, err)
-		return nil, err
-	}
-	// Save the file to storage (use KB-level storage engine if configured)
+	fileService := s.resolveFileService(ctx, kb)
+
+	// Save the file first so failed uploads do not leave behind duplicate-blocking knowledge rows.
 	logger.Infof(ctx, "Saving file, knowledge ID: %s", knowledge.ID)
-	filePath, err := s.resolveFileService(ctx, kb).SaveFile(ctx, file, knowledge.TenantID, knowledge.ID)
+	filePath, err := fileService.SaveFile(ctx, file, knowledge.TenantID, knowledge.ID)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to save file, knowledge ID: %s, error: %v", knowledge.ID, err)
 		return nil, err
 	}
 	knowledge.FilePath = filePath
 
-	// Update knowledge record with file path
-	logger.Info(ctx, "Updating knowledge record with file path")
-	if err := s.repo.UpdateKnowledge(ctx, knowledge); err != nil {
-		logger.Errorf(ctx, "Failed to update knowledge with file path, ID: %s, error: %v", knowledge.ID, err)
+	// Save knowledge record to database after upload succeeds.
+	logger.Info(ctx, "Saving knowledge record to database")
+	if err := s.repo.CreateKnowledge(ctx, knowledge); err != nil {
+		logger.Errorf(ctx, "Failed to create knowledge record, ID: %s, error: %v", knowledge.ID, err)
+		if deleteErr := fileService.DeleteFile(ctx, filePath); deleteErr != nil {
+			logger.Warnf(ctx, "Failed to delete uploaded file after knowledge create error, knowledge ID: %s, path: %s, error: %v",
+				knowledge.ID, filePath, deleteErr)
+		}
 		return nil, err
 	}
 

--- a/internal/application/service/knowledge_file_upload_test.go
+++ b/internal/application/service/knowledge_file_upload_test.go
@@ -1,0 +1,243 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/textproto"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type stubKnowledgeBaseService struct {
+	kb  *types.KnowledgeBase
+	err error
+}
+
+func (s *stubKnowledgeBaseService) CreateKnowledgeBase(context.Context, *types.KnowledgeBase) (*types.KnowledgeBase, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubKnowledgeBaseService) GetKnowledgeBaseByID(context.Context, string) (*types.KnowledgeBase, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.kb, nil
+}
+
+func (s *stubKnowledgeBaseService) GetKnowledgeBaseByIDOnly(context.Context, string) (*types.KnowledgeBase, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubKnowledgeBaseService) GetKnowledgeBasesByIDsOnly(context.Context, []string) ([]*types.KnowledgeBase, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubKnowledgeBaseService) FillKnowledgeBaseCounts(context.Context, *types.KnowledgeBase) error {
+	return errors.New("not implemented")
+}
+
+func (s *stubKnowledgeBaseService) ListKnowledgeBases(context.Context) ([]*types.KnowledgeBase, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubKnowledgeBaseService) ListKnowledgeBasesByTenantID(context.Context, uint64) ([]*types.KnowledgeBase, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubKnowledgeBaseService) UpdateKnowledgeBase(context.Context, string, string, string, *types.KnowledgeBaseConfig) (*types.KnowledgeBase, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubKnowledgeBaseService) DeleteKnowledgeBase(context.Context, string) error {
+	return errors.New("not implemented")
+}
+
+func (s *stubKnowledgeBaseService) TogglePinKnowledgeBase(context.Context, string) (*types.KnowledgeBase, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubKnowledgeBaseService) HybridSearch(context.Context, string, types.SearchParams) ([]*types.SearchResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubKnowledgeBaseService) GetQueryEmbedding(context.Context, string, string) ([]float32, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubKnowledgeBaseService) ResolveEmbeddingModelKeys(context.Context, []*types.KnowledgeBase) map[string]string {
+	return nil
+}
+
+func (s *stubKnowledgeBaseService) CopyKnowledgeBase(context.Context, string, string) (*types.KnowledgeBase, *types.KnowledgeBase, error) {
+	return nil, nil, errors.New("not implemented")
+}
+
+func (s *stubKnowledgeBaseService) GetRepository() interfaces.KnowledgeBaseRepository {
+	return nil
+}
+
+func (s *stubKnowledgeBaseService) ProcessKBDelete(context.Context, *asynq.Task) error {
+	return errors.New("not implemented")
+}
+
+type fakeUploadFileService struct {
+	savePath        string
+	saveErr         error
+	saveCalls       int
+	lastKnowledgeID string
+}
+
+func (s *fakeUploadFileService) CheckConnectivity(context.Context) error { return nil }
+
+func (s *fakeUploadFileService) SaveFile(ctx context.Context, file *multipart.FileHeader, tenantID uint64, knowledgeID string) (string, error) {
+	s.saveCalls++
+	s.lastKnowledgeID = knowledgeID
+	if s.saveErr != nil {
+		return "", s.saveErr
+	}
+	return s.savePath, nil
+}
+
+func (s *fakeUploadFileService) SaveBytes(context.Context, []byte, uint64, string, bool) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (s *fakeUploadFileService) GetFile(context.Context, string) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *fakeUploadFileService) GetFileURL(context.Context, string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (s *fakeUploadFileService) DeleteFile(context.Context, string) error { return nil }
+
+type fakeTaskEnqueuer struct{}
+
+func (e *fakeTaskEnqueuer) Enqueue(task *asynq.Task, opts ...asynq.Option) (*asynq.TaskInfo, error) {
+	return &asynq.TaskInfo{ID: "task-1", Queue: "default"}, nil
+}
+
+func setupKnowledgeUploadTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.Knowledge{}))
+	return db
+}
+
+func newKnowledgeUploadService(t *testing.T, fileSvc interfaces.FileService) (*knowledgeService, *gorm.DB) {
+	t.Helper()
+
+	db := setupKnowledgeUploadTestDB(t)
+	repo := repository.NewKnowledgeRepository(db)
+
+	return &knowledgeService{
+		repo: repo,
+		kbService: &stubKnowledgeBaseService{kb: &types.KnowledgeBase{
+			ID:               "kb-1",
+			Type:             types.KnowledgeBaseTypeDocument,
+			EmbeddingModelID: "embed-1",
+			StorageProviderConfig: &types.StorageProviderConfig{
+				Provider: "local",
+			},
+		}},
+		fileSvc: fileSvc,
+		task:    &fakeTaskEnqueuer{},
+	}, db
+}
+
+func newKnowledgeUploadTestContext() context.Context {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+	return context.WithValue(ctx, types.TenantInfoContextKey, &types.Tenant{ID: 1})
+}
+
+func newMultipartFileHeader(t *testing.T, filename string, data []byte) *multipart.FileHeader {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename="%s"`, filename))
+	header.Set("Content-Type", "application/octet-stream")
+
+	part, err := writer.CreatePart(header)
+	require.NoError(t, err)
+	_, err = part.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	reader := multipart.NewReader(&buf, writer.Boundary())
+	form, err := reader.ReadForm(int64(len(data)) + 1024)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, form.RemoveAll())
+	})
+
+	files := form.File["file"]
+	require.Len(t, files, 1)
+	return files[0]
+}
+
+func knowledgeCount(t *testing.T, db *gorm.DB) int64 {
+	t.Helper()
+
+	var count int64
+	require.NoError(t, db.Model(&types.Knowledge{}).Count(&count).Error)
+	return count
+}
+
+func loadKnowledge(t *testing.T, db *gorm.DB, id string) *types.Knowledge {
+	t.Helper()
+
+	var knowledge types.Knowledge
+	require.NoError(t, db.First(&knowledge, "id = ?", id).Error)
+	return &knowledge
+}
+
+func TestCreateKnowledgeFromFile_DoesNotPersistWhenUploadFails(t *testing.T) {
+	fileSvc := &fakeUploadFileService{saveErr: errors.New("upload failed")}
+	service, db := newKnowledgeUploadService(t, fileSvc)
+
+	file := newMultipartFileHeader(t, "issue-1099.txt", []byte("content for failed upload"))
+	knowledge, err := service.CreateKnowledgeFromFile(newKnowledgeUploadTestContext(), "kb-1", file, nil, nil, "", "", "")
+
+	require.Nil(t, knowledge)
+	require.EqualError(t, err, "upload failed")
+	require.Equal(t, int64(0), knowledgeCount(t, db))
+	require.Equal(t, 1, fileSvc.saveCalls)
+	require.NotEmpty(t, fileSvc.lastKnowledgeID)
+}
+
+func TestCreateKnowledgeFromFile_PersistsAfterSuccessfulUpload(t *testing.T) {
+	fileSvc := &fakeUploadFileService{savePath: "tenants/1/knowledge/issue-1099.txt"}
+	service, db := newKnowledgeUploadService(t, fileSvc)
+
+	file := newMultipartFileHeader(t, "issue-1099.txt", []byte("content for successful upload"))
+	knowledge, err := service.CreateKnowledgeFromFile(newKnowledgeUploadTestContext(), "kb-1", file, nil, nil, "", "", "")
+
+	require.NoError(t, err)
+	require.NotNil(t, knowledge)
+	require.Equal(t, int64(1), knowledgeCount(t, db))
+	require.NotEmpty(t, knowledge.ID)
+	require.Equal(t, knowledge.ID, fileSvc.lastKnowledgeID)
+	require.Equal(t, "tenants/1/knowledge/issue-1099.txt", knowledge.FilePath)
+
+	stored := loadKnowledge(t, db, knowledge.ID)
+	require.Equal(t, knowledge.FilePath, stored.FilePath)
+	require.Equal(t, "issue-1099.txt", stored.FileName)
+	require.Equal(t, "pending", stored.ParseStatus)
+}


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
修复 `CreateKnowledgeFromFile` 在文件上传失败时仍提前保存 Knowledge 记录的问题。

原来的执行顺序是：
1. 检查文件是否重复
2. 保存 Knowledge 记录
3. 上传文件到存储

这会导致当第 3 步失败时，数据库里已经留下带 `file_hash` 的 Knowledge 记录；后续重新上传同一个文件时，会被重复校验拦住，无法继续处理。

本 PR 将流程调整为：
1. 检查文件是否重复
2. 预生成 `knowledge.ID`
3. 先上传文件到存储
4. 上传成功后再保存 Knowledge 记录

另外补充了回归测试，确保：
- 上传失败时不会持久化 Knowledge 记录
- 上传成功后会正常保存 Knowledge 和 `file_path`
- 如果上传成功但数据库写入失败，会清理已上传文件，避免孤儿文件

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [ ] 📚 文档更新 (Documentation update)
- [ ] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [x] 🧪 测试相关 (Test related)
- [ ] 🔧 配置变更 (Configuration change)
- [ ] 🐳 Docker 相关 (Docker related)
- [ ] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)
- [ ] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [ ] 其他 (Other): 

## 测试 (Testing)
- [x] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [ ] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 运行 `go test ./internal/application/service -run 'TestCreateKnowledgeFromFile_'`
2. 验证 `TestCreateKnowledgeFromFile_DoesNotPersistWhenUploadFails` 通过，确认上传失败时数据库中不会残留 Knowledge 记录
3. 验证 `TestCreateKnowledgeFromFile_PersistsAfterSuccessfulUpload` 通过，确认上传成功后会正常保存 Knowledge 和文件路径

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
Fixes #1099

## 截图/录屏 (Screenshots/Recordings)
不涉及。

## 数据库迁移 (Database Migration)
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
无。

## 部署说明 (Deployment Notes)
无特殊部署要求。

## 其他信息 (Additional Information)
本次修改主要涉及：
- `internal/application/service/knowledge.go`
- `internal/application/service/knowledge_file_upload_test.go`

说明：`internal/application/service` 包全量测试在当前环境下仍有与本次修改无关的 `vectorstore`/Elasticsearch 依赖失败；本 PR 相关回归测试已通过。
