### PR TITLE
fix(doris): add GetIndexedSourceIDsByKnowledge stub to satisfy interface

### DIFF
--- a/internal/application/repository/retriever/doris/repository.go
+++ b/internal/application/repository/retriever/doris/repository.go
@@ -561,6 +561,13 @@ func buildRetrieveResult(results []*types.IndexWithScore, retrieverType types.Re
 	}}
 }
 
+// GetIndexedSourceIDsByKnowledge returns an empty set for the dorisRepository engine.
+// Doris does not maintain a separate source-ID index, so incremental dedup is
+// handled at the ingest layer rather than queried here.
+func (r *dorisRepository) GetIndexedSourceIDsByKnowledge(_ context.Context, _ string) (map[string]struct{}, error) {
+	return map[string]struct{}{}, nil
+}
+
 // calculateStorageSize 估算单行的存储成本。
 //
 // 与 Qdrant 一致：payload 字符串字节 + 向量 (dim*4) + HNSW M*2*8 + 元数据 24。


### PR DESCRIPTION
## Problem

Upstream added `GetIndexedSourceIDsByKnowledge` to `RetrieveEngineRepository` in the wiki reconciliation commit. All other engine implementations (qdrant, elasticsearch v7/v8, milvus, weaviate) were updated, but the doris implementation was missed, causing a compile error when doris is enabled.

## Fix

Add the stub to `dorisRepository`. Doris does not maintain a separate source-ID index — incremental dedup is handled at the ingest layer — so the method correctly returns an empty set, consistent with the pattern in other engines.

## Testing

- Verified `go build ./...` passes with doris enabled
- Confirmed the empty-set return is consistent with the weaviate and milvus stubs