### PR TITLE
fix(chat): stabilize tool ordering and report cached prompt tokens

### DIFF
--- a/internal/agent/tools/registry.go
+++ b/internal/agent/tools/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/Tencent/WeKnora/internal/common"
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -62,19 +63,34 @@ func (r *ToolRegistry) GetTool(name string) (types.Tool, error) {
 	return tool, nil
 }
 
-// ListTools returns all registered tool names
+// ListTools returns all registered tool names sorted alphabetically.
+// Sorting keeps the order stable across calls — Go map iteration is
+// intentionally randomized.
 func (r *ToolRegistry) ListTools() []string {
 	names := make([]string, 0, len(r.tools))
 	for name := range r.tools {
 		names = append(names, name)
 	}
+	sort.Strings(names)
 	return names
 }
 
-// GetFunctionDefinitions returns function definitions for all registered tools
+// GetFunctionDefinitions returns function definitions for all registered tools.
+// The slice is sorted by tool name so the serialized payload sent to the LLM
+// is byte-identical across requests. Providers that key prompt caching on a
+// byte-level prefix match (e.g. Qwen explicit caching) require this — map
+// iteration order would otherwise reshuffle the tools block and break cache
+// hits.
 func (r *ToolRegistry) GetFunctionDefinitions() []types.FunctionDefinition {
-	definitions := make([]types.FunctionDefinition, 0)
-	for _, tool := range r.tools {
+	names := make([]string, 0, len(r.tools))
+	for name := range r.tools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	definitions := make([]types.FunctionDefinition, 0, len(names))
+	for _, name := range names {
+		tool := r.tools[name]
 		definitions = append(definitions, types.FunctionDefinition{
 			Name:        tool.Name(),
 			Description: tool.Description(),

--- a/internal/agent/tools/registry_test.go
+++ b/internal/agent/tools/registry_test.go
@@ -1,0 +1,156 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockTool is a minimal types.Tool implementation for registry tests.
+type mockTool struct {
+	name        string
+	description string
+	parameters  json.RawMessage
+}
+
+func (m *mockTool) Name() string                { return m.name }
+func (m *mockTool) Description() string         { return m.description }
+func (m *mockTool) Parameters() json.RawMessage { return m.parameters }
+func (m *mockTool) Execute(ctx context.Context, args json.RawMessage) (*types.ToolResult, error) {
+	return &types.ToolResult{Success: true}, nil
+}
+
+// registerMany registers a batch of mock tools with the given names.
+func registerMany(t *testing.T, r *ToolRegistry, names []string) {
+	t.Helper()
+	for _, n := range names {
+		r.RegisterTool(&mockTool{
+			name:        n,
+			description: "desc-" + n,
+			parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","title":"%s"}`, n)),
+		})
+	}
+}
+
+// TestGetFunctionDefinitions_DeterministicOrder pins the core invariant: the
+// output is sorted by tool name and identical across repeated calls. Go's map
+// iteration is intentionally randomized, so without an explicit sort the slice
+// can reshuffle on every call — which silently breaks byte-level prompt prefix
+// caching at providers like Qwen.
+func TestGetFunctionDefinitions_DeterministicOrder(t *testing.T) {
+	// Insertion order is deliberately non-alphabetical to make any accidental
+	// "insertion order" implementation fail this test.
+	names := []string{"zeta", "alpha", "kappa", "beta", "gamma", "delta", "epsilon", "omega"}
+
+	r := NewToolRegistry()
+	registerMany(t, r, names)
+
+	expected := append([]string(nil), names...)
+	sort.Strings(expected)
+
+	// Many iterations because map randomization may happen to match the sorted
+	// order on a single call.
+	const iterations = 50
+	var prev []string
+	for i := 0; i < iterations; i++ {
+		defs := r.GetFunctionDefinitions()
+		require.Len(t, defs, len(names))
+
+		got := make([]string, len(defs))
+		for j, d := range defs {
+			got[j] = d.Name
+		}
+
+		assert.Equal(t, expected, got, "iteration %d: definitions must be sorted by name", i)
+		if prev != nil {
+			assert.Equal(t, prev, got, "iteration %d: definitions must match the previous call", i)
+		}
+		prev = got
+	}
+}
+
+// TestGetFunctionDefinitions_JSONByteStable is the real motivation for the
+// sort: two consecutive calls must produce byte-identical JSON so the prompt
+// prefix sent to the LLM stays stable and explicit caches can hit.
+func TestGetFunctionDefinitions_JSONByteStable(t *testing.T) {
+	r := NewToolRegistry()
+	registerMany(t, r, []string{"search", "fetch", "code_run", "answer", "wiki", "kb_query"})
+
+	first, err := json.Marshal(r.GetFunctionDefinitions())
+	require.NoError(t, err)
+
+	for i := 0; i < 20; i++ {
+		next, err := json.Marshal(r.GetFunctionDefinitions())
+		require.NoError(t, err)
+		assert.Equal(t, string(first), string(next),
+			"iteration %d: JSON-serialized tool definitions must be byte-stable", i)
+	}
+}
+
+// TestGetFunctionDefinitions_PreservesFields verifies the projection from
+// types.Tool to types.FunctionDefinition keeps every field intact.
+func TestGetFunctionDefinitions_PreservesFields(t *testing.T) {
+	r := NewToolRegistry()
+	r.RegisterTool(&mockTool{
+		name:        "search",
+		description: "Search the knowledge base",
+		parameters:  json.RawMessage(`{"type":"object","properties":{"q":{"type":"string"}},"required":["q"]}`),
+	})
+
+	defs := r.GetFunctionDefinitions()
+	require.Len(t, defs, 1)
+	assert.Equal(t, "search", defs[0].Name)
+	assert.Equal(t, "Search the knowledge base", defs[0].Description)
+	assert.JSONEq(t,
+		`{"type":"object","properties":{"q":{"type":"string"}},"required":["q"]}`,
+		string(defs[0].Parameters),
+	)
+}
+
+// TestGetFunctionDefinitions_Empty returns an empty (non-nil) slice for an
+// empty registry. Callers may json.Marshal the result and expect `[]`, not
+// `null`.
+func TestGetFunctionDefinitions_Empty(t *testing.T) {
+	r := NewToolRegistry()
+
+	defs := r.GetFunctionDefinitions()
+	assert.NotNil(t, defs)
+	assert.Empty(t, defs)
+
+	encoded, err := json.Marshal(defs)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(encoded))
+}
+
+// TestListTools_Sorted mirrors the determinism guarantee for ListTools.
+func TestListTools_Sorted(t *testing.T) {
+	names := []string{"zeta", "alpha", "kappa", "beta"}
+	r := NewToolRegistry()
+	registerMany(t, r, names)
+
+	expected := append([]string(nil), names...)
+	sort.Strings(expected)
+
+	for i := 0; i < 20; i++ {
+		assert.Equal(t, expected, r.ListTools(), "iteration %d: ListTools must be sorted", i)
+	}
+}
+
+// TestRegisterTool_DuplicateRejected guards the first-wins policy that
+// prevents tool execution hijacking via name collision (GHSA-67q9-58vj-32qx).
+// A re-registration must not overwrite the original tool.
+func TestRegisterTool_DuplicateRejected(t *testing.T) {
+	r := NewToolRegistry()
+	r.RegisterTool(&mockTool{name: "search", description: "original"})
+	r.RegisterTool(&mockTool{name: "search", description: "impostor"})
+
+	defs := r.GetFunctionDefinitions()
+	require.Len(t, defs, 1)
+	assert.Equal(t, "original", defs[0].Description, "first registration must win")
+}

--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -424,8 +424,8 @@ func (c *RemoteAPIChat) Chat(ctx context.Context, messages []Message, opts *Chat
 	if err != nil {
 		return nil, err
 	}
-	logger.Infof(timeoutCtx, "[LLM Usage] model=%s, prompt_tokens=%d, completion_tokens=%d, total_tokens=%d",
-		c.modelName, result.Usage.PromptTokens, result.Usage.CompletionTokens, result.Usage.TotalTokens)
+	logger.Infof(timeoutCtx, "[LLM Usage] model=%s, prompt_tokens=%d, completion_tokens=%d, total_tokens=%d, cached_tokens=%d",
+		c.modelName, result.Usage.PromptTokens, result.Usage.CompletionTokens, result.Usage.TotalTokens, result.Usage.CachedTokens)
 	return result, nil
 }
 
@@ -488,8 +488,8 @@ func (c *RemoteAPIChat) chatWithRawHTTP(ctx context.Context, endpoint string, cu
 	if err != nil {
 		return nil, err
 	}
-	logger.Infof(ctx, "[LLM Usage] model=%s, prompt_tokens=%d, completion_tokens=%d, total_tokens=%d",
-		c.modelName, result.Usage.PromptTokens, result.Usage.CompletionTokens, result.Usage.TotalTokens)
+	logger.Infof(ctx, "[LLM Usage] model=%s, prompt_tokens=%d, completion_tokens=%d, total_tokens=%d, cached_tokens=%d",
+		c.modelName, result.Usage.PromptTokens, result.Usage.CompletionTokens, result.Usage.TotalTokens, result.Usage.CachedTokens)
 	return result, nil
 }
 
@@ -512,6 +512,7 @@ func (c *RemoteAPIChat) parseCompletionResponse(resp *openai.ChatCompletionRespo
 			PromptTokens:     resp.Usage.PromptTokens,
 			CompletionTokens: resp.Usage.CompletionTokens,
 			TotalTokens:      resp.Usage.TotalTokens,
+			CachedTokens:     cachedTokens(resp.Usage.PromptTokensDetails),
 		},
 	}
 
@@ -696,8 +697,8 @@ func (c *RemoteAPIChat) processStream(ctx context.Context, stream *openai.ChatCo
 		if err != nil {
 			if err == io.EOF {
 				if state.usage != nil {
-					logger.Infof(ctx, "[LLM Usage] model=%s, prompt_tokens=%d, completion_tokens=%d, total_tokens=%d",
-						c.modelName, state.usage.PromptTokens, state.usage.CompletionTokens, state.usage.TotalTokens)
+					logger.Infof(ctx, "[LLM Usage] model=%s, prompt_tokens=%d, completion_tokens=%d, total_tokens=%d, cached_tokens=%d",
+						c.modelName, state.usage.PromptTokens, state.usage.CompletionTokens, state.usage.TotalTokens, state.usage.CachedTokens)
 				}
 				toolCalls := state.buildOrderedToolCalls()
 				streamChan <- types.StreamResponse{
@@ -723,6 +724,7 @@ func (c *RemoteAPIChat) processStream(ctx context.Context, stream *openai.ChatCo
 				PromptTokens:     response.Usage.PromptTokens,
 				CompletionTokens: response.Usage.CompletionTokens,
 				TotalTokens:      response.Usage.TotalTokens,
+				CachedTokens:     cachedTokens(response.Usage.PromptTokensDetails),
 			}
 		}
 
@@ -745,8 +747,8 @@ func (c *RemoteAPIChat) processRawHTTPStream(ctx context.Context, resp *http.Res
 		if err != nil {
 			if err == io.EOF {
 				if state.usage != nil {
-					logger.Infof(ctx, "[LLM Usage] model=%s, prompt_tokens=%d, completion_tokens=%d, total_tokens=%d",
-						c.modelName, state.usage.PromptTokens, state.usage.CompletionTokens, state.usage.TotalTokens)
+					logger.Infof(ctx, "[LLM Usage] model=%s, prompt_tokens=%d, completion_tokens=%d, total_tokens=%d, cached_tokens=%d",
+						c.modelName, state.usage.PromptTokens, state.usage.CompletionTokens, state.usage.TotalTokens, state.usage.CachedTokens)
 				}
 				toolCalls := state.buildOrderedToolCalls()
 				streamChan <- types.StreamResponse{
@@ -773,8 +775,8 @@ func (c *RemoteAPIChat) processRawHTTPStream(ctx context.Context, resp *http.Res
 
 		if event.Done {
 			if state.usage != nil {
-				logger.Infof(ctx, "[LLM Usage] model=%s, prompt_tokens=%d, completion_tokens=%d, total_tokens=%d",
-					c.modelName, state.usage.PromptTokens, state.usage.CompletionTokens, state.usage.TotalTokens)
+				logger.Infof(ctx, "[LLM Usage] model=%s, prompt_tokens=%d, completion_tokens=%d, total_tokens=%d, cached_tokens=%d",
+					c.modelName, state.usage.PromptTokens, state.usage.CompletionTokens, state.usage.TotalTokens, state.usage.CachedTokens)
 			}
 			toolCalls := state.buildOrderedToolCalls()
 			streamChan <- types.StreamResponse{
@@ -814,6 +816,7 @@ func (c *RemoteAPIChat) processRawHTTPStream(ctx context.Context, resp *http.Res
 				PromptTokens:     streamResp.Usage.PromptTokens,
 				CompletionTokens: streamResp.Usage.CompletionTokens,
 				TotalTokens:      streamResp.Usage.TotalTokens,
+				CachedTokens:     cachedTokens(streamResp.Usage.PromptTokensDetails),
 			}
 		}
 
@@ -1168,4 +1171,14 @@ func (c *RemoteAPIChat) GetBaseURL() string {
 // GetAPIKey 获取 apiKey
 func (c *RemoteAPIChat) GetAPIKey() string {
 	return c.apiKey
+}
+
+// cachedTokens returns the cached prompt-token count from an OpenAI-compatible
+// usage detail block, or zero when the provider did not report one. Some
+// providers omit PromptTokensDetails entirely, so the nil guard is required.
+func cachedTokens(d *openai.PromptTokensDetails) int {
+	if d == nil {
+		return 0
+	}
+	return d.CachedTokens
 }

--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -1176,6 +1176,16 @@ func (c *RemoteAPIChat) GetAPIKey() string {
 // cachedTokens returns the cached prompt-token count from an OpenAI-compatible
 // usage detail block, or zero when the provider did not report one. Some
 // providers omit PromptTokensDetails entirely, so the nil guard is required.
+//
+// Note on provider semantics:
+//   - Implicit-cache providers (OpenAI, Azure OpenAI, DeepSeek, …) populate
+//     `cached_tokens` automatically whenever the prompt prefix matches a
+//     previous request — no caller opt-in is required.
+//   - Explicit-cache providers (Qwen on Aliyun, Anthropic Claude, …) only
+//     populate `cached_tokens` after the caller attaches `cache_control:
+//     {"type": "ephemeral"}` to the relevant message / content block. This
+//     helper still returns zero for those providers until that opt-in is
+//     applied upstream of the request.
 func cachedTokens(d *openai.PromptTokensDetails) int {
 	if d == nil {
 		return 0

--- a/internal/models/chat/remote_api_test.go
+++ b/internal/models/chat/remote_api_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/sashabaranov/go-openai"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -382,4 +383,94 @@ func TestRemoteAPIChat(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestCachedTokensHelper covers the nil-safety contract of the cachedTokens
+// helper. Some providers omit PromptTokensDetails entirely; the helper must
+// return zero rather than panic.
+func TestCachedTokensHelper(t *testing.T) {
+	assert.Equal(t, 0, cachedTokens(nil), "nil details must return zero")
+	assert.Equal(t, 0, cachedTokens(&openai.PromptTokensDetails{}),
+		"empty details must return zero")
+	assert.Equal(t, 1234, cachedTokens(&openai.PromptTokensDetails{CachedTokens: 1234}),
+		"populated cached_tokens must round-trip")
+}
+
+// TestParseCompletionResponse_CachedTokens verifies that
+// prompt_tokens_details.cached_tokens from an OpenAI-compatible response is
+// propagated into TokenUsage.CachedTokens. This is the field Qwen explicit
+// caching populates on a cache hit.
+func TestParseCompletionResponse_CachedTokens(t *testing.T) {
+	c := newTestRemoteChat(t)
+
+	t.Run("cached_tokens populated from prompt_tokens_details", func(t *testing.T) {
+		resp := &openai.ChatCompletionResponse{
+			Choices: []openai.ChatCompletionChoice{
+				{
+					Message:      openai.ChatCompletionMessage{Role: "assistant", Content: "hi"},
+					FinishReason: openai.FinishReasonStop,
+				},
+			},
+			Usage: openai.Usage{
+				PromptTokens:     6929,
+				CompletionTokens: 42,
+				TotalTokens:      6971,
+				PromptTokensDetails: &openai.PromptTokensDetails{
+					CachedTokens: 6900,
+				},
+			},
+		}
+
+		got, err := c.parseCompletionResponse(resp)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, 6929, got.Usage.PromptTokens)
+		assert.Equal(t, 42, got.Usage.CompletionTokens)
+		assert.Equal(t, 6971, got.Usage.TotalTokens)
+		assert.Equal(t, 6900, got.Usage.CachedTokens,
+			"cached_tokens must mirror prompt_tokens_details.cached_tokens")
+	})
+
+	t.Run("missing prompt_tokens_details yields zero cached_tokens", func(t *testing.T) {
+		resp := &openai.ChatCompletionResponse{
+			Choices: []openai.ChatCompletionChoice{
+				{
+					Message:      openai.ChatCompletionMessage{Role: "assistant", Content: "hi"},
+					FinishReason: openai.FinishReasonStop,
+				},
+			},
+			Usage: openai.Usage{
+				PromptTokens:     100,
+				CompletionTokens: 10,
+				TotalTokens:      110,
+				// PromptTokensDetails intentionally nil — providers like Ollama
+				// and older OpenAI-compat backends omit this block entirely.
+			},
+		}
+
+		got, err := c.parseCompletionResponse(resp)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, 0, got.Usage.CachedTokens,
+			"missing details must surface as zero, not panic")
+	})
+}
+
+// TestTokenUsage_CachedTokensJSONOmitempty ensures the new CachedTokens field
+// stays out of serialized payloads when it is zero. This keeps logs and API
+// responses unchanged for providers that never report cache hits.
+func TestTokenUsage_CachedTokensJSONOmitempty(t *testing.T) {
+	t.Run("zero is omitted", func(t *testing.T) {
+		u := types.TokenUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}
+		b, err := json.Marshal(u)
+		require.NoError(t, err)
+		assert.NotContains(t, string(b), "cached_tokens")
+	})
+
+	t.Run("non-zero is emitted", func(t *testing.T) {
+		u := types.TokenUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15, CachedTokens: 7}
+		b, err := json.Marshal(u)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), `"cached_tokens":7`)
+	})
 }

--- a/internal/types/chat.go
+++ b/internal/types/chat.go
@@ -10,6 +10,12 @@ type TokenUsage struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
+	// CachedTokens is the subset of PromptTokens that hit a provider-side
+	// prompt cache (OpenAI prompt_tokens_details.cached_tokens, Qwen explicit
+	// caching, etc.). Zero when the provider does not report cache hits or
+	// when no cache was hit. Omitted from JSON when zero to keep payloads
+	// quiet for providers that never populate it.
+	CachedTokens int `json:"cached_tokens,omitempty"`
 }
 
 // LLMToolCall represents a function/tool call from the LLM

--- a/internal/types/chat.go
+++ b/internal/types/chat.go
@@ -11,10 +11,24 @@ type TokenUsage struct {
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
 	// CachedTokens is the subset of PromptTokens that hit a provider-side
-	// prompt cache (OpenAI prompt_tokens_details.cached_tokens, Qwen explicit
-	// caching, etc.). Zero when the provider does not report cache hits or
-	// when no cache was hit. Omitted from JSON when zero to keep payloads
-	// quiet for providers that never populate it.
+	// prompt cache. Populated from `usage.prompt_tokens_details.cached_tokens`
+	// in OpenAI-compatible responses.
+	//
+	// Whether this field is non-zero depends on the provider's caching mode:
+	//
+	//   - Implicit caching (OpenAI, Azure OpenAI, DeepSeek, …) — automatic.
+	//     The field populates whenever the prompt prefix matches a previous
+	//     request within the provider's cache TTL. No client-side opt-in.
+	//
+	//   - Explicit caching (Qwen on Aliyun, Anthropic Claude, …) — opt-in
+	//     required. The caller must attach `cache_control: {"type":
+	//     "ephemeral"}` to the relevant message or content block to make
+	//     the provider create and read the cache. Until that opt-in is
+	//     applied, CachedTokens stays zero even when the prompt prefix is
+	//     otherwise byte-stable.
+	//
+	// Omitted from JSON when zero so payloads stay quiet for providers
+	// that never populate it.
 	CachedTokens int `json:"cached_tokens,omitempty"`
 }
 


### PR DESCRIPTION
## Description

Two coupled changes plus a documentation follow-up. This PR makes prompt caching observable across all OpenAI-compatible providers and removes a hidden source of cache misses that affected every prefix-caching scheme.

**1. `fix(agent/tools): sort function definitions for deterministic ordering`**

`ToolRegistry.GetFunctionDefinitions` and `ListTools` ranged over the internal map directly. Go map iteration is intentionally randomized, so the serialized `tools` block reshuffled on every request. Any provider that keys prompt caching on a byte-level prefix match (implicit OpenAI caching, implicit DeepSeek caching, explicit Qwen / Anthropic `cache_control`, …) silently failed to hit the cache when the tools order flipped. Sorting by tool name in both functions makes the output byte-stable so every prefix-caching scheme can actually take effect.

**2. `feat(chat): surface cached prompt tokens from upstream usage`**

OpenAI-compatible providers report prompt-cache hits in `usage.prompt_tokens_details.cached_tokens`. go-openai already decodes this, but WeKnora dropped it at the `TokenUsage` boundary, leaving no signal in logs or API responses. This change plumbs the field end-to-end:

- New `TokenUsage.CachedTokens` (`json:\"cached_tokens,omitempty\"`) — additive, omitted when zero so existing consumers are unaffected.
- Nil-safe `cachedTokens` helper guards against providers that omit `PromptTokensDetails` (Ollama, older OpenAI-compat backends).
- All three response-parsing paths populate it: `parseCompletionResponse` (non-streaming), `processStream` (SDK streaming), `processRawHTTPStream` (raw-HTTP streaming, used when callers need to inject custom fields like `cache_control`).
- The five `[LLM Usage]` log lines now print `cached_tokens=%d`.

**3. `docs(chat): clarify cached-token semantics for explicit-cache providers`**

Cache reporting depends on the provider's caching mode, and this matters for what callers should expect after merging:

- **Implicit caching (OpenAI, Azure OpenAI, DeepSeek, …)** — automatic. `cached_tokens` populates once the prompt prefix matches a previous request within the provider's cache TTL. No client-side opt-in needed; this PR alone is enough to see non-zero values in production.
- **Explicit caching (Qwen on Aliyun, Anthropic Claude, …)** — opt-in required. The caller must attach `cache_control: {\"type\": \"ephemeral\"}` to the relevant message / content block to make the provider actually create and read the cache. Until that opt-in is applied, `cached_tokens` stays zero **even after this PR lands**.

The third commit documents the distinction on `TokenUsage.CachedTokens` and the `cachedTokens` helper so callers do not mistake observability for activation. For explicit-cache providers this PR is a prerequisite (stable prefix) and a meter (visibility); wiring up `cache_control` itself is a separate concern.

## Type of Change
- [x] 🐛 Bug fix
- [x] ✨ New feature (additive `CachedTokens` field on `TokenUsage`)
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
N/A — observed from production logs where `cached_tokens` was always zero across OpenAI-compatible providers (the random tool ordering masked even the providers with automatic implicit caching).

## Testing

**Unit tests added — 9 new cases, all passing locally:**

`internal/agent/tools/registry_test.go` (new file)
- `TestGetFunctionDefinitions_DeterministicOrder` — 50 iterations, sorted output every call
- `TestGetFunctionDefinitions_JSONByteStable` — 20 iterations, byte-equal JSON across calls
- `TestGetFunctionDefinitions_PreservesFields` — Name / Description / Parameters round-trip
- `TestGetFunctionDefinitions_Empty` — empty registry marshals to `[]` not `null`
- `TestListTools_Sorted` — same invariant for `ListTools`
- `TestRegisterTool_DuplicateRejected` — first-wins guard (GHSA-67q9-58vj-32qx)

`internal/models/chat/remote_api_test.go` (3 cases added)
- `TestCachedTokensHelper` — nil details and populated details
- `TestParseCompletionResponse_CachedTokens` — populated and missing-`PromptTokensDetails` paths
- `TestTokenUsage_CachedTokensJSONOmitempty` — zero is omitted, non-zero is emitted

**Local verification:**

\`\`\`
ok  github.com/Tencent/WeKnora/internal/agent/tools  0.957s
ok  github.com/Tencent/WeKnora/internal/models/chat  0.890s
\`\`\`

(Full `make test` was blocked on this Windows dev machine by repo-level cross-platform issues unrelated to these changes — `internal/sandbox/local.go` missing a `//go:build linux` constraint, gojieba C++ init failing on non-ASCII home paths, duckdb Windows static libs not shipped. Those affect any test run on this OS, not these commits.)

## Checklist
- [x] `make fmt` equivalent (`gofmt`) clean
- [x] Targeted unit tests pass (9/9)
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Documentation updated (`TokenUsage.CachedTokens` GoDoc + `cachedTokens` helper comment + per-provider semantics)
- [x] No breaking changes — new `CachedTokens` field is additive with `omitempty`