### PR TITLE
fix(chat): include history in model fallback

### DIFF
--- a/internal/application/service/chat_pipeline/common.go
+++ b/internal/application/service/chat_pipeline/common.go
@@ -75,11 +75,7 @@ func prepareMessagesWithHistory(chatManage *types.ChatManage) []chat.Message {
 		{Role: "system", Content: systemPrompt},
 	}
 
-	// Add conversation history (already limited by maxRounds in load_history/rewrite plugins)
-	for _, history := range chatManage.History {
-		chatMessages = append(chatMessages, chat.Message{Role: "user", Content: history.Query})
-		chatMessages = append(chatMessages, chat.Message{Role: "assistant", Content: history.Answer})
-	}
+	chatMessages = AppendHistoryMessages(chatMessages, chatManage.History)
 
 	// Add current user message. Only include images when the chat model supports
 	// vision; non-vision models rely on the text description in UserContent.
@@ -90,6 +86,16 @@ func prepareMessagesWithHistory(chatManage *types.ChatManage) []chat.Message {
 	chatMessages = append(chatMessages, userMsg)
 
 	return chatMessages
+}
+
+// AppendHistoryMessages appends prior Q&A rounds in chronological order.
+// History is already filtered and truncated upstream by the load_history plugin.
+func AppendHistoryMessages(messages []chat.Message, history []*types.History) []chat.Message {
+	for _, history := range history {
+		messages = append(messages, chat.Message{Role: "user", Content: history.Query})
+		messages = append(messages, chat.Message{Role: "assistant", Content: history.Answer})
+	}
+	return messages
 }
 
 // loadAndProcessHistory fetches recent messages, groups them into Q&A pairs,

--- a/internal/application/service/session_knowledge_qa.go
+++ b/internal/application/service/session_knowledge_qa.go
@@ -740,11 +740,7 @@ func (s *sessionService) handleModelFallback(ctx context.Context, chatManage *ty
 	}
 
 	// Start streaming response
-	userMsg := chat.Message{Role: "user", Content: promptContent}
-	if chatManage.ChatModelSupportsVision && len(chatManage.Images) > 0 {
-		userMsg.Images = chatManage.Images
-	}
-	responseChan, err := chatModel.ChatStream(ctx, []chat.Message{userMsg}, opt)
+	responseChan, err := chatModel.ChatStream(ctx, buildFallbackMessages(chatManage, promptContent), opt)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to start streaming fallback response: %v, falling back to fixed response", err)
 		s.handleFixedFallback(ctx, chatManage)
@@ -759,6 +755,18 @@ func (s *sessionService) handleModelFallback(ctx context.Context, chatManage *ty
 
 	// Start goroutine to consume stream and emit events
 	go s.consumeFallbackStream(ctx, chatManage, responseChan)
+}
+
+func buildFallbackMessages(chatManage *types.ChatManage, promptContent string) []chat.Message {
+	messages := make([]chat.Message, 0, len(chatManage.History)*2+1)
+	messages = chatpipeline.AppendHistoryMessages(messages, chatManage.History)
+
+	userMsg := chat.Message{Role: "user", Content: promptContent}
+	if chatManage.ChatModelSupportsVision && len(chatManage.Images) > 0 {
+		userMsg.Images = chatManage.Images
+	}
+
+	return append(messages, userMsg)
 }
 
 // renderFallbackPrompt renders the fallback prompt template with query and image context.

--- a/internal/application/service/session_knowledge_qa_test.go
+++ b/internal/application/service/session_knowledge_qa_test.go
@@ -1,0 +1,138 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/event"
+	"github.com/Tencent/WeKnora/internal/models/asr"
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/models/rerank"
+	"github.com/Tencent/WeKnora/internal/models/vlm"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type captureChatModel struct {
+	lastMessages []chat.Message
+}
+
+func (m *captureChatModel) Chat(
+	context.Context,
+	[]chat.Message,
+	*chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	return nil, nil
+}
+
+func (m *captureChatModel) ChatStream(
+	_ context.Context,
+	messages []chat.Message,
+	_ *chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	m.lastMessages = append([]chat.Message(nil), messages...)
+
+	ch := make(chan types.StreamResponse, 1)
+	ch <- types.StreamResponse{
+		ResponseType: types.ResponseTypeAnswer,
+		Content:      "ok",
+		Done:         true,
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (m *captureChatModel) GetModelName() string { return "capture" }
+func (m *captureChatModel) GetModelID() string   { return "capture" }
+
+type stubModelService struct {
+	chatModel chat.Chat
+}
+
+func (s *stubModelService) CreateModel(context.Context, *types.Model) error {
+	return nil
+}
+
+func (s *stubModelService) GetModelByID(context.Context, string) (*types.Model, error) {
+	return nil, nil
+}
+
+func (s *stubModelService) ListModels(context.Context) ([]*types.Model, error) {
+	return nil, nil
+}
+
+func (s *stubModelService) UpdateModel(context.Context, *types.Model) error {
+	return nil
+}
+
+func (s *stubModelService) DeleteModel(context.Context, string) error {
+	return nil
+}
+
+func (s *stubModelService) GetEmbeddingModel(context.Context, string) (embedding.Embedder, error) {
+	return nil, nil
+}
+
+func (s *stubModelService) GetEmbeddingModelForTenant(context.Context, string, uint64) (embedding.Embedder, error) {
+	return nil, nil
+}
+
+func (s *stubModelService) GetRerankModel(context.Context, string) (rerank.Reranker, error) {
+	return nil, nil
+}
+
+func (s *stubModelService) GetChatModel(context.Context, string) (chat.Chat, error) {
+	return s.chatModel, nil
+}
+
+func (s *stubModelService) GetVLMModel(context.Context, string) (vlm.VLM, error) {
+	return nil, nil
+}
+
+func (s *stubModelService) GetASRModel(context.Context, string) (asr.ASR, error) {
+	return nil, nil
+}
+
+func TestHandleModelFallback_IncludesHistoryMessages(t *testing.T) {
+	chatModel := &captureChatModel{}
+	svc := &sessionService{
+		modelService: &stubModelService{chatModel: chatModel},
+	}
+
+	bus := event.NewEventBus()
+	cm := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{
+			SessionID:      "session-1",
+			Query:          "现在还能继续讲吗？",
+			ChatModelID:    "chat-model",
+			FallbackPrompt: "Answer the latest user question: {{query}}",
+			SummaryConfig: types.SummaryConfig{
+				Temperature: 0.2,
+			},
+			Language: "zh-CN",
+		},
+		PipelineState: types.PipelineState{
+			History: []*types.History{
+				{
+					Query:  "先介绍一下 WeKnora",
+					Answer: "WeKnora 是一个知识库问答系统。",
+				},
+			},
+		},
+		PipelineContext: types.PipelineContext{
+			EventBus: bus.AsEventBusInterface(),
+		},
+	}
+
+	svc.handleModelFallback(context.Background(), cm)
+
+	require.Len(t, chatModel.lastMessages, 3)
+	assert.Equal(t, "user", chatModel.lastMessages[0].Role)
+	assert.Equal(t, "先介绍一下 WeKnora", chatModel.lastMessages[0].Content)
+	assert.Equal(t, "assistant", chatModel.lastMessages[1].Role)
+	assert.Equal(t, "WeKnora 是一个知识库问答系统。", chatModel.lastMessages[1].Content)
+	assert.Equal(t, "user", chatModel.lastMessages[2].Role)
+	assert.Contains(t, chatModel.lastMessages[2].Content, "现在还能继续讲吗？")
+}


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
修复聊天在未命中知识库、走模型兜底回复时未携带历史聊天记录的问题。

具体变更：
- 让 model fallback 路径复用已有历史消息拼装逻辑，向大模型发送历史轮次 + 当前 fallback prompt，而不是只发送最后一问
- 抽取共享的历史消息追加函数，保持兜底路径和正常聊天路径的上下文构造一致
- 新增回归测试，确保 fallback 调用模型时会带上历史聊天记录

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [ ] 📚 文档更新 (Documentation update)
- [ ] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [x] 🧪 测试相关 (Test related)
- [ ] 🔧 配置变更 (Configuration change)
- [ ] 🐳 Docker 相关 (Docker related)
- [ ] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)
- [ ] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [ ] 其他 (Other): 

## 测试 (Testing)
- [x] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [ ] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 运行 `go test ./internal/application/service -run '^TestHandleModelFallback_IncludesHistoryMessages$'`
2. 运行 `go test ./internal/application/service/chat_pipeline`
3. 确认 fallback 路径发送给模型的消息中包含历史 user/assistant 轮次以及当前问题

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [ ] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [ ] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
Fixes #1107

## 截图/录屏 (Screenshots/Recordings)

## 数据库迁移 (Database Migration)
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
无。

## 部署说明 (Deployment Notes)
无特殊部署要求。

## 其他信息 (Additional Information)
