### PR TITLE
perf(repository): exclude embedding field from Elasticsearch search r…

### DIFF
--- a/internal/application/repository/retriever/elasticsearch/v8/repository.go
+++ b/internal/application/repository/retriever/elasticsearch/v8/repository.go
@@ -433,12 +433,17 @@ func (e *elasticsearchRepository) VectorRetrieve(ctx context.Context,
 		},
 		MinScore: &minScore,
 	}
+	// Exclude embedding field from source to reduce response size
+	sourceFilter := &types.SourceFilter{
+		Excludes: []string{"embedding"},
+	}
 
 	log.Debugf("[Elasticsearch] Executing vector search in index: %s", e.index)
 	// Execute search with minimum score threshold
 	response, err := e.client.Search().Index(e.index).Request(&search.Request{
-		Query: &types.Query{ScriptScore: scriptScore},
-		Size:  &params.TopK,
+		Query:   &types.Query{ScriptScore: scriptScore},
+		Size:    &params.TopK,
+		Source_: sourceFilter,
 	}).Do(ctx)
 	if err != nil {
 		log.Errorf("[Elasticsearch] Vector search failed: %v", err)
@@ -488,11 +493,16 @@ func (e *elasticsearchRepository) KeywordsRetrieve(ctx context.Context,
 	must := []types.Query{
 		{Match: map[string]types.MatchQuery{"content": {Query: params.Query}}},
 	}
+	// Exclude embedding field from source to reduce response size
+	sourceFilter := &types.SourceFilter{
+		Excludes: []string{"embedding"},
+	}
 
 	log.Debugf("[Elasticsearch] Executing keyword search in index: %s", e.index)
 	response, err := e.client.Search().Index(e.index).Request(&search.Request{
-		Query: &types.Query{Bool: &types.BoolQuery{Filter: filter, Must: must}},
-		Size:  &params.TopK,
+		Query:   &types.Query{Bool: &types.BoolQuery{Filter: filter, Must: must}},
+		Size:    &params.TopK,
+		Source_: sourceFilter,
 	}).Do(ctx)
 	if err != nil {
 		log.Errorf("[Elasticsearch] Keywords search failed: %v", err)


### PR DESCRIPTION
…esponse to reduce size

<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->
Optimize the retrieval return size of Elasticsearch v8 and improve API response speed

## Description
<!-- Briefly describe the purpose and changes of this PR -->
Delete the embedding field returned by Elasticsearch query and optimize the response packet size
## Type of Change
<!-- Check applicable items -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [x] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->

## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
<img width="1575" height="193" alt="image" src="https://github.com/user-attachments/assets/8d7d4d48-9770-47a8-be41-f9ae0b8bed77" />
