### PR TITLE
  fix(repository): qualify tenant_id with table name to resolve ambiguous column reference

### DIFF
--- a/internal/application/repository/tenant_member.go
+++ b/internal/application/repository/tenant_member.go
@@ -100,7 +100,7 @@ func (r *tenantMemberRepository) CountFilteredByTenant(
 ) (int64, error) {
 	search = strings.TrimSpace(search)
 	q := r.db.WithContext(ctx).Model(&types.TenantMember{}).
-		Where("tenant_id = ?", tenantID)
+		Where("tenant_members.tenant_id = ?", tenantID)
 	var total int64
 	var err error
 	if search == "" {
@@ -122,7 +122,7 @@ func (r *tenantMemberRepository) ListPagedByTenant(
 	search = strings.TrimSpace(search)
 	var members []*types.TenantMember
 	q := r.db.WithContext(ctx).Model(&types.TenantMember{}).
-		Where("tenant_id = ?", tenantID).
+		Where("tenant_members.tenant_id = ?", tenantID).
 		Order("tenant_members.joined_at ASC, tenant_members.id ASC").
 		Offset(offset).
 		Limit(limit)


### PR DESCRIPTION

<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->
查询空间成员时页面有报错，查看后端日志发现报错日志：
```
ERROR: column reference "tenant_id" is ambiguous (SQLSTATE 42702)                            
  [0.948ms] [rows:0] SELECT "tenant_members"."id","tenant_members"."user_id","tenant_members"."tenant_id","tenant_members"."role","tenant_members"."status","tenant_members"."invited_by","tenant_members"."joined_at","ten 
  ant_members"."created_at","tenant_members"."updated_at","tenant_members"."deleted_at" FROM "tenant_members" INNER JOIN users ON users.id = tenant_members.user_id AND users.deleted_at IS NULL WHERE tenant_id = 10004    
  AND ((LOWER(users.email) LIKE LOWER('%c%') OR LOWER(users.username) LIKE LOWER('%c%'))) AND "tenant_members"."deleted_at" IS NULL ORDER BY tenant_members.joined_at ASC, tenant_members.id ASC LIMIT 20                   
  ERROR[2026-05-21 18:59:13.722] [NoPVEwY4qody] tenant_member.go:114[ListMembers] | ListMembersPage failed: tenant=10004 err=ERROR: column reference "tenant_id" is ambiguous (SQLSTATE 42702)                              
  INFO [2026-05-21 18:59:13.722] [NoPVEwY4qody client_ip=::1 latency=14.188375ms method=GET path=/api/v1/tenants/10004/members?page=1&page_size=20&q=c response_body={"error":{"code":1007,"details":"ERROR: column         
  reference \"tenant_id\" is ambiguous (SQLSTATE 42702)","message":"failed to list members"},"success":false} size=154 status_code=500]  
```
  在 ListPagedByTenant 和 CountFilteredByTenant 两个方法中，查询条件写的是裸字段名 WHERE tenant_id = ?。

  当搜索关键词非空时，这两个方法会动态追加一个 INNER JOIN users。JOIN 之后查询涉及两张表，而 users 表也有 tenant_id 列，PostgreSQL 无法判断 tenant_id 指的是哪张表的列，抛出 42702: column reference "tenant_id" is ambiguous。

  没有搜索词时走的是单表查询，不 JOIN，所以不报错——这也是为什么这个 bug 只在带搜索的请求下才复现。
## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix


## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->

## Checklist
- [x] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
<img width="887" height="440" alt="61d3160fe6e37c0b132a7568a35552bc" src="https://github.com/user-attachments/assets/16719a12-d5ca-4872-8703-677aa2c71cf1" />