### PR TITLE
fix(agent): resolve fabricated chunk citations

### DIFF
--- a/internal/agent/finalize.go
+++ b/internal/agent/finalize.go
@@ -72,7 +72,7 @@ User question: %s
 
 Requirements:
 1. Answer based on the actually retrieved content
-2. Clearly cite information sources (chunk_id, document name)
+2. Cite knowledge-base sources with <kb doc="document name" chunk_id="tool_returned_chunk_id"/> tags. Use the exact chunk_id attribute returned by the tools; never invent IDs or derive a chunk_id from knowledge_id/chunk_index.
 3. Organize the answer in a structured format
 4. If information is insufficient, honestly state so
 5. IMPORTANT: Respond in the same language as the user's question

--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -77,6 +77,21 @@ func (r *chunkRepository) GetChunkByIDOnly(ctx context.Context, id string) (*typ
 	return &chunk, nil
 }
 
+// GetChunkByKnowledgeIDAndIndexOnly retrieves a chunk by knowledge ID and chunk index without tenant filter.
+func (r *chunkRepository) GetChunkByKnowledgeIDAndIndexOnly(ctx context.Context, knowledgeID string, chunkIndex int) (*types.Chunk, error) {
+	var chunk types.Chunk
+	if err := r.db.WithContext(ctx).
+		Where("knowledge_id = ? AND chunk_index = ?", knowledgeID, chunkIndex).
+		Order("CASE WHEN chunk_type = 'text' THEN 0 ELSE 1 END").
+		First(&chunk).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("chunk not found")
+		}
+		return nil, err
+	}
+	return &chunk, nil
+}
+
 // GetChunkBySeqID retrieves a chunk by its seq_id and tenant ID
 func (r *chunkRepository) GetChunkBySeqID(ctx context.Context, tenantID uint64, seqID int64) (*types.Chunk, error) {
 	var chunk types.Chunk

--- a/internal/application/repository/chunk_sqlite_test.go
+++ b/internal/application/repository/chunk_sqlite_test.go
@@ -215,3 +215,22 @@ func TestUpdateChunk_SQLite_NoNOWError(t *testing.T) {
 	require.NoError(t, db.First(&saved, "id = ?", chunk.ID).Error)
 	assert.Equal(t, "updated content", saved.Content)
 }
+
+func TestGetChunkByKnowledgeIDAndIndexOnlyPrefersTextChunk(t *testing.T) {
+	db := setupChunkTestDB(t)
+	repo := NewChunkRepository(db)
+	ctx := context.Background()
+
+	kbID := uuid.NewString()
+	knowledgeID := uuid.NewString()
+	imageChunk := makeChunk(kbID, knowledgeID, types.ChunkTypeImageOCR)
+	imageChunk.ChunkIndex = 7
+	textChunk := makeChunk(kbID, knowledgeID, types.ChunkTypeText)
+	textChunk.ChunkIndex = 7
+
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{imageChunk, textChunk}))
+
+	got, err := repo.GetChunkByKnowledgeIDAndIndexOnly(ctx, knowledgeID, 7)
+	require.NoError(t, err)
+	assert.Equal(t, textChunk.ID, got.ID)
+}

--- a/internal/application/service/chunk.go
+++ b/internal/application/service/chunk.go
@@ -6,6 +6,8 @@ package service
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strconv"
 
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -22,6 +24,8 @@ type chunkService struct {
 	modelService    interfaces.ModelService
 	retrieveEngine  interfaces.RetrieveEngineRegistry
 }
+
+var fabricatedChunkReferencePattern = regexp.MustCompile(`^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})_chunk_([0-9]+)$`)
 
 // NewChunkService creates a new chunk service
 // It initializes a service with the provided chunk repository
@@ -103,14 +107,48 @@ func (s *chunkService) GetChunkByID(ctx context.Context, id string) (*types.Chun
 // GetChunkByIDOnly retrieves a chunk by ID without tenant filter (for permission resolution).
 func (s *chunkService) GetChunkByIDOnly(ctx context.Context, id string) (*types.Chunk, error) {
 	chunk, err := s.chunkRepository.GetChunkByIDOnly(ctx, id)
-	if err != nil {
-		if err != nil && err.Error() == "chunk not found" {
-			return nil, ErrChunkNotFound
-		}
+	if err == nil {
+		return chunk, nil
+	}
+	if !isChunkNotFoundError(err) {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{"chunk_id": id})
 		return nil, err
 	}
+
+	knowledgeID, chunkIndex, ok := parseFabricatedChunkReference(id)
+	if !ok {
+		return nil, ErrChunkNotFound
+	}
+
+	chunk, err = s.chunkRepository.GetChunkByKnowledgeIDAndIndexOnly(ctx, knowledgeID, chunkIndex)
+	if err != nil {
+		if isChunkNotFoundError(err) {
+			return nil, ErrChunkNotFound
+		}
+		logger.ErrorWithFields(ctx, err, map[string]interface{}{
+			"chunk_id":     id,
+			"knowledge_id": knowledgeID,
+			"chunk_index":  chunkIndex,
+		})
+		return nil, err
+	}
 	return chunk, nil
+}
+
+func isChunkNotFoundError(err error) bool {
+	return err != nil && err.Error() == ErrChunkNotFound.Error()
+}
+
+func parseFabricatedChunkReference(id string) (string, int, bool) {
+	matches := fabricatedChunkReferencePattern.FindStringSubmatch(id)
+	if len(matches) != 3 {
+		return "", 0, false
+	}
+	chunkIndex, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return "", 0, false
+	}
+	return matches[1], chunkIndex, true
 }
 
 // ListChunksByKnowledgeID lists all chunks for a knowledge ID

--- a/internal/application/service/chunk_reference_test.go
+++ b/internal/application/service/chunk_reference_test.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newTestChunkService(t *testing.T) (interfaces.ChunkService, *gorm.DB) {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.Chunk{}))
+
+	return NewChunkService(repository.NewChunkRepository(db), nil, nil, nil), db
+}
+
+func TestGetChunkByIDOnlyResolvesFabricatedKnowledgeChunkReference(t *testing.T) {
+	svc, db := newTestChunkService(t)
+
+	knowledgeID := uuid.NewString()
+	want := &types.Chunk{
+		ID:              uuid.NewString(),
+		TenantID:        1,
+		KnowledgeID:     knowledgeID,
+		KnowledgeBaseID: uuid.NewString(),
+		Content:         "chunk referenced by fallback id",
+		ChunkIndex:      7,
+		ChunkType:       types.ChunkTypeText,
+		IsEnabled:       true,
+	}
+	require.NoError(t, db.Create(want).Error)
+
+	got, err := svc.GetChunkByIDOnly(context.Background(), knowledgeID+"_chunk_7")
+	require.NoError(t, err)
+	require.Equal(t, want.ID, got.ID)
+}
+
+func TestGetChunkByIDOnlyRejectsMalformedFabricatedReference(t *testing.T) {
+	svc, _ := newTestChunkService(t)
+
+	_, err := svc.GetChunkByIDOnly(context.Background(), uuid.NewString()+"_chunk_not-a-number")
+	require.ErrorIs(t, err, ErrChunkNotFound)
+}

--- a/internal/types/interfaces/chunk.go
+++ b/internal/types/interfaces/chunk.go
@@ -20,6 +20,8 @@ type ChunkRepository interface {
 	GetChunkByID(ctx context.Context, tenantID uint64, id string) (*types.Chunk, error)
 	// GetChunkByIDOnly gets a chunk by id without tenant filter (for permission resolution)
 	GetChunkByIDOnly(ctx context.Context, id string) (*types.Chunk, error)
+	// GetChunkByKnowledgeIDAndIndexOnly gets a chunk by knowledge id and chunk index without tenant filter.
+	GetChunkByKnowledgeIDAndIndexOnly(ctx context.Context, knowledgeID string, chunkIndex int) (*types.Chunk, error)
 	// GetChunkBySeqID gets a chunk by seq_id
 	GetChunkBySeqID(ctx context.Context, tenantID uint64, seqID int64) (*types.Chunk, error)
 	// ListChunksByID lists chunks by ids


### PR DESCRIPTION
## Description

Fixes #1323.

Smart-reasoning final answers can sometimes cite fabricated chunk IDs such as `<knowledge_id>_chunk_<index>` instead of the UUID chunk IDs returned by `knowledge_search` / `grep_chunks`. The frontend then calls `/api/v1/chunks/by-id/{chunk_id}` and receives `Chunk not found`.

This PR keeps the normal UUID lookup path unchanged, then adds a compatibility fallback only when the direct chunk lookup misses:

- Parse strict `uuid_chunk_<index>` references.
- Resolve them by `knowledge_id + chunk_index`, preferring text chunks when multiple chunk types share an index.
- Preserve the existing permission flow: the handler still validates access through the resolved chunk's knowledge item before returning data.
- Tighten the final-answer prompt so the model uses `<kb doc="..." chunk_id="..."/>` citations with the exact tool-returned `chunk_id`, and does not derive IDs from `knowledge_id/chunk_index`.

## Testing

- `CGO_LDFLAGS='-lc++' go test ./internal/application/service -run 'TestGetChunkByIDOnly(ResolvesFabricatedKnowledgeChunkReference|RejectsMalformedFabricatedReference)' -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/repository -run TestGetChunkByKnowledgeIDAndIndexOnlyPrefersTextChunk -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/repository ./internal/application/service ./internal/handler -run '^$' -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/agent -run '^$' -count=1`
- `git diff --check`
- Docker-backed local HTTP validation with Postgres, Redis, DocReader, and local `go run ./cmd/server`: inserted a temporary KB/knowledge/chunk, verified both the real UUID and `knowledge_id_chunk_7` return the same chunk through `/api/v1/chunks/by-id/{id}`, verified malformed fallback IDs still return 404, then cleaned up the temp rows and restored the local test tenant API key.

## Notes

No database migration is required. The fallback query is only used after direct UUID lookup returns not found.