### PR TITLE
fix(agent): 统一最终答案渲染，剥离 <answer> 等假壳

### DIFF
--- a/frontend/src/utils/finalAnswer.ts
+++ b/frontend/src/utils/finalAnswer.ts
@@ -1,0 +1,71 @@
+// finalAnswer.ts
+//
+// Helpers for normalising LLM-emitted final answers before rendering.
+//
+// Background: not every model reliably calls our `final_answer` tool. Many
+// models — especially smaller ones or those SFT'd on different conventions —
+// instead embed the answer inside <answer>…</answer>, <final_answer>…</final_answer>,
+// or prefix it with "Final Answer:" / "最终答案：". When the agent loop accepts
+// such a natural-stop response as the final answer, those wrappers leak into
+// the rendered output. This module provides a single helper to strip them
+// before the markdown renderer sees the text.
+//
+// The function is intentionally conservative: it only strips a wrapper when
+// it covers the *entire* trimmed content. We don't want to corrupt user-
+// authored markdown that happens to contain the word "Final Answer:" or an
+// XML-style tag in the middle of a sentence.
+
+const ANSWER_TAG_RE =
+  /^\s*<(answer|final_answer|final-answer)\b[^>]*>([\s\S]*?)<\/\1>\s*$/i;
+
+const FENCED_ANSWER_RE =
+  /^\s*```(?:final_answer|answer)\s*\n?([\s\S]*?)\n?```\s*$/i;
+
+const ANSWER_PREFIX_RE =
+  /^\s*(?:final\s*answer|最终答案|答案|答)\s*[:：]\s*/i;
+
+/**
+ * Remove common "final answer" wrappers that some models emit instead of
+ * calling the structured `final_answer` tool. Returns the original string
+ * (trimmed only when stripping happens) when no wrapper is detected.
+ *
+ * Recognised wrappers (must cover the entire trimmed content):
+ *  - `<answer>…</answer>` / `<final_answer>…</final_answer>` (case-insensitive)
+ *  - ```` ```final_answer\n…\n``` ```` fenced code block
+ *  - Leading `Final Answer:` / `最终答案：` / `答：` prefix
+ */
+export function unwrapFinalAnswerWrappers(content: string): string {
+  if (!content || typeof content !== 'string') {
+    return content ?? '';
+  }
+
+  let result = content;
+  let changed = false;
+
+  // Strip outer XML-style answer tags. Loop in case the model nested them
+  // (e.g. <final_answer><answer>…</answer></final_answer>), but cap iterations
+  // to avoid pathological inputs.
+  for (let i = 0; i < 3; i++) {
+    const tagMatch = result.match(ANSWER_TAG_RE);
+    if (!tagMatch) break;
+    result = tagMatch[2];
+    changed = true;
+  }
+
+  // Strip fenced "```final_answer" code block wrappers.
+  const fencedMatch = result.match(FENCED_ANSWER_RE);
+  if (fencedMatch) {
+    result = fencedMatch[1];
+    changed = true;
+  }
+
+  // Strip a leading "Final Answer:" / "最终答案：" prefix when it is the very
+  // first non-whitespace token. Only applied once.
+  const prefixMatch = result.match(ANSWER_PREFIX_RE);
+  if (prefixMatch) {
+    result = result.slice(prefixMatch[0].length);
+    changed = true;
+  }
+
+  return changed ? result.trim() : result;
+}

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -207,7 +207,7 @@
             v-if="event.content && event.content.trim()"
             class="answer-content markdown-content"
           >
-               <div v-html="renderMarkdownContent(event.content)"></div>
+               <div v-html="renderAnswerContent(event.content)"></div>
           </div>
           <div v-if="event.done && event.content && event.content.trim()" class="answer-toolbar">
             <t-button size="small" variant="outline" shape="round" @click.stop="handleCopyAnswer(event)" :title="$t('agent.copy')">
@@ -385,6 +385,7 @@ import { useAuthStore } from '@/stores/auth';
 import { useI18n } from 'vue-i18n';
 import i18n from '@/i18n';
 import { hydrateProtectedFileImages } from '@/utils/security';
+import { unwrapFinalAnswerWrappers } from '@/utils/finalAnswer';
 import {
   buildManualMarkdown,
   copyTextToClipboard,
@@ -1059,12 +1060,34 @@ const buildFullEventList = (stream: any[]) => {
   return result;
 };
 
+// When the agent loop ended via natural-stop (no final_answer tool call) and
+// we promote the trailing thinking event into a virtual answer card below
+// the tree, we must hide that same thinking event from the tree to avoid
+// rendering its content twice.
+const promotedThinkingEventId = computed<string | null>(() => {
+  const final = finalContent.value;
+  if (!final || final.type !== 'thinking') return null;
+  // Only promote when there's no real answer event content already.
+  const stream = eventStream.value;
+  if (!stream || !Array.isArray(stream)) return null;
+  const hasRealAnswer = stream.some(
+    (e: any) => e.type === 'answer' && e.content && e.content.trim()
+  );
+  if (hasRealAnswer) return null;
+  return final.event_id || null;
+});
+
 // Intermediate events (tree children: everything except answer)
 const intermediateEvents = computed(() => {
   const stream = eventStream.value;
   if (!stream || !Array.isArray(stream)) return [];
   const result = buildFullEventList(stream);
-  return result.filter((e: any) => e.type !== 'answer' && e.type !== 'agent_complete');
+  const promotedId = promotedThinkingEventId.value;
+  return result.filter((e: any) => {
+    if (e.type === 'answer' || e.type === 'agent_complete') return false;
+    if (promotedId && e.type === 'thinking' && e.event_id === promotedId) return false;
+    return true;
+  });
 });
 
 // Events to display (non-tree: before answer starts show all, after answer starts show only answer)
@@ -1105,14 +1128,23 @@ const displayEvents = computed(() => {
   }
 
   if (final.type === 'thinking') {
-    const thinkingFiltered = result.filter((e: any) =>
+    // The agent loop ended via natural-stop (the model wrote its answer as
+    // free text instead of calling final_answer). Synthesize a virtual
+    // `answer` event from the trailing thinking content so it renders with
+    // the answer card UI (expanded markdown + copy/add toolbar) rather than
+    // the collapsed "思考" card. The original thinking event is still in
+    // the intermediate-steps tree when applicable.
+    const thinking = result.find((e: any) =>
       e.type === 'thinking' && e.event_id === final.event_id
     );
-    if (final.showAnswerToolbar) {
-      const answerDoneEvents = result.filter((e: any) => e.type === 'answer' && e.done === true);
-      return [...thinkingFiltered, ...answerDoneEvents];
-    }
-    return thinkingFiltered;
+    if (!thinking || !thinking.content) return result;
+    return [{
+      type: 'answer',
+      event_id: thinking.event_id,
+      content: thinking.content,
+      done: true,
+      _promoted_from_thinking: true,
+    }];
   }
 
   return result;
@@ -1761,6 +1793,15 @@ const renderMarkdownContent = (content: any): string => {
   return DOMPurify.sanitize(protectedHTML, DOMPurifyConfig);
 };
 
+// Renders an answer event's content. Strips final-answer wrappers
+// (e.g. <answer>…</answer>, "Final Answer:") that some models emit instead
+// of calling the structured final_answer tool, then delegates to the
+// standard markdown renderer.
+const renderAnswerContent = (content: any): string => {
+  const contentStr = typeof content === 'string' ? content : String(content || '');
+  return renderMarkdownContent(unwrapFinalAnswerWrappers(contentStr));
+};
+
 // Legacy Markdown rendering function (kept for summaries)
 const renderMarkdown = (content: any): string => {
   const contentStr = typeof content === 'string' ? content : String(content || '');
@@ -2168,24 +2209,26 @@ const formatJSON = (obj: any): string => {
   }
 };
 
-// Helper function to get actual content (from answer or last thinking)
+// Helper function to get actual content (from answer or last thinking).
+// Strips final-answer wrappers (e.g. <answer>…</answer>, "Final Answer:")
+// so callers like copy and add-to-knowledge get clean text.
 const getActualContent = (answerEvent: any): string => {
   // First try to get content from answer event
   const answerContent = (answerEvent?.content || '').trim();
   if (answerContent) {
-    return answerContent;
+    return unwrapFinalAnswerWrappers(answerContent).trim();
   }
-  
+
   // If answer is empty, try to get from last thinking
   const stream = eventStream.value;
   if (stream && Array.isArray(stream)) {
     const thinkingEvents = stream.filter((e: any) => e.type === 'thinking' && e.content && e.content.trim());
     if (thinkingEvents.length > 0) {
       const lastThinking = thinkingEvents[thinkingEvents.length - 1];
-      return (lastThinking.content || '').trim();
+      return unwrapFinalAnswerWrappers((lastThinking.content || '').trim()).trim();
     }
   }
-  
+
   return '';
 };
 


### PR DESCRIPTION
## Summary

承接 #1126 的方向，进一步修复 Agent 最终答案的前端渲染体验。许多模型（尤其是小模型或非 OpenAI 系训练惯例的模型）即使在系统 prompt 里写了 `MUST call final_answer`，也并不会可靠地调用 `final_answer` 工具，而是直接在自然停止内容里写答案。具体表现两种：

1. **答案被 `<answer>…</answer>` 等假壳包裹**：natural-stop 路径下后端正常把整段内容发为 `EventAgentFinalAnswer`，前端拿到后用 `renderMarkdownContent` 直接渲染，包裹标签/前缀（`<answer>` `<final_answer>` `Final Answer:` `最终答案：` 等）会以原样出现在答案卡里。
2. **完全无 answer 事件、只有 thinking**：`displayEvents` 中已有 legacy fallback 把末尾 thinking 提升为最终内容，但仍然以折叠的「思考 ▾」卡片样式渲染，用户拿不到答案卡的完整 markdown 主体和复制 / 加入知识库工具栏。

## Changes

- 新增工具函数 `frontend/src/utils/finalAnswer.ts`：`unwrapFinalAnswerWrappers()` 保守剥离三类外壳——
  - `<answer>…</answer>` / `<final_answer>…</final_answer>`（大小写不敏感，最多三层嵌套）
  - ` ```final_answer\n…\n``` ` 围栏代码块
  - 行首 `Final Answer:` / `最终答案：` / `答：`
  
  所有规则只在外壳**覆盖整段 trimmed 内容**时才生效，避免误伤用户 markdown 里偶然出现的同名标签或字样。

- `AgentStreamDisplay.vue`：
  - 新增 `renderAnswerContent()`：在 `renderMarkdownContent` 前先调用 unwrap，仅作用于 answer-event 模板，不影响 thinking 渲染。
  - `getActualContent()` 同步剥壳，保证「复制」「加入知识库」拿到的是干净文本。
  - `displayEvents` 的 thinking-fallback 分支不再返回 thinking 事件本体，而是合成一个 `_promoted_from_thinking: true` 的虚拟 answer 事件，让用户得到完整答案卡 UI（展开 markdown + 工具栏）。
  - 新增 `promotedThinkingEventId` computed，把已被提升为答案的那条 thinking 从 `intermediateEvents`（中间步骤树）里过滤掉，避免重复渲染同一段内容。

## 与 #1126 的关系

#1126 已经修了：模型自身 `<think>` reasoning 流与 answer 流分离、`agent_complete` 事件触发结束标记、引用卡片占位符、KaTeX `nonStandard:true`。

本 PR **不重叠** #1126 的任何改动，专门处理另一个独立但常见的问题：模型不调 `final_answer` 工具的渲染兜底。两者叠加后：

- 模型乖乖调 `final_answer` → 走原路径，无变化；
- 模型不调但用 `<answer>` 等包裹答案 → 渲染时剥壳，UI 干净；
- 模型既不调也不包裹、只输出 markdown → 走 natural-stop 答案事件，UI 正常；
- 完全没 answer 事件 → fallback 把末尾 thinking 升级为答案卡，不再折叠成思考卡。

## Test plan

- [x] `npm run build` 通过
- [x] `npm run type-check`：本 PR 不引入新 type error（main 上 96 个 pre-existing 同样为 96 个）
- [ ] 手动验证：用一个小模型的 wiki / smart-reasoning agent 对话，触发 `<answer>...</answer>` 包裹答案的情况，确认前端答案卡内不再出现 `<answer>` 标签
- [ ] 手动验证：触发 `final_answer` 工具调用路径，确认行为不变
- [ ] 手动验证：触发完全无 answer 事件的 fallback 路径，确认末尾 thinking 以答案卡样式渲染、且中间步骤树里不再重复出现该段内容