### PR TITLE
fix(knowledge): complete indexed documents immediately

### DIFF
--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -142,6 +142,34 @@ type ProcessChunksOptions struct {
 	Metadata     map[string]string
 }
 
+// finalizeIndexedKnowledgeState marks a document searchable as soon as chunks
+// and indexes are persisted; post-processing tasks should not keep parsing UI
+// indicators alive once retrieval can use the document.
+func finalizeIndexedKnowledgeState(
+	knowledge *types.Knowledge,
+	totalStorageSize int64,
+	textChunkCount int,
+	hasPendingMultimodal bool,
+	now time.Time,
+) {
+	if hasPendingMultimodal {
+		knowledge.ParseStatus = types.ParseStatusProcessing
+		knowledge.SummaryStatus = types.SummaryStatusNone
+	} else {
+		knowledge.ParseStatus = types.ParseStatusCompleted
+		if textChunkCount > 0 {
+			knowledge.SummaryStatus = types.SummaryStatusPending
+		} else {
+			knowledge.SummaryStatus = types.SummaryStatusNone
+		}
+	}
+
+	knowledge.EnableStatus = "enabled"
+	knowledge.StorageSize = totalStorageSize
+	knowledge.ProcessedAt = &now
+	knowledge.UpdatedAt = now
+}
+
 // buildSplitterConfig creates a SplitterConfig with fallbacks from a KnowledgeBase.
 // Defaults mirror chunker.DefaultChunkSize / DefaultChunkOverlap so behavior is
 // identical whether callers come through this path or invoke the chunker
@@ -559,15 +587,14 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	pendingMultimodal := isImage && options.EnableMultimodel && len(options.StoredImages) > 0
 	pendingPDFMultimodal := !isImage && !isVideo && options.EnableMultimodel && len(options.StoredImages) > 0
 
-	// For image files or documents with pending multimodal processing, keep "processing" status
-	if pendingMultimodal || pendingPDFMultimodal {
-		knowledge.ParseStatus = types.ParseStatusProcessing
-	}
-	knowledge.EnableStatus = "enabled"
-	knowledge.StorageSize = totalStorageSize
 	now := time.Now()
-	knowledge.ProcessedAt = &now
-	knowledge.UpdatedAt = now
+	finalizeIndexedKnowledgeState(
+		knowledge,
+		totalStorageSize,
+		len(textChunks),
+		pendingMultimodal || pendingPDFMultimodal,
+		now,
+	)
 
 	if err := s.repo.UpdateKnowledge(ctx, knowledge); err != nil {
 		logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks update knowledge failed")

--- a/internal/application/service/knowledge_process_status_test.go
+++ b/internal/application/service/knowledge_process_status_test.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestFinalizeIndexedKnowledgeState(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name                 string
+		hasPendingMultimodal bool
+		textChunkCount       int
+		wantParseStatus      string
+		wantSummaryStatus    string
+	}{
+		{
+			name:              "text document is completed once chunks are indexed",
+			textChunkCount:    2,
+			wantParseStatus:   types.ParseStatusCompleted,
+			wantSummaryStatus: types.SummaryStatusPending,
+		},
+		{
+			name:              "empty indexed document is completed without summary work",
+			textChunkCount:    0,
+			wantParseStatus:   types.ParseStatusCompleted,
+			wantSummaryStatus: types.SummaryStatusNone,
+		},
+		{
+			name:                 "document waits while multimodal image work is pending",
+			hasPendingMultimodal: true,
+			textChunkCount:       2,
+			wantParseStatus:      types.ParseStatusProcessing,
+			wantSummaryStatus:    types.SummaryStatusNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			knowledge := &types.Knowledge{
+				ParseStatus:   types.ParseStatusProcessing,
+				SummaryStatus: types.SummaryStatusCompleted,
+			}
+
+			finalizeIndexedKnowledgeState(knowledge, 4096, tt.textChunkCount, tt.hasPendingMultimodal, now)
+
+			if knowledge.ParseStatus != tt.wantParseStatus {
+				t.Fatalf("ParseStatus = %q, want %q", knowledge.ParseStatus, tt.wantParseStatus)
+			}
+			if knowledge.SummaryStatus != tt.wantSummaryStatus {
+				t.Fatalf("SummaryStatus = %q, want %q", knowledge.SummaryStatus, tt.wantSummaryStatus)
+			}
+			if knowledge.EnableStatus != "enabled" {
+				t.Fatalf("EnableStatus = %q, want enabled", knowledge.EnableStatus)
+			}
+			if knowledge.StorageSize != 4096 {
+				t.Fatalf("StorageSize = %d, want 4096", knowledge.StorageSize)
+			}
+			if knowledge.ProcessedAt == nil || !knowledge.ProcessedAt.Equal(now) {
+				t.Fatalf("ProcessedAt = %v, want %v", knowledge.ProcessedAt, now)
+			}
+			if !knowledge.UpdatedAt.Equal(now) {
+				t.Fatalf("UpdatedAt = %v, want %v", knowledge.UpdatedAt, now)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- mark documents as completed as soon as chunks and retrieval indexes are persisted when no multimodal work is pending
- keep image / document multimodal flows in processing until OCR/caption post-processing finishes
- set summary status independently so summary/question/wiki post-processing can continue without keeping the parsing UI alive

Fixes #1397

## Tests
- go test ./internal/application/service -run TestFinalizeIndexedKnowledgeState -count=1
- CGO_LDFLAGS='-lc++' go test ./internal/application/service -count=1
- CGO_LDFLAGS='-lc++' go test ./internal/application/... -count=1

Note: the broad application test run passed for the changed service/repository/chat_pipeline packages; it still reports the existing unrelated internal/application/service/file TestOssEnsureBucket_CreateFails failure in this local environment.