### PR TITLE
fix(docreader): add HTTP health check endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,6 +192,8 @@ FRONTEND_PORT=80
 
 # 文档解析模块端口，默认为50051
 DOCREADER_PORT=50051
+# DocReader HTTP 健康检查端口，默认为8081
+DOCREADER_HEALTH_PORT=8081
 
 # 数据库主机地址
 DB_HOST=localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,10 +236,12 @@ services:
     # add a `ports:` entry locally, preferably bound to 127.0.0.1.
     expose:
       - "50051"
+      - "8081"
     volumes:
       - docreader-tmp:/tmp/docreader
     environment:
       - DOCREADER_IMAGE_OUTPUT_DIR=/tmp/docreader
+      - DOCREADER_HEALTH_PORT=${DOCREADER_HEALTH_PORT:-8081}
       - MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-}
       - DOCREADER_MARKITDOWN_MAX_WORKERS=${DOCREADER_MARKITDOWN_MAX_WORKERS:-1}
       - DOCREADER_PDF_RENDER_MAX_WORKERS=${DOCREADER_PDF_RENDER_MAX_WORKERS:-1}
@@ -258,7 +260,7 @@ services:
       - OBS_PATH_PREFIX=${OBS_PATH_PREFIX:-}
       - OBS_PROXY_DOMAIN=${OBS_PROXY_DOMAIN:-}
     healthcheck:
-      test: ["CMD", "grpc_health_probe", "-addr=localhost:50051"]
+      test: ["CMD-SHELL", "curl -f http://localhost:$${DOCREADER_HEALTH_PORT:-8081}/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker/Dockerfile.docreader
+++ b/docker/Dockerfile.docreader
@@ -151,8 +151,9 @@ COPY --from=builder /app/docreader docreader
 # 创建共享临时图片目录
 RUN mkdir -p /tmp/docreader
 
-# 暴露 gRPC 端口
+# 暴露 gRPC 端口和 HTTP 健康检查端口
 EXPOSE 50051
+EXPOSE 8081
 
 # 直接运行 Python 服务（日志输出到 stdout/stderr）
 CMD ["uv", "run", "-m", "docreader.main"]

--- a/docreader/README.md
+++ b/docreader/README.md
@@ -76,6 +76,7 @@ docreader:
 
 - `DOCREADER_GRPC_MAX_WORKERS`: gRPC 服务的最大工作线程数（默认：4）
 - `DOCREADER_GRPC_PORT`: gRPC 服务监听端口（默认：50051）
+- `DOCREADER_HEALTH_PORT`: HTTP 健康检查端口（默认：8081，路径：`/healthz`）
 
 ### 解析器资源控制
 
@@ -203,15 +204,21 @@ docreader:
 
 ## 服务健康检查
 
-DocReader 服务配置了健康检查：
+DocReader 服务同时提供 gRPC health service 和 HTTP 健康检查端点：
 
 ```yaml
 healthcheck:
-  test: ["CMD", "grpc_health_probe", "-addr=localhost:50051"]
+  test: ["CMD", "curl", "-f", "http://localhost:8081/healthz"]
   interval: 30s
   timeout: 10s
   retries: 3
   start_period: 60s
+```
+
+HTTP 端点可用于 Kubernetes、负载均衡器或通用反向代理探活：
+
+```bash
+curl http://localhost:8081/healthz
 ```
 
 可以通过以下命令检查服务状态：
@@ -224,6 +231,7 @@ docker logs WeKnora-docreader
 ## 更多信息
 
 - 服务端口：50051（gRPC）
+- 健康检查端口：8081（HTTP）
 - 容器名称：WeKnora-docreader
 - 网络：WeKnora-network
 - 重启策略：unless-stopped

--- a/docreader/config.py
+++ b/docreader/config.py
@@ -51,6 +51,7 @@ class DocReaderConfig:
     grpc_max_workers: int
     grpc_max_file_size_mb: int
     grpc_port: int
+    health_port: int
 
     # Parser
     docx_max_pages: int
@@ -77,6 +78,7 @@ def load_config() -> DocReaderConfig:
         * 1024
     )
     grpc_port = _get_int(["DOCREADER_GRPC_PORT", "PORT"], 50051)
+    health_port = _get_int(["DOCREADER_HEALTH_PORT"], 8081)
     docx_max_pages = _get_int(["DOCREADER_DOCX_MAX_PAGES"], 0)
     markitdown_max_workers = _get_int(["DOCREADER_MARKITDOWN_MAX_WORKERS"], 1)
     pdf_render_max_workers = _get_int(["DOCREADER_PDF_RENDER_MAX_WORKERS"], 1)
@@ -98,6 +100,7 @@ def load_config() -> DocReaderConfig:
         grpc_max_workers=grpc_max_workers,
         grpc_max_file_size_mb=grpc_max_file_size_mb,
         grpc_port=grpc_port,
+        health_port=health_port,
         docx_max_pages=docx_max_pages,
         markitdown_max_workers=markitdown_max_workers,
         pdf_render_max_workers=pdf_render_max_workers,
@@ -118,6 +121,7 @@ def dump_config(mask_secrets: bool = True) -> Dict[str, Any]:
         "DOCREADER_GRPC_MAX_WORKERS": cfg.grpc_max_workers,
         "DOCREADER_GRPC_MAX_FILE_SIZE_MB": cfg.grpc_max_file_size_mb,
         "DOCREADER_GRPC_PORT": cfg.grpc_port,
+        "DOCREADER_HEALTH_PORT": cfg.health_port,
         "DOCREADER_DOCX_MAX_PAGES": cfg.docx_max_pages,
         "DOCREADER_MARKITDOWN_MAX_WORKERS": cfg.markitdown_max_workers,
         "DOCREADER_PDF_RENDER_MAX_WORKERS": cfg.pdf_render_max_workers,

--- a/docreader/main.py
+++ b/docreader/main.py
@@ -2,10 +2,14 @@ import logging
 import os
 import re
 import sys
+import threading
 import traceback
 import uuid
 from concurrent import futures
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Optional
+from urllib.parse import urlsplit
 
 import grpc
 from grpc_health.v1 import health_pb2_grpc
@@ -193,8 +197,35 @@ class DocReaderServicer(docreader_pb2_grpc.DocReaderServicer):
         return ListEnginesResponse(engines=engines)
 
 
+class HealthCheckHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        path = urlsplit(self.path).path
+        if path not in {"/healthz", "/health"}:
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+
+        body = b'{"status":"ok","service":"docreader"}\n'
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        logger.debug("health probe: " + format, *args)
+
+
+def start_health_server(port: int) -> ThreadingHTTPServer:
+    server = ThreadingHTTPServer(("", port), HealthCheckHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    logger.info("HTTP health check server started on port %d", port)
+    return server
+
+
 def main():
     config.print_config()
+    health_server = None
 
     interceptors = [AuthInterceptor()]
 
@@ -228,6 +259,7 @@ def main():
         )
 
     server.start()
+    health_server = start_health_server(CONFIG.health_port)
 
     logger.info("Server started on port %d", CONFIG.grpc_port)
     logger.info("Server is ready to accept connections")
@@ -236,6 +268,8 @@ def main():
         server.wait_for_termination()
     except KeyboardInterrupt:
         logger.info("Received termination signal, shutting down server")
+        if health_server:
+            health_server.shutdown()
         server.stop(0)
 
 

--- a/docreader/tests/test_healthcheck.py
+++ b/docreader/tests/test_healthcheck.py
@@ -1,0 +1,34 @@
+import json
+import urllib.error
+import urllib.request
+import unittest
+
+from docreader.main import start_health_server
+
+
+class HealthCheckTest(unittest.TestCase):
+    def setUp(self):
+        self.server = start_health_server(0)
+        self.base_url = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+    def test_healthz_returns_ok(self):
+        with urllib.request.urlopen(f"{self.base_url}/healthz", timeout=2) as response:
+            body = json.loads(response.read().decode("utf-8"))
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["service"], "docreader")
+
+    def test_unknown_path_returns_not_found(self):
+        with self.assertRaises(urllib.error.HTTPError) as ctx:
+            urllib.request.urlopen(f"{self.base_url}/unknown", timeout=2)
+
+        self.assertEqual(ctx.exception.code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/helm/templates/docreader.yaml
+++ b/helm/templates/docreader.yaml
@@ -45,26 +45,29 @@ spec:
             - containerPort: 50051
               name: grpc
               protocol: TCP
+            - containerPort: {{ .Values.docreader.service.healthPort }}
+              name: health
+              protocol: TCP
           env:
             - name: STORAGE_TYPE
               value: {{ .Values.docreader.env.STORAGE_TYPE | quote }}
+            - name: DOCREADER_HEALTH_PORT
+              value: {{ .Values.docreader.env.DOCREADER_HEALTH_PORT | quote }}
           resources:
             {{- toYaml .Values.docreader.resources | nindent 12 }}
-          # gRPC health check using grpc_health_probe
+          # HTTP health check keeps probes independent from gRPC auth/TLS settings.
           livenessProbe:
-            exec:
-              command:
-                - grpc_health_probe
-                - -addr=localhost:50051
+            httpGet:
+              path: /healthz
+              port: health
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
-            exec:
-              command:
-                - grpc_health_probe
-                - -addr=localhost:50051
+            httpGet:
+              path: /healthz
+              port: health
             initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 3
@@ -98,5 +101,9 @@ spec:
     - name: grpc
       port: {{ .Values.docreader.service.port }}
       targetPort: grpc
+      protocol: TCP
+    - name: health
+      port: {{ .Values.docreader.service.healthPort }}
+      targetPort: health
       protocol: TCP
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -220,11 +220,13 @@ docreader:
   # -- Environment variables
   env:
     STORAGE_TYPE: local
+    DOCREADER_HEALTH_PORT: "8081"
 
   # -- Service configuration
   service:
     type: ClusterIP
     port: 50051
+    healthPort: 8081
 
   # -- Node selector
   nodeSelector: {}


### PR DESCRIPTION
## Summary
- add a lightweight HTTP health server for DocReader at `/healthz` and `/health`
- expose `DOCREADER_HEALTH_PORT` with a default of `8081`
- switch Docker Compose and Helm DocReader probes to the HTTP health endpoint
- add unit tests for the health endpoint

## Tests
- `uv run --project docreader python -m unittest discover -s docreader/tests -p 'test_config.py'`
- `uv run --project docreader python -m unittest discover -s docreader/tests -p 'test_healthcheck.py'`
- `python3 -m compileall docreader/main.py docreader/config.py docreader/tests/test_healthcheck.py`
- `docker compose config`
- `git diff --check`

## Notes
Related to #366. This improves DocReader health probing and deployment observability, but does not claim to fix the restart root cause.

该 PR 为 DocReader 补充独立的 HTTP `/healthz` 探活端点，便于 Docker/Kubernetes/负载均衡器判断服务是否可用；同时避免健康检查依赖 gRPC 探针或受 gRPC TLS/auth 配置影响。