### PR TITLE
feat(im): align agent stream display with web thinking and tool progress

### DIFF
--- a/docs/IM集成开发文档.md
+++ b/docs/IM集成开发文档.md
@@ -773,8 +773,9 @@ type ReplyMessage struct {
 │ · EventBus 订阅    │
 │ · 300ms 批量刷新   │
 │ · 工具事件展示     │
-│ · SendStreamChunk  │
-│ · EndStream        │
+│ · UpdateStreamContent │
+│ · FinalizeStream      │
+│ · EndStream           │
 └────────────────────┘
             │
             ▼
@@ -833,10 +834,14 @@ type Adapter interface {
 ```go
 type StreamSender interface {
     StartStream(ctx context.Context, incoming *IncomingMessage) (streamID string, err error)
-    SendStreamChunk(ctx context.Context, incoming *IncomingMessage, streamID string, content string) error
+    UpdateStreamContent(ctx context.Context, incoming *IncomingMessage, streamID string, fullContent string) error
+    FinalizeStream(ctx context.Context, incoming *IncomingMessage, streamID string, finalContent string) error
     EndStream(ctx context.Context, incoming *IncomingMessage, streamID string) error
 }
 ```
+
+- `UpdateStreamContent`：流式过程中用**当前可见全文**替换消息（replace 语义，非增量追加）
+- `FinalizeStream`：结束前最后一次替换，通常为折叠思考/工具进度后的最终展示（多为纯答案）
 
 实现此接口后，Service 会自动路由到流式模式。渠道配置 `output_mode: "full"` 可强制关闭。
 
@@ -949,14 +954,17 @@ StartStream:
   1. POST /cardkit/v1/cards              → 创建卡片实体 (streaming_mode: true)
   2. POST /im/v1/messages                → 发送卡片消息到聊天
 
-SendStreamChunk:
+UpdateStreamContent:
   3. PUT /cardkit/v1/cards/{id}/elements/{eid}/content  → 更新元素内容 (累积全文)
 
+FinalizeStream:
+  4. PUT /cardkit/v1/cards/{id}/elements/{eid}/content  → 最终可见内容（通常为纯答案）
+
 EndStream:
-  4. PATCH /cardkit/v1/cards/{id}/settings  → 设置 streaming_mode: false
+  5. PATCH /cardkit/v1/cards/{id}/settings  → 设置 streaming_mode: false
 ```
 
-每次 `SendStreamChunk` 发送的是**累积全文**而非增量，由 `feishuStreamState` 跟踪完整内容和严格递增的 `sequence` 序号。
+每次 `UpdateStreamContent` / `FinalizeStream` 发送的是**累积全文**而非增量，由 `feishuStreamState` 跟踪完整内容和严格递增的 `sequence` 序号。
 
 **Think 块处理：** 流式输出中的 `<think>...</think>` 块会被转换为飞书 Markdown 引用块格式：
 
@@ -1017,14 +1025,17 @@ Slack 的流式输出基于消息更新 (chat.update) 实现：
 StartStream:
   1. POST /chat.postMessage              → 发送初始消息，获取 ts (timestamp)
 
-SendStreamChunk:
+UpdateStreamContent:
   2. POST /chat.update                   → 根据 ts 更新消息内容 (累积全文)
 
+FinalizeStream:
+  3. POST /chat.update                   → 最终可见内容替换
+
 EndStream:
-  3. 无需特殊操作
+  4. 无需特殊操作
 ```
 
-每次 `SendStreamChunk` 发送的是**累积全文**而非增量。
+每次 `UpdateStreamContent` / `FinalizeStream` 发送的是**累积全文**而非增量。
 
 #### 源码文件
 
@@ -1079,14 +1090,17 @@ Telegram 的流式输出基于消息编辑 (editMessageText) 实现：
 StartStream:
   1. POST sendMessage               → 发送初始 "正在思考..." 消息，获取 message_id
 
-SendStreamChunk:
-  2. POST editMessageText            → 根据 message_id 更新消息内容（累积全文）
+UpdateStreamContent:
+  2. POST editMessageText            → 根据 message_id 更新消息内容（累积全文，纯文本）
+
+FinalizeStream:
+  3. POST editMessageText            → 最终可见内容替换（与流式阶段相同，纯文本）
 
 EndStream:
-  3. POST editMessageText            → 最终更新，启用 Markdown 解析
+  4. 清理流状态
 ```
 
-每次 `SendStreamChunk` 发送的是**累积全文**而非增量，最小编辑间隔 500ms（避免触发 Telegram 速率限制）。
+每次 `UpdateStreamContent` / `FinalizeStream` 发送的是**累积全文**而非增量，最小编辑间隔 500ms（避免触发 Telegram 速率限制）。中间态与终态均使用纯文本，避免 Markdown 解析失败。
 
 **Think 块处理：** 流式输出中的 `<think>...</think>` 块会被转换为 Telegram 引用块格式：
 
@@ -1156,14 +1170,17 @@ LongConnClient ══Stream══▶ 钉钉 Stream 服务
 StartStream:
   1. POST /v1.0/card/instances/createAndDeliver  → 创建并投递 AI 卡片
 
-SendStreamChunk:
+UpdateStreamContent:
   2. PUT /v1.0/card/streaming                     → 流式更新卡片内容（累积全文）
 
+FinalizeStream:
+  3. PUT /v1.0/card/streaming                     → 最终可见内容替换
+
 EndStream:
-  3. PUT /v1.0/card/streaming (isFinalize=true)   → 标记流式结束
+  4. PUT /v1.0/card/streaming (isFinalize=true)   → 标记流式结束
 ```
 
-每次 `SendStreamChunk` 发送的是**累积全文**（`isFull: true`），最小更新间隔 500ms。
+每次 `UpdateStreamContent` / `FinalizeStream` 发送的是**累积全文**（`isFull: true`），最小更新间隔 500ms。
 
 **无卡片模板时的降级策略：** 未配置 `card_template_id` 时，流式内容在内存中累积，`EndStream` 时一次性通过 `sessionWebhook` 或 OpenAPI 发送完整回复。
 
@@ -1216,11 +1233,14 @@ Mattermost 服务器 ──HTTP POST──▶ /api/v1/im/callback/{channel_id}
 StartStream:
   1. POST /api/v4/posts                    → 创建占位帖（如「正在思考...」），得到 post id
 
-SendStreamChunk:
+UpdateStreamContent:
   2. PUT /api/v4/posts/{post_id}/patch     → Patch message 字段（累积全文）
 
+FinalizeStream:
+  3. PUT /api/v4/posts/{post_id}/patch     → 最终可见内容替换
+
 EndStream:
-  3. 最后一次 Patch，与 SendStreamChunk 相同逻辑
+  4. 清理流状态
 ```
 
 流式刷新间隔由 Service 侧 `streamFlushInterval`（300ms）批量合并，以降低编辑频率、减轻 API 压力。

--- a/internal/im/adapter.go
+++ b/internal/im/adapter.go
@@ -146,8 +146,12 @@ type StreamSender interface {
 	// Returns a platform-specific stream ID for subsequent chunk/end calls.
 	StartStream(ctx context.Context, incoming *IncomingMessage) (string, error)
 
-	// SendStreamChunk appends a content chunk to an ongoing stream.
-	SendStreamChunk(ctx context.Context, incoming *IncomingMessage, streamID string, content string) error
+	// UpdateStreamContent replaces the user-visible stream text with fullContent so far.
+	// Platforms with replace semantics (WeCom, Telegram edit, etc.) show this as the entire message.
+	UpdateStreamContent(ctx context.Context, incoming *IncomingMessage, streamID string, fullContent string) error
+
+	// FinalizeStream performs the final replace with answer-only content (thinking/tools stripped).
+	FinalizeStream(ctx context.Context, incoming *IncomingMessage, streamID string, finalContent string) error
 
 	// EndStream finalizes a streaming reply.
 	EndStream(ctx context.Context, incoming *IncomingMessage, streamID string) error

--- a/internal/im/dingtalk/adapter.go
+++ b/internal/im/dingtalk/adapter.go
@@ -189,7 +189,7 @@ func parseCallbackMessage(msg *callbackMessage) *im.IncomingMessage {
 // ── Send reply ──
 
 func (a *Adapter) SendReply(ctx context.Context, incoming *im.IncomingMessage, reply *im.ReplyMessage) error {
-	content := transformThinkBlocks(reply.Content)
+	content := im.FormatIMDisplayContent(reply.Content, im.StreamDisplayFinal)
 
 	sessionWebhook := ""
 	if incoming.Extra != nil {
@@ -520,8 +520,8 @@ func (a *Adapter) StartStream(ctx context.Context, incoming *im.IncomingMessage)
 	return streamID, nil
 }
 
-func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMessage, streamID string, content string) error {
-	if content == "" {
+func (a *Adapter) UpdateStreamContent(ctx context.Context, incoming *im.IncomingMessage, streamID string, fullContent string) error {
+	if fullContent == "" {
 		return nil
 	}
 
@@ -533,21 +533,19 @@ func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMess
 	}
 
 	state.mu.Lock()
-	state.content.WriteString(content)
+	state.content.Reset()
+	state.content.WriteString(fullContent)
 
-	// No card template → just accumulate, send at EndStream
 	if state.outTrackID == "" {
 		state.mu.Unlock()
 		return nil
 	}
 
-	// Throttle card updates
 	if time.Since(state.lastUpdate) < minCardUpdateInterval {
 		state.mu.Unlock()
 		return nil
 	}
 
-	fullContent := transformThinkBlocks(state.content.String())
 	state.lastUpdate = time.Now()
 	outTrackID := state.outTrackID
 	state.mu.Unlock()
@@ -555,8 +553,33 @@ func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMess
 	if err := a.streamingUpdateCard(ctx, outTrackID, fullContent, false); err != nil {
 		logger.Warnf(ctx, "[DingTalk] Failed to update card stream: %v", err)
 	}
-
 	return nil
+}
+
+func (a *Adapter) FinalizeStream(ctx context.Context, incoming *im.IncomingMessage, streamID string, finalContent string) error {
+	streamsMu.Lock()
+	state, ok := dStreams[streamID]
+	streamsMu.Unlock()
+	if !ok {
+		return fmt.Errorf("unknown stream ID: %s", streamID)
+	}
+
+	state.mu.Lock()
+	state.content.Reset()
+	state.content.WriteString(finalContent)
+	outTrackID := state.outTrackID
+	state.mu.Unlock()
+
+	if outTrackID != "" {
+		if err := a.streamingUpdateCard(ctx, outTrackID, finalContent, false); err != nil {
+			logger.Warnf(ctx, "[DingTalk] Failed to finalize card stream: %v", err)
+		}
+	}
+	return nil
+}
+
+func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMessage, streamID string, content string) error {
+	return a.UpdateStreamContent(ctx, incoming, streamID, content)
 }
 
 func (a *Adapter) EndStream(ctx context.Context, incoming *im.IncomingMessage, streamID string) error {
@@ -570,17 +593,17 @@ func (a *Adapter) EndStream(ctx context.Context, incoming *im.IncomingMessage, s
 	}
 
 	state.mu.Lock()
-	fullContent := transformThinkBlocks(state.content.String())
+	fullContent := state.content.String()
 	outTrackID := state.outTrackID
+	sessionWebhook := state.sessionWebhook
 	state.mu.Unlock()
 
 	if outTrackID != "" {
-		// Finalize AI card
 		if err := a.streamingUpdateCard(ctx, outTrackID, fullContent, true); err != nil {
 			logger.Warnf(ctx, "[DingTalk] Failed to finalize card stream: %v", err)
 		}
-	} else if state.sessionWebhook != "" {
-		if err := a.replyViaSessionWebhook(ctx, state.sessionWebhook, fullContent); err != nil {
+	} else if sessionWebhook != "" {
+		if err := a.replyViaSessionWebhook(ctx, sessionWebhook, fullContent); err != nil {
 			logger.Warnf(ctx, "[DingTalk] Failed to end stream: %v", err)
 		}
 	} else {
@@ -591,8 +614,4 @@ func (a *Adapter) EndStream(ctx context.Context, incoming *im.IncomingMessage, s
 
 	logger.Infof(ctx, "[DingTalk] Streaming ended: stream_id=%s", streamID)
 	return nil
-}
-
-func transformThinkBlocks(content string) string {
-	return im.TransformThinkBlocks(content, im.MarkdownThinkStyle)
 }

--- a/internal/im/feishu/adapter.go
+++ b/internal/im/feishu/adapter.go
@@ -661,11 +661,9 @@ func (a *Adapter) StartStream(ctx context.Context, incoming *im.IncomingMessage)
 	return cardID, nil
 }
 
-// SendStreamChunk accumulates content and pushes it to the card element.
-// Content containing <think>...</think> blocks is transformed into
-// Feishu-compatible markdown blockquotes before sending.
-func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMessage, streamID string, content string) error {
-	if content == "" {
+// UpdateStreamContent replaces the card element with the full visible content so far.
+func (a *Adapter) UpdateStreamContent(ctx context.Context, incoming *im.IncomingMessage, streamID string, fullContent string) error {
+	if fullContent == "" {
 		return nil
 	}
 
@@ -678,12 +676,10 @@ func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMess
 
 	state.mu.Lock()
 	if !state.firstChunk {
-		// Clear the "💭 正在思考..." placeholder on first real content
-		state.content.Reset()
 		state.firstChunk = true
 	}
-	state.content.WriteString(content)
-	fullContent := transformThinkBlocks(state.content.String())
+	state.content.Reset()
+	state.content.WriteString(fullContent)
 	seq := state.nextSeq()
 	state.mu.Unlock()
 
@@ -695,8 +691,14 @@ func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMess
 	return a.cardkitUpdateElement(ctx, accessToken, streamID, streamingElementID, fullContent, seq)
 }
 
-func transformThinkBlocks(content string) string {
-	return im.TransformThinkBlocks(content, im.MarkdownThinkStyle)
+// FinalizeStream replaces the card with answer-only content.
+func (a *Adapter) FinalizeStream(ctx context.Context, incoming *im.IncomingMessage, streamID string, finalContent string) error {
+	return a.UpdateStreamContent(ctx, incoming, streamID, finalContent)
+}
+
+// SendStreamChunk is an alias for UpdateStreamContent.
+func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMessage, streamID string, content string) error {
+	return a.UpdateStreamContent(ctx, incoming, streamID, content)
 }
 
 // EndStream disables streaming_mode and cleans up state.

--- a/internal/im/mattermost/adapter.go
+++ b/internal/im/mattermost/adapter.go
@@ -276,8 +276,8 @@ func (a *Adapter) StartStream(ctx context.Context, incoming *im.IncomingMessage)
 	return streamID, nil
 }
 
-func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMessage, streamID string, content string) error {
-	if content == "" {
+func (a *Adapter) UpdateStreamContent(ctx context.Context, incoming *im.IncomingMessage, streamID string, fullContent string) error {
+	if fullContent == "" {
 		return nil
 	}
 
@@ -289,15 +289,23 @@ func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMess
 	}
 
 	state.mu.Lock()
-	state.content.WriteString(content)
-	full := state.content.String()
+	state.content.Reset()
+	state.content.WriteString(fullContent)
 	postID := state.postID
 	state.mu.Unlock()
 
-	if err := a.client.PatchPostMessage(ctx, postID, full); err != nil {
+	if err := a.client.PatchPostMessage(ctx, postID, fullContent); err != nil {
 		logger.Warnf(ctx, "[Mattermost] Patch post failed: %v", err)
 	}
 	return nil
+}
+
+func (a *Adapter) FinalizeStream(ctx context.Context, incoming *im.IncomingMessage, streamID string, finalContent string) error {
+	return a.UpdateStreamContent(ctx, incoming, streamID, finalContent)
+}
+
+func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMessage, streamID string, content string) error {
+	return a.UpdateStreamContent(ctx, incoming, streamID, content)
 }
 
 func (a *Adapter) EndStream(ctx context.Context, incoming *im.IncomingMessage, streamID string) error {

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	agenttools "github.com/Tencent/WeKnora/internal/agent/tools"
 	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
 	"github.com/Tencent/WeKnora/internal/config"
 	apperrors "github.com/Tencent/WeKnora/internal/errors"
@@ -191,6 +192,10 @@ func holdbackCutoff(chunk string) int {
 	return cutoff
 }
 
+// formatIMOutboundAnswer strips thinking/tool blocks and applies IM content cleanup.
+func formatIMOutboundAnswer(ctx context.Context, raw string, tenant *types.Tenant, defaultFileSvc interfaces.FileService) string {
+	return cleanIMContent(ctx, FormatIMDisplayContent(raw, StreamDisplayFinal), tenant, defaultFileSvc)
+}
 // cleanIMContent applies all IM-specific content transformations:
 //  1. Collapse <image> XML blocks back to plain markdown
 //  2. Strip <kb/> and <web/> citation tags
@@ -489,6 +494,94 @@ func buildIMQARequest(
 		UserMessageID:      userMessageID,
 		WebSearchEnabled:   webSearchEnabled,
 		QuotedContext:      quotedContext,
+	}
+}
+
+func buildIMLastRequestState(agentID string, customAgent *types.CustomAgent, kbIDs []string) *types.SessionLastRequestState {
+	state := &types.SessionLastRequestState{
+		AgentID:          agentID,
+		KnowledgeBaseIDs: append([]string(nil), kbIDs...),
+	}
+	if customAgent == nil {
+		return state
+	}
+	if state.AgentID == "" {
+		state.AgentID = customAgent.ID
+	}
+	state.AgentEnabled = customAgent.IsAgentMode()
+	state.ModelID = customAgent.Config.ModelID
+	state.WebSearchEnabled = customAgent.Config.WebSearchEnabled
+	if len(state.KnowledgeBaseIDs) == 0 && len(customAgent.Config.KnowledgeBases) > 0 {
+		state.KnowledgeBaseIDs = append([]string(nil), customAgent.Config.KnowledgeBases...)
+	}
+	return state
+}
+
+func createIMUserMessagePayload(sessionID, content, requestID string) *types.Message {
+	return &types.Message{
+		SessionID:   sessionID,
+		Role:        "user",
+		Content:     content,
+		RequestID:   requestID,
+		CreatedAt:   time.Now(),
+		IsCompleted: true,
+		Channel:     "im",
+	}
+}
+
+func createIMAssistantMessagePayload(sessionID, requestID string) *types.Message {
+	return &types.Message{
+		SessionID:   sessionID,
+		Role:        "assistant",
+		RequestID:   requestID,
+		CreatedAt:   time.Now(),
+		IsCompleted: false,
+		Channel:     "im",
+	}
+}
+
+func collectIMKnowledgeReferences(dst *[]*types.SearchResult, refs interface{}) {
+	switch v := refs.(type) {
+	case []*types.SearchResult:
+		*dst = append(*dst, v...)
+	case []interface{}:
+		for _, ref := range v {
+			if sr, ok := ref.(*types.SearchResult); ok {
+				*dst = append(*dst, sr)
+			}
+		}
+	}
+}
+
+func sanitizeIMAgentSteps(raw interface{}) types.AgentSteps {
+	switch steps := raw.(type) {
+	case []types.AgentStep:
+		return types.AgentSteps(agenttools.SanitizeAgentStepsForStorage(steps))
+	case types.AgentSteps:
+		return types.AgentSteps(agenttools.SanitizeAgentStepsForStorage([]types.AgentStep(steps)))
+	default:
+		return nil
+	}
+}
+
+func applyIMCompleteDataToMessage(msg *types.Message, data event.AgentCompleteData) {
+	if msg == nil {
+		return
+	}
+	if data.MessageID != "" && data.MessageID != msg.ID {
+		return
+	}
+	msg.IsCompleted = true
+	msg.AgentDurationMs = data.TotalDurationMs
+	if len(data.KnowledgeRefs) > 0 {
+		refs := make([]*types.SearchResult, 0, len(data.KnowledgeRefs))
+		collectIMKnowledgeReferences(&refs, data.KnowledgeRefs)
+		if len(refs) > 0 {
+			msg.KnowledgeReferences = types.References(refs)
+		}
+	}
+	if steps := sanitizeIMAgentSteps(data.AgentSteps); len(steps) > 0 {
+		msg.AgentSteps = steps
 	}
 }
 
@@ -1189,8 +1282,14 @@ func (s *Service) HandleMessage(ctx context.Context, msg *IncomingMessage, chann
 		// Copy the session: the async title goroutine writes Title while the QA
 		// worker below shares the same *session.
 		sessionForTitle := *session
-		s.sessionService.GenerateTitleAsync(sessionCtx, &sessionForTitle, msg.Content, "", nil)
+		titleModelID := ""
+		if customAgent != nil && customAgent.Config.ModelID != "" {
+			titleModelID = customAgent.Config.ModelID
+		}
+		s.sessionService.GenerateTitleAsync(sessionCtx, &sessionForTitle, msg.Content, titleModelID, nil)
 	}
+
+	s.persistIMLastRequestState(sessionCtx, session.ID, agentID, customAgent, nil)
 
 	// 5. Enqueue the QA request into the bounded worker pool.
 	// The worker pool controls LLM concurrency and provides backpressure.
@@ -1240,6 +1339,13 @@ func (s *Service) HandleMessage(ctx context.Context, msg *IncomingMessage, chann
 	return nil
 }
 
+func (s *Service) persistIMLastRequestState(ctx context.Context, sessionID, agentID string, customAgent *types.CustomAgent, kbIDs []string) {
+	state := buildIMLastRequestState(agentID, customAgent, kbIDs)
+	if err := s.sessionService.UpdateSessionLastRequestState(logger.CloneContext(context.WithoutCancel(ctx)), sessionID, state); err != nil {
+		logger.Warnf(ctx, "[IM] persist last_request_state failed for session %s: %v", sessionID, err)
+	}
+}
+
 // executeQARequest is the worker handler that runs the QA pipeline for a queued request.
 // It is called by qaQueue workers and must not block indefinitely.
 func (s *Service) executeQARequest(req *qaRequest) {
@@ -1285,7 +1391,7 @@ func (s *Service) executeQARequest(req *qaRequest) {
 	}
 
 	reply := &ReplyMessage{
-		Content: cleanIMContent(ctx, answer, req.tenant, s.defaultFileSvc),
+		Content: formatIMOutboundAnswer(ctx, answer, req.tenant, s.defaultFileSvc),
 		IsFinal: true,
 	}
 	if err := req.adapter.SendReply(ctx, req.msg, reply); err != nil {
@@ -1413,16 +1519,17 @@ func (s *Service) handleCommand(
 	return nil
 }
 
-// sendStreamReply sends a complete content string via the streaming interface
-// (StartStream → SendStreamChunk → EndStream). This is used for command replies
-// when the output mode is set to "stream", so they visually match QA responses.
+// sendStreamReply sends a complete content string via the streaming interface.
 func (s *Service) sendStreamReply(ctx context.Context, msg *IncomingMessage, streamer StreamSender, content string) error {
 	streamID, err := streamer.StartStream(ctx, msg)
 	if err != nil {
 		return fmt.Errorf("start stream: %w", err)
 	}
-	if err := streamer.SendStreamChunk(ctx, msg, streamID, content); err != nil {
-		return fmt.Errorf("send stream chunk: %w", err)
+	if err := streamer.UpdateStreamContent(ctx, msg, streamID, content); err != nil {
+		return fmt.Errorf("update stream content: %w", err)
+	}
+	if err := streamer.FinalizeStream(ctx, msg, streamID, content); err != nil {
+		return fmt.Errorf("finalize stream: %w", err)
 	}
 	if err := streamer.EndStream(ctx, msg, streamID); err != nil {
 		return fmt.Errorf("end stream: %w", err)
@@ -1653,24 +1760,6 @@ func (s *Service) resolveThreadSession(ctx context.Context, msg *IncomingMessage
 // agent's reasoning process in real-time.
 // ─────────────────────────────────────────────────────────────────────
 
-// toolDisplayNames maps internal tool function names to user-friendly labels.
-var toolDisplayNames = map[string]string{
-	"thinking":              "深度思考",
-	"todo_write":            "制定计划",
-	"knowledge_search":      "知识库检索",
-	"grep_chunks":           "关键词搜索",
-	"list_knowledge_chunks": "查看文档分块",
-	"query_knowledge_graph": "查询知识图谱",
-	"get_document_info":     "获取文档信息",
-	"database_query":        "查询数据库",
-	"data_analysis":         "数据分析",
-	"data_schema":           "查看数据元信息",
-	"web_search":            "网络搜索",
-	"web_fetch":             "网页阅读",
-	"read_skill":            "读取技能",
-	"execute_skill_script":  "执行技能脚本",
-}
-
 // internalToolNames lists tools whose execution should NOT be displayed in IM
 // messages because they are internal reasoning aids (thinking, planning) rather
 // than user-facing actions.
@@ -1679,36 +1768,11 @@ var internalToolNames = map[string]bool{
 	"todo_write": true,
 }
 
-// friendlyToolName returns a human-readable name for a tool.
-func friendlyToolName(toolName string) string {
-	if display, ok := toolDisplayNames[toolName]; ok {
-		return display
-	}
-	return toolName
-}
-
 // isToolVisibleToUser returns true if the tool's execution progress should be
 // displayed to the IM user. Internal reasoning tools (thinking, planning) are
 // hidden.
 func isToolVisibleToUser(toolName string) bool {
 	return !internalToolNames[toolName]
-}
-
-// formatToolCallStart returns a plain-text line for a tool invocation (inside <think> block).
-func formatToolCallStart(toolName string) string {
-	return fmt.Sprintf("⏳ %s\n", friendlyToolName(toolName))
-}
-
-// formatToolCallResult returns a plain-text line for a tool result (inside <think> block).
-func formatToolCallResult(toolName string, success bool, output string) string {
-	friendly := friendlyToolName(toolName)
-	if success {
-		if summary := briefToolSummary(output); summary != "" {
-			return fmt.Sprintf("✅ %s · %s\n", friendly, summary)
-		}
-		return fmt.Sprintf("✅ %s\n", friendly)
-	}
-	return fmt.Sprintf("⚠️ %s 失败\n", friendly)
 }
 
 // briefToolSummary extracts a short human-readable summary from tool output.
@@ -1757,62 +1821,87 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 	qaCtx, qaCancel := context.WithCancel(ctx)
 	defer qaCancel()
 
+	useAgent := customAgent != nil && customAgent.IsAgentMode()
 	eventBus := event.NewEventBus()
 
 	var (
 		bufMu          sync.Mutex
-		buf            strings.Builder // buffered content awaiting flush
-		answerBuilder  strings.Builder // full answer for DB persistence (includes <think>)
+		pipelineInner  strings.Builder // quick QA: RAG pipeline steps
+		reasoningInner strings.Builder // quick QA: model reasoning_content
+		agentInner     strings.Builder // agent: retracted text + thoughts + tools
+		agentLiveAnswer strings.Builder // agent: optimistic answer before tool retract
+		answerOuter    strings.Builder // final answer for display persistence
+		answerBuilder  strings.Builder // answer persisted to DB
 		qaErr          error
 		done           = make(chan struct{})
+		completeDone   = make(chan struct{})
 		closeOnce      sync.Once
-		thinkBlockOpen bool // whether we've opened a <think> block (agent pipeline)
-		answerStarted  bool // whether the final answer stream has begun
+		completeOnce   sync.Once
+		agentDone      bool
+		assistantMsg   *types.Message
 
-		// seenToolCalls deduplicates EventAgentToolCall events.
-		// The engine emits tool calls twice: once during streaming (pending)
-		// and once at execution time. We only show the first occurrence.
 		seenToolCalls = make(map[string]bool)
+		agentToolIdx  = make(map[string]int)
+		pipelineIdx   = make(map[string]int)
 
-		// lastCharNewline tracks whether the most recently written character
-		// (across flush boundaries) was '\n'. This lets ensureNewlineBefore
-		// work correctly even after buf has been Reset by a flush.
-		lastCharNewline = true
-		streamedAny     bool // whether any user-visible content was written to buf
+		agentToolSteps    []IMToolStep
+		pipelineToolSteps []IMToolStep
+
+		sectionLastNewline = true
+		streamedAny        bool
 	)
 	closeDone := func() { closeOnce.Do(func() { close(done) }) }
+	closeComplete := func() { completeOnce.Do(func() { close(completeDone) }) }
 
-	// bufWrite appends s to buf and updates lastCharNewline. Must hold bufMu.
-	bufWrite := func(s string) {
+	sectionWrite := func(b *strings.Builder, s string) {
 		if s == "" {
 			return
 		}
-		buf.WriteString(s)
-		lastCharNewline = s[len(s)-1] == '\n'
+		b.WriteString(s)
+		sectionLastNewline = s[len(s)-1] == '\n'
+		streamedAny = true
 	}
 
-	// ensureNewlineBefore guarantees a '\n' exists before the next write,
-	// even if the previous content was already flushed. Must hold bufMu.
-	ensureNewlineBefore := func() {
-		if !lastCharNewline {
-			buf.WriteByte('\n')
-			lastCharNewline = true
+	sectionEnsureNewlineBefore := func(b *strings.Builder) {
+		if !sectionLastNewline {
+			b.WriteByte('\n')
+			sectionLastNewline = true
 		}
 	}
 
-	// ensureThinkOpen opens a <think> block if not already open.
-	// Used for agent pipeline to wrap thinking + tool calls. Must hold bufMu.
-	ensureThinkOpen := func() {
-		if !thinkBlockOpen {
-			thinkBlockOpen = true
-			bufWrite("<think>\n")
+	agentWrite := func(s string) { sectionWrite(&agentInner, s) }
+	reasoningWrite := func(s string) { sectionWrite(&reasoningInner, s) }
+
+	// retractAgentLiveAnswer moves the optimistic answer into the think block (Web: superseded preamble).
+	retractAgentLiveAnswer := func() {
+		if agentLiveAnswer.Len() == 0 {
+			return
+		}
+		if agentInner.Len() > 0 {
+			sectionEnsureNewlineBefore(&agentInner)
+		}
+		sectionWrite(&agentInner, agentLiveAnswer.String())
+		agentLiveAnswer.Reset()
+	}
+
+	getStreamParts := func() IMStreamParts {
+		mode := IMStreamModeQuickQA
+		if useAgent {
+			mode = IMStreamModeAgent
+		}
+		return IMStreamParts{
+			Mode:              mode,
+			PipelineInner:     pipelineInner.String(),
+			PipelineToolSteps: pipelineToolSteps,
+			ReasoningInner:    reasoningInner.String(),
+			AgentInner:        agentInner.String(),
+			AgentToolSteps:    agentToolSteps,
+			LiveAnswer:        agentLiveAnswer.String(),
+			Answer:            answerOuter.String(),
 		}
 	}
 
 	// Subscribe to answer chunks.
-	// Non-agent pipeline: content may contain <think>...</think> from the model — pass through as-is.
-	// Agent pipeline: we've already opened a <think> block via EventAgentThought/ToolCall,
-	// so we close it before streaming the answer.
 	eventBus.On(event.EventAgentFinalAnswer, func(_ context.Context, evt event.Event) error {
 		data, ok := evt.Data.(event.AgentFinalAnswerData)
 		if !ok {
@@ -1820,15 +1909,13 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 		}
 
 		bufMu.Lock()
-		answerBuilder.WriteString(data.Content)
-
-		if thinkBlockOpen && !answerStarted {
-			answerStarted = true
-			bufWrite("\n</think>\n\n")
+		if useAgent && !agentDone {
+			sectionWrite(&agentLiveAnswer, data.Content)
+		} else {
+			answerOuter.WriteString(data.Content)
+			answerBuilder.WriteString(data.Content)
+			streamedAny = true
 		}
-
-		bufWrite(data.Content)
-		streamedAny = true
 		bufMu.Unlock()
 
 		if data.Done {
@@ -1850,6 +1937,46 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 		return nil
 	})
 
+	eventBus.On(event.EventAgentReferences, func(_ context.Context, evt event.Event) error {
+		data, ok := evt.Data.(event.AgentReferencesData)
+		if !ok {
+			return nil
+		}
+		bufMu.Lock()
+		if assistantMsg != nil {
+			refs := []*types.SearchResult(assistantMsg.KnowledgeReferences)
+			collectIMKnowledgeReferences(&refs, data.References)
+			assistantMsg.KnowledgeReferences = types.References(refs)
+		}
+		bufMu.Unlock()
+		return nil
+	})
+
+	eventBus.On(event.EventAgentComplete, func(_ context.Context, evt event.Event) error {
+		data, ok := evt.Data.(event.AgentCompleteData)
+		if !ok {
+			return nil
+		}
+		bufMu.Lock()
+		agentDone = true
+		applyIMCompleteDataToMessage(assistantMsg, data)
+		if data.FinalAnswer != "" {
+			answerBuilder.Reset()
+			answerBuilder.WriteString(data.FinalAnswer)
+			answerOuter.Reset()
+			answerOuter.WriteString(data.FinalAnswer)
+			agentLiveAnswer.Reset()
+		} else if answerBuilder.Len() == 0 && agentLiveAnswer.Len() > 0 {
+			answerBuilder.WriteString(agentLiveAnswer.String())
+			answerOuter.WriteString(agentLiveAnswer.String())
+		} else if answerBuilder.Len() == 0 && answerOuter.Len() > 0 {
+			answerBuilder.WriteString(answerOuter.String())
+		}
+		bufMu.Unlock()
+		closeComplete()
+		return nil
+	})
+
 	// Subscribe to agent thought events — stream thinking content into <think> block
 	eventBus.On(event.EventAgentThought, func(_ context.Context, evt event.Event) error {
 		data, ok := evt.Data.(event.AgentThoughtData)
@@ -1857,15 +1984,16 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 			return nil
 		}
 		bufMu.Lock()
-		ensureThinkOpen()
-		bufWrite(data.Content)
+		if useAgent {
+			agentWrite(data.Content)
+		} else {
+			reasoningWrite(data.Content)
+		}
 		bufMu.Unlock()
 		return nil
 	})
 
-	// Subscribe to agent tool call events — write status line into <think> block.
-	// The engine may emit this event twice per tool call (once during streaming,
-	// once at execution), so we deduplicate by ToolCallID.
+	// Subscribe to agent tool call events — write status line into the think block.
 	eventBus.On(event.EventAgentToolCall, func(_ context.Context, evt event.Event) error {
 		data, ok := evt.Data.(event.AgentToolCallData)
 		if !ok {
@@ -1880,15 +2008,28 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 			return nil
 		}
 		seenToolCalls[data.ToolCallID] = true
-		ensureThinkOpen()
-		ensureNewlineBefore()
-		bufWrite(formatToolCallStart(data.ToolName))
+		if !useAgent && IsRAGPipelineToolName(data.ToolName) {
+			upsertIMToolStep(&pipelineToolSteps, pipelineIdx, data.ToolCallID, func(step *IMToolStep) {
+				step.ToolName = data.ToolName
+				step.Pending = true
+				step.Arguments = data.Arguments
+			})
+			streamedAny = true
+		} else if useAgent {
+			retractAgentLiveAnswer()
+			upsertIMToolStep(&agentToolSteps, agentToolIdx, data.ToolCallID, func(step *IMToolStep) {
+				step.ToolName = data.ToolName
+				step.Pending = true
+				step.Arguments = data.Arguments
+			})
+			streamedAny = true
+		}
 		bufMu.Unlock()
 		logger.Debugf(ctx, "[IM] Tool call streamed to IM: tool=%s id=%s", data.ToolName, data.ToolCallID)
 		return nil
 	})
 
-	// Subscribe to agent tool result events — write result line into <think> block
+	// Subscribe to agent tool result events
 	eventBus.On(event.EventAgentToolResult, func(_ context.Context, evt event.Event) error {
 		data, ok := evt.Data.(event.AgentToolResultData)
 		if !ok {
@@ -1898,34 +2039,42 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 			return nil
 		}
 		bufMu.Lock()
-		ensureNewlineBefore()
-		bufWrite(formatToolCallResult(data.ToolName, data.Success, data.Output))
+		if !useAgent && IsRAGPipelineToolName(data.ToolName) {
+			upsertIMToolStep(&pipelineToolSteps, pipelineIdx, data.ToolCallID, func(step *IMToolStep) {
+				step.ToolName = data.ToolName
+				step.Pending = false
+				step.Success = data.Success
+				step.Data = data.Data
+				step.Output = data.Output
+			})
+			streamedAny = true
+		} else if useAgent {
+			upsertIMToolStep(&agentToolSteps, agentToolIdx, data.ToolCallID, func(step *IMToolStep) {
+				step.ToolName = data.ToolName
+				step.Pending = false
+				step.Success = data.Success
+				step.Data = data.Data
+				step.Output = data.Output
+			})
+			streamedAny = true
+		}
 		bufMu.Unlock()
 		logger.Debugf(ctx, "[IM] Tool result streamed to IM: tool=%s success=%v duration=%dms",
 			data.ToolName, data.Success, data.Duration)
 		return nil
 	})
 
-	// Determine whether to use agent mode
-	useAgent := customAgent != nil && customAgent.IsAgentMode()
+	// Determine whether to use agent mode (already set above for event handlers).
 	requestID := uuid.New().String()
 
 	// Create user message
-	userMsg, err := s.messageService.CreateMessage(qaCtx, &types.Message{
-		SessionID: session.ID, Role: "user", Content: msg.Content,
-		RequestID: requestID, CreatedAt: time.Now(), IsCompleted: true,
-		Channel: "im",
-	})
+	userMsg, err := s.messageService.CreateMessage(qaCtx, createIMUserMessagePayload(session.ID, msg.Content, requestID))
 	if err != nil {
 		return fmt.Errorf("create user message: %w", err)
 	}
 
 	// Create placeholder assistant message
-	assistantMsg, err := s.messageService.CreateMessage(qaCtx, &types.Message{
-		SessionID: session.ID, Role: "assistant",
-		RequestID: requestID, CreatedAt: time.Now(), IsCompleted: false,
-		Channel: "im",
-	})
+	assistantMsg, err = s.messageService.CreateMessage(qaCtx, createIMAssistantMessagePayload(session.ID, requestID))
 	if err != nil {
 		return fmt.Errorf("create assistant message: %w", err)
 	}
@@ -1971,31 +2120,26 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 	ticker := time.NewTicker(streamFlushInterval)
 	defer ticker.Stop()
 
-	var holdback string // text held back from the previous flush
-
-	flush := func(final bool) {
+	flush := func(final bool, phase StreamDisplayPhase) {
 		bufMu.Lock()
-		chunk := holdback + buf.String()
-		buf.Reset()
+		parts := getStreamParts()
+		agentRunning := useAgent && !agentDone
 		bufMu.Unlock()
-		holdback = ""
 
-		if chunk == "" {
+		displaySource := FormatIMIntermediateFromParts(parts, agentRunning)
+		if displaySource == "" {
 			return
 		}
 
-		// On non-final flushes, check for incomplete patterns at the tail.
 		if !final {
-			if cut := holdbackCutoff(chunk); cut < len(chunk) {
-				holdback = chunk[cut:]
-				chunk = chunk[:cut]
+			if cut := holdbackCutoff(displaySource); cut < len(displaySource) {
+				displaySource = displaySource[:cut]
 			}
 		}
 
-		if chunk != "" {
-			if err := streamer.SendStreamChunk(ctx, msg, streamID, cleanIMContent(ctx, chunk, tenant, s.defaultFileSvc)); err != nil {
-				logger.Warnf(ctx, "[IM] SendStreamChunk failed: %v", err)
-			}
+		display := cleanIMContent(ctx, displaySource, tenant, s.defaultFileSvc)
+		if err := streamer.UpdateStreamContent(ctx, msg, streamID, display); err != nil {
+			logger.Warnf(ctx, "[IM] UpdateStreamContent failed: %v", err)
 		}
 	}
 
@@ -2003,7 +2147,7 @@ loop:
 	for {
 		select {
 		case <-ticker.C:
-			flush(false)
+			flush(false, StreamDisplayIntermediate)
 		case <-done:
 			break loop
 		case <-qaCtx.Done():
@@ -2011,29 +2155,38 @@ loop:
 		}
 	}
 
-	// Final flush of any remaining content (including holdback).
-	flush(true)
+	if useAgent {
+		select {
+		case <-completeDone:
+		case <-time.After(500 * time.Millisecond):
+			logger.Warnf(ctx, "[IM] Timed out waiting for agent complete event: session=%s", session.ID)
+		}
+	}
 
-	// If no user-visible content was streamed (e.g., the entire response was
-	// in <think> blocks, or the QA pipeline errored), send a fallback message
-	// as the last chunk so the Feishu card doesn't end up empty.
 	bufMu.Lock()
+	parts := getStreamParts()
+	if parts.Answer == "" {
+		parts.Answer = answerBuilder.String()
+	}
 	answer := answerBuilder.String()
 	finalErr := qaErr
 	noVisibleContent := !streamedAny
 	bufMu.Unlock()
 
-	if noVisibleContent {
+	finalDisplay := cleanIMContent(ctx, FormatIMFinalFromParts(parts), tenant, s.defaultFileSvc)
+	if noVisibleContent || finalDisplay == "" {
 		fallback := "抱歉，我暂时无法回答这个问题。"
 		if finalErr != nil {
 			fallback = "抱歉，处理您的问题时出现了异常，请稍后再试。"
 		}
-		if err := streamer.SendStreamChunk(ctx, msg, streamID, fallback); err != nil {
-			logger.Warnf(ctx, "[IM] SendStreamChunk fallback failed: %v", err)
-		}
+		finalDisplay = fallback
 		if answer == "" {
 			answer = fallback
 		}
+	}
+
+	if err := streamer.FinalizeStream(ctx, msg, streamID, finalDisplay); err != nil {
+		logger.Warnf(ctx, "[IM] FinalizeStream failed: %v", err)
 	}
 
 	// End the stream
@@ -2063,7 +2216,7 @@ func (s *Service) fallbackNonStream(ctx context.Context, msg *IncomingMessage, s
 		answer = "抱歉，处理您的问题时出现了异常，请稍后再试。"
 	}
 
-	return adapter.SendReply(ctx, msg, &ReplyMessage{Content: cleanIMContent(ctx, answer, tenant, s.defaultFileSvc), IsFinal: true})
+	return adapter.SendReply(ctx, msg, &ReplyMessage{Content: formatIMOutboundAnswer(ctx, answer, tenant, s.defaultFileSvc), IsFinal: true})
 }
 
 // runQA executes the WeKnora QA pipeline and returns the full answer text.
@@ -2080,8 +2233,11 @@ func (s *Service) runQA(ctx context.Context, session *types.Session, query strin
 	var answerBuilder strings.Builder
 	var qaErr error
 	done := make(chan struct{})
+	completeDone := make(chan struct{})
 	var closeOnce sync.Once
+	var completeOnce sync.Once
 	closeDone := func() { closeOnce.Do(func() { close(done) }) }
+	closeComplete := func() { completeOnce.Do(func() { close(completeDone) }) }
 
 	eventBus.On(event.EventAgentFinalAnswer, func(ctx context.Context, evt event.Event) error {
 		data, ok := evt.Data.(event.AgentFinalAnswerData)
@@ -2117,31 +2273,44 @@ func (s *Service) runQA(ctx context.Context, session *types.Session, query strin
 	requestID := uuid.New().String()
 
 	// Create user message so it appears in conversation history
-	userMsg, err := s.messageService.CreateMessage(ctx, &types.Message{
-		SessionID:   session.ID,
-		Role:        "user",
-		Content:     query,
-		RequestID:   requestID,
-		CreatedAt:   time.Now(),
-		IsCompleted: true,
-		Channel:     "im",
-	})
+	userMsg, err := s.messageService.CreateMessage(ctx, createIMUserMessagePayload(session.ID, query, requestID))
 	if err != nil {
 		return "", fmt.Errorf("create user message: %w", err)
 	}
 
 	// Create a placeholder assistant message
-	assistantMsg, err := s.messageService.CreateMessage(ctx, &types.Message{
-		SessionID:   session.ID,
-		Role:        "assistant",
-		RequestID:   requestID,
-		CreatedAt:   time.Now(),
-		IsCompleted: false,
-		Channel:     "im",
-	})
+	assistantMsg, err := s.messageService.CreateMessage(ctx, createIMAssistantMessagePayload(session.ID, requestID))
 	if err != nil {
 		return "", fmt.Errorf("create assistant message: %w", err)
 	}
+
+	eventBus.On(event.EventAgentReferences, func(ctx context.Context, evt event.Event) error {
+		data, ok := evt.Data.(event.AgentReferencesData)
+		if !ok {
+			return nil
+		}
+		answerMu.Lock()
+		refs := []*types.SearchResult(assistantMsg.KnowledgeReferences)
+		collectIMKnowledgeReferences(&refs, data.References)
+		assistantMsg.KnowledgeReferences = types.References(refs)
+		answerMu.Unlock()
+		return nil
+	})
+
+	eventBus.On(event.EventAgentComplete, func(ctx context.Context, evt event.Event) error {
+		data, ok := evt.Data.(event.AgentCompleteData)
+		if !ok {
+			return nil
+		}
+		answerMu.Lock()
+		applyIMCompleteDataToMessage(assistantMsg, data)
+		if answerBuilder.Len() == 0 && data.FinalAnswer != "" {
+			answerBuilder.WriteString(data.FinalAnswer)
+		}
+		answerMu.Unlock()
+		closeComplete()
+		return nil
+	})
 
 	// Register inflight mapping for cross-instance /stop via StreamManager.
 	if raw, ok := s.inflight.Load(userKey); ok {
@@ -2179,6 +2348,13 @@ func (s *Service) runQA(ctx context.Context, session *types.Session, query strin
 	// Wait for completion or cancellation (e.g., /stop)
 	select {
 	case <-done:
+		if useAgent {
+			select {
+			case <-completeDone:
+			case <-time.After(500 * time.Millisecond):
+				logger.Warnf(ctx, "[IM] Timed out waiting for agent complete event: session=%s", session.ID)
+			}
+		}
 	case <-ctx.Done():
 		// Mark assistant message as completed to avoid dangling incomplete records
 		assistantMsg.Content = "抱歉，回答已被取消。"
@@ -2595,9 +2771,10 @@ func (s *Service) streamSmartReply(ctx context.Context, chatModel chat.Chat, str
 
 	// Flush loop with batching (same pattern as handleMessageStream)
 	var (
-		bufMu sync.Mutex
-		buf   strings.Builder
-		done  = make(chan struct{})
+		bufMu     sync.Mutex
+		buf       strings.Builder
+		streamRaw strings.Builder
+		done      = make(chan struct{})
 	)
 
 	go func() {
@@ -2606,6 +2783,7 @@ func (s *Service) streamSmartReply(ctx context.Context, chatModel chat.Chat, str
 			if resp.Content != "" {
 				bufMu.Lock()
 				buf.WriteString(resp.Content)
+				streamRaw.WriteString(resp.Content)
 				bufMu.Unlock()
 			}
 		}
@@ -2614,16 +2792,17 @@ func (s *Service) streamSmartReply(ctx context.Context, chatModel chat.Chat, str
 	ticker := time.NewTicker(streamFlushInterval)
 	defer ticker.Stop()
 
-	flush := func() {
+	pushStream := func(phase StreamDisplayPhase) {
 		bufMu.Lock()
-		chunk := buf.String()
 		buf.Reset()
+		raw := streamRaw.String()
 		bufMu.Unlock()
-
-		if chunk != "" {
-			if err := streamer.SendStreamChunk(ctx, msg, streamID, chunk); err != nil {
-				logger.Warnf(ctx, "[IM] SendStreamChunk failed for smart reply: %v", err)
-			}
+		if raw == "" {
+			return
+		}
+		display := FormatIMDisplayContent(raw, phase)
+		if err := streamer.UpdateStreamContent(ctx, msg, streamID, display); err != nil {
+			logger.Warnf(ctx, "[IM] UpdateStreamContent failed for smart reply: %v", err)
 		}
 	}
 
@@ -2631,7 +2810,7 @@ loop:
 	for {
 		select {
 		case <-ticker.C:
-			flush()
+			pushStream(StreamDisplayIntermediate)
 		case <-done:
 			break loop
 		case <-timeoutCtx.Done():
@@ -2639,8 +2818,16 @@ loop:
 		}
 	}
 
-	// Final flush
-	flush()
+	bufMu.Lock()
+	finalRaw := streamRaw.String()
+	bufMu.Unlock()
+	finalDisplay := FormatIMDisplayContent(finalRaw, StreamDisplayFinal)
+	if finalDisplay == "" {
+		finalDisplay = finalRaw
+	}
+	if err := streamer.FinalizeStream(ctx, msg, streamID, finalDisplay); err != nil {
+		logger.Warnf(ctx, "[IM] FinalizeStream failed for smart reply: %v", err)
+	}
 
 	// End the stream
 	if err := streamer.EndStream(ctx, msg, streamID); err != nil {

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -1931,6 +1931,7 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 		qaErr = fmt.Errorf("QA pipeline error: %s", data.Error)
 		bufMu.Unlock()
 		closeDone()
+		closeComplete()
 		return nil
 	})
 
@@ -2102,6 +2103,7 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 			qaErr = fmt.Errorf("QA execution error: %w", err)
 			bufMu.Unlock()
 			closeDone()
+			closeComplete()
 		}
 	}()
 
@@ -2252,6 +2254,7 @@ func (s *Service) runQA(ctx context.Context, session *types.Session, query strin
 		qaErr = fmt.Errorf("QA pipeline error: %s", data.Error)
 		answerMu.Unlock()
 		closeDone()
+		closeComplete()
 		return nil
 	})
 
@@ -2328,6 +2331,7 @@ func (s *Service) runQA(ctx context.Context, session *types.Session, query strin
 			qaErr = fmt.Errorf("QA execution error: %w", err)
 			answerMu.Unlock()
 			closeDone()
+			closeComplete()
 		}
 	}()
 

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -41,6 +41,9 @@ const (
 	// streamFlushInterval is how often buffered stream content is flushed to the IM platform.
 	// This prevents API rate-limiting while keeping perceived latency low.
 	streamFlushInterval = 300 * time.Millisecond
+	// agentCompleteWaitTimeout bounds how long IM waits for EventAgentComplete after
+	// the final answer stream finishes, preventing indefinite hangs.
+	agentCompleteWaitTimeout = 10 * time.Second
 )
 
 // imCitationTagRe matches inline citation tags produced by the agent pipeline.
@@ -583,6 +586,50 @@ func applyIMCompleteDataToMessage(msg *types.Message, data event.AgentCompleteDa
 	}
 	if steps := sanitizeIMAgentSteps(data.AgentSteps); len(steps) > 0 {
 		msg.AgentSteps = steps
+	}
+}
+
+// waitForIMAgentComplete blocks until EventAgentComplete, ctx cancellation, or timeout.
+func waitForIMAgentComplete(ctx context.Context, completeDone <-chan struct{}, sessionID string) {
+	timer := time.NewTimer(agentCompleteWaitTimeout)
+	defer timer.Stop()
+	select {
+	case <-completeDone:
+	case <-ctx.Done():
+		logger.Warnf(ctx, "[IM] QA context ended before agent complete event: session=%s", sessionID)
+	case <-timer.C:
+		logger.Warnf(ctx, "[IM] Timed out waiting for agent complete event: session=%s", sessionID)
+	}
+}
+
+// pickIMStoredAnswer returns the best available answer text from IM stream buffers.
+func pickIMStoredAnswer(candidates ...string) string {
+	for _, s := range candidates {
+		if strings.TrimSpace(s) != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// mergeIMAgentAnswerBuffers copies optimistic/live answers into persistence buffers
+// when EventAgentFinalAnswer did not populate answerBuilder (e.g. cancel before complete).
+func mergeIMAgentAnswerBuffers(answerBuilder, answerOuter, agentLiveAnswer *strings.Builder, completeFinal string) {
+	if answerBuilder.Len() > 0 {
+		return
+	}
+	switch {
+	case agentLiveAnswer.Len() > 0:
+		live := agentLiveAnswer.String()
+		answerBuilder.WriteString(live)
+		if answerOuter.Len() == 0 {
+			answerOuter.WriteString(live)
+		}
+	case answerOuter.Len() > 0:
+		answerBuilder.WriteString(answerOuter.String())
+	case strings.TrimSpace(completeFinal) != "":
+		answerBuilder.WriteString(completeFinal)
+		answerOuter.WriteString(completeFinal)
 	}
 }
 
@@ -1847,7 +1894,8 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 		agentToolSteps    []IMToolStep
 		pipelineToolSteps []IMToolStep
 
-		streamedAny bool
+		agentCompleteFinalAnswer string
+		streamedAny              bool
 	)
 	closeDone := func() { closeOnce.Do(func() { close(done) }) }
 	closeComplete := func() { completeOnce.Do(func() { close(completeDone) }) }
@@ -1957,13 +2005,9 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 		}
 		bufMu.Lock()
 		agentDone = true
+		agentCompleteFinalAnswer = data.FinalAnswer
 		applyIMCompleteDataToMessage(assistantMsg, data)
-		if answerBuilder.Len() == 0 && agentLiveAnswer.Len() > 0 {
-			answerBuilder.WriteString(agentLiveAnswer.String())
-			answerOuter.WriteString(agentLiveAnswer.String())
-		} else if answerBuilder.Len() == 0 && answerOuter.Len() > 0 {
-			answerBuilder.WriteString(answerOuter.String())
-		}
+		mergeIMAgentAnswerBuffers(&answerBuilder, &answerOuter, &agentLiveAnswer, data.FinalAnswer)
 		bufMu.Unlock()
 		closeComplete()
 		return nil
@@ -2147,21 +2191,23 @@ loop:
 	}
 
 	if useAgent {
-		select {
-		case <-completeDone:
-		case <-qaCtx.Done():
-			logger.Warnf(ctx, "[IM] QA context ended before agent complete event: session=%s", session.ID)
-		}
+		waitForIMAgentComplete(qaCtx, completeDone, session.ID)
 	}
 
 	bufMu.Lock()
 	parts := getStreamParts()
+	resolvedAnswer := pickIMStoredAnswer(
+		answerBuilder.String(),
+		answerOuter.String(),
+		agentLiveAnswer.String(),
+		agentCompleteFinalAnswer,
+	)
 	if parts.Answer == "" {
-		parts.Answer = answerBuilder.String()
+		parts.Answer = resolvedAnswer
 	}
-	answer := answerBuilder.String()
+	answer := resolvedAnswer
 	finalErr := qaErr
-	noVisibleContent := !streamedAny
+	noVisibleContent := !streamedAny && strings.TrimSpace(resolvedAnswer) == ""
 	bufMu.Unlock()
 
 	finalDisplay := cleanIMContent(ctx, FormatIMFinalFromParts(parts), tenant, s.defaultFileSvc)
@@ -2296,6 +2342,9 @@ func (s *Service) runQA(ctx context.Context, session *types.Session, query strin
 		}
 		answerMu.Lock()
 		applyIMCompleteDataToMessage(assistantMsg, data)
+		if answerBuilder.Len() == 0 && strings.TrimSpace(data.FinalAnswer) != "" {
+			answerBuilder.WriteString(data.FinalAnswer)
+		}
 		answerMu.Unlock()
 		closeComplete()
 		return nil
@@ -2339,11 +2388,7 @@ func (s *Service) runQA(ctx context.Context, session *types.Session, query strin
 	select {
 	case <-done:
 		if useAgent {
-			select {
-			case <-completeDone:
-			case <-ctx.Done():
-				logger.Warnf(ctx, "[IM] QA context ended before agent complete event: session=%s", session.ID)
-			}
+			waitForIMAgentComplete(ctx, completeDone, session.ID)
 		}
 	case <-ctx.Done():
 		// Mark assistant message as completed to avoid dangling incomplete records

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -196,6 +196,7 @@ func holdbackCutoff(chunk string) int {
 func formatIMOutboundAnswer(ctx context.Context, raw string, tenant *types.Tenant, defaultFileSvc interfaces.FileService) string {
 	return cleanIMContent(ctx, FormatIMDisplayContent(raw, StreamDisplayFinal), tenant, defaultFileSvc)
 }
+
 // cleanIMContent applies all IM-specific content transformations:
 //  1. Collapse <image> XML blocks back to plain markdown
 //  2. Strip <kb/> and <web/> citation tags
@@ -1825,20 +1826,19 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 	eventBus := event.NewEventBus()
 
 	var (
-		bufMu          sync.Mutex
-		pipelineInner  strings.Builder // quick QA: RAG pipeline steps
-		reasoningInner strings.Builder // quick QA: model reasoning_content
-		agentInner     strings.Builder // agent: retracted text + thoughts + tools
+		bufMu           sync.Mutex
+		reasoningInner  streamSection   // quick QA: model reasoning_content
+		agentInner      streamSection   // agent: retracted text + thoughts
 		agentLiveAnswer strings.Builder // agent: optimistic answer before tool retract
-		answerOuter    strings.Builder // final answer for display persistence
-		answerBuilder  strings.Builder // answer persisted to DB
-		qaErr          error
-		done           = make(chan struct{})
-		completeDone   = make(chan struct{})
-		closeOnce      sync.Once
-		completeOnce   sync.Once
-		agentDone      bool
-		assistantMsg   *types.Message
+		answerOuter     strings.Builder // final answer for display persistence
+		answerBuilder   strings.Builder // answer persisted to DB
+		qaErr           error
+		done            = make(chan struct{})
+		completeDone    = make(chan struct{})
+		closeOnce       sync.Once
+		completeOnce    sync.Once
+		agentDone       bool
+		assistantMsg    *types.Message
 
 		seenToolCalls = make(map[string]bool)
 		agentToolIdx  = make(map[string]int)
@@ -1847,40 +1847,35 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 		agentToolSteps    []IMToolStep
 		pipelineToolSteps []IMToolStep
 
-		sectionLastNewline = true
-		streamedAny        bool
+		streamedAny bool
 	)
 	closeDone := func() { closeOnce.Do(func() { close(done) }) }
 	closeComplete := func() { completeOnce.Do(func() { close(completeDone) }) }
 
-	sectionWrite := func(b *strings.Builder, s string) {
+	agentWrite := func(s string) {
 		if s == "" {
 			return
 		}
-		b.WriteString(s)
-		sectionLastNewline = s[len(s)-1] == '\n'
+		agentInner.write(s)
 		streamedAny = true
 	}
-
-	sectionEnsureNewlineBefore := func(b *strings.Builder) {
-		if !sectionLastNewline {
-			b.WriteByte('\n')
-			sectionLastNewline = true
+	reasoningWrite := func(s string) {
+		if s == "" {
+			return
 		}
+		reasoningInner.write(s)
+		streamedAny = true
 	}
-
-	agentWrite := func(s string) { sectionWrite(&agentInner, s) }
-	reasoningWrite := func(s string) { sectionWrite(&reasoningInner, s) }
 
 	// retractAgentLiveAnswer moves the optimistic answer into the think block (Web: superseded preamble).
 	retractAgentLiveAnswer := func() {
 		if agentLiveAnswer.Len() == 0 {
 			return
 		}
-		if agentInner.Len() > 0 {
-			sectionEnsureNewlineBefore(&agentInner)
+		if agentInner.text.Len() > 0 {
+			agentInner.ensureNewlineBefore()
 		}
-		sectionWrite(&agentInner, agentLiveAnswer.String())
+		agentInner.write(agentLiveAnswer.String())
 		agentLiveAnswer.Reset()
 	}
 
@@ -1891,10 +1886,9 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 		}
 		return IMStreamParts{
 			Mode:              mode,
-			PipelineInner:     pipelineInner.String(),
 			PipelineToolSteps: pipelineToolSteps,
-			ReasoningInner:    reasoningInner.String(),
-			AgentInner:        agentInner.String(),
+			ReasoningInner:    reasoningInner.text.String(),
+			AgentInner:        agentInner.text.String(),
 			AgentToolSteps:    agentToolSteps,
 			LiveAnswer:        agentLiveAnswer.String(),
 			Answer:            answerOuter.String(),
@@ -1910,7 +1904,10 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 
 		bufMu.Lock()
 		if useAgent && !agentDone {
-			sectionWrite(&agentLiveAnswer, data.Content)
+			if data.Content != "" {
+				agentLiveAnswer.WriteString(data.Content)
+				streamedAny = true
+			}
 		} else {
 			answerOuter.WriteString(data.Content)
 			answerBuilder.WriteString(data.Content)
@@ -1960,13 +1957,7 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 		bufMu.Lock()
 		agentDone = true
 		applyIMCompleteDataToMessage(assistantMsg, data)
-		if data.FinalAnswer != "" {
-			answerBuilder.Reset()
-			answerBuilder.WriteString(data.FinalAnswer)
-			answerOuter.Reset()
-			answerOuter.WriteString(data.FinalAnswer)
-			agentLiveAnswer.Reset()
-		} else if answerBuilder.Len() == 0 && agentLiveAnswer.Len() > 0 {
+		if answerBuilder.Len() == 0 && agentLiveAnswer.Len() > 0 {
 			answerBuilder.WriteString(agentLiveAnswer.String())
 			answerOuter.WriteString(agentLiveAnswer.String())
 		} else if answerBuilder.Len() == 0 && answerOuter.Len() > 0 {
@@ -2120,7 +2111,7 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 	ticker := time.NewTicker(streamFlushInterval)
 	defer ticker.Stop()
 
-	flush := func(final bool, phase StreamDisplayPhase) {
+	flush := func() {
 		bufMu.Lock()
 		parts := getStreamParts()
 		agentRunning := useAgent && !agentDone
@@ -2131,10 +2122,8 @@ func (s *Service) handleMessageStream(ctx context.Context, msg *IncomingMessage,
 			return
 		}
 
-		if !final {
-			if cut := holdbackCutoff(displaySource); cut < len(displaySource) {
-				displaySource = displaySource[:cut]
-			}
+		if cut := holdbackCutoff(displaySource); cut < len(displaySource) {
+			displaySource = displaySource[:cut]
 		}
 
 		display := cleanIMContent(ctx, displaySource, tenant, s.defaultFileSvc)
@@ -2147,7 +2136,7 @@ loop:
 	for {
 		select {
 		case <-ticker.C:
-			flush(false, StreamDisplayIntermediate)
+			flush()
 		case <-done:
 			break loop
 		case <-qaCtx.Done():
@@ -2158,8 +2147,8 @@ loop:
 	if useAgent {
 		select {
 		case <-completeDone:
-		case <-time.After(500 * time.Millisecond):
-			logger.Warnf(ctx, "[IM] Timed out waiting for agent complete event: session=%s", session.ID)
+		case <-qaCtx.Done():
+			logger.Warnf(ctx, "[IM] QA context ended before agent complete event: session=%s", session.ID)
 		}
 	}
 
@@ -2304,9 +2293,6 @@ func (s *Service) runQA(ctx context.Context, session *types.Session, query strin
 		}
 		answerMu.Lock()
 		applyIMCompleteDataToMessage(assistantMsg, data)
-		if answerBuilder.Len() == 0 && data.FinalAnswer != "" {
-			answerBuilder.WriteString(data.FinalAnswer)
-		}
 		answerMu.Unlock()
 		closeComplete()
 		return nil
@@ -2351,8 +2337,8 @@ func (s *Service) runQA(ctx context.Context, session *types.Session, query strin
 		if useAgent {
 			select {
 			case <-completeDone:
-			case <-time.After(500 * time.Millisecond):
-				logger.Warnf(ctx, "[IM] Timed out waiting for agent complete event: session=%s", session.ID)
+			case <-ctx.Done():
+				logger.Warnf(ctx, "[IM] QA context ended before agent complete event: session=%s", session.ID)
 			}
 		}
 	case <-ctx.Done():
@@ -2772,7 +2758,6 @@ func (s *Service) streamSmartReply(ctx context.Context, chatModel chat.Chat, str
 	// Flush loop with batching (same pattern as handleMessageStream)
 	var (
 		bufMu     sync.Mutex
-		buf       strings.Builder
 		streamRaw strings.Builder
 		done      = make(chan struct{})
 	)
@@ -2782,7 +2767,6 @@ func (s *Service) streamSmartReply(ctx context.Context, chatModel chat.Chat, str
 		for resp := range streamCh {
 			if resp.Content != "" {
 				bufMu.Lock()
-				buf.WriteString(resp.Content)
 				streamRaw.WriteString(resp.Content)
 				bufMu.Unlock()
 			}
@@ -2794,7 +2778,6 @@ func (s *Service) streamSmartReply(ctx context.Context, chatModel chat.Chat, str
 
 	pushStream := func(phase StreamDisplayPhase) {
 		bufMu.Lock()
-		buf.Reset()
 		raw := streamRaw.String()
 		bufMu.Unlock()
 		if raw == "" {

--- a/internal/im/session_test.go
+++ b/internal/im/session_test.go
@@ -1,6 +1,12 @@
 package im
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/event"
+	"github.com/Tencent/WeKnora/internal/types"
+)
 
 func TestMakeUserKey_UserMode(t *testing.T) {
 	tests := []struct {
@@ -141,5 +147,114 @@ func TestIncomingMessageThreadID(t *testing.T) {
 
 	if msgMM.ThreadID != msgMM.Extra["thread_root_id"] {
 		t.Error("Mattermost ThreadID should match Extra thread_root_id")
+	}
+}
+
+func TestBuildIMLastRequestStateFromAgent(t *testing.T) {
+	agent := &types.CustomAgent{
+		ID: "agent-1",
+		Config: types.CustomAgentConfig{
+			AgentMode:        types.AgentModeSmartReasoning,
+			ModelID:          "model-1",
+			KnowledgeBases:   []string{"kb-agent"},
+			WebSearchEnabled: true,
+		},
+	}
+
+	state := buildIMLastRequestState(agent.ID, agent, nil)
+
+	if state.AgentID != "agent-1" {
+		t.Fatalf("AgentID = %q, want agent-1", state.AgentID)
+	}
+	if !state.AgentEnabled {
+		t.Fatal("AgentEnabled = false, want true")
+	}
+	if state.ModelID != "model-1" {
+		t.Fatalf("ModelID = %q, want model-1", state.ModelID)
+	}
+	if !state.WebSearchEnabled {
+		t.Fatal("WebSearchEnabled = false, want true")
+	}
+	if !reflect.DeepEqual(state.KnowledgeBaseIDs, []string{"kb-agent"}) {
+		t.Fatalf("KnowledgeBaseIDs = %#v, want [kb-agent]", state.KnowledgeBaseIDs)
+	}
+}
+
+func TestBuildIMLastRequestStateKeepsExplicitKBs(t *testing.T) {
+	agent := &types.CustomAgent{
+		ID: "agent-1",
+		Config: types.CustomAgentConfig{
+			AgentMode:      types.AgentModeQuickAnswer,
+			ModelID:        "model-1",
+			KnowledgeBases: []string{"kb-agent"},
+		},
+	}
+
+	state := buildIMLastRequestState(agent.ID, agent, []string{"kb-explicit"})
+
+	if state.AgentEnabled {
+		t.Fatal("AgentEnabled = true, want false for quick-answer agent")
+	}
+	if !reflect.DeepEqual(state.KnowledgeBaseIDs, []string{"kb-explicit"}) {
+		t.Fatalf("KnowledgeBaseIDs = %#v, want [kb-explicit]", state.KnowledgeBaseIDs)
+	}
+}
+
+func TestCreateIMMessagePayloadsShareRequestShape(t *testing.T) {
+	userMsg := createIMUserMessagePayload("session-1", "hello", "request-1")
+	assistantMsg := createIMAssistantMessagePayload("session-1", "request-1")
+
+	if userMsg.SessionID != "session-1" || assistantMsg.SessionID != "session-1" {
+		t.Fatalf("SessionID mismatch: user=%q assistant=%q", userMsg.SessionID, assistantMsg.SessionID)
+	}
+	if userMsg.RequestID != assistantMsg.RequestID || userMsg.RequestID != "request-1" {
+		t.Fatalf("RequestID mismatch: user=%q assistant=%q", userMsg.RequestID, assistantMsg.RequestID)
+	}
+	if userMsg.Role != "user" || assistantMsg.Role != "assistant" {
+		t.Fatalf("Role mismatch: user=%q assistant=%q", userMsg.Role, assistantMsg.Role)
+	}
+	if userMsg.Channel != "im" || assistantMsg.Channel != "im" {
+		t.Fatalf("Channel mismatch: user=%q assistant=%q", userMsg.Channel, assistantMsg.Channel)
+	}
+	if !userMsg.IsCompleted {
+		t.Fatal("user message should be completed")
+	}
+	if assistantMsg.IsCompleted {
+		t.Fatal("assistant placeholder should not be completed")
+	}
+	if userMsg.Content != "hello" {
+		t.Fatalf("user content = %q, want hello", userMsg.Content)
+	}
+	if assistantMsg.Content != "" {
+		t.Fatalf("assistant placeholder content = %q, want empty", assistantMsg.Content)
+	}
+}
+
+func TestApplyIMCompleteDataToMessage(t *testing.T) {
+	msg := &types.Message{ID: "assistant-1", Role: "assistant"}
+	ref := &types.SearchResult{ID: "chunk-1", KnowledgeID: "knowledge-1"}
+	steps := []types.AgentStep{{
+		Iteration:        1,
+		ReasoningContent: "thinking",
+	}}
+
+	applyIMCompleteDataToMessage(msg, event.AgentCompleteData{
+		MessageID:       "assistant-1",
+		TotalDurationMs: 1234,
+		KnowledgeRefs:   []interface{}{ref},
+		AgentSteps:      steps,
+	})
+
+	if !msg.IsCompleted {
+		t.Fatal("message should be marked completed")
+	}
+	if msg.AgentDurationMs != 1234 {
+		t.Fatalf("AgentDurationMs = %d, want 1234", msg.AgentDurationMs)
+	}
+	if len(msg.KnowledgeReferences) != 1 || msg.KnowledgeReferences[0].ID != "chunk-1" {
+		t.Fatalf("KnowledgeReferences = %#v, want chunk-1", msg.KnowledgeReferences)
+	}
+	if len(msg.AgentSteps) != 1 || msg.AgentSteps[0].ReasoningContent != "thinking" {
+		t.Fatalf("AgentSteps = %#v, want one thinking step", msg.AgentSteps)
 	}
 }

--- a/internal/im/session_test.go
+++ b/internal/im/session_test.go
@@ -2,6 +2,7 @@ package im
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/Tencent/WeKnora/internal/event"
@@ -256,5 +257,37 @@ func TestApplyIMCompleteDataToMessage(t *testing.T) {
 	}
 	if len(msg.AgentSteps) != 1 || msg.AgentSteps[0].ReasoningContent != "thinking" {
 		t.Fatalf("AgentSteps = %#v, want one thinking step", msg.AgentSteps)
+	}
+}
+
+func TestPickIMStoredAnswerPrefersFirstNonEmpty(t *testing.T) {
+	got := pickIMStoredAnswer("", "outer", "live", "complete")
+	if got != "outer" {
+		t.Fatalf("pickIMStoredAnswer = %q, want outer", got)
+	}
+	got = pickIMStoredAnswer("", "", "live", "complete")
+	if got != "live" {
+		t.Fatalf("pickIMStoredAnswer = %q, want live", got)
+	}
+}
+
+func TestMergeIMAgentAnswerBuffersUsesLiveThenComplete(t *testing.T) {
+	var builder, outer, live strings.Builder
+	live.WriteString("live answer")
+
+	mergeIMAgentAnswerBuffers(&builder, &outer, &live, "complete final")
+	if builder.String() != "live answer" {
+		t.Fatalf("builder = %q, want live answer", builder.String())
+	}
+	if outer.String() != "live answer" {
+		t.Fatalf("outer = %q, want live answer", outer.String())
+	}
+
+	builder.Reset()
+	outer.Reset()
+	live.Reset()
+	mergeIMAgentAnswerBuffers(&builder, &outer, &live, "complete final")
+	if builder.String() != "complete final" {
+		t.Fatalf("builder = %q, want complete final", builder.String())
 	}
 }

--- a/internal/im/slack/adapter.go
+++ b/internal/im/slack/adapter.go
@@ -254,8 +254,8 @@ func (a *Adapter) StartStream(ctx context.Context, incoming *im.IncomingMessage)
 	return streamID, nil
 }
 
-func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMessage, streamID string, content string) error {
-	if content == "" {
+func (a *Adapter) UpdateStreamContent(ctx context.Context, incoming *im.IncomingMessage, streamID string, fullContent string) error {
+	if fullContent == "" {
 		return nil
 	}
 
@@ -267,20 +267,25 @@ func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMess
 	}
 
 	state.mu.Lock()
-	state.content.WriteString(content)
-	fullContent := state.content.String()
+	state.content.Reset()
+	state.content.WriteString(fullContent)
+	channel := state.channel
+	ts := state.ts
 	state.mu.Unlock()
 
-	// Update the message
-	logger.Infof(ctx, "[Slack] Updating stream chunk: stream_id=%s, content=%s", streamID, fullContent)
-	_, _, _, err := a.api.UpdateMessageContext(ctx, state.channel, state.ts, slack.MsgOptionText(fullContent, false))
+	_, _, _, err := a.api.UpdateMessageContext(ctx, channel, ts, slack.MsgOptionText(fullContent, false))
 	if err != nil {
-		// slack has rate limit, so we just log the error
-		// see: https://docs.slack.dev/reference/methods/chat.update/
-		logger.Warnf(ctx, "[Slack] Failed to update stream chunk: %v", err)
+		logger.Warnf(ctx, "[Slack] Failed to update stream content: %v", err)
 	}
-
 	return nil
+}
+
+func (a *Adapter) FinalizeStream(ctx context.Context, incoming *im.IncomingMessage, streamID string, finalContent string) error {
+	return a.UpdateStreamContent(ctx, incoming, streamID, finalContent)
+}
+
+func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMessage, streamID string, content string) error {
+	return a.UpdateStreamContent(ctx, incoming, streamID, content)
 }
 
 func (a *Adapter) EndStream(ctx context.Context, incoming *im.IncomingMessage, streamID string) error {

--- a/internal/im/stream_display_test.go
+++ b/internal/im/stream_display_test.go
@@ -1,0 +1,133 @@
+package im
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// recordingStreamSender records streaming calls for TDD verification.
+type recordingStreamSender struct {
+	mu sync.Mutex
+
+	streamID      string
+	chunkContents []string // full display content per UpdateStreamContent call
+	finalContent  string
+	ended         bool
+}
+
+func (m *recordingStreamSender) StartStream(_ context.Context, _ *IncomingMessage) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.streamID = "rec-stream-1"
+	return m.streamID, nil
+}
+
+func (m *recordingStreamSender) UpdateStreamContent(_ context.Context, _ *IncomingMessage, _ string, fullContent string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.chunkContents = append(m.chunkContents, fullContent)
+	return nil
+}
+
+func (m *recordingStreamSender) FinalizeStream(_ context.Context, _ *IncomingMessage, _ string, finalContent string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.finalContent = finalContent
+	return nil
+}
+
+func (m *recordingStreamSender) EndStream(_ context.Context, _ *IncomingMessage, _ string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ended = true
+	return nil
+}
+
+func (m *recordingStreamSender) snapshot() (chunks []string, final string, ended bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.chunkContents))
+	copy(out, m.chunkContents)
+	return out, m.finalContent, m.ended
+}
+
+func TestStreamDisplayPipeline_agentScenario_redGreen(t *testing.T) {
+	// Simulates the agent IM stream lifecycle aligned with Web:
+	// 1) intermediate updates show styled thinking + tools
+	// 2) final replace shows collapsed think summary + answer
+	rawIntermediate := "<think>\n分析 Civilization VI 问题\n正在调用 搜索关键词...\n搜索关键词\n</think>\n\n"
+
+	rec := &recordingStreamSender{}
+	ctx := context.Background()
+	incoming := &IncomingMessage{Platform: PlatformWeCom, UserID: "u1"}
+
+	streamID, err := rec.StartStream(ctx, incoming)
+	if err != nil {
+		t.Fatalf("StartStream: %v", err)
+	}
+
+	intermediate := FormatIMDisplayContent(rawIntermediate, StreamDisplayIntermediate)
+	if err := rec.UpdateStreamContent(ctx, incoming, streamID, intermediate); err != nil {
+		t.Fatalf("UpdateStreamContent intermediate: %v", err)
+	}
+
+	final := FormatIMFinalFromParts(IMStreamParts{
+		Mode: IMStreamModeAgent,
+		AgentInner: "分析 Civilization VI 问题\n",
+		AgentToolSteps: []IMToolStep{
+			{ToolName: "grep_chunks", Success: true},
+			{ToolName: "knowledge_search", Success: true},
+		},
+		Answer: "《文明6》是回合制策略游戏。",
+	})
+	if err := rec.FinalizeStream(ctx, incoming, streamID, final); err != nil {
+		t.Fatalf("FinalizeStream: %v", err)
+	}
+	if err := rec.EndStream(ctx, incoming, streamID); err != nil {
+		t.Fatalf("EndStream: %v", err)
+	}
+
+	chunks, finalized, ended := rec.snapshot()
+	if !ended {
+		t.Fatal("stream should be ended")
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 intermediate update, got %d", len(chunks))
+	}
+	if chunks[0] == final {
+		t.Fatal("intermediate update should differ from final answer-only content")
+	}
+	if finalized != "《文明6》是回合制策略游戏。" && !strings.Contains(finalized, "思考过程") {
+		t.Fatalf("FinalizeStream content = %q", finalized)
+	}
+	if !strings.Contains(finalized, "《文明6》是回合制策略游戏。") {
+		t.Fatalf("FinalizeStream must include answer, got: %q", finalized)
+	}
+}
+
+func TestStreamDisplayPipeline_quickQA_redGreen(t *testing.T) {
+	during := IMStreamParts{
+		Mode:          IMStreamModeQuickQA,
+		PipelineInner: "⏳ 问题理解\n✅ 问题理解\n⏳ 知识库检索\n",
+	}
+	done := IMStreamParts{
+		Mode:          IMStreamModeQuickQA,
+		PipelineInner: "⏳ 问题理解\n✅ 问题理解\n⏳ 知识库检索\n",
+		Answer:        "答案是 B。",
+	}
+
+	intermediate := FormatIMIntermediateFromParts(during, false)
+	if intermediate == "" {
+		t.Fatal("quick QA should show pipeline progress while streaming")
+	}
+	if strings.Contains(intermediate, "思考过程") {
+		t.Fatalf("quick QA pipeline should not use agent think header, got: %q", intermediate)
+	}
+
+	final := FormatIMFinalFromParts(done)
+	if final != "答案是 B。" {
+		t.Fatalf("quick QA final = %q, want answer only", final)
+	}
+}

--- a/internal/im/stream_display_test.go
+++ b/internal/im/stream_display_test.go
@@ -56,7 +56,7 @@ func (m *recordingStreamSender) snapshot() (chunks []string, final string, ended
 func TestStreamDisplayPipeline_agentScenario_redGreen(t *testing.T) {
 	// Simulates the agent IM stream lifecycle aligned with Web:
 	// 1) intermediate updates show styled thinking + tools
-	// 2) final replace shows collapsed think summary + answer
+	// 2) final replace shows answer only (no collapsed think header)
 	rawIntermediate := "<think>\n分析 Civilization VI 问题\n正在调用 搜索关键词...\n搜索关键词\n</think>\n\n"
 
 	rec := &recordingStreamSender{}
@@ -99,7 +99,7 @@ func TestStreamDisplayPipeline_agentScenario_redGreen(t *testing.T) {
 	if chunks[0] == final {
 		t.Fatal("intermediate update should differ from final answer-only content")
 	}
-	if finalized != "《文明6》是回合制策略游戏。" && !strings.Contains(finalized, "思考过程") {
+	if finalized != "《文明6》是回合制策略游戏。" {
 		t.Fatalf("FinalizeStream content = %q", finalized)
 	}
 	if !strings.Contains(finalized, "《文明6》是回合制策略游戏。") {

--- a/internal/im/stream_display_test.go
+++ b/internal/im/stream_display_test.go
@@ -109,18 +109,27 @@ func TestStreamDisplayPipeline_agentScenario_redGreen(t *testing.T) {
 
 func TestStreamDisplayPipeline_quickQA_redGreen(t *testing.T) {
 	during := IMStreamParts{
-		Mode:          IMStreamModeQuickQA,
-		PipelineInner: "⏳ 问题理解\n✅ 问题理解\n⏳ 知识库检索\n",
+		Mode: IMStreamModeQuickQA,
+		PipelineToolSteps: []IMToolStep{
+			{ToolName: "query_understand", Success: true},
+			{ToolName: "knowledge_search", Pending: true, Arguments: map[string]any{"query": "test"}},
+		},
 	}
 	done := IMStreamParts{
-		Mode:          IMStreamModeQuickQA,
-		PipelineInner: "⏳ 问题理解\n✅ 问题理解\n⏳ 知识库检索\n",
-		Answer:        "答案是 B。",
+		Mode: IMStreamModeQuickQA,
+		PipelineToolSteps: []IMToolStep{
+			{ToolName: "query_understand", Success: true},
+			{ToolName: "knowledge_search", Success: true, Arguments: map[string]any{"query": "test"}},
+		},
+		Answer: "答案是 B。",
 	}
 
 	intermediate := FormatIMIntermediateFromParts(during, false)
 	if intermediate == "" {
 		t.Fatal("quick QA should show pipeline progress while streaming")
+	}
+	if !strings.Contains(intermediate, "问题理解") {
+		t.Fatalf("quick QA pipeline should show query_understand step, got: %q", intermediate)
 	}
 	if strings.Contains(intermediate, "思考过程") {
 		t.Fatalf("quick QA pipeline should not use agent think header, got: %q", intermediate)

--- a/internal/im/stream_lifecycle_test.go
+++ b/internal/im/stream_lifecycle_test.go
@@ -1,0 +1,166 @@
+package im
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// imStreamDisplayState mirrors the display buffers in handleMessageStream for lifecycle tests.
+type imStreamDisplayState struct {
+	useAgent          bool
+	agentDone         bool
+	agentInner        streamSection
+	agentLiveAnswer   strings.Builder
+	answerOuter       strings.Builder
+	agentToolSteps    []IMToolStep
+	agentToolIdx      map[string]int
+	pipelineToolSteps []IMToolStep
+	pipelineIdx       map[string]int
+}
+
+func newIMStreamDisplayState(useAgent bool) *imStreamDisplayState {
+	return &imStreamDisplayState{
+		useAgent:     useAgent,
+		agentToolIdx: make(map[string]int),
+		pipelineIdx:  make(map[string]int),
+	}
+}
+
+func (s *imStreamDisplayState) retractAgentLiveAnswer() {
+	if s.agentLiveAnswer.Len() == 0 {
+		return
+	}
+	if s.agentInner.text.Len() > 0 {
+		s.agentInner.ensureNewlineBefore()
+	}
+	s.agentInner.write(s.agentLiveAnswer.String())
+	s.agentLiveAnswer.Reset()
+}
+
+func (s *imStreamDisplayState) parts() IMStreamParts {
+	mode := IMStreamModeQuickQA
+	if s.useAgent {
+		mode = IMStreamModeAgent
+	}
+	return IMStreamParts{
+		Mode:              mode,
+		PipelineToolSteps: s.pipelineToolSteps,
+		AgentInner:        s.agentInner.text.String(),
+		AgentToolSteps:    s.agentToolSteps,
+		LiveAnswer:        s.agentLiveAnswer.String(),
+		Answer:            s.answerOuter.String(),
+	}
+}
+
+func (s *imStreamDisplayState) intermediate() string {
+	return FormatIMIntermediateFromParts(s.parts(), s.useAgent && !s.agentDone)
+}
+
+func (s *imStreamDisplayState) final() string {
+	return FormatIMFinalFromParts(s.parts())
+}
+
+// TestIMStreamLifecycle_agentToolRetract simulates handleMessageStream display assembly:
+// live answer → tool retract → tool result → final answer → complete.
+func TestIMStreamLifecycle_agentToolRetract(t *testing.T) {
+	state := newIMStreamDisplayState(true)
+
+	state.agentLiveAnswer.WriteString("好的，让我先搜索知识库。")
+	liveOnly := state.intermediate()
+	if liveOnly != "好的，让我先搜索知识库。" {
+		t.Fatalf("live answer phase = %q", liveOnly)
+	}
+	if strings.Contains(liveOnly, "思考过程") {
+		t.Fatal("think header must not appear before tool retract")
+	}
+
+	state.retractAgentLiveAnswer()
+	upsertIMToolStep(&state.agentToolSteps, state.agentToolIdx, "tool-1", func(step *IMToolStep) {
+		step.ToolName = "grep_chunks"
+		step.Pending = true
+	})
+	duringTools := state.intermediate()
+	if !strings.Contains(duringTools, "思考过程") {
+		t.Fatalf("after retract should show think block, got: %q", duringTools)
+	}
+	if !strings.Contains(duringTools, "好的，让我先搜索知识库") {
+		t.Fatalf("retracted preamble missing, got: %q", duringTools)
+	}
+
+	upsertIMToolStep(&state.agentToolSteps, state.agentToolIdx, "tool-1", func(step *IMToolStep) {
+		step.ToolName = "grep_chunks"
+		step.Pending = false
+		step.Success = true
+	})
+	state.agentLiveAnswer.WriteString("根据检索结果，《文明6》是回合制策略游戏。")
+	withLiveAnswer := state.intermediate()
+	if !strings.Contains(withLiveAnswer, "根据检索结果") {
+		t.Fatalf("live answer after tools missing, got: %q", withLiveAnswer)
+	}
+
+	state.agentDone = true
+	state.answerOuter.WriteString("《文明6》是回合制策略游戏。")
+	final := state.final()
+	if !strings.Contains(final, "《文明6》是回合制策略游戏。") {
+		t.Fatalf("final answer missing, got: %q", final)
+	}
+
+	rec := &recordingStreamSender{}
+	ctx := context.Background()
+	incoming := &IncomingMessage{Platform: PlatformWeCom, UserID: "u1"}
+	streamID, err := rec.StartStream(ctx, incoming)
+	if err != nil {
+		t.Fatalf("StartStream: %v", err)
+	}
+	if err := rec.UpdateStreamContent(ctx, incoming, streamID, duringTools); err != nil {
+		t.Fatalf("UpdateStreamContent: %v", err)
+	}
+	if err := rec.FinalizeStream(ctx, incoming, streamID, final); err != nil {
+		t.Fatalf("FinalizeStream: %v", err)
+	}
+	if err := rec.EndStream(ctx, incoming, streamID); err != nil {
+		t.Fatalf("EndStream: %v", err)
+	}
+
+	chunks, finalized, ended := rec.snapshot()
+	if !ended {
+		t.Fatal("stream should end")
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 intermediate update, got %d", len(chunks))
+	}
+	if chunks[0] == finalized {
+		t.Fatal("intermediate and final should differ")
+	}
+}
+
+// TestIMStreamLifecycle_quickQAPipeline verifies quick-QA pipeline steps collapse to answer-only final.
+func TestIMStreamLifecycle_quickQAPipeline(t *testing.T) {
+	state := newIMStreamDisplayState(false)
+
+	upsertIMToolStep(&state.pipelineToolSteps, state.pipelineIdx, "qu-1", func(step *IMToolStep) {
+		step.ToolName = "query_understand"
+		step.Pending = false
+		step.Success = true
+	})
+	upsertIMToolStep(&state.pipelineToolSteps, state.pipelineIdx, "ks-1", func(step *IMToolStep) {
+		step.ToolName = "knowledge_search"
+		step.Pending = true
+		step.Arguments = map[string]any{"query": "文明6"}
+	})
+
+	intermediate := state.intermediate()
+	if intermediate == "" {
+		t.Fatal("pipeline progress should be visible")
+	}
+	if strings.Contains(intermediate, "思考过程") {
+		t.Fatalf("quick QA must not use agent think header, got: %q", intermediate)
+	}
+
+	state.answerOuter.WriteString("答案是 B。")
+	final := state.final()
+	if final != "答案是 B。" {
+		t.Fatalf("final = %q, want answer only", final)
+	}
+}

--- a/internal/im/stream_section.go
+++ b/internal/im/stream_section.go
@@ -1,0 +1,24 @@
+package im
+
+import "strings"
+
+// streamSection tracks newline state for one IM stream text buffer.
+type streamSection struct {
+	lastCharNewline bool
+	text            strings.Builder
+}
+
+func (s *streamSection) write(str string) {
+	if str == "" {
+		return
+	}
+	s.text.WriteString(str)
+	s.lastCharNewline = str[len(str)-1] == '\n'
+}
+
+func (s *streamSection) ensureNewlineBefore() {
+	if !s.lastCharNewline {
+		s.text.WriteByte('\n')
+		s.lastCharNewline = true
+	}
+}

--- a/internal/im/stream_test.go
+++ b/internal/im/stream_test.go
@@ -9,11 +9,12 @@ import (
 
 // mockStreamSender is a test double that records streaming calls.
 type mockStreamSender struct {
-	mu       sync.Mutex
-	started  bool
-	streamID string
-	chunks   []string
-	ended    bool
+	mu            sync.Mutex
+	started       bool
+	streamID      string
+	updates       []string
+	finalContent  string
+	ended         bool
 }
 
 func (m *mockStreamSender) StartStream(_ context.Context, _ *IncomingMessage) (string, error) {
@@ -24,10 +25,17 @@ func (m *mockStreamSender) StartStream(_ context.Context, _ *IncomingMessage) (s
 	return m.streamID, nil
 }
 
-func (m *mockStreamSender) SendStreamChunk(_ context.Context, _ *IncomingMessage, _ string, content string) error {
+func (m *mockStreamSender) UpdateStreamContent(_ context.Context, _ *IncomingMessage, _ string, fullContent string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.chunks = append(m.chunks, content)
+	m.updates = append(m.updates, fullContent)
+	return nil
+}
+
+func (m *mockStreamSender) FinalizeStream(_ context.Context, _ *IncomingMessage, _ string, finalContent string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.finalContent = finalContent
 	return nil
 }
 
@@ -38,11 +46,11 @@ func (m *mockStreamSender) EndStream(_ context.Context, _ *IncomingMessage, _ st
 	return nil
 }
 
-func (m *mockStreamSender) getChunks() []string {
+func (m *mockStreamSender) getUpdates() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	out := make([]string, len(m.chunks))
-	copy(out, m.chunks)
+	out := make([]string, len(m.updates))
+	copy(out, m.updates)
 	return out
 }
 
@@ -56,7 +64,6 @@ func TestStreamSenderInterface(t *testing.T) {
 		Content:  "hello",
 	}
 
-	// Start stream
 	streamID, err := mock.StartStream(ctx, incoming)
 	if err != nil {
 		t.Fatalf("StartStream failed: %v", err)
@@ -65,41 +72,43 @@ func TestStreamSenderInterface(t *testing.T) {
 		t.Fatal("expected non-empty stream ID")
 	}
 
-	// Send chunks
-	chunks := []string{"Hello", ", ", "world", "!"}
-	for _, c := range chunks {
-		if err := mock.SendStreamChunk(ctx, incoming, streamID, c); err != nil {
-			t.Fatalf("SendStreamChunk failed: %v", err)
+	// Replace-based updates send the full visible content each time.
+	updates := []string{"Hello", "Hello, world", "Hello, world!"}
+	for _, content := range updates {
+		if err := mock.UpdateStreamContent(ctx, incoming, streamID, content); err != nil {
+			t.Fatalf("UpdateStreamContent failed: %v", err)
 		}
 	}
 
-	// End stream
+	if err := mock.FinalizeStream(ctx, incoming, streamID, "Hello, world!"); err != nil {
+		t.Fatalf("FinalizeStream failed: %v", err)
+	}
 	if err := mock.EndStream(ctx, incoming, streamID); err != nil {
 		t.Fatalf("EndStream failed: %v", err)
 	}
 
-	// Verify
 	if !mock.started {
 		t.Error("expected stream to be started")
 	}
 	if !mock.ended {
 		t.Error("expected stream to be ended")
 	}
-
-	got := mock.getChunks()
-	if len(got) != len(chunks) {
-		t.Fatalf("expected %d chunks, got %d", len(chunks), len(got))
+	if mock.finalContent != "Hello, world!" {
+		t.Errorf("finalContent = %q, want %q", mock.finalContent, "Hello, world!")
 	}
-	for i, want := range chunks {
+
+	got := mock.getUpdates()
+	if len(got) != len(updates) {
+		t.Fatalf("expected %d updates, got %d", len(updates), len(got))
+	}
+	for i, want := range updates {
 		if got[i] != want {
-			t.Errorf("chunk[%d] = %q, want %q", i, got[i], want)
+			t.Errorf("update[%d] = %q, want %q", i, got[i], want)
 		}
 	}
 }
 
 func TestStreamFlushBatching(t *testing.T) {
-	// Simulate the batching behavior: multiple writes within one flush interval
-	// should be combined into a single chunk.
 	mock := &mockStreamSender{}
 
 	ctx := context.Background()
@@ -111,24 +120,22 @@ func TestStreamFlushBatching(t *testing.T) {
 
 	streamID, _ := mock.StartStream(ctx, incoming)
 
-	// Simulate buffer: accumulate content then flush as one chunk
 	var buf string
 	tokens := []string{"Hello", " ", "world", "!"}
 	for _, tok := range tokens {
 		buf += tok
 	}
 
-	// Single flush
-	if err := mock.SendStreamChunk(ctx, incoming, streamID, buf); err != nil {
-		t.Fatalf("SendStreamChunk failed: %v", err)
+	if err := mock.UpdateStreamContent(ctx, incoming, streamID, buf); err != nil {
+		t.Fatalf("UpdateStreamContent failed: %v", err)
 	}
 
-	got := mock.getChunks()
+	got := mock.getUpdates()
 	if len(got) != 1 {
-		t.Fatalf("expected 1 batched chunk, got %d", len(got))
+		t.Fatalf("expected 1 batched update, got %d", len(got))
 	}
 	if got[0] != "Hello world!" {
-		t.Errorf("batched chunk = %q, want %q", got[0], "Hello world!")
+		t.Errorf("batched update = %q, want %q", got[0], "Hello world!")
 	}
 }
 

--- a/internal/im/telegram/adapter.go
+++ b/internal/im/telegram/adapter.go
@@ -438,7 +438,7 @@ func (a *Adapter) FinalizeStream(ctx context.Context, incoming *im.IncomingMessa
 	msgID := state.msgID
 	state.mu.Unlock()
 
-	if err := a.editMessage(ctx, chatID, msgID, finalContent, "Markdown"); err != nil {
+	if err := a.editMessage(ctx, chatID, msgID, finalContent, ""); err != nil {
 		logger.Warnf(ctx, "[Telegram] Failed to finalize stream: %v", err)
 	}
 	return nil

--- a/internal/im/telegram/adapter.go
+++ b/internal/im/telegram/adapter.go
@@ -215,7 +215,7 @@ func resolveChatID(incoming *im.IncomingMessage) string {
 
 func (a *Adapter) SendReply(ctx context.Context, incoming *im.IncomingMessage, reply *im.ReplyMessage) error {
 	chatID := resolveChatID(incoming)
-	text := transformThinkBlocks(reply.Content)
+	text := im.FormatIMDisplayContent(reply.Content, im.StreamDisplayFinal)
 
 	body := map[string]interface{}{
 		"chat_id":    chatID,
@@ -391,8 +391,8 @@ func (a *Adapter) StartStream(ctx context.Context, incoming *im.IncomingMessage)
 	return streamID, nil
 }
 
-func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMessage, streamID string, content string) error {
-	if content == "" {
+func (a *Adapter) UpdateStreamContent(ctx context.Context, incoming *im.IncomingMessage, streamID string, fullContent string) error {
+	if fullContent == "" {
 		return nil
 	}
 
@@ -404,28 +404,53 @@ func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMess
 	}
 
 	state.mu.Lock()
-	state.content.WriteString(content)
-
-	// Throttle: skip edit if last edit was too recent
 	if time.Since(state.lastEdit) < minEditInterval {
+		state.content.Reset()
+		state.content.WriteString(fullContent)
 		state.mu.Unlock()
 		return nil
 	}
-
-	fullContent := transformThinkBlocks(state.content.String())
+	state.content.Reset()
+	state.content.WriteString(fullContent)
+	chatID := state.chatID
+	msgID := state.msgID
 	state.lastEdit = time.Now()
 	state.mu.Unlock()
 
-	if err := a.editMessage(ctx, state.chatID, state.msgID, fullContent, ""); err != nil {
-		logger.Warnf(ctx, "[Telegram] Failed to update stream chunk: %v", err)
+	if err := a.editMessage(ctx, chatID, msgID, fullContent, ""); err != nil {
+		logger.Warnf(ctx, "[Telegram] Failed to update stream content: %v", err)
+	}
+	return nil
+}
+
+func (a *Adapter) FinalizeStream(ctx context.Context, incoming *im.IncomingMessage, streamID string, finalContent string) error {
+	streamsMu.Lock()
+	state, ok := streams[streamID]
+	streamsMu.Unlock()
+	if !ok {
+		return fmt.Errorf("unknown stream ID: %s", streamID)
 	}
 
+	state.mu.Lock()
+	state.content.Reset()
+	state.content.WriteString(finalContent)
+	chatID := state.chatID
+	msgID := state.msgID
+	state.mu.Unlock()
+
+	if err := a.editMessage(ctx, chatID, msgID, finalContent, "Markdown"); err != nil {
+		logger.Warnf(ctx, "[Telegram] Failed to finalize stream: %v", err)
+	}
 	return nil
+}
+
+func (a *Adapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMessage, streamID string, content string) error {
+	return a.UpdateStreamContent(ctx, incoming, streamID, content)
 }
 
 func (a *Adapter) EndStream(ctx context.Context, incoming *im.IncomingMessage, streamID string) error {
 	streamsMu.Lock()
-	state, ok := streams[streamID]
+	_, ok := streams[streamID]
 	delete(streams, streamID)
 	streamsMu.Unlock()
 
@@ -433,20 +458,8 @@ func (a *Adapter) EndStream(ctx context.Context, incoming *im.IncomingMessage, s
 		return nil
 	}
 
-	state.mu.Lock()
-	fullContent := transformThinkBlocks(state.content.String())
-	state.mu.Unlock()
-
-	if err := a.editMessage(ctx, state.chatID, state.msgID, fullContent, "Markdown"); err != nil {
-		logger.Warnf(ctx, "[Telegram] Failed to end stream: %v", err)
-	}
-
 	logger.Infof(ctx, "[Telegram] Streaming ended: stream_id=%s", streamID)
 	return nil
-}
-
-func transformThinkBlocks(content string) string {
-	return im.TransformThinkBlocks(content, im.TelegramThinkStyle)
 }
 
 // ── FileDownloader implementation ──

--- a/internal/im/telegram/adapter.go
+++ b/internal/im/telegram/adapter.go
@@ -438,8 +438,11 @@ func (a *Adapter) FinalizeStream(ctx context.Context, incoming *im.IncomingMessa
 	msgID := state.msgID
 	state.mu.Unlock()
 
-	if err := a.editMessage(ctx, chatID, msgID, finalContent, ""); err != nil {
-		logger.Warnf(ctx, "[Telegram] Failed to finalize stream: %v", err)
+	if err := a.editMessage(ctx, chatID, msgID, finalContent, "Markdown"); err != nil {
+		logger.Warnf(ctx, "[Telegram] Markdown finalize failed, retrying plain: %v", err)
+		if retryErr := a.editMessage(ctx, chatID, msgID, finalContent, ""); retryErr != nil {
+			logger.Warnf(ctx, "[Telegram] Failed to finalize stream: %v", retryErr)
+		}
 	}
 	return nil
 }

--- a/internal/im/think.go
+++ b/internal/im/think.go
@@ -55,7 +55,6 @@ type IMStreamParts struct {
 	Mode IMStreamMode
 
 	// Quick-QA (RagPipelineProgress on Web):
-	PipelineInner     string       // non-tool pipeline narrative (if any)
 	PipelineToolSteps []IMToolStep // query_understand / knowledge_search rows
 	ReasoningInner    string       // model reasoning_content — separate "思考" section
 
@@ -73,8 +72,7 @@ func agentThinkContent(parts IMStreamParts) string {
 }
 
 func quickQAPipelineContent(parts IMStreamParts) string {
-	toolLines := renderIMToolSteps(parts.PipelineToolSteps, FormatIMRagPipelineLine)
-	return mergeIMNarrativeAndTools(parts.PipelineInner, toolLines)
+	return renderIMToolSteps(parts.PipelineToolSteps, FormatIMRagPipelineLine)
 }
 
 // RAGThinkingStyle matches Web RagPipelineProgress thinking row (agent.think).

--- a/internal/im/think.go
+++ b/internal/im/think.go
@@ -1,7 +1,6 @@
 package im
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 )
@@ -122,37 +121,6 @@ func formatIMAgentIntermediate(parts IMStreamParts) string {
 	return strings.Join(sections, MarkdownThinkStyle.Separator)
 }
 
-// buildIMAgentCollapsedSummary returns a one-line collapsed think header (Web: tree root).
-func buildIMAgentCollapsedSummary(parts IMStreamParts) string {
-	think := strings.TrimSpace(agentThinkContent(parts))
-	if think == "" {
-		return ""
-	}
-	summary := formatIMAgentStepsSummary(parts)
-	line := "> 💭 **思考过程**"
-	if summary != "" {
-		line += " · " + summary
-	}
-	return line
-}
-
-func formatIMAgentStepsSummary(parts IMStreamParts) string {
-	toolCount := len(parts.AgentToolSteps)
-	hasNarrative := strings.TrimSpace(parts.AgentInner) != ""
-
-	var segments []string
-	if hasNarrative {
-		segments = append(segments, "思考 1 轮")
-	}
-	if toolCount > 0 {
-		segments = append(segments, fmt.Sprintf("调用 %d 次工具", toolCount))
-	}
-	if len(segments) == 0 {
-		return ""
-	}
-	return strings.Join(segments, " · ")
-}
-
 // formatIMQuickQAIntermediate mirrors Web RagPipelineProgress:
 // pipeline steps as plain lines, model reasoning in a separate "思考" block,
 // and once answer starts streaming the progress collapses to answer-only preview.
@@ -180,14 +148,9 @@ func FormatIMIntermediateFromParts(parts IMStreamParts, agentInProgress bool) st
 	return formatIMAgentIntermediate(parts)
 }
 
-// FormatIMFinalFromParts returns the final replace frame: collapsed think summary + answer for agent mode.
+// FormatIMFinalFromParts returns the final replace frame (answer-only for all modes).
 func FormatIMFinalFromParts(parts IMStreamParts) string {
 	answer := strings.TrimSpace(parts.Answer)
-	if parts.Mode == IMStreamModeAgent {
-		if collapsed := buildIMAgentCollapsedSummary(parts); collapsed != "" && answer != "" {
-			return collapsed + MarkdownThinkStyle.Separator + answer
-		}
-	}
 	if answer != "" {
 		return answer
 	}

--- a/internal/im/think.go
+++ b/internal/im/think.go
@@ -1,6 +1,215 @@
 package im
 
-import "strings"
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// StreamDisplayPhase controls how raw IM stream content is rendered.
+type StreamDisplayPhase int
+
+const (
+	// StreamDisplayIntermediate shows in-progress thinking/tools (Web: expanded progress).
+	StreamDisplayIntermediate StreamDisplayPhase = iota
+	// StreamDisplayFinal shows answer-only text (Web: collapsed/hidden intermediate steps).
+	StreamDisplayFinal
+)
+
+var (
+	thinkBlockRe    = regexp.MustCompile(`(?s)<think>.*?</think>`)
+	thinkOpenTailRe = regexp.MustCompile(`(?s)<think>.*$`)
+)
+
+// ragPipelineToolNames mirrors frontend RAG_PIPELINE_TOOL_NAMES.
+var ragPipelineToolNames = map[string]bool{
+	"query_understand": true,
+	"knowledge_search": true,
+}
+
+// IsRAGPipelineToolName reports whether a tool is part of the quick-QA progress UI.
+func IsRAGPipelineToolName(name string) bool {
+	return ragPipelineToolNames[name]
+}
+
+// StripThinkBlocks removes <think> blocks for final IM display.
+func StripThinkBlocks(content string) string {
+	if content == "" {
+		return ""
+	}
+	cleaned := thinkBlockRe.ReplaceAllString(content, "")
+	cleaned = thinkOpenTailRe.ReplaceAllString(cleaned, "")
+	return trimIMOuterWhitespace(cleaned)
+}
+
+// IMStreamMode distinguishes agent reasoning from quick-QA RAG pipeline display.
+type IMStreamMode int
+
+const (
+	IMStreamModeAgent IMStreamMode = iota
+	IMStreamModeQuickQA
+)
+
+// IMStreamParts separates stream content for IM display.
+type IMStreamParts struct {
+	Mode IMStreamMode
+
+	// Quick-QA (RagPipelineProgress on Web):
+	PipelineInner     string       // non-tool pipeline narrative (if any)
+	PipelineToolSteps []IMToolStep // query_understand / knowledge_search rows
+	ReasoningInner    string       // model reasoning_content — separate "思考" section
+
+	// Agent (AgentStreamDisplay on Web):
+	AgentInner     string       // retracted preambles + thoughts ("思考过程")
+	AgentToolSteps []IMToolStep // tool progress lines (one row per tool_call_id)
+	LiveAnswer     string       // optimistic answer stream before tools retract it
+
+	Answer string // final answer (complete / knowledge QA)
+}
+
+func agentThinkContent(parts IMStreamParts) string {
+	toolLines := renderIMToolSteps(parts.AgentToolSteps, FormatIMToolLine)
+	return mergeIMNarrativeAndTools(parts.AgentInner, toolLines)
+}
+
+func quickQAPipelineContent(parts IMStreamParts) string {
+	toolLines := renderIMToolSteps(parts.PipelineToolSteps, FormatIMRagPipelineLine)
+	return mergeIMNarrativeAndTools(parts.PipelineInner, toolLines)
+}
+
+// RAGThinkingStyle matches Web RagPipelineProgress thinking row (agent.think).
+var RAGThinkingStyle = ThinkBlockStyle{
+	ThinkingHeader: "> 💭 **思考中...**\n",
+	ThoughtHeader:  "> 💭 **思考**\n",
+	LinePrefix:     "> ",
+	LineSuffix:     "",
+	Separator:      "\n---\n\n",
+}
+
+// WrapThinkBlock wraps inner content with think tags for formatting.
+func WrapThinkBlock(inner string) string {
+	inner = strings.TrimSpace(inner)
+	if inner == "" {
+		return ""
+	}
+	return "<think>\n" + inner + "\n</think>"
+}
+
+// BuildIMAgentStreamRaw assembles agent-mode raw content.
+func BuildIMAgentStreamRaw(parts IMStreamParts, agentInProgress bool) string {
+	thinkTagged := WrapThinkBlock(agentThinkContent(parts))
+	if agentInProgress || strings.TrimSpace(parts.Answer) == "" {
+		return thinkTagged
+	}
+	if thinkTagged == "" {
+		return parts.Answer
+	}
+	return thinkTagged + "\n\n" + parts.Answer
+}
+
+// formatIMAgentIntermediate mirrors Web AgentStreamDisplay:
+// stream answer text first; when tools run, retract into "思考过程";
+// once tools exist, keep the think block visible above the streaming answer.
+func formatIMAgentIntermediate(parts IMStreamParts) string {
+	think := strings.TrimSpace(agentThinkContent(parts))
+	live := strings.TrimSpace(parts.LiveAnswer)
+
+	var sections []string
+	if think != "" {
+		sections = append(sections, FormatIMDisplayContent(WrapThinkBlock(think), StreamDisplayIntermediate))
+	}
+	if live != "" {
+		sections = append(sections, live)
+	}
+	return strings.Join(sections, MarkdownThinkStyle.Separator)
+}
+
+// buildIMAgentCollapsedSummary returns a one-line collapsed think header (Web: tree root).
+func buildIMAgentCollapsedSummary(parts IMStreamParts) string {
+	think := strings.TrimSpace(agentThinkContent(parts))
+	if think == "" {
+		return ""
+	}
+	summary := formatIMAgentStepsSummary(parts)
+	line := "> 💭 **思考过程**"
+	if summary != "" {
+		line += " · " + summary
+	}
+	return line
+}
+
+func formatIMAgentStepsSummary(parts IMStreamParts) string {
+	toolCount := len(parts.AgentToolSteps)
+	hasNarrative := strings.TrimSpace(parts.AgentInner) != ""
+
+	var segments []string
+	if hasNarrative {
+		segments = append(segments, "思考 1 轮")
+	}
+	if toolCount > 0 {
+		segments = append(segments, fmt.Sprintf("调用 %d 次工具", toolCount))
+	}
+	if len(segments) == 0 {
+		return ""
+	}
+	return strings.Join(segments, " · ")
+}
+
+// formatIMQuickQAIntermediate mirrors Web RagPipelineProgress:
+// pipeline steps as plain lines, model reasoning in a separate "思考" block,
+// and once answer starts streaming the progress collapses to answer-only preview.
+func formatIMQuickQAIntermediate(parts IMStreamParts) string {
+	if answer := strings.TrimSpace(parts.Answer); answer != "" {
+		return answer
+	}
+
+	var sections []string
+	if p := strings.TrimSpace(quickQAPipelineContent(parts)); p != "" {
+		sections = append(sections, p)
+	}
+	if r := strings.TrimSpace(parts.ReasoningInner); r != "" {
+		sections = append(sections, TransformThinkBlocks(WrapThinkBlock(r), RAGThinkingStyle))
+	}
+	return strings.Join(sections, "\n\n")
+}
+
+// FormatIMIntermediateFromParts formats in-progress IM stream display.
+func FormatIMIntermediateFromParts(parts IMStreamParts, agentInProgress bool) string {
+	if parts.Mode == IMStreamModeQuickQA {
+		return formatIMQuickQAIntermediate(parts)
+	}
+	_ = agentInProgress
+	return formatIMAgentIntermediate(parts)
+}
+
+// FormatIMFinalFromParts returns the final replace frame: collapsed think summary + answer for agent mode.
+func FormatIMFinalFromParts(parts IMStreamParts) string {
+	answer := strings.TrimSpace(parts.Answer)
+	if parts.Mode == IMStreamModeAgent {
+		if collapsed := buildIMAgentCollapsedSummary(parts); collapsed != "" && answer != "" {
+			return collapsed + MarkdownThinkStyle.Separator + answer
+		}
+	}
+	if answer != "" {
+		return answer
+	}
+	// Fallback for embedded think tags in non-agent answers.
+	return FormatIMDisplayContent(BuildIMAgentStreamRaw(parts, false), StreamDisplayFinal)
+}
+
+// FormatIMDisplayContent formats raw stream content for the given display phase.
+func FormatIMDisplayContent(raw string, phase StreamDisplayPhase) string {
+	switch phase {
+	case StreamDisplayFinal:
+		return StripThinkBlocks(raw)
+	default:
+		return TransformThinkBlocks(raw, MarkdownThinkStyle)
+	}
+}
+
+func trimIMOuterWhitespace(s string) string {
+	return strings.TrimSpace(s)
+}
 
 // ThinkBlockStyle controls how <think>...</think> blocks are rendered.
 type ThinkBlockStyle struct {

--- a/internal/im/think_test.go
+++ b/internal/im/think_test.go
@@ -1,0 +1,288 @@
+package im
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStripThinkBlocks(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "no think blocks", input: "Hello, world!", want: "Hello, world!"},
+		{name: "empty", input: "", want: ""},
+		{
+			name:  "single block before answer",
+			input: "<think>reasoning</think>The answer is 42.",
+			want:  "The answer is 42.",
+		},
+		{
+			name: "multiline think with tools",
+			input: "<think>\n让我先搜索知识库\n正在调用 搜索关键词...\n搜索关键词：「文明」\n</think>\n\n文明6是一款策略游戏。",
+			want:  "文明6是一款策略游戏。",
+		},
+		{
+			name:  "multiple blocks",
+			input: "<think>first</think>Part 1. <think>second</think>Part 2.",
+			want:  "Part 1. Part 2.",
+		},
+		{name: "only think block", input: "<think>just thinking</think>", want: ""},
+		{
+			name:  "unclosed think block",
+			input: "<think>still streaming",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripThinkBlocks(tt.input)
+			if got != tt.want {
+				t.Fatalf("StripThinkBlocks() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatIMDisplayContent_intermediate_showsThinkingStyled(t *testing.T) {
+	raw := "<think>\n分析用户问题\n正在调用 知识库检索...\n</think>\n\n"
+	got := FormatIMDisplayContent(raw, StreamDisplayIntermediate)
+
+	if !strings.Contains(got, "思考过程") {
+		t.Fatalf("intermediate display should include thinking header, got: %q", got)
+	}
+	if !strings.Contains(got, "分析用户问题") {
+		t.Fatalf("intermediate display should include thinking body, got: %q", got)
+	}
+	if !strings.Contains(got, "知识库检索") {
+		t.Fatalf("intermediate display should include tool progress, got: %q", got)
+	}
+	if strings.Contains(got, "<think>") {
+		t.Fatalf("intermediate display must not leak raw think tags, got: %q", got)
+	}
+}
+
+func TestFormatIMDisplayContent_intermediate_inProgressThink(t *testing.T) {
+	raw := "<think>\n正在推理\n正在调用 搜索关键词...\n"
+	got := FormatIMDisplayContent(raw, StreamDisplayIntermediate)
+
+	if !strings.Contains(got, "思考") {
+		t.Fatalf("open think block should show thinking header, got: %q", got)
+	}
+	if strings.Contains(got, "<think>") {
+		t.Fatalf("must not leak raw tags, got: %q", got)
+	}
+}
+
+func TestFormatIMDisplayContent_intermediate_showsAnswerPreview(t *testing.T) {
+	raw := "<think>\n检索中\n</think>\n\n文明6是回合制策略游戏。"
+	got := FormatIMDisplayContent(raw, StreamDisplayIntermediate)
+
+	if !strings.Contains(got, "文明6是回合制策略游戏") {
+		t.Fatalf("intermediate display should preview answer after think block, got: %q", got)
+	}
+}
+
+func TestFormatIMDisplayContent_final_stripsThinkingAndTools(t *testing.T) {
+	raw := "<think>\n让我先搜索知识库\n正在调用 搜索关键词...\n搜索关键词：「文明」\n</think>\n\n文明6是一款策略游戏。"
+	got := FormatIMDisplayContent(raw, StreamDisplayFinal)
+
+	want := "文明6是一款策略游戏。"
+	if got != want {
+		t.Fatalf("final display = %q, want %q", got, want)
+	}
+}
+
+func TestFormatIMDisplayContent_final_plainAnswerUnchanged(t *testing.T) {
+	raw := "这是最终答案。"
+	got := FormatIMDisplayContent(raw, StreamDisplayFinal)
+	if got != raw {
+		t.Fatalf("final display = %q, want %q", got, raw)
+	}
+}
+
+func TestFormatIMDisplayContent_final_ragPipelineHidden(t *testing.T) {
+	raw := "<think>\n正在理解问题...\n已完成问题理解\n正在检索知识库...\n检索知识库：「query」 · 找到 3 个结果\n</think>\n\n根据知识库，答案是 A。"
+	got := FormatIMDisplayContent(raw, StreamDisplayFinal)
+
+	if strings.Contains(got, "问题理解") || strings.Contains(got, "知识库检索") {
+		t.Fatalf("final display must not contain RAG pipeline steps, got: %q", got)
+	}
+	if got != "根据知识库，答案是 A。" {
+		t.Fatalf("final display = %q", got)
+	}
+}
+
+func TestFormatIMAgentIntermediate_answerFirstBeforeTools(t *testing.T) {
+	parts := IMStreamParts{
+		Mode:       IMStreamModeAgent,
+		LiveAnswer: "好的，让我先搜索知识库。",
+	}
+	got := FormatIMIntermediateFromParts(parts, true)
+	if got != "好的，让我先搜索知识库。" {
+		t.Fatalf("should stream as plain answer, got: %q", got)
+	}
+	if strings.Contains(got, "思考过程") {
+		t.Fatal("think header must not appear while answer is live")
+	}
+}
+
+func TestFormatIMAgentIntermediate_retractIntoThinkOnTools(t *testing.T) {
+	parts := IMStreamParts{
+		Mode: IMStreamModeAgent,
+		AgentInner: "好的，让我先搜索知识库。\n",
+		AgentToolSteps: []IMToolStep{
+			{ToolName: "grep_chunks", Pending: true},
+			{ToolName: "knowledge_search", Success: true, Arguments: map[string]any{"query": "文明6"}},
+		},
+	}
+	got := FormatIMIntermediateFromParts(parts, true)
+	if !strings.Contains(got, "思考过程") {
+		t.Fatalf("after tool retract should show think block, got: %q", got)
+	}
+	if !strings.Contains(got, "好的，让我先搜索知识库") {
+		t.Fatalf("retracted preamble should be inside think, got: %q", got)
+	}
+	if !strings.Contains(got, "搜索关键词") {
+		t.Fatalf("tool lines should be inside think, got: %q", got)
+	}
+	if !strings.Contains(got, "文明6") {
+		t.Fatalf("tool query should be inside think, got: %q", got)
+	}
+}
+
+func TestFormatIMAgentIntermediate_newAnswerAfterTools(t *testing.T) {
+	parts := IMStreamParts{
+		Mode: IMStreamModeAgent,
+		AgentInner: "好的，让我搜索\n",
+		AgentToolSteps: []IMToolStep{
+			{ToolName: "knowledge_search", Success: true, Arguments: map[string]any{"query": "文明6"}},
+		},
+		LiveAnswer: "根据检索结果，文明6是…",
+	}
+	got := FormatIMIntermediateFromParts(parts, true)
+	if !strings.Contains(got, "根据检索结果，文明6是…") {
+		t.Fatalf("should still stream live answer, got: %q", got)
+	}
+	if !strings.Contains(got, "思考过程") {
+		t.Fatalf("think block should stay visible above answer, got: %q", got)
+	}
+	if !strings.Contains(got, "文明6") {
+		t.Fatalf("tool query should remain in think block, got: %q", got)
+	}
+}
+
+func TestBuildIMStreamRaw_agentInProgress_mergesToolsAndNarrativeIntoThink(t *testing.T) {
+	parts := IMStreamParts{
+		Mode:       IMStreamModeAgent,
+		AgentInner: "用户又问文明6\n",
+		AgentToolSteps: []IMToolStep{
+			{ToolName: "grep_chunks", Pending: true},
+			{ToolName: "knowledge_search", Success: true},
+		},
+	}
+	got := FormatIMIntermediateFromParts(parts, true)
+
+	if !strings.Contains(got, "搜索关键词") {
+		t.Fatalf("tool progress should be inside think block, got: %q", got)
+	}
+	if !strings.Contains(got, "思考过程") {
+		t.Fatalf("agent tooling phase should show 思考过程, got: %q", got)
+	}
+}
+
+func TestFormatIMQuickQA_separatesPipelineAndThinking(t *testing.T) {
+	parts := IMStreamParts{
+		Mode: IMStreamModeQuickQA,
+		PipelineToolSteps: []IMToolStep{
+			{ToolName: "query_understand", Pending: true},
+			{ToolName: "knowledge_search", Success: true, Arguments: map[string]any{"query": "文明6"}},
+		},
+		ReasoningInner: "分析问题意图…",
+	}
+	got := FormatIMIntermediateFromParts(parts, false)
+
+	if strings.Contains(got, "思考过程") {
+		t.Fatalf("quick QA should not use agent 思考过程 header, got: %q", got)
+	}
+	if !strings.Contains(got, "> 💭 **思考**") {
+		t.Fatalf("quick QA reasoning should use separate 思考 section, got: %q", got)
+	}
+	if !strings.Contains(got, "分析问题意图") {
+		t.Fatalf("reasoning body missing, got: %q", got)
+	}
+	if !strings.Contains(got, "正在理解问题") {
+		t.Fatalf("pipeline steps missing, got: %q", got)
+	}
+	if !strings.Contains(got, "文明6") {
+		t.Fatalf("pipeline query missing, got: %q", got)
+	}
+}
+
+func TestFormatIMQuickQA_collapsesToAnswerWhenStreaming(t *testing.T) {
+	parts := IMStreamParts{
+		Mode: IMStreamModeQuickQA,
+		PipelineToolSteps: []IMToolStep{
+			{ToolName: "query_understand", Success: true},
+			{ToolName: "knowledge_search", Success: true},
+		},
+		Answer: "文明6是回合制策略游戏。",
+	}
+	got := FormatIMIntermediateFromParts(parts, false)
+	if got != "文明6是回合制策略游戏。" {
+		t.Fatalf("quick QA should collapse to answer preview, got: %q", got)
+	}
+}
+
+func TestFormatIMFinalFromParts_collapsesThinkForAgent(t *testing.T) {
+	parts := IMStreamParts{
+		Mode: IMStreamModeAgent,
+		AgentInner: "好的，让我搜索\n",
+		AgentToolSteps: []IMToolStep{
+			{ToolName: "grep_chunks", Pending: true},
+			{ToolName: "knowledge_search", Success: true},
+		},
+		LiveAnswer: "不应出现在最终消息",
+		Answer:     "文明6是一款策略游戏。",
+	}
+	got := FormatIMFinalFromParts(parts)
+	if !strings.Contains(got, "思考过程") {
+		t.Fatalf("final should keep collapsed think summary, got: %q", got)
+	}
+	if !strings.Contains(got, "调用 2 次工具") {
+		t.Fatalf("final summary should mention tool count, got: %q", got)
+	}
+	if !strings.Contains(got, "文明6是一款策略游戏。") {
+		t.Fatalf("final must include answer, got: %q", got)
+	}
+	if strings.Contains(got, "检索知识库") {
+		t.Fatalf("final must not expand full tool lines, got: %q", got)
+	}
+}
+
+func TestFormatIMFinalFromParts_usesAnswerOnly(t *testing.T) {
+	parts := IMStreamParts{
+		Mode:           IMStreamModeQuickQA,
+		PipelineToolSteps: []IMToolStep{{ToolName: "query_understand", Success: true}},
+		ReasoningInner: "推理中",
+		AgentToolSteps: []IMToolStep{{ToolName: "grep_chunks", Pending: true}},
+		Answer:         "文明6是一款策略游戏。",
+	}
+	got := FormatIMFinalFromParts(parts)
+	if got != "文明6是一款策略游戏。" {
+		t.Fatalf("final display = %q", got)
+	}
+}
+
+func TestIsRAGPipelineToolName_matchesWeb(t *testing.T) {
+	for _, name := range []string{"query_understand", "knowledge_search"} {
+		if !IsRAGPipelineToolName(name) {
+			t.Fatalf("%q should be a RAG pipeline tool", name)
+		}
+	}
+	if IsRAGPipelineToolName("grep_chunks") {
+		t.Fatal("grep_chunks is agent tool, not RAG pipeline progress tool")
+	}
+}

--- a/internal/im/think_test.go
+++ b/internal/im/think_test.go
@@ -236,7 +236,7 @@ func TestFormatIMQuickQA_collapsesToAnswerWhenStreaming(t *testing.T) {
 	}
 }
 
-func TestFormatIMFinalFromParts_collapsesThinkForAgent(t *testing.T) {
+func TestFormatIMFinalFromParts_agentAnswerOnly(t *testing.T) {
 	parts := IMStreamParts{
 		Mode: IMStreamModeAgent,
 		AgentInner: "好的，让我搜索\n",
@@ -248,17 +248,11 @@ func TestFormatIMFinalFromParts_collapsesThinkForAgent(t *testing.T) {
 		Answer:     "文明6是一款策略游戏。",
 	}
 	got := FormatIMFinalFromParts(parts)
-	if !strings.Contains(got, "思考过程") {
-		t.Fatalf("final should keep collapsed think summary, got: %q", got)
+	if got != "文明6是一款策略游戏。" {
+		t.Fatalf("final should be answer-only, got: %q", got)
 	}
-	if !strings.Contains(got, "调用 2 次工具") {
-		t.Fatalf("final summary should mention tool count, got: %q", got)
-	}
-	if !strings.Contains(got, "文明6是一款策略游戏。") {
-		t.Fatalf("final must include answer, got: %q", got)
-	}
-	if strings.Contains(got, "检索知识库") {
-		t.Fatalf("final must not expand full tool lines, got: %q", got)
+	if strings.Contains(got, "思考过程") {
+		t.Fatalf("final must not include collapsed think header, got: %q", got)
 	}
 }
 

--- a/internal/im/tool_display.go
+++ b/internal/im/tool_display.go
@@ -1,0 +1,624 @@
+package im
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// IMToolStep tracks one tool invocation for IM display (mirrors Web agent stream events).
+type IMToolStep struct {
+	ToolCallID string
+	ToolName   string
+	Pending    bool
+	Success    bool
+	Arguments  map[string]any
+	Data       map[string]interface{}
+	Output     string
+}
+
+// imLocalizedToolName returns zh-CN labels aligned with frontend agentStream.tools.
+func imLocalizedToolName(toolName string) string {
+	if name, ok := imToolNameLabels[toolName]; ok {
+		return name
+	}
+	if strings.HasPrefix(toolName, "mcp_") {
+		return formatMCPToolName(toolName)
+	}
+	return toolName
+}
+
+var imToolNameLabels = map[string]string{
+	"search_knowledge":        "知识库检索",
+	"knowledge_search":        "知识库检索",
+	"grep_chunks":             "搜索关键词",
+	"web_search":              "网络搜索",
+	"web_fetch":               "网页抓取",
+	"get_document_info":       "获取文档信息",
+	"list_knowledge_chunks":   "查看知识分块",
+	"get_related_documents":   "查找相关文档",
+	"get_document_content":    "获取文档内容",
+	"wiki_search":             "Wiki 搜索",
+	"wiki_read_page":          "Wiki 阅读",
+	"wiki_read_source_doc":    "精读源文档",
+	"todo_write":              "计划管理",
+	"knowledge_graph_extract": "知识图谱抽取",
+	"thinking":                "思考",
+	"image_analysis":          "查看图片内容",
+	"query_understand":        "理解问题",
+	"query_knowledge_graph":   "知识图谱查询",
+	"read_skill":              "读取技能",
+	"execute_skill_script":    "执行技能脚本",
+	"data_analysis":           "数据分析",
+	"data_schema":             "数据结构",
+	"database_query":          "数据库查询",
+}
+
+func formatMCPToolName(rawName string) string {
+	rest := strings.TrimPrefix(rawName, "mcp_")
+	if rest == "" {
+		return rawName
+	}
+	parts := strings.Split(rest, "_")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+func collectQueryStrings(value any) []string {
+	if value == nil {
+		return nil
+	}
+	switch v := value.(type) {
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return nil
+		}
+		if strings.HasPrefix(trimmed, "[") {
+			var parsed []any
+			if err := json.Unmarshal([]byte(trimmed), &parsed); err == nil {
+				var out []string
+				for _, item := range parsed {
+					if s, ok := item.(string); ok && strings.TrimSpace(s) != "" {
+						out = append(out, strings.TrimSpace(s))
+					}
+				}
+				return out
+			}
+		}
+		return []string{trimmed}
+	case []any:
+		var out []string
+		for _, item := range v {
+			if s, ok := item.(string); ok && strings.TrimSpace(s) != "" {
+				out = append(out, strings.TrimSpace(s))
+			}
+		}
+		return out
+	case []string:
+		var out []string
+		for _, s := range v {
+			if strings.TrimSpace(s) != "" {
+				out = append(out, strings.TrimSpace(s))
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func imGetQueryText(args any) string {
+	if args == nil {
+		return ""
+	}
+	parsed := args
+	if s, ok := args.(string); ok {
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(s), &obj); err != nil {
+			return ""
+		}
+		parsed = obj
+	}
+	record, ok := parsed.(map[string]any)
+	if !ok {
+		return ""
+	}
+	seen := make(map[string]struct{})
+	var queries []string
+	for _, q := range collectQueryStrings(record["query"]) {
+		if _, dup := seen[q]; dup {
+			continue
+		}
+		seen[q] = struct{}{}
+		queries = append(queries, q)
+	}
+	for _, q := range collectQueryStrings(record["queries"]) {
+		if _, dup := seen[q]; dup {
+			continue
+		}
+		seen[q] = struct{}{}
+		queries = append(queries, q)
+	}
+	return strings.Join(queries, "，")
+}
+
+func imGetWikiPageText(args any) string {
+	if args == nil {
+		return ""
+	}
+	parsed := args
+	if s, ok := args.(string); ok {
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(s), &obj); err != nil {
+			return ""
+		}
+		parsed = obj
+	}
+	record, ok := parsed.(map[string]any)
+	if !ok {
+		return ""
+	}
+	seen := make(map[string]struct{})
+	var slugs []string
+	for _, slug := range collectQueryStrings(record["slug"]) {
+		if _, dup := seen[slug]; dup {
+			continue
+		}
+		seen[slug] = struct{}{}
+		slugs = append(slugs, slug)
+	}
+	for _, slug := range collectQueryStrings(record["slugs"]) {
+		if _, dup := seen[slug]; dup {
+			continue
+		}
+		seen[slug] = struct{}{}
+		slugs = append(slugs, slug)
+	}
+	return strings.Join(slugs, "、")
+}
+
+func imGetGrepPatterns(args any) []string {
+	if args == nil {
+		return nil
+	}
+	record, ok := args.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if queries := collectQueryStrings(record["queries"]); len(queries) > 0 {
+		return queries
+	}
+	if patterns := collectQueryStrings(record["patterns"]); len(patterns) > 0 {
+		return patterns
+	}
+	if q := imGetQueryText(record); q != "" {
+		return []string{q}
+	}
+	if pattern, ok := record["pattern"].(string); ok && strings.TrimSpace(pattern) != "" {
+		return []string{strings.TrimSpace(pattern)}
+	}
+	return nil
+}
+
+func imGetWebSearchQuery(step IMToolStep) string {
+	if q := imGetQueryText(step.Arguments); q != "" {
+		return q
+	}
+	return imGetQueryText(step.Data)
+}
+
+func imGetGrepPatternsFromStep(step IMToolStep) []string {
+	if patterns := imGetGrepPatterns(step.Arguments); len(patterns) > 0 {
+		return patterns
+	}
+	return imGetGrepPatterns(step.Data)
+}
+
+func imAppendQueryTitle(base, query string) string {
+	if query == "" {
+		return base
+	}
+	return fmt.Sprintf("%s：「%s」", base, query)
+}
+
+func imAppendPatternsTitle(base string, patterns []string) string {
+	if len(patterns) == 0 {
+		return base
+	}
+	display := patterns
+	more := ""
+	if len(patterns) > 2 {
+		display = patterns[:2]
+		more = fmt.Sprintf(" +%d", len(patterns)-2)
+	}
+	return fmt.Sprintf("%s：「%s%s」", base, strings.Join(display, "、"), more)
+}
+
+// FormatIMToolLine formats one agent tool step (no emoji; aligned with Web getToolTitle).
+func FormatIMToolLine(step IMToolStep) string {
+	title := imAgentToolTitle(step)
+	if title == "" {
+		return ""
+	}
+	if step.Pending {
+		return title
+	}
+	if summary := imToolResultSummary(step); summary != "" {
+		return title + " · " + summary
+	}
+	return title
+}
+
+// FormatIMRagPipelineLine formats quick-QA RAG pipeline steps (Web RagPipelineProgress).
+func FormatIMRagPipelineLine(step IMToolStep) string {
+	toolName := step.ToolName
+	query := imGetQueryText(step.Arguments)
+	if query == "" {
+		query = imGetQueryText(step.Data)
+	}
+
+	switch toolName {
+	case "query_understand":
+		if step.Pending {
+			return "正在理解问题..."
+		}
+		return "已完成问题理解"
+	case "knowledge_search", "search_knowledge":
+		if step.Pending {
+			if query != "" {
+				return fmt.Sprintf("正在检索知识库：「%s」", query)
+			}
+			return "正在检索知识库..."
+		}
+		base := "检索知识库"
+		if !step.Success {
+			base = "检索知识库失败"
+		}
+		line := imAppendQueryTitle(base, query)
+		if summary := imKnowledgeSearchSummary(step.Data); summary != "" {
+			return line + " · " + summary
+		}
+		return line
+	default:
+		return ""
+	}
+}
+
+func imAgentToolTitle(step IMToolStep) string {
+	if step.Pending {
+		switch step.ToolName {
+		case "image_analysis":
+			return "正在查看图片内容..."
+		case "wiki_search", "wiki_read_page":
+			return imLocalizedToolName(step.ToolName) + "..."
+		default:
+			return fmt.Sprintf("正在调用 %s...", imLocalizedToolName(step.ToolName))
+		}
+	}
+
+	toolName := step.ToolName
+	isSearchTool := toolName == "search_knowledge" || toolName == "knowledge_search" || toolName == "wiki_search"
+	if isSearchTool {
+		base := imToolStatusDescription(step)
+		query := imGetQueryText(step.Arguments)
+		if query == "" {
+			query = imGetQueryText(step.Data)
+		}
+		return imAppendQueryTitle(base, query)
+	}
+
+	if toolName == "web_search" {
+		base := imToolStatusDescription(step)
+		return imAppendQueryTitle(base, imGetWebSearchQuery(step))
+	}
+
+	if toolName == "grep_chunks" {
+		base := imToolStatusDescription(step)
+		return imAppendPatternsTitle(base, imGetGrepPatternsFromStep(step))
+	}
+
+	if toolName == "wiki_read_page" {
+		pageLabel := ""
+		if step.Data != nil {
+			if title, ok := step.Data["title"].(string); ok {
+				pageLabel = strings.TrimSpace(title)
+			}
+		}
+		if pageLabel == "" {
+			pageLabel = imGetWikiPageText(step.Arguments)
+		}
+		if pageLabel == "" {
+			pageLabel = imGetWikiPageText(step.Data)
+		}
+		base := imToolStatusDescription(step)
+		return imAppendQueryTitle(base, pageLabel)
+	}
+
+	if summary := imToolHeaderSummary(step); summary != "" {
+		return summary
+	}
+	return imToolStatusDescription(step)
+}
+
+func imToolStatusDescription(step IMToolStep) string {
+	success := step.Success
+	toolName := step.ToolName
+
+	switch toolName {
+	case "search_knowledge", "knowledge_search":
+		if success {
+			return "检索知识库"
+		}
+		return "检索知识库失败"
+	case "wiki_search", "wiki_read_page":
+		name := imLocalizedToolName(toolName)
+		if success {
+			return name
+		}
+		return fmt.Sprintf("调用 %s 失败", name)
+	case "web_search":
+		if success {
+			return "网络搜索"
+		}
+		return "网络搜索失败"
+	case "grep_chunks":
+		if success {
+			return "搜索关键词"
+		}
+		return "搜索关键词失败"
+	case "get_document_info":
+		if success {
+			return "获取文档信息"
+		}
+		return "获取文档信息失败"
+	case "get_document_content", "wiki_read_source_doc":
+		if success {
+			return "获取文档内容"
+		}
+		return "获取文档内容失败"
+	case "thinking":
+		if success {
+			return "完成思考"
+		}
+		return "思考失败"
+	case "todo_write":
+		if success {
+			return "更新任务列表"
+		}
+		return "更新任务列表失败"
+	case "image_analysis":
+		if success {
+			return "已查看图片内容"
+		}
+		return "图片内容查看失败"
+	case "query_understand":
+		if success {
+			return "已完成问题理解"
+		}
+		return fmt.Sprintf("调用 %s 失败", imLocalizedToolName(toolName))
+	default:
+		name := imLocalizedToolName(toolName)
+		if success {
+			return fmt.Sprintf("调用 %s", name)
+		}
+		return fmt.Sprintf("调用 %s 失败", name)
+	}
+}
+
+func imToolHeaderSummary(step IMToolStep) string {
+	if step.Pending || !step.Success {
+		return ""
+	}
+	toolName := step.ToolName
+	data := step.Data
+
+	switch toolName {
+	case "search_knowledge", "knowledge_search":
+		return ""
+	case "get_document_info":
+		if data != nil {
+			if title, ok := data["title"].(string); ok && strings.TrimSpace(title) != "" {
+				return fmt.Sprintf("获取文档：%s", strings.TrimSpace(title))
+			}
+		}
+	case "list_knowledge_chunks":
+		if data != nil {
+			if question, ok := data["faq_question"].(string); ok && strings.TrimSpace(question) != "" {
+				return fmt.Sprintf("查看 FAQ：%s", strings.TrimSpace(question))
+			}
+			if _, ok := data["fetched_chunks"]; ok {
+				title := "文档"
+				if t, ok := data["knowledge_title"].(string); ok && strings.TrimSpace(t) != "" {
+					title = strings.TrimSpace(t)
+				} else if id, ok := data["knowledge_id"].(string); ok && strings.TrimSpace(id) != "" {
+					title = strings.TrimSpace(id)
+				}
+				return fmt.Sprintf("查看 %s", title)
+			}
+		}
+	}
+	return ""
+}
+
+func imToolResultSummary(step IMToolStep) string {
+	if step.Pending || !step.Success {
+		return ""
+	}
+	switch step.ToolName {
+	case "search_knowledge", "knowledge_search":
+		return imKnowledgeSearchSummary(step.Data)
+	case "web_search":
+		return imWebSearchSummary(step.Data)
+	case "grep_chunks":
+		return imGrepSearchSummary(step.Data)
+	case "list_knowledge_chunks":
+		return imKnowledgeChunksSummary(step.Data)
+	default:
+		return briefToolSummary(step.Output)
+	}
+}
+
+func imKnowledgeSearchSummary(data map[string]interface{}) string {
+	if data == nil {
+		return ""
+	}
+	count := imResultCount(data)
+	if count == 0 {
+		return "未找到匹配的内容"
+	}
+	if kbCounts, ok := data["kb_counts"].(map[string]interface{}); ok && len(kbCounts) > 0 {
+		return fmt.Sprintf("找到 %d 个结果，来自 %d 个文件", count, len(kbCounts))
+	}
+	return fmt.Sprintf("找到 %d 个结果", count)
+}
+
+func imWebSearchSummary(data map[string]interface{}) string {
+	if data == nil {
+		return ""
+	}
+	count := imResultCount(data)
+	if count == 0 {
+		return ""
+	}
+	return fmt.Sprintf("找到 %d 个网络搜索结果", count)
+}
+
+func imGrepSearchSummary(data map[string]interface{}) string {
+	if data == nil {
+		return ""
+	}
+	totalChunks := 0
+	if v, ok := data["total_matches"].(float64); ok {
+		totalChunks = int(v)
+	} else if v, ok := data["total_matches"].(int); ok {
+		totalChunks = v
+	}
+	if totalChunks == 0 {
+		return "未找到匹配的内容"
+	}
+	docCount := imGrepDocumentCount(data)
+	return fmt.Sprintf("找到 %d 个匹配片段，来自 %d 个文档", totalChunks, docCount)
+}
+
+func imGrepDocumentCount(data map[string]interface{}) int {
+	if v, ok := data["document_count"].(float64); ok && v >= 0 {
+		return int(v)
+	}
+	if v, ok := data["document_count"].(int); ok && v >= 0 {
+		return v
+	}
+	if results, ok := data["knowledge_results"].([]interface{}); ok && len(results) > 0 {
+		return len(results)
+	}
+	if results, ok := data["chunk_results"].([]interface{}); ok && len(results) > 0 {
+		return len(results)
+	}
+	return 0
+}
+
+func imKnowledgeChunksSummary(data map[string]interface{}) string {
+	if data == nil {
+		return ""
+	}
+	fetched, ok := data["fetched_chunks"]
+	if !ok {
+		return ""
+	}
+	fetchedN := imNumericValue(fetched)
+	totalN := imNumericValue(data["total_chunks"])
+	summary := fmt.Sprintf("已加载 %d / %v 个分块", fetchedN, formatIMOptionalInt(totalN, data["total_chunks"]))
+	pageSize := imNumericValue(data["page_size"])
+	if totalN > pageSize && pageSize > 0 {
+		page := imNumericValue(data["page"])
+		if page <= 0 {
+			page = 1
+		}
+		summary += fmt.Sprintf(" · 第 %d 页，每页 %d 个", page, pageSize)
+	}
+	return summary
+}
+
+func imResultCount(data map[string]interface{}) int {
+	if results, ok := data["results"].([]interface{}); ok && len(results) > 0 {
+		return len(results)
+	}
+	if count, ok := data["count"].(float64); ok && count > 0 {
+		return int(count)
+	}
+	if count, ok := data["count"].(int); ok && count > 0 {
+		return count
+	}
+	return 0
+}
+
+func imNumericValue(v any) int {
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	default:
+		return 0
+	}
+}
+
+func formatIMOptionalInt(n int, raw any) string {
+	if raw == nil {
+		return "?"
+	}
+	if _, ok := raw.(string); ok && n == 0 {
+		return "?"
+	}
+	if n == 0 {
+		return "?"
+	}
+	return fmt.Sprintf("%d", n)
+}
+
+func renderIMToolSteps(steps []IMToolStep, format func(IMToolStep) string) string {
+	if len(steps) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, step := range steps {
+		line := format(step)
+		if line == "" {
+			continue
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func mergeIMNarrativeAndTools(narrative string, toolLines string) string {
+	narrative = strings.TrimSpace(narrative)
+	toolLines = strings.TrimSpace(toolLines)
+	switch {
+	case narrative != "" && toolLines != "":
+		return narrative + "\n" + toolLines
+	case toolLines != "":
+		return toolLines
+	default:
+		return narrative
+	}
+}
+
+func upsertIMToolStep(steps *[]IMToolStep, index map[string]int, id string, update func(*IMToolStep)) {
+	if i, ok := index[id]; ok {
+		update(&(*steps)[i])
+		return
+	}
+	step := IMToolStep{ToolCallID: id}
+	update(&step)
+	index[id] = len(*steps)
+	*steps = append(*steps, step)
+}

--- a/internal/im/tool_display_test.go
+++ b/internal/im/tool_display_test.go
@@ -1,0 +1,92 @@
+package im
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatIMToolLine_pendingWithQuery(t *testing.T) {
+	line := FormatIMToolLine(IMToolStep{
+		ToolName:  "knowledge_search",
+		Pending:   true,
+		Arguments: map[string]any{"query": "文明6"},
+	})
+	if line != "正在调用 知识库检索..." {
+		t.Fatalf("pending line = %q", line)
+	}
+}
+
+func TestFormatIMToolLine_searchDoneWithQueryAndSummary(t *testing.T) {
+	line := FormatIMToolLine(IMToolStep{
+		ToolName: "knowledge_search",
+		Success:  true,
+		Arguments: map[string]any{
+			"query": "文明6",
+		},
+		Data: map[string]interface{}{
+			"results":   []interface{}{map[string]interface{}{}, map[string]interface{}{}, map[string]interface{}{}},
+			"kb_counts": map[string]interface{}{"a": 1, "b": 1},
+		},
+	})
+	if !strings.Contains(line, "检索知识库：「文明6」") {
+		t.Fatalf("title missing query: %q", line)
+	}
+	if !strings.Contains(line, "找到 3 个结果，来自 2 个文件") {
+		t.Fatalf("summary missing: %q", line)
+	}
+}
+
+func TestFormatIMToolLine_grepPatterns(t *testing.T) {
+	line := FormatIMToolLine(IMToolStep{
+		ToolName: "grep_chunks",
+		Success:  true,
+		Arguments: map[string]any{
+			"patterns": []any{"文明", "策略"},
+		},
+		Data: map[string]interface{}{
+			"total_matches": float64(5),
+			"document_count": float64(2),
+		},
+	})
+	if line != "搜索关键词：「文明、策略」 · 找到 5 个匹配片段，来自 2 个文档" {
+		t.Fatalf("grep line = %q", line)
+	}
+}
+
+func TestFormatIMRagPipelineLine_queryUnderstand(t *testing.T) {
+	pending := FormatIMRagPipelineLine(IMToolStep{
+		ToolName: "query_understand",
+		Pending:  true,
+	})
+	if pending != "正在理解问题..." {
+		t.Fatalf("pending = %q", pending)
+	}
+	done := FormatIMRagPipelineLine(IMToolStep{
+		ToolName: "query_understand",
+		Success:  true,
+	})
+	if done != "已完成问题理解" {
+		t.Fatalf("done = %q", done)
+	}
+}
+
+func TestFormatIMRagPipelineLine_searchWithQuery(t *testing.T) {
+	line := FormatIMRagPipelineLine(IMToolStep{
+		ToolName:  "knowledge_search",
+		Pending:   true,
+		Arguments: map[string]any{"query": "讯飞开放平台"},
+	})
+	if line != "正在检索知识库：「讯飞开放平台」" {
+		t.Fatalf("line = %q", line)
+	}
+}
+
+func TestIMGetQueryText_joinsUniqueQueries(t *testing.T) {
+	got := imGetQueryText(map[string]any{
+		"query":   "foo",
+		"queries": []any{"foo", "bar"},
+	})
+	if got != "foo，bar" {
+		t.Fatalf("query text = %q", got)
+	}
+}

--- a/internal/im/wecom/longconn.go
+++ b/internal/im/wecom/longconn.go
@@ -275,25 +275,33 @@ func (c *LongConnClient) StartStream(ctx context.Context, incoming *im.IncomingM
 	return streamID, nil
 }
 
-// SendStreamChunk accumulates the content and sends the full text so far.
-// WeCom stream protocol is replace-based: each frame replaces the previous display.
-func (c *LongConnClient) SendStreamChunk(ctx context.Context, incoming *im.IncomingMessage, streamID string, content string) error {
-	if content == "" {
+// UpdateStreamContent replaces the user-visible stream text (WeCom replace protocol).
+func (c *LongConnClient) UpdateStreamContent(ctx context.Context, incoming *im.IncomingMessage, streamID string, fullContent string) error {
+	if fullContent == "" {
 		return nil
 	}
 
-	// Accumulate
 	c.streamBufsMu.Lock()
 	buf, ok := c.streamBufs[streamID]
 	if !ok {
 		c.streamBufsMu.Unlock()
 		return fmt.Errorf("unknown stream ID: %s", streamID)
 	}
-	buf.WriteString(content)
-	fullContent := buf.String()
+	buf.Reset()
+	buf.WriteString(fullContent)
 	c.streamBufsMu.Unlock()
 
 	return c.sendStreamFrame(incoming, streamID, fullContent, false)
+}
+
+// FinalizeStream replaces the display with answer-only content before the stream ends.
+func (c *LongConnClient) FinalizeStream(ctx context.Context, incoming *im.IncomingMessage, streamID string, finalContent string) error {
+	return c.UpdateStreamContent(ctx, incoming, streamID, finalContent)
+}
+
+// SendStreamChunk is deprecated; kept as an alias for UpdateStreamContent.
+func (c *LongConnClient) SendStreamChunk(ctx context.Context, incoming *im.IncomingMessage, streamID string, content string) error {
+	return c.UpdateStreamContent(ctx, incoming, streamID, content)
 }
 
 // EndStream sends the final frame with the full accumulated content and cleans up.

--- a/internal/im/wecom/longconn.go
+++ b/internal/im/wecom/longconn.go
@@ -380,7 +380,7 @@ func (c *LongConnClient) connectAndRun(ctx context.Context) error {
 		_ = conn.Close()
 		// NOTE: streamBufs is intentionally NOT cleared on reconnect.
 		// Active streams survive reconnections — the WeCom replace-based
-		// protocol means the next SendStreamChunk will resend the full
+		// protocol means the next UpdateStreamContent will resend the full
 		// accumulated content on the new connection. EndStream always
 		// cleans up the buffer, so there is no memory leak.
 	}()

--- a/internal/im/wecom/ws_adapter.go
+++ b/internal/im/wecom/ws_adapter.go
@@ -60,8 +60,16 @@ func (a *WSAdapter) StartStream(ctx context.Context, incoming *im.IncomingMessag
 	return a.client.StartStream(ctx, incoming)
 }
 
+func (a *WSAdapter) UpdateStreamContent(ctx context.Context, incoming *im.IncomingMessage, streamID string, fullContent string) error {
+	return a.client.UpdateStreamContent(ctx, incoming, streamID, fullContent)
+}
+
+func (a *WSAdapter) FinalizeStream(ctx context.Context, incoming *im.IncomingMessage, streamID string, finalContent string) error {
+	return a.client.FinalizeStream(ctx, incoming, streamID, finalContent)
+}
+
 func (a *WSAdapter) SendStreamChunk(ctx context.Context, incoming *im.IncomingMessage, streamID string, content string) error {
-	return a.client.SendStreamChunk(ctx, incoming, streamID, content)
+	return a.client.UpdateStreamContent(ctx, incoming, streamID, content)
 }
 
 func (a *WSAdapter) EndStream(ctx context.Context, incoming *im.IncomingMessage, streamID string) error {


### PR DESCRIPTION
## Summary

- Unify IM streaming display across WeCom, Feishu, DingTalk, Slack, Telegram, and Mattermost with Web-aligned agent / quick-QA behavior.
- Add `StreamSender.UpdateStreamContent` + `FinalizeStream` replace semantics so platforms update the full visible message each flush (WeCom long-connection native replace included).
- Introduce `IMStreamParts` to separate agent reasoning, RAG pipeline steps, live answer retraction, and final answer — mirroring Web `AgentStreamDisplay` and `RagPipelineProgress`.
- Agent mode: stream optimistic answer first; retract into **思考过程** when tools run; keep the think block visible above the streaming answer; **finalize with answer-only** (no collapsed think header).
- Quick-QA mode: show RAG pipeline + separate **思考** block during progress; collapse to answer preview once answer starts; final message is answer-only.
- Add `tool_display.go` with Web-aligned tool titles (zh-CN), query/pattern extraction from `Arguments` / `tool_data`, and result summaries — no emoji status icons.
- Track tool steps by `tool_call_id` so each tool renders as one updatable line (pending → done).
- Harden stream lifecycle: agent complete wait timeout, answer fallbacks on cancel/stop, Telegram Markdown finalize with plain-text retry.

## Test plan

- [x] `go test ./internal/im/...`
- [ ] WeCom: agent chat with `knowledge_search` / `grep_chunks` — tools appear inside **思考过程** during stream; final message is answer-only
- [ ] Feishu / DingTalk: streaming card updates show think blockquote + answer separator
- [ ] Quick-QA (non-agent): pipeline steps (`query_understand`, `knowledge_search`) visible before answer; hidden in final reply
- [ ] Tool lines show query text, e.g. `检索知识库：「query」 · 找到 N 个结果`
- [ ] No regression on non-streaming IM replies