### PR TITLE
fix(input-field): wrong toast when selecting built-in agents other than quick-answer / smart-reasoning

### DIFF
--- a/frontend/src/components/Input-field.vue
+++ b/frontend/src/components/Input-field.vue
@@ -1810,7 +1810,15 @@ const handleSelectAgent = (agent: CustomAgent, sourceTenantId?: string) => {
 
   showAgentModeSelector.value = false;
 
-  const message = agent.is_builtin
+  // Only the two "mode-entry" built-ins are re-branded as "Normal / Agent Mode"
+  // in the dropdown — the switched-on/off toasts only make sense for them.
+  // Other built-ins (wiki researcher, data analyst, etc.) share `is_builtin`
+  // but should fall back to the generic agentSelected toast like custom agents,
+  // otherwise selecting e.g. the Wiki Questioner incorrectly says
+  // "Switched to Intelligent Reasoning".
+  const isModeBuiltin =
+    agent.id === BUILTIN_QUICK_ANSWER_ID || agent.id === BUILTIN_SMART_REASONING_ID;
+  const message = isModeBuiltin
     ? (isAgentType ? t('input.messages.agentSwitchedOn') : t('input.messages.agentSwitchedOff'))
     : t('input.messages.agentSelected', { name: agent.name });
   MessagePlugin.success(message);


### PR DESCRIPTION
## Summary

Selecting any built-in agent other than `builtin-quick-answer` /
`builtin-smart-reasoning` shows the wrong toast in the chat page's
agent selector dropdown. "Switched to Intelligent Reasoning" pops up
regardless of which agent was actually picked — Wiki Questioner, Data
Analyst, Wiki Fixer, etc.

The two original built-ins are special: the dropdown re-brands them as
"Normal Mode" / "Agent Mode", so the "Switched to X" toast text only
makes sense for them. This PR narrows the special-case toast to those
two IDs. Other built-ins fall back to the generic `agentSelected`
toast (the same path custom agents already use), so they get a toast
naming the agent.

## Reproduce on `main`

1. Open the chat page; click the agent selector dropdown next to the
   message input.
2. Select **Wiki Questioner** (or any built-in other than quick-answer
   / smart-reasoning).
3. Toast says **"Switched to Intelligent Reasoning"** — wrong.
   Expected: a toast naming the selected agent.

## Test plan

- [x] Select **Quick Answer** → "Switched to Quick Q&A" (unchanged)
- [x] Select **Smart Reasoning** → "Switched to Intelligent Reasoning" (unchanged)
- [x] Select **Wiki Questioner** → "Selected agent \"Wiki Questioner\"" (was wrong, now correct)
- [x] Select **Data Analyst** → "Selected agent \"Data Analyst\"" (was wrong, now correct)
- [x] Select a custom agent → "Selected agent \"<name>\"" (unchanged)

## Notes

- No i18n strings added or modified — uses the existing `agentSelected`
  key for the fallback path.
- No behavior change for `builtin-quick-answer` / `builtin-smart-reasoning`.
