### PR TITLE
fix: 为前端静态资源设置 Cache-Control，修复升级后需重新登录才能看到新页面

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -19,6 +19,25 @@ server {
         root /usr/share/nginx/html;
         index index.html;
         try_files $uri $uri/ /index.html;
+
+        # index.html 及 SPA fallback 不可缓存，否则前端升级后用户看不到新版本
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        # nginx add_header 不从上层继承，需要在 location 内重复声明安全头
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    }
+
+    # Vite 构建产物 /assets/* 带 hash 文件名，可长期缓存
+    location ^~ /assets/ {
+        root /usr/share/nginx/html;
+
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     }
 
     # 本地存储文件代理到后端服务（用于渲染 markdown 中的图片）

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -707,13 +707,26 @@ func serveFrontendStatic(r *gin.Engine) {
 		}
 		fullPath := filepath.Join(absDir, path)
 		if info, err := os.Stat(fullPath); err == nil && !info.IsDir() {
+			setFrontendCacheHeaders(c.Writer, path)
 			fileServer.ServeHTTP(c.Writer, c.Request)
 			c.Abort()
 			return
 		}
+		setFrontendCacheHeaders(c.Writer, "/index.html")
 		c.File(indexPath)
 		c.Abort()
 	})
+}
+
+// setFrontendCacheHeaders sets Cache-Control headers for frontend static resources.
+// Vite 构建产物中 /assets/* 的文件名带 hash，可长期缓存；其余（index.html、config.js、favicon 等）
+// 每次都需 revalidate，避免前端升级后用户看到旧版本。
+func setFrontendCacheHeaders(w http.ResponseWriter, path string) {
+	if strings.HasPrefix(path, "/assets/") {
+		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		return
+	}
+	w.Header().Set("Cache-Control", "no-cache, must-revalidate")
 }
 
 // serveFiles serves files via query parameters and tenant storage settings.


### PR DESCRIPTION
## Summary

- 修复前端升级后浏览器刷新仍展示旧页面、必须退出重新登录才会生效的缓存问题
- 为 nginx 前端容器（`frontend/nginx.conf`）和 Lite 版 Go 静态服务（`internal/router/router.go`）设置正确的分级缓存策略

## 根因

`frontend/nginx.conf` 与 Lite 版 `serveFrontendStatic` 均未显式设置 `Cache-Control`，浏览器按启发式缓存策略长期持有 `index.html`。Vite 构建产物中的 `/assets/*` 文件名带 hash 能自然失效，但入口 `index.html` 不带 hash —— 只要它被浏览器缓存，页面引用的就永远是旧一版的 hash 文件，自然看不到新页面。之所以"退出重新登录"能看到新版，是因为部分流程（如租户切换 `window.location.reload()`）触发了整页刷新，绕过了缓存。

## 改动

- **`frontend/nginx.conf`**：
  - `location /`（`index.html` 和 SPA fallback）：`Cache-Control: no-cache, must-revalidate`
  - 新增 `location ^~ /assets/`（Vite hash 产物）：`Cache-Control: public, max-age=31536000, immutable`
  - nginx 的 `add_header` 不从外层 `server` 块继承到 `location`，所以在新改动的 location 里重复声明原有的 4 条安全头（`X-Frame-Options`、`X-Content-Type-Options`、`X-XSS-Protection`、`Referrer-Policy`）
- **`internal/router/router.go`**：Lite 版 `serveFrontendStatic` 增加 `setFrontendCacheHeaders`，按同样的策略区分 `/assets/*` 长缓存与其他资源 revalidate

## Test plan

- [ ] `make docker-build-frontend` 重建前端镜像后部署，`curl -I http://<host>/` 看到 `Cache-Control: no-cache, must-revalidate`
- [ ] `curl -I http://<host>/assets/index-<hash>.js` 看到 `Cache-Control: public, max-age=31536000, immutable`
- [ ] 验证原有安全头（`X-Frame-Options` 等）仍在响应中
- [ ] Lite 版 `make build-lite && make run-lite` 启动后同样 curl 验证响应头
- [ ] 模拟升级：改动一个前端文件重建部署，浏览器普通刷新即可看到新页面，无需退出重登（历史遗留的旧缓存需要硬刷一次 overwrite）