### PR TITLE
fix(middleware): mask camelCase secret fields in request logs

### DIFF
--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -39,31 +39,17 @@ func (r loggerResponseBodyWriter) Write(b []byte) (int, error) {
 	return r.ResponseWriter.Write(b)
 }
 
+// sensitiveFieldRegex 匹配 JSON 中的敏感字段（不区分大小写，兼容 snake_case / camelCase / PascalCase）。
+// $1 捕获原始字段名（包括两侧引号），保持日志中的字段名不变，仅将值替换为 "***"。
+var sensitiveFieldRegex = regexp.MustCompile(
+	`(?i)("(?:password|passwd|token|access[_-]?token|refresh[_-]?token|id[_-]?token|` +
+		`authorization|auth[_-]?token|api[_-]?key|api[_-]?secret|secret[_-]?key|` +
+		`client[_-]?secret|private[_-]?key|secret)")\s*:\s*"[^"]*"`,
+)
+
 // sanitizeBody 清理敏感信息
 func sanitizeBody(body string) string {
-	result := body
-	// 替换常见的敏感字段（JSON格式）
-	sensitivePatterns := []struct {
-		pattern     string
-		replacement string
-	}{
-		{`"password"\s*:\s*"[^"]*"`, `"password":"***"`},
-		{`"token"\s*:\s*"[^"]*"`, `"token":"***"`},
-		{`"access_token"\s*:\s*"[^"]*"`, `"access_token":"***"`},
-		{`"refresh_token"\s*:\s*"[^"]*"`, `"refresh_token":"***"`},
-		{`"authorization"\s*:\s*"[^"]*"`, `"authorization":"***"`},
-		{`"api_key"\s*:\s*"[^"]*"`, `"api_key":"***"`},
-		{`"secret"\s*:\s*"[^"]*"`, `"secret":"***"`},
-		{`"apikey"\s*:\s*"[^"]*"`, `"apikey":"***"`},
-		{`"apisecret"\s*:\s*"[^"]*"`, `"apisecret":"***"`},
-	}
-
-	for _, p := range sensitivePatterns {
-		re := regexp.MustCompile(p.pattern)
-		result = re.ReplaceAllString(result, p.replacement)
-	}
-
-	return result
+	return sensitiveFieldRegex.ReplaceAllString(body, `$1:"***"`)
 }
 
 // readRequestBody 读取请求体（限制大小用于日志，但完整读取用于重置）

--- a/internal/middleware/logger_test.go
+++ b/internal/middleware/logger_test.go
@@ -1,0 +1,61 @@
+package middleware
+
+import "testing"
+
+func TestSanitizeBody(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "camelCase apiKey",
+			in:   `{"modelName":"gpt-5.2","apiKey":"sk-secret-123","provider":"azure_openai"}`,
+			want: `{"modelName":"gpt-5.2","apiKey":"***","provider":"azure_openai"}`,
+		},
+		{
+			name: "snake_case api_key",
+			in:   `{"api_key":"sk-secret-123"}`,
+			want: `{"api_key":"***"}`,
+		},
+		{
+			name: "PascalCase APIKey",
+			in:   `{"APIKey":"sk-secret-123"}`,
+			want: `{"APIKey":"***"}`,
+		},
+		{
+			name: "secretKey camelCase",
+			in:   `{"secretKey":"abc","accessKeyId":"id"}`,
+			want: `{"secretKey":"***","accessKeyId":"id"}`,
+		},
+		{
+			name: "refreshToken / accessToken camelCase",
+			in:   `{"refreshToken":"rt","accessToken":"at"}`,
+			want: `{"refreshToken":"***","accessToken":"***"}`,
+		},
+		{
+			name: "password and token preserved as masked",
+			in:   `{"password":"p","token":"t"}`,
+			want: `{"password":"***","token":"***"}`,
+		},
+		{
+			name: "extra whitespace around colon",
+			in:   `{"apiKey"  :   "leak"}`,
+			want: `{"apiKey":"***"}`,
+		},
+		{
+			name: "non sensitive fields untouched",
+			in:   `{"baseUrl":"https://example.com","modelName":"gpt"}`,
+			want: `{"baseUrl":"https://example.com","modelName":"gpt"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeBody(tc.in)
+			if got != tc.want {
+				t.Errorf("sanitizeBody(%q)\n got: %s\nwant: %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Request logger's `sanitizeBody` only matched lowercase / snake_case field names (`api_key`, `apikey`, `access_token`, ...), so the camelCase JSON fields actually used by handlers (`apiKey`, `secretKey`, `refreshToken`, `accessToken`, ...) were written to access logs in clear text.
- Replace the per-field patterns with a single case-insensitive regex tolerating optional `_` / `-` separators, covering snake_case / camelCase / PascalCase, and extend coverage to `id_token`, `client_secret`, `private_key`, `auth_token`, `api_secret`, `passwd`. Field name is preserved; only the value becomes `"***"`.
- Add unit tests for `sanitizeBody` covering the previously-leaking camelCase fields and common variants.

Fixes #1287

## Test plan

- [x] `go test ./internal/middleware/ -run TestSanitizeBody -v` passes (camelCase / snake_case / PascalCase / `password` / `refreshToken` / `accessToken` / extra-whitespace / non-sensitive cases).
- [x] `go vet ./internal/middleware/` clean.
- [ ] Manually verify access logs for `POST /api/v1/initialization/remote/check` no longer contain plaintext `apiKey` value.