### PR TITLE
fix(docparser): unescape MinerU markdown image syntax

### DIFF
--- a/internal/infrastructure/docparser/mineru_converter.go
+++ b/internal/infrastructure/docparser/mineru_converter.go
@@ -64,8 +64,13 @@ func (c *MinerUReader) Read(ctx context.Context, req *types.ReadRequest) (*types
 		return nil, fmt.Errorf("MinerU file_parse: %w", err)
 	}
 
-	// HTML -> Markdown conversion (equivalent to Python markdownify)
+	// HTML -> Markdown conversion (equivalent to Python markdownify).
+	// MinerU's md_content is mostly Markdown with embedded HTML blocks (e.g. <table>),
+	// but html-to-markdown sees the whole string as HTML and escapes Markdown special
+	// chars in already-valid Markdown — notably turning `![](...)` into `!\[](...)`,
+	// which then breaks downstream image extraction. Unescape those after conversion.
 	mdContent = htmlToMarkdown(mdContent)
+	mdContent = unescapeMarkdownImageSyntax(mdContent)
 
 	// Process images: decode base64, build ImageRef list, replace refs in markdown
 	imageRefs, mdContent := c.processImages(mdContent, imagesB64)
@@ -276,4 +281,17 @@ func htmlToMarkdown(content string) string {
 		return content
 	}
 	return md
+}
+
+// escapedImageSyntaxPattern matches markdown image references whose `[` was
+// over-escaped to `\[` by html-to-markdown. The URL group mirrors the
+// downstream image-extraction regex so escapes are only stripped for actual
+// image references.
+var escapedImageSyntaxPattern = regexp.MustCompile(`!\\\[(.*?)\\?\]\(([^()\n]*(?:\([^)]*\)[^()\n]*)*)\)`)
+
+// unescapeMarkdownImageSyntax restores `![alt](url)` from html-to-markdown's
+// over-escaped `!\[alt\](url)` form. Without this, the downstream image regex
+// in ImageResolver fails to match and images are never persisted.
+func unescapeMarkdownImageSyntax(content string) string {
+	return escapedImageSyntaxPattern.ReplaceAllString(content, "![$1]($2)")
 }


### PR DESCRIPTION
## Description
MinerU 返回的 `md_content` 是 Markdown 与内嵌 HTML 块（如 `<table>`）的混合体。当前实现整体丢给 `html-to-markdown` 处理，导致已经合法的 Markdown 图片语法 `![](...)` 被过度转义为 `!\[\](...)`，下游 `ImageResolver` 的图片提取正则匹配不到这种被转义的形式，最终在解析结果里丢图。

本次在 `htmlToMarkdown` 之后增加 `unescapeMarkdownImageSyntax`，仅针对图片引用回退转义，不影响其他 Markdown 转义。

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #

## Testing
- 构造一份包含图片的 MinerU 解析结果，确认转换后的 Markdown 中 `![](...)` 不再带反斜杠。
- 走一次完整文档解析流程，确认图片可被 `ImageResolver` 正常识别并持久化。
- 对纯 HTML（无图片）输入回归一遍，确认没有副作用。

## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
N/A — 无用户可见 UI 变化。
