### PR TITLE
fix: support asymmetric embedding parameters

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -452,3 +452,16 @@ curl --location --request DELETE 'http://localhost:8080/api/v1/models/8fdc464d-8
 | ---------------------- | ---- | ---- | ------------------------------- |
 | dimension              | int  | 否   | 向量维度（如 768、1024）        |
 | truncate_prompt_tokens | int  | 否   | 截断 Token 数（0 表示不截断）   |
+
+### Embedding extra_config
+
+可选字段，用于非对称 embedding 模型区分查询文本和文档文本；未配置时请求体保持默认行为。
+
+| 字段                | 适配器              | 说明 |
+| ------------------- | ------------------- | ---- |
+| query_input_type    | OpenAI 兼容         | 查询向量请求中的 `input_type` |
+| document_input_type | OpenAI 兼容         | 文档向量请求中的 `input_type` |
+| query_task          | Jina                | 查询向量请求中的 `task` |
+| document_task       | Jina                | 文档向量请求中的 `task` |
+| query_task_type     | Jina                | 查询向量请求中的 `task_type` |
+| document_task_type  | Jina                | 文档向量请求中的 `task_type` |

--- a/internal/application/service/knowledgebase_search.go
+++ b/internal/application/service/knowledgebase_search.go
@@ -35,7 +35,7 @@ func (s *knowledgeBaseService) GetQueryEmbedding(ctx context.Context, kbID strin
 		return nil, err
 	}
 
-	return embeddingModel.Embed(ctx, queryText)
+	return embeddingModel.Embed(ctx, queryText, embedding.WithQueryInput())
 }
 
 // ResolveEmbeddingModelKeys resolves embedding model IDs to their actual model
@@ -339,7 +339,7 @@ func (s *knowledgeBaseService) buildRetrievalParams(
 			logger.Infof(ctx, "Embedding model retrieved: %v", embeddingModel)
 
 			logger.Info(ctx, "Starting to generate query embedding")
-			queryEmbedding, err = embeddingModel.Embed(ctx, params.QueryText)
+			queryEmbedding, err = embeddingModel.Embed(ctx, params.QueryText, embedding.WithQueryInput())
 			if err != nil {
 				logger.Errorf(ctx, "Failed to embed query text, query text: %s, error: %v", params.QueryText, err)
 				return nil, err

--- a/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
+++ b/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
@@ -63,7 +63,7 @@ func (v *KeywordsVectorHybridRetrieveEngineService) Index(ctx context.Context,
 	params := make(map[string]any)
 	embeddingMap := make(map[string][]float32)
 	if slices.Contains(retrieverTypes, types.VectorRetrieverType) {
-		embedding, err := embedder.Embed(ctx, indexInfo.Content)
+		embedding, err := embedder.Embed(ctx, indexInfo.Content, embedding.WithDocumentInput())
 		if err != nil {
 			return err
 		}
@@ -87,7 +87,7 @@ func (v *KeywordsVectorHybridRetrieveEngineService) BatchIndex(ctx context.Conte
 		for _, indexInfo := range indexInfoList {
 			contentList = append(contentList, sanitizeForEmbedding(ctx, indexInfo.Content))
 		}
-		embeddings, err := batchEmbedWithBackoff(ctx, embedder, contentList)
+		embeddings, err := batchEmbedWithBackoff(ctx, embedder, contentList, embedding.WithDocumentInput())
 		if err != nil {
 			return err
 		}
@@ -119,14 +119,16 @@ func (v *KeywordsVectorHybridRetrieveEngineService) BatchIndex(ctx context.Conte
 // batchEmbedWithBackoff calls BatchEmbedWithPool with exponential backoff on
 // transient failures (200 / 400 / 800 / 1600 / 3200 ms). It returns the last
 // embedding result on success or the last error if every attempt failed.
-func batchEmbedWithBackoff(ctx context.Context, embedder embedding.Embedder, contentList []string) ([][]float32, error) {
+func batchEmbedWithBackoff(ctx context.Context, embedder embedding.Embedder, contentList []string,
+	opts ...embedding.EmbedOption,
+) ([][]float32, error) {
 	delay := embedRetryBaseDelay
 	var (
 		embeddings [][]float32
 		err        error
 	)
 	for attempt := 0; attempt < embedRetryAttempts; attempt++ {
-		embeddings, err = embedder.BatchEmbedWithPool(ctx, embedder, contentList)
+		embeddings, err = embedder.BatchEmbedWithPool(ctx, embedder, contentList, opts...)
 		if err == nil {
 			return embeddings, nil
 		}

--- a/internal/models/embedding/aliyun.go
+++ b/internal/models/embedding/aliyun.go
@@ -120,9 +120,9 @@ func NewAliyunEmbedder(apiKey, baseURL, modelName string,
 }
 
 // Embed converts text to vector
-func (e *AliyunEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+func (e *AliyunEmbedder) Embed(ctx context.Context, text string, opts ...EmbedOption) ([]float32, error) {
 	for range 3 {
-		embeddings, err := e.BatchEmbed(ctx, []string{text})
+		embeddings, err := e.BatchEmbed(ctx, []string{text}, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -174,7 +174,7 @@ func (e *AliyunEmbedder) doRequestWithRetry(ctx context.Context, jsonData []byte
 	return nil, err
 }
 
-func (e *AliyunEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+func (e *AliyunEmbedder) BatchEmbed(ctx context.Context, texts []string, _ ...EmbedOption) ([][]float32, error) {
 	// Build contents array from texts
 	contents := make([]AliyunContent, 0, len(texts))
 	for _, text := range texts {

--- a/internal/models/embedding/azure_openai.go
+++ b/internal/models/embedding/azure_openai.go
@@ -73,9 +73,9 @@ func NewAzureOpenAIEmbedder(apiKey, baseURL, modelName string,
 	}, nil
 }
 
-func (e *AzureOpenAIEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+func (e *AzureOpenAIEmbedder) Embed(ctx context.Context, text string, opts ...EmbedOption) ([]float32, error) {
 	for range 3 {
-		embeddings, err := e.BatchEmbed(ctx, []string{text})
+		embeddings, err := e.BatchEmbed(ctx, []string{text}, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -86,7 +86,7 @@ func (e *AzureOpenAIEmbedder) Embed(ctx context.Context, text string) ([]float32
 	return nil, fmt.Errorf("no embedding returned")
 }
 
-func (e *AzureOpenAIEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+func (e *AzureOpenAIEmbedder) BatchEmbed(ctx context.Context, texts []string, _ ...EmbedOption) ([][]float32, error) {
 	reqBody := azureOpenAIEmbedRequest{
 		Model:          e.modelName,
 		Input:          texts,

--- a/internal/models/embedding/batch.go
+++ b/internal/models/embedding/batch.go
@@ -23,7 +23,9 @@ type textEmbedding struct {
 	results []float32
 }
 
-func (e *batchEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string) ([][]float32, error) {
+func (e *batchEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string,
+	opts ...EmbedOption,
+) ([][]float32, error) {
 	// Create goroutine pool for concurrent processing of document chunks
 	var wg sync.WaitGroup
 	var mu sync.Mutex  // For synchronizing access to error
@@ -51,7 +53,7 @@ func (e *batchEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, 
 			// Embed text
 			embedding, err := model.BatchEmbed(ctx, utils.MapSlice(texts, func(text *textEmbedding) string {
 				return text.text
-			}))
+			}), opts...)
 			if err != nil {
 				mu.Lock()
 				if firstErr == nil {

--- a/internal/models/embedding/config_from_model_test.go
+++ b/internal/models/embedding/config_from_model_test.go
@@ -41,3 +41,47 @@ func TestConfigFromModel(t *testing.T) {
 		t.Errorf("cloud creds mismatch: %+v", cfg)
 	}
 }
+
+func TestNewEmbedderAppliesAsymmetricExtraConfig(t *testing.T) {
+	openAIEmbedder, err := NewEmbedder(Config{
+		Source:    types.ModelSourceRemote,
+		BaseURL:   "https://api.example.com/v1",
+		ModelName: "text-embedding",
+		Provider:  "generic",
+		ExtraConfig: map[string]string{
+			"query_input_type":    "query",
+			"document_input_type": "passage",
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("NewEmbedder returned error: %v", err)
+	}
+	openAI, ok := openAIEmbedder.(*OpenAIEmbedder)
+	if !ok {
+		t.Fatalf("embedder type = %T, want *OpenAIEmbedder", openAIEmbedder)
+	}
+	if openAI.queryInputType != "query" || openAI.documentInputType != "passage" {
+		t.Fatalf("OpenAI asymmetric config = %q/%q", openAI.queryInputType, openAI.documentInputType)
+	}
+
+	jinaEmbedder, err := NewEmbedder(Config{
+		Source:    types.ModelSourceRemote,
+		BaseURL:   "https://api.jina.ai/v1",
+		ModelName: "jina-embeddings-v5-text-small-retrieval",
+		Provider:  "jina",
+		ExtraConfig: map[string]string{
+			"query_task":    "retrieval.query",
+			"document_task": "retrieval.passage",
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("NewEmbedder returned error: %v", err)
+	}
+	jina, ok := jinaEmbedder.(*JinaEmbedder)
+	if !ok {
+		t.Fatalf("embedder type = %T, want *JinaEmbedder", jinaEmbedder)
+	}
+	if jina.queryTask != "retrieval.query" || jina.documentTask != "retrieval.passage" {
+		t.Fatalf("Jina asymmetric config = %q/%q", jina.queryTask, jina.documentTask)
+	}
+}

--- a/internal/models/embedding/embedder.go
+++ b/internal/models/embedding/embedder.go
@@ -15,10 +15,10 @@ import (
 // Embedder defines the interface for text vectorization
 type Embedder interface {
 	// Embed converts text to vector
-	Embed(ctx context.Context, text string) ([]float32, error)
+	Embed(ctx context.Context, text string, opts ...EmbedOption) ([]float32, error)
 
 	// BatchEmbed converts multiple texts to vectors in batch
-	BatchEmbed(ctx context.Context, texts []string) ([][]float32, error)
+	BatchEmbed(ctx context.Context, texts []string, opts ...EmbedOption) ([][]float32, error)
 
 	// GetModelName returns the model name
 	GetModelName() string
@@ -33,7 +33,46 @@ type Embedder interface {
 }
 
 type EmbedderPooler interface {
-	BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string) ([][]float32, error)
+	BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string, opts ...EmbedOption) ([][]float32, error)
+}
+
+type embedInputRole int
+
+const (
+	embedInputUnspecified embedInputRole = iota
+	embedInputQuery
+	embedInputDocument
+)
+
+type embedOptions struct {
+	role embedInputRole
+}
+
+// EmbedOption customizes a single embedding request without changing default behavior.
+type EmbedOption func(*embedOptions)
+
+// WithQueryInput marks the input as a retrieval query for asymmetric embedding models.
+func WithQueryInput() EmbedOption {
+	return func(opts *embedOptions) {
+		opts.role = embedInputQuery
+	}
+}
+
+// WithDocumentInput marks the input as document/passage content for asymmetric embedding models.
+func WithDocumentInput() EmbedOption {
+	return func(opts *embedOptions) {
+		opts.role = embedInputDocument
+	}
+}
+
+func resolveEmbedOptions(opts []EmbedOption) embedOptions {
+	cfg := embedOptions{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return cfg
 }
 
 // EmbedderType represents the embedder type
@@ -154,6 +193,7 @@ func newEmbedder(config Config, pooler EmbedderPooler, ollamaService *ollama.Oll
 					pooler)
 				if openaiEmb != nil {
 					openaiEmb.SetCustomHeaders(config.CustomHeaders)
+					applyOpenAIAsymmetricConfig(openaiEmb, config.ExtraConfig)
 				}
 				embedder, err = openaiEmb, oErr
 			}
@@ -183,6 +223,7 @@ func newEmbedder(config Config, pooler EmbedderPooler, ollamaService *ollama.Oll
 				pooler)
 			if jinaEmb != nil {
 				jinaEmb.SetCustomHeaders(config.CustomHeaders)
+				applyJinaAsymmetricConfig(jinaEmb, config.ExtraConfig)
 			}
 			embedder, err = jinaEmb, jErr
 			return embedder, err
@@ -245,6 +286,7 @@ func newEmbedder(config Config, pooler EmbedderPooler, ollamaService *ollama.Oll
 				pooler)
 			if openaiEmb != nil {
 				openaiEmb.SetCustomHeaders(config.CustomHeaders)
+				applyOpenAIAsymmetricConfig(openaiEmb, config.ExtraConfig)
 			}
 			embedder, err = openaiEmb, oErr
 			return embedder, err
@@ -252,4 +294,35 @@ func newEmbedder(config Config, pooler EmbedderPooler, ollamaService *ollama.Oll
 	default:
 		return nil, fmt.Errorf("unsupported embedder source: %s", config.Source)
 	}
+}
+
+func applyOpenAIAsymmetricConfig(embedder *OpenAIEmbedder, extra map[string]string) {
+	if embedder == nil || extra == nil {
+		return
+	}
+	embedder.SetAsymmetricInputTypes(
+		firstExtra(extra, "query_input_type"),
+		firstExtra(extra, "document_input_type"),
+	)
+}
+
+func applyJinaAsymmetricConfig(embedder *JinaEmbedder, extra map[string]string) {
+	if embedder == nil || extra == nil {
+		return
+	}
+	embedder.SetAsymmetricTasks(
+		firstExtra(extra, "query_task"),
+		firstExtra(extra, "document_task"),
+		firstExtra(extra, "query_task_type"),
+		firstExtra(extra, "document_task_type"),
+	)
+}
+
+func firstExtra(extra map[string]string, keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(extra[key]); value != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/internal/models/embedding/jina.go
+++ b/internal/models/embedding/jina.go
@@ -16,21 +16,33 @@ import (
 // JinaEmbedder implements text vectorization functionality using Jina AI API
 // Jina API is mostly OpenAI-compatible but does NOT support truncate_prompt_tokens
 type JinaEmbedder struct {
-	apiKey        string
-	baseURL       string
-	modelName     string
-	dimensions    int
-	modelID       string
-	httpClient    *http.Client
-	timeout       time.Duration
-	maxRetries    int
-	customHeaders map[string]string
+	apiKey           string
+	baseURL          string
+	modelName        string
+	dimensions       int
+	modelID          string
+	httpClient       *http.Client
+	timeout          time.Duration
+	maxRetries       int
+	customHeaders    map[string]string
+	queryTask        string
+	documentTask     string
+	queryTaskType    string
+	documentTaskType string
 	EmbedderPooler
 }
 
 // SetCustomHeaders 设置用户自定义 HTTP 请求头（类似 OpenAI Python SDK 的 extra_headers）。
 func (e *JinaEmbedder) SetCustomHeaders(headers map[string]string) {
 	e.customHeaders = headers
+}
+
+// SetAsymmetricTasks configures optional task/task_type values for retrieval models.
+func (e *JinaEmbedder) SetAsymmetricTasks(queryTask, documentTask, queryTaskType, documentTaskType string) {
+	e.queryTask = queryTask
+	e.documentTask = documentTask
+	e.queryTaskType = queryTaskType
+	e.documentTaskType = documentTaskType
 }
 
 // JinaEmbedRequest represents a Jina embedding request
@@ -40,6 +52,8 @@ type JinaEmbedRequest struct {
 	Input      []string `json:"input"`
 	Truncate   bool     `json:"truncate,omitempty"`   // Whether to truncate text exceeding max token length
 	Dimensions int      `json:"dimensions,omitempty"` // Output embedding dimensions (for models that support it)
+	Task       string   `json:"task,omitempty"`
+	TaskType   string   `json:"task_type,omitempty"`
 }
 
 // JinaEmbedResponse represents a Jina embedding response
@@ -83,9 +97,9 @@ func NewJinaEmbedder(apiKey, baseURL, modelName string,
 }
 
 // Embed converts text to vector
-func (e *JinaEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+func (e *JinaEmbedder) Embed(ctx context.Context, text string, opts ...EmbedOption) ([]float32, error) {
 	for range 3 {
-		embeddings, err := e.BatchEmbed(ctx, []string{text})
+		embeddings, err := e.BatchEmbed(ctx, []string{text}, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -138,13 +152,16 @@ func (e *JinaEmbedder) doRequestWithRetry(ctx context.Context, jsonData []byte) 
 	return nil, err
 }
 
-func (e *JinaEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+func (e *JinaEmbedder) BatchEmbed(ctx context.Context, texts []string, opts ...EmbedOption) ([][]float32, error) {
 	// Create request body - Jina uses 'truncate' boolean instead of 'truncate_prompt_tokens'
 	reqBody := JinaEmbedRequest{
 		Model:    e.modelName,
 		Input:    texts,
 		Truncate: true, // Enable truncation for long texts
 	}
+	task, taskType := e.taskForOptions(opts)
+	reqBody.Task = task
+	reqBody.TaskType = taskType
 
 	// Only include dimensions if specified and greater than 0
 	if e.dimensions > 0 {
@@ -193,6 +210,17 @@ func (e *JinaEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]floa
 	}
 
 	return embeddings, nil
+}
+
+func (e *JinaEmbedder) taskForOptions(opts []EmbedOption) (string, string) {
+	switch resolveEmbedOptions(opts).role {
+	case embedInputQuery:
+		return e.queryTask, e.queryTaskType
+	case embedInputDocument:
+		return e.documentTask, e.documentTaskType
+	default:
+		return "", ""
+	}
 }
 
 // GetModelName returns the model name

--- a/internal/models/embedding/jina_test.go
+++ b/internal/models/embedding/jina_test.go
@@ -1,0 +1,46 @@
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestJinaEmbedderBatchEmbedSendsConfiguredTaskByRole(t *testing.T) {
+	var seen []string
+	transport := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if task, ok := payload["task"].(string); ok {
+			seen = append(seen, task)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"data":[{"embedding":[1,2,3],"index":0}]}`)),
+		}, nil
+	})
+
+	embedder, err := NewJinaEmbedder("key", "https://api.jina.ai/v1", "jina-embeddings-v5-text-small-retrieval", 0, 3, "model-id", nil)
+	if err != nil {
+		t.Fatalf("NewJinaEmbedder returned error: %v", err)
+	}
+	embedder.httpClient = &http.Client{Transport: transport}
+	embedder.SetAsymmetricTasks("retrieval.query", "retrieval.passage", "", "")
+
+	if _, err := embedder.BatchEmbed(context.Background(), []string{"hello"}, WithQueryInput()); err != nil {
+		t.Fatalf("query BatchEmbed returned error: %v", err)
+	}
+	if _, err := embedder.BatchEmbed(context.Background(), []string{"world"}, WithDocumentInput()); err != nil {
+		t.Fatalf("document BatchEmbed returned error: %v", err)
+	}
+
+	if len(seen) != 2 || seen[0] != "retrieval.query" || seen[1] != "retrieval.passage" {
+		t.Fatalf("task values = %#v, want [retrieval.query retrieval.passage]", seen)
+	}
+}

--- a/internal/models/embedding/langfuse_wrapper.go
+++ b/internal/models/embedding/langfuse_wrapper.go
@@ -14,10 +14,10 @@ type langfuseEmbedder struct {
 	inner Embedder
 }
 
-func (l *langfuseEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+func (l *langfuseEmbedder) Embed(ctx context.Context, text string, opts ...EmbedOption) ([]float32, error) {
 	mgr := langfuse.GetManager()
 	if !mgr.Enabled() {
-		return l.inner.Embed(ctx, text)
+		return l.inner.Embed(ctx, text, opts...)
 	}
 	genCtx, gen := mgr.StartGeneration(ctx, langfuse.GenerationOptions{
 		Name:  "embedding.embed",
@@ -28,7 +28,7 @@ func (l *langfuseEmbedder) Embed(ctx context.Context, text string) ([]float32, e
 			"dimensions": l.inner.GetDimensions(),
 		},
 	})
-	result, err := l.inner.Embed(genCtx, text)
+	result, err := l.inner.Embed(genCtx, text, opts...)
 	usage := approxEmbeddingUsage([]string{text})
 	var out interface{}
 	if len(result) > 0 {
@@ -41,10 +41,10 @@ func (l *langfuseEmbedder) Embed(ctx context.Context, text string) ([]float32, e
 	return result, err
 }
 
-func (l *langfuseEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+func (l *langfuseEmbedder) BatchEmbed(ctx context.Context, texts []string, opts ...EmbedOption) ([][]float32, error) {
 	mgr := langfuse.GetManager()
 	if !mgr.Enabled() {
-		return l.inner.BatchEmbed(ctx, texts)
+		return l.inner.BatchEmbed(ctx, texts, opts...)
 	}
 	genCtx, gen := mgr.StartGeneration(ctx, langfuse.GenerationOptions{
 		Name:  "embedding.batch_embed",
@@ -61,7 +61,7 @@ func (l *langfuseEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]
 			"batch_size": len(texts),
 		},
 	})
-	result, err := l.inner.BatchEmbed(genCtx, texts)
+	result, err := l.inner.BatchEmbed(genCtx, texts, opts...)
 	usage := approxEmbeddingUsage(texts)
 	var out interface{}
 	if len(result) > 0 {
@@ -74,8 +74,10 @@ func (l *langfuseEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]
 	return result, err
 }
 
-func (l *langfuseEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string) ([][]float32, error) {
-	return l.inner.BatchEmbedWithPool(ctx, l, texts)
+func (l *langfuseEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string,
+	opts ...EmbedOption,
+) ([][]float32, error) {
+	return l.inner.BatchEmbedWithPool(ctx, l, texts, opts...)
 }
 
 func (l *langfuseEmbedder) GetModelName() string { return l.inner.GetModelName() }

--- a/internal/models/embedding/llm_debug.go
+++ b/internal/models/embedding/llm_debug.go
@@ -14,27 +14,29 @@ type debugEmbedder struct {
 	inner Embedder
 }
 
-func (d *debugEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+func (d *debugEmbedder) Embed(ctx context.Context, text string, opts ...EmbedOption) ([]float32, error) {
 	start := time.Now()
-	result, err := d.inner.Embed(ctx, text)
+	result, err := d.inner.Embed(ctx, text, opts...)
 	logEmbeddingDebug(ctx, d.inner.GetModelName(), []string{text}, singleToDouble(result), err, time.Since(start))
 	return result, err
 }
 
-func (d *debugEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+func (d *debugEmbedder) BatchEmbed(ctx context.Context, texts []string, opts ...EmbedOption) ([][]float32, error) {
 	start := time.Now()
-	result, err := d.inner.BatchEmbed(ctx, texts)
+	result, err := d.inner.BatchEmbed(ctx, texts, opts...)
 	logEmbeddingDebug(ctx, d.inner.GetModelName(), texts, result, err, time.Since(start))
 	return result, err
 }
 
-func (d *debugEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string) ([][]float32, error) {
-	return d.inner.BatchEmbedWithPool(ctx, d, texts)
+func (d *debugEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string,
+	opts ...EmbedOption,
+) ([][]float32, error) {
+	return d.inner.BatchEmbedWithPool(ctx, d, texts, opts...)
 }
 
-func (d *debugEmbedder) GetModelName() string  { return d.inner.GetModelName() }
-func (d *debugEmbedder) GetDimensions() int    { return d.inner.GetDimensions() }
-func (d *debugEmbedder) GetModelID() string    { return d.inner.GetModelID() }
+func (d *debugEmbedder) GetModelName() string { return d.inner.GetModelName() }
+func (d *debugEmbedder) GetDimensions() int   { return d.inner.GetDimensions() }
+func (d *debugEmbedder) GetModelID() string   { return d.inner.GetModelID() }
 
 func singleToDouble(v []float32) [][]float32 {
 	if v == nil {

--- a/internal/models/embedding/nvidia.go
+++ b/internal/models/embedding/nvidia.go
@@ -83,9 +83,9 @@ func NewNvidiaEmbedder(apiKey, baseURL, modelName string,
 }
 
 // Embed converts text to vector
-func (e *NvidiaEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+func (e *NvidiaEmbedder) Embed(ctx context.Context, text string, opts ...EmbedOption) ([]float32, error) {
 	for range 3 {
-		embeddings, err := e.BatchEmbed(ctx, []string{text})
+		embeddings, err := e.BatchEmbed(ctx, []string{text}, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -138,7 +138,7 @@ func (e *NvidiaEmbedder) doRequestWithRetry(ctx context.Context, jsonData []byte
 	return nil, err
 }
 
-func (e *NvidiaEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+func (e *NvidiaEmbedder) BatchEmbed(ctx context.Context, texts []string, _ ...EmbedOption) ([][]float32, error) {
 	// Create request body
 	reqBody := NvidiaEmbedRequest{
 		Model:          e.modelName,

--- a/internal/models/embedding/ollama.go
+++ b/internal/models/embedding/ollama.go
@@ -66,8 +66,8 @@ func (e *OllamaEmbedder) ensureModelAvailable(ctx context.Context) error {
 }
 
 // Embed converts text to vector
-func (e *OllamaEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
-	embedding, err := e.BatchEmbed(ctx, []string{text})
+func (e *OllamaEmbedder) Embed(ctx context.Context, text string, opts ...EmbedOption) ([]float32, error) {
+	embedding, err := e.BatchEmbed(ctx, []string{text}, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to embed text: %w", err)
 	}
@@ -80,7 +80,7 @@ func (e *OllamaEmbedder) Embed(ctx context.Context, text string) ([]float32, err
 }
 
 // BatchEmbed converts multiple texts to vectors in batch
-func (e *OllamaEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+func (e *OllamaEmbedder) BatchEmbed(ctx context.Context, texts []string, _ ...EmbedOption) ([][]float32, error) {
 	// Ensure model is available
 	if err := e.ensureModelAvailable(ctx); err != nil {
 		return nil, err

--- a/internal/models/embedding/openai.go
+++ b/internal/models/embedding/openai.go
@@ -25,6 +25,8 @@ type OpenAIEmbedder struct {
 	timeout              time.Duration
 	maxRetries           int
 	customHeaders        map[string]string
+	queryInputType       string
+	documentInputType    string
 	EmbedderPooler
 }
 
@@ -34,6 +36,7 @@ type OpenAIEmbedRequest struct {
 	Input                []string `json:"input"`
 	EncodingFormat       string   `json:"encoding_format,omitempty"`
 	TruncatePromptTokens int      `json:"truncate_prompt_tokens,omitempty"`
+	InputType            string   `json:"input_type,omitempty"`
 }
 
 // OpenAIEmbedResponse represents an OpenAI embedding response
@@ -87,10 +90,16 @@ func (e *OpenAIEmbedder) SetCustomHeaders(headers map[string]string) {
 	e.customHeaders = headers
 }
 
+// SetAsymmetricInputTypes configures optional provider-specific input_type values.
+func (e *OpenAIEmbedder) SetAsymmetricInputTypes(queryInputType, documentInputType string) {
+	e.queryInputType = queryInputType
+	e.documentInputType = documentInputType
+}
+
 // Embed converts text to vector
-func (e *OpenAIEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+func (e *OpenAIEmbedder) Embed(ctx context.Context, text string, opts ...EmbedOption) ([]float32, error) {
 	for range 3 {
-		embeddings, err := e.BatchEmbed(ctx, []string{text})
+		embeddings, err := e.BatchEmbed(ctx, []string{text}, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -155,13 +164,16 @@ func (e *OpenAIEmbedder) doRequestWithRetry(ctx context.Context, jsonData []byte
 	return nil, err
 }
 
-func (e *OpenAIEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+func (e *OpenAIEmbedder) BatchEmbed(ctx context.Context, texts []string, opts ...EmbedOption) ([][]float32, error) {
 	// Create request body
 	reqBody := OpenAIEmbedRequest{
 		Model:                e.modelName,
 		Input:                texts,
 		EncodingFormat:       "float",
 		TruncatePromptTokens: e.truncatePromptTokens,
+	}
+	if inputType := e.inputTypeForOptions(opts); inputType != "" {
+		reqBody.InputType = inputType
 	}
 
 	jsonData, err := json.Marshal(reqBody)
@@ -239,6 +251,17 @@ func (e *OpenAIEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]fl
 	}
 
 	return embeddings, nil
+}
+
+func (e *OpenAIEmbedder) inputTypeForOptions(opts []EmbedOption) string {
+	switch resolveEmbedOptions(opts).role {
+	case embedInputQuery:
+		return e.queryInputType
+	case embedInputDocument:
+		return e.documentInputType
+	default:
+		return ""
+	}
 }
 
 // GetModelName returns the model name

--- a/internal/models/embedding/openai_test.go
+++ b/internal/models/embedding/openai_test.go
@@ -1,0 +1,46 @@
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestOpenAIEmbedderBatchEmbedSendsConfiguredInputTypeByRole(t *testing.T) {
+	var seen []string
+	transport := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if inputType, ok := payload["input_type"].(string); ok {
+			seen = append(seen, inputType)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"data":[{"embedding":[1,2,3],"index":0}]}`)),
+		}, nil
+	})
+
+	embedder, err := NewOpenAIEmbedder("key", "https://example.com/v1", "text-embedding", 128, 3, "model-id", nil)
+	if err != nil {
+		t.Fatalf("NewOpenAIEmbedder returned error: %v", err)
+	}
+	embedder.httpClient = &http.Client{Transport: transport}
+	embedder.SetAsymmetricInputTypes("query", "passage")
+
+	if _, err := embedder.BatchEmbed(context.Background(), []string{"hello"}, WithQueryInput()); err != nil {
+		t.Fatalf("query BatchEmbed returned error: %v", err)
+	}
+	if _, err := embedder.BatchEmbed(context.Background(), []string{"world"}, WithDocumentInput()); err != nil {
+		t.Fatalf("document BatchEmbed returned error: %v", err)
+	}
+
+	if len(seen) != 2 || seen[0] != "query" || seen[1] != "passage" {
+		t.Fatalf("input_type values = %#v, want [query passage]", seen)
+	}
+}

--- a/internal/models/embedding/volcengine.go
+++ b/internal/models/embedding/volcengine.go
@@ -131,9 +131,9 @@ func NewVolcengineEmbedder(apiKey, baseURL, modelName string,
 }
 
 // Embed converts text to vector
-func (e *VolcengineEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+func (e *VolcengineEmbedder) Embed(ctx context.Context, text string, opts ...EmbedOption) ([]float32, error) {
 	for range 3 {
-		embeddings, err := e.BatchEmbed(ctx, []string{text})
+		embeddings, err := e.BatchEmbed(ctx, []string{text}, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -185,7 +185,7 @@ func (e *VolcengineEmbedder) doRequestWithRetry(ctx context.Context, jsonData []
 	return nil, err
 }
 
-func (e *VolcengineEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+func (e *VolcengineEmbedder) BatchEmbed(ctx context.Context, texts []string, _ ...EmbedOption) ([][]float32, error) {
 	embeddings := make([][]float32, len(texts))
 
 	// Volcengine multimodal API returns a single combined embedding for all inputs,

--- a/internal/models/embedding/weknoracloud.go
+++ b/internal/models/embedding/weknoracloud.go
@@ -66,8 +66,8 @@ type weKnoraCloudEmbedResponse struct {
 	} `json:"data"`
 }
 
-func (e *WeKnoraCloudEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
-	results, err := e.BatchEmbed(ctx, []string{text})
+func (e *WeKnoraCloudEmbedder) Embed(ctx context.Context, text string, opts ...EmbedOption) ([]float32, error) {
+	results, err := e.BatchEmbed(ctx, []string{text}, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (e *WeKnoraCloudEmbedder) Embed(ctx context.Context, text string) ([]float3
 	return results[0], nil
 }
 
-func (e *WeKnoraCloudEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+func (e *WeKnoraCloudEmbedder) BatchEmbed(ctx context.Context, texts []string, _ ...EmbedOption) ([][]float32, error) {
 	reqBody := weKnoraCloudEmbedRequest{Model: e.effectiveModelName(), Input: texts}
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
@@ -124,8 +124,10 @@ func (e *WeKnoraCloudEmbedder) BatchEmbed(ctx context.Context, texts []string) (
 	return result, nil
 }
 
-func (e *WeKnoraCloudEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string) ([][]float32, error) {
-	return e.BatchEmbed(ctx, texts)
+func (e *WeKnoraCloudEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string,
+	opts ...EmbedOption,
+) ([][]float32, error) {
+	return e.BatchEmbed(ctx, texts, opts...)
 }
 
 func (e *WeKnoraCloudEmbedder) effectiveModelName() string {

--- a/internal/models/embedding/zhipu.go
+++ b/internal/models/embedding/zhipu.go
@@ -88,9 +88,9 @@ func (e *ZhipuEmbedder) SetCustomHeaders(headers map[string]string) {
 }
 
 // Embed converts text to vector
-func (e *ZhipuEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+func (e *ZhipuEmbedder) Embed(ctx context.Context, text string, opts ...EmbedOption) ([]float32, error) {
 	for range 3 {
-		embeddings, err := e.BatchEmbed(ctx, []string{text})
+		embeddings, err := e.BatchEmbed(ctx, []string{text}, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -143,7 +143,7 @@ func (e *ZhipuEmbedder) doRequestWithRetry(ctx context.Context, jsonData []byte)
 	return nil, err
 }
 
-func (e *ZhipuEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+func (e *ZhipuEmbedder) BatchEmbed(ctx context.Context, texts []string, _ ...EmbedOption) ([][]float32, error) {
 	// Create request body
 	reqBody := ZhipuEmbedRequest{
 		Model:                e.modelName,


### PR DESCRIPTION
## Summary
- add optional embedding request roles so query embeddings and document embeddings can carry different provider parameters
- support OpenAI-compatible `input_type` via `extra_config.query_input_type` / `extra_config.document_input_type`
- support Jina `task` and `task_type` via embedding model `extra_config`, and document the supported keys

Addresses #1401.

## Validation
- `CGO_LDFLAGS='-lc++' go test ./internal/models/embedding`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service/retriever ./internal/application/service`
- `git diff --check`

Note: I validated outgoing request payloads with local HTTP transport tests. I did not call a live Jina or OpenAI-compatible embedding provider.
