### PR TITLE
test: fix stale Doris SQL-shape and flaky OSS bucket assertions

### DIFF
--- a/internal/application/repository/retriever/doris/repository_test.go
+++ b/internal/application/repository/retriever/doris/repository_test.go
@@ -265,8 +265,10 @@ func TestVectorRetrieve_SQLShape(t *testing.T) {
 		WithArgs("weknora", "weknora_embeddings_3").
 		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(1))
 
-	mock.ExpectQuery(`SELECT id, content, .*inner_product_approximate.*HAVING score >= \? ORDER BY score DESC LIMIT \?`).
-		WithArgs(true, 0.5, 5).
+	// Doris does not support placeholders for LIMIT, so TopK is inlined as a
+	// literal and is not a bound argument.
+	mock.ExpectQuery(`SELECT id, content, .*inner_product_approximate.*HAVING score >= \? ORDER BY score DESC LIMIT \d+`).
+		WithArgs(true, 0.5).
 		WillReturnRows(
 			sqlmock.NewRows([]string{
 				"id", "content", "source_id", "source_type",
@@ -298,8 +300,8 @@ func TestVectorRetrieve_SQLShape_LegacyMode(t *testing.T) {
 		WithArgs("weknora", "weknora_embeddings_3").
 		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(1))
 
-	mock.ExpectQuery(`SELECT id, content, .*cosine_distance_approximate.*HAVING score >= \? ORDER BY score DESC LIMIT \?`).
-		WithArgs(true, 0.5, 5).
+	mock.ExpectQuery(`SELECT id, content, .*cosine_distance_approximate.*HAVING score >= \? ORDER BY score DESC LIMIT \d+`).
+		WithArgs(true, 0.5).
 		WillReturnRows(
 			sqlmock.NewRows([]string{
 				"id", "content", "source_id", "source_type",
@@ -345,8 +347,10 @@ func TestKeywordsRetrieve_SQLShape(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).
 			AddRow("weknora_embeddings_768"))
 
+	// LIMIT is inlined (see VectorRetrieve), so only is_enabled and the
+	// MATCH_ANY query string are bound arguments.
 	mock.ExpectQuery(`MATCH_ANY \?`).
-		WithArgs(true, "你好", 3).
+		WithArgs(true, "你好").
 		WillReturnRows(
 			sqlmock.NewRows([]string{
 				"id", "content", "source_id", "source_type",

--- a/internal/application/service/file/oss_test.go
+++ b/internal/application/service/file/oss_test.go
@@ -192,8 +192,11 @@ func TestOssEnsureBucket_CreateFails(t *testing.T) {
 		t.Fatalf("newOSSClient() error: %v", err)
 	}
 
-	// Should fail with invalid credentials
-	err = ossEnsureBucket(client, "test-bucket")
+	// Use a bucket that does not exist so IsBucketExist returns false and the
+	// create path is exercised; with invalid credentials PutBucket then fails.
+	// A common name like "test-bucket" already exists globally on OSS, which
+	// would short-circuit at IsBucketExist and make this assertion flaky.
+	err = ossEnsureBucket(client, "weknora-nonexistent-bucket-create-fails-12345")
 	if err == nil {
 		t.Error("ossEnsureBucket with invalid credentials should return an error")
 	}


### PR DESCRIPTION
## Summary

- Fix two pre-existing, unrelated test failures that are red on `main`.
- `Doris` SQL-shape tests: production `VectorRetrieve`/`KeywordsRetrieve` inline `LIMIT` as a literal because Doris does not support placeholders for `LIMIT`/`OFFSET`. The tests still expected `LIMIT ?` with `TopK` as a bound argument, so they failed. Match the literal `LIMIT` and drop the extra arg.
- `TestOssEnsureBucket_CreateFails`: it used bucket name `test-bucket`, which already exists globally on OSS, so `IsBucketExist` short-circuited and returned `nil` instead of exercising the create path. Use a non-existent bucket name so the create-with-invalid-credentials path actually runs and returns an error.

These are test-only changes; no production behavior is modified.

## Test plan

- [ ] `go test ./internal/application/repository/retriever/doris/`
- [ ] `go test ./internal/application/service/file/`