### PR TITLE
fix(kb): persist vlm_config on knowledge base update

### DIFF
--- a/client/knowledgebase.go
+++ b/client/knowledgebase.go
@@ -14,24 +14,24 @@ import (
 
 // KnowledgeBase represents a knowledge base
 type KnowledgeBase struct {
-	ID                    string                `json:"id"`
-	Name                  string                `json:"name"` // Name must be unique within the same tenant
-	Type                  string                `json:"type"`
-	IsTemporary           bool                  `json:"is_temporary"`
-	IsPinned              bool                  `json:"is_pinned"`
-	Description           string                `json:"description"`
-	TenantID              uint64                `json:"tenant_id"`
-	ChunkingConfig        ChunkingConfig        `json:"chunking_config"`
-	ImageProcessingConfig ImageProcessingConfig `json:"image_processing_config"`
-	FAQConfig             *FAQConfig            `json:"faq_config"`
-	EmbeddingModelID      string                `json:"embedding_model_id"`
-	SummaryModelID        string                `json:"summary_model_id"`
+	ID                    string                 `json:"id"`
+	Name                  string                 `json:"name"` // Name must be unique within the same tenant
+	Type                  string                 `json:"type"`
+	IsTemporary           bool                   `json:"is_temporary"`
+	IsPinned              bool                   `json:"is_pinned"`
+	Description           string                 `json:"description"`
+	TenantID              uint64                 `json:"tenant_id"`
+	ChunkingConfig        ChunkingConfig         `json:"chunking_config"`
+	ImageProcessingConfig ImageProcessingConfig  `json:"image_processing_config"`
+	FAQConfig             *FAQConfig             `json:"faq_config"`
+	EmbeddingModelID      string                 `json:"embedding_model_id"`
+	SummaryModelID        string                 `json:"summary_model_id"`
 	VLMConfig             VLMConfig              `json:"vlm_config"`
 	StorageProviderConfig *StorageProviderConfig `json:"storage_provider_config"`
 	StorageConfig         StorageConfig          `json:"storage_config"`
 	ExtractConfig         *ExtractConfig         `json:"extract_config"`
-	CreatedAt             time.Time             `json:"created_at"`
-	UpdatedAt             time.Time             `json:"updated_at"`
+	CreatedAt             time.Time              `json:"created_at"`
+	UpdatedAt             time.Time              `json:"updated_at"`
 	// Computed fields (not stored in database)
 	KnowledgeCount  int64 `json:"knowledge_count"`
 	ChunkCount      int64 `json:"chunk_count"`
@@ -116,8 +116,8 @@ type ParserEngineRule struct {
 
 // QuestionGenerationConfig controls LLM-generated questions per chunk during parsing.
 type QuestionGenerationConfig struct {
-	Enabled         bool `json:"enabled"`
-	QuestionCount   int  `json:"question_count"`
+	Enabled       bool `json:"enabled"`
+	QuestionCount int  `json:"question_count"`
 }
 
 // ASRConfig represents automatic speech recognition settings for audio files.
@@ -297,6 +297,7 @@ type UpdateKnowledgeBaseRequest struct {
 	Name        string               `json:"name"`
 	Description string               `json:"description"`
 	Config      *KnowledgeBaseConfig `json:"config"`
+	VLMConfig   *VLMConfig           `json:"vlm_config"`
 }
 
 // UpdateKnowledgeBase updates a knowledge base
@@ -349,9 +350,9 @@ func (c *Client) ClearKnowledgeBaseContents(ctx context.Context, knowledgeBaseID
 	}
 
 	var response struct {
-		Success bool                                `json:"success"`
-		Message string                              `json:"message"`
-		Data    ClearKnowledgeBaseContentsResponse   `json:"data"`
+		Success bool                               `json:"success"`
+		Message string                             `json:"message"`
+		Data    ClearKnowledgeBaseContentsResponse `json:"data"`
 	}
 
 	if err := parseResponse(resp, &response); err != nil {

--- a/docs/api/knowledge-base.md
+++ b/docs/api/knowledge-base.md
@@ -269,6 +269,7 @@ curl --location 'http://localhost:8080/api/v1/knowledge-bases/kb-00000001' \
 | name        | string | 是   | 知识库名称                                                    |
 | description | string | 否   | 知识库描述                                                    |
 | config      | object | 否   | 更新配置；包含 `chunking_config` / `image_processing_config` / `faq_config` / `wiki_config` / `indexing_strategy` |
+| vlm_config  | object | 否   | VLM（视觉模型）配置；省略时保持原配置，传入时更新该配置       |
 
 **请求**:
 
@@ -306,6 +307,10 @@ curl --location --request PUT 'http://localhost:8080/api/v1/knowledge-bases/b582
         "image_processing_config": {
             "model_id": ""
         }
+    },
+    "vlm_config": {
+        "enabled": true,
+        "model_id": "vllm-model-id"
     }
 }'
 ```

--- a/frontend/src/api/knowledge-base/index.ts
+++ b/frontend/src/api/knowledge-base/index.ts
@@ -119,6 +119,10 @@ export function updateKnowledgeBase(id: string, data: {
       graph_enabled: boolean;
     };
   }
+  vlm_config?: {
+    enabled: boolean;
+    model_id?: string;
+  };
 }) {
   return put(`/api/v1/knowledge-bases/${id}` , data);
 }

--- a/internal/agent/tools/query_knowledge_graph_test.go
+++ b/internal/agent/tools/query_knowledge_graph_test.go
@@ -51,6 +51,7 @@ func (s *stubKnowledgeBaseService) UpdateKnowledgeBase(
 	string,
 	string,
 	*types.KnowledgeBaseConfig,
+	*types.VLMConfig,
 ) (*types.KnowledgeBase, error) {
 	return nil, nil
 }

--- a/internal/application/service/datasource_service_test.go
+++ b/internal/application/service/datasource_service_test.go
@@ -83,7 +83,7 @@ func (s *processSyncKBService) ListKnowledgeBasesByTenantID(context.Context, uin
 	return nil, nil
 }
 func (s *processSyncKBService) UpdateKnowledgeBase(
-	context.Context, string, string, string, *types.KnowledgeBaseConfig,
+	context.Context, string, string, string, *types.KnowledgeBaseConfig, *types.VLMConfig,
 ) (*types.KnowledgeBase, error) {
 	return nil, nil
 }

--- a/internal/application/service/knowledgebase.go
+++ b/internal/application/service/knowledgebase.go
@@ -426,6 +426,7 @@ func (s *knowledgeBaseService) UpdateKnowledgeBase(ctx context.Context,
 	name string,
 	description string,
 	config *types.KnowledgeBaseConfig,
+	vlmConfig *types.VLMConfig,
 ) (*types.KnowledgeBase, error) {
 	if id == "" {
 		logger.Error(ctx, "Knowledge base ID is empty")
@@ -473,6 +474,9 @@ func (s *knowledgeBaseService) UpdateKnowledgeBase(ctx context.Context,
 				kb.ExtractConfig = &types.ExtractConfig{Enabled: true}
 			}
 		}
+	}
+	if vlmConfig != nil {
+		kb.VLMConfig = *vlmConfig
 	}
 	kb.UpdatedAt = time.Now()
 	kb.EnsureDefaults()

--- a/internal/application/service/knowledgebase_pr3_test.go
+++ b/internal/application/service/knowledgebase_pr3_test.go
@@ -161,6 +161,58 @@ func TestCreateKnowledgeBase_DefaultStorageProviderFromTenant(t *testing.T) {
 	assert.Equal(t, "cos", kbExplicit.GetStorageProvider())
 }
 
+func TestUpdateKnowledgeBase_VLMConfig(t *testing.T) {
+	repo := newFakeKBRepo()
+	repo.rows["kb-1"] = &types.KnowledgeBase{
+		ID:          "kb-1",
+		Name:        "old name",
+		Description: "old description",
+		VLMConfig: types.VLMConfig{
+			Enabled: true,
+			ModelID: "vlm-old",
+		},
+	}
+	svc := newPR3KBService(repo, &fakeRegistry{}, &fakeOwnership{})
+
+	t.Run("nil vlm_config preserves existing config", func(t *testing.T) {
+		kb, err := svc.UpdateKnowledgeBase(
+			context.Background(),
+			"kb-1",
+			"new name",
+			"new description",
+			nil,
+			nil,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "new name", kb.Name)
+		assert.Equal(t, "new description", kb.Description)
+		assert.Equal(t, types.VLMConfig{
+			Enabled: true,
+			ModelID: "vlm-old",
+		}, repo.rows["kb-1"].VLMConfig)
+	})
+
+	t.Run("provided vlm_config overwrites existing config", func(t *testing.T) {
+		kb, err := svc.UpdateKnowledgeBase(
+			context.Background(),
+			"kb-1",
+			"new name",
+			"new description",
+			nil,
+			&types.VLMConfig{
+				Enabled: true,
+				ModelID: "vlm-new",
+			},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, types.VLMConfig{
+			Enabled: true,
+			ModelID: "vlm-new",
+		}, kb.VLMConfig)
+		assert.Equal(t, kb.VLMConfig, repo.rows["kb-1"].VLMConfig)
+	})
+}
+
 // ---------------------------------------------------------------------------
 // CreateKnowledgeBase — vector_store_id binding validation matrix
 // ---------------------------------------------------------------------------

--- a/internal/handler/knowledgebase.go
+++ b/internal/handler/knowledgebase.go
@@ -794,11 +794,12 @@ type UpdateKnowledgeBaseRequest struct {
 	Name        string                     `json:"name"        binding:"required"`
 	Description string                     `json:"description"`
 	Config      *types.KnowledgeBaseConfig `json:"config"`
+	VLMConfig   *types.VLMConfig           `json:"vlm_config"`
 }
 
 // UpdateKnowledgeBase godoc
 // @Summary      更新知识库
-// @Description  更新知识库的名称、描述和配置
+// @Description  更新知识库的名称、描述、配置和多模态配置
 // @Tags         知识库
 // @Accept       json
 // @Produce      json
@@ -838,7 +839,7 @@ func (h *KnowledgeBaseHandler) UpdateKnowledgeBase(c *gin.Context) {
 		secutils.SanitizeForLog(id), secutils.SanitizeForLog(req.Name))
 
 	// Update the knowledge base
-	kb, err := h.service.UpdateKnowledgeBase(ctx, id, req.Name, req.Description, req.Config)
+	kb, err := h.service.UpdateKnowledgeBase(ctx, id, req.Name, req.Description, req.Config, req.VLMConfig)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(apperrors.NewInternalServerError(err.Error()))

--- a/internal/handler/knowledgebase_request_test.go
+++ b/internal/handler/knowledgebase_request_test.go
@@ -1,11 +1,13 @@
 package handler
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
 )
 
 // TestUpdateKBRequest_DoesNotAcceptVectorStoreID is the structural enforcement
@@ -61,4 +63,21 @@ func assertNoVectorStoreIDField(t *testing.T, typ reflect.Type) {
 		}
 	}
 	visit(typ, typ.Name())
+}
+
+func TestUpdateKBRequest_AcceptsVLMConfig(t *testing.T) {
+	payload := []byte(`{
+		"name": "kb",
+		"description": "desc",
+		"vlm_config": {
+			"enabled": true,
+			"model_id": "vlm-model-1"
+		}
+	}`)
+
+	var req UpdateKnowledgeBaseRequest
+	require.NoError(t, json.Unmarshal(payload, &req))
+	require.NotNil(t, req.VLMConfig)
+	require.True(t, req.VLMConfig.Enabled)
+	require.Equal(t, "vlm-model-1", req.VLMConfig.ModelID)
 }

--- a/internal/types/interfaces/knowledgebase.go
+++ b/internal/types/interfaces/knowledgebase.go
@@ -67,11 +67,12 @@ type KnowledgeBaseService interface {
 	//   - name: New knowledge base name
 	//   - description: New knowledge base description
 	//   - config: Knowledge base configuration, including chunking strategy, vectorization settings, etc.
+	//   - vlmConfig: Optional VLM configuration. nil means keep the existing configuration.
 	// Returns:
 	//   - Updated knowledge base object
 	//   - Possible errors such as not existing, insufficient permissions, etc.
 	UpdateKnowledgeBase(ctx context.Context,
-		id string, name string, description string, config *types.KnowledgeBaseConfig,
+		id string, name string, description string, config *types.KnowledgeBaseConfig, vlmConfig *types.VLMConfig,
 	) (*types.KnowledgeBase, error)
 
 	// DeleteKnowledgeBase deletes a knowledge base


### PR DESCRIPTION
## Description

Fixes the knowledge base update API so top-level `vlm_config` is accepted and persisted by `PUT /api/v1/knowledge-bases/{id}`.

Previously, `UpdateKnowledgeBaseRequest` did not expose `vlm_config`, so Gin ignored the field during JSON binding and the service update path never saw it. The frontend already sends `vlm_config` when editing a knowledge base, but the backend response and follow-up GET kept the old disabled VLM configuration.

This PR adds `vlm_config` to the update request DTO, passes it through the knowledge base service update path, persists it only when explicitly provided, and keeps omitted `vlm_config` requests preserving the existing KB configuration. It also syncs the Go client request type, frontend API typing, and API docs.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #1723

## Testing

- `gofmt` on changed Go files
- `go test ./internal/handler ./internal/application/service ./internal/agent/tools`
- `(cd client && go test ./...)`
- Regression coverage added for the issue path:
  - `UpdateKnowledgeBaseRequest` now binds a top-level `vlm_config` field from the update JSON body.
  - `UpdateKnowledgeBase` preserves the existing VLM config when `vlm_config` is omitted.
  - `UpdateKnowledgeBase` overwrites the stored VLM config when `vlm_config` is provided.
- Verified the #1723 API scenario against a local WeKnora Lite instance:
  - Created a temporary knowledge base with VLM disabled.
  - Sent `PUT /api/v1/knowledge-bases/{kbId}` with `{"name":"test","vlm_config":{"enabled":true,"model_id":"<vlm-model-id>"}}`.
  - Confirmed the PUT response and follow-up `GET /api/v1/knowledge-bases/{kbId}` both returned `vlm_config.enabled=true` with the same `model_id`.

## Checklist

- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation

## Screenshots / Recordings

N/A; backend API fix with no UI-visible layout change.