### PR TITLE
fix(menu): stop truncating session titles when extra space is available

### DIFF
--- a/frontend/src/components/menu.vue
+++ b/frontend/src/components/menu.vue
@@ -108,7 +108,7 @@
                                     :checked="batchSelectedIds.includes(subitem.id)" @click.stop
                                     @change="toggleBatchSelect(subitem.id)" />
                                 <span class="submenu_title"
-                                    :style="batchMode ? 'margin-left:4px;max-width:165px;' : (currentSecondpath == subitem.path ? 'margin-left:14px;max-width:155px;' : 'margin-left:14px;max-width:178px;')">
+                                    :style="batchMode ? 'margin-left:4px;' : 'margin-left:14px;'">
                                     <t-icon v-if="subitem.is_pinned" name="pin" class="submenu_pin_icon"
                                         :title="t('menu.pinned')" />
                                     <img v-if="subitem.im_platform && platformLogo(subitem.im_platform)"
@@ -1229,15 +1229,17 @@ const onDragHandleMouseDown = (e: MouseEvent) => {
         position: relative;
 
         .submenu_title {
+            flex: 1 1 auto;
+            min-width: 0;
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
         }
 
         .menu-more-wrap {
-            margin-left: auto;
             opacity: 0;
             transition: opacity 0.2s ease;
+            flex-shrink: 0;
         }
 
         .menu-more {
@@ -1262,11 +1264,6 @@ const onDragHandleMouseDown = (e: MouseEvent) => {
             .menu-more-wrap {
                 opacity: 1;
             }
-
-            .submenu_title {
-                max-width: 155px !important;
-
-            }
         }
     }
 
@@ -1281,10 +1278,6 @@ const onDragHandleMouseDown = (e: MouseEvent) => {
 
         .menu-more-wrap {
             opacity: 1;
-        }
-
-        .submenu_title {
-            max-width: 155px !important;
         }
     }
 


### PR DESCRIPTION
## Summary
- The sidebar session list items forced `.submenu_title` to `max-width: 155px !important` on hover and on the active row, while `.menu-more-wrap` was pinned to the right edge with `margin-left: auto`. As a result, even when a row had plenty of horizontal space, the title was clipped with `…` and a noticeable empty gap appeared between the title and the kebab button.
- Switch the title to a flex layout (`flex: 1; min-width: 0`) so it grows to fill the remaining row space, and only shows an ellipsis when the text genuinely overflows.
- Mark `.menu-more-wrap` as `flex-shrink: 0`. It keeps `opacity: 0/1` for hover toggling, so it always reserves the same width and the layout no longer reshapes when entering hover.

## Test plan
- [ ] Short title (e.g. "测试"): no ellipsis, kebab button on the right, no gap.
- [ ] Long title that previously got cut at 155px: now uses the full row width before showing `…`.
- [ ] Hover/active states render the title at the same width as non-hover (no jump).
- [ ] Rows with pin icon and/or platform logo still align correctly and truncate at the right boundary.
- [ ] Batch-mode rows (with the checkbox) still render with the tighter left margin and don't overlap the checkbox.