### PR TITLE
feat(wiki): front-load static rules in chunk-citation prompt for prefix cache

### DIFF
--- a/internal/agent/prompts_wiki.go
+++ b/internal/agent/prompts_wiki.go
@@ -207,30 +207,27 @@ Output ONLY valid JSON. Example:
 // to read a batch of chunks and, for each candidate entity/concept, list the
 // chunk IDs that substantively discuss it. This keeps per-slug "facts" in
 // their verbatim form (the chunk text) instead of asking the LLM to paraphrase.
+// Block order matters for provider prefix caching: the static rules,
+// output schema and the per-document-stable <candidate_slugs> are placed
+// BEFORE the per-batch <chunks> block. Within one document only ChunksXML
+// changes between batches, so every batch after the first shares the long
+// [rules | candidate_slugs] prefix and avoids re-billing the static rules.
 const WikiChunkCitationPrompt = `You are a precise citation system. Your job is to scan a batch of document chunks and decide, for each candidate entity/concept below, which chunks substantively discuss it.
-
-<candidate_slugs>
-{{.CandidateSlugs}}
-</candidate_slugs>
-
-<chunks>
-{{.ChunksXML}}
-</chunks>
 
 <instructions>
 **IMPORTANT: Write ALL names, descriptions, and details in {{.Language}}**.
 
 ### Primary task
-For each candidate slug above, select the chunk IDs (from the <chunks> block) that **substantively discuss** that entity/concept. "Substantively" means the chunk states at least one concrete fact, attribute, step, date, number, relationship, or other useful piece of information about the candidate — not a passing mention.
+For each candidate slug (listed in <candidate_slugs> below), select the chunk IDs (from the <chunks> block below) that **substantively discuss** that entity/concept. "Substantively" means the chunk states at least one concrete fact, attribute, step, date, number, relationship, or other useful piece of information about the candidate — not a passing mention.
 
-- Only cite chunks that appear in the <chunks> block above.
+- Only cite chunks that appear in the <chunks> block below.
 - Use the "id" attribute of each <c> element verbatim (e.g. "c003").
 - If a candidate is not meaningfully discussed in ANY chunk in this batch, omit it from the output (do not include empty arrays).
 - A chunk CAN be cited by multiple candidates if it genuinely discusses multiple of them.
 - If a chunk is overly long or mixes unrelated topics, still cite it for every candidate it discusses.
 
 ### Secondary task: new slugs
-If this batch reveals a significant entity/concept that is **NOT** in <candidate_slugs>, you may add it under "new_slugs" so it gets incorporated. Only add genuinely new, substantively-discussed items. Do NOT rediscover items already listed above — reuse their slug if they are already candidates.
+If this batch reveals a significant entity/concept that is **NOT** in <candidate_slugs>, you may add it under "new_slugs" so it gets incorporated. Only add genuinely new, substantively-discussed items. Do NOT rediscover items already listed in <candidate_slugs> — reuse their slug if they are already candidates.
 
 Each new slug must include:
 - "type": "entity" or "concept"
@@ -261,7 +258,17 @@ Output format:
   ]
 }
 
-If nothing in this batch is cite-worthy, return: {"citations": {}, "new_slugs": []}`
+If nothing in this batch is cite-worthy, return: {"citations": {}, "new_slugs": []}
+
+<candidate_slugs>
+{{.CandidateSlugs}}
+</candidate_slugs>
+
+<chunks>
+{{.ChunksXML}}
+</chunks>
+
+Now apply the instructions above to the chunks and output ONLY the JSON.`
 
 // WikiPageModifyPrompt updates an existing wiki page with new additions and removes stale/deleted information in a single pass.
 const WikiPageModifyPrompt = `You are a wiki editor tasked with updating an existing wiki page. You must process a set of NEW information to add, AND/OR a set of deleted documents whose exclusive contributions must be REMOVED.

--- a/internal/agent/prompts_wiki_test.go
+++ b/internal/agent/prompts_wiki_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"strings"
 	"testing"
+	"text/template"
 )
 
 func TestWikiGranularityGuidance_RoutesByKey(t *testing.T) {
@@ -59,5 +60,66 @@ func TestWikiGranularityGuidance_BlocksAreDistinct(t *testing.T) {
 	}
 	if !strings.Contains(WikiGranularityGuidanceExhaustive, "EXHAUSTIVE") {
 		t.Error("exhaustive block should self-identify")
+	}
+}
+
+func renderWikiChunkCitation(t *testing.T, candidateSlugs, chunksXML, lang string) string {
+	t.Helper()
+	tmpl, err := template.New("cite").Parse(WikiChunkCitationPrompt)
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+	var b strings.Builder
+	if err := tmpl.Execute(&b, map[string]string{
+		"CandidateSlugs": candidateSlugs,
+		"ChunksXML":      chunksXML,
+		"Language":       lang,
+	}); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+	return b.String()
+}
+
+// TestWikiChunkCitationPrompt_StablePrefixAcrossBatches verifies the property
+// that enables provider prefix caching (issue #1687): within one document the
+// candidate slugs and the static rules are constant and only the per-batch
+// <chunks> block changes, so everything up to <chunks> must be byte-identical
+// across batches. If the static rules trailed <chunks> they would be re-billed
+// on every batch and this prefix would diverge.
+func TestWikiChunkCitationPrompt_StablePrefixAcrossBatches(t *testing.T) {
+	const slugs = "entity/acme = Acme Corp\nconcept/rag = Retrieval-Augmented Generation"
+
+	a := renderWikiChunkCitation(t, slugs, `<c id="c001">first batch text</c>`, "English")
+	b := renderWikiChunkCitation(t, slugs, `<c id="c099">a completely different second batch</c>`, "English")
+
+	// Match the standalone <chunks> tag line (the per-batch data block), not the
+	// inline "<chunks> block" references inside the instructions prose.
+	const marker = "\n<chunks>\n"
+	ia := strings.Index(a, marker)
+	ib := strings.Index(b, marker)
+	if ia < 0 || ib < 0 {
+		t.Fatalf("rendered prompt missing %q block", marker)
+	}
+
+	if a[:ia] != b[:ib] {
+		t.Errorf("prompt prefix before <chunks> differs across batches — provider prefix cache will miss.\nA-prefix:\n%s\n---\nB-prefix:\n%s", a[:ia], b[:ib])
+	}
+
+	// The static rules and per-document candidate-slug block must live inside
+	// that shared prefix, not after the varying chunks.
+	for _, must := range []string{"### Primary task", "### JSON Formatting Rules", "\n<candidate_slugs>\n"} {
+		if idx := strings.Index(a, must); idx < 0 || idx > ia {
+			t.Errorf("%q must appear before <chunks> to be part of the cached prefix (idx=%d, chunks=%d)", must, idx, ia)
+		}
+	}
+}
+
+// TestWikiChunkCitationPrompt_PreservesPlaceholders guards against accidental
+// loss of a template field during future reorders.
+func TestWikiChunkCitationPrompt_PreservesPlaceholders(t *testing.T) {
+	for _, field := range []string{"{{.Language}}", "{{.CandidateSlugs}}", "{{.ChunksXML}}"} {
+		if !strings.Contains(WikiChunkCitationPrompt, field) {
+			t.Errorf("WikiChunkCitationPrompt lost template field %q", field)
+		}
 	}
 }


### PR DESCRIPTION
## Description

A focused first step toward #1687 (low wiki-synthesis prefix-cache hit rate, measured ~6.4%).

`WikiChunkCitationPrompt` is rendered once per chunk batch in the chunk-cited wiki pipeline ([wiki_ingest_cite.go](internal/application/service/wiki_ingest_cite.go)). Within a single document, only `ChunksXML` changes between batches — `CandidateSlugs`, the static rules and the output schema are identical. The previous template put the per-batch `<chunks>` block **before** the static rules and `<candidate_slugs>`, so the large stable content trailed the varying chunks and could not form a long common prefix. Providers (DeepSeek-style implicit caching, etc.) therefore re-billed the static rules on every batch.

This reorders the template to `[rules | output schema | candidate_slugs | chunks]`, exactly as the issue proposes (`规则 → CandidateSlugs → ChunksXML`), so every batch after the first shares the long `[rules | candidate_slugs]` prefix.

**No instruction text was dropped** — only block order changed, plus the inline directional references (`above`/`below`) were updated to stay coherent (e.g. "the `<chunks>` block above" → "below"). The output schema, JSON-format rules and all citation rules are unchanged.

## Type of Change
- [x] ⚡ Performance improvement

## Related Issue
Addresses #1687 (scoped to the chunk-citation template; the per-page `WikiPageModifyPrompt` and a unified `WikiStaticPrefix` can follow in separate PRs).

## Testing
Added `TestWikiChunkCitationPrompt_StablePrefixAcrossBatches` and `TestWikiChunkCitationPrompt_PreservesPlaceholders` in `internal/agent/prompts_wiki_test.go`. The first renders the template for two different batches (same `CandidateSlugs`, different `ChunksXML`) and asserts the prompt prefix up to the standalone `<chunks>` block is byte-identical and contains the static rules — i.e. the property that lets the provider cache it.

I verified the change against the **real constant** (the heavy `internal/agent` package wouldn't build in my constrained local env, so I extracted and rendered the actual `WikiChunkCitationPrompt` string directly):
- **before:** cacheable prefix = **281 bytes** (only intro + candidate_slugs); the static rules sat *after* the varying chunks → re-billed per batch.
- **after:** cacheable prefix = **2366 bytes**, byte-identical across batches, with the full rule block inside it.

`gofmt -l` clean. Please let CI run the full `go vet` / `make test`.

## Checklist
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (no doc/API surface change)