### PR TITLE
refactor(settings): unify empty state handling across settings views

### DIFF
--- a/frontend/src/views/settings/McpSettings.vue
+++ b/frontend/src/views/settings/McpSettings.vue
@@ -17,13 +17,8 @@
         <p>{{ $t('mcpSettings.manageAndTest') }}</p>
       </div>
 
-      <div v-if="services.length === 0" class="empty-state">
-        <t-empty :description="$t('mcpSettings.empty')">
-          <t-button v-if="authStore.hasRole('admin')" theme="primary" variant="outline" size="small" @click="handleAdd">
-            <template #icon><t-icon name="add" /></template>
-            {{ $t('mcpSettings.addFirst') }}
-          </t-button>
-        </t-empty>
+      <div v-if="services.length === 0 && !authStore.hasRole('admin')" class="empty-state">
+        <t-empty :description="$t('mcpSettings.empty')" />
       </div>
 
       <div v-else class="services-grid">

--- a/frontend/src/views/settings/ModelSettings.vue
+++ b/frontend/src/views/settings/ModelSettings.vue
@@ -26,7 +26,10 @@
     </t-tabs>
 
     <t-loading :loading="loading" size="small" class="model-list-loading">
-      <div v-if="filteredModels.length > 0" class="model-grid">
+      <div v-if="!loading && filteredModels.length === 0 && !authStore.hasRole('admin')" class="empty-state">
+        <t-empty :description="emptyHint" />
+      </div>
+      <div v-else-if="!loading" class="model-grid">
         <div v-for="model in filteredModels" :key="`${model._modelType}-${model.id}`" class="model-card" :class="[
           `model-card--${model._modelType}`,
           {
@@ -105,15 +108,6 @@
           </span>
           <span class="model-card--add__label">{{ $t('modelSettings.actions.addModel') }}</span>
         </button>
-      </div>
-      <div v-else-if="!loading" class="empty-state">
-        <t-empty :description="emptyHint">
-          <t-button v-if="authStore.hasRole('admin')" theme="primary" variant="outline" size="small"
-            data-guide="settings-add-model" @click="openAddDialog">
-            <template #icon><add-icon /></template>
-            {{ $t('modelSettings.actions.addModel') }}
-          </t-button>
-        </t-empty>
       </div>
     </t-loading>
 

--- a/frontend/src/views/settings/VectorStoreSettings.vue
+++ b/frontend/src/views/settings/VectorStoreSettings.vue
@@ -17,7 +17,10 @@
         <!-- 与其它 settings 列表同形：左侧 engine 徽章 + 标题 + env pill + 副标题 + 测试动作。
              env 来源是只读的 (engine_type / connection_config 由 .env 写入），所以没有更多菜单；
              user 来源沿用三点菜单的编辑 / 删除入口；测试结果作为卡片底部的彩色条出现。 -->
-        <div v-if="stores.length > 0" class="store-grid">
+        <div v-if="stores.length === 0 && !authStore.hasRole('admin')" class="empty-stores">
+          <t-empty :description="t('vectorStoreSettings.emptyDesc')" />
+        </div>
+        <div v-else class="store-grid">
           <div
             v-for="store in [...envStores, ...userStores]"
             :key="store.id"
@@ -98,17 +101,6 @@
             </span>
             <span class="store-card--add__label">{{ t('vectorStoreSettings.addStore') }}</span>
           </button>
-        </div>
-
-        <!-- Empty State -->
-        <div v-else class="empty-stores">
-          <t-empty :description="t('vectorStoreSettings.emptyDesc')">
-            <t-button v-if="authStore.hasRole('admin')" theme="primary" variant="outline" size="small"
-              @click="openAddDialog">
-              <template #icon><add-icon /></template>
-              {{ t('vectorStoreSettings.addStore') }}
-            </t-button>
-          </t-empty>
         </div>
       </div>
     </template>

--- a/frontend/src/views/settings/WebSearchSettings.vue
+++ b/frontend/src/views/settings/WebSearchSettings.vue
@@ -10,7 +10,10 @@
     <!-- Provider List —— 与 ModelSettings 的卡片同形：左侧标识徽章 + 标题 / 副标题 / proxy URL 三段式。
          不复用 SettingCard 的原因和 Models 一样：每页有微妙不同的右上侧栏需求（这里没有控件，
          Mcp 有开关），SettingCard 仍服务于其它消费者。 -->
-    <div v-if="providerEntities.length > 0" class="provider-grid">
+    <div v-if="providerEntities.length === 0 && !authStore.hasRole('admin')" class="empty-state">
+      <t-empty :description="t('webSearchSettings.noProvidersDesc')" />
+    </div>
+    <div v-else class="provider-grid">
       <div
         v-for="entity in providerEntities"
         :key="entity.id"
@@ -81,16 +84,6 @@
         </span>
         <span class="provider-card--add__label">{{ t('webSearchSettings.addProvider') }}</span>
       </button>
-    </div>
-
-    <!-- Empty State -->
-    <div v-else class="empty-state">
-      <t-empty :description="t('webSearchSettings.noProvidersDesc')">
-        <t-button v-if="authStore.hasRole('admin')" theme="primary" variant="outline" size="small" @click="openAddDialog">
-          <template #icon><add-icon /></template>
-          {{ t('webSearchSettings.addProvider') }}
-        </t-button>
-      </t-empty>
     </div>
 
     <!-- Add/Edit Drawer — 与 ModelEditorDialog / Parser / Storage 抽屉同款风格 -->


### PR DESCRIPTION
- Updated McpSettings.vue, ModelSettings.vue, VectorStoreSettings.vue, and WebSearchSettings.vue to streamline the empty state display for services and models.
- Removed admin-specific add buttons from empty states, enhancing clarity for non-admin users.
- Improved consistency in the presentation of empty states across different settings components.

