### PR TITLE
fix: correct agent selector position under zoom

### DIFF
--- a/frontend/src/components/AgentSelector.vue
+++ b/frontend/src/components/AgentSelector.vue
@@ -301,6 +301,13 @@ const emit = defineEmits<{
 
 const dropdownStyle = ref<Record<string, string>>({});
 
+const getRootZoom = () => {
+  const zoom = Number.parseFloat(getComputedStyle(document.documentElement).zoom || '1');
+  return Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
+};
+
+const toFixedCssPx = (px: number, zoom: number) => Math.floor(px / zoom);
+
 // 父组件已按「当前租户停用」过滤，此处直接使用
 const agentsList = computed(() => props.agents ?? []);
 
@@ -403,6 +410,7 @@ const updateDropdownPosition = () => {
   const rect = props.anchorEl.getBoundingClientRect();
   const dropdownWidth = 200;
   const offsetY = 8;
+  const rootZoom = getRootZoom();
   const vh = window.innerHeight;
   const vw = window.innerWidth;
   
@@ -429,8 +437,8 @@ const updateDropdownPosition = () => {
     dropdownStyle.value = {
       position: 'fixed',
       width: `${dropdownWidth}px`,
-      left: `${left}px`,
-      top: `${top}px`,
+      left: `${toFixedCssPx(left, rootZoom)}px`,
+      top: `${toFixedCssPx(top, rootZoom)}px`,
       maxHeight: `${actualHeight}px`,
       zIndex: '9999'
     };
@@ -446,8 +454,8 @@ const updateDropdownPosition = () => {
     dropdownStyle.value = {
       position: 'fixed',
       width: `${dropdownWidth}px`,
-      left: `${left}px`,
-      bottom: `${bottom}px`,
+      left: `${toFixedCssPx(left, rootZoom)}px`,
+      bottom: `${toFixedCssPx(bottom, rootZoom)}px`,
       maxHeight: `${actualHeight}px`,
       zIndex: '9999'
     };


### PR DESCRIPTION
## Description
Fixes the chat input agent selector dropdown being offset to the lower-right when the UI font-size preference applies CSS `zoom` on `<html>`.

`getBoundingClientRect()` returns visual coordinates under zoom, while `position: fixed` CSS values are interpreted in CSS pixels. The selector now normalizes fixed coordinates by the root zoom value before applying `left`, `top`, or `bottom`.

## Type of Change
- [x] Bug fix

## Testing
- [x] `npm --prefix frontend run build` passes (✓ built in ~28s, no new errors).
- [ ] `npm --prefix frontend run type-check` currently fails due to existing unrelated TypeScript errors outside this change.

## Checklist
- [x] Self-reviewed the code
- [x] Fix is scoped to `frontend/src/components/AgentSelector.vue` only
- [x] Handles zoom > 1, zoom < 1, and zoom = 1 (fallback)
- [x] Both below-button and above-button dropdown placement are handled