### PR TITLE
fix(model): hide Ollama tip for remote models

### DIFF
--- a/frontend/src/components/ModelEditorDialog.vue
+++ b/frontend/src/components/ModelEditorDialog.vue
@@ -30,7 +30,10 @@
           </div>
 
           <!-- Ollama不可用时的提示信息 -->
-          <div v-else-if="ollamaServiceStatus === false" class="ollama-unavailable-tip">
+          <div
+            v-else-if="shouldShowOllamaUnavailableTip(formData.source, modelType, ollamaServiceStatus)"
+            class="ollama-unavailable-tip"
+          >
             <t-icon name="error-circle-filled" class="tip-icon" />
             <span class="tip-text">{{ $t('model.editor.ollamaUnavailable') }}</span>
             <t-button
@@ -334,6 +337,7 @@ import { getWeKnoraCloudStatus } from '@/api/model'
 import { useI18n } from 'vue-i18n'
 import { useUIStore } from '@/stores/ui'
 import SettingDrawer from '@/components/settings/SettingDrawer.vue'
+import { shouldShowOllamaUnavailableTip } from '@/components/modelEditorSourceState'
 
 interface CustomHeaderItem {
   key: string

--- a/frontend/src/components/modelEditorSourceState.test.ts
+++ b/frontend/src/components/modelEditorSourceState.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { shouldShowOllamaUnavailableTip } from './modelEditorSourceState.ts'
+
+test('hides Ollama unavailable tip while configuring a remote model', () => {
+  assert.equal(shouldShowOllamaUnavailableTip('remote', 'chat', false), false)
+})
+
+test('shows Ollama unavailable tip only for local non-rerank models', () => {
+  assert.equal(shouldShowOllamaUnavailableTip('local', 'chat', false), true)
+  assert.equal(shouldShowOllamaUnavailableTip('local', 'embedding', false), true)
+  assert.equal(shouldShowOllamaUnavailableTip('local', 'rerank', false), false)
+})
+
+test('does not show Ollama unavailable tip before status is known or when Ollama is available', () => {
+  assert.equal(shouldShowOllamaUnavailableTip('local', 'chat', null), false)
+  assert.equal(shouldShowOllamaUnavailableTip('local', 'chat', true), false)
+})

--- a/frontend/src/components/modelEditorSourceState.ts
+++ b/frontend/src/components/modelEditorSourceState.ts
@@ -1,0 +1,11 @@
+export type ModelEditorSource = 'local' | 'remote'
+
+export type ModelEditorType = 'chat' | 'embedding' | 'rerank' | 'vllm' | 'asr'
+
+export function shouldShowOllamaUnavailableTip(
+  source: ModelEditorSource,
+  modelType: ModelEditorType,
+  ollamaServiceStatus: boolean | null,
+): boolean {
+  return source === 'local' && modelType !== 'rerank' && ollamaServiceStatus === false
+}


### PR DESCRIPTION
## 修复内容

Fixes #1327。

本次修复将“**Ollama 服务不可用**”提示限制在当前选择本地模型且模型类型不是 rerank 时展示。这样在新增/配置远程模型时，即使本机未启动 Ollama，也不会继续显示本地模型相关的不可用提示。

同时把判断逻辑抽成一个小的纯函数，并补充了 Node 内置测试覆盖以下场景：

- 远程模型 + Ollama 不可用：不展示提示
- 本地 chat/embedding + Ollama 不可用：展示提示
- rerank 模型：不展示 Ollama 不可用提示，继续走原有 rerank 专属提示
- Ollama 状态未知或可用：不展示不可用提示

## 验证

- `node --experimental-strip-types --test frontend/src/components/modelEditorSourceState.test.ts`：通过，3/3 tests pass
- `npx tsc --ignoreConfig --noEmit --allowImportingTsExtensions --module NodeNext --moduleResolution NodeNext --target ES2022 --types node src/components/modelEditorSourceState.ts src/components/modelEditorSourceState.test.ts`：通过
- `npm run build-only`：通过，保留项目已有的 chunk size / dynamic import 警告
- `git diff --cached --check`：通过
- `npm run type-check`：未通过，但失败来自当前前端已有类型问题，代表性文件包括 `src/api/agent/index.ts`、`src/components/doc-content.vue`、`src/components/ModelEditorDialog.vue` 既有行 998/1027/1039/1050、`src/views/settings/AgentSettings.vue` 等；本 PR 只改动模板提示条件和新增独立 helper/test，没有触碰这些失败行