### PR TITLE
fix(frontend): allow build scripts for pnpm to unblock Docker build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,5 +60,12 @@
     "lightningcss": "none",
     "esbuild": "^0.25.0",
     "serialize-javascript": "^7.0.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@vue-office/pptx",
+      "esbuild",
+      "vue-demi"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- pnpm 10+ refuses to run dependency build scripts by default and exits with `ERR_PNPM_IGNORED_BUILDS`, breaking `RUN pnpm install` in `frontend/Dockerfile`.
- Whitelist the packages that legitimately ship install scripts (`esbuild` native binary, `@vue-office/pptx`, `vue-demi`) via `pnpm.onlyBuiltDependencies` so `pnpm install` completes successfully.

## Test plan
- [ ] `make docker-build-frontend` succeeds end-to-end on both `linux/amd64` and `linux/arm64`.
- [ ] Local `pnpm install` in `frontend/` no longer prints `ERR_PNPM_IGNORED_BUILDS`.