### PR TITLE
fix: reject cross-store reuse_vectors knowledge move

### DIFF
--- a/internal/application/service/knowledge_clone_move.go
+++ b/internal/application/service/knowledge_clone_move.go
@@ -995,6 +995,18 @@ func (s *knowledgeService) moveOneKnowledge(
 		return fmt.Errorf("knowledge %s is not in completed status (current: %s)", knowledgeID, knowledge.ParseStatus)
 	}
 
+	// Reject a cross-store reuse_vectors move BEFORE mutating status, so a
+	// rejected move leaves the knowledge untouched (Completed) rather than
+	// stranded in Processing. reuse_vectors copies indices through the source
+	// store only; a cross-store copy would corrupt vector data. The handler
+	// rejects this synchronously — this is defense-in-depth for directly
+	// enqueued tasks. Cross-store moves must use reparse mode.
+	if mode == "reuse_vectors" && !sourceKB.SharesStoreWith(targetKB) {
+		return fmt.Errorf(
+			"reuse_vectors move across different vector stores is not supported "+
+				"(source KB %s, target KB %s); use reparse mode", sourceKB.ID, targetKB.ID)
+	}
+
 	// Mark as processing during move
 	knowledge.ParseStatus = types.ParseStatusProcessing
 	if err := s.repo.UpdateKnowledge(ctx, knowledge); err != nil {
@@ -1019,6 +1031,19 @@ func (s *knowledgeService) moveKnowledgeReuseVectors(
 ) error {
 	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
 
+	// reuse_vectors copies index entries directly between KBs, which only works
+	// inside the same VectorStore backend (CopyIndices is routed through the
+	// source store). A cross-store reuse_vectors move would write target-KB rows
+	// into the source store and then delete the source indices, corrupting data.
+	// The MoveKnowledge handler rejects this up front; this is defense-in-depth
+	// for any path that enqueues a move task directly. Cross-store moves must use
+	// reparse mode (moveKnowledgeReparse), which re-indexes into the target store.
+	if !sourceKB.SharesStoreWith(targetKB) {
+		return fmt.Errorf(
+			"reuse_vectors move across different vector stores is not supported "+
+				"(source KB %s, target KB %s); use reparse mode", sourceKB.ID, targetKB.ID)
+	}
+
 	// 1. Get old chunk IDs for vector index copy mapping
 	oldChunks, err := s.chunkRepo.ListChunksByKnowledgeID(ctx, tenantID, knowledge.ID)
 	if err != nil {
@@ -1033,10 +1058,9 @@ func (s *knowledgeService) moveKnowledgeReuseVectors(
 
 	// 2. Copy vector indices from source KB to target KB
 	if len(chunkIDMapping) > 0 && knowledge.EmbeddingModelID != "" {
-		// reuse_vectors mode copies index entries directly between KBs, which
-		// only works inside the same VectorStore backend. Route through the
-		// source KB's binding; callers must reject cross-store moves before
-		// landing here.
+		// Same VectorStore backend is guaranteed by the SharesStoreWith guard at
+		// the top of this function, so routing CopyIndices through the source
+		// KB's binding also resolves the target's store.
 		var sourceStoreID *string
 		if sourceKB != nil {
 			sourceStoreID = sourceKB.VectorStoreID

--- a/internal/application/service/knowledge_move_gate_test.go
+++ b/internal/application/service/knowledge_move_gate_test.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMoveKnowledgeReuseVectors_CrossStoreRejected verifies the defense-in-depth
+// guard: a reuse_vectors move whose source and target KBs are bound to different
+// vector stores must be rejected before any index copy runs. The guard fires at
+// the top of moveKnowledgeReuseVectors, so an empty knowledgeService (no repos)
+// is sufficient — the function returns before touching any dependency.
+func TestMoveKnowledgeReuseVectors_CrossStoreRejected(t *testing.T) {
+	s := &knowledgeService{}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+
+	storeA, storeB := "store-a", "store-b"
+	tests := []struct {
+		name     string
+		srcStore *string
+		dstStore *string
+	}{
+		{"both bound, different stores", &storeA, &storeB},
+		{"source bound, target env-store", &storeA, nil},
+		{"source env-store, target bound", nil, &storeB},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := &types.KnowledgeBase{ID: "kb-src", VectorStoreID: tt.srcStore}
+			dst := &types.KnowledgeBase{ID: "kb-dst", VectorStoreID: tt.dstStore}
+			kn := &types.Knowledge{ID: "k1", EmbeddingModelID: "m1"}
+
+			err := s.moveKnowledgeReuseVectors(ctx, kn, src, dst)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "different vector stores")
+		})
+	}
+}
+
+// TestSharesStoreWith_GuardSemantics pins the same/cross-store classification the
+// move gate relies on, including the env-store (nil) normalization, so a change
+// to SharesStoreWith that would silently re-open the cross-store reuse_vectors
+// hole fails here.
+func TestSharesStoreWith_GuardSemantics(t *testing.T) {
+	storeA, storeB, empty := "store-a", "store-b", ""
+
+	same := func(a, b *string) bool {
+		return (&types.KnowledgeBase{VectorStoreID: a}).
+			SharesStoreWith(&types.KnowledgeBase{VectorStoreID: b})
+	}
+
+	assert.True(t, same(nil, nil), "both env-store → same")
+	assert.True(t, same(&empty, nil), "empty string normalizes to env-store")
+	assert.True(t, same(&storeA, &storeA), "same UUID → same")
+	assert.False(t, same(&storeA, &storeB), "different UUID → cross-store")
+	assert.False(t, same(&storeA, nil), "bound vs env-store → cross-store")
+}

--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -2003,6 +2003,18 @@ func (h *KnowledgeHandler) MoveKnowledge(c *gin.Context) {
 		return
 	}
 
+	// reuse_vectors copies index entries directly between KBs, which only works
+	// inside the same VectorStore backend. A cross-store reuse_vectors move would
+	// route CopyIndices through the SOURCE store and then delete the source
+	// indices, corrupting the vector data. Reject it and point the caller at
+	// reparse mode, which re-indexes into the target store safely.
+	if req.Mode == "reuse_vectors" && !sourceKB.SharesStoreWith(targetKB) {
+		c.Error(errors.NewBadRequestError(
+			"reuse_vectors move across different vector stores is not supported; " +
+				"use reparse mode to move into a different store"))
+		return
+	}
+
 	// Validate all knowledge IDs belong to source KB and are in completed status
 	for _, kID := range req.KnowledgeIDs {
 		knowledge, err := h.kgService.GetKnowledgeByID(ctx, kID)

--- a/internal/handler/knowledge_move_gate_test.go
+++ b/internal/handler/knowledge_move_gate_test.go
@@ -1,0 +1,136 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Tencent/WeKnora/internal/middleware"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+// MoveKnowledge cross-store reuse_vectors gate — handler-level pre-flight tests.
+//
+// reuse_vectors copies vector indices between KBs through the source store only;
+// a cross-store reuse_vectors move would corrupt vector data. The handler must
+// reject it synchronously (before enqueueing the async move) and point the
+// caller at reparse mode. reparse moves and same-store reuse_vectors must pass
+// the gate (they fail later here only because the stub knowledge does not exist,
+// which proves the gate did not short-circuit them).
+
+type stubMoveKBService struct {
+	interfaces.KnowledgeBaseService
+	byID func(ctx context.Context, id string) (*types.KnowledgeBase, error)
+}
+
+func (s *stubMoveKBService) GetKnowledgeBaseByID(ctx context.Context, id string) (*types.KnowledgeBase, error) {
+	return s.byID(ctx, id)
+}
+
+// stubMoveKGService.GetKnowledgeByID always reports not-found, so any request
+// that PASSES the store gate fails at the later knowledge-ID validation with a
+// distinct message — letting the test tell "rejected by gate" apart from
+// "passed the gate."
+type stubMoveKGService struct {
+	interfaces.KnowledgeService
+}
+
+func (s *stubMoveKGService) GetKnowledgeByID(_ context.Context, _ string) (*types.Knowledge, error) {
+	return nil, errors.New("knowledge not found")
+}
+
+func newMoveGateRouter(kb interfaces.KnowledgeBaseService, kg interfaces.KnowledgeService) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.ErrorHandler())
+	r.Use(func(c *gin.Context) {
+		c.Set(types.TenantIDContextKey.String(), uint64(1))
+		c.Set(types.UserIDContextKey.String(), "u-test")
+		c.Next()
+	})
+	// asynqClient stays nil: every case here either rejects at the gate or
+	// fails at knowledge-ID validation, so enqueue is never reached. A nil
+	// deref would mean the gate let a request through to enqueue unexpectedly.
+	h := &KnowledgeHandler{kbService: kb, kgService: kg}
+	r.POST("/move", h.MoveKnowledge)
+	return r
+}
+
+func TestMoveKnowledge_CrossStoreGate(t *testing.T) {
+	storeA, storeB := "store-a", "store-b"
+	kbWith := func(id string, store *string) *types.KnowledgeBase {
+		return &types.KnowledgeBase{ID: id, TenantID: 1, Type: "document",
+			EmbeddingModelID: "m1", VectorStoreID: store}
+	}
+
+	tests := []struct {
+		name           string
+		mode           string
+		srcStore       *string
+		dstStore       *string
+		wantStatus     int
+		wantBodyHas    string // substring that must appear
+		wantBodyNotHas string // substring that must NOT appear (gate message)
+	}{
+		{
+			name: "reuse_vectors cross-store rejected by gate",
+			mode: "reuse_vectors", srcStore: &storeA, dstStore: &storeB,
+			wantStatus: http.StatusBadRequest, wantBodyHas: "different vector stores",
+		},
+		{
+			name: "reparse cross-store passes gate (fails later at knowledge lookup)",
+			mode: "reparse", srcStore: &storeA, dstStore: &storeB,
+			wantStatus: http.StatusBadRequest, wantBodyNotHas: "different vector stores",
+		},
+		{
+			name: "reuse_vectors same-store passes gate",
+			mode: "reuse_vectors", srcStore: &storeA, dstStore: &storeA,
+			wantStatus: http.StatusBadRequest, wantBodyNotHas: "different vector stores",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kb := &stubMoveKBService{byID: func(_ context.Context, id string) (*types.KnowledgeBase, error) {
+				switch id {
+				case "kb-src":
+					return kbWith("kb-src", tt.srcStore), nil
+				case "kb-dst":
+					return kbWith("kb-dst", tt.dstStore), nil
+				}
+				return nil, errors.New("kb not found")
+			}}
+			router := newMoveGateRouter(kb, &stubMoveKGService{})
+
+			body, _ := json.Marshal(map[string]any{
+				"knowledge_ids": []string{"k1"},
+				"source_kb_id":  "kb-src",
+				"target_kb_id":  "kb-dst",
+				"mode":          tt.mode,
+			})
+			req := httptest.NewRequest(http.MethodPost, "/move", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body=%s", w.Code, tt.wantStatus, w.Body.String())
+			}
+			if tt.wantBodyHas != "" && !strings.Contains(w.Body.String(), tt.wantBodyHas) {
+				t.Fatalf("body %q does not contain %q", w.Body.String(), tt.wantBodyHas)
+			}
+			if tt.wantBodyNotHas != "" && strings.Contains(w.Body.String(), tt.wantBodyNotHas) {
+				t.Fatalf("body %q unexpectedly contains gate message %q (gate short-circuited a valid move)",
+					w.Body.String(), tt.wantBodyNotHas)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Moving a knowledge item with `mode=reuse_vectors` copies vector index entries directly between knowledge bases via `CopyIndices`, which only works when both KBs are bound to the **same** vector store — the copy is routed through the source KB's store. The code already documents this precondition ("callers must reject cross-store moves before landing here"), but nothing enforced it:

- `MoveKnowledge` validated only matching **type** and **embedding model**, never the store binding.
- `ListMoveTargets` filters candidates by type + embedding model only, so a KB bound to a *different* store is offered as a valid target.

A cross-store `reuse_vectors` move therefore ran `CopyIndices` against the source store (writing target-KB rows into the wrong store) and then `DeleteByKnowledgeIDList` removed the source indices — **corrupting/losing the vector data**. This only triggers in multi-store deployments (per-KB VectorStore binding); single-store setups are unaffected.

`reparse` mode is not affected — it re-indexes into the target store from scratch and is the supported way to move across stores.

**Changes**

Reject `reuse_vectors` moves whose source and target KBs are bound to different vector stores, reusing the existing `KnowledgeBase.SharesStoreWith` helper:

- **`MoveKnowledge` handler** — synchronous `400` before enqueueing, with a message pointing the caller at `reparse` mode.
- **`moveOneKnowledge`** — re-check **before** marking the knowledge as `processing`, so a rejected move leaves the item untouched (Completed) rather than stranded in `processing`.
- **`moveKnowledgeReuseVectors`** — a top-of-function guard as defense in depth for any directly-enqueued task, fulfilling the pre-existing "callers must reject" contract (comment updated accordingly).

`ListMoveTargets` is intentionally left as-is: cross-store KBs are valid `reparse` targets, so filtering them out would wrongly hide them. An optional frontend follow-up could disable the `reuse_vectors` option when the chosen target is cross-store.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #1610

## Testing

**Unit**
- `internal/handler/knowledge_move_gate_test.go` — handler pre-flight: `reuse_vectors` + cross-store → `400` ("different vector stores"); `reparse` + cross-store and `reuse_vectors` + same-store both pass the gate (they then fail at the stubbed knowledge lookup, confirming the gate did not short-circuit them).
- `internal/application/service/knowledge_move_gate_test.go` — worker defense-in-depth: `moveKnowledgeReuseVectors` rejects cross-store (both-bound / source-only / target-only store bindings); `SharesStoreWith` classification pinned (nil/empty/UUID normalization) so a change that re-opens the hole fails the test.

Both gates (sync handler + async worker) are exercised, and `reparse`/same-store paths are verified to pass through. The worker guard sits before the `processing` status mutation so a rejected move leaves no stranded state.

`gofmt`, `go vet`, and `go build ./...` are clean. Touched-package tests pass (`internal/handler`, `internal/application/service`, `internal/types`).

No E2E: the change is a pure pre-flight guard (`reuse_vectors && !SharesStoreWith`), and the unit tests cover both entry points and both branches; there is no runtime behavior that only surfaces against a live multi-store backend.

## Checklist

- [x] `gofmt` / `go vet` / `go build` pass locally; touched-package tests pass
- [x] Self-reviewed the code
- [x] Added tests covering the change
- [ ] Updated related documentation — N/A (no public API or doc surface change)
- [x] No breaking changes (rejects a previously-data-corrupting operation; `reparse` and same-store moves are unchanged)
