### PR TITLE
fix(agent): avoid promoting tool thoughts as answers

### DIFF
--- a/frontend/src/utils/agentStreamEvents.test.ts
+++ b/frontend/src/utils/agentStreamEvents.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { canPromoteTrailingThinkingToAnswer } from './agentStreamEvents.ts'
+
+test('allows natural-stop thinking promotion when no tools were used', () => {
+  assert.equal(canPromoteTrailingThinkingToAnswer([
+    { type: 'thinking', content: 'Final answer written as plain text.' },
+    { type: 'agent_complete' },
+  ]), true)
+})
+
+test('does not promote thinking after agent tool calls', () => {
+  assert.equal(canPromoteTrailingThinkingToAnswer([
+    { type: 'thinking', content: 'Need to query wiki first.' },
+    { type: 'tool_call', tool_name: 'wiki_search' },
+    { type: 'tool_result', tool_name: 'wiki_search' },
+    { type: 'agent_complete' },
+  ]), false)
+})

--- a/frontend/src/utils/agentStreamEvents.ts
+++ b/frontend/src/utils/agentStreamEvents.ts
@@ -1,0 +1,25 @@
+export type AgentStreamEventLike = {
+  type?: string
+  [key: string]: unknown
+}
+
+const THINKING_PROMOTION_BLOCKERS = new Set([
+  'tool_call',
+  'tool_result',
+  'tool_approval_required',
+  'tool_approval_resolved',
+  'error',
+])
+
+export function hasAgentToolActivity(stream: AgentStreamEventLike[] | null | undefined): boolean {
+  if (!Array.isArray(stream)) return false
+
+  return stream.some((event) => {
+    if (!event || typeof event !== 'object') return false
+    return THINKING_PROMOTION_BLOCKERS.has(event.type || '')
+  })
+}
+
+export function canPromoteTrailingThinkingToAnswer(stream: AgentStreamEventLike[] | null | undefined): boolean {
+  return !hasAgentToolActivity(stream)
+}

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -419,6 +419,7 @@ import { useI18n } from 'vue-i18n';
 import i18n from '@/i18n';
 import { hydrateProtectedFileImages } from '@/utils/security';
 import { unwrapFinalAnswerWrappers, thinkingEqualsAnswer } from '@/utils/finalAnswer';
+import { canPromoteTrailingThinkingToAnswer } from '@/utils/agentStreamEvents';
 import {
   buildManualMarkdown,
   copyTextToClipboard,
@@ -947,8 +948,13 @@ const finalContent = computed(() => {
     return null;
   }
 
-  // Fallback: if no answer content (legacy path or LLM didn't call final_answer),
-  // use last thinking as final content
+  // Fallback: if no answer content and no tools were used, keep supporting
+  // legacy natural-stop responses where the model wrote the answer as thinking.
+  // Once tool calls/results exist, thinking is process state, not a final answer.
+  if (!canPromoteTrailingThinkingToAnswer(stream)) {
+    return null;
+  }
+
   const thinkingEvents = stream.filter((e: any) => e.type === 'thinking' && e.content && e.content.trim());
   if (thinkingEvents.length > 0) {
     const lastThinking = thinkingEvents[thinkingEvents.length - 1];


### PR DESCRIPTION
## Summary
- prevent the chat UI from synthesizing a final answer from trailing thinking once agent tools were used
- keep the existing natural-stop compatibility path for streams that contain only thinking and no tool activity
- add focused Node tests for the promotion guard

Fixes #1371

## Testing
- node --test src/components/modelEditorSourceState.test.ts src/utils/agentStreamEvents.test.ts
- npm run build-only

## Note
- npm run type-check currently fails on existing project-wide frontend type errors unrelated to this change, so it is not listed as passing.