### PR TITLE
feat(cli): v0.5 — agent CRUD + chunk subtree + audit-driven cleanup

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -28,7 +28,7 @@ Key packages:
 - `internal/secrets/` — `Store` interface; `KeyringStore` primary, `FileStore` 0600 fallback, `MemStore` for tests
 - `internal/prompt/` — `TTYPrompter` (huh-based, password no-echo) + `AgentPrompter` (non-TTY no-prompt sentinel)
 - `internal/sse/` — `Accumulator` for chat / agent invoke SSE streams
-- `internal/mcp/` — curated stdio MCP server (wired by `cmd/mcp/serve.go`)
+- `internal/mcp/` — curated 10-tool stdio MCP server (wired by `cmd/mcp/serve.go`); see [MCP tool surface](#mcp-tool-surface) for the curation rationale and inventory
 - `client/` (parent module) — generated SDK
 
 ## Command Structure
@@ -164,4 +164,25 @@ Typed error helpers in `internal/cmdutil/errors.go`:
 Errors print to STDERR via `cmdutil.PrintError(w, err)` as `code: msg\nhint: ...`. STDOUT stays bare JSON or empty on failure, so `--json | jq` pipelines never have to filter error shapes.
 
 User-facing exit-code mapping lives in [README.md "Exit codes"](README.md#exit-codes). When adding a new `ErrorCode` constant, also append to `AllCodes()` so the acceptance contract picks it up.
+
+## MCP Tool Surface
+
+WeKnora's MCP server exposes a curated read-only tool surface. Many MCP servers in the wild ship write / mutation operations on by default and rely on credential-scope or sandbox restrictions for safety. WeKnora opts for curation instead: the server side doesn't yet enforce per-token scope, so an agent holding a user's token has full write access. Until server-side scope ships, the CLI keeps mutation tools out of the MCP surface as a belt-and-braces second line of defense. When server scope arrives this stance can loosen.
+
+The curated 10 tools (`cli/internal/mcp/tools.go`):
+
+| Tool | Purpose |
+| --- | --- |
+| `kb_list` | list knowledge bases |
+| `kb_view` | fetch a knowledge base by id |
+| `doc_list` | list documents in a kb (paginated, status-filterable) |
+| `doc_view` | fetch a document by id |
+| `doc_download` | download raw bytes (1 MiB cap, base64 for binary) |
+| `chunk_list` | list chunks of a document for RAG retrieval debug |
+| `search_chunks` | hybrid (vector + keyword) retrieval |
+| `chat` | stream a RAG answer; auto-creates a session if absent |
+| `agent_list` | list custom agents |
+| `agent_invoke` | run a query through a custom agent |
+
+Adding a tool is a deliberate API expansion — the agent-callable surface is the reason this CLI ships an MCP server, not its CLI command list, so the registration list in `registerTools` is maintained by hand.
 

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -26,7 +26,7 @@ Key packages:
 - `internal/format/` — bare JSON emitter (`WriteJSON` / `WriteJSONFiltered`)
 - `internal/iostreams/` — global IO singleton + TTY detection + `SetForTest` swap
 - `internal/secrets/` — `Store` interface; `KeyringStore` primary, `FileStore` 0600 fallback, `MemStore` for tests
-- `internal/prompt/` — `TTYPrompter` (huh-based, password no-echo) + `AgentPrompter` (non-TTY no-prompt sentinel)
+- `internal/prompt/` — `TTYPrompter` (password no-echo) + `AgentPrompter` (non-TTY no-prompt sentinel)
 - `internal/sse/` — `Accumulator` for chat / agent invoke SSE streams
 - `internal/mcp/` — curated 10-tool stdio MCP server (wired by `cmd/mcp/serve.go`); see [MCP tool surface](#mcp-tool-surface) for the curation rationale and inventory
 - `client/` (parent module) — generated SDK
@@ -195,21 +195,24 @@ Before specifying any CLI command, do this in order:
 3. For each field, decide: hot-path flag / config-file only / hidden / never-expose.
 4. Cross-check pagination signatures: an SDK `(ctx, id, page, pageSize)` shape demands `--limit` + `--all-pages` + `--page-size` on the CLI side.
 5. ONLY THEN consult mainstream CLI conventions to choose flag names, positionals, mutex, and confirm semantics.
+6. Decide which fields are "top use case" (flag) / "advanced" (`--config-file` or escape hatch via `weknora api`). Don't try to flag-cover every SDK field — mature CLIs that curate ship a tighter surface; CLIs that 1:1 mirror their API pay the UX cost.
 
 Rationale: earlier drafts produced three categories of schema errors — fields that didn't exist on the underlying SDK, wrong field counts in user-facing docs, and missing pagination flags — that all stemmed from "design from convention, not from SDK." The fix is canonical: the SDK schema is the ground truth; convention decides names and shapes around that ground truth.
 
 ## CRUD command flag canon
 
-v0.5+ follows **Mode A: hard-required + immediate flag error** for CRUD commands, not Mode B: TTY-prompts-fill (used by `auth login` only). Mode A is the standard pattern for scripted / agent-friendly CLI usage.
+CRUD commands follow the **hard-required-flags** pattern: every required input is a flag or positional, and a missing one yields an immediate `input.invalid_argument` exit. The contrast is **TTY-prompts-fill**, where missing input opens an interactive prompt; that pattern is reserved for `auth login` (the one command where a human must be at the terminal).
+
+Required-input idioms in this codebase:
 
 - Positional required: `cobra.ExactArgs(N)` or `cobra.MinimumNArgs(1)`
 - Flag required: `cmd.MarkFlagRequired("flag")`
 - Custom required (e.g., `agent edit` needs at-least-one-edit-flag): RunE-level validation that returns `input.invalid_argument`
 - Mutex: `cmd.MarkFlagsMutuallyExclusive("a", "b")`
 
-Reasons for Mode A:
+Reasons hard-required-flags is the v0.5+ default:
 
-- Admin/debug commands are not `auth login` — there is no human-interactive prompt to lean on.
+- Admin / debug commands have no natural human-interactive prompt to lean on.
 - Agent-friendly: MCP callers do not stall waiting for stdin prompts.
 - Consistent with every existing non-auth WeKnora command.
 

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -186,3 +186,30 @@ The curated 10 tools (`cli/internal/mcp/tools.go`):
 
 Adding a tool is a deliberate API expansion — the agent-callable surface is the reason this CLI ships an MCP server, not its CLI command list, so the registration list in `registerTools` is maintained by hand.
 
+## Command surface design SOP
+
+Before specifying any CLI command, do this in order:
+
+1. `grep -A 50 "type Foo struct" client/foo.go` — dump SDK request/response schemas.
+2. List every field with type and source line.
+3. For each field, decide: hot-path flag / config-file only / hidden / never-expose.
+4. Cross-check pagination signatures: an SDK `(ctx, id, page, pageSize)` shape demands `--limit` + `--all-pages` + `--page-size` on the CLI side.
+5. ONLY THEN consult mainstream CLI conventions to choose flag names, positionals, mutex, and confirm semantics.
+
+Rationale: earlier drafts produced three categories of schema errors — fields that didn't exist on the underlying SDK, wrong field counts in user-facing docs, and missing pagination flags — that all stemmed from "design from convention, not from SDK." The fix is canonical: the SDK schema is the ground truth; convention decides names and shapes around that ground truth.
+
+## CRUD command flag canon
+
+v0.5+ follows **Mode A: hard-required + immediate flag error** for CRUD commands, not Mode B: TTY-prompts-fill (used by `auth login` only). Mode A is the standard pattern for scripted / agent-friendly CLI usage.
+
+- Positional required: `cobra.ExactArgs(N)` or `cobra.MinimumNArgs(1)`
+- Flag required: `cmd.MarkFlagRequired("flag")`
+- Custom required (e.g., `agent edit` needs at-least-one-edit-flag): RunE-level validation that returns `input.invalid_argument`
+- Mutex: `cmd.MarkFlagsMutuallyExclusive("a", "b")`
+
+Reasons for Mode A:
+
+- Admin/debug commands are not `auth login` — there is no human-interactive prompt to lean on.
+- Agent-friendly: MCP callers do not stall waiting for stdin prompts.
+- Consistent with every existing non-auth WeKnora command.
+

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -27,6 +27,26 @@ CLI history before v0.3 is recorded in the project root
   fields (previously 7), grouped into 10 presentation sections.
 - `--all-pages` / `--page-size` on `search docs` and `search sessions`
   (catching up with `session list` / `doc list` canon from v0.3+v0.4).
+- `weknora doc list` gains `--keyword` / `--file-type` / `--source` /
+  `--tag-id` / `--start-time` / `--end-time` (RFC3339) — matches the
+  SDK's `KnowledgeListFilter` surface. Time flags reject malformed
+  input with `input.invalid_argument`.
+- MCP `doc_list` tool gains the same 5 filter fields (`keyword`,
+  `file_type`, `source`, `tag_id`, `start_time`, `end_time`) so agents
+  have parity with the CLI.
+- `weknora session view --full` (with `--limit`, default 50, bounds
+  1..1000) loads chat history via `LoadMessages` and renders messages
+  inline after session metadata. JSON mode projects messages into a
+  `messages` array. `--limit` without `--full` errors with
+  `input.invalid_argument`.
+- `weknora kb view` human render now includes `TYPE`, `PINNED` (badge,
+  only when set), `TEMPORARY` (badge), `PROCESSING` (with doc count,
+  only when active), `SUMMARY MODEL`, and `CREATED`. Nested config
+  structs stay JSON-only.
+- `weknora doc view` human render expands to include `TITLE` (when
+  distinct from filename), `DESC`, `SOURCE`, `CHANNEL`, `TAG`,
+  `STORAGE` (human-readable bytes), `SUMMARY`, `ENABLED`, and `HASH`
+  (12-char prefix). All omit-empty.
 
 #### Fixed
 - MCP `search_chunks` tool: `limit` arg now correctly threads into
@@ -42,6 +62,14 @@ CLI history before v0.3 is recorded in the project root
 - `cli/AGENTS.md` adds §"Command surface design SOP" and
   §"CRUD command flag canon" for v0.6+ contributors.
 - `cli/go.mod`: adds `gopkg.in/yaml.v3` for `agent create --config-file`.
+- `weknora search docs` now applies the keyword filter server-side via
+  `ListKnowledgeWithFilter` (was: page through every doc and substring-
+  match client-side). Smaller wire payload on large KBs. **Semantics
+  shift**: the match is now case-sensitive (server uses `LIKE %keyword%`),
+  whereas the previous client-side path lowered both sides. Callers that
+  relied on case-insensitive matching (e.g. `search docs Q3` finding
+  `q3 retro`) must lower-case the query, or fall back to `weknora api`
+  with a custom filter.
 
 ### v0.4 — output contract hardening and mainstream alignment
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -12,6 +12,37 @@ CLI history before v0.3 is recorded in the project root
 
 ## [Unreleased]
 
+### v0.5 — agent CRUD, chunk subtree, MCP chunk_list, audit-driven cleanup
+
+#### Added
+- `weknora agent create <name> --model <id>` / `agent edit <id>` /
+  `agent delete <id>` — hybrid surface (8 hot-path flags + `--config-file`
+  YAML/JSON tail + `--generate-skeleton` template emit). `--from <agent-id>`
+  copies from an existing agent.
+- `weknora chunk list --doc <doc-id>` / `chunk view <chunk-id>` /
+  `chunk delete <chunk-id> --doc <doc-id>` — new subtree for RAG retrieval
+  debug. Paginated with v0.4 `--limit` / `--page-size` / `--all-pages` canon.
+- `weknora mcp serve` adds `chunk_list` as the 10th curated tool.
+- `weknora agent view <id>` human output now renders all 34 AgentConfig
+  fields (previously 7), grouped into 10 presentation sections.
+- `--all-pages` / `--page-size` on `search docs` and `search sessions`
+  (catching up with `session list` / `doc list` canon from v0.3+v0.4).
+
+#### Fixed
+- MCP `search_chunks` tool: `limit` arg now correctly threads into
+  `SearchParams.MatchCount`. Previously the server's default cap won,
+  silently capping below the requested limit.
+- `search sessions` human time format: now uses `fuzzyTime` like
+  `session list` instead of raw RFC3339.
+
+#### Changed
+- `cli/AGENTS.md` MCP curation rationale rewritten: curated read-only
+  is a deliberate product call gated on server-side token scope, not
+  MCP industry canon.
+- `cli/AGENTS.md` adds §"Command surface design SOP" and
+  §"CRUD command flag canon" for v0.6+ contributors.
+- `cli/go.mod`: adds `gopkg.in/yaml.v3` for `agent create --config-file`.
+
 ### v0.4 — output contract hardening and mainstream alignment
 
 #### Breaking changes

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -16,9 +16,10 @@ CLI history before v0.3 is recorded in the project root
 
 #### Added
 - `weknora agent create <name> --model <id>` / `agent edit <id>` /
-  `agent delete <id>` — hybrid surface (8 hot-path flags + `--config-file`
-  YAML/JSON tail + `--generate-skeleton` template emit). `--from <agent-id>`
-  copies from an existing agent.
+  `agent delete <id>` — hybrid surface (hot-path flags for the common
+  fields + `--config-file` YAML/JSON for the long tail +
+  `--generate-skeleton` template emit). `--from <agent-id>` copies
+  from an existing agent.
 - `weknora chunk list --doc <doc-id>` / `chunk view <chunk-id>` /
   `chunk delete <chunk-id> --doc <doc-id>` — new subtree for RAG retrieval
   debug. Paginated with v0.4 `--limit` / `--page-size` / `--all-pages` canon.
@@ -31,7 +32,7 @@ CLI history before v0.3 is recorded in the project root
   `--tag-id` / `--start-time` / `--end-time` (RFC3339) — matches the
   SDK's `KnowledgeListFilter` surface. Time flags reject malformed
   input with `input.invalid_argument`.
-- MCP `doc_list` tool gains the same 5 filter fields (`keyword`,
+- MCP `doc_list` tool gains the same 6 filter fields (`keyword`,
   `file_type`, `source`, `tag_id`, `start_time`, `end_time`) so agents
   have parity with the CLI.
 - `weknora session view --full` (with `--limit`, default 50, bounds
@@ -47,29 +48,57 @@ CLI history before v0.3 is recorded in the project root
   distinct from filename), `DESC`, `SOURCE`, `CHANNEL`, `TAG`,
   `STORAGE` (human-readable bytes), `SUMMARY`, `ENABLED`, and `HASH`
   (12-char prefix). All omit-empty.
+- `weknora doc upload` gains `--enable-multimodel` (tri-state:
+  unset/true/false), repeatable `--metadata key=value`, and
+  `--channel` flags. `--enable-multimodel` and `--channel` apply to
+  file / `--recursive` / `--from-url`; `--metadata` is file /
+  `--recursive` only (the URL-ingest request carries no metadata
+  field server-side, so passing it with `--from-url` is rejected
+  up-front as `input.invalid_argument`). URL mode additionally
+  accepts `--title`, `--file-type`, and `--tag-id`. Threads through
+  to the SDK's `CreateKnowledgeFromFile` / `CreateKnowledgeFromURL`
+  signatures (previously hardcoded to nil/"api" and dropped URL
+  extras).
 
 #### Fixed
 - MCP `search_chunks` tool: `limit` arg now correctly threads into
   `SearchParams.MatchCount`. Previously the server's default cap won,
   silently capping below the requested limit.
-- `search sessions` human time format: now uses `fuzzyTime` like
-  `session list` instead of raw RFC3339.
+- `search sessions` human time format: now renders a relative
+  duration ("2 hours ago") matching `session list`, instead of raw
+  RFC3339.
+- `doc upload` (file path): re-uploading a file already ingested into
+  the KB now surfaces as `resource.already_exists` (exit 1) instead of
+  the misleading `network.error` ("check base URL reachability"). The
+  SDK returns its `ErrDuplicateFile` sentinel with no `HTTP error <n>:`
+  prefix because the duplicate is detected via file-hash short-circuit,
+  not by HTTP status; the previous fall-through to `WrapHTTP` therefore
+  misclassified it. The `--from-url` branch already handled the
+  symmetric `ErrDuplicateURL` correctly.
+
+#### Breaking changes
+- `weknora search docs` now applies the keyword filter server-side via
+  `ListKnowledgeWithFilter` (was: page through every doc and
+  substring-match client-side). Smaller wire payload on large KBs.
+  **The match is now case-sensitive** (server uses `LIKE %keyword%`),
+  whereas the previous client-side path lowered both sides. Callers
+  that relied on case-insensitive matching (e.g. `search docs Q3`
+  finding `q3 retro`) must lower-case the query themselves, or fall
+  back to `weknora api` with a custom filter.
 
 #### Changed
 - `cli/AGENTS.md` MCP curation rationale rewritten: curated read-only
-  is a deliberate product call gated on server-side token scope, not
-  MCP industry canon.
-- `cli/AGENTS.md` adds §"Command surface design SOP" and
-  §"CRUD command flag canon" for v0.6+ contributors.
-- `cli/go.mod`: adds `gopkg.in/yaml.v3` for `agent create --config-file`.
-- `weknora search docs` now applies the keyword filter server-side via
-  `ListKnowledgeWithFilter` (was: page through every doc and substring-
-  match client-side). Smaller wire payload on large KBs. **Semantics
-  shift**: the match is now case-sensitive (server uses `LIKE %keyword%`),
-  whereas the previous client-side path lowered both sides. Callers that
-  relied on case-insensitive matching (e.g. `search docs Q3` finding
-  `q3 retro`) must lower-case the query, or fall back to `weknora api`
-  with a custom filter.
+  is a deliberate product call gated on the absence of server-side
+  per-token scope. When server-side scope ships, mutation tools can
+  land in the MCP surface.
+- `cli/AGENTS.md` adds "Command surface design SOP" and "CRUD command
+  flag canon" sections for future contributors. The design-SOP
+  section includes a step reminding contributors to decide
+  flag-vs-escape-hatch per field rather than trying to flag-mirror
+  every SDK capability.
+- `cli/README.md` now documents the `weknora api` raw HTTP passthrough
+  as the canonical escape hatch for deep KB config, per-request `chat`
+  / `agent invoke` overrides, and operations without a CLI verb.
 
 ### v0.4 — output contract hardening and mainstream alignment
 
@@ -82,10 +111,10 @@ CLI history before v0.3 is recorded in the project root
   non-TTY callers that omit `-y` exit with code 10 and
   `input.confirmation_required` so an agent must surface the prompt
   to a human before retrying.
-- Dropped the per-command AI footer that rendered when `CLAUDECODE`
-  or `CURSOR_AGENT` was set. The same machine-readable guidance now
-  lives in the standard `--help` (visible to all callers) and in
-  `mcp serve`'s tool descriptions.
+- Dropped the per-command AI footer that rendered when AI-coding-agent
+  env detection fired. The same machine-readable guidance now lives in
+  the standard `--help` (visible to all callers) and in `mcp serve`'s
+  tool descriptions.
 
 #### Added
 - `weknora mcp serve` — curated read-only stdio MCP server exposing 9
@@ -152,8 +181,7 @@ CLI history before v0.3 is recorded in the project root
   passthrough (file or stdin); mutually exclusive with `--data`.
 - `unlink` — remove the cwd's `.weknora/project.yaml` so subsequent
   commands stop auto-resolving `--kb` from it. Walks up from cwd so a
-  user in a subdirectory can unlink without cd-ing to the project root
-  (mirrors `vercel unlink` / `netlify unlink`).
+  user in a subdirectory can unlink without cd-ing to the project root.
 - Completion smoke test guards against cobra bumps silently breaking
   bash / zsh / fish / powershell completion.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -14,6 +14,7 @@ Available Commands:
   api         Make a raw API request to the WeKnora server
   auth        Manage authentication credentials and contexts
   chat        Ask a streaming RAG question against a knowledge base
+  chunk       Manage document chunks (RAG retrieval debug)
   completion  Generate the autocompletion script for the specified shell
   context     Manage CLI contexts (named connection targets)
   doc         Manage documents in a knowledge base
@@ -28,10 +29,9 @@ Available Commands:
   version     Show CLI build metadata
 ```
 
-The command surface mirrors `gh` CLI's `<noun> <verb>` convention. The
-wire contract for AI agents (Claude Code, Cursor, Aider, …) is documented
-[below](#wire-contract). For contributing to the CLI source, see
-[AGENTS.md](AGENTS.md).
+The command surface follows a `<noun> <verb>` convention. The wire
+contract for AI agents is documented [below](#wire-contract). For
+contributing to the CLI source, see [AGENTS.md](AGENTS.md).
 
 ---
 
@@ -78,6 +78,13 @@ weknora search chunks "what is reciprocal rank fusion?"
 
 # 7. Ask the LLM (streams to terminal)
 weknora chat "summarise the design doc"
+
+# 8. Manage custom agents (full hybrid surface: see `weknora agent --help`)
+weknora agent list
+weknora agent invoke ag_abc "what's our q4 retention plan?"
+
+# 9. Inspect a document's chunks for RAG retrieval debug
+weknora chunk list --doc doc_xyz
 ```
 
 ---
@@ -179,9 +186,9 @@ The full code registry is in `cli/internal/cmdutil/errors.go`
 **Exit 10** is the wire-level signal for "destructive write needs
 explicit confirmation". Pass `-y/--yes` on `kb delete` / `kb empty` /
 `doc delete` / `session delete` / `context remove` (on the current
-context) when running headless. **Never auto-add `-y` without the
-user's explicit go-ahead** — exit 10 is the guard against unintended
-writes.
+context) / `agent delete` / `chunk delete` when running headless.
+**Never auto-add `-y` without the user's explicit go-ahead** — exit 10
+is the guard against unintended writes.
 
 ### Other agent ergonomics
 
@@ -189,8 +196,32 @@ writes.
   — streaming tokens to stdout makes JSON parsing impossible.
 - `--json` composes with the global `--context <name>` for single-shot
   context overrides without disk writes.
-- `weknora mcp serve` exposes a curated readonly tool surface over
-  stdio MCP for Claude Desktop / Code / custom MCP clients.
+- `weknora mcp serve` exposes a curated read-only tool surface over
+  stdio MCP for any MCP-compatible client.
+
+---
+
+## Advanced operations not exposed as flags
+
+WeKnora CLI exposes top use cases as polished commands; deep
+configuration goes through the raw HTTP passthrough. CLI flag coverage
+targets common workflows, not 1:1 API parity. Examples of deep
+operations that intentionally go through `weknora api`:
+
+- **Tuning a KB's nested config** — chunking strategy, summary model,
+  multimodal extraction defaults, FAQ thresholds, VLM model, storage
+  provider. Use `weknora api PUT /api/v1/knowledge-bases/<id> --input -`
+  with a JSON body matching the server's `UpdateKnowledgeBaseRequest`.
+- **Per-request `chat` parameters** — multi-KB scope, summary model
+  override, image attachments, web search toggle. Use `weknora api POST
+  /api/v1/knowledge-chat/<session-id> --input -`.
+- **Per-request `agent invoke` overrides** — same shape via
+  `weknora api POST /api/v1/agent-chat/<session-id> --input -`.
+- **Operations without a CLI verb** — register / change-password /
+  OIDC flows, organization / sharing endpoints, tenant management.
+
+`weknora api --help` documents the raw passthrough. Run
+`weknora doctor` first to verify auth and base URL.
 
 ---
 
@@ -218,6 +249,20 @@ go vet ./...
 
 CI (`.github/workflows/cli.yml`) runs build + unit + contract tests on Linux /
 macOS / Windows × Go 1.26, path-filtered to changes under `cli/`.
+
+---
+
+## Contributing / Reporting issues
+
+- **Bugs and feature requests**: file an issue at
+  [github.com/Tencent/WeKnora/issues](https://github.com/Tencent/WeKnora/issues).
+- **Security disclosures**: see the repository-level
+  [SECURITY.md](../SECURITY.md). Do not file public issues for
+  security findings.
+- **Pull requests**: the developer guide for editing the CLI lives in
+  [AGENTS.md](AGENTS.md) (build / test / command-surface design SOP /
+  CRUD flag canon). Run `go test ./... -race -count=1` and `go vet ./...`
+  before submitting.
 
 ---
 

--- a/cli/acceptance/contract/helpers_test.go
+++ b/cli/acceptance/contract/helpers_test.go
@@ -35,8 +35,6 @@ func TestMain(m *testing.M) {
 // update is the standard Go test golden-update flag.
 //
 //	go test -update ./acceptance/contract/...
-//
-// Mirrors gh / kubectl / golang-migrate convention.
 var update = flag.Bool("update", false, "update golden files")
 
 // newTestFactory builds a Factory whose Client returns mockClient.

--- a/cli/acceptance/contract/wire_test.go
+++ b/cli/acceptance/contract/wire_test.go
@@ -157,10 +157,10 @@ var wireCases = []wireCase{
 		wantStderrSubstring: "auth.unauthenticated",
 	},
 
-	// 11-13. search chunks - verb-noun shape (gh search parity), positional query, --kb required.
-	// --kb accepts either kb_<id> (passed through) or a name (resolved via
-	// list); UUID-format detection happens client-side, mirroring gcloud
-	// --project's id-or-name auto-detection.
+	// 11-13. search chunks - verb-noun shape, positional query, --kb required.
+	// --kb accepts either a kb_<id> (passed through) or a name (resolved via
+	// list); UUID-format detection happens client-side so callers can use
+	// either form interchangeably.
 	{
 		name:   "search.success",
 		args:   []string{"search", "chunks", "query", "--kb=11111111-1111-4111-8111-111111111111", "--limit=3", "--json"},

--- a/cli/acceptance/e2e/e2e_test.go
+++ b/cli/acceptance/e2e/e2e_test.go
@@ -4,8 +4,8 @@
 // server to validate the RAG closing loop end-to-end.
 //
 // Build tag isolation: //go:build acceptance_e2e excludes this file from
-// the default `go test ./...` (mirrors gh's acceptance/ build tag pattern;
-// see https://github.com/cli/cli/tree/trunk/acceptance). To run:
+// the default `go test ./...` so the e2e suite only runs when explicitly
+// requested. To run:
 //
 //	cd cli
 //	WEKNORA_E2E_HOST=https://kb.example.com \

--- a/cli/cmd/agent/agent.go
+++ b/cli/cmd/agent/agent.go
@@ -1,7 +1,7 @@
 // Package agentcmd holds the `weknora agent` command tree:
-// list / view / invoke. The directory is named `agent/` (matches cobra
-// noun-verb convention) but the Go package is `agentcmd` to avoid
-// colliding with cobra's *cobra.Command identifier.
+// list / view / invoke / create / edit / delete. The directory is named
+// `agent/` (matches cobra noun-verb convention) but the Go package is
+// `agentcmd` to avoid colliding with cobra's *cobra.Command identifier.
 //
 // "agent" in this subtree refers to WeKnora's user-defined Custom
 // Agents (server resource: GET/POST /agents/...). The CLI's
@@ -23,13 +23,16 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:   "agent",
 		Short: "Manage and invoke custom agents",
 		Long: `Custom Agents bundle a system prompt, model, tool allow-list, and KB
-scope into an addressable resource. List visible agents, view a single
-agent's configuration, or invoke an agent against a query.`,
+scope into an addressable resource. Create, edit, list, view, invoke,
+or delete agents.`,
 		Args: cobra.NoArgs,
 		Run:  func(c *cobra.Command, _ []string) { _ = c.Help() },
 	}
 	cmd.AddCommand(NewCmdList(f))
 	cmd.AddCommand(NewCmdView(f))
 	cmd.AddCommand(NewCmdInvoke(f))
+	cmd.AddCommand(NewCmdCreate(f))
+	cmd.AddCommand(NewCmdEdit(f))
+	cmd.AddCommand(NewCmdDelete(f))
 	return cmd
 }

--- a/cli/cmd/agent/create.go
+++ b/cli/cmd/agent/create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -58,11 +57,11 @@ type createFlagSet struct {
 	kbsSet             bool
 }
 
-const agentCreateExample = `  weknora agent create "Support Bot" --model gpt-4
-  weknora agent create "Code Reviewer" --model gpt-4 --system-prompt-file ./prompt.md --kb kb_eng --kb kb_arch
-  weknora agent create "From Template" --model gpt-4 --from ag_existing
+const agentCreateExample = `  weknora agent create "Support Bot" --model <model-id>
+  weknora agent create "Code Reviewer" --model <model-id> --system-prompt-file ./prompt.md --kb kb_eng --kb kb_arch
+  weknora agent create "From Template" --model <model-id> --from ag_existing
   weknora agent create --generate-skeleton > my-agent.yaml
-  weknora agent create "Tuned" --model gpt-4 --config-file ./my-agent.yaml`
+  weknora agent create "Tuned" --model <model-id> --config-file ./my-agent.yaml`
 
 const agentCreateLong = `Create a new custom agent.
 
@@ -114,17 +113,16 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			opts.flags.kbSelectionModeSet = cmd.Flags().Changed("kb-selection-mode")
 			opts.flags.kbsSet = cmd.Flags().Changed("kb")
 
-			// L-5 / §1.5.1: --temperature is bounded 0.0..2.0. Reject
-			// out-of-range early with a typed input.invalid_argument so
-			// users don't burn a roundtrip on a value the server would
-			// also reject.
+			// --temperature is bounded 0.0..2.0. Reject out-of-range
+			// early with a typed input.invalid_argument so users don't
+			// burn a roundtrip on a value the server would also reject.
 			if opts.flags.temperatureSet && (opts.Temperature < 0.0 || opts.Temperature > 2.0) {
 				return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
 					fmt.Sprintf("--temperature must be in 0.0..2.0, got %g", opts.Temperature))
 			}
 
 			if systemPromptFile != "" {
-				r, err := openInput(systemPromptFile)
+				r, err := cmdutil.OpenInput(systemPromptFile)
 				if err != nil {
 					return cmdutil.NewError(cmdutil.CodeInputInvalidArgument, fmt.Sprintf("--system-prompt-file: %v", err))
 				}
@@ -219,7 +217,7 @@ func runCreate(ctx context.Context, opts *CreateOptions, jopts *cmdutil.JSONOpti
 			base = *copied.Config
 		}
 
-		// --kb on --from REPLACES the copied KB list (per spec); when --kb
+		// --kb on --from REPLACES the copied KB list; when --kb
 		// is not set, KnowledgeBasesSet stays false inside applyCreateOverrides
 		// and the copy's KB list passes through unchanged.
 		cfg := applyCreateOverrides(&base, opts)
@@ -278,18 +276,10 @@ func applyCreateOverrides(base *sdk.AgentConfig, opts *CreateOptions) *sdk.Agent
 	return cfg
 }
 
-// openInput returns a Reader for path; "-" means the global stdin.
-func openInput(path string) (io.Reader, error) {
-	if path == "-" {
-		return iostreams.IO.In, nil
-	}
-	return os.Open(path)
-}
-
 // openConfigFile returns a Reader, the detected kind ("yaml"/"json"), or
 // an error. Format is inferred from file extension; "-" defaults to YAML.
 func openConfigFile(path string) (io.Reader, string, error) {
-	r, err := openInput(path)
+	r, err := cmdutil.OpenInput(path)
 	if err != nil {
 		return nil, "", err
 	}

--- a/cli/cmd/agent/create.go
+++ b/cli/cmd/agent/create.go
@@ -1,0 +1,312 @@
+package agentcmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
+	"github.com/Tencent/WeKnora/cli/internal/iostreams"
+	sdk "github.com/Tencent/WeKnora/client"
+)
+
+// CreateService is the narrow SDK surface this command depends on.
+// *sdk.Client satisfies it via duck typing.
+type CreateService interface {
+	CreateAgent(ctx context.Context, req *sdk.CreateAgentRequest) (*sdk.Agent, error)
+	CopyAgent(ctx context.Context, id string) (*sdk.Agent, error)
+	UpdateAgent(ctx context.Context, id string, req *sdk.UpdateAgentRequest) (*sdk.Agent, error)
+}
+
+// CreateOptions captures flag state. SystemPromptReader and ConfigFileBody
+// are populated from --system-prompt-file and --config-file respectively
+// (or stdin when the value is "-"). The embedded flags struct tracks "was
+// set" bits so MergeAgentConfig can distinguish "user passed --foo zero"
+// from "user did not pass --foo".
+type CreateOptions struct {
+	Name               string
+	Model              string
+	Description        string
+	SystemPrompt       string
+	SystemPromptReader io.Reader
+	AgentMode          string
+	KBs                []string
+	KBSelectionMode    string
+	RerankModel        string
+	Temperature        float64
+	From               string
+	ConfigFileBody     io.Reader
+	ConfigFileKind     string // "yaml" or "json"
+	GenerateSkeleton   bool
+
+	flags createFlagSet // populated in PreRunE for *Set bits
+}
+
+// createFlagSet records which hot-path flags the user explicitly passed so
+// MergeAgentConfig knows which fields to overlay onto the base config.
+type createFlagSet struct {
+	agentModeSet       bool
+	systemPromptSet    bool
+	rerankModelSet     bool
+	temperatureSet     bool
+	kbSelectionModeSet bool
+	kbsSet             bool
+}
+
+const agentCreateExample = `  weknora agent create "Support Bot" --model gpt-4
+  weknora agent create "Code Reviewer" --model gpt-4 --system-prompt-file ./prompt.md --kb kb_eng --kb kb_arch
+  weknora agent create "From Template" --model gpt-4 --from ag_existing
+  weknora agent create --generate-skeleton > my-agent.yaml
+  weknora agent create "Tuned" --model gpt-4 --config-file ./my-agent.yaml`
+
+const agentCreateLong = `Create a new custom agent.
+
+--model is required (an agent without a model cannot invoke). The 7
+optional hot-path flags cover the most frequently set AgentConfig fields;
+for the remaining 27 use --config-file with a YAML or JSON document
+matching the AgentConfig schema (run --generate-skeleton to get a
+ready-to-edit template).
+
+Precedence when both a config file and hot-path flags are supplied:
+  hot-path flag > config-file value > server default
+
+--from <id> copies an existing agent (SDK CopyAgent) then applies any
+hot-path overrides via UpdateAgent. --kb on --from REPLACES the copied
+agent's KB list (not merge) — matches surgical-flag semantics.
+
+AI agents: writes a new resource server-side. Failure surfaces as a
+typed code on stderr: input.invalid_argument (bad flags, bad file, or
+bad model), resource.not_found (--from <missing>), auth.unauthenticated.`
+
+// NewCmdCreate builds `weknora agent create <name> --model <id>`.
+func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
+	opts := &CreateOptions{}
+	var systemPromptFile, configFile string
+
+	cmd := &cobra.Command{
+		Use:     "create <name>",
+		Short:   "Create a new custom agent",
+		Long:    agentCreateLong,
+		Example: agentCreateExample,
+		// Allow 0 args for --generate-skeleton; PreRunE enforces the real
+		// arity rule once it knows whether skeleton mode is active.
+		Args: cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if opts.GenerateSkeleton {
+				return nil
+			}
+			if len(args) != 1 {
+				return cmdutil.NewFlagError(fmt.Errorf("accepts 1 arg, received %d", len(args)))
+			}
+			opts.Name = args[0]
+			if opts.Model == "" {
+				return cmdutil.NewFlagError(fmt.Errorf(`required flag(s) "model" not set`))
+			}
+			opts.flags.agentModeSet = cmd.Flags().Changed("agent-mode")
+			opts.flags.systemPromptSet = cmd.Flags().Changed("system-prompt") || cmd.Flags().Changed("system-prompt-file")
+			opts.flags.rerankModelSet = cmd.Flags().Changed("rerank-model")
+			opts.flags.temperatureSet = cmd.Flags().Changed("temperature")
+			opts.flags.kbSelectionModeSet = cmd.Flags().Changed("kb-selection-mode")
+			opts.flags.kbsSet = cmd.Flags().Changed("kb")
+
+			// L-5 / §1.5.1: --temperature is bounded 0.0..2.0. Reject
+			// out-of-range early with a typed input.invalid_argument so
+			// users don't burn a roundtrip on a value the server would
+			// also reject.
+			if opts.flags.temperatureSet && (opts.Temperature < 0.0 || opts.Temperature > 2.0) {
+				return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
+					fmt.Sprintf("--temperature must be in 0.0..2.0, got %g", opts.Temperature))
+			}
+
+			if systemPromptFile != "" {
+				r, err := openInput(systemPromptFile)
+				if err != nil {
+					return cmdutil.NewError(cmdutil.CodeInputInvalidArgument, fmt.Sprintf("--system-prompt-file: %v", err))
+				}
+				opts.SystemPromptReader = r
+			}
+			if configFile != "" {
+				r, kind, err := openConfigFile(configFile)
+				if err != nil {
+					return cmdutil.NewError(cmdutil.CodeInputInvalidArgument, fmt.Sprintf("--config-file: %v", err))
+				}
+				opts.ConfigFileBody = r
+				opts.ConfigFileKind = kind
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			jopts, err := cmdutil.CheckJSONFlags(cmd)
+			if err != nil {
+				return err
+			}
+			cli, err := f.Client()
+			if err != nil {
+				return err
+			}
+			return runCreate(cmd.Context(), opts, jopts, cli)
+		},
+	}
+
+	// Required (enforced in PreRunE rather than cmd.MarkFlagRequired so
+	// --generate-skeleton can bypass it — cobra's MarkFlagRequired runs
+	// before PreRunE and would otherwise block the skeleton path).
+	cmd.Flags().StringVar(&opts.Model, "model", "", "LLM model id (required, except with --generate-skeleton)")
+
+	// Hot-path (8 flag names, 7 distinct config fields)
+	cmd.Flags().StringVar(&opts.Description, "description", "", "Agent description")
+	cmd.Flags().StringVar(&opts.SystemPrompt, "system-prompt", "", "System prompt text (mutex with --system-prompt-file)")
+	cmd.Flags().StringVar(&systemPromptFile, "system-prompt-file", "", "Read system prompt from FILE, or '-' for stdin")
+	cmd.MarkFlagsMutuallyExclusive("system-prompt", "system-prompt-file")
+	cmd.Flags().StringVar(&opts.AgentMode, "agent-mode", "", "Agent operating mode: quick-answer | smart-reasoning")
+	cmd.Flags().StringSliceVar(&opts.KBs, "kb", nil, "Attach knowledge base id (repeatable)")
+	cmd.Flags().StringVar(&opts.KBSelectionMode, "kb-selection-mode", "", "KB selection mode: all | selected | none")
+	cmd.Flags().StringVar(&opts.RerankModel, "rerank-model", "", "Rerank model id")
+	cmd.Flags().Float64Var(&opts.Temperature, "temperature", 0.0, "Generation temperature (0.0..2.0)")
+
+	// Power-user / utility
+	cmd.Flags().StringVar(&opts.From, "from", "", "Copy from existing agent id (then apply other flags)")
+	cmd.Flags().StringVar(&configFile, "config-file", "", "Full AgentConfig YAML or JSON (use '-' for stdin)")
+	cmd.Flags().BoolVar(&opts.GenerateSkeleton, "generate-skeleton", false, "Emit blank AgentConfig YAML to stdout and exit")
+
+	cmdutil.AddJSONFlags(cmd, agentViewFields)
+	return cmd
+}
+
+func runCreate(ctx context.Context, opts *CreateOptions, jopts *cmdutil.JSONOptions, svc CreateService) error {
+	if opts.GenerateSkeleton {
+		return cmdutil.GenerateAgentSkeleton(iostreams.IO.Out)
+	}
+
+	// 1. Build base AgentConfig from --config-file (if any), else zero.
+	// (For --from, the copied agent's existing config becomes the base
+	// instead — set after CopyAgent below, before MergeAgentConfig.)
+	var base sdk.AgentConfig
+	if opts.ConfigFileBody != nil {
+		parsed, err := cmdutil.LoadAgentConfig(opts.ConfigFileBody, opts.ConfigFileKind)
+		if err != nil {
+			return cmdutil.NewError(cmdutil.CodeInputInvalidArgument, err.Error())
+		}
+		base = *parsed
+	}
+
+	// 2. Resolve system prompt (file/stdin > flag string)
+	if opts.SystemPromptReader != nil {
+		body, err := io.ReadAll(opts.SystemPromptReader)
+		if err != nil {
+			return cmdutil.NewError(cmdutil.CodeInputInvalidArgument, fmt.Sprintf("--system-prompt-file read: %v", err))
+		}
+		opts.SystemPrompt = strings.TrimSpace(string(body))
+	}
+
+	// 3. Either copy-then-update, or create from scratch. For --from we
+	// must seed `base` from the copied agent's existing config FIRST so
+	// MergeAgentConfig preserves source fields the user did not override
+	// (e.g. SystemPrompt, AgentMode, KB list). Without this seeding the
+	// surgical overrides would ship UpdateAgent with the other 33 fields
+	// zeroed, clobbering source state.
+	if opts.From != "" {
+		copied, err := svc.CopyAgent(ctx, opts.From)
+		if err != nil {
+			return cmdutil.WrapHTTP(err, "copy agent %s", opts.From)
+		}
+		if copied.Config != nil {
+			base = *copied.Config
+		}
+
+		// --kb on --from REPLACES the copied KB list (per spec); when --kb
+		// is not set, KnowledgeBasesSet stays false inside applyCreateOverrides
+		// and the copy's KB list passes through unchanged.
+		cfg := applyCreateOverrides(&base, opts)
+
+		// Apply overrides on top of copied state via UpdateAgent (no
+		// server-side template-parameters route, so we do two roundtrips).
+		updateReq := &sdk.UpdateAgentRequest{
+			Name:        opts.Name,
+			Description: opts.Description,
+			Config:      cfg,
+		}
+		updated, err := svc.UpdateAgent(ctx, copied.ID, updateReq)
+		if err != nil {
+			return cmdutil.WrapHTTP(err, "update copied agent %s", copied.ID)
+		}
+		return emitAgent(jopts, updated)
+	}
+
+	// 4. Plain create path: apply hot-path flag overrides onto base
+	// (zero-valued unless --config-file supplied content).
+	cfg := applyCreateOverrides(&base, opts)
+
+	req := &sdk.CreateAgentRequest{
+		Name:        opts.Name,
+		Description: opts.Description,
+		Config:      cfg,
+	}
+	created, err := svc.CreateAgent(ctx, req)
+	if err != nil {
+		return cmdutil.WrapHTTP(err, "create agent")
+	}
+	return emitAgent(jopts, created)
+}
+
+// applyCreateOverrides merges hot-path flag overrides into the base config,
+// then applies the "--kb implies --kb-selection-mode=selected" fallback.
+// Shared by the --from path (base=copied agent's config) and the plain
+// create path (base=zero or --config-file). Keeping both paths on one
+// helper prevents silent divergence when future flags are added.
+func applyCreateOverrides(base *sdk.AgentConfig, opts *CreateOptions) *sdk.AgentConfig {
+	overrides := cmdutil.AgentConfigFlags{
+		AgentMode: opts.AgentMode, AgentModeSet: opts.flags.agentModeSet,
+		SystemPrompt: opts.SystemPrompt, SystemPromptSet: opts.flags.systemPromptSet,
+		ModelID: opts.Model, ModelIDSet: true, // --model is required
+		RerankModelID: opts.RerankModel, RerankModelIDSet: opts.flags.rerankModelSet,
+		Temperature: opts.Temperature, TemperatureSet: opts.flags.temperatureSet,
+		KBSelectionMode: opts.KBSelectionMode, KBSelectionModeSet: opts.flags.kbSelectionModeSet,
+		KnowledgeBases: opts.KBs, KnowledgeBasesSet: opts.flags.kbsSet,
+	}
+	cfg := cmdutil.MergeAgentConfig(base, overrides)
+
+	// --kb without explicit --kb-selection-mode implies "selected".
+	if opts.flags.kbsSet && !opts.flags.kbSelectionModeSet && cfg.KBSelectionMode == "" {
+		cfg.KBSelectionMode = "selected"
+	}
+	return cfg
+}
+
+// openInput returns a Reader for path; "-" means the global stdin.
+func openInput(path string) (io.Reader, error) {
+	if path == "-" {
+		return iostreams.IO.In, nil
+	}
+	return os.Open(path)
+}
+
+// openConfigFile returns a Reader, the detected kind ("yaml"/"json"), or
+// an error. Format is inferred from file extension; "-" defaults to YAML.
+func openConfigFile(path string) (io.Reader, string, error) {
+	r, err := openInput(path)
+	if err != nil {
+		return nil, "", err
+	}
+	kind := "yaml"
+	if strings.EqualFold(filepath.Ext(path), ".json") {
+		kind = "json"
+	}
+	return r, kind, nil
+}
+
+// emitAgent writes the Agent to stdout per the v0.4 wire contract (bare
+// SDK shape for --json, human KV otherwise). Shared by create and edit;
+// defined here for proximity to the create flow.
+func emitAgent(jopts *cmdutil.JSONOptions, ag *sdk.Agent) error {
+	if jopts.Enabled() {
+		return jopts.Emit(iostreams.IO.Out, ag)
+	}
+	renderAgent(iostreams.IO.Out, ag)
+	return nil
+}

--- a/cli/cmd/agent/create_test.go
+++ b/cli/cmd/agent/create_test.go
@@ -1,0 +1,234 @@
+package agentcmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
+	"github.com/Tencent/WeKnora/cli/internal/iostreams"
+	sdk "github.com/Tencent/WeKnora/client"
+)
+
+// fakeCreateSvc records all three SDK methods this command may invoke.
+type fakeCreateSvc struct {
+	createReq    *sdk.CreateAgentRequest
+	createResp   *sdk.Agent
+	createErr    error
+	copySrcID    string
+	copyResp     *sdk.Agent
+	copyErr      error
+	updateID     string
+	updateReq    *sdk.UpdateAgentRequest
+	updateResp   *sdk.Agent
+	updateErr    error
+	updateCalled bool
+}
+
+func (f *fakeCreateSvc) CreateAgent(_ context.Context, req *sdk.CreateAgentRequest) (*sdk.Agent, error) {
+	f.createReq = req
+	return f.createResp, f.createErr
+}
+func (f *fakeCreateSvc) CopyAgent(_ context.Context, id string) (*sdk.Agent, error) {
+	f.copySrcID = id
+	return f.copyResp, f.copyErr
+}
+func (f *fakeCreateSvc) UpdateAgent(_ context.Context, id string, req *sdk.UpdateAgentRequest) (*sdk.Agent, error) {
+	f.updateCalled = true
+	f.updateID = id
+	f.updateReq = req
+	return f.updateResp, f.updateErr
+}
+
+func TestCreate_HappyPath_MinimalRequired(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeCreateSvc{createResp: &sdk.Agent{ID: "ag_new", Name: "Test"}}
+	opts := &CreateOptions{Name: "Test", Model: "gpt-4"}
+	err := runCreate(context.Background(), opts, &cmdutil.JSONOptions{}, svc)
+	require.NoError(t, err)
+	require.NotNil(t, svc.createReq)
+	assert.Equal(t, "Test", svc.createReq.Name)
+	require.NotNil(t, svc.createReq.Config)
+	assert.Equal(t, "gpt-4", svc.createReq.Config.ModelID)
+}
+
+func TestCreate_MissingName_FlagError(t *testing.T) {
+	cmd := NewCmdCreate(nil)
+	cmd.SetArgs([]string{"--model", "gpt-4"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	// PreRunE rejects "0 args" with our flag-error sentinel; the message
+	// always carries the canonical "accepts 1 arg" phrase.
+	assert.Contains(t, err.Error(), "accepts 1 arg")
+}
+
+func TestCreate_MissingModel_FlagError(t *testing.T) {
+	cmd := NewCmdCreate(nil)
+	cmd.SetArgs([]string{"Test"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `required flag(s) "model" not set`)
+}
+
+func TestCreate_ConfigFile_FlagsOverrideFile(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeCreateSvc{createResp: &sdk.Agent{ID: "ag_new"}}
+	opts := &CreateOptions{
+		Name:           "Test",
+		Model:          "gpt-4", // override file
+		ConfigFileBody: bytes.NewBufferString(`{"agent_mode":"smart-reasoning","model_id":"gpt-3.5","temperature":0.5}`),
+		ConfigFileKind: "json",
+	}
+	require.NoError(t, runCreate(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	require.NotNil(t, svc.createReq.Config)
+	assert.Equal(t, "smart-reasoning", svc.createReq.Config.AgentMode, "file value preserved when no flag override")
+	assert.Equal(t, "gpt-4", svc.createReq.Config.ModelID, "flag overrides file")
+	assert.InDelta(t, 0.5, svc.createReq.Config.Temperature, 0.001)
+}
+
+func TestCreate_From_CopiesThenUpdates(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeCreateSvc{
+		copyResp:   &sdk.Agent{ID: "ag_clone", Name: "Source", Config: &sdk.AgentConfig{ModelID: "gpt-3.5"}},
+		updateResp: &sdk.Agent{ID: "ag_clone", Name: "Renamed"},
+	}
+	opts := &CreateOptions{Name: "Renamed", Model: "gpt-4", From: "ag_source"}
+	require.NoError(t, runCreate(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	assert.Equal(t, "ag_source", svc.copySrcID)
+	require.True(t, svc.updateCalled, "must Update after Copy when overrides present")
+	assert.Equal(t, "ag_clone", svc.updateID)
+	assert.Equal(t, "Renamed", svc.updateReq.Name)
+	require.NotNil(t, svc.updateReq.Config)
+	assert.Equal(t, "gpt-4", svc.updateReq.Config.ModelID)
+}
+
+func TestCreate_GenerateSkeleton_NoAPICall(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeCreateSvc{}
+	opts := &CreateOptions{GenerateSkeleton: true}
+	require.NoError(t, runCreate(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	assert.Nil(t, svc.createReq, "must not call CreateAgent")
+	assert.Equal(t, "", svc.copySrcID, "must not call CopyAgent")
+	assert.Contains(t, out.String(), "agent_mode:", "skeleton emitted to stdout")
+}
+
+func TestCreate_RepeatedKB_ImpliesSelectedMode(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeCreateSvc{createResp: &sdk.Agent{ID: "ag_new"}}
+	opts := &CreateOptions{
+		Name:  "Test",
+		Model: "gpt-4",
+		KBs:   []string{"kb_a", "kb_b"},
+		flags: createFlagSet{kbsSet: true},
+	}
+	require.NoError(t, runCreate(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	assert.Equal(t, []string{"kb_a", "kb_b"}, svc.createReq.Config.KnowledgeBases)
+	assert.Equal(t, "selected", svc.createReq.Config.KBSelectionMode, "passing --kb implies selected mode")
+}
+
+func TestCreate_SystemPromptFile_ReaderRead(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeCreateSvc{createResp: &sdk.Agent{ID: "ag_new"}}
+	opts := &CreateOptions{
+		Name:               "Test",
+		Model:              "gpt-4",
+		SystemPromptReader: strings.NewReader("You are a helpful assistant.\n"),
+		flags:              createFlagSet{systemPromptSet: true},
+	}
+	require.NoError(t, runCreate(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	assert.Equal(t, "You are a helpful assistant.", svc.createReq.Config.SystemPrompt, "TrimSpace removes trailing newline")
+}
+
+func TestCreate_From_PreservesSourceFieldsNotOverridden(t *testing.T) {
+	// Regression: with --from X and only --temperature overridden, the
+	// other 33 AgentConfig fields must round-trip from the copied agent.
+	// Pre-fix, runCreate built `cfg` from a zero AgentConfig{} baseline,
+	// so UpdateAgent shipped temperature=0.9 plus every other field
+	// zeroed — clobbering source SystemPrompt / AgentMode / KBs.
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeCreateSvc{
+		copyResp: &sdk.Agent{ID: "ag_clone", Config: &sdk.AgentConfig{
+			ModelID:        "gpt-3.5",
+			SystemPrompt:   "Source prompt",
+			AgentMode:      "smart-reasoning",
+			Temperature:    0.5,
+			KnowledgeBases: []string{"kb_src_a", "kb_src_b"},
+		}},
+		updateResp: &sdk.Agent{ID: "ag_clone"},
+	}
+	// Only --temperature overridden; other fields should round-trip.
+	opts := &CreateOptions{
+		Name: "Renamed", Model: "gpt-3.5", From: "ag_source",
+		Temperature: 0.9,
+		flags:       createFlagSet{temperatureSet: true},
+	}
+	require.NoError(t, runCreate(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	require.NotNil(t, svc.updateReq)
+	require.NotNil(t, svc.updateReq.Config)
+	assert.Equal(t, "Source prompt", svc.updateReq.Config.SystemPrompt, "source SystemPrompt must round-trip")
+	assert.Equal(t, "smart-reasoning", svc.updateReq.Config.AgentMode, "source AgentMode must round-trip")
+	assert.Equal(t, []string{"kb_src_a", "kb_src_b"}, svc.updateReq.Config.KnowledgeBases, "source KB list must round-trip when --kb not passed")
+	assert.InDelta(t, 0.9, svc.updateReq.Config.Temperature, 0.001, "Temperature overridden")
+}
+
+func TestCreate_From_KBReplacesSourceList(t *testing.T) {
+	// --kb on --from REPLACES the copied agent's KB list (spec §2.1).
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeCreateSvc{
+		copyResp: &sdk.Agent{ID: "ag_clone", Config: &sdk.AgentConfig{
+			ModelID:        "gpt-3.5",
+			KnowledgeBases: []string{"kb_src_a", "kb_src_b"},
+		}},
+		updateResp: &sdk.Agent{ID: "ag_clone"},
+	}
+	opts := &CreateOptions{
+		Name: "X", Model: "gpt-3.5", From: "ag_source",
+		KBs:   []string{"kb_new"},
+		flags: createFlagSet{kbsSet: true},
+	}
+	require.NoError(t, runCreate(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	require.NotNil(t, svc.updateReq.Config)
+	assert.Equal(t, []string{"kb_new"}, svc.updateReq.Config.KnowledgeBases, "--kb replaces source KB list")
+	assert.Equal(t, "selected", svc.updateReq.Config.KBSelectionMode, "--kb on --from implies selected mode")
+}
+
+func TestCreate_Temperature_Bounds(t *testing.T) {
+	for _, badT := range []float64{-0.1, 2.1, 100.0} {
+		t.Run(fmt.Sprintf("t=%g", badT), func(t *testing.T) {
+			cmd := NewCmdCreate(nil)
+			cmd.SetArgs([]string{"Test", "--model", "gpt-4", "--temperature", fmt.Sprintf("%f", badT)})
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			err := cmd.Execute()
+			require.Error(t, err, "expected error for --temperature %g", badT)
+			assert.Contains(t, err.Error(), "0.0..2.0")
+		})
+	}
+}
+
+func TestCreate_CopyAgent_NotFound(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeCreateSvc{copyErr: errBadHTTP404}
+	opts := &CreateOptions{Name: "X", Model: "gpt-4", From: "ag_missing"}
+	err := runCreate(context.Background(), opts, &cmdutil.JSONOptions{}, svc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resource.not_found")
+}
+
+// errBadHTTP404 simulates the SDK's "HTTP error 404: not found" format that
+// ClassifyHTTPError parses. Defined here so create_test and edit_test/delete_test
+// can share it via package scope without spinning up an HTTP server.
+var errBadHTTP404 = &simpleErr{msg: "HTTP error 404: not found"}
+
+type simpleErr struct{ msg string }
+
+func (e *simpleErr) Error() string { return e.msg }

--- a/cli/cmd/agent/create_test.go
+++ b/cli/cmd/agent/create_test.go
@@ -48,18 +48,18 @@ func (f *fakeCreateSvc) UpdateAgent(_ context.Context, id string, req *sdk.Updat
 func TestCreate_HappyPath_MinimalRequired(t *testing.T) {
 	_, _ = iostreams.SetForTest(t)
 	svc := &fakeCreateSvc{createResp: &sdk.Agent{ID: "ag_new", Name: "Test"}}
-	opts := &CreateOptions{Name: "Test", Model: "gpt-4"}
+	opts := &CreateOptions{Name: "Test", Model: "model-x"}
 	err := runCreate(context.Background(), opts, &cmdutil.JSONOptions{}, svc)
 	require.NoError(t, err)
 	require.NotNil(t, svc.createReq)
 	assert.Equal(t, "Test", svc.createReq.Name)
 	require.NotNil(t, svc.createReq.Config)
-	assert.Equal(t, "gpt-4", svc.createReq.Config.ModelID)
+	assert.Equal(t, "model-x", svc.createReq.Config.ModelID)
 }
 
 func TestCreate_MissingName_FlagError(t *testing.T) {
 	cmd := NewCmdCreate(nil)
-	cmd.SetArgs([]string{"--model", "gpt-4"})
+	cmd.SetArgs([]string{"--model", "model-x"})
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
 	err := cmd.Execute()
@@ -84,31 +84,31 @@ func TestCreate_ConfigFile_FlagsOverrideFile(t *testing.T) {
 	svc := &fakeCreateSvc{createResp: &sdk.Agent{ID: "ag_new"}}
 	opts := &CreateOptions{
 		Name:           "Test",
-		Model:          "gpt-4", // override file
-		ConfigFileBody: bytes.NewBufferString(`{"agent_mode":"smart-reasoning","model_id":"gpt-3.5","temperature":0.5}`),
+		Model:          "model-x", // override file
+		ConfigFileBody: bytes.NewBufferString(`{"agent_mode":"smart-reasoning","model_id":"model-y","temperature":0.5}`),
 		ConfigFileKind: "json",
 	}
 	require.NoError(t, runCreate(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
 	require.NotNil(t, svc.createReq.Config)
 	assert.Equal(t, "smart-reasoning", svc.createReq.Config.AgentMode, "file value preserved when no flag override")
-	assert.Equal(t, "gpt-4", svc.createReq.Config.ModelID, "flag overrides file")
+	assert.Equal(t, "model-x", svc.createReq.Config.ModelID, "flag overrides file")
 	assert.InDelta(t, 0.5, svc.createReq.Config.Temperature, 0.001)
 }
 
 func TestCreate_From_CopiesThenUpdates(t *testing.T) {
 	_, _ = iostreams.SetForTest(t)
 	svc := &fakeCreateSvc{
-		copyResp:   &sdk.Agent{ID: "ag_clone", Name: "Source", Config: &sdk.AgentConfig{ModelID: "gpt-3.5"}},
+		copyResp:   &sdk.Agent{ID: "ag_clone", Name: "Source", Config: &sdk.AgentConfig{ModelID: "model-y"}},
 		updateResp: &sdk.Agent{ID: "ag_clone", Name: "Renamed"},
 	}
-	opts := &CreateOptions{Name: "Renamed", Model: "gpt-4", From: "ag_source"}
+	opts := &CreateOptions{Name: "Renamed", Model: "model-x", From: "ag_source"}
 	require.NoError(t, runCreate(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
 	assert.Equal(t, "ag_source", svc.copySrcID)
 	require.True(t, svc.updateCalled, "must Update after Copy when overrides present")
 	assert.Equal(t, "ag_clone", svc.updateID)
 	assert.Equal(t, "Renamed", svc.updateReq.Name)
 	require.NotNil(t, svc.updateReq.Config)
-	assert.Equal(t, "gpt-4", svc.updateReq.Config.ModelID)
+	assert.Equal(t, "model-x", svc.updateReq.Config.ModelID)
 }
 
 func TestCreate_GenerateSkeleton_NoAPICall(t *testing.T) {
@@ -126,7 +126,7 @@ func TestCreate_RepeatedKB_ImpliesSelectedMode(t *testing.T) {
 	svc := &fakeCreateSvc{createResp: &sdk.Agent{ID: "ag_new"}}
 	opts := &CreateOptions{
 		Name:  "Test",
-		Model: "gpt-4",
+		Model: "model-x",
 		KBs:   []string{"kb_a", "kb_b"},
 		flags: createFlagSet{kbsSet: true},
 	}
@@ -140,7 +140,7 @@ func TestCreate_SystemPromptFile_ReaderRead(t *testing.T) {
 	svc := &fakeCreateSvc{createResp: &sdk.Agent{ID: "ag_new"}}
 	opts := &CreateOptions{
 		Name:               "Test",
-		Model:              "gpt-4",
+		Model:              "model-x",
 		SystemPromptReader: strings.NewReader("You are a helpful assistant.\n"),
 		flags:              createFlagSet{systemPromptSet: true},
 	}
@@ -157,7 +157,7 @@ func TestCreate_From_PreservesSourceFieldsNotOverridden(t *testing.T) {
 	_, _ = iostreams.SetForTest(t)
 	svc := &fakeCreateSvc{
 		copyResp: &sdk.Agent{ID: "ag_clone", Config: &sdk.AgentConfig{
-			ModelID:        "gpt-3.5",
+			ModelID:        "model-y",
 			SystemPrompt:   "Source prompt",
 			AgentMode:      "smart-reasoning",
 			Temperature:    0.5,
@@ -167,7 +167,7 @@ func TestCreate_From_PreservesSourceFieldsNotOverridden(t *testing.T) {
 	}
 	// Only --temperature overridden; other fields should round-trip.
 	opts := &CreateOptions{
-		Name: "Renamed", Model: "gpt-3.5", From: "ag_source",
+		Name: "Renamed", Model: "model-y", From: "ag_source",
 		Temperature: 0.9,
 		flags:       createFlagSet{temperatureSet: true},
 	}
@@ -181,17 +181,20 @@ func TestCreate_From_PreservesSourceFieldsNotOverridden(t *testing.T) {
 }
 
 func TestCreate_From_KBReplacesSourceList(t *testing.T) {
-	// --kb on --from REPLACES the copied agent's KB list (spec §2.1).
+	// --kb on --from REPLACES the copied agent's KB list (instead of
+	// merging with it). The override semantic matches a from-scratch
+	// `agent create --kb a --kb b`: whatever was on the source agent is
+	// discarded for KBs the caller explicitly listed.
 	_, _ = iostreams.SetForTest(t)
 	svc := &fakeCreateSvc{
 		copyResp: &sdk.Agent{ID: "ag_clone", Config: &sdk.AgentConfig{
-			ModelID:        "gpt-3.5",
+			ModelID:        "model-y",
 			KnowledgeBases: []string{"kb_src_a", "kb_src_b"},
 		}},
 		updateResp: &sdk.Agent{ID: "ag_clone"},
 	}
 	opts := &CreateOptions{
-		Name: "X", Model: "gpt-3.5", From: "ag_source",
+		Name: "X", Model: "model-y", From: "ag_source",
 		KBs:   []string{"kb_new"},
 		flags: createFlagSet{kbsSet: true},
 	}
@@ -205,7 +208,7 @@ func TestCreate_Temperature_Bounds(t *testing.T) {
 	for _, badT := range []float64{-0.1, 2.1, 100.0} {
 		t.Run(fmt.Sprintf("t=%g", badT), func(t *testing.T) {
 			cmd := NewCmdCreate(nil)
-			cmd.SetArgs([]string{"Test", "--model", "gpt-4", "--temperature", fmt.Sprintf("%f", badT)})
+			cmd.SetArgs([]string{"Test", "--model", "model-x", "--temperature", fmt.Sprintf("%f", badT)})
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
 			err := cmd.Execute()
@@ -218,7 +221,7 @@ func TestCreate_Temperature_Bounds(t *testing.T) {
 func TestCreate_CopyAgent_NotFound(t *testing.T) {
 	_, _ = iostreams.SetForTest(t)
 	svc := &fakeCreateSvc{copyErr: errBadHTTP404}
-	opts := &CreateOptions{Name: "X", Model: "gpt-4", From: "ag_missing"}
+	opts := &CreateOptions{Name: "X", Model: "model-x", From: "ag_missing"}
 	err := runCreate(context.Background(), opts, &cmdutil.JSONOptions{}, svc)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "resource.not_found")

--- a/cli/cmd/agent/delete.go
+++ b/cli/cmd/agent/delete.go
@@ -1,0 +1,97 @@
+package agentcmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
+	"github.com/Tencent/WeKnora/cli/internal/iostreams"
+	"github.com/Tencent/WeKnora/cli/internal/prompt"
+)
+
+// agentDeleteFields enumerates the JSON discovery fields for `agent delete`.
+// Result payload is a tiny {id, deleted} object — mirrors `kb delete`.
+var agentDeleteFields = []string{"id", "deleted"}
+
+// DeleteOptions captures `agent delete` flag state.
+type DeleteOptions struct {
+	AgentID string
+	Yes     bool // sourced from the global -y/--yes persistent flag
+}
+
+// DeleteService is the narrow SDK surface this command depends on.
+type DeleteService interface {
+	DeleteAgent(ctx context.Context, id string) error
+}
+
+// deleteResult is the typed payload emitted on success in JSON mode.
+type deleteResult struct {
+	ID      string `json:"id"`
+	Deleted bool   `json:"deleted"`
+}
+
+// Delete is NOT idempotent on a missing id — it surfaces resource.not_found
+// rather than silently exiting 0. Idempotent-already-true semantics are
+// reserved for unlink-style local cleanups, not server-side resource removal.
+const agentDeleteLong = `Permanently delete a custom agent.
+
+Prompts for confirmation by default when stdout is a TTY and --json is
+not set. Pass -y/--yes (the global flag) to skip the prompt (required in
+agent / CI / piped contexts).
+
+Typed exit codes:
+  resource.not_found            no agent with the given id (exit 4)
+  auth.forbidden                caller lacks delete permission on the agent (exit 3)
+  input.confirmation_required   destructive op without -y on a TTY (exit 10)
+
+AI agents: This is a high-risk write. Without -y/--yes the CLI exits 10
+and writes input.confirmation_required to stderr. NEVER auto-pass -y
+without the user's explicit go-ahead — the exit-10 protocol exists
+exactly to guard against unintended deletes.`
+
+const agentDeleteExample = `  weknora agent delete ag_abc           # interactive confirm
+  weknora agent delete ag_abc -y        # no prompt
+  weknora agent delete ag_abc -y --json # bare {id, deleted:true} JSON`
+
+// NewCmdDelete builds `weknora agent delete <agent-id>`.
+func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
+	opts := &DeleteOptions{}
+	cmd := &cobra.Command{
+		Use:     "delete <agent-id>",
+		Short:   "Delete a custom agent",
+		Long:    agentDeleteLong,
+		Example: agentDeleteExample,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			jopts, err := cmdutil.CheckJSONFlags(cmd)
+			if err != nil {
+				return err
+			}
+			opts.AgentID = args[0]
+			opts.Yes, _ = cmd.Flags().GetBool("yes")
+			cli, err := f.Client()
+			if err != nil {
+				return err
+			}
+			return runDelete(cmd.Context(), opts, jopts, cli, f.Prompter())
+		},
+	}
+	cmdutil.AddJSONFlags(cmd, agentDeleteFields)
+	return cmd
+}
+
+func runDelete(ctx context.Context, opts *DeleteOptions, jopts *cmdutil.JSONOptions, svc DeleteService, p prompt.Prompter) error {
+	if err := cmdutil.ConfirmDestructive(p, opts.Yes, jopts.Enabled(), "agent", opts.AgentID); err != nil {
+		return err
+	}
+	if err := svc.DeleteAgent(ctx, opts.AgentID); err != nil {
+		return cmdutil.WrapHTTP(err, "delete agent %s", opts.AgentID)
+	}
+	if jopts.Enabled() {
+		return jopts.Emit(iostreams.IO.Out, deleteResult{ID: opts.AgentID, Deleted: true})
+	}
+	fmt.Fprintf(iostreams.IO.Out, "✓ Deleted agent %s\n", opts.AgentID)
+	return nil
+}

--- a/cli/cmd/agent/delete.go
+++ b/cli/cmd/agent/delete.go
@@ -15,7 +15,6 @@ import (
 // Result payload is a tiny {id, deleted} object — mirrors `kb delete`.
 var agentDeleteFields = []string{"id", "deleted"}
 
-// DeleteOptions captures `agent delete` flag state.
 type DeleteOptions struct {
 	AgentID string
 	Yes     bool // sourced from the global -y/--yes persistent flag

--- a/cli/cmd/agent/delete_test.go
+++ b/cli/cmd/agent/delete_test.go
@@ -1,0 +1,107 @@
+package agentcmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
+	"github.com/Tencent/WeKnora/cli/internal/iostreams"
+	"github.com/Tencent/WeKnora/cli/internal/testutil"
+)
+
+type fakeDeleteSvc struct {
+	gotID string
+	err   error
+}
+
+func (f *fakeDeleteSvc) DeleteAgent(_ context.Context, id string) error {
+	f.gotID = id
+	return f.err
+}
+
+func TestDelete_NonTTY_NoYes_ExitTen(t *testing.T) {
+	_, _ = iostreams.SetForTest(t) // non-TTY
+	svc := &fakeDeleteSvc{}
+	err := runDelete(
+		context.Background(),
+		&DeleteOptions{AgentID: "ag_abc", Yes: false},
+		&cmdutil.JSONOptions{}, svc, &testutil.ConfirmPrompter{},
+	)
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeInputConfirmationRequired, typed.Code)
+	assert.Empty(t, svc.gotID, "must not call DeleteAgent without confirm")
+	assert.Equal(t, 10, cmdutil.ExitCode(err), "exit code 10 per destructive-write protocol")
+}
+
+func TestDelete_NonTTY_WithYes_Direct(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeDeleteSvc{}
+	require.NoError(t, runDelete(
+		context.Background(),
+		&DeleteOptions{AgentID: "ag_abc", Yes: true},
+		nil, svc, &testutil.ConfirmPrompter{},
+	))
+	assert.Equal(t, "ag_abc", svc.gotID)
+	assert.Contains(t, out.String(), "ag_abc")
+}
+
+func TestDelete_404_PropagatesNotFound(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeDeleteSvc{err: errBadHTTP404}
+	err := runDelete(
+		context.Background(),
+		&DeleteOptions{AgentID: "ag_missing", Yes: true},
+		nil, svc, &testutil.ConfirmPrompter{},
+	)
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeResourceNotFound, typed.Code)
+}
+
+func TestDelete_TTY_ConfirmYes(t *testing.T) {
+	_, _ = iostreams.SetForTestWithTTY(t)
+	svc := &fakeDeleteSvc{}
+	p := &testutil.ConfirmPrompter{Answer: true}
+	require.NoError(t, runDelete(
+		context.Background(),
+		&DeleteOptions{AgentID: "ag_abc"},
+		nil, svc, p,
+	))
+	assert.True(t, p.Asked)
+	assert.Equal(t, "ag_abc", svc.gotID)
+}
+
+func TestDelete_TTY_ConfirmNo(t *testing.T) {
+	_, errBuf := iostreams.SetForTestWithTTY(t)
+	svc := &fakeDeleteSvc{}
+	p := &testutil.ConfirmPrompter{Answer: false}
+	err := runDelete(
+		context.Background(),
+		&DeleteOptions{AgentID: "ag_abc"},
+		nil, svc, p,
+	)
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeUserAborted, typed.Code)
+	assert.Empty(t, svc.gotID, "answer=no must not call DeleteAgent")
+	assert.Contains(t, errBuf.String(), "Aborted")
+}
+
+func TestDelete_JSON_BareObject(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeDeleteSvc{}
+	require.NoError(t, runDelete(
+		context.Background(),
+		&DeleteOptions{AgentID: "ag_abc", Yes: true},
+		&cmdutil.JSONOptions{}, svc, &testutil.ConfirmPrompter{},
+	))
+	assert.Contains(t, out.String(), `"id":"ag_abc"`)
+	assert.Contains(t, out.String(), `"deleted":true`)
+}

--- a/cli/cmd/agent/edit.go
+++ b/cli/cmd/agent/edit.go
@@ -117,15 +117,15 @@ func NewCmdEdit(f *cmdutil.Factory) *cobra.Command {
 			opts.flags.kbSelectionModeSet = cmd.Flags().Changed("kb-selection-mode")
 			opts.flags.configFileSet = cmd.Flags().Changed("config-file")
 
-			// L-5 / §1.5.1: --temperature is bounded 0.0..2.0. Reject
-			// out-of-range early with a typed input.invalid_argument.
+			// --temperature is bounded 0.0..2.0. Reject out-of-range
+			// early with a typed input.invalid_argument.
 			if opts.flags.temperatureSet && (opts.Temperature < 0.0 || opts.Temperature > 2.0) {
 				return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
 					fmt.Sprintf("--temperature must be in 0.0..2.0, got %g", opts.Temperature))
 			}
 
 			if systemPromptFile != "" {
-				r, err := openInput(systemPromptFile)
+				r, err := cmdutil.OpenInput(systemPromptFile)
 				if err != nil {
 					return cmdutil.NewError(cmdutil.CodeInputInvalidArgument, fmt.Sprintf("--system-prompt-file: %v", err))
 				}
@@ -194,7 +194,7 @@ func runEdit(ctx context.Context, opts *EditOptions, jopts *cmdutil.JSONOptions,
 		}
 	}
 
-	// L-2 fetch-then-update so omitted fields round-trip unchanged through
+	// Fetch-then-update so omitted fields round-trip unchanged through
 	// the full PUT body.
 	current, err := svc.GetAgent(ctx, opts.AgentID)
 	if err != nil {

--- a/cli/cmd/agent/edit.go
+++ b/cli/cmd/agent/edit.go
@@ -1,0 +1,329 @@
+package agentcmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
+	"github.com/Tencent/WeKnora/cli/internal/iostreams"
+	sdk "github.com/Tencent/WeKnora/client"
+)
+
+// EditService is the narrow SDK surface this command depends on. The fetch
+// half (GetAgent) is mandatory because UpdateAgent is a full PUT — without
+// the pre-fetch baseline, any field not passed as a flag would silently
+// clobber to the zero value.
+type EditService interface {
+	GetAgent(ctx context.Context, id string) (*sdk.Agent, error)
+	UpdateAgent(ctx context.Context, id string, req *sdk.UpdateAgentRequest) (*sdk.Agent, error)
+}
+
+// EditOptions captures the surgical flag state. Both string fields and
+// reader-based file inputs are tracked alongside per-flag *Set bits in
+// editFlagSet so empty strings are distinguishable from "unset".
+type EditOptions struct {
+	AgentID            string
+	Name               string
+	Description        string
+	Model              string
+	SystemPrompt       string
+	SystemPromptReader io.Reader
+	AgentMode          string
+	RerankModel        string
+	Temperature        float64
+	AddKBs             []string
+	RemoveKBs          []string
+	KBSelectionMode    string
+	ConfigFileBody     io.Reader
+	ConfigFileKind     string // "yaml" or "json"
+
+	flags editFlagSet
+}
+
+// editFlagSet tracks which surgical flags the user passed. Empty-string
+// values are valid (clear semantics) so cmd.Flags().Changed() is the only
+// reliable signal of "user supplied this flag."
+type editFlagSet struct {
+	nameSet            bool
+	descriptionSet     bool
+	modelSet           bool
+	systemPromptSet    bool
+	agentModeSet       bool
+	rerankModelSet     bool
+	temperatureSet     bool
+	addKBsSet          bool
+	removeKBsSet       bool
+	kbSelectionModeSet bool
+	configFileSet      bool
+}
+
+const agentEditLong = `Edit a custom agent's fields surgically.
+
+At least one update flag is required; flags you omit preserve the current
+server-side value via fetch-then-update. Pass --description "" to clear
+the description (empty string is a valid value, not "unset").
+
+KB list operations are list-shaped: --add-kb and --remove-kb are
+idempotent (re-adding an already-attached KB is silent success; removing
+an unattached KB is silent success). Passing the same id to both flags
+nets out to no-op and prints a stderr warning.
+
+--config-file fully replaces the AgentConfig baseline (the same shape
+GenerateAgentSkeleton emits). Surgical flags then apply on top of that
+replaced baseline. To partially update one or two fields without
+touching the rest, use surgical flags alone — that path L-2 fetches
+current state and only mutates what's set. Precedence within a single
+invocation:
+
+  surgical flag > config-file value > zero value
+
+AI agents: writes to a server resource. Failure surfaces as a typed
+code on stderr: resource.not_found (agent id or KB id), auth.forbidden,
+input.invalid_argument (no flags passed, bad file).`
+
+const agentEditExample = `  weknora agent edit ag_abc --name "Renamed"
+  weknora agent edit ag_abc --description ""                # clear description
+  weknora agent edit ag_abc --add-kb kb_new --remove-kb kb_old
+  weknora agent edit ag_abc --system-prompt-file ./prompt.md
+  weknora agent edit ag_abc --config-file ./tuned.yaml --temperature 0.9`
+
+// NewCmdEdit builds `weknora agent edit <agent-id>`.
+func NewCmdEdit(f *cmdutil.Factory) *cobra.Command {
+	opts := &EditOptions{}
+	var systemPromptFile, configFile string
+
+	cmd := &cobra.Command{
+		Use:     "edit <agent-id>",
+		Short:   "Edit a custom agent's configuration",
+		Long:    agentEditLong,
+		Example: agentEditExample,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			opts.AgentID = args[0]
+			opts.flags.nameSet = cmd.Flags().Changed("name")
+			opts.flags.descriptionSet = cmd.Flags().Changed("description")
+			opts.flags.modelSet = cmd.Flags().Changed("model")
+			opts.flags.systemPromptSet = cmd.Flags().Changed("system-prompt") || cmd.Flags().Changed("system-prompt-file")
+			opts.flags.agentModeSet = cmd.Flags().Changed("agent-mode")
+			opts.flags.rerankModelSet = cmd.Flags().Changed("rerank-model")
+			opts.flags.temperatureSet = cmd.Flags().Changed("temperature")
+			opts.flags.addKBsSet = cmd.Flags().Changed("add-kb")
+			opts.flags.removeKBsSet = cmd.Flags().Changed("remove-kb")
+			opts.flags.kbSelectionModeSet = cmd.Flags().Changed("kb-selection-mode")
+			opts.flags.configFileSet = cmd.Flags().Changed("config-file")
+
+			// L-5 / §1.5.1: --temperature is bounded 0.0..2.0. Reject
+			// out-of-range early with a typed input.invalid_argument.
+			if opts.flags.temperatureSet && (opts.Temperature < 0.0 || opts.Temperature > 2.0) {
+				return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
+					fmt.Sprintf("--temperature must be in 0.0..2.0, got %g", opts.Temperature))
+			}
+
+			if systemPromptFile != "" {
+				r, err := openInput(systemPromptFile)
+				if err != nil {
+					return cmdutil.NewError(cmdutil.CodeInputInvalidArgument, fmt.Sprintf("--system-prompt-file: %v", err))
+				}
+				opts.SystemPromptReader = r
+			}
+			if configFile != "" {
+				r, kind, err := openConfigFile(configFile)
+				if err != nil {
+					return cmdutil.NewError(cmdutil.CodeInputInvalidArgument, fmt.Sprintf("--config-file: %v", err))
+				}
+				opts.ConfigFileBody = r
+				opts.ConfigFileKind = kind
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			jopts, err := cmdutil.CheckJSONFlags(cmd)
+			if err != nil {
+				return err
+			}
+			cli, err := f.Client()
+			if err != nil {
+				return err
+			}
+			return runEdit(cmd.Context(), opts, jopts, cli)
+		},
+	}
+
+	// Surgical flags
+	cmd.Flags().StringVar(&opts.Name, "name", "", "New agent name")
+	cmd.Flags().StringVar(&opts.Description, "description", "", `New description (use "" to clear)`)
+	cmd.Flags().StringVar(&opts.Model, "model", "", "LLM model id")
+	cmd.Flags().StringVar(&opts.SystemPrompt, "system-prompt", "", "System prompt text (mutex with --system-prompt-file)")
+	cmd.Flags().StringVar(&systemPromptFile, "system-prompt-file", "", "Read system prompt from FILE, or '-' for stdin")
+	cmd.MarkFlagsMutuallyExclusive("system-prompt", "system-prompt-file")
+	cmd.Flags().StringVar(&opts.AgentMode, "agent-mode", "", "Agent operating mode: quick-answer | smart-reasoning")
+	cmd.Flags().StringVar(&opts.RerankModel, "rerank-model", "", "Rerank model id")
+	cmd.Flags().Float64Var(&opts.Temperature, "temperature", 0.0, "Generation temperature (0.0..2.0)")
+	cmd.Flags().StringSliceVar(&opts.AddKBs, "add-kb", nil, "Attach knowledge base id (repeatable, idempotent)")
+	cmd.Flags().StringSliceVar(&opts.RemoveKBs, "remove-kb", nil, "Detach knowledge base id (repeatable, idempotent)")
+	cmd.Flags().StringVar(&opts.KBSelectionMode, "kb-selection-mode", "", "KB selection mode: all | selected | none")
+
+	// Full-replace
+	cmd.Flags().StringVar(&configFile, "config-file", "", "Full AgentConfig YAML or JSON (REPLACES current config baseline; surgical flags then apply on top)")
+
+	cmdutil.AddJSONFlags(cmd, agentViewFields)
+	return cmd
+}
+
+// editHasAnyFlag reports whether opts carries at least one surgical update
+// signal. Required-flag validation lives in runEdit (not PreRunE) so unit
+// tests can invoke runEdit with a hand-built EditOptions directly.
+func editHasAnyFlag(opts *EditOptions) bool {
+	fl := opts.flags
+	return fl.nameSet || fl.descriptionSet || fl.modelSet || fl.systemPromptSet ||
+		fl.agentModeSet || fl.rerankModelSet || fl.temperatureSet ||
+		fl.addKBsSet || fl.removeKBsSet || fl.kbSelectionModeSet || fl.configFileSet
+}
+
+func runEdit(ctx context.Context, opts *EditOptions, jopts *cmdutil.JSONOptions, svc EditService) error {
+	if !editHasAnyFlag(opts) {
+		return &cmdutil.Error{
+			Code:    cmdutil.CodeInputInvalidArgument,
+			Message: "agent edit requires at least one flag",
+			Hint:    "pass at least one update flag (e.g., --name, --add-kb, --description) or --config-file",
+		}
+	}
+
+	// L-2 fetch-then-update so omitted fields round-trip unchanged through
+	// the full PUT body.
+	current, err := svc.GetAgent(ctx, opts.AgentID)
+	if err != nil {
+		return cmdutil.WrapHTTP(err, "fetch agent %s", opts.AgentID)
+	}
+
+	// Build base config: server state, then overlay --config-file (if any).
+	base := sdk.AgentConfig{}
+	if current.Config != nil {
+		base = *current.Config
+	}
+	if opts.ConfigFileBody != nil {
+		parsed, err := cmdutil.LoadAgentConfig(opts.ConfigFileBody, opts.ConfigFileKind)
+		if err != nil {
+			return cmdutil.NewError(cmdutil.CodeInputInvalidArgument, err.Error())
+		}
+		base = *parsed
+	}
+
+	// Resolve --system-prompt-file before flag overlay.
+	if opts.SystemPromptReader != nil {
+		body, err := io.ReadAll(opts.SystemPromptReader)
+		if err != nil {
+			return cmdutil.NewError(cmdutil.CodeInputInvalidArgument, fmt.Sprintf("--system-prompt-file read: %v", err))
+		}
+		opts.SystemPrompt = strings.TrimSpace(string(body))
+	}
+
+	// Compute KB list from current + add/remove with a stderr warning when
+	// the same id appears in both flags (net no-op, still idempotent).
+	kbs := computeKBList(base.KnowledgeBases, opts.AddKBs, opts.RemoveKBs)
+
+	overrides := cmdutil.AgentConfigFlags{
+		AgentMode: opts.AgentMode, AgentModeSet: opts.flags.agentModeSet,
+		SystemPrompt: opts.SystemPrompt, SystemPromptSet: opts.flags.systemPromptSet,
+		ModelID: opts.Model, ModelIDSet: opts.flags.modelSet,
+		RerankModelID: opts.RerankModel, RerankModelIDSet: opts.flags.rerankModelSet,
+		Temperature: opts.Temperature, TemperatureSet: opts.flags.temperatureSet,
+		KBSelectionMode: opts.KBSelectionMode, KBSelectionModeSet: opts.flags.kbSelectionModeSet,
+		// KB list is always replaced (its add/remove was already merged
+		// into kbs); we only signal "set" when the user actually touched
+		// the list so a plain --name edit doesn't churn the field.
+		KnowledgeBases:    kbs,
+		KnowledgeBasesSet: opts.flags.addKBsSet || opts.flags.removeKBsSet,
+	}
+	cfg := cmdutil.MergeAgentConfig(&base, overrides)
+
+	// Build the full PUT body. Name/Description default to the current
+	// server values so the surgical-flag-only path preserves them.
+	req := &sdk.UpdateAgentRequest{
+		Name:        current.Name,
+		Description: current.Description,
+		Config:      cfg,
+	}
+	if opts.flags.nameSet {
+		req.Name = opts.Name
+	}
+	if opts.flags.descriptionSet {
+		req.Description = opts.Description
+	}
+
+	updated, err := svc.UpdateAgent(ctx, opts.AgentID, req)
+	if err != nil {
+		return cmdutil.WrapHTTP(err, "edit agent %s", opts.AgentID)
+	}
+	return emitAgent(jopts, updated)
+}
+
+// computeKBList applies --add-kb / --remove-kb to current with idempotent
+// semantics. Ids present in both add and remove cancel out and surface a
+// stderr warning so users notice the conflict but don't see a hard error.
+// Stderr is the right channel here (not stdout) because callers piping
+// --json | jq would otherwise see corrupted JSON.
+func computeKBList(current, add, remove []string) []string {
+	// Detect ids in both add and remove; they net out to no-op and are
+	// excluded from both operations.
+	canceledSet := map[string]struct{}{}
+	addSeen := map[string]struct{}{}
+	for _, id := range add {
+		addSeen[id] = struct{}{}
+	}
+	for _, id := range remove {
+		if _, both := addSeen[id]; both {
+			canceledSet[id] = struct{}{}
+		}
+	}
+	if len(canceledSet) > 0 {
+		canceled := make([]string, 0, len(canceledSet))
+		for id := range canceledSet {
+			canceled = append(canceled, id)
+		}
+		// Sort for deterministic test output; map iteration is random.
+		sort.Strings(canceled)
+		fmt.Fprintf(iostreams.IO.Err, "warning: --add-kb and --remove-kb cancel out for: %s\n", strings.Join(canceled, ", "))
+	}
+
+	// Compute effective remove set (excluding canceled).
+	removeEff := map[string]struct{}{}
+	for _, id := range remove {
+		if _, c := canceledSet[id]; c {
+			continue
+		}
+		removeEff[id] = struct{}{}
+	}
+
+	// Filter removals out of the current list (idempotent: unattached id
+	// simply isn't in current).
+	out := make([]string, 0, len(current))
+	for _, id := range current {
+		if _, drop := removeEff[id]; drop {
+			continue
+		}
+		out = append(out, id)
+	}
+	// Append any add ids not already present (idempotent: already-attached
+	// id silently de-dupes).
+	present := map[string]struct{}{}
+	for _, id := range out {
+		present[id] = struct{}{}
+	}
+	for _, id := range add {
+		if _, c := canceledSet[id]; c {
+			continue
+		}
+		if _, dup := present[id]; dup {
+			continue
+		}
+		out = append(out, id)
+		present[id] = struct{}{}
+	}
+	return out
+}

--- a/cli/cmd/agent/edit_test.go
+++ b/cli/cmd/agent/edit_test.go
@@ -1,0 +1,249 @@
+package agentcmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
+	"github.com/Tencent/WeKnora/cli/internal/iostreams"
+	sdk "github.com/Tencent/WeKnora/client"
+)
+
+// fakeEditSvc scripts GetAgent (fetch baseline) + UpdateAgent (apply
+// surgical overlays). updateCalls lets tests verify that no-flag invocations
+// don't reach the wire.
+type fakeEditSvc struct {
+	getResp     *sdk.Agent
+	getErr      error
+	updateReq   *sdk.UpdateAgentRequest
+	updateID    string
+	updateResp  *sdk.Agent
+	updateErr   error
+	updateCalls int
+}
+
+func (f *fakeEditSvc) GetAgent(_ context.Context, _ string) (*sdk.Agent, error) {
+	return f.getResp, f.getErr
+}
+
+func (f *fakeEditSvc) UpdateAgent(_ context.Context, id string, req *sdk.UpdateAgentRequest) (*sdk.Agent, error) {
+	f.updateReq = req
+	f.updateID = id
+	f.updateCalls++
+	return f.updateResp, f.updateErr
+}
+
+func TestEdit_FetchThenUpdate_PreservesUntouchedFields(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeEditSvc{
+		getResp: &sdk.Agent{
+			ID: "ag_abc", Name: "Original", Description: "Keep me",
+			Config: &sdk.AgentConfig{ModelID: "gpt-4", Temperature: 0.7, KnowledgeBases: []string{"kb_a"}},
+		},
+		updateResp: &sdk.Agent{ID: "ag_abc"},
+	}
+	// Only --description passed; everything else should round-trip.
+	opts := &EditOptions{
+		AgentID:     "ag_abc",
+		Description: "Updated",
+		flags:       editFlagSet{descriptionSet: true},
+	}
+	require.NoError(t, runEdit(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	require.NotNil(t, svc.updateReq)
+	assert.Equal(t, "Original", svc.updateReq.Name, "Name must round-trip unchanged")
+	assert.Equal(t, "Updated", svc.updateReq.Description)
+	require.NotNil(t, svc.updateReq.Config)
+	assert.Equal(t, "gpt-4", svc.updateReq.Config.ModelID, "ModelID must round-trip")
+	assert.Equal(t, []string{"kb_a"}, svc.updateReq.Config.KnowledgeBases, "KBs must round-trip")
+	assert.InDelta(t, 0.7, svc.updateReq.Config.Temperature, 0.001)
+}
+
+func TestEdit_AddRemoveKB_SameID_NetNoOpWithWarning(t *testing.T) {
+	_, errBuf := iostreams.SetForTest(t)
+	svc := &fakeEditSvc{
+		getResp:    &sdk.Agent{Config: &sdk.AgentConfig{KnowledgeBases: []string{"kb_a"}}},
+		updateResp: &sdk.Agent{},
+	}
+	opts := &EditOptions{
+		AgentID:   "ag_abc",
+		AddKBs:    []string{"kb_b"},
+		RemoveKBs: []string{"kb_b"},
+		flags:     editFlagSet{addKBsSet: true, removeKBsSet: true},
+	}
+	require.NoError(t, runEdit(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	assert.Equal(t, []string{"kb_a"}, svc.updateReq.Config.KnowledgeBases, "net no-op preserves original list")
+	assert.Contains(t, errBuf.String(), "cancel out", "warning emitted to stderr")
+}
+
+func TestEdit_NoFlags_InvalidArgument(t *testing.T) {
+	svc := &fakeEditSvc{}
+	err := runEdit(context.Background(), &EditOptions{AgentID: "ag_abc"}, &cmdutil.JSONOptions{}, svc)
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code)
+	assert.Equal(t, 0, svc.updateCalls, "must not call UpdateAgent")
+}
+
+func TestEdit_AddKB_AlreadyAttached_Silent(t *testing.T) {
+	_, errBuf := iostreams.SetForTest(t)
+	svc := &fakeEditSvc{
+		getResp:    &sdk.Agent{Config: &sdk.AgentConfig{KnowledgeBases: []string{"kb_a", "kb_b"}}},
+		updateResp: &sdk.Agent{},
+	}
+	opts := &EditOptions{
+		AgentID: "ag_abc",
+		AddKBs:  []string{"kb_a"}, // already attached
+		flags:   editFlagSet{addKBsSet: true},
+	}
+	require.NoError(t, runEdit(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	assert.Equal(t, []string{"kb_a", "kb_b"}, svc.updateReq.Config.KnowledgeBases, "no duplicate")
+	assert.NotContains(t, errBuf.String(), "warning", "already-attached is silent success")
+}
+
+func TestEdit_RemoveKB_Unattached_Silent(t *testing.T) {
+	_, errBuf := iostreams.SetForTest(t)
+	svc := &fakeEditSvc{
+		getResp:    &sdk.Agent{Config: &sdk.AgentConfig{KnowledgeBases: []string{"kb_a"}}},
+		updateResp: &sdk.Agent{},
+	}
+	opts := &EditOptions{
+		AgentID:   "ag_abc",
+		RemoveKBs: []string{"kb_zzz"},
+		flags:     editFlagSet{removeKBsSet: true},
+	}
+	require.NoError(t, runEdit(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	assert.Equal(t, []string{"kb_a"}, svc.updateReq.Config.KnowledgeBases)
+	assert.NotContains(t, errBuf.String(), "warning")
+}
+
+func TestEdit_ClearDescription_EmptyString(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeEditSvc{
+		getResp:    &sdk.Agent{Name: "X", Description: "old", Config: &sdk.AgentConfig{ModelID: "m"}},
+		updateResp: &sdk.Agent{},
+	}
+	opts := &EditOptions{
+		AgentID:     "ag_abc",
+		Description: "",
+		flags:       editFlagSet{descriptionSet: true},
+	}
+	require.NoError(t, runEdit(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	assert.Equal(t, "", svc.updateReq.Description, "explicit empty must clear server-side")
+	assert.Equal(t, "X", svc.updateReq.Name, "Name round-trip unchanged")
+}
+
+func TestEdit_ConfigFile_OverridesByFlag(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeEditSvc{
+		getResp: &sdk.Agent{
+			Name:   "X",
+			Config: &sdk.AgentConfig{ModelID: "old-model", Temperature: 0.1},
+		},
+		updateResp: &sdk.Agent{},
+	}
+	opts := &EditOptions{
+		AgentID:        "ag_abc",
+		Temperature:    0.9,
+		ConfigFileBody: bytes.NewBufferString(`{"temperature":0.5,"model_id":"file-model"}`),
+		ConfigFileKind: "json",
+		flags:          editFlagSet{temperatureSet: true, configFileSet: true},
+	}
+	require.NoError(t, runEdit(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	require.NotNil(t, svc.updateReq.Config)
+	assert.Equal(t, "file-model", svc.updateReq.Config.ModelID, "file overrides current state")
+	assert.InDelta(t, 0.9, svc.updateReq.Config.Temperature, 0.001, "flag overrides file")
+}
+
+// TestEdit_ConfigFile_FullReplacesBaseline pins the documented behavior:
+// --config-file fully replaces the AgentConfig baseline; current-server
+// fields not mentioned in the file are zeroed. The Long help directs
+// users to surgical flags when they want a partial update.
+func TestEdit_ConfigFile_FullReplacesBaseline(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeEditSvc{
+		getResp: &sdk.Agent{
+			Name: "X",
+			Config: &sdk.AgentConfig{
+				SystemPrompt:   "Existing prompt",
+				ModelID:        "old-model",
+				Temperature:    0.1,
+				AgentMode:      "smart-reasoning",
+				KnowledgeBases: []string{"kb_existing"},
+			},
+		},
+		updateResp: &sdk.Agent{},
+	}
+	opts := &EditOptions{
+		AgentID:        "ag_abc",
+		ConfigFileBody: bytes.NewBufferString(`{"model_id":"file-only"}`),
+		ConfigFileKind: "json",
+		flags:          editFlagSet{configFileSet: true},
+	}
+	require.NoError(t, runEdit(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	require.NotNil(t, svc.updateReq.Config)
+	assert.Equal(t, "file-only", svc.updateReq.Config.ModelID, "file's model_id applied")
+	assert.Equal(t, "", svc.updateReq.Config.SystemPrompt, "file fully replaces baseline; unset fields are zeroed")
+	assert.InDelta(t, 0.0, svc.updateReq.Config.Temperature, 0.001, "unset fields zeroed")
+	assert.Equal(t, "", svc.updateReq.Config.AgentMode, "unset fields zeroed")
+	assert.Empty(t, svc.updateReq.Config.KnowledgeBases, "unset fields zeroed")
+}
+
+func TestEdit_NotFound(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeEditSvc{getErr: errBadHTTP404}
+	opts := &EditOptions{AgentID: "ag_missing", Name: "x", flags: editFlagSet{nameSet: true}}
+	err := runEdit(context.Background(), opts, &cmdutil.JSONOptions{}, svc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resource.not_found")
+}
+
+func TestEdit_AddKB_AppendsToExisting(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeEditSvc{
+		getResp:    &sdk.Agent{Config: &sdk.AgentConfig{KnowledgeBases: []string{"kb_a"}}},
+		updateResp: &sdk.Agent{},
+	}
+	opts := &EditOptions{
+		AgentID: "ag_abc",
+		AddKBs:  []string{"kb_b", "kb_c"},
+		flags:   editFlagSet{addKBsSet: true},
+	}
+	require.NoError(t, runEdit(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	assert.Equal(t, []string{"kb_a", "kb_b", "kb_c"}, svc.updateReq.Config.KnowledgeBases)
+}
+
+func TestEdit_Temperature_Bounds(t *testing.T) {
+	for _, badT := range []float64{-0.1, 2.1, 100.0} {
+		t.Run(fmt.Sprintf("t=%g", badT), func(t *testing.T) {
+			cmd := NewCmdEdit(nil)
+			cmd.SetArgs([]string{"ag_abc", "--temperature", fmt.Sprintf("%f", badT)})
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			err := cmd.Execute()
+			require.Error(t, err, "expected error for --temperature %g", badT)
+			assert.Contains(t, err.Error(), "0.0..2.0")
+		})
+	}
+}
+
+func TestEdit_SystemPromptFile(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeEditSvc{
+		getResp:    &sdk.Agent{Config: &sdk.AgentConfig{ModelID: "m"}},
+		updateResp: &sdk.Agent{},
+	}
+	opts := &EditOptions{
+		AgentID:            "ag_abc",
+		SystemPromptReader: strings.NewReader("new prompt\n"),
+		flags:              editFlagSet{systemPromptSet: true},
+	}
+	require.NoError(t, runEdit(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	assert.Equal(t, "new prompt", svc.updateReq.Config.SystemPrompt)
+}

--- a/cli/cmd/agent/edit_test.go
+++ b/cli/cmd/agent/edit_test.go
@@ -44,7 +44,7 @@ func TestEdit_FetchThenUpdate_PreservesUntouchedFields(t *testing.T) {
 	svc := &fakeEditSvc{
 		getResp: &sdk.Agent{
 			ID: "ag_abc", Name: "Original", Description: "Keep me",
-			Config: &sdk.AgentConfig{ModelID: "gpt-4", Temperature: 0.7, KnowledgeBases: []string{"kb_a"}},
+			Config: &sdk.AgentConfig{ModelID: "model-x", Temperature: 0.7, KnowledgeBases: []string{"kb_a"}},
 		},
 		updateResp: &sdk.Agent{ID: "ag_abc"},
 	}
@@ -59,7 +59,7 @@ func TestEdit_FetchThenUpdate_PreservesUntouchedFields(t *testing.T) {
 	assert.Equal(t, "Original", svc.updateReq.Name, "Name must round-trip unchanged")
 	assert.Equal(t, "Updated", svc.updateReq.Description)
 	require.NotNil(t, svc.updateReq.Config)
-	assert.Equal(t, "gpt-4", svc.updateReq.Config.ModelID, "ModelID must round-trip")
+	assert.Equal(t, "model-x", svc.updateReq.Config.ModelID, "ModelID must round-trip")
 	assert.Equal(t, []string{"kb_a"}, svc.updateReq.Config.KnowledgeBases, "KBs must round-trip")
 	assert.InDelta(t, 0.7, svc.updateReq.Config.Temperature, 0.001)
 }

--- a/cli/cmd/agent/view.go
+++ b/cli/cmd/agent/view.go
@@ -10,8 +10,14 @@ import (
 
 	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
 	"github.com/Tencent/WeKnora/cli/internal/iostreams"
+	"github.com/Tencent/WeKnora/cli/internal/text"
 	sdk "github.com/Tencent/WeKnora/client"
 )
+
+// promptPreviewWidth caps inline KV row prompt previews. Multi-line prompts
+// collapse to one line via text.OneLine; the Templates section gets the
+// full multi-line treatment instead.
+const promptPreviewWidth = 80
 
 // agentViewFields enumerates fields surfaced for `--json=` field discovery
 // on `agent view`. Only top-level Agent keys are listed because the
@@ -77,9 +83,9 @@ func runView(ctx context.Context, jopts *cmdutil.JSONOptions, svc ViewService, a
 }
 
 // renderAgent prints a single agent in human-readable form, grouped into
-// 10 presentation sections (spec §2.9). Zero-value fields are omitted;
-// a section header prints only when at least one of its fields is set.
-// Group labels and order match the spec exactly so spec drift surfaces
+// 10 presentation sections. Zero-value fields are omitted; a section
+// header prints only when at least one of its fields is set. Group
+// labels and order are pinned by snapshot tests so future drift surfaces
 // as test failure rather than silent divergence.
 func renderAgent(w io.Writer, a *sdk.Agent) {
 	// Identity is always rendered — id/name/created_at/updated_at are
@@ -186,10 +192,10 @@ func renderAgent(w io.Writer, a *sdk.Agent) {
 		qr = append(qr, row{"Query understand model ID", c.QueryUnderstandModelID})
 	}
 	if c.RewritePromptSystem != "" {
-		qr = append(qr, row{"Rewrite prompt (system)", truncate1Line(c.RewritePromptSystem)})
+		qr = append(qr, row{"Rewrite prompt (system)", text.OneLine(promptPreviewWidth, c.RewritePromptSystem)})
 	}
 	if c.RewritePromptUser != "" {
-		qr = append(qr, row{"Rewrite prompt (user)", truncate1Line(c.RewritePromptUser)})
+		qr = append(qr, row{"Rewrite prompt (user)", text.OneLine(promptPreviewWidth, c.RewritePromptUser)})
 	}
 	emit("Query rewrite", qr)
 
@@ -251,7 +257,7 @@ func renderAgent(w io.Writer, a *sdk.Agent) {
 		fb = append(fb, row{"Response", c.FallbackResponse})
 	}
 	if c.FallbackPrompt != "" {
-		fb = append(fb, row{"Prompt", truncate1Line(c.FallbackPrompt)})
+		fb = append(fb, row{"Prompt", text.OneLine(promptPreviewWidth, c.FallbackPrompt)})
 	}
 	emit("Fallback", fb)
 
@@ -269,18 +275,6 @@ func renderAgent(w io.Writer, a *sdk.Agent) {
 			writeIndented(w, c.ContextTemplate, "    ")
 		}
 	}
-}
-
-// truncate1Line collapses newlines and clips long values for inline KV
-// rows. Templates section gets full multi-line treatment instead.
-func truncate1Line(s string) string {
-	s = strings.ReplaceAll(s, "\n", " ")
-	s = strings.ReplaceAll(s, "\r", " ")
-	const max = 80
-	if len(s) > max {
-		return s[:max-3] + "..."
-	}
-	return s
 }
 
 // writeIndented prints s with the given prefix on every line. Trailing

--- a/cli/cmd/agent/view.go
+++ b/cli/cmd/agent/view.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -12,13 +13,16 @@ import (
 	sdk "github.com/Tencent/WeKnora/client"
 )
 
-// agentViewFields enumerates fields surfaced for `--json` discovery on
-// `agent view`. Filter applies to the bare Agent object. Config sub-fields
-// are intentionally omitted - too granular for naked projection; use
-// `--jq '.config'` to reach them.
+// agentViewFields enumerates fields surfaced for `--json=` field discovery
+// on `agent view`. Only top-level Agent keys are listed because the
+// `--json=foo,bar` field-projection filter matches flat top-level keys
+// (see internal/format/filter.go). Nested AgentConfig fields are reachable
+// via `--jq '.config.system_prompt'` or by selecting `config` whole and
+// post-processing — listing them here would misleadingly advertise a
+// projection path that does not actually filter to them.
 var agentViewFields = []string{
 	"id", "name", "description", "avatar",
-	"is_builtin", "tenant_id", "created_by",
+	"is_builtin", "tenant_id", "created_by", "config",
 	"created_at", "updated_at",
 }
 
@@ -32,12 +36,17 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "view <agent-id>",
 		Short: "Show a custom agent's configuration",
-		Long: `Renders the agent's metadata (id / name / description / created-by /
-timestamps) plus a compact config summary (mode, model, allowed tools, KB
-scope). Pass --json for the full Agent object including the nested config
-struct - or --jq '.config' to extract just the config.`,
+		Long: `Renders the agent's metadata and full AgentConfig as grouped KV
+sections (Identity / LLM / KB attachment / Retrieval / Query rewrite /
+Tools / FAQ / Web search / Multi-turn / Fallback / Templates). Zero-value
+fields are omitted; sections with no set fields are suppressed entirely.
+
+Pass --json for the bare SDK Agent object (config nested, not flattened).
+Field projection (--json=id,name) works on top-level keys only; reach
+nested config fields via --jq.`,
 		Example: `  weknora agent view ag_abc
-  weknora agent view ag_abc --json | jq '.config.allowed_tools'`,
+  weknora agent view ag_abc --json=id,name,config       # top-level projection
+  weknora agent view ag_abc --json --jq '.config.system_prompt'`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			jopts, err := cmdutil.CheckJSONFlags(c)
@@ -67,47 +76,217 @@ func runView(ctx context.Context, jopts *cmdutil.JSONOptions, svc ViewService, a
 	return nil
 }
 
-// renderAgent prints a single agent in human-readable KV form. Empty
-// fields are omitted (mirrors doc view / kb view); the Config block is
-// compacted to its agent-mode-defining keys.
+// renderAgent prints a single agent in human-readable form, grouped into
+// 10 presentation sections (spec §2.9). Zero-value fields are omitted;
+// a section header prints only when at least one of its fields is set.
+// Group labels and order match the spec exactly so spec drift surfaces
+// as test failure rather than silent divergence.
 func renderAgent(w io.Writer, a *sdk.Agent) {
-	fmt.Fprintf(w, "ID:           %s\n", a.ID)
-	fmt.Fprintf(w, "Name:         %s\n", a.Name)
+	// Identity is always rendered — id/name/created_at/updated_at are
+	// never meaningfully empty for a fetched Agent.
+	fmt.Fprintln(w, "Identity:")
+	fmt.Fprintf(w, "  ID:           %s\n", a.ID)
+	fmt.Fprintf(w, "  Name:         %s\n", a.Name)
 	if a.Description != "" {
-		fmt.Fprintf(w, "Description:  %s\n", a.Description)
+		fmt.Fprintf(w, "  Description:  %s\n", a.Description)
 	}
 	if a.IsBuiltin {
-		fmt.Fprintln(w, "Builtin:      yes")
+		fmt.Fprintln(w, "  Builtin:      yes")
 	}
 	if a.CreatedBy != "" {
-		fmt.Fprintf(w, "Created by:   %s\n", a.CreatedBy)
+		fmt.Fprintf(w, "  Created by:   %s\n", a.CreatedBy)
 	}
-	fmt.Fprintf(w, "Created at:   %s\n", a.CreatedAt.Format("2006-01-02 15:04:05"))
-	fmt.Fprintf(w, "Updated at:   %s\n", a.UpdatedAt.Format("2006-01-02 15:04:05"))
+	if a.TenantID != 0 {
+		fmt.Fprintf(w, "  Tenant ID:    %d\n", a.TenantID)
+	}
+	fmt.Fprintf(w, "  Created at:   %s\n", a.CreatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(w, "  Updated at:   %s\n", a.UpdatedAt.Format("2006-01-02 15:04:05"))
+
 	if a.Config == nil {
 		return
 	}
-	fmt.Fprintln(w)
-	fmt.Fprintln(w, "Config:")
-	if a.Config.AgentMode != "" {
-		fmt.Fprintf(w, "  Mode:                %s\n", a.Config.AgentMode)
+	c := a.Config
+
+	// Each group is rendered via a tiny helper: collect its set rows
+	// upfront, suppress the whole section if empty. Avoids the
+	// "header printed but no body" failure mode that plagues naive
+	// conditional rendering.
+	type row struct{ k, v string }
+	emit := func(label string, rows []row) {
+		if len(rows) == 0 {
+			return
+		}
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "%s:\n", label)
+		for _, r := range rows {
+			fmt.Fprintf(w, "  %-32s %s\n", r.k+":", r.v)
+		}
 	}
-	if a.Config.ModelID != "" {
-		fmt.Fprintf(w, "  Model ID:            %s\n", a.Config.ModelID)
+
+	// LLM
+	llm := []row{}
+	if c.ModelID != "" {
+		llm = append(llm, row{"Model ID", c.ModelID})
 	}
-	if a.Config.RerankModelID != "" {
-		fmt.Fprintf(w, "  Rerank model ID:     %s\n", a.Config.RerankModelID)
+	if c.RerankModelID != "" {
+		llm = append(llm, row{"Rerank model ID", c.RerankModelID})
 	}
-	if a.Config.KBSelectionMode != "" {
-		fmt.Fprintf(w, "  KB selection mode:   %s\n", a.Config.KBSelectionMode)
+	if c.Temperature != 0 {
+		llm = append(llm, row{"Temperature", fmt.Sprintf("%g", c.Temperature)})
 	}
-	if len(a.Config.KnowledgeBases) > 0 {
-		fmt.Fprintf(w, "  Knowledge bases:     %v\n", a.Config.KnowledgeBases)
+	if c.MaxCompletionTokens != 0 {
+		llm = append(llm, row{"Max completion tokens", fmt.Sprintf("%d", c.MaxCompletionTokens)})
 	}
-	if len(a.Config.AllowedTools) > 0 {
-		fmt.Fprintf(w, "  Allowed tools:       %v\n", a.Config.AllowedTools)
+	if c.MaxIterations != 0 {
+		llm = append(llm, row{"Max iterations", fmt.Sprintf("%d", c.MaxIterations)})
 	}
-	if a.Config.WebSearchEnabled {
-		fmt.Fprintln(w, "  Web search:          enabled")
+	if c.AgentMode != "" {
+		llm = append(llm, row{"Mode", c.AgentMode})
+	}
+	emit("LLM", llm)
+
+	// KB attachment
+	kb := []row{}
+	if c.KBSelectionMode != "" {
+		kb = append(kb, row{"KB selection mode", c.KBSelectionMode})
+	}
+	if len(c.KnowledgeBases) > 0 {
+		kb = append(kb, row{"Knowledge bases", strings.Join(c.KnowledgeBases, ", ")})
+	}
+	emit("KB attachment", kb)
+
+	// Retrieval
+	retr := []row{}
+	if c.EmbeddingTopK != 0 {
+		retr = append(retr, row{"Embedding top K", fmt.Sprintf("%d", c.EmbeddingTopK)})
+	}
+	if c.KeywordThreshold != 0 {
+		retr = append(retr, row{"Keyword threshold", fmt.Sprintf("%g", c.KeywordThreshold)})
+	}
+	if c.VectorThreshold != 0 {
+		retr = append(retr, row{"Vector threshold", fmt.Sprintf("%g", c.VectorThreshold)})
+	}
+	if c.RerankTopK != 0 {
+		retr = append(retr, row{"Rerank top K", fmt.Sprintf("%d", c.RerankTopK)})
+	}
+	if c.RerankThreshold != 0 {
+		retr = append(retr, row{"Rerank threshold", fmt.Sprintf("%g", c.RerankThreshold)})
+	}
+	emit("Retrieval", retr)
+
+	// Query rewrite
+	qr := []row{}
+	if c.EnableQueryExpansion {
+		qr = append(qr, row{"Query expansion", "enabled"})
+	}
+	if c.EnableRewrite {
+		qr = append(qr, row{"Rewrite", "enabled"})
+	}
+	if c.QueryUnderstandModelID != "" {
+		qr = append(qr, row{"Query understand model ID", c.QueryUnderstandModelID})
+	}
+	if c.RewritePromptSystem != "" {
+		qr = append(qr, row{"Rewrite prompt (system)", truncate1Line(c.RewritePromptSystem)})
+	}
+	if c.RewritePromptUser != "" {
+		qr = append(qr, row{"Rewrite prompt (user)", truncate1Line(c.RewritePromptUser)})
+	}
+	emit("Query rewrite", qr)
+
+	// Tools
+	tools := []row{}
+	if len(c.AllowedTools) > 0 {
+		tools = append(tools, row{"Allowed tools", strings.Join(c.AllowedTools, ", ")})
+	}
+	if c.MCPSelectionMode != "" {
+		tools = append(tools, row{"MCP selection mode", c.MCPSelectionMode})
+	}
+	if len(c.MCPServices) > 0 {
+		tools = append(tools, row{"MCP services", strings.Join(c.MCPServices, ", ")})
+	}
+	if len(c.SupportedFileTypes) > 0 {
+		tools = append(tools, row{"Supported file types", strings.Join(c.SupportedFileTypes, ", ")})
+	}
+	emit("Tools", tools)
+
+	// FAQ
+	faq := []row{}
+	if c.FAQPriorityEnabled {
+		faq = append(faq, row{"FAQ priority", "enabled"})
+	}
+	if c.FAQDirectAnswerThreshold != 0 {
+		faq = append(faq, row{"FAQ direct-answer threshold", fmt.Sprintf("%g", c.FAQDirectAnswerThreshold)})
+	}
+	if c.FAQScoreBoost != 0 {
+		faq = append(faq, row{"FAQ score boost", fmt.Sprintf("%g", c.FAQScoreBoost)})
+	}
+	emit("FAQ", faq)
+
+	// Web search
+	web := []row{}
+	if c.WebSearchEnabled {
+		web = append(web, row{"Web search", "enabled"})
+	}
+	if c.WebSearchMaxResults != 0 {
+		web = append(web, row{"Web search max results", fmt.Sprintf("%d", c.WebSearchMaxResults)})
+	}
+	emit("Web search", web)
+
+	// Multi-turn
+	mt := []row{}
+	if c.MultiTurnEnabled {
+		mt = append(mt, row{"Multi-turn", "enabled"})
+	}
+	if c.HistoryTurns != 0 {
+		mt = append(mt, row{"History turns", fmt.Sprintf("%d", c.HistoryTurns)})
+	}
+	emit("Multi-turn", mt)
+
+	// Fallback
+	fb := []row{}
+	if c.FallbackStrategy != "" {
+		fb = append(fb, row{"Strategy", c.FallbackStrategy})
+	}
+	if c.FallbackResponse != "" {
+		fb = append(fb, row{"Response", c.FallbackResponse})
+	}
+	if c.FallbackPrompt != "" {
+		fb = append(fb, row{"Prompt", truncate1Line(c.FallbackPrompt)})
+	}
+	emit("Fallback", fb)
+
+	// Templates — system_prompt and context_template can be multi-line;
+	// render headed blocks rather than KV rows for readability.
+	if c.SystemPrompt != "" || c.ContextTemplate != "" {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Templates:")
+		if c.SystemPrompt != "" {
+			fmt.Fprintln(w, "  System prompt:")
+			writeIndented(w, c.SystemPrompt, "    ")
+		}
+		if c.ContextTemplate != "" {
+			fmt.Fprintln(w, "  Context template:")
+			writeIndented(w, c.ContextTemplate, "    ")
+		}
+	}
+}
+
+// truncate1Line collapses newlines and clips long values for inline KV
+// rows. Templates section gets full multi-line treatment instead.
+func truncate1Line(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	const max = 80
+	if len(s) > max {
+		return s[:max-3] + "..."
+	}
+	return s
+}
+
+// writeIndented prints s with the given prefix on every line. Trailing
+// newline always added so the next section starts on its own line.
+func writeIndented(w io.Writer, s, prefix string) {
+	for _, line := range strings.Split(strings.TrimRight(s, "\n"), "\n") {
+		fmt.Fprintf(w, "%s%s\n", prefix, line)
 	}
 }

--- a/cli/cmd/agent/view_test.go
+++ b/cli/cmd/agent/view_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -44,10 +45,79 @@ func TestView_Human_RendersMetadataAndConfig(t *testing.T) {
 		t.Fatalf("runView: %v", err)
 	}
 	got := out.String()
-	for _, want := range []string{"ag_abc", "Research", "deep-dive helper", "Builtin:", "Config:", "smart-reasoning", "model_42", "selected", "kb_x", "knowledge_search", "Web search:"} {
+	for _, want := range []string{"ag_abc", "Research", "deep-dive helper", "Builtin:", "Identity", "LLM", "KB attachment", "Tools", "smart-reasoning", "model_42", "selected", "kb_x", "knowledge_search", "Web search"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("missing %q in:\n%s", want, got)
 		}
+	}
+}
+
+// TestAgentViewFields_TopLevelOnly pins the contract that `--json=` field
+// discovery on `agent view` only lists top-level Agent keys (including
+// `config` as a whole). Nested AgentConfig fields are NOT in the list
+// because the filter at internal/format/filter.go matches flat top-level
+// keys only — listing `config.system_prompt` etc. would advertise a
+// projection path that silently returns nothing.
+func TestAgentViewFields_TopLevelOnly(t *testing.T) {
+	for _, want := range []string{"id", "name", "config", "created_at"} {
+		if !slices.Contains(agentViewFields, want) {
+			t.Errorf("agentViewFields missing top-level key %q", want)
+		}
+	}
+	for _, dotted := range []string{"config.system_prompt", "config.model_id", "config.fallback_strategy"} {
+		if slices.Contains(agentViewFields, dotted) {
+			t.Errorf("agentViewFields must not list dotted nested key %q (filter does not support nested projection)", dotted)
+		}
+	}
+}
+
+// TestRenderAgent_RendersAllGroupsWithOmitEmpty validates the grouped
+// human rendering: present groups print, zero-value fields omit, and an
+// entire section is suppressed when all of its fields are zero.
+func TestRenderAgent_RendersAllGroupsWithOmitEmpty(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	ag := &sdk.Agent{
+		ID:   "ag_abc",
+		Name: "Test",
+		Config: &sdk.AgentConfig{
+			AgentMode:          "smart-reasoning",
+			SystemPrompt:       "You help users.",
+			ModelID:            "gpt-4",
+			Temperature:        0.7,
+			KBSelectionMode:    "selected",
+			KnowledgeBases:     []string{"kb_a"},
+			FAQPriorityEnabled: true,
+			WebSearchEnabled:   false, // zero — omitted in human
+			FallbackStrategy:   "fixed",
+			FallbackResponse:   "I don't know.",
+		},
+	}
+	renderAgent(iostreams.IO.Out, ag)
+	body := out.String()
+	// Group labels appear:
+	for _, label := range []string{"Identity", "LLM", "KB attachment", "FAQ", "Fallback", "Templates"} {
+		if !strings.Contains(body, label) {
+			t.Errorf("missing group label %q in:\n%s", label, body)
+		}
+	}
+	// Set fields rendered:
+	for _, want := range []string{"smart-reasoning", "gpt-4", "You help users."} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing value %q in:\n%s", want, body)
+		}
+	}
+	// Zero-value fields omitted (web search disabled → max_results not shown):
+	if strings.Contains(body, "web_search_max_results") {
+		t.Errorf("zero-valued web_search_max_results leaked into:\n%s", body)
+	}
+	// Section with all zero values must be suppressed entirely (no Retrieval
+	// fields were set in this fixture).
+	if strings.Contains(body, "Retrieval") {
+		t.Errorf("Retrieval section rendered with all-zero fields in:\n%s", body)
+	}
+	// Multi-turn section is all-zero too — must be suppressed.
+	if strings.Contains(body, "Multi-turn") {
+		t.Errorf("Multi-turn section rendered with all-zero fields in:\n%s", body)
 	}
 }
 
@@ -69,8 +139,11 @@ func TestView_Human_OmitsEmptyFields(t *testing.T) {
 	if strings.Contains(got, "Builtin:") {
 		t.Errorf("non-builtin should not render Builtin: line, got:\n%s", got)
 	}
-	if strings.Contains(got, "Config:") {
-		t.Errorf("nil Config should not render Config: section, got:\n%s", got)
+	// With Config==nil none of the grouped config sections should appear.
+	for _, label := range []string{"LLM:", "KB attachment:", "Retrieval:", "Query rewrite:", "Tools:", "FAQ:", "Web search:", "Multi-turn:", "Fallback:", "Templates:"} {
+		if strings.Contains(got, label) {
+			t.Errorf("nil Config should not render %q, got:\n%s", label, got)
+		}
 	}
 }
 

--- a/cli/cmd/agent/view_test.go
+++ b/cli/cmd/agent/view_test.go
@@ -82,7 +82,7 @@ func TestRenderAgent_RendersAllGroupsWithOmitEmpty(t *testing.T) {
 		Config: &sdk.AgentConfig{
 			AgentMode:          "smart-reasoning",
 			SystemPrompt:       "You help users.",
-			ModelID:            "gpt-4",
+			ModelID:            "model-x",
 			Temperature:        0.7,
 			KBSelectionMode:    "selected",
 			KnowledgeBases:     []string{"kb_a"},
@@ -101,7 +101,7 @@ func TestRenderAgent_RendersAllGroupsWithOmitEmpty(t *testing.T) {
 		}
 	}
 	// Set fields rendered:
-	for _, want := range []string{"smart-reasoning", "gpt-4", "You help users."} {
+	for _, want := range []string{"smart-reasoning", "model-x", "You help users."} {
 		if !strings.Contains(body, want) {
 			t.Errorf("missing value %q in:\n%s", want, body)
 		}

--- a/cli/cmd/auth/login.go
+++ b/cli/cmd/auth/login.go
@@ -43,7 +43,7 @@ type LoginService interface {
 
 // apiKeyValidator probes /auth/me with the supplied API key so a bad key
 // fails fast at `auth login --with-token` time rather than on the next
-// authenticated call. Mirrors gh CLI's pre-persist token verification.
+// authenticated call.
 //
 // Returns the resolved user (used to populate context.User / TenantID at
 // rest, so later `auth list` reflects who owns the key).
@@ -123,7 +123,7 @@ func runLogin(ctx context.Context, opts *LoginOptions, jopts *cmdutil.JSONOption
 		}
 		opts.APIKey = key
 		// Validate against the server before persisting so a typo'd /
-		// expired / wrong-host key fails fast (gh CLI parity). The probe
+		// expired / wrong-host key fails fast at login time. The probe
 		// is /auth/me - read-only, side-effect-free.
 		user, err := defaultAPIKeyValidator(ctx, opts.Host, key)
 		if err != nil {

--- a/cli/cmd/auth/status.go
+++ b/cli/cmd/auth/status.go
@@ -14,7 +14,8 @@ import (
 // authStatusFields enumerates the fields surfaced for `--json` discovery
 // on `auth status`. Single-resource shape: filter applies to data itself.
 var authStatusFields = []string{
-	"context", "user_id", "email", "tenant_id", "tenant_name",
+	"context", "user_id", "username", "email", "is_active",
+	"can_access_all_tenants", "tenant_id", "tenant_name",
 }
 
 // StatusService is the narrow SDK surface auth status depends on.
@@ -22,13 +23,19 @@ type StatusService interface {
 	GetCurrentUser(ctx context.Context) (*sdk.CurrentUserResponse, error)
 }
 
-// statusResult is the typed payload emitted by `--json`.
+// statusResult is the typed payload emitted by `--json`. Mirrors the
+// SDK AuthUser + AuthTenant projection so agents can branch on
+// can_access_all_tenants (cross-tenant admin) and is_active (disabled
+// account) without a second round-trip.
 type statusResult struct {
-	Context    string `json:"context"`
-	UserID     string `json:"user_id,omitempty"`
-	Email      string `json:"email,omitempty"`
-	TenantID   uint64 `json:"tenant_id,omitempty"`
-	TenantName string `json:"tenant_name,omitempty"`
+	Context             string `json:"context"`
+	UserID              string `json:"user_id,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Email               string `json:"email,omitempty"`
+	IsActive            bool   `json:"is_active,omitempty"`
+	CanAccessAllTenants bool   `json:"can_access_all_tenants,omitempty"`
+	TenantID            uint64 `json:"tenant_id,omitempty"`
+	TenantName          string `json:"tenant_name,omitempty"`
 }
 
 // NewCmdStatus builds the `weknora auth status` command.
@@ -80,7 +87,10 @@ func runStatus(ctx context.Context, jopts *cmdutil.JSONOptions, f *cmdutil.Facto
 		result := statusResult{Context: cfg.CurrentContext}
 		if user != nil {
 			result.UserID = user.ID
+			result.Username = user.Username
 			result.Email = user.Email
+			result.IsActive = user.IsActive
+			result.CanAccessAllTenants = user.CanAccessAllTenants
 			result.TenantID = user.TenantID
 		}
 		if tenant != nil {

--- a/cli/cmd/chat/chat.go
+++ b/cli/cmd/chat/chat.go
@@ -63,9 +63,9 @@ type chatData struct {
 	Answer     string              `json:"answer"`
 	References []*sdk.SearchResult `json:"references"`
 	// Thinking holds the reasoning / reflection text emitted by reasoning
-	// models (GPT-5, Claude extended thinking) via response_type=thinking
-	// frames. Omitted when empty (non-reasoning model or model didn't
-	// surface reasoning for this query).
+	// models via response_type=thinking frames. Omitted when empty
+	// (non-reasoning model or model didn't surface reasoning for this
+	// query).
 	Thinking           string `json:"thinking,omitempty"`
 	SessionID          string `json:"session_id"`
 	AssistantMessageID string `json:"assistant_message_id,omitempty"`

--- a/cli/cmd/chunk/chunk.go
+++ b/cli/cmd/chunk/chunk.go
@@ -1,0 +1,37 @@
+// Package chunkcmd implements the `chunk` verb subtree for managing
+// document chunks in a knowledge base. The directory is named `chunk/`
+// (cobra noun-verb convention) but the Go package is `chunkcmd` to
+// avoid colliding with cobra's *cobra.Command identifier.
+//
+// "chunk" in this subtree refers to indexed pieces of a knowledge
+// document (server resource: GET/DELETE /chunks/...). Each document
+// has many chunks; the chunking pipeline produces them at ingest time.
+package chunkcmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
+)
+
+const chunkLong = `Manage and inspect document chunks.
+
+Chunks are the indexed pieces of a knowledge document (1 doc → many chunks).
+Use 'chunk list' to enumerate chunks in stored order (RAG admin / debug).
+For relevance-ranked retrieval, use 'search chunks "<query>" --kb <id>'
+instead — that runs hybrid vector + keyword scoring across all chunks.`
+
+// NewCmdChunk builds the parent `chunk` command. Called from cli/cmd/root.go.
+func NewCmdChunk(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "chunk <subcommand>",
+		Short: "Manage document chunks (RAG retrieval debug)",
+		Long:  chunkLong,
+		Args:  cobra.NoArgs,
+		Run:   func(c *cobra.Command, _ []string) { _ = c.Help() },
+	}
+	cmd.AddCommand(NewCmdList(f))
+	cmd.AddCommand(NewCmdView(f))
+	cmd.AddCommand(NewCmdDelete(f))
+	return cmd
+}

--- a/cli/cmd/chunk/delete.go
+++ b/cli/cmd/chunk/delete.go
@@ -1,0 +1,108 @@
+package chunkcmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
+	"github.com/Tencent/WeKnora/cli/internal/iostreams"
+	"github.com/Tencent/WeKnora/cli/internal/prompt"
+)
+
+// chunkDeleteFields enumerates the JSON discovery fields for `chunk delete`.
+// Result payload is a tiny {id, deleted} object — mirrors `kb delete` /
+// `agent delete`.
+var chunkDeleteFields = []string{"id", "deleted"}
+
+// DeleteOptions captures `chunk delete` flag state.
+type DeleteOptions struct {
+	ChunkID string
+	DocID   string // required: SDK DeleteChunk takes both ids in the route.
+	Yes     bool   // sourced from the global -y/--yes persistent flag
+}
+
+// DeleteService is the narrow SDK surface this command depends on.
+type DeleteService interface {
+	DeleteChunk(ctx context.Context, docID, chunkID string) error
+}
+
+// deleteResult is the typed payload emitted on success in JSON mode.
+type deleteResult struct {
+	ID      string `json:"id"`
+	Deleted bool   `json:"deleted"`
+}
+
+// Delete is NOT idempotent on a missing id — it surfaces resource.not_found
+// (exit 4). Idempotent-already-true semantics are reserved for `unlink`-style
+// local cleanups, not server-side resource removal. Mirrors `agent delete`
+// and `kb delete`.
+const chunkDeleteLong = `Permanently delete a chunk from a document.
+
+Requires both the chunk id (positional) and the parent document id
+(--doc) because the server route encodes both: DELETE /chunks/{doc}/{id}.
+The CLI does not auto-resolve doc id from the chunk id because doing so
+would add a round-trip and open a race with the ingest pipeline (a chunk
+could move between documents between resolve and delete).
+
+Prompts for confirmation by default when stdout is a TTY and --json is
+not set. Pass -y/--yes (the global flag) to skip the prompt (required in
+agent / CI / piped contexts).
+
+Typed exit codes:
+  resource.not_found            no chunk with the given id under that doc (exit 4)
+  auth.forbidden                caller lacks delete permission on the chunk (exit 3)
+  input.confirmation_required   destructive op without -y on a TTY (exit 10)
+
+AI agents: this is a high-risk write. Without -y/--yes the CLI exits 10
+and writes input.confirmation_required to stderr. NEVER auto-pass -y
+without the user's explicit go-ahead — the exit-10 protocol exists
+exactly to guard against unintended deletes.`
+
+const chunkDeleteExample = `  weknora chunk delete chunk_abc --doc doc_xyz           # interactive confirm
+  weknora chunk delete chunk_abc --doc doc_xyz -y        # no prompt
+  weknora chunk delete chunk_abc --doc doc_xyz -y --json # bare {id, deleted:true} JSON`
+
+// NewCmdDelete builds `weknora chunk delete <chunk-id> --doc <doc-id>`.
+func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
+	opts := &DeleteOptions{}
+	cmd := &cobra.Command{
+		Use:     "delete <chunk-id> --doc <doc-id>",
+		Short:   "Delete a chunk from a document (scoped)",
+		Long:    chunkDeleteLong,
+		Example: chunkDeleteExample,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			jopts, err := cmdutil.CheckJSONFlags(c)
+			if err != nil {
+				return err
+			}
+			opts.ChunkID = args[0]
+			opts.Yes, _ = c.Flags().GetBool("yes")
+			cli, err := f.Client()
+			if err != nil {
+				return err
+			}
+			return runDelete(c.Context(), opts, jopts, cli, f.Prompter())
+		},
+	}
+	cmd.Flags().StringVar(&opts.DocID, "doc", "", "Parent document id (SDK knowledge_id) the chunk lives under")
+	_ = cmd.MarkFlagRequired("doc")
+	cmdutil.AddJSONFlags(cmd, chunkDeleteFields)
+	return cmd
+}
+
+func runDelete(ctx context.Context, opts *DeleteOptions, jopts *cmdutil.JSONOptions, svc DeleteService, p prompt.Prompter) error {
+	if err := cmdutil.ConfirmDestructive(p, opts.Yes, jopts.Enabled(), "chunk", opts.ChunkID); err != nil {
+		return err
+	}
+	if err := svc.DeleteChunk(ctx, opts.DocID, opts.ChunkID); err != nil {
+		return cmdutil.WrapHTTP(err, "delete chunk %s", opts.ChunkID)
+	}
+	if jopts.Enabled() {
+		return jopts.Emit(iostreams.IO.Out, deleteResult{ID: opts.ChunkID, Deleted: true})
+	}
+	fmt.Fprintf(iostreams.IO.Out, "✓ Deleted chunk %s\n", opts.ChunkID)
+	return nil
+}

--- a/cli/cmd/chunk/delete.go
+++ b/cli/cmd/chunk/delete.go
@@ -16,7 +16,6 @@ import (
 // `agent delete`.
 var chunkDeleteFields = []string{"id", "deleted"}
 
-// DeleteOptions captures `chunk delete` flag state.
 type DeleteOptions struct {
 	ChunkID string
 	DocID   string // required: SDK DeleteChunk takes both ids in the route.

--- a/cli/cmd/chunk/delete_test.go
+++ b/cli/cmd/chunk/delete_test.go
@@ -1,0 +1,106 @@
+package chunkcmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
+	"github.com/Tencent/WeKnora/cli/internal/iostreams"
+	"github.com/Tencent/WeKnora/cli/internal/testutil"
+)
+
+type fakeChunkDeleteSvc struct {
+	gotDocID, gotChunkID string
+	err                  error
+}
+
+func (f *fakeChunkDeleteSvc) DeleteChunk(_ context.Context, docID, chunkID string) error {
+	f.gotDocID = docID
+	f.gotChunkID = chunkID
+	return f.err
+}
+
+func TestDelete_NonTTY_NoYes_ExitTen(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeChunkDeleteSvc{}
+	err := runDelete(context.Background(),
+		&DeleteOptions{ChunkID: "c1", DocID: "doc_abc", Yes: false},
+		&cmdutil.JSONOptions{}, svc, &testutil.ConfirmPrompter{})
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeInputConfirmationRequired, typed.Code)
+	assert.Empty(t, svc.gotChunkID, "must not call DeleteChunk without confirm")
+	assert.Equal(t, 10, cmdutil.ExitCode(err), "exit 10 per destructive-write protocol")
+}
+
+func TestDelete_WithYes_PassesBothIDs(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeChunkDeleteSvc{}
+	require.NoError(t, runDelete(context.Background(),
+		&DeleteOptions{ChunkID: "c1", DocID: "doc_abc", Yes: true},
+		&cmdutil.JSONOptions{}, svc, &testutil.ConfirmPrompter{}))
+	assert.Equal(t, "doc_abc", svc.gotDocID)
+	assert.Equal(t, "c1", svc.gotChunkID)
+}
+
+func TestDelete_MissingDoc_FlagError(t *testing.T) {
+	cmd := NewCmdDelete(nil)
+	cmd.SetArgs([]string{"c1"}) // no --doc
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	require.Error(t, cmd.Execute())
+}
+
+func TestDelete_404_PropagatesNotFound(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeChunkDeleteSvc{err: errors.New("HTTP error 404: not found")}
+	err := runDelete(context.Background(),
+		&DeleteOptions{ChunkID: "missing", DocID: "doc_abc", Yes: true},
+		&cmdutil.JSONOptions{}, svc, &testutil.ConfirmPrompter{})
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeResourceNotFound, typed.Code)
+}
+
+func TestDelete_TTY_ConfirmYes_Calls(t *testing.T) {
+	_, _ = iostreams.SetForTestWithTTY(t)
+	svc := &fakeChunkDeleteSvc{}
+	p := &testutil.ConfirmPrompter{Answer: true}
+	require.NoError(t, runDelete(context.Background(),
+		&DeleteOptions{ChunkID: "c1", DocID: "doc_abc"},
+		nil, svc, p))
+	assert.True(t, p.Asked)
+	assert.Equal(t, "c1", svc.gotChunkID)
+}
+
+func TestDelete_TTY_ConfirmNo_Aborts(t *testing.T) {
+	_, errBuf := iostreams.SetForTestWithTTY(t)
+	svc := &fakeChunkDeleteSvc{}
+	p := &testutil.ConfirmPrompter{Answer: false}
+	err := runDelete(context.Background(),
+		&DeleteOptions{ChunkID: "c1", DocID: "doc_abc"},
+		nil, svc, p)
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeUserAborted, typed.Code)
+	assert.Empty(t, svc.gotChunkID, "answer=no must not call DeleteChunk")
+	assert.Contains(t, errBuf.String(), "Aborted")
+}
+
+func TestDelete_JSON_BareObject(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeChunkDeleteSvc{}
+	require.NoError(t, runDelete(context.Background(),
+		&DeleteOptions{ChunkID: "c1", DocID: "doc_abc", Yes: true},
+		&cmdutil.JSONOptions{}, svc, &testutil.ConfirmPrompter{}))
+	body := out.String()
+	assert.Contains(t, body, `"id":"c1"`)
+	assert.Contains(t, body, `"deleted":true`)
+}

--- a/cli/cmd/chunk/list.go
+++ b/cli/cmd/chunk/list.go
@@ -3,7 +3,6 @@ package chunkcmd
 import (
 	"context"
 	"fmt"
-	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -39,7 +38,6 @@ type ListService interface {
 	ListKnowledgeChunks(ctx context.Context, knowledgeID string, page, pageSize int) ([]sdk.Chunk, int64, error)
 }
 
-// ListOptions captures `chunk list` flag state.
 type ListOptions struct {
 	// DocID scopes the listing to a single knowledge document (SDK
 	// `knowledge_id`). The chunks SDK does not expose a KB-wide route.
@@ -79,7 +77,7 @@ const chunkListExample = `  weknora chunk list --doc doc_abc
 
 // NewCmdList builds `weknora chunk list --doc <doc-id>`.
 func NewCmdList(f *cmdutil.Factory) *cobra.Command {
-	opts := &ListOptions{PageSize: defaultPageSize, Limit: defaultLimit}
+	opts := &ListOptions{}
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List chunks of a document (admin/debug, not retrieval)",
@@ -169,7 +167,7 @@ func runList(ctx context.Context, opts *ListOptions, jopts *cmdutil.JSONOptions,
 		if c.IsEnabled {
 			enabled = "yes"
 		}
-		preview := text.Truncate(previewWidth, singleLine(c.Content))
+		preview := text.OneLine(previewWidth, c.Content)
 		if preview == "" {
 			preview = "-"
 		}
@@ -182,8 +180,3 @@ func runList(ctx context.Context, opts *ListOptions, jopts *cmdutil.JSONOptions,
 	}
 	return tw.Flush()
 }
-
-// singleLine collapses newlines/carriage-returns/tabs to spaces so the
-// chunk preview fits on one row of the human table. Without this a
-// multi-line chunk would smear across rows and break tabwriter alignment.
-var singleLine = strings.NewReplacer("\n", " ", "\r", " ", "\t", " ").Replace

--- a/cli/cmd/chunk/list.go
+++ b/cli/cmd/chunk/list.go
@@ -1,0 +1,189 @@
+package chunkcmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
+	"github.com/Tencent/WeKnora/cli/internal/iostreams"
+	"github.com/Tencent/WeKnora/cli/internal/text"
+	sdk "github.com/Tencent/WeKnora/client"
+)
+
+const (
+	defaultPageSize = 50
+	maxPageSize     = 1000
+	defaultLimit    = 50
+	maxLimit        = 1000
+	previewWidth    = 80
+)
+
+// chunkListFields enumerates the fields surfaced for `--json` discovery on
+// `chunk list`. Mirrors sdk.Chunk json tags — all 23 fields are projectable
+// because chunk list returns bare SDK objects.
+var chunkListFields = []string{
+	"id", "seq_id", "knowledge_id", "knowledge_base_id", "tenant_id",
+	"tag_id", "content", "chunk_index", "is_enabled", "status",
+	"start_at", "end_at", "pre_chunk_id", "next_chunk_id", "chunk_type",
+	"parent_chunk_id", "relation_chunks", "indirect_relation_chunks",
+	"metadata", "content_hash", "image_info", "created_at", "updated_at",
+}
+
+// ListService is the narrow SDK surface this command depends on.
+type ListService interface {
+	ListKnowledgeChunks(ctx context.Context, knowledgeID string, page, pageSize int) ([]sdk.Chunk, int64, error)
+}
+
+// ListOptions captures `chunk list` flag state.
+type ListOptions struct {
+	// DocID scopes the listing to a single knowledge document (SDK
+	// `knowledge_id`). The chunks SDK does not expose a KB-wide route.
+	DocID string
+	// PageSize is the server batch size (1..1000, default 50).
+	PageSize int
+	// Limit caps the client-side accumulated slice (1..1000, default 50).
+	// Default 50 chosen as domain-tuned for chunk enumeration (RAG debug).
+	Limit int
+	// AllPages walks server pages internally until total exhausted or
+	// --limit hit. Mirrors session list / doc list canon.
+	AllPages bool
+}
+
+const chunkListLong = `List chunks under a document in stored order.
+
+'chunk list --doc D' enumerates ALL chunks of document D in ChunkIndex
+order (the per-doc ordinal assigned at ingest time). This is the
+admin/debug surface for RAG retrieval — see what the chunking pipeline
+produced, audit content, find a chunk id to view/delete.
+
+For relevance-ranked retrieval (the RAG runtime surface), use
+'search chunks "<query>" --kb K' instead. That command runs hybrid
+vector + keyword scoring across all chunks of a knowledge base.
+
+Typed exit codes:
+  input.invalid_argument   --limit / --page-size out of 1..1000 range (exit 5)
+  resource.not_found       no document with the given id (exit 4)
+
+AI agents: prefer 'search chunks' for retrieval tasks. Use 'chunk list'
+only when you need to enumerate / verify the chunking output of a
+specific document.`
+
+const chunkListExample = `  weknora chunk list --doc doc_abc
+  weknora chunk list --doc doc_abc --all-pages --page-size 100
+  weknora chunk list --doc doc_abc --json | jq '.[] | {id, chunk_index}'`
+
+// NewCmdList builds `weknora chunk list --doc <doc-id>`.
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	opts := &ListOptions{PageSize: defaultPageSize, Limit: defaultLimit}
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List chunks of a document (admin/debug, not retrieval)",
+		Long:    chunkListLong,
+		Example: chunkListExample,
+		Args:    cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			jopts, err := cmdutil.CheckJSONFlags(c)
+			if err != nil {
+				return err
+			}
+			cli, err := f.Client()
+			if err != nil {
+				return err
+			}
+			return runList(c.Context(), opts, jopts, cli)
+		},
+	}
+	cmd.Flags().StringVar(&opts.DocID, "doc", "", "Document id (SDK knowledge_id) to enumerate chunks for")
+	_ = cmd.MarkFlagRequired("doc")
+	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", defaultLimit, "Maximum results to return (1..1000)")
+	cmd.Flags().IntVar(&opts.PageSize, "page-size", defaultPageSize, "Items per server batch (1..1000)")
+	cmd.Flags().BoolVar(&opts.AllPages, "all-pages", false, "Walk all server pages until exhausted (or --limit hit)")
+	cmdutil.AddJSONFlags(cmd, chunkListFields)
+	return cmd
+}
+
+func runList(ctx context.Context, opts *ListOptions, jopts *cmdutil.JSONOptions, svc ListService) error {
+	if opts.Limit < 1 || opts.Limit > maxLimit {
+		return &cmdutil.Error{
+			Code:    cmdutil.CodeInputInvalidArgument,
+			Message: fmt.Sprintf("--limit must be in 1..%d, got %d", maxLimit, opts.Limit),
+		}
+	}
+	if opts.PageSize < 1 || opts.PageSize > maxPageSize {
+		return &cmdutil.Error{
+			Code:    cmdutil.CodeInputInvalidArgument,
+			Message: fmt.Sprintf("--page-size must be in 1..%d, got %d", maxPageSize, opts.PageSize),
+		}
+	}
+
+	var items []sdk.Chunk
+	if opts.AllPages {
+		accum := make([]sdk.Chunk, 0)
+		for page := 1; ; page++ {
+			chunks, total, err := svc.ListKnowledgeChunks(ctx, opts.DocID, page, opts.PageSize)
+			if err != nil {
+				return cmdutil.WrapHTTP(err, "list chunks for doc %s", opts.DocID)
+			}
+			accum = append(accum, chunks...)
+			if len(accum) >= opts.Limit {
+				accum = accum[:opts.Limit]
+				break
+			}
+			if len(chunks) == 0 || int64(page*opts.PageSize) >= total {
+				break
+			}
+		}
+		items = accum
+	} else {
+		chunks, _, err := svc.ListKnowledgeChunks(ctx, opts.DocID, 1, opts.PageSize)
+		if err != nil {
+			return cmdutil.WrapHTTP(err, "list chunks for doc %s", opts.DocID)
+		}
+		items = chunks
+	}
+	if items == nil {
+		items = []sdk.Chunk{} // JSON [] not null
+	}
+	if len(items) > opts.Limit {
+		items = items[:opts.Limit]
+	}
+
+	if jopts.Enabled() {
+		return jopts.Emit(iostreams.IO.Out, items)
+	}
+
+	if len(items) == 0 {
+		fmt.Fprintln(iostreams.IO.Out, "(no chunks)")
+		return nil
+	}
+	tw := tabwriter.NewWriter(iostreams.IO.Out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "CHUNK_ID\tINDEX\tTYPE\tENABLED\tPREVIEW\tUPDATED")
+	now := time.Now()
+	for _, c := range items {
+		enabled := "-"
+		if c.IsEnabled {
+			enabled = "yes"
+		}
+		preview := text.Truncate(previewWidth, singleLine(c.Content))
+		if preview == "" {
+			preview = "-"
+		}
+		typ := c.ChunkType
+		if typ == "" {
+			typ = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%d\t%s\t%s\t%s\t%s\n",
+			c.ID, c.ChunkIndex, typ, enabled, preview, text.FuzzyAgoStr(now, c.UpdatedAt))
+	}
+	return tw.Flush()
+}
+
+// singleLine collapses newlines/carriage-returns/tabs to spaces so the
+// chunk preview fits on one row of the human table. Without this a
+// multi-line chunk would smear across rows and break tabwriter alignment.
+var singleLine = strings.NewReplacer("\n", " ", "\r", " ", "\t", " ").Replace

--- a/cli/cmd/chunk/list_test.go
+++ b/cli/cmd/chunk/list_test.go
@@ -1,0 +1,205 @@
+package chunkcmd
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
+	"github.com/Tencent/WeKnora/cli/internal/iostreams"
+	sdk "github.com/Tencent/WeKnora/client"
+)
+
+type listCall struct {
+	docID    string
+	page     int
+	pageSize int
+}
+
+type fakeListSvc struct {
+	calls   []listCall
+	pages   [][]sdk.Chunk
+	totals  []int64
+	errs    []error
+	callIdx int
+}
+
+func (f *fakeListSvc) ListKnowledgeChunks(_ context.Context, docID string, page, pageSize int) ([]sdk.Chunk, int64, error) {
+	f.calls = append(f.calls, listCall{docID, page, pageSize})
+	defer func() { f.callIdx++ }()
+	if f.callIdx >= len(f.pages) {
+		return nil, 0, nil
+	}
+	return f.pages[f.callIdx], f.totals[f.callIdx], f.errs[f.callIdx]
+}
+
+func TestList_Happy(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeListSvc{
+		pages: [][]sdk.Chunk{{
+			{ID: "c1", ChunkIndex: 0, Content: "hello", ChunkType: "text", IsEnabled: true},
+			{ID: "c2", ChunkIndex: 1, Content: "world", ChunkType: "text", IsEnabled: true},
+		}},
+		totals: []int64{2}, errs: []error{nil},
+	}
+	opts := &ListOptions{DocID: "doc_abc", Limit: 50, PageSize: 50}
+	require.NoError(t, runList(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	require.Len(t, svc.calls, 1)
+	assert.Equal(t, "doc_abc", svc.calls[0].docID)
+	assert.Equal(t, 1, svc.calls[0].page)
+	assert.Equal(t, 50, svc.calls[0].pageSize)
+	// JSON mode emits a bare array; both ids must be present.
+	body := out.String()
+	assert.Contains(t, body, `"c1"`)
+	assert.Contains(t, body, `"c2"`)
+}
+
+// TestList_AllPages_StopsOnEmptyPage exercises the empty-page stop branch:
+// total is large enough that page*pageSize < total never trips, so the loop
+// can only terminate when the server returns an empty page.
+func TestList_AllPages_StopsOnEmptyPage(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeListSvc{
+		pages: [][]sdk.Chunk{
+			{{ID: "c1"}, {ID: "c2"}},
+			{{ID: "c3"}},
+			{}, // empty page → done
+		},
+		// Inflated total isolates the empty-page branch from the
+		// page*pageSize >= total branch.
+		totals: []int64{100, 100, 100},
+		errs:   []error{nil, nil, nil},
+	}
+	opts := &ListOptions{DocID: "doc_abc", AllPages: true, PageSize: 2, Limit: 1000}
+	require.NoError(t, runList(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	assert.Equal(t, 3, len(svc.calls), "must stop on empty page, not loop forever")
+}
+
+// TestList_AllPages_StopsOnTotalExhausted exercises the page*pageSize >= total
+// stop branch: server never returns an empty page in the requested window, so
+// the loop must exit when accumulated coverage reaches total.
+func TestList_AllPages_StopsOnTotalExhausted(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeListSvc{
+		pages: [][]sdk.Chunk{
+			{{ID: "c1"}, {ID: "c2"}},
+			{{ID: "c3"}},
+		},
+		totals: []int64{3, 3},
+		errs:   []error{nil, nil},
+	}
+	opts := &ListOptions{DocID: "doc_abc", AllPages: true, PageSize: 2, Limit: 1000}
+	require.NoError(t, runList(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	// After page 2: page*pageSize=4 >= total=3 → stop. No 3rd request.
+	assert.Equal(t, 2, len(svc.calls), "must stop when total exhausted, no extra empty probe")
+}
+
+// TestList_AllPages_LimitTruncatesAccumulated exercises the limit-cap stop
+// branch: pagination halts as soon as accumulated >= limit, and the result
+// is sliced to exactly --limit items regardless of how the last page over-ran.
+func TestList_AllPages_LimitTruncatesAccumulated(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeListSvc{
+		pages: [][]sdk.Chunk{
+			{{ID: "c1"}, {ID: "c2"}},
+			{{ID: "c3"}, {ID: "c4"}},
+			{{ID: "c5"}}, // should not be requested — limit hits first
+		},
+		totals: []int64{5, 5, 5},
+		errs:   []error{nil, nil, nil},
+	}
+	opts := &ListOptions{DocID: "doc_abc", AllPages: true, PageSize: 2, Limit: 3}
+	require.NoError(t, runList(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	// After page 2: accum=4 >= limit=3 → stop. Third page never requested.
+	assert.LessOrEqual(t, len(svc.calls), 2, "must not walk past limit-hit point")
+	// Result must be exactly --limit items (server returned 4, sliced to 3).
+	var got []sdk.Chunk
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Len(t, got, 3, "accumulated must be sliced to exactly --limit")
+	// IDs preserve order: first 3 from the first 2 pages.
+	assert.Equal(t, []string{"c1", "c2", "c3"}, []string{got[0].ID, got[1].ID, got[2].ID})
+}
+
+func TestList_LimitInvalid(t *testing.T) {
+	svc := &fakeListSvc{}
+	for _, lim := range []int{0, -1, 1001} {
+		err := runList(context.Background(), &ListOptions{DocID: "d", Limit: lim, PageSize: 50}, &cmdutil.JSONOptions{}, svc)
+		require.Error(t, err, "expect error for --limit %d", lim)
+		assert.Contains(t, err.Error(), "input.invalid_argument")
+	}
+}
+
+func TestList_PageSizeInvalid(t *testing.T) {
+	svc := &fakeListSvc{}
+	for _, ps := range []int{0, -1, 1001} {
+		err := runList(context.Background(), &ListOptions{DocID: "d", Limit: 50, PageSize: ps}, &cmdutil.JSONOptions{}, svc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "input.invalid_argument")
+	}
+}
+
+func TestList_MissingDoc_FlagError(t *testing.T) {
+	cmd := NewCmdList(nil)
+	cmd.SetArgs([]string{})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	require.Error(t, cmd.Execute(), "expect required-flag error for missing --doc")
+}
+
+func TestList_Human_TableHeader(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeListSvc{
+		pages: [][]sdk.Chunk{{
+			{ID: "c1", ChunkIndex: 0, Content: "the quick brown fox", ChunkType: "text", IsEnabled: true, UpdatedAt: "2026-05-15T12:00:00Z"},
+		}},
+		totals: []int64{1}, errs: []error{nil},
+	}
+	require.NoError(t, runList(context.Background(), &ListOptions{DocID: "doc_abc", Limit: 50, PageSize: 50}, nil, svc))
+	body := out.String()
+	for _, want := range []string{"CHUNK_ID", "INDEX", "TYPE", "ENABLED", "PREVIEW", "UPDATED", "c1", "text"} {
+		assert.Contains(t, body, want)
+	}
+}
+
+func TestList_Human_PreviewTruncatedTo80(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	long := strings.Repeat("a", 200)
+	svc := &fakeListSvc{
+		pages:  [][]sdk.Chunk{{{ID: "c1", Content: long, ChunkType: "text", IsEnabled: true}}},
+		totals: []int64{1}, errs: []error{nil},
+	}
+	require.NoError(t, runList(context.Background(), &ListOptions{DocID: "doc_abc", Limit: 50, PageSize: 50}, nil, svc))
+	body := out.String()
+	// 80-col preview means we never see the 100th `a` from the content (only column truncation kicks in).
+	assert.NotContains(t, body, strings.Repeat("a", 100), "preview must be truncated to ~80 chars")
+}
+
+func TestList_JSON_BareArray(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeListSvc{
+		pages: [][]sdk.Chunk{{
+			{ID: "c1", KnowledgeID: "doc_abc", KnowledgeBaseID: "kb_x"},
+		}},
+		totals: []int64{1}, errs: []error{nil},
+	}
+	require.NoError(t, runList(context.Background(), &ListOptions{DocID: "doc_abc", Limit: 50, PageSize: 50}, &cmdutil.JSONOptions{}, svc))
+	var got []sdk.Chunk
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "doc_abc", got[0].KnowledgeID)
+	assert.Equal(t, "kb_x", got[0].KnowledgeBaseID)
+	// Bare SDK keys, not custom CLI envelope.
+	assert.Contains(t, out.String(), `"knowledge_id":"doc_abc"`)
+	assert.NotContains(t, out.String(), `"doc_id"`)
+}
+
+func TestList_EmptyResultRendersBareArray(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeListSvc{pages: [][]sdk.Chunk{{}}, totals: []int64{0}, errs: []error{nil}}
+	require.NoError(t, runList(context.Background(), &ListOptions{DocID: "doc_abc", Limit: 50, PageSize: 50}, &cmdutil.JSONOptions{}, svc))
+	assert.Equal(t, "[]\n", out.String())
+}

--- a/cli/cmd/chunk/view.go
+++ b/cli/cmd/chunk/view.go
@@ -29,7 +29,6 @@ type ViewService interface {
 	GetChunkByIDOnly(ctx context.Context, chunkID string) (*sdk.Chunk, error)
 }
 
-// ViewOptions captures `chunk view` flag state. Chunk id is the sole input.
 type ViewOptions struct {
 	ChunkID string
 }
@@ -96,7 +95,7 @@ func runView(ctx context.Context, opts *ViewOptions, jopts *cmdutil.JSONOptions,
 	return nil
 }
 
-// renderChunk prints a single chunk in human-readable KV form per spec §1.5.2.
+// renderChunk prints a single chunk in human-readable KV form.
 // Field order: id / seq_id / chunk_index / doc_id / kb_id / type / enabled /
 // status (omit-zero) / start_at (omit-zero) / end_at (omit-zero) /
 // tag_id (omit-empty) / image_info (omit-empty) / created_at / updated_at /

--- a/cli/cmd/chunk/view.go
+++ b/cli/cmd/chunk/view.go
@@ -1,0 +1,152 @@
+package chunkcmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
+	"github.com/Tencent/WeKnora/cli/internal/iostreams"
+	sdk "github.com/Tencent/WeKnora/client"
+)
+
+// chunkViewFields enumerates the 23 SDK Chunk fields surfaced for `--json`
+// discovery. JSON is bare SDK pass-through, so keys are snake_case
+// (`knowledge_id`, `knowledge_base_id`) even though the human KV labels
+// them as `doc_id` / `kb_id`.
+var chunkViewFields = []string{
+	"id", "seq_id", "knowledge_id", "knowledge_base_id", "tenant_id",
+	"tag_id", "content", "chunk_index", "is_enabled", "status",
+	"start_at", "end_at", "pre_chunk_id", "next_chunk_id", "chunk_type",
+	"parent_chunk_id", "relation_chunks", "indirect_relation_chunks",
+	"metadata", "content_hash", "image_info", "created_at", "updated_at",
+}
+
+// ViewService is the narrow SDK surface this command depends on.
+type ViewService interface {
+	GetChunkByIDOnly(ctx context.Context, chunkID string) (*sdk.Chunk, error)
+}
+
+// ViewOptions captures `chunk view` flag state. Chunk id is the sole input.
+type ViewOptions struct {
+	ChunkID string
+}
+
+const chunkViewLong = `Show a single chunk with all SDK fields.
+
+Human output is a key-value block; pass --json for the bare 23-field SDK
+Chunk object. Content renders verbatim regardless of size — pipe to
+less or use --json for large chunks. WeKnora chunks are typically bounded
+by the ingest pipeline (~1000 tokens / a few KB), so unconditional full
+rendering is reasonable.
+
+Scope asymmetry with 'chunk delete':
+  view <id>           scope-less (server: GET /chunks/by-id/{id})
+  delete <id> --doc D scoped     (server: DELETE /chunks/{doc}/{id})
+
+The asymmetry is deliberate. Auto-resolving doc id on delete would race
+the ingest pipeline; forcing --doc on view would add friction with no
+benefit. AI agents: a chunk id from any source (list, search, agent
+invoke citation) is sufficient for view.
+
+Typed exit codes:
+  resource.not_found    no chunk with the given id (exit 4)`
+
+const chunkViewExample = `  weknora chunk view chunk_abc
+  weknora chunk view chunk_abc --json | jq '.content'
+  weknora chunk view chunk_abc --json=id,chunk_index,is_enabled`
+
+// NewCmdView builds `weknora chunk view <chunk-id>`.
+func NewCmdView(f *cmdutil.Factory) *cobra.Command {
+	opts := &ViewOptions{}
+	cmd := &cobra.Command{
+		Use:     "view <chunk-id>",
+		Short:   "Show a chunk's fields and content (scope-less)",
+		Long:    chunkViewLong,
+		Example: chunkViewExample,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			jopts, err := cmdutil.CheckJSONFlags(c)
+			if err != nil {
+				return err
+			}
+			opts.ChunkID = args[0]
+			cli, err := f.Client()
+			if err != nil {
+				return err
+			}
+			return runView(c.Context(), opts, jopts, cli)
+		},
+	}
+	cmdutil.AddJSONFlags(cmd, chunkViewFields)
+	return cmd
+}
+
+func runView(ctx context.Context, opts *ViewOptions, jopts *cmdutil.JSONOptions, svc ViewService) error {
+	ch, err := svc.GetChunkByIDOnly(ctx, opts.ChunkID)
+	if err != nil {
+		return cmdutil.WrapHTTP(err, "fetch chunk %s", opts.ChunkID)
+	}
+	if jopts.Enabled() {
+		return jopts.Emit(iostreams.IO.Out, ch)
+	}
+	renderChunk(iostreams.IO.Out, ch)
+	return nil
+}
+
+// renderChunk prints a single chunk in human-readable KV form per spec §1.5.2.
+// Field order: id / seq_id / chunk_index / doc_id / kb_id / type / enabled /
+// status (omit-zero) / start_at (omit-zero) / end_at (omit-zero) /
+// tag_id (omit-empty) / image_info (omit-empty) / created_at / updated_at /
+// content (full, no truncation, last entry).
+//
+// `doc_id` / `kb_id` are the human-friendly labels for the SDK fields
+// `knowledge_id` / `knowledge_base_id`; JSON output keeps the SDK names.
+func renderChunk(w io.Writer, c *sdk.Chunk) {
+	fmt.Fprintf(w, "id:           %s\n", c.ID)
+	if c.SeqID != 0 {
+		fmt.Fprintf(w, "seq_id:       %d\n", c.SeqID)
+	}
+	fmt.Fprintf(w, "chunk_index:  %d\n", c.ChunkIndex)
+	if c.KnowledgeID != "" {
+		fmt.Fprintf(w, "doc_id:       %s\n", c.KnowledgeID)
+	}
+	if c.KnowledgeBaseID != "" {
+		fmt.Fprintf(w, "kb_id:        %s\n", c.KnowledgeBaseID)
+	}
+	if c.ChunkType != "" {
+		fmt.Fprintf(w, "type:         %s\n", c.ChunkType)
+	}
+	enabled := "no"
+	if c.IsEnabled {
+		enabled = "yes"
+	}
+	fmt.Fprintf(w, "enabled:      %s\n", enabled)
+	if c.Status != 0 {
+		fmt.Fprintf(w, "status:       %d\n", c.Status)
+	}
+	if c.StartAt != 0 {
+		fmt.Fprintf(w, "start_at:     %d\n", c.StartAt)
+	}
+	if c.EndAt != 0 {
+		fmt.Fprintf(w, "end_at:       %d\n", c.EndAt)
+	}
+	if c.TagID != "" {
+		fmt.Fprintf(w, "tag_id:       %s\n", c.TagID)
+	}
+	if c.ImageInfo != "" {
+		fmt.Fprintf(w, "image_info:   %s\n", c.ImageInfo)
+	}
+	if c.CreatedAt != "" {
+		fmt.Fprintf(w, "created_at:   %s\n", c.CreatedAt)
+	}
+	if c.UpdatedAt != "" {
+		fmt.Fprintf(w, "updated_at:   %s\n", c.UpdatedAt)
+	}
+	// Content rendered verbatim, last entry, no truncation.
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "content:")
+	fmt.Fprintln(w, c.Content)
+}

--- a/cli/cmd/chunk/view_test.go
+++ b/cli/cmd/chunk/view_test.go
@@ -1,0 +1,100 @@
+package chunkcmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
+	"github.com/Tencent/WeKnora/cli/internal/iostreams"
+	sdk "github.com/Tencent/WeKnora/client"
+)
+
+type fakeViewSvc struct {
+	resp *sdk.Chunk
+	err  error
+}
+
+func (f *fakeViewSvc) GetChunkByIDOnly(_ context.Context, _ string) (*sdk.Chunk, error) {
+	return f.resp, f.err
+}
+
+func TestView_Happy_RendersAllFields(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewSvc{resp: &sdk.Chunk{
+		ID:              "c1",
+		SeqID:           42,
+		ChunkIndex:      0,
+		KnowledgeID:     "doc_abc",
+		KnowledgeBaseID: "kb_abc",
+		ChunkType:       "text",
+		IsEnabled:       true,
+		Content:         "the quick brown fox",
+		CreatedAt:       "2026-05-15T11:00:00Z",
+		UpdatedAt:       "2026-05-15T12:00:00Z",
+	}}
+	require.NoError(t, runView(context.Background(), &ViewOptions{ChunkID: "c1"}, nil, svc))
+	body := out.String()
+	assert.Contains(t, body, "c1")
+	assert.Contains(t, body, "doc_abc")
+	assert.Contains(t, body, "kb_abc")
+	assert.Contains(t, body, "text")
+	assert.Contains(t, body, "the quick brown fox", "content must render in full")
+}
+
+func TestView_HumanLabels_DocAndKB(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewSvc{resp: &sdk.Chunk{
+		ID: "c1", KnowledgeID: "doc_abc", KnowledgeBaseID: "kb_abc",
+	}}
+	require.NoError(t, runView(context.Background(), &ViewOptions{ChunkID: "c1"}, nil, svc))
+	body := out.String()
+	// Human KV must use friendlier DOC_ID / KB_ID labels (spec §1.5.2), not raw SDK names.
+	assert.Contains(t, body, "doc_id")
+	assert.Contains(t, body, "kb_id")
+	assert.NotContains(t, body, "knowledge_id")
+	assert.NotContains(t, body, "knowledge_base_id")
+}
+
+func TestView_OmitsZeroOrEmpty(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewSvc{resp: &sdk.Chunk{ID: "c_min", Content: "x"}}
+	require.NoError(t, runView(context.Background(), &ViewOptions{ChunkID: "c_min"}, nil, svc))
+	body := out.String()
+	// status / start_at / end_at all zero → must be omitted from the human KV.
+	assert.NotContains(t, body, "status:")
+	assert.NotContains(t, body, "start_at:")
+	assert.NotContains(t, body, "end_at:")
+	// tag_id / image_info empty → omitted.
+	assert.NotContains(t, body, "tag_id:")
+	assert.NotContains(t, body, "image_info:")
+}
+
+func TestView_JSON_BareSDKShape(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewSvc{resp: &sdk.Chunk{
+		ID: "c_json", KnowledgeID: "doc_abc", KnowledgeBaseID: "kb_abc",
+	}}
+	require.NoError(t, runView(context.Background(), &ViewOptions{ChunkID: "c_json"}, &cmdutil.JSONOptions{}, svc))
+	var got sdk.Chunk
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, "c_json", got.ID)
+	assert.Equal(t, "doc_abc", got.KnowledgeID)
+	// JSON uses SDK snake_case keys (knowledge_id), not human relabel doc_id.
+	assert.Contains(t, out.String(), `"knowledge_id":"doc_abc"`)
+	assert.Contains(t, out.String(), `"knowledge_base_id":"kb_abc"`)
+	assert.NotContains(t, out.String(), `"doc_id"`)
+	assert.NotContains(t, out.String(), `"kb_id"`)
+}
+
+func TestView_404(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeViewSvc{err: errors.New("HTTP error 404: not found")}
+	err := runView(context.Background(), &ViewOptions{ChunkID: "missing"}, nil, svc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resource.not_found")
+}

--- a/cli/cmd/chunk/view_test.go
+++ b/cli/cmd/chunk/view_test.go
@@ -53,7 +53,8 @@ func TestView_HumanLabels_DocAndKB(t *testing.T) {
 	}}
 	require.NoError(t, runView(context.Background(), &ViewOptions{ChunkID: "c1"}, nil, svc))
 	body := out.String()
-	// Human KV must use friendlier DOC_ID / KB_ID labels (spec §1.5.2), not raw SDK names.
+	// Human KV uses friendlier DOC_ID / KB_ID labels (the SDK's
+	// knowledge_id / knowledge_base_id are kept only in --json output).
 	assert.Contains(t, body, "doc_id")
 	assert.Contains(t, body, "kb_id")
 	assert.NotContains(t, body, "knowledge_id")

--- a/cli/cmd/doc/list.go
+++ b/cli/cmd/doc/list.go
@@ -37,7 +37,19 @@ type ListOptions struct {
 	// AllPages walks server pages internally, accumulating items until
 	// total exhausted or --limit hit.
 	AllPages bool
+	// Additional server-side filters (each maps 1:1 to a sdk.KnowledgeListFilter
+	// field). Empty / zero values are omitted from the request.
+	Keyword   string
+	FileType  string
+	Source    string
+	TagID     string
+	StartTime string // raw RFC3339; parsed into filter.StartTime
+	EndTime   string // raw RFC3339; parsed into filter.EndTime
 }
+
+// rfc3339Example is the canonical RFC3339 hint surfaced when --start-time /
+// --end-time fail to parse. Picked to match Go's reference time docs.
+const rfc3339Example = "2006-01-02T15:04:05Z"
 
 // docListStatusValues mirrors internal/types/knowledge.go ParseStatus*
 // constants - these are the values the server accepts on the
@@ -92,6 +104,12 @@ backend storage order is not guaranteed and varies between deployments.`,
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 30, "Maximum results to return (0 = no cap, 1..10000 = explicit)")
 	cmd.Flags().BoolVar(&opts.AllPages, "all-pages", false, "Walk all server pages until exhausted (or --limit hit)")
 	cmd.Flags().StringVar(&opts.Status, "status", "", "Filter by parse status: pending | processing | completed | failed")
+	cmd.Flags().StringVar(&opts.Keyword, "keyword", "", "Server-side substring match against title / file_name (case-sensitive)")
+	cmd.Flags().StringVar(&opts.FileType, "file-type", "", `Filter by file extension (e.g. "pdf", "md")`)
+	cmd.Flags().StringVar(&opts.Source, "source", "", `Filter by ingestion source (e.g. "api", "web")`)
+	cmd.Flags().StringVar(&opts.TagID, "tag-id", "", "Filter by tag association")
+	cmd.Flags().StringVar(&opts.StartTime, "start-time", "", "Include docs with updated_at >= this RFC3339 timestamp (e.g. 2006-01-02T15:04:05Z)")
+	cmd.Flags().StringVar(&opts.EndTime, "end-time", "", "Include docs with updated_at <= this RFC3339 timestamp (e.g. 2006-01-02T15:04:05Z)")
 	cmdutil.AddJSONFlags(cmd, docListFields)
 	return cmd
 }
@@ -116,7 +134,29 @@ func runList(ctx context.Context, opts *ListOptions, jopts *cmdutil.JSONOptions,
 				strings.Join(docListStatusValues, " | "), opts.Status),
 		}
 	}
-	filter := sdk.KnowledgeListFilter{ParseStatus: opts.Status}
+	filter := sdk.KnowledgeListFilter{
+		ParseStatus: opts.Status,
+		Keyword:     opts.Keyword,
+		FileType:    opts.FileType,
+		Source:      opts.Source,
+		TagID:       opts.TagID,
+	}
+	if opts.StartTime != "" {
+		t, err := time.Parse(time.RFC3339, opts.StartTime)
+		if err != nil {
+			return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
+				fmt.Sprintf("--start-time must be RFC3339 (e.g. %s), got %q", rfc3339Example, opts.StartTime))
+		}
+		filter.StartTime = t
+	}
+	if opts.EndTime != "" {
+		t, err := time.Parse(time.RFC3339, opts.EndTime)
+		if err != nil {
+			return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
+				fmt.Sprintf("--end-time must be RFC3339 (e.g. %s), got %q", rfc3339Example, opts.EndTime))
+		}
+		filter.EndTime = t
+	}
 
 	// Pagination is always 1-indexed internally. --all-pages walks; the
 	// non-walking path returns the first page only.

--- a/cli/cmd/doc/list_test.go
+++ b/cli/cmd/doc/list_test.go
@@ -339,3 +339,110 @@ func TestList_AllPages_WithLimit_StopsAtLimit(t *testing.T) {
 	// Should have called pages 1..3 (60 items) then capped at 50.
 	assert.LessOrEqual(t, len(svc.calls), 3, "should not walk past the page that fills --limit")
 }
+
+// ----- C11: richer filter flags -----
+
+func TestList_Keyword_PassedToFilter(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeListSvc{}
+	opts := &ListOptions{PageSize: 20, Keyword: "spec"}
+	require.NoError(t, runList(context.Background(), opts, nil, svc, "kb_xxx"))
+	assert.Equal(t, "spec", svc.got.filter.Keyword)
+}
+
+func TestList_FileType_PassedToFilter(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeListSvc{}
+	opts := &ListOptions{PageSize: 20, FileType: "pdf"}
+	require.NoError(t, runList(context.Background(), opts, nil, svc, "kb_xxx"))
+	assert.Equal(t, "pdf", svc.got.filter.FileType)
+}
+
+func TestList_Source_PassedToFilter(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeListSvc{}
+	opts := &ListOptions{PageSize: 20, Source: "api"}
+	require.NoError(t, runList(context.Background(), opts, nil, svc, "kb_xxx"))
+	assert.Equal(t, "api", svc.got.filter.Source)
+}
+
+func TestList_TagID_PassedToFilter(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeListSvc{}
+	opts := &ListOptions{PageSize: 20, TagID: "tag_42"}
+	require.NoError(t, runList(context.Background(), opts, nil, svc, "kb_xxx"))
+	assert.Equal(t, "tag_42", svc.got.filter.TagID)
+}
+
+func TestList_StartTime_RFC3339Parses(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeListSvc{}
+	want := "2026-05-01T00:00:00Z"
+	opts := &ListOptions{PageSize: 20, StartTime: want}
+	require.NoError(t, runList(context.Background(), opts, nil, svc, "kb_xxx"))
+	parsed, err := time.Parse(time.RFC3339, want)
+	require.NoError(t, err)
+	assert.True(t, svc.got.filter.StartTime.Equal(parsed),
+		"--start-time must be parsed into filter.StartTime; got %v want %v",
+		svc.got.filter.StartTime, parsed)
+}
+
+func TestList_EndTime_RFC3339Parses(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeListSvc{}
+	want := "2026-06-30T23:59:59Z"
+	opts := &ListOptions{PageSize: 20, EndTime: want}
+	require.NoError(t, runList(context.Background(), opts, nil, svc, "kb_xxx"))
+	parsed, err := time.Parse(time.RFC3339, want)
+	require.NoError(t, err)
+	assert.True(t, svc.got.filter.EndTime.Equal(parsed))
+}
+
+func TestList_StartTime_InvalidFormat_Rejected(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	opts := &ListOptions{PageSize: 20, StartTime: "tomorrow"}
+	err := runList(context.Background(), opts, nil, &fakeListSvc{}, "kb_xxx")
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code)
+	assert.Contains(t, typed.Message, "--start-time")
+	assert.Contains(t, typed.Message, "RFC3339")
+}
+
+func TestList_EndTime_InvalidFormat_Rejected(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	opts := &ListOptions{PageSize: 20, EndTime: "2026-05-01"} // date-only, not RFC3339
+	err := runList(context.Background(), opts, nil, &fakeListSvc{}, "kb_xxx")
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code)
+	assert.Contains(t, typed.Message, "--end-time")
+}
+
+// TestList_AllFiltersCombined drives every new filter flag at once to confirm
+// they all land on the same filter struct (AND combine on the server).
+func TestList_AllFiltersCombined(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeListSvc{}
+	opts := &ListOptions{
+		PageSize:  20,
+		Status:    "completed",
+		Keyword:   "spec",
+		FileType:  "pdf",
+		Source:    "api",
+		TagID:     "tag_42",
+		StartTime: "2026-01-01T00:00:00Z",
+		EndTime:   "2026-12-31T23:59:59Z",
+	}
+	require.NoError(t, runList(context.Background(), opts, nil, svc, "kb_xxx"))
+	f := svc.got.filter
+	assert.Equal(t, "completed", f.ParseStatus)
+	assert.Equal(t, "spec", f.Keyword)
+	assert.Equal(t, "pdf", f.FileType)
+	assert.Equal(t, "api", f.Source)
+	assert.Equal(t, "tag_42", f.TagID)
+	assert.False(t, f.StartTime.IsZero())
+	assert.False(t, f.EndTime.IsZero())
+}

--- a/cli/cmd/doc/upload.go
+++ b/cli/cmd/doc/upload.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -13,9 +14,10 @@ import (
 	sdk "github.com/Tencent/WeKnora/client"
 )
 
-// uploadChannel is the ingestion-channel tag the server records for CLI uploads.
-// Distinct from "web" (browser UI), "browser_extension" (one-click capture),
-// and "wechat" (mini-program). The server uses this only for analytics.
+// uploadChannel is the default ingestion-channel tag the server records for
+// CLI uploads. Distinct from "web" (browser UI), "browser_extension"
+// (one-click capture), and "wechat" (mini-program). The server uses this only
+// for analytics. Users can override via --channel for cross-tool replay.
 const uploadChannel = "api"
 
 // docUploadFields enumerates the fields surfaced for `--json` discovery on
@@ -34,6 +36,25 @@ type UploadOptions struct {
 	Recursive bool   // --recursive: positional arg is a directory; walk + upload each match
 	Glob      string // --glob: filename pattern under --recursive (default "*")
 	FromURL   string // --from-url: ingest a remote URL via SDK CreateKnowledgeFromURL
+
+	// EnableMultimodel toggles server-side multimodal extraction
+	// (e.g. images-in-PDF → OCR'd text). nil means "server default" -
+	// the flag was not set. true/false explicitly override.
+	EnableMultimodel *bool
+
+	// Metadata is the raw --metadata key=value list. Parsed into a map
+	// at run-time; empty values allowed, duplicate keys last-wins.
+	Metadata []string
+
+	// Channel overrides the ingestion-channel tag recorded server-side.
+	// Empty ⇒ uploadChannel ("api"). Free-form: server validates.
+	Channel string
+
+	// URL-mode only fields. RunE-side validation rejects these if
+	// --from-url is not set (positional file path or --recursive).
+	Title    string // --title: display title (URL mode)
+	FileType string // --file-type: extension hint for extension-less URLs
+	TagID    string // --tag-id: associate the new knowledge entry with a tag
 }
 
 // UploadService is the narrow SDK surface this command depends on.
@@ -70,19 +91,46 @@ has a generic name like "report.pdf" but you want to surface it as e.g.
 
 The three input modes (positional file / --recursive directory walk /
 --from-url remote ingest) are mutually exclusive - pass exactly one.
-Use --recursive --glob to upload a directory tree (see Examples).`,
+Use --recursive --glob to upload a directory tree (see Examples).
+
+Server-side ingestion knobs apply to all modes:
+
+  --enable-multimodel      Toggle multimodal extraction (image-in-PDF → text).
+                           Unset ⇒ server default; pass true or false to override.
+  --metadata key=value     Attach arbitrary key/value metadata. Repeatable.
+                           Empty value allowed; duplicate keys ⇒ last-wins.
+                           Malformed values (no '=', empty key) ⇒
+                           input.invalid_argument.
+  --channel <name>         Override the ingestion-channel tag (default "api").
+
+URL mode (--from-url) additionally accepts --title, --file-type, and --tag-id.
+Passing any of those without --from-url is rejected as input.invalid_argument.`,
 		Example: `  weknora doc upload report.pdf
   weknora doc upload notes.md --kb a32a63ff-fb36-4874-bcaa-30f48570a694
   weknora doc upload notes.md --kb my-kb
   weknora doc upload q3.pdf --name "Q3 Marketing Report.pdf"
-  weknora doc upload ./docs --recursive --glob '*.pdf'
+  weknora doc upload report.pdf --enable-multimodel --metadata team=alpha --metadata sprint=Q4
+  weknora doc upload ./docs --recursive --glob '*.pdf' --metadata team=alpha
   weknora doc upload --from-url https://example.com/whitepaper.pdf
-  weknora doc upload --from-url https://example.com/article.html --name "Q3 Article"`,
+  weknora doc upload --from-url https://example.com/no-ext --file-type pdf --title "Whitepaper"
+  weknora doc upload --from-url https://example.com/article.html --name "Q3 Article" --tag-id tag_abc`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			jopts, err := cmdutil.CheckJSONFlags(c)
 			if err != nil {
 				return err
+			}
+			// Translate the tri-state --enable-multimodel flag into the
+			// *bool the SDK expects. Cobra's BoolVar can't distinguish
+			// "unset" from "false", so we register a String flag and read
+			// Changed() + the raw value here.
+			if c.Flags().Changed("enable-multimodel") {
+				raw, _ := c.Flags().GetString("enable-multimodel")
+				v, perr := parseTriBool(raw)
+				if perr != nil {
+					return perr
+				}
+				opts.EnableMultimodel = &v
 			}
 			if err := validateUploadFlags(opts, args); err != nil {
 				return err
@@ -114,13 +162,71 @@ Use --recursive --glob to upload a directory tree (see Examples).`,
 	cmd.Flags().BoolVar(&opts.Recursive, "recursive", false, "Treat the positional argument as a directory to walk")
 	cmd.Flags().StringVar(&opts.Glob, "glob", "*", "Filename pattern to filter when --recursive (e.g. '*.pdf')")
 	cmd.Flags().StringVar(&opts.FromURL, "from-url", "", "Ingest a remote `URL` (HTTP/HTTPS) instead of a local file")
+	// Tri-state flag: unset ⇒ server default, "true"/"false" override. The
+	// raw string is decoded into opts.EnableMultimodel in RunE.
+	cmd.Flags().String("enable-multimodel", "", "Toggle multimodal extraction (true|false); unset ⇒ server default")
+	cmd.Flags().Lookup("enable-multimodel").NoOptDefVal = "true"
+	cmd.Flags().StringSliceVar(&opts.Metadata, "metadata", nil, "Attach metadata `key=value` (repeatable; empty value allowed, last-wins on duplicate keys)")
+	cmd.Flags().StringVar(&opts.Channel, "channel", "", "Ingestion-channel tag recorded server-side (default \"api\")")
+	cmd.Flags().StringVar(&opts.Title, "title", "", "Display title for the new entry (--from-url only)")
+	cmd.Flags().StringVar(&opts.FileType, "file-type", "", "File-type hint such as \"pdf\" when the URL has no extension (--from-url only)")
+	cmd.Flags().StringVar(&opts.TagID, "tag-id", "", "Tag id to associate with the new entry (--from-url only)")
 	cmdutil.AddJSONFlags(cmd, docUploadFields)
 	return cmd
 }
 
+// parseTriBool parses the raw --enable-multimodel string into a bool. Bare
+// --enable-multimodel (no value) is treated as "true" via NoOptDefVal at
+// registration time; callers gate on Changed() so an unset flag never gets
+// here. An explicit empty string (e.g. --enable-multimodel="" from an
+// uninterpolated shell variable) is rejected as input.invalid_argument
+// rather than silently coerced.
+func parseTriBool(raw string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "true", "1", "yes":
+		return true, nil
+	case "false", "0", "no":
+		return false, nil
+	default:
+		return false, cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
+			fmt.Sprintf("--enable-multimodel expects true|false, got %q", raw))
+	}
+}
+
+// parseMetadataKV converts the raw --metadata key=value slice into a map.
+// Empty values are allowed. Duplicate keys ⇒ last-wins. Returns nil when
+// the slice is empty so callers pass nil through to the SDK unchanged.
+func parseMetadataKV(raw []string) (map[string]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(raw))
+	for _, kv := range raw {
+		eq := strings.IndexByte(kv, '=')
+		if eq <= 0 {
+			return nil, cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
+				fmt.Sprintf("--metadata expects key=value (got %q)", kv))
+		}
+		out[kv[:eq]] = kv[eq+1:]
+	}
+	return out, nil
+}
+
+// effectiveChannel returns the channel string to send to the SDK. Empty
+// opts.Channel falls back to the default "api" so the wire payload is
+// identical to the pre-flag behavior.
+func effectiveChannel(opts *UploadOptions) string {
+	if opts.Channel != "" {
+		return opts.Channel
+	}
+	return uploadChannel
+}
+
 // validateUploadFlags enforces mutual exclusion between the three input
 // modes (positional file path / --recursive directory walk / --from-url
-// remote ingest) and validates the URL when --from-url is set.
+// remote ingest) and validates the URL when --from-url is set. It also
+// rejects the URL-mode-only flags (--title, --file-type, --tag-id) when
+// --from-url isn't set so misuse fails fast with a typed code.
 func validateUploadFlags(opts *UploadOptions, args []string) error {
 	hasPath := len(args) == 1
 	hasURL := opts.FromURL != ""
@@ -139,17 +245,39 @@ func validateUploadFlags(opts *UploadOptions, args []string) error {
 		return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
 			"a file path is required (or pass --from-url)")
 	}
+	// --title / --file-type / --tag-id are URL-mode only. Reject silently
+	// ignoring them in file mode to avoid the "set X, server did nothing"
+	// surprise.
+	if opts.Title != "" {
+		return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
+			"--title is only valid with --from-url")
+	}
+	if opts.FileType != "" {
+		return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
+			"--file-type is only valid with --from-url")
+	}
+	if opts.TagID != "" {
+		return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
+			"--tag-id is only valid with --from-url")
+	}
 	return nil
 }
 
 // runUploadFromURL ingests a remote URL via SDK CreateKnowledgeFromURL.
 // `--name` becomes the FileName hint so the server's "known file extension"
 // detection upgrades crawl-mode to file-download-mode when appropriate.
+// Server-side knobs (--enable-multimodel, --metadata via Title/TagID/FileType)
+// propagate when set; the SDK request struct omits empty fields via
+// `json:",omitempty"` tags so wire payload stays minimal.
 func runUploadFromURL(ctx context.Context, opts *UploadOptions, jopts *cmdutil.JSONOptions, svc UploadService, kbID string) error {
 	req := sdk.CreateKnowledgeFromURLRequest{
-		URL:      opts.FromURL,
-		FileName: opts.Name,
-		Channel:  uploadChannel,
+		URL:              opts.FromURL,
+		FileName:         opts.Name,
+		FileType:         opts.FileType,
+		EnableMultimodel: opts.EnableMultimodel,
+		Title:            opts.Title,
+		TagID:            opts.TagID,
+		Channel:          effectiveChannel(opts),
 	}
 	k, err := svc.CreateKnowledgeFromURL(ctx, kbID, req)
 	if err != nil {
@@ -209,7 +337,11 @@ func validateUploadPath(path string) error {
 }
 
 func runUpload(ctx context.Context, opts *UploadOptions, jopts *cmdutil.JSONOptions, svc UploadService, kbID, path string) error {
-	k, err := svc.CreateKnowledgeFromFile(ctx, kbID, path, nil /*metadata*/, nil /*enableMultimodel*/, opts.Name, uploadChannel)
+	meta, err := parseMetadataKV(opts.Metadata)
+	if err != nil {
+		return err
+	}
+	k, err := svc.CreateKnowledgeFromFile(ctx, kbID, path, meta, opts.EnableMultimodel, opts.Name, effectiveChannel(opts))
 	if err != nil {
 		return cmdutil.WrapHTTP(err, "upload %s", path)
 	}

--- a/cli/cmd/doc/upload.go
+++ b/cli/cmd/doc/upload.go
@@ -93,15 +93,19 @@ The three input modes (positional file / --recursive directory walk /
 --from-url remote ingest) are mutually exclusive - pass exactly one.
 Use --recursive --glob to upload a directory tree (see Examples).
 
-Server-side ingestion knobs apply to all modes:
+Server-side ingestion knobs:
 
   --enable-multimodel      Toggle multimodal extraction (image-in-PDF → text).
                            Unset ⇒ server default; pass true or false to override.
+                           Applies to file / --recursive / --from-url.
   --metadata key=value     Attach arbitrary key/value metadata. Repeatable.
                            Empty value allowed; duplicate keys ⇒ last-wins.
                            Malformed values (no '=', empty key) ⇒
-                           input.invalid_argument.
+                           input.invalid_argument. File and --recursive modes
+                           only; rejected on --from-url because the URL-ingest
+                           request type carries no metadata field.
   --channel <name>         Override the ingestion-channel tag (default "api").
+                           Applies to file / --recursive / --from-url.
 
 URL mode (--from-url) additionally accepts --title, --file-type, and --tag-id.
 Passing any of those without --from-url is rejected as input.invalid_argument.`,
@@ -239,15 +243,28 @@ func validateUploadFlags(opts *UploadOptions, args []string) error {
 			return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
 				"--recursive cannot be combined with --from-url")
 		}
+		// The server's URL-ingest request type has no Metadata field; a
+		// --metadata pair would be silently dropped on the wire. Reject
+		// up-front so callers don't think they've set metadata when they
+		// haven't.
+		if len(opts.Metadata) > 0 {
+			return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
+				"--metadata is not supported with --from-url (server URL-ingest has no metadata field)")
+		}
 		return cmdutil.ValidateHTTPURL("--from-url", opts.FromURL)
 	}
 	if !hasPath {
 		return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
 			"a file path is required (or pass --from-url)")
 	}
-	// --title / --file-type / --tag-id are URL-mode only. Reject silently
-	// ignoring them in file mode to avoid the "set X, server did nothing"
-	// surprise.
+	return rejectURLOnlyFlags(opts)
+}
+
+// rejectURLOnlyFlags errors on --title / --file-type / --tag-id when
+// --from-url is NOT set. Shared between validateUploadFlags (file mode)
+// and runUploadRecursive (directory walk) so a future URL-mode-only flag
+// only needs to add one entry here instead of two parallel checks.
+func rejectURLOnlyFlags(opts *UploadOptions) error {
 	if opts.Title != "" {
 		return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
 			"--title is only valid with --from-url")
@@ -343,6 +360,13 @@ func runUpload(ctx context.Context, opts *UploadOptions, jopts *cmdutil.JSONOpti
 	}
 	k, err := svc.CreateKnowledgeFromFile(ctx, kbID, path, meta, opts.EnableMultimodel, opts.Name, effectiveChannel(opts))
 	if err != nil {
+		if errors.Is(err, sdk.ErrDuplicateFile) {
+			// SDK returns sentinel without an "HTTP error <status>:" prefix
+			// (the duplicate is detected by file hash, not by status code),
+			// so WrapHTTP would misclassify it as network.error.
+			return cmdutil.Wrapf(cmdutil.CodeResourceAlreadyExists, err,
+				"file already uploaded to this knowledge base")
+		}
 		return cmdutil.WrapHTTP(err, "upload %s", path)
 	}
 	return renderUploadSuccess(k, jopts, "Uploaded", opts.Name, path)

--- a/cli/cmd/doc/upload_recursive.go
+++ b/cli/cmd/doc/upload_recursive.go
@@ -32,26 +32,11 @@ func runUploadRecursive(ctx context.Context, opts *UploadOptions, jopts *cmdutil
 			Hint:    "drop --name or upload files one at a time",
 		}
 	}
-	// URL-mode-only flags are not meaningful for a directory walk; reject
-	// them so misuse fails fast (mirrors the file-mode path's check in
-	// validateUploadFlags - that path runs before --recursive dispatches).
-	if opts.Title != "" {
-		return &cmdutil.Error{
-			Code:    cmdutil.CodeInputInvalidArgument,
-			Message: "--title is only valid with --from-url",
-		}
-	}
-	if opts.FileType != "" {
-		return &cmdutil.Error{
-			Code:    cmdutil.CodeInputInvalidArgument,
-			Message: "--file-type is only valid with --from-url",
-		}
-	}
-	if opts.TagID != "" {
-		return &cmdutil.Error{
-			Code:    cmdutil.CodeInputInvalidArgument,
-			Message: "--tag-id is only valid with --from-url",
-		}
+	// URL-mode-only flags are not meaningful for a directory walk;
+	// rejectURLOnlyFlags is the single source of truth shared with
+	// file-mode upload.
+	if err := rejectURLOnlyFlags(opts); err != nil {
+		return err
 	}
 	// Parse --metadata up front so a malformed value aborts before the
 	// first SDK call - otherwise a typo in `key=value` would only surface

--- a/cli/cmd/doc/upload_recursive.go
+++ b/cli/cmd/doc/upload_recursive.go
@@ -32,6 +32,34 @@ func runUploadRecursive(ctx context.Context, opts *UploadOptions, jopts *cmdutil
 			Hint:    "drop --name or upload files one at a time",
 		}
 	}
+	// URL-mode-only flags are not meaningful for a directory walk; reject
+	// them so misuse fails fast (mirrors the file-mode path's check in
+	// validateUploadFlags - that path runs before --recursive dispatches).
+	if opts.Title != "" {
+		return &cmdutil.Error{
+			Code:    cmdutil.CodeInputInvalidArgument,
+			Message: "--title is only valid with --from-url",
+		}
+	}
+	if opts.FileType != "" {
+		return &cmdutil.Error{
+			Code:    cmdutil.CodeInputInvalidArgument,
+			Message: "--file-type is only valid with --from-url",
+		}
+	}
+	if opts.TagID != "" {
+		return &cmdutil.Error{
+			Code:    cmdutil.CodeInputInvalidArgument,
+			Message: "--tag-id is only valid with --from-url",
+		}
+	}
+	// Parse --metadata up front so a malformed value aborts before the
+	// first SDK call - otherwise a typo in `key=value` would only surface
+	// per-file as repeated identical errors.
+	meta, err := parseMetadataKV(opts.Metadata)
+	if err != nil {
+		return err
+	}
 	info, err := os.Stat(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -70,8 +98,9 @@ func runUploadRecursive(ctx context.Context, opts *UploadOptions, jopts *cmdutil
 
 	var uploaded, failed []uploadOutcome
 	var firstFailCode cmdutil.ErrorCode
+	channel := effectiveChannel(opts)
 	for _, p := range matches {
-		k, err := svc.CreateKnowledgeFromFile(ctx, kbID, p, nil, nil, "", uploadChannel)
+		k, err := svc.CreateKnowledgeFromFile(ctx, kbID, p, meta, opts.EnableMultimodel, "", channel)
 		if err != nil {
 			code := cmdutil.ClassifyHTTPError(err)
 			if firstFailCode == "" {

--- a/cli/cmd/doc/upload_recursive_test.go
+++ b/cli/cmd/doc/upload_recursive_test.go
@@ -25,16 +25,25 @@ type scriptedUploadSvc struct {
 		err error
 	}
 	called []string
+
+	// Captures from the most-recent call (every recursive iteration writes
+	// these; tests that want all-rows can extend to slices later).
+	lastMetadata         map[string]string
+	lastEnableMultimodel *bool
+	lastChannel          string
 }
 
 func (s *scriptedUploadSvc) CreateKnowledgeFromFile(
 	_ context.Context,
 	_, filePath string,
-	_ map[string]string,
-	_ *bool,
-	_, _ string,
+	metadata map[string]string,
+	enableMultimodel *bool,
+	_, channel string,
 ) (*sdk.Knowledge, error) {
 	s.called = append(s.called, filepath.Base(filePath))
+	s.lastMetadata = metadata
+	s.lastEnableMultimodel = enableMultimodel
+	s.lastChannel = channel
 	r, ok := s.results[filepath.Base(filePath)]
 	if !ok {
 		return &sdk.Knowledge{ID: "doc_" + filepath.Base(filePath), FileName: filepath.Base(filePath)}, nil
@@ -155,6 +164,68 @@ func TestUploadRecursive_RejectsNameFlag(t *testing.T) {
 	require.ErrorAs(t, err, &typed)
 	assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code)
 	assert.Contains(t, typed.Message, "--name")
+}
+
+func TestUploadRecursive_PropagatesMultimodelAndMetadata(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	dir := t.TempDir()
+	mkTree(t, dir, "a.pdf")
+
+	svc := &scriptedUploadSvc{}
+	mm := true
+	opts := &UploadOptions{
+		Recursive:        true,
+		Glob:             "*",
+		EnableMultimodel: &mm,
+		Metadata:         []string{"team=alpha"},
+		Channel:          "browser_extension",
+	}
+	require.NoError(t, runUploadRecursive(context.Background(), opts, nil, svc, "kb_xxx", dir))
+
+	require.NotNil(t, svc.lastEnableMultimodel)
+	assert.True(t, *svc.lastEnableMultimodel)
+	assert.Equal(t, map[string]string{"team": "alpha"}, svc.lastMetadata)
+	assert.Equal(t, "browser_extension", svc.lastChannel)
+}
+
+func TestUploadRecursive_MetadataInvalid_NoCalls(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	dir := t.TempDir()
+	mkTree(t, dir, "a.pdf")
+
+	svc := &scriptedUploadSvc{}
+	opts := &UploadOptions{Recursive: true, Glob: "*", Metadata: []string{"badformat"}}
+	err := runUploadRecursive(context.Background(), opts, nil, svc, "kb_xxx", dir)
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code)
+	assert.Empty(t, svc.called, "must fail before any per-file call")
+}
+
+func TestUploadRecursive_RejectsURLOnlyFlags(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	dir := t.TempDir()
+	mkTree(t, dir, "a.pdf")
+	for _, tc := range []struct {
+		name string
+		opts *UploadOptions
+		want string
+	}{
+		{"title", &UploadOptions{Recursive: true, Glob: "*", Title: "x"}, "--title"},
+		{"file-type", &UploadOptions{Recursive: true, Glob: "*", FileType: "pdf"}, "--file-type"},
+		{"tag-id", &UploadOptions{Recursive: true, Glob: "*", TagID: "t"}, "--tag-id"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &scriptedUploadSvc{}
+			err := runUploadRecursive(context.Background(), tc.opts, nil, svc, "kb_xxx", dir)
+			require.Error(t, err)
+			var typed *cmdutil.Error
+			require.ErrorAs(t, err, &typed)
+			assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code)
+			assert.Contains(t, typed.Message, tc.want)
+		})
+	}
 }
 
 func TestUploadRecursive_JSON_BareObject(t *testing.T) {

--- a/cli/cmd/doc/upload_test.go
+++ b/cli/cmd/doc/upload_test.go
@@ -258,3 +258,206 @@ func TestValidateUploadFlags_NoPathOrURL_Rejected(t *testing.T) {
 	require.ErrorAs(t, err, &typed)
 	assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code)
 }
+
+// --- C10 expanded flags: multimodel / metadata / channel / URL-mode extras ---
+
+func TestUpload_EnableMultimodel_Set_True(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	path := writeTempFile(t, "mm.pdf")
+	svc := &fakeUploadSvc{resp: &sdk.Knowledge{ID: "doc_mm", FileName: "mm.pdf"}}
+	mm := true
+	opts := &UploadOptions{EnableMultimodel: &mm}
+	require.NoError(t, runUpload(context.Background(), opts, nil, svc, "kb_xxx", path))
+	require.NotNil(t, svc.got.enableMultimodel, "expected non-nil *bool when flag set")
+	assert.True(t, *svc.got.enableMultimodel)
+}
+
+func TestUpload_EnableMultimodel_Set_False(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	path := writeTempFile(t, "mm.pdf")
+	svc := &fakeUploadSvc{resp: &sdk.Knowledge{ID: "doc_mm", FileName: "mm.pdf"}}
+	mm := false
+	opts := &UploadOptions{EnableMultimodel: &mm}
+	require.NoError(t, runUpload(context.Background(), opts, nil, svc, "kb_xxx", path))
+	require.NotNil(t, svc.got.enableMultimodel, "explicit false must still surface as non-nil *bool")
+	assert.False(t, *svc.got.enableMultimodel)
+}
+
+// TestParseTriBool pins the empty-string-rejects behavior. Bare
+// --enable-multimodel maps to "true" via NoOptDefVal before the flag reaches
+// parseTriBool, so an empty value here always indicates an explicit
+// --enable-multimodel="" (e.g. uninterpolated $VAR). Silently coercing
+// empty to true used to surprise users.
+func TestParseTriBool(t *testing.T) {
+	for _, c := range []struct {
+		in      string
+		want    bool
+		wantErr bool
+	}{
+		{"true", true, false},
+		{"1", true, false},
+		{"yes", true, false},
+		{"false", false, false},
+		{"0", false, false},
+		{"no", false, false},
+		{"", false, true},     // explicit empty rejected
+		{"  ", false, true},   // whitespace rejected
+		{"maybe", false, true},
+	} {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := parseTriBool(c.in)
+			if c.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "input.invalid_argument")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestUpload_Metadata_ParseKV(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	path := writeTempFile(t, "m.pdf")
+	svc := &fakeUploadSvc{resp: &sdk.Knowledge{ID: "doc_m", FileName: "m.pdf"}}
+	opts := &UploadOptions{Metadata: []string{"foo=bar", "baz=qux"}}
+	require.NoError(t, runUpload(context.Background(), opts, nil, svc, "kb_xxx", path))
+	assert.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, svc.got.metadata)
+}
+
+func TestUpload_Metadata_EmptyValueAllowed(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	path := writeTempFile(t, "m.pdf")
+	svc := &fakeUploadSvc{resp: &sdk.Knowledge{ID: "doc_m", FileName: "m.pdf"}}
+	opts := &UploadOptions{Metadata: []string{"foo="}}
+	require.NoError(t, runUpload(context.Background(), opts, nil, svc, "kb_xxx", path))
+	assert.Equal(t, map[string]string{"foo": ""}, svc.got.metadata)
+}
+
+func TestUpload_Metadata_LastWins(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	path := writeTempFile(t, "m.pdf")
+	svc := &fakeUploadSvc{resp: &sdk.Knowledge{ID: "doc_m", FileName: "m.pdf"}}
+	opts := &UploadOptions{Metadata: []string{"k=v1", "k=v2"}}
+	require.NoError(t, runUpload(context.Background(), opts, nil, svc, "kb_xxx", path))
+	assert.Equal(t, map[string]string{"k": "v2"}, svc.got.metadata)
+}
+
+func TestUpload_Metadata_InvalidFormat_NoEquals(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	path := writeTempFile(t, "m.pdf")
+	svc := &fakeUploadSvc{resp: &sdk.Knowledge{ID: "doc_m", FileName: "m.pdf"}}
+	opts := &UploadOptions{Metadata: []string{"foo"}}
+	err := runUpload(context.Background(), opts, nil, svc, "kb_xxx", path)
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code)
+}
+
+func TestUpload_Metadata_InvalidFormat_EmptyKey(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	path := writeTempFile(t, "m.pdf")
+	svc := &fakeUploadSvc{resp: &sdk.Knowledge{ID: "doc_m", FileName: "m.pdf"}}
+	opts := &UploadOptions{Metadata: []string{"=bar"}}
+	err := runUpload(context.Background(), opts, nil, svc, "kb_xxx", path)
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code)
+}
+
+func TestUpload_Channel_Override(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	path := writeTempFile(t, "c.pdf")
+	svc := &fakeUploadSvc{resp: &sdk.Knowledge{ID: "doc_c", FileName: "c.pdf"}}
+	opts := &UploadOptions{Channel: "browser_extension"}
+	require.NoError(t, runUpload(context.Background(), opts, nil, svc, "kb_xxx", path))
+	assert.Equal(t, "browser_extension", svc.got.channel)
+}
+
+func TestUpload_Channel_DefaultStillAPI(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	path := writeTempFile(t, "c.pdf")
+	svc := &fakeUploadSvc{resp: &sdk.Knowledge{ID: "doc_c", FileName: "c.pdf"}}
+	// Empty Channel is the runUpload contract for "use default".
+	opts := &UploadOptions{}
+	require.NoError(t, runUpload(context.Background(), opts, nil, svc, "kb_xxx", path))
+	assert.Equal(t, uploadChannel, svc.got.channel)
+}
+
+// URL-mode metadata happy paths
+
+func TestUploadFromURL_Title(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeUploadSvc{urlResp: &sdk.Knowledge{ID: "doc_u"}}
+	opts := &UploadOptions{FromURL: "https://example.com/a.pdf", Title: "My Title"}
+	require.NoError(t, runUploadFromURL(context.Background(), opts, nil, svc, "kb_xxx"))
+	assert.Equal(t, "My Title", svc.got.urlReq.Title)
+}
+
+func TestUploadFromURL_FileType(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeUploadSvc{urlResp: &sdk.Knowledge{ID: "doc_u"}}
+	opts := &UploadOptions{FromURL: "https://example.com/no-ext", FileType: "pdf"}
+	require.NoError(t, runUploadFromURL(context.Background(), opts, nil, svc, "kb_xxx"))
+	assert.Equal(t, "pdf", svc.got.urlReq.FileType)
+}
+
+func TestUploadFromURL_TagID(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeUploadSvc{urlResp: &sdk.Knowledge{ID: "doc_u"}}
+	opts := &UploadOptions{FromURL: "https://example.com/a.pdf", TagID: "tag_99"}
+	require.NoError(t, runUploadFromURL(context.Background(), opts, nil, svc, "kb_xxx"))
+	assert.Equal(t, "tag_99", svc.got.urlReq.TagID)
+}
+
+func TestUploadFromURL_EnableMultimodel_Forwarded(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeUploadSvc{urlResp: &sdk.Knowledge{ID: "doc_u"}}
+	mm := true
+	opts := &UploadOptions{FromURL: "https://example.com/a.pdf", EnableMultimodel: &mm}
+	require.NoError(t, runUploadFromURL(context.Background(), opts, nil, svc, "kb_xxx"))
+	require.NotNil(t, svc.got.urlReq.EnableMultimodel)
+	assert.True(t, *svc.got.urlReq.EnableMultimodel)
+}
+
+func TestUploadFromURL_Channel_Override(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeUploadSvc{urlResp: &sdk.Knowledge{ID: "doc_u"}}
+	opts := &UploadOptions{FromURL: "https://example.com/a.pdf", Channel: "web"}
+	require.NoError(t, runUploadFromURL(context.Background(), opts, nil, svc, "kb_xxx"))
+	assert.Equal(t, "web", svc.got.urlReq.Channel)
+}
+
+// URL-only flag misuse: error when used without --from-url.
+// validateUploadFlags should reject --title/--file-type/--tag-id paired
+// with a positional file path (i.e., no --from-url).
+
+func TestValidateUploadFlags_Title_RequiresFromURL(t *testing.T) {
+	err := validateUploadFlags(&UploadOptions{Title: "x"}, []string{"/tmp/x.pdf"})
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code)
+	assert.Contains(t, typed.Message, "--title")
+}
+
+func TestValidateUploadFlags_FileType_RequiresFromURL(t *testing.T) {
+	err := validateUploadFlags(&UploadOptions{FileType: "pdf"}, []string{"/tmp/x.pdf"})
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code)
+	assert.Contains(t, typed.Message, "--file-type")
+}
+
+func TestValidateUploadFlags_TagID_RequiresFromURL(t *testing.T) {
+	err := validateUploadFlags(&UploadOptions{TagID: "tag_x"}, []string{"/tmp/x.pdf"})
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code)
+	assert.Contains(t, typed.Message, "--tag-id")
+}

--- a/cli/cmd/doc/upload_test.go
+++ b/cli/cmd/doc/upload_test.go
@@ -132,6 +132,25 @@ func TestUpload_HTTPError_409Conflict(t *testing.T) {
 	assert.Equal(t, cmdutil.CodeResourceAlreadyExists, typed.Code)
 }
 
+// TestUpload_DuplicateFileMaps_resource_already_exists pins the contract that
+// the SDK's sentinel sdk.ErrDuplicateFile (returned with no "HTTP error <n>:"
+// prefix because the duplicate is detected by file-hash short-circuit, not by
+// status code) is mapped to resource.already_exists. Prior regression: the
+// file-upload path forwarded the sentinel to WrapHTTP, which classified the
+// prefix-less message as network.error — symmetric with the --from-url branch
+// which already handled ErrDuplicateURL.
+func TestUpload_DuplicateFileMaps_resource_already_exists(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	path := writeTempFile(t, "dup.md")
+	svc := &fakeUploadSvc{err: sdk.ErrDuplicateFile}
+	err := runUpload(context.Background(), &UploadOptions{}, nil, svc, "kb_xxx", path)
+	require.Error(t, err)
+
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeResourceAlreadyExists, typed.Code)
+}
+
 func TestValidateUploadPath_NotFound(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "does-not-exist.pdf")
 	err := validateUploadPath(missing)
@@ -238,6 +257,21 @@ func TestValidateUploadFlags_FromURL_WithRecursive_Rejected(t *testing.T) {
 	assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code)
 }
 
+// The server's URL-ingest request type has no Metadata field; the CLI must
+// reject --metadata + --from-url upfront so callers don't think they've set
+// metadata that the server then silently drops on the wire.
+func TestValidateUploadFlags_FromURL_WithMetadata_Rejected(t *testing.T) {
+	err := validateUploadFlags(&UploadOptions{
+		FromURL:  "https://example.com/x.pdf",
+		Metadata: []string{"team=alpha"},
+	}, nil)
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code)
+	assert.Contains(t, typed.Message, "--metadata is not supported with --from-url")
+}
+
 func TestValidateUploadFlags_FromURL_BadScheme(t *testing.T) {
 	err := validateUploadFlags(&UploadOptions{FromURL: "file:///etc/passwd"}, nil)
 	require.Error(t, err)
@@ -300,8 +334,8 @@ func TestParseTriBool(t *testing.T) {
 		{"false", false, false},
 		{"0", false, false},
 		{"no", false, false},
-		{"", false, true},     // explicit empty rejected
-		{"  ", false, true},   // whitespace rejected
+		{"", false, true},   // explicit empty rejected
+		{"  ", false, true}, // whitespace rejected
 		{"maybe", false, true},
 	} {
 		t.Run(c.in, func(t *testing.T) {

--- a/cli/cmd/doc/view.go
+++ b/cli/cmd/doc/view.go
@@ -65,20 +65,57 @@ func runView(ctx context.Context, opts *ViewOptions, jopts *cmdutil.JSONOptions,
 	w := iostreams.IO.Out
 	fmt.Fprintf(w, "ID:        %s\n", doc.ID)
 	fmt.Fprintf(w, "NAME:      %s\n", text.KnowledgeDisplayName(doc.FileName, doc.Title, doc.ID))
+	// Title is rendered as a separate line only when it adds info over
+	// NAME (i.e. FileName is set AND differs from Title). When FileName
+	// is empty, KnowledgeDisplayName already used Title for NAME so a
+	// duplicate TITLE line would be noise.
+	if doc.Title != "" && doc.FileName != "" && doc.Title != doc.FileName {
+		fmt.Fprintf(w, "TITLE:     %s\n", doc.Title)
+	}
 	if doc.KnowledgeBaseID != "" {
 		fmt.Fprintf(w, "KB:        %s\n", doc.KnowledgeBaseID)
+	}
+	if doc.TagID != "" {
+		fmt.Fprintf(w, "TAG:       %s\n", doc.TagID)
+	}
+	if doc.Description != "" {
+		fmt.Fprintf(w, "DESC:      %s\n", doc.Description)
 	}
 	if doc.FileType != "" {
 		fmt.Fprintf(w, "TYPE:      %s\n", doc.FileType)
 	}
+	if doc.Source != "" {
+		fmt.Fprintf(w, "SOURCE:    %s\n", doc.Source)
+	}
+	if doc.Channel != "" {
+		fmt.Fprintf(w, "CHANNEL:   %s\n", doc.Channel)
+	}
 	if doc.FileSize > 0 {
 		fmt.Fprintf(w, "SIZE:      %s\n", formatSize(doc.FileSize))
+	}
+	if doc.StorageSize > 0 {
+		fmt.Fprintf(w, "STORAGE:   %s\n", formatSize(doc.StorageSize))
 	}
 	if doc.ParseStatus != "" {
 		fmt.Fprintf(w, "STATUS:    %s\n", doc.ParseStatus)
 	}
+	if doc.SummaryStatus != "" {
+		fmt.Fprintf(w, "SUMMARY:   %s\n", doc.SummaryStatus)
+	}
+	if doc.EnableStatus != "" {
+		fmt.Fprintf(w, "ENABLED:   %s\n", doc.EnableStatus)
+	}
 	if doc.EmbeddingModelID != "" {
 		fmt.Fprintf(w, "EMBEDDING: %s\n", doc.EmbeddingModelID)
+	}
+	if doc.FileHash != "" {
+		// Git-SHA-style 12-char prefix is enough for de-duplication
+		// while keeping the line short.
+		h := doc.FileHash
+		if len(h) > 12 {
+			h = h[:12]
+		}
+		fmt.Fprintf(w, "HASH:      %s\n", h)
 	}
 	if !doc.CreatedAt.IsZero() {
 		fmt.Fprintf(w, "CREATED:   %s\n", doc.CreatedAt.Format("2006-01-02 15:04:05"))

--- a/cli/cmd/doc/view_test.go
+++ b/cli/cmd/doc/view_test.go
@@ -122,3 +122,143 @@ func TestView_NotFound_ClassifiedAs404(t *testing.T) {
 		t.Errorf("expected resource.not_found, got %v", err)
 	}
 }
+
+// --- expanded human render: title/desc/source/channel/etc. ---
+
+func TestView_Title_RendersWhenDifferentFromFileName(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewSvc{doc: &sdk.Knowledge{
+		ID: "doc_t", FileName: "raw.pdf", Title: "Quarterly Plan",
+	}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "doc_t"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "TITLE:") || !strings.Contains(got, "Quarterly Plan") {
+		t.Errorf("expected TITLE line:\n%s", got)
+	}
+}
+
+// When Title and FileName are equal, the TITLE line is redundant with NAME
+// and should be omitted.
+func TestView_Title_OmittedWhenSameAsFileName(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewSvc{doc: &sdk.Knowledge{
+		ID: "doc_t", FileName: "policy.pdf", Title: "policy.pdf",
+	}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "doc_t"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	for _, l := range strings.Split(out.String(), "\n") {
+		if strings.HasPrefix(l, "TITLE:") {
+			t.Errorf("TITLE line should be omitted when same as filename: %q", l)
+		}
+	}
+}
+
+func TestView_Description(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewSvc{doc: &sdk.Knowledge{ID: "doc_d", FileName: "x.pdf", Description: "Annual review"}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "doc_d"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	if !strings.Contains(out.String(), "Annual review") {
+		t.Errorf("expected description text:\n%s", out.String())
+	}
+}
+
+func TestView_SourceAndChannel(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewSvc{doc: &sdk.Knowledge{
+		ID: "doc_s", FileName: "x.pdf", Source: "https://example.com/x", Channel: "web",
+	}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "doc_s"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"SOURCE:", "https://example.com/x", "CHANNEL:", "web"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestView_SummaryAndEnableStatus(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewSvc{doc: &sdk.Knowledge{
+		ID: "doc_st", FileName: "x.pdf",
+		SummaryStatus: "completed",
+		EnableStatus:  "disabled",
+	}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "doc_st"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"SUMMARY:", "completed", "ENABLED:", "disabled"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestView_TagID(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewSvc{doc: &sdk.Knowledge{ID: "doc_t", FileName: "x.pdf", TagID: "tag_abc"}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "doc_t"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "TAG:") || !strings.Contains(got, "tag_abc") {
+		t.Errorf("expected TAG line:\n%s", got)
+	}
+}
+
+func TestView_StorageSize_Human(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewSvc{doc: &sdk.Knowledge{ID: "doc_sz", FileName: "x.pdf", StorageSize: 2 * 1024 * 1024}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "doc_sz"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "STORAGE:") || !strings.Contains(got, "MB") {
+		t.Errorf("expected STORAGE line with human-readable bytes:\n%s", got)
+	}
+}
+
+func TestView_FileHash_Prefix12(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewSvc{doc: &sdk.Knowledge{
+		ID:       "doc_h",
+		FileName: "x.pdf",
+		FileHash: "abcdef1234567890fedcba0987654321",
+	}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "doc_h"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "HASH:") || !strings.Contains(got, "abcdef123456") {
+		t.Errorf("expected HASH line with 12-char prefix:\n%s", got)
+	}
+	if strings.Contains(got, "abcdef1234567890fedcba0987654321") {
+		t.Errorf("full hash should be truncated, got:\n%s", got)
+	}
+}
+
+func TestView_ErrorMessage_WarnPrefix(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewSvc{doc: &sdk.Knowledge{
+		ID: "doc_e", FileName: "x.pdf", ErrorMessage: "parser failed at offset 4096",
+	}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "doc_e"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "parser failed at offset 4096") {
+		t.Errorf("expected error message rendered:\n%s", got)
+	}
+	// Either ERROR: or a WARN-prefixed label is acceptable as a "warn"
+	// signal — assert at least one.
+	if !strings.Contains(got, "ERROR:") && !strings.Contains(got, "WARN") {
+		t.Errorf("expected ERROR or WARN prefix on error line:\n%s", got)
+	}
+}

--- a/cli/cmd/kb/view.go
+++ b/cli/cmd/kb/view.go
@@ -63,17 +63,37 @@ func runView(ctx context.Context, opts *ViewOptions, jopts *cmdutil.JSONOptions,
 	if jopts.Enabled() {
 		return jopts.Emit(iostreams.IO.Out, kb)
 	}
-	// Human: KEY: VALUE
+	// Human: KEY: VALUE. Nested config structs (chunking_config, vlm_config,
+	// etc.) are intentionally omitted from the human render — those are for
+	// `--json | jq '.chunking_config'` workflows.
 	w := iostreams.IO.Out
 	fmt.Fprintf(w, "ID:        %s\n", kb.ID)
 	fmt.Fprintf(w, "NAME:      %s\n", kb.Name)
+	if kb.Type != "" {
+		fmt.Fprintf(w, "TYPE:      %s\n", kb.Type)
+	}
 	if kb.Description != "" {
 		fmt.Fprintf(w, "DESC:      %s\n", kb.Description)
 	}
+	if kb.IsPinned {
+		fmt.Fprintf(w, "PINNED:    yes\n")
+	}
+	if kb.IsTemporary {
+		fmt.Fprintf(w, "TEMPORARY: yes\n")
+	}
 	fmt.Fprintf(w, "DOCS:      %s\n", text.Pluralize(int(kb.KnowledgeCount), "doc"))
 	fmt.Fprintf(w, "CHUNKS:    %s\n", text.Pluralize(int(kb.ChunkCount), "chunk"))
+	if kb.IsProcessing {
+		fmt.Fprintf(w, "PROCESSING: %s\n", text.Pluralize(int(kb.ProcessingCount), "doc"))
+	}
 	if kb.EmbeddingModelID != "" {
 		fmt.Fprintf(w, "EMBEDDING: %s\n", kb.EmbeddingModelID)
+	}
+	if kb.SummaryModelID != "" {
+		fmt.Fprintf(w, "SUMMARY MODEL: %s\n", kb.SummaryModelID)
+	}
+	if !kb.CreatedAt.IsZero() {
+		fmt.Fprintf(w, "CREATED:   %s\n", kb.CreatedAt.Format("2006-01-02 15:04:05"))
 	}
 	if !kb.UpdatedAt.IsZero() {
 		// Detail page favors absolute time; FuzzyAgo is reserved for list views.

--- a/cli/cmd/kb/view_test.go
+++ b/cli/cmd/kb/view_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
 	"github.com/Tencent/WeKnora/cli/internal/iostreams"
@@ -60,5 +61,107 @@ func TestGet_NotFound(t *testing.T) {
 	}
 	if !cmdutil.IsNotFound(err) {
 		t.Errorf("expected resource.not_found, got %v", err)
+	}
+}
+
+// --- expanded human render: badges + extra KV lines ---
+
+func TestView_Pinned_RendersPinnedLine(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeGetSvc{kb: &sdk.KnowledgeBase{ID: "kb1", Name: "Pinned", IsPinned: true}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "kb1"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	if !strings.Contains(out.String(), "PINNED:") {
+		t.Errorf("expected PINNED line for IsPinned=true:\n%s", out.String())
+	}
+}
+
+func TestView_NotPinned_OmitsPinnedLine(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeGetSvc{kb: &sdk.KnowledgeBase{ID: "kb1", Name: "Plain", IsPinned: false}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "kb1"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	for _, l := range strings.Split(out.String(), "\n") {
+		if strings.HasPrefix(l, "PINNED:") {
+			t.Errorf("PINNED line should be omitted when IsPinned=false: %q", l)
+		}
+	}
+}
+
+func TestView_Temporary_RendersTempLine(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeGetSvc{kb: &sdk.KnowledgeBase{ID: "kb_t", Name: "Tmp", IsTemporary: true}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "kb_t"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	if !strings.Contains(out.String(), "TEMPORARY:") {
+		t.Errorf("expected TEMPORARY line:\n%s", out.String())
+	}
+}
+
+func TestView_SummaryModel(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeGetSvc{kb: &sdk.KnowledgeBase{ID: "kb1", Name: "X", SummaryModelID: "summary-model-x"}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "kb1"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "SUMMARY MODEL:") || !strings.Contains(got, "summary-model-x") {
+		t.Errorf("expected SUMMARY MODEL line:\n%s", got)
+	}
+}
+
+func TestView_TypeAndSource(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeGetSvc{kb: &sdk.KnowledgeBase{ID: "kb1", Name: "X", Type: "general", Description: "d"}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "kb1"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "TYPE:") || !strings.Contains(got, "general") {
+		t.Errorf("expected TYPE line for non-empty Type:\n%s", got)
+	}
+}
+
+func TestView_Processing(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeGetSvc{kb: &sdk.KnowledgeBase{ID: "kb_p", Name: "Busy", IsProcessing: true, ProcessingCount: 3}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "kb_p"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "PROCESSING:") || !strings.Contains(got, "3") {
+		t.Errorf("expected PROCESSING line with count:\n%s", got)
+	}
+}
+
+func TestView_NotProcessing_OmitsProcessingLine(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeGetSvc{kb: &sdk.KnowledgeBase{ID: "kb_idle", Name: "Idle", IsProcessing: false}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "kb_idle"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	for _, l := range strings.Split(out.String(), "\n") {
+		if strings.HasPrefix(l, "PROCESSING:") {
+			t.Errorf("PROCESSING line should be omitted: %q", l)
+		}
+	}
+}
+
+func TestView_CreatedAt_AlwaysRendered(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeGetSvc{kb: &sdk.KnowledgeBase{
+		ID: "kb1", Name: "X",
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+	}}
+	if err := runView(context.Background(), &ViewOptions{}, nil, svc, "kb1"); err != nil {
+		t.Fatalf("runView: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "CREATED:") || !strings.Contains(got, "2026-01-01") {
+		t.Errorf("expected CREATED line:\n%s", got)
 	}
 }

--- a/cli/cmd/mcp/mcp.go
+++ b/cli/cmd/mcp/mcp.go
@@ -23,8 +23,8 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mcp",
 		Short: "Run weknora as a Model Context Protocol server",
-		Long: `Exposes weknora's read surface as MCP tools so agentic IDE clients
-(Claude Code, Cursor, Continue, Zed) can call them over JSON-RPC.
+		Long: `Exposes weknora's read surface as MCP tools so any
+MCP-compatible client can call them over JSON-RPC.
 
 Initial tool surface is read-only and curated: kb_list / kb_view /
 doc_list / doc_view / doc_download / search_chunks / chat / agent_list /

--- a/cli/cmd/mcp/serve.go
+++ b/cli/cmd/mcp/serve.go
@@ -22,8 +22,8 @@ configured, the process exits with auth.unauthenticated before any MCP
 handshake. This way an IDE-side agent sees a clear failure mode rather
 than a server that handshakes successfully then errors on every tool.
 
-To register with your MCP client (Claude Desktop / Code / Cursor / etc.),
-add an entry pointing at this binary under "mcpServers":
+To register with your MCP client, add an entry pointing at this binary
+under "mcpServers":
 
     {
       "mcpServers": {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	apicmd "github.com/Tencent/WeKnora/cli/cmd/api"
 	"github.com/Tencent/WeKnora/cli/cmd/auth"
 	chatcmd "github.com/Tencent/WeKnora/cli/cmd/chat"
+	chunkcmd "github.com/Tencent/WeKnora/cli/cmd/chunk"
 	contextcmd "github.com/Tencent/WeKnora/cli/cmd/context"
 	"github.com/Tencent/WeKnora/cli/cmd/doc"
 	"github.com/Tencent/WeKnora/cli/cmd/doctor"
@@ -130,6 +131,7 @@ hybrid searches against a WeKnora server from your shell or an AI agent.`,
 	cmd.AddCommand(chatcmd.NewCmd(f))
 	cmd.AddCommand(sessioncmd.NewCmd(f))
 	cmd.AddCommand(agentcmd.NewCmd(f))
+	cmd.AddCommand(chunkcmd.NewCmdChunk(f))
 	cmd.AddCommand(mcpcmd.NewCmd(f))
 	return cmd
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -30,7 +30,7 @@ import (
 func Execute() int {
 	root := NewRootCmd(cmdutil.New())
 	if err := root.Execute(); err != nil {
-		// Errors go to stderr (matches gh/aws/stripe). Stdout stays
+		// Errors go to stderr. Stdout stays
 		// empty (or holds partial success the command produced) so
 		// downstream `--json | jq` pipelines never filter error shapes
 		// out of the success stream. The typed exit code (3/4/5/6/7/10)

--- a/cli/cmd/search/chunks.go
+++ b/cli/cmd/search/chunks.go
@@ -51,7 +51,7 @@ func NewCmdChunks(f *cmdutil.Factory) *cobra.Command {
 		Short: "Hybrid (vector + keyword) chunk retrieval against a knowledge base",
 		Example: `  weknora search chunks "what is RAG?" --kb engineering
   weknora search chunks "embedding model" --kb kb_abc --limit 20
-  weknora search chunks "k8s" --kb engineering --no-keyword         # vector-only`,
+  weknora search chunks "retry policy" --kb engineering --no-keyword  # vector-only`,
 		Long: `Hybrid (vector + keyword) retrieval against the knowledge base. Pass
 --no-vector or --no-keyword to disable one channel; you cannot disable both.
 --limit caps the returned slice client-side.`,

--- a/cli/cmd/search/docs.go
+++ b/cli/cmd/search/docs.go
@@ -16,9 +16,9 @@ import (
 )
 
 // docsPageSize is the default --page-size on `search docs`: how many
-// entries to pull per ListKnowledge round-trip when paging through a KB
-// to filter client-side. Server caps page_size at 1000 (per the doc/list
-// bound this branch already added). Tunable via --page-size in 1..1000.
+// entries to pull per ListKnowledgeWithFilter round-trip. The server
+// applies the keyword filter pre-pagination, so most KBs return in a
+// single page even at conservative sizes. Server caps page_size at 1000.
 const docsPageSize = 200
 
 // docsMaxPageSize bounds the --page-size flag, matching session/doc list canon.
@@ -39,10 +39,10 @@ type DocsSearchOptions struct {
 	KB    string // raw --kb (UUID or name)
 	KBID  string // resolved id; populated before listing
 	Limit int
-	// PageSize is the server batch size per ListKnowledge call (1..1000,
-	// default 200). Tunable so a caller searching a small KB can fetch
-	// everything in one round-trip, or a caller on flaky network can
-	// shorten the batch.
+	// PageSize is the server batch size per ListKnowledgeWithFilter call
+	// (1..1000, default 200). Tunable so a caller searching a small KB
+	// can fetch everything in one round-trip, or a caller on flaky
+	// network can shorten the batch.
 	PageSize int
 	// AllPages walks server pages internally until total exhausted or
 	// --limit accumulated. Default true preserves v0.4 behavior; setting
@@ -51,24 +51,31 @@ type DocsSearchOptions struct {
 }
 
 // DocsSearchService is the narrow SDK surface this command depends on.
-// Server has no fuzzy-document-name endpoint, so the CLI pages through
-// ListKnowledge and filters by Title / FileName client-side.
+// The server applies the keyword filter pre-pagination via the
+// ?keyword= query param, so the CLI just forwards opts.Query as
+// filter.Keyword and accumulates the (already-filtered) pages.
 type DocsSearchService interface {
-	ListKnowledge(ctx context.Context, kbID string, page, pageSize int, tagID string) ([]sdk.Knowledge, int64, error)
+	ListKnowledgeWithFilter(ctx context.Context, kbID string, page, pageSize int, filter sdk.KnowledgeListFilter) ([]sdk.Knowledge, int64, error)
 }
 
 // NewCmdDocs builds `weknora search docs "<query>" --kb <id-or-name>`.
 // Pages through the KB's documents and surfaces every entry whose title
-// or filename contains the query (case-insensitive). Useful for finding
-// a specific upload to download or delete.
+// or file_name contains the query as a server-side case-sensitive LIKE
+// match. Useful for finding a specific upload to download or delete.
 func NewCmdDocs(f *cmdutil.Factory) *cobra.Command {
 	opts := &DocsSearchOptions{}
 	cmd := &cobra.Command{
 		Use:   `docs "<query>"`,
-		Short: "Find documents in a knowledge base by name (client-side substring match)",
-		Long: `Pages through the KB's documents and surfaces every entry whose title or
-filename contains the query (case-insensitive). Useful for finding a
+		Short: "Find documents in a knowledge base by keyword (server-side filter)",
+		Long: `Pages through the KB's documents, forwarding the query as the server-side
+keyword filter (matched against title / file_name). Useful for finding a
 specific upload to download or delete by id.
+
+The query is a case-sensitive server-side LIKE filter (the server runs
+` + "`LIKE %keyword%`" + ` against title and file_name). For case-insensitive
+matching, lower-case the query yourself, e.g.
+` + "`weknora search docs \"$(printf %s YOUR_QUERY | tr 'A-Z' 'a-z')\"`" + `, or
+fall back to ` + "`weknora api`" + ` with a custom filter.
 
 By default, --all-pages=true walks every server page until --limit is
 reached or the KB is exhausted (matching v0.4 behavior). Pass
@@ -115,24 +122,24 @@ func runDocsSearch(ctx context.Context, opts *DocsSearchOptions, jopts *cmdutil.
 		return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
 			fmt.Sprintf("--page-size must be in 1..%d, got %d", docsMaxPageSize, opts.PageSize))
 	}
-	needle := strings.ToLower(opts.Query)
+	filter := sdk.KnowledgeListFilter{Keyword: opts.Query}
 	var matches []sdk.Knowledge
 
 	// Page through the KB until limit matches found or pagination exhausted.
+	// The server applies the keyword filter pre-pagination, so every item
+	// returned is already a match - no client-side filter needed.
 	// --all-pages=true (default) walks every server page; --all-pages=false
 	// stops after the first page. The server returns total; stop when
 	// page*pageSize >= total.
 	for page := 1; ; page++ {
-		items, total, err := svc.ListKnowledge(ctx, opts.KBID, page, opts.PageSize, "")
+		items, total, err := svc.ListKnowledgeWithFilter(ctx, opts.KBID, page, opts.PageSize, filter)
 		if err != nil {
 			return cmdutil.WrapHTTP(err, "list documents")
 		}
 		for _, k := range items {
-			if matchKnowledge(k, needle) {
-				matches = append(matches, k)
-				if opts.Limit > 0 && len(matches) >= opts.Limit {
-					goto done
-				}
+			matches = append(matches, k)
+			if opts.Limit > 0 && len(matches) >= opts.Limit {
+				goto done
 			}
 		}
 		if !opts.AllPages {
@@ -162,12 +169,6 @@ done:
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", k.ID, name, k.FileType, k.UpdatedAt.Format("2006-01-02"))
 	}
 	return tw.Flush()
-}
-
-// matchKnowledge reports whether title or filename contains needle (already
-// lowercased by caller).
-func matchKnowledge(k sdk.Knowledge, needle string) bool {
-	return text.ContainsFold(needle, k.Title, k.FileName)
 }
 
 // sortKnowledgeByRecency sorts in place by UpdatedAt desc.

--- a/cli/cmd/search/docs.go
+++ b/cli/cmd/search/docs.go
@@ -15,10 +15,14 @@ import (
 	sdk "github.com/Tencent/WeKnora/client"
 )
 
-// docsPageSize is how many entries we pull per ListKnowledge round-trip
-// when paging through a KB to filter client-side. Server caps page_size at
-// 1000 (per the doc/list bound this branch already added).
+// docsPageSize is the default --page-size on `search docs`: how many
+// entries to pull per ListKnowledge round-trip when paging through a KB
+// to filter client-side. Server caps page_size at 1000 (per the doc/list
+// bound this branch already added). Tunable via --page-size in 1..1000.
 const docsPageSize = 200
+
+// docsMaxPageSize bounds the --page-size flag, matching session/doc list canon.
+const docsMaxPageSize = 1000
 
 // docsFields enumerates the fields surfaced for `--json` discovery on
 // `search docs`. Mirrors sdk.Knowledge json tags.
@@ -35,6 +39,15 @@ type DocsSearchOptions struct {
 	KB    string // raw --kb (UUID or name)
 	KBID  string // resolved id; populated before listing
 	Limit int
+	// PageSize is the server batch size per ListKnowledge call (1..1000,
+	// default 200). Tunable so a caller searching a small KB can fetch
+	// everything in one round-trip, or a caller on flaky network can
+	// shorten the batch.
+	PageSize int
+	// AllPages walks server pages internally until total exhausted or
+	// --limit accumulated. Default true preserves v0.4 behavior; setting
+	// false stops after the first page (useful for cheap previews).
+	AllPages bool
 }
 
 // DocsSearchService is the narrow SDK surface this command depends on.
@@ -55,9 +68,14 @@ func NewCmdDocs(f *cmdutil.Factory) *cobra.Command {
 		Short: "Find documents in a knowledge base by name (client-side substring match)",
 		Long: `Pages through the KB's documents and surfaces every entry whose title or
 filename contains the query (case-insensitive). Useful for finding a
-specific upload to download or delete by id.`,
+specific upload to download or delete by id.
+
+By default, --all-pages=true walks every server page until --limit is
+reached or the KB is exhausted (matching v0.4 behavior). Pass
+--all-pages=false to stop after one page.`,
 		Example: `  weknora search docs "Q3 forecast" --kb finance
-  weknora search docs "spec" --kb engineering --limit 5`,
+  weknora search docs "spec" --kb engineering --limit 5
+  weknora search docs "spec" --kb engineering --all-pages=false`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts.Query = strings.TrimSpace(args[0])
@@ -85,19 +103,27 @@ specific upload to download or delete by id.`,
 	}
 	cmd.Flags().StringVar(&opts.KB, "kb", "", "Knowledge base UUID or name (required)")
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 30, "Maximum results to return")
+	cmd.Flags().IntVar(&opts.PageSize, "page-size", docsPageSize, "Items per server batch (1..1000)")
+	cmd.Flags().BoolVar(&opts.AllPages, "all-pages", true, "Walk every server page until exhausted or --limit hit")
 	cmdutil.AddJSONFlags(cmd, docsFields)
 	_ = cmd.MarkFlagRequired("kb")
 	return cmd
 }
 
 func runDocsSearch(ctx context.Context, opts *DocsSearchOptions, jopts *cmdutil.JSONOptions, svc DocsSearchService) error {
+	if opts.PageSize < 1 || opts.PageSize > docsMaxPageSize {
+		return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
+			fmt.Sprintf("--page-size must be in 1..%d, got %d", docsMaxPageSize, opts.PageSize))
+	}
 	needle := strings.ToLower(opts.Query)
 	var matches []sdk.Knowledge
 
 	// Page through the KB until limit matches found or pagination exhausted.
-	// The server returns total; stop when (page-1)*pageSize >= total.
+	// --all-pages=true (default) walks every server page; --all-pages=false
+	// stops after the first page. The server returns total; stop when
+	// page*pageSize >= total.
 	for page := 1; ; page++ {
-		items, total, err := svc.ListKnowledge(ctx, opts.KBID, page, docsPageSize, "")
+		items, total, err := svc.ListKnowledge(ctx, opts.KBID, page, opts.PageSize, "")
 		if err != nil {
 			return cmdutil.WrapHTTP(err, "list documents")
 		}
@@ -109,7 +135,10 @@ func runDocsSearch(ctx context.Context, opts *DocsSearchOptions, jopts *cmdutil.
 				}
 			}
 		}
-		if int64(page*docsPageSize) >= total || len(items) == 0 {
+		if !opts.AllPages {
+			break
+		}
+		if int64(page*opts.PageSize) >= total || len(items) == 0 {
 			break
 		}
 	}

--- a/cli/cmd/search/docs_test.go
+++ b/cli/cmd/search/docs_test.go
@@ -15,17 +15,20 @@ import (
 	sdk "github.com/Tencent/WeKnora/client"
 )
 
-// fakeDocsSearchSvc scripts paginated ListKnowledge responses. Pages are
-// indexed 1-based; items keyed by page.
+// fakeDocsSearchSvc scripts paginated ListKnowledgeWithFilter responses.
+// Pages are indexed 1-based; items keyed by page. The last-received filter
+// is captured so tests can assert opts.Query was threaded as filter.Keyword.
 type fakeDocsSearchSvc struct {
-	pages map[int][]sdk.Knowledge
-	total int64
-	err   error
-	calls []int // page numbers requested, for assertions
+	pages      map[int][]sdk.Knowledge
+	total      int64
+	err        error
+	calls      []int // page numbers requested, for assertions
+	lastFilter sdk.KnowledgeListFilter
 }
 
-func (f *fakeDocsSearchSvc) ListKnowledge(_ context.Context, kbID string, page, pageSize int, tagID string) ([]sdk.Knowledge, int64, error) {
+func (f *fakeDocsSearchSvc) ListKnowledgeWithFilter(_ context.Context, kbID string, page, pageSize int, filter sdk.KnowledgeListFilter) ([]sdk.Knowledge, int64, error) {
 	f.calls = append(f.calls, page)
+	f.lastFilter = filter
 	if f.err != nil {
 		return nil, 0, f.err
 	}
@@ -34,21 +37,23 @@ func (f *fakeDocsSearchSvc) ListKnowledge(_ context.Context, kbID string, page, 
 
 func TestDocsSearch_Substring(t *testing.T) {
 	out, _ := iostreams.SetForTest(t)
+	// Server applies the keyword filter pre-pagination; the fake simulates
+	// that by only returning the matching items (d1/d3, not d2).
 	svc := &fakeDocsSearchSvc{
 		pages: map[int][]sdk.Knowledge{
 			1: {
 				{ID: "d1", Title: "Q3 Forecast", FileName: "q3.pdf", UpdatedAt: mustTime(t, "2026-05-10T00:00:00Z")},
-				{ID: "d2", Title: "Random Notes", FileName: "notes.md", UpdatedAt: mustTime(t, "2026-05-12T00:00:00Z")},
 				{ID: "d3", Title: "Q3 retro", FileName: "retro.pdf", UpdatedAt: mustTime(t, "2026-05-11T00:00:00Z")},
 			},
 		},
-		total: 3,
+		total: 2,
 	}
 	require.NoError(t, runDocsSearch(context.Background(), &DocsSearchOptions{Query: "q3", KBID: "kb1", Limit: 20, PageSize: docsPageSize, AllPages: true}, nil, svc))
+	assert.Equal(t, "q3", svc.lastFilter.Keyword, "query must be threaded as filter.Keyword")
 	got := out.String()
 	assert.Contains(t, got, "d1")
 	assert.Contains(t, got, "d3")
-	assert.NotContains(t, got, "d2") // "Random Notes" doesn't contain q3
+	assert.NotContains(t, got, "d2")
 }
 
 func TestDocsSearch_MatchesFileName(t *testing.T) {
@@ -61,20 +66,24 @@ func TestDocsSearch_MatchesFileName(t *testing.T) {
 	assert.Contains(t, out.String(), "d1")
 }
 
+// TestDocsSearch_PaginatesUntilTotal walks server-paginated results.
+// Server-side filter has already been applied, so every returned item
+// is in the result set; the runner just walks pages until total exhausted
+// or --limit hit. With limit > total matches, we expect 2 pages.
 func TestDocsSearch_PaginatesUntilTotal(t *testing.T) {
 	out, _ := iostreams.SetForTest(t)
 	page1 := make([]sdk.Knowledge, docsPageSize)
 	for i := range page1 {
-		page1[i] = sdk.Knowledge{ID: "p1", Title: "no match"}
+		page1[i] = sdk.Knowledge{ID: "p1", Title: "needle"}
 	}
 	page2 := []sdk.Knowledge{{ID: "found", Title: "needle here"}}
 	svc := &fakeDocsSearchSvc{
 		pages: map[int][]sdk.Knowledge{1: page1, 2: page2},
 		total: int64(docsPageSize) + 1,
 	}
-	require.NoError(t, runDocsSearch(context.Background(), &DocsSearchOptions{Query: "needle", KBID: "kb1", Limit: 20, PageSize: docsPageSize, AllPages: true}, nil, svc))
+	require.NoError(t, runDocsSearch(context.Background(), &DocsSearchOptions{Query: "needle", KBID: "kb1", Limit: docsPageSize + 1, PageSize: docsPageSize, AllPages: true}, nil, svc))
 	assert.Contains(t, out.String(), "found")
-	assert.Equal(t, []int{1, 2}, svc.calls, "must page past the first batch when no match on page 1")
+	assert.Equal(t, []int{1, 2}, svc.calls, "must page past the first batch when more items reported")
 }
 
 func TestDocsSearch_StopsAtLimit(t *testing.T) {
@@ -143,6 +152,22 @@ func TestSearchDocs_AllPagesFalse_StopsAtFirstPage(t *testing.T) {
 	opts := &DocsSearchOptions{Query: "needle", KBID: "kb_abc", Limit: 100, PageSize: 2, AllPages: false}
 	require.NoError(t, runDocsSearch(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
 	assert.Len(t, svc.calls, 1, "must stop at first page when --all-pages=false")
+}
+
+// TestSearchDocs_KeywordPassedToFilter pins the v0.5 switch from client-side
+// substring filtering to server-side ?keyword= via ListKnowledgeWithFilter.
+// The query argument must arrive on the filter struct (not a discarded
+// client-side variable).
+func TestSearchDocs_KeywordPassedToFilter(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeDocsSearchSvc{pages: map[int][]sdk.Knowledge{1: {{ID: "d1"}}}, total: 1}
+	require.NoError(t, runDocsSearch(context.Background(), &DocsSearchOptions{Query: "my-query", KBID: "kb1", Limit: 20, PageSize: docsPageSize, AllPages: true}, nil, svc))
+	assert.Equal(t, "my-query", svc.lastFilter.Keyword, "Query must be threaded as filter.Keyword on ListKnowledgeWithFilter")
+	// Other filter fields must be empty - search docs only forwards the keyword.
+	assert.Empty(t, svc.lastFilter.ParseStatus)
+	assert.Empty(t, svc.lastFilter.FileType)
+	assert.Empty(t, svc.lastFilter.Source)
+	assert.Empty(t, svc.lastFilter.TagID)
 }
 
 // TestSearchDocs_PageSizeBound asserts the 1..1000 range guard mirrors the

--- a/cli/cmd/search/docs_test.go
+++ b/cli/cmd/search/docs_test.go
@@ -44,7 +44,7 @@ func TestDocsSearch_Substring(t *testing.T) {
 		},
 		total: 3,
 	}
-	require.NoError(t, runDocsSearch(context.Background(), &DocsSearchOptions{Query: "q3", KBID: "kb1", Limit: 20}, nil, svc))
+	require.NoError(t, runDocsSearch(context.Background(), &DocsSearchOptions{Query: "q3", KBID: "kb1", Limit: 20, PageSize: docsPageSize, AllPages: true}, nil, svc))
 	got := out.String()
 	assert.Contains(t, got, "d1")
 	assert.Contains(t, got, "d3")
@@ -57,7 +57,7 @@ func TestDocsSearch_MatchesFileName(t *testing.T) {
 		pages: map[int][]sdk.Knowledge{1: {{ID: "d1", Title: "Untitled", FileName: "report.pdf"}}},
 		total: 1,
 	}
-	require.NoError(t, runDocsSearch(context.Background(), &DocsSearchOptions{Query: "report", KBID: "kb1", Limit: 20}, nil, svc))
+	require.NoError(t, runDocsSearch(context.Background(), &DocsSearchOptions{Query: "report", KBID: "kb1", Limit: 20, PageSize: docsPageSize, AllPages: true}, nil, svc))
 	assert.Contains(t, out.String(), "d1")
 }
 
@@ -72,7 +72,7 @@ func TestDocsSearch_PaginatesUntilTotal(t *testing.T) {
 		pages: map[int][]sdk.Knowledge{1: page1, 2: page2},
 		total: int64(docsPageSize) + 1,
 	}
-	require.NoError(t, runDocsSearch(context.Background(), &DocsSearchOptions{Query: "needle", KBID: "kb1", Limit: 20}, nil, svc))
+	require.NoError(t, runDocsSearch(context.Background(), &DocsSearchOptions{Query: "needle", KBID: "kb1", Limit: 20, PageSize: docsPageSize, AllPages: true}, nil, svc))
 	assert.Contains(t, out.String(), "found")
 	assert.Equal(t, []int{1, 2}, svc.calls, "must page past the first batch when no match on page 1")
 }
@@ -84,7 +84,7 @@ func TestDocsSearch_StopsAtLimit(t *testing.T) {
 		page1[i] = sdk.Knowledge{ID: "match", Title: "needle"}
 	}
 	svc := &fakeDocsSearchSvc{pages: map[int][]sdk.Knowledge{1: page1}, total: 1000}
-	require.NoError(t, runDocsSearch(context.Background(), &DocsSearchOptions{Query: "needle", KBID: "kb1", Limit: 3}, nil, svc))
+	require.NoError(t, runDocsSearch(context.Background(), &DocsSearchOptions{Query: "needle", KBID: "kb1", Limit: 3, PageSize: docsPageSize, AllPages: true}, nil, svc))
 	// Must not request page 2 because limit was hit mid-page.
 	assert.Equal(t, []int{1}, svc.calls)
 }
@@ -95,7 +95,7 @@ func TestDocsSearch_JSON(t *testing.T) {
 		pages: map[int][]sdk.Knowledge{1: {{ID: "d1", Title: "match"}}},
 		total: 1,
 	}
-	require.NoError(t, runDocsSearch(context.Background(), &DocsSearchOptions{Query: "match", KBID: "kb1", Limit: 20}, &cmdutil.JSONOptions{}, svc))
+	require.NoError(t, runDocsSearch(context.Background(), &DocsSearchOptions{Query: "match", KBID: "kb1", Limit: 20, PageSize: docsPageSize, AllPages: true}, &cmdutil.JSONOptions{}, svc))
 	got := out.String()
 	assert.True(t, strings.HasPrefix(strings.TrimSpace(got), "["), "expected bare JSON array, got: %q", got)
 	assert.Contains(t, got, `"id":"d1"`)
@@ -105,11 +105,57 @@ func TestDocsSearch_JSON(t *testing.T) {
 func TestDocsSearch_NetworkError(t *testing.T) {
 	_, _ = iostreams.SetForTest(t)
 	svc := &fakeDocsSearchSvc{err: errors.New("HTTP error 404: kb not found")}
-	err := runDocsSearch(context.Background(), &DocsSearchOptions{Query: "x", KBID: "missing", Limit: 20}, nil, svc)
+	err := runDocsSearch(context.Background(), &DocsSearchOptions{Query: "x", KBID: "missing", Limit: 20, PageSize: docsPageSize, AllPages: true}, nil, svc)
 	require.Error(t, err)
 	var typed *cmdutil.Error
 	require.ErrorAs(t, err, &typed)
 	assert.Equal(t, cmdutil.CodeResourceNotFound, typed.Code)
+}
+
+// TestSearchDocs_AllPagesFlag_DefaultsTrue_WalksAllPages locks in that the
+// historic walk-all-pages behavior is preserved when the new --all-pages flag
+// is left at its default (true). Three pages of fake data, all match the
+// substring; the run must request every page.
+func TestSearchDocs_AllPagesFlag_DefaultsTrue_WalksAllPages(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeDocsSearchSvc{
+		pages: map[int][]sdk.Knowledge{
+			1: {{ID: "d1", Title: "needle"}, {ID: "d2", Title: "needle"}},
+			2: {{ID: "d3", Title: "needle"}},
+			3: {},
+		},
+		total: 3,
+	}
+	opts := &DocsSearchOptions{Query: "needle", KBID: "kb_abc", Limit: 100, PageSize: 2, AllPages: true}
+	require.NoError(t, runDocsSearch(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	assert.GreaterOrEqual(t, len(svc.calls), 2, "must walk multi pages by default")
+}
+
+// TestSearchDocs_AllPagesFalse_StopsAtFirstPage asserts that --all-pages=false
+// caps server round-trips at one, even when the server reports far more
+// items available. New v0.5 opt-out for the walk-all default.
+func TestSearchDocs_AllPagesFalse_StopsAtFirstPage(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeDocsSearchSvc{
+		pages: map[int][]sdk.Knowledge{1: {{ID: "d1", Title: "needle"}, {ID: "d2", Title: "needle"}}},
+		total: 100,
+	}
+	opts := &DocsSearchOptions{Query: "needle", KBID: "kb_abc", Limit: 100, PageSize: 2, AllPages: false}
+	require.NoError(t, runDocsSearch(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	assert.Len(t, svc.calls, 1, "must stop at first page when --all-pages=false")
+}
+
+// TestSearchDocs_PageSizeBound asserts the 1..1000 range guard mirrors the
+// session/doc list canon. Out-of-range values must produce
+// input.invalid_argument and never reach the SDK.
+func TestSearchDocs_PageSizeBound(t *testing.T) {
+	for _, ps := range []int{0, -1, 1001} {
+		err := runDocsSearch(context.Background(), &DocsSearchOptions{Query: "t", KBID: "k", Limit: 50, PageSize: ps}, &cmdutil.JSONOptions{}, &fakeDocsSearchSvc{})
+		require.Error(t, err)
+		var typed *cmdutil.Error
+		require.ErrorAs(t, err, &typed)
+		assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code, "page_size=%d", ps)
+	}
 }
 
 func mustTime(t *testing.T, s string) time.Time {

--- a/cli/cmd/search/sessions.go
+++ b/cli/cmd/search/sessions.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -105,12 +106,13 @@ done:
 	}
 	tw := tabwriter.NewWriter(iostreams.IO.Out, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "ID\tTITLE\tUPDATED")
+	now := time.Now()
 	for _, s := range matches {
 		title := text.Truncate(50, s.Title)
 		if title == "" {
 			title = "-"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\n", s.ID, title, s.UpdatedAt)
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", s.ID, title, text.FuzzyAgoStr(now, s.UpdatedAt))
 	}
 	return tw.Flush()
 }

--- a/cli/cmd/search/sessions.go
+++ b/cli/cmd/search/sessions.go
@@ -16,7 +16,13 @@ import (
 	sdk "github.com/Tencent/WeKnora/client"
 )
 
+// sessionsPageSize is the default --page-size on `search sessions`: how many
+// entries to pull per GetSessionsByTenant round-trip when paging through to
+// filter client-side. Tunable via --page-size in 1..1000.
 const sessionsPageSize = 200
+
+// sessionsMaxPageSize bounds the --page-size flag, matching session/doc list canon.
+const sessionsMaxPageSize = 1000
 
 // sessionsSearchFields enumerates the fields surfaced for `--json` discovery
 // on `search sessions`. Mirrors sdk.Session json tags.
@@ -27,6 +33,14 @@ var sessionsSearchFields = []string{
 type SessionsSearchOptions struct {
 	Query string
 	Limit int
+	// PageSize is the server batch size per GetSessionsByTenant call
+	// (1..1000, default 200). Tunable so a caller searching a small set
+	// can fetch everything in one round-trip.
+	PageSize int
+	// AllPages walks server pages internally until total exhausted or
+	// --limit accumulated. Default true preserves v0.4 behavior; setting
+	// false stops after the first page (useful for cheap previews).
+	AllPages bool
 }
 
 // SessionsSearchService is the narrow SDK surface this command depends on.
@@ -43,8 +57,15 @@ func NewCmdSessions(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   `sessions "<query>"`,
 		Short: "Find chat sessions by title or description (client-side substring match)",
+		Long: `Pages through the tenant's chat sessions and surfaces every entry whose
+title or description contains the query (case-insensitive).
+
+By default, --all-pages=true walks every server page until --limit is
+reached or the tenant's sessions are exhausted (matching v0.4 behavior).
+Pass --all-pages=false to stop after one page.`,
 		Example: `  weknora search sessions "onboarding"
-  weknora search sessions "Q3 review" --limit 3 --json`,
+  weknora search sessions "Q3 review" --limit 3 --json
+  weknora search sessions "Q3 review" --all-pages=false`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts.Query = strings.TrimSpace(args[0])
@@ -66,16 +87,24 @@ func NewCmdSessions(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 30, "Maximum results to return")
+	cmd.Flags().IntVar(&opts.PageSize, "page-size", sessionsPageSize, "Items per server batch (1..1000)")
+	cmd.Flags().BoolVar(&opts.AllPages, "all-pages", true, "Walk every server page until exhausted or --limit hit")
 	cmdutil.AddJSONFlags(cmd, sessionsSearchFields)
 	return cmd
 }
 
 func runSessionsSearch(ctx context.Context, opts *SessionsSearchOptions, jopts *cmdutil.JSONOptions, svc SessionsSearchService) error {
+	if opts.PageSize < 1 || opts.PageSize > sessionsMaxPageSize {
+		return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
+			fmt.Sprintf("--page-size must be in 1..%d, got %d", sessionsMaxPageSize, opts.PageSize))
+	}
 	needle := strings.ToLower(opts.Query)
 	var matches []sdk.Session
 
+	// --all-pages=true (default) walks every server page; --all-pages=false
+	// stops after the first page.
 	for page := 1; ; page++ {
-		items, total, err := svc.GetSessionsByTenant(ctx, page, sessionsPageSize)
+		items, total, err := svc.GetSessionsByTenant(ctx, page, opts.PageSize)
 		if err != nil {
 			return cmdutil.WrapHTTP(err, "list sessions")
 		}
@@ -87,7 +116,10 @@ func runSessionsSearch(ctx context.Context, opts *SessionsSearchOptions, jopts *
 				}
 			}
 		}
-		if page*sessionsPageSize >= total || len(items) == 0 {
+		if !opts.AllPages {
+			break
+		}
+		if page*opts.PageSize >= total || len(items) == 0 {
 			break
 		}
 	}

--- a/cli/cmd/search/sessions_test.go
+++ b/cli/cmd/search/sessions_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -74,4 +75,23 @@ func TestSessionsSearch_NetworkError(t *testing.T) {
 	var typed *cmdutil.Error
 	require.ErrorAs(t, err, &typed)
 	assert.Equal(t, cmdutil.CodeServerError, typed.Code)
+}
+
+// TestSessionsSearch_RendersFuzzyTime is a regression guard for the v0.5
+// audit bug: `search sessions` printed UpdatedAt as the raw RFC3339 string
+// while `session list` ran it through text.FuzzyAgoStr — same SDK field,
+// two human renderings. Asserts the human output now renders relative time
+// (and does NOT contain the RFC3339 "T" date/time separator).
+func TestSessionsSearch_RendersFuzzyTime(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeSessionsSearchSvc{
+		pages: map[int][]sdk.Session{1: {
+			{ID: "s1", Title: "needle", UpdatedAt: time.Now().Add(-2 * time.Hour).Format(time.RFC3339)},
+		}},
+		total: 1,
+	}
+	require.NoError(t, runSessionsSearch(context.Background(), &SessionsSearchOptions{Query: "needle", Limit: 10}, nil, svc))
+	body := out.String()
+	assert.Contains(t, body, "hour", "must render relative time (e.g. 'about 2 hours ago'), not raw RFC3339")
+	assert.NotContains(t, body, "T0", "raw RFC3339 has 'T' between date and time; fuzzyTime output should not")
 }

--- a/cli/cmd/search/sessions_test.go
+++ b/cli/cmd/search/sessions_test.go
@@ -39,7 +39,7 @@ func TestSessionsSearch_TitleAndDescription(t *testing.T) {
 		}},
 		total: 3,
 	}
-	require.NoError(t, runSessionsSearch(context.Background(), &SessionsSearchOptions{Query: "design", Limit: 20}, nil, svc))
+	require.NoError(t, runSessionsSearch(context.Background(), &SessionsSearchOptions{Query: "design", Limit: 20, PageSize: sessionsPageSize, AllPages: true}, nil, svc))
 	got := out.String()
 	assert.Contains(t, got, "s1")
 	assert.Contains(t, got, "s2")
@@ -52,7 +52,7 @@ func TestSessionsSearch_NoMatches(t *testing.T) {
 		pages: map[int][]sdk.Session{1: {{Title: "foo"}}},
 		total: 1,
 	}
-	require.NoError(t, runSessionsSearch(context.Background(), &SessionsSearchOptions{Query: "missing", Limit: 20}, nil, svc))
+	require.NoError(t, runSessionsSearch(context.Background(), &SessionsSearchOptions{Query: "missing", Limit: 20, PageSize: sessionsPageSize, AllPages: true}, nil, svc))
 	assert.Contains(t, out.String(), "(no matches)")
 }
 
@@ -63,14 +63,14 @@ func TestSessionsSearch_PaginatesAndStopsAtLimit(t *testing.T) {
 		page1[i] = sdk.Session{ID: "m", Title: "needle"}
 	}
 	svc := &fakeSessionsSearchSvc{pages: map[int][]sdk.Session{1: page1}, total: 1000}
-	require.NoError(t, runSessionsSearch(context.Background(), &SessionsSearchOptions{Query: "needle", Limit: 5}, nil, svc))
+	require.NoError(t, runSessionsSearch(context.Background(), &SessionsSearchOptions{Query: "needle", Limit: 5, PageSize: sessionsPageSize, AllPages: true}, nil, svc))
 	assert.Equal(t, []int{1}, svc.calls, "stops paging when limit reached")
 }
 
 func TestSessionsSearch_NetworkError(t *testing.T) {
 	_, _ = iostreams.SetForTest(t)
 	svc := &fakeSessionsSearchSvc{err: errors.New("HTTP error 500: internal")}
-	err := runSessionsSearch(context.Background(), &SessionsSearchOptions{Query: "x", Limit: 20}, nil, svc)
+	err := runSessionsSearch(context.Background(), &SessionsSearchOptions{Query: "x", Limit: 20, PageSize: sessionsPageSize, AllPages: true}, nil, svc)
 	require.Error(t, err)
 	var typed *cmdutil.Error
 	require.ErrorAs(t, err, &typed)
@@ -90,8 +90,54 @@ func TestSessionsSearch_RendersFuzzyTime(t *testing.T) {
 		}},
 		total: 1,
 	}
-	require.NoError(t, runSessionsSearch(context.Background(), &SessionsSearchOptions{Query: "needle", Limit: 10}, nil, svc))
+	require.NoError(t, runSessionsSearch(context.Background(), &SessionsSearchOptions{Query: "needle", Limit: 10, PageSize: sessionsPageSize, AllPages: true}, nil, svc))
 	body := out.String()
 	assert.Contains(t, body, "hour", "must render relative time (e.g. 'about 2 hours ago'), not raw RFC3339")
 	assert.NotContains(t, body, "T0", "raw RFC3339 has 'T' between date and time; fuzzyTime output should not")
+}
+
+// TestSearchSessions_AllPagesFlag_DefaultsTrue_WalksAllPages locks in that
+// the historic walk-all-pages behavior is preserved when --all-pages is left
+// at its default (true). Three pages of fake data with matches on each;
+// the run must request more than one page.
+func TestSearchSessions_AllPagesFlag_DefaultsTrue_WalksAllPages(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeSessionsSearchSvc{
+		pages: map[int][]sdk.Session{
+			1: {{ID: "s1", Title: "needle"}, {ID: "s2", Title: "needle"}},
+			2: {{ID: "s3", Title: "needle"}},
+			3: {},
+		},
+		total: 3,
+	}
+	opts := &SessionsSearchOptions{Query: "needle", Limit: 100, PageSize: 2, AllPages: true}
+	require.NoError(t, runSessionsSearch(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	assert.GreaterOrEqual(t, len(svc.calls), 2, "must walk multi pages by default")
+}
+
+// TestSearchSessions_AllPagesFalse_StopsAtFirstPage asserts that
+// --all-pages=false caps server round-trips at one even when the server
+// reports far more items available. New v0.5 opt-out for the walk-all default.
+func TestSearchSessions_AllPagesFalse_StopsAtFirstPage(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeSessionsSearchSvc{
+		pages: map[int][]sdk.Session{1: {{ID: "s1", Title: "needle"}, {ID: "s2", Title: "needle"}}},
+		total: 100,
+	}
+	opts := &SessionsSearchOptions{Query: "needle", Limit: 100, PageSize: 2, AllPages: false}
+	require.NoError(t, runSessionsSearch(context.Background(), opts, &cmdutil.JSONOptions{}, svc))
+	assert.Len(t, svc.calls, 1, "must stop at first page when --all-pages=false")
+}
+
+// TestSearchSessions_PageSizeBound asserts the 1..1000 range guard mirrors
+// the session/doc list canon. Out-of-range values must produce
+// input.invalid_argument and never reach the SDK.
+func TestSearchSessions_PageSizeBound(t *testing.T) {
+	for _, ps := range []int{0, -1, 1001} {
+		err := runSessionsSearch(context.Background(), &SessionsSearchOptions{Query: "t", Limit: 50, PageSize: ps}, &cmdutil.JSONOptions{}, &fakeSessionsSearchSvc{})
+		require.Error(t, err)
+		var typed *cmdutil.Error
+		require.ErrorAs(t, err, &typed)
+		assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code, "page_size=%d", ps)
+	}
 }

--- a/cli/cmd/session/list.go
+++ b/cli/cmd/session/list.go
@@ -155,7 +155,7 @@ func runList(ctx context.Context, opts *ListOptions, jopts *cmdutil.JSONOptions,
 		if title == "" {
 			title = "-"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\n", s.ID, title, fuzzyTime(now, s.UpdatedAt))
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", s.ID, title, text.FuzzyAgoStr(now, s.UpdatedAt))
 	}
 	return tw.Flush()
 }
@@ -191,18 +191,4 @@ func parseSinceDuration(s string) (time.Duration, error) {
 		}
 	}
 	return d, nil
-}
-
-// fuzzyTime renders a server-provided timestamp string in "2d ago" form.
-// Returns the raw input if parsing fails - better to surface the unknown
-// format than to silently render "-".
-func fuzzyTime(now time.Time, ts string) string {
-	if ts == "" {
-		return "-"
-	}
-	t, err := time.Parse(time.RFC3339, ts)
-	if err != nil {
-		return ts
-	}
-	return text.FuzzyAgo(now, t)
 }

--- a/cli/cmd/session/view.go
+++ b/cli/cmd/session/view.go
@@ -12,30 +12,59 @@ import (
 	sdk "github.com/Tencent/WeKnora/client"
 )
 
+const (
+	defaultFullLimit = 50
+	maxFullLimit     = 1000
+)
+
 // sessionViewFields enumerates the fields surfaced for `--json` discovery on
-// `session view`. Mirrors sdk.Session json tags.
+// `session view`. Mirrors sdk.Session json tags; adds the synthesized
+// `messages` projection surfaced by `--full`.
 var sessionViewFields = []string{
 	"id", "tenant_id", "title", "description", "created_at", "updated_at",
+	"messages",
 }
 
-type ViewOptions struct{}
+type ViewOptions struct {
+	// Full instructs runView to fetch chat history via LoadMessages and
+	// render it after the session metadata.
+	Full bool
+	// Limit caps the number of messages loaded when Full is true.
+	// Must be 1..maxFullLimit.
+	Limit int
+	// LimitSet records whether the caller explicitly set --limit, so we
+	// can reject `--limit` without `--full` (vs. silently ignoring the
+	// default).
+	LimitSet bool
+}
 
-// ViewService is the narrow SDK surface this command depends on.
+// ViewService is the narrow SDK surface this command depends on. LoadMessages
+// is only invoked under --full but lives on the same interface so the runView
+// dependency surface stays minimal.
 type ViewService interface {
 	GetSession(ctx context.Context, id string) (*sdk.Session, error)
+	LoadMessages(ctx context.Context, sessionID string, limit int, beforeTime *time.Time) ([]sdk.Message, error)
 }
 
 // NewCmdView builds `weknora session view <id>`. Renders session metadata
-// only (title/description/timestamps). Full chat-history retrieval is a
-// separate concern (the SDK has LoadMessages / GetMessagesBefore for it);
-// surfacing it as `session view --full` is queued for v0.6.
+// only by default. With `--full`, also loads the chat history via
+// `LoadMessages` and renders messages (or projects them into the JSON
+// payload under `messages`).
 func NewCmdView(f *cmdutil.Factory) *cobra.Command {
-	opts := &ViewOptions{}
+	opts := &ViewOptions{Limit: defaultFullLimit}
 	cmd := &cobra.Command{
 		Use:   "view <id>",
 		Short: "Show a chat session by ID",
-		Args:  cobra.ExactArgs(1),
+		Long: `Show a chat session.
+
+By default renders the session metadata (id, title, description, timestamps).
+
+Pass --full to also load the chat history (LoadMessages SDK call). Use
+--limit to cap the number of messages loaded (1..1000, default 50).
+--limit without --full is rejected as input.invalid_argument.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
+			opts.LimitSet = c.Flags().Changed("limit")
 			jopts, err := cmdutil.CheckJSONFlags(c)
 			if err != nil {
 				return err
@@ -47,18 +76,58 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			return runView(c.Context(), opts, jopts, cli, args[0])
 		},
 	}
+	cmd.Flags().BoolVar(&opts.Full, "full", false, "Also load chat history via LoadMessages")
+	cmd.Flags().IntVar(&opts.Limit, "limit", defaultFullLimit, "Max messages to load when --full is set (1..1000)")
 	cmdutil.AddJSONFlags(cmd, sessionViewFields)
 	return cmd
 }
 
 func runView(ctx context.Context, opts *ViewOptions, jopts *cmdutil.JSONOptions, svc ViewService, id string) error {
+	if !opts.Full && opts.LimitSet {
+		return &cmdutil.Error{
+			Code:    cmdutil.CodeInputInvalidArgument,
+			Message: "--limit requires --full",
+		}
+	}
+	if opts.Full {
+		if opts.Limit < 1 || opts.Limit > maxFullLimit {
+			return &cmdutil.Error{
+				Code:    cmdutil.CodeInputInvalidArgument,
+				Message: fmt.Sprintf("--limit must be in 1..%d, got %d", maxFullLimit, opts.Limit),
+			}
+		}
+	}
+
 	s, err := svc.GetSession(ctx, id)
 	if err != nil {
 		return cmdutil.WrapHTTP(err, "get session %q", id)
 	}
-	if jopts.Enabled() {
-		return jopts.Emit(iostreams.IO.Out, s)
+
+	var msgs []sdk.Message
+	if opts.Full {
+		msgs, err = svc.LoadMessages(ctx, id, opts.Limit, nil)
+		if err != nil {
+			return cmdutil.WrapHTTP(err, "load messages for session %q", id)
+		}
+		if msgs == nil {
+			msgs = []sdk.Message{}
+		}
 	}
+
+	if jopts.Enabled() {
+		if !opts.Full {
+			return jopts.Emit(iostreams.IO.Out, s)
+		}
+		// Project session + messages into a single bare object. Use the
+		// SDK json tags via an embedded *Session so existing keys stay
+		// stable.
+		payload := struct {
+			*sdk.Session
+			Messages []sdk.Message `json:"messages"`
+		}{Session: s, Messages: msgs}
+		return jopts.Emit(iostreams.IO.Out, payload)
+	}
+
 	w := iostreams.IO.Out
 	fmt.Fprintf(w, "ID:        %s\n", s.ID)
 	if s.Title != "" {
@@ -76,6 +145,22 @@ func runView(ctx context.Context, opts *ViewOptions, jopts *cmdutil.JSONOptions,
 		fmt.Fprintf(w, "UPDATED:   %s\n", t.Format("2006-01-02 15:04:05"))
 	} else if s.UpdatedAt != "" {
 		fmt.Fprintf(w, "UPDATED:   %s\n", s.UpdatedAt)
+	}
+
+	if opts.Full {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "Messages (%d):\n", len(msgs))
+		for _, m := range msgs {
+			fmt.Fprintln(w)
+			ts := ""
+			if !m.CreatedAt.IsZero() {
+				ts = " " + m.CreatedAt.Format("2006-01-02 15:04:05")
+			}
+			fmt.Fprintf(w, "[%s]%s\n", m.Role, ts)
+			if m.Content != "" {
+				fmt.Fprintln(w, m.Content)
+			}
+		}
 	}
 	return nil
 }

--- a/cli/cmd/session/view.go
+++ b/cli/cmd/session/view.go
@@ -25,10 +25,10 @@ type ViewService interface {
 	GetSession(ctx context.Context, id string) (*sdk.Session, error)
 }
 
-// NewCmdView builds `weknora session view <id>`. The server endpoint
-// returns metadata only (title/description/timestamps); message content
-// lives under a separate session_messages endpoint that the SDK doesn't
-// currently wrap, which is why there's no --full flag.
+// NewCmdView builds `weknora session view <id>`. Renders session metadata
+// only (title/description/timestamps). Full chat-history retrieval is a
+// separate concern (the SDK has LoadMessages / GetMessagesBefore for it);
+// surfacing it as `session view --full` is queued for v0.6.
 func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 	opts := &ViewOptions{}
 	cmd := &cobra.Command{

--- a/cli/cmd/session/view_test.go
+++ b/cli/cmd/session/view_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,16 +15,30 @@ import (
 	sdk "github.com/Tencent/WeKnora/client"
 )
 
-// fakeViewService scripts a GetSession response.
+// fakeViewService scripts a GetSession + LoadMessages response.
 type fakeViewService struct {
-	s     *sdk.Session
-	err   error
-	gotID string
+	s        *sdk.Session
+	err      error
+	gotID    string
+	msgs     []sdk.Message
+	msgsErr  error
+	loadCall struct {
+		sessionID string
+		limit     int
+		called    bool
+	}
 }
 
 func (f *fakeViewService) GetSession(_ context.Context, id string) (*sdk.Session, error) {
 	f.gotID = id
 	return f.s, f.err
+}
+
+func (f *fakeViewService) LoadMessages(_ context.Context, sessionID string, limit int, _ *time.Time) ([]sdk.Message, error) {
+	f.loadCall.called = true
+	f.loadCall.sessionID = sessionID
+	f.loadCall.limit = limit
+	return f.msgs, f.msgsErr
 }
 
 func TestView_Human(t *testing.T) {
@@ -73,4 +88,89 @@ func TestView_OmitsEmptyDescription(t *testing.T) {
 			t.Errorf("empty description should be omitted, found %q", line)
 		}
 	}
+}
+
+// --- --full / --limit tests ---
+
+func TestView_Full_LoadsMessages(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewService{
+		s: &sdk.Session{ID: "s_abc", Title: "Chat"},
+		msgs: []sdk.Message{
+			{ID: "m1", Role: "user", Content: "What is RAG?", CreatedAt: time.Date(2026, 5, 15, 14, 32, 0, 0, time.UTC)},
+			{ID: "m2", Role: "assistant", Content: "RAG stands for retrieval-augmented generation.", CreatedAt: time.Date(2026, 5, 15, 14, 32, 5, 0, time.UTC)},
+		},
+	}
+	require.NoError(t, runView(context.Background(), &ViewOptions{Full: true, Limit: 50}, nil, svc, "s_abc"))
+	got := out.String()
+	assert.True(t, svc.loadCall.called, "expected LoadMessages to be called")
+	assert.Equal(t, "s_abc", svc.loadCall.sessionID)
+	assert.Equal(t, 50, svc.loadCall.limit)
+	for _, want := range []string{"Messages (2)", "[user]", "[assistant]", "What is RAG?", "retrieval-augmented generation"} {
+		assert.Contains(t, got, want)
+	}
+}
+
+func TestView_Full_NoMessages(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewService{
+		s:    &sdk.Session{ID: "s_empty", Title: "Empty"},
+		msgs: []sdk.Message{},
+	}
+	require.NoError(t, runView(context.Background(), &ViewOptions{Full: true, Limit: 50}, nil, svc, "s_empty"))
+	got := out.String()
+	assert.Contains(t, got, "Messages (0)")
+}
+
+func TestView_Full_LimitInvalid_Zero(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeViewService{s: &sdk.Session{ID: "s"}}
+	err := runView(context.Background(), &ViewOptions{Full: true, Limit: 0}, nil, svc, "s")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "input.invalid_argument")
+}
+
+func TestView_Full_LimitInvalid_TooLarge(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeViewService{s: &sdk.Session{ID: "s"}}
+	err := runView(context.Background(), &ViewOptions{Full: true, Limit: 1001}, nil, svc, "s")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "input.invalid_argument")
+}
+
+// --limit without --full is rejected with input.invalid_argument — same
+// pattern as `--title` requires `--from-url` in `doc upload`.
+func TestView_LimitWithoutFull(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	svc := &fakeViewService{s: &sdk.Session{ID: "s"}}
+	err := runView(context.Background(), &ViewOptions{Full: false, Limit: 100, LimitSet: true}, nil, svc, "s")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "input.invalid_argument")
+	assert.Contains(t, err.Error(), "--limit")
+	assert.Contains(t, err.Error(), "--full")
+}
+
+func TestView_Full_JSON_HasMessages(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewService{
+		s: &sdk.Session{ID: "s_abc", Title: "T"},
+		msgs: []sdk.Message{
+			{ID: "m1", Role: "user", Content: "hi"},
+		},
+	}
+	require.NoError(t, runView(context.Background(), &ViewOptions{Full: true, Limit: 50}, &cmdutil.JSONOptions{}, svc, "s_abc"))
+	body := out.String()
+	assert.Contains(t, body, `"messages":`)
+	assert.Contains(t, body, `"id":"m1"`)
+	assert.Contains(t, body, `"role":"user"`)
+}
+
+// Without --full, the LoadMessages SDK call must not fire and the JSON
+// payload must not contain a `messages` key.
+func TestView_NoFull_DoesNotCallLoadMessages(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	svc := &fakeViewService{s: &sdk.Session{ID: "s_abc"}}
+	require.NoError(t, runView(context.Background(), &ViewOptions{}, &cmdutil.JSONOptions{}, svc, "s_abc"))
+	assert.False(t, svc.loadCall.called, "LoadMessages must not be called without --full")
+	assert.NotContains(t, out.String(), `"messages":`)
 }

--- a/cli/internal/cmdutil/agentconfig.go
+++ b/cli/internal/cmdutil/agentconfig.go
@@ -1,0 +1,183 @@
+package cmdutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	sdk "github.com/Tencent/WeKnora/client"
+)
+
+// AgentConfigFlags carries hot-path flag values plus per-flag "was set"
+// bits so the merge step can distinguish "user did not pass --foo" from
+// "user passed --foo zero-value". Mirrors the canonical CLI pattern of
+// keeping presence-tracking out-of-band from the value itself, which
+// pflag's Changed() facility supplies at the cobra layer.
+type AgentConfigFlags struct {
+	AgentMode          string
+	AgentModeSet       bool
+	SystemPrompt       string
+	SystemPromptSet    bool
+	ModelID            string
+	ModelIDSet         bool
+	RerankModelID      string
+	RerankModelIDSet   bool
+	Temperature        float64
+	TemperatureSet     bool
+	KBSelectionMode    string
+	KBSelectionModeSet bool
+	KnowledgeBases     []string
+	KnowledgeBasesSet  bool
+}
+
+// LoadAgentConfig parses YAML or JSON from r into an AgentConfig. kind is
+// "yaml" or "json" (typically inferred from file extension by the caller).
+// Returned errors carry no typed code — callers should wrap with
+// CodeInputInvalidArgument as the user-facing context.
+//
+// YAML route round-trips through JSON so the SDK's existing `json:` field
+// tags (snake_case) are the single source of truth for key names. yaml.v3
+// alone would lowercase field names (KnowledgeBases → knowledgebases),
+// which doesn't match the JSON schema users see elsewhere.
+func LoadAgentConfig(r io.Reader, kind string) (*sdk.AgentConfig, error) {
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	var cfg sdk.AgentConfig
+	switch strings.ToLower(kind) {
+	case "yaml", "yml":
+		var raw map[string]any
+		if err := yaml.Unmarshal(body, &raw); err != nil {
+			return nil, fmt.Errorf("parse YAML config: %w", err)
+		}
+		jsBody, err := json.Marshal(raw)
+		if err != nil {
+			return nil, fmt.Errorf("re-encode YAML as JSON: %w", err)
+		}
+		if err := json.Unmarshal(jsBody, &cfg); err != nil {
+			return nil, fmt.Errorf("parse YAML config (via JSON): %w", err)
+		}
+	case "json":
+		if err := json.Unmarshal(body, &cfg); err != nil {
+			return nil, fmt.Errorf("parse JSON config: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unknown config format %q (want yaml or json)", kind)
+	}
+	return &cfg, nil
+}
+
+// MergeAgentConfig returns base with hot-path flag overrides applied. Only
+// fields whose corresponding *Set bit is true are overridden; the rest of
+// base passes through unchanged. The returned pointer is a fresh copy so
+// callers can mutate it without aliasing base.
+func MergeAgentConfig(base *sdk.AgentConfig, ov AgentConfigFlags) *sdk.AgentConfig {
+	out := *base // shallow copy
+	if ov.AgentModeSet {
+		out.AgentMode = ov.AgentMode
+	}
+	if ov.SystemPromptSet {
+		out.SystemPrompt = ov.SystemPrompt
+	}
+	if ov.ModelIDSet {
+		out.ModelID = ov.ModelID
+	}
+	if ov.RerankModelIDSet {
+		out.RerankModelID = ov.RerankModelID
+	}
+	if ov.TemperatureSet {
+		out.Temperature = ov.Temperature
+	}
+	if ov.KBSelectionModeSet {
+		out.KBSelectionMode = ov.KBSelectionMode
+	}
+	if ov.KnowledgeBasesSet {
+		out.KnowledgeBases = ov.KnowledgeBases
+	}
+	return &out
+}
+
+// skeletonCommentVersion is embedded in the skeleton header so users
+// regenerating an outdated template after a schema bump can spot the
+// version mismatch.
+const skeletonCommentVersion = "v0.5 / 34 fields"
+
+// GenerateAgentSkeleton writes a commented YAML template with every
+// AgentConfig field at its zero value to w. Used by
+// `agent create --generate-skeleton` so users get a ready-to-edit
+// starting point without authoring the 34-field schema from memory.
+func GenerateAgentSkeleton(w io.Writer) error {
+	const skeleton = `# WeKnora AgentConfig skeleton (` + skeletonCommentVersion + `)
+# Edit this file and pass it to:
+#   weknora agent create "My Agent" --model <id> --config-file <this-file>
+# Hot-path flags on the create command override values set here.
+
+# Operating mode: "quick-answer" or "smart-reasoning"
+agent_mode: ""
+
+# System prompt for the agent (also settable via --system-prompt[-file])
+system_prompt: ""
+
+# Optional template applied to retrieved context before model input
+context_template: ""
+
+# REQUIRED: LLM model id (server-side managed); also settable via --model
+model_id: ""
+
+# Optional rerank model id (server-side managed); also settable via --rerank-model
+rerank_model_id: ""
+
+# Generation tuning
+temperature: 0.0
+max_completion_tokens: 0
+max_iterations: 0
+
+# Tools / MCP integration
+allowed_tools: []
+mcp_selection_mode: ""    # "all" / "selected" / "none"
+mcp_services: []
+
+# Knowledge base attachment
+kb_selection_mode: ""     # "all" / "selected" / "none"; also settable via --kb-selection-mode
+knowledge_bases: []       # KB ids; also settable via repeated --kb
+supported_file_types: []
+
+# FAQ
+faq_priority_enabled: false
+faq_direct_answer_threshold: 0.0
+faq_score_boost: 0.0
+
+# Web search
+web_search_enabled: false
+web_search_max_results: 0
+
+# Multi-turn
+multi_turn_enabled: false
+history_turns: 0
+
+# Retrieval thresholds
+embedding_top_k: 0
+keyword_threshold: 0.0
+vector_threshold: 0.0
+rerank_top_k: 0
+rerank_threshold: 0.0
+
+# Query understanding / rewrite
+enable_query_expansion: false
+enable_rewrite: false
+rewrite_prompt_system: ""
+rewrite_prompt_user: ""
+query_understand_model_id: ""
+
+# Fallback when retrieval / generation fails
+fallback_strategy: ""     # "fixed" or "model"
+fallback_response: ""
+fallback_prompt: ""
+`
+	_, err := io.WriteString(w, skeleton)
+	return err
+}

--- a/cli/internal/cmdutil/agentconfig_test.go
+++ b/cli/internal/cmdutil/agentconfig_test.go
@@ -1,0 +1,114 @@
+package cmdutil
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/Tencent/WeKnora/client"
+)
+
+func TestLoadConfigFile_YAML(t *testing.T) {
+	yaml := strings.NewReader(`
+agent_mode: smart-reasoning
+model_id: gpt-4
+temperature: 0.7
+knowledge_bases:
+  - kb_abc
+  - kb_def
+`)
+	cfg, err := LoadAgentConfig(yaml, "yaml")
+	require.NoError(t, err)
+	assert.Equal(t, "smart-reasoning", cfg.AgentMode)
+	assert.Equal(t, "gpt-4", cfg.ModelID)
+	assert.InDelta(t, 0.7, cfg.Temperature, 0.001)
+	assert.Equal(t, []string{"kb_abc", "kb_def"}, cfg.KnowledgeBases)
+}
+
+func TestLoadConfigFile_JSON(t *testing.T) {
+	js := strings.NewReader(`{"agent_mode":"quick-answer","model_id":"gpt-3.5"}`)
+	cfg, err := LoadAgentConfig(js, "json")
+	require.NoError(t, err)
+	assert.Equal(t, "quick-answer", cfg.AgentMode)
+	assert.Equal(t, "gpt-3.5", cfg.ModelID)
+}
+
+func TestLoadConfigFile_UnknownKind(t *testing.T) {
+	_, err := LoadAgentConfig(strings.NewReader(""), "xml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown config format")
+}
+
+func TestLoadConfigFile_BadYAML(t *testing.T) {
+	_, err := LoadAgentConfig(strings.NewReader("not: : yaml"), "yaml")
+	require.Error(t, err)
+}
+
+func TestLoadConfigFile_BadJSON(t *testing.T) {
+	_, err := LoadAgentConfig(strings.NewReader("{not json"), "json")
+	require.Error(t, err)
+}
+
+func TestMergeAgentConfig_FlagsOverrideFile(t *testing.T) {
+	base := &sdk.AgentConfig{ModelID: "gpt-3.5"}
+	overrides := AgentConfigFlags{ModelIDSet: true, ModelID: "gpt-4"}
+	merged := MergeAgentConfig(base, overrides)
+	assert.Equal(t, "gpt-4", merged.ModelID)
+}
+
+func TestMergeAgentConfig_UnsetFlagsPreserveBase(t *testing.T) {
+	base := &sdk.AgentConfig{ModelID: "gpt-3.5", Temperature: 0.5}
+	overrides := AgentConfigFlags{} // nothing set
+	merged := MergeAgentConfig(base, overrides)
+	assert.Equal(t, "gpt-3.5", merged.ModelID)
+	assert.InDelta(t, 0.5, merged.Temperature, 0.001)
+}
+
+func TestMergeAgentConfig_EveryFieldOverlay(t *testing.T) {
+	base := &sdk.AgentConfig{
+		AgentMode:       "quick-answer",
+		SystemPrompt:    "old",
+		ModelID:         "gpt-3.5",
+		RerankModelID:   "rerank-old",
+		Temperature:     0.1,
+		KBSelectionMode: "all",
+		KnowledgeBases:  []string{"kb_old"},
+	}
+	overrides := AgentConfigFlags{
+		AgentMode: "smart-reasoning", AgentModeSet: true,
+		SystemPrompt: "new", SystemPromptSet: true,
+		ModelID: "gpt-4", ModelIDSet: true,
+		RerankModelID: "rerank-new", RerankModelIDSet: true,
+		Temperature: 0.9, TemperatureSet: true,
+		KBSelectionMode: "selected", KBSelectionModeSet: true,
+		KnowledgeBases: []string{"kb_new"}, KnowledgeBasesSet: true,
+	}
+	merged := MergeAgentConfig(base, overrides)
+	assert.Equal(t, "smart-reasoning", merged.AgentMode)
+	assert.Equal(t, "new", merged.SystemPrompt)
+	assert.Equal(t, "gpt-4", merged.ModelID)
+	assert.Equal(t, "rerank-new", merged.RerankModelID)
+	assert.InDelta(t, 0.9, merged.Temperature, 0.001)
+	assert.Equal(t, "selected", merged.KBSelectionMode)
+	assert.Equal(t, []string{"kb_new"}, merged.KnowledgeBases)
+}
+
+func TestGenerateSkeleton_EmitsAllFields(t *testing.T) {
+	var out strings.Builder
+	require.NoError(t, GenerateAgentSkeleton(&out))
+	body := out.String()
+	for _, field := range []string{
+		"agent_mode:",
+		"model_id:",
+		"system_prompt:",
+		"knowledge_bases:",
+		"fallback_strategy:",
+		"context_template:",
+		"max_completion_tokens:",
+		"embedding_top_k:",
+	} {
+		assert.Contains(t, body, field, "skeleton missing field %s", field)
+	}
+}

--- a/cli/internal/cmdutil/agentconfig_test.go
+++ b/cli/internal/cmdutil/agentconfig_test.go
@@ -13,7 +13,7 @@ import (
 func TestLoadConfigFile_YAML(t *testing.T) {
 	yaml := strings.NewReader(`
 agent_mode: smart-reasoning
-model_id: gpt-4
+model_id: model-x
 temperature: 0.7
 knowledge_bases:
   - kb_abc
@@ -22,17 +22,17 @@ knowledge_bases:
 	cfg, err := LoadAgentConfig(yaml, "yaml")
 	require.NoError(t, err)
 	assert.Equal(t, "smart-reasoning", cfg.AgentMode)
-	assert.Equal(t, "gpt-4", cfg.ModelID)
+	assert.Equal(t, "model-x", cfg.ModelID)
 	assert.InDelta(t, 0.7, cfg.Temperature, 0.001)
 	assert.Equal(t, []string{"kb_abc", "kb_def"}, cfg.KnowledgeBases)
 }
 
 func TestLoadConfigFile_JSON(t *testing.T) {
-	js := strings.NewReader(`{"agent_mode":"quick-answer","model_id":"gpt-3.5"}`)
+	js := strings.NewReader(`{"agent_mode":"quick-answer","model_id":"model-y"}`)
 	cfg, err := LoadAgentConfig(js, "json")
 	require.NoError(t, err)
 	assert.Equal(t, "quick-answer", cfg.AgentMode)
-	assert.Equal(t, "gpt-3.5", cfg.ModelID)
+	assert.Equal(t, "model-y", cfg.ModelID)
 }
 
 func TestLoadConfigFile_UnknownKind(t *testing.T) {
@@ -52,17 +52,17 @@ func TestLoadConfigFile_BadJSON(t *testing.T) {
 }
 
 func TestMergeAgentConfig_FlagsOverrideFile(t *testing.T) {
-	base := &sdk.AgentConfig{ModelID: "gpt-3.5"}
-	overrides := AgentConfigFlags{ModelIDSet: true, ModelID: "gpt-4"}
+	base := &sdk.AgentConfig{ModelID: "model-y"}
+	overrides := AgentConfigFlags{ModelIDSet: true, ModelID: "model-x"}
 	merged := MergeAgentConfig(base, overrides)
-	assert.Equal(t, "gpt-4", merged.ModelID)
+	assert.Equal(t, "model-x", merged.ModelID)
 }
 
 func TestMergeAgentConfig_UnsetFlagsPreserveBase(t *testing.T) {
-	base := &sdk.AgentConfig{ModelID: "gpt-3.5", Temperature: 0.5}
+	base := &sdk.AgentConfig{ModelID: "model-y", Temperature: 0.5}
 	overrides := AgentConfigFlags{} // nothing set
 	merged := MergeAgentConfig(base, overrides)
-	assert.Equal(t, "gpt-3.5", merged.ModelID)
+	assert.Equal(t, "model-y", merged.ModelID)
 	assert.InDelta(t, 0.5, merged.Temperature, 0.001)
 }
 
@@ -70,7 +70,7 @@ func TestMergeAgentConfig_EveryFieldOverlay(t *testing.T) {
 	base := &sdk.AgentConfig{
 		AgentMode:       "quick-answer",
 		SystemPrompt:    "old",
-		ModelID:         "gpt-3.5",
+		ModelID:         "model-y",
 		RerankModelID:   "rerank-old",
 		Temperature:     0.1,
 		KBSelectionMode: "all",
@@ -79,7 +79,7 @@ func TestMergeAgentConfig_EveryFieldOverlay(t *testing.T) {
 	overrides := AgentConfigFlags{
 		AgentMode: "smart-reasoning", AgentModeSet: true,
 		SystemPrompt: "new", SystemPromptSet: true,
-		ModelID: "gpt-4", ModelIDSet: true,
+		ModelID: "model-x", ModelIDSet: true,
 		RerankModelID: "rerank-new", RerankModelIDSet: true,
 		Temperature: 0.9, TemperatureSet: true,
 		KBSelectionMode: "selected", KBSelectionModeSet: true,
@@ -88,7 +88,7 @@ func TestMergeAgentConfig_EveryFieldOverlay(t *testing.T) {
 	merged := MergeAgentConfig(base, overrides)
 	assert.Equal(t, "smart-reasoning", merged.AgentMode)
 	assert.Equal(t, "new", merged.SystemPrompt)
-	assert.Equal(t, "gpt-4", merged.ModelID)
+	assert.Equal(t, "model-x", merged.ModelID)
 	assert.Equal(t, "rerank-new", merged.RerankModelID)
 	assert.InDelta(t, 0.9, merged.Temperature, 0.001)
 	assert.Equal(t, "selected", merged.KBSelectionMode)

--- a/cli/internal/cmdutil/input.go
+++ b/cli/internal/cmdutil/input.go
@@ -1,0 +1,20 @@
+package cmdutil
+
+import (
+	"io"
+	"os"
+
+	"github.com/Tencent/WeKnora/cli/internal/iostreams"
+)
+
+// OpenInput returns a reader for path. If path == "-", returns stdin
+// (iostreams.IO.In). Otherwise opens the file. Caller is responsible
+// for closing if needed — for typical "-input <file>"/"--input -" CLI
+// patterns the file is fully read before the command exits and OS
+// reclaims the FD, so closing is cosmetic.
+func OpenInput(path string) (io.Reader, error) {
+	if path == "-" {
+		return iostreams.IO.In, nil
+	}
+	return os.Open(path)
+}

--- a/cli/internal/cmdutil/jsonflags_test.go
+++ b/cli/internal/cmdutil/jsonflags_test.go
@@ -53,9 +53,8 @@ func TestAddJSONFlags_BareYieldsEnabledOptsWithNoFields(t *testing.T) {
 
 func TestAddJSONFlags_FieldsFlagParsing(t *testing.T) {
 	// NoOptDefVal sentinel means the `=` form is required for value passing.
-	// Space form `--json id,name` parses as bare + positional, which is a
-	// documented divergence from gh CLI: weknora keeps bare `--json` as a
-	// shortcut for "full payload".
+	// Space form `--json id,name` parses as bare + positional; bare `--json`
+	// (no value) is reserved as a shortcut for the unfiltered payload.
 	cases := []struct {
 		args []string
 		want []string

--- a/cli/internal/format/bare.go
+++ b/cli/internal/format/bare.go
@@ -21,7 +21,7 @@ func WriteJSON(w io.Writer, v any) error {
 //   - len(fields) == 0 → no field filter
 //   - jqExpr == ""     → no jq filter
 //
-// Field filter rules (mirrors gh CLI's `--json field,field` semantics):
+// Field filter rules:
 //
 //   - v marshals to a top-level array  → each [*] object is restricted to
 //     the named keys

--- a/cli/internal/format/bare_test.go
+++ b/cli/internal/format/bare_test.go
@@ -105,7 +105,8 @@ func TestWriteJSONFiltered_JQOnly(t *testing.T) {
 	if err := format.WriteJSONFiltered(buf, items, nil, ".[].id"); err != nil {
 		t.Fatalf("err = %v", err)
 	}
-	// gh CLI parity: string results render without JSON quotes.
+	// String / scalar results render without JSON quotes so scalar
+	// projections (e.g. `--jq '.[].id'`) pipe cleanly into shell tools.
 	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
 	if len(lines) != 2 || lines[0] != "1" || lines[1] != "2" {
 		t.Errorf("jq output mismatch: %q", buf.String())

--- a/cli/internal/mcp/server.go
+++ b/cli/internal/mcp/server.go
@@ -35,9 +35,10 @@ type ServiceClient interface {
 	knowledgeService
 	chatService
 	agentService
+	chunkListService
 }
 
-// RunStdio constructs the MCP server, registers the curated 9 tools, and
+// RunStdio constructs the MCP server, registers the curated 10 tools, and
 // blocks reading JSON-RPC from stdin until the client disconnects or ctx
 // is cancelled. Returns the underlying transport error (if any); the cobra
 // RunE caller maps it through the usual cmdutil exit-code path.

--- a/cli/internal/mcp/tools.go
+++ b/cli/internal/mcp/tools.go
@@ -39,6 +39,13 @@ type agentService interface {
 	AgentQAStreamWithRequest(ctx context.Context, sessionID string, req *sdk.AgentQARequest, cb sdk.AgentEventCallback) error
 }
 
+// chunkListService is the narrow surface chunk_list depends on. Kept
+// separate from knowledgeService because the chunk subtree is its own
+// domain on the server side (/api/v1/chunks/...).
+type chunkListService interface {
+	ListKnowledgeChunks(ctx context.Context, knowledgeID string, page, pageSize int) ([]sdk.Chunk, int64, error)
+}
+
 // agentInvokeService composes the two SDK methods agent_invoke needs
 // (CreateSession for the auto-session path + AgentQAStreamWithRequest
 // for the run itself). Declared here alongside the per-domain
@@ -49,7 +56,7 @@ type agentInvokeService interface {
 	AgentQAStreamWithRequest(ctx context.Context, sessionID string, req *sdk.AgentQARequest, cb sdk.AgentEventCallback) error
 }
 
-// registerTools wires the curated 9 tools onto server. Adding a tool here
+// registerTools wires the curated 10 tools onto server. Adding a tool here
 // is a deliberate API expansion - the agent-callable surface is the
 // reason this CLI ships an MCP server, not its CLI command list, so this
 // list must be maintained by hand.
@@ -63,6 +70,7 @@ func registerTools(server *mcpsdk.Server, svc ServiceClient) {
 	addChat(server, svc)
 	addAgentList(server, svc)
 	addAgentInvoke(server, svc)
+	addChunkList(server, svc)
 }
 
 // ---- kb_list -------------------------------------------------------------
@@ -441,6 +449,62 @@ func addAgentInvoke(server *mcpsdk.Server, svc agentInvokeService) {
 			Thinking:   acc.Thinking(),
 			SessionID:  sessionID,
 			AgentID:    in.AgentID,
+		}, nil
+	})
+}
+
+// ---- chunk_list ----------------------------------------------------------
+
+type chunkListInput struct {
+	DocID string `json:"doc_id" jsonschema:"document (knowledge entry) ID"`
+	Limit int    `json:"limit,omitempty" jsonschema:"max chunks to return (1..1000); defaults to 50"`
+}
+
+type chunkListOutput struct {
+	Chunks           []sdk.Chunk `json:"chunks"`
+	Total            int64       `json:"total"`
+	TruncatedAtLimit bool        `json:"truncated_at_limit"`
+}
+
+// chunkListDefaultLimit + chunkListMaxLimit mirror the schema's default+max.
+// MCP schema deliberately exposes only `limit`, not the CLI's full
+// --limit/--page/--page-size triple: LLM agents typically need a single
+// bounded fetch, not pagination workflows. Above 1000, fall back to the CLI.
+const (
+	chunkListDefaultLimit = 50
+	chunkListMaxLimit     = 1000
+)
+
+func addChunkList(server *mcpsdk.Server, svc chunkListService) {
+	mcpsdk.AddTool(server, &mcpsdk.Tool{
+		Name:        "chunk_list",
+		Description: "List chunks of a knowledge document for RAG retrieval debug. Returns at most `limit` chunks starting from ChunkIndex 0; if total chunks exceed limit, truncated_at_limit=true signals the agent to fall back to the CLI for paginated retrieval.",
+	}, func(ctx context.Context, _ *mcpsdk.CallToolRequest, in chunkListInput) (*mcpsdk.CallToolResult, chunkListOutput, error) {
+		if in.DocID == "" {
+			return nil, chunkListOutput{}, fmt.Errorf("doc_id is required")
+		}
+		// `limit` is typed as int by chunkListInput, so the SDK rejects
+		// non-numeric values at schema validation (e.g. "limit":"50")
+		// before this handler runs. Here we only default+clamp the
+		// already-decoded value.
+		limit := in.Limit
+		if limit < 1 {
+			limit = chunkListDefaultLimit
+		}
+		if limit > chunkListMaxLimit {
+			limit = chunkListMaxLimit
+		}
+		chunks, total, err := svc.ListKnowledgeChunks(ctx, in.DocID, 1, limit)
+		if err != nil {
+			return nil, chunkListOutput{}, fmt.Errorf("list knowledge chunks: %w", err)
+		}
+		if chunks == nil {
+			chunks = []sdk.Chunk{}
+		}
+		return nil, chunkListOutput{
+			Chunks:           chunks,
+			Total:            total,
+			TruncatedAtLimit: total > int64(limit),
 		}, nil
 	})
 }

--- a/cli/internal/mcp/tools.go
+++ b/cli/internal/mcp/tools.go
@@ -283,6 +283,7 @@ func addSearchChunks(server *mcpsdk.Server, svc knowledgeService) {
 		}
 		results, err := svc.HybridSearch(ctx, in.KBID, &sdk.SearchParams{
 			QueryText:        in.Query,
+			MatchCount:       limit,
 			VectorThreshold:  in.VectorThreshold,
 			KeywordThreshold: in.KeywordThreshold,
 		})

--- a/cli/internal/mcp/tools.go
+++ b/cli/internal/mcp/tools.go
@@ -451,7 +451,7 @@ func addAgentInvoke(server *mcpsdk.Server, svc agentInvokeService) {
 			Channel:      "api",
 		}
 		// Auto-create session if not supplied. Sessions are agent-
-		// agnostic at creation (Q3 - verified against server source).
+		// agnostic at creation (verified against server source).
 		sessionID := in.SessionID
 		if sessionID == "" {
 			sess, err := svc.CreateSession(ctx, &sdk.CreateSessionRequest{Title: "weknora mcp agent_invoke"})

--- a/cli/internal/mcp/tools.go
+++ b/cli/internal/mcp/tools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -122,10 +123,16 @@ func addKBView(server *mcpsdk.Server, svc knowledgeBaseService) {
 // ---- doc_list ------------------------------------------------------------
 
 type docListInput struct {
-	KBID     string `json:"kb_id" jsonschema:"knowledge base ID"`
-	Page     int    `json:"page,omitempty" jsonschema:"1-indexed page number; defaults to 1"`
-	PageSize int    `json:"page_size,omitempty" jsonschema:"items per page (1..1000); defaults to 20"`
-	Status   string `json:"status,omitempty" jsonschema:"filter by parse status: pending | processing | completed | failed"`
+	KBID      string `json:"kb_id" jsonschema:"knowledge base ID"`
+	Page      int    `json:"page,omitempty" jsonschema:"1-indexed page number; defaults to 1"`
+	PageSize  int    `json:"page_size,omitempty" jsonschema:"items per page (1..1000); defaults to 20"`
+	Status    string `json:"status,omitempty" jsonschema:"filter by parse status: pending | processing | completed | failed"`
+	Keyword   string `json:"keyword,omitempty" jsonschema:"server-side substring filter (case-sensitive LIKE against title / file_name); leave empty to skip"`
+	FileType  string `json:"file_type,omitempty" jsonschema:"filter by file extension (e.g. pdf, md)"`
+	Source    string `json:"source,omitempty" jsonschema:"filter by ingestion source (e.g. api, web)"`
+	TagID     string `json:"tag_id,omitempty" jsonschema:"filter by tag association"`
+	StartTime string `json:"start_time,omitempty" jsonschema:"include docs with updated_at >= this RFC3339 timestamp (e.g. 2006-01-02T15:04:05Z)"`
+	EndTime   string `json:"end_time,omitempty" jsonschema:"include docs with updated_at <= this RFC3339 timestamp (e.g. 2006-01-02T15:04:05Z)"`
 }
 
 type docListOutput struct {
@@ -138,7 +145,7 @@ type docListOutput struct {
 func addDocList(server *mcpsdk.Server, svc knowledgeService) {
 	mcpsdk.AddTool(server, &mcpsdk.Tool{
 		Name:        "doc_list",
-		Description: "List documents in a knowledge base, with pagination and optional parse-status filter. Returns items[] with id, file_name, title, parse_status, size, updated_at - plus the page/total metadata.",
+		Description: "List documents in a knowledge base, with pagination and optional filters (parse-status, keyword, file_type, source, tag_id, start_time/end_time on updated_at). Returns items[] with id, file_name, title, parse_status, size, updated_at - plus the page/total metadata.",
 	}, func(ctx context.Context, _ *mcpsdk.CallToolRequest, in docListInput) (*mcpsdk.CallToolResult, docListOutput, error) {
 		if in.KBID == "" {
 			return nil, docListOutput{}, fmt.Errorf("kb_id is required")
@@ -154,8 +161,28 @@ func addDocList(server *mcpsdk.Server, svc knowledgeService) {
 		if size > 1000 {
 			return nil, docListOutput{}, fmt.Errorf("page_size must be in 1..1000")
 		}
-		items, total, err := svc.ListKnowledgeWithFilter(ctx, in.KBID, page, size,
-			sdk.KnowledgeListFilter{ParseStatus: in.Status})
+		filter := sdk.KnowledgeListFilter{
+			ParseStatus: in.Status,
+			Keyword:     in.Keyword,
+			FileType:    in.FileType,
+			Source:      in.Source,
+			TagID:       in.TagID,
+		}
+		if in.StartTime != "" {
+			t, err := time.Parse(time.RFC3339, in.StartTime)
+			if err != nil {
+				return nil, docListOutput{}, fmt.Errorf("start_time must be RFC3339 (e.g. 2006-01-02T15:04:05Z), got %q", in.StartTime)
+			}
+			filter.StartTime = t
+		}
+		if in.EndTime != "" {
+			t, err := time.Parse(time.RFC3339, in.EndTime)
+			if err != nil {
+				return nil, docListOutput{}, fmt.Errorf("end_time must be RFC3339 (e.g. 2006-01-02T15:04:05Z), got %q", in.EndTime)
+			}
+			filter.EndTime = t
+		}
+		items, total, err := svc.ListKnowledgeWithFilter(ctx, in.KBID, page, size, filter)
 		if err != nil {
 			return nil, docListOutput{}, fmt.Errorf("list documents: %w", err)
 		}

--- a/cli/internal/mcp/tools_test.go
+++ b/cli/internal/mcp/tools_test.go
@@ -269,6 +269,59 @@ func TestTool_DocList_StatusFilter_Forwarded(t *testing.T) {
 	}
 }
 
+// TestTool_DocList_PassesFilterFields drives every C11 filter field at once
+// and asserts they all land on filter struct (AND-combined server-side).
+func TestTool_DocList_PassesFilterFields(t *testing.T) {
+	svc := &fakeSvc{}
+	c, _ := newTestServer(t, svc)
+	args := map[string]any{
+		"kb_id":      "kb_x",
+		"status":     "completed",
+		"keyword":    "spec",
+		"file_type":  "pdf",
+		"source":     "api",
+		"tag_id":     "tag_42",
+		"start_time": "2026-01-01T00:00:00Z",
+		"end_time":   "2026-12-31T23:59:59Z",
+	}
+	callTool(t, c, "doc_list", args, nil)
+	f := svc.calls.docListFilter
+	assert.Equal(t, "completed", f.ParseStatus)
+	assert.Equal(t, "spec", f.Keyword)
+	assert.Equal(t, "pdf", f.FileType)
+	assert.Equal(t, "api", f.Source)
+	assert.Equal(t, "tag_42", f.TagID)
+	assert.False(t, f.StartTime.IsZero(), "start_time RFC3339 must populate filter.StartTime")
+	assert.False(t, f.EndTime.IsZero(), "end_time RFC3339 must populate filter.EndTime")
+}
+
+// TestTool_DocList_InvalidStartTime asserts malformed RFC3339 is rejected
+// at the handler boundary (before the SDK is called).
+func TestTool_DocList_InvalidStartTime(t *testing.T) {
+	c, _ := newTestServer(t, &fakeSvc{})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	res, err := c.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name:      "doc_list",
+		Arguments: map[string]any{"kb_id": "kb_x", "start_time": "tomorrow"},
+	})
+	require.NoError(t, err)
+	require.True(t, res.IsError, "expected IsError=true on malformed RFC3339 start_time")
+}
+
+// TestTool_DocList_InvalidEndTime mirrors the start_time guard for end_time.
+func TestTool_DocList_InvalidEndTime(t *testing.T) {
+	c, _ := newTestServer(t, &fakeSvc{})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	res, err := c.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name:      "doc_list",
+		Arguments: map[string]any{"kb_id": "kb_x", "end_time": "2026-05-01"}, // date-only, not RFC3339
+	})
+	require.NoError(t, err)
+	require.True(t, res.IsError, "expected IsError=true on malformed RFC3339 end_time")
+}
+
 func TestTool_DocView(t *testing.T) {
 	svc := &fakeSvc{getDoc: &sdk.Knowledge{ID: "k1", FileName: "a.pdf"}}
 	c, _ := newTestServer(t, svc)

--- a/cli/internal/mcp/tools_test.go
+++ b/cli/internal/mcp/tools_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	sdk "github.com/Tencent/WeKnora/client"
 )
@@ -42,6 +44,9 @@ type fakeSvc struct {
 	agentErr       error
 	agentEvents    []*sdk.AgentStreamResponse
 	agentStreamErr error
+	chunks         []sdk.Chunk
+	chunksTotal    int64
+	chunksErr      error
 	// Captured args:
 	calls struct {
 		listKBs       int
@@ -59,6 +64,9 @@ type fakeSvc struct {
 		agentViewID   string
 		agentReq      *sdk.AgentQARequest
 		agentSess     string
+		chunkDocID    string
+		chunkPage     int
+		chunkPageSize int
 	}
 }
 
@@ -119,6 +127,12 @@ func (f *fakeSvc) AgentQAStreamWithRequest(_ context.Context, sess string, req *
 		}
 	}
 	return f.agentStreamErr
+}
+func (f *fakeSvc) ListKnowledgeChunks(_ context.Context, docID string, page, pageSize int) ([]sdk.Chunk, int64, error) {
+	f.calls.chunkDocID = docID
+	f.calls.chunkPage = page
+	f.calls.chunkPageSize = pageSize
+	return f.chunks, f.chunksTotal, f.chunksErr
 }
 
 // newTestServer wires svc to an in-process MCP server and returns a
@@ -182,7 +196,7 @@ func TestTool_ListsRegistered(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTools: %v", err)
 	}
-	want := []string{"kb_list", "kb_view", "doc_list", "doc_view", "doc_download", "search_chunks", "chat", "agent_list", "agent_invoke"}
+	want := []string{"kb_list", "kb_view", "doc_list", "doc_view", "doc_download", "search_chunks", "chat", "agent_list", "agent_invoke", "chunk_list"}
 	got := map[string]bool{}
 	for _, tool := range res.Tools {
 		got[tool.Name] = true
@@ -404,4 +418,55 @@ func TestTool_AgentInvoke_StreamAbort(t *testing.T) {
 	if !res.IsError {
 		t.Fatal("expected IsError=true on mid-stream abort")
 	}
+}
+
+func TestTool_ChunkList_Happy(t *testing.T) {
+	svc := &fakeSvc{
+		chunks:      []sdk.Chunk{{ID: "c1", ChunkIndex: 0, Content: "hello"}},
+		chunksTotal: 1,
+	}
+	c, _ := newTestServer(t, svc)
+	var out chunkListOutput
+	callTool(t, c, "chunk_list", map[string]any{"doc_id": "doc_abc", "limit": 50}, &out)
+	require.Len(t, out.Chunks, 1)
+	assert.Equal(t, "c1", out.Chunks[0].ID)
+	assert.Equal(t, "doc_abc", svc.calls.chunkDocID)
+	assert.Equal(t, 1, svc.calls.chunkPage)
+	assert.Equal(t, 50, svc.calls.chunkPageSize) // SDK page=1, pageSize=limit
+}
+
+func TestTool_ChunkList_TruncatedAtLimit(t *testing.T) {
+	svc := &fakeSvc{
+		chunks:      []sdk.Chunk{{ID: "c1"}},
+		chunksTotal: 100, // more than limit
+	}
+	c, _ := newTestServer(t, svc)
+	var out chunkListOutput
+	callTool(t, c, "chunk_list", map[string]any{"doc_id": "d", "limit": 1}, &out)
+	assert.True(t, out.TruncatedAtLimit)
+}
+
+func TestTool_ChunkList_MissingDocID(t *testing.T) {
+	c, _ := newTestServer(t, &fakeSvc{})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	res, err := c.CallTool(ctx, &mcpsdk.CallToolParams{Name: "chunk_list", Arguments: map[string]any{"limit": 50}})
+	require.NoError(t, err)
+	require.True(t, res.IsError, "expected IsError=true on missing doc_id")
+}
+
+// TestTool_ChunkList_NonNumericLimit asserts the MCP framework rejects a
+// string-valued `limit`. The schema declares limit as integer (via the
+// chunkListInput struct tag), so non-numeric values fail validation
+// before the handler runs.
+func TestTool_ChunkList_NonNumericLimit(t *testing.T) {
+	c, _ := newTestServer(t, &fakeSvc{})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	res, err := c.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name:      "chunk_list",
+		Arguments: map[string]any{"doc_id": "d", "limit": "50"},
+	})
+	require.NoError(t, err)
+	require.True(t, res.IsError, "expected IsError=true when limit is a string")
 }

--- a/cli/internal/mcp/tools_test.go
+++ b/cli/internal/mcp/tools_test.go
@@ -334,6 +334,19 @@ func TestTool_SearchChunks_LimitCap(t *testing.T) {
 	}
 }
 
+// TestTool_SearchChunks_PassesMatchCountFromLimit is a regression guard for
+// the v0.5 audit bug: the search_chunks dispatch built SearchParams without
+// setting MatchCount, so the server fell back to its default cap and the
+// client-side trim (results[:limit]) was a no-op when limit > server default.
+// Verifies the limit arg is threaded into SearchParams.MatchCount.
+func TestTool_SearchChunks_PassesMatchCountFromLimit(t *testing.T) {
+	svc := &fakeSvc{}
+	c, _ := newTestServer(t, svc)
+	callTool(t, c, "search_chunks", map[string]any{"kb_id": "kb_x", "query": "test", "limit": 50}, nil)
+	require.NotNil(t, svc.calls.hybridParams, "HybridSearch must be called with non-nil SearchParams")
+	assert.Equal(t, 50, svc.calls.hybridParams.MatchCount, "MCP search_chunks must thread limit into SearchParams.MatchCount")
+}
+
 func TestTool_Chat_AccumulateAnswerAndReferences(t *testing.T) {
 	svc := &fakeSvc{
 		kbStreamEvents: []*sdk.StreamResponse{

--- a/cli/internal/sse/accumulator.go
+++ b/cli/internal/sse/accumulator.go
@@ -23,8 +23,8 @@ import (
 // Demuxes by ResponseType so the answer string is not polluted by thinking
 // or reflection fragments - the model layer (internal/models/chat/
 // remote_api.go) emits ResponseTypeThinking events whenever the upstream
-// LLM produces reasoning_content (GPT-5 / Claude extended thinking), and
-// without demux those would be silently concatenated into Result().
+// LLM produces reasoning_content frames, and without demux those would
+// be silently concatenated into Result().
 type Accumulator struct {
 	answer             strings.Builder
 	thinking           strings.Builder

--- a/cli/internal/text/oneline.go
+++ b/cli/internal/text/oneline.go
@@ -1,0 +1,13 @@
+package text
+
+import "strings"
+
+// OneLine collapses newlines/carriage-returns/tabs in s to single spaces,
+// then truncates to maxDisplayWidth columns (UTF-8 safe via Truncate).
+// Use for human-readable preview rows where multiline content would
+// break tabular layout.
+func OneLine(maxDisplayWidth int, s string) string {
+	return Truncate(maxDisplayWidth, lineReplacer.Replace(s))
+}
+
+var lineReplacer = strings.NewReplacer("\n", " ", "\r", " ", "\t", " ")

--- a/cli/internal/text/oneline_test.go
+++ b/cli/internal/text/oneline_test.go
@@ -1,0 +1,29 @@
+package text_test
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/cli/internal/text"
+)
+
+func TestOneLine(t *testing.T) {
+	cases := []struct {
+		name     string
+		max      int
+		in, want string
+	}{
+		{"empty", 10, "", ""},
+		{"no-collapse", 10, "hello", "hello"},
+		{"collapse-newline", 20, "hello\nworld", "hello world"},
+		{"collapse-cr-tab", 20, "hello\r\tworld", "hello  world"},
+		{"truncate", 8, "hello world long", "hello w…"},
+		{"truncate-after-collapse", 8, "hello\nworld\nlong", "hello w…"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := text.OneLine(c.max, c.in); got != c.want {
+				t.Errorf("OneLine(%d, %q) = %q, want %q", c.max, c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/cli/internal/text/timeago_string.go
+++ b/cli/internal/text/timeago_string.go
@@ -1,0 +1,25 @@
+package text
+
+import "time"
+
+// FuzzyAgoStr is the string-input variant of FuzzyAgo for SDK types that
+// carry timestamps as RFC3339 strings (sdk.Chunk.UpdatedAt, sdk.Session.
+// UpdatedAt, ...) rather than time.Time.
+//
+// Behavior:
+//   - ts == ""        → "-"   (server has no timestamp; render placeholder)
+//   - parse error     → ts    (surface the raw value rather than hide it)
+//   - parse OK        → FuzzyAgo(now, parsed)
+//
+// The parse-error fallback is deliberate: if the server starts emitting a
+// new format we want it visible in the table, not silently replaced by "-".
+func FuzzyAgoStr(now time.Time, ts string) string {
+	if ts == "" {
+		return "-"
+	}
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return ts
+	}
+	return FuzzyAgo(now, t)
+}

--- a/cli/internal/text/timeago_string_test.go
+++ b/cli/internal/text/timeago_string_test.go
@@ -1,0 +1,31 @@
+package text_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/cli/internal/text"
+)
+
+func TestFuzzyAgoStr(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		ts   string
+		want string
+	}{
+		{"empty renders dash", "", "-"},
+		{"valid RFC3339 5m ago", now.Add(-5 * time.Minute).Format(time.RFC3339), "about 5 minutes ago"},
+		{"valid RFC3339 2d ago", now.Add(-2 * 24 * time.Hour).Format(time.RFC3339), "about 2 days ago"},
+		{"unparseable returned verbatim", "not-a-date", "not-a-date"},
+		{"wrong format returned verbatim", "2026-05-15 12:00:00", "2026-05-15 12:00:00"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := text.FuzzyAgoStr(now, tt.ts)
+			if got != tt.want {
+				t.Errorf("FuzzyAgoStr(%q) = %q, want %q", tt.ts, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Title follows Conventional Commits: feat(cli): ... -->

## Description

v0.5 of the `weknora` CLI (the binary under `cli/`): agent CRUD + chunk subtree + MCP `chunk_list` tool + post-audit typed-error cleanup. Scope is `cli/` only — no server, SDK, or frontend changes.

### New commands / surface

| Command | Purpose |
|---|---|
| `weknora agent create / edit / delete` | Hybrid surface: hot-path flags + `--config-file` (YAML / JSON) + `--generate-skeleton` template emit. `--from <agent-id>` copies. |
| `weknora chunk list / view / delete` | RAG retrieval debug subtree, paginated with v0.4 `--limit` / `--page-size` / `--all-pages`; `delete` is high-risk (L-13 `-y` gate). |
| `weknora mcp serve` | Adds `chunk_list` as the 10th curated read-only tool. |
| `weknora agent view <id>` | Human output renders all 34 `AgentConfig` fields grouped into 10 sections (previously 7 fields). |
| `weknora doc list` | Adds `--keyword` / `--file-type` / `--source` / `--tag-id` / `--start-time` / `--end-time` (server-side filtering via `KnowledgeListFilter`). |
| `weknora doc upload` | Adds `--enable-multimodel` (tri-state), repeatable `--metadata key=value`, `--channel`, plus URL-mode `--title` / `--file-type` / `--tag-id`. |
| `weknora session view --full` | Loads chat history inline, bounded by `--limit` (1..1000, default 50). |
| `weknora kb view` / `weknora doc view` | Human render expanded with more metadata fields (`TYPE` / `PINNED` / `PROCESSING` / `STORAGE` / `ENABLED` / `HASH` / etc., all omit-empty). |
| `search docs` / `search sessions` | Catch up with `--all-pages` / `--page-size` canon from `session list` / `doc list`. |

### Notable fixes

| Symptom | Fix |
|---|---|
| `agent create --model` `MarkFlagRequired` blocks `--generate-skeleton` (cobra runs required-flag check before `PreRunE`) | Drop the flag attribute; `PreRunE` enforces the real shape so the skeleton-emit path stays reachable. |
| `agent view` `--json=` field discovery advertised 43 keys including misleading `config.*` dotted paths (the filter only matches flat top-level keys) | Scrubbed to 10 top-level keys; nested access redirected to `--jq`. |
| `doc upload` re-upload of an already-ingested file returned `network.error: check base URL reachability` | Handle `sdk.ErrDuplicateFile` symmetric to existing `ErrDuplicateURL` handling. Sentinel lacks `"HTTP error <n>:"` prefix because the SDK short-circuits on file-hash before reading status. |
| MCP `search_chunks` `limit` arg silently capped below the requested value | Threads correctly into `SearchParams.MatchCount`. |
| `search sessions` printed raw RFC3339 timestamps | Renders relative durations (`"2 hours ago"`) matching `session list`. |

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 💥 Breaking change
- [x] 📚 Documentation update
- [x] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

**Breaking change called out:** `weknora search docs` is now case-sensitive (server-side `LIKE %keyword%` via `ListKnowledgeWithFilter`, replacing the previous case-insensitive client-side substring match). Documented in `cli/CHANGELOG.md` under `#### Breaking changes` for v0.5; migration guidance included.

## Related Issue

N/A — independent CLI release on the `cli/` subtree.

## Testing

| Check | Result |
|---|---|
| `cd cli && go test ./... -race -count=1` | ✅ all 26 packages pass |
| `cd cli && go vet ./...` | ✅ clean |
| `gofmt -l cli/` | ✅ clean |
| `make lint` | ⚠️ `golangci-lint` not installed in this environment |
| `make test` (repo-wide) | ⚠️ 2 pre-existing failures on `main` in `internal/utils` (`TestSSRFSafeURL_AllowPublicDomain`, `TestSSRFSafeURL/blocked_internal_service_port`) — DNS-dependent (`example.com` resolves to `198.18.0.120` in this env), unrelated to `cli/` scope |

**End-to-end exercise against a local docker WeKnora stack** (containers: `WeKnora-app`, `WeKnora-docreader`, `WeKnora-postgres`, `WeKnora-redis`; `STORAGE_TYPE=local`; tenant configured with `storage_engine_config.default_provider=local`; one chat model + one embedding model):

| Section | Verb | Status |
|---|---|---|
| 1 | `--help` discoverability for all v0.5 verbs | ✅ |
| 2 | `kb create --embedding-model` | ✅ |
| 3 | `doc upload <file> --enable-multimodel --metadata --channel` → asynq enqueue → chunking → `parse_status=completed` | ✅ |
| 4 | `chunk list --doc` / `chunk view <id>` | ✅ |
| 5 | `search chunks "<q>" --kb` (hybrid vector + keyword, 1 result + score + match_type) | ✅ |
| 6 | `search docs "<q>" --kb` (case-sensitive LIKE filter — by design) | ✅ |
| 7 | `doc list --kb --status completed --file-type md --keyword` (server-side filters) | ✅ |
| 8 | `chat --kb "<q>"` (RAG retrieval + LLM answer + correct chunk reference) | ✅ |
| 9 | `session view --full` (user + assistant messages inline) | ✅ |
| 10 | `chunk delete --doc` (no `-y` → `input.confirmation_required` exit=10; with `-y` → real delete) | ✅ |
| 11 | `agent create --generate-skeleton` (the `MarkFlagRequired` bug fixed in `dbe4636c`) | ✅ |
| 12 | `agent edit --add-kb` / `agent create --from` (clone) / `agent view` (`--json=` projection + `--jq` nested access) | ✅ |
| 13 | `agent delete` L-13 gate + actual delete | ✅ |
| 14 | MCP `tools/list` JSON-RPC stdio roundtrip (10 tools) | ✅ |
| 15 | `doc upload --metadata --from-url` rejected up-front (`input.invalid_argument`) | ✅ |
| 16 | Re-upload already-ingested file → `resource.already_exists` (the bug fixed in `119025e5`) | ✅ |
| 17 | `auth token` / `auth status` / `context list` | ✅ |

## Checklist

- [x] `make fmt && make lint && make test` pass locally — see Testing above for environment caveats
- [x] Self-reviewed the code (4 rounds of code review + e2e exercise against real server)
- [x] Added/updated tests covering the change — every new feature + the 3 fixes have unit tests; e2e uncovered the dup-file mapping bug, which is now pinned by `TestUpload_DuplicateFileMaps_resource_already_exists`
- [x] Updated related documentation (`cli/README.md`, `cli/AGENTS.md`, `cli/CHANGELOG.md`)
- [x] Breaking changes are clearly called out (`search docs` case-sensitivity — `cli/CHANGELOG.md` `#### Breaking changes` subsection)

## Screenshots / Recordings
<img width="786" height="7593" alt="weknora-v0 5" src="https://github.com/user-attachments/assets/9dbc51c7-3d37-49b0-8a20-c879092aec3e" />
