### PR TITLE
feat(startup): support APP_ROLE for API/Worker process isolation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -650,3 +650,14 @@ DOCREADER_TRANSPORT=grpc
 # Background sweep that recovers knowledge stuck in "processing" past
 # DocumentProcessTimeout + 10m. Set to "false" to opt out (not recommended).
 # WEKNORA_HOUSEKEEPING_ENABLED=true
+
+# Deployment role gating which in-process background components run
+# (does not affect HTTP API wiring):
+#   all    - default; full single process (HTTP API + asynq worker + scheduler
+#            + offline maintenance), identical to historical behavior
+#   api    - HTTP API + enqueue + scheduler only, no worker; runtime requests
+#            are not affected by offline task load
+#   worker - asynq worker + offline maintenance only; serves no business traffic
+# To split: set APP_ROLE=api on the traffic-serving group and APP_ROLE=worker
+# on the offline group, both pointing at the same Redis/DB.
+APP_ROLE=all

--- a/helm/templates/app.yaml
+++ b/helm/templates/app.yaml
@@ -49,6 +49,8 @@ spec:
             # Application settings
             - name: GIN_MODE
               value: {{ .Values.app.env.GIN_MODE | quote }}
+            - name: APP_ROLE
+              value: {{ .Values.app.env.APP_ROLE | quote }}
             - name: TZ
               value: {{ .Values.app.env.TZ | quote }}
             # Database configuration

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -88,6 +88,14 @@ app:
   # Ref: https://github.com/Tencent/WeKnora/blob/main/docker-compose.yml
   env:
     GIN_MODE: release
+    # -- Deployment role gating which in-process background components run.
+    # "all" (default) runs everything (HTTP API + asynq worker + scheduler +
+    # retention) — identical to historical single-process behavior. "api" runs
+    # HTTP API + enqueue + scheduler but no worker, so runtime requests aren't
+    # affected by offline task load. "worker" runs the asynq worker + offline
+    # maintenance only. To split into two groups, deploy this chart twice (or
+    # add your own worker Deployment) with APP_ROLE=api and APP_ROLE=worker.
+    APP_ROLE: all
     # -- Retrieval driver: postgres, elasticsearch_v7, elasticsearch_v8, qdrant
     RETRIEVE_DRIVER: postgres
     # -- Storage type: local, minio, cos, tos, s3

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -75,6 +75,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/models/embedding"
 	"github.com/Tencent/WeKnora/internal/models/utils/ollama"
 	"github.com/Tencent/WeKnora/internal/router"
+	"github.com/Tencent/WeKnora/internal/runtime"
 	"github.com/Tencent/WeKnora/internal/stream"
 	"github.com/Tencent/WeKnora/internal/tracing"
 	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
@@ -253,6 +254,8 @@ func BuildContainer(container *dig.Container) *dig.Container {
 
 	logger.Debugf(ctx, "[Container] Registering task enqueuer...")
 	redisAvailable := os.Getenv("REDIS_ADDR") != ""
+	appRole := runtime.ResolveAppRole()
+	logger.Infof(ctx, "[Container] APP_ROLE resolved to %q (redisAvailable=%v)", appRole, redisAvailable)
 	if redisAvailable {
 		must(container.Provide(router.NewAsyncqClient, dig.As(new(interfaces.TaskEnqueuer))))
 		must(container.Provide(router.NewAsynqServer))
@@ -278,9 +281,13 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(initConnectorRegistry))
 	must(container.Provide(datasource.NewScheduler))
 	must(container.Provide(service.NewDataSourceService))
-	must(container.Invoke(startDataSourceScheduler))
+	if appRole.RunsScheduler() {
+		must(container.Invoke(startDataSourceScheduler))
+	}
 	logger.Debugf(ctx, "[Container] Data source sync framework registered")
-	must(container.Invoke(startAuditLogRetention))
+	if appRole.RunsWorker() {
+		must(container.Invoke(startAuditLogRetention))
+	}
 	logger.Debugf(ctx, "[Container] Audit log retention runner registered")
 	must(container.Provide(service.NewHousekeepingService))
 	must(container.Invoke(startHousekeepingService))
@@ -352,7 +359,9 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	logger.Debugf(ctx, "[Container] Registering router and starting task server...")
 	must(container.Provide(router.NewRouter))
 	if redisAvailable {
-		must(container.Invoke(router.RunAsynqServer))
+		if appRole.RunsWorker() {
+			must(container.Invoke(router.RunAsynqServer))
+		}
 	} else {
 		must(container.Invoke(router.RegisterSyncHandlers))
 	}

--- a/internal/runtime/role.go
+++ b/internal/runtime/role.go
@@ -1,0 +1,52 @@
+package runtime
+
+import (
+	"os"
+	"strings"
+)
+
+// AppRole is the deployment role this process plays. It only decides which
+// in-process background components start; it never affects HTTP API wiring —
+// the HTTP server listens in every role.
+//
+// The role comes from the APP_ROLE environment variable. Empty or unrecognized
+// values normalize to RoleAll, so existing single-process deployments, local
+// development, and the desktop build are unaffected.
+type AppRole string
+
+const (
+	// RoleAll runs everything in one process — the historical default behavior.
+	RoleAll AppRole = "all"
+	// RoleAPI is the runtime side: HTTP API + enqueue client + DataSourceScheduler,
+	// with no asynq worker.
+	RoleAPI AppRole = "api"
+	// RoleWorker is the offline side: asynq worker + AuditLogRetention, with no
+	// scheduler.
+	RoleWorker AppRole = "worker"
+)
+
+// ResolveAppRole reads and normalizes the APP_ROLE environment variable.
+// It is case-insensitive and trims surrounding whitespace; empty or
+// unrecognized values fall back to RoleAll.
+func ResolveAppRole() AppRole {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("APP_ROLE"))) {
+	case string(RoleAPI):
+		return RoleAPI
+	case string(RoleWorker):
+		return RoleWorker
+	default:
+		return RoleAll
+	}
+}
+
+// RunsWorker reports whether this role starts the asynq worker and offline
+// maintenance tasks (audit retention).
+func (r AppRole) RunsWorker() bool {
+	return r == RoleAll || r == RoleWorker
+}
+
+// RunsScheduler reports whether this role starts the DataSourceScheduler
+// (periodic enqueue — producer semantics).
+func (r AppRole) RunsScheduler() bool {
+	return r == RoleAll || r == RoleAPI
+}

--- a/internal/runtime/role_test.go
+++ b/internal/runtime/role_test.go
@@ -1,0 +1,49 @@
+package runtime
+
+import "testing"
+
+func TestResolveAppRole(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want AppRole
+	}{
+		{"empty defaults to all", "", RoleAll},
+		{"explicit all", "all", RoleAll},
+		{"api", "api", RoleAPI},
+		{"worker", "worker", RoleWorker},
+		{"uppercase normalized", "WORKER", RoleWorker},
+		{"whitespace trimmed", "  api  ", RoleAPI},
+		{"unknown falls back to all", "frontend", RoleAll},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("APP_ROLE", c.env)
+			if got := ResolveAppRole(); got != c.want {
+				t.Fatalf("ResolveAppRole() with APP_ROLE=%q = %q, want %q", c.env, got, c.want)
+			}
+		})
+	}
+}
+
+func TestAppRolePredicates(t *testing.T) {
+	cases := []struct {
+		role          AppRole
+		runsWorker    bool
+		runsScheduler bool
+	}{
+		{RoleAll, true, true},
+		{RoleAPI, false, true},
+		{RoleWorker, true, false},
+	}
+	for _, c := range cases {
+		t.Run(string(c.role), func(t *testing.T) {
+			if got := c.role.RunsWorker(); got != c.runsWorker {
+				t.Errorf("%q.RunsWorker() = %v, want %v", c.role, got, c.runsWorker)
+			}
+			if got := c.role.RunsScheduler(); got != c.runsScheduler {
+				t.Errorf("%q.RunsScheduler() = %v, want %v", c.role, got, c.runsScheduler)
+			}
+		})
+	}
+}

--- a/internal/runtime/startup.go
+++ b/internal/runtime/startup.go
@@ -76,6 +76,7 @@ var startupEnvVars = []envVarSpec{
 	{name: "SYSTEM_AES_KEY", sensitive: true},
 	{name: "JWT_SECRET", sensitive: true},
 	// Runtime
+	{name: "APP_ROLE"},
 	{name: "GIN_MODE"},
 	{name: "AUTO_MIGRATE"},
 	// Database


### PR DESCRIPTION
## Description

Server-side processing previously ran as a single all-in-one process: the same binary served the HTTP API (runtime), enqueued asynq tasks (producer), **and** ran the asynq worker that processes heavy offline jobs (consumer). Since asynq requires the producer and consumer to share one Redis broker, the runtime API and offline task processing competed for the same process resources — a backlog of offline work could degrade live request latency.

This PR adds an `APP_ROLE` environment variable so the **same binary/image** can be deployed as separate container groups, isolating the runtime API from offline worker load. Isolation happens at the process/deployment layer; Redis is not split.

- Add `APP_ROLE` (values `all` / `api` / `worker`, default `all`). It only gates which in-process background components start — it never touches HTTP API wiring, so the HTTP server listens in every role.
  - `all` — full single process (HTTP API + asynq worker + scheduler + retention), identical to historical behavior.
  - `api` — HTTP API + enqueue + `DataSourceScheduler`, **no** asynq worker; runtime requests are unaffected by offline task load.
  - `worker` — asynq worker + `AuditLogRetention` only; serves no business traffic.
- Empty or unrecognized values normalize to `all`, so existing single-process deployments, local dev, and the desktop build are unaffected.
- Gate the three in-process background startups in `BuildContainer` by role; the asynq client/server `Provide` calls stay as-is (dig is lazy), and the no-Redis `SyncTaskExecutor` fallback is orthogonal to role.
- Log the resolved role at boot and surface `APP_ROLE` in the startup env banner.
- Wire `APP_ROLE` through the Helm chart (`values.yaml` + `templates/app.yaml`), defaulting to `all`.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [x] 🔧 Configuration / Build / CI

## Related Issue

Fixes #

## Testing

- Added `internal/runtime/role_test.go` with table-driven coverage:
  - `ResolveAppRole`: empty → `all`, explicit `all`/`api`/`worker`, case normalization (`WORKER`), whitespace trimming (`  api  `), and unknown values (`frontend`) → `all`.
  - `RunsWorker` / `RunsScheduler` predicates for all three roles.
- `go test ./internal/runtime/` — all pass.
- `go build ./...` and `go vet ./internal/runtime/ ./internal/container/` — clean.
- `helm lint` passes; `helm template` verified `APP_ROLE` renders into the app Deployment (defaults to `all`).

## Checklist

- [x] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A — no user-visible UI changes.
