### PR TITLE
Chore: update dev script checks and Air docs

### DIFF
--- a/docs/wiki/开发部署/开发指南.md
+++ b/docs/wiki/开发部署/开发指南.md
@@ -51,7 +51,7 @@ make dev-frontend
 
 ```bash
 go install github.com/air-verse/air@latest
-air  # 修改 Go 代码后自动重新编译和重启
+make dev-app  # 检测到 Air 时自动启用热重载
 ```
 
 ## 前端独立开发

--- a/docs/开发指南.md
+++ b/docs/开发指南.md
@@ -111,71 +111,11 @@ make dev-frontend  # 修改前端代码自动热重载（无需重启）
 
 如果你希望后端代码修改后也能自动重启，可以安装 `air`：
 
-### 1. 安装 Air
-
 ```bash
 go install github.com/air-verse/air@latest
 ```
 
-### 2. 创建配置文件
-
-在项目根目录创建 `.air.toml`：
-
-```toml
-root = "."
-testdata_dir = "testdata"
-tmp_dir = "tmp"
-
-[build]
-  args_bin = []
-  bin = "./tmp/main"
-  cmd = "go build -o ./tmp/main ./cmd/server"
-  delay = 1000
-  exclude_dir = ["assets", "tmp", "vendor", "testdata", "frontend", "migrations"]
-  exclude_file = []
-  exclude_regex = ["_test.go"]
-  exclude_unchanged = false
-  follow_symlink = false
-  full_bin = ""
-  include_dir = []
-  include_ext = ["go", "tpl", "tmpl", "html", "yaml"]
-  include_file = []
-  kill_delay = "0s"
-  log = "build-errors.log"
-  poll = false
-  poll_interval = 0
-  rerun = false
-  rerun_delay = 500
-  send_interrupt = false
-  stop_on_error = false
-
-[color]
-  app = ""
-  build = "yellow"
-  main = "magenta"
-  runner = "green"
-  watcher = "cyan"
-
-[log]
-  main_only = false
-  time = false
-
-[misc]
-  clean_on_exit = false
-
-[screen]
-  clear_on_rebuild = false
-  keep_scroll = true
-```
-
-### 3. 使用 Air 启动
-
-```bash
-# 在项目根目录
-air
-```
-
-现在修改 Go 代码后会自动重新编译和重启！
+项目根目录已内置 `.air.toml`，不需要手动创建配置文件。`make dev-app` 会检测本机是否安装了 Air：检测到 Air 时使用热重载模式，未检测到时使用普通 `go run` 模式。
 
 ## 其他开发技巧
 
@@ -279,4 +219,3 @@ make dev-restart
 - **日常开发**：使用 `make dev-*` 命令，快速迭代
 - **测试集成**：使用 `sh scripts/start_all.sh --no-pull` 测试完整环境
 - **生产部署**：使用 `sh scripts/build_images.sh` + `sh scripts/start_all.sh`
-

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -153,7 +153,7 @@ start_services() {
     if [ $? -ne 0 ]; then
         return 1
     fi
-    
+
     cd "$PROJECT_ROOT"
     
     # 检查 .env 文件
@@ -300,12 +300,22 @@ restart_services() {
 
 # 查看日志
 show_logs() {
+    check_docker
+    if [ $? -ne 0 ]; then
+        return 1
+    fi
+
     cd "$PROJECT_ROOT"
     "$DOCKER_COMPOSE_BIN" $DOCKER_COMPOSE_SUBCMD -f docker-compose.dev.yml logs -f
 }
 
 # 查看状态
 show_status() {
+    check_docker
+    if [ $? -ne 0 ]; then
+        return 1
+    fi
+
     cd "$PROJECT_ROOT"
     "$DOCKER_COMPOSE_BIN" $DOCKER_COMPOSE_SUBCMD -f docker-compose.dev.yml ps
 }


### PR DESCRIPTION
## Summary

- Fix `dev-status` and `dev-logs` so they initialize Docker Compose detection before running compose commands.
<img width="411" height="171" alt="script_err" src="https://github.com/user-attachments/assets/be023b88-8eb3-438d-aba9-fc723219a6ba" />

- Replace the stale Air setup docs with the current flow: `.air.toml` is already included, Air is installed manually, and `make dev-app` auto-detects it.

## Test plan

- [x] `bash -n scripts/dev.sh`
- [x] `make dev-status` no longer fails with `: command not found`; when Docker is stopped, it now reports `Docker服务未运行`.
- [ ] Start Docker and run `make dev-status` to verify the compose service list loads.
- [ ] Start Docker and run `make dev-logs` to verify logs stream normally.