### PR TITLE
feat(auth): make JWT token TTL configurable via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -650,3 +650,7 @@ DOCREADER_TRANSPORT=grpc
 # Background sweep that recovers knowledge stuck in "processing" past
 # DocumentProcessTimeout + 10m. Set to "false" to opt out (not recommended).
 # WEKNORA_HOUSEKEEPING_ENABLED=true
+
+# JWT token validity period (in Go duration format, e.g., 24h / 168h); leave blank to use default values (access 24h / refresh 7d)
+JWT_ACCESS_TOKEN_TTL=
+JWT_REFRESH_TOKEN_TTL=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,7 +173,7 @@ services:
       - SSRF_WHITELIST_EXTRA=${SSRF_WHITELIST_EXTRA:-searxng}
       - CONCURRENCY_POOL_SIZE=${CONCURRENCY_POOL_SIZE:-5}
       - JWT_SECRET=${JWT_SECRET:-}
-      # JWT token 有效期（Go duration 格式，如 24h / 30m / 168h），不设置时使用默认值（access 24h / refresh 7d）
+      # JWT token 有效期（duration 格式，支持 d 天，如 24h / 30m / 30d），不设置时使用默认值（access 24h / refresh 7d）
       - JWT_ACCESS_TOKEN_TTL=${JWT_ACCESS_TOKEN_TTL:-}
       - JWT_REFRESH_TOKEN_TTL=${JWT_REFRESH_TOKEN_TTL:-}
       # Crypto: 主密钥和盐值，用于 AppSecret 等敏感字段的 AES-256 加密

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,6 +173,9 @@ services:
       - SSRF_WHITELIST_EXTRA=${SSRF_WHITELIST_EXTRA:-searxng}
       - CONCURRENCY_POOL_SIZE=${CONCURRENCY_POOL_SIZE:-5}
       - JWT_SECRET=${JWT_SECRET:-}
+      # JWT token 有效期（Go duration 格式，如 24h / 30m / 168h），不设置时使用默认值（access 24h / refresh 7d）
+      - JWT_ACCESS_TOKEN_TTL=${JWT_ACCESS_TOKEN_TTL:-}
+      - JWT_REFRESH_TOKEN_TTL=${JWT_REFRESH_TOKEN_TTL:-}
       # Crypto: 主密钥和盐值，用于 AppSecret 等敏感字段的 AES-256 加密
       # 若不设置则自动生成并持久化到 data-files volume（/data/files/.crypto_state.json）
       # 重启时自动从文件恢复，保证已加密数据可继续解密

--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -1,5 +1,5 @@
-// @ts-nocheck
 <script setup lang="ts">
+// @ts-nocheck
 import { marked } from "marked";
 import markedKatex from 'marked-katex-extension';
 import 'katex/dist/katex.min.css';
@@ -153,6 +153,7 @@ function onTraceDrawerResizeEnd() {
 
 function onTraceDrawerWindowResize() {
   timelineDrawerWidth.value = clampTraceDrawerWidth(timelineDrawerWidth.value);
+  mainDrawerWidth.value = clampMainDrawerWidth(mainDrawerWidth.value);
 }
 
 function cleanupTraceDrawerResize() {
@@ -161,6 +162,74 @@ function cleanupTraceDrawerResize() {
   document.body.style.cursor = '';
   document.body.style.userSelect = '';
   timelineDrawerResizing.value = false;
+}
+
+// ============== 主抽屉（文档详情）宽度可调 ==============
+const MAIN_DRAWER_WIDTH_KEY = 'weknora-doc-drawer-width';
+const MAIN_DRAWER_DEFAULT_WIDTH = 654;
+const MAIN_DRAWER_MIN_WIDTH = 480;
+
+const mainDrawerWidth = ref(MAIN_DRAWER_DEFAULT_WIDTH);
+const mainDrawerResizing = ref(false);
+
+let mainResizeStartX = 0;
+let mainResizeStartWidth = 0;
+
+function mainDrawerMaxWidth() {
+  return Math.min(1600, Math.max(MAIN_DRAWER_MIN_WIDTH, Math.floor(window.innerWidth * 0.95)));
+}
+
+function clampMainDrawerWidth(width: number) {
+  return Math.max(MAIN_DRAWER_MIN_WIDTH, Math.min(mainDrawerMaxWidth(), width));
+}
+
+function loadMainDrawerWidth() {
+  try {
+    const raw = localStorage.getItem(MAIN_DRAWER_WIDTH_KEY);
+    const parsed = raw ? parseInt(raw, 10) : NaN;
+    if (!Number.isNaN(parsed)) {
+      mainDrawerWidth.value = clampMainDrawerWidth(parsed);
+    }
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+function onMainDrawerResizeStart(e: MouseEvent) {
+  mainDrawerResizing.value = true;
+  mainResizeStartX = e.clientX;
+  mainResizeStartWidth = mainDrawerWidth.value;
+  document.addEventListener('mousemove', onMainDrawerResizeMove);
+  document.addEventListener('mouseup', onMainDrawerResizeEnd);
+  document.body.style.cursor = 'col-resize';
+  document.body.style.userSelect = 'none';
+}
+
+function onMainDrawerResizeMove(e: MouseEvent) {
+  // 抽屉在右侧，向左拖动变宽
+  const delta = mainResizeStartX - e.clientX;
+  mainDrawerWidth.value = clampMainDrawerWidth(mainResizeStartWidth + delta);
+}
+
+function onMainDrawerResizeEnd() {
+  document.removeEventListener('mousemove', onMainDrawerResizeMove);
+  document.removeEventListener('mouseup', onMainDrawerResizeEnd);
+  document.body.style.cursor = '';
+  document.body.style.userSelect = '';
+  mainDrawerResizing.value = false;
+  try {
+    localStorage.setItem(MAIN_DRAWER_WIDTH_KEY, String(mainDrawerWidth.value));
+  } catch {
+    /* ignore */
+  }
+}
+
+function cleanupMainDrawerResize() {
+  document.removeEventListener('mousemove', onMainDrawerResizeMove);
+  document.removeEventListener('mouseup', onMainDrawerResizeEnd);
+  document.body.style.cursor = '';
+  document.body.style.userSelect = '';
+  mainDrawerResizing.value = false;
 }
 
 const traceEntryTheme = computed(() => {
@@ -299,6 +368,7 @@ const mergeChunks = (chunks: any[]): string => {
 
 onMounted(() => {
   loadTraceDrawerWidth();
+  loadMainDrawerWidth();
   window.addEventListener('resize', onTraceDrawerWindowResize, { passive: true });
   nextTick(() => {
     const drawers = document.getElementsByClassName('t-drawer__body');
@@ -332,6 +402,7 @@ watch(() => props.details?.chunkLoading, (val) => {
 onUnmounted(() => {
   window.removeEventListener('resize', onTraceDrawerWindowResize);
   cleanupTraceDrawerResize();
+  cleanupMainDrawerResize();
   if (doc) {
     doc.removeEventListener('scroll', handleDetailsScroll);
   }
@@ -921,7 +992,14 @@ const handleDetailsScroll = () => {
 </script>
 <template>
   <div class="doc_content" ref="mdContentWrap">
-    <t-drawer :visible="visible" :zIndex="2000" size="654px" attach="body" :closeBtn="true" :footer="false"
+    <teleport to="body">
+      <div v-if="visible" class="doc-drawer-resize-handle" :style="{ right: `${mainDrawerWidth}px` }" role="separator"
+        aria-orientation="vertical" @mousedown.prevent="onMainDrawerResizeStart">
+        <div class="doc-drawer-resize-line" />
+      </div>
+    </teleport>
+    <t-drawer :visible="visible" :zIndex="2000" :size="`${mainDrawerWidth}px`" attach="body" :closeBtn="true"
+      :footer="false" :class="['doc-main-drawer', { 'doc-main-drawer--resizing': mainDrawerResizing }]"
       @close="handleClose">
       <template #header>
         <div class="drawer-header">
@@ -1009,7 +1087,7 @@ const handleDetailsScroll = () => {
           @click="(summaryOverflow || summaryExpanded) && (summaryExpanded = !summaryExpanded)">
           <div ref="summaryRef" :class="['summary_content', { 'summary_collapsed': !summaryExpanded }]">{{
             details.description
-          }}</div>
+            }}</div>
           <div v-if="(summaryOverflow && !summaryExpanded) || summaryExpanded" class="summary_fade"
             :class="{ 'summary_fade_expanded': summaryExpanded }">
             <t-icon :name="summaryExpanded ? 'chevron-up' : 'chevron-down'" size="14px" class="summary_fade_icon" />
@@ -1728,6 +1806,40 @@ const handleDetailsScroll = () => {
      content background need to be flushed for the timeline to fill
      edge-to-edge. -->
 <style lang="less">
+/* 主抽屉宽度可调：拖拽手柄通过 teleport 挂到 body，不受 scoped 影响，
+   故样式写在非 scoped 块里。手柄贴在抽屉面板左缘（right = 抽屉宽度）。 */
+.doc-drawer-resize-handle {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  width: 12px;
+  margin-left: -6px;
+  cursor: col-resize;
+  z-index: 2001;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.doc-drawer-resize-handle .doc-drawer-resize-line {
+  width: 2px;
+  height: 48px;
+  border-radius: 1px;
+  background: var(--td-component-border);
+  opacity: 0.55;
+  transition: opacity 0.15s ease, background 0.15s ease;
+}
+
+.doc-drawer-resize-handle:hover .doc-drawer-resize-line {
+  opacity: 1;
+  background: var(--td-brand-color);
+}
+
+/* 拖拽过程中关闭宽度过渡，避免跟手卡顿 */
+.t-drawer.doc-main-drawer--resizing .t-drawer__content {
+  transition: none !important;
+}
+
 .t-drawer.kp-secondary-drawer .t-drawer__body {
   padding: 0 !important;
 }

--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -1,5 +1,5 @@
-<script setup lang="ts">
 // @ts-nocheck
+<script setup lang="ts">
 import { marked } from "marked";
 import markedKatex from 'marked-katex-extension';
 import 'katex/dist/katex.min.css';
@@ -153,7 +153,6 @@ function onTraceDrawerResizeEnd() {
 
 function onTraceDrawerWindowResize() {
   timelineDrawerWidth.value = clampTraceDrawerWidth(timelineDrawerWidth.value);
-  mainDrawerWidth.value = clampMainDrawerWidth(mainDrawerWidth.value);
 }
 
 function cleanupTraceDrawerResize() {
@@ -162,74 +161,6 @@ function cleanupTraceDrawerResize() {
   document.body.style.cursor = '';
   document.body.style.userSelect = '';
   timelineDrawerResizing.value = false;
-}
-
-// ============== 主抽屉（文档详情）宽度可调 ==============
-const MAIN_DRAWER_WIDTH_KEY = 'weknora-doc-drawer-width';
-const MAIN_DRAWER_DEFAULT_WIDTH = 654;
-const MAIN_DRAWER_MIN_WIDTH = 480;
-
-const mainDrawerWidth = ref(MAIN_DRAWER_DEFAULT_WIDTH);
-const mainDrawerResizing = ref(false);
-
-let mainResizeStartX = 0;
-let mainResizeStartWidth = 0;
-
-function mainDrawerMaxWidth() {
-  return Math.min(1600, Math.max(MAIN_DRAWER_MIN_WIDTH, Math.floor(window.innerWidth * 0.95)));
-}
-
-function clampMainDrawerWidth(width: number) {
-  return Math.max(MAIN_DRAWER_MIN_WIDTH, Math.min(mainDrawerMaxWidth(), width));
-}
-
-function loadMainDrawerWidth() {
-  try {
-    const raw = localStorage.getItem(MAIN_DRAWER_WIDTH_KEY);
-    const parsed = raw ? parseInt(raw, 10) : NaN;
-    if (!Number.isNaN(parsed)) {
-      mainDrawerWidth.value = clampMainDrawerWidth(parsed);
-    }
-  } catch {
-    /* ignore quota / private mode */
-  }
-}
-
-function onMainDrawerResizeStart(e: MouseEvent) {
-  mainDrawerResizing.value = true;
-  mainResizeStartX = e.clientX;
-  mainResizeStartWidth = mainDrawerWidth.value;
-  document.addEventListener('mousemove', onMainDrawerResizeMove);
-  document.addEventListener('mouseup', onMainDrawerResizeEnd);
-  document.body.style.cursor = 'col-resize';
-  document.body.style.userSelect = 'none';
-}
-
-function onMainDrawerResizeMove(e: MouseEvent) {
-  // 抽屉在右侧，向左拖动变宽
-  const delta = mainResizeStartX - e.clientX;
-  mainDrawerWidth.value = clampMainDrawerWidth(mainResizeStartWidth + delta);
-}
-
-function onMainDrawerResizeEnd() {
-  document.removeEventListener('mousemove', onMainDrawerResizeMove);
-  document.removeEventListener('mouseup', onMainDrawerResizeEnd);
-  document.body.style.cursor = '';
-  document.body.style.userSelect = '';
-  mainDrawerResizing.value = false;
-  try {
-    localStorage.setItem(MAIN_DRAWER_WIDTH_KEY, String(mainDrawerWidth.value));
-  } catch {
-    /* ignore */
-  }
-}
-
-function cleanupMainDrawerResize() {
-  document.removeEventListener('mousemove', onMainDrawerResizeMove);
-  document.removeEventListener('mouseup', onMainDrawerResizeEnd);
-  document.body.style.cursor = '';
-  document.body.style.userSelect = '';
-  mainDrawerResizing.value = false;
 }
 
 const traceEntryTheme = computed(() => {
@@ -368,7 +299,6 @@ const mergeChunks = (chunks: any[]): string => {
 
 onMounted(() => {
   loadTraceDrawerWidth();
-  loadMainDrawerWidth();
   window.addEventListener('resize', onTraceDrawerWindowResize, { passive: true });
   nextTick(() => {
     const drawers = document.getElementsByClassName('t-drawer__body');
@@ -402,7 +332,6 @@ watch(() => props.details?.chunkLoading, (val) => {
 onUnmounted(() => {
   window.removeEventListener('resize', onTraceDrawerWindowResize);
   cleanupTraceDrawerResize();
-  cleanupMainDrawerResize();
   if (doc) {
     doc.removeEventListener('scroll', handleDetailsScroll);
   }
@@ -992,14 +921,7 @@ const handleDetailsScroll = () => {
 </script>
 <template>
   <div class="doc_content" ref="mdContentWrap">
-    <teleport to="body">
-      <div v-if="visible" class="doc-drawer-resize-handle" :style="{ right: `${mainDrawerWidth}px` }" role="separator"
-        aria-orientation="vertical" @mousedown.prevent="onMainDrawerResizeStart">
-        <div class="doc-drawer-resize-line" />
-      </div>
-    </teleport>
-    <t-drawer :visible="visible" :zIndex="2000" :size="`${mainDrawerWidth}px`" attach="body" :closeBtn="true"
-      :footer="false" :class="['doc-main-drawer', { 'doc-main-drawer--resizing': mainDrawerResizing }]"
+    <t-drawer :visible="visible" :zIndex="2000" size="654px" attach="body" :closeBtn="true" :footer="false"
       @close="handleClose">
       <template #header>
         <div class="drawer-header">
@@ -1087,7 +1009,7 @@ const handleDetailsScroll = () => {
           @click="(summaryOverflow || summaryExpanded) && (summaryExpanded = !summaryExpanded)">
           <div ref="summaryRef" :class="['summary_content', { 'summary_collapsed': !summaryExpanded }]">{{
             details.description
-            }}</div>
+          }}</div>
           <div v-if="(summaryOverflow && !summaryExpanded) || summaryExpanded" class="summary_fade"
             :class="{ 'summary_fade_expanded': summaryExpanded }">
             <t-icon :name="summaryExpanded ? 'chevron-up' : 'chevron-down'" size="14px" class="summary_fade_icon" />
@@ -1806,40 +1728,6 @@ const handleDetailsScroll = () => {
      content background need to be flushed for the timeline to fill
      edge-to-edge. -->
 <style lang="less">
-/* 主抽屉宽度可调：拖拽手柄通过 teleport 挂到 body，不受 scoped 影响，
-   故样式写在非 scoped 块里。手柄贴在抽屉面板左缘（right = 抽屉宽度）。 */
-.doc-drawer-resize-handle {
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  width: 12px;
-  margin-left: -6px;
-  cursor: col-resize;
-  z-index: 2001;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.doc-drawer-resize-handle .doc-drawer-resize-line {
-  width: 2px;
-  height: 48px;
-  border-radius: 1px;
-  background: var(--td-component-border);
-  opacity: 0.55;
-  transition: opacity 0.15s ease, background 0.15s ease;
-}
-
-.doc-drawer-resize-handle:hover .doc-drawer-resize-line {
-  opacity: 1;
-  background: var(--td-brand-color);
-}
-
-/* 拖拽过程中关闭宽度过渡，避免跟手卡顿 */
-.t-drawer.doc-main-drawer--resizing .t-drawer__content {
-  transition: none !important;
-}
-
 .t-drawer.kp-secondary-drawer .t-drawer__body {
   padding: 0 !important;
 }

--- a/helm/templates/app.yaml
+++ b/helm/templates/app.yaml
@@ -99,6 +99,14 @@ spec:
                 secretKeyRef:
                   name: {{ include "weknora.secretName" . }}
                   key: JWT_SECRET
+            {{- with .Values.app.env.JWT_ACCESS_TOKEN_TTL }}
+            - name: JWT_ACCESS_TOKEN_TTL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.app.env.JWT_REFRESH_TOKEN_TTL }}
+            - name: JWT_REFRESH_TOKEN_TTL
+              value: {{ . | quote }}
+            {{- end }}
             - name: TENANT_AES_KEY
               valueFrom:
                 secretKeyRef:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -98,7 +98,7 @@ app:
     CONCURRENCY_POOL_SIZE: "5"
     ENABLE_GRAPH_RAG: "false"
     TZ: UTC
-    # -- JWT token 有效期 (Go duration 格式, 如 24h / 30m / 168h)。
+    # -- JWT token 有效期 (duration 格式, 支持 d 天, 如 24h / 30m / 30d)。
     # 留空则使用应用默认值 (access token 24h / refresh token 7d)。
     JWT_ACCESS_TOKEN_TTL: ""
     JWT_REFRESH_TOKEN_TTL: ""

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -98,6 +98,10 @@ app:
     CONCURRENCY_POOL_SIZE: "5"
     ENABLE_GRAPH_RAG: "false"
     TZ: UTC
+    # -- JWT token 有效期 (Go duration 格式, 如 24h / 30m / 168h)。
+    # 留空则使用应用默认值 (access token 24h / refresh token 7d)。
+    JWT_ACCESS_TOKEN_TTL: ""
+    JWT_REFRESH_TOKEN_TTL: ""
 
   # -- Additional environment variables
   extraEnv: []

--- a/internal/application/service/token_ttl_test.go
+++ b/internal/application/service/token_ttl_test.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+// parseDuration extends time.ParseDuration with a "d" (day) unit. These tests
+// are pure-function so they need no DB/repo plumbing.
+func TestParseDuration(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "days", in: "30d", want: 30 * 24 * time.Hour},
+		{name: "single day", in: "7d", want: 7 * 24 * time.Hour},
+		{name: "fractional day", in: "0.5d", want: 12 * time.Hour},
+		{name: "native hours", in: "24h", want: 24 * time.Hour},
+		{name: "native minutes", in: "30m", want: 30 * time.Minute},
+		{name: "native composite", in: "1h30m", want: 90 * time.Minute},
+		{name: "garbage", in: "abc", wantErr: true},
+		{name: "bare unit", in: "d", wantErr: true},
+		{name: "empty", in: "", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseDuration(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseDuration(%q) = %v, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseDuration(%q) unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseDuration(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// parseDurationEnv reads a duration from an env var, falling back to the given
+// default when the var is unset, unparseable, or non-positive.
+func TestParseDurationEnv(t *testing.T) {
+	const key = "WEKNORA_TEST_TTL"
+	fallback := 24 * time.Hour
+
+	// An empty value exercises the same branch as an unset var (both trim to "").
+	cases := []struct {
+		name string
+		val  string
+		want time.Duration
+	}{
+		{name: "empty uses fallback", val: "", want: fallback},
+		{name: "whitespace uses fallback", val: "   ", want: fallback},
+		{name: "valid days override", val: "30d", want: 30 * 24 * time.Hour},
+		{name: "valid hours override", val: "48h", want: 48 * time.Hour},
+		{name: "invalid falls back", val: "nope", want: fallback},
+		{name: "zero falls back", val: "0h", want: fallback},
+		{name: "negative falls back", val: "-5h", want: fallback},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(key, tc.val)
+			if got := parseDurationEnv(key, fallback); got != tc.want {
+				t.Fatalf("parseDurationEnv(%s=%q) = %v, want %v", key, tc.val, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/application/service/user.go
+++ b/internal/application/service/user.go
@@ -35,7 +35,54 @@ type oidcAuthorizationState struct {
 var (
 	jwtSecretOnce sync.Once
 	jwtSecret     string
+
+	accessTokenTTLOnce  sync.Once
+	accessTokenTTL      time.Duration
+	refreshTokenTTLOnce sync.Once
+	refreshTokenTTL     time.Duration
 )
+
+// Default token lifetimes, used when the corresponding env var is unset or invalid.
+const (
+	defaultAccessTokenTTL  = 24 * time.Hour
+	defaultRefreshTokenTTL = 7 * 24 * time.Hour
+)
+
+// getAccessTokenTTL returns the access token lifetime. It is configurable via the
+// JWT_ACCESS_TOKEN_TTL env var using Go duration syntax (e.g. "24h", "30m", "168h"),
+// falling back to defaultAccessTokenTTL when unset or invalid.
+func getAccessTokenTTL() time.Duration {
+	accessTokenTTLOnce.Do(func() {
+		accessTokenTTL = parseDurationEnv("JWT_ACCESS_TOKEN_TTL", defaultAccessTokenTTL)
+	})
+	return accessTokenTTL
+}
+
+// getRefreshTokenTTL returns the refresh token lifetime. It is configurable via the
+// JWT_REFRESH_TOKEN_TTL env var using Go duration syntax (e.g. "168h", "720h"),
+// falling back to defaultRefreshTokenTTL when unset or invalid.
+func getRefreshTokenTTL() time.Duration {
+	refreshTokenTTLOnce.Do(func() {
+		refreshTokenTTL = parseDurationEnv("JWT_REFRESH_TOKEN_TTL", defaultRefreshTokenTTL)
+	})
+	return refreshTokenTTL
+}
+
+// parseDurationEnv reads a Go duration from the given env var, returning fallback
+// when the var is unset, unparseable, or non-positive.
+func parseDurationEnv(key string, fallback time.Duration) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		logger.Warnf(context.Background(),
+			"invalid %s=%q, falling back to %s", key, raw, fallback)
+		return fallback
+	}
+	return d
+}
 
 // getJwtSecret retrieves the JWT secret from the environment, falling back to a securely generated random secret.
 func getJwtSecret() string {
@@ -698,13 +745,17 @@ func (s *userService) generateTokensForTenant(
 	user *types.User,
 	activeTenantID uint64,
 ) (accessToken, refreshToken string, err error) {
-	// Generate access token (expires in 24 hours)
+	now := time.Now()
+	accessExpiresAt := now.Add(getAccessTokenTTL())
+	refreshExpiresAt := now.Add(getRefreshTokenTTL())
+
+	// Generate access token (lifetime configurable via JWT_ACCESS_TOKEN_TTL)
 	accessClaims := jwt.MapClaims{
 		"user_id":   user.ID,
 		"email":     user.Email,
 		"tenant_id": activeTenantID,
-		"exp":       time.Now().Add(24 * time.Hour).Unix(),
-		"iat":       time.Now().Unix(),
+		"exp":       accessExpiresAt.Unix(),
+		"iat":       now.Unix(),
 		"type":      "access",
 	}
 
@@ -714,11 +765,11 @@ func (s *userService) generateTokensForTenant(
 		return "", "", err
 	}
 
-	// Generate refresh token (expires in 7 days)
+	// Generate refresh token (lifetime configurable via JWT_REFRESH_TOKEN_TTL)
 	refreshClaims := jwt.MapClaims{
 		"user_id": user.ID,
-		"exp":     time.Now().Add(7 * 24 * time.Hour).Unix(),
-		"iat":     time.Now().Unix(),
+		"exp":     refreshExpiresAt.Unix(),
+		"iat":     now.Unix(),
 		"type":    "refresh",
 	}
 
@@ -734,9 +785,9 @@ func (s *userService) generateTokensForTenant(
 		UserID:    user.ID,
 		Token:     accessToken,
 		TokenType: "access_token",
-		ExpiresAt: time.Now().Add(24 * time.Hour),
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		ExpiresAt: accessExpiresAt,
+		CreatedAt: now,
+		UpdatedAt: now,
 	}
 
 	refreshTokenRecord := &types.AuthToken{
@@ -744,9 +795,9 @@ func (s *userService) generateTokensForTenant(
 		UserID:    user.ID,
 		Token:     refreshToken,
 		TokenType: "refresh_token",
-		ExpiresAt: time.Now().Add(7 * 24 * time.Hour),
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		ExpiresAt: refreshExpiresAt,
+		CreatedAt: now,
+		UpdatedAt: now,
 	}
 
 	_ = s.tokenRepo.CreateToken(ctx, accessTokenRecord)

--- a/internal/application/service/user.go
+++ b/internal/application/service/user.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -49,7 +50,7 @@ const (
 )
 
 // getAccessTokenTTL returns the access token lifetime. It is configurable via the
-// JWT_ACCESS_TOKEN_TTL env var using Go duration syntax (e.g. "24h", "30m", "168h"),
+// JWT_ACCESS_TOKEN_TTL env var using duration syntax (e.g. "24h", "30m", "30d"),
 // falling back to defaultAccessTokenTTL when unset or invalid.
 func getAccessTokenTTL() time.Duration {
 	accessTokenTTLOnce.Do(func() {
@@ -59,7 +60,7 @@ func getAccessTokenTTL() time.Duration {
 }
 
 // getRefreshTokenTTL returns the refresh token lifetime. It is configurable via the
-// JWT_REFRESH_TOKEN_TTL env var using Go duration syntax (e.g. "168h", "720h"),
+// JWT_REFRESH_TOKEN_TTL env var using duration syntax (e.g. "168h", "7d", "30d"),
 // falling back to defaultRefreshTokenTTL when unset or invalid.
 func getRefreshTokenTTL() time.Duration {
 	refreshTokenTTLOnce.Do(func() {
@@ -68,20 +69,34 @@ func getRefreshTokenTTL() time.Duration {
 	return refreshTokenTTL
 }
 
-// parseDurationEnv reads a Go duration from the given env var, returning fallback
+// parseDurationEnv reads a duration from the given env var, returning fallback
 // when the var is unset, unparseable, or non-positive.
 func parseDurationEnv(key string, fallback time.Duration) time.Duration {
 	raw := strings.TrimSpace(os.Getenv(key))
 	if raw == "" {
 		return fallback
 	}
-	d, err := time.ParseDuration(raw)
+	d, err := parseDuration(raw)
 	if err != nil || d <= 0 {
 		logger.Warnf(context.Background(),
 			"invalid %s=%q, falling back to %s", key, raw, fallback)
 		return fallback
 	}
 	return d
+}
+
+// parseDuration extends time.ParseDuration with a "d" (day) unit so that
+// values like "30d" work, since the standard library only supports up to "h".
+// Anything not ending in "d" is delegated to time.ParseDuration as-is.
+func parseDuration(s string) (time.Duration, error) {
+	if days, ok := strings.CutSuffix(s, "d"); ok {
+		n, err := strconv.ParseFloat(days, 64)
+		if err != nil {
+			return 0, err
+		}
+		return time.Duration(n * 24 * float64(time.Hour)), nil
+	}
+	return time.ParseDuration(s)
 }
 
 // getJwtSecret retrieves the JWT secret from the environment, falling back to a securely generated random secret.


### PR DESCRIPTION
## Description

JWT access/refresh token lifetimes were previously hardcoded (access: 24h, refresh: 7d) in `generateTokensForTenant`. This PR makes both configurable through environment variables, with full backward compatibility — when unset, the original defaults are used.

- Add `JWT_ACCESS_TOKEN_TTL` and `JWT_REFRESH_TOKEN_TTL` env vars (default `24h` / `7d`).
- Values accept Go duration syntax **plus a `d` (day) suffix** (e.g. `30m`, `24h`, `30d`), since the stdlib `time.ParseDuration` only supports units up to `h`. Invalid or non-positive values log a warning and fall back to the default.
- Compute the issuing timestamp once so the JWT `exp` claim and the persisted `AuthToken.ExpiresAt` stay in sync (previously they used separate `time.Now()` calls).
- Wire the new vars through `docker-compose.yml` and the Helm chart (`values.yaml` + `templates/app.yaml`, injected only when non-empty).

The refresh flow (`RefreshToken`) reuses `GenerateTokens`, so it picks up the configured TTLs automatically — no separate change needed.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [x] 🔧 Configuration / Build / CI

## Related Issue

Fixes #

## Testing

- Added `internal/application/service/token_ttl_test.go` with table-driven coverage:
  - `parseDuration`: `d` (day) unit (`30d`, `7d`, `0.5d`), native formats (`24h`, `30m`, `1h30m`), and error cases (`abc`, `d`, empty).
  - `parseDurationEnv`: empty/whitespace → fallback, valid overrides (`30d`, `48h`), and invalid/zero/negative → fallback.
- `go test ./internal/application/service/ -run 'TestParseDuration|TestParseDurationEnv' -v` — all pass.
- `go vet ./internal/application/service/` — clean.
- `helm template` verified: TTL env vars are injected when set, and omitted entirely when left blank (matching the docker-compose `${VAR:-}` behavior).

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A — no user-visible UI changes.