### PR TITLE
fix(llmcontext): When the model does not call the tool, the conversat…

### DIFF
--- a/internal/agent/observe.go
+++ b/internal/agent/observe.go
@@ -90,6 +90,16 @@ func (e *AgentEngine) analyzeResponse(
 		answer := response.Content
 		if answer == "" {
 			answer = "Sorry, this request was blocked by the content safety policy. Please try rephrasing your question."
+		} else {
+			err := e.contextManager.AddMessage(ctx, sessionID, chat.Message{
+				Role:    "assistant",
+				Content: answer,
+			})
+			if err != nil {
+				logger.Warnf(ctx, "[Agent] Failed to add assistant message to context(no tool): %v", err)
+			} else {
+				logger.Debugf(ctx, "[Agent] Added assistant message to context (session: %s,no tool)", e.sessionID)
+			}
 		}
 
 		answerID := generateEventID("answer")
@@ -144,6 +154,15 @@ func (e *AgentEngine) analyzeResponse(
 					Done:    false,
 				},
 			})
+			err := e.contextManager.AddMessage(ctx, sessionID, chat.Message{
+				Role:    "assistant",
+				Content: response.Content,
+			})
+			if err != nil {
+				logger.Warnf(ctx, "[Agent] Failed to add assistant message to context(no tool): %v", err)
+			} else {
+				logger.Debugf(ctx, "[Agent] Added assistant message to context (session: %s,no tool)", e.sessionID)
+			}
 		}
 		e.eventBus.Emit(ctx, event.Event{
 			ID:        answerID,

--- a/internal/agent/tools/sanitize_messages.go
+++ b/internal/agent/tools/sanitize_messages.go
@@ -30,6 +30,9 @@ func SanitizeMessages(messages []chat.Message) []chat.Message {
 			if prev.Role == msg.Role && prev.Role != "tool" {
 				// Merge with previous message
 				result[len(result)-1].Content += "\n\n" + msg.Content
+				if len(result[len(result)-1].ToolCalls) == 0 && len(msg.ToolCalls) > 0 {
+					result[len(result)-1].ToolCalls = msg.ToolCalls
+				}
 				continue
 			}
 		}


### PR DESCRIPTION

# Pull Request

## 描述 (Description)
修复智能推理模式下与大模型对话时，如果大模型没有触发工具调用则大模型返回的结果没有存入上下文中，最终导致智能推理Agent会遗忘历史对话。

## 变更类型 (Type of Change)
<!-- 请选择适用的类型，删除其他选项 -->
- [x] 🐛 Bug 修复 (Bug fix)

## 影响范围 (Scope)
<!-- 请选择受影响的组件，删除其他选项 -->
- [x] 后端 API (Backend API)

## 测试 (Testing)
<!-- 请描述如何测试这些变更 -->
- [x] 手动测试 (Manual testing)
- [x] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 与智能推理Agent进行多轮对话，注意思考中不要出现读取技能或调用工具的情况。
2. 此时去存储对话上下文的存储memory/redis查看。
3. 没有工具调用的对话没有存入上下文中。

## 检查清单 (Checklist)
<!-- 请确保完成以下检查项 -->
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [ ] 代码变更已添加适当的注释
- [ ] 相关文档已更新
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [ ] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
<!-- 如果此 PR 解决了某个 issue，请使用 "Fixes #123" 或 "Closes #123" 的格式 -->
Fixes # 1235

## 截图/录屏 (Screenshots/Recordings)
<!-- 如果是前端 UI 变更，请提供截图或录屏 -->
<img width="580" height="606" alt="image" src="https://github.com/user-attachments/assets/7eed5042-e03c-4448-a455-e958fdea8351" />
<img width="568" height="557" alt="image" src="https://github.com/user-attachments/assets/2c66cb8d-89ea-4ba0-81f5-96fee48986e1" />



## 数据库迁移 (Database Migration)
<!-- 如果涉及数据库变更，请说明 -->
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移
