### PR TITLE
fix(compose): stop publishing docreader gRPC port to the host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,8 +188,14 @@ services:
       args:
         - APT_MIRROR=${APT_MIRROR:-}
     container_name: WeKnora-docreader
-    ports:
-      - "${DOCREADER_PORT:-50051}:50051"
+    # docreader gRPC ships without auth/TLS and is only consumed by the app
+    # container over the WeKnora-network (DOCREADER_ADDR defaults to
+    # docreader:50051), so we don't publish 50051 to the host. `expose` keeps
+    # the port reachable inside the compose network for documentation only.
+    # If you need to call docreader from outside the host (e.g. for debugging),
+    # add a `ports:` entry locally, preferably bound to 127.0.0.1.
+    expose:
+      - "50051"
     volumes:
       - docreader-tmp:/tmp/docreader
     environment:


### PR DESCRIPTION
## Summary

- The `docreader` service in `docker-compose.yml` was published to the host via `ports: ["${DOCREADER_PORT:-50051}:50051"]`, which Compose binds to `0.0.0.0`. The docreader gRPC server starts with `add_insecure_port("[::]:50051")` and has no authentication or TLS, so this default exposed an unauthenticated document parser (which can also fetch arbitrary URLs via `parse_url`) on every host interface.
- The `app` container talks to docreader entirely over the internal `WeKnora-network` using `DOCREADER_ADDR=docreader:50051`, so the host port mapping is unused in normal operation.
- Replace the `ports` entry with `expose: ["50051"]` so the port is only reachable inside the compose network. Operators who actually need host access (e.g. for debugging) can re-add a `ports:` entry in a local override, preferably bound to `127.0.0.1`.

## Test plan

- [x] `docker compose config` parses successfully after the change.
- [ ] `docker compose up -d` brings the stack up and the `app` container can still call docreader (`DOCREADER_ADDR=docreader:50051`) for ingestion and URL parsing.
- [ ] From the host, `grpcurl 127.0.0.1:50051 list` (or equivalent) no longer reaches docreader, confirming the port is no longer published.