### PR TITLE
fix(auth): allow anonymous access to share-link endpoints (#1617)

### DIFF
--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -63,7 +63,12 @@ instance.interceptors.request.use(
 let isRefreshing = false;
 let failedQueue: Array<{ resolve: Function; reject: Function }> = [];
 
-const PUBLIC_AUTH_PATHS = ['/auth/auto-setup', '/auth/login', '/auth/register', '/auth/oidc/'];
+// Share-link endpoints (/auth/invitations/lookup, /auth/register-by-invite)
+// are reachable by anonymous users opening an invite link. A 401 from these
+// must surface to the page (e.g. expired token), not trigger the
+// refresh-then-redirect-to-login flow (issue #1617). '/auth/register' already
+// covers '/auth/register-by-invite' via substring match.
+const PUBLIC_AUTH_PATHS = ['/auth/auto-setup', '/auth/login', '/auth/register', '/auth/oidc/', '/auth/invitations/lookup'];
 
 function isPublicAuthRequest(url?: string): boolean {
   if (!url) return false;

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -20,15 +20,23 @@ import (
 
 // 无需认证的API列表
 var noAuthAPI = map[string][]string{
-	"/health":                    {"GET"},
-	"/api/v1/auth/register":      {"POST"},
-	"/api/v1/auth/login":         {"POST"},
-	"/api/v1/auth/auto-setup":    {"POST"},
-	"/api/v1/auth/config":        {"GET"},
-	"/api/v1/auth/oidc/config":   {"GET"},
-	"/api/v1/auth/oidc/url":      {"GET"},
-	"/api/v1/auth/oidc/callback": {"GET"},
-	"/api/v1/auth/refresh":       {"POST"},
+	"/health":                 {"GET"},
+	"/api/v1/auth/register":   {"POST"},
+	"/api/v1/auth/login":      {"POST"},
+	"/api/v1/auth/auto-setup": {"POST"},
+	// Share-link surfaces accept a plaintext invite token from anonymous
+	// callers (an invitee who hasn't registered yet). They are registered
+	// as public routes in RegisterAuthRoutes and rate-limited by IP, so the
+	// global Auth middleware must let them through — otherwise opening a
+	// share link while logged out 401s and the frontend bounces the user to
+	// /login instead of the register page (issue #1617).
+	"/api/v1/auth/invitations/lookup": {"POST"},
+	"/api/v1/auth/register-by-invite": {"POST"},
+	"/api/v1/auth/config":             {"GET"},
+	"/api/v1/auth/oidc/config":        {"GET"},
+	"/api/v1/auth/oidc/url":           {"GET"},
+	"/api/v1/auth/oidc/callback":      {"GET"},
+	"/api/v1/auth/refresh":            {"POST"},
 	// IM platforms (Feishu, Slack, etc.) commonly issue a HEAD request
 	// before GET to validate Content-Type / Content-Length when rendering
 	// image previews — both verbs must be allowed for image links to work.


### PR DESCRIPTION
## Summary

- An unauthenticated invitee opening a share link (`/register?token=...`) was redirected to the login page instead of seeing the register page (#1617).
- Root cause: the global `Auth` middleware allowlist (`noAuthAPI`) was missing the share-link routes, so `POST /api/v1/auth/invitations/lookup` returned `401 Unauthorized: missing authentication`. The frontend interceptor then treated that 401 as a session expiry and redirected to `/login`.
- Fix (backend): add `/api/v1/auth/invitations/lookup` and `/api/v1/auth/register-by-invite` (both `POST`) to `noAuthAPI`, matching how they are already registered as public, rate-limited routes in `RegisterAuthRoutes`.
- Fix (frontend): add `/auth/invitations/lookup` to `PUBLIC_AUTH_PATHS` so its 401 surfaces to the page instead of triggering the refresh-then-redirect-to-login flow.

## Test plan

- [x] `go build ./internal/middleware/...` and `go vet ./internal/middleware/...`
- [x] `go test ./internal/middleware/... ./internal/handler/...` (Auth/Invite/Register) pass
- [x] Manual: create a share link, open `/register?token=...` while logged out, confirm the register page loads instead of redirecting to `/login`

Refs: https://github.com/Tencent/WeKnora/issues/1617