### PR TITLE
feat: add tenant workspace deletion UI

### DIFF
--- a/frontend/src/api/tenant/index.ts
+++ b/frontend/src/api/tenant/index.ts
@@ -1,4 +1,4 @@
-import { get, post, put } from '@/utils/request'
+import { del, get, post, put } from '@/utils/request'
 import i18n from '@/i18n'
 
 const t = (key: string) => i18n.global.t(key)
@@ -92,6 +92,23 @@ export async function updateTenant(
 }
 
 /**
+ * 删除当前工作区。权限：owner。
+ */
+export async function deleteTenant(
+  tenantId: number,
+): Promise<{ success: boolean; message?: string }> {
+  try {
+    const response = await del(`/api/v1/tenants/${tenantId}`)
+    return response as unknown as { success: boolean; message?: string }
+  } catch (error: any) {
+    return {
+      success: false,
+      message: error.message || t('error.tenant.deleteFailed'),
+    }
+  }
+}
+
+/**
  * 创建新工作区（任意已登录用户均可调用）。
  * 后端会自动把调用者写成新租户的 Owner，并生成 api_key、默认 storage_quota
  * 等服务端字段，所以这里只暴露 name + description。
@@ -141,4 +158,3 @@ export async function searchTenants(params: SearchTenantsParams = {}): Promise<S
     }
   }
 }
-

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -3209,6 +3209,18 @@ export default {
       desc: 'Ends your membership in this workspace. You will lose access to its knowledge bases and agents. You can be invited again later.',
       button: 'Leave workspace',
     },
+    deleteDangerZone: {
+      title: 'Delete this workspace',
+      desc: 'Delete the whole workspace and its configuration. Members will no longer be able to access its knowledge bases, agents, or API key.',
+      button: 'Delete workspace',
+      confirmTitle: 'Delete this workspace?',
+      confirmBody: 'This will delete "{name}" and make its knowledge bases, agents, members, and API key unavailable. This action cannot be undone.',
+      confirmHint: 'Type the workspace name "{name}" to confirm deletion.',
+      confirm: 'Delete workspace',
+      nameMismatch: 'Workspace name does not match',
+      success: 'Workspace deleted',
+      failed: 'Failed to delete workspace',
+    },
     messages: {
       fetchFailed: 'Failed to fetch tenant information',
       networkError: 'Network error, please try again later'
@@ -3519,6 +3531,7 @@ export default {
       searchFailed: 'Failed to search tenants',
       resetApiKeyFailed: 'Failed to reset API Key',
       updateFailed: 'Failed to update tenant information',
+      deleteFailed: 'Failed to delete tenant',
     },
     initialization: {
       checkFailed: 'Check failed',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2269,6 +2269,18 @@ export default {
       desc: "终止您在本空间的成员身份。退出后将无法访问本空间的知识库与智能体，之后可被再次邀请加入。",
       button: "退出空间",
     },
+    deleteDangerZone: {
+      title: "删除当前空间",
+      desc: "删除整个空间及其配置。删除后，空间成员将无法继续访问其中的知识库、智能体与 API Key。",
+      button: "删除空间",
+      confirmTitle: "删除当前空间？",
+      confirmBody: "此操作将删除空间「{name}」，并使其中的知识库、智能体、成员与 API Key 不再可用。此操作不可撤销。",
+      confirmHint: "请输入空间名称「{name}」以确认删除。",
+      confirm: "确认删除",
+      nameMismatch: "空间名称不匹配",
+      success: "空间已删除",
+      failed: "删除空间失败",
+    },
     messages: {
       fetchFailed: "获取空间信息失败",
       networkError: "网络错误，请稍后重试",
@@ -2578,6 +2590,7 @@ export default {
       searchFailed: "搜索空间失败",
       resetApiKeyFailed: "重置 API Key 失败",
       updateFailed: "更新空间信息失败",
+      deleteFailed: "删除空间失败",
     },
     initialization: {
       checkFailed: "检查失败",

--- a/frontend/src/views/settings/TenantInfo.vue
+++ b/frontend/src/views/settings/TenantInfo.vue
@@ -199,7 +199,42 @@
         </div>
       </aside>
 
+      <aside v-if="showDeleteDangerZone" class="leave-space-panel delete-space-panel"
+        :aria-label="$t('tenant.deleteDangerZone.title')">
+        <div class="leave-space-panel-inner">
+          <div class="leave-space-panel-text">
+            <div class="leave-space-panel-title">{{ $t('tenant.deleteDangerZone.title') }}</div>
+            <p class="leave-space-panel-desc">{{ $t('tenant.deleteDangerZone.desc') }}</p>
+          </div>
+          <div class="leave-space-panel-action">
+            <t-button theme="danger" size="medium" @click="confirmDeleteTenant">
+              {{ $t('tenant.deleteDangerZone.button') }}
+            </t-button>
+          </div>
+        </div>
+      </aside>
+
     </div>
+
+    <t-dialog v-model:visible="deleteTenantVisible" :header="$t('tenant.deleteDangerZone.confirmTitle')"
+      :confirm-btn="{
+        content: $t('tenant.deleteDangerZone.confirm'),
+        theme: 'danger',
+        disabled: deleteConfirmName.trim() !== (tenantInfo?.name || ''),
+        loading: deletingTenant,
+      }" :cancel-btn="$t('common.cancel')" :close-on-overlay-click="!deletingTenant"
+      :close-btn="!deletingTenant" @confirm="deleteCurrentTenant">
+      <div class="delete-tenant-confirm">
+        <p class="delete-tenant-confirm-body">
+          {{ $t('tenant.deleteDangerZone.confirmBody', { name: tenantInfo?.name || '' }) }}
+        </p>
+        <p class="delete-tenant-confirm-hint">
+          {{ $t('tenant.deleteDangerZone.confirmHint', { name: tenantInfo?.name || '' }) }}
+        </p>
+        <t-input v-model="deleteConfirmName" :placeholder="tenantInfo?.name || ''" :disabled="deletingTenant"
+          clearable />
+      </div>
+    </t-dialog>
   </div>
 </template>
 
@@ -207,7 +242,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { DialogPlugin, MessagePlugin } from 'tdesign-vue-next'
 import { getCurrentUser, type TenantInfo } from '@/api/auth'
-import { updateTenant as updateTenantApi } from '@/api/tenant'
+import { deleteTenant as deleteTenantApi, updateTenant as updateTenantApi } from '@/api/tenant'
 import {
   leaveTenant,
   fetchAllTenantMembers,
@@ -252,6 +287,12 @@ const showLeaveDangerZone = computed(() => {
   if (!currentTenantRole.value) return false
   if (Number(tenantInfo.value.id) !== activeTenantNumericId.value) return false
   return canLeaveSpace.value
+})
+
+const showDeleteDangerZone = computed(() => {
+  if (loading.value || error.value || !tenantInfo.value) return false
+  if (Number(tenantInfo.value.id) !== activeTenantNumericId.value) return false
+  return authStore.hasRole('owner')
 })
 
 async function evaluateLeaveGate(): Promise<void> {
@@ -318,6 +359,41 @@ function confirmLeaveTenant() {
   })
 }
 
+function confirmDeleteTenant() {
+  const tid = Number(tenantInfo.value?.id ?? 0)
+  const tenantName = tenantInfo.value?.name || ''
+  if (!tid || !tenantName) return
+  deleteConfirmName.value = ''
+  deleteTenantVisible.value = true
+}
+
+async function deleteCurrentTenant() {
+  const tid = Number(tenantInfo.value?.id ?? 0)
+  const tenantName = tenantInfo.value?.name || ''
+  if (!tid || !tenantName) return
+  if (deleteConfirmName.value.trim() !== tenantName) {
+    MessagePlugin.warning(t('tenant.deleteDangerZone.nameMismatch'))
+    return
+  }
+  try {
+    deletingTenant.value = true
+    const resp = await deleteTenantApi(tid)
+    if (resp.success) {
+      MessagePlugin.success(t('tenant.deleteDangerZone.success'))
+      authStore.logout()
+      window.location.href = '/login'
+    } else {
+      MessagePlugin.error(resp.message || t('tenant.deleteDangerZone.failed'))
+    }
+  } catch (err: any) {
+    MessagePlugin.error(err?.message || t('tenant.deleteDangerZone.failed'))
+  } finally {
+    deletingTenant.value = false
+    deleteConfirmName.value = ''
+    deleteTenantVisible.value = false
+  }
+}
+
 watch(
   [() => tenantInfo.value?.id, () => authStore.currentTenantId, () => authStore.currentTenantRole],
   () => {
@@ -332,6 +408,9 @@ watch(
 const editing = ref(false)
 const editName = ref('')
 const saving = ref(false)
+const deleteConfirmName = ref('')
+const deleteTenantVisible = ref(false)
+const deletingTenant = ref(false)
 const editNameTrimmed = computed(() => editName.value.trim())
 // 保存按钮可点条件：非空、改了内容、不在保存中。
 // 后端 name 字段没有 uniqueIndex 也没有重名校验，所以这里不做"是否已存在"的判断；
@@ -723,6 +802,10 @@ onMounted(() => {
   margin-top: 4px;
 }
 
+.delete-space-panel {
+  margin-top: 12px;
+}
+
 .leave-space-panel-inner {
   display: flex;
   flex-direction: row;
@@ -792,5 +875,17 @@ onMounted(() => {
     min-width: 50px;
     text-align: right;
   }
+}
+
+.delete-tenant-confirm-body {
+  margin: 0 0 10px;
+  color: var(--td-text-color-primary);
+  line-height: 1.6;
+}
+
+.delete-tenant-confirm-hint {
+  margin: 0 0 12px;
+  color: var(--td-text-color-secondary);
+  line-height: 1.5;
 }
 </style>


### PR DESCRIPTION
## Summary
- add a frontend wrapper for the existing DELETE /api/v1/tenants/:id API
- expose an owner-only delete workspace action in the tenant settings danger zone
- require typing the workspace name before deletion and clear local auth state after success
- add English and Chinese copy for the delete workspace flow

## Tests
- npm run build-only
- npm run type-check (fails on existing unrelated main-branch TypeScript errors; no reported errors point to the changed files)