### PR TITLE
fix(frontend): prevent settings modal from overflowing viewport

### DIFF
--- a/frontend/src/views/settings/Settings.vue
+++ b/frontend/src/views/settings/Settings.vue
@@ -68,13 +68,10 @@
 
             <!-- 右侧内容区域 -->
             <div class="settings-content">
-              <div
-                class="content-wrapper"
-                :class="{
-                  'content-wrapper--wide': currentSection === 'members',
-                  'content-wrapper--full': currentSection === 'system-global',
-                }"
-              >
+              <div class="content-wrapper" :class="{
+                'content-wrapper--wide': currentSection === 'members',
+                'content-wrapper--full': currentSection === 'system-global',
+              }">
                 <!-- 角色不允许访问当前 section（deep-link 进来 / 跨租户切换后角色降级）—— 优先于具体 section 渲染。
                      正常导航走 navItems filter 不会到这里，但 watch(navItems) 的 fallback 会在角色降级
                      的瞬间触发；这一段做兜底兼容旧 URL。 -->
@@ -491,6 +488,7 @@ onUnmounted(() => {
   // and the modal shrinks to fit minus the 20px padding.
   max-width: 1080px;
   height: 780px;
+  max-height: calc(100vh - 40px);
   background: var(--td-bg-color-container);
   border-radius: 12px;
   box-shadow: 0 6px 28px rgba(15, 23, 42, 0.08);


### PR DESCRIPTION

Add max-height: calc(100vh - 40px) to .settings-modal so it never exceeds the viewport height minus overlay padding, keeping the close button always visible without requiring F11 fullscreen.
<img width="1917" height="1030" alt="屏幕截图 2026-06-19 141617" src="https://github.com/user-attachments/assets/35b48944-8f1b-4c30-8b6f-554240f5801d" />



<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #1731 

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->

## Checklist
- [x] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
