### PR TITLE
fix(org): searchable join bypasses invite code expiry

### DIFF
--- a/internal/application/service/organization.go
+++ b/internal/application/service/organization.go
@@ -300,11 +300,11 @@ func (s *organizationService) JoinByOrganizationID(ctx context.Context, orgID st
 		}
 		return org, nil
 	}
-	// Direct join using invite code flow logic (add member)
-	_, err = s.JoinByInviteCode(ctx, org.InviteCode, userID, tenantID)
-	if err != nil {
+	// Searchable direct join: do not validate invite code or expiry (product copy: no invite code required).
+	if err := s.joinAsViewerWithChecks(ctx, org, userID, tenantID); err != nil {
 		return nil, err
 	}
+	logger.Infof(ctx, "User %s joined organization %s via searchable join", userID, org.ID)
 	return org, nil
 }
 
@@ -470,6 +470,39 @@ func (s *organizationService) GenerateInviteCode(ctx context.Context, orgID stri
 	return inviteCode, nil
 }
 
+// joinAsViewerWithChecks adds the user as viewer when not already a member (enforces member limit).
+func (s *organizationService) joinAsViewerWithChecks(ctx context.Context, org *types.Organization, userID string, tenantID uint64) error {
+	_, err := s.orgRepo.GetMember(ctx, org.ID, userID)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, repository.ErrOrgMemberNotFound) {
+		return err
+	}
+
+	if org.MemberLimit > 0 {
+		count, errCount := s.orgRepo.CountMembers(ctx, org.ID)
+		if errCount != nil {
+			return errCount
+		}
+		if count >= int64(org.MemberLimit) {
+			return ErrOrgMemberLimitReached
+		}
+	}
+
+	member := &types.OrganizationMember{
+		ID:             uuid.New().String(),
+		OrganizationID: org.ID,
+		UserID:         userID,
+		TenantID:       tenantID,
+		Role:           types.OrgRoleViewer,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	return s.orgRepo.AddMember(ctx, member)
+}
+
 // JoinByInviteCode allows a user to join an organization via invite code
 func (s *organizationService) JoinByInviteCode(ctx context.Context, inviteCode string, userID string, tenantID uint64) (*types.Organization, error) {
 	org, err := s.orgRepo.GetByInviteCode(ctx, inviteCode)
@@ -489,39 +522,7 @@ func (s *organizationService) JoinByInviteCode(ctx context.Context, inviteCode s
 		return nil, ErrOrgPermissionDenied
 	}
 
-	// Check if user is already a member
-	_, err = s.orgRepo.GetMember(ctx, org.ID, userID)
-	if err == nil {
-		// User is already a member, just return the organization
-		return org, nil
-	}
-	if !errors.Is(err, repository.ErrOrgMemberNotFound) {
-		return nil, err
-	}
-
-	// Check member limit (0 = unlimited)
-	if org.MemberLimit > 0 {
-		count, errCount := s.orgRepo.CountMembers(ctx, org.ID)
-		if errCount != nil {
-			return nil, errCount
-		}
-		if count >= int64(org.MemberLimit) {
-			return nil, ErrOrgMemberLimitReached
-		}
-	}
-
-	// Add user as viewer by default
-	member := &types.OrganizationMember{
-		ID:             uuid.New().String(),
-		OrganizationID: org.ID,
-		UserID:         userID,
-		TenantID:       tenantID,
-		Role:           types.OrgRoleViewer,
-		CreatedAt:      time.Now(),
-		UpdatedAt:      time.Now(),
-	}
-
-	if err := s.orgRepo.AddMember(ctx, member); err != nil {
+	if err := s.joinAsViewerWithChecks(ctx, org, userID, tenantID); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Description

修复「开放可被搜索」空间在**无需审核、直接加入**时，仍通过内部调用 `JoinByInviteCode` 校验邀请码与 `invite_code_expires_at`，导致邀请已过期时出现 **500 / 错误码 1007（`Failed to join organization`）** 的问题。该行为与产品文案「他人可搜索并申请加入，**无需邀请码**」不一致。

本次改动：`JoinByOrganizationID` 在直接加入分支改为调用抽取的 `joinAsViewerWithChecks`，仅做成员是否已存在、人数上限与以 viewer 入会的逻辑，**不再**依赖邀请码查询与过期判断；`JoinByInviteCode` 复用同一辅助函数，避免重复代码。需要审核的加入仍走 `SubmitJoinRequest`，行为不变。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test
- [ ] Configuration / Build / CI


## Testing

1. 连接数据库将invite_code_expires_at调整为已过期，测试发现还能通过
<img width="631" height="481" alt="image" src="https://github.com/user-attachments/assets/13d55a82-b998-435d-8af4-8d5e106e326d" />


## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

无（后端逻辑变更，无 UI 改动）
