### PR TITLE
fix(embedding): OpenAIEmbedder.doRequestWithRetry shadows err · retur…

### DIFF
--- a/internal/models/embedding/openai.go
+++ b/internal/models/embedding/openai.go
@@ -122,8 +122,20 @@ func (e *OpenAIEmbedder) doRequestWithRetry(ctx context.Context, jsonData []byte
 			}
 		}
 
-		// Rebuild request each time to ensure Body is valid
-		req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonData))
+		// Rebuild request each time to ensure Body is valid.
+		// IMPORTANT: declare `req` separately (var) so the assignment to `err`
+		// below uses the outer-scope variable, not a fresh loop-local one.
+		// Previously this read `req, err := http.NewRequestWithContext(...)`,
+		// where `:=` introduced a new `err` shadowing the outer one. The
+		// `resp, err = httpClient.Do(req)` line then wrote to the shadowed
+		// `err` only, so when all retries failed with connection errors the
+		// outer `err` stayed nil. The function returned `(nil, nil)`, and
+		// callers (BatchEmbed line 195) blindly dereferenced `resp.Body` →
+		// SIGSEGV nil-pointer panic that took down the whole process.
+		// Reproduce: stop the embedding upstream (e.g. localhost:3130), make
+		// any RAG query → backend SIGSEGV instead of returning HTTP 500.
+		var req *http.Request
+		req, err = http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonData))
 		if err != nil {
 			logger.GetLogger(ctx).Errorf("OpenAIEmbedder failed to create request: %v", err)
 			continue


### PR DESCRIPTION
…ns (nil, nil) on connection failure · caller nil-derefs and SIGSEGVs

Reproduce:

  1. Run WeKnora pointing OPENAI_BASE_URL at any OpenAI-compatible embedding endpoint.
  2. Stop that endpoint.
  3. Issue any RAG-mode chat / knowledge_search query — the pipeline reaches chunk_search_parallel → knowledgeBaseService.GetQueryEmbedding → OpenAIEmbedder.Embed → OpenAIEmbedder.BatchEmbed.
  4. Observe the entire WeKnora process SIGSEGV instead of returning a graceful 5xx.

Stack (real, observed in production):

  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x2 addr=0x40]

  internal/models/embedding/openai.go:195 +0x458   BatchEmbed
  internal/models/embedding/openai.go:93  +0xb0    Embed
  internal/application/service/knowledgebase_search.go:35
                                                   GetQueryEmbedding
  internal/application/service/chat_pipeline/search.go:371
                                                   searchByTargets.func1

Root cause — variable shadowing in doRequestWithRetry:

  func (e *OpenAIEmbedder) doRequestWithRetry(...) (*http.Response, error) {
      var resp *http.Response
      var err error                                        // outer err
      ...
      for i := 0; i <= e.maxRetries; i++ {
          ...
          req, err := http.NewRequestWithContext(...)      // ← `:=` shadows
                                                           //   outer `err`
                                                           //   because `req`
                                                           //   is new in
                                                           //   the loop scope
          if err != nil { ... continue }
          ...
          resp, err = e.httpClient.Do(req)                 // writes to the
                                                           // shadowed
                                                           // loop-local err
          if err == nil { return resp, nil }
          logger.Errorf("attempt %d failed: %v", i+1, err) // logs the inner err
      }
      return nil, err                                      // returns OUTER
                                                           // err — never set
  }

When httpClient.Do returns connection errors on every attempt, the loop logs them faithfully but the outer err stays nil. The function returns (nil, nil). Caller in BatchEmbed reads:

  resp, err := e.doRequestWithRetry(ctx, jsonData)
  if err != nil { return nil, ... }       // skipped (err is nil)
  if resp.Body != nil {                   // ← line 195 · resp itself is nil
      defer resp.Body.Close()             //   nil pointer dereference
  }                                       //   → SIGSEGV → process dies

Fix — declare `req` separately so the shared `err` variable is not shadowed:

  var req *http.Request
  req, err = http.NewRequestWithContext(...)               // outer err

After the fix, when all retries fail, doRequestWithRetry returns the real error (e.g. `dial tcp 127.0.0.1:11434: connect: connection refused`), the caller propagates it as a regular error, the chat pipeline returns a 5xx to the client, and the process keeps running.

Verified by stopping the embedding upstream while WeKnora was serving queries · process stayed up · returned graceful errors · resumed normal operation when the upstream came back. Without the patch the same sequence killed the process within one query.

# Pull Request

## 描述 (Description)
<!-- 请简要描述这个 PR 的目的和变更内容 -->

## 变更类型 (Type of Change)
<!-- 请选择适用的类型，删除其他选项 -->
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [ ] 📚 文档更新 (Documentation update)
- [ ] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [ ] 🧪 测试相关 (Test related)
- [ ] 🔧 配置变更 (Configuration change)
- [ ] 🐳 Docker 相关 (Docker related)
- [ ] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
<!-- 请选择受影响的组件，删除其他选项 -->
- [ ] 后端 API (Backend API)
- [ ] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [ ] 其他 (Other): <!-- 请说明 -->

## 测试 (Testing)
<!-- 请描述如何测试这些变更 -->
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [ ] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 
2. 
3. 

## 检查清单 (Checklist)
<!-- 请确保完成以下检查项 -->
- [ ] 代码遵循项目的编码规范
- [ ] 已进行自我代码审查
- [ ] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [ ] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
<!-- 如果此 PR 解决了某个 issue，请使用 "Fixes #123" 或 "Closes #123" 的格式 -->
Fixes #

## 截图/录屏 (Screenshots/Recordings)
<!-- 如果是前端 UI 变更，请提供截图或录屏 -->

## 数据库迁移 (Database Migration)
<!-- 如果涉及数据库变更，请说明 -->
- [ ] 需要数据库迁移
- [ ] 不需要数据库迁移

## 配置变更 (Configuration Changes)
<!-- 如果涉及配置变更，请说明需要更新的配置项 -->

## 部署说明 (Deployment Notes)
<!-- 如果有特殊的部署要求，请说明 -->

## 其他信息 (Additional Information)
<!-- 任何其他需要说明的信息 -->