### PR TITLE
fix(vectordb): 修复 question 数据复制到向量数据库的 ID 映射问题

### DIFF
--- a/internal/application/repository/retriever/tencentvectordb/repository.go
+++ b/internal/application/repository/retriever/tencentvectordb/repository.go
@@ -2,6 +2,8 @@ package tencentvectordb
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"maps"
 	"os"
@@ -16,6 +18,8 @@ import (
 	"github.com/tencent/vectordatabase-sdk-go/tcvdbtext/encoder"
 	"github.com/tencent/vectordatabase-sdk-go/tcvectordb"
 )
+
+const copyIndicesQueryPageSize int64 = 500
 
 // NewTencentVectorDBRetrieveEngineRepository creates a Tencent VectorDB-backed retrieve repository.
 func NewTencentVectorDBRetrieveEngineRepository(
@@ -138,34 +142,26 @@ func (r *repository) CopyIndices(
 	}
 	collectionName := r.collectionName(dimension)
 	ids := slices.Collect(maps.Keys(sourceToTargetChunkIDMap))
-	query, err := r.client.Database(r.databaseName).Collection(collectionName).Query(
-		ctx,
-		nil,
-		&tcvectordb.QueryDocumentParams{
-			Filter:         tcvectordb.NewFilter(tcvectordb.In(fieldChunkID, ids)),
-			RetrieveVector: true,
-			OutputFields:   outputFields(),
-			Limit:          int64(len(ids)),
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("tencent vectordb query source indices: %w", err)
-	}
 
-	embeddings := make([]*vectorEmbedding, 0, len(query.Documents))
-	for _, doc := range query.Documents {
-		embedding := fromDocument(doc)
-		targetChunkID := sourceToTargetChunkIDMap[embedding.ChunkID]
-		if targetChunkID == "" {
-			continue
+	var embeddings []*vectorEmbedding
+	for offset := int64(0); ; offset += copyIndicesQueryPageSize {
+		query, err := r.client.Database(r.databaseName).Collection(collectionName).Query(
+			ctx,
+			nil,
+			copySourceQueryParams(sourceKnowledgeBaseID, ids, offset),
+		)
+		if err != nil {
+			return fmt.Errorf("tencent vectordb query source indices: %w", err)
 		}
-		embedding.ID = targetChunkID
-		embedding.ChunkID = targetChunkID
-		embedding.KnowledgeBaseID = targetKnowledgeBaseID
-		if targetKBID := sourceToTargetKBIDMap[embedding.KnowledgeID]; targetKBID != "" {
-			embedding.KnowledgeID = targetKBID
+		embeddings = append(embeddings, remapCopiedEmbeddings(
+			query.Documents,
+			sourceToTargetKBIDMap,
+			sourceToTargetChunkIDMap,
+			targetKnowledgeBaseID,
+		)...)
+		if len(query.Documents) < int(copyIndicesQueryPageSize) {
+			break
 		}
-		embeddings = append(embeddings, embedding)
 	}
 	if len(embeddings) == 0 {
 		return nil
@@ -535,7 +531,7 @@ func (r *repository) toDocumentsWithSparseVectors(
 
 func toVectorEmbedding(indexInfo *types.IndexInfo, params map[string]any) *vectorEmbedding {
 	embedding := &vectorEmbedding{
-		ID:              indexInfo.ChunkID,
+		ID:              indexInfo.ID,
 		Content:         cleanInvalidUTF8(indexInfo.Content),
 		SourceID:        indexInfo.SourceID,
 		SourceType:      int(indexInfo.SourceType),
@@ -547,6 +543,9 @@ func toVectorEmbedding(indexInfo *types.IndexInfo, params map[string]any) *vecto
 	}
 	if embedding.ID == "" {
 		embedding.ID = indexInfo.SourceID
+	}
+	if embedding.ID == "" {
+		embedding.ID = indexInfo.ChunkID
 	}
 	if params != nil && slices.Contains(slices.Collect(maps.Keys(params)), fieldVector) {
 		if embeddingMap, ok := params[fieldVector].(map[string][]float32); ok {
@@ -566,6 +565,63 @@ func lookupEmbedding(embeddingMap map[string][]float32, indexInfo *types.IndexIn
 		return embedding
 	}
 	return embeddingMap[indexInfo.ChunkID]
+}
+
+func copySourceQueryParams(sourceKnowledgeBaseID string, chunkIDs []string, offset int64) *tcvectordb.QueryDocumentParams {
+	conditions := []string{tcvectordb.In(fieldChunkID, chunkIDs)}
+	if sourceKnowledgeBaseID != "" {
+		conditions = append([]string{tcvectordb.In(fieldKnowledgeBaseID, []string{sourceKnowledgeBaseID})}, conditions...)
+	}
+	return &tcvectordb.QueryDocumentParams{
+		Filter:         tcvectordb.NewFilter(strings.Join(conditions, " and ")),
+		RetrieveVector: true,
+		OutputFields:   outputFields(),
+		Offset:         offset,
+		Limit:          copyIndicesQueryPageSize,
+	}
+}
+
+func remapCopiedEmbeddings(
+	docs []tcvectordb.Document,
+	sourceToTargetKBIDMap map[string]string,
+	sourceToTargetChunkIDMap map[string]string,
+	targetKnowledgeBaseID string,
+) []*vectorEmbedding {
+	embeddings := make([]*vectorEmbedding, 0, len(docs))
+	for _, doc := range docs {
+		embedding := fromDocument(doc)
+		targetChunkID := sourceToTargetChunkIDMap[embedding.ChunkID]
+		if targetChunkID == "" {
+			continue
+		}
+		originalSourceID := embedding.SourceID
+		if originalSourceID == "" {
+			originalSourceID = embedding.ID
+		}
+		targetSourceID := translateSourceID(originalSourceID, embedding.ChunkID, targetChunkID)
+		embedding.ID = targetSourceID
+		embedding.SourceID = targetSourceID
+		embedding.ChunkID = targetChunkID
+		embedding.KnowledgeBaseID = targetKnowledgeBaseID
+		if targetKBID := sourceToTargetKBIDMap[embedding.KnowledgeID]; targetKBID != "" {
+			embedding.KnowledgeID = targetKBID
+		}
+		embeddings = append(embeddings, embedding)
+	}
+	return embeddings
+}
+
+func translateSourceID(originalSourceID, sourceChunkID, targetChunkID string) string {
+	switch {
+	case originalSourceID == sourceChunkID:
+		return targetChunkID
+	case strings.HasPrefix(originalSourceID, sourceChunkID+"-"):
+		questionID := strings.TrimPrefix(originalSourceID, sourceChunkID+"-")
+		return fmt.Sprintf("%s-%s", targetChunkID, questionID)
+	default:
+		sum := sha256.Sum256([]byte(targetChunkID + "\x00" + sourceChunkID + "\x00" + originalSourceID))
+		return fmt.Sprintf("%s-%s", targetChunkID, hex.EncodeToString(sum[:])[:16])
+	}
 }
 
 func cleanInvalidUTF8(s string) string {


### PR DESCRIPTION
## Description

  修复向量数据库在复制 question 类型数据时 ID
  映射不正确的问题。主要改进包括：
  1. 新增分页查询逻辑（每页500条），避免大批量数据查询失败
  2. 修复 ID 字段优先级：优先使用 IndexInfo.ID，兜底使用 ChunkID
  3. 新增智能 SourceID 映射机制，正确处理 question 数据的 ID
  关联关系

  ## Type of Change

  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 💥 Breaking change
  - [ ] 📚 Documentation update
  - [ ] 🎨 Refactor
  - [ ] ⚡ Performance improvement
  - [ ] 🧪 Test
  - [ ] 🔧 Configuration / Build / CI

  ## Related Issue

  Fixes #

  ## Changes

  ### 1. 分页查询优化
  - 新增常量 `copyIndicesQueryPageSize = 500`
  - 重构 `CopyIndices`
  方法，采用分页查询避免大批量数据一次性加载失败

  ### 2. ID 字段优先级修复
  在 `toVectorEmbedding` 函数中调整 ID 赋值逻辑：
  ```go
  // 优先级：IndexInfo.ID > IndexInfo.SourceID > IndexInfo.ChunkID
  embedding.ID = indexInfo.ID
  if embedding.ID == "" {
      embedding.ID = indexInfo.SourceID
  }
  if embedding.ID == "" {
      embedding.ID = indexInfo.ChunkID
  }
```
 ### 3. 智能 SourceID 映射

  新增 translateSourceID 函数，针对不同场景智能处理：
  - 直接映射场景：当 SourceID == ChunkID 时，直接映射为目标 ChunkID
  - Question 数据场景：当 SourceID 为 "ChunkID-QuestionID"
  格式时，保留 QuestionID 部分，重新拼接为
  "targetChunkID-QuestionID"
  - 兜底方案：其他情况使用 SHA256 生成稳定的16字符哈希后缀

 ### 4. 代码重构

  - 新增 copySourceQueryParams：构建分页查询参数
  - 新增 remapCopiedEmbeddings：批量重映射复制的 embeddings

##  Testing

  测试场景：
  1. ✅ 复制大批量（>500条）向量数据，验证分页查询正常工作
  2. ✅ 复制包含 question 类型的数据，验证 SourceID 格式正确保留
  QuestionID
  3. ✅ 验证复制后的数据 ID 关联关系完整，可正常检索

  本地验证：
  # 运行相关测试
  make test

  # 格式化和 lint 检查
  make fmt && make lint

##  Impact

  修改文件：
  - internal/application/repository/retriever/tencentvectordb/reposi
  tory.go (+82, -26)

  新增函数：
  - copySourceQueryParams
  - remapCopiedEmbeddings
  - translateSourceID

  向后兼容性：✅ 完全兼容，不影响现有功能

##  Checklist

  - [x] make fmt && make lint && make test pass locally
  - [x] Self-reviewed the code
  - [ ] Added/updated tests covering the change
  - [ ] Updated related documentation (README, docs/, Swagger
  annotations, etc.)
  - [ ] Breaking changes are clearly called out in the description
  above

  Screenshots / Recordings