### PR TITLE
perf(sandbox): compile command-substitution regexps once

### DIFF
--- a/internal/sandbox/validator.go
+++ b/internal/sandbox/validator.go
@@ -217,15 +217,18 @@ func (v *ScriptValidator) hasShellOperators(s string) bool {
 	return false
 }
 
+// Command-substitution patterns, compiled once. hasCommandSubstitution runs
+// per argument in ValidateArgs, so recompiling these on every call wasted work
+// proportional to the argument count.
+var commandSubstitutionPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\$\([^)]+\)`),   // $(command)
+	regexp.MustCompile("`[^`]+`"),       // `command`
+	regexp.MustCompile(`\$\{[^}]*\$\(`), // ${...$(command)
+}
+
 // hasCommandSubstitution checks for command substitution patterns
 func (v *ScriptValidator) hasCommandSubstitution(s string) bool {
-	patterns := []*regexp.Regexp{
-		regexp.MustCompile(`\$\([^)]+\)`),   // $(command)
-		regexp.MustCompile("`[^`]+`"),       // `command`
-		regexp.MustCompile(`\$\{[^}]*\$\(`), // ${...$(command)
-	}
-
-	for _, p := range patterns {
+	for _, p := range commandSubstitutionPatterns {
 		if p.MatchString(s) {
 			return true
 		}

--- a/internal/sandbox/validator_test.go
+++ b/internal/sandbox/validator_test.go
@@ -359,3 +359,12 @@ func containsHelper(s, substr string) bool {
 	}
 	return false
 }
+
+func BenchmarkValidateArgs(b *testing.B) {
+	v := NewScriptValidator()
+	args := []string{"--input", "file.txt", "--name", "report 2024", "--out", "/tmp/x", "--verbose", "--limit=50"}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = v.ValidateArgs(args)
+	}
+}


### PR DESCRIPTION
## Description

`ScriptValidator.hasCommandSubstitution` (`internal/sandbox/validator.go`) recompiled its three command-substitution regexps with `regexp.MustCompile` on **every call**, and `ValidateArgs` calls it once per argument — so validating an N-argument command compiled 3N patterns. (`compilePatterns` for the dangerous/arg-injection lists is already done once in the constructor; this was the remaining per-call site.)

Hoist the three patterns to a package-level slice compiled once at init. **Behavior is unchanged** — same regexps — and the existing `TestScriptValidator_ValidateArgs` / `ValidateAll` tests pass.

## Type of Change
- [x] ⚡ Performance improvement

## Testing
Existing sandbox tests pass. Added `BenchmarkValidateArgs` (8 args, `-benchmem`):

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before | 16374 | 40142 | 505 |
| after | 2092 | 32 | 1 |

~7.8× faster, essentially zero allocations. `gofmt -l` clean.

## Checklist
- [x] gofmt clean
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change (benchmark; behavior covered by existing tests)
- [ ] Updated related documentation (none needed)