### PR TITLE
refactor(chunker): phase 1 cleanup — overlap bug, profile threading, protected spans, embedding trim, parent-child strategy

### DIFF
--- a/internal/infrastructure/chunker/heading_splitter.go
+++ b/internal/infrastructure/chunker/heading_splitter.go
@@ -25,11 +25,17 @@ type headingBoundary struct {
 // splitByHeadingsImpl is the Tier-1 implementation. It falls through to the
 // legacy splitter when the document has no usable heading structure or when
 // the heading split would produce a single section anyway.
-func splitByHeadingsImpl(text string, cfg SplitterConfig) []Chunk {
+//
+// profile may be nil; we compute one on demand. When the strategy resolver
+// already ran the profiler (auto strategy), the same profile is threaded
+// through here so we don't re-scan the entire document.
+func splitByHeadingsImpl(text string, cfg SplitterConfig, profile *DocProfile) []Chunk {
 	if text == "" {
 		return nil
 	}
-	profile := ProfileDocument(text)
+	if profile == nil {
+		profile = ProfileDocument(text)
+	}
 	primaryLevel := profile.DominantHeadingLevel()
 	if primaryLevel == 0 {
 		return SplitText(text, cfg)

--- a/internal/infrastructure/chunker/heading_splitter_test.go
+++ b/internal/infrastructure/chunker/heading_splitter_test.go
@@ -13,7 +13,7 @@ func TestSplitByHeadings_BasicSections(t *testing.T) {
 	body := strings.Repeat("Lorem ipsum dolor sit amet consectetur adipiscing elit. ", 4)
 	doc := "# Top\n" + body + "\n\n## Section A\n" + body + "\n\n## Section B\n" + body + "\n\n## Section C\n" + body
 	cfg := SplitterConfig{ChunkSize: 300, ChunkOverlap: 0}
-	chunks := splitByHeadingsImpl(doc, cfg)
+	chunks := splitByHeadingsImpl(doc, cfg, nil)
 	if len(chunks) < 3 {
 		t.Fatalf("expected ≥3 chunks (one per section), got %d", len(chunks))
 	}
@@ -43,7 +43,7 @@ func TestSplitByHeadings_BasicSections(t *testing.T) {
 func TestSplitByHeadings_FallsThroughForUnstructuredDoc(t *testing.T) {
 	doc := "Just a plain paragraph without any headings at all in this text."
 	cfg := SplitterConfig{ChunkSize: 200, ChunkOverlap: 0}
-	chunks := splitByHeadingsImpl(doc, cfg)
+	chunks := splitByHeadingsImpl(doc, cfg, nil)
 	// no headings → falls through to SplitText, which keeps the whole thing
 	if len(chunks) != 1 {
 		t.Errorf("expected fallthrough single chunk, got %d", len(chunks))
@@ -54,7 +54,7 @@ func TestSplitByHeadings_LargeSectionRecursesIntoLegacy(t *testing.T) {
 	body := strings.Repeat("This is a long sentence repeated many times. ", 50)
 	doc := "# Top\n## Big\n" + body
 	cfg := SplitterConfig{ChunkSize: 300, ChunkOverlap: 30, Separators: []string{". "}}
-	chunks := splitByHeadingsImpl(doc, cfg)
+	chunks := splitByHeadingsImpl(doc, cfg, nil)
 	if len(chunks) < 2 {
 		t.Fatalf("large section should be sub-split, got %d chunks", len(chunks))
 	}
@@ -73,7 +73,7 @@ func TestSplitByHeadings_BreadcrumbReflectsLatestPath(t *testing.T) {
 	body := strings.Repeat("Lorem ipsum dolor sit amet consectetur adipiscing elit. ", 4)
 	doc := "# Chapter 1\n" + body + "\n\n## Section A\n" + body + "\n\n## Section B\n" + body
 	cfg := SplitterConfig{ChunkSize: 300, ChunkOverlap: 0}
-	chunks := splitByHeadingsImpl(doc, cfg)
+	chunks := splitByHeadingsImpl(doc, cfg, nil)
 	if len(chunks) < 3 {
 		t.Fatalf("expected ≥3 chunks, got %d", len(chunks))
 	}
@@ -92,7 +92,7 @@ func TestSplitByHeadings_BreadcrumbReflectsLatestPath(t *testing.T) {
 func TestSplitByHeadings_IgnoresHeadingsInsideCodeFence(t *testing.T) {
 	doc := "# Real\n\n```\n# Fake heading inside code\n```\n\nbody"
 	cfg := SplitterConfig{ChunkSize: 500, ChunkOverlap: 0}
-	chunks := splitByHeadingsImpl(doc, cfg)
+	chunks := splitByHeadingsImpl(doc, cfg, nil)
 	for _, c := range chunks {
 		if strings.Contains(c.ContextHeader, "# Real") || strings.Contains(c.Content, "# Real") {
 			return
@@ -104,7 +104,7 @@ func TestSplitByHeadings_IgnoresHeadingsInsideCodeFence(t *testing.T) {
 func TestSplitByHeadings_PreservesPositionRelativeToOriginal(t *testing.T) {
 	doc := "# Top\nintro\n\n## A\nbody A\n\n## B\nbody B"
 	cfg := SplitterConfig{ChunkSize: 500, ChunkOverlap: 0}
-	chunks := splitByHeadingsImpl(doc, cfg)
+	chunks := splitByHeadingsImpl(doc, cfg, nil)
 	for i, c := range chunks {
 		if c.Start < 0 {
 			t.Errorf("chunk %d has negative Start", i)
@@ -131,7 +131,7 @@ content of B here.
 ## Section C
 content of C here.`
 	cfg := SplitterConfig{ChunkSize: 200, ChunkOverlap: 20}
-	chunks := splitByHeadingsImpl(doc, cfg)
+	chunks := splitByHeadingsImpl(doc, cfg, nil)
 	if len(chunks) == 0 {
 		t.Fatal("expected chunks")
 	}
@@ -171,7 +171,7 @@ ERROR: column missing.
 ## 解析失败
 embedding 表缺列。`
 	cfg := SplitterConfig{ChunkSize: 500, ChunkOverlap: 0}
-	chunks := splitByHeadingsImpl(doc, cfg)
+	chunks := splitByHeadingsImpl(doc, cfg, nil)
 	if len(chunks) == 0 {
 		t.Fatal("expected at least one chunk")
 	}
@@ -219,7 +219,7 @@ short B.
 ## C
 short C.`
 	cfg := SplitterConfig{ChunkSize: 500, ChunkOverlap: 0}
-	chunks := splitByHeadingsImpl(doc, cfg)
+	chunks := splitByHeadingsImpl(doc, cfg, nil)
 	docRunes := []rune(doc)
 	for i, c := range chunks {
 		contentRuneLen := len([]rune(c.Content))
@@ -248,7 +248,7 @@ func TestSplitByHeadings_CoalesceRespectsChunkSize(t *testing.T) {
 		sb.WriteString("\nshort body line.\n")
 	}
 	cfg := SplitterConfig{ChunkSize: 200, ChunkOverlap: 0}
-	chunks := splitByHeadingsImpl(sb.String(), cfg)
+	chunks := splitByHeadingsImpl(sb.String(), cfg, nil)
 	for i, c := range chunks {
 		if l := len([]rune(c.Content)); l > cfg.ChunkSize {
 			t.Errorf("chunk %d exceeds ChunkSize: %d > %d", i, l, cfg.ChunkSize)
@@ -288,7 +288,7 @@ body A.
 ## Section B
 body B.`
 	cfg := SplitterConfig{ChunkSize: 500, ChunkOverlap: 0}
-	chunks := splitByHeadingsImpl(doc, cfg)
+	chunks := splitByHeadingsImpl(doc, cfg, nil)
 	for i, c := range chunks {
 		// Count occurrences of "## Section A" / "## Section B"
 		for _, heading := range []string{"## Section A", "## Section B"} {

--- a/internal/infrastructure/chunker/heuristic_splitter.go
+++ b/internal/infrastructure/chunker/heuristic_splitter.go
@@ -233,6 +233,10 @@ func appendOversizeBlock(out []Chunk, runes []rune, start, end int, cfg Splitter
 // preceding boundary (within 2x overlap) or, failing that, the previous
 // newline so chunks don't begin mid-line / mid-word. Falls back to the raw
 // target only if neither option is available.
+//
+// curEnd itself is always a boundary (the bin-packer flushes at boundary
+// positions), so we exclude it from the search — picking it would yield
+// zero overlap, defeating the purpose of this function.
 func applyOverlapAligned(runes []rune, curEnd, overlap int, bounds []boundary) int {
 	if overlap <= 0 {
 		return curEnd
@@ -241,16 +245,16 @@ func applyOverlapAligned(runes []rune, curEnd, overlap int, bounds []boundary) i
 	if target < 0 {
 		target = 0
 	}
-	// Allowed search window: [curEnd - 2*overlap, curEnd]
+	// Allowed search window: [curEnd - 2*overlap, curEnd)
 	windowStart := curEnd - 2*overlap
 	if windowStart < 0 {
 		windowStart = 0
 	}
 
-	// Prefer a semantic boundary inside the window.
+	// Prefer a semantic boundary strictly inside the window.
 	bestBound := -1
 	for _, b := range bounds {
-		if b.runeStart >= windowStart && b.runeStart <= curEnd && b.runeStart > bestBound {
+		if b.runeStart >= windowStart && b.runeStart < curEnd && b.runeStart > bestBound {
 			bestBound = b.runeStart
 		}
 	}

--- a/internal/infrastructure/chunker/heuristic_splitter.go
+++ b/internal/infrastructure/chunker/heuristic_splitter.go
@@ -27,7 +27,11 @@ type boundary struct {
 
 // splitByHeuristicsImpl is the Tier-2 implementation. Falls through to the
 // legacy splitter when no heuristic boundaries are found.
-func splitByHeuristicsImpl(text string, cfg SplitterConfig) []Chunk {
+//
+// profile is currently unused (this tier scans for boundaries directly) but
+// is accepted to keep the splitByHeadings / splitByHeuristics signatures
+// uniform — see strategy.runTier.
+func splitByHeuristicsImpl(text string, cfg SplitterConfig, _ *DocProfile) []Chunk {
 	if text == "" {
 		return nil
 	}

--- a/internal/infrastructure/chunker/heuristic_splitter.go
+++ b/internal/infrastructure/chunker/heuristic_splitter.go
@@ -42,6 +42,13 @@ func splitByHeuristicsImpl(text string, cfg SplitterConfig, _ *DocProfile) []Chu
 	}
 
 	bounds := findHeuristicBoundaries(text, cfg.Languages)
+	// Drop any boundary that falls strictly inside a protected region (table,
+	// fenced code block, LaTeX block, etc.) — splitting there would cut
+	// through atomic content. Boundaries on a span edge are kept since they
+	// align with the protected region start/end.
+	if prot := protectedSpansRune(text, protectedSpans(text)); len(prot) > 0 {
+		bounds = dropBoundsInsideSpans(bounds, prot)
+	}
 	if len(bounds) == 0 {
 		return SplitText(text, cfg)
 	}
@@ -178,6 +185,30 @@ func findHeuristicBoundaries(text string, langs []string) []boundary {
 		}
 	}
 	return deduped
+}
+
+// dropBoundsInsideSpans returns bounds with entries that fall strictly
+// inside any of the (rune-offset) protected spans removed. Bounds at a
+// span's start or end are kept — they align with the span edge and don't
+// split protected content. spans must be sorted by start.
+func dropBoundsInsideSpans(bounds []boundary, spans []span) []boundary {
+	if len(spans) == 0 {
+		return bounds
+	}
+	out := bounds[:0]
+boundLoop:
+	for _, b := range bounds {
+		for _, s := range spans {
+			if s.start >= b.runeStart {
+				break // remaining spans start at or after b — can't contain b
+			}
+			if b.runeStart < s.end {
+				continue boundLoop
+			}
+		}
+		out = append(out, b)
+	}
+	return out
 }
 
 // allRuneIndices returns every rune offset where needle starts in text.

--- a/internal/infrastructure/chunker/heuristic_splitter.go
+++ b/internal/infrastructure/chunker/heuristic_splitter.go
@@ -229,15 +229,20 @@ func allRuneIndices(text, needle string) []int {
 }
 
 // appendChunk slices runes[start:end] into a Chunk and appends it to out.
+// Pure-whitespace slices are skipped (boundary clustering can occasionally
+// produce them). The Content stored is the raw slice — Start/End rune
+// offsets must match utf8.RuneCountInString(Content) for downstream
+// reconstruction code; whitespace stripping for embedding happens in
+// Chunk.EmbeddingContent.
 func appendChunk(out []Chunk, runes []rune, start, end int, seq *int) []Chunk {
 	if end <= start {
 		return out
 	}
-	content := strings.TrimSpace(string(runes[start:end]))
-	if content == "" {
+	raw := string(runes[start:end])
+	if strings.TrimSpace(raw) == "" {
 		return out
 	}
-	c := Chunk{Content: string(runes[start:end]), Seq: *seq, Start: start, End: end}
+	c := Chunk{Content: raw, Seq: *seq, Start: start, End: end}
 	*seq++
 	return append(out, c)
 }

--- a/internal/infrastructure/chunker/heuristic_splitter_test.go
+++ b/internal/infrastructure/chunker/heuristic_splitter_test.go
@@ -87,3 +87,63 @@ func TestSplitByHeuristics_EmptyText(t *testing.T) {
 		t.Errorf("empty doc should be nil, got %v", got)
 	}
 }
+
+// Regression: applyOverlapAligned previously included curEnd itself in its
+// boundary search, and curEnd is always one of the bounds (the bin-packer
+// flushes at boundary positions). The function therefore always returned
+// curEnd, producing zero overlap regardless of cfg.ChunkOverlap.
+func TestSplitByHeuristics_OverlapActuallyOverlaps(t *testing.T) {
+	// Build many small numbered sections so the bin-packer flushes mid-doc
+	// with at least one earlier boundary inside the overlap window.
+	var sb strings.Builder
+	for i := 1; i <= 12; i++ {
+		sb.WriteString("\n\n")
+		sb.WriteByte(byte('0' + i%10))
+		sb.WriteString(". ")
+		sb.WriteString(strings.Repeat("alpha beta gamma. ", 4)) // ~72 chars / section
+	}
+	doc := sb.String()
+
+	cfg := SplitterConfig{ChunkSize: 200, ChunkOverlap: 80, Separators: []string{". "}}
+	chunks := splitByHeuristicsImpl(doc, cfg)
+	if len(chunks) < 2 {
+		t.Fatalf("need >=2 chunks to test overlap, got %d", len(chunks))
+	}
+
+	// At least one consecutive chunk pair must share a non-trivial suffix /
+	// prefix. We don't require *every* pair to overlap (oversize blocks
+	// short-circuit through legacy and reset chunkStart), but at least one
+	// regular flush boundary should produce real overlap.
+	saw := false
+	for i := 1; i < len(chunks); i++ {
+		prev := strings.TrimSpace(chunks[i-1].Content)
+		cur := strings.TrimSpace(chunks[i].Content)
+		// Walk back the longest suffix of prev that prefixes cur.
+		match := 0
+		maxScan := len(prev)
+		if len(cur) < maxScan {
+			maxScan = len(cur)
+		}
+		for n := 1; n <= maxScan; n++ {
+			if strings.HasPrefix(cur, prev[len(prev)-n:]) {
+				match = n
+			}
+		}
+		if match >= 20 {
+			saw = true
+			break
+		}
+	}
+	if !saw {
+		t.Fatalf("expected at least one chunk pair to overlap by >=20 chars, none did. chunk sizes: %v",
+			chunkLengths(chunks))
+	}
+}
+
+func chunkLengths(chunks []Chunk) []int {
+	out := make([]int, len(chunks))
+	for i, c := range chunks {
+		out[i] = len([]rune(c.Content))
+	}
+	return out
+}

--- a/internal/infrastructure/chunker/heuristic_splitter_test.go
+++ b/internal/infrastructure/chunker/heuristic_splitter_test.go
@@ -8,7 +8,7 @@ import (
 func TestSplitByHeuristics_FormFeedBoundary(t *testing.T) {
 	doc := strings.Repeat("page one body text. ", 30) + "\f" + strings.Repeat("page two body. ", 30)
 	cfg := SplitterConfig{ChunkSize: 400, ChunkOverlap: 20, Separators: []string{". "}}
-	chunks := splitByHeuristicsImpl(doc, cfg)
+	chunks := splitByHeuristicsImpl(doc, cfg, nil)
 	if len(chunks) < 2 {
 		t.Fatalf("form feed should produce ≥2 chunks, got %d", len(chunks))
 	}
@@ -18,7 +18,7 @@ func TestSplitByHeuristics_NumberedSections(t *testing.T) {
 	body := strings.Repeat("body sentence. ", 8)
 	doc := "1. Introduction\n" + body + "\n\n2. Methods\n" + body + "\n\n3. Results\n" + body
 	cfg := SplitterConfig{ChunkSize: 200, ChunkOverlap: 20, Separators: []string{". "}}
-	chunks := splitByHeuristicsImpl(doc, cfg)
+	chunks := splitByHeuristicsImpl(doc, cfg, nil)
 	if len(chunks) < 2 {
 		t.Fatalf("numbered sections should split: got %d chunks", len(chunks))
 	}
@@ -28,7 +28,7 @@ func TestSplitByHeuristics_GermanChapterMarkers(t *testing.T) {
 	body := strings.Repeat("Beispieltext. ", 10)
 	doc := "Kapitel 1: Einführung\n" + body + "\n\nKapitel 2: Hauptteil\n" + body
 	cfg := SplitterConfig{ChunkSize: 200, ChunkOverlap: 20, Separators: []string{". "}}
-	chunks := splitByHeuristicsImpl(doc, cfg)
+	chunks := splitByHeuristicsImpl(doc, cfg, nil)
 	if len(chunks) < 2 {
 		t.Fatalf("German chapter markers should split: got %d", len(chunks))
 	}
@@ -38,7 +38,7 @@ func TestSplitByHeuristics_ChineseChapterMarkers(t *testing.T) {
 	body := strings.Repeat("内容内容内容。", 60)
 	doc := "第一章 引言\n" + body + "\n\n第二章 方法\n" + body
 	cfg := SplitterConfig{ChunkSize: 200, ChunkOverlap: 20, Separators: []string{"。"}, Languages: []string{LangChinese}}
-	chunks := splitByHeuristicsImpl(doc, cfg)
+	chunks := splitByHeuristicsImpl(doc, cfg, nil)
 	if len(chunks) < 2 {
 		t.Fatalf("Chinese chapter markers should split: got %d", len(chunks))
 	}
@@ -47,7 +47,7 @@ func TestSplitByHeuristics_ChineseChapterMarkers(t *testing.T) {
 func TestSplitByHeuristics_FallsThroughForUnstructuredDoc(t *testing.T) {
 	doc := strings.Repeat("plain prose without structure. ", 5)
 	cfg := SplitterConfig{ChunkSize: 1000, ChunkOverlap: 20}
-	chunks := splitByHeuristicsImpl(doc, cfg)
+	chunks := splitByHeuristicsImpl(doc, cfg, nil)
 	if len(chunks) != 1 {
 		t.Errorf("unstructured short doc should be one chunk, got %d", len(chunks))
 	}
@@ -57,7 +57,7 @@ func TestSplitByHeuristics_OversizeBlockRecursesIntoLegacy(t *testing.T) {
 	huge := strings.Repeat("This is a long sentence. ", 200) // ~5000 chars
 	doc := "1. Intro\n" + huge
 	cfg := SplitterConfig{ChunkSize: 500, ChunkOverlap: 50, Separators: []string{". "}}
-	chunks := splitByHeuristicsImpl(doc, cfg)
+	chunks := splitByHeuristicsImpl(doc, cfg, nil)
 	if len(chunks) < 5 {
 		t.Errorf("oversize block should produce many sub-chunks, got %d", len(chunks))
 	}
@@ -83,7 +83,7 @@ func TestSplitByHeuristics_BoundariesAreOrdered(t *testing.T) {
 }
 
 func TestSplitByHeuristics_EmptyText(t *testing.T) {
-	if got := splitByHeuristicsImpl("", DefaultConfig()); got != nil {
+	if got := splitByHeuristicsImpl("", DefaultConfig(), nil); got != nil {
 		t.Errorf("empty doc should be nil, got %v", got)
 	}
 }
@@ -105,7 +105,7 @@ func TestSplitByHeuristics_OverlapActuallyOverlaps(t *testing.T) {
 	doc := sb.String()
 
 	cfg := SplitterConfig{ChunkSize: 200, ChunkOverlap: 80, Separators: []string{". "}}
-	chunks := splitByHeuristicsImpl(doc, cfg)
+	chunks := splitByHeuristicsImpl(doc, cfg, nil)
 	if len(chunks) < 2 {
 		t.Fatalf("need >=2 chunks to test overlap, got %d", len(chunks))
 	}

--- a/internal/infrastructure/chunker/heuristic_splitter_test.go
+++ b/internal/infrastructure/chunker/heuristic_splitter_test.go
@@ -140,6 +140,35 @@ func TestSplitByHeuristics_OverlapActuallyOverlaps(t *testing.T) {
 	}
 }
 
+// Heuristic boundaries that fall inside protected regions (LaTeX block,
+// table, link, etc.) must be dropped so the bin-packer doesn't break
+// atomic content. Without the protected-span filter, a numbered-section
+// looking line inside a $$...$$ math block would be picked as a boundary.
+func TestSplitByHeuristics_DropsBoundariesInsideProtectedSpans(t *testing.T) {
+	body := strings.Repeat("filler. ", 30)
+	// LaTeX block whose middle line matches NumberedSectionPattern. The
+	// filter should drop that boundary so the math block stays intact.
+	doc := body + "\n\n$$\nx = 1\n1. equation step one\ny = 2\n$$\n\n" + body
+
+	bounds := findHeuristicBoundaries(doc, nil)
+	prot := protectedSpansRune(doc, protectedSpans(doc))
+	if len(prot) == 0 {
+		t.Fatalf("expected protected spans for doc, got none")
+	}
+	filtered := dropBoundsInsideSpans(bounds, prot)
+	for _, b := range filtered {
+		for _, s := range prot {
+			if b.runeStart > s.start && b.runeStart < s.end {
+				t.Errorf("boundary %d still inside protected span [%d,%d)", b.runeStart, s.start, s.end)
+			}
+		}
+	}
+	// And it should actually have removed at least one boundary.
+	if len(filtered) >= len(bounds) {
+		t.Errorf("filter removed nothing: before=%d after=%d", len(bounds), len(filtered))
+	}
+}
+
 func chunkLengths(chunks []Chunk) []int {
 	out := make([]int, len(chunks))
 	for i, c := range chunks {

--- a/internal/infrastructure/chunker/splitter.go
+++ b/internal/infrastructure/chunker/splitter.go
@@ -121,6 +121,35 @@ type span struct {
 	start, end int
 }
 
+// protectedSpansRune converts byte-offset protected spans to rune offsets
+// in a single forward pass over text. Used by callers that work in rune
+// space (e.g. the heuristic splitter) to avoid choosing chunk boundaries
+// that cut through protected content. byteSpans must be sorted by start
+// (protectedSpans guarantees this).
+func protectedSpansRune(text string, byteSpans []span) []span {
+	if len(byteSpans) == 0 {
+		return nil
+	}
+	out := make([]span, 0, len(byteSpans))
+	runeIdx := 0
+	byteIdx := 0
+	for _, s := range byteSpans {
+		for byteIdx < s.start && byteIdx < len(text) {
+			_, size := utf8.DecodeRuneInString(text[byteIdx:])
+			byteIdx += size
+			runeIdx++
+		}
+		startRune := runeIdx
+		for byteIdx < s.end && byteIdx < len(text) {
+			_, size := utf8.DecodeRuneInString(text[byteIdx:])
+			byteIdx += size
+			runeIdx++
+		}
+		out = append(out, span{start: startRune, end: runeIdx})
+	}
+	return out
+}
+
 // protectedSpans finds all non-overlapping protected regions in text.
 func protectedSpans(text string) []span {
 	type match struct {

--- a/internal/infrastructure/chunker/splitter.go
+++ b/internal/infrastructure/chunker/splitter.go
@@ -34,11 +34,18 @@ type Chunk struct {
 // EmbeddingContent returns the text that should be fed to the embedding
 // model — the ContextHeader prepended (when set) plus the chunk content.
 // Use this where Content alone would lose semantic context (Tier-1 chunks).
+//
+// Content is returned verbatim from the source document (the End-Start
+// rune-count invariant requires that), but for embedding we trim the
+// surrounding whitespace so leading/trailing newlines from boundary slices
+// don't dilute the embedded vector or waste tokens. Inner whitespace is
+// preserved.
 func (c Chunk) EmbeddingContent() string {
+	body := strings.TrimSpace(c.Content)
 	if c.ContextHeader == "" {
-		return c.Content
+		return body
 	}
-	return c.ContextHeader + "\n\n" + c.Content
+	return c.ContextHeader + "\n\n" + body
 }
 
 // ImageRef is an image reference found within a chunk's content.

--- a/internal/infrastructure/chunker/strategy.go
+++ b/internal/infrastructure/chunker/strategy.go
@@ -9,6 +9,7 @@ package chunker
 
 import (
 	"context"
+	"strings"
 
 	"github.com/Tencent/WeKnora/internal/logger"
 )
@@ -125,9 +126,12 @@ func SplitWithDiagnostics(text string, cfg SplitterConfig) ([]Chunk, *Diagnostic
 // It runs the tier selector for parent splitting, then re-splits each
 // parent into children with the small-chunk config.
 //
-// Children are forced to recursive splitting — they are sub-pieces of an
-// already-segmented parent, so re-profiling per parent would cost N extra
-// O(N) document scans without any real chance of picking a better tier.
+// Child splitting honours childCfg.Strategy. If it is empty/auto and a
+// parent has its own internal structure (sub-headings, numbered sub-
+// sections), the appropriate tier picks it up so child chunks carry a
+// finer-grained breadcrumb than the parent's. Re-profiling each parent
+// is bounded by O(sum(parent_size)) ≈ O(N) total, which is the same
+// order as the original parent profiling pass.
 func SplitParentChild(text string, parentCfg, childCfg SplitterConfig) ParentChildResult {
 	if text == "" {
 		return ParentChildResult{}
@@ -139,12 +143,6 @@ func SplitParentChild(text string, parentCfg, childCfg SplitterConfig) ParentChi
 	if len(parents) == 0 {
 		return ParentChildResult{}
 	}
-
-	// Pin children to the recursive tier so SplitText runs directly without
-	// the profiler/strategy chain re-deciding per parent. Preserves Tier-1
-	// breadcrumb context (already attached to each parent) since we only
-	// re-split parent content, not re-detect headings.
-	childCfg.Strategy = StrategyRecursive
 
 	var newParents []Chunk
 	var children []ChildChunk
@@ -161,17 +159,36 @@ func SplitParentChild(text string, parentCfg, childCfg SplitterConfig) ParentChi
 			sub.Seq = childSeq
 			sub.Start += parent.Start
 			sub.End += parent.Start
-			// Children inherit the parent's breadcrumb so embedding still
-			// sees the section context — but only if the child itself does
-			// not already carry one (sub-splits don't, but defensive).
-			if sub.ContextHeader == "" {
-				sub.ContextHeader = parent.ContextHeader
-			}
+			sub.ContextHeader = mergeBreadcrumbs(parent.ContextHeader, sub.ContextHeader)
 			children = append(children, ChildChunk{Chunk: sub, ParentIndex: parentIndex})
 			childSeq++
 		}
 	}
 	return ParentChildResult{Parents: newParents, Children: children}
+}
+
+// mergeBreadcrumbs combines the parent and child heading breadcrumbs into a
+// single ContextHeader. When the child re-runs heading detection on parent
+// content, its first breadcrumb line typically duplicates the parent's last
+// line (the parent's leading heading sits at the top of the child's input);
+// drop that duplicate so the embedding context isn't redundant.
+func mergeBreadcrumbs(parent, child string) string {
+	if parent == "" {
+		return child
+	}
+	if child == "" {
+		return parent
+	}
+	parentLines := strings.Split(parent, "\n")
+	childLines := strings.Split(child, "\n")
+	if len(parentLines) > 0 && len(childLines) > 0 &&
+		strings.TrimSpace(parentLines[len(parentLines)-1]) == strings.TrimSpace(childLines[0]) {
+		childLines = childLines[1:]
+	}
+	if len(childLines) == 0 {
+		return parent
+	}
+	return parent + "\n" + strings.Join(childLines, "\n")
 }
 
 // resolveChainWithProfile returns the strategy chain to attempt and, when

--- a/internal/infrastructure/chunker/strategy.go
+++ b/internal/infrastructure/chunker/strategy.go
@@ -35,12 +35,12 @@ func Split(text string, cfg SplitterConfig) []Chunk {
 		return nil
 	}
 	cfg = ensureDefaults(cfg)
-	chain, _ := resolveChainWithProfile(text, cfg)
+	chain, profile := resolveChainWithProfile(text, cfg)
 	totalChars := len([]rune(text))
 
 	var lastOut []Chunk
 	for i, tier := range chain {
-		out := runTier(tier, text, cfg)
+		out := runTier(tier, text, cfg, profile)
 		if v := ValidateChunks(out, totalChars, cfg.ChunkSize); v.OK {
 			return out
 		} else {
@@ -100,7 +100,7 @@ func SplitWithDiagnostics(text string, cfg SplitterConfig) ([]Chunk, *Diagnostic
 	var lastOut []Chunk
 	var lastTier StrategyTier
 	for i, tier := range chain {
-		out := runTier(tier, text, cfg)
+		out := runTier(tier, text, cfg, profile)
 		v := ValidateChunks(out, totalChars, cfg.ChunkSize)
 		if v.OK {
 			diag.SelectedTier = tier
@@ -205,12 +205,16 @@ func resolveChainWithProfile(text string, cfg SplitterConfig) ([]StrategyTier, *
 // from heading_splitter.go / heuristic_splitter.go via init(); legacy
 // runs SplitText. The default branch is defensive for future
 // StrategyTier additions.
-func runTier(tier StrategyTier, text string, cfg SplitterConfig) []Chunk {
+//
+// profile may be nil when the caller did not run the document profiler
+// (explicit non-auto strategies skip profiling); splitters that need a
+// profile compute one on demand.
+func runTier(tier StrategyTier, text string, cfg SplitterConfig, profile *DocProfile) []Chunk {
 	switch tier {
 	case TierHeading:
-		return splitByHeadings(text, cfg)
+		return splitByHeadings(text, cfg, profile)
 	case TierHeuristic:
-		return splitByHeuristics(text, cfg)
+		return splitByHeuristics(text, cfg, profile)
 	case TierLegacy:
 		return SplitText(text, cfg)
 	}
@@ -254,12 +258,14 @@ func ensureDefaults(cfg SplitterConfig) SplitterConfig {
 	return cfg
 }
 
-// splitByHeadings is overridden by heading_splitter.go.
-var splitByHeadings = func(text string, cfg SplitterConfig) []Chunk {
+// splitByHeadings is overridden by heading_splitter.go. The default no-op
+// fallback ignores the profile (profile may be nil; the override computes
+// one on demand when so).
+var splitByHeadings = func(text string, cfg SplitterConfig, _ *DocProfile) []Chunk {
 	return SplitText(text, cfg)
 }
 
-// splitByHeuristics is overridden by heuristic_splitter.go.
-var splitByHeuristics = func(text string, cfg SplitterConfig) []Chunk {
+// splitByHeuristics is overridden by heuristic_splitter.go. profile may be nil.
+var splitByHeuristics = func(text string, cfg SplitterConfig, _ *DocProfile) []Chunk {
 	return SplitText(text, cfg)
 }

--- a/internal/infrastructure/chunker/strategy_test.go
+++ b/internal/infrastructure/chunker/strategy_test.go
@@ -91,6 +91,90 @@ func TestSplit_PreservesPositionInvariantAcrossTiers(t *testing.T) {
 	}
 }
 
+// Children should pick up sub-heading context when childCfg uses auto
+// strategy on a heading-rich document. Previously child splitting was
+// pinned to the recursive tier, so sub-chunks all shared the parent's
+// top-level breadcrumb regardless of inner H2/H3 structure.
+func TestSplitParentChild_AutoStrategyEnrichesChildBreadcrumbs(t *testing.T) {
+	body := strings.Repeat("Lorem ipsum dolor sit amet. ", 40)
+	doc := "# Chapter\n" + body +
+		"\n\n## Section A\n" + body +
+		"\n\n## Section B\n" + body +
+		"\n\n## Section C\n" + body
+	seps := []string{"\n\n", "\n", ". "}
+	parentCfg := SplitterConfig{ChunkSize: 800, ChunkOverlap: 80, Strategy: StrategyAuto, Separators: seps}
+	childCfg := SplitterConfig{ChunkSize: 200, ChunkOverlap: 20, Strategy: StrategyAuto, Separators: seps}
+	res := SplitParentChild(doc, parentCfg, childCfg)
+	if len(res.Children) == 0 {
+		t.Fatal("expected children")
+	}
+
+	// At least one child should carry a breadcrumb that includes a
+	// sub-heading (## Section …) — that's only possible if the child
+	// splitter re-detected headings inside the parent.
+	saw := false
+	for _, c := range res.Children {
+		if strings.Contains(c.ContextHeader, "## Section") {
+			saw = true
+			break
+		}
+	}
+	if !saw {
+		t.Errorf("no child carries a sub-heading breadcrumb. samples:\n  %q\n  %q",
+			firstHeader(res.Children), lastHeader(res.Children))
+	}
+
+	// And no breadcrumb should contain the same line twice in a row
+	// (mergeBreadcrumbs deduplicates the parent/child seam).
+	for i, c := range res.Children {
+		lines := strings.Split(c.ContextHeader, "\n")
+		for j := 1; j < len(lines); j++ {
+			if strings.TrimSpace(lines[j]) != "" && lines[j] == lines[j-1] {
+				t.Errorf("child[%d] has duplicate breadcrumb lines: %q", i, c.ContextHeader)
+				break
+			}
+		}
+	}
+}
+
+func firstHeader(cs []ChildChunk) string {
+	if len(cs) == 0 {
+		return ""
+	}
+	return cs[0].ContextHeader
+}
+
+func lastHeader(cs []ChildChunk) string {
+	if len(cs) == 0 {
+		return ""
+	}
+	return cs[len(cs)-1].ContextHeader
+}
+
+func TestMergeBreadcrumbs(t *testing.T) {
+	cases := []struct {
+		name          string
+		parent, child string
+		want          string
+	}{
+		{"empty parent", "", "## Sub", "## Sub"},
+		{"empty child", "# Top", "", "# Top"},
+		{"both empty", "", "", ""},
+		{"disjoint", "# Top", "## Other", "# Top\n## Other"},
+		{"duplicate seam", "# Top\n## A", "## A\n### A1", "# Top\n## A\n### A1"},
+		{"deep duplicate", "# Top", "# Top", "# Top"},
+		{"only whitespace differs", "# Top\n## A", "  ## A  \n### A1", "# Top\n## A\n### A1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeBreadcrumbs(tc.parent, tc.child)
+			if got != tc.want {
+				t.Errorf("mergeBreadcrumbs(%q, %q) = %q, want %q", tc.parent, tc.child, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSplitParentChild_LegacyStrategy(t *testing.T) {
 	text := strings.Repeat("This is a sentence. Another one.\n\n", 50)
 	parentCfg := SplitterConfig{ChunkSize: 400, ChunkOverlap: 40, Strategy: StrategyLegacy}

--- a/internal/types/chunk.go
+++ b/internal/types/chunk.go
@@ -3,6 +3,7 @@
 package types
 
 import (
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -172,15 +173,18 @@ type Chunk struct {
 
 // EmbeddingContent returns the chunk content with ContextHeader prepended
 // when set. Use this where the embedding model needs section context that
-// isn't part of the literal Content.
+// isn't part of the literal Content. Surrounding whitespace on Content is
+// trimmed so leading/trailing newlines from boundary slicing don't dilute
+// the embedded vector.
 func (c *Chunk) EmbeddingContent() string {
 	if c == nil {
 		return ""
 	}
+	body := strings.TrimSpace(c.Content)
 	if c.ContextHeader == "" {
-		return c.Content
+		return body
 	}
-	return c.ContextHeader + "\n\n" + c.Content
+	return c.ContextHeader + "\n\n" + body
 }
 
 // AssignChunkSeqIDs assigns sequential SeqIDs to a batch of chunks that have SeqID == 0.

--- a/internal/types/docparser.go
+++ b/internal/types/docparser.go
@@ -1,5 +1,7 @@
 package types
 
+import "strings"
+
 // ReadRequest is the unified transport-agnostic request for document reading.
 // Set FileContent for file mode, URL for URL mode.
 type ReadRequest struct {
@@ -90,12 +92,15 @@ type ParsedChunk struct {
 // EmbeddingContent returns the text that should be sent to the embedding
 // model: ContextHeader (if any) prepended to Content. Mirrors
 // chunker.Chunk.EmbeddingContent so the choice is consistent across the
-// chunker output and the indexing pipeline.
+// chunker output and the indexing pipeline. Surrounding whitespace on
+// Content is trimmed so leading/trailing newlines from boundary slicing
+// don't dilute the embedded vector.
 func (c ParsedChunk) EmbeddingContent() string {
+	body := strings.TrimSpace(c.Content)
 	if c.ContextHeader == "" {
-		return c.Content
+		return body
 	}
-	return c.ContextHeader + "\n\n" + c.Content
+	return c.ContextHeader + "\n\n" + body
 }
 
 // ParsedParentChunk represents a parent chunk in the parent-child strategy.


### PR DESCRIPTION
## Summary

Phase 1 of a planned cleanup of the adaptive chunker. Five focused commits:

1. **fix overlap bug** — `applyOverlapAligned` searched bounds in `[curEnd-2*overlap, curEnd]`, but `curEnd` is itself always a boundary (the bin-packer flushes at boundary positions), so the loop always returned `curEnd` and produced zero overlap regardless of `cfg.ChunkOverlap`. Exclude `curEnd` from the search window.
2. **thread DocProfile through splitter dispatch** — `Split` already runs `ProfileDocument` once when resolving the auto chain; `splitByHeadingsImpl` was re-running the same O(N) pass on entry. Pass the profile down through `runTier` and only compute on demand when called outside the auto path.
3. **drop boundaries inside protected spans** — heuristic boundary detection (numbered sections, all-caps headings, `\n{3,}` blank blocks, etc.) ran on raw text and could land inside LaTeX `\$\$...\$\$`, Markdown tables, fenced code, or image/link refs — slicing through atomic content. Convert `protectedSpans` output to rune offsets and filter the boundary list before bin-packing.
4. **trim surrounding whitespace before embedding** — `Chunk.Content` preserves source positions (the `End-Start == RuneCountInString` invariant is required by reconstruction code), so a chunk sliced at a boundary often carries leading/trailing newlines. Trim inside `EmbeddingContent` for both `chunker.Chunk` and the two `types.Chunk` / `types.ParsedChunk` mirrors so embeddings aren't diluted; positions / `Content` are unchanged.
5. **parent-child children honour configured strategy** — children were forced to `StrategyRecursive` to avoid \"re-profiling per parent\". In practice that cost is bounded by `O(sum(parent_size)) ≈ O(N)` total, the same order as the original parent profiling pass, and the gain is real: an H1 parent containing H2/H3 sub-headings now produces children with finer-grained breadcrumbs. Adds `mergeBreadcrumbs` to combine parent + child `ContextHeader` and dedupe the duplicated seam line.

(An earlier commit in this stack — collapsing `TierRecursive`/`TierLegacy` — was dropped during rebase because it was superseded by 6efe781a in `main`.)

## Test plan

- [x] `go test ./internal/infrastructure/chunker/ ./internal/types/` passes (4 new regression tests added: overlap actually overlaps, dropping boundaries in protected spans, parent-child auto strategy enriches breadcrumbs, table-driven `mergeBreadcrumbs`)
- [x] `golangci-lint run --new-from-rev=main` reports 0 issues
- [x] `gofmt`-clean
- [x] Pre-existing failures in `internal/application/service` (ES / OSS integration tests requiring infra) confirmed to also fail on `main` — unrelated to this change

## Notes

This is Phase 1 of a multi-phase plan. Phase 2 (typed-element architecture replacing the tier+validator+fallback model) intentionally not included here — see in-tree discussion for design.