### PR TITLE
fix(nginx):embed iframe x-frame-options

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -45,6 +45,17 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
     }
 
+    # Internal fallback target for /embed/* routes. Keep it separate from the
+    # main SPA location so embed pages do not inherit X-Frame-Options.
+    location = /embed.html {
+        internal;
+        root /usr/share/nginx/html;
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    }
+
     # Embed widget pages may be loaded inside third-party iframes (lightweight embed.html)
     location ^~ /embed/ {
         root /usr/share/nginx/html;


### PR DESCRIPTION
## Summary  
- Fix #1869 
- Fixed the frontend Nginx embed fallback so /embed/* pages no longer inherit X-Frame-Options: SAMEORIGIN from the main SPA route.
- Added a dedicated internal /embed.html location with embed-safe headers, preserving iframe support for third-party sites.

## Validation
- curl -sI "http://127.0.0.1:5173/embed/  | grep -i x-frame
No longer return X-Frame-Options: SAMEORIGIN