### PR TITLE
feat(docreader): improve web parser for WeChat Official Account articles

### DIFF
--- a/docreader/parser/web_parser.py
+++ b/docreader/parser/web_parser.py
@@ -2,8 +2,9 @@ import asyncio
 import logging
 import re
 
+from lxml.etree import XPath
 from playwright.async_api import async_playwright
-from trafilatura import extract
+from trafilatura import extract, utils, xpaths
 
 from docreader.config import CONFIG
 from docreader.models.document import Document
@@ -13,6 +14,30 @@ from docreader.parser.markdown_parser import MarkdownParser
 from docreader.utils import endecode
 
 logger = logging.getLogger(__name__)
+
+# Monkey-patch trafilatura internals to better support WeChat Official Account
+# articles, whose images live on `mmbiz.qpic.cn` without a standard file
+# extension and whose main content sits inside `#js_content` /
+# `.rich_media_content`. Trafilatura's `utils.IMAGE_EXTENSION` and
+# `xpaths.BODY_XPATH` are internal APIs, so we guard the patch and skip
+# silently if they are renamed/removed in a future release.
+try:
+    _WECHAT_IMAGE_EXTENSION = re.compile(
+        r"[^\s]+\.(avif|bmp|gif|hei[cf]|jpe?g|png|webp)(\b|$)|"  # Standard extensions
+        r"mmbiz\.qpic\.cn/[^\s]*wx_fmt=(jpeg|jpg|png|gif|webp)"  # WeChat query format
+    )
+    utils.IMAGE_EXTENSION = _WECHAT_IMAGE_EXTENSION
+
+    _WECHAT_BODY_XPATH = XPath(
+        '(.//*[@id="js_content" or contains(@class, "rich_media_content")])[1]'
+    )
+    _wechat_xpath_str = str(_WECHAT_BODY_XPATH)
+    if not any(str(x) == _wechat_xpath_str for x in xpaths.BODY_XPATH):
+        xpaths.BODY_XPATH.insert(0, _WECHAT_BODY_XPATH)
+except (AttributeError, ImportError) as e:
+    logger.warning(
+        "Failed to patch trafilatura internals for WeChat support: %s", e
+    )
 
 
 class StdWebParser(BaseParser):


### PR DESCRIPTION
## Summary

- Patch trafilatura internals so the web parser extracts WeChat Official Account articles correctly:
  - Override `trafilatura.utils.IMAGE_EXTENSION` to recognize `avif/heic/heif/webp` plus WeChat's extension-less `mmbiz.qpic.cn/...?wx_fmt=...` image URLs.
  - Prepend a high-priority `BODY_XPATH` matching WeChat's `#js_content` / `.rich_media_content` containers so the article body is preferred over generic heuristics.
- Patch is wrapped in `try/except (AttributeError, ImportError)` and the XPath insert is idempotent, so a future trafilatura upgrade that renames these internals only logs a warning instead of crashing import, and re-imports won't accumulate duplicate XPaths.

## Test plan

- [ ] `python3 -m ast docreader/parser/web_parser.py`
- [ ] Manual: parse a WeChat article URL — main body and inline images are captured
- [ ] Manual: parse a non-WeChat URL — output unchanged vs. previous behavior