### PR TITLE
fix(auth): unify DISABLE_REGISTRATION and auth.registration_mode

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -132,12 +132,13 @@ Environment overrides (always win over YAML):
 | `WEKNORA_TENANT_ENABLE_RBAC`         | `tenant.enable_rbac`           | `true` / `false`             |
 | `WEKNORA_AUDIT_RETENTION_DAYS`       | `audit.retention_days`         | non-negative integer         |
 
-`auth.registration_mode` is intentionally not env-overridable to avoid
-duplicating the long-standing `DISABLE_REGISTRATION` env knob. Set
-`auth.registration_mode: invite_only` in `config.yaml` when you want the
-frontend to hide the registration entry in addition to the server-side
-block; use `DISABLE_REGISTRATION=true` for a quick env-level kill switch
-that only enforces server-side.
+`auth.registration_mode` has no dedicated env override to avoid
+duplicating the long-standing `DISABLE_REGISTRATION` env knob. When
+`DISABLE_REGISTRATION=true` is set, startup coerces
+`auth.registration_mode` to `invite_only` so both the API gate and the
+`/auth/config`-driven UI gate (frontend hides the registration entry)
+stay consistent. To pick a mode without the env var, set
+`auth.registration_mode` in `config.yaml`.
 
 The startup logger emits one line summarising both effective values
 plus their override sources, so you can confirm at boot which mode

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -130,8 +130,14 @@ Environment overrides (always win over YAML):
 | Env var                              | YAML key                       | Values                       |
 |--------------------------------------|--------------------------------|------------------------------|
 | `WEKNORA_TENANT_ENABLE_RBAC`         | `tenant.enable_rbac`           | `true` / `false`             |
-| `WEKNORA_AUTH_REGISTRATION_MODE`     | `auth.registration_mode`       | `self_serve` / `invite_only` |
 | `WEKNORA_AUDIT_RETENTION_DAYS`       | `audit.retention_days`         | non-negative integer         |
+
+`auth.registration_mode` is intentionally not env-overridable to avoid
+duplicating the long-standing `DISABLE_REGISTRATION` env knob. Set
+`auth.registration_mode: invite_only` in `config.yaml` when you want the
+frontend to hide the registration entry in addition to the server-side
+block; use `DISABLE_REGISTRATION=true` for a quick env-level kill switch
+that only enforces server-side.
 
 The startup logger emits one line summarising both effective values
 plus their override sources, so you can confirm at boot which mode

--- a/internal/config/auth_legacy_env_test.go
+++ b/internal/config/auth_legacy_env_test.go
@@ -1,0 +1,43 @@
+package config
+
+import "testing"
+
+// TestApplyAuthAndTenantDefaults_DisableRegistrationDrivesRegistrationMode
+// pins down the env-vs-YAML contract for DISABLE_REGISTRATION. Without this,
+// DISABLE_REGISTRATION=true would block /auth/register at the handler layer
+// but leave /auth/config reporting self_serve, so the frontend would keep
+// showing the (broken) Register entry. Coercing registration_mode here keeps
+// both gates in sync, and matches the docs/rbac.md "env always wins over
+// YAML" rule.
+func TestApplyAuthAndTenantDefaults_DisableRegistrationDrivesRegistrationMode(t *testing.T) {
+	cases := []struct {
+		name     string
+		disable  string // value for DISABLE_REGISTRATION (empty == unset)
+		cfgMode  string // pre-set value on cfg.Auth.RegistrationMode
+		expected string
+	}{
+		{"true coerces empty YAML to invite_only", "true", "", AuthRegistrationModeInviteOnly},
+		{"case-insensitive TRUE also coerces", "TRUE", "", AuthRegistrationModeInviteOnly},
+		{"true overrides explicit self_serve YAML", "true", AuthRegistrationModeSelfServe, AuthRegistrationModeInviteOnly},
+		{"true is a no-op when YAML already invite_only", "true", AuthRegistrationModeInviteOnly, AuthRegistrationModeInviteOnly},
+		{"false leaves YAML untouched", "false", AuthRegistrationModeSelfServe, AuthRegistrationModeSelfServe},
+		{"unset falls back to default self_serve", "", "", AuthRegistrationModeSelfServe},
+		{"unset keeps explicit invite_only YAML", "", AuthRegistrationModeInviteOnly, AuthRegistrationModeInviteOnly},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("DISABLE_REGISTRATION", tc.disable)
+			// Other tenant env vars must not leak between cases.
+			t.Setenv("WEKNORA_TENANT_ENABLE_RBAC", "")
+			t.Setenv("WEKNORA_TENANT_MAX_OWNED_PER_USER", "")
+
+			cfg := &Config{Auth: &AuthConfig{RegistrationMode: tc.cfgMode}}
+			applyAuthAndTenantDefaults(cfg)
+
+			if cfg.Auth.RegistrationMode != tc.expected {
+				t.Fatalf("registration_mode = %q, want %q", cfg.Auth.RegistrationMode, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -713,18 +713,29 @@ func applyAgentEnvOverrides(cfg *Config) {
 //     Unparseable / empty values are ignored so a stale shell variable
 //     can't silently disable the quota for a future deployment.
 //
-// Note: auth.registration_mode is intentionally NOT env-overridable.
-// Operators who need to turn off public registration set the legacy
-// DISABLE_REGISTRATION=true env (handled at the /auth/register handler
-// layer) or flip auth.registration_mode in config.yaml; the env layer
-// keeps a single knob to avoid two redundant ways of saying the same
-// thing.
+// Note: auth.registration_mode has no dedicated env override. The
+// long-standing DISABLE_REGISTRATION=true env var is the single env-layer
+// knob and, when set, coerces registration_mode to invite_only here. That
+// way both the API gate (handler) and the /auth/config-driven UI gate
+// (frontend hides the register entry) stay consistent — without needing
+// two parallel env vars.
 func applyAuthAndTenantDefaults(cfg *Config) {
 	if cfg.Auth == nil {
 		cfg.Auth = &AuthConfig{}
 	}
 	if cfg.Tenant == nil {
 		cfg.Tenant = &TenantConfig{}
+	}
+
+	if legacy := strings.TrimSpace(os.Getenv("DISABLE_REGISTRATION")); strings.EqualFold(legacy, "true") {
+		prev := strings.TrimSpace(cfg.Auth.RegistrationMode)
+		cfg.Auth.RegistrationMode = AuthRegistrationModeInviteOnly
+		if prev != "" && prev != AuthRegistrationModeInviteOnly {
+			fmt.Printf(
+				"[config] DISABLE_REGISTRATION=true overrides auth.registration_mode=%q -> %q\n",
+				prev, AuthRegistrationModeInviteOnly,
+			)
+		}
 	}
 
 	if strings.TrimSpace(cfg.Auth.RegistrationMode) == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -707,12 +707,18 @@ func applyAgentEnvOverrides(cfg *Config) {
 //   - tenant.enable_rbac      -> false (rolled out in two steps; flip later)
 //
 // Env overrides (when set and non-empty):
-//   - WEKNORA_AUTH_REGISTRATION_MODE  ("self_serve" or "invite_only")
 //   - WEKNORA_TENANT_ENABLE_RBAC      ("true"/"false", case-insensitive)
 //   - WEKNORA_TENANT_MAX_OWNED_PER_USER (integer; <0 disables the cap,
 //     0 falls back to the handler default, >0 enforces that exact cap).
 //     Unparseable / empty values are ignored so a stale shell variable
 //     can't silently disable the quota for a future deployment.
+//
+// Note: auth.registration_mode is intentionally NOT env-overridable.
+// Operators who need to turn off public registration set the legacy
+// DISABLE_REGISTRATION=true env (handled at the /auth/register handler
+// layer) or flip auth.registration_mode in config.yaml; the env layer
+// keeps a single knob to avoid two redundant ways of saying the same
+// thing.
 func applyAuthAndTenantDefaults(cfg *Config) {
 	if cfg.Auth == nil {
 		cfg.Auth = &AuthConfig{}
@@ -721,9 +727,6 @@ func applyAuthAndTenantDefaults(cfg *Config) {
 		cfg.Tenant = &TenantConfig{}
 	}
 
-	if value := strings.TrimSpace(os.Getenv("WEKNORA_AUTH_REGISTRATION_MODE")); value != "" {
-		cfg.Auth.RegistrationMode = value
-	}
 	if strings.TrimSpace(cfg.Auth.RegistrationMode) == "" {
 		cfg.Auth.RegistrationMode = AuthRegistrationModeSelfServe
 	}

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -70,17 +69,11 @@ func (h *AuthHandler) Register(c *gin.Context) {
 
 	logger.Info(ctx, "Start user registration")
 
-	// 通过环境变量 DISABLE_REGISTRATION=true 禁止注册
-	if os.Getenv("DISABLE_REGISTRATION") == "true" {
-		logger.Warn(ctx, "Registration is disabled by DISABLE_REGISTRATION env")
-		appErr := errors.NewForbiddenError("Registration is disabled")
-		c.Error(appErr)
-		return
-	}
-
 	// 当 auth.registration_mode=invite_only 时，public 注册被关闭。
 	// 新成员只能由 Owner 通过 /tenants/:id/members 添加（PR 3 of #1303）。
 	// 前端在 PR 1 已经会读 /auth/config 隐藏注册入口；这里是直接 API 调用的兜底。
+	// 历史变量 DISABLE_REGISTRATION=true 在 config 启动阶段已被等价提升为
+	// invite_only，因此这里只剩一条 gate。
 	if h.configInfo != nil && h.configInfo.Auth != nil && h.configInfo.Auth.IsInviteOnly() {
 		logger.Warn(ctx, "Registration rejected: auth.registration_mode=invite_only")
 		appErr := errors.NewForbiddenError("Registration is invite-only")


### PR DESCRIPTION
## Summary

Two issues were tangled together at the registration-control surface:

1. **Redundant env knobs.** `DISABLE_REGISTRATION=true` (handler layer) and `WEKNORA_AUTH_REGISTRATION_MODE=invite_only` (config layer) were two env-level ways of saying the same thing: block `/auth/register`. Keeping both invites confusion about which wins.
2. **Out-of-sync gates.** `DISABLE_REGISTRATION=true` blocked the API but `/auth/config` kept reporting `self_serve`, so the frontend still rendered the Register entry — clicking it just hit a 403.

This PR collapses both into a single, consistent story:

- **Drop the `WEKNORA_AUTH_REGISTRATION_MODE` env override.** The YAML field `auth.registration_mode` (and its `invite_only` enforcement) stays — operators who want config-file control still have it.
- **Make `DISABLE_REGISTRATION=true` drive `auth.registration_mode`.** At startup it coerces the mode to `invite_only`, so both the server-side gate and the `/auth/config`-driven UI gate stay in sync. Matches the existing "env always wins over YAML" rule documented in `docs/rbac.md`.
- **Collapse the two handler gates into one.** `IsInviteOnly()` now covers both paths; the `os.Getenv(\"DISABLE_REGISTRATION\")` check in `Register` and the unused `os` import are removed.

No behaviour change for deployments that didn't set the env var.

## Files

- `internal/config/config.go` — drop `WEKNORA_AUTH_REGISTRATION_MODE` override; add `DISABLE_REGISTRATION=true` → `invite_only` coercion (logs when it overrides an explicit YAML value).
- `internal/handler/auth.go` — remove the redundant env check in `Register`; drop the `os` import.
- `internal/config/auth_legacy_env_test.go` — new test pinning down the env/YAML matrix (coerces empty, overrides explicit self_serve, no-op when already invite_only, unset leaves YAML untouched, etc.).
- `docs/rbac.md` — remove the row from the env-mapping table and document the new contract.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/config/... ./internal/handler/...`
- [x] `go test ./internal/config/ ./internal/handler/ -run 'Register|Auth|Disable' -count=1` — new config matrix + existing invite_only/self_serve handler tests all pass.
- [ ] Operator sanity: set `DISABLE_REGISTRATION=true`, restart, confirm `/auth/config` reports `invite_only` and the frontend Register tab is hidden; clear the var, confirm self_serve restored.