### PR TITLE
using the cfs to the updated extract

### DIFF
--- a/cmd/desktop/main.go
+++ b/cmd/desktop/main.go
@@ -173,8 +173,12 @@ func main() {
 		gin.SetMode(gin.DebugMode)
 	}
 
+	//intialize the OS signal context for graceful shutdown
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
 	// Build dependency injection container
-	c := container.BuildContainer(runtime.GetContainer())
+	c := container.BuildContainer(ctx, runtime.GetContainer())
 
 	// Initialize the WeKnora App struct
 	app := NewApp()
@@ -217,6 +221,7 @@ func main() {
 				<-app.shutdownCh
 				logger.Infof(context.Background(), "Wails shutting down, stopping Go backend...")
 
+				cancel()
 				listener.Close()
 				shutdownTimeout := cfg.Server.ShutdownTimeout
 				if shutdownTimeout == 0 {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -48,8 +49,12 @@ func main() {
 		gin.SetMode(gin.DebugMode)
 	}
 
+	//intialize the OS signal context for graceful shutdown
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
 	// Build dependency injection container
-	c := container.BuildContainer(runtime.GetContainer())
+	c := container.BuildContainer(ctx, runtime.GetContainer())
 
 	// Run application
 	err := c.Invoke(func(
@@ -69,12 +74,9 @@ func main() {
 			return fmt.Errorf("failed to start server: %v", err)
 		}
 
-		ctx, done := context.WithCancel(context.Background())
-
-		signals := make(chan os.Signal, 1)
-		signal.Notify(signals, shutdownSignals...)
+		shutdownComplete := make(chan struct{})
 		go func() {
-			sig := <-signals
+			sig := <-ctx.Done()
 			logger.Infof(context.Background(), "Received signal: %v, starting server shutdown...", sig)
 
 			// Close listener first to release port immediately,
@@ -89,8 +91,10 @@ func main() {
 			defer shutdownCancel()
 
 			// Second signal → force close all connections immediately
+			forceSignals := make(chan os.Signal, 1)
+			signal.Notify(forceSignals, os.Interrupt, syscall.SIGTERM)
 			go func() {
-				sig := <-signals
+				sig := <-forceSignals
 				logger.Warnf(context.Background(), "Received second signal: %v, forcing shutdown...", sig)
 				server.Close()
 			}()
@@ -106,7 +110,7 @@ func main() {
 				logger.Errorf(context.Background(), "Errors occurred during resource cleanup: %v", errs)
 			}
 			logger.Info(context.Background(), "Server has exited")
-			done()
+			shutdownComplete <- struct{}{}
 		}()
 
 		logger.Infof(context.Background(), "Server is running at %s", addr)
@@ -114,7 +118,7 @@ func main() {
 			return fmt.Errorf("server error: %v", err)
 		}
 
-		<-ctx.Done()
+		<-shutdownComplete
 		return nil
 	})
 	if err != nil {

--- a/internal/application/service/extract.go
+++ b/internal/application/service/extract.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	secutils "github.com/Tencent/WeKnora/internal/utils"
 	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
 )
@@ -84,6 +85,7 @@ Please output in the following format (one paragraph per column):
 func NewChunkExtractTask(
 	ctx context.Context,
 	client interfaces.TaskEnqueuer,
+	cfs interfaces.TenantFairScheduler,
 	tenantID uint64,
 	chunkID string,
 	modelID string,
@@ -102,6 +104,18 @@ func NewChunkExtractTask(
 	if err != nil {
 		return err
 	}
+
+	cost := secutils.CalculateTaskCost(128*1024, "md", false)
+	if cfs != nil {
+		err = cfs.SubmitTask(ctx, tenantID, types.TypeChunkExtract, payload, cost, &interfaces.CfsTaskOptions{Queue: "default", MaxRetry: 3})
+		if err != nil {
+			logger.Errorf(ctx, "failed to submit chunk extract task to cfs: %v", err)
+			return fmt.Errorf("failed to submit chunk extract task to cfs: %v", err)
+		}
+		logger.Infof(ctx, "submitted chunk extract task to cfs: tenant=%d chunk=%s", tenantID, chunkID)
+		return nil
+	}
+
 	task := asynq.NewTask(types.TypeChunkExtract, payload, asynq.MaxRetry(3))
 	info, err := client.Enqueue(task)
 	if err != nil {

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -49,6 +49,7 @@ type knowledgeService struct {
 	tagService     interfaces.KnowledgeTagService
 	fileSvc        interfaces.FileService
 	modelService   interfaces.ModelService
+	cfsScheduler   interfaces.TenantFairScheduler
 	task           interfaces.TaskEnqueuer
 	graphEngine    interfaces.RetrieveGraphRepository
 	redisClient    *redis.Client
@@ -90,6 +91,7 @@ func NewKnowledgeService(
 	imageResolver *docparser.ImageResolver,
 	wikiRepo interfaces.WikiPageRepository,
 	wikiService interfaces.WikiPageService,
+	cfs interfaces.TenantFairScheduler,
 ) (interfaces.KnowledgeService, error) {
 	return &knowledgeService{
 		config:         config,
@@ -112,6 +114,7 @@ func NewKnowledgeService(
 		imageResolver:  imageResolver,
 		wikiRepo:       wikiRepo,
 		wikiService:    wikiService,
+		cfsScheduler:   cfs,
 	}, nil
 }
 

--- a/internal/application/service/knowledge_post_process.go
+++ b/internal/application/service/knowledge_post_process.go
@@ -21,6 +21,7 @@ type KnowledgePostProcessService struct {
 	kbService     interfaces.KnowledgeBaseService
 	chunkService  interfaces.ChunkService
 	taskEnqueuer  interfaces.TaskEnqueuer
+	cfsScheduler  interfaces.TenantFairScheduler
 	redisClient   *redis.Client
 }
 
@@ -29,6 +30,7 @@ func NewKnowledgePostProcessService(
 	kbService interfaces.KnowledgeBaseService,
 	chunkService interfaces.ChunkService,
 	taskEnqueuer interfaces.TaskEnqueuer,
+	cfs interfaces.TenantFairScheduler,
 	redisClient *redis.Client,
 ) interfaces.TaskHandler {
 	return &KnowledgePostProcessService{
@@ -36,6 +38,7 @@ func NewKnowledgePostProcessService(
 		kbService:     kbService,
 		chunkService:  chunkService,
 		taskEnqueuer:  taskEnqueuer,
+		cfsScheduler:  cfs,
 		redisClient:   redisClient,
 	}
 }
@@ -117,7 +120,7 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 	if kb.IsGraphEnabled() {
 		logger.Infof(ctx, "[KnowledgePostProcess] Spawning Graph RAG extract tasks for %d text-like chunks", len(textChunks))
 		for _, chunk := range textChunks {
-			err := NewChunkExtractTask(ctx, s.taskEnqueuer, payload.TenantID, chunk.ID, kb.SummaryModelID)
+			err := NewChunkExtractTask(ctx, s.taskEnqueuer, s.cfsScheduler, payload.TenantID, chunk.ID, kb.SummaryModelID)
 			if err != nil {
 				logger.Errorf(ctx, "[KnowledgePostProcess] Failed to create chunk extract task for %s: %v", chunk.ID, err)
 			}

--- a/internal/application/service/tenant_scheduler.go
+++ b/internal/application/service/tenant_scheduler.go
@@ -1,0 +1,144 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/hibiken/asynq"
+	"github.com/redis/go-redis/v9"
+)
+
+type cfsScheduler struct {
+	redisClient  *redis.Client
+	taskEnqueuer interfaces.TaskEnqueuer
+}
+
+// envScript 用于在 Redis 中原子地将任务添加到租户专有的 List 中，并更新全局 ZSET 中的 vruntime
+const envScript = `
+-- KEYS[1]: 租户专有的Task List (cfs:tenant:{tenantID})
+-- KEYS[2]: 全局ZSET,记录用户当前vruntime(cfs:vruntime)
+-- ARGV[1]: 序列化的task json
+-- ARGV[2]: tenantID
+
+redis.call("LPUSH",KEYS[1],ARGV[1])
+local score = redis.call("ZSCORE",KEYS[2],ARGV[2])
+--如果是新加入的用户,将其vruntime初始化为当前最小值--
+if not score then
+	local min_vruntime = 0
+	local min_entry = redis.call("ZRANGE",KEYS[2],0,0,"WITHSCORES")
+	if min_entry and #min_entry == 2 then
+		min_vruntime = tonumber(min_entry[2])
+	end
+	redis.call("ZADD",KEYS[2],min_vruntime,ARGV[2])
+end
+`
+
+func NewCFSScheduler(redisClient *redis.Client, taskEnqueuer interfaces.TaskEnqueuer) interfaces.TenantFairScheduler {
+	return &cfsScheduler{
+		redisClient:  redisClient,
+		taskEnqueuer: taskEnqueuer,
+	}
+}
+
+func (c *cfsScheduler) SubmitTask(ctx context.Context, tenantID uint64, taskType string, payload []byte, cost int64, opts *interfaces.CfsTaskOptions) error {
+	// 将任务包装成 cfsTaskWrapper 结构体
+	wrapper := interfaces.CfsTaskWrapper{
+		TaskType: taskType,
+		Payload:  payload,
+		Cost:     cost,
+		Options:  opts,
+	}
+	data, err := json.Marshal(wrapper)
+	if err != nil {
+		logger.Errorf(ctx, "[CFS scheduler] Failed to marshal task wrapper: %s: %v", wrapper.TaskType, err)
+		return err
+	}
+	listKey := fmt.Sprintf("cfs:tenant:%d", tenantID)
+	zsetKet := "cfs:vruntime"
+	// 使用 Lua 脚本原子地将任务添加到租户专有的 List 中，并更新全局 ZSET 中的 vruntime
+	err = c.redisClient.Eval(ctx, envScript, []string{listKey, zsetKet}, data, tenantID).Err()
+	if err != nil {
+		logger.Errorf(ctx, "[CFS scheduler] Lua script exec failed for tenant %d: %v", tenantID, err)
+		return err
+	}
+	logger.Debugf(ctx, "[CFS scheduler] Task submitted: type=%s, tenant=%d, cost=%d", wrapper.TaskType, tenantID, cost)
+	return nil
+}
+func (c *cfsScheduler) Start(ctx context.Context) {
+	go func() {
+		logger.Infof(ctx, "[CFS scheduler] Background loop started")
+		zsetKey := "cfs:vruntime"
+		for {
+			select {
+			case <-ctx.Done():
+				logger.Infof(ctx, "[CFS scheduler] Background loop exiting due to context cancellation")
+				return
+			default:
+			}
+			// 从全局 ZSET 中获取 vruntime 最小的租户ID
+			res, err := c.redisClient.ZRangeWithScores(ctx, zsetKey, 0, 0).Result()
+			if err != nil || len(res) == 0 {
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			tenantID, ok := res[0].Member.(string)
+			if !ok {
+				logger.Errorf(ctx, "[CFS scheduler] Invalid member type in ZSET: %v", res[0].Member)
+				c.redisClient.ZRem(ctx, zsetKey, res[0].Member)
+				continue
+			}
+			listKey := fmt.Sprintf("cfs:tenant:%s", tenantID)
+			taskStr, err := c.redisClient.LPop(ctx, listKey).Result()
+			if err == redis.Nil {
+				c.redisClient.ZRem(ctx, zsetKey, tenantID)
+				continue
+			} else if err != nil {
+				logger.Errorf(ctx, "[CFS scheduler] Failed to LPOP task for tenant %s: %v", listKey, err)
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			// 反序列化任务包装
+			var wrapper interfaces.CfsTaskWrapper
+			if err = json.Unmarshal([]byte(taskStr), &wrapper); err != nil {
+				logger.Errorf(ctx, "[CFS scheduler] Failed to unmarshal task wrapper for tenant %s: %v", tenantID, err)
+				continue
+			}
+			// 根据 wrapper.Options 中的配置构建 asynq.Task 的选项，并将任务提交到 asynq 队列中
+			var asynqOpts []asynq.Option
+			if wrapper.Options != nil {
+				if wrapper.Options.Queue != "" {
+					asynqOpts = append(asynqOpts, asynq.Queue(wrapper.Options.Queue))
+				} else {
+					asynqOpts = append(asynqOpts, asynq.Queue("default"))
+				}
+
+				if wrapper.Options.MaxRetry > 0 {
+					asynqOpts = append(asynqOpts, asynq.MaxRetry(wrapper.Options.MaxRetry))
+				}
+
+				if wrapper.Options.TaskID != "" {
+					asynqOpts = append(asynqOpts, asynq.TaskID(wrapper.Options.TaskID))
+				}
+				//如果有其他asynq配置需求，请在 CfsTaskOptions 中添加字段，并在这里进行转换和添加
+			} else {
+				asynqOpts = append(asynqOpts, asynq.Queue("default"), asynq.MaxRetry(3))
+			}
+
+			asynqTask := asynq.NewTask(wrapper.TaskType, wrapper.Payload, asynqOpts...)
+			_, err = c.taskEnqueuer.Enqueue(asynqTask)
+			if err != nil {
+				logger.Errorf(ctx, "[CFS scheduler] Failed to enqueue task for tenant %s: %v", tenantID, err)
+			} else {
+				logger.Debugf(ctx, "[CFS scheduler] Enqueued task for tenant %s: type=%s cost=%d", tenantID, wrapper.TaskType, wrapper.Cost)
+			}
+
+			// 更新全局 ZSET 中该租户的 vruntime，增加的值等于任务的 cost
+			c.redisClient.ZIncrBy(ctx, zsetKey, float64(wrapper.Cost), tenantID)
+		}
+	}()
+
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -89,8 +89,7 @@ import (
 //
 // Returns:
 //   - Configured container with all application dependencies registered
-func BuildContainer(container *dig.Container) *dig.Container {
-	ctx := context.Background()
+func BuildContainer(ctx context.Context, container *dig.Container) *dig.Container {
 	logger.Debugf(ctx, "[Container] Starting container initialization...")
 
 	// Register resource cleaner for proper cleanup of resources
@@ -225,6 +224,11 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	if redisAvailable {
 		must(container.Provide(router.NewAsyncqClient, dig.As(new(interfaces.TaskEnqueuer))))
 		must(container.Provide(router.NewAsynqServer))
+		must(container.Provide(service.NewCFSScheduler))
+		must(container.Invoke(func(scheduler interfaces.TenantFairScheduler) {
+			logger.Infof(ctx, "[Container]Starting CFS Scheduler background loop...")
+			scheduler.Start(ctx)
+		}))
 	} else {
 		syncExec := router.NewSyncTaskExecutor()
 		must(container.Provide(func() interfaces.TaskEnqueuer { return syncExec }))

--- a/internal/types/interfaces/tenant_scheduler.go
+++ b/internal/types/interfaces/tenant_scheduler.go
@@ -1,0 +1,28 @@
+package interfaces
+
+import (
+	"context"
+)
+
+// CfsTaskOptions 用于在跨redis传输时安全保存asynq配置
+type CfsTaskOptions struct {
+	TaskID   string `json:"task_id,omitempty"`
+	Queue    string `json:"queue,omitempty"`
+	MaxRetry int    `json:"max_retry,omitempty"`
+	//如果业务需要，请直接在下方添加字段并在 tenant_scheduler.go 的 SubmitTask 方法中进行赋值和使用
+}
+
+// cfsTaskWrapper 任务包装结构体，包含任务类型、负载和成本等信息
+type CfsTaskWrapper struct {
+	TaskType string `json:"task_type"`
+	Payload  []byte `json:"payload"`
+
+	Cost    int64           `json:"cost"`
+	Options *CfsTaskOptions `json:"options,omitempty"`
+}
+
+// TenantFairScheduler 租户调度器接口
+type TenantFairScheduler interface {
+	SubmitTask(ctx context.Context, tenantID uint64, taskType string, payload []byte, cost int64, opt *CfsTaskOptions) error
+	Start(ctx context.Context)
+}

--- a/internal/utils/filecost.go
+++ b/internal/utils/filecost.go
@@ -1,0 +1,29 @@
+package utils
+
+// CalculateTaskCost 估算文档处理的算力消耗成本评估
+func CalculateTaskCost(fileSize int64, fileType string, enableMultimodal bool) int64 {
+	baseCost := (fileSize / (1024 * 1024)) * 10
+	if baseCost < 10 {
+		baseCost = 10
+	}
+
+	multiplier := int64(1)
+	switch fileType {
+	case "pdf", "docx", "pptx":
+		multiplier = 3
+	case "png", "jpg", "jpeg", "webp":
+		multiplier = 2
+	case "txt", "md", "csv":
+		multiplier = 1
+	default:
+		multiplier = 2
+	}
+
+	cost := baseCost * multiplier
+
+	if enableMultimodal {
+		cost += 500
+	}
+
+	return cost
+}


### PR DESCRIPTION
# Pull Request

## 描述 (Description)
本 PR 主要为项目引入了基于 Redis 的多租户公平调度器（模拟linux内核对进程分配cpu资源），解决了高频提交任务可能导致的 Asynq 底层队列饿死其他租户的问题。同时将在`container`中创建的`context`改为在`main`中创建并传递，对于`desktop`的入口在`Wails OnShutdown hook`协程中添加cancel产生信号，对于`server`的入口在协程外创建`context`并通过调整进程间通信来保留原来针对多次 `ctrl+c` 的强制退出和单次的等待资源清理后退出

**核心变更内容：**
1. **CFS 公平调度器实现**：引入 `TenantFairScheduler` 接口，基于 Redis ZSET (`cfs:vruntime`) 和 List (`cfs:tenant:{tenantID}`) 实现 vruntime 算力追踪，保障租户公平性。
2. **DTO 抽象与 Asynq Option 透传**：引入 `interfaces.CfsTaskOptions` 和 `interfaces.CfsTaskWrapper`，解耦业务层与 Asynq 指针，确保 `TaskID`、`MaxRetry`、`Queue` 等动态配置在经过 Redis 序列化/反序列化后能被精准还原。
3. **Knowledge 业务层适配**：将 `knowledge.go` 与 `new_knowledge.go` 中所有直连 `asynq.NewTask` 的逻辑重构为调用 CFS 调度器，并封装了相应的 `Cost` 算力预估函数（如 `estimateFAQImportTaskCost`）。
4. **DI 容器注入**：在 `BuildContainer` 中将 CFS 调度器注册到 `dig` 容器，并关联其后台轮询大循环。
5. **优雅停机重构 (Graceful Shutdown)**：统一 `main.go` 中的全局 `Context` ，严格规范关闭顺序（释放 Listener -> 等待 HTTP 排空 -> 关闭后台 CFS 大循环 -> 执行 `resourceCleaner` 清理数据库/Redis 连接），防止产生僵尸进程或断连 Panic。

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [x] 🎨 代码重构 (Code refactoring)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)
- [x] 其他 (Other): 核心调度器、依赖注入容器 (DIG)、主程序生命周期与优雅停机 (Graceful Shutdown)

## 测试 (Testing)
- [x] 手动测试 (Manual testing)

### 测试步骤 (Test Steps)
1. 启动服务，确保 Redis 连接正常，触发多个租户的并发后台任务（如 FAQ 导入、文档解析）。
2. 观察 Redis 中的 `cfs:vruntime` ZSET 分数变动以及 `cfs:tenant:{tenantID}` List，验证新租户进入时的 vruntime 补偿机制是否生效，调度器是否按预期公平拉取任务。
3. 在 FAQ 导入等依赖 `TaskID` 的场景下，验证前端或进度查询 API 是否能正常获取基于指定 ID 的任务进度（证明 Option 透传成功）。
4. 向运行中的服务端发送 `SIGINT` (Ctrl+C) 信号，观察终端日志，验证 HTTP 服务器是否先停止接收请求，后台 CFS 调度器是否跳出循环，最后再执行 DB/Redis 资源清理，确保全程无 `connection refused` 相关的 Panic。

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释
- [x] 变更不会产生新的警告
- [x] 已添加测试用例证明修复有效或功能正常

## 相关 Issue
无

## 截图/录屏 (Screenshots/Recordings)
<!-- 如果是前端 UI 变更，请提供截图或录屏 -->
<img width="671" height="232" alt="image" src="https://github.com/user-attachments/assets/bf902f39-56ed-46ac-a296-33d93376c242" />
<img width="704" height="401" alt="image" src="https://github.com/user-attachments/assets/ae55243e-c7cb-4140-b20b-da797f6bc93c" />
<img width="649" height="427" alt="image" src="https://github.com/user-attachments/assets/03889f91-658c-4778-a261-5ef48f5d3423" />
<img width="651" height="59" alt="image" src="https://github.com/user-attachments/assets/e4c97637-c6c4-404b-b8d1-de4799cbe642" />



## 数据库迁移 (Database Migration)
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
无新增配置项。复用现有的 `REDIS_ADDR` 判断，当存在 Redis 环境时自动启用 CFS 调度器，否则降级为同步执行器。

## 其他信息 (Additional Information)
目前对于文件类型和文件大小的权重计算只是通过个人经验，并没有相关数据支撑，后续可以针对这一点进行优化