### PR TITLE
fix(frontend): correct floating UI positioning under root `zoom` (follow-up to #1459)

### DIFF
--- a/frontend/src/components/AgentSelector.vue
+++ b/frontend/src/components/AgentSelector.vue
@@ -280,6 +280,7 @@ import AgentAvatar from '@/components/AgentAvatar.vue';
 import { useOrganizationStore } from '@/stores/organization';
 import { useSettingsStore } from '@/stores/settings';
 import type { SharedAgentInfo } from '@/api/organization';
+import { getRootZoom, rectToCssPx, cssViewportSize } from '@/utils/zoom';
 
 const { t } = useI18n();
 const router = useRouter();
@@ -300,13 +301,6 @@ const emit = defineEmits<{
 }>();
 
 const dropdownStyle = ref<Record<string, string>>({});
-
-const getRootZoom = () => {
-  const zoom = Number.parseFloat(getComputedStyle(document.documentElement).zoom || '1');
-  return Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
-};
-
-const toFixedCssPx = (px: number, zoom: number) => Math.floor(px / zoom);
 
 // 父组件已按「当前租户停用」过滤，此处直接使用
 const agentsList = computed(() => props.agents ?? []);
@@ -406,56 +400,58 @@ const goToSettings = (agent: CustomAgent) => {
 // 更新下拉框位置（与模型选择器一致）
 const updateDropdownPosition = () => {
   if (!props.anchorEl) return;
-  
-  const rect = props.anchorEl.getBoundingClientRect();
+
+  // Normalize everything to CSS pixels up front so we can compare anchor
+  // coords, viewport bounds, and the dropdown's own width/height in a single
+  // coordinate system. `getBoundingClientRect()` and `window.innerWidth/Height`
+  // report visual pixels which are pre-multiplied by the root zoom.
+  const zoom = getRootZoom();
+  const rect = rectToCssPx(props.anchorEl.getBoundingClientRect(), zoom);
+  const { width: vw, height: vh } = cssViewportSize(zoom);
+
   const dropdownWidth = 200;
   const offsetY = 8;
-  const rootZoom = getRootZoom();
-  const vh = window.innerHeight;
-  const vw = window.innerWidth;
-  
+
   // 水平位置：左对齐
   let left = Math.floor(rect.left);
   const minLeft = 16;
   const maxLeft = Math.max(16, vw - dropdownWidth - 16);
   left = Math.max(minLeft, Math.min(maxLeft, left));
-  
+
   // 垂直位置
   const preferredDropdownHeight = 320;
   const minDropdownHeight = 100;
   const topMargin = 20;
   const spaceBelow = vh - rect.bottom;
   const spaceAbove = rect.top;
-  
+
   let actualHeight: number;
-  
+
   if (spaceBelow >= minDropdownHeight + offsetY) {
-    // 向下弹出
     actualHeight = Math.min(preferredDropdownHeight, spaceBelow - offsetY - 16);
     const top = Math.floor(rect.bottom + offsetY);
-    
+
     dropdownStyle.value = {
       position: 'fixed',
       width: `${dropdownWidth}px`,
-      left: `${toFixedCssPx(left, rootZoom)}px`,
-      top: `${toFixedCssPx(top, rootZoom)}px`,
+      left: `${left}px`,
+      top: `${top}px`,
       maxHeight: `${actualHeight}px`,
       zIndex: '9999'
     };
   } else {
-    // 向上弹出
     const availableHeight = spaceAbove - offsetY - topMargin;
-    actualHeight = availableHeight >= preferredDropdownHeight 
-      ? preferredDropdownHeight 
+    actualHeight = availableHeight >= preferredDropdownHeight
+      ? preferredDropdownHeight
       : Math.max(minDropdownHeight, availableHeight);
-    
+
     const bottom = vh - rect.top + offsetY;
-    
+
     dropdownStyle.value = {
       position: 'fixed',
       width: `${dropdownWidth}px`,
-      left: `${toFixedCssPx(left, rootZoom)}px`,
-      bottom: `${toFixedCssPx(bottom, rootZoom)}px`,
+      left: `${left}px`,
+      bottom: `${bottom}px`,
       maxHeight: `${actualHeight}px`,
       zIndex: '9999'
     };

--- a/frontend/src/components/FAQTagTooltip.vue
+++ b/frontend/src/components/FAQTagTooltip.vue
@@ -24,6 +24,7 @@
 
 <script setup lang="ts">
 import { ref, computed, nextTick, onMounted, onUnmounted, watch } from 'vue'
+import { getRootZoom, rectToCssPx, cssViewportSize } from '@/utils/zoom'
 
 const props = defineProps<{
   content: string
@@ -51,8 +52,12 @@ const updatePosition = async () => {
   // 再次检查，确保DOM已渲染
   if (!tooltipRef.value) return
   
-  const rect = wrapperRef.value.getBoundingClientRect()
-  const tooltipRect = tooltipRef.value.getBoundingClientRect()
+  // The tooltip is `position: fixed` and rendered under the root `zoom`.
+  // Normalize the visual-pixel rects so subsequent arithmetic stays in CSS px.
+  const zoom = getRootZoom()
+  const rect = rectToCssPx(wrapperRef.value.getBoundingClientRect(), zoom)
+  const tooltipRect = rectToCssPx(tooltipRef.value.getBoundingClientRect(), zoom)
+  const { width: vw, height: vh } = cssViewportSize(zoom)
   const placement = props.placement || 'top'
   
   let top = 0
@@ -80,8 +85,8 @@ const updatePosition = async () => {
   // 边界检测
   const padding = 8
   if (left < padding) left = padding
-  if (left + tooltipRect.width > window.innerWidth - padding) {
-    left = window.innerWidth - tooltipRect.width - padding
+  if (left + tooltipRect.width > vw - padding) {
+    left = vw - tooltipRect.width - padding
   }
   if (top < padding) {
     // 如果上方空间不足，改为下方显示
@@ -91,8 +96,8 @@ const updatePosition = async () => {
       top = padding
     }
   }
-  if (top + tooltipRect.height > window.innerHeight - padding) {
-    top = window.innerHeight - tooltipRect.height - padding
+  if (top + tooltipRect.height > vh - padding) {
+    top = vh - tooltipRect.height - padding
   }
   
   tooltipStyle.value = {

--- a/frontend/src/components/Input-field.vue
+++ b/frontend/src/components/Input-field.vue
@@ -13,6 +13,7 @@ import KnowledgeBaseSelector from './KnowledgeBaseSelector.vue';
 import MentionSelector from './MentionSelector.vue';
 import AgentSelector from './AgentSelector.vue';
 import { getCaretCoordinates } from '@/utils/caret';
+import { getRootZoom, rectToCssPx, cssViewportSize } from '@/utils/zoom';
 import { listModels, type ModelConfig } from '@/api/model';
 import { listAgents, type CustomAgent, BUILTIN_QUICK_ANSWER_ID, BUILTIN_SMART_REASONING_ID } from '@/api/agent';
 import { listWebSearchProviders, type WebSearchProviderEntity } from '@/api/web-search-provider';
@@ -886,8 +887,10 @@ const updateModelDropdownPosition = () => {
     return;
   }
 
-  // 获取按钮相对于视口的位置
-  const rect = anchor.getBoundingClientRect();
+  // Normalize coordinates to CSS pixels so they are interpreted the same way
+  // the browser will render them under the root `zoom` (see utils/zoom.ts).
+  const zoom = getRootZoom();
+  const rect = rectToCssPx(anchor.getBoundingClientRect(), zoom);
   console.log('[Model Dropdown] Button rect:', {
     top: rect.top,
     bottom: rect.bottom,
@@ -899,8 +902,7 @@ const updateModelDropdownPosition = () => {
 
   const dropdownWidth = 280;
   const offsetY = 8;
-  const vw = window.innerWidth;
-  const vh = window.innerHeight;
+  const { width: vw, height: vh } = cssViewportSize(zoom);
 
   // 左对齐到触发元素的左边缘
   // 使用 Math.floor 而不是 Math.round，避免像素对齐问题
@@ -1266,27 +1268,29 @@ const onInput = (val: string | InputEvent) => {
       mentionQuery.value = "";
 
       const coords = getCaretCoordinates(textarea, cursor);
-      const rect = textarea.getBoundingClientRect();
+      // Normalize coordinates to CSS pixels (root <html> may carry `zoom`).
+      const zoom = getRootZoom();
+      const rect = rectToCssPx(textarea.getBoundingClientRect(), zoom);
+      const { width: vw, height: vh } = cssViewportSize(zoom);
       const scrollTop = textarea.scrollTop;
       const menuHeight = 320; // 预估最大高度
 
       let left = rect.left + coords.left;
       // Prevent menu from going off-screen horizontally
-      if (left + 300 > window.innerWidth) {
-        left = window.innerWidth - 300 - 10;
+      if (left + 300 > vw) {
+        left = vw - 300 - 10;
       }
 
-      // 光标相对于视口的实际 top 位置
+      // 光标相对于视口的实际 top 位置（CSS 像素）
       const cursorAbsoluteTop = rect.top + coords.top - scrollTop;
       const lineHeight = coords.height; // 光标高度
 
       // Check vertical space below cursor
-      const spaceBelow = window.innerHeight - (cursorAbsoluteTop + lineHeight);
+      const spaceBelow = vh - (cursorAbsoluteTop + lineHeight);
 
       if (spaceBelow < menuHeight && cursorAbsoluteTop > menuHeight) {
         // Show above cursor (using bottom positioning)
-        // bottom distance = viewport height - cursor top position
-        const bottom = window.innerHeight - cursorAbsoluteTop;
+        const bottom = vh - cursorAbsoluteTop;
         mentionStyle.value = {
           left: `${left}px`,
           bottom: `${bottom}px`,
@@ -1344,19 +1348,22 @@ const triggerMention = () => {
   mentionQuery.value = "";
   mentionStartPos.value = textarea.selectionStart;
 
-  const rect = textarea.getBoundingClientRect();
+  // Normalize coordinates to CSS pixels (root <html> may carry `zoom`).
+  const zoom = getRootZoom();
+  const rect = rectToCssPx(textarea.getBoundingClientRect(), zoom);
+  const { height: vh } = cssViewportSize(zoom);
   const menuHeight = 320;
 
   // 判断输入框上方空间
   const spaceAbove = rect.top;
-  const spaceBelow = window.innerHeight - rect.bottom;
+  const spaceBelow = vh - rect.bottom;
 
   // 优先显示在上方，除非上方空间不足且下方空间充足
   if (spaceAbove > menuHeight || spaceAbove > spaceBelow) {
     // Show above textarea
     mentionStyle.value = {
       left: `${rect.left}px`,
-      bottom: `${window.innerHeight - rect.top + 8}px`, // 8px padding
+      bottom: `${vh - rect.top + 8}px`, // 8px padding
       top: 'auto'
     };
   } else {
@@ -1643,11 +1650,12 @@ const updateAgentModeDropdownPosition = () => {
     return;
   }
 
-  const rect = anchor.getBoundingClientRect();
+  // Normalize coordinates to CSS pixels (root <html> may carry `zoom`).
+  const zoom = getRootZoom();
+  const rect = rectToCssPx(anchor.getBoundingClientRect(), zoom);
   const dropdownWidth = 200;
   const offsetY = 8;
-  const vw = window.innerWidth;
-  const vh = window.innerHeight;
+  const { width: vw, height: vh } = cssViewportSize(zoom);
 
   // 水平位置：左对齐
   let left = Math.floor(rect.left);

--- a/frontend/src/components/KnowledgeBaseSelector.vue
+++ b/frontend/src/components/KnowledgeBaseSelector.vue
@@ -67,6 +67,7 @@ import { ref, computed, watch, nextTick } from 'vue'
 import { useSettingsStore } from '@/stores/settings'
 import { listKnowledgeBases } from '@/api/knowledge-base'
 import { useI18n } from 'vue-i18n'
+import { getRootZoom, rectToCssPx, cssViewportSize } from '@/utils/zoom'
 
 interface KnowledgeBase {
   id: string
@@ -174,14 +175,18 @@ const loadKnowledgeBases = async () => {
 const updateDropdownPosition = () => {
   const anchor = resolveAnchorEl()
   
+  // Cache root zoom for this update. Both fallback and rect-anchored paths
+  // need to convert visual measurements to CSS pixels (see utils/zoom.ts).
+  const zoom = getRootZoom()
+  const { width: vwFallback, height: vhFallback } = cssViewportSize(zoom)
+
   // fallback 函数
   const applyFallback = () => {
-    const vw = window.innerWidth;
-    const topFallback = Math.max(80, window.innerHeight / 2 - 160);
+    const topFallback = Math.max(80, vhFallback / 2 - 160);
     dropdownStyle.value = {
       position: 'fixed',
       width: `${dropdownWidth}px`,
-      left: `${Math.round((vw - dropdownWidth) / 2)}px`,
+      left: `${Math.round((vwFallback - dropdownWidth) / 2)}px`,
       top: `${Math.round(topFallback)}px`,
       transform: 'none',
       margin: '0',
@@ -195,33 +200,30 @@ const updateDropdownPosition = () => {
   }
 
   // 获取 anchor 的 bounding rect（相对于视口）
-  let rect: DOMRect | null = null
+  let rawRect: { top: number; left: number; right: number; bottom: number; width: number; height: number } | null = null
   try {
     if (typeof anchor.getBoundingClientRect === 'function') {
-      rect = anchor.getBoundingClientRect()
-      console.log('[KB Selector] Button rect:', {
-        top: rect.top,
-        bottom: rect.bottom,
-        left: rect.left,
-        right: rect.right,
-        width: rect.width,
-        height: rect.height
-      })
+      const r = anchor.getBoundingClientRect()
+      rawRect = { top: r.top, left: r.left, right: r.right, bottom: r.bottom, width: r.width, height: r.height }
     } else if (anchor.width !== undefined && anchor.left !== undefined) {
-      // 已经是 DOMRect
-      rect = anchor as DOMRect
+      // Already a DOMRect-like
+      rawRect = anchor as DOMRect
     }
   } catch (e) {
     console.error('[KnowledgeBaseSelector] Error getting bounding rect:', e)
   }
-  
-  if (!rect || rect.width === 0 || rect.height === 0) {
+
+  if (!rawRect || rawRect.width === 0 || rawRect.height === 0) {
     applyFallback()
     return
   }
 
-  const vw = window.innerWidth
-  const vh = window.innerHeight
+  // Convert to CSS pixels so subsequent comparisons against the dropdown's
+  // own width/height stay in one coordinate system.
+  const rect = rectToCssPx(rawRect, zoom)
+  console.log('[KB Selector] Button rect (css px):', rect)
+  const vw = vwFallback
+  const vh = vhFallback
   
   // 左对齐到触发元素的左边缘
   // 使用 Math.floor 而不是 Math.round，避免像素对齐问题

--- a/frontend/src/components/UserMenu.vue
+++ b/frontend/src/components/UserMenu.vue
@@ -243,6 +243,7 @@ import {
 } from '@/utils/tenantSwitch'
 import type { TenantInfo } from '@/api/tenant'
 import { useRoleLabel, useHomeTenant } from '@/composables/useRoleLabel'
+import { getRootZoom, rectToCssPx, cssViewportSize } from '@/utils/zoom'
 
 const { t } = useI18n()
 
@@ -496,13 +497,18 @@ const scheduleHideTenantSubmenu = () => {
 const positionTenantSubmenu = () => {
   const el = tenantMenuItemRef.value
   if (!el) return
-  const rect = el.getBoundingClientRect()
+  // Submenu is rendered with `position: fixed` under the root zoom — see
+  // `.tenant-submenu-floating` styles. Anchor coords come from a visual-pixel
+  // rect; normalize to CSS pixels before writing them back to CSS.
+  const zoom = getRootZoom()
+  const rect = rectToCssPx(el.getBoundingClientRect(), zoom)
+  const { width: vw } = cssViewportSize(zoom)
   const PANEL_WIDTH = 264
   const GAP = 8
   const MARGIN = 8
 
   let left = rect.right + GAP
-  if (left + PANEL_WIDTH + MARGIN > window.innerWidth) {
+  if (left + PANEL_WIDTH + MARGIN > vw) {
     left = Math.max(MARGIN, rect.left - PANEL_WIDTH - GAP)
   }
 
@@ -538,14 +544,18 @@ const onChannelsChanged = (channels: IMChannelOverview[]) => {
 const positionIMSubmenu = () => {
   const el = imMenuItemRef.value
   if (!el) return
-  const rect = el.getBoundingClientRect()
+  // Same rationale as `positionTenantSubmenu` — convert visual-pixel rect to
+  // CSS pixels before feeding the fixed submenu's CSS lengths.
+  const zoom = getRootZoom()
+  const rect = rectToCssPx(el.getBoundingClientRect(), zoom)
+  const { width: vw } = cssViewportSize(zoom)
   const PANEL_WIDTH = 300
   const GAP = 8
   const MARGIN = 8
 
   let left = rect.right + GAP
   // If the panel would overflow the right edge, flip to the left side.
-  if (left + PANEL_WIDTH + MARGIN > window.innerWidth) {
+  if (left + PANEL_WIDTH + MARGIN > vw) {
     left = Math.max(MARGIN, rect.left - PANEL_WIDTH - GAP)
   }
 
@@ -567,9 +577,13 @@ const clampFloatingToViewport = (selector: string, target: { value: Record<strin
     const panel = document.querySelector(selector) as HTMLElement | null
     if (!panel) return
     const MARGIN = 8
+    // `offsetHeight` and `target.value.top` are CSS pixels; `innerHeight` is
+    // visual pixels under root zoom. Normalize the latter to keep the
+    // comparison in one coordinate system.
+    const { height: vh } = cssViewportSize()
     const h = panel.offsetHeight
     const currentTop = parseFloat(target.value.top || '0') || 0
-    const maxTop = window.innerHeight - h - MARGIN
+    const maxTop = vh - h - MARGIN
     if (currentTop > maxTop) {
       target.value = { ...target.value, top: `${Math.max(MARGIN, maxTop)}px` }
     }

--- a/frontend/src/utils/zoom.ts
+++ b/frontend/src/utils/zoom.ts
@@ -1,0 +1,75 @@
+/**
+ * Helpers for positioning floating UI (fixed/absolute popovers) under CSS
+ * `zoom` applied on the root `<html>` element.
+ *
+ * Why this exists:
+ * - `composables/useFont.ts` writes `zoom: <scale>` onto `<html>` to honor the
+ *   user's font-size preference. That zoom multiplies everything inside.
+ * - `getBoundingClientRect()`, `window.innerWidth/innerHeight`, `MouseEvent.clientX/Y`
+ *   and similar APIs return values in **visual (device-like) pixels** — already
+ *   scaled by zoom.
+ * - CSS lengths written to a fixed/absolute element living inside the zoom
+ *   context (anywhere under `<html>`) are interpreted in **CSS pixels** and
+ *   then multiplied by zoom when rendered.
+ *
+ * To anchor a popover to a visual coordinate (e.g. the rect of a button), we
+ * must divide the visual measurement by the root zoom before writing it into
+ * CSS `left/top/right/bottom/width/height/maxHeight/...`.
+ */
+
+/**
+ * Read the current `zoom` value applied to `<html>`. Returns 1 when zoom is
+ * unset, computed as a non-finite value, or in environments without a DOM.
+ */
+export function getRootZoom(): number {
+  if (typeof document === 'undefined') return 1
+  const root = document.documentElement
+  if (!root) return 1
+  const raw = getComputedStyle(root).zoom
+  const zoom = Number.parseFloat(raw || '1')
+  if (!Number.isFinite(zoom) || zoom <= 0) return 1
+  return zoom
+}
+
+/**
+ * Convert a visual-pixel measurement to the CSS-pixel value that should be
+ * written into the style of a fixed/absolute element under the root zoom.
+ *
+ * Pass `zoom` explicitly when you already cached it for a calculation to
+ * avoid re-reading computed style multiple times.
+ */
+export function toCssPx(visualPx: number, zoom: number = getRootZoom()): number {
+  return visualPx / zoom
+}
+
+/**
+ * Normalize a `DOMRect`-like value from `getBoundingClientRect()` (visual
+ * pixels) into CSS pixels. Returns a plain object so callers can read/write
+ * freely without worrying about the immutable `DOMRect` shape.
+ */
+export function rectToCssPx(
+  rect: { top: number; left: number; right: number; bottom: number; width: number; height: number },
+  zoom: number = getRootZoom(),
+): { top: number; left: number; right: number; bottom: number; width: number; height: number } {
+  return {
+    top: rect.top / zoom,
+    left: rect.left / zoom,
+    right: rect.right / zoom,
+    bottom: rect.bottom / zoom,
+    width: rect.width / zoom,
+    height: rect.height / zoom,
+  }
+}
+
+/**
+ * Viewport size in CSS pixels (i.e., the coordinate system used by CSS
+ * lengths under the root zoom). `window.innerWidth/innerHeight` are visual
+ * pixels, so divide by zoom.
+ */
+export function cssViewportSize(zoom: number = getRootZoom()): { width: number; height: number } {
+  if (typeof window === 'undefined') return { width: 0, height: 0 }
+  return {
+    width: window.innerWidth / zoom,
+    height: window.innerHeight / zoom,
+  }
+}

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -1248,6 +1248,7 @@ import PromptTemplateSelector from '@/components/PromptTemplateSelector.vue';
 import ModelSelector from '@/components/ModelSelector.vue';
 import AgentShareSettings from '@/components/AgentShareSettings.vue';
 import IMChannelPanel from '@/components/IMChannelPanel.vue';
+import { getRootZoom, rectToCssPx } from '@/utils/zoom';
 import {
   evaluateToolRequirement,
   deriveKbFilterFromTools,
@@ -2636,7 +2637,9 @@ const calculateCursorPosition = (textarea: HTMLTextAreaElement) => {
   const textBeforeCursor = formData.value.config.system_prompt.substring(0, cursorPos);
 
   const style = window.getComputedStyle(textarea);
-  const textareaRect = textarea.getBoundingClientRect();
+  // Placeholder popup is `position: fixed` under the root zoom; normalize the
+  // visual-pixel rect to CSS pixels so the popup actually lands on the caret.
+  const textareaRect = rectToCssPx(textarea.getBoundingClientRect(), getRootZoom());
 
   const lineHeight = parseFloat(style.lineHeight) || 20;
   const paddingTop = parseFloat(style.paddingTop) || 0;
@@ -2791,7 +2794,8 @@ const calculateContextCursorPosition = (textarea: HTMLTextAreaElement) => {
   const textBeforeCursor = formData.value.config.context_template.substring(0, cursorPos);
 
   const style = window.getComputedStyle(textarea);
-  const textareaRect = textarea.getBoundingClientRect();
+  // See `calculateCursorPosition` for the zoom rationale.
+  const textareaRect = rectToCssPx(textarea.getBoundingClientRect(), getRootZoom());
 
   const lineHeight = parseFloat(style.lineHeight) || 20;
   const paddingTop = parseFloat(style.paddingTop) || 0;
@@ -2951,7 +2955,8 @@ const calculateGenericCursorPosition = (textarea: HTMLTextAreaElement, fieldValu
   const currentLine = lines.length - 1;
   const currentLineText = lines[currentLine];
 
-  const textareaRect = textarea.getBoundingClientRect();
+  // See `calculateCursorPosition` for the zoom rationale.
+  const textareaRect = rectToCssPx(textarea.getBoundingClientRect(), getRootZoom());
   const style = window.getComputedStyle(textarea);
   const lineHeight = parseFloat(style.lineHeight) || 20;
   const paddingTop = parseFloat(style.paddingTop) || 0;

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -410,6 +410,7 @@ import ToolResultRenderer from './ToolResultRenderer.vue';
 import ToolApprovalCard from './ToolApprovalCard.vue';
 import picturePreview from '@/components/picture-preview.vue';
 import { getChunkByIdOnly } from '@/api/knowledge-base';
+import { getRootZoom, rectToCssPx } from '@/utils/zoom';
 import { getWikiPage, type WikiPage } from '@/api/wiki';
 import { MessagePlugin } from 'tdesign-vue-next';
 import { useUIStore } from '@/stores/ui';
@@ -737,9 +738,14 @@ const cancelFloatClose = () => {
 };
 
 const openFloatForEl = (el: HTMLElement, widthAdjust = 120) => {
-  const rect = el.getBoundingClientRect();
-  const pageTop = window.scrollY || document.documentElement.scrollTop || 0;
-  const pageLeft = window.scrollX || document.documentElement.scrollLeft || 0;
+  // `.kb-float-popup` is `position: absolute` and teleported to <body>, so
+  // its containing block is the initial containing block — which lives under
+  // the root `zoom` in `<html>`. Convert visual-pixel measurements to CSS px
+  // so the popup actually lines up with the anchor.
+  const zoom = getRootZoom();
+  const rect = rectToCssPx(el.getBoundingClientRect(), zoom);
+  const pageTop = (window.scrollY || document.documentElement.scrollTop || 0) / zoom;
+  const pageLeft = (window.scrollX || document.documentElement.scrollLeft || 0) / zoom;
   // Reduce gap to minimize mouseout triggers when moving to popup
   floatPopup.value.top = rect.bottom + pageTop + 1;
   floatPopup.value.left = rect.left + pageLeft;


### PR DESCRIPTION
## Description

Follow-up to #1459, which fixed the agent selector dropdown alignment under root `zoom`. The same bug affects **every other popover in the app that anchors itself with `getBoundingClientRect()` + `position: fixed/absolute`**, because:

- `composables/useFont.ts` writes `zoom: <scale>` onto `<html>` to honor the user's font-size preference.
- `getBoundingClientRect()`, `window.innerWidth/innerHeight`, `scrollX/Y` are reported in **visual pixels** (already pre-multiplied by zoom).
- CSS lengths written on a fixed/absolute element under `<html>` are interpreted in **CSS pixels** and then multiplied by zoom again at paint time.

This causes popovers to drift toward the lower-right (under `zoom > 1`) or upper-left (under `zoom < 1`), with `maxHeight`/`width`/viewport-edge clamping miscomputed.

PR #1459 patched only `AgentSelector.vue` and left its `width` / `maxHeight` unnormalized.

## What this PR does

Introduces a single shared helper `frontend/src/utils/zoom.ts`:

- `getRootZoom()` — reads the current root zoom (falls back to 1).
- `rectToCssPx(rect, zoom?)` — converts a `DOMRect`-like value to CSS pixels.
- `cssViewportSize(zoom?)` — `window.innerWidth/Height` in CSS pixels.

…then applies it to every affected popover:

| File | What was broken |
| --- | --- |
| `components/AgentSelector.vue` | Refactored to use the helper; **also normalizes `width` and `maxHeight`** (#1459 missed these). |
| `components/Input-field.vue` | Model dropdown, `@`-triggered mention popup, button-triggered mention popup, and agent-mode dropdown. |
| `components/KnowledgeBaseSelector.vue` | Both primary anchor path and the centered fallback path. |
| `components/UserMenu.vue` | Tenant + IM floating submenus, plus `clampFloatingToViewport` (mixed CSS-vs-visual px comparison). |
| `components/FAQTagTooltip.vue` | Fixed tooltip + viewport edge clamping. |
| `views/agent/AgentEditorModal.vue` | Placeholder popups for `system_prompt`, `context_template`, and the rewrite/fallback prompts. |
| `views/chat/components/AgentStreamDisplay.vue` | `kb-float-popup` (absolute under `<body>`, still inside the zoom containing block). |

Not changed:
- `TenantSelector.vue` — uses pure CSS relative positioning (`position: absolute; top: calc(100% + 4px)`), not affected.
- `MentionSelector.vue` lines 283–284 — only scrolls inside the menu; not positioning.
- `utils/mermaidViewer.ts`, `WikiBrowser.vue` zoom-toward-cursor logic — internally consistent (SVG viewBox math).
- `FAQEntryManager.vue` masonry — measured heights and positions are all in the same CSS-pixel space.

## Testing

- [x] `npm --prefix frontend run build` — passes (built in ~14s).
- [ ] Manual: zoom = 0.8 / 1.0 / 1.25 / 1.5 × {below-anchor, above-anchor} for each popover above.

## Checklist

- [x] Self-reviewed the code
- [x] Shared helper centralizes the zoom math instead of inlining per-file
- [x] No behavior change at `zoom = 1`
- [x] No new TypeScript errors