### PR TITLE
fix(organization): invalidate fetch cache after creating org

### DIFF
--- a/frontend/src/stores/organization.ts
+++ b/frontend/src/stores/organization.ts
@@ -112,6 +112,9 @@ export const useOrganizationStore = defineStore('organization', () => {
       const response = await createOrganization({ name, description })
       if (response.success && response.data) {
         organizations.value.unshift(response.data)
+        // 创建成功后重置缓存时间戳，确保后续 fetchOrganizations() 不会被 TTL 缓存跳过，
+        // 从而刷新 resource_counts 等创建接口不返回的聚合字段。
+        organizationsLoadedAt = 0
         return response.data
       } else {
         error.value = response.message || 'Failed to create organization'


### PR DESCRIPTION
<!-- Title 遵循 Conventional Commits: fix(organization): invalidate fetch cache after creating org -->

## Description

创建共享空间成功后，列表页面未及时展示新创建的空间，需要手动刷新页面才能看到最新数据。

**根因**：`frontend/src/stores/organization.ts` 中 `fetchOrganizations()` 有 60 秒 TTL 缓存（通过 `organizationsLoadedAt` 控制）。创建成功后 `handleSettingsSaved` 调用 `fetchOrganizations()` 时被缓存拦截直接跳过，`resource_counts` 等 `listMyOrganizations` 才返回的字段得不到更新。

**修复**：在 `orgStore.create()` 成功后将 `organizationsLoadedAt` 重置为 `0`，使缓存失效，确保后续调用能够正常拉取完整数据。

**影响范围**：`frontend/src/stores/organization.ts` — `create()` 方法。

## Type of Change
- [x] 🐛 Bug fix

## Related Issue
Fixes #1760 

## Testing

1. 进入共享空间列表页，观察空间计数
2. 点击创建共享空间，填写名称并提交
3. 创建成功后关闭弹窗
4. 验证列表立即出现新空间，无需手动刷新

https://github.com/user-attachments/assets/8ded0eee-0c9d-4baf-968e-20b722e08aa0



## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above（无破坏性变更）

## Screenshots / Recordings

无 UI 变更，仅修复数据刷新逻辑。
