### PR TITLE
fix: keep same-knowledge overlap chunks

### DIFF
--- a/internal/application/service/chat_pipeline/search.go
+++ b/internal/application/service/chat_pipeline/search.go
@@ -193,8 +193,9 @@ func buildContentSignature(content string) string {
 }
 
 // removePartialOverlaps drops chunks whose content is largely contained within
-// a higher-scored chunk, even across different knowledge sources. This catches
-// cross-KB duplicates and near-duplicates that exact-signature dedup misses.
+// a higher-scored chunk from a different knowledge source. This catches cross-KB
+// duplicates and near-duplicates that exact-signature dedup misses without
+// dropping same-document table rows that share headers or repeated labels.
 //
 // Two thresholds are used:
 //   - Substring containment: if the normalized short text is a literal substring
@@ -237,6 +238,9 @@ func removePartialOverlaps(ctx context.Context, results []*types.SearchResult) [
 			}
 
 			a, b := entries[i], entries[j]
+			if a.result.KnowledgeID == b.result.KnowledgeID {
+				continue
+			}
 
 			shortIdx, longIdx := i, j
 			if len(a.norm) > len(b.norm) {

--- a/internal/application/service/chat_pipeline/search_dedup_test.go
+++ b/internal/application/service/chat_pipeline/search_dedup_test.go
@@ -1,0 +1,120 @@
+package chatpipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestRemovePartialOverlapsKeepsHighOverlapChunksFromSameKnowledge(t *testing.T) {
+	results := []*types.SearchResult{
+		{
+			ID:          "chunk-a",
+			KnowledgeID: "knowledge-1",
+			Content:     tableLikeContent("row-alpha station-one"),
+			Score:       0.91,
+		},
+		{
+			ID:          "chunk-b",
+			KnowledgeID: "knowledge-1",
+			Content:     tableLikeContent("row-beta station-two"),
+			Score:       0.83,
+		},
+	}
+
+	got := removePartialOverlaps(context.Background(), results)
+
+	if len(got) != 2 {
+		t.Fatalf("expected same-knowledge chunks to be preserved, got %d", len(got))
+	}
+}
+
+func TestRemovePartialOverlapsDropsHighOverlapChunksFromDifferentKnowledge(t *testing.T) {
+	results := []*types.SearchResult{
+		{
+			ID:          "chunk-a",
+			KnowledgeID: "knowledge-1",
+			Content:     tableLikeContent("row-alpha station-one"),
+			Score:       0.91,
+		},
+		{
+			ID:          "chunk-b",
+			KnowledgeID: "knowledge-2",
+			Content:     tableLikeContent("row-beta station-two"),
+			Score:       0.83,
+		},
+	}
+
+	got := removePartialOverlaps(context.Background(), results)
+
+	if len(got) != 1 {
+		t.Fatalf("expected cross-knowledge overlap to be deduplicated, got %d", len(got))
+	}
+	if got[0].ID != "chunk-a" {
+		t.Fatalf("expected higher-scored chunk to be retained, got %s", got[0].ID)
+	}
+}
+
+func TestRemoveDuplicateResultsStillDropsExactSameKnowledgeContent(t *testing.T) {
+	results := []*types.SearchResult{
+		{
+			ID:          "chunk-a",
+			KnowledgeID: "knowledge-1",
+			Content:     "same normalized content",
+			Score:       0.91,
+		},
+		{
+			ID:          "chunk-b",
+			KnowledgeID: "knowledge-1",
+			Content:     "same   normalized\ncontent",
+			Score:       0.83,
+		},
+	}
+
+	got := removeDuplicateResults(results)
+
+	if len(got) != 1 {
+		t.Fatalf("expected exact same-knowledge duplicate content to be removed, got %d", len(got))
+	}
+	if got[0].ID != "chunk-a" {
+		t.Fatalf("expected first duplicate content chunk to be retained, got %s", got[0].ID)
+	}
+}
+
+func TestMergeOverlappingChunksStillMergesSameKnowledgeContainedRanges(t *testing.T) {
+	plugin := &PluginMerge{}
+	results := []*types.SearchResult{
+		{
+			ID:          "chunk-a",
+			KnowledgeID: "knowledge-1",
+			ChunkType:   string(types.ChunkTypeText),
+			Content:     "abcdef",
+			StartAt:     0,
+			EndAt:       6,
+			Score:       0.91,
+		},
+		{
+			ID:          "chunk-b",
+			KnowledgeID: "knowledge-1",
+			ChunkType:   string(types.ChunkTypeText),
+			Content:     "cde",
+			StartAt:     2,
+			EndAt:       5,
+			Score:       0.83,
+		},
+	}
+
+	got := plugin.mergeOverlappingChunks(context.Background(), "knowledge-1", results)
+
+	if len(got) != 1 {
+		t.Fatalf("expected contained same-knowledge range to be merged, got %d", len(got))
+	}
+	if len(got[0].SubChunkID) != 1 || got[0].SubChunkID[0] != "chunk-b" {
+		t.Fatalf("expected contained chunk to be tracked as sub chunk, got %#v", got[0].SubChunkID)
+	}
+}
+
+func tableLikeContent(unique string) string {
+	return "process step failure mode cause effect severity occurrence detection control action owner station operation risk material inspection " + unique
+}


### PR DESCRIPTION
## Summary
- Keep partial-overlap deduplication from dropping high-overlap chunks that belong to the same knowledge item
- Preserve cross-knowledge near-duplicate pruning
- Add regression coverage for same-knowledge and cross-knowledge overlap cases

Fixes #1485.

## Testing
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service/chat_pipeline -run 'Test(RemovePartialOverlaps|RemoveDuplicateResultsStillDropsExactSameKnowledgeContent|MergeOverlappingChunksStillMergesSameKnowledgeContainedRanges)' -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service/chat_pipeline -count=1`
- `git diff --check FETCH_HEAD...HEAD`