### PR TITLE
fix: 解决了 Langfuse 标题模型和 DeepSeek EOF 问题

### DIFF
--- a/internal/agent/const.go
+++ b/internal/agent/const.go
@@ -48,6 +48,7 @@ var transientErrorMarkers = []string{
 	"500", "502", "503", "504",
 	"overloaded", "timeout", "timed out",
 	"connection", "server error", "temporarily unavailable",
+	"eof", "broken pipe", "connection reset",
 }
 
 // isTransientError checks whether an error is likely transient and worth retrying.

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -34,10 +34,10 @@ type qaRequestContext struct {
 	webSearchEnabled  bool
 	enableMemory      bool // Whether memory feature is enabled
 	mentionedItems    types.MentionedItems
-	effectiveTenantID uint64            // when using shared agent, tenant ID for model/KB/MCP resolution; 0 = use context tenant
-	images            []ImageAttachment // Uploaded images with analysis text
-	userMessageID     string            // Created user message ID (populated after createUserMessage)
-	channel           string            // Source channel: "web", "api", "im", etc.
+	effectiveTenantID uint64                   // when using shared agent, tenant ID for model/KB/MCP resolution; 0 = use context tenant
+	images            []ImageAttachment        // Uploaded images with analysis text
+	userMessageID     string                   // Created user message ID (populated after createUserMessage)
+	channel           string                   // Source channel: "web", "api", "im", etc.
 	attachments       types.MessageAttachments // Processed file attachments
 }
 
@@ -360,8 +360,8 @@ func (h *Handler) setupSSEStream(reqCtx *qaRequestContext, generateTitle bool) *
 	// Generate title if needed
 	if generateTitle && reqCtx.session.Title == "" {
 		// Use the same model as the conversation for title generation
-		modelID := ""
-		if reqCtx.customAgent != nil && reqCtx.customAgent.Config.ModelID != "" {
+		modelID := reqCtx.summaryModelID
+		if modelID == "" && reqCtx.customAgent != nil && reqCtx.customAgent.Config.ModelID != "" {
 			modelID = reqCtx.customAgent.Config.ModelID
 		}
 		logger.Infof(reqCtx.ctx, "Session has no title, starting async title generation, session ID: %s, model: %s", reqCtx.sessionID, modelID)

--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -58,11 +58,13 @@ func withLLMTimeout(ctx context.Context, d time.Duration) (context.Context, cont
 // Uses SSRFSafeDialContext to prevent DNS rebinding attacks at the connection layer.
 var rawHTTPClient = &http.Client{
 	Transport: &http.Transport{
-		Proxy:               http.ProxyFromEnvironment,
-		DialContext:         secutils.SSRFSafeDialContext,
-		TLSHandshakeTimeout: 10 * time.Second,
-		IdleConnTimeout:     90 * time.Second,
-		MaxIdleConnsPerHost: 5,
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           secutils.SSRFSafeDialContext,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 15 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		IdleConnTimeout:       90 * time.Second,
+		MaxIdleConnsPerHost:   5,
 	},
 }
 


### PR DESCRIPTION
 fix: 解决 Langfuse 标题模型和 DeepSeek EOF 问题

  PR Description 可以直接复制下面这版：
  
  ## Description

  修复 agent-chat 选择 DeepSeek 时，异步标题生成仍回退到 `qwen3.5-plus`，以及 DeepSeek 流式连接 EOF 未被稳定重试的问题。

  根因：
  - 标题生成只读取 custom agent 默认模型，忽略本次请求的 `summary_model_id`，导致用户选择 `deepseek-v4-pro`
  时，标题生成仍可能调用默认的 `qwen3.5-plus`。
  - 流式上游连接被中断时可能返回 `eof`、`broken pipe`、`connection reset`，但这些瞬时网络错误未被重试白名单覆盖。
  - 底层 `rawHTTPClient` 缺少响应头超时，部分上游慢失败会拖长请求耗时。
  
  改动：
  - 标题生成优先使用本次请求传入的 `summary_model_id`，避免选 `deepseek-v4-pro` 时仍调用 `qwen3.5-plus`。
  - 将 `eof`、`broken pipe`、`connection reset` 纳入 LLM 瞬时错误重试。
  - 为 `rawHTTPClient` 增加 `ResponseHeaderTimeout` 和 `ExpectContinueTimeout`，减少上游连接异常时的慢失败耗时。

  ## Type of Change
  
  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 💥 Breaking change
  - [ ] 📚 Documentation update
  - [ ] 🎨 Refactor
  - [x] ⚡ Performance improvement
  - [ ] 🧪 Test
  - [ ] 🔧 Configuration / Build / CI

  ## Related Issue

  Fixes #

  ## Testing

  已在本地执行以下验证：

  ```bash
  gofmt -w internal/handler/session/qa.go internal/agent/const.go internal/models/chat/remote_api.go
  go build ./internal/handler/session/... ./internal/agent/... ./internal/models/chat/...

  验证结果：
  - Go 文件格式化通过。
  - 受影响的 handler、agent、chat package 编译通过。
  - 本 PR 未修改 UI，无需截图或录屏。

  Checklist

  - make fmt && make lint && make test pass locally
  - Self-reviewed the code
  - Added/updated tests covering the change
  - Updated related documentation (README, docs/, Swagger annotations, etc.)
  - Breaking changes are clearly called out in the description above

  Screenshots / Recordings
<img width="1904" height="781" alt="image" src="https://github.com/user-attachments/assets/a114f15f-91be-4931-8a3a-a84a248e3ffc" />

  N/A. This PR does not include user-visible UI changes.
