### PR TITLE
feat(knowledge): count wiki ingest in the finalizing subtask counter

### DIFF
--- a/frontend/src/components/knowledge-processing-timeline.vue
+++ b/frontend/src/components/knowledge-processing-timeline.vue
@@ -1105,14 +1105,56 @@ function attemptGlyph(status: string): { ch: string; cls: string } {
   }
 }
 
+// True when the panel is showing the most recent attempt (or there's
+// only one). Historical attempts must keep their own per-attempt
+// trace.status; only the latest attempt's header should defer to the
+// knowledge-level parse_status.
+const viewingLatestAttempt = computed<boolean>(() => {
+  const latest = data.value?.latest_attempt || 0
+  if (latest <= 1) return true
+  const active = selectedAttempt.value ?? data.value?.attempt ?? latest
+  return active === latest
+})
+
+// Project the knowledge-level parse_status onto the trace-span status
+// vocabulary localizedStatus() speaks, so the header badge reads the
+// same whether it comes from the root span or from parse_status.
+// 'finalizing' keeps its own label ("优化中") to match the doc card.
+function parseStatusToTraceStatus(s?: string): string {
+  switch (s) {
+    case 'completed':
+      return 'done'
+    case 'processing':
+      return 'running'
+    case 'finalizing':
+      return 'finalizing'
+    default:
+      return s || ''
+  }
+}
+
+// The authoritative status for the header badge. During the async
+// post-pipeline window (summary / question / graph / wiki), the latest
+// attempt's ROOT span closes — so trace.status reads 'done' — while
+// those subspans keep running and the row is still 'finalizing'.
+// Trusting trace.status there flashes "已完成" mid-wiki even though the
+// doc card (and LIVE badge) still say "优化中". Prefer parse_status while
+// it is non-terminal on the latest attempt so all three agree.
+const headerStatus = computed(() => {
+  const parseStatus = data.value?.parse_status
+  if (viewingLatestAttempt.value && isPolling(parseStatus)) {
+    return parseStatusToTraceStatus(parseStatus)
+  }
+  return data.value?.trace?.status || parseStatusToTraceStatus(parseStatus)
+})
+
 const headerStatusText = computed(() => {
-  const s = data.value?.trace?.status || data.value?.parse_status || ''
+  const s = headerStatus.value
   return s ? localizedStatus(s) : ''
 })
 
 const headerStatusTheme = computed(() => {
-  const s = data.value?.trace?.status || data.value?.parse_status || ''
-  switch (s) {
+  switch (headerStatus.value) {
     case 'done':
     case 'completed':
       return 'success'
@@ -1121,6 +1163,7 @@ const headerStatusTheme = computed(() => {
     case 'running':
     case 'processing':
     case 'pending':
+    case 'finalizing':
       return 'warning'
     default:
       return 'default'

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -475,6 +475,7 @@ export default {
     status: {
       pending: 'Pending',
       running: 'Running',
+      finalizing: 'Finalizing',
       done: 'Done',
       failed: 'Failed',
       skipped: 'Skipped',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -481,6 +481,7 @@ export default {
     status: {
       pending: "대기 중",
       running: "진행 중",
+      finalizing: "최적화 중",
       done: "완료",
       failed: "실패",
       skipped: "건너뜀",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -396,6 +396,7 @@ export default {
     status: {
       pending: 'Ожидание',
       running: 'Выполняется',
+      finalizing: 'Оптимизация',
       done: 'Готово',
       failed: 'Ошибка',
       skipped: 'Пропущено',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -478,6 +478,7 @@ export default {
     status: {
       pending: "等待中",
       running: "进行中",
+      finalizing: "优化中",
       done: "已完成",
       failed: "失败",
       skipped: "已跳过",

--- a/internal/application/service/knowledge_post_process.go
+++ b/internal/application/service/knowledge_post_process.go
@@ -143,12 +143,19 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 	//    on its terminal exit; the row promotes itself to "completed" when
 	//    the counter hits zero (see knowledgeRepository.FinalizeSubtask).
 	//
-	//    Wiki ingest is NOT counted here — it's a KB-scoped debounced
-	//    batch with its own dedup queue; per-knowledge accounting is not
-	//    meaningful for it.
+	//    Wiki ingest IS counted (as a single subtask): although it's a
+	//    KB-scoped debounced batch, each upload enqueues exactly one
+	//    per-knowledge op, and the batch worker calls FinalizeSubtask once
+	//    when that op reaches a terminal state (mapped successfully or
+	//    dead-lettered after exhausting retries). Counting it keeps the row
+	//    in "finalizing" — i.e. shown as in-progress and still cancellable —
+	//    until wiki generation actually finishes instead of flipping to
+	//    completed while wiki runs minutes later. A wiki op that never
+	//    drains is bounded by the housekeeping finalizing sweep.
 	willSpawnSummary := len(textChunks) > 0
 	willSpawnQuestion := willSpawnSummary && kb.NeedsEmbeddingModel() &&
 		kb.QuestionGenerationConfig != nil && kb.QuestionGenerationConfig.Enabled
+	willSpawnWiki := kb.IndexingStrategy.WikiEnabled && len(textChunks) > 0
 	graphChunkCount := 0
 	if kb.IsGraphEnabled() {
 		graphChunkCount = len(textChunks)
@@ -158,6 +165,9 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 		expectedSubtasks++
 	}
 	if willSpawnQuestion {
+		expectedSubtasks++
+	}
+	if willSpawnWiki {
 		expectedSubtasks++
 	}
 	expectedSubtasks += graphChunkCount
@@ -265,7 +275,7 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 
 	// 6. Spawn Wiki Ingest Task if wiki indexing is enabled in IndexingStrategy
 	enqueuedWiki := false
-	if kb.IndexingStrategy.WikiEnabled && len(textChunks) > 0 {
+	if willSpawnWiki {
 		EnqueueWikiIngest(ctx, s.taskEnqueuer, s.pendingRepo, payload.TenantID, payload.KnowledgeBaseID, payload.KnowledgeID)
 		logger.Infof(ctx, "[KnowledgePostProcess] Enqueued wiki ingest task for %s", payload.KnowledgeID)
 		enqueuedWiki = true

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -886,7 +886,7 @@ func sampleLongContent(content string, maxChars int) string {
 }
 
 // ProcessSummaryGeneration handles async summary generation task
-func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asynq.Task) error {
+func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asynq.Task) (retErr error) {
 	var payload types.SummaryGenerationPayload
 	if err := json.Unmarshal(t.Payload(), &payload); err != nil {
 		logger.Errorf(ctx, "Failed to unmarshal summary generation payload: %v", err)
@@ -922,10 +922,16 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 	var summaryErr error
 	summaryOut := types.JSONMap{}
 	defer func() {
-		// Decrement the parent's enrichment counter on every terminal
-		// exit (success OR final retry failure). Intermediate retries
-		// skip the decrement so the counter cannot drain prematurely.
-		if (summaryErr == nil || isFinalAsynqAttempt(ctx)) && payload.KnowledgeID != "" {
+		// Decrement the parent's enrichment counter on terminal exit.
+		// "Terminal" is keyed on the value RETURNED to asynq, not on
+		// summaryErr: several branches record a failure on the span
+		// (summaryErr != nil) yet deliberately `return nil` so asynq does
+		// NOT retry (e.g. insufficient text content, KB/knowledge fetch
+		// failures). Those are terminal and must drain — keying on
+		// summaryErr would skip them and leave the row stuck in
+		// "finalizing". When we DO return an error asynq will retry, so
+		// we only drain on the final attempt.
+		if (retErr == nil || isFinalAsynqAttempt(ctx)) && payload.KnowledgeID != "" {
 			if _, _, ferr := s.repo.FinalizeSubtask(ctx, payload.KnowledgeID); ferr != nil {
 				logger.Warnf(ctx, "summary: FinalizeSubtask failed for %s: %v", payload.KnowledgeID, ferr)
 			}
@@ -1181,7 +1187,7 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 }
 
 // ProcessQuestionGeneration handles async question generation task
-func (s *knowledgeService) ProcessQuestionGeneration(ctx context.Context, t *asynq.Task) error {
+func (s *knowledgeService) ProcessQuestionGeneration(ctx context.Context, t *asynq.Task) (retErr error) {
 	taskStartedAt := time.Now()
 	retryCount, _ := asynq.GetRetryCount(ctx)
 	maxRetry, _ := asynq.GetMaxRetry(ctx)
@@ -1217,11 +1223,16 @@ func (s *knowledgeService) ProcessQuestionGeneration(ctx context.Context, t *asy
 	// FinalizeSubtask decrement so a stale task can't drain the new
 	// attempt's counter.
 	superseded := false
-	// Decrement enrichment counter on terminal exit (success OR final
-	// retry failure). Runs AFTER the stats-log defer below — defers
+	// Decrement enrichment counter on terminal exit. Keyed on the value
+	// RETURNED to asynq (retErr), not qErr: some branches record a span
+	// failure (qErr != nil) yet `return nil` so asynq won't retry (KB /
+	// knowledge fetch failures); those are terminal and must drain.
+	// Keying on qErr would skip them and strand the row in "finalizing".
+	// When we return an error asynq retries, so we only drain on the
+	// final attempt. Runs AFTER the stats-log defer below — defers
 	// unwind LIFO, so this one declared first executes last.
 	defer func() {
-		if !superseded && (qErr == nil || isFinalAsynqAttempt(ctx)) && payload.KnowledgeID != "" {
+		if !superseded && (retErr == nil || isFinalAsynqAttempt(ctx)) && payload.KnowledgeID != "" {
 			if _, _, ferr := s.repo.FinalizeSubtask(ctx, payload.KnowledgeID); ferr != nil {
 				logger.Warnf(ctx, "question: FinalizeSubtask failed for %s: %v", payload.KnowledgeID, ferr)
 			}

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -194,6 +194,7 @@ type wikiIngestService struct {
 	wikiService    interfaces.WikiPageService
 	kbService      interfaces.KnowledgeBaseService
 	knowledgeSvc   interfaces.KnowledgeService
+	knowledgeRepo  interfaces.KnowledgeRepository
 	chunkRepo      interfaces.ChunkRepository
 	modelService   interfaces.ModelService
 	task           interfaces.TaskEnqueuer
@@ -218,6 +219,7 @@ func NewWikiIngestService(
 	wikiService interfaces.WikiPageService,
 	kbService interfaces.KnowledgeBaseService,
 	knowledgeSvc interfaces.KnowledgeService,
+	knowledgeRepo interfaces.KnowledgeRepository,
 	chunkRepo interfaces.ChunkRepository,
 	modelService interfaces.ModelService,
 	task interfaces.TaskEnqueuer,
@@ -231,6 +233,7 @@ func NewWikiIngestService(
 		wikiService:    wikiService,
 		kbService:      kbService,
 		knowledgeSvc:   knowledgeSvc,
+		knowledgeRepo:  knowledgeRepo,
 		chunkRepo:      chunkRepo,
 		modelService:   modelService,
 		task:           task,
@@ -506,6 +509,26 @@ func (s *wikiIngestService) trimPendingList(ctx context.Context, ids []int64) {
 	}
 }
 
+// finalizeWikiSubtask releases this knowledge's slot in the finalizing
+// counter once its wiki op reaches a terminal state (mapped successfully
+// or dead-lettered). The matching +1 is seeded by
+// KnowledgePostProcess.SetFinalizing when willSpawnWiki is true. Callers
+// must only invoke this for ingest ops — retract ops are for deleted
+// knowledge that has no counter to drain.
+//
+// Safe to call on a row that is already completed or whose counter is
+// already zero: FinalizeSubtask guards both the decrement (count > 0) and
+// the promote (parse_status = finalizing AND count = 0), so an op enqueued
+// before this accounting shipped is a harmless no-op.
+func (s *wikiIngestService) finalizeWikiSubtask(ctx context.Context, knowledgeID string) {
+	if s.knowledgeRepo == nil || knowledgeID == "" {
+		return
+	}
+	if _, _, err := s.knowledgeRepo.FinalizeSubtask(ctx, knowledgeID); err != nil {
+		logger.Warnf(ctx, "wiki ingest: FinalizeSubtask failed for %s: %v", knowledgeID, err)
+	}
+}
+
 // requeueFailedOps records in-batch failures.
 //
 // For each failed op:
@@ -544,7 +567,14 @@ func (s *wikiIngestService) requeueFailedOps(ctx context.Context, payload WikiIn
 			continue
 		}
 
-		// Exhausted in-batch retries — archive and remove.
+		// Exhausted in-batch retries — archive and remove. This is the
+		// terminal failure point for the op, so release its slot in the
+		// knowledge's finalizing counter (ingest ops only; retracts are
+		// for deleted knowledge that has no counter to drain). The
+		// matching +1 was seeded by KnowledgePostProcess.SetFinalizing.
+		if op.Op == WikiOpIngest {
+			s.finalizeWikiSubtask(ctx, op.KnowledgeID)
+		}
 		logger.Warnf(ctx, "wiki ingest: dropping op %s (%s) after %d failures (limit %d)", op.KnowledgeID, op.DocTitle, count, wikiMaxFailRetries)
 		if s.deadLetterRepo != nil {
 			payloadBytes, _ := json.Marshal(op)

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -464,6 +464,21 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 				// scrub. Compare with the legacy Redis path, which kept
 				// a separate wiki:failcount:<...> key alive for 24h
 				// regardless of whether the original op had drained.
+				//
+				// The finalizing slot is drained later (after reduce +
+				// publish) in the docResults loop, so "completed" only
+				// arrives once wiki is fully written.
+			} else {
+				// err == nil && result == nil: mapOneDocument skipped this
+				// doc at a terminal, non-retryable state (knowledge
+				// deleted / no chunks / insufficient text). It produces no
+				// docResult and is not a failedOp, so neither the success
+				// nor the dead-letter drain path will fire. Release the
+				// finalizing slot here so the row doesn't hang in
+				// "finalizing" until the housekeeping sweep marks it
+				// failed. The matching +1 was seeded by
+				// KnowledgePostProcess.SetFinalizing.
+				s.finalizeWikiSubtask(mapCtx, op.KnowledgeID)
 			}
 			return nil
 		})

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -667,7 +667,17 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 	// failed).
 	failedAdditionSlugCount := len(failedAdditionSlugs)
 	for _, r := range docResults {
-		if r == nil || r.WikiSpan == nil {
+		if r == nil {
+			continue
+		}
+		// A successfully-mapped doc is terminal for its wiki op, so
+		// release the knowledge's slot in pending_subtasks_count (the row
+		// promotes to completed once the counter hits zero). Done before
+		// the WikiSpan nil-check below so a doc that had no attempt to
+		// attach a span to still drains its counter slot. The matching +1
+		// is seeded by KnowledgePostProcess.SetFinalizing.
+		s.finalizeWikiSubtask(ctx, r.KnowledgeID)
+		if r.WikiSpan == nil {
 			continue
 		}
 		writtenPages := make([]map[string]string, 0, len(r.Pages))


### PR DESCRIPTION
## Summary

Wiki ingest runs asynchronously after the parse pipeline (30s debounce + KB-scoped batch + retries) and was **not** counted in `pending_subtasks_count`. So a document flipped to `completed` while wiki generation was still minutes away — hiding the in-progress state and dropping the stop-parse affordance before wiki actually finished.

This change makes wiki a counted enrichment subtask so the row stays in `finalizing` (shown as in-progress, still cancellable) until wiki is done.

- `KnowledgePostProcess`: when `WikiEnabled && len(textChunks) > 0` (the same condition that enqueues wiki), `expectedSubtasks++` so `SetFinalizing` seeds a slot for it.
- The wiki batch worker drains that slot at the op's **terminal** state, exactly once:
  - on successful map (`wiki_ingest_batch.go`), before the span nil-check so a doc with no attempt to attach to still drains;
  - on dead-letter after exhausting in-batch retries (`requeueFailedOps`).
- Retract ops (deleted knowledge) are skipped — no counter to drain.
- `FinalizeSubtask` guards both the decrement (`count > 0`) and the promote (`finalizing AND count = 0`), so a wiki op enqueued **before** this accounting shipped is a harmless no-op on an already-completed row (safe upgrade).
- A wiki op that never drains (e.g. orphaned batch) is bounded by the existing housekeeping `finalizing` sweep, which fails the row and zeroes the counter past the stale threshold.

`wikiIngestService` gains a `KnowledgeRepository` dependency (auto-wired by dig, mirroring `ChunkExtractService`).

### Tradeoff (intended)

`completed` now arrives later — after wiki finishes — instead of immediately after the main pipeline. This is the point: it keeps "wiki processing" visible and stoppable rather than reporting a premature `completed`.

> Note: builds on the parse-status fix in #1548 (without it, text docs are marked `completed` before post-process runs, so this counter never engages).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/application/service/`
- [x] `go vet` + `gofmt` clean on changed files
- [ ] Manual: upload a doc to a wiki-enabled KB → row stays `finalizing` / in-progress with the stop button visible through the 30s debounce + wiki batch, then flips to `completed` once wiki finishes.
- [ ] Manual: wiki LLM persistently failing → row stays `finalizing` across retries, then promotes to `completed` after dead-letter (counter drained).
- [ ] Manual: non-wiki KB → unchanged behavior.