### PR TITLE
feat(im): sidebar source filter, content titles & in-flight reply recovery 

### DIFF
--- a/frontend/src/api/chat/index.ts
+++ b/frontend/src/api/chat/index.ts
@@ -6,8 +6,12 @@ export async function createSessions(data = {}) {
   return post("/api/v1/sessions", data);
 }
 
-export async function getSessionsList(page: number, page_size: number) {
-  return get(`/api/v1/sessions?page=${page}&page_size=${page_size}`);
+export async function getSessionsList(page: number, page_size: number, source?: string) {
+  const params = new URLSearchParams({ page: String(page), page_size: String(page_size) });
+  if (source) {
+    params.set("source", source);
+  }
+  return get(`/api/v1/sessions?${params.toString()}`);
 }
 
 export async function pinSession(session_id: string) {

--- a/frontend/src/components/SourceSwitcherDropdown.vue
+++ b/frontend/src/components/SourceSwitcherDropdown.vue
@@ -1,0 +1,163 @@
+<template>
+  <t-popup
+    v-model:visible="visible"
+    trigger="click"
+    placement="bottom-left"
+    :overlay-style="{ padding: 0 }"
+    :overlay-inner-style="{ padding: 0 }"
+  >
+    <template #content>
+      <div class="source-switcher-card">
+        <div class="source-switcher-list">
+          <button
+            v-for="item in sortedList"
+            :key="item.value"
+            type="button"
+            class="source-switcher-row"
+            :class="{ active: item.value === current }"
+            @click="handleSelect(item.value)"
+          >
+            <img
+              v-if="item.logo"
+              :src="item.logo"
+              :alt="item.label"
+              class="source-switcher-row-logo"
+            />
+            <t-icon
+              v-else
+              name="user"
+              class="source-switcher-row-icon"
+              size="16px"
+            />
+            <span class="source-switcher-row-name" :title="item.label">{{ item.label }}</span>
+            <t-icon
+              v-if="item.value === current"
+              name="check"
+              class="source-switcher-row-check"
+              size="14px"
+            />
+          </button>
+        </div>
+      </div>
+    </template>
+    <slot />
+  </t-popup>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+// A dumb scope switcher mirroring KBSwitcherDropdown's visual grammar. Logos are
+// pre-resolved by the caller; web (no logo) falls back to a generic icon.
+interface SourceItem {
+  value: string
+  label: string
+  logo?: string
+}
+
+const props = defineProps<{
+  sources: SourceItem[]
+  current: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'select', value: string): void
+}>()
+
+// t-popup only closes on outside click; selecting an item must close it
+// explicitly, otherwise the panel lingers and overlays the list below
+// (switching source reloads in place, so nothing else dismisses it).
+const visible = ref(false)
+
+// Pin the current source to the top so users always see "where they are" without
+// scrolling — same as KBSwitcherDropdown. The rest keeps the caller's order
+// (web first, then configured platforms).
+const sortedList = computed<SourceItem[]>(() => {
+  const all = props.sources || []
+  const current = all.find((s) => s.value === props.current)
+  if (!current) return all
+  return [current, ...all.filter((s) => s.value !== props.current)]
+})
+
+const handleSelect = (value: string): void => {
+  visible.value = false
+  if (value === props.current) return
+  emit('select', value)
+}
+</script>
+
+<style scoped lang="less">
+/* Mirrors KBSwitcherDropdown so both scope switchers stay visually identical. */
+.source-switcher-card {
+  min-width: 200px;
+  max-width: 300px;
+  max-height: min(60vh, 420px);
+  display: flex;
+  flex-direction: column;
+  padding: 6px;
+  overflow: hidden;
+}
+
+.source-switcher-list {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.source-switcher-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--td-text-color-primary);
+  font-size: 13px;
+  line-height: 1.4;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  text-align: left;
+
+  &:hover {
+    background: var(--td-bg-color-secondarycontainer);
+  }
+
+  &.active {
+    background: var(--td-brand-color-light, rgba(0, 82, 217, 0.08));
+    color: var(--td-brand-color);
+    font-weight: 500;
+  }
+}
+
+.source-switcher-row-logo {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  object-fit: contain;
+}
+
+.source-switcher-row-icon {
+  flex: 0 0 auto;
+  color: var(--td-text-color-placeholder);
+
+  .source-switcher-row.active & {
+    color: var(--td-brand-color);
+  }
+}
+
+.source-switcher-row-name {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-switcher-row-check {
+  flex: 0 0 auto;
+  color: var(--td-brand-color);
+}
+</style>

--- a/frontend/src/components/menu.vue
+++ b/frontend/src/components/menu.vue
@@ -94,6 +94,14 @@
                                     class="menu-pending-badge"
                                     :title="t('organization.settings.pendingJoinRequestsBadge')">{{
                                         orgStore.totalPendingJoinRequestCount }}</span>
+                                <!-- 「对话」标题行右侧：会话来源切换图标 -->
+                                <span v-if="item.path === 'creatChat'" class="menu-trailing">
+                                    <SourceSwitcherDropdown v-if="showSourceFilter && !batchMode"
+                                        :sources="sourceOptions" :current="currentSource" @select="switchSource">
+                                        <t-icon name="filter" @click.stop :title="currentSourceLabel"
+                                            :class="['menu-source-icon', { 'menu-source-icon-active': currentSource !== DEFAULT_SESSION_SOURCE }]" />
+                                    </SourceSwitcherDropdown>
+                                </span>
                             </template>
                         </div>
                     </div>
@@ -138,6 +146,10 @@
                         </div>
                     </div>
                 </template>
+                <!-- 空状态：加载完成且当前来源无会话（切到无会话来源时不再白屏） -->
+                <div v-if="!loading && groupedSessions.length === 0" class="submenu_empty">
+                    {{ t('menu.noSessions') }}
+                </div>
             </div>
 
             <!-- 批量管理底部操作条 -->
@@ -175,6 +187,15 @@ import { onMounted, watch, computed, ref, h } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { getSessionsList, delSession, batchDelSessions, deleteAllSessions, clearSessionMessages, pinSession, unpinSession } from "@/api/chat/index";
 import { useChatResourcesStore } from '@/stores/chatResources';
+import { listAllIMChannels } from '@/api/agent/index';
+import SourceSwitcherDropdown from './SourceSwitcherDropdown.vue';
+import {
+    DEFAULT_SESSION_SOURCE,
+    buildSourceOptions,
+    configuredPlatforms,
+    shouldShowSourceFilter,
+    type SessionSource,
+} from './sessionSourceFilter';
 import { logout as logoutApi } from '@/api/auth';
 import { useMenuStore } from '@/stores/menu';
 import { useAuthStore } from '@/stores/auth';
@@ -228,8 +249,25 @@ const currentpath = ref('');
 const currentPage = ref(1);
 const page_size = ref(30);
 const total = ref(0);
+// Monotonic token to discard stale list responses when loads race (see getMessageList).
+let listRequestToken = 0;
 const currentSecondpath = ref('');
 const scrollContainer = ref<HTMLElement | null>(null);
+// Default to the user's own web chats; only tenants with a configured IM
+// channel get the switcher to reach a platform's sessions.
+const currentSource = ref<SessionSource>(DEFAULT_SESSION_SOURCE);
+const imPlatforms = ref<string[]>([]);
+const showSourceFilter = computed(() => shouldShowSourceFilter(imPlatforms.value));
+// Options for the source switcher: web first, then each configured IM platform.
+// Logos are resolved here (where platformLogo lives) so the dropdown stays dumb.
+const sourceOptions = computed(() =>
+    buildSourceOptions(imPlatforms.value, t('menu.myChats'), (p) => t(`agentEditor.im.${p}`))
+        .map((o) => ({ ...o, logo: o.platform ? platformLogo(o.platform) : '' }))
+);
+// Full label of the active source, shown as the trigger icon's tooltip.
+const currentSourceLabel = computed(() =>
+    sourceOptions.value.find((o) => o.value === currentSource.value)?.label ?? t('menu.myChats')
+);
 // 计算总页数
 const totalPages = computed(() => Math.ceil(total.value / page_size.value));
 const hasMore = computed(() => currentPage.value < totalPages.value);
@@ -641,8 +679,10 @@ const checkScrollBottom = () => {
 }
 const handleScroll = debounce(checkScrollBottom, 200)
 const getMessageList = async (isLoadMore = false) => {
-    if (loading.value) return Promise.resolve();
-    loading.value = true;
+    // Scroll-driven load-more must never stack. A fresh load (first load, route
+    // change, or source switch) instead supersedes any in-flight request via the
+    // token below, so it is allowed through even while one is still running.
+    if (isLoadMore && loading.value) return Promise.resolve();
 
     // 只有在首次加载或路由变化时才清空数组，滚动加载时不清空
     if (!isLoadMore) {
@@ -650,9 +690,16 @@ const getMessageList = async (isLoadMore = false) => {
         usemenuStore.clearMenuArr();
     }
 
-    return getSessionsList(currentPage.value, page_size.value).then((res: any) => {
+    // Snapshot the source and claim a request token: when loads race, only the
+    // newest may mutate the list, so a slow earlier response can't append rows
+    // to the wrong source or revive a list the user has already switched away from.
+    const requestSource = currentSource.value;
+    const token = ++listRequestToken;
+    loading.value = true;
+
+    return getSessionsList(currentPage.value, page_size.value, requestSource).then((res: any) => {
+        if (token !== listRequestToken) return; // superseded by a newer load
         if (res.data && res.data.length) {
-            // Display all sessions globally without filtering
             res.data.forEach((item: any) => {
                 let obj = {
                     title: item.title ? item.title : t('menu.newSession'),
@@ -669,11 +716,14 @@ const getMessageList = async (isLoadMore = false) => {
                 usemenuStore.updatemenuArr(obj)
             });
         }
-        if ((res as any).total) {
-            total.value = (res as any).total;
+        // Use != null so an empty source (total === 0) correctly clears the count
+        // instead of leaving the previous source's total behind.
+        if (res && res.total != null) {
+            total.value = res.total;
         }
         loading.value = false;
     }).catch(() => {
+        if (token !== listRequestToken) return; // a newer load now owns `loading`
         loading.value = false;
     })
 }
@@ -692,6 +742,27 @@ async function loadCurrentKbInfo(kbId: string) {
         currentKbInfo.value = null
     }
 }
+
+// Switch the session source filter. getMessageList(false) resets pagination and
+// clears the list itself, and its request token makes any in-flight load for the
+// previous source a no-op, so the switch always lands on the chosen source.
+const switchSource = (source: SessionSource) => {
+    if (source === currentSource.value) return;
+    currentSource.value = source;
+    getMessageList();
+};
+
+// Detect whether this tenant has any IM channel configured. The filter control
+// is only shown when it does, so non-IM users see an unchanged sidebar. Failures
+// (e.g. no permission) silently leave the filter hidden.
+const loadImPlatforms = async () => {
+    try {
+        const res: any = await listAllIMChannels();
+        imPlatforms.value = configuredPlatforms(res?.data || []);
+    } catch {
+        imPlatforms.value = [];
+    }
+};
 
 onMounted(async () => {
     const routeName = typeof route.name === 'string' ? route.name : (route.name ? String(route.name) : '')
@@ -712,6 +783,8 @@ onMounted(async () => {
 
     // 加载对话列表
     getMessageList();
+    // 检测当前租户是否配置了 IM 渠道，决定是否显示来源筛选
+    loadImPlatforms();
     // 若组织列表未加载则拉取一次，用于侧栏「待审批」角标
     if (orgStore.organizations.length === 0) {
         orgStore.fetchOrganizations();
@@ -1446,6 +1519,43 @@ const onDragHandleMouseDown = (e: MouseEvent) => {
     align-items: center;
     width: 100%;
     position: relative;
+}
+
+/* Right-aligned trailing controls on the「对话」title row (source-switch icon). */
+.menu-trailing {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
+/* Source switcher icon: muted by default, brand-coloured when a non-web source is active. */
+.menu-source-icon {
+    font-size: 15px;
+    color: var(--td-text-color-placeholder);
+    opacity: 0.7;
+    flex-shrink: 0;
+    cursor: pointer;
+    transition: opacity 0.2s ease, color 0.2s ease;
+}
+
+.menu_item:hover .menu-source-icon {
+    opacity: 1;
+}
+
+.menu-source-icon-active {
+    color: var(--td-brand-color);
+    opacity: 1;
+}
+
+/* Empty state when the active source has no sessions. */
+.submenu_empty {
+    padding: 24px 14px;
+    text-align: center;
+    font-size: 12px;
+    color: var(--td-text-color-placeholder);
+    user-select: none;
 }
 
 // 顶部 logo_row 右侧的图标按钮组（搜索 + 折叠），与折叠按钮风格一致

--- a/frontend/src/components/sessionSourceFilter.test.ts
+++ b/frontend/src/components/sessionSourceFilter.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  DEFAULT_SESSION_SOURCE,
+  buildSourceOptions,
+  configuredPlatforms,
+  shouldShowSourceFilter,
+} from './sessionSourceFilter.ts'
+
+test('defaults the sidebar to web sessions so IM stays hidden until opted into', () => {
+  assert.equal(DEFAULT_SESSION_SOURCE, 'web')
+})
+
+test('source filter only appears once at least one IM channel is configured', () => {
+  assert.equal(shouldShowSourceFilter([]), false)
+  assert.equal(shouldShowSourceFilter(['feishu']), true)
+  assert.equal(shouldShowSourceFilter(['feishu', 'wecom']), true)
+})
+
+test('configuredPlatforms returns distinct platform keys in first-seen order', () => {
+  const channels = [
+    { platform: 'feishu' },
+    { platform: 'wecom' },
+    { platform: 'feishu' }, // duplicate: a second feishu channel
+    { platform: '' }, // malformed row: ignored
+  ]
+  assert.deepEqual(configuredPlatforms(channels), ['feishu', 'wecom'])
+})
+
+test('configuredPlatforms tolerates an empty overview', () => {
+  assert.deepEqual(configuredPlatforms([]), [])
+})
+
+test('buildSourceOptions puts web first, then platforms with injected labels', () => {
+  const opts = buildSourceOptions(['feishu', 'wecom'], 'My chats', (p) => `LABEL:${p}`)
+  assert.deepEqual(opts, [
+    { value: 'web', label: 'My chats', platform: null },
+    { value: 'feishu', label: 'LABEL:feishu', platform: 'feishu' },
+    { value: 'wecom', label: 'LABEL:wecom', platform: 'wecom' },
+  ])
+})
+
+test('buildSourceOptions with no IM platforms yields just the web option', () => {
+  assert.deepEqual(buildSourceOptions([], 'My chats', (p) => p), [
+    { value: 'web', label: 'My chats', platform: null },
+  ])
+})

--- a/frontend/src/components/sessionSourceFilter.ts
+++ b/frontend/src/components/sessionSourceFilter.ts
@@ -1,0 +1,57 @@
+// Pure logic for the sidebar's session source filter (issue #1560).
+//
+// IM-channel sessions are auto-generated operational traffic, not the user's own
+// chats, and IM is an optional module. So the sidebar defaults to web sessions
+// and only surfaces a quiet source filter for tenants that actually configured a
+// channel — keeping IM low-key rather than promoting it to a first-class group.
+
+// 'web' = the user's own chats (no IM mapping); any other value is a platform
+// key (e.g. 'feishu') selecting that channel's sessions. Sent verbatim as the
+// `source` query param. The `(string & {})` arm keeps 'web' as an autocomplete
+// hint instead of letting the union collapse to a bare `string`.
+export type SessionSource = 'web' | (string & {})
+
+export const DEFAULT_SESSION_SOURCE: SessionSource = 'web'
+
+// The source filter control is only rendered once the tenant has at least one
+// configured IM channel — tenants that never enabled IM see an unchanged,
+// channel-free sidebar.
+export function shouldShowSourceFilter(configured: string[]): boolean {
+  return configured.length > 0
+}
+
+// Distinct platform keys from the tenant's IM channel overview, in first-seen
+// order. Duplicates (multiple channels on one platform) collapse to one option,
+// and malformed rows with no platform are dropped.
+export function configuredPlatforms(channels: Array<{ platform: string }>): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const c of channels) {
+    if (!c.platform || seen.has(c.platform)) continue
+    seen.add(c.platform)
+    out.push(c.platform)
+  }
+  return out
+}
+
+export interface SourceOption {
+  value: SessionSource
+  label: string
+  // null for the user's own web chats; the platform key for an IM source.
+  platform: string | null
+}
+
+// Build the source switcher's options: the user's own web chats first, then each
+// configured IM platform in first-seen order. Labels are injected so this stays
+// pure and unit-testable (no i18n dependency); logos are resolved by the caller
+// (where the platform→asset map lives), keeping the dropdown component dumb.
+export function buildSourceOptions(
+  platforms: string[],
+  webLabel: string,
+  labelForPlatform: (platform: string) => string,
+): SourceOption[] {
+  return [
+    { value: DEFAULT_SESSION_SOURCE, label: webLabel, platform: null },
+    ...platforms.map((p) => ({ value: p, label: labelForPlatform(p), platform: p })),
+  ]
+}

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -27,6 +27,8 @@ export default {
     collapseSidebar: 'Collapse Sidebar',
     expandSidebar: 'Expand Sidebar',
     logoutSuccess: 'Logged out successfully',
+    myChats: 'My chats',
+    noSessions: 'No conversations yet',
   },
   newUserGuide: {
     stepOf: '{current} / {total}',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -27,6 +27,8 @@ export default {
     collapseSidebar: "사이드바 접기",
     expandSidebar: "사이드바 펼치기",
     logoutSuccess: "로그아웃되었습니다",
+    myChats: "내 대화",
+    noSessions: "대화가 없습니다",
   },
   newUserGuide: {
     stepOf: "{current} / {total}",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -25,6 +25,8 @@ export default {
     collapseSidebar: 'Свернуть боковую панель',
     expandSidebar: 'Развернуть боковую панель',
     logoutSuccess: 'Вы вышли из системы',
+    myChats: 'Мои чаты',
+    noSessions: 'Пока нет диалогов',
     agents: 'Агенты',
     organizations: 'Общие пространства'
   },

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -27,6 +27,8 @@ export default {
     collapseSidebar: "收起侧边栏",
     expandSidebar: "展开侧边栏",
     logoutSuccess: "已退出登录",
+    myChats: "我的对话",
+    noSessions: "暂无对话",
   },
   newUserGuide: {
     stepOf: "{current} / {total}",

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -68,7 +68,7 @@
                             :isFirstEnter="isFirstEnter" :embeddedMode="embeddedMode"></botmsg>
                     </div>
                 </div>
-                <div v-if="loading"
+                <div v-if="loading || isImRecovering"
                     style="height: 41px;display: flex;align-items: center;padding-left: 4px;">
                     <div class="loading-typing">
                         <span></span>
@@ -220,6 +220,16 @@ const limit = ref(20);
 const messagesList = reactive([]);
 const isReplying = ref(false);
 const currentAssistantMessageId = ref(''); // 当前正在生成的 assistant message ID
+// True only while attaching to an in-flight *IM-originated* reply via continue-stream.
+// Such replies are generated on the IM side and never stream through this server, so
+// continue-stream always fails even though the answer is coming — recover by polling
+// instead of erroring. Web/api replies are left on the original error path.
+const isAttachingImStream = ref(false);
+let recoverPollTimer = null;
+// True while polling to recover an in-flight IM reply we couldn't stream. Drives
+// the same "generating" typing indicator the normal reply path shows, so the wait
+// isn't a silent gap. IM-only: false everywhere else, so other flows are unchanged.
+const isImRecovering = ref(false);
 const scrollLock = ref(false);
 const isNeedTitle = ref(false);
 const isFirstEnter = ref(true);
@@ -694,7 +704,16 @@ const handleMsgList = async (data, isScrollType = false, newScrollHeight) => {
             currentAssistantMessageId.value = lastMessage.id;
             console.log('[Continue Stream] Set assistant message ID:', lastMessage.id);
         }
+        // Only IM-originated replies (channel === 'im') get the quiet poll-to-recover
+        // path: their answer is generated on the IM side and never streams through
+        // this server, so continue-stream always 404s even though the reply *is*
+        // coming. Web/api replies keep the original behaviour (a real failure to
+        // resume the stream still surfaces as an error) — we don't touch them.
+        isAttachingImStream.value = lastMessage.channel === 'im';
         await startStream({ session_id: session_id.value, query: lastMessage.id, method: 'GET', url: '/api/v1/sessions/continue-stream' });
+        // On success the stream resumed normally; on failure the error watcher
+        // already took over (quiet recovery for IM), so only clear the flag here.
+        if (!error.value) isAttachingImStream.value = false;
     }
 
 }
@@ -832,15 +851,70 @@ const sendMsg = async (value, modelId = '', mentionedItems = [], imageFiles = []
     });
 }
 
+// Quietly recover an in-flight IM reply we couldn't attach to (it's generated on
+// the IM side, so it never streamed through this server). Poll until it completes,
+// then reload the thread so it renders via the normal path. Bounded so an IM reply
+// that genuinely died (e.g. the bot crashed) doesn't spin forever — on timeout we
+// surface the original error so the failure isn't hidden.
+const RECOVER_POLL_INTERVAL = 2500;
+const RECOVER_POLL_MAX_ATTEMPTS = 48; // ~2 min
+const recoverIncompleteMessage = () => {
+    const targetSession = session_id.value;
+    const targetMessageId = currentAssistantMessageId.value;
+    if (recoverPollTimer) { clearTimeout(recoverPollTimer); recoverPollTimer = null; }
+    if (!targetMessageId) { isReplying.value = false; isImRecovering.value = false; return; }
+    isImRecovering.value = true; // show the "generating" indicator while we poll
+    let attempts = 0;
+    const poll = async () => {
+        recoverPollTimer = null;
+        if (session_id.value !== targetSession) { isReplying.value = false; isImRecovering.value = false; return; } // navigated away
+        attempts++;
+        try {
+            const res = await getMessageList({ session_id: targetSession, limit: limit.value, created_at: '' });
+            const target = (res?.data || []).find((m) => m.id === targetMessageId);
+            if (target && target.is_completed) {
+                created_at.value = '';
+                messagesList.splice(0);
+                getmsgList({ session_id: targetSession, limit: limit.value, created_at: '' });
+                isReplying.value = false;
+                isImRecovering.value = false;
+                currentAssistantMessageId.value = '';
+                return;
+            }
+        } catch (e) {
+            console.warn('[Continue Stream] recovery poll failed:', e);
+        }
+        if (attempts >= RECOVER_POLL_MAX_ATTEMPTS) {
+            // The IM reply never completed — don't hide it; surface the standard
+            // stream-failure message (reuses the existing i18n key, no raw HTTP code).
+            MessagePlugin.error(t('error.streamFailed'));
+            isReplying.value = false;
+            isImRecovering.value = false;
+            currentAssistantMessageId.value = '';
+            return;
+        }
+        recoverPollTimer = setTimeout(poll, RECOVER_POLL_INTERVAL);
+    };
+    recoverPollTimer = setTimeout(poll, RECOVER_POLL_INTERVAL);
+};
+
 // Watch for stream errors and show message
 watch(error, (newError) => {
-    if (newError) {
-        MessagePlugin.error(newError);
-        isReplying.value = false;
-        loading.value = false;
-        // 清空当前 assistant message ID
-        currentAssistantMessageId.value = '';
+    if (!newError) return;
+    // A failed attach to an in-flight IM reply isn't a real error — the answer is
+    // produced on the IM side and never streams here. Recover quietly by polling to
+    // completion instead of flashing a "stream failed" toast. Web/api replies fall
+    // through to the normal error toast below, unchanged.
+    if (isAttachingImStream.value) {
+        isAttachingImStream.value = false;
+        recoverIncompleteMessage();
+        return;
     }
+    MessagePlugin.error(newError);
+    isReplying.value = false;
+    loading.value = false;
+    // 清空当前 assistant message ID
+    currentAssistantMessageId.value = '';
 });
 
 // 处理流式数据
@@ -1572,10 +1646,14 @@ const clearData = () => {
     isReplying.value = false;
     fullContent.value = '';
     userquery.value = '';
+    // Stop any IM-reply recovery poll for the session we're leaving/switching.
+    if (recoverPollTimer) { clearTimeout(recoverPollTimer); recoverPollTimer = null; }
+    isImRecovering.value = false;
 
 }
 onUnmounted(() => {
     window.removeEventListener('session-messages-cleared', handleSessionCleared);
+    if (recoverPollTimer) { clearTimeout(recoverPollTimer); recoverPollTimer = null; }
 });
 onBeforeRouteLeave((to, from, next) => {
     clearData()

--- a/internal/application/repository/session.go
+++ b/internal/application/repository/session.go
@@ -136,7 +136,16 @@ func (r *sessionRepository) QueryPaged(
 	}
 
 	// LEFT JOIN IM mappings to surface origin fields and support source/agent filters.
-	joinClause := "LEFT JOIN im_channel_sessions ics ON ics.session_id = s.id AND ics.deleted_at IS NULL"
+	// Soft-deleted mappings are intentionally included: a session that was ever bound
+	// to an IM channel belongs to that platform, not "web". /clear and session
+	// recycling soft-delete the mapping (and start a fresh session), so filtering
+	// deleted mappings out here would mis-bucket those past IM conversations into the
+	// user's own web chats ("web" = ics.id IS NULL).
+	// Safe from row fan-out because the IM flow only ever creates a *fresh* session
+	// for a new mapping (never re-maps an existing one), so a session has at most one
+	// mapping row. If that ever changes, this JOIN would need a one-row-per-session
+	// guard (the unique index only constrains active mappings).
+	joinClause := "LEFT JOIN im_channel_sessions ics ON ics.session_id = s.id"
 
 	applySource := func(db *gorm.DB) *gorm.DB {
 		switch strings.ToLower(strings.TrimSpace(q.Source)) {

--- a/internal/application/repository/session_test.go
+++ b/internal/application/repository/session_test.go
@@ -161,3 +161,64 @@ func TestSessionRepositoryDeleteAllHonorsUserScope(t *testing.T) {
 	require.Zero(t, countActiveSessionsForTest(t, db, legacySession.ID))
 	require.EqualValues(t, 1, countActiveSessionsForTest(t, db, otherTenantSession.ID))
 }
+
+// im_channel_sessions row for QueryPaged source-filter tests. Mirrors the columns
+// the LEFT JOIN projects; kept local to avoid importing internal/im.
+type testIMChannelSession struct {
+	ID          string `gorm:"primaryKey"`
+	SessionID   string
+	Platform    string
+	ChatID      string
+	ThreadID    string
+	UserID      string
+	AgentID     string
+	IMChannelID string `gorm:"column:im_channel_id"`
+	TenantID    uint64
+	DeletedAt   gorm.DeletedAt
+}
+
+func (testIMChannelSession) TableName() string { return "im_channel_sessions" }
+
+func listItemIDsForTest(items []*types.SessionListItem) []string {
+	ids := make([]string, 0, len(items))
+	for _, it := range items {
+		ids = append(ids, it.ID)
+	}
+	return ids
+}
+
+// A /clear (or session recycling) soft-deletes the IM mapping and starts a fresh
+// session. The old session must stay under its IM platform, not leak into "web"
+// (which would happen if the source-filter join excluded soft-deleted mappings).
+func TestSessionRepositoryQueryPagedKeepsClearedIMSessionsOutOfWeb(t *testing.T) {
+	repo, db := newSessionRepositoryForTest(t)
+	require.NoError(t, db.AutoMigrate(&testIMChannelSession{}))
+	ctx := context.Background()
+
+	web := createSessionForTest(t, db, 1, "alice")     // never bound to IM -> web
+	active := createSessionForTest(t, db, 1, "alice")  // active IM mapping
+	cleared := createSessionForTest(t, db, 1, "alice") // IM mapping soft-deleted by /clear
+
+	require.NoError(t, db.Create(&testIMChannelSession{
+		ID: "m-active", SessionID: active.ID, Platform: "wecom", TenantID: 1,
+	}).Error)
+	clearedMapping := &testIMChannelSession{
+		ID: "m-cleared", SessionID: cleared.ID, Platform: "wecom", TenantID: 1,
+	}
+	require.NoError(t, db.Create(clearedMapping).Error)
+	require.NoError(t, db.Delete(clearedMapping).Error) // soft-delete, as /clear does
+
+	webItems, _, err := repo.QueryPaged(ctx, &types.SessionListQuery{
+		TenantID: 1, UserID: "alice", Source: "web", Page: 1, PageSize: 50,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{web.ID}, listItemIDsForTest(webItems),
+		"web must exclude sessions that ever had an IM mapping, including cleared ones")
+
+	wecomItems, _, err := repo.QueryPaged(ctx, &types.SessionListQuery{
+		TenantID: 1, UserID: "alice", Source: "wecom", Page: 1, PageSize: 50,
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{active.ID, cleared.ID}, listItemIDsForTest(wecomItems),
+		"wecom must include both the active and the cleared IM session")
+}

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -1176,6 +1176,16 @@ func (s *Service) HandleMessage(ctx context.Context, msg *IncomingMessage, chann
 		}
 	}
 
+	// Title an untitled IM session from its first text message, like web chats.
+	// GenerateTitleAsync self-guards on a non-empty title and persists to the DB;
+	// nil eventBus is fine (IM has no live stream — the sidebar reloads it).
+	if session.Title == "" && strings.TrimSpace(msg.Content) != "" {
+		// Copy the session: the async title goroutine writes Title while the QA
+		// worker below shares the same *session.
+		sessionForTitle := *session
+		s.sessionService.GenerateTitleAsync(sessionCtx, &sessionForTitle, msg.Content, "", nil)
+	}
+
 	// 5. Enqueue the QA request into the bounded worker pool.
 	// The worker pool controls LLM concurrency and provides backpressure.
 	qaCtx, qaCancel := context.WithCancel(sessionCtx)
@@ -1480,8 +1490,23 @@ func shortID(id string) string {
 	return id
 }
 
+// imInitialSessionTitle picks a new IM session's starting title: "" when the
+// message has text to summarise (so it gets a content-based title later, like
+// web chats), otherwise the IM identity title so the row is never blank.
+func imInitialSessionTitle(msg *IncomingMessage, identityTitle func(*IncomingMessage) string) string {
+	if strings.TrimSpace(msg.Content) != "" {
+		return ""
+	}
+	return identityTitle(msg)
+}
+
 // resolveUserSession finds or creates a ChannelSession keyed by (platform, user_id, chat_id, tenant_id, agent_id).
 // This is the original session resolution strategy.
+//
+// Invariant: a cache miss creates a brand-new session — we never attach a second
+// mapping to an existing session. The session-list source filter (repository
+// QueryPaged) relies on this one-mapping-per-session property; if this ever
+// re-maps an existing session, that JOIN needs a one-row-per-session guard.
 func (s *Service) resolveUserSession(ctx context.Context, msg *IncomingMessage, tenantID uint64, agentID string, imChannelID string) (*ChannelSession, error) {
 	var cs ChannelSession
 	result := s.db.Where("platform = ? AND user_id = ? AND chat_id = ? AND tenant_id = ? AND agent_id = ? AND deleted_at IS NULL",
@@ -1496,8 +1521,10 @@ func (s *Service) resolveUserSession(ctx context.Context, msg *IncomingMessage, 
 		return nil, fmt.Errorf("query channel session: %w", result.Error)
 	}
 
-	// Create a new WeKnora session
-	title := buildUserSessionTitle(msg)
+	// Create a new WeKnora session. Start untitled when there's text to summarise
+	// so it gets a content-based title after the first message (see HandleMessage);
+	// fall back to the IM identity title otherwise.
+	title := imInitialSessionTitle(msg, buildUserSessionTitle)
 
 	newSession := &types.Session{
 		TenantID:    tenantID,
@@ -1568,8 +1595,9 @@ func (s *Service) resolveThreadSession(ctx context.Context, msg *IncomingMessage
 		return nil, fmt.Errorf("query thread session: %w", result.Error)
 	}
 
-	// Build a session title including chat + thread suffix for traceability.
-	title := buildThreadSessionTitle(msg)
+	// Start untitled when there's text to summarise so it gets a content-based
+	// title after the first message; fall back to the chat/thread identity title.
+	title := imInitialSessionTitle(msg, buildThreadSessionTitle)
 
 	newSession := &types.Session{
 		TenantID:    tenantID,

--- a/internal/im/session_title_test.go
+++ b/internal/im/session_title_test.go
@@ -107,3 +107,49 @@ func TestBuildThreadSessionTitle(t *testing.T) {
 		})
 	}
 }
+
+func TestIMInitialSessionTitle(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *IncomingMessage
+		want string
+	}{
+		{
+			name: "text message starts untitled so it gets a content-based title later",
+			msg: &IncomingMessage{
+				Platform: "feishu",
+				UserName: "李四",
+				ChatType: ChatTypeDirect,
+				Content:  "如何配置单点登录?",
+			},
+			want: "",
+		},
+		{
+			name: "whitespace-only content falls back to the identity title",
+			msg: &IncomingMessage{
+				Platform: "feishu",
+				UserName: "李四",
+				ChatType: ChatTypeDirect,
+				Content:  "   ",
+			},
+			want: "李四 · dm",
+		},
+		{
+			name: "non-text message (no content) falls back to the identity title",
+			msg: &IncomingMessage{
+				Platform: "wecom",
+				UserID:   "WeCom_ZhangSan",
+				ChatType: ChatTypeGroup,
+				ChatID:   "wc_group_1234",
+			},
+			want: "user ZhangSan · group oup_1234",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := imInitialSessionTitle(tt.msg, buildUserSessionTitle); got != tt.want {
+				t.Errorf("imInitialSessionTitle() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Improves how IM (instant-messaging) channel sessions are surfaced and handled across the sidebar and chat, starting from #1560 — *"IM conversations are mixed in with regular conversations, making it messy."*

Four related changes:

1. **Sidebar source filter** *(frontend)* — The session list now defaults to the user's own web chats. Tenants with a configured IM channel get a quiet source switcher (a `filter` icon in the **对话** header, mirroring the existing `KBSwitcherDropdown`) to view a specific platform's sessions; tenants without IM see an unchanged sidebar. The dropdown scrolls, so it stays clean from 1 to many platforms.

2. **Content-based IM session titles** *(backend)* — IM sessions were titled from the sender identity (e.g. `李四 · dm`). A new IM session now starts untitled and gets a content-based title from its first message via the same `GenerateTitleAsync` flow web sessions use, falling back to the identity title when the first message has no text. Works for all platforms (shared `HandleMessage` / `resolveSession`).

3. **In-flight reply recovery** *(frontend)* — Opening a session whose reply is still being generated on an IM channel made the web client attach via `continue-stream` and fail (the IM answer never streams through this server), flashing a *"stream failed"* toast and forcing a manual refresh. A failed attach to an **IM** reply (`channel === 'im'`) is now treated as recoverable: it keeps the normal "generating" indicator, polls until the reply completes, then reloads the thread — surfacing the standard error only on timeout. Web/api replies keep their original behaviour.

4. **Source-filter classification fix** *(backend)* — The filter treats *"web"* as sessions with no IM mapping, but the list `JOIN` excluded soft-deleted mappings. `/clear` (and session recycling) soft-delete the mapping and start a fresh session, so cleared IM conversations leaked into the user's own web chats. Soft-deleted mappings are now included in the `JOIN`, so a session that was ever bound to an IM channel stays under its platform. Adds a repository regression test.

### Design notes / trade-offs
- The classification fix relies on a **behavioral invariant** — the IM flow creates a fresh session per mapping and never re-maps an existing one — documented both at the query (`QueryPaged`) and at its source (`resolveUserSession`); the unique index only constrains *active* mappings.
- In-flight recovery is intentionally scoped to IM via the existing `channel` message property; web reply resume and errors are untouched.
- Title generation is best-effort: one extra async, self-guarded LLM call per new IM session.

## Type of Change
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #1560

## Testing
- **Frontend** — `sessionSourceFilter` unit tests (6/6) green; `vue-tsc` type-check clean for all changed files.
- **Backend** — `go test ./internal/im/ -race` and `go test ./internal/application/repository/` pass, including a new regression test (`TestSessionRepositoryQueryPagedKeepsClearedIMSessionsOutOfWeb`) that **fails on the old `JOIN` and passes on the fix**; `gofmt` clean.
- **Manual, end-to-end** against a live WeCom/Feishu setup: source switching, content titles on freshly-created IM sessions, cleared-session classification (`/clear` → old conversation stays under its platform, not in *我的对话*), and in-flight recovery (open an IM session mid-generation → "generating" indicator → auto-loads, no error toast).

## Checklist
- [ ] `make fmt && make lint && make test` pass locally <!-- ran gofmt + targeted `go test` + `vue-tsc` + unit tests; please run the full target before merge -->
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.) — not applicable
- [ ] Breaking changes are clearly called out in the description above — none

## Screenshots / Recordings
no any IM-config's user can't see "对话" filter
<img width="1880" height="655" alt="image" src="https://github.com/user-attachments/assets/3d80bad1-177c-42cf-86b7-4374487bba83" />

sidebar source switcher+ dropdown+ title generator
<img width="1880" height="655" alt="image" src="https://github.com/user-attachments/assets/3dae827b-e4aa-4acd-9834-aad209188444" />

in-flight "generating" indicator (when bot generating answer on IM, web now show tips and sync msg instead of error "流式连接失败") 
<img width="1472" height="622" alt="WeChatWorkScreenshot_2248d9cd-0130-467a-8993-963e33589617" src="https://github.com/user-attachments/assets/2b7ab0fa-8b52-4cba-a518-e3f11b998176" />
