### PR TITLE
fix(markdown): resolve uploaded local image references

### DIFF
--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -40,7 +40,7 @@ export function formatStringDate(date: any) {
     year + "-" + month + "-" + day + " " + hour + ":" + minute + ":" + second
   );
 }
-const DEFAULT_VALID_TYPES = new Set(["pdf", "txt", "md", "docx", "doc", "pptx", "ppt", "jpg", "jpeg", "png", "csv", "xlsx", "xls", "mp3", "wav", "m4a", "flac", "ogg"]);
+const DEFAULT_VALID_TYPES = new Set(["pdf", "txt", "md", "markdown", "docx", "doc", "pptx", "ppt", "jpg", "jpeg", "png", "gif", "bmp", "webp", "svg", "tiff", "csv", "xlsx", "xls", "mp3", "wav", "m4a", "flac", "ogg"]);
 
 /**
  * Returns true when the file should be **rejected**.

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -1274,7 +1274,7 @@ const handleDocumentUpload = async (event: Event) => {
   for (let i = 0; i < files.length; i++) {
     const file = files[i];
     const fileExt = file.name.substring(file.name.lastIndexOf('.') + 1).toLowerCase();
-    const imageTypes = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'];
+    const imageTypes = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'svg', 'tiff'];
     const videoTypes = ['mp4', 'mov', 'avi', 'mkv', 'webm', 'wmv', 'flv'];
     const audioTypes = ['mp3', 'wav', 'm4a', 'flac', 'ogg'];
 
@@ -1402,6 +1402,9 @@ const handleFolderUpload = async (event: Event) => {
   const vlmEnabled = kbInfo.value?.vlm_config?.enabled || false;
   const asrEnabled = kbInfo.value?.asr_config?.enabled || false;
   const dynamicTypes = supportedFileTypes.value.size > 0 ? supportedFileTypes.value : undefined
+  const imageTypes = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'svg', 'tiff'];
+  const videoTypes = ['mp4', 'mov', 'avi', 'mkv', 'webm', 'wmv', 'flv'];
+  const audioTypes = ['mp3', 'wav', 'm4a', 'flac', 'ogg'];
 
   const validFiles: File[] = [];
   let hiddenFileCount = 0;
@@ -1421,9 +1424,6 @@ const handleFolderUpload = async (event: Event) => {
     }
     
     const fileExt = file.name.substring(file.name.lastIndexOf('.') + 1).toLowerCase();
-    const imageTypes = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'];
-    const videoTypes = ['mp4', 'mov', 'avi', 'mkv', 'webm', 'wmv', 'flv'];
-    const audioTypes = ['mp3', 'wav', 'm4a', 'flac', 'ogg'];
 
     if (videoTypes.includes(fileExt)) {
       videoFilteredCount++;
@@ -1468,8 +1468,17 @@ const handleFolderUpload = async (event: Event) => {
   let successCount = 0;
   let failCount = 0;
   const tagIdToUpload = selectedTagId.value !== '__untagged__' ? selectedTagId.value : undefined;
+  const uploadFiles = [...validFiles].sort((a, b) => {
+    const priority = (file: File) => {
+      const ext = file.name.substring(file.name.lastIndexOf('.') + 1).toLowerCase();
+      if (imageTypes.includes(ext)) return 0;
+      if (ext === 'md' || ext === 'markdown') return 2;
+      return 1;
+    };
+    return priority(a) - priority(b);
+  });
 
-  for (const file of validFiles) {
+  for (const file of uploadFiles) {
     const relativePath = (file as any).webkitRelativePath;
     let fileName = file.name;
     if (relativePath) {

--- a/internal/application/repository/knowledge.go
+++ b/internal/application/repository/knowledge.go
@@ -124,6 +124,27 @@ func applyKnowledgeListFilter(query *gorm.DB, filter types.KnowledgeListFilter) 
 	return query
 }
 
+// ListKnowledgeByFileNames lists knowledge entries by exact file names in a knowledge base.
+func (r *knowledgeRepository) ListKnowledgeByFileNames(
+	ctx context.Context,
+	tenantID uint64,
+	kbID string,
+	fileNames []string,
+) ([]*types.Knowledge, error) {
+	if len(fileNames) == 0 {
+		return nil, nil
+	}
+
+	var knowledges []*types.Knowledge
+	if err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND knowledge_base_id = ? AND file_name IN ?", tenantID, kbID, fileNames).
+		Order("created_at DESC").
+		Find(&knowledges).Error; err != nil {
+		return nil, err
+	}
+	return knowledges, nil
+}
+
 // ListPagedKnowledgeByKnowledgeBaseID lists all knowledge in a knowledge base with pagination
 func (r *knowledgeRepository) ListPagedKnowledgeByKnowledgeBaseID(
 	ctx context.Context,

--- a/internal/application/repository/knowledge_test.go
+++ b/internal/application/repository/knowledge_test.go
@@ -1,0 +1,83 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupKnowledgeTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.Knowledge{}))
+	return db
+}
+
+func TestListKnowledgeByFileNames(t *testing.T) {
+	db := setupKnowledgeTestDB(t)
+	repo := NewKnowledgeRepository(db)
+	ctx := context.Background()
+	now := time.Now()
+
+	knowledges := []*types.Knowledge{
+		{
+			ID:              "target",
+			TenantID:        1,
+			KnowledgeBaseID: "kb-a",
+			Type:            "file",
+			FileName:        "docs/images/pic.png",
+			FileType:        "png",
+			FilePath:        "local://target",
+			CreatedAt:       now,
+		},
+		{
+			ID:              "other-file",
+			TenantID:        1,
+			KnowledgeBaseID: "kb-a",
+			Type:            "file",
+			FileName:        "docs/images/other.png",
+			FileType:        "png",
+			FilePath:        "local://other",
+			CreatedAt:       now.Add(time.Second),
+		},
+		{
+			ID:              "other-kb",
+			TenantID:        1,
+			KnowledgeBaseID: "kb-b",
+			Type:            "file",
+			FileName:        "docs/images/pic.png",
+			FileType:        "png",
+			FilePath:        "local://other-kb",
+			CreatedAt:       now.Add(2 * time.Second),
+		},
+		{
+			ID:              "other-tenant",
+			TenantID:        2,
+			KnowledgeBaseID: "kb-a",
+			Type:            "file",
+			FileName:        "docs/images/pic.png",
+			FileType:        "png",
+			FilePath:        "local://other-tenant",
+			CreatedAt:       now.Add(3 * time.Second),
+		},
+	}
+	for _, knowledge := range knowledges {
+		require.NoError(t, db.Create(knowledge).Error)
+	}
+
+	got, err := repo.ListKnowledgeByFileNames(ctx, 1, "kb-a", []string{"docs/images/pic.png", "missing.png"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "target", got[0].ID)
+
+	empty, err := repo.ListKnowledgeByFileNames(ctx, 1, "kb-a", nil)
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+}

--- a/internal/application/service/knowledge_markdown_images.go
+++ b/internal/application/service/knowledge_markdown_images.go
@@ -1,0 +1,213 @@
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+var (
+	markdownImageRefPattern = regexp.MustCompile(`!\[(.*?)\]\(([^()\n]*(?:\([^)]*\)[^()\n]*)*)\)`)
+	uriSchemePattern        = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*:`)
+)
+
+type markdownLocalImageRef struct {
+	originalRef string
+	fileName    string
+}
+
+func (s *knowledgeService) attachMarkdownLocalImages(
+	ctx context.Context,
+	kb *types.KnowledgeBase,
+	payload types.DocumentProcessPayload,
+	result *types.ReadResult,
+) {
+	if s.repo == nil || kb == nil || result == nil || !isMarkdownFileType(payload.FileType, payload.FileName) {
+		return
+	}
+
+	refs := extractMarkdownLocalImageRefs(result.MarkdownContent, payload.FileName)
+	if len(refs) == 0 {
+		return
+	}
+
+	tenantID := payload.TenantID
+	if tenantID == 0 {
+		tenantID, _ = ctx.Value(types.TenantIDContextKey).(uint64)
+	}
+
+	knowledges, err := s.repo.ListKnowledgeByFileNames(ctx, tenantID, kb.ID, uniqueMarkdownImageFileNames(refs))
+	if err != nil {
+		logger.Warnf(ctx, "Failed to look up local markdown images for knowledge base %s: %v", kb.ID, err)
+		return
+	}
+
+	knowledgeByName := make(map[string]*types.Knowledge, len(knowledges))
+	for _, knowledge := range knowledges {
+		if knowledge == nil || knowledge.FilePath == "" || !IsImageType(strings.ToLower(knowledge.FileType)) {
+			continue
+		}
+		if _, exists := knowledgeByName[knowledge.FileName]; !exists {
+			knowledgeByName[knowledge.FileName] = knowledge
+		}
+	}
+
+	existingRefs := make(map[string]struct{}, len(result.ImageRefs))
+	for _, ref := range result.ImageRefs {
+		existingRefs[ref.OriginalRef] = struct{}{}
+	}
+
+	resolvedCount := 0
+	for _, ref := range refs {
+		if _, exists := existingRefs[ref.originalRef]; exists {
+			continue
+		}
+
+		imageKnowledge := knowledgeByName[ref.fileName]
+		if imageKnowledge == nil {
+			continue
+		}
+
+		data, err := s.readKnowledgeImageBytes(ctx, kb, imageKnowledge)
+		if err != nil {
+			logger.Warnf(ctx, "Failed to read local markdown image %s: %v", ref.fileName, err)
+			continue
+		}
+		if len(data) == 0 {
+			continue
+		}
+
+		result.ImageRefs = append(result.ImageRefs, types.ImageRef{
+			Filename:    path.Base(imageKnowledge.FileName),
+			OriginalRef: ref.originalRef,
+			MimeType:    mimeTypeForImageFile(imageKnowledge.FileName, data),
+			ImageData:   data,
+			IsOriginal:  true,
+		})
+		existingRefs[ref.originalRef] = struct{}{}
+		resolvedCount++
+	}
+
+	if resolvedCount > 0 {
+		logger.Infof(ctx, "Resolved %d local markdown images for knowledge %s", resolvedCount, payload.KnowledgeID)
+	}
+}
+
+func (s *knowledgeService) readKnowledgeImageBytes(
+	ctx context.Context,
+	kb *types.KnowledgeBase,
+	knowledge *types.Knowledge,
+) ([]byte, error) {
+	reader, err := s.resolveFileServiceForPath(ctx, kb, knowledge.FilePath).GetFile(ctx, knowledge.FilePath)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	return io.ReadAll(reader)
+}
+
+func extractMarkdownLocalImageRefs(markdown string, baseFileName string) []markdownLocalImageRef {
+	matches := markdownImageRefPattern.FindAllStringSubmatchIndex(markdown, -1)
+	refs := make([]markdownLocalImageRef, 0, len(matches))
+	for _, match := range matches {
+		originalRef := strings.TrimSpace(markdown[match[4]:match[5]])
+		fileName, ok := normalizeMarkdownLocalImagePath(originalRef, baseFileName)
+		if !ok || !IsImageType(strings.ToLower(getFileType(fileName))) {
+			continue
+		}
+		refs = append(refs, markdownLocalImageRef{
+			originalRef: originalRef,
+			fileName:    fileName,
+		})
+	}
+	return refs
+}
+
+func normalizeMarkdownLocalImagePath(rawRef string, baseFileName string) (string, bool) {
+	ref := strings.TrimSpace(rawRef)
+	if strings.HasPrefix(ref, "<") && strings.HasSuffix(ref, ">") && len(ref) > 1 {
+		ref = strings.TrimSpace(ref[1 : len(ref)-1])
+	}
+	if ref == "" {
+		return "", false
+	}
+
+	ref = strings.ReplaceAll(ref, "\\", "/")
+	if strings.HasPrefix(ref, "/") || strings.HasPrefix(ref, "//") || uriSchemePattern.MatchString(ref) {
+		return "", false
+	}
+	if idx := strings.IndexAny(ref, "?#"); idx >= 0 {
+		ref = ref[:idx]
+	}
+	if ref == "" {
+		return "", false
+	}
+
+	if decoded, err := url.PathUnescape(ref); err == nil {
+		ref = decoded
+	}
+	ref = strings.ReplaceAll(ref, "\\", "/")
+	if strings.HasPrefix(ref, "/") || strings.HasPrefix(ref, "//") || uriSchemePattern.MatchString(ref) {
+		return "", false
+	}
+
+	baseDir := path.Dir(strings.ReplaceAll(baseFileName, "\\", "/"))
+	if baseDir == "." {
+		baseDir = ""
+	}
+
+	fileName := path.Clean(path.Join(baseDir, ref))
+	if fileName == "." || fileName == ".." || strings.HasPrefix(fileName, "../") || strings.HasPrefix(fileName, "/") {
+		return "", false
+	}
+	return fileName, true
+}
+
+func uniqueMarkdownImageFileNames(refs []markdownLocalImageRef) []string {
+	seen := make(map[string]struct{}, len(refs))
+	fileNames := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		if _, exists := seen[ref.fileName]; exists {
+			continue
+		}
+		seen[ref.fileName] = struct{}{}
+		fileNames = append(fileNames, ref.fileName)
+	}
+	return fileNames
+}
+
+func isMarkdownFileType(fileType string, fileName string) bool {
+	ft := strings.ToLower(strings.TrimPrefix(fileType, "."))
+	if ft == "" || ft == "unknown" {
+		ft = strings.ToLower(getFileType(fileName))
+	}
+	return ft == "md" || ft == "markdown"
+}
+
+func mimeTypeForImageFile(fileName string, data []byte) string {
+	switch strings.ToLower(strings.TrimPrefix(path.Ext(fileName), ".")) {
+	case "jpg", "jpeg":
+		return "image/jpeg"
+	case "png":
+		return "image/png"
+	case "gif":
+		return "image/gif"
+	case "webp":
+		return "image/webp"
+	case "bmp":
+		return "image/bmp"
+	case "svg":
+		return "image/svg+xml"
+	case "tif", "tiff":
+		return "image/tiff"
+	default:
+		return http.DetectContentType(data)
+	}
+}

--- a/internal/application/service/knowledge_markdown_images_test.go
+++ b/internal/application/service/knowledge_markdown_images_test.go
@@ -1,0 +1,178 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"strings"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/types"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestExtractMarkdownLocalImageRefs(t *testing.T) {
+	markdown := strings.Join([]string{
+		`![relative](images/pic.png)`,
+		`![dot](./images/space%20name.JPG)`,
+		`![sibling](../shared/diagram.svg)`,
+		`![angle](<images/flow chart.webp>)`,
+		`![remote](https://example.com/remote.png)`,
+		`![data](data:image/png;base64,AAA)`,
+		`![provider](local://images/already.png)`,
+		`![absolute](/var/tmp/secret.png)`,
+		`![escape](../../../secret.png)`,
+		`![not-image](notes/readme.txt)`,
+	}, "\n")
+
+	refs := extractMarkdownLocalImageRefs(markdown, "docs/chapter/readme.md")
+
+	expected := map[string]string{
+		"images/pic.png":            "docs/chapter/images/pic.png",
+		"./images/space%20name.JPG": "docs/chapter/images/space name.JPG",
+		"../shared/diagram.svg":     "docs/shared/diagram.svg",
+		"<images/flow chart.webp>":  "docs/chapter/images/flow chart.webp",
+	}
+	if len(refs) != len(expected) {
+		t.Fatalf("expected %d refs but got %d: %+v", len(expected), len(refs), refs)
+	}
+
+	for _, ref := range refs {
+		if expected[ref.originalRef] != ref.fileName {
+			t.Fatalf("unexpected ref resolution for %q: got %q want %q", ref.originalRef, ref.fileName, expected[ref.originalRef])
+		}
+	}
+}
+
+func TestNormalizeMarkdownLocalImagePathSkipsUnsafeRefs(t *testing.T) {
+	tests := []struct {
+		name      string
+		ref       string
+		want      string
+		wantValid bool
+	}{
+		{name: "same directory", ref: "pic.png", want: "docs/pic.png", wantValid: true},
+		{name: "sub directory", ref: "images/pic.png", want: "docs/images/pic.png", wantValid: true},
+		{name: "sibling directory", ref: "../assets/pic.png", want: "assets/pic.png", wantValid: true},
+		{name: "encoded spaces", ref: "images/pic%201.png", want: "docs/images/pic 1.png", wantValid: true},
+		{name: "absolute path", ref: "/tmp/pic.png", wantValid: false},
+		{name: "network scheme", ref: "https://example.com/pic.png", wantValid: false},
+		{name: "provider scheme", ref: "local://images/pic.png", wantValid: false},
+		{name: "data uri", ref: "data:image/png;base64,AAA", wantValid: false},
+		{name: "windows absolute path", ref: "C:\\temp\\pic.png", wantValid: false},
+		{name: "path traversal", ref: "../../pic.png", wantValid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, valid := normalizeMarkdownLocalImagePath(tt.ref, "docs/readme.md")
+			if valid != tt.wantValid {
+				t.Fatalf("valid = %v, want %v", valid, tt.wantValid)
+			}
+			if got != tt.want {
+				t.Fatalf("path = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMimeTypeForImageFileUsesExtension(t *testing.T) {
+	if got := mimeTypeForImageFile("images/diagram.svg", []byte("<svg></svg>")); got != "image/svg+xml" {
+		t.Fatalf("got %q, want image/svg+xml", got)
+	}
+	if got := mimeTypeForImageFile("images/photo.JPG", nil); got != "image/jpeg" {
+		t.Fatalf("got %q, want image/jpeg", got)
+	}
+}
+
+func TestAttachMarkdownLocalImagesUsesUploadedImageKnowledge(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&types.Knowledge{}); err != nil {
+		t.Fatal(err)
+	}
+
+	imageData := []byte("uploaded image bytes")
+	imageFilePath := "local://images/pic.png"
+	if err := db.Create(&types.Knowledge{
+		ID:              "image-knowledge",
+		TenantID:        1,
+		KnowledgeBaseID: "kb-a",
+		Type:            "file",
+		FileName:        "docs/images/pic.png",
+		FileType:        "png",
+		FilePath:        imageFilePath,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	svc := &knowledgeService{
+		repo: repository.NewKnowledgeRepository(db),
+		fileSvc: &memoryFileService{
+			files: map[string][]byte{imageFilePath: imageData},
+		},
+	}
+	result := &types.ReadResult{
+		MarkdownContent: "![pic](images/pic.png)",
+	}
+
+	svc.attachMarkdownLocalImages(context.Background(), &types.KnowledgeBase{ID: "kb-a"}, types.DocumentProcessPayload{
+		TenantID:        1,
+		KnowledgeID:     "markdown-knowledge",
+		FileName:        "docs/readme.md",
+		FileType:        "md",
+		KnowledgeBaseID: "kb-a",
+	}, result)
+
+	if len(result.ImageRefs) != 1 {
+		t.Fatalf("expected 1 image ref but got %d", len(result.ImageRefs))
+	}
+	ref := result.ImageRefs[0]
+	if ref.OriginalRef != "images/pic.png" {
+		t.Fatalf("got original ref %q", ref.OriginalRef)
+	}
+	if !bytes.Equal(ref.ImageData, imageData) {
+		t.Fatal("image data mismatch")
+	}
+	if !ref.IsOriginal {
+		t.Fatal("local markdown image should skip icon filtering")
+	}
+}
+
+type memoryFileService struct {
+	files map[string][]byte
+}
+
+func (m *memoryFileService) CheckConnectivity(context.Context) error {
+	return nil
+}
+
+func (m *memoryFileService) SaveFile(context.Context, *multipart.FileHeader, uint64, string) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+func (m *memoryFileService) SaveBytes(context.Context, []byte, uint64, string, bool) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+func (m *memoryFileService) GetFile(_ context.Context, filePath string) (io.ReadCloser, error) {
+	data, ok := m.files[filePath]
+	if !ok {
+		return nil, fmt.Errorf("file not found: %s", filePath)
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (m *memoryFileService) GetFileURL(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (m *memoryFileService) DeleteFile(context.Context, string) error {
+	return nil
+}

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -2145,6 +2145,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 	if s.imageResolver != nil && convertResult != nil {
 		fileSvc := s.resolveFileService(ctx, kb)
 		tenantID, _ := ctx.Value(types.TenantIDContextKey).(uint64)
+		s.attachMarkdownLocalImages(ctx, kb, payload, convertResult)
 		updatedMarkdown, images, resolveErr := s.imageResolver.ResolveAndStore(ctx, convertResult, fileSvc, tenantID)
 		if resolveErr != nil {
 			logger.Warnf(ctx, "Image resolution partially failed: %v", resolveErr)

--- a/internal/application/service/knowledge_util.go
+++ b/internal/application/service/knowledge_util.go
@@ -22,7 +22,7 @@ import (
 func isValidFileType(filename string) bool {
 	switch strings.ToLower(getFileType(filename)) {
 	case "pdf", "txt", "docx", "doc", "md", "markdown", "png", "jpg", "jpeg", "gif", "csv", "xlsx", "xls", "pptx", "ppt", "json",
-		"mp3", "wav", "m4a", "flac", "ogg":
+		"webp", "bmp", "svg", "tiff", "mp3", "wav", "m4a", "flac", "ogg":
 		return true
 	default:
 		return false

--- a/internal/application/service/knowledge_util_test.go
+++ b/internal/application/service/knowledge_util_test.go
@@ -1,0 +1,17 @@
+package service
+
+import "testing"
+
+func TestIsValidFileTypeAcceptsSupportedImageFormats(t *testing.T) {
+	for _, name := range []string{
+		"diagram.png",
+		"diagram.webp",
+		"diagram.bmp",
+		"diagram.svg",
+		"diagram.tiff",
+	} {
+		if !isValidFileType(name) {
+			t.Fatalf("expected %q to be a valid file type", name)
+		}
+	}
+}

--- a/internal/infrastructure/docparser/builtin_converter.go
+++ b/internal/infrastructure/docparser/builtin_converter.go
@@ -21,7 +21,7 @@ var simpleFormats = map[string]bool{
 
 var imageFormats = map[string]bool{
 	"jpg": true, "jpeg": true, "png": true, "gif": true,
-	"bmp": true, "tiff": true, "webp": true,
+	"bmp": true, "tiff": true, "webp": true, "svg": true,
 }
 
 var audioFormats = map[string]bool{

--- a/internal/infrastructure/docparser/engine_registry.go
+++ b/internal/infrastructure/docparser/engine_registry.go
@@ -71,7 +71,7 @@ func (e *simpleEngine) Description() string {
 	return "Simple format & image parsing (no external service required)"
 }
 func (e *simpleEngine) FileTypes(_ bool) []string {
-	return []string{"md", "markdown", "txt", "csv", "json", "jpg", "jpeg", "png", "gif", "bmp", "tiff", "webp", "mp3", "wav", "m4a", "flac", "ogg"}
+	return []string{"md", "markdown", "txt", "csv", "json", "jpg", "jpeg", "png", "gif", "bmp", "tiff", "webp", "svg", "mp3", "wav", "m4a", "flac", "ogg"}
 }
 func (e *simpleEngine) CheckAvailable(_ bool, _ map[string]string) (bool, string) {
 	return true, ""

--- a/internal/infrastructure/docparser/image_resolver_test.go
+++ b/internal/infrastructure/docparser/image_resolver_test.go
@@ -270,3 +270,38 @@ func TestResolveAndStore_MultipleFormats(t *testing.T) {
 		t.Fatalf("data URI still in output after ResolveAndStore")
 	}
 }
+
+func TestResolveAndStore_LocalImageRefFromReadResult(t *testing.T) {
+	png := createTestPNG(200, 150)
+	md := `# Document
+
+![diagram](images/diagram.png)`
+	result := &types.ReadResult{
+		MarkdownContent: md,
+		ImageRefs: []types.ImageRef{
+			{
+				Filename:    "diagram.png",
+				OriginalRef: "images/diagram.png",
+				MimeType:    "image/png",
+				ImageData:   png,
+				IsOriginal:  true,
+			},
+		},
+	}
+
+	svc := &captureSaveBytes{}
+	r := NewImageResolver()
+	out, imgs, err := r.ResolveAndStore(context.Background(), result, svc, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(imgs) != 1 {
+		t.Fatalf("expected 1 image but got %d", len(imgs))
+	}
+	if len(svc.saved) != 1 || !bytes.Equal(svc.saved[0], png) {
+		t.Fatal("SaveBytes payload mismatch")
+	}
+	if strings.Contains(out, "images/diagram.png") || !strings.Contains(out, "local://test/") {
+		t.Fatalf("local image ref was not replaced: %s", out)
+	}
+}

--- a/internal/types/interfaces/knowledge.go
+++ b/internal/types/interfaces/knowledge.go
@@ -176,6 +176,8 @@ type KnowledgeRepository interface {
 	// GetKnowledgeByIDOnly returns knowledge by ID without tenant filter (for permission resolution).
 	GetKnowledgeByIDOnly(ctx context.Context, id string) (*types.Knowledge, error)
 	ListKnowledgeByKnowledgeBaseID(ctx context.Context, tenantID uint64, kbID string) ([]*types.Knowledge, error)
+	// ListKnowledgeByFileNames returns knowledge items in a knowledge base matching exact file names.
+	ListKnowledgeByFileNames(ctx context.Context, tenantID uint64, kbID string, fileNames []string) ([]*types.Knowledge, error)
 	// ListPagedKnowledgeByKnowledgeBaseID lists all knowledge in a knowledge base
 	// with pagination. The filter struct controls optional dimensions (tag, keyword,
 	// file type, parse status, source channel, updated time range); pass a zero


### PR DESCRIPTION
## Summary
- resolve Markdown local image references against images already uploaded to the same knowledge base
- keep folder upload order image-first so Markdown parsing can find referenced assets
- align frontend/backend/docparser support for additional image formats including svg/webp/bmp/tiff

Fixes #952

## Testing
- `CGO_LDFLAGS="-lc++" go test ./internal/application/service -run "Test(IsValidFileTypeAcceptsSupportedImageFormats|ExtractMarkdownLocalImageRefs|NormalizeMarkdownLocalImagePathSkipsUnsafeRefs|MimeTypeForImageFileUsesExtension|AttachMarkdownLocalImagesUsesUploadedImageKnowledge)" -count=1`
- `CGO_LDFLAGS="-lc++" go test ./internal/application/repository -run TestListKnowledgeByFileNames -count=1`
- `CGO_LDFLAGS="-lc++" go test ./internal/infrastructure/docparser -run "TestResolveAndStore_LocalImageRefFromReadResult|TestResolveAndStore_MultipleFormats" -count=1`
- `npm run build-only`
- Local service e2e: started the backend against local Postgres/DocReader, uploaded an image and Markdown via HTTP API, and verified the Markdown chunk rewrote `images/logo.svg` to a `local://...svg` storage URL