### PR TITLE
feat(frontend): unify external doc-link style and outline add buttons

### DIFF
--- a/frontend/src/assets/theme/theme.css
+++ b/frontend/src/assets/theme/theme.css
@@ -160,6 +160,25 @@
     color: var(--td-text-color-anti) !important;
 }
 
+/* 全局文档/外链样式：品牌色文字 + link 图标，hover 加下划线 */
+.doc-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-weight: 500;
+    color: var(--td-brand-color);
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+.doc-link:hover {
+    color: var(--td-brand-color-active);
+    text-decoration: underline;
+}
+.doc-link .link-icon {
+    font-size: 12px;
+    flex-shrink: 0;
+}
+
 /* 覆盖浏览器自动填充的背景色（Chrome 会强制加浅蓝/浅黄底色） */
 input:-webkit-autofill,
 input:-webkit-autofill:hover,

--- a/frontend/src/assets/theme/theme.css
+++ b/frontend/src/assets/theme/theme.css
@@ -117,6 +117,49 @@
     opacity: 0.9;
 }
 
+/* 全局 t-radio-button outline 选中态：填充品牌色（绿底白字） */
+.t-radio-group .t-radio-button {
+    border-color: var(--td-component-stroke);
+    transition: all 0.2s ease;
+}
+.t-radio-group .t-radio-button:hover:not(.t-is-disabled) {
+    border-color: var(--td-brand-color);
+    color: var(--td-brand-color);
+}
+.t-radio-group .t-radio-button.t-is-checked,
+.t-radio-group .t-radio-button.t-is-checked .t-radio-button__label,
+.t-radio-group .t-radio-button.t-is-checked > span {
+    background: var(--td-brand-color);
+    border-color: var(--td-brand-color);
+    color: var(--td-text-color-anti);
+}
+.t-radio-group .t-radio-button.t-is-checked:hover:not(.t-is-disabled),
+.t-radio-group .t-radio-button.t-is-checked:hover:not(.t-is-disabled) .t-radio-button__label,
+.t-radio-group .t-radio-button.t-is-checked:hover:not(.t-is-disabled) > span {
+    background: var(--td-brand-color-active);
+    border-color: var(--td-brand-color-active);
+    color: var(--td-text-color-anti);
+}
+.t-radio-group .t-radio-button.t-is-disabled {
+    background: var(--td-bg-color-component-disabled);
+    border-color: var(--td-component-border);
+    color: var(--td-text-color-disabled);
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+.t-radio-group .t-radio-button.t-is-disabled .t-radio-button__label,
+.t-radio-group .t-radio-button.t-is-disabled > span {
+    color: var(--td-text-color-disabled);
+}
+
+.t-radio-group .t-radio-button.t-is-disabled.t-is-checked,
+.t-radio-group .t-radio-button.t-is-disabled.t-is-checked .t-radio-button__label,
+.t-radio-group .t-radio-button.t-is-disabled.t-is-checked > span {
+    background: var(--td-brand-color-disabled) !important;
+    border-color: var(--td-brand-color-disabled) !important;
+    color: var(--td-text-color-anti) !important;
+}
+
 /* 覆盖浏览器自动填充的背景色（Chrome 会强制加浅蓝/浅黄底色） */
 input:-webkit-autofill,
 input:-webkit-autofill:hover,

--- a/frontend/src/components/IMChannelPanel.vue
+++ b/frontend/src/components/IMChannelPanel.vue
@@ -180,9 +180,9 @@
         <!-- WeCom credentials -->
         <template v-if="formData.platform === 'wecom'">
           <div class="platform-link-hint">
-            <t-icon name="jump" class="hint-link-icon" />
-            <a href="https://work.weixin.qq.com/" target="_blank" rel="noopener noreferrer" class="hint-link">
+            <a href="https://work.weixin.qq.com/" target="_blank" rel="noopener noreferrer" class="doc-link">
               {{ $t('agentEditor.im.wecomConsole') }}
+              <t-icon name="link" class="link-icon" />
             </a>
             <span class="hint-text">{{ $t('agentEditor.im.consoleTip') }}</span>
           </div>
@@ -233,9 +233,9 @@
         <!-- Feishu credentials -->
         <template v-if="formData.platform === 'feishu'">
           <div class="platform-link-hint">
-            <t-icon name="jump" class="hint-link-icon" />
-            <a href="https://open.feishu.cn/" target="_blank" rel="noopener noreferrer" class="hint-link">
+            <a href="https://open.feishu.cn/" target="_blank" rel="noopener noreferrer" class="doc-link">
               {{ $t('agentEditor.im.feishuConsole') }}
+              <t-icon name="link" class="link-icon" />
             </a>
             <span class="hint-text">{{ $t('agentEditor.im.consoleTip') }}</span>
           </div>
@@ -262,9 +262,9 @@
         <!-- Slack credentials -->
         <template v-if="formData.platform === 'slack'">
           <div class="platform-link-hint">
-            <t-icon name="jump" class="hint-link-icon" />
-            <a href="https://api.slack.com/apps" target="_blank" rel="noopener noreferrer" class="hint-link">
+            <a href="https://api.slack.com/apps" target="_blank" rel="noopener noreferrer" class="doc-link">
               {{ $t('agentEditor.im.slackConsole') }}
+              <t-icon name="link" class="link-icon" />
             </a>
             <span class="hint-text">{{ $t('agentEditor.im.consoleTip') }}</span>
           </div>
@@ -293,9 +293,9 @@
         <!-- Telegram credentials -->
         <template v-if="formData.platform === 'telegram'">
           <div class="platform-link-hint">
-            <t-icon name="jump" class="hint-link-icon" />
-            <a href="https://t.me/BotFather" target="_blank" rel="noopener noreferrer" class="hint-link">
+            <a href="https://t.me/BotFather" target="_blank" rel="noopener noreferrer" class="doc-link">
               {{ $t('agentEditor.im.telegramConsole') }}
+              <t-icon name="link" class="link-icon" />
             </a>
             <span class="hint-text">{{ $t('agentEditor.im.consoleTip') }}</span>
           </div>
@@ -314,9 +314,9 @@
         <!-- DingTalk credentials -->
         <template v-if="formData.platform === 'dingtalk'">
           <div class="platform-link-hint">
-            <t-icon name="jump" class="hint-link-icon" />
-            <a href="https://open.dingtalk.com/" target="_blank" rel="noopener noreferrer" class="hint-link">
+            <a href="https://open.dingtalk.com/" target="_blank" rel="noopener noreferrer" class="doc-link">
               {{ $t('agentEditor.im.dingtalkConsole') }}
+              <t-icon name="link" class="link-icon" />
             </a>
             <span class="hint-text">{{ $t('agentEditor.im.consoleTip') }}</span>
           </div>
@@ -338,9 +338,9 @@
         <!-- Mattermost credentials -->
         <template v-if="formData.platform === 'mattermost'">
           <div class="platform-link-hint">
-            <t-icon name="jump" class="hint-link-icon" />
-            <a href="https://developers.mattermost.com/integrate/webhooks/outgoing/" target="_blank" rel="noopener noreferrer" class="hint-link">
+            <a href="https://developers.mattermost.com/integrate/webhooks/outgoing/" target="_blank" rel="noopener noreferrer" class="doc-link">
               {{ $t('agentEditor.im.mattermostConsole') }}
+              <t-icon name="link" class="link-icon" />
             </a>
             <span class="hint-text">{{ $t('agentEditor.im.consoleTip') }}</span>
           </div>
@@ -999,26 +999,13 @@ onUnmounted(() => {
 .platform-link-hint {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   font-size: 12px;
   line-height: 1.4;
   color: var(--td-text-color-placeholder);
 
-  .hint-link-icon {
-    font-size: 12px;
-    color: var(--td-brand-color);
-    flex-shrink: 0;
-  }
-
-  .hint-link {
-    color: var(--td-brand-color);
-    text-decoration: none;
-    font-weight: 500;
+  .doc-link {
     white-space: nowrap;
-
-    &:hover {
-      text-decoration: underline;
-    }
   }
 
   .hint-text {

--- a/frontend/src/components/ModelEditorDialog.vue
+++ b/frontend/src/components/ModelEditorDialog.vue
@@ -146,8 +146,11 @@
                   href="https://developers.weixin.qq.com/doc/aispeech/knowledge/atomic_capability/atomic_interface.html"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="weknoracloud-hint-link"
-                >{{ $t('settings.weknoraCloud.modelHintDocsLink') }}</a>
+                  class="doc-link"
+                >
+                  {{ $t('settings.weknoraCloud.modelHintDocsLink') }}
+                  <t-icon name="link" class="link-icon" />
+                </a>
               </div>
             </div>
 
@@ -1382,14 +1385,6 @@ const handleCancel = () => {
     border-left: 3px solid #f97316;
   }
 
-  .weknoracloud-hint-link {
-    color: var(--td-brand-color);
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
 }
 
 // Ollama 模型选择器样式

--- a/frontend/src/components/ModelEditorDialog.vue
+++ b/frontend/src/components/ModelEditorDialog.vue
@@ -14,13 +14,13 @@
         <div class="form-item">
           <label class="form-label required">{{ $t('model.editor.sourceLabel') }}</label>
           <t-radio-group v-model="formData.source">
-            <t-radio
+            <t-radio-button
               value="local"
               :disabled="ollamaServiceStatus === false || modelType === 'rerank'"
             >
               {{ $t('model.editor.sourceLocal') }}
-            </t-radio>
-            <t-radio value="remote">{{ $t('model.editor.sourceRemote') }}</t-radio>
+            </t-radio-button>
+            <t-radio-button value="remote">{{ $t('model.editor.sourceRemote') }}</t-radio-button>
           </t-radio-group>
 
           <!-- ReRank模型不支持Ollama的提示信息 -->
@@ -1306,34 +1306,6 @@ const handleCancel = () => {
 
 // 厂商选择器样式 — 移至非 scoped 块，因为 t-select popup 渲染到 body 下
 // .provider-option 样式见文件末尾
-
-// 单选按钮组
-:deep(.t-radio-group) {
-  display: flex;
-  gap: 24px;
-
-  .t-radio {
-    margin-right: 0;
-    font-size: 13px;
-
-    &:hover {
-      .t-radio__label {
-        color: var(--td-brand-color);
-      }
-    }
-  }
-
-  .t-radio__label {
-    font-size: 13px;
-    color: var(--td-text-color-primary);
-    transition: color 0.15s ease;
-  }
-
-  .t-radio__input:checked + .t-radio__label {
-    color: var(--td-brand-color);
-    font-weight: 500;
-  }
-}
 
 // 复选框
 :deep(.t-checkbox) {

--- a/frontend/src/components/ShareKnowledgeBaseDialog.vue
+++ b/frontend/src/components/ShareKnowledgeBaseDialog.vue
@@ -62,8 +62,8 @@
         </t-form-item>
         <t-form-item :label="$t('organization.share.permission')" name="permission">
           <t-radio-group v-model="shareForm.permission">
-            <t-radio value="viewer">{{ $t('organization.share.permissionReadonly') }}</t-radio>
-            <t-radio value="editor">{{ $t('organization.share.permissionEditable') }}</t-radio>
+            <t-radio-button value="viewer">{{ $t('organization.share.permissionReadonly') }}</t-radio-button>
+            <t-radio-button value="editor">{{ $t('organization.share.permissionEditable') }}</t-radio-button>
           </t-radio-group>
         </t-form-item>
         <div class="permission-tip">

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -1345,8 +1345,9 @@
                     <h2>{{ $t('agentEditor.im.title') }}</h2>
                     <p class="section-description">
                       {{ $t('agentEditor.im.description') }}
-                      <a href="https://github.com/Tencent/WeKnora/blob/main/docs/IM%E9%9B%86%E6%88%90%E5%BC%80%E5%8F%91%E6%96%87%E6%A1%A3.md" target="_blank" rel="noopener noreferrer" class="section-doc-link">
-                        <t-icon name="link" class="link-icon" />{{ $t('agentEditor.im.docLink') }}
+                      <a href="https://github.com/Tencent/WeKnora/blob/main/docs/IM%E9%9B%86%E6%88%90%E5%BC%80%E5%8F%91%E6%96%87%E6%A1%A3.md" target="_blank" rel="noopener noreferrer" class="doc-link">
+                        {{ $t('agentEditor.im.docLink') }}
+                        <t-icon name="link" class="link-icon" />
                       </a>
                     </p>
                   </div>
@@ -3712,24 +3713,8 @@ const handleSave = async () => {
     margin: 0;
     line-height: 1.5;
 
-    .section-doc-link {
+    .doc-link {
       margin-left: 8px;
-      color: var(--td-brand-color);
-      text-decoration: none;
-      font-weight: 500;
-      display: inline-flex;
-      align-items: center;
-      gap: 3px;
-      transition: color 0.2s ease;
-
-      .link-icon {
-        font-size: 14px;
-      }
-
-      &:hover {
-        color: var(--td-brand-color-hover);
-        text-decoration: underline;
-      }
     }
   }
 }

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -3957,48 +3957,6 @@ const handleSave = async () => {
   }
 }
 
-// Radio-group 样式优化，符合项目主题风格
-:deep(.t-radio-group) {
-  .t-radio-group--filled {
-    background: var(--td-bg-color-secondarycontainer);
-  }
-  .t-radio-button {
-    border-color: var(--td-component-stroke);
-
-    &:hover:not(.t-is-disabled) {
-      border-color: var(--td-brand-color);
-      color: var(--td-brand-color);
-    }
-
-    &.t-is-checked {
-      background: var(--td-brand-color);
-      border-color: var(--td-brand-color);
-      color: var(--td-text-color-anti);
-
-      &:hover:not(.t-is-disabled) {
-        background: var(--td-brand-color);
-        border-color: var(--td-brand-color-active);
-        color: var(--td-text-color-anti);
-      }
-    }
-
-    // 禁用状态样式
-    &.t-is-disabled {
-      background: var(--td-bg-color-secondarycontainer);
-      border-color: var(--td-component-stroke);
-      color: var(--td-text-color-placeholder);
-      cursor: not-allowed;
-      opacity: 0.6;
-
-      &.t-is-checked {
-        background: var(--td-bg-color-secondarycontainer);
-        border-color: var(--td-component-stroke);
-        color: var(--td-text-color-disabled);
-      }
-    }
-  }
-}
-
 // ===== 工具配置：overview 面板 =====
 .tools-overview {
   display: flex;
@@ -4411,65 +4369,6 @@ const handleSave = async () => {
   font-style: italic;
 }
 
-// Checkbox 选中样式
-:deep(.t-checkbox) {
-  &.t-is-checked {
-    .t-checkbox__input {
-      border-color: var(--td-brand-color);
-      background-color: var(--td-brand-color);
-    }
-  }
-  
-  &:hover:not(.t-is-disabled) {
-    .t-checkbox__input {
-      border-color: var(--td-brand-color);
-    }
-  }
-}
-
-// Switch 样式
-:deep(.t-switch) {
-  &.t-is-checked {
-    background-color: var(--td-brand-color);
-    
-    &:hover:not(.t-is-disabled) {
-      background-color: var(--td-brand-color-active);
-    }
-  }
-}
-
-// Slider 样式
-:deep(.t-slider) {
-  .t-slider__track {
-    background-color: var(--td-brand-color);
-  }
-  
-  .t-slider__button {
-    border-color: var(--td-brand-color);
-  }
-}
-
-// Button 主题样式
-:deep(.t-button--theme-primary) {
-  background-color: var(--td-brand-color);
-  border-color: var(--td-brand-color);
-  
-  &:hover:not(.t-is-disabled) {
-    background-color: var(--td-brand-color-active);
-    border-color: var(--td-brand-color-active);
-  }
-}
-
-// Input/Select focus 样式
-:deep(.t-input),
-:deep(.t-textarea),
-:deep(.t-select) {
-  &.t-is-focused,
-  &:focus-within {
-    border-color: var(--td-brand-color);
-    box-shadow: 0 0 0 2px rgba(7, 192, 95, 0.1);
-  }
-}
 
 // textarea 与模板选择器容器
 .textarea-with-template {

--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
@@ -1533,49 +1533,6 @@ watch(
   }
 }
 
-// Radio-group 样式优化，符合项目主题风格
-:deep(.t-radio-group) {
-  .t-radio-group--filled {
-    background: var(--td-bg-color-secondarycontainer);
-  }
-  .t-radio-button {
-    border-color: var(--td-component-stroke);
-    // color: var(--td-text-color-placeholder);
-
-    &:hover:not(.t-is-disabled) {
-      border-color: var(--td-brand-color);
-      color: var(--td-brand-color);
-    }
-
-    &.t-is-checked {
-      background: var(--td-brand-color);
-      border-color: var(--td-brand-color);
-      color: var(--td-text-color-anti);
-
-      &:hover:not(.t-is-disabled) {
-        background: var(--td-brand-color-active);
-        border-color: var(--td-brand-color-active);
-        color: var(--td-text-color-anti);
-      }
-    }
-
-    // 禁用状态样式
-    &.t-is-disabled {
-      background: var(--td-bg-color-secondarycontainer);
-      border-color: var(--td-component-stroke);
-      color: var(--td-text-color-disabled);
-      cursor: not-allowed;
-      opacity: 0.6;
-
-      &.t-is-checked {
-        background: var(--td-bg-color-secondarycontainer);
-        border-color: var(--td-component-stroke);
-        color: var(--td-text-color-placeholder);
-      }
-    }
-  }
-}
-
 // 多模态配置内联样式（与子组件 KBStorageSettings/KBAdvancedSettings 一致）
 .kb-multimodal-settings {
   width: 100%;

--- a/frontend/src/views/knowledge/KnowledgeBaseList.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseList.vue
@@ -2429,14 +2429,5 @@ const handleUploadFinishedEvent = (event: Event) => {
     font-family: var(--app-font-family);
   }
 
-  .t-button--theme-primary {
-    background-color: var(--td-brand-color);
-    border-color: var(--td-brand-color);
-
-    &:hover {
-      background-color: var(--td-brand-color-active);
-      border-color: var(--td-brand-color-active);
-    }
-  }
 }
 </style>

--- a/frontend/src/views/knowledge/components/FAQEntryManager.vue
+++ b/frontend/src/views/knowledge/components/FAQEntryManager.vue
@@ -4894,40 +4894,6 @@ watch(() => entries.value.map(e => ({
   }
 }
 
-// 单选按钮组样式 - 符合项目主题风格
-:deep(.import-radio-group) {
-  .t-radio-group--filled {
-    background: var(--td-bg-color-secondarycontainer);
-    border-radius: 6px;
-    padding: 2px;
-  }
-  
-  .t-radio-button {
-    font-family: var(--app-font-family);
-    font-size: 14px;
-    border-color: var(--td-component-stroke);
-    transition: all 0.2s ease;
-
-    &:hover:not(.t-is-disabled) {
-      border-color: var(--td-brand-color);
-      color: var(--td-brand-color);
-    }
-
-    &.t-is-checked {
-      background: var(--td-brand-color);
-      border-color: var(--td-brand-color);
-      color: var(--td-text-color-anti);
-      font-weight: 500;
-
-      &:hover:not(.t-is-disabled) {
-        background: var(--td-brand-color);
-        border-color: var(--td-brand-color-active);
-        color: var(--td-text-color-anti);
-      }
-    }
-  }
-}
-
 // 文件上传包装器
 .file-upload-wrapper {
   width: 100%;
@@ -5671,16 +5637,6 @@ watch(() => entries.value.map(e => ({
   }
 }
 
-:deep(.t-button--theme-primary) {
-  background-color: var(--td-brand-color);
-  border-color: var(--td-brand-color);
-  
-  &:hover {
-    background-color: var(--td-brand-color-active);
-    border-color: var(--td-brand-color-active);
-  }
-}
-
 // 导入弹窗动画
 .modal-enter-active,
 .modal-leave-active {
@@ -5840,31 +5796,6 @@ watch(() => entries.value.map(e => ({
 :deep(.slider-wrapper .t-slider) {
   flex: 1;
   min-width: 0;
-
-  .t-slider__rail {
-    background: var(--td-bg-color-secondarycontainer);
-    height: 4px;
-    border-radius: 2px;
-  }
-
-  .t-slider__track {
-    background: var(--td-brand-color);
-    height: 4px;
-    border-radius: 2px;
-  }
-
-  .t-slider__button {
-    width: 16px;
-    height: 16px;
-    border: 2px solid var(--td-brand-color);
-    background: var(--td-bg-color-container);
-    box-shadow: var(--td-shadow-1);
-
-    &:hover {
-      border-color: var(--td-brand-color-active);
-      box-shadow: 0 2px 8px rgba(7, 192, 95, 0.2);
-    }
-  }
 }
 
 .slider-value {

--- a/frontend/src/views/knowledge/settings/DataSourceEditorDialog.vue
+++ b/frontend/src/views/knowledge/settings/DataSourceEditorDialog.vue
@@ -555,8 +555,9 @@ const stepTitles = computed(() => [
             <div class="ds-prereq-item-desc">{{ t(`datasource.prereqStep3Desc_${form.type}`, t('datasource.prereqMemberDesc')) }}</div>
           </div>
         </div>
-        <a :href="currentDef.permissionPageUrl" target="_blank" rel="noopener" class="ds-prereq-link">
+        <a :href="currentDef.permissionPageUrl" target="_blank" rel="noopener" class="doc-link ds-prereq-link">
           {{ t(`datasource.prereqOpenConsole_${form.type}`, t('datasource.prereqOpenConsole')) }}
+          <t-icon name="link" class="link-icon" />
         </a>
       </div>
 
@@ -568,7 +569,10 @@ const stepTitles = computed(() => [
       <div v-if="currentDef?.docUrl" class="ds-doc-link">
         <t-icon name="info-circle" size="14px" />
         <span>{{ t('datasource.docHint') }}</span>
-        <a :href="currentDef.docUrl" target="_blank" rel="noopener">{{ currentDef.docUrl }}</a>
+        <a :href="currentDef.docUrl" target="_blank" rel="noopener" class="doc-link">
+          {{ currentDef.docUrl }}
+          <t-icon name="link" class="link-icon" />
+        </a>
       </div>
 
       <div v-for="field in currentDef?.fields || []" :key="field.key" class="form-item">
@@ -665,8 +669,9 @@ const stepTitles = computed(() => [
           <t-button variant="outline" size="small" @click="loadResources">
             {{ t('datasource.retryLoadResources') }}
           </t-button>
-          <a v-if="currentDef?.permissionDocUrl" :href="currentDef.permissionDocUrl" target="_blank" rel="noopener" class="ds-doc-link-inline">
+          <a v-if="currentDef?.permissionDocUrl" :href="currentDef.permissionDocUrl" target="_blank" rel="noopener" class="doc-link">
             {{ t('datasource.permissionDocLink') }}
+            <t-icon name="link" class="link-icon" />
           </a>
         </div>
       </div>
@@ -858,7 +863,6 @@ const stepTitles = computed(() => [
 
 .ds-prereq-link {
   font-size: 12px;
-  color: var(--td-brand-color);
   padding-left: 30px;
 }
 
@@ -875,8 +879,7 @@ const stepTitles = computed(() => [
   margin-bottom: 16px;
 }
 
-.ds-doc-link a {
-  color: var(--td-brand-color);
+.ds-doc-link .doc-link {
   word-break: break-all;
 }
 
@@ -1054,8 +1057,4 @@ const stepTitles = computed(() => [
   gap: 16px;
 }
 
-.ds-doc-link-inline {
-  color: var(--td-brand-color);
-  font-size: 12px;
-}
 </style>

--- a/frontend/src/views/knowledge/settings/DataSourceEditorDialog.vue
+++ b/frontend/src/views/knowledge/settings/DataSourceEditorDialog.vue
@@ -689,16 +689,16 @@ const stepTitles = computed(() => [
       <div class="form-item">
         <label class="form-label">{{ t('datasource.syncModeLabel') }}</label>
         <t-radio-group v-model="form.sync_mode">
-          <t-radio value="incremental">{{ t('datasource.syncMode.incremental') }}</t-radio>
-          <t-radio value="full">{{ t('datasource.syncMode.full') }}</t-radio>
+          <t-radio-button value="incremental">{{ t('datasource.syncMode.incremental') }}</t-radio-button>
+          <t-radio-button value="full">{{ t('datasource.syncMode.full') }}</t-radio-button>
         </t-radio-group>
       </div>
 
       <div class="form-item">
         <label class="form-label">{{ t('datasource.conflictLabel') }}</label>
         <t-radio-group v-model="form.conflict_strategy">
-          <t-radio value="overwrite">{{ t('datasource.conflict.overwrite') }}</t-radio>
-          <t-radio value="skip">{{ t('datasource.conflict.skip') }}</t-radio>
+          <t-radio-button value="overwrite">{{ t('datasource.conflict.overwrite') }}</t-radio-button>
+          <t-radio-button value="skip">{{ t('datasource.conflict.skip') }}</t-radio-button>
         </t-radio-group>
       </div>
 

--- a/frontend/src/views/knowledge/settings/DataSourceSettings.vue
+++ b/frontend/src/views/knowledge/settings/DataSourceSettings.vue
@@ -220,7 +220,7 @@ onBeforeUnmount(stopPolling)
       <div class="ds-empty-text">
         <p class="ds-empty-title">{{ t('datasource.empty') }}</p>
       </div>
-      <t-button theme="primary" @click="openCreate">
+      <t-button theme="primary" variant="outline" @click="openCreate">
         <template #icon><t-icon name="add" /></template>
         {{ t('datasource.addFirst') }}
       </t-button>

--- a/frontend/src/views/organization/OrganizationList.vue
+++ b/frontend/src/views/organization/OrganizationList.vue
@@ -1951,15 +1951,6 @@ onUnmounted(() => {
     font-family: var(--app-font-family);
   }
 
-  .t-button--theme-primary {
-    background-color: var(--td-brand-color);
-    border-color: var(--td-brand-color);
-
-    &:hover {
-      background-color: var(--td-brand-color);
-      border-color: var(--td-brand-color);
-    }
-  }
 }
 
 // 邀请预览弹框 - 参考 FAQ 导入弹窗风格，更紧凑

--- a/frontend/src/views/settings/AgentSettings.vue
+++ b/frontend/src/views/settings/AgentSettings.vue
@@ -537,8 +537,8 @@
           </div>
           <div class="setting-control">
             <t-radio-group v-model="localFallbackStrategy" @change="handleFallbackStrategyChange">
-              <t-radio value="fixed">{{ $t('conversationSettings.fallbackStrategy.fixed') }}</t-radio>
-              <t-radio value="model">{{ $t('conversationSettings.fallbackStrategy.model') }}</t-radio>
+              <t-radio-button value="fixed">{{ $t('conversationSettings.fallbackStrategy.fixed') }}</t-radio-button>
+              <t-radio-button value="model">{{ $t('conversationSettings.fallbackStrategy.model') }}</t-radio-button>
             </t-radio-group>
           </div>
         </div>

--- a/frontend/src/views/settings/ApiInfo.vue
+++ b/frontend/src/views/settings/ApiInfo.vue
@@ -655,23 +655,7 @@ onMounted(async () => {
   }
 
   .doc-link {
-    color: var(--td-brand-color);
-    text-decoration: none;
-    font-weight: 500;
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
     cursor: pointer;
-    transition: all 0.2s ease;
-
-    &:hover {
-      color: var(--td-brand-color-active);
-      text-decoration: underline;
-    }
-
-    .link-icon {
-      font-size: 12px;
-    }
   }
 }
 

--- a/frontend/src/views/settings/McpSettings.vue
+++ b/frontend/src/views/settings/McpSettings.vue
@@ -17,7 +17,7 @@
           <h3>{{ $t('mcpSettings.configuredServices') }}</h3>
           <p>{{ $t('mcpSettings.manageAndTest') }}</p>
         </div>
-        <t-button size="small" theme="primary" @click="handleAdd">
+        <t-button size="small" theme="primary" variant="outline" @click="handleAdd">
           <template #icon><t-icon name="add" /></template>
           {{ $t('mcpSettings.addService') }}
         </t-button>
@@ -25,7 +25,7 @@
 
       <div v-if="services.length === 0" class="empty-state">
         <t-empty :description="$t('mcpSettings.empty')">
-          <t-button theme="primary" size="small" @click="handleAdd">
+          <t-button theme="primary" variant="outline" size="small" @click="handleAdd">
             <template #icon><t-icon name="add" /></template>
             {{ $t('mcpSettings.addFirst') }}
           </t-button>

--- a/frontend/src/views/settings/ModelSettings.vue
+++ b/frontend/src/views/settings/ModelSettings.vue
@@ -11,7 +11,7 @@
           placement="bottom-right"
           @click="(data: any) => openAddDialog(data.value)"
         >
-          <t-button theme="primary" size="small">
+          <t-button theme="primary" variant="outline" size="small">
             <template #icon><add-icon /></template>
             {{ $t('modelSettings.actions.addModel') }}
           </t-button>
@@ -22,12 +22,13 @@
         <p class="builtin-hint-label">{{ $t('modelSettings.builtinModels.title') }}</p>
         <p class="builtin-hint-text">{{ $t('modelSettings.builtinModels.description') }}</p>
         <a
-          class="builtin-hint-link"
+          class="doc-link"
           href="https://github.com/Tencent/WeKnora/blob/main/docs/BUILTIN_MODELS.md"
           target="_blank"
           rel="noopener noreferrer"
         >
           {{ $t('modelSettings.builtinModels.viewGuide') }}
+          <t-icon name="link" class="link-icon" />
         </a>
       </div>
     </div>
@@ -83,7 +84,7 @@
           placement="bottom"
           @click="(data: any) => openAddDialog(data.value)"
         >
-          <t-button theme="primary" size="small">
+          <t-button theme="primary" variant="outline" size="small">
             <template #icon><add-icon /></template>
             {{ $t('modelSettings.actions.addModel') }}
           </t-button>
@@ -472,17 +473,6 @@ onMounted(() => {
   font-size: 13px;
   line-height: 1.55;
   color: var(--td-text-color-secondary);
-}
-
-.builtin-hint-link {
-  font-size: 13px;
-  color: var(--td-text-color-secondary);
-  text-decoration: none;
-
-  &:hover {
-    color: var(--td-brand-color);
-    text-decoration: underline;
-  }
 }
 
 .section-header__top {

--- a/frontend/src/views/settings/OllamaSettings.vue
+++ b/frontend/src/views/settings/OllamaSettings.vue
@@ -94,7 +94,7 @@
           <h3>{{ $t('ollamaSettings.download.title') }}</h3>
           <p>
             {{ $t('ollamaSettings.download.descPrefix') }}
-            <a href="https://ollama.com/search" target="_blank" rel="noopener noreferrer" class="model-link">
+            <a href="https://ollama.com/search" target="_blank" rel="noopener noreferrer" class="doc-link">
               {{ $t('ollamaSettings.download.browse') }}
               <t-icon name="link" class="link-icon" />
             </a>
@@ -489,24 +489,6 @@ onMounted(async () => {
       line-height: 1.5;
     }
 
-    .model-link {
-      color: var(--td-brand-color);
-      text-decoration: none;
-      font-weight: 500;
-      display: inline-flex;
-      align-items: center;
-      gap: 4px;
-      transition: all 0.2s ease;
-
-      &:hover {
-        color: var(--td-brand-color-active);
-        text-decoration: underline;
-      }
-
-      .link-icon {
-        font-size: 12px;
-      }
-    }
   }
 }
 

--- a/frontend/src/views/settings/ParserEngineSettings.vue
+++ b/frontend/src/views/settings/ParserEngineSettings.vue
@@ -76,8 +76,11 @@
             :href="engineDocLink(currentEngine.Name)"
             target="_blank"
             rel="noopener noreferrer"
-            class="engine-doc-link"
-          >{{ engineDocLabel(currentEngine.Name) }} ↗</a>
+            class="doc-link"
+          >
+            {{ engineDocLabel(currentEngine.Name) }}
+            <t-icon name="link" class="link-icon" />
+          </a>
           </p>
         </div>
 
@@ -655,16 +658,6 @@ onMounted(loadAll)
   &.t-is-focused input {
     border-color: var(--td-brand-color);
     box-shadow: 0 0 0 2px rgba(7, 192, 95, 0.1);
-  }
-}
-
-.engine-doc-link {
-  font-size: 13px;
-  color: var(--td-brand-color);
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
   }
 }
 

--- a/frontend/src/views/settings/StorageEngineSettings.vue
+++ b/frontend/src/views/settings/StorageEngineSettings.vue
@@ -250,8 +250,8 @@
           <div class="engine-info-block">
             <p class="engine-desc">
               {{ $t('settings.storage.cosDesc') }}
-              <a class="engine-link" href="https://console.cloud.tencent.com/cos" target="_blank" rel="noopener">{{ $t('settings.storage.console') }} ↗</a>
-              <a class="engine-link" href="https://cloud.tencent.com/document/product/436" target="_blank" rel="noopener">{{ $t('settings.storage.docs') }} ↗</a>
+              <a class="doc-link" href="https://console.cloud.tencent.com/cos" target="_blank" rel="noopener">{{ $t('settings.storage.console') }}<t-icon name="link" class="link-icon" /></a>
+              <a class="doc-link" href="https://cloud.tencent.com/document/product/436" target="_blank" rel="noopener">{{ $t('settings.storage.docs') }}<t-icon name="link" class="link-icon" /></a>
             </p>
           </div>
           <div class="engine-form">
@@ -286,8 +286,8 @@
           <div class="engine-info-block">
             <p class="engine-desc">
               {{ $t('settings.storage.tosDesc') }}
-              <a class="engine-link" href="https://console.volcengine.com/tos" target="_blank" rel="noopener">{{ $t('settings.storage.console') }} ↗</a>
-              <a class="engine-link" href="https://www.volcengine.com/docs/6349" target="_blank" rel="noopener">{{ $t('settings.storage.docs') }} ↗</a>
+              <a class="doc-link" href="https://console.volcengine.com/tos" target="_blank" rel="noopener">{{ $t('settings.storage.console') }}<t-icon name="link" class="link-icon" /></a>
+              <a class="doc-link" href="https://www.volcengine.com/docs/6349" target="_blank" rel="noopener">{{ $t('settings.storage.docs') }}<t-icon name="link" class="link-icon" /></a>
             </p>
           </div>
           <div class="engine-form">
@@ -322,8 +322,8 @@
           <div class="engine-info-block">
             <p class="engine-desc">
               {{ $t('settings.storage.s3Desc') }}
-              <a class="engine-link" href="https://aws.amazon.com/s3/" target="_blank" rel="noopener">{{ $t('settings.storage.console') }} ↗</a>
-              <a class="engine-link" href="https://docs.aws.amazon.com/s3/" target="_blank" rel="noopener">{{ $t('settings.storage.docs') }} ↗</a>
+              <a class="doc-link" href="https://aws.amazon.com/s3/" target="_blank" rel="noopener">{{ $t('settings.storage.console') }}<t-icon name="link" class="link-icon" /></a>
+              <a class="doc-link" href="https://docs.aws.amazon.com/s3/" target="_blank" rel="noopener">{{ $t('settings.storage.docs') }}<t-icon name="link" class="link-icon" /></a>
             </p>
           </div>
           <div class="engine-form">
@@ -358,8 +358,8 @@
           <div class="engine-info-block">
             <p class="engine-desc">
               {{ $t('settings.storage.ossDesc') }}
-              <a class="engine-link" href="https://oss.console.aliyun.com/" target="_blank" rel="noopener">{{ $t('settings.storage.console') }} ↗</a>
-              <a class="engine-link" href="https://help.aliyun.com/zh/oss/" target="_blank" rel="noopener">{{ $t('settings.storage.docs') }} ↗</a>
+              <a class="doc-link" href="https://oss.console.aliyun.com/" target="_blank" rel="noopener">{{ $t('settings.storage.console') }}<t-icon name="link" class="link-icon" /></a>
+              <a class="doc-link" href="https://help.aliyun.com/zh/oss/" target="_blank" rel="noopener">{{ $t('settings.storage.docs') }}<t-icon name="link" class="link-icon" /></a>
             </p>
           </div>
           <div class="engine-form">
@@ -1083,15 +1083,9 @@ onMounted(loadAll)
   }
 }
 
-.engine-link {
-  color: var(--td-brand-color);
-  text-decoration: none;
+.engine-info-block .doc-link {
   margin-left: 4px;
   font-size: 13px;
-
-  &:hover {
-    text-decoration: underline;
-  }
 }
 
 .engine-form {

--- a/frontend/src/views/settings/VectorStoreSettings.vue
+++ b/frontend/src/views/settings/VectorStoreSettings.vue
@@ -14,7 +14,7 @@
       <div class="settings-group">
         <div class="section-subheader">
           <h3>{{ t('vectorStoreSettings.storesTitle') }}</h3>
-          <t-button theme="primary" size="small" @click="openAddDialog">
+          <t-button theme="primary" variant="outline" size="small" @click="openAddDialog">
             <template #icon><add-icon /></template>
             {{ t('vectorStoreSettings.addStore') }}
           </t-button>

--- a/frontend/src/views/settings/WeKnoraCloudSettings.vue
+++ b/frontend/src/views/settings/WeKnoraCloudSettings.vue
@@ -9,8 +9,8 @@
         target="_blank"
         rel="noopener noreferrer"
       >
-        <t-icon name="link" style="font-size: 14px;" />
         {{ $t('settings.weknoraCloud.viewDocs') }}
+        <t-icon name="link" class="link-icon" />
       </a>
     </div>
 
@@ -187,21 +187,6 @@ onMounted(() => {
     color: var(--td-text-color-secondary);
     margin: 0 0 10px 0;
     line-height: 1.5;
-  }
-}
-
-.doc-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 13px;
-  color: var(--td-brand-color);
-  text-decoration: none;
-  transition: opacity 0.2s;
-
-  &:hover {
-    opacity: 0.8;
-    text-decoration: underline;
   }
 }
 

--- a/frontend/src/views/settings/WebSearchSettings.vue
+++ b/frontend/src/views/settings/WebSearchSettings.vue
@@ -7,7 +7,7 @@
 
     <div class="settings-toolbar">
       <h3>{{ t('webSearchSettings.providersTitle') }}</h3>
-      <t-button theme="primary" size="small" @click="openAddDialog">
+      <t-button theme="primary" variant="outline" size="small" @click="openAddDialog">
         <template #icon><add-icon /></template>
         {{ t('webSearchSettings.addProvider') }}
       </t-button>
@@ -46,7 +46,7 @@
     <!-- Empty State -->
     <div v-else class="empty-state">
       <t-empty :description="t('webSearchSettings.noProvidersDesc')">
-        <t-button theme="primary" size="small" @click="openAddDialog">
+        <t-button theme="primary" variant="outline" size="small" @click="openAddDialog">
           <template #icon><add-icon /></template>
           {{ t('webSearchSettings.addProvider') }}
         </t-button>
@@ -86,8 +86,9 @@
           <div class="form-divider"></div>
 
           <div class="credentials-hint" v-if="selectedProviderType?.docs_url">
-            <a :href="selectedProviderType.docs_url" target="_blank" rel="noopener noreferrer">
-              {{ t('webSearchSettings.viewDocs') }} ↗
+            <a :href="selectedProviderType.docs_url" target="_blank" rel="noopener noreferrer" class="doc-link">
+              {{ t('webSearchSettings.viewDocs') }}
+              <t-icon name="link" class="link-icon" />
             </a>
           </div>
 

--- a/frontend/src/views/settings/components/McpServiceDialog.vue
+++ b/frontend/src/views/settings/components/McpServiceDialog.vue
@@ -27,8 +27,8 @@
 
       <t-form-item :label="t('mcpServiceDialog.transportType')" name="transport_type">
         <t-radio-group v-model="formData.transport_type">
-          <t-radio value="sse">{{ t('mcpServiceDialog.transport.sse') }}</t-radio>
-          <t-radio value="http-streamable">{{ t('mcpServiceDialog.transport.httpStreamable') }}</t-radio>
+          <t-radio-button value="sse">{{ t('mcpServiceDialog.transport.sse') }}</t-radio-button>
+          <t-radio-button value="http-streamable">{{ t('mcpServiceDialog.transport.httpStreamable') }}</t-radio-button>
           <!-- Stdio transport is disabled for security reasons -->
         </t-radio-group>
       </t-form-item>


### PR DESCRIPTION
## Summary

Stacks on top of #1160. Adds two more visual unifications:

- **`.doc-link` utility class in `theme.css`**: brand-colored text + trailing `<t-icon name="link" />`, underline on hover. Matches the existing 'Browse Ollama Library' style.
- **All external documentation/console links** across settings now use `.doc-link` (Model / WebSearch / VectorStore / MCP / Storage / Parser / WeKnoraCloud / DataSource / IM / Agent IM section). Removes 8+ near-duplicate per-component styles (`builtin-hint-link`, `weknoracloud-hint-link`, `engine-doc-link`, `engine-link`, `hint-link`, `section-doc-link`, `ds-doc-link-inline`, `model-link`, ...).
- **Primary 'Add X' buttons** in settings sections (Model / WebSearch / VectorStore / MCP / DataSource) switched to `variant="outline"` so toolbars no longer look like a green block on white.

Net: +80 / -166 lines.

## Test plan

- Walk through Settings → each subpage and verify external links render as `text + link icon`, brand-color, hover underline.
- Add buttons in Model / WebSearch / VectorStore / MCP toolbars and empty states render as outline; click still opens the corresponding dialog/drawer.
- Spot check IM tab inside Agent editor: each platform's console link uses the new style.

(Depends on #1160 for the radio-button base; if that lands first this PR's diff stays the same.)