### PR TITLE
fix(frontend): guard knowledge list against stale updates

### DIFF
--- a/frontend/src/hooks/useKnowledgeBase.ts
+++ b/frontend/src/hooks/useKnowledgeBase.ts
@@ -35,6 +35,7 @@ export default function (knowledgeBaseId?: string) {
     chunkLoading: false,
     chunkLoadError: "",
   });
+  let knowledgeListGeneration = 0;
   const getKnowled = (
     query: {
       page: number;
@@ -51,9 +52,15 @@ export default function (knowledgeBaseId?: string) {
   ): Promise<void> => {
     const targetKbId = kbId || knowledgeBaseId;
     if (!targetKbId) return Promise.resolve();
+    const requestGeneration = query.page === 1 ? ++knowledgeListGeneration : knowledgeListGeneration;
 
     return listKnowledgeFiles(targetKbId, query)
       .then((result: any) => {
+        if (requestGeneration !== knowledgeListGeneration) return;
+
+        const currentRouteKbId = (route.params as any)?.kbId as string | undefined;
+        if (currentRouteKbId && currentRouteKbId !== targetKbId) return;
+
         const { data, total: totalResult } = result;
     const cardList_ = data.map((item: any) => {
       const rawName = item.file_name || item.title || item.source || t('knowledgeBase.untitledDocument')

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -529,6 +529,8 @@ const loadKnowledgeFiles = (kbIdValue: string): Promise<void> => {
   );
 };
 
+const isCurrentKb = (targetKbId: string) => targetKbId === kbId.value;
+
 const loadTags = async (kbIdValue: string, reset = false) => {
   if (!kbIdValue) {
     tagList.value = [];
@@ -555,6 +557,8 @@ const loadTags = async (kbIdValue: string, reset = false) => {
       page_size: TAG_PAGE_SIZE,
       keyword: tagSearchQuery.value || undefined,
     });
+    if (!isCurrentKb(kbIdValue)) return;
+
     const pageData = (res?.data || {}) as {
       data?: any[];
       total?: number;
@@ -576,10 +580,13 @@ const loadTags = async (kbIdValue: string, reset = false) => {
       tagPage.value = currentPage + 1;
     }
   } catch (error) {
+    if (!isCurrentKb(kbIdValue)) return;
     console.error('Failed to load tags', error);
   } finally {
-    tagLoading.value = false;
-    tagLoadingMore.value = false;
+    if (isCurrentKb(kbIdValue)) {
+      tagLoading.value = false;
+      tagLoadingMore.value = false;
+    }
   }
 };
 
@@ -748,11 +755,15 @@ const handleKnowledgeTagChange = async (knowledgeId: string, tagValue: string) =
 const loadKnowledgeBaseInfo = async (targetKbId: string) => {
   if (!targetKbId) {
     kbInfo.value = null;
+    cardList.value = [];
+    total.value = 0;
     return;
   }
   kbLoading.value = true;
   try {
     const res: any = await getKnowledgeBaseById(targetKbId);
+    if (!isCurrentKb(targetKbId)) return;
+
     kbInfo.value = res?.data || null;
     selectedTagId.value = '';
     // 重置store中的标签选择状态，避免上传文档时自动带上之前选择的标签
@@ -766,10 +777,16 @@ const loadKnowledgeBaseInfo = async (targetKbId: string) => {
     }
     loadTags(targetKbId, true);
   } catch (error) {
+    if (!isCurrentKb(targetKbId)) return;
+
     console.error('Failed to load knowledge base info:', error);
     kbInfo.value = null;
+    cardList.value = [];
+    total.value = 0;
   } finally {
-    kbLoading.value = false;
+    if (isCurrentKb(targetKbId)) {
+      kbLoading.value = false;
+    }
   }
 };
 
@@ -815,6 +832,10 @@ watch(activeKbTab, (tab) => {
 
 watch(() => kbId.value, (newKbId, oldKbId) => {
   if (newKbId && newKbId !== oldKbId) {
+    cardList.value = [];
+    total.value = 0;
+    docListLoading.value = true;
+    resetPage();
     tagSearchQuery.value = '';
     tagPage.value = 1;
     // 重置标签选择状态，避免在不同知识库间保持标签选择
@@ -1317,7 +1338,8 @@ const handleDocumentUpload = async (event: Event) => {
   const files = input?.files;
   if (!files || files.length === 0) return;
 
-  if (!kbId.value) {
+  const targetKbId = kbId.value;
+  if (!targetKbId) {
     MessagePlugin.error(t('error.missingKbId'));
     resetUploadInput();
     return;
@@ -1393,7 +1415,7 @@ const handleDocumentUpload = async (event: Event) => {
 
   for (const file of validFiles) {
     try {
-      const responseData: any = await uploadKnowledgeFile(kbId.value, { file, tag_id: tagIdToUpload });
+      const responseData: any = await uploadKnowledgeFile(targetKbId, { file, tag_id: tagIdToUpload });
       const isSuccess = responseData?.success || responseData?.code === 200 || responseData?.status === 'success' || (!responseData?.error && responseData);
       if (isSuccess) {
         successCount++;
@@ -1427,7 +1449,7 @@ const handleDocumentUpload = async (event: Event) => {
   // 显示上传结果
   if (successCount > 0) {
     window.dispatchEvent(new CustomEvent('knowledgeFileUploaded', {
-      detail: { kbId: kbId.value }
+      detail: { kbId: targetKbId }
     }));
   }
 
@@ -1454,7 +1476,8 @@ const handleFolderUpload = async (event: Event) => {
   const files = input?.files;
   if (!files || files.length === 0) return;
 
-  if (!kbId.value) {
+  const targetKbId = kbId.value;
+  if (!targetKbId) {
     MessagePlugin.error(t('error.missingKbId'));
     if (input) input.value = '';
     return;
@@ -1542,7 +1565,7 @@ const handleFolderUpload = async (event: Event) => {
     }
 
     try {
-      await uploadKnowledgeFile(kbId.value, { file, fileName, tag_id: tagIdToUpload });
+      await uploadKnowledgeFile(targetKbId, { file, fileName, tag_id: tagIdToUpload });
       successCount++;
     } catch (error: any) {
       failCount++;
@@ -1551,7 +1574,7 @@ const handleFolderUpload = async (event: Event) => {
 
   if (successCount > 0) {
     window.dispatchEvent(new CustomEvent('knowledgeFileUploaded', {
-      detail: { kbId: kbId.value }
+      detail: { kbId: targetKbId }
     }));
   }
 
@@ -1607,7 +1630,8 @@ const handleURLImportConfirm = async () => {
     return;
   }
 
-  if (!kbId.value) {
+  const targetKbId = kbId.value;
+  if (!targetKbId) {
     MessagePlugin.error(t('error.missingKbId'));
     return;
   }
@@ -1616,9 +1640,9 @@ const handleURLImportConfirm = async () => {
   try {
     // 获取当前选中的分类ID
     const tagIdToUpload = selectedTagId.value !== '__untagged__' ? selectedTagId.value : undefined;
-    const responseData: any = await createKnowledgeFromURL(kbId.value, { url, tag_id: tagIdToUpload });
+    const responseData: any = await createKnowledgeFromURL(targetKbId, { url, tag_id: tagIdToUpload });
     window.dispatchEvent(new CustomEvent('knowledgeFileUploaded', {
-      detail: { kbId: kbId.value }
+      detail: { kbId: targetKbId }
     }));
     const isSuccess = responseData?.success || responseData?.code === 200 || responseData?.status === 'success' || (!responseData?.error && responseData);
     if (isSuccess) {
@@ -1728,7 +1752,10 @@ const rebuildConfirm = async () => {
 
 const handleScroll = () => {
   if (isFAQ.value) return;
+  if (docListLoading.value) return;
   if (scrollLoading) return;
+  const currentKbId = kbId.value;
+  if (!currentKbId) return;
   const element = knowledgeScroll.value;
   if (element) {
     let pageNum = Math.ceil(total.value / pageSize)
@@ -1737,8 +1764,10 @@ const handleScroll = () => {
       if (cardList.value.length < total.value && page < pageNum) {
         page++;
         scrollLoading = true;
-        getKnowled({ page, page_size: pageSize, ...filterParams.value }).finally(() => {
-          scrollLoading = false;
+        getKnowled({ page, page_size: pageSize, ...filterParams.value }, currentKbId).finally(() => {
+          if (isCurrentKb(currentKbId)) {
+            scrollLoading = false;
+          }
         });
       }
     }


### PR DESCRIPTION
This PR fixes knowledge-base list state leaking across KB switches and stale async responses overwriting the current list.\n\nIt keeps the existing document filter controls intact and does not change the filter UI.\n\nValidation:\n- npm --prefix frontend run build-only\n- git diff --check