### PR TITLE
feat(kb-list): source column + description subtitle, fix <style> XSS

### DIFF
--- a/frontend/src/utils/security.ts
+++ b/frontend/src/utils/security.ts
@@ -48,7 +48,7 @@ const DOMPurifyConfig = {
   // 允许的协议
   ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp):|(?:local|minio|cos|tos|s3|oss|ks3):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
   // 禁止的标签和属性
-  FORBID_TAGS: ['script', 'object', 'embed', 'form', 'input', 'button'],
+  FORBID_TAGS: ['script', 'style', 'object', 'embed', 'form', 'input', 'button'],
   FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'onblur'],
   // 其他安全配置
   KEEP_CONTENT: true,

--- a/frontend/src/views/knowledge/components/DocumentListView.vue
+++ b/frontend/src/views/knowledge/components/DocumentListView.vue
@@ -20,6 +20,8 @@ interface KnowledgeItem {
   summary_status?: string;
   updated_at?: string;
   source?: string;
+  description?: string;
+  channel?: string;
   isMore?: boolean;
 }
 
@@ -62,11 +64,19 @@ const formatTime = (time?: string) => {
   return `${yy}-${MM}-${dd} ${hh}:${mm}`;
 };
 
-const getTypeLabel = (item: KnowledgeItem) => {
-  if (item.type === 'url') return 'URL';
-  if (item.type === 'manual') return t('knowledgeBase.typeManual');
-  if (item.file_type) return item.file_type.toUpperCase();
-  return '--';
+const getSourceInfo = (item: KnowledgeItem): { icon: string; label: string } => {
+  const ch = item.channel;
+  if (ch === 'feishu') return { icon: 'cloud-download', label: t('knowledgeBase.channelFeishu') };
+  if (ch === 'notion') return { icon: 'cloud-download', label: t('knowledgeBase.channelNotion') };
+  if (ch === 'yuque') return { icon: 'cloud-download', label: t('knowledgeBase.channelYuque') };
+  if (ch === 'wechat') return { icon: 'cloud-download', label: t('knowledgeBase.channelWechat') };
+  if (ch === 'wecom') return { icon: 'cloud-download', label: t('knowledgeBase.channelWecom') };
+  if (ch === 'dingtalk') return { icon: 'cloud-download', label: t('knowledgeBase.channelDingtalk') };
+  if (ch === 'slack') return { icon: 'cloud-download', label: t('knowledgeBase.channelSlack') };
+  if (ch === 'im') return { icon: 'cloud-download', label: t('knowledgeBase.channelIm') };
+  if (item.type === 'url') return { icon: 'link', label: t('knowledgeBase.channelUrl') };
+  if (item.type === 'manual') return { icon: 'edit', label: t('knowledgeBase.channelManual') };
+  return { icon: 'upload', label: t('knowledgeBase.channelUpload') };
 };
 
 interface StatusInfo {
@@ -168,8 +178,8 @@ const handleAction = (action: 'edit' | 'reparse' | 'move' | 'delete', item: Know
       </div>
       <div class="cell cell-name" role="columnheader">{{ t('knowledgeBase.columnName') }}</div>
       <div class="cell cell-tag" role="columnheader">{{ t('knowledgeBase.columnTag') }}</div>
+      <div class="cell cell-source" role="columnheader">{{ t('knowledgeBase.columnSource') }}</div>
       <div class="cell cell-size" role="columnheader">{{ t('knowledgeBase.columnSize') }}</div>
-      <div class="cell cell-type" role="columnheader">{{ t('knowledgeBase.columnType') }}</div>
       <div class="cell cell-status" role="columnheader">{{ t('knowledgeBase.columnStatus') }}</div>
       <div class="cell cell-time" role="columnheader">{{ t('knowledgeBase.columnUpdatedAt') }}</div>
       <div class="cell cell-actions" role="columnheader" v-if="canEdit"></div>
@@ -198,7 +208,14 @@ const handleAction = (action: 'edit' | 'reparse' | 'move' | 'delete', item: Know
           <span class="row-file-icon-wrap">
             <t-icon :name="getFileIcon(item)" />
           </span>
-          <span class="row-file-name" :title="item.file_name">{{ item.file_name }}</span>
+          <div class="row-file-text">
+            <span class="row-file-name" :title="item.file_name">{{ item.file_name }}</span>
+            <span
+              v-if="item.description"
+              class="row-file-desc"
+              :title="item.description"
+            >{{ item.description }}</span>
+          </div>
         </div>
 
 
@@ -209,12 +226,13 @@ const handleAction = (action: 'edit' | 'reparse' | 'move' | 'delete', item: Know
           <span v-else class="row-muted">--</span>
         </div>
 
-        <div class="cell cell-size">
-          <span class="row-mono">{{ formatFileSize(item.file_size) || '--' }}</span>
+        <div class="cell cell-source">
+          <t-icon class="row-source-icon" :name="getSourceInfo(item).icon" />
+          <span class="row-source-label">{{ getSourceInfo(item).label }}</span>
         </div>
 
-        <div class="cell cell-type">
-          <span class="row-mono">{{ getTypeLabel(item) }}</span>
+        <div class="cell cell-size">
+          <span class="row-mono">{{ formatFileSize(item.file_size) || '--' }}</span>
         </div>
 
         <div class="cell cell-status">
@@ -313,10 +331,10 @@ const handleAction = (action: 'edit' | 'reparse' | 'move' | 'delete', item: Know
   display: grid;
   grid-template-columns:
     44px                       // checkbox
-    minmax(220px, 2.4fr)       // name
+    minmax(260px, 2.6fr)       // name
     minmax(100px, 0.9fr)       // tag
+    minmax(96px, 0.8fr)        // source
     96px                       // size
-    72px                       // type
     minmax(96px, 0.7fr)        // status
     140px                      // updated_at
     48px;                      // actions
@@ -363,7 +381,7 @@ const handleAction = (action: 'edit' | 'reparse' | 'move' | 'delete', item: Know
 
 .doc-list-row {
   position: relative;
-  min-height: 52px;
+  min-height: 60px;
   font-size: 13px;
   color: var(--td-text-color-primary);
   border-bottom: 1px solid var(--td-component-stroke);
@@ -452,8 +470,15 @@ const handleAction = (action: 'edit' | 'reparse' | 'move' | 'delete', item: Know
   color: var(--td-text-color-secondary);
 }
 
-.row-file-name {
+.row-file-text {
   flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.row-file-name {
   min-width: 0;
   white-space: nowrap;
   overflow: hidden;
@@ -462,6 +487,35 @@ const handleAction = (action: 'edit' | 'reparse' | 'move' | 'delete', item: Know
   font-weight: 600;
   letter-spacing: 0.01em;
   color: var(--td-text-color-primary);
+}
+
+.row-file-desc {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 12px;
+  color: var(--td-text-color-placeholder);
+}
+
+.cell-source {
+  gap: 6px;
+  min-width: 0;
+}
+
+.row-source-icon {
+  flex-shrink: 0;
+  font-size: 14px;
+  color: var(--td-text-color-secondary);
+}
+
+.row-source-label {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 12px;
+  color: var(--td-text-color-secondary);
 }
 
 .row-tag {


### PR DESCRIPTION
## Summary

- **List view column tweaks.** Drop the redundant Type column (file extension already appears in the filename and icon) and add a Source column driven by `channel` with a fallback to `type` — Feishu/Notion/Yuque syncs, web URLs, manual entries, and uploads are now distinguishable at a glance. Surface `description` as a 12px subtitle under the filename so the summary no longer requires hovering over the row.
- **Sanitizer fix (security).** DOMPurify was configured with `USE_PROFILES.svg`, which implicitly permits `<style>` so inline SVG styling works. A user-authored markdown doc that pasted a raw nginx error page (`<style>body { width: 35em; margin: 0 auto }</style>…`) slipped through the sanitizer and applied globally, collapsing the whole app layout. Add `style` to `FORBID_TAGS` so top-level style elements from document HTML are dropped regardless of profile. Mermaid/KaTeX output is unaffected (they rely on `style` attributes and inline CSS, not a `<style>` tag).

## Test plan

- [x] Open a knowledge base detail page and switch to list view
  - [x] Documents with a description show a truncated 12px gray subtitle under the filename; hovering reveals the full text
  - [x] Feishu/Notion/Yuque-synced entries display the correct channel label in the Source column
  - [x] URL-type entries show "Web" with a link icon; manual entries show "Manual" with an edit icon; uploaded files show "Upload" with an upload icon
  - [x] Sticky header, row hover, selection checkbox, and the more-menu still behave as before
- [x] Open the original problematic markdown document (the one with the embedded nginx error page) — layout stays intact, the `<style>` block renders as escaped text instead of applying globally
- [x] Verify Mermaid diagrams and KaTeX formulas still render correctly in the preview drawer