### PR TITLE
fix(chat): preserve provider tool-call metadata

### DIFF
--- a/internal/agent/act.go
+++ b/internal/agent/act.go
@@ -317,9 +317,10 @@ func (e *AgentEngine) runToolCall(
 		if repairErr := json.Unmarshal([]byte(repaired), &args); repairErr != nil {
 			logger.Errorf(ctx, "%s Failed to parse arguments (repair failed): %v", toolTag, err)
 			return types.ToolCall{
-				ID:   tc.ID,
-				Name: tc.Function.Name,
-				Args: map[string]any{"_raw": argsStr},
+				ID:               tc.ID,
+				Name:             tc.Function.Name,
+				Args:             map[string]any{"_raw": argsStr},
+				ProviderMetadata: tc.ProviderMetadata,
 				Result: &types.ToolResult{
 					Success: false,
 					Error: fmt.Sprintf(
@@ -413,11 +414,12 @@ func (e *AgentEngine) runToolCall(
 	duration := time.Since(toolCallStartTime).Milliseconds()
 
 	toolCall := types.ToolCall{
-		ID:       tc.ID,
-		Name:     tc.Function.Name,
-		Args:     args,
-		Result:   result,
-		Duration: duration,
+		ID:               tc.ID,
+		Name:             tc.Function.Name,
+		Args:             args,
+		Result:           result,
+		Duration:         duration,
+		ProviderMetadata: tc.ProviderMetadata,
 	}
 
 	if err != nil {

--- a/internal/agent/observe.go
+++ b/internal/agent/observe.go
@@ -326,8 +326,9 @@ func (e *AgentEngine) appendToolResults(
 				argsJSON, _ := json.Marshal(tc.Args)
 
 				assistantMsg.ToolCalls = append(assistantMsg.ToolCalls, chat.ToolCall{
-					ID:   tc.ID,
-					Type: "function",
+					ID:               tc.ID,
+					Type:             "function",
+					ProviderMetadata: tc.ProviderMetadata,
 					Function: chat.FunctionCall{
 						Name:      tc.Name,
 						Arguments: string(argsJSON),

--- a/internal/agent/observe_test.go
+++ b/internal/agent/observe_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -73,9 +74,10 @@ func TestAppendToolResults_PreservesReasoningContent(t *testing.T) {
 			Thought:          "I will call search.",
 			ReasoningContent: "Detailed chain of thought from MiMo/DeepSeek.",
 			ToolCalls: []types.ToolCall{{
-				ID:   "call_1",
-				Name: "knowledge_search",
-				Args: map[string]interface{}{"query": "hi"},
+				ID:               "call_1",
+				Name:             "knowledge_search",
+				Args:             map[string]interface{}{"query": "hi"},
+				ProviderMetadata: types.ToolCallMetadata{"google": json.RawMessage(`{"thought_signature":"gemini-thought-signature"}`)},
 				Result: &types.ToolResult{
 					Success: true,
 					Output:  "result text",
@@ -94,6 +96,8 @@ func TestAppendToolResults_PreservesReasoningContent(t *testing.T) {
 				"and DeepSeek thinking-mode see it on the next round (issue #1302)")
 		require.Len(t, out[0].ToolCalls, 1)
 		assert.Equal(t, "call_1", out[0].ToolCalls[0].ID)
+		assert.JSONEq(t, `{"thought_signature":"gemini-thought-signature"}`,
+			string(out[0].ToolCalls[0].ProviderMetadata["google"]))
 
 		assert.Equal(t, "tool", out[1].Role)
 		assert.Equal(t, "result text", out[1].Content)

--- a/internal/application/service/agent_history.go
+++ b/internal/application/service/agent_history.go
@@ -165,8 +165,9 @@ func buildAssistantHistoryMessages(m *types.Message) []chat.Message {
 		for _, tc := range nonTerminalCalls {
 			argsJSON, _ := json.Marshal(tc.Args)
 			assistantMsg.ToolCalls = append(assistantMsg.ToolCalls, chat.ToolCall{
-				ID:   tc.ID,
-				Type: "function",
+				ID:               tc.ID,
+				Type:             "function",
+				ProviderMetadata: tc.ProviderMetadata,
 				Function: chat.FunctionCall{
 					Name:      tc.Name,
 					Arguments: string(argsJSON),

--- a/internal/application/service/agent_history_test.go
+++ b/internal/application/service/agent_history_test.go
@@ -1,12 +1,14 @@
 package service
 
 import (
+	"encoding/json"
 	"testing"
 
 	agenttools "github.com/Tencent/WeKnora/internal/agent/tools"
 	"github.com/Tencent/WeKnora/internal/models/chat"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestBuildUserHistoryMessage_PrefersRenderedContent verifies the user side of
@@ -247,9 +249,10 @@ func TestBuildAssistantHistoryMessages_ReplaysReasoningContent(t *testing.T) {
 				Thought:          "Let me search.",
 				ReasoningContent: "model's chain of thought",
 				ToolCalls: []types.ToolCall{{
-					ID:   "call_1",
-					Name: agenttools.ToolKnowledgeSearch,
-					Args: map[string]interface{}{"query": "foo"},
+					ID:               "call_1",
+					Name:             agenttools.ToolKnowledgeSearch,
+					Args:             map[string]interface{}{"query": "foo"},
+					ProviderMetadata: types.ToolCallMetadata{"google": json.RawMessage(`{"thought_signature":"gemini-history-signature"}`)},
 					Result: &types.ToolResult{
 						Success: true,
 						Output:  "doc A",
@@ -265,6 +268,9 @@ func TestBuildAssistantHistoryMessages_ReplaysReasoningContent(t *testing.T) {
 	assert.Equal(t, "model's chain of thought", got[0].ReasoningContent,
 		"reasoning_content from AgentStep must be replayed onto the rebuilt assistant message "+
 			"so MiMo/DeepSeek thinking-mode does not 400 on multi-turn (issue #1302)")
+	require.Len(t, got[0].ToolCalls, 1)
+	assert.JSONEq(t, `{"thought_signature":"gemini-history-signature"}`,
+		string(got[0].ToolCalls[0].ProviderMetadata["google"]))
 	// Tool message and final answer message must NOT carry reasoning_content.
 	assert.Empty(t, got[1].ReasoningContent)
 	assert.Empty(t, got[2].ReasoningContent)

--- a/internal/models/chat/chat.go
+++ b/internal/models/chat/chat.go
@@ -71,9 +71,10 @@ type Message struct {
 
 // ToolCall represents a tool call in a message
 type ToolCall struct {
-	ID       string       `json:"id"`
-	Type     string       `json:"type"` // "function"
-	Function FunctionCall `json:"function"`
+	ID               string                 `json:"id"`
+	Type             string                 `json:"type"` // "function"
+	Function         FunctionCall           `json:"function"`
+	ProviderMetadata types.ToolCallMetadata `json:"provider_metadata,omitempty"`
 }
 
 // FunctionCall represents a function call

--- a/internal/models/chat/openai_request.go
+++ b/internal/models/chat/openai_request.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/sashabaranov/go-openai"
@@ -180,4 +181,62 @@ func (c *RemoteAPIChat) BuildChatCompletionRequest(
 	}
 
 	return req
+}
+
+func (c *RemoteAPIChat) buildProviderOpenAIRequest(
+	body any,
+	openAIMessages []openai.ChatCompletionMessage,
+	messages []Message,
+) (map[string]any, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal provider request: %w", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("unmarshal provider request: %w", err)
+	}
+
+	providerMessages := make([]map[string]any, 0, len(openAIMessages))
+	for i, msg := range openAIMessages {
+		msgData, err := json.Marshal(msg)
+		if err != nil {
+			return nil, fmt.Errorf("marshal provider message: %w", err)
+		}
+		var msgMap map[string]any
+		if err := json.Unmarshal(msgData, &msgMap); err != nil {
+			return nil, fmt.Errorf("unmarshal provider message: %w", err)
+		}
+
+		if i < len(messages) && len(messages[i].ToolCalls) > 0 && len(msg.ToolCalls) > 0 {
+			toolCalls := make([]map[string]any, 0, len(msg.ToolCalls))
+			for j, tc := range msg.ToolCalls {
+				tcData, err := json.Marshal(tc)
+				if err != nil {
+					return nil, fmt.Errorf("marshal provider tool call: %w", err)
+				}
+				var tcMap map[string]any
+				if err := json.Unmarshal(tcData, &tcMap); err != nil {
+					return nil, fmt.Errorf("unmarshal provider tool call: %w", err)
+				}
+				if j < len(messages[i].ToolCalls) {
+					c.adapter.InjectToolCallMetadata(tcMap, messages[i].ToolCalls[j].ProviderMetadata)
+				}
+				toolCalls = append(toolCalls, tcMap)
+			}
+			msgMap["tool_calls"] = toolCalls
+		}
+
+		providerMessages = append(providerMessages, msgMap)
+	}
+	out["messages"] = providerMessages
+	return out, nil
+}
+
+func (c *RemoteAPIChat) shapeProviderRequest(body any, req openai.ChatCompletionRequest, messages []Message) (any, error) {
+	if !c.adapter.ForceRawHTTP() {
+		return body, nil
+	}
+	return c.buildProviderOpenAIRequest(body, req.Messages, messages)
 }

--- a/internal/models/chat/openai_stream.go
+++ b/internal/models/chat/openai_stream.go
@@ -54,6 +54,37 @@ func (c *RemoteAPIChat) parseCompletionResponse(resp *openai.ChatCompletionRespo
 	return response, nil
 }
 
+func (c *RemoteAPIChat) applyCompletionToolCallMetadata(body []byte, result *types.ChatResponse) {
+	if result == nil || len(result.ToolCalls) == 0 {
+		return
+	}
+
+	var raw struct {
+		Choices []struct {
+			Message struct {
+				ToolCalls []json.RawMessage `json:"tool_calls,omitempty"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil || len(raw.Choices) == 0 {
+		return
+	}
+
+	for i, rawToolCall := range raw.Choices[0].Message.ToolCalls {
+		var indexed struct {
+			Index *int `json:"index,omitempty"`
+		}
+		_ = json.Unmarshal(rawToolCall, &indexed)
+		idx := i
+		if indexed.Index != nil {
+			idx = *indexed.Index
+		}
+		if idx >= 0 && idx < len(result.ToolCalls) {
+			result.ToolCalls[idx].ProviderMetadata = c.adapter.ExtractToolCallMetadata(rawToolCall)
+		}
+	}
+}
+
 // removeThinkingContent 移除思考模型输出中的 <think></think> 思考过程
 // 仅当内容以 <think> 开头时才处理
 func removeThinkingContent(content string) string {
@@ -237,8 +268,42 @@ func (c *RemoteAPIChat) processRawHTTPStream(
 				Delta:        choice.Delta.ChatCompletionStreamChoiceDelta,
 				FinishReason: choice.FinishReason,
 			}
+			c.applyStreamToolCallMetadata(event.Data, state)
 			c.processStreamDelta(ctx, &sdkChoice, state, streamChan, reasoning)
 		}
+	}
+}
+
+func (c *RemoteAPIChat) applyStreamToolCallMetadata(data []byte, state *streamState) {
+	if state == nil {
+		return
+	}
+
+	var raw struct {
+		Choices []struct {
+			Delta struct {
+				ToolCalls []json.RawMessage `json:"tool_calls,omitempty"`
+			} `json:"delta"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil || len(raw.Choices) == 0 {
+		return
+	}
+
+	for _, rawToolCall := range raw.Choices[0].Delta.ToolCalls {
+		metadata := c.adapter.ExtractToolCallMetadata(rawToolCall)
+		if len(metadata) == 0 {
+			continue
+		}
+		var indexed struct {
+			Index *int `json:"index,omitempty"`
+		}
+		_ = json.Unmarshal(rawToolCall, &indexed)
+		idx := 0
+		if indexed.Index != nil {
+			idx = *indexed.Index
+		}
+		state.setToolCallProviderMetadata(idx, metadata)
 	}
 }
 
@@ -300,6 +365,24 @@ func (s *streamState) buildOrderedToolCalls() []types.LLMToolCall {
 		return nil
 	}
 	return result
+}
+
+func (s *streamState) setToolCallProviderMetadata(index int, metadata types.ToolCallMetadata) {
+	if len(metadata) == 0 {
+		return
+	}
+	toolCallEntry, exists := s.toolCallMap[index]
+	if !exists || toolCallEntry == nil {
+		toolCallEntry = &types.LLMToolCall{
+			Type: "function",
+			Function: types.FunctionCall{
+				Name:      "",
+				Arguments: "",
+			},
+		}
+		s.toolCallMap[index] = toolCallEntry
+	}
+	toolCallEntry.ProviderMetadata = metadata
 }
 
 // processStreamDelta 处理流式响应的单个 delta

--- a/internal/models/chat/provider.go
+++ b/internal/models/chat/provider.go
@@ -1,11 +1,13 @@
 package chat
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 
 	"github.com/Tencent/WeKnora/internal/models/provider"
 	modelutils "github.com/Tencent/WeKnora/internal/models/utils"
+	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/google/uuid"
 	"github.com/sashabaranov/go-openai"
 )
@@ -46,6 +48,12 @@ type providerAdapter interface {
 	// ForceRawHTTP forces the raw HTTP path even when the body is standard
 	// (needed by providers that must sign the exact request bytes). Default: false.
 	ForceRawHTTP() bool
+	// ExtractToolCallMetadata captures provider-specific state from a raw
+	// OpenAI-compatible tool_call object. Default: nil.
+	ExtractToolCallMetadata(raw json.RawMessage) types.ToolCallMetadata
+	// InjectToolCallMetadata writes provider-specific state back into an outbound
+	// OpenAI-compatible tool_call object. Default: noop.
+	InjectToolCallMetadata(toolCall map[string]any, metadata types.ToolCallMetadata)
 }
 
 // baseProvider supplies the default behavior for every providerAdapter method.
@@ -65,6 +73,10 @@ func (baseProvider) Auth(req *http.Request, creds authCreds, _ []byte) {
 	req.Header.Set("Authorization", "Bearer "+creds.APIKey)
 }
 func (baseProvider) ForceRawHTTP() bool { return false }
+func (baseProvider) ExtractToolCallMetadata(json.RawMessage) types.ToolCallMetadata {
+	return nil
+}
+func (baseProvider) InjectToolCallMetadata(map[string]any, types.ToolCallMetadata) {}
 
 // --- WeKnoraCloud: custom endpoint + request signing + multi-content downgrade ---
 
@@ -152,6 +164,40 @@ type nvidiaProvider struct{ baseProvider }
 func (nvidiaProvider) Name() provider.ProviderName { return provider.ProviderNvidia }
 func (nvidiaProvider) Thinking() ThinkingStrategy  { return chatTemplateKwargs{} }
 
+// --- Gemini OpenAI compatibility: tool thought signatures live in extra_content ---
+
+type geminiProvider struct{ baseProvider }
+
+func (geminiProvider) Name() provider.ProviderName { return provider.ProviderGemini }
+func (geminiProvider) ForceRawHTTP() bool          { return true }
+func (geminiProvider) ExtractToolCallMetadata(raw json.RawMessage) types.ToolCallMetadata {
+	var tc struct {
+		ExtraContent map[string]json.RawMessage `json:"extra_content,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &tc); err != nil {
+		return nil
+	}
+	google, ok := tc.ExtraContent["google"]
+	if !ok || len(google) == 0 {
+		return nil
+	}
+	return types.ToolCallMetadata{"google": google}
+}
+func (geminiProvider) InjectToolCallMetadata(toolCall map[string]any, metadata types.ToolCallMetadata) {
+	if len(metadata) == 0 {
+		return
+	}
+	google, ok := metadata["google"]
+	if !ok || len(google) == 0 {
+		return
+	}
+	var googleValue any
+	if err := json.Unmarshal(google, &googleValue); err != nil {
+		return
+	}
+	toolCall["extra_content"] = map[string]any{"google": googleValue}
+}
+
 // --- Volcengine (火山引擎 Ark): thinking via { "thinking": { "type": ... } } ---
 
 type volcengineProvider struct{ baseProvider }
@@ -227,6 +273,7 @@ var providerRegistry = []providerAdapter{
 	lkeapProvider{},
 	deepseekProvider{},
 	genericProvider{},
+	geminiProvider{},
 	volcengineProvider{},
 	nvidiaProvider{},
 	azureReasoningProvider{},

--- a/internal/models/chat/provider_test.go
+++ b/internal/models/chat/provider_test.go
@@ -26,6 +26,7 @@ func TestResolveProvider(t *testing.T) {
 		{"lkeap r1 falls back", provider.ProviderLKEAP, "deepseek-r1", baseProvider{}},
 		{"qwen thinking", provider.ProviderAliyun, "qwen3-32b", qwenThinkingProvider{}},
 		{"generic", provider.ProviderGeneric, "anything", genericProvider{}},
+		{"gemini", provider.ProviderGemini, "gemini-3-flash-preview", geminiProvider{}},
 		{"nvidia", provider.ProviderNvidia, "anything", nvidiaProvider{}},
 		{"volcengine", provider.ProviderVolcengine, "doubao", volcengineProvider{}},
 		{"openai non-reasoning falls back", provider.ProviderOpenAI, "gpt-4o", baseProvider{}},
@@ -67,7 +68,8 @@ func TestBuildOutbound_Thinking(t *testing.T) {
 	t.Run("generic explicit thinking_type overrides legacy kwargs", func(t *testing.T) {
 		c := newOutboundChat(t, string(provider.ProviderGeneric), "deepseek-v4-flash",
 			map[string]string{ExtraConfigThinkingControl: "thinking_type"})
-		body, _, useRaw := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(false)}, true)
+		body, _, useRaw, err := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(false)}, true)
+		require.NoError(t, err)
 		require.True(t, useRaw)
 		js := mustJSON(t, body)
 		assert.Contains(t, js, `"thinking"`)
@@ -77,7 +79,8 @@ func TestBuildOutbound_Thinking(t *testing.T) {
 
 	t.Run("generic legacy chat_template_kwargs", func(t *testing.T) {
 		c := newOutboundChat(t, string(provider.ProviderGeneric), "qwen", nil)
-		body, _, useRaw := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(false)}, true)
+		body, _, useRaw, err := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(false)}, true)
+		require.NoError(t, err)
 		require.True(t, useRaw)
 		assert.Contains(t, mustJSON(t, body), "chat_template_kwargs")
 	})
@@ -85,7 +88,8 @@ func TestBuildOutbound_Thinking(t *testing.T) {
 	t.Run("none keeps the standard SDK request", func(t *testing.T) {
 		c := newOutboundChat(t, string(provider.ProviderGeneric), "x",
 			map[string]string{ExtraConfigThinkingControl: "none"})
-		body, _, useRaw := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(false)}, true)
+		body, _, useRaw, err := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(false)}, true)
+		require.NoError(t, err)
 		assert.False(t, useRaw)
 		_, ok := body.(*openai.ChatCompletionRequest)
 		assert.True(t, ok)
@@ -93,20 +97,23 @@ func TestBuildOutbound_Thinking(t *testing.T) {
 
 	t.Run("qwen non-stream forces disabled", func(t *testing.T) {
 		c := newOutboundChat(t, string(provider.ProviderAliyun), "qwen3-32b", nil)
-		body, _, useRaw := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(true)}, false)
+		body, _, useRaw, err := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(true)}, false)
+		require.NoError(t, err)
 		require.True(t, useRaw)
 		assert.Contains(t, mustJSON(t, body), `"enable_thinking":false`)
 	})
 
 	t.Run("qwen stream honors requested true", func(t *testing.T) {
 		c := newOutboundChat(t, string(provider.ProviderAliyun), "qwen3-32b", nil)
-		body, _, _ := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(true)}, true)
+		body, _, _, err := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(true)}, true)
+		require.NoError(t, err)
 		assert.Contains(t, mustJSON(t, body), `"enable_thinking":true`)
 	})
 
 	t.Run("volcengine thinking enabled", func(t *testing.T) {
 		c := newOutboundChat(t, string(provider.ProviderVolcengine), "doubao", nil)
-		body, _, useRaw := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(true)}, true)
+		body, _, useRaw, err := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(true)}, true)
+		require.NoError(t, err)
 		require.True(t, useRaw)
 		js := mustJSON(t, body)
 		assert.Contains(t, js, `"thinking"`)
@@ -115,14 +122,16 @@ func TestBuildOutbound_Thinking(t *testing.T) {
 
 	t.Run("lkeap deepseek-v3 emits thinking type", func(t *testing.T) {
 		c := newOutboundChat(t, string(provider.ProviderLKEAP), "deepseek-v3.1", nil)
-		body, _, useRaw := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(false)}, true)
+		body, _, useRaw, err := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(false)}, true)
+		require.NoError(t, err)
 		require.True(t, useRaw)
 		assert.Contains(t, mustJSON(t, body), `"thinking"`)
 	})
 
 	t.Run("lkeap r1 left untouched", func(t *testing.T) {
 		c := newOutboundChat(t, string(provider.ProviderLKEAP), "deepseek-r1", nil)
-		body, _, useRaw := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(false)}, true)
+		body, _, useRaw, err := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(false)}, true)
+		require.NoError(t, err)
 		assert.False(t, useRaw)
 		_, ok := body.(*openai.ChatCompletionRequest)
 		assert.True(t, ok)
@@ -136,7 +145,8 @@ func TestBuildOutbound_ShapeRequest(t *testing.T) {
 
 	t.Run("deepseek strips tool_choice", func(t *testing.T) {
 		c := newOutboundChat(t, string(provider.ProviderDeepSeek), "deepseek-chat", nil)
-		body, _, useRaw := c.buildOutbound(msgs, &ChatOptions{ToolChoice: "auto"}, false)
+		body, _, useRaw, err := c.buildOutbound(msgs, &ChatOptions{ToolChoice: "auto"}, false)
+		require.NoError(t, err)
 		assert.False(t, useRaw)
 		req := body.(*openai.ChatCompletionRequest)
 		assert.Nil(t, req.ToolChoice)
@@ -144,11 +154,39 @@ func TestBuildOutbound_ShapeRequest(t *testing.T) {
 
 	t.Run("moonshot pins temperature to 1", func(t *testing.T) {
 		c := newOutboundChat(t, string(provider.ProviderMoonshot), "moonshot-v1-8k", nil)
-		body, _, _ := c.buildOutbound(msgs, &ChatOptions{Temperature: 0.7, TopP: 0.9}, false)
+		body, _, _, err := c.buildOutbound(msgs, &ChatOptions{Temperature: 0.7, TopP: 0.9}, false)
+		require.NoError(t, err)
 		req := body.(*openai.ChatCompletionRequest)
 		assert.EqualValues(t, 1, req.Temperature)
 		assert.EqualValues(t, 0, req.TopP)
 	})
+}
+
+func TestBuildOutbound_GeminiProviderMetadata(t *testing.T) {
+	c := newOutboundChat(t, string(provider.ProviderGemini), "gemini-3-flash-preview", nil)
+	messages := []Message{
+		{Role: "user", Content: "find docs"},
+		{
+			Role: "assistant",
+			ToolCalls: []ToolCall{{
+				ID:               "call_1",
+				Type:             "function",
+				ProviderMetadata: types.ToolCallMetadata{"google": json.RawMessage(`{"thought_signature":"gemini-signature"}`)},
+				Function: FunctionCall{
+					Name:      "wiki_search",
+					Arguments: `{"query":"MACS"}`,
+				},
+			}},
+		},
+	}
+
+	body, _, useRaw, err := c.buildOutbound(messages, &ChatOptions{}, false)
+	require.NoError(t, err)
+	require.True(t, useRaw)
+
+	js := mustJSON(t, body)
+	assert.Contains(t, js, `"extra_content"`)
+	assert.Contains(t, js, `"thought_signature":"gemini-signature"`)
 }
 
 func mustJSON(t *testing.T, v any) string {

--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -131,7 +131,7 @@ func (c *RemoteAPIChat) shapedRequest(messages []Message, opts *ChatOptions, isS
 // replacing the former buildRequestCustomizer plumbing.
 func (c *RemoteAPIChat) buildOutbound(
 	messages []Message, opts *ChatOptions, isStream bool,
-) (body any, endpoint string, useRawHTTP bool) {
+) (body any, endpoint string, useRawHTTP bool, err error) {
 	req := c.shapedRequest(messages, opts, isStream)
 
 	thinking := c.thinkingOverride
@@ -144,9 +144,13 @@ func (c *RemoteAPIChat) buildOutbound(
 	if customBody != nil {
 		body = customBody
 	}
+	body, err = c.shapeProviderRequest(body, req, messages)
+	if err != nil {
+		return nil, "", false, err
+	}
 	endpoint = c.adapter.Endpoint(c.baseURL, c.modelID, isStream)
 	useRawHTTP = useRaw || c.adapter.ForceRawHTTP() || endpoint != ""
-	return body, endpoint, useRawHTTP
+	return body, endpoint, useRawHTTP, nil
 }
 
 // logRequest 记录请求日志
@@ -164,7 +168,10 @@ func (c *RemoteAPIChat) Chat(ctx context.Context, messages []Message, opts *Chat
 	timeoutCtx, cancel := withLLMTimeout(ctx, defaultChatTimeout)
 	defer cancel()
 
-	body, endpoint, useRawHTTP := c.buildOutbound(messages, opts, false)
+	body, endpoint, useRawHTTP, err := c.buildOutbound(messages, opts, false)
+	if err != nil {
+		return nil, err
+	}
 	if useRawHTTP {
 		return c.chatWithRawHTTP(timeoutCtx, endpoint, body)
 	}
@@ -233,8 +240,13 @@ func (c *RemoteAPIChat) chatWithRawHTTP(ctx context.Context, endpoint string, cu
 		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
 	var chatResp openai.ChatCompletionResponse
-	if err := json.NewDecoder(resp.Body).Decode(&chatResp); err != nil {
+	if err := json.Unmarshal(body, &chatResp); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 
@@ -242,6 +254,7 @@ func (c *RemoteAPIChat) chatWithRawHTTP(ctx context.Context, endpoint string, cu
 	if err != nil {
 		return nil, err
 	}
+	c.applyCompletionToolCallMetadata(body, result)
 	logUsage(ctx, c.modelName, &result.Usage)
 	return result, nil
 }
@@ -252,7 +265,11 @@ func (c *RemoteAPIChat) ChatStream(ctx context.Context, messages []Message, opts
 	// 因为带思考/推理的模型可能数十秒甚至几分钟才产出首 token。
 	timeoutCtx, cancel := withLLMTimeout(ctx, defaultStreamTimeout)
 
-	body, endpoint, useRawHTTP := c.buildOutbound(messages, opts, true)
+	body, endpoint, useRawHTTP, err := c.buildOutbound(messages, opts, true)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
 	if useRawHTTP {
 		ch, err := c.chatStreamWithRawHTTP(timeoutCtx, endpoint, body)
 		return wrapStreamCancel(ch, err, cancel)

--- a/internal/models/chat/remote_api_test.go
+++ b/internal/models/chat/remote_api_test.go
@@ -270,6 +270,65 @@ func TestConvertMessages_ReasoningContentRoundTrip(t *testing.T) {
 	})
 }
 
+func TestApplyCompletionToolCallMetadata(t *testing.T) {
+	c := newTestRemoteChat(t)
+	c.adapter = geminiProvider{}
+
+	resp := &types.ChatResponse{
+		ToolCalls: []types.LLMToolCall{{
+			ID:   "call_1",
+			Type: "function",
+			Function: types.FunctionCall{
+				Name:      "wiki_search",
+				Arguments: `{"query":"MACS"}`,
+			},
+		}},
+	}
+	body := []byte(`{
+		"choices":[{
+			"message":{
+				"tool_calls":[{
+					"id":"call_1",
+					"type":"function",
+					"function":{"name":"wiki_search","arguments":"{\"query\":\"MACS\"}"},
+					"extra_content":{"google":{"thought_signature":"sig-from-gemini"}}
+				}]
+			}
+		}]
+	}`)
+
+	c.applyCompletionToolCallMetadata(body, resp)
+	require.Len(t, resp.ToolCalls, 1)
+	assert.JSONEq(t, `{"thought_signature":"sig-from-gemini"}`,
+		string(resp.ToolCalls[0].ProviderMetadata["google"]))
+}
+
+func TestApplyStreamToolCallMetadata(t *testing.T) {
+	c := newTestRemoteChat(t)
+	c.adapter = geminiProvider{}
+	state := newStreamState()
+
+	body := []byte(`{
+		"choices":[{
+			"delta":{
+				"tool_calls":[{
+					"index":0,
+					"id":"call_1",
+					"type":"function",
+					"function":{"name":"wiki_search","arguments":"{\"query\":\"MACS\"}"},
+					"extra_content":{"google":{"thought_signature":"stream-sig-from-gemini"}}
+				}]
+			}
+		}]
+	}`)
+
+	c.applyStreamToolCallMetadata(body, state)
+	toolCalls := state.buildOrderedToolCalls()
+	require.Len(t, toolCalls, 1)
+	assert.JSONEq(t, `{"thought_signature":"stream-sig-from-gemini"}`,
+		string(toolCalls[0].ProviderMetadata["google"]))
+}
+
 // TestRemoteAPIChat 综合测试 Remote API Chat 的所有功能
 func TestRemoteAPIChat(t *testing.T) {
 	// 获取环境变量

--- a/internal/types/agent.go
+++ b/internal/types/agent.go
@@ -176,12 +176,13 @@ type ToolResult struct {
 
 // ToolCall represents a single tool invocation within an agent step
 type ToolCall struct {
-	ID         string                 `json:"id"`                   // Function call ID from LLM
-	Name       string                 `json:"name"`                 // Tool name
-	Args       map[string]interface{} `json:"args"`                 // Tool arguments
-	Result     *ToolResult            `json:"result"`               // Execution result (contains Output)
-	Reflection string                 `json:"reflection,omitempty"` // Agent's reflection on this tool call result (if enabled)
-	Duration   int64                  `json:"duration"`             // Execution time in milliseconds
+	ID               string                 `json:"id"`                          // Function call ID from LLM
+	Name             string                 `json:"name"`                        // Tool name
+	Args             map[string]interface{} `json:"args"`                        // Tool arguments
+	Result           *ToolResult            `json:"result"`                      // Execution result (contains Output)
+	Reflection       string                 `json:"reflection,omitempty"`        // Agent's reflection on this tool call result (if enabled)
+	Duration         int64                  `json:"duration"`                    // Execution time in milliseconds
+	ProviderMetadata ToolCallMetadata       `json:"provider_metadata,omitempty"` // Provider-specific tool-call state for replay
 }
 
 // AgentStep represents one iteration of the ReAct loop

--- a/internal/types/chat.go
+++ b/internal/types/chat.go
@@ -34,10 +34,15 @@ type TokenUsage struct {
 
 // LLMToolCall represents a function/tool call from the LLM
 type LLMToolCall struct {
-	ID       string       `json:"id"`
-	Type     string       `json:"type"` // "function"
-	Function FunctionCall `json:"function"`
+	ID               string           `json:"id"`
+	Type             string           `json:"type"` // "function"
+	Function         FunctionCall     `json:"function"`
+	ProviderMetadata ToolCallMetadata `json:"provider_metadata,omitempty"`
 }
+
+// ToolCallMetadata carries provider-specific tool-call state that must round-trip
+// with the assistant tool call, without teaching core agent code vendor fields.
+type ToolCallMetadata map[string]json.RawMessage
 
 // FunctionCall represents the function details
 type FunctionCall struct {


### PR DESCRIPTION
## Summary
- replace the core `ThoughtSignature` field with provider-neutral `ProviderMetadata` on tool calls
- add provider adapter hooks to extract and inject provider-specific tool-call metadata
- keep Gemini OpenAI-compatible `extra_content.google.thought_signature` handling inside the Gemini adapter
- preserve provider metadata through ReAct tool execution, in-turn replay, and persisted agent history

## Why
Gemini thinking models may require `thought_signature` to be replayed after tool calls, but exposing that field directly in shared agent/chat types makes the core model Gemini-specific. This keeps the core path vendor-neutral while still losslessly round-tripping Gemini metadata through the provider adapter.

## Update from the original version
- The first version added `ThoughtSignature` directly to shared tool-call structs.
- This revision moves that state into generic `ProviderMetadata`, so the core chat/agent types no longer expose a Gemini-specific field.
- Gemini-specific wire mapping is now isolated in the provider adapter via extract/inject hooks, which should make the approach reusable for other OpenAI-compatible providers with non-standard tool-call metadata.

## Testing
- `go test ./internal/models/chat`
- `go test ./internal/agent ./internal/application/service`

## Deployment validation
- verified on the GCP deployment with Gemini tool-call replay enabled
