### PR TITLE
feat: add optional embedding cache to reduce redundant embedding API calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -288,6 +288,10 @@ JWT_SECRET=weknora-jwt-secret
 # Embedding并发数，出现429错误时，可调小此参数
 CONCURRENCY_POOL_SIZE=5
 
+# 嵌入缓存开关（默认关闭）。启用后，未变化的 chunk 重索引时会复用之前缓存的向量，
+# 跳过 embedding API 调用。适合频繁 re-index 的场景（如文档多次编辑后重新解析）。
+# ENABLE_EMBEDDING_CACHE=true
+
 # (Removed: IMAGE_MAX_CONCURRENT, OCR_BACKEND — moved to Go App module after lightweight refactoring)
 
 # 如果使用ElasticSearch作为向量存储，需要配置以下参数

--- a/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
+++ b/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
@@ -23,6 +23,11 @@ import (
 // kicks in for genuinely pathological inputs.
 const safetyMaxChars = 20000
 
+// PreprocessingVersion is incremented when the content normalization pipeline
+// changes (e.g. sanitizeForEmbedding logic, base64 stripping, truncation).
+// The embedding cache uses this to invalidate stale entries automatically.
+const PreprocessingVersion = "v1"
+
 // embedRetryAttempts and embedRetryBaseDelay control the exponential backoff
 // applied to BatchEmbedWithPool calls.
 const (
@@ -42,6 +47,7 @@ var embeddingImagePayloadPatterns = []*regexp.Regexp{
 type KeywordsVectorHybridRetrieveEngineService struct {
 	indexRepository interfaces.RetrieveEngineRepository
 	engineType      types.RetrieverEngineType
+	embeddingCache  *embedding.EmbeddingCache // optional; nil disables caching
 }
 
 // NewKVHybridRetrieveEngine creates a new instance of the hybrid retrieval engine
@@ -50,6 +56,21 @@ func NewKVHybridRetrieveEngine(indexRepository interfaces.RetrieveEngineReposito
 	engineType types.RetrieverEngineType,
 ) interfaces.RetrieveEngineService {
 	return &KeywordsVectorHybridRetrieveEngineService{indexRepository: indexRepository, engineType: engineType}
+}
+
+// NewKVHybridRetrieveEngineWithCache creates a new instance with an optional
+// embedding cache. When cache is non-nil, BatchIndex checks the cache before
+// calling the embedding API, avoiding redundant computation for unchanged text.
+func NewKVHybridRetrieveEngineWithCache(
+	indexRepository interfaces.RetrieveEngineRepository,
+	engineType types.RetrieverEngineType,
+	cache *embedding.EmbeddingCache,
+) interfaces.RetrieveEngineService {
+	return &KeywordsVectorHybridRetrieveEngineService{
+		indexRepository: indexRepository,
+		engineType:      engineType,
+		embeddingCache:  cache,
+	}
 }
 
 // EngineType returns the type of the retrieval engine
@@ -96,9 +117,20 @@ func (v *KeywordsVectorHybridRetrieveEngineService) BatchIndex(ctx context.Conte
 		for _, indexInfo := range indexInfoList {
 			contentList = append(contentList, sanitizeForEmbedding(ctx, indexInfo.Content))
 		}
-		embeddings, err := batchEmbedWithBackoff(ctx, embedder, contentList)
-		if err != nil {
-			return err
+
+		var embeddings [][]float32
+		if v.embeddingCache != nil {
+			var err error
+			embeddings, err = v.cachedBatchEmbed(ctx, embedder, contentList)
+			if err != nil {
+				return err
+			}
+		} else {
+			var err error
+			embeddings, err = batchEmbedWithBackoff(ctx, embedder, contentList)
+			if err != nil {
+				return err
+			}
 		}
 
 		batchSize := 40
@@ -123,6 +155,72 @@ func (v *KeywordsVectorHybridRetrieveEngineService) BatchIndex(ctx context.Conte
 		return v.concurrentBatchSaveNoEmbedding(ctx, chunks)
 	}
 	return v.boundedConcurrentBatchSaveNoEmbedding(ctx, chunks, maxConcurrency)
+}
+
+// cachedBatchEmbed checks the embedding cache for previously computed vectors,
+// embeds only cache misses, stores new results, and returns all embeddings in
+// the original input order.
+func (v *KeywordsVectorHybridRetrieveEngineService) cachedBatchEmbed(
+	ctx context.Context,
+	embedder embedding.Embedder,
+	contentList []string,
+) ([][]float32, error) {
+	modelID := embedder.GetModelID()
+	dims := embedder.GetDimensions()
+
+	hashes := make([]string, len(contentList))
+	for i, text := range contentList {
+		hashes[i] = embedding.ComputeHash(text, modelID, dims, nil, PreprocessingVersion)
+	}
+
+	result, err := v.embeddingCache.Lookup(hashes, modelID, dims)
+	if err != nil {
+		logger.Warnf(ctx, "embedding cache lookup failed, falling back to full embedding: %v", err)
+		return batchEmbedWithBackoff(ctx, embedder, contentList)
+	}
+
+	logger.Debugf(ctx, "embedding cache: %d hits, %d misses out of %d total",
+		len(result.Hits), len(result.Misses), len(contentList))
+
+	if len(result.Misses) == 0 {
+		embeddings := make([][]float32, len(contentList))
+		for idx, emb := range result.Hits {
+			embeddings[idx] = emb
+		}
+		return embeddings, nil
+	}
+
+	missTexts := make([]string, len(result.Misses))
+	for i, idx := range result.Misses {
+		missTexts[i] = contentList[idx]
+	}
+	missEmbeddings, err := batchEmbedWithBackoff(ctx, embedder, missTexts)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]embedding.CacheEntry, len(result.Misses))
+	for i, idx := range result.Misses {
+		entries[i] = embedding.CacheEntry{
+			ContentHash:     hashes[idx],
+			ModelID:         modelID,
+			Dimensions:      dims,
+			ChunkConfigHash: "",
+			Embedding:       embedding.Float32sToBytes(missEmbeddings[i]),
+		}
+	}
+	if storeErr := v.embeddingCache.Store(entries); storeErr != nil {
+		logger.Warnf(ctx, "embedding cache store failed: %v", storeErr)
+	}
+
+	embeddings := make([][]float32, len(contentList))
+	for idx, emb := range result.Hits {
+		embeddings[idx] = emb
+	}
+	for i, idx := range result.Misses {
+		embeddings[idx] = missEmbeddings[i]
+	}
+	return embeddings, nil
 }
 
 // batchEmbedWithBackoff calls BatchEmbedWithPool with exponential backoff on

--- a/internal/application/service/retriever/keywords_vector_hybrid_indexer_cache_test.go
+++ b/internal/application/service/retriever/keywords_vector_hybrid_indexer_cache_test.go
@@ -1,0 +1,138 @@
+package retriever
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type countingEmbedder struct {
+	calls int
+}
+
+func (e *countingEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	return []float32{1.0}, nil
+}
+
+func (e *countingEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	e.calls++
+	embeddings := make([][]float32, len(texts))
+	for i := range texts {
+		embeddings[i] = []float32{1.0}
+	}
+	return embeddings, nil
+}
+
+func (e *countingEmbedder) BatchEmbedWithPool(ctx context.Context, model embedding.Embedder, texts []string) ([][]float32, error) {
+	e.calls++
+	embeddings := make([][]float32, len(texts))
+	for i := range texts {
+		embeddings[i] = []float32{1.0}
+	}
+	return embeddings, nil
+}
+
+func (e *countingEmbedder) GetModelName() string { return "test-model" }
+func (e *countingEmbedder) GetDimensions() int   { return 3 }
+func (e *countingEmbedder) GetModelID() string   { return "test-model-id" }
+
+// TestBatchIndex_CachePreventsRepeatedEmbedding verifies that the embedding
+// cache prevents redundant API calls: identical content is embedded once,
+// and subsequent calls skip the embedding API entirely.
+func TestBatchIndex_CachePreventsRepeatedEmbedding(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&embedding.CacheEntry{}))
+
+	cache := embedding.NewEmbeddingCache(db)
+	embedder := &countingEmbedder{}
+
+	engine := &KeywordsVectorHybridRetrieveEngineService{
+		indexRepository: &saveOnlyRepository{},
+		engineType:      types.PostgresRetrieverEngineType,
+		embeddingCache:  cache,
+	}
+
+	chunks := []*types.IndexInfo{
+		{Content: "chunk-1", SourceID: "s1", ChunkID: "c1"},
+		{Content: "chunk-2", SourceID: "s2", ChunkID: "c2"},
+		{Content: "chunk-3", SourceID: "s3", ChunkID: "c3"},
+	}
+	retrieverTypes := []types.RetrieverType{types.VectorRetrieverType}
+
+	// First call: all miss, 1 BatchEmbedWithPool call for 3 chunks.
+	err = engine.BatchIndex(context.Background(), embedder, chunks, retrieverTypes)
+	require.NoError(t, err)
+	assert.Equal(t, 1, embedder.calls, "first call should batch-embed all 3 chunks in one API call")
+
+	// Second call: all hit, no additional API calls.
+	prevCalls := embedder.calls
+	err = engine.BatchIndex(context.Background(), embedder, chunks, retrieverTypes)
+	require.NoError(t, err)
+	assert.Equal(t, prevCalls, embedder.calls, "second call should hit cache, make 0 additional API calls")
+}
+
+// TestBatchIndex_CachePartialMiss verifies mixed hit/miss behavior:
+// previously cached chunks skip the API while new chunks trigger embedding.
+func TestBatchIndex_CachePartialMiss(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&embedding.CacheEntry{}))
+
+	cache := embedding.NewEmbeddingCache(db)
+	embedder := &countingEmbedder{}
+
+	engine := &KeywordsVectorHybridRetrieveEngineService{
+		indexRepository: &saveOnlyRepository{},
+		engineType:      types.PostgresRetrieverEngineType,
+		embeddingCache:  cache,
+	}
+
+	// Prime cache with 2 chunks.
+	chunks1 := []*types.IndexInfo{
+		{Content: "chunk-a", SourceID: "sa", ChunkID: "ca"},
+		{Content: "chunk-b", SourceID: "sb", ChunkID: "cb"},
+	}
+	err = engine.BatchIndex(context.Background(), embedder, chunks1, typesRetrieverVector)
+	require.NoError(t, err)
+	assert.Equal(t, 1, embedder.calls)
+
+	// Second batch: 2 old + 2 new.
+	chunks2 := []*types.IndexInfo{
+		{Content: "chunk-a", SourceID: "sa2", ChunkID: "ca2"}, // cached
+		{Content: "chunk-c", SourceID: "sc", ChunkID: "cc"},    // new
+		{Content: "chunk-b", SourceID: "sb2", ChunkID: "cb2"}, // cached
+		{Content: "chunk-d", SourceID: "sd", ChunkID: "cd"},    // new
+	}
+	prevCalls := embedder.calls
+	err = engine.BatchIndex(context.Background(), embedder, chunks2, typesRetrieverVector)
+	require.NoError(t, err)
+	assert.Equal(t, prevCalls+1, embedder.calls, "cache hits should skip API; only 2 new chunks need embedding")
+}
+
+// TestBatchIndex_CacheDisabledNoEffect verifies that when cache is nil the
+// original embedding path is used with no change in behavior.
+func TestBatchIndex_CacheDisabledNoEffect(t *testing.T) {
+	embedder := &countingEmbedder{}
+
+	engine := &KeywordsVectorHybridRetrieveEngineService{
+		indexRepository: &saveOnlyRepository{},
+		engineType:      types.PostgresRetrieverEngineType,
+		embeddingCache:  nil,
+	}
+
+	chunks := []*types.IndexInfo{
+		{Content: "chunk-x", SourceID: "sx", ChunkID: "cx"},
+	}
+	err := engine.BatchIndex(context.Background(), embedder, chunks, typesRetrieverVector)
+	require.NoError(t, err)
+	assert.Equal(t, 1, embedder.calls, "without cache, every call goes through embedding API")
+}
+
+var typesRetrieverVector = []types.RetrieverType{types.VectorRetrieverType}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -121,6 +121,15 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	// Register goroutine pool cleanup handler
 	must(container.Invoke(registerPoolCleanup))
 
+	// Embedding cache is a singleton shared across all retrieve engines.
+	// Nil when ENABLE_EMBEDDING_CACHE is unset or not "true".
+	must(container.Provide(func(db *gorm.DB) *embedding.EmbeddingCache {
+		if strings.ToLower(os.Getenv("ENABLE_EMBEDDING_CACHE")) != "true" {
+			return nil
+		}
+		return embedding.NewEmbeddingCache(db)
+	}))
+
 	// Initialize retrieval engine registry for search capabilities
 	logger.Debugf(ctx, "[Container] Registering retrieval engine registry...")
 	must(container.Provide(initRetrieveEngineRegistry))
@@ -831,6 +840,7 @@ func initFileService(cfg *config.Config) (interfaces.FileService, error) {
 //   - Error if initialization fails
 func initRetrieveEngineRegistry(
 	db *gorm.DB, cfg *config.Config, auditSvc interfaces.AuditLogService,
+	embeddingCache *embedding.EmbeddingCache,
 ) (interfaces.RetrieveEngineRegistry, error) {
 	registry := retriever.NewRetrieveEngineRegistry()
 	retrieveDriver := strings.Split(os.Getenv("RETRIEVE_DRIVER"), ",")
@@ -843,7 +853,7 @@ func initRetrieveEngineRegistry(
 	if slices.Contains(retrieveDriver, "postgres") {
 		postgresRepo := postgresRepo.NewPostgresRetrieveEngineRepository(db)
 		if err := registry.Register(
-			retriever.NewKVHybridRetrieveEngine(postgresRepo, types.PostgresRetrieverEngineType),
+			retriever.NewKVHybridRetrieveEngineWithCache(postgresRepo, types.PostgresRetrieverEngineType, embeddingCache),
 		); err != nil {
 			log.Errorf("Register postgres retrieve engine failed: %v", err)
 		} else {
@@ -853,7 +863,7 @@ func initRetrieveEngineRegistry(
 	if slices.Contains(retrieveDriver, "sqlite") {
 		sqliteRepo := sqliteRetrieverRepo.NewSQLiteRetrieveEngineRepository(db)
 		if err := registry.Register(
-			retriever.NewKVHybridRetrieveEngine(sqliteRepo, types.SQLiteRetrieverEngineType),
+			retriever.NewKVHybridRetrieveEngineWithCache(sqliteRepo, types.SQLiteRetrieverEngineType, embeddingCache),
 		); err != nil {
 			log.Errorf("Register sqlite retrieve engine failed: %v", err)
 		} else {
@@ -871,8 +881,8 @@ func initRetrieveEngineRegistry(
 		} else {
 			elasticsearchRepo := elasticsearchRepoV8.NewElasticsearchEngineRepository(client, cfg, nil)
 			if err := registry.Register(
-				retriever.NewKVHybridRetrieveEngine(
-					elasticsearchRepo, types.ElasticsearchRetrieverEngineType,
+				retriever.NewKVHybridRetrieveEngineWithCache(
+					elasticsearchRepo, types.ElasticsearchRetrieverEngineType, embeddingCache,
 				),
 			); err != nil {
 				log.Errorf("Register elasticsearch_v8 retrieve engine failed: %v", err)
@@ -893,8 +903,8 @@ func initRetrieveEngineRegistry(
 		} else {
 			elasticsearchRepo := elasticsearchRepoV7.NewElasticsearchEngineRepository(client, cfg, nil)
 			if err := registry.Register(
-				retriever.NewKVHybridRetrieveEngine(
-					elasticsearchRepo, types.ElasticsearchRetrieverEngineType,
+				retriever.NewKVHybridRetrieveEngineWithCache(
+					elasticsearchRepo, types.ElasticsearchRetrieverEngineType, embeddingCache,
 				),
 			); err != nil {
 				log.Errorf("Register elasticsearch_v7 retrieve engine failed: %v", err)
@@ -919,7 +929,7 @@ func initRetrieveEngineRegistry(
 		); err != nil {
 			log.Errorf("Create opensearch repository failed: %v", err)
 		} else if err := registry.Register(
-			retriever.NewKVHybridRetrieveEngine(repo, types.OpenSearchRetrieverEngineType),
+			retriever.NewKVHybridRetrieveEngineWithCache(repo, types.OpenSearchRetrieverEngineType, embeddingCache),
 		); err != nil {
 			log.Errorf("Register opensearch retrieve engine failed: %v", err)
 		} else {
@@ -964,8 +974,8 @@ func initRetrieveEngineRegistry(
 		} else {
 			qdrantRepository := qdrantRepo.NewQdrantRetrieveEngineRepository(client, nil)
 			if err := registry.Register(
-				retriever.NewKVHybridRetrieveEngine(
-					qdrantRepository, types.QdrantRetrieverEngineType,
+				retriever.NewKVHybridRetrieveEngineWithCache(
+					qdrantRepository, types.QdrantRetrieverEngineType, embeddingCache,
 				),
 			); err != nil {
 				log.Errorf("Register qdrant retrieve engine failed: %v", err)
@@ -1007,8 +1017,8 @@ func initRetrieveEngineRegistry(
 		} else {
 			weaviateRepository := weaviateRepo.NewWeaviateRetrieveEngineRepository(weaviateClient, nil)
 			if err := registry.Register(
-				retriever.NewKVHybridRetrieveEngine(
-					weaviateRepository, types.WeaviateRetrieverEngineType,
+				retriever.NewKVHybridRetrieveEngineWithCache(
+					weaviateRepository, types.WeaviateRetrieverEngineType, embeddingCache,
 				),
 			); err != nil {
 				log.Errorf("Register weaviate retrieve engine failed: %v", err)
@@ -1044,8 +1054,8 @@ func initRetrieveEngineRegistry(
 		} else {
 			milvusRepository := milvusRepo.NewMilvusRetrieveEngineRepository(milvusCli, nil)
 			if err := registry.Register(
-				retriever.NewKVHybridRetrieveEngine(
-					milvusRepository, types.MilvusRetrieverEngineType,
+				retriever.NewKVHybridRetrieveEngineWithCache(
+					milvusRepository, types.MilvusRetrieverEngineType, embeddingCache,
 				),
 			); err != nil {
 				log.Errorf("Register milvus retrieve engine failed: %v", err)
@@ -1091,8 +1101,8 @@ func initRetrieveEngineRegistry(
 				dorisDB, httpBase, dorisUsername, dorisPassword, dorisDatabase, nil,
 			)
 			if err := registry.Register(
-				retriever.NewKVHybridRetrieveEngine(
-					dorisRepository, types.DorisRetrieverEngineType,
+				retriever.NewKVHybridRetrieveEngineWithCache(
+					dorisRepository, types.DorisRetrieverEngineType, embeddingCache,
 				),
 			); err != nil {
 				log.Errorf("Register doris retrieve engine failed: %v", err)
@@ -1121,8 +1131,8 @@ func initRetrieveEngineRegistry(
 					nil,
 				)
 				if err := registry.Register(
-					retriever.NewKVHybridRetrieveEngine(
-						tencentRepository, types.TencentVectorDBRetrieverEngineType,
+					retriever.NewKVHybridRetrieveEngineWithCache(
+						tencentRepository, types.TencentVectorDBRetrieverEngineType, embeddingCache,
 					),
 				); err != nil {
 					log.Errorf("Register tencent_vectordb retrieve engine failed: %v", err)
@@ -1134,7 +1144,7 @@ func initRetrieveEngineRegistry(
 	}
 	// ─── DB store registration (byStoreID) ───
 	if storeReg, ok := registry.(*retriever.RetrieveEngineRegistry); ok {
-		loadDBStoresIntoRegistry(storeReg, db, cfg, auditSink)
+		loadDBStoresIntoRegistry(storeReg, db, cfg, auditSink, embeddingCache)
 	}
 
 	return registry, nil
@@ -1144,6 +1154,7 @@ func initRetrieveEngineRegistry(
 // in the registry's byStoreID map. Failures are logged and skipped (non-fatal).
 func loadDBStoresIntoRegistry(
 	storeRegistry interfaces.StoreRegistry, db *gorm.DB, cfg *config.Config, auditSink openSearchRepo.AuditSink,
+	embeddingCache *embedding.EmbeddingCache,
 ) {
 	ctx := context.Background()
 	log := logger.GetLogger(ctx)
@@ -1161,7 +1172,7 @@ func loadDBStoresIntoRegistry(
 
 	log.Infof("Loading %d vector store(s) from database", len(stores))
 	for _, store := range stores {
-		svc, err := createEngineServiceFromStore(ctx, store, db, cfg, auditSink)
+		svc, err := createEngineServiceFromStore(ctx, store, db, cfg, auditSink, embeddingCache)
 		if err != nil {
 			log.Errorf("Failed to create engine for store %s (%s): %v", store.ID, store.Name, err)
 			continue

--- a/internal/container/engine_factory.go
+++ b/internal/container/engine_factory.go
@@ -31,6 +31,7 @@ import (
 	weaviateRepo "github.com/Tencent/WeKnora/internal/application/repository/retriever/weaviate"
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
 	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/models/embedding"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
@@ -38,45 +39,45 @@ import (
 
 // NewEngineFactory returns an EngineFactory function closed over db, cfg, and
 // an audit sink (built from the AuditLogService). Registered in dig and
-// injected into VectorStoreService for dynamic registry updates. The
-// EngineFactory type itself is unchanged — the audit sink is captured in the
-// closure rather than added to the signature.
-func NewEngineFactory(db *gorm.DB, cfg *config.Config, auditSvc interfaces.AuditLogService) interfaces.EngineFactory {
+// injected into VectorStoreService for dynamic registry updates.
+func NewEngineFactory(db *gorm.DB, cfg *config.Config, auditSvc interfaces.AuditLogService, embeddingCache *embedding.EmbeddingCache) interfaces.EngineFactory {
 	sink := newAuditSinkAdapter(auditSvc)
 	return func(ctx context.Context, store types.VectorStore) (interfaces.RetrieveEngineService, error) {
-		return createEngineServiceFromStore(ctx, store, db, cfg, sink)
+		return createEngineServiceFromStore(ctx, store, db, cfg, sink, embeddingCache)
 	}
 }
 
 // createEngineServiceFromStore creates a RetrieveEngineService from a VectorStore's config.
 // This is the DB store counterpart of the env-based initialization in initRetrieveEngineRegistry.
 // auditSink may be nil (audit becomes a no-op).
+// embeddingCache may be nil (caching disabled).
 func createEngineServiceFromStore(
 	ctx context.Context,
 	store types.VectorStore,
 	db *gorm.DB,
 	cfg *config.Config,
 	auditSink openSearchRepo.AuditSink,
+	embeddingCache *embedding.EmbeddingCache,
 ) (interfaces.RetrieveEngineService, error) {
 	switch store.EngineType {
 	case types.PostgresRetrieverEngineType:
-		return createPostgresEngine(store, db)
+		return createPostgresEngine(store, db, embeddingCache)
 	case types.ElasticsearchRetrieverEngineType:
-		return createElasticsearchEngine(store, cfg)
+		return createElasticsearchEngine(store, cfg, embeddingCache)
 	case types.QdrantRetrieverEngineType:
-		return createQdrantEngine(store)
+		return createQdrantEngine(store, embeddingCache)
 	case types.MilvusRetrieverEngineType:
-		return createMilvusEngine(ctx, store)
+		return createMilvusEngine(ctx, store, embeddingCache)
 	case types.WeaviateRetrieverEngineType:
-		return createWeaviateEngine(store)
+		return createWeaviateEngine(store, embeddingCache)
 	case types.DorisRetrieverEngineType:
-		return createDorisEngine(store)
+		return createDorisEngine(store, embeddingCache)
 	case types.SQLiteRetrieverEngineType:
-		return createSQLiteEngine(store, db)
+		return createSQLiteEngine(store, db, embeddingCache)
 	case types.TencentVectorDBRetrieverEngineType:
-		return createTencentVectorDBEngine(store)
+		return createTencentVectorDBEngine(store, embeddingCache)
 	case types.OpenSearchRetrieverEngineType:
-		return createOpenSearchEngine(ctx, store, auditSink)
+		return createOpenSearchEngine(ctx, store, auditSink, embeddingCache)
 	default:
 		return nil, fmt.Errorf("unsupported engine type: %s", store.EngineType)
 	}
@@ -89,6 +90,7 @@ func createEngineServiceFromStore(
 // registration rather than on first query.
 func createOpenSearchEngine(
 	ctx context.Context, store types.VectorStore, auditSink openSearchRepo.AuditSink,
+	embeddingCache *embedding.EmbeddingCache,
 ) (interfaces.RetrieveEngineService, error) {
 	client, err := openSearchRepo.NewOpenSearchClient(&store.ConnectionConfig)
 	if err != nil {
@@ -106,33 +108,33 @@ func createOpenSearchEngine(
 	if err != nil {
 		return nil, fmt.Errorf("create opensearch repository: %w", err)
 	}
-	return retriever.NewKVHybridRetrieveEngine(repo, types.OpenSearchRetrieverEngineType), nil
+	return retriever.NewKVHybridRetrieveEngineWithCache(repo, types.OpenSearchRetrieverEngineType, embeddingCache), nil
 }
 
-func createPostgresEngine(store types.VectorStore, db *gorm.DB) (interfaces.RetrieveEngineService, error) {
+func createPostgresEngine(store types.VectorStore, db *gorm.DB, cache *embedding.EmbeddingCache) (interfaces.RetrieveEngineService, error) {
 	if store.ConnectionConfig.UseDefaultConnection {
 		repo := postgresRepo.NewPostgresRetrieveEngineRepository(db)
-		return retriever.NewKVHybridRetrieveEngine(repo, types.PostgresRetrieverEngineType), nil
+		return retriever.NewKVHybridRetrieveEngineWithCache(repo, types.PostgresRetrieverEngineType, cache), nil
 	}
 	// Phase 1: only UseDefaultConnection is supported.
 	// Custom connections require connection pool management and migration handling.
 	return nil, fmt.Errorf("custom postgres connections not yet supported; use use_default_connection=true")
 }
 
-func createSQLiteEngine(_ types.VectorStore, db *gorm.DB) (interfaces.RetrieveEngineService, error) {
+func createSQLiteEngine(_ types.VectorStore, db *gorm.DB, cache *embedding.EmbeddingCache) (interfaces.RetrieveEngineService, error) {
 	repo := sqliteRetrieverRepo.NewSQLiteRetrieveEngineRepository(db)
-	return retriever.NewKVHybridRetrieveEngine(repo, types.SQLiteRetrieverEngineType), nil
+	return retriever.NewKVHybridRetrieveEngineWithCache(repo, types.SQLiteRetrieverEngineType, cache), nil
 }
 
-func createElasticsearchEngine(store types.VectorStore, cfg *config.Config) (interfaces.RetrieveEngineService, error) {
+func createElasticsearchEngine(store types.VectorStore, cfg *config.Config, cache *embedding.EmbeddingCache) (interfaces.RetrieveEngineService, error) {
 	cc := store.ConnectionConfig
 	// Version-based v7/v8 SDK selection.
 	// Version is auto-detected by PR2's TestConnection and saved to connection_config.
 	// Empty version defaults to v8 (latest SDK).
 	if isESv7(cc.Version) {
-		return createElasticsearchV7Engine(store, cfg)
+		return createElasticsearchV7Engine(store, cfg, cache)
 	}
-	return createElasticsearchV8Engine(store, cfg)
+	return createElasticsearchV8Engine(store, cfg, cache)
 }
 
 // isESv7 checks if the detected ES version is 7.x.
@@ -140,7 +142,7 @@ func isESv7(version string) bool {
 	return strings.HasPrefix(version, "7.")
 }
 
-func createElasticsearchV8Engine(store types.VectorStore, cfg *config.Config) (interfaces.RetrieveEngineService, error) {
+func createElasticsearchV8Engine(store types.VectorStore, cfg *config.Config, cache *embedding.EmbeddingCache) (interfaces.RetrieveEngineService, error) {
 	cc := store.ConnectionConfig
 	client, err := elasticsearch.NewTypedClient(elasticsearch.Config{
 		Addresses: []string{cc.Addr},
@@ -151,10 +153,10 @@ func createElasticsearchV8Engine(store types.VectorStore, cfg *config.Config) (i
 		return nil, fmt.Errorf("create elasticsearch v8 client: %w", err)
 	}
 	repo := elasticsearchRepoV8.NewElasticsearchEngineRepository(client, cfg, &store.IndexConfig)
-	return retriever.NewKVHybridRetrieveEngine(repo, types.ElasticsearchRetrieverEngineType), nil
+	return retriever.NewKVHybridRetrieveEngineWithCache(repo, types.ElasticsearchRetrieverEngineType, cache), nil
 }
 
-func createElasticsearchV7Engine(store types.VectorStore, cfg *config.Config) (interfaces.RetrieveEngineService, error) {
+func createElasticsearchV7Engine(store types.VectorStore, cfg *config.Config, cache *embedding.EmbeddingCache) (interfaces.RetrieveEngineService, error) {
 	cc := store.ConnectionConfig
 	client, err := esv7.NewClient(esv7.Config{
 		Addresses: []string{cc.Addr},
@@ -165,10 +167,10 @@ func createElasticsearchV7Engine(store types.VectorStore, cfg *config.Config) (i
 		return nil, fmt.Errorf("create elasticsearch v7 client: %w", err)
 	}
 	repo := elasticsearchRepoV7.NewElasticsearchEngineRepository(client, cfg, &store.IndexConfig)
-	return retriever.NewKVHybridRetrieveEngine(repo, types.ElasticsearchRetrieverEngineType), nil
+	return retriever.NewKVHybridRetrieveEngineWithCache(repo, types.ElasticsearchRetrieverEngineType, cache), nil
 }
 
-func createQdrantEngine(store types.VectorStore) (interfaces.RetrieveEngineService, error) {
+func createQdrantEngine(store types.VectorStore, cache *embedding.EmbeddingCache) (interfaces.RetrieveEngineService, error) {
 	cc := store.ConnectionConfig
 	port := cc.Port
 	if port == 0 {
@@ -185,17 +187,17 @@ func createQdrantEngine(store types.VectorStore) (interfaces.RetrieveEngineServi
 		return nil, fmt.Errorf("create qdrant client: %w", err)
 	}
 	repo := qdrantRepo.NewQdrantRetrieveEngineRepository(client, &store.IndexConfig)
-	return retriever.NewKVHybridRetrieveEngine(repo, types.QdrantRetrieverEngineType), nil
+	return retriever.NewKVHybridRetrieveEngineWithCache(repo, types.QdrantRetrieverEngineType, cache), nil
 }
 
-func createMilvusEngine(ctx context.Context, store types.VectorStore) (interfaces.RetrieveEngineService, error) {
+func createMilvusEngine(ctx context.Context, store types.VectorStore, cache *embedding.EmbeddingCache) (interfaces.RetrieveEngineService, error) {
 	milvusCfg := buildMilvusClientConfig(store.ConnectionConfig)
 	client, err := milvusclient.New(ctx, &milvusCfg)
 	if err != nil {
 		return nil, fmt.Errorf("create milvus client: %w", err)
 	}
 	repo := milvusRepo.NewMilvusRetrieveEngineRepository(client, &store.IndexConfig)
-	return retriever.NewKVHybridRetrieveEngine(repo, types.MilvusRetrieverEngineType), nil
+	return retriever.NewKVHybridRetrieveEngineWithCache(repo, types.MilvusRetrieverEngineType, cache), nil
 }
 
 func buildMilvusClientConfig(cc types.ConnectionConfig) milvusclient.ClientConfig {
@@ -220,7 +222,7 @@ func buildMilvusClientConfig(cc types.ConnectionConfig) milvusclient.ClientConfi
 	return milvusCfg
 }
 
-func createWeaviateEngine(store types.VectorStore) (interfaces.RetrieveEngineService, error) {
+func createWeaviateEngine(store types.VectorStore, cache *embedding.EmbeddingCache) (interfaces.RetrieveEngineService, error) {
 	cc := store.ConnectionConfig
 	host := cc.Host
 	if host == "" {
@@ -253,7 +255,7 @@ func createWeaviateEngine(store types.VectorStore) (interfaces.RetrieveEngineSer
 		return nil, fmt.Errorf("create weaviate client: %w", err)
 	}
 	repo := weaviateRepo.NewWeaviateRetrieveEngineRepository(client, &store.IndexConfig)
-	return retriever.NewKVHybridRetrieveEngine(repo, types.WeaviateRetrieverEngineType), nil
+	return retriever.NewKVHybridRetrieveEngineWithCache(repo, types.WeaviateRetrieverEngineType, cache), nil
 }
 
 // createDorisEngine 创建 Apache Doris 检索引擎服务。
@@ -263,7 +265,7 @@ func createWeaviateEngine(store types.VectorStore) (interfaces.RetrieveEngineSer
 //   - HTTP（默认 FE 8030）走 Stream Load 做 partial update。
 //
 // Addr 字段承担 host:9030 的 MySQL 端点；HTTPPort + Addr 的 host 部分组成 HTTP base URL。
-func createDorisEngine(store types.VectorStore) (interfaces.RetrieveEngineService, error) {
+func createDorisEngine(store types.VectorStore, cache *embedding.EmbeddingCache) (interfaces.RetrieveEngineService, error) {
 	cc := store.ConnectionConfig
 	if cc.Addr == "" {
 		return nil, fmt.Errorf("doris connection requires addr (host:port)")
@@ -298,7 +300,7 @@ func createDorisEngine(store types.VectorStore) (interfaces.RetrieveEngineServic
 	repo := dorisRepo.NewDorisRetrieveEngineRepository(
 		db, httpBase, cc.Username, cc.Password, cc.Database, &store.IndexConfig,
 	)
-	return retriever.NewKVHybridRetrieveEngine(repo, types.DorisRetrieverEngineType), nil
+	return retriever.NewKVHybridRetrieveEngineWithCache(repo, types.DorisRetrieverEngineType, cache), nil
 }
 
 // hostFromAddr 从 "host:port" 中拆出 host 部分；Addr 没有冒号时整段当作 host。
@@ -309,7 +311,7 @@ func hostFromAddr(addr string) string {
 	return addr
 }
 
-func createTencentVectorDBEngine(store types.VectorStore) (interfaces.RetrieveEngineService, error) {
+func createTencentVectorDBEngine(store types.VectorStore, cache *embedding.EmbeddingCache) (interfaces.RetrieveEngineService, error) {
 	cc := store.ConnectionConfig
 	client, err := tcvectordb.NewRpcClient(cc.Addr, cc.Username, cc.APIKey, &tcvectordb.ClientOption{
 		ReadConsistency: tcvectordb.EventualConsistency,
@@ -319,5 +321,5 @@ func createTencentVectorDBEngine(store types.VectorStore) (interfaces.RetrieveEn
 		return nil, fmt.Errorf("create tencent vectordb client: %w", err)
 	}
 	repo := tencentVectorDBRepo.NewTencentVectorDBRetrieveEngineRepository(client, cc.Database, &store.IndexConfig)
-	return retriever.NewKVHybridRetrieveEngine(repo, types.TencentVectorDBRetrieverEngineType), nil
+	return retriever.NewKVHybridRetrieveEngineWithCache(repo, types.TencentVectorDBRetrieverEngineType, cache), nil
 }

--- a/internal/container/engine_factory_opensearch_test.go
+++ b/internal/container/engine_factory_opensearch_test.go
@@ -39,7 +39,7 @@ func TestCreateOpenSearchEngine_WiresClientAndRepo(t *testing.T) {
 		EngineType:       types.OpenSearchRetrieverEngineType,
 		ConnectionConfig: types.ConnectionConfig{Addr: ts.URL},
 	}
-	svc, err := createOpenSearchEngine(context.Background(), store, nil)
+	svc, err := createOpenSearchEngine(context.Background(), store, nil, nil)
 	if err != nil {
 		t.Fatalf("createOpenSearchEngine: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestCreateOpenSearchEngine_RejectsBadCluster(t *testing.T) {
 	defer ts.Close()
 	_, err := createOpenSearchEngine(context.Background(),
 		types.VectorStore{EngineType: types.OpenSearchRetrieverEngineType,
-			ConnectionConfig: types.ConnectionConfig{Addr: ts.URL}}, nil)
+			ConnectionConfig: types.ConnectionConfig{Addr: ts.URL}}, nil, nil)
 	if err == nil {
 		t.Error("elasticsearch cluster should be rejected at engine creation")
 	}
@@ -69,7 +69,7 @@ func TestCreateEngineServiceFromStore_OpenSearchCaseReached(t *testing.T) {
 	svc, err := createEngineServiceFromStore(context.Background(),
 		types.VectorStore{EngineType: types.OpenSearchRetrieverEngineType,
 			ConnectionConfig: types.ConnectionConfig{Addr: ts.URL}},
-		nil, &config.Config{}, nil)
+		nil, &config.Config{}, nil, nil)
 	if err != nil {
 		t.Fatalf("createEngineServiceFromStore (opensearch case): %v", err)
 	}
@@ -94,7 +94,7 @@ func TestInitRetrieveEngineRegistry_OpenSearchEnvPath(t *testing.T) {
 	t.Setenv("RETRIEVE_DRIVER", "opensearch")
 	t.Setenv("OPENSEARCH_ADDR", ts.URL)
 
-	registry, err := initRetrieveEngineRegistry(db, &config.Config{}, &fakeAuditSvc{})
+	registry, err := initRetrieveEngineRegistry(db, &config.Config{}, &fakeAuditSvc{}, nil)
 	if err != nil {
 		t.Fatalf("initRetrieveEngineRegistry: %v", err)
 	}

--- a/internal/models/embedding/cache.go
+++ b/internal/models/embedding/cache.go
@@ -1,0 +1,164 @@
+package embedding
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// EmbeddingCache provides an optional, transparent cache layer for previously
+// computed embeddings. Cache keys are content-addressable: the same text +
+// model + dimensions + chunk config always maps to the same cached vector.
+//
+// The cache is opt-in and does not affect ingestion semantics.
+type EmbeddingCache struct {
+	db *gorm.DB
+}
+
+// CacheEntry represents a single cached embedding.
+type CacheEntry struct {
+	ContentHash     string `gorm:"column:content_hash;primaryKey"`
+	ModelID         string `gorm:"column:model_id;primaryKey"`
+	Dimensions      int    `gorm:"column:dimensions;primaryKey"`
+	ChunkConfigHash string `gorm:"column:chunk_config_hash;default:''"`
+	Embedding       []byte `gorm:"column:embedding"`
+	CreatedAt       int64  `gorm:"column:created_at;autoCreateTime"`
+}
+
+// TableName overrides the table name.
+func (CacheEntry) TableName() string {
+	return "embedding_cache"
+}
+
+// CacheResult holds the lookup result: cached embeddings indexed by their
+// original position, and the indices of cache misses.
+type CacheResult struct {
+	Hits  map[int][]float32 // original index → cached embedding
+	Misses []int            // original indices that need fresh embedding
+}
+
+// NewEmbeddingCache creates a new cache backed by the given GORM DB.
+func NewEmbeddingCache(db *gorm.DB) *EmbeddingCache {
+	return &EmbeddingCache{db: db}
+}
+
+// ComputeHash returns a SHA-256 hex digest that uniquely identifies an
+// embedding computation. It covers the sanitized text, model identity,
+// vector dimensions, chunk config, and preprocessing pipeline version.
+//
+// chunkConfig is expected to be a deterministic JSON serialization of the
+// chunk configuration (chunk_size, overlap, strategy, etc.).
+func ComputeHash(text, modelID string, dimensions int, chunkConfig []byte, preprocessingVersion string) string {
+	h := sha256.New()
+	h.Write([]byte(text))
+	h.Write([]byte{0}) // separator
+	h.Write([]byte(modelID))
+	h.Write([]byte{0})
+
+	var dimBuf [4]byte
+	binary.LittleEndian.PutUint32(dimBuf[:], uint32(dimensions))
+	h.Write(dimBuf[:])
+	h.Write([]byte{0})
+
+	h.Write(chunkConfig)
+	h.Write([]byte{0})
+	h.Write([]byte(preprocessingVersion))
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// HashChunkConfig serializes chunk configuration to a deterministic JSON byte
+// slice suitable for hashing.
+func HashChunkConfig(chunkSize, chunkOverlap int, strategy string) []byte {
+	type config struct {
+		ChunkSize    int    `json:"chunk_size"`
+		ChunkOverlap int    `json:"chunk_overlap"`
+		Strategy     string `json:"strategy"`
+	}
+	b, _ := json.Marshal(config{ChunkSize: chunkSize, ChunkOverlap: chunkOverlap, Strategy: strategy})
+	return b
+}
+
+// Lookup fetches cached embeddings for the given content hashes. It returns
+// a CacheResult with hits (indexed by original position) and misses (indices
+// that need fresh embedding via the API).
+func (c *EmbeddingCache) Lookup(
+	hashes []string,
+	modelID string,
+	dimensions int,
+) (*CacheResult, error) {
+	if len(hashes) == 0 {
+		return &CacheResult{Hits: make(map[int][]float32)}, nil
+	}
+
+	// Deduplicate hashes to avoid redundant lookups.
+	uniqueHashes := make(map[string]struct{}, len(hashes))
+	for _, h := range hashes {
+		uniqueHashes[h] = struct{}{}
+	}
+	hashList := make([]string, 0, len(uniqueHashes))
+	for h := range uniqueHashes {
+		hashList = append(hashList, h)
+	}
+
+	var entries []CacheEntry
+	if err := c.db.Where(
+		"content_hash IN ? AND model_id = ? AND dimensions = ?",
+		hashList, modelID, dimensions,
+	).Find(&entries).Error; err != nil {
+		return nil, fmt.Errorf("embedding cache lookup: %w", err)
+	}
+
+	// Build hash → embedding map.
+	cacheMap := make(map[string][]float32, len(entries))
+	for _, e := range entries {
+		cacheMap[e.ContentHash] = BytesToFloat32s(e.Embedding)
+	}
+
+	result := &CacheResult{Hits: make(map[int][]float32)}
+	for i, h := range hashes {
+		if emb, ok := cacheMap[h]; ok {
+			result.Hits[i] = emb
+		} else {
+			result.Misses = append(result.Misses, i)
+		}
+	}
+	return result, nil
+}
+
+// Store writes embedding entries to the cache. ON CONFLICT DO NOTHING ensures
+// idempotent writes — concurrent callers or retries are safe.
+func (c *EmbeddingCache) Store(entries []CacheEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	return c.db.Clauses(clause.OnConflict{DoNothing: true}).Create(&entries).Error
+}
+
+// BytesToFloat32s converts a BYTEA/BLOB byte slice back to []float32.
+func BytesToFloat32s(b []byte) []float32 {
+	if len(b)%4 != 0 {
+		return nil
+	}
+	count := len(b) / 4
+	result := make([]float32, count)
+	for i := range result {
+		result[i] = math.Float32frombits(binary.LittleEndian.Uint32(b[i*4 : (i+1)*4]))
+	}
+	return result
+}
+
+// Float32sToBytes converts a []float32 to a byte slice for BYTEA/BLOB storage.
+func Float32sToBytes(v []float32) []byte {
+	b := make([]byte, len(v)*4)
+	for i, f := range v {
+		binary.LittleEndian.PutUint32(b[i*4:], math.Float32bits(f))
+	}
+	return b
+}

--- a/internal/models/embedding/cache_test.go
+++ b/internal/models/embedding/cache_test.go
@@ -1,0 +1,91 @@
+package embedding_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeHash_Deterministic(t *testing.T) {
+	cfg := embedding.HashChunkConfig(512, 80, "auto")
+
+	h1 := embedding.ComputeHash("hello world", "model-a", 768, cfg, "v1")
+	h2 := embedding.ComputeHash("hello world", "model-a", 768, cfg, "v1")
+
+	assert.Equal(t, h1, h2, "same inputs must produce same hash")
+	assert.Len(t, h1, 64, "SHA-256 hex digest is 64 chars")
+}
+
+func TestComputeHash_DifferentInputs(t *testing.T) {
+	cfg := embedding.HashChunkConfig(512, 80, "auto")
+
+	h1 := embedding.ComputeHash("hello world", "model-a", 768, cfg, "v1")
+	h2 := embedding.ComputeHash("hello world!", "model-a", 768, cfg, "v1")
+
+	assert.NotEqual(t, h1, h2, "different text must produce different hash")
+}
+
+func TestComputeHash_DifferentModel(t *testing.T) {
+	cfg := embedding.HashChunkConfig(512, 80, "auto")
+
+	h1 := embedding.ComputeHash("hello world", "model-a", 768, cfg, "v1")
+	h2 := embedding.ComputeHash("hello world", "model-b", 768, cfg, "v1")
+
+	assert.NotEqual(t, h1, h2, "different model must produce different hash")
+}
+
+func TestComputeHash_DifferentDimensions(t *testing.T) {
+	cfg := embedding.HashChunkConfig(512, 80, "auto")
+
+	h1 := embedding.ComputeHash("hello world", "model-a", 768, cfg, "v1")
+	h2 := embedding.ComputeHash("hello world", "model-a", 1024, cfg, "v1")
+
+	assert.NotEqual(t, h1, h2, "different dimensions must produce different hash")
+}
+
+func TestComputeHash_DifferentVersion(t *testing.T) {
+	cfg := embedding.HashChunkConfig(512, 80, "auto")
+
+	h1 := embedding.ComputeHash("hello world", "model-a", 768, cfg, "v1")
+	h2 := embedding.ComputeHash("hello world", "model-a", 768, cfg, "v2")
+
+	assert.NotEqual(t, h1, h2, "different preprocessing version must produce different hash")
+}
+
+func TestComputeHash_DifferentChunkConfig(t *testing.T) {
+	cfg1 := embedding.HashChunkConfig(512, 80, "auto")
+	cfg2 := embedding.HashChunkConfig(256, 40, "heading")
+
+	h1 := embedding.ComputeHash("hello world", "model-a", 768, cfg1, "v1")
+	h2 := embedding.ComputeHash("hello world", "model-a", 768, cfg2, "v1")
+
+	assert.NotEqual(t, h1, h2, "different chunk config must produce different hash")
+}
+
+func TestHashChunkConfig_Deterministic(t *testing.T) {
+	b1 := embedding.HashChunkConfig(512, 80, "auto")
+	b2 := embedding.HashChunkConfig(512, 80, "auto")
+
+	assert.Equal(t, hex.EncodeToString(b1), hex.EncodeToString(b2),
+		"chunk config hash must be deterministic")
+}
+
+func TestFloat32sToBytes_Roundtrip(t *testing.T) {
+	original := []float32{0.1, 0.2, 0.3, -0.1, 1.0, -1.0}
+	bytes := embedding.Float32sToBytes(original)
+	result := embedding.BytesToFloat32s(bytes)
+
+	assert.Equal(t, original, result, "float32 <-> bytes roundtrip must be lossless")
+}
+
+func TestFloat32sToBytes_Empty(t *testing.T) {
+	bytes := embedding.Float32sToBytes([]float32{})
+	assert.Len(t, bytes, 0)
+}
+
+func TestBytesToFloat32s_InvalidLength(t *testing.T) {
+	result := embedding.BytesToFloat32s([]byte{0x01, 0x02, 0x03})
+	assert.Nil(t, result, "bytes with non-multiple-of-4 length must return nil")
+}

--- a/migrations/sqlite/000000_init.up.sql
+++ b/migrations/sqlite/000000_init.up.sql
@@ -685,3 +685,18 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_vector_stores_name_tenant
 CREATE INDEX IF NOT EXISTS idx_vector_stores_tenant_id ON vector_stores(tenant_id);
 CREATE INDEX IF NOT EXISTS idx_vector_stores_engine_type ON vector_stores(engine_type);
 CREATE INDEX IF NOT EXISTS idx_vector_stores_deleted_at ON vector_stores(deleted_at);
+
+-- Embedding cache for redundant computation reduction
+-- chunk_config_hash is reserved for future cache partitioning across
+-- different chunking strategies. In this initial version it defaults to ''
+-- and is intentionally excluded from the primary key.
+CREATE TABLE IF NOT EXISTS embedding_cache (
+    content_hash      VARCHAR(64) NOT NULL,
+    model_id          VARCHAR(64) NOT NULL,
+    dimensions        INTEGER NOT NULL,
+    chunk_config_hash VARCHAR(64) NOT NULL DEFAULT '',
+    embedding         BLOB NOT NULL,
+    created_at        DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (content_hash, model_id, dimensions)
+);
+CREATE INDEX IF NOT EXISTS idx_emb_cache_model ON embedding_cache(model_id);

--- a/migrations/versioned/000060_embedding_cache.down.sql
+++ b/migrations/versioned/000060_embedding_cache.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS embedding_cache;

--- a/migrations/versioned/000060_embedding_cache.up.sql
+++ b/migrations/versioned/000060_embedding_cache.up.sql
@@ -1,0 +1,28 @@
+-- Migration 000060: Embedding cache for redundant computation reduction
+--
+-- Introduces an optional, transparent cache layer that stores previously
+-- computed embeddings keyed by (content_hash, model_id, dimensions,
+-- chunk_config_hash). When enabled, unchanged chunks skip the embedding
+-- API call entirely during re-indexing.
+--
+-- The cache is opt-in (ENABLE_EMBEDDING_CACHE=false by default) and does
+-- not affect ingestion semantics or pipeline behavior.
+
+-- chunk_config_hash is stored as a reserved dimension for future cache
+-- partitioning across different chunking strategies (e.g. chunk_size=512 vs
+-- 1024). In this initial version it is set to a constant empty string and is
+-- intentionally not part of the primary key, as the cache currently operates
+-- at the (content_hash, model_id, dimensions) level. A future migration can
+-- extend the uniqueness constraint when chunk-config-aware caching is added.
+
+CREATE TABLE IF NOT EXISTS embedding_cache (
+    content_hash      VARCHAR(64) NOT NULL,
+    model_id          VARCHAR(64) NOT NULL,
+    dimensions        INT NOT NULL,
+    chunk_config_hash VARCHAR(64) NOT NULL DEFAULT '',
+    embedding         BYTEA NOT NULL,
+    created_at        TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (content_hash, model_id, dimensions)
+);
+
+CREATE INDEX IF NOT EXISTS idx_emb_cache_model ON embedding_cache(model_id);


### PR DESCRIPTION
## 增加可选 Embedding Cache，减少重复生成 Embedding

Closes #1631

### 变更说明

在 Embedding 生成流程中增加可选的透明缓存层。

以 `(content_hash, model_id, dimensions)` 作为唯一键缓存 Embedding 结果：

- Cache Hit：直接复用已有向量
- Cache Miss：调用原 Embedding API，并将结果写入缓存

默认关闭（未设置 `ENABLE_EMBEDDING_CACHE` 时为 `false`），开启后可复用于：

- 文档 re-index 时未变化的 chunk
- 不同文档中的重复内容

关闭状态下不影响现有行为。

### 实现内容

- 新增 Embedding Cache 抽象及实现
- 新增 PostgreSQL Migration
- 补充 SQLite 初始化 Schema
- 在 BatchIndex 流程中增加 Cache Lookup
- 通过 Container 单例注入 Cache 实例
- 新增 `ENABLE_EMBEDDING_CACHE` 配置项
- 补充相关单元测试和集成测试

### 测试覆盖

集成测试：

- 相同内容二次调用：全部命中 Cache，0 API 调用
- 混合新旧内容：仅新内容触发 API，已有内容命中 Cache
- Cache 关闭：每次调用均走原 Embedding API

单元测试：

- Hash 确定性
- Hash 输入差异（text / model / dims / version / chunk config）
- float32↔bytes 序列化往返

```bash
go test ./internal/models/embedding/ ./internal/application/service/retriever/ ./internal/container/
```

```
ok   github.com/Tencent/WeKnora/internal/models/embedding
ok   github.com/Tencent/WeKnora/internal/application/service/retriever
ok   github.com/Tencent/WeKnora/internal/container
```

### 兼容性

该功能默认关闭，为纯增量能力，不影响现有索引与检索流程。