### PR TITLE
fix(search): accept 'query' as alias for 'query_text' in HybridSearch

### DIFF
--- a/internal/types/search.go
+++ b/internal/types/search.go
@@ -159,6 +159,25 @@ type SearchParams struct {
 	SkipContextEnrichment bool `json:"skip_context_enrichment,omitempty"`
 }
 
+// UnmarshalJSON supports both "query_text" (canonical) and "query" (shorthand)
+// so clients using either field name can deserialize correctly.
+func (s *SearchParams) UnmarshalJSON(data []byte) error {
+	type Alias SearchParams
+	aux := &struct {
+		Query string `json:"query"`
+		*Alias
+	}{
+		Alias: (*Alias)(s),
+	}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	if s.QueryText == "" && aux.Query != "" {
+		s.QueryText = aux.Query
+	}
+	return nil
+}
+
 // Value implements the driver.Valuer interface, used to convert SearchResult to database value
 func (c SearchResult) Value() (driver.Value, error) {
 	return json.Marshal(c)


### PR DESCRIPTION
## Problem

The `SearchParams` struct uses `json:"query_text"` for the query field, but some MCP clients and API consumers send `"query"` as the JSON key. This causes the `QueryText` field to remain empty after JSON deserialization, leading to hybrid search always returning 0 results.

## Root Cause

`internal/types/search.go:142` — `QueryText string json:"query_text"` only accepts `query_text`, but some callers (e.g., external MCP tools, simplified API calls) send `query`.

## Fix

Add a custom `UnmarshalJSON` on `SearchParams` that:
1. Parses both `query_text` (canonical) and `query` (shorthand) JSON keys
2. Falls back to the `query` key when `query_text` is empty
3. Maintains full backward compatibility — existing callers sending `query_text` are unaffected

## Verification

- Tested with both `{"query_text": "test"}` and `{"query": "test"}` request bodies
- Existing MCP Python client (which correctly sends `query_text`) continues to work
- Go vet passes