### PR TITLE
fix: avoid external image links in wiki pages

### DIFF
--- a/internal/agent/prompts_wiki.go
+++ b/internal/agent/prompts_wiki.go
@@ -30,7 +30,7 @@ const WikiSummaryPrompt = `You are a wiki editor. Given the following document c
 3. Include the key facts, arguments, and conclusions.
 4. Use proper heading hierarchy (## for sections, ### for subsections).
 5. **Wiki-link rule**: The available_wiki_pages list above maps slugs to display names and their aliases (format: "[[slug]] = display name (Aliases: a, b)"). Whenever you mention a name or alias that matches a listed entry, you MUST write it as [[slug|display name]] (e.g. [[entity/zhong-guo|中国]]), NOT as bold (**name**) or bare [[slug]]. Use the EXACT slugs provided — do NOT invent new slugs.
-6. **Image rule**: If the document contains <images> tags with <image> elements, you SHOULD include the relevant images in your summary using the Markdown syntax: ![caption](url). Place the images where they are contextually relevant to the text.
+6. **Image rule**: Include an image only when the provided URL is a WeKnora-served storage/provider URL (for example local://, minio://, cos://, tos://, s3://, oss://, ks3://, obs://, or /files?...). Do NOT include external http(s) image URLs; summarize their OCR/caption text instead.
 7. At the end, include a "## Key Takeaways" section with bullet points.
 8. Write in {{.Language}}.
 9. Keep the summary concise but thorough (500-1500 words depending on document length).
@@ -73,7 +73,7 @@ Each entity should have:
 - "slug": URL-friendly slug, format "entity/<lowercase-hyphenated-name>" (use romanized/pinyin form for non-Latin names). **Reuse previous slug if the entity was extracted before.**
 - "aliases": An array of strings representing names that refer to THE EXACT SAME entity. Only include: official abbreviations (e.g. "IBM" for "International Business Machines"), full/short name variants (e.g. "腾讯" for "腾讯控股有限公司"), translations (e.g. "Apple" for "苹果公司"), and well-known alternate names (e.g. "Alphabet" for "Google母公司"). Do NOT include parent categories, related products, generic terms, or broader concepts. Provide [] if none.
 - "description": **Index listing summary** — one sentence, 15-40 words, in {{.Language}}. Describes WHAT this entity IS and its role in the document. Must be self-contained (understandable without reading the full page). This will be displayed in the wiki index.
-- "details": A 2-5 sentence summary in {{.Language}} of key facts from the document. **Image rule**: If the document contains relevant <image> elements in an <images> tag, include them in the details using Markdown syntax: ![caption](url).
+- "details": A 2-5 sentence summary in {{.Language}} of key facts from the document. **Image rule**: Include image Markdown only for WeKnora-served storage/provider URLs. Do NOT include external http(s) image URLs.
 
 Only include entities that are substantively discussed (mentioned at least twice or described in detail). Do NOT include generic terms.
 
@@ -83,7 +83,7 @@ Each concept should have:
 - "slug": URL-friendly slug, format "concept/<lowercase-hyphenated-name>" (use romanized/pinyin form for non-Latin names). **Reuse previous slug if the concept was extracted before.**
 - "aliases": An array of strings representing names that refer to THE EXACT SAME concept. Only include: official abbreviations (e.g. "RAG" for "Retrieval-Augmented Generation"), full/short name variants, and well-known synonyms used interchangeably in the field. Do NOT include sub-topics, related techniques, broader categories, or implementation details. Provide [] if none.
 - "description": **Index listing summary** — one sentence, 15-40 words, in {{.Language}}. Defines WHAT this concept IS. Must be self-contained (understandable without reading the full page). This will be displayed in the wiki index.
-- "details": A 2-5 sentence explanation in {{.Language}} as discussed in the document. **Image rule**: If the document contains relevant <image> elements in an <images> tag, include them in the details using Markdown syntax: ![caption](url).
+- "details": A 2-5 sentence explanation in {{.Language}} as discussed in the document. **Image rule**: Include image Markdown only for WeKnora-served storage/provider URLs. Do NOT include external http(s) image URLs.
 
 Only include concepts that are substantively discussed. Skip trivial or overly generic concepts.
 
@@ -323,7 +323,7 @@ The <new_information> block above is assembled from VERBATIM source chunks that 
 4. Preserve existing information that is still valid and still about {{.PageTitle}}.
 5. Keep [[slug|name]] wiki-link references ONLY if the slug appears in the <valid_wiki_links> list above. Remove any [[slug|name]] whose slug is NOT in that list. Do NOT invent new wiki-link slugs. The page's own slug ({{.PageSlug}}) MUST NOT appear as a [[...]] link inside its own content.
 6. Maintain the existing page structure and formatting style. Use "# {{.PageTitle}}" as the top-level heading if the page does not already have one. Do NOT introduce new heading levels beyond what the source or existing page justifies.
-7. **Image rule**: Include relevant images using Markdown syntax: ![caption](url) from new information if applicable.
+7. **Image rule**: Include relevant images using Markdown syntax only when their URL is a WeKnora-served storage/provider URL. Do NOT copy external http(s) image URLs into the page; use their OCR/caption text as prose instead.
 {{if .HasRetractions}}
 8. If after removing deleted content the page becomes nearly empty and there is no new information to add, output just: "SUMMARY: (empty page)\n# {{.PageTitle}}\n\n*This page's primary source document was removed.*"
 {{end}}

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -2028,6 +2028,40 @@ func stripImageMarkup(s string) string {
 	return s
 }
 
+func stripUnservableMarkdownImages(s string) string {
+	return mdImageRefRE.ReplaceAllStringFunc(s, func(match string) string {
+		open := strings.LastIndex(match, "](")
+		close := strings.LastIndex(match, ")")
+		if open < 0 || close <= open+2 {
+			return match
+		}
+		rawURL := strings.TrimSpace(match[open+2 : close])
+		if isWikiServableImageURL(rawURL) {
+			return match
+		}
+		return ""
+	})
+}
+
+func isWikiServableImageURL(rawURL string) bool {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return false
+	}
+	lower := strings.ToLower(rawURL)
+	if strings.HasPrefix(lower, "/files?") && strings.Contains(lower, "file_path=") {
+		return true
+	}
+	for _, prefix := range []string{
+		"local://", "minio://", "cos://", "tos://", "s3://", "oss://", "ks3://", "obs://",
+	} {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // extractRealText returns the trimmed content with image markup stripped.
 // Cached at the call site for use both in the threshold check and in any
 // subsequent log message, avoiding redundant regex passes over large docs.

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -779,7 +779,7 @@ func (s *wikiIngestService) mapOneDocument(
 		return nil, nil, nil
 	}
 
-	content := reconstructEnrichedContent(ctx, s.chunkRepo, payload.TenantID, chunks)
+	content := stripUnservableMarkdownImages(reconstructEnrichedContent(ctx, s.chunkRepo, payload.TenantID, chunks))
 	rawRuneCount := len([]rune(content))
 	if len([]rune(content)) > maxContentForWiki {
 		content = string([]rune(content)[:maxContentForWiki])

--- a/internal/application/service/wiki_ingest_cite.go
+++ b/internal/application/service/wiki_ingest_cite.go
@@ -259,7 +259,8 @@ func renderChunksXML(batch chunkBatch) string {
 	var sb strings.Builder
 	for _, c := range batch.chunks {
 		alias := idToAlias[c.ID]
-		fmt.Fprintf(&sb, "<c id=%q index=\"%d\">\n%s\n</c>\n", alias, c.ChunkIndex, c.Content)
+		fmt.Fprintf(&sb, "<c id=%q index=\"%d\">\n%s\n</c>\n", alias, c.ChunkIndex,
+			stripUnservableMarkdownImages(c.Content))
 	}
 	return sb.String()
 }
@@ -453,7 +454,7 @@ func collectCitedChunkContent(chunkIDs []string, contentByID map[string]string) 
 		if sb.Len() > 0 {
 			sb.WriteString("\n\n")
 		}
-		sb.WriteString(content)
+		sb.WriteString(stripUnservableMarkdownImages(content))
 	}
 	return sb.String()
 }

--- a/internal/application/service/wiki_ingest_cite_test.go
+++ b/internal/application/service/wiki_ingest_cite_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/Tencent/WeKnora/internal/types"
@@ -161,6 +162,28 @@ func TestSplitChunksIntoCitationBatches_RespectsBudgetAndOrder(t *testing.T) {
 		if len(b.aliasToID) != len(b.chunks) {
 			t.Errorf("batch %d alias count %d != chunk count %d", bi, len(b.aliasToID), len(b.chunks))
 		}
+	}
+}
+
+func TestCollectCitedChunkContentDropsExternalMarkdownImages(t *testing.T) {
+	contentByID := map[string]string{
+		"chunk-1": "Intro\n![Feishu table](https://rondsoffice.feishu.cn/file/HJ4ibCEAKoQzFxxKqZucBUh5nIg)\nMore text",
+		"chunk-2": "Stored\n![Stored diagram](local://images/diagram.png)",
+	}
+
+	got := collectCitedChunkContent([]string{"chunk-1", "chunk-2"}, contentByID)
+
+	if strings.Contains(got, "rondsoffice.feishu.cn") {
+		t.Fatalf("external image URL leaked into wiki source content: %s", got)
+	}
+	if strings.Contains(got, "![Feishu table]") {
+		t.Fatalf("external image markdown leaked into wiki source content: %s", got)
+	}
+	if !strings.Contains(got, "Intro\n\nMore text") {
+		t.Fatalf("surrounding text was not preserved: %s", got)
+	}
+	if !strings.Contains(got, "![Stored diagram](local://images/diagram.png)") {
+		t.Fatalf("storage-backed image should be preserved: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- filter wiki LLM inputs so external http(s) Markdown image links do not get persisted into generated wiki pages
- keep WeKnora-served storage/provider image URLs available for wiki rendering
- tighten wiki prompts so models do not copy private or short-lived external image URLs

## Root Cause
Feishu-synced wiki pages can contain image Markdown that points at private or short-lived Feishu URLs. Those URLs may return 404 or otherwise fail outside the original Feishu context, and the wiki editor prompt previously encouraged copying them into page content.

Fixes #1444

## Validation
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service -count=1`
- `git diff --check`
