### PR TITLE
fix(faq): correct PostgreSQL cast precedence in FAQ search

### DIFF
--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -193,14 +193,14 @@ func (r *chunkRepository) ListPagedChunksByKnowledgeID(
 			case "similar_questions":
 				// Search in similar_questions array of metadata
 				if isPostgres {
-					db = db.Where("metadata->'similar_questions'::text ILIKE ?", like)
+					db = db.Where("(metadata->'similar_questions')::text ILIKE ?", like)
 				} else {
 					db = db.Where("JSON_EXTRACT(metadata, '$.similar_questions') LIKE ?", like)
 				}
 			case "answers":
 				// Search in answers array of metadata
 				if isPostgres {
-					db = db.Where("metadata->'answers'::text ILIKE ?", like)
+					db = db.Where("(metadata->'answers')::text ILIKE ?", like)
 				} else {
 					db = db.Where("JSON_EXTRACT(metadata, '$.answers') LIKE ?", like)
 				}


### PR DESCRIPTION
# Pull Request

## 描述 (Description)

修复 PostgreSQL 下 FAQ 列表接口在 `search_field=similar_questions` 或 `search_field=answers` 时返回 `1007 Internal server error` 的问题。

根因：`metadata->'similar_questions'::text` 因为 `::` 优先级高于 `->`，被解析为 `metadata -> ('similar_questions'::text)`，结果是 jsonb 而非 text。对 jsonb 做 ILIKE 直接报：

```
ERROR: operator does not exist: jsonb ~~* unknown
```

被 GORM 透传到 `ErrorHandler` middleware 包装成 1007。

修法：把 cast 套到 json 取值结果之外，`(metadata->'similar_questions')::text ILIKE ?`，对 answers 分支做同样修正。MySQL 分支使用 `JSON_EXTRACT`，本来就没问题，未改动；`standard_question` 分支使用 `->>` 取 text，也未受影响。

## 变更类型 (Type of Change)
- [x] 🐛 Bug 修复 (Bug fix)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)

仅影响 `GET /knowledge-bases/:id/faq/entries` 在 PostgreSQL 数据库下 `search_field=similar_questions` 与 `search_field=answers` 两个分支。

## 测试 (Testing)
- [x] 手动测试 (Manual testing)
- [x] API 测试 (API testing)

未新增自动化测试：仓库现有测试基础设施未覆盖 `ListPagedChunksByKnowledgeID` 在 PG 上的查询行为（这也是该 bug 自 2025-12-24 引入以来未被发现的原因）。补该层的集成测试需要在 CI 中拉起 PG 容器，超出本次修复范围。

### 测试步骤 (Test Steps)

在 `paradedb/paradedb:v0.22.2-pg17`（与 WeKnora 默认 PG 部署一致）上复现并验证：

1. 复现原 bug，原 SQL 直接报错：
   ```sql
   SELECT id FROM chunks
   WHERE metadata->'similar_questions'::text ILIKE '%胶凝材料试验方案有哪些%';
   -- ERROR: operator does not exist: jsonb ~~* unknown
   ```

2. 修后 SQL 正常返回并命中预期记录：
   ```sql
   SELECT id FROM chunks
   WHERE (metadata->'similar_questions')::text ILIKE '%胶凝材料试验方案有哪些%';
   --  id
   -- ----
   --   1
   ```

3. 类型校验确认算符解析：
   ```sql
   SELECT pg_typeof(metadata->'similar_questions'::text)   FROM chunks LIMIT 1; -- jsonb
   SELECT pg_typeof((metadata->'similar_questions')::text) FROM chunks LIMIT 1; -- text
   ```

4. 回归：`search_field=standard_question`、`search_field=`(default 全字段) 路径均未受影响，行为不变。

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [x] 代码变更已添加适当的注释（保留原有注释，无需新增）
- [ ] 相关文档已更新（文档无需变更，API 行为对外保持不变，仅修正实现）
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常（见上文「测试」一节说明）
- [ ] 新功能和变更已更新到相关文档（非新功能）
- [ ] 破坏性变更已在描述中明确说明（非破坏性变更）

## 相关 Issue
Fixes #1264

## 截图/录屏 (Screenshots/Recordings)
N/A（后端修复）

## 数据库迁移 (Database Migration)
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
无。

## 部署说明 (Deployment Notes)
无特殊要求，常规部署即可生效。

## 其他信息 (Additional Information)

该 bug 由 commit `1c103310`（2025-12-24，"feat: 增强FAQ搜索功能，支持指定搜索字段"）引入，已存在于 0.5.1 发布版本中。