### PR TITLE
feat(rbac): enforce tenant role matrix on routes (PR 2 of 3, #1303)

### DIFF
--- a/internal/application/service/custom_agent.go
+++ b/internal/application/service/custom_agent.go
@@ -65,6 +65,14 @@ func (s *customAgentService) CreateAgent(ctx context.Context, agent *types.Custo
 	}
 	agent.TenantID = tenantID
 
+	// Record the creator. Mirrors KnowledgeBase.CreatorID — needed by
+	// RBAC's RequireOwnershipOrRole so Contributors can edit their own
+	// agents. Synthetic system-{tenantID} users (X-API-Key path) leave
+	// the field empty, which makes the agent tenant-owned (Admin+ only).
+	if uid, ok := types.UserIDFromContext(ctx); ok {
+		agent.CreatedBy = uid
+	}
+
 	// Set timestamps
 	agent.CreatedAt = time.Now()
 	agent.UpdatedAt = time.Now()
@@ -405,6 +413,11 @@ func (s *customAgentService) CopyAgent(ctx context.Context, id string) (*types.C
 		Config:      sourceAgent.Config,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
+	}
+	// The clone is owned by whoever ran the copy, not the original
+	// creator — same reasoning as CopyKnowledgeBase.
+	if uid, ok := types.UserIDFromContext(ctx); ok {
+		newAgent.CreatedBy = uid
 	}
 
 	// Ensure defaults

--- a/internal/application/service/custom_agent.go
+++ b/internal/application/service/custom_agent.go
@@ -68,8 +68,9 @@ func (s *customAgentService) CreateAgent(ctx context.Context, agent *types.Custo
 	// Record the creator. Mirrors KnowledgeBase.CreatorID — needed by
 	// RBAC's RequireOwnershipOrRole so Contributors can edit their own
 	// agents. Synthetic system-{tenantID} users (X-API-Key path) leave
-	// the field empty, which makes the agent tenant-owned (Admin+ only).
-	if uid, ok := types.UserIDFromContext(ctx); ok {
+	// the field empty via IsSyntheticUserID, which makes the agent
+	// tenant-owned (Admin+ only).
+	if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
 		agent.CreatedBy = uid
 	}
 
@@ -415,8 +416,9 @@ func (s *customAgentService) CopyAgent(ctx context.Context, id string) (*types.C
 		UpdatedAt:   time.Now(),
 	}
 	// The clone is owned by whoever ran the copy, not the original
-	// creator — same reasoning as CopyKnowledgeBase.
-	if uid, ok := types.UserIDFromContext(ctx); ok {
+	// creator — same reasoning as CopyKnowledgeBase. Skip synthetic
+	// API-key users.
+	if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
 		newAgent.CreatedBy = uid
 	}
 

--- a/internal/application/service/knowledgebase.go
+++ b/internal/application/service/knowledgebase.go
@@ -84,11 +84,13 @@ func (s *knowledgeBaseService) CreateKnowledgeBase(ctx context.Context,
 	kb.UpdatedAt = time.Now()
 	// Record the creator so RBAC's RequireOwnershipOrRole can let
 	// Contributors edit their own KBs without granting them tenant-wide
-	// edit rights. UserIDFromContext returns ("", false) for the
-	// synthetic system-{tenantID} user used by the X-API-Key auth path
-	// — leaving CreatorID empty there marks the KB as tenant-owned, which
-	// matches today's API-key semantics (any human Admin can manage it).
-	if uid, ok := types.UserIDFromContext(ctx); ok {
+	// edit rights. The X-API-Key auth path attaches a synthetic
+	// `system-<tenantID>` user; we deliberately skip those so the KB
+	// stays tenant-owned (CreatorID == ""), which matches the original
+	// API-key semantics (any human Admin can manage it) and prevents a
+	// later "list KBs by creator" feature from surfacing rows nobody can
+	// re-attribute.
+	if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
 		kb.CreatorID = uid
 	}
 	kb.EnsureDefaults()
@@ -640,8 +642,9 @@ func (s *knowledgeBaseService) CopyKnowledgeBase(ctx context.Context,
 		}
 		// The clone is owned by the caller, not the original creator —
 		// otherwise a Contributor copying someone else's KB would still
-		// not be able to edit the result.
-		if uid, ok := types.UserIDFromContext(ctx); ok {
+		// not be able to edit the result. Skip synthetic API-key users
+		// (see CreateKnowledgeBase for the same reasoning).
+		if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
 			targetKB.CreatorID = uid
 		}
 		targetKB.EnsureDefaults()

--- a/internal/application/service/knowledgebase.go
+++ b/internal/application/service/knowledgebase.go
@@ -82,6 +82,15 @@ func (s *knowledgeBaseService) CreateKnowledgeBase(ctx context.Context,
 	kb.CreatedAt = time.Now()
 	kb.TenantID = types.MustTenantIDFromContext(ctx)
 	kb.UpdatedAt = time.Now()
+	// Record the creator so RBAC's RequireOwnershipOrRole can let
+	// Contributors edit their own KBs without granting them tenant-wide
+	// edit rights. UserIDFromContext returns ("", false) for the
+	// synthetic system-{tenantID} user used by the X-API-Key auth path
+	// — leaving CreatorID empty there marks the KB as tenant-owned, which
+	// matches today's API-key semantics (any human Admin can manage it).
+	if uid, ok := types.UserIDFromContext(ctx); ok {
+		kb.CreatorID = uid
+	}
 	kb.EnsureDefaults()
 
 	logger.Infof(ctx, "Creating knowledge base, ID: %s, tenant ID: %d, name: %s", kb.ID, kb.TenantID, kb.Name)
@@ -628,6 +637,12 @@ func (s *knowledgeBaseService) CopyKnowledgeBase(ctx context.Context,
 			StorageProviderConfig: sourceKB.StorageProviderConfig,
 			StorageConfig:         sourceKB.StorageConfig,
 			FAQConfig:             faqConfig,
+		}
+		// The clone is owned by the caller, not the original creator —
+		// otherwise a Contributor copying someone else's KB would still
+		// not be able to edit the result.
+		if uid, ok := types.UserIDFromContext(ctx); ok {
+			targetKB.CreatorID = uid
 		}
 		targetKB.EnsureDefaults()
 		if err := s.repo.CreateKnowledgeBase(ctx, targetKB); err != nil {

--- a/internal/handler/rbac_lookups.go
+++ b/internal/handler/rbac_lookups.go
@@ -1,0 +1,70 @@
+package handler
+
+import (
+	"errors"
+
+	apprepo "github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+// Per-resource creator-id resolvers used by middleware.RequireOwnershipOrRole.
+// The route registration wires these as closures so they capture the handler's
+// service dependencies; the middleware just calls them with the gin.Context
+// and gets back ("", nil) for legacy tenant-owned rows or (creatorID, nil)
+// for resources we know how to attribute.
+//
+// Lookup contract (mirrors middleware.CreatorLookup):
+//   - URL param missing -> error (the middleware will 403; better than
+//     letting an unauthenticated mutation through on a malformed route).
+//   - Resource not found -> error (downstream handler would 404 anyway,
+//     and middleware-level 403 is a fine signal to clients).
+//   - Resource found but creator_id == "" -> ("", nil); the middleware
+//     treats that as tenant-owned and falls back to pure role check.
+
+// KBCreatorLookup resolves :id -> KnowledgeBase.CreatorID. Used by all
+// per-KB mutating routes.
+func (h *KnowledgeBaseHandler) KBCreatorLookup(c *gin.Context) (string, error) {
+	id := c.Param("id")
+	if id == "" {
+		return "", errors.New("missing :id param for KB creator lookup")
+	}
+	kb, err := h.service.GetKnowledgeBaseByID(c.Request.Context(), id)
+	if err != nil {
+		return "", err
+	}
+	if kb == nil {
+		return "", apprepo.ErrKnowledgeBaseNotFound
+	}
+	return kb.CreatorID, nil
+}
+
+// AgentCreatorLookup resolves :id -> CustomAgent.CreatedBy. Built-in
+// agents (IsBuiltin == true) are tenant-owned across the board: they
+// belong to the tenant rather than to any one user, so we return
+// ("", nil) and let the role check decide. The same holds for legacy
+// rows whose CreatedBy was never populated.
+func (h *CustomAgentHandler) AgentCreatorLookup(c *gin.Context) (string, error) {
+	id := c.Param("id")
+	if id == "" {
+		return "", errors.New("missing :id param for agent creator lookup")
+	}
+	agent, err := h.service.GetAgentByID(c.Request.Context(), id)
+	if err != nil {
+		return "", err
+	}
+	if agent == nil {
+		return "", errors.New("agent not found")
+	}
+	if agent.IsBuiltin {
+		return "", nil
+	}
+	return agent.CreatedBy, nil
+}
+
+// Compile-time guards: the methods must satisfy middleware.CreatorLookup
+// so route wiring stays type-safe even if a signature drifts.
+var (
+	_ middleware.CreatorLookup = (*KnowledgeBaseHandler)(nil).KBCreatorLookup
+	_ middleware.CreatorLookup = (*CustomAgentHandler)(nil).AgentCreatorLookup
+)

--- a/internal/handler/rbac_lookups.go
+++ b/internal/handler/rbac_lookups.go
@@ -4,37 +4,59 @@ import (
 	"errors"
 
 	apprepo "github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/application/service"
 	"github.com/Tencent/WeKnora/internal/middleware"
+	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/gin-gonic/gin"
 )
 
 // Per-resource creator-id resolvers used by middleware.RequireOwnershipOrRole.
 // The route registration wires these as closures so they capture the handler's
 // service dependencies; the middleware just calls them with the gin.Context
-// and gets back ("", nil) for legacy tenant-owned rows or (creatorID, nil)
-// for resources we know how to attribute.
+// and gets back one of:
 //
-// Lookup contract (mirrors middleware.CreatorLookup):
-//   - URL param missing -> error (the middleware will 403; better than
-//     letting an unauthenticated mutation through on a malformed route).
-//   - Resource not found -> error (downstream handler would 404 anyway,
-//     and middleware-level 403 is a fine signal to clients).
-//   - Resource found but creator_id == "" -> ("", nil); the middleware
-//     treats that as tenant-owned and falls back to pure role check.
+//   - (creatorID, nil)            : ownership match check decides
+//   - ("",        nil)            : tenant-owned (legacy or built-in)
+//   - ("", ErrResourceNotFound)   : :id doesn't resolve in this tenant;
+//                                   middleware passes through so the
+//                                   handler can issue a real 404
+//   - ("", <other err>)           : transient/unexpected failure;
+//                                   middleware will 503 the request
+//
+// Tenant scoping is enforced INSIDE the lookup: even if the underlying
+// `Get*ByID` repo call is unscoped, the lookup re-checks `tenant_id`
+// against the caller's context. This stops a creator-match shortcut
+// from leaking access to a same-ID resource in a different tenant.
 
-// KBCreatorLookup resolves :id -> KnowledgeBase.CreatorID. Used by all
-// per-KB mutating routes.
+// KBCreatorLookup resolves :id -> KnowledgeBase.CreatorID, scoped to
+// the caller's tenant. Used by all per-KB mutating routes.
 func (h *KnowledgeBaseHandler) KBCreatorLookup(c *gin.Context) (string, error) {
 	id := c.Param("id")
 	if id == "" {
 		return "", errors.New("missing :id param for KB creator lookup")
 	}
-	kb, err := h.service.GetKnowledgeBaseByID(c.Request.Context(), id)
+	ctx := c.Request.Context()
+	tenantID, ok := types.TenantIDFromContext(ctx)
+	if !ok {
+		// 没有租户上下文意味着 auth 中间件未完成；当作 lookup 失败让上层 503，
+		// 而不是 silently 走 fail-open 给一个不该有的访问。
+		return "", errors.New("tenant context missing")
+	}
+	kb, err := h.service.GetKnowledgeBaseByID(ctx, id)
 	if err != nil {
+		if errors.Is(err, apprepo.ErrKnowledgeBaseNotFound) {
+			return "", middleware.ErrResourceNotFound
+		}
 		return "", err
 	}
 	if kb == nil {
-		return "", apprepo.ErrKnowledgeBaseNotFound
+		return "", middleware.ErrResourceNotFound
+	}
+	// 显式重校验租户：repo.GetKnowledgeBaseByID 不带 tenant 过滤，
+	// 万一未来 :id 被攻击者从他人租户 UUID 试探到，也不会借由
+	// "ownership match" 通过中间件。
+	if kb.TenantID != tenantID {
+		return "", middleware.ErrResourceNotFound
 	}
 	return kb.CreatorID, nil
 }
@@ -44,17 +66,33 @@ func (h *KnowledgeBaseHandler) KBCreatorLookup(c *gin.Context) (string, error) {
 // belong to the tenant rather than to any one user, so we return
 // ("", nil) and let the role check decide. The same holds for legacy
 // rows whose CreatedBy was never populated.
+//
+// The underlying GetAgentByID already scopes to the caller's tenant,
+// but we keep an explicit defence-in-depth check here in case future
+// refactors loosen the service-layer scope.
 func (h *CustomAgentHandler) AgentCreatorLookup(c *gin.Context) (string, error) {
 	id := c.Param("id")
 	if id == "" {
 		return "", errors.New("missing :id param for agent creator lookup")
 	}
-	agent, err := h.service.GetAgentByID(c.Request.Context(), id)
+	ctx := c.Request.Context()
+	tenantID, ok := types.TenantIDFromContext(ctx)
+	if !ok {
+		return "", errors.New("tenant context missing")
+	}
+	agent, err := h.service.GetAgentByID(ctx, id)
 	if err != nil {
+		if errors.Is(err, service.ErrAgentNotFound) ||
+			errors.Is(err, apprepo.ErrCustomAgentNotFound) {
+			return "", middleware.ErrResourceNotFound
+		}
 		return "", err
 	}
 	if agent == nil {
-		return "", errors.New("agent not found")
+		return "", middleware.ErrResourceNotFound
+	}
+	if agent.TenantID != tenantID {
+		return "", middleware.ErrResourceNotFound
 	}
 	if agent.IsBuiltin {
 		return "", nil

--- a/internal/handler/rbac_lookups_test.go
+++ b/internal/handler/rbac_lookups_test.go
@@ -1,0 +1,150 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	apprepo "github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/application/service"
+	"github.com/Tencent/WeKnora/internal/middleware"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/gin-gonic/gin"
+)
+
+// The lookup helpers translate handler/service errors into the
+// middleware sentinel set; that translation is where bugs hide (404
+// becoming 403, cross-tenant leaks, etc.), so we test those edges
+// directly rather than via end-to-end HTTP.
+
+// stubKBService implements just enough of interfaces.KnowledgeBaseService
+// to drive KBCreatorLookup. Any other method panics so the test fails
+// loudly if a future lookup refactor reaches outside the contract.
+type stubKBService struct {
+	interfaces.KnowledgeBaseService
+	get func(ctx context.Context, id string) (*types.KnowledgeBase, error)
+}
+
+func (s *stubKBService) GetKnowledgeBaseByID(ctx context.Context, id string) (*types.KnowledgeBase, error) {
+	return s.get(ctx, id)
+}
+
+func newKBLookupCtx(t *testing.T, tenantID uint64, paramID string) *gin.Context {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/x", nil)
+	ctx := context.WithValue(c.Request.Context(), types.TenantIDContextKey, tenantID)
+	c.Request = c.Request.WithContext(ctx)
+	c.Params = gin.Params{{Key: "id", Value: paramID}}
+	return c
+}
+
+func TestKBCreatorLookup_NotFoundMapsToSentinel(t *testing.T) {
+	h := &KnowledgeBaseHandler{service: &stubKBService{
+		get: func(_ context.Context, _ string) (*types.KnowledgeBase, error) {
+			return nil, apprepo.ErrKnowledgeBaseNotFound
+		},
+	}}
+	_, err := h.KBCreatorLookup(newKBLookupCtx(t, 1, "kb-1"))
+	if !errors.Is(err, middleware.ErrResourceNotFound) {
+		t.Fatalf("expected ErrResourceNotFound, got %v", err)
+	}
+}
+
+func TestKBCreatorLookup_CrossTenantIsHiddenAsNotFound(t *testing.T) {
+	// A foreign-tenant KB must NEVER leak via the ownership shortcut.
+	// Returning the row's CreatorID would let a user-id collision pass
+	// the middleware's "creator == uid" branch; hiding it as not-found
+	// keeps the lookup strictly tenant-scoped.
+	h := &KnowledgeBaseHandler{service: &stubKBService{
+		get: func(_ context.Context, _ string) (*types.KnowledgeBase, error) {
+			return &types.KnowledgeBase{ID: "kb-1", TenantID: 999, CreatorID: "u1"}, nil
+		},
+	}}
+	_, err := h.KBCreatorLookup(newKBLookupCtx(t, 1, "kb-1"))
+	if !errors.Is(err, middleware.ErrResourceNotFound) {
+		t.Fatalf("cross-tenant KB must surface as not-found, got %v", err)
+	}
+}
+
+func TestKBCreatorLookup_OwnerMatchReturnsCreatorID(t *testing.T) {
+	h := &KnowledgeBaseHandler{service: &stubKBService{
+		get: func(_ context.Context, _ string) (*types.KnowledgeBase, error) {
+			return &types.KnowledgeBase{ID: "kb-1", TenantID: 1, CreatorID: "u-creator"}, nil
+		},
+	}}
+	creator, err := h.KBCreatorLookup(newKBLookupCtx(t, 1, "kb-1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creator != "u-creator" {
+		t.Fatalf("expected creator=u-creator, got %q", creator)
+	}
+}
+
+func TestKBCreatorLookup_MissingTenantContext(t *testing.T) {
+	// Without tenant context, the lookup can't decide scope. Surfacing
+	// a real error (which middleware turns into 503) is safer than
+	// silently returning ErrResourceNotFound: the request shouldn't be
+	// happening at all.
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/x", nil)
+	c.Params = gin.Params{{Key: "id", Value: "kb-1"}}
+	h := &KnowledgeBaseHandler{service: &stubKBService{
+		get: func(_ context.Context, _ string) (*types.KnowledgeBase, error) {
+			t.Fatalf("service must not be called without tenant context")
+			return nil, nil
+		},
+	}}
+	_, err := h.KBCreatorLookup(c)
+	if err == nil {
+		t.Fatalf("expected error when tenant context missing")
+	}
+	if errors.Is(err, middleware.ErrResourceNotFound) {
+		t.Fatalf("missing tenant must not be reported as not-found: %v", err)
+	}
+}
+
+// stubAgentService mirrors stubKBService for the agent lookup tests.
+type stubAgentService struct {
+	interfaces.CustomAgentService
+	get func(ctx context.Context, id string) (*types.CustomAgent, error)
+}
+
+func (s *stubAgentService) GetAgentByID(ctx context.Context, id string) (*types.CustomAgent, error) {
+	return s.get(ctx, id)
+}
+
+func TestAgentCreatorLookup_BuiltinIsTenantOwned(t *testing.T) {
+	h := &CustomAgentHandler{service: &stubAgentService{
+		get: func(_ context.Context, _ string) (*types.CustomAgent, error) {
+			return &types.CustomAgent{
+				ID: "smart-reasoning", TenantID: 1, IsBuiltin: true, CreatedBy: "ignored",
+			}, nil
+		},
+	}}
+	creator, err := h.AgentCreatorLookup(newKBLookupCtx(t, 1, "smart-reasoning"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creator != "" {
+		t.Fatalf("built-in agent must surface as tenant-owned (empty creator), got %q", creator)
+	}
+}
+
+func TestAgentCreatorLookup_AgentNotFoundMapsToSentinel(t *testing.T) {
+	h := &CustomAgentHandler{service: &stubAgentService{
+		get: func(_ context.Context, _ string) (*types.CustomAgent, error) {
+			return nil, service.ErrAgentNotFound
+		},
+	}}
+	_, err := h.AgentCreatorLookup(newKBLookupCtx(t, 1, "missing-agent"))
+	if !errors.Is(err, middleware.ErrResourceNotFound) {
+		t.Fatalf("expected ErrResourceNotFound, got %v", err)
+	}
+}

--- a/internal/handler/rbac_lookups_test.go
+++ b/internal/handler/rbac_lookups_test.go
@@ -148,3 +148,24 @@ func TestAgentCreatorLookup_AgentNotFoundMapsToSentinel(t *testing.T) {
 		t.Fatalf("expected ErrResourceNotFound, got %v", err)
 	}
 }
+
+func TestAgentCreatorLookup_CrossTenantIsHiddenAsNotFound(t *testing.T) {
+	// Defensive: service.GetAgentByID already scopes by tenant, but
+	// AgentCreatorLookup re-checks the row's TenantID anyway. If a
+	// future refactor loosens the service-layer scope (or adds a
+	// cross-tenant variant that gets wired here by mistake), a
+	// foreign-tenant row must NEVER leak through the ownership
+	// shortcut. Pinning the contract here so the defensive branch
+	// survives refactors.
+	h := &CustomAgentHandler{service: &stubAgentService{
+		get: func(_ context.Context, _ string) (*types.CustomAgent, error) {
+			return &types.CustomAgent{
+				ID: "agent-1", TenantID: 999, CreatedBy: "u1",
+			}, nil
+		},
+	}}
+	_, err := h.AgentCreatorLookup(newKBLookupCtx(t, 1, "agent-1"))
+	if !errors.Is(err, middleware.ErrResourceNotFound) {
+		t.Fatalf("cross-tenant agent must surface as not-found, got %v", err)
+	}
+}

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -507,6 +507,28 @@ func (h *Handler) AgentQA(c *gin.Context) {
 			agentModeEnabled, reqCtx.customAgent.Config.AgentMode)
 	}
 
+	// Tenant-RBAC gate: block Viewers from running agents whose author
+	// has cleared RunnableByViewer. The flag exists so an admin can mark
+	// an agent as "internal tools only" without turning every viewer
+	// into a contributor. Gated behind cfg.Tenant.EnableRBAC so the
+	// check is dormant during the rollout window — same pattern as
+	// middleware/rbac.go.
+	if agentModeEnabled && reqCtx.customAgent != nil && !reqCtx.customAgent.RunnableByViewer {
+		role := types.TenantRoleFromContext(reqCtx.ctx)
+		if !role.HasPermission(types.TenantRoleContributor) {
+			if h.config != nil && h.config.Tenant != nil && h.config.Tenant.EnableRBAC {
+				logger.Warnf(reqCtx.ctx,
+					"[rbac] agent run blocked: viewer cannot run runnable_by_viewer=false agent: agent=%s role=%s",
+					reqCtx.customAgent.ID, role)
+				c.Error(errors.NewForbiddenError("Forbidden: this agent is restricted to contributors and above"))
+				return
+			}
+			logger.Warnf(reqCtx.ctx,
+				"[rbac] agent run would be blocked (logged, not enforced): agent=%s role=%s",
+				reqCtx.customAgent.ID, role)
+		}
+	}
+
 	// Route to appropriate handler based on agent mode
 	if agentModeEnabled {
 		h.executeQA(reqCtx, qaModeAgent, true)

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -220,6 +220,12 @@ func Auth(
 			// 确保所有依赖 UserContextKey 的下游 handler 正常工作。
 			user, err := userService.GetUserByTenantID(c.Request.Context(), tenantID)
 			if err != nil || user == nil {
+				// Synthetic user. The "system-<tenantID>" shape is recognised
+				// by types.IsSyntheticUserID, which RBAC service-layer code
+				// uses to skip recording these IDs as a resource creator.
+				// Do NOT change the prefix or numeric suffix without
+				// updating that helper, otherwise KB/Agent CreatorID will
+				// silently start pointing at the synthetic user again.
 				user = &types.User{
 					ID:       fmt.Sprintf("system-%d", tenantID),
 					Username: fmt.Sprintf("system-%d", tenantID),

--- a/internal/middleware/rbac.go
+++ b/internal/middleware/rbac.go
@@ -1,0 +1,149 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/gin-gonic/gin"
+)
+
+// CreatorLookup resolves the creator user ID for the resource targeted
+// by the current request, based on whatever is on the gin.Context (URL
+// params, query, body). Implementations live next to the handlers they
+// guard, e.g. handler.kbCreatorLookup(c) reads ":id" and returns
+// KnowledgeBase.CreatorID.
+//
+// Returning ("", nil) means "no creator recorded" — the resource pre-dates
+// the migration backfill. RequireOwnershipOrRole treats this as
+// "tenant-owned" and requires the role check to pass.
+//
+// Any non-nil error short-circuits the request with 403; callers should
+// distinguish "not found" (404 in the handler if needed) from genuine
+// failures inside their lookup helper.
+type CreatorLookup func(c *gin.Context) (creatorID string, err error)
+
+// RequireRole returns a gin middleware that aborts the request with
+// HTTP 403 unless the caller's TenantRole (set by the auth middleware
+// in TenantRoleContextKey) is at least min.
+//
+// When cfg.Tenant.EnableRBAC is false, the middleware logs the would-be
+// rejection but lets the request through — preserving today's behaviour
+// during the rollout window. Once operators flip the flag to true,
+// the same code paths start rejecting unauthorised callers.
+//
+// The auth middleware always sets a TenantRole; if for some reason it
+// is missing, TenantRoleFromContext defaults to TenantRoleViewer, which
+// is the safest fail-closed value: anything that requires more than
+// Viewer will reject.
+func RequireRole(min types.TenantRole, cfg *config.Config) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		role := types.TenantRoleFromContext(c.Request.Context())
+		if role.HasPermission(min) {
+			c.Next()
+			return
+		}
+		uid, _ := types.UserIDFromContext(c.Request.Context())
+		if !rbacEnforcementEnabled(cfg) {
+			logger.Warnf(c.Request.Context(),
+				"[rbac] role insufficient (logged but not enforced): user=%s have=%s need=%s path=%s",
+				uid, role, min, c.Request.URL.Path)
+			c.Next()
+			return
+		}
+		logger.Warnf(c.Request.Context(),
+			"[rbac] role insufficient: user=%s have=%s need=%s path=%s",
+			uid, role, min, c.Request.URL.Path)
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": "Forbidden: insufficient tenant role",
+		})
+		c.Abort()
+	}
+}
+
+// RequireOwnershipOrRole guards endpoints whose access is allowed for
+// either (a) callers whose role is at least min, or (b) the original
+// creator of the resource being touched.
+//
+// Use it for KB / agent mutations where Contributors should only manage
+// their own resources but Admins+ have free reign. The lookup closure
+// is responsible for translating the URL into the resource's creator
+// user ID.
+//
+// Decision order:
+//  1. role >= min -> allow.
+//  2. lookup returns the caller's user ID -> allow.
+//  3. lookup returns a non-empty different user ID -> deny (or log when
+//     enforcement is disabled).
+//  4. lookup returns an empty creator ID (legacy / unmigrated row) ->
+//     treat as tenant-owned; only role >= min may proceed. Effectively
+//     equivalent to step 1 for that row.
+//  5. lookup returns an error -> deny (don't fail open on lookup errors:
+//     a broken creator query is more often a bug than a transient blip,
+//     and treating a load failure as "approve" would be a footgun).
+//
+// Like RequireRole, when cfg.Tenant.EnableRBAC is false the middleware
+// logs but does not block.
+func RequireOwnershipOrRole(min types.TenantRole, lookup CreatorLookup, cfg *config.Config) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		role := types.TenantRoleFromContext(ctx)
+
+		// Fast path: role meets the bar, skip the lookup entirely.
+		if role.HasPermission(min) {
+			c.Next()
+			return
+		}
+
+		uid, _ := types.UserIDFromContext(ctx)
+		creator, err := lookup(c)
+		if err != nil {
+			logger.Warnf(ctx,
+				"[rbac] creator lookup failed: user=%s path=%s err=%v",
+				uid, c.Request.URL.Path, err)
+			if !rbacEnforcementEnabled(cfg) {
+				c.Next()
+				return
+			}
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "Forbidden: cannot verify resource ownership",
+			})
+			c.Abort()
+			return
+		}
+
+		// Ownership match wins even when role is below min — that's the
+		// whole point: Contributors can edit their own resources.
+		if creator != "" && creator == uid {
+			c.Next()
+			return
+		}
+
+		if !rbacEnforcementEnabled(cfg) {
+			logger.Warnf(ctx,
+				"[rbac] ownership/role insufficient (logged, not enforced): "+
+					"user=%s have=%s need=%s creator=%q path=%s",
+				uid, role, min, creator, c.Request.URL.Path)
+			c.Next()
+			return
+		}
+
+		logger.Warnf(ctx,
+			"[rbac] ownership/role insufficient: user=%s have=%s need=%s creator=%q path=%s",
+			uid, role, min, creator, c.Request.URL.Path)
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": "Forbidden: must own the resource or have the required role",
+		})
+		c.Abort()
+	}
+}
+
+// rbacEnforcementEnabled reports whether middleware should actually
+// reject failed checks. When the flag is off the middleware still runs
+// (so role lookups exercise the membership table and any logging fires)
+// but rejection is downgraded to a warning. Mirrors the pattern in
+// resolveTenantRole's fail-open branch in middleware/auth.go.
+func rbacEnforcementEnabled(cfg *config.Config) bool {
+	return cfg != nil && cfg.Tenant != nil && cfg.Tenant.EnableRBAC
+}

--- a/internal/middleware/rbac.go
+++ b/internal/middleware/rbac.go
@@ -1,7 +1,10 @@
 package middleware
 
 import (
+	"context"
+	"errors"
 	"net/http"
+	"sync"
 
 	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -9,24 +12,48 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// ErrResourceNotFound is the sentinel a CreatorLookup returns when the
+// :id on the request does not match any row the lookup can see (either
+// the row is genuinely missing or its tenant doesn't match). When a
+// lookup returns this error, RequireOwnershipOrRole intentionally lets
+// the request proceed so the downstream handler can respond with its
+// own 404 — middleware-level 403 would hide real "URL is wrong" failures
+// behind a permissions error, which breaks client diagnostics and
+// operator dashboards.
+var ErrResourceNotFound = errors.New("rbac: resource not found")
+
 // CreatorLookup resolves the creator user ID for the resource targeted
 // by the current request, based on whatever is on the gin.Context (URL
 // params, query, body). Implementations live next to the handlers they
 // guard, e.g. handler.kbCreatorLookup(c) reads ":id" and returns
 // KnowledgeBase.CreatorID.
 //
-// Returning ("", nil) means "no creator recorded" — the resource pre-dates
-// the migration backfill. RequireOwnershipOrRole treats this as
-// "tenant-owned" and requires the role check to pass.
-//
-// Any non-nil error short-circuits the request with 403; callers should
-// distinguish "not found" (404 in the handler if needed) from genuine
-// failures inside their lookup helper.
+// Return value contract:
+//   - (creatorID, nil) where creatorID != ""  -> the resource has a
+//     recorded owner; ownership match grants access.
+//   - ("", nil)                                -> "tenant-owned": no
+//     human creator was recorded (legacy row or built-in resource);
+//     only callers whose role meets the bar may proceed.
+//   - ("", ErrResourceNotFound)                -> the :id does not
+//     resolve to any row visible to this caller's tenant. Middleware
+//     proceeds to the handler so the handler can return 404 instead
+//     of masking it as 403.
+//   - ("", other error)                        -> transient or
+//     unexpected failure (DB hiccup, etc.). Middleware returns 503
+//     when enforcement is on so monitoring catches the real fault;
+//     when enforcement is off, it logs and lets the request through.
 type CreatorLookup func(c *gin.Context) (creatorID string, err error)
 
 // RequireRole returns a gin middleware that aborts the request with
 // HTTP 403 unless the caller's TenantRole (set by the auth middleware
 // in TenantRoleContextKey) is at least min.
+//
+// Cross-tenant superusers (User.CanAccessAllTenants) automatically
+// satisfy any role gate. Otherwise rolling out tenant-RBAC would silently
+// break organisation-level operators who own no tenant_members row in
+// the tenant they're administering. The escape hatch is bounded by the
+// existing canAccessTenant gate in auth.go; this middleware does not
+// grant extra reach, only honours what was already approved.
 //
 // When cfg.Tenant.EnableRBAC is false, the middleware logs the would-be
 // rejection but lets the request through — preserving today's behaviour
@@ -38,21 +65,27 @@ type CreatorLookup func(c *gin.Context) (creatorID string, err error)
 // is the safest fail-closed value: anything that requires more than
 // Viewer will reject.
 func RequireRole(min types.TenantRole, cfg *config.Config) gin.HandlerFunc {
+	warnOnNilConfig(cfg)
 	return func(c *gin.Context) {
-		role := types.TenantRoleFromContext(c.Request.Context())
+		ctx := c.Request.Context()
+		role := types.TenantRoleFromContext(ctx)
 		if role.HasPermission(min) {
 			c.Next()
 			return
 		}
-		uid, _ := types.UserIDFromContext(c.Request.Context())
+		if isCrossTenantSuperuser(ctx) {
+			c.Next()
+			return
+		}
+		uid, _ := types.UserIDFromContext(ctx)
 		if !rbacEnforcementEnabled(cfg) {
-			logger.Warnf(c.Request.Context(),
+			logger.Warnf(ctx,
 				"[rbac] role insufficient (logged but not enforced): user=%s have=%s need=%s path=%s",
 				uid, role, min, c.Request.URL.Path)
 			c.Next()
 			return
 		}
-		logger.Warnf(c.Request.Context(),
+		logger.Warnf(ctx,
 			"[rbac] role insufficient: user=%s have=%s need=%s path=%s",
 			uid, role, min, c.Request.URL.Path)
 		c.JSON(http.StatusForbidden, gin.H{
@@ -69,66 +102,81 @@ func RequireRole(min types.TenantRole, cfg *config.Config) gin.HandlerFunc {
 // Use it for KB / agent mutations where Contributors should only manage
 // their own resources but Admins+ have free reign. The lookup closure
 // is responsible for translating the URL into the resource's creator
-// user ID.
+// user ID (see CreatorLookup for the return-value contract).
 //
 // Decision order:
-//  1. role >= min -> allow.
-//  2. lookup returns the caller's user ID -> allow.
-//  3. lookup returns a non-empty different user ID -> deny (or log when
-//     enforcement is disabled).
-//  4. lookup returns an empty creator ID (legacy / unmigrated row) ->
-//     treat as tenant-owned; only role >= min may proceed. Effectively
-//     equivalent to step 1 for that row.
-//  5. lookup returns an error -> deny (don't fail open on lookup errors:
-//     a broken creator query is more often a bug than a transient blip,
-//     and treating a load failure as "approve" would be a footgun).
-//
-// Like RequireRole, when cfg.Tenant.EnableRBAC is false the middleware
-// logs but does not block.
+//  1. role >= min -> allow without running lookup.
+//  2. cross-tenant superuser -> allow without running lookup.
+//  3. enforcement off -> log, allow without running lookup. This is the
+//     critical rollout-safety guarantee: when EnableRBAC is false, the
+//     lookup is NEVER invoked, so dormant mode incurs zero extra DB
+//     roundtrips on hot per-resource mutation paths.
+//  4. lookup returns ErrResourceNotFound -> pass through; let the
+//     handler issue the proper 404.
+//  5. lookup returns other error -> 503 (transient/unexpected fault).
+//     Preserves observability instead of disguising server errors as 403.
+//  6. lookup returns the caller's user ID -> allow (ownership match).
+//  7. lookup returns "" -> tenant-owned, role check already failed: 403.
+//  8. lookup returns a different non-empty user ID -> 403.
 func RequireOwnershipOrRole(min types.TenantRole, lookup CreatorLookup, cfg *config.Config) gin.HandlerFunc {
+	warnOnNilConfig(cfg)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		role := types.TenantRoleFromContext(ctx)
 
-		// Fast path: role meets the bar, skip the lookup entirely.
+		// 1. Fast path: role meets the bar.
 		if role.HasPermission(min) {
 			c.Next()
 			return
 		}
 
+		// 2. Cross-tenant superuser bypass — same reasoning as RequireRole.
+		if isCrossTenantSuperuser(ctx) {
+			c.Next()
+			return
+		}
+
 		uid, _ := types.UserIDFromContext(ctx)
-		creator, err := lookup(c)
-		if err != nil {
+
+		// 3. Fail-open shortcut: when enforcement is off, do NOT run the
+		//    lookup. Running it would add a hidden DB roundtrip on every
+		//    mutating request during the rollout window — see #1318 review.
+		if !rbacEnforcementEnabled(cfg) {
 			logger.Warnf(ctx,
+				"[rbac] ownership/role would be checked (enforcement off, lookup skipped): "+
+					"user=%s have=%s need=%s path=%s",
+				uid, role, min, c.Request.URL.Path)
+			c.Next()
+			return
+		}
+
+		creator, err := lookup(c)
+		switch {
+		case errors.Is(err, ErrResourceNotFound):
+			// 4. Hand off to the handler so the client sees a real 404
+			//    rather than a fake "no permission" 403.
+			c.Next()
+			return
+		case err != nil:
+			// 5. Genuine failure — surface it as 5xx so monitoring catches it.
+			logger.Errorf(ctx,
 				"[rbac] creator lookup failed: user=%s path=%s err=%v",
 				uid, c.Request.URL.Path, err)
-			if !rbacEnforcementEnabled(cfg) {
-				c.Next()
-				return
-			}
-			c.JSON(http.StatusForbidden, gin.H{
-				"error": "Forbidden: cannot verify resource ownership",
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"error": "Service Unavailable: cannot verify resource ownership",
 			})
 			c.Abort()
 			return
 		}
 
-		// Ownership match wins even when role is below min — that's the
-		// whole point: Contributors can edit their own resources.
+		// 6. Ownership match wins even when role is below min — that's the
+		//    whole point: Contributors can edit their own resources.
 		if creator != "" && creator == uid {
 			c.Next()
 			return
 		}
 
-		if !rbacEnforcementEnabled(cfg) {
-			logger.Warnf(ctx,
-				"[rbac] ownership/role insufficient (logged, not enforced): "+
-					"user=%s have=%s need=%s creator=%q path=%s",
-				uid, role, min, creator, c.Request.URL.Path)
-			c.Next()
-			return
-		}
-
+		// 7-8. Tenant-owned (creator=="") or non-creator with insufficient role.
 		logger.Warnf(ctx,
 			"[rbac] ownership/role insufficient: user=%s have=%s need=%s creator=%q path=%s",
 			uid, role, min, creator, c.Request.URL.Path)
@@ -141,9 +189,43 @@ func RequireOwnershipOrRole(min types.TenantRole, lookup CreatorLookup, cfg *con
 
 // rbacEnforcementEnabled reports whether middleware should actually
 // reject failed checks. When the flag is off the middleware still runs
-// (so role lookups exercise the membership table and any logging fires)
-// but rejection is downgraded to a warning. Mirrors the pattern in
-// resolveTenantRole's fail-open branch in middleware/auth.go.
+// role-only checks (logging, fast paths), but rejection is downgraded
+// to a warning and ownership lookups are skipped entirely so the dormant
+// rollout window incurs no per-request DB cost.
 func rbacEnforcementEnabled(cfg *config.Config) bool {
 	return cfg != nil && cfg.Tenant != nil && cfg.Tenant.EnableRBAC
+}
+
+// isCrossTenantSuperuser reports whether the caller is an org-level
+// superuser whose CanAccessAllTenants flag was honoured by the auth
+// middleware (cfg.Tenant.EnableCrossTenantAccess must also be on for
+// the flag to mean anything operationally). Such callers bypass tenant
+// role gates because their access is already governed by a separate
+// org-level authorisation check.
+func isCrossTenantSuperuser(ctx context.Context) bool {
+	u, ok := ctx.Value(types.UserContextKey).(*types.User)
+	if !ok || u == nil {
+		return false
+	}
+	return u.CanAccessAllTenants
+}
+
+// warnOnNilConfig emits a one-shot startup warning when a guard is
+// constructed with a nil-or-incomplete config. nil cfg makes
+// rbacEnforcementEnabled return false, which means an entire deployment
+// silently runs with RBAC disabled — usually because of a configuration
+// bug rather than an intentional choice. Operators should see a noisy
+// log line at boot pointing at the misconfiguration.
+var nilCfgWarnOnce sync.Once
+
+func warnOnNilConfig(cfg *config.Config) {
+	if cfg != nil && cfg.Tenant != nil {
+		return
+	}
+	nilCfgWarnOnce.Do(func() {
+		logger.Errorf(context.Background(),
+			"[rbac] middleware constructed with nil/incomplete config "+
+				"(cfg=%v); enforcement is permanently disabled. This is "+
+				"almost certainly a wiring bug.", cfg)
+	})
 }

--- a/internal/middleware/rbac.go
+++ b/internal/middleware/rbac.go
@@ -116,8 +116,9 @@ func RequireRole(min types.TenantRole, cfg *config.Config) gin.HandlerFunc {
 //  5. lookup returns other error -> 503 (transient/unexpected fault).
 //     Preserves observability instead of disguising server errors as 403.
 //  6. lookup returns the caller's user ID -> allow (ownership match).
-//  7. lookup returns "" -> tenant-owned, role check already failed: 403.
-//  8. lookup returns a different non-empty user ID -> 403.
+//  7. lookup returns "" (tenant-owned, no human creator) -> 403 (we
+//     already know role < min from step 1).
+//  8. lookup returns a non-empty creator that is not the caller -> 403.
 func RequireOwnershipOrRole(min types.TenantRole, lookup CreatorLookup, cfg *config.Config) gin.HandlerFunc {
 	warnOnNilConfig(cfg)
 	return func(c *gin.Context) {

--- a/internal/middleware/rbac_test.go
+++ b/internal/middleware/rbac_test.go
@@ -1,0 +1,178 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/gin-gonic/gin"
+)
+
+// rbacTestHarness builds a tiny gin engine with the RBAC middleware in
+// front of a no-op handler. It seeds context just like the real auth
+// middleware would, so RequireRole / RequireOwnershipOrRole see the
+// expected TenantRole and UserID.
+//
+// Returning the recorder rather than asserting inline keeps each test
+// case focused on the (input -> status) pair it cares about.
+func rbacTestHarness(role types.TenantRole, userID string, mw gin.HandlerFunc) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		// Mirror what middleware/auth.go's JWT path sets.
+		ctx := context.WithValue(c.Request.Context(), types.TenantRoleContextKey, role)
+		ctx = context.WithValue(ctx, types.UserIDContextKey, userID)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	r.GET("/protected", mw, func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func cfgRBAC(enabled bool) *config.Config {
+	return &config.Config{Tenant: &config.TenantConfig{EnableRBAC: enabled}}
+}
+
+// ---------- RequireRole ----------
+
+func TestRequireRole_AllowsAtMin(t *testing.T) {
+	w := rbacTestHarness(types.TenantRoleAdmin, "u1",
+		RequireRole(types.TenantRoleAdmin, cfgRBAC(true)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("Admin should clear Admin gate, got %d", w.Code)
+	}
+}
+
+func TestRequireRole_AllowsAboveMin(t *testing.T) {
+	w := rbacTestHarness(types.TenantRoleOwner, "u1",
+		RequireRole(types.TenantRoleAdmin, cfgRBAC(true)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("Owner should clear Admin gate, got %d", w.Code)
+	}
+}
+
+func TestRequireRole_RejectsBelowMin(t *testing.T) {
+	w := rbacTestHarness(types.TenantRoleContributor, "u1",
+		RequireRole(types.TenantRoleAdmin, cfgRBAC(true)))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("Contributor must NOT clear Admin gate, got %d", w.Code)
+	}
+}
+
+func TestRequireRole_FailOpenWhenRBACDisabled(t *testing.T) {
+	// EnableRBAC=false: the middleware should log but not block, so the
+	// downstream handler still runs. This is the rollout-safety guarantee.
+	w := rbacTestHarness(types.TenantRoleViewer, "u1",
+		RequireRole(types.TenantRoleOwner, cfgRBAC(false)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("EnableRBAC=false must let Viewer through Owner gate, got %d", w.Code)
+	}
+}
+
+func TestRequireRole_NilConfigFailsOpen(t *testing.T) {
+	// Defensive: nil config must not panic and must fail open (no enforcement
+	// configured = behave like the legacy path).
+	w := rbacTestHarness(types.TenantRoleViewer, "u1",
+		RequireRole(types.TenantRoleAdmin, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("nil config must fail open, got %d", w.Code)
+	}
+}
+
+// ---------- RequireOwnershipOrRole ----------
+
+func TestRequireOwnershipOrRole_AdminBypassesLookup(t *testing.T) {
+	// Admin / Owner clear the role gate without touching the lookup,
+	// so an erroring lookup still passes when the caller has the role.
+	called := false
+	lookup := func(c *gin.Context) (string, error) {
+		called = true
+		return "", errors.New("must not be called")
+	}
+	w := rbacTestHarness(types.TenantRoleAdmin, "u1",
+		RequireOwnershipOrRole(types.TenantRoleAdmin, lookup, cfgRBAC(true)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("Admin should pass without lookup, got %d", w.Code)
+	}
+	if called {
+		t.Fatalf("lookup must not run when role already meets min")
+	}
+}
+
+func TestRequireOwnershipOrRole_CreatorAllowed(t *testing.T) {
+	lookup := func(c *gin.Context) (string, error) { return "u1", nil }
+	w := rbacTestHarness(types.TenantRoleContributor, "u1",
+		RequireOwnershipOrRole(types.TenantRoleAdmin, lookup, cfgRBAC(true)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("creator must clear ownership gate, got %d", w.Code)
+	}
+}
+
+func TestRequireOwnershipOrRole_NonCreatorContributorRejected(t *testing.T) {
+	// Contributor editing someone else's resource is the exact case the
+	// matrix targets: only the original creator OR Admin+ may proceed.
+	lookup := func(c *gin.Context) (string, error) { return "someone-else", nil }
+	w := rbacTestHarness(types.TenantRoleContributor, "u1",
+		RequireOwnershipOrRole(types.TenantRoleAdmin, lookup, cfgRBAC(true)))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("non-creator Contributor must hit 403, got %d", w.Code)
+	}
+}
+
+func TestRequireOwnershipOrRole_LegacyEmptyCreatorTreatedAsTenantOwned(t *testing.T) {
+	// Pre-migration rows (or rows the backfill couldn't resolve) carry
+	// creator_id = "". Per the contract those are tenant-owned: only the
+	// role check decides.
+	lookup := func(c *gin.Context) (string, error) { return "", nil }
+	// Contributor on a tenant-owned row -> rejected, only Admin+ can mutate.
+	w := rbacTestHarness(types.TenantRoleContributor, "u1",
+		RequireOwnershipOrRole(types.TenantRoleAdmin, lookup, cfgRBAC(true)))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("Contributor on legacy tenant-owned row should hit 403, got %d", w.Code)
+	}
+}
+
+func TestRequireOwnershipOrRole_LookupErrorRejects(t *testing.T) {
+	// A failing lookup is treated as deny — failing open here would mean
+	// any DB hiccup on the creator query becomes a free pass.
+	lookup := func(c *gin.Context) (string, error) { return "", errors.New("boom") }
+	w := rbacTestHarness(types.TenantRoleContributor, "u1",
+		RequireOwnershipOrRole(types.TenantRoleAdmin, lookup, cfgRBAC(true)))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("lookup error must reject, got %d", w.Code)
+	}
+}
+
+func TestRequireOwnershipOrRole_FailOpenWhenRBACDisabled(t *testing.T) {
+	// Enforcement off: even a failing lookup + non-creator + low role lets
+	// the request through. This preserves today's "anyone in the tenant
+	// can edit anything" behaviour while we ship the schema.
+	lookup := func(c *gin.Context) (string, error) { return "someone-else", nil }
+	w := rbacTestHarness(types.TenantRoleViewer, "u1",
+		RequireOwnershipOrRole(types.TenantRoleAdmin, lookup, cfgRBAC(false)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("EnableRBAC=false must let Viewer non-creator through, got %d", w.Code)
+	}
+}
+
+func TestRequireOwnershipOrRole_FailOpenOnLookupErrorWhenRBACDisabled(t *testing.T) {
+	// Lookup errors in fail-open mode also let the request through —
+	// otherwise turning RBAC off wouldn't actually unblock anything that
+	// needs the lookup.
+	lookup := func(c *gin.Context) (string, error) { return "", errors.New("boom") }
+	w := rbacTestHarness(types.TenantRoleViewer, "u1",
+		RequireOwnershipOrRole(types.TenantRoleAdmin, lookup, cfgRBAC(false)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("EnableRBAC=false + lookup error must fail open, got %d", w.Code)
+	}
+}

--- a/internal/middleware/rbac_test.go
+++ b/internal/middleware/rbac_test.go
@@ -89,6 +89,39 @@ func TestRequireRole_NilConfigFailsOpen(t *testing.T) {
 	}
 }
 
+func TestRequireRole_CrossTenantSuperuserBypass(t *testing.T) {
+	// Org-level superusers (User.CanAccessAllTenants) bypass tenant role
+	// gates — see auth.go's resolveTenantRole, which gives them a
+	// transient Admin in foreign tenants. RequireRole has to honour the
+	// same bypass for Owner-only gates, otherwise a superuser would be
+	// locked out of DELETE /tenants/:id once enforcement turns on.
+	//
+	// Pinned as a regression test: if anyone reorders the fast paths so
+	// the superuser check ends up after the enforcement branch, this
+	// test fails before the change ships.
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		ctx := c.Request.Context()
+		ctx = context.WithValue(ctx, types.TenantRoleContextKey, types.TenantRoleViewer)
+		ctx = context.WithValue(ctx, types.UserIDContextKey, "su1")
+		ctx = context.WithValue(ctx, types.UserContextKey, &types.User{
+			ID: "su1", CanAccessAllTenants: true,
+		})
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	router.GET("/protected",
+		RequireRole(types.TenantRoleOwner, cfgRBAC(true)),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{}) },
+	)
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("superuser must bypass Owner role gate, got %d", w.Code)
+	}
+}
+
 // ---------- RequireOwnershipOrRole ----------
 
 func TestRequireOwnershipOrRole_AdminBypassesLookup(t *testing.T) {

--- a/internal/middleware/rbac_test.go
+++ b/internal/middleware/rbac_test.go
@@ -142,14 +142,106 @@ func TestRequireOwnershipOrRole_LegacyEmptyCreatorTreatedAsTenantOwned(t *testin
 	}
 }
 
-func TestRequireOwnershipOrRole_LookupErrorRejects(t *testing.T) {
-	// A failing lookup is treated as deny — failing open here would mean
+func TestRequireOwnershipOrRole_LookupErrorReturns503(t *testing.T) {
+	// A transient lookup error surfaces as 503 (not 403) so monitoring
+	// and clients can tell "your permission was denied" from "the server
+	// briefly couldn't verify ownership". Failing open here would mean
 	// any DB hiccup on the creator query becomes a free pass.
 	lookup := func(c *gin.Context) (string, error) { return "", errors.New("boom") }
 	w := rbacTestHarness(types.TenantRoleContributor, "u1",
 		RequireOwnershipOrRole(types.TenantRoleAdmin, lookup, cfgRBAC(true)))
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("lookup error must reject, got %d", w.Code)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("lookup error must surface as 503, got %d", w.Code)
+	}
+}
+
+func TestRequireOwnershipOrRole_NotFoundPassesThroughTo404(t *testing.T) {
+	// When the lookup signals "no such resource visible to this tenant",
+	// the middleware MUST NOT mask it as 403. The handler downstream
+	// gets to decide the right status (usually 404), which keeps client
+	// error handling honest and avoids hiding "wrong URL" behind a
+	// permissions error.
+	called := false
+	lookup := func(c *gin.Context) (string, error) {
+		return "", ErrResourceNotFound
+	}
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		ctx := c.Request.Context()
+		ctx = context.WithValue(ctx, types.TenantRoleContextKey, types.TenantRoleContributor)
+		ctx = context.WithValue(ctx, types.UserIDContextKey, "u1")
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	router.GET("/protected",
+		RequireOwnershipOrRole(types.TenantRoleAdmin, lookup, cfgRBAC(true)),
+		func(c *gin.Context) {
+			called = true
+			c.JSON(http.StatusNotFound, gin.H{"error": "kb not found"})
+		},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if !called {
+		t.Fatalf("handler should have been invoked so it can produce 404")
+	}
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected handler 404 to win, got %d", w.Code)
+	}
+}
+
+func TestRequireOwnershipOrRole_SkipsLookupWhenRBACDisabled(t *testing.T) {
+	// H1 regression: when enforcement is off, the lookup must not run at
+	// all. Hooking up RBAC pre-rollout used to add a hidden DB roundtrip
+	// to every mutating request even though the result was thrown away.
+	calls := 0
+	lookup := func(c *gin.Context) (string, error) {
+		calls++
+		return "someone-else", nil
+	}
+	w := rbacTestHarness(types.TenantRoleViewer, "u1",
+		RequireOwnershipOrRole(types.TenantRoleAdmin, lookup, cfgRBAC(false)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("fail-open should let the request through, got %d", w.Code)
+	}
+	if calls != 0 {
+		t.Fatalf("lookup must not run when EnableRBAC=false (got %d calls)", calls)
+	}
+}
+
+func TestRequireOwnershipOrRole_CrossTenantSuperuserBypass(t *testing.T) {
+	// Cross-tenant superusers resolve to Admin in foreign tenants (see
+	// resolveTenantRole). For Owner-only gates we additionally let them
+	// through to preserve the pre-RBAC ability to administer any tenant.
+	calls := 0
+	lookup := func(c *gin.Context) (string, error) {
+		calls++
+		return "", nil
+	}
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		ctx := c.Request.Context()
+		ctx = context.WithValue(ctx, types.TenantRoleContextKey, types.TenantRoleAdmin)
+		ctx = context.WithValue(ctx, types.UserIDContextKey, "su1")
+		ctx = context.WithValue(ctx, types.UserContextKey, &types.User{
+			ID: "su1", CanAccessAllTenants: true,
+		})
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	router.GET("/protected",
+		RequireOwnershipOrRole(types.TenantRoleOwner, lookup, cfgRBAC(true)),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{}) },
+	)
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("superuser must bypass Owner gate, got %d", w.Code)
+	}
+	if calls != 0 {
+		t.Fatalf("superuser bypass must skip lookup, got %d", calls)
 	}
 }
 

--- a/internal/router/rbac.go
+++ b/internal/router/rbac.go
@@ -1,0 +1,84 @@
+package router
+
+import (
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/handler"
+	"github.com/Tencent/WeKnora/internal/middleware"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/gin-gonic/gin"
+)
+
+// rbacGuards is the centralised role-matrix bundle for tenant-level RBAC
+// (issue #1303 PR 2). NewRouter constructs it once and threads it into
+// each Register* function that registers gated routes.
+//
+// Each method returns a fresh gin.HandlerFunc; routes call the method
+// and inline the guard, so a glance at a route line tells you what
+// authority it requires:
+//
+//	kb.PUT("/:id", g.OwnedKBOrAdmin(), handler.UpdateKnowledgeBase)
+//
+// All guards honour cfg.Tenant.EnableRBAC: when the flag is off they log
+// the would-be rejection and let the request through, preserving today's
+// "anyone in the tenant can edit anything" behaviour during the rollout
+// window. When the flag flips to true, the same code paths start
+// rejecting unauthorised callers.
+type rbacGuards struct {
+	cfg *config.Config
+
+	// Lookup closures resolve a request's :id into the resource's creator
+	// user ID. Captured up front so the handler-level methods don't have
+	// to be exported into every Register* function as well.
+	kbCreator    middleware.CreatorLookup
+	agentCreator middleware.CreatorLookup
+}
+
+// newRBACGuards wires the guards from the live configuration and the
+// already-built handlers. Called once from NewRouter.
+func newRBACGuards(cfg *config.Config, kbHandler *handler.KnowledgeBaseHandler, agentHandler *handler.CustomAgentHandler) *rbacGuards {
+	g := &rbacGuards{cfg: cfg}
+	if kbHandler != nil {
+		g.kbCreator = kbHandler.KBCreatorLookup
+	}
+	if agentHandler != nil {
+		g.agentCreator = agentHandler.AgentCreatorLookup
+	}
+	return g
+}
+
+// Role-only guards — pure RequireRole convenience wrappers, named after
+// the matrix entries so route lines stay readable.
+
+func (g *rbacGuards) Viewer() gin.HandlerFunc {
+	return middleware.RequireRole(types.TenantRoleViewer, g.cfg)
+}
+
+func (g *rbacGuards) Contributor() gin.HandlerFunc {
+	return middleware.RequireRole(types.TenantRoleContributor, g.cfg)
+}
+
+func (g *rbacGuards) Admin() gin.HandlerFunc {
+	return middleware.RequireRole(types.TenantRoleAdmin, g.cfg)
+}
+
+func (g *rbacGuards) Owner() gin.HandlerFunc {
+	return middleware.RequireRole(types.TenantRoleOwner, g.cfg)
+}
+
+// Ownership-or-role guards. Required role here is the privilege level
+// that bypasses the ownership check; Contributors ALWAYS pass when they
+// own the resource.
+
+// OwnedKBOrAdmin: KB mutations (update/delete/pin/copy). The original
+// creator may proceed; otherwise Admin+ is required. Contributors who
+// did not create the KB get 403 (when enforcement is on).
+func (g *rbacGuards) OwnedKBOrAdmin() gin.HandlerFunc {
+	return middleware.RequireOwnershipOrRole(types.TenantRoleAdmin, g.kbCreator, g.cfg)
+}
+
+// OwnedAgentOrAdmin: same shape as OwnedKBOrAdmin but for CustomAgent.
+// Built-in agents (IsBuiltin=true) are tenant-owned; their creator
+// lookup returns "" and only Admin+ may mutate them.
+func (g *rbacGuards) OwnedAgentOrAdmin() gin.HandlerFunc {
+	return middleware.RequireOwnershipOrRole(types.TenantRoleAdmin, g.agentCreator, g.cfg)
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -137,29 +137,36 @@ func NewRouter(params RouterParams) *gin.Engine {
 	// 需要认证的API路由
 	v1 := r.Group("/api/v1")
 	{
+		// rbacGuards bundles the role-gating middleware factories so each
+		// Register* function below can attach the right guard without
+		// taking a *config.Config dependency directly. The guards honour
+		// cfg.Tenant.EnableRBAC: when false, they log but pass through,
+		// preserving today's behaviour during the rollout window.
+		rbacGuards := newRBACGuards(params.Config, params.KBHandler, params.CustomAgentHandler)
+
 		RegisterAuthRoutes(v1, params.AuthHandler)
-		RegisterTenantRoutes(v1, params.TenantHandler)
-		RegisterKnowledgeBaseRoutes(v1, params.KBHandler)
+		RegisterTenantRoutes(v1, params.TenantHandler, rbacGuards)
+		RegisterKnowledgeBaseRoutes(v1, params.KBHandler, rbacGuards)
 		RegisterKnowledgeTagRoutes(v1, params.TagHandler)
-		RegisterKnowledgeRoutes(v1, params.KnowledgeHandler)
+		RegisterKnowledgeRoutes(v1, params.KnowledgeHandler, rbacGuards)
 		RegisterFAQRoutes(v1, params.FAQHandler)
-		RegisterChunkRoutes(v1, params.ChunkHandler)
+		RegisterChunkRoutes(v1, params.ChunkHandler, rbacGuards)
 		RegisterSessionRoutes(v1, params.SessionHandler)
 		RegisterChatRoutes(v1, params.SessionHandler)
 		RegisterMessageRoutes(v1, params.MessageHandler)
-		RegisterModelRoutes(v1, params.ModelHandler)
+		RegisterModelRoutes(v1, params.ModelHandler, rbacGuards)
 		RegisterEvaluationRoutes(v1, params.EvaluationHandler)
 		RegisterInitializationRoutes(v1, params.InitializationHandler)
 		RegisterSystemRoutes(v1, params.SystemHandler)
-		RegisterMCPServiceRoutes(v1, params.MCPServiceHandler)
+		RegisterMCPServiceRoutes(v1, params.MCPServiceHandler, rbacGuards)
 		RegisterWebSearchRoutes(v1, params.WebSearchHandler)
 		RegisterWebSearchProviderRoutes(v1, params.WebSearchProviderHandler)
-		RegisterVectorStoreRoutes(v1, params.VectorStoreHandler)
-		RegisterCustomAgentRoutes(v1, params.CustomAgentHandler)
+		RegisterVectorStoreRoutes(v1, params.VectorStoreHandler, rbacGuards)
+		RegisterCustomAgentRoutes(v1, params.CustomAgentHandler, rbacGuards)
 		RegisterSkillRoutes(v1, params.SkillHandler)
 		RegisterOrganizationRoutes(v1, params.OrganizationHandler)
-		RegisterIMChannelRoutes(v1, params.IMHandler)
-		RegisterDataSourceRoutes(v1, params.DataSourceHandler)
+		RegisterIMChannelRoutes(v1, params.IMHandler, rbacGuards)
+		RegisterDataSourceRoutes(v1, params.DataSourceHandler, rbacGuards)
 		RegisterWeKnoraCloudRoutes(v1, params.WeKnoraCloudHandler)
 		RegisterWikiPageRoutes(v1, params.WikiPageHandler)
 		RegisterChunkerDebugRoutes(v1)
@@ -175,73 +182,62 @@ func RegisterChunkerDebugRoutes(r *gin.RouterGroup) {
 }
 
 // RegisterChunkRoutes 注册分块相关的路由
-func RegisterChunkRoutes(r *gin.RouterGroup, handler *handler.ChunkHandler) {
+func RegisterChunkRoutes(r *gin.RouterGroup, handler *handler.ChunkHandler, g *rbacGuards) {
 	// 分块路由组
 	chunks := r.Group("/chunks")
 	{
-		// 获取分块列表
-		chunks.GET("/:knowledge_id", handler.ListKnowledgeChunks)
-		// 通过chunk_id获取单个chunk（不需要knowledge_id）
-		chunks.GET("/by-id/:id", handler.GetChunkByIDOnly)
-		// 删除分块
-		chunks.DELETE("/:knowledge_id/:id", handler.DeleteChunk)
-		// 删除知识下的所有分块
-		chunks.DELETE("/:knowledge_id", handler.DeleteChunksByKnowledgeID)
-		// 更新分块信息
-		chunks.PUT("/:knowledge_id/:id", handler.UpdateChunk)
-		// 删除单个生成的问题（通过问题ID）
-		chunks.DELETE("/by-id/:id/questions", handler.DeleteGeneratedQuestion)
+		// 获取分块列表 — Viewer+
+		chunks.GET("/:knowledge_id", g.Viewer(), handler.ListKnowledgeChunks)
+		// 通过chunk_id获取单个chunk（不需要knowledge_id） — Viewer+
+		chunks.GET("/by-id/:id", g.Viewer(), handler.GetChunkByIDOnly)
+		// 删除分块 — Contributor+ (per-KB ownership granularity is a follow-up; PR 2 v1 keeps tenant-wide edit for chunks)
+		chunks.DELETE("/:knowledge_id/:id", g.Contributor(), handler.DeleteChunk)
+		// 删除知识下的所有分块 — Contributor+
+		chunks.DELETE("/:knowledge_id", g.Contributor(), handler.DeleteChunksByKnowledgeID)
+		// 更新分块信息 — Contributor+
+		chunks.PUT("/:knowledge_id/:id", g.Contributor(), handler.UpdateChunk)
+		// 删除单个生成的问题（通过问题ID） — Contributor+
+		chunks.DELETE("/by-id/:id/questions", g.Contributor(), handler.DeleteGeneratedQuestion)
 	}
 }
 
 // RegisterKnowledgeRoutes 注册知识相关的路由
-func RegisterKnowledgeRoutes(r *gin.RouterGroup, handler *handler.KnowledgeHandler) {
+//
+// PR 2 attaches role-only guards here (Viewer for reads, Contributor for
+// writes). Per-KB-ownership granularity for knowledge entries (so that
+// Contributor X cannot edit Contributor Y's documents within the same
+// KB) is a follow-up — it requires a knowledge-id -> KB chain lookup
+// that's noisy enough to be worth its own PR.
+func RegisterKnowledgeRoutes(r *gin.RouterGroup, handler *handler.KnowledgeHandler, g *rbacGuards) {
 	// 知识库下的知识路由组
 	kb := r.Group("/knowledge-bases/:id/knowledge")
 	{
-		// 从文件创建知识
-		kb.POST("/file", handler.CreateKnowledgeFromFile)
-		// 从URL创建知识（支持网页URL和文件URL，传 file_name/file_type 或 URL 含已知扩展名时自动切换为文件下载模式）
-		kb.POST("/url", handler.CreateKnowledgeFromURL)
-		// 手工 Markdown 录入
-		kb.POST("/manual", handler.CreateManualKnowledge)
-		// 获取知识库下的知识列表
-		kb.GET("", handler.ListKnowledge)
-		// 清空知识库下的所有知识
-		kb.DELETE("", handler.ClearKnowledgeBaseContents)
+		kb.POST("/file", g.Contributor(), handler.CreateKnowledgeFromFile)
+		kb.POST("/url", g.Contributor(), handler.CreateKnowledgeFromURL)
+		kb.POST("/manual", g.Contributor(), handler.CreateManualKnowledge)
+		kb.GET("", g.Viewer(), handler.ListKnowledge)
+		// Clearing all contents under a KB is a destructive op; gate
+		// behind Admin instead of Contributor.
+		kb.DELETE("", g.Admin(), handler.ClearKnowledgeBaseContents)
 	}
 
 	// 知识路由组
 	k := r.Group("/knowledge")
 	{
-		// 批量获取知识
-		k.GET("/batch", handler.GetKnowledgeBatch)
-		// 获取知识详情
-		k.GET("/:id", handler.GetKnowledge)
-		// 删除知识
-		k.DELETE("/:id", handler.DeleteKnowledge)
-		// 更新知识
-		k.PUT("/:id", handler.UpdateKnowledge)
-		// 更新手工 Markdown 知识
-		k.PUT("/manual/:id", handler.UpdateManualKnowledge)
-		// 重新解析知识
-		k.POST("/:id/reparse", handler.ReparseKnowledge)
-		// 获取知识文件
-		k.GET("/:id/download", handler.DownloadKnowledgeFile)
-		// 预览知识文件（内联显示，返回正确 Content-Type）
-		k.GET("/:id/preview", handler.PreviewKnowledgeFile)
-		// 更新图像分块信息
-		k.PUT("/image/:id/:chunk_id", handler.UpdateImageInfo)
-		// 批量更新知识标签
-		k.PUT("/tags", handler.UpdateKnowledgeTagBatch)
-		// 搜索知识
-		k.GET("/search", handler.SearchKnowledge)
-		// 批量删除知识（同一知识库内）
-		k.POST("/batch-delete", handler.BatchDeleteKnowledge)
-		// 移动知识到其他知识库
-		k.POST("/move", handler.MoveKnowledge)
-		// 获取知识移动进度
-		k.GET("/move/progress/:task_id", handler.GetKnowledgeMoveProgress)
+		k.GET("/batch", g.Viewer(), handler.GetKnowledgeBatch)
+		k.GET("/:id", g.Viewer(), handler.GetKnowledge)
+		k.DELETE("/:id", g.Contributor(), handler.DeleteKnowledge)
+		k.PUT("/:id", g.Contributor(), handler.UpdateKnowledge)
+		k.PUT("/manual/:id", g.Contributor(), handler.UpdateManualKnowledge)
+		k.POST("/:id/reparse", g.Contributor(), handler.ReparseKnowledge)
+		k.GET("/:id/download", g.Viewer(), handler.DownloadKnowledgeFile)
+		k.GET("/:id/preview", g.Viewer(), handler.PreviewKnowledgeFile)
+		k.PUT("/image/:id/:chunk_id", g.Contributor(), handler.UpdateImageInfo)
+		k.PUT("/tags", g.Contributor(), handler.UpdateKnowledgeTagBatch)
+		k.GET("/search", g.Viewer(), handler.SearchKnowledge)
+		k.POST("/batch-delete", g.Contributor(), handler.BatchDeleteKnowledge)
+		k.POST("/move", g.Contributor(), handler.MoveKnowledge)
+		k.GET("/move/progress/:task_id", g.Viewer(), handler.GetKnowledgeMoveProgress)
 	}
 }
 
@@ -275,30 +271,30 @@ func RegisterFAQRoutes(r *gin.RouterGroup, handler *handler.FAQHandler) {
 }
 
 // RegisterKnowledgeBaseRoutes 注册知识库相关的路由
-func RegisterKnowledgeBaseRoutes(r *gin.RouterGroup, handler *handler.KnowledgeBaseHandler) {
+func RegisterKnowledgeBaseRoutes(r *gin.RouterGroup, handler *handler.KnowledgeBaseHandler, g *rbacGuards) {
 	// 知识库路由组
 	kb := r.Group("/knowledge-bases")
 	{
-		// 创建知识库
-		kb.POST("", handler.CreateKnowledgeBase)
-		// 获取知识库列表
-		kb.GET("", handler.ListKnowledgeBases)
-		// 获取知识库详情
-		kb.GET("/:id", handler.GetKnowledgeBase)
-		// 更新知识库
-		kb.PUT("/:id", handler.UpdateKnowledgeBase)
-		// 删除知识库
-		kb.DELETE("/:id", handler.DeleteKnowledgeBase)
-		// 置顶/取消置顶知识库
-		kb.PUT("/:id/pin", handler.TogglePinKnowledgeBase)
-		// 混合搜索
-		kb.GET("/:id/hybrid-search", handler.HybridSearch)
-		// 拷贝知识库
-		kb.POST("/copy", handler.CopyKnowledgeBase)
-		// 获取知识库复制进度
-		kb.GET("/copy/progress/:task_id", handler.GetKBCloneProgress)
-		// 获取可移动目标知识库列表
-		kb.GET("/:id/move-targets", handler.ListMoveTargets)
+		// 创建知识库 — Contributor+
+		kb.POST("", g.Contributor(), handler.CreateKnowledgeBase)
+		// 获取知识库列表 — Viewer+
+		kb.GET("", g.Viewer(), handler.ListKnowledgeBases)
+		// 获取知识库详情 — Viewer+
+		kb.GET("/:id", g.Viewer(), handler.GetKnowledgeBase)
+		// 更新知识库 — 创建者本人 OR Admin+
+		kb.PUT("/:id", g.OwnedKBOrAdmin(), handler.UpdateKnowledgeBase)
+		// 删除知识库 — 创建者本人 OR Admin+
+		kb.DELETE("/:id", g.OwnedKBOrAdmin(), handler.DeleteKnowledgeBase)
+		// 置顶/取消置顶知识库 — 创建者本人 OR Admin+
+		kb.PUT("/:id/pin", g.OwnedKBOrAdmin(), handler.TogglePinKnowledgeBase)
+		// 混合搜索 — Viewer+ (read-only)
+		kb.GET("/:id/hybrid-search", g.Viewer(), handler.HybridSearch)
+		// 拷贝知识库 — Contributor+ (副本归调用者所有；不需要原 KB 的所有权)
+		kb.POST("/copy", g.Contributor(), handler.CopyKnowledgeBase)
+		// 获取知识库复制进度 — Viewer+
+		kb.GET("/copy/progress/:task_id", g.Viewer(), handler.GetKBCloneProgress)
+		// 获取可移动目标知识库列表 — Viewer+
+		kb.GET("/:id/move-targets", g.Viewer(), handler.ListMoveTargets)
 	}
 }
 
@@ -377,7 +373,18 @@ func RegisterChatRoutes(r *gin.RouterGroup, handler *session.Handler) {
 }
 
 // RegisterTenantRoutes 注册租户相关的路由
-func RegisterTenantRoutes(r *gin.RouterGroup, handler *handler.TenantHandler) {
+//
+// Tenant-internal RBAC for /tenants/:id:
+//   - GET   /:id          Viewer+ (read tenant settings)
+//   - PUT   /:id          Owner+ (mutate tenant config)
+//   - DELETE /:id         Owner+ (also normally a CanAccessAllTenants op)
+//   - POST  /:id/api-key  Owner+ (rotating the tenant API key is sensitive)
+//
+// Cross-tenant superuser endpoints (/tenants/all, /tenants/search, POST
+// /tenants, GET /tenants, /tenants/kv/*) keep their existing handler-level
+// CanAccessAllTenants check — they're not gated by tenant role here
+// because the caller is operating *across* tenants, not within one.
+func RegisterTenantRoutes(r *gin.RouterGroup, handler *handler.TenantHandler, g *rbacGuards) {
 	// 添加获取所有租户的路由（需要跨租户权限）
 	r.GET("/tenants/all", handler.ListAllTenants)
 	// 添加搜索租户的路由（需要跨租户权限，支持分页和搜索）
@@ -385,37 +392,40 @@ func RegisterTenantRoutes(r *gin.RouterGroup, handler *handler.TenantHandler) {
 	// 租户路由组
 	tenantRoutes := r.Group("/tenants")
 	{
-		tenantRoutes.POST("", handler.CreateTenant)
-		tenantRoutes.GET("/:id", handler.GetTenant)
-		tenantRoutes.PUT("/:id", handler.UpdateTenant)
-		tenantRoutes.DELETE("/:id", handler.DeleteTenant)
-		tenantRoutes.POST("/:id/api-key", handler.ResetAPIKey)
-		tenantRoutes.GET("", handler.ListTenants)
+		tenantRoutes.POST("", handler.CreateTenant) // CanAccessAllTenants gate is in the handler
+		tenantRoutes.GET("/:id", g.Viewer(), handler.GetTenant)
+		tenantRoutes.PUT("/:id", g.Owner(), handler.UpdateTenant)
+		tenantRoutes.DELETE("/:id", g.Owner(), handler.DeleteTenant)
+		tenantRoutes.POST("/:id/api-key", g.Owner(), handler.ResetAPIKey)
+		tenantRoutes.GET("", handler.ListTenants) // existing handler gates by CanAccessAllTenants
 
 		// Generic KV configuration management (tenant-level)
 		// Tenant ID is obtained from authentication context
-		tenantRoutes.GET("/kv/:key", handler.GetTenantKV)
-		tenantRoutes.PUT("/kv/:key", handler.UpdateTenantKV)
+		tenantRoutes.GET("/kv/:key", g.Viewer(), handler.GetTenantKV)
+		tenantRoutes.PUT("/kv/:key", g.Admin(), handler.UpdateTenantKV)
 	}
 }
 
 // RegisterModelRoutes 注册模型相关的路由
-func RegisterModelRoutes(r *gin.RouterGroup, handler *handler.ModelHandler) {
+//
+// Models are tenant-wide infrastructure (LLM credentials, embeddings,
+// rerankers); Viewer+ for reads, Admin+ for any mutation.
+func RegisterModelRoutes(r *gin.RouterGroup, handler *handler.ModelHandler, g *rbacGuards) {
 	// 模型路由组
 	models := r.Group("/models")
 	{
-		// 获取模型厂商列表
-		models.GET("/providers", handler.ListModelProviders)
-		// 创建模型
-		models.POST("", handler.CreateModel)
-		// 获取模型列表
-		models.GET("", handler.ListModels)
-		// 获取单个模型
-		models.GET("/:id", handler.GetModel)
-		// 更新模型
-		models.PUT("/:id", handler.UpdateModel)
-		// 删除模型
-		models.DELETE("/:id", handler.DeleteModel)
+		// 获取模型厂商列表 — Viewer+
+		models.GET("/providers", g.Viewer(), handler.ListModelProviders)
+		// 创建模型 — Admin+
+		models.POST("", g.Admin(), handler.CreateModel)
+		// 获取模型列表 — Viewer+
+		models.GET("", g.Viewer(), handler.ListModels)
+		// 获取单个模型 — Viewer+
+		models.GET("/:id", g.Viewer(), handler.GetModel)
+		// 更新模型 — Admin+
+		models.PUT("/:id", g.Admin(), handler.UpdateModel)
+		// 删除模型 — Admin+
+		models.DELETE("/:id", g.Admin(), handler.DeleteModel)
 	}
 }
 
@@ -483,34 +493,41 @@ func RegisterSystemRoutes(r *gin.RouterGroup, handler *handler.SystemHandler) {
 	}
 }
 
-// RegisterMCPServiceRoutes registers MCP service routes
-func RegisterMCPServiceRoutes(r *gin.RouterGroup, handler *handler.MCPServiceHandler) {
+// RegisterMCPServiceRoutes registers MCP service routes.
+//
+// MCP services are tenant-level integrations (external tool servers); we
+// gate reads to Viewer+ and any mutation/test to Admin+. Tool-approval
+// resolution is also Admin+ since approving a pending tool call grants
+// the agent permission to execute side-effecting external commands.
+func RegisterMCPServiceRoutes(r *gin.RouterGroup, handler *handler.MCPServiceHandler, g *rbacGuards) {
 	mcpServices := r.Group("/mcp-services")
 	{
-		// Create MCP service
-		mcpServices.POST("", handler.CreateMCPService)
-		// List MCP services
-		mcpServices.GET("", handler.ListMCPServices)
-		// Get MCP service by ID
-		mcpServices.GET("/:id", handler.GetMCPService)
-		// Update MCP service
-		mcpServices.PUT("/:id", handler.UpdateMCPService)
-		// Delete MCP service
-		mcpServices.DELETE("/:id", handler.DeleteMCPService)
-		// Test MCP service connection
-		mcpServices.POST("/:id/test", handler.TestMCPService)
-		// Get MCP service tools
-		mcpServices.GET("/:id/tools", handler.GetMCPServiceTools)
-		// Get MCP service resources
-		mcpServices.GET("/:id/resources", handler.GetMCPServiceResources)
-		// MCP tool human approval (issue #1173)
-		mcpServices.GET("/:id/tool-approvals", handler.ListMCPToolApprovals)
-		mcpServices.PUT("/:id/tool-approvals/:tool_name", handler.SetMCPToolApproval)
+		// Create MCP service — Admin+
+		mcpServices.POST("", g.Admin(), handler.CreateMCPService)
+		// List MCP services — Viewer+
+		mcpServices.GET("", g.Viewer(), handler.ListMCPServices)
+		// Get MCP service by ID — Viewer+
+		mcpServices.GET("/:id", g.Viewer(), handler.GetMCPService)
+		// Update MCP service — Admin+
+		mcpServices.PUT("/:id", g.Admin(), handler.UpdateMCPService)
+		// Delete MCP service — Admin+
+		mcpServices.DELETE("/:id", g.Admin(), handler.DeleteMCPService)
+		// Test MCP service connection — Admin+ (probes external infra)
+		mcpServices.POST("/:id/test", g.Admin(), handler.TestMCPService)
+		// Get MCP service tools — Viewer+
+		mcpServices.GET("/:id/tools", g.Viewer(), handler.GetMCPServiceTools)
+		// Get MCP service resources — Viewer+
+		mcpServices.GET("/:id/resources", g.Viewer(), handler.GetMCPServiceResources)
+		// MCP tool human approval (issue #1173) — Viewer+ to read, Admin+ to set policy
+		mcpServices.GET("/:id/tool-approvals", g.Viewer(), handler.ListMCPToolApprovals)
+		mcpServices.PUT("/:id/tool-approvals/:tool_name", g.Admin(), handler.SetMCPToolApproval)
 	}
 
 	agentTool := r.Group("/agent")
 	{
-		agentTool.POST("/tool-approvals/:pending_id", handler.ResolveToolApproval)
+		// Resolving a pending tool-approval lets the agent run a sensitive
+		// external command on this tenant's behalf — Admin+.
+		agentTool.POST("/tool-approvals/:pending_id", g.Admin(), handler.ResolveToolApproval)
 	}
 }
 
@@ -543,48 +560,57 @@ func RegisterWebSearchProviderRoutes(r *gin.RouterGroup, h *handler.WebSearchPro
 	}
 }
 
-// RegisterVectorStoreRoutes registers CRUD routes for vector store configurations
-func RegisterVectorStoreRoutes(r *gin.RouterGroup, h *handler.VectorStoreHandler) {
+// RegisterVectorStoreRoutes registers CRUD routes for vector store configurations.
+//
+// Vector stores are tenant-level infrastructure; reads are Viewer+, all
+// writes (and connection tests, which probe external systems with stored
+// credentials) are Admin+.
+func RegisterVectorStoreRoutes(r *gin.RouterGroup, h *handler.VectorStoreHandler, g *rbacGuards) {
 	stores := r.Group("/vector-stores")
 	{
-		// List available engine types (metadata for UI forms)
-		stores.GET("/types", h.ListStoreTypes)
-		// Test with raw credentials (no persistence)
-		stores.POST("/test", h.TestStoreRaw)
+		// List available engine types (metadata for UI forms) — Viewer+
+		stores.GET("/types", g.Viewer(), h.ListStoreTypes)
+		// Test with raw credentials (no persistence) — Admin+
+		stores.POST("/test", g.Admin(), h.TestStoreRaw)
 		// CRUD
-		stores.POST("", h.CreateStore)
-		stores.GET("", h.ListStores)
-		stores.GET("/:id", h.GetStore)
-		stores.PUT("/:id", h.UpdateStore)
-		stores.DELETE("/:id", h.DeleteStore)
-		// Test existing saved or env store
-		stores.POST("/:id/test", h.TestStoreByID)
+		stores.POST("", g.Admin(), h.CreateStore)
+		stores.GET("", g.Viewer(), h.ListStores)
+		stores.GET("/:id", g.Viewer(), h.GetStore)
+		stores.PUT("/:id", g.Admin(), h.UpdateStore)
+		stores.DELETE("/:id", g.Admin(), h.DeleteStore)
+		// Test existing saved or env store — Admin+
+		stores.POST("/:id/test", g.Admin(), h.TestStoreByID)
 	}
 }
 
-// RegisterCustomAgentRoutes registers custom agent routes
-func RegisterCustomAgentRoutes(r *gin.RouterGroup, agentHandler *handler.CustomAgentHandler) {
+// RegisterCustomAgentRoutes registers custom agent routes.
+//
+// Mutating routes use OwnedAgentOrAdmin: the original creator can edit
+// their agent, otherwise Admin+ is required. Built-in agents
+// (IsBuiltin=true) have an empty creator and are always Admin+. Reads
+// are Viewer+, copy is Contributor+ (the copy is owned by the caller).
+func RegisterCustomAgentRoutes(r *gin.RouterGroup, agentHandler *handler.CustomAgentHandler, g *rbacGuards) {
 	agents := r.Group("/agents")
 	{
-		// Get placeholder definitions (must be before /:id to avoid conflict)
-		agents.GET("/placeholders", agentHandler.GetPlaceholders)
-		// List smart-reasoning agent type presets (rag-qa / wiki-qa / hybrid / custom)
-		agents.GET("/type-presets", agentHandler.GetAgentTypePresets)
-		// Create custom agent
-		agents.POST("", agentHandler.CreateAgent)
-		// List all agents (including built-in)
-		agents.GET("", agentHandler.ListAgents)
-		// Get agent by ID
-		agents.GET("/:id", agentHandler.GetAgent)
-		// Update agent
-		agents.PUT("/:id", agentHandler.UpdateAgent)
-		// Delete agent
-		agents.DELETE("/:id", agentHandler.DeleteAgent)
-		// Copy agent
-		agents.POST("/:id/copy", agentHandler.CopyAgent)
+		// Get placeholder definitions (must be before /:id to avoid conflict) — Viewer+
+		agents.GET("/placeholders", g.Viewer(), agentHandler.GetPlaceholders)
+		// List smart-reasoning agent type presets (rag-qa / wiki-qa / hybrid / custom) — Viewer+
+		agents.GET("/type-presets", g.Viewer(), agentHandler.GetAgentTypePresets)
+		// Create custom agent — Contributor+
+		agents.POST("", g.Contributor(), agentHandler.CreateAgent)
+		// List all agents (including built-in) — Viewer+
+		agents.GET("", g.Viewer(), agentHandler.ListAgents)
+		// Get agent by ID — Viewer+
+		agents.GET("/:id", g.Viewer(), agentHandler.GetAgent)
+		// Update agent — creator OR Admin+
+		agents.PUT("/:id", g.OwnedAgentOrAdmin(), agentHandler.UpdateAgent)
+		// Delete agent — creator OR Admin+
+		agents.DELETE("/:id", g.OwnedAgentOrAdmin(), agentHandler.DeleteAgent)
+		// Copy agent — Contributor+ (copy is owned by the caller)
+		agents.POST("/:id/copy", g.Contributor(), agentHandler.CopyAgent)
 	}
 	// Registered outside the group to avoid Gin route conflict with /agents/:id/shares in organization routes
-	r.GET("/agents/:id/suggested-questions", agentHandler.GetSuggestedQuestions)
+	r.GET("/agents/:id/suggested-questions", g.Viewer(), agentHandler.GetSuggestedQuestions)
 }
 
 // RegisterSkillRoutes registers skill routes
@@ -690,28 +716,33 @@ func RegisterIMRoutes(r *gin.Engine, imHandler *handler.IMHandler) {
 }
 
 // RegisterIMChannelRoutes registers IM channel CRUD routes (requires authentication).
-func RegisterIMChannelRoutes(r *gin.RouterGroup, imHandler *handler.IMHandler) {
+//
+// IM channels carry external bot credentials (WeChat/Feishu/Slack/...);
+// listing is Viewer+ but any mutation, toggle, or QR-code login flow
+// (which can hijack a personal WeChat session) is Admin+.
+func RegisterIMChannelRoutes(r *gin.RouterGroup, imHandler *handler.IMHandler, g *rbacGuards) {
 	// Channel CRUD under agents
 	agentChannels := r.Group("/agents/:id/im-channels")
 	{
-		agentChannels.POST("", imHandler.CreateIMChannel)
-		agentChannels.GET("", imHandler.ListIMChannels)
+		agentChannels.POST("", g.Admin(), imHandler.CreateIMChannel)
+		agentChannels.GET("", g.Viewer(), imHandler.ListIMChannels)
 	}
 
 	// Channel operations by channel ID
 	channels := r.Group("/im-channels")
 	{
-		channels.GET("", imHandler.ListAllIMChannels)
-		channels.PUT("/:id", imHandler.UpdateIMChannel)
-		channels.DELETE("/:id", imHandler.DeleteIMChannel)
-		channels.POST("/:id/toggle", imHandler.ToggleIMChannel)
+		channels.GET("", g.Viewer(), imHandler.ListAllIMChannels)
+		channels.PUT("/:id", g.Admin(), imHandler.UpdateIMChannel)
+		channels.DELETE("/:id", g.Admin(), imHandler.DeleteIMChannel)
+		channels.POST("/:id/toggle", g.Admin(), imHandler.ToggleIMChannel)
 	}
 
-	// WeChat QR code login (requires authentication)
+	// WeChat QR code login (requires authentication) — Admin+: a successful
+	// scan binds a personal WeChat account to the tenant.
 	wechatGroup := r.Group("/wechat")
 	{
-		wechatGroup.POST("/qrcode", imHandler.WeChatGetQRCode)
-		wechatGroup.POST("/qrcode/status", imHandler.WeChatPollQRCodeStatus)
+		wechatGroup.POST("/qrcode", g.Admin(), imHandler.WeChatGetQRCode)
+		wechatGroup.POST("/qrcode/status", g.Admin(), imHandler.WeChatPollQRCodeStatus)
 	}
 }
 
@@ -967,35 +998,40 @@ func servePresignedFiles(r *gin.Engine, tenantService interfaces.TenantService) 
 }
 
 // RegisterDataSourceRoutes 注册数据源相关的路由
-func RegisterDataSourceRoutes(r *gin.RouterGroup, handler *handler.DataSourceHandler) {
+//
+// Data sources hold external service credentials (Feishu/Notion/Yuque)
+// and trigger sync jobs that mutate KB content tenant-wide. Reads are
+// Viewer+; everything else (CRUD, validation, sync control, log
+// retrieval, which exposes credential validation errors) is Admin+.
+func RegisterDataSourceRoutes(r *gin.RouterGroup, handler *handler.DataSourceHandler, g *rbacGuards) {
 	// Data source routes
 	ds := r.Group("/datasource")
 	{
-		// Get available connector types
-		ds.GET("/types", handler.GetAvailableConnectors)
+		// Get available connector types — Viewer+
+		ds.GET("/types", g.Viewer(), handler.GetAvailableConnectors)
 
-		// Validate credentials without persistence (for "Test Connection" button)
-		ds.POST("/validate-credentials", handler.ValidateCredentials)
+		// Validate credentials without persistence (for "Test Connection" button) — Admin+
+		ds.POST("/validate-credentials", g.Admin(), handler.ValidateCredentials)
 
 		// CRUD operations
-		ds.POST("", handler.CreateDataSource)
-		ds.GET("", handler.ListDataSources)
-		ds.GET("/:id", handler.GetDataSource)
-		ds.PUT("/:id", handler.UpdateDataSource)
-		ds.DELETE("/:id", handler.DeleteDataSource)
+		ds.POST("", g.Admin(), handler.CreateDataSource)
+		ds.GET("", g.Viewer(), handler.ListDataSources)
+		ds.GET("/:id", g.Viewer(), handler.GetDataSource)
+		ds.PUT("/:id", g.Admin(), handler.UpdateDataSource)
+		ds.DELETE("/:id", g.Admin(), handler.DeleteDataSource)
 
-		// Connection and resource management
-		ds.POST("/:id/validate", handler.ValidateConnection)
-		ds.GET("/:id/resources", handler.ListAvailableResources)
+		// Connection and resource management — Admin+
+		ds.POST("/:id/validate", g.Admin(), handler.ValidateConnection)
+		ds.GET("/:id/resources", g.Admin(), handler.ListAvailableResources)
 
-		// Sync management
-		ds.POST("/:id/sync", handler.ManualSync)
-		ds.POST("/:id/pause", handler.PauseDataSource)
-		ds.POST("/:id/resume", handler.ResumeDataSource)
+		// Sync management — Admin+
+		ds.POST("/:id/sync", g.Admin(), handler.ManualSync)
+		ds.POST("/:id/pause", g.Admin(), handler.PauseDataSource)
+		ds.POST("/:id/resume", g.Admin(), handler.ResumeDataSource)
 
-		// Sync logs
-		ds.GET("/:id/logs", handler.GetSyncLogs)
-		ds.GET("/logs/:log_id", handler.GetSyncLog)
+		// Sync logs — Viewer+ (read-only audit trail)
+		ds.GET("/:id/logs", g.Viewer(), handler.GetSyncLogs)
+		ds.GET("/logs/:log_id", g.Viewer(), handler.GetSyncLog)
 	}
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -147,28 +147,28 @@ func NewRouter(params RouterParams) *gin.Engine {
 		RegisterAuthRoutes(v1, params.AuthHandler)
 		RegisterTenantRoutes(v1, params.TenantHandler, rbacGuards)
 		RegisterKnowledgeBaseRoutes(v1, params.KBHandler, rbacGuards)
-		RegisterKnowledgeTagRoutes(v1, params.TagHandler)
+		RegisterKnowledgeTagRoutes(v1, params.TagHandler, rbacGuards)
 		RegisterKnowledgeRoutes(v1, params.KnowledgeHandler, rbacGuards)
-		RegisterFAQRoutes(v1, params.FAQHandler)
+		RegisterFAQRoutes(v1, params.FAQHandler, rbacGuards)
 		RegisterChunkRoutes(v1, params.ChunkHandler, rbacGuards)
-		RegisterSessionRoutes(v1, params.SessionHandler)
-		RegisterChatRoutes(v1, params.SessionHandler)
-		RegisterMessageRoutes(v1, params.MessageHandler)
+		RegisterSessionRoutes(v1, params.SessionHandler, rbacGuards)
+		RegisterChatRoutes(v1, params.SessionHandler, rbacGuards)
+		RegisterMessageRoutes(v1, params.MessageHandler, rbacGuards)
 		RegisterModelRoutes(v1, params.ModelHandler, rbacGuards)
 		RegisterEvaluationRoutes(v1, params.EvaluationHandler)
 		RegisterInitializationRoutes(v1, params.InitializationHandler)
 		RegisterSystemRoutes(v1, params.SystemHandler)
 		RegisterMCPServiceRoutes(v1, params.MCPServiceHandler, rbacGuards)
-		RegisterWebSearchRoutes(v1, params.WebSearchHandler)
-		RegisterWebSearchProviderRoutes(v1, params.WebSearchProviderHandler)
+		RegisterWebSearchRoutes(v1, params.WebSearchHandler, rbacGuards)
+		RegisterWebSearchProviderRoutes(v1, params.WebSearchProviderHandler, rbacGuards)
 		RegisterVectorStoreRoutes(v1, params.VectorStoreHandler, rbacGuards)
 		RegisterCustomAgentRoutes(v1, params.CustomAgentHandler, rbacGuards)
-		RegisterSkillRoutes(v1, params.SkillHandler)
+		RegisterSkillRoutes(v1, params.SkillHandler, rbacGuards)
 		RegisterOrganizationRoutes(v1, params.OrganizationHandler)
 		RegisterIMChannelRoutes(v1, params.IMHandler, rbacGuards)
 		RegisterDataSourceRoutes(v1, params.DataSourceHandler, rbacGuards)
-		RegisterWeKnoraCloudRoutes(v1, params.WeKnoraCloudHandler)
-		RegisterWikiPageRoutes(v1, params.WikiPageHandler)
+		RegisterWeKnoraCloudRoutes(v1, params.WeKnoraCloudHandler, rbacGuards)
+		RegisterWikiPageRoutes(v1, params.WikiPageHandler, rbacGuards)
 		RegisterChunkerDebugRoutes(v1)
 	}
 
@@ -242,31 +242,35 @@ func RegisterKnowledgeRoutes(r *gin.RouterGroup, handler *handler.KnowledgeHandl
 }
 
 // RegisterFAQRoutes 注册 FAQ 相关路由
-func RegisterFAQRoutes(r *gin.RouterGroup, handler *handler.FAQHandler) {
+//
+// FAQ entries are KB content: reads are Viewer+, all mutations
+// (create / update / upsert / delete / batch field+tag updates,
+// import display flag) are Contributor+. Search is read-only.
+func RegisterFAQRoutes(r *gin.RouterGroup, handler *handler.FAQHandler, g *rbacGuards) {
 	if handler == nil {
 		return
 	}
 	faq := r.Group("/knowledge-bases/:id/faq")
 	{
-		faq.GET("/entries", handler.ListEntries)
-		faq.GET("/entries/export", handler.ExportEntries)
-		faq.GET("/entries/:entry_id", handler.GetEntry)
-		faq.POST("/entries", handler.UpsertEntries)
-		faq.POST("/entry", handler.CreateEntry)
-		faq.PUT("/entries/:entry_id", handler.UpdateEntry)
-		faq.POST("/entries/:entry_id/similar-questions", handler.AddSimilarQuestions)
+		faq.GET("/entries", g.Viewer(), handler.ListEntries)
+		faq.GET("/entries/export", g.Viewer(), handler.ExportEntries)
+		faq.GET("/entries/:entry_id", g.Viewer(), handler.GetEntry)
+		faq.POST("/entries", g.Contributor(), handler.UpsertEntries)
+		faq.POST("/entry", g.Contributor(), handler.CreateEntry)
+		faq.PUT("/entries/:entry_id", g.Contributor(), handler.UpdateEntry)
+		faq.POST("/entries/:entry_id/similar-questions", g.Contributor(), handler.AddSimilarQuestions)
 		// Unified batch update API - supports is_enabled, is_recommended, tag_id
-		faq.PUT("/entries/fields", handler.UpdateEntryFieldsBatch)
-		faq.PUT("/entries/tags", handler.UpdateEntryTagBatch)
-		faq.DELETE("/entries", handler.DeleteEntries)
-		faq.POST("/search", handler.SearchFAQ)
+		faq.PUT("/entries/fields", g.Contributor(), handler.UpdateEntryFieldsBatch)
+		faq.PUT("/entries/tags", g.Contributor(), handler.UpdateEntryTagBatch)
+		faq.DELETE("/entries", g.Contributor(), handler.DeleteEntries)
+		faq.POST("/search", g.Viewer(), handler.SearchFAQ)
 		// FAQ import result display status
-		faq.PUT("/import/last-result/display", handler.UpdateLastImportResultDisplayStatus)
+		faq.PUT("/import/last-result/display", g.Contributor(), handler.UpdateLastImportResultDisplayStatus)
 	}
-	// FAQ import progress route (outside of knowledge-base scope)
+	// FAQ import progress route (outside of knowledge-base scope) — Viewer+
 	faqImport := r.Group("/faq/import")
 	{
-		faqImport.GET("/progress/:task_id", handler.GetImportProgress)
+		faqImport.GET("/progress/:task_id", g.Viewer(), handler.GetImportProgress)
 	}
 }
 
@@ -298,39 +302,49 @@ func RegisterKnowledgeBaseRoutes(r *gin.RouterGroup, handler *handler.KnowledgeB
 	}
 }
 
-// RegisterKnowledgeTagRoutes 注册知识库标签相关路由
-func RegisterKnowledgeTagRoutes(r *gin.RouterGroup, tagHandler *handler.TagHandler) {
+// RegisterKnowledgeTagRoutes 注册知识库标签相关路由。
+//
+// Tags are KB metadata: Viewer reads, Contributor writes. Per-KB
+// ownership granularity for tags is out of scope for PR 2; this is
+// purely role-based.
+func RegisterKnowledgeTagRoutes(r *gin.RouterGroup, tagHandler *handler.TagHandler, g *rbacGuards) {
 	if tagHandler == nil {
 		return
 	}
 	kbTags := r.Group("/knowledge-bases/:id/tags")
 	{
-		kbTags.GET("", tagHandler.ListTags)
-		kbTags.POST("", tagHandler.CreateTag)
-		kbTags.PUT("/:tag_id", tagHandler.UpdateTag)
-		kbTags.DELETE("/:tag_id", tagHandler.DeleteTag)
+		kbTags.GET("", g.Viewer(), tagHandler.ListTags)
+		kbTags.POST("", g.Contributor(), tagHandler.CreateTag)
+		kbTags.PUT("/:tag_id", g.Contributor(), tagHandler.UpdateTag)
+		kbTags.DELETE("/:tag_id", g.Contributor(), tagHandler.DeleteTag)
 	}
 }
 
-// RegisterMessageRoutes 注册消息相关的路由
-func RegisterMessageRoutes(r *gin.RouterGroup, handler *handler.MessageHandler) {
-	// 消息路由组
+// RegisterMessageRoutes 注册消息相关的路由。
+//
+// Per-session ownership is already enforced inside each handler (the
+// user must own the session). We add Viewer+ here so non-members
+// (e.g. revoked accounts retained in the tenant for audit) cannot
+// reach the endpoints at all once RBAC is on.
+func RegisterMessageRoutes(r *gin.RouterGroup, handler *handler.MessageHandler, g *rbacGuards) {
 	messages := r.Group("/messages")
 	{
-		// 搜索历史对话（关键词 + 向量混合搜索）
-		messages.POST("/search", handler.SearchMessages)
-		// 获取聊天历史知识库的统计信息
-		messages.GET("/chat-history-stats", handler.GetChatHistoryKBStats)
-		// 加载更早的消息，用于向上滚动加载
-		messages.GET("/:session_id/load", handler.LoadMessages)
-		// 删除消息
-		messages.DELETE("/:session_id/:id", handler.DeleteMessage)
+		messages.POST("/search", g.Viewer(), handler.SearchMessages)
+		messages.GET("/chat-history-stats", g.Viewer(), handler.GetChatHistoryKBStats)
+		messages.GET("/:session_id/load", g.Viewer(), handler.LoadMessages)
+		messages.DELETE("/:session_id/:id", g.Viewer(), handler.DeleteMessage)
 	}
 }
 
-// RegisterSessionRoutes 注册路由
-func RegisterSessionRoutes(r *gin.RouterGroup, handler *session.Handler) {
-	sessions := r.Group("/sessions")
+// RegisterSessionRoutes 注册路由。
+//
+// Sessions are per-user resources; the handler enforces user ownership.
+// We gate at Viewer+ to keep non-members out once RBAC is on, matching
+// the message routes above. A future refactor can introduce
+// per-session ownership in the middleware layer the same way KB/agent
+// routes do today.
+func RegisterSessionRoutes(r *gin.RouterGroup, handler *session.Handler, g *rbacGuards) {
+	sessions := r.Group("/sessions", g.Viewer())
 	{
 		sessions.POST("", handler.CreateSession)
 		sessions.DELETE("/batch", handler.BatchDeleteSessions)
@@ -352,21 +366,23 @@ func RegisterSessionRoutes(r *gin.RouterGroup, handler *session.Handler) {
 	}
 }
 
-// RegisterChatRoutes 注册路由
-func RegisterChatRoutes(r *gin.RouterGroup, handler *session.Handler) {
-	knowledgeChat := r.Group("/knowledge-chat")
+// RegisterChatRoutes 注册路由。Chat endpoints are tenant-member usage
+// surfaces; Viewer+ is sufficient because per-session/per-agent
+// authorisation is enforced inside the handlers.
+func RegisterChatRoutes(r *gin.RouterGroup, handler *session.Handler, g *rbacGuards) {
+	knowledgeChat := r.Group("/knowledge-chat", g.Viewer())
 	{
 		knowledgeChat.POST("/:session_id", handler.KnowledgeQA)
 	}
 
 	// Agent-based chat
-	agentChat := r.Group("/agent-chat")
+	agentChat := r.Group("/agent-chat", g.Viewer())
 	{
 		agentChat.POST("/:session_id", handler.AgentQA)
 	}
 
 	// 新增知识检索接口，不需要session_id
-	knowledgeSearch := r.Group("/knowledge-search")
+	knowledgeSearch := r.Group("/knowledge-search", g.Viewer())
 	{
 		knowledgeSearch.POST("", handler.SearchKnowledge)
 	}
@@ -532,31 +548,35 @@ func RegisterMCPServiceRoutes(r *gin.RouterGroup, handler *handler.MCPServiceHan
 }
 
 // RegisterWebSearchRoutes registers web search routes
-func RegisterWebSearchRoutes(r *gin.RouterGroup, webSearchHandler *handler.WebSearchHandler) {
-	// Web search providers
+func RegisterWebSearchRoutes(r *gin.RouterGroup, webSearchHandler *handler.WebSearchHandler, g *rbacGuards) {
+	// Web search providers — Viewer+ (read-only listing of provider catalog).
 	webSearch := r.Group("/web-search")
 	{
-		// Get available providers
-		webSearch.GET("/providers", webSearchHandler.GetProviders)
+		webSearch.GET("/providers", g.Viewer(), webSearchHandler.GetProviders)
 	}
 }
 
-// RegisterWebSearchProviderRoutes registers CRUD routes for web search provider configurations
-func RegisterWebSearchProviderRoutes(r *gin.RouterGroup, h *handler.WebSearchProviderHandler) {
+// RegisterWebSearchProviderRoutes registers CRUD routes for web search
+// provider configurations.
+//
+// Provider rows hold external service credentials (Bing, Tavily, Google,
+// etc.); reads are Viewer+, all mutations and connection tests (which
+// probe external systems with stored credentials) are Admin+.
+func RegisterWebSearchProviderRoutes(r *gin.RouterGroup, h *handler.WebSearchProviderHandler, g *rbacGuards) {
 	providers := r.Group("/web-search-providers")
 	{
-		// List available provider types (metadata for UI forms)
-		providers.GET("/types", h.ListProviderTypes)
-		// Test with raw credentials (no persistence)
-		providers.POST("/test", h.TestProviderRaw)
+		// List available provider types (metadata for UI forms) — Viewer+
+		providers.GET("/types", g.Viewer(), h.ListProviderTypes)
+		// Test with raw credentials (no persistence) — Admin+
+		providers.POST("/test", g.Admin(), h.TestProviderRaw)
 		// CRUD
-		providers.POST("", h.CreateProvider)
-		providers.GET("", h.ListProviders)
-		providers.GET("/:id", h.GetProvider)
-		providers.PUT("/:id", h.UpdateProvider)
-		providers.DELETE("/:id", h.DeleteProvider)
-		// Test existing saved provider
-		providers.POST("/:id/test", h.TestProviderByID)
+		providers.POST("", g.Admin(), h.CreateProvider)
+		providers.GET("", g.Viewer(), h.ListProviders)
+		providers.GET("/:id", g.Viewer(), h.GetProvider)
+		providers.PUT("/:id", g.Admin(), h.UpdateProvider)
+		providers.DELETE("/:id", g.Admin(), h.DeleteProvider)
+		// Test existing saved provider — Admin+
+		providers.POST("/:id/test", g.Admin(), h.TestProviderByID)
 	}
 }
 
@@ -613,12 +633,16 @@ func RegisterCustomAgentRoutes(r *gin.RouterGroup, agentHandler *handler.CustomA
 	r.GET("/agents/:id/suggested-questions", g.Viewer(), agentHandler.GetSuggestedQuestions)
 }
 
-// RegisterSkillRoutes registers skill routes
-func RegisterSkillRoutes(r *gin.RouterGroup, skillHandler *handler.SkillHandler) {
+// RegisterSkillRoutes registers skill routes.
+//
+// PR 2 currently only exposes a read-only `ListSkills`; gated to
+// Viewer+. Future skill upload / enable endpoints must use Admin+ since
+// skills run sandboxed code on tenant resources.
+func RegisterSkillRoutes(r *gin.RouterGroup, skillHandler *handler.SkillHandler, g *rbacGuards) {
 	skills := r.Group("/skills")
 	{
-		// List all preloaded skills
-		skills.GET("", skillHandler.ListSkills)
+		// List all preloaded skills — Viewer+
+		skills.GET("", g.Viewer(), skillHandler.ListSkills)
 	}
 }
 
@@ -1036,38 +1060,47 @@ func RegisterDataSourceRoutes(r *gin.RouterGroup, handler *handler.DataSourceHan
 }
 
 // RegisterWeKnoraCloudRoutes 注册 WeKnoraCloud 初始化路由
-func RegisterWeKnoraCloudRoutes(r *gin.RouterGroup, handler *handler.WeKnoraCloudHandler) {
-	r.POST("/weknoracloud/credentials", handler.SaveCredentials)
-	r.GET("/models/weknoracloud/status", handler.Status)
+// RegisterWeKnoraCloudRoutes registers the WeKnoraCloud credential
+// management endpoints. SaveCredentials persists external SaaS keys
+// for the tenant (Admin+), Status is a low-risk readiness probe (Viewer+).
+func RegisterWeKnoraCloudRoutes(r *gin.RouterGroup, handler *handler.WeKnoraCloudHandler, g *rbacGuards) {
+	r.POST("/weknoracloud/credentials", g.Admin(), handler.SaveCredentials)
+	r.GET("/models/weknoracloud/status", g.Viewer(), handler.Status)
 }
 
-// RegisterWikiPageRoutes registers wiki page related routes
-func RegisterWikiPageRoutes(r *gin.RouterGroup, wikiHandler *handler.WikiPageHandler) {
+// RegisterWikiPageRoutes registers wiki page related routes.
+//
+// Wiki pages are KB content (wiki mode): reads are Viewer+, content
+// mutations (create/update/delete) and maintenance actions
+// (rebuild-links, auto-fix, change issue status) are Contributor+.
+// Per-KB ownership granularity for individual pages is a follow-up,
+// same as plain knowledge entries.
+func RegisterWikiPageRoutes(r *gin.RouterGroup, wikiHandler *handler.WikiPageHandler, g *rbacGuards) {
 	wiki := r.Group("/knowledgebase/:kb_id/wiki")
 	{
 		// Page CRUD
-		wiki.GET("/pages", wikiHandler.ListPages)
-		wiki.POST("/pages", wikiHandler.CreatePage)
-		wiki.GET("/pages/*slug", wikiHandler.GetPage)
-		wiki.PUT("/pages/*slug", wikiHandler.UpdatePage)
-		wiki.DELETE("/pages/*slug", wikiHandler.DeletePage)
+		wiki.GET("/pages", g.Viewer(), wikiHandler.ListPages)
+		wiki.POST("/pages", g.Contributor(), wikiHandler.CreatePage)
+		wiki.GET("/pages/*slug", g.Viewer(), wikiHandler.GetPage)
+		wiki.PUT("/pages/*slug", g.Contributor(), wikiHandler.UpdatePage)
+		wiki.DELETE("/pages/*slug", g.Contributor(), wikiHandler.DeletePage)
 
 		// Special pages
-		wiki.GET("/index", wikiHandler.GetIndex)
-		wiki.GET("/log", wikiHandler.GetLog)
+		wiki.GET("/index", g.Viewer(), wikiHandler.GetIndex)
+		wiki.GET("/log", g.Viewer(), wikiHandler.GetLog)
 
 		// Graph and stats
-		wiki.GET("/graph", wikiHandler.GetGraph)
-		wiki.GET("/stats", wikiHandler.GetStats)
+		wiki.GET("/graph", g.Viewer(), wikiHandler.GetGraph)
+		wiki.GET("/stats", g.Viewer(), wikiHandler.GetStats)
 
 		// Search and maintenance
-		wiki.GET("/search", wikiHandler.SearchPages)
-		wiki.POST("/rebuild-links", wikiHandler.RebuildLinks)
-		wiki.GET("/lint", wikiHandler.Lint)
-		wiki.POST("/auto-fix", wikiHandler.AutoFix)
+		wiki.GET("/search", g.Viewer(), wikiHandler.SearchPages)
+		wiki.POST("/rebuild-links", g.Contributor(), wikiHandler.RebuildLinks)
+		wiki.GET("/lint", g.Viewer(), wikiHandler.Lint)
+		wiki.POST("/auto-fix", g.Contributor(), wikiHandler.AutoFix)
 
 		// Issues
-		wiki.GET("/issues", wikiHandler.ListIssues)
-		wiki.PUT("/issues/:issue_id/status", wikiHandler.UpdateIssueStatus)
+		wiki.GET("/issues", g.Viewer(), wikiHandler.ListIssues)
+		wiki.PUT("/issues/:issue_id/status", g.Contributor(), wikiHandler.UpdateIssueStatus)
 	}
 }

--- a/internal/types/context_helpers.go
+++ b/internal/types/context_helpers.go
@@ -54,6 +54,33 @@ func UserIDFromContext(ctx context.Context) (string, bool) {
 	return v, ok && v != ""
 }
 
+// IsSyntheticUserID reports whether id refers to the synthetic system
+// user that the X-API-Key auth path attaches to each tenant
+// (User.ID = "system-<tenantID>"). These users have no real human
+// behind them and no tenant_members row, so RBAC ownership matching
+// against them is never meaningful — service-layer code that records
+// "the creator" should skip storing this ID and treat the resource as
+// tenant-owned instead.
+//
+// Kept minimal on purpose: the prefix and "all digits afterwards"
+// invariant comes from middleware/auth.go's User construction for the
+// API-key branch. If that prefix changes, update both sides.
+func IsSyntheticUserID(id string) bool {
+	const prefix = "system-"
+	if len(id) <= len(prefix) {
+		return false
+	}
+	if id[:len(prefix)] != prefix {
+		return false
+	}
+	for _, r := range id[len(prefix):] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // TenantRoleFromContext extracts the caller's TenantRole in the currently
 // active tenant. Returns TenantRoleViewer when the key is absent so that
 // callers fail closed (least privilege) if the auth middleware did not

--- a/internal/types/context_helpers_test.go
+++ b/internal/types/context_helpers_test.go
@@ -4,6 +4,35 @@ import (
 	"testing"
 )
 
+func TestIsSyntheticUserID(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{"matches system-<digits>", "system-1", true},
+		{"matches large tenant id", "system-1234567890", true},
+		{"empty string", "", false},
+		{"prefix only", "system-", false},
+		{"missing prefix", "1", false},
+		{"non-digit suffix", "system-abc", false},
+		{"mixed suffix", "system-1a2", false},
+		{"prefix with space", "system- 1", false},
+		{"uppercase prefix", "SYSTEM-1", false},
+		{"normal uuid user", "550e8400-e29b-41d4-a716-446655440000", false},
+		{"system uuid trap", "system-550e8400", false}, // contains '-'
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			got := IsSyntheticUserID(c.id)
+			if got != c.want {
+				t.Fatalf("IsSyntheticUserID(%q) = %v, want %v", c.id, got, c.want)
+			}
+		})
+	}
+}
+
 func TestLanguageLocaleName(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/types/custom_agent.go
+++ b/internal/types/custom_agent.go
@@ -76,9 +76,15 @@ type CustomAgent struct {
 	// Created by user ID
 	CreatedBy string `yaml:"created_by" json:"created_by" gorm:"type:varchar(36)"`
 	// RunnableByViewer controls whether users with TenantRoleViewer can
-	// start chat sessions against this agent. Defaults to true so viewers
-	// can still consume published agents; admins toggle it off for agents
-	// whose tools should be restricted to contributors and above.
+	// run this agent IN AGENT MODE (i.e. with tools, MCP, sandboxed code
+	// execution, etc.). Plain RAG / Wiki QA sessions against the same
+	// agent are unaffected — they don't invoke tools, so restricting
+	// them buys no security and would just block Viewer consumption of
+	// published agents. Defaults to true; admins toggle it off for
+	// agents whose tools should be restricted to contributors and above.
+	//
+	// Enforcement lives in handler/session/qa.go's AgentQA, gated behind
+	// cfg.Tenant.EnableRBAC like every other PR2 check.
 	//
 	// Note: no GORM `default:true` tag here. With a plain `bool` field that
 	// tag causes GORM to treat Go's zero value (false) as "unspecified" and


### PR DESCRIPTION
## Summary

- Adds `RequireRole` / `RequireOwnershipOrRole` middleware and annotates every authenticated route with the matrix from #1303 (Viewer reads, Contributor authoring, Admin tenant-infra writes, Owner tenant-config, OwnedXOrAdmin for per-resource mutations).
- Populates `CreatorID` / `CreatedBy` on KB and Custom Agent creation/copy so the ownership guards have a creator to match. Built-in agents stay tenant-owned (Admin+ only).
- Adds an agent run-time gate: Viewers cannot launch an agent whose author has cleared `RunnableByViewer`.
- All enforcement is gated behind `cfg.Tenant.EnableRBAC`; the change ships dormant and starts blocking once operators flip the flag.

This is PR 2 of 3 for #1303 and stacks on top of `feat/rbac` (PR 1). PR 3 will add the member-management endpoints and frontend role-aware UI.

### Files

- `internal/middleware/rbac.go` + `rbac_test.go` — guards and unit tests (12 cases covering role-only, ownership, lookup-error, fail-open, fail-closed branches).
- `internal/handler/rbac_lookups.go` — `KBCreatorLookup`, `AgentCreatorLookup`. Built-in agents return `("", nil)` so they fall through to Admin+.
- `internal/router/rbac.go` — `rbacGuards` bundle threaded through every Register* function.
- `internal/router/router.go` — every authenticated route group annotated per the matrix.
- `internal/application/service/{knowledgebase,custom_agent}.go` — populate creator IDs on Create/Copy.
- `internal/handler/session/qa.go` — `RunnableByViewer` enforcement in `AgentQA`.

### Rollout posture

`cfg.Tenant.EnableRBAC` defaults to `false`. With the flag off, both the middleware and the agent-run gate log the would-be rejection and let the request through, so existing tenants observe no behaviour change. Operators flip the flag to begin enforcement.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l` clean on PR 2 files
- [x] `go vet ./internal/middleware/... ./internal/router/... ./internal/handler/... ./internal/application/service/...`
- [x] `go test ./internal/middleware/...` — all RBAC tests pass (RequireRole + RequireOwnershipOrRole, 12 cases)
- [x] `go test ./internal/application/service/...` — tenant_member + JWT tests pass; pre-existing infra-dependent failures (vectorstore ES connect, oss bucket create) confirmed on `main`
- [ ] Manual: flip `enable_rbac=true`, verify a Viewer is rejected on KB POST and accepted on KB GET
- [ ] Manual: verify a Contributor can edit their own KB but is rejected on someone else's KB
- [ ] Manual: verify Admin bypasses ownership check
- [ ] Manual: verify Viewer cannot launch an agent with `runnable_by_viewer=false`