### PR TITLE
fix(frontend): pass {size} param to fileSizeExceeded i18n on Nginx 413

### DIFF
--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -12,7 +12,7 @@ declare global {
 
 // 从运行时配置获取最大文件大小(MB)，支持 Docker 环境动态配置
 // 优先级：运行时配置 > 构建时环境变量 > 默认值 50MB
-const MAX_FILE_SIZE_MB = window.__RUNTIME_CONFIG__?.MAX_FILE_SIZE_MB 
+export const MAX_FILE_SIZE_MB = window.__RUNTIME_CONFIG__?.MAX_FILE_SIZE_MB
   || Number(import.meta.env.VITE_MAX_FILE_SIZE_MB) 
   || 50;
 const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -1,6 +1,6 @@
 // src/utils/request.js
 import axios from "axios";
-import { generateRandomString } from "./index";
+import { generateRandomString, MAX_FILE_SIZE_MB } from "./index";
 import i18n from '@/i18n'
 import { getApiBaseUrl } from './api-base';
 
@@ -185,7 +185,7 @@ instance.interceptors.response.use(
     if (error.response.status === 413) {
       return Promise.reject({ 
         status: 413, 
-        message: t('error.fileSizeExceeded'),
+        message: i18n.global.t('error.fileSizeExceeded', { size: MAX_FILE_SIZE_MB }),
         success: false
       });
     }


### PR DESCRIPTION
## What

When Nginx rejects a file upload with HTTP 413 (Request Entity Too Large), the frontend shows a toast like "文件大小不能超过 M！" — the `{size}` placeholder renders as empty.

## Root cause

In `frontend/src/utils/request.ts`, the 413 error handler calls `t('error.fileSizeExceeded')` **without** the required `{size}` parameter. The i18n string `"文件大小不能超过 {size}M！"` therefore renders with a blank where the number should be.

The sibling call site in `kbFileTypeVerification()` (`frontend/src/utils/index.ts`) correctly passes `{ size: MAX_FILE_SIZE_MB }`, so the bug is isolated to the Nginx 413 fallback path.

## Fix

- Export `MAX_FILE_SIZE_MB` from `frontend/src/utils/index.ts` (was private).
- Import it in `request.ts` and pass `{ size: MAX_FILE_SIZE_MB }` to the i18n call on 413.

## Test plan

- [x] Upload a file that exceeds Nginx `client_max_body_size` → toast shows the configured limit instead of a blank number
- [x] Upload a file within the limit → no regression, upload succeeds