### PR TITLE
fix: adapt generic qwen tool call payload

### DIFF
--- a/internal/models/chat/chat_provider_spec.go
+++ b/internal/models/chat/chat_provider_spec.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -226,7 +227,77 @@ func genericRequestCustomizer(
 	req.ChatTemplateKwargs = map[string]interface{}{
 		"enable_thinking": thinking,
 	}
+	if isLocalQwenToolCallCompatModel(req.Model) {
+		return buildLocalQwenToolCallCompatRequest(req), true
+	}
 	return req, true
+}
+
+func isLocalQwenToolCallCompatModel(modelName string) bool {
+	name := strings.ToLower(strings.TrimSpace(modelName))
+	if name == "" {
+		return false
+	}
+	parts := strings.FieldsFunc(name, func(r rune) bool {
+		return r == '/' || r == ':' || r == '\\'
+	})
+	for _, part := range parts {
+		if strings.HasPrefix(part, "qwen3") {
+			return true
+		}
+	}
+	return false
+}
+
+func buildLocalQwenToolCallCompatRequest(req *openai.ChatCompletionRequest) any {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return req
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(data, &body); err != nil {
+		return req
+	}
+
+	messages, ok := body["messages"].([]any)
+	if !ok {
+		return body
+	}
+	for _, rawMsg := range messages {
+		msg, ok := rawMsg.(map[string]any)
+		if !ok || msg["role"] != "assistant" {
+			continue
+		}
+
+		toolCalls, ok := msg["tool_calls"].([]any)
+		if !ok || len(toolCalls) == 0 {
+			continue
+		}
+		if _, ok := msg["content"]; !ok || msg["content"] == nil {
+			msg["content"] = ""
+		}
+
+		for _, rawToolCall := range toolCalls {
+			toolCall, ok := rawToolCall.(map[string]any)
+			if !ok {
+				continue
+			}
+			function, ok := toolCall["function"].(map[string]any)
+			if !ok {
+				continue
+			}
+			args, ok := function["arguments"].(string)
+			if !ok || strings.TrimSpace(args) == "" {
+				continue
+			}
+			var argsObject map[string]any
+			if err := json.Unmarshal([]byte(args), &argsObject); err == nil {
+				function["arguments"] = argsObject
+			}
+		}
+	}
+	return body
 }
 
 // volcengineRequestCustomizer 自定义火山引擎请求

--- a/internal/models/chat/remote_api_test.go
+++ b/internal/models/chat/remote_api_test.go
@@ -3,11 +3,15 @@ package chat
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/Tencent/WeKnora/internal/types"
+	secutils "github.com/Tencent/WeKnora/internal/utils"
 	"github.com/sashabaranov/go-openai"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -268,6 +272,162 @@ func TestConvertMessages_ReasoningContentRoundTrip(t *testing.T) {
 		require.Len(t, out, 1)
 		assert.Empty(t, out[0].ReasoningContent)
 	})
+}
+
+func TestGenericRequestCustomizer_QwenLocalToolCallCompatibility(t *testing.T) {
+	req := openai.ChatCompletionRequest{
+		Model: "Qwen/Qwen3-VL-8B-Instruct",
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role: "assistant",
+				ToolCalls: []openai.ToolCall{
+					{
+						ID:   "call_1",
+						Type: openai.ToolTypeFunction,
+						Function: openai.FunctionCall{
+							Name:      "knowledge_search",
+							Arguments: `{"query":"hello","top_k":3}`,
+						},
+					},
+				},
+			},
+			{Role: "tool", Content: "result", ToolCallID: "call_1"},
+		},
+	}
+
+	customReq, useRawHTTP := genericRequestCustomizer(&req, nil, false)
+	require.True(t, useRawHTTP)
+
+	data, err := json.Marshal(customReq)
+	require.NoError(t, err)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(data, &body))
+	messages := body["messages"].([]any)
+	assistant := messages[0].(map[string]any)
+
+	assert.Equal(t, "", assistant["content"], "Qwen local templates expect assistant tool messages to have string content")
+
+	toolCalls := assistant["tool_calls"].([]any)
+	function := toolCalls[0].(map[string]any)["function"].(map[string]any)
+	args := function["arguments"]
+	argsMap, ok := args.(map[string]any)
+	require.True(t, ok, "Qwen local templates expect tool call arguments as an object")
+	assert.Equal(t, "hello", argsMap["query"])
+	assert.EqualValues(t, 3, argsMap["top_k"])
+}
+
+func TestGenericRequestCustomizer_NonQwenKeepsOpenAIArgumentsString(t *testing.T) {
+	req := openai.ChatCompletionRequest{
+		Model: "meta-llama/Llama-3.1-8B-Instruct",
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role: "assistant",
+				ToolCalls: []openai.ToolCall{
+					{
+						ID:   "call_1",
+						Type: openai.ToolTypeFunction,
+						Function: openai.FunctionCall{
+							Name:      "knowledge_search",
+							Arguments: `{"query":"hello"}`,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	customReq, useRawHTTP := genericRequestCustomizer(&req, nil, false)
+	require.True(t, useRawHTTP)
+
+	data, err := json.Marshal(customReq)
+	require.NoError(t, err)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(data, &body))
+	messages := body["messages"].([]any)
+	assistant := messages[0].(map[string]any)
+	toolCalls := assistant["tool_calls"].([]any)
+	function := toolCalls[0].(map[string]any)["function"].(map[string]any)
+
+	assert.Equal(t, `{"query":"hello"}`, function["arguments"])
+}
+
+func TestRemoteChat_GenericQwenSendsCompatPayload(t *testing.T) {
+	t.Setenv("SSRF_WHITELIST", "127.0.0.1,::1,localhost")
+	secutils.ResetSSRFWhitelistForTest()
+	t.Cleanup(secutils.ResetSSRFWhitelistForTest)
+
+	var captured map[string]any
+	var handlerErr error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			handlerErr = fmt.Errorf("unexpected request path: %s", r.URL.Path)
+			http.Error(w, handlerErr.Error(), http.StatusNotFound)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			handlerErr = err
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":1,
+			"model":"Qwen/Qwen3-VL-8B-Instruct",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`))
+		if err != nil {
+			handlerErr = err
+		}
+	}))
+	defer server.Close()
+
+	model, err := NewRemoteChat(&ChatConfig{
+		Source:    types.ModelSourceRemote,
+		BaseURL:   server.URL,
+		ModelName: "Qwen/Qwen3-VL-8B-Instruct",
+		APIKey:    "test-key",
+		ModelID:   "qwen3-vl",
+		Provider:  "generic",
+	})
+	require.NoError(t, err)
+
+	resp, err := model.Chat(context.Background(), []Message{
+		{
+			Role: "assistant",
+			ToolCalls: []ToolCall{
+				{
+					ID:   "call_1",
+					Type: "function",
+					Function: FunctionCall{
+						Name:      "knowledge_search",
+						Arguments: `{"query":"hello","top_k":3}`,
+					},
+				},
+			},
+		},
+		{Role: "tool", Content: "result", ToolCallID: "call_1", Name: "knowledge_search"},
+		{Role: "user", Content: "continue"},
+	}, nil)
+	require.NoError(t, handlerErr)
+	require.NoError(t, err)
+	require.Equal(t, "ok", resp.Content)
+
+	messages := captured["messages"].([]any)
+	assistant := messages[0].(map[string]any)
+	assert.Equal(t, "", assistant["content"])
+
+	toolCalls := assistant["tool_calls"].([]any)
+	function := toolCalls[0].(map[string]any)["function"].(map[string]any)
+	argsMap, ok := function["arguments"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "hello", argsMap["query"])
+	assert.EqualValues(t, 3, argsMap["top_k"])
 }
 
 // TestRemoteAPIChat 综合测试 Remote API Chat 的所有功能


### PR DESCRIPTION
## Summary
- add a Generic-provider Qwen compatibility pass for local OpenAI-compatible backends
- include empty string content on assistant tool-call messages for Qwen chat templates
- objectify JSON tool-call arguments only for Qwen3-family Generic models, while preserving standard OpenAI string arguments for non-Qwen models
- cover both the request customizer and the real NewRemoteChat -> Chat -> raw HTTP send path with a local test server

Fixes #1487

## Tests
- CGO_LDFLAGS='-lc++' go test ./internal/models/chat -run 'Test(GenericRequestCustomizer_(QwenLocalToolCallCompatibility|NonQwenKeepsOpenAIArgumentsString)|RemoteChat_GenericQwenSendsCompatPayload)' -count=1
- CGO_LDFLAGS='-lc++' go test ./internal/models/chat -count=1
- git diff --check

## Notes
- This has not been tested against a live Qwen/vLLM/Xinference endpoint; the added integration test verifies the exact HTTP payload WeKnora sends.
