### PR TITLE
fix(datasource): align Feishu connector capabilities

### DIFF
--- a/internal/datasource/connector.go
+++ b/internal/datasource/connector.go
@@ -92,7 +92,7 @@ var ConnectorMetadataRegistry = map[string]ConnectorMetadata{
 		Description:  "Sync documents, wikis, and content from Feishu",
 		Priority:     0,
 		AuthType:     "oauth2",
-		Capabilities: []string{"incremental", "webhook", "deletion_sync"},
+		Capabilities: []string{"incremental", "deletion_sync"},
 	},
 	types.ConnectorTypeNotion: {
 		Type:         types.ConnectorTypeNotion,

--- a/internal/datasource/connector_test.go
+++ b/internal/datasource/connector_test.go
@@ -1,0 +1,17 @@
+package datasource
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestFeishuMetadataDoesNotAdvertiseWebhook(t *testing.T) {
+	meta := ConnectorMetadataRegistry[types.ConnectorTypeFeishu]
+
+	for _, capability := range meta.Capabilities {
+		if capability == "webhook" {
+			t.Fatalf("Feishu connector should not advertise webhook until webhook sync is implemented")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- remove `webhook` from Feishu datasource connector capabilities
- add a regression test so Feishu does not advertise webhook sync before it is implemented

## Tests
- `CGO_CXXFLAGS="-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1" go test ./internal/datasource`
- `git diff --check`

## Notes
中文备注：当前数据源同步链路支持手动/定时拉取同步，但没有 Feishu webhook 接收或注册逻辑。这个 PR 只修正能力声明，避免 UI/API 误导用户认为 Feishu 数据源支持实时 webhook 同步。