### PR TITLE
fix(docker): default DB_HOST to postgres in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -196,7 +196,7 @@ FRONTEND_PORT=80
 DOCREADER_PORT=50051
 
 # 数据库主机地址
-DB_HOST=localhost
+DB_HOST=postgres
 
 # 数据库端口
 DB_PORT=5432


### PR DESCRIPTION
## Summary

- Change the default `DB_HOST` in `.env.example` from `localhost` to `postgres`
- Aligns the example env with Docker Compose, where the database service is reachable at hostname `postgres`

## Test plan

- [ ] Copy `.env.example` to `.env` and run `docker compose up` — app should connect to Postgres without editing `DB_HOST`
- [ ] Local non-Docker dev setups can still override `DB_HOST=localhost` in `.env`