### PR TITLE
fix: extend document processing timeout for large files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -512,3 +512,6 @@ DOCREADER_TRANSPORT=grpc
 # 用于OIDC用于信息中提取用户数据
 # OIDC_USER_INFO_MAPPING_USER_NAME=name
 # OIDC_USER_INFO_MAPPING_EMAIL=email
+
+# Document processing task timeout. Large files may need more than Asynq's default 30m.
+# WEKNORA_DOCUMENT_PROCESS_TIMEOUT=2h

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -42,6 +42,7 @@ knowledge_base:
   chunk_size: 512
   chunk_overlap: 50
   split_markers: ["\n\n", "\n", "。"]
+  document_process_timeout: 2h
   image_processing:
     enable_multimodal: true
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -154,11 +154,12 @@ type ServerConfig struct {
 
 // KnowledgeBaseConfig 知识库配置
 type KnowledgeBaseConfig struct {
-	ChunkSize       int                    `yaml:"chunk_size"       json:"chunk_size"`
-	ChunkOverlap    int                    `yaml:"chunk_overlap"    json:"chunk_overlap"`
-	SplitMarkers    []string               `yaml:"split_markers"    json:"split_markers"`
-	KeepSeparator   bool                   `yaml:"keep_separator"   json:"keep_separator"`
-	ImageProcessing *ImageProcessingConfig `yaml:"image_processing" json:"image_processing"`
+	ChunkSize              int                    `yaml:"chunk_size"       json:"chunk_size"`
+	ChunkOverlap           int                    `yaml:"chunk_overlap"    json:"chunk_overlap"`
+	SplitMarkers           []string               `yaml:"split_markers"    json:"split_markers"`
+	KeepSeparator          bool                   `yaml:"keep_separator"   json:"keep_separator"`
+	ImageProcessing        *ImageProcessingConfig `yaml:"image_processing" json:"image_processing"`
+	DocumentProcessTimeout time.Duration          `yaml:"document_process_timeout" json:"document_process_timeout"`
 }
 
 // ImageProcessingConfig 图像处理配置
@@ -434,6 +435,7 @@ func LoadConfig() (*Config, error) {
 	// Validate configuration values
 	applyOIDCEnvOverrides(&cfg)
 	applyAgentEnvOverrides(&cfg)
+	applyKnowledgeBaseEnvOverrides(&cfg)
 
 	if err := ValidateConfig(&cfg); err != nil {
 		return nil, err
@@ -558,6 +560,20 @@ func applyOIDCEnvOverrides(cfg *Config) {
 	}
 	if cfg.OIDCAuth.DiscoveryURL == "" && cfg.OIDCAuth.IssuerURL != "" {
 		cfg.OIDCAuth.DiscoveryURL = strings.TrimRight(cfg.OIDCAuth.IssuerURL, "/") + "/.well-known/openid-configuration"
+	}
+}
+
+func applyKnowledgeBaseEnvOverrides(cfg *Config) {
+	if cfg.KnowledgeBase == nil {
+		cfg.KnowledgeBase = &KnowledgeBaseConfig{}
+	}
+	if cfg.KnowledgeBase.DocumentProcessTimeout <= 0 {
+		cfg.KnowledgeBase.DocumentProcessTimeout = 2 * time.Hour
+	}
+	if value := strings.TrimSpace(os.Getenv("WEKNORA_DOCUMENT_PROCESS_TIMEOUT")); value != "" {
+		if d, err := time.ParseDuration(value); err == nil {
+			cfg.KnowledgeBase.DocumentProcessTimeout = d
+		}
 	}
 }
 


### PR DESCRIPTION
## 背景

大文件（尤其是 Excel等）在解析后可能生成大量 chunks，后续 embedding/indexing 阶段耗时较长。

目前 `document:process` 任务没有显式设置 timeout，会使用 Asynq 默认的 30 分钟超时。对于大文件场景，任务可能还在 embedding/indexing 阶段就被取消，随后进入重试。

每次重试都会重新进入文档处理的幂等清理流程，按 `knowledge_id` 清理旧 chunks/indexes，可能导致同一个知识下反复清理和重新处理，也可能影响同知识下的其他异步任务产物。

## 修改内容

- 新增 `knowledge_base.document_process_timeout` 配置项。
- 新增环境变量 `WEKNORA_DOCUMENT_PROCESS_TIMEOUT`，用于覆盖配置文件中的文档处理超时时间。
- 为所有 `document:process` 入队路径统一应用配置化 timeout。
- 保持现有 `MaxRetry(3)` 重试行为不变。

## 测试

已执行：

```bash
gofmt -w internal/config/config.go internal/application/service/knowledge_create.go internal/application/service/knowledge_process.go internal/application/service/knowledge_clone_move.go
go test ./internal/config ./internal/application/service/... ./internal/router/...
```
结果：

- internal/config：通过（无测试文件）
- internal/router：通过
- 部分 internal/application/service 测试失败，失败点与本次修改无关，属于本地环境依赖：
vectorstore_test.go 中多个测试尝试连接 http://es:9200，本地未启动 Elasticsearch，报 connection refused / EOF
service/file 中 OSS bucket 相关测试在本地环境失败

手动验证：

使用大 Excel 文件上传测试。
任务运行超过 30 分钟后没有再出现 Asynq 默认超时导致的 context deadline exceeded。
没有在 30 分钟节点触发 retry=1/3 重新处理。


说明
该修改避免文档处理任务继续依赖 Asynq 默认 30 分钟超时。部署时可根据实际 embedding/indexing 性能调整：

WEKNORA_DOCUMENT_PROCESS_TIMEOUT=2h