### PR TITLE
fix: skip empty milvus enabled status groups

### DIFF
--- a/internal/application/repository/retriever/milvus/repository.go
+++ b/internal/application/repository/retriever/milvus/repository.go
@@ -436,54 +436,50 @@ func (m *milvusRepository) BatchUpdateChunkEnabledStatus(ctx context.Context, ch
 			collectionName[:len(m.collectionBaseName)] != m.collectionBaseName {
 			continue
 		}
-		enabledEmbeddings, _, err := m.searchByFilter(ctx, collectionName, &universalFilterCondition{
-			Field:    fieldChunkID,
-			Operator: operatorIn,
-			Value:    enabledChunkIDs,
-		}, nil, nil)
-		if err != nil {
-			log.Warnf("[Milvus] Failed to search enabled chunks in %s: %v", collectionName, err)
-			continue
+		if err := m.updateChunkEnabledStatusInCollection(ctx, collectionName, enabledChunkIDs, true); err != nil {
+			log.Warnf("[Milvus] Failed to update enabled chunks in %s: %v", collectionName, err)
 		}
-		upsertEmbeddings := make([]*MilvusVectorEmbedding, 0, len(enabledEmbeddings))
-		for _, embedding := range enabledEmbeddings {
-			embedding.IsEnabled = true
-			upsertEmbeddings = append(upsertEmbeddings, &embedding.MilvusVectorEmbedding)
-		}
-		if len(upsertEmbeddings) > 0 {
-			enabledReq := createUpsert(collectionName, upsertEmbeddings)
-			_, err := m.client.Upsert(ctx, enabledReq)
-			if err != nil {
-				log.Warnf("[Milvus] Failed to update enabled chunks in %s: %v", collectionName, err)
-				continue
-			}
-		}
-
-		disabledEmbeddings, _, err := m.searchByFilter(ctx, collectionName, &universalFilterCondition{
-			Field:    fieldChunkID,
-			Operator: operatorIn,
-			Value:    disabledChunkIDs,
-		}, nil, nil)
-		if err != nil {
-			log.Warnf("[Milvus] Failed to search disabled chunks in %s: %v", collectionName, err)
-			continue
-		}
-		upsertEmbeddings = make([]*MilvusVectorEmbedding, 0, len(disabledEmbeddings))
-		for _, embedding := range disabledEmbeddings {
-			embedding.IsEnabled = false
-			upsertEmbeddings = append(upsertEmbeddings, &embedding.MilvusVectorEmbedding)
-		}
-		if len(upsertEmbeddings) > 0 {
-			disabledReq := createUpsert(collectionName, upsertEmbeddings)
-			_, err := m.client.Upsert(ctx, disabledReq)
-			if err != nil {
-				log.Warnf("[Milvus] Failed to update disabled chunks in %s: %v", collectionName, err)
-				continue
-			}
+		if err := m.updateChunkEnabledStatusInCollection(ctx, collectionName, disabledChunkIDs, false); err != nil {
+			log.Warnf("[Milvus] Failed to update disabled chunks in %s: %v", collectionName, err)
 		}
 	}
 
 	log.Infof("[Milvus] Batch update chunk enabled status completed")
+	return nil
+}
+
+func (m *milvusRepository) updateChunkEnabledStatusInCollection(
+	ctx context.Context,
+	collectionName string,
+	chunkIDs []string,
+	enabled bool,
+) error {
+	if len(chunkIDs) == 0 {
+		return nil
+	}
+
+	embeddings, _, err := m.searchByFilter(ctx, collectionName, &universalFilterCondition{
+		Field:    fieldChunkID,
+		Operator: operatorIn,
+		Value:    chunkIDs,
+	}, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	upsertEmbeddings := make([]*MilvusVectorEmbedding, 0, len(embeddings))
+	for _, embedding := range embeddings {
+		embedding.IsEnabled = enabled
+		upsertEmbeddings = append(upsertEmbeddings, &embedding.MilvusVectorEmbedding)
+	}
+	if len(upsertEmbeddings) == 0 {
+		return nil
+	}
+
+	req := createUpsert(collectionName, upsertEmbeddings)
+	if _, err := m.client.Upsert(ctx, req); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/application/repository/retriever/milvus/repository_test.go
+++ b/internal/application/repository/retriever/milvus/repository_test.go
@@ -1,0 +1,25 @@
+package milvus
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateChunkEnabledStatusInCollectionSkipsEmptyChunkIDs(t *testing.T) {
+	repo := &milvusRepository{}
+
+	require.NoError(t, repo.updateChunkEnabledStatusInCollection(
+		context.Background(),
+		"weknora_embeddings_1024",
+		nil,
+		false,
+	))
+	require.NoError(t, repo.updateChunkEnabledStatusInCollection(
+		context.Background(),
+		"weknora_embeddings_1024",
+		[]string{},
+		true,
+	))
+}


### PR DESCRIPTION
## Summary

Fixes #1450.

When FAQ entries are batch-disabled with Milvus as the retrieve driver, the update payload can contain only disabled chunk IDs. The previous Milvus sync path still tried to query the empty enabled group first, which builds an invalid `IN []` filter and skips the rest of the collection update. As a result, the database row becomes disabled but the Milvus embedding keeps `is_enabled=true`, so the disabled FAQ can still be retrieved.

This PR extracts the per-collection enabled-status update and makes empty chunk ID groups a no-op before building the Milvus filter. The enabled and disabled groups are also handled independently so one group does not block the other.

## Testing

- `CGO_LDFLAGS='-lc++' go test ./internal/application/repository/retriever/milvus -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/repository/retriever/... -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service -run FAQ -count=1`

Note: on local macOS, `CGO_LDFLAGS='-lc++'` is needed for the existing cppjieba/cgo linkage.
