### PR TITLE
fix(im): recover from deleted session when GetSession returns app sentinel (#1499)

### DIFF
--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -16,6 +16,7 @@ import (
 
 	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
 	"github.com/Tencent/WeKnora/internal/config"
+	apperrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/event"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/models/chat"
@@ -1048,8 +1049,8 @@ func (s *Service) HandleMessage(ctx context.Context, msg *IncomingMessage, chann
 		// ChannelSession mapping still exists (GORM soft-delete does not trigger
 		// SQL ON DELETE CASCADE). Recover by soft-deleting the stale mapping and
 		// re-creating a fresh session so the IM bot doesn't become permanently
-		// unresponsive. (fixes #1046)
-		if errors.Is(err, gorm.ErrRecordNotFound) {
+		// unresponsive. (fixes #1046, #1499)
+		if isSessionNotFound(err) {
 			logger.Warnf(ctx, "[IM] Session %s not found (deleted?), recycling stale channel session %s",
 				channelSession.SessionID, channelSession.ID)
 			if delErr := s.db.Delete(&ChannelSession{}, "id = ?", channelSession.ID).Error; delErr != nil {
@@ -1322,6 +1323,15 @@ func (s *Service) sendStreamReply(ctx context.Context, msg *IncomingMessage, str
 		return fmt.Errorf("end stream: %w", err)
 	}
 	return nil
+}
+
+// isSessionNotFound reports whether err indicates the underlying WeKnora
+// session no longer exists. The session repository translates GORM's
+// ErrRecordNotFound into apperrors.ErrSessionNotFound, so the application
+// sentinel is what GetSession returns today; the GORM check is kept as a
+// safety net in case a future repository revert bypasses the translation.
+func isSessionNotFound(err error) bool {
+	return errors.Is(err, apperrors.ErrSessionNotFound) || errors.Is(err, gorm.ErrRecordNotFound)
 }
 
 // resolveSession dispatches to the appropriate session resolution strategy

--- a/internal/im/session_not_found_test.go
+++ b/internal/im/session_not_found_test.go
@@ -1,0 +1,49 @@
+package im
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	apperrors "github.com/Tencent/WeKnora/internal/errors"
+	"gorm.io/gorm"
+)
+
+// TestIsSessionNotFound guards the recovery path for issue #1499.
+//
+// The session repository translates gorm.ErrRecordNotFound into
+// apperrors.ErrSessionNotFound, so an `errors.Is(err, gorm.ErrRecordNotFound)`
+// check on the value returned by SessionService.GetSession would silently
+// miss — leaving the IM bot permanently unresponsive after the user deletes
+// the underlying session from the UI.
+func TestIsSessionNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"app sentinel as returned by sessionService.GetSession today", apperrors.ErrSessionNotFound, true},
+		{"wrapped app sentinel", fmt.Errorf("get session: %w", apperrors.ErrSessionNotFound), true},
+		{"raw gorm sentinel (safety net)", gorm.ErrRecordNotFound, true},
+		{"wrapped gorm sentinel", fmt.Errorf("query session: %w", gorm.ErrRecordNotFound), true},
+		{"unrelated error", errors.New("boom"), false},
+		{"nil", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSessionNotFound(tt.err); got != tt.want {
+				t.Errorf("isSessionNotFound(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestErrSessionNotFoundIsNotGormErrRecordNotFound documents the invariant
+// that motivated the bug: the two sentinels are distinct error values, so
+// callers must explicitly match the application sentinel.
+func TestErrSessionNotFoundIsNotGormErrRecordNotFound(t *testing.T) {
+	if errors.Is(apperrors.ErrSessionNotFound, gorm.ErrRecordNotFound) {
+		t.Fatal("apperrors.ErrSessionNotFound must not unwrap to gorm.ErrRecordNotFound; " +
+			"if this changes, the IM recovery path can be simplified accordingly")
+	}
+}


### PR DESCRIPTION
## Summary

- The recovery branch added in c578fdba (for #1046) checked `errors.Is(err, gorm.ErrRecordNotFound)`, but the session repository translates the GORM error into `apperrors.ErrSessionNotFound` before it reaches the IM service. The predicate therefore never matched and the stale `ChannelSession` was never recycled — the bot stayed permanently unresponsive after the underlying session was deleted from the UI, which is exactly the symptom reported in #1499.
- Extract the predicate into `isSessionNotFound` that matches both sentinels: the application sentinel (what `SessionService.GetSession` actually returns today) and `gorm.ErrRecordNotFound` as a safety net against future repository reverts that bypass the translation layer.
- Add a focused regression test guarding the invariant so the recovery path can't silently break again.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/im/` (existing tests still green, 8 new cases pass)
- [ ] Manual: in a WeCom-connected channel, send a message, delete the auto-created session from the WeKnora UI, send another message — the bot should now reply (a new session is auto-created) instead of returning `error=session not found`.

Refs: https://github.com/Tencent/WeKnora/issues/1499