### PR TITLE
fix: propagate user attachments to agent query in AgentQA

### DIFF
--- a/internal/application/service/session_agent_qa.go
+++ b/internal/application/service/session_agent_qa.go
@@ -184,6 +184,13 @@ func (s *sessionService) AgentQA(
 	if req.QuotedContext != "" {
 		agentQuery += "\n\n" + req.QuotedContext
 	}
+	// Inject attachment content (documents, audio transcripts, etc.) so the agent
+	// can see uploaded files. Mirrors the behavior of the KnowledgeQA pipeline
+	// (see chat_pipeline/into_chat_message.go).
+	if len(req.Attachments) > 0 {
+		agentQuery += req.Attachments.BuildPrompt()
+		logger.Infof(ctx, "Appended %d attachment(s) to agent query", len(req.Attachments))
+	}
 
 	// Execute agent with streaming (asynchronously)
 	// Events will be emitted to EventBus and handled by the Handler layer


### PR DESCRIPTION
## Summary
- In "smart reasoning" (Agent) mode, files uploaded via `attachment_uploads` were parsed by the handler and set on `QARequest.Attachments`, but `session_agent_qa.go` never passed them to `engine.Execute`, so the model could not see the uploaded file and replied as if no attachment was present.
- Only `KnowledgeQA` injected attachments through `Attachments.BuildPrompt()` in `chat_pipeline/into_chat_message.go`; `AgentQA` had no equivalent.
- Append `req.Attachments.BuildPrompt()` to `agentQuery` right after `QuotedContext`, matching the existing KnowledgeQA behavior. Engine signature stays unchanged.

## Test plan
- [ ] `go build ./...` succeeds.
- [ ] Start a chat in Agent mode ("smart reasoning"), upload a small `.md`/`.txt` file, and ask the model to summarize it. The log line `Appended N attachment(s) to agent query` is emitted and the model summarizes the file content instead of listing the knowledge base.
- [ ] Repeat in KnowledgeQA mode to confirm no regression in the existing path.
- [ ] Send an Agent-mode message with no attachment; behavior is unchanged.