### PR TITLE
fix(frontend): pass allow-build flags to pnpm install in Docker build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,7 +13,7 @@ COPY packages/xlsx-0.20.2.tgz ./packages/xlsx-0.20.2.tgz
 
 # 安装依赖
 RUN corepack enable
-RUN pnpm install
+RUN pnpm install --allow-build=@vue-office/pptx --allow-build=esbuild --allow-build=vue-demi
 
 # 复制项目文件
 COPY . .


### PR DESCRIPTION
Some CI runners still fail with ERR_PNPM_IGNORED_BUILDS even with package-level configuration. Pass explicit allow-build flags to `pnpm install` in Dockerfile so required postinstall scripts are always permitted during image builds.
