### PR TITLE
feat: add MiniMax-M3 to provider model list

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -3116,7 +3116,7 @@ export default {
         },
         minimax: {
           label: 'MiniMax',
-          description: 'MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, etc.',
+          description: 'MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed, etc.',
         },
         mimo: {
           label: 'MiMo',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -2352,7 +2352,7 @@ export default {
         },
         minimax: {
           label: "MiniMax",
-          description: "MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5 등",
+          description: "MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed 등",
         },
         mimo: {
           label: "MiMo",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -2068,7 +2068,7 @@ export default {
         },
         minimax: {
           label: 'MiniMax',
-          description: 'MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, etc.'
+          description: 'MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed, etc.'
         },
         mimo: {
           label: 'MiMo',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2333,7 +2333,7 @@ export default {
         },
         minimax: {
           label: "MiniMax",
-          description: "MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5 等",
+          description: "MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed 等",
         },
         mimo: {
           label: "小米 MiMo",

--- a/internal/models/provider/minimax.go
+++ b/internal/models/provider/minimax.go
@@ -25,7 +25,7 @@ func (p *MiniMaxProvider) Info() ProviderInfo {
 	return ProviderInfo{
 		Name:        ProviderMiniMax,
 		DisplayName: "MiniMax",
-		Description: "MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, etc.",
+		Description: "MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed, etc.",
 		DefaultURLs: map[types.ModelType]string{
 			types.ModelTypeKnowledgeQA: MiniMaxCNBaseURL,
 		},


### PR DESCRIPTION
## Description

Update the Minimax provider description to include the latest MiniMax-M3 model and remove the deprecated MiniMax-M2.5 reference.

## Type of Change
- [x] ✨ New feature
- [x] 📚 Documentation update

## Changes
- Add `MiniMax-M3` to the MiniMax provider description in `internal/models/provider/minimax.go`
- Update i18n descriptions in `frontend/src/i18n/locales/{en-US,zh-CN,ko-KR,ru-RU}.ts`
- Remove deprecated `MiniMax-M2.5` reference from the description string
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as supported alternatives

## Why
MiniMax-M3 is the latest flagship model from MiniMax, offering a 512K context window, 128K max output, and image input support across both OpenAI-compatible and Anthropic-compatible interfaces. Reflecting it in the provider's user-facing description helps users quickly identify the recommended model when configuring a MiniMax model entry. M2.5 has been superseded by M2.7 / M3 in MiniMax's official lineup, so removing it avoids steering users to a deprecated model.

This change only touches description strings (no behavior change for routing, validation, or API base URL); existing tests continue to pass.

## Testing
- `go test ./internal/models/provider/...` — passes (provider registry + validation tests)
- `go build ./internal/models/provider/...` — passes
- `go vet ./internal/models/provider/...` — clean

## Checklist
- [x] `go test` passes locally for the affected package
- [x] Self-reviewed the code
- [x] No behavioral changes — only description strings updated
- [x] No breaking changes