### PR TITLE
refactor(settings): unify drawer style across model/parser/storage/vector/websearch/mcp

### DIFF
--- a/frontend/src/components/CreateTenantDialog.vue
+++ b/frontend/src/components/CreateTenantDialog.vue
@@ -18,7 +18,7 @@
     <t-form ref="formRef" :data="form" :rules="formRules" label-align="top" class="create-tenant-form" @submit.prevent>
       <t-form-item :label="$t('tenant.create.nameLabel')" name="name">
         <t-input v-model="form.name" :placeholder="$t('tenant.create.namePlaceholder')" :maxlength="128" autofocus
-          @keydown.enter="handleSubmit" />
+          @enter="handleSubmit" />
       </t-form-item>
       <t-form-item :label="$t('tenant.create.descriptionLabel')" name="description">
         <t-textarea v-model="form.description" :placeholder="$t('tenant.create.descriptionPlaceholder')"

--- a/frontend/src/components/ModelEditorDialog.vue
+++ b/frontend/src/components/ModelEditorDialog.vue
@@ -1,244 +1,311 @@
 <template>
   <SettingDrawer :visible="dialogVisible" :title="isEdit ? $t('model.editor.editTitle') : $t('model.editor.addTitle')"
-    :description="getModalDescription()" :confirm-loading="saving"
+    :description="getModalDescription()" :icon="modelTypeIcon" :confirm-loading="saving"
     :confirm-disabled="formData.provider === 'weknoracloud' && wkcCredentialState !== 'configured'"
     @update:visible="(v: boolean) => dialogVisible = v" @confirm="handleConfirm" @cancel="handleCancel">
+
+    <!--
+      Footer-left slot: connection-test button lives here so it sits next to
+      Save/Cancel — primary actions all aligned along the bottom of the
+      drawer. Avoids the "test, then scroll back down to save" dance.
+      Mirrors the pattern used in WebSearchSettings' provider drawer.
+    -->
+    <template v-if="formData.source === 'remote'" #footer-left>
+      <t-button variant="outline" @click="checkRemoteAPI" :loading="checking"
+        :disabled="!formData.modelName || (!formData.baseUrl && formData.provider !== 'weknoracloud') || (formData.provider === 'weknoracloud' && wkcCredentialState !== 'configured')">
+        <template #icon>
+          <t-icon v-if="!checking && remoteChecked && remoteAvailable" name="check-circle-filled"
+            class="status-icon available" />
+          <t-icon v-else-if="!checking && remoteChecked && !remoteAvailable" name="close-circle-filled"
+            class="status-icon unavailable" />
+        </template>
+        {{ checking ? $t('model.editor.testing') : $t('model.editor.testConnection') }}
+      </t-button>
+      <span v-if="remoteChecked" :class="['footer-test-message', remoteAvailable ? 'success' : 'error']"
+        :title="remoteMessage">
+        {{ remoteMessage }}
+      </span>
+    </template>
+
     <t-form ref="formRef" :data="formData" :rules="rules" layout="vertical">
-      <!-- 模型来源 -->
-      <div class="form-item">
-        <label class="form-label required">{{ $t('model.editor.sourceLabel') }}</label>
-        <t-radio-group v-model="formData.source" class="source-select">
-          <t-radio-button value="local" :disabled="ollamaServiceStatus === false || modelType === 'rerank'">
-            {{ $t('model.editor.sourceLocal') }}
-          </t-radio-button>
-          <t-radio-button value="remote">{{ $t('model.editor.sourceRemote') }}</t-radio-button>
-        </t-radio-group>
 
-        <!-- ReRank模型不支持Ollama的提示信息 -->
-        <div v-if="modelType === 'rerank'" class="ollama-unavailable-tip rerank-tip">
-          <t-icon name="info-circle-filled" class="tip-icon info" />
-          <span class="tip-text">{{ $t('model.editor.ollamaNotSupportRerank') }}</span>
+      <!--
+        Section 1 — 模型来源 + 模型名称（来源直接决定下方字段，所以放一节）
+      -->
+      <section class="setting-drawer__section">
+        <h4 class="setting-drawer__section-title">{{ $t('model.editor.sectionSource') }}</h4>
+
+        <div class="form-item">
+          <!--
+            Section title already says 「模型来源」，所以这里不再重复 label，
+            直接把分段控件作为 section 的首个内容呈现，避免「双标题」感。
+          -->
+          <div class="source-options" role="radiogroup" :aria-label="$t('model.editor.sourceLabel')">
+            <button
+              type="button"
+              class="source-option"
+              :class="{ 'is-active': formData.source === 'local', 'is-disabled': ollamaServiceStatus === false || modelType === 'rerank' }"
+              :disabled="ollamaServiceStatus === false || modelType === 'rerank'"
+              role="radio"
+              :aria-checked="formData.source === 'local'"
+              @click="formData.source = 'local'"
+            >
+              <t-icon name="server" class="source-option__icon" />
+              <span class="source-option__label">{{ $t('model.editor.sourceLocal') }}</span>
+            </button>
+            <button
+              type="button"
+              class="source-option"
+              :class="{ 'is-active': formData.source === 'remote' }"
+              role="radio"
+              :aria-checked="formData.source === 'remote'"
+              @click="formData.source = 'remote'"
+            >
+              <t-icon name="cloud" class="source-option__icon" />
+              <span class="source-option__label">{{ $t('model.editor.sourceRemote') }}</span>
+            </button>
+          </div>
+
+          <!-- ReRank模型不支持Ollama的提示信息 -->
+          <div v-if="modelType === 'rerank'" class="ollama-unavailable-tip rerank-tip">
+            <t-icon name="info-circle-filled" class="tip-icon info" />
+            <span class="tip-text">{{ $t('model.editor.ollamaNotSupportRerank') }}</span>
+          </div>
+
+          <!-- Ollama不可用时的提示信息 -->
+          <div v-else-if="shouldShowOllamaUnavailableTip(formData.source, modelType, ollamaServiceStatus)"
+            class="ollama-unavailable-tip">
+            <t-icon name="error-circle-filled" class="tip-icon" />
+            <span class="tip-text">{{ $t('model.editor.ollamaUnavailable') }}</span>
+            <t-button variant="text" size="small" @click="goToOllamaSettings" class="tip-link">
+              <template #icon><t-icon name="jump" /></template>
+              {{ $t('model.editor.goToOllamaSettings') }}
+            </t-button>
+          </div>
         </div>
 
-        <!-- Ollama不可用时的提示信息 -->
-        <div v-else-if="shouldShowOllamaUnavailableTip(formData.source, modelType, ollamaServiceStatus)"
-          class="ollama-unavailable-tip">
-          <t-icon name="error-circle-filled" class="tip-icon" />
-          <span class="tip-text">{{ $t('model.editor.ollamaUnavailable') }}</span>
-          <t-button variant="text" size="small" @click="goToOllamaSettings" class="tip-link">
-            <template #icon><t-icon name="jump" /></template>
-            {{ $t('model.editor.goToOllamaSettings') }}
-          </t-button>
+        <!-- Ollama 本地模型选择器 -->
+        <div v-if="formData.source === 'local'" class="form-item">
+          <label class="form-label required">{{ $t('model.modelName') }}</label>
+          <div class="model-select-row">
+            <t-select v-model="formData.modelName" :loading="loadingOllamaModels" :class="{ 'downloading': downloading }"
+              :style="downloading ? `--progress: ${downloadProgress}%` : ''" filterable :filter="handleModelFilter"
+              :placeholder="$t('model.searchPlaceholder')" @focus="loadOllamaModels"
+              @visible-change="handleDropdownVisibleChange">
+              <!-- 已下载的模型 -->
+              <t-option v-for="model in filteredOllamaModels" :key="model.name" :value="model.name" :label="model.name">
+                <div class="model-option">
+                  <t-icon name="check-circle-filled" class="downloaded-icon" />
+                  <span class="model-name">{{ model.name }}</span>
+                  <span class="model-size">{{ formatModelSize(model.size) }}</span>
+                </div>
+              </t-option>
+
+              <!-- 下载新模型选项（仅当搜索词不在列表中时显示） -->
+              <t-option v-if="showDownloadOption" :value="`__download__${searchKeyword}`"
+                :label="$t('model.editor.downloadLabel', { keyword: searchKeyword })" class="download-option">
+                <div class="model-option download">
+                  <t-icon name="download" class="download-icon" />
+                  <span class="model-name">{{ $t('model.editor.downloadLabel', { keyword: searchKeyword }) }}</span>
+                </div>
+              </t-option>
+
+              <!-- 下载进度后缀 -->
+              <template v-if="downloading" #suffix>
+                <div class="download-suffix">
+                  <t-icon name="loading" class="spinning" />
+                  <span class="progress-text">{{ downloadProgress.toFixed(1) }}%</span>
+                </div>
+              </template>
+            </t-select>
+
+            <!-- 刷新按钮 -->
+            <t-button variant="text" size="small" :loading="loadingOllamaModels" @click="refreshOllamaModels"
+              class="refresh-btn">
+              <t-icon name="refresh" />
+              {{ $t('model.editor.refreshList') }}
+            </t-button>
+          </div>
         </div>
-      </div>
-
-      <!-- Ollama 本地模型选择器 -->
-      <div v-if="formData.source === 'local'" class="form-item">
-        <label class="form-label required">{{ $t('model.modelName') }}</label>
-        <div class="model-select-row">
-          <t-select v-model="formData.modelName" :loading="loadingOllamaModels" :class="{ 'downloading': downloading }"
-            :style="downloading ? `--progress: ${downloadProgress}%` : ''" filterable :filter="handleModelFilter"
-            :placeholder="$t('model.searchPlaceholder')" @focus="loadOllamaModels"
-            @visible-change="handleDropdownVisibleChange">
-            <!-- 已下载的模型 -->
-            <t-option v-for="model in filteredOllamaModels" :key="model.name" :value="model.name" :label="model.name">
-              <div class="model-option">
-                <t-icon name="check-circle-filled" class="downloaded-icon" />
-                <span class="model-name">{{ model.name }}</span>
-                <span class="model-size">{{ formatModelSize(model.size) }}</span>
-              </div>
-            </t-option>
-
-            <!-- 下载新模型选项（仅当搜索词不在列表中时显示） -->
-            <t-option v-if="showDownloadOption" :value="`__download__${searchKeyword}`"
-              :label="$t('model.editor.downloadLabel', { keyword: searchKeyword })" class="download-option">
-              <div class="model-option download">
-                <t-icon name="download" class="download-icon" />
-                <span class="model-name">{{ $t('model.editor.downloadLabel', { keyword: searchKeyword }) }}</span>
-              </div>
-            </t-option>
-
-            <!-- 下载进度后缀 -->
-            <template v-if="downloading" #suffix>
-              <div class="download-suffix">
-                <t-icon name="loading" class="spinning" />
-                <span class="progress-text">{{ downloadProgress.toFixed(1) }}%</span>
-              </div>
-            </template>
-          </t-select>
-
-          <!-- 刷新按钮 -->
-          <t-button variant="text" size="small" :loading="loadingOllamaModels" @click="refreshOllamaModels"
-            class="refresh-btn">
-            <t-icon name="refresh" />
-            {{ $t('model.editor.refreshList') }}
-          </t-button>
-        </div>
-      </div>
+      </section>
 
       <!-- Remote API 配置 -->
       <template v-if="formData.source === 'remote'">
-        <!-- 厂商选择器 -->
-        <div class="form-item">
-          <label class="form-label">{{ $t('model.editor.providerLabel') }}</label>
-          <t-select v-model="formData.provider" :placeholder="$t('model.editor.providerPlaceholder')"
-            @change="handleProviderChange" :popup-props="{ overlayClassName: 'provider-select-popup' }">
-            <t-option v-for="opt in providerOptions" :key="opt.value" :value="opt.value" :label="opt.label">
-              <div class="provider-option">
-                <span class="provider-name">{{ opt.label }}</span>
-                <span class="provider-desc">{{ opt.description }}</span>
-              </div>
-            </t-option>
-          </t-select>
-        </div>
+        <section class="setting-drawer__section">
+          <h4 class="setting-drawer__section-title">{{ $t('model.editor.sectionProvider') }}</h4>
 
-        <!-- WeKnoraCloud 提示信息 -->
-        <template v-if="formData.provider === 'weknoracloud'">
-          <!-- 凭证已配置 -->
-          <div v-if="wkcCredentialState === 'configured'" class="weknoracloud-hint weknoracloud-hint--ok">
-            <t-icon name="check-circle-filled"
-              style="font-size: 16px; color: var(--td-success-color); flex-shrink: 0;" />
-            <div>
-              {{ $t('settings.weknoraCloud.modelHintConfigured') }}
-              <a href="https://developers.weixin.qq.com/doc/aispeech/knowledge/atomic_capability/atomic_interface.html"
-                target="_blank" rel="noopener noreferrer" class="doc-link">
-                {{ $t('settings.weknoraCloud.modelHintDocsLink') }}
-                <t-icon name="link" class="link-icon" />
-              </a>
-            </div>
+          <!-- 厂商选择器 -->
+          <div class="form-item">
+            <label class="form-label">{{ $t('model.editor.providerLabel') }}</label>
+            <t-select v-model="formData.provider" :placeholder="$t('model.editor.providerPlaceholder')"
+              @change="handleProviderChange" :popup-props="{ overlayClassName: 'provider-select-popup' }">
+              <!--
+                show-overflow-tooltip=false: TDesign 默认在 hover 时给选项浮一个
+                完整 label 的小气泡，但这里选项本身就是双行（主名 + 描述），不会
+                出现省略，tooltip 只会和已经命中的灰底打架。直接关掉。
+              -->
+              <t-option v-for="opt in providerOptions" :key="opt.value" :value="opt.value" :label="opt.label"
+                :show-overflow-tooltip="false">
+                <div class="provider-option">
+                  <span class="provider-name">{{ opt.label }}</span>
+                  <span class="provider-desc">{{ opt.description }}</span>
+                </div>
+              </t-option>
+            </t-select>
           </div>
 
-          <!-- 未配置 / 失效 -->
-          <div v-else-if="wkcCredentialState !== 'loading'" class="weknoracloud-hint weknoracloud-hint--warn">
-            <t-icon name="error-circle-filled" style="font-size: 16px; color: #f97316; flex-shrink: 0;" />
-            <div style="flex: 1;">
-              <template v-if="wkcCredentialState === 'expired'">
-                {{ $t('settings.weknoraCloud.credentialExpired') }}
+          <!-- WeKnoraCloud 提示信息 -->
+          <template v-if="formData.provider === 'weknoracloud'">
+            <!-- 凭证已配置 -->
+            <div v-if="wkcCredentialState === 'configured'" class="weknoracloud-hint weknoracloud-hint--ok">
+              <t-icon name="check-circle-filled" class="hint-icon hint-icon--ok" />
+              <div>
+                {{ $t('settings.weknoraCloud.modelHintConfigured') }}
+                <a href="https://developers.weixin.qq.com/doc/aispeech/knowledge/atomic_capability/atomic_interface.html"
+                  target="_blank" rel="noopener noreferrer" class="doc-link">
+                  {{ $t('settings.weknoraCloud.modelHintDocsLink') }}
+                  <t-icon name="link" class="link-icon" />
+                </a>
+              </div>
+            </div>
+
+            <!-- 未配置 / 失效 -->
+            <div v-else-if="wkcCredentialState !== 'loading'" class="weknoracloud-hint weknoracloud-hint--warn">
+              <t-icon name="error-circle-filled" class="hint-icon hint-icon--warn" />
+              <div style="flex: 1;">
+                <template v-if="wkcCredentialState === 'expired'">
+                  {{ $t('settings.weknoraCloud.credentialExpired') }}
+                </template>
+                <template v-else>
+                  {{ $t('settings.weknoraCloud.credentialUnconfigured') }}
+                </template>
+                <div style="margin-top: 8px;">
+                  <t-button variant="text" size="small" @click="goToWeKnoraCloudSettings"
+                    style="padding: 0; height: auto;">
+                    <template #icon><t-icon name="jump" /></template>
+                    {{ $t('settings.weknoraCloud.goToSettings') }}
+                  </t-button>
+                </div>
+              </div>
+            </div>
+
+            <!-- 加载中 -->
+            <div v-else class="weknoracloud-hint">
+              <t-icon name="loading" class="spinning hint-icon hint-icon--loading" />
+              <span>{{ $t('settings.weknoraCloud.checkingStatus') }}</span>
+            </div>
+          </template>
+
+          <!-- 模型名称 -->
+          <div class="form-item">
+            <label class="form-label required">{{ $t('model.modelName') }}</label>
+            <t-input v-model="formData.modelName" :placeholder="getModelNamePlaceholder()"
+              :disabled="formData.provider === 'weknoracloud' && wkcCredentialState !== 'configured'" />
+          </div>
+
+          <div class="form-item">
+            <label class="form-label">{{ $t('model.editor.displayNameLabel') }}</label>
+            <t-input v-model="formData.displayName" :placeholder="$t('model.editor.displayNamePlaceholder')" />
+            <p class="form-desc">{{ $t('model.editor.displayNameDesc') }}</p>
+          </div>
+
+          <div v-if="formData.provider !== 'weknoracloud'" class="form-item">
+            <label class="form-label required">{{ $t('model.editor.baseUrlLabel') }}</label>
+            <t-input v-model="formData.baseUrl" :placeholder="getBaseUrlPlaceholder()" />
+          </div>
+
+          <div v-if="formData.provider !== 'weknoracloud'" class="form-item">
+            <label class="form-label">{{ $t('model.editor.apiKeyOptional') }}</label>
+            <!--
+              Edit mode: credentials live behind the /credentials subresource
+              of the model — managed by the shared CredentialResource card,
+              which now renders an INPUT-LOOKING row (32px tall, same border
+              + radius as t-input) so it sits flush with the Base URL field
+              above and the 自定义请求头 controls below — no more
+              "card inside a card" feel.
+              Create mode: the resource doesn't exist yet, so we render a
+              plain password input with a leading lock icon and a trailing
+              show/hide eye toggle.
+            -->
+            <CredentialResource v-if="isEdit && props.modelData?.id" :api="credentialApi" :fields="credentialFields"
+              :meta="credentialMeta" />
+            <t-input v-else v-model="formData.apiKey" :type="showApiKey ? 'text' : 'password'"
+              :placeholder="apiKeyPlaceholder" class="api-key-input" autocomplete="off" spellcheck="false">
+              <template #prefix-icon><t-icon name="lock-on" /></template>
+              <template #suffix-icon>
+                <t-icon
+                  :name="showApiKey ? 'browse-off' : 'browse'"
+                  class="api-key-toggle"
+                  :aria-label="showApiKey ? 'Hide' : 'Show'"
+                  @click.stop="showApiKey = !showApiKey"
+                />
               </template>
-              <template v-else>
-                {{ $t('settings.weknoraCloud.credentialUnconfigured') }}
-              </template>
-              <div style="margin-top: 8px;">
-                <t-button variant="text" size="small" @click="goToWeKnoraCloudSettings"
-                  style="padding: 0; height: auto;">
-                  <template #icon><t-icon name="jump" /></template>
-                  {{ $t('settings.weknoraCloud.goToSettings') }}
+            </t-input>
+          </div>
+
+          <!-- 自定义 HTTP Header（类似 OpenAI Python SDK 的 extra_headers） -->
+          <div v-if="formData.provider !== 'weknoracloud'" class="form-item">
+            <div class="custom-headers-header">
+              <label class="form-label" style="margin-bottom: 0;">{{ $t('model.editor.customHeadersLabel') }}</label>
+              <t-button variant="text" size="small" theme="primary" @click="addCustomHeader">
+                <template #icon><t-icon name="add" /></template>
+                {{ $t('model.editor.customHeadersAdd') }}
+              </t-button>
+            </div>
+            <p class="form-desc custom-headers-desc">{{ $t('model.editor.customHeadersDesc') }}</p>
+            <div v-if="formData.customHeaders && formData.customHeaders.length > 0" class="custom-headers-list">
+              <div v-for="(item, idx) in formData.customHeaders" :key="idx" class="custom-header-row">
+                <t-input v-model="item.key" :placeholder="$t('model.editor.customHeadersKeyPlaceholder')"
+                  class="custom-header-key" />
+                <t-input v-model="item.value" :placeholder="$t('model.editor.customHeadersValuePlaceholder')"
+                  class="custom-header-value" />
+                <t-button variant="text" shape="square" size="small" class="custom-header-remove"
+                  @click="removeCustomHeader(idx)" :aria-label="$t('common.delete')">
+                  <t-icon name="close" />
                 </t-button>
               </div>
             </div>
           </div>
 
-          <!-- 加载中 -->
-          <div v-else class="weknoracloud-hint">
-            <t-icon name="loading" class="spinning"
-              style="font-size: 16px; color: var(--td-text-color-placeholder); flex-shrink: 0;" />
-            <span>{{ $t('settings.weknoraCloud.checkingStatus') }}</span>
-          </div>
-        </template>
-
-        <!-- 模型名称 -->
-        <div class="form-item">
-          <label class="form-label required">{{ $t('model.modelName') }}</label>
-          <t-input v-model="formData.modelName" :placeholder="getModelNamePlaceholder()"
-            :disabled="formData.provider === 'weknoracloud' && wkcCredentialState !== 'configured'" />
-        </div>
-
-        <div class="form-item">
-          <label class="form-label">{{ $t('model.editor.displayNameLabel') }}</label>
-          <t-input v-model="formData.displayName" :placeholder="$t('model.editor.displayNamePlaceholder')" />
-          <p class="form-desc">{{ $t('model.editor.displayNameDesc') }}</p>
-        </div>
-
-        <div v-if="formData.provider !== 'weknoracloud'" class="form-item">
-          <label class="form-label required">{{ $t('model.editor.baseUrlLabel') }}</label>
-          <t-input v-model="formData.baseUrl" :placeholder="getBaseUrlPlaceholder()" />
-        </div>
-
-        <div v-if="formData.provider !== 'weknoracloud'" class="form-item">
-          <label class="form-label">{{ $t('model.editor.apiKeyOptional') }}</label>
           <!--
-              Edit mode: credentials live behind the /credentials subresource
-              of the model — managed by the shared CredentialResource card.
-              Create mode: the resource doesn't exist yet, so accept the
-              initial API key in the form and POST it with the rest.
-            -->
-          <CredentialResource v-if="isEdit && props.modelData?.id" :api="credentialApi" :fields="credentialFields"
-            :meta="credentialMeta" />
-          <t-input v-else v-model="formData.apiKey" type="password" :placeholder="apiKeyPlaceholder" />
-        </div>
-
-        <!-- 自定义 HTTP Header（类似 OpenAI Python SDK 的 extra_headers） -->
-        <div v-if="formData.provider !== 'weknoracloud'" class="form-item">
-          <div class="custom-headers-header">
-            <label class="form-label" style="margin-bottom: 0;">{{ $t('model.editor.customHeadersLabel') }}</label>
-            <t-button variant="text" size="small" theme="primary" @click="addCustomHeader">
-              <template #icon><t-icon name="add" /></template>
-              {{ $t('model.editor.customHeadersAdd') }}
-            </t-button>
-          </div>
-          <p class="form-desc custom-headers-desc">{{ $t('model.editor.customHeadersDesc') }}</p>
-          <div v-if="formData.customHeaders && formData.customHeaders.length > 0" class="custom-headers-list">
-            <div v-for="(item, idx) in formData.customHeaders" :key="idx" class="custom-header-row">
-              <t-input v-model="item.key" :placeholder="$t('model.editor.customHeadersKeyPlaceholder')"
-                class="custom-header-key" />
-              <t-input v-model="item.value" :placeholder="$t('model.editor.customHeadersValuePlaceholder')"
-                class="custom-header-value" />
-              <t-button variant="text" shape="square" size="small" theme="danger" @click="removeCustomHeader(idx)"
-                :aria-label="$t('common.delete')">
-                <t-icon name="close" />
-              </t-button>
-            </div>
-          </div>
-        </div>
-
-        <!-- Remote API 校验 -->
-        <div class="form-item">
-          <label class="form-label">{{ $t('model.editor.connectionTest') }}</label>
-          <div class="api-test-section">
-            <t-button variant="outline" @click="checkRemoteAPI" :loading="checking"
-              :disabled="!formData.modelName || (!formData.baseUrl && formData.provider !== 'weknoracloud') || (formData.provider === 'weknoracloud' && wkcCredentialState !== 'configured')">
-              <template #icon>
-                <t-icon v-if="!checking && remoteChecked && remoteAvailable" name="check-circle-filled"
-                  class="status-icon available" />
-                <t-icon v-else-if="!checking && remoteChecked && !remoteAvailable" name="close-circle-filled"
-                  class="status-icon unavailable" />
-              </template>
-              {{ checking ? $t('model.editor.testing') : $t('model.editor.testConnection') }}
-            </t-button>
-            <span v-if="remoteChecked" :class="['test-message', remoteAvailable ? 'success' : 'error']">
-              {{ remoteMessage }}
-            </span>
-          </div>
-        </div>
+            Connection test action moved to the drawer footer (footer-left
+            slot above) so primary actions live in one row at the bottom.
+          -->
+        </section>
       </template>
 
-      <!-- Embedding 专用：维度 -->
-      <div v-if="modelType === 'embedding'" class="form-item">
-        <label class="form-label">{{ $t('model.editor.dimensionLabel') }}</label>
-        <div class="dimension-control">
-          <t-input v-model.number="formData.dimension" type="number" :min="128" :max="4096"
-            :placeholder="$t('model.editor.dimensionPlaceholder')"
-            :disabled="formData.source === 'local' && checking" />
-          <!-- Ollama 本地模型：自动检测维度按钮 -->
-          <t-button v-if="formData.source === 'local' && formData.modelName" variant="text" size="small"
-            :loading="checking" @click="checkOllamaDimension" class="dimension-check-btn">
-            <t-icon name="refresh" />
-            {{ $t('model.editor.checkDimension') }}
-          </t-button>
-        </div>
-        <p v-if="dimensionChecked && dimensionMessage" class="dimension-hint" :class="{ success: dimensionSuccess }">
-          {{ dimensionMessage }}
-        </p>
-      </div>
+      <!-- Section 3 — 高级选项（仅在有内容时渲染，避免空 section 出现底部分隔线） -->
+      <section v-if="modelType === 'embedding' || modelType === 'chat'" class="setting-drawer__section">
+        <h4 class="setting-drawer__section-title">{{ $t('model.editor.sectionAdvanced') }}</h4>
 
-      <!-- Chat: supports vision toggle (VLLM models are inherently multimodal) -->
-      <div v-if="modelType === 'chat'" class="form-item">
-        <label class="form-label">{{ $t('model.editor.supportsVisionLabel') }}</label>
-        <div style="display: flex; align-items: center; gap: 8px;">
-          <t-switch v-model="formData.supportsVision" />
-          <span class="form-desc">{{ $t('model.editor.supportsVisionDesc') }}</span>
+        <!-- Embedding 专用：维度 -->
+        <div v-if="modelType === 'embedding'" class="form-item">
+          <label class="form-label">{{ $t('model.editor.dimensionLabel') }}</label>
+          <div class="dimension-control">
+            <t-input v-model.number="formData.dimension" type="number" :min="128" :max="4096"
+              :placeholder="$t('model.editor.dimensionPlaceholder')"
+              :disabled="formData.source === 'local' && checking" />
+            <!-- Ollama 本地模型：自动检测维度按钮 -->
+            <t-button v-if="formData.source === 'local' && formData.modelName" variant="text" size="small"
+              :loading="checking" @click="checkOllamaDimension" class="dimension-check-btn">
+              <t-icon name="refresh" />
+              {{ $t('model.editor.checkDimension') }}
+            </t-button>
+          </div>
+          <p v-if="dimensionChecked && dimensionMessage" class="dimension-hint" :class="{ success: dimensionSuccess }">
+            {{ dimensionMessage }}
+          </p>
         </div>
-      </div>
+
+        <!-- Chat: supports vision toggle (VLLM models are inherently multimodal) -->
+        <div v-if="modelType === 'chat'" class="form-item">
+          <label class="form-label">{{ $t('model.editor.supportsVisionLabel') }}</label>
+          <div class="vision-toggle">
+            <t-switch v-model="formData.supportsVision" />
+            <span class="form-desc form-desc--inline">{{ $t('model.editor.supportsVisionDesc') }}</span>
+          </div>
+        </div>
+      </section>
 
     </t-form>
   </SettingDrawer>
@@ -464,6 +531,20 @@ const dialogVisible = computed({
 
 const isEdit = computed(() => !!props.modelData)
 
+// Header icon for the SettingDrawer — uses the same TDesign icon name table
+// as the model card list, so the drawer's leading badge visually matches the
+// card the user just clicked on.
+const modelTypeIcon = computed(() => {
+  const map: Record<string, string> = {
+    chat: 'chat',
+    embedding: 'chart-bubble',
+    rerank: 'filter-sort',
+    vllm: 'image',
+    asr: 'sound',
+  }
+  return map[props.modelType] || 'setting'
+})
+
 // Credential resource binding for the shared <CredentialResource> component.
 // "app_secret" is only relevant for the WeKnora Cloud provider; the visible
 // fields collapse to just api_key for every other provider. We always pass
@@ -506,6 +587,12 @@ const apiKeyPlaceholder = computed(() => t('model.editor.apiKeyPlaceholder'))
 
 const formRef = ref()
 const saving = ref(false)
+// Toggles the create-mode API key input between masked and plain text. Lets
+// the user proofread a freshly pasted secret without losing the password
+// affordance for everyday use. Reset every time the drawer closes (see
+// reset block in the visible watcher) so we never leak the previous value
+// across editor sessions.
+const showApiKey = ref(false)
 const modelChecked = ref(false)
 const modelAvailable = ref(false)
 const checking = ref(false)
@@ -765,6 +852,7 @@ const resetForm = () => {
   dimensionChecked.value = false
   dimensionSuccess.value = false
   dimensionMessage.value = ''
+  showApiKey.value = false
 }
 
 // 处理厂商选择变化 (自动填充默认 URL)
@@ -1269,11 +1357,10 @@ const handleCancel = () => {
 
 // 表单项样式
 .form-item {
-  margin-bottom: 16px;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
+  // No bottom margin — vertical rhythm is owned by the parent
+  // .setting-drawer__section's `gap`. That keeps the spacing inside a section
+  // tight and the gap between sections visually distinct.
+  margin-bottom: 0;
 }
 
 .form-label {
@@ -1282,24 +1369,73 @@ const handleCancel = () => {
   font-size: 13px;
   font-weight: 500;
   color: var(--td-text-color-primary);
+  line-height: 1.4;
 
-  &.required::after {
+  // TDesign-style required marker: leading asterisk before the label text,
+  // matching the rest of the app's <t-form-item required ...> appearance.
+  &.required::before {
     content: '*';
     color: var(--td-error-color);
-    margin-left: 4px;
+    margin-right: 4px;
     font-weight: 500;
+    line-height: 1;
   }
 }
 
-// 模型来源分段：两个选项等分宽度
-.source-select {
-  display: flex;
-  width: 100%;
+// 模型来源分段：紧凑单行 pill 形 segmented。容器自身是浅底圆角条，
+// 选中按钮通过实色背景 + 主题色描边浮出，未选中态接近透明，节省纵向空间。
+.source-options {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px;
+  background: var(--td-bg-color-component);
+  border: 1px solid var(--td-component-stroke);
+  border-radius: 8px;
+}
 
-  :deep(.t-radio-button) {
-    flex: 1;
-    text-align: center;
+.source-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  height: 28px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--td-text-color-secondary);
+  line-height: 1;
+  transition: all 0.15s ease;
+
+  &:hover:not(.is-disabled):not(.is-active) {
+    color: var(--td-text-color-primary);
+    background: var(--td-bg-color-container-hover);
   }
+
+  &.is-active {
+    background: var(--td-bg-color-container);
+    border-color: var(--td-brand-color);
+    color: var(--td-brand-color);
+    font-weight: 500;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  }
+
+  &.is-disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+  }
+}
+
+.source-option__icon {
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.source-option__label {
+  white-space: nowrap;
 }
 
 // 输入框样式：只在最外层 .t-input 上调字号，避免在内部 wrap/inner 上重复加边
@@ -1325,11 +1461,41 @@ const handleCancel = () => {
   }
 }
 
-// API 测试区域
+// API Key 输入：前置 lock 图标 + 后置可点击的"显示/隐藏"小眼睛。
+// TDesign 默认会让 prefix-icon 显示成灰色，这里没动；suffix 上的眼睛
+// 用 placeholder 色，hover 时切到主文本色，避免抢戏。
+.api-key-input {
+  :deep(.t-input__prefix) {
+    color: var(--td-text-color-placeholder);
+  }
+
+  :deep(.t-input__suffix) {
+    color: var(--td-text-color-placeholder);
+  }
+
+  .api-key-toggle {
+    cursor: pointer;
+    transition: color 0.15s ease;
+    font-size: 16px;
+
+    &:hover {
+      color: var(--td-text-color-primary);
+    }
+  }
+}
+
+// API 测试区域 — 弱卡片化：用浅底 + dashed 边把"操作 + 反馈"框成一块，
+// 让用户视觉上把它当成一个独立的"动作单元"，而不是又一个普通字段。
+// （历史样式保留：仅当某个分支仍以 inline 方式渲染测试块时使用；当前 RemoteAPI
+// 测试已上移到 SettingDrawer footer-left 槽，主流程不再走这块。）
 .api-test-section {
   display: flex;
   align-items: center;
   gap: 12px;
+  padding: 10px 12px;
+  background: var(--td-bg-color-container-hover);
+  border: 1px dashed var(--td-component-stroke);
+  border-radius: 8px;
 
   .test-message {
     font-size: 13px;
@@ -1367,29 +1533,82 @@ const handleCancel = () => {
   }
 }
 
+// Connection-test message rendered next to the test button in the drawer
+// footer. Truncates with ellipsis so a long backend error doesn't push
+// Save/Cancel off-screen — the full text is in the title attribute.
+.footer-test-message {
+  font-size: 12px;
+  line-height: 1.4;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &.success {
+    color: var(--td-brand-color-active);
+  }
+
+  &.error {
+    color: var(--td-error-color);
+  }
+}
+
+// Status icon variant used inside the footer button.
+.status-icon {
+  font-size: 16px;
+  flex-shrink: 0;
+
+  &.available {
+    color: var(--td-brand-color);
+  }
+
+  &.unavailable {
+    color: var(--td-error-color);
+  }
+}
+
 // WeKnoraCloud 提示信息
 .weknoracloud-hint {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
-  margin-bottom: 20px;
-  padding: 10px 12px;
-  border-radius: 6px;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 8px;
   font-size: 13px;
   color: var(--td-text-color-secondary);
   line-height: 1.5;
 
+  // Theming via tokens so the warn/ok states track light/dark switches
+  // instead of fighting hardcoded `#fff7ed` etc.
   &--ok {
     background: var(--td-success-color-light);
     border: 1px solid var(--td-success-color-focus);
   }
 
   &--warn {
-    background: #fff7ed;
-    border: 1px solid #fed7aa;
-    border-left: 3px solid #f97316;
+    background: var(--td-warning-color-light, #fff7ed);
+    border: 1px solid var(--td-warning-color-focus, #fed7aa);
+    border-left: 3px solid var(--td-warning-color, #f97316);
   }
 
+  .hint-icon {
+    font-size: 16px;
+    flex-shrink: 0;
+    margin-top: 2px;
+
+    &--ok {
+      color: var(--td-success-color);
+    }
+
+    &--warn {
+      color: var(--td-warning-color, #f97316);
+    }
+
+    &--loading {
+      color: var(--td-text-color-placeholder);
+    }
+  }
 }
 
 // Ollama 模型选择器样式
@@ -1564,11 +1783,22 @@ const handleCancel = () => {
     flex: 1;
   }
 
-  :deep(.t-button) {
+  // Ghost icon button — matches the model-card "more" affordance: invisible
+  // until hover/focus, then a subtle background pops in. Avoids painting a
+  // permanent red splotch next to every header row.
+  .custom-header-remove {
     flex-shrink: 0;
     width: 32px;
     height: 32px;
     padding: 0;
+    color: var(--td-text-color-placeholder);
+    border-radius: 6px;
+    transition: all 0.18s ease;
+
+    &:hover {
+      background: var(--td-error-color-light);
+      color: var(--td-error-color);
+    }
   }
 }
 
@@ -1577,6 +1807,18 @@ const handleCancel = () => {
   font-size: 12px;
   line-height: 1.5;
   color: var(--td-text-color-placeholder);
+
+  // Inline with switches/checkboxes — drops the top margin so the label and
+  // helper text sit on the same baseline.
+  &--inline {
+    margin: 0;
+  }
+}
+
+.vision-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 // Ollama不可用提示样式
@@ -1588,7 +1830,7 @@ const handleCancel = () => {
   padding: 10px 12px;
   background: var(--td-error-color-light);
   border: 1px solid var(--td-error-color-focus);
-  border-radius: 6px;
+  border-radius: 8px;
   font-size: 13px;
 
   .tip-icon {
@@ -1670,26 +1912,57 @@ const handleCancel = () => {
 <!-- 非 scoped 样式：t-select popup 渲染到 body 下，scoped 样式无法覆盖 -->
 <style lang="less">
 .provider-select-popup {
+  // 容器留点呼吸：避免选项贴着 popup 圆角
+  padding: 4px;
 
-  // 覆盖 TDesign option 默认固定高度，让两行内容正常展示
+  // TDesign 默认会在 t-select-option 上挂一个 overflow tooltip（浮在右侧
+  // 显示完整 label）。我们的选项排版是「主名称 + 次描述」两行，永远不会
+  // 触发省略，tooltip 反而成了视觉噪音 → 直接隐藏 popup 自带的提示。
+  + .t-popup .t-tooltip,
+  ~ .t-popup .t-tooltip {
+    display: none !important;
+  }
+
   .t-select-option {
     height: auto !important;
-    padding: 6px 12px;
+    padding: 8px 10px;
     border-radius: 6px;
-    margin: 0 4px;
+    margin: 2px 0;
     outline: none;
+    transition: background-color 0.15s ease;
 
     &:focus,
     &:focus-visible {
       outline: none;
     }
+
+    // hover 态：用浅 brand 色而非强灰，跟主题色调一致
+    &:hover:not(.t-is-selected) {
+      background-color: var(--td-bg-color-container-hover);
+    }
   }
 
-  // 命中态：浅一点的底色，去掉默认的描边/反色
+  // 命中态：浅一点的底色 + 左侧主题色条作为 affordance，不再用全填的灰底
   .t-select-option.t-is-selected {
     background-color: var(--td-brand-color-light);
     color: var(--td-text-color-primary);
     font-weight: 500;
+    position: relative;
+
+    &::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 8px;
+      bottom: 8px;
+      width: 3px;
+      background: var(--td-brand-color);
+      border-radius: 0 2px 2px 0;
+    }
+
+    .provider-name {
+      color: var(--td-brand-color);
+    }
   }
 
   .provider-option {

--- a/frontend/src/components/credentials/CredentialResource.vue
+++ b/frontend/src/components/credentials/CredentialResource.vue
@@ -118,7 +118,7 @@
         <div class="credential-edit">
           <t-input v-model="drafts[field.key]" type="password"
             :placeholder="field.placeholder ?? t('credential.inputPlaceholder')" :autocomplete="'new-password'"
-            class="credential-edit-input" @keydown.enter.prevent="onSave(field)">
+            class="credential-edit-input" @enter="onSave(field)">
             <template #prefix-icon><t-icon name="lock-on" /></template>
           </t-input>
           <div class="credential-edit-actions">

--- a/frontend/src/components/credentials/CredentialResource.vue
+++ b/frontend/src/components/credentials/CredentialResource.vue
@@ -27,51 +27,102 @@
 <template>
   <div class="credential-resource">
     <div v-for="field in fields" :key="field.key" class="credential-row">
-      <!-- Configured: read-only badge + actions -->
+      <!--
+        Per-field label, rendered only when there is more than one credential
+        (e.g. WeKnora Cloud's api_key + app_secret) so a single-field card
+        doesn't double up with the parent's outer .form-label. Single-field
+        consumers (ModelEditorDialog API key, WebSearch provider api_key,
+        McpService api_key) keep showing the parent label only.
+      -->
+      <div v-if="fields.length > 1" class="credential-row-label">{{ field.label }}</div>
+
+      <!-- Configured: faux input row (visually identical to t-input) -->
       <template v-if="stateOf(field.key) === 'configured'">
-        <div class="credential-summary">
-          <t-icon name="check-circle-filled" class="status-icon success" />
-          <div class="credential-meta">
-            <div class="credential-label">{{ field.label }}</div>
-            <div class="credential-sub">{{ t('credential.configured') }}</div>
-          </div>
-          <div class="credential-actions">
-            <t-button size="small" variant="outline" @click="enterEdit(field.key)">
-              {{ t('credential.update') }}
-            </t-button>
-            <t-button size="small" variant="outline" theme="danger" :loading="busy[field.key] === 'remove'"
-              @click="onRemove(field)">
-              {{ t('credential.remove') }}
-            </t-button>
-          </div>
+        <!--
+          Two possible looks:
+          a) default — ✓ 已配置 + [更换 | 移除]
+          b) confirm-remove pending — ⚠ 确认移除？此操作不可撤销 + [取消 | 确认移除]
+
+          We use a sub-state instead of a global modal because the modal
+          forces the user to context-switch to the screen center, then back
+          to this row to see the result. Inline confirm keeps focus on the
+          row that's actually changing.
+        -->
+        <div
+          class="credential-faux-input"
+          :class="{ 'is-confirm-remove': pendingRemove[field.key] }"
+          :title="pendingRemove[field.key] ? '' : t('credential.configured')"
+        >
+          <template v-if="pendingRemove[field.key]">
+            <t-icon name="error-circle-filled" class="status-icon warn" />
+            <span class="credential-faux-text danger">{{ t('credential.confirmRemovePrompt') }}</span>
+            <div class="credential-actions">
+              <t-button size="small" variant="text" @click="cancelPendingRemove(field.key)">
+                {{ t('common.cancel') }}
+              </t-button>
+              <span class="action-divider"></span>
+              <t-button size="small" variant="text" theme="danger" :loading="busy[field.key] === 'remove'"
+                @click="confirmRemove(field)">
+                {{ t('credential.confirmRemove') }}
+              </t-button>
+            </div>
+          </template>
+          <template v-else>
+            <t-icon name="check-circle-filled" class="status-icon success" />
+            <span class="credential-faux-text">{{ t('credential.configured') }}</span>
+            <div class="credential-actions">
+              <t-button size="small" variant="text" @click="enterEdit(field.key)">
+                {{ t('credential.update') }}
+              </t-button>
+              <span class="action-divider"></span>
+              <t-button size="small" variant="text" theme="danger" @click="requestRemove(field.key)">
+                {{ t('credential.remove') }}
+              </t-button>
+            </div>
+          </template>
         </div>
       </template>
 
-      <!-- Unconfigured: collapsed prompt + "Configure" -->
+      <!-- Unconfigured: faux input row with a single "Configure" affordance -->
       <template v-else-if="stateOf(field.key) === 'unconfigured'">
-        <div class="credential-summary">
-          <t-icon name="info-circle" class="status-icon muted" />
-          <div class="credential-meta">
-            <div class="credential-label">{{ field.label }}</div>
-            <div class="credential-sub">{{ t('credential.unconfigured') }}</div>
-          </div>
-          <div class="credential-actions">
-            <t-button size="small" variant="outline" @click="enterEdit(field.key)">
-              {{ t('credential.configure') }}
-            </t-button>
-          </div>
+        <div
+          class="credential-faux-input is-empty"
+          :class="{ 'is-just-removed': inlineToast[field.key]?.kind === 'removed' }"
+          @click="enterEdit(field.key)"
+        >
+          <!--
+            Right after a successful remove we hold the row in place but swap
+            the icon + placeholder text for a brief success state. After
+            ~2.4s the row fades back to its plain "未配置" prompt. This
+            keeps feedback anchored to where the user just clicked, instead
+            of asking them to glance at a global toast somewhere else.
+          -->
+          <template v-if="inlineToast[field.key]?.kind === 'removed'">
+            <t-icon name="check-circle-filled" class="status-icon success" />
+            <span class="credential-faux-text">{{ t('credential.removedToast') }}</span>
+          </template>
+          <template v-else>
+            <t-icon name="lock-on" class="status-icon muted" />
+            <span class="credential-faux-text muted">{{ t('credential.unconfigured') }}</span>
+            <div class="credential-actions">
+              <t-button size="small" variant="text" theme="primary" @click.stop="enterEdit(field.key)">
+                {{ t('credential.configure') }}
+              </t-button>
+            </div>
+          </template>
         </div>
       </template>
 
-      <!-- Editing: inline input + Save / Cancel -->
+      <!-- Editing: real input + tiny action row beneath -->
       <template v-else>
         <div class="credential-edit">
-          <div class="credential-label">{{ field.label }}</div>
           <t-input v-model="drafts[field.key]" type="password"
             :placeholder="field.placeholder ?? t('credential.inputPlaceholder')" :autocomplete="'new-password'"
-            @keydown.enter.prevent="onSave(field)" />
+            class="credential-edit-input" @keydown.enter.prevent="onSave(field)">
+            <template #prefix-icon><t-icon name="lock-on" /></template>
+          </t-input>
           <div class="credential-edit-actions">
-            <t-button size="small" variant="outline" @click="cancelEdit(field.key)">
+            <t-button size="small" variant="text" @click="cancelEdit(field.key)">
               {{ t('common.cancel') }}
             </t-button>
             <t-button size="small" theme="primary" :loading="busy[field.key] === 'save'" :disabled="!drafts[field.key]"
@@ -86,7 +137,7 @@
 </template>
 
 <script setup lang="ts" generic="K extends string">
-import { ref, reactive, watch } from 'vue'
+import { onBeforeUnmount, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { MessagePlugin } from 'tdesign-vue-next'
 
@@ -134,6 +185,31 @@ const states = reactive<Record<string, State>>({})
 const drafts = reactive<Record<string, string>>({})
 const busy = reactive<Record<string, 'save' | 'remove' | null>>({})
 
+// Per-field "did the user just press Remove" flag. While true, the
+// configured row swaps to an inline confirm prompt instead of immediately
+// deleting. Cleared on cancel, on the actual DELETE request firing, and
+// any time the field leaves the configured state for any other reason.
+const pendingRemove = reactive<Record<string, boolean>>({})
+
+// Inline per-field flash message used as an anchored "toast" instead of the
+// global MessagePlugin one for actions whose effect happens at this exact
+// row (currently: remove). Cleared after a short delay so the row reverts
+// to its normal placeholder. Keyed by field.key.
+type InlineToastKind = 'removed'
+const inlineToast = reactive<Record<string, { kind: InlineToastKind } | null>>({})
+const inlineToastTimers: Record<string, ReturnType<typeof setTimeout> | null> = {}
+
+function flashInlineToast(key: string, kind: InlineToastKind, ms = 2400) {
+  inlineToast[key] = { kind }
+  if (inlineToastTimers[key]) {
+    clearTimeout(inlineToastTimers[key]!)
+  }
+  inlineToastTimers[key] = setTimeout(() => {
+    inlineToast[key] = null
+    inlineToastTimers[key] = null
+  }, ms)
+}
+
 function deriveStatesFromMeta(meta: Record<string, { configured: boolean }>) {
   for (const f of props.fields) {
     // Preserve in-progress edits across parent re-renders — `meta` describes
@@ -157,6 +233,7 @@ watch(
 watch(() => props.api, () => {
   for (const k of Object.keys(states)) delete states[k]
   for (const k of Object.keys(drafts)) delete drafts[k]
+  for (const k of Object.keys(pendingRemove)) delete pendingRemove[k]
 })
 
 function stateOf(key: string): State {
@@ -166,6 +243,10 @@ function stateOf(key: string): State {
 function enterEdit(key: string) {
   drafts[key] = ''
   states[key] = 'editing'
+  // If the user was mid-confirm and changed their mind ("update" instead
+  // of "remove"), drop the pending flag so we don't bounce back into the
+  // confirm UI when they cancel the edit.
+  pendingRemove[key] = false
 }
 
 // Cancel returns directly to whatever the parent told us via props.meta —
@@ -202,18 +283,29 @@ async function onSave(field: CredentialFieldDef) {
   }
 }
 
-// Remove is a single-click action: skip the modal confirm dialog and just
-// do it, with a toast for feedback. Rationale: the secret is irrecoverable
-// from the client side regardless of whether we confirm (we never had the
-// plaintext), so a modal adds friction without adding safety — re-typing
-// the secret is the recovery path either way. The danger-themed "Remove"
-// button itself already serves as a visual deterrent against misclicks.
-async function onRemove(field: CredentialFieldDef) {
+// Two-step remove. First click flips the row to a confirm state; second
+// click actually fires DELETE. We deliberately do NOT use a global modal
+// here — the row is also the place where the result will appear, and a
+// modal forces an unnecessary screen-center detour. The danger-themed
+// "确认移除" button on a tinted-warning row gives the same protection
+// against fat-fingered destructive clicks without that detour.
+//
+// Errors still surface via global MessagePlugin so the user can't miss them.
+function requestRemove(key: string) {
+  pendingRemove[key] = true
+}
+
+function cancelPendingRemove(key: string) {
+  pendingRemove[key] = false
+}
+
+async function confirmRemove(field: CredentialFieldDef) {
   busy[field.key] = 'remove'
   try {
     await props.api.remove(field.key as K)
     states[field.key] = 'unconfigured'
-    MessagePlugin.success(t('credential.removedToast'))
+    pendingRemove[field.key] = false
+    flashInlineToast(field.key, 'removed')
     emit('changed')
   } catch (err: any) {
     MessagePlugin.error(err?.message || t('credential.removeFailed'))
@@ -221,54 +313,152 @@ async function onRemove(field: CredentialFieldDef) {
     busy[field.key] = null
   }
 }
+
+// Cancel pending inline-toast timers when the component unmounts so we
+// don't write to a torn-down reactive object after navigation.
+onBeforeUnmount(() => {
+  for (const k of Object.keys(inlineToastTimers)) {
+    if (inlineToastTimers[k]) {
+      clearTimeout(inlineToastTimers[k]!)
+      inlineToastTimers[k] = null
+    }
+  }
+})
 </script>
 
 <style scoped lang="less">
 .credential-resource {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
 }
 
 .credential-row {
-  border: 1px solid var(--td-component-stroke);
-  border-radius: 6px;
-  padding: 12px 14px;
-  background: var(--td-bg-color-container);
+  /* Empty wrapper now — each state owns its own outer styling so the
+     "configured" and "unconfigured" rows can mimic a t-input exactly,
+     and the editing state can defer the chrome to t-input itself. */
 }
 
-.credential-summary {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.credential-meta {
-  flex: 1;
-  min-width: 0;
-}
-
-.credential-label {
-  font-size: 14px;
+.credential-row-label {
+  font-size: 13px;
   font-weight: 500;
   color: var(--td-text-color-primary);
-  margin-bottom: 2px;
+  margin-bottom: 4px;
+  line-height: 1.4;
 }
 
-.credential-sub {
-  font-size: 12px;
-  color: var(--td-text-color-secondary);
-}
-
-.credential-actions {
+/*
+  Faux-input row: visually identical to a TDesign default t-input
+    - 32px tall
+    - same border (--td-component-border) + radius (6px) + bg
+    - 0 12px horizontal padding
+  This makes the credential card stop looking like "a card inside a card"
+  when it sits between Base URL and 自定义请求头 — it reads as a normal
+  field, just one that doesn't accept typed input.
+*/
+.credential-faux-input {
   display: flex;
+  align-items: center;
   gap: 8px;
-  flex-shrink: 0;
+  height: 32px;
+  padding: 0 4px 0 12px;
+  background: var(--td-bg-color-container);
+  border: 1px solid var(--td-component-border);
+  border-radius: 6px;
+  font-size: 13px;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+
+  &:hover {
+    border-color: var(--td-brand-color-hover);
+  }
+
+  &.is-empty {
+    cursor: pointer;
+    background: var(--td-bg-color-container);
+
+    &:hover {
+      background: var(--td-bg-color-container-hover);
+    }
+  }
+
+  /*
+    Just-removed flash state: brief tinted background + brand-color border
+    so the row gives the user clear, anchored confirmation that the remove
+    actually happened — no need for them to find a corner toast. Auto-fades
+    after ~2.4s back to plain "未配置" via the inlineToast timer.
+  */
+  &.is-just-removed {
+    background: var(--td-success-color-light);
+    border-color: var(--td-success-color-focus);
+    animation: credential-toast-flash 0.25s ease both;
+    cursor: default;
+
+    &:hover {
+      background: var(--td-success-color-light);
+      border-color: var(--td-success-color-focus);
+    }
+  }
+
+  /*
+    Confirm-remove state: warning-tinted background + danger-color border,
+    making it obvious that the row is in a destructive-action standoff. The
+    button group changes to [Cancel | Confirm-danger]; user has to make a
+    deliberate second click to actually delete.
+  */
+  &.is-confirm-remove {
+    background: var(--td-error-color-light);
+    border-color: var(--td-error-color-focus);
+    animation: credential-confirm-flash 0.2s ease both;
+
+    &:hover {
+      border-color: var(--td-error-color-focus);
+    }
+  }
+}
+
+@keyframes credential-toast-flash {
+  from {
+    background: var(--td-bg-color-container);
+    border-color: var(--td-component-border);
+  }
+  to {
+    background: var(--td-success-color-light);
+    border-color: var(--td-success-color-focus);
+  }
+}
+
+@keyframes credential-confirm-flash {
+  from {
+    background: var(--td-bg-color-container);
+    border-color: var(--td-component-border);
+  }
+  to {
+    background: var(--td-error-color-light);
+    border-color: var(--td-error-color-focus);
+  }
+}
+
+.credential-faux-text {
+  flex: 1;
+  min-width: 0;
+  color: var(--td-text-color-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &.muted {
+    color: var(--td-text-color-placeholder);
+  }
+
+  &.danger {
+    color: var(--td-error-color);
+    font-weight: 500;
+  }
 }
 
 .status-icon {
-  font-size: 18px;
   flex-shrink: 0;
+  font-size: 16px;
 
   &.success {
     color: var(--td-success-color);
@@ -277,17 +467,59 @@ async function onRemove(field: CredentialFieldDef) {
   &.muted {
     color: var(--td-text-color-placeholder);
   }
+
+  &.warn {
+    color: var(--td-error-color);
+  }
 }
 
+/*
+  Inline action buttons inside the faux input. We use `variant="text"` so
+  they read as inline text affordances — same visual weight as the eye
+  toggle on the create-mode API key input. A 1px divider between Update
+  and Remove gives them just enough separation without adding boxes.
+*/
+.credential-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+
+  :deep(.t-button--variant-text) {
+    height: 24px;
+    padding: 0 8px;
+    font-size: 12px;
+    border-radius: 4px;
+  }
+}
+
+.action-divider {
+  width: 1px;
+  height: 14px;
+  background: var(--td-component-stroke);
+  margin: 0 2px;
+}
+
+/*
+  Editing state — let t-input own its frame; we just stack a tiny
+  end-aligned action row underneath. No border on this wrapper.
+*/
 .credential-edit {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
 .credential-edit-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  align-items: center;
+  gap: 4px;
+
+  :deep(.t-button) {
+    height: 28px;
+    padding: 0 12px;
+    font-size: 12px;
+  }
 }
 </style>

--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -284,7 +284,6 @@ let loadingChunks = false;
 let pendingRequestedPage: number | null = null;
 let pendingChunksBeforeLoad = 0;
 let doc = null;
-let down = ref()
 let mdContentWrap = ref()
 let url = ref('')
 // 视图模式：chunks / merged / preview
@@ -1007,13 +1006,21 @@ const handleDetailsScroll = () => {
           <t-tag v-if="details.type" class="header-type-tag" size="small" :theme="getTypeTheme()" variant="light">
             {{ getTypeLabel() }}
           </t-tag>
-          <t-button v-if="details.id && hasTimelineSpans" class="trace-entry-btn" size="small" variant="outline"
-            :theme="traceEntryTheme" :title="traceEntryTitle" @click="openTimeline">
-            <template #icon>
-              <t-icon name="chart-bar" size="14px" />
-            </template>
-            {{ $t('knowledgeStages.traceBtn') }}
-          </t-button>
+          <div class="header-actions">
+            <t-button v-if="details.type === 'file' || details.type === 'manual'" class="header-action-btn" size="small"
+              variant="text" shape="square" theme="default" :title="$t('common.download') || 'Download'"
+              @click="downloadFile()">
+              <template #icon>
+                <t-icon name="download" size="16px" />
+              </template>
+            </t-button>
+            <t-button v-if="details.id && hasTimelineSpans" class="header-action-btn trace-entry-btn" size="small"
+              variant="text" shape="square" :theme="traceEntryTheme" :title="traceEntryTitle" @click="openTimeline">
+              <template #icon>
+                <t-icon name="chart-line" size="16px" />
+              </template>
+            </t-button>
+          </div>
         </div>
       </template>
 
@@ -1027,35 +1034,26 @@ const handleDetailsScroll = () => {
       </div>
 
       <!-- 二级抽屉：完整 Langfuse-style waterfall -->
+      <teleport to="body">
+        <div v-if="timelineDrawerVisible" class="trace-drawer-resize-handle"
+          :style="{ right: `${timelineDrawerWidth}px` }" role="separator" aria-orientation="vertical"
+          :aria-label="$t('knowledgeStages.resizeDrawer')" :title="$t('knowledgeStages.resizeDrawer')"
+          @mousedown.prevent="onTraceDrawerResizeStart">
+          <div class="trace-drawer-resize-line" />
+        </div>
+      </teleport>
       <t-drawer :visible="timelineDrawerVisible" :zIndex="2100" :size="`${timelineDrawerWidth}px`" attach="body"
         :closeBtn="false" :footer="false" :header="false" :showOverlay="true" :closeOnOverlayClick="true"
         placement="right" :class="['kp-secondary-drawer', { 'kp-secondary-drawer--resizing': timelineDrawerResizing }]"
         @close="closeTimeline">
         <div class="kp-drawer-shell" :class="{ 'kp-drawer-shell--resizing': timelineDrawerResizing }">
-          <div class="kp-drawer-resize-handle" role="separator" aria-orientation="vertical"
-            :aria-label="$t('knowledgeStages.resizeDrawer')" :title="$t('knowledgeStages.resizeDrawer')"
-            @mousedown.prevent="onTraceDrawerResizeStart">
-            <div class="kp-drawer-resize-line" />
-          </div>
           <KnowledgeProcessingTimeline v-if="details.id && timelineDrawerVisible" :knowledge-id="details.id"
             :parse-status="details.parse_status" :doc-title="details.title" show-close @close="closeTimeline" />
         </div>
       </t-drawer>
 
-      <!-- 文件类型专属区域 -->
-      <div v-if="details.type === 'file'" class="doc_box">
-        <a :href="url" style="display: none" ref="down" :download="details.title"></a>
-        <span class="label">{{ $t('knowledgeBase.fileName') }}</span>
-        <div class="download_box">
-          <span class="doc_t">{{ details.title }}</span>
-          <div class="icon_box" @click="downloadFile()" aria-label="Download">
-            <img class="download_box" src="@/assets/img/download.svg" alt="">
-          </div>
-        </div>
-      </div>
-
-      <!-- URL类型专属区域 -->
-      <div v-else-if="details.type === 'url'" class="url_box">
+      <!-- URL类型专属区域（保留：source 是真实链接，不与标题重复） -->
+      <div v-if="details.type === 'url'" class="url_box">
         <span class="label">{{ $t('knowledgeBase.urlSource') }}</span>
         <div class="url_link_box">
           <a :href="isValidURL(details.source) ? details.source : 'javascript:void(0)'"
@@ -1064,19 +1062,6 @@ const handleDetailsScroll = () => {
             <span class="url_text">{{ details.source }}</span>
             <t-icon name="jump" size="14px" class="jump-icon" />
           </a>
-        </div>
-      </div>
-
-      <!-- 手动创建类型专属区域 -->
-      <div v-else-if="details.type === 'manual'" class="manual_box">
-        <span class="label">{{ $t('knowledgeBase.documentTitle') }}</span>
-        <div class="download_box">
-          <div class="manual_title_box">
-            <span class="manual_title">{{ details.title }}</span>
-          </div>
-          <div class="icon_box" @click="downloadFile()" aria-label="Download">
-            <img class="download_box" src="@/assets/img/download.svg" alt="">
-          </div>
         </div>
       </div>
 
@@ -1284,9 +1269,15 @@ const handleDetailsScroll = () => {
   align-items: center;
   gap: 8px;
   min-width: 0;
+  width: 100%;
+  /* TDesign 抽屉的 X 关闭按钮浮在 header 右上角（约 16px 宽 + 16px 间距），
+     给右侧留出空间，避免我们的图标按钮被 X 遮挡。 */
+  padding-right: 32px;
 
   .header-title {
-    flex: 1;
+    /* flex: 1 1 auto + min-width:0 让标题在标题超长时收缩出省略号，
+       而不是把右侧 tag/操作按钮挤出 header。 */
+    flex: 1 1 auto;
     min-width: 0;
     font-size: 16px;
     font-weight: 500;
@@ -1295,22 +1286,52 @@ const handleDetailsScroll = () => {
     white-space: nowrap;
   }
 
-  .header-type-tag,
-  .trace-entry-btn {
+  .header-type-tag {
     flex-shrink: 0;
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    /* 关键：操作区永不收缩，标题再长也能完整看到图标 */
+    flex-shrink: 0;
+    flex-grow: 0;
+  }
+
+  .header-action-btn {
+    /* 28×28 文本按钮：无边框，与抽屉头部融为一体；hover 时浅灰背景，
+       与右上角 X 关闭按钮的视觉风格一致。 */
+    width: 28px;
+    min-width: 28px;
+    height: 28px;
+    padding: 0;
+    flex-shrink: 0;
+    color: var(--td-text-color-secondary);
+    border-radius: 4px;
+    transition: background-color 0.15s ease, color 0.15s ease;
+
+    &:hover {
+      background: var(--td-bg-color-container-hover);
+      color: var(--td-text-color-primary);
+    }
+
+    :deep(.t-button__text) {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
   }
 }
 
-// 信息面板通用样式
+// 信息面板通用样式（仅 url_box 在用，file/manual 已合并到 header）
 .info_panel {
   display: flex;
   flex-direction: column;
   margin-bottom: 16px;
 }
 
-.doc_box,
-.url_box,
-.manual_box {
+.url_box {
   .info_panel();
 }
 
@@ -1339,39 +1360,6 @@ const handleDetailsScroll = () => {
      declaration in a flex chain, clip rather than overflow the drawer. */
   overflow: hidden;
   min-width: 0;
-}
-
-.kp-drawer-resize-handle {
-  position: absolute;
-  top: 0;
-  left: -6px;
-  bottom: 0;
-  width: 12px;
-  cursor: col-resize;
-  z-index: 20;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  &:hover .kp-drawer-resize-line,
-  .kp-drawer-shell--resizing & .kp-drawer-resize-line {
-    opacity: 1;
-    background: var(--td-brand-color);
-  }
-}
-
-.kp-drawer-resize-line {
-  width: 2px;
-  height: 48px;
-  border-radius: 1px;
-  background: var(--td-component-border);
-  opacity: 0.55;
-  transition: opacity 0.15s ease, background 0.15s ease;
-}
-
-.kp-drawer-shell--resizing .kp-drawer-resize-line {
-  opacity: 1;
-  background: var(--td-brand-color);
 }
 
 .kp-drawer-shell> :deep(.kp-timeline) {
@@ -1471,38 +1459,6 @@ const handleDetailsScroll = () => {
   margin-bottom: 8px;
 }
 
-// 文件下载区域
-.download_box {
-  display: flex;
-  align-items: center;
-  background: var(--td-bg-color-container-hover);
-  border-radius: 4px;
-  padding: 6px 10px;
-}
-
-.doc_t {
-  display: flex;
-  align-items: center;
-  word-break: break-all;
-  font-size: 13px;
-  color: var(--td-text-color-primary);
-  flex: 1;
-}
-
-.icon_box {
-  margin-left: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--td-brand-color);
-  cursor: pointer;
-
-  img.download_box {
-    width: 16px;
-    height: 16px;
-  }
-}
-
 // URL链接区域
 .url_link_box {
   border-radius: 4px;
@@ -1526,19 +1482,6 @@ const handleDetailsScroll = () => {
       flex-shrink: 0;
       color: var(--td-brand-color);
     }
-  }
-}
-
-// 手动创建标题区域
-.manual_title_box {
-  flex: 1;
-  display: flex;
-  align-items: center;
-
-  .manual_title {
-    color: var(--td-text-color-primary);
-    font-size: 13px;
-    word-break: break-word;
   }
 }
 
@@ -1838,6 +1781,41 @@ const handleDetailsScroll = () => {
 /* 拖拽过程中关闭宽度过渡，避免跟手卡顿 */
 .t-drawer.doc-main-drawer--resizing .t-drawer__content {
   transition: none !important;
+}
+
+/* Trace 二级抽屉拖拽手柄：与主抽屉保持一致，teleport 到 body，
+   position: fixed，z-index 高于二级抽屉本体，避免被其他层级遮挡。 */
+.trace-drawer-resize-handle {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  width: 12px;
+  margin-left: -6px;
+  cursor: col-resize;
+  z-index: 2101;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.trace-drawer-resize-handle .trace-drawer-resize-line {
+  width: 2px;
+  height: 48px;
+  border-radius: 1px;
+  background: var(--td-component-border);
+  opacity: 0.55;
+  transition: opacity 0.15s ease, background 0.15s ease;
+}
+
+.trace-drawer-resize-handle:hover .trace-drawer-resize-line {
+  opacity: 1;
+  background: var(--td-brand-color);
+}
+
+.t-drawer.kp-secondary-drawer--resizing .trace-drawer-resize-line,
+body:has(.t-drawer.kp-secondary-drawer--resizing) .trace-drawer-resize-line {
+  opacity: 1;
+  background: var(--td-brand-color);
 }
 
 .t-drawer.kp-secondary-drawer .t-drawer__body {

--- a/frontend/src/components/settings/SettingDrawer.vue
+++ b/frontend/src/components/settings/SettingDrawer.vue
@@ -1,13 +1,37 @@
 <template>
   <t-drawer
     v-model:visible="drawerVisible"
-    :header="title"
-    :size="width"
+    :size="effectiveWidth"
+    :size-draggable="resizable ? sizeDragLimit : false"
     placement="right"
     destroy-on-close
+    class="setting-drawer"
+    @size-drag-end="onSizeDragEnd"
   >
+    <!--
+      Custom header. We replace TDesign's default header so we can put a leading
+      icon badge and an optional subtitle (description) right next to the title,
+      keeping the body uncluttered. The close affordance is the slide-out drawer
+      itself + the underlying overlay click — TDesign already wires those up,
+      so we don't need a redundant X button.
+    -->
+    <template #header>
+      <div class="setting-drawer__header">
+        <div v-if="$slots.headerIcon || icon" class="setting-drawer__header-icon">
+          <slot name="headerIcon">
+            <t-icon v-if="icon" :name="icon" />
+          </slot>
+        </div>
+        <div class="setting-drawer__header-text">
+          <div class="setting-drawer__title">{{ title }}</div>
+          <div v-if="description || $slots.subtitle" class="setting-drawer__subtitle">
+            <slot name="subtitle">{{ description }}</slot>
+          </div>
+        </div>
+      </div>
+    </template>
+
     <div class="setting-drawer__body">
-      <p v-if="description" class="setting-drawer__desc">{{ description }}</p>
       <slot />
     </div>
     <template v-if="!hideFooter" #footer>
@@ -34,14 +58,37 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 interface Props {
   visible: boolean
   title: string
   description?: string
+  /** Optional TDesign icon name shown as a leading badge in the header. */
+  icon?: string
+  /**
+   * Initial width when the user has no persisted preference. Accepts any
+   * CSS length string (e.g. "560px", "40%").
+   */
   width?: string
+  /**
+   * Whether the drawer can be horizontally resized by dragging its left
+   * edge. We delegate to TDesign's built-in `sizeDraggable` — it already
+   * renders the resize cursor on the panel edge and takes care of the
+   * mousemove handlers, so all we do here is bound it and persist the
+   * final size on drag-end.
+   */
+  resizable?: boolean
+  /** Min/max bounds for the drag-resize, in px. */
+  minWidth?: number
+  maxWidth?: number
+  /**
+   * localStorage key used to remember the user's chosen width. Set to '' to
+   * disable persistence. Default key is namespaced per-consumer using the
+   * drawer title.
+   */
+  storageKey?: string
   confirmLoading?: boolean
   confirmDisabled?: boolean
   confirmText?: string
@@ -51,7 +98,12 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   description: '',
-  width: '500px',
+  icon: '',
+  width: '560px',
+  resizable: true,
+  minWidth: 480,
+  maxWidth: 1200,
+  storageKey: '',
   confirmLoading: false,
   confirmDisabled: false,
   confirmText: '',
@@ -67,10 +119,65 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
+// ---------- visibility ----------
 const drawerVisible = computed({
   get: () => props.visible,
   set: (val) => emit('update:visible', val)
 })
+
+// ---------- width state ----------
+// Storage key derives from the drawer title so different drawers (model
+// editor vs MCP service vs web search provider) get independent widths.
+// Callers can override via the `storageKey` prop when titles collide.
+const resolvedStorageKey = computed(
+  () => props.storageKey || `setting-drawer:width:${props.title || 'default'}`
+)
+
+const clampWidth = (n: number) =>
+  Math.max(props.minWidth, Math.min(props.maxWidth, Math.round(n)))
+
+const loadStoredWidth = (): number | null => {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.localStorage.getItem(resolvedStorageKey.value)
+    if (!raw) return null
+    const n = Number(raw)
+    if (!Number.isFinite(n)) return null
+    return clampWidth(n)
+  } catch {
+    return null
+  }
+}
+
+// User's persisted width (px) wins over the prop default.
+const userWidthPx = ref<number | null>(loadStoredWidth())
+
+const effectiveWidth = computed(() =>
+  userWidthPx.value != null ? `${userWidthPx.value}px` : props.width
+)
+
+// ---------- TDesign-native drag-resize ----------
+// `sizeDraggable` accepts true (no clamp) or { min, max }. We always pass
+// the bounds so the user can't accidentally collapse the drawer to nothing
+// or push it past the viewport.
+const sizeDragLimit = computed(() => ({
+  min: props.minWidth,
+  max: props.maxWidth,
+}))
+
+const onSizeDragEnd = (ctx: { e: MouseEvent; size: number }) => {
+  const next = clampWidth(ctx.size)
+  userWidthPx.value = next
+  if (typeof window !== 'undefined' && props.storageKey !== '') {
+    try {
+      window.localStorage.setItem(resolvedStorageKey.value, String(next))
+    } catch {
+      // localStorage can throw in private mode / quota errors. The width
+      // still applies for this session; we just lose the persistence on
+      // next open.
+    }
+  }
+}
 
 const handleConfirm = () => emit('confirm')
 const handleCancel = () => {
@@ -80,19 +187,136 @@ const handleCancel = () => {
 </script>
 
 <style lang="less" scoped>
+/* ---------- Header ---------- */
+.setting-drawer__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+  padding: 2px 0;
+}
+
+.setting-drawer__header-icon {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(7, 192, 95, 0.1);
+  color: var(--td-brand-color);
+  font-size: 16px;
+  transition: background 0.2s ease;
+}
+
+.setting-drawer__header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.setting-drawer__title {
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--td-text-color-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.setting-drawer__subtitle {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--td-text-color-secondary);
+}
+
+/* ---------- Body ---------- */
 .setting-drawer__body {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 4px;
+  /* The Body is the entry-animation host. Children (.form-item) get
+     a subtle staggered slide-in to echo the model-card hover transform. */
+  animation: setting-drawer-body-in 0.28s ease both;
 }
 
-.setting-drawer__desc {
-  margin: 0;
+@keyframes setting-drawer-body-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ---------- Sections (consumed by ModelEditorDialog & friends) ---------- */
+.setting-drawer__body :deep(.setting-drawer__section) {
+  padding: 12px 0 16px;
+  border-bottom: 1px solid var(--td-component-stroke);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  animation: setting-drawer-section-in 0.32s ease both;
+
+  &:first-child {
+    padding-top: 0;
+    animation-delay: 0.04s;
+  }
+
+  &:nth-child(2) {
+    animation-delay: 0.08s;
+  }
+
+  &:nth-child(3) {
+    animation-delay: 0.12s;
+  }
+
+  &:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+}
+
+@keyframes setting-drawer-section-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.setting-drawer__body :deep(.setting-drawer__section-title) {
   font-size: 13px;
-  color: var(--td-text-color-secondary);
-  line-height: 1.6;
+  font-weight: 600;
+  color: var(--td-text-color-primary);
+  margin: 0 0 4px;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  /* A subtle leading bar — replaces the previous all-caps + letter-spacing
+     trick (which mangles Chinese). Gives the section title a consistent
+     visual anchor without yelling at the user. */
+  &::before {
+    content: '';
+    width: 3px;
+    height: 14px;
+    background: var(--td-brand-color);
+    border-radius: 2px;
+  }
 }
 
+/* ---------- Footer ---------- */
 .setting-drawer__footer {
   display: flex;
   align-items: center;
@@ -114,5 +338,57 @@ const handleCancel = () => {
   align-items: center;
   gap: 12px;
   flex-shrink: 0;
+}
+</style>
+
+<!--
+  Non-scoped block: t-drawer renders header/footer wrappers outside the
+  scoped style boundary in some TDesign builds, so we tweak chrome (border,
+  padding) at the global level — namespaced under `.setting-drawer` to avoid
+  bleeding into other drawers in the app.
+-->
+<style lang="less">
+.setting-drawer {
+  .t-drawer__header {
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--td-component-stroke);
+  }
+
+  .t-drawer__body {
+    padding: 16px 18px;
+  }
+
+  .t-drawer__footer {
+    padding: 10px 18px;
+    border-top: 1px solid var(--td-component-stroke);
+    box-shadow: 0 -2px 8px rgba(15, 23, 42, 0.04);
+  }
+
+  /*
+    TDesign renders the drag handle as a class-less <div> on the panel edge
+    when sizeDraggable is on, with inline style `cursor: col-resize` and a
+    16px-wide TRANSPARENT background — so users can drag, but they have no
+    visual cue that they can. We use an attribute selector on the inline
+    cursor style to give it a visible 3px line that lights up on hover/drag,
+    matching the brand color so it reads as a deliberate affordance.
+  */
+  .t-drawer__content-wrapper > div[style*="col-resize"] {
+    /* Override TDesign's hardcoded inline width so the visible line is a
+       reasonable thickness; the handle still extends past it because the
+       hit area is generous on hover. */
+    background: var(--td-component-stroke) !important;
+    width: 3px !important;
+    transition: background 0.15s ease, width 0.15s ease;
+
+    &:hover {
+      background: var(--td-brand-color) !important;
+      width: 4px !important;
+    }
+
+    &:active {
+      background: var(--td-brand-color-active, var(--td-brand-color)) !important;
+      width: 4px !important;
+    }
+  }
 }
 </style>

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -13,7 +13,6 @@ const messages = {
 
 // Получаем сохраненный язык из localStorage или используем китайский по умолчанию
 const savedLocale = localStorage.getItem('locale') || 'zh-CN'
-console.log('i18n инициализация с языком:', savedLocale)
 
 const i18n = createI18n({
   legacy: false,

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -895,6 +895,11 @@ export default {
     parser: {
       title: 'Parser Engine',
       description: 'Document parser engine status and configuration. Settings here take priority over server environment variables. Leave empty to use environment variable defaults.',
+      // Section / label keys for the redesigned drawer
+      supportedFileTypes: 'Supported Formats',
+      statusSection: 'Status',
+      configSection: 'Configuration',
+      featuresLabel: 'Features',
       loading: 'Loading...',
       retry: 'Retry',
       noEngineDetected: 'No parser engine detected. Please ensure the DocReader service is running properly.',
@@ -932,6 +937,12 @@ export default {
     storage: {
       title: 'Storage Engine',
       description: 'Configure document and image storage. Set engine parameters here; knowledge bases only select which engine to use.',
+      // Section / label keys for the redesigned drawer
+      basicSection: 'Basic',
+      modeSection: 'Deployment Mode',
+      credentialsSection: 'Credentials',
+      bucketSection: 'Bucket',
+      useSslDesc: 'Connect to MinIO over HTTPS',
       loading: 'Loading...',
       retry: 'Retry',
       defaultEngine: 'Default Engine',
@@ -1010,6 +1021,10 @@ export default {
   webSearchSettings: {
     title: 'Web Search Configuration',
     description: 'Configure web search so answers can include up-to-date information from the internet.',
+    // Section keys for the redesigned drawer
+    basicSection: 'Basic',
+    credentialsSection: 'Connection',
+    optionsSection: 'Options',
     // Provider entity management
     providersTitle: 'Search Engine Providers',
     addProvider: 'Add Provider',
@@ -1077,6 +1092,8 @@ export default {
   vectorStoreSettings: {
     title: 'Vector Database Engine',
     description: 'Register and manage vector database instances for knowledge base search.',
+    // Section key for the redesigned drawer
+    basicSection: 'Basic',
     storesTitle: 'Vector Databases',
     addStore: 'Add Database',
     editStore: 'Edit Database',
@@ -3498,6 +3515,9 @@ export default {
   mcpSettings: {
     title: 'MCP Services',
     description: 'Manage external MCP (Model Context Protocol) services for tools/resources in Agent mode',
+    // Drawer subtitle chip
+    enabled: 'Enabled',
+    disabled: 'Disabled',
     configuredServices: 'Configured Services',
     manageAndTest: 'Manage and test MCP service connections',
     addService: 'Add Service',
@@ -3538,7 +3558,8 @@ export default {
     },
     source: {
       remote: 'Remote',
-      openaiCompatible: 'OpenAI-compatible'
+      openaiCompatible: 'OpenAI-compatible',
+      custom: 'Custom',
     },
     rawModelName: 'Model name',
     chat: {
@@ -3645,6 +3666,13 @@ export default {
   mcpServiceDialog: {
     addTitle: 'Add MCP Service',
     editTitle: 'Edit MCP Service',
+    // Section + drawer-only keys
+    basicSection: 'Basic',
+    connectionSection: 'Connection',
+    enableServiceDesc: 'When off, this service will not be invoked',
+    testAfterSaveHint: 'Save first to test the connection',
+    unitSecond: 's',
+    unitTimes: '×',
     name: 'Service Name',
     namePlaceholder: 'Enter service name',
     description: 'Description',
@@ -4175,6 +4203,10 @@ export default {
         weknoracloud: {
           name: 'WeKnora Cloud',
           desc: 'Document parsing via WeKnora Cloud',
+        },
+        markitdown: {
+          name: 'MarkItDown',
+          desc: "Microsoft MarkItDown converter (PDF/Office/HTML and more)",
         },
       },
     },

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2972,9 +2972,12 @@ export default {
     editor: {
       addTitle: 'Add Model',
       editTitle: 'Edit Model',
+      sectionSource: 'Source',
+      sectionProvider: 'Provider Settings',
+      sectionAdvanced: 'Advanced Options',
       sourceLabel: 'Model Source',
-      sourceLocal: 'Ollama (Local)',
-      sourceRemote: 'Remote API',
+      sourceLocal: 'Ollama',
+      sourceRemote: 'API',
       description: {
         chat: 'Configure large language models for conversations',
         embedding: 'Configure embedding models for text vectorization',
@@ -4803,6 +4806,8 @@ export default {
     saveFailed: 'Failed to save credential',
     removedToast: 'Credential removed',
     removeFailed: 'Failed to remove credential',
+    confirmRemovePrompt: 'Remove this credential? This cannot be undone.',
+    confirmRemove: 'Confirm remove',
     confirmRemoveTitle: 'Remove {field}?',
     confirmRemoveBody:
       'This permanently deletes the stored credential. Integrations using it will stop working until you configure a new value.',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -2210,9 +2210,12 @@ export default {
     editor: {
       addTitle: "모델 추가",
       editTitle: "모델 편집",
+      sectionSource: "모델 소스",
+      sectionProvider: "연결 설정",
+      sectionAdvanced: "고급 옵션",
       sourceLabel: "모델 소스",
-      sourceLocal: "Ollama (로컬)",
-      sourceRemote: "Remote API (원격)",
+      sourceLocal: "Ollama",
+      sourceRemote: "API",
       description: {
         chat: "대화용 대규모 언어 모델 설정",
         embedding: "텍스트 벡터화용 임베딩 모델 설정",
@@ -4862,6 +4865,8 @@ export default {
     saveFailed: "credential 저장 실패",
     removedToast: "credential이 제거되었습니다",
     removeFailed: "credential 제거 실패",
+    confirmRemovePrompt: "이 credential을 제거하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+    confirmRemove: "제거 확인",
     confirmRemoveTitle: "{field} 제거하시겠습니까?",
     confirmRemoveBody:
       "저장된 credential이 영구적으로 삭제되며, 이를 사용하는 통합은 새 값을 구성할 때까지 동작하지 않습니다.",

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -755,6 +755,11 @@ export default {
     parser: {
       title: '파서 엔진',
       description: '문서 파서 엔진 상태 및 구성. 이 설정은 서버 환경변수보다 우선 적용됩니다. 비워두면 환경변수 기본값을 사용합니다.',
+      // Section / label keys for the redesigned drawer
+      supportedFileTypes: '지원 형식',
+      statusSection: '상태',
+      configSection: '구성',
+      featuresLabel: '기능',
       loading: '로딩 중...',
       retry: '재시도',
       noEngineDetected: '파서 엔진이 감지되지 않았습니다. DocReader 서비스가 정상적으로 실행 중인지 확인하세요.',
@@ -792,6 +797,12 @@ export default {
     storage: {
       title: '스토리지 엔진',
       description: '문서 및 이미지 저장 방식을 구성합니다. 엔진 파라미터를 설정하면 지식베이스에서 사용할 엔진만 선택합니다.',
+      // Section / label keys for the redesigned drawer
+      basicSection: '기본',
+      modeSection: '배포 모드',
+      credentialsSection: '자격 증명',
+      bucketSection: '버킷',
+      useSslDesc: 'HTTPS로 MinIO에 연결',
       loading: '로딩 중...',
       retry: '재시도',
       defaultEngine: '기본 엔진',
@@ -871,6 +882,10 @@ export default {
     title: "웹 검색 설정",
     description:
       "웹 검색 기능을 구성하여 질문에 답변할 때 인터넷에서 실시간 정보를 가져와 지식베이스 내용을 보완합니다",
+    // Section keys for the redesigned drawer
+    basicSection: '기본',
+    credentialsSection: '연결',
+    optionsSection: '옵션',
     providersTitle: "검색 엔진 프로바이더 설정",
     addProvider: "프로바이더 추가",
     editProvider: "프로바이더 편집",
@@ -937,6 +952,8 @@ export default {
   vectorStoreSettings: {
     title: "벡터 데이터베이스 엔진",
     description: "지식 베이스 검색을 위한 벡터 데이터베이스 인스턴스를 등록하고 관리합니다.",
+    // Section key for the redesigned drawer
+    basicSection: '기본',
     storesTitle: "벡터 데이터베이스",
     addStore: "데이터베이스 추가",
     editStore: "데이터베이스 수정",
@@ -3539,6 +3556,9 @@ export default {
     title: "MCP 서비스 관리",
     description:
       "외부 MCP (Model Context Protocol) 서비스를 관리합니다. Agent 모드에서 외부 도구와 리소스를 호출합니다",
+    // Drawer subtitle chip
+    enabled: "활성화됨",
+    disabled: "비활성화됨",
     configuredServices: "설정된 서비스",
     manageAndTest: "MCP 서비스 연결 관리 및 테스트",
     addService: "서비스 추가",
@@ -3580,6 +3600,7 @@ export default {
     source: {
       remote: "Remote",
       openaiCompatible: "OpenAI 호환",
+      custom: "사용자 지정",
     },
     rawModelName: "모델 이름",
     chat: {
@@ -3686,6 +3707,13 @@ export default {
   mcpServiceDialog: {
     addTitle: "MCP 서비스 추가",
     editTitle: "MCP 서비스 편집",
+    // Section + drawer-only keys
+    basicSection: "기본",
+    connectionSection: "연결",
+    enableServiceDesc: "비활성화 시 이 서비스가 호출되지 않습니다",
+    testAfterSaveHint: "저장 후 연결을 테스트할 수 있습니다",
+    unitSecond: "초",
+    unitTimes: "회",
     name: "서비스 이름",
     namePlaceholder: "서비스 이름을 입력해주세요",
     description: "설명",
@@ -4237,6 +4265,10 @@ export default {
         weknoracloud: {
           name: 'WeKnora Cloud',
           desc: 'WeKnora Cloud를 통한 문서 파싱',
+        },
+        markitdown: {
+          name: 'MarkItDown',
+          desc: 'Microsoft MarkItDown 변환기 (PDF/Office/HTML 등)',
         },
       },
     },

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -810,6 +810,11 @@ export default {
     parser: {
       title: 'Парсер',
       description: 'Состояние и конфигурация парсеров документов. Настройки здесь приоритетнее переменных окружения сервера. Оставьте пустым для значений по умолчанию.',
+      // Section / label keys for the redesigned drawer
+      supportedFileTypes: 'Поддерживаемые форматы',
+      statusSection: 'Статус',
+      configSection: 'Конфигурация',
+      featuresLabel: 'Опции',
       loading: 'Загрузка...',
       retry: 'Повторить',
       noEngineDetected: 'Парсеры не обнаружены. Убедитесь, что сервис DocReader работает.',
@@ -844,6 +849,12 @@ export default {
     storage: {
       title: 'Хранилище',
       description: 'Настройте хранение документов и изображений. Здесь задаются параметры хранилищ; в базе знаний выбирается только тип хранилища.',
+      // Section / label keys for the redesigned drawer
+      basicSection: 'Основное',
+      modeSection: 'Режим развёртывания',
+      credentialsSection: 'Учётные данные',
+      bucketSection: 'Bucket',
+      useSslDesc: 'Подключаться к MinIO по HTTPS',
       loading: 'Загрузка...',
       retry: 'Повторить',
       defaultEngine: 'Хранилище по умолчанию',
@@ -922,6 +933,10 @@ export default {
   webSearchSettings: {
     title: 'Настройки веб-поиска',
     description: 'Настройте веб-поиск, чтобы ответы могли включать актуальную информацию из интернета.',
+    // Section keys for the redesigned drawer
+    basicSection: 'Основное',
+    credentialsSection: 'Подключение',
+    optionsSection: 'Опции',
     providersTitle: 'Поисковые провайдеры',
     addProvider: 'Добавить провайдер',
     editProvider: 'Редактировать провайдер',
@@ -989,6 +1004,8 @@ export default {
   vectorStoreSettings: {
     title: 'Движок векторной базы данных',
     description: 'Регистрация и управление экземплярами векторных баз данных для поиска по базе знаний.',
+    // Section key for the redesigned drawer
+    basicSection: 'Основное',
     storesTitle: 'Векторные базы данных',
     addStore: 'Добавить базу данных',
     editStore: 'Редактировать базу данных',
@@ -3200,6 +3217,9 @@ export default {
   mcpSettings: {
     title: 'Сервисы MCP',
     description: 'Управление внешними сервисами MCP (Model Context Protocol) для использования инструментов и ресурсов в режиме Agent',
+    // Drawer subtitle chip
+    enabled: 'Включён',
+    disabled: 'Отключён',
     configuredServices: 'Настроенные сервисы',
     manageAndTest: 'Управляйте и тестируйте подключения MCP',
     addService: 'Добавить сервис',
@@ -3244,7 +3264,8 @@ export default {
     },
     source: {
       remote: 'Удалённая',
-      openaiCompatible: 'Совместимо с OpenAI'
+      openaiCompatible: 'Совместимо с OpenAI',
+      custom: 'Своё',
     },
     rawModelName: 'Имя модели',
     embedding: {
@@ -3344,6 +3365,13 @@ export default {
   mcpServiceDialog: {
     addTitle: 'Добавить сервис MCP',
     editTitle: 'Редактировать сервис MCP',
+    // Section + drawer-only keys
+    basicSection: 'Основное',
+    connectionSection: 'Подключение',
+    enableServiceDesc: 'При выключении сервис не будет вызываться',
+    testAfterSaveHint: 'Сохраните, чтобы протестировать подключение',
+    unitSecond: 'с',
+    unitTimes: '×',
     name: 'Название сервиса',
     namePlaceholder: 'Введите название сервиса',
     description: 'Описание',
@@ -3737,6 +3765,10 @@ export default {
         weknoracloud: {
           name: 'WeKnora Cloud',
           desc: 'Парсинг документов через WeKnora Cloud',
+        },
+        markitdown: {
+          name: 'MarkItDown',
+          desc: 'Конвертер Microsoft MarkItDown (PDF/Office/HTML и др.)',
         },
       },
     },

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -1929,9 +1929,12 @@ export default {
     editor: {
       addTitle: 'Добавить модель',
       editTitle: 'Редактировать модель',
+      sectionSource: 'Источник',
+      sectionProvider: 'Настройки провайдера',
+      sectionAdvanced: 'Дополнительные параметры',
       sourceLabel: 'Источник модели',
-      sourceLocal: 'Ollama (локальный)',
-      sourceRemote: 'Remote API (удалённый)',
+      sourceLocal: 'Ollama',
+      sourceRemote: 'API',
       description: {
         chat: 'Настройте языковую модель для диалогов',
         embedding: 'Настройте модель встраивания для текстовой векторизации',
@@ -4684,6 +4687,8 @@ export default {
     saveFailed: 'Не удалось сохранить учётные данные',
     removedToast: 'Учётные данные удалены',
     removeFailed: 'Не удалось удалить учётные данные',
+    confirmRemovePrompt: 'Удалить учётные данные? Действие необратимо.',
+    confirmRemove: 'Подтвердить удаление',
     confirmRemoveTitle: 'Удалить {field}?',
     confirmRemoveBody:
       'Сохранённые учётные данные будут безвозвратно удалены. Интеграции, использующие их, перестанут работать до настройки нового значения.',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2189,9 +2189,12 @@ export default {
     editor: {
       addTitle: "添加模型",
       editTitle: "编辑模型",
+      sectionSource: "模型来源",
+      sectionProvider: "接入配置",
+      sectionAdvanced: "高级选项",
       sourceLabel: "模型来源",
-      sourceLocal: "Ollama（本地）",
-      sourceRemote: "Remote API（远程）",
+      sourceLocal: "Ollama",
+      sourceRemote: "API",
       description: {
         chat: "配置用于对话的大语言模型",
         embedding: "配置用于文本向量化的嵌入模型",
@@ -4794,6 +4797,8 @@ export default {
     saveFailed: "保存凭据失败",
     removedToast: "凭据已移除",
     removeFailed: "移除凭据失败",
+    confirmRemovePrompt: "确认移除？此操作不可撤销",
+    confirmRemove: "确认移除",
     confirmRemoveTitle: "移除 {field}？",
     confirmRemoveBody:
       "此操作将永久删除已保存的凭据，依赖它的集成将停止工作，直到您重新配置。",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -751,6 +751,11 @@ export default {
     parser: {
       title: "解析引擎",
       description: "文档解析引擎状态及配置。此处设置优先于服务端环境变量，留空则使用环境变量默认值。",
+      // Section / label keys for the redesigned drawer
+      supportedFileTypes: "支持文件类型",
+      statusSection: "状态信息",
+      configSection: "配置",
+      featuresLabel: "识别选项",
       loading: "加载中...",
       retry: "重试",
       noEngineDetected: "未检测到解析引擎，请确认 DocReader 服务正常运行。",
@@ -788,6 +793,12 @@ export default {
     storage: {
       title: "存储引擎",
       description: "配置文档与图片的存储方式。此处设置各引擎参数，知识库中仅选择使用哪个引擎。",
+      // Section / label keys for the redesigned drawer
+      basicSection: "基本配置",
+      modeSection: "部署模式",
+      credentialsSection: "凭证",
+      bucketSection: "Bucket",
+      useSslDesc: "通过 HTTPS 访问 MinIO",
       loading: "加载中...",
       retry: "重试",
       defaultEngine: "默认引擎",
@@ -867,6 +878,10 @@ export default {
     title: "网络搜索配置",
     description:
       "配置网络搜索功能，在回答问题时可以从互联网获取实时信息补充知识库内容",
+    // Section keys for the redesigned drawer
+    basicSection: "基本信息",
+    credentialsSection: "连接配置",
+    optionsSection: "选项",
     // Provider entity management
     providersTitle: "搜索引擎配置",
     addProvider: "添加搜索引擎",
@@ -935,6 +950,8 @@ export default {
   vectorStoreSettings: {
     title: "向量数据库引擎",
     description: "注册和管理用于知识库搜索的向量数据库实例。",
+    // Section key for the redesigned drawer
+    basicSection: "基本信息",
     storesTitle: "向量数据库",
     addStore: "添加数据库",
     editStore: "编辑数据库",
@@ -3491,6 +3508,9 @@ export default {
     title: "MCP 服务管理",
     description:
       "管理外部 MCP (Model Context Protocol) 服务，在 Agent 模式下调用外部工具和资源",
+    // Drawer subtitle chip
+    enabled: "已启用",
+    disabled: "已禁用",
     configuredServices: "已配置的服务",
     manageAndTest: "管理和测试 MCP 服务连接",
     addService: "添加服务",
@@ -3533,6 +3553,7 @@ export default {
     source: {
       remote: "Remote",
       openaiCompatible: "OpenAI兼容",
+      custom: "自定义",
     },
     rawModelName: "模型名称",
     chat: {
@@ -3639,6 +3660,13 @@ export default {
   mcpServiceDialog: {
     addTitle: "添加 MCP 服务",
     editTitle: "编辑 MCP 服务",
+    // Section + drawer-only keys
+    basicSection: "基本信息",
+    connectionSection: "连接配置",
+    enableServiceDesc: "关闭后该服务不会被调用",
+    testAfterSaveHint: "保存后可测试连接",
+    unitSecond: "秒",
+    unitTimes: "次",
     name: "服务名称",
     namePlaceholder: "请输入服务名称",
     description: "描述",
@@ -4169,6 +4197,10 @@ export default {
         weknoracloud: {
           name: "WeKnora Cloud",
           desc: "使用 WeKnora Cloud 进行文档解析",
+        },
+        markitdown: {
+          name: "MarkItDown",
+          desc: "Microsoft MarkItDown 文档转换工具（支持 PDF/Office/HTML 等）",
         },
       },
     },

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -201,7 +201,8 @@
             <t-input
               v-model="formData.email"
               :placeholder="$t('auth.emailPlaceholder')"
-              type="email"
+              type="text"
+              autocomplete="email"
               size="large"
               :disabled="loading"
             />
@@ -214,7 +215,7 @@
               type="password"
               size="large"
               :disabled="loading"
-              @keydown.enter="handleLogin"
+              @enter="handleLogin"
             />
           </t-form-item>
 
@@ -321,7 +322,8 @@
             <t-input
               v-model="registerData.email"
               :placeholder="$t('auth.emailPlaceholder')"
-              type="email"
+              type="text"
+              autocomplete="email"
               size="large"
               :disabled="loading"
             />
@@ -344,7 +346,7 @@
               type="password"
               size="large"
               :disabled="loading"
-              @keydown.enter="handleRegister"
+              @enter="handleRegister"
             />
           </t-form-item>
 

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -2211,7 +2211,8 @@ async function createNewSession(value: string): Promise<void> {
                     <div class="tag-edit-input">
                       <t-input ref="newTagInputRef" v-model="newTagName" size="small" :maxlength="40"
                         :placeholder="$t('knowledgeBase.tagNamePlaceholder')"
-                        @keydown.enter.stop.prevent="submitCreateTag" @keydown.esc.stop.prevent="cancelCreateTag" />
+                        @enter="submitCreateTag"
+                        @keydown="(_v, ctx) => { if (ctx?.e?.key === 'Escape') { ctx.e.stopPropagation(); ctx.e.preventDefault(); cancelCreateTag() } }" />
                     </div>
                   </div>
                   <div class="tag-inline-actions">
@@ -2235,8 +2236,8 @@ async function createNewSession(value: string): Promise<void> {
                       <template v-if="editingTagId === tag.id">
                         <div class="tag-edit-input" @click.stop>
                           <t-input :ref="setEditingTagInputRefByTag(tag.id)" v-model="editingTagName" size="small"
-                            :maxlength="40" @keydown.enter.stop.prevent="submitEditTag"
-                            @keydown.esc.stop.prevent="cancelEditTag" />
+                            :maxlength="40" @enter="submitEditTag"
+                            @keydown="(_v, ctx) => { if (ctx?.e?.key === 'Escape') { ctx.e.stopPropagation(); ctx.e.preventDefault(); cancelEditTag() } }" />
                         </div>
                       </template>
                       <template v-else>
@@ -2298,7 +2299,7 @@ async function createNewSession(value: string): Promise<void> {
               <div class="doc-filter-bar">
                 <t-input v-model.trim="docSearchKeyword" :placeholder="$t('knowledgeBase.docSearchPlaceholder')"
                   clearable class="doc-search-input" @clear="loadKnowledgeFiles(kbId)"
-                  @keydown.enter="loadKnowledgeFiles(kbId)">
+                  @enter="loadKnowledgeFiles(kbId)">
                   <template #prefix-icon>
                     <t-icon name="search" size="16px" />
                   </template>
@@ -2715,7 +2716,7 @@ async function createNewSession(value: string): Promise<void> {
               <div class="url-import-form">
                 <div class="url-input-label">{{ $t('knowledgeBase.urlLabel') }}</div>
                 <t-input v-model="urlInputValue" :placeholder="$t('knowledgeBase.urlPlaceholder')" clearable autofocus
-                  @keydown.enter="handleURLImportConfirm" />
+                  @enter="handleURLImportConfirm" />
                 <div class="url-input-tip">{{ $t('knowledgeBase.urlTip') }}</div>
               </div>
             </t-dialog>

--- a/frontend/src/views/knowledge/components/FAQEntryManager.vue
+++ b/frontend/src/views/knowledge/components/FAQEntryManager.vue
@@ -184,7 +184,8 @@
                   <div class="tag-edit-input">
                     <t-input ref="newTagInputRef" v-model="newTagName" size="small" :maxlength="40"
                       :placeholder="$t('knowledgeBase.tagNamePlaceholder')"
-                      @keydown.enter.stop.prevent="submitCreateTag" @keydown.esc.stop.prevent="cancelCreateTag" />
+                      @enter="submitCreateTag"
+                      @keydown="(_v, ctx) => { if (ctx?.e?.key === 'Escape') { ctx.e.stopPropagation(); ctx.e.preventDefault(); cancelCreateTag() } }" />
                   </div>
                 </div>
                 <div class="tag-inline-actions">
@@ -208,8 +209,8 @@
                     <template v-if="editingTagId === tag.id">
                       <div class="tag-edit-input" @click.stop>
                         <t-input :ref="setEditingTagInputRefByTag(tag.id)" v-model="editingTagName" size="small"
-                          :maxlength="40" @keydown.enter.stop.prevent="submitEditTag"
-                          @keydown.esc.stop.prevent="cancelEditTag" />
+                          :maxlength="40" @enter="submitEditTag"
+                          @keydown="(_v, ctx) => { if (ctx?.e?.key === 'Escape') { ctx.e.stopPropagation(); ctx.e.preventDefault(); cancelEditTag() } }" />
                       </div>
                     </template>
                     <template v-else>
@@ -268,7 +269,7 @@
           <!-- 搜索栏与管理 FAQ -->
           <div class="faq-search-bar">
             <t-input v-model.trim="entrySearchKeyword" :placeholder="$t('knowledgeEditor.faq.searchPlaceholder')"
-              clearable class="faq-search-input" @clear="loadEntries()" @keydown.enter="loadEntries()">
+              clearable class="faq-search-input" @clear="loadEntries()" @enter="loadEntries()">
               <template #prefix-icon>
                 <t-icon name="search" size="16px" />
               </template>
@@ -529,7 +530,7 @@
               <div class="setting-control">
                 <div class="full-width-input-wrapper">
                   <t-input v-model="similarInput" :placeholder="$t('knowledgeEditor.faq.similarPlaceholder')"
-                    @keydown.enter.prevent="addSimilar" class="full-width-input" />
+                    @enter="addSimilar" class="full-width-input" />
                   <t-button theme="primary" variant="outline"
                     :disabled="!similarInput.trim() || editorForm.similar_questions.length >= 10" @click="addSimilar"
                     class="add-item-btn" size="small">
@@ -557,7 +558,7 @@
               <div class="setting-control">
                 <div class="full-width-input-wrapper">
                   <t-input v-model="negativeInput" :placeholder="$t('knowledgeEditor.faq.negativePlaceholder')"
-                    @keydown.enter.prevent="addNegative" class="full-width-input" />
+                    @enter="addNegative" class="full-width-input" />
                   <t-button theme="primary" variant="outline"
                     :disabled="!negativeInput.trim() || editorForm.negative_questions.length >= 10" @click="addNegative"
                     class="add-item-btn" size="small">
@@ -806,7 +807,7 @@
               </div>
               <div class="setting-control">
                 <t-input v-model="searchForm.query" :placeholder="$t('knowledgeEditor.faq.queryPlaceholder')"
-                  @keydown.enter.prevent="handleSearch" class="full-width-input" />
+                  @enter="handleSearch" class="full-width-input" />
               </div>
             </div>
 

--- a/frontend/src/views/settings/McpSettings.vue
+++ b/frontend/src/views/settings/McpSettings.vue
@@ -99,6 +99,7 @@
       :service="currentService"
       :mode="dialogMode"
       @success="handleDialogSuccess"
+      @test="handleDrawerTest"
     />
 
     <!-- Test Result Dialog -->
@@ -119,7 +120,6 @@ import {
   listMCPServices,
   updateMCPService,
   deleteMCPService,
-  testMCPService,
   type MCPService,
   type MCPTestResult
 } from '@/api/mcp-service'
@@ -141,7 +141,6 @@ const testDialogVisible = ref(false)
 const testResult = ref<MCPTestResult | null>(null)
 const testingServiceName = ref('')
 const testingServiceId = ref('')
-const testing = ref(false)
 
 // Load MCP services
 const loadServices = async () => {
@@ -191,52 +190,6 @@ const handleToggleEnabled = async (service: MCPService) => {
   }
 }
 
-// Handle test button click
-const handleTest = async (service: MCPService) => {
-  if (!service || !service.id) return
-
-  testingServiceName.value = service.name
-  testingServiceId.value = service.id
-  testing.value = true
-
-  MessagePlugin.info({
-    content: t('mcpSettings.toasts.testing', { name: service.name }),
-    duration: 0,
-    closeBtn: false
-  })
-
-  try {
-    const result = await testMCPService(service.id)
-
-    MessagePlugin.closeAll()
-
-    if (!result) {
-      testResult.value = {
-        success: false,
-        message: t('mcpSettings.toasts.noResponse')
-      }
-      testDialogVisible.value = true
-      return
-    }
-
-    testResult.value = result
-    testDialogVisible.value = true
-  } catch (error: any) {
-    MessagePlugin.closeAll()
-
-    const errorMessage = error?.response?.data?.error?.message || error?.message || t('mcpSettings.toasts.testFailed')
-    console.error('Failed to test MCP service:', error)
-
-    testResult.value = {
-      success: false,
-      message: errorMessage
-    }
-    testDialogVisible.value = true
-  } finally {
-    testing.value = false
-  }
-}
-
 // Handle delete button click
 const handleDelete = (service: MCPService) => {
   if (!service || !service.id) return
@@ -256,9 +209,10 @@ const handleDelete = (service: MCPService) => {
   })
 }
 
-// Get service options for dropdown menu. MCP service mutations and the
-// /test endpoint (which probes external infra with stored creds) are all
+// Get service options for dropdown menu. MCP service mutations are all
 // Admin+ in the backend matrix, so non-Admins see an empty action menu.
+// 测试连接已挪到编辑抽屉的 footer，不再放在外层菜单里 — 单一入口减少
+// 用户疑惑（"为什么有两个测试入口，结果一样吗？"）。
 const getServiceOptions = (service: MCPService) => {
   if (!authStore.hasRole('admin')) {
     return []
@@ -268,35 +222,41 @@ const getServiceOptions = (service: MCPService) => {
       content: service.enabled ? t('common.off') : t('common.on'),
       value: 'toggle',
     },
-    { content: t('mcpSettings.actions.test'), value: 'test' },
     { content: t('common.edit'), value: 'edit' },
     { content: t('common.delete'), value: 'delete', theme: 'error' as const }
   ]
 }
 
-// Builtin: 仅测试 (Admin+ only as well — testing a builtin still hits
-// the same /test endpoint that requires Admin+ role).
+// Builtin: 仅编辑（同样 Admin+ only）。内置服务测试也通过抽屉的 footer 触发，
+// 不再在外层菜单露出"测试连接"项。
 const getBuiltinServiceOptions = () => {
   if (!authStore.hasRole('admin')) {
     return []
   }
   return [
-    { content: t('mcpSettings.actions.test'), value: 'test' }
+    { content: t('common.edit'), value: 'edit' }
   ]
 }
 
-// Handle menu action
+// Drawer 内点击"测试连接"后，复用现有的 testResult dialog 展示结果。
+// 抽屉只负责调 API + 拿结果，弹窗位置/状态由父组件统一管。
+const handleDrawerTest = ({ service, result }: { service: MCPService; result: MCPTestResult }) => {
+  testingServiceName.value = service.name
+  testingServiceId.value = service.id
+  testResult.value = result
+  testDialogVisible.value = true
+}
+
+// Handle menu action. 'test' has been removed from the menu — testing now
+// lives only in the editor drawer. We keep the switch's case list narrow
+// so a stray 'test' from somewhere else falls through harmlessly.
 const handleMenuAction = (data: { value: string }, service: MCPService) => {
-  if (testing.value) return
   switch (data.value) {
     case 'toggle':
       // Flip the local model and reuse the toggle path so the API call,
       // optimistic UI, and rollback-on-failure all stay in one place.
       service.enabled = !service.enabled
       handleToggleEnabled(service)
-      break
-    case 'test':
-      handleTest(service)
       break
     case 'edit':
       handleEdit(service)

--- a/frontend/src/views/settings/ModelSettings.vue
+++ b/frontend/src/views/settings/ModelSettings.vue
@@ -42,9 +42,9 @@
 
     <div v-if="filteredModels.length > 0" class="model-grid">
       <!--
-        Model card (this page only). 我们刻意不复用 SettingCard：
-        模型卡需要左侧类型徽章 + 多级元信息，而 SettingCard 还在 Mcp /
-        WebSearch 页用，加 prefix 槽给单一消费者属于过度抽象。
+        Model card. 我们刻意不复用 SettingCard：模型卡需要左侧类型徽章 + 多
+        级元信息（chip 行 + monospace 原名 + baseUrl），SettingCard 还在
+        Mcp / WebSearch 页用，加 prefix 槽属于过度抽象。
       -->
       <div
         v-for="model in filteredModels"
@@ -56,10 +56,22 @@
           <t-icon :name="typeIcon(model._modelType)" size="18px" />
         </div>
         <div class="model-card__body">
+          <!--
+            Title row. Display name primary; on hover the lock (builtin) and
+            ellipsis menu fade in from the right. The lock badge is muted by
+            default since most cards in a typical install ARE built-in —
+            making it loud everywhere just produces visual noise. User-added
+            cards stand out by NOT having a lock.
+          -->
           <div class="model-card__header">
-            <h3 class="model-card__title" :title="model.name">{{ modelDisplayName(model) }}</h3>
-            <span v-if="model.isBuiltin" class="model-card__pill">
-              {{ $t('modelSettings.builtinTag') }}
+            <h3 class="model-card__title" :title="modelDisplayName(model)">{{ modelDisplayName(model) }}</h3>
+            <span
+              v-if="model.isBuiltin"
+              class="model-card__lock"
+              :title="$t('modelSettings.builtinTag')"
+              :aria-label="$t('modelSettings.builtinTag')"
+            >
+              <t-icon name="lock-on" />
             </span>
             <t-dropdown
               v-if="getModelOptions(model._modelType, model).length > 0"
@@ -74,25 +86,55 @@
               </t-button>
             </t-dropdown>
           </div>
-          <div class="model-card__subtitle">
-            <span class="model-card__type">{{ typeLabel(model._modelType) }}</span>
-            <span class="model-card__sep">·</span>
-            <span class="model-card__source">
-              {{ model.source === 'local' ? 'Ollama' : sourceLabel(model._modelType) }}
+
+          <!--
+            Compact identity row. Only rendered when there's actually
+            something to show — most built-in models have no displayName
+            AND no baseUrl, so an "always render" approach left them with
+            either a blank line or a noisy pseudo-URL. CSS grid's default
+            row stretching keeps cards in the same row aligned, so we
+            don't need to fake content for visual symmetry.
+
+            When both raw name and URL are present we show ONLY the URL
+            here, because cramming both into one ellipsizing line — as
+            seen in the screenshot — produced "deepseek-… · https://…tencen…"
+            with both ends truncated and neither readable. The raw name
+            is already accessible via the title attribute on the card.
+          -->
+          <div
+            v-if="identityVisible(model)"
+            class="model-card__identity"
+            :title="identityTooltip(model)"
+          >
+            <!-- Show URL by preference (it's the more diagnostic of the
+                 two for "is this model wired up correctly"); fall back to
+                 the raw name when there's no URL (display-name-only case). -->
+            <span class="model-card__identity-text">{{ identityText(model) }}</span>
+          </div>
+
+          <!--
+            Meta chips, single row. We deliberately keep this line to a
+            FIXED set of facts so every card renders to the same height,
+            no matter what optional fields are filled out. Order: type →
+            vendor → optional dim → optional vision flag. Type chip is
+            text-only (the 36×36 badge on the left already shows the icon).
+          -->
+          <div class="model-card__meta">
+            <span class="model-card__chip model-card__chip--type">
+              {{ typeLabel(model._modelType) }}
             </span>
-            <template v-if="model._modelType === 'embedding' && model.dimension">
-              <span class="model-card__sep">·</span>
-              <span>{{ $t('model.editor.dimensionLabel') }} {{ model.dimension }}</span>
-            </template>
-          </div>
-          <div v-if="model.displayName" class="model-card__raw-name" :title="model.name">
-            {{ $t('modelSettings.rawModelName') }}: {{ model.name }}
-          </div>
-          <div v-if="model.baseUrl" class="model-card__url" :title="model.baseUrl">
-            {{ model.baseUrl }}
-          </div>
-          <div v-else-if="model.source === 'local'" class="model-card__url model-card__url--muted">
-            Ollama local
+            <span class="model-card__chip">
+              {{ vendorLabel(model) }}
+            </span>
+            <span v-if="model._modelType === 'embedding' && model.dimension" class="model-card__chip">
+              {{ model.dimension }} dim
+            </span>
+            <span v-if="model._modelType === 'chat' && model.supportsVision"
+              class="model-card__chip model-card__chip--icon-only"
+              :title="$t('model.editor.supportsVisionLabel')"
+              :aria-label="$t('model.editor.supportsVisionLabel')">
+              <t-icon name="image" />
+            </span>
           </div>
         </div>
       </div>
@@ -130,7 +172,7 @@ import { useConfirmDelete } from '@/components/settings/useConfirmDelete'
 import { listModels, createModel, updateModel as updateModelAPI, deleteModel as deleteModelAPI, type ModelConfig } from '@/api/model'
 import { useAuthStore } from '@/stores/auth'
 
-const { t } = useI18n()
+const { t, te } = useI18n()
 const authStore = useAuthStore()
 const confirmDelete = useConfirmDelete()
 
@@ -230,6 +272,88 @@ const sourceLabel = (type: ModelType) => {
     return t('modelSettings.source.openaiCompatible')
   }
   return t('modelSettings.source.remote')
+}
+
+// Maps a backend `provider` id (e.g. "openai", "aliyun", "weknoracloud")
+// to its localized short label. Reuses the same i18n keys the editor's
+// provider dropdown uses, so the model card and the editor stay in sync
+// when a provider is renamed. Falls back to '' when the backend didn't
+// store a provider — caller falls back to sourceLabel().
+const providerLabel = (model: any): string => {
+  const id = model.provider
+  if (!id) return ''
+  const key = `model.editor.providers.${id}.label`
+  return te(key) ? t(key) : id
+}
+
+// What the vendor chip on a card shows. Keeps the chip text uniformly
+// short so cards line up:
+//   local  → "Ollama"
+//   remote → provider's localized short name (e.g. "腾讯云 LKEAP",
+//            "阿里云 DashScope"). For the catch-all "generic" provider
+//            we render a single short word ("自定义" / "Custom") — the
+//            editor dropdown's longer "自定义 (OpenAI兼容接口)" label
+//            blows out the card chip row, and the "OpenAI 兼容" framing
+//            isn't meaningful to most end users (they didn't pick "I
+//            want OpenAI compatibility", they just pasted a base URL).
+const vendorLabel = (model: any): string => {
+  if (model.source === 'local') return 'Ollama'
+  if (model.provider === 'generic') {
+    return t('modelSettings.source.custom')
+  }
+  return providerLabel(model) || sourceLabel(model._modelType)
+}
+
+// Hover tooltip for the whole card — shows the long-form details we
+// removed from the visible card body so they're still one mouseover
+// away. baseUrl is the most useful for debugging "why is this model
+// failing" scenarios.
+const cardTooltip = (model: any): string => {
+  const lines: string[] = []
+  if (model.displayName && model.displayName !== model.name) {
+    lines.push(`${t('modelSettings.rawModelName')}: ${model.name}`)
+  }
+  if (model.baseUrl) {
+    lines.push(model.baseUrl)
+  } else if (model.source === 'local') {
+    lines.push('Ollama (localhost)')
+  }
+  return lines.join('\n')
+}
+
+// Whether the raw model identifier is worth showing on the card. We hide
+// it when the user did NOT set a display name, because then the title is
+// already the raw name and printing it again is just noise.
+const rawNameVisible = (model: any): boolean => {
+  const displayName = typeof model.displayName === 'string' ? model.displayName.trim() : ''
+  return Boolean(displayName) && displayName !== model.name
+}
+
+// What goes in the URL slot of the identity row. Local models intentionally
+// return '' here — "ollama://localhost" is just noise on Ollama-only built-in
+// cards. Only remote models with an explicit base URL get this row.
+const urlText = (model: any): string => {
+  return model.baseUrl || ''
+}
+
+// Single-line text shown in the identity row. Picks the more useful of
+// the two (URL > raw name) — never crams both into one ellipsizing line
+// because that produces double-end truncation that nobody can read.
+const identityText = (model: any): string => {
+  return urlText(model) || (rawNameVisible(model) ? model.name : '')
+}
+
+// Whether the identity row should render at all.
+const identityVisible = (model: any): boolean => identityText(model).length > 0
+
+// Identity-row tooltip — exposes BOTH name and URL when the user hovers,
+// so the diagnostic info we hid from the visible row is still one mouse
+// move away.
+const identityTooltip = (model: any): string => {
+  const parts: string[] = []
+  if (rawNameVisible(model)) parts.push(model.name)
+  if (urlText(model)) parts.push(urlText(model))
+  return parts.join('\n')
 }
 
 const modelDisplayName = (model: any) => {
@@ -612,12 +736,13 @@ onMounted(() => {
   gap: 12px;
 }
 
-// 模型卡片 —— 左侧类型徽章 + 标题 / 副标题 / baseUrl 三段式
+// 模型卡片 —— 左侧类型徽章 + 标题 / identity / 元 chip 行（固定三行）
 .model-card {
+  position: relative;
   display: flex;
   align-items: flex-start;
   gap: 12px;
-  padding: 14px 14px 14px 12px;
+  padding: 12px 14px;
   border: 1px solid var(--td-component-stroke);
   border-radius: 10px;
   background: var(--td-bg-color-container);
@@ -631,10 +756,6 @@ onMounted(() => {
 
   &--builtin {
     background: var(--td-bg-color-secondarycontainer);
-
-    .model-card__title {
-      color: var(--td-text-color-secondary);
-    }
 
     &:hover {
       box-shadow: none;
@@ -688,6 +809,7 @@ onMounted(() => {
   min-width: 0;
   display: flex;
   flex-direction: column;
+  justify-content: center;
   gap: 4px;
 }
 
@@ -711,15 +833,105 @@ onMounted(() => {
   white-space: nowrap;
 }
 
-.model-card__pill {
+/*
+  Generic chip used for: built-in tag, type chip, source chip, dimension,
+  vision flag. Same shape across all so the row reads as one consistent
+  rhythm of pills. Variants tweak color only.
+*/
+.model-card__chip {
   flex-shrink: 0;
-  padding: 1px 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 7px 1px 6px;
+  height: 20px;
   font-size: 11px;
   font-weight: 500;
-  line-height: 16px;
-  color: var(--td-warning-color-7, #B85C00);
-  background: var(--td-warning-color-1, #FEF3E6);
-  border-radius: 3px;
+  line-height: 18px;
+  color: var(--td-text-color-secondary);
+  background: var(--td-bg-color-component);
+  border-radius: 4px;
+  white-space: nowrap;
+
+  .t-icon {
+    font-size: 12px;
+    flex-shrink: 0;
+  }
+}
+
+/*
+  Built-in lock indicator. Most cards in a typical install ARE built-in,
+  so loud styling everywhere becomes noise — instead the lock is muted
+  and small by default, and lights up on hover. The signal that matters
+  to users is "which models did I add" → user-added cards stand out by
+  the absence of the lock.
+*/
+.model-card__lock {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  color: var(--td-text-color-placeholder);
+  opacity: 0.6;
+  transition: color 0.15s ease, opacity 0.15s ease;
+
+  .t-icon {
+    font-size: 13px;
+  }
+}
+
+.model-card:hover .model-card__lock {
+  opacity: 1;
+  color: var(--td-text-color-secondary);
+}
+
+/*
+  Icon-only chip variant. Drops horizontal padding to a tight square so the
+  chip reads as a status badge (vision flag) rather than a text pill that
+  happens to start with an icon.
+*/
+.model-card__chip--icon-only {
+  padding: 0;
+  width: 20px;
+  justify-content: center;
+
+  .t-icon {
+    font-size: 12px;
+  }
+}
+
+/* Type chip in the meta row — slightly emphasized, picks up the type's
+   accent color so it links to the left badge. */
+.model-card__chip--type {
+  color: var(--td-text-color-primary);
+  font-weight: 500;
+}
+
+.model-card--chat .model-card__chip--type {
+  color: #0052D9;
+  background: rgba(0, 82, 217, 0.08);
+}
+
+.model-card--embedding .model-card__chip--type {
+  color: #6235BB;
+  background: rgba(98, 53, 187, 0.08);
+}
+
+.model-card--rerank .model-card__chip--type {
+  color: #B85C00;
+  background: rgba(184, 92, 0, 0.08);
+}
+
+.model-card--vllm .model-card__chip--type {
+  color: #C93E3E;
+  background: rgba(201, 62, 62, 0.08);
+}
+
+.model-card--asr .model-card__chip--type {
+  color: #118053;
+  background: rgba(17, 128, 83, 0.08);
 }
 
 .model-card__more {
@@ -742,50 +954,40 @@ onMounted(() => {
   opacity: 1;
 }
 
-.model-card__subtitle {
+.model-card__meta {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 4px;
-  font-size: 12px;
-  line-height: 1.4;
-  color: var(--td-text-color-secondary);
   min-width: 0;
-}
-
-.model-card__raw-name {
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 12px;
-  line-height: 1.4;
-  color: var(--td-text-color-placeholder);
+  // Truncate at the row level rather than within each chip — chips clip
+  // off-screen if the card narrows below the chip set's natural width
+  // (rare at 320px+ minmax but possible if grid recomputes).
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-.model-card__type {
-  font-weight: 500;
-  color: var(--td-text-color-secondary);
-}
-
-.model-card__sep {
-  color: var(--td-text-color-placeholder);
-}
-
-.model-card__url {
+/*
+  Compact identity row: monospace one-liner showing whichever of
+  baseUrl / raw name is more useful (URL preferred). Conditionally
+  rendered — empty cards (most built-in ones) skip this row entirely
+  and grid auto-sizing handles the height.
+*/
+.model-card__identity {
+  display: flex;
+  align-items: center;
+  min-width: 0;
   font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
   font-size: 11px;
   line-height: 1.4;
   color: var(--td-text-color-placeholder);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
 }
 
-.model-card__url--muted {
-  font-family: inherit;
-  font-style: italic;
+.model-card__identity-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .empty-state {

--- a/frontend/src/views/settings/ParserEngineSettings.vue
+++ b/frontend/src/views/settings/ParserEngineSettings.vue
@@ -92,81 +92,140 @@
       </div>
     </template>
 
-    <!-- 配置抽屉 -->
-    <t-drawer
+    <!-- 配置抽屉 — 用 SettingDrawer 包装，保持与 ModelEditorDialog 同款视觉/交互 -->
+    <SettingDrawer
       v-model:visible="drawerVisible"
-      :header="drawerTitle"
-      size="500px"
+      :title="drawerTitle"
+      :class="currentEngine ? `parser-engine-drawer parser-engine-drawer--${currentEngine.Name}` : 'parser-engine-drawer'"
+      :hide-footer="!authStore.hasRole('admin') && !needsTestButton"
+      :confirm-loading="saving"
+      @confirm="onSave"
+      @cancel="drawerVisible = false"
     >
-      <div v-if="currentEngine" class="drawer-content">
-        <div class="engine-info-block">
-          <p class="engine-desc">{{ getEngineDisplayDesc(currentEngine.Name, currentEngine.Description) }}
-          <a
-            v-if="engineDocLink(currentEngine.Name)"
-            :href="engineDocLink(currentEngine.Name)"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="doc-link"
-          >
-            {{ engineDocLabel(currentEngine.Name) }}
-            <t-icon name="link" class="link-icon" />
-          </a>
-          </p>
-        </div>
+      <!--
+        Header icon — 与列表卡片同款 monogram 徽章：首字母 + per-engine 配色，
+        通过 .parser-engine-drawer--{name} .setting-drawer__header-icon 在
+        非 scoped 块里覆盖背景与文字色。Parser 引擎没有真实 logo，所以这
+        里只渲染字母；存储引擎那边走的是 logo 图片/mask，pattern 一致。
+      -->
+      <template v-if="currentEngine" #headerIcon>
+        <span class="header-icon__text">{{ engineInitial(currentEngine.Name) }}</span>
+      </template>
+      <!--
+        Subtitle slot: 引擎描述 + 内联文档链接。我们把"参考资料"从一个
+        独立 section 收回到头部副标题里 — 一个外链不值得占一整个 section。
+      -->
+      <template v-if="currentEngine" #subtitle>
+        <span>{{ getEngineDisplayDesc(currentEngine.Name, currentEngine.Description) }}</span>
+        <a
+          v-if="engineDocLink(currentEngine.Name)"
+          :href="engineDocLink(currentEngine.Name)"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="doc-link doc-link--inline"
+        >
+          {{ engineDocLabel(currentEngine.Name) }}
+          <t-icon name="link" class="link-icon" />
+        </a>
+      </template>
+      <!--
+        Footer-left slot: 测试连接按钮 + 状态文案 — 主操作栏沿底边对齐，
+        与 ModelEditorDialog 远程模型抽屉保持一致。仅在引擎有可校验的
+        配置/状态时才挂载。
+      -->
+      <template v-if="needsTestButton" #footer-left>
+        <t-button variant="outline" :loading="checking" @click="onCheck">
+          <template #icon>
+            <t-icon v-if="!checking && saveSuccess && checkMessage" name="check-circle-filled"
+              class="status-icon available" />
+            <t-icon v-else-if="!checking && checkMessage && !saveSuccess" name="close-circle-filled"
+              class="status-icon unavailable" />
+          </template>
+          {{ checking ? $t('settings.parser.checking', $t('settings.parser.testConnection')) : $t('settings.parser.testConnection') }}
+        </t-button>
+        <span v-if="checkMessage" :class="['footer-test-message', saveSuccess ? 'success' : 'error']" :title="checkMessage">
+          {{ checkMessage }}
+        </span>
+      </template>
 
-        <!-- builtin: DocReader 连接信息 -->
-        <div v-if="currentEngine.Name === 'builtin'" class="docreader-inline">
-          <div class="status-line">
-            <t-tag v-if="connected" theme="success" variant="light" size="small">{{ $t('settings.parser.connected') }}</t-tag>
-            <t-tag v-else theme="danger" variant="light" size="small">{{ $t('settings.parser.disconnected') }}</t-tag>
-            <t-tag theme="default" variant="light" size="small">{{ docreaderTransport === 'http' ? 'HTTP' : 'gRPC' }}</t-tag>
-            <span v-if="docreaderAddrEnv" class="env-hint">{{ $t('settings.parser.currentAddr') }}: {{ docreaderAddrEnv }}</span>
+      <div v-if="currentEngine">
+        <!--
+          Section 1 — 支持文件类型。放在内容开头作为引擎"能干什么"的
+          一目了然概览，对所有引擎都有意义；与状态/配置区分开。
+        -->
+        <section
+          v-if="currentEngine.FileTypes && currentEngine.FileTypes.length"
+          class="setting-drawer__section"
+        >
+          <h4 class="setting-drawer__section-title">{{ $t('settings.parser.supportedFileTypes', '支持文件类型') }}</h4>
+          <div class="file-types">
+            <span v-for="ft in currentEngine.FileTypes" :key="ft" class="file-type-chip">
+              {{ ft }}
+            </span>
           </div>
-          <p class="docreader-desc">
-            {{ $t('settings.parser.envVarHint') }}
-          </p>
-        </div>
+        </section>
 
-        <!-- weknoracloud: 凭证状态 -->
-        <template v-if="currentEngine.Name === 'weknoracloud'">
-          <div v-if="wkcState === 'configured'" class="wkc-status wkc-status--ok">
-            <t-icon name="check-circle" style="font-size: 15px; color: var(--td-success-color); flex-shrink: 0;" />
-            <span>{{ $t('settings.weknoraCloud.credentialConfigured') }}</span>
-          </div>
-          <div v-else-if="wkcState === 'loading'" class="wkc-status">
-            <t-loading size="small" />
-            <span>{{ $t('settings.weknoraCloud.checkingStatus') }}</span>
-          </div>
-          <div v-else class="wkc-status wkc-status--warn">
-            <t-icon name="error-circle" style="font-size: 15px; color: #f97316; flex-shrink: 0;" />
-            <div style="flex: 1;">
-              <span v-if="wkcState === 'expired'">{{ $t('settings.weknoraCloud.credentialExpired') }}</span>
-              <span v-else>{{ $t('settings.weknoraCloud.unconfigured') }}</span>
-              <div style="margin-top: 6px;">
-                <t-button
-                  variant="text"
-                  size="small"
-                  theme="primary"
-                  @click="goToWkcSettings"
-                  style="padding: 0; height: auto;"
-                >{{ $t('settings.weknoraCloud.goToSettings') }}</t-button>
-              </div>
+        <!--
+          Section 2 — 状态信息（DocReader 连接 / WeKnoraCloud 凭证）
+          只有有内容时才渲染，避免空 section 空底部分隔线。
+        -->
+        <section
+          v-if="currentEngine.Name === 'builtin' || currentEngine.Name === 'weknoracloud'"
+          class="setting-drawer__section"
+        >
+          <h4 class="setting-drawer__section-title">{{ $t('settings.parser.statusSection', '状态信息') }}</h4>
+
+          <!-- builtin: DocReader 连接信息 -->
+          <div v-if="currentEngine.Name === 'builtin'" class="docreader-block">
+            <div class="status-line">
+              <t-tag v-if="connected" theme="success" variant="light" size="small">
+                {{ $t('settings.parser.connected') }}
+              </t-tag>
+              <t-tag v-else theme="danger" variant="light" size="small">
+                {{ $t('settings.parser.disconnected') }}
+              </t-tag>
+              <t-tag theme="default" variant="light" size="small">
+                {{ docreaderTransport === 'http' ? 'HTTP' : 'gRPC' }}
+              </t-tag>
+              <span v-if="docreaderAddrEnv" class="env-hint">
+                {{ $t('settings.parser.currentAddr') }}: {{ docreaderAddrEnv }}
+              </span>
             </div>
+            <p class="form-desc">{{ $t('settings.parser.envVarHint') }}</p>
           </div>
-        </template>
 
-        <div v-if="currentEngine.FileTypes && currentEngine.FileTypes.length" class="file-types">
-          <t-tag
-            v-for="ft in currentEngine.FileTypes"
-            :key="ft"
-            size="small"
-            variant="light"
-            theme="default"
-          >{{ ft }}</t-tag>
-        </div>
+          <!--
+            weknoracloud: 凭证状态 — 不再用大块卡片。已配置 / 加载中 / 未配置
+            统一用 inline alert：图标 + 一行文案 + 行尾跳转 link，体量
+            匹配"一条信息"该有的样子。
+          -->
+          <template v-if="currentEngine.Name === 'weknoracloud'">
+            <div v-if="wkcState === 'configured'" class="inline-alert inline-alert--ok">
+              <t-icon name="check-circle-filled" class="inline-alert__icon" />
+              <span>{{ $t('settings.weknoraCloud.credentialConfigured') }}</span>
+            </div>
+            <div v-else-if="wkcState === 'loading'" class="inline-alert">
+              <t-icon name="loading" class="inline-alert__icon spinning" />
+              <span>{{ $t('settings.weknoraCloud.checkingStatus') }}</span>
+            </div>
+            <div v-else class="inline-alert inline-alert--warn">
+              <t-icon name="error-circle-filled" class="inline-alert__icon" />
+              <span class="inline-alert__text">
+                <span v-if="wkcState === 'expired'">{{ $t('settings.weknoraCloud.credentialExpired') }}</span>
+                <span v-else>{{ $t('settings.weknoraCloud.unconfigured') }}</span>
+              </span>
+              <a class="inline-alert__action" @click="goToWkcSettings">
+                {{ $t('settings.weknoraCloud.goToSettings') }}
+                <t-icon name="chevron-right" />
+              </a>
+            </div>
+          </template>
+        </section>
 
-        <!-- mineru 自建配置 -->
-        <div v-if="currentEngine.Name === 'mineru'" class="engine-form">
+        <!-- Section 3 — mineru 自建配置 -->
+        <section v-if="currentEngine.Name === 'mineru'" class="setting-drawer__section">
+          <h4 class="setting-drawer__section-title">{{ $t('settings.parser.configSection', '配置') }}</h4>
+
           <div class="form-item">
             <label class="form-label">{{ t('settings.parser.selfHostedEndpoint') }}</label>
             <t-input
@@ -192,14 +251,17 @@
               :placeholder="$t('settings.parser.vlmServerUrlPlaceholder')"
               clearable
             />
-            <p class="form-hint">{{ $t('settings.parser.vlmServerUrlHint') }}</p>
+            <p class="form-desc">{{ $t('settings.parser.vlmServerUrlHint') }}</p>
           </div>
-          <div class="form-toggles">
-            <t-checkbox v-model="config.mineru_enable_formula">{{ $t('settings.parser.formulaRecognition') }}</t-checkbox>
-            <t-checkbox v-model="config.mineru_enable_table">{{ $t('settings.parser.tableRecognition') }}</t-checkbox>
-            <t-checkbox v-model="config.mineru_enable_ocr">OCR</t-checkbox>
+          <div class="form-item">
+            <label class="form-label">{{ $t('settings.parser.featuresLabel', '识别选项') }}</label>
+            <div class="form-toggles">
+              <t-checkbox v-model="config.mineru_enable_formula">{{ $t('settings.parser.formulaRecognition') }}</t-checkbox>
+              <t-checkbox v-model="config.mineru_enable_table">{{ $t('settings.parser.tableRecognition') }}</t-checkbox>
+              <t-checkbox v-model="config.mineru_enable_ocr">OCR</t-checkbox>
+            </div>
           </div>
-          <div class="form-item" style="margin-top: 16px;">
+          <div class="form-item">
             <label class="form-label">{{ t('settings.parser.language') }}</label>
             <t-input
               v-model="config.mineru_language"
@@ -207,18 +269,22 @@
               clearable
             />
           </div>
-        </div>
+        </section>
 
-        <!-- mineru_cloud 云 API 配置 -->
-        <div v-if="currentEngine.Name === 'mineru_cloud'" class="engine-form">
+        <!-- Section 3 — mineru_cloud 云 API 配置 -->
+        <section v-if="currentEngine.Name === 'mineru_cloud'" class="setting-drawer__section">
+          <h4 class="setting-drawer__section-title">{{ $t('settings.parser.configSection', '配置') }}</h4>
+
           <div class="form-item">
-            <label class="form-label">API Key</label>
+            <label class="form-label required">API Key</label>
             <t-input
               v-model="config.mineru_api_key"
               type="password"
               :placeholder="$t('settings.parser.mineruCloudApiKeyPlaceholder')"
               clearable
-            />
+            >
+              <template #prefix-icon><t-icon name="lock-on" /></template>
+            </t-input>
           </div>
           <div class="form-item">
             <label class="form-label">Model Version</label>
@@ -228,12 +294,15 @@
               <t-option value="MinerU-HTML" :label="$t('settings.parser.mineruHtmlLabel')" />
             </t-select>
           </div>
-          <div class="form-toggles">
-            <t-checkbox v-model="config.mineru_cloud_enable_formula">{{ $t('settings.parser.formulaRecognition') }}</t-checkbox>
-            <t-checkbox v-model="config.mineru_cloud_enable_table">{{ $t('settings.parser.tableRecognition') }}</t-checkbox>
-            <t-checkbox v-model="config.mineru_cloud_enable_ocr">OCR</t-checkbox>
+          <div class="form-item">
+            <label class="form-label">{{ $t('settings.parser.featuresLabel', '识别选项') }}</label>
+            <div class="form-toggles">
+              <t-checkbox v-model="config.mineru_cloud_enable_formula">{{ $t('settings.parser.formulaRecognition') }}</t-checkbox>
+              <t-checkbox v-model="config.mineru_cloud_enable_table">{{ $t('settings.parser.tableRecognition') }}</t-checkbox>
+              <t-checkbox v-model="config.mineru_cloud_enable_ocr">OCR</t-checkbox>
+            </div>
           </div>
-          <div class="form-item" style="margin-top: 16px;">
+          <div class="form-item">
             <label class="form-label">{{ t('settings.parser.language') }}</label>
             <t-input
               v-model="config.mineru_cloud_language"
@@ -241,27 +310,9 @@
               clearable
             />
           </div>
-        </div>
-        <div class="form-item" v-if="currentEngine && (hasConfigFields(currentEngine.Name) || currentEngine.Name === 'builtin')">
-          <label class="form-label">{{ $t('settings.parser.testConnection', '测试连接') }}</label>
-          <div class="api-test-section">
-            <t-button variant="outline" :loading="checking" @click="onCheck">
-              {{ $t('settings.parser.testConnection', '测试连接') }}
-            </t-button>
-            <span v-if="checkMessage || saveMessage" :class="['test-message', saveSuccess && !checkMessage ? 'success' : (checkMessage ? 'hint' : 'error')]">
-              {{ checkMessage || saveMessage }}
-            </span>
-          </div>
-        </div>
+        </section>
       </div>
-      
-      <template #footer>
-        <div class="drawer-footer-actions">
-          <t-button theme="default" variant="outline" @click="drawerVisible = false">{{ $t('common.cancel') }}</t-button>
-          <t-button v-if="authStore.hasRole('admin')" theme="primary" :loading="saving" @click="onSave">{{ $t('common.save') }}</t-button>
-        </div>
-      </template>
-    </t-drawer>
+    </SettingDrawer>
   </div>
 </template>
 
@@ -270,6 +321,7 @@ import { ref, computed, onMounted, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useUIStore } from '@/stores/ui'
 import { useAuthStore } from '@/stores/auth'
+import SettingDrawer from '@/components/settings/SettingDrawer.vue'
 import {
   getParserEngines,
   getParserEngineConfig,
@@ -333,6 +385,18 @@ const drawerVisible = ref(false)
 const currentEngine = ref<ParserEngineInfo | null>(null)
 const drawerTitle = computed(() => {
   return currentEngine.value ? getEngineDisplayName(currentEngine.value.Name) : ''
+})
+
+// SettingDrawer 头部图标走 #headerIcon 槽（首字母 monogram + per-engine
+// 配色，与列表卡片完全一致），不再需要 t-icon name 兜底。
+
+// Whether the footer test-connection button should appear. Engines without
+// configurable fields and that aren't the builtin DocReader (whose connection
+// status is the whole point of the drawer) skip the test affordance — for
+// e.g. simple/markitdown there's nothing to validate beyond presence.
+const needsTestButton = computed(() => {
+  if (!currentEngine.value) return false
+  return hasConfigFields(currentEngine.value.Name) || currentEngine.value.Name === 'builtin'
 })
 
 /** 固定展示顺序，未列出的引擎排在末尾按名称排序 */
@@ -755,67 +819,69 @@ onMounted(loadAll)
   overflow: hidden;
 }
 
-// ---- 抽屉内容 ----
-.drawer-content {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
+// ---- 抽屉内容 — 与 ModelEditorDialog 同款约定 ----
+// .form-item / .form-label / .form-desc / .weknoracloud-hint / .api-test
+// 参照 frontend/src/components/ModelEditorDialog.vue 的命名与字号/间距
+.form-item {
+  margin-bottom: 0;
 }
 
-.engine-info-block {
-  .engine-desc {
-    font-size: 13px;
-    color: var(--td-text-color-secondary);
-    margin: 0 0 8px 0;
-    line-height: 1.5;
+.form-label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--td-text-color-primary);
+  line-height: 1.4;
+
+  // 与 ModelEditorDialog 一致：必填星号前置
+  &.required::before {
+    content: '*';
+    color: var(--td-error-color);
+    margin-right: 4px;
+    font-weight: 500;
+    line-height: 1;
   }
 }
 
-// 输入框样式
+.form-desc {
+  margin: 4px 0 0 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--td-text-color-placeholder);
+}
+
+// 输入框统一字号
 :deep(.t-input),
-:deep(.t-select) {
+:deep(.t-select),
+:deep(.t-textarea),
+:deep(.t-input-number) {
   width: 100%;
   font-size: 13px;
+}
 
-  .t-input__inner,
-  .t-input__wrap,
-  input {
+:deep(.t-checkbox) {
+  font-size: 13px;
+
+  .t-checkbox__label {
     font-size: 13px;
-    border-radius: 6px;
-    border-color: var(--td-component-stroke);
-    transition: all 0.15s ease;
-  }
-
-  &:hover .t-input__inner,
-  &:hover .t-input__wrap,
-  &:hover input {
-    border-color: var(--td-component-stroke);
-  }
-
-  &.t-is-focused .t-input__inner,
-  &.t-is-focused .t-input__wrap,
-  &.t-is-focused input {
-    border-color: var(--td-brand-color);
-    box-shadow: 0 0 0 2px rgba(7, 192, 95, 0.1);
+    color: var(--td-text-color-primary);
   }
 }
 
-// ---- DocReader 连接信息 ----
-.docreader-inline {
-  padding: 12px 16px;
-  background: var(--td-bg-color-secondarycontainer);
+// ---- DocReader 连接信息（builtin 引擎） ----
+.docreader-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  background: var(--td-bg-color-container-hover);
+  border: 1px solid var(--td-component-stroke);
   border-radius: 8px;
 
-  .status-line {
-    margin-bottom: 8px;
+  .form-desc {
+    margin-top: 0;
   }
-}
-
-.docreader-desc {
-  margin: 0;
-  font-size: 12px;
-  color: var(--td-text-color-placeholder);
-  line-height: 1.6;
 }
 
 .status-line {
@@ -828,152 +894,200 @@ onMounted(loadAll)
 .env-hint {
   font-size: 12px;
   color: var(--td-text-color-placeholder);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
 }
 
-// ---- 文件类型标签 ----
+// ---- 文件类型 chip ----
 .file-types {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
 }
 
-// ---- 配置表单 ----
-.engine-form {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-
-.form-item {
-  margin-bottom: 20px;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-}
-
-.form-label {
-  display: block;
-  margin-bottom: 8px;
-  font-size: 14px;
+.file-type-chip {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 8px;
+  font-size: 11px;
   font-weight: 500;
+  color: var(--td-text-color-secondary);
+  background: var(--td-bg-color-component);
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  letter-spacing: 0.02em;
+}
+
+// ---- Inline alert（替代之前的 .weknoracloud-hint 卡片） ----
+// 一行内表达 "状态信号 + 一句话 + 跳转 link"，无外框/无 3px 左边，
+// 视觉重量与一行文字相当，section 内不会再被一个独立卡片打断。
+.inline-alert {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--td-text-color-secondary);
+  flex-wrap: wrap;
+}
+
+.inline-alert__icon {
+  font-size: 15px;
+  flex-shrink: 0;
+  color: var(--td-text-color-placeholder);
+}
+
+.inline-alert--ok .inline-alert__icon {
+  color: var(--td-success-color);
+}
+
+.inline-alert--warn {
   color: var(--td-text-color-primary);
 
-  &.required::after {
-    content: '*';
-    color: var(--td-error-color);
-    margin-left: 4px;
-    font-weight: 600;
+  .inline-alert__icon {
+    color: var(--td-warning-color, #f97316);
   }
 }
 
-.form-hint {
-  margin: 4px 0 0 0;
-  font-size: 12px;
-  color: var(--td-text-color-placeholder);
-  line-height: 1.5;
+.inline-alert__text {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
+// 行尾 link：跟普通 doc-link 一致的主题色，但更紧凑，行内排版
+.inline-alert__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--td-brand-color);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.15s ease;
+
+  &:hover {
+    color: var(--td-brand-color-active);
+  }
+
+  .t-icon {
+    font-size: 14px;
+  }
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.spinning {
+  animation: spin 1s linear infinite;
+}
+
+// ---- 表单切换组（公式/表格/OCR） ----
 .form-toggles {
   display: flex;
   flex-wrap: wrap;
   gap: 16px;
-  margin-bottom: 20px;
+  padding: 8px 0 0;
 }
 
-// ---- WeKnoraCloud 凭证状态 ----
-.wkc-status {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 12px 16px;
-  border-radius: 6px;
-  font-size: 13px;
-  color: var(--td-text-color-secondary);
-  background: var(--td-bg-color-secondarycontainer);
+// ---- footer-left 测试连接消息（与 ModelEditorDialog 同款） ----
+.footer-test-message {
+  font-size: 12px;
+  line-height: 1.4;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
-  &--ok {
-    background: var(--td-success-color-light);
-    border: 1px solid var(--td-success-color-focus);
-    color: var(--td-success-color);
+  &.success {
+    color: var(--td-brand-color-active);
   }
 
-  &--warn {
-    background: #fff7ed;
-    border: 1px solid #fed7aa;
-    border-left: 3px solid #f97316;
+  &.error {
+    color: var(--td-error-color);
   }
 }
 
-.api-test-section {
-  display: flex;
+.status-icon {
+  font-size: 16px;
+  flex-shrink: 0;
+
+  &.available {
+    color: var(--td-brand-color);
+  }
+
+  &.unavailable {
+    color: var(--td-error-color);
+  }
+}
+
+// ---- 文档外链 ----
+.doc-link {
+  display: inline-flex;
   align-items: center;
-  gap: 12px;
+  gap: 4px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--td-brand-color);
+  text-decoration: none;
+  transition: color 0.15s ease;
 
-  .test-message {
-    font-size: 13px;
-    line-height: 1.5;
-    flex: 1;
-
-    &.success {
-      color: var(--td-brand-color-active);
-    }
-
-    &.error {
-      color: var(--td-error-color);
-    }
-
-    &.hint {
-      color: var(--td-text-color-secondary);
-    }
+  &:hover {
+    color: var(--td-brand-color-active);
   }
 
-  :deep(.t-button) {
-    min-width: 88px;
-    height: 32px;
-    font-size: 13px;
-    border-radius: 6px;
-    flex-shrink: 0;
+  .link-icon {
+    font-size: 14px;
   }
 
-  .status-icon {
-    font-size: 16px;
-    flex-shrink: 0;
+  // 副标题里的 inline 文档链接：与描述文字平铺一行，体量等同小字
+  &--inline {
+    margin-left: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    vertical-align: baseline;
 
-    &.available {
-      color: var(--td-brand-color);
-    }
-
-    &.unavailable {
-      color: var(--td-error-color);
+    .link-icon {
+      font-size: 12px;
     }
   }
 }
 
-.drawer-footer-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 12px;
-  width: 100%;
+// ---- Header 图标的首字母 monogram（per-engine 配色见非 scoped 块）----
+.header-icon__text {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+</style>
 
-  :deep(.t-button) {
-    min-width: 80px;
-    height: 36px;
-    font-weight: 500;
-    font-size: 14px;
-    border-radius: 6px;
-    transition: all 0.15s ease;
-
-    &.t-button--variant-outline {
-      color: var(--td-text-color-secondary);
-      border-color: var(--td-component-stroke);
-
-      &:hover {
-        border-color: var(--td-brand-color);
-        color: var(--td-brand-color);
-        background: rgba(7, 192, 95, 0.04);
-      }
-    }
-  }
+<!--
+  Non-scoped block: per-engine header-icon coloring. Same approach as
+  StorageEngineSettings — keep these rules global so they always apply
+  regardless of whether the drawer panel inherits the parent's scoped
+  data attributes. Each rule mirrors the matching .engine-card--{name}
+  .engine-card__badge from the scoped block above.
+-->
+<style lang="less">
+.parser-engine-drawer--builtin .setting-drawer__header-icon,
+.parser-engine-drawer--weknoracloud .setting-drawer__header-icon {
+  background: rgba(7, 192, 95, 0.12);
+  color: #07C05F;
+}
+.parser-engine-drawer--simple .setting-drawer__header-icon {
+  background: rgba(70, 70, 70, 0.1);
+  color: #464646;
+}
+.parser-engine-drawer--markitdown .setting-drawer__header-icon {
+  background: rgba(0, 137, 255, 0.12);
+  color: #0089FF;
+}
+.parser-engine-drawer--mineru .setting-drawer__header-icon,
+.parser-engine-drawer--mineru_cloud .setting-drawer__header-icon {
+  background: rgba(98, 53, 187, 0.12);
+  color: #6235BB;
 }
 </style>

--- a/frontend/src/views/settings/StorageEngineSettings.vue
+++ b/frontend/src/views/settings/StorageEngineSettings.vue
@@ -98,19 +98,89 @@
       </div>
     </template>
 
-    <t-drawer
+    <!-- 配置抽屉 — SettingDrawer 包装，与 ModelEditorDialog / ParserEngineSettings 同款 -->
+    <SettingDrawer
       v-model:visible="drawerVisible"
-      :header="drawerTitle"
-      size="500px"
-      :footer="true"
+      :title="drawerTitle"
+      :class="currentEngine ? `storage-engine-drawer storage-engine-drawer--${currentEngine}` : 'storage-engine-drawer'"
+      :hide-footer="!authStore.hasRole('admin') && !needsTestButton"
+      :confirm-loading="saving"
       @confirm="onSave"
+      @cancel="drawerVisible = false"
     >
-      <div class="drawer-content">
+      <!--
+        Header icon — 复用列表卡片同款 logo / 配色徽章。
+        - color logo（如 MinIO/AWS）: 直接 <img>，保留品牌彩色
+        - mono logo（mask-image）: 通过 ::before + currentColor 染色，颜色由
+          .storage-engine-drawer--{id} :deep(.setting-drawer__header-icon) 决定
+        - 无 logo（local）: 渲染首字母作为 monogram
+      -->
+      <template v-if="currentEngine" #headerIcon>
+        <img
+          v-if="currentLogo?.mode === 'color'"
+          :src="currentLogo.url"
+          :alt="currentEngine"
+          class="header-icon__img"
+        />
+        <span
+          v-else-if="currentLogo?.mode === 'mono'"
+          class="header-icon__mono"
+          :style="monoLogoStyle"
+        />
+        <span v-else class="header-icon__text">{{ providerInitial(currentEngine as StorageProviderId) }}</span>
+      </template>
+
+      <!-- 副标题：引擎描述 + inline 控制台/文档外链（若有） -->
+      <template v-if="currentEngine" #subtitle>
+        <span>{{ engineDescText }}</span>
+        <template v-for="link in engineLinks" :key="link.url">
+          <a :href="link.url" target="_blank" rel="noopener" class="doc-link doc-link--inline">
+            {{ link.label }}
+            <t-icon name="link" class="link-icon" />
+          </a>
+        </template>
+      </template>
+
+      <!-- 测试连接挪到 footer-left（local 不需要） -->
+      <template v-if="needsTestButton" #footer-left>
+        <t-button
+          variant="outline"
+          :loading="currentCheckState.loading"
+          @click="currentCheckState.onCheck"
+        >
+          <template #icon>
+            <t-icon
+              v-if="!currentCheckState.loading && currentCheckState.result?.ok"
+              name="check-circle-filled"
+              class="status-icon available"
+            />
+            <t-icon
+              v-else-if="!currentCheckState.loading && currentCheckState.result && !currentCheckState.result.ok"
+              name="close-circle-filled"
+              class="status-icon unavailable"
+            />
+          </template>
+          {{ $t('settings.storage.testConnection') }}
+        </t-button>
+        <span
+          v-if="currentCheckState.result"
+          :class="[
+            'footer-test-message',
+            currentCheckState.result.ok
+              ? (currentCheckState.result.bucket_created ? 'created' : 'success')
+              : 'error'
+          ]"
+          :title="currentCheckState.result.message"
+        >
+          {{ currentCheckState.result.message }}
+        </span>
+      </template>
+
+      <div v-if="currentEngine">
+        <!-- ===== local ===== -->
         <template v-if="currentEngine === 'local'">
-          <div class="engine-info-block">
-            <p class="engine-desc">{{ $t('settings.storage.localDesc') }}</p>
-          </div>
-          <div class="engine-form">
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.basicSection', '基本配置') }}</h4>
             <div class="form-item">
               <label class="form-label">{{ $t('settings.storage.pathPrefix') }}</label>
               <t-input
@@ -119,377 +189,335 @@
                 clearable
               />
             </div>
-          </div>
+          </section>
         </template>
 
+        <!-- ===== minio ===== -->
         <template v-else-if="currentEngine === 'minio'">
-          <div class="engine-info-block">
-            <p class="engine-desc">{{ $t('settings.storage.minioDesc') }}</p>
-          </div>
-          <div class="mode-selector">
-            <div
-              :class="['mode-option', { active: config.minio.mode !== 'remote' }]"
-              @click="config.minio.mode = 'docker'"
-            >
-              <span class="mode-label">{{ $t('settings.storage.minioDocker') }}</span>
-              <t-tag v-if="minioEnvAvailable" theme="success" variant="light" size="small">{{ $t('settings.storage.detected') }}</t-tag>
-              <t-tag v-else theme="default" variant="light" size="small">{{ $t('settings.storage.notDetected') }}</t-tag>
-            </div>
-            <div
-              :class="['mode-option', { active: config.minio.mode === 'remote' }]"
-              @click="config.minio.mode = 'remote'"
-            >
-              <span class="mode-label">{{ $t('settings.storage.minioRemote') }}</span>
-            </div>
-          </div>
+          <!-- Section 1 — 部署模式（Docker / 远程） -->
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.modeSection', '部署模式') }}</h4>
+            <div class="form-item">
+              <div class="source-options" role="radiogroup">
+                <button
+                  type="button"
+                  class="source-option"
+                  :class="{ 'is-active': config.minio.mode !== 'remote' }"
+                  @click="config.minio.mode = 'docker'"
+                >
+                  <t-icon name="server" class="source-option__icon" />
+                  <span class="source-option__label">{{ $t('settings.storage.minioDocker') }}</span>
+                </button>
+                <button
+                  type="button"
+                  class="source-option"
+                  :class="{ 'is-active': config.minio.mode === 'remote' }"
+                  @click="config.minio.mode = 'remote'"
+                >
+                  <t-icon name="cloud" class="source-option__icon" />
+                  <span class="source-option__label">{{ $t('settings.storage.minioRemote') }}</span>
+                </button>
+              </div>
 
-          <div v-if="config.minio.mode !== 'remote'">
-            <div v-if="minioEnvAvailable" class="engine-hint success">
-              {{ $t('settings.storage.minioDockerDetected') }}
-            </div>
-            <div v-else class="engine-hint warning">
-              {{ $t('settings.storage.minioDockerNotDetected') }}
-            </div>
-            <div class="engine-form">
-              <div class="form-item">
-                <label class="form-label">{{ $t('settings.storage.bucketName') }}</label>
-                <t-input
-                  v-model="config.minio.bucket_name"
-                  :placeholder="$t('settings.storage.bucketPlaceholder')"
-                  :disabled="!minioEnvAvailable"
-                  clearable
+              <!-- Docker 模式状态提示 inline-alert -->
+              <div v-if="config.minio.mode !== 'remote'" class="inline-alert"
+                :class="minioEnvAvailable ? 'inline-alert--ok' : 'inline-alert--warn'">
+                <t-icon
+                  :name="minioEnvAvailable ? 'check-circle-filled' : 'error-circle-filled'"
+                  class="inline-alert__icon"
                 />
+                <span class="inline-alert__text">
+                  {{ minioEnvAvailable ? $t('settings.storage.minioDockerDetected') : $t('settings.storage.minioDockerNotDetected') }}
+                </span>
               </div>
-              <div class="form-item form-item--inline">
-                <label class="form-label">Use SSL</label>
-                <t-switch v-model="config.minio.use_ssl" size="small" />
-              </div>
-              <div class="form-item">
-                <label class="form-label">{{ $t('settings.storage.pathPrefix') }}</label>
-                <t-input
-                  v-model="config.minio.path_prefix"
-                  :placeholder="$t('settings.storage.prefixPlaceholder')"
-                  clearable
-                />
-              </div>
-            </div>
-          </div>
 
-          <div v-else>
-            <div class="engine-hint">{{ $t('settings.storage.minioRemoteHint') }}</div>
-            <div class="engine-form">
-              <div class="form-item">
-                <label class="form-label">Endpoint</label>
-                <t-input v-model="config.minio.endpoint" placeholder="e.g. minio.example.com:9000" clearable />
-              </div>
-              <div class="form-item">
-                <label class="form-label">Access Key ID</label>
-                <t-input v-model="config.minio.access_key_id" placeholder="MinIO Access Key" clearable />
-              </div>
-              <div class="form-item">
-                <label class="form-label">Secret Access Key</label>
-                <t-input v-model="config.minio.secret_access_key" type="password" placeholder="MinIO Secret Key" clearable />
-              </div>
-              <div class="form-item">
-                <label class="form-label">{{ $t('settings.storage.bucketName') }}</label>
-                <t-input v-model="config.minio.bucket_name" :placeholder="$t('settings.storage.bucketPlaceholder')" clearable />
-              </div>
-              <div class="form-item form-item--inline">
-                <label class="form-label">Use SSL</label>
-                <t-switch v-model="config.minio.use_ssl" size="small" />
-              </div>
-              <div class="form-item">
-                <label class="form-label">{{ $t('settings.storage.pathPrefix') }}</label>
-                <t-input v-model="config.minio.path_prefix" :placeholder="$t('settings.storage.prefixPlaceholder')" clearable />
+              <div v-else class="inline-alert">
+                <t-icon name="info-circle-filled" class="inline-alert__icon" />
+                <span class="inline-alert__text">{{ $t('settings.storage.minioRemoteHint') }}</span>
               </div>
             </div>
-          </div>
+          </section>
+
+          <!-- Section 2 — 远程模式凭证（仅 remote） -->
+          <section v-if="config.minio.mode === 'remote'" class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.credentialsSection', '凭证') }}</h4>
+            <div class="form-item">
+              <label class="form-label required">Endpoint</label>
+              <t-input v-model="config.minio.endpoint" placeholder="e.g. minio.example.com:9000" clearable />
+            </div>
+            <div class="form-item">
+              <label class="form-label required">Access Key ID</label>
+              <t-input v-model="config.minio.access_key_id" placeholder="MinIO Access Key" clearable>
+                <template #prefix-icon><t-icon name="lock-on" /></template>
+              </t-input>
+            </div>
+            <div class="form-item">
+              <label class="form-label required">Secret Access Key</label>
+              <t-input v-model="config.minio.secret_access_key" type="password" placeholder="MinIO Secret Key" clearable>
+                <template #prefix-icon><t-icon name="lock-on" /></template>
+              </t-input>
+            </div>
+          </section>
+
+          <!-- Section 3 — Bucket 与选项 -->
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.bucketSection', 'Bucket') }}</h4>
+            <div class="form-item">
+              <label class="form-label required">{{ $t('settings.storage.bucketName') }}</label>
+              <t-input
+                v-model="config.minio.bucket_name"
+                :placeholder="$t('settings.storage.bucketPlaceholder')"
+                :disabled="config.minio.mode !== 'remote' && !minioEnvAvailable"
+                clearable
+              />
+            </div>
+            <div class="form-item">
+              <label class="form-label">{{ $t('settings.storage.pathPrefix') }}</label>
+              <t-input
+                v-model="config.minio.path_prefix"
+                :placeholder="$t('settings.storage.prefixPlaceholder')"
+                clearable
+              />
+            </div>
+            <div class="form-item">
+              <label class="form-label">SSL</label>
+              <div class="vision-toggle">
+                <t-switch v-model="config.minio.use_ssl" />
+                <span class="form-desc form-desc--inline">{{ $t('settings.storage.useSslDesc', '通过 HTTPS 访问 MinIO') }}</span>
+              </div>
+            </div>
+          </section>
         </template>
 
+        <!-- ===== cos ===== -->
         <template v-else-if="currentEngine === 'cos'">
-          <div class="engine-info-block">
-            <p class="engine-desc">
-              {{ $t('settings.storage.cosDesc') }}
-              <a class="doc-link" href="https://console.cloud.tencent.com/cos" target="_blank" rel="noopener">{{ $t('settings.storage.console') }}<t-icon name="link" class="link-icon" /></a>
-              <a class="doc-link" href="https://cloud.tencent.com/document/product/436" target="_blank" rel="noopener">{{ $t('settings.storage.docs') }}<t-icon name="link" class="link-icon" /></a>
-            </p>
-          </div>
-          <div class="engine-form">
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.credentialsSection', '凭证') }}</h4>
             <div class="form-item">
-              <label class="form-label">Secret ID</label>
-              <t-input v-model="config.cos.secret_id" :placeholder="$t('settings.storage.cosSecretIdPlaceholder')" clearable />
+              <label class="form-label required">Secret ID</label>
+              <t-input v-model="config.cos.secret_id" :placeholder="$t('settings.storage.cosSecretIdPlaceholder')" clearable>
+                <template #prefix-icon><t-icon name="lock-on" /></template>
+              </t-input>
             </div>
             <div class="form-item">
-              <label class="form-label">Secret Key</label>
-              <t-input v-model="config.cos.secret_key" type="password" :placeholder="$t('settings.storage.cosSecretKeyPlaceholder')" clearable />
+              <label class="form-label required">Secret Key</label>
+              <t-input v-model="config.cos.secret_key" type="password" :placeholder="$t('settings.storage.cosSecretKeyPlaceholder')" clearable>
+                <template #prefix-icon><t-icon name="lock-on" /></template>
+              </t-input>
             </div>
             <div class="form-item">
-              <label class="form-label">Region</label>
+              <label class="form-label required">App ID</label>
+              <t-input v-model="config.cos.app_id" :placeholder="$t('settings.storage.cosAppIdPlaceholder')" clearable />
+            </div>
+          </section>
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.bucketSection', 'Bucket') }}</h4>
+            <div class="form-item">
+              <label class="form-label required">Region</label>
               <t-input v-model="config.cos.region" placeholder="e.g. ap-guangzhou" clearable />
             </div>
             <div class="form-item">
-              <label class="form-label">{{ $t('settings.storage.bucketName') }}</label>
+              <label class="form-label required">{{ $t('settings.storage.bucketName') }}</label>
               <t-input v-model="config.cos.bucket_name" :placeholder="$t('settings.storage.bucketPlaceholder')" clearable />
-            </div>
-            <div class="form-item">
-              <label class="form-label">App ID</label>
-              <t-input v-model="config.cos.app_id" :placeholder="$t('settings.storage.cosAppIdPlaceholder')" clearable />
             </div>
             <div class="form-item">
               <label class="form-label">{{ $t('settings.storage.pathPrefix') }}</label>
               <t-input v-model="config.cos.path_prefix" :placeholder="$t('settings.storage.prefixPlaceholder')" clearable />
             </div>
-          </div>
+          </section>
         </template>
 
+        <!-- ===== tos ===== -->
         <template v-else-if="currentEngine === 'tos'">
-          <div class="engine-info-block">
-            <p class="engine-desc">
-              {{ $t('settings.storage.tosDesc') }}
-              <a class="doc-link" href="https://console.volcengine.com/tos" target="_blank" rel="noopener">{{ $t('settings.storage.console') }}<t-icon name="link" class="link-icon" /></a>
-              <a class="doc-link" href="https://www.volcengine.com/docs/6349" target="_blank" rel="noopener">{{ $t('settings.storage.docs') }}<t-icon name="link" class="link-icon" /></a>
-            </p>
-          </div>
-          <div class="engine-form">
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.credentialsSection', '凭证') }}</h4>
             <div class="form-item">
-              <label class="form-label">Endpoint</label>
+              <label class="form-label required">Access Key</label>
+              <t-input v-model="config.tos.access_key" :placeholder="$t('settings.storage.tosAccessKeyPlaceholder')" clearable>
+                <template #prefix-icon><t-icon name="lock-on" /></template>
+              </t-input>
+            </div>
+            <div class="form-item">
+              <label class="form-label required">Secret Key</label>
+              <t-input v-model="config.tos.secret_key" type="password" :placeholder="$t('settings.storage.tosSecretKeyPlaceholder')" clearable>
+                <template #prefix-icon><t-icon name="lock-on" /></template>
+              </t-input>
+            </div>
+          </section>
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.bucketSection', 'Bucket') }}</h4>
+            <div class="form-item">
+              <label class="form-label required">Endpoint</label>
               <t-input v-model="config.tos.endpoint" placeholder="e.g. https://tos-cn-beijing.volces.com" clearable />
             </div>
             <div class="form-item">
-              <label class="form-label">Region</label>
+              <label class="form-label required">Region</label>
               <t-input v-model="config.tos.region" placeholder="e.g. cn-beijing" clearable />
             </div>
             <div class="form-item">
-              <label class="form-label">Access Key</label>
-              <t-input v-model="config.tos.access_key" :placeholder="$t('settings.storage.tosAccessKeyPlaceholder')" clearable />
-            </div>
-            <div class="form-item">
-              <label class="form-label">Secret Key</label>
-              <t-input v-model="config.tos.secret_key" type="password" :placeholder="$t('settings.storage.tosSecretKeyPlaceholder')" clearable />
-            </div>
-            <div class="form-item">
-              <label class="form-label">{{ $t('settings.storage.bucketName') }}</label>
+              <label class="form-label required">{{ $t('settings.storage.bucketName') }}</label>
               <t-input v-model="config.tos.bucket_name" :placeholder="$t('settings.storage.bucketPlaceholder')" clearable />
             </div>
             <div class="form-item">
               <label class="form-label">{{ $t('settings.storage.pathPrefix') }}</label>
               <t-input v-model="config.tos.path_prefix" :placeholder="$t('settings.storage.prefixPlaceholder')" clearable />
             </div>
-          </div>
+          </section>
         </template>
 
+        <!-- ===== s3 ===== -->
         <template v-else-if="currentEngine === 's3'">
-          <div class="engine-info-block">
-            <p class="engine-desc">
-              {{ $t('settings.storage.s3Desc') }}
-              <a class="doc-link" href="https://aws.amazon.com/s3/" target="_blank" rel="noopener">{{ $t('settings.storage.console') }}<t-icon name="link" class="link-icon" /></a>
-              <a class="doc-link" href="https://docs.aws.amazon.com/s3/" target="_blank" rel="noopener">{{ $t('settings.storage.docs') }}<t-icon name="link" class="link-icon" /></a>
-            </p>
-          </div>
-          <div class="engine-form">
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.credentialsSection', '凭证') }}</h4>
             <div class="form-item">
-              <label class="form-label">Endpoint</label>
+              <label class="form-label required">Access Key</label>
+              <t-input v-model="config.s3.access_key" :placeholder="$t('settings.storage.s3AccessKeyPlaceholder')" clearable>
+                <template #prefix-icon><t-icon name="lock-on" /></template>
+              </t-input>
+            </div>
+            <div class="form-item">
+              <label class="form-label required">Secret Key</label>
+              <t-input v-model="config.s3.secret_key" type="password" :placeholder="$t('settings.storage.s3SecretKeyPlaceholder')" clearable>
+                <template #prefix-icon><t-icon name="lock-on" /></template>
+              </t-input>
+            </div>
+          </section>
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.bucketSection', 'Bucket') }}</h4>
+            <div class="form-item">
+              <label class="form-label required">Endpoint</label>
               <t-input v-model="config.s3.endpoint" placeholder="e.g. https://s3.amazonaws.com" clearable />
             </div>
             <div class="form-item">
-              <label class="form-label">Region</label>
+              <label class="form-label required">Region</label>
               <t-input v-model="config.s3.region" placeholder="e.g. us-east-1" clearable />
             </div>
             <div class="form-item">
-              <label class="form-label">Access Key</label>
-              <t-input v-model="config.s3.access_key" :placeholder="$t('settings.storage.s3AccessKeyPlaceholder')" clearable />
-            </div>
-            <div class="form-item">
-              <label class="form-label">Secret Key</label>
-              <t-input v-model="config.s3.secret_key" type="password" :placeholder="$t('settings.storage.s3SecretKeyPlaceholder')" clearable />
-            </div>
-            <div class="form-item">
-              <label class="form-label">{{ $t('settings.storage.bucketName') }}</label>
+              <label class="form-label required">{{ $t('settings.storage.bucketName') }}</label>
               <t-input v-model="config.s3.bucket_name" :placeholder="$t('settings.storage.bucketPlaceholder')" clearable />
             </div>
             <div class="form-item">
               <label class="form-label">{{ $t('settings.storage.pathPrefix') }}</label>
               <t-input v-model="config.s3.path_prefix" :placeholder="$t('settings.storage.prefixPlaceholder')" clearable />
             </div>
-          </div>
+          </section>
         </template>
 
+        <!-- ===== oss ===== -->
         <template v-else-if="currentEngine === 'oss'">
-          <div class="engine-info-block">
-            <p class="engine-desc">
-              {{ $t('settings.storage.ossDesc') }}
-              <a class="doc-link" href="https://oss.console.aliyun.com/" target="_blank" rel="noopener">{{ $t('settings.storage.console') }}<t-icon name="link" class="link-icon" /></a>
-              <a class="doc-link" href="https://help.aliyun.com/zh/oss/" target="_blank" rel="noopener">{{ $t('settings.storage.docs') }}<t-icon name="link" class="link-icon" /></a>
-            </p>
-          </div>
-          <div class="engine-form">
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.credentialsSection', '凭证') }}</h4>
             <div class="form-item">
-              <label class="form-label">Endpoint</label>
+              <label class="form-label required">Access Key</label>
+              <t-input v-model="config.oss.access_key" :placeholder="$t('settings.storage.ossAccessKeyPlaceholder')" clearable>
+                <template #prefix-icon><t-icon name="lock-on" /></template>
+              </t-input>
+            </div>
+            <div class="form-item">
+              <label class="form-label required">Secret Key</label>
+              <t-input v-model="config.oss.secret_key" type="password" :placeholder="$t('settings.storage.ossSecretKeyPlaceholder')" clearable>
+                <template #prefix-icon><t-icon name="lock-on" /></template>
+              </t-input>
+            </div>
+          </section>
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.bucketSection', 'Bucket') }}</h4>
+            <div class="form-item">
+              <label class="form-label required">Endpoint</label>
               <t-input v-model="config.oss.endpoint" placeholder="e.g. https://oss-cn-hangzhou.aliyuncs.com" clearable />
             </div>
             <div class="form-item">
-              <label class="form-label">Region</label>
+              <label class="form-label required">Region</label>
               <t-input v-model="config.oss.region" placeholder="e.g. cn-hangzhou" clearable />
             </div>
             <div class="form-item">
-              <label class="form-label">Access Key</label>
-              <t-input v-model="config.oss.access_key" :placeholder="$t('settings.storage.ossAccessKeyPlaceholder')" clearable />
-            </div>
-            <div class="form-item">
-              <label class="form-label">Secret Key</label>
-              <t-input v-model="config.oss.secret_key" type="password" :placeholder="$t('settings.storage.ossSecretKeyPlaceholder')" clearable />
-            </div>
-            <div class="form-item">
-              <label class="form-label">{{ $t('settings.storage.bucketName') }}</label>
+              <label class="form-label required">{{ $t('settings.storage.bucketName') }}</label>
               <t-input v-model="config.oss.bucket_name" :placeholder="$t('settings.storage.bucketPlaceholder')" clearable />
             </div>
             <div class="form-item">
               <label class="form-label">{{ $t('settings.storage.pathPrefix') }}</label>
               <t-input v-model="config.oss.path_prefix" :placeholder="$t('settings.storage.prefixPlaceholder')" clearable />
             </div>
-          </div>
+          </section>
         </template>
 
+        <!-- ===== ks3 ===== -->
         <template v-else-if="currentEngine === 'ks3'">
-          <div class="engine-info-block">
-            <p class="engine-desc">
-              {{ $t('settings.storage.ks3Desc') }}
-            </p>
-          </div>
-          <div class="engine-form">
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.credentialsSection', '凭证') }}</h4>
             <div class="form-item">
-              <label class="form-label">Endpoint</label>
-              <t-input
-                v-model="config.ks3.endpoint"
-                :placeholder="$t('settings.storage.ks3EndpointPlaceholder')"
-                clearable
-              />
+              <label class="form-label required">Access Key</label>
+              <t-input v-model="config.ks3.access_key" :placeholder="$t('settings.storage.ks3AccessKeyPlaceholder')" clearable>
+                <template #prefix-icon><t-icon name="lock-on" /></template>
+              </t-input>
             </div>
             <div class="form-item">
-              <label class="form-label">Region</label>
-              <t-input
-                v-model="config.ks3.region"
-                :placeholder="$t('settings.storage.ks3RegionPlaceholder')"
-                clearable
-              />
+              <label class="form-label required">Secret Key</label>
+              <t-input v-model="config.ks3.secret_key" type="password" :placeholder="$t('settings.storage.ks3SecretKeyPlaceholder')" clearable>
+                <template #prefix-icon><t-icon name="lock-on" /></template>
+              </t-input>
+            </div>
+          </section>
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.bucketSection', 'Bucket') }}</h4>
+            <div class="form-item">
+              <label class="form-label required">Endpoint</label>
+              <t-input v-model="config.ks3.endpoint" :placeholder="$t('settings.storage.ks3EndpointPlaceholder')" clearable />
             </div>
             <div class="form-item">
-              <label class="form-label">Access Key</label>
-              <t-input
-                v-model="config.ks3.access_key"
-                :placeholder="$t('settings.storage.ks3AccessKeyPlaceholder')"
-                clearable
-              />
+              <label class="form-label required">Region</label>
+              <t-input v-model="config.ks3.region" :placeholder="$t('settings.storage.ks3RegionPlaceholder')" clearable />
             </div>
             <div class="form-item">
-              <label class="form-label">Secret Key</label>
-              <t-input
-                v-model="config.ks3.secret_key"
-                type="password"
-                :placeholder="$t('settings.storage.ks3SecretKeyPlaceholder')"
-                clearable
-              />
-            </div>
-            <div class="form-item">
-              <label class="form-label">{{ $t('settings.storage.bucketName') }}</label>
-              <t-input
-                v-model="config.ks3.bucket_name"
-                :placeholder="$t('settings.storage.bucketPlaceholder')"
-                clearable
-              />
+              <label class="form-label required">{{ $t('settings.storage.bucketName') }}</label>
+              <t-input v-model="config.ks3.bucket_name" :placeholder="$t('settings.storage.bucketPlaceholder')" clearable />
             </div>
             <div class="form-item">
               <label class="form-label">{{ $t('settings.storage.pathPrefix') }}</label>
-              <t-input
-                v-model="config.ks3.path_prefix"
-                :placeholder="$t('settings.storage.prefixPlaceholder')"
-                clearable
-              />
+              <t-input v-model="config.ks3.path_prefix" :placeholder="$t('settings.storage.prefixPlaceholder')" clearable />
             </div>
-          </div>
+          </section>
         </template>
 
+        <!-- ===== obs ===== -->
         <template v-else-if="currentEngine === 'obs'">
-          <div class="engine-info-block">
-            <p class="engine-desc">
-              {{ $t('settings.storage.obsDesc') }}
-              <a class="engine-link" href="https://obs.huaweicloud.com/" target="_blank" rel="noopener">{{ $t('settings.storage.console') }} ↗</a>
-              <a class="engine-link" href="https://support.huaweicloud.com/obs/" target="_blank" rel="noopener">{{ $t('settings.storage.docs') }} ↗</a>
-            </p>
-          </div>
-          <div class="engine-form">
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.credentialsSection', '凭证') }}</h4>
             <div class="form-item">
-              <label class="form-label">Endpoint</label>
-              <t-input
-                v-model="config.obs.endpoint"
-                :placeholder="$t('settings.storage.obsEndpointPlaceholder')"
-                clearable
-              />
+              <label class="form-label required">Access Key</label>
+              <t-input v-model="config.obs.access_key" :placeholder="$t('settings.storage.obsAccessKeyPlaceholder')" clearable>
+                <template #prefix-icon><t-icon name="lock-on" /></template>
+              </t-input>
             </div>
             <div class="form-item">
-              <label class="form-label">Region</label>
-              <t-input
-                v-model="config.obs.region"
-                :placeholder="$t('settings.storage.obsRegionPlaceholder')"
-                clearable
-              />
+              <label class="form-label required">Secret Key</label>
+              <t-input v-model="config.obs.secret_key" type="password" :placeholder="$t('settings.storage.obsSecretKeyPlaceholder')" clearable>
+                <template #prefix-icon><t-icon name="lock-on" /></template>
+              </t-input>
+            </div>
+          </section>
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ $t('settings.storage.bucketSection', 'Bucket') }}</h4>
+            <div class="form-item">
+              <label class="form-label required">Endpoint</label>
+              <t-input v-model="config.obs.endpoint" :placeholder="$t('settings.storage.obsEndpointPlaceholder')" clearable />
             </div>
             <div class="form-item">
-              <label class="form-label">Access Key</label>
-              <t-input
-                v-model="config.obs.access_key"
-                :placeholder="$t('settings.storage.obsAccessKeyPlaceholder')"
-                clearable
-              />
+              <label class="form-label required">Region</label>
+              <t-input v-model="config.obs.region" :placeholder="$t('settings.storage.obsRegionPlaceholder')" clearable />
             </div>
             <div class="form-item">
-              <label class="form-label">Secret Key</label>
-              <t-input
-                v-model="config.obs.secret_key"
-                type="password"
-                :placeholder="$t('settings.storage.obsSecretKeyPlaceholder')"
-                clearable
-              />
-            </div>
-            <div class="form-item">
-              <label class="form-label">{{ $t('settings.storage.bucketName') }}</label>
-              <t-input
-                v-model="config.obs.bucket_name"
-                :placeholder="$t('settings.storage.bucketPlaceholder')"
-                clearable
-              />
+              <label class="form-label required">{{ $t('settings.storage.bucketName') }}</label>
+              <t-input v-model="config.obs.bucket_name" :placeholder="$t('settings.storage.bucketPlaceholder')" clearable />
             </div>
             <div class="form-item">
               <label class="form-label">{{ $t('settings.storage.pathPrefix') }}</label>
-              <t-input
-                v-model="config.obs.path_prefix"
-                :placeholder="$t('settings.storage.prefixPlaceholder')"
-                clearable
-              />
+              <t-input v-model="config.obs.path_prefix" :placeholder="$t('settings.storage.prefixPlaceholder')" clearable />
             </div>
-          </div>
+          </section>
         </template>
-
-        <div class="form-item" v-if="currentEngine && currentEngine !== 'local'">
-          <label class="form-label">{{ $t('settings.storage.testConnection') }}</label>
-          <div class="api-test-section">
-            <t-button variant="outline" :loading="currentCheckState.loading" @click="currentCheckState.onCheck">
-              {{ $t('settings.storage.testConnection') }}
-            </t-button>
-            <span v-if="currentCheckState.result" :class="['test-message', currentCheckState.result.ok ? (currentCheckState.result.bucket_created ? 'created' : 'success') : 'error']">
-              {{ currentCheckState.result.message }}
-            </span>
-          </div>
-        </div>
       </div>
-
-      <template #footer>
-        <div class="drawer-footer-actions">
-          <t-button theme="default" variant="outline" @click="drawerVisible = false">{{ $t('common.cancel') }}</t-button>
-          <t-button v-if="authStore.hasRole('admin')" theme="primary" :loading="saving" @click="onSave">{{ $t('common.save') }}</t-button>
-        </div>
-      </template>
-    </t-drawer>
+    </SettingDrawer>
   </div>
 </template>
 
@@ -505,6 +533,7 @@ import {
 } from '@/api/system'
 import { useAuthStore } from '@/stores/auth'
 import { providerLogo } from './providerLogos'
+import SettingDrawer from '@/components/settings/SettingDrawer.vue'
 
 const { t } = useI18n()
 const authStore = useAuthStore()
@@ -620,6 +649,72 @@ const drawerTitle = computed(() => {
     obs: t('settings.storage.obsTitle'),
   }
   return titles[currentEngine.value] || currentEngine.value
+})
+
+// SettingDrawer 头部图标 — 走列表卡片同款 logo（color / mono / fallback）。
+// providerLogo 已经处理了 storage 域内每个 id 的 logo URL + 模式。
+const currentLogo = computed(() => {
+  if (!currentEngine.value) return null
+  return providerLogo('storage', currentEngine.value as StorageProviderId)
+})
+
+// Inline style for the mono mask span. We expose it as a computed instead
+// of inlining the literal in the template because Vue's template parser
+// chokes on the nested-quote pattern (template-literal inside an object
+// literal inside a v-bind expression).
+const monoLogoStyle = computed((): Record<string, string> => {
+  const logo = currentLogo.value
+  if (!logo || logo.mode !== 'mono') return {}
+  return { '--logo-url': `url("${logo.url}")` }
+})
+
+// 引擎描述（副标题主体文本）。
+const engineDescText = computed((): string => {
+  if (!currentEngine.value) return ''
+  const key = `settings.storage.${currentEngine.value}Desc`
+  const translated = t(key)
+  return translated !== key ? translated : ''
+})
+
+// 控制台 / 文档外链 — 副标题尾部 inline 显示，与 ParserEngineSettings
+// 同款。各 provider 的 console / docs 链接来自原模板里的硬编码地址。
+const ENGINE_LINK_TABLE: Record<string, { console?: string; docs?: string }> = {
+  cos: {
+    console: 'https://console.cloud.tencent.com/cos',
+    docs: 'https://cloud.tencent.com/document/product/436',
+  },
+  tos: {
+    console: 'https://console.volcengine.com/tos',
+    docs: 'https://www.volcengine.com/docs/6349',
+  },
+  s3: {
+    console: 'https://aws.amazon.com/s3/',
+    docs: 'https://docs.aws.amazon.com/s3/',
+  },
+  oss: {
+    console: 'https://oss.console.aliyun.com/',
+    docs: 'https://help.aliyun.com/zh/oss/',
+  },
+  obs: {
+    console: 'https://obs.huaweicloud.com/',
+    docs: 'https://support.huaweicloud.com/obs/',
+  },
+}
+
+const engineLinks = computed((): Array<{ label: string; url: string }> => {
+  if (!currentEngine.value) return []
+  const links = ENGINE_LINK_TABLE[currentEngine.value]
+  if (!links) return []
+  const result: Array<{ label: string; url: string }> = []
+  if (links.console) result.push({ label: t('settings.storage.console'), url: links.console })
+  if (links.docs) result.push({ label: t('settings.storage.docs'), url: links.docs })
+  return result
+})
+
+// 是否在 footer 显示"测试连接"按钮 — 本地直接读写文件系统，无连接概念，
+// 跳过；其余 provider 都需要远程 endpoint，必须能测。
+const needsTestButton = computed(() => {
+  return !!currentEngine.value && currentEngine.value !== 'local'
 })
 
 const minioAvailable = computed(() => {
@@ -1288,214 +1383,235 @@ onMounted(loadAll)
   overflow: hidden;
 }
 
-.drawer-content {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
+// ---- 抽屉内容 — 与 ModelEditorDialog 同款约定 ----
+
+// color logo 容器内部的图片
+.header-icon__img {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  display: block;
 }
 
-.engine-info-block {
-  .engine-desc {
-    font-size: 13px;
-    color: var(--td-text-color-secondary);
-    margin: 0 0 8px 0;
-    line-height: 1.5;
-  }
+// mono logo（用 mask-image 渲染，颜色由 currentColor 决定）
+.header-icon__mono {
+  display: inline-block;
+  width: 22px;
+  height: 22px;
+  background-color: currentColor;
+  -webkit-mask-image: var(--logo-url);
+  -webkit-mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-image: var(--logo-url);
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: contain;
 }
 
-:deep(.t-input),
-:deep(.t-select) {
-  width: 100%;
-  font-size: 13px;
-
-  .t-input__inner,
-  .t-input__wrap,
-  input {
-    font-size: 13px;
-    border-radius: 6px;
-    border-color: var(--td-component-stroke);
-    transition: all 0.15s ease;
-  }
-
-  &:hover .t-input__inner,
-  &:hover .t-input__wrap,
-  &:hover input {
-    border-color: var(--td-component-stroke);
-  }
-
-  &.t-is-focused .t-input__inner,
-  &.t-is-focused .t-input__wrap,
-  &.t-is-focused input {
-    border-color: var(--td-brand-color);
-    box-shadow: 0 0 0 2px rgba(7, 192, 95, 0.1);
-  }
-}
-
-.engine-info-block .doc-link {
-  margin-left: 4px;
-  font-size: 13px;
-}
-
-.engine-form {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
+// fallback：首字母 monogram
+.header-icon__text {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
 .form-item {
-  margin-bottom: 20px;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
+  margin-bottom: 0;
 }
 
 .form-label {
   display: block;
-  margin-bottom: 8px;
-  font-size: 14px;
+  margin-bottom: 6px;
+  font-size: 13px;
   font-weight: 500;
   color: var(--td-text-color-primary);
+  line-height: 1.4;
 
-  &.required::after {
+  // 必填星号前置（与 ModelEditorDialog 一致）
+  &.required::before {
     content: '*';
     color: var(--td-error-color);
-    margin-left: 4px;
-    font-weight: 600;
+    margin-right: 4px;
+    font-weight: 500;
+    line-height: 1;
   }
 }
 
-.form-item--inline {
-  display: flex;
+.form-desc {
+  margin: 4px 0 0 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--td-text-color-placeholder);
+
+  &--inline {
+    margin: 0;
+  }
+}
+
+:deep(.t-input),
+:deep(.t-select),
+:deep(.t-textarea),
+:deep(.t-input-number) {
+  width: 100%;
+  font-size: 13px;
+}
+
+// ---- MinIO 部署模式：紧凑 pill segmented（与 ModelEditorDialog 来源切换同款）----
+.source-options {
+  display: inline-flex;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 20px;
-
-  .form-label {
-    margin-bottom: 0;
-    flex-shrink: 0;
-  }
+  gap: 4px;
+  padding: 3px;
+  background: var(--td-bg-color-component);
+  border: 1px solid var(--td-component-stroke);
+  border-radius: 8px;
 }
 
-.mode-selector {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 20px;
-}
-
-.mode-option {
-  display: flex;
+.source-option {
+  display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 16px;
-  border: 1px solid var(--td-component-stroke);
+  padding: 5px 12px;
+  height: 28px;
+  background: transparent;
+  border: 1px solid transparent;
   border-radius: 6px;
   cursor: pointer;
-  transition: all 0.2s;
-  background: var(--td-bg-color-secondarycontainer);
-
-  &:hover {
-    border-color: var(--td-text-color-disabled);
-  }
-
-  &.active {
-    border-color: var(--td-brand-color);
-    background: rgba(7, 192, 95, 0.06);
-  }
-
-  .mode-label {
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--td-text-color-primary);
-  }
-}
-
-.engine-hint {
+  font-family: inherit;
   font-size: 13px;
   color: var(--td-text-color-secondary);
-  line-height: 1.6;
-  padding: 10px 14px;
-  margin-bottom: 16px;
-  border-radius: 6px;
-  background: var(--td-bg-color-secondarycontainer);
-  border: 1px solid var(--td-component-stroke);
+  line-height: 1;
+  transition: all 0.15s ease;
+
+  &:hover:not(.is-active) {
+    color: var(--td-text-color-primary);
+    background: var(--td-bg-color-container-hover);
+  }
+
+  &.is-active {
+    background: var(--td-bg-color-container);
+    border-color: var(--td-brand-color);
+    color: var(--td-brand-color);
+    font-weight: 500;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  }
+}
+
+.source-option__icon {
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.source-option__label {
+  white-space: nowrap;
+}
+
+// ---- inline-alert（与 ParserEngineSettings 同款，瘦身的状态行） ----
+.inline-alert {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--td-text-color-secondary);
+  flex-wrap: wrap;
+}
+
+.inline-alert__icon {
+  font-size: 15px;
+  flex-shrink: 0;
+  color: var(--td-text-color-placeholder);
+}
+
+.inline-alert--ok .inline-alert__icon {
+  color: var(--td-success-color);
+}
+
+.inline-alert--warn {
+  color: var(--td-text-color-primary);
+
+  .inline-alert__icon {
+    color: var(--td-warning-color, #f97316);
+  }
+}
+
+.inline-alert__text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+// ---- vision-toggle（switch + 行内描述）----
+.vision-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+// ---- footer-left 测试连接消息（与 ModelEditorDialog 同款） ----
+.footer-test-message {
+  font-size: 12px;
+  line-height: 1.4;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
   &.success {
-    color: var(--td-text-color-primary);
-    background: var(--td-success-color-light);
-    border-color: var(--td-success-color-focus);
+    color: var(--td-brand-color-active);
   }
 
-  &.warning {
-    color: var(--td-text-color-primary);
-    background: var(--td-warning-color-light);
-    border-color: var(--td-warning-color-focus);
+  &.error {
+    color: var(--td-error-color);
+  }
+
+  &.created {
+    color: var(--td-warning-color, #f97316);
   }
 }
 
-.drawer-actions {
-  display: flex;
+.status-icon {
+  font-size: 16px;
+  flex-shrink: 0;
+
+  &.available {
+    color: var(--td-brand-color);
+  }
+
+  &.unavailable {
+    color: var(--td-error-color);
+  }
+}
+
+// ---- 文档外链 ----
+.doc-link {
+  display: inline-flex;
   align-items: center;
-  margin-top: 16px;
-  padding-top: 16px;
-  border-top: 1px dashed var(--td-component-stroke);
-}
+  gap: 4px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--td-brand-color);
+  text-decoration: none;
+  transition: color 0.15s ease;
 
-.api-test-section {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-
-  .test-message {
-    font-size: 13px;
-    line-height: 1.5;
-    flex: 1;
-
-    &.success {
-      color: var(--td-brand-color-active);
-    }
-
-    &.error {
-      color: var(--td-error-color);
-    }
-
-    &.created {
-      color: var(--td-warning-color);
-    }
+  &:hover {
+    color: var(--td-brand-color-active);
   }
 
-  :deep(.t-button) {
-    min-width: 88px;
-    height: 32px;
-    font-size: 13px;
-    border-radius: 6px;
-    flex-shrink: 0;
-  }
-}
-
-.drawer-footer-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 12px;
-  width: 100%;
-
-  :deep(.t-button) {
-    min-width: 80px;
-    height: 36px;
-    font-weight: 500;
+  .link-icon {
     font-size: 14px;
-    border-radius: 6px;
-    transition: all 0.15s ease;
+  }
 
-    &.t-button--variant-outline {
-      color: var(--td-text-color-secondary);
-      border-color: var(--td-component-stroke);
+  &--inline {
+    margin-left: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    vertical-align: baseline;
 
-      &:hover {
-        border-color: var(--td-brand-color);
-        color: var(--td-brand-color);
-        background: rgba(7, 192, 95, 0.04);
-      }
+    .link-icon {
+      font-size: 12px;
     }
   }
 }
@@ -1510,5 +1626,61 @@ onMounted(loadAll)
   &.error {
     color: var(--td-error-color);
   }
+}
+</style>
+
+<!--
+  Non-scoped block: per-engine header icon coloring. The drawer panel is
+  rendered into the component tree (no teleport since attach is unset),
+  but TDesign's t-drawer can in some builds reuse a shared root that
+  drops scoped data attributes — keep these rules global so the mapping
+  always lands. Namespaced under .storage-engine-drawer--{id} so it
+  cannot bleed into other consumers of SettingDrawer.
+
+  Each rule mirrors the matching .engine-card--{id} .engine-card__badge
+  background + color pair from the scoped block above, so the list-card
+  → drawer hand-off is visually continuous.
+-->
+<style lang="less">
+// 当抽屉里渲染了彩色 logo（如 MinIO/AWS）时，给 header-icon 容器一个白底
+// + 细边，避免品牌色浅底盖在彩色图标上影响对比度。
+.storage-engine-drawer .setting-drawer__header-icon:has(.header-icon__img) {
+  background: var(--td-bg-color-container, #fff);
+  box-shadow: inset 0 0 0 1px var(--td-component-stroke);
+}
+
+// 单色 logo / 首字母 fallback 的徽章配色 — 与列表卡片 .engine-card--{id}
+// .engine-card__badge 完全一致。
+.storage-engine-drawer--local .setting-drawer__header-icon {
+  background: rgba(70, 70, 70, 0.1);
+  color: #464646;
+}
+.storage-engine-drawer--minio .setting-drawer__header-icon {
+  background: rgba(225, 38, 38, 0.12);
+  color: #C0382B;
+}
+.storage-engine-drawer--cos .setting-drawer__header-icon {
+  background: rgba(0, 82, 217, 0.1);
+  color: #0052D9;
+}
+.storage-engine-drawer--tos .setting-drawer__header-icon {
+  background: rgba(0, 137, 255, 0.12);
+  color: #0089FF;
+}
+.storage-engine-drawer--s3 .setting-drawer__header-icon {
+  background: rgba(255, 153, 0, 0.12);
+  color: #D97706;
+}
+.storage-engine-drawer--oss .setting-drawer__header-icon {
+  background: rgba(255, 90, 0, 0.12);
+  color: #E55A00;
+}
+.storage-engine-drawer--ks3 .setting-drawer__header-icon {
+  background: rgba(7, 192, 95, 0.12);
+  color: #07A050;
+}
+.storage-engine-drawer--obs .setting-drawer__header-icon {
+  background: rgba(206, 17, 38, 0.1);
+  color: #CE1126;
 }
 </style>

--- a/frontend/src/views/settings/TenantInfo.vue
+++ b/frontend/src/views/settings/TenantInfo.vue
@@ -176,8 +176,9 @@
           <div class="setting-control">
             <div class="usage-control">
               <span class="usage-text">{{ getUsagePercentage() }}%</span>
+              <!-- t-progress: theme = 形态（line/plump/circle）；颜色用 status -->
               <t-progress :percentage="getUsagePercentage()" :show-info="false" size="small"
-                :theme="getUsagePercentage() > 80 ? 'warning' : 'success'" style="flex: 1;" />
+                :status="getUsagePercentage() > 80 ? 'warning' : 'success'" style="flex: 1;" />
             </div>
           </div>
         </div>

--- a/frontend/src/views/settings/VectorStoreSettings.vue
+++ b/frontend/src/views/settings/VectorStoreSettings.vue
@@ -54,15 +54,12 @@
                   <span v-if="store.source === 'env'" class="store-card__pill">
                     {{ t('vectorStoreSettings.envTag') }}
                   </span>
-                  <!-- 测试连接收进三点菜单，结果走 MessagePlugin toast；测试中卡片标题
-                       右侧用一个小 spinner 给出进度反馈，避免菜单已经关掉后没有可见状态。 -->
-                  <t-loading
-                    v-if="testingId === store.id"
-                    size="14px"
-                    class="store-card__loading"
-                  />
+                  <!--
+                    测试连接已挪到编辑抽屉的 footer，外层菜单不再有"测试"入口。
+                    env 来源（.env 写入）也不需要 dropdown — 没有可执行的动作。
+                  -->
                   <t-dropdown
-                    v-if="authStore.hasRole('admin')"
+                    v-if="authStore.hasRole('admin') && storeActionsFor(store).length > 0"
                     :options="storeActionsFor(store)"
                     placement="bottom-right"
                     attach="body"
@@ -93,22 +90,87 @@
       </div>
     </template>
 
-    <!-- Add/Edit Dialog -->
-    <t-dialog
+    <!-- Add/Edit Drawer — 与 ModelEditorDialog/Storage/Parser/WebSearch 同款 -->
+    <SettingDrawer
       v-model:visible="showDialog"
-      :header="editingStore ? t('vectorStoreSettings.editStore') : t('vectorStoreSettings.addStore')"
-      width="580px"
-      placement="center"
-      :footer="false"
-      destroy-on-close
+      :title="editingStore ? t('vectorStoreSettings.editStore') : t('vectorStoreSettings.addStore')"
+      :class="drawerClass"
+      :confirm-loading="saving"
+      @confirm="onDrawerConfirm"
+      @cancel="showDialog = false"
     >
-      <div class="dialog-form-container">
-        <!-- Edit Mode: immutable info banner + readonly fields -->
-        <template v-if="editingStore">
-          <div class="immutable-notice">
-            <t-icon name="info-circle" size="14px" />
-            <span>{{ t('vectorStoreSettings.immutableNotice') }}</span>
+      <!--
+        Header icon — 与列表 .store-card__badge 同款 logo/mono/fallback。
+        per-engine 配色由非 scoped 块的 .vectorstore-drawer--{engine} 注入。
+      -->
+      <template v-if="form.engine_type" #headerIcon>
+        <img
+          v-if="drawerLogo?.mode === 'color'"
+          :src="drawerLogo.url"
+          :alt="form.engine_type"
+          class="header-icon__img"
+        />
+        <span
+          v-else-if="drawerLogo?.mode === 'mono'"
+          class="header-icon__mono"
+          :style="drawerLogoStyle"
+        />
+        <span v-else class="header-icon__text">{{ engineInitial(form.engine_type) }}</span>
+      </template>
+
+      <!-- 副标题：engine display_name -->
+      <template v-if="selectedType" #subtitle>
+        <span>{{ selectedType.display_name || form.engine_type }}</span>
+      </template>
+
+      <!--
+        Test connection (footer-left). create 模式：实时验证当前表单的连接信息；
+        edit 模式：用存储的连接配置（连接配置在编辑模式不可改 — engine 是 immutable）。
+        始终显示按钮，由 canTestConnection 控制 disabled。
+      -->
+      <template #footer-left>
+        <t-button
+          variant="outline"
+          :loading="testing"
+          :disabled="!canTestConnection"
+          @click="onDrawerTest"
+        >
+          <template #icon>
+            <t-icon
+              v-if="!testing && lastTestOk === true"
+              name="check-circle-filled"
+              class="status-icon available"
+            />
+            <t-icon
+              v-else-if="!testing && lastTestOk === false"
+              name="close-circle-filled"
+              class="status-icon unavailable"
+            />
+          </template>
+          {{ testing ? t('vectorStoreSettings.testing') : t('vectorStoreSettings.testConnection') }}
+        </t-button>
+      </template>
+
+      <t-form ref="formRef" :data="form" :rules="formRules" label-align="top" class="store-form">
+        <!--
+          Edit 模式特殊提示：engine_type / connection_config / index_config
+          创建后不可改，仅 name 可编辑。用 inline-alert 而不是大块 banner，
+          视觉与其他抽屉的提示一致。
+        -->
+        <section v-if="editingStore" class="setting-drawer__section">
+          <h4 class="setting-drawer__section-title">{{ t('vectorStoreSettings.basicSection', '基本信息') }}</h4>
+
+          <div class="inline-alert inline-alert--info">
+            <t-icon name="info-circle-filled" class="inline-alert__icon" />
+            <span class="inline-alert__text">{{ t('vectorStoreSettings.immutableNotice') }}</span>
           </div>
+
+          <div class="form-item">
+            <label class="form-label required">{{ t('vectorStoreSettings.nameLabel') }}</label>
+            <t-input v-model="form.name" :placeholder="t('vectorStoreSettings.namePlaceholder')" />
+          </div>
+
+          <!-- 只读字段以 inline list 展示（轻量 readonly 行） -->
           <div class="readonly-fields">
             <div class="readonly-row">
               <span class="readonly-label">{{ t('vectorStoreSettings.engineTypeLabel') }}</span>
@@ -118,7 +180,9 @@
               <template v-for="field in selectedType.connection_fields" :key="field.name">
                 <div v-if="field.sensitive || form.connection_config[field.name]" class="readonly-row">
                   <span class="readonly-label">{{ fieldLabel(field.name) }}</span>
-                  <span class="readonly-value">{{ field.sensitive ? '********' : form.connection_config[field.name] }}</span>
+                  <span class="readonly-value">
+                    {{ field.sensitive ? '********' : form.connection_config[field.name] }}
+                  </span>
                 </div>
               </template>
             </template>
@@ -131,14 +195,16 @@
               </template>
             </template>
           </div>
-          <div class="form-divider"></div>
-        </template>
+        </section>
 
-        <t-form :data="form" :rules="formRules" label-align="top" @submit="saveStore" class="store-form">
-          <div class="form-scroll-area">
-          <!-- Create Mode: engine type + connection fields -->
-          <template v-if="!editingStore">
-            <t-form-item :label="t('vectorStoreSettings.engineTypeLabel')" name="engine_type">
+        <!-- Create 模式：基本信息 + 连接配置 + 高级索引 三段 -->
+        <template v-else>
+          <!-- Section 1 — 基本信息：engine 类型 + 名称 -->
+          <section class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ t('vectorStoreSettings.basicSection', '基本信息') }}</h4>
+
+            <div class="form-item">
+              <label class="form-label required">{{ t('vectorStoreSettings.engineTypeLabel') }}</label>
               <t-select v-model="form.engine_type" @change="onEngineTypeChange">
                 <t-option
                   v-for="st in storeTypes"
@@ -147,122 +213,129 @@
                   :label="st.display_name"
                 />
               </t-select>
-            </t-form-item>
-          </template>
+            </div>
 
-          <!-- Name (always editable) -->
-          <t-form-item :label="t('vectorStoreSettings.nameLabel')" name="name">
-            <t-input v-model="form.name" :placeholder="t('vectorStoreSettings.namePlaceholder')" />
-          </t-form-item>
+            <div class="form-item">
+              <label class="form-label required">{{ t('vectorStoreSettings.nameLabel') }}</label>
+              <t-input v-model="form.name" :placeholder="t('vectorStoreSettings.namePlaceholder')" />
+            </div>
+          </section>
 
-          <!-- Create Mode: connection fields -->
-          <template v-if="!editingStore && selectedType">
-            <div class="form-divider"></div>
-            <div class="form-section-label">{{ t('vectorStoreSettings.connectionInfo') }}</div>
+          <!-- Section 2 — 连接配置（engine type 决定具体字段） -->
+          <section v-if="selectedType" class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ t('vectorStoreSettings.connectionInfo') }}</h4>
 
-            <template v-for="field in selectedType.connection_fields" :key="field.name">
-              <t-form-item
-                :label="fieldLabel(field.name)"
-                :name="`connection_config.${field.name}`"
-              >
-                <div v-if="field.type === 'boolean'" class="boolean-field">
+            <div
+              v-for="field in selectedType.connection_fields"
+              :key="field.name"
+              class="form-item"
+            >
+              <label
+                class="form-label"
+                :class="{ required: field.required }"
+              >{{ fieldLabel(field.name) }}</label>
+
+              <!-- boolean 字段：switch + 行内描述 / TLS 警告 -->
+              <template v-if="field.type === 'boolean'">
+                <div class="vision-toggle">
                   <t-switch v-model="form.connection_config[field.name]" />
-                  <div
-                    v-if="field.name === 'insecure_skip_verify' && form.connection_config[field.name]"
-                    class="field-warning"
-                  >
-                    {{ t('vectorStoreSettings.insecureSkipVerifyWarning') }}
-                  </div>
                 </div>
+                <p
+                  v-if="field.name === 'insecure_skip_verify' && form.connection_config[field.name]"
+                  class="form-desc form-desc--warn"
+                >
+                  {{ t('vectorStoreSettings.insecureSkipVerifyWarning') }}
+                </p>
+              </template>
+
+              <!-- 敏感字段（password / api key 等）：lock prefix + password -->
+              <t-input
+                v-else-if="field.type === 'string' && field.sensitive"
+                v-model="form.connection_config[field.name]"
+                type="password"
+                placeholder="********"
+              >
+                <template #prefix-icon><t-icon name="lock-on" /></template>
+              </t-input>
+
+              <!-- 数字字段：用 t-input + type=number，与 MCP 高级配置同款；无单位提示 -->
+              <t-input
+                v-else-if="field.type === 'number'"
+                v-model="connectionNumberTextProxy[field.name].value"
+                type="number"
+                :placeholder="field.default != null ? String(field.default) : ' '"
+                class="number-input"
+              />
+
+              <!-- 普通字符串 -->
+              <t-input
+                v-else
+                v-model="form.connection_config[field.name]"
+                :placeholder="field.default?.toString() || ''"
+              />
+            </div>
+          </section>
+
+          <!-- Section 3 — 高级索引（仅 selectedType 有 index_fields 时显示） -->
+          <section v-if="selectedType?.index_fields?.length" class="setting-drawer__section">
+            <h4 class="setting-drawer__section-title">{{ t('vectorStoreSettings.advancedIndexConfig') }}</h4>
+
+            <!-- 折叠/展开开关：保留之前的可选展示行为，但样式更轻量 -->
+            <button
+              type="button"
+              class="advanced-toggle"
+              @click="showAdvanced = !showAdvanced"
+            >
+              <t-icon :name="showAdvanced ? 'chevron-down' : 'chevron-right'" />
+              <span>{{ showAdvanced ? t('common.collapse', '收起') : t('common.expand', '展开') }}</span>
+            </button>
+
+            <template v-if="showAdvanced">
+              <div
+                v-for="field in selectedType.index_fields"
+                :key="field.name"
+                class="form-item"
+              >
+                <label class="form-label">{{ fieldLabel(field.name) }}</label>
+
+                <!-- 枚举 → 下拉 -->
+                <t-select
+                  v-if="field.enum && field.enum.length"
+                  v-model="form.index_config[field.name]"
+                  :placeholder="field.default?.toString() || ''"
+                >
+                  <t-option v-for="opt in field.enum" :key="opt" :value="opt" :label="opt" />
+                </t-select>
+
+                <!-- 数字 → number input -->
                 <t-input
-                  v-else-if="field.type === 'string' && field.sensitive"
-                  v-model="form.connection_config[field.name]"
-                  type="password"
-                  placeholder="********"
-                />
-                <t-input-number
                   v-else-if="field.type === 'number'"
-                  v-model="form.connection_config[field.name]"
-                  :placeholder="field.default != null ? String(field.default) : ' '"
-                  theme="normal"
-                  style="width: 100%;"
+                  v-model="indexNumberTextProxy[field.name].value"
+                  type="number"
+                  :placeholder="field.default?.toString()"
+                  :min="field.min ?? 1"
+                  :max="field.max ?? (isReplicaField(field.name) ? 10 : 64)"
+                  class="number-input"
                 />
+
+                <!-- 字符串 -->
                 <t-input
                   v-else
-                  v-model="form.connection_config[field.name]"
+                  v-model="form.index_config[field.name]"
                   :placeholder="field.default?.toString() || ''"
+                  :maxlength="128"
                 />
-              </t-form-item>
-            </template>
-
-            <!-- Advanced: index fields -->
-            <template v-if="selectedType.index_fields?.length">
-              <div class="form-divider"></div>
-              <div class="advanced-toggle" @click="showAdvanced = !showAdvanced">
-                <t-icon :name="showAdvanced ? 'chevron-down' : 'chevron-right'" size="14px" />
-                <span>{{ t('vectorStoreSettings.advancedIndexConfig') }}</span>
               </div>
-
-              <template v-if="showAdvanced">
-                <template v-for="field in selectedType.index_fields" :key="field.name">
-                  <t-form-item :label="fieldLabel(field.name)" :name="`index_config.${field.name}`">
-                    <!-- Closed value set → dropdown (e.g. knn_engine) -->
-                    <t-select
-                      v-if="field.enum && field.enum.length"
-                      v-model="form.index_config[field.name]"
-                      :placeholder="field.default?.toString() || ''"
-                    >
-                      <t-option v-for="opt in field.enum" :key="opt" :value="opt" :label="opt" />
-                    </t-select>
-                    <t-input-number
-                      v-else-if="field.type === 'number'"
-                      v-model="form.index_config[field.name]"
-                      :placeholder="field.default?.toString()"
-                      :min="field.min ?? 1"
-                      :max="field.max ?? (isReplicaField(field.name) ? 10 : 64)"
-                      theme="normal"
-                      style="width: 100%;"
-                    />
-                    <t-input
-                      v-else
-                      v-model="form.index_config[field.name]"
-                      :placeholder="field.default?.toString() || ''"
-                      :maxlength="128"
-                    />
-                  </t-form-item>
-                </template>
-              </template>
             </template>
-          </template>
-
-          </div><!-- /.form-scroll-area -->
-
-          <!-- Dialog Footer (outside scroll area) -->
-          <div class="dialog-footer">
-            <div class="footer-left">
-              <t-button
-                v-if="!editingStore"
-                theme="default"
-                variant="outline"
-                :loading="testing"
-                @click="testFromDialog"
-              >
-                {{ testing ? t('vectorStoreSettings.testing') : t('vectorStoreSettings.testConnection') }}
-              </t-button>
-            </div>
-            <div class="footer-right">
-              <t-button theme="default" variant="base" @click="showDialog = false">{{ t('common.cancel') }}</t-button>
-              <t-button theme="primary" type="submit" :loading="saving">{{ t('common.save') }}</t-button>
-            </div>
-          </div>
-        </t-form>
-      </div>
-    </t-dialog>
+          </section>
+        </template>
+      </t-form>
+    </SettingDrawer>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch, type WritableComputedRef } from 'vue'
 import { MessagePlugin, DialogPlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
 import { AddIcon } from 'tdesign-icons-vue-next'
@@ -273,12 +346,12 @@ import {
   updateVectorStore,
   deleteVectorStore as deleteVectorStoreAPI,
   testVectorStoreRaw,
-  testVectorStoreById,
   type VectorStoreEntity,
   type VectorStoreTypeInfo,
 } from '@/api/vector-store'
 import { useAuthStore } from '@/stores/auth'
 import { providerLogo } from './providerLogos'
+import SettingDrawer from '@/components/settings/SettingDrawer.vue'
 
 const { t } = useI18n()
 const authStore = useAuthStore()
@@ -290,9 +363,9 @@ const loading = ref(false)
 const showDialog = ref(false)
 const editingStore = ref<VectorStoreEntity | null>(null)
 const testing = ref(false)
-const testingId = ref<string | null>(null)
 const saving = ref(false)
 const showAdvanced = ref(false)
+const formRef = ref<any>()
 
 const form = ref<{
   name: string
@@ -306,22 +379,66 @@ const form = ref<{
   index_config: {},
 })
 
+// Tri-state hint icon next to the test button: null=neutral, true=just
+// succeeded, false=just failed. Cleared when the user changes any
+// connection-relevant field so a stale ✓/✗ doesn't follow a config the
+// user is still editing.
+const lastTestOk = ref<boolean | null>(null)
+
+watch(
+  () => [form.value.engine_type, form.value.connection_config],
+  () => { lastTestOk.value = null },
+  { deep: true },
+)
+
 // ===== Computed =====
 const envStores = computed(() => stores.value.filter(s => s.source === 'env'))
 const userStores = computed(() => stores.value.filter(s => s.source === 'user'))
 const selectedType = computed(() => storeTypes.value.find(st => st.type === form.value.engine_type))
 
-// Per-store dropdown options. env 来源是 .env 写入的，UI 不允许 edit / delete，
-// 但仍然需要一个"测试连接"入口；user 来源叠加 edit / delete。
-const storeActionsFor = (store: VectorStoreEntity) => {
-  const actions: Array<{ content: string; value: string; theme?: 'error' }> = [
-    { content: t('vectorStoreSettings.testConnection'), value: 'test' },
-  ]
-  if (store.source !== 'env') {
-    actions.push({ content: t('common.edit'), value: 'edit' })
-    actions.push({ content: t('common.delete'), value: 'delete', theme: 'error' })
+// Drawer header logo — 与列表 .store-card__badge 同源（providerLogo()），让
+// 列表卡 → 抽屉 hand-off 视觉连贯。
+const drawerLogo = computed(() => {
+  if (!form.value.engine_type) return null
+  return providerLogo('vectorstore', form.value.engine_type)
+})
+
+const drawerLogoStyle = computed((): Record<string, string> => {
+  const logo = drawerLogo.value
+  if (!logo || logo.mode !== 'mono') return {}
+  return { '--logo-url': `url("${logo.url}")` }
+})
+
+// per-engine class on drawer for non-scoped header-icon coloring rules.
+const drawerClass = computed(() => {
+  return form.value.engine_type
+    ? `vectorstore-drawer vectorstore-drawer--${form.value.engine_type}`
+    : 'vectorstore-drawer'
+})
+
+// 测试连接是否可点。create 模式：必须填全所有 required 连接字段；
+// edit 模式：engine 不可改、连接配置只读，禁用测试（要重新建条目，不在抽屉里测）。
+const canTestConnection = computed(() => {
+  if (editingStore.value) return false
+  const st = selectedType.value
+  if (!st) return false
+  for (const f of st.connection_fields) {
+    if (!f.required) continue
+    const v = form.value.connection_config[f.name]
+    if (v == null || v === '' || (typeof v === 'string' && v.trim() === '')) return false
   }
-  return actions
+  return true
+})
+
+// Per-store dropdown options. env 来源由 .env 写入，UI 不允许 edit / delete；
+// 测试连接已挪到编辑抽屉的 footer，外层菜单不再露出"测试"项。env 来源没有
+// 编辑/删除入口 → 整个 dropdown 都不需要展示。
+const storeActionsFor = (store: VectorStoreEntity) => {
+  if (store.source === 'env') return []
+  return [
+    { content: t('common.edit'), value: 'edit' },
+    { content: t('common.delete'), value: 'delete', theme: 'error' as const },
+  ]
 }
 
 const formRules = computed(() => {
@@ -403,7 +520,53 @@ const onEngineTypeChange = () => {
   form.value.connection_config = {}
   form.value.index_config = {}
   showAdvanced.value = false
+  // Drop cached number-text proxies so a switch to a different engine
+  // doesn't keep stale entries pointing at the old field set.
+  for (const k of Object.keys(connectionNumberText)) delete connectionNumberText[k]
+  for (const k of Object.keys(indexNumberText)) delete indexNumberText[k]
 }
+
+// ---- Number-input text proxies (lazy per field name) ----
+// type=number 输入会因为 v-model 把空字符串 coerce 成 0 / NaN，导致
+// "用户清空 → 自动塞回 0" 的烦躁交互。我们用 WritableComputedRef 包一层：
+// 读取时把数字转成字符串展示；写入时空串 → 删除字段（让 placeholder 显示
+// 出来），非空 → 转 int。Proxy 按字段名按需创建并缓存，避免重复 computed。
+const connectionNumberText: Record<string, WritableComputedRef<string>> = {}
+const indexNumberText: Record<string, WritableComputedRef<string>> = {}
+
+function ensureNumberProxy(
+  bag: Record<string, WritableComputedRef<string>>,
+  store: Record<string, any>,
+  key: string,
+): WritableComputedRef<string> {
+  if (bag[key]) return bag[key]
+  bag[key] = computed<string>({
+    get: () => {
+      const v = store[key]
+      return v == null || v === '' ? '' : String(v)
+    },
+    set: (raw: string) => {
+      const s = String(raw ?? '').trim()
+      if (!s) {
+        delete store[key]
+        return
+      }
+      const n = Number(s)
+      store[key] = Number.isFinite(n) ? n : s
+    },
+  })
+  return bag[key]
+}
+
+// Vue templates can't call ensureNumberProxy on every render without the
+// keys multiplying — wrap in a Proxy so `connectionNumberText[name].value`
+// from the template lazily creates the proxy on first read.
+const connectionNumberTextProxy = new Proxy(connectionNumberText, {
+  get: (target, name: string) => ensureNumberProxy(target, form.value.connection_config, name),
+})
+const indexNumberTextProxy = new Proxy(indexNumberText, {
+  get: (target, name: string) => ensureNumberProxy(target, form.value.index_config, name),
+})
 
 const loadStores = async () => {
   try {
@@ -433,6 +596,7 @@ const openAddDialog = () => {
     connection_config: {},
     index_config: {},
   }
+  lastTestOk.value = null
   showDialog.value = true
 }
 
@@ -445,12 +609,21 @@ const editStore = (store: VectorStoreEntity) => {
     connection_config: { ...store.connection_config },
     index_config: { ...store.index_config },
   }
+  lastTestOk.value = null
   showDialog.value = true
 }
 
-const saveStore = async ({ validateResult, firstError }: any) => {
-  if (validateResult !== true && validateResult !== undefined) {
-    MessagePlugin.warning(firstError || t('vectorStoreSettings.toasts.errorGeneric'))
+// SettingDrawer 的"保存"按钮触发：手动校验后写后端。
+// edit 模式只能改 name；create 模式提交完整 connection / index 配置。
+const onDrawerConfirm = async () => {
+  const result = await formRef.value?.validate()
+  if (result !== true && result !== undefined) {
+    // 取第一条错误展示
+    const firstError =
+      typeof result === 'object'
+        ? Object.values(result).map((errs: any) => Array.isArray(errs) ? errs[0]?.message : '').find(Boolean)
+        : ''
+    MessagePlugin.warning(firstError || (t('vectorStoreSettings.toasts.errorGeneric') as string))
     return
   }
 
@@ -484,9 +657,8 @@ const saveStore = async ({ validateResult, firstError }: any) => {
 }
 
 const handleAction = (action: { value: string }, store: VectorStoreEntity) => {
-  if (action.value === 'test') {
-    testExisting(store)
-  } else if (action.value === 'edit') {
+  // test 已挪到抽屉，外层菜单不再处理 'test' 值。
+  if (action.value === 'edit') {
     editStore(store)
   } else if (action.value === 'delete') {
     confirmDelete(store)
@@ -512,23 +684,10 @@ const confirmDelete = (store: VectorStoreEntity) => {
   })
 }
 
-const testExisting = async (store: VectorStoreEntity) => {
-  testingId.value = store.id!
-  try {
-    const res = await testVectorStoreById(store.id!)
-    if (res.success) {
-      MessagePlugin.success(t('vectorStoreSettings.toasts.testSuccess'))
-    } else {
-      MessagePlugin.error(res.error || t('vectorStoreSettings.toasts.testFailed'))
-    }
-  } catch (error: any) {
-    MessagePlugin.error(error?.message || t('vectorStoreSettings.toasts.testFailed'))
-  } finally {
-    testingId.value = null
-  }
-}
-
-const testFromDialog = async () => {
+// 测试连接（在抽屉内触发）。create 模式下用当前表单数据，调
+// /test/raw 端点。edit 模式按钮 disabled，所以这里只处理 create 路径。
+const onDrawerTest = async () => {
+  if (editingStore.value) return
   testing.value = true
   try {
     const data = {
@@ -536,12 +695,14 @@ const testFromDialog = async () => {
       connection_config: { ...form.value.connection_config },
     }
     const res = await testVectorStoreRaw(data)
+    lastTestOk.value = !!res.success
     if (res.success) {
       MessagePlugin.success(t('vectorStoreSettings.toasts.testSuccess'))
     } else {
       MessagePlugin.error(res.error || t('vectorStoreSettings.toasts.testFailed'))
     }
   } catch (error: any) {
+    lastTestOk.value = false
     MessagePlugin.error(error?.message || t('vectorStoreSettings.toasts.testFailed'))
   } finally {
     testing.value = false
@@ -776,12 +937,6 @@ onMounted(async () => {
   background: var(--td-warning-color-1, #FEF3E6);
 }
 
-// 测试中 spinner（toast 弹出前的进度反馈）
-.store-card__loading {
-  flex-shrink: 0;
-  color: var(--td-text-color-placeholder);
-}
-
 .store-card__more {
   flex-shrink: 0;
   color: var(--td-text-color-placeholder);
@@ -840,131 +995,249 @@ onMounted(async () => {
   font-size: 14px;
 }
 
-// Dialog
-.dialog-form-container {
-  margin-top: 12px;
-  display: flex;
-  flex-direction: column;
-  max-height: 70vh;
+// ---- 抽屉内容 — 与 ModelEditorDialog 同款约定 ----
+.form-item {
+  margin-bottom: 0;
 }
 
-.store-form {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
+.form-label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--td-text-color-primary);
+  line-height: 1.4;
+
+  &.required::before {
+    content: '*';
+    color: var(--td-error-color);
+    margin-right: 4px;
+    font-weight: 500;
+    line-height: 1;
+  }
 }
 
-.form-scroll-area {
-  flex: 1;
-  overflow-y: auto;
-  padding-right: 12px;
+.form-desc {
+  margin: 4px 0 0 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--td-text-color-placeholder);
+
+  &--inline { margin: 0; }
+
+  // TLS 警告等"危险确认"用红字
+  &--warn { color: var(--td-error-color); }
 }
 
-.immutable-notice {
+:deep(.t-input),
+:deep(.t-select),
+:deep(.t-textarea) {
+  width: 100%;
+  font-size: 13px;
+}
+
+// 隐藏 t-form 默认 form-item 容器 — 走自定义 .form-item / .form-label
+:deep(.t-form) .t-form-item {
+  display: none;
+}
+
+.vision-toggle {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
-  padding: 10px 14px;
-  margin-bottom: 16px;
-  background: rgba(7, 192, 95, 0.1);
-  border-radius: 6px;
+}
+
+// ---- inline alert（替代之前的 .immutable-notice 大块横幅） ----
+.inline-alert {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-size: 13px;
   line-height: 1.5;
-  color: var(--td-brand-color);
+  color: var(--td-text-color-secondary);
+  flex-wrap: wrap;
+
   white-space: pre-line;
+
+  &__icon {
+    font-size: 15px;
+    flex-shrink: 0;
+    color: var(--td-text-color-placeholder);
+  }
+
+  &__text {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  &--info {
+    color: var(--td-text-color-primary);
+
+    .inline-alert__icon { color: var(--td-brand-color); }
+  }
 }
 
-/* Wrap switch + warning in a vertical stack so the warning sits on its own
-   line below the switch, independent of TDesign's form-item content flex
-   (which is a nowrap row — margin-top alone has no visible effect there). */
-.boolean-field {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  width: 100%;
-}
-
-.field-warning {
-  margin-top: 8px;
-  font-size: 12px;
-  line-height: 1.4;
-  color: var(--td-error-color, #d54941);
-}
-
+// ---- 编辑模式只读字段列表（保持原有视觉，但去掉外框，紧贴 alert 下方）----
 .readonly-fields {
-  padding: 10px 14px;
+  padding: 10px 12px;
   background: var(--td-bg-color-secondarycontainer);
-  border-radius: 6px;
-  margin-bottom: 16px;
+  border-radius: 8px;
 }
 
 .readonly-row {
   display: flex;
   align-items: baseline;
   gap: 8px;
-  padding: 3px 0;
+  padding: 4px 0;
   font-size: 12px;
   line-height: 1.4;
   border-bottom: 1px solid var(--td-component-stroke);
 
-  &:last-child {
-    border-bottom: none;
-  }
+  &:last-child { border-bottom: none; }
 }
 
 .readonly-label {
   color: var(--td-text-color-placeholder);
   font-size: 11px;
   white-space: nowrap;
-  min-width: 60px;
+  min-width: 80px;
 }
 
 .readonly-value {
   color: var(--td-text-color-primary);
   font-size: 12px;
-  font-family: var(--app-font-family-mono);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
   word-break: break-all;
 }
 
-.form-divider {
-  height: 1px;
-  background: var(--td-component-border);
-  margin: 20px 0;
-}
-
-.form-section-label {
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--td-text-color-secondary);
-  margin-bottom: 12px;
-}
-
+// ---- 高级索引展开/收起按钮 ----
 .advanced-toggle {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
+  padding: 4px 0;
   font-size: 13px;
   color: var(--td-text-color-secondary);
+  background: transparent;
+  border: none;
+  font-family: inherit;
   cursor: pointer;
   user-select: none;
-  margin-bottom: 12px;
+  align-self: flex-start;
 
-  &:hover {
-    color: var(--td-brand-color);
+  &:hover { color: var(--td-brand-color); }
+
+  .t-icon { font-size: 14px; }
+}
+
+// ---- Number input：去原生 spinner（与 MCP 高级配置同款）----
+.number-input {
+  :deep(input::-webkit-outer-spin-button),
+  :deep(input::-webkit-inner-spin-button) {
+    -webkit-appearance: none;
+    appearance: none;
+    margin: 0;
+  }
+
+  :deep(input[type="number"]) {
+    -moz-appearance: textfield;
+    appearance: textfield;
   }
 }
 
-.dialog-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 32px;
-  padding-top: 20px;
-  border-top: 1px solid var(--td-component-border);
+// ---- Header 图标徽章 ----
+.header-icon__img {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  display: block;
+}
 
-  .footer-right {
-    display: flex;
-    gap: 12px;
-  }
+.header-icon__mono {
+  display: inline-block;
+  width: 22px;
+  height: 22px;
+  background-color: currentColor;
+  -webkit-mask-image: var(--logo-url);
+  -webkit-mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-image: var(--logo-url);
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: contain;
+}
+
+.header-icon__text {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+// ---- footer-left 测试按钮的状态 icon ----
+.status-icon {
+  font-size: 16px;
+  flex-shrink: 0;
+
+  &.available { color: var(--td-brand-color); }
+  &.unavailable { color: var(--td-error-color); }
+}
+</style>
+
+<!--
+  Non-scoped block: per-engine header-icon coloring + color-logo background
+  tweak. Same pattern as Storage/Parser/WebSearch drawers — these rules
+  must be global so they reach the t-drawer panel even if its scoped
+  data-attribute is dropped in some builds. Each rule mirrors the matching
+  .store-card--{engine} .store-card__badge from the scoped block above so
+  list-card → drawer hand-off stays visually continuous.
+-->
+<style lang="less">
+// 彩色 logo 时给 header-icon 容器一个白底 + 1px 边
+.vectorstore-drawer .setting-drawer__header-icon:has(.header-icon__img) {
+  background: var(--td-bg-color-container, #fff);
+  box-shadow: inset 0 0 0 1px var(--td-component-stroke);
+}
+
+.vectorstore-drawer--qdrant .setting-drawer__header-icon {
+  background: rgba(225, 38, 38, 0.12);
+  color: #E12626;
+}
+.vectorstore-drawer--milvus .setting-drawer__header-icon {
+  background: rgba(0, 137, 255, 0.12);
+  color: #0089FF;
+}
+.vectorstore-drawer--weaviate .setting-drawer__header-icon {
+  background: rgba(7, 192, 95, 0.12);
+  color: #07A050;
+}
+.vectorstore-drawer--elasticsearch .setting-drawer__header-icon,
+.vectorstore-drawer--elasticfaiss .setting-drawer__header-icon {
+  background: rgba(255, 153, 0, 0.12);
+  color: #D97706;
+}
+.vectorstore-drawer--postgres .setting-drawer__header-icon {
+  background: rgba(0, 82, 217, 0.1);
+  color: #0052D9;
+}
+.vectorstore-drawer--opensearch .setting-drawer__header-icon {
+  background: rgba(98, 53, 187, 0.12);
+  color: #6235BB;
+}
+.vectorstore-drawer--infinity .setting-drawer__header-icon {
+  background: rgba(98, 53, 187, 0.12);
+  color: #6235BB;
+}
+.vectorstore-drawer--tencent_vectordb .setting-drawer__header-icon {
+  background: rgba(0, 82, 217, 0.1);
+  color: #0052D9;
+}
+.vectorstore-drawer--doris .setting-drawer__header-icon {
+  background: rgba(255, 90, 0, 0.12);
+  color: #E55A00;
+}
+.vectorstore-drawer--sqlite .setting-drawer__header-icon {
+  background: rgba(70, 70, 70, 0.1);
+  color: #464646;
 }
 </style>

--- a/frontend/src/views/settings/WebSearchSettings.vue
+++ b/frontend/src/views/settings/WebSearchSettings.vue
@@ -79,106 +79,202 @@
       </t-empty>
     </div>
 
-    <!-- Add/Edit Drawer -->
-    <SettingDrawer v-model:visible="showAddProviderDialog"
+    <!-- Add/Edit Drawer — 与 ModelEditorDialog / Parser / Storage 抽屉同款风格 -->
+    <SettingDrawer
+      v-model:visible="showAddProviderDialog"
       :title="editingProvider ? t('webSearchSettings.editProvider') : t('webSearchSettings.addProvider')"
-      :confirm-loading="saving" @confirm="saveProvider">
-      <t-form ref="formRef" :data="providerForm" label-align="top" class="provider-form">
-        <t-form-item :label="t('webSearchSettings.providerTypeLabel')" name="provider">
-          <t-select v-model="providerForm.provider" :disabled="!!editingProvider" @change="onProviderTypeChange">
-            <t-option v-for="pt in providerTypes" :key="pt.id" :value="pt.id" :label="pt.name">
-              <div class="provider-option">
-                <span>{{ pt.name }}</span>
-                <t-tag v-if="isProviderFree(pt)" theme="success" size="small" variant="light">
-                  {{ t('webSearchSettings.free') }}
-                </t-tag>
-              </div>
-            </t-option>
-          </t-select>
-        </t-form-item>
+      :class="drawerClass"
+      :confirm-loading="saving"
+      @confirm="saveProvider"
+    >
+      <!--
+        Header icon — 与列表 .provider-card__badge 同款 logo/mono/fallback。
+        - color logo（如 Bing/Google 彩色徽标）→ <img>，header 容器变白底 + 细边
+        - mono logo（mask-image）→ ::before-style span，currentColor 染色
+        - fallback：providerId 首字母 monogram
+      -->
+      <template v-if="selectedProviderType" #headerIcon>
+        <img
+          v-if="drawerLogo?.mode === 'color'"
+          :src="drawerLogo.url"
+          :alt="selectedProviderType.id"
+          class="header-icon__img"
+        />
+        <span
+          v-else-if="drawerLogo?.mode === 'mono'"
+          class="header-icon__mono"
+          :style="drawerLogoStyle"
+        />
+        <span v-else class="header-icon__text">{{ providerInitial(selectedProviderType.id) }}</span>
+      </template>
 
-        <t-form-item :label="t('webSearchSettings.providerNameLabel')" name="name">
-          <t-input v-model="providerForm.name"
-            :placeholder="selectedProviderType?.name || t('webSearchSettings.providerNamePlaceholder')" />
-        </t-form-item>
+      <!--
+        Subtitle: provider 类型名 + 官方文档外链（若有）。
+      -->
+      <template v-if="selectedProviderType" #subtitle>
+        <span>{{ selectedProviderType.name }}</span>
+        <a
+          v-if="selectedProviderType.docs_url"
+          :href="selectedProviderType.docs_url"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="doc-link doc-link--inline"
+        >
+          {{ t('webSearchSettings.viewDocs') }}
+          <t-icon name="link" class="link-icon" />
+        </a>
+      </template>
 
-        <t-form-item :label="t('webSearchSettings.providerDescLabel')" name="description">
-          <t-input v-model="providerForm.description" :placeholder="t('webSearchSettings.providerDescPlaceholder')" />
-        </t-form-item>
+      <!--
+        Test connection (footer-left, 与其他抽屉同款)。已经统一为唯一入口 —
+        外层卡片菜单不再露出"测试连接"，所有测试都从这里发起。
 
-        <template
-          v-if="selectedProviderType?.requires_api_key || selectedProviderType?.requires_engine_id || selectedProviderType?.requires_base_url">
-          <div class="form-divider"></div>
-
-          <div class="credentials-hint" v-if="selectedProviderType?.docs_url">
-            <a :href="selectedProviderType.docs_url" target="_blank" rel="noopener noreferrer" class="doc-link">
-              {{ t('webSearchSettings.viewDocs') }}
-              <t-icon name="link" class="link-icon" />
-            </a>
-          </div>
-
-          <t-form-item v-if="selectedProviderType?.requires_base_url" :label="t('webSearchSettings.baseUrlLabel')"
-            name="parameters.base_url">
-            <t-input v-model="providerForm.parameters.base_url"
-              :placeholder="t('webSearchSettings.baseUrlPlaceholder')" />
-          </t-form-item>
-          <!--
-            Edit mode: credential is managed by the shared <CredentialResource>
-            card via the /credentials subresource. Create mode keeps a plain
-            input so the initial api_key flows in with the first POST.
-
-            API key is mandatory for every requires_api_key=true provider
-            (validation in service/web_search_provider.go). The component's
-            "Remove" action is still available because a user might want to
-            rotate via remove + re-add, but in normal use they will use
-            "Replace" instead.
-          -->
-          <div v-if="selectedProviderType?.requires_api_key" class="credential-field">
-            <label class="credential-label">{{ t('webSearchSettings.apiKeyLabel') }}</label>
-            <CredentialResource v-if="editingProvider?.id" :api="credentialApi" :fields="credentialFields"
-              :meta="credentialMeta" />
-            <t-input v-else v-model="providerForm.parameters.api_key" type="password"
-              :placeholder="apiKeyPlaceholder" />
-          </div>
-          <t-form-item v-if="selectedProviderType?.requires_engine_id" :label="t('webSearchSettings.engineIdLabel')"
-            name="parameters.engine_id">
-            <t-input v-model="providerForm.parameters.engine_id" :placeholder="t('webSearchSettings.engineIdLabel')" />
-          </t-form-item>
-        </template>
-
-        <t-form-item v-if="selectedProviderType?.supports_proxy" :label="t('webSearchSettings.proxyUrlLabel')"
-          name="parameters.proxy_url">
-          <t-input v-model="providerForm.parameters.proxy_url"
-            :placeholder="t('webSearchSettings.proxyUrlPlaceholder')" />
-          <template #help>
-            <span class="switch-help">{{ t('webSearchSettings.proxyUrlHelp') }}</span>
+        全部 provider 都显示按钮（包括 DuckDuckGo / SearXNG 这些"免费"的）—
+        免费只是不要 api_key，不代表不需要测：DuckDuckGo 走外网可能被墙、
+        SearXNG 是自托管要验 base_url 可达性。disabled 由 canTestConnection
+        统一控制，缺哪个必填字段就置灰。
+      -->
+      <template v-if="selectedProviderType" #footer-left>
+        <t-button
+          variant="outline"
+          :loading="testing"
+          :disabled="!canTestConnection"
+          @click="testConnection"
+        >
+          <template #icon>
+            <t-icon
+              v-if="!testing && lastTestOk === true"
+              name="check-circle-filled"
+              class="status-icon available"
+            />
+            <t-icon
+              v-else-if="!testing && lastTestOk === false"
+              name="close-circle-filled"
+              class="status-icon unavailable"
+            />
           </template>
-        </t-form-item>
-
-        <div class="form-divider"></div>
-
-        <t-form-item :label="t('webSearchSettings.setAsDefault')" name="is_default">
-          <template #help>
-            <div class="switch-help">
-              {{ t('webSearchSettings.setAsDefaultDesc') }}
-            </div>
-          </template>
-          <t-switch v-model="providerForm.is_default" />
-        </t-form-item>
-      </t-form>
-
-      <template #footer-left>
-        <t-button v-if="selectedProviderType && !isProviderFree(selectedProviderType)" theme="default" variant="outline"
-          :loading="testing" @click="testConnection">
           {{ testing ? t('webSearchSettings.testing') : t('webSearchSettings.testConnection') }}
         </t-button>
       </template>
+
+      <t-form ref="formRef" :data="providerForm" label-align="top" class="provider-form">
+        <!-- Section 1 — 基本信息 -->
+        <section class="setting-drawer__section">
+          <h4 class="setting-drawer__section-title">{{ t('webSearchSettings.basicSection', '基本信息') }}</h4>
+
+          <!-- providerType 选择器：仅在新建时可改 -->
+          <div class="form-item">
+            <label class="form-label required">{{ t('webSearchSettings.providerTypeLabel') }}</label>
+            <t-select
+              v-model="providerForm.provider"
+              :disabled="!!editingProvider"
+              @change="onProviderTypeChange"
+            >
+              <!--
+                Just provider name in each option — we used to append a "免费"
+                t-tag for providers that don't take an api_key, but the
+                "免费"分类对用户决策没什么帮助（DuckDuckGo / SearXNG 也都
+                需要可用的网络/自托管实例），反而占视觉空间。
+              -->
+              <t-option v-for="pt in providerTypes" :key="pt.id" :value="pt.id" :label="pt.name" />
+            </t-select>
+          </div>
+
+          <div class="form-item">
+            <label class="form-label">{{ t('webSearchSettings.providerNameLabel') }}</label>
+            <t-input
+              v-model="providerForm.name"
+              :placeholder="selectedProviderType?.name || t('webSearchSettings.providerNamePlaceholder')"
+            />
+          </div>
+
+          <div class="form-item">
+            <label class="form-label">{{ t('webSearchSettings.providerDescLabel') }}</label>
+            <t-input
+              v-model="providerForm.description"
+              :placeholder="t('webSearchSettings.providerDescPlaceholder')"
+            />
+          </div>
+        </section>
+
+        <!-- Section 2 — 连接配置（base url / api key / engine id），仅当任意字段需要时渲染 -->
+        <section
+          v-if="selectedProviderType?.requires_api_key || selectedProviderType?.requires_engine_id || selectedProviderType?.requires_base_url"
+          class="setting-drawer__section"
+        >
+          <h4 class="setting-drawer__section-title">{{ t('webSearchSettings.credentialsSection', '连接配置') }}</h4>
+
+          <div v-if="selectedProviderType?.requires_base_url" class="form-item">
+            <label class="form-label required">{{ t('webSearchSettings.baseUrlLabel') }}</label>
+            <t-input
+              v-model="providerForm.parameters.base_url"
+              :placeholder="t('webSearchSettings.baseUrlPlaceholder')"
+            />
+          </div>
+
+          <!--
+            Edit 模式下凭证由 CredentialResource 管理（独立的 /credentials
+            子资源调用），不与本表单 submit 耦合；Create 模式下用 plain
+            password input + lock prefix-icon，与 ModelEditorDialog 一致。
+          -->
+          <div v-if="selectedProviderType?.requires_api_key" class="form-item">
+            <label class="form-label required">{{ t('webSearchSettings.apiKeyLabel') }}</label>
+            <CredentialResource
+              v-if="editingProvider?.id"
+              :api="credentialApi"
+              :fields="credentialFields"
+              :meta="credentialMeta"
+            />
+            <t-input
+              v-else
+              v-model="providerForm.parameters.api_key"
+              type="password"
+              :placeholder="apiKeyPlaceholder"
+            >
+              <template #prefix-icon><t-icon name="lock-on" /></template>
+            </t-input>
+          </div>
+
+          <div v-if="selectedProviderType?.requires_engine_id" class="form-item">
+            <label class="form-label required">{{ t('webSearchSettings.engineIdLabel') }}</label>
+            <t-input
+              v-model="providerForm.parameters.engine_id"
+              :placeholder="t('webSearchSettings.engineIdLabel')"
+            />
+          </div>
+        </section>
+
+        <!-- Section 3 — 选项（代理 / 默认） -->
+        <section
+          v-if="selectedProviderType?.supports_proxy || selectedProviderType"
+          class="setting-drawer__section"
+        >
+          <h4 class="setting-drawer__section-title">{{ t('webSearchSettings.optionsSection', '选项') }}</h4>
+
+          <div v-if="selectedProviderType?.supports_proxy" class="form-item">
+            <label class="form-label">{{ t('webSearchSettings.proxyUrlLabel') }}</label>
+            <t-input
+              v-model="providerForm.parameters.proxy_url"
+              :placeholder="t('webSearchSettings.proxyUrlPlaceholder')"
+            />
+            <p class="form-desc">{{ t('webSearchSettings.proxyUrlHelp') }}</p>
+          </div>
+
+          <div class="form-item">
+            <label class="form-label">{{ t('webSearchSettings.setAsDefault') }}</label>
+            <div class="vision-toggle">
+              <t-switch v-model="providerForm.is_default" />
+              <span class="form-desc form-desc--inline">{{ t('webSearchSettings.setAsDefaultDesc') }}</span>
+            </div>
+          </div>
+        </section>
+      </t-form>
     </SettingDrawer>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
 import { AddIcon } from 'tdesign-icons-vue-next'
@@ -214,9 +310,14 @@ const providerTypes = ref<WebSearchProviderTypeInfo[]>([])
 const showAddProviderDialog = ref(false)
 const editingProvider = ref<WebSearchProviderEntity | null>(null)
 const testing = ref(false)
-const testingId = ref<string | null>(null)
 const saving = ref(false)
 const formRef = ref<any>()
+
+// Tri-state hint icon next to the test button: null=neutral, true=just
+// succeeded, false=just failed. Cleared whenever the user changes the
+// underlying connection inputs (see watch() below, set up after providerForm
+// is initialized so the watch's source function doesn't trip on TDZ).
+const lastTestOk = ref<boolean | null>(null)
 
 const providerForm = ref<{
   name: string
@@ -231,6 +332,21 @@ const providerForm = ref<{
   parameters: {},
   is_default: false,
 })
+
+// Invalidate the cached test result whenever the user edits a connection
+// field. Set up after providerForm is declared so the watch's source
+// function — which dereferences providerForm.value on first run — doesn't
+// hit a TDZ ReferenceError. proxy_url is excluded because the upstream
+// call doesn't actually use it for credential validation.
+watch(
+  () => [
+    providerForm.value.provider,
+    providerForm.value.parameters?.api_key,
+    providerForm.value.parameters?.engine_id,
+    providerForm.value.parameters?.base_url,
+  ],
+  () => { lastTestOk.value = null },
+)
 
 // ===== Computed =====
 const selectedProviderType = computed(() => {
@@ -264,12 +380,42 @@ const credentialMeta = computed(() => editingProvider.value?.credentials ?? {
   api_key: { configured: false },
 })
 
-const isProviderFree = (providerType: WebSearchProviderTypeInfo) => {
-  // "Free" here means no upstream-paid credentials are required. Self-hosted
-  // providers (requires_base_url) are still free to use even though they need
-  // an instance URL, so they should keep the free badge.
-  return !providerType.requires_api_key && !providerType.requires_engine_id
-}
+// Per-provider class on the drawer — the non-scoped CSS block at the
+// bottom uses .websearch-drawer--{id} to color the header-icon container
+// to match the matching list-card badge.
+const drawerClass = computed(() => {
+  const id = providerForm.value.provider
+  return id
+    ? `websearch-drawer websearch-drawer--${id}`
+    : 'websearch-drawer'
+})
+
+// Reuses providerLogo() so the drawer header icon matches whatever the
+// list card showed for the same provider id.
+const drawerLogo = computed(() => {
+  const id = providerForm.value.provider
+  return id ? providerLogo('websearch', id) : null
+})
+
+const drawerLogoStyle = computed((): Record<string, string> => {
+  const logo = drawerLogo.value
+  if (!logo || logo.mode !== 'mono') return {}
+  return { '--logo-url': `url("${logo.url}")` }
+})
+
+// Whether "Test connection" can fire. New-mode requires the user to have
+// typed an api_key (and engine_id / base_url where applicable); edit-mode
+// can fire with no fresh api_key because the backend will fall back to
+// the stored credential. Free providers don't show the button at all.
+const canTestConnection = computed(() => {
+  const pt = selectedProviderType.value
+  if (!pt) return false
+  if (editingProvider.value) return true
+  if (pt.requires_api_key && !providerForm.value.parameters.api_key) return false
+  if (pt.requires_engine_id && !providerForm.value.parameters.engine_id) return false
+  if (pt.requires_base_url && !providerForm.value.parameters.base_url) return false
+  return true
+})
 
 // 卡片首字母徽章。复用 providerType 信息表，让多字节缩写也走同一处。
 const providerInitial = (providerId: string) => {
@@ -301,6 +447,7 @@ const providerTypeLabel = (providerId: string) => {
 // ===== Methods =====
 const onProviderTypeChange = () => {
   providerForm.value.parameters = {}
+  lastTestOk.value = null
 }
 
 const loadProviderEntities = async () => {
@@ -331,6 +478,7 @@ const openAddDialog = () => {
     parameters: {},
     is_default: providerEntities.value.length === 0
   }
+  lastTestOk.value = null
   showAddProviderDialog.value = true
 }
 
@@ -350,6 +498,7 @@ const editProvider = (entity: WebSearchProviderEntity) => {
     },
     is_default: entity.is_default || false,
   }
+  lastTestOk.value = null
   showAddProviderDialog.value = true
 }
 
@@ -422,8 +571,10 @@ const testConnection = async () => {
       parameters: { ...providerForm.value.parameters },
     }
 
+    let ok = false
     if (editingProvider.value && !data.parameters.api_key) {
       const res = await testWebSearchProvider(editingProvider.value.id!)
+      ok = !!res.success
       if (res.success) {
         MessagePlugin.success(t('webSearchSettings.toasts.testSuccess'))
       } else {
@@ -431,32 +582,19 @@ const testConnection = async () => {
       }
     } else {
       const res = await testWebSearchProvider(undefined, data)
+      ok = !!res.success
       if (res.success) {
         MessagePlugin.success(t('webSearchSettings.toasts.testSuccess'))
       } else {
         MessagePlugin.error(res.error || t('webSearchSettings.toasts.testFailed'))
       }
     }
+    lastTestOk.value = ok
   } catch (error: any) {
     MessagePlugin.error(error?.message || t('webSearchSettings.toasts.testFailed'))
+    lastTestOk.value = false
   } finally {
     testing.value = false
-  }
-}
-
-const testExistingConnection = async (entity: WebSearchProviderEntity) => {
-  testingId.value = entity.id!
-  try {
-    const res = await testWebSearchProvider(entity.id!)
-    if (res.success) {
-      MessagePlugin.success(t('webSearchSettings.toasts.testSuccess'))
-    } else {
-      MessagePlugin.error(res.error || t('webSearchSettings.toasts.testFailed'))
-    }
-  } catch (error: any) {
-    MessagePlugin.error(error?.message || t('webSearchSettings.toasts.testFailed'))
-  } finally {
-    testingId.value = null
   }
 }
 
@@ -464,11 +602,12 @@ const getProviderOptions = (_entity: WebSearchProviderEntity) => {
   // Web search providers carry external API credentials; the backend
   // gates every mutation/test behind Admin+ (RegisterWebSearchProviderRoutes).
   // Hide the action menu entirely for non-Admins so they don't trip 403s.
+  // 测试连接已挪到编辑抽屉的 footer，不再放在外层菜单里 — 单一入口减少
+  // 用户疑惑（"为什么有两个测试入口，结果一样吗？"）。
   if (!authStore.hasRole('admin')) {
     return []
   }
   return [
-    { content: t('webSearchSettings.testConnection'), value: 'test' },
     { content: t('common.edit'), value: 'edit' },
     { content: t('common.delete'), value: 'delete', theme: 'error' as const }
   ]
@@ -476,9 +615,6 @@ const getProviderOptions = (_entity: WebSearchProviderEntity) => {
 
 const handleMenuAction = (data: { value: string }, entity: WebSearchProviderEntity) => {
   switch (data.value) {
-    case 'test':
-      testExistingConnection(entity)
-      break
     case 'edit':
       editProvider(entity)
       break
@@ -621,8 +757,10 @@ onMounted(async () => {
   color: #6235BB;
 }
 .provider-card--baidu .provider-card__badge {
-  background: rgba(225, 38, 38, 0.12);
-  color: #E12626;
+  // 百度官方主色（搜索框 du 标识那个蓝），#2932E1。低饱和版用 12% alpha
+  // 浅底，跟其他 provider 一致。之前误填红色（混淆了百度地图等子产品）。
+  background: rgba(41, 50, 225, 0.12);
+  color: #2932E1;
 }
 .provider-card--searxng .provider-card__badge {
   background: rgba(33, 86, 137, 0.12);
@@ -735,55 +873,174 @@ onMounted(async () => {
   width: 100%;
 }
 
-.form-divider {
-  height: 1px;
-  background: var(--td-component-border);
-  margin: 20px 0;
+// ---- 抽屉内容 — 与 ModelEditorDialog 同款约定 ----
+.form-item {
+  margin-bottom: 0;
 }
 
-/**
- * Credential field: stacks the label row, password input, and the optional
- * "Remove this credential" checkbox vertically. Matches the pattern in
- * McpServiceDialog and ModelEditorDialog so the whole UI reads consistently.
- */
-.credential-field {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-bottom: 20px;
-}
-
-.credential-label {
+.form-label {
   display: block;
-  font-size: 14px;
+  margin-bottom: 6px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--td-text-color-primary);
-}
+  line-height: 1.4;
 
-.clear-credential {
-  :deep(.t-checkbox__label) {
+  &.required::before {
+    content: '*';
     color: var(--td-error-color);
-    font-size: 13px;
+    margin-right: 4px;
+    font-weight: 500;
+    line-height: 1;
   }
 }
 
-.credentials-hint {
-  margin-bottom: 12px;
+.form-desc {
+  margin: 4px 0 0 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--td-text-color-placeholder);
+
+  &--inline {
+    margin: 0;
+  }
+}
+
+:deep(.t-input),
+:deep(.t-select),
+:deep(.t-textarea),
+:deep(.t-input-number) {
+  width: 100%;
   font-size: 13px;
+}
 
-  a {
+// 隐藏 t-form 默认的 form-item 容器 — 我们走自定义 .form-item / .form-label。
+:deep(.t-form) .t-form-item {
+  display: none;
+}
+
+.vision-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+// ---- footer-left 测试按钮的状态 icon（与 ModelEditorDialog/MCP 同款） ----
+.status-icon {
+  font-size: 16px;
+  flex-shrink: 0;
+
+  &.available {
     color: var(--td-brand-color);
-    text-decoration: none;
+  }
 
-    &:hover {
-      text-decoration: underline;
+  &.unavailable {
+    color: var(--td-error-color);
+  }
+}
+
+// ---- Header 图标徽章 ----
+.header-icon__img {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  display: block;
+}
+
+.header-icon__mono {
+  display: inline-block;
+  width: 22px;
+  height: 22px;
+  background-color: currentColor;
+  -webkit-mask-image: var(--logo-url);
+  -webkit-mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-image: var(--logo-url);
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: contain;
+}
+
+.header-icon__text {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.doc-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--td-brand-color);
+  text-decoration: none;
+  transition: color 0.15s ease;
+
+  &:hover {
+    color: var(--td-brand-color-active);
+  }
+
+  .link-icon {
+    font-size: 14px;
+  }
+
+  &--inline {
+    margin-left: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    vertical-align: baseline;
+
+    .link-icon {
+      font-size: 12px;
     }
   }
 }
+</style>
 
-.switch-help {
-  font-size: 12px;
-  color: var(--td-text-color-secondary);
-  margin-top: 4px;
-  line-height: 1.4;
+<!--
+  Non-scoped block: per-provider header-icon coloring + color-logo
+  background tweak. Same pattern as Storage/Parser drawers — these rules
+  must be global so they always reach the t-drawer panel even if its
+  scoped data-attribute is dropped in some builds. Each rule mirrors the
+  matching .provider-card--{id} .provider-card__badge from the scoped
+  block above so list-card → drawer hand-off stays visually continuous.
+-->
+<style lang="less">
+// 彩色 logo 时给 header-icon 容器一个白底 + 1px 边，避免品牌色浅底压在
+// 彩色图标上影响对比度。
+.websearch-drawer .setting-drawer__header-icon:has(.header-icon__img) {
+  background: var(--td-bg-color-container, #fff);
+  box-shadow: inset 0 0 0 1px var(--td-component-stroke);
+}
+
+.websearch-drawer--duckduckgo .setting-drawer__header-icon {
+  background: rgba(222, 88, 51, 0.12);
+  color: #DE5833;
+}
+.websearch-drawer--bing .setting-drawer__header-icon {
+  background: rgba(0, 137, 255, 0.12);
+  color: #0089FF;
+}
+.websearch-drawer--google .setting-drawer__header-icon {
+  background: rgba(66, 133, 244, 0.12);
+  color: #4285F4;
+}
+.websearch-drawer--tavily .setting-drawer__header-icon {
+  background: rgba(98, 53, 187, 0.12);
+  color: #6235BB;
+}
+.websearch-drawer--baidu .setting-drawer__header-icon {
+  background: rgba(41, 50, 225, 0.12);
+  color: #2932E1;
+}
+.websearch-drawer--searxng .setting-drawer__header-icon {
+  background: rgba(33, 86, 137, 0.12);
+  color: #215689;
+}
+.websearch-drawer--ollama .setting-drawer__header-icon {
+  background: rgba(70, 70, 70, 0.12);
+  color: #464646;
 }
 </style>

--- a/frontend/src/views/settings/components/McpServiceDialog.vue
+++ b/frontend/src/views/settings/components/McpServiceDialog.vue
@@ -1,78 +1,222 @@
 <template>
-  <SettingDrawer :visible="dialogVisible"
+  <SettingDrawer
+    :visible="dialogVisible"
     :title="mode === 'add' ? t('mcpServiceDialog.addTitle') : t('mcpServiceDialog.editTitle')"
-    :confirm-loading="submitting" @update:visible="(v: boolean) => dialogVisible = v" @confirm="handleSubmit"
-    @cancel="handleClose">
+    :class="`mcp-drawer mcp-drawer--${formData.transport_type}`"
+    :confirm-loading="submitting"
+    @update:visible="(v: boolean) => dialogVisible = v"
+    @confirm="handleSubmit"
+    @cancel="handleClose"
+  >
+    <!--
+      Header icon — 与 McpSettings 列表 .service-card__badge 同款：
+      transport_type 决定图标和容器配色。SSE 绿、HTTP-Streamable 蓝。
+      非 scoped 块 .mcp-drawer--{transport} 注入背景与文字色，currentColor
+      让 t-icon 跟着染色。
+    -->
+    <template #headerIcon>
+      <t-icon :name="transportIcon" />
+    </template>
+
+    <!-- 副标题：transport 类型名 + 启用状态 mini chip -->
+    <template #subtitle>
+      <span>{{ transportLabel }}</span>
+      <span
+        class="subtitle-tag"
+        :class="formData.enabled ? 'subtitle-tag--ok' : 'subtitle-tag--muted'"
+      >
+        {{ formData.enabled ? t('mcpSettings.enabled', '已启用') : t('mcpSettings.disabled', '已禁用') }}
+      </span>
+    </template>
+
+    <!--
+      测试连接按钮挪到 footer-left，与 ModelEditorDialog/Storage/Parser/
+      WebSearch 抽屉同款。仅 edit 模式有效（需要服务 id 才能调 /test 端点）。
+      create 模式下按钮 disabled 并提示"保存后可测试"。
+    -->
+    <template #footer-left>
+      <t-button
+        variant="outline"
+        :loading="testing"
+        :disabled="mode === 'add' || !props.service?.id"
+        :title="mode === 'add' ? t('mcpServiceDialog.testAfterSaveHint', '保存后可测试连接') : ''"
+        @click="handleTestConnection"
+      >
+        <template #icon>
+          <t-icon
+            v-if="!testing && lastTestOk === true"
+            name="check-circle-filled"
+            class="status-icon available"
+          />
+          <t-icon
+            v-else-if="!testing && lastTestOk === false"
+            name="close-circle-filled"
+            class="status-icon unavailable"
+          />
+        </template>
+        {{ testing ? t('webSearchSettings.testing', '测试中…') : t('mcpSettings.actions.test', '测试连接') }}
+      </t-button>
+    </template>
+
     <t-form ref="formRef" :data="formData" :rules="rules" label-align="top">
-      <t-form-item :label="t('mcpServiceDialog.name')" name="name">
-        <t-input v-model="formData.name" :placeholder="t('mcpServiceDialog.namePlaceholder')" />
-      </t-form-item>
+      <!-- Section 1 — 基本信息 -->
+      <section class="setting-drawer__section">
+        <h4 class="setting-drawer__section-title">{{ t('mcpServiceDialog.basicSection', '基本信息') }}</h4>
 
-      <t-form-item :label="t('mcpServiceDialog.description')" name="description">
-        <t-textarea v-model="formData.description" :autosize="{ minRows: 3, maxRows: 5 }"
-          :placeholder="t('mcpServiceDialog.descriptionPlaceholder')" />
-      </t-form-item>
+        <div class="form-item">
+          <label class="form-label required">{{ t('mcpServiceDialog.name') }}</label>
+          <t-input v-model="formData.name" :placeholder="t('mcpServiceDialog.namePlaceholder')" />
+        </div>
 
-      <t-form-item :label="t('mcpServiceDialog.transportType')" name="transport_type">
-        <t-radio-group v-model="formData.transport_type">
-          <t-radio-button value="sse">{{ t('mcpServiceDialog.transport.sse') }}</t-radio-button>
-          <t-radio-button value="http-streamable">{{ t('mcpServiceDialog.transport.httpStreamable') }}</t-radio-button>
-          <!-- Stdio transport is disabled for security reasons -->
-        </t-radio-group>
-      </t-form-item>
+        <div class="form-item">
+          <label class="form-label">{{ t('mcpServiceDialog.description') }}</label>
+          <t-textarea
+            v-model="formData.description"
+            :autosize="{ minRows: 2, maxRows: 5 }"
+            :placeholder="t('mcpServiceDialog.descriptionPlaceholder')"
+          />
+        </div>
 
-      <!-- URL for SSE/HTTP Streamable -->
-      <t-form-item :label="t('mcpServiceDialog.serviceUrl')" name="url">
-        <t-input v-model="formData.url" :placeholder="t('mcpServiceDialog.serviceUrlPlaceholder')" />
-      </t-form-item>
+        <div class="form-item">
+          <label class="form-label">{{ t('mcpServiceDialog.enableService') }}</label>
+          <div class="vision-toggle">
+            <t-switch v-model="formData.enabled" />
+            <span class="form-desc form-desc--inline">
+              {{ t('mcpServiceDialog.enableServiceDesc', '关闭后该服务不会被调用') }}
+            </span>
+          </div>
+        </div>
+      </section>
 
-      <!-- Stdio Config removed for security reasons -->
+      <!-- Section 2 — 连接配置（transport + url） -->
+      <section class="setting-drawer__section">
+        <h4 class="setting-drawer__section-title">{{ t('mcpServiceDialog.connectionSection', '连接配置') }}</h4>
 
-      <t-form-item :label="t('mcpServiceDialog.enableService')" name="enabled">
-        <t-switch v-model="formData.enabled" />
-      </t-form-item>
+        <div class="form-item">
+          <label class="form-label required">{{ t('mcpServiceDialog.transportType') }}</label>
+          <!-- 紧凑 pill segmented，与 ModelEditorDialog 来源切换 / Storage MinIO 部署模式同款 -->
+          <div class="source-options" role="radiogroup">
+            <button
+              type="button"
+              class="source-option"
+              :class="{ 'is-active': formData.transport_type === 'sse' }"
+              @click="formData.transport_type = 'sse'"
+            >
+              <t-icon name="cast" class="source-option__icon" />
+              <span class="source-option__label">SSE</span>
+            </button>
+            <button
+              type="button"
+              class="source-option"
+              :class="{ 'is-active': formData.transport_type === 'http-streamable' }"
+              @click="formData.transport_type = 'http-streamable'"
+            >
+              <t-icon name="link" class="source-option__icon" />
+              <span class="source-option__label">HTTP Streamable</span>
+            </button>
+          </div>
+        </div>
 
-      <!-- Authentication Config -->
-      <t-collapse :default-value="[]">
-        <t-collapse-panel :header="t('mcpServiceDialog.authConfig')" value="auth">
-          <!--
-            Edit mode: credentials live behind a dedicated subresource. The
-            CredentialResource component drives configured/unconfigured/editing
-            state per field and commits each change to /credentials directly,
-            decoupling credential edits from the surrounding form.
+        <div class="form-item">
+          <label class="form-label required">{{ t('mcpServiceDialog.serviceUrl') }}</label>
+          <t-input v-model="formData.url" :placeholder="t('mcpServiceDialog.serviceUrlPlaceholder')" />
+        </div>
+      </section>
 
-            Add mode: the resource doesn't exist yet, so we accept the initial
-            credentials as plain inputs and POST them together with the rest of
-            the service in handleSubmit. From the second save onwards, the
-            edit-mode path takes over.
-          -->
-          <CredentialResource v-if="mode === 'edit' && props.service?.id" :api="credentialApi"
-            :fields="credentialFields" :meta="credentialMeta" />
-          <template v-else>
-            <t-form-item :label="t('mcpServiceDialog.apiKey')">
-              <t-input v-model="formData.auth_config.api_key" type="password"
-                :placeholder="t('mcpServiceDialog.optional')" />
-            </t-form-item>
-            <t-form-item :label="t('mcpServiceDialog.bearerToken')">
-              <t-input v-model="formData.auth_config.token" type="password"
-                :placeholder="t('mcpServiceDialog.optional')" />
-            </t-form-item>
-          </template>
-        </t-collapse-panel>
+      <!-- Section 3 — 认证配置（API Key / Bearer Token） -->
+      <section class="setting-drawer__section">
+        <h4 class="setting-drawer__section-title">{{ t('mcpServiceDialog.authConfig') }}</h4>
 
-        <!-- Advanced Config -->
-        <t-collapse-panel :header="t('mcpServiceDialog.advancedConfig')" value="advanced">
-          <t-form-item :label="t('mcpServiceDialog.timeoutSec')">
-            <t-input-number v-model="formData.advanced_config.timeout" :min="1" :max="300" placeholder="30" />
-          </t-form-item>
-          <t-form-item :label="t('mcpServiceDialog.retryCount')">
-            <t-input-number v-model="formData.advanced_config.retry_count" :min="0" :max="10" placeholder="3" />
-          </t-form-item>
-          <t-form-item :label="t('mcpServiceDialog.retryDelaySec')">
-            <t-input-number v-model="formData.advanced_config.retry_delay" :min="0" :max="60" placeholder="1" />
-          </t-form-item>
-        </t-collapse-panel>
-      </t-collapse>
+        <!--
+          Edit 模式下凭证由 CredentialResource 管理（独立的 /credentials
+          子资源调用），不与本表单 submit 耦合；Create 模式下用 plain
+          password input + lock prefix-icon。两个字段都是 optional —
+          MCP 服务可能完全不需要鉴权（依赖 IP 白名单等）。
+        -->
+        <CredentialResource
+          v-if="mode === 'edit' && props.service?.id"
+          :api="credentialApi"
+          :fields="credentialFields"
+          :meta="credentialMeta"
+        />
+        <template v-else>
+          <div class="form-item">
+            <label class="form-label">{{ t('mcpServiceDialog.apiKey') }}</label>
+            <t-input
+              v-model="formData.auth_config.api_key"
+              type="password"
+              :placeholder="t('mcpServiceDialog.optional')"
+            >
+              <template #prefix-icon><t-icon name="lock-on" /></template>
+            </t-input>
+          </div>
+          <div class="form-item">
+            <label class="form-label">{{ t('mcpServiceDialog.bearerToken') }}</label>
+            <t-input
+              v-model="formData.auth_config.token"
+              type="password"
+              :placeholder="t('mcpServiceDialog.optional')"
+            >
+              <template #prefix-icon><t-icon name="lock-on" /></template>
+            </t-input>
+          </div>
+        </template>
+      </section>
+
+      <!-- Section 4 — 高级配置（超时/重试），改用带后缀单位的轻量数字输入框，
+           不再用 t-input-number 的加减器（步进按钮在这里没必要，用户更倾向直接键入）。 -->
+      <section class="setting-drawer__section">
+        <h4 class="setting-drawer__section-title">{{ t('mcpServiceDialog.advancedConfig') }}</h4>
+
+        <div class="form-item">
+          <label class="form-label">{{ t('mcpServiceDialog.timeoutSec') }}</label>
+          <t-input
+            v-model="advancedTimeoutText"
+            type="number"
+            :min="1"
+            :max="300"
+            placeholder="30"
+            class="number-input"
+            @blur="onAdvancedNumberBlur('timeout', 30, 1, 300)"
+          >
+            <template #suffix>
+              <span class="number-input__unit">{{ t('mcpServiceDialog.unitSecond', '秒') }}</span>
+            </template>
+          </t-input>
+        </div>
+        <div class="form-item">
+          <label class="form-label">{{ t('mcpServiceDialog.retryCount') }}</label>
+          <t-input
+            v-model="advancedRetryCountText"
+            type="number"
+            :min="0"
+            :max="10"
+            placeholder="3"
+            class="number-input"
+            @blur="onAdvancedNumberBlur('retry_count', 3, 0, 10)"
+          >
+            <template #suffix>
+              <span class="number-input__unit">{{ t('mcpServiceDialog.unitTimes', '次') }}</span>
+            </template>
+          </t-input>
+        </div>
+        <div class="form-item">
+          <label class="form-label">{{ t('mcpServiceDialog.retryDelaySec') }}</label>
+          <t-input
+            v-model="advancedRetryDelayText"
+            type="number"
+            :min="0"
+            :max="60"
+            placeholder="1"
+            class="number-input"
+            @blur="onAdvancedNumberBlur('retry_delay', 1, 0, 60)"
+          >
+            <template #suffix>
+              <span class="number-input__unit">{{ t('mcpServiceDialog.unitSecond', '秒') }}</span>
+            </template>
+          </t-input>
+        </div>
+      </section>
     </t-form>
   </SettingDrawer>
 </template>
@@ -87,8 +231,10 @@ import {
   updateMCPService,
   putMCPCredentials,
   deleteMCPCredentialField,
+  testMCPService,
   type MCPService,
   type McpCredentialField,
+  type MCPTestResult,
 } from '@/api/mcp-service'
 import SettingDrawer from '@/components/settings/SettingDrawer.vue'
 import CredentialResource, {
@@ -105,6 +251,11 @@ interface Props {
 interface Emits {
   (e: 'update:visible', value: boolean): void
   (e: 'success'): void
+  // Fired after a /test call inside the drawer so the parent can reuse its
+  // existing McpTestResult dialog. We deliberately don't render that dialog
+  // here — the parent owns the test-result dialog state across multiple
+  // entry points (drawer test button, list 行操作菜单 used to call it too).
+  (e: 'test', payload: { service: MCPService; result: MCPTestResult }): void
 }
 
 const props = defineProps<Props>()
@@ -130,6 +281,16 @@ const formData = ref({
     retry_count: 3,
     retry_delay: 1,
   },
+})
+
+// Header icon name + transport label, mirrored from McpSettings list cards
+// so the list-card → drawer hand-off stays visually continuous.
+const transportIcon = computed(() => {
+  return formData.value.transport_type === 'http-streamable' ? 'link' : 'cast'
+})
+
+const transportLabel = computed(() => {
+  return formData.value.transport_type === 'http-streamable' ? 'HTTP Streamable' : 'SSE'
 })
 
 // Field metadata for the credential subresource. Keep label keys local to
@@ -189,6 +350,100 @@ const dialogVisible = computed({
   set: (value) => emit('update:visible', value),
 })
 
+// ---- Test connection state (in-drawer) ----
+const testing = ref(false)
+// Tri-state icon hint on the test button: null=neutral, true=just succeeded,
+// false=just failed. Cleared when transport/url change so a stale ✓/✗
+// doesn't sit next to a config the user is now editing.
+const lastTestOk = ref<boolean | null>(null)
+
+watch(
+  () => [formData.value.transport_type, formData.value.url],
+  () => {
+    lastTestOk.value = null
+  },
+)
+
+async function handleTestConnection() {
+  if (!props.service?.id) return
+  testing.value = true
+  MessagePlugin.info({
+    content: t('mcpSettings.toasts.testing', { name: props.service.name || '' }),
+    duration: 0,
+    closeBtn: false,
+  })
+  try {
+    const result = await testMCPService(props.service.id)
+    MessagePlugin.closeAll()
+    const safe: MCPTestResult = result ?? {
+      success: false,
+      message: t('mcpSettings.toasts.noResponse') as string,
+    }
+    lastTestOk.value = safe.success === true
+    emit('test', { service: props.service, result: safe })
+  } catch (error: any) {
+    MessagePlugin.closeAll()
+    const errorMessage =
+      error?.response?.data?.error?.message ||
+      error?.message ||
+      (t('mcpSettings.toasts.testFailed') as string)
+    console.error('Failed to test MCP service:', error)
+    lastTestOk.value = false
+    emit('test', {
+      service: props.service,
+      result: { success: false, message: errorMessage },
+    })
+  } finally {
+    testing.value = false
+  }
+}
+
+// ---- Advanced numeric inputs (text-bound proxies) ----
+// We bind text instead of v-model directly to advanced_config.<n> so the
+// user can clear the field and see the placeholder while typing. On blur
+// we coerce, clamp, and write back; bad values fall back to the default.
+const advancedTimeoutText = computed<string>({
+  get: () => String(formData.value.advanced_config.timeout ?? ''),
+  set: (v) => { formData.value.advanced_config.timeout = parseSloppyInt(v) ?? 30 },
+})
+const advancedRetryCountText = computed<string>({
+  get: () => String(formData.value.advanced_config.retry_count ?? ''),
+  set: (v) => { formData.value.advanced_config.retry_count = parseSloppyInt(v) ?? 3 },
+})
+const advancedRetryDelayText = computed<string>({
+  get: () => String(formData.value.advanced_config.retry_delay ?? ''),
+  set: (v) => { formData.value.advanced_config.retry_delay = parseSloppyInt(v) ?? 1 },
+})
+
+// Permissive int parser — keeps '' / NaN inputs as null instead of 0 so the
+// field can stay visually empty while the user is still typing. Negative
+// numbers and non-int chars are rejected (returns null).
+function parseSloppyInt(raw: string): number | null {
+  if (raw == null) return null
+  const s = String(raw).trim()
+  if (!s) return null
+  const n = Number(s)
+  if (!Number.isFinite(n)) return null
+  return Math.trunc(n)
+}
+
+function onAdvancedNumberBlur(
+  field: 'timeout' | 'retry_count' | 'retry_delay',
+  fallback: number,
+  min: number,
+  max: number,
+) {
+  const cur = formData.value.advanced_config[field]
+  if (cur == null || !Number.isFinite(cur)) {
+    formData.value.advanced_config[field] = fallback
+    return
+  }
+  // Clamp to [min, max] on blur — gives the input "settled" feedback even
+  // though native type=number doesn't enforce its own min/max attribute
+  // for typed values (only for stepper buttons).
+  formData.value.advanced_config[field] = Math.min(max, Math.max(min, cur))
+}
+
 const resetForm = () => {
   formData.value = {
     name: '',
@@ -205,6 +460,8 @@ const resetForm = () => {
 watch(
   () => props.service,
   (service) => {
+    // 切到不同服务（或新增）时清空上次测试反馈，避免旧的 ✓/✗ 漂在新表单上
+    lastTestOk.value = null
     if (service) {
       const transportType = service.transport_type === 'stdio' ? 'sse' : (service.transport_type || 'sse')
       formData.value = {
@@ -279,5 +536,183 @@ const handleClose = () => {
 </script>
 
 <style scoped lang="less">
-/* Stdio-related styles removed as stdio transport is disabled for security reasons */
+// ---- 抽屉内容 — 与 ModelEditorDialog 同款约定 ----
+.form-item {
+  margin-bottom: 0;
+}
+
+.form-label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--td-text-color-primary);
+  line-height: 1.4;
+
+  &.required::before {
+    content: '*';
+    color: var(--td-error-color);
+    margin-right: 4px;
+    font-weight: 500;
+    line-height: 1;
+  }
+}
+
+.form-desc {
+  margin: 4px 0 0 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--td-text-color-placeholder);
+
+  &--inline {
+    margin: 0;
+  }
+}
+
+:deep(.t-input),
+:deep(.t-select),
+:deep(.t-textarea),
+:deep(.t-input-number) {
+  width: 100%;
+  font-size: 13px;
+}
+
+// 隐藏 t-form 默认 form-item 容器 — 走自定义 .form-item / .form-label
+:deep(.t-form) .t-form-item {
+  display: none;
+}
+
+// ---- 紧凑 pill segmented（transport 切换） ----
+.source-options {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px;
+  background: var(--td-bg-color-component);
+  border: 1px solid var(--td-component-stroke);
+  border-radius: 8px;
+}
+
+.source-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  height: 28px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--td-text-color-secondary);
+  line-height: 1;
+  transition: all 0.15s ease;
+
+  &:hover:not(.is-active) {
+    color: var(--td-text-color-primary);
+    background: var(--td-bg-color-container-hover);
+  }
+
+  &.is-active {
+    background: var(--td-bg-color-container);
+    border-color: var(--td-brand-color);
+    color: var(--td-brand-color);
+    font-weight: 500;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  }
+}
+
+.source-option__icon {
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.source-option__label {
+  white-space: nowrap;
+}
+
+.vision-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+// ---- 高级配置数字输入：替代 t-input-number 的步进按钮，更轻量 ----
+// 用普通 t-input + suffix 单位 + type=number。原生 number 输入会
+// 在 Chrome 上显示一对 spin button，scoped 里把它们隐藏掉以保持视觉
+// 干净。最大/最小值通过 onBlur clamp，而不是依赖原生 step 限制。
+.number-input {
+  :deep(input::-webkit-outer-spin-button),
+  :deep(input::-webkit-inner-spin-button) {
+    -webkit-appearance: none;
+    appearance: none;
+    margin: 0;
+  }
+
+  // Firefox 把 type=number 渲染成 textfield 风格更好看
+  :deep(input[type="number"]) {
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+.number-input__unit {
+  font-size: 12px;
+  color: var(--td-text-color-placeholder);
+  user-select: none;
+}
+
+// ---- footer-left 测试按钮的状态 icon ----
+.status-icon {
+  font-size: 16px;
+  flex-shrink: 0;
+
+  &.available {
+    color: var(--td-brand-color);
+  }
+
+  &.unavailable {
+    color: var(--td-error-color);
+  }
+}
+
+// ---- 副标题里的小标签 ----
+.subtitle-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 6px;
+  margin-left: 6px;
+  height: 16px;
+  font-size: 10px;
+  font-weight: 500;
+  border-radius: 3px;
+
+  &--ok {
+    color: var(--td-success-color);
+    background: var(--td-success-color-light);
+  }
+
+  &--muted {
+    color: var(--td-text-color-placeholder);
+    background: var(--td-bg-color-component);
+  }
+}
+</style>
+
+<!--
+  Non-scoped block: per-transport header-icon coloring. Mirrors the matching
+  .service-card--{transport} .service-card__badge in McpSettings so the
+  list-card → drawer hand-off stays visually continuous.
+-->
+<style lang="less">
+.mcp-drawer--sse .setting-drawer__header-icon {
+  background: rgba(17, 128, 83, 0.12);
+  color: #118053;
+}
+
+.mcp-drawer--http-streamable .setting-drawer__header-icon {
+  background: rgba(0, 82, 217, 0.1);
+  color: #0052D9;
+}
 </style>


### PR DESCRIPTION
## Summary

Aligns every settings-page editor drawer to one consistent visual + interaction language, anchored on the `SettingDrawer` shell originally built for the model editor. List-card → drawer hand-off is now visually continuous (same per-engine logo/badge color), and form chrome (sections, labels, footer, test affordance) is identical across:

- Model Settings (`ModelEditorDialog`)
- Parser Engine Settings
- Storage Engine Settings
- Vector Store Settings
- Web Search Settings
- MCP Service Settings (`McpServiceDialog`)

### Drawer shell upgrades (`SettingDrawer`)
- Custom header: 32×32 leading icon badge + title + optional subtitle slot
- Native drag-resize using TDesign's `sizeDraggable` + `@size-drag-end`; width persists per-drawer to `localStorage`
- Body entrance + per-section stagger animations
- `setting-drawer__section` / `setting-drawer__section-title` styles (left brand bar) consumed by every drawer

### Per-drawer changes (visual + structural)
- All drawers route credentials through `<CredentialResource>`; the component was redesigned as a flat row that mimics a `t-input` (no more "card inside a card")
- `CredentialResource` "Remove" is now an inline two-step confirmation (`Remove? → Confirm`), with a localized inline success flash on the row when removal succeeds — replacing global toasts so feedback stays anchored where the action happened
- Source / mode / transport pickers replaced ad-hoc radio-button strips with one shared compact pill segmented control
- Test connection moved to the drawer footer (footer-left slot) for every drawer that supports it; list-card dropdowns no longer carry a separate "Test connection" entry — single entry point
- Per-engine `setting-drawer__header-icon` background/color rules mirror the matching list-card badge, including color-logo white-bg pass for vendor logos
- "Free" tag dropped from web-search provider picker and subtitle (was misleading — DuckDuckGo / SearXNG still need to be testable)
- Baidu provider color corrected from red (#E12626) to actual Baidu blue (#2932E1)

### Model card list (`ModelSettings.vue`)
- Two-row card with stable height: title row + identity row + meta-chip row
- Identity row shows the most useful diagnostic line (URL > raw name) instead of cramming both into one ellipsizing `name · url`
- Built-in indicator de-emphasized (the noise was inverse: most cards are built-in, so user-added cards stand out by NOT having a lock)

### MCP Service Dialog
- Advanced timeout / retry-count / retry-delay use plain `<t-input type="number">` with suffix unit chips, replacing `t-input-number` steppers
- Test entry consolidated into the drawer (previously: list dropdown menu)

### i18n
- Added section / label keys across `zh-CN / en-US / ko-KR / ru-RU` for every new drawer concept (`basicSection`, `connectionSection`, `credentialsSection`, `optionsSection`, `bucketSection`, `modeSection`, `useSslDesc`, `unitSecond`, `unitTimes`, `enableServiceDesc`, `testAfterSaveHint`, `enabled / disabled`, `markitdown.{name,desc}`, ...)
- Source labels shortened: `Ollama / API` instead of `Ollama (本地) / Remote API (远程)`

### Bug fixes (pre-existing, surfaced during this work)
- **`Cannot use 'in' operator to search for 'key'` crash on every keystroke in `t-input`**: TDesign emits `keydown` with `(value, ctx)` signature, so Vue's `.enter` / `.esc` modifiers crash on the string value. Switched all affected `t-input`s in `Login`, `CreateTenantDialog`, `CredentialResource`, `KnowledgeBase`, `FAQEntryManager` from `@keydown.enter` → `@enter`, and from `@keydown.esc` → manual `@keydown` handler that reads `ctx.e.key`
- `<t-input type="email">` rejected by validator (Login email field) — switched to `type="text"` + `autocomplete="email"`
- `<t-progress :theme="warning|success">` rejected by validator (TenantInfo usage card) — `theme` is shape; colors go on `:status`

### Doc content viewer (`doc-content.vue`)
- Removed redundant duplicate file/manual-type sections; consolidated download / timeline actions into a single header action row

## Test plan

- [x] Open Settings → Model → Add Chat Model: drawer header shows colored type badge; section + form chrome match the rest of settings
- [x] Open Settings → Parser Engine → click any engine: header shows monogram with the same per-engine accent color as the list card; "测试连接" lives in the footer
- [x] Open Settings → Storage → MinIO: deployment mode is a pill segmented; remote/Docker switch shows inline alert; SSL toggle uses `vision-toggle`
- [x] Open Settings → Vector Store → Add: header logo matches list card; number fields don't reset to 0 when cleared; advanced section collapses; test button works for create mode and is disabled for edit
- [x] Open Settings → Web Search → Add → DuckDuckGo / SearXNG: test button now appears (was hidden before because they were tagged "free")
- [x] Open Settings → MCP → edit a service: footer test button reflects success/fail with status icon; advanced timeout/retry/retry-delay use number inputs with suffix unit
- [x] Edit any model in edit mode → click "Remove" on the API Key row: row turns red with `Remove? Cancel | Confirm` instead of deleting immediately; click Confirm → row flashes green "Removed"
- [x] Login page: type into email/password fields → no `Cannot use 'in' operator` error in console
- [x] Resize any drawer by dragging its left edge; reopen the drawer → width persists
- [x] All four locales (zh-CN / en-US / ko-KR / ru-RU): no `[intlify] Not found … key` warnings from the redesigned drawers

