### PR TITLE
[codex] Polish chat suggestions, citations, and drawers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ data/files/
 data/weknora.db
 data/weknora.db-wal
 data/weknora.db-shm
+skills-lock.json
 
 web/
 

--- a/frontend/src/api/chat/streame.ts
+++ b/frontend/src/api/chat/streame.ts
@@ -29,6 +29,7 @@ export function useStream() {
   const error = ref<string | null>(null)// 错误信息
   const lastStreamRequest = ref<StreamRequestMeta | null>(null)
   let controller = new AbortController()
+  let streamGeneration = 0
 
   // 流式渲染缓冲
   let buffer: string[] = []
@@ -36,6 +37,7 @@ export function useStream() {
 
   // 启动流式请求
   const startStream = async (params: { session_id: any; query: any; knowledge_base_ids?: string[]; knowledge_ids?: string[]; agent_enabled?: boolean; agent_id?: string; web_search_enabled?: boolean; enable_memory?: boolean; summary_model_id?: string; mcp_service_ids?: string[]; mentioned_items?: Array<{id: string; name: string; type: string; kb_type?: string}>; images?: Array<{data: string}>; attachment_uploads?: Array<{data: string; file_name: string; file_size: number}>; method: string; url: string; embed_token?: string; embed_session_sig?: string }) => {
+    const myGeneration = ++streamGeneration
     // 重置状态
     output.value = '';
     error.value = null;
@@ -159,6 +161,7 @@ export function useStream() {
         },
 
         onmessage: (ev) => {
+          if (myGeneration !== streamGeneration) return
           const parsed = JSON.parse(ev.data);
           // Log first answer chunk for end-to-end TTFB measurement.
           // Filter by event type so non-answer events (references, tool
@@ -197,6 +200,7 @@ export function useStream() {
 
   // 停止流
   const stopStream = () => {
+    streamGeneration++
     controller.abort();
     controller = new AbortController(); // 重置控制器（如需重新发起）
     isStreaming.value = false;

--- a/frontend/src/components/EmbedChannelPreview.vue
+++ b/frontend/src/components/EmbedChannelPreview.vue
@@ -1,6 +1,6 @@
 <template>
   <t-drawer :visible="visible" :header="title || $t('embedPublish.preview')" size="720px" :footer="false"
-    :z-index="2600" class="embed-preview-drawer" @close="emit('update:visible', false)">
+    :z-index="2600" attach="body" class="embed-preview-drawer" @close="emit('update:visible', false)">
     <div class="preview-body">
       <template v-if="mode === 'iframe'">
         <p class="preview-hint">{{ $t('embedPublish.previewIframeHint') }}</p>

--- a/frontend/src/components/UserMenu.vue
+++ b/frontend/src/components/UserMenu.vue
@@ -1006,7 +1006,7 @@ onUnmounted(() => {
       background: var(--td-bg-color-container-hover);
 
       .dropdown-tenant-panel-trail {
-        color: var(--td-brand-color);
+        color: var(--td-text-color-secondary);
       }
     }
   }
@@ -1324,12 +1324,12 @@ onUnmounted(() => {
     }
 
     &.is-current {
-      background: rgba(7, 192, 95, 0.08);
+      background: var(--td-bg-color-secondarycontainer);
       cursor: default;
 
       .tenant-submenu-item-name {
-        color: var(--td-brand-color);
-        font-weight: 500;
+        color: var(--td-text-color-primary);
+        font-weight: 600;
       }
     }
   }
@@ -1400,8 +1400,8 @@ onUnmounted(() => {
     line-height: 1.2;
     padding: 2px 6px;
     border-radius: 4px;
-    background: var(--td-brand-color-light);
-    color: var(--td-brand-color);
+    background: var(--td-bg-color-component);
+    color: var(--td-text-color-secondary);
   }
 
   // Home 标识改为叠在 avatar 右下角的小 dot，不在 meta 行额外占位，让
@@ -1419,7 +1419,7 @@ onUnmounted(() => {
     height: 14px;
     border-radius: 50%;
     background: var(--td-bg-color-container);
-    color: var(--td-brand-color);
+    color: var(--td-text-color-secondary);
     border: 1.5px solid var(--td-bg-color-container);
     display: flex;
     align-items: center;

--- a/frontend/src/components/css/chat-markdown.less
+++ b/frontend/src/components/css/chat-markdown.less
@@ -574,6 +574,38 @@
     transition: transform 0.2s ease;
   }
 
+  // Protected images not yet hydrated still carry the 1x1 placeholder gif.
+  // Without a fixed size width:auto/height:auto collapse it to a ~1px line that
+  // jumps to full size on load (reads as flicker during streaming). Give it a
+  // stable skeleton box so the later swap to the real image is a calm fade-in.
+  // Match both the explicit loading marker and the transparent GIF itself.
+  // During a streaming DOM patch the marker can briefly be absent while src is
+  // already the 1x1 placeholder; matching src prevents that frame becoming a
+  // tall, one-pixel vertical line in Chromium.
+  :deep(img[data-img-loading]),
+  :deep(img[data-protected-src][src^='data:image/gif;base64']) {
+    width: 260px;
+    height: 180px;
+    min-width: min(260px, 80%);
+    min-height: 180px;
+    max-width: 80%;
+    object-fit: cover;
+    cursor: default;
+    background: linear-gradient(
+      100deg,
+      var(--td-bg-color-secondarycontainer, #f3f3f3) 30%,
+      var(--td-bg-color-container-hover, #eaeaea) 50%,
+      var(--td-bg-color-secondarycontainer, #f3f3f3) 70%
+    );
+    background-size: 200% 100%;
+    animation: chat-img-skeleton 1.2s ease-in-out infinite;
+  }
+
+  @keyframes chat-img-skeleton {
+    0% { background-position: 100% 0; }
+    100% { background-position: -100% 0; }
+  }
+
   :deep(p:has(> img:only-child)) {
     margin: 1.25em 0;
     line-height: 0;

--- a/frontend/src/components/css/suggested-questions.less
+++ b/frontend/src/components/css/suggested-questions.less
@@ -1,0 +1,197 @@
+@suggested-ease: cubic-bezier(0.16, 1, 0.3, 1);
+
+.suggested-questions-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 12px 16px 12px;
+    max-width: 720px;
+    margin: 0 auto;
+    width: 100%;
+    min-height: 0;
+
+    &.has-questions {
+        min-height: 64px;
+    }
+}
+
+.suggested-questions-inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+}
+
+.suggested-questions-title-row {
+    margin-bottom: 8px;
+}
+
+.suggested-questions-caption {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin: 0;
+    padding: 0;
+    line-height: 1;
+}
+
+.suggested-questions-title {
+    font-size: 12px;
+    color: var(--td-text-color-placeholder);
+    font-weight: 400;
+    letter-spacing: 0.02em;
+}
+
+.suggested-questions-refresh {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--td-text-color-placeholder);
+    cursor: pointer;
+    transition: color 0.2s @suggested-ease, background 0.2s @suggested-ease;
+
+    :deep(.t-icon) {
+        font-size: 12px;
+    }
+
+    &:hover:not(:disabled) {
+        color: var(--td-text-color-secondary);
+        background: var(--td-bg-color-secondarycontainer);
+    }
+
+    &:active:not(:disabled) {
+        transform: scale(0.94);
+    }
+
+    &:disabled {
+        cursor: default;
+        opacity: 0.7;
+    }
+}
+
+.sq-refresh-spin {
+    animation: sq-refresh-rotate 0.8s linear infinite;
+}
+
+@keyframes sq-refresh-rotate {
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.suggested-questions-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+    width: 100%;
+}
+
+.suggested-question-card {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    max-width: 100%;
+    padding: 6px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--td-component-stroke);
+    background: transparent;
+    cursor: pointer;
+    transition:
+        background 0.2s @suggested-ease,
+        border-color 0.2s @suggested-ease,
+        transform 0.15s @suggested-ease;
+
+    &:not(.sq-card-skeleton):hover {
+        background: var(--td-bg-color-secondarycontainer);
+        border-color: var(--td-component-border);
+    }
+
+    &:not(.sq-card-skeleton):active {
+        transform: scale(0.98);
+        background: var(--td-bg-color-secondarycontainer-active);
+    }
+
+    &.sq-card-skeleton {
+        pointer-events: none;
+        cursor: default;
+        flex-shrink: 0;
+        border-color: transparent;
+        background: var(--td-bg-color-secondarycontainer);
+
+        :deep(.t-skeleton) {
+            width: 100%;
+        }
+
+        :deep(.t-skeleton__row) {
+            margin: 0;
+        }
+
+        :deep(.t-skeleton__col) {
+            border-radius: 3px;
+        }
+
+        &:nth-child(1) {
+            width: 132px;
+        }
+
+        &:nth-child(2) {
+            width: 168px;
+        }
+
+        &:nth-child(3) {
+            width: 116px;
+        }
+
+        &:nth-child(4) {
+            width: 152px;
+        }
+
+        &:nth-child(5) {
+            width: 124px;
+        }
+
+        &:nth-child(6) {
+            width: 144px;
+        }
+    }
+}
+
+.suggested-question-text {
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--td-text-color-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    transition: color 0.2s @suggested-ease;
+}
+
+.suggested-question-card:not(.sq-card-skeleton):hover .suggested-question-text {
+    color: var(--td-text-color-primary);
+}
+
+.suggested-question-badge {
+    flex-shrink: 0;
+    padding: 0 4px;
+    border-radius: 3px;
+    border: 1px solid var(--td-component-stroke);
+    background: transparent;
+    font-size: 10px;
+    font-weight: 500;
+    line-height: 1.6;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--td-text-color-placeholder);
+}

--- a/frontend/src/components/css/suggested-questions.less
+++ b/frontend/src/components/css/suggested-questions.less
@@ -18,28 +18,29 @@
 .suggested-questions-inner {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
     width: 100%;
 }
 
 .suggested-questions-title-row {
-    margin-bottom: 8px;
+    margin-bottom: 12px;
+    text-align: center;
 }
 
 .suggested-questions-caption {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
+    gap: 6px;
     margin: 0;
     padding: 0;
     line-height: 1;
 }
 
 .suggested-questions-title {
-    font-size: 12px;
+    font-size: 13px;
     color: var(--td-text-color-placeholder);
     font-weight: 400;
-    letter-spacing: 0.02em;
+    letter-spacing: 0.01em;
 }
 
 .suggested-questions-refresh {
@@ -47,11 +48,11 @@
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    width: 18px;
-    height: 18px;
+    width: 20px;
+    height: 20px;
     padding: 0;
     border: none;
-    border-radius: 4px;
+    border-radius: 6px;
     background: transparent;
     color: var(--td-text-color-placeholder);
     cursor: pointer;
@@ -62,12 +63,12 @@
     }
 
     &:hover:not(:disabled) {
-        color: var(--td-text-color-secondary);
+        color: var(--td-brand-color);
         background: var(--td-bg-color-secondarycontainer);
     }
 
     &:active:not(:disabled) {
-        transform: scale(0.94);
+        transform: scale(0.92);
     }
 
     &:disabled {
@@ -93,42 +94,112 @@
 .suggested-questions-grid {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
     justify-content: center;
+    gap: 10px;
     width: 100%;
 }
 
 .suggested-question-card {
+    position: relative;
     display: inline-flex;
     align-items: center;
-    gap: 6px;
+    gap: 8px;
+    min-width: 0;
     max-width: 100%;
-    padding: 6px 12px;
-    border-radius: 8px;
+    width: auto;
+    box-sizing: border-box;
+    padding: 11px 14px;
+    border-radius: 14px;
     border: 1px solid var(--td-component-stroke);
-    background: transparent;
+    background: var(--td-bg-color-container);
     cursor: pointer;
+    overflow: hidden;
     transition:
-        background 0.2s @suggested-ease,
-        border-color 0.2s @suggested-ease,
-        transform 0.15s @suggested-ease;
+        background 0.25s @suggested-ease,
+        border-color 0.25s @suggested-ease,
+        box-shadow 0.25s @suggested-ease,
+        transform 0.2s @suggested-ease;
+
+    // 左侧主题色渐隐高光，hover 时淡入，营造柔和的呼吸感
+    &::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        background: linear-gradient(
+            105deg,
+            var(--td-brand-color-light) 0%,
+            transparent 55%
+        );
+        opacity: 0;
+        transition: opacity 0.25s @suggested-ease;
+        pointer-events: none;
+    }
 
     &:not(.sq-card-skeleton):hover {
-        background: var(--td-bg-color-secondarycontainer);
-        border-color: var(--td-component-border);
+        border-color: var(--td-brand-color-light-active, var(--td-brand-color));
+        background: var(--td-bg-color-container);
+        box-shadow: 0 3px 10px -8px rgba(0, 0, 0, 0.14);
+        transform: translateY(-1px);
+
+        &::before {
+            opacity: 0.45;
+        }
+    }
+
+    // 右侧引导箭头：默认隐藏并向左收起，hover 时滑入
+    &::after {
+        content: "›";
+        position: relative;
+        flex-shrink: 0;
+        margin-left: -2px;
+        font-size: 17px;
+        line-height: 1;
+        color: var(--td-brand-color);
+        opacity: 0;
+        transform: translateX(-6px);
+        transition:
+            opacity 0.25s @suggested-ease,
+            transform 0.25s @suggested-ease;
     }
 
     &:not(.sq-card-skeleton):active {
-        transform: scale(0.98);
-        background: var(--td-bg-color-secondarycontainer-active);
+        transform: translateY(0) scale(0.99);
+        box-shadow: 0 2px 8px -6px rgba(0, 0, 0, 0.2);
+    }
+
+    &:not(.sq-card-skeleton):hover::after {
+        opacity: 1;
+        transform: translateX(0);
     }
 
     &.sq-card-skeleton {
+        width: 180px;
+        max-width: 100%;
         pointer-events: none;
         cursor: default;
         flex-shrink: 0;
         border-color: transparent;
         background: var(--td-bg-color-secondarycontainer);
+        box-shadow: none;
+
+        // 不等宽的骨架，呼应错落的标签云布局
+        &:nth-child(2n) {
+            width: 240px;
+        }
+
+        &:nth-child(3n) {
+            width: 150px;
+        }
+
+        &:nth-child(5n) {
+            width: 210px;
+        }
+
+        &::before,
+        &::after {
+            display: none;
+        }
 
         :deep(.t-skeleton) {
             width: 100%;
@@ -142,36 +213,16 @@
             border-radius: 3px;
         }
 
-        &:nth-child(1) {
-            width: 132px;
-        }
-
-        &:nth-child(2) {
-            width: 168px;
-        }
-
-        &:nth-child(3) {
-            width: 116px;
-        }
-
-        &:nth-child(4) {
-            width: 152px;
-        }
-
-        &:nth-child(5) {
-            width: 124px;
-        }
-
-        &:nth-child(6) {
-            width: 144px;
-        }
     }
 }
 
 .suggested-question-text {
+    position: relative;
+    flex: 0 1 auto;
+    min-width: 0;
     font-size: 13px;
     line-height: 1.5;
-    color: var(--td-text-color-secondary);
+    color: var(--td-text-color-primary);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -179,19 +230,21 @@
 }
 
 .suggested-question-card:not(.sq-card-skeleton):hover .suggested-question-text {
-    color: var(--td-text-color-primary);
+    color: var(--td-brand-color);
 }
 
 .suggested-question-badge {
+    position: relative;
     flex-shrink: 0;
-    padding: 0 4px;
-    border-radius: 3px;
-    border: 1px solid var(--td-component-stroke);
-    background: transparent;
+    padding: 1px 6px;
+    border-radius: 6px;
+    border: none;
+    background: var(--td-brand-color-light);
     font-size: 10px;
-    font-weight: 500;
+    font-weight: 600;
     line-height: 1.6;
     letter-spacing: 0.04em;
     text-transform: uppercase;
-    color: var(--td-text-color-placeholder);
+    color: var(--td-brand-color);
 }
+

--- a/frontend/src/components/manual-knowledge-editor.vue
+++ b/frontend/src/components/manual-knowledge-editor.vue
@@ -150,7 +150,11 @@ const setSelectionRange = (start: number, end: number) => {
     if (!textarea || activeTab.value !== 'edit') {
       return
     }
-    textarea.focus()
+    // Initialization can finish while the drawer is still sliding in. A plain
+    // focus() makes the browser scroll the transformed textarea into view,
+    // which intermittently shifts the drawer away from the right edge for a
+    // frame. Keep keyboard focus without letting it move the viewport.
+    textarea.focus({ preventScroll: true })
     textarea.setSelectionRange(start, end)
   })
 }
@@ -735,7 +739,6 @@ onBeforeUnmount(() => {
     :min-width="560"
     :max-width="1280"
     storage-key="setting-drawer:width:manual-markdown-editor"
-    :destroy-on-close="false"
     :hide-footer="!initialLoaded"
     :confirm-loading="saving && savingAction === 'publish'"
     :confirm-text="$t('manualEditor.actions.publish')"
@@ -1111,5 +1114,3 @@ onBeforeUnmount(() => {
   color: var(--td-text-color-placeholder);
 }
 </style>
-
-

--- a/frontend/src/components/menu.vue
+++ b/frontend/src/components/menu.vue
@@ -1385,7 +1385,7 @@ const onDragHandleMouseDown = (e: MouseEvent) => {
 
     .menu_item_active {
         border-radius: 4px;
-        background: var(--td-brand-color-light) !important;
+        background: var(--td-bg-color-secondarycontainer) !important;
 
         .menu_icon,
         .menu_title {

--- a/frontend/src/components/settings/SettingDrawer.vue
+++ b/frontend/src/components/settings/SettingDrawer.vue
@@ -1,14 +1,14 @@
 <template>
   <teleport to="body">
     <div v-if="drawerVisible && resizable" class="setting-drawer-resize-handle"
-      :class="{ 'setting-drawer-resize-handle--active': drawerResizing }" :style="{ right: `${drawerWidthPx}px` }"
+      :class="{ 'setting-drawer-resize-handle--active': drawerResizing }"
+      :style="{ right: `${drawerWidthPx}px`, '--setting-drawer-travel': `${drawerWidthPx}px` }"
       role="separator" aria-orientation="vertical" @mousedown.prevent="onResizeStart">
       <div class="setting-drawer-resize-line" />
     </div>
   </teleport>
   <t-drawer v-model:visible="drawerVisible" :size="effectiveWidth" :z-index="2500" placement="right"
-    :attach="attach"
-    :destroy-on-close="destroyOnClose"
+    attach="body" destroy-on-close
     :class="['setting-drawer', { 'setting-drawer--resizing': drawerResizing }]">
     <!--
       Custom header. We replace TDesign's default header so we can put a leading
@@ -88,23 +88,6 @@ interface Props {
   confirmText?: string
   cancelText?: string
   hideFooter?: boolean
-  /**
-   * Whether to destroy the drawer body content on close. Defaults to true to
-   * match historical behavior. Heavy editors (e.g. the markdown knowledge
-   * editor) pass false so the drawer panel persists across opens — this avoids
-   * the panel being removed/re-inserted on every open, which can cause a
-   * one-frame layout flicker as it slides in.
-   */
-  destroyOnClose?: boolean
-  /**
-   * Where to render the drawer. Defaults to 'body' so the drawer escapes the
-   * app root, which carries `transform: translateZ(0)` for GPU compositing.
-   * A transformed ancestor becomes the containing block for `position: fixed`,
-   * which mis-anchors the overlay (it briefly appears mid-screen then snaps to
-   * the edge). Teleporting to <body> keeps it fixed to the viewport, matching
-   * the resize handle that is already teleported to body.
-   */
-  attach?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -119,9 +102,7 @@ const props = withDefaults(defineProps<Props>(), {
   confirmDisabled: false,
   confirmText: '',
   cancelText: '',
-  hideFooter: false,
-  destroyOnClose: true,
-  attach: 'body'
+  hideFooter: false
 })
 
 const emit = defineEmits<{
@@ -441,6 +422,20 @@ const handleCancel = () => {
   display: flex;
   align-items: center;
   justify-content: center;
+  /* The handle is teleported separately from TDesign's sliding panel. Move it
+     along the same path instead of letting it flash at the panel's final left
+     edge while the drawer is still entering from the right. */
+  animation: setting-drawer-resize-handle-in 0.28s cubic-bezier(0.38, 0, 0.24, 1) both;
+}
+
+@keyframes setting-drawer-resize-handle-in {
+  from {
+    transform: translateX(var(--setting-drawer-travel));
+  }
+
+  to {
+    transform: translateX(0);
+  }
 }
 
 .setting-drawer-resize-line {

--- a/frontend/src/composables/useChatStreamHandler.ts
+++ b/frontend/src/composables/useChatStreamHandler.ts
@@ -67,6 +67,53 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
     return undefined
   }
 
+  /** Incomplete assistant row for the current turn (must be the list tail). */
+  const getTrailingIncompleteAssistant = () => {
+    const last = messagesList[messagesList.length - 1]
+    if (last?.role === 'assistant' && !last.is_completed) return last
+    return undefined
+  }
+
+  const markAssistantStopped = (message: ChatMessage) => {
+    if (!message || message.is_completed) return
+    message.is_completed = true
+    if (message.isAgentMode) {
+      if (!message.agentEventStream) message.agentEventStream = []
+      const stream = message.agentEventStream as ChatMessage[]
+      if (!stream.some((e) => e.type === 'stop')) {
+        stream.push({
+          type: 'stop',
+          timestamp: Date.now(),
+          reason: 'user_requested',
+        })
+      }
+    }
+  }
+
+  /** Finalize any in-flight assistant rows before a new user query is sent. */
+  const prepareForNewOutgoingMessage = () => {
+    for (const msg of messagesList) {
+      if (msg.role === 'assistant' && !msg.is_completed) {
+        markAssistantStopped(msg)
+      }
+    }
+    fullContent.value = ''
+    currentAssistantMessageId.value = ''
+  }
+
+  /** Mark the assistant row being stopped without clearing its id (stop API still needs it). */
+  const markInFlightAssistantStopped = (messageId?: string) => {
+    let target: ChatMessage | undefined
+    if (messageId) {
+      target = messagesList.find(
+        (m) => m.id === messageId || m.request_id === messageId,
+      )
+    }
+    if (!target) target = getTrailingIncompleteAssistant()
+    if (target) markAssistantStopped(target)
+    fullContent.value = ''
+  }
+
   const extractKnowledgeReferences = (data: ChatMessage) => {
     const dataPayload = data.data as ChatMessage | undefined
     const refs =
@@ -93,7 +140,7 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
     })
     if (matched) return matched
 
-    return findLastMessage((item) => item.role === 'assistant' && !item.is_completed)
+    return getTrailingIncompleteAssistant()
   }
 
   const applyKnowledgeReferences = (data: ChatMessage) => {
@@ -744,8 +791,11 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
           timestamp: Date.now(),
           reason: dataPayload?.reason || 'user_requested',
         })
+        message.is_completed = true
+        loading.value = false
         isReplying.value = false
         fullContent.value = ''
+        currentAssistantMessageId.value = ''
         break
       }
     }
@@ -767,9 +817,7 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
 
     if (data.response_type === 'agent_query') {
       if (data.id) {
-        const earlyMsg = findLastMessage(
-          (item) => item.role === 'assistant' && !item.is_completed,
-        )
+        const earlyMsg = getTrailingIncompleteAssistant()
         if (earlyMsg) earlyMsg.request_id = data.id
       }
       if (data.assistant_message_id) {
@@ -788,8 +836,9 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
       )
       const created = !existingMessage
       if (!existingMessage) {
+        const assistantId = data.assistant_message_id as string | undefined
         existingMessage = {
-          id: data.id,
+          id: assistantId || data.id,
           request_id: data.id,
           role: 'assistant',
           content: '',
@@ -849,6 +898,8 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
       handleAgentChunk(data)
       if (data.response_type === 'stop') {
         log('[Stop Event] Generation stopped')
+        const stoppedMessage = resolveActiveAssistantMessage(data)
+        if (stoppedMessage) markAssistantStopped(stoppedMessage)
         loading.value = false
         isReplying.value = false
         currentAssistantMessageId.value = ''
@@ -924,5 +975,7 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
     shouldShowGlobalTypingIndicator,
     handleMsgList,
     processStreamChunk,
+    prepareForNewOutgoingMessage,
+    markInFlightAssistantStopped,
   }
 }

--- a/frontend/src/composables/useEmbedChatSession.ts
+++ b/frontend/src/composables/useEmbedChatSession.ts
@@ -152,8 +152,22 @@ export function useEmbedChatSession(options: {
 
   const debouncedScrollTop = debounce(onChatScrollTop, 500)
 
+  let lastScrollTop = 0
   const handleScroll = () => {
-    userHasScrolledUp.value = !isNearBottom()
+    const el = scrollContainer.value
+    if (el) {
+      const currentTop = el.scrollTop
+      // Only an actual upward scroll detaches from the live edge. Content that
+      // grows after a chunk (images, diagrams) keeps scrollTop fixed and would
+      // otherwise fire a stale scroll event that falsely marks the user as
+      // scrolled up, killing the auto-follow during streaming.
+      if (currentTop < lastScrollTop - 1) {
+        userHasScrolledUp.value = !isNearBottom()
+      } else if (isNearBottom()) {
+        userHasScrolledUp.value = false
+      }
+      lastScrollTop = currentTop
+    }
     debouncedScrollTop()
   }
 

--- a/frontend/src/composables/useEmbedChatSession.ts
+++ b/frontend/src/composables/useEmbedChatSession.ts
@@ -118,6 +118,8 @@ export function useEmbedChatSession(options: {
     shouldShowGlobalTypingIndicator,
     handleMsgList,
     processStreamChunk,
+    prepareForNewOutgoingMessage,
+    markInFlightAssistantStopped,
   } = useChatStreamHandler({
     messagesList,
     loading,
@@ -220,6 +222,7 @@ export function useEmbedChatSession(options: {
 
   const handleStopGeneration = () => {
     stopStream()
+    markInFlightAssistantStopped(currentAssistantMessageId.value)
     const messageId = currentAssistantMessageId.value
     if (messageId) {
       stopEmbedSession(
@@ -238,6 +241,8 @@ export function useEmbedChatSession(options: {
     value: string,
     opts: { webSearchEnabled?: boolean; imageFiles?: File[]; attachmentFiles?: File[] } = {},
   ) => {
+    stopStream()
+    prepareForNewOutgoingMessage()
     const outboundQuery = buildQueryWithHostContext(value, options.hostContext?.value)
     const visitorWebSearchEnabled = opts.webSearchEnabled ?? false
     const imageFiles = (options.allowFileUpload ? opts.imageFiles : undefined) || []

--- a/frontend/src/composables/useEmbedChatSession.ts
+++ b/frontend/src/composables/useEmbedChatSession.ts
@@ -20,6 +20,7 @@ import { buildQueryWithHostContext } from '@/utils/embedContext'
 import { fileToDataURI } from '@/utils/embedFile'
 import { useI18n } from 'vue-i18n'
 import { useChatStreamHandler } from '@/composables/useChatStreamHandler'
+import { useStickyBottomOnResize } from '@/composables/useStickyBottomOnResize'
 
 export function useEmbedChatSession(options: {
   sessionId: Ref<string>
@@ -89,6 +90,8 @@ export function useEmbedChatSession(options: {
     userHasScrolledUp.value = false
     scrollToBottom(true)
   }
+
+  useStickyBottomOnResize(scrollContainer, userHasScrolledUp, scrollToBottom)
 
   const debounce = <T extends (...args: never[]) => void>(fn: T, delay: number) => {
     let timer: ReturnType<typeof setTimeout>

--- a/frontend/src/composables/useStickyBottomOnResize.ts
+++ b/frontend/src/composables/useStickyBottomOnResize.ts
@@ -1,0 +1,44 @@
+import { onMounted, onUnmounted, type Ref } from 'vue'
+
+/**
+ * Keep a chat pinned to the bottom when asynchronously rendered content grows.
+ *
+ * Streaming text already requests scrolling when chunks arrive, but images,
+ * Mermaid diagrams, and other rich content can change height later. Observe the
+ * message list itself so all delayed layout changes share the same behavior.
+ * A user who has intentionally scrolled up is never pulled back down.
+ */
+export function useStickyBottomOnResize(
+  scrollContainer: Ref<HTMLElement | null>,
+  userHasScrolledUp: Ref<boolean>,
+  scrollToBottom: () => void,
+): void {
+  let resizeObserver: ResizeObserver | null = null
+  let scrollFrame: number | null = null
+
+  const scheduleFollow = () => {
+    if (userHasScrolledUp.value || scrollFrame !== null) return
+
+    scrollFrame = requestAnimationFrame(() => {
+      scrollFrame = null
+      if (!userHasScrolledUp.value) scrollToBottom()
+    })
+  }
+
+  onMounted(() => {
+    const messageList = scrollContainer.value?.firstElementChild
+    if (!messageList || typeof ResizeObserver === 'undefined') return
+
+    resizeObserver = new ResizeObserver(scheduleFollow)
+    resizeObserver.observe(messageList)
+  })
+
+  onUnmounted(() => {
+    resizeObserver?.disconnect()
+    resizeObserver = null
+    if (scrollFrame !== null) {
+      cancelAnimationFrame(scrollFrame)
+      scrollFrame = null
+    }
+  })
+}

--- a/frontend/src/composables/useTypewriter.test.ts
+++ b/frontend/src/composables/useTypewriter.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { nextTypewriterReveal } from './useTypewriter.ts'
+
+test('reveals Chinese text in compact phrase groups', () => {
+  const text = '这是一个自然流畅的回答。'
+  assert.equal(nextTypewriterReveal(text, 0, 1), 0)
+  assert.equal(nextTypewriterReveal(text, 0, 2), 2)
+  assert.equal(nextTypewriterReveal(text, 0, 20), 4)
+})
+
+test('waits for a complete English word instead of revealing letter by letter', () => {
+  const text = 'Hello world'
+  assert.equal(nextTypewriterReveal(text, 0, 3), 0)
+  assert.equal(nextTypewriterReveal(text, 0, 6), 6)
+  assert.equal(text.slice(0, nextTypewriterReveal(text, 0, 6)), 'Hello ')
+})
+
+test('uses punctuation as a natural reveal boundary', () => {
+  const text = '你好，接下来继续。'
+  assert.equal(nextTypewriterReveal(text, 0, 3), 3)
+})
+
+test('never splits a surrogate pair', () => {
+  const text = '🙂 hello'
+  assert.equal(nextTypewriterReveal(text, 0, 1), 2)
+})

--- a/frontend/src/composables/useTypewriter.ts
+++ b/frontend/src/composables/useTypewriter.ts
@@ -1,0 +1,200 @@
+import { computed, onBeforeUnmount, ref, watch, type ComputedRef } from 'vue';
+
+export interface TypewriterOptions {
+  /** Comfortable reveal floor in characters per second. */
+  minCps?: number;
+  /** Time window (seconds) over which ordinary backlog is drained. */
+  drainSeconds?: number;
+  /** Upper speed limit when a large SSE chunk arrives at once. */
+  maxCps?: number;
+  /** Largest frame delta honored after a backgrounded tab resumes. */
+  maxFrameSeconds?: number;
+}
+
+const NATURAL_BREAK_RE = /[\s，。！？；：、,.!?;:)\]】》」』]/u;
+const CJK_RE = /[\u3400-\u9fff\uf900-\ufaff\u3040-\u30ff\uac00-\ud7af]/u;
+const WORD_CHARACTER_RE = /[\p{L}\p{N}_]/u;
+
+function nextCodePointEnd(text: string, index: number): number {
+  if (index >= text.length) return text.length;
+  const code = text.charCodeAt(index);
+  return index + (code >= 0xd800 && code <= 0xdbff ? 2 : 1);
+}
+
+function previousCodePointStart(text: string, index: number): number {
+  if (index <= 0) return 0;
+  const code = text.charCodeAt(index - 1);
+  return code >= 0xdc00 && code <= 0xdfff ? index - 2 : index - 1;
+}
+
+function advanceCodePoints(text: string, start: number, count: number): number {
+  let end = start;
+  for (let i = 0; i < count && end < text.length; i += 1) {
+    end = nextCodePointEnd(text, end);
+  }
+  return end;
+}
+
+/**
+ * Pick the next human-readable reveal boundary.
+ *
+ * CJK text advances in compact 2–4 character phrases. Latin text waits briefly
+ * for a whole-word boundary instead of crawling through a word letter by letter.
+ */
+export function nextTypewriterReveal(
+  text: string,
+  start: number,
+  availableCharacters: number,
+): number {
+  if (start >= text.length) return text.length;
+
+  const firstEnd = nextCodePointEnd(text, start);
+  const firstCharacter = text.slice(start, firstEnd);
+  const isCjk = CJK_RE.test(firstCharacter);
+  const isWordCharacter = WORD_CHARACTER_RE.test(firstCharacter);
+  const minimumGroup = isCjk ? 2 : 1;
+  const maximumGroup = isCjk ? 4 : 14;
+  const available = Math.max(0, Math.floor(availableCharacters));
+  if (available < minimumGroup && text.length - start > available) return start;
+
+  const hardEnd = advanceCodePoints(text, start, Math.min(maximumGroup, Math.max(minimumGroup, available)));
+  const minimumEnd = advanceCodePoints(text, start, minimumGroup);
+
+  // Prefer the latest complete phrase/word already covered by the reveal budget.
+  let cursor = hardEnd;
+  while (cursor >= minimumEnd) {
+    const characterStart = previousCodePointStart(text, cursor);
+    if (NATURAL_BREAK_RE.test(text.slice(characterStart, cursor))) return cursor;
+    cursor = characterStart;
+  }
+
+  // CJK has no spaces between words; reveal small even groups. For Latin text,
+  // wait for the word to finish unless it has grown long enough to need a split.
+  if (isCjk || !isWordCharacter || hardEnd === text.length || available >= maximumGroup) return hardEnd;
+  return start;
+}
+
+/**
+ * Smooth streamed text into an adaptive phrase cadence.
+ *
+ * Network chunks arrive in uneven bursts. The displayed slice follows them with
+ * short semantic groups, accelerates under backlog, and eases back near the live
+ * edge. This feels closer to a model composing text than a mechanical cursor.
+ */
+export function useTypewriter(
+  getTarget: () => string,
+  getComplete: () => boolean,
+  options: TypewriterOptions = {},
+): { displayed: ComputedRef<string> } {
+  const minCps = options.minCps ?? 72;
+  const drainSeconds = options.drainSeconds ?? 0.42;
+  const maxCps = options.maxCps ?? 240;
+  const maxFrameSeconds = options.maxFrameSeconds ?? 0.05;
+
+  const typedLength = ref(0);
+  let revealCredit = 0;
+  let raf: number | null = null;
+  let lastTs = 0;
+  let initialized = false;
+  let reduceMotion = false;
+  let motionQuery: MediaQueryList | null = null;
+
+  if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+    motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    reduceMotion = motionQuery.matches;
+  }
+
+  const displayed = computed(() => {
+    const full = getTarget();
+    let n = Math.min(typedLength.value, full.length);
+    // Never cut on a high surrogate, which would render a broken glyph.
+    if (n > 0 && n < full.length) {
+      const code = full.charCodeAt(n - 1);
+      if (code >= 0xd800 && code <= 0xdbff) n -= 1;
+    }
+    return full.slice(0, n);
+  });
+
+  const stop = () => {
+    if (raf !== null) {
+      cancelAnimationFrame(raf);
+      raf = null;
+    }
+    lastTs = 0;
+  };
+
+  const tick = (ts: number) => {
+    const full = getTarget();
+    const target = full.length;
+    if (typedLength.value > target) {
+      typedLength.value = 0;
+      revealCredit = 0;
+    }
+    if (typedLength.value >= target) {
+      stop();
+      return;
+    }
+
+    const dt = lastTs ? Math.min((ts - lastTs) / 1000, maxFrameSeconds) : 0;
+    lastTs = ts;
+    const remaining = target - typedLength.value;
+    const cps = Math.min(maxCps, Math.max(minCps, remaining / drainSeconds));
+    revealCredit += cps * dt;
+
+    const next = nextTypewriterReveal(full, typedLength.value, revealCredit);
+    if (next > typedLength.value) {
+      revealCredit = Math.max(0, revealCredit - (next - typedLength.value));
+      typedLength.value = next;
+    }
+
+    raf = requestAnimationFrame(tick);
+  };
+
+  const ensure = () => {
+    if (raf === null) {
+      lastTs = 0;
+      raf = requestAnimationFrame(tick);
+    }
+  };
+
+  const handleMotionChange = (event: MediaQueryListEvent) => {
+    reduceMotion = event.matches;
+    if (reduceMotion) {
+      typedLength.value = getTarget().length;
+      revealCredit = 0;
+      stop();
+    }
+  };
+  motionQuery?.addEventListener('change', handleMotionChange);
+
+  watch(
+    getTarget,
+    (full) => {
+      const target = full.length;
+      if (!initialized) {
+        initialized = true;
+        if (getComplete() || reduceMotion) {
+          typedLength.value = target;
+          return;
+        }
+      }
+      if (typedLength.value > target) {
+        typedLength.value = 0;
+        revealCredit = 0;
+      }
+      if (reduceMotion) {
+        typedLength.value = target;
+      } else if (typedLength.value < target) {
+        ensure();
+      }
+    },
+    { immediate: true },
+  );
+
+  onBeforeUnmount(() => {
+    stop();
+    motionQuery?.removeEventListener('change', handleMotionChange);
+  });
+
+  return { displayed };
+}

--- a/frontend/src/directives/stableHtml.ts
+++ b/frontend/src/directives/stableHtml.ts
@@ -1,0 +1,116 @@
+import type { ObjectDirective } from 'vue';
+
+function imageIdentity(img: HTMLImageElement): string {
+  return (img.getAttribute('data-protected-src') || img.currentSrc || img.src || '').trim();
+}
+
+function canMorph(current: Node, next: Node): boolean {
+  if (current.nodeType !== next.nodeType) return false;
+  if (current.nodeType !== Node.ELEMENT_NODE) return true;
+  return (current as Element).tagName === (next as Element).tagName;
+}
+
+function syncAttributes(current: Element, next: Element, preserved: Set<string> = new Set()): void {
+  Array.from(current.attributes).forEach(({ name }) => {
+    if (!preserved.has(name) && !next.hasAttribute(name)) current.removeAttribute(name);
+  });
+  Array.from(next.attributes).forEach(({ name, value }) => {
+    if (!preserved.has(name) && current.getAttribute(name) !== value) {
+      current.setAttribute(name, value);
+    }
+  });
+}
+
+function morphImage(current: HTMLImageElement, next: HTMLImageElement): void {
+  const sameProtectedSource = Boolean(
+    current.getAttribute('data-protected-src')
+      && current.getAttribute('data-protected-src') === next.getAttribute('data-protected-src'),
+  );
+  const sameIdentity = imageIdentity(current) === imageIdentity(next);
+  const sameProtectedAlt = Boolean(
+    current.getAttribute('data-protected-src')
+      && next.getAttribute('data-protected-src')
+      && current.alt
+      && current.alt === next.alt,
+  );
+  const keepDecodedImage = current.complete
+    && current.naturalWidth > 1
+    && (sameProtectedSource || sameIdentity || sameProtectedAlt);
+
+  if (keepDecodedImage) {
+    // Never write the placeholder src (or loading flags) over an image Chrome
+    // has already decoded. More importantly, leave this exact DOM node attached
+    // to the document so Chromium keeps its painted image layer.
+    syncAttributes(current, next, new Set([
+      'src',
+      'data-protected-src',
+      'data-img-loading',
+      'data-auth-hydrated',
+    ]));
+    return;
+  }
+
+  syncAttributes(current, next);
+}
+
+function morphNode(current: Node, next: Node): void {
+  if (current.nodeType === Node.TEXT_NODE || current.nodeType === Node.COMMENT_NODE) {
+    if (current.nodeValue !== next.nodeValue) current.nodeValue = next.nodeValue;
+    return;
+  }
+
+  const currentElement = current as Element;
+  const nextElement = next as Element;
+  if (currentElement instanceof HTMLImageElement && nextElement instanceof HTMLImageElement) {
+    morphImage(currentElement, nextElement);
+    return;
+  }
+
+  syncAttributes(currentElement, nextElement);
+  morphChildren(currentElement, nextElement);
+}
+
+function morphChildren(currentParent: ParentNode, nextParent: ParentNode): void {
+  const desiredChildren = Array.from(nextParent.childNodes);
+  let current = currentParent.firstChild;
+
+  for (const desired of desiredChildren) {
+    if (current && canMorph(current, desired)) {
+      const following = current.nextSibling;
+      morphNode(current, desired);
+      current = following;
+      continue;
+    }
+
+    // Insert only the new/mismatched subtree. Existing matching ancestors and
+    // their image descendants remain connected throughout streaming updates.
+    currentParent.insertBefore(desired.cloneNode(true), current);
+  }
+
+  while (current) {
+    const following = current.nextSibling;
+    currentParent.removeChild(current);
+    current = following;
+  }
+}
+
+/**
+ * Patch sanitized streaming HTML in place.
+ *
+ * Replacing innerHTML — or moving decoded images through a detached template —
+ * makes Chromium briefly drop the image's painted layer on every typewriter
+ * frame. This directive morphs text and surrounding markup without detaching a
+ * matching loaded <img> node.
+ */
+export const vStableHtml: ObjectDirective<HTMLElement, string> = {
+  beforeMount(el, binding) {
+    el.innerHTML = binding.value || '';
+  },
+  updated(el, binding) {
+    const html = binding.value || '';
+    if (html === binding.oldValue) return;
+    const template = document.createElement('template');
+    template.innerHTML = html;
+    morphChildren(el, template.content);
+  },
+};

--- a/frontend/src/utils/chatMarkdownRenderer.test.ts
+++ b/frontend/src/utils/chatMarkdownRenderer.test.ts
@@ -6,8 +6,14 @@ import {
   preprocessMathDelimiters,
   renderChatMarkdown,
   replaceIncompleteImageWithPlaceholder,
+  stripTrailingStreamingHorizontalRule,
 } from './chatMarkdownRenderer.ts'
-import { resolveCitationChunkId, joinCitationTagsToPreviousLine, collapseStandaloneCitationParagraphs } from './citationMarkdown.ts'
+import {
+  collapseStandaloneCitationParagraphs,
+  joinCitationTagsToPreviousLine,
+  resolveCitationChunkId,
+  stripIncompleteCitationTag,
+} from './citationMarkdown.ts'
 
 const SAMPLE_DOC = 'example-report.docx'
 const SAMPLE_CHUNK_A = '00000001-0000-4000-8000-000000000001'
@@ -27,6 +33,35 @@ test('replaceIncompleteImageWithPlaceholder hides an unfinished streaming image'
     replaceIncompleteImageWithPlaceholder('before ![chart](local://bucket/path'),
     'before <span class="streaming-image-loading"><span class="streaming-image-loading__skeleton"></span></span>',
   )
+})
+
+test('stripIncompleteCitationTag hides only an unfinished streaming citation tail', () => {
+  const prefix = 'Source '
+  const complete = '<kb doc="2.jpg" chunk_id="3c67efd5-f2ff-4e26-9032-9e44e6861178" />'
+
+  for (const partial of ['<', '<k', '<kb', '<kb ', '<kb doc="2.jpg"', '<w', '<we', '<web url="https://example.com"']) {
+    assert.equal(stripIncompleteCitationTag(prefix + partial), prefix)
+  }
+
+  assert.equal(stripIncompleteCitationTag(prefix + complete), prefix + complete)
+  assert.equal(stripIncompleteCitationTag('Value < 5'), 'Value < 5')
+})
+
+test('stripTrailingStreamingHorizontalRule hides an ambiguous trailing rule only mid-stream', () => {
+  for (const rule of ['---', '* * *', '___']) {
+    assert.equal(stripTrailingStreamingHorizontalRule(`- item\n\n${rule}`), '- item\n\n')
+  }
+  assert.equal(stripTrailingStreamingHorizontalRule('- item\n\n---\nnext'), '- item\n\n---\nnext')
+
+  const renderer = createChatMarkdownRenderer()
+  const options = {
+    renderer,
+    escapeMarkdown: (text: string) => text,
+    sanitizeHtml: (html: string) => html,
+  }
+  const source = '- item\n\n---'
+  assert.doesNotMatch(renderChatMarkdown(source, { ...options, streaming: true }), /<hr>/)
+  assert.match(renderChatMarkdown(source, { ...options, streaming: false }), /<hr>/)
 })
 
 test('renderChatMarkdown preserves citations, math, and sanitized output through one shared pipeline', () => {

--- a/frontend/src/utils/chatMarkdownRenderer.test.ts
+++ b/frontend/src/utils/chatMarkdownRenderer.test.ts
@@ -167,10 +167,37 @@ test('renderChatMarkdown inlines consecutive citation tags across newlines', () 
   assert.doesNotMatch(html, /<\/p>\s*<p>\s*<span class="citation citation-kb"/)
 })
 
-test('joinCitationTagsToPreviousLine keeps citations on a new line after a list', () => {
-  const tag = '<kb doc="doc.pdf" chunk_id="1" />'
-  const input = `1. first\n2. second\n\n${tag}`
-  assert.equal(joinCitationTagsToPreviousLine(input), `1. first\n2. second\n\n${tag}`)
+test('joinCitationTagsToPreviousLine appends an indented citation to the preceding list item', () => {
+  const tag = '<kb doc="阅读之星全国青少年阅读风采展示活动.pdf" chunk_id="chunk-1" />'
+  const input = [
+    '#### 5️⃣ 阅读之星培养基地',
+    '- 每个组别冠亚季军及前十强所在的学校，将获得 **"阅读之星培养基地"** 奖牌',
+    '',
+    `  ${tag}`,
+  ].join('\n')
+  assert.equal(
+    joinCitationTagsToPreviousLine(input),
+    [
+      '#### 5️⃣ 阅读之星培养基地',
+      `- 每个组别冠亚季军及前十强所在的学校，将获得 **"阅读之星培养基地"** 奖牌 ${tag}`,
+    ].join('\n'),
+  )
+})
+
+test('renderChatMarkdown renders a citation after a list item inline in that item', () => {
+  const renderer = createChatMarkdownRenderer({
+    imageRenderer: ({ href, text }) => `<img src="${href}" alt="${text}">`,
+    isValidImageUrl: () => true,
+  })
+  const tag = '<kb doc="阅读之星全国青少年阅读风采展示活动.pdf" chunk_id="chunk-1" />'
+  const html = renderChatMarkdown(`- 培养基地奖牌\n\n  ${tag}`, {
+    renderer,
+    escapeMarkdown: (text) => text,
+    sanitizeHtml: (value) => value,
+  })
+
+  assert.match(html, /<li>培养基地奖牌 <span class="citation citation-kb"/)
+  assert.doesNotMatch(html, /<\/ul>\s*<p>\s*<span class="citation citation-kb"/)
 })
 
 test('joinCitationTagsToPreviousLine does not merge citations onto fenced code closing delimiter', () => {

--- a/frontend/src/utils/chatMarkdownRenderer.ts
+++ b/frontend/src/utils/chatMarkdownRenderer.ts
@@ -9,6 +9,7 @@ import {
   preserveCitationTags,
   restoreCitationHtmlPlaceholders,
   restoreCitationTags,
+  stripIncompleteCitationTag,
   type CitationKnowledgeRef,
 } from './citationMarkdown.ts'
 
@@ -34,6 +35,8 @@ export type RenderChatMarkdownOptions = {
   renderer: Renderer
   escapeMarkdown: (markdown: string) => string
   sanitizeHtml: (html: string) => string
+  /** The source is still growing and may end in ambiguous partial Markdown. */
+  streaming?: boolean
   collapseStandaloneCitations?: boolean
   knowledgeReferences?: CitationKnowledgeRef[] | null
   cachedMermaidSvgHtml?: string | null
@@ -75,6 +78,22 @@ export function replaceIncompleteImageWithPlaceholder(content: string): string {
   return content
 }
 
+/**
+ * Hide a trailing Markdown horizontal-rule candidate while content is streaming.
+ *
+ * A model often emits `---` as the beginning of a table delimiter or another
+ * structure. At that exact typewriter frame, marked renders it as `<hr>`, then
+ * removes it when more characters arrive. A real completed horizontal rule is
+ * still rendered because this guard is enabled only for an active stream.
+ */
+export function stripTrailingStreamingHorizontalRule(content: string): string {
+  if (!content) return content
+  return content.replace(
+    /(^|\n)[ \t]{0,3}(?:(?:-[ \t]*){3,}|(?:\*[ \t]*){3,}|(?:_[ \t]*){3,})$/,
+    '$1',
+  )
+}
+
 export function createChatMarkdownRenderer(options: ChatMarkdownRendererOptions = {}): Renderer {
   const renderer = new marked.Renderer()
 
@@ -113,7 +132,11 @@ export function renderChatMarkdown(rawMarkdown: unknown, options: RenderChatMark
 
   configureMarkedForChatMarkdown()
 
-  const { text: tagSafe, tags } = preserveCitationTags(rawText)
+  const streamingSafeText = options.streaming
+    ? stripTrailingStreamingHorizontalRule(rawText)
+    : rawText
+  const citationSafeText = stripIncompleteCitationTag(streamingSafeText)
+  const { text: tagSafe, tags } = preserveCitationTags(citationSafeText)
   const imageSafe = replaceIncompleteImageWithPlaceholder(tagSafe)
   const mathSafe = preprocessMathDelimiters(imageSafe)
   const restoredTags = restoreCitationTags(mathSafe, tags)

--- a/frontend/src/utils/citationMarkdown.ts
+++ b/frontend/src/utils/citationMarkdown.ts
@@ -8,6 +8,29 @@ const WEB_TAG_ATTR_RE = /<web\b([^>]*?)\s*\/?>/g
 const ATTRIBUTE_REGEX = /([\w-]+)\s*=\s*"([^"]*)"/g
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
+/**
+ * Hide a citation tag while the typewriter has only emitted part of it.
+ *
+ * Without this guard, Markdown renders the leading `<` as ordinary text until
+ * the closing `>` arrives. Only the unfinished tail is removed; a complete tag
+ * continues through the normal citation pipeline.
+ */
+export function stripIncompleteCitationTag(content: string): string {
+  if (!content) return content
+
+  const start = content.lastIndexOf('<')
+  if (start < 0) return content
+
+  const tail = content.slice(start)
+  if (tail.includes('>')) return content
+
+  const isCitationPrefix = tail === '<'
+    || /^<k(?:b(?:\s[\s\S]*)?)?$/i.test(tail)
+    || /^<w(?:e(?:b(?:\s[\s\S]*)?)?)?$/i.test(tail)
+
+  return isCitationPrefix ? content.slice(0, start) : content
+}
+
 export type CitationKnowledgeRef = {
   id?: string
   knowledge_id?: string

--- a/frontend/src/utils/citationMarkdown.ts
+++ b/frontend/src/utils/citationMarkdown.ts
@@ -224,16 +224,15 @@ export function joinCitationTagsToPreviousLine(content: string): string {
     )
   }
 
-  // Blank lines before citations: join to previous prose, but keep a break after lists
-  // or fenced-code delimiters (``` / ~~~ must stay on their own line).
+  // Blank lines before citations: join to the previous content. Fenced-code
+  // delimiters are the only exception because ``` / ~~~ must stay on their own line.
   result = result.replace(/\n[ \t]*\n+([ \t]*<(?:kb|web)\b)/gi, (match, kbStart, offset, full) => {
     const before = full.slice(0, offset)
-    const lastLine = before.split('\n').filter((line) => line.trim()).pop() || ''
-    const isListItem = /^\s*(\d+\.|[-*+])\s+\S/.test(lastLine)
-    if (isListItem || isFencedCodeDelimiterLine(lastLine)) {
+    const lastLine = before.split('\n').filter((line: string) => line.trim()).pop() || ''
+    if (isFencedCodeDelimiterLine(lastLine)) {
       return `\n\n${kbStart}`
     }
-    return ` ${kbStart}`
+    return ` ${kbStart.trimStart()}`
   })
 
   // Single newline before citation when it follows text or another citation (not after a blank line)
@@ -243,7 +242,7 @@ export function joinCitationTagsToPreviousLine(content: string): string {
       if (isFencedCodeDelimiterLine(beforePart)) {
         return match
       }
-      return `${beforePart} ${kbStart}`
+      return `${beforePart} ${kbStart.trimStart()}`
     },
   )
 

--- a/frontend/src/utils/markdownDomPurify.ts
+++ b/frontend/src/utils/markdownDomPurify.ts
@@ -2,7 +2,7 @@ export const domPurifyForbidTags = ['script', 'style', 'object', 'embed', 'form'
 export const domPurifyForbidAttr = ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'onblur'] as const;
 
 export const domPurifyAllowedUriRegexp =
-  /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp):|(?:local|minio|cos|tos|s3|oss|ks3|obs):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;
+  /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|blob):|(?:local|minio|cos|tos|s3|oss|ks3|obs):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;
 
 /** Shared DOMPurify security options (FORBID_*, URI scheme, DOM flags). */
 export const domPurifySecurityOptions = {
@@ -60,7 +60,7 @@ export const markdownDomPurifyConfig = {
   ],
   ALLOWED_ATTR: [
     'href', 'title', 'target', 'rel', 'data-tooltip', 'data-url', 'data-kb-id',
-    'data-chunk-id', 'data-doc', 'data-slug', 'class', 'role', 'tabindex', 'src', 'alt', 'data-protected-src',
+    'data-chunk-id', 'data-doc', 'data-slug', 'class', 'role', 'tabindex', 'src', 'alt', 'data-protected-src', 'data-img-loading',
     'width', 'height', 'style', 'id', 'type', 'aria-label', 'data-mermaid', 'disabled',
     'd', 'fill', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin',
     'stroke-dasharray', 'stroke-dashoffset', 'stroke-miterlimit', 'stroke-opacity',

--- a/frontend/src/utils/security.ts
+++ b/frontend/src/utils/security.ts
@@ -32,7 +32,7 @@ const DOMPurifyConfig = {
   ],
   // 允许的属性
   ALLOWED_ATTR: [
-    'href', 'title', 'alt', 'src', 'class', 'id', 'style', 'data-protected-src',
+    'href', 'title', 'alt', 'src', 'class', 'id', 'style', 'data-protected-src', 'data-img-loading',
     'target', 'rel', 'width', 'height', 'open',
     'type', 'aria-label', 'disabled', 'role', 'tabindex',
     // Mermaid SVG 支持的属性
@@ -99,7 +99,23 @@ export function protectProviderImageSrcInHTML(html: string): string {
     (_m, before, quote, provider, restPathRaw, after) => {
       const restPath = decodeProviderURL(restPathRaw);
       const protectedSrc = `${provider}://${restPath}`;
-      return `<img${before} src=${quote}${PROVIDER_IMAGE_PLACEHOLDER}${quote} data-protected-src=${quote}${protectedSrc}${quote}${after}>`;
+      // A definitive 404 should not leave a skeleton behind. Streaming
+      // re-renders call this function repeatedly, so remember the missing
+      // source until the explicit end-of-stream retry clears the cache.
+      if (protectedFileMissingSources.has(protectedSrc)) {
+        return '';
+      }
+      // Reuse the already-hydrated blob if we have one, so repeated re-renders
+      // (typewriter streaming) keep the same stable image instead of flashing
+      // back to the placeholder every frame.
+      const cachedBlobURL = protectedFileBlobBySource.get(protectedSrc);
+      if (cachedBlobURL) {
+        return `<img${before} src=${quote}${cachedBlobURL}${quote} data-protected-src=${quote}${protectedSrc}${quote}${after}>`;
+      }
+      // Not hydrated yet: render the 1x1 placeholder but tag it so CSS can give
+      // it a stable skeleton box. Otherwise width:auto/height:auto collapse the
+      // 1x1 gif to a ~1px line that violently jumps to full size once loaded.
+      return `<img${before} src=${quote}${PROVIDER_IMAGE_PLACEHOLDER}${quote} data-protected-src=${quote}${protectedSrc}${quote} data-img-loading=${quote}1${quote}${after}>`;
     },
   );
 }
@@ -288,15 +304,54 @@ export function createSafeImage(src: string, alt: string = '', title: string = '
   return `<img src="${safeSrc}" alt="${safeAlt}" title="${safeTitle}" class="markdown-image" style="max-width: 100%; height: auto;">`;
 }
 
-const protectedFileBlobCache = new Map<string, string>();
+type ProtectedFileLoadResult =
+  | { status: 'loaded'; blobURL: string }
+  | { status: 'missing' }
+  | { status: 'failed' };
+
+type ProtectedFileCacheState = {
+  blobByRequest: Map<string, string>;
+  blobBySource: Map<string, string>;
+  missingSources: Set<string>;
+  failures: Map<string, number>;
+  inflight: Map<string, Promise<ProtectedFileLoadResult>>;
+};
+
+// Keep object URLs alive across Vite hot updates. A hot update replaces this
+// module but not the page document, so module-local Maps would forget valid
+// blob URLs and make already-loaded images fall back to the 1x1 placeholder.
+const protectedFileCacheState = (() => {
+  const fresh = (): ProtectedFileCacheState => ({
+    blobByRequest: new Map(),
+    blobBySource: new Map(),
+    missingSources: new Set(),
+    failures: new Map(),
+    inflight: new Map(),
+  });
+  if (typeof window === 'undefined') return fresh();
+  const scope = window as typeof window & {
+    __weknoraProtectedFileCacheV1__?: ProtectedFileCacheState;
+  };
+  scope.__weknoraProtectedFileCacheV1__ ||= fresh();
+  return scope.__weknoraProtectedFileCacheV1__;
+})();
+
+const protectedFileBlobCache = protectedFileCacheState.blobByRequest;
+// Blob URL keyed by the protected source URL (e.g. `local://...`). Once an image
+// has been hydrated, re-renders of the same markdown can emit the blob src
+// directly instead of the placeholder. Without this, the typewriter re-renders
+// the answer every frame, recreating each <img> as a placeholder that hydration
+// only restores a microtask later — which reads as a per-frame flicker.
+const protectedFileBlobBySource = protectedFileCacheState.blobBySource;
+const protectedFileMissingSources = protectedFileCacheState.missingSources;
 // Throttle retries of failed file fetches. During streaming the same markdown
 // is re-rendered on every chunk, producing brand-new <img> elements (so the
 // per-element `authHydrated` flag is reset each time). Without throttling a
 // not-yet-generated file (404) would be re-requested on every chunk. We record
 // the last failure time per URL and skip re-fetching within a cooldown window,
 // while still allowing a later attempt once the file becomes available.
-const protectedFileFailureCache = new Map<string, number>();
-const protectedFileInflight = new Set<string>();
+const protectedFileFailureCache = protectedFileCacheState.failures;
+const protectedFileInflight = protectedFileCacheState.inflight;
 const PROTECTED_FILE_RETRY_COOLDOWN_MS = 5000;
 
 function getProtectedFileRequestHeaders(): Record<string, string> {
@@ -333,6 +388,43 @@ function getProtectedFileRequestHeaders(): Record<string, string> {
  */
 export function clearProtectedFileFailureCache(): void {
   protectedFileFailureCache.clear();
+  protectedFileMissingSources.clear();
+}
+
+function protectedImageSource(img: HTMLImageElement): string {
+  return normalizeProtectedImageElement(img)
+    || (img.getAttribute('data-protected-src') || '').trim()
+    || (img.getAttribute('src') || '').trim();
+}
+
+function forEachProtectedImageWithSource(
+  root: ParentNode,
+  sourceURL: string,
+  callback: (img: HTMLImageElement) => void,
+): void {
+  root.querySelectorAll<HTMLImageElement>('img[data-protected-src]').forEach((candidate) => {
+    if (protectedImageSource(candidate) === sourceURL) callback(candidate);
+  });
+}
+
+function removeMissingProtectedImages(root: ParentNode, sourceURL: string): void {
+  forEachProtectedImageWithSource(root, sourceURL, (img) => {
+    const parent = img.parentElement;
+    img.remove();
+    // Markdown emits a dedicated paragraph for a standalone image. Remove that
+    // wrapper too so a missing image leaves no vertical placeholder/gap.
+    if (parent?.tagName === 'P' && !parent.textContent?.trim() && parent.children.length === 0) {
+      parent.remove();
+    }
+  });
+}
+
+function applyHydratedProtectedImage(root: ParentNode, sourceURL: string, blobURL: string): void {
+  forEachProtectedImageWithSource(root, sourceURL, (img) => {
+    img.src = blobURL;
+    img.dataset.authHydrated = '1';
+    img.removeAttribute('data-img-loading');
+  });
 }
 
 export async function hydrateProtectedFileImages(
@@ -367,6 +459,10 @@ export async function hydrateProtectedFileImages(
     if (img.dataset.authHydrated === '1') {
       return;
     }
+    if (protectedFileMissingSources.has(sourceURL)) {
+      removeMissingProtectedImages(root, sourceURL);
+      return;
+    }
     img.dataset.authHydrated = '1';
 
     const isProviderScheme = isProviderFileURL(sourceURL);
@@ -388,46 +484,66 @@ export async function hydrateProtectedFileImages(
 
     const cachedBlobURL = protectedFileBlobCache.get(requestURL);
     if (cachedBlobURL) {
-      img.src = cachedBlobURL;
+      applyHydratedProtectedImage(root, sourceURL, cachedBlobURL);
       return;
     }
 
-    // Skip while a fetch for the same URL is already in flight, or while the
-    // last attempt failed recently. Allow a fresh attempt to fix the element.
-    if (protectedFileInflight.has(requestURL)) {
-      img.dataset.authHydrated = '0';
-      return;
-    }
     const lastFailure = protectedFileFailureCache.get(requestURL);
     if (lastFailure !== undefined && Date.now() - lastFailure < PROTECTED_FILE_RETRY_COOLDOWN_MS) {
       img.dataset.authHydrated = '0';
       return;
     }
 
-    protectedFileInflight.add(requestURL);
-    try {
-      const resp = await fetch(requestURL, {
-        method: 'GET',
-        headers,
-        credentials: 'include',
-      });
-      if (!resp.ok) {
-        throw new Error(`HTTP ${resp.status}`);
-      }
-      const blob = await resp.blob();
-      const blobURL = URL.createObjectURL(blob);
-      protectedFileBlobCache.set(requestURL, blobURL);
-      protectedFileFailureCache.delete(requestURL);
-      img.src = blobURL;
-      if (protectedSrc) {
-        img.removeAttribute('data-protected-src');
-      }
-    } catch (error) {
-      console.warn('[security] hydrateProtectedFileImages failed:', error);
-      protectedFileFailureCache.set(requestURL, Date.now());
+    // Every component that references the same image awaits the shared task.
+    // The previous Set-based de-dupe made later components return immediately;
+    // only the component that started the fetch was updated, leaving all other
+    // occurrences stuck on the transparent placeholder forever.
+    let loadTask = protectedFileInflight.get(requestURL);
+    if (!loadTask) {
+      loadTask = (async (): Promise<ProtectedFileLoadResult> => {
+        try {
+          const resp = await fetch(requestURL, {
+            method: 'GET',
+            headers,
+            credentials: 'include',
+          });
+          if (!resp.ok) {
+            if (resp.status === 404) {
+              protectedFileFailureCache.set(requestURL, Date.now());
+              return { status: 'missing' };
+            }
+            throw new Error(`HTTP ${resp.status}`);
+          }
+          const blob = await resp.blob();
+          const blobURL = URL.createObjectURL(blob);
+          protectedFileBlobCache.set(requestURL, blobURL);
+          protectedFileFailureCache.delete(requestURL);
+          return { status: 'loaded', blobURL };
+        } catch (error) {
+          console.warn('[security] hydrateProtectedFileImages failed:', error);
+          protectedFileFailureCache.set(requestURL, Date.now());
+          return { status: 'failed' };
+        } finally {
+          protectedFileInflight.delete(requestURL);
+        }
+      })();
+      protectedFileInflight.set(requestURL, loadTask);
+    }
+
+    const result = await loadTask;
+    if (result.status === 'loaded') {
+      protectedFileBlobBySource.set(sourceURL, result.blobURL);
+      protectedFileMissingSources.delete(sourceURL);
+      applyHydratedProtectedImage(root, sourceURL, result.blobURL);
+      return;
+    }
+    if (result.status === 'missing') {
+      protectedFileMissingSources.add(sourceURL);
+      removeMissingProtectedImages(root, sourceURL);
+      return;
+    }
+    if (result.status === 'failed') {
       img.dataset.authHydrated = '0';
-    } finally {
-      protectedFileInflight.delete(requestURL);
     }
   }));
 }

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -260,7 +260,7 @@
             <div v-else-if="event.type === 'answer' && (event.done || (event.content && event.content.trim()))"
               class="answer-event">
               <div v-if="event.content && event.content.trim()" class="answer-content markdown-content">
-                <div :key="event.content" v-html="renderAnswerContent(event.content)"></div>
+                <div v-stable-html="renderAnswerContent(event === activeAnswerEventRef ? typedAnswer : event.content)"></div>
               </div>
               <div v-if="event.done && event.content && event.content.trim() && !embeddedMode" class="answer-toolbar">
                 <t-button size="small" variant="outline" shape="round" @click.stop="handleCopyAnswer(event)"
@@ -456,6 +456,8 @@ import {
   renderMermaidToSvg,
 } from '@/utils/mermaidShared';
 import { attachMarkdownEnhancementListeners, refreshMarkdownEnhancements } from '@/utils/markdownEnhancements';
+import { useTypewriter } from '@/composables/useTypewriter';
+import { vStableHtml } from '@/directives/stableHtml';
 
 const getToolIconName = getAgentToolIconName;
 
@@ -884,6 +886,23 @@ const activeAnswerMarkdown = computed(() => {
   return typeof active?.content === 'string' ? active.content : '';
 });
 
+// The answer event whose text is currently streaming. The template renders the
+// smoothed typewriter text for this event and the raw content for any others.
+const activeAnswerEventRef = computed(() => {
+  const stream = eventStream.value;
+  if (!stream?.length) return null;
+  const answers = stream.filter((e: any) => e.type === 'answer' && !e.superseded);
+  return answers.find((e: any) => !e.done) ?? answers[answers.length - 1] ?? null;
+});
+
+// Smooth the streamed answer into a steady typewriter cadence (shared with the
+// non-Agent markdown path). History reloads arrive already complete and snap to
+// full instead of replaying.
+const { displayed: typedAnswer } = useTypewriter(
+  () => activeAnswerMarkdown.value,
+  () => isConversationDone.value,
+);
+
 const cacheStreamingMermaidSvg = async () => {
   if (streamingMermaidSvgCache.value) return;
   const code = extractFirstMermaidCode(activeAnswerMarkdown.value);
@@ -921,10 +940,21 @@ watch(activeAnswerMarkdown, () => {
 // Files referenced mid-stream (e.g. exported images) may only become available
 // at completion; throttling stops the chunk-by-chunk 404 spam during streaming,
 // and this final pass guarantees they load without waiting out the cooldown.
-watch(isConversationDone, (done) => {
-  if (!done) return;
+//
+// Gate this on the typewriter having fully revealed the answer: when done flips,
+// the smoothed text may still be catching up, so the <img> tag is not in the DOM
+// yet. Hydrating too early would find nothing and leave a permanent placeholder
+// (until a manual reload). Waiting for full reveal guarantees the image exists.
+const answerFullyRendered = computed(
+  () => isConversationDone.value && typedAnswer.value.length >= activeAnswerMarkdown.value.length,
+);
+watch(answerFullyRendered, (ready) => {
+  if (!ready) return;
+  // Clear before this reactive update renders, so a source that returned 404
+  // mid-stream gets one real final-attempt <img> node instead of remaining
+  // suppressed by the missing-source cache.
+  clearProtectedFileFailureCache();
   nextTick(async () => {
-    clearProtectedFileFailureCache();
     await hydrateProtectedFileImages(rootElement.value);
   });
 });
@@ -1649,8 +1679,15 @@ onBeforeUnmount(() => {
 });
 
 onUpdated(() => {
-  nextTick(() => {
+  nextTick(async () => {
     rebindCitations();
+    // Hydrate protected-file images (e.g. local:// exports) as soon as the
+    // typewriter reveals their <img> into the DOM, so they show in real time
+    // mid-stream instead of waiting for the turn to finish. Hydration is cheap
+    // and idempotent: blob results are cached per URL, in-flight fetches are
+    // de-duped, and failures back off for a cooldown — so a not-yet-ready file
+    // simply retries later (and the answerFullyRendered pass is the backstop).
+    await hydrateProtectedFileImages(rootElement.value);
   });
 });
 
@@ -1676,6 +1713,7 @@ const renderAgentMarkdown = (
     renderer: agentRenderer,
     escapeMarkdown,
     sanitizeHtml: sanitizeMarkdownHTML,
+    streaming: !isConversationDone.value,
     knowledgeReferences: props.session?.knowledge_references,
     cachedMermaidSvgHtml: streamingMermaidSvgCache.value,
     prepareMarkdown: prepareAgentMarkdown,
@@ -2316,8 +2354,6 @@ const handleAddToKnowledge = (answerEvent: any) => {
       .chat-citation-pills();
 
       :deep(img) {
-        min-height: 100px;
-        /* 防止流式输出时图片高度塌陷导致抖动 */
         background-color: var(--td-bg-color-secondarycontainer);
         /* 加载时的占位背景色 */
       }

--- a/frontend/src/views/chat/components/botmsg.vue
+++ b/frontend/src/views/chat/components/botmsg.vue
@@ -31,7 +31,7 @@
             <!-- 直接渲染完整内容，避免切分导致的问题，样式与 thinking 一致 -->
             <!-- 只有当有实际内容时才显示包围框 -->
             <div class="content-wrapper" v-if="hasActualContent">
-                <div class="ai-markdown-template markdown-content" v-html="renderedHTML">
+                <div class="ai-markdown-template markdown-content" v-stable-html="renderedHTML">
                 </div>
             </div>
             <!-- Streaming indicator (non-Agent mode) -->
@@ -101,6 +101,8 @@ import {
 } from '@/utils/mermaidShared';
 import { refreshMarkdownEnhancements } from '@/utils/markdownEnhancements';
 import { useChatCitationPopover } from '@/composables/useChatCitationPopover';
+import { useTypewriter } from '@/composables/useTypewriter';
+import { vStableHtml } from '@/directives/stableHtml';
 
 ensureMermaidInitialized();
 
@@ -170,14 +172,26 @@ const mentionedItems = computed(() => {
     return props.session?.mentioned_items || [];
 });
 
+// Smooth the streamed answer into a steady typewriter cadence (shared with the
+// Agent path). Copy/toolbar still read the full content; only display is paced.
+const answerText = computed(() => {
+    const text = props.content || props.session?.content || '';
+    return typeof text === 'string' ? text : '';
+});
+const { displayed: typedAnswer } = useTypewriter(
+    () => answerText.value,
+    () => Boolean(props.session?.is_completed),
+);
+
 // 单次渲染整个 Markdown 内容（替代 token-by-token，修复 KaTeX 公式在 streaming 时闪烁消失的问题）
 const renderedHTML = computed(() => {
-    const text = props.content || props.session?.content || '';
+    const text = typedAnswer.value;
     if (!text || typeof text !== 'string') return '';
     return renderChatMarkdown(text, {
         renderer: markdownRenderer,
         escapeMarkdown: safeMarkdownToHTML,
         sanitizeHtml: sanitizeMarkdownHTML,
+        streaming: !props.session?.is_completed,
         knowledgeReferences: props.session?.knowledge_references,
     });
 });

--- a/frontend/src/views/chat/components/usermsg.vue
+++ b/frontend/src/views/chat/components/usermsg.vue
@@ -221,21 +221,23 @@ const closePreImg = () => {
 
 .user_msg {
     width: max-content;
-    max-width: 776px;
+    max-width: min(76%, 680px);
     display: flex;
-    padding: 10px 12px;
+    padding: 8px 12px;
     flex-direction: column;
     justify-content: center;
-    align-items: center;
+    align-items: flex-start;
     gap: 4px;
     flex: 1 0 0;
-    border-radius: 4px;
-    background: #8CE97F;
+    border-radius: 8px;
+    background: var(--td-bg-color-secondarycontainer);
     margin-left: auto;
-    color: #000000e6;
+    color: var(--td-text-color-primary);
     font-size: 16px;
-    text-align: justify;
-    word-break: break-all;
+    line-height: 1.6;
+    text-align: left;
+    word-break: break-word;
+    overflow-wrap: anywhere;
     box-sizing: border-box;
     white-space: pre-wrap;
 }
@@ -348,8 +350,8 @@ const closePreImg = () => {
 
 html[theme-mode="dark"] {
     .user_msg {
-        background: var(--td-brand-color-3);
-        color: rgba(255, 255, 255, 0.9);
+        background: var(--td-bg-color-secondarycontainer);
+        color: var(--td-text-color-primary);
     }
 }
 </style>

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -26,7 +26,7 @@
                     <div v-if="suggestedQuestionsLoading && suggestedQuestions.length === 0"
                         class="suggested-questions-inner">
                         <div class="suggested-questions-title"><t-skeleton animation="gradient"
-                                :row-col="[{ width: '120px', height: '18px' }]" /></div>
+                                :row-col="[{ width: '120px', height: '14px' }]" /></div>
                         <div class="suggested-questions-grid">
                             <div v-for="n in 6" :key="'sq-skel-' + n" class="suggested-question-card sq-card-skeleton">
                                 <t-skeleton animation="gradient"
@@ -37,12 +37,17 @@
                     <transition v-else appear name="sq-fade">
                         <div v-if="suggestedQuestions.length > 0" class="suggested-questions-inner">
                             <div class="suggested-questions-title-row">
-                                <div class="suggested-questions-title">{{ t('chat.suggestedQuestions') }}</div>
-                                <t-button variant="text" shape="square" size="small" class="suggested-questions-refresh"
-                                    :loading="suggestedQuestionsLoading" :title="t('chat.refreshSuggestedQuestions')"
-                                    @click="fetchSuggestedQuestions">
-                                    <template #icon><t-icon name="refresh" /></template>
-                                </t-button>
+                                <p class="suggested-questions-caption">
+                                    <span class="suggested-questions-title">{{ t('chat.suggestedQuestions') }}</span>
+                                    <button type="button" class="suggested-questions-refresh"
+                                        :disabled="suggestedQuestionsLoading"
+                                        :title="t('chat.refreshSuggestedQuestions')"
+                                        :aria-label="t('chat.refreshSuggestedQuestions')"
+                                        @click="fetchSuggestedQuestions">
+                                        <t-icon :name="suggestedQuestionsLoading ? 'loading' : 'refresh'"
+                                            :class="{ 'sq-refresh-spin': suggestedQuestionsLoading }" />
+                                    </button>
+                                </p>
                             </div>
                             <div class="suggested-questions-grid">
                                 <div v-for="(item, index) in suggestedQuestions" :key="item.question"
@@ -1078,152 +1083,23 @@ onBeforeRouteUpdate((to, from, next) => {
     }
 }
 
-.suggested-questions-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 32px 16px 16px;
-    max-width: 800px;
-    margin: 0 auto;
-    width: 100%;
-    min-height: 0;
-    transition: min-height 0.3s ease;
+@import '../../components/css/suggested-questions.less';
 
-    &.has-questions {
-        min-height: 80px;
-    }
+.suggested-questions-container {
+    transition: min-height 0.3s @suggested-ease;
 }
 
 .suggested-questions-inner {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
     animation: contentFadeIn 0.3s ease-out;
 }
 
 .sq-fade-enter-active,
 .sq-fade-leave-active {
-    transition: opacity 0.25s ease;
+    transition: opacity 0.25s @suggested-ease;
 }
 
 .sq-fade-enter-from,
 .sq-fade-leave-to {
     opacity: 0;
-}
-
-.suggested-questions-title-row {
-    display: flex;
-    align-items: center;
-    gap: 2px;
-    margin-bottom: 16px;
-}
-
-.suggested-questions-title {
-    font-size: 14px;
-    color: var(--td-text-color-secondary);
-    margin-bottom: 0;
-    font-weight: 500;
-}
-
-.suggested-questions-refresh {
-    flex-shrink: 0;
-    color: var(--td-text-color-secondary);
-
-    &:hover:not(.t-is-disabled) {
-        color: var(--td-text-color-primary);
-    }
-}
-
-.suggested-questions-grid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-    justify-content: center;
-    width: 100%;
-}
-
-.suggested-question-card {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 10px 16px;
-    border-radius: 20px;
-    border: 1px solid var(--td-component-stroke);
-    background: var(--td-bg-color-container);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    max-width: 100%;
-
-    &.sq-card-skeleton {
-        pointer-events: none;
-        flex-shrink: 0;
-        border-color: transparent;
-        background: var(--td-bg-color-secondarycontainer);
-
-        :deep(.t-skeleton) {
-            width: 100%;
-        }
-
-        :deep(.t-skeleton__row) {
-            margin: 0;
-        }
-
-        :deep(.t-skeleton__col) {
-            border-radius: 4px;
-        }
-
-        &:nth-child(1) {
-            width: 132px;
-        }
-
-        &:nth-child(2) {
-            width: 168px;
-        }
-
-        &:nth-child(3) {
-            width: 116px;
-        }
-
-        &:nth-child(4) {
-            width: 152px;
-        }
-
-        &:nth-child(5) {
-            width: 124px;
-        }
-
-        &:nth-child(6) {
-            width: 144px;
-        }
-    }
-
-    &:not(.sq-card-skeleton):hover {
-        border-color: var(--td-brand-color);
-        background: var(--td-brand-color-light);
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-    }
-}
-
-.suggested-question-text {
-    font-size: 13px;
-    color: var(--td-text-color-primary);
-    line-height: 1.4;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.suggested-question-badge {
-    font-size: 10px;
-    padding: 1px 5px;
-    border-radius: 4px;
-    flex-shrink: 0;
-    font-weight: 500;
-
-    &.faq {
-        background: var(--td-success-color-1);
-        color: var(--td-success-color);
-    }
 }
 </style>

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -126,6 +126,7 @@ import { useUIStore } from '@/stores/ui';
 import KnowledgeBaseEditorModal from '@/views/knowledge/KnowledgeBaseEditorModal.vue';
 import { useKnowledgeBaseCreationNavigation } from '@/hooks/useKnowledgeBaseCreationNavigation';
 import { useChatStreamHandler } from '@/composables/useChatStreamHandler';
+import { useStickyBottomOnResize } from '@/composables/useStickyBottomOnResize';
 import { clearCitationChunkCache } from '@/utils/citationChunkCache';
 
 const props = defineProps({
@@ -392,6 +393,12 @@ const onClickScrollToBottom = () => {
     userHasScrolledUp.value = false;
     scrollToBottom(true);
 }
+
+// Images and other rich Markdown content can grow after the SSE chunk that
+// introduced them. Follow those delayed height changes while the user remains
+// at the live edge; preserve position when they intentionally scroll upward.
+useStickyBottomOnResize(scrollContainer, userHasScrolledUp, scrollToBottom);
+
 const debounce = (fn, delay) => {
     let timer
     return (...args) => {

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -421,8 +421,22 @@ const onChatScrollTop = () => {
     }
 }
 const debouncedScrollTop = debounce(onChatScrollTop, 500);
+let lastScrollTop = 0;
 const handleScroll = () => {
-    userHasScrolledUp.value = !isNearBottom();
+    const el = scrollContainer.value;
+    if (el) {
+        const currentTop = el.scrollTop;
+        // Only an actual upward scroll detaches from the live edge. Content that
+        // grows after a chunk (images, diagrams) keeps scrollTop fixed and would
+        // otherwise fire a stale scroll event that falsely marks the user as
+        // scrolled up, killing the auto-follow during streaming.
+        if (currentTop < lastScrollTop - 1) {
+            userHasScrolledUp.value = !isNearBottom();
+        } else if (isNearBottom()) {
+            userHasScrolledUp.value = false;
+        }
+        lastScrollTop = currentTop;
+    }
     debouncedScrollTop();
 };
 

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -448,6 +448,8 @@ const {
     shouldShowGlobalTypingIndicator,
     handleMsgList,
     processStreamChunk,
+    prepareForNewOutgoingMessage,
+    markInFlightAssistantStopped,
 } = useChatStreamHandler({
     messagesList,
     loading,
@@ -488,10 +490,6 @@ const {
     },
     onAgentQuery: (data, existingMessage) => {
         pendingStreamDebug.value = buildStreamDebugPayload();
-        if (data.id) {
-            const earlyMsg = findLastMessage((item) => item.role === 'assistant' && !item.is_completed);
-            if (earlyMsg) attachStreamDebugToMessage(earlyMsg);
-        }
         if (existingMessage) attachStreamDebugToMessage(existingMessage);
     },
     onMessageCreated: (message) => attachStreamDebugToMessage(message),
@@ -557,13 +555,17 @@ const getmsgList = (data, isScrollType = false, scrollHeight) => {
 // 处理停止生成事件 - 立即清除 loading 状态
 const handleStopGeneration = () => {
     console.log('[Stop Generation] Immediately clearing loading state');
+    stopStream();
     loading.value = false;
     isReplying.value = false;
-    // 注意：不在这里清空 currentAssistantMessageId，因为需要它来调用 API
-    // API 调用成功后，后端的 stop 事件会清空它
+    // 标记当前 assistant 为已结束，避免下一条 query 复用该消息行
+    markInFlightAssistantStopped(currentAssistantMessageId.value);
+    // 保留 currentAssistantMessageId，Input-field 仍需用它调用 stop API
 };
 
 const sendMsg = async (value, modelId = '', mentionedItems = [], imageFiles = [], attachmentFiles = []) => {
+    stopStream();
+    prepareForNewOutgoingMessage();
     isReplying.value = true;
     loading.value = true;
 

--- a/frontend/src/views/creatChat/creatChat.vue
+++ b/frontend/src/views/creatChat/creatChat.vue
@@ -9,7 +9,7 @@
                 <!-- 骨架屏占位 -->
                 <div v-if="sqLoading && suggestedQuestions.length === 0" class="suggested-questions-inner">
                     <div class="suggested-questions-title"><t-skeleton animation="gradient"
-                            :row-col="[{ width: '120px', height: '18px' }]" /></div>
+                            :row-col="[{ width: '120px', height: '14px' }]" /></div>
                     <div class="suggested-questions-grid">
                         <div v-for="n in 6" :key="'sq-skel-' + n" class="suggested-question-card sq-card-skeleton">
                             <t-skeleton animation="gradient"
@@ -21,12 +21,15 @@
                     @after-leave="onAfterLeave" @enter="onEnter" @after-enter="onQuestionsEntered">
                     <div v-if="suggestedQuestions.length > 0" :key="sqRenderKey" class="suggested-questions-inner">
                         <div class="suggested-questions-title-row">
-                            <div class="suggested-questions-title">{{ $t('chat.suggestedQuestions') }}</div>
-                            <t-button variant="text" shape="square" size="small" class="suggested-questions-refresh"
-                                :loading="sqLoading" :title="$t('chat.refreshSuggestedQuestions')"
-                                @click="fetchSuggestedQuestions">
-                                <template #icon><t-icon name="refresh" /></template>
-                            </t-button>
+                            <p class="suggested-questions-caption">
+                                <span class="suggested-questions-title">{{ $t('chat.suggestedQuestions') }}</span>
+                                <button type="button" class="suggested-questions-refresh" :disabled="sqLoading"
+                                    :title="$t('chat.refreshSuggestedQuestions')"
+                                    :aria-label="$t('chat.refreshSuggestedQuestions')" @click="fetchSuggestedQuestions">
+                                    <t-icon :name="sqLoading ? 'loading' : 'refresh'"
+                                        :class="{ 'sq-refresh-spin': sqLoading }" />
+                                </button>
+                            </p>
                         </div>
                         <div class="suggested-questions-grid">
                             <div v-for="(item, index) in suggestedQuestions" :key="item.question"
@@ -251,6 +254,7 @@ const handleKBEditorSuccess = (kbId: string) => {
     align-items: center;
     width: 100%;
     max-width: 800px;
+    gap: 24px;
 
     :deep(.answers-input) {
         position: static;
@@ -265,7 +269,7 @@ const handleKBEditorSuccess = (kbId: string) => {
     font-size: 28px;
     font-weight: 600;
     align-items: center;
-    margin-bottom: 30px;
+    margin-bottom: 0;
 
     .icon {
         display: flex;
@@ -285,15 +289,7 @@ const handleKBEditorSuccess = (kbId: string) => {
     }
 }
 
-.suggested-questions-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin-bottom: 24px;
-    width: 100%;
-    max-width: 800px;
-    transition: height 0.35s cubic-bezier(0.4, 0, 0.2, 1);
-}
+@import '../../components/css/suggested-questions.less';
 
 @keyframes skeletonFadeIn {
     from {
@@ -305,18 +301,19 @@ const handleKBEditorSuccess = (kbId: string) => {
     }
 }
 
+.suggested-questions-container {
+    max-width: 800px;
+    margin: 0;
+    padding: 0 16px;
+    transition: height 0.35s @suggested-ease;
+}
+
 .suggested-questions-inner {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
     animation: skeletonFadeIn 0.3s ease-out;
 }
 
-// 容器整体过渡：淡入 + 轻微上滑
 .sq-slide-fade-enter-active {
-    transition: opacity 0.35s cubic-bezier(0.4, 0, 0.2, 1),
-        transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: opacity 0.35s @suggested-ease, transform 0.35s @suggested-ease;
 }
 
 .sq-slide-fade-leave-active {
@@ -334,99 +331,18 @@ const handleKBEditorSuccess = (kbId: string) => {
     transform: translateY(-4px);
 }
 
-.suggested-questions-title-row {
-    display: flex;
-    align-items: center;
-    gap: 2px;
-    margin-bottom: 12px;
-}
-
-.suggested-questions-title {
-    font-size: 14px;
-    color: var(--td-text-color-secondary);
-    margin-bottom: 0;
-    font-weight: 500;
-}
-
-.suggested-questions-refresh {
-    flex-shrink: 0;
-    color: var(--td-text-color-secondary);
-
-    &:hover:not(.t-is-disabled) {
-        color: var(--td-text-color-primary);
-    }
-}
-
-.suggested-questions-grid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-    justify-content: center;
-    width: 100%;
-}
-
 .suggested-question-card {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 10px 16px;
-    border-radius: 20px;
-    border: 1px solid var(--td-component-stroke);
-    background: var(--td-bg-color-container);
-    cursor: pointer;
-    max-width: 100%;
     opacity: 0;
     transform: translateY(8px) scale(0.97);
-    transition: opacity 0.35s cubic-bezier(0.4, 0, 0.2, 1),
-        transform 0.35s cubic-bezier(0.4, 0, 0.2, 1),
-        border-color 0.2s ease,
-        background 0.2s ease,
-        box-shadow 0.2s ease;
+    transition:
+        opacity 0.35s @suggested-ease,
+        transform 0.35s @suggested-ease,
+        background 0.2s @suggested-ease,
+        border-color 0.2s @suggested-ease;
 
     &.sq-card-skeleton {
         opacity: 1;
         transform: none;
-        cursor: default;
-        pointer-events: none;
-        flex-shrink: 0;
-        border-color: transparent;
-        background: var(--td-bg-color-secondarycontainer);
-
-        :deep(.t-skeleton) {
-            width: 100%;
-        }
-
-        :deep(.t-skeleton__row) {
-            margin: 0;
-        }
-
-        :deep(.t-skeleton__col) {
-            border-radius: 4px;
-        }
-
-        &:nth-child(1) {
-            width: 132px;
-        }
-
-        &:nth-child(2) {
-            width: 168px;
-        }
-
-        &:nth-child(3) {
-            width: 116px;
-        }
-
-        &:nth-child(4) {
-            width: 152px;
-        }
-
-        &:nth-child(5) {
-            width: 124px;
-        }
-
-        &:nth-child(6) {
-            width: 144px;
-        }
     }
 
     &.sq-card-visible {
@@ -434,32 +350,12 @@ const handleKBEditorSuccess = (kbId: string) => {
         transform: translateY(0) scale(1);
     }
 
-    &:not(.sq-card-skeleton):hover {
-        border-color: var(--td-brand-color);
-        background: var(--td-brand-color-light);
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    &:not(.sq-card-skeleton):active {
+        transform: scale(0.98);
     }
-}
 
-.suggested-question-text {
-    font-size: 13px;
-    color: var(--td-text-color-primary);
-    line-height: 1.4;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.suggested-question-badge {
-    font-size: 10px;
-    padding: 1px 5px;
-    border-radius: 4px;
-    flex-shrink: 0;
-    font-weight: 500;
-
-    &.faq {
-        background: var(--td-success-color-1);
-        color: var(--td-success-color);
+    &.sq-card-visible:active {
+        transform: scale(0.98);
     }
 }
 

--- a/frontend/src/views/creatChat/creatChat.vue
+++ b/frontend/src/views/creatChat/creatChat.vue
@@ -338,7 +338,8 @@ const handleKBEditorSuccess = (kbId: string) => {
         opacity 0.35s @suggested-ease,
         transform 0.35s @suggested-ease,
         background 0.2s @suggested-ease,
-        border-color 0.2s @suggested-ease;
+        border-color 0.25s @suggested-ease,
+        box-shadow 0.25s @suggested-ease;
 
     &.sq-card-skeleton {
         opacity: 1;

--- a/frontend/src/views/embed/EmbedBotMessage.vue
+++ b/frontend/src/views/embed/EmbedBotMessage.vue
@@ -13,7 +13,7 @@
     <DeepThink v-if="session?.showThink && !session?.isAgentMode" :deep-session="session" />
     <div v-if="!session?.hideContent && !session?.isAgentMode" ref="parentMd">
       <div v-if="hasActualContent" class="content-wrapper">
-        <div class="ai-markdown-template markdown-content" v-html="renderedHTML" />
+        <div class="ai-markdown-template markdown-content" v-stable-html="renderedHTML" />
       </div>
       <div v-if="hasActualContent && !session?.is_completed" class="loading-indicator">
         <div class="loading-typing">
@@ -63,6 +63,8 @@ import {
   enhanceMarkdownContainer,
 } from '@/utils/mermaidShared'
 import { useEmbedCitationPopover } from '@/composables/useEmbedCitationPopover'
+import { useTypewriter } from '@/composables/useTypewriter'
+import { vStableHtml } from '@/directives/stableHtml'
 
 const RagPipelineProgress = defineAsyncComponent(
   () => import('@/views/chat/components/RagPipelineProgress.vue'),
@@ -142,13 +144,22 @@ const scheduleCitationClose = () => {
   }, 120)
 }
 
+// Smooth the streamed answer into a steady typewriter cadence (shared with the
+// Agent path). History reloads arrive complete and snap to full.
+const answerText = computed(() => String(props.content || props.session?.content || ''))
+const { displayed: typedAnswer } = useTypewriter(
+  () => answerText.value,
+  () => Boolean(props.session?.is_completed),
+)
+
 const renderedHTML = computed(() => {
-  const text = String(props.content || props.session?.content || '')
+  const text = typedAnswer.value
   if (!text.trim()) return ''
   return renderChatMarkdown(text, {
     renderer: markdownRenderer,
     escapeMarkdown: safeMarkdownToHTML,
     sanitizeHtml: sanitizeMarkdownHTML,
+    streaming: !props.session?.is_completed,
   })
 })
 

--- a/frontend/src/views/embed/EmbedUserMessage.vue
+++ b/frontend/src/views/embed/EmbedUserMessage.vue
@@ -106,15 +106,17 @@ const formatFileSize = (bytes: number): string => {
 
 .user_msg {
   width: max-content;
-  max-width: 776px;
-  padding: 10px 12px;
-  border-radius: 4px;
-  background: #8ce97f;
+  max-width: min(76%, 680px);
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: var(--td-bg-color-secondarycontainer);
   margin-left: auto;
-  color: #000000e6;
+  color: var(--td-text-color-primary);
   font-size: 16px;
-  text-align: justify;
-  word-break: break-all;
+  line-height: 1.6;
+  text-align: left;
+  word-break: break-word;
+  overflow-wrap: anywhere;
   box-sizing: border-box;
   white-space: pre-wrap;
 }
@@ -167,7 +169,7 @@ const formatFileSize = (bytes: number): string => {
 }
 
 html[theme-mode='dark'] .user_msg {
-  background: var(--td-brand-color-3);
-  color: rgba(255, 255, 255, 0.9);
+  background: var(--td-bg-color-secondarycontainer);
+  color: var(--td-text-color-primary);
 }
 </style>


### PR DESCRIPTION
## What changed

- unify suggested-question styling across the existing and new-chat views
- keep citation markers attached to their preceding list content, with regression coverage
- prevent the manual Markdown editor from shifting the viewport while its drawer opens
- synchronize the resize handle with the drawer transition
- render the embedded-channel preview and settings drawers in the same body-level stacking context

## Why

The chat entry points had duplicated suggested-question markup and styling, citations after list items could render as detached blocks, and opening the Markdown editor could intermittently leave a brief gap at the right edge. The drawer issue was caused by focusing a transformed textarea during its entrance animation, which allowed the browser to scroll it into view. The embedded preview also lived in a different stacking context, so its higher numeric z-index could still appear below the editor drawer.

## Impact

Suggested prompts are visually consistent across chat surfaces, citations remain inline with the content they reference, and the Markdown editor and embedded preview now open smoothly with predictable layering.

## Validation

- `npm test -- src/utils/chatMarkdownRenderer.test.ts` (14 tests passed)
- `npm run build-only`
- manually opened, closed, and reopened the Markdown editor; its right edge remained aligned with the viewport and horizontal scroll stayed at zero
