### PR TITLE
feat(agent): rerank threshold, tool persist trimming, and Langfuse tracing

### DIFF
--- a/internal/agent/tools/grep_chunks.go
+++ b/internal/agent/tools/grep_chunks.go
@@ -190,13 +190,17 @@ func (t *GrepChunksTool) Execute(ctx context.Context, args json.RawMessage) (*ty
 		finalResults = finalResults[:limit]
 	}
 
-	// Per-chunk rows for the UI (FAQ entries are one chunk each — do not fold
-	// them into the parent knowledge container). Knowledge-level aggregation is
-	// kept for backward compatibility.
+	// chunk_results: per-chunk hits for UI detail (grouped by knowledge_id on the
+	// frontend). knowledge_results: pre-aggregated per document for summaries;
+	// document_count is the full distinct-document total even when the knowledge
+	// list is truncated for payload size.
 	chunkResults := buildGrepChunkResults(finalResults, compiled)
 	aggregatedResults := t.aggregateByKnowledge(finalResults, queries, compiled)
-	if len(aggregatedResults) > 20 {
-		aggregatedResults = aggregatedResults[:20]
+	documentCount := len(aggregatedResults)
+	knowledgeResultsForUI := aggregatedResults
+	const maxKnowledgeRows = 20
+	if len(knowledgeResultsForUI) > maxKnowledgeRows {
+		knowledgeResultsForUI = knowledgeResultsForUI[:maxKnowledgeRows]
 	}
 
 	output := t.formatOutput(ctx, finalResults, queries, compiled)
@@ -209,8 +213,9 @@ func (t *GrepChunksTool) Execute(ctx context.Context, args json.RawMessage) (*ty
 			"queries":            queries, // legacy alias for older frontends
 			"patterns":           queries, // legacy alias for older frontends
 			"chunk_results":      chunkResults,
-			"knowledge_results":  aggregatedResults,
+			"knowledge_results":  knowledgeResultsForUI,
 			"result_count":       len(chunkResults),
+			"document_count":     documentCount,
 			"total_matches":      len(finalResults),
 			"knowledge_base_ids": kbIDs,
 			"limit":              limit,

--- a/internal/agent/tools/grep_chunks_aggregate_test.go
+++ b/internal/agent/tools/grep_chunks_aggregate_test.go
@@ -1,0 +1,58 @@
+package tools
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestAggregateByKnowledge_mergesChunksFromSameDocument(t *testing.T) {
+	tool := &GrepChunksTool{}
+	compiled := []*regexp.Regexp{regexp.MustCompile(`(?i)sample`)}
+	results := []chunkWithTitle{
+		{
+			Chunk: types.Chunk{
+				ID:              "chunk-a",
+				KnowledgeID:     "doc-1",
+				KnowledgeBaseID: "kb-1",
+				Content:         "sample hit one",
+			},
+			KnowledgeTitle: "report-a.pdf",
+		},
+		{
+			Chunk: types.Chunk{
+				ID:              "chunk-b",
+				KnowledgeID:     "doc-1",
+				KnowledgeBaseID: "kb-1",
+				Content:         "sample hit two",
+			},
+			KnowledgeTitle: "report-a.pdf",
+		},
+		{
+			Chunk: types.Chunk{
+				ID:              "chunk-c",
+				KnowledgeID:     "doc-2",
+				KnowledgeBaseID: "kb-1",
+				Content:         "sample other doc",
+			},
+			KnowledgeTitle: "report-b.pdf",
+		},
+	}
+
+	aggregated := tool.aggregateByKnowledge(results, []string{"sample"}, compiled)
+	if len(aggregated) != 2 {
+		t.Fatalf("want 2 documents, got %d", len(aggregated))
+	}
+
+	byID := make(map[string]knowledgeAggregation, len(aggregated))
+	for _, row := range aggregated {
+		byID[row.KnowledgeID] = row
+	}
+	if byID["doc-1"].ChunkHitCount != 2 {
+		t.Fatalf("doc-1 chunk hits = %d, want 2", byID["doc-1"].ChunkHitCount)
+	}
+	if byID["doc-2"].ChunkHitCount != 1 {
+		t.Fatalf("doc-2 chunk hits = %d, want 1", byID["doc-2"].ChunkHitCount)
+	}
+}

--- a/internal/agent/tools/knowledge_search.go
+++ b/internal/agent/tools/knowledge_search.go
@@ -299,8 +299,8 @@ func (t *KnowledgeSearchTool) Execute(ctx context.Context, args json.RawMessage)
 	var filteredResults []*searchResultWithMeta
 
 	if (t.rerankModel != nil || t.chatModel != nil) && len(deduplicatedBeforeRerank) > 0 && rerankQuery != "" {
-		logger.Infof(ctx, "[Tool][KnowledgeSearch] Applying rerank, input: %d results, queries: %v",
-			len(deduplicatedBeforeRerank), queries)
+		logger.Infof(ctx, "[Tool][KnowledgeSearch] Applying rerank, input: %d results, threshold: %.2f, queries: %v",
+			len(deduplicatedBeforeRerank), t.rerankThreshold(), queries)
 		rerankedResults, err := t.rerankResults(ctx, rerankQuery, deduplicatedBeforeRerank)
 		if err != nil {
 			logger.Warnf(ctx, "[Tool][KnowledgeSearch] Rerank failed, using original results: %v", err)
@@ -361,12 +361,12 @@ func (t *KnowledgeSearchTool) Execute(ctx context.Context, args json.RawMessage)
 		return deduplicatedResults[i].KnowledgeID < deduplicatedResults[j].KnowledgeID
 	})
 
-	// Log top results
+	// Log all ranked results (including lower ranks for rerank debugging)
 	if len(deduplicatedResults) > 0 {
-		for i := 0; i < len(deduplicatedResults) && i < 5; i++ {
-			r := deduplicatedResults[i]
-			logger.Infof(ctx, "[Tool][KnowledgeSearch][Top %d] score=%.3f, type=%s, kb=%s, chunk_id=%s",
-				i+1, r.Score, r.QueryType, r.KnowledgeID, r.ID)
+		total := len(deduplicatedResults)
+		for i, r := range deduplicatedResults {
+			logger.Infof(ctx, "[Tool][KnowledgeSearch][Rank %d/%d] score=%.3f, type=%s, kb=%s, chunk_id=%s",
+				i+1, total, r.Score, r.QueryType, r.KnowledgeID, r.ID)
 		}
 	}
 
@@ -594,90 +594,50 @@ func (t *KnowledgeSearchTool) concurrentSearchByTargets(
 	return allResults
 }
 
-// rerankResults applies reranking to search results using LLM prompt scoring or rerank model
+// rerankResults applies reranking to all search results (including FAQ entries)
+// using the rerank model or LLM fallback, then filters by threshold and applies
+// composite scoring so MMR/sorting uses a single score scale.
 func (t *KnowledgeSearchTool) rerankResults(
 	ctx context.Context,
 	query string,
 	results []*searchResultWithMeta,
 ) ([]*searchResultWithMeta, error) {
-	// Separate FAQ and normal results.
-	// FAQ results keep original scores and bypass reranking model.
-	faqResults := make([]*searchResultWithMeta, 0)
-	rerankCandidates := make([]*searchResultWithMeta, 0, len(results))
-
-	for _, result := range results {
-		// Skip reranking for FAQ results (they are explicitly matched Q&A pairs)
-		if result.KnowledgeBaseType == types.KnowledgeBaseTypeFAQ {
-			faqResults = append(faqResults, result)
-		} else {
-			rerankCandidates = append(rerankCandidates, result)
-		}
-	}
-
-	// If there are no candidates to rerank, return original list (already all FAQ)
-	if len(rerankCandidates) == 0 {
+	if len(results) == 0 {
 		return results, nil
 	}
 
 	var (
-		rerankedCandidates []*searchResultWithMeta
-		err                error
+		reranked []*searchResultWithMeta
+		err      error
 	)
 
-	// Apply reranking only to candidates
-	// Try rerankModel first, fallback to chatModel if rerankModel fails or returns no results
 	if t.rerankModel != nil {
-		rerankedCandidates, err = t.rerankWithModel(ctx, query, rerankCandidates)
-		// If rerankModel fails or returns no results, fallback to chatModel
-		if err != nil || len(rerankedCandidates) == 0 {
+		reranked, err = t.rerankWithModel(ctx, query, results)
+		if err != nil || len(reranked) == 0 {
 			if err != nil {
 				logger.Warnf(ctx, "[Tool][KnowledgeSearch] Rerank model failed, falling back to chat model: %v", err)
 			} else {
-				logger.Warnf(ctx, "[Tool][KnowledgeSearch] Rerank model returned no results, falling back to chat model")
+				logger.Warnf(ctx, "[Tool][KnowledgeSearch] Rerank model returned no results above threshold, falling back to chat model")
 			}
-			// Reset error to allow fallback
 			err = nil
-			// Try chatModel if available
 			if t.chatModel != nil {
-				rerankedCandidates, err = t.rerankWithLLM(ctx, query, rerankCandidates)
-			} else {
-				// No fallback available, use original results
-				rerankedCandidates = rerankCandidates
+				reranked, err = t.rerankWithLLM(ctx, query, results)
+			} else if len(reranked) == 0 {
+				reranked = results
 			}
 		}
 	} else if t.chatModel != nil {
-		// No rerankModel, use chatModel directly
-		rerankedCandidates, err = t.rerankWithLLM(ctx, query, rerankCandidates)
+		reranked, err = t.rerankWithLLM(ctx, query, results)
 	} else {
-		// No reranking available, use original results
-		rerankedCandidates = rerankCandidates
+		return results, nil
 	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	// Apply composite scoring to reranked results
-	logger.Debugf(ctx, "[Tool][KnowledgeSearch] Applying composite scoring")
-
-	// Store base scores before composite scoring
-	for _, result := range rerankedCandidates {
-		baseScore := result.Score
-		// Apply composite score
-		result.Score = t.compositeScore(result, result.Score, baseScore)
-	}
-
-	// Combine FAQ results (with original order) and reranked candidates
-	combined := make([]*searchResultWithMeta, 0, len(results))
-	combined = append(combined, faqResults...)
-	combined = append(combined, rerankedCandidates...)
-
-	// Sort by score (descending) to keep consistent output order
-	sort.Slice(combined, func(i, j int) bool {
-		return combined[i].Score > combined[j].Score
-	})
-
-	return combined, nil
+	logger.Debugf(ctx, "[Tool][KnowledgeSearch] Rerank produced %d results after threshold filter", len(reranked))
+	return reranked, nil
 }
 
 func (t *KnowledgeSearchTool) getFAQMetadata(
@@ -732,7 +692,6 @@ func (t *KnowledgeSearchTool) rerankWithLLM(
 
 	// Process in batches
 	allScores := make([]float64, len(results))
-	allReranked := make([]*searchResultWithMeta, 0, len(results))
 
 	for batchStart := 0; batchStart < len(results); batchStart += batchSize {
 		batchEnd := batchStart + batchSize
@@ -862,23 +821,25 @@ Output only the scores, no explanations or additional text.`,
 		}
 	}
 
-	// Create reranked results with new scores
-	for i, result := range results {
-		newResult := *result
-		if i < len(allScores) {
-			newResult.Score = allScores[i]
+	// Create rerank rank results and apply the same threshold + composite path as the model.
+	rankResults := make([]rerank.RankResult, 0, len(results))
+	for i, score := range allScores {
+		if i >= len(results) {
+			break
 		}
-		allReranked = append(allReranked, &newResult)
+		rankResults = append(rankResults, rerank.RankResult{
+			Index:          i,
+			RelevanceScore: score,
+		})
 	}
-
-	// Sort by new scores (descending)
-	sort.Slice(allReranked, func(i, j int) bool {
-		return allReranked[i].Score > allReranked[j].Score
+	sort.Slice(rankResults, func(i, j int) bool {
+		return rankResults[i].RelevanceScore > rankResults[j].RelevanceScore
 	})
 
-	logger.Infof(ctx, "[Tool][KnowledgeSearch] LLM reranked %d results from %d original results (processed in batches)",
-		len(allReranked), len(results))
-	return allReranked, nil
+	ranked := t.applyModelRerankScores(results, rankResults, t.rerankThreshold())
+	logger.Infof(ctx, "[Tool][KnowledgeSearch] LLM reranked %d/%d results above threshold %.2f",
+		len(ranked), len(results), t.rerankThreshold())
+	return ranked, nil
 }
 
 // parseScoresFromResponse parses scores from LLM response text
@@ -951,42 +912,87 @@ func (t *KnowledgeSearchTool) parseScoresFromResponse(responseText string, expec
 	return scores, nil
 }
 
-// rerankWithModel uses the rerank model for reranking (fallback)
+// rerankWithModel uses the rerank model for reranking.
 func (t *KnowledgeSearchTool) rerankWithModel(
 	ctx context.Context,
 	query string,
 	results []*searchResultWithMeta,
 ) ([]*searchResultWithMeta, error) {
-	// Prepare passages for reranking (with enriched content including image info)
 	passages := make([]string, len(results))
 	for i, result := range results {
 		passages[i] = t.getEnrichedPassage(ctx, result.SearchResult)
 	}
 
-	// Call rerank model
 	rerankResp, err := t.rerankModel.Rerank(ctx, query, passages)
 	if err != nil {
 		return nil, fmt.Errorf("rerank call failed: %w", err)
 	}
 
-	// Map reranked results back with new scores
-	reranked := make([]*searchResultWithMeta, 0, len(rerankResp))
-	for _, rr := range rerankResp {
-		if rr.Index >= 0 && rr.Index < len(results) {
-			// Create new result with reranked score
-			newResult := *results[rr.Index]
-			newResult.Score = rr.RelevanceScore
-			reranked = append(reranked, &newResult)
-		}
-	}
-
+	ranked := t.applyModelRerankScores(results, rerankResp, t.rerankThreshold())
 	logger.Infof(
 		ctx,
-		"[Tool][KnowledgeSearch] Reranked %d results from %d original results",
-		len(reranked),
+		"[Tool][KnowledgeSearch] Reranked %d/%d results above threshold %.2f",
+		len(ranked),
 		len(results),
+		t.rerankThreshold(),
 	)
-	return reranked, nil
+	return ranked, nil
+}
+
+func (t *KnowledgeSearchTool) rerankThreshold() float64 {
+	if t.config != nil && t.config.Conversation != nil && t.config.Conversation.RerankThreshold > 0 {
+		return t.config.Conversation.RerankThreshold
+	}
+	return 0.3
+}
+
+const agentRerankFallbackMinScore = 0.15
+
+func filterRerankRankResults(rankResults []rerank.RankResult, threshold float64) []rerank.RankResult {
+	if len(rankResults) == 0 {
+		return nil
+	}
+	filtered := make([]rerank.RankResult, 0, len(rankResults))
+	for _, r := range rankResults {
+		if r.RelevanceScore >= threshold {
+			filtered = append(filtered, r)
+		}
+	}
+	if len(filtered) == 0 {
+		top := rankResults[0]
+		for _, r := range rankResults[1:] {
+			if r.RelevanceScore > top.RelevanceScore {
+				top = r
+			}
+		}
+		if top.RelevanceScore >= agentRerankFallbackMinScore {
+			return []rerank.RankResult{top}
+		}
+	}
+	return filtered
+}
+
+func (t *KnowledgeSearchTool) applyModelRerankScores(
+	originals []*searchResultWithMeta,
+	rankResults []rerank.RankResult,
+	threshold float64,
+) []*searchResultWithMeta {
+	filtered := filterRerankRankResults(rankResults, threshold)
+	out := make([]*searchResultWithMeta, 0, len(filtered))
+	for _, rr := range filtered {
+		if rr.Index < 0 || rr.Index >= len(originals) {
+			continue
+		}
+		newResult := *originals[rr.Index]
+		baseScore := newResult.Score
+		modelScore := rr.RelevanceScore
+		newResult.Score = t.compositeScore(&newResult, modelScore, baseScore)
+		out = append(out, &newResult)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Score > out[j].Score
+	})
+	return out
 }
 
 // deduplicateResults removes duplicate chunks, keeping the highest score

--- a/internal/agent/tools/knowledge_search_rerank_test.go
+++ b/internal/agent/tools/knowledge_search_rerank_test.go
@@ -1,0 +1,77 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/models/rerank"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestFilterRerankRankResults_thresholdAndFallback(t *testing.T) {
+	t.Parallel()
+	rankResults := []rerank.RankResult{
+		{Index: 0, RelevanceScore: 0.05},
+		{Index: 1, RelevanceScore: 0.02},
+	}
+	filtered := filterRerankRankResults(rankResults, 0.3)
+	if len(filtered) != 0 {
+		t.Fatalf("expected empty filter, got %#v", filtered)
+	}
+
+	rankResults = []rerank.RankResult{
+		{Index: 0, RelevanceScore: 0.05},
+		{Index: 1, RelevanceScore: 0.20},
+	}
+	filtered = filterRerankRankResults(rankResults, 0.3)
+	if len(filtered) != 1 || filtered[0].Index != 1 {
+		t.Fatalf("expected fallback top score, got %#v", filtered)
+	}
+
+	rankResults = []rerank.RankResult{
+		{Index: 0, RelevanceScore: 0.8},
+		{Index: 1, RelevanceScore: 0.4},
+		{Index: 2, RelevanceScore: 0.1},
+	}
+	filtered = filterRerankRankResults(rankResults, 0.3)
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 passing scores, got %#v", filtered)
+	}
+}
+
+func TestApplyModelRerankScores_faqUsesCompositeScale(t *testing.T) {
+	t.Parallel()
+	tool := &KnowledgeSearchTool{
+		config: &config.Config{
+			Conversation: &config.ConversationConfig{RerankThreshold: 0.3},
+		},
+	}
+	originals := []*searchResultWithMeta{
+		{
+			SearchResult:      &types.SearchResult{ID: "faq-1", Content: "Q: WeKnora", Score: 0.011},
+			KnowledgeBaseType: types.KnowledgeBaseTypeFAQ,
+		},
+		{
+			SearchResult: &types.SearchResult{ID: "doc-1", Content: "swimming club", Score: 0.02},
+		},
+	}
+	rankResults := []rerank.RankResult{
+		{Index: 0, RelevanceScore: 0.05},
+		{Index: 1, RelevanceScore: 0.9},
+	}
+	out := tool.applyModelRerankScores(originals, rankResults, 0.3)
+	if len(out) != 1 || out[0].ID != "doc-1" {
+		t.Fatalf("weak FAQ should be filtered out, got %#v", out)
+	}
+	if out[0].Score <= 0.011 {
+		t.Fatalf("composite score should exceed raw retrieval score, got %.4f", out[0].Score)
+	}
+}
+
+func TestRerankThreshold_default(t *testing.T) {
+	t.Parallel()
+	tool := &KnowledgeSearchTool{}
+	if got := tool.rerankThreshold(); got != 0.3 {
+		t.Fatalf("default threshold = %v, want 0.3", got)
+	}
+}

--- a/internal/agent/tools/list_knowledge_chunks.go
+++ b/internal/agent/tools/list_knowledge_chunks.go
@@ -269,6 +269,7 @@ func (t *ListKnowledgeChunksTool) Execute(ctx context.Context, args json.RawMess
 		Success: true,
 		Output:  output,
 		Data: map[string]interface{}{
+			"display_type":    "knowledge_chunks_list",
 			"knowledge_id":    knowledgeID,
 			"knowledge_title": knowledgeTitle,
 			"total_chunks":    totalChunks,
@@ -325,6 +326,7 @@ func (t *ListKnowledgeChunksTool) executeByChunkID(ctx context.Context, chunkID 
 	normalizeFAQChunkDataMap(formattedChunks[0], chunk)
 
 	data := map[string]interface{}{
+		"display_type":    "knowledge_chunks_list",
 		"knowledge_id":    chunk.KnowledgeID,
 		"knowledge_title": knowledgeTitle,
 		"total_chunks":    int64(1),

--- a/internal/agent/tools/persist.go
+++ b/internal/agent/tools/persist.go
@@ -1,0 +1,198 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// persistStripFields lists bulky Data keys to drop before SSE replay / DB storage.
+var persistStripFields = map[string][]string{
+	"knowledge_chunks_list": {"chunks"},
+	"grep_results":          {"chunk_results"},
+}
+
+// ShouldOmitRawToolOutput reports whether the raw XML/text Output should be
+// excluded from SSE replay and persisted agent_steps. The full Output remains
+// available in-memory for the current agent turn.
+func ShouldOmitRawToolOutput(_ string, data map[string]interface{}) bool {
+	if data == nil {
+		return false
+	}
+	displayType, ok := data["display_type"].(string)
+	return ok && displayType != ""
+}
+
+// SanitizeToolDataForPersist returns a copy of tool Data safe for DB / SSE replay.
+func SanitizeToolDataForPersist(data map[string]interface{}) map[string]interface{} {
+	if data == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(data))
+	for k, v := range data {
+		out[k] = v
+	}
+	displayType := stringField(data, "display_type")
+	for _, key := range persistStripFields[displayType] {
+		delete(out, key)
+	}
+	return out
+}
+
+// SanitizeToolResultForClient builds stream / persistence metadata for the UI.
+func SanitizeToolResultForClient(_ string, result *types.ToolResult) map[string]interface{} {
+	meta := map[string]interface{}{}
+	if result == nil {
+		return meta
+	}
+	if result.Data != nil {
+		for k, v := range SanitizeToolDataForPersist(result.Data) {
+			meta[k] = v
+		}
+	}
+	if !ShouldOmitRawToolOutput("", result.Data) && result.Output != "" {
+		meta["output"] = result.Output
+	}
+	return meta
+}
+
+// StreamContentForToolResult is the short SSE Content field for tool results.
+func StreamContentForToolResult(toolName string, success bool, errMsg string, data map[string]interface{}) string {
+	if !success {
+		return errMsg
+	}
+	if ShouldOmitRawToolOutput(toolName, data) {
+		return compactToolSummary(success, errMsg, data)
+	}
+	return ""
+}
+
+// SanitizeAgentStepsForStorage strips LLM-only payloads from persisted steps.
+func SanitizeAgentStepsForStorage(steps []types.AgentStep) []types.AgentStep {
+	if len(steps) == 0 {
+		return steps
+	}
+	out := make([]types.AgentStep, len(steps))
+	for i, step := range steps {
+		out[i] = step
+		if len(step.ToolCalls) == 0 {
+			continue
+		}
+		toolCalls := make([]types.ToolCall, len(step.ToolCalls))
+		for j, tc := range step.ToolCalls {
+			toolCalls[j] = tc
+			if tc.Result == nil {
+				continue
+			}
+			result := *tc.Result
+			if ShouldOmitRawToolOutput(tc.Name, result.Data) {
+				result.Output = compactToolSummary(result.Success, result.Error, result.Data)
+				result.Data = SanitizeToolDataForPersist(result.Data)
+			}
+			toolCalls[j].Result = &result
+		}
+		out[i].ToolCalls = toolCalls
+	}
+	return out
+}
+
+// CompactToolOutputForHistory rebuilds a short tool message when replaying history.
+func CompactToolOutputForHistory(toolName string, result *types.ToolResult) string {
+	if result == nil {
+		return ""
+	}
+	if !result.Success {
+		if result.Error != "" {
+			return "Error: " + result.Error
+		}
+		return "Error: tool call failed"
+	}
+	if result.Output != "" && !ShouldOmitRawToolOutput(toolName, result.Data) {
+		return result.Output
+	}
+	return compactToolSummary(result.Success, result.Error, result.Data)
+}
+
+func compactToolSummary(success bool, errMsg string, data map[string]interface{}) string {
+	if !success {
+		if errMsg != "" {
+			return "Error: " + errMsg
+		}
+		return "Error: tool call failed"
+	}
+	switch stringField(data, "display_type") {
+	case "knowledge_chunks_list":
+		title := stringField(data, "knowledge_title")
+		if title == "" {
+			title = stringField(data, "knowledge_id")
+		}
+		fetched := intField(data, "fetched_chunks")
+		total := intField(data, "total_chunks")
+		if q := stringField(data, "faq_question"); q != "" {
+			return fmt.Sprintf("Loaded FAQ entry: %s (content omitted from history)", q)
+		}
+		if title != "" && total > 0 {
+			return fmt.Sprintf("Listed %d/%d chunks from %s (content omitted from history)", fetched, total, title)
+		}
+		if title != "" {
+			return fmt.Sprintf("Listed chunks from %s (content omitted from history)", title)
+		}
+	case "grep_results":
+		chunks := intField(data, "total_matches")
+		docs := intField(data, "document_count")
+		if docs == 0 {
+			docs = intField(data, "result_count")
+		}
+		if chunks > 0 {
+			return fmt.Sprintf("Keyword search found %d matching chunks across %d document(s) (details omitted from history)", chunks, docs)
+		}
+	case "search_results":
+		count := intField(data, "result_count")
+		if count == 0 {
+			count = intField(data, "count")
+		}
+		if count > 0 {
+			return fmt.Sprintf("Semantic search returned %d result(s) (details omitted from history)", count)
+		}
+	}
+	if displayType := stringField(data, "display_type"); displayType != "" {
+		return fmt.Sprintf("Tool completed (%s; payload omitted from history)", displayType)
+	}
+	return "Tool completed (payload omitted from history)"
+}
+
+func stringField(data map[string]interface{}, key string) string {
+	if data == nil {
+		return ""
+	}
+	v, ok := data[key]
+	if !ok || v == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(v))
+}
+
+func intField(data map[string]interface{}, key string) int {
+	if data == nil {
+		return 0
+	}
+	v, ok := data[key]
+	if !ok || v == nil {
+		return 0
+	}
+	switch n := v.(type) {
+	case int:
+		return n
+	case int32:
+		return int(n)
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	case float32:
+		return int(n)
+	default:
+		return 0
+	}
+}

--- a/internal/agent/tools/persist_test.go
+++ b/internal/agent/tools/persist_test.go
@@ -1,0 +1,89 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestShouldOmitRawToolOutput(t *testing.T) {
+	if !ShouldOmitRawToolOutput(ToolListKnowledgeChunks, map[string]interface{}{"display_type": "knowledge_chunks_list"}) {
+		t.Fatal("structured list_knowledge_chunks output should be omitted")
+	}
+	if !ShouldOmitRawToolOutput(ToolGrepChunks, map[string]interface{}{"display_type": "grep_results"}) {
+		t.Fatal("structured grep output should be omitted")
+	}
+	if ShouldOmitRawToolOutput("custom_tool", nil) {
+		t.Fatal("unknown tools should keep raw output by default")
+	}
+}
+
+func TestSanitizeToolDataForPersist_knowledgeChunksList(t *testing.T) {
+	data := map[string]interface{}{
+		"display_type":    "knowledge_chunks_list",
+		"knowledge_title": "sample.pdf",
+		"fetched_chunks":  50,
+		"total_chunks":    282,
+		"chunks":          []map[string]interface{}{{"content": "secret"}},
+	}
+	out := SanitizeToolDataForPersist(data)
+	if _, ok := out["chunks"]; ok {
+		t.Fatal("chunk bodies should be stripped from persisted tool data")
+	}
+	if out["fetched_chunks"] != 50 {
+		t.Fatalf("summary fields should be kept, got %#v", out["fetched_chunks"])
+	}
+}
+
+func TestSanitizeAgentStepsForStorage_stripsLargeOutput(t *testing.T) {
+	steps := []types.AgentStep{{
+		Iteration: 1,
+		ToolCalls: []types.ToolCall{{
+			ID:   "call-1",
+			Name: ToolListKnowledgeChunks,
+			Result: &types.ToolResult{
+				Success: true,
+				Output:  strings.Repeat("x", 10000),
+				Data: map[string]interface{}{
+					"display_type":    "knowledge_chunks_list",
+					"knowledge_title": "sample.pdf",
+					"fetched_chunks":  50,
+					"total_chunks":    282,
+					"chunks":          []map[string]interface{}{{"content": "body"}},
+				},
+			},
+		}},
+	}}
+
+	sanitized := SanitizeAgentStepsForStorage(steps)
+	result := sanitized[0].ToolCalls[0].Result
+	if len(result.Output) >= 10000 {
+		t.Fatal("persisted output should be compacted")
+	}
+	if !strings.Contains(result.Output, "content omitted from history") {
+		t.Fatalf("unexpected compact output: %q", result.Output)
+	}
+	if _, ok := result.Data["chunks"]; ok {
+		t.Fatal("chunk bodies should be removed from persisted data")
+	}
+}
+
+func TestSanitizeToolResultForClient_omitsOutput(t *testing.T) {
+	meta := SanitizeToolResultForClient(ToolListKnowledgeChunks, &types.ToolResult{
+		Success: true,
+		Output:  "<knowledge_chunks>very large</knowledge_chunks>",
+		Data: map[string]interface{}{
+			"display_type":    "knowledge_chunks_list",
+			"knowledge_title": "sample.pdf",
+			"fetched_chunks":  1,
+			"total_chunks":    1,
+		},
+	})
+	if _, ok := meta["output"]; ok {
+		t.Fatal("raw output should not be sent to client metadata")
+	}
+	if meta["fetched_chunks"] != 1 {
+		t.Fatalf("summary metadata should remain, got %#v", meta["fetched_chunks"])
+	}
+}

--- a/internal/application/service/agent_history.go
+++ b/internal/application/service/agent_history.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	agenttools "github.com/Tencent/WeKnora/internal/agent/tools"
 	"github.com/Tencent/WeKnora/internal/models/chat"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
@@ -227,7 +228,7 @@ func toolCallOutput(tc types.ToolCall) string {
 		}
 		return "Error: tool call failed"
 	}
-	return tc.Result.Output
+	return agenttools.CompactToolOutputForHistory(tc.Name, tc.Result)
 }
 
 // extractImageCaptionsFromMessage concatenates non-empty Caption fields from

--- a/internal/application/service/chat_pipeline/rerank.go
+++ b/internal/application/service/chat_pipeline/rerank.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/models/rerank"
 	"github.com/Tencent/WeKnora/internal/searchutil"
+	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 )
@@ -83,9 +84,7 @@ func (p *PluginRerank) OnEvent(ctx context.Context,
 			})
 			continue
 		}
-		// 合并Content和ImageInfo的文本内容
 		passage := getEnrichedPassage(ctx, result)
-		// Skip passages that become empty after cleaning
 		if strings.TrimSpace(passage) == "" {
 			pipelineInfo(ctx, "Rerank", "empty_passage_skip", map[string]interface{}{
 				"chunk_id": result.ID,
@@ -96,6 +95,31 @@ func (p *PluginRerank) OnEvent(ctx context.Context,
 		candidatesToRerank = append(candidatesToRerank, result)
 	}
 
+	passagesPreview := langfuse.SummarizePassagePreviews(candidatesToRerank, passages, 25)
+	rerankCtx, rerankSpan := langfuse.GetManager().StartSpan(ctx, langfuse.SpanOptions{
+		Name: "rerank",
+		Input: map[string]interface{}{
+			"query":             chatManage.RewriteQuery,
+			"candidate_count":   len(candidatesToRerank),
+			"direct_load_count": len(directLoadResults),
+			"rerank_model_id":   chatManage.RerankModelID,
+			"threshold":         chatManage.RerankThreshold,
+			"rerank_top_k":      chatManage.RerankTopK,
+			"faq_priority":      chatManage.FAQPriorityEnabled,
+			"faq_score_boost":   chatManage.FAQScoreBoost,
+			"passages_preview":  passagesPreview,
+		},
+		Metadata: map[string]interface{}{
+			"session_id": chatManage.SessionID,
+		},
+	})
+	ctx = rerankCtx
+	spanOutput := map[string]interface{}{}
+	var spanErr error
+	defer func() {
+		rerankSpan.Finish(spanOutput, nil, spanErr)
+	}()
+
 	pipelineInfo(ctx, "Rerank", "build_passages", map[string]interface{}{
 		"total_cnt":     len(chatManage.SearchResult),
 		"candidate_cnt": len(candidatesToRerank),
@@ -103,6 +127,8 @@ func (p *PluginRerank) OnEvent(ctx context.Context,
 	})
 
 	var rerankResp []rerank.RankResult
+	var rawRerankResp []rerank.RankResult
+	thresholdDegraded := false
 
 	// Only call rerank model if there are candidates
 	if len(candidatesToRerank) > 0 {
@@ -119,11 +145,18 @@ func (p *PluginRerank) OnEvent(ctx context.Context,
 				"candidate_cnt": len(candidatesToRerank),
 			})
 			chatManage.SearchResult = append(directLoadResults, candidatesToRerank...)
+			spanOutput = map[string]interface{}{
+				"stage":           "api_error_fallback",
+				"candidate_count": len(candidatesToRerank),
+				"error":           rerankErr.Error(),
+			}
 			return next()
 		}
+		rawRerankResp = append([]rerank.RankResult(nil), rerankResp...)
 
 		// If no results and threshold is high enough, try with lower threshold
 		if len(rerankResp) == 0 && originalThreshold > 0.3 {
+			thresholdDegraded = true
 			degradedThreshold := originalThreshold * 0.7
 			if degradedThreshold < 0.3 {
 				degradedThreshold = 0.3
@@ -144,8 +177,15 @@ func (p *PluginRerank) OnEvent(ctx context.Context,
 					"candidate_cnt": len(candidatesToRerank),
 				})
 				chatManage.SearchResult = append(directLoadResults, candidatesToRerank...)
+				spanOutput = map[string]interface{}{
+					"stage":              "api_error_fallback",
+					"candidate_count":    len(candidatesToRerank),
+					"threshold_degraded": thresholdDegraded,
+					"error":              rerankErr.Error(),
+				}
 				return next()
 			}
+			rawRerankResp = append([]rerank.RankResult(nil), rerankResp...)
 		}
 	}
 
@@ -169,6 +209,7 @@ func (p *PluginRerank) OnEvent(ctx context.Context,
 		base := sr.Score
 		sr.Metadata["base_score"] = fmt.Sprintf("%.4f", base)
 		modelScore := rr.RelevanceScore
+		sr.Metadata["model_score"] = fmt.Sprintf("%.4f", modelScore)
 		sr.Score = compositeScore(sr, modelScore, base)
 
 		// Apply FAQ score boost if enabled
@@ -193,8 +234,9 @@ func (p *PluginRerank) OnEvent(ctx context.Context,
 	for _, sr := range directLoadResults {
 		base := sr.Score
 		sr.Metadata["base_score"] = fmt.Sprintf("%.4f", base)
-		// Assign high model score for direct load items
 		modelScore := 1.0
+		sr.Metadata["model_score"] = fmt.Sprintf("%.4f", modelScore)
+		// Assign high model score for direct load items
 		sr.Score = compositeScore(sr, modelScore, base)
 		reranked = append(reranked, sr)
 	}
@@ -216,13 +258,82 @@ func (p *PluginRerank) OnEvent(ctx context.Context,
 		pipelineWarn(ctx, "Rerank", "output", map[string]interface{}{
 			"filtered_cnt": 0,
 		})
+		spanOutput = buildRerankSpanOutput(
+			candidatesToRerank,
+			passages,
+			directLoadResults,
+			rawRerankResp,
+			reranked,
+			nil,
+			chatManage,
+			thresholdDegraded,
+		)
 		return ErrSearchNothing
 	}
 
+	spanOutput = buildRerankSpanOutput(
+		candidatesToRerank,
+		passages,
+		directLoadResults,
+		rawRerankResp,
+		reranked,
+		chatManage.RerankResult,
+		chatManage,
+		thresholdDegraded,
+	)
 	pipelineInfo(ctx, "Rerank", "output", map[string]interface{}{
 		"filtered_cnt": len(chatManage.RerankResult),
 	})
 	return next()
+}
+
+func buildRerankSpanOutput(
+	candidates []*types.SearchResult,
+	passages []string,
+	directLoad []*types.SearchResult,
+	modelScores []rerank.RankResult,
+	composite []*types.SearchResult,
+	final []*types.SearchResult,
+	chatManage *types.ChatManage,
+	thresholdDegraded bool,
+) map[string]interface{} {
+	modelRows := make([]map[string]interface{}, 0, len(modelScores))
+	for i, rr := range modelScores {
+		row := map[string]interface{}{
+			"rank":        i + 1,
+			"index":       rr.Index,
+			"model_score": rr.RelevanceScore,
+		}
+		if rr.Index >= 0 && rr.Index < len(candidates) {
+			row["chunk_id"] = candidates[rr.Index].ID
+			row["knowledge_id"] = candidates[rr.Index].KnowledgeID
+			row["knowledge_title"] = candidates[rr.Index].KnowledgeTitle
+			row["match_type"] = candidates[rr.Index].MatchType
+			row["retrieval_score"] = candidates[rr.Index].Score
+			if rr.Index < len(passages) {
+				row["preview"] = langfuse.TruncateRunes(passages[rr.Index], 160)
+			}
+		}
+		modelRows = append(modelRows, row)
+	}
+
+	out := map[string]interface{}{
+		"candidate_count":    len(candidates),
+		"direct_load_count":  len(directLoad),
+		"model_result_count": len(modelScores),
+		"composite_count":    len(composite),
+		"final_count":        len(final),
+		"threshold":          chatManage.RerankThreshold,
+		"rerank_top_k":       chatManage.RerankTopK,
+		"threshold_degraded": thresholdDegraded,
+		"model_scores":       langfuse.SummarizeRankScores(modelRows, 50),
+		"composite_results":  langfuse.SummarizeSearchResults(composite, 25),
+		"final_results":      langfuse.SummarizeSearchResults(final, 25),
+	}
+	if len(modelScores) > 50 {
+		out["model_scores_truncated"] = len(modelScores) - 50
+	}
+	return out
 }
 
 // rerank performs the actual reranking operation with given query and passages

--- a/internal/application/service/knowledgebase_search.go
+++ b/internal/application/service/knowledgebase_search.go
@@ -191,15 +191,26 @@ func (s *knowledgeBaseService) HybridSearch(ctx context.Context,
 	retrieveCtx, retrieveSpan := langfuse.GetManager().StartSpan(ctx, langfuse.SpanOptions{
 		Name: "retrieve",
 		Input: map[string]interface{}{
-			"kb_ids":      searchKBIDs,
-			"group_count": len(groups),
-			"match_count": matchCount,
+			"query_text":             params.QueryText,
+			"kb_ids":                 searchKBIDs,
+			"knowledge_ids":          params.KnowledgeIDs,
+			"tag_ids":                params.TagIDs,
+			"match_count":            matchCount,
+			"vector_threshold":       params.VectorThreshold,
+			"keyword_threshold":      params.KeywordThreshold,
+			"disable_vector_match":   params.DisableVectorMatch,
+			"disable_keywords_match": params.DisableKeywordsMatch,
+			"group_count":            len(groups),
+		},
+		Metadata: map[string]interface{}{
+			"primary_kb_id":      kb.ID,
+			"primary_kb_type":    string(kb.Type),
+			"embedding_model_id": kb.EmbeddingModelID,
+			"has_query_embedding": len(params.QueryEmbedding) > 0,
 		},
 	})
 	retrieveResults, err := s.retrieveFromStores(retrieveCtx, groups, retriever.EngineAwareNormalizer{})
-	retrieveSpan.Finish(map[string]interface{}{
-		"result_count": totalHits(retrieveResults),
-	}, nil, err)
+	retrieveSpan.Finish(langfuse.SummarizeRetrieveOutput(retrieveResults), nil, err)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"knowledge_base_ids": searchKBIDs,
@@ -278,7 +289,7 @@ func allBaseParamsEmpty(groups []*storeGroup) bool {
 }
 
 // totalHits counts the IndexWithScore entries across a slice of retrieve
-// results. Used only for langfuse span metadata.
+// results.
 func totalHits(rrs []*types.RetrieveResult) int {
 	n := 0
 	for _, r := range rrs {

--- a/internal/models/rerank/langfuse_wrapper.go
+++ b/internal/models/rerank/langfuse_wrapper.go
@@ -6,6 +6,9 @@ import (
 	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 )
 
+const langfuseRerankPreviewDocs = 8
+const langfuseRerankMaxScores = 50
+
 // langfuseReranker wraps a Reranker and reports each rerank call as a
 // Langfuse generation observation. Rerankers don't return token usage, but
 // the call still incurs cost (billed per 1K documents by most vendors); we
@@ -24,30 +27,73 @@ func (l *langfuseReranker) Rerank(ctx context.Context, query string, documents [
 		return l.inner.Rerank(ctx, query, documents)
 	}
 
+	totalChars := len([]rune(query))
+	for _, doc := range documents {
+		totalChars += len([]rune(doc))
+	}
+
 	genCtx, gen := mgr.StartGeneration(ctx, langfuse.GenerationOptions{
 		Name:  "rerank",
 		Model: l.inner.GetModelName(),
 		Input: map[string]interface{}{
-			"query":          query,
-			"document_count": len(documents),
-			// Only send short previews — reranker inputs can be hundreds of
-			// passages totalling hundreds of KB, which would bloat traces.
-			"documents_preview": previewDocs(documents, 5),
+			"query":             query,
+			"document_count":    len(documents),
+			"documents_preview": previewDocs(documents, langfuseRerankPreviewDocs),
 		},
 		Metadata: map[string]interface{}{
-			"model_id":    l.inner.GetModelID(),
-			"num_queries": 1,
+			"model_id":        l.inner.GetModelID(),
+			"num_queries":     1,
+			"total_chars":     totalChars,
+			"avg_doc_chars":   avgDocChars(documents),
 		},
 	})
 
 	results, err := l.inner.Rerank(genCtx, query, documents)
 
 	output := map[string]interface{}{
-		"results":     summarizeResults(results, 10),
+		"results":     summarizeResults(results, documents, langfuseRerankMaxScores),
 		"total_count": len(results),
+		"score_stats": scoreStats(results),
+	}
+	if len(results) > langfuseRerankMaxScores {
+		output["truncated"] = len(results) - langfuseRerankMaxScores
 	}
 	gen.Finish(output, approxRerankUsage(query, documents), err)
 	return results, err
+}
+
+func avgDocChars(documents []string) int {
+	if len(documents) == 0 {
+		return 0
+	}
+	total := 0
+	for _, doc := range documents {
+		total += len([]rune(doc))
+	}
+	return total / len(documents)
+}
+
+func scoreStats(results []RankResult) map[string]interface{} {
+	if len(results) == 0 {
+		return nil
+	}
+	minScore := results[0].RelevanceScore
+	maxScore := results[0].RelevanceScore
+	sum := 0.0
+	for _, r := range results {
+		if r.RelevanceScore < minScore {
+			minScore = r.RelevanceScore
+		}
+		if r.RelevanceScore > maxScore {
+			maxScore = r.RelevanceScore
+		}
+		sum += r.RelevanceScore
+	}
+	return map[string]interface{}{
+		"min": minScore,
+		"max": maxScore,
+		"avg": sum / float64(len(results)),
+	}
 }
 
 func approxRerankUsage(query string, documents []string) *langfuse.TokenUsage {
@@ -80,16 +126,22 @@ func previewDocs(docs []string, n int) []map[string]interface{} {
 	return out
 }
 
-func summarizeResults(results []RankResult, n int) []map[string]interface{} {
+func summarizeResults(results []RankResult, documents []string, n int) []map[string]interface{} {
 	if len(results) < n {
 		n = len(results)
 	}
 	out := make([]map[string]interface{}, 0, n)
 	for i := 0; i < n; i++ {
-		out = append(out, map[string]interface{}{
-			"index": results[i].Index,
-			"score": results[i].RelevanceScore,
-		})
+		row := map[string]interface{}{
+			"rank":        i + 1,
+			"index":       results[i].Index,
+			"model_score": results[i].RelevanceScore,
+		}
+		idx := results[i].Index
+		if idx >= 0 && idx < len(documents) {
+			row["preview"] = truncateRunes(documents[idx], 160)
+		}
+		out = append(out, row)
 	}
 	return out
 }

--- a/internal/tracing/langfuse/retrieval_obs.go
+++ b/internal/tracing/langfuse/retrieval_obs.go
@@ -1,0 +1,204 @@
+package langfuse
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+const defaultHitPreviewLimit = 25
+
+// TruncateRunes shortens s to at most maxRunes runes for trace payloads.
+func TruncateRunes(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	r := []rune(s)
+	if len(r) <= maxRunes {
+		return s
+	}
+	return string(r[:maxRunes]) + "..."
+}
+
+// SummarizeRetrieveOutput builds Langfuse output for the retrieve span.
+func SummarizeRetrieveOutput(results []*types.RetrieveResult) map[string]interface{} {
+	out := map[string]interface{}{
+		"total_hits":   0,
+		"vector_hits":  0,
+		"keyword_hits": 0,
+		"group_count":  len(results),
+		"by_retriever": []map[string]interface{}{},
+		"top_hits":     []map[string]interface{}{},
+	}
+	if len(results) == 0 {
+		return out
+	}
+
+	byRetriever := make([]map[string]interface{}, 0, len(results))
+	var all []*types.IndexWithScore
+	for _, rr := range results {
+		if rr == nil {
+			continue
+		}
+		count := len(rr.Results)
+		out["total_hits"] = out["total_hits"].(int) + count
+		if rr.RetrieverType == types.VectorRetrieverType {
+			out["vector_hits"] = out["vector_hits"].(int) + count
+		} else {
+			out["keyword_hits"] = out["keyword_hits"].(int) + count
+		}
+		byRetriever = append(byRetriever, map[string]interface{}{
+			"engine":    string(rr.RetrieverEngineType),
+			"retriever": string(rr.RetrieverType),
+			"count":     count,
+		})
+		all = append(all, rr.Results...)
+	}
+	out["by_retriever"] = byRetriever
+	out["top_hits"] = summarizeIndexHits(all, defaultHitPreviewLimit)
+	return out
+}
+
+// SummarizeSearchResults builds a compact ranked preview for rerank spans.
+func SummarizeSearchResults(results []*types.SearchResult, limit int) map[string]interface{} {
+	if limit <= 0 {
+		limit = defaultHitPreviewLimit
+	}
+	out := map[string]interface{}{
+		"count":    len(results),
+		"top_hits": []map[string]interface{}{},
+	}
+	if len(results) == 0 {
+		return out
+	}
+
+	sorted := append([]*types.SearchResult(nil), results...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Score != sorted[j].Score {
+			return sorted[i].Score > sorted[j].Score
+		}
+		return sorted[i].ID < sorted[j].ID
+	})
+
+	hits := make([]map[string]interface{}, 0, minInt(limit, len(sorted)))
+	for i, sr := range sorted {
+		if i >= limit {
+			break
+		}
+		item := map[string]interface{}{
+			"rank":            i + 1,
+			"chunk_id":        sr.ID,
+			"knowledge_id":    sr.KnowledgeID,
+			"knowledge_title": sr.KnowledgeTitle,
+			"composite_score": fmt.Sprintf("%.4f", sr.Score),
+			"match_type":      sr.MatchType,
+			"chunk_type":      sr.ChunkType,
+			"preview":         TruncateRunes(sr.Content, 160),
+		}
+		if sr.Metadata != nil {
+			if base, ok := sr.Metadata["base_score"]; ok {
+				item["retrieval_score"] = base
+			}
+			if model, ok := sr.Metadata["model_score"]; ok {
+				item["model_score"] = model
+			}
+			if boosted, ok := sr.Metadata["faq_boosted"]; ok {
+				item["faq_boosted"] = boosted
+			}
+			if orig, ok := sr.Metadata["faq_original_score"]; ok {
+				item["faq_original_score"] = orig
+			}
+		}
+		hits = append(hits, item)
+	}
+	out["top_hits"] = hits
+	if len(sorted) > limit {
+		out["truncated"] = len(sorted) - limit
+	}
+	return out
+}
+
+// SummarizeRankScores builds rerank model score rows for Langfuse output.
+func SummarizeRankScores(
+	results []map[string]interface{},
+	limit int,
+) []map[string]interface{} {
+	if limit <= 0 {
+		limit = defaultHitPreviewLimit
+	}
+	if len(results) <= limit {
+		return results
+	}
+	out := make([]map[string]interface{}, limit)
+	copy(out, results[:limit])
+	return out
+}
+
+func summarizeIndexHits(hits []*types.IndexWithScore, limit int) []map[string]interface{} {
+	if len(hits) == 0 {
+		return nil
+	}
+	sorted := append([]*types.IndexWithScore(nil), hits...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Score != sorted[j].Score {
+			return sorted[i].Score > sorted[j].Score
+		}
+		return sorted[i].ChunkID < sorted[j].ChunkID
+	})
+
+	n := minInt(limit, len(sorted))
+	out := make([]map[string]interface{}, 0, n)
+	for i := 0; i < n; i++ {
+		hit := sorted[i]
+		out = append(out, map[string]interface{}{
+			"rank":              i + 1,
+			"chunk_id":          hit.ChunkID,
+			"knowledge_id":      hit.KnowledgeID,
+			"knowledge_base_id": hit.KnowledgeBaseID,
+			"score":             fmt.Sprintf("%.4f", hit.Score),
+			"match_type":        hit.MatchType,
+			"preview":           TruncateRunes(hit.Content, 160),
+		})
+	}
+	return out
+}
+
+// SummarizePassagePreviews builds rerank passage previews aligned with candidates.
+func SummarizePassagePreviews(
+	candidates []*types.SearchResult,
+	passages []string,
+	limit int,
+) []map[string]interface{} {
+	if limit <= 0 {
+		limit = defaultHitPreviewLimit
+	}
+	n := len(candidates)
+	if len(passages) < n {
+		n = len(passages)
+	}
+	if limit < n {
+		n = limit
+	}
+	out := make([]map[string]interface{}, 0, n)
+	for i := 0; i < n; i++ {
+		sr := candidates[i]
+		out = append(out, map[string]interface{}{
+			"index":             i,
+			"chunk_id":          sr.ID,
+			"knowledge_id":      sr.KnowledgeID,
+			"knowledge_title":   sr.KnowledgeTitle,
+			"retrieval_score":   fmt.Sprintf("%.4f", sr.Score),
+			"match_type":        sr.MatchType,
+			"preview":           TruncateRunes(passages[i], 160),
+		})
+	}
+	return out
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/tracing/langfuse/retrieval_obs_test.go
+++ b/internal/tracing/langfuse/retrieval_obs_test.go
@@ -1,0 +1,49 @@
+package langfuse
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestSummarizeRetrieveOutput_countsAndPreviews(t *testing.T) {
+	out := SummarizeRetrieveOutput([]*types.RetrieveResult{
+		{
+			RetrieverEngineType: types.PostgresRetrieverEngineType,
+			RetrieverType:       types.VectorRetrieverType,
+			Results: []*types.IndexWithScore{
+				{ChunkID: "c1", KnowledgeID: "k1", Score: 0.9, Content: "alpha"},
+				{ChunkID: "c2", KnowledgeID: "k1", Score: 0.5, Content: "beta"},
+			},
+		},
+		{
+			RetrieverEngineType: types.PostgresRetrieverEngineType,
+			RetrieverType:       types.KeywordsRetrieverType,
+			Results: []*types.IndexWithScore{
+				{ChunkID: "c3", KnowledgeID: "k2", Score: 0.7, Content: "gamma"},
+			},
+		},
+	})
+
+	if out["total_hits"] != 3 {
+		t.Fatalf("total_hits = %v, want 3", out["total_hits"])
+	}
+	if out["vector_hits"] != 2 || out["keyword_hits"] != 1 {
+		t.Fatalf("vector/keyword hits = %v/%v", out["vector_hits"], out["keyword_hits"])
+	}
+	hits := out["top_hits"].([]map[string]interface{})
+	if len(hits) != 3 || hits[0]["chunk_id"] != "c1" {
+		t.Fatalf("unexpected top_hits: %#v", hits)
+	}
+}
+
+func TestSummarizeSearchResults_sortsByScore(t *testing.T) {
+	out := SummarizeSearchResults([]*types.SearchResult{
+		{ID: "low", Score: 0.2, Content: "low"},
+		{ID: "high", Score: 0.9, Content: "high"},
+	}, 10)
+	hits := out["top_hits"].([]map[string]interface{})
+	if len(hits) != 2 || hits[0]["chunk_id"] != "high" {
+		t.Fatalf("unexpected hits: %#v", hits)
+	}
+}


### PR DESCRIPTION
## Summary
- Rerank all knowledge search hits (remove FAQ bypass) with configurable threshold filtering
- Add display_type-based tool output trimming for SSE/DB persistence
- Enhance Langfuse retrieve/rerank spans with previews and score stats

## Test plan
- [ ] `go test ./internal/agent/tools/... ./internal/tracing/langfuse/...`
- [ ] Agent knowledge_search: verify low-score FAQ noise is filtered
- [ ] list_knowledge_chunks: verify large chunk bodies are stripped from persisted history