### PR TITLE
fix: support lkeap rerank provider

### DIFF
--- a/internal/handler/initialization.go
+++ b/internal/handler/initialization.go
@@ -1532,13 +1532,14 @@ type ModelTestRequest struct {
 	ModelName     string            `json:"modelName" binding:"required"`
 	BaseURL       string            `json:"baseUrl"`
 	APIKey        string            `json:"apiKey"`
+	AppSecret     string            `json:"appSecret,omitempty"`
 	Provider      string            `json:"provider"`
 	InterfaceType string            `json:"interfaceType,omitempty"`
 	Dimension     int               `json:"dimension,omitempty"`
 	CustomHeaders map[string]string `json:"customHeaders,omitempty"`
 	ExtraConfig   map[string]string `json:"extraConfig,omitempty"`
 	// ModelID, when set, instructs the handler to substitute any missing
-	// secrets (APIKey, AppSecret via ExtraConfig) from the stored model
+	// secrets (APIKey, AppSecret) from the stored model
 	// record before assembling the test client. This lets the "Test
 	// connection" button work on existing models without making the
 	// frontend reload — and ship — the plaintext API key. Other fields
@@ -1559,10 +1560,8 @@ func (h *InitializationHandler) fillSecretsFromStoredModel(ctx context.Context, 
 	if req == nil || req.ModelID == "" {
 		return
 	}
-	if req.APIKey != "" {
-		// Already supplied — nothing to merge. (We don't need to look up
-		// AppSecret separately since the WeKnoraCloud path resolves it
-		// from the tenant, not the model record.)
+	if req.APIKey != "" && req.AppSecret != "" {
+		// Already supplied; nothing to merge.
 		return
 	}
 	stored, err := h.modelService.GetModelByID(ctx, req.ModelID)
@@ -1573,6 +1572,9 @@ func (h *InitializationHandler) fillSecretsFromStoredModel(ctx context.Context, 
 	}
 	if req.APIKey == "" {
 		req.APIKey = stored.Parameters.APIKey
+	}
+	if req.AppSecret == "" {
+		req.AppSecret = stored.Parameters.AppSecret
 	}
 }
 
@@ -1598,6 +1600,7 @@ func (h *InitializationHandler) buildTestModel(
 		Parameters: types.ModelParameters{
 			BaseURL:       req.BaseURL,
 			APIKey:        req.APIKey,
+			AppSecret:     req.AppSecret,
 			Provider:      req.Provider,
 			InterfaceType: req.InterfaceType,
 			ExtraConfig:   req.ExtraConfig,

--- a/internal/models/provider/lkeap.go
+++ b/internal/models/provider/lkeap.go
@@ -10,6 +10,8 @@ import (
 const (
 	// LKEAPBaseURL 腾讯云知识引擎原子能力 (LKEAP) 兼容 OpenAI 协议的 BaseURL
 	LKEAPBaseURL = "https://api.lkeap.cloud.tencent.com/v1"
+	// LKEAPRerankBaseURL 腾讯云知识引擎原子能力 RunRerank 云 API 域名
+	LKEAPRerankBaseURL = "https://lkeap.tencentcloudapi.com"
 )
 
 // LKEAPProvider 实现腾讯云 LKEAP 的 Provider 接口
@@ -28,9 +30,11 @@ func (p *LKEAPProvider) Info() ProviderInfo {
 		Description: "DeepSeek-R1, DeepSeek-V3 系列模型，支持思维链",
 		DefaultURLs: map[types.ModelType]string{
 			types.ModelTypeKnowledgeQA: LKEAPBaseURL,
+			types.ModelTypeRerank:      LKEAPRerankBaseURL,
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeRerank,
 		},
 		RequiresAuth: true,
 	}

--- a/internal/models/provider/provider_test.go
+++ b/internal/models/provider/provider_test.go
@@ -230,15 +230,25 @@ func TestListByModelType(t *testing.T) {
 	t.Run("rerank models", func(t *testing.T) {
 		providers := ListByModelType(types.ModelTypeRerank)
 		assert.NotEmpty(t, providers)
-		// Check that Aliyun supports rerank
-		found := false
+		// Check that Aliyun and Tencent Cloud LKEAP support rerank
+		foundAliyun := false
+		foundLKEAP := false
 		for _, p := range providers {
 			if p.Name == ProviderAliyun {
-				found = true
-				break
+				foundAliyun = true
+			}
+			if p.Name == ProviderLKEAP {
+				foundLKEAP = true
 			}
 		}
-		assert.True(t, found, "Aliyun should support rerank")
+		assert.True(t, foundAliyun, "Aliyun should support rerank")
+		assert.True(t, foundLKEAP, "LKEAP should support rerank")
+	})
+
+	t.Run("lkeap rerank default url", func(t *testing.T) {
+		p, ok := Get(ProviderLKEAP)
+		require.True(t, ok)
+		assert.Equal(t, "https://lkeap.tencentcloudapi.com", p.Info().GetDefaultURL(types.ModelTypeRerank))
 	})
 
 	t.Run("embedding models include openrouter", func(t *testing.T) {

--- a/internal/models/rerank/config_from_model_test.go
+++ b/internal/models/rerank/config_from_model_test.go
@@ -30,3 +30,20 @@ func TestConfigFromModel(t *testing.T) {
 		t.Errorf("cloud creds mismatch: %+v", cfg)
 	}
 }
+
+func TestConfigFromModelFallsBackToModelAppSecret(t *testing.T) {
+	m := &types.Model{
+		ID:   "rr-2",
+		Name: "lke-reranker-base",
+		Parameters: types.ModelParameters{
+			Provider:  "lkeap",
+			APIKey:    "secret-id",
+			AppSecret: "secret-key",
+		},
+	}
+
+	cfg := ConfigFromModel(m, "", "")
+	if cfg.AppSecret != "secret-key" {
+		t.Fatalf("AppSecret = %q, want model parameter AppSecret", cfg.AppSecret)
+	}
+}

--- a/internal/models/rerank/lkeap_reranker.go
+++ b/internal/models/rerank/lkeap_reranker.go
@@ -1,0 +1,251 @@
+package rerank
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	lkeapRerankDefaultBaseURL = "https://lkeap.tencentcloudapi.com"
+	lkeapRerankAction         = "RunRerank"
+	lkeapRerankVersion        = "2024-05-22"
+	lkeapRerankService        = "lkeap"
+	lkeapRerankDefaultRegion  = "ap-guangzhou"
+)
+
+type LKEAPReranker struct {
+	modelName string
+	modelID   string
+	secretID  string
+	secretKey string
+	baseURL   string
+	region    string
+	client    *http.Client
+}
+
+func NewLKEAPReranker(config *RerankerConfig) (*LKEAPReranker, error) {
+	if strings.TrimSpace(config.APIKey) == "" {
+		return nil, fmt.Errorf("LKEAP reranker: SecretId is required")
+	}
+	if strings.TrimSpace(config.AppSecret) == "" {
+		return nil, fmt.Errorf("LKEAP reranker: SecretKey is required")
+	}
+	baseURL := strings.TrimRight(config.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = lkeapRerankDefaultBaseURL
+	}
+	region := lkeapRerankDefaultRegion
+	if config.ExtraConfig != nil && strings.TrimSpace(config.ExtraConfig["region"]) != "" {
+		region = strings.TrimSpace(config.ExtraConfig["region"])
+	}
+	return &LKEAPReranker{
+		modelName: strings.TrimSpace(config.ModelName),
+		modelID:   config.ModelID,
+		secretID:  strings.TrimSpace(config.APIKey),
+		secretKey: strings.TrimSpace(config.AppSecret),
+		baseURL:   baseURL,
+		region:    region,
+		client:    &http.Client{Timeout: 60 * time.Second},
+	}, nil
+}
+
+type lkeapRerankRequest struct {
+	Query string   `json:"Query"`
+	Docs  []string `json:"Docs"`
+	Model string   `json:"Model,omitempty"`
+}
+
+type lkeapRerankResponse struct {
+	Response struct {
+		ScoreList []float64 `json:"ScoreList"`
+		RequestID string    `json:"RequestId"`
+		Error     *struct {
+			Code    string `json:"Code"`
+			Message string `json:"Message"`
+		} `json:"Error,omitempty"`
+	} `json:"Response"`
+}
+
+func (r *LKEAPReranker) Rerank(ctx context.Context, query string, documents []string) ([]RankResult, error) {
+	originalDocuments := documents
+	query, documents, indexMap, err := prepareLKEAPInputs(query, documents)
+	if err != nil {
+		return nil, err
+	}
+	reqBody := lkeapRerankRequest{
+		Query: query,
+		Docs:  documents,
+		Model: r.modelName,
+	}
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("lkeap reranker: marshal: %w", err)
+	}
+
+	endpoint, err := url.Parse(r.baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("lkeap reranker: invalid base URL: %w", err)
+	}
+	endpoint.Path = "/"
+	endpoint.RawQuery = ""
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("lkeap reranker: create request: %w", err)
+	}
+	req.Host = endpoint.Host
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("X-TC-Action", lkeapRerankAction)
+	req.Header.Set("X-TC-Version", lkeapRerankVersion)
+	req.Header.Set("X-TC-Region", r.region)
+	req.Header.Set("X-TC-Timestamp", fmt.Sprintf("%d", time.Now().Unix()))
+	req.Header.Set("Authorization", r.authorization(req, bodyBytes))
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("lkeap reranker: do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("lkeap reranker: read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("lkeap reranker: status %d: %s", resp.StatusCode, string(respBytes))
+	}
+
+	var rerankResp lkeapRerankResponse
+	if err := json.Unmarshal(respBytes, &rerankResp); err != nil {
+		return nil, fmt.Errorf("lkeap reranker: unmarshal: %w", err)
+	}
+	if rerankResp.Response.Error != nil {
+		return nil, fmt.Errorf("lkeap reranker: %s: %s", rerankResp.Response.Error.Code, rerankResp.Response.Error.Message)
+	}
+	if len(rerankResp.Response.ScoreList) > len(documents) {
+		return nil, fmt.Errorf("lkeap reranker: score count %d exceeds document count %d",
+			len(rerankResp.Response.ScoreList), len(documents))
+	}
+
+	results := make([]RankResult, 0, len(rerankResp.Response.ScoreList))
+	for i, score := range rerankResp.Response.ScoreList {
+		originalIndex := indexMap[i]
+		results = append(results, RankResult{
+			Index:          originalIndex,
+			Document:       DocumentInfo{Text: originalDocuments[originalIndex]},
+			RelevanceScore: score,
+		})
+	}
+	sort.SliceStable(results, func(i, j int) bool {
+		return results[i].RelevanceScore > results[j].RelevanceScore
+	})
+	return results, nil
+}
+
+func (r *LKEAPReranker) authorization(req *http.Request, payload []byte) string {
+	timestamp := req.Header.Get("X-TC-Timestamp")
+	date := time.Unix(mustParseInt64(timestamp), 0).UTC().Format("2006-01-02")
+	credentialScope := date + "/" + lkeapRerankService + "/tc3_request"
+	signedHeaders := "content-type;host;x-tc-action"
+	hashedPayload := sha256Hex(payload)
+	canonicalHeaders := "content-type:" + req.Header.Get("Content-Type") + "\n" +
+		"host:" + req.Host + "\n" +
+		"x-tc-action:" + strings.ToLower(req.Header.Get("X-TC-Action")) + "\n"
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		"/",
+		"",
+		canonicalHeaders,
+		signedHeaders,
+		hashedPayload,
+	}, "\n")
+	stringToSign := strings.Join([]string{
+		"TC3-HMAC-SHA256",
+		timestamp,
+		credentialScope,
+		sha256Hex([]byte(canonicalRequest)),
+	}, "\n")
+
+	secretDate := hmacSHA256([]byte("TC3"+r.secretKey), date)
+	secretService := hmacSHA256(secretDate, lkeapRerankService)
+	secretSigning := hmacSHA256(secretService, "tc3_request")
+	signature := hex.EncodeToString(hmacSHA256(secretSigning, stringToSign))
+
+	return fmt.Sprintf("TC3-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		r.secretID, credentialScope, signedHeaders, signature)
+}
+
+func (r *LKEAPReranker) GetModelName() string { return r.modelName }
+func (r *LKEAPReranker) GetModelID() string   { return r.modelID }
+
+func prepareLKEAPInputs(query string, documents []string) (string, []string, []int, error) {
+	const (
+		maxDocs       = 60
+		maxTotalRunes = 2000
+	)
+	queryRunes := []rune(query)
+	if len(queryRunes) >= maxTotalRunes {
+		return "", nil, nil, fmt.Errorf("lkeap reranker: query length %d exceeds RunRerank limit %d",
+			len(queryRunes), maxTotalRunes)
+	}
+	remaining := maxTotalRunes - len(queryRunes)
+	limit := len(documents)
+	if limit > maxDocs {
+		limit = maxDocs
+	}
+	limitedDocs := make([]string, 0, limit)
+	indexMap := make([]int, 0, limit)
+	for i := 0; i < limit && remaining > 0; i++ {
+		doc := strings.TrimSpace(documents[i])
+		if doc == "" {
+			continue
+		}
+		docRunes := []rune(doc)
+		if len(docRunes) > remaining {
+			docRunes = docRunes[:remaining]
+		}
+		limitedDocs = append(limitedDocs, string(docRunes))
+		indexMap = append(indexMap, i)
+		remaining -= len(docRunes)
+	}
+	if len(limitedDocs) == 0 {
+		return "", nil, nil, fmt.Errorf("lkeap reranker: no documents fit RunRerank input limit")
+	}
+	return query, limitedDocs, indexMap, nil
+}
+
+func totalRunes(values []string) int {
+	total := 0
+	for _, value := range values {
+		total += len([]rune(value))
+	}
+	return total
+}
+
+func sha256Hex(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+func hmacSHA256(key []byte, msg string) []byte {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write([]byte(msg))
+	return mac.Sum(nil)
+}
+
+func mustParseInt64(s string) int64 {
+	var n int64
+	_, _ = fmt.Sscan(s, &n)
+	return n
+}

--- a/internal/models/rerank/lkeap_reranker_test.go
+++ b/internal/models/rerank/lkeap_reranker_test.go
@@ -1,0 +1,148 @@
+package rerank
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/provider"
+)
+
+func TestLKEAPRerankerCallsRunRerankAndSortsScoreList(t *testing.T) {
+	var gotAction string
+	var gotVersion string
+	var gotAuth string
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAction = r.Header.Get("X-TC-Action")
+		gotVersion = r.Header.Get("X-TC-Version")
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"Response":{"RequestId":"req-1","ScoreList":[-9.006162,2.8577538]}}`))
+	}))
+	defer server.Close()
+
+	r, err := NewReranker(&RerankerConfig{
+		Provider:  string(provider.ProviderLKEAP),
+		BaseURL:   server.URL,
+		ModelName: "lke-reranker-base",
+		APIKey:    "secret-id",
+		AppSecret: "secret-key",
+	})
+	if err != nil {
+		t.Fatalf("NewReranker: %v", err)
+	}
+
+	results, err := r.Rerank(context.Background(), "知识引擎大模型", []string{"混元大模型", "腾讯知识引擎"})
+	if err != nil {
+		t.Fatalf("Rerank: %v", err)
+	}
+
+	if gotAction != "RunRerank" {
+		t.Fatalf("X-TC-Action = %q, want RunRerank", gotAction)
+	}
+	if gotVersion != "2024-05-22" {
+		t.Fatalf("X-TC-Version = %q, want 2024-05-22", gotVersion)
+	}
+	if gotAuth == "" {
+		t.Fatal("Authorization header was not signed")
+	}
+	if gotBody["Query"] != "知识引擎大模型" {
+		t.Fatalf("Query = %v", gotBody["Query"])
+	}
+	if gotBody["Model"] != "lke-reranker-base" {
+		t.Fatalf("Model = %v", gotBody["Model"])
+	}
+	if !reflect.DeepEqual(gotBody["Docs"], []any{"混元大模型", "腾讯知识引擎"}) {
+		t.Fatalf("Docs = %#v", gotBody["Docs"])
+	}
+
+	want := []RankResult{
+		{Index: 1, Document: DocumentInfo{Text: "腾讯知识引擎"}, RelevanceScore: 2.8577538},
+		{Index: 0, Document: DocumentInfo{Text: "混元大模型"}, RelevanceScore: -9.006162},
+	}
+	if !reflect.DeepEqual(results, want) {
+		t.Fatalf("results = %#v, want %#v", results, want)
+	}
+}
+
+func TestLKEAPRerankerRespectsRunRerankInputLimits(t *testing.T) {
+	docs := make([]string, 61)
+	for i := range docs {
+		docs[i] = "abcdef"
+	}
+	docs[0] = strings.Repeat("你", 3000)
+
+	query, limitedDocs, indexMap, err := prepareLKEAPInputs("query", docs)
+	if err != nil {
+		t.Fatalf("prepareLKEAPInputs: %v", err)
+	}
+	if query != "query" {
+		t.Fatalf("query = %q", query)
+	}
+	if len(limitedDocs) != 1 {
+		t.Fatalf("len(limitedDocs) = %d, want 1", len(limitedDocs))
+	}
+	if len([]rune(query))+totalRunes(limitedDocs) > 2000 {
+		t.Fatalf("query + docs exceeded RunRerank limit")
+	}
+	if len([]rune(limitedDocs[0])) != 1995 {
+		t.Fatalf("first doc len = %d, want 1995", len([]rune(limitedDocs[0])))
+	}
+	if !reflect.DeepEqual(indexMap, []int{0}) {
+		t.Fatalf("indexMap = %#v", indexMap)
+	}
+}
+
+func TestLKEAPRerankerReturnsOriginalDocumentAfterInputTruncation(t *testing.T) {
+	longDoc := strings.Repeat("你", 3000)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var gotBody map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		docs, ok := gotBody["Docs"].([]any)
+		if !ok || len(docs) != 1 {
+			t.Fatalf("Docs = %#v", gotBody["Docs"])
+		}
+		doc, ok := docs[0].(string)
+		if !ok {
+			t.Fatalf("Docs[0] = %#v", docs[0])
+		}
+		if len([]rune(doc)) != 1995 {
+			t.Fatalf("sent doc len = %d, want 1995", len([]rune(doc)))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"Response":{"RequestId":"req-1","ScoreList":[0.5]}}`))
+	}))
+	defer server.Close()
+
+	r, err := NewLKEAPReranker(&RerankerConfig{
+		BaseURL:   server.URL,
+		ModelName: "lke-reranker-base",
+		APIKey:    "secret-id",
+		AppSecret: "secret-key",
+	})
+	if err != nil {
+		t.Fatalf("NewLKEAPReranker: %v", err)
+	}
+
+	results, err := r.Rerank(context.Background(), "query", []string{longDoc})
+	if err != nil {
+		t.Fatalf("Rerank: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	if results[0].Document.Text != longDoc {
+		t.Fatal("result document was truncated")
+	}
+}

--- a/internal/models/rerank/reranker.go
+++ b/internal/models/rerank/reranker.go
@@ -89,12 +89,12 @@ type RerankerConfig struct {
 	// CustomHeaders 允许在调用远程 API 时附加自定义 HTTP 请求头（类似 OpenAI Python SDK 的 extra_headers）。
 	CustomHeaders map[string]string
 	AppID         string
-	AppSecret     string // 加密值，工厂函数调用方传入，使用前已解密
+	AppSecret     string
 }
 
 // ConfigFromModel 根据 types.Model 构造 RerankerConfig。
 // 生产路径（从 DB 拉起）和测试连接路径（临时表单）共享这份映射。
-// appID / appSecret 是已解密的 WeKnoraCloud 凭证，调用方负责传入。
+// appID / appSecret 优先使用调用方显式传入的凭证；为空时回退到模型参数。
 func ConfigFromModel(m *types.Model, appID, appSecret string) *RerankerConfig {
 	if m == nil {
 		return nil
@@ -108,9 +108,18 @@ func ConfigFromModel(m *types.Model, appID, appSecret string) *RerankerConfig {
 		Provider:      m.Parameters.Provider,
 		ExtraConfig:   m.Parameters.ExtraConfig,
 		CustomHeaders: m.Parameters.CustomHeaders,
-		AppID:         appID,
-		AppSecret:     appSecret,
+		AppID:         firstNonEmpty(appID, m.Parameters.AppID),
+		AppSecret:     firstNonEmpty(appSecret, m.Parameters.AppSecret),
 	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 // NewReranker creates a reranker based on the configuration
@@ -150,6 +159,8 @@ func newReranker(config *RerankerConfig) (Reranker, error) {
 		reranker, err = NewJinaReranker(config)
 	case provider.ProviderNvidia:
 		reranker, err = NewNvidiaReranker(config)
+	case provider.ProviderLKEAP:
+		reranker, err = NewLKEAPReranker(config)
 	case provider.ProviderWeKnoraCloud:
 		reranker, err = NewWeKnoraCloudReranker(config)
 	default:


### PR DESCRIPTION
## Summary
- add a Tencent Cloud LKEAP RunRerank implementation with TC3 request signing
- register LKEAP as a rerank-capable provider with the official Cloud API endpoint
- carry AppSecret through rerank test-connection requests and model config fallback

## Motivation
Addresses #1513. The existing LKEAP provider only covered OpenAI-compatible KnowledgeQA models, so rerank models fell back to the generic OpenAI-style /rerank path instead of Tencent Cloud RunRerank.

## Validation
- `CGO_LDFLAGS='-lc++' go test ./internal/models/rerank -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/models/provider -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/handler -count=1`
- `git diff --check`
