### PR TITLE
fix(frontend): lower UploadConfirmDialog z-index so Settings modal appears above it

### DIFF
--- a/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
+++ b/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
@@ -910,7 +910,7 @@ const handleConfirm = () => {
 .upload-confirm-overlay {
   position: fixed;
   inset: 0;
-  z-index: 2500;
+  z-index: 1000;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
修复"上传文档确认"弹窗中点击"前往全局设置添加模型"时，设置弹窗被遮挡的问题。将 UploadConfirmDialog 遮罩层的 z-index 从 2500 降为 1000，使其与项目中其他模态框（KnowledgeBaseEditorModal、AgentEditorModal 等）保持一致，低于全局设置弹窗（1100）。

https://github.com/user-attachments/assets/edcc2a81-a440-40f3-a4e1-7a439f48b0a6


<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #1736 

