### PR TITLE
fix(frontend): hide redundant card badges when section headers apply

### DIFF
--- a/frontend/src/utils/card-list-badge.ts
+++ b/frontend/src/utils/card-list-badge.ts
@@ -1,0 +1,49 @@
+/**
+ * Helpers to suppress card corner badges that repeat what a visible section
+ * header (Group) already communicates.
+ */
+
+export type ListCardSectionKey =
+  | 'pinned'
+  | 'mine'
+  | 'tenantOthers'
+  | 'builtin'
+  | 'sharedByMe'
+  | 'sharedEditable'
+  | 'sharedReadonly'
+  | 'created'
+  | 'joined'
+
+export type ResourceOriginVariant = 'mine' | 'tenant' | 'creator' | 'space' | 'shared'
+
+/** ResourceOriginBadge on KB / Agent cards. */
+export function shouldShowResourceOriginBadge(opts: {
+  section: ListCardSectionKey | null
+  variant: ResourceOriginVariant
+  creatorName?: string
+  showSectionHeaders?: boolean
+}): boolean {
+  if (!opts.showSectionHeaders) return true
+
+  const { section, variant, creatorName } = opts
+  const hasCreator = Boolean(creatorName?.trim())
+
+  if (section === 'mine' && variant === 'mine') return false
+  if (section === 'builtin') return false
+  if (section === 'tenantOthers' && variant === 'creator' && !hasCreator) return false
+
+  return true
+}
+
+/** Owner / role tag on organization cards. */
+export function shouldShowOrgRelationTag(opts: {
+  spaceSelection: 'all' | 'created' | 'joined'
+  isOwner: boolean
+  myRole?: string
+}): boolean {
+  if (opts.spaceSelection === 'created') return false
+  if (opts.spaceSelection === 'joined' && !opts.myRole) return false
+  if (opts.spaceSelection === 'all' && opts.isOwner) return false
+  if (opts.spaceSelection === 'all' && !opts.isOwner && !opts.myRole) return false
+  return true
+}

--- a/frontend/src/views/agent/AgentList.vue
+++ b/frontend/src/views/agent/AgentList.vue
@@ -296,11 +296,11 @@
                   <img src="@/assets/img/organization-green.svg" class="org-icon" alt="" aria-hidden="true" />
                   <span class="org-source-text">{{ agent.org_name }}</span>
                 </div>
-                <div v-else-if="agent.is_builtin" class="builtin-badge">
+                <div v-else-if="showAgentBuiltinBadge(agent)" class="builtin-badge">
                   <t-icon name="lock-on" size="12px" />
                   <span>{{ $t('agent.builtin') }}</span>
                 </div>
-                <ResourceOriginBadge v-else :variant="agentOriginVariant(agent)"
+                <ResourceOriginBadge v-else-if="showAgentOriginBadge(agent)" :variant="agentOriginVariant(agent)"
                   :creator-name="(agent as any).creator_name" />
               </div>
             </div>
@@ -483,11 +483,11 @@
                   </div>
                 </div>
                 <!-- 右下角：内置 / 来源徽章（我创建 / 同租户其他成员） -->
-                <div v-if="agent.is_builtin" class="builtin-badge">
+                <div v-if="showAgentBuiltinBadge(agent)" class="builtin-badge">
                   <t-icon name="lock-on" size="12px" />
                   <span>{{ $t('agent.builtin') }}</span>
                 </div>
-                <ResourceOriginBadge v-else :variant="agentOriginVariant(agent)"
+                <ResourceOriginBadge v-else-if="showAgentOriginBadge(agent)" :variant="agentOriginVariant(agent)"
                   :creator-name="(agent as any).creator_name" />
               </div>
             </div>
@@ -630,11 +630,6 @@
                       <div class="feature-badge multi-turn"><t-icon name="chat-bubble" size="16px" /></div>
                     </t-tooltip>
                   </div>
-                </div>
-                <!-- 右下角：空间图标+名称 -->
-                <div class="card-bottom-source">
-                  <img src="@/assets/img/organization-green.svg" class="org-icon" alt="" aria-hidden="true" />
-                  <span class="org-source-text">{{ shared.org_name }}</span>
                 </div>
               </div>
             </div>
@@ -839,6 +834,7 @@ import { useUIStore } from '@/stores/ui'
 import AgentAvatar from '@/components/AgentAvatar.vue'
 import ListSpaceSidebar from '@/components/ListSpaceSidebar.vue'
 import ResourceOriginBadge from '@/components/ResourceOriginBadge.vue'
+import { shouldShowResourceOriginBadge } from '@/utils/card-list-badge'
 import { useAuthStore } from '@/stores/auth'
 import { useListUrlState } from '@/composables/useListUrlState'
 import { useResourcePins } from '@/composables/useResourcePins'
@@ -1345,6 +1341,24 @@ function isMyAgent(agent: { created_by?: string }): boolean {
 // 内建 agent 走 v-else 前的 builtin 分支，到不了这里。
 function agentOriginVariant(agent: { created_by?: string }): 'mine' | 'creator' {
   return isMyAgent(agent) ? 'mine' : 'creator'
+}
+
+function showAgentOriginBadge(agent: { created_by?: string; creator_name?: string }): boolean {
+  return shouldShowResourceOriginBadge({
+    section: agentSectionOf(agent),
+    variant: agentOriginVariant(agent),
+    creatorName: (agent as any).creator_name,
+    showSectionHeaders: showShareGroupHeaders.value,
+  })
+}
+
+function showAgentBuiltinBadge(agent: { is_builtin?: boolean }): boolean {
+  if (!agent.is_builtin) return false
+  return shouldShowResourceOriginBadge({
+    section: agentSectionOf(agent),
+    variant: 'mine',
+    showSectionHeaders: showShareGroupHeaders.value,
+  })
 }
 
 // 共享 agent 的可编辑/只读分组开关，与 KB 列表逻辑保持一致：仅对

--- a/frontend/src/views/knowledge/KnowledgeBaseList.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseList.vue
@@ -279,7 +279,7 @@
                     </t-tooltip>
                   </div>
                 </div>
-                <div v-if="!authStore.isLiteMode" class="bottom-right">
+                <div v-if="!authStore.isLiteMode && showKbOriginBadge(kb)" class="bottom-right">
                   <ResourceOriginBadge :variant="kbOriginVariant(kb)" :creator-name="kb.creator_name" />
                 </div>
               </div>
@@ -504,7 +504,7 @@
                     </t-tooltip>
                   </div>
                 </div>
-                <div v-if="!authStore.isLiteMode" class="bottom-right">
+                <div v-if="!authStore.isLiteMode && showKbOriginBadge(kb)" class="bottom-right">
                   <ResourceOriginBadge :variant="kbOriginVariant(kb)" :creator-name="kb.creator_name" />
                 </div>
               </div>
@@ -603,15 +603,6 @@
                       </div>
                     </t-tooltip>
                   </div>
-                </div>
-                <div class="bottom-right">
-                  <t-tooltip :content="shared.org_name" placement="top">
-                    <div class="org-source">
-                      <img src="@/assets/img/organization-green.svg" class="org-source-icon" alt=""
-                        aria-hidden="true" />
-                      <span>{{ shared.org_name }}</span>
-                    </div>
-                  </t-tooltip>
                 </div>
               </div>
             </div>
@@ -783,6 +774,7 @@ import KnowledgeBaseEditorModal from './KnowledgeBaseEditorModal.vue'
 import ShareKnowledgeBaseDialog from '@/components/ShareKnowledgeBaseDialog.vue'
 import ListSpaceSidebar from '@/components/ListSpaceSidebar.vue'
 import ResourceOriginBadge from '@/components/ResourceOriginBadge.vue'
+import { shouldShowResourceOriginBadge } from '@/utils/card-list-badge'
 import ContextualGuide from '@/components/ContextualGuide.vue'
 import { isContextualGuideDone, markContextualGuideDone } from '@/config/contextualGuides'
 import { useTenantModelReadiness } from '@/composables/useTenantModelReadiness'
@@ -1359,6 +1351,15 @@ function isMyKb(kb: { creator_id?: string }): boolean {
 //     resourceOrigin.tenant 文案（"本空间"），不会出现空标签。
 function kbOriginVariant(kb: { creator_id?: string }): 'mine' | 'creator' {
   return isMyKb(kb) ? 'mine' : 'creator'
+}
+
+function showKbOriginBadge(kb: { creator_id?: string; creator_name?: string }): boolean {
+  return shouldShowResourceOriginBadge({
+    section: kbSectionOf(kb),
+    variant: kbOriginVariant(kb),
+    creatorName: kb.creator_name,
+    showSectionHeaders: showShareGroupHeaders.value,
+  })
 }
 
 // 通过 ID 处理设置（用于全部 Tab 下的知识库）

--- a/frontend/src/views/organization/OrganizationList.vue
+++ b/frontend/src/views/organization/OrganizationList.vue
@@ -161,7 +161,7 @@
                     $t('organization.settings.pendingReview') }}</span>
                 </t-tooltip>
               </div>
-              <div class="bottom-right">
+              <div v-if="showOrgRelationTag(org)" class="bottom-right">
                 <div class="relation-role-tag" :class="org.is_owner ? 'owner' : (org.my_role || '')">
                   <t-icon :name="org.is_owner ? 'usergroup-add' : 'usergroup'" size="14px" />
                   <span>{{ org.is_owner ? $t('organization.owner') : (org.my_role ?
@@ -557,6 +557,7 @@ import { useI18n } from 'vue-i18n'
 import OrganizationSettingsModal from './OrganizationSettingsModal.vue'
 import SpaceAvatar from '@/components/SpaceAvatar.vue'
 import ListSpaceSidebar from '@/components/ListSpaceSidebar.vue'
+import { shouldShowOrgRelationTag } from '@/utils/card-list-badge'
 
 interface OrgWithUI extends Organization {
   showMore?: boolean
@@ -808,6 +809,14 @@ const orgSectionCounts = computed<Record<OrgSectionKey, number>>(() => {
   filteredOrganizations.value.forEach(o => { c[orgSectionOf(o)]++ })
   return c
 })
+
+function showOrgRelationTag(org: { is_owner?: boolean; my_role?: string }): boolean {
+  return shouldShowOrgRelationTag({
+    spaceSelection: spaceSelection.value,
+    isOwner: !!org.is_owner,
+    myRole: org.my_role,
+  })
+}
 
 const emptyStateTitle = computed(() => {
   if (spaceSelection.value === 'created') return t('organization.emptyCreated')


### PR DESCRIPTION
## Summary
- Add shared `card-list-badge` helpers to suppress corner badges that repeat visible list section headers.
- Hide redundant origin/builtin badges on knowledge base and agent cards (e.g. "我创建" under the "我创建的" group).
- Hide redundant owner/joined role tags on organization cards when the sidebar filter or section header already conveys the relationship.
- Remove duplicate org-name pills when browsing resources filtered to a single shared space.

## Test plan
- [ ] Open Knowledge Bases → All: cards under "我创建的" no longer show a duplicate "我创建" badge; cards under "本空间 · 仅查看" still show creator names when available.
- [ ] Open Agents → All / Mine: builtin and mine badges are hidden inside their respective section groups.
- [ ] Open Organizations → All: owner/joined tags are hidden when redundant; specific roles (e.g. admin) still show in joined spaces.
- [ ] Filter KB/Agent lists by a single shared space: bottom-right org name is no longer repeated on every card.