### PR TITLE
fix(agent): recover concatenated tool arguments

### DIFF
--- a/internal/agent/act.go
+++ b/internal/agent/act.go
@@ -314,23 +314,34 @@ func (e *AgentEngine) runToolCall(
 	var args map[string]any
 	argsStr := tc.Function.Arguments
 	if err := json.Unmarshal([]byte(argsStr), &args); err != nil {
-		repaired := agenttools.RepairJSON(argsStr)
-		if repairErr := json.Unmarshal([]byte(repaired), &args); repairErr != nil {
-			logger.Errorf(ctx, "%s Failed to parse arguments (repair failed): %v", toolTag, err)
-			return types.ToolCall{
-				ID:   tc.ID,
-				Name: tc.Function.Name,
-				Args: map[string]any{"_raw": argsStr},
-				Result: &types.ToolResult{
-					Success: false,
-					Error: fmt.Sprintf(
-						"Failed to parse tool arguments: %v", err,
-					) + "\n\n[Analyze the error above and try a different approach.]",
-				},
+		parsed := false
+		if firstObject, ok := agenttools.ExtractFirstJSONObject(argsStr); ok {
+			if firstErr := json.Unmarshal([]byte(firstObject), &args); firstErr == nil {
+				logger.Warnf(ctx, "%s Recovered concatenated JSON arguments by using first object", toolTag)
+				tc.Function.Arguments = firstObject
+				parsed = true
 			}
 		}
-		logger.Warnf(ctx, "%s Repaired malformed JSON arguments", toolTag)
-		tc.Function.Arguments = repaired
+
+		if !parsed {
+			repaired := agenttools.RepairJSON(argsStr)
+			if repairErr := json.Unmarshal([]byte(repaired), &args); repairErr != nil {
+				logger.Errorf(ctx, "%s Failed to parse arguments (repair failed): %v", toolTag, err)
+				return types.ToolCall{
+					ID:   tc.ID,
+					Name: tc.Function.Name,
+					Args: map[string]any{"_raw": argsStr},
+					Result: &types.ToolResult{
+						Success: false,
+						Error: fmt.Sprintf(
+							"Failed to parse tool arguments: %v", err,
+						) + "\n\n[Analyze the error above and try a different approach.]",
+					},
+				}
+			}
+			logger.Warnf(ctx, "%s Repaired malformed JSON arguments", toolTag)
+			tc.Function.Arguments = repaired
+		}
 	}
 
 	logger.Debugf(ctx, "%s Args: %s", toolTag, tc.Function.Arguments)

--- a/internal/agent/act_test.go
+++ b/internal/agent/act_test.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	agenttools "github.com/Tencent/WeKnora/internal/agent/tools"
+	"github.com/Tencent/WeKnora/internal/event"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+type captureArgsTool struct {
+	args json.RawMessage
+}
+
+func (t *captureArgsTool) Name() string {
+	return "grep_chunksknowledge_search"
+}
+
+func (t *captureArgsTool) Description() string {
+	return "captures tool arguments"
+}
+
+func (t *captureArgsTool) Parameters() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"queries":{"type":"array","items":{"type":"string"}},
+			"knowledge_base_ids":{"type":"array","items":{"type":"string"}},
+			"limit":{"type":"number"}
+		},
+		"required":["queries","knowledge_base_ids"]
+	}`)
+}
+
+func (t *captureArgsTool) Execute(_ context.Context, args json.RawMessage) (*types.ToolResult, error) {
+	t.args = append(t.args[:0], args...)
+	return &types.ToolResult{Success: true, Output: "ok"}, nil
+}
+
+func TestRunToolCallRecoversConcatenatedJSONArguments(t *testing.T) {
+	tool := &captureArgsTool{}
+	registry := agenttools.NewToolRegistry()
+	registry.RegisterTool(tool)
+	engine := &AgentEngine{
+		toolRegistry: registry,
+		eventBus:     event.NewEventBus(),
+	}
+
+	firstArgs := `{"queries":["急救站.{0,20}质量控制系统|质量控制系统|急救站"],"knowledge_base_ids":["kb-1","kb-2"],"limit":10}`
+	secondArgs := `{"queries":["介绍急救站质量控制系统的定位、功能和组成"],"knowledge_base_ids":["kb-1","kb-2"]}`
+	call := types.LLMToolCall{
+		ID:   "call-1",
+		Type: "function",
+		Function: types.FunctionCall{
+			Name:      tool.Name(),
+			Arguments: firstArgs + secondArgs,
+		},
+	}
+
+	result := engine.runToolCall(context.Background(), call, 0, 0, 1, "session-1", "message-1")
+
+	require.NotNil(t, result.Result)
+	require.True(t, result.Result.Success, "unexpected tool error: %s", result.Result.Error)
+	require.JSONEq(t, firstArgs, string(tool.args))
+	require.Equal(t, []any{"急救站.{0,20}质量控制系统|质量控制系统|急救站"}, result.Args["queries"])
+}

--- a/internal/agent/tools/json_repair.go
+++ b/internal/agent/tools/json_repair.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode"
 )
@@ -43,6 +44,54 @@ func RepairJSON(s string) string {
 	s = balanceBrackets(s)
 
 	return s
+}
+
+// ExtractFirstJSONObject returns the first complete top-level JSON object from s.
+// Some model providers occasionally concatenate two tool-argument objects into
+// one string; the first object is still a valid executable argument payload.
+func ExtractFirstJSONObject(s string) (string, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" || s[0] != '{' {
+		return "", false
+	}
+
+	depth := 0
+	inString := false
+	escaped := false
+
+	for i, r := range s {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inString {
+			switch r {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+
+		switch r {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				first := s[:i+1]
+				return first, json.Valid([]byte(first))
+			}
+			if depth < 0 {
+				return "", false
+			}
+		}
+	}
+
+	return "", false
 }
 
 // fixInvalidEscapes turns invalid JSON string escapes into literal backslash

--- a/internal/agent/tools/json_repair_test.go
+++ b/internal/agent/tools/json_repair_test.go
@@ -124,3 +124,32 @@ func TestRepairJSON(t *testing.T) {
 		assert.True(t, json.Valid([]byte(result)))
 	})
 }
+
+func TestExtractFirstJSONObject(t *testing.T) {
+	t.Run("extracts first object from concatenated tool arguments", func(t *testing.T) {
+		first := `{"queries":["急救站.{0,20}质量控制系统|质量控制系统|急救站"],"knowledge_base_ids":["kb-1","kb-2"],"limit":10}`
+		second := `{"queries":["介绍急救站质量控制系统的定位、功能和组成"],"knowledge_base_ids":["kb-1","kb-2"]}`
+
+		result, ok := ExtractFirstJSONObject(first + second)
+
+		require.True(t, ok)
+		assert.Equal(t, first, result)
+		assert.True(t, json.Valid([]byte(result)))
+	})
+
+	t.Run("ignores braces inside strings", func(t *testing.T) {
+		first := `{"pattern":"literal } brace","nested":{"query":"{value}"}}`
+
+		result, ok := ExtractFirstJSONObject(first + `{"extra":true}`)
+
+		require.True(t, ok)
+		assert.Equal(t, first, result)
+	})
+
+	t.Run("rejects incomplete object", func(t *testing.T) {
+		result, ok := ExtractFirstJSONObject(`{"queries":["missing close"]`)
+
+		assert.False(t, ok)
+		assert.Empty(t, result)
+	})
+}


### PR DESCRIPTION
## Summary

- Fixes #1455.
- Recovers tool calls where the model/provider concatenates two JSON argument objects into one `Function.Arguments` string, e.g. `{...}{...}`.
- Uses only the first complete top-level JSON object, then keeps the existing `RepairJSON` fallback unchanged for other malformed JSON cases.
- Adds regression coverage for the Agent tool-call path and JSON object extraction edge cases.

## Why this is safe

- Valid JSON arguments are not changed because this recovery only runs after normal `json.Unmarshal` fails.
- Existing JSON repair behavior is preserved when no complete first JSON object can be recovered.
- The fix does not merge multiple objects, which would be ambiguous; it executes the first valid argument payload and logs the recovery.

## Tests

- `CGO_LDFLAGS="-lc++" go test ./internal/agent -run TestRunToolCallRecoversConcatenatedJSONArguments -count=1`
- `CGO_LDFLAGS="-lc++" go test ./internal/agent/tools -run 'Test(ExtractFirstJSONObject|RepairJSON)' -count=1`
- `CGO_LDFLAGS="-lc++" go test ./internal/agent ./internal/agent/tools -count=1`
- `CGO_LDFLAGS="-lc++" go test ./internal/agent/... -count=1`
- `git diff --check`

Also ran `CGO_LDFLAGS="-lc++" go test ./internal/... -count=1`; Agent-related packages passed, while unrelated existing tests failed in `internal/application/service`, `internal/application/service/file`, `internal/datasource/connector/yuque`, and `internal/infrastructure/web_search`.
