### PR TITLE
fix(search): use computed matchCount for final truncation in HybridSearch

### DIFF
--- a/internal/application/service/knowledgebase_search.go
+++ b/internal/application/service/knowledgebase_search.go
@@ -247,8 +247,8 @@ func (s *knowledgeBaseService) HybridSearch(ctx context.Context,
 		return nil, err
 	}
 
-	if len(deduplicatedChunks) > params.MatchCount {
-		deduplicatedChunks = deduplicatedChunks[:params.MatchCount]
+	if len(deduplicatedChunks) > matchCount {
+		deduplicatedChunks = deduplicatedChunks[:matchCount]
 	}
 
 	return s.processSearchResults(ctx, deduplicatedChunks, params.SkipContextEnrichment)


### PR DESCRIPTION
## Summary

- Fix HybridSearch returning empty results when `match_count` is omitted from the request
- The retrieval step correctly defaults to a floor of 50 when `match_count` is 0, but the final truncation at the end of `HybridSearch` used the raw `params.MatchCount` (which is 0), slicing results to nothing
- Use the already-computed `matchCount` for the final truncation, consistent with how it is used for over-retrieval upstream

## Bug

When `match_count` is not passed in the request body, `params.MatchCount` defaults to Go's zero value (`0`). The over-retrieval logic at line 151 correctly computes:

```go
matchCount := max(params.MatchCount*5, 50) * len(searchKBIDs) // = 50
```

But the final truncation at line 250 uses the raw param:

```go
deduplicatedChunks = deduplicatedChunks[:params.MatchCount] // = [:0] → empty
```

## Fix

Change the final truncation to use the computed `matchCount` instead of `params.MatchCount`.

## Test plan

- [x] Call `POST /api/v1/knowledge-bases/{id}/hybrid-search` without `match_count` and verify results are returned
- [x] Call with `match_count: 10` and verify exactly up to 10 results are returned
- [x] Call with `match_count: 0` explicitly and verify behavior (should use default floor)