### PR TITLE
fix: refresh wiki status after document polling completes

### DIFF
--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -42,6 +42,11 @@ import DocumentListView from './components/DocumentListView.vue';
 import DocumentBatchBar from './components/DocumentBatchBar.vue';
 import WikiBrowser from './wiki/WikiBrowser.vue';
 import { getWikiStats } from '@/api/wiki';
+import {
+  isKnowledgeParseInFlight,
+  knowledgeNeedsStatusPolling,
+  shouldRefreshWikiStatusAfterKnowledgePoll,
+} from './wikiStatusRefresh';
 import { listMoveTargets, moveKnowledge, getKnowledgeMoveProgress } from '@/api/knowledge-base';
 import { useI18n } from 'vue-i18n';
 import { formatStringDate, kbFileTypeVerification } from '@/utils';
@@ -320,7 +325,7 @@ function clearTraceAvailabilityCache() {
 // (primary parse OR post-process fan-out). Trace data exists and the
 // UI should treat the row as "in flight" rather than terminal.
 function isParseInFlight(status?: string): boolean {
-  return status === 'pending' || status === 'processing' || status === 'finalizing';
+  return isKnowledgeParseInFlight(status);
 }
 
 // Status line shown on the card body while parse is still in flight.
@@ -1091,9 +1096,7 @@ type KnowledgeCard = {
 // graph extract still running), and a `completed` row whose summary
 // hasn't landed yet keeps polling so the description fills in.
 const needsStatusPolling = (item: KnowledgeCard) => {
-  if (isParseInFlight(item.parse_status)) return true;
-  return item.parse_status == 'completed' &&
-    (item.summary_status == 'pending' || item.summary_status == 'processing');
+  return knowledgeNeedsStatusPolling(item);
 };
 
 const updateStatus = (analyzeList: KnowledgeCard[]) => {
@@ -1110,6 +1113,7 @@ const updateStatus = (analyzeList: KnowledgeCard[]) => {
   timeout = setTimeout(() => {
     batchQueryKnowledge(query).then((result: any) => {
       let hasChanges = false;
+      let shouldRefreshWikiStatus = false;
       if (result.success && result.data) {
         (result.data as KnowledgeCard[]).forEach((item: KnowledgeCard) => {
           const index = cardList.value.findIndex(card => card.id == item.id);
@@ -1118,6 +1122,7 @@ const updateStatus = (analyzeList: KnowledgeCard[]) => {
           if (cardList.value[index].parse_status !== item.parse_status ||
             cardList.value[index].summary_status !== item.summary_status ||
             cardList.value[index].description !== item.description) {
+            shouldRefreshWikiStatus ||= shouldRefreshWikiStatusAfterKnowledgePoll(cardList.value[index], item);
 
             // Always update the card data
             cardList.value[index].parse_status = item.parse_status;
@@ -1127,6 +1132,9 @@ const updateStatus = (analyzeList: KnowledgeCard[]) => {
             hasChanges = true;
           }
         });
+      }
+      if (shouldRefreshWikiStatus) {
+        void fetchWikiStatusOnce();
       }
       // If there are no changes, the watch won't trigger, so we must manually poll again
       // Even if there are changes, we can manually poll again just to be safe.

--- a/frontend/src/views/knowledge/wikiStatusRefresh.test.ts
+++ b/frontend/src/views/knowledge/wikiStatusRefresh.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { shouldRefreshWikiStatusAfterKnowledgePoll } from './wikiStatusRefresh.ts'
+
+test('refreshes wiki status when a polled document leaves an in-flight state', () => {
+  assert.equal(
+    shouldRefreshWikiStatusAfterKnowledgePoll(
+      { parse_status: 'finalizing', summary_status: 'processing' },
+      { parse_status: 'completed', summary_status: 'completed' },
+    ),
+    true,
+  )
+})
+
+test('does not refresh wiki status for ordinary in-flight polling updates', () => {
+  assert.equal(
+    shouldRefreshWikiStatusAfterKnowledgePoll(
+      { parse_status: 'pending' },
+      { parse_status: 'processing' },
+    ),
+    false,
+  )
+})

--- a/frontend/src/views/knowledge/wikiStatusRefresh.ts
+++ b/frontend/src/views/knowledge/wikiStatusRefresh.ts
@@ -1,0 +1,21 @@
+export type KnowledgePollStatus = {
+  parse_status?: string
+  summary_status?: string
+}
+
+export function isKnowledgeParseInFlight(status?: string): boolean {
+  return status === 'pending' || status === 'processing' || status === 'finalizing'
+}
+
+export function knowledgeNeedsStatusPolling(item: KnowledgePollStatus): boolean {
+  if (isKnowledgeParseInFlight(item.parse_status)) return true
+  return item.parse_status === 'completed' &&
+    (item.summary_status === 'pending' || item.summary_status === 'processing')
+}
+
+export function shouldRefreshWikiStatusAfterKnowledgePoll(
+  before: KnowledgePollStatus,
+  after: KnowledgePollStatus,
+): boolean {
+  return knowledgeNeedsStatusPolling(before) && !knowledgeNeedsStatusPolling(after)
+}


### PR DESCRIPTION
## Summary
- Fixes #1591.
- Refresh the parent Wiki status when a polled document leaves parsing/finalizing/summary generation state.
- Extract the polling-state transition logic into a small tested helper.

## Tests
- npx tsx --test src/components/modelEditorSourceState.test.ts src/utils/thinkingControl.test.ts src/views/knowledge/wikiStatusRefresh.test.ts
- npm run build-only
- npx playwright screenshot --wait-for-timeout=3000 http://127.0.0.1:5173/ D:\\tmp\\weknora-frontend-check.png

## Notes
- npm run type-check currently fails on existing unrelated frontend type errors across src/api, src/components, and src/views; this PR does not add new type-check-only errors in the touched files.