### PR TITLE
fix(agent): 统一最终答案渲染并去除重复/空思考块

### DIFF
--- a/frontend/src/utils/finalAnswer.ts
+++ b/frontend/src/utils/finalAnswer.ts
@@ -69,3 +69,45 @@ export function unwrapFinalAnswerWrappers(content: string): string {
 
   return changed ? result.trim() : result;
 }
+
+const THINK_BLOCK_RE = /<think\b[^>]*>[\s\S]*?<\/think>/gi;
+
+/**
+ * Normalise content for cross-event comparison. Strips <think>…</think>
+ * blocks (which appear in raw thinking chunks but not in the final answer
+ * event), strips final-answer wrappers, and collapses whitespace. Used to
+ * detect when the natural-stop path emits the same content twice (once as
+ * streaming thinking chunks and once as a final answer event).
+ */
+export function normaliseForComparison(content: string): string {
+  if (!content || typeof content !== 'string') return '';
+  const stripped = content.replace(THINK_BLOCK_RE, '');
+  const unwrapped = unwrapFinalAnswerWrappers(stripped);
+  return unwrapped.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Returns true when `thinking` and `answer` represent the same final answer
+ * after normalisation. Tolerates small differences (≤2% length delta with
+ * matching head/tail) to absorb chunk-boundary whitespace noise.
+ */
+export function thinkingEqualsAnswer(thinking: string, answer: string): boolean {
+  const a = normaliseForComparison(thinking);
+  const b = normaliseForComparison(answer);
+  if (!a || !b) return false;
+  if (a === b) return true;
+
+  const maxLen = Math.max(a.length, b.length);
+  // Require at least ~80 chars of signal to avoid matching trivial prefixes.
+  if (maxLen < 80) return false;
+
+  const lenDelta = Math.abs(a.length - b.length);
+  if (lenDelta > maxLen * 0.02) return false;
+
+  const head = 50;
+  const tail = 50;
+  return (
+    a.slice(0, head) === b.slice(0, head) &&
+    a.slice(-tail) === b.slice(-tail)
+  );
+}

--- a/frontend/src/utils/finalAnswer.ts
+++ b/frontend/src/utils/finalAnswer.ts
@@ -1,0 +1,71 @@
+// finalAnswer.ts
+//
+// Helpers for normalising LLM-emitted final answers before rendering.
+//
+// Background: not every model reliably calls our `final_answer` tool. Many
+// models — especially smaller ones or those SFT'd on different conventions —
+// instead embed the answer inside <answer>…</answer>, <final_answer>…</final_answer>,
+// or prefix it with "Final Answer:" / "最终答案：". When the agent loop accepts
+// such a natural-stop response as the final answer, those wrappers leak into
+// the rendered output. This module provides a single helper to strip them
+// before the markdown renderer sees the text.
+//
+// The function is intentionally conservative: it only strips a wrapper when
+// it covers the *entire* trimmed content. We don't want to corrupt user-
+// authored markdown that happens to contain the word "Final Answer:" or an
+// XML-style tag in the middle of a sentence.
+
+const ANSWER_TAG_RE =
+  /^\s*<(answer|final_answer|final-answer)\b[^>]*>([\s\S]*?)<\/\1>\s*$/i;
+
+const FENCED_ANSWER_RE =
+  /^\s*```(?:final_answer|answer)\s*\n?([\s\S]*?)\n?```\s*$/i;
+
+const ANSWER_PREFIX_RE =
+  /^\s*(?:final\s*answer|最终答案|答案|答)\s*[:：]\s*/i;
+
+/**
+ * Remove common "final answer" wrappers that some models emit instead of
+ * calling the structured `final_answer` tool. Returns the original string
+ * (trimmed only when stripping happens) when no wrapper is detected.
+ *
+ * Recognised wrappers (must cover the entire trimmed content):
+ *  - `<answer>…</answer>` / `<final_answer>…</final_answer>` (case-insensitive)
+ *  - ```` ```final_answer\n…\n``` ```` fenced code block
+ *  - Leading `Final Answer:` / `最终答案：` / `答：` prefix
+ */
+export function unwrapFinalAnswerWrappers(content: string): string {
+  if (!content || typeof content !== 'string') {
+    return content ?? '';
+  }
+
+  let result = content;
+  let changed = false;
+
+  // Strip outer XML-style answer tags. Loop in case the model nested them
+  // (e.g. <final_answer><answer>…</answer></final_answer>), but cap iterations
+  // to avoid pathological inputs.
+  for (let i = 0; i < 3; i++) {
+    const tagMatch = result.match(ANSWER_TAG_RE);
+    if (!tagMatch) break;
+    result = tagMatch[2];
+    changed = true;
+  }
+
+  // Strip fenced "```final_answer" code block wrappers.
+  const fencedMatch = result.match(FENCED_ANSWER_RE);
+  if (fencedMatch) {
+    result = fencedMatch[1];
+    changed = true;
+  }
+
+  // Strip a leading "Final Answer:" / "最终答案：" prefix when it is the very
+  // first non-whitespace token. Only applied once.
+  const prefixMatch = result.match(ANSWER_PREFIX_RE);
+  if (prefixMatch) {
+    result = result.slice(prefixMatch[0].length);
+    changed = true;
+  }
+
+  return changed ? result.trim() : result;
+}

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -385,7 +385,7 @@ import { useAuthStore } from '@/stores/auth';
 import { useI18n } from 'vue-i18n';
 import i18n from '@/i18n';
 import { hydrateProtectedFileImages } from '@/utils/security';
-import { unwrapFinalAnswerWrappers } from '@/utils/finalAnswer';
+import { unwrapFinalAnswerWrappers, thinkingEqualsAnswer } from '@/utils/finalAnswer';
 import {
   buildManualMarkdown,
   copyTextToClipboard,
@@ -1060,21 +1060,52 @@ const buildFullEventList = (stream: any[]) => {
   return result;
 };
 
-// When the agent loop ended via natural-stop (no final_answer tool call) and
-// we promote the trailing thinking event into a virtual answer card below
-// the tree, we must hide that same thinking event from the tree to avoid
-// rendering its content twice.
-const promotedThinkingEventId = computed<string | null>(() => {
-  const final = finalContent.value;
-  if (!final || final.type !== 'thinking') return null;
-  // Only promote when there's no real answer event content already.
+// IDs of thinking events that should NOT be rendered in the intermediate-
+// steps tree because their content is already shown as the final answer.
+// Two cases produce duplicates:
+//   1. `promotedThinkingEventId` — agent loop ended via natural-stop with
+//      no answer event at all; we promote the trailing thinking into a
+//      virtual answer card (see displayEvents) and must hide the source
+//      thinking from the tree.
+//   2. Natural-stop path on the backend streams answer chunks as thought
+//      events first, then re-emits the *same* content as one big answer
+//      event. The merged thinking event in the tree would duplicate the
+//      answer card, so detect content-equivalence and hide it.
+const hiddenThinkingEventIds = computed<Set<string>>(() => {
+  const hidden = new Set<string>();
   const stream = eventStream.value;
-  if (!stream || !Array.isArray(stream)) return null;
-  const hasRealAnswer = stream.some(
-    (e: any) => e.type === 'answer' && e.content && e.content.trim()
-  );
-  if (hasRealAnswer) return null;
-  return final.event_id || null;
+  if (!stream || !Array.isArray(stream)) return hidden;
+
+  // Case 1: trailing thinking promoted to answer (no answer events present).
+  const final = finalContent.value;
+  if (final && final.type === 'thinking') {
+    const hasRealAnswer = stream.some(
+      (e: any) => e.type === 'answer' && e.content && e.content.trim()
+    );
+    if (!hasRealAnswer && final.event_id) {
+      hidden.add(final.event_id);
+    }
+  }
+
+  // Case 2: natural-stop duplicates — answer events carry the same content
+  // already streamed as thinking chunks. Compare merged thinking events
+  // against the concatenated answer content and hide on match.
+  const answerContent = stream
+    .filter((e: any) => e.type === 'answer' && e.content)
+    .map((e: any) => e.content)
+    .join('');
+  if (answerContent.trim()) {
+    const merged = buildFullEventList(stream);
+    for (const e of merged) {
+      if (e.type !== 'thinking' || !e.event_id || !e.content) continue;
+      if (hidden.has(e.event_id)) continue;
+      if (thinkingEqualsAnswer(e.content, answerContent)) {
+        hidden.add(e.event_id);
+      }
+    }
+  }
+
+  return hidden;
 });
 
 // Intermediate events (tree children: everything except answer)
@@ -1082,10 +1113,10 @@ const intermediateEvents = computed(() => {
   const stream = eventStream.value;
   if (!stream || !Array.isArray(stream)) return [];
   const result = buildFullEventList(stream);
-  const promotedId = promotedThinkingEventId.value;
+  const hidden = hiddenThinkingEventIds.value;
   return result.filter((e: any) => {
     if (e.type === 'answer' || e.type === 'agent_complete') return false;
-    if (promotedId && e.type === 'thinking' && e.event_id === promotedId) return false;
+    if (e.type === 'thinking' && e.event_id && hidden.has(e.event_id)) return false;
     return true;
   });
 });

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -207,7 +207,7 @@
             v-if="event.content && event.content.trim()"
             class="answer-content markdown-content"
           >
-               <div v-html="renderMarkdownContent(event.content)"></div>
+               <div v-html="renderAnswerContent(event.content)"></div>
           </div>
           <div v-if="event.done && event.content && event.content.trim()" class="answer-toolbar">
             <t-button size="small" variant="outline" shape="round" @click.stop="handleCopyAnswer(event)" :title="$t('agent.copy')">
@@ -385,6 +385,7 @@ import { useAuthStore } from '@/stores/auth';
 import { useI18n } from 'vue-i18n';
 import i18n from '@/i18n';
 import { hydrateProtectedFileImages } from '@/utils/security';
+import { unwrapFinalAnswerWrappers } from '@/utils/finalAnswer';
 import {
   buildManualMarkdown,
   copyTextToClipboard,
@@ -1059,12 +1060,34 @@ const buildFullEventList = (stream: any[]) => {
   return result;
 };
 
+// When the agent loop ended via natural-stop (no final_answer tool call) and
+// we promote the trailing thinking event into a virtual answer card below
+// the tree, we must hide that same thinking event from the tree to avoid
+// rendering its content twice.
+const promotedThinkingEventId = computed<string | null>(() => {
+  const final = finalContent.value;
+  if (!final || final.type !== 'thinking') return null;
+  // Only promote when there's no real answer event content already.
+  const stream = eventStream.value;
+  if (!stream || !Array.isArray(stream)) return null;
+  const hasRealAnswer = stream.some(
+    (e: any) => e.type === 'answer' && e.content && e.content.trim()
+  );
+  if (hasRealAnswer) return null;
+  return final.event_id || null;
+});
+
 // Intermediate events (tree children: everything except answer)
 const intermediateEvents = computed(() => {
   const stream = eventStream.value;
   if (!stream || !Array.isArray(stream)) return [];
   const result = buildFullEventList(stream);
-  return result.filter((e: any) => e.type !== 'answer' && e.type !== 'agent_complete');
+  const promotedId = promotedThinkingEventId.value;
+  return result.filter((e: any) => {
+    if (e.type === 'answer' || e.type === 'agent_complete') return false;
+    if (promotedId && e.type === 'thinking' && e.event_id === promotedId) return false;
+    return true;
+  });
 });
 
 // Events to display (non-tree: before answer starts show all, after answer starts show only answer)
@@ -1105,14 +1128,23 @@ const displayEvents = computed(() => {
   }
 
   if (final.type === 'thinking') {
-    const thinkingFiltered = result.filter((e: any) =>
+    // The agent loop ended via natural-stop (the model wrote its answer as
+    // free text instead of calling final_answer). Synthesize a virtual
+    // `answer` event from the trailing thinking content so it renders with
+    // the answer card UI (expanded markdown + copy/add toolbar) rather than
+    // the collapsed "思考" card. The original thinking event is still in
+    // the intermediate-steps tree when applicable.
+    const thinking = result.find((e: any) =>
       e.type === 'thinking' && e.event_id === final.event_id
     );
-    if (final.showAnswerToolbar) {
-      const answerDoneEvents = result.filter((e: any) => e.type === 'answer' && e.done === true);
-      return [...thinkingFiltered, ...answerDoneEvents];
-    }
-    return thinkingFiltered;
+    if (!thinking || !thinking.content) return result;
+    return [{
+      type: 'answer',
+      event_id: thinking.event_id,
+      content: thinking.content,
+      done: true,
+      _promoted_from_thinking: true,
+    }];
   }
 
   return result;
@@ -1761,6 +1793,15 @@ const renderMarkdownContent = (content: any): string => {
   return DOMPurify.sanitize(protectedHTML, DOMPurifyConfig);
 };
 
+// Renders an answer event's content. Strips final-answer wrappers
+// (e.g. <answer>…</answer>, "Final Answer:") that some models emit instead
+// of calling the structured final_answer tool, then delegates to the
+// standard markdown renderer.
+const renderAnswerContent = (content: any): string => {
+  const contentStr = typeof content === 'string' ? content : String(content || '');
+  return renderMarkdownContent(unwrapFinalAnswerWrappers(contentStr));
+};
+
 // Legacy Markdown rendering function (kept for summaries)
 const renderMarkdown = (content: any): string => {
   const contentStr = typeof content === 'string' ? content : String(content || '');
@@ -2168,24 +2209,26 @@ const formatJSON = (obj: any): string => {
   }
 };
 
-// Helper function to get actual content (from answer or last thinking)
+// Helper function to get actual content (from answer or last thinking).
+// Strips final-answer wrappers (e.g. <answer>…</answer>, "Final Answer:")
+// so callers like copy and add-to-knowledge get clean text.
 const getActualContent = (answerEvent: any): string => {
   // First try to get content from answer event
   const answerContent = (answerEvent?.content || '').trim();
   if (answerContent) {
-    return answerContent;
+    return unwrapFinalAnswerWrappers(answerContent).trim();
   }
-  
+
   // If answer is empty, try to get from last thinking
   const stream = eventStream.value;
   if (stream && Array.isArray(stream)) {
     const thinkingEvents = stream.filter((e: any) => e.type === 'thinking' && e.content && e.content.trim());
     if (thinkingEvents.length > 0) {
       const lastThinking = thinkingEvents[thinkingEvents.length - 1];
-      return (lastThinking.content || '').trim();
+      return unwrapFinalAnswerWrappers((lastThinking.content || '').trim()).trim();
     }
   }
-  
+
   return '';
 };
 

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -1057,7 +1057,17 @@ const buildFullEventList = (stream: any[]) => {
 
     result.push(event);
   }
-  return result;
+
+  // Drop thinking events whose content is whitespace-only. Some models emit
+  // "\n\n" before a tool call (see e.g. qwen3 emitting blank lines between
+  // [assistant] and tool_calls), which the backend faithfully forwards as
+  // thought_chunk events. Without this filter the tree shows an empty
+  // "思考" card with no text — confusing to the user.
+  return result.filter((e: any) => {
+    if (e.type !== 'thinking') return true;
+    const content = typeof e.content === 'string' ? e.content : '';
+    return content.trim().length > 0;
+  });
 };
 
 // IDs of thinking events that should NOT be rendered in the intermediate-


### PR DESCRIPTION
## Summary

修复 Agent 流式对话里由模型输出不稳定导致的 3 类前端显示问题：

- 模型不调用 `final_answer` 工具时，答案常以 `<answer>...</answer>` / `Final Answer:` 等外壳输出，前端原样显示不友好。
- natural-stop 路径下，Step 里的末尾 thinking 与 Answer 卡内容重复（同一段文本渲染两次）。
- 某些模型（如 qwen3）在 tool_call 前会输出仅空白字符（如 `\n\n`），导致出现“空思考块”。

## Changes

- 新增 `frontend/src/utils/finalAnswer.ts`
  - `unwrapFinalAnswerWrappers`：剥离 `<answer>` / `<final_answer>` / fenced `final_answer` 代码块 / `Final Answer:` 等包裹。
  - `normaliseForComparison` + `thinkingEqualsAnswer`：用于判断 thinking 与 answer 是否语义同一，从而去重。

- 更新 `frontend/src/views/chat/components/AgentStreamDisplay.vue`
  - answer 渲染链路统一走剥壳逻辑（显示、复制、加入知识库都用干净文本）。
  - 当没有 answer 事件时，保留“末尾 thinking 提升为 answer 卡片”兜底。
  - 新增 `hiddenThinkingEventIds`：
    - 隐藏已被提升为 answer 的 thinking；
    - 隐藏与 answer 内容等价的 trailing thinking（解决 Step/Answer 重复）。
  - 在 `buildFullEventList` 末尾过滤 whitespace-only thinking，消除空思考块。

## Test plan

- [x] `npm run build` 通过
- [x] `npm run type-check` 未引入新错误（仓库现存错误数保持一致）
- [ ] 手动验证：不调用 `final_answer` 的模型，Answer 卡不再出现 `<answer>` 外壳
- [ ] 手动验证：natural-stop 场景下 Step 与 Answer 不再重复同段内容
- [ ] 手动验证：tool_call 前空白 thinking 不再显示为空思考块