### PR TITLE
fix: guide data analyst to exact knowledge ids

### DIFF
--- a/config/prompt_templates/agent_system_prompt.yaml
+++ b/config/prompt_templates/agent_system_prompt.yaml
@@ -191,11 +191,12 @@ templates:
       1. **Schema First:** ALWAYS call data_schema before writing any SQL query to understand the table structure.
       2. **Read-Only:** Only SELECT queries allowed. INSERT, UPDATE, DELETE, CREATE, DROP are forbidden.
       3. **Iterative Refinement:** If a query fails, analyze the error and refine your approach.
+      4. **Exact Knowledge ID:** Use the exact `knowledge_id` shown in `<runtime_context>` under `<recent_documents>` or `<pinned_documents>`. Do NOT invent table aliases or semantic names such as `customer_data` for tool arguments.
 
       ### Workflow
-      1. **Understand:** Call data_schema to get table name, columns, types, and row count.
+      1. **Understand:** Pick the relevant document from `<runtime_context>` and call data_schema with its exact `knowledge_id` to get table name, columns, types, and row count.
       2. **Plan:** For complex questions, break the analysis into sub-queries. Plan internally by default; if `thinking` is in your tool list, you MAY reason out loud there, and if `todo_write` is available you MAY also track tasks with it.
-      3. **Query:** Call data_analysis with the knowledge_id and SQL query.
+      3. **Query:** Call data_analysis with the same exact `knowledge_id` and SQL query.
       4. **Analyze:** Interpret results and provide insights.
 
       ### SQL Best Practices for DuckDB

--- a/internal/agent/data_analyst_prompt_test.go
+++ b/internal/agent/data_analyst_prompt_test.go
@@ -1,0 +1,26 @@
+package agent
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDataAnalystPromptRequiresExactKnowledgeID(t *testing.T) {
+	content, err := os.ReadFile("../../config/prompt_templates/agent_system_prompt.yaml")
+	if err != nil {
+		t.Fatalf("read agent system prompt templates: %v", err)
+	}
+
+	prompt := string(content)
+	for _, want := range []string{
+		"Use the exact `knowledge_id`",
+		"`<runtime_context>`",
+		"Do NOT invent table aliases",
+		"`customer_data`",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("data analyst prompt should mention %q", want)
+		}
+	}
+}

--- a/internal/agent/tools/data_analysis.go
+++ b/internal/agent/tools/data_analysis.go
@@ -103,7 +103,7 @@ func buildMissingColumnSuggestion(sqlErr error, schema *TableSchema) string {
 }
 
 type DataAnalysisInput struct {
-	KnowledgeID string `json:"knowledge_id" jsonschema:"id of the knowledge to query"`
+	KnowledgeID string `json:"knowledge_id" jsonschema:"exact knowledge_id from runtime_context recent_documents or pinned_documents; do not use invented aliases"`
 	Sql         string `json:"sql" jsonschema:"SQL to be executed on knowledge"`
 }
 
@@ -122,7 +122,7 @@ type DataAnalysisTool struct {
 	// env var at request time can produce a different (or empty) value if the
 	// variable was not exported to the sub-process or was set programmatically
 	// after startup, causing GetFile to look in the wrong directory (#1040).
-	localBaseDir         string
+	localBaseDir string
 }
 
 func NewDataAnalysisTool(
@@ -145,7 +145,7 @@ func NewDataAnalysisTool(
 		// call to resolveFileServiceForKnowledge uses the same base path.  The
 		// env var is guaranteed to be set (or empty == "/data/files" fallback)
 		// when the application starts and the DI container is assembled.
-		localBaseDir:         strings.TrimSpace(os.Getenv("LOCAL_STORAGE_BASE_DIR")),
+		localBaseDir: strings.TrimSpace(os.Getenv("LOCAL_STORAGE_BASE_DIR")),
 	}
 }
 

--- a/internal/agent/tools/data_schema.go
+++ b/internal/agent/tools/data_schema.go
@@ -17,7 +17,7 @@ var dataSchemaTool = BaseTool{
 }
 
 type DataSchemaInput struct {
-	KnowledgeID string `json:"knowledge_id" jsonschema:"id of the knowledge to query"`
+	KnowledgeID string `json:"knowledge_id" jsonschema:"exact knowledge_id from runtime_context recent_documents or pinned_documents; do not use invented aliases"`
 }
 
 type DataSchemaTool struct {

--- a/internal/agent/tools/data_schema_test.go
+++ b/internal/agent/tools/data_schema_test.go
@@ -1,0 +1,40 @@
+package tools
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestDataSchemaKnowledgeIDDescriptionPointsToRuntimeContext(t *testing.T) {
+	assertKnowledgeIDDescriptionPointsToRuntimeContext(t, dataSchemaTool.Parameters())
+}
+
+func TestDataAnalysisKnowledgeIDDescriptionPointsToRuntimeContext(t *testing.T) {
+	assertKnowledgeIDDescriptionPointsToRuntimeContext(t, dataAnalysisTool.Parameters())
+}
+
+func assertKnowledgeIDDescriptionPointsToRuntimeContext(t *testing.T, parameters []byte) {
+	t.Helper()
+
+	var schema map[string]any
+	if err := json.Unmarshal(parameters, &schema); err != nil {
+		t.Fatalf("unmarshal tool parameters: %v", err)
+	}
+
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool parameters missing properties")
+	}
+	knowledgeID, ok := properties["knowledge_id"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool parameters missing knowledge_id")
+	}
+	description, _ := knowledgeID["description"].(string)
+
+	for _, want := range []string{"exact", "runtime_context", "recent_documents", "pinned_documents"} {
+		if !strings.Contains(description, want) {
+			t.Fatalf("knowledge_id description should mention %q, got %q", want, description)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Clarify the built-in data analyst prompt so it uses the exact document `knowledge_id` from runtime context instead of inventing aliases like `customer_data`.
- Tighten the `knowledge_id` schema descriptions for `data_schema` and `data_analysis` so tool calling models see the same constraint.
- Add tests that lock the prompt and tool parameter contract.

## Root Cause
The data analyst tools require the real Knowledge ID, but the prompt and generated JSON schema only described the argument generically. This allowed models to pass semantic table names such as `customer_data`, which then failed with `knowledge not found`.

Fixes #591

## Tests
- `CGO_LDFLAGS='-lc++' go test ./internal/agent -run TestDataAnalystPromptRequiresExactKnowledgeID -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/agent/tools -run 'TestData(Schema|Analysis)KnowledgeIDDescriptionPointsToRuntimeContext' -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/agent -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/agent/tools -count=1`
- `git diff --check`
