### PR TITLE
fix(memory): dedupe episode write on duplicate streaming Done

### DIFF
--- a/internal/application/service/chat_pipeline/memory.go
+++ b/internal/application/service/chat_pipeline/memory.go
@@ -3,6 +3,7 @@ package chatpipeline
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/Tencent/WeKnora/internal/event"
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -118,6 +119,7 @@ func (p *MemoryPlugin) handleStorage(
 	// If streaming, subscribe to events
 	if chatManage.EventBus != nil {
 		var fullResponse string
+		var storeOnce sync.Once
 		userID := chatManage.UserID
 		sessionID := chatManage.SessionID
 		bgCtx := context.WithoutCancel(ctx)
@@ -129,15 +131,19 @@ func (p *MemoryPlugin) handleStorage(
 			}
 			fullResponse += data.Content
 			if data.Done {
-				messages := []types.Message{
-					{Role: "user", Content: chatManage.Query},
-					{Role: "assistant", Content: fullResponse},
-				}
-				go func() {
-					if err := p.memoryService.AddEpisode(bgCtx, userID, sessionID, messages); err != nil {
-						logger.Errorf(bgCtx, "failed to add episode: %v", err)
+				// Stream layer may emit Done:true twice (e.g. finish_reason chunk + EOF sentinel).
+				// qa.go dedupes with completionHandled; keep memory writes consistent with one episode only.
+				storeOnce.Do(func() {
+					messages := []types.Message{
+						{Role: "user", Content: chatManage.Query},
+						{Role: "assistant", Content: fullResponse},
 					}
-				}()
+					go func() {
+						if err := p.memoryService.AddEpisode(bgCtx, userID, sessionID, messages); err != nil {
+							logger.Errorf(bgCtx, "failed to add episode: %v", err)
+						}
+					}()
+				})
 			}
 			return nil
 		})


### PR DESCRIPTION
# Pull Request

## 描述 (Description)

流式对话结束时，`AgentFinalAnswer` 可能被发送多次 `Done: true`（例如 finish 分片与 EOF 哨兵），导致记忆插件在每次 `Done` 时都异步调用 `AddEpisode`。`AddEpisode` 内部会再次调用 KnowledgeQA 模型做图谱抽取并写入记忆图，从而造成**同一轮对话重复写入记忆、重复模型调用**。

本 PR 在流式路径下使用 `sync.Once` 包裹触发 `AddEpisode` 的逻辑，确保每轮仅持久化一次 episode，与 `qa.go` 中对完成的去重行为一致。

## 变更类型 (Type of Change)

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [ ] 📚 文档更新 (Documentation update)
- [ ] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [ ] 🧪 测试相关 (Test related)
- [ ] 🔧 配置变更 (Configuration change)
- [ ] 🐳 Docker 相关 (Docker related)
- [ ] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)

- [x] 后端 API (Backend API)
- [ ] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [ ] 其他 (Other):

（说明：记忆写入经 `MemoryService.AddEpisode` 调用模型并写入记忆仓储，属后端聊天流水线行为。）

## 测试 (Testing)

- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)


## 检查清单 (Checklist)

- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明


## 数据库迁移 (Database Migration)

- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)

无。

## 部署说明 (Deployment Notes)

无特殊部署步骤；合并后随常规后端发布即可。

## 其他信息 (Additional Information)

- **注意**：开启记忆后，一轮对话仍可能存在「检索」与「写入」各一次 KnowledgeQA 调用（`RetrieveMemory` 关键词抽取 + `AddEpisode` 图谱抽取），这是既有产品设计；本 PR 仅消除因**重复 `Done`** 导致的**额外一次写入侧调用**。
- **变更文件**：`internal/application/service/chat_pipeline/memory.go`