### PR TITLE
feat(knowledge): ingest local files via file:// URLs (opt-in allowlist)

### DIFF
--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -540,14 +540,36 @@ func (s *knowledgeService) createKnowledgeFromFileURL(
 		return nil, err
 	}
 
-	// Validate URL format and security (static check only, no HEAD request)
-	if !isValidURL(fileURL) || !secutils.IsValidURL(fileURL) {
-		logger.Error(ctx, "Invalid or unsafe file URL format")
+	// Validate URL format and security (static check only, no HEAD request).
+	// `isValidURL` is the local format gate (http/https/file). `secutils.IsValidURL`
+	// is a broader allow-list shaped for network destinations + length /
+	// character checks. file:// URLs intentionally skip the latter — their
+	// security envelope is enforced separately by resolveLocalFileURL
+	// against the WEKNORA_LOCAL_FILE_URL_ROOTS allowlist below.
+	if !isValidURL(fileURL) {
+		logger.Error(ctx, "Invalid file URL format")
 		return nil, ErrInvalidURL
 	}
-	if err := secutils.ValidateURLForSSRF(fileURL); err != nil {
-		logger.Errorf(ctx, "File URL rejected for SSRF protection: %s, err: %v", fileURL, err)
-		return nil, ErrInvalidURL
+	if isLocalFileURL(fileURL) {
+		// file:// URLs don't have an HTTP hostname, so the network-oriented
+		// SSRF check would reject them. Their security policy is the
+		// WEKNORA_LOCAL_FILE_URL_ROOTS allowlist enforced inside
+		// resolveLocalFileURL (called by readLocalFileURL at fetch time);
+		// validate it eagerly here so we fail closed before creating the
+		// knowledge row.
+		if _, err := resolveLocalFileURL(fileURL); err != nil {
+			logger.Errorf(ctx, "Local file URL rejected: %s, err: %v", fileURL, err)
+			return nil, ErrInvalidURL
+		}
+	} else {
+		if !secutils.IsValidURL(fileURL) {
+			logger.Error(ctx, "Unsafe file URL format")
+			return nil, ErrInvalidURL
+		}
+		if err := secutils.ValidateURLForSSRF(fileURL); err != nil {
+			logger.Errorf(ctx, "File URL rejected for SSRF protection: %s, err: %v", fileURL, err)
+			return nil, ErrInvalidURL
+		}
 	}
 
 	// Resolve fileName: user-provided > extracted from URL path

--- a/internal/application/service/knowledge_localfileurl_test.go
+++ b/internal/application/service/knowledge_localfileurl_test.go
@@ -1,0 +1,190 @@
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withLocalFileURLRoots resets the sync.Once + roots slice, sets the env
+// to `dirs` (colon-joined), and triggers a fresh load. Tests must call
+// the returned cleanup to restore previous state — sync.Once is reset
+// again so other tests aren't affected by this one's env.
+func withLocalFileURLRoots(t *testing.T, dirs ...string) func() {
+	t.Helper()
+	prevEnv, prevSet := os.LookupEnv("WEKNORA_LOCAL_FILE_URL_ROOTS")
+	prevOnce := localFileURLRootsOnce
+	prevRoots := localFileURLRoots
+
+	localFileURLRootsOnce = sync.Once{}
+	localFileURLRoots = nil
+	require.NoError(t, os.Setenv("WEKNORA_LOCAL_FILE_URL_ROOTS", strings.Join(dirs, string(os.PathListSeparator))))
+	// Force load now so the test gets a deterministic snapshot.
+	localFileURLRootsOnce.Do(loadLocalFileURLRoots)
+
+	return func() {
+		if prevSet {
+			_ = os.Setenv("WEKNORA_LOCAL_FILE_URL_ROOTS", prevEnv)
+		} else {
+			_ = os.Unsetenv("WEKNORA_LOCAL_FILE_URL_ROOTS")
+		}
+		localFileURLRootsOnce = prevOnce
+		localFileURLRoots = prevRoots
+	}
+}
+
+// TestResolveLocalFileURL_DisabledByDefault asserts that without the env
+// var the feature stays off — protecting fresh deployments from
+// accidental LFI even if a frontend tries to fall back to file:// URLs.
+func TestResolveLocalFileURL_DisabledByDefault(t *testing.T) {
+	prev, set := os.LookupEnv("WEKNORA_LOCAL_FILE_URL_ROOTS")
+	_ = os.Unsetenv("WEKNORA_LOCAL_FILE_URL_ROOTS")
+	prevOnce := localFileURLRootsOnce
+	prevRoots := localFileURLRoots
+	localFileURLRootsOnce = sync.Once{}
+	localFileURLRoots = nil
+	t.Cleanup(func() {
+		if set {
+			_ = os.Setenv("WEKNORA_LOCAL_FILE_URL_ROOTS", prev)
+		}
+		localFileURLRootsOnce = prevOnce
+		localFileURLRoots = prevRoots
+	})
+
+	_, err := resolveLocalFileURL("file:///tmp/anything.html")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "WEKNORA_LOCAL_FILE_URL_ROOTS",
+		"error message should point operators at the env var that enables this")
+}
+
+// TestResolveLocalFileURL_AllowedPath: a file inside the configured root
+// canonicalises and is returned.
+func TestResolveLocalFileURL_AllowedPath(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "sub", "doc.html")
+	require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
+	require.NoError(t, os.WriteFile(target, []byte("<html>ok</html>"), 0o644))
+
+	defer withLocalFileURLRoots(t, root)()
+
+	got, err := resolveLocalFileURL("file://" + target)
+	require.NoError(t, err)
+	// EvalSymlinks may normalise /private prefix on macOS — compare via
+	// EvalSymlinks on both sides.
+	want, _ := filepath.EvalSymlinks(target)
+	assert.Equal(t, want, got)
+}
+
+// TestResolveLocalFileURL_RejectsTraversal: ../ escape is blocked.
+func TestResolveLocalFileURL_RejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	defer withLocalFileURLRoots(t, root)()
+
+	// Try to read /etc/hosts via a traversal-encoded path. The path is
+	// canonicalised first, so this becomes /etc/hosts which is outside
+	// the temp root.
+	_, err := resolveLocalFileURL("file://" + root + "/../../../../../etc/hosts")
+	require.Error(t, err)
+	assert.True(t,
+		strings.Contains(err.Error(), "not under any") ||
+			strings.Contains(err.Error(), "evaluate symlinks"),
+		"expected rejection or symlink-resolve error, got: %v", err)
+}
+
+// TestResolveLocalFileURL_RejectsOutsideRoot: an absolute path outside
+// any configured root is rejected even without traversal markers.
+func TestResolveLocalFileURL_RejectsOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	other := t.TempDir() // a different temp dir not in the allowlist
+	target := filepath.Join(other, "secret.txt")
+	require.NoError(t, os.WriteFile(target, []byte("secret"), 0o600))
+
+	defer withLocalFileURLRoots(t, root)()
+
+	_, err := resolveLocalFileURL("file://" + target)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not under any")
+}
+
+// TestResolveLocalFileURL_RejectsSymlinkEscape: a symlink inside the
+// allowed root that points outside the root is rejected — this is the
+// key reason resolveLocalFileURL calls EvalSymlinks before the prefix
+// check.
+func TestResolveLocalFileURL_RejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	outsideFile := filepath.Join(outside, "secret.txt")
+	require.NoError(t, os.WriteFile(outsideFile, []byte("secret"), 0o600))
+
+	// Place a symlink inside `root` that points to a file outside.
+	linkPath := filepath.Join(root, "escape.html")
+	require.NoError(t, os.Symlink(outsideFile, linkPath))
+
+	defer withLocalFileURLRoots(t, root)()
+
+	_, err := resolveLocalFileURL("file://" + linkPath)
+	require.Error(t, err, "symlink escape must be rejected")
+	assert.Contains(t, err.Error(), "not under any")
+}
+
+// TestResolveLocalFileURL_RejectsRemoteHost: file://server/share-style
+// URLs are not allowed (would be a remote SMB import path on Windows).
+func TestResolveLocalFileURL_RejectsRemoteHost(t *testing.T) {
+	root := t.TempDir()
+	defer withLocalFileURLRoots(t, root)()
+
+	_, err := resolveLocalFileURL("file://otherhost/etc/passwd")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-local host")
+}
+
+// TestResolveLocalFileURL_LocalhostAccepted: file://localhost/<path> is
+// equivalent to file:///<path>.
+func TestResolveLocalFileURL_LocalhostAccepted(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "doc.html")
+	require.NoError(t, os.WriteFile(target, []byte("ok"), 0o644))
+
+	defer withLocalFileURLRoots(t, root)()
+
+	got, err := resolveLocalFileURL("file://localhost" + target)
+	require.NoError(t, err)
+	want, _ := filepath.EvalSymlinks(target)
+	assert.Equal(t, want, got)
+}
+
+// TestReadLocalFileURL_PopulatesFilenameAndType: round-trip through the
+// integration point downloadFileFromURL uses (file:// short-circuit).
+func TestReadLocalFileURL_PopulatesFilenameAndType(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "page.html")
+	body := []byte("<html><body><h1>Hi</h1></body></html>")
+	require.NoError(t, os.WriteFile(target, body, 0o644))
+
+	defer withLocalFileURLRoots(t, root)()
+
+	var name, typ string
+	got, err := readLocalFileURL(context.Background(), "file://"+target, &name, &typ)
+	require.NoError(t, err)
+	assert.Equal(t, body, got)
+	assert.Equal(t, "page.html", name)
+	assert.Equal(t, "html", typ)
+}
+
+// TestIsValidURL_AcceptsFileScheme proves the URL-shape gate is in sync
+// with the local-file path so a file:// URL doesn't get blocked at the
+// service entrypoint before reaching resolveLocalFileURL.
+func TestIsValidURL_AcceptsFileScheme(t *testing.T) {
+	assert.True(t, isValidURL("file:///tmp/x.html"))
+	assert.True(t, isValidURL("file://localhost/tmp/x.html"))
+	assert.True(t, isValidURL("https://example.com/x.html"))
+	assert.False(t, isValidURL("ftp://example.com/x.html"))
+	assert.False(t, isValidURL("/tmp/x.html"))
+	assert.False(t, isValidURL(""))
+}

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -2817,8 +2817,24 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 	var chunks []types.ParsedChunk
 
 	if payload.FileURL != "" {
-		// file_url import: SSRF re-check (防 DNS 重绑定), download, persist, then delegate to convert()
-		if err := secutils.ValidateURLForSSRF(payload.FileURL); err != nil {
+		// file_url import: re-check the URL inside the async worker as a
+		// defence against DNS rebinding (the SSRF check at request time
+		// resolves the hostname against the *current* DNS state; an
+		// attacker could swap the answer between create-time and fetch
+		// time). For file:// URLs the SSRF model doesn't apply — instead
+		// re-validate against WEKNORA_LOCAL_FILE_URL_ROOTS so a config
+		// change that tightens the allowlist between create-time and
+		// fetch-time is enforced too.
+		if isLocalFileURL(payload.FileURL) {
+			if _, err := resolveLocalFileURL(payload.FileURL); err != nil {
+				logger.Errorf(ctx, "Local file URL rejected in ProcessDocument: %s, err: %v", payload.FileURL, err)
+				knowledge.ParseStatus = "failed"
+				knowledge.ErrorMessage = "Local file URL is not allowed by WEKNORA_LOCAL_FILE_URL_ROOTS"
+				knowledge.UpdatedAt = time.Now()
+				s.repo.UpdateKnowledge(ctx, knowledge)
+				return nil
+			}
+		} else if err := secutils.ValidateURLForSSRF(payload.FileURL); err != nil {
 			logger.Errorf(ctx, "File URL rejected for SSRF protection in ProcessDocument: %s, err: %v", payload.FileURL, err)
 			knowledge.ParseStatus = "failed"
 			knowledge.ErrorMessage = "File URL is not allowed for security reasons"

--- a/internal/application/service/knowledge_util.go
+++ b/internal/application/service/knowledge_util.go
@@ -8,8 +8,11 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
@@ -44,7 +47,162 @@ func isValidURL(url string) bool {
 	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
 		return true
 	}
+	// file:// is recognised as a syntactically-valid URL here. Whether the
+	// path is actually allowed to be read is gated by the
+	// WEKNORA_LOCAL_FILE_URL_ROOTS allowlist (see resolveLocalFileURL).
+	if strings.HasPrefix(url, "file://") {
+		return true
+	}
 	return false
+}
+
+// isLocalFileURL reports whether the rawURL uses the file:// scheme.
+//
+// Used to branch the URL-import path between remote HTTP fetch and local
+// filesystem read. file:// imports are opt-in: even when this returns true,
+// resolveLocalFileURL still rejects the path unless the operator has set
+// WEKNORA_LOCAL_FILE_URL_ROOTS to whitelist allowed prefixes.
+func isLocalFileURL(rawURL string) bool {
+	return strings.HasPrefix(rawURL, "file://")
+}
+
+var (
+	localFileURLRootsOnce sync.Once
+	localFileURLRoots     []string // canonical absolute paths, symlinks resolved if possible
+)
+
+// loadLocalFileURLRoots parses WEKNORA_LOCAL_FILE_URL_ROOTS (colon-separated,
+// path-list-separator on Windows, ~ expanded) once per process. Empty / unset
+// leaves localFileURLRoots empty, which disables file:// imports.
+func loadLocalFileURLRoots() {
+	raw := strings.TrimSpace(os.Getenv("WEKNORA_LOCAL_FILE_URL_ROOTS"))
+	if raw == "" {
+		return
+	}
+	home, _ := os.UserHomeDir()
+	for _, p := range strings.Split(raw, string(os.PathListSeparator)) {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		// Expand ~ / ~/ — common operator convenience.
+		if p == "~" {
+			if home != "" {
+				p = home
+			}
+		} else if strings.HasPrefix(p, "~/") && home != "" {
+			p = filepath.Join(home, p[2:])
+		}
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			continue
+		}
+		// Resolve symlinks on the root itself so the per-request EvalSymlinks
+		// comparison below sees a canonical path on both sides.
+		if real, err := filepath.EvalSymlinks(abs); err == nil {
+			abs = real
+		}
+		localFileURLRoots = append(localFileURLRoots, abs)
+	}
+}
+
+// resolveLocalFileURL parses a file:// URL, validates it against the
+// WEKNORA_LOCAL_FILE_URL_ROOTS allowlist, resolves symlinks, and returns
+// the canonical filesystem path.
+//
+// Behaviour:
+//   - WEKNORA_LOCAL_FILE_URL_ROOTS unset / empty → returns an error
+//     (feature disabled by default; the explicit allowlist makes the
+//     policy decision visible in deployment config).
+//   - URL host must be empty or "localhost"; remote SMB-style file://host/...
+//     URLs are rejected.
+//   - Path is canonicalised (filepath.Abs + filepath.Clean) and symlinks
+//     are resolved. The resolved path must sit underneath at least one of
+//     the configured root prefixes; this catches both "../" traversal and
+//     "symlink inside the allowed root that points outside" tricks.
+//
+// LocalHub deployments run the backend with the same UID as the operator,
+// so an LFI here exposes only files the operator can already read from a
+// shell. The allowlist is still required because (a) it surfaces the policy
+// choice explicitly, (b) it prevents accidental exposure when this fork is
+// repackaged into a multi-user service, and (c) it keeps the blast radius
+// of any future bug in this code path bounded to a known directory set.
+func resolveLocalFileURL(rawURL string) (string, error) {
+	localFileURLRootsOnce.Do(loadLocalFileURLRoots)
+	if len(localFileURLRoots) == 0 {
+		return "", fmt.Errorf("local file URL import is disabled; set WEKNORA_LOCAL_FILE_URL_ROOTS to a colon-separated list of allowed directory prefixes to enable")
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid file URL: %w", err)
+	}
+	if u.Scheme != "file" {
+		return "", fmt.Errorf("expected file:// scheme, got %q", u.Scheme)
+	}
+	// file:// may carry an empty host (file:///path) or "localhost"
+	// (file://localhost/path). Anything else (e.g. SMB-style file://host/share)
+	// is rejected.
+	if u.Host != "" && u.Host != "localhost" {
+		return "", fmt.Errorf("file URL with non-local host is not allowed: %q", u.Host)
+	}
+	rawPath := u.Path
+	if rawPath == "" {
+		return "", fmt.Errorf("empty file URL path")
+	}
+	cleaned, err := filepath.Abs(filepath.Clean(rawPath))
+	if err != nil {
+		return "", fmt.Errorf("resolve path: %w", err)
+	}
+	// Resolve symlinks before the allowlist check so a symlink rooted inside
+	// the allowlist that points outside still gets rejected.
+	real, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return "", fmt.Errorf("evaluate symlinks for %s: %w", cleaned, err)
+	}
+	for _, root := range localFileURLRoots {
+		rel, err := filepath.Rel(root, real)
+		if err != nil {
+			continue
+		}
+		if rel == "." || (!strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel)) {
+			return real, nil
+		}
+	}
+	return "", fmt.Errorf("path %s is not under any WEKNORA_LOCAL_FILE_URL_ROOTS prefix (resolved: %s)", rawPath, real)
+}
+
+// readLocalFileURL reads a file:// URL into memory, applying the same
+// size cap (maxFileURLSize) as the HTTP download path. The path is
+// validated against the WEKNORA_LOCAL_FILE_URL_ROOTS allowlist via
+// resolveLocalFileURL — callers do NOT need to pre-validate.
+//
+// payloadFileName / payloadFileType are in/out pointers, populated from
+// the resolved filesystem path when empty so the downstream parser sees
+// the right extension.
+func readLocalFileURL(ctx context.Context, fileURL string, payloadFileName, payloadFileType *string) ([]byte, error) {
+	fsPath, err := resolveLocalFileURL(fileURL)
+	if err != nil {
+		return nil, err
+	}
+	fi, err := os.Stat(fsPath)
+	if err != nil {
+		return nil, fmt.Errorf("stat local file: %w", err)
+	}
+	if !fi.Mode().IsRegular() {
+		return nil, fmt.Errorf("not a regular file: %s", fsPath)
+	}
+	if fi.Size() > maxFileURLSize {
+		return nil, fmt.Errorf("file size %d bytes exceeds limit of %d bytes (10MB)", fi.Size(), maxFileURLSize)
+	}
+	if *payloadFileName == "" {
+		*payloadFileName = filepath.Base(fsPath)
+	}
+	if *payloadFileType == "" && *payloadFileName != "" {
+		*payloadFileType = getFileType(*payloadFileName)
+	}
+	logger.Infof(ctx, "Reading local file URL: path=%s size=%d name=%s type=%s",
+		fsPath, fi.Size(), *payloadFileName, *payloadFileType)
+	return os.ReadFile(fsPath)
 }
 
 // calculateFileHash calculates MD5 hash of a file
@@ -335,7 +493,14 @@ func IsVideoType(fileType string) bool {
 // payloadFileName and payloadFileType are in/out pointers: if they point to an empty string,
 // the function resolves the value from Content-Disposition / URL path and writes it back.
 // It does NOT perform SSRF validation — callers are responsible for that.
+//
+// file:// URLs are short-circuited to readLocalFileURL, which enforces the
+// WEKNORA_LOCAL_FILE_URL_ROOTS allowlist instead of running through the
+// HTTP client and SSRF path.
 func downloadFileFromURL(ctx context.Context, fileURL string, payloadFileName, payloadFileType *string) ([]byte, error) {
+	if isLocalFileURL(fileURL) {
+		return readLocalFileURL(ctx, fileURL, payloadFileName, payloadFileType)
+	}
 	httpClient := &http.Client{Timeout: 60 * time.Second}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
 	if err != nil {

--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -449,11 +449,21 @@ func (h *KnowledgeHandler) CreateKnowledgeFromURL(c *gin.Context) {
 		secutils.SanitizeForLog(req.FileType),
 	)
 
-	// SSRF validation for user-supplied URL
-	if err := secutils.ValidateURLForSSRF(req.URL); err != nil {
-		logger.Warnf(ctx, "SSRF validation failed for knowledge URL: %v", err)
-		c.Error(errors.NewBadRequestError(secutils.FormatSSRFError("URL", req.URL, err)))
-		return
+	// SSRF validation for user-supplied URL.
+	//
+	// file:// URLs are not network destinations and so don't fit the SSRF
+	// allowlist (which requires a hostname). Their security envelope is
+	// enforced by service.resolveLocalFileURL against the
+	// WEKNORA_LOCAL_FILE_URL_ROOTS allowlist — both at create-time (so we
+	// fail fast before persisting a knowledge row) and at fetch-time inside
+	// readLocalFileURL when the async worker reads the bytes. Skip the
+	// SSRF gate here for file:// so it reaches the service layer.
+	if !strings.HasPrefix(req.URL, "file://") {
+		if err := secutils.ValidateURLForSSRF(req.URL); err != nil {
+			logger.Warnf(ctx, "SSRF validation failed for knowledge URL: %v", err)
+			c.Error(errors.NewBadRequestError(secutils.FormatSSRFError("URL", req.URL, err)))
+			return
+		}
 	}
 
 	logger.Infof(ctx,


### PR DESCRIPTION
## What

Extends the existing **Import URL** path to also accept `file:///abs/path`
(and `file://localhost/abs/path`), so the URL dialog can ingest a local
HTML / PDF / DOCX / Markdown file without a manual upload step. Useful when a
curated local document tree is the source of truth and WeKnora is a
rebuildable index over it.

## Opt-in & security model

Disabled by default. Enabled only via an explicit allowlist:

```
WEKNORA_LOCAL_FILE_URL_ROOTS=/srv/docs:/data/imports
```

- Unset/empty → feature **OFF**.
- OS-path-list-separated absolute directory prefixes; `~`/`~/` expand against the backend process HOME.
- Symlinks on the roots and on each request are resolved; the resolved target must sit under a resolved root → blocks `../` traversal **and** "symlink inside an allowed root that points outside".
- Non-local file URLs (`file://server/share`) are rejected.

The three SSRF gates that require a hostname (`ValidateURLForSSRF`) get a
`file://` bypass routed to `resolveLocalFileURL()` instead, failing closed at:
request entry (handler), pre-persist (service), and async fetch (worker).

## Tests

New `internal/application/service/knowledge_localfileurl_test.go` (~190 lines):
disabled-by-default, allowed path, traversal reject, outside-root reject,
symlink-escape reject, remote-host reject, localhost accepted, filename/type
population. `go build ./...` is clean and the feature tests pass on `main`.

## Compatibility

No behavior change when the env var is unset — purely additive, opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
