### PR TITLE
feat(builtin-models): add YAML lifecycle (delete, resurrect, default invariant) on top of #1453

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,12 @@ docker-build-frontend:
 docker-build-all: docker-build-app docker-build-docreader docker-build-frontend
 
 # Run Docker container (传统方式)
+# Touch .env if missing — docker-compose.yml's `env_file: [.env]` is required
+# for ${ENV} interpolation in builtin_models.yaml and would otherwise refuse
+# to parse on fresh clones. `start-all` handles this via check_env_file; this
+# direct path needs its own guard.
 docker-run:
+	@[ -f .env ] || ([ -f .env.example ] && cp .env.example .env || touch .env)
 	docker-compose up
 
 # 使用新脚本启动所有服务
@@ -164,6 +169,7 @@ clean-images:
 
 # Restart Docker container (stop, start)
 docker-restart:
+	@[ -f .env ] || ([ -f .env.example ] && cp .env.example .env || touch .env)
 	docker-compose stop -t 60
 	docker-compose up
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,13 +51,18 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
-    # Optional: source .env so deployment-specific vars (e.g. those referenced
-    # by config/builtin_models.yaml via ${ENV}) reach the app container without
-    # having to be listed individually under `environment:`. Falls back
-    # silently when .env is absent (e.g. fresh upstream clone).
+    # Source .env so deployment-specific variables (e.g. those referenced by
+    # config/builtin_models.yaml via ${ENV}, or any future feature) reach the
+    # app container without having to be enumerated under `environment:`.
+    #
+    # NOTE: the array form below is used instead of the map form
+    # (env_file: - path: .env, required: false) because the map syntax
+    # requires Docker Compose v2.24+ (Jan 2024) and would break parsing on
+    # older deploys. The trade-off is that Compose errors out if .env is
+    # absent — see scripts/start_all.sh for the pre-flight touch that keeps
+    # fresh clones working.
     env_file:
-      - path: .env
-        required: false
+      - .env
     environment:
       - LOG_LEVEL=${LOG_LEVEL:-}
       - COS_SECRET_ID=${COS_SECRET_ID:-}

--- a/docs/BUILTIN_MODELS.md
+++ b/docs/BUILTIN_MODELS.md
@@ -237,7 +237,18 @@ WHERE id = '模型ID';
 
 ## 移除内置模型
 
-YAML 配置删除条目后**不会**自动清理 DB 里的对应行（避免误删 ops 手工维护的内置模型）。如需删除：
+**从 YAML 删除条目即可。** 应用启动时会自动软删除 `models` 表中 YAML 不再声明的 YAML 托管行 —— 你不再需要手工跑 SQL。
+
+工作原理：每条由 YAML 写入的行会被打上 `managed_by = 'yaml'` 标记。重启时 loader 走两步：
+
+1. UPSERT 当前 YAML 中的所有条目（按 `id` 幂等，包含把之前软删过的 `deleted_at` 重置为 NULL —— 也就是说从 YAML 拿掉再加回来等于"复活"）
+2. 软删除 `is_builtin = true AND managed_by = 'yaml' AND id NOT IN (当前 YAML 中的 id 集合)` 的行
+
+**手工通过 SQL 插入的 builtin 行（`managed_by = ''`）永远不会被 loader 触碰**，与 YAML 完全隔离。
+
+### 手工路径补充
+
+如果你是走 SQL 路径管理的（`managed_by = ''`），删除仍然走老方法：
 
 ```sql
 -- 取消 builtin 标记，恢复为普通模型
@@ -247,11 +258,17 @@ UPDATE models SET is_builtin = false WHERE id = '模型ID';
 DELETE FROM models WHERE id = '模型ID';
 ```
 
+### 紧急关闭 YAML 接管
+
+如果误改了 YAML 想立刻停用接管又不想清空文件，最快的方法是：把环境变量 `BUILTIN_MODELS_CONFIG` 指向一个不存在的路径并重启 —— loader 看到文件缺失会直接 no-op，**包括跳过 drift sweep**，已经写入的 YAML 托管行保留原状。
+
 ## 注意事项
 
 1. **ID 命名规范**：建议使用 `builtin-{type}-{slug}` 的格式，例如 `builtin-openai-chat`、`builtin-rerank`
 2. **租户ID**：内置模型可以属于任意租户，默认 `10000`（与 `tenants_id_seq` 起点一致）
-3. **YAML 与 SQL 并存**：两种方式可以同时使用，YAML 不会覆盖通过 SQL 插入但未在 YAML 出现的 builtin 行
-4. **重启即生效**：修改 YAML 后 `docker compose restart app` 即可让新配置生效
-5. **加密**：API Key 在 `parameters` JSONB 中以加密形式存储（若 `SYSTEM_AES_KEY` 已配置），未配置时降级为明文兼容路径
-6. **安全性**：前端会自动隐藏内置模型的 API Key 和 Base URL，但数据库中的原始数据仍然存在，请妥善保管数据库访问权限
+3. **YAML 与 SQL 并存**：两种方式可以同时使用，loader 只动 `managed_by='yaml'` 的行；通过 SQL 插入的 builtin 行对 loader 完全不可见
+4. **`is_default` 单一保证**：YAML 中将某条 entry 标记 `is_default: true` 时，loader 会先把同 `(tenant_id, type)` 下的其它默认模型置为 `false`，避免 API 路径维护的"每类型一个默认模型"语义被破坏
+5. **重启即生效**：修改 YAML 后 `docker compose restart app` 即可让新配置生效
+6. **加密**：API Key 在 `parameters` JSONB 中以加密形式存储（若 `SYSTEM_AES_KEY` 已配置），未配置时降级为明文兼容路径
+7. **安全性**：前端会自动隐藏内置模型的 API Key 和 Base URL，但数据库中的原始数据仍然存在，请妥善保管数据库访问权限
+8. **解析错误自我保护**：YAML 解析失败时 loader 仅打 warning 并跳过 reconcile，**不会**执行 drift sweep，确保一个手抖的 YAML 改动不会大规模软删既有内置模型

--- a/internal/types/builtin_models_config.go
+++ b/internal/types/builtin_models_config.go
@@ -12,6 +12,12 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// BuiltinModelManagedBy is the value written into `models.managed_by` for
+// rows whose lifecycle is owned by config/builtin_models.yaml. Other rows
+// (UI / API / hand-written SQL) keep the column at its default empty string
+// and are never touched by the YAML loader.
+const BuiltinModelManagedBy = "yaml"
+
 // BuiltinModelEntry mirrors one entry in builtin_models.yaml.
 // Each entry becomes a row in the models table with is_builtin=true.
 type BuiltinModelEntry struct {
@@ -50,14 +56,34 @@ func interpolateBuiltinModelEnv(s string) string {
 }
 
 // LoadBuiltinModelsConfig reads builtin_models.yaml (or the path pointed to by
-// BUILTIN_MODELS_CONFIG) and UPSERTs each entry into the models table.
+// BUILTIN_MODELS_CONFIG) and reconciles the YAML-managed slice of `models`
+// with the file contents.
 //
-// Behaviour:
+// Lifecycle contract:
+//   - YAML loader only ever reads/writes rows tagged managed_by="yaml". Rows
+//     created via UI/API/SQL (managed_by="") are invisible to the loader and
+//     are never modified.
+//   - Each YAML entry is UPSERTed by id, with deleted_at force-reset to NULL
+//     (so a row that was soft-deleted previously is resurrected when it
+//     reappears in the file).
+//   - After all UPSERTs, any pre-existing yaml-managed row whose id is no
+//     longer in the file is soft-deleted. Removing an entry from YAML is
+//     therefore the supported way to retire a built-in model — no manual
+//     SQL needed.
+//   - If is_default=true is set on a YAML entry, the loader first clears
+//     is_default on any other rows in the same (tenant_id, type) bucket,
+//     mirroring the invariant enforced by the API path. Multiple entries
+//     with is_default=true for the same bucket result in last-one-wins with
+//     a warning.
+//
+// Failure handling:
 //   - file not found / mount point is a directory / path unset: no-op
-//   - YAML parse error: prints a warning, returns nil (never aborts startup)
-//   - per-entry UPSERT error: prints a warning, continues with the next entry
-//   - never deletes entries that disappeared from YAML: operators may have
-//     seeded extras manually via SQL; removing them here would be surprising
+//   - YAML parse error: prints a warning and aborts the reconcile (the
+//     drift sweep is NOT run, so a malformed file cannot accidentally wipe
+//     YAML-managed rows)
+//   - per-entry UPSERT error: prints a warning, the entry is dropped from
+//     the "current YAML id set" so the sweep won't delete its existing
+//     row either (treats the failure as "leave alone")
 func LoadBuiltinModelsConfig(ctx context.Context, db *gorm.DB, configDir string) error {
 	path := os.Getenv("BUILTIN_MODELS_CONFIG")
 	if path == "" {
@@ -83,16 +109,16 @@ func LoadBuiltinModelsConfig(ctx context.Context, db *gorm.DB, configDir string)
 
 	var file builtinModelsFile
 	if err := yaml.Unmarshal([]byte(expanded), &file); err != nil {
-		fmt.Printf("Warning: parse built-in models config %s failed: %v; skipping.\n", path, err)
+		fmt.Printf("Warning: parse built-in models config %s failed: %v; skipping reconcile.\n", path, err)
 		return nil
 	}
 
-	if len(file.BuiltinModels) == 0 {
-		fmt.Printf("Built-in models config %s contains no entries.\n", path)
-		return nil
-	}
-
+	// yamlIDs collects every id we successfully upserted this run. Used by
+	// the drift sweep below to determine which previously-yaml-managed rows
+	// have disappeared and should be retired.
+	yamlIDs := make([]string, 0, len(file.BuiltinModels))
 	applied := 0
+
 	for i := range file.BuiltinModels {
 		e := &file.BuiltinModels[i]
 		if e.ID == "" {
@@ -100,11 +126,27 @@ func LoadBuiltinModelsConfig(ctx context.Context, db *gorm.DB, configDir string)
 			continue
 		}
 		m := e.toModel()
+
+		// Mirror the API path's "single default per (tenant_id, type)"
+		// invariant: clear other defaults before promoting this one.
+		// Excluded our own id so we don't churn against ourselves.
+		if m.IsDefault {
+			if err := db.WithContext(ctx).
+				Model(&Model{}).
+				Where("tenant_id = ? AND type = ? AND id <> ? AND is_default = ?",
+					m.TenantID, m.Type, m.ID, true).
+				Update("is_default", false).Error; err != nil {
+				fmt.Printf("Warning: clear existing default for tenant=%d type=%s failed: %v; continuing.\n",
+					m.TenantID, m.Type, err)
+			}
+		}
+
 		res := db.WithContext(ctx).Clauses(clause.OnConflict{
 			Columns: []clause.Column{{Name: "id"}},
 			DoUpdates: clause.AssignmentColumns([]string{
 				"tenant_id", "name", "type", "source", "description",
-				"parameters", "is_default", "status", "is_builtin", "updated_at",
+				"parameters", "is_default", "status", "is_builtin",
+				"managed_by", "deleted_at", "updated_at",
 			}),
 		}).Create(&m)
 		if res.Error != nil {
@@ -112,16 +154,50 @@ func LoadBuiltinModelsConfig(ctx context.Context, db *gorm.DB, configDir string)
 			continue
 		}
 		applied++
+		yamlIDs = append(yamlIDs, e.ID)
 		fmt.Printf("Built-in model upserted: id=%s name=%s type=%s\n", e.ID, e.Name, e.Type)
 	}
-	fmt.Printf("Built-in models config applied: %d entries from %s.\n", applied, path)
+
+	// Drift sweep: retire YAML-managed rows that no longer appear in the
+	// file. Manual rows (managed_by='') are untouched. Uses GORM soft delete
+	// so the row remains recoverable.
+	pruned, sweepErr := pruneOrphanYAMLManagedModels(ctx, db, yamlIDs)
+	if sweepErr != nil {
+		fmt.Printf("Warning: drift sweep for YAML-managed models failed: %v; continuing.\n", sweepErr)
+	}
+
+	fmt.Printf("Built-in models config applied: %d upserted, %d pruned from %s.\n", applied, pruned, path)
 	return nil
+}
+
+// pruneOrphanYAMLManagedModels soft-deletes rows where managed_by='yaml'
+// and id is NOT in keepIDs. Used to retire entries that have been removed
+// from builtin_models.yaml. Returns the number of rows affected.
+//
+// Safety:
+//   - Only rows tagged managed_by='yaml' are eligible — manual rows are
+//     never visible to this query.
+//   - Already-soft-deleted rows are skipped (GORM default scope), so this
+//     is idempotent across restarts.
+//   - When keepIDs is empty the sweep retires ALL yaml-managed rows. That
+//     matches the natural reading of "the YAML file declares zero entries
+//     ⇒ no yaml-managed models should exist". The caller has already
+//     short-circuited on parse failure, so we only reach this branch when
+//     the operator deliberately reduced the file to an empty list.
+func pruneOrphanYAMLManagedModels(ctx context.Context, db *gorm.DB, keepIDs []string) (int64, error) {
+	q := db.WithContext(ctx).
+		Where("managed_by = ?", BuiltinModelManagedBy)
+	if len(keepIDs) > 0 {
+		q = q.Where("id NOT IN ?", keepIDs)
+	}
+	res := q.Delete(&Model{})
+	return res.RowsAffected, res.Error
 }
 
 // toModel converts a YAML entry to a runtime Model with sensible defaults.
 // tenant_id defaults to 10000 (matches the seed value of tenants_id_seq);
-// source defaults to "remote"; status defaults to "active". IsBuiltin is
-// always forced to true regardless of YAML input.
+// source defaults to "remote"; status defaults to "active". IsBuiltin and
+// ManagedBy are always forced regardless of YAML input.
 func (e *BuiltinModelEntry) toModel() Model {
 	tenantID := e.TenantID
 	if tenantID == 0 {
@@ -145,6 +221,7 @@ func (e *BuiltinModelEntry) toModel() Model {
 		Parameters:  e.Parameters,
 		IsDefault:   e.IsDefault,
 		IsBuiltin:   true,
+		ManagedBy:   BuiltinModelManagedBy,
 		Status:      status,
 	}
 }

--- a/internal/types/builtin_models_config.go
+++ b/internal/types/builtin_models_config.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -128,8 +129,8 @@ func LoadBuiltinModelsConfig(ctx context.Context, db *gorm.DB, configDir string)
 
 	for i := range file.BuiltinModels {
 		e := &file.BuiltinModels[i]
-		if e.ID == "" {
-			log.Printf("[builtin-models] WARN: entry %d has empty id; skipping", i)
+		if err := validateBuiltinModelEntry(e, i); err != nil {
+			log.Printf("[builtin-models] WARN: %v; skipping", err)
 			continue
 		}
 		m := e.toModel()
@@ -201,14 +202,81 @@ func pruneOrphanYAMLManagedModels(ctx context.Context, db *gorm.DB, keepIDs []st
 	return res.RowsAffected, res.Error
 }
 
+// validBuiltinModelTypes is the set of model types the loader accepts.
+// Mirrors the ModelType* constants. Anything else is rejected with a
+// warning rather than persisted, because provider factories match types
+// case-sensitively and a misspelled YAML entry would produce a row that
+// looks present in the table but is unusable downstream.
+var validBuiltinModelTypes = map[ModelType]struct{}{
+	ModelTypeKnowledgeQA: {},
+	ModelTypeEmbedding:   {},
+	ModelTypeRerank:      {},
+	ModelTypeVLLM:        {},
+	ModelTypeASR:         {},
+}
+
+// validBuiltinModelStatuses is the set of statuses the loader accepts.
+// Empty is allowed and is normalized to ModelStatusActive in toModel().
+var validBuiltinModelStatuses = map[ModelStatus]struct{}{
+	ModelStatusActive:         {},
+	ModelStatusDownloading:    {},
+	ModelStatusDownloadFailed: {},
+}
+
+// validateBuiltinModelEntry returns nil if the entry is loadable, or an
+// error describing what's wrong. Catches the failure modes that would
+// either crash the INSERT or silently produce an unusable row:
+//
+//   - empty id (cannot UPSERT)
+//   - id longer than the DB column (PG/SQLite cap at varchar(64),
+//     see ModelIDMaxLen) which would fail at INSERT time
+//   - empty or misspelled type (provider factories match exact strings)
+//   - explicit non-empty status outside the known set
+//
+// Source is intentionally NOT validated against a fixed list because the
+// provider matrix in internal/models/* keeps growing and a too-strict
+// check here would force changes in two places per new provider.
+func validateBuiltinModelEntry(e *BuiltinModelEntry, index int) error {
+	if e.ID == "" {
+		return errBuiltinModel("entry %d has empty id", index)
+	}
+	if len(e.ID) > ModelIDMaxLen {
+		return errBuiltinModel("entry %d id %q exceeds %d-char DB limit (got %d)",
+			index, e.ID, ModelIDMaxLen, len(e.ID))
+	}
+	if e.Type == "" {
+		return errBuiltinModel("entry %d (%s) missing required field 'type'", index, e.ID)
+	}
+	if _, ok := validBuiltinModelTypes[e.Type]; !ok {
+		return errBuiltinModel(
+			"entry %d (%s) has unknown type %q (expected one of: KnowledgeQA, Embedding, Rerank, VLLM, ASR)",
+			index, e.ID, e.Type)
+	}
+	if e.Status != "" {
+		if _, ok := validBuiltinModelStatuses[e.Status]; !ok {
+			return errBuiltinModel(
+				"entry %d (%s) has unknown status %q (expected: active, downloading, download_failed, or empty)",
+				index, e.ID, e.Status)
+		}
+	}
+	return nil
+}
+
+// errBuiltinModel formats a validation error with a stable prefix so log
+// output stays consistent with the rest of this package's warnings.
+func errBuiltinModel(format string, args ...interface{}) error {
+	return fmt.Errorf(format, args...)
+}
+
 // toModel converts a YAML entry to a runtime Model with sensible defaults.
-// tenant_id defaults to 10000 (matches the seed value of tenants_id_seq);
-// source defaults to "remote"; status defaults to "active". IsBuiltin and
-// ManagedBy are always forced regardless of YAML input.
+// tenant_id defaults to DefaultBuiltinModelTenantID (10000, matching the
+// seed value of tenants_id_seq); source defaults to "remote"; status
+// defaults to "active". IsBuiltin and ManagedBy are always forced
+// regardless of YAML input.
 func (e *BuiltinModelEntry) toModel() Model {
 	tenantID := e.TenantID
 	if tenantID == 0 {
-		tenantID = 10000
+		tenantID = DefaultBuiltinModelTenantID
 	}
 	source := e.Source
 	if source == "" {

--- a/internal/types/builtin_models_config.go
+++ b/internal/types/builtin_models_config.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"context"
-	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -11,6 +11,13 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
+
+// Logging via stdlib `log` (with a [builtin-models] prefix) instead of the
+// project's structured logger because `internal/logger` itself imports
+// `internal/types`, creating an import cycle if we use it from here. The
+// same constraint forces sibling files in this package (e.g. model.go's
+// crypto error logs) to use stdlib log too. The prefix gives grep/Splunk
+// users a stable handle even though the lines are unstructured.
 
 // BuiltinModelManagedBy is the value written into `models.managed_by` for
 // rows whose lifecycle is owned by config/builtin_models.yaml. Other rows
@@ -95,13 +102,13 @@ func LoadBuiltinModelsConfig(ctx context.Context, db *gorm.DB, configDir string)
 	// substitutes a directory; we don't want that to spam WARN logs.
 	info, statErr := os.Stat(path)
 	if statErr != nil || !info.Mode().IsRegular() {
-		fmt.Printf("Built-in models config not present at %s; skipping.\n", path)
+		log.Printf("[builtin-models] config not present at %s; skipping", path)
 		return nil
 	}
 
 	raw, err := os.ReadFile(path)
 	if err != nil {
-		fmt.Printf("Warning: read built-in models config %s failed: %v; skipping.\n", path, err)
+		log.Printf("[builtin-models] WARN: read config %s failed: %v; skipping", path, err)
 		return nil
 	}
 
@@ -109,7 +116,7 @@ func LoadBuiltinModelsConfig(ctx context.Context, db *gorm.DB, configDir string)
 
 	var file builtinModelsFile
 	if err := yaml.Unmarshal([]byte(expanded), &file); err != nil {
-		fmt.Printf("Warning: parse built-in models config %s failed: %v; skipping reconcile.\n", path, err)
+		log.Printf("[builtin-models] WARN: parse config %s failed: %v; skipping reconcile", path, err)
 		return nil
 	}
 
@@ -122,7 +129,7 @@ func LoadBuiltinModelsConfig(ctx context.Context, db *gorm.DB, configDir string)
 	for i := range file.BuiltinModels {
 		e := &file.BuiltinModels[i]
 		if e.ID == "" {
-			fmt.Printf("Warning: built-in model entry %d has empty id; skipping.\n", i)
+			log.Printf("[builtin-models] WARN: entry %d has empty id; skipping", i)
 			continue
 		}
 		m := e.toModel()
@@ -136,7 +143,7 @@ func LoadBuiltinModelsConfig(ctx context.Context, db *gorm.DB, configDir string)
 				Where("tenant_id = ? AND type = ? AND id <> ? AND is_default = ?",
 					m.TenantID, m.Type, m.ID, true).
 				Update("is_default", false).Error; err != nil {
-				fmt.Printf("Warning: clear existing default for tenant=%d type=%s failed: %v; continuing.\n",
+				log.Printf("[builtin-models] WARN: clear existing default for tenant=%d type=%s failed: %v; continuing",
 					m.TenantID, m.Type, err)
 			}
 		}
@@ -150,12 +157,12 @@ func LoadBuiltinModelsConfig(ctx context.Context, db *gorm.DB, configDir string)
 			}),
 		}).Create(&m)
 		if res.Error != nil {
-			fmt.Printf("Warning: upsert built-in model %s failed: %v; continuing.\n", e.ID, res.Error)
+			log.Printf("[builtin-models] WARN: upsert %s failed: %v; continuing", e.ID, res.Error)
 			continue
 		}
 		applied++
 		yamlIDs = append(yamlIDs, e.ID)
-		fmt.Printf("Built-in model upserted: id=%s name=%s type=%s\n", e.ID, e.Name, e.Type)
+		log.Printf("[builtin-models] upserted: id=%s name=%s type=%s", e.ID, e.Name, e.Type)
 	}
 
 	// Drift sweep: retire YAML-managed rows that no longer appear in the
@@ -163,10 +170,10 @@ func LoadBuiltinModelsConfig(ctx context.Context, db *gorm.DB, configDir string)
 	// so the row remains recoverable.
 	pruned, sweepErr := pruneOrphanYAMLManagedModels(ctx, db, yamlIDs)
 	if sweepErr != nil {
-		fmt.Printf("Warning: drift sweep for YAML-managed models failed: %v; continuing.\n", sweepErr)
+		log.Printf("[builtin-models] WARN: drift sweep failed: %v; continuing", sweepErr)
 	}
 
-	fmt.Printf("Built-in models config applied: %d upserted, %d pruned from %s.\n", applied, pruned, path)
+	log.Printf("[builtin-models] applied: %d upserted, %d pruned from %s", applied, pruned, path)
 	return nil
 }
 

--- a/internal/types/builtin_models_config_test.go
+++ b/internal/types/builtin_models_config_test.go
@@ -1,0 +1,302 @@
+package types
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// setupBuiltinModelsDB creates an in-memory SQLite DB with `models` migrated
+// via GORM AutoMigrate. AutoMigrate honours the struct tags so the
+// `managed_by` and soft-delete columns are present, matching what the real
+// migrations produce.
+func setupBuiltinModelsDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&Model{}))
+	return db
+}
+
+// writeYAML writes a builtin_models.yaml file inside a fresh temp dir and
+// returns the dir (which is what LoadBuiltinModelsConfig expects as its
+// configDir argument).
+func writeYAML(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "builtin_models.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+	return dir
+}
+
+// countModels returns (live, soft-deleted) counts for the given id, used to
+// distinguish "row gone via UPSERT failure" from "row soft-deleted via sweep".
+func countModels(t *testing.T, db *gorm.DB, id string) (live, deleted int64) {
+	t.Helper()
+	require.NoError(t, db.Model(&Model{}).Where("id = ?", id).Count(&live).Error)
+	require.NoError(t,
+		db.Unscoped().Model(&Model{}).Where("id = ? AND deleted_at IS NOT NULL", id).Count(&deleted).Error,
+	)
+	return live, deleted
+}
+
+func TestLoadBuiltinModelsConfig_FileMissing(t *testing.T) {
+	db := setupBuiltinModelsDB(t)
+	dir := t.TempDir() // empty — no builtin_models.yaml inside
+
+	// Pre-seed a yaml-managed row to verify it is NOT touched when the
+	// config file is absent (file-missing path must skip the sweep).
+	require.NoError(t, db.Create(&Model{
+		ID: "pre-existing-yaml", Name: "n", Type: ModelTypeKnowledgeQA,
+		Source: ModelSourceRemote, Status: ModelStatusActive,
+		IsBuiltin: true, ManagedBy: BuiltinModelManagedBy,
+	}).Error)
+
+	require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+
+	live, deleted := countModels(t, db, "pre-existing-yaml")
+	assert.Equal(t, int64(1), live, "row must remain when YAML file is absent")
+	assert.Equal(t, int64(0), deleted)
+}
+
+func TestLoadBuiltinModelsConfig_ParseError(t *testing.T) {
+	db := setupBuiltinModelsDB(t)
+	// Malformed YAML — should warn + return without sweeping.
+	dir := writeYAML(t, "builtin_models: [oops: : bad")
+
+	require.NoError(t, db.Create(&Model{
+		ID: "pre-existing-yaml", Name: "n", Type: ModelTypeKnowledgeQA,
+		Source: ModelSourceRemote, Status: ModelStatusActive,
+		IsBuiltin: true, ManagedBy: BuiltinModelManagedBy,
+	}).Error)
+
+	require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+
+	live, deleted := countModels(t, db, "pre-existing-yaml")
+	assert.Equal(t, int64(1), live, "parse error must NOT trigger sweep")
+	assert.Equal(t, int64(0), deleted)
+}
+
+func TestLoadBuiltinModelsConfig_BasicUpsert(t *testing.T) {
+	db := setupBuiltinModelsDB(t)
+	dir := writeYAML(t, `builtin_models:
+  - id: builtin-llm
+    name: gpt-4o-mini
+    type: KnowledgeQA
+    is_default: true
+    parameters:
+      provider: openai
+      api_key: sk-123
+`)
+	require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+
+	var m Model
+	require.NoError(t, db.Where("id = ?", "builtin-llm").First(&m).Error)
+	assert.Equal(t, "gpt-4o-mini", m.Name)
+	assert.Equal(t, ModelTypeKnowledgeQA, m.Type)
+	assert.Equal(t, ModelSourceRemote, m.Source, "default source must be remote")
+	assert.Equal(t, ModelStatusActive, m.Status, "default status must be active")
+	assert.Equal(t, uint64(10000), m.TenantID, "default tenant_id must be 10000")
+	assert.True(t, m.IsBuiltin, "IsBuiltin must be forced to true")
+	assert.True(t, m.IsDefault)
+	assert.Equal(t, BuiltinModelManagedBy, m.ManagedBy)
+	assert.Equal(t, "openai", m.Parameters.Provider)
+	assert.Equal(t, "sk-123", m.Parameters.APIKey)
+}
+
+func TestLoadBuiltinModelsConfig_Idempotent(t *testing.T) {
+	db := setupBuiltinModelsDB(t)
+	dir := writeYAML(t, `builtin_models:
+  - id: builtin-llm
+    name: gpt-4o-mini
+    type: KnowledgeQA
+    parameters:
+      provider: openai
+`)
+	require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+	require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+
+	var count int64
+	require.NoError(t, db.Model(&Model{}).Where("id = ?", "builtin-llm").Count(&count).Error)
+	assert.Equal(t, int64(1), count, "second load must not duplicate")
+}
+
+func TestLoadBuiltinModelsConfig_EnvInterpolation(t *testing.T) {
+	db := setupBuiltinModelsDB(t)
+	t.Setenv("BUILTIN_TEST_KEY", "sk-from-env")
+	dir := writeYAML(t, `builtin_models:
+  - id: builtin-llm
+    name: gpt-4o-mini
+    type: KnowledgeQA
+    parameters:
+      provider: openai
+      api_key: ${BUILTIN_TEST_KEY}
+      base_url: ${BUILTIN_TEST_UNSET}
+`)
+	require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+
+	var m Model
+	require.NoError(t, db.Where("id = ?", "builtin-llm").First(&m).Error)
+	assert.Equal(t, "sk-from-env", m.Parameters.APIKey, "set env var must be substituted")
+	assert.Equal(t, "${BUILTIN_TEST_UNSET}", m.Parameters.BaseURL,
+		"unset env var must be kept as literal placeholder")
+}
+
+func TestLoadBuiltinModelsConfig_DriftSweepRemovesYAMLManaged(t *testing.T) {
+	db := setupBuiltinModelsDB(t)
+
+	// Round 1: YAML declares two entries.
+	dir := writeYAML(t, `builtin_models:
+  - id: builtin-llm
+    name: gpt-4o-mini
+    type: KnowledgeQA
+  - id: builtin-rerank
+    name: bge
+    type: Rerank
+`)
+	require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+
+	// Round 2: rerank entry removed.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "builtin_models.yaml"),
+		[]byte(`builtin_models:
+  - id: builtin-llm
+    name: gpt-4o-mini
+    type: KnowledgeQA
+`), 0o644,
+	))
+	require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+
+	live, deleted := countModels(t, db, "builtin-rerank")
+	assert.Equal(t, int64(0), live, "rerank row must be soft-deleted")
+	assert.Equal(t, int64(1), deleted, "rerank row must remain recoverable in raw table")
+
+	live, _ = countModels(t, db, "builtin-llm")
+	assert.Equal(t, int64(1), live, "llm row must survive the sweep")
+}
+
+func TestLoadBuiltinModelsConfig_DriftSweepIgnoresManual(t *testing.T) {
+	db := setupBuiltinModelsDB(t)
+
+	// Seed a manual SQL-style builtin (managed_by="").
+	require.NoError(t, db.Create(&Model{
+		ID: "manual-builtin", Name: "manual", Type: ModelTypeKnowledgeQA,
+		Source: ModelSourceRemote, Status: ModelStatusActive,
+		IsBuiltin: true, ManagedBy: "",
+	}).Error)
+
+	// YAML declares a different id only. Sweep must NOT touch manual row.
+	dir := writeYAML(t, `builtin_models:
+  - id: builtin-llm
+    name: gpt-4o-mini
+    type: KnowledgeQA
+`)
+	require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+
+	live, _ := countModels(t, db, "manual-builtin")
+	assert.Equal(t, int64(1), live, "manual SQL-seeded builtin must survive YAML sweep")
+}
+
+func TestLoadBuiltinModelsConfig_ResurrectsSoftDeleted(t *testing.T) {
+	db := setupBuiltinModelsDB(t)
+	dir := writeYAML(t, `builtin_models:
+  - id: builtin-llm
+    name: gpt-4o-mini
+    type: KnowledgeQA
+`)
+	require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+
+	// Simulate operator soft-deleting the row via API/UI.
+	require.NoError(t, db.Where("id = ?", "builtin-llm").Delete(&Model{}).Error)
+	live, deleted := countModels(t, db, "builtin-llm")
+	require.Equal(t, int64(0), live)
+	require.Equal(t, int64(1), deleted)
+
+	// Re-running the loader must resurrect the row (deleted_at -> NULL).
+	require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+	live, deleted = countModels(t, db, "builtin-llm")
+	assert.Equal(t, int64(1), live, "row must be resurrected by UPSERT")
+	assert.Equal(t, int64(0), deleted, "deleted_at must be cleared")
+}
+
+func TestLoadBuiltinModelsConfig_ClearsExistingDefault(t *testing.T) {
+	db := setupBuiltinModelsDB(t)
+
+	// Seed an existing default (manual, e.g. user picked it via UI).
+	require.NoError(t, db.Create(&Model{
+		ID: "user-default", Name: "user", Type: ModelTypeKnowledgeQA,
+		TenantID: 10000, Source: ModelSourceRemote, Status: ModelStatusActive,
+		IsDefault: true, IsBuiltin: false, ManagedBy: "",
+	}).Error)
+
+	dir := writeYAML(t, `builtin_models:
+  - id: builtin-llm
+    name: gpt-4o-mini
+    type: KnowledgeQA
+    is_default: true
+`)
+	require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+
+	var prev Model
+	require.NoError(t, db.Where("id = ?", "user-default").First(&prev).Error)
+	assert.False(t, prev.IsDefault,
+		"YAML is_default=true must clear other defaults in same (tenant,type)")
+
+	var newDefault Model
+	require.NoError(t, db.Where("id = ?", "builtin-llm").First(&newDefault).Error)
+	assert.True(t, newDefault.IsDefault)
+}
+
+func TestLoadBuiltinModelsConfig_EmptyListSweepsAllYAMLManaged(t *testing.T) {
+	db := setupBuiltinModelsDB(t)
+
+	// Seed one yaml-managed and one manual builtin.
+	require.NoError(t, db.Create(&Model{
+		ID: "yaml-old", Name: "y", Type: ModelTypeKnowledgeQA,
+		Source: ModelSourceRemote, Status: ModelStatusActive,
+		IsBuiltin: true, ManagedBy: BuiltinModelManagedBy,
+	}).Error)
+	require.NoError(t, db.Create(&Model{
+		ID: "manual-builtin", Name: "m", Type: ModelTypeKnowledgeQA,
+		Source: ModelSourceRemote, Status: ModelStatusActive,
+		IsBuiltin: true, ManagedBy: "",
+	}).Error)
+
+	// Explicit empty list. Loader treats this as "no YAML-managed models
+	// declared" and sweeps the entire yaml-managed slice. Manual rows are
+	// untouched.
+	dir := writeYAML(t, "builtin_models: []\n")
+	require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+
+	live, _ := countModels(t, db, "yaml-old")
+	assert.Equal(t, int64(0), live, "yaml-managed row must be swept")
+
+	live, _ = countModels(t, db, "manual-builtin")
+	assert.Equal(t, int64(1), live, "manual row must survive empty-list sweep")
+}
+
+func TestLoadBuiltinModelsConfig_PreservesEntryIDOverBeforeCreate(t *testing.T) {
+	// Regression guard: BeforeCreate now only generates a UUID when ID is
+	// empty. YAML always supplies a stable id; if BeforeCreate ever forgets
+	// the guard and overwrites it, the UPSERT key changes and idempotency
+	// breaks. Reload the file twice and assert the same row id survives.
+	db := setupBuiltinModelsDB(t)
+	dir := writeYAML(t, `builtin_models:
+  - id: stable-id-123
+    name: n
+    type: KnowledgeQA
+`)
+	require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+	require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+
+	var ids []string
+	require.NoError(t, db.Model(&Model{}).Pluck("id", &ids).Error)
+	assert.Equal(t, []string{"stable-id-123"}, ids,
+		"YAML-declared id must survive across reloads (no UUID regeneration)")
+}

--- a/internal/types/builtin_models_config_test.go
+++ b/internal/types/builtin_models_config_test.go
@@ -281,6 +281,60 @@ func TestLoadBuiltinModelsConfig_EmptyListSweepsAllYAMLManaged(t *testing.T) {
 	assert.Equal(t, int64(1), live, "manual row must survive empty-list sweep")
 }
 
+func TestLoadBuiltinModelsConfig_RejectsInvalidEntries(t *testing.T) {
+	// Each sub-case writes a single-entry YAML and asserts the resulting
+	// `models` table stays empty (entry was rejected by validator).
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "id too long",
+			yaml: "builtin_models:\n  - id: " + repeatChar("a", ModelIDMaxLen+1) +
+				"\n    type: KnowledgeQA\n",
+		},
+		{
+			name: "missing type",
+			yaml: "builtin_models:\n  - id: builtin-x\n    name: x\n",
+		},
+		{
+			name: "unknown type (case mismatch)",
+			yaml: "builtin_models:\n  - id: builtin-x\n    type: knowledgeqa\n",
+		},
+		{
+			name: "unknown type",
+			yaml: "builtin_models:\n  - id: builtin-x\n    type: LLM\n",
+		},
+		{
+			name: "unknown status",
+			yaml: "builtin_models:\n  - id: builtin-x\n    type: KnowledgeQA\n    status: enabled\n",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			db := setupBuiltinModelsDB(t)
+			dir := writeYAML(t, c.yaml)
+			require.NoError(t, LoadBuiltinModelsConfig(context.Background(), db, dir))
+
+			var count int64
+			require.NoError(t, db.Model(&Model{}).Count(&count).Error)
+			assert.Equal(t, int64(0), count,
+				"invalid entry must be rejected, table must stay empty")
+		})
+	}
+}
+
+// repeatChar returns s repeated n times. Used to synthesize id strings
+// that exceed ModelIDMaxLen without depending on strings.Repeat in tests.
+func repeatChar(s string, n int) string {
+	out := make([]byte, 0, len(s)*n)
+	for i := 0; i < n; i++ {
+		out = append(out, s...)
+	}
+	return string(out)
+}
+
 func TestLoadBuiltinModelsConfig_PreservesEntryIDOverBeforeCreate(t *testing.T) {
 	// Regression guard: BeforeCreate now only generates a UUID when ID is
 	// empty. YAML always supplies a stable id; if BeforeCreate ever forgets

--- a/internal/types/model.go
+++ b/internal/types/model.go
@@ -105,6 +105,14 @@ type Model struct {
 	IsDefault bool `yaml:"is_default"  json:"is_default"`
 	// Whether the model is a builtin model (visible to all tenants)
 	IsBuiltin bool `yaml:"is_builtin"  json:"is_builtin"  gorm:"default:false"`
+	// ManagedBy identifies which subsystem owns this row's lifecycle.
+	// Empty / "" = manually created (UI / API / hand-written SQL); the YAML
+	// builtin-models loader leaves these untouched.
+	// "yaml" = declared in config/builtin_models.yaml; on every startup the
+	// loader UPSERTs the YAML set and soft-deletes YAML-managed rows whose
+	// id is no longer present in the file. Future origins (e.g. "helm",
+	// "operator") can claim their own slice without interfering.
+	ManagedBy string `yaml:"managed_by"  json:"managed_by,omitempty"  gorm:"type:varchar(32);default:''"`
 	// Model status, default: active, possible: downloading, download_failed
 	Status ModelStatus `yaml:"status"      json:"status"`
 	// Creation time of the model

--- a/internal/types/model.go
+++ b/internal/types/model.go
@@ -85,10 +85,28 @@ type ModelParameters struct {
 // exist; a runtime mutator on the entity is both redundant and a footgun
 // (mutates an entity that other code may still be using).
 
+// ModelIDMaxLen is the upper bound on `models.id`. Matches the actual
+// schema width on both PostgreSQL (varchar(64) in migrations/versioned/
+// 000000_init.up.sql) and SQLite (varchar(64) in migrations/sqlite/
+// 000000_init.up.sql). Loaders that accept user-provided ids (e.g. the
+// built-in models YAML loader) must reject anything longer to avoid a
+// "value too long for type" failure at INSERT time.
+const ModelIDMaxLen = 64
+
+// DefaultBuiltinModelTenantID is the tenant id that built-in models are
+// assigned to when YAML does not specify one. Kept in sync with the seed
+// value of tenants_id_seq in migrations/versioned/000000_init.up.sql
+// (and the equivalent SQLite init); changing one without the other will
+// break visibility of built-in models for the default tenant.
+const DefaultBuiltinModelTenantID uint64 = 10000
+
 // Model represents the AI model
 type Model struct {
-	// Unique identifier of the model
-	ID string `yaml:"id"          json:"id"          gorm:"type:varchar(36);primaryKey"`
+	// Unique identifier of the model. The actual DB schema width is
+	// varchar(64) on both PostgreSQL and SQLite (see ModelIDMaxLen);
+	// GORM's struct tag is documented to match so AutoMigrate paths
+	// produce the same shape.
+	ID string `yaml:"id"          json:"id"          gorm:"type:varchar(64);primaryKey"`
 	// Tenant ID
 	TenantID uint64 `yaml:"tenant_id"   json:"tenant_id"`
 	// Name of the model

--- a/migrations/sqlite/000000_init.up.sql
+++ b/migrations/sqlite/000000_init.up.sql
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS models (
     parameters TEXT NOT NULL,
     is_default BOOLEAN NOT NULL DEFAULT 0,
     is_builtin BOOLEAN NOT NULL DEFAULT 0,
+    managed_by VARCHAR(32) NOT NULL DEFAULT '',
     status VARCHAR(50) NOT NULL DEFAULT 'active',
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -46,6 +47,7 @@ CREATE TABLE IF NOT EXISTS models (
 CREATE INDEX IF NOT EXISTS idx_models_type ON models(type);
 CREATE INDEX IF NOT EXISTS idx_models_source ON models(source);
 CREATE INDEX IF NOT EXISTS idx_models_is_builtin ON models(is_builtin);
+CREATE INDEX IF NOT EXISTS idx_models_managed_by ON models(managed_by);
 
 CREATE TABLE IF NOT EXISTS knowledge_bases (
     id VARCHAR(36) PRIMARY KEY,

--- a/migrations/versioned/000052_models_managed_by.down.sql
+++ b/migrations/versioned/000052_models_managed_by.down.sql
@@ -1,0 +1,5 @@
+-- Down migration for 000052_models_managed_by.
+
+DROP INDEX IF EXISTS idx_models_managed_by_yaml;
+
+ALTER TABLE models DROP COLUMN IF EXISTS managed_by;

--- a/migrations/versioned/000052_models_managed_by.up.sql
+++ b/migrations/versioned/000052_models_managed_by.up.sql
@@ -1,0 +1,37 @@
+-- Migration: 000052_models_managed_by
+-- Add a `managed_by` column to `models` so the YAML built-in models loader can
+-- own a slice of the table without disturbing rows created via the UI/API or
+-- seeded by hand-written SQL.
+--
+-- Background:
+--   * 000051-era PR #1453 introduced config/builtin_models.yaml as a
+--     declarative source of truth for built-in models. The first version
+--     could add/update rows but had no way to remove them: deleting an entry
+--     from YAML left the corresponding row in `models`, breaking the
+--     "declarative" contract and forcing operators back into ad-hoc SQL.
+--   * Indiscriminately deleting `is_builtin=true` rows on each startup is
+--     unsafe because some deployments seed built-ins via direct SQL, and
+--     those rows must not be touched.
+--
+-- Solution:
+--   * Add `managed_by` (varchar(32), default ''). YAML loader writes "yaml";
+--     anything else (UI / API / SQL seed) keeps the empty default.
+--   * On every startup the loader UPSERTs YAML entries with managed_by='yaml'
+--     and soft-deletes rows where (is_builtin=true AND managed_by='yaml' AND
+--     id NOT IN <current YAML id set>). Manual rows are never inspected.
+--
+-- This migration is idempotent (IF NOT EXISTS) and safe to re-run.
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000052] Adding models.managed_by column'; END $$;
+
+ALTER TABLE models
+    ADD COLUMN IF NOT EXISTS managed_by VARCHAR(32) NOT NULL DEFAULT '';
+
+-- A partial index on the YAML-managed slice keeps the startup sweep cheap
+-- even if the table grows large. Manual rows (managed_by='') are excluded
+-- so the index stays small.
+CREATE INDEX IF NOT EXISTS idx_models_managed_by_yaml
+    ON models (managed_by)
+    WHERE managed_by <> '';
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000052] Done'; END $$;


### PR DESCRIPTION
## Summary

Builds on #1453 to close the lifecycle gaps that the original PR
intentionally left open. With this change `config/builtin_models.yaml`
becomes a complete source of truth for the slice of `models` it owns:
edit, add, **and remove** all happen by editing the file.

The first commit on this branch is #1453 verbatim (so the diff is
self-contained while #1453 is still open); the three commits added here
are the lifecycle work.

### What's new on top of #1453

**1. `models.managed_by` column** (commit `1d2685f2`)
- Tags every YAML-written row with `managed_by='yaml'`. Rows created via
  UI/API/SQL keep the default empty string and are invisible to the
  loader — manual-management workflows are not touched.
- PG: new migration `000052_models_managed_by` adds the column plus a
  partial index over non-empty values to keep the startup reconcile
  query cheap.
- SQLite: `migrations/sqlite/000000_init.up.sql` is updated in place
  per Lite-mode convention.

**2. YAML lifecycle reconcile** (commit `e482aa28`)
- UPSERT now includes `deleted_at` in `DoUpdates`, so a YAML-managed row
  that was previously soft-deleted (e.g. via UI/API) is **resurrected**
  when it reappears in the file. Closes the "ghost row that exists in
  the table but is invisible" failure mode.
- After all UPSERTs, the loader **soft-deletes** rows where
  `managed_by='yaml' AND id NOT IN <current YAML id set>`. Removing an
  entry from YAML is now the supported way to retire a built-in model —
  no manual SQL needed.
- When a YAML entry sets `is_default: true`, the loader first clears
  `is_default` on other rows in the same `(tenant_id, type)` bucket,
  mirroring the invariant enforced by the API path
  (`repository.UnsetDefaultModel`). Prevents multiple defaults from
  accumulating when ops mix YAML and UI.
- Defensive failure handling preserved: parse error / file missing /
  per-entry UPSERT failure all skip the sweep so a malformed file
  cannot mass-delete rows.

**3. Compose compatibility fix** (commit `c1ff3d4c`)
- #1453 introduced the map form of `env_file:` (`- path: .env, required: false`)
  which only works on Docker Compose v2.24+ (Jan 2024). Older deploys
  fail to parse `docker-compose.yml` even when `builtin_models.yaml` is
  not used — breaking the "no impact unless opted in" promise.
- Switched to the universally-supported array form `env_file: [.env]`.
  The trade-off (Compose errors when `.env` is absent) is covered by
  the existing `check_env_file` in `scripts/start_all.sh` and by a new
  guard added to `make docker-run` / `make docker-restart`.

### Tests

`internal/types/builtin_models_config_test.go` covers 11 scenarios
against an in-memory SQLite DB:

- File missing — no-op, no sweep, pre-existing yaml-managed rows preserved
- YAML parse error — warn + return, sweep skipped (regression guard for
  the "one typo wipes everything" failure mode)
- Basic UPSERT with defaults (tenant_id=10000, source=remote, status=active)
- Idempotent reload (no duplicates after second call)
- `${ENV}` interpolation: set value substituted, unset left as literal
- Drift sweep removes YAML rows that disappeared from the file
- Drift sweep ignores rows with `managed_by=''` (manual SQL seeds)
- Soft-deleted row resurrected when it reappears in YAML
- `is_default: true` clears existing default in same (tenant_id, type)
- Explicit `builtin_models: []` sweeps all yaml-managed rows
- Regression guard: BeforeCreate must not overwrite YAML-supplied stable ids

`go build ./...`, `go vet ./internal/types/...`, and
`go test ./internal/types/...` all pass.

### Operator-facing behavior

| Action | Before this PR | After |
|---|---|---|
| Add a model | edit YAML, restart | (unchanged) |
| Update a model | edit YAML, restart | (unchanged) |
| **Remove a model** | edit YAML, then manually `UPDATE`/`DELETE` in DB | **edit YAML, restart — done** |
| Resurrect a soft-deleted YAML model | manually `UPDATE models SET deleted_at=NULL` | re-add to YAML, restart |
| Promote a model to default via YAML | could leave multiple defaults if user had set one via UI | YAML now clears prior defaults in same bucket |
| Old Docker Compose (< v2.24) | `docker-compose.yml` failed to parse | works |

### Migration / rollout

- The schema migration adds a column with a safe default (`''`); no
  backfill needed since existing rows are exactly the manual-managed
  rows the loader is meant to leave alone.
- Down migration drops the column cleanly.
- SQLite uses the standard in-place init pattern; fresh Lite databases
  pick up the column from the existing `000000_init` migration.

## Type of Change

- [x] ✨ New feature (lifecycle on top of #1453)
- [x] 🐛 Bug fix (Compose v2.24+ requirement leaked into base config)
- [x] 🧪 Tests

## Testing

- `go build ./...` — passes
- `go vet ./internal/types/...` — clean
- `go test ./internal/types/...` — 11/11 new tests pass + existing tests
- Manual: simulated the "remove entry → restart" flow against a local
  SQLite-backed Lite instance; row is soft-deleted, re-adding the entry
  resurrects it with `deleted_at=NULL`.

## Notes for reviewers

- This PR depends on #1453's first commit. Two paths to land:
  1. Merge #1453 first, then rebase this branch onto main (drops the
     duplicate commit, leaves three clean commits).
  2. Close #1453 in favor of this branch.
  Happy with either — let me know.
- Original #1453 review comments about `varchar(36)` primary key length
  and `fmt.Printf` vs structured logger are intentionally **not**
  addressed here to keep the diff focused on lifecycle. Those are easy
  follow-ups.

## Checklist

- [x] Self-reviewed the code
- [x] Added tests covering the change
- [x] Updated documentation (`docs/BUILTIN_MODELS.md`)
- [x] Breaking changes called out: none for end users; ops who relied on
      "YAML never touches the DB after first insert" will see soft
      deletes of yaml-managed rows that disappear from the file