### PR TITLE
chore(github): translate issue/PR templates to English and improve content

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,82 +1,127 @@
-name: 🐛 Bug 报告
-description: 报告一个 bug 或问题
+name: 🐛 Bug Report
+description: Report a bug or issue
 title: "[Bug]: "
 labels: ["bug", "needs-triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        感谢您报告 bug！请填写以下信息帮助我们快速定位和解决问题。
+        Thanks for reporting a bug! Please fill in the information below to help us locate and fix the issue quickly.
 
   - type: dropdown
     id: component
     attributes:
-      label: 相关组件
-      description: 选择出现问题的组件
+      label: Affected Component
+      description: Select the component where the issue occurs
       options:
-        - 前端界面
-        - 后端服务及API
-        - 文档解析服务
-        - 向量数据库
-        - 模型服务
-        - 其他
+        - Frontend UI
+        - Backend Service & API
+        - Document Reader Service
+        - Vector Database
+        - Model Service
+        - Other
     validations:
       required: true
 
   - type: textarea
     id: description
     attributes:
-      label: Bug 描述
-      description: 请详细描述遇到的问题
-      placeholder: "请描述 bug 的具体表现..."
+      label: Bug Description
+      description: A clear and concise description of the issue
+      placeholder: "Describe what the bug looks like..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps that reliably reproduce the problem
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Send request '...'
+        4. See error
     validations:
       required: true
 
   - type: textarea
     id: expected
     attributes:
-      label: 期望行为
-      description: 描述您期望的正确行为
-      placeholder: "应该发生什么..."
+      label: Expected Behavior
+      description: Describe what you expected to happen
+      placeholder: "What should have happened..."
     validations:
       required: true
 
-
-  - type: markdown
-    attributes:
-      value: |
-        ## 📋 日志收集指南
-        
-        请按照以下步骤收集相关日志：
-        
-        docker compose logs -f --tail=1000 app docreader postgres
-        
-        请重现问题并收集相关日志，然后粘贴到下面的日志字段中。
-
   - type: textarea
-    id: logs
+    id: actual
     attributes:
-      label: 相关日志
-      description: 请按照上面的指南收集并粘贴相关日志
-      placeholder: |
-        请粘贴从以下命令收集的日志：
-        docker compose logs -f --tail=1000 app docreader postgres
-      render: shell
+      label: Actual Behavior
+      description: Describe what actually happened (error messages, screenshots, etc.)
+      placeholder: "What actually happened..."
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: WeKnora Version
+      description: The WeKnora version or commit you are running
+      placeholder: "e.g., v0.5.0, or commit abc1234"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment Method
+      description: How are you running WeKnora?
+      options:
+        - Docker Compose
+        - Build from source
+        - Lite (single binary)
+        - Desktop app
+        - Kubernetes (Helm)
+        - Other
+    validations:
+      required: true
 
   - type: input
     id: os
     attributes:
-      label: 操作系统
-      description: 您当前使用的操作系统
-      placeholder: "例如: macOS 13.0, Ubuntu 20.04, Windows 11"
+      label: Operating System
+      description: The operating system you are using
+      placeholder: "e.g., macOS 13.0, Ubuntu 20.04, Windows 11"
     validations:
       required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## 📋 Log Collection Guide
+
+        Please collect logs and paste them into the field below. Pick the command matching your deployment:
+
+        - Docker Compose:
+          ```bash
+          docker compose logs -f --tail=1000 app docreader postgres
+          ```
+        - Lite / Desktop / build from source: include the console output or log files (e.g., `logs/*.log`).
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs
+      description: Paste relevant logs or error messages here
+      placeholder: "Paste logs or error messages..."
+      render: shell
 
   - type: checkboxes
     id: terms
     attributes:
-      label: 确认事项
-      description: 请确认以下事项
+      label: Confirmation
+      description: Please confirm the following
       options:
-        - label: 我已经搜索了现有的 issues，确认这是一个新问题
+        - label: I have searched existing issues and confirmed this is a new one
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: WeKnora 文档
+  - name: WeKnora Documentation
     url: https://github.com/Tencent/WeKnora/blob/main/docs/QA.md
-    about: 查看 WeKnora 的常见问题解答
-  - name: 讨论区
+    about: Check WeKnora FAQ
+  - name: Discussions
     url: https://github.com/Tencent/WeKnora/discussions
-    about: 在讨论区提问或分享想法
+    about: Ask questions or share ideas in Discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,88 +1,88 @@
-name: ✨ 功能请求
-description: 建议新功能或改进现有功能
+name: ✨ Feature Request
+description: Suggest a new feature or improvement
 title: "[Feature]: "
 labels: ["enhancement", "needs-triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        感谢您提出功能请求！请详细描述您的建议，这将帮助我们更好地理解您的需求。
+        Thanks for the feature request! Please describe your idea in detail so we can better understand your needs.
 
   - type: dropdown
     id: component
     attributes:
-      label: 相关组件
-      description: 选择功能请求相关的组件
+      label: Affected Component
+      description: Select the component related to this request
       options:
-        - 前端界面
-        - 后端服务及API
-        - 文档解析服务
-        - 向量数据库
-        - 模型服务
-        - 配置管理
-        - 其他
+        - Frontend UI
+        - Backend Service & API
+        - Document Reader Service
+        - Vector Database
+        - Model Service
+        - Configuration Management
+        - Other
     validations:
       required: true
 
   - type: textarea
     id: problem
     attributes:
-      label: 问题描述
-      description: 请描述您遇到的问题或当前功能的不足
-      placeholder: "当前功能有什么问题或限制？"
+      label: Problem Description
+      description: Describe the problem or limitation of the current feature
+      placeholder: "What is wrong or missing today?"
     validations:
       required: true
 
   - type: textarea
     id: solution
     attributes:
-      label: 建议的解决方案
-      description: 请详细描述您希望看到的功能或改进
-      placeholder: "您希望如何解决这个问题？"
+      label: Proposed Solution
+      description: Describe the feature or improvement you would like to see
+      placeholder: "How would you like to solve it?"
     validations:
       required: true
 
   - type: textarea
     id: alternatives
     attributes:
-      label: 替代方案
-      description: 描述您考虑过的其他解决方案
-      placeholder: "您是否考虑过其他解决方案？"
+      label: Alternatives
+      description: Describe alternative solutions you have considered
+      placeholder: "Any alternatives you considered?"
 
   - type: dropdown
-    id: priority
+    id: impact
     attributes:
-      label: 优先级
-      description: 您认为这个功能请求的优先级如何？
+      label: Impact
+      description: Who is affected by the absence of this feature?
       options:
-        - 低 - 可以稍后考虑
-        - 中 - 有一定价值
-        - 高 - 对工作流程很重要
-        - 紧急 - 阻塞了重要工作
+        - Just me / a personal preference
+        - My team or a small group
+        - Many users would benefit
+        - Blocking adoption of WeKnora
     validations:
       required: true
 
   - type: textarea
     id: usecase
     attributes:
-      label: 使用场景
-      description: 请描述这个功能的具体使用场景
-      placeholder: "在什么情况下您会使用这个功能？"
+      label: Use Case
+      description: Describe the specific use case for this feature
+      placeholder: "When would you use this feature?"
 
   - type: textarea
     id: additional
     attributes:
-      label: 补充信息
-      description: 任何其他相关信息、截图或链接
-      placeholder: "添加任何其他相关信息..."
+      label: Additional Information
+      description: Any other context, screenshots, or links
+      placeholder: "Add any other relevant information..."
 
   - type: checkboxes
     id: terms
     attributes:
-      label: 确认事项
-      description: 请确认以下事项
+      label: Confirmation
+      description: Please confirm the following
       options:
-        - label: 我已经搜索了现有的 issues，确认这是一个新的功能请求
+        - label: I have searched existing issues and confirmed this is a new request
           required: true
-        - label: 我理解这个功能请求可能需要讨论和评估
+        - label: I understand this request may need discussion and evaluation
           required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,73 +1,73 @@
-name: ❓ 问题咨询
-description: 询问关于 WeKnora 的问题或寻求帮助
+name: ❓ Question
+description: Ask a question about WeKnora or seek help
 title: "[Question]: "
 labels: ["question", "needs-triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        欢迎提问！请提供足够的信息，这样我们就能更好地帮助您。
+        Welcome! Please provide enough information so we can help you effectively.
 
   - type: dropdown
     id: category
     attributes:
-      label: 问题类别
-      description: 选择您的问题类别
+      label: Question Category
+      description: Select the category of your question
       options:
-        - 安装和部署
-        - 配置问题
-        - 使用问题
-        - 性能问题
-        - 集成问题
-        - 其他
+        - Installation & Deployment
+        - Configuration
+        - Usage
+        - Performance
+        - Integration
+        - Other
     validations:
       required: true
 
   - type: textarea
     id: question
     attributes:
-      label: 问题描述
-      description: 请详细描述您的问题
-      placeholder: "您遇到了什么问题？需要什么帮助？"
+      label: Question Description
+      description: Please describe your question in detail
+      placeholder: "What problem did you encounter? What help do you need?"
     validations:
       required: true
 
   - type: textarea
     id: context
     attributes:
-      label: 背景信息
-      description: 请提供相关的背景信息
+      label: Context
+      description: Please provide relevant context
       placeholder: |
-        - 您正在尝试做什么？
-        - 您期望的结果是什么？
-        - 您已经尝试了什么？
+        - What are you trying to do?
+        - What outcome do you expect?
+        - What have you tried so far?
 
   - type: input
     id: os
     attributes:
-      label: 操作系统
-      description: 您当前使用的操作系统
-      placeholder: "例如: macOS 13.0, Ubuntu 20.04, Windows 11"
+      label: Operating System
+      description: The operating system you are using
+      placeholder: "e.g., macOS 13.0, Ubuntu 20.04, Windows 11"
     validations:
       required: true
 
   - type: textarea
     id: environment
     attributes:
-      label: 其他环境信息
-      description: 请提供其他相关的环境信息
+      label: Other Environment Info
+      description: Please provide other relevant environment information
       placeholder: |
-        - WeKnora 版本: [例如: v1.0.0]
-        - 部署方式: [例如: Docker, 源码编译]
-        - 其他相关信息...
+        - WeKnora Version: [e.g., v1.0.0]
+        - Deployment: [e.g., Docker, build from source]
+        - Other relevant info...
 
   - type: markdown
     attributes:
       value: |
-        ## 📋 日志收集指南（如需要）
-        
-        如果问题涉及错误或需要调试，请收集相关日志：
-        
+        ## 📋 Log Collection Guide (if needed)
+
+        If the issue involves errors or requires debugging, please collect logs:
+
         ```bash
         docker compose logs -f --tail=1000 app docreader postgres
         ```
@@ -75,28 +75,28 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: 相关日志
-      description: 如果有相关日志或错误信息，请粘贴在这里
-      placeholder: "粘贴相关日志或错误信息..."
+      label: Relevant Logs
+      description: Paste relevant logs or error messages here if available
+      placeholder: "Paste logs or error messages..."
       render: shell
 
   - type: textarea
     id: research
     attributes:
-      label: 已查找的资源
-      description: 请列出您已经查看过的文档、issues 或其他资源
+      label: Resources Already Checked
+      description: List the docs, issues or other resources you've already checked
       placeholder: |
-        - 已查看的文档: [例如: README.md, API.md]
-        - 已查看的 issues: [例如: #123, #456]
-        - 其他资源: [例如: 官方文档, Stack Overflow]
+        - Docs checked: [e.g., README.md, API.md]
+        - Issues checked: [e.g., #123, #456]
+        - Other resources: [e.g., official docs, Stack Overflow]
 
   - type: checkboxes
     id: terms
     attributes:
-      label: 确认事项
-      description: 请确认以下事项
+      label: Confirmation
+      description: Please confirm the following
       options:
-        - label: 我已经搜索了现有的 issues 和文档
+        - label: I have searched existing issues and documentation
           required: true
-        - label: 我已经提供了足够的信息来帮助理解问题
+        - label: I have provided enough information to help understand the question
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,73 +1,32 @@
-# Pull Request
+<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->
 
-## 描述 (Description)
-<!-- 请简要描述这个 PR 的目的和变更内容 -->
+## Description
+<!-- Briefly describe the purpose and changes of this PR -->
 
-## 变更类型 (Type of Change)
-<!-- 请选择适用的类型，删除其他选项 -->
-- [ ] 🐛 Bug 修复 (Bug fix)
-- [ ] ✨ 新功能 (New feature)
-- [ ] 💥 破坏性变更 (Breaking change)
-- [ ] 📚 文档更新 (Documentation update)
-- [ ] 🎨 代码重构 (Code refactoring)
-- [ ] ⚡ 性能优化 (Performance improvement)
-- [ ] 🧪 测试相关 (Test related)
-- [ ] 🔧 配置变更 (Configuration change)
-- [ ] 🐳 Docker 相关 (Docker related)
-- [ ] 🎨 前端 UI/UX (Frontend UI/UX)
+## Type of Change
+<!-- Check applicable items -->
+- [ ] 🐛 Bug fix
+- [ ] ✨ New feature
+- [ ] 💥 Breaking change
+- [ ] 📚 Documentation update
+- [ ] 🎨 Refactor
+- [ ] ⚡ Performance improvement
+- [ ] 🧪 Test
+- [ ] 🔧 Configuration / Build / CI
 
-## 影响范围 (Scope)
-<!-- 请选择受影响的组件，删除其他选项 -->
-- [ ] 后端 API (Backend API)
-- [ ] 前端界面 (Frontend UI)
-- [ ] 数据库 (Database)
-- [ ] 文档解析服务 (Document Reader Service)
-- [ ] MCP 服务器 (MCP Server)
-- [ ] Docker 配置 (Docker Configuration)
-- [ ] 配置文件 (Configuration)
-- [ ] 其他 (Other): <!-- 请说明 -->
-
-## 测试 (Testing)
-<!-- 请描述如何测试这些变更 -->
-- [ ] 单元测试 (Unit tests)
-- [ ] 集成测试 (Integration tests)
-- [ ] 手动测试 (Manual testing)
-- [ ] 前端测试 (Frontend testing)
-- [ ] API 测试 (API testing)
-
-### 测试步骤 (Test Steps)
-1. 
-2. 
-3. 
-
-## 检查清单 (Checklist)
-<!-- 请确保完成以下检查项 -->
-- [ ] 代码遵循项目的编码规范
-- [ ] 已进行自我代码审查
-- [ ] 代码变更已添加适当的注释
-- [ ] 相关文档已更新
-- [ ] 变更不会产生新的警告
-- [ ] 已添加测试用例证明修复有效或功能正常
-- [ ] 新功能和变更已更新到相关文档
-- [ ] 破坏性变更已在描述中明确说明
-
-## 相关 Issue
-<!-- 如果此 PR 解决了某个 issue，请使用 "Fixes #123" 或 "Closes #123" 的格式 -->
+## Related Issue
+<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
 Fixes #
 
-## 截图/录屏 (Screenshots/Recordings)
-<!-- 如果是前端 UI 变更，请提供截图或录屏 -->
+## Testing
+<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
 
-## 数据库迁移 (Database Migration)
-<!-- 如果涉及数据库变更，请说明 -->
-- [ ] 需要数据库迁移
-- [ ] 不需要数据库迁移
+## Checklist
+- [ ] `make fmt && make lint && make test` pass locally
+- [ ] Self-reviewed the code
+- [ ] Added/updated tests covering the change
+- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
+- [ ] Breaking changes are clearly called out in the description above
 
-## 配置变更 (Configuration Changes)
-<!-- 如果涉及配置变更，请说明需要更新的配置项 -->
-
-## 部署说明 (Deployment Notes)
-<!-- 如果有特殊的部署要求，请说明 -->
-
-## 其他信息 (Additional Information)
-<!-- 任何其他需要说明的信息 -->
+## Screenshots / Recordings
+<!-- Required for user-visible UI changes -->


### PR DESCRIPTION
## Description

Refines GitHub issue and PR templates so external contributors can use them comfortably and so that bug reports carry the information maintainers actually need to triage.

## Type of Change

- [x] 📚 Documentation update
- [x] 🔧 Configuration / Build / CI

## Changes

- Translate all issue templates and the PR template to English only (previously Chinese-only), making them accessible to the broader open-source community.
- `bug_report.yml`: add four required fields — **Steps to Reproduce**, **Actual Behavior**, **WeKnora Version**, **Deployment Method** — and expand the log-collection guide to cover Lite / Desktop / source builds in addition to Docker Compose.
- `feature_request.yml`: replace the user-selected **Priority** dropdown (frequently inflated to "Urgent / blocking") with an **Impact** dropdown describing who is affected.
- `pull_request_template.md`: trim from 11 sections to 6, add a Conventional Commits hint at the top, and add `make fmt && make lint && make test` to the checklist to align with the project's contribution guide.

## Testing

Pure documentation / template change — no code paths affected. Verified that the YAML templates are syntactically valid and that the rendered fields cover the required information.

## Checklist

- [x] Self-reviewed the change
- [x] No code, build, or runtime behavior is affected