### PR TITLE
feat(wiki): add "View in Graph" entry on wiki page

### DIFF
--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -72,6 +72,12 @@ const wikiIndexingTip = computed(() => {
 const onWikiStatusChange = (payload: { pendingTasks: number; isActive: boolean; pendingIssues: number }) => {
   wikiStatus.value = payload
 }
+const onViewWikiInGraph = async (slug: string) => {
+  // Write tab+slug first so the activeKbTab watcher's later replace
+  // (which spreads route.query) preserves slug instead of clobbering it.
+  await router.replace({ query: { ...route.query, tab: 'graph', slug } })
+  activeKbTab.value = 'graph'
+}
 
 let wikiStatusTimer: ReturnType<typeof setInterval> | null = null
 let wikiStatusProbeTimers: Array<ReturnType<typeof setTimeout>> = []
@@ -2099,7 +2105,8 @@ async function createNewSession(value: string): Promise<void> {
       <!-- Wiki Browser / Graph (shown when wiki or graph tab is active) -->
       <div v-if="isWiki && (activeKbTab === 'wiki' || activeKbTab === 'graph')" class="wiki-main-area">
         <WikiBrowser v-if="kbId" :knowledge-base-id="kbId" :view="activeKbTab === 'graph' ? 'graph' : 'browser'"
-          :can-edit="canEdit" @open-source-doc="openSourceDoc" @status-change="onWikiStatusChange" />
+          :can-edit="canEdit" @open-source-doc="openSourceDoc" @status-change="onWikiStatusChange"
+          @view-graph="onViewWikiInGraph" />
       </div>
 
       <template v-if="activeKbTab === 'documents' || !isWiki">

--- a/frontend/src/views/knowledge/wiki/WikiBrowser.vue
+++ b/frontend/src/views/knowledge/wiki/WikiBrowser.vue
@@ -424,6 +424,15 @@
                   </t-tag>
                   <span class="wiki-reader-meta-text">{{ $t('knowledgeEditor.wikiBrowser.version', { ver: selectedPage.version }) }}</span>
                   <span class="wiki-reader-meta-text">{{ formatDate(selectedPage.updated_at) }}</span>
+                  <t-link
+                    theme="primary"
+                    hover="color"
+                    class="wiki-reader-graph-link"
+                    @click="emit('view-graph', selectedPage.slug)"
+                  >
+                    <template #prefixIcon><t-icon name="chart-bubble" /></template>
+                    {{ $t('knowledgeEditor.wikiBrowser.viewInGraph') }}
+                  </t-link>
                 </div>
               </div>
 
@@ -684,6 +693,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'open-source-doc', knowledgeId: string): void
   (e: 'status-change', payload: { pendingTasks: number; isActive: boolean; pendingIssues: number }): void
+  (e: 'view-graph', slug: string): void
 }>()
 const pages = ref<WikiPage[]>([])
 const selectedPage = ref<WikiPage | null>(null)
@@ -3932,6 +3942,11 @@ onUnmounted(() => {
 .wiki-reader-meta-text {
   font-size: 13px;
   color: var(--td-text-color-placeholder);
+}
+
+.wiki-reader-graph-link {
+  margin-left: auto;
+  font-size: 13px;
 }
 
 .wiki-reader-links {


### PR DESCRIPTION
## Description
Add a "View in Graph" link in the wiki page header. Clicking it switches the knowledge base to the graph tab and centers the canvas on the corresponding node, so users can jump from a wiki page to its graph node in one click. Mirrors the existing entry already used by the agent stream wiki drawer (`AgentStreamDisplay.vue`).

Implementation:
- `WikiBrowser.vue`: emit a new `view-graph` event from the page meta row using the existing `knowledgeEditor.wikiBrowser.viewInGraph` i18n key and `chart-bubble` icon.
- `KnowledgeBase.vue`: handle the event by writing `tab=graph&slug=<slug>` to the URL first, then flipping `activeKbTab` to `graph`. The order matters — doing it the other way lets the `activeKbTab` watcher's later `router.replace({ ...route.query, tab })` clobber the slug before it lands. After the tab switch, `WikiBrowser`'s existing `loadGraph()` tail picks up `route.query.slug` and calls `handleGraphSearchSelect` to focus the node (same path used by the agent drawer).

## Type of Change
- [x] ✨ New feature

## Related Issue
Fixes #

## Testing
- Open a wiki-enabled KB → `?tab=wiki` → select a page → click "View in Graph"; verify URL becomes `?tab=graph&slug=<slug>`, the graph tab activates, and the canvas centers on the node.
- Repeat for a slug whose node is outside the current overview subgraph; verify `handleGraphSearchSelect` falls back to `loadEgoGraph` and still focuses.

## Checklist
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
_TBD_