### PR TITLE
feat(chunk): support filtering chunks by multiple chunk_type params

### DIFF
--- a/client/chunk.go
+++ b/client/chunk.go
@@ -75,19 +75,24 @@ type UpdateChunkRequest struct {
 //   - knowledgeID: Knowledge ID
 //   - page: Page number, starts from 1
 //   - pageSize: Number of items per page
+//   - chunkTypes: Optional chunk type filter (e.g. "text", "image_caption", "image_ocr").
+//     When empty, the server defaults to text chunks only.
 //
 // Returns:
 //   - []Chunk: List of chunks
 //   - int64: Total count
 //   - error: Error information
 func (c *Client) ListKnowledgeChunks(ctx context.Context,
-	knowledgeID string, page int, pageSize int,
+	knowledgeID string, page int, pageSize int, chunkTypes ...string,
 ) ([]Chunk, int64, error) {
 	path := fmt.Sprintf("/api/v1/chunks/%s", knowledgeID)
 
 	queryParams := url.Values{}
 	queryParams.Add("page", strconv.Itoa(page))
 	queryParams.Add("page_size", strconv.Itoa(pageSize))
+	for _, ct := range chunkTypes {
+		queryParams.Add("chunk_type", ct)
+	}
 
 	resp, err := c.doRequest(ctx, http.MethodGet, path, nil, queryParams)
 	if err != nil {

--- a/internal/handler/chunk.go
+++ b/internal/handler/chunk.go
@@ -128,7 +128,14 @@ func (h *ChunkHandler) ListKnowledgeChunks(c *gin.Context) {
 		pagination.PageSize = 100
 	}
 
+	// Default to text chunks; callers may override via ?chunk_type=image_caption etc.
 	chunkType := []types.ChunkType{types.ChunkTypeText}
+	if queryTypes := c.QueryArray("chunk_type"); len(queryTypes) > 0 {
+		chunkType = make([]types.ChunkType, 0, len(queryTypes))
+		for _, qt := range queryTypes {
+			chunkType = append(chunkType, types.ChunkType(qt))
+		}
+	}
 
 	// The route-level guard has rewritten the request's tenant context
 	// to the effective tenant for shared KBs.


### PR DESCRIPTION
## Summary

- Allow `GET /api/v1/chunks/{knowledgeID}` to accept multiple `chunk_type` query parameters (e.g. `?chunk_type=text&chunk_type=image_caption`); defaults to `text` when omitted, preserving existing behavior.
- Extend the Go SDK `Client.ListKnowledgeChunks` with a variadic `chunkTypes ...string` argument so existing callers keep compiling while new code can opt into multi-type filtering.

## Test plan

- [ ] `go build ./client/...`
- [ ] Manual: `curl ".../api/v1/chunks/<id>?chunk_type=text&chunk_type=image_caption"` returns mixed-type chunks
- [ ] Manual: omitting `chunk_type` still returns only text chunks