### PR TITLE
fix(menu): avoid refreshing session list when opening an existing chat

### DIFF
--- a/frontend/src/components/menu.vue
+++ b/frontend/src/components/menu.vue
@@ -709,14 +709,17 @@ watch([() => route.name, () => route.params], (newvalue, oldvalue) => {
 
     // 只在必要时刷新对话列表，避免不必要的重新加载导致列表抖动
     // 需要刷新的情况：
-    // 1. 创建新会话后（从 creatChat/kbCreatChat 跳转到 chat/:id）
+    // 1. 创建新会话后（从 creatChat/kbCreatChat 跳转到 chat/:id 且该 id 不在列表里）
     // 2. 删除会话后已在 delCard 中处理，不需要在这里刷新
     const oldRouteNameStr = typeof oldvalue?.[0] === 'string' ? (oldvalue[0] as string) : (oldvalue?.[0] ? String(oldvalue[0]) : '')
-    const isCreatingNewSession = (oldRouteNameStr === 'globalCreatChat' || oldRouteNameStr === 'kbCreatChat') &&
+    const leavingCreatChat = (oldRouteNameStr === 'globalCreatChat' || oldRouteNameStr === 'kbCreatChat') &&
         nameStr !== 'globalCreatChat' && nameStr !== 'kbCreatChat';
+    // 只有跳转到的目标会话不在当前列表里，才认为是"刚创建的新会话"，
+    // 避免从 creatChat 点击已有 session 时把整个列表清空重拉造成抖动。
+    const newChatId = (newvalue[1] as any)?.chatid as string | undefined;
+    const targetIsNewSession = !!newChatId && !allSessionIds.value.includes(newChatId);
 
-    // 只在创建新会话时才刷新列表
-    if (isCreatingNewSession) {
+    if (leavingCreatChat && targetIsNewSession) {
         getMessageList();
     }
 


### PR DESCRIPTION
## Summary
- The sidebar route watcher in `frontend/src/components/menu.vue` treated **any** navigation away from `globalCreatChat` / `kbCreatChat` as "a new session was just created" and called `getMessageList()`, which clears `menuArr` and re-fetches page 1.
- As a result, simply clicking an existing session from `/platform/creatChat` (e.g. opening `/platform/chat/<existing-id>`) made the whole session list flicker.
- Now we only refresh when the target chat id is not already present in the loaded list — the real signal that a brand-new session was just created.

## Test plan
- [ ] Open `/platform/creatChat`, then click an existing session in the sidebar. The list should NOT clear/reload (no flicker).
- [ ] On `/platform/creatChat`, send a first message that creates a new session. After the navigation to `/platform/chat/<new-id>`, the new session should appear in the sidebar list (still triggers a refresh because the new id isn't in the list yet).
- [ ] Same for the KB-scoped variant: from `/platform/knowledge-bases/<kb>/creatChat`, opening an existing chat under that KB should not cause the list to refresh.
- [ ] Deleting / clearing sessions still behaves as before (handled in their own paths, not in this watcher).