### PR TITLE
feat(parser): support PaddleOCR-VL API key

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15729,6 +15729,10 @@ const docTemplate = `{
                     "description": "PaddleOCR-VL self-hosted pipeline service (full /layout-parsing API).",
                     "type": "string"
                 },
+                "paddleocr_vl_bearer_token": {
+                    "description": "Optional Bearer token for self-hosted services protected by a gateway or reverse proxy. Official PaddleX Serving does not require this field.",
+                    "type": "string"
+                },
                 "paddleocr_vl_use_chart_recognition": {
                     "type": "boolean"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -15722,6 +15722,10 @@
                     "description": "PaddleOCR-VL self-hosted pipeline service (full /layout-parsing API).",
                     "type": "string"
                 },
+                "paddleocr_vl_bearer_token": {
+                    "description": "Optional Bearer token for self-hosted services protected by a gateway or reverse proxy. Official PaddleX Serving does not require this field.",
+                    "type": "string"
+                },
                 "paddleocr_vl_use_chart_recognition": {
                     "type": "boolean"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2271,9 +2271,10 @@ definitions:
         description: PaddleOCR-VL self-hosted pipeline service (full /layout-parsing
           API).
         type: string
-      paddleocr_vl_api_key:
-        description: Optional Bearer token for protected self-hosted PaddleOCR-VL
-          services.
+      paddleocr_vl_bearer_token:
+        description: Optional Bearer token for self-hosted services protected by
+          a gateway or reverse proxy. Official PaddleX Serving does not require
+          this field.
         type: string
       paddleocr_vl_use_chart_recognition:
         type: boolean

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2271,6 +2271,10 @@ definitions:
         description: PaddleOCR-VL self-hosted pipeline service (full /layout-parsing
           API).
         type: string
+      paddleocr_vl_api_key:
+        description: Optional Bearer token for protected self-hosted PaddleOCR-VL
+          services.
+        type: string
       paddleocr_vl_use_chart_recognition:
         type: boolean
       paddleocr_vl_use_seal_recognition:

--- a/frontend/src/api/system/index.ts
+++ b/frontend/src/api/system/index.ts
@@ -92,6 +92,7 @@ export interface ParserEngineConfig {
   mineru_cloud_language?: string
   // PaddleOCR-VL 自建参数
   paddleocr_vl_endpoint?: string
+  paddleocr_vl_bearer_token?: string
   paddleocr_vl_api_key?: string
   paddleocr_vl_use_seal_recognition?: boolean | null
   paddleocr_vl_use_chart_recognition?: boolean | null

--- a/frontend/src/api/system/index.ts
+++ b/frontend/src/api/system/index.ts
@@ -92,6 +92,7 @@ export interface ParserEngineConfig {
   mineru_cloud_language?: string
   // PaddleOCR-VL 自建参数
   paddleocr_vl_endpoint?: string
+  paddleocr_vl_api_key?: string
   paddleocr_vl_use_seal_recognition?: boolean | null
   paddleocr_vl_use_chart_recognition?: boolean | null
   // PaddleOCR-VL 云 API 参数

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1310,8 +1310,8 @@ export default {
       vlmServerUrlHint: 'Required when Backend is vlm-http-client or hybrid-http-client',
       paddleocrVlEndpointPlaceholder: 'e.g. http://your-paddleocr-vl:8080',
       paddleocrVlEndpointHint: 'Base URL of the full PaddleOCR-VL pipeline service; no /layout-parsing suffix needed',
-      paddleocrVlApiKeyPlaceholder: 'Self-hosted service API Key (optional)',
-      paddleocrVlApiKeyHint: 'When set, requests include Authorization: Bearer <API Key>',
+      paddleocrVlBearerTokenPlaceholder: 'Bearer token for a protected endpoint (optional)',
+      paddleocrVlBearerTokenHint: 'Only needed when your self-hosted service is behind an auth gateway. Official PaddleX serving does not require it.',
       paddleocrVlCloudTokenPlaceholder: 'PaddleOCR-VL AI Studio Token',
     },
     storage: {

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1310,6 +1310,8 @@ export default {
       vlmServerUrlHint: 'Required when Backend is vlm-http-client or hybrid-http-client',
       paddleocrVlEndpointPlaceholder: 'e.g. http://your-paddleocr-vl:8080',
       paddleocrVlEndpointHint: 'Base URL of the full PaddleOCR-VL pipeline service; no /layout-parsing suffix needed',
+      paddleocrVlApiKeyPlaceholder: 'Self-hosted service API Key (optional)',
+      paddleocrVlApiKeyHint: 'When set, requests include Authorization: Bearer <API Key>',
       paddleocrVlCloudTokenPlaceholder: 'PaddleOCR-VL AI Studio Token',
     },
     storage: {

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -1165,8 +1165,8 @@ export default {
       vlmServerUrlHint: 'Backend가 vlm-http-client 또는 hybrid-http-client인 경우 필요',
       paddleocrVlEndpointPlaceholder: '예: http://your-paddleocr-vl:8080',
       paddleocrVlEndpointHint: 'PaddleOCR-VL 전체 서비스(pipeline) 주소를 입력하세요. /layout-parsing 접미사는 불필요합니다',
-      paddleocrVlApiKeyPlaceholder: '자체 호스팅 서비스 API Key (선택 사항)',
-      paddleocrVlApiKeyHint: '입력하면 요청에 Authorization: Bearer <API Key>가 포함됩니다',
+      paddleocrVlBearerTokenPlaceholder: '보호된 엔드포인트용 Bearer Token (선택 사항)',
+      paddleocrVlBearerTokenHint: '자체 호스팅 서비스가 인증 게이트웨이 뒤에 있을 때만 필요합니다. 공식 PaddleX Serving에는 필요하지 않습니다',
       paddleocrVlCloudTokenPlaceholder: 'PaddleOCR-VL AI Studio Token',
     },
     storage: {

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -1165,6 +1165,8 @@ export default {
       vlmServerUrlHint: 'Backend가 vlm-http-client 또는 hybrid-http-client인 경우 필요',
       paddleocrVlEndpointPlaceholder: '예: http://your-paddleocr-vl:8080',
       paddleocrVlEndpointHint: 'PaddleOCR-VL 전체 서비스(pipeline) 주소를 입력하세요. /layout-parsing 접미사는 불필요합니다',
+      paddleocrVlApiKeyPlaceholder: '자체 호스팅 서비스 API Key (선택 사항)',
+      paddleocrVlApiKeyHint: '입력하면 요청에 Authorization: Bearer <API Key>가 포함됩니다',
       paddleocrVlCloudTokenPlaceholder: 'PaddleOCR-VL AI Studio Token',
     },
     storage: {

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -1220,6 +1220,8 @@ export default {
       mineruHtmlLabel: 'MinerU-HTML (HTML парсинг)',
       paddleocrVlEndpointPlaceholder: 'напр. http://your-paddleocr-vl:8080',
       paddleocrVlEndpointHint: 'Адрес полного сервиса PaddleOCR-VL (pipeline); суффикс /layout-parsing не требуется',
+      paddleocrVlApiKeyPlaceholder: 'API Key самостоятельного сервиса (необязательно)',
+      paddleocrVlApiKeyHint: 'Если задано, запросы будут содержать Authorization: Bearer <API Key>',
       paddleocrVlCloudTokenPlaceholder: 'Токен PaddleOCR-VL AI Studio'
     },
     storage: {

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -1220,8 +1220,8 @@ export default {
       mineruHtmlLabel: 'MinerU-HTML (HTML парсинг)',
       paddleocrVlEndpointPlaceholder: 'напр. http://your-paddleocr-vl:8080',
       paddleocrVlEndpointHint: 'Адрес полного сервиса PaddleOCR-VL (pipeline); суффикс /layout-parsing не требуется',
-      paddleocrVlApiKeyPlaceholder: 'API Key самостоятельного сервиса (необязательно)',
-      paddleocrVlApiKeyHint: 'Если задано, запросы будут содержать Authorization: Bearer <API Key>',
+      paddleocrVlBearerTokenPlaceholder: 'Bearer Token для защищенного endpoint (необязательно)',
+      paddleocrVlBearerTokenHint: 'Нужно только если самостоятельный сервис находится за auth gateway. Официальный PaddleX Serving этого не требует',
       paddleocrVlCloudTokenPlaceholder: 'Токен PaddleOCR-VL AI Studio'
     },
     storage: {

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1173,6 +1173,8 @@ export default {
       vlmServerUrlHint: "当 Backend 选择 vlm-http-client 或 hybrid-http-client 时需要填写",
       paddleocrVlEndpointPlaceholder: "如 http://your-paddleocr-vl:8080",
       paddleocrVlEndpointHint: "填写 PaddleOCR-VL 完整服务（pipeline）地址，无需 /layout-parsing 后缀",
+      paddleocrVlApiKeyPlaceholder: "自建服务 API Key（可选）",
+      paddleocrVlApiKeyHint: "填写后请求会携带 Authorization: Bearer <API Key>",
       paddleocrVlCloudTokenPlaceholder: "PaddleOCR-VL 飞桨星河社区 Token",
     },
     storage: {

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1173,8 +1173,8 @@ export default {
       vlmServerUrlHint: "当 Backend 选择 vlm-http-client 或 hybrid-http-client 时需要填写",
       paddleocrVlEndpointPlaceholder: "如 http://your-paddleocr-vl:8080",
       paddleocrVlEndpointHint: "填写 PaddleOCR-VL 完整服务（pipeline）地址，无需 /layout-parsing 后缀",
-      paddleocrVlApiKeyPlaceholder: "自建服务 API Key（可选）",
-      paddleocrVlApiKeyHint: "填写后请求会携带 Authorization: Bearer <API Key>",
+      paddleocrVlBearerTokenPlaceholder: "受保护服务的 Bearer Token（可选）",
+      paddleocrVlBearerTokenHint: "仅当自部署服务位于鉴权网关后时填写；官方 PaddleX Serving 不需要该字段",
       paddleocrVlCloudTokenPlaceholder: "PaddleOCR-VL 飞桨星河社区 Token",
     },
     storage: {

--- a/frontend/src/views/settings/ParserEngineSettings.vue
+++ b/frontend/src/views/settings/ParserEngineSettings.vue
@@ -326,6 +326,18 @@
             <p class="form-desc">{{ $t('settings.parser.paddleocrVlEndpointHint') }}</p>
           </div>
           <div class="form-item">
+            <label class="form-label">API Key</label>
+            <t-input
+              v-model="config.paddleocr_vl_api_key"
+              type="password"
+              :placeholder="$t('settings.parser.paddleocrVlApiKeyPlaceholder')"
+              clearable
+            >
+              <template #prefix-icon><t-icon name="lock-on" /></template>
+            </t-input>
+            <p class="form-desc">{{ $t('settings.parser.paddleocrVlApiKeyHint') }}</p>
+          </div>
+          <div class="form-item">
             <label class="form-label">{{ $t('settings.parser.featuresLabel', '识别选项') }}</label>
             <div class="form-toggles">
               <t-checkbox v-model="config.paddleocr_vl_use_seal_recognition">{{ $t('settings.parser.sealRecognition') }}</t-checkbox>
@@ -420,6 +432,7 @@ const DEFAULT_PARSER_CONFIG: ParserEngineConfig = {
   mineru_cloud_enable_ocr: true,
   mineru_cloud_language: 'ch',
   paddleocr_vl_endpoint: '',
+  paddleocr_vl_api_key: '',
   paddleocr_vl_use_seal_recognition: true,
   paddleocr_vl_use_chart_recognition: false,
   paddleocr_vl_cloud_token: '',
@@ -557,6 +570,7 @@ async function loadConfig() {
       mineru_cloud_enable_ocr: data?.mineru_cloud_enable_ocr ?? DEFAULT_PARSER_CONFIG.mineru_cloud_enable_ocr ?? true,
       mineru_cloud_language: data?.mineru_cloud_language ?? DEFAULT_PARSER_CONFIG.mineru_cloud_language ?? 'ch',
       paddleocr_vl_endpoint: data?.paddleocr_vl_endpoint ?? DEFAULT_PARSER_CONFIG.paddleocr_vl_endpoint ?? '',
+      paddleocr_vl_api_key: data?.paddleocr_vl_api_key ?? DEFAULT_PARSER_CONFIG.paddleocr_vl_api_key ?? '',
       paddleocr_vl_use_seal_recognition: data?.paddleocr_vl_use_seal_recognition ?? DEFAULT_PARSER_CONFIG.paddleocr_vl_use_seal_recognition ?? true,
       paddleocr_vl_use_chart_recognition: data?.paddleocr_vl_use_chart_recognition ?? DEFAULT_PARSER_CONFIG.paddleocr_vl_use_chart_recognition ?? false,
       paddleocr_vl_cloud_token: data?.paddleocr_vl_cloud_token ?? DEFAULT_PARSER_CONFIG.paddleocr_vl_cloud_token ?? '',
@@ -594,6 +608,7 @@ function buildConfigPayload(): ParserEngineConfig {
     mineru_cloud_enable_ocr: config.value.mineru_cloud_enable_ocr,
     mineru_cloud_language: config.value.mineru_cloud_language?.trim() ?? '',
     paddleocr_vl_endpoint: config.value.paddleocr_vl_endpoint?.trim() ?? '',
+    paddleocr_vl_api_key: config.value.paddleocr_vl_api_key?.trim() ?? '',
     paddleocr_vl_use_seal_recognition: config.value.paddleocr_vl_use_seal_recognition,
     paddleocr_vl_use_chart_recognition: config.value.paddleocr_vl_use_chart_recognition,
     paddleocr_vl_cloud_token: config.value.paddleocr_vl_cloud_token?.trim() ?? '',

--- a/frontend/src/views/settings/ParserEngineSettings.vue
+++ b/frontend/src/views/settings/ParserEngineSettings.vue
@@ -326,16 +326,16 @@
             <p class="form-desc">{{ $t('settings.parser.paddleocrVlEndpointHint') }}</p>
           </div>
           <div class="form-item">
-            <label class="form-label">API Key</label>
+            <label class="form-label">Bearer Token</label>
             <t-input
-              v-model="config.paddleocr_vl_api_key"
+              v-model="config.paddleocr_vl_bearer_token"
               type="password"
-              :placeholder="$t('settings.parser.paddleocrVlApiKeyPlaceholder')"
+              :placeholder="$t('settings.parser.paddleocrVlBearerTokenPlaceholder')"
               clearable
             >
               <template #prefix-icon><t-icon name="lock-on" /></template>
             </t-input>
-            <p class="form-desc">{{ $t('settings.parser.paddleocrVlApiKeyHint') }}</p>
+            <p class="form-desc">{{ $t('settings.parser.paddleocrVlBearerTokenHint') }}</p>
           </div>
           <div class="form-item">
             <label class="form-label">{{ $t('settings.parser.featuresLabel', '识别选项') }}</label>
@@ -432,7 +432,7 @@ const DEFAULT_PARSER_CONFIG: ParserEngineConfig = {
   mineru_cloud_enable_ocr: true,
   mineru_cloud_language: 'ch',
   paddleocr_vl_endpoint: '',
-  paddleocr_vl_api_key: '',
+  paddleocr_vl_bearer_token: '',
   paddleocr_vl_use_seal_recognition: true,
   paddleocr_vl_use_chart_recognition: false,
   paddleocr_vl_cloud_token: '',
@@ -570,7 +570,7 @@ async function loadConfig() {
       mineru_cloud_enable_ocr: data?.mineru_cloud_enable_ocr ?? DEFAULT_PARSER_CONFIG.mineru_cloud_enable_ocr ?? true,
       mineru_cloud_language: data?.mineru_cloud_language ?? DEFAULT_PARSER_CONFIG.mineru_cloud_language ?? 'ch',
       paddleocr_vl_endpoint: data?.paddleocr_vl_endpoint ?? DEFAULT_PARSER_CONFIG.paddleocr_vl_endpoint ?? '',
-      paddleocr_vl_api_key: data?.paddleocr_vl_api_key ?? DEFAULT_PARSER_CONFIG.paddleocr_vl_api_key ?? '',
+      paddleocr_vl_bearer_token: data?.paddleocr_vl_bearer_token ?? data?.paddleocr_vl_api_key ?? DEFAULT_PARSER_CONFIG.paddleocr_vl_bearer_token ?? '',
       paddleocr_vl_use_seal_recognition: data?.paddleocr_vl_use_seal_recognition ?? DEFAULT_PARSER_CONFIG.paddleocr_vl_use_seal_recognition ?? true,
       paddleocr_vl_use_chart_recognition: data?.paddleocr_vl_use_chart_recognition ?? DEFAULT_PARSER_CONFIG.paddleocr_vl_use_chart_recognition ?? false,
       paddleocr_vl_cloud_token: data?.paddleocr_vl_cloud_token ?? DEFAULT_PARSER_CONFIG.paddleocr_vl_cloud_token ?? '',
@@ -608,7 +608,7 @@ function buildConfigPayload(): ParserEngineConfig {
     mineru_cloud_enable_ocr: config.value.mineru_cloud_enable_ocr,
     mineru_cloud_language: config.value.mineru_cloud_language?.trim() ?? '',
     paddleocr_vl_endpoint: config.value.paddleocr_vl_endpoint?.trim() ?? '',
-    paddleocr_vl_api_key: config.value.paddleocr_vl_api_key?.trim() ?? '',
+    paddleocr_vl_bearer_token: config.value.paddleocr_vl_bearer_token?.trim() ?? '',
     paddleocr_vl_use_seal_recognition: config.value.paddleocr_vl_use_seal_recognition,
     paddleocr_vl_use_chart_recognition: config.value.paddleocr_vl_use_chart_recognition,
     paddleocr_vl_cloud_token: config.value.paddleocr_vl_cloud_token?.trim() ?? '',

--- a/internal/infrastructure/docparser/engine_registry.go
+++ b/internal/infrastructure/docparser/engine_registry.go
@@ -151,7 +151,7 @@ func (e *paddleOCRVLEngine) CheckAvailable(_ bool, overrides map[string]string) 
 	if endpoint == "" {
 		return false, "PaddleOCR-VL service not configured"
 	}
-	return PingPaddleOCRVL(endpoint, overrides["paddleocr_vl_api_key"])
+	return PingPaddleOCRVL(endpoint, paddleOCRVLBearerToken(overrides))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/infrastructure/docparser/engine_registry.go
+++ b/internal/infrastructure/docparser/engine_registry.go
@@ -151,7 +151,7 @@ func (e *paddleOCRVLEngine) CheckAvailable(_ bool, overrides map[string]string) 
 	if endpoint == "" {
 		return false, "PaddleOCR-VL service not configured"
 	}
-	return PingPaddleOCRVL(endpoint)
+	return PingPaddleOCRVL(endpoint, overrides["paddleocr_vl_api_key"])
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/infrastructure/docparser/paddleocr_vl_converter.go
+++ b/internal/infrastructure/docparser/paddleocr_vl_converter.go
@@ -27,6 +27,7 @@ const paddleOCRVLTimeout = 1000 * time.Second // large scanned PDFs can take a w
 // response containing per-page markdown + inline base64 images.
 type PaddleOCRVLReader struct {
 	endpoint string
+	apiKey   string
 	useSeal  bool
 	useChart bool
 }
@@ -35,6 +36,7 @@ type PaddleOCRVLReader struct {
 func NewPaddleOCRVLReader(overrides map[string]string) *PaddleOCRVLReader {
 	return &PaddleOCRVLReader{
 		endpoint: strings.TrimRight(overrides["paddleocr_vl_endpoint"], "/"),
+		apiKey:   strings.TrimSpace(overrides["paddleocr_vl_api_key"]),
 		useSeal:  parseBoolOr(overrides["paddleocr_vl_use_seal_recognition"], true),
 		useChart: parseBoolOr(overrides["paddleocr_vl_use_chart_recognition"], false),
 	}
@@ -150,6 +152,7 @@ func (c *PaddleOCRVLReader) callLayoutParsing(
 		return "", nil, fmt.Errorf("create request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	setPaddleOCRVLAuthHeader(httpReq, c.apiKey)
 
 	client := &http.Client{Timeout: paddleOCRVLTimeout}
 	resp, err := client.Do(httpReq)
@@ -254,7 +257,7 @@ func (c *PaddleOCRVLReader) processImages(
 }
 
 // PingPaddleOCRVL checks whether a self-hosted PaddleOCR-VL service is reachable.
-func PingPaddleOCRVL(endpoint string) (bool, string) {
+func PingPaddleOCRVL(endpoint, apiKey string) (bool, string) {
 	endpoint = strings.TrimRight(endpoint, "/")
 	if endpoint == "" {
 		return false, "未配置 PaddleOCR-VL 端点"
@@ -265,7 +268,12 @@ func PingPaddleOCRVL(endpoint string) (bool, string) {
 	})
 	// The pipeline only exposes POST /layout-parsing; an empty GET should still
 	// produce a routed HTTP response (e.g. 404/405) when the service is up.
-	resp, err := client.Get(endpoint + "/layout-parsing")
+	req, err := http.NewRequest(http.MethodGet, endpoint+"/layout-parsing", nil)
+	if err != nil {
+		return false, fmt.Sprintf("PaddleOCR-VL 检测请求创建失败: %v", err)
+	}
+	setPaddleOCRVLAuthHeader(req, strings.TrimSpace(apiKey))
+	resp, err := client.Do(req)
 	if err != nil {
 		return false, fmt.Sprintf("PaddleOCR-VL 服务不可达: %v", err)
 	}
@@ -274,4 +282,11 @@ func PingPaddleOCRVL(endpoint string) (bool, string) {
 		return false, fmt.Sprintf("PaddleOCR-VL 服务返回状态 %d", resp.StatusCode)
 	}
 	return true, ""
+}
+
+func setPaddleOCRVLAuthHeader(req *http.Request, apiKey string) {
+	if apiKey == "" {
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
 }

--- a/internal/infrastructure/docparser/paddleocr_vl_converter.go
+++ b/internal/infrastructure/docparser/paddleocr_vl_converter.go
@@ -26,20 +26,27 @@ const paddleOCRVLTimeout = 1000 * time.Second // large scanned PDFs can take a w
 // Flow: POST {endpoint}/layout-parsing with base64 file → synchronous JSON
 // response containing per-page markdown + inline base64 images.
 type PaddleOCRVLReader struct {
-	endpoint string
-	apiKey   string
-	useSeal  bool
-	useChart bool
+	endpoint    string
+	bearerToken string
+	useSeal     bool
+	useChart    bool
 }
 
 // NewPaddleOCRVLReader creates a reader from ParserEngineOverrides.
 func NewPaddleOCRVLReader(overrides map[string]string) *PaddleOCRVLReader {
 	return &PaddleOCRVLReader{
-		endpoint: strings.TrimRight(overrides["paddleocr_vl_endpoint"], "/"),
-		apiKey:   strings.TrimSpace(overrides["paddleocr_vl_api_key"]),
-		useSeal:  parseBoolOr(overrides["paddleocr_vl_use_seal_recognition"], true),
-		useChart: parseBoolOr(overrides["paddleocr_vl_use_chart_recognition"], false),
+		endpoint:    strings.TrimRight(overrides["paddleocr_vl_endpoint"], "/"),
+		bearerToken: paddleOCRVLBearerToken(overrides),
+		useSeal:     parseBoolOr(overrides["paddleocr_vl_use_seal_recognition"], true),
+		useChart:    parseBoolOr(overrides["paddleocr_vl_use_chart_recognition"], false),
 	}
+}
+
+func paddleOCRVLBearerToken(overrides map[string]string) string {
+	if token := strings.TrimSpace(overrides["paddleocr_vl_bearer_token"]); token != "" {
+		return token
+	}
+	return strings.TrimSpace(overrides["paddleocr_vl_api_key"])
 }
 
 func (c *PaddleOCRVLReader) Read(ctx context.Context, req *types.ReadRequest) (*types.ReadResult, error) {
@@ -152,7 +159,7 @@ func (c *PaddleOCRVLReader) callLayoutParsing(
 		return "", nil, fmt.Errorf("create request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	setPaddleOCRVLAuthHeader(httpReq, c.apiKey)
+	setPaddleOCRVLAuthHeader(httpReq, c.bearerToken)
 
 	client := &http.Client{Timeout: paddleOCRVLTimeout}
 	resp, err := client.Do(httpReq)
@@ -257,7 +264,7 @@ func (c *PaddleOCRVLReader) processImages(
 }
 
 // PingPaddleOCRVL checks whether a self-hosted PaddleOCR-VL service is reachable.
-func PingPaddleOCRVL(endpoint, apiKey string) (bool, string) {
+func PingPaddleOCRVL(endpoint, bearerToken string) (bool, string) {
 	endpoint = strings.TrimRight(endpoint, "/")
 	if endpoint == "" {
 		return false, "未配置 PaddleOCR-VL 端点"
@@ -272,7 +279,7 @@ func PingPaddleOCRVL(endpoint, apiKey string) (bool, string) {
 	if err != nil {
 		return false, fmt.Sprintf("PaddleOCR-VL 检测请求创建失败: %v", err)
 	}
-	setPaddleOCRVLAuthHeader(req, strings.TrimSpace(apiKey))
+	setPaddleOCRVLAuthHeader(req, strings.TrimSpace(bearerToken))
 	resp, err := client.Do(req)
 	if err != nil {
 		return false, fmt.Sprintf("PaddleOCR-VL 服务不可达: %v", err)
@@ -284,9 +291,9 @@ func PingPaddleOCRVL(endpoint, apiKey string) (bool, string) {
 	return true, ""
 }
 
-func setPaddleOCRVLAuthHeader(req *http.Request, apiKey string) {
-	if apiKey == "" {
+func setPaddleOCRVLAuthHeader(req *http.Request, bearerToken string) {
+	if bearerToken == "" {
 		return
 	}
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Authorization", "Bearer "+bearerToken)
 }

--- a/internal/infrastructure/docparser/paddleocr_vl_converter_test.go
+++ b/internal/infrastructure/docparser/paddleocr_vl_converter_test.go
@@ -23,8 +23,8 @@ func TestPaddleOCRVLReaderAddsBearerToken(t *testing.T) {
 	defer server.Close()
 
 	reader := NewPaddleOCRVLReader(map[string]string{
-		"paddleocr_vl_endpoint": server.URL,
-		"paddleocr_vl_api_key":  token,
+		"paddleocr_vl_endpoint":     server.URL,
+		"paddleocr_vl_bearer_token": token,
 	})
 
 	result, err := reader.Read(context.Background(), &types.ReadRequest{

--- a/internal/infrastructure/docparser/paddleocr_vl_converter_test.go
+++ b/internal/infrastructure/docparser/paddleocr_vl_converter_test.go
@@ -1,0 +1,78 @@
+package docparser
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestPaddleOCRVLReaderAddsBearerToken(t *testing.T) {
+	const token = "test-token"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Fatalf("Authorization header = %q, want Bearer token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"errorCode":0,"result":{"layoutParsingResults":[{"markdown":{"text":"ok","images":{}}}]}}`))
+	}))
+	defer server.Close()
+
+	reader := NewPaddleOCRVLReader(map[string]string{
+		"paddleocr_vl_endpoint": server.URL,
+		"paddleocr_vl_api_key":  token,
+	})
+
+	result, err := reader.Read(context.Background(), &types.ReadRequest{
+		FileName:    "doc.pdf",
+		FileType:    "pdf",
+		FileContent: []byte("pdf"),
+	})
+	if err != nil {
+		t.Fatalf("Read returned error: %v", err)
+	}
+	if result.MarkdownContent != "ok" {
+		t.Fatalf("MarkdownContent = %q, want ok", result.MarkdownContent)
+	}
+}
+
+func TestSetPaddleOCRVLAuthHeaderAddsBearerToken(t *testing.T) {
+	const token = "test-token"
+
+	req := httptest.NewRequest(http.MethodGet, "/layout-parsing", nil)
+	setPaddleOCRVLAuthHeader(req, token)
+	if got := req.Header.Get("Authorization"); got != "Bearer "+token {
+		t.Fatalf("Authorization header = %q, want Bearer token", got)
+	}
+}
+
+func TestPaddleOCRVLReaderKeepsImageRefs(t *testing.T) {
+	png := createTestPNG(10, 10)
+	imgB64 := base64.StdEncoding.EncodeToString(png)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"errorCode":0,"result":{"layoutParsingResults":[{"markdown":{"text":"![](images/plot.png)","images":{"plot.png":"` + imgB64 + `"}}}]}}`))
+	}))
+	defer server.Close()
+
+	reader := NewPaddleOCRVLReader(map[string]string{"paddleocr_vl_endpoint": server.URL})
+	result, err := reader.Read(context.Background(), &types.ReadRequest{
+		FileName:    "doc.pdf",
+		FileType:    "pdf",
+		FileContent: []byte("pdf"),
+	})
+	if err != nil {
+		t.Fatalf("Read returned error: %v", err)
+	}
+	if len(result.ImageRefs) != 1 {
+		t.Fatalf("ImageRefs len = %d, want 1", len(result.ImageRefs))
+	}
+	if result.ImageRefs[0].OriginalRef != "images/plot.png" {
+		t.Fatalf("OriginalRef = %q, want images/plot.png", result.ImageRefs[0].OriginalRef)
+	}
+}

--- a/internal/types/tenant.go
+++ b/internal/types/tenant.go
@@ -295,6 +295,7 @@ type ParserEngineConfig struct {
 
 	// PaddleOCR-VL self-hosted pipeline service (full /layout-parsing API).
 	PaddleOCRVLEndpoint            string `json:"paddleocr_vl_endpoint,omitempty"` // e.g. http://paddleocr-vl:8080
+	PaddleOCRVLAPIKey              string `json:"paddleocr_vl_api_key,omitempty"`  // optional Bearer token for protected self-hosted services
 	PaddleOCRVLUseSealRecognition  *bool  `json:"paddleocr_vl_use_seal_recognition,omitempty"`
 	PaddleOCRVLUseChartRecognition *bool  `json:"paddleocr_vl_use_chart_recognition,omitempty"`
 
@@ -368,6 +369,9 @@ func (c *ParserEngineConfig) ToOverridesMap() map[string]string {
 	}
 	if c.PaddleOCRVLEndpoint != "" {
 		m["paddleocr_vl_endpoint"] = c.PaddleOCRVLEndpoint
+	}
+	if c.PaddleOCRVLAPIKey != "" {
+		m["paddleocr_vl_api_key"] = c.PaddleOCRVLAPIKey
 	}
 	if c.PaddleOCRVLUseSealRecognition != nil {
 		m["paddleocr_vl_use_seal_recognition"] = fmt.Sprintf("%v", *c.PaddleOCRVLUseSealRecognition)

--- a/internal/types/tenant.go
+++ b/internal/types/tenant.go
@@ -295,7 +295,8 @@ type ParserEngineConfig struct {
 
 	// PaddleOCR-VL self-hosted pipeline service (full /layout-parsing API).
 	PaddleOCRVLEndpoint            string `json:"paddleocr_vl_endpoint,omitempty"` // e.g. http://paddleocr-vl:8080
-	PaddleOCRVLAPIKey              string `json:"paddleocr_vl_api_key,omitempty"`  // optional Bearer token for protected self-hosted services
+	PaddleOCRVLBearerToken         string `json:"paddleocr_vl_bearer_token,omitempty"`
+	PaddleOCRVLAPIKey              string `json:"paddleocr_vl_api_key,omitempty" swaggerignore:"true"` // deprecated: use paddleocr_vl_bearer_token
 	PaddleOCRVLUseSealRecognition  *bool  `json:"paddleocr_vl_use_seal_recognition,omitempty"`
 	PaddleOCRVLUseChartRecognition *bool  `json:"paddleocr_vl_use_chart_recognition,omitempty"`
 
@@ -370,8 +371,10 @@ func (c *ParserEngineConfig) ToOverridesMap() map[string]string {
 	if c.PaddleOCRVLEndpoint != "" {
 		m["paddleocr_vl_endpoint"] = c.PaddleOCRVLEndpoint
 	}
-	if c.PaddleOCRVLAPIKey != "" {
-		m["paddleocr_vl_api_key"] = c.PaddleOCRVLAPIKey
+	if c.PaddleOCRVLBearerToken != "" {
+		m["paddleocr_vl_bearer_token"] = c.PaddleOCRVLBearerToken
+	} else if c.PaddleOCRVLAPIKey != "" {
+		m["paddleocr_vl_bearer_token"] = c.PaddleOCRVLAPIKey
 	}
 	if c.PaddleOCRVLUseSealRecognition != nil {
 		m["paddleocr_vl_use_seal_recognition"] = fmt.Sprintf("%v", *c.PaddleOCRVLUseSealRecognition)


### PR DESCRIPTION
## Summary

- add an optional `paddleocr_vl_api_key` setting for the self-hosted PaddleOCR-VL parser
- send `Authorization: Bearer <API Key>` on self-hosted PaddleOCR-VL availability checks and `/layout-parsing` parse requests
- expose the optional API Key field in Parser Engine settings and update API typings / i18n / swagger schema

Closes #1721

## Test plan

```bash
go test ./internal/infrastructure/docparser
```

`npm run type-check` was also run. It fails with pre-existing unrelated TypeScript errors that are reproducible on upstream `main` (`3b317f7e`) in files such as `src/api/agent/index.ts`, `src/api/embed/index.ts`, and `src/views/knowledge/KnowledgeBase.vue`.
