### PR TITLE
fix(pipeline): fallback to raw retrieval results when rerank API fails

### DIFF
--- a/internal/application/service/chat_pipeline/rerank.go
+++ b/internal/application/service/chat_pipeline/rerank.go
@@ -108,7 +108,19 @@ func (p *PluginRerank) OnEvent(ctx context.Context,
 	if len(candidatesToRerank) > 0 {
 		// Single rerank call with RewriteQuery, use threshold degradation if no results
 		originalThreshold := chatManage.RerankThreshold
-		rerankResp = p.rerank(ctx, chatManage, rerankModel, chatManage.RewriteQuery, passages, candidatesToRerank)
+		var rerankErr error
+		rerankResp, rerankErr = p.rerank(ctx, chatManage, rerankModel, chatManage.RewriteQuery, passages, candidatesToRerank)
+
+		if rerankErr != nil {
+			// Rerank API failed — fallback to original retrieval results so the
+			// pipeline can still return something useful to the caller.
+			pipelineWarn(ctx, "Rerank", "api_error_fallback", map[string]interface{}{
+				"error":         rerankErr.Error(),
+				"candidate_cnt": len(candidatesToRerank),
+			})
+			chatManage.SearchResult = append(directLoadResults, candidatesToRerank...)
+			return next()
+		}
 
 		// If no results and threshold is high enough, try with lower threshold
 		if len(rerankResp) == 0 && originalThreshold > 0.3 {
@@ -123,9 +135,17 @@ func (p *PluginRerank) OnEvent(ctx context.Context,
 				"reason":        "no results above original threshold, retrying with lower threshold",
 			})
 			chatManage.RerankThreshold = degradedThreshold
-			rerankResp = p.rerank(ctx, chatManage, rerankModel, chatManage.RewriteQuery, passages, candidatesToRerank)
+			rerankResp, rerankErr = p.rerank(ctx, chatManage, rerankModel, chatManage.RewriteQuery, passages, candidatesToRerank)
 			// Restore original threshold
 			chatManage.RerankThreshold = originalThreshold
+			if rerankErr != nil {
+				pipelineWarn(ctx, "Rerank", "api_error_fallback", map[string]interface{}{
+					"error":         rerankErr.Error(),
+					"candidate_cnt": len(candidatesToRerank),
+				})
+				chatManage.SearchResult = append(directLoadResults, candidatesToRerank...)
+				return next()
+			}
 		}
 	}
 
@@ -209,7 +229,7 @@ func (p *PluginRerank) OnEvent(ctx context.Context,
 func (p *PluginRerank) rerank(ctx context.Context,
 	chatManage *types.ChatManage, rerankModel rerank.Reranker, query string, passages []string,
 	candidates []*types.SearchResult,
-) []rerank.RankResult {
+) ([]rerank.RankResult, error) {
 	pipelineInfo(ctx, "Rerank", "model_call", map[string]interface{}{
 		"query_variant": query,
 		"passages":      len(passages),
@@ -230,7 +250,7 @@ func (p *PluginRerank) rerank(ctx context.Context,
 		pipelineInfo(ctx, "Rerank", "model_call_skip", map[string]interface{}{
 			"reason": "all_passages_empty",
 		})
-		return nil
+		return nil, nil
 	}
 	passages = cleanPassages
 	candidates = cleanCandidates
@@ -241,7 +261,7 @@ func (p *PluginRerank) rerank(ctx context.Context,
 			"query_variant": query,
 			"error":         err.Error(),
 		})
-		return nil
+		return nil, err
 	}
 
 	// Log top scores for debugging
@@ -300,7 +320,7 @@ func (p *PluginRerank) rerank(ctx context.Context,
 		})
 	}
 
-	return rankFilter
+	return rankFilter, nil
 }
 
 // ensureMetadata ensures the metadata is not nil


### PR DESCRIPTION

<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->
 - 现象
  用户通过 /knowledge-search 搜索知识库返回空结果，而知识库本身数据正常。

  - 根因
  日志显示 rerank 模型调用返回 401 Unauthorized（API Key 认证失败）。
  p.rerank 方法在 API 失败时直接 return nil，没有 error 返回值，上层无法区分"API 失败"和"所有结果低于 threshold 被过滤"这两种情况。最终 chatManage.RerankResult 被设为空，CHUNK_MERGE 阶段虽然有 SearchResult fallback 路径，但 因为 RerankResult 被显式设为空 slice（非 nil），触发了 filtered_cnt=0 警告并返回空。

  - 修复
  p.rerank 改为返回 ([]RankResult, error)，API 失败时透传 error。上层收到 error 时将 rerank 前的原始检索结果（directLoadResults + candidatesToRerank）写回 chatManage.SearchResult，然后 return next() 让后续 pipeline（CHUNK_MERGE → FILTER_TOP_K）继续处理。                                                                                                                                                                                                  

  - 效果
  rerank 模型故障时降级为无 rerank 排序的结果返回，而不是静默返回空。

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->

## Checklist
- [x] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
