### PR TITLE
修复客户端模型类型枚举

### DIFF
--- a/client/example.go
+++ b/client/example.go
@@ -90,8 +90,8 @@ func ExampleUsage() {
 	fmt.Println("\n3. Creating model...")
 	modelRequest := &CreateModelRequest{
 		Name:        "Test Model",
-		Type:        ModelTypeChat,
-		Source:      ModelSourceInternal,
+		Type:        ModelTypeKnowledgeQA,
+		Source:      ModelSourceLocal,
 		Description: "This is a test model",
 		Parameters: ModelParameters{
 			"temperature": 0.7,

--- a/client/model.go
+++ b/client/model.go
@@ -10,11 +10,39 @@ import (
 	"net/url"
 )
 
-// ModelType model type
+// ModelType represents the type of AI model
 type ModelType string
 
-// ModelSource model source
+const (
+	ModelTypeEmbedding   ModelType = "Embedding"   // Embedding model
+	ModelTypeRerank      ModelType = "Rerank"      // Rerank model
+	ModelTypeKnowledgeQA ModelType = "KnowledgeQA" // KnowledgeQA model
+	ModelTypeVLLM        ModelType = "VLLM"        // VLLM model
+	ModelTypeASR         ModelType = "ASR"         // ASR (Automatic Speech Recognition) model
+)
+
+// ModelSource represents the source of the model
 type ModelSource string
+
+const (
+	ModelSourceLocal       ModelSource = "local"        // Local model
+	ModelSourceRemote      ModelSource = "remote"       // Remote model
+	ModelSourceAliyun      ModelSource = "aliyun"       // Aliyun DashScope model
+	ModelSourceZhipu       ModelSource = "zhipu"        // Zhipu model
+	ModelSourceVolcengine  ModelSource = "volcengine"   // Volcengine model
+	ModelSourceDeepseek    ModelSource = "deepseek"     // Deepseek model
+	ModelSourceHunyuan     ModelSource = "hunyuan"      // Hunyuan model
+	ModelSourceMinimax     ModelSource = "minimax"      // Minimax mode
+	ModelSourceOpenAI      ModelSource = "openai"       // OpenAI model
+	ModelSourceGemini      ModelSource = "gemini"       // Gemini model
+	ModelSourceMimo        ModelSource = "mimo"         // Mimo model
+	ModelSourceSiliconFlow ModelSource = "siliconflow"  // SiliconFlow model
+	ModelSourceJina        ModelSource = "jina"         // Jina AI model
+	ModelSourceOpenRouter  ModelSource = "openrouter"   // OpenRouter model
+	ModelSourceNvidia      ModelSource = "nvidia"       // NVIDIA model
+	ModelSourceNovita      ModelSource = "novita"       // Novita AI model
+	ModelSourceAzureOpenAI ModelSource = "azure_openai" // Azure OpenAI model
+)
 
 // ModelParameters model parameters
 type ModelParameters map[string]interface{}
@@ -62,20 +90,6 @@ type ModelListResponse struct {
 	Success bool    `json:"success"`
 	Data    []Model `json:"data"`
 }
-
-// Model type constants
-const (
-	ModelTypeEmbedding ModelType = "embedding"
-	ModelTypeChat      ModelType = "chat"
-	ModelTypeRerank    ModelType = "rerank"
-	ModelTypeSummary   ModelType = "summary"
-)
-
-// Model source constants
-const (
-	ModelSourceInternal ModelSource = "internal"
-	ModelSourceExternal ModelSource = "external"
-)
 
 // CreateModel creates a model
 func (c *Client) CreateModel(ctx context.Context, request *CreateModelRequest) (*Model, error) {


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->

## Checklist
- [x] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->

我想将公共用到的请求响应数据结构和枚举类型提取到pkg让外部可以引用，但是发现改动太大了，你们可能不太能接受。
很多公共的类型枚举和数据结构都在internal包下面，希望官方可以主导将公共的数据结构和枚举类型放在pkg包
将internal/types/中的gorm和和json标签分离出来，分离成model,request和response包
Handler和Service只会用到request和response
Repository只会用到model


```mermaid
sequenceDiagram
    participant Client
    participant Router
    participant Handler
    participant Service
    participant Repository
    participant DB as Database

    Client->>Router: 发送请求（含查询参数）
    Router->>Handler: 路由匹配，转发请求

    Note over Handler: 解析请求参数<br/>(如query、body、path params)

    Handler->>Service: 调用Service方法<br/>(传入解析后的参数)

    Note over Service: 业务逻辑处理<br/>参数校验、转换、组装查询条件

    Service->>Repository: 调用Repository查询方法<br/>(传入查询条件)

    Repository->>DB: 执行数据查询
    DB-->>Repository: 返回原始数据

    Repository-->>Service: 返回数据实体

    Note over Service: 生成View层数据<br/>

    Service-->>Handler: 返回处理完成的View数据

    Note over Handler: 构建HTTP响应

    Handler-->>Client: 返回Response
```