### PR TITLE
fix: show agent id in editor

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -637,6 +637,8 @@ export default {
       webSearchConfig: 'Web Search',
       webSearchConfigDesc: 'Configure web search capabilities for the agent',
       configuration: 'Configuration',
+      agentId: 'Agent ID',
+      agentIdDesc: 'Use this ID to target the agent in API integrations',
       name: 'Name',
       namePlaceholder: 'Enter agent name',
       nameRequired: 'Agent name is required',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -1569,6 +1569,8 @@ export default {
       webSearchConfig: "웹 검색",
       webSearchConfigDesc: "에이전트의 네트워크 검색 기능 구성",
       configuration: "구성 항목",
+      agentId: "에이전트 ID",
+      agentIdDesc: "API 연동에서 이 ID로 에이전트를 지정할 수 있습니다",
       name: "이름",
       namePlaceholder: "에이전트 이름을 입력해주세요.",
       nameRequired: "에이전트 이름을 입력해주세요.",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -461,6 +461,8 @@ export default {
       webSearchConfig: 'Web Search',
       webSearchConfigDesc: 'Configure web search capabilities for the agent',
       configuration: 'Configuration',
+      agentId: 'Agent ID',
+      agentIdDesc: 'Use this ID to target the agent in API integrations',
       name: 'Name',
       namePlaceholder: 'Enter agent name',
       nameRequired: 'Agent name is required',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1562,6 +1562,8 @@ export default {
       webSearchConfig: "网络搜索",
       webSearchConfigDesc: "配置智能体的网络搜索能力",
       configuration: "配置项",
+      agentId: "智能体 ID",
+      agentIdDesc: "API 集成时可使用此 ID 指定智能体",
       name: "名称",
       namePlaceholder: "请输入智能体名称",
       nameRequired: "请输入智能体名称",

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -43,6 +43,26 @@
                       <span>{{ $t('agentEditor.builtinHint') }}</span>
                     </div>
 
+                    <!-- 智能体 ID（用于 API 集成） -->
+                    <div v-if="mode === 'edit' && props.agent?.id" class="setting-row">
+                      <div class="setting-info">
+                        <label>{{ $t('agent.editor.agentId') }}</label>
+                        <p class="desc">{{ $t('agent.editor.agentIdDesc') }}</p>
+                      </div>
+                      <div class="setting-control">
+                        <div class="agent-id-control">
+                          <t-input :value="props.agent.id" readonly class="agent-id-input" />
+                          <t-tooltip :content="$t('common.copy')" placement="top">
+                            <t-button variant="outline" theme="default" shape="square" @click="copyAgentId">
+                              <template #icon>
+                                <t-icon name="file-copy" />
+                              </template>
+                            </t-button>
+                          </t-tooltip>
+                        </div>
+                      </div>
+                    </div>
+
                     <!-- 运行模式（首先选择） -->
                     <div class="setting-row">
                       <div class="setting-info">
@@ -1341,6 +1361,30 @@ const emit = defineEmits<{
   (e: 'update:visible', visible: boolean): void;
   (e: 'success'): void;
 }>();
+
+const copyAgentId = async () => {
+  const id = props.agent?.id;
+  if (!id) return;
+
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(id);
+    } else {
+      const textarea = document.createElement('textarea');
+      textarea.value = id;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+    }
+    MessagePlugin.success(t('common.copied'));
+  } catch {
+    MessagePlugin.error(t('common.copyFailed'));
+  }
+};
 
 const currentSection = ref(props.initialSection || 'basic');
 const saving = ref(false);
@@ -3938,6 +3982,18 @@ const handleSave = async () => {
   .name-input {
     flex: 1;
   }
+}
+
+.agent-id-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.agent-id-input {
+  flex: 1;
+  min-width: 0;
 }
 
 .settings-footer {


### PR DESCRIPTION
## Summary

Expose the agent ID in the agent editor basic-info section and add a copy button, so API users can find the ID without checking backend logs.

Fixes #1322.

## Testing

- npm run build-only
- git diff --check

Note: npm run type-check is currently blocked by existing repository-wide TypeScript errors unrelated to this change.