### PR TITLE
fix(agent): correct graph config reporting

### DIFF
--- a/internal/agent/tools/query_knowledge_graph.go
+++ b/internal/agent/tools/query_knowledge_graph.go
@@ -12,6 +12,11 @@ import (
 	"github.com/Tencent/WeKnora/internal/utils"
 )
 
+type graphConfigSummary struct {
+	Nodes     []string
+	Relations []string
+}
+
 var queryKnowledgeGraphTool = BaseTool{
 	name: ToolQueryKnowledgeGraph,
 	description: `Query knowledge graph to explore entity relationships and knowledge networks.
@@ -168,7 +173,7 @@ func (t *QueryKnowledgeGraphTool) Execute(ctx context.Context, args json.RawMess
 	// Collect and deduplicate results
 	seenChunks := make(map[string]*types.SearchResult)
 	var errors []string
-	graphConfigs := make(map[string]map[string]interface{})
+	graphConfigs := make(map[string]graphConfigSummary)
 	kbCounts := make(map[string]int)
 
 	for _, kbID := range input.KnowledgeBaseIDs {
@@ -179,10 +184,7 @@ func (t *QueryKnowledgeGraphTool) Execute(ctx context.Context, args json.RawMess
 		}
 
 		if result.kb != nil && result.kb.ExtractConfig != nil {
-			graphConfigs[kbID] = map[string]interface{}{
-				"nodes":     result.kb.ExtractConfig.Nodes,
-				"relations": result.kb.ExtractConfig.Relations,
-			}
+			graphConfigs[kbID] = summarizeGraphConfig(result.kb.ExtractConfig)
 		}
 
 		kbCounts[kbID] = len(result.results)
@@ -211,7 +213,8 @@ func (t *QueryKnowledgeGraphTool) Execute(ctx context.Context, args json.RawMess
 				"knowledge_base_ids": input.KnowledgeBaseIDs,
 				"query":              query,
 				"results":            []interface{}{},
-				"graph_configs":      graphConfigs,
+				"graph_configs":      graphConfigsToData(graphConfigs),
+				"graph_config":       aggregateGraphConfig(graphConfigs),
 				"errors":             errors,
 			},
 		}, nil
@@ -238,35 +241,14 @@ func (t *QueryKnowledgeGraphTool) Execute(ctx context.Context, args json.RawMess
 		hasGraphConfig = true
 		output += fmt.Sprintf("Knowledge Base [%s]:\n", kbID)
 
-		nodes, _ := config["nodes"].([]interface{})
-		relations, _ := config["relations"].([]interface{})
-
-		if len(nodes) > 0 {
-			output += fmt.Sprintf("  ✓ Entity Types (%d): ", len(nodes))
-			nodeNames := make([]string, 0, len(nodes))
-			for _, n := range nodes {
-				if nodeMap, ok := n.(map[string]interface{}); ok {
-					if name, ok := nodeMap["name"].(string); ok {
-						nodeNames = append(nodeNames, name)
-					}
-				}
-			}
-			output += fmt.Sprintf("%v\n", nodeNames)
+		if len(config.Nodes) > 0 {
+			output += fmt.Sprintf("  ✓ Entity Types (%d): %v\n", len(config.Nodes), config.Nodes)
 		} else {
 			output += "  ⚠️ No entity types configured\n"
 		}
 
-		if len(relations) > 0 {
-			output += fmt.Sprintf("  ✓ Relationship Types (%d): ", len(relations))
-			relNames := make([]string, 0, len(relations))
-			for _, r := range relations {
-				if relMap, ok := r.(map[string]interface{}); ok {
-					if name, ok := relMap["name"].(string); ok {
-						relNames = append(relNames, name)
-					}
-				}
-			}
-			output += fmt.Sprintf("%v\n", relNames)
+		if len(config.Relations) > 0 {
+			output += fmt.Sprintf("  ✓ Relationship Types (%d): %v\n", len(config.Relations), config.Relations)
 		} else {
 			output += "  ⚠️ No relationship types configured\n"
 		}
@@ -338,7 +320,7 @@ func (t *QueryKnowledgeGraphTool) Execute(ctx context.Context, args json.RawMess
 	output += "- ⏳ Full graph query language (Cypher) support is under development\n"
 
 	// Build structured graph data for frontend visualization
-	graphData := buildGraphVisualizationData(allResults, graphConfigs)
+	graphData := buildGraphVisualizationData(allResults)
 
 	return &types.ToolResult{
 		Success: true,
@@ -349,7 +331,8 @@ func (t *QueryKnowledgeGraphTool) Execute(ctx context.Context, args json.RawMess
 			"results":            formattedResults,
 			"count":              len(allResults),
 			"kb_counts":          kbCounts,
-			"graph_configs":      graphConfigs,
+			"graph_configs":      graphConfigsToData(graphConfigs),
+			"graph_config":       aggregateGraphConfig(graphConfigs),
 			"graph_data":         graphData,
 			"has_graph_config":   hasGraphConfig,
 			"errors":             errors,
@@ -358,11 +341,102 @@ func (t *QueryKnowledgeGraphTool) Execute(ctx context.Context, args json.RawMess
 	}, nil
 }
 
+func summarizeGraphConfig(config *types.ExtractConfig) graphConfigSummary {
+	if config == nil {
+		return graphConfigSummary{}
+	}
+
+	return graphConfigSummary{
+		Nodes:     uniqueSortedNodeNames(config.Nodes),
+		Relations: uniqueSortedRelationNames(config.Relations),
+	}
+}
+
+func uniqueSortedNodeNames(nodes []*types.GraphNode) []string {
+	seen := make(map[string]struct{}, len(nodes))
+	names := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		if node == nil || node.Name == "" {
+			continue
+		}
+		if _, exists := seen[node.Name]; exists {
+			continue
+		}
+		seen[node.Name] = struct{}{}
+		names = append(names, node.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func uniqueSortedRelationNames(relations []*types.GraphRelation) []string {
+	seen := make(map[string]struct{}, len(relations))
+	names := make([]string, 0, len(relations))
+	for _, relation := range relations {
+		if relation == nil || relation.Type == "" {
+			continue
+		}
+		if _, exists := seen[relation.Type]; exists {
+			continue
+		}
+		seen[relation.Type] = struct{}{}
+		names = append(names, relation.Type)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func graphConfigsToData(graphConfigs map[string]graphConfigSummary) map[string]map[string]interface{} {
+	if len(graphConfigs) == 0 {
+		return nil
+	}
+
+	data := make(map[string]map[string]interface{}, len(graphConfigs))
+	for kbID, config := range graphConfigs {
+		data[kbID] = map[string]interface{}{
+			"nodes":     config.Nodes,
+			"relations": config.Relations,
+		}
+	}
+	return data
+}
+
+func aggregateGraphConfig(graphConfigs map[string]graphConfigSummary) map[string]interface{} {
+	if len(graphConfigs) == 0 {
+		return nil
+	}
+
+	merged := graphConfigSummary{}
+	for _, config := range graphConfigs {
+		merged.Nodes = append(merged.Nodes, config.Nodes...)
+		merged.Relations = append(merged.Relations, config.Relations...)
+	}
+
+	return map[string]interface{}{
+		"nodes":     uniqueStrings(merged.Nodes),
+		"relations": uniqueStrings(merged.Relations),
+	}
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
 // buildGraphVisualizationData builds structured data for graph visualization
-func buildGraphVisualizationData(
-	results []*types.SearchResult,
-	graphConfigs map[string]map[string]interface{},
-) map[string]interface{} {
+func buildGraphVisualizationData(results []*types.SearchResult) map[string]interface{} {
 	// Build a simple graph structure for frontend visualization
 	nodes := make([]map[string]interface{}, 0)
 	edges := make([]map[string]interface{}, 0)

--- a/internal/agent/tools/query_knowledge_graph_test.go
+++ b/internal/agent/tools/query_knowledge_graph_test.go
@@ -99,28 +99,53 @@ func TestQueryKnowledgeGraph_ReportsConfiguredEntityAndRelationTypes(t *testing.
 				Enabled: true,
 				Nodes: []*types.GraphNode{
 					{Name: "合同"},
-					{Name: "部门"},
+					{Name: "法务部门"},
+					{Name: "审批流程"},
+					{Name: "合同"},
+					nil,
+					{Name: ""},
 				},
 				Relations: []*types.GraphRelation{
 					{Type: "属于"},
 					{Type: "管理"},
+					{Type: "审批"},
+					{Type: "管理"},
+					{Type: ""},
+					nil,
 				},
 			},
 		},
 		results: []*types.SearchResult{
 			{
-				ID:             "chunk-1",
-				Content:        "合同管理流程由法务部门负责。",
-				KnowledgeID:    "doc-1",
-				KnowledgeTitle: "合同管理制度",
-				Score:          0.91,
+				ID:             "chunk-approval-1",
+				Content:        "合同审批流程由法务部门与采购部门共同维护，法务部门负责合规审查。",
+				KnowledgeID:    "doc-approval",
+				KnowledgeTitle: "合同审批管理制度",
+				Score:          0.97,
+				MatchType:      types.MatchTypeEmbedding,
+			},
+			{
+				ID:             "chunk-approval-2",
+				Content:        "采购申请提交后进入合同审批流程，审批完成后归档到合同台账。",
+				KnowledgeID:    "doc-procurement",
+				KnowledgeTitle: "采购与合同协作规范",
+				Score:          0.89,
+				MatchType:      types.MatchTypeKeywords,
+			},
+			{
+				ID:             "chunk-approval-3",
+				Content:        "法务部门管理标准合同模板，并维护合同风险审查清单。",
+				KnowledgeID:    "doc-legal",
+				KnowledgeTitle: "法务部职责说明",
+				Score:          0.84,
+				MatchType:      types.MatchTypeEmbedding,
 			},
 		},
 	})
 
 	args, err := json.Marshal(QueryKnowledgeGraphInput{
 		KnowledgeBaseIDs: []string{"kb-1"},
-		Query:            "合同管理",
+		Query:            "合同审批与法务协作",
 	})
 	require.NoError(t, err)
 
@@ -130,15 +155,23 @@ func TestQueryKnowledgeGraph_ReportsConfiguredEntityAndRelationTypes(t *testing.
 	require.True(t, result.Success)
 	t.Logf("tool output:\n%s", result.Output)
 
-	assert.Contains(t, result.Output, "Entity Types (2)")
-	assert.Contains(t, result.Output, "Relationship Types (2)")
+	assert.Contains(t, result.Output, "Entity Types (3)")
+	assert.Contains(t, result.Output, "Relationship Types (3)")
 	assert.NotContains(t, result.Output, "No entity types configured")
 	assert.NotContains(t, result.Output, "No relationship types configured")
 	assert.Contains(t, result.Output, "合同")
+	assert.Contains(t, result.Output, "法务部门")
+	assert.Contains(t, result.Output, "审批流程")
 	assert.Contains(t, result.Output, "管理")
+	assert.Contains(t, result.Output, "审批")
+	assert.Contains(t, result.Output, "✓ Found 3 relevant results (deduplicated)")
+	assert.Contains(t, result.Output, "Result #1:")
+	assert.Contains(t, result.Output, "Result #2:")
+	assert.Contains(t, result.Output, "Result #3:")
+	assert.Contains(t, result.Output, "合同审批管理制度")
 
 	graphConfig, ok := result.Data["graph_config"].(map[string]interface{})
 	require.True(t, ok)
-	assert.ElementsMatch(t, []string{"合同", "部门"}, graphConfig["nodes"])
-	assert.ElementsMatch(t, []string{"属于", "管理"}, graphConfig["relations"])
+	assert.ElementsMatch(t, []string{"合同", "审批流程", "法务部门"}, graphConfig["nodes"])
+	assert.ElementsMatch(t, []string{"属于", "审批", "管理"}, graphConfig["relations"])
 }

--- a/internal/agent/tools/query_knowledge_graph_test.go
+++ b/internal/agent/tools/query_knowledge_graph_test.go
@@ -1,0 +1,144 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubKnowledgeBaseService struct {
+	kb      *types.KnowledgeBase
+	results []*types.SearchResult
+}
+
+func (s *stubKnowledgeBaseService) CreateKnowledgeBase(context.Context, *types.KnowledgeBase) (*types.KnowledgeBase, error) {
+	return nil, nil
+}
+
+func (s *stubKnowledgeBaseService) GetKnowledgeBaseByID(context.Context, string) (*types.KnowledgeBase, error) {
+	return s.kb, nil
+}
+
+func (s *stubKnowledgeBaseService) GetKnowledgeBaseByIDOnly(context.Context, string) (*types.KnowledgeBase, error) {
+	return s.kb, nil
+}
+
+func (s *stubKnowledgeBaseService) GetKnowledgeBasesByIDsOnly(context.Context, []string) ([]*types.KnowledgeBase, error) {
+	return nil, nil
+}
+
+func (s *stubKnowledgeBaseService) FillKnowledgeBaseCounts(context.Context, *types.KnowledgeBase) error {
+	return nil
+}
+
+func (s *stubKnowledgeBaseService) ListKnowledgeBases(context.Context) ([]*types.KnowledgeBase, error) {
+	return nil, nil
+}
+
+func (s *stubKnowledgeBaseService) ListKnowledgeBasesByTenantID(context.Context, uint64) ([]*types.KnowledgeBase, error) {
+	return nil, nil
+}
+
+func (s *stubKnowledgeBaseService) UpdateKnowledgeBase(
+	context.Context,
+	string,
+	string,
+	string,
+	*types.KnowledgeBaseConfig,
+) (*types.KnowledgeBase, error) {
+	return nil, nil
+}
+
+func (s *stubKnowledgeBaseService) DeleteKnowledgeBase(context.Context, string) error {
+	return nil
+}
+
+func (s *stubKnowledgeBaseService) TogglePinKnowledgeBase(context.Context, string) (*types.KnowledgeBase, error) {
+	return nil, nil
+}
+
+func (s *stubKnowledgeBaseService) HybridSearch(context.Context, string, types.SearchParams) ([]*types.SearchResult, error) {
+	return s.results, nil
+}
+
+func (s *stubKnowledgeBaseService) GetQueryEmbedding(context.Context, string, string) ([]float32, error) {
+	return nil, nil
+}
+
+func (s *stubKnowledgeBaseService) ResolveEmbeddingModelKeys(context.Context, []*types.KnowledgeBase) map[string]string {
+	return nil
+}
+
+func (s *stubKnowledgeBaseService) CopyKnowledgeBase(
+	context.Context,
+	string,
+	string,
+) (*types.KnowledgeBase, *types.KnowledgeBase, error) {
+	return nil, nil, nil
+}
+
+func (s *stubKnowledgeBaseService) GetRepository() interfaces.KnowledgeBaseRepository {
+	return nil
+}
+
+func (s *stubKnowledgeBaseService) ProcessKBDelete(context.Context, *asynq.Task) error {
+	return nil
+}
+
+func TestQueryKnowledgeGraph_ReportsConfiguredEntityAndRelationTypes(t *testing.T) {
+	tool := NewQueryKnowledgeGraphTool(&stubKnowledgeBaseService{
+		kb: &types.KnowledgeBase{
+			ID: "kb-1",
+			ExtractConfig: &types.ExtractConfig{
+				Enabled: true,
+				Nodes: []*types.GraphNode{
+					{Name: "合同"},
+					{Name: "部门"},
+				},
+				Relations: []*types.GraphRelation{
+					{Type: "属于"},
+					{Type: "管理"},
+				},
+			},
+		},
+		results: []*types.SearchResult{
+			{
+				ID:             "chunk-1",
+				Content:        "合同管理流程由法务部门负责。",
+				KnowledgeID:    "doc-1",
+				KnowledgeTitle: "合同管理制度",
+				Score:          0.91,
+			},
+		},
+	})
+
+	args, err := json.Marshal(QueryKnowledgeGraphInput{
+		KnowledgeBaseIDs: []string{"kb-1"},
+		Query:            "合同管理",
+	})
+	require.NoError(t, err)
+
+	result, err := tool.Execute(context.Background(), args)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.Success)
+	t.Logf("tool output:\n%s", result.Output)
+
+	assert.Contains(t, result.Output, "Entity Types (2)")
+	assert.Contains(t, result.Output, "Relationship Types (2)")
+	assert.NotContains(t, result.Output, "No entity types configured")
+	assert.NotContains(t, result.Output, "No relationship types configured")
+	assert.Contains(t, result.Output, "合同")
+	assert.Contains(t, result.Output, "管理")
+
+	graphConfig, ok := result.Data["graph_config"].(map[string]interface{})
+	require.True(t, ok)
+	assert.ElementsMatch(t, []string{"合同", "部门"}, graphConfig["nodes"])
+	assert.ElementsMatch(t, []string{"属于", "管理"}, graphConfig["relations"])
+}


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
修复 `query_knowledge_graph` 在知识库已配置实体/关系类型时仍错误显示“未配置”的问题，并补齐前端当前结果组件需要的 `graph_config` 返回结构。

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [ ] 📚 文档更新 (Documentation update)
- [ ] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [x] 🧪 测试相关 (Test related)
- [ ] 🔧 配置变更 (Configuration change)
- [ ] 🐳 Docker 相关 (Docker related)
- [ ] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)
- [ ] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [ ] 其他 (Other): <!-- 请说明 -->

## 测试 (Testing)
- [x] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [ ] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 运行 `go test ./internal/agent/tools -run '^TestQueryKnowledgeGraph_ReportsConfiguredEntityAndRelationTypes$' -v`
2. 确认终端输出中显示 `Entity Types (3)` / `Relationship Types (3)`，且包含多个检索结果
3. 确认输出中不再出现 `No entity types configured` / `No relationship types configured`

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [ ] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
Fixes #1106

## 截图/录屏 (Screenshots/Recordings)
<img width="1358" height="1387" alt="屏幕截图 2026-05-01 223924" src="https://github.com/user-attachments/assets/5bf17c8e-4aad-4568-b9fa-9e99a6845423" />
<img width="1301" height="423" alt="屏幕截图 2026-05-01 224003" src="https://github.com/user-attachments/assets/f4cad875-fb97-4187-bc9e-2110b3964467" />


## 数据库迁移 (Database Migration)
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)

## 部署说明 (Deployment Notes)

## 其他信息 (Additional Information)
本次修复聚焦于 #1106 中“图谱配置已存在但 tool 误报未配置、且返回结构与前端不兼容”的直接问题。`query_knowledge_graph` 目前仍主要是基于检索结果的包装输出，尚未升级为真正的 Neo4j 图查询工具；这一更深层的增强需求与 #799 中提到的“知识问答时不检索知识图谱”属于同一后续方向。
