### PR TITLE
feat(migrations): HNSW index for 1024-dim embeddings (bge-m3)

### DIFF
--- a/migrations/versioned/000059_embeddings_hnsw_1024.down.sql
+++ b/migrations/versioned/000059_embeddings_hnsw_1024.down.sql
@@ -1,0 +1,2 @@
+-- Down migration: drop the 1024-dim HNSW partial index added in 000044.
+DROP INDEX IF EXISTS embeddings_embedding_idx_1024;

--- a/migrations/versioned/000059_embeddings_hnsw_1024.up.sql
+++ b/migrations/versioned/000059_embeddings_hnsw_1024.up.sql
@@ -1,0 +1,39 @@
+-- Migration 000044: HNSW index for bge-m3 / 1024-dim embeddings
+--
+-- Upstream's 000002 only created HNSW partial indexes for dim=3584 (OpenAI
+-- text-embedding-3-large) and dim=798. Both queries fall through to a
+-- sequential scan on the 1024-dim halfvec column when the bound embedder
+-- is bge-m3 — which is the default for any on-device deployment using
+-- localhub-embedder.
+--
+-- Symptom: vector recall stays "correct but slow" (seq scan of all rows in
+-- the embeddings table per query, ~100-500ms by KB size). Downstream agents
+-- that probe latency-sensitive endpoints assumed degradation.
+--
+-- Fix: same partial-index pattern, dim=1024. Matches the exact expression
+-- used in repository.go SearchEmbedding query (embedding::halfvec(1024) <=>
+-- $1::halfvec(1024)) so the planner picks it up automatically.
+--
+-- Note: CONCURRENTLY is not used here because plpgsql DO blocks open an
+-- implicit transaction and CREATE INDEX CONCURRENTLY can't run inside one.
+-- For a fresh install this is a no-op (empty table); for production
+-- backfill the operator should build the index manually using
+-- CREATE INDEX CONCURRENTLY before applying this migration, then this
+-- block becomes idempotent via IF NOT EXISTS.
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'embeddings_embedding_idx_1024' OR indexname LIKE 'embeddings_embedding%1024%') THEN
+            CREATE INDEX embeddings_embedding_idx_1024 ON embeddings
+            USING hnsw ((embedding::halfvec(1024)) halfvec_cosine_ops)
+            WITH (m = 16, ef_construction = 64)
+            WHERE (dimension = 1024);
+            RAISE NOTICE '[Migration 000044] Created HNSW index for dimension 1024 (bge-m3)';
+        ELSE
+            RAISE NOTICE '[Migration 000044] HNSW index for dimension 1024 already exists';
+        END IF;
+    ELSE
+        RAISE NOTICE '[Migration 000044] pgvector extension not installed · skipping';
+    END IF;
+END $$;


### PR DESCRIPTION
## Problem

`migrations/versioned/000002_embeddings.up.sql` adds HNSW partial indexes only for `dimension = 3584` (OpenAI `text-embedding-3-large`) and `dimension = 798`. Every deployment binding **bge-m3** as the embedder — which is the default for local / on-device setups and one of the most common open-source multilingual choices — produces 1024-dim vectors and finds no matching index.

`internal/application/repository/retriever/postgres/repository.go` (around line 397-413) carefully builds its `ORDER BY embedding::halfvec(<dim>) <=> $1::halfvec(<dim>)` expression to match the indexed expression exactly so the planner picks up HNSW. With dim=1024, there is no such index, so the planner silently falls back to a sequential scan over the entire `embeddings` table.

Result: vector recall stays **correct** but adds 100-500 ms per query depending on KB size. On chat / agent paths this dominates p50 latency. Symptoms are easy to misdiagnose as embedder regression (the original report on a downstream consumer described it as "vector channel returns constant rankings" because seq-scan latency made every request indistinguishable from BM25-only timing).

## Fix

Add migration `000044_embeddings_hnsw_1024.up.sql` (with matching `.down.sql`). Same partial-index pattern as 000002 — same expression, same opclass, same `m`/`ef_construction` — just targeting `dimension = 1024`:

```sql
CREATE INDEX embeddings_embedding_idx_1024 ON embeddings
USING hnsw ((embedding::halfvec(1024)) halfvec_cosine_ops)
WITH (m = 16, ef_construction = 64)
WHERE (dimension = 1024);
```

`CONCURRENTLY` is not used because plpgsql `DO` blocks open an implicit transaction and `CREATE INDEX CONCURRENTLY` cannot run inside one — same pattern as the existing 3584/798 blocks. On fresh installs the table is empty so the cost is zero; for production backfill the operator can build the index manually with `CONCURRENTLY` first and the `IF NOT EXISTS` guard makes this migration a no-op.

## Measurement

63274-row `embeddings` table, single KB filter:

| | latency |
|---|---|
| Before (seq scan) | 100-500 ms per vector query |
| After (HNSW scan) | **27-30 ms** (`EXPLAIN ANALYZE` confirms `Index Scan using embeddings_embedding_idx_1024`) |

Planner verification:

```
Index Scan using embeddings_embedding_idx_1024 on embeddings
  Order By: ((embedding)::halfvec(1024) <=> ($0)::halfvec(1024))
  actual time=27.678..30.794 rows=10 loops=1
```

## Scope

Pure additive migration. No code changes, no behavioral changes for non-1024-dim deployments, no risk to existing 3584 / 798 HNSW paths.