### PR TITLE
feat(frontend): add wiki tool support and enhance agent tool icon mapping

### DIFF
--- a/frontend/src/utils/agent-tool-display.test.mjs
+++ b/frontend/src/utils/agent-tool-display.test.mjs
@@ -5,6 +5,7 @@ import {
   getKnowledgeSearchSummaryHtml,
   getQueryText,
   getRagPipelineStepTitle,
+  getWikiPageText,
 } from './agent-tool-display.ts'
 
 const t = (key, params) => {
@@ -22,6 +23,12 @@ test('getAgentToolIconName maps rag pipeline tools', () => {
   assert.equal(getAgentToolIconName('knowledge_search'), 'data-search')
 })
 
+test('getAgentToolIconName maps Wiki tools to semantic search and reading icons', () => {
+  assert.equal(getAgentToolIconName('wiki_search'), 'search')
+  assert.equal(getAgentToolIconName('wiki_read_page'), 'file-search')
+  assert.equal(getAgentToolIconName('wiki_read_source_doc'), 'file-search')
+})
+
 test('getQueryText joins unique query strings', () => {
   assert.equal(getQueryText({ query: 'foo', queries: ['foo', 'bar'] }), 'foo，bar')
 })
@@ -33,6 +40,14 @@ test('getQueryText parses JSON-encoded queries string', () => {
     }),
     '合力天胜游泳俱乐部介绍，合力天胜游泳训练机构，合力天胜游泳队',
   )
+})
+
+test('getWikiPageText supports persisted slugs arrays', () => {
+  assert.equal(
+    getWikiPageText({ slugs: ['entity/知识助理', 'concept/API管理'] }),
+    'entity/知识助理、concept/API管理',
+  )
+  assert.equal(getWikiPageText('{"slug":"index"}'), 'index')
 })
 
 test('getKnowledgeSearchSummaryHtml includes file count when present', () => {

--- a/frontend/src/utils/agent-tool-display.ts
+++ b/frontend/src/utils/agent-tool-display.ts
@@ -49,6 +49,28 @@ export function getQueryText(args: unknown): string {
   return Array.from(new Set(queries)).join('，')
 }
 
+export function getWikiPageText(args: unknown): string {
+  if (!args) return ''
+
+  let parsedArgs = args
+  if (typeof parsedArgs === 'string') {
+    try {
+      parsedArgs = JSON.parse(parsedArgs)
+    } catch {
+      return ''
+    }
+  }
+
+  if (!parsedArgs || typeof parsedArgs !== 'object') return ''
+
+  const record = parsedArgs as Record<string, unknown>
+  const slugs = [
+    ...collectQueryStrings(record.slug),
+    ...collectQueryStrings(record.slugs),
+  ]
+  return Array.from(new Set(slugs)).join('、')
+}
+
 export function getKnowledgeSearchSummaryHtml(
   t: ComposerTranslation,
   toolData: Record<string, unknown> | null | undefined,

--- a/frontend/src/utils/agent-tool-icons.ts
+++ b/frontend/src/utils/agent-tool-icons.ts
@@ -6,6 +6,9 @@ export function getAgentToolIconName(toolName: string): string {
   if (toolName === 'search_knowledge' || toolName === 'knowledge_search') {
     return 'data-search'
   }
+  if (toolName === 'wiki_search') {
+    return 'search'
+  }
   if (toolName === 'grep_chunks') {
     return 'search'
   }
@@ -15,7 +18,7 @@ export function getAgentToolIconName(toolName: string): string {
   if (toolName === 'get_document_info' || toolName === 'list_knowledge_chunks') {
     return 'file-search'
   }
-  if (toolName === 'get_document_content' || toolName === 'wiki_read_source_doc') {
+  if (toolName === 'get_document_content' || toolName === 'wiki_read_page' || toolName === 'wiki_read_source_doc') {
     return 'file-search'
   }
   if (toolName === 'todo_write') {

--- a/frontend/src/views/chat/components/AgentStreamDisplay.style.test.mjs
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.style.test.mjs
@@ -51,6 +51,8 @@ test('final done row uses an existing common translation key', () => {
 test('tool rows use line icon names instead of legacy asset masks', () => {
   assert.match(source, /getAgentToolIconName/)
   assert.match(source, /:name="getToolIconName\(event\.tool_name\)"/)
+  assert.match(source, /wiki_search: 'agentEditor\.tools\.wikiSearch'/)
+  assert.match(source, /wiki_read_page: 'agentEditor\.tools\.wikiReadPage'/)
   assert.match(source, /wiki_read_source_doc: 'agentStream\.tools\.wikiReadSourceDoc'/)
   assert.match(source, /toolName === 'get_document_content' \|\| toolName === 'wiki_read_source_doc'/)
   assert.doesNotMatch(source, /getToolIcon\(event\.tool_name\)/)

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -435,7 +435,7 @@ import i18n from '@/i18n';
 import { hydrateProtectedFileImages, clearProtectedFileFailureCache, sanitizeMarkdownHTML } from '@/utils/security';
 import { unwrapFinalAnswerWrappers, thinkingEqualsAnswer } from '@/utils/finalAnswer';
 import { getAgentToolIconName } from '@/utils/agent-tool-icons';
-import { getQueryText } from '@/utils/agent-tool-display';
+import { getQueryText, getWikiPageText } from '@/utils/agent-tool-display';
 import {
   buildManualMarkdown,
   copyTextToClipboard,
@@ -481,6 +481,8 @@ const TOOL_NAME_KEYS: Record<string, string> = {
   list_knowledge_chunks: 'agentStream.tools.listKnowledgeChunks',
   get_related_documents: 'agentStream.tools.getRelatedDocuments',
   get_document_content: 'agentStream.tools.getDocumentContent',
+  wiki_search: 'agentEditor.tools.wikiSearch',
+  wiki_read_page: 'agentEditor.tools.wikiReadPage',
   wiki_read_source_doc: 'agentStream.tools.wikiReadSourceDoc',
   todo_write: 'agentStream.tools.todoWrite',
   knowledge_graph_extract: 'agentStream.tools.knowledgeGraphExtract',
@@ -1935,12 +1937,15 @@ const getToolTitle = (event: any): string => {
     if (event.tool_name === 'image_analysis') {
       return t('agentStream.toolStatus.imageAnalyzing');
     }
+    if (event.tool_name === 'wiki_search' || event.tool_name === 'wiki_read_page') {
+      return `${getLocalizedToolName(event.tool_name)}...`;
+    }
     const localizedName = getLocalizedToolName(event.tool_name);
     return t('agentStream.toolStatus.calling', { name: localizedName });
   }
 
   const toolName = event.tool_name;
-  const isSearchTool = toolName === 'search_knowledge' || toolName === 'knowledge_search';
+  const isSearchTool = toolName === 'search_knowledge' || toolName === 'knowledge_search' || toolName === 'wiki_search';
   const isWebSearchTool = toolName === 'web_search';
   const isGrepTool = toolName === 'grep_chunks';
 
@@ -2020,6 +2025,16 @@ const getToolTitle = (event: any): string => {
     return baseTitle;
   }
 
+  if (toolName === 'wiki_read_page') {
+    const pageLabel = String(
+      event.tool_data?.title ||
+      getWikiPageText(event.arguments) ||
+      getWikiPageText(event.tool_data)
+    ).trim();
+    const baseTitle = getToolDescription(event);
+    return pageLabel ? `${baseTitle}：「${sanitizeForDisplay(pageLabel)}」` : baseTitle;
+  }
+
   // Use tool summary if available
   const summary = getToolSummary(event);
   return summary || getToolDescription(event);
@@ -2043,6 +2058,9 @@ const getToolDescription = (event: any): string => {
 
   if (toolName === 'search_knowledge' || toolName === 'knowledge_search') {
     return success ? t('agentStream.toolStatus.searchKb') : t('agentStream.toolStatus.searchKbFailed');
+  } else if (toolName === 'wiki_search' || toolName === 'wiki_read_page') {
+    const localizedName = getLocalizedToolName(toolName);
+    return success ? localizedName : t('agentStream.toolStatus.calledFailed', { name: localizedName });
   } else if (toolName === 'web_search') {
     return success ? t('agentStream.toolStatus.webSearch') : t('agentStream.toolStatus.webSearchFailed');
   } else if (toolName === 'grep_chunks') {

--- a/frontend/src/views/dev/MarkdownTestPage.vue
+++ b/frontend/src/views/dev/MarkdownTestPage.vue
@@ -290,6 +290,8 @@ graph TD
 
 // --- Streaming Simulation ---
 const fullStreamText = `
+好的，以下是根据知识库中**《xxx》学程手册**整理的有关XXX的介绍：
+
 **XBRL（eXtensible Business Reporting Language，可扩展商业报告语言）**是一种基于XML的标准化标记语言，专门用于电子化商业和财务报告的编制、交换和分析
 
 该数据集包含90个文本和方程对，挑战模型提取、解释和推理相互关联的财务术语和公式的能力，例如：


### PR DESCRIPTION

- Implement `getWikiPageText` function to handle persisted slugs and JSON input for wiki page text retrieval.
- Update `getAgentToolIconName` to include mappings for `wiki_search` and `wiki_read_page` tools.
- Enhance tests to cover new functionality for wiki tools and ensure proper icon mapping in the agent stream display.
- Modify `AgentStreamDisplay` to utilize new wiki tool features and improve localization for wiki-related actions.
