### PR TITLE
fix(agent): harden tool parameter parsing against LLM type mismatches

### DIFF
--- a/internal/agent/tools/param_cast.go
+++ b/internal/agent/tools/param_cast.go
@@ -69,8 +69,13 @@ func CastParams(args json.RawMessage, schema json.RawMessage) json.RawMessage {
 func castValue(val interface{}, targetType string) (interface{}, bool) {
 	switch targetType {
 	case "array":
-		// Allow a single string to satisfy string-array parameters used by tools.
 		if s, ok := val.(string); ok {
+			// Try JSON parsing first (handles "[{...}]" → []interface{})
+			var parsed []interface{}
+			if err := json.Unmarshal([]byte(s), &parsed); err == nil {
+				return parsed, true
+			}
+			// Fall back: single string → string array
 			return []string{s}, true
 		}
 

--- a/internal/agent/tools/todo_write.go
+++ b/internal/agent/tools/todo_write.go
@@ -143,7 +143,7 @@ type TodoWriteTool struct {
 
 // TodoWriteInput defines the input parameters for todo_write tool
 type TodoWriteInput struct {
-	Task  string     `json:"task" jsonschema:"The complex task or question you need to create a plan for"`
+	Task  string     `json:"task,omitempty" jsonschema:"The complex task or question you need to create a plan for"`
 	Steps []PlanStep `json:"steps" jsonschema:"Array of research plan steps with status tracking"`
 }
 


### PR DESCRIPTION
## Changes

两个针对 Agent Tool 层的健壮性修复：

### 1. `internal/agent/tools/param_cast.go`
LLM 在调用工具时，可能将 JSON 数组字符串（如 `"[{"name":"a"},{"name":"b"}]"`）直接作为字符串参数传入，而非解析后的数组。原代码会将其 fallback 为 `[]string{s}`，导致下游处理失败。

修复：先尝试 `json.Unmarshal` 解析为 `[]interface{}`，解析成功则直接返回；失败时再 fallback 为单字符串数组。

### 2. `internal/agent/tools/todo_write.go`
`TodoWriteInput.Task` 字段标记为 `json:"task"`（required），但部分 LLM 在调用 `todo_write` 时只提供 `steps` 而不提供 `task`，导致反序列化失败。

修复：将 tag 改为 `json:"task,omitempty"`，允许 LLM 省略 task 字段。

## Testing
- 已在生产环境（WeKnora v0.6.0）验证，修复后 LLM 调用 `todo_write` 和参数含 JSON 数组字符串的工具不再报错。