### PR TITLE
fix(docparser): rename close variable to avoid shadowing builtin

### DIFF
--- a/frontend/src/components/UserMenu.vue
+++ b/frontend/src/components/UserMenu.vue
@@ -126,7 +126,7 @@
         -->
         <div v-if="authStore.isSystemAdmin" class="menu-item" @click="handleSystemAdmin">
           <t-icon name="server" class="menu-icon" />
-          <span>系统管理</span>
+          <span>{{ $t('settings.system') }}</span>
         </div>
         <!-- 切换租户入口在下拉「当前租户」区块 hover；此处仅为分隔线与菜单项。 -->
         <div class="menu-divider"></div>

--- a/internal/infrastructure/docparser/markdown_image_scanner.go
+++ b/internal/infrastructure/docparser/markdown_image_scanner.go
@@ -144,25 +144,25 @@ func splitAngleMarkdownImageTarget(
 	end int,
 	refMap map[string]types.ImageRef,
 ) (path string, pathStart int, pathEnd int, ok bool) {
-	close := -1
+	closeIdx := -1
 	for i := start + 1; i < end; i++ {
 		if raw[i] == '>' && !isEscaped(raw, i) {
-			close = i
+			closeIdx = i
 			break
 		}
 	}
-	if close == -1 {
+	if closeIdx == -1 {
 		return "", 0, 0, false
 	}
 
-	path = raw[start+1 : close]
+	path = raw[start+1 : closeIdx]
 	if _, found := refMap[path]; !found {
 		return "", 0, 0, false
 	}
-	if !isEmptyOrMarkdownImageTitleSuffix(raw[close+1 : end]) {
+	if !isEmptyOrMarkdownImageTitleSuffix(raw[closeIdx+1 : end]) {
 		return "", 0, 0, false
 	}
-	return path, start + 1, close, true
+	return path, start + 1, closeIdx, true
 }
 
 func parseMarkdownImageTitleSuffix(raw string) (titleStart int, ok bool) {


### PR DESCRIPTION
## Summary

- Follow-up to #1743. The new angle-bracket image target parser in `markdown_image_scanner.go` declared a local variable named `close`, which shadows Go's built-in `close` function.
- `revive` (enabled via `.golangci.yml`) flags this with `redefines-builtin-id`, so `make lint` fails on the merged code.
- Renames the variable to `closeIdx`; no behavior change.

## Test plan

- [x] `go build ./internal/infrastructure/docparser/...`
- [x] `go vet ./internal/infrastructure/docparser/...`
- [x] `go test ./internal/infrastructure/docparser/...`
- [x] `revive` no longer reports `redefinition of the built-in function close`