### PR TITLE
Fix MCP code import placeholder

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -4508,8 +4508,6 @@ export default {
     codeImport: {
       toggle: 'Import from code',
       hint: 'Paste a standard mcpServers JSON config to auto-fill the form',
-      placeholder:
-        '{\n  "mcpServers": {\n    "my-server": {\n      "url": "https://example.com/sse"\n    }\n  }\n}',
       parse: 'Parse & Fill',
       editOverwriteHint: 'Importing overwrites the current form (saved credentials are unaffected; click Save to apply)',
       errors: {

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -4504,8 +4504,6 @@ export default {
     codeImport: {
       toggle: "코드에서 가져오기",
       hint: "표준 mcpServers JSON 설정을 붙여넣으면 양식이 자동으로 채워집니다",
-      placeholder:
-        '{\n  "mcpServers": {\n    "my-server": {\n      "url": "https://example.com/sse"\n    }\n  }\n}',
       parse: "파싱 후 채우기",
       editOverwriteHint: "가져오기는 현재 양식을 덮어씁니다(저장된 자격 증명은 영향받지 않으며, 저장을 눌러야 적용됩니다)",
       errors: {

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -4156,8 +4156,6 @@ export default {
     codeImport: {
       toggle: 'Импорт из кода',
       hint: 'Вставьте стандартную JSON-конфигурацию mcpServers для автозаполнения формы',
-      placeholder:
-        '{\n  "mcpServers": {\n    "my-server": {\n      "url": "https://example.com/sse"\n    }\n  }\n}',
       parse: 'Разобрать и заполнить',
       editOverwriteHint: 'Импорт перезапишет текущую форму (сохранённые учётные данные не затрагиваются; нажмите «Сохранить», чтобы применить)',
       errors: {

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -4521,8 +4521,6 @@ export default {
     codeImport: {
       toggle: "从代码导入",
       hint: "粘贴标准 mcpServers JSON 配置，自动填充表单",
-      placeholder:
-        '{\n  "mcpServers": {\n    "my-server": {\n      "url": "https://example.com/sse"\n    }\n  }\n}',
       parse: "解析并填充",
       editOverwriteHint: "导入会覆盖当前表单内容（不影响已保存的凭证，需点保存生效）",
       errors: {

--- a/frontend/src/views/settings/components/McpServiceDialog.vue
+++ b/frontend/src/views/settings/components/McpServiceDialog.vue
@@ -76,7 +76,7 @@
           <t-textarea
             v-model="codeImportText"
             :autosize="{ minRows: 5, maxRows: 14 }"
-            :placeholder="t('mcpServiceDialog.codeImport.placeholder')"
+            :placeholder="codeImportPlaceholder"
             class="code-import__textarea"
           />
           <p v-if="codeImportError" class="code-import__error">{{ codeImportError }}</p>
@@ -408,6 +408,13 @@ const emit = defineEmits<Emits>()
 const formRef = ref<FormInstanceFunctions>()
 const submitting = ref(false)
 const { t } = useI18n()
+const codeImportPlaceholder = `{
+  "mcpServers": {
+    "my-server": {
+      "url": "https://example.com/sse"
+    }
+  }
+}`
 
 const formData = ref({
   name: '',


### PR DESCRIPTION
## Summary

- Move the MCP code import JSON placeholder out of i18n messages and into a component constant.
- Remove the JSON placeholder entry from zh-CN, en-US, ru-RU, and ko-KR locale files.

## Root Cause

The placeholder text starts with a JSON object containing `mcpServers`. Vue i18n attempts to compile braces in locale messages as placeholders, which caused `Invalid token in placeholder` errors when rendering `McpServiceDialog`.

## Validation

- `npm run type-check`
- `npm run build-only`