### PR TITLE
feat(knowledge): expose generated questions per knowledge via REST API

### DIFF
--- a/internal/application/service/knowledge_generated_questions.go
+++ b/internal/application/service/knowledge_generated_questions.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// GetGeneratedQuestions returns all AI-generated questions for a knowledge item,
+// aggregated across all of its text chunks.
+func (s *knowledgeService) GetGeneratedQuestions(ctx context.Context, knowledgeID string) ([]*types.KnowledgeGeneratedQuestion, error) {
+	chunks, err := s.chunkService.ListChunksByKnowledgeID(ctx, knowledgeID)
+	if err != nil {
+		logger.Errorf(ctx, "GetGeneratedQuestions: failed to list chunks for knowledge %s: %v", knowledgeID, err)
+		return nil, err
+	}
+
+	results := aggregateGeneratedQuestions(chunks)
+	logger.Infof(ctx, "GetGeneratedQuestions: knowledge %s returned %d questions from %d chunks",
+		knowledgeID, len(results), len(chunks))
+	return results, nil
+}
+
+// aggregateGeneratedQuestions extracts all AI-generated questions from a slice of
+// chunks, skipping non-text chunks and empty questions. Exported as a package-level
+// helper so tests can exercise the aggregation logic without mocking the full service.
+func aggregateGeneratedQuestions(chunks []*types.Chunk) []*types.KnowledgeGeneratedQuestion {
+	var results []*types.KnowledgeGeneratedQuestion
+	for _, chunk := range chunks {
+		if chunk.ChunkType != types.ChunkTypeText {
+			continue
+		}
+		meta, err := chunk.DocumentMetadata()
+		if err != nil || meta == nil || len(meta.GeneratedQuestions) == 0 {
+			continue
+		}
+		for _, gq := range meta.GeneratedQuestions {
+			if gq.Question == "" {
+				continue
+			}
+			results = append(results, &types.KnowledgeGeneratedQuestion{
+				ChunkID:    chunk.ID,
+				QuestionID: gq.ID,
+				Question:   gq.Question,
+			})
+		}
+	}
+	return results
+}

--- a/internal/application/service/knowledge_generated_questions.go
+++ b/internal/application/service/knowledge_generated_questions.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"strings"
 
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
@@ -36,13 +37,14 @@ func aggregateGeneratedQuestions(chunks []*types.Chunk) []*types.KnowledgeGenera
 			continue
 		}
 		for _, gq := range meta.GeneratedQuestions {
-			if gq.Question == "" {
+			question := strings.TrimSpace(gq.Question)
+			if question == "" {
 				continue
 			}
 			results = append(results, &types.KnowledgeGeneratedQuestion{
 				ChunkID:    chunk.ID,
 				QuestionID: gq.ID,
-				Question:   gq.Question,
+				Question:   question,
 			})
 		}
 	}

--- a/internal/application/service/knowledge_generated_questions_test.go
+++ b/internal/application/service/knowledge_generated_questions_test.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// buildTextChunkWithQuestions creates a text Chunk with embedded GeneratedQuestions.
+func buildTextChunkWithQuestions(id string, questions []types.GeneratedQuestion) *types.Chunk {
+	chunk := &types.Chunk{
+		ID:        id,
+		ChunkType: types.ChunkTypeText,
+	}
+	if len(questions) > 0 {
+		meta := &types.DocumentChunkMetadata{GeneratedQuestions: questions}
+		_ = chunk.SetDocumentMetadata(meta)
+	}
+	return chunk
+}
+
+func TestAggregateGeneratedQuestions_ReturnsQuestionsFromTextChunks(t *testing.T) {
+	chunks := []*types.Chunk{
+		buildTextChunkWithQuestions("chunk-1", []types.GeneratedQuestion{
+			{ID: "q1", Question: "What is the return policy?"},
+			{ID: "q2", Question: "How long does shipping take?"},
+		}),
+	}
+
+	got := aggregateGeneratedQuestions(chunks)
+
+	require.Len(t, got, 2)
+	require.Equal(t, "chunk-1", got[0].ChunkID)
+	require.Equal(t, "q1", got[0].QuestionID)
+	require.Equal(t, "What is the return policy?", got[0].Question)
+	require.Equal(t, "q2", got[1].QuestionID)
+}
+
+func TestAggregateGeneratedQuestions_SkipsNonTextChunks(t *testing.T) {
+	textChunk := buildTextChunkWithQuestions("chunk-text", []types.GeneratedQuestion{
+		{ID: "q1", Question: "How do I contact support?"},
+	})
+	faqChunk := &types.Chunk{
+		ID:        "chunk-faq",
+		ChunkType: types.ChunkTypeFAQ,
+	}
+	_ = faqChunk.SetDocumentMetadata(&types.DocumentChunkMetadata{
+		GeneratedQuestions: []types.GeneratedQuestion{{ID: "q99", Question: "Should be skipped"}},
+	})
+
+	got := aggregateGeneratedQuestions([]*types.Chunk{textChunk, faqChunk})
+
+	require.Len(t, got, 1)
+	require.Equal(t, "chunk-text", got[0].ChunkID)
+}
+
+func TestAggregateGeneratedQuestions_EmptyWhenNoQuestionsGenerated(t *testing.T) {
+	chunks := []*types.Chunk{
+		buildTextChunkWithQuestions("chunk-1", nil),
+	}
+
+	got := aggregateGeneratedQuestions(chunks)
+
+	require.Empty(t, got)
+}
+
+func TestAggregateGeneratedQuestions_SkipsEmptyQuestionText(t *testing.T) {
+	chunks := []*types.Chunk{
+		buildTextChunkWithQuestions("chunk-1", []types.GeneratedQuestion{
+			{ID: "q1", Question: "Valid question"},
+			{ID: "q2", Question: ""},
+		}),
+	}
+
+	got := aggregateGeneratedQuestions(chunks)
+
+	require.Len(t, got, 1)
+	require.Equal(t, "Valid question", got[0].Question)
+}
+
+func TestAggregateGeneratedQuestions_MultipleChunks(t *testing.T) {
+	chunks := []*types.Chunk{
+		buildTextChunkWithQuestions("chunk-1", []types.GeneratedQuestion{
+			{ID: "q1", Question: "First chunk question"},
+		}),
+		buildTextChunkWithQuestions("chunk-2", []types.GeneratedQuestion{
+			{ID: "q2", Question: "Second chunk question"},
+			{ID: "q3", Question: "Another second chunk question"},
+		}),
+	}
+
+	got := aggregateGeneratedQuestions(chunks)
+
+	require.Len(t, got, 3)
+	require.Equal(t, "chunk-1", got[0].ChunkID)
+	require.Equal(t, "chunk-2", got[1].ChunkID)
+	require.Equal(t, "chunk-2", got[2].ChunkID)
+}

--- a/internal/application/service/knowledge_generated_questions_test.go
+++ b/internal/application/service/knowledge_generated_questions_test.go
@@ -68,8 +68,9 @@ func TestAggregateGeneratedQuestions_EmptyWhenNoQuestionsGenerated(t *testing.T)
 func TestAggregateGeneratedQuestions_SkipsEmptyQuestionText(t *testing.T) {
 	chunks := []*types.Chunk{
 		buildTextChunkWithQuestions("chunk-1", []types.GeneratedQuestion{
-			{ID: "q1", Question: "Valid question"},
+			{ID: "q1", Question: "  Valid question  "},
 			{ID: "q2", Question: ""},
+			{ID: "q3", Question: " \t\n "},
 		}),
 	}
 

--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -2403,13 +2403,15 @@ func (h *KnowledgeHandler) GetKnowledgeGeneratedQuestions(c *gin.Context) {
 		return
 	}
 
-	// Validate KB access (viewer permission is sufficient for read)
-	if _, _, err := h.resolveKnowledgeAndValidateKBAccess(c, id, types.OrgRoleViewer); err != nil {
+	// Validate KB access (viewer permission is sufficient for read).
+	// Use the effective context so shared KB reads query the source tenant.
+	_, effCtx, err := h.resolveKnowledgeAndValidateKBAccess(c, id, types.OrgRoleViewer)
+	if err != nil {
 		c.Error(err)
 		return
 	}
 
-	questions, err := h.kgService.GetGeneratedQuestions(ctx, id)
+	questions, err := h.kgService.GetGeneratedQuestions(effCtx, id)
 	if err != nil {
 		logger.Errorf(ctx, "GetKnowledgeGeneratedQuestions: failed for knowledge %s: %v", id, err)
 		c.Error(err)

--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -2380,3 +2380,44 @@ func (h *KnowledgeHandler) BatchReparseKnowledge(c *gin.Context) {
 		},
 	})
 }
+
+// GetKnowledgeGeneratedQuestions godoc
+// @Summary      Get AI-generated questions for a knowledge item
+// @Description  Returns all questions that were automatically generated from the
+//
+//	knowledge item's text chunks during post-processing. Each question is linked
+//	to the chunk it was derived from, enabling downstream pipelines (e.g. FAQ
+//	population) to retrieve the source context via the chunk ID.
+//
+// @Tags         知识管理
+// @Produce      json
+// @Param        id   path   string  true  "Knowledge ID"
+// @Success      200  {object}  map[string]interface{}  "data: [{chunk_id, question_id, question}]"
+// @Router       /api/v1/knowledge/{id}/generated-questions [get]
+func (h *KnowledgeHandler) GetKnowledgeGeneratedQuestions(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	id := secutils.SanitizeForLog(c.Param("id"))
+	if id == "" {
+		c.Error(errors.NewBadRequestError("Knowledge ID cannot be empty"))
+		return
+	}
+
+	// Validate KB access (viewer permission is sufficient for read)
+	if _, _, err := h.resolveKnowledgeAndValidateKBAccess(c, id, types.OrgRoleViewer); err != nil {
+		c.Error(err)
+		return
+	}
+
+	questions, err := h.kgService.GetGeneratedQuestions(ctx, id)
+	if err != nil {
+		logger.Errorf(ctx, "GetKnowledgeGeneratedQuestions: failed for knowledge %s: %v", id, err)
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    questions,
+	})
+}

--- a/internal/handler/rbac_lookups_test.go
+++ b/internal/handler/rbac_lookups_test.go
@@ -221,6 +221,7 @@ func newKnowledgeHandlerCtx(t *testing.T, tenantID uint64, knowledgeID string) (
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/knowledge/"+knowledgeID+"/generated-questions", nil)
 	ctx := context.WithValue(c.Request.Context(), types.TenantIDContextKey, tenantID)
+	ctx = context.WithValue(ctx, types.TenantRoleContextKey, types.TenantRoleAdmin)
 	c.Request = c.Request.WithContext(ctx)
 	c.Set(types.TenantIDContextKey.String(), tenantID)
 	c.Params = gin.Params{{Key: "id", Value: knowledgeID}}

--- a/internal/handler/rbac_lookups_test.go
+++ b/internal/handler/rbac_lookups_test.go
@@ -182,17 +182,49 @@ func TestAgentCreatorLookup_CrossTenantIsHiddenAsNotFound(t *testing.T) {
 // reaches outside GetOwningKBCreatorID should fail loudly, not silently.
 type stubKgService struct {
 	interfaces.KnowledgeService
-	getOwningKBCreatorID func(ctx context.Context, knowledgeID string) (string, error)
+	getOwningKBCreatorID  func(ctx context.Context, knowledgeID string) (string, error)
+	getKnowledgeByIDOnly  func(ctx context.Context, knowledgeID string) (*types.Knowledge, error)
+	getGeneratedQuestions func(ctx context.Context, knowledgeID string) ([]*types.KnowledgeGeneratedQuestion, error)
 }
 
 func (s *stubKgService) GetOwningKBCreatorID(ctx context.Context, knowledgeID string) (string, error) {
 	return s.getOwningKBCreatorID(ctx, knowledgeID)
 }
 
+func (s *stubKgService) GetKnowledgeByIDOnly(ctx context.Context, knowledgeID string) (*types.Knowledge, error) {
+	return s.getKnowledgeByIDOnly(ctx, knowledgeID)
+}
+
+func (s *stubKgService) GetGeneratedQuestions(ctx context.Context, knowledgeID string) ([]*types.KnowledgeGeneratedQuestion, error) {
+	return s.getGeneratedQuestions(ctx, knowledgeID)
+}
+
+type stubKnowledgeKBShareService struct {
+	interfaces.KBShareService
+	check func(ctx context.Context, kbID string, callerTenantID uint64, callerTenantRole types.TenantRole) (types.OrgMemberRole, bool, error)
+}
+
+func (s *stubKnowledgeKBShareService) CheckTenantKBPermission(ctx context.Context, kbID string, callerTenantID uint64, callerTenantRole types.TenantRole) (types.OrgMemberRole, bool, error) {
+	return s.check(ctx, kbID, callerTenantID, callerTenantRole)
+}
+
 // newKnowledgeLookupCtx builds a gin.Context shaped like the
 // /knowledge/:id route — :id holds a knowledge id.
 func newKnowledgeLookupCtx(t *testing.T, tenantID uint64, knowledgeID string) *gin.Context {
 	return newKBLookupCtx(t, tenantID, knowledgeID)
+}
+
+func newKnowledgeHandlerCtx(t *testing.T, tenantID uint64, knowledgeID string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/knowledge/"+knowledgeID+"/generated-questions", nil)
+	ctx := context.WithValue(c.Request.Context(), types.TenantIDContextKey, tenantID)
+	c.Request = c.Request.WithContext(ctx)
+	c.Set(types.TenantIDContextKey.String(), tenantID)
+	c.Params = gin.Params{{Key: "id", Value: knowledgeID}}
+	return c, w
 }
 
 // newChunkLookupCtx builds a gin.Context shaped like the
@@ -220,6 +252,59 @@ func newWikiLookupCtx(t *testing.T, tenantID uint64, kbID string) *gin.Context {
 	c.Request = c.Request.WithContext(ctx)
 	c.Params = gin.Params{{Key: "kb_id", Value: kbID}}
 	return c
+}
+
+func TestGetKnowledgeGeneratedQuestions_UsesEffectiveTenantContextForSharedKB(t *testing.T) {
+	const (
+		callerTenantID uint64 = 100
+		sourceTenantID uint64 = 200
+		knowledgeID           = "kn-1"
+		kbID                  = "kb-1"
+	)
+
+	var gotTenantID uint64
+	h := &KnowledgeHandler{
+		kgService: &stubKgService{
+			getKnowledgeByIDOnly: func(_ context.Context, id string) (*types.Knowledge, error) {
+				if id != knowledgeID {
+					t.Fatalf("unexpected knowledge id: %s", id)
+				}
+				return &types.Knowledge{
+					ID:              knowledgeID,
+					TenantID:        sourceTenantID,
+					KnowledgeBaseID: kbID,
+				}, nil
+			},
+			getGeneratedQuestions: func(ctx context.Context, id string) ([]*types.KnowledgeGeneratedQuestion, error) {
+				if id != knowledgeID {
+					t.Fatalf("unexpected generated question knowledge id: %s", id)
+				}
+				gotTenantID = types.MustTenantIDFromContext(ctx)
+				return []*types.KnowledgeGeneratedQuestion{{ChunkID: "chunk-1", QuestionID: "q1", Question: "Question?"}}, nil
+			},
+		},
+		kbShareService: &stubKnowledgeKBShareService{
+			check: func(_ context.Context, checkedKBID string, checkedTenantID uint64, _ types.TenantRole) (types.OrgMemberRole, bool, error) {
+				if checkedKBID != kbID {
+					t.Fatalf("unexpected kb id: %s", checkedKBID)
+				}
+				if checkedTenantID != callerTenantID {
+					t.Fatalf("unexpected caller tenant id: %d", checkedTenantID)
+				}
+				return types.OrgRoleViewer, true, nil
+			},
+		},
+	}
+	c, w := newKnowledgeHandlerCtx(t, callerTenantID, knowledgeID)
+
+	h.GetKnowledgeGeneratedQuestions(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if gotTenantID != sourceTenantID {
+		t.Fatalf("expected service tenant %d, got %d", sourceTenantID, gotTenantID)
+	}
 }
 
 func TestKBCreatorLookupFromKnowledgeID_NotFoundMapsToSentinel(t *testing.T) {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -310,6 +310,7 @@ func RegisterKnowledgeRoutes(r *gin.RouterGroup, handler *handler.KnowledgeHandl
 		k.GET("/:id", g.Viewer(), g.KBAccessReadFromKnowledgeIDParam("id"), handler.GetKnowledge)
 		k.GET("/:id/stages", g.Viewer(), g.KBAccessReadFromKnowledgeIDParam("id"), handler.GetKnowledgeSpans)
 		k.GET("/:id/spans", g.Viewer(), g.KBAccessReadFromKnowledgeIDParam("id"), handler.GetKnowledgeSpans)
+		k.GET("/:id/generated-questions", g.Viewer(), g.KBAccessReadFromKnowledgeIDParam("id"), handler.GetKnowledgeGeneratedQuestions)
 		k.DELETE("/:id", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.DeleteKnowledge)
 		k.PUT("/:id", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.UpdateKnowledge)
 		k.PUT("/manual/:id", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.UpdateManualKnowledge)

--- a/internal/types/faq.go
+++ b/internal/types/faq.go
@@ -729,3 +729,14 @@ func NormalizeQueryText(q string) string {
 func IsChineseChar(r rune) bool {
 	return unicode.Is(unicode.Han, r)
 }
+
+// KnowledgeGeneratedQuestion represents a single AI-generated question
+// associated with a specific chunk of a knowledge item.
+type KnowledgeGeneratedQuestion struct {
+	// ChunkID is the ID of the chunk this question was generated from.
+	ChunkID string `json:"chunk_id"`
+	// QuestionID is the unique identifier of this generated question within the chunk.
+	QuestionID string `json:"question_id"`
+	// Question is the generated question text.
+	Question string `json:"question"`
+}

--- a/internal/types/interfaces/knowledge.go
+++ b/internal/types/interfaces/knowledge.go
@@ -197,6 +197,11 @@ type KnowledgeService interface {
 	SearchKnowledge(ctx context.Context, keyword string, offset, limit int, fileTypes []string) ([]*types.Knowledge, bool, int64, error)
 	// SearchKnowledgeForScopes searches knowledge within the given (tenant_id, kb_id) scopes (e.g. for shared agent context).
 	SearchKnowledgeForScopes(ctx context.Context, scopes []types.KnowledgeSearchScope, keyword string, offset, limit int, fileTypes []string) ([]*types.Knowledge, bool, int64, error)
+
+	// GetGeneratedQuestions returns all AI-generated questions for a knowledge item,
+	// aggregated across all of its text chunks. Questions are produced during
+	// post-processing and stored in chunk metadata.
+	GetGeneratedQuestions(ctx context.Context, knowledgeID string) ([]*types.KnowledgeGeneratedQuestion, error)
 }
 
 // KnowledgeRepository defines the interface for knowledge repositories.


### PR DESCRIPTION
## Summary

WeKnora auto-generates questions for document chunks during post-processing (via the `generate_questions` prompt), but currently provides no API to retrieve them. This makes it impossible to build downstream pipelines that consume generated questions — for example, auto-populating a FAQ knowledge base by pairing each question with the answer obtained from the `/api/v1/knowledge-search` API.

## Changes

### New endpoint
```
GET /api/v1/knowledge/:id/generated-questions
```
- Returns `{ success: true, data: [{chunk_id, question_id, question}] }`
- Requires Viewer role on the knowledge base (same as `GET /api/v1/knowledge/:id`)
- Returns an empty array when no questions have been generated yet (e.g. generation still in progress or disabled)

### Files changed
| File | Change |
|---|---|
| `internal/types/faq.go` | Add `KnowledgeGeneratedQuestion` response type |
| `internal/types/interfaces/knowledge.go` | Add `GetGeneratedQuestions` to `KnowledgeService` interface |
| `internal/application/service/knowledge_generated_questions.go` | Service implementation + `aggregateGeneratedQuestions` pure helper |
| `internal/application/service/knowledge_generated_questions_test.go` | 5 unit tests |
| `internal/handler/knowledge.go` | `GetKnowledgeGeneratedQuestions` handler with Swagger annotation |
| `internal/router/router.go` | Route registration |

## Testing

5 unit tests added for the aggregation logic (pure function, no interface mocking needed):

- `TestAggregateGeneratedQuestions_ReturnsQuestionsFromTextChunks`
- `TestAggregateGeneratedQuestions_SkipsNonTextChunks` — FAQ/image chunks are excluded
- `TestAggregateGeneratedQuestions_EmptyWhenNoQuestionsGenerated`
- `TestAggregateGeneratedQuestions_SkipsEmptyQuestionText`
- `TestAggregateGeneratedQuestions_MultipleChunks`

```
ok  github.com/Tencent/WeKnora/internal/application/service  1.098s
```

## Example usage

```bash
# 1. Upload a document and wait for parse_status=completed
# 2. Retrieve generated questions
curl -H "Authorization: Bearer $TOKEN" \
  https://your-weknora/api/v1/knowledge/$KNOWLEDGE_ID/generated-questions

# Response
{
  "success": true,
  "data": [
    {"chunk_id": "c-001", "question_id": "q1", "question": "What is the return policy?"},
    {"chunk_id": "c-001", "question_id": "q2", "question": "How long does shipping take?"},
    {"chunk_id": "c-002", "question_id": "q3", "question": "Which payment methods are accepted?"}
  ]
}

# 3. For each question, call /api/v1/knowledge-search or knowledge-chat to get the answer
# 4. Write Q+A pairs to a FAQ knowledge base via POST /api/v1/knowledge-bases/:id/faqs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)