### PR TITLE
fix(client): correct GetChunkByIDOnly endpoint

### DIFF
--- a/client/chunk.go
+++ b/client/chunk.go
@@ -156,7 +156,7 @@ func (c *Client) DeleteChunk(ctx context.Context, knowledgeID string, chunkID st
 
 // GetChunkByIDOnly retrieves a chunk by its ID without requiring knowledge ID
 func (c *Client) GetChunkByIDOnly(ctx context.Context, chunkID string) (*Chunk, error) {
-	path := fmt.Sprintf("/api/v1/chunks/get-by-id/%s", chunkID)
+	path := fmt.Sprintf("/api/v1/chunks/by-id/%s", chunkID)
 	resp, err := c.doRequest(ctx, http.MethodGet, path, nil, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## 描述 (Description)
本 PR 修复 Go 客户端 `Client.GetChunkByIDOnly` 请求路径错误的问题：将原先请求的 `/api/v1/chunks/get-by-id/{id}` 更正为后端实际提供的 `/api/v1/chunks/by-id/{id}`，避免调用 404/路由不匹配。

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [ ] 📚 文档更新 (Documentation update)
- [ ] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [ ] 🧪 测试相关 (Test related)
- [ ] 🔧 配置变更 (Configuration change)
- [ ] 🐳 Docker 相关 (Docker related)
- [ ] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
- [ ] 后端 API (Backend API)
- [ ] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [ ] 配置文件 (Configuration)
- [x] 其他 (Other): Go Client（`client/chunk.go`）

## 测试 (Testing)
- [ ] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [x] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 使用该 Go client 调用 `GetChunkByIDOnly(ctx, chunkID)`。
2. 确认请求 URL 为 `/api/v1/chunks/by-id/{chunkID}`。
3. 服务端返回 200 且响应体可正常反序列化为 `ChunkResponse`（不再出现因 endpoint 错误导致的 404）。

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [ ] 代码变更已添加适当的注释（本次为 endpoint 字符串修正，无额外注释需求）
- [ ] 相关文档已更新（本次不涉及）
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常（本次未新增自动化测试）
- [ ] 新功能和变更已更新到相关文档（本次不涉及）
- [ ] 破坏性变更已在描述中明确说明（本次不涉及）

## 相关 Issue
Fixes #（如有对应 issue 请补充编号）

## 截图/录屏 (Screenshots/Recordings)
不适用（非前端 UI 变更）

## 数据库迁移 (Database Migration)
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
无

## 部署说明 (Deployment Notes)
无特殊部署要求；更新 client 版本后即可生效。

## 其他信息 (Additional Information)
- 变更点仅涉及 `client/chunk.go` 中 `GetChunkByIDOnly` 的请求路径拼接，行为与后端路由 `/api/v1/chunks/by-id/:id` 对齐。