### PR TITLE
feat(frontend): tenant switcher in user menu + role-aware UI gates (#1303)

### DIFF
--- a/frontend/src/components/IMChannelPanel.vue
+++ b/frontend/src/components/IMChannelPanel.vue
@@ -32,9 +32,11 @@
               <t-switch
                 :value="channel.enabled"
                 size="small"
+                :disabled="!authStore.hasRole('admin')"
                 @change="handleToggle(channel)"
               />
               <t-dropdown
+                v-if="authStore.hasRole('admin')"
                 trigger="click"
                 placement="bottom-right"
                 :options="[
@@ -77,7 +79,7 @@
     </div>
 
     <!-- Add button -->
-    <t-button theme="default" variant="dashed" block @click="showCreateDialog = true" class="add-btn">
+    <t-button v-if="authStore.hasRole('admin')" theme="default" variant="dashed" block @click="showCreateDialog = true" class="add-btn">
       <t-icon name="add" />
       {{ $t('agentEditor.im.addChannel') }}
     </t-button>
@@ -429,8 +431,10 @@ import {
 } from '@/api/agent';
 import { listKnowledgeBases } from '@/api/knowledge-base';
 import type { IMChannel } from '@/api/agent';
+import { useAuthStore } from '@/stores/auth';
 
 const { t } = useI18n();
+const authStore = useAuthStore();
 
 const props = defineProps<{
   agentId: string;

--- a/frontend/src/components/IMChannelsOverviewPanel.vue
+++ b/frontend/src/components/IMChannelsOverviewPanel.vue
@@ -84,6 +84,7 @@
               :value="ch.enabled"
               size="small"
               :loading="togglingId === ch.id"
+              :disabled="!authStore.hasRole('admin')"
               @change="handleToggle(ch)"
             />
           </div>
@@ -98,6 +99,7 @@ import { ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { MessagePlugin } from 'tdesign-vue-next';
+import { useAuthStore } from '@/stores/auth';
 import {
   listAllIMChannels,
   listAgents,
@@ -138,6 +140,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 const router = useRouter();
+const authStore = useAuthStore();
 
 const channels = ref<IMChannelOverview[]>([]);
 const agentMap = ref<Map<string, CustomAgent>>(new Map());

--- a/frontend/src/components/UserMenu.vue
+++ b/frontend/src/components/UserMenu.vue
@@ -71,6 +71,23 @@
           <t-icon name="setting" class="menu-icon" />
           <span>{{ $t('general.allSettings') }}</span>
         </div>
+        <!-- Tenant switcher submenu — only meaningful when the user belongs
+             to more than one tenant. Superusers (canAccessAllTenants) keep
+             using the sidebar TenantSelector for "any tenant in the system";
+             the entry here is the curated "tenants I'm a member of" list,
+             matching what the backend memberships claim covers. -->
+        <div
+          v-if="showTenantSwitcher"
+          ref="tenantMenuItemRef"
+          class="menu-item menu-item--submenu"
+          :class="{ 'is-open': tenantSubmenuOpen }"
+          @mouseenter="showTenantSubmenu"
+          @mouseleave="scheduleHideTenantSubmenu"
+        >
+          <t-icon name="swap" class="menu-icon" />
+          <span class="menu-item-label">{{ $t('tenant.switcher.menuLabel') }}</span>
+          <t-icon name="chevron-right" class="menu-chevron" />
+        </div>
         <div class="menu-divider"></div>
         <div class="menu-item" @click="openClawhubSkill">
           <span class="menu-icon menu-icon--emoji" role="img" :aria-label="$t('common.clawhubSkill')">🦞</span>
@@ -143,6 +160,47 @@
         />
       </div>
     </Teleport>
+
+    <!-- Tenant switcher floating panel — shares the same teleport rationale
+         as the IM submenu. Lists every tenant the user is an active member
+         of (from the JWT-issued memberships claim cached in authStore). -->
+    <Teleport to="body">
+      <div
+        v-if="tenantSubmenuOpen"
+        class="tenant-submenu-floating"
+        :style="tenantSubmenuStyle"
+        @mouseenter="showTenantSubmenu"
+        @mouseleave="scheduleHideTenantSubmenu"
+      >
+        <div class="tenant-submenu-header">
+          {{ $t('tenant.switcher.menuLabel') }}
+        </div>
+        <div class="tenant-submenu-list">
+          <div
+            v-for="m in switchableMemberships"
+            :key="m.tenant_id"
+            class="tenant-submenu-item"
+            :class="{ 'is-current': isCurrentTenant(m.tenant_id) }"
+            @click="switchToTenant(m)"
+          >
+            <div class="tenant-submenu-item-avatar" :class="{ 'is-current': isCurrentTenant(m.tenant_id) }">
+              {{ tenantInitial(m) }}
+            </div>
+            <div class="tenant-submenu-item-info">
+              <span class="tenant-submenu-item-name">{{ tenantDisplayName(m) }}</span>
+              <span class="tenant-submenu-item-role">{{ formatRole(m.role) }}</span>
+            </div>
+            <span
+              v-if="isCurrentTenant(m.tenant_id)"
+              class="tenant-submenu-item-badge"
+            >{{ $t('tenant.switcher.currentBadge') }}</span>
+          </div>
+          <div v-if="switchableMemberships.length === 0" class="tenant-submenu-empty">
+            {{ $t('tenant.switcher.empty') }}
+          </div>
+        </div>
+      </div>
+    </Teleport>
   </div>
 </template>
 
@@ -165,11 +223,15 @@ const authStore = useAuthStore()
 
 const menuRef = ref<HTMLElement>()
 const imMenuItemRef = ref<HTMLElement>()
+const tenantMenuItemRef = ref<HTMLElement>()
 const menuVisible = ref(false)
 const imSubmenuOpen = ref(false)
 const imSubmenuStyle = ref<Record<string, string>>({})
+const tenantSubmenuOpen = ref(false)
+const tenantSubmenuStyle = ref<Record<string, string>>({})
 const hasActiveIMChannels = ref(false)
 let imSubmenuHideTimer: ReturnType<typeof setTimeout> | null = null
+let tenantSubmenuHideTimer: ReturnType<typeof setTimeout> | null = null
 
 // 用户信息
 const userInfo = ref({
@@ -236,7 +298,127 @@ const scheduleHideIMSubmenu = () => {
 
 const closeAll = () => {
   imSubmenuOpen.value = false
+  tenantSubmenuOpen.value = false
   menuVisible.value = false
+}
+
+// ---------- Tenant switcher submenu ----------
+//
+// Same hover-driven submenu pattern as the IM panel above; data comes from
+// authStore.memberships (populated by /auth/login). PR 4 of #1303 relaxed
+// the X-Tenant-ID gate in middleware/auth.go to accept active membership
+// rows, so flipping authStore.selectedTenantId here is enough — the next
+// page reload re-issues every request with the new header and the server
+// resolves the role server-side.
+type Membership = {
+  tenant_id: number
+  tenant_name?: string
+  role: string
+}
+
+// switchableMemberships is the curated list shown in the dropdown. We keep
+// the active tenant in there (with a "Current" badge) so the user has a
+// single place to glance at "where am I right now"; clicking the current
+// row is a no-op (handled in switchToTenant).
+const switchableMemberships = computed<Membership[]>(() => {
+  return authStore.memberships ?? []
+})
+
+// Rendered only when there's something to switch *to*. Multi-tenant members
+// (memberships.length > 1) need it for tenant switching; superusers keep
+// using the sidebar TenantSelector for the "any tenant in the system" case,
+// so we don't double-show the entry there.
+const showTenantSwitcher = computed(() => {
+  return switchableMemberships.value.length > 1
+})
+
+const isCurrentTenant = (id: number) => {
+  const active = authStore.effectiveTenantId
+  return active != null && Number(active) === Number(id)
+}
+
+const tenantDisplayName = (m: Membership) =>
+  m.tenant_name && m.tenant_name.trim() !== '' ? m.tenant_name : `#${m.tenant_id}`
+
+const tenantInitial = (m: Membership) => {
+  const name = tenantDisplayName(m).trim()
+  return (name.charAt(0) || '?').toUpperCase()
+}
+
+const formatRole = (role: string) => {
+  // Roles match the backend enum: viewer/contributor/admin/owner. The
+  // i18n bundle already carries human labels under tenantMember.role.*
+  // (see PR 3); reuse those rather than inventing a new key namespace.
+  const key = `tenantMember.role.${role}`
+  const label = t(key)
+  // Fallback when the locale doesn't have the key: show the raw role.
+  return label === key ? role : label
+}
+
+const switchToTenant = (m: Membership) => {
+  if (isCurrentTenant(m.tenant_id)) {
+    closeAll()
+    return
+  }
+  // Treat switching back to the user's home tenant as "clear the
+  // override" so request.ts stops attaching X-Tenant-ID. This mirrors
+  // what TenantSelector.vue does in selectTenant().
+  const homeTenantId = authStore.tenant?.id ? Number(authStore.tenant.id) : null
+  if (homeTenantId !== null && homeTenantId === m.tenant_id) {
+    authStore.setSelectedTenant(null, null)
+  } else {
+    authStore.setSelectedTenant(m.tenant_id, tenantDisplayName(m))
+  }
+  closeAll()
+  MessagePlugin.success(t('tenant.switchSuccess'))
+  // Hard reload so every cached store / open SSE stream / in-flight
+  // request gets re-keyed under the new tenant. Same approach as
+  // TenantSelector.vue.
+  setTimeout(() => {
+    window.location.reload()
+  }, 400)
+}
+
+const showTenantSubmenu = () => {
+  if (tenantSubmenuHideTimer) {
+    clearTimeout(tenantSubmenuHideTimer)
+    tenantSubmenuHideTimer = null
+  }
+  positionTenantSubmenu()
+  tenantSubmenuOpen.value = true
+}
+
+const scheduleHideTenantSubmenu = () => {
+  if (tenantSubmenuHideTimer) clearTimeout(tenantSubmenuHideTimer)
+  tenantSubmenuHideTimer = setTimeout(() => {
+    tenantSubmenuOpen.value = false
+    tenantSubmenuHideTimer = null
+  }, 180)
+}
+
+const positionTenantSubmenu = () => {
+  const el = tenantMenuItemRef.value
+  if (!el) return
+  const rect = el.getBoundingClientRect()
+  const PANEL_WIDTH = 280
+  const PANEL_MAX_HEIGHT = 360
+  const GAP = 8
+  const MARGIN = 8
+
+  let left = rect.right + GAP
+  if (left + PANEL_WIDTH + MARGIN > window.innerWidth) {
+    left = Math.max(MARGIN, rect.left - PANEL_WIDTH - GAP)
+  }
+
+  let top = rect.top - 4
+  const maxTop = window.innerHeight - Math.min(PANEL_MAX_HEIGHT, window.innerHeight - MARGIN * 2) - MARGIN
+  if (top > maxTop) top = maxTop
+  if (top < MARGIN) top = MARGIN
+
+  tenantSubmenuStyle.value = {
+    left: `${left}px`,
+    top: `${top}px`,
+  }
 }
 
 // Silent prefetch so the "live" indicator on the IM menu item reflects reality
@@ -374,12 +556,16 @@ const loadUserInfo = async () => {
 const handleClickOutside = (e: MouseEvent) => {
   const target = e.target as Node
   if (menuRef.value && menuRef.value.contains(target)) return
-  // The submenu is teleported to body, so it's not inside menuRef — check it
-  // separately to avoid closing the dropdown when the user clicks the submenu.
-  const floating = document.querySelector('.im-submenu-floating')
-  if (floating && floating.contains(target)) return
+  // The IM and tenant submenus are teleported to body, so they're not inside
+  // menuRef — check them separately to avoid closing the dropdown when the
+  // user clicks one of the floating panels.
+  const imFloating = document.querySelector('.im-submenu-floating')
+  if (imFloating && imFloating.contains(target)) return
+  const tenantFloating = document.querySelector('.tenant-submenu-floating')
+  if (tenantFloating && tenantFloating.contains(target)) return
   menuVisible.value = false
   imSubmenuOpen.value = false
+  tenantSubmenuOpen.value = false
 }
 
 onMounted(() => {
@@ -724,6 +910,121 @@ onUnmounted(() => {
   // Invisible padding forms a pointer bridge from the menu item to the
   // panel so hovering across the gap doesn't fire mouseleave-hide.
   padding-left: 2px;
+}
+
+// Tenant switcher submenu — same teleport rationale as .im-submenu-floating.
+// All styling for the panel itself lives here (not in a child component) so
+// the markup in UserMenu.vue stays self-contained.
+.tenant-submenu-floating {
+  position: fixed;
+  z-index: 1100;
+  width: 280px;
+  max-height: 360px;
+  display: flex;
+  flex-direction: column;
+  background: var(--td-bg-color-container);
+  border: 0.5px solid var(--td-component-stroke);
+  border-radius: 10px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.12);
+  // Pointer bridge so the user can slide off the menu item onto the panel
+  // without hitting the gap and triggering mouseleave-hide.
+  padding-left: 2px;
+  overflow: hidden;
+
+  .tenant-submenu-header {
+    padding: 10px 14px 8px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--td-text-color-secondary);
+    border-bottom: 0.5px solid var(--td-component-stroke);
+  }
+
+  .tenant-submenu-list {
+    overflow-y: auto;
+    padding: 6px;
+  }
+
+  .tenant-submenu-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.15s;
+
+    &:hover {
+      background: var(--td-bg-color-secondarycontainer);
+    }
+
+    &.is-current {
+      background: rgba(7, 192, 95, 0.08);
+      cursor: default;
+
+      .tenant-submenu-item-name {
+        color: var(--td-brand-color);
+        font-weight: 500;
+      }
+    }
+  }
+
+  .tenant-submenu-item-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 6px;
+    background: var(--td-bg-color-secondarycontainer);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--td-text-color-secondary);
+    flex-shrink: 0;
+
+    &.is-current {
+      background: linear-gradient(135deg, var(--td-brand-color) 0%, var(--td-brand-color-active) 100%);
+      color: var(--td-text-color-anti);
+    }
+  }
+
+  .tenant-submenu-item-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .tenant-submenu-item-name {
+    font-size: 13px;
+    color: var(--td-text-color-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .tenant-submenu-item-role {
+    font-size: 11px;
+    color: var(--td-text-color-placeholder);
+  }
+
+  .tenant-submenu-item-badge {
+    flex-shrink: 0;
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 1.2;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: var(--td-brand-color-light);
+    color: var(--td-brand-color);
+  }
+
+  .tenant-submenu-empty {
+    padding: 16px 12px;
+    text-align: center;
+    font-size: 12px;
+    color: var(--td-text-color-placeholder);
+  }
 }
 </style>
 

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2268,6 +2268,11 @@ export default {
     title: 'Tenant Information',
     currentTenant: 'Current Tenant',
     switchTenant: 'Switch Tenant',
+    switcher: {
+      menuLabel: 'Switch Tenant',
+      currentBadge: 'Current',
+      empty: 'You only belong to one tenant',
+    },
     sectionDescription: 'View detailed configuration for the tenant',
     apiDocument: 'API Document',
     name: 'Tenant Name',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -1526,6 +1526,11 @@ export default {
     title: "테넌트 정보",
     currentTenant: "현재 테넌트",
     switchTenant: "테넌트 전환",
+    switcher: {
+      menuLabel: "테넌트 전환",
+      currentBadge: "현재",
+      empty: "현재 하나의 테넌트에만 속해 있습니다",
+    },
     sectionDescription: "테넌트의 상세 설정 정보 보기",
     apiDocument: "API 문서",
     name: "테넌트 이름",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -1344,6 +1344,11 @@ export default {
     title: 'Информация об арендаторе',
     currentTenant: 'Текущий арендатор',
     switchTenant: 'Сменить арендатора',
+    switcher: {
+      menuLabel: 'Сменить арендатора',
+      currentBadge: 'Текущий',
+      empty: 'Вы состоите только в одном арендаторе',
+    },
     sectionDescription: 'Просмотр детальной конфигурации арендатора',
     apiDocument: 'Документация API',
     name: 'Имя арендатора',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1507,6 +1507,11 @@ export default {
     title: "租户信息",
     currentTenant: "当前租户",
     switchTenant: "切换租户",
+    switcher: {
+      menuLabel: "切换租户",
+      currentBadge: "当前",
+      empty: "你目前只属于这一个租户",
+    },
     sectionDescription: "查看租户的详细配置信息",
     apiDocument: "API文档",
     name: "租户名称",

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -73,6 +73,25 @@ export const useAuthStore = defineStore('auth', () => {
     return match?.role || ''
   })
 
+  // hasRole answers "is the current tenant role at least <min>?", used by
+  // role-aware UI gating across KB / Agent / settings views. The numeric
+  // ordering (viewer < contributor < admin < owner) mirrors the server-side
+  // matrix in middleware/rbac.go so a v-if here lines up with the 403 the
+  // backend would return.
+  //
+  // SECURITY: shares the same caveat as currentTenantRole — derived from
+  // localStorage, MUST be treated as UI-rendering-only. Never rely on
+  // hasRole() for security decisions; the server is the source of truth.
+  const ROLE_LEVEL: Record<string, number> = {
+    viewer: 10,
+    contributor: 20,
+    admin: 30,
+    owner: 40,
+  }
+  const hasRole = (min: 'viewer' | 'contributor' | 'admin' | 'owner'): boolean => {
+    return (ROLE_LEVEL[currentTenantRole.value] ?? 0) >= ROLE_LEVEL[min]
+  }
+
   const effectiveTenantId = computed(() => {
     // 如果选择了其他租户，使用选择的租户ID，否则使用用户默认租户ID
     return selectedTenantId.value || (tenant.value?.id ? Number(tenant.value.id) : null)
@@ -294,6 +313,7 @@ export const useAuthStore = defineStore('auth', () => {
     currentUserId,
     canAccessAllTenants,
     currentTenantRole,
+    hasRole,
     effectiveTenantId,
     isLiteMode,
 

--- a/frontend/src/views/agent/AgentList.vue
+++ b/frontend/src/views/agent/AgentList.vue
@@ -14,7 +14,7 @@
         <div class="header-title" style="--wails-draggable: drag">
           <div class="title-row" style="--wails-draggable: drag">
             <h2 style="--wails-draggable: drag">{{ $t('agent.title') }}</h2>
-            <t-tooltip :content="$t('agent.createAgent')" placement="bottom">
+            <t-tooltip v-if="authStore.hasRole('contributor')" :content="$t('agent.createAgent')" placement="bottom">
               <t-button
                 variant="text"
                 theme="default"
@@ -412,7 +412,7 @@
       <img class="empty-img" src="@/assets/img/upload.svg" alt="">
       <span class="empty-txt">{{ $t('agent.empty.title') }}</span>
       <span class="empty-desc">{{ $t('agent.empty.description') }}</span>
-      <t-button class="agent-create-btn empty-state-btn" @click="handleCreateAgent">
+      <t-button v-if="authStore.hasRole('contributor')" class="agent-create-btn empty-state-btn" @click="handleCreateAgent">
         <template #icon>
           <span class="btn-icon-wrapper">
             <svg class="sparkles-icon" width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -430,7 +430,7 @@
       <img class="empty-img" src="@/assets/img/upload.svg" alt="">
       <span class="empty-txt">{{ $t('agent.empty.title') }}</span>
       <span class="empty-desc">{{ $t('agent.empty.description') }}</span>
-      <t-button class="agent-create-btn empty-state-btn" @click="handleCreateAgent">
+      <t-button v-if="authStore.hasRole('contributor')" class="agent-create-btn empty-state-btn" @click="handleCreateAgent">
         <template #icon>
           <span class="btn-icon-wrapper">
             <svg class="sparkles-icon" width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/frontend/src/views/knowledge/KnowledgeBaseList.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseList.vue
@@ -13,7 +13,7 @@
         <div class="header-title" style="--wails-draggable: drag">
           <div class="title-row" style="--wails-draggable: drag">
             <h2 style="--wails-draggable: drag">{{ $t('knowledgeBase.title') }}</h2>
-            <t-tooltip :content="$t('knowledgeList.create')" placement="bottom">
+            <t-tooltip v-if="authStore.hasRole('contributor')" :content="$t('knowledgeList.create')" placement="bottom">
               <t-button
                 variant="text"
                 theme="default"
@@ -517,7 +517,7 @@
       <img class="empty-img" src="@/assets/img/upload.svg" alt="">
       <span class="empty-txt">{{ $t('knowledgeList.empty.title') }}</span>
       <span class="empty-desc">{{ $t('knowledgeList.empty.description') }}</span>
-      <t-button class="kb-create-btn empty-state-btn" @click="handleCreateKnowledgeBase">
+      <t-button v-if="authStore.hasRole('contributor')" class="kb-create-btn empty-state-btn" @click="handleCreateKnowledgeBase">
         <template #icon><t-icon name="folder-add" /></template>
         {{ $t('knowledgeList.create') }}
       </t-button>
@@ -528,7 +528,7 @@
       <img class="empty-img" src="@/assets/img/upload.svg" alt="">
       <span class="empty-txt">{{ $t('knowledgeList.empty.title') }}</span>
       <span class="empty-desc">{{ $t('knowledgeList.empty.description') }}</span>
-      <t-button class="kb-create-btn empty-state-btn" @click="handleCreateKnowledgeBase">
+      <t-button v-if="authStore.hasRole('contributor')" class="kb-create-btn empty-state-btn" @click="handleCreateKnowledgeBase">
         <template #icon><t-icon name="folder-add" /></template>
         {{ $t('knowledgeList.create') }}
       </t-button>

--- a/frontend/src/views/settings/ApiInfo.vue
+++ b/frontend/src/views/settings/ApiInfo.vue
@@ -53,6 +53,7 @@
               <t-icon name="file-copy" />
             </t-button>
             <t-button
+              v-if="authStore.hasRole('owner')"
               size="small"
               variant="text"
               theme="danger"
@@ -230,8 +231,10 @@ import { resetTenantApiKey } from '@/api/tenant'
 import { getApiBaseUrl } from '@/utils/api-base'
 import { DialogPlugin, MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '@/stores/auth'
 
 const { t, locale } = useI18n()
+const authStore = useAuthStore()
 
 // Reactive state
 const tenantInfo = ref<TenantInfo | null>(null)

--- a/frontend/src/views/settings/McpSettings.vue
+++ b/frontend/src/views/settings/McpSettings.vue
@@ -17,7 +17,7 @@
           <h3>{{ $t('mcpSettings.configuredServices') }}</h3>
           <p>{{ $t('mcpSettings.manageAndTest') }}</p>
         </div>
-        <t-button size="small" theme="primary" variant="outline" @click="handleAdd">
+        <t-button v-if="authStore.hasRole('admin')" size="small" theme="primary" variant="outline" @click="handleAdd">
           <template #icon><t-icon name="add" /></template>
           {{ $t('mcpSettings.addService') }}
         </t-button>
@@ -25,7 +25,7 @@
 
       <div v-if="services.length === 0" class="empty-state">
         <t-empty :description="$t('mcpSettings.empty')">
-          <t-button theme="primary" variant="outline" size="small" @click="handleAdd">
+          <t-button v-if="authStore.hasRole('admin')" theme="primary" variant="outline" size="small" @click="handleAdd">
             <template #icon><t-icon name="add" /></template>
             {{ $t('mcpSettings.addFirst') }}
           </t-button>
@@ -70,7 +70,7 @@
             <t-switch
               v-model="service.enabled"
               size="medium"
-              :disabled="service.is_builtin"
+              :disabled="service.is_builtin || !authStore.hasRole('admin')"
               @change="() => handleToggleEnabled(service)"
             />
           </template>
@@ -118,8 +118,10 @@ import McpServiceDialog from './components/McpServiceDialog.vue'
 import McpTestResult from './components/McpTestResult.vue'
 import SettingCard from '@/components/settings/SettingCard.vue'
 import { useConfirmDelete } from '@/components/settings/useConfirmDelete'
+import { useAuthStore } from '@/stores/auth'
 
 const { t } = useI18n()
+const authStore = useAuthStore()
 const confirmDelete = useConfirmDelete()
 
 const services = ref<MCPService[]>([])
@@ -246,8 +248,13 @@ const handleDelete = (service: MCPService) => {
   })
 }
 
-// Get service options for dropdown menu
+// Get service options for dropdown menu. MCP service mutations and the
+// /test endpoint (which probes external infra with stored creds) are all
+// Admin+ in the backend matrix, so non-Admins see an empty action menu.
 const getServiceOptions = () => {
+  if (!authStore.hasRole('admin')) {
+    return []
+  }
   return [
     { content: t('mcpSettings.actions.test'), value: 'test' },
     { content: t('common.edit'), value: 'edit' },
@@ -255,8 +262,12 @@ const getServiceOptions = () => {
   ]
 }
 
-// Builtin: 仅测试
+// Builtin: 仅测试 (Admin+ only as well — testing a builtin still hits
+// the same /test endpoint that requires Admin+ role).
 const getBuiltinServiceOptions = () => {
+  if (!authStore.hasRole('admin')) {
+    return []
+  }
   return [
     { content: t('mcpSettings.actions.test'), value: 'test' }
   ]

--- a/frontend/src/views/settings/ModelSettings.vue
+++ b/frontend/src/views/settings/ModelSettings.vue
@@ -7,6 +7,7 @@
           <p class="section-description">{{ $t('modelSettings.description') }}</p>
         </div>
         <t-dropdown
+          v-if="authStore.hasRole('admin')"
           :options="addModelOptions"
           placement="bottom-right"
           @click="(data: any) => openAddDialog(data.value)"
@@ -80,6 +81,7 @@
     <div v-else class="empty-state">
       <t-empty :description="emptyHint">
         <t-dropdown
+          v-if="authStore.hasRole('admin')"
           :options="addModelOptions"
           placement="bottom"
           @click="(data: any) => openAddDialog(data.value)"
@@ -112,8 +114,10 @@ import ModelEditorDialog from '@/components/ModelEditorDialog.vue'
 import SettingCard from '@/components/settings/SettingCard.vue'
 import { useConfirmDelete } from '@/components/settings/useConfirmDelete'
 import { listModels, createModel, updateModel as updateModelAPI, deleteModel as deleteModelAPI, type ModelConfig } from '@/api/model'
+import { useAuthStore } from '@/stores/auth'
 
 const { t } = useI18n()
+const authStore = useAuthStore()
 const confirmDelete = useConfirmDelete()
 
 type ModelType = 'chat' | 'embedding' | 'rerank' | 'vllm' | 'asr'
@@ -346,6 +350,14 @@ const getModelOptions = (type: ModelType, model: any) => {
   const options: any[] = []
 
   if (model.isBuiltin) {
+    return options
+  }
+
+  // Models are tenant-wide infrastructure (LLM credentials); the
+  // backend gates every mutation behind Admin+ (see RegisterModelRoutes).
+  // Non-Admins get an empty action menu — viewing is fine, but editing,
+  // copying (also goes through createModel), and deleting are not.
+  if (!authStore.hasRole('admin')) {
     return options
   }
 

--- a/frontend/src/views/settings/ParserEngineSettings.vue
+++ b/frontend/src/views/settings/ParserEngineSettings.vue
@@ -219,7 +219,7 @@
       <template #footer>
         <div class="drawer-footer-actions">
           <t-button theme="default" variant="outline" @click="drawerVisible = false">{{ $t('common.cancel') }}</t-button>
-          <t-button theme="primary" :loading="saving" @click="onSave">{{ $t('common.save') }}</t-button>
+          <t-button v-if="authStore.hasRole('admin')" theme="primary" :loading="saving" @click="onSave">{{ $t('common.save') }}</t-button>
         </div>
       </template>
     </t-drawer>
@@ -230,6 +230,7 @@
 import { ref, computed, onMounted, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useUIStore } from '@/stores/ui'
+import { useAuthStore } from '@/stores/auth'
 import {
   getParserEngines,
   getParserEngineConfig,
@@ -242,6 +243,7 @@ import { getWeKnoraCloudStatus } from '@/api/model'
 
 const { t } = useI18n()
 const uiStore = useUIStore()
+const authStore = useAuthStore()
 
 const CONFIGURABLE_ENGINES = new Set(['mineru', 'mineru_cloud'])
 

--- a/frontend/src/views/settings/RetrievalSettings.vue
+++ b/frontend/src/views/settings/RetrievalSettings.vue
@@ -19,6 +19,7 @@
           <ModelSelector
             model-type="Rerank"
             :selected-model-id="localConfig.rerank_model_id"
+            :disabled="!canEdit"
             @update:selected-model-id="handleModelChange"
           />
         </div>
@@ -35,6 +36,7 @@
           :min="1"
           :max="100"
           :step="1"
+          :disabled="!canEdit"
           @change="handleParamChange"
         />
       </div>
@@ -50,6 +52,7 @@
           :min="0"
           :max="1"
           :step="0.05"
+          :disabled="!canEdit"
           @change="handleParamChange"
         />
       </div>
@@ -65,6 +68,7 @@
           :min="0"
           :max="1"
           :step="0.05"
+          :disabled="!canEdit"
           @change="handleParamChange"
         />
       </div>
@@ -80,6 +84,7 @@
           :min="1"
           :max="100"
           :step="1"
+          :disabled="!canEdit"
           @change="handleParamChange"
         />
       </div>
@@ -95,6 +100,7 @@
           :min="-10"
           :max="10"
           :step="0.1"
+          :disabled="!canEdit"
           @change="handleParamChange"
         />
       </div>
@@ -103,7 +109,7 @@
 </template>
 
 <script setup lang="ts">
-import { reactive, onMounted, nextTick } from 'vue'
+import { reactive, computed, onMounted, nextTick } from 'vue'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
 import ModelSelector from '@/components/ModelSelector.vue'
@@ -112,8 +118,14 @@ import {
   updateTenantRetrievalConfig,
   type RetrievalConfig,
 } from '@/api/retrieval'
+import { useAuthStore } from '@/stores/auth'
 
 const { t } = useI18n()
+const authStore = useAuthStore()
+// PUT /tenants/kv/retrieval-config requires Admin+ on the server. Hide the
+// banner + lock all controls for non-Admins so they can read the
+// configuration without tripping a 403 mid-edit.
+const canEdit = computed(() => authStore.hasRole('admin'))
 
 const defaultConfig: RetrievalConfig = {
   embedding_top_k: 50,

--- a/frontend/src/views/settings/StorageEngineSettings.vue
+++ b/frontend/src/views/settings/StorageEngineSettings.vue
@@ -465,7 +465,7 @@
       <template #footer>
         <div class="drawer-footer-actions">
           <t-button theme="default" variant="outline" @click="drawerVisible = false">{{ $t('common.cancel') }}</t-button>
-          <t-button theme="primary" :loading="saving" @click="onSave">{{ $t('common.save') }}</t-button>
+          <t-button v-if="authStore.hasRole('admin')" theme="primary" :loading="saving" @click="onSave">{{ $t('common.save') }}</t-button>
         </div>
       </template>
     </t-drawer>
@@ -482,8 +482,10 @@ import {
   updateStorageEngineConfig,
   type StorageEngineConfig,
 } from '@/api/system'
+import { useAuthStore } from '@/stores/auth'
 
 const { t } = useI18n()
+const authStore = useAuthStore()
 
 const defaultConfig = (): StorageEngineConfig => ({
   default_provider: 'local',

--- a/frontend/src/views/settings/VectorStoreSettings.vue
+++ b/frontend/src/views/settings/VectorStoreSettings.vue
@@ -14,7 +14,7 @@
       <div class="settings-group">
         <div class="section-subheader">
           <h3>{{ t('vectorStoreSettings.storesTitle') }}</h3>
-          <t-button theme="primary" variant="outline" size="small" @click="openAddDialog">
+          <t-button v-if="authStore.hasRole('admin')" theme="primary" variant="outline" size="small" @click="openAddDialog">
             <template #icon><add-icon /></template>
             {{ t('vectorStoreSettings.addStore') }}
           </t-button>
@@ -35,6 +35,7 @@
               </div>
               <div class="item-actions">
                 <t-button
+                  v-if="authStore.hasRole('admin')"
                   theme="default" variant="outline" size="small"
                   :loading="testingId === store.id"
                   @click="testExisting(store)"
@@ -64,13 +65,14 @@
               </div>
               <div class="item-actions">
                 <t-button
+                  v-if="authStore.hasRole('admin')"
                   theme="default" variant="outline" size="small"
                   :loading="testingId === store.id"
                   @click="testExisting(store)"
                 >
                   {{ t('vectorStoreSettings.testConnection') }}
                 </t-button>
-                <t-dropdown :options="storeActions" trigger="click" @click="(action: any) => handleAction(action, store)">
+                <t-dropdown v-if="authStore.hasRole('admin')" :options="storeActions" trigger="click" @click="(action: any) => handleAction(action, store)">
                   <t-button theme="default" variant="text" size="small" shape="square">
                     <template #icon><t-icon name="more" /></template>
                   </t-button>
@@ -262,8 +264,10 @@ import {
   type VectorStoreEntity,
   type VectorStoreTypeInfo,
 } from '@/api/vector-store'
+import { useAuthStore } from '@/stores/auth'
 
 const { t } = useI18n()
+const authStore = useAuthStore()
 
 // ===== State =====
 const stores = ref<VectorStoreEntity[]>([])

--- a/frontend/src/views/settings/WebSearchSettings.vue
+++ b/frontend/src/views/settings/WebSearchSettings.vue
@@ -7,7 +7,7 @@
 
     <div class="settings-toolbar">
       <h3>{{ t('webSearchSettings.providersTitle') }}</h3>
-      <t-button theme="primary" variant="outline" size="small" @click="openAddDialog">
+      <t-button v-if="authStore.hasRole('admin')" theme="primary" variant="outline" size="small" @click="openAddDialog">
         <template #icon><add-icon /></template>
         {{ t('webSearchSettings.addProvider') }}
       </t-button>
@@ -46,7 +46,7 @@
     <!-- Empty State -->
     <div v-else class="empty-state">
       <t-empty :description="t('webSearchSettings.noProvidersDesc')">
-        <t-button theme="primary" variant="outline" size="small" @click="openAddDialog">
+        <t-button v-if="authStore.hasRole('admin')" theme="primary" variant="outline" size="small" @click="openAddDialog">
           <template #icon><add-icon /></template>
           {{ t('webSearchSettings.addProvider') }}
         </t-button>
@@ -165,8 +165,10 @@ import {
 import SettingCard from '@/components/settings/SettingCard.vue'
 import SettingDrawer from '@/components/settings/SettingDrawer.vue'
 import { useConfirmDelete } from '@/components/settings/useConfirmDelete'
+import { useAuthStore } from '@/stores/auth'
 
 const { t } = useI18n()
+const authStore = useAuthStore()
 const confirmDelete = useConfirmDelete()
 
 // ===== State =====
@@ -363,6 +365,12 @@ const testExistingConnection = async (entity: WebSearchProviderEntity) => {
 }
 
 const getProviderOptions = (_entity: WebSearchProviderEntity) => {
+  // Web search providers carry external API credentials; the backend
+  // gates every mutation/test behind Admin+ (RegisterWebSearchProviderRoutes).
+  // Hide the action menu entirely for non-Admins so they don't trip 403s.
+  if (!authStore.hasRole('admin')) {
+    return []
+  }
   return [
     { content: t('webSearchSettings.testConnection'), value: 'test' },
     { content: t('common.edit'), value: 'edit' },


### PR DESCRIPTION
## Summary

PR 4 of #1303 relaxed the backend X-Tenant-ID gate to accept active \`tenant_members\` rows, but the frontend never exposed a switcher to ordinary multi-tenant members. The only existing entry, the sidebar \`TenantSelector\`, is gated to \`canAccessAllTenants\` and queries \`/tenants/search\` — both wrong for a Contributor that an Owner just invited to a second tenant.

This PR closes the gap with two changes:

1. **Tenant switcher inside the user-avatar dropdown.** New \"Switch Tenant\" submenu in \`UserMenu.vue\`, hover-triggered with a teleported floating panel (same pattern as the existing IM overview submenu so layout/animation read consistently). Data source is \`authStore.memberships\` — populated by the existing \`/auth/login\` claim, no new API call. Visibility: \`memberships.length > 1\`. Click writes via \`authStore.setSelectedTenant(...)\` and triggers \`window.location.reload()\` so every cached store / open SSE stream / in-flight request is re-keyed under the new tenant.

2. **Role-aware UI gates on high-friction surfaces.** \`authStore\` exposes a new \`hasRole(min: 'viewer'|'contributor'|'admin'|'owner')\` helper whose numeric ordering matches \`middleware/rbac.go\` so \`v-if\` gates line up with the server-side matrix. Applied per the PR 4 audit (full list in the commit message):
   - KB list / Agent list \"Create\" buttons — Contributor+
   - Model / VectorStore / WebSearch / MCP add/edit/delete/test — Admin+ (per-card action dropdowns return \`[]\` for non-Admins so the menu disappears entirely, not just disables)
   - Parser/Storage engine Save buttons + Retrieval inputs — Admin+
   - API key reset — Owner+
   - IM channel toggle/CRUD — Admin+, both in the channel panel and the avatar-menu submenu

The server is the source of truth for every gated action — these changes only hide buttons that would 403, never grant new authority. \`hasRole\` and \`currentTenantRole\` both carry a SECURITY comment noting they read from localStorage and are UI-rendering-only.

Cluster superusers keep using the sidebar \`TenantSelector\` for \"any tenant in the system\"; the avatar entry is the curated \"tenants I'm a member of\" list.

## Test plan

- [x] \`npm run type-check\` (vue-tsc --build) error count unchanged from baseline (90, all pre-existing issues unrelated to this PR)
- [x] Read-through audit of all 18 touched files; confirmed every gated action's backend route is at the matching role bar in \`internal/router/router.go\`
- [ ] Manual end-to-end with \`enable_rbac=true\`:
  - Owner of tenant A invites Bob as Contributor → Bob logs in → avatar dropdown shows two tenants → click A → role=Contributor in top context → KB/Agent \"Create\" still visible, Models settings \"Add\" hidden → switch back to home → role=Owner, full UI restored
  - Login as a user with no membership and no superuser flag, set \`weknora_selected_tenant_id\` manually → next request 403 (server enforcement intact)
- [ ] Spot-check Vue dev tools to confirm \`authStore.hasRole(...)\` returns expected booleans across role transitions

## Notes

- Built on top of \`feat/rbac\`. PR base: \`Tencent/WeKnora:feat/rbac\`.
- Backend middleware refactor for the same #1303 series is in #1328 (independent — those two PRs can land in either order, the wiring already merged into \`feat/rbac\` is enough for this PR to function).
- The \`KnowledgeBase\` per-card edit/delete actions already gate on \`kb.isMine\`, and the Admin-fallback for non-creator Admins is intentionally deferred — it requires restructuring the mine-vs-shared section grouping. Tracked as a follow-up.