### PR TITLE
fix(frontend): list writable shared KBs in manual knowledge editor

### DIFF
--- a/frontend/src/components/manual-knowledge-editor.vue
+++ b/frontend/src/components/manual-knowledge-editor.vue
@@ -11,6 +11,7 @@ import {
   updateManualKnowledge,
 } from '@/api/knowledge-base'
 import { useUploadConfirmStore } from '@/stores/uploadConfirm'
+import { useOrganizationStore } from '@/stores/organization'
 import type { KnowledgeProcessOverrides } from '@/types/knowledgeProcess'
 import { sanitizeHTML, safeMarkdownToHTML } from '@/utils/security'
 import { useI18n } from 'vue-i18n'
@@ -33,6 +34,7 @@ type ManualStatus = 'draft' | 'publish'
 
 const uiStore = useUIStore()
 const uploadConfirmStore = useUploadConfirmStore()
+const organizationStore = useOrganizationStore()
 const { t } = useI18n()
 
 const visible = computed({
@@ -410,22 +412,30 @@ const lastUpdatedText = computed(() =>
 const loadKnowledgeBases = async () => {
   kbLoading.value = true
   try {
-    const res: any = await listKnowledgeBases()
-    console.log('[ManualEditor] Raw knowledge bases response:', res?.data)
-    
-    const allKbs = Array.isArray(res?.data) ? res.data : []
-    console.log('[ManualEditor] All knowledge bases:', allKbs)
-    console.log('[ManualEditor] KB types:', allKbs.map((kb: any) => ({ name: kb.name, type: kb.type })))
-    
-    const list: KnowledgeBaseOption[] = allKbs
-      .filter((item: any) => {
-        const isDocument = !item.type || item.type === 'document'
-        console.log(`[ManualEditor] KB "${item.name}" (type: ${item.type}): ${isDocument ? 'INCLUDED' : 'FILTERED OUT'}`)
-        return isDocument
-      })
+    const [ownRes, sharedKbs] = await Promise.all([
+      listKnowledgeBases() as Promise<any>,
+      organizationStore.fetchSharedKnowledgeBases().catch(() => []),
+    ])
+
+    const isDocumentKb = (type?: string) => !type || type === 'document'
+
+    const ownKbs = Array.isArray(ownRes?.data) ? ownRes.data : []
+    const list: KnowledgeBaseOption[] = ownKbs
+      .filter((item: any) => isDocumentKb(item.type))
       .map((item: any) => ({ label: item.name, value: item.id }))
-    
-    console.log('[ManualEditor] Filtered knowledge bases:', list)
+
+    // Knowledge bases shared to the user with write access (editor/admin)
+    // also accept manually-added content, so they must appear in the picker;
+    // viewer-only shares are excluded since the backend would reject writes.
+    const seen = new Set(list.map((o) => o.value))
+    for (const share of sharedKbs) {
+      const kb = share?.knowledge_base
+      const canWrite = share?.permission === 'editor' || share?.permission === 'admin'
+      if (!kb || !canWrite || !isDocumentKb(kb.type) || seen.has(kb.id)) continue
+      seen.add(kb.id)
+      list.push({ label: kb.name, value: kb.id })
+    }
+
     kbOptions.value = list
 
     if (mode.value === 'create') {
@@ -443,9 +453,6 @@ const loadKnowledgeBases = async () => {
         form.kbId = list[0]?.value ?? ''
       }
     }
-    
-    console.log('[ManualEditor] Final kbOptions:', kbOptions.value)
-    console.log('[ManualEditor] Selected kbId:', form.kbId)
   } catch (error) {
     console.error('[ManualEditor] Failed to load knowledge base list:', error)
     kbOptions.value = []


### PR DESCRIPTION
## Description

On the chat page, **Add to knowledge base** opens the manual knowledge editor (`manual-knowledge-editor.vue`), whose target-KB picker was populated only from `listKnowledgeBases()` — i.e. the caller's **own** knowledge bases. A user who was granted **editor** access to a knowledge base shared into their space could therefore not select it in the picker, so they could not save a chat message into that shared KB.

The backend already permits this: `CreateManualKnowledge` (`internal/handler/knowledge.go`) accepts `editor`/`admin` permission on shared KBs. Only the frontend list was missing them.

This change additionally fetches shared knowledge bases (via the existing cached `organizationStore.fetchSharedKnowledgeBases()`) and merges those the user can write to into the picker:
- only **editor**/**admin** shares (viewer-only stays excluded — the backend would reject the write);
- de-duplicated against owned KBs;
- limited to `document`-type KBs, same as the existing filter.

The permission filter matches the store's existing `canEditKB` semantics. Both chat entry points (`botmsg.vue` and `AgentStreamDisplay.vue`) route through this editor, so both are covered. I also dropped the leftover `console.log` debug lines in the function being edited.

## Type of Change
- [x] 🐛 Bug fix

## Related Issue
Fixes #1689

## Testing
- Traced both "add to knowledge base" entry points to `uiStore.openManualEditor` → `manual-knowledge-editor.vue#loadKnowledgeBases`, confirmed the picker is the only gate.
- Verified `CreateManualKnowledge` permits `editor`/`admin` shared-KB writes, so the picker was the sole blocker.
- Note: a full local frontend type-check/lint was not run in this environment (no `node_modules` installed); the change reuses already-typed store/API surfaces (`SharedKnowledgeBase`, `fetchSharedKnowledgeBases`). Please let CI's lint/type-check confirm.

## Checklist
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change (no FE unit-test harness for this component)
- [ ] Updated related documentation (no doc/API surface change)