### PR TITLE
refactor(knowledge): make checkStorageEngineConfigured a service method with global file-service fallback

### DIFF
--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -160,8 +160,14 @@ func (s *knowledgeService) isKnowledgeDeleting(ctx context.Context, tenantID uin
 }
 
 // checkStorageEngineConfigured verifies that the knowledge base has a storage engine configured
-// (either at the KB level or via the tenant default). Returns an error if no storage engine is found.
-func checkStorageEngineConfigured(ctx context.Context, kb *types.KnowledgeBase) error {
+// (either at the KB level or via the tenant default).
+//
+// 内部版兜底语义：当 KB 与租户都未配置 storage provider 时，如果服务实例持有
+// 全局 FileService（由容器按 STORAGE_TYPE 注入，默认 local），允许直接落到该
+// 全局 fileSvc 上，不再硬性阻断。这与 resolveFileService / resolveFileServiceForPath
+// 在 provider 为空时回退到 s.fileSvc 的行为保持一致，避免上层闸门和下游解析口径不一。
+// 仅当 KB/租户/全局三处都拿不到任何可用 FileService 时才报错。
+func (s *knowledgeService) checkStorageEngineConfigured(ctx context.Context, kb *types.KnowledgeBase) error {
 	provider := kb.GetStorageProvider()
 	if provider == "" {
 		tenant, _ := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
@@ -169,10 +175,23 @@ func checkStorageEngineConfigured(ctx context.Context, kb *types.KnowledgeBase) 
 			provider = strings.ToLower(strings.TrimSpace(tenant.StorageEngineConfig.DefaultProvider))
 		}
 	}
-	if provider == "" {
-		return werrors.NewBadRequestError("请先为知识库选择存储引擎，再上传内容。请前往知识库设置页面进行配置。")
+	if provider != "" {
+		return nil
 	}
-	return nil
+	if s != nil && s.fileSvc != nil {
+		logger.Warnf(ctx,
+			"[storage] checkStorageEngineConfigured: no KB/tenant provider, fallback to global fileSvc (kb=%s)",
+			kbIDOrEmpty(kb))
+		return nil
+	}
+	return werrors.NewBadRequestError("请先为知识库选择存储引擎，再上传内容。请前往知识库设置页面进行配置。")
+}
+
+func kbIDOrEmpty(kb *types.KnowledgeBase) string {
+	if kb == nil {
+		return ""
+	}
+	return kb.ID
 }
 
 func defaultChannel(ch string) string {

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -56,7 +56,7 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 		return nil, werrors.NewBadRequestError("FAQ 知识库不支持文件上传，请使用 FAQ 导入功能")
 	}
 
-	if err := checkStorageEngineConfigured(ctx, kb); err != nil {
+	if err := s.checkStorageEngineConfigured(ctx, kb); err != nil {
 		return nil, err
 	}
 
@@ -322,7 +322,7 @@ func (s *knowledgeService) CreateKnowledgeFromURL(ctx context.Context,
 		return nil, err
 	}
 
-	if err := checkStorageEngineConfigured(ctx, kb); err != nil {
+	if err := s.checkStorageEngineConfigured(ctx, kb); err != nil {
 		return nil, err
 	}
 
@@ -518,7 +518,7 @@ func (s *knowledgeService) createKnowledgeFromFileURL(
 		return nil, err
 	}
 
-	if err := checkStorageEngineConfigured(ctx, kb); err != nil {
+	if err := s.checkStorageEngineConfigured(ctx, kb); err != nil {
 		return nil, err
 	}
 
@@ -722,7 +722,7 @@ func (s *knowledgeService) CreateKnowledgeFromManual(ctx context.Context,
 		return nil, err
 	}
 
-	if err := checkStorageEngineConfigured(ctx, kb); err != nil {
+	if err := s.checkStorageEngineConfigured(ctx, kb); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

- Convert `checkStorageEngineConfigured` from a free function into a method on `knowledgeService` for better encapsulation.
- When neither the knowledge base nor the tenant has a storage provider configured, fall back to the globally-registered file service instead of failing outright.
- Add comments documenting the lookup order (KB-level → tenant-level → global file service).

## Test plan

- [ ] `go build ./...`
- [ ] Manual: upload to a KB without per-KB storage config — succeeds via global file service
- [ ] Manual: KB with explicit storage config still uses that provider