### PR TITLE
fix(i18n): remove duplicate liveIndicator key in ko-KR locale

### DIFF
--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -4104,7 +4104,6 @@ export default {
     loadFailed: "IM 봇 목록을 불러오지 못했습니다",
     builtinAgent: "내장 에이전트",
     liveIndicator: "활성화된 IM 채널이 실행 중입니다",
-    liveIndicator: "활성화된 IM 채널이 실행 중입니다",
     detailsTitle: "IM 봇 상세",
     gotoAgentEditor: "에이전트 편집기에서 열기",
     outputMode: "출력 모드",


### PR DESCRIPTION
## Summary
- Vite was warning `Duplicate key "liveIndicator" in object literal` at `frontend/src/i18n/locales/ko-KR.ts:4107`.
- Both duplicate entries mapped to the exact same Korean translation, so the second was pure redundancy — removed.
- Ran a brace-scope-aware duplicate-key scan over `en-US.ts` / `zh-CN.ts` / `ko-KR.ts` / `ru-RU.ts`: all four clean, no other duplicates.

## Test plan
- [ ] `npm --prefix frontend run dev` — confirm the "Duplicate key" warning no longer appears in Vite output
- [ ] Open the IM channels overview page with the Korean locale selected — verify the "활성화된 IM 채널이 실행 중입니다" indicator still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)