### PR TITLE
fix(knowledge): wrap locale code with LanguageLocaleName in wiki ingest prompts

### DIFF
--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -425,7 +425,7 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 						RetractDocContent: op.DocSummary,
 						DocTitle:          op.DocTitle,
 						KnowledgeID:       op.KnowledgeID,
-						Language:          op.Language,
+						Language:          types.LanguageLocaleName(op.Language),
 					})
 				}
 				mapMu.Unlock()
@@ -770,7 +770,7 @@ func (s *wikiIngestService) mapOneDocument(
 ) (*docIngestResult, []SlugUpdate, error) {
 	docStartedAt := time.Now()
 	knowledgeID := op.KnowledgeID
-	lang := op.Language
+	lang := types.LanguageLocaleName(op.Language)
 
 	// Open a postprocess.wiki subspan under the parent attempt's
 	// postprocess stage so the actual per-doc work (LLM extraction +


### PR DESCRIPTION
## What

The wiki ingest pipeline passes raw locale codes (e.g. `"zh-CN"`, `"en-US"`) directly into LLM prompts where a human-readable language name is expected. The model sees `"zh-CN"` instead of `"Chinese (Simplified)"`, which can degrade output quality.

## Root cause

`WikiIngestPayload.Language` stores a BCP-47 locale code. Two call sites forward it straight into prompt templates without converting to a descriptive name via the existing `types.LanguageLocaleName()` helper.

## Fix

Wrap both call sites with `types.LanguageLocaleName()`:

- `wiki_ingest_batch.go:428` — `SlugUpdate.Language` consumed by the reduce phase to instruct the page editor model
- `wiki_ingest_batch.go:773` — `lang` variable consumed by entity / concept extraction, chunk citation classification, and index page rebuild

Unknown locales fall through unchanged (the default branch of `LanguageLocaleName` returns the raw locale), so no information is lost.

## Test plan

- [x] Trigger wiki ingest for a `zh-CN` document, verify LLM prompt receives `"Chinese (Simplified)"` instead of `"zh-CN"`
- [x] Verify unknown locales fall through unchanged
