### PR TITLE
fix: preserve agent system prompt for greetings

### DIFF
--- a/internal/application/service/chat_pipeline/query_understand.go
+++ b/internal/application/service/chat_pipeline/query_understand.go
@@ -470,13 +470,17 @@ func mergeImageDescAndOCR(desc, ocr string) (string, bool) {
 
 // applyIntentPromptOverride resolves the system-prompt override for the current
 // non-retrieval intent. Agent-level overrides take precedence; otherwise the
-// tenant/global IntentSystemPrompts map is consulted. Whitespace-only agent
-// overrides are treated as unset and fall through to the global default. Returns
-// true when a non-empty override was applied.
+// tenant/global IntentSystemPrompts map is consulted. When a custom agent
+// system prompt is already applied, global intent prompts must not replace it.
+// Whitespace-only agent overrides are treated as unset. Returns true when a
+// non-empty override was applied.
 func applyIntentPromptOverride(chatManage *types.ChatManage, globalPrompts map[string]string) bool {
 	intentKey := string(chatManage.Intent)
 	if raw, ok := chatManage.IntentPromptOverrides[intentKey]; ok && strings.TrimSpace(raw) != "" {
 		chatManage.SystemPromptOverride = raw
+	}
+	if chatManage.AgentSystemPromptApplied {
+		return chatManage.SystemPromptOverride != ""
 	}
 	if chatManage.SystemPromptOverride == "" {
 		if prompt, ok := globalPrompts[intentKey]; ok {

--- a/internal/application/service/chat_pipeline/query_understand_test.go
+++ b/internal/application/service/chat_pipeline/query_understand_test.go
@@ -59,6 +59,23 @@ func TestApplyIntentPromptOverride_BlankAgentFallsBackToGlobal(t *testing.T) {
 	}
 }
 
+func TestApplyIntentPromptOverride_CustomAgentSystemPromptSkipsGlobalFallback(t *testing.T) {
+	cm := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{
+			AgentSystemPromptApplied: true,
+		},
+		PipelineState: types.PipelineState{Intent: types.IntentGreeting},
+	}
+	global := map[string]string{"greeting": "global prompt"}
+
+	if applyIntentPromptOverride(cm, global) {
+		t.Fatal("expected applied=false")
+	}
+	if cm.SystemPromptOverride != "" {
+		t.Errorf("override should remain empty, got %q", cm.SystemPromptOverride)
+	}
+}
+
 func TestApplyIntentPromptOverride_NoOverrideAndNoGlobal(t *testing.T) {
 	cm := &types.ChatManage{
 		PipelineState: types.PipelineState{Intent: types.IntentChitchat},

--- a/internal/application/service/session_qa_helpers.go
+++ b/internal/application/service/session_qa_helpers.go
@@ -117,6 +117,7 @@ func (s *sessionService) applyAgentOverridesToChatManage(
 	// Override summary config fields
 	if customAgent.Config.SystemPrompt != "" {
 		cm.SummaryConfig.Prompt = customAgent.Config.SystemPrompt
+		cm.AgentSystemPromptApplied = true
 		logger.Infof(ctx, "Using custom agent's system_prompt")
 	}
 	if customAgent.Config.ContextTemplate != "" {

--- a/internal/application/service/session_qa_helpers_test.go
+++ b/internal/application/service/session_qa_helpers_test.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestApplyAgentOverridesToChatManageMarksCustomSystemPrompt(t *testing.T) {
+	s := &sessionService{}
+	cm := &types.ChatManage{}
+	agent := &types.CustomAgent{
+		Config: types.CustomAgentConfig{SystemPrompt: "You are Xiaochi."},
+	}
+
+	s.applyAgentOverridesToChatManage(context.Background(), agent, cm)
+
+	if cm.SummaryConfig.Prompt != "You are Xiaochi." {
+		t.Errorf("prompt: got %q", cm.SummaryConfig.Prompt)
+	}
+	if !cm.AgentSystemPromptApplied {
+		t.Fatal("expected custom agent system prompt to be marked as applied")
+	}
+}

--- a/internal/types/chat_manage.go
+++ b/internal/types/chat_manage.go
@@ -62,6 +62,9 @@ type PipelineRequest struct {
 	// IntentPromptOverrides holds agent-level intent prompt overrides for the
 	// query-understanding stage. Empty values fall back to tenant/global defaults.
 	IntentPromptOverrides map[string]string `json:"-"`
+	// AgentSystemPromptApplied is true when SummaryConfig.Prompt was supplied
+	// by a custom agent. Global intent prompts must not replace that prompt.
+	AgentSystemPromptApplied bool `json:"-"`
 
 	// Misc request-scoped config
 	TenantID            uint64 `json:"-"`
@@ -226,6 +229,7 @@ func (c *ChatManage) Clone() *ChatManage {
 			WebFetchTopN:             c.WebFetchTopN,
 			Language:                 c.Language,
 			IntentPromptOverrides:    maps.Clone(c.IntentPromptOverrides),
+			AgentSystemPromptApplied: c.AgentSystemPromptApplied,
 		},
 		PipelineState: PipelineState{
 			RewriteQuery:         c.RewriteQuery,


### PR DESCRIPTION
## Summary
- keep custom agent system prompts active for non-retrieval intents such as greeting/chitchat
- still allow agent-specific intent prompts to override the base prompt
- add tests for the prompt override decision and the custom-agent override marker

## Root Cause
For quick-answer agents, query understanding can classify short messages like hi as a non-retrieval greeting. The pipeline then applied the tenant/global greeting prompt as SystemPromptOverride, which took precedence over the custom agent system_prompt and could make the assistant answer with the default WeKnora identity instead of the configured role.

Fixes #882

## Tests
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service/chat_pipeline -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service -run TestApplyAgentOverridesToChatManageMarksCustomSystemPrompt -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/types -count=1`
- `git diff --check`

Also ran `CGO_LDFLAGS='-lc++' go test ./internal/application/service/... -count=1`; unrelated OSS credential behavior failed in `internal/application/service/file` `TestOssEnsureBucket_CreateFails`, while `service`, `chat_pipeline`, `metric`, and `retriever` passed.
