### PR TITLE
feat(wiki/graph): 优化操作帮助入口与图例视觉

### DIFF
--- a/frontend/src/views/knowledge/wiki/WikiBrowser.vue
+++ b/frontend/src/views/knowledge/wiki/WikiBrowser.vue
@@ -7,21 +7,49 @@
 
         <!-- Graph Search Overlay -->
         <div v-if="graphReady" class="wiki-graph-search-container">
-          <div class="wiki-graph-search">
-            <t-select
-              v-model="graphSearchValue"
-              filterable
-              :options="graphSearchEffectiveOptions"
-              :loading="graphSearchLoading"
-              :on-search="handleGraphRemoteSearch"
-              :placeholder="$t('knowledgeEditor.wikiBrowser.searchPlaceholder')"
-              @change="handleGraphSearchSelect"
-              @enter="handleGraphSearchEnter"
-              :popup-props="{ zIndex: 100 }"
-              class="graph-search-select"
+          <div class="wiki-graph-search-row">
+            <div class="wiki-graph-search">
+              <t-select
+                v-model="graphSearchValue"
+                filterable
+                :options="graphSearchEffectiveOptions"
+                :loading="graphSearchLoading"
+                :on-search="handleGraphRemoteSearch"
+                :placeholder="$t('knowledgeEditor.wikiBrowser.searchPlaceholder')"
+                @change="handleGraphSearchSelect"
+                @enter="handleGraphSearchEnter"
+                :popup-props="{ zIndex: 100 }"
+                class="graph-search-select"
+              >
+                <template #prefixIcon><t-icon name="search" /></template>
+              </t-select>
+            </div>
+            <t-popup
+              trigger="click"
+              placement="bottom-right"
+              :show-arrow="true"
+              overlay-class-name="wiki-graph-help-popup"
             >
-              <template #prefixIcon><t-icon name="search" /></template>
-            </t-select>
+              <div
+                class="wiki-graph-help-trigger"
+                role="button"
+                tabindex="0"
+                :title="$t('knowledgeEditor.wikiBrowser.helpButtonTitle')"
+              >
+                <t-icon name="help-circle" />
+              </div>
+              <template #content>
+                <div class="wiki-graph-help">
+                  <div class="help-section-title">{{ $t('knowledgeEditor.wikiBrowser.helpTitle') }}</div>
+                  <div class="help-rows">
+                    <div class="help-row" v-for="row in graphHelpRows" :key="row.action">
+                      <span class="help-key">{{ row.action }}</span>
+                      <span class="help-desc">{{ row.desc }}</span>
+                    </div>
+                  </div>
+                </div>
+              </template>
+            </t-popup>
           </div>
           <div v-if="stats && stats.pending_issues > 0" class="wiki-global-issues-status graph-issues-badge" @click="showGlobalIssuesDrawer = true">
             <t-icon name="error-circle" style="color: var(--td-warning-color);" />
@@ -30,7 +58,7 @@
         </div>
 
         <!-- Legend Overlay -->
-        <div v-if="graphReady" class="wiki-graph-legend">
+        <div v-if="graphReady" class="wiki-graph-legend" :class="{ 'legend-shifted': graphDrawerVisible }">
           <div class="legend-items">
             <div 
               class="legend-item clickable" 
@@ -96,31 +124,8 @@
               <span class="legend-action-icon"><t-icon name="rollback" /></span>
               <span>{{ $t('knowledgeEditor.wikiBrowser.backToOverview') }}</span>
             </div>
-            <t-popup
-              trigger="click"
-              placement="top-right"
-              :show-arrow="true"
-              overlay-class-name="wiki-graph-help-popup"
-            >
-              <div class="legend-action" :title="$t('knowledgeEditor.wikiBrowser.helpButtonTitle')">
-                <span class="legend-action-icon help-glyph-icon">?</span>
-                <span>{{ $t('knowledgeEditor.wikiBrowser.helpButtonTitle') }}</span>
-              </div>
-              <template #content>
-                <div class="wiki-graph-help">
-                  <div class="help-section-title">{{ $t('knowledgeEditor.wikiBrowser.helpTitle') }}</div>
-                  <div class="help-rows">
-                    <div class="help-row" v-for="row in graphHelpRows" :key="row.action">
-                      <span class="help-key">{{ row.action }}</span>
-                      <span class="help-desc">{{ row.desc }}</span>
-                    </div>
-                  </div>
-                </div>
-              </template>
-            </t-popup>
           </div>
           <template v-if="graphStatusCard">
-            <div class="legend-divider"></div>
             <div class="wiki-graph-status-card">
               <div class="status-card-header">
                 <t-icon :name="graphStatusCard.icon" />
@@ -4383,7 +4388,7 @@ onUnmounted(() => {
   flex-direction: column;
   gap: 12px;
   z-index: 10;
-  width: 280px;
+  width: 320px;
 }
 
 .wiki-graph-search {
@@ -4412,6 +4417,42 @@ onUnmounted(() => {
   min-height: 500px;
 }
 
+.wiki-graph-search-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.wiki-graph-search-row :deep(.t-popup__reference) {
+  display: inline-flex;
+}
+
+.wiki-graph-search-row .wiki-graph-search {
+  flex: 1;
+  min-width: 0;
+}
+
+.wiki-graph-help-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: var(--td-text-color-placeholder);
+  font-size: 18px;
+  cursor: pointer;
+  user-select: none;
+  transition: color 0.15s ease;
+}
+
+.wiki-graph-help-trigger:hover {
+  color: var(--td-brand-color);
+}
+
 .wiki-graph-legend {
   position: absolute;
   top: 16px;
@@ -4426,6 +4467,11 @@ onUnmounted(() => {
   gap: 12px;
   z-index: 10;
   opacity: 0.95;
+  transition: right 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+
+.wiki-graph-legend.legend-shifted {
+  right: calc(480px + 16px);
 }
 
 .legend-items {
@@ -4516,7 +4562,8 @@ onUnmounted(() => {
   flex-direction: column;
   gap: 4px;
   max-width: 240px;
-  padding: 8px 2px 2px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--td-component-stroke);
   user-select: none;
 
   .status-card-header {
@@ -4526,18 +4573,19 @@ onUnmounted(() => {
     font-size: 11px;
     line-height: 14px;
     color: var(--td-text-color-placeholder);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
 
     .t-icon {
       font-size: 12px;
     }
   }
 
+  .status-card-title {
+    font-weight: 500;
+  }
+
   .status-card-primary {
-    font-size: 13px;
-    font-weight: 600;
-    line-height: 18px;
+    font-size: 12px;
+    line-height: 16px;
     color: var(--td-text-color-primary);
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

调整知识库 Graph 视图的几个细节体验问题：

- **操作帮助按钮挪位**：原本藏在右上图例底部的灰色 `?` 操作帮助项，用户不易发现。改为放置在左上角搜索框右侧的图标按钮（与搜索框高度对齐、placeholder 色，hover 高亮主题色），点击仍弹出原画布操作说明。
- **状态卡片视觉清理**：图例底部的"全库概览 / 当前焦点"状态卡片之前用大写英文 + 字间距 + 加粗大字的排版，与图例其他元素风格不统一。改为去掉大写转换、降低主标题字号字重，使用 1px 虚线分隔，整体视觉更轻、更连贯。
- **抽屉打开时图例自动让位**：右侧详情抽屉(480px)打开后会完全遮挡右上角图例。现在图例在抽屉可见时自动向左平移 480px + 16px，使用与 TDesign drawer 一致的 cubic-bezier 缓动，关闭后回归原位。

## Test plan

- [x] 进入任意知识库 `?tab=graph` 页面，确认搜索框右侧存在 `?` 帮助图标，点击弹出"画布操作"说明
- [x] 确认右上图例底部不再出现"操作帮助"操作项
- [x] 在 Overview 与 Ego 两种模式下，状态卡片排版整洁、与图例其他元素视觉一致
- [x] 点击节点打开右侧详情抽屉，确认图例平滑左移、未被遮挡；关闭抽屉后图例回到右上角