### PR TITLE
fix(frontend): unify radio button theme and disabled selection

### DIFF
--- a/frontend/src/assets/theme/theme.css
+++ b/frontend/src/assets/theme/theme.css
@@ -117,6 +117,49 @@
     opacity: 0.9;
 }
 
+/* 全局 t-radio-button outline 选中态：填充品牌色（绿底白字） */
+.t-radio-group .t-radio-button {
+    border-color: var(--td-component-stroke);
+    transition: all 0.2s ease;
+}
+.t-radio-group .t-radio-button:hover:not(.t-is-disabled) {
+    border-color: var(--td-brand-color);
+    color: var(--td-brand-color);
+}
+.t-radio-group .t-radio-button.t-is-checked,
+.t-radio-group .t-radio-button.t-is-checked .t-radio-button__label,
+.t-radio-group .t-radio-button.t-is-checked > span {
+    background: var(--td-brand-color);
+    border-color: var(--td-brand-color);
+    color: var(--td-text-color-anti);
+}
+.t-radio-group .t-radio-button.t-is-checked:hover:not(.t-is-disabled),
+.t-radio-group .t-radio-button.t-is-checked:hover:not(.t-is-disabled) .t-radio-button__label,
+.t-radio-group .t-radio-button.t-is-checked:hover:not(.t-is-disabled) > span {
+    background: var(--td-brand-color-active);
+    border-color: var(--td-brand-color-active);
+    color: var(--td-text-color-anti);
+}
+.t-radio-group .t-radio-button.t-is-disabled {
+    background: var(--td-bg-color-component-disabled);
+    border-color: var(--td-component-border);
+    color: var(--td-text-color-disabled);
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+.t-radio-group .t-radio-button.t-is-disabled .t-radio-button__label,
+.t-radio-group .t-radio-button.t-is-disabled > span {
+    color: var(--td-text-color-disabled);
+}
+
+.t-radio-group .t-radio-button.t-is-disabled.t-is-checked,
+.t-radio-group .t-radio-button.t-is-disabled.t-is-checked .t-radio-button__label,
+.t-radio-group .t-radio-button.t-is-disabled.t-is-checked > span {
+    background: var(--td-brand-color-disabled) !important;
+    border-color: var(--td-brand-color-disabled) !important;
+    color: var(--td-text-color-anti) !important;
+}
+
 /* 覆盖浏览器自动填充的背景色（Chrome 会强制加浅蓝/浅黄底色） */
 input:-webkit-autofill,
 input:-webkit-autofill:hover,

--- a/frontend/src/components/ModelEditorDialog.vue
+++ b/frontend/src/components/ModelEditorDialog.vue
@@ -14,13 +14,13 @@
         <div class="form-item">
           <label class="form-label required">{{ $t('model.editor.sourceLabel') }}</label>
           <t-radio-group v-model="formData.source">
-            <t-radio
+            <t-radio-button
               value="local"
               :disabled="ollamaServiceStatus === false || modelType === 'rerank'"
             >
               {{ $t('model.editor.sourceLocal') }}
-            </t-radio>
-            <t-radio value="remote">{{ $t('model.editor.sourceRemote') }}</t-radio>
+            </t-radio-button>
+            <t-radio-button value="remote">{{ $t('model.editor.sourceRemote') }}</t-radio-button>
           </t-radio-group>
 
           <!-- ReRank模型不支持Ollama的提示信息 -->
@@ -1306,34 +1306,6 @@ const handleCancel = () => {
 
 // 厂商选择器样式 — 移至非 scoped 块，因为 t-select popup 渲染到 body 下
 // .provider-option 样式见文件末尾
-
-// 单选按钮组
-:deep(.t-radio-group) {
-  display: flex;
-  gap: 24px;
-
-  .t-radio {
-    margin-right: 0;
-    font-size: 13px;
-
-    &:hover {
-      .t-radio__label {
-        color: var(--td-brand-color);
-      }
-    }
-  }
-
-  .t-radio__label {
-    font-size: 13px;
-    color: var(--td-text-color-primary);
-    transition: color 0.15s ease;
-  }
-
-  .t-radio__input:checked + .t-radio__label {
-    color: var(--td-brand-color);
-    font-weight: 500;
-  }
-}
 
 // 复选框
 :deep(.t-checkbox) {

--- a/frontend/src/components/ShareKnowledgeBaseDialog.vue
+++ b/frontend/src/components/ShareKnowledgeBaseDialog.vue
@@ -62,8 +62,8 @@
         </t-form-item>
         <t-form-item :label="$t('organization.share.permission')" name="permission">
           <t-radio-group v-model="shareForm.permission">
-            <t-radio value="viewer">{{ $t('organization.share.permissionReadonly') }}</t-radio>
-            <t-radio value="editor">{{ $t('organization.share.permissionEditable') }}</t-radio>
+            <t-radio-button value="viewer">{{ $t('organization.share.permissionReadonly') }}</t-radio-button>
+            <t-radio-button value="editor">{{ $t('organization.share.permissionEditable') }}</t-radio-button>
           </t-radio-group>
         </t-form-item>
         <div class="permission-tip">

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -3957,48 +3957,6 @@ const handleSave = async () => {
   }
 }
 
-// Radio-group 样式优化，符合项目主题风格
-:deep(.t-radio-group) {
-  .t-radio-group--filled {
-    background: var(--td-bg-color-secondarycontainer);
-  }
-  .t-radio-button {
-    border-color: var(--td-component-stroke);
-
-    &:hover:not(.t-is-disabled) {
-      border-color: var(--td-brand-color);
-      color: var(--td-brand-color);
-    }
-
-    &.t-is-checked {
-      background: var(--td-brand-color);
-      border-color: var(--td-brand-color);
-      color: var(--td-text-color-anti);
-
-      &:hover:not(.t-is-disabled) {
-        background: var(--td-brand-color);
-        border-color: var(--td-brand-color-active);
-        color: var(--td-text-color-anti);
-      }
-    }
-
-    // 禁用状态样式
-    &.t-is-disabled {
-      background: var(--td-bg-color-secondarycontainer);
-      border-color: var(--td-component-stroke);
-      color: var(--td-text-color-placeholder);
-      cursor: not-allowed;
-      opacity: 0.6;
-
-      &.t-is-checked {
-        background: var(--td-bg-color-secondarycontainer);
-        border-color: var(--td-component-stroke);
-        color: var(--td-text-color-disabled);
-      }
-    }
-  }
-}
-
 // ===== 工具配置：overview 面板 =====
 .tools-overview {
   display: flex;
@@ -4411,65 +4369,6 @@ const handleSave = async () => {
   font-style: italic;
 }
 
-// Checkbox 选中样式
-:deep(.t-checkbox) {
-  &.t-is-checked {
-    .t-checkbox__input {
-      border-color: var(--td-brand-color);
-      background-color: var(--td-brand-color);
-    }
-  }
-  
-  &:hover:not(.t-is-disabled) {
-    .t-checkbox__input {
-      border-color: var(--td-brand-color);
-    }
-  }
-}
-
-// Switch 样式
-:deep(.t-switch) {
-  &.t-is-checked {
-    background-color: var(--td-brand-color);
-    
-    &:hover:not(.t-is-disabled) {
-      background-color: var(--td-brand-color-active);
-    }
-  }
-}
-
-// Slider 样式
-:deep(.t-slider) {
-  .t-slider__track {
-    background-color: var(--td-brand-color);
-  }
-  
-  .t-slider__button {
-    border-color: var(--td-brand-color);
-  }
-}
-
-// Button 主题样式
-:deep(.t-button--theme-primary) {
-  background-color: var(--td-brand-color);
-  border-color: var(--td-brand-color);
-  
-  &:hover:not(.t-is-disabled) {
-    background-color: var(--td-brand-color-active);
-    border-color: var(--td-brand-color-active);
-  }
-}
-
-// Input/Select focus 样式
-:deep(.t-input),
-:deep(.t-textarea),
-:deep(.t-select) {
-  &.t-is-focused,
-  &:focus-within {
-    border-color: var(--td-brand-color);
-    box-shadow: 0 0 0 2px rgba(7, 192, 95, 0.1);
-  }
-}
 
 // textarea 与模板选择器容器
 .textarea-with-template {

--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
@@ -1533,49 +1533,6 @@ watch(
   }
 }
 
-// Radio-group 样式优化，符合项目主题风格
-:deep(.t-radio-group) {
-  .t-radio-group--filled {
-    background: var(--td-bg-color-secondarycontainer);
-  }
-  .t-radio-button {
-    border-color: var(--td-component-stroke);
-    // color: var(--td-text-color-placeholder);
-
-    &:hover:not(.t-is-disabled) {
-      border-color: var(--td-brand-color);
-      color: var(--td-brand-color);
-    }
-
-    &.t-is-checked {
-      background: var(--td-brand-color);
-      border-color: var(--td-brand-color);
-      color: var(--td-text-color-anti);
-
-      &:hover:not(.t-is-disabled) {
-        background: var(--td-brand-color-active);
-        border-color: var(--td-brand-color-active);
-        color: var(--td-text-color-anti);
-      }
-    }
-
-    // 禁用状态样式
-    &.t-is-disabled {
-      background: var(--td-bg-color-secondarycontainer);
-      border-color: var(--td-component-stroke);
-      color: var(--td-text-color-disabled);
-      cursor: not-allowed;
-      opacity: 0.6;
-
-      &.t-is-checked {
-        background: var(--td-bg-color-secondarycontainer);
-        border-color: var(--td-component-stroke);
-        color: var(--td-text-color-placeholder);
-      }
-    }
-  }
-}
-
 // 多模态配置内联样式（与子组件 KBStorageSettings/KBAdvancedSettings 一致）
 .kb-multimodal-settings {
   width: 100%;

--- a/frontend/src/views/knowledge/KnowledgeBaseList.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseList.vue
@@ -2429,14 +2429,5 @@ const handleUploadFinishedEvent = (event: Event) => {
     font-family: var(--app-font-family);
   }
 
-  .t-button--theme-primary {
-    background-color: var(--td-brand-color);
-    border-color: var(--td-brand-color);
-
-    &:hover {
-      background-color: var(--td-brand-color-active);
-      border-color: var(--td-brand-color-active);
-    }
-  }
 }
 </style>

--- a/frontend/src/views/knowledge/components/FAQEntryManager.vue
+++ b/frontend/src/views/knowledge/components/FAQEntryManager.vue
@@ -4894,40 +4894,6 @@ watch(() => entries.value.map(e => ({
   }
 }
 
-// 单选按钮组样式 - 符合项目主题风格
-:deep(.import-radio-group) {
-  .t-radio-group--filled {
-    background: var(--td-bg-color-secondarycontainer);
-    border-radius: 6px;
-    padding: 2px;
-  }
-  
-  .t-radio-button {
-    font-family: var(--app-font-family);
-    font-size: 14px;
-    border-color: var(--td-component-stroke);
-    transition: all 0.2s ease;
-
-    &:hover:not(.t-is-disabled) {
-      border-color: var(--td-brand-color);
-      color: var(--td-brand-color);
-    }
-
-    &.t-is-checked {
-      background: var(--td-brand-color);
-      border-color: var(--td-brand-color);
-      color: var(--td-text-color-anti);
-      font-weight: 500;
-
-      &:hover:not(.t-is-disabled) {
-        background: var(--td-brand-color);
-        border-color: var(--td-brand-color-active);
-        color: var(--td-text-color-anti);
-      }
-    }
-  }
-}
-
 // 文件上传包装器
 .file-upload-wrapper {
   width: 100%;
@@ -5671,16 +5637,6 @@ watch(() => entries.value.map(e => ({
   }
 }
 
-:deep(.t-button--theme-primary) {
-  background-color: var(--td-brand-color);
-  border-color: var(--td-brand-color);
-  
-  &:hover {
-    background-color: var(--td-brand-color-active);
-    border-color: var(--td-brand-color-active);
-  }
-}
-
 // 导入弹窗动画
 .modal-enter-active,
 .modal-leave-active {
@@ -5840,31 +5796,6 @@ watch(() => entries.value.map(e => ({
 :deep(.slider-wrapper .t-slider) {
   flex: 1;
   min-width: 0;
-
-  .t-slider__rail {
-    background: var(--td-bg-color-secondarycontainer);
-    height: 4px;
-    border-radius: 2px;
-  }
-
-  .t-slider__track {
-    background: var(--td-brand-color);
-    height: 4px;
-    border-radius: 2px;
-  }
-
-  .t-slider__button {
-    width: 16px;
-    height: 16px;
-    border: 2px solid var(--td-brand-color);
-    background: var(--td-bg-color-container);
-    box-shadow: var(--td-shadow-1);
-
-    &:hover {
-      border-color: var(--td-brand-color-active);
-      box-shadow: 0 2px 8px rgba(7, 192, 95, 0.2);
-    }
-  }
 }
 
 .slider-value {

--- a/frontend/src/views/knowledge/settings/DataSourceEditorDialog.vue
+++ b/frontend/src/views/knowledge/settings/DataSourceEditorDialog.vue
@@ -689,16 +689,16 @@ const stepTitles = computed(() => [
       <div class="form-item">
         <label class="form-label">{{ t('datasource.syncModeLabel') }}</label>
         <t-radio-group v-model="form.sync_mode">
-          <t-radio value="incremental">{{ t('datasource.syncMode.incremental') }}</t-radio>
-          <t-radio value="full">{{ t('datasource.syncMode.full') }}</t-radio>
+          <t-radio-button value="incremental">{{ t('datasource.syncMode.incremental') }}</t-radio-button>
+          <t-radio-button value="full">{{ t('datasource.syncMode.full') }}</t-radio-button>
         </t-radio-group>
       </div>
 
       <div class="form-item">
         <label class="form-label">{{ t('datasource.conflictLabel') }}</label>
         <t-radio-group v-model="form.conflict_strategy">
-          <t-radio value="overwrite">{{ t('datasource.conflict.overwrite') }}</t-radio>
-          <t-radio value="skip">{{ t('datasource.conflict.skip') }}</t-radio>
+          <t-radio-button value="overwrite">{{ t('datasource.conflict.overwrite') }}</t-radio-button>
+          <t-radio-button value="skip">{{ t('datasource.conflict.skip') }}</t-radio-button>
         </t-radio-group>
       </div>
 

--- a/frontend/src/views/organization/OrganizationList.vue
+++ b/frontend/src/views/organization/OrganizationList.vue
@@ -1951,15 +1951,6 @@ onUnmounted(() => {
     font-family: var(--app-font-family);
   }
 
-  .t-button--theme-primary {
-    background-color: var(--td-brand-color);
-    border-color: var(--td-brand-color);
-
-    &:hover {
-      background-color: var(--td-brand-color);
-      border-color: var(--td-brand-color);
-    }
-  }
 }
 
 // 邀请预览弹框 - 参考 FAQ 导入弹窗风格，更紧凑

--- a/frontend/src/views/settings/AgentSettings.vue
+++ b/frontend/src/views/settings/AgentSettings.vue
@@ -537,8 +537,8 @@
           </div>
           <div class="setting-control">
             <t-radio-group v-model="localFallbackStrategy" @change="handleFallbackStrategyChange">
-              <t-radio value="fixed">{{ $t('conversationSettings.fallbackStrategy.fixed') }}</t-radio>
-              <t-radio value="model">{{ $t('conversationSettings.fallbackStrategy.model') }}</t-radio>
+              <t-radio-button value="fixed">{{ $t('conversationSettings.fallbackStrategy.fixed') }}</t-radio-button>
+              <t-radio-button value="model">{{ $t('conversationSettings.fallbackStrategy.model') }}</t-radio-button>
             </t-radio-group>
           </div>
         </div>

--- a/frontend/src/views/settings/components/McpServiceDialog.vue
+++ b/frontend/src/views/settings/components/McpServiceDialog.vue
@@ -27,8 +27,8 @@
 
       <t-form-item :label="t('mcpServiceDialog.transportType')" name="transport_type">
         <t-radio-group v-model="formData.transport_type">
-          <t-radio value="sse">{{ t('mcpServiceDialog.transport.sse') }}</t-radio>
-          <t-radio value="http-streamable">{{ t('mcpServiceDialog.transport.httpStreamable') }}</t-radio>
+          <t-radio-button value="sse">{{ t('mcpServiceDialog.transport.sse') }}</t-radio-button>
+          <t-radio-button value="http-streamable">{{ t('mcpServiceDialog.transport.httpStreamable') }}</t-radio-button>
           <!-- Stdio transport is disabled for security reasons -->
         </t-radio-group>
       </t-form-item>


### PR DESCRIPTION
## Summary

Centralize `t-radio-button` outline styling in `theme.css` (brand fill on checked, hover, disabled states) so dialogs and settings pages look consistent.

Replace remaining `t-radio` pairs with `t-radio-button` where the UX matches segmented controls (model source, share permission, datasource sync/conflict, agent/MCP settings).

Remove duplicate per-component `:deep` overrides that fought TDesign defaults (Agent editor, KB editor, FAQ import, KB/org lists).

Fix disabled-but-checked radio buttons (e.g. builtin agent mode): use `--td-brand-color-disabled` background with anti text so the current value stays readable instead of blending with unselected gray.

## Test plan

- Open Agent editor for a **builtin** agent: running mode shows a clearly distinct selected segment when the group is disabled.
- Spot-check: Model editor source, share KB permission, datasource sync mode, conversation fallback in settings, MCP transport type — segments match global style.
- Light/dark: quick visual pass on one dialog if theme toggle exists.