### PR TITLE
feat(agent): add configurable MCP OAuth wait timeout per agent

### DIFF
--- a/frontend/src/api/agent/index.ts
+++ b/frontend/src/api/agent/index.ts
@@ -33,6 +33,9 @@ export interface CustomAgentConfig {
   // MCP服务选择模式：all=全部启用的MCP服务, selected=指定服务, none=不使用MCP
   mcp_selection_mode?: 'all' | 'selected' | 'none';
   mcp_services?: string[];          // 选择的MCP服务ID列表
+  // 对话中触发 OAuth 授权时的等待超时（秒）：到点后自动跳过授权提示。
+  // <=0 时使用服务端默认超时。仅对使用 OAuth 的 MCP 服务生效。
+  mcp_auth_wait_timeout?: number;
 
   // ===== Skills设置（仅Agent模式）=====
   // Skills选择模式：all=全部预装, selected=指定, none=不使用

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -5440,6 +5440,9 @@ export default {
       selectLabel: 'Select MCP Services',
       selectDesc: 'Select MCP services to enable',
       selectPlaceholder: 'Select MCP services',
+      authWaitTimeout: 'Authentication Wait Timeout (s)',
+      authWaitTimeoutDesc: 'Maximum seconds to wait for you to complete OAuth authentication when prompted during a conversation; the prompt is skipped after it elapses (only affects OAuth MCP services).',
+      authWaitTimeoutPlaceholder: 'Default 600 seconds',
     },
     llmCallTimeout: {
       label: "LLM Call Timeout",

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -5451,6 +5451,9 @@ export default {
       selectLabel: 'MCP 서비스 선택',
       selectDesc: '활성화할 MCP 서비스를 선택하세요',
       selectPlaceholder: 'MCP 서비스 선택',
+      authWaitTimeout: '인증 대기 시간(초)',
+      authWaitTimeoutDesc: '대화 중 OAuth 인증이 필요할 때 인증 완료를 기다리는 최대 시간(초)이며, 초과하면 인증 요청을 건너뜁니다(OAuth를 사용하는 MCP 서비스에만 적용).',
+      authWaitTimeoutPlaceholder: '기본 600초',
     },
     llmCallTimeout: {
       label: "LLM 호출 타임아웃",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -4950,7 +4950,9 @@ export default {
       desc: 'Выберите MCP-сервисы, доступные агенту',
       selectLabel: 'Выбор MCP-сервисов',
       selectDesc: 'Выберите MCP-сервисы для включения',
-      selectPlaceholder: 'Выберите MCP-сервисы'
+      selectPlaceholder: 'Выберите MCP-сервисы',
+      authWaitTimeout: 'Тайм-аут ожидания аутентификации (с)',
+      authWaitTimeoutDesc: 'Максимальное время ожидания (в секундах) завершения OAuth-аутентификации при запросе во время диалога; по его истечении запрос пропускается (влияет только на MCP-сервисы с OAuth).'
     },
     llmCallTimeout: {
       label: 'Таймаут вызова LLM',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -5453,6 +5453,9 @@ export default {
       selectLabel: "选择 MCP 服务",
       selectDesc: "选择要启用的 MCP 服务",
       selectPlaceholder: "选择 MCP 服务",
+      authWaitTimeout: "授权等待超时（秒）",
+      authWaitTimeoutDesc: "对话中触发 OAuth 授权时，等待你完成授权的最长秒数，超时后自动跳过授权提示（仅对使用 OAuth 的 MCP 服务生效）。",
+      authWaitTimeoutPlaceholder: "默认 600 秒",
     },
     llmCallTimeout: {
       label: "LLM 调用超时",

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -967,6 +967,18 @@
                         </t-select>
                       </div>
                     </div>
+
+                    <!-- 授权等待超时：对话中触发 OAuth 授权时的等待秒数 -->
+                    <div v-if="mcpSelectionMode !== 'none'" class="setting-row">
+                      <div class="setting-info">
+                        <label>{{ $t('agentEditor.mcp.authWaitTimeout') }}</label>
+                        <p class="desc">{{ $t('agentEditor.mcp.authWaitTimeoutDesc') }}</p>
+                      </div>
+                      <div class="setting-control">
+                        <t-input-number v-model="formData.config.mcp_auth_wait_timeout" :min="5" :max="3600"
+                          theme="column" :placeholder="$t('agentEditor.mcp.authWaitTimeoutPlaceholder')" />
+                      </div>
+                    </div>
                   </div>
                 </div>
 
@@ -1990,6 +2002,8 @@ const defaultFormData = {
     // MCP 服务设置
     mcp_selection_mode: 'none' as 'all' | 'selected' | 'none',
     mcp_services: [] as string[],
+    // 对话中触发 OAuth 授权时的等待超时（秒），默认 600
+    mcp_auth_wait_timeout: 600,
     // Skills 设置
     skills_selection_mode: 'none' as 'all' | 'selected' | 'none',
     selected_skills: [] as string[],
@@ -2561,6 +2575,10 @@ watch(() => props.visible, async (val) => {
       if (!agentData.config.knowledge_bases) agentData.config.knowledge_bases = [];
       if (!agentData.config.allowed_tools) agentData.config.allowed_tools = [];
       if (!agentData.config.mcp_services) agentData.config.mcp_services = [];
+      // 授权等待超时：旧数据缺省时用默认 600 秒
+      if (agentData.config.mcp_auth_wait_timeout == null || agentData.config.mcp_auth_wait_timeout <= 0) {
+        agentData.config.mcp_auth_wait_timeout = 600;
+      }
       if (!agentData.config.selected_skills) agentData.config.selected_skills = [];
       if (!agentData.config.supported_file_types) agentData.config.supported_file_types = [];
 

--- a/internal/agent/approval/gate.go
+++ b/internal/agent/approval/gate.go
@@ -117,6 +117,10 @@ type OAuthPendingRequest struct {
 	ServiceName        string
 	MCPToolName        string
 	ToolCallID         string
+	// WaitTimeout overrides the gate's default wait timeout when > 0. The wait
+	// is always bounded (either by this value, the gate default, or ctx
+	// cancellation) so the blocked goroutine never leaks.
+	WaitTimeout time.Duration
 }
 
 var _ MCPApproval = (*Gate)(nil)
@@ -446,7 +450,12 @@ func (g *Gate) RequestOAuthAndWait(ctx context.Context, req OAuthPendingRequest)
 		g.mu.Unlock()
 	}()
 
-	timeoutSec := int(g.timeout / time.Second)
+	waitTimeout := g.timeout
+	if req.WaitTimeout > 0 {
+		waitTimeout = req.WaitTimeout
+	}
+
+	timeoutSec := int(waitTimeout / time.Second)
 	if timeoutSec < 1 {
 		timeoutSec = 1
 	}
@@ -497,7 +506,7 @@ func (g *Gate) RequestOAuthAndWait(ctx context.Context, req OAuthPendingRequest)
 		})
 	}
 
-	timer := time.NewTimer(g.timeout)
+	timer := time.NewTimer(waitTimeout)
 	defer timer.Stop()
 
 	var d Decision

--- a/internal/agent/tools/mcp_oauth.go
+++ b/internal/agent/tools/mcp_oauth.go
@@ -15,6 +15,18 @@ import (
 
 const defaultMCPToolExecTimeout = 60 * time.Second
 
+// oauthWaitTimeout derives the in-conversation OAuth wait timeout from the
+// agent's user-configured value (carried on the session, in seconds). The wait
+// is ALWAYS bounded to avoid leaking the blocked goroutine when the user
+// neither authorizes nor skips: a value <= 0 returns 0, which tells the gate to
+// fall back to its configured default timeout.
+func oauthWaitTimeout(sess *MCPOAuthSession) time.Duration {
+	if sess == nil || sess.AuthWaitTimeoutSeconds <= 0 {
+		return 0
+	}
+	return time.Duration(sess.AuthWaitTimeoutSeconds) * time.Second
+}
+
 // MCPOAuthSession carries chat/session metadata so MCP connect and tool
 // registration can pause for in-conversation OAuth. Nil disables the prompt.
 type MCPOAuthSession struct {
@@ -28,6 +40,9 @@ type MCPOAuthSession struct {
 	ApprovalCtx context.Context
 	// ExecTimeout, when >0, caps the retry ctx after a successful authorization.
 	ExecTimeout time.Duration
+	// AuthWaitTimeoutSeconds is the agent-level, user-configured number of
+	// seconds to wait for in-conversation OAuth authorization. See oauthWaitTimeout.
+	AuthWaitTimeoutSeconds int
 }
 
 // oauthSessionFromToolExec builds an OAuth session from per-tool execution metadata.
@@ -54,6 +69,16 @@ func oauthSessionFromToolExec(ctx context.Context, meta *ToolExecContext) *MCPOA
 	}
 }
 
+// withAuthWaitTimeout returns sess with the agent-level OAuth wait timeout
+// (seconds) applied. Safe on a nil session.
+func (s *MCPOAuthSession) withAuthWaitTimeout(seconds int) *MCPOAuthSession {
+	if s == nil {
+		return nil
+	}
+	s.AuthWaitTimeoutSeconds = seconds
+	return s
+}
+
 // oauthSessionForRegistration builds an OAuth session for tool discovery at agent startup.
 func oauthSessionForRegistration(ctx context.Context, sess *MCPOAuthSession, retryTimeout time.Duration) *MCPOAuthSession {
 	if sess == nil || sess.EventBus == nil {
@@ -73,13 +98,14 @@ func oauthSessionForRegistration(ctx context.Context, sess *MCPOAuthSession, ret
 		requestID, _ = types.RequestIDFromContext(ctx)
 	}
 	return &MCPOAuthSession{
-		EventBus:           sess.EventBus,
-		SessionID:          sess.SessionID,
-		AssistantMessageID: sess.AssistantMessageID,
-		UserID:             userID,
-		RequestID:          requestID,
-		ApprovalCtx:        approvalCtx,
-		ExecTimeout:        retryTimeout,
+		EventBus:               sess.EventBus,
+		SessionID:              sess.SessionID,
+		AssistantMessageID:     sess.AssistantMessageID,
+		UserID:                 userID,
+		RequestID:              requestID,
+		ApprovalCtx:            approvalCtx,
+		ExecTimeout:            retryTimeout,
+		AuthWaitTimeoutSeconds: sess.AuthWaitTimeoutSeconds,
 	}
 }
 
@@ -161,6 +187,7 @@ func waitForMCPOAuthAuthorization(
 		ServiceName:        service.Name,
 		MCPToolName:        mcpToolName,
 		ToolCallID:         toolCallID,
+		WaitTimeout:        oauthWaitTimeout(sess),
 	})
 	if waitErr != nil || !decision.Approved {
 		return ctx, noop, false

--- a/internal/agent/tools/mcp_tool.go
+++ b/internal/agent/tools/mcp_tool.go
@@ -22,15 +22,24 @@ type MCPTool struct {
 	mcpTool    *types.MCPTool
 	mcpManager *mcp.MCPManager
 	gate       approval.MCPApproval // optional human approval before CallTool (issue #1173)
+	// authWaitTimeoutSeconds carries the agent-level, user-configured OAuth wait
+	// timeout (seconds) applied when a tool call triggers in-conversation auth.
+	// <=0 uses the gate's configured default.
+	authWaitTimeoutSeconds int
 }
 
-// NewMCPTool creates a new MCP tool wrapper
-func NewMCPTool(service *types.MCPService, mcpTool *types.MCPTool, mcpManager *mcp.MCPManager, gate approval.MCPApproval) *MCPTool {
+// NewMCPTool creates a new MCP tool wrapper. authWaitTimeoutSeconds carries the
+// agent-level OAuth wait timeout applied when a tool call triggers in-conversation auth.
+func NewMCPTool(
+	service *types.MCPService, mcpTool *types.MCPTool,
+	mcpManager *mcp.MCPManager, gate approval.MCPApproval, authWaitTimeoutSeconds int,
+) *MCPTool {
 	return &MCPTool{
-		service:    service,
-		mcpTool:    mcpTool,
-		mcpManager: mcpManager,
-		gate:       gate,
+		service:                service,
+		mcpTool:                mcpTool,
+		mcpManager:             mcpManager,
+		gate:                   gate,
+		authWaitTimeoutSeconds: authWaitTimeoutSeconds,
 	}
 }
 
@@ -175,7 +184,7 @@ func (t *MCPTool) Execute(ctx context.Context, args json.RawMessage) (*types.Too
 
 	isStdio := t.service.TransportType == types.MCPTransportStdio
 	meta, _ := ToolExecFromContext(ctx)
-	oauthSess := oauthSessionFromToolExec(ctx, meta)
+	oauthSess := oauthSessionFromToolExec(ctx, meta).withAuthWaitTimeout(t.authWaitTimeoutSeconds)
 	toolCallID := ""
 	if meta != nil {
 		toolCallID = meta.ToolCallID
@@ -424,6 +433,10 @@ func RegisterMCPTools(
 	}
 
 	registered := 0
+	authWaitTimeoutSeconds := 0
+	if oauthSess != nil {
+		authWaitTimeoutSeconds = oauthSess.AuthWaitTimeoutSeconds
+	}
 	regOAuth := oauthSessionForRegistration(ctx, oauthSess, listToolsTimeout)
 	for _, service := range services {
 		if !service.Enabled {
@@ -479,7 +492,7 @@ func RegisterMCPTools(
 
 		// Register each tool
 		for _, mcpTool := range mcpTools {
-			tool := NewMCPTool(service, mcpTool, mcpManager, gate)
+			tool := NewMCPTool(service, mcpTool, mcpManager, gate, authWaitTimeoutSeconds)
 			toolName := tool.Name()
 
 			// Check for name collision before registering (first-wins policy).

--- a/internal/application/service/agent_service.go
+++ b/internal/application/service/agent_service.go
@@ -283,10 +283,11 @@ func (s *agentService) registerMCPTools(
 		var regCtx *tools.MCPOAuthSession
 		if eventBus != nil && sessionID != "" && assistantMessageID != "" {
 			regCtx = &tools.MCPOAuthSession{
-				EventBus:           eventBus,
-				SessionID:          sessionID,
-				AssistantMessageID: assistantMessageID,
-				ApprovalCtx:        ctx,
+				EventBus:               eventBus,
+				SessionID:              sessionID,
+				AssistantMessageID:     assistantMessageID,
+				ApprovalCtx:            ctx,
+				AuthWaitTimeoutSeconds: config.MCPAuthWaitTimeout,
 			}
 		}
 		registered, err := tools.RegisterMCPTools(

--- a/internal/application/service/session_agent_qa.go
+++ b/internal/application/service/session_agent_qa.go
@@ -227,6 +227,7 @@ func (s *sessionService) buildAgentConfig(
 		HistoryTurns:                customAgent.Config.HistoryTurns,
 		MCPSelectionMode:            customAgent.Config.MCPSelectionMode,
 		MCPServices:                 customAgent.Config.MCPServices,
+		MCPAuthWaitTimeout:          customAgent.Config.MCPAuthWaitTimeout,
 		Thinking:                    customAgent.Config.Thinking,
 		RetrieveKBOnlyWhenMentioned: customAgent.Config.RetrieveKBOnlyWhenMentioned,
 		LLMCallTimeout:              customAgent.Config.LLMCallTimeout,

--- a/internal/types/agent.go
+++ b/internal/types/agent.go
@@ -32,6 +32,10 @@ type AgentConfig struct {
 	// MCP service selection
 	MCPSelectionMode string   `json:"mcp_selection_mode"` // MCP selection mode: "all", "selected", "none"
 	MCPServices      []string `json:"mcp_services"`       // Selected MCP service IDs (when mode is "selected")
+	// MCPAuthWaitTimeout is how many seconds an agent run waits for
+	// in-conversation OAuth authorization before skipping. <=0 falls back to
+	// the gate's configured timeout. The wait is always bounded (no leak).
+	MCPAuthWaitTimeout int `json:"mcp_auth_wait_timeout,omitempty"`
 	// Whether to enable thinking mode (for models that support extended thinking)
 	Thinking *bool `json:"thinking"`
 	// Whether to retrieve knowledge base only when explicitly mentioned with @ (default: false)

--- a/internal/types/custom_agent.go
+++ b/internal/types/custom_agent.go
@@ -135,6 +135,9 @@ type CustomAgentConfig struct {
 	MCPSelectionMode string `yaml:"mcp_selection_mode" json:"mcp_selection_mode"`
 	// Selected MCP service IDs (only used when MCPSelectionMode is "selected")
 	MCPServices []string `yaml:"mcp_services" json:"mcp_services"`
+	// MCPAuthWaitTimeout is how many seconds to wait for in-conversation OAuth
+	// authorization before skipping. <=0 uses the gate's configured timeout.
+	MCPAuthWaitTimeout int `yaml:"mcp_auth_wait_timeout,omitempty" json:"mcp_auth_wait_timeout,omitempty"`
 
 	// ===== Skills Settings (only for smart-reasoning mode) =====
 	// Skills selection mode: "all" = all preloaded skills, "selected" = specific skills, "none" = no skills


### PR DESCRIPTION
## Summary
- Add `mcp_auth_wait_timeout` to custom agent config so each agent can control how long in-conversation OAuth prompts wait before auto-skipping (default 600s).
- Wire the timeout through agent runtime, MCP tool registration/execution, and the approval gate so waits are always bounded.
- Expose the setting in the agent editor with i18n strings (zh-CN, en-US, ko-KR, ru-RU).

## Test plan
- [ ] Create/edit an agent with MCP services enabled and set a short auth wait timeout (e.g. 10s).
- [ ] Start a conversation that triggers MCP OAuth; confirm the prompt auto-skips after the configured timeout.
- [ ] Leave the field at default (600s) and verify existing agents behave as before.
- [ ] Confirm the setting is hidden when MCP selection mode is `none`.