### PR TITLE
feat: support Milvus database selection for vector stores

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1365,6 +1365,7 @@ export default {
       use_tls: 'Use TLS',
       scheme: 'Scheme',
       grpc_address: 'gRPC Address',
+      database: 'Database Name',
       use_default_connection: 'Use Default Connection',
       index_name: 'Index Name',
       number_of_shards: 'Shards',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -1223,6 +1223,7 @@ export default {
       use_tls: "TLS 사용",
       scheme: "프로토콜",
       grpc_address: "gRPC 주소",
+      database: "데이터베이스 이름",
       use_default_connection: "기본 연결 사용",
       index_name: "인덱스 이름",
       number_of_shards: "샤드 수",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -1277,6 +1277,7 @@ export default {
       use_tls: 'Использовать TLS',
       scheme: 'Схема',
       grpc_address: 'gRPC адрес',
+      database: 'Имя базы данных',
       use_default_connection: 'Использовать подключение по умолчанию',
       index_name: 'Имя индекса',
       number_of_shards: 'Шарды',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1231,6 +1231,7 @@ export default {
       use_tls: "使用 TLS",
       scheme: "协议",
       grpc_address: "gRPC 地址",
+      database: "数据库名",
       use_default_connection: "使用默认连接",
       index_name: "索引名称",
       number_of_shards: "分片数",

--- a/internal/container/engine_factory.go
+++ b/internal/container/engine_factory.go
@@ -189,7 +189,16 @@ func createQdrantEngine(store types.VectorStore) (interfaces.RetrieveEngineServi
 }
 
 func createMilvusEngine(ctx context.Context, store types.VectorStore) (interfaces.RetrieveEngineService, error) {
-	cc := store.ConnectionConfig
+	milvusCfg := buildMilvusClientConfig(store.ConnectionConfig)
+	client, err := milvusclient.New(ctx, &milvusCfg)
+	if err != nil {
+		return nil, fmt.Errorf("create milvus client: %w", err)
+	}
+	repo := milvusRepo.NewMilvusRetrieveEngineRepository(client, &store.IndexConfig)
+	return retriever.NewKVHybridRetrieveEngine(repo, types.MilvusRetrieverEngineType), nil
+}
+
+func buildMilvusClientConfig(cc types.ConnectionConfig) milvusclient.ClientConfig {
 	addr := cc.Addr
 	if addr == "" {
 		addr = "localhost:19530"
@@ -205,15 +214,10 @@ func createMilvusEngine(ctx context.Context, store types.VectorStore) (interface
 	if cc.Password != "" {
 		milvusCfg.Password = cc.Password
 	}
-	// NOTE: Milvus DBName is not yet in ConnectionConfig.
-	// Phase 1 limitation — only the default database is used.
-
-	client, err := milvusclient.New(ctx, &milvusCfg)
-	if err != nil {
-		return nil, fmt.Errorf("create milvus client: %w", err)
+	if cc.Database != "" {
+		milvusCfg.DBName = cc.Database
 	}
-	repo := milvusRepo.NewMilvusRetrieveEngineRepository(client, &store.IndexConfig)
-	return retriever.NewKVHybridRetrieveEngine(repo, types.MilvusRetrieverEngineType), nil
+	return milvusCfg
 }
 
 func createWeaviateEngine(store types.VectorStore) (interfaces.RetrieveEngineService, error) {

--- a/internal/container/engine_factory_test.go
+++ b/internal/container/engine_factory_test.go
@@ -1,0 +1,46 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestBuildMilvusClientConfig_UsesDatabaseName(t *testing.T) {
+	cfg := buildMilvusClientConfig(types.ConnectionConfig{
+		Addr:     "milvus.example.com:19530",
+		Username: "tester",
+		Password: "secret",
+		Database: "regdi_ram_haom1",
+	})
+
+	if cfg.Address != "milvus.example.com:19530" {
+		t.Fatalf("expected address to be preserved, got %q", cfg.Address)
+	}
+	if cfg.Username != "tester" {
+		t.Fatalf("expected username to be preserved, got %q", cfg.Username)
+	}
+	if cfg.Password != "secret" {
+		t.Fatalf("expected password to be preserved, got %q", cfg.Password)
+	}
+	if cfg.DBName != "regdi_ram_haom1" {
+		t.Fatalf("expected DBName to be propagated, got %q", cfg.DBName)
+	}
+	if len(cfg.DialOptions) != 1 {
+		t.Fatalf("expected one dial option, got %d", len(cfg.DialOptions))
+	}
+}
+
+func TestBuildMilvusClientConfig_DefaultsAddressWhenMissing(t *testing.T) {
+	cfg := buildMilvusClientConfig(types.ConnectionConfig{})
+
+	if cfg.Address != "localhost:19530" {
+		t.Fatalf("expected default address localhost:19530, got %q", cfg.Address)
+	}
+	if cfg.DBName != "" {
+		t.Fatalf("expected empty DBName by default, got %q", cfg.DBName)
+	}
+	if len(cfg.DialOptions) != 1 {
+		t.Fatalf("expected one dial option, got %d", len(cfg.DialOptions))
+	}
+}

--- a/internal/types/vectorstore.go
+++ b/internal/types/vectorstore.go
@@ -137,7 +137,8 @@ type ConnectionConfig struct {
 	// Weaviate
 	GrpcAddress string `yaml:"grpc_address" json:"grpc_address,omitempty"`
 	Scheme      string `yaml:"scheme" json:"scheme,omitempty"`
-	// Tencent VectorDB and Doris database name.
+	// Database name used by engines that support database-level namespaces
+	// (currently Milvus, Tencent VectorDB, and Doris).
 	Database string `yaml:"database" json:"database,omitempty"`
 	// Postgres
 	UseDefaultConnection bool `yaml:"use_default_connection" json:"use_default_connection,omitempty"`
@@ -681,6 +682,7 @@ func GetVectorStoreTypes() []VectorStoreTypeInfo {
 			DisplayName: "Milvus",
 			ConnectionFields: []VectorStoreFieldInfo{
 				{Name: "addr", Type: "string", Required: true, Description: "Address", Default: "localhost:19530"},
+				{Name: "database", Type: "string", Required: false, Description: "Database Name"},
 				{Name: "username", Type: "string", Required: false, Description: "Username", Default: "root"},
 				{Name: "password", Type: "string", Required: false, Sensitive: true, Description: "Password"},
 			},

--- a/internal/types/vectorstore_test.go
+++ b/internal/types/vectorstore_test.go
@@ -286,6 +286,25 @@ func TestGetVectorStoreTypes(t *testing.T) {
 		assert.True(t, seen["password"].Sensitive)
 	})
 
+	t.Run("milvus exposes optional database connection field", func(t *testing.T) {
+		var milvusType VectorStoreTypeInfo
+		for _, typ := range types {
+			if typ.Type == "milvus" {
+				milvusType = typ
+				break
+			}
+		}
+		require.NotEmpty(t, milvusType.ConnectionFields)
+
+		seen := map[string]VectorStoreFieldInfo{}
+		for _, f := range milvusType.ConnectionFields {
+			seen[f.Name] = f
+		}
+		require.Contains(t, seen, "database")
+		assert.False(t, seen["database"].Required)
+		assert.Equal(t, "string", seen["database"].Type)
+	})
+
 	t.Run("elasticsearch has connection and index fields", func(t *testing.T) {
 		var esType VectorStoreTypeInfo
 		for _, typ := range types {


### PR DESCRIPTION
## Description

This PR adds Milvus database selection to the vector store configuration flow.

Today the Milvus vector store UI only allows configuring the server address, credentials, and collection name. When a database is not specified, the Milvus client falls back to the `default` database.

In our environment, the `default` database is protected and regular application accounts are not allowed to create collections there. As a result, users can connect successfully but later fail during indexing with permission errors such as `PrivilegeCreateCollection` or `PrivilegeDelete` in the `default` database.

This change makes the Milvus database configurable in the vector store settings and passes the configured value through to the Milvus client `DBName`. The UI also exposes this field in the connection section, placed under the Milvus address to match the Attu connection flow and make the database/collection distinction clearer.

Changes included:
- add an optional `database` field to the Milvus vector store connection schema
- pass `connection_config.database` into the Milvus client config
- add tests covering the new Milvus database config behavior
- add UI labels for the new field

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #

## Testing

Manual verification:
1. Open Settings → Vector Stores → Add Milvus
2. Confirm the form now shows a `Database Name` field under the address field
3. Create a Milvus vector store with:
   - Milvus address
   - database name
   - username / password
   - collection name
4. Re-run knowledge parsing / indexing
5. Confirm the Milvus client uses the configured database instead of falling back to `default`

Automated coverage:
- added a test to verify the Milvus type metadata exposes the optional `database` field
- added a test to verify the Milvus client config propagates `connection_config.database` into `DBName`

Note:
- I could not fully run `make test` in the current environment because external Go module download access was unavailable.

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

UI before/after:
- added Milvus `Database Name` field in the connection section
- placed below the Milvus address, following the Attu connection layout

before:
没有数据库名的选项
after: 
<img width="603" height="1091" alt="image" src="https://github.com/user-attachments/assets/8999ce8e-91a2-4c31-9c3b-9e46f794c9cb" />
<img width="541" height="507" alt="截屏2026-06-04 23 31 03" src="https://github.com/user-attachments/assets/89d017ce-f8ad-4ea6-ad99-5293756656e6" />

