### PR TITLE
fix(model): allow updating built-in (global) models

### DIFF
--- a/internal/application/repository/model.go
+++ b/internal/application/repository/model.go
@@ -65,8 +65,11 @@ func (r *modelRepository) List(
 // Update updates a model
 func (r *modelRepository) Update(ctx context.Context, m *types.Model) error {
 	// Use Select to explicitly update all fields, including zero values like false
+	// Allow updates if:
+	//   1. The model belongs to the tenant (tenant_id match), OR  
+	//   2. The model is a built-in model (is_builtin = true)
 	return r.db.WithContext(ctx).Debug().Model(&types.Model{}).Where(
-		"id = ? AND tenant_id = ?", m.ID, m.TenantID,
+		"id = ? AND (tenant_id = ? OR is_builtin = true)", m.ID, m.TenantID,
 	).Select("*").Updates(m).Error
 }
 


### PR DESCRIPTION
Fixes #1373.

Previously, the Update function had Where("id = ? AND tenant_id = ?", ...) which prevented updating built-in models (is_builtin=true) from other tenants.

Now allows updates if:
  1. The model belongs to the tenant, OR
  2. The model is a built-in model (is_builtin = true)

This enables tenants to customize/configure global models for their usage.
### Issue Reference
Fixes #1373

### Problem Description
The UI and API do not support creating/updating global models (built-in models). When trying to update a built-in model (`is_builtin=true`), the operation fails because the `Update` function in the repository only allows updates when both `id` and `tenant_id` match.

### Root Cause
In `internal/application/repository/model.go`, the `Update` function had:
```go
Where("id = ? AND tenant_id = ?", m.ID, m.TenantID)
```
This prevented updating built-in models that belong to other tenants.

### Solution
Modified the `Where` clause to allow updates if EITHER condition is met:
1. The model belongs to the current tenant (`tenant_id` matches), OR
2. The model is a built-in model (`is_builtin = true`)

New code:
```go
Where("id = ? AND (tenant_id = ? OR is_builtin = true)", m.ID, m.TenantID)
```

### Impact
- Tenants can now update/configure global (built-in) models for their usage
- No breaking changes - the check is relaxed, not removed
- Maintains security by still requiring the `id` to match

### Testing
- [ ] Unit tests pass
- [ ] Manual testing: Try to update a built-in model from a different tenant

### Checklist
- [x] Code follows project coding style
- [x] Commit message follows Conventional Commits
- [ ] Tests added/updated (if applicable)
