### PR TITLE
refactor(get_document_info): update schema definition and input parameters

### DIFF
--- a/internal/agent/tools/get_document_info.go
+++ b/internal/agent/tools/get_document_info.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
-	"github.com/Tencent/WeKnora/internal/utils"
 )
 
 var getDocumentInfoTool = BaseTool{
@@ -46,13 +45,28 @@ Do not use when:
 ## IDs
 - knowledge_ids: regular documents knowledges
 - faq_ids: individual FAQ entries. Returns the standard question and answers, not the container title.`,
-	schema: utils.GenerateSchema[GetDocumentInfoInput](),
+	schema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "knowledge_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Document/knowledge IDs for regular documents"
+    },
+    "faq_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "FAQ entry IDs (= chunk_id from grep_chunks). Use instead of knowledge_ids for a single FAQ Q&A."
+    }
+  }
+}`),
 }
 
-// GetDocumentInfoInput defines the input parameters for get document info tool
+// GetDocumentInfoInput defines the input parameters for get document info tool.
+// Either knowledge_ids or faq_ids may be provided (at least one); both are optional in the schema.
 type GetDocumentInfoInput struct {
-	KnowledgeIDs []string `json:"knowledge_ids" jsonschema:"Document/knowledge IDs for regular documents or FAQ containers"`
-	FAQIDs       []string `json:"faq_ids" jsonschema:"FAQ entry IDs (= chunk_id from grep_chunks). Use instead of knowledge_ids for a single FAQ Q&A."`
+	KnowledgeIDs []string `json:"knowledge_ids,omitempty"`
+	FAQIDs       []string `json:"faq_ids,omitempty"`
 }
 
 // GetDocumentInfoTool retrieves detailed information about a document/knowledge


### PR DESCRIPTION

- Removed dependency on utils for schema generation, replacing it with a hardcoded JSON schema for GetDocumentInfoInput.
- Updated the input struct to use omitempty for JSON fields, clarifying that either knowledge_ids or faq_ids may be provided, but both are optional.
- Enhanced documentation for GetDocumentInfoInput to specify the usage of knowledge_ids and faq_ids.
