### PR TITLE
feat(kb-list): group pinned knowledge bases into a labeled section

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1548,6 +1548,10 @@ export default {
       unpinSuccess: 'Unpinned',
       failed: 'Operation failed',
     },
+    sections: {
+      pinned: 'Pinned',
+      others: 'Others',
+    },
     messages: {
       deleted: 'Knowledge base deleted',
       deleteFailed: 'Failed to delete knowledge base',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -2146,6 +2146,10 @@ export default {
       unpinSuccess: "고정 해제됨",
       failed: "작업 실패",
     },
+    sections: {
+      pinned: "고정됨",
+      others: "기타",
+    },
     detail: {
       title: "공유 지식베이스",
       overview: "개요",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -1753,6 +1753,10 @@ export default {
       unpinSuccess: 'Откреплено',
       failed: 'Операция не удалась'
     },
+    sections: {
+      pinned: 'Закреплённые',
+      others: 'Другие'
+    },
     messages: {
       deleted: 'База знаний удалена',
       deleteFailed: 'Не удалось удалить базу знаний',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2119,6 +2119,10 @@ export default {
       unpinSuccess: "已取消置顶",
       failed: "操作失败",
     },
+    sections: {
+      pinned: "置顶",
+      others: "其他",
+    },
     detail: {
       title: "共享知识库",
       overview: "概览",

--- a/frontend/src/views/knowledge/KnowledgeBaseList.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseList.vue
@@ -95,8 +95,26 @@
 
     <!-- 卡片网格：全部 -->
     <div v-if="spaceSelection === 'all' && filteredKnowledgeBases.length > 0" class="kb-card-wrap">
+      <!-- 置顶分组标题 -->
+      <div
+        v-if="filteredKnowledgeBases[0] && filteredKnowledgeBases[0].isMine && filteredKnowledgeBases[0].is_pinned"
+        class="kb-section-header kb-section-header-pinned"
+      >
+        <t-icon name="pin-filled" size="14px" />
+        <span>{{ $t('knowledgeList.sections.pinned') }}</span>
+      </div>
       <!-- 全部：我的知识库 + 共享给我的知识库 -->
-      <template v-for="kb in filteredKnowledgeBases" :key="kb.id">
+      <template v-for="(kb, index) in filteredKnowledgeBases" :key="kb.id">
+        <!-- 「其他」分组标题：从置顶过渡到非置顶时插入 -->
+        <div
+          v-if="index > 0
+            && filteredKnowledgeBases[index - 1].isMine
+            && filteredKnowledgeBases[index - 1].is_pinned
+            && !(kb.isMine && kb.is_pinned)"
+          class="kb-section-header"
+        >
+          <span>{{ $t('knowledgeList.sections.others') }}</span>
+        </div>
         <!-- 我的知识库卡片 -->
         <div
           v-if="kb.isMine"
@@ -262,10 +280,21 @@
     </div>
 
     <div v-if="spaceSelection === 'mine' && kbs.length > 0" class="kb-card-wrap">
+      <!-- 置顶分组标题 -->
+      <div v-if="kbs[0] && kbs[0].is_pinned" class="kb-section-header kb-section-header-pinned">
+        <t-icon name="pin-filled" size="14px" />
+        <span>{{ $t('knowledgeList.sections.pinned') }}</span>
+      </div>
       <!-- 我的知识库 -->
+      <template v-for="(kb, index) in kbs" :key="kb.id">
+        <!-- 「其他」分组标题：从置顶过渡到非置顶时插入 -->
+        <div
+          v-if="index > 0 && kbs[index - 1].is_pinned && !kb.is_pinned"
+          class="kb-section-header"
+        >
+          <span>{{ $t('knowledgeList.sections.others') }}</span>
+        </div>
       <div
-        v-for="(kb, index) in kbs"
-        :key="kb.id"
         class="kb-card"
         :class="{
           'uninitialized': !isInitialized(kb),
@@ -367,6 +396,7 @@
           </div>
         </div>
       </div>
+      </template>
     </div>
 
     <!-- 卡片网格：共享给我 -->
@@ -1613,6 +1643,27 @@ const handleUploadFinishedEvent = (event: Event) => {
   gap: 20px;
   grid-template-columns: 1fr;
   animation: contentFadeIn 0.32s ease-out;
+}
+
+.kb-section-header {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0 4px;
+  color: var(--td-text-color-secondary);
+  font-family: var(--app-font-family);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 20px;
+
+  .t-icon {
+    color: var(--td-brand-color);
+  }
+
+  &.kb-section-header-pinned {
+    color: var(--td-brand-color);
+  }
 }
 
 .kb-card {


### PR DESCRIPTION
## Summary

- 知识库列表页（`/platform/knowledge-bases`）中置顶项只是排序靠前，和普通项视觉上无差别，扫视时分不清哪里是置顶组的结束。
- 在「全部」和「我的」两个 tab 的卡片网格里，当列表从置顶项过渡到非置顶项时，插入一个跨整行的小分组标题：置顶 / 其他。
- 纯前端视觉分组；排序仍沿用后端已有的 `is_pinned DESC, pinned_at DESC, created_at DESC`，不改任何后端逻辑。
- 标题样式：13px / 600 字重，置顶组带 📌 图标 + 品牌绿，其他组灰字；无分割线。
- 四种语言的 i18n 都已补齐：`knowledgeList.sections.pinned` / `knowledgeList.sections.others`（zh-CN / en-US / ko-KR / ru-RU）。
- 共享给我的知识库后端不参与置顶，所以永远落在「其他」组里。

## Test plan

- [x] 我的 tab：仅有置顶项 → 仅显示「置顶」标题
- [x] 我的 tab：仅有非置顶项 → 不显示任何分组标题
- [x] 我的 tab：同时有置顶 + 非置顶 → 依次显示「置顶」标题 → 置顶卡片 → 「其他」标题 → 非置顶卡片
- [x] 全部 tab：置顶的个人 KB 与共享 KB 混合 → 置顶组仅含个人 KB，共享 KB 落在「其他」组
- [x] 置顶 / 取消置顶后，分组自动刷新
- [x] 切换 zh-CN / en-US / ko-KR / ru-RU，标题文案正确