### PR TITLE
fix: support custom jieba dictionary directory

### DIFF
--- a/internal/types/evaluation.go
+++ b/internal/types/evaluation.go
@@ -2,13 +2,30 @@ package types
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/yanyiwu/gojieba"
 )
 
 // Jieba is a global instance of Chinese text segmentation tool
-var Jieba *gojieba.Jieba = gojieba.NewJieba()
+var Jieba *gojieba.Jieba = newJieba()
+
+func newJieba() *gojieba.Jieba {
+	dictDir := os.Getenv("JIEBA_DICT_DIR")
+	if dictDir == "" {
+		return gojieba.NewJieba()
+	}
+
+	return gojieba.NewJieba(
+		filepath.Join(dictDir, "jieba.dict.utf8"),
+		filepath.Join(dictDir, "hmm_model.utf8"),
+		filepath.Join(dictDir, "user.dict.utf8"),
+		filepath.Join(dictDir, "idf.utf8"),
+		filepath.Join(dictDir, "stop_words.utf8"),
+	)
+}
 
 // EvaluationStatue represents the status of an evaluation task
 type EvaluationStatue int


### PR DESCRIPTION
## Summary
- add optional JIEBA_DICT_DIR support for gojieba initialization
- keep the existing default dictionary lookup when JIEBA_DICT_DIR is not set

## Why
In some deployment environments, the build-time Go module cache path is not available at runtime. Passing explicit dictionary paths lets deployments provide a runtime dictionary directory without changing the default behavior.

## Tests
- go test ./internal/types