### PR TITLE
fix(frontend): configure pnpm v11 build approvals in workspace file

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,11 +9,12 @@ ENV VITE_IS_DOCKER=true
 
 # 复制依赖文件
 COPY package*.json ./
+COPY pnpm-workspace.yaml ./
 COPY packages/xlsx-0.20.2.tgz ./packages/xlsx-0.20.2.tgz
 
 # 安装依赖
 RUN corepack enable
-RUN pnpm install --allow-build=@vue-office/pptx --allow-build=esbuild --allow-build=vue-demi
+RUN pnpm install
 
 # 复制项目文件
 COPY . .

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,12 +60,5 @@
     "lightningcss": "none",
     "esbuild": "^0.25.0",
     "serialize-javascript": "^7.0.3"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@vue-office/pptx",
-      "esbuild",
-      "vue-demi"
-    ]
   }
 }

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  "@vue-office/pptx": true
+  esbuild: true
+  vue-demi: true


### PR DESCRIPTION
pnpm v11 no longer supports onlyBuiltDependencies in package.json and does not accept install-time --allow-build flags. Move build-script approvals to pnpm-workspace.yaml and copy it before install in Dockerfile so CI Docker builds can apply allowBuilds during pnpm install.
