### PR TITLE
feat(knowledge): reuse rebuild caches across processing stages   (#1679)

### DIFF
--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -159,6 +159,20 @@ func (r *chunkRepository) ListChunksByKnowledgeID(
 	return chunks, nil
 }
 
+// ListAllChunksByKnowledgeID lists all chunk types for a knowledge ID.
+func (r *chunkRepository) ListAllChunksByKnowledgeID(
+	ctx context.Context, tenantID uint64, knowledgeID string,
+) ([]*types.Chunk, error) {
+	var chunks []*types.Chunk
+	if err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND knowledge_id = ?", tenantID, knowledgeID).
+		Order("chunk_index ASC, created_at ASC").
+		Find(&chunks).Error; err != nil {
+		return nil, err
+	}
+	return chunks, nil
+}
+
 // ListPagedChunksByKnowledgeID lists chunks for a knowledge ID with pagination
 func (r *chunkRepository) ListPagedChunksByKnowledgeID(
 	ctx context.Context,

--- a/internal/application/repository/document_parse_cache.go
+++ b/internal/application/repository/document_parse_cache.go
@@ -1,0 +1,58 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type documentParseCacheRepository struct {
+	db *gorm.DB
+}
+
+func NewDocumentParseCacheRepository(db *gorm.DB) interfaces.DocumentParseCacheRepository {
+	return &documentParseCacheRepository{db: db}
+}
+
+func (r *documentParseCacheRepository) GetByKey(
+	ctx context.Context,
+	tenantID uint64,
+	knowledgeID string,
+	cacheKey string,
+) (*types.DocumentParseCache, error) {
+	if knowledgeID == "" || cacheKey == "" {
+		return nil, nil
+	}
+	var cache types.DocumentParseCache
+	err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND knowledge_id = ? AND cache_key = ?", tenantID, knowledgeID, cacheKey).
+		First(&cache).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &cache, nil
+}
+
+func (r *documentParseCacheRepository) Upsert(ctx context.Context, cache *types.DocumentParseCache) error {
+	if cache == nil || cache.KnowledgeID == "" || cache.CacheKey == "" {
+		return nil
+	}
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "tenant_id"}, {Name: "knowledge_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"cache_key",
+			"content_key",
+			"config_hash",
+			"schema_ver",
+			"payload",
+			"updated_at",
+		}),
+	}).Create(cache).Error
+}

--- a/internal/application/repository/graph_extraction_cache.go
+++ b/internal/application/repository/graph_extraction_cache.go
@@ -1,0 +1,57 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type graphExtractionCacheRepository struct {
+	db *gorm.DB
+}
+
+func NewGraphExtractionCacheRepository(db *gorm.DB) interfaces.GraphExtractionCacheRepository {
+	return &graphExtractionCacheRepository{db: db}
+}
+
+func (r *graphExtractionCacheRepository) GetByKey(
+	ctx context.Context,
+	tenantID uint64,
+	cacheKey string,
+) (*types.GraphExtractionCache, error) {
+	if cacheKey == "" {
+		return nil, nil
+	}
+	var cache types.GraphExtractionCache
+	err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND cache_key = ?", tenantID, cacheKey).
+		First(&cache).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &cache, nil
+}
+
+func (r *graphExtractionCacheRepository) Upsert(ctx context.Context, cache *types.GraphExtractionCache) error {
+	if cache == nil || cache.CacheKey == "" {
+		return nil
+	}
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "tenant_id"}, {Name: "cache_key"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"content_key",
+			"model_id",
+			"config_hash",
+			"schema_ver",
+			"graph",
+			"updated_at",
+		}),
+	}).Create(cache).Error
+}

--- a/internal/application/repository/image_multimodal_cache.go
+++ b/internal/application/repository/image_multimodal_cache.go
@@ -1,0 +1,57 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type imageMultimodalCacheRepository struct {
+	db *gorm.DB
+}
+
+func NewImageMultimodalCacheRepository(db *gorm.DB) interfaces.ImageMultimodalCacheRepository {
+	return &imageMultimodalCacheRepository{db: db}
+}
+
+func (r *imageMultimodalCacheRepository) GetByKey(
+	ctx context.Context,
+	tenantID uint64,
+	cacheKey string,
+) (*types.ImageMultimodalCache, error) {
+	if cacheKey == "" {
+		return nil, nil
+	}
+	var cache types.ImageMultimodalCache
+	err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND cache_key = ?", tenantID, cacheKey).
+		First(&cache).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &cache, nil
+}
+
+func (r *imageMultimodalCacheRepository) Upsert(ctx context.Context, cache *types.ImageMultimodalCache) error {
+	if cache == nil || cache.CacheKey == "" {
+		return nil
+	}
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "tenant_id"}, {Name: "cache_key"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"content_key",
+			"model_id",
+			"config_hash",
+			"schema_ver",
+			"payload",
+			"updated_at",
+		}),
+	}).Create(cache).Error
+}

--- a/internal/application/repository/wiki_map_cache.go
+++ b/internal/application/repository/wiki_map_cache.go
@@ -1,0 +1,54 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type wikiMapCacheRepository struct {
+	db *gorm.DB
+}
+
+func NewWikiMapCacheRepository(db *gorm.DB) interfaces.WikiMapCacheRepository {
+	return &wikiMapCacheRepository{db: db}
+}
+
+func (r *wikiMapCacheRepository) GetByKey(ctx context.Context, tenantID uint64, cacheKey string) (*types.WikiMapCache, error) {
+	if cacheKey == "" {
+		return nil, nil
+	}
+	var cache types.WikiMapCache
+	err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND cache_key = ?", tenantID, cacheKey).
+		First(&cache).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &cache, nil
+}
+
+func (r *wikiMapCacheRepository) Upsert(ctx context.Context, cache *types.WikiMapCache) error {
+	if cache == nil || cache.CacheKey == "" {
+		return nil
+	}
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "tenant_id"}, {Name: "cache_key"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"kind",
+			"content_key",
+			"model_id",
+			"config_hash",
+			"schema_ver",
+			"payload",
+			"updated_at",
+		}),
+	}).Create(cache).Error
+}

--- a/internal/application/service/chat_pipeline/extract_entity.go
+++ b/internal/application/service/chat_pipeline/extract_entity.go
@@ -267,6 +267,13 @@ func (qa *QAPromptGenerator) System(ctx context.Context) string {
 			promptLines = append(promptLines, "")
 		}
 	}
+	promptLines = append(promptLines,
+		"# Output Constraints",
+		fmt.Sprintf("- Return at most %d entities and at most %d relations.", graphExtractionMaxNodes, graphExtractionMaxRelations),
+		fmt.Sprintf("- Keep each entity name concise, no more than %d characters.", graphExtractionMaxNameRunes),
+		"- Prefer high-confidence central entities and relations; ignore OCR noise, garbled text, repeated SQL fragments, and low-value syntax tokens.",
+		"- Return only the requested JSON extraction payload. Do not add prose before or after it.",
+	)
 	return strings.Join(promptLines, "\n")
 }
 
@@ -311,9 +318,22 @@ const (
 	_FENCE_END     = "```"
 )
 
+const (
+	graphExtractionMaxNodes     = 12
+	graphExtractionMaxRelations = 12
+	graphExtractionMaxNameRunes = 80
+)
+
 var _FENCE_RE = regexp.MustCompile(
 	_FENCE_START + _LANGUAGE_TAG + _FENCE_NEWLINE + _FENCE_BODY + _FENCE_END,
 )
+
+// GraphExtractionLimitSignature is included in the cache config hash so
+// changing output limits never reuses graph JSON produced under older rules.
+func GraphExtractionLimitSignature() string {
+	return fmt.Sprintf("nodes=%d;relations=%d;name_runes=%d",
+		graphExtractionMaxNodes, graphExtractionMaxRelations, graphExtractionMaxNameRunes)
+}
 
 // Formater is a struct for formatting entities
 type Formater struct {
@@ -389,6 +409,16 @@ func (f *Formater) parseOutput(ctx context.Context, text string) ([]map[string]i
 	var err error
 	if f.formatType == FormatTypeJSON {
 		err = json.Unmarshal([]byte(content), &parsed)
+		if err != nil {
+			if repaired := repairJSONLike(content); repaired != "" && repaired != content {
+				var repairedParsed interface{}
+				if repairErr := json.Unmarshal([]byte(repaired), &repairedParsed); repairErr == nil {
+					logger.Warnf(ctx, "recovered malformed JSON extraction output: %v", err)
+					parsed = repairedParsed
+					err = nil
+				}
+			}
+		}
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse %s content: %s", strings.ToUpper(string(f.formatType)), err.Error())
@@ -462,7 +492,111 @@ func (f *Formater) ParseGraph(ctx context.Context, text string) (*types.GraphDat
 		Relation: relations,
 	}
 	f.rebuildGraph(ctx, graph)
+	limitGraphExtraction(ctx, graph)
 	return graph, nil
+}
+
+func limitGraphExtraction(ctx context.Context, graph *types.GraphData) {
+	if graph == nil {
+		return
+	}
+	originalNodes := len(graph.Node)
+	originalRelations := len(graph.Relation)
+	if originalNodes <= graphExtractionMaxNodes && originalRelations <= graphExtractionMaxRelations {
+		trimGraphNodeNames(graph)
+		return
+	}
+
+	nodeByName := make(map[string]*types.GraphNode, len(graph.Node))
+	for _, node := range graph.Node {
+		if node == nil {
+			continue
+		}
+		node.Name = trimGraphName(node.Name)
+		if node.Name != "" {
+			nodeByName[node.Name] = node
+		}
+	}
+
+	selected := make(map[string]bool, graphExtractionMaxNodes)
+	nodes := make([]*types.GraphNode, 0, graphExtractionMaxNodes)
+	relations := make([]*types.GraphRelation, 0, graphExtractionMaxRelations)
+
+	addNode := func(name string) bool {
+		name = trimGraphName(name)
+		if name == "" {
+			return false
+		}
+		if selected[name] {
+			return true
+		}
+		if len(nodes) >= graphExtractionMaxNodes {
+			return false
+		}
+		node := nodeByName[name]
+		if node == nil {
+			node = &types.GraphNode{Name: name}
+		}
+		node.Name = name
+		nodes = append(nodes, node)
+		selected[name] = true
+		return true
+	}
+
+	for _, relation := range graph.Relation {
+		if len(relations) >= graphExtractionMaxRelations {
+			break
+		}
+		if relation == nil {
+			continue
+		}
+		relation.Node1 = trimGraphName(relation.Node1)
+		relation.Node2 = trimGraphName(relation.Node2)
+		if relation.Node1 == "" || relation.Node2 == "" || relation.Node1 == relation.Node2 {
+			continue
+		}
+		if !addNode(relation.Node1) || !addNode(relation.Node2) {
+			continue
+		}
+		relations = append(relations, relation)
+	}
+
+	for _, node := range graph.Node {
+		if len(nodes) >= graphExtractionMaxNodes {
+			break
+		}
+		if node != nil {
+			addNode(node.Name)
+		}
+	}
+
+	graph.Node = nodes
+	graph.Relation = relations
+	logger.Warnf(ctx, "graph extraction truncated nodes %d->%d relations %d->%d",
+		originalNodes, len(graph.Node), originalRelations, len(graph.Relation))
+}
+
+func trimGraphNodeNames(graph *types.GraphData) {
+	for _, node := range graph.Node {
+		if node != nil {
+			node.Name = trimGraphName(node.Name)
+		}
+	}
+	for _, relation := range graph.Relation {
+		if relation != nil {
+			relation.Node1 = trimGraphName(relation.Node1)
+			relation.Node2 = trimGraphName(relation.Node2)
+		}
+	}
+}
+
+func trimGraphName(name string) string {
+	name = strings.TrimSpace(name)
+	runes := []rune(name)
+	if len(runes) <= graphExtractionMaxNameRunes {
+		return name
+	}
+	return string(runes[:graphExtractionMaxNameRunes])
 }
 
 func (f *Formater) rebuildGraph(ctx context.Context, graph *types.GraphData) {
@@ -614,6 +748,76 @@ func stripFencesAndExtract(text string, format FormatType) string {
 	}
 
 	return ""
+}
+
+func repairJSONLike(s string) string {
+	s = strings.TrimSpace(s)
+	if extracted := extractJSONLike(s); extracted != "" {
+		s = extracted
+	}
+	return sanitizeJSONEscapes(s)
+}
+
+func sanitizeJSONEscapes(s string) string {
+	var buf strings.Builder
+	buf.Grow(len(s))
+	inString := false
+	escape := false
+	for _, r := range s {
+		if escape {
+			switch {
+			case isValidJSONEscape(r):
+				buf.WriteRune('\\')
+				buf.WriteRune(r)
+			case r == '\n':
+				buf.WriteString(`\n`)
+			case r == '\r':
+				buf.WriteString(`\r`)
+			case r == '\t':
+				buf.WriteString(`\t`)
+			default:
+				buf.WriteRune(r)
+			}
+			escape = false
+			continue
+		}
+		if r == '\\' && inString {
+			escape = true
+			continue
+		}
+		if r == '"' {
+			inString = !inString
+			buf.WriteRune(r)
+			continue
+		}
+		if inString {
+			switch r {
+			case '\n':
+				buf.WriteString(`\n`)
+				continue
+			case '\r':
+				buf.WriteString(`\r`)
+				continue
+			case '\t':
+				buf.WriteString(`\t`)
+				continue
+			}
+		}
+		buf.WriteRune(r)
+	}
+	if escape {
+		buf.WriteString(`\\`)
+	}
+	return buf.String()
+}
+
+func isValidJSONEscape(r rune) bool {
+	switch r {
+	case '"', '\\', '/', 'b', 'f', 'n', 'r', 't', 'u':
+		return true
+	default:
+		return false
+	}
 }
 
 // isLikelyLanguageTag reports whether s looks like a markdown fence language

--- a/internal/application/service/chunk.go
+++ b/internal/application/service/chunk.go
@@ -167,6 +167,19 @@ func (s *chunkService) ListChunksByKnowledgeID(ctx context.Context, knowledgeID 
 	return chunks, nil
 }
 
+func (s *chunkService) ListAllChunksByKnowledgeID(ctx context.Context, knowledgeID string) ([]*types.Chunk, error) {
+	tenantID := types.MustTenantIDFromContext(ctx)
+	chunks, err := s.chunkRepository.ListAllChunksByKnowledgeID(ctx, tenantID, knowledgeID)
+	if err != nil {
+		logger.ErrorWithFields(ctx, err, map[string]interface{}{
+			"knowledge_id": knowledgeID,
+			"tenant_id":    tenantID,
+		})
+		return nil, err
+	}
+	return chunks, nil
+}
+
 // ListPagedChunksByKnowledgeID lists chunks for a knowledge ID with pagination
 // This method retrieves chunks with pagination support for better performance with large datasets
 // Parameters:

--- a/internal/application/service/extract.go
+++ b/internal/application/service/extract.go
@@ -235,11 +235,13 @@ func graphExtractionConfigHash(template *types.PromptTemplateStructured) string 
 		Description string            `json:"description"`
 		Tags        []string          `json:"tags,omitempty"`
 		Examples    []types.GraphData `json:"examples,omitempty"`
+		Limits      string            `json:"limits,omitempty"`
 	}{
 		Schema:      types.GraphExtractionCacheSchemaVersion,
 		Description: template.Description,
 		Tags:        template.Tags,
 		Examples:    template.Examples,
+		Limits:      chatpipeline.GraphExtractionLimitSignature(),
 	})
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:])

--- a/internal/application/service/extract.go
+++ b/internal/application/service/extract.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -185,6 +187,7 @@ type ChunkExtractService struct {
 	knowledgeRepo     interfaces.KnowledgeRepository
 	chunkRepo         interfaces.ChunkRepository
 	graphEngine       interfaces.RetrieveGraphRepository
+	graphCacheRepo    interfaces.GraphExtractionCacheRepository
 	// spanTracker records this graph-extract task's subspan under the
 	// parent attempt's postprocess stage so the trace viewer shows real
 	// per-chunk graph extraction time rather than the upstream's enqueue.
@@ -199,6 +202,7 @@ func NewChunkExtractService(
 	knowledgeRepo interfaces.KnowledgeRepository,
 	chunkRepo interfaces.ChunkRepository,
 	graphEngine interfaces.RetrieveGraphRepository,
+	graphCacheRepo interfaces.GraphExtractionCacheRepository,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
 	return &ChunkExtractService{
@@ -208,6 +212,7 @@ func NewChunkExtractService(
 		knowledgeRepo:     knowledgeRepo,
 		chunkRepo:         chunkRepo,
 		graphEngine:       graphEngine,
+		graphCacheRepo:    graphCacheRepo,
 		spanTracker:       spanTracker,
 	}
 }
@@ -217,6 +222,118 @@ func (s *ChunkExtractService) tracker() SpanTracker {
 		return noopSpanTracker{}
 	}
 	return s.spanTracker
+}
+
+func graphExtractionContentKey(content string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(content)))
+	return hex.EncodeToString(sum[:])
+}
+
+func graphExtractionConfigHash(template *types.PromptTemplateStructured) string {
+	b, _ := json.Marshal(struct {
+		Schema      string            `json:"schema"`
+		Description string            `json:"description"`
+		Tags        []string          `json:"tags,omitempty"`
+		Examples    []types.GraphData `json:"examples,omitempty"`
+	}{
+		Schema:      types.GraphExtractionCacheSchemaVersion,
+		Description: template.Description,
+		Tags:        template.Tags,
+		Examples:    template.Examples,
+	})
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func graphExtractionCacheKey(contentKey, modelSignature, configHash string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		types.GraphExtractionCacheSchemaVersion,
+		contentKey,
+		modelSignature,
+		configHash,
+	}, "\x00")))
+	return hex.EncodeToString(sum[:])
+}
+
+func cloneGraphData(graph *types.GraphData) *types.GraphData {
+	if graph == nil {
+		return &types.GraphData{}
+	}
+	cloned := &types.GraphData{
+		Text:     graph.Text,
+		Node:     make([]*types.GraphNode, 0, len(graph.Node)),
+		Relation: make([]*types.GraphRelation, 0, len(graph.Relation)),
+	}
+	for _, node := range graph.Node {
+		if node == nil {
+			continue
+		}
+		n := *node
+		if node.Chunks != nil {
+			n.Chunks = append([]string(nil), node.Chunks...)
+		}
+		if node.Attributes != nil {
+			n.Attributes = append([]string(nil), node.Attributes...)
+		}
+		cloned.Node = append(cloned.Node, &n)
+	}
+	for _, rel := range graph.Relation {
+		if rel == nil {
+			continue
+		}
+		r := *rel
+		cloned.Relation = append(cloned.Relation, &r)
+	}
+	return cloned
+}
+
+func bindGraphToChunk(graph *types.GraphData, chunkID string) *types.GraphData {
+	bound := cloneGraphData(graph)
+	for _, node := range bound.Node {
+		node.Chunks = []string{chunkID}
+	}
+	return bound
+}
+
+func graphFromCache(cache *types.GraphExtractionCache) (*types.GraphData, error) {
+	if cache == nil || len(cache.Graph) == 0 {
+		return nil, nil
+	}
+	var graph types.GraphData
+	if err := json.Unmarshal(cache.Graph, &graph); err != nil {
+		return nil, err
+	}
+	return &graph, nil
+}
+
+func isGraphJSONParseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "failed to parse json content")
+}
+
+func extractGraphWithJSONRetry(
+	ctx context.Context,
+	extractor chatpipeline.Extractor,
+	content string,
+	chunkID string,
+	graphOut types.JSONMap,
+) (*types.GraphData, error) {
+	graph, err := extractor.Extract(ctx, content)
+	if err == nil || !isGraphJSONParseError(err) {
+		graphOut["extract_attempts"] = 1
+		return graph, err
+	}
+
+	logger.Warnf(ctx, "graph extraction JSON parse failed for chunk %s, retry once: %v", chunkID, err)
+	graphOut["extract_retry_reason"] = "json_parse_failed"
+	graphOut["extract_attempts"] = 2
+	graph, retryErr := extractor.Extract(ctx, content)
+	if retryErr != nil {
+		return nil, retryErr
+	}
+	return graph, nil
 }
 
 // Handle handles the chunk extraction task
@@ -350,11 +467,68 @@ func (s *ChunkExtractService) Handle(ctx context.Context, t *asynq.Task) error {
 			},
 		},
 	}
-	extractor := chatpipeline.NewExtractor(chatModel, template)
-	graph, err := extractor.Extract(ctx, chunk.Content)
-	if err != nil {
-		handleErr = err
-		return err
+	modelID := chatModel.GetModelID()
+	if modelID == "" {
+		modelID = p.ModelID
+	}
+	modelSignature := strings.Join([]string{modelID, chatModel.GetModelName()}, "\x00")
+	contentKey := graphExtractionContentKey(chunk.Content)
+	configHash := graphExtractionConfigHash(template)
+	cacheKey := graphExtractionCacheKey(contentKey, modelSignature, configHash)
+	graphOut["cache_key"] = cacheKey
+	graphOut["cache_schema"] = types.GraphExtractionCacheSchemaVersion
+
+	var graph *types.GraphData
+	cacheHit := false
+	if s.graphCacheRepo != nil {
+		cache, cacheErr := s.graphCacheRepo.GetByKey(ctx, p.TenantID, cacheKey)
+		if cacheErr != nil {
+			logger.Warnf(ctx, "graph extraction cache lookup failed for chunk %s: %v", p.ChunkID, cacheErr)
+			graphOut["cache_error"] = cacheErr.Error()
+		} else if cache != nil {
+			cachedGraph, parseErr := graphFromCache(cache)
+			if parseErr != nil {
+				logger.Warnf(ctx, "graph extraction cache decode failed for chunk %s: %v", p.ChunkID, parseErr)
+				graphOut["cache_error"] = parseErr.Error()
+			} else {
+				graph = cachedGraph
+				cacheHit = true
+				graphOut["cache_hit"] = true
+			}
+		}
+	}
+	if graph == nil {
+		graphOut["cache_hit"] = false
+		extractor := chatpipeline.NewExtractor(chatModel, template)
+		graph, err = extractGraphWithJSONRetry(ctx, extractor, chunk.Content, p.ChunkID, graphOut)
+		if err != nil {
+			handleErr = err
+			return err
+		}
+		if s.graphCacheRepo != nil {
+			cacheGraph := cloneGraphData(graph)
+			for _, node := range cacheGraph.Node {
+				node.Chunks = nil
+			}
+			rawGraph, marshalErr := json.Marshal(cacheGraph)
+			if marshalErr != nil {
+				logger.Warnf(ctx, "graph extraction cache marshal failed for chunk %s: %v", p.ChunkID, marshalErr)
+				graphOut["cache_error"] = marshalErr.Error()
+			} else {
+				if cacheErr := s.graphCacheRepo.Upsert(ctx, &types.GraphExtractionCache{
+					TenantID:   p.TenantID,
+					CacheKey:   cacheKey,
+					ContentKey: contentKey,
+					ModelID:    modelID,
+					ConfigHash: configHash,
+					SchemaVer:  types.GraphExtractionCacheSchemaVersion,
+					Graph:      types.JSON(rawGraph),
+				}); cacheErr != nil {
+					logger.Warnf(ctx, "graph extraction cache upsert failed for chunk %s: %v", p.ChunkID, cacheErr)
+					graphOut["cache_error"] = cacheErr.Error()
+				}
+			}
+		}
 	}
 
 	chunk, err = s.chunkRepo.GetChunkByID(ctx, p.TenantID, p.ChunkID)
@@ -364,9 +538,7 @@ func (s *ChunkExtractService) Handle(ctx context.Context, t *asynq.Task) error {
 		return nil
 	}
 
-	for _, node := range graph.Node {
-		node.Chunks = []string{chunk.ID}
-	}
+	graph = bindGraphToChunk(graph, chunk.ID)
 	if err = s.graphEngine.AddGraph(ctx,
 		types.NameSpace{KnowledgeBase: chunk.KnowledgeBaseID, Knowledge: chunk.KnowledgeID},
 		[]*types.GraphData{graph},
@@ -374,6 +546,9 @@ func (s *ChunkExtractService) Handle(ctx context.Context, t *asynq.Task) error {
 		logger.Errorf(ctx, "failed to add graph: %v", err)
 		handleErr = err
 		return err
+	}
+	if cacheHit {
+		logger.Infof(ctx, "graph extraction cache hit for chunk %s", p.ChunkID)
 	}
 	graphOut["nodes_added"] = len(graph.Node)
 	graphOut["relations_added"] = len(graph.Relation)

--- a/internal/application/service/extract.go
+++ b/internal/application/service/extract.go
@@ -225,7 +225,7 @@ func (s *ChunkExtractService) tracker() SpanTracker {
 }
 
 func graphExtractionContentKey(content string) string {
-	sum := sha256.Sum256([]byte(strings.TrimSpace(content)))
+	sum := sha256.Sum256([]byte(content))
 	return hex.EncodeToString(sum[:])
 }
 

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -357,7 +357,9 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 				logger.Warnf(ctx, "[ImageMultimodal] Cache payload invalid for image %s: %v", payload.ImageURL, err)
 				imgOut["cache_error"] = err.Error()
 			} else {
-				imgOut["cache_hit"] = true
+				imgOut["cache_hit"] =
+					(!payload.EnableOCR || cachePayload.HasOCR) &&
+						(!payload.EnableCaption || cachePayload.HasCaption)
 			}
 		}
 	}
@@ -396,27 +398,29 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 	}
 
-	if cachePayload.HasCaption {
-		imageInfo.Caption = cachePayload.Caption
-		imgOut["caption_cache_hit"] = true
-		imgOut["caption_chars"] = len([]rune(cachePayload.Caption))
-		if cachePayload.Caption != "" {
-			imgOut["caption_preview"] = previewText(cachePayload.Caption, 200)
-		}
-	} else {
-		imgOut["caption_cache_hit"] = false
-		caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, captionPrompt)
-		if capErr != nil {
-			logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
-			imgOut["caption_error"] = capErr.Error()
+	if payload.EnableCaption {
+		if cachePayload.HasCaption {
+			imageInfo.Caption = cachePayload.Caption
+			imgOut["caption_cache_hit"] = true
+			imgOut["caption_chars"] = len([]rune(cachePayload.Caption))
+			if cachePayload.Caption != "" {
+				imgOut["caption_preview"] = previewText(cachePayload.Caption, 200)
+			}
 		} else {
-			cachePayload.HasCaption = true
-			cachePayload.Caption = caption
-			cacheDirty = true
-			if caption != "" {
-				imageInfo.Caption = caption
-				imgOut["caption_chars"] = len([]rune(caption))
-				imgOut["caption_preview"] = previewText(caption, 200)
+			imgOut["caption_cache_hit"] = false
+			caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, captionPrompt)
+			if capErr != nil {
+				logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
+				imgOut["caption_error"] = capErr.Error()
+			} else {
+				cachePayload.HasCaption = true
+				cachePayload.Caption = caption
+				cacheDirty = true
+				if caption != "" {
+					imageInfo.Caption = caption
+					imgOut["caption_chars"] = len([]rune(caption))
+					imgOut["caption_preview"] = previewText(caption, 200)
+				}
 			}
 		}
 	}

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -71,6 +73,7 @@ type ImageMultimodalService struct {
 	retrieveEngine interfaces.RetrieveEngineRegistry
 	ownership      retriever.TenantStoreOwnership
 	ollamaService  *ollama.OllamaService
+	imageCacheRepo interfaces.ImageMultimodalCacheRepository
 	taskEnqueuer   interfaces.TaskEnqueuer
 	redisClient    *redis.Client
 	// fileSvc is the globally configured default FileService used as a fallback
@@ -99,6 +102,7 @@ func NewImageMultimodalService(
 	retrieveEngine interfaces.RetrieveEngineRegistry,
 	ownership retriever.TenantStoreOwnership,
 	ollamaService *ollama.OllamaService,
+	imageCacheRepo interfaces.ImageMultimodalCacheRepository,
 	taskEnqueuer interfaces.TaskEnqueuer,
 	redisClient *redis.Client,
 	fileSvc interfaces.FileService,
@@ -115,6 +119,7 @@ func NewImageMultimodalService(
 		retrieveEngine:  retrieveEngine,
 		ownership:       ownership,
 		ollamaService:   ollamaService,
+		imageCacheRepo:  imageCacheRepo,
 		taskEnqueuer:    taskEnqueuer,
 		redisClient:     redisClient,
 		fileSvc:         fileSvc,
@@ -131,6 +136,69 @@ func (s *ImageMultimodalService) tracker() SpanTracker {
 		return noopSpanTracker{}
 	}
 	return s.spanTracker
+}
+
+type imageMultimodalCachePayload struct {
+	OCRText    string `json:"ocr_text,omitempty"`
+	Caption    string `json:"caption,omitempty"`
+	HasOCR     bool   `json:"has_ocr"`
+	HasCaption bool   `json:"has_caption"`
+}
+
+func imageMultimodalCacheModelID(cfg types.VLMConfig) string {
+	if modelID := strings.TrimSpace(cfg.ModelID); modelID != "" {
+		return modelID
+	}
+	if modelName := strings.TrimSpace(cfg.ModelName); modelName != "" {
+		return "legacy:" + modelName
+	}
+	return "legacy_inline"
+}
+
+func imageMultimodalCacheKeys(
+	imgBytes []byte,
+	vlmCfg types.VLMConfig,
+	ocrPrompt string,
+	captionPrompt string,
+) (contentKey, modelID, configHash, cacheKey string) {
+	contentKey = hashBytesHex(imgBytes)
+	modelID = imageMultimodalCacheModelID(vlmCfg)
+	configHash = hashJSONHex(struct {
+		Schema        string `json:"schema"`
+		ModelID       string `json:"model_id"`
+		ModelName     string `json:"model_name"`
+		BaseURL       string `json:"base_url"`
+		InterfaceType string `json:"interface_type"`
+		OCRPrompt     string `json:"ocr_prompt"`
+		CaptionPrompt string `json:"caption_prompt"`
+	}{
+		Schema:        types.ImageMultimodalCacheSchemaVersion,
+		ModelID:       strings.TrimSpace(vlmCfg.ModelID),
+		ModelName:     strings.TrimSpace(vlmCfg.ModelName),
+		BaseURL:       strings.TrimSpace(vlmCfg.BaseURL),
+		InterfaceType: strings.TrimSpace(vlmCfg.InterfaceType),
+		OCRPrompt:     hashStringHex(ocrPrompt),
+		CaptionPrompt: hashStringHex(captionPrompt),
+	})
+	cacheKey = hashStringHex(types.ImageMultimodalCacheSchemaVersion + "\x00" + contentKey + "\x00" + modelID + "\x00" + configHash)
+	return contentKey, modelID, configHash, cacheKey
+}
+
+func hashBytesHex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func hashStringHex(s string) string {
+	return hashBytesHex([]byte(s))
+}
+
+func hashJSONHex(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return hashStringHex(fmt.Sprintf("%#v", v))
+	}
+	return hashBytesHex(b)
 }
 
 // Handle implements asynq handler for TypeImageMultimodal.
@@ -257,43 +325,121 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		OriginalURL: payload.ImageURL,
 	}
 
-	if payload.EnableOCR {
-		prompt := vlmOCRPrompt
-		if payload.ImageSourceType == "scanned_pdf" {
-			prompt = vlmOCRScannedPDFPrompt
+	ocrPrompt := vlmOCRPrompt
+	if payload.ImageSourceType == "scanned_pdf" {
+		ocrPrompt = vlmOCRScannedPDFPrompt
+		if payload.EnableOCR {
 			logger.Infof(ctx, "[ImageMultimodal] Using scanned PDF prompt for OCR: %s", payload.ImageURL)
 			imgOut["ocr_prompt"] = "scanned_pdf"
-		} else {
-			imgOut["ocr_prompt"] = "default"
 		}
-		prompt = types.AppendCustomPromptInstructions(prompt, vlmCfg.CustomInstructions, "image_ocr")
+	} else if payload.EnableOCR {
+		imgOut["ocr_prompt"] = "default"
+	}
+	ocrPrompt = types.AppendCustomPromptInstructions(ocrPrompt, vlmCfg.CustomInstructions, "image_ocr")
+	captionPrompt := buildVLMCaptionPrompt(ctx, vlmCfg)
 
-		ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt)
-		if ocrErr != nil {
-			logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
-			imgOut["ocr_error"] = ocrErr.Error()
-		} else {
-			ocrText = sanitizeOCRText(ocrText)
-			if ocrText != "" {
-				imageInfo.OCRText = ocrText
-				imgOut["ocr_chars"] = len([]rune(ocrText))
-				imgOut["ocr_preview"] = previewText(ocrText, 200)
+	contentKey, cacheModelID, cacheConfigHash, cacheKey := imageMultimodalCacheKeys(
+		imgBytes, vlmCfg, ocrPrompt, captionPrompt,
+	)
+	imgOut["cache_schema"] = types.ImageMultimodalCacheSchemaVersion
+	imgOut["image_content_key"] = contentKey
+	imgOut["cache_hit"] = false
+
+	cachePayload := imageMultimodalCachePayload{}
+	cacheDirty := false
+	if s.imageCacheRepo != nil {
+		cache, cacheErr := s.imageCacheRepo.GetByKey(ctx, payload.TenantID, cacheKey)
+		if cacheErr != nil {
+			logger.Warnf(ctx, "[ImageMultimodal] Cache lookup failed for image %s: %v", payload.ImageURL, cacheErr)
+			imgOut["cache_error"] = cacheErr.Error()
+		} else if cache != nil {
+			if err := json.Unmarshal(cache.Payload, &cachePayload); err != nil {
+				logger.Warnf(ctx, "[ImageMultimodal] Cache payload invalid for image %s: %v", payload.ImageURL, err)
+				imgOut["cache_error"] = err.Error()
 			} else {
-				logger.Warnf(ctx, "[ImageMultimodal] OCR returned empty/invalid content for %s, discarded", payload.ImageURL)
-				imgOut["ocr_chars"] = 0
-				imgOut["ocr_skipped"] = "empty_or_invalid"
+				imgOut["cache_hit"] = true
 			}
 		}
 	}
 
-	caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, buildVLMCaptionPrompt(ctx, vlmCfg))
-	if capErr != nil {
-		logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
-		imgOut["caption_error"] = capErr.Error()
-	} else if caption != "" {
-		imageInfo.Caption = caption
-		imgOut["caption_chars"] = len([]rune(caption))
-		imgOut["caption_preview"] = previewText(caption, 200)
+	if payload.EnableOCR {
+		if cachePayload.HasOCR {
+			imageInfo.OCRText = cachePayload.OCRText
+			imgOut["ocr_cache_hit"] = true
+			imgOut["ocr_chars"] = len([]rune(cachePayload.OCRText))
+			if cachePayload.OCRText != "" {
+				imgOut["ocr_preview"] = previewText(cachePayload.OCRText, 200)
+			} else {
+				imgOut["ocr_skipped"] = "empty_or_invalid"
+			}
+		} else {
+			imgOut["ocr_cache_hit"] = false
+			ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, ocrPrompt)
+			if ocrErr != nil {
+				logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
+				imgOut["ocr_error"] = ocrErr.Error()
+			} else {
+				ocrText = sanitizeOCRText(ocrText)
+				cachePayload.HasOCR = true
+				cachePayload.OCRText = ocrText
+				cacheDirty = true
+				if ocrText != "" {
+					imageInfo.OCRText = ocrText
+					imgOut["ocr_chars"] = len([]rune(ocrText))
+					imgOut["ocr_preview"] = previewText(ocrText, 200)
+				} else {
+					logger.Warnf(ctx, "[ImageMultimodal] OCR returned empty/invalid content for %s, discarded", payload.ImageURL)
+					imgOut["ocr_chars"] = 0
+					imgOut["ocr_skipped"] = "empty_or_invalid"
+				}
+			}
+		}
+	}
+
+	if cachePayload.HasCaption {
+		imageInfo.Caption = cachePayload.Caption
+		imgOut["caption_cache_hit"] = true
+		imgOut["caption_chars"] = len([]rune(cachePayload.Caption))
+		if cachePayload.Caption != "" {
+			imgOut["caption_preview"] = previewText(cachePayload.Caption, 200)
+		}
+	} else {
+		imgOut["caption_cache_hit"] = false
+		caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, captionPrompt)
+		if capErr != nil {
+			logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
+			imgOut["caption_error"] = capErr.Error()
+		} else {
+			cachePayload.HasCaption = true
+			cachePayload.Caption = caption
+			cacheDirty = true
+			if caption != "" {
+				imageInfo.Caption = caption
+				imgOut["caption_chars"] = len([]rune(caption))
+				imgOut["caption_preview"] = previewText(caption, 200)
+			}
+		}
+	}
+
+	if cacheDirty && s.imageCacheRepo != nil {
+		cacheBytes, _ := json.Marshal(cachePayload)
+		now := time.Now()
+		if err := s.imageCacheRepo.Upsert(ctx, &types.ImageMultimodalCache{
+			TenantID:   payload.TenantID,
+			CacheKey:   cacheKey,
+			ContentKey: contentKey,
+			ModelID:    cacheModelID,
+			ConfigHash: cacheConfigHash,
+			SchemaVer:  types.ImageMultimodalCacheSchemaVersion,
+			Payload:    types.JSON(cacheBytes),
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}); err != nil {
+			logger.Warnf(ctx, "[ImageMultimodal] Cache upsert failed for image %s: %v", payload.ImageURL, err)
+			imgOut["cache_write_error"] = err.Error()
+		} else {
+			imgOut["cache_stored"] = true
+		}
 	}
 
 	// Build child chunks for OCR and caption results

--- a/internal/application/service/image_multimodal_cache_test.go
+++ b/internal/application/service/image_multimodal_cache_test.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImageMultimodalCacheKeys(t *testing.T) {
+	cfg := types.VLMConfig{
+		Enabled:       true,
+		ModelID:       "vlm-model-1",
+		BaseURL:       "https://example.test/v1",
+		InterfaceType: "openai",
+	}
+	captionPrompt := buildVLMCaptionPrompt(context.Background(), cfg)
+
+	contentKey, modelID, configHash, cacheKey := imageMultimodalCacheKeys(
+		[]byte("image-bytes"), cfg, vlmOCRPrompt, captionPrompt,
+	)
+	contentKey2, modelID2, configHash2, cacheKey2 := imageMultimodalCacheKeys(
+		[]byte("image-bytes"), cfg, vlmOCRPrompt, captionPrompt,
+	)
+
+	assert.NotEmpty(t, contentKey)
+	assert.Equal(t, "vlm-model-1", modelID)
+	assert.Equal(t, contentKey, contentKey2)
+	assert.Equal(t, modelID, modelID2)
+	assert.Equal(t, configHash, configHash2)
+	assert.Equal(t, cacheKey, cacheKey2)
+
+	_, _, _, changedImageKey := imageMultimodalCacheKeys(
+		[]byte("different-image-bytes"), cfg, vlmOCRPrompt, captionPrompt,
+	)
+	assert.NotEqual(t, cacheKey, changedImageKey)
+
+	cfg.ModelID = "vlm-model-2"
+	_, _, _, changedModelKey := imageMultimodalCacheKeys(
+		[]byte("image-bytes"), cfg, vlmOCRPrompt, captionPrompt,
+	)
+	assert.NotEqual(t, cacheKey, changedModelKey)
+
+	cfg.ModelID = "vlm-model-1"
+	_, _, _, changedPromptKey := imageMultimodalCacheKeys(
+		[]byte("image-bytes"), cfg, vlmOCRScannedPDFPrompt, captionPrompt,
+	)
+	assert.NotEqual(t, cacheKey, changedPromptKey)
+}

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -66,6 +66,7 @@ type knowledgeService struct {
 	redisClient     *redis.Client
 	kbShareService  interfaces.KBShareService
 	imageResolver   *docparser.ImageResolver
+	parseCacheRepo  interfaces.DocumentParseCacheRepository
 	taskPendingRepo interfaces.TaskPendingOpsRepository
 
 	// In-memory fallbacks for Lite mode (no Redis)
@@ -112,6 +113,7 @@ func NewKnowledgeService(
 	redisClient *redis.Client,
 	kbShareService interfaces.KBShareService,
 	imageResolver *docparser.ImageResolver,
+	parseCacheRepo interfaces.DocumentParseCacheRepository,
 	wikiRepo interfaces.WikiPageRepository,
 	wikiService interfaces.WikiPageService,
 	taskPendingRepo interfaces.TaskPendingOpsRepository,
@@ -141,6 +143,7 @@ func NewKnowledgeService(
 		redisClient:     redisClient,
 		kbShareService:  kbShareService,
 		imageResolver:   imageResolver,
+		parseCacheRepo:  parseCacheRepo,
 		wikiRepo:        wikiRepo,
 		wikiService:     wikiService,
 		taskPendingRepo: taskPendingRepo,

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -1089,7 +1089,7 @@ func (s *knowledgeService) UpdateManualKnowledge(ctx context.Context,
 
 // enqueueManualProcessing enqueues a manual:process Asynq task for async cleanup + re-indexing.
 func (s *knowledgeService) enqueueManualProcessing(ctx context.Context,
-	knowledge *types.Knowledge, content string, needCleanup bool,
+	knowledge *types.Knowledge, content string, needCleanup bool, reuseOptions ...ProcessChunksOptions,
 ) (string, error) {
 	requestID, _ := types.RequestIDFromContext(ctx)
 	payload := types.ManualProcessPayload{
@@ -1099,6 +1099,11 @@ func (s *knowledgeService) enqueueManualProcessing(ctx context.Context,
 		KnowledgeBaseID: knowledge.KnowledgeBaseID,
 		Content:         content,
 		NeedCleanup:     needCleanup,
+	}
+	if len(reuseOptions) > 0 {
+		payload.ReuseUnchangedChunks = reuseOptions[0].ReuseUnchangedChunks
+		payload.AllowLegacyChunkReuse = reuseOptions[0].AllowLegacyChunkReuse
+		payload.ReindexReusedChunks = reuseOptions[0].ReindexReusedChunks
 	}
 	langfuse.InjectTracing(ctx, &payload)
 	payloadBytes, err := json.Marshal(payload)
@@ -1160,6 +1165,7 @@ func sanitizeManualDownloadFilename(title string) string {
 
 func (s *knowledgeService) triggerManualProcessing(ctx context.Context,
 	kb *types.KnowledgeBase, knowledge *types.Knowledge, content string, doSync bool,
+	reuseOptions ...ProcessChunksOptions,
 ) {
 	clean := strings.TrimSpace(content)
 	if clean == "" {
@@ -1198,6 +1204,11 @@ func (s *knowledgeService) triggerManualProcessing(ctx context.Context,
 	opts := ProcessChunksOptions{
 		EnableMultimodel: eff.EnableMultimodel && len(resolvedImages) > 0,
 		StoredImages:     resolvedImages,
+	}
+	if len(reuseOptions) > 0 {
+		opts.ReuseUnchangedChunks = reuseOptions[0].ReuseUnchangedChunks
+		opts.AllowLegacyChunkReuse = reuseOptions[0].AllowLegacyChunkReuse
+		opts.ReindexReusedChunks = reuseOptions[0].ReindexReusedChunks
 	}
 	if eff.QuestionGenerationConfig.Enabled {
 		opts.EnableQuestionGeneration = true

--- a/internal/application/service/knowledge_post_process.go
+++ b/internal/application/service/knowledge_post_process.go
@@ -189,10 +189,6 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 	if willSpawnQuestion {
 		for _, c := range textChunks {
 			if c.ChunkType == types.ChunkTypeText {
-				meta, metaErr := c.DocumentMetadata()
-				if metaErr == nil && meta != nil && len(meta.GeneratedQuestions) > 0 {
-					continue
-				}
 				questionChunks = append(questionChunks, c)
 			}
 		}

--- a/internal/application/service/knowledge_post_process.go
+++ b/internal/application/service/knowledge_post_process.go
@@ -189,6 +189,10 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 	if willSpawnQuestion {
 		for _, c := range textChunks {
 			if c.ChunkType == types.ChunkTypeText {
+				meta, metaErr := c.DocumentMetadata()
+				if metaErr == nil && meta != nil && len(meta.GeneratedQuestions) > 0 {
+					continue
+				}
 				questionChunks = append(questionChunks, c)
 			}
 		}

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
+	"github.com/Tencent/WeKnora/internal/config"
 	werrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/infrastructure/chunker"
 	"github.com/Tencent/WeKnora/internal/infrastructure/docparser"
@@ -158,6 +159,7 @@ type ProcessChunksOptions struct {
 	StoredImages             []docparser.StoredImage
 	ReuseUnchangedChunks     bool
 	AllowLegacyChunkReuse    bool
+	ReindexReusedChunks      bool
 	// ParentChunks holds parent chunk data when parent-child chunking is enabled.
 	// When set, the chunks passed to processChunks are child chunks, and each
 	// child's ParentIndex references an entry in this slice.
@@ -261,6 +263,7 @@ type chunkReuseState struct {
 	oldByID          map[string]*types.Chunk
 	reusedIDs        map[string]struct{}
 	oldChunkIDs      map[string]struct{}
+	forceReindex     bool
 	enabled          bool
 }
 
@@ -269,12 +272,14 @@ func newChunkReuseState(
 	knowledge *types.Knowledge,
 	oldChunks []*types.Chunk,
 	allowLegacyChunkReuse bool,
+	forceReindex bool,
 ) *chunkReuseState {
 	state := &chunkReuseState{
 		oldByFingerprint: make(map[string][]*types.Chunk),
 		oldByID:          make(map[string]*types.Chunk),
 		reusedIDs:        make(map[string]struct{}),
 		oldChunkIDs:      make(map[string]struct{}),
+		forceReindex:     forceReindex,
 		enabled:          true,
 	}
 	for _, c := range oldChunks {
@@ -286,7 +291,17 @@ func newChunkReuseState(
 		if c.ChunkType != types.ChunkTypeText {
 			continue
 		}
+		// Reparse historically replaces manually edited chunks. Reusing one
+		// would attach freshly parsed content to the old revision chain and can
+		// corrupt optimistic revision updates, so edited rows remain stale and
+		// are replaced below.
+		if c.ContentRevision != 0 {
+			continue
+		}
 		fingerprint := strings.TrimSpace(c.ContentHash)
+		if forceReindex {
+			fingerprint = documentChunkFingerprintForKnowledge(knowledge, c.Content, c.ContextHeader)
+		}
 		if fingerprint == "" {
 			fingerprint = documentChunkFingerprintForKnowledge(knowledge, c.Content, c.ContextHeader)
 		}
@@ -327,6 +342,14 @@ func (s *chunkReuseState) takeTextChunk(fingerprint string) (*types.Chunk, bool)
 	return nil, false
 }
 
+func (s *chunkReuseState) shouldReindex(chunkID string) bool {
+	if s == nil || !s.forceReindex {
+		return false
+	}
+	_, reused := s.reusedIDs[chunkID]
+	return reused
+}
+
 func (s *chunkReuseState) staleChunkIDs() []string {
 	if s == nil || !s.enabled {
 		return nil
@@ -358,6 +381,41 @@ func (s *chunkReuseState) staleImageInfos() []string {
 	return imageInfos
 }
 
+func (s *knowledgeService) rollbackChunkReuseWrites(
+	ctx context.Context,
+	reuseState *chunkReuseState,
+	createdChunks []*types.Chunk,
+) {
+	newChunkIDs := make([]string, 0, len(createdChunks))
+	for _, chunk := range createdChunks {
+		if chunk != nil && chunk.ID != "" {
+			newChunkIDs = append(newChunkIDs, chunk.ID)
+		}
+	}
+	if len(newChunkIDs) > 0 {
+		if err := s.chunkService.DeleteChunks(ctx, newChunkIDs); err != nil {
+			logger.Errorf(ctx, "Rollback newly created chunks failed: %v", err)
+		}
+	}
+	if reuseState == nil {
+		return
+	}
+	reusedIDs := make([]string, 0, len(reuseState.reusedIDs))
+	for id := range reuseState.reusedIDs {
+		reusedIDs = append(reusedIDs, id)
+	}
+	sort.Strings(reusedIDs)
+	for _, id := range reusedIDs {
+		oldChunk := reuseState.oldByID[id]
+		if oldChunk == nil {
+			continue
+		}
+		if err := s.chunkService.UpdateChunk(ctx, oldChunk); err != nil {
+			logger.Errorf(ctx, "Rollback reused chunk %s failed: %v", id, err)
+		}
+	}
+}
+
 func documentChunkFingerprintForKnowledge(knowledge *types.Knowledge, content, contextHeader string) string {
 	title := ""
 	modelID := ""
@@ -369,12 +427,8 @@ func documentChunkFingerprintForKnowledge(knowledge *types.Knowledge, content, c
 }
 
 func textChunkIndexInfo(knowledge *types.Knowledge, chunk *types.Chunk) *types.IndexInfo {
-	titlePrefix := ""
-	if t := strings.TrimSpace(knowledge.Title); t != "" {
-		titlePrefix = t + "\n"
-	}
 	return &types.IndexInfo{
-		Content:         titlePrefix + chunk.EmbeddingContent(),
+		Content:         buildKnowledgeIndexContent(knowledge, chunk.EmbeddingContent()),
 		SourceID:        chunk.ID,
 		SourceType:      types.ChunkSourceType,
 		ChunkID:         chunk.ID,
@@ -384,12 +438,175 @@ func textChunkIndexInfo(knowledge *types.Knowledge, chunk *types.Chunk) *types.I
 	}
 }
 
+type documentParseCachePayload struct {
+	MarkdownContent string                  `json:"markdown_content"`
+	StoredImages    []docparser.StoredImage `json:"stored_images,omitempty"`
+	Metadata        map[string]string       `json:"metadata,omitempty"`
+}
+
+func (s *knowledgeService) documentParseCacheKeys(
+	ctx context.Context,
+	payload types.DocumentProcessPayload,
+	knowledge *types.Knowledge,
+	kb *types.KnowledgeBase,
+	eff types.EffectiveProcessConfig,
+) (contentKey, configHash, cacheKey string) {
+	if knowledge == nil || kb == nil || payload.FilePath == "" || payload.FileURL != "" || payload.URL != "" {
+		return "", "", ""
+	}
+	contentKey = strings.TrimSpace(knowledge.FileHash)
+	if contentKey == "" {
+		return "", "", ""
+	}
+
+	tenantOverrides := s.getParserEngineOverridesFromContext(ctx)
+	var uploadOverrides map[string]string
+	if processOverrides, err := knowledge.ProcessOverrides(); err == nil && processOverrides != nil {
+		uploadOverrides = processOverrides.ParserEngineOverrides
+	}
+	mergedOverrides := MergeParserEngineOverrides(tenantOverrides, uploadOverrides)
+	applyParserRuleOverrides(mergedOverrides, eff.ChunkingConfig, payload.FileType)
+	parserEngine := eff.ChunkingConfig.ResolveParserEngine(payload.FileType)
+	storageConfig := s.buildStorageConfig(ctx, kb)
+	storageBackendID := ""
+	if kb.StorageBackendID != nil {
+		storageBackendID = strings.TrimSpace(*kb.StorageBackendID)
+	}
+	type storageTarget struct {
+		BackendID string `json:"backend_id,omitempty"`
+		Provider  string `json:"provider,omitempty"`
+		Endpoint  string `json:"endpoint,omitempty"`
+		Region    string `json:"region,omitempty"`
+		Bucket    string `json:"bucket,omitempty"`
+		AppID     string `json:"app_id,omitempty"`
+		Path      string `json:"path,omitempty"`
+	}
+	resolvedStorage := storageTarget{BackendID: storageBackendID}
+	if storageConfig != nil {
+		resolvedStorage.Provider = strings.ToLower(strings.TrimSpace(storageConfig.Provider))
+		resolvedStorage.Endpoint = strings.TrimSpace(storageConfig.Endpoint)
+		resolvedStorage.Region = strings.TrimSpace(storageConfig.Region)
+		resolvedStorage.Bucket = strings.TrimSpace(storageConfig.BucketName)
+		resolvedStorage.AppID = strings.TrimSpace(storageConfig.AppID)
+		resolvedStorage.Path = strings.TrimSpace(storageConfig.PathPrefix)
+	}
+	configBytes, err := json.Marshal(struct {
+		FileType      string            `json:"file_type"`
+		ParserEngine  string            `json:"parser_engine"`
+		ParserOptions map[string]string `json:"parser_options,omitempty"`
+		DocumentTitle string            `json:"document_title,omitempty"`
+		ASRConfig     types.ASRConfig   `json:"asr_config"`
+		StorageTarget storageTarget     `json:"storage_target"`
+	}{
+		FileType:      strings.ToLower(strings.TrimSpace(payload.FileType)),
+		ParserEngine:  parserEngine,
+		ParserOptions: mergedOverrides,
+		DocumentTitle: knowledge.Title,
+		ASRConfig:     eff.ASRConfig,
+		StorageTarget: resolvedStorage,
+	})
+	if err != nil {
+		return "", "", ""
+	}
+	configHash = hashStringHex(string(configBytes))
+	cacheKey = hashStringHex(strings.Join([]string{
+		types.DocumentParseCacheSchemaVersion,
+		contentKey,
+		configHash,
+	}, "\x00"))
+	return contentKey, configHash, cacheKey
+}
+
+func (s *knowledgeService) loadDocumentParseCache(
+	ctx context.Context,
+	knowledge *types.Knowledge,
+	cacheKey string,
+) (*types.ReadResult, []docparser.StoredImage, bool) {
+	if s.parseCacheRepo == nil || knowledge == nil || cacheKey == "" {
+		return nil, nil, false
+	}
+	cache, err := s.parseCacheRepo.GetByKey(ctx, knowledge.TenantID, knowledge.ID, cacheKey)
+	if err != nil {
+		logger.Warnf(ctx, "Document parse cache lookup failed for %s: %v", knowledge.ID, err)
+		return nil, nil, false
+	}
+	if cache == nil {
+		return nil, nil, false
+	}
+	var cached documentParseCachePayload
+	if err := json.Unmarshal(cache.Payload, &cached); err != nil {
+		logger.Warnf(ctx, "Document parse cache payload invalid for %s: %v", knowledge.ID, err)
+		return nil, nil, false
+	}
+	if strings.TrimSpace(cached.MarkdownContent) == "" {
+		return nil, nil, false
+	}
+	return &types.ReadResult{
+		MarkdownContent: cached.MarkdownContent,
+		Metadata:        cached.Metadata,
+	}, cached.StoredImages, true
+}
+
+func (s *knowledgeService) storeDocumentParseCache(
+	ctx context.Context,
+	knowledge *types.Knowledge,
+	contentKey, configHash, cacheKey string,
+	result *types.ReadResult,
+	storedImages []docparser.StoredImage,
+) {
+	if s.parseCacheRepo == nil || knowledge == nil || result == nil || cacheKey == "" ||
+		strings.TrimSpace(result.MarkdownContent) == "" {
+		return
+	}
+	payload, err := json.Marshal(documentParseCachePayload{
+		MarkdownContent: result.MarkdownContent,
+		StoredImages:    storedImages,
+		Metadata:        result.Metadata,
+	})
+	if err != nil {
+		logger.Warnf(ctx, "Document parse cache marshal failed for %s: %v", knowledge.ID, err)
+		return
+	}
+	now := time.Now()
+	if err := s.parseCacheRepo.Upsert(ctx, &types.DocumentParseCache{
+		TenantID:    knowledge.TenantID,
+		KnowledgeID: knowledge.ID,
+		CacheKey:    cacheKey,
+		ContentKey:  contentKey,
+		ConfigHash:  configHash,
+		SchemaVer:   types.DocumentParseCacheSchemaVersion,
+		Payload:     types.JSON(payload),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}); err != nil {
+		logger.Warnf(ctx, "Document parse cache upsert failed for %s: %v", knowledge.ID, err)
+	}
+}
+
 func (s *knowledgeService) deleteExtractedImagesFromInfo(
 	ctx context.Context,
 	kb *types.KnowledgeBase,
 	imageInfos []string,
 ) {
+	s.deleteExtractedImagesFromInfoExcept(ctx, kb, imageInfos, nil)
+}
+
+func (s *knowledgeService) deleteExtractedImagesFromInfoExcept(
+	ctx context.Context,
+	kb *types.KnowledgeBase,
+	imageInfos []string,
+	retainedURLs map[string]struct{},
+) {
 	imageURLs := collectImageURLs(ctx, imageInfos)
+	if len(retainedURLs) > 0 {
+		kept := imageURLs[:0]
+		for _, imageURL := range imageURLs {
+			if _, retained := retainedURLs[imageURL]; !retained {
+				kept = append(kept, imageURL)
+			}
+		}
+		imageURLs = kept
+	}
 	if len(imageURLs) == 0 {
 		return
 	}
@@ -459,11 +676,10 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		return
 	}
 
-	hasPendingMultimodalInput := options.EnableMultimodel && len(options.StoredImages) > 0
-	reuseEnabled := options.ReuseUnchangedChunks && !hasPendingMultimodalInput && len(options.ParentChunks) == 0
+	reuseEnabled := options.ReuseUnchangedChunks && len(options.ParentChunks) == 0
 	if options.ReuseUnchangedChunks && !reuseEnabled {
-		logger.Infof(ctx, "Chunk reuse disabled for knowledge %s: multimodal_inputs=%v parent_child=%v",
-			knowledge.ID, hasPendingMultimodalInput, len(options.ParentChunks) > 0)
+		logger.Infof(ctx, "Chunk reuse disabled for knowledge %s: parent_child=%v",
+			knowledge.ID, len(options.ParentChunks) > 0)
 	}
 	var reuseState *chunkReuseState
 	var oldChunks []*types.Chunk
@@ -474,7 +690,9 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			logger.Warnf(ctx, "Failed to list existing chunks for reuse, falling back to full cleanup: %v", listErr)
 			reuseEnabled = false
 		} else {
-			reuseState = newChunkReuseState(ctx, knowledge, oldChunks, options.AllowLegacyChunkReuse)
+			reuseState = newChunkReuseState(
+				ctx, knowledge, oldChunks, options.AllowLegacyChunkReuse, options.ReindexReusedChunks,
+			)
 		}
 	}
 
@@ -642,17 +860,25 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		}
 
 		if oldChunk, ok := reuseState.takeTextChunk(fingerprint); ok {
-			textChunk.ID = oldChunk.ID
-			textChunk.SeqID = oldChunk.SeqID
-			if meta, metaErr := oldChunk.DocumentMetadata(); metaErr == nil && meta != nil && len(meta.GeneratedQuestions) > 0 {
-				textChunk.Metadata = oldChunk.Metadata
+			// UpdateChunk persists every field, so begin with the complete
+			// database row and overwrite only parser-owned fields. Building
+			// a partial replacement here would zero fields added by chunk
+			// editing (for example index_status and source_content).
+			reusedChunk := *oldChunk
+			textChunk = &reusedChunk
+			textChunk.Content = chunkData.Content
+			textChunk.ContextHeader = chunkData.ContextHeader
+			textChunk.ChunkIndex = int(chunkData.Seq)
+			textChunk.StartAt = int(chunkData.Start)
+			textChunk.EndAt = int(chunkData.End)
+			textChunk.ContentHash = fingerprint
+			textChunk.PreChunkID = ""
+			textChunk.NextChunkID = ""
+			textChunk.ParentChunkID = ""
+			textChunk.UpdatedAt = time.Now()
+			if textChunk.IndexStatus == "" {
+				textChunk.IndexStatus = "ready"
 			}
-			textChunk.CreatedAt = oldChunk.CreatedAt
-			textChunk.ImageInfo = oldChunk.ImageInfo
-			textChunk.TagID = oldChunk.TagID
-			textChunk.Flags = oldChunk.Flags
-			textChunk.Status = oldChunk.Status
-			textChunk.IsEnabled = oldChunk.IsEnabled
 			if textChunk.CreatedAt.IsZero() {
 				textChunk.CreatedAt = time.Now()
 			}
@@ -738,6 +964,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	}
 	for _, chunk := range updateChunks {
 		if err := s.chunkService.UpdateChunk(ctx, chunk); err != nil {
+			s.rollbackChunkReuseWrites(ctx, reuseState, createChunks)
 			knowledge.ParseStatus = types.ParseStatusFailed
 			knowledge.ErrorMessage = err.Error()
 			knowledge.UpdatedAt = time.Now()
@@ -792,20 +1019,21 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		// question-style queries and statement-style chunk content.
 		allIndexInfoList := make([]*types.IndexInfo, 0, len(textChunks))
 		indexInfoList := make([]*types.IndexInfo, 0, len(textChunks))
+		reusedVectorCount := 0
 		for _, chunk := range textChunks {
 			// chunk.EmbeddingContent prepends ContextHeader (heading breadcrumb)
 			// when the chunker populated it during Tier-1 splitting; falls back
-			// to plain Content otherwise. The document title sits outermost;
-			// custom metadata remains document-scoped model context.
+			// to plain Content otherwise. Title prefix sits outermost.
 			info := textChunkIndexInfo(knowledge, chunk)
 			allIndexInfoList = append(allIndexInfoList, info)
-			if _, reused := reusedChunkIDs[chunk.ID]; reused {
+			if _, reused := reusedChunkIDs[chunk.ID]; reused && !reuseState.shouldReindex(chunk.ID) {
+				reusedVectorCount++
 				continue
 			}
 			indexInfoList = append(indexInfoList, info)
 		}
 		embedInput["chunks_to_embed"] = len(indexInfoList)
-		embedInput["chunks_reused"] = len(updateChunks)
+		embedInput["chunks_reused"] = reusedVectorCount
 		s.beginStage(ctx, knowledge.ID, types.StageEmbedding, embedInput)
 
 		// Calculate storage size required for embeddings
@@ -815,6 +1043,9 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			// Re-fetch tenant storage information
 			tenantInfo, err = s.tenantRepo.GetTenantByID(ctx, tenantInfo.ID)
 			if err != nil {
+				if reuseEnabled {
+					s.rollbackChunkReuseWrites(ctx, reuseState, createChunks)
+				}
 				knowledge.ParseStatus = types.ParseStatusFailed
 				knowledge.ErrorMessage = err.Error()
 				knowledge.UpdatedAt = time.Now()
@@ -823,6 +1054,9 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			}
 			// Check if there's enough storage quota available
 			if storageDelta > 0 && tenantInfo.StorageUsed+storageDelta > tenantInfo.StorageQuota {
+				if reuseEnabled {
+					s.rollbackChunkReuseWrites(ctx, reuseState, createChunks)
+				}
 				knowledge.ParseStatus = types.ParseStatusFailed
 				knowledge.ErrorMessage = "存储空间不足"
 				knowledge.UpdatedAt = time.Now()
@@ -857,10 +1091,8 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 					for _, chunk := range createChunks {
 						newChunkIDs = append(newChunkIDs, chunk.ID)
 					}
+					s.rollbackChunkReuseWrites(ctx, reuseState, createChunks)
 					if len(newChunkIDs) > 0 {
-						if err := s.chunkService.DeleteChunks(ctx, newChunkIDs); err != nil {
-							logger.Errorf(ctx, "Delete newly created chunks failed: %v", err)
-						}
 						if err := retrieveEngine.DeleteByChunkIDList(ctx, newChunkIDs, embeddingModel.GetDimensions(), kb.Type); err != nil {
 							logger.Errorf(ctx, "Delete newly created indexes failed: %v", err)
 						}
@@ -892,7 +1124,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		logger.GetLogger(ctx).Infof("processChunks batch index successfully, with %d index", len(indexInfoList))
 		s.endStage(ctx, knowledge.ID, types.StageEmbedding, types.JSONMap{
 			"vectors_written": len(indexInfoList),
-			"vectors_reused":  len(updateChunks),
+			"vectors_reused":  reusedVectorCount,
 			"storage_bytes":   totalStorageSize,
 		})
 
@@ -930,7 +1162,13 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			}
 		}
 		if reuseState != nil {
-			s.deleteExtractedImagesFromInfo(ctx, kb, reuseState.staleImageInfos())
+			retainedImageURLs := make(map[string]struct{}, len(options.StoredImages))
+			for _, image := range options.StoredImages {
+				if image.ServingURL != "" {
+					retainedImageURLs[image.ServingURL] = struct{}{}
+				}
+			}
+			s.deleteExtractedImagesFromInfoExcept(ctx, kb, reuseState.staleImageInfos(), retainedImageURLs)
 		}
 		if err := s.chunkService.DeleteChunks(ctx, staleChunkIDs); err != nil {
 			knowledge.ParseStatus = types.ParseStatusFailed
@@ -1023,6 +1261,225 @@ const imageDominatedTextThreshold = 200
 // mark the knowledge's summary as failed instead of falling back to the first
 // chunk's raw content (which would just be a bare image reference).
 var errInsufficientSummaryContent = errors.New("insufficient text content for summary generation")
+
+const summaryGenerationCacheSchemaVersion = "document_summary_v1"
+
+func summaryGenerationCacheKey(
+	ctx context.Context,
+	summaryModel chat.Chat,
+	knowledge *types.Knowledge,
+	chunks []*types.Chunk,
+	config *config.Config,
+) string {
+	if summaryModel == nil || knowledge == nil || config == nil {
+		return ""
+	}
+	maxInputChars := defaultMaxInputChars
+	maxTokens := 2048
+	if config.Conversation.Summary != nil {
+		if config.Conversation.Summary.MaxInputChars > 0 {
+			maxInputChars = config.Conversation.Summary.MaxInputChars
+		}
+		if config.Conversation.Summary.MaxCompletionTokens > 0 {
+			maxTokens = config.Conversation.Summary.MaxCompletionTokens
+		}
+	}
+	prompt := types.RenderPromptPlaceholders(config.Conversation.GenerateSummaryPrompt, types.PlaceholderValues{
+		"language": types.LanguageNameFromContext(ctx),
+	})
+
+	type cacheChunk struct {
+		ChunkType       types.ChunkType `json:"chunk_type"`
+		ParentChunkKey  string          `json:"parent_chunk_key,omitempty"`
+		ChunkIndex      int             `json:"chunk_index"`
+		StartAt         int             `json:"start_at"`
+		EndAt           int             `json:"end_at"`
+		Content         string          `json:"content"`
+		ContextHeader   string          `json:"context_header,omitempty"`
+		ImageInfo       string          `json:"image_info,omitempty"`
+		ContentRevision int             `json:"content_revision"`
+		IsEnabled       bool            `json:"is_enabled"`
+	}
+	parentChunkKeys := make(map[string]string)
+	for _, chunk := range chunks {
+		if chunk == nil || chunk.ChunkType != types.ChunkTypeText {
+			continue
+		}
+		parentChunkKeys[chunk.ID] = hashStringHex(strings.Join([]string{
+			fmt.Sprintf("%d:%d:%d", chunk.ChunkIndex, chunk.StartAt, chunk.EndAt),
+			chunk.ContextHeader,
+			chunk.Content,
+		}, "\x00"))
+	}
+	inputs := make([]cacheChunk, 0, len(chunks))
+	for _, chunk := range chunks {
+		if chunk == nil {
+			continue
+		}
+		switch chunk.ChunkType {
+		case types.ChunkTypeText, types.ChunkTypeImageOCR, types.ChunkTypeImageCaption:
+		default:
+			continue
+		}
+		inputs = append(inputs, cacheChunk{
+			ChunkType:       chunk.ChunkType,
+			ParentChunkKey:  parentChunkKeys[chunk.ParentChunkID],
+			ChunkIndex:      chunk.ChunkIndex,
+			StartAt:         chunk.StartAt,
+			EndAt:           chunk.EndAt,
+			Content:         chunk.Content,
+			ContextHeader:   chunk.ContextHeader,
+			ImageInfo:       chunk.ImageInfo,
+			ContentRevision: chunk.ContentRevision,
+			IsEnabled:       chunk.IsEnabled,
+		})
+	}
+	sort.Slice(inputs, func(i, j int) bool {
+		if inputs[i].ChunkType != inputs[j].ChunkType {
+			return inputs[i].ChunkType < inputs[j].ChunkType
+		}
+		if inputs[i].ParentChunkKey != inputs[j].ParentChunkKey {
+			return inputs[i].ParentChunkKey < inputs[j].ParentChunkKey
+		}
+		if inputs[i].ChunkIndex != inputs[j].ChunkIndex {
+			return inputs[i].ChunkIndex < inputs[j].ChunkIndex
+		}
+		if inputs[i].StartAt != inputs[j].StartAt {
+			return inputs[i].StartAt < inputs[j].StartAt
+		}
+		if inputs[i].EndAt != inputs[j].EndAt {
+			return inputs[i].EndAt < inputs[j].EndAt
+		}
+		if inputs[i].Content != inputs[j].Content {
+			return inputs[i].Content < inputs[j].Content
+		}
+		if inputs[i].ContextHeader != inputs[j].ContextHeader {
+			return inputs[i].ContextHeader < inputs[j].ContextHeader
+		}
+		if inputs[i].ImageInfo != inputs[j].ImageInfo {
+			return inputs[i].ImageInfo < inputs[j].ImageInfo
+		}
+		if inputs[i].ContentRevision != inputs[j].ContentRevision {
+			return inputs[i].ContentRevision < inputs[j].ContentRevision
+		}
+		return !inputs[i].IsEnabled && inputs[j].IsEnabled
+	})
+	inputBytes, err := json.Marshal(inputs)
+	if err != nil {
+		return ""
+	}
+	return hashStringHex(strings.Join([]string{
+		summaryGenerationCacheSchemaVersion,
+		summaryModel.GetModelID(),
+		summaryModel.GetModelName(),
+		prompt,
+		knowledge.CustomMetadataText(),
+		fmt.Sprintf("max_input_chars=%d;temperature=0.3;max_tokens=%d;thinking=false", maxInputChars, maxTokens),
+		string(inputBytes),
+	}, "\x00"))
+}
+
+func summaryIndexCacheKey(knowledge *types.Knowledge, kb *types.KnowledgeBase, content string) string {
+	if knowledge == nil || kb == nil || content == "" {
+		return ""
+	}
+	return hashStringHex(strings.Join([]string{
+		"document_summary_index_v1",
+		kb.EmbeddingModelID,
+		buildKnowledgeIndexContent(knowledge, content),
+	}, "\x00"))
+}
+
+func (s *knowledgeService) ensureSummaryChunkIndexed(
+	ctx context.Context,
+	knowledge *types.Knowledge,
+	kb *types.KnowledgeBase,
+	allChunks []*types.Chunk,
+	textChunks []*types.Chunk,
+	summary string,
+) (bool, error) {
+	if knowledge == nil || kb == nil || strings.TrimSpace(summary) == "" || !kb.NeedsEmbeddingModel() {
+		return false, nil
+	}
+	if len(textChunks) == 0 {
+		return false, fmt.Errorf("no text chunks available for summary index")
+	}
+
+	content := "# Summary\n" + summary
+	indexKey := summaryIndexCacheKey(knowledge, kb, content)
+	maxChunkIndex := 0
+	summaryChunks := make([]*types.Chunk, 0, 1)
+	for _, chunk := range allChunks {
+		if chunk == nil {
+			continue
+		}
+		if chunk.ChunkIndex > maxChunkIndex {
+			maxChunkIndex = chunk.ChunkIndex
+		}
+		if chunk.ChunkType == types.ChunkTypeSummary {
+			summaryChunks = append(summaryChunks, chunk)
+		}
+	}
+
+	toIndex := make([]*types.Chunk, 0, len(summaryChunks)+1)
+	if len(summaryChunks) == 0 {
+		summaryChunk := &types.Chunk{
+			ID:              uuid.NewString(),
+			TenantID:        knowledge.TenantID,
+			KnowledgeID:     knowledge.ID,
+			KnowledgeBaseID: knowledge.KnowledgeBaseID,
+			Content:         content,
+			SourceContent:   content,
+			ChunkIndex:      maxChunkIndex + 1,
+			IsEnabled:       true,
+			ChunkType:       types.ChunkTypeSummary,
+			ParentChunkID:   textChunks[0].ID,
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
+		}
+		if err := s.chunkService.CreateChunks(ctx, []*types.Chunk{summaryChunk}); err != nil {
+			return false, err
+		}
+		summaryChunks = append(summaryChunks, summaryChunk)
+		toIndex = append(toIndex, summaryChunk)
+	} else {
+		for _, chunk := range summaryChunks {
+			if chunk.Content == content && chunk.ContentHash == indexKey &&
+				chunk.IsEnabled && chunk.ParentChunkID == textChunks[0].ID {
+				continue
+			}
+			chunk.Content = content
+			chunk.SourceContent = content
+			chunk.ContentHash = ""
+			chunk.ParentChunkID = textChunks[0].ID
+			chunk.IsEnabled = true
+			chunk.UpdatedAt = time.Now()
+			if err := s.chunkService.UpdateChunk(ctx, chunk); err != nil {
+				return false, err
+			}
+			toIndex = append(toIndex, chunk)
+		}
+	}
+	if len(toIndex) == 0 {
+		return false, nil
+	}
+
+	indexCtx, err := restoreSummaryRefreshTenantInfo(ctx, s.tenantRepo, knowledge.TenantID)
+	if err != nil {
+		return false, err
+	}
+	if err := s.updateChunkVector(indexCtx, knowledge.KnowledgeBaseID, toIndex); err != nil {
+		return false, err
+	}
+	for _, chunk := range toIndex {
+		chunk.ContentHash = indexKey
+		chunk.UpdatedAt = time.Now()
+		if err := s.chunkService.UpdateChunk(ctx, chunk); err != nil {
+			return true, err
+		}
+	}
+	return true, nil
+}
 
 // checkSufficientSummaryContent returns errInsufficientSummaryContent if the
 // given content does not carry enough real text (after stripping image markup)
@@ -1419,9 +1876,26 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 		return fmt.Errorf("failed to get chat model: %w", err)
 	}
 
-	// Generate summary
+	// Generate summary only when the exact model/prompt/input contract changed.
 	summaryMetadataVersion := string(knowledge.CustomMetadata)
-	summary, err := s.getSummary(ctx, chatModel, knowledge, textChunks)
+	summaryCacheKey := summaryGenerationCacheKey(ctx, chatModel, knowledge, chunks, s.config)
+	summary := ""
+	summaryGenerated := false
+	cacheMetadata, cacheMetadataErr := knowledge.SummaryCacheMetadata()
+	if cacheMetadataErr != nil {
+		logger.Warnf(ctx, "Failed to read summary cache metadata for %s: %v", knowledge.ID, cacheMetadataErr)
+	}
+	if cacheMetadata != nil && summaryCacheKey != "" &&
+		cacheMetadata.Key == summaryCacheKey &&
+		cacheMetadata.ContentHash == hashStringHex(cacheMetadata.Content) &&
+		strings.TrimSpace(cacheMetadata.Content) != "" {
+		summary = cacheMetadata.Content
+		summaryOut["cache_hit"] = true
+	} else {
+		summaryOut["cache_hit"] = false
+		summary, err = s.getSummary(ctx, chatModel, knowledge, textChunks)
+		summaryGenerated = err == nil
+	}
 	if err != nil {
 		logger.Errorf(ctx, "Failed to generate summary for knowledge %s: %v", payload.KnowledgeID, err)
 		// Surface the underlying LLM/IO error on the span so the trace UI
@@ -1481,6 +1955,15 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 	knowledge.Description = summary
 	knowledge.SummaryStatus = types.SummaryStatusCompleted
 	knowledge.UpdatedAt = time.Now()
+	if summaryGenerated && summaryCacheKey != "" {
+		if err := knowledge.SetSummaryCacheMetadata(&types.KnowledgeSummaryCacheMetadata{
+			Key:         summaryCacheKey,
+			ContentHash: hashStringHex(summary),
+			Content:     summary,
+		}); err != nil {
+			logger.Warnf(ctx, "Failed to persist summary cache metadata for %s: %v", knowledge.ID, err)
+		}
+	}
 	summaryOut["summary_chars"] = len([]rune(summary))
 	// Preview the generated summary on the span output so the trace
 	// viewer can show "this is what the LLM produced" at a glance,
@@ -1493,88 +1976,13 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 		return fmt.Errorf("failed to update knowledge: %w", err)
 	}
 
-	// Create summary chunk and index it — only when RAG indexing is enabled.
-	// Wiki-only KBs don't need summary chunks in the vector index.
-	if strings.TrimSpace(summary) != "" && kb.NeedsEmbeddingModel() {
-		// Get max chunk index
-		maxChunkIndex := 0
-		for _, chunk := range chunks {
-			if chunk.ChunkIndex > maxChunkIndex {
-				maxChunkIndex = chunk.ChunkIndex
-			}
-		}
-
-		// Embed only the LLM-generated summary in the indexed chunk.
-		// We deliberately omit knowledge.FileName here: filenames are an
-		// unreliable signal (e.g. "MX5280.pdf" for a scanned legal letter)
-		// and surfacing them in retrieved RAG context can re-introduce the
-		// hallucination vector this branch is meant to close.
-		summaryChunk := &types.Chunk{
-			ID:              uuid.New().String(),
-			TenantID:        knowledge.TenantID,
-			KnowledgeID:     knowledge.ID,
-			KnowledgeBaseID: knowledge.KnowledgeBaseID,
-			Content:         fmt.Sprintf("# Summary\n%s", summary),
-			ChunkIndex:      maxChunkIndex + 1,
-			IsEnabled:       true,
-			CreatedAt:       time.Now(),
-			UpdatedAt:       time.Now(),
-			StartAt:         0,
-			EndAt:           0,
-			ChunkType:       types.ChunkTypeSummary,
-			ParentChunkID:   textChunks[0].ID,
-		}
-
-		// Save summary chunk
-		if err := s.chunkService.CreateChunks(ctx, []*types.Chunk{summaryChunk}); err != nil {
-			logger.Errorf(ctx, "Failed to create summary chunk: %v", err)
-			summaryErr = err
-			return fmt.Errorf("failed to create summary chunk: %w", err)
-		}
-
-		// Index summary chunk
-		tenantInfo, err := s.tenantRepo.GetTenantByID(ctx, payload.TenantID)
-		if err != nil {
-			logger.Errorf(ctx, "Failed to get tenant info: %v", err)
-			summaryErr = err
-			return fmt.Errorf("failed to get tenant info: %w", err)
-		}
-		ctx = context.WithValue(ctx, types.TenantInfoContextKey, tenantInfo)
-
-		retrieveEngine, err := retriever.CreateRetrieveEngineForKB(
-			ctx, s.retrieveEngine, s.ownership, tenantInfo.ID, kb.VectorStoreID)
-		if err != nil {
-			logger.Errorf(ctx, "Failed to init retrieve engine: %v", err)
-			summaryErr = err
-			return fmt.Errorf("failed to init retrieve engine: %w", err)
-		}
-
-		embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
-		if err != nil {
-			logger.Errorf(ctx, "Failed to get embedding model: %v", err)
-			summaryErr = err
-			return fmt.Errorf("failed to get embedding model: %w", err)
-		}
-
-		indexInfo := []*types.IndexInfo{{
-			Content:         summaryChunk.Content,
-			SourceID:        summaryChunk.ID,
-			SourceType:      types.ChunkSourceType,
-			ChunkID:         summaryChunk.ID,
-			KnowledgeID:     knowledge.ID,
-			KnowledgeBaseID: knowledge.KnowledgeBaseID,
-			IsEnabled:       true,
-		}}
-
-		if err := retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfo); err != nil {
-			logger.Errorf(ctx, "Failed to index summary chunk: %v", err)
-			summaryErr = err
-			return fmt.Errorf("failed to index summary chunk: %w", err)
-		}
-
-		logger.Infof(ctx, "Successfully created and indexed summary chunk for knowledge: %s", payload.KnowledgeID)
-		summaryOut["summary_chunk_indexed"] = true
+	indexed, err := s.ensureSummaryChunkIndexed(ctx, knowledge, kb, chunks, textChunks, summary)
+	if err != nil {
+		logger.Errorf(ctx, "Failed to persist summary chunk: %v", err)
+		summaryErr = err
+		return fmt.Errorf("persist summary chunk: %w", err)
 	}
+	summaryOut["summary_chunk_indexed"] = indexed
 
 	logger.Infof(ctx, "Successfully generated summary for knowledge: %s", payload.KnowledgeID)
 	summaryOut["status"] = "completed"
@@ -2221,20 +2629,72 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 		return enrich(nextChunk)
 	}
 
+	type pendingQuestionUpdate struct {
+		chunk             *types.Chunk
+		metadata          *types.DocumentChunkMetadata
+		obsoleteSourceIDs []string
+	}
 	var indexInfoList []*types.IndexInfo
+	var pendingUpdates []pendingQuestionUpdate
+	queueCachedQuestions := func(
+		chunk *types.Chunk,
+		metadata *types.DocumentChunkMetadata,
+		generationKey string,
+	) bool {
+		if chunk == nil || metadata == nil || generationKey == "" ||
+			metadata.GeneratedQuestionsCacheKey != generationKey {
+			return false
+		}
+		indexKey := questionGenerationIndexKey(
+			kb.EmbeddingModelID, knowledge, generationKey, metadata.GeneratedQuestions,
+		)
+		if metadata.GeneratedQuestionsIndexKey == indexKey {
+			return true
+		}
+		updatedMetadata := *metadata
+		updatedMetadata.GeneratedQuestionsIndexKey = indexKey
+		for _, question := range metadata.GeneratedQuestions {
+			if strings.TrimSpace(question.Question) == "" {
+				continue
+			}
+			indexInfoList = append(indexInfoList, &types.IndexInfo{
+				Content:         buildKnowledgeIndexContent(knowledge, question.Question),
+				SourceID:        types.GeneratedQuestionSourceID(chunk.ID, question.ID),
+				SourceType:      types.ChunkSourceType,
+				ChunkID:         chunk.ID,
+				KnowledgeID:     knowledge.ID,
+				KnowledgeBaseID: knowledge.KnowledgeBaseID,
+				IsEnabled:       true,
+			})
+		}
+		pendingUpdates = append(pendingUpdates, pendingQuestionUpdate{
+			chunk:    chunk,
+			metadata: &updatedMetadata,
+		})
+		return true
+	}
 	for i, chunk := range batchChunks {
 		if chunk == nil || strings.TrimSpace(chunk.Content) == "" {
 			emptyChunks++
 			continue
 		}
-		if meta, metaErr := chunk.DocumentMetadata(); metaErr == nil && meta != nil && len(meta.GeneratedQuestions) > 0 {
+		prompt, promptErr := s.renderQuestionGenerationPrompt(
+			ctx, enrich(chunk), prevContentAt(i), nextContentAt(i), knowledge.Title, questionCount,
+			customInstructions,
+		)
+		if promptErr != nil {
+			llmCallFailed++
+			logger.Warnf(ctx, "Failed to render question prompt for chunk %s: %v", chunk.ID, promptErr)
+			continue
+		}
+		cacheKey := questionGenerationCacheKey(chatModel, prompt)
+		existingMeta, metaErr := chunk.DocumentMetadata()
+		if metaErr == nil && queueCachedQuestions(chunk, existingMeta, cacheKey) {
 			continue
 		}
 
 		generationRevision := chunk.ContentRevision
-		questions, gerr := s.generateQuestionsWithContext(
-			ctx, chatModel, enrich(chunk), prevContentAt(i), nextContentAt(i), knowledge.Title, questionCount,
-			customInstructions)
+		questions, gerr := generateQuestionsFromPrompt(ctx, chatModel, prompt, questionCount)
 		if gerr != nil {
 			llmCallFailed++
 			logger.Warnf(ctx, "Failed to generate questions for chunk %s: %v", chunk.ID, gerr)
@@ -2249,6 +2709,10 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 			continue
 		}
 		chunk = latestChunk
+		existingMeta, _ = chunk.DocumentMetadata()
+		if queueCachedQuestions(chunk, existingMeta, cacheKey) {
+			continue
+		}
 		chunksProcessed++
 		generatedQuestionsTotal += len(questions)
 		if sampleQuestion == "" {
@@ -2265,20 +2729,20 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 			}
 		}
 		meta := &types.DocumentChunkMetadata{
-			GeneratedQuestions: generatedQuestions, GeneratedQuestionsRevision: chunk.ContentRevision,
+			GeneratedQuestions:         generatedQuestions,
+			GeneratedQuestionsRevision: chunk.ContentRevision,
+			GeneratedQuestionsCacheKey: cacheKey,
+			GeneratedQuestionsIndexKey: questionGenerationIndexKey(
+				kb.EmbeddingModelID, knowledge, cacheKey, generatedQuestions,
+			),
 		}
-		if err := chunk.SetDocumentMetadata(meta); err != nil {
-			logger.Warnf(ctx, "Failed to set document metadata for chunk %s: %v", chunk.ID, err)
-			continue
-		}
-		if err := s.chunkService.UpdateChunk(ctx, chunk); err != nil {
-			logger.Warnf(ctx, "Failed to update chunk %s: %v", chunk.ID, err)
-			continue
-		}
+		newSourceIDs := make(map[string]struct{}, len(generatedQuestions))
 		for _, gq := range generatedQuestions {
+			sourceID := types.GeneratedQuestionSourceID(chunk.ID, gq.ID)
+			newSourceIDs[sourceID] = struct{}{}
 			indexInfoList = append(indexInfoList, &types.IndexInfo{
 				Content:         buildKnowledgeIndexContent(knowledge, gq.Question),
-				SourceID:        types.GeneratedQuestionSourceID(chunk.ID, gq.ID),
+				SourceID:        sourceID,
 				SourceType:      types.ChunkSourceType,
 				ChunkID:         chunk.ID,
 				KnowledgeID:     knowledge.ID,
@@ -2286,6 +2750,20 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 				IsEnabled:       true,
 			})
 		}
+		var obsoleteSourceIDs []string
+		if existingMeta != nil {
+			for _, oldQuestion := range existingMeta.GeneratedQuestions {
+				oldSourceID := types.GeneratedQuestionSourceID(chunk.ID, oldQuestion.ID)
+				if _, stillUsed := newSourceIDs[oldSourceID]; !stillUsed {
+					obsoleteSourceIDs = append(obsoleteSourceIDs, oldSourceID)
+				}
+			}
+		}
+		pendingUpdates = append(pendingUpdates, pendingQuestionUpdate{
+			chunk:             chunk,
+			metadata:          meta,
+			obsoleteSourceIDs: obsoleteSourceIDs,
+		})
 	}
 
 	indexEntriesPrepared = len(indexInfoList)
@@ -2300,21 +2778,45 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 		logger.Infof(ctx, "Indexed %d generated questions for knowledge=%s batch=%d",
 			len(indexInfoList), payload.KnowledgeID, payload.BatchIndex)
 	}
+	for _, update := range pendingUpdates {
+		if len(update.obsoleteSourceIDs) > 0 {
+			if err := retrieveEngine.DeleteBySourceIDList(
+				ctx, update.obsoleteSourceIDs, embeddingModel.GetDimensions(), kb.Type,
+			); err != nil {
+				exitStatus = "delete_stale_questions_failed"
+				qErr = err
+				return fmt.Errorf("delete stale question indexes for chunk %s: %w", update.chunk.ID, err)
+			}
+		}
+		if err := update.chunk.SetDocumentMetadata(update.metadata); err != nil {
+			exitStatus = "set_question_metadata_failed"
+			qErr = err
+			return fmt.Errorf("set question metadata for chunk %s: %w", update.chunk.ID, err)
+		}
+		if err := s.chunkService.UpdateChunk(ctx, update.chunk); err != nil {
+			exitStatus = "update_question_metadata_failed"
+			qErr = err
+			return fmt.Errorf("update question metadata for chunk %s: %w", update.chunk.ID, err)
+		}
+	}
 	return nil
 }
 
-// generateQuestionsWithContext generates questions for a chunk with surrounding context
-func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
-	chatModel chat.Chat, content, prevContent, nextContent, docName string, questionCount int,
+const questionGenerationCacheSchemaVersion = "question_generation_v2"
+
+func (s *knowledgeService) renderQuestionGenerationPrompt(
+	ctx context.Context,
+	content, prevContent, nextContent, docName string,
+	questionCount int,
 	customInstructions string,
-) ([]string, error) {
+) (string, error) {
 	if content == "" || questionCount <= 0 {
-		return nil, nil
+		return "", nil
 	}
 
 	prompt := strings.TrimSpace(s.config.Conversation.GenerateQuestionsPrompt)
 	if prompt == "" {
-		return nil, fmt.Errorf("generate questions prompt not configured")
+		return "", fmt.Errorf("generate questions prompt not configured")
 	}
 
 	// Build context section
@@ -2339,7 +2841,44 @@ func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
 		"language":       langName,
 	})
 	prompt = types.AppendCustomPromptInstructions(prompt, customInstructions, "question_generation")
+	return prompt, nil
+}
 
+func questionGenerationCacheKey(chatModel chat.Chat, prompt string) string {
+	if chatModel == nil || prompt == "" {
+		return ""
+	}
+	return hashStringHex(strings.Join([]string{
+		questionGenerationCacheSchemaVersion,
+		chatModel.GetModelID(),
+		chatModel.GetModelName(),
+		"temperature=0.7;max_tokens=512;thinking=false",
+		prompt,
+	}, "\x00"))
+}
+
+func questionGenerationIndexKey(
+	embeddingModelID string,
+	knowledge *types.Knowledge,
+	generationKey string,
+	questions []types.GeneratedQuestion,
+) string {
+	parts := []string{"question_generation_index_v1", strings.TrimSpace(embeddingModelID), generationKey}
+	for _, question := range questions {
+		parts = append(parts, buildKnowledgeIndexContent(knowledge, question.Question))
+	}
+	return hashStringHex(strings.Join(parts, "\x00"))
+}
+
+func generateQuestionsFromPrompt(
+	ctx context.Context,
+	chatModel chat.Chat,
+	prompt string,
+	questionCount int,
+) ([]string, error) {
+	if prompt == "" || questionCount <= 0 {
+		return nil, nil
+	}
 	thinking := false
 	modelCtx := types.WithLLMCallMetadata(ctx, "question_generation", "")
 	response, err := chatModel.Chat(modelCtx, []chat.Message{
@@ -2375,6 +2914,20 @@ func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
 	}
 
 	return questions, nil
+}
+
+// generateQuestionsWithContext generates questions for a chunk with surrounding context.
+func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
+	chatModel chat.Chat, content, prevContent, nextContent, docName string, questionCount int,
+	customInstructions string,
+) ([]string, error) {
+	prompt, err := s.renderQuestionGenerationPrompt(
+		ctx, content, prevContent, nextContent, docName, questionCount, customInstructions,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return generateQuestionsFromPrompt(ctx, chatModel, prompt, questionCount)
 }
 
 // RegenerateChunkQuestions synchronously refreshes Doc2Query-style auxiliary
@@ -2426,13 +2979,18 @@ func (s *knowledgeService) RegenerateChunkQuestions(
 	if count > 10 {
 		count = 10
 	}
-	questions, err := s.generateQuestionsWithContext(
-		ctx, chatModel, chunk.Content, resolveNeighbor(chunk.PreChunkID),
+	prompt, err := s.renderQuestionGenerationPrompt(
+		ctx, chunk.Content, resolveNeighbor(chunk.PreChunkID),
 		resolveNeighbor(chunk.NextChunkID), knowledge.Title, count, config.CustomInstructions,
 	)
 	if err != nil {
 		return nil, err
 	}
+	questions, err := generateQuestionsFromPrompt(ctx, chatModel, prompt, count)
+	if err != nil {
+		return nil, err
+	}
+	cacheKey := questionGenerationCacheKey(chatModel, prompt)
 	latestChunk, err := s.chunkRepo.GetChunkByID(ctx, tenantID, chunkID)
 	if err != nil {
 		return nil, err
@@ -2449,7 +3007,12 @@ func (s *knowledgeService) RegenerateChunkQuestions(
 		})
 	}
 	meta := &types.DocumentChunkMetadata{
-		GeneratedQuestions: generated, GeneratedQuestionsRevision: chunk.ContentRevision,
+		GeneratedQuestions:         generated,
+		GeneratedQuestionsRevision: chunk.ContentRevision,
+		GeneratedQuestionsCacheKey: cacheKey,
+		GeneratedQuestionsIndexKey: questionGenerationIndexKey(
+			kb.EmbeddingModelID, knowledge, cacheKey, generated,
+		),
 	}
 	if err := chunk.SetDocumentMetadata(meta); err != nil {
 		return nil, err
@@ -2522,44 +3085,21 @@ func (s *knowledgeService) RegenerateKnowledgeSummary(
 	knowledge.Description = summary
 	knowledge.SummaryStatus = types.SummaryStatusCompleted
 	knowledge.UpdatedAt = time.Now()
+	cacheKey := summaryGenerationCacheKey(ctx, chatModel, knowledge, allChunks, s.config)
+	if cacheKey != "" {
+		if err := knowledge.SetSummaryCacheMetadata(&types.KnowledgeSummaryCacheMetadata{
+			Key:         cacheKey,
+			ContentHash: hashStringHex(summary),
+			Content:     summary,
+		}); err != nil {
+			return nil, err
+		}
+	}
 	if err := s.repo.UpdateKnowledge(ctx, knowledge); err != nil {
 		return nil, err
 	}
-	if kb.NeedsEmbeddingModel() {
-		found := false
-		maxIndex := 0
-		summaryChunks := make([]*types.Chunk, 0, 1)
-		for _, chunk := range allChunks {
-			if chunk.ChunkIndex > maxIndex {
-				maxIndex = chunk.ChunkIndex
-			}
-			if chunk.ChunkType == types.ChunkTypeSummary {
-				chunk.Content = "# Summary\n" + summary
-				chunk.SourceContent = chunk.Content
-				chunk.IsEnabled = true
-				chunk.UpdatedAt = time.Now()
-				if err := s.chunkRepo.UpdateChunk(ctx, chunk); err != nil {
-					return nil, err
-				}
-				summaryChunks = append(summaryChunks, chunk)
-				found = true
-			}
-		}
-		if !found {
-			summaryChunk := &types.Chunk{
-				ID: uuid.NewString(), TenantID: tenantID, KnowledgeID: knowledge.ID,
-				KnowledgeBaseID: knowledge.KnowledgeBaseID, Content: "# Summary\n" + summary,
-				ChunkIndex: maxIndex + 1, IsEnabled: true, ChunkType: types.ChunkTypeSummary,
-				ParentChunkID: textChunks[0].ID, CreatedAt: time.Now(), UpdatedAt: time.Now(),
-			}
-			if err := s.chunkRepo.CreateChunks(ctx, []*types.Chunk{summaryChunk}); err != nil {
-				return nil, err
-			}
-			summaryChunks = append(summaryChunks, summaryChunk)
-		}
-		if err := s.updateChunkVector(ctx, knowledge.KnowledgeBaseID, summaryChunks); err != nil {
-			return nil, err
-		}
+	if _, err := s.ensureSummaryChunkIndexed(ctx, knowledge, kb, allChunks, textChunks, summary); err != nil {
+		return nil, err
 	}
 	return knowledge, nil
 }
@@ -2620,7 +3160,8 @@ func (s *knowledgeService) ReparseKnowledge(
 
 	processOverrides, _ = existing.ProcessOverrides()
 	reparseEff := ResolveProcessConfig(kb, processOverrides)
-	allowLegacyChunkReuse := existing.EmbeddingModelID == "" || existing.EmbeddingModelID == kb.EmbeddingModelID
+	embeddingModelChanged := existing.EmbeddingModelID != "" && existing.EmbeddingModelID != kb.EmbeddingModelID
+	allowLegacyChunkReuse := !embeddingModelChanged
 
 	// Keep wiki's pending queue consistent across both manual and non-manual
 	// paths. The destructive work (swapping old wiki contributions for new)
@@ -2656,7 +3197,11 @@ func (s *knowledgeService) ReparseKnowledge(
 			return nil, err
 		}
 
-		if _, err := s.enqueueManualProcessing(ctx, existing, meta.Content, true); err != nil {
+		if _, err := s.enqueueManualProcessing(ctx, existing, meta.Content, true, ProcessChunksOptions{
+			ReuseUnchangedChunks:  true,
+			AllowLegacyChunkReuse: allowLegacyChunkReuse,
+			ReindexReusedChunks:   embeddingModelChanged,
+		}); err != nil {
 			logger.Errorf(ctx, "Failed to enqueue manual reparse task: %v", err)
 			existing.ParseStatus = "failed"
 			existing.ErrorMessage = "Failed to enqueue processing task"
@@ -2710,6 +3255,7 @@ func (s *knowledgeService) ReparseKnowledge(
 			Attempt:                  reparseAttempt,
 			ReuseUnchangedChunks:     true,
 			AllowLegacyChunkReuse:    allowLegacyChunkReuse,
+			ReindexReusedChunks:      embeddingModelChanged,
 		}
 
 		langfuse.InjectTracing(ctx, &taskPayload)
@@ -2764,6 +3310,7 @@ func (s *knowledgeService) ReparseKnowledge(
 			Attempt:                  reparseAttempt,
 			ReuseUnchangedChunks:     true,
 			AllowLegacyChunkReuse:    allowLegacyChunkReuse,
+			ReindexReusedChunks:      embeddingModelChanged,
 		}
 
 		langfuse.InjectTracing(ctx, &taskPayload)
@@ -2815,6 +3362,7 @@ func (s *knowledgeService) ReparseKnowledge(
 			Attempt:                  reparseAttempt,
 			ReuseUnchangedChunks:     true,
 			AllowLegacyChunkReuse:    allowLegacyChunkReuse,
+			ReindexReusedChunks:      embeddingModelChanged,
 		}
 
 		langfuse.InjectTracing(ctx, &taskPayload)
@@ -2848,6 +3396,10 @@ func (s *knowledgeService) ReparseKnowledge(
 // new processing attempt rather than retaining terminal state from the
 // previous one.
 func resetKnowledgeForReparse(knowledge *types.Knowledge, kb *types.KnowledgeBase) {
+	if cache, err := knowledge.SummaryCacheMetadata(); err != nil ||
+		(cache != nil && cache.Content != knowledge.Description) {
+		_ = knowledge.SetSummaryCacheMetadata(nil)
+	}
 	knowledge.ParseStatus = types.ParseStatusPending
 	knowledge.EnableStatus = "disabled"
 	knowledge.Description = ""
@@ -3300,7 +3852,7 @@ func (s *knowledgeService) ProcessManualUpdate(ctx context.Context, t *asynq.Tas
 	ctx = withAttempt(ctx, attempt)
 
 	// Cleanup old resources (indexes, chunks, graph) for update operations
-	if payload.NeedCleanup {
+	if payload.NeedCleanup && !payload.ReuseUnchangedChunks {
 		if err := s.cleanupKnowledgeResources(ctx, knowledge); err != nil {
 			logger.ErrorWithFields(ctx, err, map[string]interface{}{
 				"knowledge_id": payload.KnowledgeID,
@@ -3314,7 +3866,11 @@ func (s *knowledgeService) ProcessManualUpdate(ctx context.Context, t *asynq.Tas
 	}
 
 	// Run manual processing (image resolution + chunking + embedding) synchronously within the worker
-	s.triggerManualProcessing(ctx, kb, knowledge, payload.Content, true)
+	s.triggerManualProcessing(ctx, kb, knowledge, payload.Content, true, ProcessChunksOptions{
+		ReuseUnchangedChunks:  payload.ReuseUnchangedChunks,
+		AllowLegacyChunkReuse: payload.AllowLegacyChunkReuse,
+		ReindexReusedChunks:   payload.ReindexReusedChunks,
+	})
 	return nil
 }
 
@@ -3472,7 +4028,10 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 
 	// New pipeline: convert -> store images -> chunk -> vectorize -> multimodal tasks
 	var convertResult *types.ReadResult
+	var storedImages []docparser.StoredImage
 	var chunks []types.ParsedChunk
+	parseContentKey, parseConfigHash, parseCacheKey := s.documentParseCacheKeys(ctx, payload, knowledge, kb, eff)
+	parseCacheHit := false
 
 	if payload.FileURL != "" {
 		// file_url import: SSRF re-check (防 DNS 重绑定), download, persist, then delegate to convert()
@@ -3581,14 +4140,32 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 			QuestionCount:            payload.QuestionCount,
 			ReuseUnchangedChunks:     payload.ReuseUnchangedChunks,
 			AllowLegacyChunkReuse:    payload.AllowLegacyChunkReuse,
+			ReindexReusedChunks:      payload.ReindexReusedChunks,
 		}
 		s.processChunks(ctx, kb, knowledge, passageChunks, passageOpts)
 		return nil
 	} else {
 		// File import
-		convertResult, err = s.convert(ctx, payload, kb, knowledge, eff, isLastRetry)
-		if err != nil {
-			return err
+		if payload.ReuseUnchangedChunks {
+			convertResult, storedImages, parseCacheHit = s.loadDocumentParseCache(ctx, knowledge, parseCacheKey)
+		}
+		if parseCacheHit {
+			s.beginStage(ctx, knowledge.ID, types.StageDocReader, types.JSONMap{
+				"file_name":    payload.FileName,
+				"file_type":    payload.FileType,
+				"cache_lookup": true,
+			})
+			s.endStage(ctx, knowledge.ID, types.StageDocReader, types.JSONMap{
+				"cache_hit":    true,
+				"text_length":  len(convertResult.MarkdownContent),
+				"images_found": len(storedImages),
+			})
+			logger.Infof(ctx, "Reused resolved document parse artifact for knowledge %s", knowledge.ID)
+		} else {
+			convertResult, err = s.convert(ctx, payload, kb, knowledge, eff, isLastRetry)
+			if err != nil {
+				return err
+			}
 		}
 		if convertResult == nil {
 			return nil
@@ -3596,7 +4173,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 	}
 
 	// Step 1.5: ASR transcription for audio files
-	if convertResult != nil && convertResult.IsAudio && len(convertResult.AudioData) > 0 {
+	if !parseCacheHit && convertResult != nil && convertResult.IsAudio && len(convertResult.AudioData) > 0 {
 		if !eff.ASRConfig.IsASREnabled() {
 			logger.Error(ctx, "Audio file detected but ASR is not configured")
 			knowledge.ParseStatus = "failed"
@@ -3649,9 +4226,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 	}
 
 	// Step 2: Store images and update markdown references
-	var storedImages []docparser.StoredImage
-
-	if s.imageResolver != nil && convertResult != nil {
+	if !parseCacheHit && s.imageResolver != nil && convertResult != nil {
 		fileSvc := s.resolveFileService(ctx, kb)
 		tenantID, _ := ctx.Value(types.TenantIDContextKey).(uint64)
 		updatedMarkdown, images, resolveErr := s.imageResolver.ResolveAndStore(ctx, convertResult, fileSvc, tenantID)
@@ -3677,6 +4252,11 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 
 		logger.Infof(ctx, "Resolved %d total images for knowledge %s", len(storedImages), knowledge.ID)
 	}
+	if !parseCacheHit {
+		s.storeDocumentParseCache(
+			ctx, knowledge, parseContentKey, parseConfigHash, parseCacheKey, convertResult, storedImages,
+		)
+	}
 
 	// Step 3: Split into chunks using Go chunker
 	chunkCfg := buildSplitterConfigFromChunking(eff.ChunkingConfig)
@@ -3688,6 +4268,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 		StoredImages:             storedImages,
 		ReuseUnchangedChunks:     payload.ReuseUnchangedChunks,
 		AllowLegacyChunkReuse:    payload.AllowLegacyChunkReuse,
+		ReindexReusedChunks:      payload.ReindexReusedChunks,
 	}
 
 	if convertResult != nil {

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -156,6 +156,8 @@ type ProcessChunksOptions struct {
 	QuestionCount            int
 	EnableMultimodel         bool
 	StoredImages             []docparser.StoredImage
+	ReuseUnchangedChunks     bool
+	AllowLegacyChunkReuse    bool
 	// ParentChunks holds parent chunk data when parent-child chunking is enabled.
 	// When set, the chunks passed to processChunks are child chunks, and each
 	// child's ParentIndex references an entry in this slice.
@@ -254,6 +256,165 @@ func buildParentChildConfigs(cc types.ChunkingConfig, base chunker.SplitterConfi
 	return
 }
 
+type chunkReuseState struct {
+	oldByFingerprint map[string][]*types.Chunk
+	oldByID          map[string]*types.Chunk
+	reusedIDs        map[string]struct{}
+	oldChunkIDs      map[string]struct{}
+	enabled          bool
+}
+
+func newChunkReuseState(
+	ctx context.Context,
+	knowledge *types.Knowledge,
+	oldChunks []*types.Chunk,
+	allowLegacyChunkReuse bool,
+) *chunkReuseState {
+	state := &chunkReuseState{
+		oldByFingerprint: make(map[string][]*types.Chunk),
+		oldByID:          make(map[string]*types.Chunk),
+		reusedIDs:        make(map[string]struct{}),
+		oldChunkIDs:      make(map[string]struct{}),
+		enabled:          true,
+	}
+	for _, c := range oldChunks {
+		if c == nil {
+			continue
+		}
+		state.oldChunkIDs[c.ID] = struct{}{}
+		state.oldByID[c.ID] = c
+		if c.ChunkType != types.ChunkTypeText {
+			continue
+		}
+		fingerprint := strings.TrimSpace(c.ContentHash)
+		if fingerprint == "" {
+			fingerprint = documentChunkFingerprintForKnowledge(knowledge, c.Content, c.ContextHeader)
+		}
+		if fingerprint == "" {
+			continue
+		}
+		state.oldByFingerprint[fingerprint] = append(state.oldByFingerprint[fingerprint], c)
+		if allowLegacyChunkReuse && c.ContentHash == "" {
+			legacyFingerprint := c.DocumentFingerprint()
+			if legacyFingerprint != "" && legacyFingerprint != fingerprint {
+				state.oldByFingerprint[legacyFingerprint] = append(state.oldByFingerprint[legacyFingerprint], c)
+			}
+		}
+	}
+	logger.Infof(ctx, "Prepared chunk reuse state: old_chunks=%d reusable_text_fingerprints=%d",
+		len(oldChunks), len(state.oldByFingerprint))
+	return state
+}
+
+func (s *chunkReuseState) takeTextChunk(fingerprint string) (*types.Chunk, bool) {
+	if s == nil || !s.enabled || fingerprint == "" {
+		return nil, false
+	}
+	candidates := s.oldByFingerprint[fingerprint]
+	for len(candidates) > 0 {
+		chunk := candidates[0]
+		candidates = candidates[1:]
+		s.oldByFingerprint[fingerprint] = candidates
+		if chunk == nil {
+			continue
+		}
+		if _, used := s.reusedIDs[chunk.ID]; used {
+			continue
+		}
+		s.reusedIDs[chunk.ID] = struct{}{}
+		return chunk, true
+	}
+	return nil, false
+}
+
+func (s *chunkReuseState) staleChunkIDs() []string {
+	if s == nil || !s.enabled {
+		return nil
+	}
+	ids := make([]string, 0, len(s.oldChunkIDs)-len(s.reusedIDs))
+	for id := range s.oldChunkIDs {
+		if _, reused := s.reusedIDs[id]; !reused {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func (s *chunkReuseState) staleImageInfos() []string {
+	if s == nil || !s.enabled {
+		return nil
+	}
+	imageInfos := make([]string, 0)
+	for id, chunk := range s.oldByID {
+		if chunk == nil || chunk.ImageInfo == "" {
+			continue
+		}
+		if _, reused := s.reusedIDs[id]; reused {
+			continue
+		}
+		imageInfos = append(imageInfos, chunk.ImageInfo)
+	}
+	return imageInfos
+}
+
+func documentChunkFingerprintForKnowledge(knowledge *types.Knowledge, content, contextHeader string) string {
+	title := ""
+	modelID := ""
+	if knowledge != nil {
+		title = strings.TrimSpace(knowledge.Title)
+		modelID = strings.TrimSpace(knowledge.EmbeddingModelID)
+	}
+	return types.DocumentChunkScopedFingerprint(content, contextHeader, "document_chunk_v2", title, modelID)
+}
+
+func textChunkIndexInfo(knowledge *types.Knowledge, chunk *types.Chunk) *types.IndexInfo {
+	titlePrefix := ""
+	if t := strings.TrimSpace(knowledge.Title); t != "" {
+		titlePrefix = t + "\n"
+	}
+	return &types.IndexInfo{
+		Content:         titlePrefix + chunk.EmbeddingContent(),
+		SourceID:        chunk.ID,
+		SourceType:      types.ChunkSourceType,
+		ChunkID:         chunk.ID,
+		KnowledgeID:     knowledge.ID,
+		KnowledgeBaseID: knowledge.KnowledgeBaseID,
+		IsEnabled:       true,
+	}
+}
+
+func (s *knowledgeService) deleteExtractedImagesFromInfo(
+	ctx context.Context,
+	kb *types.KnowledgeBase,
+	imageInfos []string,
+) {
+	imageURLs := collectImageURLs(ctx, imageInfos)
+	if len(imageURLs) == 0 {
+		return
+	}
+	fileSvc := s.resolveFileService(ctx, kb)
+	deleteExtractedImages(ctx, fileSvc, imageURLs)
+}
+
+func (s *knowledgeService) deleteExtractedImagesForKnowledge(
+	ctx context.Context,
+	kb *types.KnowledgeBase,
+	tenantID uint64,
+	knowledgeID string,
+) {
+	chunkImageInfos, imgErr := s.chunkService.GetRepository().ListImageInfoByKnowledgeIDs(ctx, tenantID, []string{knowledgeID})
+	if imgErr != nil {
+		logger.GetLogger(ctx).WithField("error", imgErr).Warnf("Failed to collect image URLs for cleanup")
+		return
+	}
+	imageInfos := make([]string, 0, len(chunkImageInfos))
+	for _, ci := range chunkImageInfos {
+		imageInfos = append(imageInfos, ci.ImageInfo)
+	}
+	s.deleteExtractedImagesFromInfo(ctx, kb, imageInfos)
+}
+
 // processChunks processes chunks and creates embeddings for knowledge content
 func (s *knowledgeService) processChunks(ctx context.Context,
 	kb *types.KnowledgeBase, knowledge *types.Knowledge, chunks []types.ParsedChunk,
@@ -286,29 +447,63 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping embedding model", kb.ID)
 	}
 
-	// 幂等性处理：清理旧的chunks和索引数据，避免重复数据
-	logger.Infof(ctx, "Cleaning up existing chunks and index data for knowledge: %s", knowledge.ID)
-
-	// 删除旧的chunks
-	if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
-		logger.Warnf(ctx, "Failed to delete existing chunks (may not exist): %v", err)
-		// 不返回错误，继续处理（可能没有旧数据）
-	}
-
-	// 删除旧的索引数据 — only when vector/keyword indexing is enabled
 	tenantInfo := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
 	retrieveEngine, err := retriever.CreateRetrieveEngineForKB(
 		ctx, s.retrieveEngine, s.ownership, tenantInfo.ID, kb.VectorStoreID)
-	if err == nil && embeddingModel != nil {
-		if err := retrieveEngine.DeleteByKnowledgeIDList(ctx, []string{knowledge.ID}, embeddingModel.GetDimensions(), knowledge.Type); err != nil {
-			logger.Warnf(ctx, "Failed to delete existing index data (may not exist): %v", err)
-			// 不返回错误，继续处理（可能没有旧数据）
+	if err != nil && kb.NeedsEmbeddingModel() {
+		logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks init retrieve engine failed")
+		knowledge.ParseStatus = types.ParseStatusFailed
+		knowledge.ErrorMessage = err.Error()
+		knowledge.UpdatedAt = time.Now()
+		s.repo.UpdateKnowledge(ctx, knowledge)
+		return
+	}
+
+	hasPendingMultimodalInput := options.EnableMultimodel && len(options.StoredImages) > 0
+	reuseEnabled := options.ReuseUnchangedChunks && !hasPendingMultimodalInput && len(options.ParentChunks) == 0
+	if options.ReuseUnchangedChunks && !reuseEnabled {
+		logger.Infof(ctx, "Chunk reuse disabled for knowledge %s: multimodal_inputs=%v parent_child=%v",
+			knowledge.ID, hasPendingMultimodalInput, len(options.ParentChunks) > 0)
+	}
+	var reuseState *chunkReuseState
+	var oldChunks []*types.Chunk
+	if reuseEnabled {
+		var listErr error
+		oldChunks, listErr = s.chunkService.ListAllChunksByKnowledgeID(ctx, knowledge.ID)
+		if listErr != nil {
+			logger.Warnf(ctx, "Failed to list existing chunks for reuse, falling back to full cleanup: %v", listErr)
+			reuseEnabled = false
 		} else {
-			logger.Infof(ctx, "Successfully deleted existing index data for knowledge: %s", knowledge.ID)
+			reuseState = newChunkReuseState(ctx, knowledge, oldChunks, options.AllowLegacyChunkReuse)
 		}
 	}
 
-	// 删除知识图谱数据（如果存在）
+	if !reuseEnabled {
+		// 幂等性处理：清理旧的chunks和索引数据，避免重复数据
+		logger.Infof(ctx, "Cleaning up existing chunks and index data for knowledge: %s", knowledge.ID)
+		s.deleteExtractedImagesForKnowledge(ctx, kb, tenantInfo.ID, knowledge.ID)
+
+		// 删除旧的chunks
+		if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
+			logger.Warnf(ctx, "Failed to delete existing chunks (may not exist): %v", err)
+			// 不返回错误，继续处理（可能没有旧数据）
+		}
+
+		// 删除旧的索引数据 — only when vector/keyword indexing is enabled
+		if err == nil && embeddingModel != nil {
+			if err := retrieveEngine.DeleteByKnowledgeIDList(ctx, []string{knowledge.ID}, embeddingModel.GetDimensions(), knowledge.Type); err != nil {
+				logger.Warnf(ctx, "Failed to delete existing index data (may not exist): %v", err)
+				// 不返回错误，继续处理（可能没有旧数据）
+			} else {
+				logger.Infof(ctx, "Successfully deleted existing index data for knowledge: %s", knowledge.ID)
+			}
+		}
+	} else {
+		logger.Infof(ctx, "Chunk reuse enabled for knowledge %s: old_chunks=%d", knowledge.ID, len(oldChunks))
+	}
+
+	// 删除知识图谱数据（如果存在）。GraphRAG 目前没有 chunk 级删除/复用语义，
+	// 因此这里仍按知识粒度重建，避免旧图谱和新图谱混在一起。
 	namespace := types.NameSpace{KnowledgeBase: knowledge.KnowledgeBaseID, Knowledge: knowledge.ID}
 	if err := s.graphEngine.DelGraph(ctx, []types.NameSpace{namespace}); err != nil {
 		logger.Warnf(ctx, "Failed to delete existing graph data (may not exist): %v", err)
@@ -415,6 +610,8 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	// 重新分配容量，考虑图片相关的Chunk + parent chunks
 	parentCount := len(options.ParentChunks)
 	insertChunks := make([]*types.Chunk, 0, len(chunks)+imageChunkCount+parentCount)
+	reusedTextChunkCount := 0
+	newTextChunkCount := 0
 	// Add parent chunks first (they go into DB but NOT into the vector index)
 	if hasParentChild {
 		insertChunks = append(insertChunks, parentDBChunks...)
@@ -425,6 +622,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			continue
 		}
 
+		fingerprint := documentChunkFingerprintForKnowledge(knowledge, chunkData.Content, chunkData.ContextHeader)
 		// 创建主文本Chunk
 		textChunk := &types.Chunk{
 			ID:              uuid.New().String(),
@@ -440,6 +638,27 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			StartAt:         int(chunkData.Start),
 			EndAt:           int(chunkData.End),
 			ChunkType:       types.ChunkTypeText,
+			ContentHash:     fingerprint,
+		}
+
+		if oldChunk, ok := reuseState.takeTextChunk(fingerprint); ok {
+			textChunk.ID = oldChunk.ID
+			textChunk.SeqID = oldChunk.SeqID
+			if meta, metaErr := oldChunk.DocumentMetadata(); metaErr == nil && meta != nil && len(meta.GeneratedQuestions) > 0 {
+				textChunk.Metadata = oldChunk.Metadata
+			}
+			textChunk.CreatedAt = oldChunk.CreatedAt
+			textChunk.ImageInfo = oldChunk.ImageInfo
+			textChunk.TagID = oldChunk.TagID
+			textChunk.Flags = oldChunk.Flags
+			textChunk.Status = oldChunk.Status
+			textChunk.IsEnabled = oldChunk.IsEnabled
+			if textChunk.CreatedAt.IsZero() {
+				textChunk.CreatedAt = time.Now()
+			}
+			reusedTextChunkCount++
+		} else {
+			newTextChunkCount++
 		}
 
 		// Wire up ParentChunkID for child chunks
@@ -490,16 +709,56 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	// Save chunks to database — ALWAYS, regardless of indexing strategy.
 	// Chunks are needed for wiki generation, graph extraction, and summary generation
 	// even when vector/keyword indexing is disabled.
+	reusedChunkIDs := map[string]struct{}{}
+	if reuseState != nil {
+		reusedChunkIDs = reuseState.reusedIDs
+	}
+	createChunks := make([]*types.Chunk, 0, len(insertChunks))
+	updateChunks := make([]*types.Chunk, 0, len(reusedChunkIDs))
+	for _, c := range insertChunks {
+		if _, reused := reusedChunkIDs[c.ID]; reused {
+			updateChunks = append(updateChunks, c)
+			continue
+		}
+		createChunks = append(createChunks, c)
+	}
 	s.beginStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
 		"chunks_planned": len(insertChunks),
 	})
-	if err := s.chunkService.CreateChunks(ctx, insertChunks); err != nil {
+	if len(createChunks) > 0 {
+		if err := s.chunkService.CreateChunks(ctx, createChunks); err != nil {
+			knowledge.ParseStatus = types.ParseStatusFailed
+			knowledge.ErrorMessage = err.Error()
+			knowledge.UpdatedAt = time.Now()
+			s.repo.UpdateKnowledge(ctx, knowledge)
+			s.failStage(ctx, knowledge.ID, types.StageChunking,
+				werrors.ErrCodeChunkingFailed, "create chunks failed", err)
+			return
+		}
+	}
+	for _, chunk := range updateChunks {
+		if err := s.chunkService.UpdateChunk(ctx, chunk); err != nil {
+			knowledge.ParseStatus = types.ParseStatusFailed
+			knowledge.ErrorMessage = err.Error()
+			knowledge.UpdatedAt = time.Now()
+			s.repo.UpdateKnowledge(ctx, knowledge)
+			s.failStage(ctx, knowledge.ID, types.StageChunking,
+				werrors.ErrCodeChunkingFailed, "update reused chunk failed", err)
+			return
+		}
+	}
+
+	staleChunkIDs := []string(nil)
+	if reuseEnabled && reuseState != nil {
+		staleChunkIDs = reuseState.staleChunkIDs()
+	}
+	if len(insertChunks) == 0 && len(staleChunkIDs) == 0 {
 		knowledge.ParseStatus = types.ParseStatusFailed
-		knowledge.ErrorMessage = err.Error()
+		knowledge.ErrorMessage = "no chunks generated"
 		knowledge.UpdatedAt = time.Now()
 		s.repo.UpdateKnowledge(ctx, knowledge)
 		s.failStage(ctx, knowledge.ID, types.StageChunking,
-			werrors.ErrCodeChunkingFailed, "create chunks failed", err)
+			werrors.ErrCodeChunkingFailed, "no chunks generated", nil)
 		return
 	}
 	totalChunkChars := 0
@@ -508,45 +767,50 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	}
 	s.endStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
 		"chunks_written":   len(insertChunks),
+		"chunks_created":   len(createChunks),
+		"chunks_reused":    len(updateChunks),
+		"chunks_to_delete": len(staleChunkIDs),
 		"total_text_chars": totalChunkChars,
 	})
+	logger.Infof(ctx, "Chunk reuse result for knowledge %s: text_reused=%d text_new=%d stale_deleted=%d",
+		knowledge.ID, reusedTextChunkCount, newTextChunkCount, len(staleChunkIDs))
 
 	// Create index information and perform vector indexing — only when vector/keyword is enabled.
 	// Chunks are ALWAYS saved to DB (above) because wiki and graph need them even without vector indexing.
 	var totalStorageSize int64
+	var storageDelta int64
 	if kb.NeedsEmbeddingModel() && embeddingModel != nil {
 		embedInput := types.JSONMap{
-			"chunks_to_embed": len(textChunks),
-			"model_id":        kb.EmbeddingModelID,
+			"model_id": kb.EmbeddingModelID,
 		}
 		if dim := embeddingModel.GetDimensions(); dim > 0 {
 			embedInput["dim"] = dim
 		}
-		s.beginStage(ctx, knowledge.ID, types.StageEmbedding, embedInput)
 		// Create index information — only for child/flat chunks, NOT parent chunks.
 		// Parent chunks are stored for context retrieval but do not need vector embeddings.
 		// Prepend the document title to improve semantic alignment between
 		// question-style queries and statement-style chunk content.
+		allIndexInfoList := make([]*types.IndexInfo, 0, len(textChunks))
 		indexInfoList := make([]*types.IndexInfo, 0, len(textChunks))
 		for _, chunk := range textChunks {
 			// chunk.EmbeddingContent prepends ContextHeader (heading breadcrumb)
 			// when the chunker populated it during Tier-1 splitting; falls back
 			// to plain Content otherwise. The document title sits outermost;
 			// custom metadata remains document-scoped model context.
-			indexContent := buildKnowledgeIndexContent(knowledge, chunk.EmbeddingContent())
-			indexInfoList = append(indexInfoList, &types.IndexInfo{
-				Content:         indexContent,
-				SourceID:        chunk.ID,
-				SourceType:      types.ChunkSourceType,
-				ChunkID:         chunk.ID,
-				KnowledgeID:     knowledge.ID,
-				KnowledgeBaseID: knowledge.KnowledgeBaseID,
-				IsEnabled:       true,
-			})
+			info := textChunkIndexInfo(knowledge, chunk)
+			allIndexInfoList = append(allIndexInfoList, info)
+			if _, reused := reusedChunkIDs[chunk.ID]; reused {
+				continue
+			}
+			indexInfoList = append(indexInfoList, info)
 		}
+		embedInput["chunks_to_embed"] = len(indexInfoList)
+		embedInput["chunks_reused"] = len(updateChunks)
+		s.beginStage(ctx, knowledge.ID, types.StageEmbedding, embedInput)
 
 		// Calculate storage size required for embeddings
-		totalStorageSize = retrieveEngine.EstimateStorageSize(ctx, embeddingModel, indexInfoList)
+		totalStorageSize = retrieveEngine.EstimateStorageSize(ctx, embeddingModel, allIndexInfoList)
+		storageDelta = totalStorageSize - knowledge.StorageSize
 		if tenantInfo.StorageQuota > 0 {
 			// Re-fetch tenant storage information
 			tenantInfo, err = s.tenantRepo.GetTenantByID(ctx, tenantInfo.ID)
@@ -558,7 +822,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 				return
 			}
 			// Check if there's enough storage quota available
-			if tenantInfo.StorageUsed+totalStorageSize > tenantInfo.StorageQuota {
+			if storageDelta > 0 && tenantInfo.StorageUsed+storageDelta > tenantInfo.StorageQuota {
 				knowledge.ParseStatus = types.ParseStatusFailed
 				knowledge.ErrorMessage = "存储空间不足"
 				knowledge.UpdatedAt = time.Now()
@@ -580,37 +844,55 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			return
 		}
 
-		err = retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfoList)
-		if err != nil {
-			knowledge.ParseStatus = types.ParseStatusFailed
-			knowledge.ErrorMessage = err.Error()
-			knowledge.UpdatedAt = time.Now()
-			s.repo.UpdateKnowledge(ctx, knowledge)
+		if len(indexInfoList) > 0 {
+			err = retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfoList)
+			if err != nil {
+				knowledge.ParseStatus = types.ParseStatusFailed
+				knowledge.ErrorMessage = err.Error()
+				knowledge.UpdatedAt = time.Now()
+				s.repo.UpdateKnowledge(ctx, knowledge)
 
-			// delete failed chunks
-			if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
-				logger.Errorf(ctx, "Delete chunks failed: %v", err)
-			}
+				if reuseEnabled {
+					newChunkIDs := make([]string, 0, len(createChunks))
+					for _, chunk := range createChunks {
+						newChunkIDs = append(newChunkIDs, chunk.ID)
+					}
+					if len(newChunkIDs) > 0 {
+						if err := s.chunkService.DeleteChunks(ctx, newChunkIDs); err != nil {
+							logger.Errorf(ctx, "Delete newly created chunks failed: %v", err)
+						}
+						if err := retrieveEngine.DeleteByChunkIDList(ctx, newChunkIDs, embeddingModel.GetDimensions(), kb.Type); err != nil {
+							logger.Errorf(ctx, "Delete newly created indexes failed: %v", err)
+						}
+					}
+				} else {
+					// delete failed chunks
+					if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
+						logger.Errorf(ctx, "Delete chunks failed: %v", err)
+					}
 
-			// delete index
-			if err := retrieveEngine.DeleteByKnowledgeIDList(
-				ctx, []string{knowledge.ID}, embeddingModel.GetDimensions(), kb.Type,
-			); err != nil {
-				logger.Errorf(ctx, "Delete index failed: %v", err)
+					// delete index
+					if err := retrieveEngine.DeleteByKnowledgeIDList(
+						ctx, []string{knowledge.ID}, embeddingModel.GetDimensions(), kb.Type,
+					); err != nil {
+						logger.Errorf(ctx, "Delete index failed: %v", err)
+					}
+				}
+				// Map vector store / embedding rate-limit errors to a
+				// stable code so the UI can offer "retry later" hints.
+				code := werrors.ErrCodeVectorStoreWriteFailed
+				if isLikelyRateLimitError(err) {
+					code = werrors.ErrCodeEmbeddingRateLimit
+				}
+				s.failStage(ctx, knowledge.ID, types.StageEmbedding,
+					code, "batch index failed", err)
+				return
 			}
-			// Map vector store / embedding rate-limit errors to a
-			// stable code so the UI can offer "retry later" hints.
-			code := werrors.ErrCodeVectorStoreWriteFailed
-			if isLikelyRateLimitError(err) {
-				code = werrors.ErrCodeEmbeddingRateLimit
-			}
-			s.failStage(ctx, knowledge.ID, types.StageEmbedding,
-				code, "batch index failed", err)
-			return
 		}
 		logger.GetLogger(ctx).Infof("processChunks batch index successfully, with %d index", len(indexInfoList))
 		s.endStage(ctx, knowledge.ID, types.StageEmbedding, types.JSONMap{
 			"vectors_written": len(indexInfoList),
+			"vectors_reused":  len(updateChunks),
 			"storage_bytes":   totalStorageSize,
 		})
 
@@ -633,6 +915,32 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	} else {
 		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping BatchIndex", kb.ID)
 		s.skipStage(ctx, knowledge.ID, types.StageEmbedding, "skipped")
+	}
+
+	if reuseEnabled && len(staleChunkIDs) > 0 {
+		if embeddingModel != nil && retrieveEngine != nil {
+			if err := retrieveEngine.DeleteByChunkIDList(ctx, staleChunkIDs, embeddingModel.GetDimensions(), knowledge.Type); err != nil {
+				knowledge.ParseStatus = types.ParseStatusFailed
+				knowledge.ErrorMessage = err.Error()
+				knowledge.UpdatedAt = time.Now()
+				s.repo.UpdateKnowledge(ctx, knowledge)
+				s.failStage(ctx, knowledge.ID, types.StageEmbedding,
+					werrors.ErrCodeVectorStoreWriteFailed, "delete stale chunk indexes failed", err)
+				return
+			}
+		}
+		if reuseState != nil {
+			s.deleteExtractedImagesFromInfo(ctx, kb, reuseState.staleImageInfos())
+		}
+		if err := s.chunkService.DeleteChunks(ctx, staleChunkIDs); err != nil {
+			knowledge.ParseStatus = types.ParseStatusFailed
+			knowledge.ErrorMessage = err.Error()
+			knowledge.UpdatedAt = time.Now()
+			s.repo.UpdateKnowledge(ctx, knowledge)
+			s.failStage(ctx, knowledge.ID, types.StageChunking,
+				werrors.ErrCodeChunkingFailed, "delete stale chunks failed", err)
+			return
+		}
 	}
 
 	// Check if this document has extracted images that will be processed asynchronously
@@ -689,9 +997,11 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	}
 
 	// Update tenant's storage usage
-	tenantInfo.StorageUsed += totalStorageSize
-	if err := s.tenantRepo.AdjustStorageUsed(ctx, tenantInfo.ID, totalStorageSize); err != nil {
-		logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks update tenant storage used failed")
+	if storageDelta != 0 {
+		tenantInfo.StorageUsed += storageDelta
+		if err := s.tenantRepo.AdjustStorageUsed(ctx, tenantInfo.ID, storageDelta); err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks update tenant storage used failed")
+		}
 	}
 	logger.GetLogger(ctx).Infof("processChunks successfully")
 }
@@ -1566,6 +1876,9 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 			emptyContentChunks++
 			continue
 		}
+		if meta, metaErr := chunk.DocumentMetadata(); metaErr == nil && meta != nil && len(meta.GeneratedQuestions) > 0 {
+			continue
+		}
 
 		// Build context from adjacent chunks
 		var prevContent, nextContent string
@@ -1606,9 +1919,8 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 		generatedQuestions := make([]types.GeneratedQuestion, len(questions))
 		questionRevision := chunk.ContentRevision
 		for j, question := range questions {
-			questionID := fmt.Sprintf("q%d", time.Now().UnixNano()+int64(j))
 			generatedQuestions[j] = types.GeneratedQuestion{
-				ID:              questionID,
+				ID:              types.StableGeneratedQuestionID(question, j),
 				Question:        question,
 				ContentRevision: &questionRevision,
 			}
@@ -1915,6 +2227,9 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 			emptyChunks++
 			continue
 		}
+		if meta, metaErr := chunk.DocumentMetadata(); metaErr == nil && meta != nil && len(meta.GeneratedQuestions) > 0 {
+			continue
+		}
 
 		generationRevision := chunk.ContentRevision
 		questions, gerr := s.generateQuestionsWithContext(
@@ -1944,7 +2259,7 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 		questionRevision := chunk.ContentRevision
 		for j, question := range questions {
 			generatedQuestions[j] = types.GeneratedQuestion{
-				ID:              fmt.Sprintf("q%d", time.Now().UnixNano()+int64(j)),
+				ID:              types.StableGeneratedQuestionID(question, j),
 				Question:        question,
 				ContentRevision: &questionRevision,
 			}
@@ -2305,6 +2620,7 @@ func (s *knowledgeService) ReparseKnowledge(
 
 	processOverrides, _ = existing.ProcessOverrides()
 	reparseEff := ResolveProcessConfig(kb, processOverrides)
+	allowLegacyChunkReuse := existing.EmbeddingModelID == "" || existing.EmbeddingModelID == kb.EmbeddingModelID
 
 	// Keep wiki's pending queue consistent across both manual and non-manual
 	// paths. The destructive work (swapping old wiki contributions for new)
@@ -2351,16 +2667,9 @@ func (s *knowledgeService) ReparseKnowledge(
 		return existing, nil
 	}
 
-	// For non-manual knowledge, cleanup synchronously then enqueue document processing
-	logger.Infof(ctx, "Cleaning up existing resources for knowledge: %s", knowledgeID)
-	if err := s.cleanupKnowledgeResources(ctx, existing); err != nil {
-		logger.ErrorWithFields(ctx, err, map[string]interface{}{
-			"knowledge_id": knowledgeID,
-		})
-		return nil, err
-	}
-
-	// Step 2: Update knowledge status and metadata
+	// For non-manual knowledge, keep existing chunks until the worker can
+	// compare them with the newly parsed chunks and delete only misses.
+	// processChunks remains responsible for full cleanup when reuse is disabled.
 	resetKnowledgeForReparse(existing, kb)
 
 	if err := s.repo.UpdateKnowledge(ctx, existing); err != nil {
@@ -2399,6 +2708,8 @@ func (s *knowledgeService) ReparseKnowledge(
 			QuestionCount:            questionCount,
 			Language:                 lang,
 			Attempt:                  reparseAttempt,
+			ReuseUnchangedChunks:     true,
+			AllowLegacyChunkReuse:    allowLegacyChunkReuse,
 		}
 
 		langfuse.InjectTracing(ctx, &taskPayload)
@@ -2451,6 +2762,8 @@ func (s *knowledgeService) ReparseKnowledge(
 			QuestionCount:            questionCount,
 			Language:                 lang,
 			Attempt:                  reparseAttempt,
+			ReuseUnchangedChunks:     true,
+			AllowLegacyChunkReuse:    allowLegacyChunkReuse,
 		}
 
 		langfuse.InjectTracing(ctx, &taskPayload)
@@ -2500,6 +2813,8 @@ func (s *knowledgeService) ReparseKnowledge(
 			QuestionCount:            questionCount,
 			Language:                 lang,
 			Attempt:                  reparseAttempt,
+			ReuseUnchangedChunks:     true,
+			AllowLegacyChunkReuse:    allowLegacyChunkReuse,
 		}
 
 		langfuse.InjectTracing(ctx, &taskPayload)
@@ -3264,6 +3579,8 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 		passageOpts := ProcessChunksOptions{
 			EnableQuestionGeneration: payload.EnableQuestionGeneration,
 			QuestionCount:            payload.QuestionCount,
+			ReuseUnchangedChunks:     payload.ReuseUnchangedChunks,
+			AllowLegacyChunkReuse:    payload.AllowLegacyChunkReuse,
 		}
 		s.processChunks(ctx, kb, knowledge, passageChunks, passageOpts)
 		return nil
@@ -3369,6 +3686,8 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 		QuestionCount:            payload.QuestionCount,
 		EnableMultimodel:         payload.EnableMultimodel,
 		StoredImages:             storedImages,
+		ReuseUnchangedChunks:     payload.ReuseUnchangedChunks,
+		AllowLegacyChunkReuse:    payload.AllowLegacyChunkReuse,
 	}
 
 	if convertResult != nil {

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -320,17 +320,18 @@ type WikiPendingOp struct {
 // both of which are correctness-critical short-lived flags rather
 // than data the system should survive without.
 type wikiIngestService struct {
-	wikiService    interfaces.WikiPageService
-	kbService      interfaces.KnowledgeBaseService
-	knowledgeSvc   interfaces.KnowledgeService
-	knowledgeRepo  interfaces.KnowledgeRepository
-	chunkRepo      interfaces.ChunkRepository
-	modelService   interfaces.ModelService
-	task           interfaces.TaskEnqueuer
-	audit          interfaces.AuditLogService
-	pendingRepo    interfaces.TaskPendingOpsRepository
-	deadLetterRepo interfaces.TaskDeadLetterRepository
-	redisClient    *redis.Client // nil in Lite mode (no Redis)
+	wikiService      interfaces.WikiPageService
+	kbService        interfaces.KnowledgeBaseService
+	knowledgeSvc     interfaces.KnowledgeService
+	knowledgeRepo    interfaces.KnowledgeRepository
+	chunkRepo        interfaces.ChunkRepository
+	modelService     interfaces.ModelService
+	task             interfaces.TaskEnqueuer
+	audit            interfaces.AuditLogService
+	pendingRepo      interfaces.TaskPendingOpsRepository
+	deadLetterRepo   interfaces.TaskDeadLetterRepository
+	wikiMapCacheRepo interfaces.WikiMapCacheRepository
+	redisClient      *redis.Client // nil in Lite mode (no Redis)
 	// spanTracker lets per-document map work surface as a
 	// postprocess.wiki subspan in the knowledge trace tree. Async
 	// batch design means we look up the parent attempt by knowledge
@@ -370,22 +371,24 @@ func NewWikiIngestService(
 	audit interfaces.AuditLogService,
 	pendingRepo interfaces.TaskPendingOpsRepository,
 	deadLetterRepo interfaces.TaskDeadLetterRepository,
+	wikiMapCacheRepo interfaces.WikiMapCacheRepository,
 	redisClient *redis.Client,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
 	svc := &wikiIngestService{
-		wikiService:    wikiService,
-		kbService:      kbService,
-		knowledgeSvc:   knowledgeSvc,
-		knowledgeRepo:  knowledgeRepo,
-		chunkRepo:      chunkRepo,
-		modelService:   modelService,
-		task:           task,
-		audit:          audit,
-		pendingRepo:    pendingRepo,
-		deadLetterRepo: deadLetterRepo,
-		redisClient:    redisClient,
-		spanTracker:    spanTracker,
+		wikiService:      wikiService,
+		kbService:        kbService,
+		knowledgeSvc:     knowledgeSvc,
+		knowledgeRepo:    knowledgeRepo,
+		chunkRepo:        chunkRepo,
+		modelService:     modelService,
+		task:             task,
+		audit:            audit,
+		pendingRepo:      pendingRepo,
+		deadLetterRepo:   deadLetterRepo,
+		wikiMapCacheRepo: wikiMapCacheRepo,
+		redisClient:      redisClient,
+		spanTracker:      spanTracker,
 	}
 	return svc
 }
@@ -3068,11 +3071,14 @@ func cleanLLMJSON(s string) string {
 	s = strings.TrimPrefix(s, "```")
 	s = strings.TrimSuffix(s, "```")
 	s = strings.TrimSpace(s)
+	if extracted := extractWikiJSONLike(s); extracted != "" {
+		s = extracted
+	}
 	return sanitizeJSONString(s)
 }
 
 // sanitizeJSONString sanitizes a string that is intended to be parsed as JSON,
-// by properly escaping unescaped control characters (like newlines) inside string literals.
+// by escaping control characters and dropping invalid string escapes produced by LLMs.
 func sanitizeJSONString(s string) string {
 	var buf strings.Builder
 	buf.Grow(len(s))
@@ -3080,21 +3086,24 @@ func sanitizeJSONString(s string) string {
 	escape := false
 	for _, r := range s {
 		if escape {
-			if r == '\n' {
-				buf.WriteString(`n`)
-			} else if r == '\r' {
-				buf.WriteString(`r`)
-			} else if r == '\t' {
-				buf.WriteString(`t`)
-			} else {
+			switch {
+			case isValidJSONEscape(r):
+				buf.WriteRune('\\')
+				buf.WriteRune(r)
+			case r == '\n':
+				buf.WriteString(`\n`)
+			case r == '\r':
+				buf.WriteString(`\r`)
+			case r == '\t':
+				buf.WriteString(`\t`)
+			default:
 				buf.WriteRune(r)
 			}
 			escape = false
 			continue
 		}
-		if r == '\\' {
+		if r == '\\' && inString {
 			escape = true
-			buf.WriteRune(r)
 			continue
 		}
 		if r == '"' {
@@ -3118,5 +3127,68 @@ func sanitizeJSONString(s string) string {
 		}
 		buf.WriteRune(r)
 	}
+	if escape {
+		buf.WriteString(`\\`)
+	}
 	return buf.String()
+}
+
+func isValidJSONEscape(r rune) bool {
+	switch r {
+	case '"', '\\', '/', 'b', 'f', 'n', 'r', 't', 'u':
+		return true
+	default:
+		return false
+	}
+}
+
+func extractWikiJSONLike(s string) string {
+	objStart := strings.IndexByte(s, '{')
+	arrStart := strings.IndexByte(s, '[')
+	var open, closeCh byte
+	var start int
+	switch {
+	case objStart < 0 && arrStart < 0:
+		return ""
+	case objStart < 0:
+		open, closeCh, start = '[', ']', arrStart
+	case arrStart < 0:
+		open, closeCh, start = '{', '}', objStart
+	case objStart < arrStart:
+		open, closeCh, start = '{', '}', objStart
+	default:
+		open, closeCh, start = '[', ']', arrStart
+	}
+
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch c {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case open:
+			depth++
+		case closeCh:
+			depth--
+			if depth == 0 {
+				return strings.TrimSpace(s[start : i+1])
+			}
+		}
+	}
+	return ""
 }

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -1241,17 +1241,18 @@ func (s *wikiIngestService) mapOneDocument(
 		extractedConcepts []extractedItem
 		slugItems         map[string]extractedItem
 		pass0Failed       bool
+		pass0CacheHit     bool
 	)
 	logger.Infof(ctx, "wiki ingest: pass 0 — extracting candidate slugs for %s", knowledgeID)
 	extractSpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.extract", types.SpanKindSubSpan, types.JSONMap{
 		"content_chars": utf8.RuneCountInString(content),
 		"old_pages":     len(oldPageSlugs),
 	})
-	extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
+	extractedEntities, extractedConcepts, slugItems, pass0CacheHit, err = s.extractCandidateSlugs(ctx, chatModel, payload.TenantID, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
 	if err != nil {
 		logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) — falling back to legacy extractor", knowledgeID, err)
 		pass0Failed = true
-		extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
+		extractedEntities, extractedConcepts, slugItems, pass0CacheHit, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, payload.TenantID, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
 		if err != nil {
 			logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
 			s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
@@ -1263,6 +1264,7 @@ func (s *wikiIngestService) mapOneDocument(
 		"entities":         len(extractedEntities),
 		"concepts":         len(extractedConcepts),
 		"pass0_fallback":   pass0Failed,
+		"cache_hit":        pass0CacheHit,
 		"entities_preview": previewExtractedItems(extractedEntities, 8),
 		"concepts_preview": previewExtractedItems(extractedConcepts, 8),
 	})
@@ -1295,11 +1297,13 @@ func (s *wikiIngestService) mapOneDocument(
 	// run them in parallel. Summary handles wiki-link injection; classification
 	// attaches concrete chunk IDs to each candidate slug.
 	var (
-		summaryContent string
-		summaryErr     error
-		citations      map[string][]string
-		newSlugs       []newSlugFromCitation
-		batchCount     int
+		summaryContent    string
+		summaryErr        error
+		summaryCacheHit   bool
+		citations         map[string][]string
+		newSlugs          []newSlugFromCitation
+		batchCount        int
+		citationCacheHits int
 	)
 
 	// Both calls run in parallel goroutines under the same wikiSpan
@@ -1321,19 +1325,20 @@ func (s *wikiIngestService) mapOneDocument(
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		summaryContent, summaryErr = s.generateWithTemplate(ctx, chatModel, agent.WikiSummaryPrompt, map[string]string{
+		summaryContent, summaryCacheHit, summaryErr = s.generateWikiMapWithCache(ctx, payload.TenantID, chatModel, "wiki_summary", agent.WikiSummaryPrompt, map[string]string{
 			"Content":            content,
 			"Language":           lang,
 			"ExtractedSlugs":     slugListing,
 			"CustomInstructions": batchCtx.ContentInstructions,
 			"InstructionScope":   "wiki_content",
-		})
+		}, nil)
 		if summaryErr != nil {
 			s.tracker().FailSpan(ctx, summarySpan, "SUMMARY_FAILED", summaryErr.Error(), summaryErr)
 		} else {
 			sumLine, sumBody := splitSummaryLine(summaryContent)
 			s.tracker().EndSpan(ctx, summarySpan, types.JSONMap{
 				"chars":        utf8.RuneCountInString(summaryContent),
+				"cache_hit":    summaryCacheHit,
 				"summary_line": previewText(sumLine, 160),
 				"body_preview": previewText(sumBody, 320),
 			})
@@ -1349,11 +1354,13 @@ func (s *wikiIngestService) mapOneDocument(
 			return
 		}
 		candidatesXML := renderCandidateSlugsXML(extractedEntities, extractedConcepts)
-		citations, newSlugs, batchCount = s.classifyChunkCitations(ctx, chatModel, candidatesXML, chunks, lang, batchCtx)
+		citations, newSlugs, batchCount, citationCacheHits = s.classifyChunkCitations(ctx, payload.TenantID, chatModel, candidatesXML, chunks, lang, batchCtx)
 		s.tracker().EndSpan(ctx, classifySpan, types.JSONMap{
 			"cited_slugs":      len(citations),
 			"new_slugs":        len(newSlugs),
 			"batches":          batchCount,
+			"cache_hits":       citationCacheHits,
+			"cache_misses":     batchCount - citationCacheHits,
 			"top_cited":        topCitedSlugs(citations, 8),
 			"new_slugs_sample": previewNewSlugs(newSlugs, 8),
 		})
@@ -1566,20 +1573,23 @@ func (s *wikiIngestService) mapOneDocument(
 	// "wiki processing for this knowledge" time the user sees in the
 	// trace viewer, not just the LLM extraction slice.
 	mapStats := types.JSONMap{
-		"doc_title":        previewText(docTitle, 120),
-		"chunks":           len(chunks),
-		"candidate_slugs":  len(slugItems),
-		"cited_chunks":     len(citedChunkSet),
-		"uncited_slugs":    uncited,
-		"new_slugs":        len(newSlugs),
-		"updates":          len(updates),
-		"reparse_slugs":    reparseOverlap,
-		"stale_slugs":      staleCount,
-		"extracted_pages":  len(extractedPages),
-		"summary_chars":    utf8.RuneCountInString(docSummary),
-		"pass0_fallback":   pass0Failed,
-		"classify_batches": batchCount,
-		"summary_preview":  previewText(docSummaryLine, 160),
+		"doc_title":           previewText(docTitle, 120),
+		"chunks":              len(chunks),
+		"candidate_slugs":     len(slugItems),
+		"cited_chunks":        len(citedChunkSet),
+		"uncited_slugs":       uncited,
+		"new_slugs":           len(newSlugs),
+		"updates":             len(updates),
+		"reparse_slugs":       reparseOverlap,
+		"stale_slugs":         staleCount,
+		"extracted_pages":     len(extractedPages),
+		"summary_chars":       utf8.RuneCountInString(docSummary),
+		"pass0_fallback":      pass0Failed,
+		"pass0_cache_hit":     pass0CacheHit,
+		"summary_cache_hit":   summaryCacheHit,
+		"citation_cache_hits": citationCacheHits,
+		"classify_batches":    batchCount,
+		"summary_preview":     previewText(docSummaryLine, 160),
 	}
 
 	return &docIngestResult{
@@ -1595,39 +1605,34 @@ func (s *wikiIngestService) mapOneDocument(
 func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 	ctx context.Context,
 	chatModel chat.Chat,
+	tenantID uint64,
 	kbID string,
 	content, lang string,
 	oldPageSlugs map[string]bool,
 	batchCtx *WikiBatchContext,
-) ([]extractedItem, []extractedItem, map[string]extractedItem, error) {
+) ([]extractedItem, []extractedItem, map[string]extractedItem, bool, error) {
 	// Only entity/* and concept/* slugs are relevant for LLM slug-continuity —
 	// summary slugs are code-generated from the knowledge ID and never appear
 	// in the extraction output, so including them just wastes tokens and risks
 	// confusing the model.
-	var prevSlugsText string
-	if len(oldPageSlugs) > 0 {
-		var sb strings.Builder
-		for slug := range oldPageSlugs {
-			if !strings.HasPrefix(slug, "entity/") && !strings.HasPrefix(slug, "concept/") {
-				continue
-			}
-			fmt.Fprintf(&sb, "- %s\n", slug)
-		}
-		prevSlugsText = sb.String()
-	}
-	if prevSlugsText == "" {
-		prevSlugsText = "(none — this is a new document)"
-	}
-
-	extractionJSON, err := s.generateWithTemplate(ctx, chatModel, agent.WikiKnowledgeExtractPrompt, map[string]string{
+	prevSlugsText := renderPreviousWikiSlugs(oldPageSlugs)
+	extractionData := map[string]string{
 		"Content":            content,
 		"Language":           lang,
 		"PreviousSlugs":      prevSlugsText,
 		"CustomInstructions": batchCtx.ExtractionInstructions,
 		"InstructionScope":   "wiki_extraction",
-	})
+	}
+	extractionKeyData := map[string]string{
+		"Content":            content,
+		"Language":           lang,
+		"PreviousSlugs":      prevSlugsText,
+		"CustomInstructions": batchCtx.ExtractionInstructions,
+		"InstructionScope":   "wiki_extraction",
+	}
+	extractionJSON, cacheHit, err := s.generateWikiMapWithCacheKeyData(ctx, tenantID, chatModel, "wiki_legacy_extract", agent.WikiKnowledgeExtractPrompt, extractionData, extractionKeyData, validateWikiCombinedExtractionJSON)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("combined extraction failed: %w", err)
+		return nil, nil, nil, false, fmt.Errorf("combined extraction failed: %w", err)
 	}
 
 	extractionJSON = cleanLLMJSON(extractionJSON)
@@ -1635,7 +1640,7 @@ func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 	var result combinedExtraction
 	if err := json.Unmarshal([]byte(extractionJSON), &result); err != nil {
 		logger.Warnf(ctx, "wiki ingest: failed to parse combined extraction JSON: %v\nRaw: %s", err, extractionJSON)
-		return nil, nil, nil, fmt.Errorf("parse combined extraction JSON: %w", err)
+		return nil, nil, nil, false, fmt.Errorf("parse combined extraction JSON: %w", err)
 	}
 
 	// Dedup pre-filter is dispatched against the wiki page repo via
@@ -1659,7 +1664,7 @@ func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 		}
 	}
 
-	return result.Entities, result.Concepts, slugItems, nil
+	return result.Entities, result.Concepts, slugItems, cacheHit, nil
 }
 
 // reduceSlugUpdates returns:

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -1274,6 +1274,7 @@ func (s *wikiIngestService) mapOneDocument(
 	for slug := range slugItems {
 		summaryExtractedPages = append(summaryExtractedPages, slug)
 	}
+	sort.Strings(summaryExtractedPages)
 	// Wiki summary slug is derived from the knowledge ID rather than the
 	// docTitle (which is typically the upload filename). Filename-based slugs
 	// like "summary/mx5280-pdf" expose the filename in cross-link contexts

--- a/internal/application/service/wiki_ingest_cite.go
+++ b/internal/application/service/wiki_ingest_cite.go
@@ -72,28 +72,15 @@ type citationPipelineOutcome struct {
 func (s *wikiIngestService) extractCandidateSlugs(
 	ctx context.Context,
 	chatModel chat.Chat,
+	tenantID uint64,
 	kbID string,
 	content, lang string,
 	oldPageSlugs map[string]bool,
 	batchCtx *WikiBatchContext,
-) ([]extractedItem, []extractedItem, map[string]extractedItem, error) {
-	var prevSlugsText string
-	if len(oldPageSlugs) > 0 {
-		var sb strings.Builder
-		for slug := range oldPageSlugs {
-			if !strings.HasPrefix(slug, "entity/") && !strings.HasPrefix(slug, "concept/") {
-				continue
-			}
-			fmt.Fprintf(&sb, "- %s\n", slug)
-		}
-		prevSlugsText = sb.String()
-	}
-	if prevSlugsText == "" {
-		prevSlugsText = "(none — this is a new document)"
-	}
-
+) ([]extractedItem, []extractedItem, map[string]extractedItem, bool, error) {
+	prevSlugsText := renderPreviousWikiSlugs(oldPageSlugs)
 	granularity := batchCtx.ExtractionGranularity.Normalize()
-	raw, err := s.generateWithTemplate(ctx, chatModel, agent.WikiCandidateSlugPrompt, map[string]string{
+	extractionData := map[string]string{
 		"Content":             content,
 		"Language":            lang,
 		"PreviousSlugs":       prevSlugsText,
@@ -101,9 +88,19 @@ func (s *wikiIngestService) extractCandidateSlugs(
 		"GranularityGuidance": agent.WikiGranularityGuidance(string(granularity)),
 		"CustomInstructions":  batchCtx.ExtractionInstructions,
 		"InstructionScope":    "wiki_extraction",
-	})
+	}
+	extractionKeyData := map[string]string{
+		"Content":             content,
+		"Language":            lang,
+		"PreviousSlugs":       prevSlugsText,
+		"Granularity":         string(granularity),
+		"GranularityGuidance": agent.WikiGranularityGuidance(string(granularity)),
+		"CustomInstructions":  batchCtx.ExtractionInstructions,
+		"InstructionScope":    "wiki_extraction",
+	}
+	raw, cacheHit, err := s.generateWikiMapWithCacheKeyData(ctx, tenantID, chatModel, "wiki_candidate_slugs", agent.WikiCandidateSlugPrompt, extractionData, extractionKeyData, validateWikiCombinedExtractionJSON)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("candidate slug extraction failed: %w", err)
+		return nil, nil, nil, false, fmt.Errorf("candidate slug extraction failed: %w", err)
 	}
 
 	raw = cleanLLMJSON(raw)
@@ -111,7 +108,7 @@ func (s *wikiIngestService) extractCandidateSlugs(
 	var result combinedExtraction
 	if err := json.Unmarshal([]byte(raw), &result); err != nil {
 		logger.Warnf(ctx, "wiki ingest: failed to parse candidate slug JSON: %v\nRaw: %s", err, raw)
-		return nil, nil, nil, fmt.Errorf("parse candidate slug JSON: %w", err)
+		return nil, nil, nil, false, fmt.Errorf("parse candidate slug JSON: %w", err)
 	}
 
 	result.Entities, result.Concepts = s.deduplicateExtractedBatch(
@@ -130,7 +127,7 @@ func (s *wikiIngestService) extractCandidateSlugs(
 		}
 	}
 
-	return result.Entities, result.Concepts, slugItems, nil
+	return result.Entities, result.Concepts, slugItems, cacheHit, nil
 }
 
 // chunkBatch groups chunks that will be sent in a single WikiChunkCitationPrompt call.
@@ -255,15 +252,16 @@ func renderChunksXML(batch chunkBatch) string {
 // likewise carry real chunk UUIDs in SourceChunks.
 func (s *wikiIngestService) classifyChunkCitations(
 	ctx context.Context,
+	tenantID uint64,
 	chatModel chat.Chat,
 	candidatesXML string,
 	chunks []*types.Chunk,
 	lang string,
 	batchCtx *WikiBatchContext,
-) (map[string][]string, []newSlugFromCitation, int) {
+) (map[string][]string, []newSlugFromCitation, int, int) {
 	batches := splitChunksIntoCitationBatches(chunks)
 	if len(batches) == 0 || strings.TrimSpace(candidatesXML) == "" {
-		return map[string][]string{}, nil, 0
+		return map[string][]string{}, nil, 0, 0
 	}
 
 	// Merge state. Using sets keyed by (slug, chunkID) to dedup across
@@ -271,6 +269,7 @@ func (s *wikiIngestService) classifyChunkCitations(
 	var mu sync.Mutex
 	citationSet := make(map[string]map[string]bool) // slug → set of real chunk IDs
 	var newSlugsAll []newSlugFromCitation
+	cacheHits := 0
 
 	eg, ectx := errgroup.WithContext(ctx)
 	eg.SetLimit(maxCitationBatchConcurrency)
@@ -280,11 +279,11 @@ func (s *wikiIngestService) classifyChunkCitations(
 		batchIdx := bi
 		eg.Go(func() error {
 			chunksXML := renderChunksXML(batch)
-			raw, err := s.generateWithTemplate(ectx, chatModel, agent.WikiChunkCitationPrompt, map[string]string{
+			raw, cacheHit, err := s.generateWikiMapWithCache(ectx, tenantID, chatModel, "wiki_chunk_citation", agent.WikiChunkCitationPrompt, map[string]string{
 				"CandidateSlugs": candidatesXML,
 				"ChunksXML":      chunksXML,
 				"Language":       lang,
-			})
+			}, validateWikiCitationJSON)
 			if err != nil {
 				logger.Warnf(ectx, "wiki ingest: citation batch %d failed: %v", batchIdx, err)
 				return nil // don't abort peer batches
@@ -300,6 +299,9 @@ func (s *wikiIngestService) classifyChunkCitations(
 			// Translate handles → real chunk UUIDs; drop unknown handles.
 			mu.Lock()
 			defer mu.Unlock()
+			if cacheHit {
+				cacheHits++
+			}
 
 			for slug, handleList := range parsed.Citations {
 				if slug == "" {
@@ -356,7 +358,7 @@ func (s *wikiIngestService) classifyChunkCitations(
 		out[slug] = ids
 	}
 
-	return out, newSlugsAll, len(batches)
+	return out, newSlugsAll, len(batches), cacheHits
 }
 
 // resolveCitedChunks loads the content of every chunk referenced by the

--- a/internal/application/service/wiki_ingest_cite.go
+++ b/internal/application/service/wiki_ingest_cite.go
@@ -280,9 +280,11 @@ func (s *wikiIngestService) classifyChunkCitations(
 		eg.Go(func() error {
 			chunksXML := renderChunksXML(batch)
 			raw, cacheHit, err := s.generateWikiMapWithCache(ectx, tenantID, chatModel, "wiki_chunk_citation", agent.WikiChunkCitationPrompt, map[string]string{
-				"CandidateSlugs": candidatesXML,
-				"ChunksXML":      chunksXML,
-				"Language":       lang,
+				"CandidateSlugs":     candidatesXML,
+				"ChunksXML":          chunksXML,
+				"Language":           lang,
+				"CustomInstructions": batchCtx.ExtractionInstructions,
+				"InstructionScope":   "wiki_extraction",
 			}, validateWikiCitationJSON)
 			if err != nil {
 				logger.Warnf(ectx, "wiki ingest: citation batch %d failed: %v", batchIdx, err)

--- a/internal/application/service/wiki_map_cache.go
+++ b/internal/application/service/wiki_map_cache.go
@@ -1,0 +1,182 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+type wikiCachedTextPayload struct {
+	Text string `json:"text"`
+}
+
+func wikiMapContentKey(kind string, data map[string]string) string {
+	raw, _ := json.Marshal(struct {
+		Schema string            `json:"schema"`
+		Kind   string            `json:"kind"`
+		Data   map[string]string `json:"data"`
+	}{
+		Schema: types.WikiMapCacheSchemaVersion,
+		Kind:   kind,
+		Data:   data,
+	})
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+func wikiMapConfigHash(promptTpl string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		types.WikiMapCacheSchemaVersion,
+		promptTpl,
+	}, "\x00")))
+	return hex.EncodeToString(sum[:])
+}
+
+func wikiMapCacheKey(kind, contentKey, modelSignature, configHash string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		types.WikiMapCacheSchemaVersion,
+		kind,
+		contentKey,
+		modelSignature,
+		configHash,
+	}, "\x00")))
+	return hex.EncodeToString(sum[:])
+}
+
+func wikiChatModelSignature(chatModel chat.Chat) (modelID string, signature string) {
+	modelID = chatModel.GetModelID()
+	signature = strings.Join([]string{modelID, chatModel.GetModelName()}, "\x00")
+	return modelID, signature
+}
+
+func (s *wikiIngestService) generateWikiMapWithCache(
+	ctx context.Context,
+	tenantID uint64,
+	chatModel chat.Chat,
+	kind string,
+	promptTpl string,
+	data map[string]string,
+	validate func(string) error,
+) (string, bool, error) {
+	return s.generateWikiMapWithCacheKeyData(ctx, tenantID, chatModel, kind, promptTpl, data, data, validate)
+}
+
+func (s *wikiIngestService) generateWikiMapWithCacheKeyData(
+	ctx context.Context,
+	tenantID uint64,
+	chatModel chat.Chat,
+	kind string,
+	promptTpl string,
+	data map[string]string,
+	keyData map[string]string,
+	validate func(string) error,
+) (string, bool, error) {
+	if s.wikiMapCacheRepo == nil {
+		text, _, err := s.generateValidatedWikiMapText(ctx, chatModel, kind, promptTpl, data, validate)
+		return text, false, err
+	}
+
+	modelID, modelSignature := wikiChatModelSignature(chatModel)
+	contentKey := wikiMapContentKey(kind, keyData)
+	configHash := wikiMapConfigHash(promptTpl)
+	cacheKey := wikiMapCacheKey(kind, contentKey, modelSignature, configHash)
+
+	cache, cacheErr := s.wikiMapCacheRepo.GetByKey(ctx, tenantID, cacheKey)
+	if cacheErr != nil {
+		logger.Warnf(ctx, "wiki map cache lookup failed kind=%s key=%s: %v", kind, cacheKey, cacheErr)
+	} else if cache != nil {
+		var payload wikiCachedTextPayload
+		if err := json.Unmarshal(cache.Payload, &payload); err != nil {
+			logger.Warnf(ctx, "wiki map cache decode failed kind=%s key=%s: %v", kind, cacheKey, err)
+		} else {
+			logger.Infof(ctx, "wiki map cache hit kind=%s key=%s", kind, cacheKey)
+			return payload.Text, true, nil
+		}
+	}
+
+	text, valid, err := s.generateValidatedWikiMapText(ctx, chatModel, kind, promptTpl, data, validate)
+	if err != nil {
+		return "", false, err
+	}
+	if !valid {
+		logger.Warnf(ctx, "wiki map cache skip invalid output kind=%s key=%s", kind, cacheKey)
+		return text, false, nil
+	}
+	rawPayload, err := json.Marshal(wikiCachedTextPayload{Text: text})
+	if err != nil {
+		logger.Warnf(ctx, "wiki map cache marshal failed kind=%s key=%s: %v", kind, cacheKey, err)
+		return text, false, nil
+	}
+	if err := s.wikiMapCacheRepo.Upsert(ctx, &types.WikiMapCache{
+		TenantID:   tenantID,
+		CacheKey:   cacheKey,
+		Kind:       kind,
+		ContentKey: contentKey,
+		ModelID:    modelID,
+		ConfigHash: configHash,
+		SchemaVer:  types.WikiMapCacheSchemaVersion,
+		Payload:    types.JSON(rawPayload),
+	}); err != nil {
+		logger.Warnf(ctx, "wiki map cache upsert failed kind=%s key=%s: %v", kind, cacheKey, err)
+	}
+	return text, false, nil
+}
+
+func (s *wikiIngestService) generateValidatedWikiMapText(
+	ctx context.Context,
+	chatModel chat.Chat,
+	kind string,
+	promptTpl string,
+	data map[string]string,
+	validate func(string) error,
+) (string, bool, error) {
+	text, err := s.generateWithTemplate(ctx, chatModel, promptTpl, data)
+	if err != nil {
+		return "", false, err
+	}
+
+	normalized, validErr := normalizeWikiMapText(text, validate)
+	if validErr == nil {
+		return normalized, true, nil
+	}
+
+	logger.Warnf(ctx, "wiki map output invalid kind=%s, retry once: %v", kind, validErr)
+	retryText, retryErr := s.generateWithTemplate(ctx, chatModel, promptTpl, data)
+	if retryErr != nil {
+		logger.Warnf(ctx, "wiki map output retry failed kind=%s: %v", kind, retryErr)
+		return normalized, false, nil
+	}
+	normalizedRetry, retryValidErr := normalizeWikiMapText(retryText, validate)
+	if retryValidErr != nil {
+		logger.Warnf(ctx, "wiki map output still invalid kind=%s: %v", kind, retryValidErr)
+		return normalizedRetry, false, nil
+	}
+	return normalizedRetry, true, nil
+}
+
+func normalizeWikiMapText(text string, validate func(string) error) (string, error) {
+	if validate == nil {
+		return text, nil
+	}
+	normalized := cleanLLMJSON(text)
+	if err := validate(normalized); err != nil {
+		return normalized, err
+	}
+	return normalized, nil
+}
+
+func validateWikiCombinedExtractionJSON(text string) error {
+	var parsed combinedExtraction
+	return json.Unmarshal([]byte(cleanLLMJSON(text)), &parsed)
+}
+
+func validateWikiCitationJSON(text string) error {
+	var parsed citationBatchResult
+	return json.Unmarshal([]byte(cleanLLMJSON(text)), &parsed)
+}

--- a/internal/application/service/wiki_map_cache.go
+++ b/internal/application/service/wiki_map_cache.go
@@ -5,6 +5,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -14,6 +16,28 @@ import (
 
 type wikiCachedTextPayload struct {
 	Text string `json:"text"`
+}
+
+func renderPreviousWikiSlugs(oldPageSlugs map[string]bool) string {
+	if len(oldPageSlugs) == 0 {
+		return "(none — this is a new document)"
+	}
+	slugs := make([]string, 0, len(oldPageSlugs))
+	for slug := range oldPageSlugs {
+		if !strings.HasPrefix(slug, "entity/") && !strings.HasPrefix(slug, "concept/") {
+			continue
+		}
+		slugs = append(slugs, slug)
+	}
+	if len(slugs) == 0 {
+		return "(none — this is a new document)"
+	}
+	sort.Strings(slugs)
+	var sb strings.Builder
+	for _, slug := range slugs {
+		fmt.Fprintf(&sb, "- %s\n", slug)
+	}
+	return sb.String()
 }
 
 func wikiMapContentKey(kind string, data map[string]string) string {

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -148,6 +148,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewKnowledgeSpanRepository))
 	must(container.Provide(repository.NewChunkRepository))
 	must(container.Provide(repository.NewGraphExtractionCacheRepository))
+	must(container.Provide(repository.NewWikiMapCacheRepository))
 	must(container.Provide(repository.NewKnowledgeTagRepository))
 	must(container.Provide(repository.NewSessionRepository))
 	must(container.Provide(repository.NewMessageRepository))

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -147,6 +147,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewKnowledgeRepository))
 	must(container.Provide(repository.NewKnowledgeSpanRepository))
 	must(container.Provide(repository.NewChunkRepository))
+	must(container.Provide(repository.NewGraphExtractionCacheRepository))
 	must(container.Provide(repository.NewKnowledgeTagRepository))
 	must(container.Provide(repository.NewSessionRepository))
 	must(container.Provide(repository.NewMessageRepository))

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -150,6 +150,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewGraphExtractionCacheRepository))
 	must(container.Provide(repository.NewWikiMapCacheRepository))
 	must(container.Provide(repository.NewImageMultimodalCacheRepository))
+	must(container.Provide(repository.NewDocumentParseCacheRepository))
 	must(container.Provide(repository.NewKnowledgeTagRepository))
 	must(container.Provide(repository.NewSessionRepository))
 	must(container.Provide(repository.NewMessageRepository))

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -149,6 +149,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewChunkRepository))
 	must(container.Provide(repository.NewGraphExtractionCacheRepository))
 	must(container.Provide(repository.NewWikiMapCacheRepository))
+	must(container.Provide(repository.NewImageMultimodalCacheRepository))
 	must(container.Provide(repository.NewKnowledgeTagRepository))
 	must(container.Provide(repository.NewSessionRepository))
 	must(container.Provide(repository.NewMessageRepository))

--- a/internal/types/chunk.go
+++ b/internal/types/chunk.go
@@ -3,6 +3,8 @@
 package types
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 	"time"
 
@@ -208,6 +210,33 @@ func (c *Chunk) EmbeddingContent() string {
 		return body
 	}
 	return c.ContextHeader + "\n\n" + body
+}
+
+// DocumentChunkFingerprint returns a stable hash for parsed document text.
+// It intentionally mirrors EmbeddingContent because a cache hit must mean the
+// existing chunk vector can be reused without another embedding call.
+func DocumentChunkFingerprint(content, contextHeader string) string {
+	return DocumentChunkScopedFingerprint(content, contextHeader)
+}
+
+func DocumentChunkScopedFingerprint(content, contextHeader string, scopeParts ...string) string {
+	body := strings.TrimSpace(content)
+	input := body
+	if contextHeader != "" {
+		input = contextHeader + "\n\n" + body
+	}
+	if len(scopeParts) > 0 {
+		input = strings.Join(scopeParts, "\x00") + "\x00" + input
+	}
+	sum := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(sum[:])
+}
+
+func (c *Chunk) DocumentFingerprint() string {
+	if c == nil {
+		return ""
+	}
+	return DocumentChunkFingerprint(c.Content, c.ContextHeader)
 }
 
 // AssignChunkSeqIDs assigns sequential SeqIDs to a batch of chunks that have SeqID == 0.

--- a/internal/types/document_parse_cache.go
+++ b/internal/types/document_parse_cache.go
@@ -1,0 +1,25 @@
+package types
+
+import "time"
+
+const DocumentParseCacheSchemaVersion = "document_parse_v1"
+
+// DocumentParseCache stores the latest resolved parser artifact for one
+// knowledge. It is deliberately knowledge-scoped because the resolved image
+// resources follow the knowledge lifecycle and must not leak across documents.
+type DocumentParseCache struct {
+	ID          uint64    `json:"id" gorm:"primaryKey;autoIncrement"`
+	TenantID    uint64    `json:"tenant_id" gorm:"not null;uniqueIndex:idx_document_parse_cache_knowledge"`
+	KnowledgeID string    `json:"knowledge_id" gorm:"type:varchar(36);not null;uniqueIndex:idx_document_parse_cache_knowledge"`
+	CacheKey    string    `json:"cache_key" gorm:"type:varchar(64);not null;index"`
+	ContentKey  string    `json:"content_key" gorm:"type:varchar(128);not null"`
+	ConfigHash  string    `json:"config_hash" gorm:"type:varchar(64);not null"`
+	SchemaVer   string    `json:"schema_ver" gorm:"type:varchar(32);not null"`
+	Payload     JSON      `json:"payload" gorm:"type:jsonb;not null"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+func (DocumentParseCache) TableName() string {
+	return "document_parse_caches"
+}

--- a/internal/types/faq.go
+++ b/internal/types/faq.go
@@ -63,6 +63,13 @@ type DocumentChunkMetadata struct {
 	GeneratedQuestions []GeneratedQuestion `json:"generated_questions,omitempty"`
 	// GeneratedQuestionsRevision ties the questions to Chunk.ContentRevision.
 	GeneratedQuestionsRevision int `json:"generated_questions_revision,omitempty"`
+	// GeneratedQuestionsCacheKey identifies the exact model, prompt, config,
+	// content, and surrounding context used to generate the questions.
+	GeneratedQuestionsCacheKey string `json:"generated_questions_cache_key,omitempty"`
+	// GeneratedQuestionsIndexKey identifies the embedding/index contract for
+	// GeneratedQuestions. It changes independently from generation so switching
+	// embedding models does not call the chat model again.
+	GeneratedQuestionsIndexKey string `json:"generated_questions_index_key,omitempty"`
 }
 
 // IsQuestionCurrent reports whether a generated question was authored for the

--- a/internal/types/faq.go
+++ b/internal/types/faq.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -47,6 +48,11 @@ func GeneratedQuestionSourceID(chunkID, questionID string) string {
 	// UUID chunk IDs use 36 bytes; "-q" plus 24 hex characters keeps the
 	// complete identifier at 62 bytes while retaining ample collision space.
 	return chunkID + "-q" + hex.EncodeToString(digest[:12])
+}
+
+func StableGeneratedQuestionID(question string, index int) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(question) + "\x00" + strconv.Itoa(index)))
+	return "q" + hex.EncodeToString(sum[:8])
 }
 
 // DocumentChunkMetadata 定义文档 Chunk 的元数据结构

--- a/internal/types/graph_extraction_cache.go
+++ b/internal/types/graph_extraction_cache.go
@@ -1,0 +1,32 @@
+package types
+
+import "time"
+
+const (
+	// GraphExtractionCacheSchemaVersion bumps whenever the cached graph JSON
+	// contract changes. It is part of the cache key so old rows become cold
+	// misses instead of being interpreted with new semantics.
+	GraphExtractionCacheSchemaVersion = "graph_extract_v1"
+)
+
+// GraphExtractionCache stores the LLM-produced per-chunk GraphRAG extraction.
+//
+// The row is intentionally scoped by the deterministic extraction inputs
+// (chunk text, model, prompt/config), not by chunk_id. That lets reparses reuse
+// the expensive LLM output even when the rebuilt document receives new chunk IDs.
+type GraphExtractionCache struct {
+	ID         uint64    `json:"id" gorm:"primaryKey;autoIncrement"`
+	TenantID   uint64    `json:"tenant_id" gorm:"index;not null;uniqueIndex:idx_graph_extract_cache_key"`
+	CacheKey   string    `json:"cache_key" gorm:"type:varchar(64);not null;uniqueIndex:idx_graph_extract_cache_key"`
+	ContentKey string    `json:"content_key" gorm:"type:varchar(64);not null;index"`
+	ModelID    string    `json:"model_id" gorm:"type:varchar(128);not null;default:''"`
+	ConfigHash string    `json:"config_hash" gorm:"type:varchar(64);not null"`
+	SchemaVer  string    `json:"schema_ver" gorm:"type:varchar(32);not null"`
+	Graph      JSON      `json:"graph" gorm:"type:jsonb;not null"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+func (GraphExtractionCache) TableName() string {
+	return "graph_extraction_caches"
+}

--- a/internal/types/image_multimodal_cache.go
+++ b/internal/types/image_multimodal_cache.go
@@ -1,0 +1,32 @@
+package types
+
+import "time"
+
+const (
+	// ImageMultimodalCacheSchemaVersion bumps when cached OCR/caption payload
+	// semantics or prompt contracts change. It is part of every key so old rows
+	// become cold misses.
+	ImageMultimodalCacheSchemaVersion = "image_multimodal_v1"
+)
+
+// ImageMultimodalCache stores deterministic OCR/caption outputs for one image.
+//
+// The row is scoped by image bytes + VLM model/config + prompt version, not by
+// knowledge_id or chunk_id. That lets reparses reuse the expensive VLM result
+// even when rebuilt chunks receive new IDs.
+type ImageMultimodalCache struct {
+	ID         uint64    `json:"id" gorm:"primaryKey;autoIncrement"`
+	TenantID   uint64    `json:"tenant_id" gorm:"index;not null;uniqueIndex:idx_image_multimodal_cache_key"`
+	CacheKey   string    `json:"cache_key" gorm:"type:varchar(64);not null;uniqueIndex:idx_image_multimodal_cache_key"`
+	ContentKey string    `json:"content_key" gorm:"type:varchar(64);not null;index"`
+	ModelID    string    `json:"model_id" gorm:"type:varchar(128);not null;default:''"`
+	ConfigHash string    `json:"config_hash" gorm:"type:varchar(64);not null"`
+	SchemaVer  string    `json:"schema_ver" gorm:"type:varchar(32);not null"`
+	Payload    JSON      `json:"payload" gorm:"type:jsonb;not null"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+func (ImageMultimodalCache) TableName() string {
+	return "image_multimodal_caches"
+}

--- a/internal/types/interfaces/chunk.go
+++ b/internal/types/interfaces/chunk.go
@@ -30,6 +30,8 @@ type ChunkRepository interface {
 	ListChunksBySeqID(ctx context.Context, tenantID uint64, seqIDs []int64) ([]*types.Chunk, error)
 	// ListChunksByKnowledgeID lists chunks by knowledge id
 	ListChunksByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) ([]*types.Chunk, error)
+	// ListAllChunksByKnowledgeID lists all chunk types by knowledge id.
+	ListAllChunksByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) ([]*types.Chunk, error)
 	// ListPagedChunksByKnowledgeID lists paged chunks by knowledge id.
 	// When tagIDs is non-empty, results are filtered by tag_id (OR semantics).
 	// knowledgeType: "faq" or "manual" - determines sort order and search behavior
@@ -134,6 +136,8 @@ type ChunkService interface {
 	GetChunkByIDOnly(ctx context.Context, id string) (*types.Chunk, error)
 	// ListChunksByKnowledgeID lists chunks by knowledge id
 	ListChunksByKnowledgeID(ctx context.Context, knowledgeID string) ([]*types.Chunk, error)
+	// ListAllChunksByKnowledgeID lists all chunk types by knowledge id
+	ListAllChunksByKnowledgeID(ctx context.Context, knowledgeID string) ([]*types.Chunk, error)
 	// ListPagedChunksByKnowledgeID lists paged chunks by knowledge id
 	ListPagedChunksByKnowledgeID(
 		ctx context.Context,

--- a/internal/types/interfaces/document_parse_cache.go
+++ b/internal/types/interfaces/document_parse_cache.go
@@ -1,0 +1,14 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// DocumentParseCacheRepository persists resolved parser artifacts used by
+// reparses of the same knowledge.
+type DocumentParseCacheRepository interface {
+	GetByKey(ctx context.Context, tenantID uint64, knowledgeID, cacheKey string) (*types.DocumentParseCache, error)
+	Upsert(ctx context.Context, cache *types.DocumentParseCache) error
+}

--- a/internal/types/interfaces/graph_extraction_cache.go
+++ b/internal/types/interfaces/graph_extraction_cache.go
@@ -1,0 +1,15 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// GraphExtractionCacheRepository persists deterministic GraphRAG per-chunk
+// extraction outputs. It caches only the LLM result; callers still own writing
+// the graph into the current knowledge namespace.
+type GraphExtractionCacheRepository interface {
+	GetByKey(ctx context.Context, tenantID uint64, cacheKey string) (*types.GraphExtractionCache, error)
+	Upsert(ctx context.Context, cache *types.GraphExtractionCache) error
+}

--- a/internal/types/interfaces/image_multimodal_cache.go
+++ b/internal/types/interfaces/image_multimodal_cache.go
@@ -1,0 +1,13 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// ImageMultimodalCacheRepository persists deterministic OCR/caption outputs.
+type ImageMultimodalCacheRepository interface {
+	GetByKey(ctx context.Context, tenantID uint64, cacheKey string) (*types.ImageMultimodalCache, error)
+	Upsert(ctx context.Context, cache *types.ImageMultimodalCache) error
+}

--- a/internal/types/interfaces/wiki_map_cache.go
+++ b/internal/types/interfaces/wiki_map_cache.go
@@ -1,0 +1,14 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// WikiMapCacheRepository persists deterministic per-document Wiki map outputs.
+// It intentionally does not cache Wiki reduce/merge results.
+type WikiMapCacheRepository interface {
+	GetByKey(ctx context.Context, tenantID uint64, cacheKey string) (*types.WikiMapCache, error)
+	Upsert(ctx context.Context, cache *types.WikiMapCache) error
+}

--- a/internal/types/knowledge.go
+++ b/internal/types/knowledge.go
@@ -385,7 +385,63 @@ func (p ManualKnowledgePayload) IsDraft() bool {
 	return p.Status == "" || p.Status == ManualKnowledgeStatusDraft
 }
 
-const metadataKeyProcessOverrides = "process_overrides"
+const (
+	metadataKeyProcessOverrides = "process_overrides"
+	metadataKeySummaryCache     = "summary_cache"
+)
+
+// KnowledgeSummaryCacheMetadata records which deterministic summary input
+// produced Description. ContentHash prevents a manually edited description
+// from being mistaken for the cached model output.
+type KnowledgeSummaryCacheMetadata struct {
+	Key         string `json:"key"`
+	ContentHash string `json:"content_hash"`
+	Content     string `json:"content"`
+}
+
+func (k *Knowledge) SummaryCacheMetadata() (*KnowledgeSummaryCacheMetadata, error) {
+	if k == nil || len(k.Metadata) == 0 {
+		return nil, nil
+	}
+	metadataMap, err := k.Metadata.Map()
+	if err != nil {
+		return nil, err
+	}
+	raw, ok := metadataMap[metadataKeySummaryCache]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	bytes, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	var cache KnowledgeSummaryCacheMetadata
+	if err := json.Unmarshal(bytes, &cache); err != nil {
+		return nil, err
+	}
+	return &cache, nil
+}
+
+func (k *Knowledge) SetSummaryCacheMetadata(cache *KnowledgeSummaryCacheMetadata) error {
+	if k == nil {
+		return nil
+	}
+	metadataMap, err := k.Metadata.Map()
+	if err != nil {
+		return err
+	}
+	if cache == nil {
+		delete(metadataMap, metadataKeySummaryCache)
+	} else {
+		metadataMap[metadataKeySummaryCache] = cache
+	}
+	bytes, err := json.Marshal(metadataMap)
+	if err != nil {
+		return err
+	}
+	k.Metadata = JSON(bytes)
+	return nil
+}
 
 // ProcessOverrides parses process config overrides from knowledge metadata.
 func (k *Knowledge) ProcessOverrides() (*KnowledgeProcessOverrides, error) {

--- a/internal/types/task.go
+++ b/internal/types/task.go
@@ -283,6 +283,8 @@ type DocumentProcessPayload struct {
 	EnableQuestionGeneration bool     `json:"enable_question_generation"` // 是否启用问题生成
 	QuestionCount            int      `json:"question_count,omitempty"`   // 每个chunk生成的问题数量
 	Language                 string   `json:"language,omitempty"`         // Request locale for {{language}} in prompt templates
+	ReuseUnchangedChunks     bool     `json:"reuse_unchanged_chunks,omitempty"`
+	AllowLegacyChunkReuse    bool     `json:"allow_legacy_chunk_reuse,omitempty"`
 	// Attempt is the per-knowledge attempt number this task belongs to.
 	// Set on enqueue (initial parse → attempt 1; reparse → max+1) so
 	// every span recorded by this task lands on the right attempt

--- a/internal/types/task.go
+++ b/internal/types/task.go
@@ -285,6 +285,7 @@ type DocumentProcessPayload struct {
 	Language                 string   `json:"language,omitempty"`         // Request locale for {{language}} in prompt templates
 	ReuseUnchangedChunks     bool     `json:"reuse_unchanged_chunks,omitempty"`
 	AllowLegacyChunkReuse    bool     `json:"allow_legacy_chunk_reuse,omitempty"`
+	ReindexReusedChunks      bool     `json:"reindex_reused_chunks,omitempty"`
 	// Attempt is the per-knowledge attempt number this task belongs to.
 	// Set on enqueue (initial parse → attempt 1; reparse → max+1) so
 	// every span recorded by this task lands on the right attempt
@@ -459,12 +460,15 @@ type KnowledgeMoveProgress struct {
 // Used for both create (publish) and update operations.
 type ManualProcessPayload struct {
 	TracingContext
-	RequestId       string `json:"request_id"`
-	TenantID        uint64 `json:"tenant_id"`
-	KnowledgeID     string `json:"knowledge_id"`
-	KnowledgeBaseID string `json:"knowledge_base_id"`
-	Content         string `json:"content"`      // cleaned markdown content
-	NeedCleanup     bool   `json:"need_cleanup"` // true for update, false for create
+	RequestId             string `json:"request_id"`
+	TenantID              uint64 `json:"tenant_id"`
+	KnowledgeID           string `json:"knowledge_id"`
+	KnowledgeBaseID       string `json:"knowledge_base_id"`
+	Content               string `json:"content"`      // cleaned markdown content
+	NeedCleanup           bool   `json:"need_cleanup"` // true for update, false for create
+	ReuseUnchangedChunks  bool   `json:"reuse_unchanged_chunks,omitempty"`
+	AllowLegacyChunkReuse bool   `json:"allow_legacy_chunk_reuse,omitempty"`
+	ReindexReusedChunks   bool   `json:"reindex_reused_chunks,omitempty"`
 }
 
 // ImageMultimodalPayload represents the image multimodal processing task payload.

--- a/internal/types/wiki_map_cache.go
+++ b/internal/types/wiki_map_cache.go
@@ -1,0 +1,29 @@
+package types
+
+import "time"
+
+const (
+	// WikiMapCacheSchemaVersion bumps when cached Wiki map payload semantics
+	// change. It is part of every key so old rows become cold misses.
+	WikiMapCacheSchemaVersion = "wiki_map_v1"
+)
+
+// WikiMapCache stores deterministic LLM outputs from the per-document Wiki map
+// phase. Reduce/merge stays uncached because it depends on current KB state.
+type WikiMapCache struct {
+	ID         uint64    `json:"id" gorm:"primaryKey;autoIncrement"`
+	TenantID   uint64    `json:"tenant_id" gorm:"index;not null;uniqueIndex:idx_wiki_map_cache_key"`
+	CacheKey   string    `json:"cache_key" gorm:"type:varchar(64);not null;uniqueIndex:idx_wiki_map_cache_key"`
+	Kind       string    `json:"kind" gorm:"type:varchar(64);not null;index"`
+	ContentKey string    `json:"content_key" gorm:"type:varchar(64);not null;index"`
+	ModelID    string    `json:"model_id" gorm:"type:varchar(128);not null;default:''"`
+	ConfigHash string    `json:"config_hash" gorm:"type:varchar(64);not null"`
+	SchemaVer  string    `json:"schema_ver" gorm:"type:varchar(32);not null"`
+	Payload    JSON      `json:"payload" gorm:"type:jsonb;not null"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+func (WikiMapCache) TableName() string {
+	return "wiki_map_caches"
+}

--- a/migrations/sqlite/000000_init.down.sql
+++ b/migrations/sqlite/000000_init.down.sql
@@ -20,6 +20,7 @@ DROP TABLE IF EXISTS auth_tokens;
 DROP TABLE IF EXISTS audit_logs;
 DROP TABLE IF EXISTS tenant_members;
 DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS graph_extraction_caches;
 DROP TABLE IF EXISTS chunks;
 DROP TABLE IF EXISTS messages;
 DROP TABLE IF EXISTS temporary_documents;

--- a/migrations/sqlite/000000_init.down.sql
+++ b/migrations/sqlite/000000_init.down.sql
@@ -20,6 +20,7 @@ DROP TABLE IF EXISTS auth_tokens;
 DROP TABLE IF EXISTS audit_logs;
 DROP TABLE IF EXISTS tenant_members;
 DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS image_multimodal_caches;
 DROP TABLE IF EXISTS wiki_map_caches;
 DROP TABLE IF EXISTS graph_extraction_caches;
 DROP TABLE IF EXISTS chunks;

--- a/migrations/sqlite/000000_init.down.sql
+++ b/migrations/sqlite/000000_init.down.sql
@@ -20,6 +20,7 @@ DROP TABLE IF EXISTS auth_tokens;
 DROP TABLE IF EXISTS audit_logs;
 DROP TABLE IF EXISTS tenant_members;
 DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS wiki_map_caches;
 DROP TABLE IF EXISTS graph_extraction_caches;
 DROP TABLE IF EXISTS chunks;
 DROP TABLE IF EXISTS messages;

--- a/migrations/sqlite/000000_init.up.sql
+++ b/migrations/sqlite/000000_init.up.sql
@@ -297,6 +297,25 @@ CREATE TABLE IF NOT EXISTS chunk_revisions (
 );
 CREATE INDEX IF NOT EXISTS idx_chunk_revisions_tenant_chunk ON chunk_revisions(tenant_id, chunk_id);
 
+CREATE TABLE IF NOT EXISTS graph_extraction_caches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id INTEGER NOT NULL,
+    cache_key VARCHAR(64) NOT NULL,
+    content_key VARCHAR(64) NOT NULL,
+    model_id VARCHAR(128) NOT NULL DEFAULT '',
+    config_hash VARCHAR(64) NOT NULL,
+    schema_ver VARCHAR(32) NOT NULL,
+    graph TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, cache_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_graph_extraction_caches_content_key
+    ON graph_extraction_caches(content_key);
+CREATE INDEX IF NOT EXISTS idx_graph_extraction_caches_tenant_model
+    ON graph_extraction_caches(tenant_id, model_id);
+
 CREATE TABLE IF NOT EXISTS users (
     id VARCHAR(36) PRIMARY KEY,
     username VARCHAR(100) NOT NULL UNIQUE,

--- a/migrations/sqlite/000000_init.up.sql
+++ b/migrations/sqlite/000000_init.up.sql
@@ -336,6 +336,25 @@ CREATE INDEX IF NOT EXISTS idx_wiki_map_caches_kind_content
 CREATE INDEX IF NOT EXISTS idx_wiki_map_caches_tenant_kind_model
     ON wiki_map_caches(tenant_id, kind, model_id);
 
+CREATE TABLE IF NOT EXISTS image_multimodal_caches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id INTEGER NOT NULL,
+    cache_key VARCHAR(64) NOT NULL,
+    content_key VARCHAR(64) NOT NULL,
+    model_id VARCHAR(128) NOT NULL DEFAULT '',
+    config_hash VARCHAR(64) NOT NULL,
+    schema_ver VARCHAR(32) NOT NULL,
+    payload TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, cache_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_image_multimodal_caches_content_key
+    ON image_multimodal_caches(content_key);
+CREATE INDEX IF NOT EXISTS idx_image_multimodal_caches_tenant_model
+    ON image_multimodal_caches(tenant_id, model_id);
+
 CREATE TABLE IF NOT EXISTS users (
     id VARCHAR(36) PRIMARY KEY,
     username VARCHAR(100) NOT NULL UNIQUE,

--- a/migrations/sqlite/000000_init.up.sql
+++ b/migrations/sqlite/000000_init.up.sql
@@ -316,6 +316,26 @@ CREATE INDEX IF NOT EXISTS idx_graph_extraction_caches_content_key
 CREATE INDEX IF NOT EXISTS idx_graph_extraction_caches_tenant_model
     ON graph_extraction_caches(tenant_id, model_id);
 
+CREATE TABLE IF NOT EXISTS wiki_map_caches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id INTEGER NOT NULL,
+    cache_key VARCHAR(64) NOT NULL,
+    kind VARCHAR(64) NOT NULL,
+    content_key VARCHAR(64) NOT NULL,
+    model_id VARCHAR(128) NOT NULL DEFAULT '',
+    config_hash VARCHAR(64) NOT NULL,
+    schema_ver VARCHAR(32) NOT NULL,
+    payload TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, cache_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wiki_map_caches_kind_content
+    ON wiki_map_caches(kind, content_key);
+CREATE INDEX IF NOT EXISTS idx_wiki_map_caches_tenant_kind_model
+    ON wiki_map_caches(tenant_id, kind, model_id);
+
 CREATE TABLE IF NOT EXISTS users (
     id VARCHAR(36) PRIMARY KEY,
     username VARCHAR(100) NOT NULL UNIQUE,

--- a/migrations/sqlite/000079_graph_extraction_cache.down.sql
+++ b/migrations/sqlite/000079_graph_extraction_cache.down.sql
@@ -1,0 +1,2 @@
+-- Roll back migration 000079_graph_extraction_cache.
+DROP TABLE IF EXISTS graph_extraction_caches;

--- a/migrations/sqlite/000079_graph_extraction_cache.up.sql
+++ b/migrations/sqlite/000079_graph_extraction_cache.up.sql
@@ -1,0 +1,20 @@
+-- Migration: 000079_graph_extraction_cache
+CREATE TABLE IF NOT EXISTS graph_extraction_caches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id INTEGER NOT NULL,
+    cache_key VARCHAR(64) NOT NULL,
+    content_key VARCHAR(64) NOT NULL,
+    model_id VARCHAR(128) NOT NULL DEFAULT '',
+    config_hash VARCHAR(64) NOT NULL,
+    schema_ver VARCHAR(32) NOT NULL,
+    graph TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, cache_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_graph_extraction_caches_content_key
+    ON graph_extraction_caches(content_key);
+
+CREATE INDEX IF NOT EXISTS idx_graph_extraction_caches_tenant_model
+    ON graph_extraction_caches(tenant_id, model_id);

--- a/migrations/sqlite/000080_wiki_map_cache.down.sql
+++ b/migrations/sqlite/000080_wiki_map_cache.down.sql
@@ -1,0 +1,2 @@
+-- Roll back migration 000080_wiki_map_cache.
+DROP TABLE IF EXISTS wiki_map_caches;

--- a/migrations/sqlite/000080_wiki_map_cache.up.sql
+++ b/migrations/sqlite/000080_wiki_map_cache.up.sql
@@ -1,0 +1,21 @@
+-- Migration: 000080_wiki_map_cache
+CREATE TABLE IF NOT EXISTS wiki_map_caches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id INTEGER NOT NULL,
+    cache_key VARCHAR(64) NOT NULL,
+    kind VARCHAR(64) NOT NULL,
+    content_key VARCHAR(64) NOT NULL,
+    model_id VARCHAR(128) NOT NULL DEFAULT '',
+    config_hash VARCHAR(64) NOT NULL,
+    schema_ver VARCHAR(32) NOT NULL,
+    payload TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, cache_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wiki_map_caches_kind_content
+    ON wiki_map_caches(kind, content_key);
+
+CREATE INDEX IF NOT EXISTS idx_wiki_map_caches_tenant_kind_model
+    ON wiki_map_caches(tenant_id, kind, model_id);

--- a/migrations/sqlite/000081_image_multimodal_cache.down.sql
+++ b/migrations/sqlite/000081_image_multimodal_cache.down.sql
@@ -1,0 +1,2 @@
+-- Roll back migration 000081_image_multimodal_cache.
+DROP TABLE IF EXISTS image_multimodal_caches;

--- a/migrations/sqlite/000081_image_multimodal_cache.up.sql
+++ b/migrations/sqlite/000081_image_multimodal_cache.up.sql
@@ -1,0 +1,20 @@
+-- Migration: 000081_image_multimodal_cache
+CREATE TABLE IF NOT EXISTS image_multimodal_caches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id INTEGER NOT NULL,
+    cache_key VARCHAR(64) NOT NULL,
+    content_key VARCHAR(64) NOT NULL,
+    model_id VARCHAR(128) NOT NULL DEFAULT '',
+    config_hash VARCHAR(64) NOT NULL,
+    schema_ver VARCHAR(32) NOT NULL,
+    payload TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, cache_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_image_multimodal_caches_content_key
+    ON image_multimodal_caches(content_key);
+
+CREATE INDEX IF NOT EXISTS idx_image_multimodal_caches_tenant_model
+    ON image_multimodal_caches(tenant_id, model_id);

--- a/migrations/sqlite/000082_document_parse_cache.down.sql
+++ b/migrations/sqlite/000082_document_parse_cache.down.sql
@@ -1,0 +1,2 @@
+-- Migration: 000082_document_parse_cache rollback
+DROP TABLE IF EXISTS document_parse_caches;

--- a/migrations/sqlite/000082_document_parse_cache.up.sql
+++ b/migrations/sqlite/000082_document_parse_cache.up.sql
@@ -1,0 +1,18 @@
+-- Migration: 000082_document_parse_cache
+CREATE TABLE IF NOT EXISTS document_parse_caches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id INTEGER NOT NULL,
+    knowledge_id VARCHAR(36) NOT NULL,
+    cache_key VARCHAR(64) NOT NULL,
+    content_key VARCHAR(128) NOT NULL,
+    config_hash VARCHAR(64) NOT NULL,
+    schema_ver VARCHAR(32) NOT NULL,
+    payload TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, knowledge_id),
+    FOREIGN KEY (knowledge_id) REFERENCES knowledges(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_parse_caches_key
+    ON document_parse_caches(tenant_id, cache_key);

--- a/migrations/versioned/000079_graph_extraction_cache.down.sql
+++ b/migrations/versioned/000079_graph_extraction_cache.down.sql
@@ -1,0 +1,2 @@
+-- Roll back migration 000079_graph_extraction_cache.
+DROP TABLE IF EXISTS graph_extraction_caches;

--- a/migrations/versioned/000079_graph_extraction_cache.up.sql
+++ b/migrations/versioned/000079_graph_extraction_cache.up.sql
@@ -1,0 +1,29 @@
+-- Migration: 000079_graph_extraction_cache
+--
+-- Cache deterministic GraphRAG per-chunk extraction results. The cached value
+-- is the LLM-produced graph JSON only; graph storage is still rebuilt into the
+-- current knowledge namespace on every parse/reparse.
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000079] Creating table: graph_extraction_caches'; END $$;
+
+CREATE TABLE IF NOT EXISTS graph_extraction_caches (
+    id          BIGSERIAL PRIMARY KEY,
+    tenant_id   BIGINT NOT NULL,
+    cache_key   VARCHAR(64) NOT NULL,
+    content_key VARCHAR(64) NOT NULL,
+    model_id    VARCHAR(128) NOT NULL DEFAULT '',
+    config_hash VARCHAR(64) NOT NULL,
+    schema_ver  VARCHAR(32) NOT NULL,
+    graph       JSONB NOT NULL,
+    created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_graph_extraction_caches_tenant_key UNIQUE (tenant_id, cache_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_graph_extraction_caches_content_key
+    ON graph_extraction_caches (content_key);
+
+CREATE INDEX IF NOT EXISTS idx_graph_extraction_caches_tenant_model
+    ON graph_extraction_caches (tenant_id, model_id);
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000079] graph_extraction_caches table ready'; END $$;

--- a/migrations/versioned/000080_wiki_map_cache.down.sql
+++ b/migrations/versioned/000080_wiki_map_cache.down.sql
@@ -1,0 +1,2 @@
+-- Roll back migration 000080_wiki_map_cache.
+DROP TABLE IF EXISTS wiki_map_caches;

--- a/migrations/versioned/000080_wiki_map_cache.up.sql
+++ b/migrations/versioned/000080_wiki_map_cache.up.sql
@@ -1,0 +1,30 @@
+-- Migration: 000080_wiki_map_cache
+--
+-- Cache deterministic LLM outputs from the per-document Wiki map phase.
+-- Wiki reduce/merge is intentionally uncached because it depends on current
+-- knowledge-base page state.
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000080] Creating table: wiki_map_caches'; END $$;
+
+CREATE TABLE IF NOT EXISTS wiki_map_caches (
+    id          BIGSERIAL PRIMARY KEY,
+    tenant_id   BIGINT NOT NULL,
+    cache_key   VARCHAR(64) NOT NULL,
+    kind        VARCHAR(64) NOT NULL,
+    content_key VARCHAR(64) NOT NULL,
+    model_id    VARCHAR(128) NOT NULL DEFAULT '',
+    config_hash VARCHAR(64) NOT NULL,
+    schema_ver  VARCHAR(32) NOT NULL,
+    payload     JSONB NOT NULL,
+    created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_wiki_map_caches_tenant_key UNIQUE (tenant_id, cache_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wiki_map_caches_kind_content
+    ON wiki_map_caches (kind, content_key);
+
+CREATE INDEX IF NOT EXISTS idx_wiki_map_caches_tenant_kind_model
+    ON wiki_map_caches (tenant_id, kind, model_id);
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000080] wiki_map_caches table ready'; END $$;

--- a/migrations/versioned/000081_image_multimodal_cache.down.sql
+++ b/migrations/versioned/000081_image_multimodal_cache.down.sql
@@ -1,0 +1,2 @@
+-- Roll back migration 000081_image_multimodal_cache.
+DROP TABLE IF EXISTS image_multimodal_caches;

--- a/migrations/versioned/000081_image_multimodal_cache.up.sql
+++ b/migrations/versioned/000081_image_multimodal_cache.up.sql
@@ -1,0 +1,29 @@
+-- Migration: 000081_image_multimodal_cache
+--
+-- Cache deterministic OCR/caption outputs for document images. The key is
+-- derived from image bytes + VLM model/config + prompt schema so reparses can
+-- reuse expensive VLM calls without coupling cache rows to chunk IDs.
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000081] Creating table: image_multimodal_caches'; END $$;
+
+CREATE TABLE IF NOT EXISTS image_multimodal_caches (
+    id          BIGSERIAL PRIMARY KEY,
+    tenant_id   BIGINT NOT NULL,
+    cache_key   VARCHAR(64) NOT NULL,
+    content_key VARCHAR(64) NOT NULL,
+    model_id    VARCHAR(128) NOT NULL DEFAULT '',
+    config_hash VARCHAR(64) NOT NULL,
+    schema_ver  VARCHAR(32) NOT NULL,
+    payload     JSONB NOT NULL,
+    created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_image_multimodal_caches_tenant_key UNIQUE (tenant_id, cache_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_image_multimodal_caches_content_key
+    ON image_multimodal_caches (content_key);
+
+CREATE INDEX IF NOT EXISTS idx_image_multimodal_caches_tenant_model
+    ON image_multimodal_caches (tenant_id, model_id);
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000081] image_multimodal_caches table ready'; END $$;

--- a/migrations/versioned/000082_document_parse_cache.down.sql
+++ b/migrations/versioned/000082_document_parse_cache.down.sql
@@ -1,0 +1,2 @@
+-- Migration: 000082_document_parse_cache rollback
+DROP TABLE IF EXISTS document_parse_caches;

--- a/migrations/versioned/000082_document_parse_cache.up.sql
+++ b/migrations/versioned/000082_document_parse_cache.up.sql
@@ -1,0 +1,26 @@
+-- Migration: 000082_document_parse_cache
+-- Store the latest resolved parser artifact for each knowledge so an unchanged
+-- reparse can reuse Markdown and already-persisted image resources.
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000082] Creating table: document_parse_caches'; END $$;
+
+CREATE TABLE IF NOT EXISTS document_parse_caches (
+    id           BIGSERIAL PRIMARY KEY,
+    tenant_id    BIGINT NOT NULL,
+    knowledge_id VARCHAR(36) NOT NULL,
+    cache_key    VARCHAR(64) NOT NULL,
+    content_key  VARCHAR(128) NOT NULL,
+    config_hash  VARCHAR(64) NOT NULL,
+    schema_ver   VARCHAR(32) NOT NULL,
+    payload      JSONB NOT NULL,
+    created_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_document_parse_caches_knowledge UNIQUE (tenant_id, knowledge_id),
+    CONSTRAINT fk_document_parse_caches_knowledge FOREIGN KEY (knowledge_id)
+        REFERENCES knowledges(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_parse_caches_key
+    ON document_parse_caches (tenant_id, cache_key);
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000082] document_parse_caches table ready'; END $$;


### PR DESCRIPTION
## Description

  Fixes #1679

  This PR reduces repeated rebuild cost by reusing deterministic intermediate outputs when a document is reprocessed.

  Changes include:
  - Reuse unchanged text chunks, embeddings, generated questions, and question embeddings during rebuilds.
  - Cache GraphRAG per-chunk extraction results by stable extraction keys.
  - Cache wiki per-document map outputs, including candidate slugs, document summary, and chunk citation mapping.
  - Cache image multimodal OCR/caption outputs for identical image bytes and VLM configuration.
  - Include schema, prompt, model, and relevant state inputs in cache keys.
  - Stabilize wiki cache keys by sorting slug inputs.
  - Include `PreviousSlugs` in wiki cache keys to avoid stale slug  reuse across different wiki states.
  - Reconcile wiki ingest enqueue failures so knowledge does not remain stuck in `finalizing`.
  - Clean up only the newly inserted wiki pending op if trigger  enqueue fails.
  - Add processing span metadata for cache hits/misses to make rebuild reuse observable.
  - Expand `knowledge_processing_spans.name` length to support  longer graph/wiki span names.

  ## Type of Change

  - [ ] 🐛 Bug fix
  - [x] ✨ New feature
  - [ ] 💥 Breaking change
  - [ ] 📚 Documentation update
  - [ ] 🎨 Refactor
  - [x] ⚡ Performance improvement
  - [x] 🧪 Test
  - [ ] 🔧 Configuration / Build / CI

  ## Related Issue

  Fixes #1679

  ## Testing

  - Verified rebuild flow locally with Docker.
  - Confirmed unchanged chunks were reused:
    - `chunks_reused=38`
    - `vectors_reused=38`
    - `vectors_written=0`
  - Confirmed GraphRAG cache reuse through processing spans:
    - 37/38 graph chunks hit cache in the tested document.
    - The remaining chunk had no reusable cache entry because the  model returned invalid JSON for OCR-noisy text.
  - Confirmed wiki map cache reuse through processing spans:
    - `postprocess.wiki.extract`: `cache_hit=true`
    - `postprocess.wiki.summary`: `cache_hit=true`
    - `postprocess.wiki.classify`: `cache_hits=2`, `cache_misses=0`
  - Verified image multimodal OCR/caption cache key behavior with  unit coverage.
  - Ran `git diff --check`.
  - Ran `make fmt` successfully.
  - `make test` was attempted, but several existing tests failed because the current environment disallows local socket/listener creation (`socket: operation not permitted`), and Go cache trimming failed due to a read-only cache directory.
  - Verified rebuild cache behavior with Docker, including chunk vector reuse, GraphRAG cache hits, and wiki map cache hits.

  ## Checklist

  - [ ] `make fmt && make lint && make test` pass locally
  - [x] Self-reviewed the code
  - [x] Added/updated tests covering the change
  - [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
  - [ ] Breaking changes are clearly called out in the description above

  ## Screenshots / Recordings

  N/A. No user-visible UI changes.