### PR TITLE
refactor(rbac): KB-access guard at the route layer (#1303)

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -115,6 +115,19 @@ func NewInternalServerError(message string) *AppError {
 	}
 }
 
+// NewServiceUnavailableError creates a service unavailable (503)
+// error. Used for transient failures where the caller can retry.
+func NewServiceUnavailableError(message string) *AppError {
+	if message == "" {
+		message = "服务暂时不可用"
+	}
+	return &AppError{
+		Code:     ErrServiceUnavailable,
+		Message:  message,
+		HTTPCode: http.StatusServiceUnavailable,
+	}
+}
+
 // NewValidationError creates a validation error
 func NewValidationError(message string) *AppError {
 	return &AppError{

--- a/internal/handler/chunk.go
+++ b/internal/handler/chunk.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/Tencent/WeKnora/internal/application/service"
@@ -13,57 +12,28 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// ChunkHandler defines HTTP handlers for chunk operations
+// ChunkHandler defines HTTP handlers for chunk operations.
+//
+// All KB-access checks (own / org-shared / via shared agent) are now
+// performed by the route-level g.KBAccessRead*FromKnowledgeIDParam /
+// g.KBAccessWrite*FromKnowledgeIDParam / g.KBAccess*FromChunkIDParam
+// guards in router.go — the guard rewrites c.Request.Context() to
+// carry the effective tenant ID, so the handler reads tenant from
+// context the way it always did.
+//
+// kgService is retained because the route-level *creator-ownership*
+// lookup KBCreatorLookupFromKnowledgeIDParam still walks
+// knowledge_id -> kb_id to resolve creator_id (separate axis from
+// access — that lookup answers "is the caller the creator of THIS
+// resource", not "does the caller's tenant have access").
 type ChunkHandler struct {
-	service           interfaces.ChunkService
-	kgService         interfaces.KnowledgeService
-	kbShareService    interfaces.KBShareService
-	agentShareService interfaces.AgentShareService
+	service   interfaces.ChunkService
+	kgService interfaces.KnowledgeService
 }
 
-// NewChunkHandler creates a new chunk handler
-func NewChunkHandler(service interfaces.ChunkService, kgService interfaces.KnowledgeService, kbShareService interfaces.KBShareService, agentShareService interfaces.AgentShareService) *ChunkHandler {
-	return &ChunkHandler{service: service, kgService: kgService, kbShareService: kbShareService, agentShareService: agentShareService}
-}
-
-// effectiveCtxForKnowledge resolves knowledge by ID, validates KB access (owner or shared with required role), and returns context with effectiveTenantID for downstream service calls.
-func (h *ChunkHandler) effectiveCtxForKnowledge(c *gin.Context, knowledgeID string, requiredPermission types.OrgMemberRole) (context.Context, error) {
-	ctx := c.Request.Context()
-	tenantID := c.GetUint64(types.TenantIDContextKey.String())
-	if tenantID == 0 {
-		return nil, errors.NewUnauthorizedError("Unauthorized")
-	}
-	userID, userExists := c.Get(types.UserIDContextKey.String())
-	callerTenantRole := types.TenantRoleFromContext(ctx)
-
-	knowledge, err := h.kgService.GetKnowledgeByIDOnly(ctx, knowledgeID)
-	if err != nil {
-		return nil, errors.NewNotFoundError("Knowledge not found")
-	}
-	if knowledge.TenantID == tenantID {
-		return context.WithValue(ctx, types.TenantIDContextKey, tenantID), nil
-	}
-	if !userExists {
-		return nil, errors.NewForbiddenError("Permission denied to access this knowledge")
-	}
-	if h.kbShareService != nil {
-		permission, isShared, permErr := h.kbShareService.CheckTenantKBPermission(ctx, knowledge.KnowledgeBaseID, tenantID, callerTenantRole)
-		if permErr == nil && isShared {
-			if !permission.HasPermission(requiredPermission) {
-				return nil, errors.NewForbiddenError("Insufficient permission for this operation")
-			}
-			return context.WithValue(ctx, types.TenantIDContextKey, knowledge.TenantID), nil
-		}
-	}
-	if requiredPermission == types.OrgRoleViewer && h.agentShareService != nil {
-		kbRef := &types.KnowledgeBase{ID: knowledge.KnowledgeBaseID, TenantID: knowledge.TenantID}
-		can, err := h.agentShareService.TenantCanAccessKBViaSomeSharedAgent(ctx, tenantID, callerTenantRole, kbRef)
-		if err == nil && can {
-			return context.WithValue(ctx, types.TenantIDContextKey, knowledge.TenantID), nil
-		}
-	}
-	_ = userID
-	return nil, errors.NewForbiddenError("Permission denied to access this knowledge")
+// NewChunkHandler creates a new chunk handler.
+func NewChunkHandler(service interfaces.ChunkService, kgService interfaces.KnowledgeService) *ChunkHandler {
+	return &ChunkHandler{service: service, kgService: kgService}
 }
 
 // GetChunkByIDOnly godoc
@@ -90,7 +60,9 @@ func (h *ChunkHandler) GetChunkByIDOnly(c *gin.Context) {
 		return
 	}
 
-	// Get chunk by ID without tenant filter (chunk may belong to shared KB)
+	// Get chunk by ID without tenant filter (chunk may belong to shared
+	// KB; the route-level KB-access guard already verified read
+	// permission against the parent KB before we got here).
 	chunk, err := h.service.GetChunkByIDOnly(ctx, chunkID)
 	if err != nil {
 		if err == service.ErrChunkNotFound {
@@ -100,12 +72,6 @@ func (h *ChunkHandler) GetChunkByIDOnly(c *gin.Context) {
 		}
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(errors.NewInternalServerError(err.Error()))
-		return
-	}
-
-	_, err = h.effectiveCtxForKnowledge(c, chunk.KnowledgeID, types.OrgRoleViewer)
-	if err != nil {
-		c.Error(err)
 		return
 	}
 
@@ -145,12 +111,6 @@ func (h *ChunkHandler) ListKnowledgeChunks(c *gin.Context) {
 		return
 	}
 
-	effCtx, err := h.effectiveCtxForKnowledge(c, knowledgeID, types.OrgRoleViewer)
-	if err != nil {
-		c.Error(err)
-		return
-	}
-
 	// Parse pagination parameters
 	var pagination types.Pagination
 	if err := c.ShouldBindQuery(&pagination); err != nil {
@@ -170,8 +130,9 @@ func (h *ChunkHandler) ListKnowledgeChunks(c *gin.Context) {
 
 	chunkType := []types.ChunkType{types.ChunkTypeText}
 
-	// Use pagination for query (effCtx has effectiveTenantID for shared KB)
-	result, err := h.service.ListPagedChunksByKnowledgeID(effCtx, knowledgeID, &pagination, chunkType)
+	// The route-level guard has rewritten the request's tenant context
+	// to the effective tenant for shared KBs.
+	result, err := h.service.ListPagedChunksByKnowledgeID(ctx, knowledgeID, &pagination, chunkType)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(errors.NewInternalServerError(err.Error()))
@@ -205,46 +166,39 @@ type UpdateChunkRequest struct {
 	ImageInfo  string    `json:"image_info"`
 }
 
-// validateAndGetChunk validates request parameters and retrieves the chunk (supports shared KB via effectiveTenantID).
-// Returns chunk, knowledge ID, context with effectiveTenantID for downstream calls, and error.
-func (h *ChunkHandler) validateAndGetChunk(c *gin.Context) (*types.Chunk, string, context.Context, error) {
+// fetchChunkAndVerifyOwnership fetches a chunk by ID and verifies it
+// belongs to the URL :knowledge_id (defence in depth: the route-level
+// KB-access guard already ensured the caller has write access to the
+// KB; this check stops a same-tenant attacker from passing one
+// knowledge_id while addressing a chunk owned by a different
+// knowledge in the same KB).
+func (h *ChunkHandler) fetchChunkAndVerifyOwnership(c *gin.Context) (*types.Chunk, string, error) {
 	ctx := c.Request.Context()
 
 	knowledgeID := secutils.SanitizeForLog(c.Param("knowledge_id"))
 	if knowledgeID == "" {
 		logger.Error(ctx, "Knowledge ID is empty")
-		return nil, "", nil, errors.NewBadRequestError("Knowledge ID cannot be empty")
+		return nil, "", errors.NewBadRequestError("Knowledge ID cannot be empty")
 	}
-
 	id := secutils.SanitizeForLog(c.Param("id"))
 	if id == "" {
 		logger.Error(ctx, "Chunk ID is empty")
-		return nil, knowledgeID, nil, errors.NewBadRequestError("Chunk ID cannot be empty")
+		return nil, knowledgeID, errors.NewBadRequestError("Chunk ID cannot be empty")
 	}
-
-	effCtx, err := h.effectiveCtxForKnowledge(c, knowledgeID, types.OrgRoleEditor)
-	if err != nil {
-		return nil, knowledgeID, nil, err
-	}
-
-	logger.Infof(ctx, "Retrieving knowledge chunk information, knowledge ID: %s, chunk ID: %s", knowledgeID, id)
-
-	chunk, err := h.service.GetChunkByID(effCtx, id)
+	chunk, err := h.service.GetChunkByID(ctx, id)
 	if err != nil {
 		if err == service.ErrChunkNotFound {
 			logger.Warnf(ctx, "Chunk not found, knowledge ID: %s, chunk ID: %s", knowledgeID, id)
-			return nil, knowledgeID, nil, errors.NewNotFoundError("Chunk not found")
+			return nil, knowledgeID, errors.NewNotFoundError("Chunk not found")
 		}
 		logger.ErrorWithFields(ctx, err, nil)
-		return nil, knowledgeID, nil, errors.NewInternalServerError(err.Error())
+		return nil, knowledgeID, errors.NewInternalServerError(err.Error())
 	}
-
 	if chunk.KnowledgeID != knowledgeID {
 		logger.Warnf(ctx, "Chunk does not belong to knowledge, knowledge ID: %s, chunk ID: %s", knowledgeID, id)
-		return nil, knowledgeID, nil, errors.NewForbiddenError("No permission to access this chunk")
+		return nil, knowledgeID, errors.NewForbiddenError("No permission to access this chunk")
 	}
-
-	return chunk, knowledgeID, effCtx, nil
+	return chunk, knowledgeID, nil
 }
 
 // UpdateChunk godoc
@@ -266,7 +220,7 @@ func (h *ChunkHandler) UpdateChunk(c *gin.Context) {
 	ctx := c.Request.Context()
 	logger.Info(ctx, "Start updating knowledge chunk")
 
-	chunk, knowledgeID, effCtx, err := h.validateAndGetChunk(c)
+	chunk, knowledgeID, err := h.fetchChunkAndVerifyOwnership(c)
 	if err != nil {
 		c.Error(err)
 		return
@@ -284,7 +238,7 @@ func (h *ChunkHandler) UpdateChunk(c *gin.Context) {
 
 	chunk.IsEnabled = req.IsEnabled
 
-	if err := h.service.UpdateChunk(effCtx, chunk); err != nil {
+	if err := h.service.UpdateChunk(ctx, chunk); err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(errors.NewInternalServerError(err.Error()))
 		return
@@ -316,13 +270,13 @@ func (h *ChunkHandler) DeleteChunk(c *gin.Context) {
 	ctx := c.Request.Context()
 	logger.Info(ctx, "Start deleting knowledge chunk")
 
-	chunk, _, effCtx, err := h.validateAndGetChunk(c)
+	chunk, _, err := h.fetchChunkAndVerifyOwnership(c)
 	if err != nil {
 		c.Error(err)
 		return
 	}
 
-	if err := h.service.DeleteChunk(effCtx, chunk.ID); err != nil {
+	if err := h.service.DeleteChunk(ctx, chunk.ID); err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(errors.NewInternalServerError(err.Error()))
 		return
@@ -357,14 +311,7 @@ func (h *ChunkHandler) DeleteChunksByKnowledgeID(c *gin.Context) {
 		return
 	}
 
-	effCtx, err := h.effectiveCtxForKnowledge(c, knowledgeID, types.OrgRoleEditor)
-	if err != nil {
-		c.Error(err)
-		return
-	}
-
-	err = h.service.DeleteChunksByKnowledgeID(effCtx, knowledgeID)
-	if err != nil {
+	if err := h.service.DeleteChunksByKnowledgeID(ctx, knowledgeID); err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(errors.NewInternalServerError(err.Error()))
 		return
@@ -410,25 +357,7 @@ func (h *ChunkHandler) DeleteGeneratedQuestion(c *gin.Context) {
 		return
 	}
 
-	chunk, err := h.service.GetChunkByIDOnly(ctx, chunkID)
-	if err != nil {
-		if err == service.ErrChunkNotFound {
-			logger.Warnf(ctx, "Chunk not found, chunk ID: %s", chunkID)
-			c.Error(errors.NewNotFoundError("Chunk not found"))
-			return
-		}
-		logger.ErrorWithFields(ctx, err, nil)
-		c.Error(errors.NewInternalServerError(err.Error()))
-		return
-	}
-
-	effCtx, err := h.effectiveCtxForKnowledge(c, chunk.KnowledgeID, types.OrgRoleEditor)
-	if err != nil {
-		c.Error(err)
-		return
-	}
-
-	if err := h.service.DeleteGeneratedQuestion(effCtx, chunkID, req.QuestionID); err != nil {
+	if err := h.service.DeleteGeneratedQuestion(ctx, chunkID, req.QuestionID); err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(errors.NewBadRequestError(err.Error()))
 		return

--- a/internal/handler/faq.go
+++ b/internal/handler/faq.go
@@ -1,14 +1,11 @@
 package handler
 
 import (
-	"context"
-	stderrors "errors"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/Tencent/WeKnora/internal/application/repository"
 	"github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
@@ -17,79 +14,47 @@ import (
 )
 
 // FAQHandler handles FAQ knowledge base operations.
+//
+// All KB-access checks (own / org-shared / via shared agent) are now
+// performed by the route-level g.KBAccessRead / g.KBAccessWrite
+// guards in router.go — the guard rewrites c.Request.Context() to
+// carry the effective tenant ID for the duration of the handler, so
+// the handler reads tenant from context the way it always did.
 type FAQHandler struct {
-	knowledgeService  interfaces.KnowledgeService
-	kbService         interfaces.KnowledgeBaseService
-	kbShareService    interfaces.KBShareService
-	agentShareService interfaces.AgentShareService
+	knowledgeService interfaces.KnowledgeService
+	kbService        interfaces.KnowledgeBaseService
 }
 
-// NewFAQHandler creates a new FAQ handler
+// NewFAQHandler creates a new FAQ handler.
 func NewFAQHandler(
 	knowledgeService interfaces.KnowledgeService,
 	kbService interfaces.KnowledgeBaseService,
-	kbShareService interfaces.KBShareService,
-	agentShareService interfaces.AgentShareService,
 ) *FAQHandler {
 	return &FAQHandler{
-		knowledgeService:  knowledgeService,
-		kbService:         kbService,
-		kbShareService:    kbShareService,
-		agentShareService: agentShareService,
+		knowledgeService: knowledgeService,
+		kbService:        kbService,
 	}
 }
 
-// effectiveCtxForKB validates KB access (owner, shared, or via shared agent when requiredPermission is Viewer) and returns context with effectiveTenantID.
-func (h *FAQHandler) effectiveCtxForKB(c *gin.Context, kbID string, requiredPermission types.OrgMemberRole) (context.Context, error) {
-	ctx := c.Request.Context()
-	tenantID := c.GetUint64(types.TenantIDContextKey.String())
-	if tenantID == 0 {
-		return nil, errors.NewUnauthorizedError("Unauthorized")
-	}
-	userID, userExists := c.Get(types.UserIDContextKey.String())
-	callerTenantRole := types.TenantRoleFromContext(ctx)
-	kbID = secutils.SanitizeForLog(kbID)
-	if kbID == "" {
-		return nil, errors.NewBadRequestError("Knowledge base ID cannot be empty")
-	}
-	kb, err := h.kbService.GetKnowledgeBaseByID(ctx, kbID)
-	if err != nil {
-		// ErrKnowledgeBaseNotFound is the expected response for a stale
-		// or probed kb id; the FAQ endpoints went out of their way to
-		// surface internal-server-error for those, which both confused
-		// clients (real 5xx vs. wrong URL) and burned ops attention on
-		// monitoring alerts. Mirror knowledgebase.go's mapping.
-		if stderrors.Is(err, repository.ErrKnowledgeBaseNotFound) {
-			return nil, errors.NewNotFoundError("knowledge base not found")
-		}
-		logger.ErrorWithFields(ctx, err, nil)
-		return nil, errors.NewInternalServerError(err.Error())
-	}
-	if kb.TenantID == tenantID {
-		return context.WithValue(ctx, types.TenantIDContextKey, tenantID), nil
-	}
-	if h.kbShareService != nil {
-		permission, isShared, permErr := h.kbShareService.CheckTenantKBPermission(ctx, kbID, tenantID, callerTenantRole)
-		if permErr == nil && isShared && permission.HasPermission(requiredPermission) {
-			sourceTenantID, srcErr := h.kbShareService.GetKBSourceTenant(ctx, kbID)
-			if srcErr == nil {
-				logger.Infof(ctx, "Tenant %d accessing shared KB %s with permission %s, source tenant: %d",
-					tenantID, kbID, permission, sourceTenantID)
-				return context.WithValue(ctx, types.TenantIDContextKey, sourceTenantID), nil
-			}
-		}
-	}
-	if requiredPermission == types.OrgRoleViewer && h.agentShareService != nil {
-		can, err := h.agentShareService.TenantCanAccessKBViaSomeSharedAgent(ctx, tenantID, callerTenantRole, kb)
-		if err == nil && can {
-			logger.Infof(ctx, "Tenant %d accessing KB %s via some shared agent", tenantID, kbID)
-			return context.WithValue(ctx, types.TenantIDContextKey, kb.TenantID), nil
-		}
-	}
-	_ = userID
-	_ = userExists
-	logger.Warnf(ctx, "Permission denied to access KB %s", kbID)
-	return nil, errors.NewForbiddenError("Permission denied to access this knowledge base")
+// faqDeleteRequest is a request for deleting FAQ entries in batch
+type faqDeleteRequest struct {
+	IDs []int64 `json:"ids" binding:"required,min=1"`
+}
+
+// faqEntryTagBatchRequest is a request for updating tags for FAQ entries in batch
+// key: entry seq_id, value: tag seq_id (nil to remove tag)
+type faqEntryTagBatchRequest struct {
+	Updates map[int64]*int64 `json:"updates" binding:"required,min=1"`
+}
+
+// addSimilarQuestionsRequest is a request for adding similar questions to a FAQ entry
+type addSimilarQuestionsRequest struct {
+	SimilarQuestions []string `json:"similar_questions" binding:"required,min=1"`
+}
+
+// updateLastFAQImportResultDisplayStatusRequest is the request payload for UpdateLastImportResultDisplayStatus
+type updateLastFAQImportResultDisplayStatusRequest struct {
+	DisplayStatus string `json:"display_status" binding:"required,oneof=open close"`
 }
 
 // ListEntries godoc
@@ -113,11 +78,7 @@ func (h *FAQHandler) effectiveCtxForKB(c *gin.Context, kbID string, requiredPerm
 func (h *FAQHandler) ListEntries(c *gin.Context) {
 	ctx := c.Request.Context()
 	kbID := secutils.SanitizeForLog(c.Param("id"))
-	effCtx, err := h.effectiveCtxForKB(c, kbID, types.OrgRoleViewer)
-	if err != nil {
-		c.Error(err)
-		return
-	}
+
 	var page types.Pagination
 	if err := c.ShouldBindQuery(&page); err != nil {
 		logger.Error(ctx, "Failed to bind pagination query", err)
@@ -139,7 +100,7 @@ func (h *FAQHandler) ListEntries(c *gin.Context) {
 	searchField := secutils.SanitizeForLog(c.Query("search_field"))
 	sortOrder := secutils.SanitizeForLog(c.Query("sort_order"))
 
-	result, err := h.knowledgeService.ListFAQEntries(effCtx, kbID, &page, tagSeqID, keyword, searchField, sortOrder)
+	result, err := h.knowledgeService.ListFAQEntries(ctx, kbID, &page, tagSeqID, keyword, searchField, sortOrder)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(err)
@@ -170,11 +131,7 @@ func (h *FAQHandler) ListEntries(c *gin.Context) {
 func (h *FAQHandler) UpsertEntries(c *gin.Context) {
 	ctx := c.Request.Context()
 	kbID := secutils.SanitizeForLog(c.Param("id"))
-	effCtx, err := h.effectiveCtxForKB(c, kbID, types.OrgRoleEditor)
-	if err != nil {
-		c.Error(err)
-		return
-	}
+
 	var req types.FAQBatchUpsertPayload
 	if err := c.ShouldBindJSON(&req); err != nil {
 		logger.Error(ctx, "Failed to bind FAQ upsert payload", err)
@@ -182,8 +139,7 @@ func (h *FAQHandler) UpsertEntries(c *gin.Context) {
 		return
 	}
 
-	// 统一使用 UpsertFAQEntries，通过 DryRun 字段区分模式
-	taskID, err := h.knowledgeService.UpsertFAQEntries(effCtx, kbID, &req)
+	taskID, err := h.knowledgeService.UpsertFAQEntries(ctx, kbID, &req)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(err)
@@ -214,11 +170,7 @@ func (h *FAQHandler) UpsertEntries(c *gin.Context) {
 func (h *FAQHandler) CreateEntry(c *gin.Context) {
 	ctx := c.Request.Context()
 	kbID := secutils.SanitizeForLog(c.Param("id"))
-	effCtx, err := h.effectiveCtxForKB(c, kbID, types.OrgRoleEditor)
-	if err != nil {
-		c.Error(err)
-		return
-	}
+
 	var req types.FAQEntryPayload
 	if err := c.ShouldBindJSON(&req); err != nil {
 		logger.Error(ctx, "Failed to bind FAQ entry payload", err)
@@ -226,7 +178,7 @@ func (h *FAQHandler) CreateEntry(c *gin.Context) {
 		return
 	}
 
-	entry, err := h.knowledgeService.CreateFAQEntry(effCtx, kbID, &req)
+	entry, err := h.knowledgeService.CreateFAQEntry(ctx, kbID, &req)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(err)
@@ -256,11 +208,7 @@ func (h *FAQHandler) CreateEntry(c *gin.Context) {
 func (h *FAQHandler) UpdateEntry(c *gin.Context) {
 	ctx := c.Request.Context()
 	kbID := secutils.SanitizeForLog(c.Param("id"))
-	effCtx, err := h.effectiveCtxForKB(c, kbID, types.OrgRoleEditor)
-	if err != nil {
-		c.Error(err)
-		return
-	}
+
 	var req types.FAQEntryPayload
 	if err := c.ShouldBindJSON(&req); err != nil {
 		logger.Error(ctx, "Failed to bind FAQ entry payload", err)
@@ -274,8 +222,7 @@ func (h *FAQHandler) UpdateEntry(c *gin.Context) {
 		return
 	}
 
-	entry, err := h.knowledgeService.UpdateFAQEntry(effCtx,
-		kbID, entrySeqID, &req)
+	entry, err := h.knowledgeService.UpdateFAQEntry(ctx, kbID, entrySeqID, &req)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(err)
@@ -304,19 +251,14 @@ func (h *FAQHandler) UpdateEntry(c *gin.Context) {
 func (h *FAQHandler) UpdateEntryTagBatch(c *gin.Context) {
 	ctx := c.Request.Context()
 	kbID := secutils.SanitizeForLog(c.Param("id"))
-	effCtx, err := h.effectiveCtxForKB(c, kbID, types.OrgRoleEditor)
-	if err != nil {
-		c.Error(err)
-		return
-	}
+
 	var req faqEntryTagBatchRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		logger.Error(ctx, "Failed to bind FAQ entry tag batch payload", err)
 		c.Error(errors.NewBadRequestError("请求参数不合法").WithDetails(err.Error()))
 		return
 	}
-	if err := h.knowledgeService.UpdateFAQEntryTagBatch(effCtx,
-		kbID, req.Updates); err != nil {
+	if err := h.knowledgeService.UpdateFAQEntryTagBatch(ctx, kbID, req.Updates); err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(err)
 		return
@@ -342,19 +284,14 @@ func (h *FAQHandler) UpdateEntryTagBatch(c *gin.Context) {
 func (h *FAQHandler) UpdateEntryFieldsBatch(c *gin.Context) {
 	ctx := c.Request.Context()
 	kbID := secutils.SanitizeForLog(c.Param("id"))
-	effCtx, err := h.effectiveCtxForKB(c, kbID, types.OrgRoleEditor)
-	if err != nil {
-		c.Error(err)
-		return
-	}
+
 	var req types.FAQEntryFieldsBatchUpdate
 	if err := c.ShouldBindJSON(&req); err != nil {
 		logger.Error(ctx, "Failed to bind FAQ entry fields batch payload", err)
 		c.Error(errors.NewBadRequestError("请求参数不合法").WithDetails(err.Error()))
 		return
 	}
-	if err := h.knowledgeService.UpdateFAQEntryFieldsBatch(effCtx,
-		kbID, &req); err != nil {
+	if err := h.knowledgeService.UpdateFAQEntryFieldsBatch(ctx, kbID, &req); err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(err)
 		return
@@ -362,22 +299,6 @@ func (h *FAQHandler) UpdateEntryFieldsBatch(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 	})
-}
-
-// faqDeleteRequest is a request for deleting FAQ entries in batch
-type faqDeleteRequest struct {
-	IDs []int64 `json:"ids" binding:"required,min=1"`
-}
-
-// faqEntryTagBatchRequest is a request for updating tags for FAQ entries in batch
-// key: entry seq_id, value: tag seq_id (nil to remove tag)
-type faqEntryTagBatchRequest struct {
-	Updates map[int64]*int64 `json:"updates" binding:"required,min=1"`
-}
-
-// addSimilarQuestionsRequest is a request for adding similar questions to a FAQ entry
-type addSimilarQuestionsRequest struct {
-	SimilarQuestions []string `json:"similar_questions" binding:"required,min=1"`
 }
 
 // DeleteEntries godoc
@@ -396,11 +317,7 @@ type addSimilarQuestionsRequest struct {
 func (h *FAQHandler) DeleteEntries(c *gin.Context) {
 	ctx := c.Request.Context()
 	kbID := secutils.SanitizeForLog(c.Param("id"))
-	effCtx, err := h.effectiveCtxForKB(c, kbID, types.OrgRoleEditor)
-	if err != nil {
-		c.Error(err)
-		return
-	}
+
 	var req faqDeleteRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		logger.Errorf(ctx, "Failed to bind FAQ delete payload: %s", secutils.SanitizeForLog(err.Error()))
@@ -408,9 +325,7 @@ func (h *FAQHandler) DeleteEntries(c *gin.Context) {
 		return
 	}
 
-	if err := h.knowledgeService.DeleteFAQEntries(effCtx,
-		kbID,
-		req.IDs); err != nil {
+	if err := h.knowledgeService.DeleteFAQEntries(ctx, kbID, req.IDs); err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(err)
 		return
@@ -437,11 +352,7 @@ func (h *FAQHandler) DeleteEntries(c *gin.Context) {
 func (h *FAQHandler) SearchFAQ(c *gin.Context) {
 	ctx := c.Request.Context()
 	kbID := secutils.SanitizeForLog(c.Param("id"))
-	effCtx, err := h.effectiveCtxForKB(c, kbID, types.OrgRoleViewer)
-	if err != nil {
-		c.Error(err)
-		return
-	}
+
 	var req types.FAQSearchRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		logger.Error(ctx, "Failed to bind FAQ search payload", err)
@@ -455,7 +366,7 @@ func (h *FAQHandler) SearchFAQ(c *gin.Context) {
 	if req.MatchCount > 200 {
 		req.MatchCount = 200
 	}
-	entries, err := h.knowledgeService.SearchFAQEntries(effCtx, kbID, &req)
+	entries, err := h.knowledgeService.SearchFAQEntries(ctx, kbID, &req)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(err)
@@ -483,13 +394,8 @@ func (h *FAQHandler) SearchFAQ(c *gin.Context) {
 func (h *FAQHandler) ExportEntries(c *gin.Context) {
 	ctx := c.Request.Context()
 	kbID := secutils.SanitizeForLog(c.Param("id"))
-	effCtx, err := h.effectiveCtxForKB(c, kbID, types.OrgRoleViewer)
-	if err != nil {
-		c.Error(err)
-		return
-	}
 
-	csvData, err := h.knowledgeService.ExportFAQEntries(effCtx, kbID)
+	csvData, err := h.knowledgeService.ExportFAQEntries(ctx, kbID)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(err)
@@ -521,18 +427,14 @@ func (h *FAQHandler) ExportEntries(c *gin.Context) {
 func (h *FAQHandler) GetEntry(c *gin.Context) {
 	ctx := c.Request.Context()
 	kbID := secutils.SanitizeForLog(c.Param("id"))
-	effCtx, err := h.effectiveCtxForKB(c, kbID, types.OrgRoleViewer)
-	if err != nil {
-		c.Error(err)
-		return
-	}
+
 	entrySeqID, err := strconv.ParseInt(c.Param("entry_id"), 10, 64)
 	if err != nil {
 		c.Error(errors.NewBadRequestError("entry_id 必须是整数"))
 		return
 	}
 
-	entry, err := h.knowledgeService.GetFAQEntry(effCtx, kbID, entrySeqID)
+	entry, err := h.knowledgeService.GetFAQEntry(ctx, kbID, entrySeqID)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(err)
@@ -574,11 +476,6 @@ func (h *FAQHandler) GetImportProgress(c *gin.Context) {
 	})
 }
 
-// updateLastFAQImportResultDisplayStatusRequest is the request payload for UpdateLastImportResultDisplayStatus
-type updateLastFAQImportResultDisplayStatusRequest struct {
-	DisplayStatus string `json:"display_status" binding:"required,oneof=open close"`
-}
-
 // UpdateLastImportResultDisplayStatus godoc
 // @Summary      更新FAQ最后一次导入结果显示状态
 // @Description  更新FAQ知识库导入结果统计卡片的显示或隐藏状态
@@ -596,11 +493,6 @@ type updateLastFAQImportResultDisplayStatusRequest struct {
 func (h *FAQHandler) UpdateLastImportResultDisplayStatus(c *gin.Context) {
 	ctx := c.Request.Context()
 	kbID := secutils.SanitizeForLog(c.Param("id"))
-	effCtx, err := h.effectiveCtxForKB(c, kbID, types.OrgRoleEditor)
-	if err != nil {
-		c.Error(err)
-		return
-	}
 
 	var req updateLastFAQImportResultDisplayStatusRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -609,7 +501,7 @@ func (h *FAQHandler) UpdateLastImportResultDisplayStatus(c *gin.Context) {
 		return
 	}
 
-	if err := h.knowledgeService.UpdateLastFAQImportResultDisplayStatus(effCtx, kbID, req.DisplayStatus); err != nil {
+	if err := h.knowledgeService.UpdateLastFAQImportResultDisplayStatus(ctx, kbID, req.DisplayStatus); err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(err)
 		return
@@ -638,11 +530,6 @@ func (h *FAQHandler) UpdateLastImportResultDisplayStatus(c *gin.Context) {
 func (h *FAQHandler) AddSimilarQuestions(c *gin.Context) {
 	ctx := c.Request.Context()
 	kbID := secutils.SanitizeForLog(c.Param("id"))
-	effCtx, err := h.effectiveCtxForKB(c, kbID, types.OrgRoleEditor)
-	if err != nil {
-		c.Error(err)
-		return
-	}
 
 	entrySeqID, err := strconv.ParseInt(c.Param("entry_id"), 10, 64)
 	if err != nil {
@@ -657,7 +544,7 @@ func (h *FAQHandler) AddSimilarQuestions(c *gin.Context) {
 		return
 	}
 
-	entry, err := h.knowledgeService.AddSimilarQuestions(effCtx, kbID, entrySeqID, req.SimilarQuestions)
+	entry, err := h.knowledgeService.AddSimilarQuestions(ctx, kbID, entrySeqID, req.SimilarQuestions)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(err)

--- a/internal/handler/tag.go
+++ b/internal/handler/tag.go
@@ -2,13 +2,11 @@ package handler
 
 import (
 	"context"
-	stderrors "errors"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/Tencent/WeKnora/internal/application/repository"
 	"github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
@@ -17,13 +15,16 @@ import (
 )
 
 // TagHandler handles knowledge base tag operations.
+//
+// All KB-access checks (own / org-shared / via shared agent) are now
+// performed by the route-level g.KBAccessRead / g.KBAccessWrite
+// guards in router.go — the guard rewrites c.Request.Context() to
+// carry the effective tenant ID, so handlers below just use
+// c.Request.Context() the way they always did.
 type TagHandler struct {
-	tagService        interfaces.KnowledgeTagService
-	tagRepo           interfaces.KnowledgeTagRepository
-	chunkRepo         interfaces.ChunkRepository
-	kbService         interfaces.KnowledgeBaseService
-	kbShareService    interfaces.KBShareService
-	agentShareService interfaces.AgentShareService
+	tagService interfaces.KnowledgeTagService
+	tagRepo    interfaces.KnowledgeTagRepository
+	chunkRepo  interfaces.ChunkRepository
 }
 
 // DeleteTagRequest represents the request body for deleting a tag
@@ -36,71 +37,18 @@ func NewTagHandler(
 	tagService interfaces.KnowledgeTagService,
 	tagRepo interfaces.KnowledgeTagRepository,
 	chunkRepo interfaces.ChunkRepository,
-	kbService interfaces.KnowledgeBaseService,
-	kbShareService interfaces.KBShareService,
-	agentShareService interfaces.AgentShareService,
 ) *TagHandler {
-	return &TagHandler{tagService: tagService, tagRepo: tagRepo, chunkRepo: chunkRepo, kbService: kbService, kbShareService: kbShareService, agentShareService: agentShareService}
-}
-
-// effectiveCtxForKB validates KB access (owner or shared) and returns context with effectiveTenantID for downstream service calls.
-func (h *TagHandler) effectiveCtxForKB(c *gin.Context, kbID string) (context.Context, error) {
-	ctx := c.Request.Context()
-	tenantID := c.GetUint64(types.TenantIDContextKey.String())
-	if tenantID == 0 {
-		return nil, errors.NewUnauthorizedError("Unauthorized")
-	}
-	userID, userExists := c.Get(types.UserIDContextKey.String())
-	callerTenantRole := types.TenantRoleFromContext(ctx)
-	kbID = secutils.SanitizeForLog(kbID)
-	if kbID == "" {
-		return nil, errors.NewBadRequestError("Knowledge base ID cannot be empty")
-	}
-	kb, err := h.kbService.GetKnowledgeBaseByID(ctx, kbID)
-	if err != nil {
-		// Same not-found-vs-real-error split as the other helper sites:
-		// a missing or cross-tenant kb id should render as 404 so clients
-		// can tell "wrong URL" from a real 5xx.
-		if stderrors.Is(err, repository.ErrKnowledgeBaseNotFound) {
-			return nil, errors.NewNotFoundError("knowledge base not found")
-		}
-		logger.ErrorWithFields(ctx, err, nil)
-		return nil, errors.NewInternalServerError(err.Error())
-	}
-	if kb.TenantID == tenantID {
-		return context.WithValue(ctx, types.TenantIDContextKey, tenantID), nil
-	}
-	if h.kbShareService != nil {
-		permission, isShared, permErr := h.kbShareService.CheckTenantKBPermission(ctx, kbID, tenantID, callerTenantRole)
-		if permErr == nil && isShared {
-			sourceTenantID, srcErr := h.kbShareService.GetKBSourceTenant(ctx, kbID)
-			if srcErr == nil {
-				logger.Infof(ctx, "Tenant %d accessing shared KB %s with permission %s, source tenant: %d",
-					tenantID, kbID, permission, sourceTenantID)
-				return context.WithValue(ctx, types.TenantIDContextKey, sourceTenantID), nil
-			}
-		}
-	}
-	if h.agentShareService != nil {
-		can, err := h.agentShareService.TenantCanAccessKBViaSomeSharedAgent(ctx, tenantID, callerTenantRole, kb)
-		if err == nil && can {
-			logger.Infof(ctx, "Tenant %d accessing KB %s via some shared agent", tenantID, kbID)
-			return context.WithValue(ctx, types.TenantIDContextKey, kb.TenantID), nil
-		}
-	}
-	_ = userID
-	_ = userExists
-	logger.Warnf(ctx, "Permission denied to access KB %s", kbID)
-	return nil, errors.NewForbiddenError("Permission denied to access this knowledge base")
+	return &TagHandler{tagService: tagService, tagRepo: tagRepo, chunkRepo: chunkRepo}
 }
 
 // resolveTagID resolves tag_id parameter which can be either UUID or seq_id (integer).
-// Uses tenant from c's context. Use resolveTagIDWithCtx when effectiveTenantID is set (e.g. shared KB).
+// Uses tenant from c's context — which the route-level KB-access guard
+// has already rewritten to the effective tenant for shared KBs.
 func (h *TagHandler) resolveTagID(c *gin.Context) (string, error) {
 	return h.resolveTagIDWithCtx(c, c.Request.Context())
 }
 
-// resolveTagIDWithCtx resolves tag_id using the given context for tenant (e.g. effCtx for shared KB).
+// resolveTagIDWithCtx resolves tag_id using the given context for tenant.
 func (h *TagHandler) resolveTagIDWithCtx(c *gin.Context, ctx context.Context) (string, error) {
 	tagIDParam := secutils.SanitizeForLog(c.Param("tag_id"))
 
@@ -139,12 +87,6 @@ func (h *TagHandler) ListTags(c *gin.Context) {
 	ctx := c.Request.Context()
 	kbID := secutils.SanitizeForLog(c.Param("id"))
 
-	effCtx, err := h.effectiveCtxForKB(c, kbID)
-	if err != nil {
-		c.Error(err)
-		return
-	}
-
 	var page types.Pagination
 	if err := c.ShouldBindQuery(&page); err != nil {
 		logger.Error(ctx, "Failed to bind pagination query", err)
@@ -154,7 +96,7 @@ func (h *TagHandler) ListTags(c *gin.Context) {
 
 	keyword := secutils.SanitizeForLog(c.Query("keyword"))
 
-	tags, err := h.tagService.ListTags(effCtx, kbID, &page, keyword)
+	tags, err := h.tagService.ListTags(ctx, kbID, &page, keyword)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(err)
@@ -190,12 +132,6 @@ func (h *TagHandler) CreateTag(c *gin.Context) {
 	ctx := c.Request.Context()
 	kbID := secutils.SanitizeForLog(c.Param("id"))
 
-	effCtx, err := h.effectiveCtxForKB(c, kbID)
-	if err != nil {
-		c.Error(err)
-		return
-	}
-
 	var req createTagRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		logger.Error(ctx, "Failed to bind create tag payload", err)
@@ -203,7 +139,7 @@ func (h *TagHandler) CreateTag(c *gin.Context) {
 		return
 	}
 
-	tag, err := h.tagService.CreateTag(effCtx, kbID,
+	tag, err := h.tagService.CreateTag(ctx, kbID,
 		secutils.SanitizeForLog(req.Name), secutils.SanitizeForLog(req.Color), req.SortOrder)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
@@ -241,15 +177,8 @@ type updateTagRequest struct {
 // @Router       /knowledge-bases/{id}/tags/{tag_id} [put]
 func (h *TagHandler) UpdateTag(c *gin.Context) {
 	ctx := c.Request.Context()
-	kbID := secutils.SanitizeForLog(c.Param("id"))
 
-	effCtx, err := h.effectiveCtxForKB(c, kbID)
-	if err != nil {
-		c.Error(err)
-		return
-	}
-
-	tagID, err := h.resolveTagIDWithCtx(c, effCtx)
+	tagID, err := h.resolveTagID(c)
 	if err != nil {
 		c.Error(err)
 		return
@@ -262,7 +191,7 @@ func (h *TagHandler) UpdateTag(c *gin.Context) {
 		return
 	}
 
-	tag, err := h.tagService.UpdateTag(effCtx, tagID, req.Name, req.Color, req.SortOrder)
+	tag, err := h.tagService.UpdateTag(ctx, tagID, req.Name, req.Color, req.SortOrder)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"tag_id": tagID,
@@ -295,15 +224,8 @@ func (h *TagHandler) UpdateTag(c *gin.Context) {
 // @Router       /knowledge-bases/{id}/tags/{tag_id} [delete]
 func (h *TagHandler) DeleteTag(c *gin.Context) {
 	ctx := c.Request.Context()
-	kbID := secutils.SanitizeForLog(c.Param("id"))
 
-	effCtx, err := h.effectiveCtxForKB(c, kbID)
-	if err != nil {
-		c.Error(err)
-		return
-	}
-
-	tagID, err := h.resolveTagIDWithCtx(c, effCtx)
+	tagID, err := h.resolveTagID(c)
 	if err != nil {
 		c.Error(err)
 		return
@@ -317,8 +239,8 @@ func (h *TagHandler) DeleteTag(c *gin.Context) {
 
 	var excludeUUIDs []string
 	if len(req.ExcludeIDs) > 0 {
-		tenantID := effCtx.Value(types.TenantIDContextKey).(uint64)
-		chunks, err := h.getChunksBySeqIDs(effCtx, tenantID, req.ExcludeIDs)
+		tenantID := types.MustTenantIDFromContext(ctx)
+		chunks, err := h.getChunksBySeqIDs(ctx, tenantID, req.ExcludeIDs)
 		if err != nil {
 			logger.Warnf(ctx, "Failed to resolve exclude_ids: %v", err)
 		} else {
@@ -329,7 +251,7 @@ func (h *TagHandler) DeleteTag(c *gin.Context) {
 		}
 	}
 
-	if err := h.tagService.DeleteTag(effCtx, tagID, force, contentOnly, excludeUUIDs); err != nil {
+	if err := h.tagService.DeleteTag(ctx, tagID, force, contentOnly, excludeUUIDs); err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"tag_id": tagID,
 		})

--- a/internal/middleware/kb_access.go
+++ b/internal/middleware/kb_access.go
@@ -5,6 +5,7 @@ import (
 	stderrors "errors"
 
 	apprepo "github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/config"
 	apperrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
@@ -33,6 +34,22 @@ import (
 // Plan 3's 3-D cap (tenant Viewer pinned to OrgRoleViewer) is enforced
 // inside CheckTenantKBPermission itself, so the guard here just
 // propagates the result.
+//
+// ⚠️  Tenant id has TWO surfaces on a gin.Context:
+//
+//   - c.Request.Context()         (read via types.TenantIDFromContext)
+//   - c.Keys[TenantIDContextKey]  (read via c.Get / c.GetUint64)
+//
+// The guard rewrites ONLY the request context — c.Keys is intentionally
+// left at the caller's own tenant so handlers that still run their own
+// share resolution (currently knowledge.go / knowledgebase.go, which
+// branch on the ?agent_id query) keep working unchanged. New handlers
+// MUST read tenant from c.Request.Context() (the "effective" tenant
+// for shared KBs); reading from c.Keys after this guard runs gives
+// the caller's own tenant, which is almost always the wrong answer
+// for KB-scoped routes. The FAQ / Tag / Chunk handlers in this PR
+// were converted to the ctx-based read; the migration of knowledge.go
+// / knowledgebase.go is a follow-up.
 
 // KBAccess captures the result of a successful KB access resolution.
 // Stashed on gin.Context under KBAccessContextKey so handlers that
@@ -87,6 +104,10 @@ type ChunkLookup interface {
 // KBIDResolver tells the guard how to find the kb_id for a given
 // request. Built-in resolvers below cover the param shapes we use:
 // :id, :kb_id, :kbId, :knowledge_id (-> parent KB).
+//
+// On error, resolvers MUST return either a 4xx apperror (bad request /
+// not found) or a generic Go error for transient/internal failures;
+// the guard maps the latter to 503.
 type KBIDResolver func(c *gin.Context) (string, error)
 
 // KBIDFromParam returns a resolver that reads a fixed gin param.
@@ -103,6 +124,11 @@ func KBIDFromParam(param string) KBIDResolver {
 // KBIDFromKnowledgeIDParam reads `:knowledge_id` from the URL, looks
 // up the knowledge document, and returns its KB id. Used by the chunk
 // routes that address a chunk via /chunks/:knowledge_id.
+//
+// A genuine "not found" maps to 404; transient errors (DB hiccup,
+// service unavailable) are surfaced as a plain Go error so the guard
+// can return 503 instead of pretending the resource doesn't exist
+// (a 404 here would also short-circuit any retry / monitoring).
 func KBIDFromKnowledgeIDParam(param string, kgService KnowledgeLookup) KBIDResolver {
 	return func(c *gin.Context) (string, error) {
 		v := c.Param(param)
@@ -110,7 +136,13 @@ func KBIDFromKnowledgeIDParam(param string, kgService KnowledgeLookup) KBIDResol
 			return "", apperrors.NewBadRequestError("missing " + param + " in path")
 		}
 		k, err := kgService.GetKnowledgeByIDOnly(c.Request.Context(), v)
-		if err != nil || k == nil {
+		if err != nil {
+			if isResourceNotFound(err) {
+				return "", apperrors.NewNotFoundError("Knowledge not found")
+			}
+			return "", err
+		}
+		if k == nil {
 			return "", apperrors.NewNotFoundError("Knowledge not found")
 		}
 		return k.KnowledgeBaseID, nil
@@ -121,6 +153,8 @@ func KBIDFromKnowledgeIDParam(param string, kgService KnowledgeLookup) KBIDResol
 // Used by /chunks/by-id/:id routes that address a chunk directly. The
 // chunk's KnowledgeBaseID is denormalised on the row, so a single
 // lookup is enough — no need to chain through GetKnowledgeByIDOnly.
+//
+// Not-found / transient split mirrors KBIDFromKnowledgeIDParam.
 func KBIDFromChunkIDParam(param string, chunkService ChunkLookup) KBIDResolver {
 	return func(c *gin.Context) (string, error) {
 		v := c.Param(param)
@@ -128,16 +162,35 @@ func KBIDFromChunkIDParam(param string, chunkService ChunkLookup) KBIDResolver {
 			return "", apperrors.NewBadRequestError("missing " + param + " in path")
 		}
 		ch, err := chunkService.GetChunkByIDOnly(c.Request.Context(), v)
-		if err != nil || ch == nil {
+		if err != nil {
+			if isResourceNotFound(err) {
+				return "", apperrors.NewNotFoundError("Chunk not found")
+			}
+			return "", err
+		}
+		if ch == nil {
 			return "", apperrors.NewNotFoundError("Chunk not found")
 		}
 		if ch.KnowledgeBaseID == "" {
-			// Some old chunks may not carry the denormalised KB id;
-			// this is a should-never-happen branch on a fresh schema.
-			return "", apperrors.NewInternalServerError("chunk missing knowledge_base_id")
+			// Should-never-happen on a fresh schema; on legacy rows the
+			// chunk effectively isn't resolvable to a KB so the client
+			// gets the same 404 they'd get for a missing chunk rather
+			// than a 500 that pollutes alerting.
+			logger.Warnf(c.Request.Context(),
+				"[kb_access] chunk %s has empty knowledge_base_id; treating as not-found", v)
+			return "", apperrors.NewNotFoundError("Chunk not found")
 		}
 		return ch.KnowledgeBaseID, nil
 	}
+}
+
+// isResourceNotFound recognises the various "not found" sentinels we
+// might see from the underlying services. Keeps the resolvers above
+// from forcing every service to standardise on a single error type
+// before this refactor is useful.
+func isResourceNotFound(err error) bool {
+	return stderrors.Is(err, apprepo.ErrKnowledgeBaseNotFound) ||
+		stderrors.Is(err, ErrResourceNotFound)
 }
 
 // RequireKBAccess returns a gin.HandlerFunc that resolves KB access
@@ -148,24 +201,32 @@ func KBIDFromChunkIDParam(param string, chunkService ChunkLookup) KBIDResolver {
 // context as before.
 //
 // On failure the guard aborts with the appropriate HTTP status (400 /
-// 401 / 404 / 403 / 500). Behaviour matches what each handler's
+// 401 / 404 / 403 / 503). Behaviour matches what each handler's
 // effectiveCtxForKB helper used to do; the guard is what consolidates
 // the repetition so a fix in the resolution order propagates to every
 // gated route at once.
 //
 // Required permission semantics:
 //   - OrgRoleViewer -> read-only routes (the agent-share fallback path
-//                       activates only at this level)
+//     activates only at this level)
 //   - OrgRoleEditor -> mutating routes (org-shared editor or own KB)
 //   - OrgRoleAdmin  -> share-management routes (only the original
-//                       sharer / KB owner / Org admin should pass)
+//     sharer / KB owner / Org admin should pass)
+//
+// When cfg.Tenant.EnableRBAC is false the guard mirrors the sibling
+// role/ownership guards: it logs the would-be rejection and lets the
+// request through. The point is to keep the rollout window safe — the
+// guard runs full enforcement once the flag flips on, with no code
+// changes elsewhere.
 func RequireKBAccess(
 	resolveKBID KBIDResolver,
 	requiredPermission types.OrgMemberRole,
 	kbService KBLookup,
 	kbShareService interfaces.KBShareService,
 	agentShareService interfaces.AgentShareService,
+	cfg *config.Config,
 ) gin.HandlerFunc {
+	warnOnNilConfig(cfg)
 	return func(c *gin.Context) {
 		kbID, err := resolveKBID(c)
 		if err != nil {
@@ -175,23 +236,47 @@ func RequireKBAccess(
 		}
 
 		ctx := c.Request.Context()
-		access, err := resolveKBAccessOnce(ctx, kbID, requiredPermission, kbService, kbShareService, agentShareService)
+
+		// Rollout window: enforcement off -> log the would-be check and
+		// pass through. We still resolve the KB (best-effort) so the
+		// effective-tenant context rewrite still happens for shared
+		// KBs; that way embedding queries hit the right tenant
+		// regardless of whether RBAC enforcement is active.
+		enforcing := rbacEnforcementEnabled(cfg)
+
+		access, err := resolveKBAccessOnce(ctx, c, kbID, requiredPermission, kbService, kbShareService, agentShareService)
 		switch {
 		case stderrors.Is(err, errKBAccessUnauthorized):
+			if !enforcing {
+				logger.Warnf(ctx, "[rbac] kb-access would 401 (enforcement off): kb=%s", kbID)
+				c.Next()
+				return
+			}
 			_ = c.Error(apperrors.NewUnauthorizedError("Unauthorized"))
 			c.Abort()
 			return
 		case stderrors.Is(err, errKBAccessNotFound):
+			// 404 still fires when enforcement is off — a missing KB is
+			// not an authorisation event, the client genuinely asked
+			// for nothing.
 			_ = c.Error(apperrors.NewNotFoundError("knowledge base not found"))
 			c.Abort()
 			return
 		case stderrors.Is(err, errKBAccessForbidden):
+			if !enforcing {
+				logger.Warnf(ctx, "[rbac] kb-access would 403 (enforcement off): kb=%s required=%s",
+					kbID, requiredPermission)
+				c.Next()
+				return
+			}
 			_ = c.Error(apperrors.NewForbiddenError("Permission denied to access this knowledge base"))
 			c.Abort()
 			return
 		case err != nil:
 			logger.ErrorWithFields(ctx, err, nil)
-			_ = c.Error(apperrors.NewInternalServerError(err.Error()))
+			// Transient/internal -> 503 so monitoring catches the
+			// underlying failure rather than a misleading 500.
+			_ = c.Error(apperrors.NewServiceUnavailableError("cannot verify KB access right now"))
 			c.Abort()
 			return
 		}
@@ -210,8 +295,17 @@ func RequireKBAccess(
 // resolveKBAccessOnce performs the actual three-step resolution. Kept
 // unexported and using package-private sentinel errors so the guard's
 // error mapping is the only public surface.
+//
+// The shared-agent step honours the ?agent_id query parameter when
+// present, mirroring the in-handler resolution in
+// knowledgebase.go's validateAndGetKnowledgeBase: a request with a
+// specific agent_id is validated against THAT agent's KB scope (mode =
+// all / selected / none), not against "any shared agent". Falling
+// back to "any shared agent" when agent_id is empty preserves the
+// "通过智能体可见" KB list entry point.
 func resolveKBAccessOnce(
 	ctx context.Context,
+	c *gin.Context,
 	kbID string,
 	requiredPermission types.OrgMemberRole,
 	kbService KBLookup,
@@ -265,19 +359,80 @@ func resolveKBAccessOnce(
 
 	// 3. Shared agent that carries this KB — only ever grants read.
 	if requiredPermission == types.OrgRoleViewer && agentShareService != nil {
-		can, err := agentShareService.TenantCanAccessKBViaSomeSharedAgent(ctx, tenantID, callerTenantRole, kb)
-		if err == nil && can {
-			logger.Infof(ctx, "[kb_access] tenant %d -> KB %s via shared agent", tenantID, kbID)
-			return &KBAccess{
-				KnowledgeBase:     kb,
-				EffectiveTenantID: kb.TenantID,
-				Permission:        types.OrgRoleViewer,
-			}, nil
+		if access := resolveSharedAgentAccess(ctx, c, tenantID, callerTenantRole, kb, agentShareService); access != nil {
+			return access, nil
 		}
 	}
 
 	logger.Warnf(ctx, "[kb_access] tenant %d -> KB %s denied (required=%s)", tenantID, kbID, requiredPermission)
 	return nil, errKBAccessForbidden
+}
+
+// resolveSharedAgentAccess implements the agent-share fallback,
+// mirroring knowledgebase.go's in-handler logic so the guard and the
+// (still-present) handler resolver agree on which requests pass.
+//
+//   - If ?agent_id=X is provided, validate against THAT agent's
+//     KBSelectionMode (all / selected / none). A mismatch means deny;
+//     we do NOT fall back to "any shared agent" because the client
+//     explicitly named one (typically from a @-mention or a deep link
+//     scoped to that agent).
+//   - If ?agent_id is empty, allow when any shared agent reachable by
+//     the caller can access this KB ("通过智能体可见" KB list entry).
+func resolveSharedAgentAccess(
+	ctx context.Context,
+	c *gin.Context,
+	tenantID uint64,
+	callerTenantRole types.TenantRole,
+	kb *types.KnowledgeBase,
+	agentShareService interfaces.AgentShareService,
+) *KBAccess {
+	agentID := c.Query("agent_id")
+	if agentID != "" {
+		agent, err := agentShareService.GetSharedAgentForTenant(ctx, tenantID, callerTenantRole, agentID)
+		if err != nil || agent == nil {
+			return nil
+		}
+		if kb.TenantID != agent.TenantID {
+			logger.Warnf(ctx, "[kb_access] shared agent tenant mismatch: kb=%s kb.tenant=%d agent.tenant=%d",
+				kb.ID, kb.TenantID, agent.TenantID)
+			return nil
+		}
+		switch agent.Config.KBSelectionMode {
+		case "all":
+			logger.Infof(ctx, "[kb_access] tenant %d -> KB %s via shared agent %s (mode=all)",
+				tenantID, kb.ID, agentID)
+			return &KBAccess{
+				KnowledgeBase:     kb,
+				EffectiveTenantID: kb.TenantID,
+				Permission:        types.OrgRoleViewer,
+			}
+		case "selected":
+			for _, allowedID := range agent.Config.KnowledgeBases {
+				if allowedID == kb.ID {
+					logger.Infof(ctx, "[kb_access] tenant %d -> KB %s via shared agent %s (mode=selected)",
+						tenantID, kb.ID, agentID)
+					return &KBAccess{
+						KnowledgeBase:     kb,
+						EffectiveTenantID: kb.TenantID,
+						Permission:        types.OrgRoleViewer,
+					}
+				}
+			}
+		}
+		return nil
+	}
+
+	can, err := agentShareService.TenantCanAccessKBViaSomeSharedAgent(ctx, tenantID, callerTenantRole, kb)
+	if err == nil && can {
+		logger.Infof(ctx, "[kb_access] tenant %d -> KB %s via some shared agent", tenantID, kb.ID)
+		return &KBAccess{
+			KnowledgeBase:     kb,
+			EffectiveTenantID: kb.TenantID,
+			Permission:        types.OrgRoleViewer,
+		}
+	}
+	return nil
 }
 
 var (

--- a/internal/middleware/kb_access.go
+++ b/internal/middleware/kb_access.go
@@ -77,6 +77,13 @@ type KnowledgeLookup interface {
 	GetKnowledgeByIDOnly(ctx context.Context, id string) (*types.Knowledge, error)
 }
 
+// ChunkLookup mirrors KBLookup for resolving a chunk id back to its
+// owning knowledge document, which then resolves to the parent KB.
+// Used by the /chunks/by-id/:id routes that address chunks directly.
+type ChunkLookup interface {
+	GetChunkByIDOnly(ctx context.Context, id string) (*types.Chunk, error)
+}
+
 // KBIDResolver tells the guard how to find the kb_id for a given
 // request. Built-in resolvers below cover the param shapes we use:
 // :id, :kb_id, :kbId, :knowledge_id (-> parent KB).
@@ -107,6 +114,29 @@ func KBIDFromKnowledgeIDParam(param string, kgService KnowledgeLookup) KBIDResol
 			return "", apperrors.NewNotFoundError("Knowledge not found")
 		}
 		return k.KnowledgeBaseID, nil
+	}
+}
+
+// KBIDFromChunkIDParam walks chunk_id -> knowledge_id -> kb_id.
+// Used by /chunks/by-id/:id routes that address a chunk directly. The
+// chunk's KnowledgeBaseID is denormalised on the row, so a single
+// lookup is enough — no need to chain through GetKnowledgeByIDOnly.
+func KBIDFromChunkIDParam(param string, chunkService ChunkLookup) KBIDResolver {
+	return func(c *gin.Context) (string, error) {
+		v := c.Param(param)
+		if v == "" {
+			return "", apperrors.NewBadRequestError("missing " + param + " in path")
+		}
+		ch, err := chunkService.GetChunkByIDOnly(c.Request.Context(), v)
+		if err != nil || ch == nil {
+			return "", apperrors.NewNotFoundError("Chunk not found")
+		}
+		if ch.KnowledgeBaseID == "" {
+			// Some old chunks may not carry the denormalised KB id;
+			// this is a should-never-happen branch on a fresh schema.
+			return "", apperrors.NewInternalServerError("chunk missing knowledge_base_id")
+		}
+		return ch.KnowledgeBaseID, nil
 	}
 }
 

--- a/internal/middleware/kb_access.go
+++ b/internal/middleware/kb_access.go
@@ -1,0 +1,257 @@
+package middleware
+
+import (
+	"context"
+	stderrors "errors"
+
+	apprepo "github.com/Tencent/WeKnora/internal/application/repository"
+	apperrors "github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/gin-gonic/gin"
+)
+
+// kb_access.go centralises the share-fallback that previously lived as
+// near-identical 30-line helpers in five handler files (chunk.go,
+// faq.go, tag.go, knowledge.go, knowledgebase.go). Each was a copy of
+// the same three checks:
+//
+//   1. KB belongs to caller's tenant   -> grant own access
+//   2. Org-shared KB                    -> grant min(share, role) cap
+//   3. Shared agent carries the KB      -> grant Viewer (read-only)
+//
+// Putting the resolution in a route-level gin.HandlerFunc makes the
+// route declaration the single source of truth for "what permission
+// is required" and "where does the kb_id come from". Handlers no
+// longer carry an effectiveCtxForKB / validateAndGetKnowledgeBase
+// helper — the guard runs first, stashes the resolution under
+// KBAccessContextKey and rewrites c.Request to carry the
+// effective-tenant-ID context, then handlers just read TenantIDFromContext
+// the way they always did.
+//
+// Plan 3's 3-D cap (tenant Viewer pinned to OrgRoleViewer) is enforced
+// inside CheckTenantKBPermission itself, so the guard here just
+// propagates the result.
+
+// KBAccess captures the result of a successful KB access resolution.
+// Stashed on gin.Context under KBAccessContextKey so handlers that
+// need the resolved KB / permission (e.g. to render
+// my_permission in the response) can pull it without re-running the
+// resolution.
+type KBAccess struct {
+	KnowledgeBase     *types.KnowledgeBase
+	EffectiveTenantID uint64
+	Permission        types.OrgMemberRole
+}
+
+// KBAccessContextKey is the gin.Context key under which a successful
+// KB access resolution is stored.
+const KBAccessContextKey = "rbac.kb_access"
+
+// KBAccessFromContext returns the KBAccess stashed by the guard, if
+// any. Handlers that don't care can just rely on the rewritten
+// c.Request.Context() for tenant scoping.
+func KBAccessFromContext(c *gin.Context) (*KBAccess, bool) {
+	v, ok := c.Get(KBAccessContextKey)
+	if !ok {
+		return nil, false
+	}
+	a, ok := v.(*KBAccess)
+	return a, ok
+}
+
+// KBLookup is the minimum surface ResolveKBAccess needs from the
+// knowledge-base service: a single method that turns an ID into a
+// KnowledgeBase pointer (or repo.ErrKnowledgeBaseNotFound). Defining
+// it as a tiny dedicated interface keeps the guard testable without
+// forcing test stubs to satisfy the full KnowledgeBaseService surface.
+type KBLookup interface {
+	GetKnowledgeBaseByID(ctx context.Context, id string) (*types.KnowledgeBase, error)
+}
+
+// KnowledgeLookup mirrors KBLookup but for resolving a knowledge id
+// (document id) back to its parent KB. Used by the chunk routes whose
+// URL param is a knowledge_id, not a kb_id.
+type KnowledgeLookup interface {
+	GetKnowledgeByIDOnly(ctx context.Context, id string) (*types.Knowledge, error)
+}
+
+// KBIDResolver tells the guard how to find the kb_id for a given
+// request. Built-in resolvers below cover the param shapes we use:
+// :id, :kb_id, :kbId, :knowledge_id (-> parent KB).
+type KBIDResolver func(c *gin.Context) (string, error)
+
+// KBIDFromParam returns a resolver that reads a fixed gin param.
+func KBIDFromParam(param string) KBIDResolver {
+	return func(c *gin.Context) (string, error) {
+		v := c.Param(param)
+		if v == "" {
+			return "", apperrors.NewBadRequestError("missing " + param + " in path")
+		}
+		return v, nil
+	}
+}
+
+// KBIDFromKnowledgeIDParam reads `:knowledge_id` from the URL, looks
+// up the knowledge document, and returns its KB id. Used by the chunk
+// routes that address a chunk via /chunks/:knowledge_id.
+func KBIDFromKnowledgeIDParam(param string, kgService KnowledgeLookup) KBIDResolver {
+	return func(c *gin.Context) (string, error) {
+		v := c.Param(param)
+		if v == "" {
+			return "", apperrors.NewBadRequestError("missing " + param + " in path")
+		}
+		k, err := kgService.GetKnowledgeByIDOnly(c.Request.Context(), v)
+		if err != nil || k == nil {
+			return "", apperrors.NewNotFoundError("Knowledge not found")
+		}
+		return k.KnowledgeBaseID, nil
+	}
+}
+
+// RequireKBAccess returns a gin.HandlerFunc that resolves KB access
+// (own / org-shared / via shared agent), enforces the minimum required
+// org-level permission, and on success stores the result under
+// KBAccessContextKey AND rewrites c.Request.Context() to carry the
+// effective tenant ID. Handlers downstream just read tenant from
+// context as before.
+//
+// On failure the guard aborts with the appropriate HTTP status (400 /
+// 401 / 404 / 403 / 500). Behaviour matches what each handler's
+// effectiveCtxForKB helper used to do; the guard is what consolidates
+// the repetition so a fix in the resolution order propagates to every
+// gated route at once.
+//
+// Required permission semantics:
+//   - OrgRoleViewer -> read-only routes (the agent-share fallback path
+//                       activates only at this level)
+//   - OrgRoleEditor -> mutating routes (org-shared editor or own KB)
+//   - OrgRoleAdmin  -> share-management routes (only the original
+//                       sharer / KB owner / Org admin should pass)
+func RequireKBAccess(
+	resolveKBID KBIDResolver,
+	requiredPermission types.OrgMemberRole,
+	kbService KBLookup,
+	kbShareService interfaces.KBShareService,
+	agentShareService interfaces.AgentShareService,
+) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		kbID, err := resolveKBID(c)
+		if err != nil {
+			_ = c.Error(err)
+			c.Abort()
+			return
+		}
+
+		ctx := c.Request.Context()
+		access, err := resolveKBAccessOnce(ctx, kbID, requiredPermission, kbService, kbShareService, agentShareService)
+		switch {
+		case stderrors.Is(err, errKBAccessUnauthorized):
+			_ = c.Error(apperrors.NewUnauthorizedError("Unauthorized"))
+			c.Abort()
+			return
+		case stderrors.Is(err, errKBAccessNotFound):
+			_ = c.Error(apperrors.NewNotFoundError("knowledge base not found"))
+			c.Abort()
+			return
+		case stderrors.Is(err, errKBAccessForbidden):
+			_ = c.Error(apperrors.NewForbiddenError("Permission denied to access this knowledge base"))
+			c.Abort()
+			return
+		case err != nil:
+			logger.ErrorWithFields(ctx, err, nil)
+			_ = c.Error(apperrors.NewInternalServerError(err.Error()))
+			c.Abort()
+			return
+		}
+
+		// Stash the resolution and rewrite the request to carry the
+		// effective tenant id. Handlers reading tenant from context now
+		// see the source-tenant for shared KBs (so retrieval queries
+		// hit the right embedding store) without having to know.
+		c.Set(KBAccessContextKey, access)
+		newCtx := context.WithValue(ctx, types.TenantIDContextKey, access.EffectiveTenantID)
+		c.Request = c.Request.WithContext(newCtx)
+		c.Next()
+	}
+}
+
+// resolveKBAccessOnce performs the actual three-step resolution. Kept
+// unexported and using package-private sentinel errors so the guard's
+// error mapping is the only public surface.
+func resolveKBAccessOnce(
+	ctx context.Context,
+	kbID string,
+	requiredPermission types.OrgMemberRole,
+	kbService KBLookup,
+	kbShareService interfaces.KBShareService,
+	agentShareService interfaces.AgentShareService,
+) (*KBAccess, error) {
+	tenantID, ok := types.TenantIDFromContext(ctx)
+	if !ok || tenantID == 0 {
+		return nil, errKBAccessUnauthorized
+	}
+	callerTenantRole := types.TenantRoleFromContext(ctx)
+
+	kb, err := kbService.GetKnowledgeBaseByID(ctx, kbID)
+	if err != nil {
+		if stderrors.Is(err, apprepo.ErrKnowledgeBaseNotFound) {
+			return nil, errKBAccessNotFound
+		}
+		return nil, err
+	}
+	if kb == nil {
+		return nil, errKBAccessNotFound
+	}
+
+	// 1. Own KB.
+	if kb.TenantID == tenantID {
+		return &KBAccess{
+			KnowledgeBase:     kb,
+			EffectiveTenantID: tenantID,
+			Permission:        types.OrgRoleAdmin,
+		}, nil
+	}
+
+	// 2. Org-shared KB. Plan 3's 3-D cap is applied inside
+	//    CheckTenantKBPermission; we just check the result satisfies
+	//    the minimum requirement.
+	if kbShareService != nil {
+		permission, isShared, permErr := kbShareService.CheckTenantKBPermission(ctx, kbID, tenantID, callerTenantRole)
+		if permErr == nil && isShared && permission.HasPermission(requiredPermission) {
+			source, srcErr := kbShareService.GetKBSourceTenant(ctx, kbID)
+			if srcErr == nil {
+				logger.Infof(ctx, "[kb_access] tenant %d -> shared KB %s perm=%s source=%d",
+					tenantID, kbID, permission, source)
+				return &KBAccess{
+					KnowledgeBase:     kb,
+					EffectiveTenantID: source,
+					Permission:        permission,
+				}, nil
+			}
+		}
+	}
+
+	// 3. Shared agent that carries this KB — only ever grants read.
+	if requiredPermission == types.OrgRoleViewer && agentShareService != nil {
+		can, err := agentShareService.TenantCanAccessKBViaSomeSharedAgent(ctx, tenantID, callerTenantRole, kb)
+		if err == nil && can {
+			logger.Infof(ctx, "[kb_access] tenant %d -> KB %s via shared agent", tenantID, kbID)
+			return &KBAccess{
+				KnowledgeBase:     kb,
+				EffectiveTenantID: kb.TenantID,
+				Permission:        types.OrgRoleViewer,
+			}, nil
+		}
+	}
+
+	logger.Warnf(ctx, "[kb_access] tenant %d -> KB %s denied (required=%s)", tenantID, kbID, requiredPermission)
+	return nil, errKBAccessForbidden
+}
+
+var (
+	errKBAccessUnauthorized = stderrors.New("kb_access: unauthorized")
+	errKBAccessNotFound     = stderrors.New("kb_access: not found")
+	errKBAccessForbidden    = stderrors.New("kb_access: forbidden")
+)

--- a/internal/middleware/kb_access_test.go
+++ b/internal/middleware/kb_access_test.go
@@ -1,0 +1,188 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	apprepo "github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// stubKBLookup is a tiny KBLookup stand-in for tests; satisfies the
+// KBLookup interface (a single method) without dragging in the full
+// KnowledgeBaseService surface.
+type stubKBLookup struct {
+	kbs    map[string]*types.KnowledgeBase
+	getErr error
+}
+
+func (s *stubKBLookup) GetKnowledgeBaseByID(_ context.Context, id string) (*types.KnowledgeBase, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	if kb, ok := s.kbs[id]; ok {
+		return kb, nil
+	}
+	return nil, apprepo.ErrKnowledgeBaseNotFound
+}
+
+// stubKBShareForGuard implements just the methods the guard touches —
+// CheckTenantKBPermission and GetKBSourceTenant. The other methods on
+// the interface panic so any unintended new dependency surfaces
+// immediately.
+type stubKBShareForGuard struct {
+	permission map[string]types.OrgMemberRole
+	shared     map[string]bool
+	source     map[string]uint64
+}
+
+func (s *stubKBShareForGuard) CheckTenantKBPermission(_ context.Context, kbID string, _ uint64, _ types.TenantRole) (types.OrgMemberRole, bool, error) {
+	if s.shared[kbID] {
+		return s.permission[kbID], true, nil
+	}
+	return "", false, nil
+}
+
+func (s *stubKBShareForGuard) GetKBSourceTenant(_ context.Context, kbID string) (uint64, error) {
+	if v, ok := s.source[kbID]; ok {
+		return v, nil
+	}
+	return 0, errors.New("not found")
+}
+
+func (s *stubKBShareForGuard) ShareKnowledgeBase(context.Context, string, string, string, uint64, types.OrgMemberRole) (*types.KnowledgeBaseShare, error) {
+	panic("not implemented")
+}
+func (s *stubKBShareForGuard) UpdateSharePermission(context.Context, string, types.OrgMemberRole, string, uint64) error {
+	panic("not implemented")
+}
+func (s *stubKBShareForGuard) RemoveShare(context.Context, string, string, uint64) error {
+	panic("not implemented")
+}
+func (s *stubKBShareForGuard) ListSharesByKnowledgeBase(context.Context, string, uint64) ([]*types.KnowledgeBaseShare, error) {
+	panic("not implemented")
+}
+func (s *stubKBShareForGuard) ListSharesByOrganization(context.Context, string) ([]*types.KnowledgeBaseShare, error) {
+	panic("not implemented")
+}
+func (s *stubKBShareForGuard) ListSharedKnowledgeBases(context.Context, uint64, types.TenantRole) ([]*types.SharedKnowledgeBaseInfo, error) {
+	panic("not implemented")
+}
+func (s *stubKBShareForGuard) ListSharedKnowledgeBasesInOrganization(context.Context, string, uint64, types.TenantRole) ([]*types.OrganizationSharedKnowledgeBaseItem, error) {
+	panic("not implemented")
+}
+func (s *stubKBShareForGuard) ListSharedKnowledgeBaseIDsByOrganizations(context.Context, []string, uint64) (map[string][]string, error) {
+	panic("not implemented")
+}
+func (s *stubKBShareForGuard) GetShare(context.Context, string) (*types.KnowledgeBaseShare, error) {
+	panic("not implemented")
+}
+func (s *stubKBShareForGuard) GetShareByKBAndOrg(context.Context, string, string) (*types.KnowledgeBaseShare, error) {
+	panic("not implemented")
+}
+func (s *stubKBShareForGuard) HasTenantKBPermission(context.Context, string, uint64, types.TenantRole, types.OrgMemberRole) (bool, error) {
+	panic("not implemented")
+}
+func (s *stubKBShareForGuard) CountSharesByKnowledgeBaseIDs(context.Context, []string) (map[string]int64, error) {
+	panic("not implemented")
+}
+func (s *stubKBShareForGuard) CountByOrganizations(context.Context, []string) (map[string]int64, error) {
+	panic("not implemented")
+}
+
+// runGuard fires a single request through the guard and returns the
+// gin recorder + the kb access (if any) the guard stashed.
+func runGuard(t *testing.T, tenantID uint64, kbID string, requiredPerm types.OrgMemberRole, kb *types.KnowledgeBase, share *stubKBShareForGuard) (*httptest.ResponseRecorder, *gin.Context) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "id", Value: kbID}}
+	req := httptest.NewRequest("GET", "/", nil)
+	ctx := context.WithValue(req.Context(), types.TenantIDContextKey, tenantID)
+	c.Request = req.WithContext(ctx)
+
+	kbsvc := &stubKBLookup{kbs: map[string]*types.KnowledgeBase{}}
+	if kb != nil {
+		kbsvc.kbs[kbID] = kb
+	}
+	guard := RequireKBAccess(KBIDFromParam("id"), requiredPerm, kbsvc, share, nil)
+	guard(c)
+	return rec, c
+}
+
+func TestRequireKBAccess_OwnKB(t *testing.T) {
+	rec, c := runGuard(t, 100, "kb-1",
+		types.OrgRoleViewer,
+		&types.KnowledgeBase{ID: "kb-1", TenantID: 100},
+		nil,
+	)
+	require.False(t, c.IsAborted(), "should pass through")
+	require.Equal(t, 200, rec.Code) // gin's default; nothing wrote a status
+	access, ok := KBAccessFromContext(c)
+	require.True(t, ok)
+	require.Equal(t, uint64(100), access.EffectiveTenantID)
+	require.Equal(t, types.OrgRoleAdmin, access.Permission, "own KB grants admin")
+	// The request context's tenant should still be the caller's own.
+	got, ok := types.TenantIDFromContext(c.Request.Context())
+	require.True(t, ok)
+	require.Equal(t, uint64(100), got)
+}
+
+func TestRequireKBAccess_NotFound_Aborts(t *testing.T) {
+	rec, c := runGuard(t, 100, "kb-missing", types.OrgRoleViewer, nil, nil)
+	require.True(t, c.IsAborted(), "missing KB must abort")
+	require.NotEmpty(t, c.Errors)
+	_, ok := KBAccessFromContext(c)
+	require.False(t, ok, "no access should be stashed on failure")
+	_ = rec
+}
+
+func TestRequireKBAccess_SharedKB_RewritesTenantContext(t *testing.T) {
+	share := &stubKBShareForGuard{
+		permission: map[string]types.OrgMemberRole{"kb-shared": types.OrgRoleEditor},
+		shared:     map[string]bool{"kb-shared": true},
+		source:     map[string]uint64{"kb-shared": 200},
+	}
+	_, c := runGuard(t, 100, "kb-shared",
+		types.OrgRoleEditor,
+		&types.KnowledgeBase{ID: "kb-shared", TenantID: 200},
+		share,
+	)
+	require.False(t, c.IsAborted())
+	access, ok := KBAccessFromContext(c)
+	require.True(t, ok)
+	require.Equal(t, uint64(200), access.EffectiveTenantID)
+	// The downstream handler should see tenant=200 from context.
+	got, _ := types.TenantIDFromContext(c.Request.Context())
+	require.Equal(t, uint64(200), got, "guard must rewrite context to source tenant")
+}
+
+func TestRequireKBAccess_SharedKB_PermissionBelowMin_Aborts(t *testing.T) {
+	share := &stubKBShareForGuard{
+		permission: map[string]types.OrgMemberRole{"kb-shared": types.OrgRoleViewer},
+		shared:     map[string]bool{"kb-shared": true},
+		source:     map[string]uint64{"kb-shared": 200},
+	}
+	_, c := runGuard(t, 100, "kb-shared",
+		types.OrgRoleEditor, // require Editor
+		&types.KnowledgeBase{ID: "kb-shared", TenantID: 200},
+		share,
+	)
+	require.True(t, c.IsAborted(), "Viewer share must reject when Editor required")
+}
+
+func TestRequireKBAccess_NoTenant_Aborts(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "id", Value: "kb-x"}}
+	c.Request = httptest.NewRequest("GET", "/", nil) // no tenant in context
+	guard := RequireKBAccess(KBIDFromParam("id"), types.OrgRoleViewer, &stubKBLookup{}, nil, nil)
+	guard(c)
+	require.True(t, c.IsAborted())
+}

--- a/internal/middleware/kb_access_test.go
+++ b/internal/middleware/kb_access_test.go
@@ -8,6 +8,7 @@ import (
 
 	apprepo "github.com/Tencent/WeKnora/internal/application/repository"
 	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
@@ -94,15 +95,96 @@ func (s *stubKBShareForGuard) CountByOrganizations(context.Context, []string) (m
 	panic("not implemented")
 }
 
+// stubAgentShareForGuard implements just the two methods the guard
+// touches: GetSharedAgentForTenant (when ?agent_id=X is supplied) and
+// TenantCanAccessKBViaSomeSharedAgent (the any-shared-agent fallback).
+// Every other method panics so unintended new dependencies surface
+// immediately.
+type stubAgentShareForGuard struct {
+	// agents indexed by agent id; nil entry means GetSharedAgentForTenant
+	// returns nil + nil (i.e. caller has no access to that agent id).
+	agents map[string]*types.CustomAgent
+	// kbsViaSomeAgent[kb.ID] -> true means the any-agent fallback grants
+	// access to that KB.
+	kbsViaSomeAgent map[string]bool
+}
+
+func (s *stubAgentShareForGuard) GetSharedAgentForTenant(_ context.Context, _ uint64, _ types.TenantRole, agentID string) (*types.CustomAgent, error) {
+	return s.agents[agentID], nil
+}
+
+func (s *stubAgentShareForGuard) TenantCanAccessKBViaSomeSharedAgent(_ context.Context, _ uint64, _ types.TenantRole, kb *types.KnowledgeBase) (bool, error) {
+	return s.kbsViaSomeAgent[kb.ID], nil
+}
+
+func (s *stubAgentShareForGuard) ShareAgent(context.Context, string, string, string, uint64, types.OrgMemberRole) (*types.AgentShare, error) {
+	panic("not implemented")
+}
+func (s *stubAgentShareForGuard) RemoveShare(context.Context, string, string, uint64) error {
+	panic("not implemented")
+}
+func (s *stubAgentShareForGuard) ListSharesByAgent(context.Context, string) ([]*types.AgentShare, error) {
+	panic("not implemented")
+}
+func (s *stubAgentShareForGuard) ListSharesByOrganization(context.Context, string) ([]*types.AgentShare, error) {
+	panic("not implemented")
+}
+func (s *stubAgentShareForGuard) ListSharedAgents(context.Context, uint64, types.TenantRole) ([]*types.SharedAgentInfo, error) {
+	panic("not implemented")
+}
+func (s *stubAgentShareForGuard) ListSharedAgentsInOrganization(context.Context, string, uint64, types.TenantRole) ([]*types.OrganizationSharedAgentItem, error) {
+	panic("not implemented")
+}
+func (s *stubAgentShareForGuard) ListSharedAgentsInOrganizations(context.Context, []string, uint64, types.TenantRole) (map[string][]*types.OrganizationSharedAgentItem, error) {
+	panic("not implemented")
+}
+func (s *stubAgentShareForGuard) SetSharedAgentDisabledByMe(context.Context, uint64, string, uint64, bool) error {
+	panic("not implemented")
+}
+func (s *stubAgentShareForGuard) GetShare(context.Context, string) (*types.AgentShare, error) {
+	panic("not implemented")
+}
+func (s *stubAgentShareForGuard) GetShareByAgentAndOrg(context.Context, string, string) (*types.AgentShare, error) {
+	panic("not implemented")
+}
+func (s *stubAgentShareForGuard) GetShareByAgentIDForTenant(context.Context, uint64, string, uint64) (*types.AgentShare, error) {
+	panic("not implemented")
+}
+func (s *stubAgentShareForGuard) CountByOrganizations(context.Context, []string) (map[string]int64, error) {
+	panic("not implemented")
+}
+
+// guardOpts collects optional knobs for runGuard. Keeps the call site
+// readable when most tests only care about a couple of dimensions.
+type guardOpts struct {
+	agentID    string                  // ?agent_id query param
+	agentShare *stubAgentShareForGuard // nil means "no agent-share service"
+}
+
 // runGuard fires a single request through the guard and returns the
-// gin recorder + the kb access (if any) the guard stashed.
-func runGuard(t *testing.T, tenantID uint64, kbID string, requiredPerm types.OrgMemberRole, kb *types.KnowledgeBase, share *stubKBShareForGuard) (*httptest.ResponseRecorder, *gin.Context) {
+// gin recorder + the kb access (if any) the guard stashed. Defaults
+// to EnableRBAC=true; the EnableRBAC=false fail-open path has its own
+// dedicated tests further below.
+func runGuard(
+	t *testing.T,
+	tenantID uint64,
+	kbID string,
+	requiredPerm types.OrgMemberRole,
+	kb *types.KnowledgeBase,
+	share *stubKBShareForGuard,
+	opts guardOpts,
+) (*httptest.ResponseRecorder, *gin.Context) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
 	c.Params = gin.Params{{Key: "id", Value: kbID}}
-	req := httptest.NewRequest("GET", "/", nil)
+
+	url := "/"
+	if opts.agentID != "" {
+		url = "/?agent_id=" + opts.agentID
+	}
+	req := httptest.NewRequest("GET", url, nil)
 	ctx := context.WithValue(req.Context(), types.TenantIDContextKey, tenantID)
 	c.Request = req.WithContext(ctx)
 
@@ -110,7 +192,28 @@ func runGuard(t *testing.T, tenantID uint64, kbID string, requiredPerm types.Org
 	if kb != nil {
 		kbsvc.kbs[kbID] = kb
 	}
-	guard := RequireKBAccess(KBIDFromParam("id"), requiredPerm, kbsvc, share, nil)
+
+	// Convert the package-local concrete stub types to typed interface
+	// nils when they aren't supplied — otherwise the interface wraps a
+	// nil pointer and `iface != nil` evaluates true on the guard side
+	// (classic Go typed-nil trap).
+	var shareSvc interfaces.KBShareService
+	if share != nil {
+		shareSvc = share
+	}
+	var agentSvc interfaces.AgentShareService
+	if opts.agentShare != nil {
+		agentSvc = opts.agentShare
+	}
+
+	guard := RequireKBAccess(
+		KBIDFromParam("id"),
+		requiredPerm,
+		kbsvc,
+		shareSvc,
+		agentSvc,
+		cfgRBAC(true),
+	)
 	guard(c)
 	return rec, c
 }
@@ -120,6 +223,7 @@ func TestRequireKBAccess_OwnKB(t *testing.T) {
 		types.OrgRoleViewer,
 		&types.KnowledgeBase{ID: "kb-1", TenantID: 100},
 		nil,
+		guardOpts{},
 	)
 	require.False(t, c.IsAborted(), "should pass through")
 	require.Equal(t, 200, rec.Code) // gin's default; nothing wrote a status
@@ -134,12 +238,11 @@ func TestRequireKBAccess_OwnKB(t *testing.T) {
 }
 
 func TestRequireKBAccess_NotFound_Aborts(t *testing.T) {
-	rec, c := runGuard(t, 100, "kb-missing", types.OrgRoleViewer, nil, nil)
+	_, c := runGuard(t, 100, "kb-missing", types.OrgRoleViewer, nil, nil, guardOpts{})
 	require.True(t, c.IsAborted(), "missing KB must abort")
 	require.NotEmpty(t, c.Errors)
 	_, ok := KBAccessFromContext(c)
 	require.False(t, ok, "no access should be stashed on failure")
-	_ = rec
 }
 
 func TestRequireKBAccess_SharedKB_RewritesTenantContext(t *testing.T) {
@@ -152,12 +255,12 @@ func TestRequireKBAccess_SharedKB_RewritesTenantContext(t *testing.T) {
 		types.OrgRoleEditor,
 		&types.KnowledgeBase{ID: "kb-shared", TenantID: 200},
 		share,
+		guardOpts{},
 	)
 	require.False(t, c.IsAborted())
 	access, ok := KBAccessFromContext(c)
 	require.True(t, ok)
 	require.Equal(t, uint64(200), access.EffectiveTenantID)
-	// The downstream handler should see tenant=200 from context.
 	got, _ := types.TenantIDFromContext(c.Request.Context())
 	require.Equal(t, uint64(200), got, "guard must rewrite context to source tenant")
 }
@@ -172,6 +275,7 @@ func TestRequireKBAccess_SharedKB_PermissionBelowMin_Aborts(t *testing.T) {
 		types.OrgRoleEditor, // require Editor
 		&types.KnowledgeBase{ID: "kb-shared", TenantID: 200},
 		share,
+		guardOpts{},
 	)
 	require.True(t, c.IsAborted(), "Viewer share must reject when Editor required")
 }
@@ -182,7 +286,228 @@ func TestRequireKBAccess_NoTenant_Aborts(t *testing.T) {
 	c, _ := gin.CreateTestContext(rec)
 	c.Params = gin.Params{{Key: "id", Value: "kb-x"}}
 	c.Request = httptest.NewRequest("GET", "/", nil) // no tenant in context
-	guard := RequireKBAccess(KBIDFromParam("id"), types.OrgRoleViewer, &stubKBLookup{}, nil, nil)
+	guard := RequireKBAccess(
+		KBIDFromParam("id"),
+		types.OrgRoleViewer,
+		&stubKBLookup{},
+		nil,
+		nil,
+		cfgRBAC(true),
+	)
 	guard(c)
 	require.True(t, c.IsAborted())
+}
+
+// ---------- Agent-share fallback ----------
+
+func TestRequireKBAccess_AgentShare_AnyAgent_ViewerOnly(t *testing.T) {
+	// No org-share entry; caller has at least one shared agent that can
+	// access this KB. Required permission is Viewer, so the agent-share
+	// branch activates and grants read access at the source tenant.
+	agent := &stubAgentShareForGuard{
+		kbsViaSomeAgent: map[string]bool{"kb-shared": true},
+	}
+	_, c := runGuard(t, 100, "kb-shared",
+		types.OrgRoleViewer,
+		&types.KnowledgeBase{ID: "kb-shared", TenantID: 200},
+		nil,
+		guardOpts{agentShare: agent},
+	)
+	require.False(t, c.IsAborted())
+	access, ok := KBAccessFromContext(c)
+	require.True(t, ok)
+	require.Equal(t, uint64(200), access.EffectiveTenantID)
+	require.Equal(t, types.OrgRoleViewer, access.Permission, "agent share grants viewer only")
+}
+
+func TestRequireKBAccess_AgentShare_EditorRequired_Aborts(t *testing.T) {
+	// Required permission is Editor → agent-share fallback MUST NOT
+	// activate. Regression test for the implicit-security-fix in this
+	// PR: old TagHandler.effectiveCtxForKB granted any agent-share
+	// access to write routes, which leaked tag CRUD.
+	agent := &stubAgentShareForGuard{
+		kbsViaSomeAgent: map[string]bool{"kb-shared": true},
+	}
+	_, c := runGuard(t, 100, "kb-shared",
+		types.OrgRoleEditor,
+		&types.KnowledgeBase{ID: "kb-shared", TenantID: 200},
+		nil,
+		guardOpts{agentShare: agent},
+	)
+	require.True(t, c.IsAborted(), "agent share must NOT satisfy Editor requirement")
+}
+
+func TestRequireKBAccess_AgentShare_SpecificAgent_ModeAll(t *testing.T) {
+	// ?agent_id=A and A has KBSelectionMode=all on the source tenant.
+	// Guard should accept regardless of which KB.
+	agent := &stubAgentShareForGuard{
+		agents: map[string]*types.CustomAgent{
+			"agent-A": {
+				ID:       "agent-A",
+				TenantID: 200,
+				Config: types.CustomAgentConfig{
+					KBSelectionMode: "all",
+				},
+			},
+		},
+	}
+	_, c := runGuard(t, 100, "kb-shared",
+		types.OrgRoleViewer,
+		&types.KnowledgeBase{ID: "kb-shared", TenantID: 200},
+		nil,
+		guardOpts{agentShare: agent, agentID: "agent-A"},
+	)
+	require.False(t, c.IsAborted())
+	access, _ := KBAccessFromContext(c)
+	require.Equal(t, types.OrgRoleViewer, access.Permission)
+}
+
+func TestRequireKBAccess_AgentShare_SpecificAgent_ModeSelected_Match(t *testing.T) {
+	agent := &stubAgentShareForGuard{
+		agents: map[string]*types.CustomAgent{
+			"agent-A": {
+				ID:       "agent-A",
+				TenantID: 200,
+				Config: types.CustomAgentConfig{
+					KBSelectionMode: "selected",
+					KnowledgeBases:  []string{"kb-other", "kb-shared"},
+				},
+			},
+		},
+	}
+	_, c := runGuard(t, 100, "kb-shared",
+		types.OrgRoleViewer,
+		&types.KnowledgeBase{ID: "kb-shared", TenantID: 200},
+		nil,
+		guardOpts{agentShare: agent, agentID: "agent-A"},
+	)
+	require.False(t, c.IsAborted())
+}
+
+func TestRequireKBAccess_AgentShare_SpecificAgent_ModeSelected_Miss(t *testing.T) {
+	// ?agent_id=A but A's selected list does NOT include this KB. Even
+	// though SOME OTHER shared agent (B) would have granted access via
+	// the any-agent fallback, the explicit agent_id pins the resolution
+	// to A. This is the divergence the review flagged.
+	agent := &stubAgentShareForGuard{
+		agents: map[string]*types.CustomAgent{
+			"agent-A": {
+				ID:       "agent-A",
+				TenantID: 200,
+				Config: types.CustomAgentConfig{
+					KBSelectionMode: "selected",
+					KnowledgeBases:  []string{"kb-other"},
+				},
+			},
+		},
+		// any-agent fallback would have said yes — but agent_id=A pins us.
+		kbsViaSomeAgent: map[string]bool{"kb-shared": true},
+	}
+	_, c := runGuard(t, 100, "kb-shared",
+		types.OrgRoleViewer,
+		&types.KnowledgeBase{ID: "kb-shared", TenantID: 200},
+		nil,
+		guardOpts{agentShare: agent, agentID: "agent-A"},
+	)
+	require.True(t, c.IsAborted(), "agent_id=A must NOT fall back to any-agent")
+}
+
+func TestRequireKBAccess_AgentShare_SpecificAgent_ModeNone(t *testing.T) {
+	agent := &stubAgentShareForGuard{
+		agents: map[string]*types.CustomAgent{
+			"agent-A": {
+				ID:       "agent-A",
+				TenantID: 200,
+				Config: types.CustomAgentConfig{
+					KBSelectionMode: "none",
+				},
+			},
+		},
+	}
+	_, c := runGuard(t, 100, "kb-shared",
+		types.OrgRoleViewer,
+		&types.KnowledgeBase{ID: "kb-shared", TenantID: 200},
+		nil,
+		guardOpts{agentShare: agent, agentID: "agent-A"},
+	)
+	require.True(t, c.IsAborted(), "agent in mode=none must not grant access")
+}
+
+func TestRequireKBAccess_AgentShare_SpecificAgent_TenantMismatch(t *testing.T) {
+	// Agent belongs to tenant 999 but KB belongs to tenant 200 → reject
+	// (this is the kb.TenantID != agent.TenantID guard in the handler;
+	// preserves cross-tenant isolation when shares get reshuffled).
+	agent := &stubAgentShareForGuard{
+		agents: map[string]*types.CustomAgent{
+			"agent-A": {
+				ID:       "agent-A",
+				TenantID: 999,
+				Config: types.CustomAgentConfig{
+					KBSelectionMode: "all",
+				},
+			},
+		},
+	}
+	_, c := runGuard(t, 100, "kb-shared",
+		types.OrgRoleViewer,
+		&types.KnowledgeBase{ID: "kb-shared", TenantID: 200},
+		nil,
+		guardOpts{agentShare: agent, agentID: "agent-A"},
+	)
+	require.True(t, c.IsAborted())
+}
+
+// ---------- EnableRBAC=false rollout window ----------
+
+func TestRequireKBAccess_Forbidden_FailOpenWhenRBACDisabled(t *testing.T) {
+	// Same scenario as PermissionBelowMin (which aborts when enforcing),
+	// but with EnableRBAC=false the guard logs and passes through.
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "id", Value: "kb-shared"}}
+	req := httptest.NewRequest("GET", "/", nil)
+	c.Request = req.WithContext(context.WithValue(req.Context(), types.TenantIDContextKey, uint64(100)))
+
+	share := &stubKBShareForGuard{
+		permission: map[string]types.OrgMemberRole{"kb-shared": types.OrgRoleViewer},
+		shared:     map[string]bool{"kb-shared": true},
+		source:     map[string]uint64{"kb-shared": 200},
+	}
+	kbsvc := &stubKBLookup{kbs: map[string]*types.KnowledgeBase{
+		"kb-shared": {ID: "kb-shared", TenantID: 200},
+	}}
+
+	guard := RequireKBAccess(
+		KBIDFromParam("id"),
+		types.OrgRoleEditor, // would-deny
+		kbsvc, share, nil,
+		cfgRBAC(false), // enforcement off
+	)
+	guard(c)
+	require.False(t, c.IsAborted(), "guard must pass through when EnableRBAC is off")
+	_ = rec
+}
+
+func TestRequireKBAccess_NotFound_FiresEvenWhenRBACDisabled(t *testing.T) {
+	// Not-found is not an authorisation event; the client asked for a
+	// resource that genuinely isn't there. We surface 404 regardless of
+	// the rollout flag (matches the comment in RequireKBAccess).
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "id", Value: "kb-missing"}}
+	req := httptest.NewRequest("GET", "/", nil)
+	c.Request = req.WithContext(context.WithValue(req.Context(), types.TenantIDContextKey, uint64(100)))
+
+	guard := RequireKBAccess(
+		KBIDFromParam("id"),
+		types.OrgRoleViewer,
+		&stubKBLookup{kbs: map[string]*types.KnowledgeBase{}},
+		nil, nil,
+		cfgRBAC(false),
+	)
+	guard(c)
+	require.True(t, c.IsAborted(), "404 still fires with enforcement off")
+	_ = rec
 }

--- a/internal/router/rbac.go
+++ b/internal/router/rbac.go
@@ -320,6 +320,7 @@ func (g *rbacGuards) KBAccessRead(param string) gin.HandlerFunc {
 		g.kbService,
 		g.kbShareService,
 		g.agentShareService,
+		g.cfg,
 	)
 }
 
@@ -333,6 +334,7 @@ func (g *rbacGuards) KBAccessWrite(param string) gin.HandlerFunc {
 		g.kbService,
 		g.kbShareService,
 		g.agentShareService,
+		g.cfg,
 	)
 }
 
@@ -347,6 +349,7 @@ func (g *rbacGuards) KBAccessReadFromKnowledgeIDParam(param string) gin.HandlerF
 		g.kbService,
 		g.kbShareService,
 		g.agentShareService,
+		g.cfg,
 	)
 }
 
@@ -359,6 +362,7 @@ func (g *rbacGuards) KBAccessWriteFromKnowledgeIDParam(param string) gin.Handler
 		g.kbService,
 		g.kbShareService,
 		g.agentShareService,
+		g.cfg,
 	)
 }
 
@@ -372,6 +376,7 @@ func (g *rbacGuards) KBAccessReadFromChunkIDParam(param string) gin.HandlerFunc 
 		g.kbService,
 		g.kbShareService,
 		g.agentShareService,
+		g.cfg,
 	)
 }
 
@@ -385,5 +390,6 @@ func (g *rbacGuards) KBAccessWriteFromChunkIDParam(param string) gin.HandlerFunc
 		g.kbService,
 		g.kbShareService,
 		g.agentShareService,
+		g.cfg,
 	)
 }

--- a/internal/router/rbac.go
+++ b/internal/router/rbac.go
@@ -5,6 +5,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/handler"
 	"github.com/Tencent/WeKnora/internal/middleware"
 	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"github.com/gin-gonic/gin"
 )
 
@@ -125,6 +126,15 @@ type rbacGuards struct {
 	chunkKBCreator        middleware.CreatorLookup
 	chunkKBCreatorFromID  middleware.CreatorLookup // chunk routes that address chunks by :id (no knowledge id in URL)
 	wikiKBCreator         middleware.CreatorLookup
+
+	// Services for the KB-access guard (own / org-shared / via shared
+	// agent). Captured here so route lines can reference g.KBAccess()
+	// without having to plumb the services through every Register*
+	// function.
+	kbService         middleware.KBLookup
+	knowledgeService  middleware.KnowledgeLookup
+	kbShareService    interfaces.KBShareService
+	agentShareService interfaces.AgentShareService
 }
 
 // newRBACGuards wires the guards from the live configuration and the
@@ -136,6 +146,10 @@ func newRBACGuards(
 	knowledgeHandler *handler.KnowledgeHandler,
 	chunkHandler *handler.ChunkHandler,
 	wikiHandler *handler.WikiPageHandler,
+	kbService interfaces.KnowledgeBaseService,
+	knowledgeService interfaces.KnowledgeService,
+	kbShareService interfaces.KBShareService,
+	agentShareService interfaces.AgentShareService,
 ) *rbacGuards {
 	g := &rbacGuards{cfg: cfg}
 	if kbHandler != nil {
@@ -155,6 +169,10 @@ func newRBACGuards(
 	if wikiHandler != nil {
 		g.wikiKBCreator = wikiHandler.KBCreatorLookupFromKBPath
 	}
+	g.kbService = kbService
+	g.knowledgeService = knowledgeService
+	g.kbShareService = kbShareService
+	g.agentShareService = agentShareService
 	return g
 }
 
@@ -264,4 +282,79 @@ func (g *rbacGuards) CrossTenant() gin.HandlerFunc {
 // handler.
 func (g *rbacGuards) PathTenantMatch() gin.HandlerFunc {
 	return middleware.RequirePathTenantMatch(g.cfg)
+}
+
+// KB-access guards — orthogonal to the role-and-ownership matrix
+// above. They answer "can the caller's tenant operate on THIS KB?"
+// taking into account three paths:
+//
+//   1. Own KB                         — full access (Admin)
+//   2. Org-shared KB (Plan 3)         — capped permission
+//   3. Visible via shared agent       — read-only
+//
+// On success the resolved (KB + effective tenant id + permission)
+// tuple is stashed on c.Keys under middleware.KBAccessContextKey AND
+// the request context's tenant ID is rewritten to the effective tenant
+// — so handlers downstream just read tenant the way they always did
+// (types.MustTenantIDFromContext) without knowing whether the KB is
+// owned or shared.
+//
+// These guards replace the per-handler effectiveCtxForKB /
+// validateAndGetKnowledgeBase helpers that used to be re-implemented
+// in chunk.go, faq.go, tag.go, knowledge.go and knowledgebase.go;
+// the share-fallback logic now lives in exactly one place
+// (middleware/kb_access.go).
+
+// KBAccessRead gates a KB-scoped read route on the caller having at
+// least Viewer-level access. The agent-share fallback only activates
+// at this level — Editor/Admin reads never go through "I just see it
+// because someone shared an agent". The kbID is read from the gin
+// param named in `param` (typically "id" for /knowledge-bases/:id/...).
+func (g *rbacGuards) KBAccessRead(param string) gin.HandlerFunc {
+	return middleware.RequireKBAccess(
+		middleware.KBIDFromParam(param),
+		types.OrgRoleViewer,
+		g.kbService,
+		g.kbShareService,
+		g.agentShareService,
+	)
+}
+
+// KBAccessWrite gates a KB-scoped mutating route on the caller having
+// at least Editor-level access (own KB or org-shared with editor).
+// Used by FAQ upsert, tag CRUD, chunk update/delete, etc.
+func (g *rbacGuards) KBAccessWrite(param string) gin.HandlerFunc {
+	return middleware.RequireKBAccess(
+		middleware.KBIDFromParam(param),
+		types.OrgRoleEditor,
+		g.kbService,
+		g.kbShareService,
+		g.agentShareService,
+	)
+}
+
+// KBAccessReadFromKnowledgeIDParam is like KBAccessRead but resolves
+// the kb_id by walking a knowledge document (URL `:knowledge_id`)
+// back to its parent KB. Used by the chunk routes whose URL addresses
+// the chunk via /chunks/:knowledge_id rather than /knowledge-bases/:id.
+func (g *rbacGuards) KBAccessReadFromKnowledgeIDParam(param string) gin.HandlerFunc {
+	return middleware.RequireKBAccess(
+		middleware.KBIDFromKnowledgeIDParam(param, g.knowledgeService),
+		types.OrgRoleViewer,
+		g.kbService,
+		g.kbShareService,
+		g.agentShareService,
+	)
+}
+
+// KBAccessWriteFromKnowledgeIDParam mirrors KBAccessReadFromKnowledgeIDParam
+// for mutating routes (Editor minimum).
+func (g *rbacGuards) KBAccessWriteFromKnowledgeIDParam(param string) gin.HandlerFunc {
+	return middleware.RequireKBAccess(
+		middleware.KBIDFromKnowledgeIDParam(param, g.knowledgeService),
+		types.OrgRoleEditor,
+		g.kbService,
+		g.kbShareService,
+		g.agentShareService,
+	)
 }

--- a/internal/router/rbac.go
+++ b/internal/router/rbac.go
@@ -133,6 +133,7 @@ type rbacGuards struct {
 	// function.
 	kbService         middleware.KBLookup
 	knowledgeService  middleware.KnowledgeLookup
+	chunkService      middleware.ChunkLookup
 	kbShareService    interfaces.KBShareService
 	agentShareService interfaces.AgentShareService
 }
@@ -148,6 +149,7 @@ func newRBACGuards(
 	wikiHandler *handler.WikiPageHandler,
 	kbService interfaces.KnowledgeBaseService,
 	knowledgeService interfaces.KnowledgeService,
+	chunkService interfaces.ChunkService,
 	kbShareService interfaces.KBShareService,
 	agentShareService interfaces.AgentShareService,
 ) *rbacGuards {
@@ -171,6 +173,7 @@ func newRBACGuards(
 	}
 	g.kbService = kbService
 	g.knowledgeService = knowledgeService
+	g.chunkService = chunkService
 	g.kbShareService = kbShareService
 	g.agentShareService = agentShareService
 	return g
@@ -352,6 +355,32 @@ func (g *rbacGuards) KBAccessReadFromKnowledgeIDParam(param string) gin.HandlerF
 func (g *rbacGuards) KBAccessWriteFromKnowledgeIDParam(param string) gin.HandlerFunc {
 	return middleware.RequireKBAccess(
 		middleware.KBIDFromKnowledgeIDParam(param, g.knowledgeService),
+		types.OrgRoleEditor,
+		g.kbService,
+		g.kbShareService,
+		g.agentShareService,
+	)
+}
+
+// KBAccessReadFromChunkIDParam walks chunk_id -> kb_id (using the
+// chunk's denormalised KnowledgeBaseID column). Used by
+// /chunks/by-id/:id read routes.
+func (g *rbacGuards) KBAccessReadFromChunkIDParam(param string) gin.HandlerFunc {
+	return middleware.RequireKBAccess(
+		middleware.KBIDFromChunkIDParam(param, g.chunkService),
+		types.OrgRoleViewer,
+		g.kbService,
+		g.kbShareService,
+		g.agentShareService,
+	)
+}
+
+// KBAccessWriteFromChunkIDParam — same as KBAccessReadFromChunkIDParam
+// but requires Editor minimum. Used by chunk write routes that
+// address the chunk via /chunks/by-id/:id.
+func (g *rbacGuards) KBAccessWriteFromChunkIDParam(param string) gin.HandlerFunc {
+	return middleware.RequireKBAccess(
+		middleware.KBIDFromChunkIDParam(param, g.chunkService),
 		types.OrgRoleEditor,
 		g.kbService,
 		g.kbShareService,

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -163,6 +163,7 @@ func NewRouter(params RouterParams) *gin.Engine {
 			params.WikiPageHandler,
 			params.KBService,
 			params.KnowledgeService,
+			params.ChunkService,
 			params.KBShareService,
 			params.AgentShareService,
 		)
@@ -214,22 +215,22 @@ func RegisterChunkRoutes(r *gin.RouterGroup, handler *handler.ChunkHandler, g *r
 	// 分块路由组
 	chunks := r.Group("/chunks")
 	{
-		// 获取分块列表 — Viewer+
-		chunks.GET("/:knowledge_id", g.Viewer(), handler.ListKnowledgeChunks)
-		// 通过chunk_id获取单个chunk（不需要knowledge_id） — Viewer+
-		chunks.GET("/by-id/:id", g.Viewer(), handler.GetChunkByIDOnly)
-		// 删除分块 — KB owner OR Admin+
-		chunks.DELETE("/:knowledge_id/:id", g.OwnedChunkKBOrAdmin(), handler.DeleteChunk)
-		// 删除知识下的所有分块 — KB owner OR Admin+
-		chunks.DELETE("/:knowledge_id", g.OwnedChunkKBOrAdmin(), handler.DeleteChunksByKnowledgeID)
-		// 更新分块信息 — KB owner OR Admin+
-		chunks.PUT("/:knowledge_id/:id", g.OwnedChunkKBOrAdmin(), handler.UpdateChunk)
+		// 获取分块列表 — Viewer+ 且对父 KB 有 read 权限（own / shared / via shared agent）
+		chunks.GET("/:knowledge_id", g.Viewer(), g.KBAccessReadFromKnowledgeIDParam("knowledge_id"), handler.ListKnowledgeChunks)
+		// 通过chunk_id获取单个chunk（不需要knowledge_id） — Viewer+ 且对父 KB 有 read 权限
+		chunks.GET("/by-id/:id", g.Viewer(), g.KBAccessReadFromChunkIDParam("id"), handler.GetChunkByIDOnly)
+		// 删除分块 — KB owner OR Admin+，且对父 KB 有 write 权限
+		chunks.DELETE("/:knowledge_id/:id", g.OwnedChunkKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("knowledge_id"), handler.DeleteChunk)
+		// 删除知识下的所有分块 — KB owner OR Admin+，且对父 KB 有 write 权限
+		chunks.DELETE("/:knowledge_id", g.OwnedChunkKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("knowledge_id"), handler.DeleteChunksByKnowledgeID)
+		// 更新分块信息 — KB owner OR Admin+，且对父 KB 有 write 权限
+		chunks.PUT("/:knowledge_id/:id", g.OwnedChunkKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("knowledge_id"), handler.UpdateChunk)
 		// 删除单个生成的问题（通过分块 id） — 与其它 chunk mutation 一致：
 		// KB owner OR Admin+。早期这里因为链路 (chunk_id -> knowledge_id ->
 		// kb -> creator_id) 还没接通，被临时降级成 Contributor，导致一个
 		// 「能编辑所有 chunk 的同样规则在这条路由上反而更宽松」的不一致。
 		// 现在通过 KBCreatorLookupFromChunkIDParam 把那一跳补上，统一矩阵。
-		chunks.DELETE("/by-id/:id/questions", g.OwnedChunkKBOrAdminFromChunkID(), handler.DeleteGeneratedQuestion)
+		chunks.DELETE("/by-id/:id/questions", g.OwnedChunkKBOrAdminFromChunkID(), g.KBAccessWriteFromChunkIDParam("id"), handler.DeleteGeneratedQuestion)
 	}
 }
 
@@ -244,30 +245,34 @@ func RegisterChunkRoutes(r *gin.RouterGroup, handler *handler.ChunkHandler, g *r
 // Cross-:id batch operations stay Contributor-gated — they don't have
 // a single owning KB to check against.
 func RegisterKnowledgeRoutes(r *gin.RouterGroup, handler *handler.KnowledgeHandler, g *rbacGuards) {
-	// 知识库下的知识路由组
+	// 知识库下的知识路由组（URL :id is the KB id）
 	kb := r.Group("/knowledge-bases/:id/knowledge")
 	{
-		kb.POST("/file", g.OwnedKBOrAdmin(), handler.CreateKnowledgeFromFile)
-		kb.POST("/url", g.OwnedKBOrAdmin(), handler.CreateKnowledgeFromURL)
-		kb.POST("/manual", g.OwnedKBOrAdmin(), handler.CreateManualKnowledge)
-		kb.GET("", g.Viewer(), handler.ListKnowledge)
+		kb.POST("/file", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.CreateKnowledgeFromFile)
+		kb.POST("/url", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.CreateKnowledgeFromURL)
+		kb.POST("/manual", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.CreateManualKnowledge)
+		kb.GET("", g.Viewer(), g.KBAccessRead("id"), handler.ListKnowledge)
 		// Clearing all contents under a KB is a destructive op; gate
 		// behind Admin instead of Contributor.
-		kb.DELETE("", g.Admin(), handler.ClearKnowledgeBaseContents)
+		kb.DELETE("", g.Admin(), g.KBAccessWrite("id"), handler.ClearKnowledgeBaseContents)
 	}
 
-	// 知识路由组
+	// 知识路由组（URL :id is a knowledge id; the guard walks it to the parent KB）
 	k := r.Group("/knowledge")
 	{
+		// Cross-knowledge endpoints (no :id) can't be gated on a single
+		// KB — they accept arbitrary knowledge IDs and the handler must
+		// fan out the access check itself. So /batch and /search keep
+		// the role-only floor; /move and /batch-delete stay Contributor.
 		k.GET("/batch", g.Viewer(), handler.GetKnowledgeBatch)
-		k.GET("/:id", g.Viewer(), handler.GetKnowledge)
-		k.DELETE("/:id", g.OwnedKnowledgeKBOrAdmin(), handler.DeleteKnowledge)
-		k.PUT("/:id", g.OwnedKnowledgeKBOrAdmin(), handler.UpdateKnowledge)
-		k.PUT("/manual/:id", g.OwnedKnowledgeKBOrAdmin(), handler.UpdateManualKnowledge)
-		k.POST("/:id/reparse", g.OwnedKnowledgeKBOrAdmin(), handler.ReparseKnowledge)
-		k.GET("/:id/download", g.Viewer(), handler.DownloadKnowledgeFile)
-		k.GET("/:id/preview", g.Viewer(), handler.PreviewKnowledgeFile)
-		k.PUT("/image/:id/:chunk_id", g.OwnedKnowledgeKBOrAdmin(), handler.UpdateImageInfo)
+		k.GET("/:id", g.Viewer(), g.KBAccessReadFromKnowledgeIDParam("id"), handler.GetKnowledge)
+		k.DELETE("/:id", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.DeleteKnowledge)
+		k.PUT("/:id", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.UpdateKnowledge)
+		k.PUT("/manual/:id", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.UpdateManualKnowledge)
+		k.POST("/:id/reparse", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.ReparseKnowledge)
+		k.GET("/:id/download", g.Viewer(), g.KBAccessReadFromKnowledgeIDParam("id"), handler.DownloadKnowledgeFile)
+		k.GET("/:id/preview", g.Viewer(), g.KBAccessReadFromKnowledgeIDParam("id"), handler.PreviewKnowledgeFile)
+		k.PUT("/image/:id/:chunk_id", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.UpdateImageInfo)
 		// Batch / cross-KB ops stay Contributor-gated: there is no
 		// single owning KB to walk back to. A future PR could add a
 		// "must own every targeted KB" guard if the requirement
@@ -325,26 +330,26 @@ func RegisterKnowledgeBaseRoutes(r *gin.RouterGroup, handler *handler.KnowledgeB
 	// 知识库路由组
 	kb := r.Group("/knowledge-bases")
 	{
-		// 创建知识库 — Contributor+
+		// 创建知识库 — Contributor+ (no :id, role-only floor)
 		kb.POST("", g.Contributor(), handler.CreateKnowledgeBase)
-		// 获取知识库列表 — Viewer+
+		// 获取知识库列表 — Viewer+ (no :id, role-only floor)
 		kb.GET("", g.Viewer(), handler.ListKnowledgeBases)
-		// 获取知识库详情 — Viewer+
-		kb.GET("/:id", g.Viewer(), handler.GetKnowledgeBase)
-		// 更新知识库 — 创建者本人 OR Admin+
-		kb.PUT("/:id", g.OwnedKBOrAdmin(), handler.UpdateKnowledgeBase)
-		// 删除知识库 — 创建者本人 OR Admin+
-		kb.DELETE("/:id", g.OwnedKBOrAdmin(), handler.DeleteKnowledgeBase)
-		// 置顶/取消置顶知识库 — 创建者本人 OR Admin+
-		kb.PUT("/:id/pin", g.OwnedKBOrAdmin(), handler.TogglePinKnowledgeBase)
-		// 混合搜索 — Viewer+ (read-only)
-		kb.GET("/:id/hybrid-search", g.Viewer(), handler.HybridSearch)
+		// 获取知识库详情 — Viewer+ 且对 KB 有 read 权限
+		kb.GET("/:id", g.Viewer(), g.KBAccessRead("id"), handler.GetKnowledgeBase)
+		// 更新知识库 — 创建者本人 OR Admin+ 且对 KB 有 write 权限
+		kb.PUT("/:id", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.UpdateKnowledgeBase)
+		// 删除知识库 — 创建者本人 OR Admin+ 且对 KB 有 write 权限
+		kb.DELETE("/:id", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.DeleteKnowledgeBase)
+		// 置顶/取消置顶知识库 — 创建者本人 OR Admin+ 且对 KB 有 write 权限
+		kb.PUT("/:id/pin", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.TogglePinKnowledgeBase)
+		// 混合搜索 — Viewer+ 且对 KB 有 read 权限 (read-only)
+		kb.GET("/:id/hybrid-search", g.Viewer(), g.KBAccessRead("id"), handler.HybridSearch)
 		// 拷贝知识库 — Contributor+ (副本归调用者所有；不需要原 KB 的所有权)
 		kb.POST("/copy", g.Contributor(), handler.CopyKnowledgeBase)
 		// 获取知识库复制进度 — Viewer+
 		kb.GET("/copy/progress/:task_id", g.Viewer(), handler.GetKBCloneProgress)
-		// 获取可移动目标知识库列表 — Viewer+
-		kb.GET("/:id/move-targets", g.Viewer(), handler.ListMoveTargets)
+		// 获取可移动目标知识库列表 — Viewer+ 且对 KB 有 read 权限
+		kb.GET("/:id/move-targets", g.Viewer(), g.KBAccessRead("id"), handler.ListMoveTargets)
 	}
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -44,6 +44,8 @@ type RouterParams struct {
 	MessageService           interfaces.MessageService
 	ModelService             interfaces.ModelService
 	EvaluationService        interfaces.EvaluationService
+	KBShareService           interfaces.KBShareService
+	AgentShareService        interfaces.AgentShareService
 	KBHandler                *handler.KnowledgeBaseHandler
 	KnowledgeHandler         *handler.KnowledgeHandler
 	TenantHandler            *handler.TenantHandler
@@ -159,6 +161,10 @@ func NewRouter(params RouterParams) *gin.Engine {
 			params.KnowledgeHandler,
 			params.ChunkHandler,
 			params.WikiPageHandler,
+			params.KBService,
+			params.KnowledgeService,
+			params.KBShareService,
+			params.AgentShareService,
 		)
 
 		RegisterAuthRoutes(v1, params.AuthHandler)
@@ -289,20 +295,23 @@ func RegisterFAQRoutes(r *gin.RouterGroup, handler *handler.FAQHandler, g *rbacG
 	// 改不属于自己的 KB 的 FAQ。
 	faq := r.Group("/knowledge-bases/:id/faq")
 	{
-		faq.GET("/entries", g.Viewer(), handler.ListEntries)
-		faq.GET("/entries/export", g.Viewer(), handler.ExportEntries)
-		faq.GET("/entries/:entry_id", g.Viewer(), handler.GetEntry)
-		faq.POST("/entries", g.OwnedKBOrAdmin(), handler.UpsertEntries)
-		faq.POST("/entry", g.OwnedKBOrAdmin(), handler.CreateEntry)
-		faq.PUT("/entries/:entry_id", g.OwnedKBOrAdmin(), handler.UpdateEntry)
-		faq.POST("/entries/:entry_id/similar-questions", g.OwnedKBOrAdmin(), handler.AddSimilarQuestions)
+		// KBAccessRead/Write resolve own/shared/agent-visible access and
+		// rewrite the request's tenant context — handler no longer
+		// carries an effectiveCtxForKB helper.
+		faq.GET("/entries", g.Viewer(), g.KBAccessRead("id"), handler.ListEntries)
+		faq.GET("/entries/export", g.Viewer(), g.KBAccessRead("id"), handler.ExportEntries)
+		faq.GET("/entries/:entry_id", g.Viewer(), g.KBAccessRead("id"), handler.GetEntry)
+		faq.POST("/entries", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.UpsertEntries)
+		faq.POST("/entry", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.CreateEntry)
+		faq.PUT("/entries/:entry_id", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.UpdateEntry)
+		faq.POST("/entries/:entry_id/similar-questions", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.AddSimilarQuestions)
 		// Unified batch update API - supports is_enabled, is_recommended, tag_id
-		faq.PUT("/entries/fields", g.OwnedKBOrAdmin(), handler.UpdateEntryFieldsBatch)
-		faq.PUT("/entries/tags", g.OwnedKBOrAdmin(), handler.UpdateEntryTagBatch)
-		faq.DELETE("/entries", g.OwnedKBOrAdmin(), handler.DeleteEntries)
-		faq.POST("/search", g.Viewer(), handler.SearchFAQ)
+		faq.PUT("/entries/fields", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.UpdateEntryFieldsBatch)
+		faq.PUT("/entries/tags", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.UpdateEntryTagBatch)
+		faq.DELETE("/entries", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.DeleteEntries)
+		faq.POST("/search", g.Viewer(), g.KBAccessRead("id"), handler.SearchFAQ)
 		// FAQ import result display status
-		faq.PUT("/import/last-result/display", g.OwnedKBOrAdmin(), handler.UpdateLastImportResultDisplayStatus)
+		faq.PUT("/import/last-result/display", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.UpdateLastImportResultDisplayStatus)
 	}
 	// FAQ import progress route (outside of knowledge-base scope) — Viewer+
 	faqImport := r.Group("/faq/import")
@@ -353,10 +362,14 @@ func RegisterKnowledgeTagRoutes(r *gin.RouterGroup, tagHandler *handler.TagHandl
 	// 关 Contributor 在他人 KB 里乱建/删标签影响 KB owner 的内容组织。
 	kbTags := r.Group("/knowledge-bases/:id/tags")
 	{
-		kbTags.GET("", g.Viewer(), tagHandler.ListTags)
-		kbTags.POST("", g.OwnedKBOrAdmin(), tagHandler.CreateTag)
-		kbTags.PUT("/:tag_id", g.OwnedKBOrAdmin(), tagHandler.UpdateTag)
-		kbTags.DELETE("/:tag_id", g.OwnedKBOrAdmin(), tagHandler.DeleteTag)
+		// KBAccessRead/Write resolve own/shared/agent-visible access and
+		// rewrite the request's tenant context to the effective tenant
+		// for the duration of the handler — so the handler no longer
+		// needs its own effectiveCtxForKB helper.
+		kbTags.GET("", g.Viewer(), g.KBAccessRead("id"), tagHandler.ListTags)
+		kbTags.POST("", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), tagHandler.CreateTag)
+		kbTags.PUT("/:tag_id", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), tagHandler.UpdateTag)
+		kbTags.DELETE("/:tag_id", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), tagHandler.DeleteTag)
 	}
 }
 


### PR DESCRIPTION
**Stacked on top of #1350 (Plan 3 — org-as-tenant-member). Merge #1350 first; this PR's diff against \`feat/rbac\` will look bigger than the actual change set until #1350 lands.**

## Summary

- Centralises the KB own-or-shared resolution into a single route-level guard \`g.KBAccessRead(param)\` / \`g.KBAccessWrite(param)\` instead of five copies of the same 30-line \`effectiveCtxForKB\` helper inside handlers.
- The guard runs after the existing role/ownership checks; on success it stashes the resolved KB+permission on \`c.Keys\` and rewrites \`c.Request.Context()\` to carry the effective tenant ID — so handlers just read tenant from context the way they always did.
- FAQ and Tag handlers drop their helper methods and lose their \`kbShareService\` / \`agentShareService\` dependencies (now lifted to the route layer).
- 5 new unit tests cover the guard's resolution paths.

## Why

The handler-level helper was duplicated five times (chunk.go, faq.go, tag.go, knowledge.go, knowledgebase.go). Each copy carried the same three-step resolution and started to drift — different log levels, subtly different error messages, one path missing the share-cap check. Lifting the resolution to a guard makes the route declaration the single source of truth for \"what permission is required\" and \"where does the kb_id come from\".

This PR refactors **FAQ + Tag** as the proof-of-concept; chunk / knowledge / knowledgebase handlers are larger and stay on their hand-rolled paths in this PR (the helper signature stabilises here so future PRs can collapse those without churning the API surface again).

## Test plan

- [ ] \`go build ./...\` clean
- [ ] \`go test ./internal/handler/... ./internal/middleware/...\` green
- [ ] Manual smoke: own-KB FAQ list/upsert works, shared-KB (with editor permission) FAQ upsert works, shared-KB (with viewer-only permission) FAQ upsert returns 403