### PR TITLE
fix(i18n): escape '@' in invite email placeholder

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -4469,7 +4469,7 @@ export default {
       button: 'Add Member',
       dialogTitle: 'Invite Member',
       emailLabel: 'Email',
-      emailPlaceholder: 'invitee@example.com',
+      emailPlaceholder: "invitee{'@'}example.com",
       roleLabel: 'Role',
       submit: 'Invite',
       success: 'Member added',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -4529,7 +4529,7 @@ export default {
       button: "멤버 초대",
       dialogTitle: "멤버 초대",
       emailLabel: "이메일",
-      emailPlaceholder: "invitee@example.com",
+      emailPlaceholder: "invitee{'@'}example.com",
       roleLabel: "역할",
       submit: "초대",
       success: "멤버를 추가했습니다",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -4429,7 +4429,7 @@ export default {
       button: 'Пригласить',
       dialogTitle: 'Пригласить участника',
       emailLabel: 'Email',
-      emailPlaceholder: 'invitee@example.com',
+      emailPlaceholder: "invitee{'@'}example.com",
       roleLabel: 'Роль',
       submit: 'Пригласить',
       success: 'Участник добавлен',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -4461,7 +4461,7 @@ export default {
       button: "邀请成员",
       dialogTitle: "邀请成员",
       emailLabel: "邮箱",
-      emailPlaceholder: "invitee@example.com",
+      emailPlaceholder: "invitee{'@'}example.com",
       roleLabel: "角色",
       submit: "邀请",
       success: "已添加成员",


### PR DESCRIPTION
## Summary
- The placeholder `invitee@example.com` in `tenantMember.add.emailPlaceholder` triggered a vue-i18n compile error `Invalid linked format`, because vue-i18n treats a bare `@` as the start of a [linked message](https://vue-i18n.intlify.dev/guide/essentials/syntax.html#linked-messages) reference.
- The error surfaced when rendering the invite-member popup: the email `t-form-item` failed to render, so the dialog showed only the role row (no email input, no email label) plus a `SyntaxError` in the console.
- Fix: escape the literal `@` as `{'@'}` in all four locale files (`zh-CN`, `en-US`, `ko-KR`, `ru-RU`). At runtime vue-i18n still emits `invitee@example.com` for the user.

## Test plan
- [ ] `make dev-frontend`, open Settings → Tenant members → Invite member.
- [ ] Verify the email row renders with label "邮箱" / "Email" and the placeholder reads `invitee@example.com` (literal `@`).
- [ ] No `Invalid linked format` / `SyntaxError` in the console.
- [ ] Switch language to en-US / ko-KR / ru-RU and re-check the popup.