### PR TITLE
fix(docreader): restore epub and mhtml parser registration

### DIFF
--- a/docreader/parser/registry.py
+++ b/docreader/parser/registry.py
@@ -4,10 +4,12 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 from docreader.parser.base_parser import BaseParser
 from docreader.parser.doc_parser import DocParser
 from docreader.parser.docx2_parser import Docx2Parser
+from docreader.parser.epub_parser import EPUBParser
 from docreader.parser.excel_parser import ExcelParser
 from docreader.parser.image_parser import ImageParser
 from docreader.parser.markdown_parser import MarkdownParser
 from docreader.parser.markitdown_parser import MarkitdownParser
+from docreader.parser.mhtml_parser import MHTMLParser
 from docreader.parser.opendataloader_parser import (
     OpenDataLoaderParser,
     opendataloader_available,
@@ -131,6 +133,8 @@ def _build_default_registry() -> ParserEngineRegistry:
             "markdown": MarkdownParser,
             "xlsx": ExcelParser,
             "xls": ExcelParser,
+            "epub": EPUBParser,
+            "mhtml": MHTMLParser,
             **_image_types,
         },
         description="内置解析引擎",


### PR DESCRIPTION
## Description

Restore EPUB and MHTML parser registration in the Python docreader registry.

PR #1702 updated the OpenDataLoader availability probe to use the quick check, but the merge dropped the EPUB/MHTML builtin parser imports and registry entries added by PR #1695. This caused `epub` and `mhtml` files to pass the frontend/backend file-type checks while the Python parser registry could no longer resolve them.

This PR restores the `EPUBParser` and `MHTMLParser` builtin registrations while keeping the OpenDataLoader quick availability probe intact.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

```bash
PYTHONPATH=$(pwd) uv run --project docreader python -m unittest discover -s docreader/tests -p 'test_epub_parser.py'
PYTHONPATH=$(pwd) uv run --project docreader python -m unittest discover -s docreader/tests -p 'test_mhtml_parser.py'
PYTHONPATH=$(pwd) uv run --project docreader python -m unittest discover -s docreader/tests -p 'test_opendataloader_parser.py'
```

All targeted tests passed.

Full `docreader/tests` was also attempted, but it is currently blocked by missing local `testdata/rag_test` fixture files and an existing config default mismatch unrelated to this change.

## Checklist

* [ ] `make fmt && make lint && make test` pass locally
* [x] Self-reviewed the code
* [x] Added/updated tests covering the change
* [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
* [x] No breaking changes introduced

## Screenshots / Recordings

N/A. No user-visible UI changes.
