### PR TITLE
fix: apply rewritten query in agent qa

### DIFF
--- a/internal/application/service/chat_pipeline/query_understand.go
+++ b/internal/application/service/chat_pipeline/query_understand.go
@@ -386,6 +386,23 @@ func (p *PluginQueryUnderstand) parseOutput(chatManage *types.ChatManage, raw st
 	}
 }
 
+// ExtractRewriteQuery returns the rewritten query from query-understanding
+// model output. It accepts the structured JSON shape used by QueryUnderstand
+// and falls back to raw text for providers that return plain rewritten text.
+func ExtractRewriteQuery(raw string) string {
+	content := strings.TrimSpace(raw)
+	if content == "" {
+		return ""
+	}
+	if output, ok := parseStructuredQueryOutput(content); ok {
+		if rewrite := strings.TrimSpace(output.RewriteQuery); rewrite != "" {
+			return rewrite
+		}
+		return ""
+	}
+	return content
+}
+
 func parseStructuredQueryOutput(raw string) (queryUnderstandOutput, bool) {
 	content := strings.TrimSpace(raw)
 	if content == "" {

--- a/internal/application/service/chat_pipeline/query_understand_test.go
+++ b/internal/application/service/chat_pipeline/query_understand_test.go
@@ -85,3 +85,35 @@ func TestApplyIntentPromptOverride_GlobalOnly(t *testing.T) {
 		t.Errorf("override: got %q, want %q", cm.SystemPromptOverride, "hi there")
 	}
 }
+
+func TestExtractRewriteQueryAcceptsStructuredAndPlainTextOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "structured rewrite query",
+			raw:  `{"rewrite_query":"改写后的问题","intent":"kb_search"}`,
+			want: "改写后的问题",
+		},
+		{
+			name: "plain text fallback",
+			raw:  "改写后的问题",
+			want: "改写后的问题",
+		},
+		{
+			name: "structured output without rewrite",
+			raw:  `{"intent":"kb_search"}`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractRewriteQuery(tt.raw); got != tt.want {
+				t.Fatalf("ExtractRewriteQuery() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/application/service/session_agent_qa.go
+++ b/internal/application/service/session_agent_qa.go
@@ -169,13 +169,13 @@ func (s *sessionService) AgentQA(
 		}
 	}
 
-	agentQuery := req.Query
+	agentQuery := s.rewriteAgentQueryIfNeeded(ctx, req, effectiveModelID, llmContext)
 	var agentImageURLs []string
 	if agentModelSupportsVision && len(req.ImageURLs) > 0 {
 		agentImageURLs = req.ImageURLs
 		logger.Infof(ctx, "Agent model supports vision, passing %d image(s) directly", len(agentImageURLs))
 	} else if req.ImageDescription != "" {
-		agentQuery = req.Query + "\n\n[用户上传图片内容]\n" + req.ImageDescription
+		agentQuery += "\n\n[用户上传图片内容]\n" + req.ImageDescription
 		logger.Infof(ctx, "Agent model does not support vision, appending image description (%d chars)", len(req.ImageDescription))
 	}
 	if req.QuotedContext != "" {

--- a/internal/application/service/session_agent_qa_test.go
+++ b/internal/application/service/session_agent_qa_test.go
@@ -1,0 +1,319 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	agenttools "github.com/Tencent/WeKnora/internal/agent/tools"
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/event"
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/models/rerank"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type captureAgentEngine struct {
+	query      string
+	llmContext []chat.Message
+}
+
+func (e *captureAgentEngine) Execute(
+	ctx context.Context,
+	sessionID string,
+	messageID string,
+	query string,
+	llmContext []chat.Message,
+	imageURLs ...[]string,
+) (*types.AgentState, error) {
+	_, _, _, _ = ctx, sessionID, messageID, imageURLs
+	e.query = query
+	e.llmContext = append([]chat.Message(nil), llmContext...)
+	return &types.AgentState{}, nil
+}
+
+type captureAgentService struct {
+	engine *captureAgentEngine
+}
+
+func (s *captureAgentService) CreateAgentEngine(
+	context.Context,
+	*types.AgentConfig,
+	chat.Chat,
+	rerank.Reranker,
+	*event.EventBus,
+	string,
+) (interfaces.AgentEngine, error) {
+	return s.engine, nil
+}
+
+func (s *captureAgentService) ValidateConfig(*types.AgentConfig) error {
+	return nil
+}
+
+type agentQAMessageRepo struct {
+	messages []*types.Message
+}
+
+func (r *agentQAMessageRepo) CreateMessage(context.Context, *types.Message) (*types.Message, error) {
+	return nil, nil
+}
+
+func (r *agentQAMessageRepo) GetMessage(context.Context, string, string) (*types.Message, error) {
+	return nil, nil
+}
+
+func (r *agentQAMessageRepo) GetMessagesBySession(context.Context, string, int, int) ([]*types.Message, error) {
+	return nil, nil
+}
+
+func (r *agentQAMessageRepo) GetRecentMessagesBySession(context.Context, string, int) ([]*types.Message, error) {
+	return r.messages, nil
+}
+
+func (r *agentQAMessageRepo) GetMessagesBySessionBeforeTime(
+	context.Context,
+	string,
+	time.Time,
+	int,
+) ([]*types.Message, error) {
+	return nil, nil
+}
+
+func (r *agentQAMessageRepo) UpdateMessage(context.Context, *types.Message) error {
+	return nil
+}
+
+func (r *agentQAMessageRepo) UpdateMessageImages(context.Context, string, string, types.MessageImages) error {
+	return nil
+}
+
+func (r *agentQAMessageRepo) UpdateMessageRenderedContent(context.Context, string, string, string) error {
+	return nil
+}
+
+func (r *agentQAMessageRepo) DeleteMessage(context.Context, string, string) error {
+	return nil
+}
+
+func (r *agentQAMessageRepo) DeleteMessagesBySessionID(context.Context, string) error {
+	return nil
+}
+
+func (r *agentQAMessageRepo) GetFirstMessageOfUser(context.Context, string) (*types.Message, error) {
+	return nil, nil
+}
+
+func (r *agentQAMessageRepo) SearchMessagesByKeyword(
+	context.Context,
+	uint64,
+	string,
+	[]string,
+	int,
+) ([]*types.MessageWithSession, error) {
+	return nil, nil
+}
+
+func (r *agentQAMessageRepo) GetMessagesByKnowledgeIDs(context.Context, []string) ([]*types.MessageWithSession, error) {
+	return nil, nil
+}
+
+func (r *agentQAMessageRepo) GetMessagesByRequestIDs(context.Context, []string) ([]*types.MessageWithSession, error) {
+	return nil, nil
+}
+
+func (r *agentQAMessageRepo) GetKnowledgeIDsBySessionID(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+func (r *agentQAMessageRepo) UpdateMessageKnowledgeID(context.Context, string, string) error {
+	return nil
+}
+
+func TestAgentQAUsesRewrittenQueryForAgentExecution(t *testing.T) {
+	rewriteModel := &captureChatModel{
+		chatResponse: &types.ChatResponse{
+			Content: `{"rewrite_query":"改写后的完整问题","intent":"kb_search"}`,
+		},
+	}
+	engine := &captureAgentEngine{}
+	now := time.Now()
+	svc := &sessionService{
+		cfg: &config.Config{
+			Conversation: &config.ConversationConfig{
+				RewritePromptSystem: "rewrite system",
+				RewritePromptUser:   "history={{conversation}}\nquery={{query}}",
+			},
+		},
+		modelService: &stubModelService{
+			chatModel: rewriteModel,
+			modelByID: &types.Model{ID: "chat-model"},
+		},
+		messageRepo: &agentQAMessageRepo{
+			messages: []*types.Message{
+				{
+					ID:          "user-1",
+					SessionID:   "session-1",
+					RequestID:   "request-1",
+					Role:        "user",
+					Content:     "上一轮问题",
+					IsCompleted: true,
+					CreatedAt:   now.Add(-2 * time.Minute),
+				},
+				{
+					ID:          "assistant-1",
+					SessionID:   "session-1",
+					RequestID:   "request-1",
+					Role:        "assistant",
+					Content:     "上一轮回答",
+					IsCompleted: true,
+					CreatedAt:   now.Add(-time.Minute),
+				},
+			},
+		},
+		agentService: &captureAgentService{engine: engine},
+	}
+	req := &types.QARequest{
+		Session:            &types.Session{ID: "session-1", TenantID: 1},
+		Query:              "它的价格是多少？",
+		AssistantMessageID: "assistant-2",
+		CustomAgent: &types.CustomAgent{
+			ID:       "agent-1",
+			TenantID: 1,
+			Config: types.CustomAgentConfig{
+				AgentMode:           "smart-reasoning",
+				ModelID:             "chat-model",
+				AllowedTools:        []string{agenttools.ToolFinalAnswer},
+				MultiTurnEnabled:    true,
+				HistoryTurns:        5,
+				EnableRewrite:       true,
+				WebSearchProviderID: "provider-1",
+			},
+		},
+		WebSearchEnabled: true,
+	}
+
+	err := svc.AgentQA(context.Background(), req, event.NewEventBus())
+
+	require.NoError(t, err)
+	assert.Equal(t, "改写后的完整问题", engine.query)
+	assert.Len(t, engine.llmContext, 2)
+	require.Len(t, rewriteModel.lastMessages, 2)
+	assert.Contains(t, rewriteModel.lastMessages[1].Content, "上一轮问题")
+	assert.Contains(t, rewriteModel.lastMessages[1].Content, "它的价格是多少？")
+}
+
+func TestAgentQAKeepsOriginalQueryWhenRewriteDisabled(t *testing.T) {
+	rewriteModel := &captureChatModel{
+		chatResponse: &types.ChatResponse{
+			Content: `{"rewrite_query":"不应该被使用","intent":"kb_search"}`,
+		},
+	}
+	engine := &captureAgentEngine{}
+	svc := &sessionService{
+		cfg: &config.Config{
+			Conversation: &config.ConversationConfig{
+				RewritePromptSystem: "rewrite system",
+				RewritePromptUser:   "query={{query}}",
+			},
+		},
+		modelService: &stubModelService{
+			chatModel: rewriteModel,
+			modelByID: &types.Model{ID: "chat-model"},
+		},
+		messageRepo:  &agentQAMessageRepo{},
+		agentService: &captureAgentService{engine: engine},
+	}
+	req := &types.QARequest{
+		Session:            &types.Session{ID: "session-1", TenantID: 1},
+		Query:              "原始问题",
+		AssistantMessageID: "assistant-1",
+		CustomAgent: &types.CustomAgent{
+			ID:       "agent-1",
+			TenantID: 1,
+			Config: types.CustomAgentConfig{
+				AgentMode:           "smart-reasoning",
+				ModelID:             "chat-model",
+				AllowedTools:        []string{agenttools.ToolFinalAnswer},
+				EnableRewrite:       false,
+				WebSearchProviderID: "provider-1",
+			},
+		},
+	}
+
+	err := svc.AgentQA(context.Background(), req, event.NewEventBus())
+
+	require.NoError(t, err)
+	assert.Equal(t, "原始问题", engine.query)
+	assert.Empty(t, rewriteModel.lastMessages)
+}
+
+func TestAgentQAFallsBackToOriginalQueryWhenRewriteIsEmpty(t *testing.T) {
+	rewriteModel := &captureChatModel{
+		chatResponse: &types.ChatResponse{
+			Content: `{"intent":"kb_search"}`,
+		},
+	}
+	engine := &captureAgentEngine{}
+	svc := &sessionService{
+		cfg: &config.Config{
+			Conversation: &config.ConversationConfig{
+				RewritePromptSystem: "rewrite system",
+				RewritePromptUser:   "query={{query}}",
+			},
+		},
+		modelService: &stubModelService{
+			chatModel: rewriteModel,
+			modelByID: &types.Model{ID: "chat-model"},
+		},
+		messageRepo:  &agentQAMessageRepo{},
+		agentService: &captureAgentService{engine: engine},
+	}
+	req := &types.QARequest{
+		Session:            &types.Session{ID: "session-1", TenantID: 1},
+		Query:              "原始问题",
+		AssistantMessageID: "assistant-1",
+		CustomAgent: &types.CustomAgent{
+			ID:       "agent-1",
+			TenantID: 1,
+			Config: types.CustomAgentConfig{
+				AgentMode:           "smart-reasoning",
+				ModelID:             "chat-model",
+				AllowedTools:        []string{agenttools.ToolFinalAnswer},
+				EnableRewrite:       true,
+				WebSearchProviderID: "provider-1",
+			},
+		},
+	}
+
+	err := svc.AgentQA(context.Background(), req, event.NewEventBus())
+
+	require.NoError(t, err)
+	assert.Equal(t, "原始问题", engine.query)
+	require.Len(t, rewriteModel.lastMessages, 2)
+}
+
+func TestBuildAgentRewriteQueryContentIncludesImageDescriptionAndAttachments(t *testing.T) {
+	req := &types.QARequest{
+		Query:            "总结这份材料",
+		ImageDescription: "图片里有船期表",
+		Attachments: types.MessageAttachments{
+			{
+				FileName: "rate.txt",
+				FileType: ".txt",
+				FileSize: 1024,
+				Content:  "上海到洛杉矶运价",
+			},
+		},
+	}
+
+	content := buildAgentRewriteQueryContent(req)
+
+	assert.Contains(t, content, "总结这份材料")
+	assert.Contains(t, content, "图片里有船期表")
+	assert.Contains(t, content, "rate.txt")
+	assert.Contains(t, content, "上海到洛杉矶运价")
+}

--- a/internal/application/service/session_agent_query_rewrite.go
+++ b/internal/application/service/session_agent_query_rewrite.go
@@ -1,0 +1,127 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	chatpipeline "github.com/Tencent/WeKnora/internal/application/service/chat_pipeline"
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func (s *sessionService) rewriteAgentQueryIfNeeded(
+	ctx context.Context,
+	req *types.QARequest,
+	chatModelID string,
+	llmContext []chat.Message,
+) string {
+	if req.CustomAgent == nil || !req.CustomAgent.Config.EnableRewrite {
+		return req.Query
+	}
+
+	systemPrompt := ""
+	userPrompt := ""
+	if s.cfg != nil && s.cfg.Conversation != nil {
+		systemPrompt = s.cfg.Conversation.RewritePromptSystem
+		userPrompt = s.cfg.Conversation.RewritePromptUser
+	}
+	if req.CustomAgent.Config.RewritePromptSystem != "" {
+		systemPrompt = req.CustomAgent.Config.RewritePromptSystem
+	}
+	if req.CustomAgent.Config.RewritePromptUser != "" {
+		userPrompt = req.CustomAgent.Config.RewritePromptUser
+	}
+	if strings.TrimSpace(systemPrompt) == "" && strings.TrimSpace(userPrompt) == "" {
+		logger.Warnf(ctx, "Agent query rewrite enabled but rewrite prompts are empty, using original query")
+		return req.Query
+	}
+
+	modelID := chatModelID
+	if req.CustomAgent.Config.QueryUnderstandModelID != "" {
+		modelID = req.CustomAgent.Config.QueryUnderstandModelID
+	}
+	rewriteModel, err := s.modelService.GetChatModel(ctx, modelID)
+	if err != nil {
+		if req.CustomAgent.Config.QueryUnderstandModelID != "" && modelID != chatModelID {
+			logger.Warnf(ctx, "Failed to get agent query-understand model %s: %v, falling back to chat model",
+				modelID, err)
+			rewriteModel, err = s.modelService.GetChatModel(ctx, chatModelID)
+		}
+		if err != nil {
+			logger.Warnf(ctx, "Failed to get agent query rewrite model: %v, using original query", err)
+			return req.Query
+		}
+	}
+
+	vals := types.PlaceholderValues{
+		"conversation": formatAgentRewriteHistory(llmContext),
+		"query":        buildAgentRewriteQueryContent(req),
+		"language":     "",
+	}
+	thinking := false
+	resp, err := rewriteModel.Chat(ctx, []chat.Message{
+		{Role: "system", Content: types.RenderPromptPlaceholders(systemPrompt, vals)},
+		{Role: "user", Content: types.RenderPromptPlaceholders(userPrompt, vals)},
+	}, &chat.ChatOptions{
+		Temperature:         0.3,
+		MaxCompletionTokens: 150,
+		Thinking:            &thinking,
+	})
+	if err != nil || resp == nil {
+		logger.Warnf(ctx, "Agent query rewrite failed: %v, using original query", err)
+		return req.Query
+	}
+
+	rewrite := strings.TrimSpace(chatpipeline.ExtractRewriteQuery(resp.Content))
+	if rewrite == "" {
+		logger.Warnf(ctx, "Agent query rewrite returned empty query, using original query")
+		return req.Query
+	}
+	logger.Infof(ctx, "Agent query rewritten for session %s", req.Session.ID)
+	return rewrite
+}
+
+func buildAgentRewriteQueryContent(req *types.QARequest) string {
+	queryContent := req.Query
+	if req.ImageDescription != "" {
+		queryContent += "\n\n[用户上传图片内容]\n" + req.ImageDescription
+	} else if len(req.ImageURLs) > 0 {
+		queryContent += fmt.Sprintf("\n\n<images_uploaded count=\"%d\" />", len(req.ImageURLs))
+	} else {
+		queryContent += "\n\n<no_image_attached />"
+	}
+	if len(req.Attachments) > 0 {
+		queryContent += req.Attachments.BuildPrompt()
+	} else {
+		queryContent += "\n<no_document_attached />"
+	}
+	return queryContent
+}
+
+func formatAgentRewriteHistory(llmContext []chat.Message) string {
+	if len(llmContext) == 0 {
+		return ""
+	}
+
+	var builder strings.Builder
+	for _, msg := range llmContext {
+		content := strings.TrimSpace(msg.Content)
+		if content == "" {
+			continue
+		}
+		switch msg.Role {
+		case "user":
+			builder.WriteString("------BEGIN------\n")
+			builder.WriteString("User question: ")
+			builder.WriteString(content)
+			builder.WriteString("\n")
+		case "assistant":
+			builder.WriteString("Assistant answer: ")
+			builder.WriteString(content)
+			builder.WriteString("\n------END------\n")
+		}
+	}
+	return builder.String()
+}

--- a/internal/application/service/session_knowledge_qa_test.go
+++ b/internal/application/service/session_knowledge_qa_test.go
@@ -17,13 +17,18 @@ import (
 
 type captureChatModel struct {
 	lastMessages []chat.Message
+	chatResponse *types.ChatResponse
 }
 
 func (m *captureChatModel) Chat(
-	context.Context,
-	[]chat.Message,
-	*chat.ChatOptions,
+	_ context.Context,
+	messages []chat.Message,
+	_ *chat.ChatOptions,
 ) (*types.ChatResponse, error) {
+	m.lastMessages = append([]chat.Message(nil), messages...)
+	if m.chatResponse != nil {
+		return m.chatResponse, nil
+	}
 	return nil, nil
 }
 
@@ -49,6 +54,7 @@ func (m *captureChatModel) GetModelID() string   { return "capture" }
 
 type stubModelService struct {
 	chatModel chat.Chat
+	modelByID *types.Model
 }
 
 func (s *stubModelService) CreateModel(context.Context, *types.Model) error {
@@ -56,7 +62,7 @@ func (s *stubModelService) CreateModel(context.Context, *types.Model) error {
 }
 
 func (s *stubModelService) GetModelByID(context.Context, string) (*types.Model, error) {
-	return nil, nil
+	return s.modelByID, nil
 }
 
 func (s *stubModelService) ListModels(context.Context) ([]*types.Model, error) {


### PR DESCRIPTION
## Summary
- Apply custom agent query rewrite before AgentQA executes the ReAct engine, so multi-turn agent calls use the rewritten query instead of the original user query.
- Reuse the existing query-understanding output parser and preserve backward-compatible fallbacks to the original query when rewrite is disabled, misconfigured, fails, or returns an empty result.
- Include image descriptions and attachments in the rewrite prompt context while keeping the existing final agent-query augmentation behavior.

Fixes #1437

## Tests
- CGO_LDFLAGS="-lc++" go test ./internal/application/service/chat_pipeline -count=1
- CGO_LDFLAGS="-lc++" go test ./internal/application/service -count=1
- CGO_LDFLAGS="-lc++" go test ./internal/agent/... -count=1

## Notes
- CGO_LDFLAGS="-lc++" go test ./internal/application/service/... -count=1 still has an unrelated existing failure in ./internal/application/service/file: TestOssEnsureBucket_CreateFails expects invalid OSS credentials to return an error.