### PR TITLE
feat: support MySQL as relational database backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,9 +147,14 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434
 
 # 存储配置
 # 主数据库类型(postgres/mysql)
+# - postgres：默认。可同时作为向量库（RETRIEVE_DRIVER=postgres，基于 pgvector）。
+# - mysql   ：作为关系型主库的替代。MySQL 不含向量能力，必须把 RETRIEVE_DRIVER
+#             指向外部向量库（如 milvus / qdrant）。切换步骤见 docs/使用MySQL数据库.md。
+#             注意：MySQL 模式下不可用自建 Langfuse（其仅支持 PostgreSQL）。
 DB_DRIVER=postgres
 
 # 向量存储类型(postgres/elasticsearch_v7/elasticsearch_v8/qdrant/milvus/weaviate/doris/tencent_vectordb)
+# 若 DB_DRIVER=mysql，此处不能为 postgres，请改用 milvus / qdrant 等外部向量库。
 RETRIEVE_DRIVER=postgres
 
 # 允许用户使用哪些文件存储类型，使用逗号分隔，留空则允许所有类型的存储
@@ -196,9 +201,11 @@ FRONTEND_PORT=80
 DOCREADER_PORT=50051
 
 # 数据库主机地址
+# Docker Compose 部署时用服务名：postgres 或 mysql；本地开发用 localhost。
 DB_HOST=postgres
 
 # 数据库端口
+# PostgreSQL 默认 5432；MySQL 默认 3306。
 DB_PORT=5432
 
 # 数据库用户名

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ Detailed API documentation is available at: [API Docs](./docs/api/README.md)
 
 Product plans and upcoming features: [Roadmap](./docs/ROADMAP.md)
 
+Using MySQL as the primary database: [MySQL Setup Guide](./docs/使用MySQL数据库.md)
+
 ## 🧭 Developer Guide
 
 ### ⚡ Fast Development Mode (Recommended)

--- a/README_CN.md
+++ b/README_CN.md
@@ -240,6 +240,8 @@ WeKnora 作为[微信对话开放平台](https://chatbot.weixin.qq.com)的核心
 
 产品规划与计划：[路线图 (Roadmap)](./docs/ROADMAP.md)
 
+使用 MySQL 作为主数据库：[MySQL 配置说明](./docs/使用MySQL数据库.md)
+
 ## 🧭 开发指南
 
 ### ⚡ 快速开发模式（推荐）

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
     image: paradedb/paradedb:v0.22.2-pg17
     container_name: WeKnora-postgres-dev
     ports:
-      - "${DB_PORT:-5432}:5432"
+      - "${POSTGRES_DEV_PORT:-5432}:5432"
     environment:
       - POSTGRES_USER=${DB_USER}
       - POSTGRES_PASSWORD=${DB_PASSWORD}
@@ -22,6 +22,36 @@ services:
       start_period: 30s
     restart: unless-stopped
     stop_grace_period: 1m
+    profiles:
+      - postgres
+      - full
+
+  # MySQL alternative to PostgreSQL. Enable with: DB_DRIVER=mysql and
+  # `./scripts/dev.sh start --profile mysql` (or dev.sh auto-selects it when DB_DRIVER=mysql).
+  mysql:
+    image: mysql:8.0
+    container_name: WeKnora-mysql-dev
+    ports:
+      - "${MYSQL_DEV_PORT:-3306}:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
+      - MYSQL_DATABASE=${DB_NAME}
+      - MYSQL_USER=${DB_USER}
+      - MYSQL_PASSWORD=${DB_PASSWORD}
+    volumes:
+      - mysql-data-dev:/var/lib/mysql
+    networks:
+      - WeKnora-network-dev
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "${DB_USER}", "--password=${DB_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+    profiles:
+      - mysql
+      - full
 
   redis:
     image: redis:7.0-alpine
@@ -520,6 +550,7 @@ networks:
 
 volumes:
   postgres-data-dev:
+  mysql-data-dev:
   redis_data_dev:
   minio_data_dev:
   neo4j-data-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -309,6 +309,32 @@ services:
     # 添加停机时的优雅退出时间
     stop_grace_period: 1m
 
+  # MySQL alternative to PostgreSQL. To use MySQL instead of Postgres:
+  #   1. Set DB_DRIVER=mysql, DB_HOST=mysql, DB_PORT=3306 in app environment
+  #   2. Remove or comment out the postgres service dependency in the app service
+  #   3. Use an external vector store (e.g. Milvus/Qdrant) — pgvector is not available with MySQL
+  mysql:
+    image: mysql:8.0
+    container_name: WeKnora-mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
+      - MYSQL_DATABASE=${DB_NAME}
+      - MYSQL_USER=${DB_USER}
+      - MYSQL_PASSWORD=${DB_PASSWORD}
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+    networks:
+      - WeKnora-network
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "${DB_USER}", "--password=${DB_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
   redis:
     image: redis:7.0-alpine
     container_name: WeKnora-redis
@@ -789,6 +815,7 @@ networks:
 
 volumes:
   postgres-data:
+  mysql-data:
   data-files:
   docreader-tmp:
   minio_data:

--- a/docs/使用MySQL数据库.md
+++ b/docs/使用MySQL数据库.md
@@ -1,0 +1,96 @@
+# 使用 MySQL 作为主数据库
+
+WeKnora 默认使用 PostgreSQL 作为关系型主库。从本版本起，也支持使用 **MySQL 8.0** 作为主库的替代方案（对应 issue #1418）。
+
+本文说明两者的区别、切换步骤，以及已知限制。
+
+## 架构说明：关系层与向量层是解耦的
+
+WeKnora 有两条独立的数据链路，由两个环境变量分别控制：
+
+| 变量 | 作用 | 可选值 |
+| --- | --- | --- |
+| `DB_DRIVER` | 关系型主库（租户、知识库、会话、任务等元数据） | `postgres` / `mysql` / `sqlite` |
+| `RETRIEVE_DRIVER` | 向量检索引擎（embedding 存储与相似度检索） | `postgres`（pgvector）/ `milvus` / `qdrant` / `weaviate` / `doris` / `elasticsearch_*` / `tencent_vectordb` |
+
+默认部署里两者都用 PostgreSQL：主库是 Postgres，向量库复用同一个 Postgres 的 pgvector 扩展。
+
+**MySQL 没有等价的向量能力**，因此当 `DB_DRIVER=mysql` 时，`RETRIEVE_DRIVER` 必须指向一个外部向量库（推荐 `milvus` 或 `qdrant`）。关系层与向量层互不影响。
+
+## 切换步骤
+
+### 1. 修改 `.env`
+
+```dotenv
+# 关系型主库改为 MySQL
+DB_DRIVER=mysql
+DB_HOST=mysql          # Docker Compose 部署用服务名；本地开发用 localhost
+DB_PORT=3306           # MySQL 默认端口
+DB_USER=<your_user>
+DB_PASSWORD=<your_password>
+DB_NAME=WeKnora
+
+# 向量库改为外部引擎（pgvector 在 MySQL 模式下不可用）
+RETRIEVE_DRIVER=milvus
+MILVUS_ADDRESS=milvus:19530
+```
+
+> 密码可以包含 `@`、`#`、`!` 等特殊字符——连接串通过 `go-sql-driver` 的 `Config.FormatDSN()` 构造，会正确转义。
+
+### 2. 启动 MySQL 与向量库
+
+**Docker Compose（生产/完整部署）**
+
+`docker-compose.yml` 已内置 `mysql` 服务。按需启动 MySQL + Milvus：
+
+```bash
+docker compose up -d mysql
+docker compose --profile milvus up -d milvus
+```
+
+**本地开发（`scripts/dev.sh`）**
+
+dev 脚本会读取 `.env` 的 `DB_DRIVER`，自动二选一启动数据库：
+
+```bash
+./scripts/dev.sh start      # DB_DRIVER=mysql 时自动启动 mysql-dev，跳过 postgres/langfuse
+```
+
+也可显式追加 `--mysql`。MySQL dev 容器默认映射到宿主机 `3306`（可用 `MYSQL_DEV_PORT` 覆盖）。
+
+### 3. 启动应用
+
+首次启动时，golang-migrate 会自动运行 `migrations/mysql/` 下的初始化脚本建表（无需手动导入）。
+
+```bash
+make dev-app            # 或正常的容器启动流程
+```
+
+日志出现 `Database is up to date (version: 0)` 且服务监听 `:8080`，即表示 MySQL 主库就绪。
+
+## 迁移脚本
+
+MySQL 的建表脚本位于 `migrations/mysql/`，采用与 SQLite 相同的「单文件整合 init」模式（`000000_init.up.sql` / `.down.sql`），而非 PostgreSQL 那套逐版本增量迁移。
+
+相较 PostgreSQL 版本，MySQL schema 做了以下方言适配：
+
+- 自增主键 `BIGINT AUTO_INCREMENT`
+- 时间戳 `DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6)`
+- `JSONB` → `JSON`
+- `TEXT`/`LONGTEXT` 列的默认值使用 MySQL 8.0.13+ 的表达式默认语法 `DEFAULT ('...')`
+- 复合索引对长文本列加前缀长度限制（规避 3072 字节 key 上限）
+- 部分索引（partial index）降级为普通索引，唯一性约束在应用层保证
+- 统一 `ENGINE=InnoDB`、`utf8mb4` / `utf8mb4_unicode_ci`
+
+## 已知限制
+
+- **向量检索必须用外部引擎**：`RETRIEVE_DRIVER=postgres`（pgvector）在 MySQL 模式下不可用，请改用 Milvus / Qdrant 等。
+- **自建 Langfuse 不可用**：Langfuse 上游仅支持 PostgreSQL（Prisma provider 写死为 postgresql），MySQL 模式下 `scripts/dev.sh` 会自动跳过 Langfuse 栈。若仍需可观测性，可为 Langfuse 单独部署一个 PostgreSQL 实例，或使用 Langfuse 云端。
+- **要求 MySQL ≥ 8.0.13**：初始化脚本依赖 TEXT 列的表达式默认值语法。
+
+## 相关文件
+
+- `.env.example` — DB 配置说明
+- `docker-compose.yml` / `docker-compose.dev.yml` — `mysql` 服务定义
+- `migrations/mysql/` — MySQL 初始化脚本
+- `internal/container/container.go` — MySQL 驱动接入（`case "mysql"`）

--- a/go.mod
+++ b/go.mod
@@ -335,6 +335,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gorm.io/driver/mysql v1.6.0 // indirect
 	k8s.io/apimachinery v0.32.3 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3783,6 +3783,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/driver/mysql v1.6.0 h1:eNbLmNTpPpTOVZi8MMxCi2aaIm0ZpInbORNXDwyLGvg=
+gorm.io/driver/mysql v1.6.0/go.mod h1:D/oCC2GWK3M/dqoLxnOlaNKmXz8WNTfcS9y5ovaSqKo=
 gorm.io/driver/postgres v1.6.0 h1:2dxzU8xJ+ivvqTRph34QX+WrRaJlmfyPqXmoGVjMBa4=
 gorm.io/driver/postgres v1.6.0/go.mod h1:vUw0mrGgrTK+uPHEhAdV4sfFELrByKVGnaVRkXDhtWo=
 gorm.io/driver/sqlite v1.6.0 h1:WHRRrIiulaPiPFmDcod6prc4l2VGVWHz80KspNsxSfQ=

--- a/internal/application/repository/system_setting.go
+++ b/internal/application/repository/system_setting.go
@@ -30,7 +30,7 @@ func NewSystemSettingRepository(db *gorm.DB) interfaces.SystemSettingRepository 
 // not an error. Real DB errors (connection lost, etc.) surface up.
 func (r *systemSettingRepository) Get(ctx context.Context, key string) (*types.SystemSetting, error) {
 	var s types.SystemSetting
-	err := r.db.WithContext(ctx).Where("key = ?", key).First(&s).Error
+	err := r.db.WithContext(ctx).Where(clause.Eq{Column: clause.Column{Name: "key"}, Value: key}).First(&s).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -44,7 +44,10 @@ func (r *systemSettingRepository) Get(ctx context.Context, key string) (*types.S
 // for stable management-UI rendering. No pagination — see type comment.
 func (r *systemSettingRepository) List(ctx context.Context) ([]*types.SystemSetting, error) {
 	var rows []*types.SystemSetting
-	err := r.db.WithContext(ctx).Order("category ASC, key ASC").Find(&rows).Error
+	err := r.db.WithContext(ctx).
+		Order(clause.OrderByColumn{Column: clause.Column{Name: "category"}}).
+		Order(clause.OrderByColumn{Column: clause.Column{Name: "key"}}).
+		Find(&rows).Error
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +85,7 @@ func (r *systemSettingRepository) Upsert(ctx context.Context, s *types.SystemSet
 // rather than translating to gorm.ErrRecordNotFound so the caller's
 // happy path is a single nil check on err.
 func (r *systemSettingRepository) Delete(ctx context.Context, key string) (bool, error) {
-	res := r.db.WithContext(ctx).Where("key = ?", key).Delete(&types.SystemSetting{})
+	res := r.db.WithContext(ctx).Where(clause.Eq{Column: clause.Column{Name: "key"}, Value: key}).Delete(&types.SystemSetting{})
 	if res.Error != nil {
 		return false, res.Error
 	}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -21,7 +21,7 @@ import (
 	_ "github.com/duckdb/duckdb-go/v2"
 	esv7 "github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v8"
-	_ "github.com/go-sql-driver/mysql" // 给 Doris (database/sql) 注册 MySQL 协议驱动
+	gomysql "github.com/go-sql-driver/mysql" // 给 Doris (database/sql) 注册 MySQL 协议驱动
 	"github.com/milvus-io/milvus/client/v2/milvusclient"
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j"
 	"github.com/panjf2000/ants/v2"
@@ -29,6 +29,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/dig"
 	"google.golang.org/grpc"
+	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -510,6 +511,33 @@ func initDatabase(cfg *config.Config) (*gorm.DB, error) {
 			os.Getenv("DB_PORT"),
 			os.Getenv("DB_NAME"),
 		)
+	case "mysql":
+		// Use Config.FormatDSN so special chars in password (e.g. @, #) are handled correctly.
+		mysqlCfg := gomysql.NewConfig()
+		mysqlCfg.User = os.Getenv("DB_USER")
+		mysqlCfg.Passwd = os.Getenv("DB_PASSWORD")
+		mysqlCfg.Net = "tcp"
+		mysqlCfg.Addr = os.Getenv("DB_HOST") + ":" + os.Getenv("DB_PORT")
+		mysqlCfg.DBName = os.Getenv("DB_NAME")
+		mysqlCfg.ParseTime = true
+		mysqlCfg.Loc = time.UTC
+		mysqlCfg.Params = map[string]string{"charset": "utf8mb4"}
+		dsn := mysqlCfg.FormatDSN()
+		dialector = mysql.Open(dsn)
+		migrateDSN = fmt.Sprintf(
+			"mysql://%s:%s@tcp(%s:%s)/%s",
+			url.QueryEscape(os.Getenv("DB_USER")),
+			url.QueryEscape(os.Getenv("DB_PASSWORD")),
+			os.Getenv("DB_HOST"),
+			os.Getenv("DB_PORT"),
+			os.Getenv("DB_NAME"),
+		)
+		logger.Infof(context.Background(), "DB Config: driver=mysql user=%s host=%s port=%s dbname=%s",
+			os.Getenv("DB_USER"),
+			os.Getenv("DB_HOST"),
+			os.Getenv("DB_PORT"),
+			os.Getenv("DB_NAME"),
+		)
 	case "sqlite":
 		dbPath := os.Getenv("DB_PATH")
 		if dbPath == "" {
@@ -544,9 +572,9 @@ func initDatabase(cfg *config.Config) (*gorm.DB, error) {
 	// different name (e.g., a wrapper dialect for managed PG) would silently
 	// fall back to the SQLite path, dropping the row-level X-lock. Catching
 	// the mismatch at startup is loud and inexpensive.
-	if name := db.Dialector.Name(); name != "postgres" && name != "sqlite" {
+	if name := db.Dialector.Name(); name != "postgres" && name != "sqlite" && name != "mysql" {
 		return nil, fmt.Errorf(
-			"unsupported gorm dialector %q; expected postgres or sqlite "+
+			"unsupported gorm dialector %q; expected postgres, sqlite, or mysql "+
 				"(see vectorStoreService.isPostgres for impact)", name)
 	}
 

--- a/internal/database/migration.go
+++ b/internal/database/migration.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/mysql"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	sqlite3migrate "github.com/golang-migrate/migrate/v4/database/sqlite3"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -106,6 +107,8 @@ func RunMigrationsWithOptions(dsn string, opts MigrationOptions) error {
 	migrationsPath := "file://migrations/versioned"
 	if strings.HasPrefix(dsn, "sqlite3://") {
 		migrationsPath = "file://migrations/sqlite"
+	} else if strings.HasPrefix(dsn, "mysql://") {
+		migrationsPath = "file://migrations/mysql"
 	}
 
 	var m *migrate.Migrate

--- a/migrations/mysql/000000_init.down.sql
+++ b/migrations/mysql/000000_init.down.sql
@@ -1,0 +1,47 @@
+-- Drop all WeKnora tables in reverse dependency order.
+SET FOREIGN_KEY_CHECKS = 0;
+
+DROP TABLE IF EXISTS knowledge_processing_spans;
+DROP TABLE IF EXISTS system_settings;
+DROP TABLE IF EXISTS task_dead_letters;
+DROP TABLE IF EXISTS task_pending_ops;
+DROP TABLE IF EXISTS wiki_folders;
+DROP TABLE IF EXISTS wiki_log_entries;
+DROP TABLE IF EXISTS wiki_page_issues;
+DROP TABLE IF EXISTS wiki_pages;
+DROP TABLE IF EXISTS knowledge_tag_relations;
+DROP TABLE IF EXISTS sync_logs;
+DROP TABLE IF EXISTS data_sources;
+DROP TABLE IF EXISTS embed_channels;
+DROP TABLE IF EXISTS im_channel_sessions;
+DROP TABLE IF EXISTS im_channels;
+DROP TABLE IF EXISTS agent_shares;
+DROP TABLE IF EXISTS tenant_disabled_shared_agents;
+DROP TABLE IF EXISTS kb_shares;
+DROP TABLE IF EXISTS organization_join_requests;
+DROP TABLE IF EXISTS organization_tenant_members;
+DROP TABLE IF EXISTS organizations;
+DROP TABLE IF EXISTS custom_agents;
+DROP TABLE IF EXISTS mcp_oauth_tokens;
+DROP TABLE IF EXISTS mcp_oauth_clients;
+DROP TABLE IF EXISTS mcp_tool_approvals;
+DROP TABLE IF EXISTS mcp_services;
+DROP TABLE IF EXISTS knowledge_tags;
+DROP TABLE IF EXISTS tenant_invitations;
+DROP TABLE IF EXISTS user_kb_pins;
+DROP TABLE IF EXISTS user_resource_favorites;
+DROP TABLE IF EXISTS audit_logs;
+DROP TABLE IF EXISTS tenant_members;
+DROP TABLE IF EXISTS auth_tokens;
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS chunks;
+DROP TABLE IF EXISTS messages;
+DROP TABLE IF EXISTS sessions;
+DROP TABLE IF EXISTS knowledges;
+DROP TABLE IF EXISTS vector_stores;
+DROP TABLE IF EXISTS web_search_providers;
+DROP TABLE IF EXISTS knowledge_bases;
+DROP TABLE IF EXISTS models;
+DROP TABLE IF EXISTS tenants;
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/migrations/mysql/000000_init.up.sql
+++ b/migrations/mysql/000000_init.up.sql
@@ -1,0 +1,897 @@
+-- MySQL schema for WeKnora (consolidated from all Postgres migrations)
+-- Requires MySQL 8.0.13+ (expression defaults for JSON columns).
+-- Use with DB_DRIVER=mysql and an external vector store (Milvus/Qdrant/etc.).
+
+CREATE TABLE IF NOT EXISTS tenants (
+    id              BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name            VARCHAR(255) NOT NULL,
+    description     TEXT,
+    api_key         VARCHAR(256) NOT NULL,
+    retriever_engines TEXT NOT NULL DEFAULT ('[]'),
+    status          VARCHAR(50) DEFAULT 'active',
+    business        VARCHAR(255) NOT NULL,
+    storage_quota   BIGINT NOT NULL DEFAULT 10737418240,
+    storage_used    BIGINT NOT NULL DEFAULT 0,
+    agent_config    TEXT DEFAULT NULL,
+    context_config  TEXT,
+    conversation_config TEXT,
+    web_search_config   TEXT DEFAULT NULL,
+    parser_engine_config    TEXT DEFAULT NULL,
+    storage_engine_config   TEXT DEFAULT NULL,
+    credentials     TEXT DEFAULT NULL,
+    chat_history_config TEXT,
+    retrieval_config TEXT,
+    created_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at      DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_tenants_api_key ON tenants(api_key);
+CREATE INDEX idx_tenants_status ON tenants(status);
+
+CREATE TABLE IF NOT EXISTS models (
+    id              VARCHAR(64) PRIMARY KEY,
+    tenant_id       BIGINT NOT NULL,
+    name            VARCHAR(255) NOT NULL,
+    display_name    VARCHAR(255) NOT NULL DEFAULT '',
+    type            VARCHAR(50) NOT NULL,
+    source          VARCHAR(50) NOT NULL,
+    description     TEXT,
+    parameters      TEXT NOT NULL,
+    is_default      TINYINT(1) NOT NULL DEFAULT 0,
+    is_builtin      TINYINT(1) NOT NULL DEFAULT 0,
+    managed_by      VARCHAR(32) NOT NULL DEFAULT '',
+    status          VARCHAR(50) NOT NULL DEFAULT 'active',
+    created_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at      DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_models_type ON models(type);
+CREATE INDEX idx_models_source ON models(source);
+CREATE INDEX idx_models_is_builtin ON models(is_builtin);
+CREATE INDEX idx_models_managed_by ON models(managed_by);
+
+CREATE TABLE IF NOT EXISTS knowledge_bases (
+    id                      VARCHAR(36) PRIMARY KEY,
+    name                    VARCHAR(255) NOT NULL,
+    description             TEXT,
+    tenant_id               BIGINT NOT NULL,
+    type                    VARCHAR(32) NOT NULL DEFAULT 'document',
+    chunking_config         TEXT NOT NULL DEFAULT ('{"chunk_size": 512, "chunk_overlap": 50, "split_markers": ["\n\n", "\n", "。"], "keep_separator": true}'),
+    image_processing_config TEXT NOT NULL DEFAULT ('{"enable_multimodal": false, "model_id": ""}'),
+    embedding_model_id      VARCHAR(64) NOT NULL,
+    summary_model_id        VARCHAR(64) NOT NULL,
+    cos_config              TEXT NOT NULL DEFAULT ('{}'),
+    storage_provider_config TEXT DEFAULT NULL,
+    vlm_config              TEXT NOT NULL DEFAULT ('{}'),
+    extract_config          TEXT NULL DEFAULT NULL,
+    faq_config              TEXT,
+    question_generation_config TEXT NULL,
+    is_temporary            TINYINT(1) NOT NULL DEFAULT 0,
+    is_pinned               INT NOT NULL DEFAULT 0,
+    pinned_at               DATETIME(6) NULL,
+    asr_config              TEXT,
+    vector_store_id         VARCHAR(36),
+    creator_id              VARCHAR(36),
+    wiki_config             JSON DEFAULT NULL,
+    indexing_strategy       JSON DEFAULT NULL,
+    created_at              DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at              DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at              DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_knowledge_bases_tenant_id ON knowledge_bases(tenant_id);
+CREATE INDEX idx_knowledge_bases_tenant_vector_store ON knowledge_bases(tenant_id, vector_store_id);
+CREATE INDEX idx_knowledge_bases_tenant_creator ON knowledge_bases(tenant_id, creator_id);
+
+CREATE TABLE IF NOT EXISTS knowledges (
+    id                  VARCHAR(36) PRIMARY KEY,
+    tenant_id           BIGINT NOT NULL,
+    knowledge_base_id   VARCHAR(36) NOT NULL,
+    type                VARCHAR(50) NOT NULL,
+    title               VARCHAR(255) NOT NULL,
+    description         TEXT,
+    source              VARCHAR(2048) NOT NULL,
+    parse_status        VARCHAR(50) NOT NULL DEFAULT 'unprocessed',
+    enable_status       VARCHAR(50) NOT NULL DEFAULT 'enabled',
+    embedding_model_id  VARCHAR(64),
+    file_name           VARCHAR(255),
+    file_type           VARCHAR(50),
+    file_size           BIGINT,
+    file_path           TEXT,
+    file_hash           VARCHAR(64),
+    storage_size        BIGINT NOT NULL DEFAULT 0,
+    metadata            TEXT,
+    summary_status      VARCHAR(32) DEFAULT 'none',
+    last_faq_import_result TEXT DEFAULT NULL,
+    channel             VARCHAR(50) NOT NULL DEFAULT 'web',
+    created_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    processed_at        DATETIME(6),
+    error_message       TEXT,
+    pending_subtasks_count INT NOT NULL DEFAULT 0,
+    deleted_at          DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_knowledges_tenant_id ON knowledges(tenant_id);
+CREATE INDEX idx_knowledges_base_id ON knowledges(knowledge_base_id);
+CREATE INDEX idx_knowledges_parse_status ON knowledges(parse_status);
+CREATE INDEX idx_knowledges_enable_status ON knowledges(enable_status);
+CREATE INDEX idx_knowledges_summary_status ON knowledges(summary_status);
+
+CREATE TABLE IF NOT EXISTS knowledge_tag_relations (
+    knowledge_id    VARCHAR(36) NOT NULL,
+    tag_id          VARCHAR(36) NOT NULL,
+    created_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (knowledge_id, tag_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_ktr_knowledge ON knowledge_tag_relations(knowledge_id);
+CREATE INDEX idx_ktr_tag ON knowledge_tag_relations(tag_id);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id                  VARCHAR(36) PRIMARY KEY,
+    tenant_id           BIGINT NOT NULL,
+    title               VARCHAR(255),
+    description         TEXT,
+    knowledge_base_id   VARCHAR(36),
+    max_rounds          INT NOT NULL DEFAULT 5,
+    enable_rewrite      TINYINT(1) NOT NULL DEFAULT 1,
+    fallback_strategy   VARCHAR(255) NOT NULL DEFAULT 'fixed',
+    fallback_response   TEXT NOT NULL,
+    keyword_threshold   FLOAT NOT NULL DEFAULT 0.5,
+    vector_threshold    FLOAT NOT NULL DEFAULT 0.5,
+    rerank_model_id     VARCHAR(64),
+    embedding_top_k     INT NOT NULL DEFAULT 10,
+    rerank_top_k        INT NOT NULL DEFAULT 10,
+    rerank_threshold    FLOAT NOT NULL DEFAULT 0.65,
+    summary_model_id    VARCHAR(64),
+    summary_parameters  TEXT NOT NULL DEFAULT ('{}'),
+    agent_config        TEXT DEFAULT NULL,
+    context_config      TEXT DEFAULT NULL,
+    agent_id            VARCHAR(36),
+    user_id             VARCHAR(36),
+    is_pinned           TINYINT(1) NOT NULL DEFAULT 0,
+    pinned_at           DATETIME(6),
+    created_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at          DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_sessions_tenant_id ON sessions(tenant_id);
+CREATE INDEX idx_sessions_agent_id ON sessions(agent_id);
+-- Note: Postgres has a partial index (WHERE deleted_at IS NULL); MySQL uses a full index.
+CREATE INDEX idx_sessions_tenant_user_pin ON sessions(tenant_id, user_id, is_pinned, pinned_at, updated_at);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id                  VARCHAR(36) PRIMARY KEY,
+    request_id          VARCHAR(36) NOT NULL,
+    session_id          VARCHAR(36) NOT NULL,
+    role                VARCHAR(50) NOT NULL,
+    content             LONGTEXT NOT NULL,
+    rendered_content    LONGTEXT NOT NULL DEFAULT (''),
+    knowledge_references TEXT NOT NULL DEFAULT ('[]'),
+    agent_steps         TEXT DEFAULT NULL,
+    mentioned_items     TEXT DEFAULT ('[]'),
+    images              TEXT DEFAULT ('[]'),
+    is_completed        TINYINT(1) NOT NULL DEFAULT 0,
+    is_fallback         TINYINT(1) NOT NULL DEFAULT 0,
+    channel             VARCHAR(50) NOT NULL DEFAULT '',
+    agent_duration_ms   INT DEFAULT 0,
+    knowledge_id        VARCHAR(36),
+    created_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at          DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_messages_session_id ON messages(session_id);
+CREATE INDEX idx_messages_knowledge_id ON messages(knowledge_id);
+
+CREATE TABLE IF NOT EXISTS chunks (
+    id                      VARCHAR(36) PRIMARY KEY,
+    tenant_id               BIGINT NOT NULL,
+    knowledge_base_id       VARCHAR(36) NOT NULL,
+    knowledge_id            VARCHAR(36) NOT NULL,
+    content                 LONGTEXT NOT NULL,
+    chunk_index             INT NOT NULL,
+    is_enabled              TINYINT(1) NOT NULL DEFAULT 1,
+    start_at                INT NOT NULL,
+    end_at                  INT NOT NULL,
+    pre_chunk_id            VARCHAR(36),
+    next_chunk_id           VARCHAR(36),
+    chunk_type              VARCHAR(20) NOT NULL DEFAULT 'text',
+    parent_chunk_id         VARCHAR(36),
+    image_info              TEXT,
+    video_info              TEXT,
+    relation_chunks         TEXT,
+    indirect_relation_chunks TEXT,
+    metadata                TEXT,
+    tag_id                  VARCHAR(36),
+    status                  INT NOT NULL DEFAULT 0,
+    content_hash            VARCHAR(64),
+    flags                   INT NOT NULL DEFAULT 1,
+    seq_id                  INT,
+    created_at              DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at              DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at              DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_chunks_tenant_kg ON chunks(tenant_id, knowledge_id);
+CREATE INDEX idx_chunks_parent_id ON chunks(parent_chunk_id);
+CREATE INDEX idx_chunks_chunk_type ON chunks(chunk_type);
+CREATE INDEX idx_chunks_tag ON chunks(tag_id);
+CREATE INDEX idx_chunks_content_hash ON chunks(content_hash);
+CREATE UNIQUE INDEX idx_chunks_seq_id ON chunks(seq_id);
+CREATE INDEX idx_chunks_kb_tenant ON chunks(knowledge_base_id, tenant_id);
+CREATE INDEX idx_chunks_knowledge_enabled ON chunks(knowledge_id, is_enabled, deleted_at);
+
+CREATE TABLE IF NOT EXISTS users (
+    id                      VARCHAR(36) PRIMARY KEY,
+    username                VARCHAR(100) NOT NULL UNIQUE,
+    email                   VARCHAR(255) NOT NULL UNIQUE,
+    password_hash           VARCHAR(255) NOT NULL,
+    avatar                  VARCHAR(500),
+    tenant_id               BIGINT,
+    is_active               TINYINT(1) NOT NULL DEFAULT 1,
+    can_access_all_tenants  TINYINT(1) NOT NULL DEFAULT 0,
+    is_system_admin         TINYINT(1) NOT NULL DEFAULT 0,
+    preferences             TEXT NOT NULL DEFAULT ('{}'),
+    created_at              DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at              DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at              DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_users_username ON users(username);
+CREATE INDEX idx_users_email ON users(email);
+CREATE INDEX idx_users_tenant_id ON users(tenant_id);
+CREATE INDEX idx_users_deleted_at ON users(deleted_at);
+CREATE INDEX idx_users_is_system_admin ON users(is_system_admin);
+
+CREATE TABLE IF NOT EXISTS auth_tokens (
+    id          VARCHAR(36) PRIMARY KEY,
+    user_id     VARCHAR(36) NOT NULL,
+    token       TEXT NOT NULL,
+    token_type  VARCHAR(50) NOT NULL,
+    expires_at  DATETIME(6) NOT NULL,
+    is_revoked  TINYINT(1) NOT NULL DEFAULT 0,
+    created_at  DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at  DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_auth_tokens_user_id ON auth_tokens(user_id);
+CREATE INDEX idx_auth_tokens_token_type ON auth_tokens(token_type);
+CREATE INDEX idx_auth_tokens_expires_at ON auth_tokens(expires_at);
+
+CREATE TABLE IF NOT EXISTS tenant_members (
+    id          BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    user_id     VARCHAR(36) NOT NULL,
+    tenant_id   BIGINT NOT NULL,
+    role        VARCHAR(20) NOT NULL DEFAULT 'contributor',
+    status      VARCHAR(20) NOT NULL DEFAULT 'active',
+    invited_by  VARCHAR(36),
+    joined_at   DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    created_at  DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at  DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at  DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE UNIQUE INDEX idx_tenant_members_user_tenant_unique ON tenant_members(user_id, tenant_id);
+CREATE INDEX idx_tenant_members_tenant_role ON tenant_members(tenant_id, role);
+CREATE INDEX idx_tenant_members_user ON tenant_members(user_id);
+
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id              BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    tenant_id       BIGINT NOT NULL,
+    actor_user_id   VARCHAR(36) NOT NULL DEFAULT '',
+    actor_role      VARCHAR(32) NOT NULL DEFAULT '',
+    action          VARCHAR(64) NOT NULL,
+    target_type     VARCHAR(32) NOT NULL DEFAULT '',
+    target_id       VARCHAR(64) NOT NULL DEFAULT '',
+    target_user_id  VARCHAR(36) NOT NULL DEFAULT '',
+    request_path    VARCHAR(512) NOT NULL DEFAULT '',
+    request_method  VARCHAR(16) NOT NULL DEFAULT '',
+    outcome         VARCHAR(16) NOT NULL DEFAULT 'success',
+    details         TEXT NOT NULL DEFAULT ('{}'),
+    created_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_audit_logs_tenant_id_desc ON audit_logs(tenant_id, id);
+CREATE INDEX idx_audit_logs_actor ON audit_logs(actor_user_id);
+CREATE INDEX idx_audit_logs_tenant_action ON audit_logs(tenant_id, action);
+CREATE INDEX idx_audit_logs_created_at ON audit_logs(created_at);
+
+CREATE TABLE IF NOT EXISTS user_resource_favorites (
+    user_id         VARCHAR(36) NOT NULL,
+    tenant_id       BIGINT NOT NULL,
+    resource_type   VARCHAR(16) NOT NULL,
+    resource_id     VARCHAR(64) NOT NULL,
+    created_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (user_id, tenant_id, resource_type, resource_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_user_resource_favorites_user_tenant_type_created_at ON user_resource_favorites(user_id, tenant_id, resource_type, created_at);
+CREATE INDEX idx_user_resource_favorites_tenant_id ON user_resource_favorites(tenant_id);
+
+CREATE TABLE IF NOT EXISTS user_kb_pins (
+    tenant_id   BIGINT NOT NULL,
+    user_id     VARCHAR(36) NOT NULL,
+    kb_id       VARCHAR(36) NOT NULL,
+    pinned_at   DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (tenant_id, user_id, kb_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_user_kb_pins_user_tenant_pinned_at ON user_kb_pins(tenant_id, user_id, pinned_at);
+
+CREATE TABLE IF NOT EXISTS tenant_invitations (
+    id              BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    tenant_id       BIGINT NOT NULL,
+    invitee_user_id VARCHAR(36) NOT NULL,
+    invited_by      VARCHAR(36),
+    role            VARCHAR(20) NOT NULL,
+    status          VARCHAR(20) NOT NULL DEFAULT 'pending',
+    message         VARCHAR(500),
+    expires_at      DATETIME(6) NOT NULL,
+    responded_at    DATETIME(6),
+    created_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at      DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Note: Postgres uses a partial UNIQUE index (WHERE status='pending' AND deleted_at IS NULL).
+-- MySQL does not support partial indexes; uniqueness is enforced at application level.
+CREATE INDEX idx_tenant_invitations_unique_pending ON tenant_invitations(tenant_id, invitee_user_id);
+CREATE INDEX idx_tenant_invitations_tenant ON tenant_invitations(tenant_id);
+CREATE INDEX idx_tenant_invitations_invitee ON tenant_invitations(invitee_user_id);
+
+CREATE TABLE IF NOT EXISTS knowledge_tags (
+    id                  VARCHAR(36) PRIMARY KEY,
+    tenant_id           BIGINT NOT NULL,
+    knowledge_base_id   VARCHAR(36) NOT NULL,
+    name                VARCHAR(128) NOT NULL,
+    color               VARCHAR(32),
+    sort_order          INT NOT NULL DEFAULT 0,
+    seq_id              INT,
+    created_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at          DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE UNIQUE INDEX idx_knowledge_tags_kb_name ON knowledge_tags(tenant_id, knowledge_base_id, name);
+CREATE INDEX idx_knowledge_tags_kb ON knowledge_tags(tenant_id, knowledge_base_id);
+CREATE UNIQUE INDEX idx_knowledge_tags_seq_id ON knowledge_tags(seq_id);
+
+CREATE TABLE IF NOT EXISTS mcp_services (
+    id              VARCHAR(36) PRIMARY KEY,
+    tenant_id       BIGINT NOT NULL,
+    name            VARCHAR(255) NOT NULL,
+    description     TEXT,
+    enabled         TINYINT(1) DEFAULT 1,
+    transport_type  VARCHAR(50) NOT NULL,
+    url             VARCHAR(512),
+    headers         TEXT,
+    auth_config     TEXT,
+    advanced_config TEXT,
+    stdio_config    TEXT,
+    env_vars        TEXT,
+    is_builtin      TINYINT(1) NOT NULL DEFAULT 0,
+    created_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at      DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_mcp_services_tenant_id ON mcp_services(tenant_id);
+CREATE INDEX idx_mcp_services_enabled ON mcp_services(enabled);
+CREATE INDEX idx_mcp_services_is_builtin ON mcp_services(is_builtin);
+CREATE INDEX idx_mcp_services_deleted_at ON mcp_services(deleted_at);
+
+CREATE TABLE IF NOT EXISTS mcp_tool_approvals (
+    id                  VARCHAR(36) PRIMARY KEY,
+    tenant_id           BIGINT NOT NULL,
+    service_id          VARCHAR(36) NOT NULL,
+    tool_name           VARCHAR(512) NOT NULL,
+    require_approval    TINYINT(1) NOT NULL DEFAULT 0,
+    created_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    FOREIGN KEY (service_id) REFERENCES mcp_services(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE UNIQUE INDEX idx_mcp_tool_approvals_tenant_svc_tool ON mcp_tool_approvals(tenant_id, service_id, tool_name);
+CREATE INDEX idx_mcp_tool_approvals_service_id ON mcp_tool_approvals(service_id);
+
+CREATE TABLE IF NOT EXISTS mcp_oauth_clients (
+    id              VARCHAR(36) PRIMARY KEY,
+    tenant_id       BIGINT NOT NULL,
+    service_id      VARCHAR(36) NOT NULL,
+    client_id       VARCHAR(512) NOT NULL,
+    client_secret   TEXT,
+    redirect_uri    VARCHAR(1024),
+    created_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    FOREIGN KEY (service_id) REFERENCES mcp_services(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE UNIQUE INDEX idx_mcp_oauth_clients_tenant_svc ON mcp_oauth_clients(tenant_id, service_id);
+CREATE INDEX idx_mcp_oauth_clients_service_id ON mcp_oauth_clients(service_id);
+
+CREATE TABLE IF NOT EXISTS mcp_oauth_tokens (
+    id              VARCHAR(36) PRIMARY KEY,
+    tenant_id       BIGINT NOT NULL,
+    user_id         VARCHAR(64) NOT NULL,
+    service_id      VARCHAR(36) NOT NULL,
+    access_token    TEXT,
+    refresh_token   TEXT,
+    token_type      VARCHAR(32),
+    expires_at      DATETIME(6),
+    created_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    FOREIGN KEY (service_id) REFERENCES mcp_services(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE UNIQUE INDEX idx_mcp_oauth_tokens_tenant_user_svc ON mcp_oauth_tokens(tenant_id, user_id, service_id);
+CREATE INDEX idx_mcp_oauth_tokens_service_id ON mcp_oauth_tokens(service_id);
+CREATE INDEX idx_mcp_oauth_tokens_user_id ON mcp_oauth_tokens(user_id);
+
+CREATE TABLE IF NOT EXISTS custom_agents (
+    id              VARCHAR(36) NOT NULL,
+    name            VARCHAR(255) NOT NULL,
+    description     TEXT,
+    avatar          VARCHAR(64),
+    is_builtin      TINYINT(1) NOT NULL DEFAULT 0,
+    tenant_id       BIGINT NOT NULL,
+    created_by      VARCHAR(36),
+    runnable_by_viewer TINYINT(1) NOT NULL DEFAULT 1,
+    config          TEXT NOT NULL DEFAULT ('{}'),
+    created_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at      DATETIME(6),
+    PRIMARY KEY (id, tenant_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_custom_agents_tenant_id ON custom_agents(tenant_id);
+CREATE INDEX idx_custom_agents_is_builtin ON custom_agents(is_builtin);
+CREATE INDEX idx_custom_agents_deleted_at ON custom_agents(deleted_at);
+
+CREATE TABLE IF NOT EXISTS organizations (
+    id                          VARCHAR(36) PRIMARY KEY,
+    name                        VARCHAR(255) NOT NULL,
+    description                 TEXT,
+    owner_id                    VARCHAR(36) NOT NULL,
+    owner_tenant_id             BIGINT NOT NULL DEFAULT 0,
+    invite_code                 VARCHAR(32),
+    require_approval            TINYINT(1) DEFAULT 0,
+    invite_code_expires_at      DATETIME(6),
+    invite_code_validity_days   SMALLINT NOT NULL DEFAULT 7,
+    avatar                      VARCHAR(512) DEFAULT '',
+    searchable                  TINYINT(1) NOT NULL DEFAULT 0,
+    member_limit                INT NOT NULL DEFAULT 50,
+    created_at                  DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at                  DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at                  DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_organizations_owner_id ON organizations(owner_id);
+CREATE INDEX idx_organizations_owner_tenant ON organizations(owner_tenant_id);
+CREATE INDEX idx_organizations_deleted_at ON organizations(deleted_at);
+
+CREATE TABLE IF NOT EXISTS organization_tenant_members (
+    id                      VARCHAR(36) PRIMARY KEY,
+    organization_id         VARCHAR(36) NOT NULL,
+    tenant_id               BIGINT NOT NULL,
+    role                    VARCHAR(32) NOT NULL DEFAULT 'viewer',
+    representative_user_id  VARCHAR(36) NOT NULL DEFAULT '',
+    joined_at               DATETIME(6),
+    created_at              DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at              DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE UNIQUE INDEX idx_org_tenant_members_unique ON organization_tenant_members(organization_id, tenant_id);
+CREATE INDEX idx_org_tenant_members_by_tenant ON organization_tenant_members(tenant_id);
+CREATE INDEX idx_org_tenant_members_role ON organization_tenant_members(organization_id, role);
+
+CREATE TABLE IF NOT EXISTS kb_shares (
+    id                  VARCHAR(36) PRIMARY KEY,
+    knowledge_base_id   VARCHAR(36) NOT NULL,
+    organization_id     VARCHAR(36) NOT NULL,
+    shared_by_user_id   VARCHAR(36) NOT NULL,
+    source_tenant_id    BIGINT NOT NULL,
+    permission          VARCHAR(32) NOT NULL DEFAULT 'viewer',
+    created_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at          DATETIME(6),
+    FOREIGN KEY (knowledge_base_id) REFERENCES knowledge_bases(id) ON DELETE CASCADE,
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_kb_shares_kb_id ON kb_shares(knowledge_base_id);
+CREATE INDEX idx_kb_shares_org_id ON kb_shares(organization_id);
+CREATE INDEX idx_kb_shares_source_tenant ON kb_shares(source_tenant_id);
+CREATE INDEX idx_kb_shares_deleted_at ON kb_shares(deleted_at);
+
+CREATE TABLE IF NOT EXISTS organization_join_requests (
+    id              VARCHAR(36) PRIMARY KEY,
+    organization_id VARCHAR(36) NOT NULL,
+    user_id         VARCHAR(36) NOT NULL,
+    tenant_id       BIGINT NOT NULL,
+    status          VARCHAR(32) NOT NULL DEFAULT 'pending',
+    requested_role  VARCHAR(32) NOT NULL DEFAULT 'viewer',
+    request_type    VARCHAR(32) NOT NULL DEFAULT 'join',
+    prev_role       VARCHAR(32),
+    message         TEXT,
+    reviewed_by     VARCHAR(36),
+    reviewed_at     DATETIME(6),
+    review_message  TEXT,
+    created_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_org_join_requests_org_id ON organization_join_requests(organization_id);
+CREATE INDEX idx_org_join_requests_user_id ON organization_join_requests(user_id);
+CREATE INDEX idx_org_join_requests_status ON organization_join_requests(status);
+-- Note: Postgres has partial UNIQUE (WHERE status='pending'); MySQL enforces at app level.
+CREATE INDEX uq_org_join_requests_pending_per_tenant ON organization_join_requests(organization_id, tenant_id, request_type);
+
+CREATE TABLE IF NOT EXISTS agent_shares (
+    id                  VARCHAR(36) PRIMARY KEY,
+    agent_id            VARCHAR(36) NOT NULL,
+    organization_id     VARCHAR(36) NOT NULL,
+    shared_by_user_id   VARCHAR(36) NOT NULL,
+    source_tenant_id    BIGINT NOT NULL,
+    permission          VARCHAR(32) NOT NULL DEFAULT 'viewer',
+    created_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at          DATETIME(6),
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_agent_shares_agent_id ON agent_shares(agent_id);
+CREATE INDEX idx_agent_shares_org_id ON agent_shares(organization_id);
+CREATE INDEX idx_agent_shares_source_tenant ON agent_shares(source_tenant_id);
+CREATE INDEX idx_agent_shares_deleted_at ON agent_shares(deleted_at);
+
+CREATE TABLE IF NOT EXISTS tenant_disabled_shared_agents (
+    tenant_id       BIGINT NOT NULL,
+    agent_id        VARCHAR(36) NOT NULL,
+    source_tenant_id BIGINT NOT NULL,
+    created_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (tenant_id, agent_id, source_tenant_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_tenant_disabled_shared_agents_tenant_id ON tenant_disabled_shared_agents(tenant_id);
+
+CREATE TABLE IF NOT EXISTS im_channel_sessions (
+    id              VARCHAR(36) PRIMARY KEY,
+    platform        VARCHAR(20) NOT NULL,
+    user_id         VARCHAR(128) NOT NULL,
+    chat_id         VARCHAR(128) NOT NULL DEFAULT '',
+    session_id      VARCHAR(36) NOT NULL,
+    tenant_id       BIGINT NOT NULL,
+    agent_id        VARCHAR(36) DEFAULT '',
+    im_channel_id   VARCHAR(36) DEFAULT '',
+    thread_id       VARCHAR(128) NOT NULL DEFAULT '',
+    status          VARCHAR(20) NOT NULL DEFAULT 'active',
+    metadata        TEXT DEFAULT ('{}'),
+    created_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at      DATETIME(6),
+    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Note: Postgres has partial UNIQUE indexes (WHERE deleted_at IS NULL). MySQL uses plain indexes.
+CREATE INDEX idx_channel_lookup ON im_channel_sessions(platform, user_id, chat_id, tenant_id);
+CREATE INDEX idx_channel_thread_lookup ON im_channel_sessions(platform, chat_id, thread_id, tenant_id);
+CREATE INDEX idx_im_channel_tenant ON im_channel_sessions(tenant_id);
+CREATE INDEX idx_im_channel_session ON im_channel_sessions(session_id);
+CREATE INDEX idx_im_channel_sessions_channel ON im_channel_sessions(im_channel_id);
+
+CREATE TABLE IF NOT EXISTS im_channels (
+    id                  VARCHAR(36) PRIMARY KEY,
+    tenant_id           BIGINT NOT NULL,
+    agent_id            VARCHAR(36) NOT NULL,
+    platform            VARCHAR(20) NOT NULL,
+    name                VARCHAR(255) NOT NULL DEFAULT '',
+    enabled             INT NOT NULL DEFAULT 1,
+    mode                VARCHAR(20) NOT NULL DEFAULT 'websocket',
+    output_mode         VARCHAR(20) NOT NULL DEFAULT 'stream',
+    credentials         TEXT NOT NULL DEFAULT ('{}'),
+    knowledge_base_id   VARCHAR(36) DEFAULT '',
+    bot_identity        VARCHAR(255) NOT NULL DEFAULT '',
+    session_mode        VARCHAR(20) NOT NULL DEFAULT 'user',
+    created_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at          DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_im_channels_tenant ON im_channels(tenant_id);
+CREATE INDEX idx_im_channels_agent ON im_channels(agent_id);
+-- Note: Postgres has partial UNIQUE (WHERE deleted_at IS NULL AND bot_identity != '').
+CREATE INDEX idx_im_channels_bot_identity ON im_channels(bot_identity);
+
+CREATE TABLE IF NOT EXISTS embed_channels (
+    id                      VARCHAR(36) PRIMARY KEY,
+    tenant_id               BIGINT NOT NULL,
+    agent_id                VARCHAR(36) NOT NULL DEFAULT 'builtin-quick-answer',
+    name                    VARCHAR(255) NOT NULL DEFAULT '',
+    enabled                 INT NOT NULL DEFAULT 1,
+    publish_token           VARCHAR(64) NOT NULL DEFAULT '',
+    allowed_origins         TEXT NOT NULL DEFAULT ('[]'),
+    welcome_message         TEXT NOT NULL DEFAULT (''),
+    rate_limit_per_minute   INT NOT NULL DEFAULT 30,
+    rate_limit_per_day      INT NOT NULL DEFAULT 10000,
+    primary_color           VARCHAR(32) NOT NULL DEFAULT '',
+    page_title              VARCHAR(255) NOT NULL DEFAULT '',
+    header_title_mode       VARCHAR(32) NOT NULL DEFAULT 'channel',
+    show_suggested_questions INT NOT NULL DEFAULT 1,
+    widget_position         VARCHAR(32) NOT NULL DEFAULT 'bottom-right',
+    allow_web_search        INT NOT NULL DEFAULT 0,
+    allow_memory            INT NOT NULL DEFAULT 0,
+    allow_file_upload       INT NOT NULL DEFAULT 0,
+    default_locale          VARCHAR(16) NOT NULL DEFAULT '',
+    webhook_url             VARCHAR(512) NOT NULL DEFAULT '',
+    webhook_secret          VARCHAR(128) NOT NULL DEFAULT '',
+    created_at              DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at              DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at              DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_embed_channels_tenant ON embed_channels(tenant_id);
+CREATE INDEX idx_embed_channels_agent ON embed_channels(agent_id);
+-- Note: Postgres has partial UNIQUE (WHERE publish_token != '' AND deleted_at IS NULL).
+CREATE INDEX idx_embed_channels_publish_token ON embed_channels(publish_token);
+
+CREATE TABLE IF NOT EXISTS data_sources (
+    id                      VARCHAR(36) NOT NULL PRIMARY KEY,
+    tenant_id               BIGINT NOT NULL,
+    knowledge_base_id       VARCHAR(36) NOT NULL,
+    name                    VARCHAR(255) NOT NULL,
+    type                    VARCHAR(50) NOT NULL,
+    config                  TEXT,
+    sync_schedule           VARCHAR(100),
+    sync_mode               VARCHAR(20) DEFAULT 'incremental',
+    status                  VARCHAR(32) DEFAULT 'active',
+    conflict_strategy       VARCHAR(32) DEFAULT 'overwrite',
+    sync_deletions          INT DEFAULT 1,
+    last_sync_at            DATETIME(6) NULL,
+    last_sync_cursor        TEXT,
+    last_sync_result        TEXT,
+    error_message           TEXT,
+    sync_log_retention_days INT DEFAULT 30,
+    created_at              DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at              DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at              DATETIME(6) NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_data_sources_tenant_id ON data_sources(tenant_id);
+CREATE INDEX idx_data_sources_knowledge_base_id ON data_sources(knowledge_base_id);
+CREATE INDEX idx_data_sources_type ON data_sources(type);
+CREATE INDEX idx_data_sources_status ON data_sources(status);
+CREATE INDEX idx_data_sources_deleted_at ON data_sources(deleted_at);
+
+CREATE TABLE IF NOT EXISTS sync_logs (
+    id              VARCHAR(36) NOT NULL PRIMARY KEY,
+    data_source_id  VARCHAR(36) NOT NULL,
+    tenant_id       BIGINT NOT NULL,
+    status          VARCHAR(32) NOT NULL,
+    started_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    finished_at     DATETIME(6) NULL,
+    items_total     INT DEFAULT 0,
+    items_created   INT DEFAULT 0,
+    items_updated   INT DEFAULT 0,
+    items_deleted   INT DEFAULT 0,
+    items_skipped   INT DEFAULT 0,
+    items_failed    INT DEFAULT 0,
+    error_message   TEXT,
+    result          TEXT,
+    created_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    FOREIGN KEY (data_source_id) REFERENCES data_sources(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_sync_logs_data_source_id ON sync_logs(data_source_id);
+CREATE INDEX idx_sync_logs_tenant_id ON sync_logs(tenant_id);
+CREATE INDEX idx_sync_logs_status ON sync_logs(status);
+CREATE INDEX idx_sync_logs_started_at ON sync_logs(started_at);
+
+CREATE TABLE IF NOT EXISTS web_search_providers (
+    id          VARCHAR(36) NOT NULL PRIMARY KEY,
+    tenant_id   BIGINT NOT NULL,
+    name        VARCHAR(255) NOT NULL,
+    provider    VARCHAR(50) NOT NULL,
+    description TEXT,
+    parameters  TEXT,
+    is_default  INT DEFAULT 0,
+    created_at  DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at  DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at  DATETIME(6) NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_web_search_providers_tenant_id ON web_search_providers(tenant_id);
+CREATE INDEX idx_web_search_providers_provider ON web_search_providers(provider);
+CREATE INDEX idx_web_search_providers_deleted_at ON web_search_providers(deleted_at);
+
+CREATE TABLE IF NOT EXISTS vector_stores (
+    id                  VARCHAR(36) NOT NULL PRIMARY KEY,
+    name                VARCHAR(255) NOT NULL,
+    engine_type         VARCHAR(50) NOT NULL,
+    connection_config   TEXT NOT NULL DEFAULT ('{}'),
+    index_config        TEXT NOT NULL DEFAULT ('{}'),
+    tenant_id           BIGINT NOT NULL,
+    created_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at          DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at          DATETIME(6) NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Note: Postgres has partial UNIQUE (WHERE deleted_at IS NULL); MySQL uses a plain index.
+CREATE INDEX idx_vector_stores_name_tenant ON vector_stores(name, tenant_id);
+CREATE INDEX idx_vector_stores_tenant_id ON vector_stores(tenant_id);
+CREATE INDEX idx_vector_stores_engine_type ON vector_stores(engine_type);
+CREATE INDEX idx_vector_stores_deleted_at ON vector_stores(deleted_at);
+
+CREATE TABLE IF NOT EXISTS wiki_pages (
+    id                  VARCHAR(36) PRIMARY KEY,
+    tenant_id           BIGINT NOT NULL,
+    knowledge_base_id   VARCHAR(36) NOT NULL,
+    slug                VARCHAR(255) NOT NULL,
+    title               VARCHAR(512) NOT NULL DEFAULT '',
+    page_type           VARCHAR(32) NOT NULL DEFAULT 'summary',
+    status              VARCHAR(32) NOT NULL DEFAULT 'published',
+    content             LONGTEXT NOT NULL DEFAULT (''),
+    summary             TEXT NOT NULL DEFAULT (''),
+    parent_slug         VARCHAR(255) NOT NULL DEFAULT '',
+    folder_id           VARCHAR(36) NOT NULL DEFAULT '',
+    category_path       JSON,
+    wiki_path           VARCHAR(1024) NOT NULL DEFAULT '',
+    depth               INT NOT NULL DEFAULT 0,
+    sort_order          INT NOT NULL DEFAULT 0,
+    source_refs         JSON,
+    chunk_refs          JSON,
+    in_links            JSON,
+    out_links           JSON,
+    page_metadata       JSON,
+    aliases             JSON,
+    version             INT NOT NULL DEFAULT 1,
+    created_at          DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at          DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at          DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Note: Postgres has partial UNIQUE (WHERE deleted_at IS NULL).
+CREATE UNIQUE INDEX idx_wiki_pages_kb_slug ON wiki_pages(knowledge_base_id, slug);
+CREATE INDEX idx_wiki_pages_kb_id ON wiki_pages(knowledge_base_id);
+CREATE INDEX idx_wiki_pages_page_type ON wiki_pages(knowledge_base_id, page_type);
+CREATE INDEX idx_wiki_pages_parent_slug ON wiki_pages(knowledge_base_id, parent_slug);
+CREATE INDEX idx_wiki_pages_tree ON wiki_pages(knowledge_base_id, page_type, wiki_path(100), sort_order, title(100));
+CREATE INDEX idx_wiki_pages_folder_id ON wiki_pages(folder_id);
+
+CREATE TABLE IF NOT EXISTS wiki_page_issues (
+    id                      VARCHAR(36) PRIMARY KEY,
+    tenant_id               BIGINT NOT NULL,
+    knowledge_base_id       VARCHAR(36) NOT NULL,
+    slug                    VARCHAR(255) NOT NULL,
+    issue_type              VARCHAR(50) NOT NULL,
+    description             TEXT NOT NULL,
+    suspected_knowledge_ids JSON,
+    status                  VARCHAR(20) NOT NULL DEFAULT 'pending',
+    reported_by             VARCHAR(100) NOT NULL,
+    created_at              DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at              DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at              DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_wiki_page_issues_tenant_id ON wiki_page_issues(tenant_id);
+CREATE INDEX idx_wiki_page_issues_knowledge_base_id ON wiki_page_issues(knowledge_base_id);
+CREATE INDEX idx_wiki_page_issues_slug ON wiki_page_issues(slug);
+CREATE INDEX idx_wiki_page_issues_status ON wiki_page_issues(status);
+
+CREATE TABLE IF NOT EXISTS wiki_log_entries (
+    id                  BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    tenant_id           BIGINT NOT NULL,
+    knowledge_base_id   VARCHAR(36) NOT NULL,
+    action              VARCHAR(32) NOT NULL,
+    knowledge_id        VARCHAR(36) NOT NULL DEFAULT '',
+    doc_title           TEXT NOT NULL DEFAULT (''),
+    summary             TEXT NOT NULL DEFAULT (''),
+    pages_affected      JSON,
+    created_at          DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_wiki_log_entries_kb_id_desc ON wiki_log_entries(knowledge_base_id, id);
+CREATE INDEX idx_wiki_log_entries_tenant_id ON wiki_log_entries(tenant_id);
+
+CREATE TABLE IF NOT EXISTS wiki_folders (
+    id                  VARCHAR(36) PRIMARY KEY,
+    tenant_id           BIGINT NOT NULL DEFAULT 0,
+    knowledge_base_id   VARCHAR(36) NOT NULL,
+    parent_id           VARCHAR(36) NOT NULL DEFAULT '',
+    name                VARCHAR(255) NOT NULL,
+    path                VARCHAR(1024) NOT NULL DEFAULT '',
+    depth               INT NOT NULL DEFAULT 0,
+    sort_order          INT NOT NULL DEFAULT 0,
+    created_at          DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at          DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at          DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Note: Postgres has partial UNIQUE (WHERE deleted_at IS NULL).
+CREATE UNIQUE INDEX idx_wiki_folders_parent_name ON wiki_folders(knowledge_base_id, parent_id, name);
+CREATE INDEX idx_wiki_folders_parent ON wiki_folders(knowledge_base_id, parent_id);
+CREATE INDEX idx_wiki_folders_deleted_at ON wiki_folders(deleted_at);
+
+CREATE TABLE IF NOT EXISTS task_pending_ops (
+    id          BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    tenant_id   BIGINT NOT NULL,
+    task_type   VARCHAR(64) NOT NULL,
+    scope       VARCHAR(32) NOT NULL,
+    scope_id    VARCHAR(64) NOT NULL,
+    op          VARCHAR(32) NOT NULL,
+    dedup_key   VARCHAR(128) NOT NULL DEFAULT '',
+    payload     JSON NOT NULL,
+    fail_count  INT NOT NULL DEFAULT 0,
+    enqueued_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    claimed_at  DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_task_pending_ops_scope ON task_pending_ops(task_type, scope, scope_id, id);
+CREATE INDEX idx_task_pending_ops_tenant ON task_pending_ops(tenant_id);
+
+CREATE TABLE IF NOT EXISTS task_dead_letters (
+    id          BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    tenant_id   BIGINT NOT NULL,
+    task_type   VARCHAR(64) NOT NULL,
+    scope       VARCHAR(32) NOT NULL,
+    scope_id    VARCHAR(64) NOT NULL,
+    related_id  VARCHAR(64) NOT NULL DEFAULT '',
+    payload     JSON NOT NULL,
+    last_error  TEXT NOT NULL DEFAULT (''),
+    fail_count  INT NOT NULL,
+    failed_at   DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_task_dead_letters_scope ON task_dead_letters(scope, scope_id, failed_at);
+CREATE INDEX idx_task_dead_letters_tenant ON task_dead_letters(tenant_id, failed_at);
+CREATE INDEX idx_task_dead_letters_task_type ON task_dead_letters(task_type, failed_at);
+
+CREATE TABLE IF NOT EXISTS system_settings (
+    id                  BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `key`               VARCHAR(128) NOT NULL UNIQUE,
+    value               JSON NOT NULL,
+    value_type          VARCHAR(16) NOT NULL,
+    category            VARCHAR(32) NOT NULL,
+    description         TEXT NOT NULL DEFAULT (''),
+    is_secret           TINYINT(1) NOT NULL DEFAULT 0,
+    requires_restart    TINYINT(1) NOT NULL DEFAULT 0,
+    last_modified_by    VARCHAR(36) NOT NULL DEFAULT '',
+    created_at          DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at          DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_system_settings_category ON system_settings(category);
+
+CREATE TABLE IF NOT EXISTS knowledge_processing_spans (
+    id              BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    knowledge_id    VARCHAR(64) NOT NULL,
+    attempt         INT NOT NULL DEFAULT 1,
+    span_id         VARCHAR(64) NOT NULL,
+    parent_span_id  VARCHAR(64),
+    name            VARCHAR(64) NOT NULL,
+    kind            VARCHAR(16) NOT NULL,
+    status          VARCHAR(16) NOT NULL,
+    input           JSON,
+    output          JSON,
+    metadata        JSON,
+    error_code      VARCHAR(64),
+    error_message   TEXT,
+    error_detail    TEXT,
+    started_at      DATETIME(6),
+    finished_at     DATETIME(6),
+    duration_ms     BIGINT,
+    created_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    CONSTRAINT uq_kpspan_attempt_span UNIQUE (knowledge_id, attempt, span_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_kpspan_knowledge_attempt ON knowledge_processing_spans(knowledge_id, attempt);
+CREATE INDEX idx_kpspan_status_started ON knowledge_processing_spans(status, started_at);
+CREATE INDEX idx_kpspan_parent ON knowledge_processing_spans(parent_span_id);

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -76,6 +76,7 @@ show_help() {
     echo ""
     echo "示例："
     echo "  $0 start                    # 启动基础服务"
+    echo "  $0 start --mysql            # 启动基础服务 + MySQL（或设置 DB_DRIVER=mysql 自动触发）"
     echo "  $0 start --qdrant           # 启动基础服务 + Qdrant"
     echo "  $0 start --dex             # 启动基础服务 + Dex"
     echo "  $0 start --odl-hybrid       # 启动基础服务 + OpenDataLoader hybrid"
@@ -171,10 +172,22 @@ start_services() {
     shift  # 移除 "start" 命令本身
     # 默认启动基础设施（postgres / redis / docreader）+ langfuse，
     # 其余可选服务通过 --minio / --qdrant / --neo4j / --dex / --full 按需开启。
-    PROFILES="--profile langfuse"
-    ENABLED_SERVICES="langfuse"
+    # 根据 DB_DRIVER 二选一启动数据库
+    # MySQL 模式：只启动 mysql + redis + docreader（langfuse 依赖 postgres，跳过）
+    # Postgres 模式：启动 postgres + redis + docreader + langfuse
+    if [ "${DB_DRIVER:-}" = "mysql" ]; then
+        PROFILES="--profile mysql"
+        ENABLED_SERVICES="mysql"
+    else
+        PROFILES="--profile postgres --profile langfuse"
+        ENABLED_SERVICES="postgres langfuse"
+    fi
     while [ $# -gt 0 ]; do
         case "$1" in
+            --mysql)
+                PROFILES="$PROFILES --profile mysql"
+                ENABLED_SERVICES="$ENABLED_SERVICES mysql"
+                ;;
             --minio)
                 PROFILES="$PROFILES --profile minio"
                 ENABLED_SERVICES="$ENABLED_SERVICES minio"
@@ -234,11 +247,18 @@ start_services() {
         log_success "基础设施服务已启动"
         echo ""
         log_info "服务访问地址:"
-        echo "  - PostgreSQL:    localhost:5432"
+        if [ "${DB_DRIVER:-}" = "mysql" ]; then
+            echo "  - MySQL:         localhost:${MYSQL_DEV_PORT:-3306}"
+        else
+            echo "  - PostgreSQL:    localhost:${POSTGRES_DEV_PORT:-5432}"
+        fi
         echo "  - Redis:         localhost:6379"
         echo "  - DocReader:     localhost:50051"
-        
+
         # 根据启用的 profile 显示额外服务
+        if [[ "$ENABLED_SERVICES" == *"mysql"* ]] && [ "${DB_DRIVER:-}" != "mysql" ]; then
+            echo "  - MySQL:         localhost:${MYSQL_DEV_PORT:-3306}"
+        fi
         if [[ "$ENABLED_SERVICES" == *"minio"* ]]; then
             echo "  - MinIO:         localhost:9000 (Console: localhost:9001)"
         fi


### PR DESCRIPTION
## Description

Add MySQL 8.0 as an alternative to PostgreSQL for the relational primary database (`DB_DRIVER=mysql`).

WeKnora has two independent data layers: the relational layer (`DB_DRIVER`) and the vector layer (`RETRIEVE_DRIVER`). Since MySQL has no native vector capability, MySQL mode must be paired with an external vector store (e.g. Milvus / Qdrant) — pgvector is not used.

Main changes:
- **Driver wiring** (`internal/container/container.go`): add `case "mysql"`, building the DSN via `gomysql.Config.FormatDSN()` so special chars (`@`, `#`, `!`) in the password are escaped correctly; wire `gorm.io/driver/mysql` and relax the dialector allowlist.
- **Migrations** (`internal/database/migration.go` + `migrations/mysql/`): route `mysql://` DSNs to `migrations/mysql/`; add a consolidated single-file init (mirroring the SQLite pattern). MySQL dialect adaptations: `AUTO_INCREMENT`, `DATETIME(6)`, `JSON`, 8.0.13+ expression defaults for TEXT columns, index prefix lengths, `ENGINE=InnoDB`/`utf8mb4`.
- **Reserved word fix** (`internal/application/repository/system_setting.go`): quote the reserved word `key` via `clause.Column`.
- **Orchestration / scripts** (`docker-compose.yml`, `docker-compose.dev.yml`, `scripts/dev.sh`): add a `mysql` service (profile); `dev.sh` selects postgres or mysql based on `DB_DRIVER` (MySQL mode skips the postgres-dependent Langfuse stack).
- **Docs**: new `docs/使用MySQL数据库.md` guide; annotate `.env.example`; link from both READMEs.

## Type of Change
- [x] ✨ New feature

## Related Issue
Closes #1418

## Testing
Local `./scripts/dev.sh start` (with `DB_DRIVER=mysql`) brings up mysql-dev + redis + docreader; `make dev-app` starts the backend:
- golang-migrate creates all tables cleanly from version 0 (no dirty state)
- No `key ASC` reserved-word error, no `pending_subtasks_count` missing-column error
- App listens on `:8080`; register/login works
- `gofmt` clean, `go build ./...` passes, `bash -n scripts/dev.sh` passes

## Checklist
- [x] `make fmt && make lint && make test` pass locally (verified gofmt/build/bash-syntax; full lint/test recommended in CI)
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change (migration + driver wiring verified via manual e2e)
- [x] Updated related documentation (README, docs/, .env.example)
- [x] Breaking changes are clearly called out — none; default remains postgres

## Known Limitations
- Vector retrieval must use an external engine (pgvector unavailable in MySQL mode)
- Self-hosted Langfuse is unavailable (Langfuse upstream only supports PostgreSQL); `dev.sh` skips it automatically in MySQL mode
- Requires MySQL >= 8.0.13 (expression defaults for TEXT columns)
