### PR TITLE
fix(feishu): tolerate per-subtree failures during wiki sync

### DIFF
--- a/internal/datasource/connector/feishu/client.go
+++ b/internal/datasource/connector/feishu/client.go
@@ -227,41 +227,61 @@ func (c *Client) ListWikiNodes(ctx context.Context, spaceID string, parentNodeTo
 	return allNodes, nil
 }
 
+// FailedWikiNode captures a node whose children could not be listed during
+// recursive walk. Returned alongside successful nodes so callers can record
+// failures (e.g. in items_failed / last_sync_log) without aborting the sync.
+type FailedWikiNode struct {
+	SpaceID   string
+	NodeToken string
+	Title     string
+	Err       error
+}
+
 // ListAllWikiNodesRecursive recursively lists all nodes under a wiki space.
 // It walks the tree depth-first to discover all nested documents.
-func (c *Client) ListAllWikiNodesRecursive(ctx context.Context, spaceID string) ([]wikiNode, error) {
-	// Start with top-level nodes
+//
+// Partial-failure semantics (issue #1262): when listing children of a single
+// node fails (typical cause: transient Feishu 5xx, code=1663), the failure is
+// collected into failed and the walk continues with sibling nodes. Only a
+// failure of the top-level ListWikiNodes call returns a hard error, since
+// without any nodes there is nothing to sync.
+func (c *Client) ListAllWikiNodesRecursive(ctx context.Context, spaceID string) (nodes []wikiNode, failed []FailedWikiNode, err error) {
+	// Start with top-level nodes — a failure here is fatal: we have nothing.
 	topNodes, err := c.ListWikiNodes(ctx, spaceID, "")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var allNodes []wikiNode
-	var walk func(nodes []wikiNode) error
+	var failures []FailedWikiNode
+	var walk func(parent []wikiNode)
 
-	walk = func(nodes []wikiNode) error {
-		for _, node := range nodes {
+	walk = func(parent []wikiNode) {
+		for _, node := range parent {
 			allNodes = append(allNodes, node)
 
-			// Recurse into child nodes if this node has children
-			if node.HasChild {
-				children, err := c.ListWikiNodes(ctx, spaceID, node.NodeToken)
-				if err != nil {
-					return fmt.Errorf("list children of %s: %w", node.NodeToken, err)
-				}
-				if err := walk(children); err != nil {
-					return err
-				}
+			if !node.HasChild {
+				continue
 			}
+			children, childErr := c.ListWikiNodes(ctx, spaceID, node.NodeToken)
+			if childErr != nil {
+				logger.Warnf(ctx,
+					"[Feishu] list children of %s (%q) failed, skipping subtree: %v",
+					node.NodeToken, node.Title, childErr)
+				failures = append(failures, FailedWikiNode{
+					SpaceID:   spaceID,
+					NodeToken: node.NodeToken,
+					Title:     node.Title,
+					Err:       fmt.Errorf("list children of %s: %w", node.NodeToken, childErr),
+				})
+				continue
+			}
+			walk(children)
 		}
-		return nil
 	}
 
-	if err := walk(topNodes); err != nil {
-		return nil, err
-	}
-
-	return allNodes, nil
+	walk(topNodes)
+	return allNodes, failures, nil
 }
 
 // GetDocumentRawContent retrieves the raw text content of a Feishu docx document.

--- a/internal/datasource/connector/feishu/connector.go
+++ b/internal/datasource/connector/feishu/connector.go
@@ -82,10 +82,26 @@ func (c *Connector) FetchAll(ctx context.Context, config *types.DataSourceConfig
 	var allItems []types.FetchedItem
 
 	for _, spaceID := range resourceIDs {
-		// List all nodes in this wiki space recursively
-		nodes, err := client.ListAllWikiNodesRecursive(ctx, spaceID)
+		// List all nodes in this wiki space recursively. A failure on the
+		// top-level listing is fatal (we have nothing to sync from this
+		// space); per-subtree failures are reported via failedNodes and the
+		// walk continues with siblings (issue #1262).
+		nodes, failedNodes, err := client.ListAllWikiNodesRecursive(ctx, spaceID)
 		if err != nil {
 			return nil, fmt.Errorf("list nodes in space %s: %w", spaceID, err)
+		}
+
+		// Record subtree-listing failures so they surface in last_sync_log
+		// instead of aborting the whole run.
+		for _, f := range failedNodes {
+			allItems = append(allItems, types.FetchedItem{
+				ExternalID:       f.NodeToken,
+				Title:            f.Title,
+				SourceResourceID: spaceID,
+				Metadata: map[string]string{
+					"error": f.Err.Error(),
+				},
+			})
 		}
 
 		// Fetch content for each document node
@@ -144,13 +160,43 @@ func (c *Connector) FetchIncremental(ctx context.Context, config *types.DataSour
 	}
 
 	for _, spaceID := range resourceIDs {
-		// List all nodes in this space
-		nodes, err := client.ListAllWikiNodesRecursive(ctx, spaceID)
+		// List all nodes in this space. Per-subtree listing failures are
+		// returned via failedNodes so we can record them without aborting
+		// the sync (issue #1262).
+		nodes, failedNodes, err := client.ListAllWikiNodesRecursive(ctx, spaceID)
 		if err != nil {
 			return nil, nil, fmt.Errorf("list nodes in space %s: %w", spaceID, err)
 		}
 
 		newCursor.SpaceNodeTimes[spaceID] = make(map[string]string)
+
+		// Record subtree-listing failures so they appear in last_sync_log
+		// and can be retried on the next incremental run.
+		for _, f := range failedNodes {
+			changedItems = append(changedItems, types.FetchedItem{
+				ExternalID:       f.NodeToken,
+				Title:            f.Title,
+				SourceResourceID: spaceID,
+				Metadata: map[string]string{
+					"error": f.Err.Error(),
+				},
+			})
+		}
+
+		// When the node listing is incomplete, suppress deletion detection
+		// and preserve the prior cursor entries for this space. Otherwise an
+		// unreachable subtree would be misclassified as "deleted" and the
+		// next run would have no record to retry from.
+		partialListing := len(failedNodes) > 0
+		if partialListing {
+			if prevCursor.SpaceNodeTimes != nil {
+				if prev, ok := prevCursor.SpaceNodeTimes[spaceID]; ok {
+					for token, t := range prev {
+						newCursor.SpaceNodeTimes[spaceID][token] = t
+					}
+				}
+			}
+		}
 
 		// Build a set of current node tokens for deletion detection
 		currentNodes := make(map[string]bool)
@@ -196,8 +242,9 @@ func (c *Connector) FetchIncremental(ctx context.Context, config *types.DataSour
 			}
 		}
 
-		// Detect deleted nodes
-		if prevCursor.SpaceNodeTimes != nil {
+		// Detect deleted nodes — skipped when the listing was incomplete,
+		// otherwise unreachable subtrees would be wrongly marked as deleted.
+		if !partialListing && prevCursor.SpaceNodeTimes != nil {
 			if prevTimes, ok := prevCursor.SpaceNodeTimes[spaceID]; ok {
 				for nodeToken := range prevTimes {
 					if !currentNodes[nodeToken] {

--- a/internal/datasource/connector/feishu/connector_test.go
+++ b/internal/datasource/connector/feishu/connector_test.go
@@ -832,3 +832,119 @@ func TestFeishuCursorRoundTrip(t *testing.T) {
 		t.Errorf("restored nt2 = %q, want 200", restored.SpaceNodeTimes["space1"]["nt2"])
 	}
 }
+
+// ──────────────────────────────────────────────────────────────────────
+// Partial-failure semantics for recursive wiki node listing (issue #1262)
+// ──────────────────────────────────────────────────────────────────────
+
+// fakeFeishuWithChildFailure builds a server whose top-level wiki listing
+// returns two nodes (parent_ok, parent_bad), both with HasChild=true.
+// Listing children of parent_ok succeeds with one leaf; listing children of
+// parent_bad returns HTTP 500 to emulate the failure mode in issue #1262.
+func fakeFeishuWithChildFailure() (*httptest.Server, *Config) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/open-apis/auth/v3/tenant_access_token/internal", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, tokenResponse{
+			apiResponse:       apiResponse{Code: 0},
+			TenantAccessToken: "fake-token",
+			Expire:            7200,
+		})
+	})
+
+	mux.HandleFunc("/open-apis/wiki/v2/spaces/space1/nodes", func(w http.ResponseWriter, r *http.Request) {
+		parent := r.URL.Query().Get("parent_node_token")
+		switch parent {
+		case "":
+			writeJSON(w, wikiNodeListResponse{
+				apiResponse: apiResponse{Code: 0},
+				Data: struct {
+					Items     []wikiNode `json:"items"`
+					HasMore   bool       `json:"has_more"`
+					PageToken string     `json:"page_token"`
+				}{
+					Items: []wikiNode{
+						{NodeToken: "parent_ok", Title: "OK", ObjType: "docx", HasChild: true, ObjToken: "doc_ok"},
+						{NodeToken: "parent_bad", Title: "Bad", ObjType: "docx", HasChild: true, ObjToken: "doc_bad"},
+					},
+				},
+			})
+		case "parent_ok":
+			writeJSON(w, wikiNodeListResponse{
+				apiResponse: apiResponse{Code: 0},
+				Data: struct {
+					Items     []wikiNode `json:"items"`
+					HasMore   bool       `json:"has_more"`
+					PageToken string     `json:"page_token"`
+				}{
+					Items: []wikiNode{
+						{NodeToken: "leaf", Title: "Leaf", ObjType: "docx", HasChild: false, ObjToken: "doc_leaf"},
+					},
+				},
+			})
+		case "parent_bad":
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, `{"code":1663,"msg":"internal error"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	ts := httptest.NewServer(mux)
+	cfg := &Config{AppID: "id", AppSecret: "sec", BaseURL: ts.URL}
+	return ts, cfg
+}
+
+func TestListAllWikiNodesRecursive_PartialChildFailure(t *testing.T) {
+	ts, cfg := fakeFeishuWithChildFailure()
+	defer ts.Close()
+
+	client := NewClient(cfg)
+	nodes, failed, err := client.ListAllWikiNodesRecursive(context.Background(), "space1")
+	if err != nil {
+		t.Fatalf("expected no hard error on partial child failure, got %v", err)
+	}
+
+	// Both parents and the leaf under parent_ok must be returned.
+	got := map[string]bool{}
+	for _, n := range nodes {
+		got[n.NodeToken] = true
+	}
+	for _, want := range []string{"parent_ok", "parent_bad", "leaf"} {
+		if !got[want] {
+			t.Errorf("missing node %q in result (have %v)", want, got)
+		}
+	}
+
+	if len(failed) != 1 {
+		t.Fatalf("expected 1 failed subtree, got %d (%+v)", len(failed), failed)
+	}
+	if failed[0].NodeToken != "parent_bad" {
+		t.Errorf("failed token = %q, want parent_bad", failed[0].NodeToken)
+	}
+	if failed[0].Err == nil {
+		t.Error("failed entry must carry a non-nil Err")
+	}
+}
+
+func TestListAllWikiNodesRecursive_TopLevelFailureIsFatal(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/open-apis/auth/v3/tenant_access_token/internal", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, tokenResponse{
+			apiResponse:       apiResponse{Code: 0},
+			TenantAccessToken: "fake-token",
+			Expire:            7200,
+		})
+	})
+	mux.HandleFunc("/open-apis/wiki/v2/spaces/space1/nodes", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"code":1663,"msg":"internal error"}`)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := NewClient(&Config{AppID: "id", AppSecret: "sec", BaseURL: ts.URL})
+	if _, _, err := client.ListAllWikiNodesRecursive(context.Background(), "space1"); err == nil {
+		t.Fatal("expected error when top-level listing fails")
+	}
+}


### PR DESCRIPTION
## Summary
- When syncing a Feishu wiki space, `ListAllWikiNodesRecursive` previously aborted the entire walk on the first child-listing failure (typical cause: transient Feishu 5xx with `code=1663`). Both `FetchAll` and `FetchIncremental` then short-circuited with the error, discarding every node collected so far and marking the whole sync run as failed — making it effectively impossible to initialise large wiki spaces that contain even one flaky subtree (#1262).
- `ListAllWikiNodesRecursive` now returns `(nodes, failedNodes, err)`. Top-level listing failures remain fatal; per-subtree failures are collected and the walk continues with sibling nodes.
- `FetchAll` / `FetchIncremental` record failed subtrees as `FetchedItem` with an error metadata entry so they surface in `last_sync_log` and `items_failed` instead of aborting the run.
- `FetchIncremental` suppresses deletion detection and preserves the prior cursor entries for any space with a partial listing, so an unreachable subtree is not misclassified as deleted on the next run.

Fixes #1262

## Test plan
- [x] `go test ./internal/datasource/connector/feishu/...` (incl. new `TestListAllWikiNodesRecursive_PartialChildFailure` and `TestListAllWikiNodesRecursive_TopLevelFailureIsFatal`)
- [x] `go build ./...`
- [ ] Manual: trigger an initial sync against a Feishu wiki space where one subtree intermittently returns 5xx; confirm successful nodes are persisted, failed subtree is recorded in `last_sync_log`, and the next incremental run does not mark the missing subtree as deleted.