### PR TITLE
fix(auth): clear session resource caches on logout

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -8,6 +8,16 @@ import { reloadFontFromStorage } from '@/composables/useFont'
 import { reloadThemeFromStorage } from '@/composables/useTheme'
 import { resetMigrationLatch } from '@/composables/preferenceStorage'
 import { BUILTIN_QUICK_ANSWER_ID } from '@/api/agent'
+import { useChatResourcesStore } from '@/stores/chatResources'
+import { useEditorResourcesStore } from '@/stores/editorResources'
+import { useOrganizationStore } from '@/stores/organization'
+
+/** 登出时丢弃 Pinia 内的租户级资源缓存，避免 SPA 重登复用上一账号数据。 */
+function clearSessionResourceCaches() {
+  useChatResourcesStore().invalidate()
+  useEditorResourcesStore().invalidate()
+  useOrganizationStore().clearState()
+}
 
 // Per-user UI preferences are namespaced by user id in localStorage.
 // Reload them whenever the active user changes.
@@ -380,6 +390,7 @@ export const useAuthStore = defineStore('auth', () => {
     allTenants.value = []
     memberships.value = []
     pendingInvitationCount.value = 0
+    clearSessionResourceCaches()
 
     // 清空localStorage
     localStorage.removeItem('weknora_user')

--- a/frontend/src/stores/editorResources.ts
+++ b/frontend/src/stores/editorResources.ts
@@ -170,9 +170,13 @@ export const useEditorResourcesStore = defineStore('editorResources', () => {
       tenantRetrievalConfig.value = null
       parserEngines.value = []
       systemInfo.value = null
+      inflight.clear()
       return
     }
-    keys.forEach((k) => delete loadedAt.value[k])
+    keys.forEach((k) => {
+      delete loadedAt.value[k]
+      inflight.delete(k)
+    })
   }
 
   return {


### PR DESCRIPTION
## Summary

- Clear in-memory Pinia resource caches (`chatResources`, `editorResources`, `organization`) when the user logs out, preventing stale knowledge bases, agents, models, and related data from appearing after SPA re-login without a full page reload.
- Harden `editorResources.invalidate()` to also clear in-flight request handles, matching `chatResources` behavior and avoiding old responses being written back after invalidation.

## Test plan

- [ ] Log in as user A, open knowledge base / agent lists
- [ ] Log out (no browser refresh), log in as user B (or same user on a different tenant)
- [ ] Confirm lists show the new account's data and network tab shows fresh API requests
- [ ] Log out and log back in within 60s (cache TTL window) and verify no stale data from the previous session