### PR TITLE
fix(session): scope wiki fixer to shared KB tenant

### DIFF
--- a/internal/handler/session/handler.go
+++ b/internal/handler/session/handler.go
@@ -24,6 +24,7 @@ type Handler struct {
 	customAgentService   interfaces.CustomAgentService   // Service for managing custom agents
 	tenantService        interfaces.TenantService        // Service for loading tenant (shared agent context)
 	agentShareService    interfaces.AgentShareService    // Service for resolving shared agents (KB scope in retrieval)
+	kbShareService       interfaces.KBShareService       // Service for resolving shared KB permissions
 	fileService          interfaces.FileService          // Service for file storage (image uploads)
 	modelService         interfaces.ModelService         // Service for model management (VLM access)
 	userService          interfaces.UserService          // Service for resolving per-user preferences (e.g. enable_memory default)
@@ -40,6 +41,7 @@ func NewHandler(
 	customAgentService interfaces.CustomAgentService,
 	tenantService interfaces.TenantService,
 	agentShareService interfaces.AgentShareService,
+	kbShareService interfaces.KBShareService,
 	fileService interfaces.FileService,
 	modelService interfaces.ModelService,
 	userService interfaces.UserService,
@@ -55,6 +57,7 @@ func NewHandler(
 		customAgentService:   customAgentService,
 		tenantService:        tenantService,
 		agentShareService:    agentShareService,
+		kbShareService:       kbShareService,
 		fileService:          fileService,
 		modelService:         modelService,
 		userService:          userService,

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -123,6 +123,23 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 	// Merge @mentioned items into knowledge_base_ids and knowledge_ids
 	kbIDs, knowledgeIDs := mergeKnowledgeTargets(request.KnowledgeBaseIDs, request.KnowledgeIds, request.MentionedItems)
 
+	// The built-in wiki fixer is invoked from a KB page, not from a tenant's
+	// regular agent picker. When the KB is shared, run it in the source tenant
+	// only if the caller has edit permission, so KB-scoped models/tools resolve
+	// without granting viewers write capability.
+	if customAgent != nil && customAgent.ID == types.BuiltinWikiFixerID {
+		if scopedAgent, scopedTenantID := h.resolveWikiFixerTenantScope(
+			ctx,
+			customAgent,
+			c.GetUint64(types.TenantIDContextKey.String()),
+			types.TenantRoleFromContext(ctx),
+			kbIDs,
+		); scopedTenantID != 0 {
+			customAgent = scopedAgent
+			effectiveTenantID = scopedTenantID
+		}
+	}
+
 	// Log merge results for debugging
 	logger.Infof(ctx, "[%s] @mention merge: request.KnowledgeBaseIDs=%v, request.MentionedItems=%d, merged kbIDs=%v, merged knowledgeIDs=%v",
 		logPrefix, request.KnowledgeBaseIDs, len(request.MentionedItems), kbIDs, knowledgeIDs)

--- a/internal/handler/session/wiki_fixer_scope.go
+++ b/internal/handler/session/wiki_fixer_scope.go
@@ -1,0 +1,80 @@
+package session
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+	secutils "github.com/Tencent/WeKnora/internal/utils"
+)
+
+type wikiFixerKBLookup interface {
+	GetKnowledgeBaseByIDOnly(ctx context.Context, id string) (*types.KnowledgeBase, error)
+}
+
+type wikiFixerKBSharePermission interface {
+	CheckTenantKBPermission(ctx context.Context, kbID string, callerTenantID uint64, callerTenantRole types.TenantRole) (types.OrgMemberRole, bool, error)
+}
+
+func (h *Handler) resolveWikiFixerTenantScope(
+	ctx context.Context,
+	agent *types.CustomAgent,
+	currentTenantID uint64,
+	callerTenantRole types.TenantRole,
+	kbIDs []string,
+) (*types.CustomAgent, uint64) {
+	return resolveBuiltinWikiFixerTenantScope(
+		ctx,
+		agent,
+		currentTenantID,
+		callerTenantRole,
+		kbIDs,
+		h.knowledgebaseService,
+		h.kbShareService,
+	)
+}
+
+func resolveBuiltinWikiFixerTenantScope(
+	ctx context.Context,
+	agent *types.CustomAgent,
+	currentTenantID uint64,
+	callerTenantRole types.TenantRole,
+	kbIDs []string,
+	kbLookup wikiFixerKBLookup,
+	kbShare wikiFixerKBSharePermission,
+) (*types.CustomAgent, uint64) {
+	if agent == nil || agent.ID != types.BuiltinWikiFixerID {
+		return agent, 0
+	}
+	if currentTenantID == 0 || len(kbIDs) != 1 || kbLookup == nil || kbShare == nil {
+		return agent, 0
+	}
+
+	kbID := kbIDs[0]
+	kb, err := kbLookup.GetKnowledgeBaseByIDOnly(ctx, kbID)
+	if err != nil {
+		logger.Warnf(ctx, "wiki fixer: failed to resolve KB %s for shared scope: %v", secutils.SanitizeForLog(kbID), err)
+		return agent, 0
+	}
+	if kb == nil {
+		logger.Warnf(ctx, "wiki fixer: KB %s not found for shared scope", secutils.SanitizeForLog(kbID))
+		return agent, 0
+	}
+	if kb.TenantID == 0 || kb.TenantID == currentTenantID {
+		return agent, 0
+	}
+
+	permission, isShared, err := kbShare.CheckTenantKBPermission(ctx, kb.ID, currentTenantID, callerTenantRole)
+	if err != nil {
+		logger.Warnf(ctx, "wiki fixer: failed to check shared KB %s permission: %v", secutils.SanitizeForLog(kb.ID), err)
+		return agent, 0
+	}
+	if !isShared || !permission.HasPermission(types.OrgRoleEditor) {
+		return agent, 0
+	}
+
+	scopedAgent := *agent
+	scopedAgent.TenantID = kb.TenantID
+	logger.Infof(ctx, "wiki fixer: using shared KB source tenant %d for KB %s", kb.TenantID, secutils.SanitizeForLog(kb.ID))
+	return &scopedAgent, kb.TenantID
+}

--- a/internal/handler/session/wiki_fixer_scope_test.go
+++ b/internal/handler/session/wiki_fixer_scope_test.go
@@ -1,0 +1,177 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+type wikiFixerKBLookupStub struct {
+	kb         *types.KnowledgeBase
+	err        error
+	calledWith string
+}
+
+func (s *wikiFixerKBLookupStub) GetKnowledgeBaseByIDOnly(_ context.Context, id string) (*types.KnowledgeBase, error) {
+	s.calledWith = id
+	return s.kb, s.err
+}
+
+type wikiFixerKBShareStub struct {
+	permission        types.OrgMemberRole
+	isShared          bool
+	err               error
+	checkedKBID       string
+	checkedTenantID   uint64
+	checkedTenantRole types.TenantRole
+}
+
+func (s *wikiFixerKBShareStub) CheckTenantKBPermission(
+	_ context.Context,
+	kbID string,
+	callerTenantID uint64,
+	callerTenantRole types.TenantRole,
+) (types.OrgMemberRole, bool, error) {
+	s.checkedKBID = kbID
+	s.checkedTenantID = callerTenantID
+	s.checkedTenantRole = callerTenantRole
+	return s.permission, s.isShared, s.err
+}
+
+func TestResolveBuiltinWikiFixerTenantScope_SharedEditorUsesSourceTenant(t *testing.T) {
+	agent := &types.CustomAgent{ID: types.BuiltinWikiFixerID, TenantID: 10, Name: "Wiki Fixer"}
+	kbLookup := &wikiFixerKBLookupStub{
+		kb: &types.KnowledgeBase{ID: "kb-shared", TenantID: 20, Name: "Shared KB"},
+	}
+	kbShare := &wikiFixerKBShareStub{
+		permission: types.OrgRoleEditor,
+		isShared:   true,
+	}
+
+	gotAgent, effectiveTenantID := resolveBuiltinWikiFixerTenantScope(
+		context.Background(),
+		agent,
+		10,
+		types.TenantRoleContributor,
+		[]string{"kb-shared"},
+		kbLookup,
+		kbShare,
+	)
+
+	require.NotSame(t, agent, gotAgent)
+	require.Equal(t, uint64(20), gotAgent.TenantID)
+	require.Equal(t, uint64(20), effectiveTenantID)
+	require.Equal(t, uint64(10), agent.TenantID, "must not mutate the cached built-in agent")
+	require.Equal(t, "kb-shared", kbLookup.calledWith)
+	require.Equal(t, "kb-shared", kbShare.checkedKBID)
+	require.Equal(t, uint64(10), kbShare.checkedTenantID)
+	require.Equal(t, types.TenantRoleContributor, kbShare.checkedTenantRole)
+}
+
+func TestResolveBuiltinWikiFixerTenantScope_SharedViewerDoesNotSwitchTenant(t *testing.T) {
+	agent := &types.CustomAgent{ID: types.BuiltinWikiFixerID, TenantID: 10}
+	kbLookup := &wikiFixerKBLookupStub{
+		kb: &types.KnowledgeBase{ID: "kb-shared", TenantID: 20},
+	}
+	kbShare := &wikiFixerKBShareStub{
+		permission: types.OrgRoleViewer,
+		isShared:   true,
+	}
+
+	gotAgent, effectiveTenantID := resolveBuiltinWikiFixerTenantScope(
+		context.Background(),
+		agent,
+		10,
+		types.TenantRoleContributor,
+		[]string{"kb-shared"},
+		kbLookup,
+		kbShare,
+	)
+
+	require.Same(t, agent, gotAgent)
+	require.Zero(t, effectiveTenantID)
+	require.Equal(t, uint64(10), gotAgent.TenantID)
+}
+
+func TestResolveBuiltinWikiFixerTenantScope_IgnoresNonWikiFixerAgents(t *testing.T) {
+	agent := &types.CustomAgent{ID: "custom-agent", TenantID: 10}
+	kbLookup := &wikiFixerKBLookupStub{
+		kb: &types.KnowledgeBase{ID: "kb-shared", TenantID: 20},
+	}
+	kbShare := &wikiFixerKBShareStub{
+		permission: types.OrgRoleEditor,
+		isShared:   true,
+	}
+
+	gotAgent, effectiveTenantID := resolveBuiltinWikiFixerTenantScope(
+		context.Background(),
+		agent,
+		10,
+		types.TenantRoleContributor,
+		[]string{"kb-shared"},
+		kbLookup,
+		kbShare,
+	)
+
+	require.Same(t, agent, gotAgent)
+	require.Zero(t, effectiveTenantID)
+	require.Empty(t, kbLookup.calledWith)
+}
+
+func TestResolveBuiltinWikiFixerTenantScope_RequiresSingleKnowledgeBase(t *testing.T) {
+	agent := &types.CustomAgent{ID: types.BuiltinWikiFixerID, TenantID: 10}
+	kbLookup := &wikiFixerKBLookupStub{
+		kb: &types.KnowledgeBase{ID: "kb-shared", TenantID: 20},
+	}
+
+	gotAgent, effectiveTenantID := resolveBuiltinWikiFixerTenantScope(
+		context.Background(),
+		agent,
+		10,
+		types.TenantRoleContributor,
+		[]string{"kb-a", "kb-b"},
+		kbLookup,
+		&wikiFixerKBShareStub{permission: types.OrgRoleEditor, isShared: true},
+	)
+
+	require.Same(t, agent, gotAgent)
+	require.Zero(t, effectiveTenantID)
+	require.Empty(t, kbLookup.calledWith)
+}
+
+func TestResolveBuiltinWikiFixerTenantScope_FallsBackOnLookupOrPermissionErrors(t *testing.T) {
+	agent := &types.CustomAgent{ID: types.BuiltinWikiFixerID, TenantID: 10}
+
+	t.Run("kb lookup error", func(t *testing.T) {
+		gotAgent, effectiveTenantID := resolveBuiltinWikiFixerTenantScope(
+			context.Background(),
+			agent,
+			10,
+			types.TenantRoleContributor,
+			[]string{"kb-shared"},
+			&wikiFixerKBLookupStub{err: errors.New("lookup failed")},
+			&wikiFixerKBShareStub{permission: types.OrgRoleEditor, isShared: true},
+		)
+
+		require.Same(t, agent, gotAgent)
+		require.Zero(t, effectiveTenantID)
+	})
+
+	t.Run("permission check error", func(t *testing.T) {
+		gotAgent, effectiveTenantID := resolveBuiltinWikiFixerTenantScope(
+			context.Background(),
+			agent,
+			10,
+			types.TenantRoleContributor,
+			[]string{"kb-shared"},
+			&wikiFixerKBLookupStub{kb: &types.KnowledgeBase{ID: "kb-shared", TenantID: 20}},
+			&wikiFixerKBShareStub{err: errors.New("permission failed")},
+		)
+
+		require.Same(t, agent, gotAgent)
+		require.Zero(t, effectiveTenantID)
+	})
+}


### PR DESCRIPTION
## Summary
- Fixes #1399.
- Scope the built-in `builtin-wiki-fixer` to the shared knowledge base source tenant when the caller has editor/admin permission on that shared KB.
- Keep viewer access, non-wiki-fixer agents, ambiguous multi-KB requests, and lookup/permission failures on the original tenant to avoid privilege escalation.
- Add unit coverage for editor, viewer, non-wiki-fixer, multi-KB, and fallback paths.

## Why
The Wiki smart-fix drawer invokes the built-in wiki fixer from a KB page. For a shared KB, the handler previously resolved that built-in agent under the caller tenant. Model selection then tried to resolve the shared KB's model with the wrong tenant context and could fail with `failed to get model: model not found`.

## Tests
- `CGO_LDFLAGS='-lc++' go test ./internal/handler/session -run TestResolveBuiltinWikiFixerTenantScope -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/handler/session -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/middleware -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/container ./internal/router ./internal/handler/... -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service/... -run 'Test.*Shared|Test.*Knowledge|Test.*Agent|Test.*Model|TestResolve|TestUse' -count=1`
- `git diff --check`

Also ran `CGO_LDFLAGS='-lc++' go test ./internal/... -count=1`; it still has unrelated existing environment-sensitive failures outside this change path:
- `internal/application/service/file`: `TestOssEnsureBucket_CreateFails`
- `internal/infrastructure/web_search`: `TestValidateSearxngBaseURL/loopback_ok_via_whitelist`, `TestSearxngProvider_Search`
