### PR TITLE
fix:avoid forcing parallel tool calls by default

### DIFF
--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -24,16 +24,18 @@ type mockResponse struct {
 type mockChat struct {
 	mu        sync.Mutex
 	responses []mockResponse
+	opts      []*chat.ChatOptions
 	callCount int
 }
 
-func (m *mockChat) ChatStream(_ context.Context, _ []chat.Message, _ *chat.ChatOptions) (<-chan types.StreamResponse, error) {
+func (m *mockChat) ChatStream(_ context.Context, _ []chat.Message, opts *chat.ChatOptions) (<-chan types.StreamResponse, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.callCount >= len(m.responses) {
 		return nil, fmt.Errorf("unexpected ChatStream call #%d (only %d responses prepared)", m.callCount, len(m.responses))
 	}
 	resp := m.responses[m.callCount]
+	m.opts = append(m.opts, opts)
 	m.callCount++
 
 	ch := make(chan types.StreamResponse, len(resp.chunks))
@@ -60,6 +62,12 @@ type testEngineOption func(*types.AgentConfig)
 func withMaxIterations(n int) testEngineOption {
 	return func(cfg *types.AgentConfig) {
 		cfg.MaxIterations = n
+	}
+}
+
+func withParallelToolCalls(enabled bool) testEngineOption {
+	return func(cfg *types.AgentConfig) {
+		cfg.ParallelToolCalls = enabled
 	}
 }
 
@@ -217,6 +225,51 @@ func TestStreamThinkingToEventBus_PropagatesFinishReason(t *testing.T) {
 			assert.Equal(t, tt.wantReason, resp.FinishReason)
 		})
 	}
+}
+
+func TestStreamThinkingToEventBus_ParallelToolCallsFollowsConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  bool
+		want *bool
+	}{
+		{name: "default_false_omits_field", cfg: false, want: nil},
+		{name: "enabled_sends_true", cfg: true, want: boolPtr(true)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockChat{
+				responses: []mockResponse{
+					{chunks: []types.StreamResponse{
+						{Content: "test content", Done: true, FinishReason: "stop"},
+					}},
+				},
+			}
+
+			engine := newTestEngine(t, mock, withParallelToolCalls(tt.cfg))
+			_, err := engine.streamThinkingToEventBus(
+				context.Background(),
+				[]chat.Message{{Role: "user", Content: "test"}},
+				[]chat.Tool{},
+				0,
+				"sess-1",
+			)
+
+			require.NoError(t, err)
+			require.Len(t, mock.opts, 1)
+			if tt.want == nil {
+				assert.Nil(t, mock.opts[0].ParallelToolCalls)
+			} else {
+				require.NotNil(t, mock.opts[0].ParallelToolCalls)
+				assert.Equal(t, *tt.want, *mock.opts[0].ParallelToolCalls)
+			}
+		})
+	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }
 
 func TestStreamFinalAnswerToEventBus_EmitsDoneWhenProviderEndsWithEmptyChunk(t *testing.T) {

--- a/internal/agent/think.go
+++ b/internal/agent/think.go
@@ -120,12 +120,14 @@ func (e *AgentEngine) streamThinkingToEventBus(
 	logger.Debugf(ctx, "[Agent][Thinking] Iteration-%d: temp=%.2f, tools=%d, thinking=%v",
 		iteration+1, e.config.Temperature, len(tools), e.config.Thinking)
 
-	parallelToolCalls := true
 	opts := &chat.ChatOptions{
-		Temperature:       e.config.Temperature,
-		Tools:             tools,
-		Thinking:          e.config.Thinking,
-		ParallelToolCalls: &parallelToolCalls,
+		Temperature: e.config.Temperature,
+		Tools:       tools,
+		Thinking:    e.config.Thinking,
+	}
+	if e.config.ParallelToolCalls {
+		parallelToolCalls := true
+		opts.ParallelToolCalls = &parallelToolCalls
 	}
 
 	pendingToolCalls := make(map[string]bool)


### PR DESCRIPTION
## 背景

Agent 配置中已有 `ParallelToolCalls` 字段，用于控制是否允许并行工具调用：

```go
ParallelToolCalls bool `json:"parallel_tool_calls,omitempty"`

parallelToolCalls := true
opts := &chat.ChatOptions{
    Temperature:       e.config.Temperature,
    Tools:             tools,
    Thinking:          e.config.Thinking,
    ParallelToolCalls: &parallelToolCalls,
}

```
但当前 Agent 在调用 LLM 时，无论该配置是否开启，都会固定向模型请求中传递：

"parallel_tool_calls": true
这导致配置语义没有被真正使用。

## 问题
存在2点问题：

1. 配置失效。当 AgentConfig.ParallelToolCalls=false 时，请求 LLM 仍然携带 parallel_tool_calls=true，与配置含义不一致。

2. 行为不一致。工具执行层会根据 AgentConfig.ParallelToolCalls 判断是否并行执行工具，但 LLM 请求层始终允许模型一轮返回多个工具调用。举例，我在进行excel解析时候，需要串行执行函数data_schema、data_analysis  后者依赖前者结果。执行过程中并行调用出现了问题。


## 修改内容
调整 Agent 构造 LLM ChatOptions 的逻辑：

```
当 AgentConfig.ParallelToolCalls=false 时，不发送 parallel_tool_calls 字段
当 AgentConfig.ParallelToolCalls=true 时，才发送 parallel_tool_calls=true
```

## 影响范围
该修改不会禁用工具调用能力。

它只影响是否向 LLM 显式声明允许一轮返回多个工具调用：

修复前：
默认发送 parallel_tool_calls=true

修复后：
默认不发送 parallel_tool_calls
仅在配置开启时发送 parallel_tool_calls=true


## 测试
新增/更新测试覆盖：

```
ParallelToolCalls=false 时，LLM 请求中不设置 ParallelToolCalls
ParallelToolCalls=true 时，LLM 请求中设置 ParallelToolCalls=true
```

同时已完成本地测试，测试结果ok