### PR TITLE
fix: skip credential validation when editing data source

### DIFF
--- a/frontend/src/views/knowledge/settings/DataSourceEditorDialog.vue
+++ b/frontend/src/views/knowledge/settings/DataSourceEditorDialog.vue
@@ -311,12 +311,14 @@ function selectType(def: ConnectorDef) {
 
 // --- Test connection (stateless, no DB write) ---
 async function testConnection() {
-  const fields = currentDef.value?.fields || []
-  for (const f of fields) {
-    if (f.optional) continue
-    if (!form.value.config.credentials[f.key]) {
-      MessagePlugin.warning(`${t(f.labelKey)} ${t('datasource.isRequired')}`)
-      return
+  if (!isEdit.value || !credentialsConfigured.value || replaceCredentialsMode.value) {
+    const fields = currentDef.value?.fields || []
+    for (const f of fields) {
+      if (f.optional) continue
+      if (!form.value.config.credentials[f.key]) {
+        MessagePlugin.warning(`${t(f.labelKey)} ${t('datasource.isRequired')}`)
+        return
+      }
     }
   }
 
@@ -441,6 +443,10 @@ function toggleResource(id: string) {
 }
 
 function validateStep1Fields(): boolean {
+  if (isEdit.value && credentialsConfigured.value && !replaceCredentialsMode.value) {
+    return true
+  }
+
   const fields = currentDef.value?.fields || []
   for (const f of fields) {
     if (f.optional) continue


### PR DESCRIPTION
## Summary
- skip required credential field validation when editing a data source that already has credentials configured
- keep validation unchanged for creating a data source or explicitly replacing credentials

## Issue
- I did not find a matching open issue for this bug.

## Test
- npm run build
- git diff --check