### PR TITLE
fix(im,kb): storage URL rewriting and tenant default KB storage

### DIFF
--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
@@ -387,6 +387,7 @@ import { MessagePlugin, DialogPlugin } from 'tdesign-vue-next'
 import { createKnowledgeBase, getKnowledgeBaseById, listKnowledgeFiles, updateKnowledgeBase, rebuildKBIndex } from '@/api/knowledge-base'
 import { updateKBConfig, type KBModelConfigRequest } from '@/api/initialization'
 import { listModels } from '@/api/model'
+import { getStorageEngineConfig } from '@/api/system'
 import { useUIStore } from '@/stores/ui'
 import { useAuthStore } from '@/stores/auth'
 import KBModelConfig from './settings/KBModelConfig.vue'
@@ -449,6 +450,8 @@ const loading = ref(false)
 const allModels = ref<any[]>([])
 const hasFiles = ref(false)
 const initialStorageProvider = ref<string>('')
+/** Tenant-wide default from Settings → Storage engine (used when creating a KB). */
+const tenantDefaultStorageProvider = ref('local')
 const initialIndexingStrategy = ref<any>(null)
 const dsCount = ref(0)
 // Identifier of the user who created this KB. Empty for older rows
@@ -870,8 +873,24 @@ const handleAddWikiModel = () => {
 
 const handleStorageProviderUpdate = (value: string) => {
   if (formData.value) {
-    formData.value.storageProvider = value || 'local'
+    formData.value.storageProvider = value || tenantDefaultStorageProvider.value || 'local'
   }
+}
+
+async function loadTenantDefaultStorageProvider() {
+  try {
+    const res = await getStorageEngineConfig()
+    tenantDefaultStorageProvider.value = res?.data?.default_provider || 'local'
+  } catch {
+    tenantDefaultStorageProvider.value = 'local'
+  }
+}
+
+/** Resolved storage provider for create payload (never silently default to local before tenant config loads). */
+function resolvedStorageProvider(): string {
+  const explicit = formData.value?.storageProvider?.trim()
+  if (explicit) return explicit
+  return tenantDefaultStorageProvider.value || 'local'
 }
 
 const handleVectorStoreIdUpdate = (id: string) => {
@@ -1005,11 +1024,12 @@ const buildSubmitData = () => {
 
   // 存储引擎：仅传 provider，参数从全局设置读取
   // Write to storage_provider_config (authoritative) + storage_config (legacy dual-write)
+  const storageProvider = resolvedStorageProvider()
   data.storage_provider_config = {
-    provider: formData.value.storageProvider || 'local'
+    provider: storageProvider
   }
   data.storage_config = {
-    provider: formData.value.storageProvider || 'local'
+    provider: storageProvider
   }
 
   // 添加知识图谱配置 — now synced via indexingStrategy.graphEnabled
@@ -1258,6 +1278,7 @@ const resetState = () => {
   formData.value = null
   hasFiles.value = false
   initialStorageProvider.value = ''
+  tenantDefaultStorageProvider.value = 'local'
   initialIndexingStrategy.value = null
   saving.value = false
   loading.value = false
@@ -1284,15 +1305,16 @@ watch(() => props.visible, async (newVal) => {
       currentSection.value = uiStore.kbEditorInitialSection
     }
     
-    // 加载模型列表
-    await loadAllModels()
+    // 加载模型列表与租户默认存储引擎（创建 KB 时即使用，不依赖是否打开「存储引擎」Tab）
+    await Promise.all([loadAllModels(), loadTenantDefaultStorageProvider()])
     
     // 根据模式加载数据
     if (props.mode === 'edit' && props.kbId) {
       await loadKBData()
     } else {
-      // 创建模式：初始化空表单
+      // 创建模式：初始化空表单，并预填租户默认存储引擎
       formData.value = initFormData(props.initialType || 'document')
+      formData.value.storageProvider = tenantDefaultStorageProvider.value
       hasFiles.value = false
     }
   } else {

--- a/frontend/src/views/knowledge/settings/KBStorageSettings.vue
+++ b/frontend/src/views/knowledge/settings/KBStorageSettings.vue
@@ -68,7 +68,8 @@ const emit = defineEmits<{
 }>()
 
 const uiStore = useUIStore()
-const localProvider = ref(props.storageProvider || 'local')
+// Keep empty until tenant default_provider is loaded — do not pre-fill 'local'.
+const localProvider = ref(props.storageProvider)
 const loading = ref(true)
 const engineStatus = ref<StorageEngineStatusItem[]>([])
 const defaultProvider = ref('local')
@@ -188,9 +189,12 @@ async function load() {
     defaultProvider.value = configRes?.data?.default_provider || 'local'
     const d = configRes?.data
     hasAnyConfig.value = !!(d?.local?.path_prefix || d?.minio?.bucket_name || d?.cos?.bucket_name || d?.tos?.bucket_name || d?.s3?.bucket_name || d?.oss?.bucket_name || d?.ks3?.bucket_name || d?.obs?.bucket_name)
-    if (!localProvider.value || localProvider.value === '') {
+    const parentUnset = !props.storageProvider
+    if (parentUnset) {
       localProvider.value = defaultProvider.value
       emit('update:storageProvider', localProvider.value)
+    } else {
+      localProvider.value = props.storageProvider
     }
     ensureAllowedProvider()
   } catch {
@@ -200,9 +204,13 @@ async function load() {
   }
 }
 
+// Sync only when parent sets an explicit provider (edit mode). Create mode leaves
+// storageProvider empty until load() applies tenant default_provider.
 watch(() => props.storageProvider, (v) => {
-  localProvider.value = v || defaultProvider.value || 'local'
-}, { immediate: true })
+  if (v) {
+    localProvider.value = v
+  }
+})
 
 onMounted(load)
 </script>

--- a/internal/application/service/file/cos.go
+++ b/internal/application/service/file/cos.go
@@ -123,7 +123,10 @@ func (s *cosFileService) SaveFile(ctx context.Context,
 
 // GetFile retrieves a file from COS storage by its path URL
 func (s *cosFileService) GetFile(ctx context.Context, filePathUrl string) (io.ReadCloser, error) {
-	objectName := s.parseCosObjectName(filePathUrl)
+	objectName, err := s.parseCosObjectName(filePathUrl)
+	if err != nil {
+		return nil, err
+	}
 	if err := utils.SafeObjectKey(objectName); err != nil {
 		return nil, fmt.Errorf("invalid file path: %w", err)
 	}
@@ -136,11 +139,14 @@ func (s *cosFileService) GetFile(ctx context.Context, filePathUrl string) (io.Re
 
 // DeleteFile removes a file from COS storage
 func (s *cosFileService) DeleteFile(ctx context.Context, filePath string) error {
-	objectName := s.parseCosObjectName(filePath)
+	objectName, err := s.parseCosObjectName(filePath)
+	if err != nil {
+		return err
+	}
 	if err := utils.SafeObjectKey(objectName); err != nil {
 		return fmt.Errorf("invalid file path: %w", err)
 	}
-	_, err := s.client.Object.Delete(ctx, objectName)
+	_, err = s.client.Object.Delete(ctx, objectName)
 	if err != nil {
 		return fmt.Errorf("failed to delete file: %w", err)
 	}
@@ -150,18 +156,23 @@ func (s *cosFileService) DeleteFile(ctx context.Context, filePath string) error 
 // parseCosObjectName extracts the object name from:
 // - provider scheme: cos://{bucket}/{region}/{objectKey}
 // - legacy URL: https://bucket.cos.region.myqcloud.com/{objectKey}
-func (s *cosFileService) parseCosObjectName(filePath string) string {
+func (s *cosFileService) parseCosObjectName(filePath string) (string, error) {
+	for _, other := range []string{"local://", "minio://", "s3://", "tos://", "oss://", "ks3://", "obs://"} {
+		if strings.HasPrefix(filePath, other) {
+			return "", fmt.Errorf("cos file service cannot resolve %s path", strings.Split(other, "://")[0])
+		}
+	}
 	// Provider scheme format: cos://{bucket}/{region}/{objectKey}
 	if strings.HasPrefix(filePath, cosScheme) {
 		rest := strings.TrimPrefix(filePath, cosScheme)
 		parts := strings.SplitN(rest, "/", 3)
 		if len(parts) == 3 {
-			return parts[2]
+			return parts[2], nil
 		}
-		return rest
+		return rest, nil
 	}
 	// Legacy format: https://bucket.cos.region.myqcloud.com/{objectKey}
-	return strings.TrimPrefix(filePath, s.bucketURL)
+	return strings.TrimPrefix(filePath, s.bucketURL), nil
 }
 
 // SaveBytes saves bytes data to COS
@@ -212,7 +223,10 @@ func (s *cosFileService) GetFileURL(ctx context.Context, filePath string) (strin
 		return presignedURL.String(), nil
 	}
 
-	objectName := s.parseCosObjectName(filePath)
+	objectName, err := s.parseCosObjectName(filePath)
+	if err != nil {
+		return "", err
+	}
 	if err := utils.SafeObjectKey(objectName); err != nil {
 		return "", fmt.Errorf("invalid file path: %w", err)
 	}

--- a/internal/application/service/file/cos_parse_test.go
+++ b/internal/application/service/file/cos_parse_test.go
@@ -20,3 +20,10 @@ func TestParseCosObjectName_CosScheme(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "weknora/10000/exports/a.png", key)
 }
+
+func TestParseCosObjectName_RejectsMinioScheme(t *testing.T) {
+	svc := &cosFileService{bucketURL: "https://b.cos.ap-shanghai.myqcloud.com/"}
+	_, err := svc.parseCosObjectName("minio://wizard-test/10000/exports/img.png")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "minio")
+}

--- a/internal/application/service/file/cos_parse_test.go
+++ b/internal/application/service/file/cos_parse_test.go
@@ -1,0 +1,22 @@
+package file
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCosObjectName_RejectsLocalScheme(t *testing.T) {
+	svc := &cosFileService{bucketURL: "https://b.cos.ap-shanghai.myqcloud.com/"}
+	_, err := svc.parseCosObjectName("local://10000/exports/img.png")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local")
+}
+
+func TestParseCosObjectName_CosScheme(t *testing.T) {
+	svc := &cosFileService{bucketURL: "https://b.cos.ap-shanghai.myqcloud.com/"}
+	key, err := svc.parseCosObjectName("cos://bucket/ap-shanghai/weknora/10000/exports/a.png")
+	require.NoError(t, err)
+	assert.Equal(t, "weknora/10000/exports/a.png", key)
+}

--- a/internal/application/service/knowledgebase.go
+++ b/internal/application/service/knowledgebase.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
@@ -105,6 +106,7 @@ func (s *knowledgeBaseService) CreateKnowledgeBase(ctx context.Context,
 		kb.CreatorID = uid
 	}
 	kb.EnsureDefaults()
+	applyTenantDefaultStorageProvider(ctx, kb)
 
 	// Fold empty-string vector_store_id into nil so this path and the
 	// retrieve-engine factory's pre-condition share a single representation.
@@ -134,6 +136,23 @@ func (s *knowledgeBaseService) CreateKnowledgeBase(ctx context.Context,
 
 	logger.Infof(ctx, "Knowledge base created successfully, ID: %s, name: %s", kb.ID, kb.Name)
 	return kb, nil
+}
+
+// applyTenantDefaultStorageProvider fills an empty KB storage provider from the
+// tenant's global default (Settings → Storage engine). Frontend should send the
+// same value; this keeps API clients and legacy UIs consistent.
+func applyTenantDefaultStorageProvider(ctx context.Context, kb *types.KnowledgeBase) {
+	if kb == nil || strings.TrimSpace(kb.GetStorageProvider()) != "" {
+		return
+	}
+	tenant, _ := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
+	provider := "local"
+	if tenant != nil && tenant.StorageEngineConfig != nil {
+		if p := strings.ToLower(strings.TrimSpace(tenant.StorageEngineConfig.DefaultProvider)); p != "" {
+			provider = p
+		}
+	}
+	kb.SetStorageProvider(provider)
 }
 
 // validateVectorStoreBinding routes through retriever.VerifyBinding so the

--- a/internal/application/service/knowledgebase_pr3_test.go
+++ b/internal/application/service/knowledgebase_pr3_test.go
@@ -131,6 +131,33 @@ func ctxWithTenant(tenantID uint64) context.Context {
 	return context.WithValue(context.Background(), types.TenantIDContextKey, tenantID)
 }
 
+func ctxWithTenantStorage(tenantID uint64, defaultProvider string) context.Context {
+	ctx := ctxWithTenant(tenantID)
+	tenant := &types.Tenant{
+		ID: tenantID,
+		StorageEngineConfig: &types.StorageEngineConfig{
+			DefaultProvider: defaultProvider,
+		},
+	}
+	return context.WithValue(ctx, types.TenantInfoContextKey, tenant)
+}
+
+func TestCreateKnowledgeBase_DefaultStorageProviderFromTenant(t *testing.T) {
+	repo := newFakeKBRepo()
+	svc := newPR3KBService(repo, &fakeRegistry{registered: map[string]struct{}{}}, &fakeOwnership{})
+
+	kb, err := svc.CreateKnowledgeBase(ctxWithTenantStorage(1, "minio"), &types.KnowledgeBase{Name: "kb"})
+	require.NoError(t, err)
+	assert.Equal(t, "minio", kb.GetStorageProvider())
+
+	kbExplicit, err := svc.CreateKnowledgeBase(ctxWithTenantStorage(1, "minio"), &types.KnowledgeBase{
+		Name:                  "kb2",
+		StorageProviderConfig: &types.StorageProviderConfig{Provider: "cos"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "cos", kbExplicit.GetStorageProvider())
+}
+
 // ---------------------------------------------------------------------------
 // CreateKnowledgeBase — vector_store_id binding validation matrix
 // ---------------------------------------------------------------------------

--- a/internal/im/content_rewrite_test.go
+++ b/internal/im/content_rewrite_test.go
@@ -2,6 +2,7 @@ package im
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -231,6 +232,28 @@ func TestRewriteStorageURLs_COSPathNotSignedAsLocalKey(t *testing.T) {
 	}
 }
 
+func TestFindIncompleteMarkdownImage(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"complete image", "![img](local://1/a.png)", -1},
+		{"complete then text", "![img](local://1/a.png) trailing", -1},
+		{"truncated provider URL in image", `![知识助理"知识库"管理视图界面](minio://wizard-test/10000/exports/c91cf852`, 0},
+		{"open paren only", "text ![alt](", 5},
+		{"bare provider suffix without markdown", "text minio://wizard-test/10000/exp", -1},
+		{"two images complete", "![a](local://1/a.png) ![b](local://1/b.png)", -1},
+		{"first complete second incomplete", "![a](local://1/a.png) ![b](minio://part", 22},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findIncompleteMarkdownImage(tt.in)
+			assert.Equal(t, tt.want, got, "findIncompleteMarkdownImage(%q)", tt.in)
+		})
+	}
+}
+
 func TestHoldbackCutoff(t *testing.T) {
 	tests := []struct {
 		name string
@@ -240,13 +263,17 @@ func TestHoldbackCutoff(t *testing.T) {
 		{
 			"no holdback needed",
 			"plain text with complete ![img](local://1/img.png) content",
-			// URL is terminated by `)` then space → no holdback
-			-1, // placeholder, computed below
+			-1,
 		},
 		{
-			"truncated URL",
+			"truncated URL inside markdown image",
 			"text ![img](local://1/abc/im",
-			12,
+			5, // hold back from ![ — not from local://
+		},
+		{
+			"truncated markdown image with quotes in alt",
+			"### 2\n![知识助理\"知识库\"管理视图界面](minio://wizard-test/10000/exports/c91cf852",
+			-2, // computed via strings.Index below
 		},
 		{
 			"truncated XML",
@@ -254,19 +281,179 @@ func TestHoldbackCutoff(t *testing.T) {
 			5,
 		},
 		{
-			"both truncated, URL earlier",
+			"both truncated, XML earlier",
 			"<image url=\"local://1/im",
-			0, // <image at 0 is earlier than local:// at 12
+			0,
+		},
+		{
+			"bare truncated provider URL without markdown wrapper",
+			"prefix minio://wizard-test/10000/exp",
+			7,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			want := tt.want
+			if want == -2 {
+				want = strings.Index(tt.in, "![知识助理")
+				require.GreaterOrEqual(t, want, 0)
+			}
 			got := holdbackCutoff(tt.in)
-			if tt.want == -1 {
+			if want == -1 {
 				assert.Equal(t, len(tt.in), got, "holdbackCutoff(%q) should be len(in)", tt.in)
 			} else {
-				assert.Equal(t, tt.want, got, "holdbackCutoff(%q)", tt.in)
+				assert.Equal(t, want, got, "holdbackCutoff(%q)", tt.in)
 			}
 		})
 	}
+}
+
+// simulateIMStreamFlushStep mirrors one handleMessageStream flush (see flush() in service.go).
+func simulateIMStreamFlushStep(holdback, incoming string, final bool) (sent, newHoldback string) {
+	chunk := holdback + incoming
+	holdback = ""
+	if chunk == "" {
+		return "", ""
+	}
+	if !final {
+		if cut := holdbackCutoff(chunk); cut < len(chunk) {
+			holdback = chunk[cut:]
+			chunk = chunk[:cut]
+		}
+	}
+	return chunk, holdback
+}
+
+// simulateIMStreamFlush mirrors handleMessageStream's flush/holdback logic (non-final
+// flushes apply holdbackCutoff; final flush sends everything).
+func simulateIMStreamFlush(parts []string) (sent []string, remainder string) {
+	var pending string
+	for i, part := range parts {
+		final := i == len(parts)-1
+		var chunk string
+		chunk, pending = simulateIMStreamFlushStep(pending, part, final)
+		if chunk != "" {
+			sent = append(sent, chunk)
+		}
+	}
+	return sent, pending
+}
+
+// orphanMarkdownImageOpenRe detects a flush chunk that ends with an opened Markdown
+// image (](...) without the URL — the bug we fixed.
+var orphanMarkdownImageOpenRe = regexp.MustCompile(`!\[[^\]]*\]\(\s*$`)
+
+func TestSimulateIMStreamFlush_MiddleImageNotSplit(t *testing.T) {
+	// Reproduces the user report: three images; the middle one was split at minio://.
+	part1 := "### 1️⃣ 智能交互入口\n\n" +
+		"![知识助理AI对话界面](minio://wizard-test/10000/exports/bb524693-a3f7-48bd-88ca-0c3957cb56e7.png)\n\n" +
+		"### 2️⃣ 知识管理\n- 支持创建\n\n"
+	part2 := `![知识助理"知识库"管理视图界面](minio://wizard-test/10000/exports/c91cf852`
+	part3 := `-9c72-f549da25619a.png)\n\n### 3️⃣ API\n\n` +
+		"![API](minio://wizard-test/10000/exports/a0423e91-95c9-46bf-ab4c-9586b43d0a61.png)\n"
+
+	sent, remainder := simulateIMStreamFlush([]string{part1, part2, part3})
+	require.Empty(t, remainder, "final flush should drain holdback")
+
+	for i, chunk := range sent {
+		assert.False(t, orphanMarkdownImageOpenRe.MatchString(chunk),
+			"chunk %d must not end with orphan ![alt]( : %q", i, chunk)
+	}
+
+	joined := strings.Join(sent, "")
+	assert.Contains(t, joined, "bb524693-a3f7-48bd-88ca-0c3957cb56e7.png)")
+	assert.Contains(t, joined, "c91cf852-9c72-f549da25619a.png)")
+	assert.Contains(t, joined, "a0423e91-95c9-46bf-ab4c-9586b43d0a61.png)")
+
+	// Middle image must appear intact in some single sent chunk (after merge for assertion).
+	middleImg := `![知识助理"知识库"管理视图界面](minio://wizard-test/10000/exports/c91cf852-9c72-f549da25619a.png)`
+	assert.Contains(t, joined, middleImg)
+
+	foundMiddleIntact := false
+	for _, chunk := range sent {
+		if strings.Contains(chunk, middleImg) {
+			foundMiddleIntact = true
+			break
+		}
+	}
+	assert.True(t, foundMiddleIntact, "middle markdown image should ship in one chunk, got %d chunks", len(sent))
+}
+
+func TestSimulateIMStreamFlush_FirstChunkHoldsMiddleImagePrefix(t *testing.T) {
+	part1 := "### 1\n![ok](minio://wizard-test/10000/exports/ok.png)\n\n### 2\n"
+	part2 := `![知识助理"知识库"管理视图界面](minio://wizard-test/10000/exports/c91cf852`
+
+	s1, hb1 := simulateIMStreamFlushStep("", part1, false)
+	assert.Equal(t, part1, s1)
+	assert.Empty(t, hb1)
+
+	s2, hb2 := simulateIMStreamFlushStep(hb1, part2, false)
+	assert.Empty(t, s2, "incomplete middle image must not be sent on non-final flush")
+	require.NotEmpty(t, hb2)
+	assert.True(t, strings.HasPrefix(hb2, "![知识助理"),
+		"holdback should include full markdown image prefix, got %q", hb2)
+	assert.False(t, orphanMarkdownImageOpenRe.MatchString(s1))
+}
+
+func TestSimulateIMStreamFlush_CompleteImageInOnePart(t *testing.T) {
+	one := `![x](minio://wizard-test/10000/exports/uuid.png) tail`
+	sent, rem := simulateIMStreamFlush([]string{one})
+	require.Empty(t, rem)
+	require.Len(t, sent, 1)
+	assert.Equal(t, one, sent[0])
+}
+
+func TestSimulateIMStreamFlush_BareProviderURLStillHeld(t *testing.T) {
+	s1, hb1 := simulateIMStreamFlushStep("", "intro ", false)
+	assert.Equal(t, "intro ", s1)
+
+	s2, hb2 := simulateIMStreamFlushStep(hb1, "minio://wizard-test/10000/exp", false)
+	assert.Empty(t, s2)
+	require.NotEmpty(t, hb2)
+	assert.True(t, strings.HasPrefix(hb2, "minio://wizard-test/10000/exp"))
+}
+
+func TestCleanIMContent_AfterStreamReassembly(t *testing.T) {
+	t.Setenv("SYSTEM_AES_KEY", "weknora-test-aes-key-32bytes!!!")
+	t.Setenv("APP_EXTERNAL_URL", "https://weknora.example.com")
+
+	tenant := &types.Tenant{
+		StorageEngineConfig: &types.StorageEngineConfig{
+			DefaultProvider: "cos",
+			COS: &types.COSEngineConfig{
+				SecretID:   "id",
+				SecretKey:  "key",
+				BucketName: "bucket",
+				Region:     "ap-shanghai",
+			},
+		},
+	}
+
+	parts := []string{
+		`![知识助理"知识库"管理视图界面](local://10000/exports/c91cf852`,
+		`-9c72-f549da25619a.png)`,
+	}
+	sent, rem := simulateIMStreamFlush(parts)
+	require.Empty(t, rem)
+	joined := strings.Join(sent, "")
+	out := cleanIMContent(context.Background(), joined, tenant)
+	assert.Contains(t, out, "/api/v1/files/presigned")
+	assert.NotContains(t, out, "local://10000")
+}
+
+func TestRewriteStorageURLs_MultipleImagesInOneChunk(t *testing.T) {
+	t.Setenv("SYSTEM_AES_KEY", "weknora-test-aes-key-32bytes!!!")
+	t.Setenv("APP_EXTERNAL_URL", "https://weknora.example.com")
+
+	tenant := &types.Tenant{
+		StorageEngineConfig: &types.StorageEngineConfig{DefaultProvider: "cos"},
+	}
+
+	doc := "### 1\n\n![a](local://10000/exports/bb524693.png)\n\n### 2\n\n" +
+		`![知识助理"知识库"管理视图界面](local://10000/exports/c91cf852.png)` + "\n\n### 3\n\n" +
+		"![c](local://10000/exports/a0423e91.png)\n"
+
+	out := rewriteStorageURLs(context.Background(), doc, tenant)
+	assert.NotContains(t, out, "local://")
+	assert.Equal(t, 3, strings.Count(out, "/api/v1/files/presigned"))
 }

--- a/internal/im/content_rewrite_test.go
+++ b/internal/im/content_rewrite_test.go
@@ -177,7 +177,7 @@ func TestResolveIMFileServiceForPath_LocalSchemeDespiteCOSDefault(t *testing.T) 
 			},
 		},
 	}
-	svc := resolveIMFileServiceForPath(tenant, "local://10000/exports/img.png")
+	svc := resolveIMFileServiceForPath(tenant, "local://10000/exports/img.png", nil)
 	require.NotNil(t, svc)
 	got, err := svc.GetFileURL(context.Background(), "local://10000/exports/img.png")
 	require.NoError(t, err)
@@ -201,7 +201,7 @@ func TestRewriteStorageURLs_LocalUsesPresignedAPI(t *testing.T) {
 	}
 
 	in := "![img](local://10000/exports/abc.png)"
-	out := rewriteStorageURLs(context.Background(), in, tenant)
+	out := rewriteStorageURLs(context.Background(), in, newIMFileServiceResolver(tenant, nil))
 	assert.Contains(t, out, "/api/v1/files/presigned")
 	assert.NotContains(t, out, "myqcloud.com")
 }
@@ -222,11 +222,11 @@ func TestRewriteStorageURLs_COSPathNotSignedAsLocalKey(t *testing.T) {
 		},
 	}
 	path := "cos://test-bucket/ap-shanghai/weknora/10000/exports/abc.png"
-	svc := resolveIMFileServiceForPath(tenant, path)
+	svc := resolveIMFileServiceForPath(tenant, path, nil)
 	require.NotNil(t, svc)
 
 	in := "![img](" + path + ")"
-	out := rewriteStorageURLs(context.Background(), in, tenant)
+	out := rewriteStorageURLs(context.Background(), in, newIMFileServiceResolver(tenant, nil))
 	if out != in {
 		assert.False(t, strings.Contains(out, "local%3A"), "COS URL must not treat local:// as object key")
 	}
@@ -245,6 +245,7 @@ func TestFindIncompleteMarkdownImage(t *testing.T) {
 		{"bare provider suffix without markdown", "text minio://wizard-test/10000/exp", -1},
 		{"two images complete", "![a](local://1/a.png) ![b](local://1/b.png)", -1},
 		{"first complete second incomplete", "![a](local://1/a.png) ![b](minio://part", 22},
+		{"bracket inside alt text", "![a[b]](minio://wizard-test/10000/part", 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -436,9 +437,30 @@ func TestCleanIMContent_AfterStreamReassembly(t *testing.T) {
 	sent, rem := simulateIMStreamFlush(parts)
 	require.Empty(t, rem)
 	joined := strings.Join(sent, "")
-	out := cleanIMContent(context.Background(), joined, tenant)
+	out := cleanIMContent(context.Background(), joined, tenant, nil)
 	assert.Contains(t, out, "/api/v1/files/presigned")
 	assert.NotContains(t, out, "local://10000")
+}
+
+func TestHoldbackCutoff_BracketInAlt(t *testing.T) {
+	in := "text ![a[b]](minio://wizard-test/10000/exp"
+	want := strings.Index(in, "![a[b]]")
+	require.GreaterOrEqual(t, want, 0)
+	assert.Equal(t, want, holdbackCutoff(in))
+}
+
+func TestSimulateIMStreamFlush_BracketInAltMiddleImage(t *testing.T) {
+	part1 := "### 1\n![ok](minio://wizard-test/10000/exports/ok.png)\n\n### 2\n"
+	part2 := "![a[b]](minio://wizard-test/10000/exports/c91cf852"
+	part3 := "-suffix.png)\n"
+
+	sent, rem := simulateIMStreamFlush([]string{part1, part2, part3})
+	require.Empty(t, rem)
+	joined := strings.Join(sent, "")
+	assert.Contains(t, joined, "![a[b]](minio://wizard-test/10000/exports/c91cf852-suffix.png)")
+	for _, chunk := range sent {
+		assert.False(t, orphanMarkdownImageOpenRe.MatchString(chunk))
+	}
 }
 
 func TestRewriteStorageURLs_MultipleImagesInOneChunk(t *testing.T) {
@@ -453,7 +475,7 @@ func TestRewriteStorageURLs_MultipleImagesInOneChunk(t *testing.T) {
 		`![知识助理"知识库"管理视图界面](local://10000/exports/c91cf852.png)` + "\n\n### 3\n\n" +
 		"![c](local://10000/exports/a0423e91.png)\n"
 
-	out := rewriteStorageURLs(context.Background(), doc, tenant)
+	out := rewriteStorageURLs(context.Background(), doc, newIMFileServiceResolver(tenant, nil))
 	assert.NotContains(t, out, "local://")
 	assert.Equal(t, 3, strings.Count(out, "/api/v1/files/presigned"))
 }

--- a/internal/im/content_rewrite_test.go
+++ b/internal/im/content_rewrite_test.go
@@ -1,9 +1,13 @@
 package im
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStripIMCitationTags(t *testing.T) {
@@ -154,6 +158,76 @@ func TestFindIncompleteXMLTag(t *testing.T) {
 			got := findIncompleteXMLTag(tt.in)
 			assert.Equal(t, tt.want, got, "findIncompleteXMLTag(%q)", tt.in)
 		})
+	}
+}
+
+func TestResolveIMFileServiceForPath_LocalSchemeDespiteCOSDefault(t *testing.T) {
+	t.Setenv("SYSTEM_AES_KEY", "weknora-test-aes-key-32bytes!!!")
+	t.Setenv("APP_EXTERNAL_URL", "https://weknora.example.com")
+
+	tenant := &types.Tenant{
+		StorageEngineConfig: &types.StorageEngineConfig{
+			DefaultProvider: "cos",
+			COS: &types.COSEngineConfig{
+				SecretID:   "id",
+				SecretKey:  "key",
+				BucketName: "bucket",
+				Region:     "ap-shanghai",
+			},
+		},
+	}
+	svc := resolveIMFileServiceForPath(tenant, "local://10000/exports/img.png")
+	require.NotNil(t, svc)
+	got, err := svc.GetFileURL(context.Background(), "local://10000/exports/img.png")
+	require.NoError(t, err)
+	assert.Contains(t, got, "/api/v1/files/presigned")
+}
+
+func TestRewriteStorageURLs_LocalUsesPresignedAPI(t *testing.T) {
+	t.Setenv("SYSTEM_AES_KEY", "weknora-test-aes-key-32bytes!!!")
+	t.Setenv("APP_EXTERNAL_URL", "https://weknora.example.com")
+
+	tenant := &types.Tenant{
+		StorageEngineConfig: &types.StorageEngineConfig{
+			DefaultProvider: "cos",
+			COS: &types.COSEngineConfig{
+				SecretID:   "id",
+				SecretKey:  "key",
+				BucketName: "bucket",
+				Region:     "ap-shanghai",
+			},
+		},
+	}
+
+	in := "![img](local://10000/exports/abc.png)"
+	out := rewriteStorageURLs(context.Background(), in, tenant)
+	assert.Contains(t, out, "/api/v1/files/presigned")
+	assert.NotContains(t, out, "myqcloud.com")
+}
+
+func TestRewriteStorageURLs_COSPathNotSignedAsLocalKey(t *testing.T) {
+	// Without real COS credentials, GetFileURL may fail; ensure we never embed
+	// local:// as a COS object key when rewriting fails.
+	tenant := &types.Tenant{
+		StorageEngineConfig: &types.StorageEngineConfig{
+			DefaultProvider: "cos",
+			COS: &types.COSEngineConfig{
+				SecretID:   "id",
+				SecretKey:  "key",
+				BucketName: "test-bucket",
+				Region:     "ap-shanghai",
+				PathPrefix: "weknora",
+			},
+		},
+	}
+	path := "cos://test-bucket/ap-shanghai/weknora/10000/exports/abc.png"
+	svc := resolveIMFileServiceForPath(tenant, path)
+	require.NotNil(t, svc)
+
+	in := "![img](" + path + ")"
+	out := rewriteStorageURLs(context.Background(), in, tenant)
+	if out != in {
+		assert.False(t, strings.Contains(out, "local%3A"), "COS URL must not treat local:// as object key")
 	}
 }
 

--- a/internal/im/im_file_service_test.go
+++ b/internal/im/im_file_service_test.go
@@ -1,0 +1,122 @@
+package im
+
+import (
+	"context"
+	"io"
+	"mime/multipart"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubIMFileService implements interfaces.FileService for IM resolver tests.
+type stubIMFileService struct {
+	getFileURL func(ctx context.Context, filePath string) (string, error)
+}
+
+func (s *stubIMFileService) CheckConnectivity(context.Context) error { return nil }
+
+func (s *stubIMFileService) SaveFile(context.Context, *multipart.FileHeader, uint64, string) (string, error) {
+	return "", nil
+}
+
+func (s *stubIMFileService) SaveBytes(context.Context, []byte, uint64, string, bool) (string, error) {
+	return "", nil
+}
+
+func (s *stubIMFileService) GetFile(context.Context, string) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (s *stubIMFileService) GetFileURL(ctx context.Context, filePath string) (string, error) {
+	if s.getFileURL != nil {
+		return s.getFileURL(ctx, filePath)
+	}
+	return "https://global-storage.example/" + filePath, nil
+}
+
+func (s *stubIMFileService) DeleteFile(context.Context, string) error { return nil }
+
+func TestBuildIMFileServiceForProvider_FallbackToGlobal(t *testing.T) {
+	stub := &stubIMFileService{}
+	tenant := &types.Tenant{
+		StorageEngineConfig: &types.StorageEngineConfig{
+			DefaultProvider: "cos",
+			COS: &types.COSEngineConfig{
+				SecretID:   "id",
+				SecretKey:  "key",
+				BucketName: "bucket",
+				Region:     "ap-shanghai",
+			},
+		},
+	}
+
+	svc := buildIMFileServiceForProvider(tenant, "minio", stub)
+	require.NotNil(t, svc)
+	got, err := svc.GetFileURL(context.Background(), "minio://wizard-test/10000/exports/a.png")
+	require.NoError(t, err)
+	assert.Equal(t, "https://global-storage.example/minio://wizard-test/10000/exports/a.png", got)
+}
+
+func TestIMFileServiceResolver_CachesPerProvider(t *testing.T) {
+	stub := &stubIMFileService{}
+	tenant := &types.Tenant{
+		StorageEngineConfig: &types.StorageEngineConfig{
+			DefaultProvider: "cos",
+			COS: &types.COSEngineConfig{
+				SecretID:   "id",
+				SecretKey:  "key",
+				BucketName: "bucket",
+				Region:     "ap-shanghai",
+			},
+		},
+	}
+	r := newIMFileServiceResolver(tenant, stub)
+
+	svc1 := r.resolve("minio://wizard-test/10000/a.png")
+	svc2 := r.resolve("minio://wizard-test/10000/b.png")
+	assert.Same(t, svc1, svc2, "same provider should reuse cached FileService")
+
+	svc3 := r.resolve("local://10000/c.png")
+	assert.NotSame(t, svc1, svc3, "different provider should use a different service")
+}
+
+func TestRewriteStorageURLs_MinIOFallbackViaGlobal(t *testing.T) {
+	stub := &stubIMFileService{
+		getFileURL: func(_ context.Context, filePath string) (string, error) {
+			return "https://minio.example/presigned?path=" + filePath, nil
+		},
+	}
+	tenant := &types.Tenant{
+		StorageEngineConfig: &types.StorageEngineConfig{
+			DefaultProvider: "cos",
+			COS: &types.COSEngineConfig{
+				SecretID:   "id",
+				SecretKey:  "key",
+				BucketName: "bucket",
+				Region:     "ap-shanghai",
+			},
+		},
+	}
+	in := `![知识助理"知识库"管理视图界面](minio://wizard-test/10000/exports/c91cf852.png)`
+	resolver := newIMFileServiceResolver(tenant, stub)
+	out := rewriteStorageURLs(context.Background(), in, resolver)
+	assert.Contains(t, out, "https://minio.example/presigned")
+	assert.NotContains(t, out, "](minio://")
+}
+
+func TestCleanIMContent_MinIOFallbackIntegration(t *testing.T) {
+	stub := &stubIMFileService{
+		getFileURL: func(_ context.Context, _ string) (string, error) {
+			return "https://minio.example/img.png", nil
+		},
+	}
+	tenant := &types.Tenant{
+		StorageEngineConfig: &types.StorageEngineConfig{DefaultProvider: "cos"},
+	}
+	in := "see ![x](minio://wizard-test/10000/exports/x.png) ok"
+	out := cleanIMContent(context.Background(), in, tenant, stub)
+	assert.Contains(t, out, "https://minio.example/img.png")
+}

--- a/internal/im/qaqueue.go
+++ b/internal/im/qaqueue.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
-	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -44,9 +43,8 @@ type qaRequest struct {
 	channel   *IMChannel
 	channelID string
 
-	// fileSvc resolves storage URLs to HTTP URLs for the tenant's storage backend.
-	// May be nil if the tenant has no storage config.
-	fileSvc interfaces.FileService
+	// tenant is used to resolve provider:// URLs in outbound replies (scheme-aware).
+	tenant *types.Tenant
 
 	// userKey is "channelID:userID:chatID", used for per-user limits and /stop.
 	userKey    string

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -90,9 +90,12 @@ var storageSchemeRe = regexp.MustCompile(`\b(local|minio|s3|cos|tos|oss)://[^\s)
 //   - Failure or no-op rewrite logs at WARN. The no-op case typically means
 //     APP_EXTERNAL_URL is not configured for the local backend, which is
 //     the most common cause of "image broken in IM" reports.
-func rewriteStorageURLs(ctx context.Context, content string, tenant *types.Tenant) string {
+func rewriteStorageURLs(ctx context.Context, content string, resolver *imFileServiceResolver) string {
+	if resolver == nil {
+		return content
+	}
 	return storageSchemeRe.ReplaceAllStringFunc(content, func(match string) string {
-		fileSvc := resolveIMFileServiceForPath(tenant, match)
+		fileSvc := resolver.resolve(match)
 		if fileSvc == nil {
 			logger.Warnf(ctx, "[IM] rewriteStorageURLs: no file service for src=%s", match)
 			return match
@@ -144,6 +147,15 @@ var incompleteMarkdownImageSuffixRe = regexp.MustCompile(`!\[[^\]]*\]\([^)]*$`)
 // findIncompleteMarkdownImage returns the byte offset of an unclosed ![alt](url
 // suffix at the end of s, or -1 if none.
 func findIncompleteMarkdownImage(s string) int {
+	// Prefer pairing a trailing provider:// fragment with the nearest preceding ![…](
+	// so alt text may contain ']' (e.g. ![a[b]](minio://part).
+	if urlIdx := findIncompleteStorageURL(s); urlIdx >= 0 {
+		if imgIdx := strings.LastIndex(s[:urlIdx], "!["); imgIdx >= 0 {
+			if strings.Contains(s[imgIdx:urlIdx], "](") {
+				return imgIdx
+			}
+		}
+	}
 	loc := incompleteMarkdownImageSuffixRe.FindStringIndex(s)
 	if loc == nil {
 		return -1
@@ -186,10 +198,11 @@ func holdbackCutoff(chunk string) int {
 //  1. Collapse <image> XML blocks back to plain markdown
 //  2. Strip <kb/> and <web/> citation tags
 //  3. Rewrite provider:// URLs to HTTP URLs (scheme-aware per tenant config)
-func cleanIMContent(ctx context.Context, content string, tenant *types.Tenant) string {
+func cleanIMContent(ctx context.Context, content string, tenant *types.Tenant, defaultFileSvc interfaces.FileService) string {
 	content = stripImageXMLTags(content)
 	content = stripIMCitationTags(content)
-	content = rewriteStorageURLs(ctx, content, tenant)
+	resolver := newIMFileServiceResolver(tenant, defaultFileSvc)
+	content = rewriteStorageURLs(ctx, content, resolver)
 	return content
 }
 
@@ -201,34 +214,75 @@ func imLocalStorageBaseDir() string {
 	return baseDir
 }
 
-// resolveIMFileServiceForPath selects the FileService that matches the URL scheme in
-// filePath (e.g. local:// → local backend), not the tenant's default provider.
-// Mirrors /api/v1/files/presigned and ImageMultimodalService.resolveFileServiceForPayload.
-func resolveIMFileServiceForPath(tenant *types.Tenant, filePath string) interfaces.FileService {
-	baseDir := imLocalStorageBaseDir()
-	provider := types.ParseProviderScheme(filePath)
-	var sec *types.StorageEngineConfig
-	if tenant != nil {
-		sec = tenant.StorageEngineConfig
+// imFileServiceResolver resolves and caches FileService instances per storage provider
+// for the lifetime of one cleanIMContent / outbound message (avoids re-creating SDK clients
+// for every URL in a long answer).
+type imFileServiceResolver struct {
+	tenant     *types.Tenant
+	defaultSvc interfaces.FileService
+	cache      map[string]interfaces.FileService
+}
+
+func newIMFileServiceResolver(tenant *types.Tenant, defaultSvc interfaces.FileService) *imFileServiceResolver {
+	return &imFileServiceResolver{
+		tenant:     tenant,
+		defaultSvc: defaultSvc,
+		cache:      make(map[string]interfaces.FileService),
 	}
+}
+
+func (r *imFileServiceResolver) resolve(filePath string) interfaces.FileService {
+	provider := types.ParseProviderScheme(filePath)
 	if provider == "" {
-		if sec != nil {
-			provider = strings.ToLower(strings.TrimSpace(sec.DefaultProvider))
+		if r.tenant != nil && r.tenant.StorageEngineConfig != nil {
+			provider = strings.ToLower(strings.TrimSpace(r.tenant.StorageEngineConfig.DefaultProvider))
 		}
 		if provider == "" {
 			return nil
 		}
 	}
-
-	svc, _, err := filesvc.NewFileServiceFromStorageConfig(provider, sec, baseDir)
-	if err != nil {
-		if provider == "local" {
-			externalURL := strings.TrimSpace(os.Getenv("APP_EXTERNAL_URL"))
-			return filesvc.NewLocalFileService(baseDir, externalURL)
-		}
-		return nil
+	if svc, ok := r.cache[provider]; ok {
+		return svc
+	}
+	svc := buildIMFileServiceForProvider(r.tenant, provider, r.defaultSvc)
+	if svc != nil {
+		r.cache[provider] = svc
 	}
 	return svc
+}
+
+// buildIMFileServiceForProvider selects the FileService for a storage provider.
+// filePath scheme wins over tenant DefaultProvider. Falls back to the process-wide
+// default FileService (STORAGE_TYPE / env) when tenant config is missing — mirrors
+// ImageMultimodalService.resolveFileServiceForPayload (issue #1282).
+func buildIMFileServiceForProvider(
+	tenant *types.Tenant,
+	provider string,
+	defaultSvc interfaces.FileService,
+) interfaces.FileService {
+	baseDir := imLocalStorageBaseDir()
+	var sec *types.StorageEngineConfig
+	if tenant != nil {
+		sec = tenant.StorageEngineConfig
+	}
+
+	svc, _, err := filesvc.NewFileServiceFromStorageConfig(provider, sec, baseDir)
+	if err == nil {
+		return svc
+	}
+	if provider == "local" {
+		externalURL := strings.TrimSpace(os.Getenv("APP_EXTERNAL_URL"))
+		return filesvc.NewLocalFileService(baseDir, externalURL)
+	}
+	if defaultSvc != nil {
+		return defaultSvc
+	}
+	return nil
+}
+
+// resolveIMFileServiceForPath is a test/helper entry point without caching.
+func resolveIMFileServiceForPath(tenant *types.Tenant, filePath string, defaultSvc interfaces.FileService) interfaces.FileService {
+	return newIMFileServiceResolver(tenant, defaultSvc).resolve(filePath)
 }
 
 const (
@@ -302,6 +356,10 @@ type Service struct {
 	// consistent with the web StopSession mechanism. May be nil in Lite mode
 	// (but NewStreamManager always returns at least a memory implementation).
 	streamManager interfaces.StreamManager
+
+	// defaultFileSvc is the process-wide storage backend (STORAGE_TYPE / env).
+	// Used when tenant StorageEngineConfig cannot build a service for the URL scheme.
+	defaultFileSvc interfaces.FileService
 
 	// cmdRegistry holds all registered slash-commands.
 	cmdRegistry *CommandRegistry
@@ -466,6 +524,7 @@ func NewService(
 	kbService interfaces.KnowledgeBaseService,
 	modelService interfaces.ModelService,
 	streamManager interfaces.StreamManager,
+	defaultFileSvc interfaces.FileService,
 	redisClient *redis.Client,
 	appCfg *config.Config,
 ) *Service {
@@ -491,6 +550,7 @@ func NewService(
 		kbService:        kbService,
 		modelService:     modelService,
 		streamManager:    streamManager,
+		defaultFileSvc:   defaultFileSvc,
 		cmdRegistry:      registry,
 		channels:         make(map[string]*channelState),
 		adapterFactories: make(map[string]AdapterFactory),
@@ -1230,7 +1290,7 @@ func (s *Service) executeQARequest(req *qaRequest) {
 	}
 
 	reply := &ReplyMessage{
-		Content: cleanIMContent(ctx, answer, req.tenant),
+		Content: cleanIMContent(ctx, answer, req.tenant, s.defaultFileSvc),
 		IsFinal: true,
 	}
 	if err := req.adapter.SendReply(ctx, req.msg, reply); err != nil {
@@ -1932,7 +1992,7 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 		}
 
 		if chunk != "" {
-			if err := streamer.SendStreamChunk(ctx, msg, streamID, cleanIMContent(ctx, chunk, tenant)); err != nil {
+			if err := streamer.SendStreamChunk(ctx, msg, streamID, cleanIMContent(ctx, chunk, tenant, s.defaultFileSvc)); err != nil {
 				logger.Warnf(ctx, "[IM] SendStreamChunk failed: %v", err)
 			}
 		}
@@ -2002,7 +2062,7 @@ func (s *Service) fallbackNonStream(ctx context.Context, msg *IncomingMessage, s
 		answer = "抱歉，处理您的问题时出现了异常，请稍后再试。"
 	}
 
-	return adapter.SendReply(ctx, msg, &ReplyMessage{Content: cleanIMContent(ctx, answer, tenant), IsFinal: true})
+	return adapter.SendReply(ctx, msg, &ReplyMessage{Content: cleanIMContent(ctx, answer, tenant, s.defaultFileSvc), IsFinal: true})
 }
 
 // runQA executes the WeKnora QA pipeline and returns the full answer text.

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -90,11 +90,13 @@ var storageSchemeRe = regexp.MustCompile(`\b(local|minio|s3|cos|tos|oss)://[^\s)
 //   - Failure or no-op rewrite logs at WARN. The no-op case typically means
 //     APP_EXTERNAL_URL is not configured for the local backend, which is
 //     the most common cause of "image broken in IM" reports.
-func rewriteStorageURLs(ctx context.Context, content string, fileSvc interfaces.FileService) string {
-	if fileSvc == nil {
-		return content
-	}
+func rewriteStorageURLs(ctx context.Context, content string, tenant *types.Tenant) string {
 	return storageSchemeRe.ReplaceAllStringFunc(content, func(match string) string {
+		fileSvc := resolveIMFileServiceForPath(tenant, match)
+		if fileSvc == nil {
+			logger.Warnf(ctx, "[IM] rewriteStorageURLs: no file service for src=%s", match)
+			return match
+		}
 		httpURL, err := fileSvc.GetFileURL(ctx, match)
 		if err != nil {
 			logger.Warnf(ctx, "[IM] rewriteStorageURLs failed: src=%s err=%v", match, err)
@@ -165,29 +167,50 @@ func holdbackCutoff(chunk string) int {
 // cleanIMContent applies all IM-specific content transformations:
 //  1. Collapse <image> XML blocks back to plain markdown
 //  2. Strip <kb/> and <web/> citation tags
-//  3. Rewrite provider:// URLs to HTTP URLs (if fileSvc is available)
-func cleanIMContent(ctx context.Context, content string, fileSvc interfaces.FileService) string {
+//  3. Rewrite provider:// URLs to HTTP URLs (scheme-aware per tenant config)
+func cleanIMContent(ctx context.Context, content string, tenant *types.Tenant) string {
 	content = stripImageXMLTags(content)
 	content = stripIMCitationTags(content)
-	content = rewriteStorageURLs(ctx, content, fileSvc)
+	content = rewriteStorageURLs(ctx, content, tenant)
 	return content
 }
 
-// buildTenantFileService creates a FileService for the given tenant's storage config.
-// Returns nil if the tenant has no storage config or if creation fails.
-func buildTenantFileService(tenant *types.Tenant) interfaces.FileService {
-	if tenant == nil {
-		return nil
-	}
-	baseDir := os.Getenv("LOCAL_STORAGE_BASE_DIR")
+func imLocalStorageBaseDir() string {
+	baseDir := strings.TrimSpace(os.Getenv("LOCAL_STORAGE_BASE_DIR"))
 	if baseDir == "" {
 		baseDir = "/data/files"
 	}
-	fileSvc, _, err := filesvc.NewFileServiceFromStorageConfig("", tenant.StorageEngineConfig, baseDir)
+	return baseDir
+}
+
+// resolveIMFileServiceForPath selects the FileService that matches the URL scheme in
+// filePath (e.g. local:// → local backend), not the tenant's default provider.
+// Mirrors /api/v1/files/presigned and ImageMultimodalService.resolveFileServiceForPayload.
+func resolveIMFileServiceForPath(tenant *types.Tenant, filePath string) interfaces.FileService {
+	baseDir := imLocalStorageBaseDir()
+	provider := types.ParseProviderScheme(filePath)
+	var sec *types.StorageEngineConfig
+	if tenant != nil {
+		sec = tenant.StorageEngineConfig
+	}
+	if provider == "" {
+		if sec != nil {
+			provider = strings.ToLower(strings.TrimSpace(sec.DefaultProvider))
+		}
+		if provider == "" {
+			return nil
+		}
+	}
+
+	svc, _, err := filesvc.NewFileServiceFromStorageConfig(provider, sec, baseDir)
 	if err != nil {
+		if provider == "local" {
+			externalURL := strings.TrimSpace(os.Getenv("APP_EXTERNAL_URL"))
+			return filesvc.NewLocalFileService(baseDir, externalURL)
+		}
 		return nil
 	}
-	return fileSvc
+	return svc
 }
 
 const (
@@ -1100,7 +1123,7 @@ func (s *Service) HandleMessage(ctx context.Context, msg *IncomingMessage, chann
 		adapter:   adapter,
 		channel:   channel,
 		channelID: channelID,
-		fileSvc:   buildTenantFileService(tenant),
+		tenant:    tenant,
 		userKey:   userKey,
 	}
 
@@ -1172,7 +1195,7 @@ func (s *Service) executeQARequest(req *qaRequest) {
 	// If the adapter supports streaming and output is not "full", use streaming.
 	if !streamDisabled {
 		if streamer, ok := req.adapter.(StreamSender); ok {
-			if err := s.handleMessageStream(ctx, req.msg, req.session, req.agent, kbIDs, streamer, req.adapter, req.userKey, req.fileSvc); err != nil {
+			if err := s.handleMessageStream(ctx, req.msg, req.session, req.agent, kbIDs, streamer, req.adapter, req.userKey, req.tenant); err != nil {
 				span.SetStatus(codes.Error, err.Error())
 				logger.Errorf(ctx, "[IM] Stream QA failed: %v", err)
 			}
@@ -1189,7 +1212,7 @@ func (s *Service) executeQARequest(req *qaRequest) {
 	}
 
 	reply := &ReplyMessage{
-		Content: cleanIMContent(ctx, answer, req.fileSvc),
+		Content: cleanIMContent(ctx, answer, req.tenant),
 		IsFinal: true,
 	}
 	if err := req.adapter.SendReply(ctx, req.msg, reply); err != nil {
@@ -1641,12 +1664,12 @@ func briefToolSummary(output string) string {
 // handleMessageStream runs the QA pipeline and streams answer chunks to the IM platform
 // in real-time via the StreamSender interface. Chunks are batched at streamFlushInterval
 // to avoid API rate-limiting.
-func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage, session *types.Session, customAgent *types.CustomAgent, kbIDs []string, streamer StreamSender, adapter Adapter, userKey string, fileSvc interfaces.FileService) error {
+func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage, session *types.Session, customAgent *types.CustomAgent, kbIDs []string, streamer StreamSender, adapter Adapter, userKey string, tenant *types.Tenant) error {
 	// Start the stream on the IM platform (e.g., create Feishu streaming card)
 	streamID, err := streamer.StartStream(ctx, msg)
 	if err != nil {
 		logger.Warnf(ctx, "[IM] StartStream failed, falling back to non-streaming: %v", err)
-		return s.fallbackNonStream(ctx, msg, session, customAgent, kbIDs, adapter, userKey, fileSvc)
+		return s.fallbackNonStream(ctx, msg, session, customAgent, kbIDs, adapter, userKey, tenant)
 	}
 
 	// Prepare the QA pipeline
@@ -1891,7 +1914,7 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 		}
 
 		if chunk != "" {
-			if err := streamer.SendStreamChunk(ctx, msg, streamID, cleanIMContent(ctx, chunk, fileSvc)); err != nil {
+			if err := streamer.SendStreamChunk(ctx, msg, streamID, cleanIMContent(ctx, chunk, tenant)); err != nil {
 				logger.Warnf(ctx, "[IM] SendStreamChunk failed: %v", err)
 			}
 		}
@@ -1954,14 +1977,14 @@ loop:
 }
 
 // fallbackNonStream is used when streaming initialization fails.
-func (s *Service) fallbackNonStream(ctx context.Context, msg *IncomingMessage, session *types.Session, customAgent *types.CustomAgent, kbIDs []string, adapter Adapter, userKey string, fileSvc interfaces.FileService) error {
+func (s *Service) fallbackNonStream(ctx context.Context, msg *IncomingMessage, session *types.Session, customAgent *types.CustomAgent, kbIDs []string, adapter Adapter, userKey string, tenant *types.Tenant) error {
 	answer, err := s.runQA(ctx, session, msg.Content, customAgent, kbIDs, userKey, msg.Quote)
 	if err != nil {
 		logger.Errorf(ctx, "[IM] QA fallback failed: %v", err)
 		answer = "抱歉，处理您的问题时出现了异常，请稍后再试。"
 	}
 
-	return adapter.SendReply(ctx, msg, &ReplyMessage{Content: cleanIMContent(ctx, answer, fileSvc), IsFinal: true})
+	return adapter.SendReply(ctx, msg, &ReplyMessage{Content: cleanIMContent(ctx, answer, tenant), IsFinal: true})
 }
 
 // runQA executes the WeKnora QA pipeline and returns the full answer text.

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -135,6 +135,22 @@ func findIncompleteStorageURL(s string) int {
 	return loc[0]
 }
 
+// incompleteMarkdownImageSuffixRe matches a Markdown image whose destination URL
+// (the parenthesized part) is not yet closed — e.g. "![alt](minio://part" or "![alt](".
+// Holding back only from "minio://" would flush "![alt](" to the IM client and break
+// the image once the URL arrives in the next chunk.
+var incompleteMarkdownImageSuffixRe = regexp.MustCompile(`!\[[^\]]*\]\([^)]*$`)
+
+// findIncompleteMarkdownImage returns the byte offset of an unclosed ![alt](url
+// suffix at the end of s, or -1 if none.
+func findIncompleteMarkdownImage(s string) int {
+	loc := incompleteMarkdownImageSuffixRe.FindStringIndex(s)
+	if loc == nil {
+		return -1
+	}
+	return loc[0]
+}
+
 // incompleteXMLTagRe matches the opening of an <image…>, <kb…>, or <web…> tag
 // that reaches the end of the string without a closing '>'.
 var incompleteXMLTagRe = regexp.MustCompile(
@@ -155,7 +171,9 @@ func findIncompleteXMLTag(s string) int {
 // chunk, or len(chunk) if the chunk is safe to flush entirely.
 func holdbackCutoff(chunk string) int {
 	cutoff := len(chunk)
-	if idx := findIncompleteStorageURL(chunk); idx >= 0 && idx < cutoff {
+	if idx := findIncompleteMarkdownImage(chunk); idx >= 0 && idx < cutoff {
+		cutoff = idx
+	} else if idx := findIncompleteStorageURL(chunk); idx >= 0 && idx < cutoff {
 		cutoff = idx
 	}
 	if idx := findIncompleteXMLTag(chunk); idx >= 0 && idx < cutoff {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1227,6 +1227,12 @@ func serveFiles(r getRouteRegistrar, globalFileService interfaces.FileService) {
 			return
 		}
 
+		if err := secutils.ValidateStoragePathTenant(filePath, tenant.ID); err != nil {
+			logger.Warnf(context.Background(), "[Router] /files denied cross-tenant or invalid path: tenant_id=%d file_path=%q err=%v", tenant.ID, filePath, err)
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden: file path not accessible"})
+			return
+		}
+
 		var (
 			fileSvc          interfaces.FileService
 			resolvedProvider string

--- a/internal/router/router_files_test.go
+++ b/internal/router/router_files_test.go
@@ -62,7 +62,7 @@ func TestServeFilesFallsBackToGlobalFileService(t *testing.T) {
 		},
 	})
 
-	filePath := "local://docs/example.txt"
+	filePath := "local://42/docs/example.txt"
 	req := httptest.NewRequest(http.MethodGet, "/files?file_path="+url.QueryEscape(filePath), nil)
 	req = req.WithContext(context.WithValue(req.Context(), types.TenantInfoContextKey, &types.Tenant{ID: 42}))
 
@@ -92,13 +92,59 @@ func TestServeFilesDoesNotFallbackWhenProviderDoesNotMatchGlobalStorage(t *testi
 		},
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/files?file_path="+url.QueryEscape("local://docs/example.txt"), nil)
+	req := httptest.NewRequest(http.MethodGet, "/files?file_path="+url.QueryEscape("local://42/docs/example.txt"), nil)
 	req = req.WithContext(context.WithValue(req.Context(), types.TenantInfoContextKey, &types.Tenant{ID: 42}))
 
 	recorder := httptest.NewRecorder()
 	engine.ServeHTTP(recorder, req)
 
 	if got, want := recorder.Code, http.StatusBadRequest; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+}
+
+func TestServeFilesRejectsCrossTenantPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("STORAGE_TYPE", "local")
+
+	engine := gin.New()
+	serveFiles(engine, &stubFileService{
+		getFile: func(ctx context.Context, filePath string) (io.ReadCloser, error) {
+			t.Fatalf("GetFile should not be called for cross-tenant path, got %q", filePath)
+			return nil, nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/files?file_path="+url.QueryEscape("local://7/knowledge/secret.pdf"), nil)
+	req = req.WithContext(context.WithValue(req.Context(), types.TenantInfoContextKey, &types.Tenant{ID: 42}))
+
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, req)
+
+	if got, want := recorder.Code, http.StatusForbidden; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+}
+
+func TestServeFilesRejectsPathWithoutTenantSegment(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("STORAGE_TYPE", "local")
+
+	engine := gin.New()
+	serveFiles(engine, &stubFileService{
+		getFile: func(ctx context.Context, filePath string) (io.ReadCloser, error) {
+			t.Fatalf("GetFile should not be called without tenant segment, got %q", filePath)
+			return nil, nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/files?file_path="+url.QueryEscape("local://docs/example.txt"), nil)
+	req = req.WithContext(context.WithValue(req.Context(), types.TenantInfoContextKey, &types.Tenant{ID: 42}))
+
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, req)
+
+	if got, want := recorder.Code, http.StatusForbidden; got != want {
 		t.Fatalf("status = %d, want %d", got, want)
 	}
 }

--- a/internal/utils/presign.go
+++ b/internal/utils/presign.go
@@ -95,6 +95,20 @@ func VerifyFileURLSig(filePath string, tenantID uint64, expiresStr, sig string) 
 	return hmac.Equal([]byte(expected), []byte(sig))
 }
 
+// ValidateStoragePathTenant ensures the tenant segment embedded in a provider://
+// storage path matches the authenticated caller's tenant. Cross-tenant access
+// must use /api/v1/files/presigned with an HMAC bound to the resource owner.
+func ValidateStoragePathTenant(filePath string, tenantID uint64) error {
+	pathTenant := ParseTenantIDFromStoragePath(filePath)
+	if pathTenant == 0 {
+		return fmt.Errorf("storage path has no tenant segment")
+	}
+	if pathTenant != tenantID {
+		return fmt.Errorf("storage path tenant mismatch")
+	}
+	return nil
+}
+
 // ParseTenantIDFromStoragePath extracts the tenant ID from a provider:// storage path.
 // Storage paths follow the convention: {scheme}://.../{tenantID}/...
 // Returns 0 if the path does not contain a valid tenant ID.

--- a/internal/utils/presign_test.go
+++ b/internal/utils/presign_test.go
@@ -86,6 +86,12 @@ func TestVerifyFileURLSig_NoKey(t *testing.T) {
 	assert.False(t, VerifyFileURLSig("local://1/img.png", 1, "99999999999", "abc"))
 }
 
+func TestValidateStoragePathTenant(t *testing.T) {
+	assert.NoError(t, ValidateStoragePathTenant("local://42/knowledge/file.pdf", 42))
+	assert.Error(t, ValidateStoragePathTenant("local://7/knowledge/file.pdf", 42))
+	assert.Error(t, ValidateStoragePathTenant("local://docs/example.txt", 42))
+}
+
 func TestParseTenantIDFromStoragePath(t *testing.T) {
 	tests := []struct {
 		path string


### PR DESCRIPTION
## Summary

- **IM storage URLs**: Resolve `FileService` by URL scheme (e.g. `local://`, `minio://`, `cos://`) instead of always using the tenant default provider, preventing COS presigning of `local://` paths and enabling MinIO URL rewriting when tenant MinIO config is missing (global fallback + per-provider resolver cache).
- **IM streaming**: Hold back incomplete Markdown image syntax (`![...](`) during SSE flush so multi-chunk URLs are not split mid-link.
- **COS**: Reject unsupported schemes in `parseCosObjectName` so `local://` keys are never treated as COS object names.
- **Knowledge Base creation**: Apply tenant `default_provider` on create (frontend prefill + backend `applyTenantDefaultStorageProvider`) instead of silently defaulting to `local`.

## Test plan

- [x] `go test ./internal/im/`
- [x] `go test ./internal/application/service/ -run TestCreateKnowledgeBase_DefaultStorageProvider`
- [ ] IM channel: agent reply with `minio://` / `local://` images shows presigned HTTPS URLs in Feishu/WeCom
- [ ] Settings → Storage: set default engine to MinIO; create KB → storage provider matches tenant default
- [ ] Existing KB with explicit `local` provider unchanged on edit