### PR TITLE
feat(frontend): support custom app logo via APP_LOGO_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -458,6 +458,13 @@ COS_ENABLE_OLD_DOMAIN=true
 # internal/utils/filesize.go 注释）。
 # MAX_FILE_SIZE_MB=50
 
+# ========== 前端 Logo ==========
+# 自定义 Logo 图片 URL，留空则使用内置默认 logo。
+# 将图片放到 frontend/public/ 下，例如 public/image.webp → APP_LOGO_URL=/image.webp
+# 本地开发：make dev-frontend 启动时会写入 public/config.js
+# Docker 部署：frontend 容器启动时写入 config.js，修改后需重启 frontend 容器
+# APP_LOGO_URL=
+
 # ========== Agent Skills Sandbox 配置 ==========
 # Sandbox 模式: docker(默认), local, disabled
 WEKNORA_SANDBOX_MODE=docker

--- a/.env.example
+++ b/.env.example
@@ -459,10 +459,9 @@ COS_ENABLE_OLD_DOMAIN=true
 # MAX_FILE_SIZE_MB=50
 
 # ========== 前端 Logo ==========
-# 自定义 Logo 图片 URL，留空则使用内置默认 logo。
-# 将图片放到 frontend/public/ 下，例如 public/image.webp → APP_LOGO_URL=/image.webp
-# 本地开发：make dev-frontend 启动时会写入 public/config.js
-# Docker 部署：frontend 容器启动时写入 config.js，修改后需重启 frontend 容器
+# 登录页/侧栏 Logo URL，留空用内置默认。例：public/logo.webp → APP_LOGO_URL=/logo.webp；
+# 或完整 https:// 外链。运行时写入 public/config.js，改 .env 后本地 make dev-frontend、
+# Docker 需 restart frontend；public/ 新图在 Docker 下还要重建 frontend 镜像。
 # APP_LOGO_URL=
 
 # ========== Agent Skills Sandbox 配置 ==========

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "${FRONTEND_PORT:-80}:80"
     environment:
       - MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
+      - APP_LOGO_URL=${APP_LOGO_URL:-}
       - APP_HOST=${APP_HOST:-app}
       # APP_BACKEND_PORT: the port NGINX proxies to (default 8080).
       # For local deployment this is the App container's listening port, independent of host-mapped APP_PORT.

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -3,7 +3,8 @@
 # 生成运行时配置文件，注入环境变量到前端
 cat > /usr/share/nginx/html/config.js << EOF
 window.__RUNTIME_CONFIG__ = {
-  MAX_FILE_SIZE_MB: ${MAX_FILE_SIZE_MB:-50}
+  MAX_FILE_SIZE_MB: ${MAX_FILE_SIZE_MB:-50},
+  APP_LOGO_URL: "${APP_LOGO_URL:-}"
 };
 EOF
 

--- a/frontend/public/config.js
+++ b/frontend/public/config.js
@@ -1,4 +1,4 @@
-// 运行时配置（本地开发默认值，Docker 环境会被 entrypoint 脚本覆盖）
 window.__RUNTIME_CONFIG__ = {
-  MAX_FILE_SIZE_MB: 50
+  MAX_FILE_SIZE_MB: 50,
+  APP_LOGO_URL: ""
 };

--- a/frontend/public/config.js
+++ b/frontend/public/config.js
@@ -1,3 +1,4 @@
+// 运行时配置（本地开发默认值，Docker 环境会被 entrypoint 脚本覆盖）
 window.__RUNTIME_CONFIG__ = {
   MAX_FILE_SIZE_MB: 50,
   APP_LOGO_URL: ""

--- a/frontend/src/components/menu.vue
+++ b/frontend/src/components/menu.vue
@@ -3,7 +3,7 @@
         <!-- 展开时：Logo + 折叠按钮同行 -->
         <div class="logo_row" v-if="!uiStore.sidebarCollapsed">
             <div class="logo_box" @click="router.push('/platform/knowledge-bases')" style="cursor: pointer;">
-                <img class="logo" src="@/assets/img/weknora.png" alt="">
+                <img class="logo" :src="logoUrl" alt="">
                 <sup v-if="isLiteEdition" class="lite-badge">Lite</sup>
             </div>
             <div class="sidebar-toggle" @click="uiStore.toggleSidebar" :title="t('menu.collapseSidebar')">
@@ -168,6 +168,7 @@ import { MessagePlugin, DialogPlugin, Icon as TIcon } from "tdesign-vue-next";
 import UserMenu from '@/components/UserMenu.vue';
 import TenantSelector from '@/components/TenantSelector.vue';
 import { useI18n } from 'vue-i18n';
+import { getAppLogoUrl } from '@/utils/branding';
 import { getSystemInfo } from '@/api/system';
 // Platform logos reused from IMChannelsOverviewPanel — keeps the session list
 // visually consistent with the channels admin view.
@@ -190,6 +191,8 @@ const PLATFORM_LOGO: Record<string, string> = {
 };
 
 const platformLogo = (p: string): string => (p ? PLATFORM_LOGO[p] || '' : '');
+
+const logoUrl = getAppLogoUrl();
 
 const { t } = useI18n();
 const usemenuStore = useMenuStore();

--- a/frontend/src/utils/branding.ts
+++ b/frontend/src/utils/branding.ts
@@ -1,0 +1,7 @@
+import defaultLogo from '@/assets/img/weknora.png';
+
+/** Logo URL from window.__RUNTIME_CONFIG__ (see public/config.js); falls back to default. */
+export function getAppLogoUrl(): string {
+  const url = window.__RUNTIME_CONFIG__?.APP_LOGO_URL?.trim() || '';
+  return url || defaultLogo;
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -6,6 +6,7 @@ declare global {
   interface Window {
     __RUNTIME_CONFIG__?: {
       MAX_FILE_SIZE_MB?: number;
+      APP_LOGO_URL?: string;
     };
   }
 }

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -94,7 +94,7 @@
 
     <!-- Logo - Top Left -->
     <a href="https://github.com/Tencent/WeKnora" target="_blank" class="header-logo" :title="$t('common.github')">
-      <img src="@/assets/img/weknora.png" alt="WeKnora" class="logo-image" />
+      <img :src="logoUrl" alt="WeKnora" class="logo-image" />
     </a>
 
     <!-- Header Links - Top Right -->
@@ -416,6 +416,7 @@ import {
 } from '@/api/auth'
 import { useAuthStore } from '@/stores/auth'
 import { useI18n } from 'vue-i18n'
+import { getAppLogoUrl } from '@/utils/branding'
 
 // Import screenshot images
 import screenshot1 from '@/assets/img/screenshot-1.svg'
@@ -425,6 +426,7 @@ import screenshot4 from '@/assets/img/screenshot-4.svg'
 const router = useRouter()
 const route = useRoute()
 const authStore = useAuthStore()
+const logoUrl = getAppLogoUrl()
 const { t, tm, locale } = useI18n()
 const { formatRole, roleIcon } = useRoleLabel()
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -317,6 +317,19 @@ start_frontend() {
         npm install
     fi
     
+    # 加载 .env 并生成 config.js（与 docker-entrypoint.sh 逻辑一致）
+    if [ -f "$PROJECT_ROOT/.env" ]; then
+        set -a
+        source "$PROJECT_ROOT/.env"
+        set +a
+    fi
+    cat > public/config.js << EOF
+window.__RUNTIME_CONFIG__ = {
+  MAX_FILE_SIZE_MB: ${MAX_FILE_SIZE_MB:-50},
+  APP_LOGO_URL: "${APP_LOGO_URL:-}"
+};
+EOF
+
     log_info "启动 Vite 开发服务器..."
     log_info "前端将运行在 http://localhost:5173"
     log_info "前端 API 代理目标: ${VITE_DEV_PROXY_TARGET:-${FRONTEND_BACKEND_URL:-http://localhost:8080}}"


### PR DESCRIPTION
## Summary

- Add `APP_LOGO_URL` runtime config so deployments can override the default WeKnora logo without rebuilding the frontend bundle.
- Wire the setting through Docker (`docker-entrypoint.sh`), docker-compose, local dev (`scripts/dev.sh`), and `.env.example`.
- Use the configured logo in the sidebar menu and login page, with a fallback to the built-in default.

## Test plan

- [ ] Leave `APP_LOGO_URL` empty — sidebar and login page show the default logo
- [ ] Set `APP_LOGO_URL=/image.webp` in `.env`, run `make dev-frontend` — custom logo appears
- [ ] Deploy with Docker Compose, set `APP_LOGO_URL`, restart frontend container — custom logo appears
- [ ] Verify `MAX_FILE_SIZE_MB` in `config.js` is unchanged


Made with [Cursor](https://cursor.com)