### PR TITLE
Fix authentication API documentation links

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -59,7 +59,7 @@ WeKnora API 按功能分为以下几类：
 
 | 分类 | 描述 | 文档链接 |
 |------|------|----------|
-| 认证管理 | 用户注册、登录、令牌管理 | [auth.md](./auth.md) |
+| 认证管理 | 用户注册、登录、令牌管理 | [OIDC认证调用流程.md](../OIDC认证调用流程.md) |
 | 租户管理 | 创建和管理租户账户 | [tenant.md](./tenant.md) |
 | 知识库管理 | 创建、查询和管理知识库 | [knowledge-base.md](./knowledge-base.md) |
 | 知识管理 | 上传、检索和管理知识内容 | [knowledge.md](./knowledge.md) |

--- a/docs/wiki/API参考/API文档概览.md
+++ b/docs/wiki/API参考/API文档概览.md
@@ -45,7 +45,7 @@ API Key 在 Web 页面完成账户注册后，前往账户信息页面获取。
 
 | 分类 | 描述 | 详细文档 |
 |------|------|----------|
-| 认证管理 | 用户注册、登录、令牌管理 | [auth.md](../../api/auth.md) |
+| 认证管理 | 用户注册、登录、令牌管理 | [OIDC认证调用流程.md](../安全认证/OIDC认证调用流程.md) |
 | 租户管理 | 创建和管理租户账户 | [tenant.md](../../api/tenant.md) |
 | 知识库管理 | 创建、查询和管理知识库 | [knowledge-base.md](../../api/knowledge-base.md) |
 | 知识管理 | 上传、检索和管理知识内容 | [knowledge.md](../../api/knowledge.md) |


### PR DESCRIPTION
## Summary
- replace broken auth.md links in the API overview documents with the existing OIDC authentication documentation

## Verification
- checked local Markdown links in the changed files
- git diff --check