### PR TITLE
feat(chat): shared markdown rendering and citation popover

### DIFF
--- a/frontend/src/components/ChatCitationFloat.vue
+++ b/frontend/src/components/ChatCitationFloat.vue
@@ -1,0 +1,36 @@
+<template>
+  <Teleport to="body">
+    <div v-if="float.visible" class="chat-citation-float" :style="{ top: `${float.top}px`, left: `${float.left}px` }"
+      @mouseenter="onEnter?.()" @mouseleave="onLeave?.()">
+      <template v-if="float.type === 'web'">
+        <div class="chat-citation-float__title">{{ float.title || float.url }}</div>
+        <a v-if="float.url" class="chat-citation-float__link" :href="float.url" target="_blank"
+          rel="noopener noreferrer">{{ float.url }}</a>
+      </template>
+      <template v-else>
+        <div class="chat-citation-float__title">{{ float.title }}</div>
+        <div v-if="float.loading" class="chat-citation-float__muted">{{ loadingText }}</div>
+        <div v-else-if="float.error" class="chat-citation-float__error">{{ float.error }}</div>
+        <div v-else class="chat-citation-float__body">{{ float.content }}</div>
+      </template>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import type { CitationFloatState } from '@/composables/useChatCitationPopover'
+
+defineProps<{
+  float: CitationFloatState
+  onEnter?: () => void
+  onLeave?: () => void
+}>()
+
+const { t } = useI18n()
+const loadingText = t('common.loading')
+</script>
+
+<style lang="less">
+@import './css/chat-citations.less';
+</style>

--- a/frontend/src/components/css/chat-citations.less
+++ b/frontend/src/components/css/chat-citations.less
@@ -1,0 +1,152 @@
+.chat-citation-pills() {
+  :deep(.citation) {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    vertical-align: baseline;
+    box-sizing: border-box;
+    border-radius: 999px;
+    padding: 0 5px;
+    font-size: 0.72em;
+    line-height: 1.45;
+    margin: 0 0.06em;
+    background-clip: padding-box;
+    transform: translateY(-0.04em);
+  }
+
+  :deep(.citation-icon) {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    flex-shrink: 0;
+    background-color: currentColor;
+    opacity: 0.68;
+    mask-size: contain;
+    mask-repeat: no-repeat;
+    mask-position: center;
+    -webkit-mask-size: contain;
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+  }
+
+  :deep(.citation-icon--book) {
+    mask-image: url('@/assets/img/ziliao.svg');
+    -webkit-mask-image: url('@/assets/img/ziliao.svg');
+  }
+
+  :deep(.citation-icon--web) {
+    mask-image: url('@/assets/img/websearch-globe.svg');
+    -webkit-mask-image: url('@/assets/img/websearch-globe.svg');
+  }
+
+  :deep(.citation-text),
+  :deep(.citation-domain) {
+    line-height: 1.45;
+    max-width: 180px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  :deep(.citation-kb) {
+    background: color-mix(in srgb, var(--td-text-color-primary) 4%, transparent);
+    color: color-mix(in srgb, var(--td-text-color-secondary) 86%, var(--td-text-color-primary));
+    border: 0;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--td-text-color-primary) 10%, transparent);
+    cursor: pointer;
+    white-space: nowrap;
+    position: relative;
+    transition: background 0.15s ease, box-shadow 0.15s ease, color 0.15s ease;
+  }
+
+  :deep(.citation-kb:hover) {
+    background: color-mix(in srgb, var(--td-text-color-primary) 7%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--td-text-color-primary) 18%, transparent);
+    color: var(--td-text-color-primary);
+  }
+
+  :deep(.citation-web) {
+    background: color-mix(in srgb, var(--td-brand-color) 6%, transparent);
+    color: color-mix(in srgb, var(--td-brand-color) 72%, var(--td-text-color-secondary));
+    border: 0;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--td-brand-color) 17%, transparent);
+    cursor: pointer;
+    white-space: nowrap;
+    position: relative;
+    text-decoration: none;
+    transition: background 0.15s ease, box-shadow 0.15s ease, color 0.15s ease;
+  }
+
+  :deep(.citation-web:hover) {
+    background: color-mix(in srgb, var(--td-brand-color) 10%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--td-brand-color) 28%, transparent);
+    color: color-mix(in srgb, var(--td-brand-color) 82%, var(--td-text-color-primary));
+  }
+
+  :deep(.citation-web:focus-visible),
+  :deep(.citation-kb:focus-visible) {
+    outline: 2px solid var(--td-component-border);
+    outline-offset: 2px;
+  }
+
+  :deep(.citation-tip) {
+    display: none;
+  }
+
+  :deep(a.wiki-content-link) {
+    color: var(--td-brand-color);
+    border-bottom: 1px dashed var(--td-brand-color);
+    text-decoration: none;
+    font-weight: 500;
+    transition: border-bottom-style 0.15s ease;
+
+    &:hover {
+      border-bottom-style: solid;
+      text-decoration: none !important;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--td-brand-color);
+      outline-offset: 2px;
+      border-radius: 2px;
+    }
+  }
+}
+
+.chat-citation-float {
+  position: absolute;
+  z-index: 10000;
+  max-width: 320px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--td-bg-color-container);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--td-text-color-primary);
+
+  &__title {
+    font-weight: 600;
+    color: var(--td-brand-color);
+    margin-bottom: 4px;
+  }
+
+  &__link {
+    color: var(--td-brand-color);
+    word-break: break-all;
+  }
+
+  &__body {
+    max-height: 200px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+  }
+
+  &__muted,
+  &__error {
+    color: var(--td-text-color-secondary);
+  }
+
+  &__error {
+    color: var(--td-error-color);
+  }
+}

--- a/frontend/src/components/css/chat-citations.test.mjs
+++ b/frontend/src/components/css/chat-citations.test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const css = readFileSync(join(here, 'chat-citations.less'), 'utf8')
+
+test('citation pills use compact baseline-aligned source styling', () => {
+  assert.match(css, /border-radius:\s*999px/)
+  assert.match(css, /font-size:\s*0\.72em/)
+  assert.match(css, /box-shadow:\s*inset 0 0 0 1px/)
+})

--- a/frontend/src/components/css/chat-hljs-dark.less
+++ b/frontend/src/components/css/chat-hljs-dark.less
@@ -1,0 +1,75 @@
+// Dark-theme highlight token colors only. Chat Markdown layout/chrome styles
+// belong to chat-markdown.less.
+html[theme-mode='dark'] {
+  .markdown-content .chat-code-block__pre,
+  .answer-content .chat-code-block__pre,
+  .ai-markdown-template .chat-code-block__pre,
+  .agent-stream-display .chat-code-block__pre {
+    .hljs {
+      color: #c9d1d9;
+    }
+
+    .hljs-doctag,
+    .hljs-keyword,
+    .hljs-meta .hljs-keyword,
+    .hljs-template-tag,
+    .hljs-template-variable,
+    .hljs-type,
+    .hljs-variable.language_ {
+      color: #ff7b72;
+    }
+
+    .hljs-title,
+    .hljs-title.class_,
+    .hljs-title.class_.inherited__,
+    .hljs-title.function_ {
+      color: #d2a8ff;
+    }
+
+    .hljs-attr,
+    .hljs-attribute,
+    .hljs-literal,
+    .hljs-meta,
+    .hljs-number,
+    .hljs-operator,
+    .hljs-variable,
+    .hljs-selector-attr,
+    .hljs-selector-class,
+    .hljs-selector-id {
+      color: #79c0ff;
+    }
+
+    .hljs-regexp,
+    .hljs-string,
+    .hljs-meta .hljs-string {
+      color: #a5d6ff;
+    }
+
+    .hljs-built_in,
+    .hljs-symbol {
+      color: #ffa657;
+    }
+
+    .hljs-comment,
+    .hljs-code,
+    .hljs-formula {
+      color: #8b949e;
+    }
+
+    .hljs-name,
+    .hljs-quote,
+    .hljs-selector-tag,
+    .hljs-selector-pseudo {
+      color: #7ee787;
+    }
+
+    .hljs-subst {
+      color: #c9d1d9;
+    }
+
+    .hljs-section {
+      color: #1f6feb;
+      font-weight: 700;
+    }
+  }
+}

--- a/frontend/src/components/css/chat-hljs.less
+++ b/frontend/src/components/css/chat-hljs.less
@@ -1,0 +1,72 @@
+// Syntax highlighting tokens for chat code blocks.
+.chat-markdown-hljs() {
+  :deep(.chat-code-block__pre) {
+    .hljs {
+      color: #24292e;
+      background: transparent;
+    }
+
+    .hljs-doctag,
+    .hljs-keyword,
+    .hljs-meta .hljs-keyword,
+    .hljs-template-tag,
+    .hljs-template-variable,
+    .hljs-type,
+    .hljs-variable.language_ {
+      color: #d73a49;
+    }
+
+    .hljs-title,
+    .hljs-title.class_,
+    .hljs-title.class_.inherited__,
+    .hljs-title.function_ {
+      color: #6f42c1;
+    }
+
+    .hljs-attr,
+    .hljs-attribute,
+    .hljs-literal,
+    .hljs-meta,
+    .hljs-number,
+    .hljs-operator,
+    .hljs-variable,
+    .hljs-selector-attr,
+    .hljs-selector-class,
+    .hljs-selector-id {
+      color: #005cc5;
+    }
+
+    .hljs-regexp,
+    .hljs-string,
+    .hljs-meta .hljs-string {
+      color: #032f62;
+    }
+
+    .hljs-built_in,
+    .hljs-symbol {
+      color: #e36209;
+    }
+
+    .hljs-comment,
+    .hljs-code,
+    .hljs-formula {
+      color: #6a737d;
+    }
+
+    .hljs-name,
+    .hljs-quote,
+    .hljs-selector-tag,
+    .hljs-selector-pseudo {
+      color: #22863a;
+    }
+
+    .hljs-subst {
+      color: #24292e;
+    }
+
+    .hljs-section {
+      color: #005cc5;
+      font-weight: 700;
+    }
+  }
+}

--- a/frontend/src/components/css/chat-markdown.less
+++ b/frontend/src/components/css/chat-markdown.less
@@ -1,0 +1,587 @@
+@import './chat-hljs.less';
+
+// Single source of truth for chat answer Markdown typography and block styles.
+// Used by botmsg, AgentStreamDisplay, embed chat, and the dev Markdown test page.
+// Future chat Markdown visual changes should be made here instead of in
+// individual Vue components. Non-chat document/wiki preview styles intentionally
+// live outside this file.
+//
+// Shared typography for chat answer markdown (botmsg, AgentStreamDisplay, embed).
+// Tuned against ChatGPT markdown test doc: 16px body, 24px line-height on paragraphs,
+// stepped headings, dotted links, light tables, pill inline code, kbd chips.
+.chat-markdown-typography() {
+  font-size: 16px;
+  color: var(--td-text-color-primary);
+  line-height: 1.625;
+  letter-spacing: normal;
+  -webkit-font-smoothing: antialiased;
+
+  :deep(p) {
+    margin: 0 0 0.25em;
+    line-height: 1.625;
+
+    + p {
+      margin-top: 0.75em;
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  // Citation-only paragraphs from marked (tag on its own line) — keep compact.
+  :deep(p:has(> .citation:only-child)) {
+    margin: 0.125em 0 0.375em;
+    line-height: 1.625;
+  }
+
+  // Inline citations share the paragraph line box with body text.
+  :deep(p:has(.citation)) {
+    line-height: 1.625;
+  }
+
+  :deep(p:has(.citation) + p:has(> img:only-child)),
+  :deep(p:has(> .citation:only-child) + p:has(> img:only-child)) {
+    margin-top: 0.5em;
+  }
+
+  // Models often emit standalone **小节标题：** paragraphs instead of headings.
+  :deep(p:has(> strong:only-child)) {
+    margin-top: 1.25em;
+    margin-bottom: 0.5em;
+    line-height: 1.5;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  :deep(p + ul),
+  :deep(p + ol),
+  :deep(ul + p),
+  :deep(ol + p),
+  :deep(blockquote + p),
+  :deep(p + blockquote) {
+    margin-top: 0.75em;
+  }
+
+  :deep(strong) {
+    font-weight: 600;
+  }
+
+  :deep(em) {
+    font-style: italic;
+  }
+
+  :deep(del) {
+    text-decoration: line-through;
+    opacity: 0.72;
+  }
+
+  :deep(kbd) {
+    display: inline-block;
+    padding: 0.15em 0.45em;
+    font-family: var(--app-font-family-mono);
+    font-size: 0.8125em;
+    font-weight: 500;
+    line-height: 1.4;
+    color: var(--td-text-color-primary);
+    background: var(--td-bg-color-secondarycontainer);
+    border: 1px solid var(--td-component-stroke);
+    border-radius: 5px;
+    box-shadow: 0 1px 0 color-mix(in srgb, var(--td-text-color-primary) 8%, transparent);
+  }
+
+  :deep(code):not(pre code) {
+    background: color-mix(in srgb, var(--td-text-color-primary) 8%, transparent);
+    padding: 0.15em 0.3em;
+    border-radius: 4px;
+    font-family: var(--app-font-family-mono);
+    font-size: 0.875em;
+    font-weight: 500;
+  }
+
+  :deep(pre:not(.chat-code-block__pre):not(.chat-mermaid-block__canvas)) {
+    background: var(--td-bg-color-secondarycontainer);
+    padding: 14px 16px;
+    border: 1px solid var(--td-component-stroke);
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 0.75em 0;
+    line-height: 1.55;
+    font-size: 13px;
+
+    code {
+      background: none;
+      padding: 0;
+      font-size: inherit;
+      font-weight: 400;
+    }
+  }
+
+  :deep(.chat-code-block) {
+    margin: 0.75em 0;
+    border: 1px solid var(--td-component-stroke);
+    border-radius: 8px;
+    overflow: hidden;
+    background: var(--td-bg-color-container);
+    box-shadow: 0 1px 2px color-mix(in srgb, var(--td-text-color-primary) 6%, transparent);
+  }
+
+  :deep(.chat-code-block__header) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    min-height: 36px;
+    padding: 6px 10px 6px 12px;
+    background: var(--td-bg-color-secondarycontainer);
+    border-bottom: 1px solid var(--td-component-stroke);
+  }
+
+  :deep(.chat-code-block__lang) {
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.2;
+    color: var(--td-text-color-secondary);
+    letter-spacing: 0.02em;
+    text-transform: none;
+  }
+
+  :deep(.chat-code-block__copy) {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0;
+    padding: 4px 8px;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--td-text-color-secondary);
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+
+    &:hover {
+      background: color-mix(in srgb, var(--td-text-color-primary) 6%, var(--td-bg-color-secondarycontainer));
+      border-color: var(--td-component-border);
+      color: var(--td-text-color-primary);
+    }
+
+    &.is-copied {
+      color: var(--td-text-color-primary);
+    }
+
+    &.is-error {
+      color: var(--td-error-color);
+    }
+  }
+
+  :deep(.chat-code-block__copy-icon) {
+    flex-shrink: 0;
+  }
+
+  :deep(.chat-code-block__pre) {
+    margin: 0;
+    padding: 14px 16px;
+    border-radius: 0;
+    background: color-mix(in srgb, var(--td-bg-color-secondarycontainer) 88%, var(--td-bg-color-container));
+    overflow-x: auto;
+    font-size: 13px;
+    line-height: 1.55;
+
+    code {
+      background: transparent;
+      padding: 0;
+      border-radius: 0;
+      font-size: inherit;
+      font-weight: 400;
+      white-space: pre;
+      display: block;
+    }
+  }
+
+  :deep(.chat-mermaid-block) {
+    margin: 0.75em 0;
+    border: 1px solid var(--td-component-stroke);
+    border-radius: 10px;
+    overflow: hidden;
+    background: var(--td-bg-color-container);
+    box-shadow: 0 1px 3px color-mix(in srgb, var(--td-text-color-primary) 5%, transparent);
+  }
+
+  :deep(.chat-mermaid-block__header) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    min-height: 36px;
+    padding: 6px 10px 6px 12px;
+    background: var(--td-bg-color-secondarycontainer);
+    border-bottom: 1px solid var(--td-component-stroke);
+  }
+
+  :deep(.chat-mermaid-block__badge) {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--td-text-color-secondary);
+  }
+
+  :deep(.chat-mermaid-block__expand) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    margin: 0;
+    padding: 0;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--td-text-color-secondary);
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+
+    &:hover:not(:disabled) {
+      background: color-mix(in srgb, var(--td-text-color-primary) 6%, var(--td-bg-color-secondarycontainer));
+      border-color: var(--td-component-border);
+      color: var(--td-text-color-primary);
+    }
+
+    &:disabled,
+    &.is-disabled {
+      opacity: 0.35;
+      cursor: not-allowed;
+    }
+  }
+
+  :deep(.chat-mermaid-block__canvas) {
+    margin: 0;
+    padding: 20px 16px 18px;
+    border: 0;
+    border-radius: 0;
+    background: var(--td-bg-color-container);
+    overflow-x: auto;
+    text-align: center;
+    cursor: zoom-in;
+
+    svg {
+      max-width: 100%;
+      height: auto;
+    }
+
+    .node rect,
+    .node circle,
+    .node ellipse,
+    .node polygon,
+    .node path {
+      stroke-width: 1.5px;
+    }
+
+    .edgePath path,
+    .flowchart-link {
+      stroke-width: 1.6px;
+    }
+
+    .label,
+    .nodeLabel,
+    .edgeLabel {
+      font-family: var(--app-font-family);
+    }
+  }
+
+  :deep(.chat-mermaid-block--loading .streaming-mermaid-loading) {
+    margin: 0;
+    max-width: none;
+    min-height: 200px;
+    border: 0;
+    border-radius: 0;
+  }
+
+  :deep(pre.mermaid:not(.chat-mermaid-block__canvas)) {
+    margin: 0.75em 0;
+    padding: 20px 16px;
+    border: 1px solid var(--td-component-stroke);
+    border-radius: 10px;
+    background: var(--td-bg-color-secondarycontainer);
+    overflow-x: auto;
+    text-align: center;
+    cursor: zoom-in;
+
+    svg {
+      max-width: 100%;
+      height: auto;
+    }
+  }
+
+  :deep(ul) {
+    margin: 0.35em 0 0.75em;
+    padding-left: 1.625em;
+    list-style-type: disc;
+    list-style-position: outside;
+
+    ul {
+      list-style-type: disc;
+      margin: 0.25em 0 0;
+      padding-left: 1.25em;
+    }
+  }
+
+  :deep(ol) {
+    margin: 0.35em 0 0.75em;
+    padding-left: 1.625em;
+    list-style-type: decimal;
+    list-style-position: outside;
+
+    ol {
+      list-style-type: decimal;
+      margin: 0.25em 0 0;
+      padding-left: 1.25em;
+    }
+  }
+
+  :deep(li) {
+    margin: 0;
+    line-height: 1.625;
+    padding-left: 0.375em;
+
+    + li {
+      margin-top: 0.375em;
+    }
+
+    &::marker {
+      font-weight: 700;
+      color: var(--td-text-color-primary);
+    }
+
+    > p {
+      margin: 0;
+
+      + p {
+        margin-top: 0.25em;
+      }
+    }
+  }
+
+  :deep(ol > li)::marker {
+    font-variant-numeric: tabular-nums;
+  }
+
+  :deep(li > ul),
+  :deep(li > ol) {
+    margin-top: 0.25em;
+    margin-bottom: 0;
+  }
+
+  :deep(li:has(> input[type='checkbox'])) {
+    list-style: none;
+    margin-left: -1.625em;
+    padding-left: 0;
+
+    &::marker {
+      content: none;
+    }
+
+    input[type='checkbox'] {
+      margin: 0 0.5em 0 0;
+      vertical-align: middle;
+      accent-color: var(--td-brand-color);
+    }
+  }
+
+  :deep(blockquote) {
+    border-left: 2px solid var(--td-component-stroke);
+    padding: 0.5em 0 0.5em 1.25em;
+    margin: 0.5em 0 0.75em;
+    color: var(--td-text-color-secondary);
+    font-weight: 400;
+    font-style: normal;
+
+    blockquote {
+      margin-top: 0.35em;
+      margin-bottom: 0;
+    }
+  }
+
+  :deep(blockquote),
+  :deep(blockquote p) {
+    line-height: 1.5;
+  }
+
+  :deep(hr) {
+    margin: 1.75em 0;
+    border: none;
+    border-top: 1px solid var(--td-component-stroke);
+  }
+
+  :deep(h1) {
+    font-size: 1.5em;
+    font-weight: 600;
+    margin: 0 0 0.375em;
+    line-height: 1.333;
+  }
+
+  :deep(h2) {
+    font-size: 1.25em;
+    font-weight: 600;
+    margin: 1em 0 0.25em;
+    line-height: 1.4;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  :deep(h3) {
+    font-size: 1.125em;
+    font-weight: 600;
+    margin: 0.875em 0 0.25em;
+    line-height: 1.556;
+  }
+
+  :deep(h4),
+  :deep(h5),
+  :deep(h6) {
+    font-weight: 600;
+    margin: 1em 0 0;
+    line-height: 1.5;
+  }
+
+  :deep(h4) {
+    font-size: 1em;
+  }
+
+  :deep(h5) {
+    font-size: 0.9375em;
+  }
+
+  :deep(h6) {
+    font-size: 0.875em;
+    font-weight: 600;
+    color: var(--td-text-color-secondary);
+  }
+
+  :deep(h1:first-child),
+  :deep(h2:first-child),
+  :deep(h3:first-child),
+  :deep(h4:first-child),
+  :deep(h5:first-child),
+  :deep(h6:first-child) {
+    margin-top: 0;
+  }
+
+  :deep(a) {
+    color: var(--td-brand-color);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in srgb, var(--td-brand-color) 45%, transparent);
+    text-underline-offset: 0.18em;
+
+    &:hover {
+      color: var(--td-brand-color-hover);
+      text-decoration-color: var(--td-brand-color);
+    }
+  }
+
+  :deep(.chat-markdown-table) {
+    width: fit-content;
+    max-width: 100%;
+    margin: 0.875em 0 1em;
+    overflow-x: auto;
+    border: 1px solid var(--td-component-stroke);
+    border-radius: 8px;
+    background: var(--td-bg-color-container);
+    -webkit-overflow-scrolling: touch;
+  }
+
+  :deep(table) {
+    word-break: initial;
+    border-collapse: separate;
+    border-spacing: 0;
+    display: table;
+    font-size: 14px;
+    line-height: 1.55;
+    width: max-content;
+    min-width: 0;
+  }
+
+  :deep(table thead) {
+    background-color: color-mix(in srgb, var(--td-bg-color-secondarycontainer) 75%, var(--td-bg-color-container));
+  }
+
+  :deep(table tbody tr:nth-child(2n)) {
+    background-color: color-mix(in srgb, var(--td-bg-color-secondarycontainer) 45%, transparent);
+  }
+
+  :deep(table tr th) {
+    font-weight: 600;
+    border: 0;
+    border-right: 1px solid var(--td-component-stroke);
+    border-bottom: 1px solid var(--td-component-stroke);
+    background-color: color-mix(in srgb, var(--td-bg-color-secondarycontainer) 75%, var(--td-bg-color-container));
+    text-align: left;
+    margin: 0;
+    padding: 8px 12px;
+    white-space: nowrap;
+  }
+
+  :deep(table tr td) {
+    border: 0;
+    border-right: 1px solid var(--td-component-stroke);
+    border-bottom: 1px solid var(--td-component-stroke);
+    text-align: left;
+    margin: 0;
+    padding: 8px 12px;
+    vertical-align: top;
+  }
+
+  :deep(table tr th:last-child),
+  :deep(table tr td:last-child) {
+    border-right: 0;
+  }
+
+  :deep(table tbody tr:last-child td) {
+    border-bottom: 0;
+  }
+
+  :deep(table th[align='center']),
+  :deep(table td[align='center']) {
+    text-align: center;
+  }
+
+  :deep(table th[align='right']),
+  :deep(table td[align='right']) {
+    text-align: right;
+  }
+
+  :deep(img) {
+    max-width: 80%;
+    max-height: 300px;
+    width: auto;
+    height: auto;
+    border-radius: 8px;
+    display: block;
+    margin: 1.25em 0;
+    border: 0.5px solid var(--td-component-stroke);
+    object-fit: contain;
+    cursor: pointer;
+    transition: transform 0.2s ease;
+  }
+
+  :deep(p:has(> img:only-child)) {
+    margin: 1.25em 0;
+    line-height: 0;
+  }
+
+  :deep(.mermaid) {
+    margin: 0;
+  }
+
+  .chat-markdown-hljs();
+}

--- a/frontend/src/components/css/markdown.less
+++ b/frontend/src/components/css/markdown.less
@@ -1,3 +1,5 @@
+// Legacy Markdown styles for non-chat document/editor surfaces that render
+// `.md-content`. Chat answer Markdown must use `chat-markdown.less` only.
 :deep(.md-content) {
     box-sizing: border-box !important;
 

--- a/frontend/src/composables/useChatCitationPopover.ts
+++ b/frontend/src/composables/useChatCitationPopover.ts
@@ -1,9 +1,14 @@
-import { onBeforeUnmount, ref, unref, watch, type MaybeRef, type Ref } from 'vue'
+import { onBeforeUnmount, onMounted, ref, watch, type Ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { getChunkByIdOnly } from '@/api/knowledge-base'
 import { getEmbedChunkById } from '@/api/embed'
+import { resolveCitationChunkId, type CitationKnowledgeRef } from '@/utils/citationMarkdown'
 import {
   getCitationChunkCache,
   setCitationChunkCache,
 } from '@/utils/citationChunkCache'
+
+export { clearCitationChunkCache } from '@/utils/citationChunkCache'
 
 type FloatState = {
   visible: boolean
@@ -17,11 +22,28 @@ type FloatState = {
   error: string
 }
 
-export function useEmbedCitationPopover(
+export type CitationFloatState = FloatState
+
+export type ChatCitationPopoverOptions = {
+  getKnowledgeReferences?: () => CitationKnowledgeRef[] | null | undefined
+  embedChannelId?: () => string | undefined
+  embedToken?: () => string | undefined
+  sessionId?: () => string | undefined
+}
+
+export function useChatCitationPopover(
   rootRef: Ref<HTMLElement | null>,
-  channelId: MaybeRef<string>,
-  token: MaybeRef<string>,
+  options?: ChatCitationPopoverOptions,
 ) {
+  const { t } = useI18n()
+
+  const getCacheScope = () => {
+    const channelId = options?.embedChannelId?.()
+    const token = options?.embedToken?.()
+    if (channelId && token) return `embed:${channelId}:${token}`
+    return options?.sessionId?.() || 'default'
+  }
+
   const float = ref<FloatState>({
     visible: false,
     type: 'kb',
@@ -36,8 +58,6 @@ export function useEmbedCitationPopover(
 
   let hoverTimer: number | null = null
   let closeTimer: number | null = null
-
-  const getCacheScope = () => `embed:${unref(channelId)}:${unref(token)}`
 
   const positionFor = (el: HTMLElement, offsetY = 0) => {
     const rect = el.getBoundingClientRect()
@@ -57,9 +77,24 @@ export function useEmbedCitationPopover(
     positionFor(el)
   }
 
+  const fetchChunkContent = async (chunkId: string) => {
+    const channelId = options?.embedChannelId?.()
+    const token = options?.embedToken?.()
+    if (channelId && token) {
+      return getEmbedChunkById(channelId, token, chunkId)
+    }
+    return getChunkByIdOnly(chunkId)
+  }
+
   const openKb = async (el: HTMLElement) => {
-    const chunkId = el.getAttribute('data-chunk-id') || ''
+    const rawChunkId = el.getAttribute('data-chunk-id') || ''
     const title = el.getAttribute('data-doc') || ''
+    const kbId = el.getAttribute('data-kb-id') || ''
+    const chunkId = resolveCitationChunkId(
+      rawChunkId,
+      { doc: title, kbId },
+      options?.getKnowledgeReferences?.(),
+    ) || rawChunkId
     if (!chunkId) return
     float.value.type = 'kb'
     float.value.title = title
@@ -80,12 +115,18 @@ export function useEmbedCitationPopover(
     float.value.error = ''
     float.value.content = ''
     try {
-      const res = await getEmbedChunkById(unref(channelId), unref(token), chunkId)
+      const res = await fetchChunkContent(chunkId)
       const content = String(res?.data?.content || '').trim()
+      if (!content) {
+        const msg = t('agentStream.citation.notFound')
+        setCitationChunkCache(scope, chunkId, { content: '', error: msg })
+        float.value.error = msg
+        return
+      }
       setCitationChunkCache(scope, chunkId, { content })
       float.value.content = content
     } catch {
-      const msg = 'Failed to load'
+      const msg = t('agentStream.citation.loadFailed')
       setCitationChunkCache(scope, chunkId, { content: '', error: msg })
       float.value.error = msg
     } finally {
@@ -96,8 +137,19 @@ export function useEmbedCitationPopover(
   const scheduleClose = () => {
     if (closeTimer) window.clearTimeout(closeTimer)
     closeTimer = window.setTimeout(() => {
-      float.value.visible = false
+      const hoveredCitation = document.querySelector('.citation-kb:hover, .citation-web:hover')
+      const hoveredPopup = document.querySelector('.chat-citation-float:hover')
+      if (!hoveredCitation && !hoveredPopup) {
+        float.value.visible = false
+      }
     }, 120)
+  }
+
+  const cancelClose = () => {
+    if (closeTimer) {
+      window.clearTimeout(closeTimer)
+      closeTimer = null
+    }
   }
 
   const onMouseOver = (e: Event) => {
@@ -105,10 +157,7 @@ export function useEmbedCitationPopover(
     const kbEl = target.closest?.('.citation-kb') as HTMLElement | null
     const webEl = target.closest?.('.citation-web') as HTMLElement | null
     if (!kbEl && !webEl) return
-    if (closeTimer) {
-      window.clearTimeout(closeTimer)
-      closeTimer = null
-    }
+    cancelClose()
     if (hoverTimer) window.clearTimeout(hoverTimer)
     hoverTimer = window.setTimeout(() => {
       if (kbEl) void openKb(kbEl)
@@ -118,7 +167,7 @@ export function useEmbedCitationPopover(
 
   const onMouseOut = (e: Event) => {
     const rt = (e as MouseEvent).relatedTarget as HTMLElement | null
-    if (rt?.closest?.('.citation-kb, .citation-web, .embed-citation-float')) return
+    if (rt?.closest?.('.citation-kb, .citation-web, .chat-citation-float')) return
     if (hoverTimer) {
       window.clearTimeout(hoverTimer)
       hoverTimer = null
@@ -133,13 +182,11 @@ export function useEmbedCitationPopover(
       e.preventDefault()
       e.stopPropagation()
       void openKb(kbEl)
-      return
     }
-    const wikiEl = target.closest?.('.citation-wiki') as HTMLElement | null
-    if (wikiEl) {
-      e.preventDefault()
-      e.stopPropagation()
-    }
+  }
+
+  const onViewportChange = () => {
+    if (float.value.visible) scheduleClose()
   }
 
   const bind = () => {
@@ -148,14 +195,19 @@ export function useEmbedCitationPopover(
     root.addEventListener('mouseover', onMouseOver, true)
     root.addEventListener('mouseout', onMouseOut, true)
     root.addEventListener('click', onClick, true)
+    window.addEventListener('scroll', onViewportChange, true)
+    window.addEventListener('resize', onViewportChange, true)
   }
 
   const unbind = () => {
     const root = rootRef.value
-    if (!root) return
-    root.removeEventListener('mouseover', onMouseOver, true)
-    root.removeEventListener('mouseout', onMouseOut, true)
-    root.removeEventListener('click', onClick, true)
+    if (root) {
+      root.removeEventListener('mouseover', onMouseOver, true)
+      root.removeEventListener('mouseout', onMouseOut, true)
+      root.removeEventListener('click', onClick, true)
+    }
+    window.removeEventListener('scroll', onViewportChange, true)
+    window.removeEventListener('resize', onViewportChange, true)
   }
 
   watch(rootRef, () => {
@@ -163,11 +215,15 @@ export function useEmbedCitationPopover(
     bind()
   }, { flush: 'post' })
 
+  onMounted(() => {
+    bind()
+  })
+
   onBeforeUnmount(() => {
     unbind()
     if (hoverTimer) window.clearTimeout(hoverTimer)
     if (closeTimer) window.clearTimeout(closeTimer)
   })
 
-  return { float, rebind: () => { unbind(); bind() } }
+  return { float, rebind: () => { unbind(); bind() }, cancelClose, scheduleClose }
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -8,6 +8,7 @@ import TDesign from "tdesign-vue-next";
 import "tdesign-vue-next/es/style/index.css";
 import "@/assets/theme/theme.css";
 import "@/assets/dropdown-menu.less";
+import "@/components/css/chat-hljs-dark.less";
 // vue-virtual-scroller ships its own tiny stylesheet — required for
 // RecycleScroller/DynamicScroller to size their viewport correctly.
 // Without it the scroller computes 0 height and renders no items.

--- a/frontend/src/utils/chatMarkdownRenderer.test.ts
+++ b/frontend/src/utils/chatMarkdownRenderer.test.ts
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createChatMarkdownRenderer,
+  preprocessMathDelimiters,
+  renderChatMarkdown,
+  replaceIncompleteImageWithPlaceholder,
+} from './chatMarkdownRenderer.ts'
+import { resolveCitationChunkId, joinCitationTagsToPreviousLine, collapseStandaloneCitationParagraphs } from './citationMarkdown.ts'
+
+const SAMPLE_DOC = 'example-report.docx'
+const SAMPLE_CHUNK_A = '00000001-0000-4000-8000-000000000001'
+const SAMPLE_CHUNK_B = '00000002-0000-4000-8000-000000000002'
+const SAMPLE_CHUNK_C = '00000003-0000-4000-8000-000000000003'
+const SAMPLE_CHUNK_PRESERVE = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+
+test('preprocessMathDelimiters converts escaped math delimiters for marked-katex', () => {
+  assert.equal(
+    preprocessMathDelimiters('inline \\(a+b\\) and block \\[x^2\\]'),
+    'inline $a+b$ and block $$x^2$$',
+  )
+})
+
+test('replaceIncompleteImageWithPlaceholder hides an unfinished streaming image', () => {
+  assert.equal(
+    replaceIncompleteImageWithPlaceholder('before ![chart](local://bucket/path'),
+    'before <span class="streaming-image-loading"><span class="streaming-image-loading__skeleton"></span></span>',
+  )
+})
+
+test('renderChatMarkdown preserves citations, math, and sanitized output through one shared pipeline', () => {
+  const renderer = createChatMarkdownRenderer({
+    imageRenderer: ({ href, title, text }) =>
+      `<img src="${href}" alt="${text}" title="${title || ''}" class="markdown-image">`,
+    isValidImageUrl: (href) => href.startsWith('https://'),
+  })
+
+  const html = renderChatMarkdown(
+    [
+      'See <kb doc="sample-product-guide.pdf" chunk_id="chunk-1" kb_id="kb-1"/>',
+      '',
+      'Formula: \\(E=mc^2\\)',
+      '',
+      '| A | B |',
+      '| --- | --- |',
+      '| 1 | 2 |',
+      '',
+      '![ok](https://example.com/a.png "图")',
+      '',
+      '![bad](javascript:alert(1))',
+    ].join('\n'),
+    {
+      renderer,
+      escapeMarkdown: (text) => text,
+      sanitizeHtml: (html) => html.replace(/javascript:alert\(1\)/g, ''),
+    },
+  )
+
+  assert.match(html, /class="citation citation-kb"/)
+  assert.match(html, /data-chunk-id="chunk-1"/)
+  assert.match(html, /katex/)
+  assert.match(html, /<div class="chat-markdown-table"><table>/)
+  assert.match(html, /<img src="https:\/\/example\.com\/a\.png"/)
+  assert.doesNotMatch(html, /javascript:alert/)
+})
+
+test('resolveCitationChunkId maps context index to retrieval chunk UUID', () => {
+  const refs = [
+    { id: 'uuid-chunk-1', knowledge_title: 'Doc A', chunk_type: 'faq' },
+    { id: 'uuid-chunk-2', knowledge_title: 'FAQ TEST - FAQ', chunk_type: 'faq' },
+  ]
+
+  assert.equal(
+    resolveCitationChunkId('2', { doc: 'FAQ TEST - FAQ' }, refs),
+    'uuid-chunk-2',
+  )
+  assert.equal(
+    resolveCitationChunkId('FAQ-2', { doc: 'FAQ TEST - FAQ' }, refs),
+    'uuid-chunk-2',
+  )
+  assert.equal(
+    resolveCitationChunkId('uuid-chunk-1', { doc: 'Doc A' }, refs),
+    'uuid-chunk-1',
+  )
+})
+
+test('renderChatMarkdown preserves chunk UUIDs when escapeMarkdown strips UUIDs from prose', () => {
+  const renderer = createChatMarkdownRenderer({
+    imageRenderer: ({ href, text }) => `<img src="${href}" alt="${text}">`,
+    isValidImageUrl: () => true,
+  })
+  const chunkId = SAMPLE_CHUNK_PRESERVE
+  const stripUuids = (text: string) => text.replace(
+    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+    '',
+  )
+
+  const html = renderChatMarkdown(
+    `Sample text <kb doc="sample-topic.pdf" chunk_id="${chunkId}" />`,
+    {
+      renderer,
+      escapeMarkdown: stripUuids,
+      sanitizeHtml: (html) => html,
+    },
+  )
+
+  assert.match(html, /class="citation citation-kb"/)
+  assert.match(html, new RegExp(`data-chunk-id="${chunkId}"`))
+})
+
+test('renderChatMarkdown resolves indexed chunk_id when knowledge references are provided', () => {
+  const renderer = createChatMarkdownRenderer({
+    imageRenderer: ({ href, text }) => `<img src="${href}" alt="${text}">`,
+    isValidImageUrl: () => true,
+  })
+
+  const html = renderChatMarkdown(
+    'See <kb doc="Sample FAQ" chunk_id="2" />',
+    {
+      renderer,
+      escapeMarkdown: (text) => text,
+      sanitizeHtml: (html) => html,
+      knowledgeReferences: [
+        { id: 'resolved-chunk-id', knowledge_title: 'Sample FAQ', chunk_type: 'faq' },
+        { id: 'other-chunk', knowledge_title: 'Other FAQ', chunk_type: 'faq' },
+      ],
+    },
+  )
+
+  assert.match(html, /data-chunk-id="resolved-chunk-id"/)
+  assert.doesNotMatch(html, /data-chunk-id="2"/)
+})
+
+test('joinCitationTagsToPreviousLine removes blank lines before citation tags', () => {
+  const input = 'Setup is complete.\n\n<kb doc="faq.pdf" chunk_id="1" />'
+  assert.equal(joinCitationTagsToPreviousLine(input), 'Setup is complete. <kb doc="faq.pdf" chunk_id="1" />')
+})
+
+test('joinCitationTagsToPreviousLine inlines consecutive citation tags across single newlines', () => {
+  const tag1 = `<kb doc="${SAMPLE_DOC}" chunk_id="${SAMPLE_CHUNK_A}" />`
+  const tag2 = `<kb doc="${SAMPLE_DOC}" chunk_id="${SAMPLE_CHUNK_B}" />`
+  const tag3 = `<kb doc="${SAMPLE_DOC}" chunk_id="${SAMPLE_CHUNK_C}" />`
+  const input = `${tag1}\n${tag2}\n${tag3}`
+  assert.equal(joinCitationTagsToPreviousLine(input), `${tag1} ${tag2} ${tag3}`)
+})
+
+test('renderChatMarkdown inlines consecutive citation tags across newlines', () => {
+  const renderer = createChatMarkdownRenderer({
+    imageRenderer: ({ href, text }) => `<img src="${href}" alt="${text}">`,
+    isValidImageUrl: () => true,
+  })
+  const html = renderChatMarkdown(
+    [
+      `<kb doc="${SAMPLE_DOC}" chunk_id="${SAMPLE_CHUNK_A}" />`,
+      `<kb doc="${SAMPLE_DOC}" chunk_id="${SAMPLE_CHUNK_B}" />`,
+      `<kb doc="${SAMPLE_DOC}" chunk_id="${SAMPLE_CHUNK_C}" />`,
+    ].join('\n'),
+    {
+      renderer,
+      escapeMarkdown: (text) => text,
+      sanitizeHtml: (html) => html,
+    },
+  )
+
+  assert.equal((html.match(/citation-kb/g) || []).length, 3)
+  assert.doesNotMatch(html, /<\/p>\s*<p>\s*<span class="citation citation-kb"/)
+})
+
+test('joinCitationTagsToPreviousLine keeps citations on a new line after a list', () => {
+  const tag = '<kb doc="doc.pdf" chunk_id="1" />'
+  const input = `1. first\n2. second\n\n${tag}`
+  assert.equal(joinCitationTagsToPreviousLine(input), `1. first\n2. second\n\n${tag}`)
+})
+
+test('collapseStandaloneCitationParagraphs merges citations across empty paragraphs', () => {
+  const html = '<p>Steps:</p><p></p><p><span class="citation citation-kb" data-chunk-id="x">doc</span></p>'
+  const out = collapseStandaloneCitationParagraphs(html)
+  assert.match(out, /Steps:.*citation-kb/s)
+  assert.doesNotMatch(out, /<p><\/p>/)
+})

--- a/frontend/src/utils/chatMarkdownRenderer.ts
+++ b/frontend/src/utils/chatMarkdownRenderer.ts
@@ -1,0 +1,143 @@
+import { marked, type Renderer } from 'marked'
+import markedKatex from 'marked-katex-extension'
+import type { Tokens } from 'marked'
+
+import {
+  collapseStandaloneCitationParagraphs,
+  extractCitationHtmlPlaceholders,
+  joinCitationTagsToPreviousLine,
+  preserveCitationTags,
+  restoreCitationHtmlPlaceholders,
+  restoreCitationTags,
+  type CitationKnowledgeRef,
+} from './citationMarkdown.ts'
+
+const STREAMING_IMAGE_PLACEHOLDER =
+  '<span class="streaming-image-loading"><span class="streaming-image-loading__skeleton"></span></span>'
+
+let markedConfigured = false
+
+export type ImageRendererArgs = {
+  href: string
+  title: string | null
+  text: string
+}
+
+export type ChatMarkdownRendererOptions = {
+  codeRenderer?: Renderer['code']
+  imageRenderer?: (args: ImageRendererArgs) => string
+  invalidImageHtml?: (href: string) => string
+  isValidImageUrl?: (href: string) => boolean
+}
+
+export type RenderChatMarkdownOptions = {
+  renderer: Renderer
+  escapeMarkdown: (markdown: string) => string
+  sanitizeHtml: (html: string) => string
+  collapseStandaloneCitations?: boolean
+  knowledgeReferences?: CitationKnowledgeRef[] | null
+  cachedMermaidSvgHtml?: string | null
+  injectCachedMermaidSvg?: (html: string, cachedSvgHtml?: string | null) => string
+  prepareMarkdown?: (markdown: string, cachedSvgHtml?: string | null) => string
+}
+
+export function configureMarkedForChatMarkdown(): void {
+  if (markedConfigured) return
+  marked.use({ breaks: true, gfm: true })
+  marked.use(markedKatex({ throwOnError: false, nonStandard: true }))
+  markedConfigured = true
+}
+
+export function preprocessMathDelimiters(rawText: string): string {
+  if (!rawText || typeof rawText !== 'string') return ''
+  return rawText
+    .replace(/\\\[([\s\S]*?)\\\]/g, '$$$$$1$$$$')
+    .replace(/\\\(([\s\S]*?)\\\)/g, '$$$1$$')
+}
+
+export function replaceIncompleteImageWithPlaceholder(content: string): string {
+  if (!content) return ''
+
+  const lastImgStart = content.lastIndexOf('![')
+  if (lastImgStart < 0) return content
+
+  const tail = content.slice(lastImgStart)
+  const hasImageOpen = tail.startsWith('![')
+  const hasBracketClose = tail.includes(']')
+  const hasParenOpen = tail.includes('(')
+  const hasParenClose = tail.includes(')')
+  if (!hasImageOpen) return content
+
+  if (!hasBracketClose || (hasParenOpen && !hasParenClose)) {
+    return content.slice(0, lastImgStart) + STREAMING_IMAGE_PLACEHOLDER
+  }
+
+  return content
+}
+
+export function createChatMarkdownRenderer(options: ChatMarkdownRendererOptions = {}): Renderer {
+  const renderer = new marked.Renderer()
+
+  if (options.imageRenderer) {
+    renderer.image = ({ href, title, text }: Tokens.Image) => {
+      const imageHref = href || ''
+      if (options.isValidImageUrl && !options.isValidImageUrl(imageHref)) {
+        return options.invalidImageHtml?.(imageHref) ?? ''
+      }
+      return options.imageRenderer?.({
+        href: imageHref,
+        title: title || null,
+        text: text || '',
+      }) ?? ''
+    }
+  }
+
+  if (options.codeRenderer) {
+    renderer.code = options.codeRenderer
+  }
+
+  return renderer
+}
+
+export function wrapChatMarkdownTables(html: string): string {
+  if (!html || !html.includes('<table')) return html
+  return html.replace(
+    /<table\b[\s\S]*?<\/table>/gi,
+    (tableHtml) => `<div class="chat-markdown-table">${tableHtml}</div>`,
+  )
+}
+
+export function renderChatMarkdown(rawMarkdown: unknown, options: RenderChatMarkdownOptions): string {
+  const rawText = typeof rawMarkdown === 'string' ? rawMarkdown : String(rawMarkdown || '')
+  if (!rawText.trim()) return ''
+
+  configureMarkedForChatMarkdown()
+
+  const { text: tagSafe, tags } = preserveCitationTags(rawText)
+  const imageSafe = replaceIncompleteImageWithPlaceholder(tagSafe)
+  const mathSafe = preprocessMathDelimiters(imageSafe)
+  const restoredTags = restoreCitationTags(mathSafe, tags)
+  const inlineTags = joinCitationTagsToPreviousLine(restoredTags)
+  const preparedMarkdown = options.prepareMarkdown
+    ? options.prepareMarkdown(inlineTags, options.cachedMermaidSvgHtml)
+    : inlineTags
+  // Convert <kb>/<web>/wiki tags to HTML placeholders before escapeMarkdown so
+  // agent sanitizers (e.g. UUID stripping) cannot damage chunk_id attributes.
+  const { content: markdownWithPlaceholders, htmlSnippets } =
+    extractCitationHtmlPlaceholders(preparedMarkdown, options.knowledgeReferences)
+  const escapedMarkdown = options.escapeMarkdown(markdownWithPlaceholders)
+  const html = marked.parse(markdownWithPlaceholders, {
+    renderer: options.renderer,
+    breaks: true,
+    async: false,
+  }) as string
+  const restoredHtml = restoreCitationHtmlPlaceholders(html, htmlSnippets)
+  const citationHtml = options.collapseStandaloneCitations === false
+    ? restoredHtml
+    : collapseStandaloneCitationParagraphs(restoredHtml)
+  const tableWrappedHtml = wrapChatMarkdownTables(citationHtml)
+  const sanitized = options.sanitizeHtml(tableWrappedHtml)
+  return options.injectCachedMermaidSvg
+    ? options.injectCachedMermaidSvg(sanitized, options.cachedMermaidSvgHtml)
+    : sanitized
+}

--- a/frontend/src/utils/chatMessageShared.ts
+++ b/frontend/src/utils/chatMessageShared.ts
@@ -1,6 +1,9 @@
 import i18n from '@/i18n';
+import { buildMermaidBlockHtml, buildMermaidLoadingHtml } from '@/utils/markdownEnhancements';
 
 const STREAMING_IMAGE_PLACEHOLDER = '<span class="streaming-image-loading"><span class="streaming-image-loading__skeleton"></span></span>';
+const STREAMING_MERMAID_PLACEHOLDER = buildMermaidLoadingHtml();
+const MERMAID_FENCE_START = '```mermaid';
 
 export const replaceIncompleteImageWithPlaceholder = (content: string): string => {
   if (!content) return '';
@@ -21,6 +24,65 @@ export const replaceIncompleteImageWithPlaceholder = (content: string): string =
   }
 
   return content;
+};
+
+/** Hide an unclosed trailing ```mermaid fence while streaming to avoid layout jitter. */
+export const replaceIncompleteMermaidWithPlaceholder = (content: string): string => {
+  if (!content) return '';
+
+  const start = content.lastIndexOf(MERMAID_FENCE_START);
+  if (start < 0) return content;
+
+  const tail = content.slice(start + MERMAID_FENCE_START.length);
+  if (tail.includes('```')) return content;
+
+  return content.slice(0, start) + STREAMING_MERMAID_PLACEHOLDER;
+};
+
+const MERMAID_BLOCK_RE = /```mermaid[\s\S]*?```/;
+
+/** Keep mermaid as a stable placeholder for the whole stream; render once at the end. */
+export const maskMermaidBlocksForStreaming = (content: string): string => {
+  if (!content) return '';
+  const masked = content.replace(MERMAID_BLOCK_RE, STREAMING_MERMAID_PLACEHOLDER);
+  return replaceIncompleteMermaidWithPlaceholder(masked);
+};
+
+export const hasCompleteMermaidBlock = (content: string): boolean => {
+  return MERMAID_BLOCK_RE.test(content);
+};
+
+/** While streaming: loading placeholder for mermaid; swap to cached SVG after sanitize. */
+export const prepareStreamingMermaidMarkdown = (
+  content: string,
+  _cachedSvgHtml?: string | null,
+): string => {
+  if (!content) return '';
+
+  if (hasCompleteMermaidBlock(content)) {
+    return maskMermaidBlocksForStreaming(content);
+  }
+
+  return replaceIncompleteMermaidWithPlaceholder(content);
+};
+
+export const extractFirstMermaidCode = (content: string): string | null => {
+  const match = content.match(/```mermaid([\s\S]*?)```/);
+  return match?.[1]?.trim() || null;
+};
+
+const STREAMING_MERMAID_LOADING_RE = /<div class="chat-mermaid-block[^"]*"[^>]*>[\s\S]*?<div class="streaming-mermaid-loading"[^>]*>[\s\S]*?<\/div>[\s\S]*?<\/div>/g;
+
+/** Inject trusted Mermaid SVG after DOMPurify, replacing the streaming loading shell. */
+export const injectCachedMermaidSvg = (
+  html: string,
+  cachedSvgHtml: string | null | undefined,
+): string => {
+  if (!html || !cachedSvgHtml) return html;
+  return html.replace(
+    STREAMING_MERMAID_LOADING_RE,
+    buildMermaidBlockHtml(cachedSvgHtml, 'data-mermaid="cached"'),
+  );
 };
 
 export const formatManualTitle = (question?: string): string => {

--- a/frontend/src/utils/citationChunkCache.test.mjs
+++ b/frontend/src/utils/citationChunkCache.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  clearCitationChunkCache,
+  getCitationChunkCache,
+  makeCitationCacheKey,
+  setCitationChunkCache,
+} from './citationChunkCache.ts'
+
+test('makeCitationCacheKey combines scope and chunkId', () => {
+  assert.equal(makeCitationCacheKey('session-1', 'chunk-a'), 'session-1::chunk-a')
+  assert.equal(
+    makeCitationCacheKey('embed:ch:tok', 'chunk-b'),
+    'embed:ch:tok::chunk-b',
+  )
+})
+
+test('get/set are isolated per scope', () => {
+  clearCitationChunkCache()
+  setCitationChunkCache('session-1', 'chunk-a', { content: 'one' })
+  setCitationChunkCache('session-2', 'chunk-a', { content: 'two' })
+
+  assert.equal(getCitationChunkCache('session-1', 'chunk-a')?.content, 'one')
+  assert.equal(getCitationChunkCache('session-2', 'chunk-a')?.content, 'two')
+})
+
+test('clearCitationChunkCache clears one scope or all', () => {
+  clearCitationChunkCache()
+  setCitationChunkCache('session-1', 'chunk-a', { content: 'one' })
+  setCitationChunkCache('session-2', 'chunk-a', { content: 'two' })
+
+  clearCitationChunkCache('session-1')
+  assert.equal(getCitationChunkCache('session-1', 'chunk-a'), undefined)
+  assert.equal(getCitationChunkCache('session-2', 'chunk-a')?.content, 'two')
+
+  clearCitationChunkCache()
+  assert.equal(getCitationChunkCache('session-2', 'chunk-a'), undefined)
+})

--- a/frontend/src/utils/citationChunkCache.ts
+++ b/frontend/src/utils/citationChunkCache.ts
@@ -1,0 +1,35 @@
+export type CitationChunkCacheValue = { content: string; error?: string }
+
+const chunkCache = new Map<string, CitationChunkCacheValue>()
+
+export function makeCitationCacheKey(scope: string, chunkId: string): string {
+  return `${scope}::${chunkId}`
+}
+
+export function getCitationChunkCache(
+  scope: string,
+  chunkId: string,
+): CitationChunkCacheValue | undefined {
+  return chunkCache.get(makeCitationCacheKey(scope, chunkId))
+}
+
+export function setCitationChunkCache(
+  scope: string,
+  chunkId: string,
+  value: CitationChunkCacheValue,
+): void {
+  chunkCache.set(makeCitationCacheKey(scope, chunkId), value)
+}
+
+export function clearCitationChunkCache(scope?: string): void {
+  if (scope === undefined) {
+    chunkCache.clear()
+    return
+  }
+  const prefix = `${scope}::`
+  for (const key of chunkCache.keys()) {
+    if (key.startsWith(prefix)) {
+      chunkCache.delete(key)
+    }
+  }
+}

--- a/frontend/src/utils/citationMarkdown.ts
+++ b/frontend/src/utils/citationMarkdown.ts
@@ -1,6 +1,22 @@
 /** Shared citation tag preprocessing for chat markdown (QA + agent). */
 
+/** Self-closing or unclosed `<kb/>` / `<web/>` tags from model output. */
+export const KB_WEB_TAG_RE = /<(?:kb|web)\b[^>]*?\s*\/?>/g
+const KB_TAG_ATTR_RE = /<kb\b([^>]*?)\s*\/?>/g
+const WEB_TAG_ATTR_RE = /<web\b([^>]*?)\s*\/?>/g
+
 const ATTRIBUTE_REGEX = /([\w-]+)\s*=\s*"([^"]*)"/g
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export type CitationKnowledgeRef = {
+  id?: string
+  knowledge_id?: string
+  knowledge_title?: string
+  knowledge_filename?: string
+  chunk_index?: number
+  chunk_type?: string
+  knowledge_base_id?: string
+}
 
 function parseTagAttributes(attrString: string): Record<string, string> {
   const attributes: Record<string, string> = {}
@@ -30,12 +46,88 @@ function truncateMiddle(text: string, maxLength = 13): string {
   return `${start}...${end}`
 }
 
+function normalizeDocTitle(title: string): string {
+  return title.trim().toLowerCase()
+}
+
+function docTitlesMatch(a: string, b: string): boolean {
+  if (!a || !b) return false
+  const na = normalizeDocTitle(a)
+  const nb = normalizeDocTitle(b)
+  return na === nb || na.includes(nb) || nb.includes(na)
+}
+
+/** Map model context index (1, FAQ-1, DOC-2) to the real chunk UUID from retrieval results. */
+export function resolveCitationChunkId(
+  rawChunkId: string,
+  attrs: { doc?: string; kbId?: string },
+  refs?: CitationKnowledgeRef[] | null,
+): string {
+  const raw = String(rawChunkId || '').trim()
+  if (!raw || UUID_RE.test(raw)) return raw
+
+  const list = (refs || []).filter((r) => r && r.chunk_type !== 'web_search')
+  if (!list.length) return raw
+
+  const doc = (attrs.doc || '').trim()
+  const kbId = (attrs.kbId || '').trim()
+
+  if (doc) {
+    const byDoc = list.find(
+      (r) =>
+        docTitlesMatch(doc, r.knowledge_title || '') ||
+        docTitlesMatch(doc, r.knowledge_filename || ''),
+    )
+    if (byDoc?.id) return byDoc.id
+  }
+
+  const faqMatch = raw.match(/^FAQ-(\d+)$/i)
+  if (faqMatch) {
+    const faqRefs = list.filter((r) => r.chunk_type === 'faq')
+    const hit = faqRefs[parseInt(faqMatch[1], 10) - 1]
+    if (hit?.id) return hit.id
+  }
+
+  const docMatch = raw.match(/^DOC-(\d+)$/i)
+  if (docMatch) {
+    const docRefs = list.filter((r) => r.chunk_type !== 'faq')
+    const hit = docRefs[parseInt(docMatch[1], 10) - 1]
+    if (hit?.id) return hit.id
+  }
+
+  const num = parseInt(raw, 10)
+  if (!Number.isNaN(num) && String(num) === raw) {
+    const byPos = list[num - 1]
+    if (byPos?.id) return byPos.id
+    const byChunkIndex = list.find((r) => r.chunk_index === num || r.chunk_index === num - 1)
+    if (byChunkIndex?.id) return byChunkIndex.id
+  }
+
+  if (kbId) {
+    const scoped = list.filter((r) => r.knowledge_base_id === kbId)
+    if (doc) {
+      const byDoc = scoped.find(
+        (r) =>
+          docTitlesMatch(doc, r.knowledge_title || '') ||
+          docTitlesMatch(doc, r.knowledge_filename || ''),
+      )
+      if (byDoc?.id) return byDoc.id
+    }
+    if (scoped.length === 1 && scoped[0].id) return scoped[0].id
+  }
+
+  return raw
+}
+
 /** Convert <web/> / <kb/> / [[wiki]] tags into inline citation HTML. */
-export function preprocessCitationTags(contentStr: string): string {
+export function preprocessCitationTags(
+  contentStr: string,
+  refs?: CitationKnowledgeRef[] | null,
+): string {
   if (!contentStr.trim()) return ''
 
   return contentStr
-    .replace(/<web\b([^>]*)\/>/g, (_m, attrString: string) => {
+    .replace(WEB_TAG_ATTR_RE, (_m, attrString: string) => {
       const attrs = parseTagAttributes(attrString)
       const url = attrs.url || ''
       const title = attrs.title || ''
@@ -52,20 +144,21 @@ export function preprocessCitationTags(contentStr: string): string {
       }
       const safeTitle = escapeHtml(title)
       const safeUrl = escapeHtml(url)
-      return `<a class="citation citation-web" data-url="${safeUrl}" href="${safeUrl}" target="_blank" rel="noopener noreferrer"><span class="citation-icon web"></span><span class="citation-domain">${domain}</span><span class="citation-tip"><span class="tip-title">${safeTitle}</span><span class="tip-url">${safeUrl}</span></span></a>`
+      return `<a class="citation citation-web" data-url="${safeUrl}" href="${safeUrl}" target="_blank" rel="noopener noreferrer"><span class="citation-icon citation-icon--web" aria-hidden="true"></span><span class="citation-domain">${domain}</span><span class="citation-tip"><span class="tip-title">${safeTitle}</span><span class="tip-url">${safeUrl}</span></span></a>`
     })
-    .replace(/<kb\b([^>]*)\/>/g, (_m, attrString: string) => {
+    .replace(KB_TAG_ATTR_RE, (_m, attrString: string) => {
       const attrs = parseTagAttributes(attrString)
       const doc = attrs.doc || ''
-      const chunkId = attrs.chunk_id || attrs.chunkId || ''
+      const rawChunkId = attrs.chunk_id || attrs.chunkId || ''
       const kbId = attrs.kb_id || attrs.kbId || ''
+      const chunkId = resolveCitationChunkId(rawChunkId, { doc, kbId }, refs)
       if (!doc || !chunkId) return ''
 
       const safeDoc = escapeHtml(doc)
       const safeKbId = escapeHtml(kbId)
       const safeChunkId = escapeHtml(chunkId)
       const displayDoc = escapeHtml(truncateMiddle(doc))
-      return `<span class="citation citation-kb" data-kb-id="${safeKbId}" data-chunk-id="${safeChunkId}" data-doc="${safeDoc}" role="button" tabindex="0"><span class="citation-icon kb"></span><span class="citation-text">${displayDoc}</span><span class="citation-tip"><span class="tip-loading">…</span></span></span>`
+      return `<span class="citation citation-kb" data-kb-id="${safeKbId}" data-chunk-id="${safeChunkId}" data-doc="${safeDoc}" role="button" tabindex="0"><span class="citation-icon citation-icon--book" aria-hidden="true"></span><span class="citation-text">${displayDoc}</span><span class="citation-tip"><span class="tip-loading">…</span></span></span>`
     })
     .replace(/\[\[([^\]]+)\]\]/g, (match, inner: string) => {
       const pipeIdx = inner.indexOf('|')
@@ -85,7 +178,10 @@ export function preprocessCitationTags(contentStr: string): string {
 const HTML_PLACEHOLDER_RE = /@@WEKNORA_HTML_PLACEHOLDER_(\d+)@@/g
 
 /** Protect citation HTML from markdown parser; restore after marked.parse. */
-export function extractCitationHtmlPlaceholders(contentStr: string): { content: string; htmlSnippets: string[] } {
+export function extractCitationHtmlPlaceholders(
+  contentStr: string,
+  refs?: CitationKnowledgeRef[] | null,
+): { content: string; htmlSnippets: string[] } {
   const htmlSnippets: string[] = []
   const storeHtml = (html: string): string => {
     const idx = htmlSnippets.length
@@ -94,8 +190,8 @@ export function extractCitationHtmlPlaceholders(contentStr: string): { content: 
   }
 
   const content = contentStr
-    .replace(/<(?:kb|web)\b[^>]*\/>/g, (match) => storeHtml(preprocessCitationTags(match)))
-    .replace(/\[\[([^\]]+)\]\]/g, (match) => storeHtml(preprocessCitationTags(match)))
+    .replace(KB_WEB_TAG_RE, (match) => storeHtml(preprocessCitationTags(match, refs)))
+    .replace(/\[\[([^\]]+)\]\]/g, (match) => storeHtml(preprocessCitationTags(match, refs)))
 
   return { content, htmlSnippets }
 }
@@ -105,10 +201,67 @@ export function restoreCitationHtmlPlaceholders(html: string, htmlSnippets: stri
   return html.replace(HTML_PLACEHOLDER_RE, (_match, idx) => htmlSnippets[Number(idx)] || '')
 }
 
+/** Collapse newlines around <kb/> / <web/> so marked keeps citations inline. */
+export function joinCitationTagsToPreviousLine(content: string): string {
+  if (!content) return content
+
+  let result = content
+
+  // Newlines between consecutive citation tags
+  let prev = ''
+  while (result !== prev) {
+    prev = result
+    result = result.replace(
+      /(<(?:kb|web)\b[^>]*?\s*\/?>)\s*\n+\s*(<(?:kb|web)\b)/gi,
+      '$1 $2',
+    )
+  }
+
+  // Blank lines before citations: join to previous prose, but keep a break after lists
+  result = result.replace(/\n[ \t]*\n+([ \t]*<(?:kb|web)\b)/gi, (match, kbStart, offset, full) => {
+    const before = full.slice(0, offset)
+    const lastLine = before.split('\n').filter((line) => line.trim()).pop() || ''
+    const isListItem = /^\s*(\d+\.|[-*+])\s+\S/.test(lastLine)
+    return isListItem ? `\n\n${kbStart}` : ` ${kbStart}`
+  })
+
+  // Single newline before citation when it follows text or another citation (not after a blank line)
+  result = result.replace(
+    /(?<!\n)(<(?:kb|web)\b[^>]*?\s*\/?>|[ \t]*\S[^\n]*?)\n([ \t]*<(?:kb|web)\b)/g,
+    '$1 $2',
+  )
+
+  return result
+}
+
+const CITATION_HTML_FRAGMENT =
+  '(?:<span class="citation\\b[^]*?</span>|<a class="citation\\b[^]*?</a>)'
+
+/** Merge citation-only <p> blocks into the preceding paragraph (marked splits on newlines). */
+export function collapseStandaloneCitationParagraphs(html: string): string {
+  if (!html || !html.includes('citation')) return html
+
+  const mergePattern = new RegExp(
+    `(<\\/(?:p|li)>)\\s*(?:<p>\\s*<\\/p>\\s*)*<p>\\s*(${CITATION_HTML_FRAGMENT})\\s*<\\/p>`,
+    'g',
+  )
+
+  let result = html
+  let prev = ''
+  while (result !== prev) {
+    prev = result
+    result = result.replace(mergePattern, (_match, closeTag: string, citation: string) => {
+      return ` ${citation}${closeTag}`
+    })
+  }
+
+  return result
+}
+
 /** Preserve raw <kb>/<web> tags before sanitizers that would strip them. */
 export function preserveCitationTags(contentStr: string): { text: string; tags: string[] } {
   const tags: string[] = []
-  const text = contentStr.replace(/<(?:kb|web)\b[^>]*\/>/g, (match) => {
+  const text = contentStr.replace(KB_WEB_TAG_RE, (match) => {
     const idx = tags.length
     tags.push(match)
     return `\x00TAG${idx}\x00`

--- a/frontend/src/utils/markdownDomPurify.test.mjs
+++ b/frontend/src/utils/markdownDomPurify.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  domPurifyAllowedUriRegexp,
+  markdownDomPurifyConfig,
+} from './markdownDomPurify.ts';
+
+test('markdownDomPurifyConfig FORBID_TAGS includes script', () => {
+  assert.ok(Array.isArray(markdownDomPurifyConfig.FORBID_TAGS));
+  assert.ok(markdownDomPurifyConfig.FORBID_TAGS.includes('script'));
+});
+
+test('ALLOWED_URI_REGEXP allows s3:// and rejects javascript:', () => {
+  const re = markdownDomPurifyConfig.ALLOWED_URI_REGEXP ?? domPurifyAllowedUriRegexp;
+  assert.match('s3://bucket/key', re);
+  assert.doesNotMatch('javascript:alert(1)', re);
+});

--- a/frontend/src/utils/markdownDomPurify.ts
+++ b/frontend/src/utils/markdownDomPurify.ts
@@ -1,0 +1,83 @@
+export const domPurifyForbidTags = ['script', 'style', 'object', 'embed', 'form', 'input'] as const;
+export const domPurifyForbidAttr = ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'onblur'] as const;
+
+export const domPurifyAllowedUriRegexp =
+  /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp):|(?:local|minio|cos|tos|s3|oss|ks3|obs):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;
+
+/** Shared DOMPurify security options (FORBID_*, URI scheme, DOM flags). */
+export const domPurifySecurityOptions = {
+  ALLOWED_URI_REGEXP: domPurifyAllowedUriRegexp,
+  FORBID_TAGS: [...domPurifyForbidTags],
+  FORBID_ATTR: [...domPurifyForbidAttr],
+  KEEP_CONTENT: true,
+  RETURN_DOM: false,
+  RETURN_DOM_FRAGMENT: false,
+  RETURN_DOM_IMPORT: false,
+  SANITIZE_DOM: true,
+  SANITIZE_NAMED_PROPS: true,
+  WHOLE_DOCUMENT: false,
+} as const;
+
+/** Shared DOMPurify hooks: strip scripts/event attrs; noopener links; alt on images. */
+export const domPurifySecurityHooks = {
+  beforeSanitizeElements: (currentNode: Element) => {
+    if (currentNode.tagName === 'SCRIPT') {
+      currentNode.remove();
+      return null;
+    }
+    domPurifyForbidAttr.forEach((attr) => {
+      if (currentNode.hasAttribute(attr)) {
+        currentNode.removeAttribute(attr);
+      }
+    });
+  },
+  afterSanitizeElements: (currentNode: Element) => {
+    if (currentNode.tagName === 'A') {
+      const href = currentNode.getAttribute('href');
+      if (href && href.startsWith('http')) {
+        currentNode.setAttribute('rel', 'noopener noreferrer');
+        currentNode.setAttribute('target', '_blank');
+      }
+    }
+    if (currentNode.tagName === 'IMG' && !currentNode.getAttribute('alt')) {
+      currentNode.setAttribute('alt', '');
+    }
+  },
+};
+
+/** Shared DOMPurify config for chat / dev markdown (KaTeX + Mermaid SVG). */
+export const markdownDomPurifyConfig = {
+  ALLOWED_TAGS: [
+    'p', 'br', 'strong', 'em', 'u', 'code', 'pre', 'ul', 'ol', 'li', 'blockquote',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'a', 'span', 'table', 'thead', 'tbody',
+    'tr', 'th', 'td', 'img', 'figure', 'figcaption', 'div',
+    'svg', 'g', 'path', 'rect', 'circle', 'ellipse', 'line', 'polygon',
+    'polyline', 'text', 'tspan', 'defs', 'marker', 'filter', 'use',
+    'clippath', 'lineargradient', 'radialgradient', 'stop', 'pattern',
+    'image', 'foreignobject', 'desc', 'title', 'switch', 'symbol', 'mask',
+    'math', 'annotation', 'semantics', 'mo', 'mi', 'mn', 'msup', 'mrow', 'mfrac', 'msqrt', 'mroot', 'mstyle',
+    'button',
+  ],
+  ALLOWED_ATTR: [
+    'href', 'title', 'target', 'rel', 'data-tooltip', 'data-url', 'data-kb-id',
+    'data-chunk-id', 'data-doc', 'data-slug', 'class', 'role', 'tabindex', 'src', 'alt', 'data-protected-src',
+    'width', 'height', 'style', 'id', 'type', 'aria-label', 'data-mermaid', 'disabled',
+    'd', 'fill', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin',
+    'stroke-dasharray', 'stroke-dashoffset', 'stroke-miterlimit', 'stroke-opacity',
+    'fill-opacity', 'opacity', 'transform', 'viewbox', 'preserveaspectratio',
+    'x', 'y', 'x1', 'y1', 'x2', 'y2', 'cx', 'cy', 'rx', 'ry', 'r',
+    'dx', 'dy', 'text-anchor', 'dominant-baseline', 'font-family', 'font-size',
+    'font-weight', 'font-style', 'letter-spacing', 'word-spacing',
+    'marker-start', 'marker-mid', 'marker-end', 'markerunits', 'markerwidth',
+    'markerheight', 'refx', 'refy', 'orient', 'points', 'offset',
+    'gradientunits', 'gradienttransform', 'spreadmethod', 'stop-color', 'stop-opacity',
+    'patternunits', 'patterntransform', 'clippathunits', 'maskunits',
+    'filterunits', 'primitiveunits', 'xmlns', 'xmlns:xlink', 'xlink:href',
+    'version', 'baseprofile', 'enable-background', 'overflow', 'visibility',
+    'display', 'pointer-events', 'cursor', 'data-emit', 'direction',
+    'mathvariant', 'encoding', 'aria-hidden',
+  ],
+  USE_PROFILES: { html: true, svg: true, mathMl: true },
+  ...domPurifySecurityOptions,
+  HOOKS: domPurifySecurityHooks,
+};

--- a/frontend/src/utils/markdownEnhancements.ts
+++ b/frontend/src/utils/markdownEnhancements.ts
@@ -1,0 +1,231 @@
+import i18n from '@/i18n';
+import hljs from 'highlight.js';
+import { openMermaidFullscreen } from '@/utils/mermaidViewer';
+
+const ENHANCE_FLAG = 'data-markdown-enhancements';
+const boundMarkdownRoots = new WeakSet<HTMLElement>();
+
+const MERMAID_DIAGRAM_SVG_SELECTOR = '.chat-mermaid-block__canvas svg, pre.mermaid svg';
+
+function getMermaidDiagramSvg(block: Element | null | undefined): SVGElement | null {
+  if (!block) return null;
+  const svg = block.querySelector(MERMAID_DIAGRAM_SVG_SELECTOR);
+  return svg instanceof SVGElement ? svg : null;
+}
+
+function openMermaidFromBlock(block: Element | null | undefined): void {
+  const svg = getMermaidDiagramSvg(block);
+  if (svg) openMermaidFullscreen(svg.outerHTML);
+}
+
+export function syncMermaidExpandButtons(root: HTMLElement | null | undefined): void {
+  if (!root) return;
+  root.querySelectorAll<HTMLElement>('.chat-mermaid-block').forEach((block) => {
+    const expandBtn = block.querySelector<HTMLButtonElement>('.chat-mermaid-block__expand');
+    if (!expandBtn) return;
+    const hasSvg = !!getMermaidDiagramSvg(block);
+    expandBtn.disabled = !hasSvg;
+    expandBtn.classList.toggle('is-disabled', !hasSvg);
+  });
+}
+
+const COPY_ICON = '<svg class="chat-code-block__copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+
+const EXPAND_ICON = '<svg class="chat-mermaid-block__expand-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M21 8V5a2 2 0 0 0-2-2h-3"/><path d="M3 16v3a2 2 0 0 0 2 2h3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/></svg>';
+
+const LANG_LABELS: Record<string, string> = {
+  js: 'JavaScript',
+  javascript: 'JavaScript',
+  ts: 'TypeScript',
+  typescript: 'TypeScript',
+  py: 'Python',
+  python: 'Python',
+  go: 'Go',
+  rust: 'Rust',
+  java: 'Java',
+  kotlin: 'Kotlin',
+  swift: 'Swift',
+  rb: 'Ruby',
+  ruby: 'Ruby',
+  php: 'PHP',
+  cs: 'C#',
+  cpp: 'C++',
+  c: 'C',
+  sql: 'SQL',
+  bash: 'Bash',
+  sh: 'Shell',
+  shell: 'Shell',
+  json: 'JSON',
+  yaml: 'YAML',
+  yml: 'YAML',
+  xml: 'XML',
+  html: 'HTML',
+  css: 'CSS',
+  markdown: 'Markdown',
+  md: 'Markdown',
+};
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+export function formatCodeLang(lang: string): string {
+  const normalized = (lang || 'Code').trim();
+  if (!normalized) return 'Code';
+  const key = normalized.toLowerCase();
+  return LANG_LABELS[key] || normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
+export function buildCodeBlockHtml(
+  lang: string,
+  highlighted: string,
+  highlightLang: string,
+): string {
+  const displayLang = escapeHtml(formatCodeLang(lang));
+  const copyLabel = escapeHtml(i18n.global.t('embedPublish.copyCode'));
+  const safeLang = escapeHtml(highlightLang || lang || 'text');
+  return `<div class="chat-code-block">
+    <div class="chat-code-block__header">
+      <span class="chat-code-block__lang">${displayLang}</span>
+      <div class="chat-code-block__actions">
+        <button type="button" class="chat-code-block__copy" aria-label="${copyLabel}" title="${copyLabel}">
+          ${COPY_ICON}<span class="chat-code-block__copy-text">${copyLabel}</span>
+        </button>
+      </div>
+    </div>
+    <pre class="chat-code-block__pre"><code class="hljs language-${safeLang}">${highlighted}</code></pre>
+  </div>`;
+}
+
+export function buildMermaidBlockHtml(innerHtml: string, preAttrs = ''): string {
+  const label = escapeHtml(i18n.global.t('mermaid.diagram'));
+  const expandLabel = escapeHtml(i18n.global.t('mermaid.expand'));
+  const attrs = preAttrs ? ` ${preAttrs}` : '';
+  return `<div class="chat-mermaid-block">
+    <div class="chat-mermaid-block__header">
+      <span class="chat-mermaid-block__badge">${label}</span>
+      <div class="chat-mermaid-block__actions">
+        <button type="button" class="chat-mermaid-block__expand" aria-label="${expandLabel}" title="${expandLabel}">${EXPAND_ICON}</button>
+      </div>
+    </div>
+    <pre class="chat-mermaid-block__canvas mermaid"${attrs}>${innerHtml}</pre>
+  </div>`;
+}
+
+export function buildMermaidLoadingHtml(): string {
+  const label = escapeHtml(i18n.global.t('mermaid.diagram'));
+  return `<div class="chat-mermaid-block chat-mermaid-block--loading">
+    <div class="chat-mermaid-block__header">
+      <span class="chat-mermaid-block__badge">${label}</span>
+    </div>
+    <div class="streaming-mermaid-loading" aria-hidden="true"><span class="streaming-mermaid-loading__skeleton"></span></div>
+  </div>`;
+}
+
+async function handleCodeCopy(btn: HTMLButtonElement): Promise<void> {
+  const code = btn.closest('.chat-code-block')?.querySelector('code')?.textContent ?? '';
+  if (!code) return;
+
+  const textEl = btn.querySelector<HTMLElement>('.chat-code-block__copy-text');
+  const copiedLabel = i18n.global.t('common.copied');
+  const defaultLabel = i18n.global.t('embedPublish.copyCode');
+
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(code);
+    } else {
+      const textArea = document.createElement('textarea');
+      textArea.value = code;
+      textArea.style.position = 'fixed';
+      textArea.style.opacity = '0';
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+    }
+    btn.classList.add('is-copied');
+    if (textEl) textEl.textContent = copiedLabel;
+    window.setTimeout(() => {
+      btn.classList.remove('is-copied');
+      if (textEl) textEl.textContent = defaultLabel;
+    }, 1600);
+  } catch {
+    btn.classList.add('is-error');
+    window.setTimeout(() => btn.classList.remove('is-error'), 1600);
+  }
+}
+
+export function highlightCodeBlocksInContainer(root: HTMLElement | null | undefined): void {
+  if (!root) return;
+
+  root.querySelectorAll<HTMLElement>('.chat-code-block__pre code').forEach((codeEl) => {
+    if (codeEl.querySelector('span[class^="hljs-"], span.hljs')) return;
+    const language = [...codeEl.classList]
+      .find((cls) => cls.startsWith('language-'))
+      ?.slice('language-'.length);
+    if (language && hljs.getLanguage(language)) {
+      try {
+        codeEl.innerHTML = hljs.highlight(codeEl.textContent || '', { language }).value;
+        codeEl.classList.add('hljs');
+        return;
+      } catch {
+        // fall through
+      }
+    }
+    hljs.highlightElement(codeEl);
+  });
+}
+
+export function refreshMarkdownEnhancements(root: HTMLElement | null | undefined): void {
+  if (!root) return;
+  highlightCodeBlocksInContainer(root);
+  syncMermaidExpandButtons(root);
+}
+
+export function attachMarkdownEnhancementListeners(
+  root: HTMLElement | null | undefined,
+): void {
+  if (!root || boundMarkdownRoots.has(root)) return;
+  boundMarkdownRoots.add(root);
+  root.setAttribute(ENHANCE_FLAG, 'true');
+
+  const onClick = (event: Event) => {
+    const target = event.target as HTMLElement;
+
+    const copyBtn = target.closest<HTMLButtonElement>('.chat-code-block__copy');
+    if (copyBtn) {
+      event.preventDefault();
+      event.stopPropagation();
+      void handleCodeCopy(copyBtn);
+      return;
+    }
+
+    const expandBtn = target.closest<HTMLButtonElement>('.chat-mermaid-block__expand');
+    if (expandBtn) {
+      event.preventDefault();
+      event.stopPropagation();
+      if (expandBtn.disabled) return;
+      openMermaidFromBlock(expandBtn.closest('.chat-mermaid-block'));
+      return;
+    }
+
+    const canvas = target.closest<HTMLElement>(
+      '.chat-mermaid-block__canvas[data-mermaid="true"], .chat-mermaid-block__canvas[data-mermaid="cached"], pre.mermaid[data-mermaid="true"], pre.mermaid[data-mermaid="cached"]',
+    );
+    if (canvas && !target.closest('button')) {
+      const svg = canvas.querySelector('svg');
+      if (svg) {
+        event.preventDefault();
+        event.stopPropagation();
+        openMermaidFullscreen(svg.outerHTML);
+      }
+    }
+  };
+
+  root.addEventListener('click', onClick, true);
+  syncMermaidExpandButtons(root);
+}

--- a/frontend/src/utils/mermaidShared.ts
+++ b/frontend/src/utils/mermaidShared.ts
@@ -1,37 +1,155 @@
 import type { Tokens } from 'marked'
+import hljs from 'highlight.js'
+import 'highlight.js/styles/github.css'
 import { openMermaidFullscreen } from '@/utils/mermaidViewer.ts'
+import {
+  buildCodeBlockHtml,
+  buildMermaidBlockHtml,
+  attachMarkdownEnhancementListeners,
+  highlightCodeBlocksInContainer,
+  syncMermaidExpandButtons,
+} from '@/utils/markdownEnhancements'
+
+hljs.registerAliases('mermaid', { languageName: 'plaintext' })
 
 let mermaidMod: typeof import('mermaid') | null = null
-let hljsMod: typeof import('highlight.js') | null = null
 let mermaidInitialized = false
 let initPromise: Promise<void> | null = null
-let hljsPromise: Promise<typeof import('highlight.js').default> | null = null
+
+const MERMAID_LIGHT_THEME = {
+  darkMode: false,
+  background: '#ffffff',
+  primaryColor: '#e2e8f0',
+  primaryTextColor: '#334155',
+  primaryBorderColor: '#94a3b8',
+  secondaryColor: '#f1f5f9',
+  secondaryTextColor: '#475569',
+  secondaryBorderColor: '#cbd5e1',
+  tertiaryColor: '#f8fafc',
+  tertiaryTextColor: '#64748b',
+  tertiaryBorderColor: '#e2e8f0',
+  lineColor: '#94a3b8',
+  textColor: '#334155',
+  mainBkg: '#ffffff',
+  nodeBorder: '#94a3b8',
+  clusterBkg: '#f8fafc',
+  clusterBorder: '#cbd5e1',
+  titleColor: '#1e293b',
+  edgeLabelBackground: '#ffffff',
+  actorBorder: '#94a3b8',
+  actorBkg: '#f1f5f9',
+  actorTextColor: '#334155',
+  actorLineColor: '#94a3b8',
+  signalColor: '#94a3b8',
+  labelBoxBkgColor: '#f1f5f9',
+  labelBoxBorderColor: '#cbd5e1',
+  labelTextColor: '#334155',
+  loopTextColor: '#475569',
+  noteBkgColor: '#f8fafc',
+  noteTextColor: '#475569',
+  noteBorderColor: '#cbd5e1',
+  // Gantt
+  sectionBkgColor: '#f8fafc',
+  altSectionBkgColor: '#ffffff',
+  gridColor: '#e2e8f0',
+  todayLineColor: '#64748b',
+  taskBorderColor: '#94a3b8',
+  taskBkgColor: '#e2e8f0',
+  activeTaskBorderColor: '#64748b',
+  activeTaskBkgColor: '#94a3b8',
+  doneTaskBkgColor: '#cbd5e1',
+  doneTaskBorderColor: '#94a3b8',
+  critBkgColor: '#fecaca',
+  critBorderColor: '#f87171',
+  fontSize: '14px',
+}
+
+const MERMAID_DARK_THEME = {
+  darkMode: true,
+  background: '#1a1f28',
+  primaryColor: '#475569',
+  primaryTextColor: '#e2e8f0',
+  primaryBorderColor: '#64748b',
+  secondaryColor: '#334155',
+  secondaryTextColor: '#cbd5e1',
+  secondaryBorderColor: '#64748b',
+  tertiaryColor: '#1e293b',
+  tertiaryTextColor: '#94a3b8',
+  tertiaryBorderColor: '#475569',
+  lineColor: '#64748b',
+  textColor: '#e2e8f0',
+  mainBkg: '#1e293b',
+  nodeBorder: '#64748b',
+  clusterBkg: '#1a2332',
+  clusterBorder: '#475569',
+  titleColor: '#f1f5f9',
+  edgeLabelBackground: '#1e293b',
+  actorBorder: '#64748b',
+  actorBkg: '#1e293b',
+  actorTextColor: '#f1f5f9',
+  actorLineColor: '#64748b',
+  signalColor: '#64748b',
+  labelBoxBkgColor: '#334155',
+  labelBoxBorderColor: '#64748b',
+  labelTextColor: '#e2e8f0',
+  loopTextColor: '#cbd5e1',
+  noteBkgColor: '#334155',
+  noteTextColor: '#e2e8f0',
+  noteBorderColor: '#64748b',
+  // Gantt
+  sectionBkgColor: '#1a2332',
+  altSectionBkgColor: '#1e293b',
+  gridColor: '#334155',
+  todayLineColor: '#94a3b8',
+  taskBorderColor: '#64748b',
+  taskBkgColor: '#475569',
+  activeTaskBorderColor: '#94a3b8',
+  activeTaskBkgColor: '#64748b',
+  doneTaskBkgColor: '#334155',
+  doneTaskBorderColor: '#64748b',
+  critBkgColor: '#7f1d1d',
+  critBorderColor: '#ef4444',
+  fontSize: '14px',
+}
+
+function resolveMermaidThemeVariables() {
+  const isDark = document.documentElement.getAttribute('theme-mode') === 'dark'
+  return isDark ? MERMAID_DARK_THEME : MERMAID_LIGHT_THEME
+}
 
 const MERMAID_CONFIG = {
   startOnLoad: false,
-  theme: 'default',
-  securityLevel: 'strict',
+  theme: 'base' as const,
+  securityLevel: 'strict' as const,
   fontFamily: 'PingFang SC, Microsoft YaHei, sans-serif',
   flowchart: {
     useMaxWidth: true,
     htmlLabels: true,
     curve: 'basis',
+    padding: 16,
   },
   sequence: {
     useMaxWidth: true,
-    diagramMarginX: 8,
-    diagramMarginY: 8,
-    actorMargin: 50,
-    width: 150,
-    height: 65,
+    diagramMarginX: 12,
+    diagramMarginY: 12,
+    actorMargin: 56,
+    width: 156,
+    height: 68,
+    boxMargin: 10,
   },
   gantt: {
     useMaxWidth: true,
-    leftPadding: 75,
-    gridLineStartPadding: 35,
-    barHeight: 20,
-    barGap: 4,
-    topPadding: 50,
+    leftPadding: 80,
+    gridLineStartPadding: 40,
+    barHeight: 22,
+    barGap: 6,
+    topPadding: 56,
+  },
+  er: {
+    useMaxWidth: true,
+  },
+  journey: {
+    useMaxWidth: true,
   },
 }
 
@@ -42,15 +160,6 @@ async function getMermaid() {
   return mermaidMod.default
 }
 
-async function getHljs() {
-  if (!hljsMod) {
-    hljsMod = await import('highlight.js')
-    await import('highlight.js/styles/github.css')
-    hljsMod.default.registerAliases('mermaid', { languageName: 'plaintext' })
-  }
-  return hljsMod.default
-}
-
 function escapeHtml(text: string) {
   return text
     .replace(/&/g, '&amp;')
@@ -59,12 +168,29 @@ function escapeHtml(text: string) {
     .replace(/"/g, '&quot;')
 }
 
+function highlightCode(text: string, lang?: string | null) {
+  const language = (lang || '').trim()
+  if (language && hljs.getLanguage(language)) {
+    try {
+      const result = hljs.highlight(text, { language })
+      return { html: result.value, language: result.language || language }
+    } catch {
+      // fall through
+    }
+  }
+  const auto = hljs.highlightAuto(text, language ? [language] : undefined)
+  return { html: auto.value, language: auto.language || language || 'plaintext' }
+}
+
 export const ensureMermaidInitialized = () => {
   if (!initPromise) {
     initPromise = (async () => {
       const mermaid = await getMermaid()
       if (!mermaidInitialized) {
-        mermaid.initialize(MERMAID_CONFIG as Parameters<typeof mermaid.initialize>[0])
+        mermaid.initialize({
+          ...MERMAID_CONFIG,
+          themeVariables: resolveMermaidThemeVariables(),
+        } as Parameters<typeof mermaid.initialize>[0])
         mermaidInitialized = true
       }
     })()
@@ -74,34 +200,29 @@ export const ensureMermaidInitialized = () => {
 let mermaidCount = 0
 
 export const createMermaidCodeRenderer = (idPrefix: string) => {
-  if (!hljsPromise) {
-    hljsPromise = getHljs()
-  }
-
   return ({ text, lang }: Tokens.Code) => {
-    let highlighted = escapeHtml(text)
-    let highlightLang: string = lang || 'Code'
-    const hljs = hljsMod?.default
-    if (hljs) {
-      if (highlightLang && hljs.getLanguage(highlightLang)) {
-        try {
-          highlighted = hljs.highlight(text, { language: highlightLang }).value
-        } catch {
-          const ret = hljs.highlightAuto(text)
-          highlighted = ret.value
-          highlightLang = ret.language || 'Code'
-        }
-      } else {
-        const ret = hljs.highlightAuto(text)
-        highlighted = ret.value
-        highlightLang = ret.language || 'Code'
-      }
-    }
+    const { html: highlighted, language: highlightLang } = highlightCode(text, lang)
     if (lang === 'mermaid') {
       const id = `${idPrefix}-${++mermaidCount}`
-      return `<pre id="${id}" data-mermaid="false"><code class="hljs language-${highlightLang}">${highlighted}</code></pre>`
+      const inner = `<code class="hljs language-${highlightLang}">${highlighted}</code>`
+      return buildMermaidBlockHtml(inner, `id="${id}" data-mermaid="false"`)
     }
-    return `<pre><code class="hljs language-${highlightLang}">${highlighted}</code></pre>`
+    return buildCodeBlockHtml(lang || highlightLang, highlighted, highlightLang)
+  }
+}
+
+export const renderMermaidToSvg = async (code: string, id: string): Promise<string | null> => {
+  if (!code.trim()) return null
+  try {
+    const mermaid = await getMermaid()
+    ensureMermaidInitialized()
+    await initPromise
+    await mermaid.parse(code)
+    const { svg } = await mermaid.render(id, code)
+    return svg
+  } catch (e) {
+    console.error('Mermaid rendering error:', e)
+    return null
   }
 }
 
@@ -109,25 +230,36 @@ export const renderMermaidInContainer = async (
   rootElement: HTMLElement | null | undefined,
 ) => {
   if (!rootElement) return
+
   const mermaid = await getMermaid()
   ensureMermaidInitialized()
   await initPromise
 
-  const mermaidElements = rootElement.querySelectorAll<HTMLElement>('pre[data-mermaid="false"]')
+  const mermaidElements = rootElement.querySelectorAll<HTMLElement>(
+    'pre[data-mermaid="false"], .chat-mermaid-block__canvas[data-mermaid="false"]',
+  )
   for (const el of mermaidElements) {
     try {
       const code = el.innerText
       await mermaid.parse(code)
-      const { svg } = await mermaid.render(`${el.id}-svg`, code)
+      const renderId = el.id ? `${el.id}-svg` : `mermaid-render-${++mermaidCount}`
+      const { svg } = await mermaid.render(renderId, code)
       el.classList.add('mermaid')
       el.innerHTML = svg
-      el.onclick = (event) => {
-        event.stopPropagation()
-        openMermaidFullscreen(svg)
-      }
+      el.setAttribute('data-mermaid', 'true')
     } catch (e) {
       console.error('Mermaid rendering error:', e)
+      continue
     }
-    el.setAttribute('data-mermaid', 'true')
   }
+}
+
+export async function enhanceMarkdownContainer(
+  rootElement: HTMLElement | null | undefined,
+): Promise<void> {
+  if (!rootElement) return
+  attachMarkdownEnhancementListeners(rootElement)
+  highlightCodeBlocksInContainer(rootElement)
+  await renderMermaidInContainer(rootElement)
+  syncMermaidExpandButtons(rootElement)
 }

--- a/frontend/src/utils/mermaidViewer.ts
+++ b/frontend/src/utils/mermaidViewer.ts
@@ -54,7 +54,7 @@ const downloadSvgAsImage = async (svgElement: SVGElement, filename = 'mermaid-di
 const showBtnFeedback = (btn: HTMLElement, success: boolean, text?: string): void => {
   const origColor = btn.style.color
   const origTitle = btn.title
-  btn.style.color = success ? '#07c05f' : '#ef4444'
+  btn.style.color = success ? '#374151' : '#ef4444'
   btn.title = text || (success ? i18n.global.t('common.success') : i18n.global.t('common.failed'))
   setTimeout(() => {
     btn.style.color = origColor
@@ -89,7 +89,7 @@ export const openMermaidFullscreen = (svgHtml: string): void => {
     btn.title = title
     btn.style.cssText = 'display:flex;align-items:center;justify-content:center;width:36px;height:36px;border:1px solid #e5e7eb;border-radius:6px;background:rgba(255,255,255,0.95);color:#6b7280;cursor:pointer;padding:0;box-shadow:0 2px 8px rgba(0,0,0,0.15);'
     btn.innerHTML = icon
-    btn.onmouseenter = () => { btn.style.background = '#f0fdf4'; btn.style.color = '#07c05f' }
+    btn.onmouseenter = () => { btn.style.background = '#f3f4f6'; btn.style.color = '#374151' }
     btn.onmouseleave = () => { btn.style.background = 'rgba(255,255,255,0.95)'; btn.style.color = '#6b7280' }
     return btn
   }

--- a/frontend/src/utils/security.ts
+++ b/frontend/src/utils/security.ts
@@ -3,8 +3,12 @@
  */
 
 import DOMPurify from 'dompurify';
-
-const PROVIDER_IMAGE_PLACEHOLDER = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+import type { Config } from 'dompurify';
+import {
+  domPurifySecurityHooks,
+  domPurifySecurityOptions,
+  markdownDomPurifyConfig,
+} from '@/utils/markdownDomPurify';
 
 // 配置 DOMPurify 的安全策略
 const DOMPurifyConfig = {
@@ -14,7 +18,7 @@ const DOMPurifyConfig = {
     'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
     'ul', 'ol', 'li', 'blockquote', 'pre', 'code',
     'a', 'img', 'table', 'thead', 'tbody', 'tr', 'th', 'td',
-    'div', 'span', 'figure', 'figcaption', 'details', 'summary', 'think',
+    'div', 'span', 'figure', 'figcaption', 'details', 'summary', 'think', 'button',
     // Mermaid SVG 支持的标签
     'svg', 'g', 'path', 'rect', 'circle', 'ellipse', 'line', 'polygon',
     'polyline', 'text', 'tspan', 'defs', 'marker', 'filter', 'use',
@@ -27,6 +31,7 @@ const DOMPurifyConfig = {
   ALLOWED_ATTR: [
     'href', 'title', 'alt', 'src', 'class', 'id', 'style', 'data-protected-src',
     'target', 'rel', 'width', 'height', 'open',
+    'type', 'aria-label', 'disabled', 'role', 'tabindex',
     // Mermaid SVG 支持的属性
     'd', 'fill', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin',
     'stroke-dasharray', 'stroke-dashoffset', 'stroke-miterlimit', 'stroke-opacity',
@@ -45,54 +50,8 @@ const DOMPurifyConfig = {
     'mathvariant', 'encoding', 'aria-hidden'
   ],
   USE_PROFILES: { html: true, svg: true, mathMl: true },
-  // 允许的协议
-  ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp):|(?:local|minio|cos|tos|s3|oss|ks3|obs):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
-  // 禁止的标签和属性
-  FORBID_TAGS: ['script', 'style', 'object', 'embed', 'form', 'input', 'button'],
-  FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'onblur'],
-  // 其他安全配置
-  KEEP_CONTENT: true,
-  RETURN_DOM: false,
-  RETURN_DOM_FRAGMENT: false,
-  RETURN_DOM_IMPORT: false,
-  SANITIZE_DOM: true,
-  SANITIZE_NAMED_PROPS: true,
-  WHOLE_DOCUMENT: false,
-  // 自定义钩子函数
-  HOOKS: {
-    // 在清理前处理
-    beforeSanitizeElements: (currentNode: Element) => {
-      // 移除所有 script 标签
-      if (currentNode.tagName === 'SCRIPT') {
-        currentNode.remove();
-        return null;
-      }
-      // 移除所有事件处理器
-      const eventAttrs = ['onclick', 'onload', 'onerror', 'onmouseover', 'onfocus', 'onblur'];
-      eventAttrs.forEach(attr => {
-        if (currentNode.hasAttribute(attr)) {
-          currentNode.removeAttribute(attr);
-        }
-      });
-    },
-    // 在清理后处理
-    afterSanitizeElements: (currentNode: Element) => {
-      // 确保所有链接都有 rel="noopener noreferrer"
-      if (currentNode.tagName === 'A') {
-        const href = currentNode.getAttribute('href');
-        if (href && href.startsWith('http')) {
-          currentNode.setAttribute('rel', 'noopener noreferrer');
-          currentNode.setAttribute('target', '_blank');
-        }
-      }
-      // 确保所有图片都有 alt 属性
-      if (currentNode.tagName === 'IMG') {
-        if (!currentNode.getAttribute('alt')) {
-          currentNode.setAttribute('alt', '');
-        }
-      }
-    }
-  }
+  ...domPurifySecurityOptions,
+  HOOKS: domPurifySecurityHooks,
 };
 
 /**
@@ -115,7 +74,22 @@ export function sanitizeHTML(html: string): string {
   }
 }
 
-function protectProviderImageSrcInHTML(html: string): string {
+/** Sanitize assistant markdown HTML (code/mermaid toolbars, KaTeX, SVG). */
+export function sanitizeMarkdownHTML(html: string): string {
+  if (!html || typeof html !== 'string') {
+    return '';
+  }
+
+  try {
+    const preparedHTML = protectProviderImageSrcInHTML(html);
+    return DOMPurify.sanitize(preparedHTML, markdownDomPurifyConfig as Config);
+  } catch (error) {
+    console.error('Markdown HTML sanitization failed:', error);
+    return escapeHTML(html);
+  }
+}
+
+export function protectProviderImageSrcInHTML(html: string): string {
   if (!html) return html;
   const decodeProviderURL = (raw: string): string =>
     raw

--- a/frontend/src/views/chat/components/botmsg.vue
+++ b/frontend/src/views/chat/components/botmsg.vue
@@ -3,23 +3,27 @@
         <div style="display: flex;flex-direction: column; gap:8px">
             <!-- 显示@的知识库和文件（非 Agent 模式下显示） -->
             <div v-if="!session.isAgentMode && mentionedItems && mentionedItems.length > 0" class="mentioned_items">
-                <span
-                    v-for="item in mentionedItems"
-                    :key="item.id"
-                    class="mentioned_tag"
-                    :class="[
-                      item.type === 'kb' ? (item.kb_type === 'faq' ? 'faq-tag' : 'kb-tag') : 'file-tag'
-                    ]"
-                >
+                <span v-for="item in mentionedItems" :key="item.id" class="mentioned_tag" :class="[
+                    item.type === 'kb' ? (item.kb_type === 'faq' ? 'faq-tag' : 'kb-tag') : 'file-tag'
+                ]">
                     <span class="tag_icon">
-                        <t-icon v-if="item.type === 'kb'" :name="item.kb_type === 'faq' ? 'chat-bubble-help' : 'folder'" />
+                        <t-icon v-if="item.type === 'kb'"
+                            :name="item.kb_type === 'faq' ? 'chat-bubble-help' : 'folder'" />
                         <t-icon v-else name="file" />
                     </span>
                     <span class="tag_name">{{ item.name }}</span>
                 </span>
             </div>
-            <docInfo :session="session"></docInfo>
-            <AgentStreamDisplay :session="session" :session-id="sessionId" :user-query="userQuery" v-if="session.isAgentMode"></AgentStreamDisplay>
+            <div v-if="session.isRagMode" class="rag-answer-stack">
+                <RagPipelineProgress :session="session" :embedded-mode="embeddedMode" />
+                <AgentStreamDisplay v-if="session.isAgentMode" :session="session" :session-id="sessionId"
+                    :user-query="userQuery" :rag-mode="true" />
+            </div>
+            <template v-else>
+                <docInfo v-if="session.knowledge_references?.length" :session="session"></docInfo>
+                <AgentStreamDisplay :session="session" :session-id="sessionId" :user-query="userQuery"
+                    v-if="session.isAgentMode" />
+            </template>
             <deepThink :deepSession="session" v-if="session.showThink && !session.isAgentMode"></deepThink>
         </div>
         <!-- 非 Agent 模式下才显示传统的 markdown 渲染 -->
@@ -40,10 +44,12 @@
             </div>
             <!-- 复制和添加到知识库按钮 - 非 Agent 模式下显示 -->
             <div v-if="session.is_completed && (content || session.content)" class="answer-toolbar">
-                <t-button size="small" variant="outline" shape="round" @click.stop="handleCopyAnswer" :title="$t('agent.copy')">
+                <t-button size="small" variant="outline" shape="round" @click.stop="handleCopyAnswer"
+                    :title="$t('agent.copy')">
                     <t-icon name="copy" />
                 </t-button>
-                <t-button size="small" variant="outline" shape="round" @click.stop="handleAddToKnowledge" :title="$t('agent.addToKnowledgeBase')">
+                <t-button size="small" variant="outline" shape="round" @click.stop="handleAddToKnowledge"
+                    :title="$t('agent.addToKnowledgeBase')">
                     <t-icon name="add" />
                 </t-button>
                 <!-- Fallback 提示图标 -->
@@ -52,28 +58,29 @@
                         <t-icon name="info-circle" />
                     </t-button>
                 </t-tooltip>
-                <ChatRequestInfoButton
-                    v-if="showRequestInfo"
-                    :session="session"
-                    :session-id="sessionId"
-                />
+                <ChatRequestInfoButton v-if="showRequestInfo" :session="session" :session-id="sessionId" />
             </div>
-            <div v-if="isImgLoading" class="img_loading"><t-loading size="small"></t-loading><span>{{ $t('common.loading') }}</span></div>
+            <div v-if="isImgLoading" class="img_loading"><t-loading size="small"></t-loading><span>{{
+                $t('common.loading') }}</span></div>
         </div>
         <picturePreview :reviewImg="reviewImg" :reviewUrl="reviewUrl" @closePreImg="closePreImg"></picturePreview>
+        <Teleport to="body">
+            <ChatCitationFloat :float="citationFloat" :on-enter="cancelCitationClose"
+                :on-leave="scheduleCitationClose" />
+        </Teleport>
     </div>
 </template>
 <script setup>
 import { onMounted, onBeforeUnmount, watch, computed, ref, reactive, defineProps, nextTick, onUpdated } from 'vue';
-import { marked } from 'marked';
-import markedKatex from 'marked-katex-extension';
 import 'katex/dist/katex.min.css';
 import docInfo from './docInfo.vue';
 import deepThink from './deepThink.vue';
 import AgentStreamDisplay from './AgentStreamDisplay.vue';
+import RagPipelineProgress from './RagPipelineProgress.vue';
 import ChatRequestInfoButton from '@/components/ChatRequestInfoButton.vue';
+import ChatCitationFloat from '@/components/ChatCitationFloat.vue';
 import picturePreview from '@/components/picture-preview.vue';
-import { sanitizeHTML, safeMarkdownToHTML, createSafeImage, isValidImageURL, hydrateProtectedFileImages } from '@/utils/security';
+import { sanitizeMarkdownHTML, safeMarkdownToHTML, createSafeImage, isValidImageURL, hydrateProtectedFileImages } from '@/utils/security';
 import { useI18n } from 'vue-i18n';
 import { MessagePlugin } from 'tdesign-vue-next';
 import { useUIStore } from '@/stores/ui';
@@ -81,36 +88,30 @@ import {
     buildManualMarkdown,
     copyTextToClipboard,
     formatManualTitle,
-    replaceIncompleteImageWithPlaceholder
 } from '@/utils/chatMessageShared';
+import {
+    createChatMarkdownRenderer,
+    renderChatMarkdown,
+} from '@/utils/chatMarkdownRenderer';
 import {
     createMermaidCodeRenderer,
     ensureMermaidInitialized,
-    renderMermaidInContainer
+    renderMermaidInContainer,
+    enhanceMarkdownContainer,
 } from '@/utils/mermaidShared';
-
-marked.use({
-    breaks: true,  // 全局启用单个换行支持
-});
-
-marked.use(markedKatex({ throwOnError: false, nonStandard: true }));
-
-const preprocessMathDelimiters = (rawText) => {
-    if (!rawText || typeof rawText !== 'string') {
-        return '';
-    }
-    return rawText
-        .replace(/\\\[([\s\S]*?)\\\]/g, '$$$$$1$$$$')
-        .replace(/\\\(([\s\S]*?)\\\)/g, '$$$1$$');
-};
+import { refreshMarkdownEnhancements } from '@/utils/markdownEnhancements';
+import { useChatCitationPopover } from '@/composables/useChatCitationPopover';
 
 ensureMermaidInitialized();
 
 const emit = defineEmits(['scroll-bottom'])
 const { t } = useI18n()
 const uiStore = useUIStore();
-const renderer = new marked.Renderer();
 let parentMd = ref()
+const { float: citationFloat, rebind: rebindCitations, cancelClose: cancelCitationClose, scheduleClose: scheduleCitationClose } = useChatCitationPopover(parentMd, {
+    getKnowledgeReferences: () => props.session?.knowledge_references,
+    sessionId: () => props.sessionId,
+});
 let reviewUrl = ref('')
 let reviewImg = ref(false)
 let isImgLoading = ref(false);
@@ -157,18 +158,12 @@ const closePreImg = () => {
     reviewUrl.value = '';
 }
 
-// 创建自定义渲染器实例
-const customRenderer = new marked.Renderer();
-// 覆盖图片渲染方法
-customRenderer.image = function({href, title, text}){
-    if (!isValidImageURL(href)) {
-        return `<p>${t('error.invalidImageLink')}</p>`;
-    }
-    return createSafeImage(href, text || '', title || '');
-};
-
-// 覆盖代码块渲染方法，支持 Mermaid
-customRenderer.code = createMermaidCodeRenderer('mermaid-botmsg');
+const markdownRenderer = createChatMarkdownRenderer({
+    codeRenderer: createMermaidCodeRenderer('mermaid-botmsg'),
+    imageRenderer: ({ href, title, text }) => createSafeImage(href, text || '', title || ''),
+    invalidImageHtml: () => `<p>${t('error.invalidImageLink')}</p>`,
+    isValidImageUrl: isValidImageURL,
+});
 
 // 计算属性：将 Markdown 文本转换为 tokens
 const mentionedItems = computed(() => {
@@ -179,11 +174,12 @@ const mentionedItems = computed(() => {
 const renderedHTML = computed(() => {
     const text = props.content || props.session?.content || '';
     if (!text || typeof text !== 'string') return '';
-    const processed = replaceIncompleteImageWithPlaceholder(text);
-    const safeText = preprocessMathDelimiters(processed);
-    const safeMarkdown = safeMarkdownToHTML(safeText);
-    const html = marked.parse(safeMarkdown, { renderer: customRenderer, breaks: true });
-    return sanitizeHTML(html);
+    return renderChatMarkdown(text, {
+        renderer: markdownRenderer,
+        escapeMarkdown: safeMarkdownToHTML,
+        sanitizeHtml: sanitizeMarkdownHTML,
+        knowledgeReferences: props.session?.knowledge_references,
+    });
 });
 
 // 计算属性：判断是否有实际内容（非空且不只是空白）
@@ -225,7 +221,7 @@ const handleAddToKnowledge = () => {
     const question = (props.userQuery || '').trim();
     const manualContent = buildManualMarkdown(question, content);
     const manualTitle = formatManualTitle(question);
-``
+    ``
     uiStore.openManualEditor({
         mode: 'create',
         title: manualTitle,
@@ -249,18 +245,19 @@ const handleMarkdownImageClick = (e) => {
     }
 };
 
-// 渲染 Mermaid 图表的函数
-const renderMermaidDiagrams = async () => {
-  await renderMermaidInContainer(parentMd.value);
-};
+watch(renderedHTML, () => {
+    nextTick(() => {
+        rebindCitations();
+    });
+});
 
-// 监听内容变化并渲染 Mermaid - 只在会话完成后渲染
+// 渲染 Mermaid 图表的函数
 onUpdated(() => {
     nextTick(async () => {
         await hydrateProtectedFileImages(parentMd.value);
-        // 只在会话完成后渲染 mermaid
+        refreshMarkdownEnhancements(parentMd.value);
         if (props.session?.is_completed) {
-            renderMermaidDiagrams();
+            await renderMermaidInContainer(parentMd.value);
         }
     });
 });
@@ -271,9 +268,9 @@ onMounted(async () => {
         if (parentMd.value) {
             parentMd.value.addEventListener('click', handleMarkdownImageClick, true);
         }
+        rebindCitations();
         await hydrateProtectedFileImages(parentMd.value);
-        // 初始渲染 Mermaid 图表
-        renderMermaidDiagrams();
+        await enhanceMarkdownContainer(parentMd.value);
     });
 });
 
@@ -284,25 +281,36 @@ onBeforeUnmount(() => {
 });
 </script>
 <style lang="less" scoped>
-@import '../../../components/css/markdown.less';
+@import '../../../components/css/chat-markdown.less';
 @import '../../../components/css/chat-message-shared.less';
+@import '../../../components/css/chat-citations.less';
 
 .bot_msg {
     &.is-embedded {
         width: 100%;
-        
+
         :deep(.agent-stream-display) {
             width: 100%;
         }
     }
 }
 
+.rag-answer-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
 // 内容包装器 - 与 Agent 模式的 answer 样式一致
 .content-wrapper {
-    background: var(--td-bg-color-container);
-    border-radius: 6px;
-    padding: 8px 0px;
-    transition: all 0.2s ease;
+    padding: 2px 0;
+}
+
+.markdown-content {
+    // Chat Markdown visual styles are centralized in chat-markdown.less.
+    // Do not add element-level Markdown rules here; update the shared mixin.
+    .chat-markdown-typography();
+    .chat-citation-pills();
 }
 
 .mentioned_items {
@@ -376,128 +384,10 @@ onBeforeUnmount(() => {
         opacity: 0;
         transform: translateY(8px);
     }
+
     to {
         opacity: 1;
         transform: translateY(0);
-    }
-}
-
-.ai-markdown-template {
-    font-size: 15px;
-    color: var(--td-text-color-primary);
-    line-height: 1.6;
-}
-
-.markdown-content {
-    :deep(p) {
-        margin: 6px 0;
-        line-height: 1.6;
-    }
-
-    :deep(code) {
-        background: var(--td-bg-color-secondarycontainer);
-        padding: 2px 5px;
-        border-radius: 3px;
-        font-family: var(--app-font-family-mono);
-        font-size: 11px;
-    }
-
-    :deep(pre) {
-        background: var(--td-bg-color-secondarycontainer);
-        padding: 10px;
-        border-radius: 4px;
-        overflow-x: auto;
-        margin: 6px 0;
-
-        code {
-            background: none;
-            padding: 0;
-        }
-    }
-
-    :deep(ul), :deep(ol) {
-        margin: 6px 0;
-        padding-left: 20px;
-    }
-
-    :deep(li) {
-        margin: 3px 0;
-    }
-
-    :deep(blockquote) {
-        border-left: 2px solid var(--td-brand-color);
-        padding-left: 10px;
-        margin: 6px 0;
-        color: var(--td-text-color-secondary);
-    }
-
-    :deep(h1), :deep(h2), :deep(h3), :deep(h4), :deep(h5), :deep(h6) {
-        margin: 10px 0 6px 0;
-        font-weight: 600;
-        color: var(--td-text-color-primary);
-    }
-
-    :deep(a) {
-        color: var(--td-brand-color);
-        text-decoration: none;
-
-        &:hover {
-            text-decoration: underline;
-        }
-    }
-
-    :deep(table) {
-        border-collapse: collapse;
-        margin: 6px 0;
-        font-size: 11px;
-        width: 100%;
-
-        th, td {
-            border: 1px solid var(--td-component-stroke);
-            padding: 5px 8px;
-            text-align: left;
-        }
-
-        th {
-            background: var(--td-bg-color-secondarycontainer);
-            font-weight: 600;
-        }
-
-        tbody tr:nth-child(even) {
-            background: var(--td-bg-color-secondarycontainer);
-        }
-    }
-
-    :deep(img) {
-        max-width: 80%;
-        max-height: 300px;
-        width: auto;
-        height: auto;
-        border-radius: 8px;
-        display: block;
-        margin: 8px 0;
-        border: 0.5px solid var(--td-component-stroke);
-        object-fit: contain;
-        cursor: pointer;
-        transition: transform 0.2s ease;
-
-        &:hover {
-        }
-    }
-
-    // Mermaid 图表样式
-    :deep(.mermaid) {
-        margin: 16px 0;
-        padding: 16px;
-        background: var(--td-bg-color-secondarycontainer);
-        border-radius: 8px;
-        overflow-x: auto;
-        text-align: center;
-
-        svg {
-            max-width: 100%;
-            height: auto;
-        }
     }
 }
 
@@ -548,22 +438,22 @@ onBeforeUnmount(() => {
     display: flex;
     align-items: center;
     gap: 4px;
-    
+
     span {
         width: 6px;
         height: 6px;
         border-radius: 50%;
         background: var(--td-brand-color);
         animation: typingBounce 1.4s ease-in-out infinite;
-        
+
         &:nth-child(1) {
             animation-delay: 0s;
         }
-        
+
         &:nth-child(2) {
             animation-delay: 0.2s;
         }
-        
+
         &:nth-child(3) {
             animation-delay: 0.4s;
         }
@@ -571,9 +461,13 @@ onBeforeUnmount(() => {
 }
 
 @keyframes typingBounce {
-    0%, 60%, 100% {
+
+    0%,
+    60%,
+    100% {
         transform: translateY(0);
     }
+
     30% {
         transform: translateY(-8px);
     }

--- a/frontend/src/views/dev/MarkdownTestPage.vue
+++ b/frontend/src/views/dev/MarkdownTestPage.vue
@@ -2,16 +2,25 @@
   <div class="markdown-test-page">
     <h1 class="page-title">Markdown Rendering Test</h1>
     <p class="page-desc">
-      Dev-only page for visual regression testing of markdown / LaTeX / Mermaid rendering.
+      Dev-only page for visual regression testing of chat answer markdown
+      (same typography as botmsg / AgentStreamDisplay / embed).
       Add new test cases or paste arbitrary markdown in the editor below.
     </p>
+
+    <!-- Basic Text Styles (GPT markdown test doc alignment) -->
+    <section class="test-section">
+      <h2>Basic Text Styles</h2>
+      <div class="test-case">
+        <div class="test-rendered markdown-content" v-html="basicTextHtml"></div>
+      </div>
+    </section>
 
     <!-- LaTeX Formulas -->
     <section class="test-section">
       <h2>LaTeX Formulas</h2>
-      <div v-for="(tc, i) in latexCases" :key="'latex-'+i" class="test-case">
+      <div v-for="(tc, i) in latexCases" :key="'latex-' + i" class="test-case">
         <div class="test-raw"><code>{{ tc.raw }}</code></div>
-        <div class="test-rendered markdown-content" v-html="render(tc.raw)"></div>
+        <div class="test-rendered markdown-content" v-html="tc.html"></div>
       </div>
     </section>
 
@@ -19,7 +28,7 @@
     <section class="test-section">
       <h2>Code Blocks</h2>
       <div class="test-case">
-        <div class="test-rendered markdown-content" v-html="render(codeBlockSample)"></div>
+        <div class="test-rendered markdown-content" v-html="codeBlockHtml"></div>
       </div>
     </section>
 
@@ -27,7 +36,7 @@
     <section class="test-section">
       <h2>Tables</h2>
       <div class="test-case">
-        <div class="test-rendered markdown-content" v-html="render(tableSample)"></div>
+        <div class="test-rendered markdown-content" v-html="tableHtml"></div>
       </div>
     </section>
 
@@ -35,7 +44,7 @@
     <section class="test-section">
       <h2>Lists &amp; Blockquotes</h2>
       <div class="test-case">
-        <div class="test-rendered markdown-content" v-html="render(listsSample)"></div>
+        <div class="test-rendered markdown-content" v-html="listsHtml"></div>
       </div>
     </section>
 
@@ -43,7 +52,7 @@
     <section class="test-section">
       <h2>Mixed Content</h2>
       <div class="test-case">
-        <div class="test-rendered markdown-content" v-html="render(mixedSample)"></div>
+        <div class="test-rendered markdown-content" v-html="mixedHtml"></div>
       </div>
     </section>
 
@@ -51,7 +60,7 @@
     <section class="test-section">
       <h2>Mermaid Diagram</h2>
       <div class="test-case">
-        <div ref="mermaidContainer" class="test-rendered markdown-content" v-html="render(mermaidSample)"></div>
+        <div ref="mermaidContainer" class="test-rendered markdown-content" v-html="mermaidHtml"></div>
       </div>
     </section>
 
@@ -69,7 +78,7 @@
         </label>
       </div>
       <div class="test-case">
-        <div class="test-rendered markdown-content" v-html="render(streamBuffer)"></div>
+        <div ref="streamContainer" class="test-rendered markdown-content" v-html="streamHtml"></div>
         <div v-if="isStreaming" class="loading-typing">
           <span></span><span></span><span></span>
         </div>
@@ -80,57 +89,83 @@
     <section class="test-section">
       <h2>Custom Input</h2>
       <p class="test-hint">Paste any markdown here to test rendering.</p>
-      <textarea
-        v-model="customInput"
-        class="custom-textarea"
-        rows="8"
-        placeholder="Type or paste markdown here..."
-      ></textarea>
+      <textarea v-model="customInput" class="custom-textarea" rows="8"
+        placeholder="Type or paste markdown here..."></textarea>
       <div v-if="customInput.trim()" class="test-case">
-        <div class="test-rendered markdown-content" v-html="render(customInput)"></div>
+        <div ref="customContainer" class="test-rendered markdown-content" v-html="customHtml"></div>
       </div>
     </section>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, nextTick, watch } from 'vue';
-import { marked } from 'marked';
-import markedKatex from 'marked-katex-extension';
-import DOMPurify from 'dompurify';
+import { ref, computed, onMounted, nextTick, watch } from 'vue';
 import 'katex/dist/katex.min.css';
+import { sanitizeMarkdownHTML } from '@/utils/security';
+import {
+  createChatMarkdownRenderer,
+  renderChatMarkdown,
+} from '@/utils/chatMarkdownRenderer';
 import {
   ensureMermaidInitialized,
-  renderMermaidInContainer,
+  enhanceMarkdownContainer,
+  renderMermaidToSvg,
   createMermaidCodeRenderer,
 } from '@/utils/mermaidShared';
-
-// Configure marked
-marked.use({ breaks: true, gfm: true });
-marked.use(markedKatex({ throwOnError: false, nonStandard: true }));
-
-const mermaidRenderer = new marked.Renderer();
-mermaidRenderer.code = createMermaidCodeRenderer('mermaid-test');
+import {
+  replaceIncompleteMermaidWithPlaceholder,
+  prepareStreamingMermaidMarkdown,
+  extractFirstMermaidCode,
+  injectCachedMermaidSvg,
+} from '@/utils/chatMessageShared';
 
 ensureMermaidInitialized();
 
-const mermaidContainer = ref<HTMLElement | null>(null);
+const mermaidRenderer = createChatMarkdownRenderer({
+  codeRenderer: createMermaidCodeRenderer('mermaid-test'),
+});
 
-const preprocessMathDelimiters = (rawText: string): string => {
-  if (!rawText) return '';
-  return rawText
-    .replace(/\\\[([\s\S]*?)\\\]/g, '$$$$$1$$$$')
-    .replace(/\\\(([\s\S]*?)\\\)/g, '$$$1$$');
-};
+const mermaidContainer = ref<HTMLElement | null>(null);
+const streamContainer = ref<HTMLElement | null>(null);
+const customContainer = ref<HTMLElement | null>(null);
 
 const render = (raw: string): string => {
   if (!raw) return '';
-  const processed = preprocessMathDelimiters(raw);
-  const html = marked.parse(processed, { renderer: mermaidRenderer }) as string;
-  return DOMPurify.sanitize(html, { USE_PROFILES: { html: true, svg: true, mathMl: true } });
+  return renderChatMarkdown(raw, {
+    renderer: mermaidRenderer,
+    escapeMarkdown: (markdown) => markdown,
+    sanitizeHtml: sanitizeMarkdownHTML,
+    prepareMarkdown: (markdown) => replaceIncompleteMermaidWithPlaceholder(markdown),
+  });
+};
+
+const renderStreamMarkdown = (raw: string): string => {
+  if (!raw) return '';
+  return renderChatMarkdown(raw, {
+    renderer: mermaidRenderer,
+    escapeMarkdown: (markdown) => markdown,
+    sanitizeHtml: sanitizeMarkdownHTML,
+    cachedMermaidSvgHtml: streamMermaidSvgHtml.value,
+    prepareMarkdown: prepareStreamingMermaidMarkdown,
+    injectCachedMermaidSvg,
+  });
 };
 
 // --- Test Data ---
+
+const basicTextSample = `这是一段普通文本，包含 **加粗**、*斜体*、***加粗斜体***、~~删除线~~、行内 \`code\`。
+
+也可以包含快捷键样式：<kbd>⌘</kbd> + <kbd>K</kbd>。
+
+这里有一个链接：[GitHub](https://github.com)。
+
+> 一级引用
+>
+> > 嵌套引用，用于对比 GPT 的引用层级与字重。
+
+- [ ] 未完成任务
+- [x] 已完成任务
+`;
 
 const latexCases = [
   { raw: 'Inline math: $E = mc^2$ in the middle of text.' },
@@ -140,7 +175,7 @@ const latexCases = [
   { raw: 'Summation: $\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}$' },
   { raw: 'Matrix:\n$$\\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}$$' },
   { raw: 'Escaped delimiters: \\(\\alpha + \\beta = \\gamma\\) and \\[\\int_a^b f(x)\\,dx\\]' },
-];
+].map((tc) => ({ ...tc, html: '' }));
 
 const codeBlockSample = `Here is some Python:
 
@@ -240,12 +275,76 @@ def greet(name):
 
 And the derivative rule: $\\frac{d}{dx}\\sin x = \\cos x$.
 
+\`\`\`mermaid
+graph TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Process A]
+    B -->|No| D[Process B]
+    C --> E[End]
+    D --> E
+\`\`\`
+
+### Ordered List
+1. First item
+2. Second item
+   1. Nested item A
+   2. Nested item B
+3. Third item
+
+### Unordered List
+- Alpha
+- Beta
+  - Sub-item
+  - Another sub-item
+- Gamma
+
+### Blockquote
+> This is a blockquote with **bold** and *italic* text.
+>
+> It can span multiple paragraphs.
+
 Done.`;
 
 const streamBuffer = ref('');
 const isStreaming = ref(false);
 const streamSpeed = ref(30);
+const customInput = ref('');
+const streamMermaidSvgHtml = ref('');
 let streamTimer: ReturnType<typeof setInterval> | null = null;
+let streamMermaidRenderId = 0;
+let streamMermaidRenderTask: Promise<void> | null = null;
+
+// Pre-render static fixtures once so streaming ticks do not reset other sections.
+latexCases.forEach((tc) => {
+  tc.html = render(tc.raw);
+});
+const codeBlockHtml = render(codeBlockSample);
+const basicTextHtml = render(basicTextSample);
+const tableHtml = render(tableSample);
+const listsHtml = render(listsSample);
+const mixedHtml = render(mixedSample);
+const mermaidHtml = render(mermaidSample);
+
+const streamHtml = computed(() => renderStreamMarkdown(streamBuffer.value));
+const customHtml = computed(() => render(customInput.value));
+
+const cacheStreamMermaidSvg = async () => {
+  if (streamMermaidSvgHtml.value) return;
+
+  const code = extractFirstMermaidCode(streamBuffer.value);
+  if (!code) return;
+
+  if (!streamMermaidRenderTask) {
+    streamMermaidRenderTask = (async () => {
+      const svg = await renderMermaidToSvg(code, `mermaid-stream-${++streamMermaidRenderId}`);
+      if (svg) streamMermaidSvgHtml.value = svg;
+    })().finally(() => {
+      streamMermaidRenderTask = null;
+    });
+  }
+
+  await streamMermaidRenderTask;
+};
 
 const startStream = () => {
   resetStream();
@@ -265,26 +364,49 @@ const startStream = () => {
 const resetStream = () => {
   if (streamTimer) clearInterval(streamTimer);
   streamBuffer.value = '';
+  streamMermaidSvgHtml.value = '';
+  streamMermaidRenderTask = null;
   isStreaming.value = false;
 };
 
-// Custom input
-const customInput = ref('');
-
-// Render mermaid after mount and content changes
-const doMermaid = async () => {
+const refreshMermaid = async (root?: HTMLElement | null) => {
   await nextTick();
-  if (mermaidContainer.value) {
-    await renderMermaidInContainer(mermaidContainer.value);
-  }
+  await enhanceMarkdownContainer(root ?? mermaidContainer.value);
 };
 
-onMounted(doMermaid);
-watch(mermaidSample, doMermaid);
+onMounted(() => refreshMermaid());
+
+watch(streamBuffer, () => {
+  void cacheStreamMermaidSvg();
+});
+
+watch(streamHtml, () => {
+  nextTick(() => refreshMermaid(streamContainer.value));
+});
+
+watch(isStreaming, (streaming) => {
+  if (!streaming) {
+    void cacheStreamMermaidSvg().then(() => refreshMermaid(streamContainer.value));
+  }
+});
+
+let customMermaidTimer: ReturnType<typeof setTimeout> | null = null;
+const COMPLETE_MERMAID_RE = /```mermaid[\s\S]*?```/;
+
+watch(customInput, () => {
+  if (!COMPLETE_MERMAID_RE.test(customInput.value)) return;
+  if (customMermaidTimer) clearTimeout(customMermaidTimer);
+  customMermaidTimer = setTimeout(() => {
+    customMermaidTimer = null;
+    void refreshMermaid(customContainer.value);
+  }, 200);
+});
 </script>
 
 <style lang="less" scoped>
-@import '../../components/css/markdown.less';
+@import '../../components/css/chat-markdown.less';
+@import '../../components/css/chat-citations.less';
+@import '../../components/css/chat-message-shared.less';
 
 .markdown-test-page {
   max-width: 860px;
@@ -409,71 +531,38 @@ watch(mermaidSample, doMermaid);
     background: var(--td-brand-color, #0052d9);
     animation: typingBounce 1.4s ease-in-out infinite;
 
-    &:nth-child(1) { animation-delay: 0s; }
-    &:nth-child(2) { animation-delay: 0.2s; }
-    &:nth-child(3) { animation-delay: 0.4s; }
+    &:nth-child(1) {
+      animation-delay: 0s;
+    }
+
+    &:nth-child(2) {
+      animation-delay: 0.2s;
+    }
+
+    &:nth-child(3) {
+      animation-delay: 0.4s;
+    }
   }
 }
 
 @keyframes typingBounce {
-  0%, 60%, 100% { transform: translateY(0); }
-  30% { transform: translateY(-8px); }
+
+  0%,
+  60%,
+  100% {
+    transform: translateY(0);
+  }
+
+  30% {
+    transform: translateY(-8px);
+  }
 }
 
-// Markdown content styles (same as chat)
+// Chat answer markdown — shared with botmsg / AgentStreamDisplay / embed
 .markdown-content {
-  font-size: 15px;
-  color: var(--td-text-color-primary);
-  line-height: 1.6;
-
-  :deep(p) { margin: 6px 0; }
-  :deep(code) {
-    background: var(--td-bg-color-secondarycontainer, #f5f5f5);
-    padding: 2px 5px;
-    border-radius: 3px;
-    font-family: var(--app-font-family-mono);
-    font-size: 13px;
-  }
-  :deep(pre) {
-    background: var(--td-bg-color-secondarycontainer, #f5f5f5);
-    padding: 12px;
-    border-radius: 4px;
-    overflow-x: auto;
-    margin: 8px 0;
-    code { background: none; padding: 0; }
-  }
-  :deep(table) {
-    border-collapse: collapse;
-    margin: 8px 0;
-    width: 100%;
-    th, td {
-      border: 1px solid var(--td-component-stroke, #e5e5e5);
-      padding: 6px 10px;
-      text-align: left;
-    }
-    th {
-      background: var(--td-bg-color-secondarycontainer, #f5f5f5);
-      font-weight: 600;
-    }
-  }
-  :deep(blockquote) {
-    border-left: 3px solid var(--td-brand-color, #0052d9);
-    padding-left: 12px;
-    margin: 8px 0;
-    color: var(--td-text-color-secondary);
-  }
-  :deep(img) {
-    max-width: 80%;
-    border-radius: 8px;
-    margin: 8px 0;
-  }
-  :deep(.mermaid) {
-    margin: 16px 0;
-    padding: 16px;
-    background: var(--td-bg-color-secondarycontainer, #f5f5f5);
-    border-radius: 8px;
-    text-align: center;
-    svg { max-width: 100%; height: auto; }
-  }
+  // Dev page intentionally uses the same chat Markdown mixin as runtime chat.
+  // Keep visual changes in chat-markdown.less so this page remains a regression target.
+  .chat-markdown-typography();
+  .chat-citation-pills();
 }
 </style>

--- a/frontend/src/views/embed/EmbedBotMessage.vue
+++ b/frontend/src/views/embed/EmbedBotMessage.vue
@@ -1,51 +1,36 @@
 <template>
   <div class="embed-bot-msg" :class="{ 'is-embedded': embeddedMode }">
-    <DocInfo
-      v-if="session && !session.isAgentMode"
-      :session="session"
-      embedded-mode
-    />
-    <AgentStreamDisplay
-      v-if="session?.isAgentMode"
-      :session="session"
-      :session-id="sessionId"
-      :user-query="userQuery"
-      :embedded-mode="embeddedMode"
-      :embed-channel-id="embedChannelId"
-      :embed-token="embedToken"
-    />
-    <template v-else-if="!session?.isAgentMode">
-      <DeepThink v-if="session?.showThink" :deep-session="session" />
-      <div v-if="!session?.hideContent" ref="parentMd">
-        <div v-if="hasActualContent" class="content-wrapper">
-          <div class="ai-markdown-template markdown-content" v-html="renderedHTML" />
-        </div>
-        <div v-if="hasActualContent && !session?.is_completed" class="loading-indicator">
-          <div class="loading-typing">
-            <span></span>
-            <span></span>
-            <span></span>
-          </div>
+    <div v-if="session?.isRagMode" class="rag-answer-stack">
+      <RagPipelineProgress :session="session" embedded-mode />
+      <AgentStreamDisplay v-if="session?.isAgentMode" :session="session" :session-id="sessionId" :user-query="userQuery"
+        rag-mode :embedded-mode="embeddedMode" :embed-channel-id="embedChannelId" :embed-token="embedToken" />
+    </div>
+    <template v-else>
+      <DocInfo v-if="session?.knowledge_references?.length" :session="session" embedded-mode />
+      <AgentStreamDisplay v-if="session?.isAgentMode" :session="session" :session-id="sessionId" :user-query="userQuery"
+        :embedded-mode="embeddedMode" :embed-channel-id="embedChannelId" :embed-token="embedToken" />
+    </template>
+    <DeepThink v-if="session?.showThink && !session?.isAgentMode" :deep-session="session" />
+    <div v-if="!session?.hideContent && !session?.isAgentMode" ref="parentMd">
+      <div v-if="hasActualContent" class="content-wrapper">
+        <div class="ai-markdown-template markdown-content" v-html="renderedHTML" />
+      </div>
+      <div v-if="hasActualContent && !session?.is_completed" class="loading-indicator">
+        <div class="loading-typing">
+          <span></span>
+          <span></span>
+          <span></span>
         </div>
       </div>
-    </template>
+    </div>
     <Teleport to="body">
-      <div
-        v-if="citationFloat.visible"
-        class="embed-citation-float"
-        :style="{ top: `${citationFloat.top}px`, left: `${citationFloat.left}px` }"
-        @mouseenter="cancelCitationClose"
-        @mouseleave="scheduleCitationClose"
-      >
+      <div v-if="citationFloat.visible" class="embed-citation-float"
+        :style="{ top: `${citationFloat.top}px`, left: `${citationFloat.left}px` }" @mouseenter="cancelCitationClose"
+        @mouseleave="scheduleCitationClose">
         <template v-if="citationFloat.type === 'web'">
           <div class="embed-citation-float__title">{{ citationFloat.title || citationFloat.url }}</div>
-          <a
-            v-if="citationFloat.url"
-            class="embed-citation-float__link"
-            :href="citationFloat.url"
-            target="_blank"
-            rel="noopener noreferrer"
-          >{{ citationFloat.url }}</a>
+          <a v-if="citationFloat.url" class="embed-citation-float__link" :href="citationFloat.url" target="_blank"
+            rel="noopener noreferrer">{{ citationFloat.url }}</a>
         </template>
         <template v-else>
           <div class="embed-citation-float__title">{{ citationFloat.title }}</div>
@@ -60,30 +45,28 @@
 
 <script setup lang="ts">
 import { computed, defineAsyncComponent, nextTick, onMounted, onUpdated, ref, watch } from 'vue'
-import { marked } from 'marked'
-import markedKatex from 'marked-katex-extension'
 import 'katex/dist/katex.min.css'
 import {
-  sanitizeHTML,
+  sanitizeMarkdownHTML,
   safeMarkdownToHTML,
   createSafeImage,
   isValidImageURL,
   hydrateProtectedFileImages,
 } from '@/utils/security'
-import { replaceIncompleteImageWithPlaceholder } from '@/utils/chatMessageShared'
+import {
+  createChatMarkdownRenderer,
+  renderChatMarkdown,
+} from '@/utils/chatMarkdownRenderer'
 import {
   createMermaidCodeRenderer,
   ensureMermaidInitialized,
-  renderMermaidInContainer,
+  enhanceMarkdownContainer,
 } from '@/utils/mermaidShared'
-import {
-  extractCitationHtmlPlaceholders,
-  preserveCitationTags,
-  restoreCitationHtmlPlaceholders,
-  restoreCitationTags,
-} from '@/utils/citationMarkdown'
 import { useEmbedCitationPopover } from '@/composables/useEmbedCitationPopover'
 
+const RagPipelineProgress = defineAsyncComponent(
+  () => import('@/views/chat/components/RagPipelineProgress.vue'),
+)
 const AgentStreamDisplay = defineAsyncComponent(
   () => import('@/views/chat/components/AgentStreamDisplay.vue'),
 )
@@ -94,28 +77,29 @@ const DeepThink = defineAsyncComponent(
   () => import('@/views/chat/components/deepThink.vue'),
 )
 
-marked.use({ breaks: true })
-marked.use(markedKatex({ throwOnError: false, nonStandard: true }))
 ensureMermaidInitialized()
 
-const preprocessMathDelimiters = (rawText: string): string => {
-  if (!rawText || typeof rawText !== 'string') return ''
-  return rawText
-    .replace(/\\\[([\s\S]*?)\\\]/g, '$$$$$1$$$$')
-    .replace(/\\\(([\s\S]*?)\\\)/g, '$$$1$$')
-}
+const markdownRenderer = createChatMarkdownRenderer({
+  codeRenderer: createMermaidCodeRenderer('mermaid-embed-botmsg'),
+  imageRenderer: ({ href, title, text }) => createSafeImage(href, text || '', title || ''),
+  isValidImageUrl: isValidImageURL,
+})
 
-const customRenderer = new marked.Renderer()
-customRenderer.image = function ({ href, title, text }) {
-  if (!isValidImageURL(href)) return ''
-  return createSafeImage(href, text || '', title || '')
+type EmbedSession = {
+  content?: string
+  isRagMode?: boolean
+  isAgentMode?: boolean
+  showThink?: boolean
+  hideContent?: boolean
+  is_completed?: boolean
+  agentEventStream?: Array<Record<string, unknown>>
+  knowledge_references?: Array<{ chunk_type?: string; knowledge_id?: string; knowledge_title?: string }>
 }
-customRenderer.code = createMermaidCodeRenderer('mermaid-embed-botmsg')
 
 const props = withDefaults(
   defineProps<{
     content?: string
-    session?: Record<string, unknown>
+    session?: EmbedSession
     sessionId?: string
     userQuery?: string
     embeddedMode?: boolean
@@ -161,15 +145,11 @@ const scheduleCitationClose = () => {
 const renderedHTML = computed(() => {
   const text = String(props.content || props.session?.content || '')
   if (!text.trim()) return ''
-  const { text: tagSafe, tags } = preserveCitationTags(text)
-  const processed = replaceIncompleteImageWithPlaceholder(tagSafe)
-  const mathSafe = preprocessMathDelimiters(processed)
-  const restoredTags = restoreCitationTags(mathSafe, tags)
-  const safeMarkdown = safeMarkdownToHTML(restoredTags)
-  const { content: mdWithPlaceholders, htmlSnippets } = extractCitationHtmlPlaceholders(safeMarkdown)
-  const html = marked.parse(mdWithPlaceholders, { renderer: customRenderer, breaks: true }) as string
-  const withCitations = restoreCitationHtmlPlaceholders(html, htmlSnippets)
-  return sanitizeHTML(withCitations)
+  return renderChatMarkdown(text, {
+    renderer: markdownRenderer,
+    escapeMarkdown: safeMarkdownToHTML,
+    sanitizeHtml: sanitizeMarkdownHTML,
+  })
 })
 
 const hasActualContent = computed(() => {
@@ -186,7 +166,7 @@ const hydrateImages = async () => {
 }
 
 const renderMermaidDiagrams = async () => {
-  await renderMermaidInContainer(parentMd.value)
+  await enhanceMarkdownContainer(parentMd.value)
 }
 
 watch(renderedHTML, () => {
@@ -217,7 +197,8 @@ onMounted(() => {
 </script>
 
 <style scoped lang="less">
-@import '../../components/css/markdown.less';
+@import '../../components/css/chat-markdown.less';
+@import '../../components/css/chat-citations.less';
 
 .embed-bot-msg {
   border-radius: 4px;
@@ -236,130 +217,21 @@ onMounted(() => {
   }
 }
 
-.content-wrapper {
-  background: var(--td-bg-color-container);
-  border-radius: 6px;
-  padding: 8px 0;
+.rag-answer-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
 }
 
-.ai-markdown-template {
-  font-size: 15px;
-  color: var(--td-text-color-primary);
-  line-height: 1.6;
+.content-wrapper {
+  padding: 2px 0;
 }
 
 .markdown-content {
-  :deep(p) {
-    margin: 6px 0;
-    line-height: 1.6;
-  }
-
-  :deep(code) {
-    background: var(--td-bg-color-secondarycontainer);
-    padding: 2px 5px;
-    border-radius: 3px;
-    font-family: var(--app-font-family-mono);
-    font-size: 11px;
-  }
-
-  :deep(pre) {
-    background: var(--td-bg-color-secondarycontainer);
-    padding: 10px;
-    border-radius: 4px;
-    overflow-x: auto;
-    margin: 6px 0;
-
-    code {
-      background: none;
-      padding: 0;
-    }
-  }
-
-  :deep(ul),
-  :deep(ol) {
-    margin: 6px 0;
-    padding-left: 20px;
-  }
-
-  :deep(li) {
-    margin: 3px 0;
-  }
-
-  :deep(blockquote) {
-    border-left: 2px solid var(--td-brand-color);
-    padding-left: 10px;
-    margin: 6px 0;
-    color: var(--td-text-color-secondary);
-  }
-
-  :deep(h1),
-  :deep(h2),
-  :deep(h3),
-  :deep(h4),
-  :deep(h5),
-  :deep(h6) {
-    margin: 10px 0 6px;
-    font-weight: 600;
-    color: var(--td-text-color-primary);
-  }
-
-  :deep(a) {
-    color: var(--td-brand-color);
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-
-  :deep(table) {
-    border-collapse: collapse;
-    margin: 6px 0;
-    font-size: 11px;
-    width: 100%;
-
-    th,
-    td {
-      border: 1px solid var(--td-component-stroke);
-      padding: 5px 8px;
-      text-align: left;
-    }
-
-    th {
-      background: var(--td-bg-color-secondarycontainer);
-      font-weight: 600;
-    }
-
-    tbody tr:nth-child(even) {
-      background: var(--td-bg-color-secondarycontainer);
-    }
-  }
-
-  :deep(img) {
-    max-width: 80%;
-    max-height: 300px;
-    width: auto;
-    height: auto;
-    border-radius: 8px;
-    display: block;
-    margin: 8px 0;
-    border: 0.5px solid var(--td-component-stroke);
-    object-fit: contain;
-  }
-
-  :deep(.mermaid) {
-    margin: 16px 0;
-    padding: 16px;
-    background: var(--td-bg-color-secondarycontainer);
-    border-radius: 8px;
-    overflow-x: auto;
-    text-align: center;
-
-    svg {
-      max-width: 100%;
-      height: auto;
-    }
-  }
+  // Chat Markdown visual styles are centralized in chat-markdown.less.
+  // Do not add element-level Markdown rules here; update the shared mixin.
+  .chat-markdown-typography();
+  .chat-citation-pills();
 }
 
 .loading-indicator {
@@ -393,6 +265,7 @@ onMounted(() => {
 }
 
 @keyframes typingBounce {
+
   0%,
   60%,
   100% {
@@ -401,69 +274,6 @@ onMounted(() => {
 
   30% {
     transform: translateY(-8px);
-  }
-}
-
-.markdown-content {
-  :deep(.citation) {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    border-radius: 10px;
-    padding: 2px 4px;
-    font-size: 11px;
-    line-height: 1.4;
-    margin: 0 4px;
-  }
-
-  :deep(.citation-web),
-  :deep(.citation-kb) {
-    background: color-mix(in srgb, var(--td-brand-color) 8%, transparent);
-    color: var(--td-brand-color);
-    border: 1px solid color-mix(in srgb, var(--td-brand-color) 20%, transparent);
-    cursor: pointer;
-    white-space: nowrap;
-  }
-
-  :deep(.citation-web:hover),
-  :deep(.citation-kb:hover) {
-    background: color-mix(in srgb, var(--td-brand-color) 12%, transparent);
-    border-color: var(--td-brand-color);
-  }
-
-  :deep(.citation .citation-icon) {
-    display: inline-block;
-    width: 14px;
-    height: 14px;
-    background-color: var(--embed-primary, var(--td-brand-color));
-    mask-size: contain;
-    mask-repeat: no-repeat;
-    mask-position: center;
-    -webkit-mask-size: contain;
-    -webkit-mask-repeat: no-repeat;
-    -webkit-mask-position: center;
-    flex-shrink: 0;
-  }
-
-  :deep(.citation .citation-icon.web) {
-    mask-image: url('@/assets/img/websearch-globe.svg');
-    -webkit-mask-image: url('@/assets/img/websearch-globe.svg');
-  }
-
-  :deep(.citation .citation-icon.kb) {
-    mask-image: url('@/assets/img/zhishiku.svg');
-    -webkit-mask-image: url('@/assets/img/zhishiku.svg');
-  }
-
-  :deep(.citation-tip) {
-    display: none;
-  }
-
-  :deep(a.wiki-content-link) {
-    color: var(--td-brand-color);
-    border-bottom: 1px dashed var(--td-brand-color);
-    text-decoration: none;
-    font-weight: 500;
   }
 }
 

--- a/frontend/src/views/embed/EmbedChatCore.vue
+++ b/frontend/src/views/embed/EmbedChatCore.vue
@@ -70,7 +70,7 @@
           </div>
         </div>
 
-        <div v-if="loading" class="embed-chat__typing">
+        <div v-if="showGlobalTypingIndicator" class="embed-chat__typing">
           <div class="loading-typing">
             <span></span>
             <span></span>
@@ -179,6 +179,7 @@ const {
   scrollContainer,
   userHasScrolledUp,
   shouldRenderAssistantMessage,
+  shouldShowGlobalTypingIndicator,
   getUserQuery,
   handleScroll,
   scrollToBottom,
@@ -208,6 +209,10 @@ const hasWelcomeText = computed(() => welcomeText.value.length > 0)
 
 const hasUserMessage = computed(() =>
   messagesList.some((m) => m.role === 'user'))
+
+const showGlobalTypingIndicator = computed(() =>
+  shouldShowGlobalTypingIndicator(messagesList, loading.value),
+)
 
 /** 访客未发言前始终展示欢迎语（含历史加载中），发送后隐藏 */
 const showWelcome = computed(() => hasWelcomeText.value && !hasUserMessage.value)
@@ -444,7 +449,7 @@ watch(
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--embed-primary, #0052d9);
+    background: var(--td-text-color-placeholder);
     animation: typingBounce 1.4s ease-in-out infinite;
 
     &:nth-child(1) { animation-delay: 0s; }

--- a/frontend/src/views/embed/EmbedUserMessage.vue
+++ b/frontend/src/views/embed/EmbedUserMessage.vue
@@ -1,14 +1,8 @@
 <template>
   <div ref="containerRef" class="embed-user-msg" :class="{ 'is-embedded': embeddedMode }">
     <div v-if="hasImages" class="user_images">
-      <img
-        v-for="(img, idx) in displayImages"
-        :key="idx"
-        :src="img.url"
-        class="user_image_thumb"
-        alt=""
-        @click="previewImage($event)"
-      />
+      <img v-for="(img, idx) in displayImages" :key="idx" :src="img.url" class="user_image_thumb" alt=""
+        @click="previewImage($event)" />
     </div>
     <div v-if="hasAttachments" class="user_attachments">
       <div v-for="(att, idx) in attachments" :key="idx" class="user_attachment_card">
@@ -118,7 +112,7 @@ const formatFileSize = (bytes: number): string => {
   background: #8ce97f;
   margin-left: auto;
   color: #000000e6;
-  font-size: 15px;
+  font-size: 16px;
   text-align: justify;
   word-break: break-all;
   box-sizing: border-box;


### PR DESCRIPTION
## Summary
- Extract shared chat markdown styles, renderer, DOMPurify config, syntax highlighting, and mermaid support
- Add ChatCitationFloat hover UI and session-scoped citation chunk cache
- Unify citation markdown handling for main chat and embed views

## Test plan
- [ ] `node --test frontend/src/utils/chatMarkdownRenderer.test.ts frontend/src/utils/citationChunkCache.test.mjs`
- [ ] Hover citation tags in chat and embed — verify popover content loads
- [ ] Verify markdown code blocks, mermaid, and math render correctly