### PR TITLE
fix(tenant): purge memberships on delete and filter stale switcher rows

### DIFF
--- a/frontend/src/views/settings/TenantInfo.vue
+++ b/frontend/src/views/settings/TenantInfo.vue
@@ -251,8 +251,16 @@ import {
 } from '@/api/tenant/members'
 import { useAuthStore } from '@/stores/auth'
 import { useI18n } from 'vue-i18n'
+import { useRoleLabel, useHomeTenant } from '@/composables/useRoleLabel'
+import {
+  navigateAfterTenantSwitch,
+  persistLastActiveTenantPreference,
+  stashTenantSwitchToast,
+} from '@/utils/tenantSwitch'
 
 const { t, locale } = useI18n()
+const { formatRole } = useRoleLabel()
+const { homeTenantId } = useHomeTenant()
 const authStore = useAuthStore()
 
 // Reactive state
@@ -380,6 +388,30 @@ async function deleteCurrentTenant() {
     const resp = await deleteTenantApi(tid)
     if (resp.success) {
       MessagePlugin.success(t('tenant.deleteDangerZone.success'))
+      authStore.setMemberships(
+        (authStore.memberships ?? []).filter((m) => m.tenant_id !== tid),
+      )
+      await authStore.refreshFromAuthMe()
+      const next =
+        authStore.memberships.find((m) => m.tenant_id === homeTenantId.value) ??
+        authStore.memberships[0]
+      if (next) {
+        const switchingToHome =
+          homeTenantId.value !== null && homeTenantId.value === next.tenant_id
+        const name = next.tenant_name?.trim() || `#${next.tenant_id}`
+        authStore.setSelectedTenant(next.tenant_id, name)
+        stashTenantSwitchToast({
+          name,
+          role: formatRole(next.role) || undefined,
+          roleEnum: next.role || undefined,
+        })
+        const persist = persistLastActiveTenantPreference(
+          switchingToHome ? null : next.tenant_id,
+        )
+        await Promise.race([persist, new Promise((r) => setTimeout(r, 400))])
+        navigateAfterTenantSwitch()
+        return
+      }
       authStore.logout()
       window.location.href = '/login'
     } else {

--- a/internal/application/repository/tenant.go
+++ b/internal/application/repository/tenant.go
@@ -139,9 +139,17 @@ func (r *tenantRepository) UpdateTenant(ctx context.Context, tenant *types.Tenan
 	return err
 }
 
-// DeleteTenant deletes tenant
+// DeleteTenant soft-deletes the tenant and every active membership row
+// for that tenant in one transaction. Without the membership purge,
+// /auth/me still lists the defunct tenant (name lookup fails → UI shows
+// "#<id>").
 func (r *tenantRepository) DeleteTenant(ctx context.Context, id uint64) error {
-	return r.db.WithContext(ctx).Where("id = ?", id).Delete(&types.Tenant{}).Error
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("tenant_id = ?", id).Delete(&types.TenantMember{}).Error; err != nil {
+			return err
+		}
+		return tx.Where("id = ?", id).Delete(&types.Tenant{}).Error
+	})
 }
 
 func (r *tenantRepository) AdjustStorageUsed(ctx context.Context, tenantID uint64, delta int64) error {

--- a/internal/application/repository/tenant_test.go
+++ b/internal/application/repository/tenant_test.go
@@ -20,7 +20,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&types.Tenant{}))
+	require.NoError(t, db.AutoMigrate(&types.Tenant{}, &types.TenantMember{}))
 	return db
 }
 
@@ -165,4 +165,40 @@ func TestUpdateTenant_NoEncryptionWithoutAESKey(t *testing.T) {
 
 func isEncrypted(s string) bool {
 	return len(s) > len(utils.EncPrefix) && s[:len(utils.EncPrefix)] == utils.EncPrefix
+}
+
+func TestDeleteTenant_SoftDeletesMemberships(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	repo := NewTenantRepository(db)
+
+	tenant := &types.Tenant{Name: "gone", Status: "active"}
+	require.NoError(t, db.Create(tenant).Error)
+
+	member := &types.TenantMember{
+		UserID:   "user-1",
+		TenantID: tenant.ID,
+		Role:     types.TenantRoleOwner,
+		Status:   types.TenantMemberStatusActive,
+	}
+	require.NoError(t, db.Create(member).Error)
+
+	require.NoError(t, repo.DeleteTenant(ctx, tenant.ID))
+
+	var tenantCount int64
+	require.NoError(t, db.Model(&types.Tenant{}).Count(&tenantCount).Error)
+	assert.Equal(t, int64(0), tenantCount)
+
+	var memberCount int64
+	require.NoError(t, db.Model(&types.TenantMember{}).Count(&memberCount).Error)
+	assert.Equal(t, int64(0), memberCount)
+
+	// Unscoped: rows still exist but are soft-deleted.
+	var rawTenantCount int64
+	require.NoError(t, db.Unscoped().Model(&types.Tenant{}).Count(&rawTenantCount).Error)
+	assert.Equal(t, int64(1), rawTenantCount)
+
+	var rawMemberCount int64
+	require.NoError(t, db.Unscoped().Model(&types.TenantMember{}).Count(&rawMemberCount).Error)
+	assert.Equal(t, int64(1), rawMemberCount)
 }

--- a/internal/application/service/user.go
+++ b/internal/application/service/user.go
@@ -303,6 +303,11 @@ func (s *userService) buildMembershipsForUser(
 		} else if t, ok := tenantByID[m.TenantID]; ok && t != nil {
 			name = t.Name
 		}
+		// Drop memberships whose tenant row is gone (deleted tenant or
+		// stale tenant_members left over from before cascade delete).
+		if strings.TrimSpace(name) == "" {
+			continue
+		}
 		out = append(out, types.Membership{
 			TenantID:   m.TenantID,
 			TenantName: name,


### PR DESCRIPTION
## Summary
- Cascade soft-delete `tenant_members` when a workspace is deleted so orphaned membership rows no longer appear in the tenant switcher.
- Filter memberships whose tenant name cannot be resolved in `/auth/me`, preventing legacy ghost entries from rendering as `#<id>`.
- After deleting a workspace, switch to another available workspace instead of always logging the user out.

## Test plan
- [x] `go test -v ./internal/application/repository/ -run TestDeleteTenant_SoftDeletesMemberships`
- [x] `go test ./internal/application/service/`
- [x] Delete a workspace you own while belonging to multiple workspaces; confirm it disappears from the switcher and you land in another workspace
- [x] Re-login after deleting a workspace; confirm no `#<tenant_id>` ghost entry remains