### PR TITLE
feat(frontend): redesign knowledge document tag selector

### DIFF
--- a/frontend/src/assets/dropdown-menu.less
+++ b/frontend/src/assets/dropdown-menu.less
@@ -296,13 +296,113 @@
   }
 }
 
+/* 文档卡片标签选择弹窗 */
+.card-tag-popup {
+  z-index: 99 !important;
+
+  .t-popup__content {
+    padding: 4px !important;
+    margin-top: 4px !important;
+    border-radius: 10px !important;
+    background: var(--td-bg-color-container) !important;
+    border: 0.5px solid var(--td-component-stroke) !important;
+    box-shadow:
+      0 0 0 0.5px rgba(0, 0, 0, 0.03),
+      0 2px 4px rgba(0, 0, 0, 0.04),
+      0 8px 24px rgba(0, 0, 0, 0.1) !important;
+    backdrop-filter: blur(20px) saturate(180%) !important;
+    -webkit-backdrop-filter: blur(20px) saturate(180%) !important;
+    animation: dropdownSlideIn 0.18s cubic-bezier(0.2, 0, 0, 1) both;
+    overflow: hidden;
+  }
+
+  .tag-popup-list {
+    min-width: 160px;
+    max-width: 240px;
+    max-height: 280px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .tag-popup-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    border-radius: 6px;
+    font-size: 13px;
+    color: var(--td-text-color-primary);
+    cursor: pointer;
+    line-height: 1.2;
+    transition: background-color 0.15s ease;
+
+    &:hover {
+      background: var(--td-bg-color-container-hover);
+    }
+
+    &.is-selected {
+      color: var(--td-brand-color);
+      background: var(--td-bg-color-secondarycontainer);
+    }
+  }
+
+  .tag-popup-check {
+    font-size: 14px;
+    color: var(--td-brand-color);
+    visibility: hidden;
+    flex-shrink: 0;
+
+    &.visible {
+      visibility: visible;
+    }
+  }
+
+  .tag-popup-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &.muted {
+      color: var(--td-text-color-secondary);
+    }
+  }
+
+  .tag-popup-item.is-action {
+    color: var(--td-text-color-secondary);
+
+    .tag-popup-check {
+      visibility: visible;
+      color: var(--td-text-color-secondary);
+    }
+
+    &:hover {
+      color: var(--td-error-color);
+      background: var(--td-error-color-1);
+
+      .tag-popup-check {
+        color: var(--td-error-color);
+      }
+    }
+  }
+
+  .tag-popup-divider {
+    height: 1px;
+    margin: 4px 4px;
+    background: var(--td-component-stroke);
+  }
+}
+
 /* ============================================
    五、暗色模式增强
    ============================================ */
 :root[theme-mode="dark"] {
   .card-more-popup .t-popup__content,
   .card-more .t-popup__content,
-  .tag-more-popup .t-popup__content {
+  .tag-more-popup .t-popup__content,
+  .card-tag-popup .t-popup__content {
     background: rgba(36, 36, 36, 0.85) !important;
     border-color: rgba(255, 255, 255, 0.08) !important;
     box-shadow:

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -95,6 +95,7 @@ export default {
     category: 'Category',
     faqCategoryTitle: 'FAQ Categories',
     untagged: 'Uncategorized',
+    tagClearAction: 'Clear category',
     tagSearchTooltip: 'Search tags',
     tagCreateAction: 'Create tag',
     tagSearchPlaceholder: 'Type to filter tags',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -93,6 +93,7 @@ export default {
     documentCategoryTitle: "문서 분류",
     faqCategoryTitle: "질문 분류",
     untagged: "미분류",
+    tagClearAction: "분류 해제",
     tagUpdateSuccess: "태그 업데이트 성공",
     tagSearchTooltip: "태그 검색",
     category: "분류",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -55,6 +55,7 @@ export default {
     documentCategoryTitle: 'Категории документов',
     faqCategoryTitle: 'Категории FAQ',
     untagged: 'Без метки',
+    tagClearAction: 'Снять категорию',
     tagSearchTooltip: 'Поиск тегов',
     tagUpdateSuccess: 'Тег успешно обновлен',
     category: 'Категория',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -93,6 +93,7 @@ export default {
     documentCategoryTitle: "文档分类",
     faqCategoryTitle: "问题分类",
     untagged: "未分类",
+    tagClearAction: "取消分类",
     tagUpdateSuccess: "标签更新成功",
     tagSearchTooltip: "搜索标签",
     category: "分类",

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -427,12 +427,13 @@ const filterParams = computed(() => {
   };
 });
 type TagInputInstance = ComponentPublicInstance<{ focus: () => void; select: () => void }>;
-const tagDropdownOptions = computed(() =>
-  tagList.value.map((tag: any) => ({
-    content: tag.name,
-    value: tag.id,
-  })),
-);
+const onPickTag = (item: any, tagId: string | number) => {
+  if (item) item.isTagPopup = false;
+  const currentId = item?.tag_id ? String(item.tag_id) : '';
+  const nextId = tagId ? String(tagId) : '';
+  if (currentId === nextId) return;
+  handleKnowledgeTagChange(item.id, nextId);
+};
 const tagMap = computed<Record<string, any>>(() => {
   const map: Record<string, any> = {};
   tagList.value.forEach((tag) => {
@@ -2389,13 +2390,37 @@ async function createNewSession(value: string): Promise<void> {
                         <span class="card-time">{{ formatDocTime(item.updated_at) }}</span>
                         <div class="card-bottom-right">
                           <div v-if="tagList.length" class="card-tag-selector" @click.stop>
-                            <t-dropdown v-if="canEdit" :options="tagDropdownOptions" trigger="click"
-                              @click="(data: any) => handleKnowledgeTagChange(item.id, data.value as string)">
-                              <t-tag size="small" variant="light-outline">
+                            <t-popup v-if="canEdit" v-model="item.isTagPopup" trigger="click" placement="bottom-right"
+                              overlayClassName="card-tag-popup" destroy-on-close>
+                              <template #content>
+                                <div class="tag-popup-list">
+                                  <div v-for="tag in tagList" :key="tag.id" class="tag-popup-item"
+                                    :class="{ 'is-selected': String(item.tag_id) === String(tag.id) }"
+                                    @click="onPickTag(item, tag.id)">
+                                    <t-icon class="tag-popup-check"
+                                      :class="{ visible: String(item.tag_id) === String(tag.id) }" name="check" />
+                                    <span class="tag-popup-name">{{ tag.name }}</span>
+                                  </div>
+                                  <template v-if="item.tag_id">
+                                    <div class="tag-popup-divider"></div>
+                                    <div class="tag-popup-item is-action" @click="onPickTag(item, '')">
+                                      <t-icon class="tag-popup-check" name="close" />
+                                      <span class="tag-popup-name">{{ t('knowledgeBase.tagClearAction') }}</span>
+                                    </div>
+                                  </template>
+                                </div>
+                              </template>
+                              <t-tag v-if="getTagName(item.tag_id)" size="small" variant="light-outline"
+                                class="card-tag-chip">
                                 <span class="tag-text">{{ getTagName(item.tag_id) }}</span>
                               </t-tag>
-                            </t-dropdown>
-                            <t-tag v-else size="small" variant="light-outline">
+                              <span v-else class="card-tag-add">
+                                <t-icon name="add" size="12px" />
+                                <span>{{ t('knowledgeBase.tagLabel') }}</span>
+                              </span>
+                            </t-popup>
+                            <t-tag v-else-if="getTagName(item.tag_id)" size="small" variant="light-outline"
+                              class="card-tag-chip">
                               <span class="tag-text">{{ getTagName(item.tag_id) }}</span>
                             </t-tag>
                           </div>
@@ -3463,7 +3488,33 @@ async function createNewSession(value: string): Promise<void> {
     vertical-align: middle;
     font-size: 11px;
   }
+
+  .card-tag-add {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    height: 18px;
+    padding: 0 6px;
+    border-radius: 999px;
+    border: 1px dashed var(--td-component-stroke);
+    color: var(--td-text-color-placeholder);
+    font-size: 11px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    .t-icon {
+      font-size: 12px;
+    }
+
+    &:hover {
+      border-color: var(--td-brand-color);
+      color: var(--td-brand-color-active);
+      background: var(--td-bg-color-secondarycontainer);
+      border-style: solid;
+    }
+  }
 }
+
 
 .card-bottom-right {
   display: flex;


### PR DESCRIPTION
## Summary

- Replace the default `t-dropdown` on knowledge document cards with a custom `t-popup`-based list that matches the existing `card-more` popup styling (rounded corners, soft shadow, blur, dark-mode support). The currently selected tag is highlighted with a brand-colored check icon.
- Fix the empty placeholder issue: when a document has no tag, render a dashed "+ category" affordance for users with edit permission instead of an empty tag chip; non-editors see nothing.
- Add a "clear category" action that only appears at the bottom of the popup (with a divider) when a tag is already set, so it never collides with a user-defined tag that happens to be named the same as the generic "Uncategorized" label.
- Add the new `knowledgeBase.tagClearAction` i18n key in `zh-CN`, `en-US`, `ko-KR` and `ru-RU`.

## Before / After

Before: every card showed an empty tag chip when no tag was assigned, and the default dropdown was visually inconsistent with the rest of the card menus. A user-created tag literally named "Uncategorized" would appear twice in the picker.

After: the picker UI is consistent with other card popups, empty cards show a subtle "+ category" trigger only when actionable, and clearing a tag is a distinct destructive-styled action only available when there's something to clear.

## Test plan

- [ ] Open a knowledge base and verify document cards without a tag show the dashed "+ category" trigger (edit permission) or nothing (read-only).
- [ ] Click the trigger / existing tag chip and confirm the popup matches the styling of other card popups, including dark mode.
- [ ] Switch a document between tags and verify the check icon updates and the popup closes on selection.
- [ ] Verify "clear category" only appears when a tag is set and successfully untags the document.
- [ ] Verify the i18n labels render correctly in zh-CN, en-US, ko-KR and ru-RU.