### PR TITLE
fix(handler): /knowledge/search — accept ?query= alias, reject empty keyword

### DIFF
--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -1793,7 +1793,19 @@ func (h *KnowledgeHandler) SearchKnowledge(c *gin.Context) {
 	if userID, ok := c.Get(types.UserIDContextKey.String()); ok {
 		ctx = context.WithValue(ctx, types.UserIDContextKey, userID)
 	}
+	// Accept both ?keyword= (legacy / upstream name) and ?query= (what most
+	// MCP / agent integrations send). Falling silently back to an unsorted
+	// listing when both are empty caused the "all queries return the same 5
+	// newest cards" footgun — return 400 instead so the caller gets a clear
+	// signal that the search wasn't query-driven.
 	keyword := c.Query("keyword")
+	if keyword == "" {
+		keyword = c.Query("query")
+	}
+	if strings.TrimSpace(keyword) == "" {
+		c.Error(errors.NewBadRequestError("missing search keyword: pass ?keyword=... or ?query=..."))
+		return
+	}
 	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
 	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
 


### PR DESCRIPTION
## Problem

`SearchKnowledge` reads only `?keyword=` and, when that parameter is missing, falls through to a default listing sorted by `created_at DESC`. The combination is a silent-failure footgun:

```go
keyword := c.Query("keyword")   // ← any other param name → ""
// service called with keyword="" → returns "latest N knowledges" with no
// indication that the query was never actually used.
```

This bit a downstream agent (Support GPT) hard. The integration was sending `?query=...` — the parameter name MCP / semantic-search consumers default to — and getting back the same 5 newest cards for every distinct user query. The team spent hours diagnosing it as "WeKnora embedding regression" / "vector channel returns constant rankings" before tracing it to the handler silently dropping the query and returning a date-sorted listing instead.

The handler itself is a thin filename/title `LIKE` search (its real purpose is the document-management UI in the frontend) — that's fine, the failure mode isn't. Returning a result that *looks like* a search but isn't query-driven is much more dangerous than a 400.

## Fix

Two tiny additive tweaks:

1. **Accept `?query=` as an alias for `?keyword=`.** Cheap compatibility win — almost every consumer (MCP servers, agent tooling, SDKs that mirror OpenAI/Anthropic search conventions) calls the parameter `query`. The original `keyword` keeps working for the frontend, no breakage.

2. **Reject empty keyword/query with 400.** Refusing the request is strictly better than silently returning a default listing dressed as search results. The error message also doubles as inline documentation:
   `\"missing search keyword: pass ?keyword=... or ?query=...\"`

Service layer (`knowledgeService.SearchKnowledge`) is untouched. Behavior for existing `?keyword=...` callers is byte-identical.

## Diff

```diff
- keyword := c.Query("keyword")
+ keyword := c.Query("keyword")
+ if keyword == "" {
+     keyword = c.Query("query")
+ }
+ if strings.TrimSpace(keyword) == "" {
+     c.Error(errors.NewBadRequestError(\"missing search keyword: pass ?keyword=... or ?query=...\"))
+     return
+ }
```

12 lines, single file, single function. Same handler.

## Tested

- `GET /api/v1/knowledge/search?keyword=foo` → unchanged behavior ✓
- `GET /api/v1/knowledge/search?query=foo` → now works (previously returned default listing) ✓
- `GET /api/v1/knowledge/search` → now returns 400 with usage hint (previously returned default listing) ✓

## Note on semantic search

Callers who actually want RAG retrieval should hit `POST /api/v1/knowledge-bases/{kb_id}/hybrid-search` — that's the real vector + BM25 endpoint and it works correctly. The PR here is purely about preventing this filename-search handler from masquerading as one when called with the wrong parameter name.