### PR TITLE
fix: include shared knowledge in knowledge search

### DIFF
--- a/frontend/src/views/knowledge/KnowledgeSearch.vue
+++ b/frontend/src/views/knowledge/KnowledgeSearch.vue
@@ -269,11 +269,13 @@ import { searchMessages, type MessageSearchGroupItem } from '@/api/chat-history'
 import RetrievalSettings from '@/views/settings/RetrievalSettings.vue'
 import { useMenuStore } from '@/stores/menu'
 import { useSettingsStore } from '@/stores/settings'
+import { useOrganizationStore } from '@/stores/organization'
 
 const { t } = useI18n()
 const router = useRouter()
 const menuStore = useMenuStore()
 const settingsStore = useSettingsStore()
+const orgStore = useOrganizationStore()
 
 // ─── Shared state ───
 const query = ref('')
@@ -346,6 +348,21 @@ const groupedResults = computed<FileGroup[]>(() => {
 
 const totalChunks = computed(() => results.value.length)
 
+const mergeKnowledgeBases = (myKbs: any[], sharedShares: any[]) => {
+  const ownKbIds = new Set(myKbs.map((kb: any) => String(kb.id)))
+  const sharedKbs = (sharedShares || [])
+    .filter((share: any) => share?.knowledge_base != null)
+    .map((share: any) => ({
+      id: String(share.knowledge_base.id),
+      name: share.knowledge_base.name,
+      type: share.knowledge_base.type || 'document',
+      org_name: share.org_name || '',
+    }))
+    .filter((kb: any) => !ownKbIds.has(kb.id))
+
+  return [...myKbs, ...sharedKbs]
+}
+
 const switchTab = (tab: 'knowledge' | 'messages') => {
   activeTab.value = tab
 }
@@ -353,10 +370,17 @@ const switchTab = (tab: 'knowledge' | 'messages') => {
 const fetchKnowledgeBases = async () => {
   kbLoading.value = true
   try {
-    const res: any = await listKnowledgeBases()
-    if (res?.data) {
-      knowledgeBases.value = res.data
-    }
+    const [kbRes, sharedKbs] = await Promise.all([
+      listKnowledgeBases(),
+      orgStore.fetchSharedKnowledgeBases(),
+    ])
+
+    const myKbs = (kbRes?.data || []).map((kb: any) => ({
+      ...kb,
+      id: String(kb.id),
+    }))
+
+    knowledgeBases.value = mergeKnowledgeBases(myKbs, sharedKbs)
   } catch (e) {
     console.error('Failed to load knowledge bases', e)
   } finally {

--- a/internal/application/service/knowledge_shared_access_test.go
+++ b/internal/application/service/knowledge_shared_access_test.go
@@ -1,0 +1,155 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type fakeKBShareService struct {
+	allowedKBs map[string]bool
+}
+
+func (f *fakeKBShareService) ShareKnowledgeBase(context.Context, string, string, string, uint64, types.OrgMemberRole) (*types.KnowledgeBaseShare, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeKBShareService) UpdateSharePermission(context.Context, string, types.OrgMemberRole, string) error {
+	return errors.New("not implemented")
+}
+func (f *fakeKBShareService) RemoveShare(context.Context, string, string) error {
+	return errors.New("not implemented")
+}
+func (f *fakeKBShareService) ListSharesByKnowledgeBase(context.Context, string, uint64) ([]*types.KnowledgeBaseShare, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeKBShareService) ListSharesByOrganization(context.Context, string) ([]*types.KnowledgeBaseShare, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeKBShareService) ListSharedKnowledgeBases(context.Context, string, uint64) ([]*types.SharedKnowledgeBaseInfo, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeKBShareService) ListSharedKnowledgeBasesInOrganization(context.Context, string, string, uint64) ([]*types.OrganizationSharedKnowledgeBaseItem, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeKBShareService) ListSharedKnowledgeBaseIDsByOrganizations(context.Context, []string, string) (map[string][]string, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeKBShareService) GetShare(context.Context, string) (*types.KnowledgeBaseShare, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeKBShareService) GetShareByKBAndOrg(context.Context, string, string) (*types.KnowledgeBaseShare, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeKBShareService) CheckUserKBPermission(context.Context, string, string) (types.OrgMemberRole, bool, error) {
+	return "", false, errors.New("not implemented")
+}
+func (f *fakeKBShareService) HasKBPermission(ctx context.Context, kbID string, userID string, requiredRole types.OrgMemberRole) (bool, error) {
+	return f.allowedKBs[kbID], nil
+}
+func (f *fakeKBShareService) GetKBSourceTenant(context.Context, string) (uint64, error) {
+	return 0, errors.New("not implemented")
+}
+func (f *fakeKBShareService) CountSharesByKnowledgeBaseIDs(context.Context, []string) (map[string]int64, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeKBShareService) CountByOrganizations(context.Context, []string) (map[string]int64, error) {
+	return nil, errors.New("not implemented")
+}
+
+func setupKnowledgeSharedAccessDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.Knowledge{}))
+	return db
+}
+
+func newKnowledgeSharedAccessService(t *testing.T, kbShare interfaces.KBShareService) (*knowledgeService, *gorm.DB) {
+	t.Helper()
+
+	db := setupKnowledgeSharedAccessDB(t)
+	repo := repository.NewKnowledgeRepository(db)
+	return &knowledgeService{
+		repo:           repo,
+		kbShareService: kbShare,
+	}, db
+}
+
+func newSharedAccessContext() context.Context {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+	ctx = context.WithValue(ctx, types.UserIDContextKey, "user-1")
+	return ctx
+}
+
+func seedKnowledge(t *testing.T, db *gorm.DB, knowledge *types.Knowledge) {
+	t.Helper()
+	require.NoError(t, db.Create(knowledge).Error)
+}
+
+func TestGetKnowledgeBatchWithSharedAccess_IncludesSharedKnowledgeWithPermission(t *testing.T) {
+	service, db := newKnowledgeSharedAccessService(t, &fakeKBShareService{
+		allowedKBs: map[string]bool{"kb-shared": true},
+	})
+
+	now := time.Now()
+	sharedKnowledge := &types.Knowledge{
+		ID:              "k-shared",
+		TenantID:        2,
+		KnowledgeBaseID: "kb-shared",
+		Type:            "file",
+		Title:           "shared doc",
+		FileName:        "shared.txt",
+		FileType:        "txt",
+		ParseStatus:     types.ParseStatusCompleted,
+		EnableStatus:    "enabled",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	seedKnowledge(t, db, sharedKnowledge)
+
+	got, err := service.GetKnowledgeBatchWithSharedAccess(newSharedAccessContext(), 1, []string{"k-shared"})
+
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "k-shared", got[0].ID)
+	require.Equal(t, uint64(2), got[0].TenantID)
+	require.Equal(t, "kb-shared", got[0].KnowledgeBaseID)
+}
+
+func TestGetKnowledgeBatchWithSharedAccess_ExcludesSharedKnowledgeWithoutPermission(t *testing.T) {
+	service, db := newKnowledgeSharedAccessService(t, &fakeKBShareService{
+		allowedKBs: map[string]bool{},
+	})
+
+	now := time.Now()
+	sharedKnowledge := &types.Knowledge{
+		ID:              "k-shared",
+		TenantID:        2,
+		KnowledgeBaseID: "kb-shared",
+		Type:            "file",
+		Title:           "shared doc",
+		FileName:        "shared.txt",
+		FileType:        "txt",
+		ParseStatus:     types.ParseStatusCompleted,
+		EnableStatus:    "enabled",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	seedKnowledge(t, db, sharedKnowledge)
+
+	got, err := service.GetKnowledgeBatchWithSharedAccess(newSharedAccessContext(), 1, []string{"k-shared"})
+
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+var _ interfaces.KBShareService = (*fakeKBShareService)(nil)


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
修复知识搜索页面无法查询和选择共享空间中共享知识库的问题。

问题表现：
1. 搜索页面的知识库下拉框只显示当前租户自有知识库
2. 共享空间里的共享知识库不会出现在候选列表中
3. 未显式选择知识库时，默认搜索范围也不会包含共享知识库

本 PR 的修复内容：
1. 搜索页面加载时同时拉取自有知识库和共享知识库
2. 按知识库 ID 合并并去重，确保共享知识库出现在下拉框中
3. 使用合并后的知识库列表作为默认搜索范围，使共享知识库内容可被搜索
4. 增加回归测试，验证共享权限下可以通过 `knowledge_ids` 访问共享知识

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [ ] 📚 文档更新 (Documentation update)
- [ ] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [x] 🧪 测试相关 (Test related)
- [ ] 🔧 配置变更 (Configuration change)
- [ ] 🐳 Docker 相关 (Docker related)
- [ ] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)
- [x] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [ ] 其他 (Other): 

## 测试 (Testing)
- [x] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [ ] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 运行 `go test ./internal/application/service -run 'TestGetKnowledgeBatchWithSharedAccess_'`
2. 验证共享权限存在时，可以通过共享 `knowledge_ids` 取回知识记录
3. 打开知识搜索页面，确认共享知识库会出现在下拉框中，且未显式选择时也会进入默认搜索范围

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [ ] 代码变更已添加适当的注释
- [x] 相关文档已更新
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
Fixes #1103

## 截图/录屏 (Screenshots/Recordings)

<img width="1280" height="760" alt="屏幕截图 2026-05-01 215948" src="https://github.com/user-attachments/assets/d08ff945-04a9-48a5-874a-a80fa506f653" />

<br>

<img width="1280" height="760" alt="屏幕截图 2026-05-01 215641" src="https://github.com/user-attachments/assets/744e3344-e35e-447a-8cc6-79cf5a14032d" />


## 数据库迁移 (Database Migration)
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
无。

## 部署说明 (Deployment Notes)
无特殊部署要求。

## 其他信息 (Additional Information)
本次修改主要涉及：
- `frontend/src/views/knowledge/KnowledgeSearch.vue`
- `internal/application/service/knowledge_shared_access_test.go`

补充说明：前端现有 `npm --prefix frontend run type-check` 在当前基线下仍有与本次修改无关的既有报错；本次新增的后端回归测试已通过。
