### PR TITLE
feat(models): add purpose tags as a soft recommendation for model role

### DIFF
--- a/frontend/src/api/model/index.ts
+++ b/frontend/src/api/model/index.ts
@@ -37,6 +37,10 @@ export interface ModelConfig {
   is_default?: boolean;
   is_builtin?: boolean;
   status?: string;
+  // Soft tag list of intended usage roles for the model. Common values:
+  // "qa" (user-facing chat) and "wiki-synthesis" (wiki page generation).
+  // Open-ended — new roles can be added without API changes.
+  purposes?: string[];
   // Per-field configured? metadata from the main response. Absent for
   // builtin models.
   credentials?: Record<ModelCredentialField, { configured: boolean }>;

--- a/frontend/src/components/ModelEditorDialog.vue
+++ b/frontend/src/components/ModelEditorDialog.vue
@@ -240,6 +240,16 @@
         </div>
       </div>
 
+      <!-- Chat: purpose tags (soft recommendations consumed by KB editor) -->
+      <div v-if="modelType === 'chat'" class="form-item">
+        <label class="form-label">{{ $t('model.editor.purposesLabel') }}</label>
+        <t-checkbox-group v-model="formData.purposes">
+          <t-checkbox value="qa">{{ $t('model.editor.purposes.qa') }}</t-checkbox>
+          <t-checkbox value="wiki-synthesis">{{ $t('model.editor.purposes.wikiSynthesis') }}</t-checkbox>
+        </t-checkbox-group>
+        <p class="form-desc">{{ $t('model.editor.purposesDesc') }}</p>
+      </div>
+
     </t-form>
   </SettingDrawer>
 </template>
@@ -283,6 +293,8 @@ interface ModelFormData {
   supportsVision?: boolean
   // 自定义 HTTP 请求头（类似 OpenAI Python SDK 的 extra_headers）
   customHeaders?: CustomHeaderItem[]
+  // 用途软标签，目前仅 chat 类型暴露给用户：qa / wiki-synthesis
+  purposes?: string[]
 }
 
 interface Props {
@@ -570,7 +582,8 @@ const formData = ref<ModelFormData>({
   interfaceType: 'ollama',
   isDefault: false,
   supportsVision: false,
-  customHeaders: []
+  customHeaders: [],
+  purposes: []
 })
 
 const rules = computed(() => ({
@@ -718,6 +731,9 @@ watch(() => props.visible, (val) => {
         apiKey: '',
         customHeaders: Array.isArray(props.modelData.customHeaders)
           ? props.modelData.customHeaders.map(h => ({ key: h.key, value: h.value }))
+          : [],
+        purposes: Array.isArray(props.modelData.purposes)
+          ? [...props.modelData.purposes]
           : []
       }
     } else if (lastOpenedModelId.value !== null || !formData.value.id) {
@@ -755,7 +771,8 @@ const resetForm = () => {
     interfaceType: undefined,
     isDefault: false,
     supportsVision: false,
-    customHeaders: []
+    customHeaders: [],
+    purposes: []
   }
   modelChecked.value = false
   modelAvailable.value = false

--- a/frontend/src/components/ModelSelector.vue
+++ b/frontend/src/components/ModelSelector.vue
@@ -11,7 +11,7 @@
     >
       <!-- 已有的模型选项 -->
       <t-option
-        v-for="model in models"
+        v-for="model in displayedModels"
         :key="model.id"
         :value="model.id"
         :label="modelDisplayName(model)"
@@ -20,6 +20,14 @@
           <t-icon name="check-circle-filled" class="model-icon" />
           <span class="model-name">{{ modelDisplayName(model) }}</span>
           <span v-if="model.display_name" class="model-raw-name">{{ model.name }}</span>
+          <t-tag
+            v-if="preferredPurpose && (model.purposes || []).includes(preferredPurpose)"
+            size="small"
+            theme="success"
+            variant="light-outline"
+          >
+            {{ recommendedTagText }}
+          </t-tag>
           <t-tag v-if="model.is_builtin" size="small" theme="primary">{{ $t('model.builtinTag') }}</t-tag>
           <t-tag v-if="model.is_default" size="small" theme="success">{{ $t('model.defaultTag') }}</t-tag>
         </div>
@@ -53,6 +61,9 @@ interface Props {
   placeholder?: string
   // 可选：外部传入的所有模型列表，如果提供则不调用API
   allModels?: ModelConfig[]
+  // 软推荐：当指定时，purposes 含该值的模型会被置顶并打上推荐标签。
+  // 不强制过滤——其他同类型模型仍可选择。例：'wiki-synthesis'。
+  preferredPurpose?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -88,6 +99,29 @@ watch(() => props.allModels, (newModels) => {
 const selectedModel = computed(() => {
   if (!props.selectedModelId) return null
   return models.value.find(m => m.id === props.selectedModelId)
+})
+
+// Sort models so the ones tagged with the caller's preferred purpose
+// appear at the top. Stable for everything else.
+const displayedModels = computed(() => {
+  if (!props.preferredPurpose) return models.value
+  const target = props.preferredPurpose
+  return [...models.value].sort((a, b) => {
+    const aHit = (a.purposes || []).includes(target) ? 1 : 0
+    const bHit = (b.purposes || []).includes(target) ? 1 : 0
+    return bHit - aHit
+  })
+})
+
+// Tag text for the "recommended for this purpose" badge.
+const recommendedTagText = computed(() => {
+  if (props.preferredPurpose === 'wiki-synthesis') {
+    return t('model.purposeTag.wikiSynthesis')
+  }
+  if (props.preferredPurpose === 'qa') {
+    return t('model.purposeTag.qa')
+  }
+  return t('model.purposeTag.generic')
 })
 
 // 加载模型列表（仅在未提供 allModels 时调用）

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1914,7 +1914,7 @@ export default {
       description: 'Configure Wiki auto-generation preferences',
       synthesisModelLabel: 'Wiki Synthesis Model',
       synthesisModelPlaceholder: 'Select the LLM model for Wiki generation',
-      synthesisModelTip: 'Falls back to the summary model if not set',
+      synthesisModelTip: 'Models tagged "Recommended for Wiki synthesis" are surfaced first. Falls back to the chat model when unset.',
       languageLabel: 'Wiki Language',
       maxPagesLabel: 'Max Pages Per Ingest',
       maxPagesTip: 'Maximum number of pages to create/update per ingest (0 = no limit)',
@@ -3009,6 +3009,12 @@ export default {
       remoteDimensionDetected: 'Detected vector dimension: {value}',
       supportsVisionLabel: 'Supports Vision / Multimodal',
       supportsVisionDesc: 'Whether the model accepts image and multimodal input',
+      purposesLabel: 'Purpose tags',
+      purposesDesc: 'Pick the roles this chat model is suitable for. The knowledge base editor will recommend tagged models first but does not enforce a hard restriction.',
+      purposes: {
+        qa: 'User Q&A',
+        wikiSynthesis: 'Wiki synthesis',
+      },
       dimensionHint: 'Model selected. Click "Detect Dimension" to fetch the vector dimension automatically.',
       loadModelListFailed: 'Failed to load model list',
       listRefreshed: 'List refreshed',
@@ -3136,6 +3142,11 @@ export default {
       },
     },
     builtinTag: 'Built-in',
+    purposeTag: {
+      qa: 'Recommended for Q&A',
+      wikiSynthesis: 'Recommended for Wiki synthesis',
+      generic: 'Recommended',
+    },
   },
   language: {
     zhCN: '简体中文',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -2249,6 +2249,12 @@ export default {
       remoteDimensionDetected: "감지된 벡터 차원: {value}",
       supportsVisionLabel: "비전/멀티모달 지원",
       supportsVisionDesc: "모델의 이미지 등 멀티모달 입력 지원 여부",
+      purposesLabel: "용도 태그",
+      purposesDesc: "이 대화 모델에 적합한 역할을 선택하세요. 지식 베이스 편집기는 태그된 모델을 우선 추천하지만 강제하지는 않습니다.",
+      purposes: {
+        qa: "사용자 Q&A",
+        wikiSynthesis: "Wiki 합성",
+      },
       dimensionHint:
         '모델이 선택되었습니다. "차원 감지" 버튼을 클릭하여 벡터 차원을 자동으로 가져옵니다',
       loadModelListFailed: "모델 목록 로드 실패",
@@ -2374,6 +2380,11 @@ export default {
       },
     },
     builtinTag: '내장',
+    purposeTag: {
+      qa: "Q&A 권장",
+      wikiSynthesis: "Wiki 합성 권장",
+      generic: "권장",
+    },
   },
   language: {
     zhCN: "简体中文",
@@ -2737,7 +2748,7 @@ export default {
       description: "Wiki 자동 생성 환경설정을 구성합니다",
       synthesisModelLabel: "합성 모델",
       synthesisModelPlaceholder: "Wiki 생성에 사용할 LLM 모델을 선택하세요",
-      synthesisModelTip: "설정하지 않으면 요약 모델로 대체됩니다",
+      synthesisModelTip: "\"Wiki 합성 권장\" 태그가 붙은 모델이 우선 표시됩니다. 설정하지 않으면 대화 모델로 대체됩니다.",
       languageLabel: "Wiki 언어",
       maxPagesLabel: "Ingest당 최대 페이지 수",
       maxPagesTip: "Ingest당 생성/업데이트할 최대 페이지 수 (0 = 제한 없음)",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -1968,6 +1968,12 @@ export default {
       remoteDimensionDetected: 'Обнаружена размерность: {value}',
       supportsVisionLabel: 'Поддержка визуального / мультимодального ввода',
       supportsVisionDesc: 'Поддерживает ли модель изображения и другой мультимодальный ввод',
+      purposesLabel: 'Теги назначения',
+      purposesDesc: 'Выберите роли, для которых подходит эта модель чата. Редактор базы знаний будет рекомендовать модели с тегами в первую очередь, но не запрещает остальные.',
+      purposes: {
+        qa: 'Пользовательские Q&A',
+        wikiSynthesis: 'Wiki-синтез',
+      },
       dimensionHint: 'Модель выбрана. Нажмите «Определить размерность», чтобы автоматически получить значение.',
       loadModelListFailed: 'Не удалось загрузить список моделей',
       listRefreshed: 'Список обновлён',
@@ -2089,7 +2095,12 @@ export default {
         },
       }
     },
-    builtinTag: 'Built-in'
+    builtinTag: 'Built-in',
+    purposeTag: {
+      qa: 'Рекомендуется для Q&A',
+      wikiSynthesis: 'Рекомендуется для Wiki-синтеза',
+      generic: 'Рекомендуется',
+    },
   },
   createChat: {
     title: 'Привет, я WeKnora — ваши знания всегда под рукой',
@@ -2249,7 +2260,7 @@ export default {
       description: 'Настройте автоматическую генерацию Wiki',
       synthesisModelLabel: 'Модель синтеза',
       synthesisModelPlaceholder: 'Выберите LLM модель для генерации Wiki',
-      synthesisModelTip: 'Если не указано, используется модель суммаризации',
+      synthesisModelTip: 'Модели с тегом «Рекомендуется для Wiki-синтеза» отображаются первыми. Если не задано, используется чат-модель.',
       languageLabel: 'Язык Wiki',
       maxPagesLabel: 'Макс. страниц за Ingest',
       maxPagesTip: 'Максимальное количество страниц для создания/обновления за одну операцию (0 = без ограничения)',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2228,6 +2228,12 @@ export default {
       remoteDimensionDetected: "检测到向量维度：{value}",
       supportsVisionLabel: "支持视觉/多模态",
       supportsVisionDesc: "模型是否支持图片等多模态输入",
+      purposesLabel: "用途标签",
+      purposesDesc: "为该对话模型勾选适用场景，知识库编辑器会优先推荐带相应标签的模型，但不强制限定。",
+      purposes: {
+        qa: "用户问答",
+        wikiSynthesis: "Wiki 合成",
+      },
       dimensionHint: '模型已选择，点击"检测维度"按钮自动获取向量维度',
       loadModelListFailed: "加载模型列表失败",
       listRefreshed: "列表已刷新",
@@ -2355,6 +2361,11 @@ export default {
       },
     },
     builtinTag: "内置",
+    purposeTag: {
+      qa: "推荐用于问答",
+      wikiSynthesis: "推荐用于 Wiki 合成",
+      generic: "推荐",
+    },
   },
   language: {
     zhCN: "简体中文",
@@ -2711,7 +2722,7 @@ export default {
       description: "配置 Wiki 知识库的自动生成偏好",
       synthesisModelLabel: "Wiki 合成模型",
       synthesisModelPlaceholder: "选择用于 Wiki 生成的 LLM 模型",
-      synthesisModelTip: "不设置时将回退使用摘要模型",
+      synthesisModelTip: "带 \"推荐用于 Wiki 合成\" 标签的模型会被置顶；未设置时会回退使用对话模型。",
       languageLabel: "Wiki 语言",
       maxPagesLabel: "单次最大页面数",
       maxPagesTip: "每次 Ingest 最多创建/更新的页面数（0 表示不限制）",

--- a/frontend/src/views/knowledge/settings/KBModelConfig.vue
+++ b/frontend/src/views/knowledge/settings/KBModelConfig.vue
@@ -60,10 +60,11 @@
         <div class="setting-control">
           <ModelSelector
             model-type="KnowledgeQA"
+            preferred-purpose="wiki-synthesis"
             :selected-model-id="config.wikiSynthesisModelId"
             :all-models="allModels"
             @update:selected-model-id="handleWikiModelChange"
-            @add-model="handleAddModel('knowledgeqa')"
+            @add-model="handleAddModel('chat')"
             :placeholder="$t('knowledgeEditor.wiki.synthesisModelPlaceholder')"
           />
         </div>

--- a/frontend/src/views/settings/ModelSettings.vue
+++ b/frontend/src/views/settings/ModelSettings.vue
@@ -176,6 +176,7 @@ function convertToLegacyFormat(model: ModelConfig) {
     customHeaders: model.parameters.custom_headers
       ? Object.entries(model.parameters.custom_headers).map(([key, value]) => ({ key, value: String(value) }))
       : [],
+    purposes: Array.isArray(model.purposes) ? [...model.purposes] : [],
     _modelType: backendTypeToModelType[model.type] || 'chat' as ModelType,
     // Preserve the credential metadata map so the editor dialog can render
     // the "Configured" state without an extra round-trip.
@@ -344,6 +345,12 @@ const handleModelSave = async (modelData: any) => {
       type: getModelType(currentModelType.value),
       source: modelData.source,
       description: '',
+      // Only chat models surface a purpose picker in the editor; for the
+      // other types we send [] (i.e. "clear any stale tags") rather than
+      // leaving it undefined, so the backend receives a deterministic value.
+      purposes: currentModelType.value === 'chat' && Array.isArray(modelData.purposes)
+        ? [...modelData.purposes]
+        : [],
       parameters: {
         base_url: modelData.baseUrl?.trim() || '',
         ...apiKeyFields,

--- a/internal/handler/dto/model.go
+++ b/internal/handler/dto/model.go
@@ -28,6 +28,9 @@ type ModelResponse struct {
 	Status      types.ModelStatus  `json:"status"`
 	CreatedAt   time.Time          `json:"created_at"`
 	UpdatedAt   time.Time          `json:"updated_at"`
+	// Purposes is the soft-tag list of intended usage roles for the model
+	// (e.g. "qa", "wiki-synthesis"). Omitted when empty.
+	Purposes types.ModelPurposes `json:"purposes,omitempty"`
 	// Per-field "configured?" map. Omitted for builtin models (no
 	// per-tenant credentials). See MCPServiceResponse.Credentials.
 	Credentials map[string]CredentialFieldMetadata `json:"credentials,omitempty"`
@@ -99,6 +102,7 @@ func NewModelResponse(m *types.Model) *ModelResponse {
 		Status:      m.Status,
 		CreatedAt:   m.CreatedAt,
 		UpdatedAt:   m.UpdatedAt,
+		Purposes:    m.Purposes,
 		Credentials: creds,
 	}
 }

--- a/internal/handler/model.go
+++ b/internal/handler/model.go
@@ -43,6 +43,7 @@ type CreateModelRequest struct {
 	Source      types.ModelSource     `json:"source"      binding:"required"`
 	Description string                `json:"description"`
 	Parameters  types.ModelParameters `json:"parameters"  binding:"required"`
+	Purposes    types.ModelPurposes   `json:"purposes,omitempty"`
 }
 
 // CreateModel godoc
@@ -95,6 +96,7 @@ func (h *ModelHandler) CreateModel(c *gin.Context) {
 		Source:      req.Source,
 		Description: secutils.SanitizeForLog(req.Description),
 		Parameters:  req.Parameters,
+		Purposes:    req.Purposes,
 	}
 
 	if err := h.service.CreateModel(ctx, model); err != nil {
@@ -208,6 +210,10 @@ type UpdateModelRequest struct {
 	Parameters  types.ModelParameters `json:"parameters"`
 	Source      types.ModelSource     `json:"source"`
 	Type        types.ModelType       `json:"type"`
+	// Purposes is treated as a full replacement of the model's purpose
+	// tags. Send `[]` to clear all purposes; omit the field to leave
+	// existing tags untouched (handled by handler-side check).
+	Purposes *types.ModelPurposes `json:"purposes,omitempty"`
 }
 
 // UpdateModel godoc
@@ -299,6 +305,9 @@ func (h *ModelHandler) UpdateModel(c *gin.Context) {
 
 	model.Source = req.Source
 	model.Type = req.Type
+	if req.Purposes != nil {
+		model.Purposes = *req.Purposes
+	}
 
 	logger.Infof(ctx, "Updating model, ID: %s, Name: %s", id, model.Name)
 	if err := h.service.UpdateModel(ctx, model); err != nil {

--- a/internal/types/model.go
+++ b/internal/types/model.go
@@ -22,6 +22,43 @@ const (
 	ModelTypeASR         ModelType = "ASR"         // ASR (Automatic Speech Recognition) model
 )
 
+// ModelPurposes is a soft-tag list describing intended usage roles for a
+// model (e.g. "qa", "wiki-synthesis"). Intentionally open-ended — new
+// roles can be added without schema or enum changes. Empty/nil means the
+// model carries no usage hint and falls back to type-based selection.
+type ModelPurposes []string
+
+const (
+	ModelPurposeQA            = "qa"             // user-facing chat / Q&A
+	ModelPurposeWikiSynthesis = "wiki-synthesis" // wiki page generation
+)
+
+// Value implements driver.Valuer so ModelPurposes persists as a JSON column.
+func (p ModelPurposes) Value() (driver.Value, error) {
+	if len(p) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(p)
+}
+
+// Scan implements sql.Scanner so a NULL or empty column decodes to a nil
+// slice instead of an error. Tolerates rows that predate the column.
+func (p *ModelPurposes) Scan(value interface{}) error {
+	if value == nil {
+		*p = nil
+		return nil
+	}
+	b, ok := value.([]byte)
+	if !ok {
+		return nil
+	}
+	if len(b) == 0 {
+		*p = nil
+		return nil
+	}
+	return json.Unmarshal(b, p)
+}
+
 // ModelStatus represents the status of the model
 type ModelStatus string
 
@@ -141,6 +178,10 @@ type Model struct {
 	UpdatedAt time.Time `yaml:"updated_at"  json:"updated_at"`
 	// Deletion time of the model
 	DeletedAt gorm.DeletedAt `yaml:"deleted_at"  json:"deleted_at"  gorm:"index"`
+	// Purposes is a soft tag list of intended usage roles for the model
+	// (e.g. "qa", "wiki-synthesis"). Used by selectors to recommend a model
+	// for a specific role without enforcing a hard constraint.
+	Purposes ModelPurposes `yaml:"purposes,omitempty" json:"purposes,omitempty" gorm:"type:json"`
 }
 
 // Value implements the driver.Valuer interface, used to convert ModelParameters to database value.

--- a/migrations/versioned/000057_models_purposes.down.sql
+++ b/migrations/versioned/000057_models_purposes.down.sql
@@ -1,0 +1,7 @@
+-- Rollback for 000057_models_purposes.
+DO $$ BEGIN RAISE NOTICE '[Migration 000057] Dropping models.purposes'; END $$;
+
+ALTER TABLE models
+    DROP COLUMN IF EXISTS purposes;
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000057] models.purposes dropped'; END $$;

--- a/migrations/versioned/000057_models_purposes.up.sql
+++ b/migrations/versioned/000057_models_purposes.up.sql
@@ -1,0 +1,24 @@
+-- Migration: 000057_models_purposes
+-- Add a soft-tag list of intended usage roles to the models table.
+--
+-- Background:
+--   * The `type` column already disambiguates the API contract a model
+--     speaks (Embedding / Rerank / KnowledgeQA / VLLM / ASR), but it
+--     can't express the role a model is *recommended for* within a
+--     given contract — e.g. two KnowledgeQA-typed chat models, one
+--     tuned for user-facing Q&A and one optimized for wiki page
+--     generation, both speak the same chat-completion API.
+--   * Operators currently have to encode the intended role in the
+--     model name, which selectors can't reliably parse.
+--
+-- The `purposes` column stores a JSONB array of free-form string tags
+-- (e.g. ["qa"], ["wiki-synthesis"], ["qa", "wiki-synthesis"]). It is
+-- intentionally open-ended so new roles can be added without enum or
+-- schema changes — selectors interpret an empty/NULL value as "no
+-- preference" and fall back to type-based selection.
+DO $$ BEGIN RAISE NOTICE '[Migration 000057] Adding models.purposes'; END $$;
+
+ALTER TABLE models
+    ADD COLUMN IF NOT EXISTS purposes JSONB;
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000057] models.purposes added'; END $$;


### PR DESCRIPTION
## Summary

Adds a soft-tag mechanism for declaring what role a model is *recommended for*, complementing the existing `ModelType` axis. This is the tag-based redesign of #1509, pivoted per @lyingbug's feedback on that PR: rather than introducing a new `ModelType` enum value (hard constraint), a model now carries an open-ended `purposes []string` that selectors interpret as a sort/highlight hint while still allowing untagged models in the same dropdown (soft constraint, better extensibility).

## Background

Operators today cannot distinguish "chat models that are good for user-facing Q&A" from "chat models that are good for wiki page generation" — both speak the same `KnowledgeQA` chat-completion API contract. The practical pain we hit in production:

1. Users can't tell the two kinds of chat models apart, so they default to whichever model is configured as the system LLM.
2. When the system LLM happens to be a high-end reasoning model, wiki ingestion (long-context Map-Reduce) becomes extremely slow and burns disproportionate token budget.

`ModelType` already encodes the *API contract* a model speaks (`Embedding` / `Rerank` / `KnowledgeQA` / `VLLM` / `ASR`). What was missing was a way to declare the *intended role within a contract*. `purposes` fills exactly that gap, and is intentionally open-ended (string slice rather than enum) so future roles — summary, entity extraction, agent reasoning, image captioning, … — can land without schema or enum churn.

## What's in this PR

Three commits:

1. **`feat(types): add Purposes soft-tag field on Model`**
    - `ModelPurposes []string` with `Scan`/`Value` JSON column impl
    - `Model.Purposes` GORM field
    - `CreateModelRequest.Purposes` and `UpdateModelRequest.Purposes` (the update field is a pointer so omitting it leaves stored tags untouched, sending `[]` clears them, sending `[...]` replaces)
    - `ModelResponse.Purposes` with `omitempty` so untagged models keep the field absent in API responses
    - Migration `000057_models_purposes` — nullable JSONB column, `IF NOT EXISTS` guarded, idempotent and reversible
    - Matching TS type alignment in `frontend/src/api/model/index.ts`

2. **`feat(model-settings): expose Purposes multi-select for chat models`**
    - In the model editor dialog, `KnowledgeQA`-typed (chat) models get a new "Purposes" multi-select with initial options `qa` and `wiki-synthesis`
    - The picker is **hidden** for `Embedding` / `Rerank` / `VLLM` / `ASR` since those are already differentiated by API contract
    - `ModelSettings` forwards the selected purposes through `createModel` / `updateModel` and back-fills on edit
    - For non-chat types, sends `[]` explicitly so a type-switch deterministically clears stale tags
    - i18n keys added across all four locales (zh-CN, en-US, ko-KR, ru-RU); `synthesisModelTip` wording also updated to describe the new behavior

3. **`feat(kb-editor): soft-prefer purposes-tagged models in the wiki synthesis selector`**
    - `ModelSelector` gains an optional `preferredPurpose` prop
    - When set, models whose `purposes` contain that value sort to the top and render a green outlined "Recommended for ..." tag
    - Untagged models of the same type stay in the dropdown and remain selectable — soft preference, **not** a hard filter
    - `KBModelConfig` wires `preferred-purpose="wiki-synthesis"` on the wiki synthesis dropdown
    - No backend or fallback behavior changes: KBs without a synthesis model continue to fall back to the chat model at ingest time

## Backwards compatibility

- **Existing models** have `purposes = NULL`; the column is nullable and `omitempty` in responses, so untagged models behave exactly as before (no usage hint, selectors fall back to type-based ordering).
- **Existing KBs** that reference a `KnowledgeQA` model for wiki synthesis keep working — lookup is by model ID and ignores tags.
- **No new `ModelType`**, no provider-file changes, no API breaking changes. The DTO addition is additive.
- **Migration is one column add**, guarded with `IF NOT EXISTS`, cleanly rollback-able.

## Visual

A chat model registered with both purposes ticked:

`Model editor → Chat → Purposes ☑ User Q&A  ☑ Wiki synthesis`

When opening the KB editor → Wiki synthesis dropdown:

```
✓ Qwen3-27B-wiki         [Recommended for Wiki synthesis]   ← sorted top
✓ kimi-k2          [Built-in] [Default]
+ Add a model in Settings
```

The tagged model floats to the top with a green outlined badge; the untagged `kimi-k2` is still selectable in the same dropdown.

## Test plan

- [x] `go build ./internal/... ./cmd/...` — passes
- [x] `npx vue-tsc --noEmit` — passes
- [x] `go test ./internal/handler/... ./internal/handler/dto/...` — passes
- [x] Manual: register a chat model with `purposes=["wiki-synthesis"]` via the UI → persists, reopen editor reflects the checked boxes
- [x] Manual: KB editor wiki synthesis dropdown places the tagged model on top with the "Recommended for Wiki synthesis" tag; untagged chat models remain selectable
- [x] Manual: editor for `Embedding` / `Rerank` / `VLLM` / `ASR` does **not** show the Purposes picker
- [x] DB roundtrip: `purposes` written via `UpdateModel` is retrievable via `GET /api/v1/models`

## Non-goals / out of scope

- No automatic "default to first wiki-synthesis-tagged model" in the KB editor — operators still pick explicitly, matching the existing optional-field UX.
- No backend-side filtering on `purposes` at ingest time — purposes are advisory metadata for selectors, not a runtime gate.
- The wiki ingest fallback to the chat model (when `wiki_config.synthesis_model_id` is unset) is intentionally preserved.

## Relationship to #1509

This PR supersedes the approach in #1509. Closing #1509 in favor of this one once review here lands. Discussion thread on [#1509](https://github.com/Tencent/WeKnora/pull/1509) has the original context.
