### PR TITLE
fix(agent): treat end_turn as natural stop

### DIFF
--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -338,6 +338,29 @@ func TestExecuteLoop_NaturalStop_DoesNotDuplicateAnswer(t *testing.T) {
 	assert.GreaterOrEqual(t, doneCount, 1, "a Done marker must close the answer stream")
 }
 
+// TestExecuteLoop_EndTurnTerminates ensures Anthropic-style end_turn is treated
+// like OpenAI's stop when no tool calls are present. Otherwise the ReAct loop
+// keeps asking the model again and streams repeated answer chunks.
+func TestExecuteLoop_EndTurnTerminates(t *testing.T) {
+	mock := &mockChat{
+		responses: []mockResponse{
+			{chunks: []types.StreamResponse{
+				{ResponseType: types.ResponseTypeAnswer, Content: "The answer.", Done: true, FinishReason: "end_turn"},
+			}},
+		},
+	}
+
+	engine := newTestEngine(t, mock)
+	state := &types.AgentState{}
+	_, err := engine.executeLoop(context.Background(), state, "test query",
+		emptyMessages(), emptyTools(), "sess-1", "msg-1")
+	require.NoError(t, err)
+
+	assert.True(t, state.IsComplete)
+	assert.Equal(t, "The answer.", state.FinalAnswer)
+	assert.Equal(t, 1, mock.callCount, "end_turn must end the loop after the first model call")
+}
+
 func TestStreamFinalAnswerToEventBus_EmitsDoneWhenProviderEndsWithEmptyChunk(t *testing.T) {
 	mock := &mockChat{
 		responses: []mockResponse{

--- a/internal/agent/observe.go
+++ b/internal/agent/observe.go
@@ -58,8 +58,19 @@ type responseVerdict struct {
 	step         types.AgentStep
 }
 
+// isNaturalStopFinishReason reports whether a provider finish reason means the
+// assistant has ended its message without requesting more tool work.
+func isNaturalStopFinishReason(reason string) bool {
+	switch strings.ToLower(strings.TrimSpace(reason)) {
+	case "stop", "end_turn", "stop_sequence":
+		return true
+	default:
+		return false
+	}
+}
+
 // analyzeResponse inspects the LLM response for stop conditions:
-//   - finish_reason == "stop" with no tool calls → agent is done (natural stop)
+//   - natural finish reason with no tool calls → agent is done (natural stop)
 //   - finish_reason == "content_filter" with no tool calls → agent is done (content filtered)
 //
 // The agent ends a turn by stopping naturally with its answer as plain
@@ -114,8 +125,8 @@ func (e *AgentEngine) analyzeResponse(
 		}
 	}
 
-	// Case 1: LLM stopped naturally without requesting any tool calls
-	if response.FinishReason == "stop" && len(response.ToolCalls) == 0 {
+	// Case 1: LLM stopped naturally without requesting any tool calls.
+	if isNaturalStopFinishReason(response.FinishReason) && len(response.ToolCalls) == 0 {
 		// Strip <think>…</think> blocks that some models embed in content
 		// (DeepSeek, Qwen, etc.) before processing or displaying.
 		response.Content = agenttools.StripThinkBlocks(response.Content)

--- a/internal/agent/observe_test.go
+++ b/internal/agent/observe_test.go
@@ -41,22 +41,36 @@ func TestAnalyzeResponse_ToolCall_DoesNotTerminate(t *testing.T) {
 		"non-terminal tool calls must keep the loop running")
 }
 
-// TestAnalyzeResponse_NaturalStop_Terminates guards the sole termination path:
-// finish_reason == "stop" with no tool calls ends the loop and surfaces the
-// plain content as the final answer.
+// TestAnalyzeResponse_NaturalStop_Terminates guards the termination path:
+// a natural finish reason with no tool calls ends the loop and surfaces the
+// plain content as the final answer. Different providers use different labels
+// for the same "assistant turn is done" state.
 func TestAnalyzeResponse_NaturalStop_Terminates(t *testing.T) {
-	engine := newTestEngine(t, &mockChat{})
-	resp := &types.ChatResponse{
-		FinishReason: "stop",
-		Content:      "Here is the answer.",
+	tests := []struct {
+		name         string
+		finishReason string
+	}{
+		{name: "openai_stop", finishReason: "stop"},
+		{name: "anthropic_end_turn", finishReason: "end_turn"},
+		{name: "anthropic_stop_sequence", finishReason: "stop_sequence"},
 	}
 
-	verdict := engine.analyzeResponse(
-		context.Background(), resp, types.AgentStep{}, 0, "sess-1", time.Now(),
-	)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine := newTestEngine(t, &mockChat{})
+			resp := &types.ChatResponse{
+				FinishReason: tt.finishReason,
+				Content:      "Here is the answer.",
+			}
 
-	assert.True(t, verdict.isDone, "a natural stop with no tool calls must terminate the loop")
-	assert.Equal(t, "Here is the answer.", verdict.finalAnswer)
+			verdict := engine.analyzeResponse(
+				context.Background(), resp, types.AgentStep{}, 0, "sess-1", time.Now(),
+			)
+
+			assert.True(t, verdict.isDone, "a natural stop with no tool calls must terminate the loop")
+			assert.Equal(t, "Here is the answer.", verdict.finalAnswer)
+		})
+	}
 }
 
 // TestAppendToolResults_PreservesReasoningContent verifies that the assistant

--- a/internal/agent/think.go
+++ b/internal/agent/think.go
@@ -437,9 +437,9 @@ func (e *AgentEngine) callLLMWithRetry(
 			round, response.FinishReason, len(response.Content))
 		// Early signal for natural-stop path: this round will be analyzed as a
 		// likely final answer (no tool call branch).
-		if response.FinishReason == "stop" {
-			logger.Infof(ctx, "[Agent][Round-%d] Natural-stop candidate detected (finish=stop, tool_calls=0, content=%d chars)",
-				round, len(response.Content))
+		if isNaturalStopFinishReason(response.FinishReason) {
+			logger.Infof(ctx, "[Agent][Round-%d] Natural-stop candidate detected (finish=%s, tool_calls=0, content=%d chars)",
+				round, response.FinishReason, len(response.Content))
 		}
 	}
 	if response.Content != "" {


### PR DESCRIPTION
## Summary
- Treat provider finish reasons `end_turn` and `stop_sequence` as natural agent stops when no tool calls are present.
- Reuse the same natural-stop detection in diagnostic logging.
- Add regression tests for response analysis and the ReAct execute loop so `end_turn` does not trigger another model round.

## Root Cause
Some providers, including Anthropic-compatible APIs, use `end_turn` to signal that the assistant message is complete. The Agent loop only recognized `finish_reason == "stop"`, so `end_turn` responses with no tool calls were treated as non-terminal and the loop continued, streaming repeated answer chunks.

## Validation
- `git diff --check`
- `go test ./internal/agent` *(blocked on Windows by existing upstream build issue in `internal/utils/inject.go`: `undefined: pg_query.Parse` / `pg_query.Deparse` from `github.com/pganalyze/pg_query_go/v6`)*
