### PR TITLE
fix(frontend): keep X-Tenant-ID override when switching back to home

### DIFF
--- a/frontend/src/components/TenantSelector.vue
+++ b/frontend/src/components/TenantSelector.vue
@@ -103,7 +103,12 @@ const loading = ref(false)
 const searchTimer = ref<number | null>(null)
 
 const selectedTenantId = computed(() => authStore.selectedTenantId)
-const defaultTenantId = computed(() => authStore.tenant?.id ? Number(authStore.tenant.id) : null)
+// home 租户 id 来自 user.tenant_id（注册时分配、永不变）。不要读
+// authStore.tenant.id —— 那是当前激活租户，会随 X-Tenant-ID 切换；用它
+// 当 home 会让「切回 home」分支错判，详见 useHomeTenant() 注释。
+const defaultTenantId = computed(() =>
+  authStore.user?.tenant_id ? Number(authStore.user.tenant_id) : null,
+)
 
 const currentTenantId = computed(() => {
   return selectedTenantId.value || defaultTenantId.value
@@ -164,15 +169,21 @@ const selectTenant = (tenantId: number) => {
   // 找到选中的租户信息
   const selectedTenant = tenants.value.find(t => t.id === tenantId)
 
+  // 始终写入 override，让 request.ts 永远附 X-Tenant-ID 覆盖 JWT；不要因为
+  // 切到 home 就清空（详见 UserMenu.switchToTenant 同名注释）。服务端持久化
+  // 偏好仍然区分对待——切到 home 时清 last_active，让下次干净重登回到 home。
   const switchingToHome = tenantId === defaultTenantId.value
-  if (switchingToHome) {
-    authStore.setSelectedTenant(null, null)
-  } else {
-    authStore.setSelectedTenant(tenantId, selectedTenant?.name || null)
-  }
+  // 切到 home 时，selectedTenant 可能因为分页 / 搜索没把 home 加载进列表，
+  // 退而求其次从 memberships 上挑名字。注意不要回退到 authStore.tenant?.name
+  // —— 那是当前激活租户的名字，在 active != home 的会话里就是 peer 的名字。
+  const homeNameFallback = switchingToHome
+    ? (authStore.memberships ?? []).find((m) => Number(m.tenant_id) === tenantId)?.tenant_name
+      || null
+    : null
+  authStore.setSelectedTenant(tenantId, selectedTenant?.name || homeNameFallback || null)
   closeDropdown()
   const displayName = selectedTenant?.name
-    || (tenantId === defaultTenantId.value ? authStore.tenant?.name : null)
+    || homeNameFallback
     || `#${tenantId}`
   // Cross-tenant superusers may not have a membership row in the target
   // tenant; in that case skip the role line rather than show a misleading

--- a/frontend/src/components/UserMenu.vue
+++ b/frontend/src/components/UserMenu.vue
@@ -440,16 +440,15 @@ const switchToTenant = (m: Membership) => {
     closeAll()
     return
   }
-  // Treat switching back to the user's home tenant as "clear the
-  // override" so request.ts stops attaching X-Tenant-ID. This mirrors
-  // what TenantSelector.vue does in selectTenant().
+  // 始终把激活租户写进 selectedTenantId，让 request.ts 永远附 X-Tenant-ID。
+  // 历史实现里「切回 home 就清 override」会让请求落回 JWT 编码的租户，
+  // 而 JWT 在 last_active != home 的会话里恰好是 peer 租户（见
+  // userService.resolveLoginTenantID），结果切回 home 反而原地不动。
+  // 服务端持久化偏好仍然按 home/peer 区分：home 时清空 last_active，
+  // 让下次干净重登能正确回到 home。
   const home = homeTenantId.value
   const switchingToHome = home !== null && home === m.tenant_id
-  if (switchingToHome) {
-    authStore.setSelectedTenant(null, null)
-  } else {
-    authStore.setSelectedTenant(m.tenant_id, tenantDisplayName(m))
-  }
+  authStore.setSelectedTenant(m.tenant_id, tenantDisplayName(m))
   closeAll()
   // Toast 在 reload 后由 App.vue 弹出（直接在这里弹会被 hard reload 干掉）。
   stashTenantSwitchToast({


### PR DESCRIPTION
## Summary

After a user re-logs in with a `last_active_tenant_id` preference set, the backend mints the JWT with that peer tenant (see `userService.resolveLoginTenantID`). Both `TenantSelector.vue` and `UserMenu.vue` used to *clear* `weknora_selected_tenant_id` when the user clicked their home tenant, which made `request.ts` stop attaching `X-Tenant-ID`. Without the header, `internal/middleware/auth.go` fell back to the JWT-encoded tenant id — i.e. the peer tenant the user just tried to leave — so the "switch to home" action was a silent no-op. The toast still rendered (it's stashed in `sessionStorage` and consumed after reload), but the page, KB list and tenant info all stayed on the peer tenant. The only recovery was to manually wipe `localStorage` and log in again.

Two changes:

- **Always write the active tenant id into `selectedTenantId`** in both `switchToTenant` (`UserMenu.vue`) and `selectTenant` (`TenantSelector.vue`). This preserves the "always attach `X-Tenant-ID`" invariant that `request.ts:40-52` depends on, so the header reliably overrides whatever tenant is encoded in the JWT. The server-side `last_active_tenant_id` preference is still cleared when switching to home, so a clean re-login (cleared cookies / new device) still lands the user on home — `Login.vue:596-602` then takes the `activeIdNum === homeIdNum` branch and skips the override entirely.
- **Fix `TenantSelector.defaultTenantId`** to read `authStore.user?.tenant_id` (the immutable home id) instead of `authStore.tenant?.id` (the active tenant, which is overwritten by `/auth/me`). This matches the contract spelled out in `useHomeTenant()` and prevents `switchingToHome` from misfiring when the active tenant differs from home. Falls back to `memberships` for the home tenant name when the dropdown's paginated list hasn't loaded it yet.

## Test plan

- [ ] Manual repro: from home tenant A, create new tenant B → switch to B → log out → log back in (should land on B because of `last_active_tenant_id`).
- [ ] In B, click home A in the avatar dropdown → page, KB list and tenant info should immediately reflect A.
- [ ] Log out and log back in → should land directly on home A (server-side `last_active_tenant_id` cleared).
- [ ] Repeat steps 2–3 from the sidebar `TenantSelector` instead of the avatar dropdown.
- [ ] Cross-tenant superuser flow (no membership row in the target tenant) still works through `TenantSelector`.