### PR TITLE
fix: apply document process timeout to asynq tasks

### DIFF
--- a/internal/application/service/knowledge_clone_move.go
+++ b/internal/application/service/knowledge_clone_move.go
@@ -1008,7 +1008,8 @@ func (s *knowledgeService) moveKnowledgeReparse(
 			return fmt.Errorf("failed to marshal document process payload: %w", err)
 		}
 
-		task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue("default"), asynq.MaxRetry(3))
+		task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes,
+			documentProcessTaskOptions(s.config, asynq.MaxRetry(3))...)
 		info, err := s.task.Enqueue(task)
 		if err != nil {
 			return fmt.Errorf("failed to enqueue document process task: %w", err)

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -262,7 +262,11 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 		return knowledge, nil
 	}
 
-	task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue("default"), asynq.MaxRetry(3))
+	task := asynq.NewTask(
+		types.TypeDocumentProcess,
+		payloadBytes,
+		documentProcessTaskOptions(s.config, asynq.MaxRetry(3))...,
+	)
 	info, err := s.task.Enqueue(task)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to enqueue document process task: %v", err)
@@ -436,7 +440,11 @@ func (s *knowledgeService) CreateKnowledgeFromURL(ctx context.Context,
 		return knowledge, nil
 	}
 
-	task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue("default"), asynq.MaxRetry(3))
+	task := asynq.NewTask(
+		types.TypeDocumentProcess,
+		payloadBytes,
+		documentProcessTaskOptions(s.config, asynq.MaxRetry(3))...,
+	)
 	info, err := s.task.Enqueue(task)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to enqueue URL process task: %v", err)
@@ -659,7 +667,11 @@ func (s *knowledgeService) createKnowledgeFromFileURL(
 		return knowledge, nil
 	}
 
-	task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue("default"))
+	task := asynq.NewTask(
+		types.TypeDocumentProcess,
+		payloadBytes,
+		documentProcessTaskOptions(s.config)...,
+	)
 	info, err := s.task.Enqueue(task)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to enqueue file URL process task: %v", err)
@@ -879,7 +891,11 @@ func (s *knowledgeService) createKnowledgeFromPassageInternal(ctx context.Contex
 			return knowledge, nil
 		}
 
-		task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue("default"), asynq.MaxRetry(3))
+		task := asynq.NewTask(
+			types.TypeDocumentProcess,
+			payloadBytes,
+			documentProcessTaskOptions(s.config, asynq.MaxRetry(3))...,
+		)
 		info, err := s.task.Enqueue(task)
 		if err != nil {
 			logger.Errorf(ctx, "Failed to enqueue passage process task: %v", err)

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -1669,7 +1669,11 @@ func (s *knowledgeService) ReparseKnowledge(ctx context.Context, knowledgeID str
 			return existing, nil
 		}
 
-		task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue("default"), asynq.MaxRetry(3))
+		task := asynq.NewTask(
+			types.TypeDocumentProcess,
+			payloadBytes,
+			documentProcessTaskOptions(s.config, asynq.MaxRetry(3))...,
+		)
 		info, err := s.task.Enqueue(task)
 		if err != nil {
 			logger.Errorf(ctx, "Failed to enqueue reparse task: %v", err)
@@ -1723,7 +1727,11 @@ func (s *knowledgeService) ReparseKnowledge(ctx context.Context, knowledgeID str
 			return existing, nil
 		}
 
-		task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue("default"))
+		task := asynq.NewTask(
+			types.TypeDocumentProcess,
+			payloadBytes,
+			documentProcessTaskOptions(s.config)...,
+		)
 		info, err := s.task.Enqueue(task)
 		if err != nil {
 			logger.Errorf(ctx, "Failed to enqueue file URL reparse task: %v", err)
@@ -1770,7 +1778,11 @@ func (s *knowledgeService) ReparseKnowledge(ctx context.Context, knowledgeID str
 			return existing, nil
 		}
 
-		task := asynq.NewTask(types.TypeDocumentProcess, payloadBytes, asynq.Queue("default"), asynq.MaxRetry(3))
+		task := asynq.NewTask(
+			types.TypeDocumentProcess,
+			payloadBytes,
+			documentProcessTaskOptions(s.config, asynq.MaxRetry(3))...,
+		)
 		info, err := s.task.Enqueue(task)
 		if err != nil {
 			logger.Errorf(ctx, "Failed to enqueue URL reparse task: %v", err)

--- a/internal/application/service/knowledge_task_options.go
+++ b/internal/application/service/knowledge_task_options.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/hibiken/asynq"
+)
+
+func documentProcessTaskOptions(cfg *config.Config, extra ...asynq.Option) []asynq.Option {
+	timeout := 2 * time.Hour
+	if cfg != nil &&
+		cfg.KnowledgeBase != nil &&
+		cfg.KnowledgeBase.DocumentProcessTimeout > 0 {
+		timeout = cfg.KnowledgeBase.DocumentProcessTimeout
+	}
+
+	opts := []asynq.Option{
+		asynq.Queue("default"),
+		asynq.Timeout(timeout),
+	}
+	opts = append(opts, extra...)
+	return opts
+}


### PR DESCRIPTION
## Description
扩展了文档解析任务入队时的超时设置。

新增 `knowledge_task_options.go`，用于统一封装任务队列的参数配置。目前仅提供 `DocumentProcess` 相关 option，用于将 `knowledge_base.document_process_timeout` / `WEKNORA_DOCUMENT_PROCESS_TIMEOUT` 配置应用到 `document:process` Asynq 任务。后续如其他任务类型也需要独立的队列参数配置，可在此基础上继续扩展。

此前虽然已经增加了文档解析超时配置，但 `document:process` 任务入队时没有传入 `asynq.Timeout(...)`，实际仍使用 Asynq 默认的 30 分钟超时。因此大文件解析可能在配置为 `2h` 的情况下，仍于 30 分钟左右报 `context deadline exceeded`。

已修改的入队路径包括：
- 文件上传
- URL 导入
- file URL 导入
- 文本片段导入
- 重新解析
- 移动后重新解析

非文档解析任务，例如 manual processing 和 knowledge post-processing，保持原逻辑不变。

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #

## Testing
- [x] `make build-prod` 本地通过
- [x] 已确认所有 `types.TypeDocumentProcess` 入队点都使用配置化 timeout helper
- [x] 已确认 `TypeManualProcess` 和 `TypeKnowledgePostProcess` 入队逻辑保持不变
- [x] 线上环境验证：上传并解析约 10MB 的 Excel 文件成功，整体耗时约 1 小时 30 分钟，未再于 30 分钟左右触发 `context deadline exceeded`

## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above