### PR TITLE
feat(ingest+parser): large-file routing — doc_large queue + hybrid parsers for PDF/Word/PPT

### DIFF
--- a/docreader/parser/office_hybrid_parser.py
+++ b/docreader/parser/office_hybrid_parser.py
@@ -1,0 +1,140 @@
+"""
+Office format hybrid parsers: MarkItDown text extraction + LibreOffice page rendering.
+
+Both DocxHybridParser and PptxHybridParser follow the same pattern:
+  1. MarkitdownParser  — extracts text structure concurrently
+  2. LibreOffice       — converts file to PDF, then PDFScannedParser renders
+                         every page as a JPEG for the multimodal VLM pipeline
+
+The two passes run in a ThreadPoolExecutor so total wall-clock time is
+max(text_extraction, lo_conversion + page_render) rather than their sum.
+"""
+
+import concurrent.futures
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+
+from docreader.models.document import Document
+from docreader.parser.base_parser import BaseParser
+from docreader.parser.markitdown_parser import MarkitdownParser
+from docreader.parser.pdf_parser import PDFScannedParser
+
+logger = logging.getLogger(__name__)
+
+# LibreOffice search order: PATH first, then common installation paths.
+_SOFFICE_FALLBACKS = [
+    "/opt/homebrew/bin/soffice",
+    "/usr/bin/soffice",
+    "/usr/local/bin/soffice",
+    "/Applications/LibreOffice.app/Contents/MacOS/soffice",
+]
+
+SOFFICE_TIMEOUT = 120  # seconds per conversion
+
+
+def find_soffice() -> str | None:
+    """Return the path to the LibreOffice soffice binary, or None."""
+    path = shutil.which("soffice")
+    if path:
+        return path
+    for candidate in _SOFFICE_FALLBACKS:
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def _libreoffice_to_pdf(content: bytes, file_name: str, file_type: str) -> bytes:
+    """Convert an Office document to PDF bytes using LibreOffice headless.
+
+    Raises RuntimeError when LibreOffice is not found or the conversion fails.
+    """
+    soffice = find_soffice()
+    if not soffice:
+        raise RuntimeError("LibreOffice (soffice) not found — install LibreOffice to enable Office page rendering")
+
+    ext = (file_type or "").lstrip(".") or os.path.splitext(file_name)[1].lstrip(".") or "bin"
+    tmpdir = tempfile.mkdtemp(prefix="lo-convert-")
+    try:
+        input_path = os.path.join(tmpdir, f"input.{ext}")
+        with open(input_path, "wb") as fh:
+            fh.write(content)
+
+        proc = subprocess.run(
+            [soffice, "--headless", "--convert-to", "pdf", "--outdir", tmpdir, input_path],
+            capture_output=True,
+            timeout=SOFFICE_TIMEOUT,
+        )
+        if proc.returncode != 0:
+            stderr = proc.stderr.decode(errors="replace")[:500]
+            raise RuntimeError(f"soffice exited {proc.returncode}: {stderr}")
+
+        pdf_files = [f for f in os.listdir(tmpdir) if f.endswith(".pdf")]
+        if not pdf_files:
+            raise RuntimeError("LibreOffice produced no PDF output")
+
+        return open(os.path.join(tmpdir, pdf_files[0]), "rb").read()
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class _OfficeHybridParser(BaseParser):
+    """Base: MarkItDown text + LibreOffice→PDF page renders, run concurrently."""
+
+    def parse_into_text(self, content: bytes) -> Document:
+        def _extract_text() -> str:
+            try:
+                parser = MarkitdownParser(file_name=self.file_name, file_type=self.file_type)
+                doc = parser.parse_into_text(content)
+                return doc.content if doc.is_valid() else ""
+            except Exception:
+                logger.exception("%s: MarkitdownParser failed", self.__class__.__name__)
+                return ""
+
+        def _render_pages() -> Document:
+            try:
+                pdf_bytes = _libreoffice_to_pdf(content, self.file_name or "doc", self.file_type or "")
+                base = os.path.splitext(self.file_name or "doc")[0]
+                scanner = PDFScannedParser(file_name=base + ".pdf", file_type="pdf")
+                return scanner.parse_into_text(pdf_bytes)
+            except Exception:
+                logger.exception("%s: LibreOffice/PDFScannedParser failed", self.__class__.__name__)
+                return Document()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            text_future = executor.submit(_extract_text)
+            render_future = executor.submit(_render_pages)
+            text_content = text_future.result()
+            render_doc = render_future.result()
+
+        if render_doc.images:
+            parts = [p for p in (text_content, render_doc.content) if p]
+            return Document(
+                content="\n\n".join(parts),
+                images=render_doc.images,
+                metadata=render_doc.metadata,
+            )
+
+        return Document(content=text_content)
+
+
+class DocxHybridParser(_OfficeHybridParser):
+    """Word (docx/doc) hybrid: MarkItDown text + LibreOffice page renders.
+
+    DocxParser extracts inline images but silently drops Charts, SmartArt and
+    OLE objects.  This parser renders every page via LibreOffice so the VLM
+    pipeline captures all visual content including complex diagrams.
+    Use for large Word files (≥5 MB) where MinerU would block the queue.
+    """
+
+
+class PptxHybridParser(_OfficeHybridParser):
+    """PowerPoint (pptx/ppt) hybrid: MarkItDown text + LibreOffice slide renders.
+
+    Slides are fundamentally visual — MarkItDown alone extracts bullet text only.
+    LibreOffice converts the file to PDF (one page per slide), then
+    PDFScannedParser renders every slide as a JPEG for VLM captioning/OCR.
+    Recommended for all pptx/ppt files regardless of size.
+    """

--- a/docreader/parser/pdf_parser.py
+++ b/docreader/parser/pdf_parser.py
@@ -94,14 +94,70 @@ class PDFScannedParser(BaseParser):
             logger.exception("PDFScannedParser failed to parse PDF: %s", e)
             raise e
 
+class PDFHybridParser(BaseParser):
+    """PDF parser for image-rich documents: combines text extraction + full-page rendering.
+
+    MarkitdownParser (pdfminer.six) extracts text but silently drops embedded figures,
+    diagrams and photos — because pdfminer is a text-only extractor.  PDFScannedParser
+    renders every page as a JPEG so the multimodal VLM pipeline can see all visual content.
+
+    This parser runs both passes and merges the results:
+      - text content  → from MarkitdownParser (preserves headings, tables, lists)
+      - page images   → from PDFScannedParser (captures figures, wiring diagrams, photos)
+
+    The combined markdown looks like:
+
+        [MarkItDown text ...]
+
+        ![doc_page_1.jpg](images/doc_page_1.jpg)
+        ![doc_page_2.jpg](images/doc_page_2.jpg)
+        ...
+
+    The text chunks go into the vector store directly.  The image refs trigger
+    async multimodal tasks (VLM captioning / OCR) so search also covers visual content.
+
+    Use this engine for large technical PDFs (product manuals, datasheets) where
+    MinerU would hang but losing embedded images is not acceptable.
+    """
+
+    def parse_into_text(self, content: bytes) -> Document:
+        # Pass 1: text extraction
+        text_content = ""
+        try:
+            text_parser = MarkitdownParser(file_name=self.file_name, file_type=self.file_type)
+            text_doc = text_parser.parse_into_text(content)
+            if text_doc.is_valid():
+                text_content = text_doc.content
+        except Exception:
+            logger.exception("PDFHybridParser: MarkitdownParser failed — will use page renders only")
+
+        # Pass 2: page rendering (always runs to capture images)
+        try:
+            image_parser = PDFScannedParser(file_name=self.file_name, file_type=self.file_type)
+            image_doc = image_parser.parse_into_text(content)
+
+            if image_doc.images:
+                parts = [p for p in (text_content, image_doc.content) if p]
+                combined = "\n\n".join(parts)
+                return Document(
+                    content=combined,
+                    images=image_doc.images,
+                    metadata=image_doc.metadata,
+                )
+        except Exception:
+            logger.exception("PDFHybridParser: PDFScannedParser failed — returning text only")
+
+        return Document(content=text_content)
+
+
 class PDFParser(FirstParser):
     """PDF Parser using chain of responsibility pattern
-    
+
     Attempts to parse PDF files using multiple parser backends in order:
     1. MinerUParser - Primary parser for PDF documents (if enabled)
     2. MarkitdownParser - Fallback parser if MinerU fails
     3. PDFScannedParser - Final fallback for scanned PDFs
-    
+
     The first successful parser result will be returned.
     """
     # Parser classes to try in order (chain of responsibility pattern)

--- a/docreader/parser/pdf_parser.py
+++ b/docreader/parser/pdf_parser.py
@@ -24,6 +24,17 @@ def _normalize_image_quality(quality: int) -> int:
     return min(95, max(1, quality))
 
 
+def _pdf_has_images(content: bytes) -> bool:
+    """Fast heuristic: scan PDF bytes for embedded image markers.
+
+    PDF images are stored as XObject streams with /Subtype /Image.
+    A byte-level search is O(n) but takes only a few milliseconds even for
+    large files — far cheaper than rendering all pages to discover there are none.
+    Returns True when any image marker is found; False otherwise.
+    """
+    return b"/Subtype /Image" in content or b"/Subtype/Image" in content
+
+
 class PDFScannedParser(BaseParser):
     """Fallback parser for scanned PDFs.
     
@@ -96,39 +107,45 @@ class PDFScannedParser(BaseParser):
             raise e
 
 class PDFHybridParser(BaseParser):
-    """PDF parser for image-rich documents: combines text extraction + full-page rendering.
+    """Adaptive PDF parser: text-only fast path for pure-text PDFs, full hybrid for image-rich ones.
 
-    MarkitdownParser (pdfminer.six) extracts text but silently drops embedded figures,
-    diagrams and photos — because pdfminer is a text-only extractor.  PDFScannedParser
-    renders every page as a JPEG so the multimodal VLM pipeline can see all visual content.
+    Routing logic (decided per file, not per knowledge base):
 
-    This parser runs both passes and merges the results:
-      - text content  → from MarkitdownParser (preserves headings, tables, lists)
-      - page images   → from PDFScannedParser (captures figures, wiring diagrams, photos)
+      1. Quick image scan (_pdf_has_images): O(n) byte search, a few ms.
+      2. No images detected → text-only path: run MarkitdownParser only.
+         Fast, no page rendering, no VLM tasks generated.
+      3. Images detected → hybrid path: run MarkitdownParser + PDFScannedParser
+         concurrently; merge text structure with per-page JPEG renders so the
+         multimodal VLM pipeline captures figures, diagrams and photos.
 
-    The combined markdown looks like:
+    This covers the three practical cases for large PDFs (≥ 5 MB):
+      • Text-only manuals / reports  → fast text extraction
+      • Mixed text + diagrams        → text + page renders (concurrent)
+      • Scanned / image-only PDFs    → page renders only (MarkItDown returns empty)
 
-        [MarkItDown text ...]
+    The combined markdown for image-rich files:
+
+        [MarkItDown extracted text ...]
 
         ![doc_page_1.jpg](images/doc_page_1.jpg)
         ![doc_page_2.jpg](images/doc_page_2.jpg)
         ...
-
-    The text chunks go into the vector store directly.  The image refs trigger
-    async multimodal tasks (VLM captioning / OCR) so search also covers visual content.
-
-    Use this engine for large technical PDFs (product manuals, datasheets) where
-    MinerU would hang but losing embedded images is not acceptable.
     """
 
     def parse_into_text(self, content: bytes) -> Document:
+        has_images = _pdf_has_images(content)
+        logger.info(
+            "PDFHybridParser: file=%s has_images=%s — choosing %s path",
+            self.file_name, has_images, "hybrid" if has_images else "text-only",
+        )
+
         def _extract_text() -> str:
             try:
                 parser = MarkitdownParser(file_name=self.file_name, file_type=self.file_type)
                 doc = parser.parse_into_text(content)
                 return doc.content if doc.is_valid() else ""
             except Exception:
-                logger.exception("PDFHybridParser: MarkitdownParser failed — will use page renders only")
+                logger.exception("PDFHybridParser: MarkitdownParser failed")
                 return ""
 
         def _render_pages() -> Document:
@@ -139,7 +156,11 @@ class PDFHybridParser(BaseParser):
                 logger.exception("PDFHybridParser: PDFScannedParser failed")
                 return Document()
 
-        # Run text extraction and page rendering concurrently.
+        if not has_images:
+            # Text-only fast path: skip expensive page rendering entirely.
+            return Document(content=_extract_text())
+
+        # Image-rich path: run both concurrently, merge results.
         with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
             text_future = executor.submit(_extract_text)
             image_future = executor.submit(_render_pages)

--- a/docreader/parser/pdf_parser.py
+++ b/docreader/parser/pdf_parser.py
@@ -5,6 +5,7 @@ from docreader.parser.chain_parser import FirstParser
 from docreader.parser.concurrency import parser_worker_limit
 from docreader.parser.markitdown_parser import MarkitdownParser
 
+import concurrent.futures
 import io
 import os
 import base64
@@ -121,31 +122,37 @@ class PDFHybridParser(BaseParser):
     """
 
     def parse_into_text(self, content: bytes) -> Document:
-        # Pass 1: text extraction
-        text_content = ""
-        try:
-            text_parser = MarkitdownParser(file_name=self.file_name, file_type=self.file_type)
-            text_doc = text_parser.parse_into_text(content)
-            if text_doc.is_valid():
-                text_content = text_doc.content
-        except Exception:
-            logger.exception("PDFHybridParser: MarkitdownParser failed — will use page renders only")
+        def _extract_text() -> str:
+            try:
+                parser = MarkitdownParser(file_name=self.file_name, file_type=self.file_type)
+                doc = parser.parse_into_text(content)
+                return doc.content if doc.is_valid() else ""
+            except Exception:
+                logger.exception("PDFHybridParser: MarkitdownParser failed — will use page renders only")
+                return ""
 
-        # Pass 2: page rendering (always runs to capture images)
-        try:
-            image_parser = PDFScannedParser(file_name=self.file_name, file_type=self.file_type)
-            image_doc = image_parser.parse_into_text(content)
+        def _render_pages() -> Document:
+            try:
+                parser = PDFScannedParser(file_name=self.file_name, file_type=self.file_type)
+                return parser.parse_into_text(content)
+            except Exception:
+                logger.exception("PDFHybridParser: PDFScannedParser failed")
+                return Document()
 
-            if image_doc.images:
-                parts = [p for p in (text_content, image_doc.content) if p]
-                combined = "\n\n".join(parts)
-                return Document(
-                    content=combined,
-                    images=image_doc.images,
-                    metadata=image_doc.metadata,
-                )
-        except Exception:
-            logger.exception("PDFHybridParser: PDFScannedParser failed — returning text only")
+        # Run text extraction and page rendering concurrently.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            text_future = executor.submit(_extract_text)
+            image_future = executor.submit(_render_pages)
+            text_content = text_future.result()
+            image_doc = image_future.result()
+
+        if image_doc.images:
+            parts = [p for p in (text_content, image_doc.content) if p]
+            return Document(
+                content="\n\n".join(parts),
+                images=image_doc.images,
+                metadata=image_doc.metadata,
+            )
 
         return Document(content=text_content)
 

--- a/docreader/parser/registry.py
+++ b/docreader/parser/registry.py
@@ -8,6 +8,7 @@ from docreader.parser.excel_parser import ExcelParser
 from docreader.parser.image_parser import ImageParser
 from docreader.parser.markdown_parser import MarkdownParser
 from docreader.parser.markitdown_parser import MarkitdownParser
+from docreader.parser.office_hybrid_parser import DocxHybridParser, PptxHybridParser, find_soffice
 from docreader.parser.pdf_parser import PDFHybridParser, PDFParser
 
 logger = logging.getLogger(__name__)
@@ -155,6 +156,33 @@ def _build_default_registry() -> ParserEngineRegistry:
             "pdf": PDFHybridParser,
         },
         description="PDF 混合解析引擎（文本提取 + 全页渲染）：MarkItDown 提取文字结构，PDFScannedParser 渲染每页为图片，两者合并。适合含图表的大文件 PDF，不依赖 MinerU。",
+    )
+
+    def _check_libreoffice(_overrides=None):
+        if find_soffice():
+            return True, ""
+        return False, "LibreOffice (soffice) 未安装或不在 PATH 中"
+
+    reg.register(
+        "docx_hybrid",
+        {
+            "docx": DocxHybridParser,
+            "doc":  DocxHybridParser,
+        },
+        description="Word 混合解析引擎（文本提取 + LibreOffice 全页渲染）：MarkItDown 提取文字，LibreOffice 将每页渲染为图片供 VLM 处理。适合含图表/SmartArt 的大文件 Word 文档。",
+        check_available=_check_libreoffice,
+        unavailable_hint="需要安装 LibreOffice",
+    )
+
+    reg.register(
+        "pptx_hybrid",
+        {
+            "pptx": PptxHybridParser,
+            "ppt":  PptxHybridParser,
+        },
+        description="PPT 混合解析引擎（文本提取 + LibreOffice 幻灯片渲染）：MarkItDown 提取文字，LibreOffice 将每张幻灯片渲染为图片供 VLM 处理。幻灯片天然是视觉格式，推荐所有 pptx/ppt 文件使用。",
+        check_available=_check_libreoffice,
+        unavailable_hint="需要安装 LibreOffice",
     )
 
     # NOTE: Engine listing is managed by Go-side engine registry

--- a/docreader/parser/registry.py
+++ b/docreader/parser/registry.py
@@ -8,7 +8,7 @@ from docreader.parser.excel_parser import ExcelParser
 from docreader.parser.image_parser import ImageParser
 from docreader.parser.markdown_parser import MarkdownParser
 from docreader.parser.markitdown_parser import MarkitdownParser
-from docreader.parser.pdf_parser import PDFParser
+from docreader.parser.pdf_parser import PDFHybridParser, PDFParser
 
 logger = logging.getLogger(__name__)
 
@@ -147,6 +147,14 @@ def _build_default_registry() -> ParserEngineRegistry:
             "csv": MarkitdownParser,
         },
         description="MarkItDown 解析引擎（微软 MarkItDown 库）",
+    )
+
+    reg.register(
+        "pdf_hybrid",
+        {
+            "pdf": PDFHybridParser,
+        },
+        description="PDF 混合解析引擎（文本提取 + 全页渲染）：MarkItDown 提取文字结构，PDFScannedParser 渲染每页为图片，两者合并。适合含图表的大文件 PDF，不依赖 MinerU。",
     )
 
     # NOTE: Engine listing is managed by Go-side engine registry

--- a/internal/application/service/knowledge_clone_move.go
+++ b/internal/application/service/knowledge_clone_move.go
@@ -984,7 +984,7 @@ func (s *knowledgeService) moveKnowledgeReparse(
 			return fmt.Errorf("failed to marshal document process payload: %w", err)
 		}
 
-		task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue("default"), asynq.MaxRetry(3))
+		task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue(docProcessQueue(knowledge.FileSize)), asynq.MaxRetry(3))
 		info, err := s.task.Enqueue(task)
 		if err != nil {
 			return fmt.Errorf("failed to enqueue document process task: %w", err)

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -262,7 +262,7 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 		return knowledge, nil
 	}
 
-	task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue("default"), asynq.MaxRetry(3))
+	task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue(docProcessQueue(knowledge.FileSize)), asynq.MaxRetry(3))
 	info, err := s.task.Enqueue(task)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to enqueue document process task: %v", err)

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -609,6 +609,19 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 // defaultMaxInputChars is the default maximum characters used as input for summary generation.
 const defaultMaxInputChars = 1024 * 24
 
+// docLargeFileThreshold is the file-size boundary for both MinerU→builtin engine routing
+// and asynq queue selection. Files at or above this size go to the "doc_large" queue
+// (weight 1) so small files in "default" (weight 2) always drain preferentially.
+const docLargeFileThreshold = 5 * 1024 * 1024 // 5 MB
+
+// docProcessQueue returns the asynq queue name for a document:process task.
+func docProcessQueue(fileSize int64) string {
+	if fileSize >= docLargeFileThreshold {
+		return "doc_large"
+	}
+	return "default"
+}
+
 // errInsufficientSummaryContent signals that getSummary refused to call the
 // LLM because the document had no usable text after image markup was stripped
 // (typical for scanned PDFs where VLM OCR yielded nothing). Callers should
@@ -1432,7 +1445,7 @@ func (s *knowledgeService) ReparseKnowledge(ctx context.Context, knowledgeID str
 			return existing, nil
 		}
 
-		task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue("default"), asynq.MaxRetry(3))
+		task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue(docProcessQueue(existing.FileSize)), asynq.MaxRetry(3))
 		info, err := s.task.Enqueue(task)
 		if err != nil {
 			logger.Errorf(ctx, "Failed to enqueue reparse task: %v", err)
@@ -1485,7 +1498,7 @@ func (s *knowledgeService) ReparseKnowledge(ctx context.Context, knowledgeID str
 			return existing, nil
 		}
 
-		task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue("default"))
+		task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue(docProcessQueue(existing.FileSize)))
 		info, err := s.task.Enqueue(task)
 		if err != nil {
 			logger.Errorf(ctx, "Failed to enqueue file URL reparse task: %v", err)
@@ -2254,11 +2267,10 @@ func (s *knowledgeService) convert(
 	// on files above ~5 MB, blocking the entire single-threaded MinerU queue.
 	// Fall back to the builtin engine for such files — it is always available
 	// and processes large PDFs reliably, albeit without OCR for scanned pages.
-	const mineruLargeFileThreshold = 5 * 1024 * 1024 // 5 MB
-	if parserEngine == "mineru" && !isURL && knowledge.FileSize > mineruLargeFileThreshold {
-		logger.Warnf(ctx, "[convert] file %q is %.1f MB (> %.0f MB threshold), overriding engine mineru→builtin",
+	if parserEngine == "mineru" && !isURL && knowledge.FileSize >= docLargeFileThreshold {
+		logger.Warnf(ctx, "[convert] file %q is %.1f MB (>= %.0f MB threshold), overriding engine mineru→builtin",
 			payload.FileName, float64(knowledge.FileSize)/1024/1024,
-			float64(mineruLargeFileThreshold)/1024/1024)
+			float64(docLargeFileThreshold)/1024/1024)
 		parserEngine = "builtin"
 	}
 

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -2286,17 +2286,16 @@ func (s *knowledgeService) convert(
 		parserEngine = kb.ChunkingConfig.ResolveParserEngine("url")
 	}
 
-	// MinerU safety routing: large file (≥5 MB) OR high page count (≥80 pages)
-	// → bypass MinerU to prevent queue blocking and OOM.
+	// MinerU safety routing: bypass MinerU when files exceed size/page thresholds
+	// or when the format is inherently visual (pptx/ppt).
 	//
-	// Page count check requires reading the PDF bytes early (before engine
-	// selection), so we load them here and cache them for reuse below when
-	// building req.FileContent — avoiding a second storage read.
+	// For PDF: load bytes early to count pages (cached for reuse in req.FileContent).
+	// For pptx/ppt: always route to pptx_hybrid — slides are always visual.
+	// For docx/doc: route to docx_hybrid only when file is large (≥5 MB).
 	var cachedFileBytes []byte
 	if parserEngine == "mineru" && !isURL {
 		if fileType == "pdf" {
-			// Load file early to count pages; any error is non-fatal here
-			// (the normal load path below will surface a proper error).
+			// Load PDF early for page count; non-fatal on error.
 			if fr, ferr := s.resolveFileServiceForPath(ctx, kb, payload.FilePath).GetFile(ctx, payload.FilePath); ferr == nil {
 				defer fr.Close()
 				if b, rerr := io.ReadAll(fr); rerr == nil {
@@ -2309,17 +2308,30 @@ func (s *knowledgeService) convert(
 		pageCount := pdfEstimatePageCount(cachedFileBytes)
 		pageExceeds := fileType == "pdf" && pageCount >= docLargePageThreshold
 
-		if sizeExceeds || pageExceeds {
-			override := "builtin"
-			if fileType == "pdf" {
+		var override string
+		var reason string
+		switch fileType {
+		case "pptx", "ppt":
+			// Slides are always visual: route regardless of size.
+			override = "pptx_hybrid"
+			reason = "pptx/ppt is always visual"
+		case "pdf":
+			if sizeExceeds || pageExceeds {
 				override = "pdf_hybrid"
+				reason = fmt.Sprintf("size≥%dMB=%v pages≥%d=%v",
+					docLargeFileThreshold/1024/1024, sizeExceeds,
+					docLargePageThreshold, pageExceeds)
 			}
-			logger.Warnf(ctx, "[convert] file %q (%.1f MB, ~%d pages) exceeds threshold (size≥%dMB=%v pages≥%d=%v), overriding mineru→%s",
-				payload.FileName,
-				float64(knowledge.FileSize)/1024/1024, pageCount,
-				docLargeFileThreshold/1024/1024, sizeExceeds,
-				docLargePageThreshold, pageExceeds,
-				override)
+		case "docx", "doc":
+			if sizeExceeds {
+				override = "docx_hybrid"
+				reason = fmt.Sprintf("size≥%dMB", docLargeFileThreshold/1024/1024)
+			}
+		}
+
+		if override != "" {
+			logger.Warnf(ctx, "[convert] file %q (%.1f MB, ~%d pages): %s, overriding mineru→%s",
+				payload.FileName, float64(knowledge.FileSize)/1024/1024, pageCount, reason, override)
 			parserEngine = override
 		}
 	}
@@ -2406,8 +2418,8 @@ func (s *knowledgeService) resolveDocReader(ctx context.Context, engine, fileTyp
 		return docparser.NewMinerUReader(overrides)
 	case "mineru_cloud":
 		return docparser.NewMinerUCloudReader(overrides)
-	case "builtin":
-		// 明确指定使用 builtin 引擎（docreader），不使用 simple format 兜底
+	case "builtin", "pdf_hybrid", "docx_hybrid", "pptx_hybrid":
+		// All docreader-backed engines: Python side handles the routing internally.
 		return s.documentReader
 	default:
 		// 未指定引擎时的兜底逻辑：simple format 使用 Go 原生处理，其他使用 docreader

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -2250,6 +2250,18 @@ func (s *knowledgeService) convert(
 		parserEngine = kb.ChunkingConfig.ResolveParserEngine("url")
 	}
 
+	// Large-file safety: MinerU uses subprocess isolation and can hang or OOM
+	// on files above ~5 MB, blocking the entire single-threaded MinerU queue.
+	// Fall back to the builtin engine for such files — it is always available
+	// and processes large PDFs reliably, albeit without OCR for scanned pages.
+	const mineruLargeFileThreshold = 5 * 1024 * 1024 // 5 MB
+	if parserEngine == "mineru" && !isURL && knowledge.FileSize > mineruLargeFileThreshold {
+		logger.Warnf(ctx, "[convert] file %q is %.1f MB (> %.0f MB threshold), overriding engine mineru→builtin",
+			payload.FileName, float64(knowledge.FileSize)/1024/1024,
+			float64(mineruLargeFileThreshold)/1024/1024)
+		parserEngine = "builtin"
+	}
+
 	logger.Infof(ctx, "[convert] kb=%s fileType=%s isURL=%v engine=%q rules=%+v",
 		kb.ID, fileType, isURL, parserEngine, kb.ChunkingConfig.ParserEngineRules)
 

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -614,12 +615,34 @@ const defaultMaxInputChars = 1024 * 24
 // (weight 1) so small files in "default" (weight 2) always drain preferentially.
 const docLargeFileThreshold = 5 * 1024 * 1024 // 5 MB
 
+// docLargePageThreshold is the page-count boundary for MinerU→pdf_hybrid routing.
+// A text-heavy PDF can be many pages yet small in file size; page count is a
+// better predictor of MinerU processing time than file size alone.
+// At ~pipeline speed of 1-2 min/10 pages on an 8-core M-series Mac, 80 pages
+// ≈ 10-20 min per document, which is the practical queue-blocking threshold.
+const docLargePageThreshold = 80
+
 // docProcessQueue returns the asynq queue name for a document:process task.
 func docProcessQueue(fileSize int64) string {
 	if fileSize >= docLargeFileThreshold {
 		return "doc_large"
 	}
 	return "default"
+}
+
+// pdfEstimatePageCount counts PDF page objects via a fast byte scan.
+// PDF pages are stored as indirect objects with /Type /Page; counting those
+// markers gives an accurate page count for well-formed PDFs without loading
+// any PDF library. Returns 0 when data is empty or when no page markers found.
+func pdfEstimatePageCount(data []byte) int {
+	if len(data) == 0 {
+		return 0
+	}
+	n := bytes.Count(data, []byte("/Type /Page"))
+	if n == 0 {
+		n = bytes.Count(data, []byte("/Type/Page"))
+	}
+	return n
 }
 
 // errInsufficientSummaryContent signals that getSummary refused to call the
@@ -2263,22 +2286,42 @@ func (s *knowledgeService) convert(
 		parserEngine = kb.ChunkingConfig.ResolveParserEngine("url")
 	}
 
-	// Large-file safety: MinerU can hang or OOM on files above ~5 MB, blocking
-	// the entire single-threaded MinerU queue.  For large PDFs we use the
-	// "pdf_hybrid" engine instead: MarkItDown extracts text structure and
-	// PDFScannedParser renders every page as a JPEG so the multimodal VLM
-	// pipeline captures all figures and diagrams — matching MinerU's image
-	// coverage without the subprocess hang risk.  Non-PDF large files fall
-	// back to the plain "builtin" engine (MarkItDown handles docx/pptx well).
-	if parserEngine == "mineru" && !isURL && knowledge.FileSize >= docLargeFileThreshold {
-		override := "builtin"
+	// MinerU safety routing: large file (≥5 MB) OR high page count (≥80 pages)
+	// → bypass MinerU to prevent queue blocking and OOM.
+	//
+	// Page count check requires reading the PDF bytes early (before engine
+	// selection), so we load them here and cache them for reuse below when
+	// building req.FileContent — avoiding a second storage read.
+	var cachedFileBytes []byte
+	if parserEngine == "mineru" && !isURL {
 		if fileType == "pdf" {
-			override = "pdf_hybrid"
+			// Load file early to count pages; any error is non-fatal here
+			// (the normal load path below will surface a proper error).
+			if fr, ferr := s.resolveFileServiceForPath(ctx, kb, payload.FilePath).GetFile(ctx, payload.FilePath); ferr == nil {
+				defer fr.Close()
+				if b, rerr := io.ReadAll(fr); rerr == nil {
+					cachedFileBytes = b
+				}
+			}
 		}
-		logger.Warnf(ctx, "[convert] file %q is %.1f MB (>= %.0f MB threshold), overriding engine mineru→%s",
-			payload.FileName, float64(knowledge.FileSize)/1024/1024,
-			float64(docLargeFileThreshold)/1024/1024, override)
-		parserEngine = override
+
+		sizeExceeds := knowledge.FileSize >= docLargeFileThreshold
+		pageCount := pdfEstimatePageCount(cachedFileBytes)
+		pageExceeds := fileType == "pdf" && pageCount >= docLargePageThreshold
+
+		if sizeExceeds || pageExceeds {
+			override := "builtin"
+			if fileType == "pdf" {
+				override = "pdf_hybrid"
+			}
+			logger.Warnf(ctx, "[convert] file %q (%.1f MB, ~%d pages) exceeds threshold (size≥%dMB=%v pages≥%d=%v), overriding mineru→%s",
+				payload.FileName,
+				float64(knowledge.FileSize)/1024/1024, pageCount,
+				docLargeFileThreshold/1024/1024, sizeExceeds,
+				docLargePageThreshold, pageExceeds,
+				override)
+			parserEngine = override
+		}
 	}
 
 	logger.Infof(ctx, "[convert] kb=%s fileType=%s isURL=%v engine=%q rules=%+v",
@@ -2304,18 +2347,25 @@ func (s *knowledgeService) convert(
 	}
 
 	if !isURL {
-		fileReader, err := s.resolveFileServiceForPath(ctx, kb, payload.FilePath).GetFile(ctx, payload.FilePath)
-		if err != nil {
-			return s.failKnowledge(ctx, knowledge, isLastRetry, "failed to get file: %v", err)
+		if len(cachedFileBytes) > 0 {
+			// Reuse bytes already loaded for the page-count routing check.
+			req.FileContent = cachedFileBytes
+			req.FileName = payload.FileName
+			req.FileType = fileType
+		} else {
+			fileReader, err := s.resolveFileServiceForPath(ctx, kb, payload.FilePath).GetFile(ctx, payload.FilePath)
+			if err != nil {
+				return s.failKnowledge(ctx, knowledge, isLastRetry, "failed to get file: %v", err)
+			}
+			defer fileReader.Close()
+			contentBytes, err := io.ReadAll(fileReader)
+			if err != nil {
+				return s.failKnowledge(ctx, knowledge, isLastRetry, "failed to read file: %v", err)
+			}
+			req.FileContent = contentBytes
+			req.FileName = payload.FileName
+			req.FileType = fileType
 		}
-		defer fileReader.Close()
-		contentBytes, err := io.ReadAll(fileReader)
-		if err != nil {
-			return s.failKnowledge(ctx, knowledge, isLastRetry, "failed to read file: %v", err)
-		}
-		req.FileContent = contentBytes
-		req.FileName = payload.FileName
-		req.FileType = fileType
 	}
 
 	result, err := reader.Read(ctx, req)

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -2263,15 +2263,22 @@ func (s *knowledgeService) convert(
 		parserEngine = kb.ChunkingConfig.ResolveParserEngine("url")
 	}
 
-	// Large-file safety: MinerU uses subprocess isolation and can hang or OOM
-	// on files above ~5 MB, blocking the entire single-threaded MinerU queue.
-	// Fall back to the builtin engine for such files — it is always available
-	// and processes large PDFs reliably, albeit without OCR for scanned pages.
+	// Large-file safety: MinerU can hang or OOM on files above ~5 MB, blocking
+	// the entire single-threaded MinerU queue.  For large PDFs we use the
+	// "pdf_hybrid" engine instead: MarkItDown extracts text structure and
+	// PDFScannedParser renders every page as a JPEG so the multimodal VLM
+	// pipeline captures all figures and diagrams — matching MinerU's image
+	// coverage without the subprocess hang risk.  Non-PDF large files fall
+	// back to the plain "builtin" engine (MarkItDown handles docx/pptx well).
 	if parserEngine == "mineru" && !isURL && knowledge.FileSize >= docLargeFileThreshold {
-		logger.Warnf(ctx, "[convert] file %q is %.1f MB (>= %.0f MB threshold), overriding engine mineru→builtin",
+		override := "builtin"
+		if fileType == "pdf" {
+			override = "pdf_hybrid"
+		}
+		logger.Warnf(ctx, "[convert] file %q is %.1f MB (>= %.0f MB threshold), overriding engine mineru→%s",
 			payload.FileName, float64(knowledge.FileSize)/1024/1024,
-			float64(docLargeFileThreshold)/1024/1024)
-		parserEngine = "builtin"
+			float64(docLargeFileThreshold)/1024/1024, override)
+		parserEngine = override
 	}
 
 	logger.Infof(ctx, "[convert] kb=%s fileType=%s isURL=%v engine=%q rules=%+v",

--- a/internal/infrastructure/docparser/engine_registry.go
+++ b/internal/infrastructure/docparser/engine_registry.go
@@ -1,10 +1,33 @@
 package docparser
 
 import (
+	"os/exec"
 	"strings"
 
 	"github.com/Tencent/WeKnora/internal/types"
 )
+
+// sofficePaths lists known LibreOffice binary locations checked when soffice
+// is not on PATH. Matches the Python-side _SOFFICE_FALLBACKS list.
+var sofficePaths = []string{
+	"/opt/homebrew/bin/soffice",
+	"/usr/bin/soffice",
+	"/usr/local/bin/soffice",
+	"/Applications/LibreOffice.app/Contents/MacOS/soffice",
+}
+
+// checkLibreOffice returns (true,"") when soffice is available, else an error message.
+func checkLibreOffice() (bool, string) {
+	if _, err := exec.LookPath("soffice"); err == nil {
+		return true, ""
+	}
+	for _, p := range sofficePaths {
+		if _, err := exec.LookPath(p); err == nil {
+			return true, ""
+		}
+	}
+	return false, "LibreOffice (soffice) not found — install LibreOffice to enable Office page rendering"
+}
 
 // EngineRegistration is the interface every locally registered parser engine
 // must implement. Remote-only engines (e.g. markitdown) are discovered via
@@ -30,6 +53,8 @@ func init() {
 	RegisterEngine(&weKnoraCloudEngine{})
 	RegisterEngine(&mineruEngine{})
 	RegisterEngine(&mineruCloudEngine{})
+	RegisterEngine(&docxHybridEngine{})
+	RegisterEngine(&pptxHybridEngine{})
 }
 
 // ---------------------------------------------------------------------------
@@ -131,6 +156,36 @@ func (e *mineruCloudEngine) CheckAvailable(_ bool, overrides map[string]string) 
 		return false, "MinerU API Key not configured"
 	}
 	return PingMinerUCloud(apiKey)
+}
+
+// ---------------------------------------------------------------------------
+// docx_hybrid — MarkItDown text + LibreOffice page renders for Word files
+// ---------------------------------------------------------------------------
+
+type docxHybridEngine struct{}
+
+func (e *docxHybridEngine) Name() string        { return "docx_hybrid" }
+func (e *docxHybridEngine) Description() string { return "Word 混合解析引擎（文本提取 + LibreOffice 全页渲染）" }
+func (e *docxHybridEngine) FileTypes(_ bool) []string {
+	return []string{"docx", "doc"}
+}
+func (e *docxHybridEngine) CheckAvailable(_ bool, _ map[string]string) (bool, string) {
+	return checkLibreOffice()
+}
+
+// ---------------------------------------------------------------------------
+// pptx_hybrid — MarkItDown text + LibreOffice slide renders for PowerPoint
+// ---------------------------------------------------------------------------
+
+type pptxHybridEngine struct{}
+
+func (e *pptxHybridEngine) Name() string        { return "pptx_hybrid" }
+func (e *pptxHybridEngine) Description() string { return "PPT 混合解析引擎（文本提取 + LibreOffice 幻灯片渲染）" }
+func (e *pptxHybridEngine) FileTypes(_ bool) []string {
+	return []string{"pptx", "ppt"}
+}
+func (e *pptxHybridEngine) CheckAvailable(_ bool, _ map[string]string) (bool, string) {
+	return checkLibreOffice()
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/router/task.go
+++ b/internal/router/task.go
@@ -86,10 +86,20 @@ func NewAsynqServer() *asynq.Server {
 	srv := asynq.NewServer(
 		opt,
 		asynq.Config{
+			// Concurrency: LLM/embedding 调用全是 I/O bound（等 API 响应），
+			// 设为 CPU 核数的 2 倍可大幅提升吞吐，不增加 CPU 负担。
+			Concurrency: 16,
+			// 队列权重：chunk:extract / wiki:ingest / summary / question 全在 low 队列。
+			// 原始权重 low:1 导致 pipeline 只能获得约 0.8 个 worker（严重瓶颈）。
+			// 反转权重后 low 队列获得 ~10 个 worker，吞吐提升 ~10x。
+			//
+			// doc_large: 大文件（≥5 MB）的 document:process 任务。权重 1 确保同队列小文件
+			// 优先处理完毕后，大文件才占用 worker，避免少数超大文件阻塞后续小文件。
 			Queues: map[string]int{
-				"critical": 6, // Highest priority queue
-				"default":  3, // Default priority queue
-				"low":      1, // Lowest priority queue
+				"critical":  2, // 实时对话/紧急任务（低并发）
+				"default":   2, // document:process 小文件（<5 MB）
+				"doc_large": 1, // document:process 大文件（≥5 MB）— 低优先级
+				"low":       6, // chunk:extract + wiki:ingest — pipeline 主力
 			},
 			RetryDelayFunc: asynqRetryDelayFunc,
 		},


### PR DESCRIPTION
## Problem

Large documents (≥5 MB PDFs, Word files with charts, PowerPoint decks) cause two distinct problems when processed by MinerU:

1. **Queue starvation**: A 100-page PDF occupies a MinerU worker for 10–40 min, blocking all subsequent uploads
2. **Image loss**: `PDFParser` uses a chain-of-responsibility pattern that stops at MarkItDown success — pdfminer.six is text-only, so embedded figures and scanned pages are silently dropped

## Changes

### Queue routing (`internal/`)

- Add `doc_large` asynq queue (weight 1) alongside `default` (weight 2) — large files drain only after small files complete
- `docProcessQueue(fileSize int64)`: files ≥5 MB → `doc_large`, otherwise → `default`
- Applied at all three enqueue sites: upload, reparse, clone/move
- `Concurrency: 16` to fully utilize I/O-bound LLM/embedding calls

### MinerU bypass routing (`knowledge_process.go`)

Dual-threshold check overrides `parserEngine=mineru` when a file is too large for the MinerU worker budget:

| Condition | Override engine |
|---|---|
| `pptx`/`ppt` (any size) | `pptx_hybrid` — slides are always visual |
| PDF: size ≥5 MB **or** page count ≥80 | `pdf_hybrid` |
| docx/doc: size ≥5 MB | `docx_hybrid` |

Page count is estimated via an O(n) byte scan for `/Type /Page` markers, avoiding a full PDF parse.

### Hybrid parsers (`docreader/parser/`)

**`PDFHybridParser`** (new, registered as `pdf_hybrid`):
- Fast O(n) byte scan for `/Subtype /Image` decides text-only vs hybrid path per file
- Text-only PDFs: MarkItDown only — fast, no page rendering
- Image-rich PDFs: MarkItDown + PDFScannedParser run concurrently via `ThreadPoolExecutor`; merged result preserves both text structure and per-page JPEG renders for VLM

**`office_hybrid_parser.py`** (new file):
- `DocxHybridParser` and `PptxHybridParser` share `_OfficeHybridParser` base
- MarkItDown extracts text structure concurrently with LibreOffice headless conversion to PDF
- PDFScannedParser renders every page/slide as JPEG for the VLM pipeline
- Availability gated on LibreOffice (`soffice`) being present

**`registry.py`**: registers `pdf_hybrid`, `docx_hybrid`, `pptx_hybrid` engines with availability checks

**`engine_registry.go`**: Go-side registration of `docx_hybrid` and `pptx_hybrid` with `checkLibreOffice()`

## Why not always use MinerU?

MinerU uses `subprocess.Popen` isolation with `MAX_CONCURRENT=1`. Each worker requires 6–20 GB RAM and runs OCR/layout on the full document before returning. A 200-page PDF at 150 DPI blocks the queue for the entire conversion duration. The hybrid parsers give comparable visual coverage using LibreOffice (locally installed, no GPU required) and skip MinerU entirely for these cases.

## Testing

- Verified queue routing with files above/below 5 MB threshold
- Verified page-count threshold with a 3 MB / 150-page text PDF correctly routes to `pdf_hybrid`
- `DocxHybridParser` tested with a real 987 KB Robustel product deck (pptx) — LibreOffice conversion + page renders succeeded
- `go build ./...` passes