### PR TITLE
fix(rbac): tighten organization mutating routes and UI owner check

### DIFF
--- a/frontend/src/api/organization/index.ts
+++ b/frontend/src/api/organization/index.ts
@@ -7,6 +7,15 @@ export interface Organization {
   description: string
   avatar?: string
   owner_id: string
+  /**
+   * Persisted owner tenant of the organization (Plan 3, migration 000046).
+   * After Plan 3, member ownership is tenant-keyed: identifying the
+   * "owner row" in the members list means matching member.tenant_id
+   * against owner_tenant_id (NOT member.user_id against owner_id).
+   * May be 0 on pre-000046 legacy rows; in that case fall back to
+   * owner_id for display only.
+   */
+  owner_tenant_id: number
   invite_code?: string
   invite_code_expires_at?: string | null
   invite_code_validity_days?: number

--- a/frontend/src/views/organization/OrganizationSettingsModal.vue
+++ b/frontend/src/views/organization/OrganizationSettingsModal.vue
@@ -347,12 +347,12 @@
                     
                     <t-loading :loading="membersLoading">
                       <div class="members-list">
-                        <div 
-                          v-for="member in filteredMembers" 
-                          :key="member.id" 
+                        <div
+                          v-for="member in filteredMembers"
+                          :key="member.id"
                           class="member-item"
-                          :class="{ 
-                            'is-owner': member.user_id === orgInfo?.owner_id,
+                          :class="{
+                            'is-owner': isOwnerMember(member),
                             'is-me': member.user_id === authStore.currentUserId
                           }"
                         >
@@ -369,7 +369,7 @@
                           </div>
                           <div class="member-role">
                             <t-select
-                              v-if="isAdmin && member.user_id !== orgInfo?.owner_id"
+                              v-if="isAdmin && !isOwnerMember(member)"
                               v-model="member.role"
                               :options="roleOptions"
                               size="small"
@@ -377,10 +377,10 @@
                             />
                             <t-tag v-else size="small" :theme="getRoleTheme(member.role)">
                               {{ $t(`organization.role.${member.role}`) }}
-                              <span v-if="member.user_id === orgInfo?.owner_id">({{ $t('organization.owner') }})</span>
+                              <span v-if="isOwnerMember(member)">({{ $t('organization.owner') }})</span>
                             </t-tag>
                           </div>
-                          <div v-if="isAdmin && member.user_id !== orgInfo?.owner_id" class="member-actions">
+                          <div v-if="isAdmin && !isOwnerMember(member)" class="member-actions">
                             <t-button
                               variant="text"
                               theme="danger"
@@ -943,11 +943,25 @@ const roleOptions = computed(() => [
 const filteredMembers = computed(() => {
   const query = memberSearchQuery.value.toLowerCase()
   if (!query) return members.value
-  return members.value.filter(m => 
-    m.username.toLowerCase().includes(query) || 
+  return members.value.filter(m =>
+    m.username.toLowerCase().includes(query) ||
     m.email.toLowerCase().includes(query)
   )
 })
+
+// Owner identification is tenant-keyed after Plan 3 (#1303): the org's
+// pinned owner_tenant_id (migration 000046) is the authority on which
+// row in the per-tenant members list represents the owner. Falling
+// back to owner_id (user-id) only matters for legacy rows where
+// owner_tenant_id wasn't backfilled — in that case the old per-user
+// rule is still better than nothing.
+const isOwnerMember = (member: OrganizationMember): boolean => {
+  const ownerTenantID = orgInfo.value?.owner_tenant_id
+  if (ownerTenantID && ownerTenantID > 0) {
+    return member.tenant_id === ownerTenantID
+  }
+  return member.user_id === orgInfo.value?.owner_id
+}
 
 const inviteLink = computed(() => {
   if (!inviteCode.value) return ''

--- a/internal/handler/organization.go
+++ b/internal/handler/organization.go
@@ -1662,13 +1662,25 @@ func (h *OrganizationHandler) SetSharedAgentDisabledByMe(c *gin.Context) {
 // toOrgResponse converts an organization to response format
 func (h *OrganizationHandler) toOrgResponse(ctx context.Context, org *types.Organization, currentUserID string) types.OrganizationResponse {
 	currentTenantID := types.MustTenantIDFromContext(ctx)
+	// Post-Plan-3 the canonical "is the caller the owner side?" check
+	// is tenant-based: org.OwnerTenantID is the pinned column; legacy
+	// rows with OwnerTenantID == 0 (pre-000046, unlikely in prod)
+	// fall back to the user-id check so we don't show the wrong tenant
+	// as "owner" in those edge cases.
+	isOwner := false
+	if org.OwnerTenantID != 0 {
+		isOwner = org.OwnerTenantID == currentTenantID
+	} else {
+		isOwner = org.OwnerID == currentUserID
+	}
 	resp := types.OrganizationResponse{
 		ID:                     org.ID,
 		Name:                   org.Name,
 		Description:            org.Description,
 		Avatar:                 org.Avatar,
 		OwnerID:                org.OwnerID,
-		IsOwner:                org.OwnerID == currentUserID,
+		OwnerTenantID:          org.OwnerTenantID,
+		IsOwner:                isOwner,
 		RequireApproval:        org.RequireApproval,
 		Searchable:             org.Searchable,
 		MemberLimit:            org.MemberLimit,

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -803,35 +803,47 @@ func RegisterOrganizationRoutes(r *gin.RouterGroup, orgHandler *handler.Organiza
 		orgs.POST("/join-by-id", g.Admin(), orgHandler.JoinByOrganizationID)
 		// Get organization by ID
 		orgs.GET("/:id", orgHandler.GetOrganization)
-		// Update organization
-		orgs.PUT("/:id", orgHandler.UpdateOrganization)
-		// Delete organization
-		orgs.DELETE("/:id", orgHandler.DeleteOrganization)
+		// Update organization — Admin+ in caller's tenant.
+		// Service still gates on "caller's tenant is the org owner";
+		// the route guard adds a defence-in-depth layer that stops a
+		// tenant Viewer/Contributor from ever reaching the service.
+		orgs.PUT("/:id", g.Admin(), orgHandler.UpdateOrganization)
+		// Delete organization — Admin+ in caller's tenant. Same
+		// rationale as PUT above; deletion is irreversible so the
+		// route-layer floor is at least as strict.
+		orgs.DELETE("/:id", g.Admin(), orgHandler.DeleteOrganization)
 		// Leave organization (Admin+ in caller's tenant only)
 		orgs.POST("/:id/leave", g.Admin(), orgHandler.LeaveOrganization)
 		// Request role upgrade (Admin+ in caller's tenant only).
 		// An upgrade approval changes the whole tenant's org role, so it
 		// must not be initiated by a tenant Viewer/Contributor.
 		orgs.POST("/:id/request-upgrade", g.Admin(), orgHandler.RequestRoleUpgrade)
-		// Generate invite code
-		orgs.POST("/:id/invite-code", orgHandler.GenerateInviteCode)
+		// Generate invite code — Admin+ in caller's tenant. Issuing an
+		// invite code is an admin action; the service layer additionally
+		// requires the caller's tenant to be admin in the org.
+		orgs.POST("/:id/invite-code", g.Admin(), orgHandler.GenerateInviteCode)
 		// Search users for invite (admin only)
-		orgs.GET("/:id/search-users", orgHandler.SearchUsersForInvite)
+		orgs.GET("/:id/search-users", g.Admin(), orgHandler.SearchUsersForInvite)
 		// Invite member directly (admin only)
-		orgs.POST("/:id/invite", orgHandler.InviteMember)
+		orgs.POST("/:id/invite", g.Admin(), orgHandler.InviteMember)
 		// List members
 		orgs.GET("/:id/members", orgHandler.ListMembers)
-		// Update member role (path parameter is the member tenant_id)
-		orgs.PUT("/:id/members/:tenant_id", orgHandler.UpdateMemberRole)
+		// Update member role (path parameter is the member tenant_id) —
+		// Admin+ in caller's tenant. Changing another tenant's org role
+		// is the symmetric counterpart of removing them; both must be
+		// gated the same way.
+		orgs.PUT("/:id/members/:tenant_id", g.Admin(), orgHandler.UpdateMemberRole)
 		// Remove member (path parameter is the member tenant_id).
 		// Both self-removal (caller's own tenant) and admin-removal-of-other
 		// take a whole tenant out of the org, so the route must be Admin+
 		// in the caller's tenant — symmetric with POST /:id/leave above.
 		orgs.DELETE("/:id/members/:tenant_id", g.Admin(), orgHandler.RemoveMember)
-		// List join requests (admin only)
-		orgs.GET("/:id/join-requests", orgHandler.ListJoinRequests)
+		// List join requests (admin only) — caller's tenant must be at
+		// least Admin to even see the queue (a tenant Viewer has no
+		// authority to act on it).
+		orgs.GET("/:id/join-requests", g.Admin(), orgHandler.ListJoinRequests)
 		// Review join request (admin only)
-		orgs.PUT("/:id/join-requests/:request_id/review", orgHandler.ReviewJoinRequest)
+		orgs.PUT("/:id/join-requests/:request_id/review", g.Admin(), orgHandler.ReviewJoinRequest)
 		// List knowledge bases shared to this organization
 		orgs.GET("/:id/shares", orgHandler.ListOrgShares)
 		// List agents shared to this organization

--- a/internal/types/organization.go
+++ b/internal/types/organization.go
@@ -382,11 +382,17 @@ type UpdateSharePermissionRequest struct {
 
 // OrganizationResponse represents an organization in API responses
 type OrganizationResponse struct {
-	ID                      string     `json:"id"`
-	Name                    string     `json:"name"`
-	Description             string     `json:"description"`
-	Avatar                  string     `json:"avatar,omitempty"`
-	OwnerID                 string     `json:"owner_id"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Avatar      string `json:"avatar,omitempty"`
+	OwnerID     string `json:"owner_id"`
+	// OwnerTenantID is the persisted owner tenant of the organization
+	// (Plan 3, migration 000046). Frontend uses this to identify the
+	// "owner row" in the tenant-keyed members list — comparing
+	// member.tenant_id against owner_tenant_id is the post-Plan-3
+	// equivalent of the old member.user_id == owner_id check.
+	OwnerTenantID           uint64     `json:"owner_tenant_id"`
 	InviteCode              string     `json:"invite_code,omitempty"`
 	InviteCodeExpiresAt     *time.Time `json:"invite_code_expires_at,omitempty"`
 	InviteCodeValidityDays  int        `json:"invite_code_validity_days"`
@@ -395,7 +401,7 @@ type OrganizationResponse struct {
 	MemberLimit             int        `json:"member_limit"` // 0 = unlimited
 	MemberCount             int        `json:"member_count"`
 	ShareCount              int        `json:"share_count"`                // 共享到该组织的知识库数量
-	AgentShareCount         int        `json:"agent_share_count"`        // 共享到该组织的智能体数量
+	AgentShareCount         int        `json:"agent_share_count"`          // 共享到该组织的智能体数量
 	PendingJoinRequestCount int        `json:"pending_join_request_count"` // 待审批加入申请数（仅管理员可见）
 	IsOwner                 bool       `json:"is_owner"`
 	MyRole                  string     `json:"my_role,omitempty"`


### PR DESCRIPTION
## Summary

Two follow-ups that came out of reviewing the four `feat/rbac` org commits (Plan 3 #1303 + e1deb810 / 0b71e86f / 40fdb978).

- **Route layer:** add `g.Admin()` to the remaining org mutating endpoints. Plan 3 already gates `POST /organizations`, `/join`, `/join-request`, `/join-by-id`, `/:id/leave`, `/:id/request-upgrade`, and `e1deb810` added it to `DELETE /:id/members/:tenant_id`. The rest still relied solely on the service-layer "is the caller's tenant admin in this org?" check, with no route-level floor — a tenant Viewer/Contributor could reach those handlers and get a 403 only at the service layer. Closed routes:
  - `PUT /organizations/:id`
  - `DELETE /organizations/:id`
  - `POST /organizations/:id/invite-code`
  - `GET /organizations/:id/search-users`
  - `POST /organizations/:id/invite`
  - `PUT /organizations/:id/members/:tenant_id`
  - `GET /organizations/:id/join-requests`
  - `PUT /organizations/:id/join-requests/:request_id/review`
- **UI layer:** `OrganizationSettingsModal` was still deciding "which member row is the owner" by `member.user_id === orgInfo.owner_id`. Plan 3 lifted membership from per-user to per-tenant, and migration 000046 (40fdb978) pinned `organizations.owner_tenant_id` as the source of truth. Surface that column in `OrganizationResponse`, expose it in the frontend `Organization` type, and switch the owner-row check to a tenant-keyed `isOwnerMember(member)` helper (with a user-id fallback for legacy rows where `owner_tenant_id == 0`). The role select, "(owner)" suffix, and remove button now all gate on tenant. The "is-me" / me-tag still uses `user_id` because that one really is a per-user marker.

Behaviour with `EnableRBAC=false` is unchanged: `RequireRole` continues to log-and-pass.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/handler/... ./internal/router/... ./internal/middleware/...`
- [ ] Manual: as a tenant Viewer, hit each newly-gated route and confirm 403 (with `EnableRBAC=true`)
- [ ] Manual: with the owner user moved to another tenant, confirm the modal still tags the original tenant row as owner and hides the role-select / remove button on it
- [ ] Manual: confirm the "(me)" tag and `is-me` styling still appear on the signed-in user's row regardless of which tenant they're in