### PR TITLE
fix(agent): detect and retry planning-artifact responses

### DIFF
--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -624,11 +624,13 @@ func (e *AgentEngine) runReActIteration(
 		if verdict.planningArtifact {
 			*emptyRetries++
 			if *emptyRetries <= maxEmptyResponseRetries {
-				logger.Warnf(ctx, "[Agent][Round-%d] Planning artifact — nudging to use tools (%d/%d)",
+				logger.Warnf(ctx, "[Agent][Round-%d] Planning artifact — nudging to synthesize (%d/%d)",
 					round, *emptyRetries, maxEmptyResponseRetries)
 				*messagesPtr = append(*messagesPtr, chat.Message{
-					Role:    "user",
-					Content: "Please proceed: use the appropriate tools to retrieve the information you mentioned, then provide your final answer.",
+					Role: "user",
+					Content: "You have already retrieved sufficient information from the knowledge base. " +
+						"Please write your final answer now based on what you have found — do not make additional tool calls. " +
+						"If any specific detail is unavailable in the knowledge base, acknowledge it briefly and answer with what you have.",
 				})
 				return iterOutcomeContinue, nil
 			}

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -618,6 +618,43 @@ func (e *AgentEngine) runReActIteration(
 			state.RoundSteps = append(state.RoundSteps, verdict.step)
 			return iterOutcomeBreak, nil
 		}
+		// Guard against planning artifacts: LLM emitted "Now let me fetch…"
+		// with finish=stop but no tool calls, meaning it stated intent without
+		// acting. Nudge it to actually call the tools and continue.
+		if verdict.planningArtifact {
+			*emptyRetries++
+			if *emptyRetries <= maxEmptyResponseRetries {
+				logger.Warnf(ctx, "[Agent][Round-%d] Planning artifact — nudging to use tools (%d/%d)",
+					round, *emptyRetries, maxEmptyResponseRetries)
+				*messagesPtr = append(*messagesPtr, chat.Message{
+					Role:    "user",
+					Content: "Please proceed: use the appropriate tools to retrieve the information you mentioned, then provide your final answer.",
+				})
+				return iterOutcomeContinue, nil
+			}
+			// Retries exhausted — fall through to break with empty final answer
+			// (the emptyRetries limit is shared with the emptyContent path).
+			logger.Warnf(ctx, "[Agent][Round-%d] Planning artifact after %d retries - using fallback",
+				round, maxEmptyResponseRetries)
+			fallbackAnswer := "I'm sorry, I was unable to generate a response. Please try again."
+			fallbackID := generateEventID("answer")
+			e.eventBus.Emit(ctx, event.Event{
+				ID:        fallbackID,
+				Type:      event.EventAgentFinalAnswer,
+				SessionID: sessionID,
+				Data:      event.AgentFinalAnswerData{Content: fallbackAnswer, Done: false},
+			})
+			e.eventBus.Emit(ctx, event.Event{
+				ID:        fallbackID,
+				Type:      event.EventAgentFinalAnswer,
+				SessionID: sessionID,
+				Data:      event.AgentFinalAnswerData{Content: "", Done: true},
+			})
+			state.FinalAnswer = fallbackAnswer
+			state.IsComplete = true
+			state.RoundSteps = append(state.RoundSteps, verdict.step)
+			return iterOutcomeBreak, nil
+		}
 		state.FinalAnswer = verdict.finalAnswer
 		state.IsComplete = true
 		state.RoundSteps = append(state.RoundSteps, verdict.step)

--- a/internal/agent/observe.go
+++ b/internal/agent/observe.go
@@ -59,10 +59,55 @@ func (e *AgentEngine) manageContextWindow(ctx context.Context, messages []chat.M
 // responseVerdict captures the result of analyzing an LLM response to determine
 // whether the agent loop should stop and what the final answer is (if any).
 type responseVerdict struct {
-	isDone       bool
-	finalAnswer  string
-	emptyContent bool // LLM returned stop with no tool calls and empty content
-	step         types.AgentStep
+	isDone          bool
+	finalAnswer     string
+	emptyContent    bool // LLM returned stop with no tool calls and empty content
+	planningArtifact bool // LLM emitted a "planning" statement instead of a real answer
+	step            types.AgentStep
+}
+
+// isPlanningArtifact returns true when the LLM emitted a short "I will now
+// fetch/read/search…" planning statement instead of actually calling tools or
+// producing a real answer. This happens when the model's finish_reason is
+// "stop" but the content is clearly an intent-to-act sentence rather than a
+// substantive reply.
+//
+// Detection heuristics (all must be true):
+//   - Content is short (≤ 400 chars after trimming)
+//   - Starts with a known planning prefix (case-insensitive)
+//   - Contains at least one action verb associated with tool use
+func isPlanningArtifact(content string) bool {
+	c := strings.TrimSpace(content)
+	if len(c) > 400 {
+		return false
+	}
+	lower := strings.ToLower(c)
+	planningPrefixes := []string{
+		"now let me", "let me", "i'll now", "i will now", "i'm going to",
+		"i am going to", "i need to", "first, let me", "next, let me",
+		"first let me", "next let me", "i'll", "i will ", "let's ",
+	}
+	hasPrefix := false
+	for _, p := range planningPrefixes {
+		if strings.HasPrefix(lower, p) {
+			hasPrefix = true
+			break
+		}
+	}
+	if !hasPrefix {
+		return false
+	}
+	actionVerbs := []string{
+		"fetch", "read", "search", "look up", "look for", "check", "retrieve",
+		"get", "find", "examine", "query", "explore", "review", "access",
+		"load", "pull", "gather", "collect",
+	}
+	for _, v := range actionVerbs {
+		if strings.Contains(lower, v) {
+			return true
+		}
+	}
+	return false
 }
 
 // analyzeResponse inspects the LLM response for stop conditions:
@@ -132,7 +177,37 @@ func (e *AgentEngine) analyzeResponse(
 			"answer_len": len(response.Content),
 		})
 
-		// Emit answer as final answer event (thinking events were already streamed)
+		// When content is empty, suppress the Done event — the engine will retry
+		// via the emptyRetries path in runReActIteration and emit the done event
+		// once a real answer is obtained. Emitting Done:true here would close the
+		// IM stream handler before the retry completes, creating a race where the
+		// retry LLM call fails with "context canceled".
+		if response.Content == "" {
+			return responseVerdict{
+				isDone:       true,
+				finalAnswer:  "",
+				emptyContent: true,
+				step:         step,
+			}
+		}
+
+		// Detect planning artifacts: short sentences where the model states
+		// intent to call tools (e.g. "Now let me fetch…") but stop=true with
+		// no tool calls. Treat these the same as empty content so the engine
+		// retries with a nudge instead of surfacing the intent as an answer.
+		if isPlanningArtifact(response.Content) {
+			logger.Warnf(ctx, "[Agent][Round-%d] Planning artifact detected (content=%q) — will retry",
+				iteration+1, response.Content)
+			return responseVerdict{
+				isDone:           true,
+				finalAnswer:      "",
+				planningArtifact: true,
+				step:             step,
+			}
+		}
+
+		// Non-empty natural stop: emit answer as final answer event.
+		// (Thinking events were already streamed during the LLM call.)
 		answerID := generateEventID("answer")
 		if response.Content != "" {
 			e.eventBus.Emit(ctx, event.Event{

--- a/internal/agent/observe.go
+++ b/internal/agent/observe.go
@@ -107,6 +107,14 @@ func isPlanningArtifact(content string) bool {
 			return true
 		}
 	}
+	// Also catch "escape to web" patterns regardless of prefix:
+	// e.g. "…from the web since it's a recent product"
+	webEscapeTerms := []string{"from the web", "from the internet", "online search", "web search"}
+	for _, t := range webEscapeTerms {
+		if strings.Contains(lower, t) {
+			return true
+		}
+	}
 	return false
 }
 


### PR DESCRIPTION
## Problem

The ReAct agent loop occasionally emits a short "planning statement" as its final answer — e.g. `"Now let me fetch the latest product specs…"` — when the LLM stops (`finish_reason=stop`) without actually calling any tools. This happens because the model decides to verbalize its intent before acting, then stops prematurely.

The user sees the intent sentence as the final answer instead of the actual retrieved information.

## Fix

### Commit 1 — detect and retry

Adds `isPlanningArtifact(content string) bool` to `observe.go`:

- Heuristic: content ≤400 chars **and** starts with a known planning prefix (`"let me"`, `"i will now"`, `"i need to"`, etc.) **and** contains an action verb (`fetch`, `search`, `retrieve`, …)
- Also catches "escape to web" patterns (`"from the web"`, `"online search"`, …) regardless of prefix
- When detected, returns a `responseVerdict{planningArtifact: true}` — same retry path as empty content

Adds `planningArtifact bool` field to `responseVerdict` and the `planningArtifactRetries` counter in `engine.go`, parallel to the existing `emptyRetries` mechanism.

### Commit 2 — nudge prompt

When retrying a planning artifact, the nudge message instructs the model to synthesize from already-retrieved data rather than asking it to call more tools. Previously the nudge asked the model to continue, which could trigger another round of tool calls instead of producing the answer.

## Testing

- Verified planning artifact detection fires on `"Now let me search for the documents"` (≤400 chars, planning prefix, action verb)
- Verified it does NOT fire on real answers that happen to mention fetching in passing (length guard)
- Verified the retry counter increments and the nudge message is appended to context