### PR TITLE
feat(frontend): make Vite dev proxy target configurable

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,10 @@ const require = createRequire(import.meta.url)
 
 const pkg = require('./package.json') as { version?: string }
 const FRONTEND_VERSION = pkg.version ?? 'unknown'
+const DEV_PROXY_TARGET =
+  process.env.VITE_DEV_PROXY_TARGET ||
+  process.env.FRONTEND_BACKEND_URL ||
+  'http://localhost:8080'
 
 function resolveVueOfficePptxEntry(): string {
   try {
@@ -47,12 +51,12 @@ export default defineConfig({
     // 代理配置，用于开发环境
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: DEV_PROXY_TARGET,
         changeOrigin: true,
         secure: false,
       },
       '/files': {
-        target: 'http://localhost:8080',
+        target: DEV_PROXY_TARGET,
         changeOrigin: true,
         secure: false,
       }

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -319,6 +319,7 @@ start_frontend() {
     
     log_info "启动 Vite 开发服务器..."
     log_info "前端将运行在 http://localhost:5173"
+    log_info "前端 API 代理目标: ${VITE_DEV_PROXY_TARGET:-${FRONTEND_BACKEND_URL:-http://localhost:8080}}"
     
     # 运行开发服务器
     npm run dev


### PR DESCRIPTION
## Summary
- Allow overriding the Vite dev server API/file proxy target via `VITE_DEV_PROXY_TARGET` or `FRONTEND_BACKEND_URL` (default remains `http://localhost:8080`).
- Log the resolved proxy target when starting the frontend via `scripts/dev.sh`.

## Test plan
- [ ] Run `make dev-frontend` without env overrides; confirm log shows default target and `/api` proxies work.
- [ ] Set `VITE_DEV_PROXY_TARGET` to another backend URL and confirm proxy and log.
- [ ] Set only `FRONTEND_BACKEND_URL` and confirm fallback behavior.
