### PR TITLE
fix(deploy): support reverse proxy subpaths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -190,6 +190,13 @@ APP_PORT=8080
 # 前端服务端口，默认为80
 FRONTEND_PORT=80
 
+# Optional reverse-proxy subpath, for deployments such as https://example.com/weknora/.
+# Build the frontend with BASE_URL=/weknora/ so static assets, router links, and
+# axios requests include the prefix. If your proxy forwards the prefix unchanged
+# to the backend, also set SUBPATH_PREFIX=/weknora so the Go server strips it
+# before routing. Leave empty for root-path deployments.
+# SUBPATH_PREFIX=
+
 # 文档解析模块端口，默认为50051
 DOCREADER_PORT=50051
 

--- a/.env.lite.example
+++ b/.env.lite.example
@@ -7,6 +7,11 @@ GIN_MODE=debug
 # 日志级别，可选值：debug, info, warn, error, fatal
 LOG_LEVEL=debug
 
+# Optional reverse-proxy subpath, for deployments such as https://example.com/weknora/.
+# Build the frontend with BASE_URL=/weknora/ and set this only when the proxy
+# forwards the prefix unchanged to the backend.
+# SUBPATH_PREFIX=
+
 # 可选：日志文件绝对路径；未配置时，macOS .app 默认写入
 # ~/Library/Logs/WeKnora Lite/WeKnora Lite.log
 # LOG_PATH=/absolute/path/to/weknora-lite.log

--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ make dev-frontend
 
 **Detailed Documentation:** [Development Environment Quick Start](./docs/开发指南.md)
 
+### Deploy Behind a Subpath
+
+When serving WeKnora under a path prefix such as `https://example.com/weknora/`, build the frontend with `BASE_URL=/weknora/` so static assets, Vue Router, and API requests use the same prefix.
+
+If your reverse proxy forwards the prefix unchanged to the Go backend, set `SUBPATH_PREFIX=/weknora` on the backend. The server strips this prefix before routing requests, so `/weknora/api/v1/*`, `/weknora/files`, `/weknora/health`, and SPA fallback routes continue to work.
+
 
 ## 🤝 Contributing
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -257,6 +257,12 @@ make dev-frontend
 
 **详细文档：** [开发环境快速入门](./docs/开发指南.md)
 
+### 子路径部署
+
+如果需要把 WeKnora 挂在 `https://example.com/weknora/` 这类路径前缀下，前端构建时设置 `BASE_URL=/weknora/`，这样静态资源、Vue Router 和 API 请求都会带上同一个前缀。
+
+如果反向代理会把前缀原样转发给 Go 后端，则后端同时设置 `SUBPATH_PREFIX=/weknora`。服务端会在路由前剥掉此前缀，因此 `/weknora/api/v1/*`、`/weknora/files`、`/weknora/health` 和 SPA fallback 都能正常工作。
+
 
 ## 🤝 贡献指南
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -71,7 +72,7 @@ func main() {
 	) error {
 		// Create HTTP server
 		server := &http.Server{
-			Handler: router,
+			Handler: withSubpathPrefix(router, os.Getenv("SUBPATH_PREFIX")),
 		}
 
 		addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
@@ -141,4 +142,28 @@ func main() {
 	if err != nil {
 		logger.Fatalf(context.Background(), "Failed to run application: %v", err)
 	}
+}
+
+// withSubpathPrefix strips an optional reverse-proxy path prefix before Gin
+// routing. Some gateways forward /weknora/api/v1/* to the backend unchanged,
+// while this server registers routes at /api/v1/*. Rewriting before Gin sees
+// the request avoids the 404 headers that can happen when rerouting from a Gin
+// middleware after the no-route chain has already started.
+func withSubpathPrefix(h http.Handler, prefix string) http.Handler {
+	prefix = strings.TrimRight(strings.TrimSpace(prefix), "/")
+	if prefix == "" {
+		return h
+	}
+	if !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch p := r.URL.Path; {
+		case p == prefix:
+			r.URL.Path = "/"
+		case strings.HasPrefix(p, prefix+"/"):
+			r.URL.Path = strings.TrimPrefix(p, prefix)
+		}
+		h.ServeHTTP(w, r)
+	})
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWithSubpathPrefix(t *testing.T) {
+	cases := []struct {
+		name     string
+		prefix   string
+		inPath   string
+		wantPath string
+	}{
+		{"empty prefix leaves path unchanged", "", "/weknora/api/v1/x", "/weknora/api/v1/x"},
+		{"trailing slash is normalized", "/weknora/", "/weknora/api/v1/x", "/api/v1/x"},
+		{"surrounding spaces are trimmed", "  /weknora  ", "/weknora/api/v1/x", "/api/v1/x"},
+		{"leading slash is optional", "weknora", "/weknora/api/v1/x", "/api/v1/x"},
+		{"exact prefix match rewrites to root", "/weknora", "/weknora", "/"},
+		{"nested prefix is stripped", "/kb/weknora", "/kb/weknora/api/v1/x/y", "/api/v1/x/y"},
+		{"non-matching path is left intact", "/weknora", "/api/v1/health", "/api/v1/health"},
+		{"prefix-looking path is left intact", "/weknora", "/weknora-other/x", "/weknora-other/x"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				got = r.URL.Path
+			})
+			wrapped := withSubpathPrefix(inner, tc.prefix)
+
+			req := httptest.NewRequest(http.MethodGet, "http://localhost"+tc.inPath, nil)
+			wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+			if got != tc.wantPath {
+				t.Fatalf("path mismatch: got %q, want %q", got, tc.wantPath)
+			}
+		})
+	}
+}

--- a/frontend/src/utils/api-base.ts
+++ b/frontend/src/utils/api-base.ts
@@ -1,9 +1,16 @@
+export function getAppBasePath(): string {
+  // Respect Vite's base path so API calls work when the app is mounted behind
+  // a reverse-proxy subpath. Strip trailing slash to avoid double slashes when
+  // axios receives absolute API paths such as /api/v1/auth/login.
+  return (import.meta.env.BASE_URL || '/').replace(/\/+$/, '');
+}
+
 export function getApiBaseUrl(): string {
-  // LocalHub plugin patch (2026-04-29): respect vite's BASE_URL so that
-  // axios calls work at `/app/weknora/` (LocalHub reverse proxy). Without
-  // this · axios hits `/api/v1/...` at LocalHub root · gets 404 "Cannot
-  // POST". Strip trailing slash so axios doesn't produce `/app/weknora//api/v1/...`.
-  // See: plugins/weknora/patches/api-base-baseurl.patch
-  const base = (import.meta.env.BASE_URL || '/').replace(/\/+$/, '');
-  return base;
+  return getAppBasePath();
+}
+
+export function withAppBasePath(path: string): string {
+  const base = getAppBasePath();
+  const cleanPath = path.startsWith('/') ? path : `/${path}`;
+  return `${base}${cleanPath}`.replace(/\/{2,}/g, '/');
 }

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -2,7 +2,7 @@
 import axios from "axios";
 import { generateRandomString } from "./index";
 import i18n from '@/i18n'
-import { getApiBaseUrl } from './api-base';
+import { getApiBaseUrl, withAppBasePath } from './api-base';
 
 const t = (key: string) => i18n.global.t(key)
 
@@ -85,8 +85,9 @@ const processQueue = (error: any, token: string | null = null) => {
 
 function redirectToLogin() {
   if (typeof window === 'undefined') return;
-  if (window.location.pathname === '/login') return;
-  window.location.href = '/login';
+  const loginPath = withAppBasePath('/login');
+  if (window.location.pathname === loginPath) return;
+  window.location.href = loginPath;
 }
 
 instance.interceptors.response.use(


### PR DESCRIPTION
## Summary
- add optional backend SUBPATH_PREFIX handling before Gin routing for reverse proxies that forward a path prefix unchanged
- make frontend login redirects respect Vite BASE_URL, matching existing API base path behavior
- document subpath deployment in README and env examples

## Tests
- CGO_CXXFLAGS="-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1" go test ./cmd/server
- npm run build-only

## Notes
- npm run type-check currently fails on existing repository-wide TypeScript issues unrelated to this change, including src/api/agent/index.ts generic request calls and several existing component type mismatches.