### PR TITLE
fix: guard against empty choices and message=None in LLM response

### DIFF
--- a/dataset/qa_dataset.py
+++ b/dataset/qa_dataset.py
@@ -177,6 +177,8 @@ Answer:"""
             messages=[{"role": "user", "content": prompt}],
             temperature=0.3,
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
 
 


### PR DESCRIPTION
## Problem

In `dataset/qa_dataset.py`, the LLM response is accessed without checking:

```python
return response.choices[0].message.content
```

This raises `IndexError` (empty choices) or `AttributeError` (message=None on filtered content).

## Fix

```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
return response.choices[0].message.content
```

**2 lines added, 0 deleted.**

Detected by [pact](https://github.com/qizwiz/pact) static analysis.