### PR TITLE
test: add document process task options tests

### DIFF
--- a/internal/application/service/knowledge_task_options.go
+++ b/internal/application/service/knowledge_task_options.go
@@ -1,23 +1,14 @@
 package service
 
 import (
-	"time"
-
 	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/hibiken/asynq"
 )
 
 func documentProcessTaskOptions(cfg *config.Config, extra ...asynq.Option) []asynq.Option {
-	timeout := 2 * time.Hour
-	if cfg != nil &&
-		cfg.KnowledgeBase != nil &&
-		cfg.KnowledgeBase.DocumentProcessTimeout > 0 {
-		timeout = cfg.KnowledgeBase.DocumentProcessTimeout
-	}
-
 	opts := []asynq.Option{
 		asynq.Queue("default"),
-		asynq.Timeout(timeout),
+		asynq.Timeout(config.DocumentProcessTimeout(cfg)),
 	}
 	opts = append(opts, extra...)
 	return opts

--- a/internal/application/service/knowledge_task_options_test.go
+++ b/internal/application/service/knowledge_task_options_test.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parseDocumentProcessOpts(t *testing.T, opts []asynq.Option) (queue string, timeout time.Duration, maxRetry *int) {
+	t.Helper()
+	for _, opt := range opts {
+		switch opt.Type() {
+		case asynq.QueueOpt:
+			queue, _ = opt.Value().(string)
+		case asynq.TimeoutOpt:
+			timeout, _ = opt.Value().(time.Duration)
+		case asynq.MaxRetryOpt:
+			n, _ := opt.Value().(int)
+			maxRetry = &n
+		default:
+			t.Fatalf("unexpected asynq option type %v", opt.Type())
+		}
+	}
+	return queue, timeout, maxRetry
+}
+
+func TestDocumentProcessTaskOptions_defaults(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{"nil config", nil},
+		{"nil knowledge base", &config.Config{}},
+		{"zero timeout", &config.Config{KnowledgeBase: &config.KnowledgeBaseConfig{}}},
+		{"negative timeout", &config.Config{
+			KnowledgeBase: &config.KnowledgeBaseConfig{DocumentProcessTimeout: -time.Minute},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			opts := documentProcessTaskOptions(tc.cfg)
+			queue, timeout, maxRetry := parseDocumentProcessOpts(t, opts)
+			assert.Equal(t, "default", queue)
+			assert.Equal(t, config.DefaultDocumentProcessTimeout, timeout)
+			assert.Nil(t, maxRetry)
+		})
+	}
+}
+
+func TestDocumentProcessTaskOptions_configuredTimeout(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		KnowledgeBase: &config.KnowledgeBaseConfig{
+			DocumentProcessTimeout: 90 * time.Minute,
+		},
+	}
+	opts := documentProcessTaskOptions(cfg)
+	queue, timeout, maxRetry := parseDocumentProcessOpts(t, opts)
+	assert.Equal(t, "default", queue)
+	assert.Equal(t, 90*time.Minute, timeout)
+	assert.Nil(t, maxRetry)
+}
+
+func TestDocumentProcessTaskOptions_extraMaxRetry(t *testing.T) {
+	t.Parallel()
+	opts := documentProcessTaskOptions(nil, asynq.MaxRetry(3))
+	queue, timeout, maxRetry := parseDocumentProcessOpts(t, opts)
+	assert.Equal(t, "default", queue)
+	assert.Equal(t, config.DefaultDocumentProcessTimeout, timeout)
+	require.NotNil(t, maxRetry)
+	assert.Equal(t, 3, *maxRetry)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -177,6 +177,19 @@ type KnowledgeBaseConfig struct {
 	DocReaderCallTimeout time.Duration `yaml:"docreader_call_timeout"   json:"docreader_call_timeout"`
 }
 
+// DefaultDocumentProcessTimeout is the ceiling for a single document:process
+// Asynq task when document_process_timeout is unset or non-positive.
+const DefaultDocumentProcessTimeout = 2 * time.Hour
+
+// DocumentProcessTimeout returns the effective document-process task timeout.
+// Partial configs (e.g. unit tests) receive the default when unset.
+func DocumentProcessTimeout(cfg *Config) time.Duration {
+	if cfg != nil && cfg.KnowledgeBase != nil && cfg.KnowledgeBase.DocumentProcessTimeout > 0 {
+		return cfg.KnowledgeBase.DocumentProcessTimeout
+	}
+	return DefaultDocumentProcessTimeout
+}
+
 // ImageProcessingConfig 图像处理配置
 type ImageProcessingConfig struct {
 	EnableMultimodal bool `yaml:"enable_multimodal" json:"enable_multimodal"`
@@ -715,7 +728,7 @@ func applyKnowledgeBaseEnvOverrides(cfg *Config) {
 		cfg.KnowledgeBase = &KnowledgeBaseConfig{}
 	}
 	if cfg.KnowledgeBase.DocumentProcessTimeout <= 0 {
-		cfg.KnowledgeBase.DocumentProcessTimeout = 2 * time.Hour
+		cfg.KnowledgeBase.DocumentProcessTimeout = DefaultDocumentProcessTimeout
 	}
 	if value := strings.TrimSpace(os.Getenv("WEKNORA_DOCUMENT_PROCESS_TIMEOUT")); value != "" {
 		if d, err := time.ParseDuration(value); err == nil {


### PR DESCRIPTION
## Summary

- Add unit tests for `documentProcessTaskOptions` covering default timeout, configured timeout, and `MaxRetry` passthrough.
- Centralize `DefaultDocumentProcessTimeout` and `DocumentProcessTimeout()` in the config package to remove duplicated `2h` fallback logic.

Follow-up to #1525 (`edfabf31`).

## Test plan

- [x] `go test ./internal/application/service/ -run TestDocumentProcessTaskOptions`
- [x] `go test ./internal/config/`