### PR TITLE
fix (chat history): #1431 Preserve multiline formatting in chat messages

### DIFF
--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -244,7 +244,7 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 		sessionID:   sessionID,
 		requestID:   requestID,
 		receivedAt:  receivedAt,
-		query:       secutils.SanitizeForLog(request.Query),
+		query:       request.Query,
 		session:     session,
 		customAgent: customAgent,
 		assistantMessage: &types.Message{


### PR DESCRIPTION
## Fix: Preserve multiline formatting in chat messages (issue #1431)

### Problem

When a user sends a message containing multiple lines (using Shift+Enter), the message displays correctly in the current session. However, when the conversation is reloaded from history, the message collapses into a single line — all newlines are lost.

### Root Cause

In `internal/handler/session/qa.go`, the user's query was being passed through `secutils.SanitizeForLog()` before being assigned to `reqCtx.query`:

```go
query: secutils.SanitizeForLog(request.Query),
```

`SanitizeForLog` replaces all `\n`, `\r`, and `\t` characters with spaces. While this is appropriate for log output to prevent log injection, it was also being applied to the query content that gets:
- Stored in the database as the user message
- Sent to the LLM pipeline for processing

This meant any multiline formatting was permanently stripped before persistence.

### Fix

```diff
- query: secutils.SanitizeForLog(request.Query),
+ query: request.Query,
```

Use `request.Query` directly so the original multiline text is preserved in the database and LLM pipeline.

### Security

Log injection protection is **not affected**. The full request body (including the query) is already sanitized when logged at the top of `parseQARequest` (line 108–111):

```go
if requestJSON, err := json.Marshal(request); err == nil {
    logger.Infof(ctx, "[%s] Request: session_id=%s, request=%s",
        logPrefix, sessionID, secutils.SanitizeForLog(secutils.CompactImageDataURLForLog(string(requestJSON))))
}
```

All downstream log statements that output user content also apply `SanitizeForLog` independently. Only the stored/processed query now retains its original formatting.

### Testing

- Send a multiline message (using Shift+Enter) in the chat
- Refresh the page or navigate away and back
- Verify the message in history preserves the original line breaks