### PR TITLE
fix(moonshot): pin temperature=1 for models that reject other values

### DIFF
--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -285,7 +285,15 @@ func (c *RemoteAPIChat) BuildChatCompletionRequest(messages []Message, opts *Cha
 		isOpenAIReasoning := (c.provider == provider.ProviderOpenAI || c.provider == provider.ProviderAzureOpenAI) &&
 			provider.IsOpenAIReasoningOrGPT5Model(c.modelName)
 
-		if !isOpenAIReasoning {
+		// Moonshot v1 系列模型只接受 temperature=1，传入其他值会返回 400 错误。
+		isMoonshotFixedTemp := c.provider == provider.ProviderMoonshot &&
+			provider.IsMoonshotFixedTempModel(c.modelName)
+
+		if isOpenAIReasoning {
+			// 不设置 temperature / top_p 等参数
+		} else if isMoonshotFixedTemp {
+			req.Temperature = 1
+		} else {
 			req.Temperature = float32(opts.Temperature)
 			if opts.TopP > 0 {
 				req.TopP = float32(opts.TopP)

--- a/internal/models/provider/moonshot.go
+++ b/internal/models/provider/moonshot.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Tencent/WeKnora/internal/types"
 )
@@ -9,6 +10,26 @@ import (
 const (
 	MoonshotBaseURL = "https://api.moonshot.ai/v1"
 )
+
+// IsMoonshotFixedTempModel reports whether the given Moonshot/Kimi model
+// only accepts temperature=1. The following models reject any temperature
+// value other than 1:
+//   - moonshot-v1 series (moonshot-v1-8k, moonshot-v1-32k, moonshot-v1-128k)
+//   - kimi-k2.5 and kimi-k2.6 (no temperature param in API docs)
+//
+// kimi-k2 / kimi-k2-turbo / kimi-k2-thinking models accept the full [0,1]
+// range and are NOT affected.
+func IsMoonshotFixedTempModel(modelName string) bool {
+	name := strings.ToLower(strings.TrimSpace(modelName))
+	if strings.HasPrefix(name, "moonshot-v1") {
+		return true
+	}
+	// kimi-k2.5, kimi-k2.6 — no temperature parameter supported
+	if name == "kimi-k2.5" || name == "kimi-k2.6" {
+		return true
+	}
+	return false
+}
 
 // MoonshotProvider 实现 Moonshot AI (Kimi) 的 Provider 接口
 type MoonshotProvider struct{}


### PR DESCRIPTION
## Description
`moonshot-v1-*`（8k / 32k / 128k）以及 `kimi-k2.5` / `kimi-k2.6` 在 API 层面只接受 `temperature=1`，传任意其它值都会返回 HTTP 400。当前 `BuildChatCompletionRequest` 会把用户传入的 `opts.Temperature` 透传给这些模型，导致线上调用失败。

本次新增 `provider.IsMoonshotFixedTempModel` 做模型识别，命中时强制 `Temperature = 1`；未命中的 `kimi-k2` / `kimi-k2-turbo` / `kimi-k2-thinking` 保持原有可调行为。

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #

## Testing
- 使用 `moonshot-v1-8k` 调一次 chat，确认请求体里 `temperature=1` 且返回正常。
- 使用 `kimi-k2-turbo` 调一次 chat，确认 `temperature` 仍按用户设置传递。
- 验证 `IsMoonshotFixedTempModel` 对大小写、前后空格、`moonshot-v1-128k` 等输入均能正确判定。

## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
N/A — 无用户可见 UI 变化。
