### PR TITLE
fix(data-analysis): capture LOCAL_STORAGE_BASE_DIR at init time (#1040)

### DIFF
--- a/internal/agent/tools/data_analysis.go
+++ b/internal/agent/tools/data_analysis.go
@@ -116,6 +116,13 @@ type DataAnalysisTool struct {
 	db                   *sql.DB
 	sessionID            string
 	createdTables        []string // Track tables created in this session
+	// localBaseDir is the LOCAL_STORAGE_BASE_DIR value captured at construction
+	// time so resolveFileServiceForKnowledge uses the same base path that was
+	// used when the local FileService was initialised by DI.  Re-reading the
+	// env var at request time can produce a different (or empty) value if the
+	// variable was not exported to the sub-process or was set programmatically
+	// after startup, causing GetFile to look in the wrong directory (#1040).
+	localBaseDir         string
 }
 
 func NewDataAnalysisTool(
@@ -134,6 +141,11 @@ func NewDataAnalysisTool(
 		tenantService:        tenantService,
 		db:                   db,
 		sessionID:            sessionID,
+		// Capture LOCAL_STORAGE_BASE_DIR once at construction time so that every
+		// call to resolveFileServiceForKnowledge uses the same base path.  The
+		// env var is guaranteed to be set (or empty == "/data/files" fallback)
+		// when the application starts and the DI container is assembled.
+		localBaseDir:         strings.TrimSpace(os.Getenv("LOCAL_STORAGE_BASE_DIR")),
 	}
 }
 
@@ -806,7 +818,14 @@ func (t *DataAnalysisTool) resolveFileServiceForKnowledge(ctx context.Context, k
 	}
 
 	storageConfig := tenant.StorageEngineConfig
-	baseDir := strings.TrimSpace(os.Getenv("LOCAL_STORAGE_BASE_DIR"))
+	// Use the localBaseDir captured at construction time rather than re-reading
+	// LOCAL_STORAGE_BASE_DIR from os.Getenv here.  Reading the env var at
+	// request-handling time can produce an empty string (or the wrong value)
+	// when the variable was set programmatically before startup or is absent
+	// from the process environment of the DI-constructed sub-component, causing
+	// the newly created local FileService to use the /data/files fallback
+	// instead of the configured path and therefore fail to locate files (#1040).
+	baseDir := t.localBaseDir
 
 	resolvedSvc, resolvedProvider, err := filesvc.NewFileServiceFromStorageConfig(provider, storageConfig, baseDir)
 	if err != nil {


### PR DESCRIPTION
resolveFileServiceForKnowledge was reading os.Getenv("LOCAL_STORAGE_BASE_DIR") on every request.  This causes a mismatch when the variable is not in the process environment at request time (e.g. it was set programmatically before app startup but not exported, or the DI-constructed fileService uses a different configured path).

Fix: store the value in a new localBaseDir field at NewDataAnalysisTool construction time — the same moment the DI container assembles the local FileService — and use t.localBaseDir in resolveFileServiceForKnowledge instead.  This guarantees the data-analysis tool always resolves files under the same base directory that the local FileService was configured with, eliminating the "path not found" errors when LOCAL storage is used for a knowledge base while the global storage backend is minio/oss/cos.

Fixes #1040

# Pull Request

## 描述 (Description)

`DataAnalysisTool.resolveFileServiceForKnowledge` 在每次请求时通过 `os.Getenv("LOCAL_STORAGE_BASE_DIR")` 读取 base 路径。当全局存储配置为 minio/oss/cos 而某个知识库使用 local storage 时，DI 容器注入的 `fileService` 是 minio 实例，但 `resolveFileServiceForKnowledge` 需要为 local 知识库创建一个新的 local FileService。

**问题根因**：如果 `LOCAL_STORAGE_BASE_DIR` 环境变量在该请求时上下文中未被正确读取（例如：变量以非标准方式在启动前被设置，或者 DI 子组件的 `os.Getenv` 调用返回空字符串），则新创建的 local FileService 会使用 `/data/files` 作为 fallback 路径，而实际文件存储在另一个路径下，导致 `GetFile` 失败。

**修复**：在 `NewDataAnalysisTool` 构造函数中（与 DI 容器组装的同一时刻）捕获 `LOCAL_STORAGE_BASE_DIR` 并存入新增的 `localBaseDir` 字段。`resolveFileServiceForKnowledge` 改为使用 `t.localBaseDir`，确保与 local FileService 初始化时使用的路径完全一致。

## 变更类型 (Type of Change)

- [x] 🐛 Bug 修复 (Bug fix)

## 变更文件

- `internal/agent/tools/data_analysis.go`
  - `DataAnalysisTool` struct 新增 `localBaseDir string` 字段
  - `NewDataAnalysisTool` 在构造时捕获 `os.Getenv("LOCAL_STORAGE_BASE_DIR")`
  - `resolveFileServiceForKnowledge` 使用 `t.localBaseDir` 替代运行时 `os.Getenv()`

## 确认事项

- [x] 向后兼容，仅改变读取时机（构造时 vs 请求时），行为相同
- [x] 不影响 `strings.TrimSpace` 逻辑（仍在构造时应用）
- [x] `os` 和 `strings` 包在文件其他位置仍有使用，无多余 import

Fixes #1040
