### PR TITLE
fix(embedding): repair broken comment in Zhipu embedder

### DIFF
--- a/internal/models/embedding/zhipu.go
+++ b/internal/models/embedding/zhipu.go
@@ -157,12 +157,11 @@ func (e *ZhipuEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]flo
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-
 	// Log request details for debugging
 	logger.GetLogger(ctx).Debugf("ZhipuEmbedder BatchEmbed: model=%s, input_count=%d, truncate_tokens=%d",
 		e.modelName, len(texts), e.truncatePromptTokens)
-	/
-	/ Check for invalid input lengths and log details
+
+	// Check for invalid input lengths and log details
 	hasInvalidLength := false
 	for i, text := range texts {
 		textLen := len(text)


### PR DESCRIPTION
## Summary
- Repairs a typo in `internal/models/embedding/zhipu.go` where a single-line comment was split into `/` and `/ Check…`, which is invalid Go and broke `make build-prod` / CI.
- Restores a normal `//` comment so the package compiles.

## Test plan
- [x] `go build ./internal/models/embedding/...`
- [ ] CI `build-prod` / full pipeline on this PR