### PR TITLE
fix(frontend): enhance repairFlankingEmphasis to handle opening delimiters correctly

### DIFF
--- a/frontend/src/utils/chatMarkdownRenderer.test.ts
+++ b/frontend/src/utils/chatMarkdownRenderer.test.ts
@@ -128,6 +128,15 @@ test('repairFlankingEmphasis bolds punctuation-adjacent emphasis CommonMark woul
   assert.equal(repairFlankingEmphasis('~~删除）~~文字'), '<del>删除）</del>文字')
   assert.equal(repairFlankingEmphasis('*斜体）*文字'), '<em>斜体）</em>文字')
 
+  // Opening delimiter sits between a letter/number and punctuation -> CommonMark
+  // refuses to open emphasis even though the closer is valid; we bold it too.
+  assert.equal(
+    repairFlankingEmphasis('知识库中**《xxx》学程手册**整理'),
+    '知识库中<strong>《xxx》学程手册</strong>整理',
+  )
+  assert.equal(repairFlankingEmphasis('在**《书名》**'), '在<strong>《书名》</strong>')
+  assert.equal(repairFlankingEmphasis('看到~~《删》文字~~后面'), '看到<del>《删》文字</del>后面')
+
   // Cases marked already handles, literal markers, and code must be untouched.
   assert.equal(repairFlankingEmphasis('**中文**后面'), '**中文**后面')
   assert.equal(repairFlankingEmphasis('**中文）** 后面'), '**中文）** 后面')
@@ -135,6 +144,10 @@ test('repairFlankingEmphasis bolds punctuation-adjacent emphasis CommonMark woul
   assert.equal(repairFlankingEmphasis('`**a)**b`'), '`**a)**b`')
   assert.equal(repairFlankingEmphasis('2 ** 3 ** 4'), '2 ** 3 ** 4')
   assert.equal(repairFlankingEmphasis('价格 3 * 5 * 7 元'), '价格 3 * 5 * 7 元')
+  // Exponent / glob markers stay literal: the opener is followed by a number or
+  // path content, not an emphasis-opening punctuation run.
+  assert.equal(repairFlankingEmphasis('x**2 + y**2'), 'x**2 + y**2')
+  assert.equal(repairFlankingEmphasis('2**3**4'), '2**3**4')
 })
 
 test('renderChatMarkdown bolds punctuation-adjacent emphasis both mid-stream and when complete', () => {

--- a/frontend/src/utils/chatMarkdownRenderer.ts
+++ b/frontend/src/utils/chatMarkdownRenderer.ts
@@ -181,10 +181,21 @@ const FLANKING_BOLD = /(?<!\*)\*\*(?=\S)([^*\n]*?\p{P})\*\*(?=[\p{L}\p{N}])/gu
 const FLANKING_STRIKE = /(?<!~)~~(?=\S)([^~\n]*?\p{P})~~(?=[\p{L}\p{N}])/gu
 const FLANKING_ITALIC = /(?<![*\p{L}\p{N}])\*(?=\S)([^*\n]*?\p{P})\*(?=[\p{L}\p{N}])/gu
 
+// Opening-delimiter variant of the rule above. CommonMark also refuses to *open*
+// emphasis when the run is preceded by a letter/number and immediately followed
+// by punctuation, so `知识库中**《手册》**整理` stays literal even though the
+// closing `**` is fine. The `(?=\p{P})` guard keeps exponent/glob/math markers
+// like `x**2`, `2**3**4`, and `**/*.js` untouched (those are followed by a
+// number or slash-as-content, not an emphasis-opening punctuation run).
+const FLANKING_BOLD_OPEN = /(?<=[\p{L}\p{N}])\*\*(?=\p{P})([^*\n]+?)\*\*/gu
+const FLANKING_STRIKE_OPEN = /(?<=[\p{L}\p{N}])~~(?=\p{P})([^~\n]+?)~~/gu
+
 function repairFlankingEmphasisSegment(segment: string): string {
   return segment
     .replace(FLANKING_BOLD, '<strong>$1</strong>')
+    .replace(FLANKING_BOLD_OPEN, '<strong>$1</strong>')
     .replace(FLANKING_STRIKE, '<del>$1</del>')
+    .replace(FLANKING_STRIKE_OPEN, '<del>$1</del>')
     .replace(FLANKING_ITALIC, '<em>$1</em>')
 }
 
@@ -194,10 +205,11 @@ function repairFlankingEmphasisSegment(segment: string): string {
  * CommonMark's flanking rule rejects a closing `**`/`*`/`~~` that is preceded by
  * punctuation and immediately followed by a letter/number, so a very common
  * model pattern like `**XBRL（…语言）**是一种` (and even ASCII `**a)**b`) renders
- * as literal asterisks — both mid-stream and when complete. We convert just that
- * blocked pattern (closing delimiter after punctuation, before an alphanumeric)
- * into explicit HTML so it bolds reliably. Code spans/fences are skipped so
- * their literal markers are untouched.
+ * as literal asterisks — both mid-stream and when complete. The mirror case is
+ * an *opening* `**`/`~~` preceded by a letter/number and immediately followed by
+ * punctuation (`知识库中**《手册》**整理`), which CommonMark also refuses to open.
+ * We convert just those blocked patterns into explicit HTML so they bold
+ * reliably. Code spans/fences are skipped so their literal markers are untouched.
  */
 export function repairFlankingEmphasis(text: string): string {
   if (!text || !/[*~]/.test(text)) return text


### PR DESCRIPTION
- Update regex patterns to account for opening delimiters preceded by letters/numbers and followed by punctuation, ensuring proper rendering of emphasis in markdown.
- Add tests to validate new behavior for various edge cases, including punctuation-adjacent emphasis and exponent markers.
- Improve overall markdown rendering consistency in chat components.
