### PR TITLE
feat(frontend): implement marquee selection for knowledge base

### DIFF
--- a/frontend/src/hooks/useMarqueeSelect.ts
+++ b/frontend/src/hooks/useMarqueeSelect.ts
@@ -1,0 +1,211 @@
+import { computed, onBeforeUnmount, ref, type Ref } from 'vue';
+
+type Rect = { left: number; top: number; right: number; bottom: number };
+/** iOS Photos select-mode marquee: add or subtract for the whole gesture. */
+type MarqueeMode = 'add' | 'subtract';
+
+const IGNORE_TARGET_SELECTOR = [
+  'button',
+  'a',
+  'input',
+  'textarea',
+  'select',
+  'label',
+  '.t-checkbox',
+  '.more-wrap',
+  '.card-menu',
+  '.card-menu-item',
+  '.card-tag-selector',
+  '.row-more-btn',
+  '.row-menu',
+  '.row-menu-item',
+  '.doc-list-header',
+].join(', ');
+
+const DEFAULT_MIN_DRAG_PX = 6;
+
+function normalizeRect(x1: number, y1: number, x2: number, y2: number): Rect {
+  return {
+    left: Math.min(x1, x2),
+    top: Math.min(y1, y2),
+    right: Math.max(x1, x2),
+    bottom: Math.max(y1, y2),
+  };
+}
+
+function rectsIntersect(a: Rect, b: DOMRect): boolean {
+  return !(a.right < b.left || a.left > b.right || a.bottom < b.top || a.top > b.bottom);
+}
+
+function shouldIgnoreTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return true;
+  return !!target.closest(IGNORE_TARGET_SELECTOR);
+}
+
+/**
+ * iOS Photos「选择」模式框选规则：
+ * - 手势起点落在未选中项（或空白区域）→ 本次拖选全程追加选中
+ * - 手势起点落在已选中项 → 本次拖选全程取消选中
+ */
+function resolveMarqueeModeFromStart(
+  e: MouseEvent,
+  itemSelector: string,
+  getItemId: (el: HTMLElement) => string | null,
+  selectedIds: Set<string>,
+): MarqueeMode {
+  const target = e.target;
+  if (!(target instanceof Element)) return 'add';
+  const itemEl = target.closest<HTMLElement>(itemSelector);
+  if (!itemEl) return 'add';
+  const id = getItemId(itemEl);
+  if (!id) return 'add';
+  return selectedIds.has(id) ? 'subtract' : 'add';
+}
+
+export interface UseMarqueeSelectOptions {
+  containerRef: Ref<HTMLElement | null>;
+  itemSelector: string;
+  selectedIds: Ref<Set<string>>;
+  getItemId: (el: HTMLElement) => string | null;
+  enabled?: Ref<boolean>;
+  onSelectionStart?: () => void;
+  minDragDistance?: number;
+}
+
+export function useMarqueeSelect(options: UseMarqueeSelectOptions) {
+  const {
+    containerRef,
+    itemSelector,
+    selectedIds,
+    getItemId,
+    enabled,
+    onSelectionStart,
+    minDragDistance = DEFAULT_MIN_DRAG_PX,
+  } = options;
+
+  const isActive = ref(false);
+  const boxVisible = ref(false);
+  const boxStyle = ref<Record<string, string>>({});
+  const suppressClickUntil = ref(0);
+  const marqueeMode = ref<MarqueeMode>('add');
+
+  let startClientX = 0;
+  let startClientY = 0;
+  let currentClientX = 0;
+  let currentClientY = 0;
+  let baseSelection = new Set<string>();
+  let dragMode: MarqueeMode = 'add';
+
+  const updateBoxStyle = () => {
+    const container = containerRef.value;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    const left = Math.min(startClientX, currentClientX) - rect.left + container.scrollLeft;
+    const top = Math.min(startClientY, currentClientY) - rect.top + container.scrollTop;
+    const width = Math.abs(currentClientX - startClientX);
+    const height = Math.abs(currentClientY - startClientY);
+    boxStyle.value = {
+      left: `${left}px`,
+      top: `${top}px`,
+      width: `${width}px`,
+      height: `${height}px`,
+    };
+  };
+
+  const collectIntersectingIds = (): Set<string> => {
+    const container = containerRef.value;
+    if (!container) return new Set();
+    const box = normalizeRect(startClientX, startClientY, currentClientX, currentClientY);
+    const ids = new Set<string>();
+    container.querySelectorAll<HTMLElement>(itemSelector).forEach((el) => {
+      const id = getItemId(el);
+      if (!id) return;
+      if (rectsIntersect(box, el.getBoundingClientRect())) ids.add(id);
+    });
+    return ids;
+  };
+
+  const applyMarqueeSelection = () => {
+    const hit = collectIntersectingIds();
+    const next = new Set(baseSelection);
+    if (dragMode === 'subtract') {
+      hit.forEach((id) => next.delete(id));
+    } else {
+      hit.forEach((id) => next.add(id));
+    }
+    selectedIds.value = next;
+  };
+
+  const endDrag = () => {
+    if (!isActive.value) return;
+    isActive.value = false;
+    boxVisible.value = false;
+    marqueeMode.value = 'add';
+    document.body.style.removeProperty('user-select');
+    document.removeEventListener('mousemove', onDocumentMouseMove);
+    document.removeEventListener('mouseup', onDocumentMouseUp);
+    if (Math.hypot(currentClientX - startClientX, currentClientY - startClientY) >= minDragDistance) {
+      suppressClickUntil.value = Date.now() + 150;
+    }
+  };
+
+  const onDocumentMouseMove = (e: MouseEvent) => {
+    if (!isActive.value) return;
+    currentClientX = e.clientX;
+    currentClientY = e.clientY;
+    const distance = Math.hypot(currentClientX - startClientX, currentClientY - startClientY);
+    if (!boxVisible.value && distance >= minDragDistance) {
+      boxVisible.value = true;
+      marqueeMode.value = dragMode;
+      onSelectionStart?.();
+    }
+    if (boxVisible.value) {
+      updateBoxStyle();
+      applyMarqueeSelection();
+    }
+  };
+
+  const onDocumentMouseUp = () => {
+    endDrag();
+  };
+
+  const onContainerMouseDown = (e: MouseEvent) => {
+    if (e.button !== 0) return;
+    if (enabled && !enabled.value) return;
+    if (shouldIgnoreTarget(e.target)) return;
+
+    const container = containerRef.value;
+    if (!container) return;
+
+    dragMode = resolveMarqueeModeFromStart(e, itemSelector, getItemId, selectedIds.value);
+    baseSelection = new Set(selectedIds.value);
+
+    isActive.value = true;
+    startClientX = e.clientX;
+    startClientY = e.clientY;
+    currentClientX = e.clientX;
+    currentClientY = e.clientY;
+    boxVisible.value = false;
+    boxStyle.value = {};
+
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', onDocumentMouseMove);
+    document.addEventListener('mouseup', onDocumentMouseUp);
+  };
+
+  const shouldSuppressClick = () => Date.now() < suppressClickUntil.value;
+
+  const marqueeVisible = computed(() => boxVisible.value);
+
+  onBeforeUnmount(() => {
+    endDrag();
+  });
+
+  return {
+    onContainerMouseDown,
+    marqueeVisible,
+    marqueeMode,
+    boxStyle,
+    shouldSuppressClick,
+  };
+}

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -57,6 +57,7 @@ import { listMoveTargets, moveKnowledge, getKnowledgeMoveProgress } from '@/api/
 import { useI18n } from 'vue-i18n';
 import { formatStringDate } from '@/utils';
 import { formatFileSize } from '@/utils/files';
+import { useMarqueeSelect } from '@/hooks/useMarqueeSelect';
 import type { ParserEngineInfo } from '@/api/system';
 const route = useRoute();
 const { t } = useI18n();
@@ -1823,7 +1824,25 @@ const handleEnterBatchFromCard = (item: any) => {
   clearSelection();
   batchMode.value = true;
 };
+const {
+  onContainerMouseDown: onDocMarqueeMouseDown,
+  marqueeVisible: docMarqueeVisible,
+  marqueeMode: docMarqueeMode,
+  boxStyle: docMarqueeBoxStyle,
+  shouldSuppressClick: shouldSuppressDocClick,
+} = useMarqueeSelect({
+  containerRef: knowledgeScroll,
+  itemSelector: '.knowledge-card[data-select-id], .doc-list-row[data-select-id]',
+  selectedIds,
+  getItemId: (el) => el.dataset.selectId || null,
+  enabled: computed(() => canEdit.value && !isFAQ.value && cardList.value.length > 0),
+  onSelectionStart: () => {
+    batchMode.value = true;
+  },
+});
+
 const onCardClick = (item: any) => {
+  if (shouldSuppressDocClick()) return;
   if (batchMode.value) {
     onCardGridCheckboxChange(item.id, !selectedIds.value.has(item.id));
   } else {
@@ -2218,8 +2237,15 @@ async function createNewSession(value: string): Promise<void> {
                   />
                 </div>
               </div>
-              <div class="doc-scroll-container" :class="{ 'is-empty': !cardList.length && !docListLoading }" ref="knowledgeScroll"
-                @scroll="handleScroll">
+              <div class="doc-scroll-container" :class="{ 'is-empty': !cardList.length && !docListLoading, 'is-marquee-active': docMarqueeVisible }" ref="knowledgeScroll"
+                @scroll="handleScroll" @mousedown="onDocMarqueeMouseDown">
+                <div
+                  v-if="docMarqueeVisible"
+                  class="doc-marquee-box"
+                  :class="{ 'is-add': docMarqueeMode === 'add', 'is-subtract': docMarqueeMode === 'subtract' }"
+                  :style="docMarqueeBoxStyle"
+                  aria-hidden="true"
+                />
                 <!-- 文档骨架屏 -->
                 <div v-if="docListLoading && cardList.length === 0" class="doc-card-list doc-card-list-animated">
                   <div v-for="n in 8" :key="'doc-skel-' + n" class="knowledge-card knowledge-card-skeleton">
@@ -2241,6 +2267,7 @@ async function createNewSession(value: string): Promise<void> {
                     <!-- 现有文档卡片 -->
                     <div class="knowledge-card"
                       :class="{ 'is-selected': selectedIds.has(item.id), 'batch-mode': batchMode }"
+                      :data-select-id="item.id"
                       v-for="(item, index) in cardList" :key="item.id" @click="onCardClick(item)"
                       @mouseenter="onCardMouseEnter($event, item)" @mousemove="onCardMouseMove($event)"
                       @mouseleave="onCardMouseLeave">
@@ -2553,7 +2580,7 @@ async function createNewSession(value: string): Promise<void> {
                 </template>
                 <template v-else-if="cardList.length && viewMode === 'list'">
                   <DocumentListView :items="cardList" :selected-ids="selectedIds" :tag-list="tagList"
-                    :can-edit="canEdit" @open="(item: any) => openCardDetails(item)" @toggle-row="toggleSelectRow"
+                    :can-edit="canEdit" @open="(item: any) => { if (!shouldSuppressDocClick()) openCardDetails(item); }" @toggle-row="toggleSelectRow"
                     @toggle-all="toggleSelectAll"
                     @action="(action: any, item: any) => handleListAction(action, item)" />
                 </template>
@@ -3178,6 +3205,7 @@ async function createNewSession(value: string): Promise<void> {
 }
 
 .doc-scroll-container {
+  position: relative;
   flex: 1;
   min-height: 0;
   overflow-y: auto;
@@ -3189,6 +3217,29 @@ async function createNewSession(value: string): Promise<void> {
     align-items: center;
     justify-content: center;
     overflow-y: hidden;
+  }
+
+  &.is-marquee-active {
+    cursor: crosshair;
+  }
+}
+
+.doc-marquee-box {
+  position: absolute;
+  z-index: 4;
+  pointer-events: none;
+  border: 1px solid var(--td-brand-color);
+  background: color-mix(in srgb, var(--td-brand-color) 12%, transparent);
+  border-radius: 2px;
+
+  &.is-add {
+    border-color: var(--td-brand-color);
+    background: color-mix(in srgb, var(--td-brand-color) 14%, transparent);
+  }
+
+  &.is-subtract {
+    border-color: var(--td-error-color-6);
+    background: color-mix(in srgb, var(--td-error-color-6) 12%, transparent);
   }
 }
 

--- a/frontend/src/views/knowledge/components/DocumentListView.vue
+++ b/frontend/src/views/knowledge/components/DocumentListView.vue
@@ -218,6 +218,7 @@ const handleAction = (action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'de
         :key="item.id"
         class="doc-list-row"
         :class="{ selected: selectedIds.has(item.id), 'menu-open': moreOpen === item.id }"
+        :data-select-id="item.id"
         role="row"
         @click="emit('open', item)"
       >


### PR DESCRIPTION
- Introduced a new `useMarqueeSelect` hook to enable marquee selection functionality in the knowledge base view.
- Integrated marquee selection with mouse events to allow users to select multiple items by dragging a selection box.
- Updated the `KnowledgeBase.vue` and `DocumentListView.vue` components to support the new selection feature, including visual indicators for selection mode.
- Enhanced user experience by providing a responsive selection interface that adapts to user interactions.
