### PR TITLE
refactor(knowledge): route single delete through async pipeline

### DIFF
--- a/client/knowledge.go
+++ b/client/knowledge.go
@@ -353,7 +353,9 @@ func (c *Client) ListKnowledgeWithFilter(ctx context.Context,
 	return response.Data, response.Total, nil
 }
 
-// DeleteKnowledge deletes a knowledge entry by its ID
+// DeleteKnowledge enqueues an asynchronous delete for the given knowledge entry.
+// The server returns 200 once the task has been submitted; the actual deletion is
+// performed by a background worker (same pipeline as BatchDeleteKnowledge).
 func (c *Client) DeleteKnowledge(ctx context.Context, knowledgeID string) error {
 	path := fmt.Sprintf("/api/v1/knowledge/%s", knowledgeID)
 	resp, err := c.doRequest(ctx, http.MethodDelete, path, nil, nil)

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -5926,7 +5926,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "根据ID删除知识条目",
+                "description": "根据ID异步删除知识条目。请求会被入队到与批量删除相同的异步管道（asynq）；\n接口返回 200 仅表示任务已提交（响应 data.task_id 为任务 ID），实际删除由后台 worker 完成。",
                 "consumes": [
                     "application/json"
                 ],
@@ -5948,7 +5948,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "删除成功",
+                        "description": "任务已提交，返回 task_id",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5919,7 +5919,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "根据ID删除知识条目",
+                "description": "根据ID异步删除知识条目。请求会被入队到与批量删除相同的异步管道（asynq）；\n接口返回 200 仅表示任务已提交（响应 data.task_id 为任务 ID），实际删除由后台 worker 完成。",
                 "consumes": [
                     "application/json"
                 ],
@@ -5941,7 +5941,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "删除成功",
+                        "description": "任务已提交，返回 task_id",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -7901,7 +7901,9 @@ paths:
     delete:
       consumes:
       - application/json
-      description: 根据ID删除知识条目
+      description: |-
+        根据ID异步删除知识条目。请求会被入队到与批量删除相同的异步管道（asynq）；
+        接口返回 200 仅表示任务已提交（响应 data.task_id 为任务 ID），实际删除由后台 worker 完成。
       parameters:
       - description: 知识ID
         in: path
@@ -7912,7 +7914,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: 删除成功
+          description: 任务已提交，返回 task_id
           schema:
             additionalProperties: true
             type: object

--- a/frontend/src/hooks/useKnowledgeBase.ts
+++ b/frontend/src/hooks/useKnowledgeBase.ts
@@ -91,13 +91,22 @@ export default function (knowledgeBaseId?: string) {
     cardList.value[index].isMore = false;
     moreIndex.value = -1;
     return delKnowledgeDetails(item.id)
-      .then((result: any) => {
+      .then(async (result: any) => {
         if (result.success) {
           MessagePlugin.info(t('knowledgeBase.deleteSuccess'));
           if (onSuccess) {
             onSuccess();
           } else {
-            getKnowled();
+            // 后端已将单条删除放入异步队列，立即拉列表仍可能包含待删项；
+            // 短轮询直到列表与后端一致或超时。
+            const maxPolls = 30;
+            const delayMs = 400;
+            for (let i = 0; i < maxPolls; i++) {
+              await getKnowled();
+              const stillPresent = (cardList.value || []).some((c: any) => c.id === item.id);
+              if (!stillPresent) break;
+              await new Promise<void>((r) => setTimeout(r, delayMs));
+            }
           }
           return true;
         } else {

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -1158,6 +1158,11 @@ const onCardMouseLeave = () => {
 const delCard = (index: number, item: KnowledgeCard) => {
   knowledgeIndex.value = index;
   knowledge.value = item;
+  // 关闭卡片上仍处于打开状态的"更多操作"弹出菜单，避免 popover 浮在确认对话框之上
+  if (cardList.value?.[index]) {
+    cardList.value[index].isMore = false;
+  }
+  moreIndex.value = -1;
   delDialog.value = true;
 };
 

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -1786,10 +1786,20 @@ const getDoc = (page: number) => {
 
 const delCardConfirm = () => {
   delDialog.value = false;
-  delKnowledge(knowledgeIndex.value, knowledge.value, () => {
+  const deletedId = knowledge.value?.id;
+  delKnowledge(knowledgeIndex.value, knowledge.value, async () => {
     // 删除成功后刷新文档列表和分类数量
     resetPage(); // Reset page counter when reloading files after deletion
-    loadKnowledgeFiles(kbId.value);
+    // 后端将单条删除放入异步队列，立刻拉列表仍可能包含待删项；
+    // 短轮询直到列表与后端一致或超时（与批量删除一致）。
+    const maxPolls = 30;
+    const delayMs = 400;
+    for (let i = 0; i < maxPolls; i++) {
+      await loadKnowledgeFiles(kbId.value);
+      const stillPresent = (cardList.value || []).some((c: KnowledgeCard) => c.id === deletedId);
+      if (!stillPresent) break;
+      await new Promise<void>((r) => setTimeout(r, delayMs));
+    }
     loadTags(kbId.value);
   });
 };

--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -651,12 +651,13 @@ func (h *KnowledgeHandler) ListKnowledge(c *gin.Context) {
 
 // DeleteKnowledge godoc
 // @Summary      删除知识
-// @Description  根据ID删除知识条目
+// @Description  根据ID异步删除知识条目。请求会被入队到与批量删除相同的异步管道（asynq）；
+// @Description  接口返回 200 仅表示任务已提交（响应 data.task_id 为任务 ID），实际删除由后台 worker 完成。
 // @Tags         知识管理
 // @Accept       json
 // @Produce      json
 // @Param        id   path      string  true  "知识ID"
-// @Success      200  {object}  map[string]interface{}  "删除成功"
+// @Success      200  {object}  map[string]interface{}  "任务已提交，返回 task_id"
 // @Failure      400  {object}  errors.AppError         "请求参数错误"
 // @Security     Bearer
 // @Security     ApiKeyAuth
@@ -678,18 +679,32 @@ func (h *KnowledgeHandler) DeleteKnowledge(c *gin.Context) {
 		c.Error(err)
 		return
 	}
-	logger.Infof(ctx, "Deleting knowledge, ID: %s", secutils.SanitizeForLog(id))
-	err = h.kgService.DeleteKnowledge(effCtx, id)
-	if err != nil {
-		logger.ErrorWithFields(ctx, err, nil)
-		c.Error(errors.NewInternalServerError(err.Error()))
+
+	// Reuse the batch async pipeline so single-item delete shares the same
+	// hardening (asynq retries, business-aware queue routing, marking-as-deleting
+	// inside the worker) as BatchDeleteKnowledge / ClearKnowledgeBaseContents.
+	effectiveTenantID, _ := effCtx.Value(types.TenantIDContextKey).(uint64)
+	if effectiveTenantID == 0 {
+		logger.Error(ctx, "Effective tenant ID missing after access validation")
+		c.Error(errors.NewInternalServerError("tenant context unavailable"))
 		return
 	}
 
-	logger.Infof(ctx, "Knowledge deleted successfully, ID: %s", secutils.SanitizeForLog(id))
+	logger.Infof(ctx, "Enqueuing knowledge delete, ID: %s", secutils.SanitizeForLog(id))
+	taskID, err := h.enqueueKnowledgeListDelete(effCtx, effectiveTenantID, []string{id})
+	if err != nil {
+		logger.Errorf(ctx, "Failed to enqueue knowledge delete task: %v", err)
+		c.Error(errors.NewInternalServerError("Failed to enqueue delete task"))
+		return
+	}
+
+	logger.Infof(ctx, "Knowledge delete task enqueued: %s, knowledge_id: %s", taskID, secutils.SanitizeForLog(id))
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"message": "Deleted successfully",
+		"message": "Delete task submitted",
+		"data": gin.H{
+			"task_id": taskID,
+		},
 	})
 }
 


### PR DESCRIPTION
## Description

Reuse `enqueueKnowledgeListDelete` inside `DeleteKnowledge` so the single-item
delete endpoint shares the same hardening as `BatchDeleteKnowledge` /
`ClearKnowledgeBaseContents`:

- asynq retries
- business-aware queue routing
- marking-as-deleting performed inside the worker (not on the request goroutine)

The endpoint now returns `200` once the delete task has been enqueued. The
response body carries the asynq `task_id` and the message is updated to
`Delete task submitted`. Swagger annotations, generated docs and the Go client
SDK comment are updated to reflect the new asynchronous semantics.

## Type of Change

- [x] 🎨 Refactor
- [x] 💥 Breaking change (response semantics)

## Related Issue

N/A

## Behavior change

`DELETE /api/v1/knowledge/{id}` previously returned `200` only after the
knowledge was actually deleted. After this change `200` indicates the delete
task has been submitted; the deletion is performed asynchronously by a worker.

- Response body adds `data.task_id` and the `message` field changes to
  `Delete task submitted`.
- Callers expecting strict read-after-delete consistency should either poll
  task status or accept eventual consistency, matching the existing
  `BatchDeleteKnowledge` contract.
- The Go client SDK signature is unchanged (still returns `error`); only the
  doc comment is updated.

## Testing

- `go build ./...` (main module): pass
- `cd client && go vet ./...`: pass
- Local `make lint` was not run because the locally installed `golangci-lint`
  was built against an older Go toolchain than the project requires; this is
  unrelated to the change.
- Manual: `curl -X DELETE /api/v1/knowledge/{id}` returns the new payload and
  the worker performs the actual deletion (verified against the existing batch
  delete pipeline that this PR now reuses).

## Checklist

- [x] `make fmt && go build ./...` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change (no new tests added; follow-up
      welcome — the underlying batch pipeline is already covered)
- [x] Updated related documentation (Swagger annotations, generated
      `docs/swagger.{yaml,json}` and `docs/docs.go`, Go SDK comment)
- [x] Breaking changes are clearly called out in the description above