### PR TITLE
feat(lkeap): integrate Tencent Cloud LKEAP Rerank support

### DIFF
--- a/frontend/src/api/initialization/index.ts
+++ b/frontend/src/api/initialization/index.ts
@@ -276,6 +276,8 @@ interface BaseModelTestPayload {
     customHeaders?: Record<string, string>;
     extraConfig?: Record<string, string>;
     interfaceType?: string;
+    /** 第二段密钥（如 LKEAP Rerank 的腾讯云 SecretKey） */
+    appSecret?: string;
 }
 
 // 检查远程API模型

--- a/frontend/src/components/ModelEditorDialog.vue
+++ b/frontend/src/components/ModelEditorDialog.vue
@@ -215,7 +215,9 @@
           </div>
 
           <div v-if="formData.provider !== 'weknoracloud'" class="form-item">
-            <label class="form-label">{{ $t('model.editor.apiKeyOptional') }}</label>
+            <label class="form-label">{{
+              isLkeapRerank ? $t('model.editor.lkeap.secretIdLabel') : $t('model.editor.apiKeyOptional')
+            }}</label>
             <!--
               Edit mode: credentials live behind the /credentials subresource
               of the model — managed by the shared CredentialResource card,
@@ -230,7 +232,8 @@
             <CredentialResource v-if="isEdit && props.modelData?.id" :api="credentialApi" :fields="credentialFields"
               :meta="credentialMeta" />
             <t-input v-else v-model="formData.apiKey" :type="showApiKey ? 'text' : 'password'"
-              :placeholder="apiKeyPlaceholder" class="api-key-input" autocomplete="off" spellcheck="false">
+              :placeholder="isLkeapRerank ? $t('model.editor.lkeap.secretIdPlaceholder') : apiKeyPlaceholder"
+              class="api-key-input" autocomplete="off" spellcheck="false">
               <template #prefix-icon><t-icon name="lock-on" /></template>
               <template #suffix-icon>
                 <t-icon
@@ -241,6 +244,22 @@
                 />
               </template>
             </t-input>
+            <p v-if="isLkeapRerank" class="form-desc">{{ $t('model.editor.lkeap.rerankCredentialHint') }}</p>
+          </div>
+
+          <!-- LKEAP Rerank 创建模式：SecretKey（编辑模式由 CredentialResource 管理） -->
+          <div v-if="isLkeapRerank && !isEdit" class="form-item">
+            <label class="form-label required">{{ $t('model.editor.lkeap.secretKeyLabel') }}</label>
+            <t-input v-model="formData.appSecret" type="password"
+              :placeholder="$t('model.editor.lkeap.secretKeyPlaceholder')" autocomplete="off" spellcheck="false">
+              <template #prefix-icon><t-icon name="lock-on" /></template>
+            </t-input>
+          </div>
+
+          <div v-if="isLkeapRerank" class="form-item">
+            <label class="form-label">{{ $t('model.editor.lkeap.regionLabel') }}</label>
+            <t-input v-model="formData.lkeapRegion" :placeholder="$t('model.editor.lkeap.regionPlaceholder')" />
+            <p class="form-desc">{{ $t('model.editor.lkeap.regionDesc') }}</p>
           </div>
 
           <!-- 自定义 HTTP Header（类似 OpenAI Python SDK 的 extra_headers） -->
@@ -350,6 +369,10 @@ interface ModelFormData {
   supportsVision?: boolean
   // 自定义 HTTP 请求头（类似 OpenAI Python SDK 的 extra_headers）
   customHeaders?: CustomHeaderItem[]
+  /** LKEAP Rerank：腾讯云 SecretKey（创建时写入 app_secret） */
+  appSecret?: string
+  /** LKEAP Rerank：地域，如 ap-guangzhou */
+  lkeapRegion?: string
 }
 
 interface Props {
@@ -555,17 +578,24 @@ const modelTypeIcon = computed(() => {
   return map[props.modelType] || 'setting'
 })
 
+const isLkeapRerank = computed(
+  () => props.modelType === 'rerank' && formData.value.provider === 'lkeap',
+)
+
 // Credential resource binding for the shared <CredentialResource> component.
-// "app_secret" is only relevant for the WeKnora Cloud provider; the visible
-// fields collapse to just api_key for every other provider. We always pass
-// both keys to the backend (it returns metadata for each), but only render
-// the ones meaningful to the current provider.
 const credentialFields = computed<CredentialFieldDef<ModelCredentialField>[]>(() => {
   const fields: CredentialFieldDef<ModelCredentialField>[] = [
-    { key: 'api_key', label: t('model.editor.apiKeyOptional') as string },
+    {
+      key: 'api_key',
+      label: (isLkeapRerank.value
+        ? t('model.editor.lkeap.secretIdLabel')
+        : t('model.editor.apiKeyOptional')) as string,
+    },
   ]
   if (formData.value.provider === 'weknoracloud') {
     fields.push({ key: 'app_secret', label: 'App Secret' })
+  } else if (isLkeapRerank.value) {
+    fields.push({ key: 'app_secret', label: t('model.editor.lkeap.secretKeyLabel') as string })
   }
   return fields
 })
@@ -667,7 +697,9 @@ const formData = ref<ModelFormData>({
   interfaceType: 'ollama',
   isDefault: false,
   supportsVision: false,
-  customHeaders: []
+  customHeaders: [],
+  appSecret: '',
+  lkeapRegion: 'ap-guangzhou',
 })
 
 const rules = computed(() => ({
@@ -852,7 +884,9 @@ const resetForm = () => {
     interfaceType: undefined,
     isDefault: false,
     supportsVision: false,
-    customHeaders: []
+    customHeaders: [],
+    appSecret: '',
+    lkeapRegion: 'ap-guangzhou',
   }
   modelChecked.value = false
   modelAvailable.value = false
@@ -873,6 +907,9 @@ const handleProviderChange = (value: string) => {
     const defaultUrl = provider.defaultUrls[props.modelType]
     if (defaultUrl) {
       formData.value.baseUrl = defaultUrl
+    }
+    if (value === 'lkeap' && props.modelType === 'rerank' && !formData.value.modelName?.trim()) {
+      formData.value.modelName = 'lke-reranker-base'
     }
     // 重置校验状态
     remoteChecked.value = false
@@ -1097,8 +1134,17 @@ const checkRemoteAPI = async () => {
         }
         break
 
-      case 'rerank':
-        // Rerank 模型
+      case 'rerank': {
+        const lkeapExtra = isLkeapRerank.value
+          ? {
+              extraConfig: {
+                region: (formData.value.lkeapRegion || 'ap-guangzhou').trim(),
+              },
+              ...(formData.value.appSecret?.trim()
+                ? { appSecret: formData.value.appSecret.trim() }
+                : {}),
+            }
+          : {}
         result = await checkRerankModel({
           modelName: formData.value.modelName,
           baseUrl: formData.value.baseUrl,
@@ -1106,8 +1152,10 @@ const checkRemoteAPI = async () => {
           provider: formData.value.provider,
           ...idPayload,
           ...headerPayload,
+          ...lkeapExtra,
         })
         break
+      }
 
       case 'vllm':
         // VLLM 模型（多模态）

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -3292,6 +3292,17 @@ export default {
       baseUrlPlaceholderAsr: 'e.g. https://api.openai.com/v1',
       apiKeyOptional: 'API Key (optional)',
       apiKeyPlaceholder: 'Enter API Key',
+      lkeap: {
+        secretIdLabel: 'SecretId',
+        secretIdPlaceholder: 'Tencent Cloud API SecretId',
+        secretKeyLabel: 'SecretKey',
+        secretKeyPlaceholder: 'Tencent Cloud API SecretKey',
+        regionLabel: 'Region',
+        regionPlaceholder: 'ap-guangzhou',
+        regionDesc: 'RunRerank supports ap-beijing, ap-guangzhou, etc. Default: ap-guangzhou',
+        rerankCredentialHint:
+          'Rerank uses Tencent Cloud API signature (not the OpenAI-style LKEAP API key). Create SecretId/SecretKey in the CAM console.',
+      },
       customHeadersLabel: 'Custom Request Headers (optional)',
       customHeadersDesc: 'Extra HTTP headers appended to requests to the remote model API (e.g. for enterprise gateway auth or tracing). Reserved headers like Authorization / Content-Type are ignored.',
       customHeadersAdd: 'Add Header',
@@ -3425,7 +3436,7 @@ export default {
         },
         lkeap: {
           label: 'Tencent Cloud LKEAP',
-          description: 'DeepSeek-R1, DeepSeek-V3 series with chain-of-thought',
+          description: 'DeepSeek-R1, DeepSeek-V3, lke-reranker-base, etc.',
         },
         nvidia: {
           label: "NVIDIA",

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -2654,7 +2654,7 @@ export default {
         },
         lkeap: {
           label: "텐센트 클라우드 LKEAP",
-          description: "DeepSeek-R1, DeepSeek-V3 시리즈, 사고 체인 지원",
+          description: "DeepSeek-R1, DeepSeek-V3, lke-reranker-base 등",
         },
         nvidia: {
           label: "NVIDIA",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -2368,7 +2368,7 @@ export default {
         },
         lkeap: {
           label: 'Tencent Cloud LKEAP',
-          description: 'DeepSeek-R1, DeepSeek-V3 с поддержкой цепочки рассуждений'
+          description: 'DeepSeek-R1, DeepSeek-V3, lke-reranker-base и др.'
         },
         nvidia: {
           label: "NVIDIA",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2509,6 +2509,17 @@ export default {
       baseUrlPlaceholderAsr: "例如：https://api.openai.com/v1",
       apiKeyOptional: "API Key（可选）",
       apiKeyPlaceholder: "输入 API Key",
+      lkeap: {
+        secretIdLabel: "SecretId",
+        secretIdPlaceholder: "腾讯云 API 密钥 SecretId",
+        secretKeyLabel: "SecretKey",
+        secretKeyPlaceholder: "腾讯云 API 密钥 SecretKey",
+        regionLabel: "地域",
+        regionPlaceholder: "ap-guangzhou",
+        regionDesc: "RunRerank 支持 ap-beijing、ap-guangzhou 等，默认 ap-guangzhou",
+        rerankCredentialHint:
+          "Rerank 使用腾讯云 API 签名（非 OpenAI API Key）。请在云 API 密钥控制台创建 SecretId/SecretKey。",
+      },
       customHeadersLabel: "自定义请求头（可选）",
       customHeadersDesc: "调用远程模型 API 时附加的 HTTP 请求头，常用于企业网关鉴权、链路追踪等场景；Authorization、Content-Type 等保留头会被自动忽略。",
       customHeadersAdd: "添加请求头",
@@ -2642,7 +2653,7 @@ export default {
         },
         lkeap: {
           label: "腾讯云 LKEAP",
-          description: "DeepSeek-R1, DeepSeek-V3 系列模型，支持思维链",
+          description: "DeepSeek-R1、DeepSeek-V3、lke-reranker-base 等",
         },
         nvidia: {
             label: "NVIDIA",

--- a/frontend/src/views/settings/ModelSettings.vue
+++ b/frontend/src/views/settings/ModelSettings.vue
@@ -161,6 +161,7 @@ function convertToLegacyFormat(model: ModelConfig) {
     customHeaders: model.parameters.custom_headers
       ? Object.entries(model.parameters.custom_headers).map(([key, value]) => ({ key, value: String(value) }))
       : [],
+    lkeapRegion: model.parameters.extra_config?.region || 'ap-guangzhou',
     _modelType: backendTypeToModelType[model.type] || 'chat' as ModelType,
     // Preserve the credential metadata map so the editor dialog can render
     // the "Configured" state without an extra round-trip.
@@ -371,6 +372,17 @@ const handleModelSave = async (modelData: any) => {
     const trimmedApiKey = (modelData.apiKey ?? '').trim()
     const apiKeyFields: { api_key?: string } =
       !editingModel.value && trimmedApiKey ? { api_key: trimmedApiKey } : {}
+    const trimmedAppSecret = (modelData.appSecret ?? '').trim()
+    const appSecretFields: { app_secret?: string } =
+      !editingModel.value && trimmedAppSecret ? { app_secret: trimmedAppSecret } : {}
+    const lkeapExtra =
+      modelData.provider === 'lkeap' && currentModelType.value === 'rerank'
+        ? {
+            extra_config: {
+              region: (modelData.lkeapRegion || 'ap-guangzhou').trim(),
+            },
+          }
+        : {}
 
     const apiModelData: ModelConfig = {
       name: modelData.modelName.trim(),
@@ -381,7 +393,9 @@ const handleModelSave = async (modelData: any) => {
       parameters: {
         base_url: modelData.baseUrl?.trim() || '',
         ...apiKeyFields,
+        ...appSecretFields,
         provider: modelData.provider || '',
+        ...lkeapExtra,
         ...(Object.keys(customHeadersMap).length > 0 ? { custom_headers: customHeadersMap } : {}),
         ...(currentModelType.value === 'embedding' && modelData.dimension ? {
           embedding_parameters: {

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,8 @@ require (
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
 	github.com/tencent/vectordatabase-sdk-go v1.8.4
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.103
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/lkeap v1.3.103
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.73
 	github.com/tiktoken-go/tokenizer v0.7.0
 	github.com/volcengine/ve-tos-golang-sdk/v2 v2.9.4

--- a/go.sum
+++ b/go.sum
@@ -2479,7 +2479,11 @@ github.com/swaggo/swag v1.16.6/go.mod h1:ngP2etMK5a0P3QBizic5MEwpRmluJZPHjXcMoj4
 github.com/tencent/vectordatabase-sdk-go v1.8.4 h1:jVATTavFzDypX/TOx+eNrOJk7DcOA0U8REH5NEIC2bs=
 github.com/tencent/vectordatabase-sdk-go v1.8.4/go.mod h1:cb53Vbd9Lnh3mA1CwqV9Jy8MrNsxpIUlrhzBiBE7A2M=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.563/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.103 h1:W1dpZ/Q6+DjUpiAUSmIHuFn7rAvetlSqzQCtf0tKEEA=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.103/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/kms v1.0.563/go.mod h1:uom4Nvi9W+Qkom0exYiJ9VWJjXwyxtPYTkKkaLMlfE0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/lkeap v1.3.103 h1:z7Xh69LIe65ea866b9BVXJL/Jrf/kxOy5ggaIqpIrc0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/lkeap v1.3.103/go.mod h1:vw9jKKb4OeMEYnZqsKYoyMEJ/xv16oWnKVh3/JLOJvg=
 github.com/tencentyun/cos-go-sdk-v5 v0.7.73 h1:uFfgp1A7cQaAGR6QP9DsIkoEQ67b8ewj5r1RV6XB540=
 github.com/tencentyun/cos-go-sdk-v5 v0.7.73/go.mod h1:STbTNaNKq03u+gscPEGOahKzLcGSYOj6Dzc5zNay7Pg=
 github.com/tencentyun/qcloud-cos-sts-sdk v0.0.0-20250515025012-e0eec8a5d123/go.mod h1:b18KQa4IxHbxeseW1GcZox53d7J0z39VNONTxvvlkXw=

--- a/internal/handler/initialization.go
+++ b/internal/handler/initialization.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/models/asr"
 	"github.com/Tencent/WeKnora/internal/models/chat"
 	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/models/provider"
 	"github.com/Tencent/WeKnora/internal/models/rerank"
 	"github.com/Tencent/WeKnora/internal/models/utils/ollama"
 	"github.com/Tencent/WeKnora/internal/types"
@@ -1537,6 +1538,8 @@ type ModelTestRequest struct {
 	Dimension     int               `json:"dimension,omitempty"`
 	CustomHeaders map[string]string `json:"customHeaders,omitempty"`
 	ExtraConfig   map[string]string `json:"extraConfig,omitempty"`
+	// AppSecret 用于 LKEAP Rerank 等需要第二段密钥的场景（对应模型 Parameters.AppSecret）。
+	AppSecret string `json:"appSecret,omitempty"`
 	// ModelID, when set, instructs the handler to substitute any missing
 	// secrets (APIKey, AppSecret via ExtraConfig) from the stored model
 	// record before assembling the test client. This lets the "Test
@@ -1559,10 +1562,7 @@ func (h *InitializationHandler) fillSecretsFromStoredModel(ctx context.Context, 
 	if req == nil || req.ModelID == "" {
 		return
 	}
-	if req.APIKey != "" {
-		// Already supplied — nothing to merge. (We don't need to look up
-		// AppSecret separately since the WeKnoraCloud path resolves it
-		// from the tenant, not the model record.)
+	if req.APIKey != "" && req.AppSecret != "" {
 		return
 	}
 	stored, err := h.modelService.GetModelByID(ctx, req.ModelID)
@@ -1574,12 +1574,28 @@ func (h *InitializationHandler) fillSecretsFromStoredModel(ctx context.Context, 
 	if req.APIKey == "" {
 		req.APIKey = stored.Parameters.APIKey
 	}
+	if req.AppSecret == "" {
+		req.AppSecret = stored.Parameters.AppSecret
+	}
 }
 
 // RemoteModelCheckRequest 兼容旧 swagger 定义。
 //
 // Deprecated: 保留是为了不破坏已生成的 API 文档，新代码请直接使用 ModelTestRequest。
 type RemoteModelCheckRequest = ModelTestRequest
+
+// decryptModelAppSecret 解密模型 Parameters 中的 AppSecret（与 modelService 行为一致）。
+func decryptModelAppSecret(encrypted string) string {
+	if encrypted == "" {
+		return encrypted
+	}
+	if key := utils.GetAESKey(); key != nil {
+		if plain, err := utils.DecryptAESGCM(encrypted, key); err == nil {
+			return plain
+		}
+	}
+	return encrypted
+}
 
 // buildTestModel 把测试连接请求转成一个临时的 *types.Model（不落库），
 // 供 ConfigFromModel 使用。source 为空时按 defaultSource 兜底（chat/rerank/asr
@@ -1598,6 +1614,7 @@ func (h *InitializationHandler) buildTestModel(
 		Parameters: types.ModelParameters{
 			BaseURL:       req.BaseURL,
 			APIKey:        req.APIKey,
+			AppSecret:     req.AppSecret,
 			Provider:      req.Provider,
 			InterfaceType: req.InterfaceType,
 			ExtraConfig:   req.ExtraConfig,
@@ -1896,6 +1913,10 @@ func (h *InitializationHandler) CheckRerankModel(c *gin.Context) {
 	}
 
 	model := h.buildTestModel(&req, types.ModelTypeRerank, types.ModelSourceRemote)
+	if provider.ProviderName(model.Parameters.Provider) == provider.ProviderLKEAP {
+		appID = ""
+		appSecret = decryptModelAppSecret(model.Parameters.AppSecret)
+	}
 	available, message := h.checkRerankModelConnection(ctx, model, appID, appSecret)
 
 	logger.Infof(ctx, "Rerank model check completed, available: %v, message: %s", available, message)

--- a/internal/models/provider/lkeap.go
+++ b/internal/models/provider/lkeap.go
@@ -10,6 +10,8 @@ import (
 const (
 	// LKEAPBaseURL 腾讯云知识引擎原子能力 (LKEAP) 兼容 OpenAI 协议的 BaseURL
 	LKEAPBaseURL = "https://api.lkeap.cloud.tencent.com/v1"
+	// LKEAPRerankBaseURL 腾讯云知识引擎原子能力 Rerank API 域名（TC3 签名）
+	LKEAPRerankBaseURL = "https://lkeap.tencentcloudapi.com"
 )
 
 // LKEAPProvider 实现腾讯云 LKEAP 的 Provider 接口
@@ -25,12 +27,14 @@ func (p *LKEAPProvider) Info() ProviderInfo {
 	return ProviderInfo{
 		Name:        ProviderLKEAP,
 		DisplayName: "腾讯云 LKEAP",
-		Description: "DeepSeek-R1, DeepSeek-V3 系列模型，支持思维链",
+		Description: "DeepSeek-R1, DeepSeek-V3, lke-reranker-base 等",
 		DefaultURLs: map[types.ModelType]string{
 			types.ModelTypeKnowledgeQA: LKEAPBaseURL,
+			types.ModelTypeRerank:      LKEAPRerankBaseURL,
 		},
 		ModelTypes: []types.ModelType{
 			types.ModelTypeKnowledgeQA,
+			types.ModelTypeRerank,
 		},
 		RequiresAuth: true,
 	}

--- a/internal/models/provider/provider.go
+++ b/internal/models/provider/provider.go
@@ -258,7 +258,7 @@ func DetectProvider(baseURL string) ProviderName {
 		return ProviderQianfan
 	case containsAny(baseURL, "longcat.chat"):
 		return ProviderLongCat
-	case containsAny(baseURL, "lkeap.cloud.tencent.com", "api.lkeap"):
+	case containsAny(baseURL, "lkeap.cloud.tencent.com", "api.lkeap", "lkeap.tencentcloudapi.com"):
 		return ProviderLKEAP
 	case containsAny(baseURL, "nvidia.com"):
 		return ProviderNvidia

--- a/internal/models/provider/provider_test.go
+++ b/internal/models/provider/provider_test.go
@@ -231,14 +231,19 @@ func TestListByModelType(t *testing.T) {
 		providers := ListByModelType(types.ModelTypeRerank)
 		assert.NotEmpty(t, providers)
 		// Check that Aliyun supports rerank
-		found := false
+		foundAliyun := false
+		foundLKEAP := false
 		for _, p := range providers {
 			if p.Name == ProviderAliyun {
-				found = true
-				break
+				foundAliyun = true
+			}
+			if p.Name == ProviderLKEAP {
+				foundLKEAP = true
+				assert.Equal(t, LKEAPRerankBaseURL, p.GetDefaultURL(types.ModelTypeRerank))
 			}
 		}
-		assert.True(t, found, "Aliyun should support rerank")
+		assert.True(t, foundAliyun, "Aliyun should support rerank")
+		assert.True(t, foundLKEAP, "LKEAP should support rerank")
 	})
 
 	t.Run("embedding models include openrouter", func(t *testing.T) {

--- a/internal/models/rerank/lkeap_reranker.go
+++ b/internal/models/rerank/lkeap_reranker.go
@@ -1,0 +1,124 @@
+package rerank
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"
+	lkeap "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/lkeap/v20240522"
+)
+
+const (
+	// LKEAPRerankEndpoint 腾讯云知识引擎原子能力 Rerank API 域名
+	LKEAPRerankEndpoint = "lkeap.tencentcloudapi.com"
+	// LKEAPDefaultRegion RunRerank 支持的地域，默认广州
+	LKEAPDefaultRegion = "ap-guangzhou"
+	// LKEAPDefaultRerankModel 默认 rerank 模型名
+	LKEAPDefaultRerankModel = "lke-reranker-base"
+)
+
+// LKEAPReranker 使用腾讯云知识引擎原子能力 RunRerank 接口进行重排序。
+// 鉴权使用腾讯云 API 密钥：APIKey 为 SecretId，AppSecret 为 SecretKey。
+type LKEAPReranker struct {
+	modelName string
+	modelID   string
+	client    *lkeap.Client
+}
+
+// NewLKEAPReranker 创建 LKEAP rerank 客户端。
+func NewLKEAPReranker(config *RerankerConfig) (*LKEAPReranker, error) {
+	secretID := strings.TrimSpace(config.APIKey)
+	secretKey := strings.TrimSpace(config.AppSecret)
+	if secretKey == "" && config.ExtraConfig != nil {
+		secretKey = strings.TrimSpace(config.ExtraConfig["secret_key"])
+	}
+	if secretID == "" || secretKey == "" {
+		return nil, fmt.Errorf("secret_id and secret_key are required for LKEAP rerank (set API Key and Secret Key)")
+	}
+
+	region := LKEAPDefaultRegion
+	if config.ExtraConfig != nil {
+		if r := strings.TrimSpace(config.ExtraConfig["region"]); r != "" {
+			region = r
+		}
+	}
+
+	credential := common.NewCredential(secretID, secretKey)
+	cpf := profile.NewClientProfile()
+	cpf.HttpProfile.Endpoint = LKEAPRerankEndpoint
+
+	client, err := lkeap.NewClient(credential, region, cpf)
+	if err != nil {
+		return nil, fmt.Errorf("create LKEAP client: %w", err)
+	}
+
+	modelName := strings.TrimSpace(config.ModelName)
+	if modelName == "" {
+		modelName = LKEAPDefaultRerankModel
+	}
+
+	return &LKEAPReranker{
+		modelName: modelName,
+		modelID:   config.ModelID,
+		client:    client,
+	}, nil
+}
+
+// Rerank 调用 RunRerank 对文档按与 query 的相关性打分。
+func (r *LKEAPReranker) Rerank(ctx context.Context, query string, documents []string) ([]RankResult, error) {
+	if len(documents) == 0 {
+		return []RankResult{}, nil
+	}
+	if len(documents) > 60 {
+		return nil, fmt.Errorf("LKEAP rerank supports at most 60 documents, got %d", len(documents))
+	}
+
+	req := lkeap.NewRunRerankRequest()
+	req.Query = common.StringPtr(query)
+	req.Docs = common.StringPtrs(documents)
+	req.Model = common.StringPtr(r.modelName)
+
+	logger.Debugf(ctx, "%s", buildRerankRequestDebug(r.modelName, LKEAPRerankEndpoint, query, documents))
+
+	resp, err := r.client.RunRerankWithContext(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("LKEAP RunRerank: %w", err)
+	}
+	if resp == nil || resp.Response == nil || len(resp.Response.ScoreList) == 0 {
+		return nil, fmt.Errorf("LKEAP rerank API returned empty score list")
+	}
+
+	scores := resp.Response.ScoreList
+	if len(scores) != len(documents) {
+		return nil, fmt.Errorf("LKEAP rerank score count mismatch: got %d scores for %d documents",
+			len(scores), len(documents))
+	}
+
+	results := make([]RankResult, len(documents))
+	for i, score := range scores {
+		if score == nil {
+			continue
+		}
+		results[i] = RankResult{
+			Index: i,
+			Document: DocumentInfo{
+				Text: documents[i],
+			},
+			RelevanceScore: *score,
+		}
+	}
+	return results, nil
+}
+
+// GetModelName returns the rerank model name.
+func (r *LKEAPReranker) GetModelName() string {
+	return r.modelName
+}
+
+// GetModelID returns the model ID.
+func (r *LKEAPReranker) GetModelID() string {
+	return r.modelID
+}

--- a/internal/models/rerank/lkeap_reranker_test.go
+++ b/internal/models/rerank/lkeap_reranker_test.go
@@ -1,0 +1,67 @@
+package rerank
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewLKEAPReranker_requiresCredentials(t *testing.T) {
+	_, err := NewLKEAPReranker(&RerankerConfig{
+		ModelName: "lke-reranker-base",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret_id")
+}
+
+func TestNewLKEAPReranker_secretKeyFromExtraConfig(t *testing.T) {
+	r, err := NewLKEAPReranker(&RerankerConfig{
+		APIKey:    "AKIDtest",
+		ModelName: "lke-reranker-base",
+		ExtraConfig: map[string]string{
+			"secret_key": "sk-test",
+			"region":     "ap-beijing",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	assert.Equal(t, "lke-reranker-base", r.GetModelName())
+}
+
+func TestNewLKEAPReranker_defaultModelName(t *testing.T) {
+	r, err := NewLKEAPReranker(&RerankerConfig{
+		APIKey:    "AKIDtest",
+		AppSecret: "sk-test",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, LKEAPDefaultRerankModel, r.GetModelName())
+}
+
+func TestLKEAPReranker_Rerank_emptyDocuments(t *testing.T) {
+	r, err := NewLKEAPReranker(&RerankerConfig{
+		APIKey:    "AKIDtest",
+		AppSecret: "sk-test",
+	})
+	require.NoError(t, err)
+
+	results, err := r.Rerank(t.Context(), "query", nil)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestLKEAPReranker_Rerank_tooManyDocuments(t *testing.T) {
+	r, err := NewLKEAPReranker(&RerankerConfig{
+		APIKey:    "AKIDtest",
+		AppSecret: "sk-test",
+	})
+	require.NoError(t, err)
+
+	docs := make([]string, 61)
+	for i := range docs {
+		docs[i] = "doc"
+	}
+	_, err = r.Rerank(t.Context(), "query", docs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "60")
+}

--- a/internal/models/rerank/reranker.go
+++ b/internal/models/rerank/reranker.go
@@ -152,6 +152,8 @@ func newReranker(config *RerankerConfig) (Reranker, error) {
 		reranker, err = NewNvidiaReranker(config)
 	case provider.ProviderWeKnoraCloud:
 		reranker, err = NewWeKnoraCloudReranker(config)
+	case provider.ProviderLKEAP:
+		reranker, err = NewLKEAPReranker(config)
 	default:
 		reranker, err = NewOpenAIReranker(config)
 	}


### PR DESCRIPTION
- Added support for Tencent Cloud LKEAP Rerank, including new configuration options for SecretId and SecretKey.
- Updated frontend components to handle LKEAP-specific fields and enhance user experience with appropriate labels and placeholders.
- Enhanced backend logic to manage LKEAP credentials and integrate with the new rerank API.
- Improved localization for LKEAP-related terms across multiple languages, ensuring clarity and consistency in user-facing messages.
- Introduced tests for LKEAP Reranker functionality to ensure reliability and correctness in handling requests.

Close #1513 