### PR TITLE
fix(migration): fail fast on critical schema gaps

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -490,11 +490,13 @@ func initDatabase(cfg *config.Config) (*gorm.DB, error) {
 		// Run base migrations (all versioned migrations including embeddings)
 		// The embeddings migration will be conditionally executed based on skip_embedding parameter in DSN
 		if err := database.RunMigrationsWithOptions(migrateDSN, migrationOpts); err != nil {
-			// Log warning but don't fail startup - migrations might be handled externally
 			logger.Warnf(context.Background(), "Database migration failed: %v", err)
+			if validationErr := validateCriticalSchemaAfterMigrationFailure(db, os.Getenv("DB_DRIVER"), err); validationErr != nil {
+				return nil, validationErr
+			}
 			logger.Warnf(
 				context.Background(),
-				"Continuing with application startup. Please run migrations manually if needed.",
+				"Database migration failed, but the critical wiki/task schema is present. Continuing with application startup.",
 			)
 		}
 

--- a/internal/container/migration_validation.go
+++ b/internal/container/migration_validation.go
@@ -1,0 +1,77 @@
+package container
+
+import (
+	"fmt"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+var criticalMigrationTables = []string{
+	"wiki_pages",
+	"wiki_log_entries",
+	"task_pending_ops",
+	"task_dead_letters",
+}
+
+func validateCriticalSchemaAfterMigrationFailure(db *gorm.DB, dbDriver string, migrationErr error) error {
+	dirty, err := hasDirtyMigrationState(db)
+	if err != nil {
+		return fmt.Errorf(
+			"database migration failed: %w; unable to inspect schema_migrations dirty state: %v",
+			migrationErr,
+			err,
+		)
+	}
+
+	missing := missingCriticalMigrationTables(db)
+	if !dirty && len(missing) == 0 {
+		return nil
+	}
+
+	advice := "Run database migrations manually before restarting the application."
+	if dirty {
+		advice += " If schema_migrations is dirty, inspect the partially applied migration and use make migrate-force version=<last-good-version> only after repairing it."
+	}
+	if strings.EqualFold(dbDriver, "postgres") {
+		advice += " For PostgreSQL/ParadeDB deployments, verify that pg_trgm is available before rerunning migration 000041: CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+	}
+
+	reasons := make([]string, 0, 2)
+	if dirty {
+		reasons = append(reasons, "schema_migrations is dirty")
+	}
+	if len(missing) > 0 {
+		reasons = append(reasons, "missing critical tables after failed migration: "+strings.Join(missing, ", "))
+	}
+
+	return fmt.Errorf(
+		"database migration failed: %w; %s. "+
+			"Refusing to continue application startup because wiki ingest and task processing would break silently. %s",
+		migrationErr,
+		strings.Join(reasons, "; "),
+		advice,
+	)
+}
+
+func missingCriticalMigrationTables(db *gorm.DB) []string {
+	missing := make([]string, 0, len(criticalMigrationTables))
+	for _, tableName := range criticalMigrationTables {
+		if !db.Migrator().HasTable(tableName) {
+			missing = append(missing, tableName)
+		}
+	}
+	return missing
+}
+
+func hasDirtyMigrationState(db *gorm.DB) (bool, error) {
+	if !db.Migrator().HasTable("schema_migrations") {
+		return false, nil
+	}
+
+	var dirty bool
+	if err := db.Raw("SELECT dirty FROM schema_migrations LIMIT 1").Scan(&dirty).Error; err != nil {
+		return false, err
+	}
+	return dirty, nil
+}

--- a/internal/container/migration_validation_test.go
+++ b/internal/container/migration_validation_test.go
@@ -1,0 +1,88 @@
+package container
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestValidateCriticalSchemaAfterMigrationFailureRejectsMissingWikiTaskTables(t *testing.T) {
+	db := newMigrationValidationTestDB(t)
+
+	err := validateCriticalSchemaAfterMigrationFailure(db, "postgres", errors.New("migration 41 failed"))
+	if err == nil {
+		t.Fatal("expected startup validation to fail when migration failed and critical tables are missing")
+	}
+
+	msg := err.Error()
+	for _, want := range []string{
+		"migration 41 failed",
+		"task_pending_ops",
+		"task_dead_letters",
+		"wiki_pages",
+		"wiki_log_entries",
+		"pg_trgm",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("expected error to mention %q, got %q", want, msg)
+		}
+	}
+}
+
+func TestValidateCriticalSchemaAfterMigrationFailureAllowsExternallyMigratedSchema(t *testing.T) {
+	db := newMigrationValidationTestDB(t)
+	for _, table := range criticalMigrationTables {
+		if err := db.Table(table).AutoMigrate(&migrationValidationTestRow{}); err != nil {
+			t.Fatalf("create table %s: %v", table, err)
+		}
+	}
+
+	err := validateCriticalSchemaAfterMigrationFailure(db, "postgres", errors.New("migration 41 failed"))
+	if err != nil {
+		t.Fatalf("expected complete externally managed schema to keep startup allowed, got %v", err)
+	}
+}
+
+func TestValidateCriticalSchemaAfterMigrationFailureRejectsDirtyMigrationState(t *testing.T) {
+	db := newMigrationValidationTestDB(t)
+	for _, table := range criticalMigrationTables {
+		if err := db.Table(table).AutoMigrate(&migrationValidationTestRow{}); err != nil {
+			t.Fatalf("create table %s: %v", table, err)
+		}
+	}
+	if err := db.Exec("CREATE TABLE schema_migrations (version INTEGER, dirty BOOLEAN)").Error; err != nil {
+		t.Fatalf("create schema_migrations: %v", err)
+	}
+	if err := db.Exec("INSERT INTO schema_migrations (version, dirty) VALUES (?, ?)", 41, true).Error; err != nil {
+		t.Fatalf("insert dirty migration state: %v", err)
+	}
+
+	err := validateCriticalSchemaAfterMigrationFailure(db, "postgres", errors.New("migration 41 failed"))
+	if err == nil {
+		t.Fatal("expected dirty migration state to stop startup even when critical tables exist")
+	}
+
+	msg := err.Error()
+	for _, want := range []string{"migration 41 failed", "schema_migrations", "dirty", "migrate-force"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("expected error to mention %q, got %q", want, msg)
+		}
+	}
+}
+
+func newMigrationValidationTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	return db
+}
+
+type migrationValidationTestRow struct {
+	ID uint
+}


### PR DESCRIPTION
## 背景

修复 #1319。

Fixes #1319.

当前启动流程里，`RunMigrationsWithOptions` 失败后只打印 warning 并继续启动。如果 000041 迁移因为 `pg_trgm` / trigram index / dirty migration 等问题失败，Wiki 入库、任务队列和知识图谱相关功能可能在缺少关键 schema 的情况下继续运行，表现为前端无感知卡住或后台任务静默失败。

## 修改内容

- 在迁移失败后增加启动前 schema 校验：如果 `schema_migrations.dirty=true`，直接拒绝启动并给出修复指引。
- 校验 Wiki/任务队列依赖的关键表：`wiki_pages`、`wiki_log_entries`、`task_pending_ops`、`task_dead_letters`。
- 对 PostgreSQL/ParadeDB 场景补充 `pg_trgm` 修复提示，便于定位 000041 trigram index 失败。
- 保留外部迁移工具场景：如果迁移命令失败，但 schema 不 dirty 且关键表都已存在，仍允许继续启动。
- 增加回归单测覆盖关键表缺失、外部迁移已完成、dirty migration 三种路径。

## 验证

- `CGO_LDFLAGS='-lc++' go test ./internal/container -run 'TestValidateCriticalSchemaAfterMigrationFailure' -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/database ./internal/container -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/repository ./internal/application/service -run '^$' -count=1`
- `git diff --cached --check`
- Docker Postgres 非破坏性校验：确认 `schema_migrations` 为 `42|false`，且 `wiki_pages`、`wiki_log_entries`、`task_pending_ops`、`task_dead_letters` 均存在。
- Docker 依赖下本地启动后端并请求 `GET /health`，返回 `{"status":"ok"}`；日志显示迁移版本 42、dirty=false、服务成功监听 `0.0.0.0:8080`。
