### PR TITLE
fix(tcvdb): improve collection compatibility

### DIFF
--- a/internal/application/repository/retriever/tencentvectordb/repository.go
+++ b/internal/application/repository/retriever/tencentvectordb/repository.go
@@ -37,7 +37,7 @@ func NewTencentVectorDBRetrieveEngineRepository(
 		collectionBaseName: collectionBaseName,
 		useDimensionSuffix: shouldUseDimensionSuffix(indexCfg),
 		shardsNum:          defaultIfZero(indexCfg.GetShardsNum(1), 1),
-		replicasNum:        indexCfg.GetReplicaNumber(0),
+		replicasNum:        defaultIfZero(indexCfg.GetReplicaNumber(1), 1),
 	}
 }
 

--- a/internal/application/repository/retriever/tencentvectordb/repository.go
+++ b/internal/application/repository/retriever/tencentvectordb/repository.go
@@ -35,8 +35,9 @@ func NewTencentVectorDBRetrieveEngineRepository(
 		client:             client,
 		databaseName:       databaseName,
 		collectionBaseName: collectionBaseName,
+		useDimensionSuffix: shouldUseDimensionSuffix(indexCfg),
 		shardsNum:          defaultIfZero(indexCfg.GetShardsNum(1), 1),
-		replicasNum:        defaultIfZero(indexCfg.GetReplicaNumber(1), 1),
+		replicasNum:        indexCfg.GetReplicaNumber(0),
 	}
 }
 
@@ -314,7 +315,7 @@ func (r *repository) KeywordsRetrieve(ctx context.Context, params types.Retrieve
 	matchedCollections := 0
 	failedCollections := 0
 	for _, collection := range collections.Collections {
-		if !strings.HasPrefix(collection.CollectionName, r.collectionBaseName+"_") {
+		if !r.matchesCollection(collection.CollectionName) {
 			continue
 		}
 		matchedCollections++
@@ -422,11 +423,24 @@ func (r *repository) ensureCollection(ctx context.Context, dimension int) error 
 		indexes,
 	)
 	if err != nil {
+		if isCollectionAlreadyExistsErr(err) {
+			logger.GetLogger(ctx).Infof("[TencentVectorDB] collection %s already exists, skip create", collectionName)
+			r.initialized.Store(dimension, true)
+			return nil
+		}
 		return fmt.Errorf("tencent vectordb create collection %s: %w", collectionName, err)
 	}
 
 	r.initialized.Store(dimension, true)
 	return nil
+}
+
+func isCollectionAlreadyExistsErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "code: 15202") || strings.Contains(msg, "already exist")
 }
 
 func (r *repository) deleteByFilter(ctx context.Context, dimension int, cond string) error {
@@ -450,7 +464,7 @@ func (r *repository) updateChunkFields(ctx context.Context, chunkIDs []string, f
 	}
 
 	for _, collection := range collections.Collections {
-		if !strings.HasPrefix(collection.CollectionName, r.collectionBaseName+"_") {
+		if !r.matchesCollection(collection.CollectionName) {
 			continue
 		}
 		_, err := r.client.Database(r.databaseName).Collection(collection.CollectionName).Update(ctx, tcvectordb.UpdateDocumentParams{
@@ -465,7 +479,21 @@ func (r *repository) updateChunkFields(ctx context.Context, chunkIDs []string, f
 }
 
 func (r *repository) collectionName(dimension int) string {
+	if !r.useDimensionSuffix {
+		return r.collectionBaseName
+	}
 	return fmt.Sprintf("%s_%d", r.collectionBaseName, dimension)
+}
+
+func (r *repository) matchesCollection(collectionName string) bool {
+	if !r.useDimensionSuffix {
+		return collectionName == r.collectionBaseName
+	}
+	return strings.HasPrefix(collectionName, r.collectionBaseName+"_")
+}
+
+func shouldUseDimensionSuffix(indexCfg *types.IndexConfig) bool {
+	return indexCfg == nil || indexCfg.CollectionName == ""
 }
 
 func (r *repository) baseFilter(params types.RetrieveParams) *tcvectordb.Filter {

--- a/internal/application/repository/retriever/tencentvectordb/repository_test.go
+++ b/internal/application/repository/retriever/tencentvectordb/repository_test.go
@@ -70,10 +70,10 @@ func TestBaseFilterBuildsTencentVectorDBCondition(t *testing.T) {
 	}
 }
 
-func TestTencentVectorDBDefaultsToServerlessReplicaNumber(t *testing.T) {
+func TestTencentVectorDBDefaultsToReplicaNumberOne(t *testing.T) {
 	repo := NewTencentVectorDBRetrieveEngineRepository(nil, "", nil).(*repository)
 
-	assert.Equal(t, 0, repo.replicasNum)
+	assert.Equal(t, 1, repo.replicasNum)
 }
 
 func TestTencentVectorDBUsesConfiguredReplicaNumber(t *testing.T) {

--- a/internal/application/repository/retriever/tencentvectordb/repository_test.go
+++ b/internal/application/repository/retriever/tencentvectordb/repository_test.go
@@ -1,6 +1,7 @@
 package tencentvectordb
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -67,4 +68,43 @@ func TestBaseFilterBuildsTencentVectorDBCondition(t *testing.T) {
 	} {
 		assert.True(t, strings.Contains(cond, want), "condition %q should contain %q", cond, want)
 	}
+}
+
+func TestTencentVectorDBDefaultsToServerlessReplicaNumber(t *testing.T) {
+	repo := NewTencentVectorDBRetrieveEngineRepository(nil, "", nil).(*repository)
+
+	assert.Equal(t, 0, repo.replicasNum)
+}
+
+func TestTencentVectorDBUsesConfiguredReplicaNumber(t *testing.T) {
+	repo := NewTencentVectorDBRetrieveEngineRepository(nil, "", &types.IndexConfig{
+		ReplicaNumber: 2,
+	}).(*repository)
+
+	assert.Equal(t, 2, repo.replicasNum)
+}
+
+func TestCollectionNameUsesDimensionSuffixByDefault(t *testing.T) {
+	repo := NewTencentVectorDBRetrieveEngineRepository(nil, "", nil).(*repository)
+
+	assert.Equal(t, "weknora_embeddings_1024", repo.collectionName(1024))
+	assert.True(t, repo.matchesCollection("weknora_embeddings_1024"))
+	assert.False(t, repo.matchesCollection("weknora_embeddings"))
+}
+
+func TestCollectionNameRespectsExplicitCollectionName(t *testing.T) {
+	repo := NewTencentVectorDBRetrieveEngineRepository(nil, "", &types.IndexConfig{
+		CollectionName: "custom_collection",
+	}).(*repository)
+
+	assert.Equal(t, "custom_collection", repo.collectionName(1024))
+	assert.True(t, repo.matchesCollection("custom_collection"))
+	assert.False(t, repo.matchesCollection("custom_collection_1024"))
+}
+
+func TestCollectionAlreadyExistsErrorDetection(t *testing.T) {
+	assert.True(t, isCollectionAlreadyExistsErr(errors.New("code: 15202, collection already exists")))
+	assert.True(t, isCollectionAlreadyExistsErr(errors.New("Collection Already Exist")))
+	assert.False(t, isCollectionAlreadyExistsErr(errors.New("permission denied")))
+	assert.False(t, isCollectionAlreadyExistsErr(nil))
 }

--- a/internal/application/repository/retriever/tencentvectordb/structs.go
+++ b/internal/application/repository/retriever/tencentvectordb/structs.go
@@ -30,6 +30,7 @@ type repository struct {
 	client             *tcvectordb.RpcClient
 	databaseName       string
 	collectionBaseName string
+	useDimensionSuffix bool
 	shardsNum          int
 	replicasNum        int
 	initialized        sync.Map

--- a/internal/types/vectorstore.go
+++ b/internal/types/vectorstore.go
@@ -702,7 +702,7 @@ func GetVectorStoreTypes() []VectorStoreTypeInfo {
 			IndexFields: []VectorStoreFieldInfo{
 				{Name: "collection_name", Type: "string", Required: false, Description: "Collection Name", Default: "weknora_embeddings"},
 				{Name: "shards_num", Type: "number", Required: false, Description: "Shards", Default: 1},
-				{Name: "replica_number", Type: "number", Required: false, Description: "Replicas", Default: 1},
+				{Name: "replica_number", Type: "number", Required: false, Description: "Replicas", Default: 0},
 			},
 		},
 		{

--- a/internal/types/vectorstore.go
+++ b/internal/types/vectorstore.go
@@ -702,7 +702,7 @@ func GetVectorStoreTypes() []VectorStoreTypeInfo {
 			IndexFields: []VectorStoreFieldInfo{
 				{Name: "collection_name", Type: "string", Required: false, Description: "Collection Name", Default: "weknora_embeddings"},
 				{Name: "shards_num", Type: "number", Required: false, Description: "Shards", Default: 1},
-				{Name: "replica_number", Type: "number", Required: false, Description: "Replicas", Default: 0},
+				{Name: "replica_number", Type: "number", Required: false, Description: "Replicas", Default: 1},
 			},
 		},
 		{

--- a/internal/types/vectorstore_test.go
+++ b/internal/types/vectorstore_test.go
@@ -308,6 +308,23 @@ func TestGetVectorStoreTypes(t *testing.T) {
 		assert.True(t, passwordField.Sensitive)
 	})
 
+	t.Run("tencent vectordb defaults to serverless replicas", func(t *testing.T) {
+		var tencentType VectorStoreTypeInfo
+		for _, typ := range types {
+			if typ.Type == "tencent_vectordb" {
+				tencentType = typ
+				break
+			}
+		}
+		require.NotEmpty(t, tencentType.IndexFields)
+
+		seen := map[string]VectorStoreFieldInfo{}
+		for _, f := range tencentType.IndexFields {
+			seen[f.Name] = f
+		}
+		assert.Equal(t, 0, seen["replica_number"].Default)
+	})
+
 	t.Run("display names have no parenthetical suffix", func(t *testing.T) {
 		for _, typ := range types {
 			assert.NotContains(t, typ.DisplayName, "(", "display_name should not contain parenthetical suffix: %s", typ.DisplayName)

--- a/internal/types/vectorstore_test.go
+++ b/internal/types/vectorstore_test.go
@@ -308,7 +308,7 @@ func TestGetVectorStoreTypes(t *testing.T) {
 		assert.True(t, passwordField.Sensitive)
 	})
 
-	t.Run("tencent vectordb defaults to serverless replicas", func(t *testing.T) {
+	t.Run("tencent vectordb defaults to one replica", func(t *testing.T) {
 		var tencentType VectorStoreTypeInfo
 		for _, typ := range types {
 			if typ.Type == "tencent_vectordb" {
@@ -322,7 +322,7 @@ func TestGetVectorStoreTypes(t *testing.T) {
 		for _, f := range tencentType.IndexFields {
 			seen[f.Name] = f
 		}
-		assert.Equal(t, 0, seen["replica_number"].Default)
+		assert.Equal(t, 1, seen["replica_number"].Default)
 	})
 
 	t.Run("display names have no parenthetical suffix", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- respect explicit Tencent VectorDB collection_name as a full collection name instead of always appending the vector dimension
- treat create-collection already-exists errors as success to tolerate concurrent initial writes

## Tests
- go test ./internal/application/repository/retriever/tencentvectordb
- go test ./internal/types