### PR TITLE
fix(frontend): persist graph extract toggle state on KB save (#1297)

### DIFF
--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
@@ -934,14 +934,15 @@ const buildSubmitData = () => {
     }
   }
 
-  // Sync extract_config.enabled from indexingStrategy.graphEnabled
-  if (formData.value.indexingStrategy?.graphEnabled && formData.value.nodeExtractConfig?.enabled) {
+  // Always persist extract_config so the toggle state from GraphSettings is saved,
+  // regardless of whether the graph indexing strategy is currently enabled.
+  if (formData.value.nodeExtractConfig) {
     data.extract_config = {
-      enabled: true,
-      text: formData.value.nodeExtractConfig.text,
-      tags: formData.value.nodeExtractConfig.tags,
-      nodes: formData.value.nodeExtractConfig.nodes,
-      relations: formData.value.nodeExtractConfig.relations
+      enabled: !!formData.value.nodeExtractConfig.enabled,
+      text: formData.value.nodeExtractConfig.text || '',
+      tags: formData.value.nodeExtractConfig.tags || [],
+      nodes: formData.value.nodeExtractConfig.nodes || [],
+      relations: formData.value.nodeExtractConfig.relations || []
     }
   }
 

--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -267,21 +267,43 @@ func (c *RemoteAPIChat) BuildChatCompletionRequest(messages []Message, opts *Cha
 	}
 
 	if opts != nil {
-		req.Temperature = float32(opts.Temperature)
-		if opts.TopP > 0 {
-			req.TopP = float32(opts.TopP)
+		// OpenAI / Azure OpenAI 的推理类模型（o-series）以及 GPT-5 系列
+		// 不再支持 max_tokens，必须使用 max_completion_tokens；且不支持
+		// temperature / top_p / frequency_penalty / presence_penalty 的非默认值。
+		// 这里做兼容处理，避免上层无差别地传 MaxTokens 导致 400 错误：
+		//   "this model is not supported MaxTokens, please use MaxCompletionTokens"
+		// 参考 issue #1283。
+		isOpenAIReasoning := (c.provider == provider.ProviderOpenAI || c.provider == provider.ProviderAzureOpenAI) &&
+			provider.IsOpenAIReasoningOrGPT5Model(c.modelName)
+
+		if !isOpenAIReasoning {
+			req.Temperature = float32(opts.Temperature)
+			if opts.TopP > 0 {
+				req.TopP = float32(opts.TopP)
+			}
+			if opts.FrequencyPenalty > 0 {
+				req.FrequencyPenalty = float32(opts.FrequencyPenalty)
+			}
+			if opts.PresencePenalty > 0 {
+				req.PresencePenalty = float32(opts.PresencePenalty)
+			}
 		}
-		if opts.MaxTokens > 0 {
-			req.MaxTokens = opts.MaxTokens
-		}
-		if opts.MaxCompletionTokens > 0 {
-			req.MaxCompletionTokens = opts.MaxCompletionTokens
-		}
-		if opts.FrequencyPenalty > 0 {
-			req.FrequencyPenalty = float32(opts.FrequencyPenalty)
-		}
-		if opts.PresencePenalty > 0 {
-			req.PresencePenalty = float32(opts.PresencePenalty)
+
+		switch {
+		case isOpenAIReasoning:
+			// 强制使用 max_completion_tokens；MaxTokens 字段保持零值，依赖 omitempty 不发送。
+			if opts.MaxCompletionTokens > 0 {
+				req.MaxCompletionTokens = opts.MaxCompletionTokens
+			} else if opts.MaxTokens > 0 {
+				req.MaxCompletionTokens = opts.MaxTokens
+			}
+		default:
+			if opts.MaxTokens > 0 {
+				req.MaxTokens = opts.MaxTokens
+			}
+			if opts.MaxCompletionTokens > 0 {
+				req.MaxCompletionTokens = opts.MaxCompletionTokens
+			}
 		}
 
 		// 处理 Tools

--- a/internal/models/chat/remote_api_test.go
+++ b/internal/models/chat/remote_api_test.go
@@ -128,6 +128,84 @@ func TestBuildChatCompletionRequest_MCPToolsFormat(t *testing.T) {
 	}
 }
 
+// TestBuildChatCompletionRequest_GPT5MaxCompletionTokens 验证 GPT-5 / o-series
+// 模型的 MaxTokens 自动迁移到 MaxCompletionTokens，且采样参数被剔除。
+// 见 issue #1283：Azure OpenAI 的 gpt-5 系列模型不再支持 max_tokens 字段。
+func TestBuildChatCompletionRequest_GPT5MaxCompletionTokens(t *testing.T) {
+	build := func(t *testing.T, providerName, modelName string) *RemoteAPIChat {
+		t.Helper()
+		c, err := NewRemoteAPIChat(&ChatConfig{
+			Source:    types.ModelSourceRemote,
+			BaseURL:   "https://example.openai.azure.com",
+			ModelName: modelName,
+			APIKey:    "test-key",
+			ModelID:   modelName,
+			Provider:  providerName,
+			ExtraConfig: map[string]string{
+				"api_version": "2025-04-01-preview",
+			},
+		})
+		require.NoError(t, err)
+		return c
+	}
+
+	messages := []Message{{Role: "user", Content: "test"}}
+
+	cases := []struct {
+		name              string
+		provider          string
+		model             string
+		shouldRewriteMaxT bool
+	}{
+		{"AzureOpenAI gpt-5.2", "azure_openai", "gpt-5.2", true},
+		{"AzureOpenAI gpt-5-mini", "azure_openai", "gpt-5-mini", true},
+		{"OpenAI gpt-5", "openai", "gpt-5", true},
+		{"OpenAI o1-mini", "openai", "o1-mini", true},
+		{"OpenAI o3", "openai", "o3", true},
+		{"OpenAI o4-mini", "openai", "o4-mini", true},
+		{"OpenAI gpt-4o (unchanged)", "openai", "gpt-4o", false},
+		{"AzureOpenAI gpt-4 (unchanged)", "azure_openai", "gpt-4", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := build(t, tc.provider, tc.model)
+			opts := &ChatOptions{
+				Temperature:      0.7,
+				TopP:             0.9,
+				MaxTokens:        128,
+				FrequencyPenalty: 0.1,
+				PresencePenalty:  0.2,
+			}
+			req := c.BuildChatCompletionRequest(messages, opts, false)
+
+			if tc.shouldRewriteMaxT {
+				assert.Equal(t, 0, req.MaxTokens, "MaxTokens must NOT be sent for GPT-5/o-series")
+				assert.Equal(t, 128, req.MaxCompletionTokens, "MaxCompletionTokens should be populated from MaxTokens")
+				assert.EqualValues(t, 0, req.Temperature, "temperature must be omitted")
+				assert.EqualValues(t, 0, req.TopP, "top_p must be omitted")
+				assert.EqualValues(t, 0, req.FrequencyPenalty, "frequency_penalty must be omitted")
+				assert.EqualValues(t, 0, req.PresencePenalty, "presence_penalty must be omitted")
+			} else {
+				assert.Equal(t, 128, req.MaxTokens)
+				assert.Equal(t, 0, req.MaxCompletionTokens)
+				assert.InDelta(t, 0.7, req.Temperature, 1e-6)
+			}
+		})
+	}
+
+	t.Run("MaxCompletionTokens takes precedence over MaxTokens", func(t *testing.T) {
+		c := build(t, "openai", "gpt-5.2")
+		opts := &ChatOptions{
+			MaxTokens:           128,
+			MaxCompletionTokens: 2048,
+		}
+		req := c.BuildChatCompletionRequest(messages, opts, false)
+		assert.Equal(t, 0, req.MaxTokens)
+		assert.Equal(t, 2048, req.MaxCompletionTokens)
+	})
+}
+
 func TestBuildChatCompletionRequest_ToolChoice(t *testing.T) {
 	chat := newTestRemoteChat(t)
 	messages := []Message{{Role: "user", Content: "test"}}

--- a/internal/models/provider/openai.go
+++ b/internal/models/provider/openai.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Tencent/WeKnora/internal/types"
 )
@@ -50,4 +51,36 @@ func (p *OpenAIProvider) ValidateConfig(config *Config) error {
 		return fmt.Errorf("model name is required")
 	}
 	return nil
+}
+
+// IsOpenAIReasoningOrGPT5Model 判断模型是否为 OpenAI / Azure OpenAI 的
+// 推理类（o-series）或 GPT-5 系列模型。
+//
+// 这些模型在 OpenAI Chat Completions API 中：
+//   - 不再支持 `max_tokens`，必须使用 `max_completion_tokens`；
+//   - 仅支持默认的 `temperature=1`、`top_p=1`，且不支持 `frequency_penalty` /
+//     `presence_penalty` 等采样参数（传非默认值会被拒绝）。
+//
+// 参考：
+//   - https://platform.openai.com/docs/api-reference/chat
+//   - https://learn.microsoft.com/azure/ai-services/openai/how-to/reasoning
+//
+// 仅基于模型名做启发式匹配；对于 Azure OpenAI，因为模型名实际上是 deployment 名，
+// 用户若用了自定义部署名我们无法识别，此时仍会按普通模型处理（保持原行为）。
+func IsOpenAIReasoningOrGPT5Model(modelName string) bool {
+	name := strings.ToLower(strings.TrimSpace(modelName))
+	if name == "" {
+		return false
+	}
+	if strings.HasPrefix(name, "gpt-5") {
+		return true
+	}
+	// o1 / o1-mini / o1-preview / o3 / o3-mini / o4-mini ...
+	// 必须精确匹配，避免误命中 "openai-..." 之类。
+	for _, prefix := range []string{"o1", "o3", "o4"} {
+		if name == prefix || strings.HasPrefix(name, prefix+"-") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/models/provider/openai_test.go
+++ b/internal/models/provider/openai_test.go
@@ -1,0 +1,46 @@
+package provider
+
+import "testing"
+
+// TestIsOpenAIReasoningOrGPT5Model 验证 GPT-5 / o-series 模型识别逻辑。
+// 见 issue #1283：这些模型必须使用 max_completion_tokens 替代 max_tokens。
+func TestIsOpenAIReasoningOrGPT5Model(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"empty", "", false},
+
+		{"gpt-5", "gpt-5", true},
+		{"gpt-5-mini", "gpt-5-mini", true},
+		{"gpt-5.2", "gpt-5.2", true},
+		{"gpt-5.5-pro", "gpt-5.5-pro", true},
+		{"gpt-5 mixed case", "GPT-5.4-Mini", true},
+
+		{"o1", "o1", true},
+		{"o1-mini", "o1-mini", true},
+		{"o1-preview", "o1-preview", true},
+		{"o3", "o3", true},
+		{"o3-mini", "o3-mini", true},
+		{"o4-mini", "o4-mini", true},
+
+		{"gpt-4", "gpt-4", false},
+		{"gpt-4o", "gpt-4o", false},
+		{"gpt-4o-mini", "gpt-4o-mini", false},
+		{"gpt-3.5-turbo", "gpt-3.5-turbo", false},
+
+		{"name starting with 'o1' but not o-series", "olympus-1", false},
+		{"name starting with 'openai-'", "openai-gpt-4", false},
+		{"name starting with 'o3' but not o-series", "o3xtra", false},
+		{"random", "qwen-max", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsOpenAIReasoningOrGPT5Model(tc.input)
+			if got != tc.want {
+				t.Errorf("IsOpenAIReasoningOrGPT5Model(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1297. The "启用实体关系提取" switch in the knowledge base GraphSettings panel was silently dropped on save, so toggling it on then reopening the KB always showed it as off.

Root cause is in `frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue` `buildSubmitData`: `extract_config` was only attached to the request when **both** `indexingStrategy.graphEnabled` and `nodeExtractConfig.enabled` were true. With the graph indexing strategy off (the default), the toggle change never reached the backend; `doSubmit` then resolved `nodeExtract.enabled` to `false` from the missing `data.extract_config` and POSTed `enabled: false` to `updateKBConfig`.

## Fix

Always emit `extract_config` based on the user's actual `nodeExtractConfig.enabled` value, with the other fields defaulted to safe empties so the toggle round-trips correctly through `updateKBConfig` regardless of whether the graph indexing strategy is enabled.

## Test plan

- [ ] Open a KB → 知识库设置 → 知识图谱配置, toggle "启用实体关系提取" on, save, reopen — switch stays on.
- [ ] Toggle it off, save, reopen — switch stays off.
- [ ] Other settings (indexing, chunking, ASR, multimodal) still save as before.