### PR TITLE
fix(wiki): preserve graph and tenant integrity

### DIFF
--- a/internal/application/service/wiki_page.go
+++ b/internal/application/service/wiki_page.go
@@ -47,6 +47,33 @@ func NewWikiPageService(
 	}
 }
 
+type wikiPageKnowledgeBaseLookup interface {
+	GetKnowledgeBaseByIDOnly(ctx context.Context, id string) (*types.KnowledgeBase, error)
+}
+
+func inheritWikiPageTenant(
+	ctx context.Context,
+	page *types.WikiPage,
+	kbLookup wikiPageKnowledgeBaseLookup,
+) error {
+	if page.TenantID != 0 {
+		return nil
+	}
+	if kbLookup == nil {
+		return errors.New("knowledge base service is required to resolve wiki page tenant")
+	}
+
+	kb, err := kbLookup.GetKnowledgeBaseByIDOnly(ctx, page.KnowledgeBaseID)
+	if err != nil {
+		return fmt.Errorf("resolve wiki page tenant: %w", err)
+	}
+	if kb == nil || kb.TenantID == 0 {
+		return errors.New("knowledge base tenant is required to create wiki page")
+	}
+	page.TenantID = kb.TenantID
+	return nil
+}
+
 // CreatePage creates a new wiki page
 func (s *wikiPageService) CreatePage(ctx context.Context, page *types.WikiPage) (*types.WikiPage, error) {
 	if page.ID == "" {
@@ -57,6 +84,9 @@ func (s *wikiPageService) CreatePage(ctx context.Context, page *types.WikiPage) 
 	}
 	if page.KnowledgeBaseID == "" {
 		return nil, errors.New("knowledge_base_id is required")
+	}
+	if err := inheritWikiPageTenant(ctx, page, s.kbService); err != nil {
+		return nil, err
 	}
 	if page.Status == "" {
 		page.Status = types.WikiPageStatusPublished
@@ -380,7 +410,7 @@ func (s *wikiPageService) GetLog(ctx context.Context, kbID string) (*types.WikiP
 // Two modes are supported:
 //
 //   - WikiGraphModeOverview (default): returns the top `Limit` pages sorted
-//     by link_count (in+out), plus every edge that connects two surviving
+//     by distinct live neighbor count, plus every edge that connects two surviving
 //     nodes. This is what the frontend fetches on the first graph open —
 //     4万-page wikis would otherwise ship ~30MB of JSON and crash the
 //     browser trying to render 100k SVG elements.
@@ -426,7 +456,7 @@ func computeGraphSubset(pages []*types.WikiPage, req *types.WikiGraphRequest) (*
 		mode = types.WikiGraphModeOverview
 	}
 
-	// Pre-compute link_count and the type allow-list used for candidate
+	// Pre-compute distinct live neighbor counts and the type allow-list used for candidate
 	// filtering. We keep the full page list around so ego mode can still
 	// traverse through neighbors whose type is in the allow-list.
 	typeAllow := make(map[string]bool, len(req.Types))
@@ -441,7 +471,24 @@ func computeGraphSubset(pages []*types.WikiPage, req *types.WikiGraphRequest) (*
 	linkCount := make(map[string]int, len(pages))
 	for _, p := range pages {
 		pageBySlug[p.Slug] = p
-		linkCount[p.Slug] = len(p.InLinks) + len(p.OutLinks)
+	}
+	for _, p := range pages {
+		neighbors := make(map[string]struct{}, len(p.InLinks)+len(p.OutLinks))
+		for _, slug := range p.InLinks {
+			if slug != p.Slug {
+				if _, exists := pageBySlug[slug]; exists {
+					neighbors[slug] = struct{}{}
+				}
+			}
+		}
+		for _, slug := range p.OutLinks {
+			if slug != p.Slug {
+				if _, exists := pageBySlug[slug]; exists {
+					neighbors[slug] = struct{}{}
+				}
+			}
+		}
+		linkCount[p.Slug] = len(neighbors)
 	}
 
 	// Select the node slug set for the requested slice.

--- a/internal/application/service/wiki_page_test.go
+++ b/internal/application/service/wiki_page_test.go
@@ -1,10 +1,58 @@
 package service
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/Tencent/WeKnora/internal/types"
 )
+
+type wikiPageKBLookupStub struct {
+	kb  *types.KnowledgeBase
+	err error
+}
+
+func (s *wikiPageKBLookupStub) GetKnowledgeBaseByIDOnly(
+	_ context.Context,
+	_ string,
+) (*types.KnowledgeBase, error) {
+	return s.kb, s.err
+}
+
+func TestInheritWikiPageTenant(t *testing.T) {
+	t.Run("inherits tenant from knowledge base", func(t *testing.T) {
+		page := &types.WikiPage{KnowledgeBaseID: "kb-1"}
+		err := inheritWikiPageTenant(context.Background(), page, &wikiPageKBLookupStub{
+			kb: &types.KnowledgeBase{ID: "kb-1", TenantID: 10000},
+		})
+		if err != nil {
+			t.Fatalf("inheritWikiPageTenant: %v", err)
+		}
+		if page.TenantID != 10000 {
+			t.Fatalf("TenantID = %d, want 10000", page.TenantID)
+		}
+	})
+
+	t.Run("keeps explicit tenant without lookup", func(t *testing.T) {
+		page := &types.WikiPage{KnowledgeBaseID: "kb-1", TenantID: 42}
+		if err := inheritWikiPageTenant(context.Background(), page, nil); err != nil {
+			t.Fatalf("inheritWikiPageTenant: %v", err)
+		}
+		if page.TenantID != 42 {
+			t.Fatalf("TenantID = %d, want 42", page.TenantID)
+		}
+	})
+
+	t.Run("returns lookup error", func(t *testing.T) {
+		page := &types.WikiPage{KnowledgeBaseID: "kb-1"}
+		sentinel := errors.New("lookup failed")
+		err := inheritWikiPageTenant(context.Background(), page, &wikiPageKBLookupStub{err: sentinel})
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("error = %v, want wrapped lookup error", err)
+		}
+	})
+}
 
 func TestParseOutLinks(t *testing.T) {
 	svc := &wikiPageService{}
@@ -221,7 +269,7 @@ func TestComputeGraphSubset_OverviewTruncatesByLinkCount(t *testing.T) {
 		t.Errorf("want 3 nodes, got %d (%v)", len(got.Nodes), nodeSlugs(got))
 	}
 	slugs := nodeSlugs(got)
-	// hub has link_count 6 (4 out + 2 in), must survive the cap.
+	// hub has the largest distinct live-neighbor count, so it must survive the cap.
 	if !slugs["hub"] {
 		t.Errorf("expected hub to survive the top-3 cap, got %v", slugs)
 	}
@@ -241,6 +289,51 @@ func TestComputeGraphSubset_OverviewTruncatesByLinkCount(t *testing.T) {
 			t.Errorf("edge %s->%s references a non-returned node", e.Source, e.Target)
 		}
 	}
+}
+
+func TestComputeGraphSubset_LinkCountDeduplicatesBidirectionalNeighbors(t *testing.T) {
+	pages := []*types.WikiPage{
+		{
+			Slug:     "concept/a",
+			Title:    "A",
+			PageType: types.WikiPageTypeConcept,
+			InLinks:  types.StringArray{"concept/b", "missing"},
+			OutLinks: types.StringArray{"concept/b", "concept/c"},
+		},
+		{
+			Slug:     "concept/b",
+			Title:    "B",
+			PageType: types.WikiPageTypeConcept,
+			InLinks:  types.StringArray{"concept/a"},
+			OutLinks: types.StringArray{"concept/a"},
+		},
+		{
+			Slug:     "concept/c",
+			Title:    "C",
+			PageType: types.WikiPageTypeConcept,
+			InLinks:  types.StringArray{"concept/a"},
+		},
+	}
+
+	got, err := computeGraphSubset(pages, &types.WikiGraphRequest{
+		Mode:   types.WikiGraphModeEgo,
+		Center: "concept/a",
+		Depth:  1,
+		Limit:  10,
+	})
+	if err != nil {
+		t.Fatalf("computeGraphSubset: %v", err)
+	}
+
+	for _, node := range got.Nodes {
+		if node.Slug == "concept/a" {
+			if node.LinkCount != 2 {
+				t.Fatalf("concept/a LinkCount = %d, want 2 distinct live neighbors", node.LinkCount)
+			}
+			return
+		}
+	}
+	t.Fatal("concept/a not found in graph response")
 }
 
 // TestComputeGraphSubset_OverviewUncapped ensures the Limit<=0 escape hatch


### PR DESCRIPTION
## Summary

- count graph links as distinct, live neighbors instead of raw `in_links + out_links`
- inherit the knowledge base tenant when a Wiki page is created without an explicit `tenant_id`
- add regression tests for both data-integrity issues

## Root cause

Reciprocal Wiki links appear in both `in_links` and `out_links`. Adding both array lengths double-counts the same neighbor, while missing and self-referential targets are counted even though the graph cannot render them. This can make the sidebar report an unreachable or dead neighbor when every real neighbor is present.

The built-in Wiki fixer creates pages without setting `TenantID`. `CreatePage` previously persisted that zero value instead of resolving ownership from the parent knowledge base, leaving tenantless Wiki rows.

## Impact

- graph neighbor totals match the distinct nodes that can actually be displayed
- reciprocal links no longer create false dead-link warnings
- Wiki fixer-created pages remain scoped to the knowledge base tenant

## Validation

```text
go test ./internal/application/service \
  -run 'Test(InheritWikiPageTenant|ComputeGraphSubset|ParseOutLinks)' \
  -count=1

ok github.com/Tencent/WeKnora/internal/application/service 0.278s
```

`gofmt` and `git diff --check` also pass.
