### PR TITLE
fix(agent): relax rerank model requirement for custom agents

### DIFF
--- a/frontend/src/components/Input-field.vue
+++ b/frontend/src/components/Input-field.vue
@@ -1875,14 +1875,11 @@ const getCustomAgentNotReadyReasons = (agent: CustomAgent): string[] => {
   if (!config.model_id || config.model_id.trim() === '') {
     reasons.push(t('input.customAgentMissingSummaryModel'))
   }
-  // 检查重排模型（Rerank Model）- 仅当允许使用 knowledge_search 工具时需要
-  const hasKnowledgeSearchTool = config.allowed_tools && config.allowed_tools.includes('knowledge_search')
-  if (hasKnowledgeSearchTool) {
-    if (!config.rerank_model_id || config.rerank_model_id.trim() === '') {
-      reasons.push(t('input.customAgentMissingRerankModel'))
-    }
-  }
-  
+  // Rerank 模型不在此处强制校验：当 knowledge_search 实际命中 RAG 知识库时，
+  // 后端会优先使用 agent.rerank_model_id，未配置则回退到租户默认 rerank 模型；
+  // 仅在两者都缺失时由后端报错。这样可以避免"作用域内无 RAG KB 却被拦"的误报，
+  // 并支持后续添加 RAG KB 时的自动兜底。
+
   return reasons
 }
 

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -509,6 +509,7 @@ export default {
       rerankModel: 'ReRank Model',
       rerankModelDesc: 'Used to rerank knowledge base retrieval results for better accuracy',
       rerankModelPlaceholder: 'Select ReRank Model',
+      rerankModelOptionalHint: 'No RAG knowledge base in current scope, so this is optional. If a RAG knowledge base is added later, the tenant default rerank model will be used as a fallback. Configuring it explicitly is still recommended.',
       maxIterations: 'Max Iterations',
       allowedTools: 'Allowed Tools',
       multiTurn: 'Multi-turn Conversation',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -1398,6 +1398,7 @@ export default {
       rerankModel: "리랭크 모델",
       rerankModelDesc: "지식베이스 검색 결과를 재정렬하여 답변 정확도를 높입니다",
       rerankModelPlaceholder: "ReRank 모델을 선택하세요.",
+      rerankModelOptionalHint: "현재 범위에 RAG 유형의 지식베이스가 없으므로 선택 사항입니다. 이후 RAG 지식베이스가 추가되면 테넌트 기본 ReRank 모델로 자동 폴백되지만, 명시적으로 설정하는 것을 권장합니다.",
       maxIterations: "최대 반복 횟수",
       allowedTools: "허용된 도구",
       multiTurn: "여러 라운드의 대화",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -416,6 +416,7 @@ export default {
       rerankModel: 'ReRank Model',
       rerankModelDesc: 'Used to rerank knowledge base retrieval results for better accuracy',
       rerankModelPlaceholder: 'Select ReRank Model',
+      rerankModelOptionalHint: 'В текущей области нет RAG-базы знаний, поэтому поле необязательное. Если RAG-база будет добавлена позже, будет использоваться модель ReRank по умолчанию для тенанта; всё же рекомендуется настроить её явно.',
       maxIterations: 'Max Iterations',
       allowedTools: 'Allowed Tools',
       multiTurn: 'Multi-turn Conversation',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1385,6 +1385,7 @@ export default {
       rerankModel: "ReRank 模型",
       rerankModelDesc: "用于对知识库检索结果进行重排序，提高回答准确性",
       rerankModelPlaceholder: "请选择 ReRank 模型",
+      rerankModelOptionalHint: "当前作用域内暂无 RAG 类型知识库，可不填；后续若加入 RAG 知识库，将自动使用租户默认重排模型，仍建议显式配置。",
       maxIterations: "最大迭代次数",
       allowedTools: "允许的工具",
       multiTurn: "多轮对话",

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -988,11 +988,20 @@
                       </div>
                     </div>
 
-                    <!-- ReRank 模型（当配置了知识库时显示） -->
-                    <div v-if="needsRerankModel" class="setting-row">
+                    <!-- ReRank 模型（关联知识库时常驻显示，仅在作用域内存在 RAG 类型 KB 时必填） -->
+                    <div v-if="hasKnowledgeBase" class="setting-row">
                       <div class="setting-info">
-                        <label>{{ $t('agent.editor.rerankModel') }} <span class="required">*</span></label>
-                        <p class="desc">{{ $t('agent.editor.rerankModelDesc') }}</p>
+                        <label>
+                          {{ $t('agent.editor.rerankModel') }}
+                          <span v-if="needsRerankModel" class="required">*</span>
+                        </label>
+                        <p class="desc">
+                          {{ $t('agent.editor.rerankModelDesc') }}
+                          <template v-if="!needsRerankModel">
+                            <br />
+                            <span class="hint">{{ $t('agent.editor.rerankModelOptionalHint') }}</span>
+                          </template>
+                        </p>
                       </div>
                       <div class="setting-control">
                         <ModelSelector
@@ -1202,8 +1211,8 @@
                       </div>
                     </div>
 
-                    <!-- 重排TopK -->
-                    <div class="setting-row">
+                    <!-- 重排TopK（仅在配置了 Rerank 模型时展示） -->
+                    <div v-if="formData.config.rerank_model_id" class="setting-row">
                       <div class="setting-info">
                         <label>{{ $t('agent.editor.rerankTopK') }}</label>
                         <p class="desc">{{ $t('agentEditor.desc.rerankTopK') }}</p>
@@ -1213,8 +1222,8 @@
                       </div>
                     </div>
 
-                    <!-- 重排阈值 -->
-                    <div class="setting-row">
+                    <!-- 重排阈值（仅在配置了 Rerank 模型时展示） -->
+                    <div v-if="formData.config.rerank_model_id" class="setting-row">
                       <div class="setting-info">
                         <label>{{ $t('agent.editor.rerankThreshold') }}</label>
                         <p class="desc">{{ $t('agentEditor.desc.rerankThreshold') }}</p>
@@ -3826,6 +3835,10 @@ const handleSave = async () => {
     color: var(--td-text-color-secondary);
     margin: 0;
     line-height: 1.5;
+
+    .hint {
+      color: var(--td-warning-color, var(--td-text-color-placeholder));
+    }
   }
 }
 

--- a/internal/application/service/session_agent_qa.go
+++ b/internal/application/service/session_agent_qa.go
@@ -100,10 +100,21 @@ func (s *sessionService) AgentQA(
 	}
 
 	if hasKnowledgeSearchTool {
+		// Resolve rerank model: agent-level first, then fall back to tenant default
+		// (ConversationConfig.RerankModelID). This lets users leave rerank empty when
+		// their KB scope currently has no RAG-type KB, while still working correctly
+		// if a RAG-type KB is added later.
 		rerankModelID := req.CustomAgent.Config.RerankModelID
+		if rerankModelID == "" && tenantInfo != nil && tenantInfo.ConversationConfig != nil {
+			rerankModelID = tenantInfo.ConversationConfig.RerankModelID
+			if rerankModelID != "" {
+				logger.Infof(ctx, "Custom agent %s has no rerank model; falling back to tenant default rerank model %s",
+					req.CustomAgent.ID, rerankModelID)
+			}
+		}
 		if rerankModelID == "" {
-			logger.Warnf(ctx, "No rerank model configured for custom agent %s, but knowledge_search tool is enabled", req.CustomAgent.ID)
-			return errors.New("rerank model (rerank_model_id) is not configured in custom agent settings")
+			logger.Warnf(ctx, "No rerank model configured for custom agent %s (and no tenant default), but knowledge_search tool is enabled", req.CustomAgent.ID)
+			return errors.New("rerank model is not configured: please set rerank_model_id on the agent or configure a tenant default rerank model")
 		}
 
 		rerankModel, err = s.modelService.GetRerankModel(ctx, rerankModelID)


### PR DESCRIPTION
## Summary

- Custom agent editor used to hide the rerank model field when no RAG-type knowledge base existed in scope, while the not-ready check and runtime kept hard-failing whenever `knowledge_search` was in `allowed_tools`. Users with wiki-only or empty KB scopes saw an unresolvable "Rerank Model required" warning, and `All knowledge bases` agents would silently break once any RAG-type KB was added later.
- Backend now falls back to the tenant default rerank model (`ConversationConfig.RerankModelID`) before erroring out, matching the built-in agent behaviour. The editor keeps the rerank field always visible (when a KB scope is selected) and only marks it required when the scope actually contains a RAG KB, with a hint about the tenant-default fallback.
- The eager "missing rerank" not-ready reason on the input field is removed; the backend is now the single source of truth for rerank availability. `rerank_top_k` / `rerank_threshold` sliders are only rendered when a rerank model is actually selected.

## Changes

- `internal/application/service/session_agent_qa.go`: resolve rerank as agent → tenant default → error.
- `frontend/src/views/agent/AgentEditorModal.vue`: rerank field always visible with KB scope; required `*` only when scope has a RAG KB; sliders gated on `rerank_model_id`; new optional hint.
- `frontend/src/components/Input-field.vue`: drop the rerank check from `getCustomAgentNotReadyReasons`.
- `frontend/src/i18n/locales/{zh-CN,en-US,ko-KR,ru-RU}.ts`: add `agent.editor.rerankModelOptionalHint`.

## Test plan

- [ ] Create a custom agent with `knowledge_search` allowed and KB scope = "All", in a tenant with no RAG-type KB and no tenant-default rerank → editor lets you save with empty rerank, and the agent does not show "Not Ready" in the chat input.
- [ ] Same agent, then add a RAG-type KB and configure a tenant-default rerank model → asking a question runs successfully using the tenant default rerank.
- [ ] Same agent, no tenant-default rerank, then add a RAG-type KB → runtime returns a clear error pointing to either the agent rerank or tenant default.
- [ ] Custom agent with KB scope = "Selected" containing a RAG KB and rerank empty → editor blocks save with the existing required-field error (red `*`).
- [ ] Editor: switching `knowledge_bases` between RAG / non-RAG selections toggles the required `*` and the optional hint correctly; `rerank_top_k` / `rerank_threshold` only render after picking a rerank model.