### PR TITLE
fix: handle empty and async MinerU parse results

### DIFF
--- a/internal/infrastructure/docparser/mineru_converter.go
+++ b/internal/infrastructure/docparser/mineru_converter.go
@@ -86,16 +86,21 @@ func (c *MinerUReader) Read(ctx context.Context, req *types.ReadRequest) (*types
 
 // mineruFileParseResponse mirrors the relevant fields from the MinerU API response.
 type mineruFileParseResponse struct {
-	Results struct {
-		Document struct {
-			MDContent string            `json:"md_content"`
-			Images    map[string]string `json:"images"` // path -> "data:image/png;base64,..." or raw base64
-		} `json:"document"`
-		Files struct {
-			MDContent string            `json:"md_content"`
-			Images    map[string]string `json:"images"` // path -> "data:image/png;base64,..." or raw base64
-		} `json:"files"`
-	} `json:"results"`
+	TaskID    string                     `json:"task_id"`
+	Status    string                     `json:"status"`
+	StatusURL string                     `json:"status_url"`
+	ResultURL string                     `json:"result_url"`
+	Error     string                     `json:"error"`
+	Message   string                     `json:"message"`
+	Results   map[string]mineruParseFile `json:"results"`
+}
+
+type mineruParseFile struct {
+	MDContent string            `json:"md_content"`
+	Markdown  string            `json:"markdown"`
+	Content   string            `json:"content"`
+	Text      string            `json:"text"`
+	Images    map[string]string `json:"images"` // path -> "data:image/png;base64,..." or raw base64
 }
 
 func (c *MinerUReader) callFileParse(ctx context.Context, content []byte) (string, map[string]string, error) {
@@ -153,16 +158,34 @@ func (c *MinerUReader) callFileParse(ctx context.Context, content []byte) (strin
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return "", nil, fmt.Errorf("MinerU API status %d: %s", resp.StatusCode, string(respBody))
-	}
-
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", nil, fmt.Errorf("read response body: %w", err)
 	}
 
+	mdContent, imagesB64, result, hasResult, err := c.extractFileParseResponse(respBody)
+	if err != nil {
+		return "", nil, err
+	}
+	if resp.StatusCode == http.StatusOK {
+		if hasResult {
+			return mdContent, imagesB64, nil
+		}
+		if result.hasAsyncTask() && !result.isFailed() {
+			return c.pollTaskResult(ctx, result)
+		}
+		return "", nil, fmt.Errorf("MinerU response contained no markdown/images")
+	}
+	if result.hasAsyncTask() && !result.isFailed() {
+		return c.pollTaskResult(ctx, result)
+	}
+	if result.isFailed() {
+		return "", nil, fmt.Errorf("MinerU task failed: %s", firstNonEmpty(result.Error, result.Message))
+	}
+	return "", nil, fmt.Errorf("MinerU API status %d: %s", resp.StatusCode, string(respBody))
+}
+
+func (c *MinerUReader) extractFileParseResponse(respBody []byte) (string, map[string]string, mineruFileParseResponse, bool, error) {
 	// Dump raw response for debugging (truncate if too large)
 	rawStr := string(respBody)
 	if len(rawStr) > 4000 {
@@ -180,27 +203,110 @@ func (c *MinerUReader) callFileParse(ctx context.Context, content []byte) (strin
 	return c.extractFileParseResult(respBody)
 }
 
-func (c *MinerUReader) extractFileParseResult(respBody []byte) (string, map[string]string, error) {
+func (c *MinerUReader) extractFileParseResult(respBody []byte) (string, map[string]string, mineruFileParseResponse, bool, error) {
 	var result mineruFileParseResponse
 	if err := json.Unmarshal(respBody, &result); err != nil {
-		return "", nil, fmt.Errorf("decode response: %w", err)
+		return "", nil, result, false, fmt.Errorf("decode response: %w", err)
 	}
 
 	// MinerU response schema differs by version/deployment:
 	// - older/self-hosted variants: results.document.*
 	// - some variants:            results.files.*
-	// Prefer document when available, then fallback to files.
-	if result.Results.Document.MDContent != "" || len(result.Results.Document.Images) > 0 {
-		logger.Infof(context.Background(), "[MinerU] Using response path: results.document")
-		return result.Results.Document.MDContent, result.Results.Document.Images, nil
+	// - MinerU 3.x:               results.<uploaded-stem>.*
+	// Prefer known legacy keys, then scan dynamic keys for the first content.
+	for _, key := range []string{"document", "files"} {
+		if parsed, ok := result.Results[key]; ok {
+			if mdContent := firstNonEmpty(parsed.MDContent, parsed.Markdown, parsed.Content, parsed.Text); mdContent != "" || len(parsed.Images) > 0 {
+				logger.Infof(context.Background(), "[MinerU] Using response path: results.%s", key)
+				return mdContent, parsed.Images, result, true, nil
+			}
+		}
 	}
-	if result.Results.Files.MDContent != "" || len(result.Results.Files.Images) > 0 {
-		logger.Infof(context.Background(), "[MinerU] Using response path: results.files")
-		return result.Results.Files.MDContent, result.Results.Files.Images, nil
+	for key, parsed := range result.Results {
+		if mdContent := firstNonEmpty(parsed.MDContent, parsed.Markdown, parsed.Content, parsed.Text); mdContent != "" || len(parsed.Images) > 0 {
+			logger.Infof(context.Background(), "[MinerU] Using response path: results.%s", key)
+			return mdContent, parsed.Images, result, true, nil
+		}
 	}
 
-	logger.Errorf(context.Background(), "[MinerU] Response has no markdown/images under results.document or results.files")
-	return "", nil, fmt.Errorf("MinerU response has no markdown/images under results.document or results.files")
+	logger.Errorf(context.Background(), "[MinerU] Response has no markdown/images under results")
+	return "", nil, result, false, nil
+}
+
+func (r mineruFileParseResponse) hasAsyncTask() bool {
+	return r.TaskID != "" || r.ResultURL != "" || r.StatusURL != ""
+}
+
+func (r mineruFileParseResponse) isFailed() bool {
+	return strings.EqualFold(r.Status, "failed") || r.Error != ""
+}
+
+func (c *MinerUReader) pollTaskResult(ctx context.Context, task mineruFileParseResponse) (string, map[string]string, error) {
+	resultURL, err := c.taskResultURL(task)
+	if err != nil {
+		return "", nil, err
+	}
+
+	deadline := time.Now().Add(mineruTimeout)
+	client := &http.Client{Timeout: 30 * time.Second}
+	for time.Now().Before(deadline) {
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, resultURL, nil)
+		if err != nil {
+			return "", nil, fmt.Errorf("create task result request: %w", err)
+		}
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			return "", nil, fmt.Errorf("poll task result: %w", err)
+		}
+		respBody, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return "", nil, fmt.Errorf("read task result response: %w", readErr)
+		}
+
+		mdContent, imagesB64, result, hasResult, err := c.extractFileParseResponse(respBody)
+		if err != nil {
+			return "", nil, err
+		}
+		if resp.StatusCode == http.StatusOK && hasResult {
+			return mdContent, imagesB64, nil
+		}
+		if result.isFailed() || resp.StatusCode == http.StatusConflict {
+			return "", nil, fmt.Errorf("MinerU task failed: %s", firstNonEmpty(result.Error, result.Message))
+		}
+		if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
+			return "", nil, fmt.Errorf("MinerU task result status %d: %s", resp.StatusCode, string(respBody))
+		}
+		if err := ctx.Err(); err != nil {
+			return "", nil, err
+		}
+		sleepCtx(ctx, time.Second)
+	}
+
+	return "", nil, fmt.Errorf("MinerU task timed out")
+}
+
+func (c *MinerUReader) taskResultURL(task mineruFileParseResponse) (string, error) {
+	rawURL := task.ResultURL
+	if rawURL == "" && task.TaskID != "" {
+		rawURL = "/tasks/" + task.TaskID + "/result"
+	}
+	if rawURL == "" {
+		return "", fmt.Errorf("MinerU async task response missing result_url")
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse task result URL: %w", err)
+	}
+	if parsed.IsAbs() {
+		return parsed.String(), nil
+	}
+	base, err := url.Parse(c.endpoint + "/")
+	if err != nil {
+		return "", fmt.Errorf("parse MinerU endpoint: %w", err)
+	}
+	return base.ResolveReference(parsed).String(), nil
 }
 
 // processImages decodes base64 images from MinerU response and returns ImageRef list.

--- a/internal/infrastructure/docparser/mineru_converter.go
+++ b/internal/infrastructure/docparser/mineru_converter.go
@@ -177,6 +177,10 @@ func (c *MinerUReader) callFileParse(ctx context.Context, content []byte) (strin
 		c.logMinerUResponseStructure(rawMap, "")
 	}
 
+	return c.extractFileParseResult(respBody)
+}
+
+func (c *MinerUReader) extractFileParseResult(respBody []byte) (string, map[string]string, error) {
 	var result mineruFileParseResponse
 	if err := json.Unmarshal(respBody, &result); err != nil {
 		return "", nil, fmt.Errorf("decode response: %w", err)
@@ -196,7 +200,7 @@ func (c *MinerUReader) callFileParse(ctx context.Context, content []byte) (strin
 	}
 
 	logger.Errorf(context.Background(), "[MinerU] Response has no markdown/images under results.document or results.files")
-	return "", nil, nil
+	return "", nil, fmt.Errorf("MinerU response has no markdown/images under results.document or results.files")
 }
 
 // processImages decodes base64 images from MinerU response and returns ImageRef list.

--- a/internal/infrastructure/docparser/mineru_converter_test.go
+++ b/internal/infrastructure/docparser/mineru_converter_test.go
@@ -87,3 +87,21 @@ func TestProcessImagesMatchesPathsWithSpaces(t *testing.T) {
 		t.Fatalf("unexpected OriginalRef: %q", refs[0].OriginalRef)
 	}
 }
+
+func TestMinerUFileParseRejectsEmptyResult(t *testing.T) {
+	reader := &MinerUReader{}
+
+	mdContent, images, err := reader.extractFileParseResult([]byte(`{"results":{}}`))
+	if err == nil {
+		t.Fatalf("expected empty MinerU result to return an error")
+	}
+	if mdContent != "" {
+		t.Fatalf("expected no markdown content, got %q", mdContent)
+	}
+	if images != nil {
+		t.Fatalf("expected no images, got %v", images)
+	}
+	if !strings.Contains(err.Error(), "no markdown/images") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/infrastructure/docparser/mineru_converter_test.go
+++ b/internal/infrastructure/docparser/mineru_converter_test.go
@@ -1,7 +1,11 @@
 package docparser
 
 import (
+	"context"
 	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -88,20 +92,58 @@ func TestProcessImagesMatchesPathsWithSpaces(t *testing.T) {
 	}
 }
 
-func TestMinerUFileParseRejectsEmptyResult(t *testing.T) {
-	reader := &MinerUReader{}
+func TestCallFileParsePollsMinerUAsyncTaskResult(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/file_parse":
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Fatalf("parse multipart form: %v", err)
+			}
+			if got := r.FormValue("backend"); got != "hybrid-auto-engine" {
+				t.Fatalf("backend = %q, want hybrid-auto-engine", got)
+			}
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = fmt.Fprintf(w, `{"task_id":"task-1","status":"processing","result_url":"%s/tasks/task-1/result"}`, server.URL)
+		case "/tasks/task-1/result":
+			_, _ = w.Write([]byte(`{"task_id":"task-1","status":"completed","results":{"document":{"md_content":"# Parsed with hybrid","images":{}}}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
 
-	mdContent, images, err := reader.extractFileParseResult([]byte(`{"results":{}}`))
+	reader := &MinerUReader{endpoint: server.URL, backend: "hybrid-auto-engine"}
+
+	mdContent, images, err := reader.callFileParse(context.Background(), []byte("%PDF"))
+	if err != nil {
+		t.Fatalf("callFileParse returned error: %v", err)
+	}
+	if mdContent != "# Parsed with hybrid" {
+		t.Fatalf("mdContent = %q", mdContent)
+	}
+	if len(images) != 0 {
+		t.Fatalf("expected no images, got %d", len(images))
+	}
+}
+
+func TestCallFileParseFailsOnEmptyMinerUResult(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/file_parse" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"backend":"hybrid-auto-engine","results":{"document":{"md_content":"","images":{}}}}`))
+	}))
+	defer server.Close()
+
+	reader := &MinerUReader{endpoint: server.URL, backend: "hybrid-auto-engine"}
+
+	_, _, err := reader.callFileParse(context.Background(), []byte("%PDF"))
 	if err == nil {
-		t.Fatalf("expected empty MinerU result to return an error")
+		t.Fatal("expected empty MinerU result to return an error")
 	}
-	if mdContent != "" {
-		t.Fatalf("expected no markdown content, got %q", mdContent)
-	}
-	if images != nil {
-		t.Fatalf("expected no images, got %v", images)
-	}
-	if !strings.Contains(err.Error(), "no markdown/images") {
+	if !strings.Contains(err.Error(), "no markdown") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- poll self-hosted MinerU async task results when `/file_parse` returns task metadata
- support dynamic MinerU 3.x result keys such as `results.<uploaded-stem>` while preserving `results.document` / `results.files`
- return an explicit MinerU parse error when the final response contains neither markdown nor images

## Root Cause
MinerU 3.x hybrid parsing can route through an async task manager and return task metadata instead of an immediate synchronous parse result. WeKnora previously treated non-200 task responses as failures and could also accept an empty 200 response as a successful empty document.

Fixes #1402

## Tests

- `CGO_LDFLAGS='-lc++' go test ./internal/infrastructure/docparser -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service -run ^$ -count=1`
- `git diff --check`
