### PR TITLE
fix: 修复流式回答think/answer混淆及对话结束标记问题

### DIFF
--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -55,7 +55,7 @@ marked.use({
   breaks: true,      // 启用单行换行转 <br>
   gfm: true,         // 启用 GitHub Flavored Markdown
 });
-marked.use(markedKatex({ throwOnError: false }));
+marked.use(markedKatex({ throwOnError: false, nonStandard: true }));
 
 const preprocessMathDelimiters = (rawText: string): string => {
   if (!rawText || typeof rawText !== 'string') {

--- a/frontend/src/components/document-preview.vue
+++ b/frontend/src/components/document-preview.vue
@@ -218,7 +218,7 @@ async function renderMarkdown(blob: Blob) {
     breaks: true,
     gfm: true,
   });
-  marked.use(markedKatex({ throwOnError: false }));
+  marked.use(markedKatex({ throwOnError: false, nonStandard: true }));
   const renderer = new marked.Renderer();
   renderer.code = function ({text, lang}) {
     // 空值校验：防止 text 为 undefined 或 null

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -736,7 +736,7 @@ const props = defineProps<{
 
 // Configure marked for security
 marked.use({});
-marked.use(markedKatex({ throwOnError: false }));
+marked.use(markedKatex({ throwOnError: false, nonStandard: true }));
 
 const preprocessMathDelimiters = (rawText: string): string => {
   if (!rawText || typeof rawText !== 'string') {
@@ -1684,6 +1684,28 @@ const preprocessMarkdown = (contentStr: string): string => {
     );
 };
 
+const HTML_PLACEHOLDER_RE = /@@WEKNORA_HTML_PLACEHOLDER_(\d+)@@/g;
+
+const extractRenderableHtmlPlaceholders = (contentStr: string): { content: string; htmlSnippets: string[] } => {
+  const htmlSnippets: string[] = [];
+  const storeHtml = (html: string): string => {
+    const idx = htmlSnippets.length;
+    htmlSnippets.push(html);
+    return `@@WEKNORA_HTML_PLACEHOLDER_${idx}@@`;
+  };
+
+  const content = contentStr
+    .replace(/<(?:kb|web)\b[^>]*\/>/g, (match) => storeHtml(preprocessMarkdown(match)))
+    .replace(/\[\[([^\]]+)\]\]/g, (match) => storeHtml(preprocessMarkdown(match)));
+
+  return { content, htmlSnippets };
+};
+
+const restoreRenderableHtmlPlaceholders = (html: string, htmlSnippets: string[]): string => {
+  if (!htmlSnippets.length) return html;
+  return html.replace(HTML_PLACEHOLDER_RE, (_match, idx) => htmlSnippets[Number(idx)] || '');
+};
+
 // 自定义渲染器 - 支持 Mermaid
 const agentRenderer = new marked.Renderer();
 agentRenderer.code = createMermaidCodeRenderer('mermaid-agent');
@@ -1730,9 +1752,12 @@ const renderMarkdownContent = (content: any): string => {
   // Restore preserved tags
   sanitized = sanitized.replace(/\x00TAG(\d+)\x00/g, (_, idx) => tagPlaceholders[Number(idx)]);
 
-  const processed = preprocessMarkdown(preprocessMathDelimiters(sanitized));
-  const html = marked.parse(processed, { renderer: agentRenderer }) as string;
-  const protectedHTML = protectProviderImageSrcInHTML(html);
+  const mathSafe = preprocessMathDelimiters(sanitized);
+  const imageSafe = replaceIncompleteImageWithPlaceholder(mathSafe);
+  const { content: markdownWithPlaceholders, htmlSnippets } = extractRenderableHtmlPlaceholders(imageSafe);
+  const html = marked.parse(markdownWithPlaceholders, { renderer: agentRenderer }) as string;
+  const htmlWithCitations = restoreRenderableHtmlPlaceholders(html, htmlSnippets);
+  const protectedHTML = protectProviderImageSrcInHTML(htmlWithCitations);
   return DOMPurify.sanitize(protectedHTML, DOMPurifyConfig);
 };
 
@@ -1742,11 +1767,14 @@ const renderMarkdown = (content: any): string => {
   if (!contentStr.trim()) return '';
 
   try {
-    const processed = preprocessMarkdown(preprocessMathDelimiters(contentStr));
-    const html = marked.parse(processed, { renderer: agentRenderer }) as string;
+    const mathSafe = preprocessMathDelimiters(contentStr);
+    const imageSafe = replaceIncompleteImageWithPlaceholder(mathSafe);
+    const { content: markdownWithPlaceholders, htmlSnippets } = extractRenderableHtmlPlaceholders(imageSafe);
+    const html = marked.parse(markdownWithPlaceholders, { renderer: agentRenderer }) as string;
     if (!html) return '';
 
-    const protectedHTML = protectProviderImageSrcInHTML(html);
+    const htmlWithCitations = restoreRenderableHtmlPlaceholders(html, htmlSnippets);
+    const protectedHTML = protectProviderImageSrcInHTML(htmlWithCitations);
     return DOMPurify.sanitize(protectedHTML, DOMPurifyConfig);
   } catch (e) {
     console.error('Markdown rendering error:', e, 'Content:', contentStr.substring(0, 100));

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -865,6 +865,12 @@ const isConversationDone = computed(() => {
     console.log('[Collapse] Found stop event, conversation done');
     return true;
   }
+
+  const completeEvent = stream.find((e: any) => e.type === 'agent_complete');
+  if (completeEvent) {
+    console.log('[Collapse] Found complete event, conversation done');
+    return true;
+  }
   
   // Check for answer event with done=true
   const answerEvents = stream.filter((e: any) => e.type === 'answer');

--- a/frontend/src/views/chat/components/botmsg.vue
+++ b/frontend/src/views/chat/components/botmsg.vue
@@ -87,7 +87,7 @@ marked.use({
     breaks: true,  // 全局启用单个换行支持
 });
 
-marked.use(markedKatex({ throwOnError: false }));
+marked.use(markedKatex({ throwOnError: false, nonStandard: true }));
 
 const preprocessMathDelimiters = (rawText) => {
     if (!rawText || typeof rawText !== 'string') {

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -1095,12 +1095,15 @@ const handleAgentChunk = (data) => {
             console.log('[Agent] Complete event received');
             loading.value = false;
             isReplying.value = false;
+            message.is_completed = true;
+            fullContent.value = '';
+            currentAssistantMessageId.value = '';
             // 将 total_duration_ms 存入事件流供 AgentStreamDisplay 使用
-            if (data.data?.total_duration_ms && message.agentEventStream) {
+            if (message.agentEventStream) {
                 message.agentEventStream.push({
                     type: 'agent_complete',
-                    total_duration_ms: data.data.total_duration_ms,
-                    total_steps: data.data.total_steps,
+                    total_duration_ms: data.data?.total_duration_ms || 0,
+                    total_steps: data.data?.total_steps || 0,
                 });
             }
             break;

--- a/frontend/src/views/dev/MarkdownTestPage.vue
+++ b/frontend/src/views/dev/MarkdownTestPage.vue
@@ -107,7 +107,7 @@ import {
 
 // Configure marked
 marked.use({ breaks: true, gfm: true });
-marked.use(markedKatex({ throwOnError: false }));
+marked.use(markedKatex({ throwOnError: false, nonStandard: true }));
 
 const mermaidRenderer = new marked.Renderer();
 mermaidRenderer.code = createMermaidCodeRenderer('mermaid-test');

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -219,3 +219,34 @@ func TestStreamThinkingToEventBus_PropagatesFinishReason(t *testing.T) {
 		})
 	}
 }
+
+func TestStreamFinalAnswerToEventBus_EmitsDoneWhenProviderEndsWithEmptyChunk(t *testing.T) {
+	mock := &mockChat{
+		responses: []mockResponse{
+			{chunks: []types.StreamResponse{
+				{ResponseType: types.ResponseTypeAnswer, Content: "final answer", Done: false},
+				{ResponseType: types.ResponseTypeAnswer, Done: true, FinishReason: "stop"},
+			}},
+		},
+	}
+
+	engine := newTestEngine(t, mock)
+	var finalAnswerEvents []event.AgentFinalAnswerData
+	engine.eventBus.On(event.EventAgentFinalAnswer, func(_ context.Context, evt event.Event) error {
+		data, ok := evt.Data.(event.AgentFinalAnswerData)
+		require.True(t, ok)
+		finalAnswerEvents = append(finalAnswerEvents, data)
+		return nil
+	})
+
+	state := &types.AgentState{}
+	err := engine.streamFinalAnswerToEventBus(context.Background(), "test query", state, "sess-1")
+
+	require.NoError(t, err)
+	require.Len(t, finalAnswerEvents, 2)
+	assert.Equal(t, "final answer", finalAnswerEvents[0].Content)
+	assert.False(t, finalAnswerEvents[0].Done)
+	assert.Empty(t, finalAnswerEvents[1].Content)
+	assert.True(t, finalAnswerEvents[1].Done)
+	assert.Equal(t, "final answer", state.FinalAnswer)
+}

--- a/internal/agent/finalize.go
+++ b/internal/agent/finalize.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	agenttools "github.com/Tencent/WeKnora/internal/agent/tools"
 	"github.com/Tencent/WeKnora/internal/common"
 	"github.com/Tencent/WeKnora/internal/event"
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -86,12 +87,17 @@ Now generate the final answer:`, query)
 	// Generate a single ID for this entire final answer stream
 	answerID := generateEventID("answer")
 	logger.Debugf(ctx, "[Agent][FinalAnswer] AnswerID: %s", answerID)
+	answerDoneEmitted := false
 
 	llmResult, err := e.streamLLMToEventBus(
 		ctx,
 		messages,
-		&chat.ChatOptions{Temperature: e.config.Temperature, Thinking: e.config.Thinking},
+		&chat.ChatOptions{Temperature: e.config.Temperature}, // Thinking disabled for final answer synthesis
 		func(chunk *types.StreamResponse, fullContent string) {
+			// Defensive filter: only emit answer content, skip thinking chunks
+			if chunk.ResponseType == types.ResponseTypeThinking {
+				return
+			}
 			if chunk.Content != "" {
 				logger.Debugf(ctx, "[Agent][FinalAnswer] Emitting answer chunk: %d chars", len(chunk.Content))
 				e.eventBus.Emit(ctx, event.Event{
@@ -103,6 +109,9 @@ Now generate the final answer:`, query)
 						Done:    chunk.Done,
 					},
 				})
+				if chunk.Done {
+					answerDoneEmitted = true
+				}
 			}
 		},
 	)
@@ -115,7 +124,20 @@ Now generate the final answer:`, query)
 		return err
 	}
 
-	fullAnswer := llmResult.Content
+	if !answerDoneEmitted {
+		e.eventBus.Emit(ctx, event.Event{
+			ID:        answerID,
+			Type:      event.EventAgentFinalAnswer,
+			SessionID: sessionID,
+			Data: event.AgentFinalAnswerData{
+				Content: "",
+				Done:    true,
+			},
+		})
+	}
+
+	// Safety net: strip any residual <think> blocks that may have leaked through
+	fullAnswer := agenttools.StripThinkBlocks(llmResult.Content)
 	logger.Infof(ctx, "[Agent][FinalAnswer] Final answer generated: %d characters", len(fullAnswer))
 	common.PipelineInfo(ctx, "Agent", "final_answer_done", map[string]interface{}{
 		"session_id": sessionID,

--- a/internal/agent/think.go
+++ b/internal/agent/think.go
@@ -15,11 +15,12 @@ import (
 
 // streamLLMResult holds accumulated output from a streaming LLM call.
 type streamLLMResult struct {
-	Content      string
-	ToolCalls    []types.LLMToolCall
-	Usage        *types.TokenUsage
-	FinishReason string // actual finish_reason from LLM (captured from last stream chunk)
-	StreamError  string // error message from stream (e.g., timeout), kept separate from Content
+	Content         string
+	ThinkingContent string // accumulated thinking/reasoning content, kept separate from answer
+	ToolCalls       []types.LLMToolCall
+	Usage           *types.TokenUsage
+	FinishReason    string // actual finish_reason from LLM (captured from last stream chunk)
+	StreamError     string // error message from stream (e.g., timeout), kept separate from Content
 }
 
 // streamLLMToEventBus streams LLM response through EventBus (generic method)
@@ -64,7 +65,11 @@ func (e *AgentEngine) streamLLMToEventBus(
 		if chunk.Content != "" {
 			isExtracted := chunk.Data != nil && chunk.Data["source"] != nil
 			if !isExtracted {
-				result.Content += chunk.Content
+				if chunk.ResponseType == types.ResponseTypeThinking {
+					result.ThinkingContent += chunk.Content
+				} else {
+					result.Content += chunk.Content
+				}
 			}
 		}
 


### PR DESCRIPTION
## 描述 (Description)
<!-- 请简要描述这个 PR 的目的和变更内容 -->

本 PR 修复了 Agent 流式对话中的两个核心问题及一个附加修复：
<img width="1278" height="673" alt="问题1" src="https://github.com/user-attachments/assets/2f6522ca-084d-4aac-b02d-06832f3dc479" />
1. **流式回答 think 内容与 answer 混淆**：在流式输出过程中，LLM 的 thinking/reasoning 内容（`<think>` 标签）会混入最终回答，导致前端显示推理过程。修复方式包括：
   - 后端 `streamLLMToEventBus` 将 thinking 内容与 answer 内容分离存储（`ThinkingContent` vs `Content`），不再混入同一个字段
   - Final answer 阶段禁用 Thinking 参数，并增加防御性过滤跳过 thinking chunk
   - 使用 `StripThinkBlocks` 清理最终回答中可能残留的 `<think>` 块
   - 前端 Markdown 渲染增加 HTML 占位符机制，防止引用卡片（`<kb/>`、`<web/>`、`[[...]]`）被 marked 解析破坏
<img width="2536" height="1356" alt="问题4" src="https://github.com/user-attachments/assets/c0d1e548-341f-43bd-8363-08110708faa9" />
2. **对话完成后前端未显示结束标记**：当后端通过 `agent_complete` 事件通知对话结束时，前端未正确识别该事件，导致加载状态不消失。修复方式：
   - 前端 `isConversationDone` 计算属性增加对 `agent_complete` 事件的检测
   - `handleAgentChunk` 中收到 complete 事件时正确设置 `is_completed`、清空流式状态
   - 后端 final answer 流结束时确保发送 `Done: true` 事件（即使 LLM 未显式发送 done chunk）
<img width="1273" height="681" alt="问题2" src="https://github.com/user-attachments/assets/51bf1494-085f-4b25-a067-66926f16d013" />
<img width="2520" height="1348" alt="问题3" src="https://github.com/user-attachments/assets/bd3e3c5c-a091-46b5-ad24-0902cb94bf1b" />
3. **附加修复**：KaTeX 公式渲染启用 `nonStandard: true` 选项，修复小概率情况下公式加载失败的问题（如 `$...$` 行内公式无法识别）。

## 变更类型 (Type of Change)
<!-- 请选择适用的类型，删除其他选项 -->
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [ ] 📚 文档更新 (Documentation update)
- [ ] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [ ] 🧪 测试相关 (Test related)
- [ ] 🔧 配置变更 (Configuration change)
- [ ] 🐳 Docker 相关 (Docker related)
- [ ] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
<!-- 请选择受影响的组件，删除其他选项 -->
- [x] 后端 API (Backend API)
- [x] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [ ] 其他 (Other): <!-- 请说明 -->

## 测试 (Testing)
<!-- 请描述如何测试这些变更 -->
- [x] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [x] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 发起一次 Agent 对话，等待对话完成，验证前端正确显示结束标记且加载状态消失
2. 使用会返回 thinking 内容的模型进行对话，验证最终回答中不包含 `<think>` 标签或推理内容
3. 在对话中触发引用卡片（知识库引用、网页引用），验证卡片正常渲染不被 Markdown 解析破坏
4. 输入包含 `$...$` 行内公式和 `$$...$$` 块级公式的内容，验证公式正常渲染
5. 运行后端单元测试 `TestStreamFinalAnswerToEventBus_EmitsDoneWhenProviderEndsWithEmptyChunk`

## 检查清单 (Checklist)
<!-- 请确保完成以下检查项 -->
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
<!-- 如果此 PR 解决了某个 issue，请使用 "Fixes #123" 或 "Closes #123" 的格式 -->
Fixes #

## 截图/录屏 (Screenshots/Recordings)
<!-- 如果是前端 UI 变更，请提供截图或录屏 -->
<img width="1280" height="675" alt="联想截图_20260503234110" src="https://github.com/user-attachments/assets/70c1811b-1a47-4e68-bb11-bca9abf09ae8" />
<img width="1276" height="673" alt="联想截图_20260503234212" src="https://github.com/user-attachments/assets/21e60dc0-e845-4b0f-8817-ab1695fba735" />
<img width="1278" height="677" alt="联想截图_20260504004039" src="https://github.com/user-attachments/assets/fca87618-9080-4621-aee2-cdc3e3b6b7f4" />

## 数据库迁移 (Database Migration)
<!-- 如果涉及数据库变更，请说明 -->
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
<!-- 如果涉及配置变更，请说明需要更新的配置项 -->

无

## 部署说明 (Deployment Notes)
<!-- 如果有特殊的部署要求，请说明 -->

无特殊部署要求

## 其他信息 (Additional Information)
<!-- 任何其他需要说明的信息 -->

- 后端变更涉及 `internal/agent/think.go`（流式内容分离）、`internal/agent/finalize.go`（final answer 防御性过滤 + done 事件保底发送）
- 前端变更涉及 `AgentStreamDisplay.vue`（结束标记检测 + Markdown 渲染占位符机制）、`chat/index.vue`（complete 事件处理）
- KaTeX `nonStandard: true` 选项在 5 个文件中统一启用