### PR TITLE
feat: modify the skills registration directory

### DIFF
--- a/internal/application/service/session_agent_qa.go
+++ b/internal/application/service/session_agent_qa.go
@@ -325,19 +325,19 @@ func (s *sessionService) configureSkillsFromAgent(
 		logger.Infof(ctx, "Sandbox is disabled: skills are not available")
 		return
 	}
-
+	dir := getPreloadedSkillsDir()
 	switch customAgent.Config.SkillsSelectionMode {
 	case "all":
 		// Enable all preloaded skills
 		agentConfig.SkillsEnabled = true
-		agentConfig.SkillDirs = []string{DefaultPreloadedSkillsDir}
+		agentConfig.SkillDirs = []string{dir}
 		agentConfig.AllowedSkills = nil // Empty means all skills allowed
 		logger.Infof(ctx, "SkillsSelectionMode=all: enabled all preloaded skills")
 	case "selected":
 		// Enable only selected skills
 		if len(customAgent.Config.SelectedSkills) > 0 {
 			agentConfig.SkillsEnabled = true
-			agentConfig.SkillDirs = []string{DefaultPreloadedSkillsDir}
+			agentConfig.SkillDirs = []string{dir}
 			agentConfig.AllowedSkills = customAgent.Config.SelectedSkills
 			logger.Infof(ctx, "SkillsSelectionMode=selected: enabled %d selected skills: %v",
 				len(customAgent.Config.SelectedSkills), customAgent.Config.SelectedSkills)


### PR DESCRIPTION
## Description
When configuring agent skills in `configureSkillsFromAgent`, `SkillDirs` was set to the hardcoded constant `DefaultPreloadedSkillsDir` (`"skills/preloaded"`). That relative path does not match the directory actually used elsewhere when:
- `WEKNORA_SKILLS_DIR` is set (e.g. custom mount in Docker)
- skills are resolved relative to the executable or working directory via `getPreloadedSkillsDir()`
This change reuses `getPreloadedSkillsDir()` so `SkillDirs` points to the same resolved path as the skill service, allowing the agent to discover preloaded skills in Docker and custom deployment layouts.
**Changed file:** `internal/application/service/session_agent_qa.go`  
- `SkillsSelectionMode=all` and `selected`: `agentConfig.SkillDirs` now uses the resolved `dir` from `getPreloadedSkillsDir()` instead of `DefaultPreloadedSkillsDir`.
## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI
## Related Issue
Fixes #
## Testing
1. Start WeKnora with sandbox enabled (`WEKNORA_SANDBOX_MODE` not `disabled`).
2. Create or use a custom agent with `SkillsSelectionMode` set to `all` or `selected` (with at least one skill selected).
3. **Default layout:** verify preloaded skills under `skills/preloaded/` are still loaded in a QA session.
4. **Custom directory:** set `WEKNORA_SKILLS_DIR` to an absolute path containing valid skills (or use Docker bind mount as in `docker-compose.yml`), restart the service, and confirm the agent discovers skills from that path (not only from the relative `skills/preloaded` string).
5. Optional: run `make fmt && make lint && make test` locally.
## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above
## Screenshots / Recordings
N/A — backend configuration change only, no UI impact.