### PR TITLE
fix(knowledge): update doc-scroll-container class binding to account for loading state

### DIFF
--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -2315,7 +2315,7 @@ async function createNewSession(value: string): Promise<void> {
                   </t-tooltip>
                 </div>
               </div>
-              <div class="doc-scroll-container" :class="{ 'is-empty': !cardList.length }" ref="knowledgeScroll"
+              <div class="doc-scroll-container" :class="{ 'is-empty': !cardList.length && !docListLoading }" ref="knowledgeScroll"
                 @scroll="handleScroll">
                 <!-- 文档骨架屏 -->
                 <div v-if="docListLoading && cardList.length === 0" class="doc-card-list doc-card-list-animated">


### PR DESCRIPTION

- Modified the class binding of the doc-scroll-container to include a check for the loading state of the document list, ensuring the 'is-empty' class is applied correctly when there are no cards and documents are still loading.
