### PR TITLE
fix(qa): wire agent thinking toggle and show reasoning in RAG timeline

### DIFF
--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -2459,6 +2459,9 @@ watch(() => props.visible, async (val) => {
 
       // 补全可能缺失的字段
       agentData.config = { ...defaultFormData.config, ...agentData.config };
+      if (agentData.config.thinking == null) {
+        agentData.config.thinking = false;
+      }
 
       // 确保数组字段存在
       if (!agentData.config.suggested_prompts) agentData.config.suggested_prompts = [];

--- a/frontend/src/views/chat/components/AgentStreamDisplay.style.test.mjs
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.style.test.mjs
@@ -63,6 +63,14 @@ test('rag mode delegates pre-answer loading to pipeline and keeps dots while ans
   assert.match(source, /v-if="!ragMode \|\| displayEvents\.length > 0 \|\| showAgentActivityIndicator"/)
 })
 
+test('rag mode keeps model thinking out of the answer stream component', () => {
+  assert.match(source, /if \(props\.ragMode\)\s*\{[\s\S]*e\.type === 'answer'/)
+  assert.doesNotMatch(
+    source,
+    /if \(props\.ragMode\)\s*\{[\s\S]*e\.type === 'answer' \|\| e\.type === 'thinking'/,
+  )
+})
+
 test('only the collapsed root summary shows an expand chevron', () => {
   assert.match(source, /tree-root-summary[\s\S]*class="action-show-icon"/)
   assert.match(source, /showIntermediateSteps \? 'chevron-down' : 'chevron-right'/)

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -1337,9 +1337,8 @@ const displayEvents = computed(() => {
 
   const result = buildFullEventList(stream);
 
-  // Quick-answer RAG: only render the final answer stream here. Pipeline steps
-  // are ephemeral UI in RagPipelineProgress and are replaced by citations or
-  // answer output — never show tool_call cards in this component.
+  // Quick-answer RAG: pipeline steps and model thinking live in RagPipelineProgress;
+  // here we only render the final answer stream.
   if (props.ragMode) {
     return result.filter((e: any) => e.type === 'answer');
   }

--- a/frontend/src/views/chat/components/RagPipelineProgress.style.test.mjs
+++ b/frontend/src/views/chat/components/RagPipelineProgress.style.test.mjs
@@ -82,3 +82,9 @@ test('collapsed summary uses the same title-to-answer spacing as agent', () => {
   assert.match(source, /\.tree-container \{\s*margin: 0 0 16px;/)
   assert.match(source, /\.rag-pipeline-progress \{[\s\S]*margin: 0;/)
 })
+
+test('rag pipeline auto-scrolls capped thinking detail while streaming', () => {
+  assert.match(source, /isThinkingStreaming/)
+  assert.match(source, /scrollThinkingDetailToBottom/)
+  assert.match(source, /watch\(thinkingContent[\s\S]*scrollThinkingDetailToBottom/)
+})

--- a/frontend/src/views/chat/components/RagPipelineProgress.style.test.mjs
+++ b/frontend/src/views/chat/components/RagPipelineProgress.style.test.mjs
@@ -21,7 +21,8 @@ test('rag pipeline persists and collapses after the answer arrives', () => {
   assert.match(source, /showCollapsedRoot/)
   assert.match(source, /tree-root-summary/)
   assert.match(source, /collapsedSummaryHtml/)
-  assert.match(source, /visible = computed\(\(\) => steps\.value\.length > 0 \|\| showPrePipelineWait\.value\)/)
+  assert.match(source, /hasThinking\.value/)
+  assert.match(source, /const visible = computed\([\s\S]*showPrePipelineWait\.value/)
 })
 
 test('rag pipeline toggles expand and collapse from the root header', () => {
@@ -42,10 +43,12 @@ test('rag pipeline embeds references in the timeline instead of a separate card'
   assert.match(source, /rag-ref-step[\s\S]*name="file-search"/)
 })
 
-test('rag pipeline keeps loading inside the timeline without duplicate dots', () => {
+test('rag pipeline keeps loading inside the thinking step instead of orphan dots', () => {
   assert.match(source, /showPrePipelineWait/)
-  assert.match(source, /showActivityIndicator = computed\(\s*\(\) => steps\.value\.length > 0 && !hasAnswer\.value/)
-  assert.match(source, /showPrePipelineWait = computed/)
+  assert.match(source, /showThinkingStep/)
+  assert.match(source, /thinking-loading/)
+  assert.match(source, /hasThinkingEvent/)
+  assert.doesNotMatch(source, /showActivityIndicator/)
 })
 
 test('rag pipeline places references before the done row', () => {
@@ -53,6 +56,20 @@ test('rag pipeline places references before the done row', () => {
   const doneIndex = source.indexOf('agent-step-done')
   assert.ok(refsIndex > -1 && doneIndex > -1)
   assert.ok(refsIndex < doneIndex)
+})
+
+test('done row appears only after the full turn completes', () => {
+  assert.match(source, /const showDoneRow = computed\(\(\) => \{[\s\S]*hasAnswer\.value/)
+})
+
+test('rag pipeline renders model thinking inside the timeline before the done row', () => {
+  assert.match(source, /rag-thinking-step/)
+  assert.match(source, /showThinkingStep/)
+  assert.match(source, /name="lightbulb"/)
+  const doneIndex = source.indexOf('agent-step-done')
+  const thinkingIndex = source.indexOf('rag-thinking-step')
+  assert.ok(doneIndex > -1 && thinkingIndex > -1)
+  assert.ok(thinkingIndex < doneIndex)
 })
 
 test('clickable timeline headers use pointer cursor', () => {

--- a/frontend/src/views/chat/components/RagPipelineProgress.vue
+++ b/frontend/src/views/chat/components/RagPipelineProgress.vue
@@ -348,6 +348,14 @@ const thinkingPending = computed(
     !props.session?.is_completed,
 )
 
+const isThinkingStreaming = computed(
+  () =>
+    showThinkingStep.value &&
+    thinkingExpanded.value &&
+    !hasAnswer.value &&
+    !props.session?.is_completed,
+)
+
 const visible = computed(
   () => steps.value.length > 0 || showPrePipelineWait.value || showThinkingStep.value,
 )
@@ -427,6 +435,16 @@ function toggleThinking() {
   thinkingExpanded.value = !thinkingExpanded.value
 }
 
+function scrollThinkingDetailToBottom() {
+  nextTick(() => {
+    if (!rootElement.value) return
+    rootElement.value.querySelectorAll('.thinking-detail-content').forEach((el) => {
+      const htmlEl = el as HTMLElement
+      htmlEl.scrollTop = htmlEl.scrollHeight
+    })
+  })
+}
+
 watch(thinkingPending, (pending) => {
   if (pending) {
     thinkingExpanded.value = true
@@ -440,17 +458,13 @@ watch(hasAnswer, (answered) => {
 })
 
 watch(thinkingContent, () => {
-  if (!thinkingPending.value) return
-  nextTick(() => {
-    if (!rootElement.value) return
-    const els = rootElement.value.querySelectorAll('.thinking-detail-content')
-    els.forEach((el) => {
-      const htmlEl = el as HTMLElement
-      if (htmlEl.scrollHeight > htmlEl.clientHeight) {
-        htmlEl.scrollTop = htmlEl.scrollHeight
-      }
-    })
-  })
+  if (!isThinkingStreaming.value) return
+  scrollThinkingDetailToBottom()
+})
+
+watch(thinkingExpanded, (expanded) => {
+  if (!expanded || !isThinkingStreaming.value) return
+  scrollThinkingDetailToBottom()
 })
 </script>
 

--- a/frontend/src/views/chat/components/RagPipelineProgress.vue
+++ b/frontend/src/views/chat/components/RagPipelineProgress.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="visible" class="rag-pipeline-progress">
+  <div v-if="visible" ref="rootElement" class="rag-pipeline-progress">
     <div v-if="showPrePipelineWait" class="tree-children">
       <div class="tree-child tree-child-last streaming-loading-node">
         <div class="tree-branch" />
@@ -18,9 +18,9 @@
     <div v-else-if="!showCollapsedRoot" class="tree-children">
       <div v-for="(step, index) in steps" :key="step.id" class="tree-child" :class="{
         'tree-child-last':
-          !showActivityIndicator
-          && !showDoneRow
+          !showDoneRow
           && !hasReferences
+          && !showThinkingStep
           && index === steps.length - 1,
       }">
         <div class="tree-branch" />
@@ -42,7 +42,7 @@
       </div>
 
       <div v-if="hasReferences" class="tree-child rag-ref-step"
-        :class="{ 'tree-child-last': !showDoneRow && !showActivityIndicator }">
+        :class="{ 'tree-child-last': !showThinkingStep && !showDoneRow }">
         <div class="tree-branch" />
         <div class="tree-child-content">
           <div class="tool-event">
@@ -60,7 +60,34 @@
         </div>
       </div>
 
-      <div v-if="showDoneRow" class="tree-child agent-step-done" :class="{ 'tree-child-last': !showActivityIndicator }">
+      <div v-if="showThinkingStep" class="tree-child rag-thinking-step"
+        :class="{ 'tree-child-last': !showDoneRow }">
+        <div class="tree-branch" />
+        <div class="tree-child-content">
+          <div class="tool-event">
+            <div class="action-card" :class="{ 'action-pending': thinkingPending }">
+              <div class="action-header" :class="{ 'no-results': !thinkingContent }" @click="toggleThinking">
+                <div class="action-title">
+                  <t-icon class="action-title-icon" name="lightbulb" />
+                  <span class="action-name">{{ t('agent.think') }}</span>
+                </div>
+              </div>
+              <div v-if="thinkingPending && !thinkingContent" class="thinking-loading">
+                <div class="loading-typing">
+                  <span />
+                  <span />
+                  <span />
+                </div>
+              </div>
+              <div v-else-if="thinkingContent && thinkingExpanded" class="thinking-detail-content">
+                {{ thinkingContent }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="showDoneRow" class="tree-child agent-step-done tree-child-last">
         <div class="tree-branch" />
         <div class="tree-child-content">
           <div class="tool-event">
@@ -71,19 +98,6 @@
                   <span class="action-name">{{ t('common.finish') }}</span>
                 </div>
               </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div v-if="showActivityIndicator" class="tree-child tree-child-last streaming-loading-node">
-        <div class="tree-branch" />
-        <div class="tree-child-content">
-          <div class="loading-indicator">
-            <div class="loading-typing">
-              <span />
-              <span />
-              <span />
             </div>
           </div>
         </div>
@@ -106,7 +120,7 @@
 
       <div v-if="showExpandedTimeline" class="tree-children tree-children-expanded">
         <div v-for="(step, index) in steps" :key="step.id" class="tree-child"
-          :class="{ 'tree-child-last': index === steps.length - 1 && !hasReferences && !showDoneRow }">
+          :class="{ 'tree-child-last': index === steps.length - 1 && !hasReferences && !showDoneRow && !showThinkingStep }">
           <div class="tree-branch" />
           <div class="tree-child-content">
             <div class="tool-event">
@@ -125,7 +139,8 @@
           </div>
         </div>
 
-        <div v-if="hasReferences" class="tree-child rag-ref-step" :class="{ 'tree-child-last': !showDoneRow }">
+        <div v-if="hasReferences" class="tree-child rag-ref-step"
+          :class="{ 'tree-child-last': !showThinkingStep && !showDoneRow }">
           <div class="tree-branch" />
           <div class="tree-child-content">
             <div class="tool-event">
@@ -138,6 +153,32 @@
                 </div>
                 <DocInfo v-show="refsExpanded" :session="session" :embedded-mode="embeddedMode" timeline-mode
                   content-only />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div v-if="showThinkingStep" class="tree-child rag-thinking-step" :class="{ 'tree-child-last': !showDoneRow }">
+          <div class="tree-branch" />
+          <div class="tree-child-content">
+            <div class="tool-event">
+              <div class="action-card" :class="{ 'action-pending': thinkingPending }">
+                <div class="action-header" :class="{ 'no-results': !thinkingContent }" @click="toggleThinking">
+                  <div class="action-title">
+                    <t-icon class="action-title-icon" name="lightbulb" />
+                    <span class="action-name">{{ t('agent.think') }}</span>
+                  </div>
+                </div>
+                <div v-if="thinkingPending && !thinkingContent" class="thinking-loading">
+                  <div class="loading-typing">
+                    <span />
+                    <span />
+                    <span />
+                  </div>
+                </div>
+                <div v-else-if="thinkingContent && thinkingExpanded" class="thinking-detail-content">
+                  {{ thinkingContent }}
+                </div>
               </div>
             </div>
           </div>
@@ -164,7 +205,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import DocInfo from './docInfo.vue'
 import { getAgentToolIconName } from '@/utils/agent-tool-icons'
@@ -187,6 +228,25 @@ const props = defineProps<{
 const { t } = useI18n()
 const userExpanded = ref(false)
 const refsExpanded = ref(false)
+const thinkingExpanded = ref(true)
+const rootElement = ref<HTMLElement | null>(null)
+
+const thinkingContent = computed(() => {
+  const stream = props.session?.agentEventStream
+  if (!Array.isArray(stream)) return ''
+  return stream
+    .filter((event) => event.type === 'thinking')
+    .map((event) => String(event.content || ''))
+    .join('')
+})
+
+const hasThinking = computed(() => thinkingContent.value.trim().length > 0)
+
+const hasThinkingEvent = computed(() => {
+  const stream = props.session?.agentEventStream
+  if (!Array.isArray(stream)) return false
+  return stream.some((event) => event.type === 'thinking')
+})
 
 const hasAnswer = computed(() => {
   const sessionContent = props.session?.content
@@ -252,7 +312,9 @@ const allStepsDone = computed(
 )
 
 const showCollapsedRoot = computed(
-  () => (hasAnswer.value || Boolean(props.session?.is_completed)) && steps.value.length > 0,
+  () =>
+    (hasAnswer.value || Boolean(props.session?.is_completed)) &&
+    (steps.value.length > 0 || hasThinking.value),
 )
 
 const showExpandedTimeline = computed(() => {
@@ -260,18 +322,35 @@ const showExpandedTimeline = computed(() => {
   return userExpanded.value
 })
 
-const showDoneRow = computed(() => allStepsDone.value)
+const showDoneRow = computed(() => {
+  const turnDone = hasAnswer.value || Boolean(props.session?.is_completed)
+  if (!turnDone) return false
+  if (steps.value.length > 0 && !allStepsDone.value) return false
+  return true
+})
 
-const showPrePipelineWait = computed(
-  () => !hasAnswer.value && !props.session?.is_completed && steps.value.length === 0,
+const showPrePipelineWait = computed(() => {
+  if (hasAnswer.value || props.session?.is_completed || steps.value.length > 0 || hasThinking.value) {
+    return false
+  }
+  return true
+})
+
+// Only show the thinking row once the backend actually streams thinking events.
+// Do not pre-empt during the model phase — that flashes "思考" even when thinking is disabled.
+const showThinkingStep = computed(() => hasThinkingEvent.value)
+
+const thinkingPending = computed(
+  () =>
+    showThinkingStep.value &&
+    !hasThinking.value &&
+    !hasAnswer.value &&
+    !props.session?.is_completed,
 )
 
-// Trailing dots on the timeline axis while pipeline steps are running or waiting for the answer.
-const showActivityIndicator = computed(
-  () => steps.value.length > 0 && !hasAnswer.value && !props.session?.is_completed,
+const visible = computed(
+  () => steps.value.length > 0 || showPrePipelineWait.value || showThinkingStep.value,
 )
-
-const visible = computed(() => steps.value.length > 0 || showPrePipelineWait.value)
 
 const referenceDocCount = computed(() => {
   const refs = props.session?.knowledge_references ?? []
@@ -303,6 +382,10 @@ const referencesHeaderText = computed(() => {
 })
 
 const collapsedSummaryHtml = computed(() => {
+  if (steps.value.length === 0) {
+    return hasThinking.value ? t('agentStream.toolStatus.thinkingDone') : ''
+  }
+
   const parts: string[] = [t('agentStream.ragPipeline.searchDone')]
   const docCount = referenceDocCount.value
   const webCount = referenceWebCount.value
@@ -338,6 +421,37 @@ function toggleExpanded() {
 function toggleReferences() {
   refsExpanded.value = !refsExpanded.value
 }
+
+function toggleThinking() {
+  if (!showThinkingStep.value || !thinkingContent.value) return
+  thinkingExpanded.value = !thinkingExpanded.value
+}
+
+watch(thinkingPending, (pending) => {
+  if (pending) {
+    thinkingExpanded.value = true
+  }
+})
+
+watch(hasAnswer, (answered) => {
+  if (answered && hasThinking.value) {
+    thinkingExpanded.value = false
+  }
+})
+
+watch(thinkingContent, () => {
+  if (!thinkingPending.value) return
+  nextTick(() => {
+    if (!rootElement.value) return
+    const els = rootElement.value.querySelectorAll('.thinking-detail-content')
+    els.forEach((el) => {
+      const htmlEl = el as HTMLElement
+      if (htmlEl.scrollHeight > htmlEl.clientHeight) {
+        htmlEl.scrollTop = htmlEl.scrollHeight
+      }
+    })
+  })
+})
 </script>
 
 <style scoped lang="less">
@@ -529,6 +643,29 @@ function toggleReferences() {
       color: var(--td-text-color-secondary);
       font-weight: 500;
     }
+  }
+}
+
+.rag-thinking-step {
+  .thinking-loading {
+    padding: 4px 0 0;
+  }
+
+  .thinking-detail-content {
+    margin-top: 4px;
+    padding: 0;
+    font-size: var(--agent-step-summary-size);
+    font-weight: 400;
+    color: var(--td-text-color-placeholder);
+    line-height: 1.55;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 200px;
+    overflow-y: auto;
+  }
+
+  .action-pending .action-name {
+    color: var(--td-text-color-secondary);
   }
 }
 </style>

--- a/internal/application/service/chat_pipeline/common.go
+++ b/internal/application/service/chat_pipeline/common.go
@@ -53,6 +53,11 @@ func prepareChatModel(ctx context.Context, modelService interfaces.ModelService,
 		PresencePenalty:     chatManage.SummaryConfig.PresencePenalty,
 		Thinking:            chatManage.SummaryConfig.Thinking,
 	}
+	if opt.Thinking != nil {
+		pipelineInfo(ctx, "Stream", "thinking_option", map[string]interface{}{
+			"enabled": *opt.Thinking,
+		})
+	}
 
 	return chatModel, opt, nil
 }

--- a/internal/application/service/session_qa_helpers.go
+++ b/internal/application/service/session_qa_helpers.go
@@ -131,10 +131,14 @@ func (s *sessionService) applyAgentOverridesToChatManage(
 		cm.SummaryConfig.MaxCompletionTokens = customAgent.Config.MaxCompletionTokens
 		logger.Infof(ctx, "Using custom agent's max_completion_tokens: %d", customAgent.Config.MaxCompletionTokens)
 	}
-	// Agent-level thinking setting takes full control (no global fallback)
+	// Agent-level thinking setting takes full control (no global fallback).
+	// EnsureDefaults pins nil to explicit false so thinking_control wire formats
+	// always receive a value.
 	cm.SummaryConfig.Thinking = customAgent.Config.Thinking
 	if customAgent.Config.Thinking != nil {
 		logger.Infof(ctx, "Using custom agent's thinking: %v", *customAgent.Config.Thinking)
+	} else {
+		logger.Warnf(ctx, "Custom agent thinking is unset after EnsureDefaults; model thinking param will be omitted")
 	}
 
 	// Override retrieval strategy settings

--- a/internal/types/custom_agent.go
+++ b/internal/types/custom_agent.go
@@ -315,6 +315,12 @@ func (a *CustomAgent) EnsureDefaults() {
 	if a.Config.AgentMode == AgentModeSmartReasoning {
 		a.Config.MultiTurnEnabled = true
 	}
+	// Pin thinking to an explicit false when unset so provider-specific wire
+	// formats (e.g. thinking_control=thinking_type) always receive a value.
+	if a.Config.Thinking == nil {
+		disabled := false
+		a.Config.Thinking = &disabled
+	}
 }
 
 // IsAgentMode returns true if this agent uses ReAct agent mode

--- a/internal/types/custom_agent_test.go
+++ b/internal/types/custom_agent_test.go
@@ -1,0 +1,23 @@
+package types
+
+import "testing"
+
+func TestEnsureDefaults_ThinkingExplicitFalse(t *testing.T) {
+	agent := &CustomAgent{Config: CustomAgentConfig{}}
+	agent.EnsureDefaults()
+	if agent.Config.Thinking == nil {
+		t.Fatal("EnsureDefaults should set Thinking to explicit false when unset")
+	}
+	if *agent.Config.Thinking {
+		t.Fatal("default Thinking should be false")
+	}
+}
+
+func TestEnsureDefaults_ThinkingPreservesTrue(t *testing.T) {
+	enabled := true
+	agent := &CustomAgent{Config: CustomAgentConfig{Thinking: &enabled}}
+	agent.EnsureDefaults()
+	if agent.Config.Thinking == nil || !*agent.Config.Thinking {
+		t.Fatal("EnsureDefaults must not overwrite an explicit Thinking=true")
+	}
+}


### PR DESCRIPTION
## Summary

- Default unset agent `config.thinking` to explicit `false` in `EnsureDefaults`, so models with `thinking_control: thinking_type` always receive `thinking.type=disabled|enabled` on the wire instead of omitting the field entirely.
- Add pipeline logging for the resolved thinking option to simplify debugging agent overrides.
- Show model reasoning inside the quick-answer RAG timeline (`RagPipelineProgress`) when `thinking` SSE events are present, and avoid flashing the "思考" step while waiting for the answer when thinking mode is off.
- Normalize `thinking: null` to `false` in the agent editor when loading existing configs.

## Test plan

- [x] Enable thinking on the built-in quick-answer agent, save, send a message — LLM request should include `"thinking": {"type": "enabled"}` and logs should show `Using custom agent's thinking: true`.
- [x] With thinking disabled (default), send a quick-answer message — no brief "思考" row before the answer; timeline goes from query understand to answer/done.
- [x] With thinking enabled on a model that streams `reasoning_content`, verify the thinking row appears inside the timeline and collapses after the answer starts.
- [x] `go test ./internal/types/ -run TestEnsureDefaults_Thinking`
- [x] `node --test frontend/src/views/chat/components/RagPipelineProgress.style.test.mjs`