### PR TITLE
fix(frontend): reflect PDF scanned parsing in upload overview

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -663,6 +663,7 @@ export default {
     summaryParentChildShort: 'Parent-child',
     summaryParserMode: 'Mode',
     summaryParserBuiltin: 'Built-in engine (default)',
+    summaryParserForceScanned: 'Scanned mode',
     summaryChunkSize: 'Chunk size',
     summaryChunkOverlap: 'Overlap',
     summaryStrategy: 'Strategy',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -668,6 +668,7 @@ export default {
     summaryParentChildShort: "부모-자식 청킹",
     summaryParserMode: "모드",
     summaryParserBuiltin: "내장 엔진(기본)",
+    summaryParserForceScanned: "스캔 문서 파싱",
     summaryChunkSize: "청크 크기",
     summaryChunkOverlap: "겹침",
     summaryStrategy: "전략",
@@ -706,6 +707,10 @@ export default {
     asrRequiredForAudio: "꺼짐(이 배치에 오디오 포함)",
     vlmModelSelectRequired: "멀티모달이 활성화되었습니다. VLM 모델을 선택하세요",
     asrModelSelectRequired: "음성 인식이 활성화되었습니다. ASR 모델을 선택하세요",
+    pdfForceScanned: {
+      label: "스캔 PDF로 파싱",
+      description: "웹 인쇄, 스캔본, 이미지 위주 PDF에 적합합니다. 모든 페이지를 이미지로 렌더링한 뒤 OCR/VLM으로 처리합니다. 처리 시간과 모델 호출 비용이 늘어날 수 있습니다."
+    },
     continueAdd: "계속 추가",
     addMoreFiles: "파일 더 추가",
     addMoreFolder: "폴더에서 더 추가",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -632,6 +632,7 @@ export default {
     summaryParentChildShort: 'Родительско-дочернее',
     summaryParserMode: 'Режим',
     summaryParserBuiltin: 'Встроенный движок (по умолчанию)',
+    summaryParserForceScanned: 'режим скана',
     summaryChunkSize: 'Размер чанка',
     summaryChunkOverlap: 'Перекрытие',
     summaryStrategy: 'Стратегия',
@@ -670,6 +671,10 @@ export default {
     asrRequiredForAudio: 'Выкл. (в партии есть аудио)',
     vlmModelSelectRequired: 'Мультимодальность включена. Выберите модель VLM.',
     asrModelSelectRequired: 'Распознавание речи включено. Выберите модель ASR.',
+    pdfForceScanned: {
+      label: 'Разбор PDF как сканированного документа',
+      description: 'Подходит для PDF с веб-печати, сканов и документов с большим числом изображений. Каждая страница будет отрендерена в изображение и обработана через OCR/VLM. Может увеличить время обработки и расходы на модели.'
+    },
     continueAdd: 'Добавить ещё',
     addMoreFiles: 'Добавить файлы',
     addMoreFolder: 'Добавить из папки',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -666,6 +666,7 @@ export default {
     summaryParentChildShort: "父子分块",
     summaryParserMode: "模式",
     summaryParserBuiltin: "内置引擎（默认）",
+    summaryParserForceScanned: "扫描件解析",
     summaryChunkSize: "分块大小",
     summaryChunkOverlap: "重叠",
     summaryStrategy: "策略",

--- a/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
+++ b/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
@@ -455,14 +455,21 @@ const hasPdf = computed(() => {
 
 function resolveEngineForExt(ext: string): string {
   const rules = uiState.value.chunkingConfig.parserEngineRules
+  let engineKey = 'builtin'
+  let name = t('uploadConfirm.summaryParserBuiltin')
   if (rules?.length) {
     for (const rule of rules) {
       if (rule.file_types.includes(ext)) {
-        return getEngineDisplayName(rule.engine)
+        engineKey = rule.engine
+        name = getEngineDisplayName(rule.engine)
+        break
       }
     }
   }
-  return t('uploadConfirm.summaryParserBuiltin')
+  if (ext === 'pdf' && uiState.value.pdfForceScanned && engineKey === 'builtin') {
+    return `${name} · ${t('uploadConfirm.summaryParserForceScanned')}`
+  }
+  return name
 }
 
 const parserOverviewValue = computed(() => {


### PR DESCRIPTION
## Summary
- Show force-scanned PDF mode in the upload confirmation parser overview (e.g. `.pdf → 内置 · 扫描件解析`) when the toggle is enabled for builtin PDF uploads.
- Add missing `uploadConfirm.pdfForceScanned` strings for ko-KR and ru-RU.
- Add `uploadConfirm.summaryParserForceScanned` across all locales for the overview suffix.

## Test plan
- [ ] Upload a PDF with builtin parser, enable「按扫描件解析 PDF」, return to overview and confirm parser line shows scanned mode.
- [ ] Disable the toggle and confirm overview reverts to `.pdf → 内置` only.
- [ ] Switch UI language to ko-KR / ru-RU and verify toggle label/description render correctly.