### PR TITLE
fix: join searchable organization

### DIFF
--- a/internal/application/service/organization.go
+++ b/internal/application/service/organization.go
@@ -300,8 +300,10 @@ func (s *organizationService) JoinByOrganizationID(ctx context.Context, orgID st
 		}
 		return org, nil
 	}
-	// Direct join using invite code flow logic (add member)
-	_, err = s.JoinByInviteCode(ctx, org.InviteCode, userID, tenantID)
+	// Direct join for searchable organizations should not depend on invite code validity.
+	// Reuse AddMember so member limit and role validation stay consistent, while
+	// keeping invite-code expiry checks exclusive to the invite-code join flow.
+	err = s.AddMember(ctx, orgID, userID, tenantID, requestedRole)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
在加入共享空间中搜索到的公开空间时，会加入失败，日志中提示:

```
organization.go:717[JoinByOrganizationID] | Failed to join organization by ID: invite code has expired
```
代码中错误地复用了使用邀请码加入的方法，流程中并不存在有效邀请码。

## Type of Change
- [x] 🐛 Bug fix


## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
创建一个可被搜索的共享空间，用另一个账号测试加入

## Checklist
- [x] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
