### PR TITLE
fix(vlm): allow configurable temperature for VLM models

### DIFF
--- a/internal/models/vlm/remote_api.go
+++ b/internal/models/vlm/remote_api.go
@@ -40,10 +40,11 @@ func vlmHTTPTimeout() time.Duration {
 
 // RemoteAPIVLM implements VLM via an OpenAI-compatible chat completions API.
 type RemoteAPIVLM struct {
-	modelName string
-	modelID   string
-	client    *openai.Client
-	baseURL   string
+	modelName   string
+	modelID     string
+	client      *openai.Client
+	baseURL     string
+	temperature float32
 }
 
 // NewRemoteAPIVLM creates a remote-API backed VLM instance.
@@ -81,11 +82,23 @@ func NewRemoteAPIVLM(config *Config) (*RemoteAPIVLM, error) {
 		apiCfg.HTTPClient = httpClient
 	}
 
+	temp := defaultTemp
+	if config.Extra != nil {
+		if v, ok := config.Extra["temperature"]; ok {
+			if vs, ok := v.(string); ok {
+				if f, err := strconv.ParseFloat(vs, 32); err == nil {
+					temp = float32(f)
+				}
+			}
+		}
+	}
+
 	return &RemoteAPIVLM{
-		modelName: config.ModelName,
-		modelID:   config.ModelID,
-		client:    openai.NewClientWithConfig(apiCfg),
-		baseURL:   config.BaseURL,
+		modelName:   config.ModelName,
+		modelID:     config.ModelID,
+		client:      openai.NewClientWithConfig(apiCfg),
+		baseURL:     config.BaseURL,
+		temperature: temp,
 	}, nil
 }
 
@@ -124,7 +137,7 @@ func (v *RemoteAPIVLM) Predict(ctx context.Context, imgBytesList [][]byte, promp
 			},
 		},
 		MaxTokens:   defaultMaxToks,
-		Temperature: defaultTemp,
+		Temperature: v.temperature,
 	}
 
 	totalImageSize := 0


### PR DESCRIPTION
## Summary
- Fix VLM temperature hardcoded to 0.1 which causes 400 error for models that only accept temperature=1
- Now reads temperature from model's `ExtraConfig["temperature"]` with fallback to default 0.1

## Problem
When using certain VLM models (vision models), the API returns:
```
OpenAI VLM request: error, status code: 400, status: 400 Bad Request, message: invalid temperature: only 1 is allowed for this model
```

## Solution
- Added `temperature` field to `RemoteAPIVLM` struct
- In constructor, reads from `Config.Extra["temperature"]` if present
- Uses configured temperature in API requests instead of hardcoded default

## Usage
Set `temperature=1` in the VLM model's `ExtraConfig`:
```json
{
  "extra_config": {
    "temperature": "1"
  }
}
```

## Test plan
- [ ] Configure a VLM model with `ExtraConfig.temperature=1`
- [ ] Test image upload and VLM analysis
- [ ] Verify no 400 error for temperature