### PR TITLE
feat(web-search): add SearXNG provider (#1166)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -204,11 +204,25 @@ SYSTEM_AES_KEY=weknora-system-aes-key-32bytes!!
 # SSRF_WHITELIST=internal.service,*.corp.example,172.16.0.0/12,2001:db8::1,fd00::/8
 
 # ===== SearXNG（可选自建网络搜索）=====
-# 启用：docker compose --profile searxng up -d
-# 默认对外端口 8888，容器内主机名 searxng:8080；后端通过 docker network 直接访问。
-# WeKnora 控制台中 Provider 类型选 "SearXNG"，Instance URL 填 http://searxng:8080 即可。
+# 启用：先生成强随机 SEARXNG_SECRET，再 `docker compose --profile searxng up -d`。
+#   openssl rand -hex 32
+# 没有 SEARXNG_SECRET 时 docker compose 会主动报错，避免使用公开默认值。
+#
+# 后端访问方式（容器化部署）：控制台中 Provider 类型选 "SearXNG"，
+# Instance URL 填 http://searxng:8080 ；docker compose 已默认把 `searxng` 主机名
+# 注入 SSRF_WHITELIST_EXTRA，无需额外配置。
+#
+# 本地开发（go run + docker compose -f docker-compose.dev.yml --profile searxng up）：
+# 后端跑在宿主机，需走 published 端口；Instance URL 填 http://127.0.0.1:8888 ，
+# 并把 127.0.0.1 加入下方 SSRF_WHITELIST：
+#   SSRF_WHITELIST=127.0.0.1
+#
+# 端口默认仅监听 127.0.0.1，避免把开了 limiter:false 的实例暴露到 LAN。
+# 如需对内网开放，显式覆盖 SEARXNG_BIND=0.0.0.0 并自行加固。
 # SEARXNG_PORT=8888
-# SEARXNG_SECRET=please-change-me-to-a-long-random-string  # openssl rand -hex 32
+# SEARXNG_BIND=127.0.0.1
+# SEARXNG_SECRET=
+# SSRF_WHITELIST_EXTRA=searxng
 
 # 是否开启知识图谱构建和检索（构建阶段需调用大模型，耗时较长）
 ENABLE_GRAPH_RAG=false

--- a/.env.example
+++ b/.env.example
@@ -204,9 +204,11 @@ SYSTEM_AES_KEY=weknora-system-aes-key-32bytes!!
 # SSRF_WHITELIST=internal.service,*.corp.example,172.16.0.0/12,2001:db8::1,fd00::/8
 
 # ===== SearXNG（可选自建网络搜索）=====
-# 启用：先生成强随机 SEARXNG_SECRET，再 `docker compose --profile searxng up -d`。
-#   openssl rand -hex 32
-# 没有 SEARXNG_SECRET 时 docker compose 会主动报错，避免使用公开默认值。
+# 启用：`docker compose --profile searxng up -d`。
+# SEARXNG_SECRET 不设时使用 docker-compose 中的写死默认值，足够本机/loopback
+# 部署使用；如果改 SEARXNG_BIND=0.0.0.0 把实例暴露到 LAN/公网，请务必用
+# `openssl rand -hex 32` 生成并显式设置 SEARXNG_SECRET，否则默认值会被任何人
+# 用于签名 image-proxy URL。
 #
 # 后端访问方式（容器化部署）：控制台中 Provider 类型选 "SearXNG"，
 # Instance URL 填 http://searxng:8080 ；docker compose 已默认把 `searxng` 主机名

--- a/.env.example
+++ b/.env.example
@@ -203,6 +203,13 @@ SYSTEM_AES_KEY=weknora-system-aes-key-32bytes!!
 # 列入者会在 URL 校验等地方绕过常规 SSRF 规则，生产环境请谨慎配置。
 # SSRF_WHITELIST=internal.service,*.corp.example,172.16.0.0/12,2001:db8::1,fd00::/8
 
+# ===== SearXNG（可选自建网络搜索）=====
+# 启用：docker compose --profile searxng up -d
+# 默认对外端口 8888，容器内主机名 searxng:8080；后端通过 docker network 直接访问。
+# WeKnora 控制台中 Provider 类型选 "SearXNG"，Instance URL 填 http://searxng:8080 即可。
+# SEARXNG_PORT=8888
+# SEARXNG_SECRET=please-change-me-to-a-long-random-string  # openssl rand -hex 32
+
 # 是否开启知识图谱构建和检索（构建阶段需调用大模型，耗时较长）
 ENABLE_GRAPH_RAG=false
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -63,7 +63,8 @@ services:
     environment:
       - SEARXNG_BASE_URL=http://localhost:${SEARXNG_PORT:-8888}/
       - INSTANCE_NAME=weknora-searxng-dev
-      - SEARXNG_SECRET=${SEARXNG_SECRET:?SEARXNG_SECRET must be set (e.g. openssl rand -hex 32) before starting the searxng profile}
+      # See docker-compose.yml for rationale on the default secret.
+      - SEARXNG_SECRET=${SEARXNG_SECRET:-weknora-default-searxng-secret-rotate-before-exposing-publicly}
     cap_drop:
       - ALL
     cap_add:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,17 +35,35 @@ services:
     networks:
       - WeKnora-network-dev
 
+  # See docker-compose.yml searxng-init for rationale (avoid in-place rewrite of
+  # the repo-tracked settings.yml by the searxng entrypoint).
+  searxng-init:
+    image: busybox:1.36
+    container_name: WeKnora-searxng-init-dev
+    command: ["sh", "-c", "cp /template/settings.yml /etc/searxng/settings.yml && chmod 0644 /etc/searxng/settings.yml"]
+    volumes:
+      - ./docker/searxng/settings.yml:/template/settings.yml:ro
+      - searxng_config_dev:/etc/searxng
+    restart: "no"
+    networks:
+      - WeKnora-network-dev
+    profiles:
+      - searxng
+      - full
+
   searxng:
     image: searxng/searxng:latest
     container_name: WeKnora-searxng-dev
+    # Local dev: bind to loopback by default; the host-side WeKnora process
+    # reaches it at http://127.0.0.1:${SEARXNG_PORT}.
     ports:
-      - "${SEARXNG_PORT:-8888}:8080"
+      - "${SEARXNG_BIND:-127.0.0.1}:${SEARXNG_PORT:-8888}:8080"
     volumes:
-      - ./docker/searxng/settings.yml:/etc/searxng/settings.yml:rw
+      - searxng_config_dev:/etc/searxng
     environment:
       - SEARXNG_BASE_URL=http://localhost:${SEARXNG_PORT:-8888}/
       - INSTANCE_NAME=weknora-searxng-dev
-      - SEARXNG_SECRET=${SEARXNG_SECRET:-please-change-me-to-a-long-random-string}
+      - SEARXNG_SECRET=${SEARXNG_SECRET:?SEARXNG_SECRET must be set (e.g. openssl rand -hex 32) before starting the searxng profile}
     cap_drop:
       - ALL
     cap_add:
@@ -53,6 +71,9 @@ services:
       - SETGID
       - SETUID
     restart: unless-stopped
+    depends_on:
+      searxng-init:
+        condition: service_completed_successfully
     networks:
       - WeKnora-network-dev
     profiles:
@@ -445,3 +466,4 @@ volumes:
   langfuse_clickhouse_data_dev:
   langfuse_clickhouse_logs_dev:
   langfuse_minio_data_dev:
+  searxng_config_dev:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,6 +35,30 @@ services:
     networks:
       - WeKnora-network-dev
 
+  searxng:
+    image: searxng/searxng:latest
+    container_name: WeKnora-searxng-dev
+    ports:
+      - "${SEARXNG_PORT:-8888}:8080"
+    volumes:
+      - ./docker/searxng/settings.yml:/etc/searxng/settings.yml:rw
+    environment:
+      - SEARXNG_BASE_URL=http://localhost:${SEARXNG_PORT:-8888}/
+      - INSTANCE_NAME=weknora-searxng-dev
+      - SEARXNG_SECRET=${SEARXNG_SECRET:-please-change-me-to-a-long-random-string}
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETGID
+      - SETUID
+    restart: unless-stopped
+    networks:
+      - WeKnora-network-dev
+    profiles:
+      - searxng
+      - full
+
   minio:
     image: minio/minio:latest
     container_name: WeKnora-minio-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,7 +134,10 @@ services:
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:-password}
       - TENANT_AES_KEY=${TENANT_AES_KEY:-}
       - SYSTEM_AES_KEY=${SYSTEM_AES_KEY:-}
-      - SSRF_WHITELIST=${SSRF_WHITELIST:-searxng}
+      - SSRF_WHITELIST=${SSRF_WHITELIST:-}
+      # Always allow the optional searxng sidecar (compose service hostname);
+      # merged on top of SSRF_WHITELIST so user overrides don't clobber it.
+      - SSRF_WHITELIST_EXTRA=${SSRF_WHITELIST_EXTRA:-searxng}
       - CONCURRENCY_POOL_SIZE=${CONCURRENCY_POOL_SIZE:-5}
       - JWT_SECRET=${JWT_SECRET:-}
       # Crypto: 主密钥和盐值，用于 AppSecret 等敏感字段的 AES-256 加密

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,17 +240,38 @@ services:
     networks:
       - WeKnora-network
 
+  # One-shot init: copy the read-only template settings.yml into a named volume
+  # before searxng starts. Necessary because the searxng entrypoint sed-replaces
+  # `ultrasecretkey` in /etc/searxng/settings.yml in place; bind-mounting the
+  # repo file directly would write the resolved SEARXNG_SECRET back into the
+  # working tree (and prevent re-templating on subsequent restarts).
+  searxng-init:
+    image: busybox:1.36
+    container_name: WeKnora-searxng-init
+    command: ["sh", "-c", "cp /template/settings.yml /etc/searxng/settings.yml && chmod 0644 /etc/searxng/settings.yml"]
+    volumes:
+      - ./docker/searxng/settings.yml:/template/settings.yml:ro
+      - searxng_config:/etc/searxng
+    restart: "no"
+    networks:
+      - WeKnora-network
+    profiles:
+      - searxng
+      - full
+
   searxng:
     image: searxng/searxng:latest
     container_name: WeKnora-searxng
+    # Bind to loopback by default; override SEARXNG_BIND=0.0.0.0 only after
+    # rotating SEARXNG_SECRET and (optionally) re-enabling limiter in settings.yml.
     ports:
-      - "${SEARXNG_PORT:-8888}:8080"
+      - "${SEARXNG_BIND:-127.0.0.1}:${SEARXNG_PORT:-8888}:8080"
     volumes:
-      - ./docker/searxng/settings.yml:/etc/searxng/settings.yml:rw
+      - searxng_config:/etc/searxng
     environment:
       - SEARXNG_BASE_URL=http://localhost:${SEARXNG_PORT:-8888}/
       - INSTANCE_NAME=weknora-searxng
-      - SEARXNG_SECRET=${SEARXNG_SECRET:-please-change-me-to-a-long-random-string}
+      - SEARXNG_SECRET=${SEARXNG_SECRET:?SEARXNG_SECRET must be set (e.g. openssl rand -hex 32) before starting the searxng profile}
     cap_drop:
       - ALL
     cap_add:
@@ -258,6 +279,9 @@ services:
       - SETGID
       - SETUID
     restart: unless-stopped
+    depends_on:
+      searxng-init:
+        condition: service_completed_successfully
     networks:
       - WeKnora-network
     profiles:
@@ -706,3 +730,4 @@ volumes:
   langfuse_clickhouse_data:
   langfuse_clickhouse_logs:
   langfuse_minio_data:
+  searxng_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,7 +134,7 @@ services:
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:-password}
       - TENANT_AES_KEY=${TENANT_AES_KEY:-}
       - SYSTEM_AES_KEY=${SYSTEM_AES_KEY:-}
-      - SSRF_WHITELIST=${SSRF_WHITELIST:-}
+      - SSRF_WHITELIST=${SSRF_WHITELIST:-searxng}
       - CONCURRENCY_POOL_SIZE=${CONCURRENCY_POOL_SIZE:-5}
       - JWT_SECRET=${JWT_SECRET:-}
       # Crypto: 主密钥和盐值，用于 AppSecret 等敏感字段的 AES-256 加密
@@ -236,6 +236,30 @@ services:
     restart: always
     networks:
       - WeKnora-network
+
+  searxng:
+    image: searxng/searxng:latest
+    container_name: WeKnora-searxng
+    ports:
+      - "${SEARXNG_PORT:-8888}:8080"
+    volumes:
+      - ./docker/searxng/settings.yml:/etc/searxng/settings.yml:rw
+    environment:
+      - SEARXNG_BASE_URL=http://localhost:${SEARXNG_PORT:-8888}/
+      - INSTANCE_NAME=weknora-searxng
+      - SEARXNG_SECRET=${SEARXNG_SECRET:-please-change-me-to-a-long-random-string}
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETGID
+      - SETUID
+    restart: unless-stopped
+    networks:
+      - WeKnora-network
+    profiles:
+      - searxng
+      - full
 
   minio:
     image: minio/minio:RELEASE.2025-09-07T16-13-09Z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -271,7 +271,11 @@ services:
     environment:
       - SEARXNG_BASE_URL=http://localhost:${SEARXNG_PORT:-8888}/
       - INSTANCE_NAME=weknora-searxng
-      - SEARXNG_SECRET=${SEARXNG_SECRET:?SEARXNG_SECRET must be set (e.g. openssl rand -hex 32) before starting the searxng profile}
+      # Default value lets `docker compose --profile searxng up` work zero-config.
+      # Override via .env (e.g. `openssl rand -hex 32`) before exposing the
+      # instance beyond the default 127.0.0.1 bind, since secret_key signs
+      # image-proxy URLs and a shared default would be guessable by anyone.
+      - SEARXNG_SECRET=${SEARXNG_SECRET:-weknora-default-searxng-secret-rotate-before-exposing-publicly}
     cap_drop:
       - ALL
     cap_add:

--- a/docker/searxng/settings.yml
+++ b/docker/searxng/settings.yml
@@ -1,0 +1,49 @@
+use_default_settings: true
+
+general:
+  instance_name: "WeKnora SearXNG"
+  privacypolicy_url: false
+  donation_url: false
+  contact_url: false
+  enable_metrics: false
+
+server:
+  # Override via env SEARXNG_SECRET; the entrypoint script substitutes ultrasecretkey.
+  secret_key: "ultrasecretkey"
+  base_url: false
+  image_proxy: true
+  http_protocol_version: "1.0"
+  method: "GET"
+  # Disabled so WeKnora's backend can call /search without IP-based throttling.
+  # Re-enable and add WeKnora's egress IP to a limiter allowlist if you expose
+  # this instance to the public internet.
+  limiter: false
+  public_instance: false
+
+ui:
+  static_use_hash: true
+  default_locale: ""
+  query_in_title: false
+  infinite_scroll: false
+  center_alignment: false
+  theme_args:
+    simple_style: auto
+  search_on_category_select: true
+  hotkeys: default
+
+search:
+  safe_search: 0
+  autocomplete: ""
+  default_lang: "auto"
+  ban_time_on_fail: 5
+  max_ban_time_on_fail: 120
+  formats:
+    - html
+    - json
+
+outgoing:
+  request_timeout: 6.0
+  max_request_timeout: 10.0
+  pool_connections: 100
+  pool_maxsize: 20
+  enable_http2: true

--- a/frontend/src/api/web-search-provider.ts
+++ b/frontend/src/api/web-search-provider.ts
@@ -5,11 +5,12 @@ export interface WebSearchProviderEntity {
   id?: string
   tenant_id?: number
   name: string
-  provider: 'bing' | 'google' | 'duckduckgo' | 'tavily' | 'ollama' | 'baidu'
+  provider: 'bing' | 'google' | 'duckduckgo' | 'tavily' | 'ollama' | 'baidu' | 'searxng'
   description?: string
   parameters: {
     api_key?: string
     engine_id?: string
+    base_url?: string
     proxy_url?: string
     extra_config?: Record<string, string>
   }
@@ -24,6 +25,7 @@ export interface WebSearchProviderTypeInfo {
   name: string
   requires_api_key: boolean
   requires_engine_id?: boolean
+  requires_base_url?: boolean
   supports_proxy?: boolean
   description?: string
   docs_url?: string

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -824,6 +824,8 @@ export default {
     proxyUrlPlaceholder: 'e.g. http://proxy.example.com:3128 (optional; http/https only)',
     proxyUrlHelp: 'Use when outbound access to the search API requires a proxy; leave empty to rely on HTTP_PROXY/HTTPS_PROXY environment variables.',
     apiKeyLabel: 'API Key',
+    baseUrlLabel: 'Instance URL',
+    baseUrlPlaceholder: 'https://searxng.example.com',
     apiKeyDescription: 'Enter the API key for the selected search provider',
     apiKeyPlaceholder: 'Enter API key',
     maxResultsLabel: 'Maximum Results',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -702,6 +702,8 @@ export default {
     proxyUrlPlaceholder: "예: http://127.0.0.1:7890 (선택 사항)",
     proxyUrlHelp: "검색 API 접근에 프록시가 필요한 경우 입력합니다. 비우면 HTTP_PROXY/HTTPS_PROXY를 사용합니다.",
     apiKeyLabel: "API 키",
+    baseUrlLabel: "인스턴스 URL",
+    baseUrlPlaceholder: "https://searxng.example.com",
     apiKeyDescription: "선택한 검색 엔진의 API 키 입력",
     apiKeyPlaceholder: "API 키를 입력하세요",
     maxResultsLabel: "최대 결과 수",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -807,6 +807,8 @@ export default {
     proxyUrlPlaceholder: 'Напр. http://127.0.0.1:7890 (необязательно)',
     proxyUrlHelp: 'Укажите, если доступ к API поиска нужен через прокси; иначе используются переменные HTTP_PROXY/HTTPS_PROXY.',
     apiKeyLabel: 'API-ключ',
+    baseUrlLabel: 'URL экземпляра',
+    baseUrlPlaceholder: 'https://searxng.example.com',
     apiKeyDescription: 'Введите API-ключ выбранного провайдера поиска',
     apiKeyPlaceholder: 'Введите API-ключ',
     maxResultsLabel: 'Максимум результатов',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -701,6 +701,8 @@ export default {
     proxyUrlPlaceholder: "例如 http://proxy.example.com:3128（可选，仅支持 http/https）",
     proxyUrlHelp: "若环境访问搜索 API 需代理，在此填写；留空则使用系统环境变量 HTTP(S)_PROXY。",
     apiKeyLabel: "API 密钥",
+    baseUrlLabel: "实例地址",
+    baseUrlPlaceholder: "https://searxng.example.com",
     apiKeyDescription: "输入所选搜索引擎的 API 密钥",
     apiKeyPlaceholder: "请输入 API 密钥",
     maxResultsLabel: "最大结果数",

--- a/frontend/src/views/settings/WebSearchSettings.vue
+++ b/frontend/src/views/settings/WebSearchSettings.vue
@@ -199,7 +199,10 @@ const selectedProviderType = computed(() => {
 })
 
 const isProviderFree = (providerType: WebSearchProviderTypeInfo) => {
-  return !providerType.requires_api_key && !providerType.requires_engine_id && !providerType.requires_base_url
+  // "Free" here means no upstream-paid credentials are required. Self-hosted
+  // providers (requires_base_url) are still free to use even though they need
+  // an instance URL, so they should keep the free badge.
+  return !providerType.requires_api_key && !providerType.requires_engine_id
 }
 
 const isEntityFree = (entity: WebSearchProviderEntity) => {

--- a/frontend/src/views/settings/WebSearchSettings.vue
+++ b/frontend/src/views/settings/WebSearchSettings.vue
@@ -92,10 +92,10 @@
             </a>
           </div>
 
-          <t-form-item v-if="selectedProviderType?.requires_base_url" label="Instance URL" name="parameters.base_url">
+          <t-form-item v-if="selectedProviderType?.requires_base_url" :label="t('webSearchSettings.baseUrlLabel')" name="parameters.base_url">
             <t-input
               v-model="providerForm.parameters.base_url"
-              placeholder="https://searxng.example.com"
+              :placeholder="t('webSearchSettings.baseUrlPlaceholder')"
             />
           </t-form-item>
           <t-form-item v-if="selectedProviderType?.requires_api_key" :label="t('webSearchSettings.apiKeyLabel')" name="parameters.api_key">

--- a/frontend/src/views/settings/WebSearchSettings.vue
+++ b/frontend/src/views/settings/WebSearchSettings.vue
@@ -82,7 +82,7 @@
           <t-input v-model="providerForm.description" :placeholder="t('webSearchSettings.providerDescPlaceholder')" />
         </t-form-item>
 
-        <template v-if="selectedProviderType?.requires_api_key || selectedProviderType?.requires_engine_id">
+        <template v-if="selectedProviderType?.requires_api_key || selectedProviderType?.requires_engine_id || selectedProviderType?.requires_base_url">
           <div class="form-divider"></div>
 
           <div class="credentials-hint" v-if="selectedProviderType?.docs_url">
@@ -92,6 +92,12 @@
             </a>
           </div>
 
+          <t-form-item v-if="selectedProviderType?.requires_base_url" label="Instance URL" name="parameters.base_url">
+            <t-input
+              v-model="providerForm.parameters.base_url"
+              placeholder="https://searxng.example.com"
+            />
+          </t-form-item>
           <t-form-item v-if="selectedProviderType?.requires_api_key" :label="t('webSearchSettings.apiKeyLabel')" name="parameters.api_key">
             <t-input
               v-model="providerForm.parameters.api_key"
@@ -177,7 +183,7 @@ const providerForm = ref<{
   name: string
   provider: string
   description: string
-  parameters: { api_key?: string; engine_id?: string; proxy_url?: string }
+  parameters: { api_key?: string; engine_id?: string; base_url?: string; proxy_url?: string }
   is_default: boolean
 }>({
   name: '',
@@ -193,7 +199,7 @@ const selectedProviderType = computed(() => {
 })
 
 const isProviderFree = (providerType: WebSearchProviderTypeInfo) => {
-  return !providerType.requires_api_key && !providerType.requires_engine_id
+  return !providerType.requires_api_key && !providerType.requires_engine_id && !providerType.requires_base_url
 }
 
 const isEntityFree = (entity: WebSearchProviderEntity) => {
@@ -246,6 +252,7 @@ const editProvider = (entity: WebSearchProviderEntity) => {
     parameters: {
       api_key: '',
       engine_id: entity.parameters?.engine_id || '',
+      base_url: entity.parameters?.base_url || '',
       proxy_url: entity.parameters?.proxy_url || '',
     },
     is_default: entity.is_default || false,

--- a/internal/application/service/web_search_provider.go
+++ b/internal/application/service/web_search_provider.go
@@ -122,11 +122,8 @@ func validateProviderParameters(provider types.WebSearchProviderType, params typ
 	case types.WebSearchProviderTypeDuckDuckGo:
 		// No API key required
 	case types.WebSearchProviderTypeSearxng:
-		if params.BaseURL == "" {
-			return fmt.Errorf("base_url is required for SearXNG provider")
-		}
-		if err := infra_web_search.ValidateProxyURL(params.BaseURL); err != nil {
-			return fmt.Errorf("invalid SearXNG base_url: %w", err)
+		if err := infra_web_search.ValidateSearxngBaseURL(params.BaseURL); err != nil {
+			return err
 		}
 	}
 	if err := validateOptionalProxyURL(params.ProxyURL); err != nil {

--- a/internal/application/service/web_search_provider.go
+++ b/internal/application/service/web_search_provider.go
@@ -85,7 +85,8 @@ func isValidProviderType(provider types.WebSearchProviderType) bool {
 		types.WebSearchProviderTypeDuckDuckGo,
 		types.WebSearchProviderTypeTavily,
 		types.WebSearchProviderTypeOllama,
-		types.WebSearchProviderTypeBaidu:
+		types.WebSearchProviderTypeBaidu,
+		types.WebSearchProviderTypeSearxng:
 		return true
 	default:
 		return false
@@ -120,6 +121,13 @@ func validateProviderParameters(provider types.WebSearchProviderType, params typ
 		}
 	case types.WebSearchProviderTypeDuckDuckGo:
 		// No API key required
+	case types.WebSearchProviderTypeSearxng:
+		if params.BaseURL == "" {
+			return fmt.Errorf("base_url is required for SearXNG provider")
+		}
+		if err := infra_web_search.ValidateProxyURL(params.BaseURL); err != nil {
+			return fmt.Errorf("invalid SearXNG base_url: %w", err)
+		}
 	}
 	if err := validateOptionalProxyURL(params.ProxyURL); err != nil {
 		return err

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -1244,6 +1244,7 @@ func registerWebSearchProviders(registry *infra_web_search.Registry) {
 	registry.Register("tavily", infra_web_search.NewTavilyProvider)
 	registry.Register("ollama", infra_web_search.NewOllamaProvider)
 	registry.Register("baidu", infra_web_search.NewBaiduProvider)
+	registry.Register("searxng", infra_web_search.NewSearxngProvider)
 }
 
 // registerIMAdapterFactories registers adapter factories for each IM platform

--- a/internal/infrastructure/web_search/searxng.go
+++ b/internal/infrastructure/web_search/searxng.go
@@ -16,7 +16,10 @@ import (
 	"github.com/Tencent/WeKnora/internal/utils"
 )
 
-const defaultSearxngTimeout = 15 * time.Second
+// defaultSearxngTimeout is sized slightly above the SearXNG image's default
+// outgoing.max_request_timeout (10s in docker/searxng/settings.yml) so a slow
+// upstream engine surfaces as a SearXNG-side error instead of a client cancel.
+const defaultSearxngTimeout = 12 * time.Second
 
 // SearxngProvider implements web search using a self-hosted SearXNG instance.
 //
@@ -48,6 +51,9 @@ func ValidateSearxngBaseURL(rawURL string) error {
 	}
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
 		return fmt.Errorf("invalid SearXNG base_url scheme: %s", parsed.Scheme)
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fmt.Errorf("invalid SearXNG base_url: must not contain query or fragment")
 	}
 	if err := utils.ValidateURLForSSRF(base); err != nil {
 		return fmt.Errorf("invalid SearXNG base_url: %w", err)
@@ -163,9 +169,10 @@ func (p *SearxngProvider) Search(
 
 // searxngDateLayouts covers the formats different SearXNG engines emit for
 // publishedDate. Order matters only for performance; first match wins.
+// time.RFC3339 already accepts the nanosecond-precision form, so RFC3339Nano
+// is intentionally omitted.
 var searxngDateLayouts = []string{
 	time.RFC3339,
-	time.RFC3339Nano,
 	"2006-01-02T15:04:05",
 	"2006-01-02 15:04:05",
 	"2006-01-02",
@@ -187,7 +194,6 @@ func parseSearxngDate(s string) (time.Time, bool) {
 }
 
 type searxngResponse struct {
-	Query   string `json:"query"`
 	Results []struct {
 		Title         string `json:"title"`
 		URL           string `json:"url"`

--- a/internal/infrastructure/web_search/searxng.go
+++ b/internal/infrastructure/web_search/searxng.go
@@ -27,13 +27,9 @@ const defaultSearxngTimeout = 12 * time.Second
 // supplied by the tenant via WebSearchProviderParameters.BaseURL. The URL is
 // validated with utils.ValidateURLForSSRF; private/loopback hosts must be added
 // to the SSRF_WHITELIST environment variable.
-//
-// API key is optional and only required when the SearXNG instance enables it
-// (server.secret_key with limiter / json format restrictions).
 type SearxngProvider struct {
 	client  *http.Client
 	baseURL string
-	apiKey  string
 }
 
 // ValidateSearxngBaseURL validates a SearXNG instance URL: must be a non-empty,
@@ -75,7 +71,6 @@ func NewSearxngProvider(params types.WebSearchProviderParameters) (interfaces.We
 	return &SearxngProvider{
 		client:  client,
 		baseURL: strings.TrimRight(base, "/"),
-		apiKey:  strings.TrimSpace(params.APIKey),
 	}, nil
 }
 
@@ -115,11 +110,6 @@ func (p *SearxngProvider) Search(
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", "WeKnora/1.0")
-	if p.apiKey != "" {
-		// SearXNG does not have a built-in auth header; the api_key field is reused
-		// to support reverse-proxies that gate access via Authorization.
-		req.Header.Set("Authorization", "Bearer "+p.apiKey)
-	}
 
 	resp, err := p.client.Do(req)
 	if err != nil {

--- a/internal/infrastructure/web_search/searxng.go
+++ b/internal/infrastructure/web_search/searxng.go
@@ -33,21 +33,33 @@ type SearxngProvider struct {
 	apiKey  string
 }
 
-// NewSearxngProvider builds a SearXNG provider from tenant parameters.
-func NewSearxngProvider(params types.WebSearchProviderParameters) (interfaces.WebSearchProvider, error) {
-	base := strings.TrimSpace(params.BaseURL)
+// ValidateSearxngBaseURL validates a SearXNG instance URL: must be a non-empty,
+// absolute http(s) URL, and must pass the SSRF whitelist check. Shared between
+// the service-layer parameter validation and the provider constructor so that
+// "save" and "use" never disagree.
+func ValidateSearxngBaseURL(rawURL string) error {
+	base := strings.TrimSpace(rawURL)
 	if base == "" {
-		return nil, fmt.Errorf("base_url is required for SearXNG provider")
-	}
-	if err := utils.ValidateURLForSSRF(base); err != nil {
-		return nil, fmt.Errorf("invalid SearXNG base_url: %w", err)
+		return fmt.Errorf("base_url is required for SearXNG provider")
 	}
 	parsed, err := url.Parse(base)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return nil, fmt.Errorf("invalid SearXNG base_url: must be an absolute http(s) URL")
+		return fmt.Errorf("invalid SearXNG base_url: must be an absolute http(s) URL")
 	}
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return nil, fmt.Errorf("invalid SearXNG base_url scheme: %s", parsed.Scheme)
+		return fmt.Errorf("invalid SearXNG base_url scheme: %s", parsed.Scheme)
+	}
+	if err := utils.ValidateURLForSSRF(base); err != nil {
+		return fmt.Errorf("invalid SearXNG base_url: %w", err)
+	}
+	return nil
+}
+
+// NewSearxngProvider builds a SearXNG provider from tenant parameters.
+func NewSearxngProvider(params types.WebSearchProviderParameters) (interfaces.WebSearchProvider, error) {
+	base := strings.TrimSpace(params.BaseURL)
+	if err := ValidateSearxngBaseURL(base); err != nil {
+		return nil, err
 	}
 
 	client, err := NewSearchHTTPClient(defaultSearxngTimeout, params.ProxyURL)
@@ -82,8 +94,11 @@ func (p *SearxngProvider) Search(
 	q := url.Values{}
 	q.Set("q", query)
 	q.Set("format", "json")
-	q.Set("safesearch", "1")
-	q.Set("language", "auto")
+	// Use "all" (SearXNG's documented value for "no language filter") instead
+	// of "auto", which is a UI-side default and not a valid /search parameter.
+	// safesearch is intentionally not set here so the value configured in the
+	// instance's settings.yml is honored.
+	q.Set("language", "all")
 
 	reqURL := p.baseURL + "/search?" + q.Encode()
 	logger.Infof(ctx, "[WebSearch][SearXNG] query=%q maxResults=%d url=%s", query, maxResults, p.baseURL)
@@ -131,14 +146,44 @@ func (p *SearxngProvider) Search(
 			Source:  "searxng",
 		}
 		if includeDate && r.PublishedDate != "" {
-			if t, err := time.Parse(time.RFC3339, r.PublishedDate); err == nil {
+			if t, ok := parseSearxngDate(r.PublishedDate); ok {
 				item.PublishedAt = &t
+			} else {
+				logger.Debugf(ctx, "[WebSearch][SearXNG] unparsable publishedDate=%q", r.PublishedDate)
 			}
 		}
 		results = append(results, item)
 	}
+	if len(results) == 0 && len(data.UnresponsiveEngines) > 0 {
+		logger.Warnf(ctx, "[WebSearch][SearXNG] empty results, unresponsive_engines=%v", data.UnresponsiveEngines)
+	}
 	logger.Infof(ctx, "[WebSearch][SearXNG] returned %d results", len(results))
 	return results, nil
+}
+
+// searxngDateLayouts covers the formats different SearXNG engines emit for
+// publishedDate. Order matters only for performance; first match wins.
+var searxngDateLayouts = []string{
+	time.RFC3339,
+	time.RFC3339Nano,
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04:05",
+	"2006-01-02",
+	time.RFC1123Z,
+	time.RFC1123,
+}
+
+func parseSearxngDate(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range searxngDateLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
 }
 
 type searxngResponse struct {
@@ -149,4 +194,8 @@ type searxngResponse struct {
 		Content       string `json:"content"`
 		PublishedDate string `json:"publishedDate,omitempty"`
 	} `json:"results"`
+	// UnresponsiveEngines is a list of [engine, reason] tuples returned by
+	// SearXNG when one or more upstream engines fail. We surface it on empty
+	// result sets to aid debugging.
+	UnresponsiveEngines [][]string `json:"unresponsive_engines,omitempty"`
 }

--- a/internal/infrastructure/web_search/searxng.go
+++ b/internal/infrastructure/web_search/searxng.go
@@ -1,0 +1,152 @@
+package web_search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/Tencent/WeKnora/internal/utils"
+)
+
+const defaultSearxngTimeout = 15 * time.Second
+
+// SearxngProvider implements web search using a self-hosted SearXNG instance.
+//
+// Unlike commercial providers, SearXNG is self-hosted, so the instance URL is
+// supplied by the tenant via WebSearchProviderParameters.BaseURL. The URL is
+// validated with utils.ValidateURLForSSRF; private/loopback hosts must be added
+// to the SSRF_WHITELIST environment variable.
+//
+// API key is optional and only required when the SearXNG instance enables it
+// (server.secret_key with limiter / json format restrictions).
+type SearxngProvider struct {
+	client  *http.Client
+	baseURL string
+	apiKey  string
+}
+
+// NewSearxngProvider builds a SearXNG provider from tenant parameters.
+func NewSearxngProvider(params types.WebSearchProviderParameters) (interfaces.WebSearchProvider, error) {
+	base := strings.TrimSpace(params.BaseURL)
+	if base == "" {
+		return nil, fmt.Errorf("base_url is required for SearXNG provider")
+	}
+	if err := utils.ValidateURLForSSRF(base); err != nil {
+		return nil, fmt.Errorf("invalid SearXNG base_url: %w", err)
+	}
+	parsed, err := url.Parse(base)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("invalid SearXNG base_url: must be an absolute http(s) URL")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("invalid SearXNG base_url scheme: %s", parsed.Scheme)
+	}
+
+	client, err := NewSearchHTTPClient(defaultSearxngTimeout, params.ProxyURL)
+	if err != nil {
+		return nil, err
+	}
+	return &SearxngProvider{
+		client:  client,
+		baseURL: strings.TrimRight(base, "/"),
+		apiKey:  strings.TrimSpace(params.APIKey),
+	}, nil
+}
+
+// Name returns the provider name.
+func (p *SearxngProvider) Name() string { return "searxng" }
+
+// Search performs a metasearch query against the configured SearXNG instance.
+// SearXNG must have `search.formats: [json]` enabled in settings.yml.
+func (p *SearxngProvider) Search(
+	ctx context.Context,
+	query string,
+	maxResults int,
+	includeDate bool,
+) ([]*types.WebSearchResult, error) {
+	if strings.TrimSpace(query) == "" {
+		return nil, fmt.Errorf("query is empty")
+	}
+	if maxResults <= 0 {
+		maxResults = 5
+	}
+
+	q := url.Values{}
+	q.Set("q", query)
+	q.Set("format", "json")
+	q.Set("safesearch", "1")
+	q.Set("language", "auto")
+
+	reqURL := p.baseURL + "/search?" + q.Encode()
+	logger.Infof(ctx, "[WebSearch][SearXNG] query=%q maxResults=%d url=%s", query, maxResults, p.baseURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "WeKnora/1.0")
+	if p.apiKey != "" {
+		// SearXNG does not have a built-in auth header; the api_key field is reused
+		// to support reverse-proxies that gate access via Authorization.
+		req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("searxng returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var data searxngResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, fmt.Errorf("failed to decode SearXNG response (ensure JSON format is enabled in settings.yml): %w", err)
+	}
+
+	results := make([]*types.WebSearchResult, 0, maxResults)
+	for _, r := range data.Results {
+		if len(results) >= maxResults {
+			break
+		}
+		if r.URL == "" || r.Title == "" {
+			continue
+		}
+		item := &types.WebSearchResult{
+			Title:   r.Title,
+			URL:     r.URL,
+			Snippet: r.Content,
+			Source:  "searxng",
+		}
+		if includeDate && r.PublishedDate != "" {
+			if t, err := time.Parse(time.RFC3339, r.PublishedDate); err == nil {
+				item.PublishedAt = &t
+			}
+		}
+		results = append(results, item)
+	}
+	logger.Infof(ctx, "[WebSearch][SearXNG] returned %d results", len(results))
+	return results, nil
+}
+
+type searxngResponse struct {
+	Query   string `json:"query"`
+	Results []struct {
+		Title         string `json:"title"`
+		URL           string `json:"url"`
+		Content       string `json:"content"`
+		PublishedDate string `json:"publishedDate,omitempty"`
+	} `json:"results"`
+}

--- a/internal/infrastructure/web_search/searxng_test.go
+++ b/internal/infrastructure/web_search/searxng_test.go
@@ -1,0 +1,111 @@
+package web_search
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestValidateSearxngBaseURL(t *testing.T) {
+	os.Setenv("SSRF_WHITELIST", "127.0.0.1,localhost")
+	defer os.Unsetenv("SSRF_WHITELIST")
+
+	cases := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{name: "empty", url: "", wantErr: true},
+		{name: "no scheme", url: "searxng:8080", wantErr: true},
+		{name: "bad scheme", url: "ftp://searxng:8080", wantErr: true},
+		{name: "with query", url: "http://127.0.0.1:8080/?x=1", wantErr: true},
+		{name: "with fragment", url: "http://127.0.0.1:8080/#frag", wantErr: true},
+		{name: "loopback ok via whitelist", url: "http://127.0.0.1:8888", wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateSearxngBaseURL(tc.url)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateSearxngBaseURL(%q) err=%v wantErr=%v", tc.url, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseSearxngDate(t *testing.T) {
+	cases := []struct {
+		in string
+		ok bool
+	}{
+		{"", false},
+		{"2024-05-01", true},
+		{"2024-05-01T12:30:45", true},
+		{"2024-05-01T12:30:45Z", true},
+		{"2024-05-01T12:30:45.123456789Z", true},
+		{"2024-05-01 12:30:45", true},
+		{"Wed, 01 May 2024 12:30:45 GMT", true},
+		{"not-a-date", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			_, ok := parseSearxngDate(tc.in)
+			if ok != tc.ok {
+				t.Fatalf("parseSearxngDate(%q) ok=%v want=%v", tc.in, ok, tc.ok)
+			}
+		})
+	}
+}
+
+func TestSearxngProvider_Search(t *testing.T) {
+	os.Setenv("SSRF_WHITELIST", "127.0.0.1,localhost")
+	defer os.Unsetenv("SSRF_WHITELIST")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("format"); got != "json" {
+			t.Errorf("expected format=json, got %q", got)
+		}
+		if got := r.URL.Query().Get("q"); got != "hello" {
+			t.Errorf("expected q=hello, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"results": []map[string]any{
+				{"title": "T1", "url": "https://e/1", "content": "c1", "publishedDate": "2024-05-01"},
+				{"title": "", "url": "https://e/skip"},
+				{"title": "T2", "url": "https://e/2", "content": "c2"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	provider, err := NewSearxngProvider(types.WebSearchProviderParameters{BaseURL: srv.URL})
+	if err != nil {
+		t.Fatalf("NewSearxngProvider: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	results, err := provider.Search(ctx, "hello", 5, true)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (one skipped), got %d", len(results))
+	}
+	if results[0].PublishedAt == nil {
+		t.Fatalf("expected first result PublishedAt to be set")
+	}
+	if got := results[0].Source; got != "searxng" {
+		t.Fatalf("unexpected source: %q", got)
+	}
+}

--- a/internal/types/web_search_provider.go
+++ b/internal/types/web_search_provider.go
@@ -21,6 +21,7 @@ const (
 	WebSearchProviderTypeTavily     WebSearchProviderType = "tavily"
 	WebSearchProviderTypeOllama     WebSearchProviderType = "ollama"
 	WebSearchProviderTypeBaidu      WebSearchProviderType = "baidu"
+	WebSearchProviderTypeSearxng    WebSearchProviderType = "searxng"
 )
 
 // WebSearchProviderEntity represents a configured web search provider instance for a tenant.
@@ -71,6 +72,9 @@ type WebSearchProviderParameters struct {
 	APIKey string `yaml:"api_key" json:"api_key,omitempty"`
 	// Google Custom Search Engine ID (only for Google provider)
 	EngineID string `yaml:"engine_id" json:"engine_id,omitempty"`
+	// Base URL for self-hosted search engines (e.g. SearXNG instance URL).
+	// Validated with utils.ValidateURLForSSRF; private hosts must be added to SSRF_WHITELIST.
+	BaseURL string `yaml:"base_url" json:"base_url,omitempty"`
 	// Optional HTTP/HTTPS proxy URL for outbound search requests (e.g. http://host:port); validated with utils.ValidateURLForSSRF.
 	// Does not replace the search API endpoint; only tunnels traffic to the official APIs.
 	ProxyURL string `yaml:"proxy_url" json:"proxy_url,omitempty"`
@@ -121,6 +125,8 @@ type WebSearchProviderTypeInfo struct {
 	RequiresAPIKey bool `json:"requires_api_key"`
 	// Whether the provider requires an engine ID (e.g., Google CSE)
 	RequiresEngineID bool `json:"requires_engine_id"`
+	// Whether the provider requires a user-supplied base URL (e.g., self-hosted SearXNG instance)
+	RequiresBaseURL bool `json:"requires_base_url"`
 	// Whether optional proxy_url in parameters is honored for outbound requests
 	SupportsProxy bool `json:"supports_proxy"`
 	// Description
@@ -171,6 +177,15 @@ func GetWebSearchProviderTypes() []WebSearchProviderTypeInfo {
 			RequiresAPIKey: true,
 			Description:    "Ollama Cloud web search (requires Ollama API key)",
 			DocsURL:        "https://docs.ollama.com/capabilities/web-search",
+		},
+		{
+			ID:              "searxng",
+			Name:            "SearXNG",
+			RequiresAPIKey:  false,
+			RequiresBaseURL: true,
+			SupportsProxy:   true,
+			Description:     "Self-hosted SearXNG metasearch instance (provide instance URL; private hosts must be SSRF-whitelisted)",
+			DocsURL:         "https://docs.searxng.org/",
 		},
 		{
 			ID:             "baidu",

--- a/internal/utils/security.go
+++ b/internal/utils/security.go
@@ -880,8 +880,20 @@ func loadSSRFWhitelist() *ssrfWhitelistConfig {
 			exactHosts: make(map[string]bool),
 		}
 		raw := os.Getenv("SSRF_WHITELIST")
-		if raw == "" {
+		// SSRF_WHITELIST_EXTRA is merged in addition to SSRF_WHITELIST so that
+		// deployment-managed defaults (e.g. docker-compose injected sidecar host
+		// names like "searxng") aren't accidentally clobbered when an operator
+		// overrides SSRF_WHITELIST in their .env.
+		extra := os.Getenv("SSRF_WHITELIST_EXTRA")
+		if raw == "" && extra == "" {
 			return
+		}
+		if extra != "" {
+			if raw == "" {
+				raw = extra
+			} else {
+				raw = raw + "," + extra
+			}
 		}
 		for _, entry := range strings.Split(raw, ",") {
 			entry = strings.TrimSpace(entry)

--- a/internal/utils/security_test.go
+++ b/internal/utils/security_test.go
@@ -212,6 +212,43 @@ func TestValidateURLForSSRF_IPv6Whitelist(t *testing.T) {
 	}
 }
 
+// TestSSRFWhitelistExtraMerge verifies that SSRF_WHITELIST_EXTRA is merged
+// into the effective whitelist alongside SSRF_WHITELIST, so deployment-managed
+// defaults (e.g. docker-compose injected sidecar host names) survive when an
+// operator overrides SSRF_WHITELIST in their .env.
+func TestSSRFWhitelistExtraMerge(t *testing.T) {
+	cases := []struct {
+		name    string
+		main    string
+		extra   string
+		host    string
+		want    bool
+	}{
+		{name: "extra only", main: "", extra: "searxng", host: "searxng", want: true},
+		{name: "main only does not match extra host", main: "internal", extra: "", host: "searxng", want: false},
+		{name: "both merged - main host", main: "internal", extra: "searxng", host: "internal", want: true},
+		{name: "both merged - extra host", main: "internal", extra: "searxng", host: "searxng", want: true},
+		{name: "neither matches unrelated host", main: "internal", extra: "searxng", host: "evil.example", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetSSRFWhitelistForTest()
+			os.Setenv("SSRF_WHITELIST", tc.main)
+			os.Setenv("SSRF_WHITELIST_EXTRA", tc.extra)
+			defer func() {
+				os.Unsetenv("SSRF_WHITELIST")
+				os.Unsetenv("SSRF_WHITELIST_EXTRA")
+				resetSSRFWhitelistForTest()
+			}()
+			if got := IsSSRFWhitelisted(tc.host); got != tc.want {
+				t.Fatalf("IsSSRFWhitelisted(%q) main=%q extra=%q = %v, want %v",
+					tc.host, tc.main, tc.extra, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestIsRestrictedIP_IPv6 tests IPv6-specific restricted range detection.
 func TestIsRestrictedIP_IPv6(t *testing.T) {
 	t.Parallel()

--- a/internal/utils/security_test.go
+++ b/internal/utils/security_test.go
@@ -218,11 +218,11 @@ func TestValidateURLForSSRF_IPv6Whitelist(t *testing.T) {
 // operator overrides SSRF_WHITELIST in their .env.
 func TestSSRFWhitelistExtraMerge(t *testing.T) {
 	cases := []struct {
-		name    string
-		main    string
-		extra   string
-		host    string
-		want    bool
+		name  string
+		main  string
+		extra string
+		host  string
+		want  bool
 	}{
 		{name: "extra only", main: "", extra: "searxng", host: "searxng", want: true},
 		{name: "main only does not match extra host", main: "internal", extra: "", host: "searxng", want: false},


### PR DESCRIPTION
## Summary

实现 #1166：新增 SearXNG 网络搜索引擎对接，缓解免费搜索引擎在国内访问受限的问题。

- 后端
  - 新增 `WebSearchProviderTypeSearxng` 与参数字段 `BaseURL`，`WebSearchProviderTypeInfo` 增加 `RequiresBaseURL` 元数据
  - `internal/infrastructure/web_search/searxng.go`：调用 `/search?format=json`，`base_url` 经 `utils.ValidateURLForSSRF` 校验（私网地址需加 `SSRF_WHITELIST`），可选 `api_key` 作为 Bearer 透传给反代鉴权
  - service 参数校验、container DI 注册同步接入
- 前端
  - `WebSearchSettings` 表单根据 `requires_base_url` 动态渲染 Instance URL 输入框
  - API 类型扩展 `searxng` / `base_url` / `requires_base_url`
- Docker
  - `docker-compose.yml` / `docker-compose.dev.yml` 新增可选 `searxng` 服务（`profiles: [searxng, full]`），挂载 `docker/searxng/settings.yml`（启用 JSON 格式、关闭 limiter、关闭遥测）
  - 默认 `SSRF_WHITELIST` 包含 `searxng` 容器名
  - `.env.example` 补充 `SEARXNG_PORT` / `SEARXNG_SECRET` 说明

## Test plan

- [x] `go build ./...` / `go vet ./...` 通过
- [x] `docker compose --profile searxng config` 通过
- [ ] 手动验证：本地起 SearXNG 容器 + WeKnora，控制台创建 Provider 并执行一次 web_search 工具调用

Closes #1166