### PR TITLE
fix(migration): ensure pg_trgm is created before trigram index in 000041

### DIFF
--- a/migrations/versioned/000041_task_queue_and_wiki_indexes.up.sql
+++ b/migrations/versioned/000041_task_queue_and_wiki_indexes.up.sql
@@ -20,6 +20,17 @@
 
 DO $$ BEGIN RAISE NOTICE '[Migration 000041] Applying task queue + wiki indexes schema'; END $$;
 
+-- Ensure pg_trgm is loaded before creating the trigram GIN index below.
+-- Migration 000002 also creates this extension, but only inside the
+-- conditional embeddings block (app.skip_embedding gate). Environments that
+-- skip 000002's body — or had pg_trgm install silently fail there — would
+-- otherwise blow up on the gin_trgm_ops index further down. Re-issuing
+-- CREATE EXTENSION IF NOT EXISTS here is a no-op when it's already present
+-- and surfaces a clear error early when the extension genuinely isn't
+-- available, instead of failing midway and leaving task_pending_ops /
+-- task_dead_letters uncreated (see issue #1319).
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
 -- ---------------------------------------------------------------------------
 -- 1) task_pending_ops
 --


### PR DESCRIPTION
## Summary

- Migration `000002_embeddings.up.sql` creates the `pg_trgm` extension only inside the conditional embeddings block guarded by `app.skip_embedding`. Deployments that use a non-postgres retrieve driver (Qdrant / Elasticsearch / Milvus / Weaviate) `RETURN` from that block early and never install `pg_trgm`.
- Migration `000041_task_queue_and_wiki_indexes.up.sql` then runs `CREATE INDEX ... USING GIN (lower(title) gin_trgm_ops)`, which aborts the whole migration. Because the app treats migration failures as warnings, startup continues but `task_pending_ops` / `task_dead_letters` are never created — wiki ingest enqueue silently fails and wiki pages are never produced (see #1319).
- Re-issue `CREATE EXTENSION IF NOT EXISTS pg_trgm` at the top of `000041` so the trigram index is guaranteed to find the extension. The statement is idempotent on environments where 000002 already installed it, and surfaces a clear, early error on environments where the extension genuinely cannot be loaded.

Fixes #1319.

## Test plan

- [ ] On a Postgres deployment with a non-pgvector retrieve driver (e.g. Qdrant), drop `pg_trgm`, re-run migrations, confirm 000041 now installs the extension and creates `task_pending_ops`, `task_dead_letters`, and `idx_wiki_pages_title_trgm` successfully.
- [ ] On a deployment that already has `pg_trgm`, re-run migrations and confirm the additional `CREATE EXTENSION IF NOT EXISTS` is a no-op.
- [ ] On an environment where `pg_trgm` is genuinely unavailable (e.g. lacking the shared library), confirm the migration now fails loudly with a clear error pointing at `pg_trgm` instead of silently leaving wiki tables uncreated.

Made with [Cursor](https://cursor.com)