### PR TITLE
fix: preserve Gemini tool call thought signatures

### DIFF
--- a/internal/agent/act.go
+++ b/internal/agent/act.go
@@ -318,9 +318,10 @@ func (e *AgentEngine) runToolCall(
 		if repairErr := json.Unmarshal([]byte(repaired), &args); repairErr != nil {
 			logger.Errorf(ctx, "%s Failed to parse arguments (repair failed): %v", toolTag, err)
 			return types.ToolCall{
-				ID:   tc.ID,
-				Name: tc.Function.Name,
-				Args: map[string]any{"_raw": argsStr},
+				ID:           tc.ID,
+				Name:         tc.Function.Name,
+				Args:         map[string]any{"_raw": argsStr},
+				ExtraContent: tc.ExtraContent,
 				Result: &types.ToolResult{
 					Success: false,
 					Error: fmt.Sprintf(
@@ -414,11 +415,12 @@ func (e *AgentEngine) runToolCall(
 	duration := time.Since(toolCallStartTime).Milliseconds()
 
 	toolCall := types.ToolCall{
-		ID:       tc.ID,
-		Name:     tc.Function.Name,
-		Args:     args,
-		Result:   result,
-		Duration: duration,
+		ID:           tc.ID,
+		Name:         tc.Function.Name,
+		Args:         args,
+		Result:       result,
+		Duration:     duration,
+		ExtraContent: tc.ExtraContent,
 	}
 
 	if err != nil {

--- a/internal/agent/observe.go
+++ b/internal/agent/observe.go
@@ -392,8 +392,9 @@ func (e *AgentEngine) appendToolResults(
 				argsJSON, _ := json.Marshal(tc.Args)
 
 				assistantMsg.ToolCalls = append(assistantMsg.ToolCalls, chat.ToolCall{
-					ID:   tc.ID,
-					Type: "function",
+					ID:           tc.ID,
+					Type:         "function",
+					ExtraContent: tc.ExtraContent,
 					Function: chat.FunctionCall{
 						Name:      tc.Name,
 						Arguments: string(argsJSON),

--- a/internal/agent/observe_test.go
+++ b/internal/agent/observe_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -137,14 +138,16 @@ func TestAppendToolResults_PreservesReasoningContent(t *testing.T) {
 	engine := &AgentEngine{}
 
 	t.Run("assistant message carries reasoning_content alongside thought and tool_calls", func(t *testing.T) {
+		extra := json.RawMessage(`{"google":{"thought_signature":"sig-123"}}`)
 		step := types.AgentStep{
 			Iteration:        0,
 			Thought:          "I will call search.",
 			ReasoningContent: "Detailed chain of thought from MiMo/DeepSeek.",
 			ToolCalls: []types.ToolCall{{
-				ID:   "call_1",
-				Name: "knowledge_search",
-				Args: map[string]interface{}{"query": "hi"},
+				ID:           "call_1",
+				Name:         "knowledge_search",
+				Args:         map[string]interface{}{"query": "hi"},
+				ExtraContent: extra,
 				Result: &types.ToolResult{
 					Success: true,
 					Output:  "result text",
@@ -163,6 +166,8 @@ func TestAppendToolResults_PreservesReasoningContent(t *testing.T) {
 				"and DeepSeek thinking-mode see it on the next round (issue #1302)")
 		require.Len(t, out[0].ToolCalls, 1)
 		assert.Equal(t, "call_1", out[0].ToolCalls[0].ID)
+		assert.JSONEq(t, string(extra), string(out[0].ToolCalls[0].ExtraContent),
+			"Gemini thought signatures and similar provider tool-call metadata must be replayed")
 
 		assert.Equal(t, "tool", out[1].Role)
 		assert.Equal(t, "result text", out[1].Content)

--- a/internal/application/service/agent_history.go
+++ b/internal/application/service/agent_history.go
@@ -166,8 +166,9 @@ func buildAssistantHistoryMessages(m *types.Message) []chat.Message {
 		for _, tc := range nonTerminalCalls {
 			argsJSON, _ := json.Marshal(tc.Args)
 			assistantMsg.ToolCalls = append(assistantMsg.ToolCalls, chat.ToolCall{
-				ID:   tc.ID,
-				Type: "function",
+				ID:           tc.ID,
+				Type:         "function",
+				ExtraContent: tc.ExtraContent,
 				Function: chat.FunctionCall{
 					Name:      tc.Name,
 					Arguments: string(argsJSON),

--- a/internal/application/service/agent_history_test.go
+++ b/internal/application/service/agent_history_test.go
@@ -1,12 +1,14 @@
 package service
 
 import (
+	"encoding/json"
 	"testing"
 
 	agenttools "github.com/Tencent/WeKnora/internal/agent/tools"
 	"github.com/Tencent/WeKnora/internal/models/chat"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestBuildUserHistoryMessage_PrefersRenderedContent verifies the user side of
@@ -236,6 +238,7 @@ func TestFilterNonTerminalToolCalls(t *testing.T) {
 // must be re-attached to the rebuilt assistant message, otherwise MiMo and
 // DeepSeek thinking-mode reject the next turn with HTTP 400 (issue #1302).
 func TestBuildAssistantHistoryMessages_ReplaysReasoningContent(t *testing.T) {
+	extra := json.RawMessage(`{"google":{"thought_signature":"sig-123"}}`)
 	msg := &types.Message{
 		Role:    "assistant",
 		Content: "Found 3 matches in the docs.",
@@ -245,9 +248,10 @@ func TestBuildAssistantHistoryMessages_ReplaysReasoningContent(t *testing.T) {
 				Thought:          "Let me search.",
 				ReasoningContent: "model's chain of thought",
 				ToolCalls: []types.ToolCall{{
-					ID:   "call_1",
-					Name: agenttools.ToolKnowledgeSearch,
-					Args: map[string]interface{}{"query": "foo"},
+					ID:           "call_1",
+					Name:         agenttools.ToolKnowledgeSearch,
+					Args:         map[string]interface{}{"query": "foo"},
+					ExtraContent: extra,
 					Result: &types.ToolResult{
 						Success: true,
 						Output:  "doc A",
@@ -263,6 +267,9 @@ func TestBuildAssistantHistoryMessages_ReplaysReasoningContent(t *testing.T) {
 	assert.Equal(t, "model's chain of thought", got[0].ReasoningContent,
 		"reasoning_content from AgentStep must be replayed onto the rebuilt assistant message "+
 			"so MiMo/DeepSeek thinking-mode does not 400 on multi-turn (issue #1302)")
+	require.Len(t, got[0].ToolCalls, 1)
+	assert.JSONEq(t, string(extra), string(got[0].ToolCalls[0].ExtraContent),
+		"provider-specific tool-call metadata must survive historical replay")
 	// Tool message and final answer message must NOT carry reasoning_content.
 	assert.Empty(t, got[1].ReasoningContent)
 	assert.Empty(t, got[2].ReasoningContent)

--- a/internal/models/chat/chat.go
+++ b/internal/models/chat/chat.go
@@ -72,9 +72,10 @@ type Message struct {
 
 // ToolCall represents a tool call in a message
 type ToolCall struct {
-	ID       string       `json:"id"`
-	Type     string       `json:"type"` // "function"
-	Function FunctionCall `json:"function"`
+	ID           string          `json:"id"`
+	Type         string          `json:"type"` // "function"
+	Function     FunctionCall    `json:"function"`
+	ExtraContent json.RawMessage `json:"extra_content,omitempty"`
 }
 
 // FunctionCall represents a function call

--- a/internal/models/chat/chat_provider_spec.go
+++ b/internal/models/chat/chat_provider_spec.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -20,7 +21,7 @@ type ProviderSpec struct {
 	// Used for sub-provider routing (e.g. Qwen3 within Aliyun).
 	ModelMatcher func(modelName string) bool
 	// RequestCustomizer: provider-specific request modification.
-	RequestCustomizer func(req *openai.ChatCompletionRequest, opts *ChatOptions, isStream bool) (any, bool)
+	RequestCustomizer func(req *openai.ChatCompletionRequest, opts *ChatOptions, isStream bool, messages []Message) (any, bool)
 	// EndpointCustomizer: provider-specific endpoint URL override.
 	EndpointCustomizer func(baseURL string, modelID string, isStream bool) string
 	// HeaderCustomizer: provider-specific raw HTTP header customization.
@@ -70,6 +71,12 @@ var chatProviderSpecs = []ProviderSpec{
 		Provider:          provider.ProviderNvidia,
 		RequestCustomizer: genericRequestCustomizer,
 	},
+	// Gemini OpenAI-compatible endpoint requires provider-specific tool metadata
+	// such as extra_content.google.thought_signature to be round-tripped.
+	{
+		Provider:          provider.ProviderGemini,
+		RequestCustomizer: geminiRequestCustomizer,
+	},
 }
 
 // findProviderSpec finds the matching spec for the given provider and model name.
@@ -95,6 +102,49 @@ type QwenChatCompletionRequest struct {
 	EnableThinking *bool `json:"enable_thinking,omitempty"`
 }
 
+type chatCompletionRequestWithToolCallExtras struct {
+	Request  openai.ChatCompletionRequest
+	Messages []chatCompletionMessageWithToolCallExtras
+}
+
+func (r chatCompletionRequestWithToolCallExtras) MarshalJSON() ([]byte, error) {
+	payload, err := json.Marshal(r.Request)
+	if err != nil {
+		return nil, err
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(payload, &obj); err != nil {
+		return nil, err
+	}
+	obj["messages"] = r.Messages
+	return json.Marshal(obj)
+}
+
+type chatCompletionMessageWithToolCallExtras struct {
+	openai.ChatCompletionMessage
+	ToolCalls []toolCallWithExtraContent `json:"tool_calls,omitempty"`
+}
+
+func (m chatCompletionMessageWithToolCallExtras) MarshalJSON() ([]byte, error) {
+	payload, err := json.Marshal(m.ChatCompletionMessage)
+	if err != nil {
+		return nil, err
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(payload, &obj); err != nil {
+		return nil, err
+	}
+	if len(m.ToolCalls) > 0 {
+		obj["tool_calls"] = m.ToolCalls
+	}
+	return json.Marshal(obj)
+}
+
+type toolCallWithExtraContent struct {
+	openai.ToolCall
+	ExtraContent json.RawMessage `json:"extra_content,omitempty"`
+}
+
 // ThinkingConfig 思维链配置（LKEAP / Volcengine 等通用格式）
 type ThinkingConfig struct {
 	Type string `json:"type"` // "enabled" 或 "disabled"
@@ -113,7 +163,7 @@ type ThinkingChatCompletionRequest struct {
 // WeKnoraCloud 走 OpenAI 兼容格式，除了 MultiContent 需要降级为纯文本 Content 之外，
 // 其他字段（tools / tool_choice / parallel_tool_calls / response_format / stream_options 等）直接透传，
 // 以保证 function calling 等能力可用。
-func weKnoraCloudRequestCustomizer(req *openai.ChatCompletionRequest, _ *ChatOptions, isStream bool) (any, bool) {
+func weKnoraCloudRequestCustomizer(req *openai.ChatCompletionRequest, _ *ChatOptions, isStream bool, _ []Message) (any, bool) {
 	cloudReq := *req
 	cloudReq.Stream = isStream
 	cloudReq.Messages = convertToWeKnoraCloudMessagesFromOpenAI(req.Messages)
@@ -127,6 +177,36 @@ func weKnoraCloudHeaderCustomizer(chat *RemoteAPIChat, req *http.Request, body [
 		req.Header.Set(k, v)
 	}
 	return nil
+}
+
+func geminiRequestCustomizer(
+	req *openai.ChatCompletionRequest, _ *ChatOptions, _ bool, messages []Message,
+) (any, bool) {
+	geminiReq := chatCompletionRequestWithToolCallExtras{
+		Request:  *req,
+		Messages: make([]chatCompletionMessageWithToolCallExtras, 0, len(req.Messages)),
+	}
+	for i, msg := range req.Messages {
+		customMsg := chatCompletionMessageWithToolCallExtras{
+			ChatCompletionMessage: msg,
+		}
+		var originalToolCalls []ToolCall
+		if i < len(messages) {
+			originalToolCalls = messages[i].ToolCalls
+		}
+		if len(msg.ToolCalls) > 0 {
+			customMsg.ToolCalls = make([]toolCallWithExtraContent, 0, len(msg.ToolCalls))
+			for j, tc := range msg.ToolCalls {
+				customTC := toolCallWithExtraContent{ToolCall: tc}
+				if j < len(originalToolCalls) && len(originalToolCalls[j].ExtraContent) > 0 {
+					customTC.ExtraContent = originalToolCalls[j].ExtraContent
+				}
+				customMsg.ToolCalls = append(customMsg.ToolCalls, customTC)
+			}
+		}
+		geminiReq.Messages = append(geminiReq.Messages, customMsg)
+	}
+	return geminiReq, true
 }
 
 // convertToWeKnoraCloudMessagesFromOpenAI 将 MultiContent 降级为纯文本，
@@ -152,7 +232,7 @@ func convertToWeKnoraCloudMessagesFromOpenAI(messages []openai.ChatCompletionMes
 
 // qwenThinkingRequestCustomizer 自定义 Qwen 系列（阿里云）模型的思考请求
 func qwenThinkingRequestCustomizer(
-	req *openai.ChatCompletionRequest, opts *ChatOptions, isStream bool,
+	req *openai.ChatCompletionRequest, opts *ChatOptions, isStream bool, _ []Message,
 ) (any, bool) {
 	if !isStream {
 		// Qwen3 模型在非流式请求时需要显式禁用 thinking
@@ -182,7 +262,7 @@ func qwenThinkingRequestCustomizer(
 // 仅对 DeepSeek V3.x 系列模型设置 thinking 参数；R1 系列默认开启思维链
 // 参考：https://cloud.tencent.com/document/product/1772/115963
 func lkeapRequestCustomizer(
-	req *openai.ChatCompletionRequest, opts *ChatOptions, _ bool,
+	req *openai.ChatCompletionRequest, opts *ChatOptions, _ bool, _ []Message,
 ) (any, bool) {
 	modelName := req.Model
 	if !strings.Contains(strings.ToLower(modelName), "deepseek-v3") || opts == nil || opts.Thinking == nil {
@@ -205,7 +285,7 @@ func lkeapRequestCustomizer(
 // deepseekRequestCustomizer 自定义 DeepSeek 请求
 // DeepSeek 模型不支持 tool_choice 参数，需要清除
 func deepseekRequestCustomizer(
-	req *openai.ChatCompletionRequest, opts *ChatOptions, _ bool,
+	req *openai.ChatCompletionRequest, opts *ChatOptions, _ bool, _ []Message,
 ) (any, bool) {
 	if opts != nil && opts.ToolChoice != "" {
 		logger.Infof(context.Background(), "deepseek model, skip tool_choice")
@@ -217,7 +297,7 @@ func deepseekRequestCustomizer(
 // genericRequestCustomizer 自定义 Generic 请求
 // Generic provider（如 vLLM）使用 ChatTemplateKwargs 传递 thinking 参数
 func genericRequestCustomizer(
-	req *openai.ChatCompletionRequest, opts *ChatOptions, _ bool,
+	req *openai.ChatCompletionRequest, opts *ChatOptions, _ bool, _ []Message,
 ) (any, bool) {
 	thinking := false
 	if opts != nil && opts.Thinking != nil {
@@ -232,7 +312,7 @@ func genericRequestCustomizer(
 // volcengineRequestCustomizer 自定义火山引擎请求
 // 火山引擎使用 thinking 参数控制深度思考，格式同 LKEAP: { "type": "enabled"/"disabled" }
 func volcengineRequestCustomizer(
-	req *openai.ChatCompletionRequest, opts *ChatOptions, _ bool,
+	req *openai.ChatCompletionRequest, opts *ChatOptions, _ bool, _ []Message,
 ) (any, bool) {
 	if opts == nil || opts.Thinking == nil {
 		return nil, false

--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -82,7 +82,7 @@ type RemoteAPIChat struct {
 
 	// requestCustomizer 允许子类自定义请求
 	// 返回自定义请求体（如果为 nil 则使用标准请求）和是否需要使用原始 HTTP 请求
-	requestCustomizer func(req *openai.ChatCompletionRequest, opts *ChatOptions, isStream bool) (customReq any, useRawHTTP bool)
+	requestCustomizer func(req *openai.ChatCompletionRequest, opts *ChatOptions, isStream bool, messages []Message) (customReq any, useRawHTTP bool)
 
 	// endpointCustomizer 允许子类自定义请求的 endpoint
 	// 返回是否使用自定义请求地址, 返回空则使用默认OpenAI格式地址
@@ -164,7 +164,7 @@ func NewRemoteAPIChat(chatConfig *ChatConfig) (*RemoteAPIChat, error) {
 }
 
 // SetRequestCustomizer 设置请求自定义器
-func (c *RemoteAPIChat) SetRequestCustomizer(customizer func(req *openai.ChatCompletionRequest, opts *ChatOptions, isStream bool) (any, bool)) {
+func (c *RemoteAPIChat) SetRequestCustomizer(customizer func(req *openai.ChatCompletionRequest, opts *ChatOptions, isStream bool, messages []Message) (any, bool)) {
 	c.requestCustomizer = customizer
 }
 
@@ -395,7 +395,7 @@ func (c *RemoteAPIChat) Chat(ctx context.Context, messages []Message, opts *Chat
 	}
 	// 检查是否需要自定义请求
 	if c.requestCustomizer != nil {
-		customReq, useRawHTTP := c.requestCustomizer(&req, opts, false)
+		customReq, useRawHTTP := c.requestCustomizer(&req, opts, false, messages)
 		if useRawHTTP && customReq != nil {
 			return c.chatWithRawHTTP(timeoutCtx, customEndpoint, customReq)
 		}
@@ -479,14 +479,28 @@ func (c *RemoteAPIChat) chatWithRawHTTP(ctx context.Context, endpoint string, cu
 		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
 	var chatResp openai.ChatCompletionResponse
-	if err := json.NewDecoder(resp.Body).Decode(&chatResp); err != nil {
+	if err := json.Unmarshal(body, &chatResp); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 
 	result, err := c.parseCompletionResponse(&chatResp)
 	if err != nil {
 		return nil, err
+	}
+	var rawResp struct {
+		Choices []struct {
+			Message struct {
+				ToolCalls []toolCallWithExtraContent `json:"tool_calls,omitempty"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &rawResp); err == nil && len(rawResp.Choices) > 0 {
+		applyToolCallExtraContent(result.ToolCalls, rawResp.Choices[0].Message.ToolCalls)
 	}
 	logger.Infof(ctx, "[LLM Usage] model=%s, prompt_tokens=%d, completion_tokens=%d, total_tokens=%d, cached_tokens=%d",
 		c.modelName, result.Usage.PromptTokens, result.Usage.CompletionTokens, result.Usage.TotalTokens, result.Usage.CachedTokens)
@@ -570,7 +584,7 @@ func (c *RemoteAPIChat) ChatStream(ctx context.Context, messages []Message, opts
 
 	// 检查是否需要自定义请求
 	if c.requestCustomizer != nil {
-		customReq, useRawHTTP := c.requestCustomizer(&req, opts, true)
+		customReq, useRawHTTP := c.requestCustomizer(&req, opts, true, messages)
 		if useRawHTTP && customReq != nil {
 			ch, err := c.chatStreamWithRawHTTP(timeoutCtx, customEndpoint, customReq)
 			return wrapStreamCancel(ch, err, cancel)
@@ -729,7 +743,7 @@ func (c *RemoteAPIChat) processStream(ctx context.Context, stream *openai.ChatCo
 		}
 
 		if len(response.Choices) > 0 {
-			c.processStreamDelta(ctx, &response.Choices[0], state, streamChan, response.Choices[0].Delta.ReasoningContent)
+			c.processStreamDelta(ctx, &response.Choices[0], state, streamChan, response.Choices[0].Delta.ReasoningContent, nil)
 		}
 	}
 }
@@ -800,7 +814,8 @@ func (c *RemoteAPIChat) processRawHTTPStream(ctx context.Context, resp *http.Res
 				Index int `json:"index"`
 				Delta struct {
 					openai.ChatCompletionStreamChoiceDelta
-					Reasoning string `json:"reasoning,omitempty"`
+					Reasoning string                     `json:"reasoning,omitempty"`
+					ToolCalls []toolCallWithExtraContent `json:"tool_calls,omitempty"`
 				} `json:"delta"`
 				FinishReason openai.FinishReason `json:"finish_reason"`
 			} `json:"choices"`
@@ -834,7 +849,13 @@ func (c *RemoteAPIChat) processRawHTTPStream(ctx context.Context, resp *http.Res
 				Delta:        choice.Delta.ChatCompletionStreamChoiceDelta,
 				FinishReason: choice.FinishReason,
 			}
-			c.processStreamDelta(ctx, &sdkChoice, state, streamChan, reasoning)
+			if len(choice.Delta.ToolCalls) > 0 {
+				sdkChoice.Delta.ToolCalls = make([]openai.ToolCall, 0, len(choice.Delta.ToolCalls))
+				for _, tc := range choice.Delta.ToolCalls {
+					sdkChoice.Delta.ToolCalls = append(sdkChoice.Delta.ToolCalls, tc.ToolCall)
+				}
+			}
+			c.processStreamDelta(ctx, &sdkChoice, state, streamChan, reasoning, choice.Delta.ToolCalls)
 		}
 	}
 }
@@ -901,7 +922,14 @@ func (s *streamState) buildOrderedToolCalls() []types.LLMToolCall {
 }
 
 // processStreamDelta 处理流式响应的单个 delta
-func (c *RemoteAPIChat) processStreamDelta(ctx context.Context, choice *openai.ChatCompletionStreamChoice, state *streamState, streamChan chan types.StreamResponse, reasoningContent string) {
+func (c *RemoteAPIChat) processStreamDelta(
+	ctx context.Context,
+	choice *openai.ChatCompletionStreamChoice,
+	state *streamState,
+	streamChan chan types.StreamResponse,
+	reasoningContent string,
+	toolCallsWithExtra []toolCallWithExtraContent,
+) {
 	delta := choice.Delta
 	isDone := string(choice.FinishReason) != ""
 
@@ -912,7 +940,7 @@ func (c *RemoteAPIChat) processStreamDelta(ctx context.Context, choice *openai.C
 
 	// 处理 tool calls
 	if len(delta.ToolCalls) > 0 {
-		c.processToolCallsDelta(ctx, delta.ToolCalls, state, streamChan)
+		c.processToolCallsDelta(ctx, delta.ToolCalls, toolCallsWithExtra, state, streamChan)
 	}
 
 	// Earliest reliable "no tool_calls" signal at the OpenAI-protocol level:
@@ -1014,7 +1042,13 @@ func (c *RemoteAPIChat) processStreamDelta(ctx context.Context, choice *openai.C
 }
 
 // processToolCallsDelta 处理 tool calls 的增量更新
-func (c *RemoteAPIChat) processToolCallsDelta(ctx context.Context, toolCalls []openai.ToolCall, state *streamState, streamChan chan types.StreamResponse) {
+func (c *RemoteAPIChat) processToolCallsDelta(
+	ctx context.Context,
+	toolCalls []openai.ToolCall,
+	toolCallsWithExtra []toolCallWithExtraContent,
+	state *streamState,
+	streamChan chan types.StreamResponse,
+) {
 	// Earliest signal at the OpenAI-protocol level that this stream will
 	// produce at least one tool call. Fires *before* the function name has
 	// stabilized, i.e. earlier than the higher-level ResponseTypeToolCall
@@ -1064,6 +1098,12 @@ func (c *RemoteAPIChat) processToolCallsDelta(ctx context.Context, toolCalls []o
 		}
 		if tc.Type != "" {
 			toolCallEntry.Type = string(tc.Type)
+		}
+		for _, rawTC := range toolCallsWithExtra {
+			if sameToolCallDelta(tc, rawTC) && len(rawTC.ExtraContent) > 0 {
+				toolCallEntry.ExtraContent = rawTC.ExtraContent
+				break
+			}
 		}
 		if tc.Function.Name != "" {
 			// 防御性校验：解决部分供应商（如vLLM Ascend等）在每个流 Chunk 中重复发送完整工具名的问题。
@@ -1143,6 +1183,32 @@ func (c *RemoteAPIChat) processToolCallsDelta(ctx context.Context, toolCalls []o
 						"tool_call_id": toolCallEntry.ID,
 					},
 				}
+			}
+		}
+	}
+}
+
+func sameToolCallDelta(tc openai.ToolCall, rawTC toolCallWithExtraContent) bool {
+	if tc.Index != nil || rawTC.Index != nil {
+		if tc.Index == nil || rawTC.Index == nil {
+			return false
+		}
+		return *tc.Index == *rawTC.Index
+	}
+	if tc.ID != "" || rawTC.ID != "" {
+		return tc.ID == rawTC.ID
+	}
+	return tc.Function.Name == rawTC.Function.Name
+}
+
+func applyToolCallExtraContent(toolCalls []types.LLMToolCall, rawToolCalls []toolCallWithExtraContent) {
+	for i := range toolCalls {
+		for j := range rawToolCalls {
+			if j == i || toolCalls[i].ID == rawToolCalls[j].ID {
+				if len(rawToolCalls[j].ExtraContent) > 0 {
+					toolCalls[i].ExtraContent = rawToolCalls[j].ExtraContent
+				}
+				break
 			}
 		}
 	}

--- a/internal/models/chat/remote_api_test.go
+++ b/internal/models/chat/remote_api_test.go
@@ -129,6 +129,62 @@ func TestBuildChatCompletionRequest_MCPToolsFormat(t *testing.T) {
 	}
 }
 
+func TestGeminiRequestCustomizerPreservesToolCallExtraContent(t *testing.T) {
+	chat := newTestRemoteChat(t)
+	extra := json.RawMessage(`{"google":{"thought_signature":"sig-123"}}`)
+	messages := []Message{
+		{Role: "user", Content: "search docs"},
+		{
+			Role:    "assistant",
+			Content: "I will search.",
+			ToolCalls: []ToolCall{{
+				ID:           "call_1",
+				Type:         "function",
+				ExtraContent: extra,
+				Function: FunctionCall{
+					Name:      "knowledge_search",
+					Arguments: `{"query":"docs"}`,
+				},
+			}},
+		},
+	}
+	req := chat.BuildChatCompletionRequest(messages, &ChatOptions{}, true)
+	customReq, useRawHTTP := geminiRequestCustomizer(&req, &ChatOptions{}, true, messages)
+	require.True(t, useRawHTTP)
+
+	payload, err := json.Marshal(customReq)
+	require.NoError(t, err)
+	assert.Contains(t, string(payload), `"thought_signature":"sig-123"`)
+	assert.Contains(t, string(payload), `"extra_content":{"google"`)
+}
+
+func TestRawHTTPStreamPreservesToolCallExtraContent(t *testing.T) {
+	chat := newTestRemoteChat(t)
+	idx := 0
+	extra := json.RawMessage(`{"google":{"thought_signature":"sig-123"}}`)
+	state := newStreamState()
+	streamChan := make(chan types.StreamResponse, 1)
+	toolCalls := []openai.ToolCall{{
+		Index: &idx,
+		ID:    "call_1",
+		Type:  openai.ToolTypeFunction,
+		Function: openai.FunctionCall{
+			Name:      "knowledge_search",
+			Arguments: `{"query":"docs"}`,
+		},
+	}}
+	rawToolCalls := []toolCallWithExtraContent{{
+		ToolCall:     toolCalls[0],
+		ExtraContent: extra,
+	}}
+
+	chat.processToolCallsDelta(context.Background(), toolCalls, rawToolCalls, state, streamChan)
+
+	got := state.buildOrderedToolCalls()
+	require.Len(t, got, 1)
+	assert.JSONEq(t, string(extra), string(got[0].ExtraContent))
+}
+
 // TestBuildChatCompletionRequest_GPT5MaxCompletionTokens 验证 GPT-5 / o-series
 // 模型的 MaxTokens 自动迁移到 MaxCompletionTokens，且采样参数被剔除。
 // 见 issue #1283：Azure OpenAI 的 gpt-5 系列模型不再支持 max_tokens 字段。

--- a/internal/types/agent.go
+++ b/internal/types/agent.go
@@ -176,12 +176,13 @@ type ToolResult struct {
 
 // ToolCall represents a single tool invocation within an agent step
 type ToolCall struct {
-	ID         string                 `json:"id"`                   // Function call ID from LLM
-	Name       string                 `json:"name"`                 // Tool name
-	Args       map[string]interface{} `json:"args"`                 // Tool arguments
-	Result     *ToolResult            `json:"result"`               // Execution result (contains Output)
-	Reflection string                 `json:"reflection,omitempty"` // Agent's reflection on this tool call result (if enabled)
-	Duration   int64                  `json:"duration"`             // Execution time in milliseconds
+	ID           string                 `json:"id"`                   // Function call ID from LLM
+	Name         string                 `json:"name"`                 // Tool name
+	Args         map[string]interface{} `json:"args"`                 // Tool arguments
+	Result       *ToolResult            `json:"result"`               // Execution result (contains Output)
+	Reflection   string                 `json:"reflection,omitempty"` // Agent's reflection on this tool call result (if enabled)
+	Duration     int64                  `json:"duration"`             // Execution time in milliseconds
+	ExtraContent json.RawMessage        `json:"extra_content,omitempty"`
 }
 
 // AgentStep represents one iteration of the ReAct loop

--- a/internal/types/chat.go
+++ b/internal/types/chat.go
@@ -34,9 +34,10 @@ type TokenUsage struct {
 
 // LLMToolCall represents a function/tool call from the LLM
 type LLMToolCall struct {
-	ID       string       `json:"id"`
-	Type     string       `json:"type"` // "function"
-	Function FunctionCall `json:"function"`
+	ID           string          `json:"id"`
+	Type         string          `json:"type"` // "function"
+	Function     FunctionCall    `json:"function"`
+	ExtraContent json.RawMessage `json:"extra_content,omitempty"`
 }
 
 // FunctionCall represents the function details


### PR DESCRIPTION
## Summary
- preserve provider-specific tool-call extra_content through raw Gemini responses
- replay extra_content when rebuilding assistant tool-call messages in the Agent loop/history
- route Gemini through the raw HTTP request path so extra_content.google.thought_signature is emitted back to Gemini

## Root cause
Gemini OpenAI-compatible tool calls can include extra_content.google.thought_signature, and Gemini rejects later tool turns when that signature is missing. The generic go-openai structs drop unknown tool-call fields, so the Agent loop lost the signature before replaying assistant tool calls.

Fixes #527.

## Tests
- CGO_LDFLAGS='-lc++' go test ./internal/models/chat -run 'TestGeminiRequestCustomizerPreservesToolCallExtraContent|TestRawHTTPStreamPreservesToolCallExtraContent' -count=1\n- CGO_LDFLAGS='-lc++' go test ./internal/agent -run TestAppendToolResults_PreservesReasoningContent -count=1\n- CGO_LDFLAGS='-lc++' go test ./internal/application/service -run TestBuildAssistantHistoryMessages_ReplaysReasoningContent -count=1\n- CGO_LDFLAGS='-lc++' go test ./internal/models/chat -count=1\n- CGO_LDFLAGS='-lc++' go test ./internal/agent -count=1\n- CGO_LDFLAGS='-lc++' go test ./internal/application/service -count=1\n- git diff --check\n\nNote: kept as draft because this has not been verified against a live Gemini endpoint.