### PR TITLE
fix(settings): correctly gate Enable Memory toggle when Neo4j is unavailable

### DIFF
--- a/frontend/src/api/system/index.ts
+++ b/frontend/src/api/system/index.ts
@@ -9,6 +9,10 @@ export interface SystemInfo {
   keyword_index_engine?: string
   vector_store_engine?: string
   graph_database_engine?: string
+  /** True only when the Neo4j driver is wired up (NEO4J_ENABLE=true and the
+   *  driver initialised). Use this to gate features that depend on the
+   *  graph database; do NOT compare graph_database_engine against a string. */
+  graph_database_enabled?: boolean
   minio_enabled?: boolean
   db_version?: string
   /** Human-readable error message when the startup migration failed.

--- a/frontend/src/views/settings/GeneralSettings.vue
+++ b/frontend/src/views/settings/GeneralSettings.vue
@@ -236,7 +236,7 @@ const currentMonoStack = computed(() => MONO_STACKS[localMonoFont.value] ?? MONO
 const systemInfo = ref<any>(null)
 
 const isNeo4jAvailable = computed(() => {
-  return systemInfo.value?.graph_database_engine && systemInfo.value.graph_database_engine !== '未启用'
+  return !!systemInfo.value?.graph_database_enabled
 })
 
 // 记忆功能状态：只读 computed（toggleMemory 现在是 async + 后端持久化，

--- a/internal/handler/system.go
+++ b/internal/handler/system.go
@@ -114,8 +114,12 @@ type GetSystemInfoResponse struct {
 	KeywordIndexEngine  string `json:"keyword_index_engine,omitempty"`
 	VectorStoreEngine   string `json:"vector_store_engine,omitempty"`
 	GraphDatabaseEngine string `json:"graph_database_engine,omitempty"`
-	MinioEnabled        bool   `json:"minio_enabled,omitempty"`
-	DBVersion           string `json:"db_version,omitempty"`
+	// GraphDatabaseEnabled mirrors graph_database_engine availability as an
+	// explicit boolean so the frontend's "memory feature requires Neo4j"
+	// gate doesn't rely on a translated string comparison.
+	GraphDatabaseEnabled bool   `json:"graph_database_enabled"`
+	MinioEnabled         bool   `json:"minio_enabled,omitempty"`
+	DBVersion            string `json:"db_version,omitempty"`
 	// DBMigrationError carries the human-readable error message recorded when
 	// the most recent startup migration attempt failed. Empty when migrations
 	// succeeded; non-empty values let the frontend surface a troubleshooting
@@ -173,17 +177,18 @@ func (h *SystemHandler) GetSystemInfo(c *gin.Context) {
 	}
 
 	response := GetSystemInfoResponse{
-		Version:             Version,
-		Edition:             Edition,
-		CommitID:            CommitID,
-		BuildTime:           BuildTime,
-		GoVersion:           GoVersion,
-		KeywordIndexEngine:  keywordIndexEngine,
-		VectorStoreEngine:   vectorStoreEngine,
-		GraphDatabaseEngine: graphDatabaseEngine,
-		MinioEnabled:        minioEnabled,
-		DBVersion:           dbVersion,
-		DBMigrationError:    dbMigrationErr,
+		Version:              Version,
+		Edition:              Edition,
+		CommitID:             CommitID,
+		BuildTime:            BuildTime,
+		GoVersion:            GoVersion,
+		KeywordIndexEngine:   keywordIndexEngine,
+		VectorStoreEngine:    vectorStoreEngine,
+		GraphDatabaseEngine:  graphDatabaseEngine,
+		GraphDatabaseEnabled: h.neo4jDriver != nil,
+		MinioEnabled:         minioEnabled,
+		DBVersion:            dbVersion,
+		DBMigrationError:     dbMigrationErr,
 	}
 
 	logger.Info(ctx, "System info retrieved successfully")


### PR DESCRIPTION
## What

The "Enable Memory" switch in General Settings is clickable on
deployments without Neo4j configured. Turning it on persists
`enable_memory=true` to the user preference, but every subsequent chat
silently fails to retrieve or store memory because the backend
`MemoryRepository.IsAvailable()` check short-circuits with an error
that is only logged on the server.

## Root cause

`isNeo4jAvailable` in `GeneralSettings.vue` compares
`systemInfo.graph_database_engine` against the literal string `'未启用'`
(Chinese). The backend's `system.go:getGraphDatabaseEngine()` returns
`"Not Enabled"` (English). The mismatch makes the computed property
always return `true`, so the toggle is never disabled and the warning
alert is never shown.

## Fix

Add an explicit `graph_database_enabled` boolean field to
`GetSystemInfoResponse`, set from `h.neo4jDriver != nil`. Frontend
reads the boolean instead of comparing translated strings.

Effect after fix:
- The memory toggle is correctly disabled when Neo4j is unavailable
- The existing "memory feature requires Neo4j" alert is now visible
- The `onMounted` self-heal in `GeneralSettings.vue:277` will turn off
  any previously-persisted `enable_memory=true` preferences from users
  who hit this bug

## Files changed

- `internal/handler/system.go` — new `GraphDatabaseEnabled` field
- `frontend/src/api/system/index.ts` — TS type update
- `frontend/src/views/settings/GeneralSettings.vue` — read the boolean

## Test plan

- [x] Without `NEO4J_ENABLE=true`: memory toggle is grayed out, alert is shown
- [x] With `NEO4J_ENABLE=true`: memory toggle remains functional
- [x] Users who previously enabled memory without Neo4j: preference is
      auto-reset on next page mount
