### PR TITLE
fix(frontend): gate API integration tab and polish landing pages

### DIFF
--- a/frontend/src/components/menu.vue
+++ b/frontend/src/components/menu.vue
@@ -257,10 +257,17 @@ import UserMenu from '@/components/UserMenu.vue';
 import TenantSelector from '@/components/TenantSelector.vue';
 import { useI18n } from 'vue-i18n';
 import { getSystemInfo } from '@/api/system';
-import { INTEGRATION_PREVIEW_ITEMS } from '@/config/integrations';
+import { INTEGRATION_PREVIEW_ITEMS, INTEGRATION_TAB_MIN_ROLE } from '@/config/integrations';
 
 const chatResources = useChatResourcesStore();
-const integrationPreviewItems = INTEGRATION_PREVIEW_ITEMS;
+const integrationPreviewItems = computed(() =>
+    INTEGRATION_PREVIEW_ITEMS.filter((item) => {
+        const min = INTEGRATION_TAB_MIN_ROLE[item.key];
+        if (!min) return true;
+        if (authStore.canAccessAllTenants) return true;
+        return authStore.hasRole(min);
+    }),
+);
 // Platform logos reused from IMChannelsOverviewPanel — keeps the session list
 // visually consistent with the channels admin view.
 import wecomLogo from '@/assets/img/im/wecom.svg';

--- a/frontend/src/config/integrations.ts
+++ b/frontend/src/config/integrations.ts
@@ -7,6 +7,13 @@ export type IntegrationTab = 'im' | 'embed' | 'api' | 'chrome' | 'claw'
 
 export const INTEGRATION_TABS: IntegrationTab[] = ['im', 'embed', 'api', 'chrome', 'claw']
 
+/** Aligns with Settings.vue SECTION_MIN_ROLE.api and router.go g.Owner() on /api-principal-config. */
+export type IntegrationTabRole = 'viewer' | 'contributor' | 'admin' | 'owner'
+
+export const INTEGRATION_TAB_MIN_ROLE: Partial<Record<IntegrationTab, IntegrationTabRole>> = {
+  api: 'owner',
+}
+
 export type IntegrationPreviewIcon =
   | { type: 'icon'; name: string }
   | { type: 'emoji'; value: string }

--- a/frontend/src/views/integrations/ChromeExtensionLanding.vue
+++ b/frontend/src/views/integrations/ChromeExtensionLanding.vue
@@ -4,10 +4,6 @@
     :subtitle="$t('integrations.chrome.subtitle')"
     variant="chrome"
   >
-    <template #icon>
-      <t-icon name="extension" size="22px" />
-    </template>
-
     <template #tags>
       <span v-for="key in scenarioKeys" :key="key" class="scenario-tag">
         {{ $t(`integrations.chrome.scenarios.${key}`) }}

--- a/frontend/src/views/integrations/ClawSkillLanding.vue
+++ b/frontend/src/views/integrations/ClawSkillLanding.vue
@@ -4,10 +4,6 @@
     :subtitle="$t('integrations.claw.subtitle')"
     variant="claw"
   >
-    <template #icon>
-      <span role="img" :aria-label="$t('common.clawhubSkill')">🦞</span>
-    </template>
-
     <template #actions>
       <IntegrationExternalCta
         variant="claw"

--- a/frontend/src/views/integrations/IntegrationLandingLayout.vue
+++ b/frontend/src/views/integrations/IntegrationLandingLayout.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="integration-landing" :class="{ 'integration-landing--claw': variant === 'claw' }">
     <header class="landing-hero" :class="{ 'landing-hero--claw': variant === 'claw' }">
-      <div class="landing-hero__icon" :class="`landing-hero__icon--${variant}`">
-        <slot name="icon" />
-      </div>
       <div class="landing-hero__content">
         <h2 class="landing-hero__title">{{ title }}</h2>
         <p v-if="subtitle" class="landing-hero__subtitle">{{ subtitle }}</p>

--- a/frontend/src/views/integrations/IntegrationsModal.vue
+++ b/frontend/src/views/integrations/IntegrationsModal.vue
@@ -84,11 +84,18 @@ import AgentEmbedChannelPanel from '@/components/AgentEmbedChannelPanel.vue';
 import ApiIntegrationSettings from '@/views/integrations/ApiIntegrationSettings.vue';
 import ChromeExtensionLanding from '@/views/integrations/ChromeExtensionLanding.vue';
 import ClawSkillLanding from '@/views/integrations/ClawSkillLanding.vue';
-import { INTEGRATION_PREVIEW_ITEMS, INTEGRATION_TABS, type IntegrationTab } from '@/config/integrations';
+import {
+  INTEGRATION_PREVIEW_ITEMS,
+  INTEGRATION_TAB_MIN_ROLE,
+  INTEGRATION_TABS,
+  type IntegrationTab,
+} from '@/config/integrations';
+import { useAuthStore } from '@/stores/auth';
 
 const { t } = useI18n();
 const route = useRoute();
 const router = useRouter();
+const authStore = useAuthStore();
 
 const currentSection = ref<IntegrationTab>('im');
 const filterAgentId = ref('');
@@ -99,19 +106,34 @@ const isLandingSection = computed(
   () => currentSection.value === 'chrome' || currentSection.value === 'claw',
 );
 
+function canSeeTab(tab: IntegrationTab): boolean {
+  const min = INTEGRATION_TAB_MIN_ROLE[tab];
+  if (!min) return true;
+  if (authStore.canAccessAllTenants) return true;
+  return authStore.hasRole(min);
+}
+
 const navItems = computed(() =>
-  INTEGRATION_PREVIEW_ITEMS.map((item) => ({
-    key: item.key,
-    icon: item.icon.type === 'icon' ? item.icon.name : '',
-    emoji: item.icon.type === 'emoji' ? item.icon.value : undefined,
-    label: t(`integrations.tabs.${item.key}`),
-  })),
+  INTEGRATION_PREVIEW_ITEMS
+    .filter((item) => canSeeTab(item.key))
+    .map((item) => ({
+      key: item.key,
+      icon: item.icon.type === 'icon' ? item.icon.name : '',
+      emoji: item.icon.type === 'emoji' ? item.icon.value : undefined,
+      label: t(`integrations.tabs.${item.key}`),
+    })),
 );
 
 function applyRouteQuery() {
   const tab = route.query.tab as string;
-  if (INTEGRATION_TABS.includes(tab as IntegrationTab)) {
+  if (INTEGRATION_TABS.includes(tab as IntegrationTab) && canSeeTab(tab as IntegrationTab)) {
     currentSection.value = tab as IntegrationTab;
+  } else if (INTEGRATION_TABS.includes(tab as IntegrationTab)) {
+    currentSection.value = navItems.value[0]?.key ?? 'im';
+    if (visible.value) syncRouteQuery();
+  } else if (navItems.value.length > 0 && !canSeeTab(currentSection.value)) {
+    currentSection.value = navItems.value[0].key;
+    if (visible.value) syncRouteQuery();
   }
   filterAgentId.value = (route.query.agentId as string) || '';
 }

--- a/frontend/src/views/integrations/integration-landing.less
+++ b/frontend/src/views/integrations/integration-landing.less
@@ -46,30 +46,6 @@
       var(--td-bg-color-container) 72%
     );
     box-shadow: inset 0 1px 0 color-mix(in srgb, @claw-accent 10%, transparent);
-
-    .landing-hero__icon {
-      background: color-mix(in srgb, @claw-accent 14%, var(--td-bg-color-container));
-    }
-  }
-
-  &__icon {
-    flex-shrink: 0;
-    width: 44px;
-    height: 44px;
-    border-radius: 10px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: color-mix(in srgb, var(--td-brand-color) 14%, var(--td-bg-color-container));
-    color: var(--td-brand-color);
-    font-size: 22px;
-    line-height: 1;
-
-    :deep(.t-icon) {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-    }
   }
 
   &__content {
@@ -126,18 +102,18 @@
     background 0.18s ease,
     box-shadow 0.18s ease;
 
-  &:hover {
+  &:not(&--claw):hover {
     border-style: solid;
     border-color: color-mix(in srgb, var(--td-brand-color) 40%, var(--td-component-stroke));
     background: color-mix(in srgb, var(--td-bg-color-container) 92%, transparent);
     box-shadow: 0 2px 10px rgba(15, 23, 42, 0.05);
   }
 
-  &:active {
+  &:not(&--claw):active {
     box-shadow: none;
   }
 
-  &:focus-visible {
+  &:not(&--claw):focus-visible {
     outline: 2px solid var(--td-brand-color);
     outline-offset: 2px;
   }
@@ -146,7 +122,14 @@
     border-color: color-mix(in srgb, @claw-accent 30%, var(--td-component-stroke));
 
     &:hover {
+      border-style: solid;
       border-color: color-mix(in srgb, @claw-accent 45%, var(--td-component-stroke));
+      background: color-mix(in srgb, var(--td-bg-color-container) 92%, transparent);
+      box-shadow: 0 2px 10px rgba(15, 23, 42, 0.05);
+    }
+
+    &:active {
+      box-shadow: none;
     }
 
     .ext-cta__badge {
@@ -165,7 +148,8 @@
     }
 
     &:focus-visible {
-      outline-color: @claw-accent;
+      outline: 2px solid @claw-accent;
+      outline-offset: 2px;
     }
   }
 
@@ -232,7 +216,7 @@
     justify-content: center;
   }
 
-  &:hover &__arrow-wrap {
+  &:not(&--claw):hover &__arrow-wrap {
     background: color-mix(in srgb, var(--td-brand-color) 14%, transparent);
     color: var(--td-brand-color);
   }
@@ -246,11 +230,6 @@
 
 // ── Claw / 龙虾主题色 ──
 .integration-landing--claw {
-  .landing-hero__icon--claw {
-    color: @claw-accent-dark;
-    background: color-mix(in srgb, @claw-accent 14%, var(--td-bg-color-container));
-  }
-
   .landing-group {
     .setting-drawer__section-title::before {
       background: @claw-accent;
@@ -279,10 +258,6 @@
 
   .landing-meta {
     color: color-mix(in srgb, @claw-accent-dark 55%, var(--td-text-color-placeholder));
-  }
-
-  .ext-cta--claw:hover .ext-cta__arrow-wrap {
-    color: @claw-accent-dark;
   }
 
   :deep(.t-button--variant-outline) {


### PR DESCRIPTION
## Summary

- Hide the **API Integration** tab (and sidebar preview icon) for tenants without the `owner` role, matching Settings and the backend `g.Owner()` guard on `/api-principal-config`, so non-owners no longer hit a 403 when opening the tab.
- Redirect `?tab=api` to the first visible integrations tab when the user lacks permission.
- Polish **Chrome Extension** and **Claw Skill** landing pages: remove redundant hero icons and keep Claw CTA hover/focus states on the lobster accent instead of the default brand green.

## Test plan

- [ ] As tenant **owner**, open Integrations → API Integration; tab is visible and settings load normally.
- [ ] As **admin/contributor/viewer**, open Integrations; API tab is hidden and sidebar preview no longer shows the API icon.
- [ ] Navigate to `/platform/integrations?tab=api` as a non-owner; verify redirect to a visible tab (e.g. IM).
- [ ] Open Chrome Extension and Claw Skill tabs; verify hero area has no large side icon.
- [ ] Hover the ClawHub CTA on the Claw Skill page; verify arrow background uses orange accent, not brand green.