### PR TITLE
fix(docreader): align pdf JPEG quality default assertion

### DIFF
--- a/docreader/tests/test_config.py
+++ b/docreader/tests/test_config.py
@@ -13,7 +13,7 @@ class DocReaderConfigTest(unittest.TestCase):
         self.assertEqual(cfg.markitdown_max_workers, 1)
         self.assertEqual(cfg.pdf_render_max_workers, 1)
         self.assertEqual(cfg.pdf_render_dpi, 200)
-        self.assertEqual(cfg.pdf_jpeg_quality, 90)
+        self.assertEqual(cfg.pdf_jpeg_quality, 85)
 
     def test_loads_parser_concurrency_env(self):
         env = {


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->
修正文档读取器配置测试中 `pdf_jpeg_quality` 默认值的assertion，使其与当前实际配置保持一致。

目前 `docreader/config.py` 中 `DOCREADER_PDF_JPEG_QUALITY` 的默认值是 `85`，但 `docreader/tests/test_config.py` 中仍断言为 `90`，导致直接运行该测试时失败。

相关位置：

- `config.py`: https://github.com/Tencent/WeKnora/blob/main/docreader/config.py#L113
- `test_config.py`: https://github.com/Tencent/WeKnora/blob/main/docreader/tests/test_config.py#L16

本 PR 仅调整测试期望值，不改变运行时配置行为。
## Type of Change
<!-- Check applicable items -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
本地运行以下测试通过：

```bash
python -m unittest docreader.tests.test_config
```
## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above
