### PR TITLE
fix(frontend): make rerank model optional in agent editor save

### DIFF
--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -3583,12 +3583,9 @@ const handleSave = async () => {
     return;
   }
 
-  // 校验 ReRank 模型（当需要时必填）
-  if (needsRerankModel.value && !formData.value.config.rerank_model_id) {
-    MessagePlugin.error(t('agent.editor.rerankModelRequired'));
-    currentSection.value = 'knowledge';
-    return;
-  }
+  // ReRank 模型（可选）
+  // 运行时若 rerank_model_id 为空会自动跳过 rerank，无需在保存时强制要求。
+  // 仅当用户已选择 rerank 模型时，才校验相关参数。
 
   // 过滤空推荐问题
   if (formData.value.config.suggested_prompts) {


### PR DESCRIPTION
The runtime chat pipeline (internal/application/service/chat_pipeline/rerank.go:56) already skips rerank when rerank_model_id is empty, so it should not be required at save time.

The editor incorrectly required rerank_model_id whenever a RAG KB was selected, even though the field is optional. This fix removes the validation so users can save agents without configuring a rerank model.

Fixes #1252

## Description

### Problem

The agent editor incorrectly required `rerank_model_id` to be set whenever a RAG knowledge base was selected, even though the runtime chat pipeline already handles missing rerank gracefully:

- **Runtime behavior** (`internal/application/service/chat_pipeline/rerank.go:56`): When `rerank_model_id` is empty, rerank is simply skipped — no error, no blocking.
- **Editor behavior** (`frontend/src/views/agent/AgentEditorModal.vue:3587`): The save validation unconditionally required `rerank_model_id` when `needsRerankModel === true` (i.e., any selected KB has RAG enabled).

This meant users could not save a "quick-answer" agent with RAG KBs unless they also configured a rerank model, even though rerank is optional.

### Solution

Removed the `rerank_model_id` required validation in `handleSave()`.

The computed property `needsRerankModel` still correctly indicates whether any selected KB needs RAG, and the UI still shows the rerank section — 

### Reproduction Steps

1. Create or edit a "quick-answer" agent
2. Select a knowledge base with RAG enabled
3. Leave `rerank_model_id` empty
4. Try to save — **before fix**: error "Rerank model is required"; **after fix**: saves successfully, rerank is skipped at runtime.

### Verification

- [x] Runtime rerank skip confirmed in `chat_pipeline/rerank.go:56`
- [x] UI still shows rerank section when `needsRerankModel === true`
- [x] Save succeeds without `rerank_model_id`
- [x] No regression to existing agents that already have `rerank_model_id` set

Fixes #1252
