### PR TITLE
refactor(chunk): remove unused VideoInfo field from Chunk struct

### DIFF
--- a/internal/types/chunk.go
+++ b/internal/types/chunk.go
@@ -156,8 +156,6 @@ type Chunk struct {
 	ContentHash string `json:"content_hash"             gorm:"type:varchar(64);index"`
 	// 图片信息，存储为 JSON
 	ImageInfo string `json:"image_info"               gorm:"type:text"`
-	// 视频信息，存储为 JSON
-	VideoInfo string `json:"video_info"               gorm:"type:text"`
 	// Chunk creation time
 	CreatedAt time.Time `json:"created_at"`
 	// Chunk last update time


### PR DESCRIPTION
## Summary

- Drop the `VideoInfo` field from `internal/types.Chunk`. It is no longer read or written anywhere in the codebase, so removing it keeps the chunk schema lean and avoids confusion about what gets persisted.

## Test plan

- [ ] `go build ./...`
- [ ] `make test`