### PR TITLE
fix(hybrid-search): guard MatchCount=0 truncating all results

### DIFF
--- a/internal/application/service/knowledgebase_search.go
+++ b/internal/application/service/knowledgebase_search.go
@@ -236,10 +236,14 @@ func (s *knowledgeBaseService) HybridSearch(ctx context.Context,
 		return nil, err
 	}
 
-	if len(deduplicatedChunks) > params.MatchCount {
-		deduplicatedChunks = deduplicatedChunks[:params.MatchCount]
+	// Limit to MatchCount; 0 means "no explicit limit" — use over-retrieval floor (50).
+	effectiveMatchCount := params.MatchCount
+	if effectiveMatchCount <= 0 {
+		effectiveMatchCount = 50
 	}
-
+	if len(deduplicatedChunks) > effectiveMatchCount {
+		deduplicatedChunks = deduplicatedChunks[:effectiveMatchCount]
+	}
 	return s.processSearchResults(ctx, deduplicatedChunks, params.SkipContextEnrichment)
 }
 


### PR DESCRIPTION
When HybridSearch is called from the HTTP endpoint without a match_count field, params.MatchCount defaults to Go's zero value. The guard

  if len(deduplicatedChunks) > params.MatchCount { … [:0] }

then silently truncated every result list to empty, so processSearchResults was called with 0 chunks and returned nil — 64 RRF-fused results → 0.

Fix: treat MatchCount ≤ 0 as "no explicit limit" and fall back to the same floor (50) used by the over-retrieval phase.  Callers that set MatchCount explicitly (chat pipeline, knowledge.go, agent tools) are unaffected.

Verified: vector=50 + keyword=50 → RRF=64 → processSearchResults(50) → 108 final results (50 primary + 61 enrichment neighbours/parents) for "M1000 MP frequency bands LTE cellular" query.

# Pull Request

## 描述 (Description)
<!-- 请简要描述这个 PR 的目的和变更内容 -->

## 变更类型 (Type of Change)
<!-- 请选择适用的类型，删除其他选项 -->
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [ ] 📚 文档更新 (Documentation update)
- [ ] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [ ] 🧪 测试相关 (Test related)
- [ ] 🔧 配置变更 (Configuration change)
- [ ] 🐳 Docker 相关 (Docker related)
- [ ] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
<!-- 请选择受影响的组件，删除其他选项 -->
- [ ] 后端 API (Backend API)
- [ ] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [ ] 其他 (Other): <!-- 请说明 -->

## 测试 (Testing)
<!-- 请描述如何测试这些变更 -->
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [ ] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [ ] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 
2. 
3. 

## 检查清单 (Checklist)
<!-- 请确保完成以下检查项 -->
- [ ] 代码遵循项目的编码规范
- [ ] 已进行自我代码审查
- [ ] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [ ] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
<!-- 如果此 PR 解决了某个 issue，请使用 "Fixes #123" 或 "Closes #123" 的格式 -->
Fixes #

## 截图/录屏 (Screenshots/Recordings)
<!-- 如果是前端 UI 变更，请提供截图或录屏 -->

## 数据库迁移 (Database Migration)
<!-- 如果涉及数据库变更，请说明 -->
- [ ] 需要数据库迁移
- [ ] 不需要数据库迁移

## 配置变更 (Configuration Changes)
<!-- 如果涉及配置变更，请说明需要更新的配置项 -->

## 部署说明 (Deployment Notes)
<!-- 如果有特殊的部署要求，请说明 -->

## 其他信息 (Additional Information)
<!-- 任何其他需要说明的信息 -->