### PR TITLE
feat(models): introduce WikiSynthesis as a first-class model type

### DIFF
--- a/frontend/src/api/model/index.ts
+++ b/frontend/src/api/model/index.ts
@@ -8,7 +8,7 @@ export interface ModelConfig {
   id?: string;
   tenant_id?: number;
   name: string;
-  type: 'KnowledgeQA' | 'Embedding' | 'Rerank' | 'VLLM' | 'ASR';
+  type: 'KnowledgeQA' | 'WikiSynthesis' | 'Embedding' | 'Rerank' | 'VLLM' | 'ASR';
   source: 'local' | 'remote';
   description?: string;
   parameters: {

--- a/frontend/src/components/ModelEditorDialog.vue
+++ b/frontend/src/components/ModelEditorDialog.vue
@@ -280,7 +280,7 @@ interface ModelFormData {
 
 interface Props {
   visible: boolean
-  modelType: 'chat' | 'embedding' | 'rerank' | 'vllm' | 'asr'
+  modelType: 'chat' | 'wikisynthesis' | 'embedding' | 'rerank' | 'vllm' | 'asr'
   modelData?: ModelFormData | null
 }
 
@@ -960,7 +960,9 @@ const checkRemoteAPI = async () => {
 
     switch (props.modelType) {
       case 'chat':
-        // 对话模型（KnowledgeQA）
+      case 'wikisynthesis':
+        // 对话模型 (KnowledgeQA) 和 Wiki 合成模型 (WikiSynthesis) 都走 chat completion
+        // 接口，共用同一个连通性测试
         result = await checkRemoteModel({
           modelName: formData.value.modelName,
           baseUrl: formData.value.baseUrl,

--- a/frontend/src/components/ModelSelector.vue
+++ b/frontend/src/components/ModelSelector.vue
@@ -21,6 +21,7 @@
           <span class="model-name">{{ model.name }}</span>
           <t-tag v-if="model.is_builtin" size="small" theme="primary">{{ $t('model.builtinTag') }}</t-tag>
           <t-tag v-if="model.is_default" size="small" theme="success">{{ $t('model.defaultTag') }}</t-tag>
+          <t-tag v-if="model.type === 'WikiSynthesis'" size="small" theme="success" variant="outline">{{ $t('model.wikiSynthesisTag') }}</t-tag>
         </div>
       </t-option>
       
@@ -45,8 +46,14 @@ import { listModels, type ModelConfig } from '@/api/model'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
 
+type SingleModelType = 'KnowledgeQA' | 'WikiSynthesis' | 'Embedding' | 'Rerank' | 'VLLM' | 'ASR'
+
 interface Props {
-  modelType: 'KnowledgeQA' | 'Embedding' | 'Rerank' | 'VLLM' | 'ASR'
+  // Single type or array of types. For example, the wiki synthesis selector
+  // passes ['WikiSynthesis', 'KnowledgeQA'] so WikiSynthesis-typed models
+  // surface first, and KnowledgeQA models act as a fallback pool for
+  // deployments that haven't registered any WikiSynthesis model.
+  modelType: SingleModelType | SingleModelType[]
   selectedModelId?: string
   disabled?: boolean
   placeholder?: string
@@ -72,10 +79,15 @@ const placeholderText = computed(() => {
   return props.placeholder || t('model.selectModelPlaceholder')
 })
 
+// Normalise the prop to an array so filtering can use includes() uniformly.
+const acceptedTypes = computed(() => {
+  return Array.isArray(props.modelType) ? props.modelType : [props.modelType]
+})
+
 // 监听 allModels 变化，自动过滤当前类型的模型
 watch(() => props.allModels, (newModels) => {
   if (newModels && Array.isArray(newModels)) {
-    models.value = newModels.filter(m => m.type === props.modelType)
+    models.value = newModels.filter(m => acceptedTypes.value.includes(m.type as SingleModelType))
   }
 }, { immediate: true })
 
@@ -96,7 +108,7 @@ const loadModels = async () => {
     const result = await listModels()
     // 前端按类型筛选模型
     if (result && Array.isArray(result)) {
-      models.value = result.filter(m => m.type === props.modelType)
+      models.value = result.filter(m => acceptedTypes.value.includes(m.type as SingleModelType))
     } else {
       models.value = []
     }

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2846,6 +2846,7 @@ export default {
       sourceRemote: 'Remote API',
       description: {
         chat: 'Configure large language models for conversations',
+        wikisynthesis: 'Configure large language models used for wiki page synthesis',
         embedding: 'Configure embedding models for text vectorization',
         rerank: 'Configure models for result re-ranking',
         vllm: 'Configure vision-language models for multimodal understanding',
@@ -3390,6 +3391,7 @@ export default {
     description: 'Manage different types of AI models, including local Ollama and remote APIs',
     typeShort: {
       chat: 'Chat',
+      wikisynthesis: 'Wiki Synth',
       embedding: 'Embedding',
       rerank: 'ReRank',
       vllm: 'Vision',
@@ -3407,6 +3409,11 @@ export default {
       title: 'Chat Models',
       desc: 'Configure large language models for chatting',
       empty: 'No chat models'
+    },
+    wikisynthesis: {
+      title: 'Wiki Synthesis Models',
+      desc: 'Configure large language models used for wiki page synthesis',
+      empty: 'No wiki synthesis models'
     },
     embedding: {
       title: 'Embedding Models',

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1792,7 +1792,7 @@ export default {
       description: 'Configure Wiki auto-generation preferences',
       synthesisModelLabel: 'Wiki Synthesis Model',
       synthesisModelPlaceholder: 'Select the LLM model for Wiki generation',
-      synthesisModelTip: 'Falls back to the summary model if not set',
+      synthesisModelTip: 'Falls back to the LLM model if not set',
       languageLabel: 'Wiki Language',
       maxPagesLabel: 'Max Pages Per Ingest',
       maxPagesTip: 'Maximum number of pages to create/update per ingest (0 = no limit)',
@@ -3012,6 +3012,7 @@ export default {
       },
     },
     builtinTag: 'Built-in',
+    wikiSynthesisTag: 'Wiki-only',
   },
   language: {
     zhCN: '简体中文',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -2087,6 +2087,7 @@ export default {
       sourceRemote: "Remote API (원격)",
       description: {
         chat: "대화용 대규모 언어 모델 설정",
+        wikisynthesis: "위키 페이지 합성용 대규모 언어 모델 설정",
         embedding: "텍스트 벡터화용 임베딩 모델 설정",
         rerank: "결과 재정렬용 모델 설정",
         vllm: "시각 이해 및 멀티모달용 비전 언어 모델 설정",
@@ -3432,6 +3433,7 @@ export default {
     description: "다양한 유형의 AI 모델을 관리합니다. Ollama 로컬 모델과 원격 API를 지원합니다",
     typeShort: {
       chat: "대화",
+      wikisynthesis: "Wiki 합성",
       embedding: "Embedding",
       rerank: "ReRank",
       vllm: "비전",
@@ -3449,6 +3451,11 @@ export default {
       title: "대화 모델",
       desc: "대화용 대규모 언어 모델 설정",
       empty: "대화 모델 없음",
+    },
+    wikisynthesis: {
+      title: "Wiki 합성 모델",
+      desc: "위키 페이지 합성용 대규모 언어 모델 설정",
+      empty: "Wiki 합성 모델 없음",
     },
     embedding: {
       title: "Embedding 모델",

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -2251,6 +2251,7 @@ export default {
       },
     },
     builtinTag: '내장',
+    wikiSynthesisTag: 'Wiki 전용',
   },
   language: {
     zhCN: "简体中文",
@@ -2614,7 +2615,7 @@ export default {
       description: "Wiki 자동 생성 환경설정을 구성합니다",
       synthesisModelLabel: "합성 모델",
       synthesisModelPlaceholder: "Wiki 생성에 사용할 LLM 모델을 선택하세요",
-      synthesisModelTip: "설정하지 않으면 요약 모델로 대체됩니다",
+      synthesisModelTip: "설정하지 않으면 LLM 대규모 언어 모델로 대체됩니다",
       languageLabel: "Wiki 언어",
       maxPagesLabel: "Ingest당 최대 페이지 수",
       maxPagesTip: "Ingest당 생성/업데이트할 최대 페이지 수 (0 = 제한 없음)",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -1855,6 +1855,7 @@ export default {
       sourceRemote: 'Remote API (удалённый)',
       description: {
         chat: 'Настройте языковую модель для диалогов',
+        wikisynthesis: 'Настройте языковую модель для синтеза Wiki-страниц',
         embedding: 'Настройте модель встраивания для текстовой векторизации',
         rerank: 'Настройте модель для повторного ранжирования результатов',
         vllm: 'Настройте визуально-языковую модель для мультимодального понимания',
@@ -3141,6 +3142,7 @@ export default {
     description: 'Управление типами AI‑моделей: локальные (Ollama) и удалённые API',
     typeShort: {
       chat: 'Чат',
+      wikisynthesis: 'Wiki синтез',
       embedding: 'Embedding',
       rerank: 'ReRank',
       vllm: 'Зрение',
@@ -3154,6 +3156,11 @@ export default {
       title: 'Модели диалога',
       desc: 'Модели для диалога',
       empty: 'Нет моделей диалога'
+    },
+    wikisynthesis: {
+      title: 'Модели Wiki-синтеза',
+      desc: 'Языковые модели для синтеза Wiki-страниц',
+      empty: 'Нет моделей Wiki-синтеза'
     },
     source: {
       remote: 'Удалённая',

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -2015,7 +2015,8 @@ export default {
         },
       }
     },
-    builtinTag: 'Built-in'
+    builtinTag: 'Built-in',
+    wikiSynthesisTag: 'Только для Wiki'
   },
   createChat: {
     title: 'Привет, я WeKnora — ваши знания всегда под рукой',
@@ -2175,7 +2176,7 @@ export default {
       description: 'Настройте автоматическую генерацию Wiki',
       synthesisModelLabel: 'Модель синтеза',
       synthesisModelPlaceholder: 'Выберите LLM модель для генерации Wiki',
-      synthesisModelTip: 'Если не указано, используется модель суммаризации',
+      synthesisModelTip: 'Если не указано, используется LLM языковая модель',
       languageLabel: 'Язык Wiki',
       maxPagesLabel: 'Макс. страниц за Ingest',
       maxPagesTip: 'Максимальное количество страниц для создания/обновления за одну операцию (0 = без ограничения)',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2232,6 +2232,7 @@ export default {
       },
     },
     builtinTag: "内置",
+    wikiSynthesisTag: "Wiki 专用",
   },
   language: {
     zhCN: "简体中文",
@@ -2588,7 +2589,7 @@ export default {
       description: "配置 Wiki 知识库的自动生成偏好",
       synthesisModelLabel: "Wiki 合成模型",
       synthesisModelPlaceholder: "选择用于 Wiki 生成的 LLM 模型",
-      synthesisModelTip: "不设置时将回退使用摘要模型",
+      synthesisModelTip: "未指定时将复用 LLM 大语言模型",
       languageLabel: "Wiki 语言",
       maxPagesLabel: "单次最大页面数",
       maxPagesTip: "每次 Ingest 最多创建/更新的页面数（0 表示不限制）",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2066,6 +2066,7 @@ export default {
       sourceRemote: "Remote API（远程）",
       description: {
         chat: "配置用于对话的大语言模型",
+        wikisynthesis: "配置用于 Wiki 页面合成的大语言模型",
         embedding: "配置用于文本向量化的嵌入模型",
         rerank: "配置用于结果重排序的模型",
         vllm: "配置用于视觉理解和多模态的视觉语言模型",
@@ -3385,6 +3386,7 @@ export default {
     description: "管理不同类型的 AI 模型，支持 Ollama 本地模型和远程 API",
     typeShort: {
       chat: "对话",
+      wikisynthesis: "Wiki 合成",
       embedding: "Embedding",
       rerank: "ReRank",
       vllm: "视觉",
@@ -3402,6 +3404,11 @@ export default {
       title: "对话模型",
       desc: "配置用于对话的大语言模型",
       empty: "暂无对话模型",
+    },
+    wikisynthesis: {
+      title: "Wiki 合成模型",
+      desc: "配置用于 Wiki 页面合成的大语言模型",
+      empty: "暂无 Wiki 合成模型",
     },
     embedding: {
       title: "Embedding 模型",

--- a/frontend/src/views/knowledge/settings/KBModelConfig.vue
+++ b/frontend/src/views/knowledge/settings/KBModelConfig.vue
@@ -58,12 +58,17 @@
           <p class="desc">{{ $t('knowledgeEditor.wiki.synthesisModelTip') }}</p>
         </div>
         <div class="setting-control">
+          <!-- The wiki synthesis selector surfaces both WikiSynthesis-typed
+               and KnowledgeQA-typed models. Purpose-registered WikiSynthesis
+               models get a "Wiki-only" tag; deployments without any
+               WikiSynthesis model fall back to the KnowledgeQA pool so there
+               is always something to pick. -->
           <ModelSelector
-            model-type="KnowledgeQA"
+            :model-type="['WikiSynthesis', 'KnowledgeQA']"
             :selected-model-id="config.wikiSynthesisModelId"
             :all-models="allModels"
             @update:selected-model-id="handleWikiModelChange"
-            @add-model="handleAddModel('knowledgeqa')"
+            @add-model="handleAddModel('wikisynthesis')"
             :placeholder="$t('knowledgeEditor.wiki.synthesisModelPlaceholder')"
           />
         </div>

--- a/frontend/src/views/settings/ModelSettings.vue
+++ b/frontend/src/views/settings/ModelSettings.vue
@@ -33,6 +33,8 @@
     <t-tabs v-model="activeTypeFilter" class="model-type-tabs">
       <t-tab-panel value="all" :label="`${$t('common.all')}(${allLegacyModels.length})`" />
       <t-tab-panel value="chat" :label="`${$t('modelSettings.typeShort.chat')}(${countByType('chat')})`" />
+      <t-tab-panel value="wikisynthesis"
+        :label="`${$t('modelSettings.typeShort.wikisynthesis')}(${countByType('wikisynthesis')})`" />
       <t-tab-panel value="embedding"
         :label="`${$t('modelSettings.typeShort.embedding')}(${countByType('embedding')})`" />
       <t-tab-panel value="rerank" :label="`${$t('modelSettings.typeShort.rerank')}(${countByType('rerank')})`" />
@@ -131,7 +133,7 @@ const { t } = useI18n()
 const authStore = useAuthStore()
 const confirmDelete = useConfirmDelete()
 
-type ModelType = 'chat' | 'embedding' | 'rerank' | 'vllm' | 'asr'
+type ModelType = 'chat' | 'wikisynthesis' | 'embedding' | 'rerank' | 'vllm' | 'asr'
 type FilterType = 'all' | ModelType
 
 const showDialog = ref(false)
@@ -146,6 +148,7 @@ const allModels = ref<ModelConfig[]>([])
 // 后端 type → 前端分组 type 的映射
 const backendTypeToModelType: Record<string, ModelType> = {
   KnowledgeQA: 'chat',
+  WikiSynthesis: 'wikisynthesis',
   Embedding: 'embedding',
   Rerank: 'rerank',
   VLLM: 'vllm',
@@ -191,6 +194,7 @@ const countByType = (type: ModelType) => allLegacyModels.value.filter(m => m._mo
 // "+新增模型" 下拉菜单
 const addModelOptions = computed(() => ([
   { content: t('modelSettings.typeShort.chat'), value: 'chat' },
+  { content: t('modelSettings.typeShort.wikisynthesis'), value: 'wikisynthesis' },
   { content: t('modelSettings.typeShort.embedding'), value: 'embedding' },
   { content: t('modelSettings.typeShort.rerank'), value: 'rerank' },
   { content: t('modelSettings.typeShort.vllm'), value: 'vllm' },
@@ -201,6 +205,7 @@ const addModelOptions = computed(() => ([
 const typeIcon = (type: ModelType): string => {
   const map: Record<ModelType, string> = {
     chat: 'chat',
+    wikisynthesis: 'file-paste',
     embedding: 'chart-bubble',
     rerank: 'filter-sort',
     vllm: 'image',
@@ -212,6 +217,7 @@ const typeIcon = (type: ModelType): string => {
 const typeLabel = (type: ModelType) => {
   const map: Record<ModelType, string> = {
     chat: t('modelSettings.typeShort.chat'),
+    wikisynthesis: t('modelSettings.typeShort.wikisynthesis'),
     embedding: t('modelSettings.typeShort.embedding'),
     rerank: t('modelSettings.typeShort.rerank'),
     vllm: t('modelSettings.typeShort.vllm'),
@@ -232,6 +238,7 @@ const emptyHint = computed(() => {
   if (activeTypeFilter.value === 'all') return t('modelSettings.chat.empty')
   const map: Record<ModelType, string> = {
     chat: t('modelSettings.chat.empty'),
+    wikisynthesis: t('modelSettings.wikisynthesis.empty'),
     embedding: t('modelSettings.embedding.empty'),
     rerank: t('modelSettings.rerank.empty'),
     vllm: t('modelSettings.vllm.empty'),
@@ -476,9 +483,10 @@ const copyModel = async (_type: ModelType, modelId: string) => {
 }
 
 // 获取后端模型类型
-function getModelType(type: ModelType): 'KnowledgeQA' | 'Embedding' | 'Rerank' | 'VLLM' | 'ASR' {
+function getModelType(type: ModelType): 'KnowledgeQA' | 'WikiSynthesis' | 'Embedding' | 'Rerank' | 'VLLM' | 'ASR' {
   const typeMap = {
     chat: 'KnowledgeQA' as const,
+    wikisynthesis: 'WikiSynthesis' as const,
     embedding: 'Embedding' as const,
     rerank: 'Rerank' as const,
     vllm: 'VLLM' as const,
@@ -641,10 +649,15 @@ onMounted(() => {
   color: #0052D9;
 }
 
-// 5 种类型的徽章配色 —— 比原 tag 配色饱和度低一档，避免炫光
+// 6 种类型的徽章配色 —— 比原 tag 配色饱和度低一档，避免炫光
 .model-card--chat .model-card__badge {
   background: rgba(0, 82, 217, 0.1);
   color: #0052D9;
+}
+
+.model-card--wikisynthesis .model-card__badge {
+  background: rgba(0, 137, 123, 0.1);
+  color: #00897B;
 }
 
 .model-card--embedding .model-card__badge {

--- a/internal/handler/initialization.go
+++ b/internal/handler/initialization.go
@@ -766,6 +766,11 @@ func (h *InitializationHandler) findExistingModelID(kb *types.KnowledgeBase, mod
 		return kb.EmbeddingModelID
 	case types.ModelTypeKnowledgeQA:
 		return kb.SummaryModelID
+	case types.ModelTypeWikiSynthesis:
+		if kb.WikiConfig != nil {
+			return kb.WikiConfig.SynthesisModelID
+		}
+		return ""
 	case types.ModelTypeVLLM:
 		return kb.VLMConfig.ModelID
 	default:
@@ -1393,6 +1398,13 @@ func (h *InitializationHandler) buildConfigResponse(ctx context.Context, models 
 		switch model.Type {
 		case types.ModelTypeKnowledgeQA:
 			config["llm"] = map[string]interface{}{
+				"source":    string(model.Source),
+				"modelName": model.Name,
+				"baseUrl":   baseURL,
+				"apiKey":    apiKey,
+			}
+		case types.ModelTypeWikiSynthesis:
+			config["wikiSynthesis"] = map[string]interface{}{
 				"source":    string(model.Source),
 				"modelName": model.Name,
 				"baseUrl":   baseURL,

--- a/internal/handler/model.go
+++ b/internal/handler/model.go
@@ -362,11 +362,14 @@ type ModelProviderDTO struct {
 }
 
 // modelTypeToFrontend 将后端 ModelType 转换为前端兼容的字符串
-// KnowledgeQA -> chat, Embedding -> embedding, Rerank -> rerank, VLLM -> vllm
+// KnowledgeQA -> chat, WikiSynthesis -> wikisynthesis, Embedding -> embedding,
+// Rerank -> rerank, VLLM -> vllm, ASR -> asr
 func modelTypeToFrontend(mt types.ModelType) string {
 	switch mt {
 	case types.ModelTypeKnowledgeQA:
 		return "chat"
+	case types.ModelTypeWikiSynthesis:
+		return "wikisynthesis"
 	case types.ModelTypeEmbedding:
 		return "embedding"
 	case types.ModelTypeRerank:
@@ -404,6 +407,8 @@ func (h *ModelHandler) ListModelProviders(c *gin.Context) {
 	switch modelType {
 	case "chat":
 		backendModelType = types.ModelTypeKnowledgeQA
+	case "wikisynthesis":
+		backendModelType = types.ModelTypeWikiSynthesis
 	case "embedding":
 		backendModelType = types.ModelTypeEmbedding
 	case "rerank":

--- a/internal/models/provider/aliyun.go
+++ b/internal/models/provider/aliyun.go
@@ -35,6 +35,7 @@ func (p *AliyunProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeEmbedding,
 			types.ModelTypeRerank,
 			types.ModelTypeVLLM,

--- a/internal/models/provider/anthropic.go
+++ b/internal/models/provider/anthropic.go
@@ -25,6 +25,7 @@ func (p *AnthropicProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 		},
 		RequiresAuth: true,
 	}

--- a/internal/models/provider/azure_openai.go
+++ b/internal/models/provider/azure_openai.go
@@ -28,6 +28,7 @@ func (p *AzureOpenAIProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeEmbedding,
 			types.ModelTypeVLLM,
 			types.ModelTypeASR,

--- a/internal/models/provider/deepseek.go
+++ b/internal/models/provider/deepseek.go
@@ -29,6 +29,7 @@ func (p *DeepSeekProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 		},
 		RequiresAuth: true,
 	}

--- a/internal/models/provider/gemini.go
+++ b/internal/models/provider/gemini.go
@@ -31,6 +31,7 @@ func (p *GeminiProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 		},
 		RequiresAuth: true,
 	}

--- a/internal/models/provider/generic.go
+++ b/internal/models/provider/generic.go
@@ -22,6 +22,7 @@ func (p *GenericProvider) Info() ProviderInfo {
 		DefaultURLs: map[types.ModelType]string{}, // 需要用户自行配置填写
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeEmbedding,
 			types.ModelTypeRerank,
 			types.ModelTypeVLLM,

--- a/internal/models/provider/gpustack.go
+++ b/internal/models/provider/gpustack.go
@@ -35,6 +35,7 @@ func (p *GPUStackProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeEmbedding,
 			types.ModelTypeRerank,
 			types.ModelTypeVLLM,

--- a/internal/models/provider/hunyuan.go
+++ b/internal/models/provider/hunyuan.go
@@ -30,6 +30,7 @@ func (p *HunyuanProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeEmbedding,
 		},
 		RequiresAuth: true,

--- a/internal/models/provider/lkeap.go
+++ b/internal/models/provider/lkeap.go
@@ -31,6 +31,7 @@ func (p *LKEAPProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 		},
 		RequiresAuth: true,
 	}

--- a/internal/models/provider/longcat.go
+++ b/internal/models/provider/longcat.go
@@ -28,6 +28,7 @@ func (p *LongCatProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 		},
 		RequiresAuth: true,
 	}

--- a/internal/models/provider/mimo.go
+++ b/internal/models/provider/mimo.go
@@ -29,6 +29,7 @@ func (p *MimoProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 		},
 		RequiresAuth: true,
 	}

--- a/internal/models/provider/minimax.go
+++ b/internal/models/provider/minimax.go
@@ -31,6 +31,7 @@ func (p *MiniMaxProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 		},
 		RequiresAuth: true,
 	}

--- a/internal/models/provider/modelscope.go
+++ b/internal/models/provider/modelscope.go
@@ -31,6 +31,7 @@ func (p *ModelScopeProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeEmbedding,
 			types.ModelTypeVLLM,
 		},

--- a/internal/models/provider/moonshot.go
+++ b/internal/models/provider/moonshot.go
@@ -50,6 +50,7 @@ func (p *MoonshotProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeVLLM,
 		},
 		RequiresAuth: true,

--- a/internal/models/provider/novita.go
+++ b/internal/models/provider/novita.go
@@ -31,6 +31,7 @@ func (p *NovitaProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeEmbedding,
 			types.ModelTypeVLLM,
 		},

--- a/internal/models/provider/nvidia.go
+++ b/internal/models/provider/nvidia.go
@@ -34,6 +34,7 @@ func (p *NvidiaProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeEmbedding,
 			types.ModelTypeRerank,
 			types.ModelTypeVLLM,

--- a/internal/models/provider/openai.go
+++ b/internal/models/provider/openai.go
@@ -33,6 +33,7 @@ func (p *OpenAIProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeEmbedding,
 			types.ModelTypeRerank,
 			types.ModelTypeVLLM,

--- a/internal/models/provider/openrouter.go
+++ b/internal/models/provider/openrouter.go
@@ -30,6 +30,7 @@ func (p *OpenRouterProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeEmbedding,
 			types.ModelTypeVLLM,
 		},

--- a/internal/models/provider/qianfan.go
+++ b/internal/models/provider/qianfan.go
@@ -31,6 +31,7 @@ func (p *QianfanProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeEmbedding,
 			types.ModelTypeRerank,
 			types.ModelTypeVLLM,

--- a/internal/models/provider/qiniu.go
+++ b/internal/models/provider/qiniu.go
@@ -29,6 +29,7 @@ func (p *QiniuProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 		},
 		RequiresAuth: true,
 	}

--- a/internal/models/provider/siliconflow.go
+++ b/internal/models/provider/siliconflow.go
@@ -32,6 +32,7 @@ func (p *SiliconFlowProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeEmbedding,
 			types.ModelTypeRerank,
 			types.ModelTypeVLLM,

--- a/internal/models/provider/volcengine.go
+++ b/internal/models/provider/volcengine.go
@@ -33,6 +33,7 @@ func (p *VolcengineProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeEmbedding,
 			types.ModelTypeVLLM,
 		},

--- a/internal/models/provider/weknoracloud.go
+++ b/internal/models/provider/weknoracloud.go
@@ -28,6 +28,7 @@ func (p *WeKnoraCloudProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeEmbedding,
 			types.ModelTypeRerank,
 			types.ModelTypeVLLM,

--- a/internal/models/provider/zhipu.go
+++ b/internal/models/provider/zhipu.go
@@ -36,6 +36,7 @@ func (p *ZhipuProvider) Info() ProviderInfo {
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeWikiSynthesis,
 			types.ModelTypeEmbedding,
 			types.ModelTypeRerank,
 			types.ModelTypeVLLM,

--- a/internal/types/model.go
+++ b/internal/types/model.go
@@ -15,11 +15,12 @@ import (
 type ModelType string
 
 const (
-	ModelTypeEmbedding   ModelType = "Embedding"   // Embedding model
-	ModelTypeRerank      ModelType = "Rerank"      // Rerank model
-	ModelTypeKnowledgeQA ModelType = "KnowledgeQA" // KnowledgeQA model
-	ModelTypeVLLM        ModelType = "VLLM"        // VLLM model
-	ModelTypeASR         ModelType = "ASR"         // ASR (Automatic Speech Recognition) model
+	ModelTypeEmbedding     ModelType = "Embedding"     // Embedding model
+	ModelTypeRerank        ModelType = "Rerank"        // Rerank model
+	ModelTypeKnowledgeQA   ModelType = "KnowledgeQA"   // KnowledgeQA model (chat completion for user-facing Q&A)
+	ModelTypeWikiSynthesis ModelType = "WikiSynthesis" // WikiSynthesis model (chat completion used by wiki page generation)
+	ModelTypeVLLM          ModelType = "VLLM"          // VLLM model
+	ModelTypeASR           ModelType = "ASR"           // ASR (Automatic Speech Recognition) model
 )
 
 // ModelStatus represents the status of the model


### PR DESCRIPTION
## Summary

Wiki synthesis currently shares the `KnowledgeQA` model pool with the chat
LLM. The KB editor's wiki-synthesis selector filters the same list as the
chat model selector, and `wiki_ingest_batch.go` silently falls back to
`kb.SummaryModelID` when `wiki_config.synthesis_model_id` is unset. As a
result, operators have no way to declare a model as **specifically intended
for wiki synthesis** — the UI cannot distinguish "models suitable for wiki
page generation" from "models suitable for user-facing Q&A".

This matters in deployments that serve both general Q&A and wiki ingestion,
since the two roles usually want different models:

- **Chat (KnowledgeQA)**: latency-sensitive, smaller context, conversational.
- **Wiki synthesis**: long-context, batch-style, can afford a slower or
  cheaper model that's better at consolidating multiple chunks into a
  coherent wiki page.

Today the only way to surface "this model is meant for wiki synthesis" is
to name it something like `wiki-summary-gpt` and rely on naming
conventions, which is brittle.

This PR introduces a new `ModelTypeWikiSynthesis` enum value, parallel to
the existing `KnowledgeQA`, `Embedding`, `Rerank`, `VLLM`, and `ASR` types,
and wires it through Settings → Model Management and the KB editor so the
operator's intent becomes explicit.

The change is **additive and backwards-compatible**: existing KBs that
reference a `KnowledgeQA` model for wiki synthesis keep working, and the
ingest-time fallback to `kb.SummaryModelID` is left untouched. Deployments
that don't register any `WikiSynthesis`-typed model see no functional
change.

## What's in this PR

Three logical commits:

1. **`feat(types): introduce WikiSynthesis as a first-class model type`**
   Type system + backend handler wiring.
   - Add `ModelTypeWikiSynthesis` enum value in `internal/types/model.go`.
   - Declare it in `ModelTypes` for every chat-completion-capable provider
     (24 files). `GetDefaultURL`'s existing fallback to the chat URL means
     no `DefaultURLs` changes are needed.
   - Extend the frontend/backend type-name bridge in
     `internal/handler/model.go` so the UI can round-trip
     `"wikisynthesis"` ↔ `ModelTypeWikiSynthesis`.
   - Extend `findExistingModelID` (returns
     `kb.WikiConfig.SynthesisModelID`) and `buildConfigResponse` (emits a
     `wikiSynthesis` map entry) in `internal/handler/initialization.go`.
   - Add `'WikiSynthesis'` to the `ModelConfig.type` union in
     `frontend/src/api/model/index.ts` so the frontend TypeScript
     contract matches the backend enum.

2. **`feat(model-settings): surface WikiSynthesis as a first-class type in
   the model management UI`**
   - Add a dedicated tab and "Add Model" dropdown entry in
     `ModelSettings.vue`, plus a teal-ish `model-card__badge` style and
     `typeIcon` mapping.
   - Extend `ModelEditorDialog.vue`'s `Props.modelType` union.
   - Add `model.editor.description.wikisynthesis`,
     `modelSettings.typeShort.wikisynthesis`, and a per-type section
     across `zh-CN`, `en-US`, `ko-KR`, and `ru-RU` locales.

3. **`feat(kb-editor): route the wiki synthesis selector to the
   WikiSynthesis pool with KnowledgeQA fallback`**
   - Widen `ModelSelector.vue`'s `modelType` prop to accept an array, so
     the wiki synthesis selector can pass
     `['WikiSynthesis', 'KnowledgeQA']`. Single-string usages elsewhere
     (LLM / Embedding / Rerank / VLLM / ASR) are unaffected.
   - Render a `Wiki-only` outlined tag next to options whose
     `model.type === 'WikiSynthesis'`, so users can tell a purpose-
     registered wiki model apart from a chat model that also appears in
     the dropdown.
   - `KBModelConfig.vue` passes the new array prop and changes the
     "Add Model" action target from `knowledgeqa` to `wikisynthesis`.
   - Update `synthesisModelTip` i18n to make the fallback behavior
     explicit: "Falls back to the LLM model if not set" (the old
     "summary model" wording didn't match the actual KB field name).

The wiki ingest fallback in
`internal/application/service/wiki_ingest_batch.go` is deliberately left
intact — KBs that don't explicitly pick a wiki synthesis model continue
to fall back to the main LLM.

## Backwards compatibility

- **Existing KBs** with `wiki_config.synthesis_model_id` pointing at a
  KnowledgeQA-typed model continue to work; model lookup is by ID and
  ignores the type tag.
- **Existing deployments** without any WikiSynthesis-typed model
  registered see the wiki synthesis selector behave exactly as before —
  it shows the KnowledgeQA pool.
- **No schema migration** required. `ModelType` is a string enum; adding
  a value doesn't change any DB schema.
- **Wiki ingest fallback** to `kb.SummaryModelID` is preserved, so KBs
  that never pick a synthesis model still complete ingestion.

## Reproduce the new behavior

1. Restart the app after this PR is applied.
2. Go to **Settings → Model Management**. A new **Wiki Synth** tab
   appears between **Chat** and **Embedding**. The "Add Model" dropdown
   gets a corresponding entry.
3. Register a model under the **Wiki Synth** type (the same form as
   Chat; backed by the same chat-completion API).
4. Create a new knowledge base with Wiki enabled. Open **Models** in the
   editor: the **Wiki Synthesis Model** selector now shows the
   WikiSynthesis-typed model with a green **Wiki-only** tag, alongside
   any KnowledgeQA models as fallback options.

## Test plan

- [x] Backend: `go build ./internal/... ./cmd/...` — passes
- [x] Frontend: `npx vue-tsc --noEmit` — passes
- [x] Provider test suite (`go test ./internal/models/provider/...`) — passes
- [x] Register a WikiSynthesis model via the API (`POST /api/v1/models`
      with `"type":"WikiSynthesis"`) — succeeds.
- [x] Provider listing (`GET /api/v1/models/providers?model_type=wikisynthesis`)
      returns the same set of providers as `?model_type=chat`.
- [x] Settings UI shows the new tab, the new model card, and the
      type-coloured badge.
- [x] KB editor wiki synthesis dropdown shows both WikiSynthesis (with
      "Wiki-only" tag) and KnowledgeQA models.
- [x] Selecting either type and saving persists `wiki_config.synthesis_model_id`
      correctly.

## Non-goals / out of scope

- No change to the wiki ingest path; the fallback to `kb.SummaryModelID`
  is intentional to preserve current behavior.
- No automatic "default to first WikiSynthesis model" in the KB editor;
  operators pick explicitly. (The current behavior shows nothing
  pre-selected, matching the existing optional-field UX.)
- No model registry / catalog feature; this PR is strictly the type-
  system plumbing and UI wiring.
