### PR TITLE
fix: clean up tenant deletion state

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -469,19 +469,6 @@ export const useAuthStore = defineStore('auth', () => {
       }
     }
 
-    if (storedSelectedTenantId) {
-      try {
-        selectedTenantId.value = Number(storedSelectedTenantId)
-        if (storedSelectedTenantName) {
-          selectedTenantName.value = storedSelectedTenantName
-        }
-      } catch (e) {
-        console.error('Failed to parse selected tenant ID', e)
-        selectedTenantId.value = null
-        selectedTenantName.value = null
-      }
-    }
-
     const storedMemberships = localStorage.getItem('weknora_memberships')
     if (storedMemberships) {
       try {
@@ -490,6 +477,28 @@ export const useAuthStore = defineStore('auth', () => {
       } catch (e) {
         console.error('Failed to parse memberships', e)
         memberships.value = []
+      }
+    }
+
+    if (storedSelectedTenantId) {
+      try {
+        const parsedTenantId = Number(storedSelectedTenantId)
+        const hasMembership = memberships.value.some((m) => Number(m.tenant_id) === parsedTenantId)
+        if (Number.isFinite(parsedTenantId) && hasMembership) {
+          selectedTenantId.value = parsedTenantId
+          if (storedSelectedTenantName) {
+            selectedTenantName.value = storedSelectedTenantName
+          }
+        } else {
+          localStorage.removeItem('weknora_selected_tenant_id')
+          localStorage.removeItem('weknora_selected_tenant_name')
+          selectedTenantId.value = null
+          selectedTenantName.value = null
+        }
+      } catch (e) {
+        console.error('Failed to parse selected tenant ID', e)
+        selectedTenantId.value = null
+        selectedTenantName.value = null
       }
     }
 

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -120,7 +120,7 @@ instance.interceptors.response.use(
     }
   },
   async (error: any) => {
-    const originalRequest = error.config;
+    const originalRequest = error.config || {};
     
     if (!error.response) {
       return Promise.reject({ message: t('error.networkError') });
@@ -237,6 +237,15 @@ instance.interceptors.response.use(
       }
     } else if (typeof data === 'string') {
       errorMessage = data;
+    }
+    if (status === 400 && errorMessage === 'Invalid target tenant ID' && !originalRequest._tenantRetry) {
+      originalRequest._tenantRetry = true;
+      localStorage.removeItem('weknora_selected_tenant_id');
+      localStorage.removeItem('weknora_selected_tenant_name');
+      if (originalRequest.headers) {
+        delete originalRequest.headers['X-Tenant-ID'];
+      }
+      return instance(originalRequest);
     }
     return Promise.reject({ 
       status, 

--- a/frontend/src/views/settings/TenantInfo.vue
+++ b/frontend/src/views/settings/TenantInfo.vue
@@ -240,6 +240,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import { DialogPlugin, MessagePlugin } from 'tdesign-vue-next'
 import { getCurrentUser, type TenantInfo } from '@/api/auth'
 import { deleteTenant as deleteTenantApi, updateTenant as updateTenantApi } from '@/api/tenant'
@@ -250,10 +251,14 @@ import {
   type TenantRole,
 } from '@/api/tenant/members'
 import { useAuthStore } from '@/stores/auth'
+import { useUIStore } from '@/stores/ui'
 import { useI18n } from 'vue-i18n'
+import { persistLastActiveTenantPreference } from '@/utils/tenantSwitch'
 
 const { t, locale } = useI18n()
+const router = useRouter()
 const authStore = useAuthStore()
+const uiStore = useUIStore()
 
 // Reactive state
 const tenantInfo = ref<TenantInfo | null>(null)
@@ -380,8 +385,7 @@ async function deleteCurrentTenant() {
     const resp = await deleteTenantApi(tid)
     if (resp.success) {
       MessagePlugin.success(t('tenant.deleteDangerZone.success'))
-      authStore.logout()
-      window.location.href = '/login'
+      await switchToHomeTenantAfterDelete()
     } else {
       MessagePlugin.error(resp.message || t('tenant.deleteDangerZone.failed'))
     }
@@ -392,6 +396,14 @@ async function deleteCurrentTenant() {
     deleteConfirmName.value = ''
     deleteTenantVisible.value = false
   }
+}
+
+async function switchToHomeTenantAfterDelete() {
+  authStore.setSelectedTenant(null, null)
+  await persistLastActiveTenantPreference(null)
+  await authStore.refreshFromAuthMe()
+  uiStore.closeSettings()
+  await router.replace('/platform/knowledge-bases')
 }
 
 watch(

--- a/internal/application/repository/tenant.go
+++ b/internal/application/repository/tenant.go
@@ -141,7 +141,12 @@ func (r *tenantRepository) UpdateTenant(ctx context.Context, tenant *types.Tenan
 
 // DeleteTenant deletes tenant
 func (r *tenantRepository) DeleteTenant(ctx context.Context, id uint64) error {
-	return r.db.WithContext(ctx).Where("id = ?", id).Delete(&types.Tenant{}).Error
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("tenant_id = ?", id).Delete(&types.TenantMember{}).Error; err != nil {
+			return err
+		}
+		return tx.Where("id = ?", id).Delete(&types.Tenant{}).Error
+	})
 }
 
 func (r *tenantRepository) AdjustStorageUsed(ctx context.Context, tenantID uint64, delta int64) error {

--- a/internal/application/repository/tenant_test.go
+++ b/internal/application/repository/tenant_test.go
@@ -20,7 +20,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&types.Tenant{}))
+	require.NoError(t, db.AutoMigrate(&types.Tenant{}, &types.TenantMember{}))
 	return db
 }
 
@@ -161,6 +161,43 @@ func TestUpdateTenant_NoEncryptionWithoutAESKey(t *testing.T) {
 	// Without SYSTEM_AES_KEY, api_key should remain as-is (no guard needed).
 	rawAfter := readAPIKeyRaw(t, db, 3)
 	assert.Equal(t, "sk-no-encryption", rawAfter)
+}
+
+func TestDeleteTenantSoftDeletesMemberships(t *testing.T) {
+	db := setupTestDB(t)
+	now := time.Now()
+	tenant := &types.Tenant{
+		ID:        10001,
+		Name:      "tenant-to-delete",
+		Status:    "active",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	require.NoError(t, db.Create(tenant).Error)
+	require.NoError(t, db.Create(&types.TenantMember{
+		UserID:    "user-1",
+		TenantID:  tenant.ID,
+		Role:      types.TenantRoleOwner,
+		Status:    types.TenantMemberStatusActive,
+		JoinedAt:  now,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+
+	repo := NewTenantRepository(db)
+	require.NoError(t, repo.DeleteTenant(context.Background(), tenant.ID))
+
+	var activeTenantCount int64
+	require.NoError(t, db.Model(&types.Tenant{}).Where("id = ?", tenant.ID).Count(&activeTenantCount).Error)
+	assert.Equal(t, int64(0), activeTenantCount)
+
+	var activeMemberCount int64
+	require.NoError(t, db.Model(&types.TenantMember{}).Where("tenant_id = ?", tenant.ID).Count(&activeMemberCount).Error)
+	assert.Equal(t, int64(0), activeMemberCount)
+
+	var allMemberCount int64
+	require.NoError(t, db.Unscoped().Model(&types.TenantMember{}).Where("tenant_id = ?", tenant.ID).Count(&allMemberCount).Error)
+	assert.Equal(t, int64(1), allMemberCount)
 }
 
 func isEncrypted(s string) bool {

--- a/internal/application/service/user.go
+++ b/internal/application/service/user.go
@@ -302,6 +302,10 @@ func (s *userService) buildMembershipsForUser(
 			name = activeTenant.Name
 		} else if t, ok := tenantByID[m.TenantID]; ok && t != nil {
 			name = t.Name
+		} else {
+			// Membership rows can outlive a tenant when older builds deleted
+			// only the tenant row. Do not expose those dangling rows to the UI.
+			continue
 		}
 		out = append(out, types.Membership{
 			TenantID:   m.TenantID,

--- a/internal/application/service/user_membership_test.go
+++ b/internal/application/service/user_membership_test.go
@@ -1,0 +1,120 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeUserTenantService struct {
+	tenants map[uint64]*types.Tenant
+}
+
+func (f *fakeUserTenantService) CreateTenant(context.Context, *types.Tenant) (*types.Tenant, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeUserTenantService) GetTenantByID(_ context.Context, id uint64) (*types.Tenant, error) {
+	if tenant, ok := f.tenants[id]; ok {
+		return tenant, nil
+	}
+	return nil, errors.New("tenant not found")
+}
+
+func (f *fakeUserTenantService) GetTenantsByIDs(_ context.Context, ids []uint64) (map[uint64]*types.Tenant, error) {
+	out := make(map[uint64]*types.Tenant, len(ids))
+	for _, id := range ids {
+		if tenant, ok := f.tenants[id]; ok {
+			out[id] = tenant
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeUserTenantService) ListTenants(context.Context) ([]*types.Tenant, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeUserTenantService) UpdateTenant(context.Context, *types.Tenant) (*types.Tenant, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeUserTenantService) DeleteTenant(context.Context, uint64) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeUserTenantService) UpdateAPIKey(context.Context, uint64) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (f *fakeUserTenantService) ExtractTenantIDFromAPIKey(string) (uint64, error) {
+	return 0, errors.New("not implemented")
+}
+
+func (f *fakeUserTenantService) ListAllTenants(context.Context) ([]*types.Tenant, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeUserTenantService) BulkSetStorageQuota(context.Context, int64) (int64, error) {
+	return 0, errors.New("not implemented")
+}
+
+func (f *fakeUserTenantService) SearchTenants(context.Context, string, uint64, int, int) ([]*types.Tenant, int64, error) {
+	return nil, 0, errors.New("not implemented")
+}
+
+func (f *fakeUserTenantService) GetTenantByIDForUser(context.Context, uint64, string) (*types.Tenant, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeUserTenantService) GetWeKnoraCloudCredentials(context.Context) *types.WeKnoraCloudCredentials {
+	return nil
+}
+
+func TestBuildLoginMembershipsSkipsDeletedTenantRows(t *testing.T) {
+	memberRepo := newFakeRepo()
+	memberSvc := NewTenantMemberService(memberRepo, nil)
+	now := time.Now()
+	require.NoError(t, memberRepo.Create(context.Background(), &types.TenantMember{
+		UserID:    "user-1",
+		TenantID:  10000,
+		Role:      types.TenantRoleOwner,
+		Status:    types.TenantMemberStatusActive,
+		JoinedAt:  now,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}))
+	require.NoError(t, memberRepo.Create(context.Background(), &types.TenantMember{
+		UserID:    "user-1",
+		TenantID:  10001,
+		Role:      types.TenantRoleOwner,
+		Status:    types.TenantMemberStatusActive,
+		JoinedAt:  now.Add(time.Second),
+		CreatedAt: now,
+		UpdatedAt: now,
+	}))
+
+	activeTenant := &types.Tenant{ID: 10000, Name: "active workspace"}
+	svc := &userService{
+		tenantService: &fakeUserTenantService{
+			tenants: map[uint64]*types.Tenant{
+				activeTenant.ID: activeTenant,
+			},
+		},
+		memberService: memberSvc,
+	}
+
+	memberships := svc.BuildLoginMemberships(context.Background(), &types.User{
+		ID:       "user-1",
+		TenantID: activeTenant.ID,
+	}, activeTenant)
+
+	require.Len(t, memberships, 1)
+	assert.Equal(t, uint64(10000), memberships[0].TenantID)
+	assert.Equal(t, "active workspace", memberships[0].TenantName)
+}


### PR DESCRIPTION
## Summary
- soft-delete tenant membership rows when deleting a tenant
- omit dangling tenant memberships from login/current-user responses
- clear stale selected-tenant state and return to the home workspace after self-service tenant deletion
- retry once without X-Tenant-ID when the client carries a deleted tenant id

This is a follow-up to the tenant workspace deletion UI added in PR #1706. The delete entry was present, but deleting the active tenant could leave stale membership/client state behind.

## Testing
- go test ./internal/application/repository ./internal/application/service
- npm run build