### PR TITLE
fix(frontend): render markdown tables in chat wiki drawer

### DIFF
--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -3546,6 +3546,58 @@ const handleAddToKnowledge = (answerEvent: any) => {
         text-decoration: none !important;
       }
     }
+
+    table {
+      display: block;
+      width: fit-content;
+      max-width: 100%;
+      overflow-x: auto;
+      margin: 0 0 16px;
+      border-collapse: collapse;
+      font-size: 13px;
+      line-height: 1.55;
+      background: var(--td-bg-color-container);
+      border: 1px solid var(--td-component-stroke);
+      border-radius: 6px;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    table thead {
+      background: var(--td-bg-color-secondarycontainer);
+    }
+
+    table th,
+    table td {
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--td-component-stroke);
+      border-right: 1px solid var(--td-component-stroke);
+      text-align: left;
+      vertical-align: top;
+      word-break: break-word;
+    }
+
+    table th {
+      font-weight: 600;
+      color: var(--td-text-color-primary);
+      white-space: nowrap;
+    }
+
+    table th:last-child,
+    table td:last-child {
+      border-right: none;
+    }
+
+    table tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    table tbody tr:hover {
+      background: var(--td-bg-color-secondarycontainer);
+    }
+
+    table code {
+      font-size: 12px;
+    }
   }
 }
 // Dark mode: invert agent icon (uses currentColor which doesn't work in <img>)


### PR DESCRIPTION
## Summary

- The wiki page drawer opened from the chat view (`AgentStreamDisplay.vue`) was rendering markdown tables without borders, padding or header styling, so tables degraded to the browser default and were hard to read.
- Root cause: the global `.wiki-graph-drawer .wiki-reader-body` style block defined headings, lists, code, blockquote and link styles, but no rules for `<table>/<thead>/<th>/<td>`. `WikiBrowser.vue` already had the proper GFM table styles.
- Fix: copy the same table styles from `WikiBrowser.vue` into the drawer's global style block so tables render consistently across both entry points (borders, header background, row hover, horizontal scroll for wide tables).

## Test plan

- [x] Open a chat session with a wiki knowledge base, click an entity citation in the answer to open the right-side wiki drawer, and verify markdown tables now render with borders, header background and hover state matching the standalone Wiki Browser.
- [x] Verify wide tables scroll horizontally inside the drawer instead of overflowing.
- [x] Verify other content (headings, lists, code blocks, wiki links, images) is unchanged.