### PR TITLE
fix(frontend): apply default context template when switching to quick-answer mode

### DIFF
--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -1666,7 +1666,7 @@ const defaultFormData = {
     // 基础设置
     agent_mode: 'smart-reasoning' as 'quick-answer' | 'smart-reasoning',
     system_prompt: '',
-    context_template: '{{query}}',
+    context_template: '',
     // 模型设置
     model_id: '',
     rerank_model_id: '',


### PR DESCRIPTION
## Summary
- Initialize new agent `context_template` as empty instead of the hardcoded `{{query}}` placeholder.
- Ensures switching from smart-reasoning to quick-answer mode correctly fills the system default context template from prompt-templates.

## Test plan
- [ ] Open Agent Editor and create a new agent (defaults to smart-reasoning mode)
- [ ] Switch mode to quick-answer
- [ ] Verify context template is auto-filled with the full default template (not just `{{query}}`)
- [ ] Click "Restore default" and confirm it still works
- [ ] Save the agent in quick-answer mode and confirm context template persists


Made with [Cursor](https://cursor.com)