### PR TITLE
fix(agent): replay attachments in multi-turn history

### DIFF
--- a/internal/application/service/agent_history.go
+++ b/internal/application/service/agent_history.go
@@ -127,8 +127,17 @@ func buildUserHistoryMessage(m *types.Message) chat.Message {
 	if content == "" {
 		content = m.Content
 	}
-	if captions := extractImageCaptionsFromMessage(m.Images); captions != "" && m.RenderedContent == "" {
-		content += "\n\n[用户上传图片内容]\n" + captions
+	// Only append fallbacks when RenderedContent is absent — when present, it
+	// already carries the augmented version persisted by the original turn.
+	// Agent-mode turns currently do not persist RenderedContent, so attachments
+	// and image captions would otherwise be invisible to subsequent rounds.
+	if m.RenderedContent == "" {
+		if captions := extractImageCaptionsFromMessage(m.Images); captions != "" {
+			content += "\n\n[用户上传图片内容]\n" + captions
+		}
+		if len(m.Attachments) > 0 {
+			content += m.Attachments.BuildPrompt()
+		}
 	}
 	return chat.Message{Role: "user", Content: content}
 }

--- a/internal/application/service/agent_history_test.go
+++ b/internal/application/service/agent_history_test.go
@@ -42,6 +42,48 @@ func TestBuildUserHistoryMessage_FallsBackToContentWithCaptions(t *testing.T) {
 	assert.Equal(t, "look at this\n\n[用户上传图片内容]\na bar chart\na pie chart", got.Content)
 }
 
+// TestBuildUserHistoryMessage_AppendsAttachmentsWhenNoRenderedContent covers
+// the Agent-mode multi-turn path: AgentQA does not persist RenderedContent, so
+// the next turn's history must reconstruct the original attachment prompt from
+// the stored Attachments column. Otherwise, follow-up questions like "what is
+// in there?" lose all reference to the uploaded file.
+func TestBuildUserHistoryMessage_AppendsAttachmentsWhenNoRenderedContent(t *testing.T) {
+	msg := &types.Message{
+		Role:    "user",
+		Content: "summarize this",
+		Attachments: types.MessageAttachments{
+			{
+				FileName: "report.pdf",
+				FileType: ".pdf",
+				FileSize: 2048,
+				Content:  "hello world",
+			},
+		},
+	}
+	got := buildUserHistoryMessage(msg)
+	assert.Equal(t, "user", got.Role)
+	assert.Contains(t, got.Content, "summarize this")
+	assert.Contains(t, got.Content, `<attachment index="1" name="report.pdf">`)
+	assert.Contains(t, got.Content, "hello world")
+}
+
+// TestBuildUserHistoryMessage_RenderedContentSkipsAttachmentReplay ensures the
+// KnowledgeQA path (where RenderedContent already includes the attachment
+// prompt persisted by the pipeline) does not double-inject attachments.
+func TestBuildUserHistoryMessage_RenderedContentSkipsAttachmentReplay(t *testing.T) {
+	msg := &types.Message{
+		Role:            "user",
+		Content:         "summarize this",
+		RenderedContent: "summarize this [with retrieval context already included]",
+		Attachments: types.MessageAttachments{
+			{FileName: "report.pdf", FileType: ".pdf", Content: "hello"},
+		},
+	}
+	got := buildUserHistoryMessage(msg)
+	assert.Equal(t, "summarize this [with retrieval context already included]", got.Content)
+	assert.NotContains(t, got.Content, "<attachment")
+}
+
 // TestBuildAssistantHistoryMessages_NaturalFinishEmitsSingleAnswer covers the
 // most common path: a turn with no tool calls (model answered directly). The
 // result must be a single assistant message holding the canonical answer —


### PR DESCRIPTION
## Summary

Agent mode does not persist `rendered_content` for user messages, so when the next turn's history was rebuilt from DB, attachments uploaded in prior turns disappeared. The model only saw the raw user query plus the prior assistant reply, breaking follow-up questions that referenced the file (e.g. "这里面是啥" / "what is in there?").

`#1237` / `#1175` fixed the first-turn visibility by appending `req.Attachments.BuildPrompt()` to `agentQuery` inside `AgentQA`, but did not address multi-turn replay — the augmented content is never written back to the user message, and `buildUserHistoryMessage` only looked at `RenderedContent` / `Content` / image captions.

### Fix

In `buildUserHistoryMessage`, when `RenderedContent` is empty, reconstruct the attachment prompt from the stored `Attachments` column using the same `MessageAttachments.BuildPrompt()` helper. KnowledgeQA turns (which do persist `RenderedContent` via `persistRenderedContent`) are unaffected and won't get attachments injected twice.

### Why not write back `RenderedContent` in `AgentQA`?

That would require plumbing `UserMessageID` into `AgentQA` and adding an async DB write, mirroring the chat pipeline. The history-layer fix is strictly smaller, keeps the DB schema and call graph untouched, and produces an identical LLM-visible prompt.

## Test plan

- [x] New unit test `TestBuildUserHistoryMessage_AppendsAttachmentsWhenNoRenderedContent` covers the Agent multi-turn path
- [x] New unit test `TestBuildUserHistoryMessage_RenderedContentSkipsAttachmentReplay` guards against double injection on the KnowledgeQA path
- [x] Existing `TestBuildUserHistoryMessage_*` tests still pass
- [ ] Manual: upload a file in turn 1 of an Agent-mode session, ask a follow-up referencing the file in turn 2, verify the model sees attachment metadata + content

Refs #1237