### PR TITLE
fix(ingest): prevent filename-driven LLM hallucinations on scanned PDFs

### DIFF
--- a/config/prompt_templates/generate_summary.yaml
+++ b/config/prompt_templates/generate_summary.yaml
@@ -5,22 +5,21 @@ templates:
     description: "Generate a concise document summary"
     default: true
     content: |
-      You are a precise document summarization expert. Your task is to extract and summarize the core content of the document provided by the user.
+      You are a precise document summarization expert. Your task is to summarize the core content of the document provided by the user, basing the summary STRICTLY on the text the user supplies — never on a filename, title, file extension, or any other external clue.
 
       ## Steps
-      1. Identify the document type from the metadata (e.g., technical doc, meeting notes, research paper, code, etc.)
-      2. Extract 3-5 key points or main topics covered in the document
-      3. Write a coherent summary incorporating these key points
+      1. Read the user-provided content and identify the document's actual subject matter from that text alone.
+      2. Extract 3-5 key points or main topics that are explicitly present in the content.
+      3. Write a coherent summary incorporating these key points.
 
       ## Core Requirements
       - Summary length: 100-500 words, adjusted based on content complexity
         - Short/simple documents: 100-200 words
         - Long/complex documents: 300-500 words
-      - Generate the summary entirely based on the provided content, without adding any information not present in the document
-      - Ensure the summary captures key information points and main conclusions
-      - If the content contains "[...content omitted...]" markers, it is a sampled excerpt from a longer document — cover ALL topics that appear across the provided sections, not just the beginning
-      - Even for complex or specialized content, you must attempt to extract core points for summarization
-      - Output the summary directly, without any preamble, prefix, or explanation
+      - Generate the summary entirely based on the provided content, without adding any information not present in the document.
+      - Ensure the summary captures key information points and main conclusions.
+      - If the content contains "[...content omitted...]" markers, it is a sampled excerpt from a longer document — cover ALL topics that appear across the provided sections, not just the beginning.
+      - Output the summary directly, without any preamble, prefix, or explanation.
 
       ## Format and Style
       - Use an objective, neutral third-person narrative tone
@@ -29,10 +28,10 @@ templates:
       - For technical documents: preserve key terms, metrics, and specific details
       - For meeting notes/reports: highlight decisions, action items, and conclusions
 
-      ## Important Notes
-      - NEVER output refusal phrases such as "unable to generate", "unable to summarize", or "insufficient content"
-      - Do not copy or reference any content from examples; ensure the summary is entirely based on the user's document
-      - Make every effort to extract key points and summarize for any text, regardless of length or complexity
+      ## Empty or Insufficient Content
+      - If the user-provided content is empty, contains only image/figure references with no extracted text, or otherwise carries no substantive textual information, you MUST output exactly the single line: "No textual content was extractable from this document." and nothing else.
+      - Do NOT fabricate a topic, do NOT guess from any other clue, and do NOT copy content from examples or unrelated sources.
+      - It is correct and expected to refuse to summarise when the content is absent. This is preferred over inventing a plausible-sounding but unsupported summary.
 
       ## Language
       - Use {{language}} for all outputs

--- a/internal/agent/prompts_wiki.go
+++ b/internal/agent/prompts_wiki.go
@@ -5,12 +5,16 @@ package agent
 // knowledge from raw documents and build/update wiki pages.
 
 // WikiSummaryPrompt generates a summary page for a newly ingested document.
+//
+// Filename and title are intentionally NOT passed to the LLM: documents
+// uploaded to WeKnora often carry filenames that say nothing about the
+// content (e.g. scanned PDFs named after the scanner model "MX5280.pdf"),
+// and feeding such filenames to the model invites hallucinated summaries
+// when the actual extracted content is thin. The model must rely solely on
+// the document content provided below.
 const WikiSummaryPrompt = `You are a wiki editor. Given the following document content, create a structured wiki summary page in Markdown format.
 
 <document>
-<title>{{.Title}}</title>
-<file_name>{{.FileName}}</file_name>
-<file_type>{{.FileType}}</file_type>
 <content>
 {{.Content}}
 </content>
@@ -30,6 +34,7 @@ const WikiSummaryPrompt = `You are a wiki editor. Given the following document c
 7. At the end, include a "## Key Takeaways" section with bullet points.
 8. Write in {{.Language}}.
 9. Keep the summary concise but thorough (500-1500 words depending on document length).
+10. **Empty content rule**: If the <content> block above is empty, contains only image references with no extracted text, or otherwise carries no substantive information, output exactly: "SUMMARY: No textual content was extractable from this document." followed by a brief note explaining that the document could not be summarised. Do NOT invent a topic, do NOT guess from any other clue.
 </instructions>
 
 Output the SUMMARY line first, then the Markdown content. Do not include any other preamble.`
@@ -40,7 +45,6 @@ Output the SUMMARY line first, then the Markdown content. Do not include any oth
 const WikiKnowledgeExtractPrompt = `You are a knowledge extraction system. Analyze the following document and extract all significant entities AND key concepts.
 
 <document>
-<title>{{.Title}}</title>
 <content>
 {{.Content}}
 </content>
@@ -53,6 +57,8 @@ const WikiKnowledgeExtractPrompt = `You are a knowledge extraction system. Analy
 <instructions>
 Return a JSON object with two arrays: "entities" and "concepts".
 **IMPORTANT: Write ALL names, descriptions, and details in {{.Language}}**.
+
+If the <content> block above is empty, contains only image references with no extracted text, or otherwise carries no substantive information, return {"entities": [], "concepts": []}. Do NOT invent entities or concepts from any other source.
 
 ### Slug Continuity Rules
 If previous slugs are provided above, you MUST follow these rules:
@@ -121,7 +127,6 @@ Output ONLY valid JSON. Example:
 const WikiCandidateSlugPrompt = `You are a knowledge extraction system. Analyze the following document and list all significant entities AND key concepts as a lightweight candidate set. Another pass will later attach concrete supporting chunks to each item, so you do NOT need to write exhaustive per-item facts here.
 
 <document>
-<title>{{.Title}}</title>
 <content>
 {{.Content}}
 </content>
@@ -134,6 +139,8 @@ const WikiCandidateSlugPrompt = `You are a knowledge extraction system. Analyze 
 <instructions>
 Return a JSON object with two arrays: "entities" and "concepts".
 **IMPORTANT: Write ALL names, descriptions, and details in {{.Language}}**.
+
+If the <content> block above is empty, contains only image references with no extracted text, or otherwise carries no substantive information, return {"entities": [], "concepts": []}. Do NOT invent entities or concepts from any other source.
 
 ### Extraction Scope (Granularity: {{.Granularity}})
 {{.GranularityGuidance}}
@@ -201,8 +208,6 @@ Output ONLY valid JSON. Example:
 // chunk IDs that substantively discuss it. This keeps per-slug "facts" in
 // their verbatim form (the chunk text) instead of asking the LLM to paraphrase.
 const WikiChunkCitationPrompt = `You are a precise citation system. Your job is to scan a batch of document chunks and decide, for each candidate entity/concept below, which chunks substantively discuss it.
-
-<document_title>{{.DocTitle}}</document_title>
 
 <candidate_slugs>
 {{.CandidateSlugs}}

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -2242,6 +2242,13 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 // defaultMaxInputChars is the default maximum characters used as input for summary generation.
 const defaultMaxInputChars = 1024 * 24
 
+// errInsufficientSummaryContent signals that getSummary refused to call the
+// LLM because the document had no usable text after image markup was stripped
+// (typical for scanned PDFs where VLM OCR yielded nothing). Callers should
+// mark the knowledge's summary as failed instead of falling back to the first
+// chunk's raw content (which would just be a bare image reference).
+var errInsufficientSummaryContent = errors.New("insufficient text content for summary generation")
+
 // getSummary generates a summary for knowledge content using an AI model
 func (s *knowledgeService) getSummary(ctx context.Context,
 	summaryModel chat.Chat, knowledge *types.Knowledge, chunks []*types.Chunk,
@@ -2295,21 +2302,22 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 	logger.GetLogger(ctx).Infof("getSummary: content length=%d chars (max=%d) for knowledge %s",
 		len([]rune(chunkContents)), maxInputChars, knowledge.ID)
 
-	// Prepare content with metadata for summary generation
-	contentWithMetadata := chunkContents
-
-	// Add knowledge metadata if available
-	if knowledge != nil {
-		metadataIntro := fmt.Sprintf("Document Type: %s\nFile Name: %s\n", knowledge.FileType, knowledge.FileName)
-
-		// Add additional metadata if available
-		if knowledge.Type != "" {
-			metadataIntro += fmt.Sprintf("Knowledge Type: %s\n", knowledge.Type)
-		}
-
-		// Prepend metadata to content
-		contentWithMetadata = metadataIntro + "\nContent:\n" + contentWithMetadata
+	// Bail out before the LLM call when there is not enough actual text to
+	// summarise. We deliberately do not pass filename/file-type metadata to the
+	// LLM: scanned PDFs frequently carry filenames like "MX5280.pdf" (the
+	// scanner model), and feeding that to the model would invite it to
+	// hallucinate a scanner manual instead of admitting the document had no
+	// extractable text.
+	if !hasSufficientTextContent(chunkContents) {
+		logger.GetLogger(ctx).Warnf(
+			"getSummary: content for knowledge %s has insufficient text after stripping image markup (len=%d); skipping LLM call",
+			knowledge.ID, len([]rune(strings.TrimSpace(stripImageMarkup(chunkContents)))),
+		)
+		return "", errInsufficientSummaryContent
 	}
+
+	// Pass the raw chunk text to the LLM with no filename / file-type framing.
+	contentWithMetadata := chunkContents
 
 	// Determine max output tokens from config
 	maxTokens := 2048
@@ -2482,11 +2490,24 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 	summary, err := s.getSummary(ctx, chatModel, knowledge, textChunks)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to generate summary for knowledge %s: %v", payload.KnowledgeID, err)
-		// Use first chunk content as fallback
+		// For the insufficient-content case (scanned PDF without OCR, etc.)
+		// we deliberately do NOT fall back to the first chunk's raw content,
+		// since that chunk is typically just a bare markdown image reference
+		// and surfacing it in the description is misleading.
+		if errors.Is(err, errInsufficientSummaryContent) {
+			knowledge.Description = ""
+			knowledge.SummaryStatus = types.SummaryStatusFailed
+			knowledge.UpdatedAt = time.Now()
+			if updateErr := s.repo.UpdateKnowledge(ctx, knowledge); updateErr != nil {
+				logger.Errorf(ctx, "Failed to mark summary as failed: %v", updateErr)
+				return fmt.Errorf("failed to update knowledge: %w", updateErr)
+			}
+			return nil
+		}
+		// For other errors (LLM API issues etc.), fall back to the first chunk.
 		if len(textChunks) > 0 {
 			summary = textChunks[0].Content
 			if len(summary) > 500 {
-				// Use rune-based truncation to avoid cutting UTF-8 multi-byte characters
 				runes := []rune(summary)
 				if len(runes) > 500 {
 					summary = string(runes[:500])

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -2249,6 +2249,25 @@ const defaultMaxInputChars = 1024 * 24
 // chunk's raw content (which would just be a bare image reference).
 var errInsufficientSummaryContent = errors.New("insufficient text content for summary generation")
 
+// checkSufficientSummaryContent returns errInsufficientSummaryContent if the
+// given content does not carry enough real text (after stripping image markup)
+// for an LLM summary call, and logs a warning at the call site. Returns nil
+// when the content passes the threshold.
+//
+// Extracted so the threshold gate can be unit-tested without standing up the
+// full ProcessSummaryGeneration dependency graph.
+func checkSufficientSummaryContent(ctx context.Context, knowledgeID, content string) error {
+	realTextLen := realTextRuneCount(content)
+	if realTextLen < minTextContentRunes {
+		logger.GetLogger(ctx).Warnf(
+			"summary content check: knowledge %s has insufficient text after stripping image markup (real_text_runes=%d, min=%d); skipping LLM call",
+			knowledgeID, realTextLen, minTextContentRunes,
+		)
+		return errInsufficientSummaryContent
+	}
+	return nil
+}
+
 // getSummary generates a summary for knowledge content using an AI model
 func (s *knowledgeService) getSummary(ctx context.Context,
 	summaryModel chat.Chat, knowledge *types.Knowledge, chunks []*types.Chunk,
@@ -2308,13 +2327,8 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 	// scanner model), and feeding that to the model would invite it to
 	// hallucinate a scanner manual instead of admitting the document had no
 	// extractable text.
-	realTextLen := realTextRuneCount(chunkContents)
-	if realTextLen < minTextContentRunes {
-		logger.GetLogger(ctx).Warnf(
-			"getSummary: content for knowledge %s has insufficient text after stripping image markup (real_text_runes=%d, min=%d); skipping LLM call",
-			knowledge.ID, realTextLen, minTextContentRunes,
-		)
-		return "", errInsufficientSummaryContent
+	if err := checkSufficientSummaryContent(ctx, knowledge.ID, chunkContents); err != nil {
+		return "", err
 	}
 
 	// Pass the raw chunk text to the LLM with no filename / file-type framing.

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -2308,10 +2308,11 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 	// scanner model), and feeding that to the model would invite it to
 	// hallucinate a scanner manual instead of admitting the document had no
 	// extractable text.
-	if !hasSufficientTextContent(chunkContents) {
+	realTextLen := realTextRuneCount(chunkContents)
+	if realTextLen < minTextContentRunes {
 		logger.GetLogger(ctx).Warnf(
-			"getSummary: content for knowledge %s has insufficient text after stripping image markup (len=%d); skipping LLM call",
-			knowledge.ID, len([]rune(strings.TrimSpace(stripImageMarkup(chunkContents)))),
+			"getSummary: content for knowledge %s has insufficient text after stripping image markup (real_text_runes=%d, min=%d); skipping LLM call",
+			knowledge.ID, realTextLen, minTextContentRunes,
 		)
 		return "", errInsufficientSummaryContent
 	}
@@ -2536,12 +2537,17 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 			}
 		}
 
+		// Embed only the LLM-generated summary in the indexed chunk.
+		// We deliberately omit knowledge.FileName here: filenames are an
+		// unreliable signal (e.g. "MX5280.pdf" for a scanned legal letter)
+		// and surfacing them in retrieved RAG context can re-introduce the
+		// hallucination vector this branch is meant to close.
 		summaryChunk := &types.Chunk{
 			ID:              uuid.New().String(),
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
-			Content:         fmt.Sprintf("# Document\n%s\n\n# Summary\n%s", knowledge.FileName, summary),
+			Content:         fmt.Sprintf("# Summary\n%s", summary),
 			ChunkIndex:      maxChunkIndex + 1,
 			IsEnabled:       true,
 			CreatedAt:       time.Now(),

--- a/internal/application/service/knowledge_summary_test.go
+++ b/internal/application/service/knowledge_summary_test.go
@@ -1,0 +1,105 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestCheckSufficientSummaryContent verifies the gate that prevents getSummary
+// from calling the LLM (and ProcessSummaryGeneration from creating a summary
+// chunk) when the document has no usable text. This is the entry point for
+// the errInsufficientSummaryContent → SummaryStatusFailed flow that the
+// caller in ProcessSummaryGeneration relies on.
+func TestCheckSufficientSummaryContent(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		content   string
+		wantError bool
+	}{
+		{
+			name:      "empty content rejected",
+			content:   "",
+			wantError: true,
+		},
+		{
+			name:      "only whitespace rejected",
+			content:   "   \n\n\t  ",
+			wantError: true,
+		},
+		{
+			name:      "below threshold rejected",
+			content:   "hi",
+			wantError: true,
+		},
+		{
+			name: "scanned PDF with no OCR (image-only) rejected",
+			content: "![MX5280_page_1.png](images/MX5280_page_1.png)\n" +
+				"![MX5280_page_2.png](images/MX5280_page_2.png)",
+			wantError: true,
+		},
+		{
+			name: "scanned PDF with empty <image> wrapper rejected",
+			content: `<image url="x"><image_original>![a](x)</image_original></image>`,
+			wantError: true,
+		},
+		{
+			name:      "short legitimate note above threshold accepted",
+			content:   "Meeting at 3pm tomorrow.",
+			wantError: false,
+		},
+		{
+			name: "scanned PDF with successful VLM OCR accepted",
+			content: `<image url="images/p1.png">
+<image_original>![p1](images/p1.png)</image_original>
+<image_caption>scanned letter</image_caption>
+<image_ocr>Sehr geehrter Herr Mustermann, in der Sache 4711/2024 ...</image_ocr>
+</image>`,
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkSufficientSummaryContent(ctx, "test-knowledge-id", tt.content)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("expected errInsufficientSummaryContent, got nil")
+					return
+				}
+				if !errors.Is(err, errInsufficientSummaryContent) {
+					t.Errorf("expected errInsufficientSummaryContent sentinel, got %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestCheckSufficientSummaryContent_ThresholdOverride verifies that
+// minTextContentRunes is a `var` (not const) so tests and future runtime
+// configuration can adjust the threshold without a rebuild.
+func TestCheckSufficientSummaryContent_ThresholdOverride(t *testing.T) {
+	ctx := context.Background()
+	content := "Meeting at 3pm." // 15 runes
+
+	originalThreshold := minTextContentRunes
+	t.Cleanup(func() { minTextContentRunes = originalThreshold })
+
+	// With default threshold (10), this content passes.
+	if err := checkSufficientSummaryContent(ctx, "kid", content); err != nil {
+		t.Fatalf("default threshold: expected pass, got %v", err)
+	}
+
+	// With a tighter threshold (50), the same content is rejected.
+	minTextContentRunes = 50
+	err := checkSufficientSummaryContent(ctx, "kid", content)
+	if !errors.Is(err, errInsufficientSummaryContent) {
+		t.Fatalf("tightened threshold: expected errInsufficientSummaryContent, got %v", err)
+	}
+}

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -1211,6 +1212,48 @@ func appendUnique(arr types.StringArray, s string) types.StringArray {
 		}
 	}
 	return append(arr, s)
+}
+
+// minTextContentRunes is the minimum number of non-whitespace, non-image-reference
+// runes required for content to be considered substantive enough for LLM
+// summarization or wiki extraction. Documents below this threshold (e.g. a
+// scanned PDF where OCR yielded nothing) are routed to a deterministic empty-
+// content fallback instead of being passed to the LLM, which would otherwise
+// hallucinate based on metadata alone.
+const minTextContentRunes = 50
+
+var (
+	mdImageRefRE = regexp.MustCompile(`!\[[^\]]*\]\([^)]*\)`)
+	// Strip the outer <images> wrapper before the inner <image> blocks so that
+	// nested structures like "<images><image>x</image></images>" don't leave a
+	// stray closing tag behind. RE2 has no backreferences, so we use two
+	// separate patterns instead of `<(image|images)\b...</\1>`.
+	htmlImagesBlockRE = regexp.MustCompile(`(?is)<images\b[^>]*>.*?</images>`)
+	htmlImageBlockRE  = regexp.MustCompile(`(?is)<image\b[^>]*>.*?</image>`)
+	htmlImageTagRE    = regexp.MustCompile(`(?i)<img\b[^>]*>`)
+)
+
+// stripImageMarkup removes markdown image references, raw <img> tags, and
+// <image>/<images> XML blocks so that content consisting only of image
+// placeholders (e.g. from PDFScannedParser pages without successful VLM OCR)
+// is recognised as effectively empty.
+func stripImageMarkup(s string) string {
+	s = htmlImagesBlockRE.ReplaceAllString(s, "")
+	s = htmlImageBlockRE.ReplaceAllString(s, "")
+	s = mdImageRefRE.ReplaceAllString(s, "")
+	s = htmlImageTagRE.ReplaceAllString(s, "")
+	return s
+}
+
+// hasSufficientTextContent reports whether the given content carries enough
+// real text (after image markup is stripped) to warrant an LLM call. It is
+// the primary defence against filename-driven hallucinations on scanned PDFs.
+func hasSufficientTextContent(content string) bool {
+	stripped := strings.TrimSpace(stripImageMarkup(content))
+	if stripped == "" {
+		return false
+	}
+	return len([]rune(stripped)) >= minTextContentRunes
 }
 
 // cleanLLMJSON strips markdown code-fence wrappers and sanitizes control characters

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -1225,7 +1225,10 @@ func appendUnique(arr types.StringArray, s string) types.StringArray {
 // The threshold is intentionally low: legitimate short documents (brief
 // memos, single-line notes) must still pass. The goal is only to catch
 // the empty-image-only case.
-const minTextContentRunes = 10
+//
+// Declared as a var (not const) so tests can override it and future config
+// plumbing can adjust it at runtime without a rebuild.
+var minTextContentRunes = 10
 
 var (
 	// Markdown image references like ![alt](path) — pure visual placeholders

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"text/template"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Tencent/WeKnora/internal/agent"
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -1217,43 +1218,76 @@ func appendUnique(arr types.StringArray, s string) types.StringArray {
 // minTextContentRunes is the minimum number of non-whitespace, non-image-reference
 // runes required for content to be considered substantive enough for LLM
 // summarization or wiki extraction. Documents below this threshold (e.g. a
-// scanned PDF where OCR yielded nothing) are routed to a deterministic empty-
-// content fallback instead of being passed to the LLM, which would otherwise
-// hallucinate based on metadata alone.
-const minTextContentRunes = 50
+// scanned PDF where OCR yielded nothing AND no caption either) are routed to
+// a deterministic empty-content fallback instead of being passed to the LLM,
+// which would otherwise hallucinate based on metadata alone.
+//
+// The threshold is intentionally low: legitimate short documents (brief
+// memos, single-line notes) must still pass. The goal is only to catch
+// the empty-image-only case.
+const minTextContentRunes = 10
 
 var (
+	// Markdown image references like ![alt](path) — pure visual placeholders
+	// with no extractable text, so the whole reference is removed.
 	mdImageRefRE = regexp.MustCompile(`!\[[^\]]*\]\([^)]*\)`)
-	// Strip the outer <images> wrapper before the inner <image> blocks so that
-	// nested structures like "<images><image>x</image></images>" don't leave a
-	// stray closing tag behind. RE2 has no backreferences, so we use two
-	// separate patterns instead of `<(image|images)\b...</\1>`.
-	htmlImagesBlockRE = regexp.MustCompile(`(?is)<images\b[^>]*>.*?</images>`)
-	htmlImageBlockRE  = regexp.MustCompile(`(?is)<image\b[^>]*>.*?</image>`)
-	htmlImageTagRE    = regexp.MustCompile(`(?i)<img\b[^>]*>`)
+
+	// <image_original>...</image_original> blocks wrap the verbatim Markdown
+	// image reference inside an enriched <image> block (see
+	// searchutil.EnrichContentWithImageInfo). The content is just a redundant
+	// copy of an already-stripped image link, so the whole block (tags +
+	// content) is removed.
+	imageOriginalBlockRE = regexp.MustCompile(`(?is)<image_original\b[^>]*>.*?</image_original>`)
+
+	// Self-closing or attribute-only HTML <img> tags.
+	htmlImgTagRE = regexp.MustCompile(`(?i)<img\b[^>]*/?>`)
+
+	// Wrapper-style <image>, <images>, <image_caption>, <image_ocr> tags
+	// (opening or closing). Matches ONLY the tag; the text content between
+	// open and close tags is preserved. This is critical: VLM-generated OCR
+	// and caption text live inside <image_ocr>...</image_ocr> and
+	// <image_caption>...</image_caption> blocks, and stripping the content
+	// would silently destroy the very text we want to keep.
+	imageWrapperTagRE = regexp.MustCompile(`(?i)</?image[a-z_]*\b[^>]*/?>`)
 )
 
-// stripImageMarkup removes markdown image references, raw <img> tags, and
-// <image>/<images> XML blocks so that content consisting only of image
-// placeholders (e.g. from PDFScannedParser pages without successful VLM OCR)
-// is recognised as effectively empty.
+// stripImageMarkup removes image-only placeholders (Markdown image refs,
+// <img> tags, <image_original> redundancy blocks) and unwraps the
+// <image>/<image_caption>/<image_ocr> XML wrappers produced by the search
+// enrichment layer, leaving any OCR or caption text as plain inline text.
+//
+// This shape matters: when VLM OCR succeeds on a scanned PDF page, the
+// extracted text reaches downstream code wrapped in <image_ocr> tags inside
+// an <image> block. A naive "strip the whole <image>...</image> block"
+// approach would discard the OCR text — the exact opposite of what we want.
 func stripImageMarkup(s string) string {
-	s = htmlImagesBlockRE.ReplaceAllString(s, "")
-	s = htmlImageBlockRE.ReplaceAllString(s, "")
+	s = imageOriginalBlockRE.ReplaceAllString(s, "")
 	s = mdImageRefRE.ReplaceAllString(s, "")
-	s = htmlImageTagRE.ReplaceAllString(s, "")
+	s = htmlImgTagRE.ReplaceAllString(s, "")
+	s = imageWrapperTagRE.ReplaceAllString(s, "")
 	return s
 }
 
+// extractRealText returns the trimmed content with image markup stripped.
+// Cached at the call site for use both in the threshold check and in any
+// subsequent log message, avoiding redundant regex passes over large docs.
+func extractRealText(content string) string {
+	return strings.TrimSpace(stripImageMarkup(content))
+}
+
 // hasSufficientTextContent reports whether the given content carries enough
-// real text (after image markup is stripped) to warrant an LLM call. It is
-// the primary defence against filename-driven hallucinations on scanned PDFs.
+// real text (after image markup is stripped, with OCR/caption text retained)
+// to warrant an LLM call. It is the primary defence against filename-driven
+// hallucinations on scanned PDFs that have NO usable text at all.
 func hasSufficientTextContent(content string) bool {
-	stripped := strings.TrimSpace(stripImageMarkup(content))
-	if stripped == "" {
-		return false
-	}
-	return len([]rune(stripped)) >= minTextContentRunes
+	return realTextRuneCount(content) >= minTextContentRunes
+}
+
+// realTextRuneCount returns the rune length of the content after image
+// markup is stripped. Uses utf8.RuneCountInString to avoid allocating a
+// rune slice for the count.
+func realTextRuneCount(content string) int {
+	return utf8.RuneCountInString(extractRealText(content))
 }
 
 // cleanLLMJSON strips markdown code-fence wrappers and sanitizes control characters

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -473,6 +473,18 @@ func (s *wikiIngestService) mapOneDocument(
 	}
 	logger.Infof(ctx, "wiki ingest: doc %s chunks=%d content_len(raw=%d,truncated=%d)", knowledgeID, len(chunks), rawRuneCount, len([]rune(content)))
 
+	// Refuse to run LLM-based extraction when the document carries no real
+	// text — e.g. a scanned PDF whose pages were converted to images but where
+	// VLM OCR produced nothing usable. Without this guard the LLM would have
+	// only image markup left and would happily fabricate entities/concepts.
+	if !hasSufficientTextContent(content) {
+		logger.Warnf(ctx,
+			"wiki ingest: doc %s has insufficient text content after stripping image markup (raw_len=%d), skipping LLM extraction",
+			knowledgeID, rawRuneCount,
+		)
+		return nil, nil, nil
+	}
+
 	docTitle := knowledgeID
 	if kn, err := s.knowledgeSvc.GetKnowledgeByIDOnly(ctx, knowledgeID); err == nil && kn != nil && kn.Title != "" {
 		docTitle = kn.Title
@@ -547,9 +559,6 @@ func (s *wikiIngestService) mapOneDocument(
 	go func() {
 		defer wg.Done()
 		summaryContent, summaryErr = s.generateWithTemplate(ctx, chatModel, agent.WikiSummaryPrompt, map[string]string{
-			"Title":          docTitle,
-			"FileName":       docTitle,
-			"FileType":       "document",
 			"Content":        content,
 			"Language":       lang,
 			"ExtractedSlugs": slugListing,
@@ -780,7 +789,6 @@ func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 	}
 
 	extractionJSON, err := s.generateWithTemplate(ctx, chatModel, agent.WikiKnowledgeExtractPrompt, map[string]string{
-		"Title":         docTitle,
 		"Content":       content,
 		"Language":      lang,
 		"PreviousSlugs": prevSlugsText,

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -779,7 +779,7 @@ func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 	batchCtx *WikiBatchContext,
 ) ([]extractedItem, []extractedItem, map[string]extractedItem, error) {
 	// Only entity/* and concept/* slugs are relevant for LLM slug-continuity —
-	// summary slugs are code-generated from the document title and never appear
+	// summary slugs are code-generated from the knowledge ID and never appear
 	// in the extraction output, so including them just wastes tokens and risks
 	// confusing the model.
 	var prevSlugsText string

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -500,7 +500,11 @@ func (s *wikiIngestService) mapOneDocument(
 		}
 	}
 
-	sourceRef := fmt.Sprintf("%s|%s", knowledgeID, docTitle)
+	// Citation source reference. We deliberately use only the knowledge ID
+	// (not docTitle, which is typically the upload filename) so the filename
+	// does not leak into citation strings that downstream LLM prompts may
+	// surface during wiki page editing.
+	sourceRef := knowledgeID
 	oldPageSlugs := s.getExistingPageSlugsForKnowledge(ctx, payload.KnowledgeBaseID, knowledgeID)
 
 	// Pass 0: lightweight candidate slug extraction (skeleton only).
@@ -513,11 +517,11 @@ func (s *wikiIngestService) mapOneDocument(
 		pass0Failed       bool
 	)
 	logger.Infof(ctx, "wiki ingest: pass 0 — extracting candidate slugs for %s", knowledgeID)
-	extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, chatModel, content, docTitle, lang, oldPageSlugs, batchCtx)
+	extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, chatModel, content, lang, oldPageSlugs, batchCtx)
 	if err != nil {
 		logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) — falling back to legacy extractor", knowledgeID, err)
 		pass0Failed = true
-		extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, content, docTitle, lang, oldPageSlugs, batchCtx)
+		extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, content, lang, oldPageSlugs, batchCtx)
 		if err != nil {
 			logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
 			return nil, nil, err
@@ -529,7 +533,12 @@ func (s *wikiIngestService) mapOneDocument(
 	for slug := range slugItems {
 		summaryExtractedPages = append(summaryExtractedPages, slug)
 	}
-	summarySlug := fmt.Sprintf("summary/%s", slugify(docTitle))
+	// Wiki summary slug is derived from the knowledge ID rather than the
+	// docTitle (which is typically the upload filename). Filename-based slugs
+	// like "summary/mx5280-pdf" expose the filename in cross-link contexts
+	// that downstream LLM prompts read; a UUID-based slug is uglier but
+	// hallucination-safe.
+	summarySlug := fmt.Sprintf("summary/%s", slugify(knowledgeID))
 	var slugListing string
 	for _, slug := range summaryExtractedPages {
 		if item, ok := slugItems[slug]; ok {
@@ -574,7 +583,7 @@ func (s *wikiIngestService) mapOneDocument(
 			return
 		}
 		candidatesXML := renderCandidateSlugsXML(extractedEntities, extractedConcepts)
-		citations, newSlugs, batchCount = s.classifyChunkCitations(ctx, chatModel, candidatesXML, docTitle, chunks, lang)
+		citations, newSlugs, batchCount = s.classifyChunkCitations(ctx, chatModel, candidatesXML, chunks, lang)
 	}()
 	wg.Wait()
 
@@ -765,7 +774,7 @@ func (s *wikiIngestService) mapOneDocument(
 func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 	ctx context.Context,
 	chatModel chat.Chat,
-	content, docTitle, lang string,
+	content, lang string,
 	oldPageSlugs map[string]bool,
 	batchCtx *WikiBatchContext,
 ) ([]extractedItem, []extractedItem, map[string]extractedItem, error) {

--- a/internal/application/service/wiki_ingest_cite.go
+++ b/internal/application/service/wiki_ingest_cite.go
@@ -92,7 +92,6 @@ func (s *wikiIngestService) extractCandidateSlugs(
 
 	granularity := batchCtx.ExtractionGranularity.Normalize()
 	raw, err := s.generateWithTemplate(ctx, chatModel, agent.WikiCandidateSlugPrompt, map[string]string{
-		"Title":               docTitle,
 		"Content":             content,
 		"Language":            lang,
 		"PreviousSlugs":       prevSlugsText,
@@ -301,7 +300,6 @@ func (s *wikiIngestService) classifyChunkCitations(
 		eg.Go(func() error {
 			chunksXML := renderChunksXML(batch)
 			raw, err := s.generateWithTemplate(ectx, chatModel, agent.WikiChunkCitationPrompt, map[string]string{
-				"DocTitle":       docTitle,
 				"CandidateSlugs": candidatesXML,
 				"ChunksXML":      chunksXML,
 				"Language":       lang,

--- a/internal/application/service/wiki_ingest_cite.go
+++ b/internal/application/service/wiki_ingest_cite.go
@@ -71,7 +71,7 @@ type citationPipelineOutcome struct {
 func (s *wikiIngestService) extractCandidateSlugs(
 	ctx context.Context,
 	chatModel chat.Chat,
-	content, docTitle, lang string,
+	content, lang string,
 	oldPageSlugs map[string]bool,
 	batchCtx *WikiBatchContext,
 ) ([]extractedItem, []extractedItem, map[string]extractedItem, error) {
@@ -276,7 +276,6 @@ func (s *wikiIngestService) classifyChunkCitations(
 	ctx context.Context,
 	chatModel chat.Chat,
 	candidatesXML string,
-	docTitle string,
 	chunks []*types.Chunk,
 	lang string,
 ) (map[string][]string, []newSlugFromCitation, int) {

--- a/internal/application/service/wiki_ingest_test.go
+++ b/internal/application/service/wiki_ingest_test.go
@@ -106,3 +106,70 @@ func TestReconstructContentEmpty(t *testing.T) {
 		t.Errorf("Empty chunks should produce empty content, got %q", content)
 	}
 }
+
+func TestStripImageMarkup(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain text untouched", "Hello world.", "Hello world."},
+		{"single markdown image removed", "![alt](images/page_1.png)", ""},
+		{
+			"scanned-pdf style page references all stripped",
+			"![MX5280_page_1.png](images/MX5280_page_1.png)\n\n![MX5280_page_2.png](images/MX5280_page_2.png)",
+			"\n\n",
+		},
+		{"mixed text and image keeps text", "Intro paragraph.\n![fig](a.png)\nConclusion.", "Intro paragraph.\n\nConclusion."},
+		{"html img tag stripped", `Before <img src="x.png" alt="y"/> after`, "Before  after"},
+		{"images xml block stripped", "Body <images><image>x</image></images> tail", "Body  tail"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripImageMarkup(tt.input)
+			if got != tt.want {
+				t.Errorf("stripImageMarkup(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasSufficientTextContent(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"empty string", "", false},
+		{"only whitespace", "   \n\n\t  ", false},
+		{
+			"only image references (scanned PDF without OCR)",
+			"![MX5280_page_1.png](images/MX5280_page_1.png)\n![MX5280_page_2.png](images/MX5280_page_2.png)",
+			false,
+		},
+		{"short text below threshold", "tiny", false},
+		{
+			"short text mixed with images still below threshold",
+			"![a](x.png)\nshort\n![b](y.png)",
+			false,
+		},
+		{
+			"sufficient text passes",
+			"This is a substantial paragraph of real content describing a legal matter and the parties involved.",
+			true,
+		},
+		{
+			"sufficient text mixed with images still passes",
+			"![cover](cover.png)\nThis is a substantial paragraph of real content describing a legal matter and the parties involved.\n![sig](sig.png)",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasSufficientTextContent(tt.input)
+			if got != tt.want {
+				t.Errorf("hasSufficientTextContent(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/application/service/wiki_ingest_test.go
+++ b/internal/application/service/wiki_ingest_test.go
@@ -122,7 +122,24 @@ func TestStripImageMarkup(t *testing.T) {
 		},
 		{"mixed text and image keeps text", "Intro paragraph.\n![fig](a.png)\nConclusion.", "Intro paragraph.\n\nConclusion."},
 		{"html img tag stripped", `Before <img src="x.png" alt="y"/> after`, "Before  after"},
-		{"images xml block stripped", "Body <images><image>x</image></images> tail", "Body  tail"},
+		{
+			// Regression guard: an earlier version stripped the WHOLE
+			// <image>...</image> block (including <image_ocr> content),
+			// silently destroying successful VLM OCR results. The fix must
+			// preserve the inner OCR / caption text.
+			"enriched <image> block keeps inner OCR + caption text",
+			`<image url="images/page_1.png">
+<image_original>![p1](images/page_1.png)</image_original>
+<image_caption>scanned letter on letterhead</image_caption>
+<image_ocr>SEHR GEEHRTER HERR MUSTERMANN, ...</image_ocr>
+</image>`,
+			"\n\nscanned letter on letterhead\nSEHR GEEHRTER HERR MUSTERMANN, ...\n",
+		},
+		{
+			"empty <image> block (OCR failed) reduces to whitespace",
+			`<image url="x"><image_original>![a](x)</image_original></image>`,
+			"",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -147,20 +164,31 @@ func TestHasSufficientTextContent(t *testing.T) {
 			"![MX5280_page_1.png](images/MX5280_page_1.png)\n![MX5280_page_2.png](images/MX5280_page_2.png)",
 			false,
 		},
-		{"short text below threshold", "tiny", false},
+		{"too-short text below 10-rune threshold", "hi", false},
 		{
-			"short text mixed with images still below threshold",
-			"![a](x.png)\nshort\n![b](y.png)",
-			false,
-		},
-		{
-			"sufficient text passes",
-			"This is a substantial paragraph of real content describing a legal matter and the parties involved.",
+			"short legitimate note above threshold",
+			"Meeting at 3pm tomorrow.",
 			true,
 		},
 		{
+			"image-only with successful VLM OCR (the fix)",
+			`<image url="images/p1.png">
+<image_original>![p1](images/p1.png)</image_original>
+<image_caption>scanned letter</image_caption>
+<image_ocr>Sehr geehrter Herr Mustermann, in der Sache 4711/2024 ...</image_ocr>
+</image>`,
+			true,
+		},
+		{
+			"image-only with failed VLM OCR (still rejected)",
+			`<image url="images/p1.png">
+<image_original>![p1](images/p1.png)</image_original>
+</image>`,
+			false,
+		},
+		{
 			"sufficient text mixed with images still passes",
-			"![cover](cover.png)\nThis is a substantial paragraph of real content describing a legal matter and the parties involved.\n![sig](sig.png)",
+			"![cover](cover.png)\nDie Beklagte hat die Klage anerkannt.\n![sig](sig.png)",
 			true,
 		},
 	}


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
Scanned PDFs without embedded text reach the summary and wiki-ingest
pipelines with no extractable content — only Markdown image references.
The downstream LLM prompts used to receive the filename, file type, and
title alongside that empty content, and the `generate_summary` template
explicitly forbade the model from refusing. As a result, uploading a
scanned legal letter named after the scanner model (e.g. `MX5280.pdf`)
produced a confidently-fabricated "Canon scanner manual" summary.

This PR closes that hallucination vector with two layers of defence:

1. **Filename / title removed from every LLM prompt input.** The wiki
   summary, knowledge extract, candidate slug, and chunk citation
   prompts now see only the document content. The knowledge summary
   path no longer prepends the `Document Type: X / File Name: Y` intro.

2. **Content-sufficiency guard before the LLM call.** A new helper
   strips Markdown image references and HTML image tags while
   preserving inner `<image_ocr>` / `<image_caption>` text from the
   search-enrichment layer. If fewer than 10 real-text runes remain,
   `getSummary` returns a sentinel error and the caller marks the
   knowledge as `SummaryStatusFailed`; wiki ingest skips LLM extraction
   with a clear log line.

Additional cleanups:
- The `generate_summary.yaml` prompt drops its "NEVER refuse" clause
  and gains an explicit empty-content rule that returns a deterministic
  placeholder line.
- `FileName` is no longer embedded in the indexed summary chunk,
  preventing the filename from leaking back into RAG retrieval context.
- The wiki summary slug is derived from the knowledge ID instead of
  the upload filename, so cross-link contexts that downstream prompts
  read no longer expose filename strings.
- Citation `sourceRef` drops the `|<docTitle>` suffix; all existing
  parsers handle the pipe-less form via their existing fallback path.
- Dead `docTitle` parameter removed from three extract / classify
  functions and their callers.

Real OCR (Tesseract / PaddleOCR) and filename-pattern sanitisation are
intentionally out of scope here and tracked for separate PRs.

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)
- [x] 配置文件 (Configuration) — `config/prompt_templates/generate_summary.yaml`

## 测试 (Testing)
- [x] 单元测试 (Unit tests)
- [x] 手动测试 (Manual testing)

### 测试步骤 (Test Steps)
1. Upload a scanned PDF whose filename misleadingly references the
   scanner model (e.g. `MX5280.pdf`) into a KB that has **no VLM
   configured**. Confirm the knowledge surfaces with
   `summary_status = failed` and an empty description rather than a
   fabricated summary.
2. Upload the same kind of scanned PDF into a KB that has VLM enabled
   and successful OCR. Confirm the summary is generated from the
   recovered OCR text and reflects the real document content.
3. Upload a regular text PDF / DOCX. Confirm summary generation and
   wiki ingest still work end-to-end with no regressions.
4. Upload a very short legitimate note (e.g. one sentence ≥ 10 runes)
   and confirm it is summarised normally.
5. Re-ingest a knowledge that previously produced a filename-based
   wiki slug (`summary/<filename-slug>`) and confirm the stale slug
   is retracted while the new UUID-based slug is created.

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [x] 变更不会产生新的警告 (`go build ./...` and `go vet ./...` clean)
- [x] 已添加测试用例证明修复有效或功能正常
  (`TestStripImageMarkup`, `TestHasSufficientTextContent` — including
  a regression guard that pins the `<image_ocr>` preservation case)
- [ ] 破坏性变更已在描述中明确说明 (no breaking changes)

## 相关 Issue
N/A — discovered during user testing of a scanned legal document.

## 截图/录屏 (Screenshots/Recordings)
N/A — backend-only change.

## 数据库迁移 (Database Migration)
- [x] 不需要数据库迁移

Existing wiki rows that carry the legacy `knowledgeID|filename`
`source_refs` format remain readable: every parser in the codebase
already has a pipe-less fallback path, and `ListBySourceRef` /
`removeSourceRef` query both formats. New rows written by this PR
use the pipe-less form.

## 配置变更 (Configuration Changes)
`config/prompt_templates/generate_summary.yaml` is updated:
- The `NEVER output refusal phrases` clause is removed.
- A new `Empty or Insufficient Content` section instructs the model to
  output the deterministic line `No textual content was extractable
  from this document.` instead of fabricating a summary.

Deployments that override this template via `generate_summary_prompt_id`
should mirror the same change in their custom template, otherwise the
hallucination behaviour can return through the custom prompt.

## 部署说明 (Deployment Notes)
Rolling deploy is safe. On first ingest after rollout, scanned PDFs
that previously produced a filename-based summary will be marked as
`summary_status = failed`; any wiki pages whose slug was derived from
the filename (`summary/<filename-slug>`) become stale and will be
retracted on the next re-ingest of the affected knowledge — this is
the intended migration path.

## 其他信息 (Additional Information)
Known remaining filename surface (intentionally out of scope here):
- Wiki page display titles and the wiki-index-rebuild prompt still
  flow `DocTitle` (today populated from the upload filename) through
  to the LLM. Closing that channel requires a larger refactor of the
  wiki edit pipeline and is tracked for a follow-up PR.
- Real local OCR (Tesseract / PaddleOCR) for scanned PDFs that have
  no VLM configured is also a separate follow-up.