### PR TITLE
fix(frontend): mirror cross-tenant superuser Admin role in UI gates

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -114,7 +114,16 @@ export const useAuthStore = defineStore('auth', () => {
         : ''
     if (!tid) return ''
     const match = memberships.value.find((m) => String(m.tenant_id) === tid)
-    return match?.role || ''
+    if (match?.role) return match.role
+    // Cross-tenant superuser visiting a tenant they're not a member of:
+    // backend auth.go resolveTenantRole step2 grants a temporary Admin
+    // role without writing tenant_members. Mirror that here so mutation
+    // UIs aren't hidden in tenants the superuser switched into. Never
+    // surface Owner — the backend caps the temporary grant at Admin too
+    // (Owner-only ops like tenant deletion stay reserved for a real
+    // Owner inside the target tenant).
+    if (canAccessAllTenants.value) return 'admin'
+    return ''
   })
 
   // hasRole answers "is the current tenant role at least <min>?", used by


### PR DESCRIPTION
When a CanAccessAllTenants user switches into a tenant without a tenant_members row, the backend grants temporary Admin via resolveTenantRole step2 but currentTenantRole stayed empty, hiding all mutation controls. Fall back to admin for UI gating only; Owner surfaces remain hidden to match the server cap.
