### PR TITLE
fix(excel): filter out image function strings from parsed content

### DIFF
--- a/docreader/parser/excel_parser.py
+++ b/docreader/parser/excel_parser.py
@@ -6,6 +6,7 @@ structured Document objects with text content and chunks. It supports multiple
 sheets and handles various Excel formats using pandas.
 """
 import logging
+import re
 from io import BytesIO
 from typing import List
 
@@ -23,6 +24,21 @@ from docreader.parser.xlsx_merge import fill_merged_cells_xlsx
 from docreader.parser.xlsx_repair import repair_xlsx_bytes
 
 logger = logging.getLogger(__name__)
+
+# Pattern to detect Excel image function strings that should be excluded from
+# parsed text content.  WPS uses =DISPIMG("ID",mode) to embed images in cells;
+# when opened by other tools the formula may appear as plain text prefixed with
+# "_xlfn." or "=".  Office 365 uses =_xlfn.IMAGE(url, ...) similarly.
+_IMAGE_FUNC_RE = re.compile(
+    r"^=?_xlfn\.(DISPIMG|IMAGE)\(", re.IGNORECASE
+)
+
+
+def _is_image_function(value: object) -> bool:
+    """Return True if *value* looks like an embedded-image function string."""
+    if not isinstance(value, str):
+        return False
+    return _IMAGE_FUNC_RE.match(value) is not None
 
 
 class ExcelParser(BaseParser):
@@ -81,7 +97,7 @@ class ExcelParser(BaseParser):
                 page_content = []
                 # Build key-value pairs for non-null values
                 for k, v in row.items():
-                    if pd.notna(v):  # Skip NaN/null values
+                    if pd.notna(v) and not _is_image_function(v):
                         page_content.append(f"{k}: {v}")
                 
                 # Skip rows with no valid content

--- a/docreader/tests/test_excel_parser.py
+++ b/docreader/tests/test_excel_parser.py
@@ -181,6 +181,75 @@ class XlsxMergeFillTest(unittest.TestCase):
         self.assertIn("D: D10", chunks[9])
 
 
+class ExcelImageFilterTest(unittest.TestCase):
+    """Tests for filtering embedded image function strings (#1779)."""
+
+    def _xlsx_with_image_functions(self) -> bytes:
+        """Create an XLSX where image functions are stored as text values.
+
+        WPS embeds images using =DISPIMG("ID",1) which may appear as plain
+        text (not a formula) in some export scenarios.
+        """
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws["A1"] = "Name"
+        ws["B1"] = "Photo"
+        ws["A2"] = "Alice"
+        ws["B2"] = '_xlfn.DISPIMG("ID_ABCDEF123",1)'
+        ws["A3"] = "Bob"
+        ws["B3"] = '_xlfn.DISPIMG("ID_GHIJKL456",1)'
+        ws["A4"] = "Charlie"
+        ws["B4"] = "real data"
+        bio = io.BytesIO()
+        wb.save(bio)
+        return bio.getvalue()
+
+    def test_dispimg_text_values_are_excluded(self):
+        """Image function strings stored as text must not appear in output."""
+        document = ExcelParser().parse_into_text(self._xlsx_with_image_functions())
+        self.assertNotIn("DISPIMG", document.content)
+        self.assertNotIn("_xlfn", document.content)
+        # Real data must still be present
+        self.assertIn("Alice", document.content)
+        self.assertIn("Bob", document.content)
+        self.assertIn("Charlie", document.content)
+        self.assertIn("real data", document.content)
+
+    def test_dispimg_with_equals_prefix(self):
+        """=_xlfn.DISPIMG(...) as text (not formula) should also be filtered."""
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws["A1"] = "Name"
+        ws["B1"] = "Photo"
+        ws["A2"] = "Alice"
+        # Stored as text with = prefix (some exporters do this)
+        ws["B2"] = '=_xlfn.DISPIMG("ID_123",1)'
+        bio = io.BytesIO()
+        wb.save(bio)
+        # Note: openpyxl treats strings starting with = as formulas,
+        # so data_only=True in fill_merged_cells_xlsx will turn them to None.
+        # This test verifies the formula path also works correctly.
+        document = ExcelParser().parse_into_text(bio.getvalue())
+        self.assertNotIn("DISPIMG", document.content)
+        self.assertIn("Alice", document.content)
+
+    def test_image_function_variations(self):
+        """Various image function patterns should all be filtered."""
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws["A1"] = '_xlfn.DISPIMG("ID_001",1)'
+        ws["A2"] = '=DISPIMG("ID_002",1)'
+        ws["A3"] = '_xlfn.IMAGE("https://example.com/img.png")'
+        ws["A4"] = '=_xlfn.IMAGE("https://example.com/img.png",1)'
+        ws["A5"] = "Normal text"
+        bio = io.BytesIO()
+        wb.save(bio)
+        document = ExcelParser().parse_into_text(bio.getvalue())
+        self.assertNotIn("DISPIMG", document.content)
+        self.assertNotIn("_xlfn.IMAGE", document.content)
+        self.assertIn("Normal text", document.content)
+
+
 class ExcelParserTest(unittest.TestCase):
     def test_parse_phantom_shared_strings_workbook(self):
         document = ExcelParser().parse_into_text(_xlsx_with_phantom_shared_strings())


### PR DESCRIPTION
## Summary

WPS embeds images in cells using `=DISPIMG("ID", mode)`. When these files are processed by openpyxl, the function string may appear as plain text (prefixed with `_xlfn.`) rather than being recognized as a formula. This causes the image function strings to be included in the RAG-indexed document content, polluting search results and AI responses.

This PR adds a regex-based filter in `ExcelParser.parse_into_text()` that detects common image function patterns and excludes matching cell values during row processing:

- `_xlfn.DISPIMG(...)` — WPS embedded images
- `_xlfn.IMAGE(...)` — Office 365 web images
- Both with optional `=` prefix

Closes #1779

## Test plan

- [x] New `ExcelImageFilterTest` with 3 cases: text-stored DISPIMG, formula-stored DISPIMG, and IMAGE() variants
- [x] All existing `test_excel_parser.py` tests pass (12 total, 2 skipped due to missing fixtures)
- [x] End-to-end verification: product catalog with DISPIMG columns correctly filters image functions while preserving real data
