### PR TITLE
chore(agent): add fire-once stream diagnostic logs (agent + OpenAI layer)

### DIFF
--- a/internal/agent/think.go
+++ b/internal/agent/think.go
@@ -358,8 +358,14 @@ func (e *AgentEngine) callLLMWithRetry(
 		logger.Infof(ctx, "[Agent][Round-%d] LLM responded: finish=%s, content=%d chars, tools=%v",
 			round, response.FinishReason, len(response.Content), tcNames)
 	} else {
-		logger.Infof(ctx, "[Agent][Round-%d] LLM responded: finish=%s, content=%d chars",
+		logger.Infof(ctx, "[Agent][Round-%d] LLM responded: finish=%s, content=%d chars, tool_calls=0",
 			round, response.FinishReason, len(response.Content))
+		// Early signal for natural-stop path: this round will be analyzed as a
+		// likely final answer (no tool call branch).
+		if response.FinishReason == "stop" {
+			logger.Infof(ctx, "[Agent][Round-%d] Natural-stop candidate detected (finish=stop, tool_calls=0, content=%d chars)",
+				round, len(response.Content))
+		}
 	}
 	if response.Content != "" {
 		preview := response.Content

--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -737,6 +737,18 @@ type streamState struct {
 	fieldExtractors  map[int]*jsonFieldExtractor // per tool-call-index extractors for streaming field extraction
 	usage            *types.TokenUsage           // captured from the final stream chunk when include_usage is enabled
 	lastFinishReason string                      // last observed finish_reason for EOF handler fallback
+
+	// Diagnostic flags (fire-once) used to log earliest signals of tool_call
+	// presence/absence at the OpenAI-protocol level. These are independent of
+	// the higher-level ResponseTypeToolCall marker (which only fires once
+	// function name has stabilized) and let us distinguish between
+	//   (A) no tool_calls field ever observed (true natural-stop), and
+	//   (B) tool_calls field observed but marker not yet emitted.
+	firstToolCallSeen    bool // true once any delta carried tool_calls
+	noToolCallStopLogged bool // true once we logged "stop without tool_calls"
+	firstContentSeen     bool // true once delta.Content first appeared
+	firstReasoningSeen   bool // true once reasoning_content first appeared
+	streamStartedAt      time.Time
 }
 
 func newStreamState() *streamState {
@@ -746,7 +758,19 @@ func newStreamState() *streamState {
 		nameNotified:     make(map[int]bool),
 		hasThinking:      false,
 		fieldExtractors:  make(map[int]*jsonFieldExtractor),
+		streamStartedAt:  time.Now(),
 	}
+}
+
+// elapsedMs returns the milliseconds elapsed since the stream state was
+// initialized. Used to attach time-since-stream-start to fire-once diagnostic
+// logs so a single grep can reveal the temporal layout of a single stream
+// (TTFC / TTFT / first-tool-call / natural-stop confirmation, etc).
+func (s *streamState) elapsedMs() int64 {
+	if s.streamStartedAt.IsZero() {
+		return 0
+	}
+	return time.Since(s.streamStartedAt).Milliseconds()
 }
 
 func (s *streamState) buildOrderedToolCalls() []types.LLMToolCall {
@@ -780,8 +804,32 @@ func (c *RemoteAPIChat) processStreamDelta(ctx context.Context, choice *openai.C
 		c.processToolCallsDelta(ctx, delta.ToolCalls, state, streamChan)
 	}
 
+	// Earliest reliable "no tool_calls" signal at the OpenAI-protocol level:
+	// finish_reason=stop arrived AND we never observed a tool_calls field on
+	// any prior delta. Logged once per stream so callers can grep for the
+	// natural-stop entry point without waiting for the higher-level summary.
+	if isDone &&
+		string(choice.FinishReason) == "stop" &&
+		!state.firstToolCallSeen &&
+		!state.noToolCallStopLogged {
+		logger.Infof(ctx, "[LLM Stream] Natural-stop at OpenAI layer "+
+			"(finish=stop, tool_calls field never observed, thinking_seen=%t, "+
+			"first_content_seen=%t, elapsed_ms=%d)",
+			state.hasThinking, state.firstContentSeen, state.elapsedMs())
+		state.noToolCallStopLogged = true
+	}
+
 	// 发送思考内容（ReasoningContent，支持 DeepSeek 等模型）
 	if reasoningContent != "" {
+		// Earliest reasoning_content signal at the OpenAI-protocol level. Fired
+		// once per stream so we can distinguish "model emitted thinking before
+		// answer" vs "model never produced thinking" when triaging logs.
+		if !state.firstReasoningSeen {
+			state.firstReasoningSeen = true
+			logger.Infof(ctx, "[LLM Stream] First reasoning_content at OpenAI layer "+
+				"(len=%d, preview=%q, elapsed_ms=%d)",
+				len(reasoningContent), truncateForDebug(reasoningContent, 80), state.elapsedMs())
+		}
 		state.hasThinking = true
 		streamChan <- types.StreamResponse{
 			ResponseType: types.ResponseTypeThinking,
@@ -792,6 +840,16 @@ func (c *RemoteAPIChat) processStreamDelta(ctx context.Context, choice *openai.C
 
 	// 发送回答内容
 	if delta.Content != "" {
+		// Earliest delta.Content signal at the OpenAI-protocol level. Fired once
+		// per stream so we can measure TTFC (time-to-first-content) and tell
+		// "answer started before any tool_call" from "tool_call came first".
+		if !state.firstContentSeen {
+			state.firstContentSeen = true
+			logger.Infof(ctx, "[LLM Stream] First delta.Content at OpenAI layer "+
+				"(len=%d, preview=%q, tool_call_seen=%t, thinking_seen=%t, elapsed_ms=%d)",
+				len(delta.Content), truncateForDebug(delta.Content, 80),
+				state.firstToolCallSeen, state.firstReasoningSeen, state.elapsedMs())
+		}
 		// If we had thinking content and this is the first answer chunk,
 		// send a thinking done event first
 		if state.hasThinking {
@@ -846,6 +904,33 @@ func (c *RemoteAPIChat) processStreamDelta(ctx context.Context, choice *openai.C
 
 // processToolCallsDelta 处理 tool calls 的增量更新
 func (c *RemoteAPIChat) processToolCallsDelta(ctx context.Context, toolCalls []openai.ToolCall, state *streamState, streamChan chan types.StreamResponse) {
+	// Earliest signal at the OpenAI-protocol level that this stream will
+	// produce at least one tool call. Fires *before* the function name has
+	// stabilized, i.e. earlier than the higher-level ResponseTypeToolCall
+	// marker downstream consumers see. Useful for distinguishing
+	// "tool_calls field arrived but marker not yet emitted" from
+	// "tool_calls field truly absent" when triaging stream behavior.
+	if !state.firstToolCallSeen && len(toolCalls) > 0 {
+		state.firstToolCallSeen = true
+		var firstID, firstName string
+		for _, tc := range toolCalls {
+			if tc.ID != "" {
+				firstID = tc.ID
+			}
+			if tc.Function.Name != "" {
+				firstName = tc.Function.Name
+			}
+			if firstID != "" || firstName != "" {
+				break
+			}
+		}
+		logger.Infof(ctx, "[LLM Stream] First tool_calls delta at OpenAI layer "+
+			"(count=%d, first_id=%q, first_name=%q, "+
+			"first_content_seen=%t, thinking_seen=%t, elapsed_ms=%d)",
+			len(toolCalls), firstID, firstName,
+			state.firstContentSeen, state.firstReasoningSeen, state.elapsedMs())
+	}
+
 	for _, tc := range toolCalls {
 		var toolCallIndex int
 		if tc.Index != nil {


### PR DESCRIPTION
## Summary

为 agent stream 流程加一组**只触发一次**的诊断日志，用于在不开启 LLM debug 抓包的情况下，仅靠业务日志即可还原一条 stream 的时间线，并判断走的是 natural-stop 还是 tool-call 路径。

包含两层补丁：

### 1. agent 层 (`internal/agent/think.go`)
- 在 `tool_calls=0` 的汇总日志里显式加入 `tool_calls=0`，方便 grep
- 当 `finish_reason=stop` 且本轮无任何 tool_calls 时，额外打印一条 `[Agent][Round-N] Natural-stop candidate detected`，作为本轮会被 `analyzeResponse` 判定为 final-answer 的早期信号

### 2. OpenAI 层 (`internal/models/chat/remote_api.go`)
扩展 `streamState`，新增 `streamStartedAt` / `firstContentSeen` / `firstReasoningSeen`，并在 `processStreamDelta` / `processToolCallsDelta` 中输出**每条 stream 至多一次**的诊断日志：

| 日志 | 触发时机 |
| --- | --- |
| `[LLM Stream] First reasoning_content at OpenAI layer` | `delta.reasoning_content` 第一次非空 |
| `[LLM Stream] First delta.Content at OpenAI layer` | `delta.content` 第一次非空 |
| `[LLM Stream] First tool_calls delta at OpenAI layer` | `delta.tool_calls` 第一次出现（早于高层 `ResponseTypeToolCall` marker） |
| `[LLM Stream] Natural-stop at OpenAI layer` | `finish_reason=stop` 抵达且全程未观察到 `tool_calls` 字段 |

每条都附带 `elapsed_ms`（自 stream 起始）和必要的上下文字段（如 `first_content_seen` / `thinking_seen` / `preview`），文本预览用包内已有的 `truncateForDebug`（rune-safe，截断到 80 字符）。

## Why

之前出现过模型不调 `final_answer` 工具、直接以纯文本结束的情况，前端表现为思考块和答案块内容重复或答案被错误地渲染成思考。排查时只能依赖一条 LLM 完整聚合后的 INFO 日志，无法判断 stream 中实际的协议级行为。这组日志可以让我们：

- 在 stream 中途就识别出 natural-stop 路径（`tool_calls field never observed`），区分"真自然停止"和"高层 marker 未触发但其实有 tool_calls"两种情况
- 度量 TTFC（time-to-first-content）和"reasoning → content → tool_call"的相对顺序，给后续可能的兜底/重路由策略提供依据

## Scope

- 纯日志，无行为变化
- 不改协议/事件类型/前端
- 涉及文件：`internal/agent/think.go`、`internal/models/chat/remote_api.go`

## Test plan

- [ ] 跑一轮 natural-stop（模型直接给文本作答）的对话，确认四条 OpenAI 层日志按顺序出现：`First reasoning_content`（如有）→ `First delta.Content` → `Natural-stop at OpenAI layer`，且 `tool_calls field never observed`
- [ ] 跑一轮调用工具的对话，确认 `First tool_calls delta` 早于上层 `ResponseTypeToolCall` marker 出现，且 `Natural-stop` 日志不会触发
- [ ] 跑一轮 DeepSeek 思维链模型，确认 `First reasoning_content` 在 `First delta.Content` 之前打印
- [ ] `go build ./...` 通过