### PR TITLE
fix(security): block SSRF in knowledge import, web_fetch, and datasource connectors

### DIFF
--- a/docreader/parser/web_parser.py
+++ b/docreader/parser/web_parser.py
@@ -14,6 +14,7 @@ from docreader.parser.base_parser import BaseParser
 from docreader.parser.chain_parser import PipelineParser
 from docreader.parser.markdown_parser import MarkdownParser
 from docreader.utils import endecode
+from docreader.utils.ssrf import is_ssrf_safe_url
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +123,22 @@ async def read_visible_text(page: Page) -> str:
     )
 
 
+async def install_ssrf_route_guard(page: Page) -> None:
+    """Block navigation/subresource requests to SSRF-restricted targets (incl. redirects)."""
+
+    async def handle_route(route) -> None:
+        safe, reason = is_ssrf_safe_url(route.request.url)
+        if not safe:
+            logger.warning(
+                "SSRF guard blocked request to %s: %s", route.request.url, reason
+            )
+            await route.abort("blockedbyclient")
+            return
+        await route.continue_()
+
+    await page.route("**/*", handle_route)
+
+
 class StdWebParser(BaseParser):
     """Standard web page parser using Playwright and Trafilatura.
 
@@ -154,6 +171,10 @@ class StdWebParser(BaseParser):
         """
         logger.info(f"Starting web page scraping for URL: {url}")
         empty = _ScrapeResult(html="", visible_text="", page_title="")
+        safe, reason = is_ssrf_safe_url(url)
+        if not safe:
+            logger.error("URL blocked by SSRF guard before navigation: %s", reason)
+            return empty
         try:
             async with async_playwright() as p:
                 kwargs = {}
@@ -163,6 +184,7 @@ class StdWebParser(BaseParser):
                 logger.info("Launching WebKit browser")
                 browser = await p.webkit.launch(**kwargs)
                 page = await browser.new_page()
+                await install_ssrf_route_guard(page)
 
                 logger.info(f"Navigating to URL: {url}")
                 try:

--- a/docreader/tests/test_ssrf.py
+++ b/docreader/tests/test_ssrf.py
@@ -1,0 +1,46 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from docreader.utils.ssrf import is_ssrf_safe_url, reset_ssrf_whitelist_cache_for_test
+
+
+class TestSSRFValidation(unittest.TestCase):
+    def setUp(self) -> None:
+        self._env_patch = patch.dict(
+            os.environ,
+            {"SSRF_WHITELIST": "", "SSRF_WHITELIST_EXTRA": ""},
+            clear=False,
+        )
+        self._env_patch.start()
+        reset_ssrf_whitelist_cache_for_test()
+
+    def tearDown(self) -> None:
+        self._env_patch.stop()
+        reset_ssrf_whitelist_cache_for_test()
+
+    def test_blocks_loopback_ip(self):
+        safe, reason = is_ssrf_safe_url("http://127.0.0.1:8080/page")
+        self.assertFalse(safe)
+        self.assertTrue(reason)
+
+    def test_blocks_restricted_hostname(self):
+        safe, reason = is_ssrf_safe_url("http://host.docker.internal/secret")
+        self.assertFalse(safe)
+        self.assertIn("restricted", reason)
+
+    def test_blocks_metadata_host(self):
+        safe, reason = is_ssrf_safe_url(
+            "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+        )
+        self.assertFalse(safe)
+        self.assertTrue(reason)
+
+    def test_allows_public_https(self):
+        safe, reason = is_ssrf_safe_url("https://example.com/article")
+        self.assertTrue(safe, reason)
+        self.assertEqual(reason, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docreader/tests/test_web_parser.py
+++ b/docreader/tests/test_web_parser.py
@@ -1,12 +1,29 @@
+import os
 import unittest
+from unittest.mock import patch
 
 from docreader.parser.web_parser import (
     build_visible_text_fallback,
     extract_markdown_from_html,
+    install_ssrf_route_guard,
 )
+from docreader.utils.ssrf import is_ssrf_safe_url, reset_ssrf_whitelist_cache_for_test
 
 
 class TestWebParserHelpers(unittest.TestCase):
+    def setUp(self) -> None:
+        self._env_patch = patch.dict(
+            os.environ,
+            {"SSRF_WHITELIST": "", "SSRF_WHITELIST_EXTRA": ""},
+            clear=False,
+        )
+        self._env_patch.start()
+        reset_ssrf_whitelist_cache_for_test()
+
+    def tearDown(self) -> None:
+        self._env_patch.stop()
+        reset_ssrf_whitelist_cache_for_test()
+
     def test_extract_markdown_empty_html(self):
         self.assertIsNone(extract_markdown_from_html(""))
         self.assertIsNone(extract_markdown_from_html("   "))
@@ -36,6 +53,14 @@ class TestWebParserHelpers(unittest.TestCase):
         text = "B" * 60
         md = build_visible_text_fallback(text, page_title="")
         self.assertEqual(md, text)
+
+    def test_install_ssrf_route_guard_is_importable(self):
+        self.assertTrue(callable(install_ssrf_route_guard))
+
+    def test_redirect_target_blocked_before_navigation(self):
+        safe, reason = is_ssrf_safe_url("http://127.0.0.1:39127/audit.txt")
+        self.assertFalse(safe)
+        self.assertTrue(reason)
 
 
 if __name__ == "__main__":

--- a/docreader/utils/ssrf.py
+++ b/docreader/utils/ssrf.py
@@ -1,0 +1,250 @@
+"""SSRF URL validation for docreader outbound HTTP requests.
+
+Mirrors the core policy in internal/utils/security.go so redirect targets
+during Playwright navigation are blocked the same way as Go-side imports.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import re
+import socket
+from functools import lru_cache
+from typing import FrozenSet, Optional, Tuple, Union
+from urllib.parse import urlparse
+
+RESTRICTED_HOSTNAMES: FrozenSet[str] = frozenset(
+    {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "0.0.0.0",
+        "metadata.google.internal",
+        "metadata.tencentyun.com",
+        "metadata.aws.internal",
+        "host.docker.internal",
+        "gateway.docker.internal",
+        "kubernetes.docker.internal",
+        "kubernetes",
+        "kubernetes.default",
+        "kubernetes.default.svc",
+        "kubernetes.default.svc.cluster.local",
+    }
+)
+
+RESTRICTED_SUFFIXES: Tuple[str, ...] = (
+    ".local",
+    ".localhost",
+    ".internal",
+    ".corp",
+    ".lan",
+    ".home",
+    ".localdomain",
+    ".svc.cluster.local",
+    ".pod.cluster.local",
+)
+
+EXTRA_RESTRICTED_CIDRS: Tuple[Union[ipaddress.IPv4Network, ipaddress.IPv6Network], ...] = tuple(
+    ipaddress.ip_network(cidr)
+    for cidr in (
+        "100.64.0.0/10",
+        "198.18.0.0/15",
+        "198.51.100.0/24",
+        "203.0.113.0/24",
+        "192.0.0.0/24",
+        "192.0.2.0/24",
+        "0.0.0.0/8",
+        "240.0.0.0/4",
+        "255.255.255.255/32",
+        "172.17.0.0/16",
+        "172.18.0.0/16",
+        "172.19.0.0/16",
+        "172.20.0.0/16",
+    )
+)
+
+BLOCKED_PORTS: FrozenSet[str] = frozenset(
+    {
+        "22",
+        "23",
+        "25",
+        "445",
+        "3389",
+        "5432",
+        "3306",
+        "6379",
+        "27017",
+        "9200",
+        "2379",
+        "2380",
+        "8500",
+        "4001",
+    }
+)
+
+_IP_LIKE_PATTERNS = (
+    re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$"),
+    re.compile(r"^\d{8,10}$"),
+    re.compile(r"^0[0-7]+\."),
+    re.compile(r"(?i)^0x[0-9a-f]+\."),
+    re.compile(r"(?i)^0x[0-9a-f]{6,8}$"),
+    re.compile(r"(?i)^[0-9a-f:]+::[0-9a-f:]*$"),
+    re.compile(r"(?i)^[0-9a-f]{1,4}(:[0-9a-f]{1,4}){7}$"),
+)
+
+
+def _normalize_url(raw_url: str) -> str:
+    if "://" not in raw_url:
+        return f"https://{raw_url}"
+    return raw_url
+
+
+@lru_cache(maxsize=1)
+def _load_whitelist() -> Tuple[FrozenSet[str], Tuple[str, ...], Tuple[Union[ipaddress.IPv4Network, ipaddress.IPv6Network], ...]]:
+    entries: list[str] = []
+    for env_key in ("SSRF_WHITELIST", "SSRF_WHITELIST_EXTRA"):
+        raw = os.environ.get(env_key, "")
+        if raw.strip():
+            entries.extend(part.strip() for part in raw.split(",") if part.strip())
+
+    exact_hosts: set[str] = set()
+    suffix_hosts: list[str] = []
+    cidr_nets: list[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]] = []
+    for entry in entries:
+        lowered = entry.lower()
+        if lowered.startswith("*."):
+            suffix_hosts.append(lowered[1:])
+            continue
+        if "/" in lowered:
+            try:
+                cidr_nets.append(ipaddress.ip_network(lowered, strict=False))
+            except ValueError:
+                continue
+            continue
+        exact_hosts.add(lowered)
+    return frozenset(exact_hosts), tuple(suffix_hosts), tuple(cidr_nets)
+
+
+def _is_whitelisted(hostname: str) -> bool:
+    lowered = hostname.lower()
+    exact_hosts, suffix_hosts, cidr_nets = _load_whitelist()
+    if lowered in exact_hosts:
+        return True
+    for suffix in suffix_hosts:
+        if lowered.endswith(suffix) or lowered == suffix.lstrip("."):
+            return True
+    try:
+        ip = ipaddress.ip_address(lowered)
+    except ValueError:
+        return False
+    return any(ip in net for net in cidr_nets)
+
+
+def _is_ip_like_hostname(hostname: str) -> bool:
+    return any(pattern.search(hostname) for pattern in _IP_LIKE_PATTERNS)
+
+
+def _is_restricted_ip(ip: Union[ipaddress.IPv4Address, ipaddress.IPv6Address]) -> Optional[str]:
+    if ip.is_private:
+        return "private IP address"
+    if ip.is_loopback:
+        return "loopback address"
+    if ip.is_link_local:
+        return "link-local address"
+    if ip.is_multicast:
+        return "multicast address"
+    if ip.is_unspecified:
+        return "unspecified address"
+    if isinstance(ip, ipaddress.IPv4Address):
+        for net in EXTRA_RESTRICTED_CIDRS:
+            if isinstance(net, ipaddress.IPv4Network) and ip in net:
+                return f"restricted range {net}"
+    if isinstance(ip, ipaddress.IPv6Address):
+        # Site-local (fec0::/10)
+        if (ip.packed[0] == 0xFE) and (ip.packed[1] & 0xC0) == 0xC0:
+            return "site-local IPv6 address"
+    return None
+
+
+def _resolve_host_ips(hostname: str) -> Tuple[Tuple[Union[ipaddress.IPv4Address, ipaddress.IPv6Address], ...], Optional[str]]:
+    try:
+        infos = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        return (), f"DNS resolution failed for hostname {hostname}: {exc}"
+    ips: list[Union[ipaddress.IPv4Address, ipaddress.IPv6Address]] = []
+    seen: set[str] = set()
+    for info in infos:
+        sockaddr = info[4]
+        if not sockaddr:
+            continue
+        ip_str = sockaddr[0]
+        if ip_str in seen:
+            continue
+        seen.add(ip_str)
+        try:
+            ips.append(ipaddress.ip_address(ip_str))
+        except ValueError:
+            continue
+    if not ips:
+        return (), f"DNS resolution failed for hostname {hostname}: no addresses"
+    return tuple(ips), None
+
+
+def is_ssrf_safe_url(raw_url: str) -> Tuple[bool, str]:
+    """Return (safe, reason). reason is empty when safe is True."""
+    if not raw_url or not raw_url.strip():
+        return False, "URL is empty"
+
+    normalized = _normalize_url(raw_url.strip())
+    parsed = urlparse(normalized)
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in {"http", "https"}:
+        return False, f"invalid scheme: {scheme or '(none)'} (only http/https allowed)"
+
+    hostname = (parsed.hostname or "").strip()
+    if not hostname:
+        return False, "URL has no hostname"
+
+    hostname_lower = hostname.lower()
+    if _is_whitelisted(hostname_lower):
+        return True, ""
+
+    if hostname_lower in RESTRICTED_HOSTNAMES:
+        return False, f"hostname {hostname_lower} is restricted"
+
+    for suffix in RESTRICTED_SUFFIXES:
+        if hostname_lower.endswith(suffix):
+            return False, f"hostname suffix {suffix} is restricted"
+
+    try:
+        ipaddress.ip_address(hostname_lower)
+        return False, "direct IP address access is not allowed, use domain name or add to SSRF_WHITELIST"
+    except ValueError:
+        pass
+
+    if _is_ip_like_hostname(hostname_lower):
+        return False, "IP-like hostname format is not allowed"
+
+    resolved_ips, resolve_err = _resolve_host_ips(hostname_lower)
+    if resolve_err:
+        return False, resolve_err
+
+    for resolved_ip in resolved_ips:
+        reason = _is_restricted_ip(resolved_ip)
+        if reason:
+            return (
+                False,
+                f"hostname {hostname_lower} resolves to restricted IP {resolved_ip}: {reason}",
+            )
+
+    port = parsed.port
+    if port is not None and str(port) in BLOCKED_PORTS:
+        return False, f"port {port} is blocked for security reasons"
+
+    return True, ""
+
+
+def reset_ssrf_whitelist_cache_for_test() -> None:
+    """Clear cached whitelist entries (for unit tests only)."""
+    _load_whitelist.cache_clear()

--- a/internal/application/service/knowledge_util.go
+++ b/internal/application/service/knowledge_util.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
 
 // isValidFileType checks if a file type is supported
@@ -336,7 +337,10 @@ func IsVideoType(fileType string) bool {
 // the function resolves the value from Content-Disposition / URL path and writes it back.
 // It does NOT perform SSRF validation — callers are responsible for that.
 func downloadFileFromURL(ctx context.Context, fileURL string, payloadFileName, payloadFileType *string) ([]byte, error) {
-	httpClient := &http.Client{Timeout: 60 * time.Second}
+	httpClient := secutils.NewSSRFSafeHTTPClient(secutils.SSRFSafeHTTPClientConfig{
+		Timeout:      60 * time.Second,
+		MaxRedirects: 10,
+	})
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for file URL: %w", err)

--- a/internal/application/service/knowledge_util_ssrf_test.go
+++ b/internal/application/service/knowledge_util_ssrf_test.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	secutils "github.com/Tencent/WeKnora/internal/utils"
+)
+
+func TestDownloadFileFromURLBlocksRedirectToLoopback(t *testing.T) {
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("INTERNAL_SECRET=metadata-token-AKIAEXAMPLE"))
+	}))
+	defer internal.Close()
+
+	if err := secutils.ValidateURLForSSRF(internal.URL); err == nil {
+		t.Fatalf("precondition: direct internal URL should be blocked")
+	}
+
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, internal.URL, http.StatusFound)
+	}))
+	defer attacker.Close()
+
+	attackerURL := attacker.URL + "/malicious.pdf"
+	fileName := ""
+	fileType := "pdf"
+	_, err := downloadFileFromURL(context.Background(), attackerURL, &fileName, &fileType)
+	if err == nil {
+		t.Fatal("expected redirect to loopback to be blocked")
+	}
+	if !strings.Contains(err.Error(), "redirect blocked") && !strings.Contains(err.Error(), "connection blocked") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/datasource/connector/feishu/client.go
+++ b/internal/datasource/connector/feishu/client.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Tencent/WeKnora/internal/datasource"
 	"github.com/Tencent/WeKnora/internal/logger"
 )
 
@@ -55,7 +56,7 @@ func NewClient(config *Config) *Client {
 		baseURL:    config.GetBaseURL(),
 		appID:      config.AppID,
 		appSecret:  config.AppSecret,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: datasource.NewConnectorHTTPClient(30 * time.Second),
 	}
 }
 

--- a/internal/datasource/connector/feishu/connector.go
+++ b/internal/datasource/connector/feishu/connector.go
@@ -10,6 +10,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/Tencent/WeKnora/internal/datasource"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
 )
@@ -497,6 +498,10 @@ func parseFeishuConfig(config *types.DataSourceConfig) (*Config, error) {
 
 	if feishuConfig.AppID == "" || feishuConfig.AppSecret == "" {
 		return nil, fmt.Errorf("feishu app_id and app_secret are required")
+	}
+
+	if err := datasource.ValidateConnectorBaseURL(feishuConfig.GetBaseURL()); err != nil {
+		return nil, err
 	}
 
 	return &feishuConfig, nil

--- a/internal/datasource/connector/feishu/connector_test.go
+++ b/internal/datasource/connector/feishu/connector_test.go
@@ -6,13 +6,21 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
 	"unicode/utf8"
 
+	secutils "github.com/Tencent/WeKnora/internal/utils"
 	"github.com/Tencent/WeKnora/internal/types"
 )
+
+func TestMain(m *testing.M) {
+	os.Setenv("SSRF_WHITELIST", "127.0.0.1,localhost")
+	secutils.ResetSSRFWhitelistForTest()
+	os.Exit(m.Run())
+}
 
 // ──────────────────────────────────────────────────────────────────────
 // Fake Feishu API server
@@ -374,13 +382,13 @@ func TestParseFeishuConfig(t *testing.T) {
 			Credentials: map[string]interface{}{
 				"app_id":     "id1",
 				"app_secret": "sec1",
-				"base_url":   "https://custom.example.com",
+				"base_url":   "https://open.feishu.cn",
 			},
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if cfg.AppID != "id1" || cfg.AppSecret != "sec1" || cfg.BaseURL != "https://custom.example.com" {
+		if cfg.AppID != "id1" || cfg.AppSecret != "sec1" || cfg.BaseURL != "https://open.feishu.cn" {
 			t.Errorf("unexpected config: %+v", cfg)
 		}
 	})

--- a/internal/datasource/connector/notion/client.go
+++ b/internal/datasource/connector/notion/client.go
@@ -26,16 +26,19 @@ type notionClient struct {
 }
 
 // newClient creates a new Notion API client.
-func newClient(token, baseURL string) *notionClient {
+func newClient(token, baseURL string) (*notionClient, error) {
 	if baseURL == "" {
 		baseURL = DefaultBaseURL
 	}
+	if err := datasource.ValidateConnectorBaseURL(baseURL); err != nil {
+		return nil, err
+	}
 	return &notionClient{
 		token:      token,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
-		limiter:    rate.NewLimiter(rate.Limit(3), 3), // 3 req/s with burst of 3 (matches Notion's actual behavior)
+		httpClient: datasource.NewConnectorHTTPClient(30 * time.Second),
+		limiter:    rate.NewLimiter(rate.Limit(3), 3),
 		baseURL:    baseURL,
-	}
+	}, nil
 }
 
 const maxRetries = 3

--- a/internal/datasource/connector/notion/client_test.go
+++ b/internal/datasource/connector/notion/client_test.go
@@ -7,7 +7,21 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
+
+func mustTestClient(t *testing.T, token, baseURL string) *notionClient {
+	t.Helper()
+	t.Setenv("SSRF_WHITELIST", "127.0.0.1,localhost")
+	secutils.ResetSSRFWhitelistForTest()
+
+	client, err := newClient(token, baseURL)
+	if err != nil {
+		t.Fatalf("newClient: %v", err)
+	}
+	return client
+}
 
 // fakeNotion builds an httptest.Server that emulates relevant Notion API endpoints.
 func fakeNotion() (*httptest.Server, *Config) {
@@ -233,7 +247,7 @@ func TestClientPing(t *testing.T) {
 	ts, cfg := fakeNotion()
 	defer ts.Close()
 
-	client := newClient(cfg.APIKey, ts.URL)
+	client := mustTestClient(t, cfg.APIKey, ts.URL)
 	if err := client.Ping(context.Background()); err != nil {
 		t.Fatalf("Ping() error: %v", err)
 	}
@@ -243,7 +257,7 @@ func TestClientPing_InvalidToken(t *testing.T) {
 	ts, _ := fakeNotion()
 	defer ts.Close()
 
-	client := newClient("wrong-token", ts.URL)
+	client := mustTestClient(t, "wrong-token", ts.URL)
 	err := client.Ping(context.Background())
 	if err == nil {
 		t.Fatal("expected error for invalid token")
@@ -254,7 +268,7 @@ func TestClientSearchPages(t *testing.T) {
 	ts, cfg := fakeNotion()
 	defer ts.Close()
 
-	client := newClient(cfg.APIKey, ts.URL)
+	client := mustTestClient(t, cfg.APIKey, ts.URL)
 	pages, err := client.SearchPages(context.Background())
 	if err != nil {
 		t.Fatalf("SearchPages() error: %v", err)
@@ -277,7 +291,7 @@ func TestClientGetBlockChildrenAll(t *testing.T) {
 	ts, cfg := fakeNotion()
 	defer ts.Close()
 
-	client := newClient(cfg.APIKey, ts.URL)
+	client := mustTestClient(t, cfg.APIKey, ts.URL)
 	blocks, err := client.GetBlockChildrenAll(context.Background(), "page-1")
 	if err != nil {
 		t.Fatalf("GetBlockChildrenAll() error: %v", err)
@@ -301,7 +315,7 @@ func TestClientGetPage(t *testing.T) {
 	ts, cfg := fakeNotion()
 	defer ts.Close()
 
-	client := newClient(cfg.APIKey, ts.URL)
+	client := mustTestClient(t, cfg.APIKey, ts.URL)
 	page, err := client.GetPage(context.Background(), "page-1")
 	if err != nil {
 		t.Fatalf("GetPage() error: %v", err)
@@ -318,7 +332,7 @@ func TestClientQueryDatabaseAll(t *testing.T) {
 	ts, cfg := fakeNotion()
 	defer ts.Close()
 
-	client := newClient(cfg.APIKey, ts.URL)
+	client := mustTestClient(t, cfg.APIKey, ts.URL)
 	records, err := client.QueryDatabaseAll(context.Background(), "db-1")
 	if err != nil {
 		t.Fatalf("QueryDatabaseAll() error: %v", err)

--- a/internal/datasource/connector/notion/connector.go
+++ b/internal/datasource/connector/notion/connector.go
@@ -40,7 +40,10 @@ func (c *Connector) Validate(ctx context.Context, config *types.DataSourceConfig
 		return err
 	}
 
-	client := newClient(notionCfg.APIKey, extractBaseURL(config))
+	client, err := newClient(notionCfg.APIKey, extractBaseURL(config))
+	if err != nil {
+		return err
+	}
 	return client.Ping(ctx)
 }
 
@@ -71,7 +74,10 @@ func (c *Connector) ListResources(
 		return nil, err
 	}
 
-	client := newClient(notionCfg.APIKey, extractBaseURL(config))
+	client, err := newClient(notionCfg.APIKey, extractBaseURL(config))
+	if err != nil {
+		return nil, err
+	}
 	pages, err := client.SearchPages(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("search notion pages: %w", err)
@@ -131,7 +137,10 @@ func (c *Connector) FetchAll(ctx context.Context, config *types.DataSourceConfig
 		return nil, err
 	}
 
-	client := newClient(notionCfg.APIKey, extractBaseURL(config))
+	client, err := newClient(notionCfg.APIKey, extractBaseURL(config))
+	if err != nil {
+		return nil, err
+	}
 	visited := c.excludedSetFromListResources(ctx, config, resourceIDs)
 	var allItems []types.FetchedItem
 
@@ -167,7 +176,10 @@ func (c *Connector) FetchIncremental(ctx context.Context, config *types.DataSour
 		return nil, nil, fmt.Errorf("no resource IDs configured")
 	}
 
-	client := newClient(notionCfg.APIKey, extractBaseURL(config))
+	client, err := newClient(notionCfg.APIKey, extractBaseURL(config))
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// Parse previous cursor
 	var prevCursor notionCursor

--- a/internal/datasource/connector/yuque/client.go
+++ b/internal/datasource/connector/yuque/client.go
@@ -36,7 +36,7 @@ func newClient(cfg *Config) *client {
 	return &client{
 		baseURL:    cfg.GetBaseURL(),
 		token:      cfg.APIToken,
-		httpClient: &http.Client{Timeout: defaultTimeout},
+		httpClient: datasource.NewConnectorHTTPClient(defaultTimeout),
 	}
 }
 

--- a/internal/datasource/connector/yuque/connector_test.go
+++ b/internal/datasource/connector/yuque/connector_test.go
@@ -4,10 +4,18 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
+	secutils "github.com/Tencent/WeKnora/internal/utils"
 	"github.com/Tencent/WeKnora/internal/types"
 )
+
+func TestMain(m *testing.M) {
+	os.Setenv("SSRF_WHITELIST", "127.0.0.1,localhost")
+	secutils.ResetSSRFWhitelistForTest()
+	os.Exit(m.Run())
+}
 
 func makeDSConfig(f *fakeYuque, resourceIDs []string) *types.DataSourceConfig {
 	return &types.DataSourceConfig{

--- a/internal/datasource/connector/yuque/types.go
+++ b/internal/datasource/connector/yuque/types.go
@@ -77,6 +77,9 @@ func parseYuqueConfig(config *types.DataSourceConfig) (*Config, error) {
 	if strings.TrimSpace(cfg.APIToken) == "" {
 		return nil, fmt.Errorf("%w: api_token is required", datasource.ErrInvalidCredentials)
 	}
+	if err := datasource.ValidateConnectorBaseURL(cfg.GetBaseURL()); err != nil {
+		return nil, err
+	}
 	return &cfg, nil
 }
 

--- a/internal/datasource/httpclient.go
+++ b/internal/datasource/httpclient.go
@@ -1,0 +1,33 @@
+package datasource
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/utils"
+)
+
+// ValidateConnectorBaseURL checks a connector API base URL against the SSRF policy.
+// Empty rawURL is allowed; callers apply their own default before issuing requests.
+func ValidateConnectorBaseURL(rawURL string) error {
+	url := strings.TrimSpace(rawURL)
+	if url == "" {
+		return nil
+	}
+	if !strings.Contains(url, "://") {
+		url = "https://" + url
+	}
+	if err := utils.ValidateURLForSSRF(url); err != nil {
+		return fmt.Errorf("base_url SSRF validation failed: %w", err)
+	}
+	return nil
+}
+
+// NewConnectorHTTPClient returns an HTTP client with redirect and dial-time SSRF guards.
+func NewConnectorHTTPClient(timeout time.Duration) *http.Client {
+	cfg := utils.DefaultSSRFSafeHTTPClientConfig()
+	cfg.Timeout = timeout
+	return utils.NewSSRFSafeHTTPClient(cfg)
+}

--- a/internal/datasource/httpclient_test.go
+++ b/internal/datasource/httpclient_test.go
@@ -1,0 +1,26 @@
+package datasource
+
+import (
+	"testing"
+
+	secutils "github.com/Tencent/WeKnora/internal/utils"
+)
+
+func TestValidateConnectorBaseURLBlocksLoopback(t *testing.T) {
+	secutils.ResetSSRFWhitelistForTest()
+	t.Cleanup(secutils.ResetSSRFWhitelistForTest)
+
+	err := ValidateConnectorBaseURL("http://127.0.0.1:8000")
+	if err == nil {
+		t.Fatal("expected loopback base_url to be rejected")
+	}
+}
+
+func TestValidateConnectorBaseURLAllowsPublicHTTPS(t *testing.T) {
+	secutils.ResetSSRFWhitelistForTest()
+	t.Cleanup(secutils.ResetSSRFWhitelistForTest)
+
+	if err := ValidateConnectorBaseURL("https://open.feishu.cn"); err != nil {
+		t.Fatalf("expected public base_url to pass: %v", err)
+	}
+}

--- a/internal/infrastructure/web_fetch/fetcher.go
+++ b/internal/infrastructure/web_fetch/fetcher.go
@@ -4,10 +4,8 @@ package web_fetch
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -24,13 +22,12 @@ const (
 )
 
 // FetchURLContent fetches a URL and returns its text content (HTML converted to clean text).
-// Includes SSRF validation, DNS pinning, browser-like headers, and content size limits.
+// Includes SSRF validation, redirect re-validation, dial-time guards, and content size limits.
 func FetchURLContent(ctx context.Context, rawURL string) (string, error) {
 	if rawURL == "" {
 		return "", fmt.Errorf("url is empty")
 	}
 
-	// SSRF validation
 	if err := utils.ValidateURLForSSRF(rawURL); err != nil {
 		return "", fmt.Errorf("URL rejected: %w", err)
 	}
@@ -40,53 +37,22 @@ func FetchURLContent(ctx context.Context, rawURL string) (string, error) {
 		return "", fmt.Errorf("invalid URL: %w", err)
 	}
 	hostname := u.Hostname()
-	port := u.Port()
-	if port == "" {
-		if u.Scheme == "https" {
-			port = "443"
-		} else {
-			port = "80"
-		}
-	}
-
-	// DNS pinning: resolve once, use pinned IP
-	ips, err := net.DefaultResolver.LookupIP(context.Background(), "ip", hostname)
-	if err != nil || len(ips) == 0 {
-		return "", fmt.Errorf("DNS lookup failed for %s: %w", hostname, err)
-	}
-	var pinnedIP net.IP
-	for _, ip := range ips {
-		if utils.IsPublicIP(ip) {
-			pinnedIP = ip
-			break
-		}
-	}
-	if pinnedIP == nil {
-		return "", fmt.Errorf("no public IP for host %s", hostname)
-	}
-
-	// Build request with pinned IP
-	hostPort := net.JoinHostPort(pinnedIP.String(), port)
-	fetchURL := *u
-	fetchURL.Host = hostPort
 
 	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return "", err
 	}
-	req.Host = hostname
 
 	// Browser-like headers to reduce 403 rejections.
-	// These match a real Chrome browser fingerprint.
 	req.Header.Set("User-Agent",
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
 	req.Header.Set("Accept",
 		"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7")
 	req.Header.Set("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6")
-	req.Header.Set("Accept-Encoding", "identity") // no gzip to simplify reading
+	req.Header.Set("Accept-Encoding", "identity")
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Pragma", "no-cache")
 	req.Header.Set("Sec-Ch-Ua", `"Chromium";v="131", "Not_A Brand";v="24"`)
@@ -99,16 +65,10 @@ func FetchURLContent(ctx context.Context, rawURL string) (string, error) {
 	req.Header.Set("Upgrade-Insecure-Requests", "1")
 	req.Header.Set("Referer", u.Scheme+"://"+hostname+"/")
 
-	// Custom transport: TLS ServerName for certificate validation with pinned IP.
-	client := &http.Client{
-		Timeout: fetchTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				ServerName: hostname,
-			},
-		},
-		// Follow redirects (default behavior), up to 10 hops
-	}
+	client := utils.NewSSRFSafeHTTPClient(utils.SSRFSafeHTTPClientConfig{
+		Timeout:      fetchTimeout,
+		MaxRedirects: 10,
+	})
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("fetch failed: %w", err)
@@ -143,7 +103,6 @@ func htmlToText(html string) string {
 	})
 	text := sb.String()
 
-	// Normalize whitespace: collapse blank lines
 	lines := strings.Split(text, "\n")
 	var cleaned []string
 	for _, line := range lines {

--- a/internal/infrastructure/web_fetch/fetcher_ssrf_test.go
+++ b/internal/infrastructure/web_fetch/fetcher_ssrf_test.go
@@ -1,0 +1,41 @@
+package web_fetch
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFetchURLContentBlocksRedirectToLoopback(t *testing.T) {
+	internalHit := make(chan struct{}, 1)
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		internalHit <- struct{}{}
+		fmt.Fprint(w, "<html><body>WEKNORA_INTERNAL_CANARY_178193</body></html>")
+	}))
+	defer internal.Close()
+
+	if _, err := FetchURLContent(context.Background(), internal.URL); err == nil {
+		t.Fatal("direct loopback URL was not rejected")
+	}
+
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, internal.URL, http.StatusFound)
+	}))
+	defer attacker.Close()
+
+	got, err := FetchURLContent(context.Background(), attacker.URL+"/entry")
+	if err == nil {
+		if strings.Contains(got, "WEKNORA_INTERNAL_CANARY_178193") {
+			t.Fatalf("redirect followed to loopback, got %q", got)
+		}
+		t.Fatal("expected redirect to loopback to be blocked")
+	}
+	select {
+	case <-internalHit:
+		t.Fatal("internal loopback server was reached via redirect")
+	default:
+	}
+}


### PR DESCRIPTION
## Summary

- **Knowledge URL import (file_url):** use `NewSSRFSafeHTTPClient` in `downloadFileFromURL` (GHSA-44fp, GHSA-rv6v).
- **Knowledge URL import (docreader):** add redirect-aware SSRF guards to Playwright web parser (GHSA-c7m6).
- **Chat pipeline web_fetch:** replace redirect-unsafe client in `FetchURLContent` with `NewSSRFSafeHTTPClient` (GHSA-v6hm).
- **Datasource connectors:** validate tenant `base_url` and use SSRF-safe HTTP clients for Feishu, Yuque, and Notion (GHSA-p9j6).

## Test plan

- [x] `go test ./internal/application/service/ -run TestDownloadFileFromURL`
- [x] `go test ./internal/infrastructure/web_fetch/ -run TestFetchURLContentBlocksRedirectToLoopback`
- [x] `go test ./internal/datasource/ -run TestValidateConnectorBaseURL`
- [x] `go test ./internal/datasource/connector/feishu/ ./internal/datasource/connector/yuque/ ./internal/datasource/connector/notion/`
- [x] `PYTHONPATH=docreader docreader/.venv/bin/python -m unittest docreader.tests.test_ssrf docreader.tests.test_web_parser`