### PR TITLE
feat(observability): fill Langfuse trace gaps and add end-to-end TTFB logs

### DIFF
--- a/frontend/src/api/chat/streame.ts
+++ b/frontend/src/api/chat/streame.ts
@@ -71,11 +71,21 @@ export function useStream() {
     // Removed validation - allow empty knowledge_base_ids array
     // The backend should handle this case appropriately
 
+    // TTFB instrumentation: record the moment we kick off the request so
+    // we can compare it with the first answer chunk we receive from the
+    // server. This makes it possible to correlate the frontend-observed
+    // latency with the backend "TTFB:first_answer_chunk" log line by
+    // matching on X-Request-ID.
+    const sentAt = performance.now();
+    const requestID = generateRandomString(12);
+    let firstAnswerLogged = false;
+
     try {
       let url =
         params.method == "POST"
           ? `${apiUrl}${params.url}/${params.session_id}`
           : `${apiUrl}${params.url}/${params.session_id}?message_id=${params.query}`;
+      console.log(`[TTFB] request:start request_id=${requestID} url=${url} sent_at=${Date.now()}`);
       
       // Prepare POST body with required fields for agent-chat
       // knowledge_base_ids array and agent_enabled can update Session's SessionAgentConfig
@@ -131,7 +141,7 @@ export function useStream() {
           "Content-Type": "application/json",
           "Authorization": `Bearer ${token}`,
           "Accept-Language": i18n.global.locale?.value || localStorage.getItem('locale') || 'zh-CN',
-          "X-Request-ID": `${generateRandomString(12)}`,
+          "X-Request-ID": requestID,
           ...(tenantIdHeader ? { "X-Tenant-ID": tenantIdHeader } : {}),
         },
         body:
@@ -143,14 +153,23 @@ export function useStream() {
 
         onopen: async (res) => {
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          console.log(`[TTFB] response:headers request_id=${requestID} elapsed_ms=${(performance.now() - sentAt).toFixed(1)}`);
           isLoading.value = false;
         },
 
         onmessage: (ev) => {
-          buffer.push(JSON.parse(ev.data)); // 数据存入缓冲
+          const parsed = JSON.parse(ev.data);
+          // Log first answer chunk for end-to-end TTFB measurement.
+          // Filter by event type so non-answer events (references, tool
+          // calls, etc.) don't count as the "first token" arrival.
+          if (!firstAnswerLogged && (parsed?.response_type === 'answer' || parsed?.type === 'answer')) {
+            firstAnswerLogged = true;
+            console.log(`[TTFB] response:first_answer request_id=${requestID} elapsed_ms=${(performance.now() - sentAt).toFixed(1)}`);
+          }
+          buffer.push(parsed); // 数据存入缓冲
           // 执行自定义处理
           if (chunkHandler) {
-            chunkHandler(JSON.parse(ev.data));
+            chunkHandler(parsed);
           }
         },
 

--- a/internal/application/service/chat_pipeline/search.go
+++ b/internal/application/service/chat_pipeline/search.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/searchutil"
+	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 )
@@ -645,7 +646,18 @@ func (p *PluginSearch) searchWebIfEnabled(ctx context.Context, chatManage *types
 		"tenant_id":   chatManage.TenantID,
 		"provider_id": providerID,
 	})
-	webResults, err := p.webSearchService.Search(ctx, providerID, webConfig, chatManage.RewriteQuery)
+	webCtx, webSpan := langfuse.GetManager().StartSpan(ctx, langfuse.SpanOptions{
+		Name: "web_search",
+		Input: map[string]interface{}{
+			"provider_id": providerID,
+			"query":       chatManage.RewriteQuery,
+			"max_results": webConfig.MaxResults,
+		},
+	})
+	webResults, err := p.webSearchService.Search(webCtx, providerID, webConfig, chatManage.RewriteQuery)
+	webSpan.Finish(map[string]interface{}{
+		"hit_count": len(webResults),
+	}, nil, err)
 	if err != nil {
 		pipelineWarn(ctx, "Search", "web_search_error", map[string]interface{}{
 			"tenant_id": chatManage.TenantID,

--- a/internal/application/service/knowledgebase_search.go
+++ b/internal/application/service/knowledgebase_search.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
 )
 
@@ -133,9 +134,30 @@ func (s *knowledgeBaseService) HybridSearch(ctx context.Context,
 		return nil, nil
 	}
 
-	// Execute retrieval using the configured engines
+	// Execute retrieval using the configured engines.
+	// A dedicated span captures the actual vector/keyword DB round-trip
+	// — this is the time previously visible in Langfuse only as the gap
+	// between embedding generations and the rerank call.
 	logger.Infof(ctx, "Starting retrieval, parameter count: %d", len(retrieveParams))
-	retrieveResults, err := retrieveEngine.Retrieve(ctx, retrieveParams)
+	retrieverTypes := make([]string, 0, len(retrieveParams))
+	for _, rp := range retrieveParams {
+		retrieverTypes = append(retrieverTypes, string(rp.RetrieverType))
+	}
+	retrieveCtx, retrieveSpan := langfuse.GetManager().StartSpan(ctx, langfuse.SpanOptions{
+		Name: "retrieve",
+		Input: map[string]interface{}{
+			"kb_ids":      searchKBIDs,
+			"match_count": matchCount,
+			"retrievers":  retrieverTypes,
+		},
+		Metadata: map[string]interface{}{
+			"param_count": len(retrieveParams),
+		},
+	})
+	retrieveResults, err := retrieveEngine.Retrieve(retrieveCtx, retrieveParams)
+	retrieveSpan.Finish(map[string]interface{}{
+		"result_count": len(retrieveResults),
+	}, nil, err)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"knowledge_base_ids": searchKBIDs,

--- a/internal/application/service/session_knowledge_qa.go
+++ b/internal/application/service/session_knowledge_qa.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/event"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
 )
 
@@ -31,6 +32,17 @@ func (s *sessionService) KnowledgeQA(
 		req.WebSearchEnabled,
 		req.EnableMemory,
 	)
+
+	// Span the request setup (KB / model resolution, search target building,
+	// agent override application). This covers the visible gap between trace
+	// start and the first stage observation in the Langfuse timeline.
+	setupCtx, setupSpan := langfuse.GetManager().StartSpan(ctx, langfuse.SpanOptions{
+		Name: "qa.setup",
+		Metadata: map[string]interface{}{
+			"session_id": req.Session.ID,
+		},
+	})
+	ctx = setupCtx
 
 	// Resolve knowledge bases using shared helper
 	knowledgeBaseIDs, knowledgeIDs := s.resolveKnowledgeBases(ctx, req)
@@ -191,6 +203,11 @@ func (s *sessionService) KnowledgeQA(
 	// Start knowledge QA event processing (set session tenant so pipeline session/message lookups use session owner)
 	ctx = context.WithValue(ctx, types.SessionTenantIDContextKey, req.Session.TenantID)
 	logger.Info(ctx, "Triggering question answering event")
+	setupSpan.Finish(map[string]interface{}{
+		"stages":             len(pipeline),
+		"knowledge_base_ids": knowledgeBaseIDs,
+		"search_targets":     len(searchTargets),
+	}, nil, nil)
 	err = s.KnowledgeQAByEvent(ctx, chatManage, pipeline)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
@@ -536,8 +553,40 @@ func (s *sessionService) KnowledgeQAByEvent(ctx context.Context,
 	pipelineStart := time.Now()
 	for _, eventType := range eventList {
 		stageStart := time.Now()
-		err := s.eventManager.Trigger(ctx, eventType, chatManage)
+		// Wrap each pipeline stage in a Langfuse span so the trace timeline
+		// shows the gaps between LLM/embedding/rerank generations (the work
+		// that happens between them — vector DB search, merge, filter, prompt
+		// assembly — was previously invisible). Generations created inside
+		// the stage automatically nest under this span.
+		//
+		// CHAT_COMPLETION_STREAM is intentionally skipped: its OnEvent kicks
+		// off a streaming goroutine and returns immediately, so a span would
+		// finish well before the chat.completion.stream generation does. The
+		// generation already captures the full stream duration; adding a
+		// stage span here would just produce a child observation that
+		// visually exceeds its parent.
+		stageCtx := ctx
+		var stageSpan *langfuse.Span
+		if eventType != types.CHAT_COMPLETION_STREAM {
+			stageCtx, stageSpan = langfuse.GetManager().StartSpan(ctx, langfuse.SpanOptions{
+				Name: "pipeline." + string(eventType),
+				Metadata: map[string]interface{}{
+					"event_type": string(eventType),
+					"session_id": chatManage.SessionID,
+				},
+			})
+		}
+		err := s.eventManager.Trigger(stageCtx, eventType, chatManage)
 		stageDuration := time.Since(stageStart)
+		var spanErr error
+		if err != nil && err != chatpipeline.ErrSearchNothing {
+			spanErr = err.Err
+		}
+		if stageSpan != nil {
+			stageSpan.Finish(map[string]interface{}{
+				"duration_ms": stageDuration.Milliseconds(),
+			}, nil, spanErr)
+		}
 
 		if err == chatpipeline.ErrSearchNothing {
 			common.PipelineWarn(ctx, "Pipeline", "stage_fallback", map[string]interface{}{
@@ -664,7 +713,19 @@ func (s *sessionService) SearchKnowledge(ctx context.Context,
 
 	for _, event := range searchEvents {
 		logger.Infof(ctx, "Starting to trigger search event: %v", event)
-		err := s.eventManager.Trigger(ctx, event, chatManage)
+		stageCtx, stageSpan := langfuse.GetManager().StartSpan(ctx, langfuse.SpanOptions{
+			Name: "pipeline." + string(event),
+			Metadata: map[string]interface{}{
+				"event_type": string(event),
+				"flow":       "search_knowledge",
+			},
+		})
+		err := s.eventManager.Trigger(stageCtx, event, chatManage)
+		var spanErr error
+		if err != nil && err != chatpipeline.ErrSearchNothing {
+			spanErr = err.Err
+		}
+		stageSpan.Finish(nil, nil, spanErr)
 
 		if err == chatpipeline.ErrSearchNothing {
 			logger.Warnf(ctx, "Event %v triggered, search result is empty", event)

--- a/internal/handler/session/agent_stream_handler.go
+++ b/internal/handler/session/agent_stream_handler.go
@@ -21,6 +21,8 @@ type AgentStreamHandler struct {
 	sessionID          string
 	assistantMessageID string
 	requestID          string
+	receivedAt         time.Time // Handler entry timestamp, used for TTFB logging
+	ttfbLogged         bool      // Guards one-shot TTFB log on first answer chunk
 	assistantMessage   *types.Message
 	streamManager      interfaces.StreamManager
 
@@ -37,6 +39,7 @@ type AgentStreamHandler struct {
 func NewAgentStreamHandler(
 	ctx context.Context,
 	sessionID, assistantMessageID, requestID string,
+	receivedAt time.Time,
 	assistantMessage *types.Message,
 	streamManager interfaces.StreamManager,
 	eventBus *event.EventBus,
@@ -46,6 +49,7 @@ func NewAgentStreamHandler(
 		sessionID:          sessionID,
 		assistantMessageID: assistantMessageID,
 		requestID:          requestID,
+		receivedAt:         receivedAt,
 		assistantMessage:   assistantMessage,
 		streamManager:      streamManager,
 		eventBus:           eventBus,
@@ -345,6 +349,17 @@ func (h *AgentStreamHandler) handleFinalAnswer(ctx context.Context, evt event.Ev
 	// Track start time on first chunk
 	if _, exists := h.eventStartTimes[evt.ID]; !exists {
 		h.eventStartTimes[evt.ID] = time.Now()
+	}
+
+	// Emit a one-shot TTFB log the first time *any* answer chunk reaches
+	// the stream handler. This lets us compare the backend's "request in →
+	// first token out" timing against the frontend-observed TTFB and pin
+	// down where latency lives (network vs server vs LLM).
+	if !h.ttfbLogged && !h.receivedAt.IsZero() {
+		h.ttfbLogged = true
+		ttfb := time.Since(h.receivedAt)
+		logger.GetLogger(h.ctx).Infof("TTFB:first_answer_chunk request_id=%s, session_id=%s, ttfb_ms=%d",
+			h.requestID, h.sessionID, ttfb.Milliseconds())
 	}
 
 	// Accumulate final answer locally for assistant message (database)

--- a/internal/handler/session/helpers.go
+++ b/internal/handler/session/helpers.go
@@ -191,11 +191,12 @@ func (h *Handler) createAssistantMessage(ctx context.Context, assistantMessage *
 func (h *Handler) setupStreamHandler(
 	ctx context.Context,
 	sessionID, assistantMessageID, requestID string,
+	receivedAt time.Time,
 	assistantMessage *types.Message,
 	eventBus *event.EventBus,
 ) *AgentStreamHandler {
 	streamHandler := NewAgentStreamHandler(
-		ctx, sessionID, assistantMessageID, requestID,
+		ctx, sessionID, assistantMessageID, requestID, receivedAt,
 		assistantMessage, h.streamManager, eventBus,
 	)
 	streamHandler.Subscribe()

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -24,6 +24,7 @@ type qaRequestContext struct {
 	c                 *gin.Context
 	sessionID         string
 	requestID         string
+	receivedAt        time.Time // Wall-clock time the handler started processing the request
 	query             string
 	session           *types.Session
 	customAgent       *types.CustomAgent
@@ -63,8 +64,11 @@ func (rc *qaRequestContext) buildQARequest() *types.QARequest {
 
 // parseQARequest parses and validates a QA request, returns the request context
 func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestContext, *CreateKnowledgeQARequest, error) {
+	receivedAt := time.Now()
 	ctx := logger.CloneContext(c.Request.Context())
-	logger.Infof(ctx, "[%s] Start processing request", logPrefix)
+	requestID := secutils.SanitizeForLog(c.GetString(types.RequestIDContextKey.String()))
+	logger.Infof(ctx, "[%s] TTFB:start request_id=%s received_at=%d",
+		logPrefix, requestID, receivedAt.UnixMilli())
 
 	// Get session ID from URL parameter
 	sessionID := secutils.SanitizeForLog(c.Param("session_id"))
@@ -204,7 +208,8 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 		ctx:         ctx,
 		c:           c,
 		sessionID:   sessionID,
-		requestID:   secutils.SanitizeForLog(c.GetString(types.RequestIDContextKey.String())),
+		requestID:   requestID,
+		receivedAt:  receivedAt,
 		query:       secutils.SanitizeForLog(request.Query),
 		session:     session,
 		customAgent: customAgent,
@@ -355,7 +360,7 @@ func (h *Handler) setupSSEStream(reqCtx *qaRequestContext, generateTitle bool) *
 
 	// Setup stream handler
 	h.setupStreamHandler(asyncCtx, reqCtx.sessionID, reqCtx.assistantMessage.ID,
-		reqCtx.requestID, reqCtx.assistantMessage, eventBus)
+		reqCtx.requestID, reqCtx.receivedAt, reqCtx.assistantMessage, eventBus)
 
 	// Generate title if needed
 	if generateTitle && reqCtx.session.Title == "" {


### PR DESCRIPTION
## Description

When debugging chat-pipeline latency on Langfuse, the timeline only showed model generations (chat.completion, embedding.embed, rerank), so the work that happens between them — request setup, vector/keyword retrieval, web search, merge, prompt assembly — appeared as unexplained gaps. This PR fills those gaps and adds a single end-to-end latency number that can be matched across the browser console and the server log.

### Langfuse spans

* \`qa.setup\` wraps request-time KB / model / search-target resolution before the pipeline starts.
* \`pipeline.<event>\` wraps each pipeline stage's \`eventManager.Trigger\` call so generations inside a stage nest under it. \`CHAT_COMPLETION_STREAM\` is intentionally skipped because its \`OnEvent\` returns as soon as the streaming goroutine starts; a stage span would always finish before the \`chat.completion.stream\` generation it nominally parents.
* \`retrieve\` wraps the actual vector + keyword retrieve call inside \`HybridSearch\`, exposing the DB round-trip that previously sat invisibly between embedding generations and rerank.
* \`web_search\` wraps the external web-search HTTP call when enabled.

After this PR the trace tree looks like:

\`\`\`
trace
├─ qa.setup
├─ pipeline.load_history
├─ pipeline.query_understand
│   └─ chat.completion
├─ pipeline.chunk_search_parallel
│   ├─ embedding.embed × N
│   ├─ retrieve × N
│   └─ web_search (optional)
├─ pipeline.chunk_rerank
│   └─ rerank
├─ pipeline.chunk_merge
├─ pipeline.filter_top_k
├─ pipeline.into_chat_message
└─ chat.completion.stream
\`\`\`

### TTFB correlation logs

Both sides log keyed by the same \`X-Request-ID\`:

* Frontend (\`streame.ts\`): \`request:start\`, \`response:headers\`, \`response:first_answer\` (filtered to \`response_type === 'answer'\` so non-answer events don't count as the first token).
* Backend (\`session/qa.go\`, \`agent_stream_handler.go\`): \`TTFB:start\` at handler entry, \`TTFB:first_answer_chunk\` the first time \`AgentFinalAnswerData\` reaches the stream handler. \`receivedAt\` is threaded from \`parseQARequest\` through \`setupStreamHandler\` into \`AgentStreamHandler\`.

\`frontend_first_answer_elapsed − backend_first_answer_ttfb\` is then the network + gin middleware budget, which was previously invisible.

## Type of Change

- [x] ✨ New feature
- [x] 🎨 Refactor (observability surface, no behaviour change)

## Related Issue

None.

## Testing

* \`go build ./...\` passes.
* Manual: ran knowledge-chat against a Langfuse-enabled environment and confirmed (a) the spans listed above show up in the order described, and (b) the new TTFB logs appear with matching \`X-Request-ID\` on both ends.

## Checklist

- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change — observability only, no behavioural change
- [ ] Updated related documentation — none required
- [x] Breaking changes are clearly called out in the description above — none

## Screenshots / Recordings

N/A (Langfuse UI / browser console output).