### PR TITLE
fix(agent): preserve agent intent prompt whitespace and add tests

### DIFF
--- a/internal/application/service/chat_pipeline/query_understand.go
+++ b/internal/application/service/chat_pipeline/query_understand.go
@@ -187,16 +187,7 @@ func (p *PluginQueryUnderstand) OnEvent(ctx context.Context,
 
 	// --- Apply intent-specific system prompt override ---
 	if !chatManage.NeedsRetrieval() {
-		intentKey := string(chatManage.Intent)
-		if chatManage.IntentPromptOverrides != nil {
-			chatManage.SystemPromptOverride = strings.TrimSpace(chatManage.IntentPromptOverrides[intentKey])
-		}
-		if chatManage.SystemPromptOverride == "" {
-			if prompt, ok := p.config.Conversation.IntentSystemPrompts[intentKey]; ok {
-				chatManage.SystemPromptOverride = prompt
-			}
-		}
-		if chatManage.SystemPromptOverride != "" {
+		if applyIntentPromptOverride(chatManage, p.config.Conversation.IntentSystemPrompts) {
 			pipelineInfo(ctx, "QueryUnderstand", "prompt_override", map[string]interface{}{
 				"session_id": chatManage.SessionID,
 				"intent":     chatManage.Intent,
@@ -475,6 +466,24 @@ func mergeImageDescAndOCR(desc, ocr string) (string, bool) {
 		return desc, true
 	}
 	return desc + "\n\n[OCR]\n" + ocr, true
+}
+
+// applyIntentPromptOverride resolves the system-prompt override for the current
+// non-retrieval intent. Agent-level overrides take precedence; otherwise the
+// tenant/global IntentSystemPrompts map is consulted. Whitespace-only agent
+// overrides are treated as unset and fall through to the global default. Returns
+// true when a non-empty override was applied.
+func applyIntentPromptOverride(chatManage *types.ChatManage, globalPrompts map[string]string) bool {
+	intentKey := string(chatManage.Intent)
+	if raw, ok := chatManage.IntentPromptOverrides[intentKey]; ok && strings.TrimSpace(raw) != "" {
+		chatManage.SystemPromptOverride = raw
+	}
+	if chatManage.SystemPromptOverride == "" {
+		if prompt, ok := globalPrompts[intentKey]; ok {
+			chatManage.SystemPromptOverride = prompt
+		}
+	}
+	return chatManage.SystemPromptOverride != ""
 }
 
 // formatConversationHistory formats conversation history for prompt template.

--- a/internal/application/service/chat_pipeline/query_understand_test.go
+++ b/internal/application/service/chat_pipeline/query_understand_test.go
@@ -1,0 +1,87 @@
+package chatpipeline
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestApplyIntentPromptOverride_AgentOverrideWins(t *testing.T) {
+	cm := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{
+			IntentPromptOverrides: map[string]string{"chitchat": "agent prompt"},
+		},
+		PipelineState: types.PipelineState{Intent: types.IntentChitchat},
+	}
+	global := map[string]string{"chitchat": "global prompt"}
+
+	if !applyIntentPromptOverride(cm, global) {
+		t.Fatal("expected applied=true")
+	}
+	if cm.SystemPromptOverride != "agent prompt" {
+		t.Errorf("override: got %q, want %q", cm.SystemPromptOverride, "agent prompt")
+	}
+}
+
+func TestApplyIntentPromptOverride_PreservesAgentWhitespace(t *testing.T) {
+	// Agent-supplied prompts with surrounding whitespace must reach the model
+	// verbatim; trim is only used for emptiness detection.
+	raw := "  agent prompt with trailing newline\n"
+	cm := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{
+			IntentPromptOverrides: map[string]string{"chitchat": raw},
+		},
+		PipelineState: types.PipelineState{Intent: types.IntentChitchat},
+	}
+
+	if !applyIntentPromptOverride(cm, nil) {
+		t.Fatal("expected applied=true")
+	}
+	if cm.SystemPromptOverride != raw {
+		t.Errorf("override: got %q, want %q", cm.SystemPromptOverride, raw)
+	}
+}
+
+func TestApplyIntentPromptOverride_BlankAgentFallsBackToGlobal(t *testing.T) {
+	cm := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{
+			IntentPromptOverrides: map[string]string{"chitchat": "   \n\t  "},
+		},
+		PipelineState: types.PipelineState{Intent: types.IntentChitchat},
+	}
+	global := map[string]string{"chitchat": "global prompt"}
+
+	if !applyIntentPromptOverride(cm, global) {
+		t.Fatal("expected applied=true")
+	}
+	if cm.SystemPromptOverride != "global prompt" {
+		t.Errorf("override: got %q, want %q", cm.SystemPromptOverride, "global prompt")
+	}
+}
+
+func TestApplyIntentPromptOverride_NoOverrideAndNoGlobal(t *testing.T) {
+	cm := &types.ChatManage{
+		PipelineState: types.PipelineState{Intent: types.IntentChitchat},
+	}
+
+	if applyIntentPromptOverride(cm, nil) {
+		t.Fatal("expected applied=false")
+	}
+	if cm.SystemPromptOverride != "" {
+		t.Errorf("override should remain empty, got %q", cm.SystemPromptOverride)
+	}
+}
+
+func TestApplyIntentPromptOverride_GlobalOnly(t *testing.T) {
+	cm := &types.ChatManage{
+		PipelineState: types.PipelineState{Intent: types.IntentGreeting},
+	}
+	global := map[string]string{"greeting": "hi there"}
+
+	if !applyIntentPromptOverride(cm, global) {
+		t.Fatal("expected applied=true")
+	}
+	if cm.SystemPromptOverride != "hi there" {
+		t.Errorf("override: got %q, want %q", cm.SystemPromptOverride, "hi there")
+	}
+}


### PR DESCRIPTION
## Summary
- Stop trimming agent-supplied intent prompts before assignment in `PluginQueryUnderstand`; whitespace is now used only for emptiness detection so trailing newlines / formatting reach the model verbatim.
- Extract the override resolution into `applyIntentPromptOverride` so the agent → global → empty fallback chain is testable in isolation.
- Add unit tests covering agent-wins, whitespace preservation, blank-string fallback, no-config, and global-only paths.

Follow-up to #1491.

## Test plan
- [x] `go test ./internal/application/service/chat_pipeline/...`
- [x] `go build ./...`
- [x] `go vet ./internal/application/service/chat_pipeline/...`