### PR TITLE
fix: parse xlsx files with malformed styles

### DIFF
--- a/docreader/parser/excel_parser.py
+++ b/docreader/parser/excel_parser.py
@@ -6,8 +6,12 @@ structured Document objects with text content and chunks. It supports multiple
 sheets and handles various Excel formats using pandas.
 """
 import logging
+import posixpath
+import re
+import xml.etree.ElementTree as ET
 from io import BytesIO
 from typing import List
+import zipfile
 
 import pandas as pd
 
@@ -15,6 +19,12 @@ from docreader.models.document import Chunk, Document
 from docreader.parser.base_parser import BaseParser
 
 logger = logging.getLogger(__name__)
+
+MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+OFFICE_REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+XML_NS = {"m": MAIN_NS, "r": REL_NS}
+CELL_REF_RE = re.compile(r"([A-Z]+)")
 
 
 class ExcelParser(BaseParser):
@@ -56,13 +66,17 @@ class ExcelParser(BaseParser):
             - Each row is formatted as: "col1: val1,col2: val2,..."
             - Chunks maintain sequential ordering across all sheets
         """
-        chunks: List[Chunk] = []
-        text: List[str] = []
-        start, end = 0, 0
-
         # Load Excel file from bytes into pandas ExcelFile object
-        excel_file = pd.ExcelFile(BytesIO(content))
+        try:
+            excel_file = pd.ExcelFile(BytesIO(content))
+        except Exception as exc:
+            try:
+                return self._parse_xlsx_without_styles(content)
+            except Exception:
+                raise exc
         
+        rows: List[List[str]] = []
+
         # Process each sheet in the Excel file
         for excel_sheet_name in excel_file.sheet_names:
             # Parse the sheet into a DataFrame
@@ -81,20 +95,124 @@ class ExcelParser(BaseParser):
                 # Skip rows with no valid content
                 if not page_content:
                     continue
-                
-                # Format row as comma-separated key-value pairs
-                content_row = ",".join(page_content) + "\n"
-                end += len(content_row)
-                text.append(content_row)
-                
-                # Create a chunk for this row with position tracking
-                chunks.append(
-                    Chunk(content=content_row, seq=len(chunks), start=start, end=end)
-                )
-                start = end
+
+                rows.append(page_content)
 
         # Combine all text and return as Document
+        return self._build_document(rows)
+
+    def _parse_xlsx_without_styles(self, content: bytes) -> Document:
+        rows: List[List[str]] = []
+        with zipfile.ZipFile(BytesIO(content)) as zf:
+            shared_strings = self._load_shared_strings(zf)
+            for _, sheet_path in self._load_sheet_paths(zf):
+                sheet_rows = self._load_sheet_rows(zf, sheet_path, shared_strings)
+                if not sheet_rows:
+                    continue
+                headers = sheet_rows[0]
+                for values in sheet_rows[1:]:
+                    page_content = []
+                    for idx, value in enumerate(values):
+                        if not value:
+                            continue
+                        header = headers[idx] if idx < len(headers) and headers[idx] else f"Column{idx + 1}"
+                        page_content.append(f"{header}: {value}")
+                    if page_content:
+                        rows.append(page_content)
+        return self._build_document(rows)
+
+    @staticmethod
+    def _build_document(rows: List[List[str]]) -> Document:
+        chunks: List[Chunk] = []
+        text: List[str] = []
+        start, end = 0, 0
+        for page_content in rows:
+            content_row = ",".join(page_content) + "\n"
+            end += len(content_row)
+            text.append(content_row)
+            chunks.append(Chunk(content=content_row, seq=len(chunks), start=start, end=end))
+            start = end
         return Document(content="".join(text), chunks=chunks)
+
+    @staticmethod
+    def _load_shared_strings(zf: zipfile.ZipFile) -> List[str]:
+        try:
+            root = ET.fromstring(zf.read("xl/sharedStrings.xml"))
+        except KeyError:
+            return []
+        strings = []
+        for item in root.findall("m:si", XML_NS):
+            parts = [text.text or "" for text in item.findall(".//m:t", XML_NS)]
+            strings.append("".join(parts))
+        return strings
+
+    @staticmethod
+    def _load_sheet_paths(zf: zipfile.ZipFile) -> List[tuple[str, str]]:
+        workbook = ET.fromstring(zf.read("xl/workbook.xml"))
+        rels = ET.fromstring(zf.read("xl/_rels/workbook.xml.rels"))
+        targets = {}
+        for rel in rels.findall("r:Relationship", XML_NS):
+            rel_id = rel.get("Id")
+            target = rel.get("Target", "")
+            if target.startswith("/"):
+                sheet_path = target.lstrip("/")
+            else:
+                sheet_path = posixpath.normpath(posixpath.join("xl", target))
+            targets[rel_id] = sheet_path
+
+        sheets = []
+        for sheet in workbook.findall(".//m:sheet", XML_NS):
+            rel_id = sheet.get(f"{{{OFFICE_REL_NS}}}id")
+            sheet_path = targets.get(rel_id)
+            if sheet_path:
+                sheets.append((sheet.get("name", ""), sheet_path))
+        return sheets
+
+    @staticmethod
+    def _load_sheet_rows(zf: zipfile.ZipFile, sheet_path: str, shared_strings: List[str]) -> List[List[str]]:
+        root = ET.fromstring(zf.read(sheet_path))
+        rows = []
+        for row in root.findall(".//m:sheetData/m:row", XML_NS):
+            cells = {}
+            for cell in row.findall("m:c", XML_NS):
+                value = ExcelParser._cell_value(cell, shared_strings)
+                if value == "":
+                    continue
+                cells[ExcelParser._cell_column_index(cell)] = value
+            if cells:
+                rows.append([cells.get(idx, "") for idx in range(max(cells) + 1)])
+        return rows
+
+    @staticmethod
+    def _cell_column_index(cell: ET.Element) -> int:
+        ref = cell.get("r", "")
+        match = CELL_REF_RE.match(ref)
+        if not match:
+            return 0
+        index = 0
+        for char in match.group(1):
+            index = index * 26 + ord(char) - ord("A") + 1
+        return index - 1
+
+    @staticmethod
+    def _cell_value(cell: ET.Element, shared_strings: List[str]) -> str:
+        cell_type = cell.get("t")
+        if cell_type == "inlineStr":
+            return "".join(text.text or "" for text in cell.findall(".//m:t", XML_NS)).strip()
+
+        value_node = cell.find("m:v", XML_NS)
+        if value_node is None or value_node.text is None:
+            return ""
+
+        value = value_node.text.strip()
+        if cell_type == "s":
+            try:
+                return shared_strings[int(value)].strip()
+            except (ValueError, IndexError):
+                return ""
+        if cell_type == "b":
+            return "TRUE" if value == "1" else "FALSE"
+        return value
 
 
 if __name__ == "__main__":

--- a/docreader/tests/test_excel_parser.py
+++ b/docreader/tests/test_excel_parser.py
@@ -1,0 +1,77 @@
+import io
+import unittest
+import zipfile
+from unittest.mock import patch
+
+from docreader.parser.excel_parser import ExcelParser
+
+
+def build_minimal_xlsx() -> bytes:
+    files = {
+        "[Content_Types].xml": """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+</Types>""",
+        "_rels/.rels": """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>""",
+        "xl/workbook.xml": """<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>""",
+        "xl/_rels/workbook.xml.rels": """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>""",
+        "xl/sharedStrings.xml": """<?xml version="1.0" encoding="UTF-8"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <si><t>Name</t></si>
+  <si><t>Age</t></si>
+  <si><t>Alice</t></si>
+</sst>""",
+        "xl/worksheets/sheet1.xml": """<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1">
+      <c r="A1" t="s"><v>0</v></c>
+      <c r="B1" t="s"><v>1</v></c>
+    </row>
+    <row r="2">
+      <c r="A2" t="s"><v>2</v></c>
+      <c r="B2"><v>30</v></c>
+    </row>
+  </sheetData>
+</worksheet>""",
+    }
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in files.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+class ExcelParserTest(unittest.TestCase):
+    def test_xlsx_falls_back_to_raw_xml_when_openpyxl_rejects_styles(self):
+        parser = ExcelParser(file_name="bad-styles.xlsx")
+
+        with patch(
+            "docreader.parser.excel_parser.pd.ExcelFile",
+            side_effect=TypeError("expected <class 'openpyxl.styles.fills.Fill'>"),
+        ):
+            document = parser.parse_into_text(build_minimal_xlsx())
+
+        self.assertEqual(document.content, "Name: Alice,Age: 30\n")
+        self.assertEqual(len(document.chunks), 1)
+        self.assertEqual(document.chunks[0].content, "Name: Alice,Age: 30\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a raw `.xlsx` XML fallback when pandas/openpyxl rejects workbook styles
- preserve the existing row-to-chunk output format by treating the first row as headers
- add a regression test for the openpyxl `expected Fill` failure path

This addresses the Excel parsing failure reported in #612. The MCP timeout mentioned there appears separate.

## Testing
- `uv run --project docreader python -m unittest discover -s docreader/tests -p 'test_excel_parser.py'`
- `uv run --project docreader python -m unittest discover -s docreader/tests`
- `git diff --check`
