### PR TITLE
style(menu): tighten session list density in sidebar

### DIFF
--- a/frontend/src/components/menu.vue
+++ b/frontend/src/components/menu.vue
@@ -1194,9 +1194,9 @@ const onDragHandleMouseDown = (e: MouseEvent) => {
         font-size: 11px;
         font-weight: 600;
         color: var(--td-text-color-disabled);
-        padding: 8px 14px 4px 14px;
-        margin-top: 6px;
-        line-height: 18px;
+        padding: 6px 14px 3px 14px;
+        margin-top: 4px;
+        line-height: 17px;
         user-select: none;
         animation: menuItemFadeIn 0.25s ease-out;
 
@@ -1206,8 +1206,8 @@ const onDragHandleMouseDown = (e: MouseEvent) => {
     }
 
     .submenu_item_p {
-        height: 38px;
-        padding: 2px 0px 2px 0px;
+        height: 34px;
+        padding: 1px 0px 1px 0px;
         box-sizing: border-box;
         animation: menuItemFadeIn 0.25s ease-out;
     }
@@ -1219,8 +1219,8 @@ const onDragHandleMouseDown = (e: MouseEvent) => {
         align-items: center;
         color: var(--td-text-color-primary);
         font-weight: 400;
-        line-height: 20px;
-        height: 32px;
+        line-height: 19px;
+        height: 30px;
         padding-left: 0px;
         padding-right: 10px;
         position: relative;


### PR DESCRIPTION
## Summary
- Tighten the chat session list in the left sidebar so more sessions fit on screen without feeling cramped.
- Row container height 38→34px, item height 32→30px (line-height 20→19), with 1px vertical padding.
- Timeline group headers: padding 8/4→6/3, margin-top 6→4px, line-height 18→17px.

## Test plan
- [ ] Open the app, verify the session list looks denser but still has comfortable hover/active padding.
- [ ] Verify pinned/source-icon/title alignment remains correct.
- [ ] Verify batch-mode rows and the active session highlight still render correctly.
- [ ] Verify timeline headers (Today / Yesterday / etc.) still group cleanly without overlap.