### PR TITLE
fix: preserve same-knowledge overlap chunks

### DIFF
--- a/internal/application/service/chat_pipeline/search.go
+++ b/internal/application/service/chat_pipeline/search.go
@@ -193,8 +193,9 @@ func buildContentSignature(content string) string {
 }
 
 // removePartialOverlaps drops chunks whose content is largely contained within
-// a higher-scored chunk, even across different knowledge sources. This catches
-// cross-KB duplicates and near-duplicates that exact-signature dedup misses.
+// a higher-scored chunk from a different knowledge source. This catches
+// cross-KB duplicates and near-duplicates that exact-signature dedup misses,
+// while preserving table-heavy chunks from the same knowledge item.
 //
 // Two thresholds are used:
 //   - Substring containment: if the normalized short text is a literal substring
@@ -237,6 +238,9 @@ func removePartialOverlaps(ctx context.Context, results []*types.SearchResult) [
 			}
 
 			a, b := entries[i], entries[j]
+			if a.result.KnowledgeID != "" && a.result.KnowledgeID == b.result.KnowledgeID {
+				continue
+			}
 
 			shortIdx, longIdx := i, j
 			if len(a.norm) > len(b.norm) {

--- a/internal/application/service/chat_pipeline/search_test.go
+++ b/internal/application/service/chat_pipeline/search_test.go
@@ -1,0 +1,50 @@
+package chatpipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestRemovePartialOverlapsKeepsSameKnowledgeChunks(t *testing.T) {
+	results := []*types.SearchResult{
+		overlapSearchResult("chunk-a", "knowledge-1", 0.92, overlapContent("row10")),
+		overlapSearchResult("chunk-b", "knowledge-1", 0.88, overlapContent("row11")),
+	}
+
+	deduplicated := removePartialOverlaps(context.Background(), results)
+
+	if len(deduplicated) != 2 {
+		t.Fatalf("same-knowledge chunks should be preserved, got %d results", len(deduplicated))
+	}
+}
+
+func TestRemovePartialOverlapsDropsCrossKnowledgeDuplicates(t *testing.T) {
+	results := []*types.SearchResult{
+		overlapSearchResult("chunk-a", "knowledge-1", 0.92, overlapContent("row10")),
+		overlapSearchResult("chunk-b", "knowledge-2", 0.88, overlapContent("row11")),
+	}
+
+	deduplicated := removePartialOverlaps(context.Background(), results)
+
+	if len(deduplicated) != 1 {
+		t.Fatalf("cross-knowledge near duplicates should be deduplicated, got %d results", len(deduplicated))
+	}
+	if deduplicated[0].ID != "chunk-a" {
+		t.Fatalf("expected higher-scored chunk to be kept, got %s", deduplicated[0].ID)
+	}
+}
+
+func overlapSearchResult(id, knowledgeID string, score float64, content string) *types.SearchResult {
+	return &types.SearchResult{
+		ID:          id,
+		KnowledgeID: knowledgeID,
+		Content:     content,
+		Score:       score,
+	}
+}
+
+func overlapContent(row string) string {
+	return "PFMEA process step station operation function failure mode cause effect severity control detection owner " + row
+}


### PR DESCRIPTION
## Summary
- keep high-overlap chunks from the same knowledge item during final partial-overlap deduplication
- retain cross-knowledge near-duplicate removal behavior
- add focused regression coverage for both paths

Fixes #1485.

## Testing
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service/chat_pipeline -run 'TestRemovePartialOverlaps' -count=1`\n- `CGO_LDFLAGS='-lc++' go test ./internal/application/service/chat_pipeline -count=1`\n- `git diff --check`