### PR TITLE
fix(im): clamp reconnect backoff to avoid int64 overflow busy loop

### DIFF
--- a/internal/im/wechat/longpoll.go
+++ b/internal/im/wechat/longpoll.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -297,7 +296,17 @@ func (c *LongPollClient) parseMessage(msg *weixinMessage) *im.IncomingMessage {
 }
 
 func pollReconnectDelay(attempt int) time.Duration {
-	delay := reconnectBaseDelay * time.Duration(math.Pow(2, float64(attempt-1)))
+	if attempt < 1 {
+		return reconnectBaseDelay
+	}
+	// Cap the exponent to avoid int64 overflow: base (1e9 ns) * 2^shift
+	// overflows when shift ≥ 34, producing a negative duration that would
+	// bypass the max-delay check and cause a busy reconnect loop.
+	shift := attempt - 1
+	if shift > 30 {
+		return reconnectMaxDelay
+	}
+	delay := reconnectBaseDelay * (1 << shift)
 	if delay > reconnectMaxDelay {
 		delay = reconnectMaxDelay
 	}

--- a/internal/im/wecom/longconn.go
+++ b/internal/im/wecom/longconn.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -772,7 +771,18 @@ func (c *LongConnClient) writeJSON(v interface{}) error {
 }
 
 func reconnectDelay(attempt int) time.Duration {
-	delay := defaultReconnectBaseDelay * time.Duration(math.Pow(2, float64(attempt-1)))
+	if attempt < 1 {
+		return defaultReconnectBaseDelay
+	}
+	// Cap the exponent to avoid int64 overflow: base (1e9 ns) * 2^shift
+	// overflows when shift ≥ 34, producing a negative duration that would
+	// bypass the max-delay check and cause a busy reconnect loop.
+	// Any shift ≥ 5 already exceeds the 30s max, so 30 is a safe ceiling.
+	shift := attempt - 1
+	if shift > 30 {
+		return defaultReconnectMaxDelay
+	}
+	delay := defaultReconnectBaseDelay * (1 << shift)
 	if delay > defaultReconnectMaxDelay {
 		delay = defaultReconnectMaxDelay
 	}

--- a/internal/im/wecom/reconnect_test.go
+++ b/internal/im/wecom/reconnect_test.go
@@ -1,0 +1,37 @@
+package wecom
+
+import (
+	"testing"
+	"time"
+)
+
+// TestReconnectDelayOverflow guards against the bug where large attempt
+// counters produced a negative time.Duration, bypassing the max-delay
+// cap and causing a busy reconnect loop (e.g. "reconnecting in -1s").
+func TestReconnectDelayOverflow(t *testing.T) {
+	tests := []struct {
+		name    string
+		attempt int
+		want    time.Duration
+	}{
+		{"zero attempt clamps to base", 0, defaultReconnectBaseDelay},
+		{"negative attempt clamps to base", -5, defaultReconnectBaseDelay},
+		{"attempt 1 = base", 1, defaultReconnectBaseDelay},
+		{"attempt 2 = 2× base", 2, 2 * defaultReconnectBaseDelay},
+		{"attempt 5 = 16s", 5, 16 * time.Second},
+		{"attempt 6 caps at max", 6, defaultReconnectMaxDelay},
+		{"attempt 100 caps at max", 100, defaultReconnectMaxDelay},
+		{"attempt 4601 caps at max (regression)", 4601, defaultReconnectMaxDelay},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reconnectDelay(tt.attempt)
+			if got != tt.want {
+				t.Errorf("reconnectDelay(%d) = %v, want %v", tt.attempt, got, tt.want)
+			}
+			if got <= 0 {
+				t.Errorf("reconnectDelay(%d) returned non-positive %v — would cause busy loop", tt.attempt, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `reconnectDelay` in `internal/im/wecom/longconn.go` (and `pollReconnectDelay` in `internal/im/wechat/longpoll.go`) computed backoff as `baseDelay * time.Duration(math.Pow(2, attempt-1))`. After ~34 failed reconnects, the `float64 → int64` conversion overflows and produces a **negative** `time.Duration`, which is not `> maxDelay`, so the cap is bypassed.
- `time.After(-1s)` fires immediately, turning a persistent auth failure (e.g. WeCom `code=853000 invalid bot_id or secret`) into a busy reconnect loop with thousands of log entries like `reconnecting in -1s (attempt 4601)`.
- Replaced the `math.Pow` with a bit-shift and capped the exponent at 30 (well above the ~5 needed to reach the 30s max). Added a regression test exercising attempt=4601.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/im/...` — all pass
- [x] New `TestReconnectDelayOverflow` covers attempts 0, 1, 2, 5, 6, 100, 4601 and asserts the returned duration is always positive and capped at `defaultReconnectMaxDelay`
- [x] In an environment with an invalid WeCom `bot_id`/`secret`, confirm the reconnect loop honors the 30s cap instead of spamming logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)