### PR TITLE
feat(docker): streamline frontend build process and update Docker configuration

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,12 +10,35 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  NODE_VERSION: "24"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build-ui:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Prepare version info
+        id: version
+        run: |
+          eval "$(./scripts/get_version.sh env)"
+          echo "commit_id=$COMMIT_ID" >> $GITHUB_OUTPUT
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend
+        env:
+          VITE_IS_DOCKER: true
+          VITE_FRONTEND_COMMIT: ${{ steps.version.outputs.commit_id }}
+        run: ./scripts/build_frontend_dist.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -32,12 +55,6 @@ jobs:
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/weknora-ui
 
-      - name: Prepare version info
-        id: version
-        run: |
-          eval "$(./scripts/get_version.sh env)"
-          echo "commit_id=$COMMIT_ID" >> $GITHUB_OUTPUT
-
       - name: Build ui Image
         uses: docker/build-push-action@v7
         with:
@@ -45,8 +62,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: frontend/Dockerfile
           context: ./frontend
-          build-args: |
-            ${{ format('COMMIT_ID_ARG={0}', steps.version.outputs.commit_id) }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha,scope=build-ui

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ docker-build-docreader:
 
 # Build frontend Docker image
 docker-build-frontend:
+	./scripts/build_frontend_dist.sh
 	docker build --platform $(PLATFORM) -f frontend/Dockerfile -t wechatopenai/weknora-ui:latest frontend/
 
 # Build all Docker images

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,9 @@
 services:
   frontend:
     image: wechatopenai/weknora-ui:${WEKNORA_VERSION:-latest}
+    # Requires frontend/dist — run ./scripts/build_frontend_dist.sh before --build
     build:
       context: ./frontend
-      args:
-        - MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
-        - COMMIT_ID_ARG=${COMMIT_ID:-unknown}
     container_name: WeKnora-frontend
     ports:
       - "${FRONTEND_PORT:-80}:80"

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,8 +1,4 @@
-node_modules
-dist
-.git
-.gitignore
-README.md
-.vscode
-*.log
-.DS_Store 
+*
+!dist
+!nginx.conf
+!docker-entrypoint.sh

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,47 +1,16 @@
-# 构建阶段
-FROM node:24-alpine AS build-stage
+# Production image. Build static assets on the host first:
+#   ./scripts/build_frontend_dist.sh
+FROM nginx:stable-alpine
 
-WORKDIR /app
+COPY dist /usr/share/nginx/html
 
-# 设置环境变量，忽略类型检查错误
-ENV NODE_OPTIONS="--max-old-space-size=4096"
-ENV VITE_IS_DOCKER=true
-
-# 注入前端 commit hash（构建上下文为 frontend/，无 .git，故通过构建参数传入）
-ARG COMMIT_ID_ARG=unknown
-ENV VITE_FRONTEND_COMMIT=${COMMIT_ID_ARG}
-
-# 复制依赖文件
-COPY package*.json ./
-COPY pnpm-workspace.yaml ./
-COPY packages/xlsx-0.20.2.tgz ./packages/xlsx-0.20.2.tgz
-
-# 安装依赖
-RUN npm ci
-
-# 复制项目文件
-COPY . .
-
-# 构建应用
-RUN npm run build
-
-# 生产阶段
-FROM nginx:stable-alpine AS production-stage
-
-# 复制构建产物到nginx服务目录
-COPY --from=build-stage /app/dist /usr/share/nginx/html
-
-# 复制nginx配置模板文件
 COPY nginx.conf /etc/nginx/templates/default.conf.template
 
-# 复制启动脚本
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
-# 设置默认环境变量（MB）
 ENV MAX_FILE_SIZE_MB=50
 
-# 暴露端口
 EXPOSE 80
 
-ENTRYPOINT ["/docker-entrypoint.sh"] 
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/scripts/build_frontend_dist.sh
+++ b/scripts/build_frontend_dist.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Build frontend static assets for Docker / release packaging.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -z "${VITE_FRONTEND_COMMIT:-}" ]; then
+	# shellcheck source=/dev/null
+	eval "$("$PROJECT_ROOT/scripts/get_version.sh" env)"
+	export VITE_FRONTEND_COMMIT="${COMMIT_ID:-unknown}"
+fi
+
+export VITE_IS_DOCKER="${VITE_IS_DOCKER:-true}"
+
+cd "$PROJECT_ROOT/frontend"
+npm ci
+npm run build

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -187,11 +187,13 @@ build_frontend_image() {
     
     # 获取版本信息（用于注入前端 commit hash）
     get_version_info
-    
+
+    log_info "构建前端静态资源..."
+    VITE_IS_DOCKER=true VITE_FRONTEND_COMMIT="$COMMIT_ID" "$SCRIPT_DIR/build_frontend_dist.sh"
+
     docker build \
         --platform $PLATFORM \
         -f frontend/Dockerfile \
-        --build-arg COMMIT_ID_ARG="$COMMIT_ID" \
         -t wechatopenai/weknora-ui:latest \
         frontend/
     


### PR DESCRIPTION
- Added a new script `build_frontend_dist.sh` to handle the building of frontend static assets.
- Updated `docker-compose.yml` to include a note about running the build script before building the frontend service.
- Modified the GitHub Actions workflow to integrate the new build script for frontend assets.
- Adjusted the Dockerfile to copy built assets directly from the `dist` directory.
- Refined the `.dockerignore` to exclude unnecessary files while keeping the `dist` directory.
