### PR TITLE
fix(security): redact integration secrets from viewer-accessible endpoints

### DIFF
--- a/frontend/src/api/initialization/index.ts
+++ b/frontend/src/api/initialization/index.ts
@@ -3,26 +3,42 @@ import i18n from '@/i18n'
 
 const t = (key: string) => i18n.global.t(key)
 
+// GET /initialization/config/:kbId exposes credential presence, not values.
+export interface ModelCredentialStatus {
+    apiKey?: boolean;
+}
+
+export interface COSCredentialStatus {
+    secretId?: boolean;
+    secretKey?: boolean;
+}
+
 // 初始化配置数据类型
 export interface InitializationConfig {
     llm: {
         source: string;
         modelName: string;
         baseUrl?: string;
+        /** @deprecated Use credentials.apiKey from GET responses */
         apiKey?: string;
+        credentials?: ModelCredentialStatus;
     };
     embedding: {
         source: string;
         modelName: string;
         baseUrl?: string;
+        /** @deprecated Use credentials.apiKey from GET responses */
         apiKey?: string;
         dimension?: number; // 添加embedding维度字段
+        credentials?: ModelCredentialStatus;
     };
     rerank: {
         modelName: string;
         baseUrl: string;
+        /** @deprecated Use credentials.apiKey from GET responses */
         apiKey?: string;
         enabled: boolean;
+        credentials?: ModelCredentialStatus;
     };
     multimodal: {
         enabled: boolean;
@@ -30,16 +46,21 @@ export interface InitializationConfig {
         vlm?: {
             modelName: string;
             baseUrl: string;
+            /** @deprecated Use credentials.apiKey from GET responses */
             apiKey?: string;
             interfaceType?: string; // "ollama" or "openai"
+            credentials?: ModelCredentialStatus;
         };
         cos?: {
-            secretId: string;
-            secretKey: string;
             region: string;
             bucketName: string;
             appId: string;
             pathPrefix?: string;
+            /** @deprecated Use credentials from GET responses */
+            secretId?: string;
+            /** @deprecated Use credentials from GET responses */
+            secretKey?: string;
+            credentials?: COSCredentialStatus;
         };
         minio?: {
             bucketName: string;

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/handler/dto"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
@@ -522,7 +523,7 @@ func (h *AuthHandler) GetCurrentUser(c *gin.Context) {
 		"success": true,
 		"data": gin.H{
 			"user":        userInfo,
-			"tenant":      tenant,
+			"tenant":      dto.NewTenantResponse(ctx, tenant),
 			"memberships": memberships,
 		},
 	})

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -211,14 +211,14 @@ func (h *AuthHandler) Login(c *gin.Context) {
 	// Check if login was successful
 	if !response.Success {
 		logger.Warnf(ctx, "Login failed: %s", response.Message)
-		c.JSON(http.StatusUnauthorized, response)
+		c.JSON(http.StatusUnauthorized, dto.NewAuthLoginResponse(response))
 		return
 	}
 
 	// User is already in the correct format from service
 
 	logger.Infof(ctx, "User logged in successfully, email: %s", email)
-	c.JSON(http.StatusOK, response)
+	c.JSON(http.StatusOK, dto.NewAuthLoginResponse(response))
 }
 
 // GetOIDCAuthorizationURL godoc
@@ -336,7 +336,7 @@ func (h *AuthHandler) OIDCRedirectCallback(c *gin.Context) {
 }
 
 func encodeOIDCCallbackPayload(resp *types.OIDCCallbackResponse) (string, error) {
-	payload, err := json.Marshal(resp)
+	payload, err := json.Marshal(dto.NewAuthOIDCCallbackResponse(resp))
 	if err != nil {
 		return "", err
 	}
@@ -711,10 +711,8 @@ func (h *AuthHandler) SwitchTenant(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, resp)
+	c.JSON(http.StatusOK, dto.NewAuthLoginResponse(resp))
 }
-
-// AutoSetup godoc
 // @Summary      自动初始化（Lite 桌面版）
 // @Description  Lite 版专用：首次启动时自动创建默认用户和租户并返回令牌，后续启动直接签发令牌，免除手动注册/登录流程
 // @Tags         认证
@@ -777,7 +775,7 @@ func (h *AuthHandler) AutoSetup(c *gin.Context) {
 	tenant, _ := h.tenantService.GetTenantByID(ctx, user.TenantID)
 
 	logger.Info(ctx, "Auto-setup: completed successfully")
-	c.JSON(http.StatusOK, &types.LoginResponse{
+	c.JSON(http.StatusOK, dto.NewAuthLoginResponse(&types.LoginResponse{
 		Success:      true,
 		Message:      "Auto-setup successful",
 		User:         user,
@@ -789,7 +787,7 @@ func (h *AuthHandler) AutoSetup(c *gin.Context) {
 		}},
 		Token:        accessToken,
 		RefreshToken: refreshToken,
-	})
+	}))
 }
 
 // tenantNameOrEmpty returns t.Name when t is non-nil, "" otherwise.

--- a/internal/handler/auth_register_by_invite.go
+++ b/internal/handler/auth_register_by_invite.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	apperrors "github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/handler/dto"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
@@ -200,7 +201,7 @@ func (h *AuthHandler) RegisterByInvite(c *gin.Context) {
 	}
 
 	tenant, _ := h.tenantService.GetTenantByID(ctx, inv.TenantID)
-	c.JSON(http.StatusCreated, &types.LoginResponse{
+	c.JSON(http.StatusCreated, dto.NewAuthLoginResponse(&types.LoginResponse{
 		Success:      true,
 		Message:      "Registration successful",
 		User:         user,
@@ -212,5 +213,5 @@ func (h *AuthHandler) RegisterByInvite(c *gin.Context) {
 		}},
 		Token:        accessToken,
 		RefreshToken: refreshToken,
-	})
+	}))
 }

--- a/internal/handler/dto/auth.go
+++ b/internal/handler/dto/auth.go
@@ -1,0 +1,76 @@
+package dto
+
+import "github.com/Tencent/WeKnora/internal/types"
+
+// AuthLoginResponse is the HTTP-safe login / switch-tenant response shape.
+type AuthLoginResponse struct {
+	Success      bool              `json:"success"`
+	Message      string            `json:"message,omitempty"`
+	User         *types.User       `json:"user,omitempty"`
+	ActiveTenant *TenantResponse   `json:"active_tenant,omitempty"`
+	Memberships  []types.Membership `json:"memberships"`
+	Token        string            `json:"token,omitempty"`
+	RefreshToken string            `json:"refresh_token,omitempty"`
+}
+
+// AuthOIDCCallbackResponse is the HTTP-safe OIDC callback payload shape.
+type AuthOIDCCallbackResponse struct {
+	Success      bool               `json:"success"`
+	Message      string             `json:"message,omitempty"`
+	User         *types.User        `json:"user,omitempty"`
+	Tenant       *TenantResponse    `json:"tenant,omitempty"`
+	Memberships  []types.Membership `json:"memberships"`
+	Token        string             `json:"token,omitempty"`
+	RefreshToken string             `json:"refresh_token,omitempty"`
+	IsNewUser    bool               `json:"is_new_user,omitempty"`
+}
+
+// NewAuthLoginResponse converts a service-layer login response for HTTP output.
+func NewAuthLoginResponse(resp *types.LoginResponse) *AuthLoginResponse {
+	if resp == nil {
+		return nil
+	}
+	var role types.TenantRole
+	if resp.ActiveTenant != nil {
+		role = membershipRoleForTenant(resp.Memberships, resp.ActiveTenant.ID)
+	}
+	return &AuthLoginResponse{
+		Success:      resp.Success,
+		Message:      resp.Message,
+		User:         resp.User,
+		ActiveTenant: NewTenantResponseWithRole(resp.ActiveTenant, role),
+		Memberships:  resp.Memberships,
+		Token:        resp.Token,
+		RefreshToken: resp.RefreshToken,
+	}
+}
+
+// NewAuthOIDCCallbackResponse converts an OIDC callback response for HTTP output.
+func NewAuthOIDCCallbackResponse(resp *types.OIDCCallbackResponse) *AuthOIDCCallbackResponse {
+	if resp == nil {
+		return nil
+	}
+	var role types.TenantRole
+	if resp.Tenant != nil {
+		role = membershipRoleForTenant(resp.Memberships, resp.Tenant.ID)
+	}
+	return &AuthOIDCCallbackResponse{
+		Success:      resp.Success,
+		Message:      resp.Message,
+		User:         resp.User,
+		Tenant:       NewTenantResponseWithRole(resp.Tenant, role),
+		Memberships:  resp.Memberships,
+		Token:        resp.Token,
+		RefreshToken: resp.RefreshToken,
+		IsNewUser:    resp.IsNewUser,
+	}
+}
+
+func membershipRoleForTenant(memberships []types.Membership, tenantID uint64) types.TenantRole {
+	for _, m := range memberships {
+		if m.TenantID == tenantID && m.Role.IsValid() {
+			return m.Role
+		}
+	}
+	return ""
+}

--- a/internal/handler/dto/auth_test.go
+++ b/internal/handler/dto/auth_test.go
@@ -1,0 +1,57 @@
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthLoginResponse_ViewerOmitsActiveTenantSecrets(t *testing.T) {
+	tenant := sampleSecretTenant()
+	resp := NewAuthLoginResponse(&types.LoginResponse{
+		Success:      true,
+		ActiveTenant: tenant,
+		Memberships: []types.Membership{{
+			TenantID: tenant.ID,
+			Role:     types.TenantRoleViewer,
+		}},
+	})
+	body, err := json.Marshal(resp)
+	require.NoError(t, err)
+	s := string(body)
+	assert.NotContains(t, s, "tenant-api-key-123")
+	assert.NotContains(t, s, "parser-secret-123")
+}
+
+func TestAuthLoginResponse_OwnerGetsAPIKey(t *testing.T) {
+	tenant := sampleSecretTenant()
+	resp := NewAuthLoginResponse(&types.LoginResponse{
+		Success:      true,
+		ActiveTenant: tenant,
+		Memberships: []types.Membership{{
+			TenantID: tenant.ID,
+			Role:     types.TenantRoleOwner,
+		}},
+	})
+	body, err := json.Marshal(resp)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "tenant-api-key-123")
+}
+
+func TestAuthOIDCCallbackResponse_ViewerOmitsTenantSecrets(t *testing.T) {
+	tenant := sampleSecretTenant()
+	resp := NewAuthOIDCCallbackResponse(&types.OIDCCallbackResponse{
+		Success: true,
+		Tenant:  tenant,
+		Memberships: []types.Membership{{
+			TenantID: tenant.ID,
+			Role:     types.TenantRoleViewer,
+		}},
+	})
+	body, err := json.Marshal(resp)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "tenant-api-key-123")
+}

--- a/internal/handler/dto/mcp.go
+++ b/internal/handler/dto/mcp.go
@@ -93,6 +93,9 @@ func NewMCPServiceResponse(ctx context.Context, svc *types.MCPService) *MCPServi
 	if !includeDetail {
 		resp.Headers = nil
 		resp.EnvVars = nil
+		resp.URL = nil
+		resp.StdioConfig = nil
+		resp.AdvancedConfig = nil
 	}
 	if svc.AuthConfig != nil {
 		auth := &MCPAuthConfigResponse{

--- a/internal/handler/dto/mcp.go
+++ b/internal/handler/dto/mcp.go
@@ -10,6 +10,7 @@
 package dto
 
 import (
+	"context"
 	"time"
 
 	"github.com/Tencent/WeKnora/internal/types"
@@ -68,10 +69,11 @@ type CredentialFieldMetadata struct {
 // Headers, EnvVars, StdioConfig) stripped — these reveal how the tenant
 // configured an upstream provider and must not be visible to other tenants
 // that see the same builtin row via the cross-tenant list.
-func NewMCPServiceResponse(svc *types.MCPService) *MCPServiceResponse {
+func NewMCPServiceResponse(ctx context.Context, svc *types.MCPService) *MCPServiceResponse {
 	if svc == nil {
 		return nil
 	}
+	includeDetail := CanViewIntegrationSecrets(ctx)
 	resp := &MCPServiceResponse{
 		ID:             svc.ID,
 		TenantID:       svc.TenantID,
@@ -88,14 +90,22 @@ func NewMCPServiceResponse(svc *types.MCPService) *MCPServiceResponse {
 		CreatedAt:      svc.CreatedAt,
 		UpdatedAt:      svc.UpdatedAt,
 	}
+	if !includeDetail {
+		resp.Headers = nil
+		resp.EnvVars = nil
+	}
 	if svc.AuthConfig != nil {
-		resp.AuthConfig = &MCPAuthConfigResponse{
+		auth := &MCPAuthConfigResponse{
 			AuthType:              svc.AuthConfig.AuthType,
 			APIKeyHeader:          svc.AuthConfig.APIKeyHeader,
 			CustomHeaders:         svc.AuthConfig.CustomHeaders,
 			Scopes:                svc.AuthConfig.Scopes,
 			AuthServerMetadataURL: svc.AuthConfig.AuthServerMetadataURL,
 		}
+		if !includeDetail {
+			auth.CustomHeaders = nil
+		}
+		resp.AuthConfig = auth
 	}
 	if svc.IsBuiltin {
 		// Builtin services are shared across tenants — strip everything that
@@ -115,10 +125,10 @@ func NewMCPServiceResponse(svc *types.MCPService) *MCPServiceResponse {
 }
 
 // NewMCPServiceResponses is the slice convenience wrapper used by ListMCPServices.
-func NewMCPServiceResponses(svcs []*types.MCPService) []*MCPServiceResponse {
+func NewMCPServiceResponses(ctx context.Context, svcs []*types.MCPService) []*MCPServiceResponse {
 	out := make([]*MCPServiceResponse, 0, len(svcs))
 	for _, s := range svcs {
-		out = append(out, NewMCPServiceResponse(s))
+		out = append(out, NewMCPServiceResponse(ctx, s))
 	}
 	return out
 }

--- a/internal/handler/dto/mcp_test.go
+++ b/internal/handler/dto/mcp_test.go
@@ -25,7 +25,7 @@ func TestMCPServiceResponse_OmitsSecrets(t *testing.T) {
 			CustomHeaders: map[string]string{"X-Trace": "abc"},
 		},
 	}
-	body, err := json.Marshal(NewMCPServiceResponse(svc))
+	body, err := json.Marshal(NewMCPServiceResponse(adminContext(), svc))
 	assert.NoError(t, err)
 	s := string(body)
 	assert.NotContains(t, s, "sk-real-api-key-do-not-leak",
@@ -63,7 +63,7 @@ func TestMCPServiceResponse_BuiltinStripsTenantConfig(t *testing.T) {
 			APIKey: "should-not-leak-via-builtin",
 		},
 	}
-	resp := NewMCPServiceResponse(svc)
+	resp := NewMCPServiceResponse(adminContext(), svc)
 	assert.Nil(t, resp.URL, "builtin must not leak per-tenant URL")
 	assert.Nil(t, resp.Headers, "builtin must not leak per-tenant headers")
 	assert.Nil(t, resp.AuthConfig, "builtin must not leak auth config")
@@ -73,7 +73,23 @@ func TestMCPServiceResponse_BuiltinStripsTenantConfig(t *testing.T) {
 	assert.False(t, strings.Contains(string(body), "X-Tenant-Secret"))
 }
 
+func TestMCPServiceResponse_ViewerStripsIntegrationDetail(t *testing.T) {
+	svc := &types.MCPService{
+		ID:      "svc-2",
+		Headers: types.MCPHeaders{"Authorization": "Bearer secret"},
+		EnvVars: types.MCPEnvVars{"TOKEN": "secret"},
+		AuthConfig: &types.MCPAuthConfig{
+			CustomHeaders: map[string]string{"X-Auth": "secret"},
+		},
+	}
+	resp := NewMCPServiceResponse(viewerContext(), svc)
+	assert.Nil(t, resp.Headers)
+	assert.Nil(t, resp.EnvVars)
+	assert.NotNil(t, resp.AuthConfig)
+	assert.Nil(t, resp.AuthConfig.CustomHeaders)
+}
+
 func TestMCPServiceResponse_NilSafe(t *testing.T) {
-	assert.Nil(t, NewMCPServiceResponse(nil))
-	assert.Equal(t, []*MCPServiceResponse{}, NewMCPServiceResponses(nil))
+	assert.Nil(t, NewMCPServiceResponse(adminContext(), nil))
+	assert.Equal(t, []*MCPServiceResponse{}, NewMCPServiceResponses(adminContext(), nil))
 }

--- a/internal/handler/dto/mcp_test.go
+++ b/internal/handler/dto/mcp_test.go
@@ -74,17 +74,27 @@ func TestMCPServiceResponse_BuiltinStripsTenantConfig(t *testing.T) {
 }
 
 func TestMCPServiceResponse_ViewerStripsIntegrationDetail(t *testing.T) {
+	url := "https://tenant-private.example.com"
 	svc := &types.MCPService{
 		ID:      "svc-2",
+		URL:     &url,
 		Headers: types.MCPHeaders{"Authorization": "Bearer secret"},
 		EnvVars: types.MCPEnvVars{"TOKEN": "secret"},
+		StdioConfig: &types.MCPStdioConfig{
+			Command: "npx",
+			Args:    []string{"-y", "mcp-server"},
+		},
+		AdvancedConfig: &types.MCPAdvancedConfig{},
 		AuthConfig: &types.MCPAuthConfig{
 			CustomHeaders: map[string]string{"X-Auth": "secret"},
 		},
 	}
 	resp := NewMCPServiceResponse(viewerContext(), svc)
+	assert.Nil(t, resp.URL)
 	assert.Nil(t, resp.Headers)
 	assert.Nil(t, resp.EnvVars)
+	assert.Nil(t, resp.StdioConfig)
+	assert.Nil(t, resp.AdvancedConfig)
 	assert.NotNil(t, resp.AuthConfig)
 	assert.Nil(t, resp.AuthConfig.CustomHeaders)
 }

--- a/internal/handler/dto/model.go
+++ b/internal/handler/dto/model.go
@@ -72,6 +72,7 @@ func NewModelResponse(ctx context.Context, m *types.Model) *ModelResponse {
 	if !CanViewIntegrationSecrets(ctx) {
 		params.ExtraConfig = nil
 		params.CustomHeaders = nil
+		params.BaseURL = ""
 	}
 	if m.IsBuiltin {
 		// Builtin: strip everything that could reveal per-tenant config.

--- a/internal/handler/dto/model.go
+++ b/internal/handler/dto/model.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"context"
 	"time"
 
 	"github.com/Tencent/WeKnora/internal/types"
@@ -53,7 +54,7 @@ type ModelParametersDTO struct {
 //
 // Builtin models are shared across tenants — strip BaseURL (which can leak
 // the tenant's private endpoint) and any non-shared parameters.
-func NewModelResponse(m *types.Model) *ModelResponse {
+func NewModelResponse(ctx context.Context, m *types.Model) *ModelResponse {
 	if m == nil {
 		return nil
 	}
@@ -67,6 +68,10 @@ func NewModelResponse(m *types.Model) *ModelResponse {
 		CustomHeaders:       m.Parameters.CustomHeaders,
 		SupportsVision:      m.Parameters.SupportsVision,
 		AppID:               m.Parameters.AppID,
+	}
+	if !CanViewIntegrationSecrets(ctx) {
+		params.ExtraConfig = nil
+		params.CustomHeaders = nil
 	}
 	if m.IsBuiltin {
 		// Builtin: strip everything that could reveal per-tenant config.
@@ -104,10 +109,10 @@ func NewModelResponse(m *types.Model) *ModelResponse {
 }
 
 // NewModelResponses is the slice convenience wrapper.
-func NewModelResponses(models []*types.Model) []*ModelResponse {
+func NewModelResponses(ctx context.Context, models []*types.Model) []*ModelResponse {
 	out := make([]*ModelResponse, 0, len(models))
 	for _, m := range models {
-		out = append(out, NewModelResponse(m))
+		out = append(out, NewModelResponse(ctx, m))
 	}
 	return out
 }

--- a/internal/handler/dto/model_test.go
+++ b/internal/handler/dto/model_test.go
@@ -22,7 +22,7 @@ func TestModelResponse_OmitsSecrets(t *testing.T) {
 			Provider:  "openai",
 		},
 	}
-	body, err := json.Marshal(NewModelResponse(m))
+	body, err := json.Marshal(NewModelResponse(adminContext(), m))
 	assert.NoError(t, err)
 	s := string(body)
 	assert.NotContains(t, s, "sk-real-api-key-do-not-leak")
@@ -55,7 +55,7 @@ func TestModelResponse_BuiltinStripsTenantConfig(t *testing.T) {
 			ExtraConfig:    map[string]string{"region": "cn-hangzhou"},
 		},
 	}
-	resp := NewModelResponse(m)
+	resp := NewModelResponse(adminContext(), m)
 	assert.Empty(t, resp.Parameters.BaseURL,
 		"builtin must not leak per-tenant base URL")
 	assert.Empty(t, resp.Parameters.AppID,
@@ -70,7 +70,20 @@ func TestModelResponse_BuiltinStripsTenantConfig(t *testing.T) {
 	assert.False(t, strings.Contains(string(body), "tenant-private.example.com"))
 }
 
+func TestModelResponse_ViewerStripsIntegrationDetail(t *testing.T) {
+	m := &types.Model{
+		ID: "m-2",
+		Parameters: types.ModelParameters{
+			CustomHeaders: map[string]string{"Authorization": "Bearer secret"},
+			ExtraConfig:     map[string]string{"region": "cn-hangzhou"},
+		},
+	}
+	resp := NewModelResponse(viewerContext(), m)
+	assert.Nil(t, resp.Parameters.CustomHeaders)
+	assert.Nil(t, resp.Parameters.ExtraConfig)
+}
+
 func TestModelResponse_NilSafe(t *testing.T) {
-	assert.Nil(t, NewModelResponse(nil))
-	assert.Equal(t, []*ModelResponse{}, NewModelResponses(nil))
+	assert.Nil(t, NewModelResponse(adminContext(), nil))
+	assert.Equal(t, []*ModelResponse{}, NewModelResponses(adminContext(), nil))
 }

--- a/internal/handler/dto/model_test.go
+++ b/internal/handler/dto/model_test.go
@@ -74,11 +74,13 @@ func TestModelResponse_ViewerStripsIntegrationDetail(t *testing.T) {
 	m := &types.Model{
 		ID: "m-2",
 		Parameters: types.ModelParameters{
+			BaseURL:       "https://tenant-private.example.com",
 			CustomHeaders: map[string]string{"Authorization": "Bearer secret"},
-			ExtraConfig:     map[string]string{"region": "cn-hangzhou"},
+			ExtraConfig:   map[string]string{"region": "cn-hangzhou"},
 		},
 	}
 	resp := NewModelResponse(viewerContext(), m)
+	assert.Empty(t, resp.Parameters.BaseURL)
 	assert.Nil(t, resp.Parameters.CustomHeaders)
 	assert.Nil(t, resp.Parameters.ExtraConfig)
 }

--- a/internal/handler/dto/role.go
+++ b/internal/handler/dto/role.go
@@ -1,0 +1,22 @@
+package dto
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// RoleFromContext returns the caller's tenant role from ctx.
+func RoleFromContext(ctx context.Context) types.TenantRole {
+	return types.TenantRoleFromContext(ctx)
+}
+
+// CanViewIntegrationSecrets is true for Admin+ (includes Owner).
+func CanViewIntegrationSecrets(ctx context.Context) bool {
+	return RoleFromContext(ctx).HasPermission(types.TenantRoleAdmin)
+}
+
+// CanViewTenantAPIKey is true for Owner+ only.
+func CanViewTenantAPIKey(ctx context.Context) bool {
+	return RoleFromContext(ctx).HasPermission(types.TenantRoleOwner)
+}

--- a/internal/handler/dto/role.go
+++ b/internal/handler/dto/role.go
@@ -16,7 +16,12 @@ func CanViewIntegrationSecrets(ctx context.Context) bool {
 	return RoleFromContext(ctx).HasPermission(types.TenantRoleAdmin)
 }
 
+// RoleCanViewTenantAPIKey is true for Owner+ only.
+func RoleCanViewTenantAPIKey(role types.TenantRole) bool {
+	return role.HasPermission(types.TenantRoleOwner)
+}
+
 // CanViewTenantAPIKey is true for Owner+ only.
 func CanViewTenantAPIKey(ctx context.Context) bool {
-	return RoleFromContext(ctx).HasPermission(types.TenantRoleOwner)
+	return RoleCanViewTenantAPIKey(RoleFromContext(ctx))
 }

--- a/internal/handler/dto/tenant.go
+++ b/internal/handler/dto/tenant.go
@@ -83,3 +83,14 @@ func NewTenantResponses(ctx context.Context, tenants []*types.Tenant) []*TenantR
 	}
 	return out
 }
+
+// NewTenantResponsesCrossTenant redacts every tenant as Viewer regardless of
+// the caller's active-tenant role. Used by cross-tenant list/search endpoints
+// where the caller's home-tenant role must not unlock other tenants' secrets.
+func NewTenantResponsesCrossTenant(tenants []*types.Tenant) []*TenantResponse {
+	out := make([]*TenantResponse, 0, len(tenants))
+	for _, t := range tenants {
+		out = append(out, NewTenantResponseWithRole(t, types.TenantRoleViewer))
+	}
+	return out
+}

--- a/internal/handler/dto/tenant.go
+++ b/internal/handler/dto/tenant.go
@@ -35,27 +35,33 @@ type TenantResponse struct {
 
 // NewTenantResponse converts a stored tenant into its HTTP response shape.
 func NewTenantResponse(ctx context.Context, tenant *types.Tenant) *TenantResponse {
+	return NewTenantResponseWithRole(tenant, RoleFromContext(ctx))
+}
+
+// NewTenantResponseWithRole converts a stored tenant using an explicit role
+// (for auth flows where tenant role is not yet in request context).
+func NewTenantResponseWithRole(tenant *types.Tenant, role types.TenantRole) *TenantResponse {
 	if tenant == nil {
 		return nil
 	}
-	includeSecrets := CanViewIntegrationSecrets(ctx)
-	includeAPIKey := CanViewTenantAPIKey(ctx)
+	includeSecrets := role.HasPermission(types.TenantRoleAdmin)
+	includeAPIKey := role.HasPermission(types.TenantRoleOwner)
 
 	resp := &TenantResponse{
-		ID:               tenant.ID,
-		Name:             tenant.Name,
-		Description:      tenant.Description,
-		Status:           tenant.Status,
-		RetrieverEngines: tenant.RetrieverEngines,
-		Business:         tenant.Business,
-		StorageQuota:     tenant.StorageQuota,
-		StorageUsed:      tenant.StorageUsed,
-		ContextConfig:    tenant.ContextConfig,
+		ID:                tenant.ID,
+		Name:              tenant.Name,
+		Description:       tenant.Description,
+		Status:            tenant.Status,
+		RetrieverEngines:  tenant.RetrieverEngines,
+		Business:          tenant.Business,
+		StorageQuota:      tenant.StorageQuota,
+		StorageUsed:       tenant.StorageUsed,
+		ContextConfig:     tenant.ContextConfig,
 		ChatHistoryConfig: tenant.ChatHistoryConfig,
-		RetrievalConfig:  tenant.RetrievalConfig,
-		CreatedAt:        tenant.CreatedAt,
-		UpdatedAt:        tenant.UpdatedAt,
-		DeletedAt:        tenant.DeletedAt,
+		RetrievalConfig:   tenant.RetrievalConfig,
+		CreatedAt:         tenant.CreatedAt,
+		UpdatedAt:         tenant.UpdatedAt,
+		DeletedAt:         tenant.DeletedAt,
 	}
 	if includeAPIKey {
 		resp.APIKey = tenant.APIKey

--- a/internal/handler/dto/tenant.go
+++ b/internal/handler/dto/tenant.go
@@ -45,7 +45,7 @@ func NewTenantResponseWithRole(tenant *types.Tenant, role types.TenantRole) *Ten
 		return nil
 	}
 	includeSecrets := role.HasPermission(types.TenantRoleAdmin)
-	includeAPIKey := role.HasPermission(types.TenantRoleOwner)
+	includeAPIKey := RoleCanViewTenantAPIKey(role)
 
 	resp := &TenantResponse{
 		ID:                tenant.ID,

--- a/internal/handler/dto/tenant.go
+++ b/internal/handler/dto/tenant.go
@@ -1,0 +1,79 @@
+package dto
+
+import (
+	"context"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"gorm.io/gorm"
+)
+
+// TenantResponse is the viewer-safe tenant profile shape. Secret-bearing
+// columns are omitted or redacted unless the caller has Admin+ (Owner for
+// api_key).
+type TenantResponse struct {
+	ID                  uint64                      `json:"id"`
+	Name                string                      `json:"name"`
+	Description         string                      `json:"description"`
+	APIKey              string                      `json:"api_key,omitempty"`
+	Status              string                      `json:"status"`
+	RetrieverEngines    types.RetrieverEngines      `json:"retriever_engines"`
+	Business            string                      `json:"business"`
+	StorageQuota        int64                       `json:"storage_quota"`
+	StorageUsed         int64                       `json:"storage_used"`
+	ContextConfig       *types.ContextConfig        `json:"context_config,omitempty"`
+	WebSearchConfig     *types.WebSearchConfig      `json:"web_search_config,omitempty"`
+	ParserEngineConfig  *types.ParserEngineConfig   `json:"parser_engine_config,omitempty"`
+	Credentials         *types.CredentialsConfig    `json:"credentials,omitempty"`
+	StorageEngineConfig *types.StorageEngineConfig  `json:"storage_engine_config,omitempty"`
+	ChatHistoryConfig   *types.ChatHistoryConfig    `json:"chat_history_config,omitempty"`
+	RetrievalConfig     *types.RetrievalConfig      `json:"retrieval_config,omitempty"`
+	CreatedAt           time.Time                   `json:"created_at"`
+	UpdatedAt           time.Time                   `json:"updated_at"`
+	DeletedAt           gorm.DeletedAt              `json:"deleted_at"`
+}
+
+// NewTenantResponse converts a stored tenant into its HTTP response shape.
+func NewTenantResponse(ctx context.Context, tenant *types.Tenant) *TenantResponse {
+	if tenant == nil {
+		return nil
+	}
+	includeSecrets := CanViewIntegrationSecrets(ctx)
+	includeAPIKey := CanViewTenantAPIKey(ctx)
+
+	resp := &TenantResponse{
+		ID:               tenant.ID,
+		Name:             tenant.Name,
+		Description:      tenant.Description,
+		Status:           tenant.Status,
+		RetrieverEngines: tenant.RetrieverEngines,
+		Business:         tenant.Business,
+		StorageQuota:     tenant.StorageQuota,
+		StorageUsed:      tenant.StorageUsed,
+		ContextConfig:    tenant.ContextConfig,
+		ChatHistoryConfig: tenant.ChatHistoryConfig,
+		RetrievalConfig:  tenant.RetrievalConfig,
+		CreatedAt:        tenant.CreatedAt,
+		UpdatedAt:        tenant.UpdatedAt,
+		DeletedAt:        tenant.DeletedAt,
+	}
+	if includeAPIKey {
+		resp.APIKey = tenant.APIKey
+	}
+	if includeSecrets {
+		resp.WebSearchConfig = types.WebSearchConfigForResponse(tenant.WebSearchConfig, true)
+		resp.ParserEngineConfig = types.ParserEngineConfigForResponse(tenant.ParserEngineConfig, true)
+		resp.Credentials = types.CredentialsConfigForResponse(tenant.Credentials, true)
+		resp.StorageEngineConfig = types.StorageEngineConfigForResponse(tenant.StorageEngineConfig, true)
+	}
+	return resp
+}
+
+// NewTenantResponses is the slice convenience wrapper.
+func NewTenantResponses(ctx context.Context, tenants []*types.Tenant) []*TenantResponse {
+	out := make([]*TenantResponse, 0, len(tenants))
+	for _, t := range tenants {
+		out = append(out, NewTenantResponse(ctx, t))
+	}
+	return out
+}

--- a/internal/handler/dto/tenant_test.go
+++ b/internal/handler/dto/tenant_test.go
@@ -1,0 +1,77 @@
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTenantResponse_ViewerOmitsSecrets(t *testing.T) {
+	tenant := sampleSecretTenant()
+	body, err := json.Marshal(NewTenantResponse(viewerContext(), tenant))
+	require.NoError(t, err)
+	s := string(body)
+	assert.NotContains(t, s, "tenant-api-key-123")
+	assert.NotContains(t, s, "legacy-search-secret-999")
+	assert.NotContains(t, s, "wk-app-secret-def")
+	assert.NotContains(t, s, "parser-secret-123")
+	assert.NotContains(t, s, "minio-secret-789")
+	assert.NotContains(t, s, "web_search_config")
+	assert.NotContains(t, s, "parser_engine_config")
+	assert.NotContains(t, s, "storage_engine_config")
+	assert.NotContains(t, s, "credentials")
+}
+
+func TestTenantResponse_OwnerGetsAPIKeyOnly(t *testing.T) {
+	tenant := sampleSecretTenant()
+	body, err := json.Marshal(NewTenantResponse(ownerContext(), tenant))
+	require.NoError(t, err)
+	s := string(body)
+	assert.Contains(t, s, "tenant-api-key-123")
+	assert.NotContains(t, s, "legacy-search-secret-999")
+	assert.NotContains(t, s, "parser-secret-123")
+}
+
+func TestTenantResponse_AdminGetsRedactedIntegrationConfigs(t *testing.T) {
+	tenant := sampleSecretTenant()
+	resp := NewTenantResponse(adminContext(), tenant)
+	require.NotNil(t, resp.WebSearchConfig)
+	assert.Equal(t, types.RedactedSecretPlaceholder, resp.WebSearchConfig.ProxyURL)
+	assert.Empty(t, resp.WebSearchConfig.APIKey)
+	require.NotNil(t, resp.ParserEngineConfig)
+	assert.Equal(t, types.RedactedSecretPlaceholder, resp.ParserEngineConfig.MinerUAPIKey)
+	require.NotNil(t, resp.StorageEngineConfig.MinIO)
+	assert.Equal(t, types.RedactedSecretPlaceholder, resp.StorageEngineConfig.MinIO.SecretAccessKey)
+}
+
+func sampleSecretTenant() *types.Tenant {
+	return &types.Tenant{
+		ID:     42,
+		Name:   "tenant",
+		APIKey: "tenant-api-key-123",
+		WebSearchConfig: &types.WebSearchConfig{
+			APIKey:   "legacy-search-secret-999",
+			ProxyURL: "http://proxy.internal:8080",
+		},
+		Credentials: &types.CredentialsConfig{
+			WeKnoraCloud: &types.WeKnoraCloudCredentials{
+				AppID:     "wk-app-id-abc",
+				AppSecret: "wk-app-secret-def",
+			},
+		},
+		ParserEngineConfig: &types.ParserEngineConfig{
+			MinerUAPIKey:          "parser-secret-123",
+			PaddleOCRVLCloudToken: "paddle-secret-456",
+		},
+		StorageEngineConfig: &types.StorageEngineConfig{
+			DefaultProvider: "minio",
+			MinIO: &types.MinIOEngineConfig{
+				AccessKeyID:     "minio-access-id",
+				SecretAccessKey: "minio-secret-789",
+			},
+		},
+	}
+}

--- a/internal/handler/dto/tenant_test.go
+++ b/internal/handler/dto/tenant_test.go
@@ -47,6 +47,15 @@ func TestTenantResponse_AdminGetsRedactedIntegrationConfigs(t *testing.T) {
 	assert.Equal(t, types.RedactedSecretPlaceholder, resp.StorageEngineConfig.MinIO.SecretAccessKey)
 }
 
+func TestTenantResponsesCrossTenant_RedactsEvenForOwnerContext(t *testing.T) {
+	tenant := sampleSecretTenant()
+	body, err := json.Marshal(NewTenantResponsesCrossTenant([]*types.Tenant{tenant}))
+	require.NoError(t, err)
+	s := string(body)
+	assert.NotContains(t, s, "tenant-api-key-123")
+	assert.NotContains(t, s, "parser-secret-123")
+}
+
 func sampleSecretTenant() *types.Tenant {
 	return &types.Tenant{
 		ID:     42,

--- a/internal/handler/dto/test_helpers.go
+++ b/internal/handler/dto/test_helpers.go
@@ -1,0 +1,22 @@
+package dto
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func adminContext() context.Context {
+	ctx := context.Background()
+	return context.WithValue(ctx, types.TenantRoleContextKey, types.TenantRoleAdmin)
+}
+
+func viewerContext() context.Context {
+	ctx := context.Background()
+	return context.WithValue(ctx, types.TenantRoleContextKey, types.TenantRoleViewer)
+}
+
+func ownerContext() context.Context {
+	ctx := context.Background()
+	return context.WithValue(ctx, types.TenantRoleContextKey, types.TenantRoleOwner)
+}

--- a/internal/handler/dto/web_search_provider.go
+++ b/internal/handler/dto/web_search_provider.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"context"
 	"time"
 
 	"github.com/Tencent/WeKnora/internal/types"
@@ -34,9 +35,19 @@ type WebSearchProviderParametersDTO struct {
 }
 
 // NewWebSearchProviderResponse converts a stored entity into its response shape.
-func NewWebSearchProviderResponse(e *types.WebSearchProviderEntity) *WebSearchProviderResponse {
+func NewWebSearchProviderResponse(ctx context.Context, e *types.WebSearchProviderEntity) *WebSearchProviderResponse {
 	if e == nil {
 		return nil
+	}
+	params := WebSearchProviderParametersDTO{
+		EngineID:    e.Parameters.EngineID,
+		BaseURL:     e.Parameters.BaseURL,
+		ProxyURL:    e.Parameters.ProxyURL,
+		ExtraConfig: e.Parameters.ExtraConfig,
+	}
+	if !CanViewIntegrationSecrets(ctx) {
+		params.ProxyURL = ""
+		params.ExtraConfig = nil
 	}
 	return &WebSearchProviderResponse{
 		ID:          e.ID,
@@ -44,25 +55,20 @@ func NewWebSearchProviderResponse(e *types.WebSearchProviderEntity) *WebSearchPr
 		Name:        e.Name,
 		Provider:    e.Provider,
 		Description: e.Description,
-		Parameters: WebSearchProviderParametersDTO{
-			EngineID:    e.Parameters.EngineID,
-			BaseURL:     e.Parameters.BaseURL,
-			ProxyURL:    e.Parameters.ProxyURL,
-			ExtraConfig: e.Parameters.ExtraConfig,
-		},
-		IsDefault: e.IsDefault,
-		CreatedAt: e.CreatedAt,
-		UpdatedAt: e.UpdatedAt,
+		Parameters:  params,
+		IsDefault:   e.IsDefault,
+		CreatedAt:   e.CreatedAt,
+		UpdatedAt:   e.UpdatedAt,
 		Credentials: map[string]CredentialFieldMetadata{
 			"api_key": {Configured: e.Parameters.APIKey != ""},
 		},
 	}
 }
 
-func NewWebSearchProviderResponses(es []*types.WebSearchProviderEntity) []*WebSearchProviderResponse {
+func NewWebSearchProviderResponses(ctx context.Context, es []*types.WebSearchProviderEntity) []*WebSearchProviderResponse {
 	out := make([]*WebSearchProviderResponse, 0, len(es))
 	for _, e := range es {
-		out = append(out, NewWebSearchProviderResponse(e))
+		out = append(out, NewWebSearchProviderResponse(ctx, e))
 	}
 	return out
 }

--- a/internal/handler/dto/web_search_provider_test.go
+++ b/internal/handler/dto/web_search_provider_test.go
@@ -19,7 +19,7 @@ func TestWebSearchProviderResponse_OmitsSecrets(t *testing.T) {
 			BaseURL:  "https://example.com",
 		},
 	}
-	body, err := json.Marshal(NewWebSearchProviderResponse(e))
+	body, err := json.Marshal(NewWebSearchProviderResponse(adminContext(), e))
 	assert.NoError(t, err)
 	s := string(body)
 	assert.NotContains(t, s, "bing-secret-do-not-leak")
@@ -35,7 +35,20 @@ func TestWebSearchProviderResponse_OmitsSecrets(t *testing.T) {
 	assert.Contains(t, s, "example.com")
 }
 
+func TestWebSearchProviderResponse_ViewerStripsIntegrationDetail(t *testing.T) {
+	e := &types.WebSearchProviderEntity{
+		ID: "wsp-2",
+		Parameters: types.WebSearchProviderParameters{
+			ProxyURL:    "http://proxy:8080",
+			ExtraConfig: map[string]string{"token": "secret"},
+		},
+	}
+	resp := NewWebSearchProviderResponse(viewerContext(), e)
+	assert.Empty(t, resp.Parameters.ProxyURL)
+	assert.Nil(t, resp.Parameters.ExtraConfig)
+}
+
 func TestWebSearchProviderResponse_NilSafe(t *testing.T) {
-	assert.Nil(t, NewWebSearchProviderResponse(nil))
-	assert.Equal(t, []*WebSearchProviderResponse{}, NewWebSearchProviderResponses(nil))
+	assert.Nil(t, NewWebSearchProviderResponse(adminContext(), nil))
+	assert.Equal(t, []*WebSearchProviderResponse{}, NewWebSearchProviderResponses(adminContext(), nil))
 }

--- a/internal/handler/initialization.go
+++ b/internal/handler/initialization.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/assets"
 	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/handler/dto"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/models/asr"
 	"github.com/Tencent/WeKnora/internal/models/chat"
@@ -1377,15 +1378,16 @@ func (h *InitializationHandler) buildConfigResponse(ctx context.Context, models 
 	config := map[string]interface{}{
 		"hasFiles": hasFiles,
 	}
+	includeIntegrationDetail := dto.CanViewIntegrationSecrets(ctx)
 
 	// 按类型分组模型
 	for _, model := range models {
 		if model == nil {
 			continue
 		}
-		// Hide sensitive information for builtin models
+		// Hide sensitive information for builtin models and viewers.
 		baseURL := model.Parameters.BaseURL
-		if model.IsBuiltin {
+		if model.IsBuiltin || !includeIntegrationDetail {
 			baseURL = ""
 		}
 
@@ -1415,7 +1417,7 @@ func (h *InitializationHandler) buildConfigResponse(ctx context.Context, models 
 				"modelName": model.Name,
 				"baseUrl":   baseURL,
 				"credentials": map[string]bool{
-					"apiKey": model.Parameters.APIKey != "",
+					"apiKey": model.Parameters.APIKey != "" && !model.IsBuiltin,
 				},
 			}
 		case types.ModelTypeVLLM:

--- a/internal/handler/initialization.go
+++ b/internal/handler/initialization.go
@@ -1385,10 +1385,8 @@ func (h *InitializationHandler) buildConfigResponse(ctx context.Context, models 
 		}
 		// Hide sensitive information for builtin models
 		baseURL := model.Parameters.BaseURL
-		apiKey := model.Parameters.APIKey
 		if model.IsBuiltin {
 			baseURL = ""
-			apiKey = ""
 		}
 
 		switch model.Type {
@@ -1397,22 +1395,28 @@ func (h *InitializationHandler) buildConfigResponse(ctx context.Context, models 
 				"source":    string(model.Source),
 				"modelName": model.Name,
 				"baseUrl":   baseURL,
-				"apiKey":    apiKey,
+				"credentials": map[string]bool{
+					"apiKey": model.Parameters.APIKey != "" && !model.IsBuiltin,
+				},
 			}
 		case types.ModelTypeEmbedding:
 			config["embedding"] = map[string]interface{}{
 				"source":    string(model.Source),
 				"modelName": model.Name,
 				"baseUrl":   baseURL,
-				"apiKey":    apiKey,
 				"dimension": model.Parameters.EmbeddingParameters.Dimension,
+				"credentials": map[string]bool{
+					"apiKey": model.Parameters.APIKey != "" && !model.IsBuiltin,
+				},
 			}
 		case types.ModelTypeRerank:
 			config["rerank"] = map[string]interface{}{
 				"enabled":   true,
 				"modelName": model.Name,
 				"baseUrl":   baseURL,
-				"apiKey":    apiKey,
+				"credentials": map[string]bool{
+					"apiKey": model.Parameters.APIKey != "",
+				},
 			}
 		case types.ModelTypeVLLM:
 			if config["multimodal"] == nil {
@@ -1424,9 +1428,11 @@ func (h *InitializationHandler) buildConfigResponse(ctx context.Context, models 
 			multimodal["vlm"] = map[string]interface{}{
 				"modelName":     model.Name,
 				"baseUrl":       baseURL,
-				"apiKey":        apiKey,
 				"interfaceType": model.Parameters.InterfaceType,
 				"modelId":       model.ID,
+				"credentials": map[string]bool{
+					"apiKey": model.Parameters.APIKey != "" && !model.IsBuiltin,
+				},
 			}
 		}
 	}
@@ -1450,7 +1456,9 @@ func (h *InitializationHandler) buildConfigResponse(ctx context.Context, models 
 			"enabled":   false,
 			"modelName": "",
 			"baseUrl":   "",
-			"apiKey":    "",
+			"credentials": map[string]bool{
+				"apiKey": false,
+			},
 		}
 	}
 
@@ -1485,12 +1493,14 @@ func (h *InitializationHandler) buildConfigResponse(ctx context.Context, models 
 			switch effectiveProvider {
 			case "cos":
 				multimodal["cos"] = map[string]interface{}{
-					"secretId":   kb.StorageConfig.SecretID,
-					"secretKey":  kb.StorageConfig.SecretKey,
 					"region":     kb.StorageConfig.Region,
 					"bucketName": kb.StorageConfig.BucketName,
 					"appId":      kb.StorageConfig.AppID,
 					"pathPrefix": kb.StorageConfig.PathPrefix,
+					"credentials": map[string]bool{
+						"secretId":  kb.StorageConfig.SecretID != "",
+						"secretKey": kb.StorageConfig.SecretKey != "",
+					},
 				}
 			case "minio":
 				multimodal["minio"] = map[string]interface{}{

--- a/internal/handler/initialization_config_redaction_test.go
+++ b/internal/handler/initialization_config_redaction_test.go
@@ -1,0 +1,58 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildConfigResponse_ViewerOmitsModelBaseURL(t *testing.T) {
+	h := &InitializationHandler{}
+	ctx := context.WithValue(context.Background(), types.TenantRoleContextKey, types.TenantRoleViewer)
+	models := []*types.Model{{
+		Type: types.ModelTypeKnowledgeQA,
+		Name: "custom-llm",
+		Parameters: types.ModelParameters{
+			BaseURL: "https://tenant-private.example.com",
+			APIKey:  "sk-secret-do-not-leak",
+		},
+	}}
+	kb := &types.KnowledgeBase{}
+
+	config := h.buildConfigResponse(ctx, models, kb, false)
+	llm, ok := config["llm"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Empty(t, llm["baseUrl"])
+
+	body, err := json.Marshal(config)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "tenant-private.example.com")
+	assert.NotContains(t, string(body), "sk-secret-do-not-leak")
+}
+
+func TestBuildConfigResponse_AdminKeepsModelBaseURL(t *testing.T) {
+	h := &InitializationHandler{}
+	ctx := context.WithValue(context.Background(), types.TenantRoleContextKey, types.TenantRoleAdmin)
+	models := []*types.Model{{
+		Type: types.ModelTypeKnowledgeQA,
+		Name: "custom-llm",
+		Parameters: types.ModelParameters{
+			BaseURL: "https://tenant-private.example.com",
+			APIKey:  "sk-secret-do-not-leak",
+		},
+	}}
+	kb := &types.KnowledgeBase{}
+
+	config := h.buildConfigResponse(ctx, models, kb, false)
+	llm, ok := config["llm"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "https://tenant-private.example.com", llm["baseUrl"])
+
+	body, err := json.Marshal(config)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "sk-secret-do-not-leak")
+}

--- a/internal/handler/mcp_service.go
+++ b/internal/handler/mcp_service.go
@@ -85,7 +85,7 @@ func (h *MCPServiceHandler) CreateMCPService(c *gin.Context) {
 	// construction — no runtime redaction needed.
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    dto.NewMCPServiceResponse(&service),
+		"data":    dto.NewMCPServiceResponse(ctx,&service),
 	})
 }
 
@@ -119,7 +119,7 @@ func (h *MCPServiceHandler) ListMCPServices(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    dto.NewMCPServiceResponses(services),
+		"data":    dto.NewMCPServiceResponses(ctx, services),
 	})
 }
 
@@ -158,7 +158,7 @@ func (h *MCPServiceHandler) GetMCPService(c *gin.Context) {
 	// so the cross-tenant builtin list does not leak per-tenant config.
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    dto.NewMCPServiceResponse(service),
+		"data":    dto.NewMCPServiceResponse(ctx,service),
 	})
 }
 
@@ -351,7 +351,7 @@ func (h *MCPServiceHandler) UpdateMCPService(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    dto.NewMCPServiceResponse(stored),
+		"data":    dto.NewMCPServiceResponse(ctx,stored),
 	})
 }
 

--- a/internal/handler/mcp_service.go
+++ b/internal/handler/mcp_service.go
@@ -85,7 +85,7 @@ func (h *MCPServiceHandler) CreateMCPService(c *gin.Context) {
 	// construction — no runtime redaction needed.
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    dto.NewMCPServiceResponse(ctx,&service),
+		"data":    dto.NewMCPServiceResponse(ctx, &service),
 	})
 }
 
@@ -158,7 +158,7 @@ func (h *MCPServiceHandler) GetMCPService(c *gin.Context) {
 	// so the cross-tenant builtin list does not leak per-tenant config.
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    dto.NewMCPServiceResponse(ctx,service),
+		"data":    dto.NewMCPServiceResponse(ctx, service),
 	})
 }
 
@@ -351,7 +351,7 @@ func (h *MCPServiceHandler) UpdateMCPService(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    dto.NewMCPServiceResponse(ctx,stored),
+		"data":    dto.NewMCPServiceResponse(ctx, stored),
 	})
 }
 

--- a/internal/handler/model.go
+++ b/internal/handler/model.go
@@ -118,7 +118,7 @@ func (h *ModelHandler) CreateModel(c *gin.Context) {
 
 	c.JSON(http.StatusCreated, gin.H{
 		"success": true,
-		"data":    dto.NewModelResponse(ctx,model),
+		"data":    dto.NewModelResponse(ctx, model),
 	})
 }
 
@@ -163,7 +163,7 @@ func (h *ModelHandler) GetModel(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    dto.NewModelResponse(ctx,model),
+		"data":    dto.NewModelResponse(ctx, model),
 	})
 }
 
@@ -634,7 +634,7 @@ func (h *ModelHandler) UpdateModel(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    dto.NewModelResponse(ctx,model),
+		"data":    dto.NewModelResponse(ctx, model),
 	})
 }
 

--- a/internal/handler/model.go
+++ b/internal/handler/model.go
@@ -118,7 +118,7 @@ func (h *ModelHandler) CreateModel(c *gin.Context) {
 
 	c.JSON(http.StatusCreated, gin.H{
 		"success": true,
-		"data":    dto.NewModelResponse(model),
+		"data":    dto.NewModelResponse(ctx,model),
 	})
 }
 
@@ -163,7 +163,7 @@ func (h *ModelHandler) GetModel(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    dto.NewModelResponse(model),
+		"data":    dto.NewModelResponse(ctx,model),
 	})
 }
 
@@ -201,7 +201,7 @@ func (h *ModelHandler) ListModels(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    dto.NewModelResponses(models),
+		"data":    dto.NewModelResponses(ctx, models),
 	})
 }
 
@@ -634,7 +634,7 @@ func (h *ModelHandler) UpdateModel(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    dto.NewModelResponse(model),
+		"data":    dto.NewModelResponse(ctx,model),
 	})
 }
 

--- a/internal/handler/system.go
+++ b/internal/handler/system.go
@@ -326,15 +326,22 @@ func (h *SystemHandler) CheckParserEngines(c *gin.Context) {
 		c.JSON(400, gin.H{"code": 1, "msg": "请求体格式错误"})
 		return
 	}
-	overrides := body.ToOverridesMap()
+	var existing *types.ParserEngineConfig
+	var tenant *types.Tenant
 	if v, exists := c.Get(types.TenantInfoContextKey.String()); exists {
-		if tenant, ok := v.(*types.Tenant); ok && tenant != nil {
-			if creds := tenant.Credentials.GetWeKnoraCloud(); creds != nil {
-				if overrides == nil {
-					overrides = make(map[string]string)
-				}
-				overrides["weknoracloud_app_id"] = creds.AppID
+		if t, ok := v.(*types.Tenant); ok && t != nil {
+			tenant = t
+			existing = t.ParserEngineConfig
+		}
+	}
+	merged := types.MergeParserEngineConfigForUpdate(&body, existing)
+	overrides := merged.ToOverridesMap()
+	if tenant != nil {
+		if creds := tenant.Credentials.GetWeKnoraCloud(); creds != nil {
+			if overrides == nil {
+				overrides = make(map[string]string)
 			}
+			overrides["weknoracloud_app_id"] = creds.AppID
 		}
 	}
 	reader, docreaderAddr, docreaderTransport := h.resolveDocReader(c.Request.Context(), overrides)

--- a/internal/handler/system_parser_check_test.go
+++ b/internal/handler/system_parser_check_test.go
@@ -1,0 +1,29 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParserEngineCheckOverrides_PreservesStoredSecrets(t *testing.T) {
+	body := types.ParserEngineConfig{
+		MinerUAPIKey:          types.RedactedSecretPlaceholder,
+		PaddleOCRVLCloudToken: types.RedactedSecretPlaceholder,
+		MinerUEndpoint:        "http://mineru-new",
+	}
+	existing := &types.ParserEngineConfig{
+		MinerUAPIKey:          "mineru-secret",
+		PaddleOCRVLCloudToken: "paddle-secret",
+		MinerUEndpoint:        "http://mineru-old",
+	}
+
+	merged := types.MergeParserEngineConfigForUpdate(&body, existing)
+	require.NotNil(t, merged)
+	overrides := merged.ToOverridesMap()
+	assert.Equal(t, "mineru-secret", overrides["mineru_api_key"])
+	assert.Equal(t, "paddle-secret", overrides["paddleocr_vl_cloud_token"])
+	assert.Equal(t, "http://mineru-new", overrides["mineru_endpoint"])
+}

--- a/internal/handler/tenant.go
+++ b/internal/handler/tenant.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/handler/dto"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
@@ -411,7 +412,7 @@ func (h *TenantHandler) GetTenant(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    tenant,
+		"data":    dto.NewTenantResponse(ctx, tenant),
 	})
 }
 
@@ -502,7 +503,7 @@ func (h *TenantHandler) UpdateTenant(c *gin.Context) {
 	)
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    updatedTenant,
+		"data":    dto.NewTenantResponse(ctx, updatedTenant),
 	})
 }
 
@@ -852,7 +853,7 @@ func (h *TenantHandler) ListTenants(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"data": gin.H{
-			"items": []*types.Tenant{tenant},
+			"items": []*dto.TenantResponse{dto.NewTenantResponse(ctx, tenant)},
 		},
 	})
 }
@@ -982,6 +983,14 @@ func (h *TenantHandler) SearchTenants(c *gin.Context) {
 func (h *TenantHandler) GetTenantKV(c *gin.Context) {
 	ctx := c.Request.Context()
 	key := secutils.SanitizeForLog(c.Param("key"))
+
+	switch key {
+	case "web-search-config", "parser-engine-config", "storage-engine-config":
+		if !dto.CanViewIntegrationSecrets(ctx) {
+			c.Error(errors.NewForbiddenError("integration configuration requires admin access"))
+			return
+		}
+	}
 
 	switch key {
 	case "web-search-config":
@@ -1120,7 +1129,7 @@ func (h *TenantHandler) GetTenantWebSearchConfig(c *gin.Context) {
 	logger.Infof(ctx, "Tenant web search config retrieved successfully, Tenant ID: %d", tenant.ID)
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    types.EffectiveWebSearchConfig(tenant.WebSearchConfig),
+		"data":    types.WebSearchConfigForResponse(tenant.WebSearchConfig, true),
 	})
 }
 
@@ -1133,7 +1142,7 @@ func (h *TenantHandler) GetTenantParserEngineConfig(c *gin.Context) {
 		c.Error(errors.NewBadRequestError("Tenant is empty"))
 		return
 	}
-	data := tenant.ParserEngineConfig
+	data := types.ParserEngineConfigForResponse(tenant.ParserEngineConfig, true)
 	if data == nil {
 		data = &types.ParserEngineConfig{}
 	}
@@ -1185,7 +1194,7 @@ func (h *TenantHandler) GetTenantStorageEngineConfig(c *gin.Context) {
 		c.Error(errors.NewBadRequestError("Tenant is empty"))
 		return
 	}
-	data := tenant.StorageEngineConfig
+	data := types.StorageEngineConfigForResponse(tenant.StorageEngineConfig, true)
 	if data == nil {
 		data = &types.StorageEngineConfig{}
 	}

--- a/internal/handler/tenant.go
+++ b/internal/handler/tenant.go
@@ -1099,7 +1099,7 @@ func (h *TenantHandler) updateTenantWebSearchConfigInternal(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    types.EffectiveWebSearchConfig(updatedTenant.WebSearchConfig),
+		"data":    types.WebSearchConfigForResponse(updatedTenant.WebSearchConfig, true),
 		"message": "Web search configuration updated successfully",
 	})
 }
@@ -1180,7 +1180,7 @@ func (h *TenantHandler) updateTenantParserEngineConfigInternal(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    updatedTenant.ParserEngineConfig,
+		"data":    types.ParserEngineConfigForResponse(updatedTenant.ParserEngineConfig, true),
 		"message": "解析引擎配置已更新",
 	})
 }
@@ -1245,7 +1245,7 @@ func (h *TenantHandler) updateTenantStorageEngineConfigInternal(c *gin.Context) 
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    updatedTenant.StorageEngineConfig,
+		"data":    types.StorageEngineConfigForResponse(updatedTenant.StorageEngineConfig, true),
 		"message": "存储引擎配置已更新",
 	})
 }

--- a/internal/handler/tenant.go
+++ b/internal/handler/tenant.go
@@ -890,7 +890,7 @@ func (h *TenantHandler) ListAllTenants(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"data": gin.H{
-			"items": tenants,
+			"items": dto.NewTenantResponsesCrossTenant(tenants),
 		},
 	})
 }
@@ -960,7 +960,7 @@ func (h *TenantHandler) SearchTenants(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"data": gin.H{
-			"items":     tenants,
+			"items":     dto.NewTenantResponsesCrossTenant(tenants),
 			"total":     total,
 			"page":      page,
 			"page_size": pageSize,
@@ -1070,18 +1070,18 @@ func (h *TenantHandler) updateTenantWebSearchConfigInternal(c *gin.Context) {
 		return
 	}
 
-	cfg = *types.EffectiveWebSearchConfig(&cfg)
-
-	// Validate configuration
-	if cfg.MaxResults < 1 || cfg.MaxResults > 50 {
-		c.Error(errors.NewBadRequestError("max_results must be between 1 and 50"))
-		return
-	}
-
 	tenant, _ := types.TenantInfoFromContext(ctx)
 	if tenant == nil {
 		logger.Error(ctx, "Tenant is empty")
 		c.Error(errors.NewBadRequestError("Tenant is empty"))
+		return
+	}
+
+	cfg = *types.MergeWebSearchConfigForUpdate(&cfg, tenant.WebSearchConfig)
+
+	// Validate configuration
+	if cfg.MaxResults < 1 || cfg.MaxResults > 50 {
+		c.Error(errors.NewBadRequestError("max_results must be between 1 and 50"))
 		return
 	}
 
@@ -1167,7 +1167,8 @@ func (h *TenantHandler) updateTenantParserEngineConfigInternal(c *gin.Context) {
 		c.Error(errors.NewBadRequestError("Tenant is empty"))
 		return
 	}
-	tenant.ParserEngineConfig = &cfg
+	merged := types.MergeParserEngineConfigForUpdate(&cfg, tenant.ParserEngineConfig)
+	tenant.ParserEngineConfig = merged
 	updatedTenant, err := h.service.UpdateTenant(ctx, tenant)
 	if err != nil {
 		if appErr, ok := errors.IsAppError(err); ok {
@@ -1232,7 +1233,8 @@ func (h *TenantHandler) updateTenantStorageEngineConfigInternal(c *gin.Context) 
 		c.Error(errors.NewBadRequestError("Tenant is empty"))
 		return
 	}
-	tenant.StorageEngineConfig = &cfg
+	merged := types.MergeStorageEngineConfigForUpdate(&cfg, tenant.StorageEngineConfig)
+	tenant.StorageEngineConfig = merged
 	updatedTenant, err := h.service.UpdateTenant(ctx, tenant)
 	if err != nil {
 		if appErr, ok := errors.IsAppError(err); ok {

--- a/internal/handler/tenant_secret_disclosure_test.go
+++ b/internal/handler/tenant_secret_disclosure_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Tencent/WeKnora/internal/middleware"
@@ -18,6 +19,11 @@ type stubTenantService struct {
 	tenant *types.Tenant
 }
 
+func (s *stubTenantService) UpdateTenant(_ context.Context, tenant *types.Tenant) (*types.Tenant, error) {
+	s.tenant = tenant
+	return tenant, nil
+}
+
 func (s *stubTenantService) CreateTenant(context.Context, *types.Tenant) (*types.Tenant, error) {
 	return nil, nil
 }
@@ -26,9 +32,6 @@ func (s *stubTenantService) GetTenantByID(context.Context, uint64) (*types.Tenan
 }
 func (s *stubTenantService) GetTenantsByIDs(context.Context, []uint64) (map[uint64]*types.Tenant, error) {
 	return map[uint64]*types.Tenant{s.tenant.ID: s.tenant}, nil
-}
-func (s *stubTenantService) UpdateTenant(context.Context, *types.Tenant) (*types.Tenant, error) {
-	return s.tenant, nil
 }
 func (s *stubTenantService) DeleteTenant(context.Context, uint64) error { return nil }
 func (s *stubTenantService) ListTenants(context.Context) ([]*types.Tenant, error) {
@@ -71,6 +74,7 @@ func newTenantHandlerTestEngine(t *testing.T, role types.TenantRole, tenant *typ
 	r.GET("/tenants", h.ListTenants)
 	r.GET("/tenants/:id", h.GetTenant)
 	r.GET("/tenants/kv/:key", h.GetTenantKV)
+	r.PUT("/tenants/kv/:key", h.UpdateTenantKV)
 	return r
 }
 
@@ -159,4 +163,19 @@ func TestGetTenantKVViewerAllowedForNonSecretKey(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/tenants/kv/retrieval-config", nil)
 	engine.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestPutTenantParserConfigAdminPreservesRedactedSecrets(t *testing.T) {
+	tenant := secretTenantFixture()
+	engine := newTenantHandlerTestEngine(t, types.TenantRoleAdmin, tenant)
+
+	body := `{"mineru_api_key":"***","mineru_endpoint":"http://new-endpoint"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/tenants/kv/parser-engine-config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, tenant.ParserEngineConfig)
+	assert.Equal(t, "parser-secret-123", tenant.ParserEngineConfig.MinerUAPIKey)
+	assert.Equal(t, "http://new-endpoint", tenant.ParserEngineConfig.MinerUEndpoint)
 }

--- a/internal/handler/tenant_secret_disclosure_test.go
+++ b/internal/handler/tenant_secret_disclosure_test.go
@@ -1,0 +1,162 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/middleware"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubTenantService struct {
+	tenant *types.Tenant
+}
+
+func (s *stubTenantService) CreateTenant(context.Context, *types.Tenant) (*types.Tenant, error) {
+	return nil, nil
+}
+func (s *stubTenantService) GetTenantByID(context.Context, uint64) (*types.Tenant, error) {
+	return s.tenant, nil
+}
+func (s *stubTenantService) GetTenantsByIDs(context.Context, []uint64) (map[uint64]*types.Tenant, error) {
+	return map[uint64]*types.Tenant{s.tenant.ID: s.tenant}, nil
+}
+func (s *stubTenantService) UpdateTenant(context.Context, *types.Tenant) (*types.Tenant, error) {
+	return s.tenant, nil
+}
+func (s *stubTenantService) DeleteTenant(context.Context, uint64) error { return nil }
+func (s *stubTenantService) ListTenants(context.Context) ([]*types.Tenant, error) {
+	return []*types.Tenant{s.tenant}, nil
+}
+func (s *stubTenantService) ListAllTenants(context.Context) ([]*types.Tenant, error) {
+	return nil, nil
+}
+func (s *stubTenantService) SearchTenants(context.Context, string, uint64, int, int) ([]*types.Tenant, int64, error) {
+	return nil, 0, nil
+}
+func (s *stubTenantService) UpdateAPIKey(context.Context, uint64) (string, error) { return "", nil }
+func (s *stubTenantService) ExtractTenantIDFromAPIKey(string) (uint64, error)      { return 0, nil }
+func (s *stubTenantService) BulkSetStorageQuota(context.Context, int64) (int64, error) {
+	return 0, nil
+}
+func (s *stubTenantService) GetTenantByIDForUser(context.Context, uint64, string) (*types.Tenant, error) {
+	return s.tenant, nil
+}
+func (s *stubTenantService) GetWeKnoraCloudCredentials(context.Context) *types.WeKnoraCloudCredentials {
+	return nil
+}
+
+func newTenantHandlerTestEngine(t *testing.T, role types.TenantRole, tenant *types.Tenant) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	h := &TenantHandler{service: &stubTenantService{tenant: tenant}}
+
+	r := gin.New()
+	r.Use(middleware.ErrorHandler())
+	r.Use(func(c *gin.Context) {
+		ctx := c.Request.Context()
+		ctx = context.WithValue(ctx, types.TenantIDContextKey, tenant.ID)
+		ctx = context.WithValue(ctx, types.TenantRoleContextKey, role)
+		ctx = context.WithValue(ctx, types.TenantInfoContextKey, tenant)
+		c.Request = c.Request.WithContext(ctx)
+		c.Set(types.TenantIDContextKey.String(), tenant.ID)
+		c.Next()
+	})
+	r.GET("/tenants", h.ListTenants)
+	r.GET("/tenants/:id", h.GetTenant)
+	r.GET("/tenants/kv/:key", h.GetTenantKV)
+	return r
+}
+
+func TestListTenantsViewerDoesNotLeakSecrets(t *testing.T) {
+	tenant := secretTenantFixture()
+	engine := newTenantHandlerTestEngine(t, types.TenantRoleViewer, tenant)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/tenants", nil)
+	engine.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	body := rec.Body.String()
+	assert.NotContains(t, body, "tenant-api-key-123")
+	assert.NotContains(t, body, "parser-secret-123")
+}
+
+func TestGetTenantViewerDoesNotLeakSecrets(t *testing.T) {
+	tenant := secretTenantFixture()
+	engine := newTenantHandlerTestEngine(t, types.TenantRoleViewer, tenant)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/tenants/42", nil)
+	engine.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "tenant-api-key-123")
+}
+
+func TestGetTenantKVViewerForbiddenForSecretKeys(t *testing.T) {
+	tenant := secretTenantFixture()
+	engine := newTenantHandlerTestEngine(t, types.TenantRoleViewer, tenant)
+
+	for _, key := range []string{"web-search-config", "parser-engine-config", "storage-engine-config"} {
+		t.Run(key, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/tenants/kv/"+key, nil)
+			engine.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusForbidden, rec.Code)
+		})
+	}
+}
+
+func TestGetTenantKVAdminReturnsRedactedSecrets(t *testing.T) {
+	tenant := secretTenantFixture()
+	engine := newTenantHandlerTestEngine(t, types.TenantRoleAdmin, tenant)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/tenants/kv/parser-engine-config", nil)
+	engine.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var payload struct {
+		Success bool                           `json:"success"`
+		Data    types.ParserEngineConfig       `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+	assert.Equal(t, types.RedactedSecretPlaceholder, payload.Data.MinerUAPIKey)
+	assert.NotContains(t, rec.Body.String(), "parser-secret-123")
+}
+
+func secretTenantFixture() *types.Tenant {
+	return &types.Tenant{
+		ID:     42,
+		Name:   "tenant",
+		APIKey: "tenant-api-key-123",
+		WebSearchConfig: &types.WebSearchConfig{
+			APIKey: "legacy-search-secret-999",
+		},
+		ParserEngineConfig: &types.ParserEngineConfig{
+			MinerUAPIKey: "parser-secret-123",
+		},
+		StorageEngineConfig: &types.StorageEngineConfig{
+			MinIO: &types.MinIOEngineConfig{
+				SecretAccessKey: "minio-secret-789",
+			},
+		},
+	}
+}
+
+func TestGetTenantKVViewerAllowedForNonSecretKey(t *testing.T) {
+	tenant := secretTenantFixture()
+	tenant.RetrievalConfig = &types.RetrievalConfig{}
+	engine := newTenantHandlerTestEngine(t, types.TenantRoleViewer, tenant)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/tenants/kv/retrieval-config", nil)
+	engine.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+}

--- a/internal/handler/web_search_provider.go
+++ b/internal/handler/web_search_provider.go
@@ -111,7 +111,7 @@ func (h *WebSearchProviderHandler) CreateProvider(c *gin.Context) {
 
 	c.JSON(http.StatusCreated, gin.H{
 		"success": true,
-		"data":    dto.NewWebSearchProviderResponse(ctx,provider),
+		"data":    dto.NewWebSearchProviderResponse(ctx, provider),
 	})
 }
 
@@ -169,7 +169,7 @@ func (h *WebSearchProviderHandler) GetProvider(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    dto.NewWebSearchProviderResponse(ctx,provider),
+		"data":    dto.NewWebSearchProviderResponse(ctx, provider),
 	})
 }
 
@@ -263,7 +263,7 @@ func (h *WebSearchProviderHandler) UpdateProvider(c *gin.Context) {
 	// Re-fetch to get the full stored state
 	updated, _ := h.repo.GetByID(ctx, tenantID, id)
 	if updated != nil {
-		c.JSON(http.StatusOK, gin.H{"success": true, "data": dto.NewWebSearchProviderResponse(ctx,updated)})
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": dto.NewWebSearchProviderResponse(ctx, updated)})
 	} else {
 		c.JSON(http.StatusOK, gin.H{"success": true})
 	}

--- a/internal/handler/web_search_provider.go
+++ b/internal/handler/web_search_provider.go
@@ -111,7 +111,7 @@ func (h *WebSearchProviderHandler) CreateProvider(c *gin.Context) {
 
 	c.JSON(http.StatusCreated, gin.H{
 		"success": true,
-		"data":    dto.NewWebSearchProviderResponse(provider),
+		"data":    dto.NewWebSearchProviderResponse(ctx,provider),
 	})
 }
 
@@ -134,7 +134,7 @@ func (h *WebSearchProviderHandler) ListProviders(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    dto.NewWebSearchProviderResponses(providers),
+		"data":    dto.NewWebSearchProviderResponses(ctx, providers),
 	})
 }
 
@@ -169,7 +169,7 @@ func (h *WebSearchProviderHandler) GetProvider(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"data":    dto.NewWebSearchProviderResponse(provider),
+		"data":    dto.NewWebSearchProviderResponse(ctx,provider),
 	})
 }
 
@@ -263,7 +263,7 @@ func (h *WebSearchProviderHandler) UpdateProvider(c *gin.Context) {
 	// Re-fetch to get the full stored state
 	updated, _ := h.repo.GetByID(ctx, tenantID, id)
 	if updated != nil {
-		c.JSON(http.StatusOK, gin.H{"success": true, "data": dto.NewWebSearchProviderResponse(updated)})
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": dto.NewWebSearchProviderResponse(ctx,updated)})
 	} else {
 		c.JSON(http.StatusOK, gin.H{"success": true})
 	}

--- a/internal/types/config_redaction.go
+++ b/internal/types/config_redaction.go
@@ -141,3 +141,112 @@ func CredentialsConfigForResponse(cfg *CredentialsConfig, maskSecrets bool) *Cre
 	}
 	return &out
 }
+
+// MergeWebSearchConfigForUpdate applies preserve semantics to secret fields on
+// tenant KV PUT.
+func MergeWebSearchConfigForUpdate(incoming, existing *WebSearchConfig) *WebSearchConfig {
+	out := *EffectiveWebSearchConfig(incoming)
+	var prev WebSearchConfig
+	if existing != nil {
+		prev = *EffectiveWebSearchConfig(existing)
+	}
+	out.APIKey = PreserveIfRedacted(out.APIKey, prev.APIKey)
+	out.ProxyURL = PreserveIfRedacted(out.ProxyURL, prev.ProxyURL)
+	return &out
+}
+
+// MergeParserEngineConfigForUpdate applies preserve semantics to secret fields
+// on tenant KV PUT.
+func MergeParserEngineConfigForUpdate(incoming, existing *ParserEngineConfig) *ParserEngineConfig {
+	if incoming == nil {
+		return nil
+	}
+	out := *incoming
+	var prev ParserEngineConfig
+	if existing != nil {
+		prev = *existing
+	}
+	out.MinerUAPIKey = PreserveIfRedacted(out.MinerUAPIKey, prev.MinerUAPIKey)
+	out.PaddleOCRVLCloudToken = PreserveIfRedacted(out.PaddleOCRVLCloudToken, prev.PaddleOCRVLCloudToken)
+	return &out
+}
+
+// MergeStorageEngineConfigForUpdate applies preserve semantics to provider
+// secret fields on tenant KV PUT.
+func MergeStorageEngineConfigForUpdate(incoming, existing *StorageEngineConfig) *StorageEngineConfig {
+	if incoming == nil {
+		return nil
+	}
+	out := *incoming
+	if out.MinIO != nil {
+		minio := *out.MinIO
+		var prev MinIOEngineConfig
+		if existing != nil && existing.MinIO != nil {
+			prev = *existing.MinIO
+		}
+		minio.AccessKeyID = PreserveIfRedacted(minio.AccessKeyID, prev.AccessKeyID)
+		minio.SecretAccessKey = PreserveIfRedacted(minio.SecretAccessKey, prev.SecretAccessKey)
+		out.MinIO = &minio
+	}
+	if out.COS != nil {
+		cos := *out.COS
+		var prev COSEngineConfig
+		if existing != nil && existing.COS != nil {
+			prev = *existing.COS
+		}
+		cos.SecretID = PreserveIfRedacted(cos.SecretID, prev.SecretID)
+		cos.SecretKey = PreserveIfRedacted(cos.SecretKey, prev.SecretKey)
+		out.COS = &cos
+	}
+	if out.TOS != nil {
+		tos := *out.TOS
+		var prev TOSEngineConfig
+		if existing != nil && existing.TOS != nil {
+			prev = *existing.TOS
+		}
+		tos.AccessKey = PreserveIfRedacted(tos.AccessKey, prev.AccessKey)
+		tos.SecretKey = PreserveIfRedacted(tos.SecretKey, prev.SecretKey)
+		out.TOS = &tos
+	}
+	if out.S3 != nil {
+		s3 := *out.S3
+		var prev S3EngineConfig
+		if existing != nil && existing.S3 != nil {
+			prev = *existing.S3
+		}
+		s3.AccessKey = PreserveIfRedacted(s3.AccessKey, prev.AccessKey)
+		s3.SecretKey = PreserveIfRedacted(s3.SecretKey, prev.SecretKey)
+		out.S3 = &s3
+	}
+	if out.OSS != nil {
+		oss := *out.OSS
+		var prev OSSEngineConfig
+		if existing != nil && existing.OSS != nil {
+			prev = *existing.OSS
+		}
+		oss.AccessKey = PreserveIfRedacted(oss.AccessKey, prev.AccessKey)
+		oss.SecretKey = PreserveIfRedacted(oss.SecretKey, prev.SecretKey)
+		out.OSS = &oss
+	}
+	if out.KS3 != nil {
+		ks3 := *out.KS3
+		var prev KS3EngineConfig
+		if existing != nil && existing.KS3 != nil {
+			prev = *existing.KS3
+		}
+		ks3.AccessKey = PreserveIfRedacted(ks3.AccessKey, prev.AccessKey)
+		ks3.SecretKey = PreserveIfRedacted(ks3.SecretKey, prev.SecretKey)
+		out.KS3 = &ks3
+	}
+	if out.OBS != nil {
+		obs := *out.OBS
+		var prev OBSEngineConfig
+		if existing != nil && existing.OBS != nil {
+			prev = *existing.OBS
+		}
+		obs.AccessKey = PreserveIfRedacted(obs.AccessKey, prev.AccessKey)
+		obs.SecretKey = PreserveIfRedacted(obs.SecretKey, prev.SecretKey)
+		out.OBS = &obs
+	}
+	return &out
+}

--- a/internal/types/config_redaction.go
+++ b/internal/types/config_redaction.go
@@ -1,0 +1,143 @@
+package types
+
+import "strings"
+
+// WebSearchConfigForResponse returns a copy safe for HTTP responses.
+// When maskSecrets is true, api_key is omitted and a configured proxy_url
+// is replaced with RedactedSecretPlaceholder.
+func WebSearchConfigForResponse(cfg *WebSearchConfig, maskSecrets bool) *WebSearchConfig {
+	if cfg == nil {
+		return nil
+	}
+	out := *EffectiveWebSearchConfig(cfg)
+	if !maskSecrets {
+		return &out
+	}
+	out.APIKey = ""
+	if strings.TrimSpace(out.ProxyURL) != "" {
+		out.ProxyURL = RedactedSecretPlaceholder
+	}
+	return &out
+}
+
+// ParserEngineConfigForResponse returns a copy with secret fields redacted
+// when maskSecrets is true.
+func ParserEngineConfigForResponse(cfg *ParserEngineConfig, maskSecrets bool) *ParserEngineConfig {
+	if cfg == nil {
+		return nil
+	}
+	out := *cfg
+	if !maskSecrets {
+		return &out
+	}
+	if out.MinerUAPIKey != "" {
+		out.MinerUAPIKey = RedactedSecretPlaceholder
+	}
+	if out.PaddleOCRVLCloudToken != "" {
+		out.PaddleOCRVLCloudToken = RedactedSecretPlaceholder
+	}
+	return &out
+}
+
+// StorageEngineConfigForResponse returns a copy with provider secret fields
+// redacted when maskSecrets is true.
+func StorageEngineConfigForResponse(cfg *StorageEngineConfig, maskSecrets bool) *StorageEngineConfig {
+	if cfg == nil {
+		return nil
+	}
+	out := *cfg
+	if !maskSecrets {
+		return &out
+	}
+	if out.MinIO != nil {
+		minio := *out.MinIO
+		if minio.AccessKeyID != "" {
+			minio.AccessKeyID = RedactedSecretPlaceholder
+		}
+		if minio.SecretAccessKey != "" {
+			minio.SecretAccessKey = RedactedSecretPlaceholder
+		}
+		out.MinIO = &minio
+	}
+	if out.COS != nil {
+		cos := *out.COS
+		if cos.SecretID != "" {
+			cos.SecretID = RedactedSecretPlaceholder
+		}
+		if cos.SecretKey != "" {
+			cos.SecretKey = RedactedSecretPlaceholder
+		}
+		out.COS = &cos
+	}
+	if out.TOS != nil {
+		tos := *out.TOS
+		if tos.AccessKey != "" {
+			tos.AccessKey = RedactedSecretPlaceholder
+		}
+		if tos.SecretKey != "" {
+			tos.SecretKey = RedactedSecretPlaceholder
+		}
+		out.TOS = &tos
+	}
+	if out.S3 != nil {
+		s3 := *out.S3
+		if s3.AccessKey != "" {
+			s3.AccessKey = RedactedSecretPlaceholder
+		}
+		if s3.SecretKey != "" {
+			s3.SecretKey = RedactedSecretPlaceholder
+		}
+		out.S3 = &s3
+	}
+	if out.OSS != nil {
+		oss := *out.OSS
+		if oss.AccessKey != "" {
+			oss.AccessKey = RedactedSecretPlaceholder
+		}
+		if oss.SecretKey != "" {
+			oss.SecretKey = RedactedSecretPlaceholder
+		}
+		out.OSS = &oss
+	}
+	if out.KS3 != nil {
+		ks3 := *out.KS3
+		if ks3.AccessKey != "" {
+			ks3.AccessKey = RedactedSecretPlaceholder
+		}
+		if ks3.SecretKey != "" {
+			ks3.SecretKey = RedactedSecretPlaceholder
+		}
+		out.KS3 = &ks3
+	}
+	if out.OBS != nil {
+		obs := *out.OBS
+		if obs.AccessKey != "" {
+			obs.AccessKey = RedactedSecretPlaceholder
+		}
+		if obs.SecretKey != "" {
+			obs.SecretKey = RedactedSecretPlaceholder
+		}
+		out.OBS = &obs
+	}
+	return &out
+}
+
+// CredentialsConfigForResponse returns a copy with app_secret redacted when
+// maskSecrets is true.
+func CredentialsConfigForResponse(cfg *CredentialsConfig, maskSecrets bool) *CredentialsConfig {
+	if cfg == nil {
+		return nil
+	}
+	out := *cfg
+	if !maskSecrets {
+		return &out
+	}
+	if out.WeKnoraCloud != nil {
+		cloud := *out.WeKnoraCloud
+		if cloud.AppSecret != "" {
+			cloud.AppSecret = RedactedSecretPlaceholder
+		}
+		out.WeKnoraCloud = &cloud
+	}
+	return &out
+}

--- a/internal/types/config_redaction_test.go
+++ b/internal/types/config_redaction_test.go
@@ -1,0 +1,92 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebSearchConfigForResponse_MasksSecrets(t *testing.T) {
+	cfg := &WebSearchConfig{
+		APIKey:   "search-secret",
+		ProxyURL: "http://proxy.internal:8080",
+	}
+	resp := WebSearchConfigForResponse(cfg, true)
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.APIKey)
+	assert.Equal(t, RedactedSecretPlaceholder, resp.ProxyURL)
+}
+
+func TestWebSearchConfigForResponse_Unmasked(t *testing.T) {
+	cfg := &WebSearchConfig{APIKey: "search-secret", ProxyURL: "http://proxy"}
+	resp := WebSearchConfigForResponse(cfg, false)
+	require.NotNil(t, resp)
+	assert.Equal(t, "search-secret", resp.APIKey)
+	assert.Equal(t, "http://proxy", resp.ProxyURL)
+}
+
+func TestMergeWebSearchConfigForUpdate_PreservesRedactedSecrets(t *testing.T) {
+	existing := &WebSearchConfig{APIKey: "stored-key", ProxyURL: "http://stored"}
+	incoming := &WebSearchConfig{
+		APIKey:     "",
+		ProxyURL:   RedactedSecretPlaceholder,
+		MaxResults: 10,
+	}
+	merged := MergeWebSearchConfigForUpdate(incoming, existing)
+	require.NotNil(t, merged)
+	assert.Equal(t, "stored-key", merged.APIKey)
+	assert.Equal(t, "http://stored", merged.ProxyURL)
+	assert.Equal(t, 10, merged.MaxResults)
+}
+
+func TestMergeParserEngineConfigForUpdate_PreservesRedactedSecrets(t *testing.T) {
+	existing := &ParserEngineConfig{
+		MinerUAPIKey:          "mineru-secret",
+		PaddleOCRVLCloudToken: "paddle-secret",
+		MinerUEndpoint:        "http://mineru",
+	}
+	incoming := &ParserEngineConfig{
+		MinerUAPIKey:          RedactedSecretPlaceholder,
+		PaddleOCRVLCloudToken: RedactedSecretPlaceholder,
+		MinerUEndpoint:        "http://mineru-new",
+	}
+	merged := MergeParserEngineConfigForUpdate(incoming, existing)
+	require.NotNil(t, merged)
+	assert.Equal(t, "mineru-secret", merged.MinerUAPIKey)
+	assert.Equal(t, "paddle-secret", merged.PaddleOCRVLCloudToken)
+	assert.Equal(t, "http://mineru-new", merged.MinerUEndpoint)
+}
+
+func TestMergeStorageEngineConfigForUpdate_PreservesRedactedSecrets(t *testing.T) {
+	existing := &StorageEngineConfig{
+		DefaultProvider: "minio",
+		MinIO: &MinIOEngineConfig{
+			AccessKeyID:     "access-id",
+			SecretAccessKey: "secret-key",
+			BucketName:      "bucket",
+		},
+	}
+	incoming := &StorageEngineConfig{
+		DefaultProvider: "minio",
+		MinIO: &MinIOEngineConfig{
+			AccessKeyID:     RedactedSecretPlaceholder,
+			SecretAccessKey: RedactedSecretPlaceholder,
+			BucketName:      "bucket-new",
+		},
+	}
+	merged := MergeStorageEngineConfigForUpdate(incoming, existing)
+	require.NotNil(t, merged)
+	require.NotNil(t, merged.MinIO)
+	assert.Equal(t, "access-id", merged.MinIO.AccessKeyID)
+	assert.Equal(t, "secret-key", merged.MinIO.SecretAccessKey)
+	assert.Equal(t, "bucket-new", merged.MinIO.BucketName)
+}
+
+func TestParserEngineConfigForResponse_NilSafe(t *testing.T) {
+	assert.Nil(t, ParserEngineConfigForResponse(nil, true))
+}
+
+func TestStorageEngineConfigForResponse_NilSafe(t *testing.T) {
+	assert.Nil(t, StorageEngineConfigForResponse(nil, true))
+}

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -1,23 +1,32 @@
-// Package types — shared secret-handling helpers.
+// Package types — shared secret redaction helpers.
 //
-// Historically this file also held PreserveIfRedacted / IsRedactedOrEmpty
-// to support the old "echo redacted placeholder back, server merges on
-// Update" pattern shared by MCP / Model / WebSearch / DataSource. Those
-// resources have since moved to the credential-resource pattern (a
-// dedicated /credentials subresource), so the merge helpers were removed.
+// VectorStore connection configs and tenant KV configs (web search, parser
+// engine, storage engine) use the redacted-placeholder round-trip pattern:
 //
-// The placeholder constant survives because VectorStore connection configs
-// still inline-redact a Password / APIKey on response (see
-// types/vectorstore.go → ConnectionConfig.MaskSensitiveFields); migrating
-// VectorStore to the credential-resource pattern is left for a future PR
-// because it would require introducing a separate connection record (the
-// secret currently lives inline on the knowledge base config).
+//   - GET responses replace set secrets with RedactedSecretPlaceholder (or
+//     empty string when unset).
+//   - PUT requests treat "", or RedactedSecretPlaceholder as "preserve
+//     existing"; any other value replaces the stored secret.
+//
+// MCP / Model / WebSearch provider / DataSource credentials use a dedicated
+// /credentials subresource instead; see internal/handler/dto/mcp.go.
 package types
 
 // RedactedSecretPlaceholder is the fixed value returned in API responses
-// whenever a sensitive field is set but withheld from the client. Currently
-// used only by VectorStore connection responses. New code should NOT
-// introduce redacted-placeholder semantics — model the credential as a
-// subresource and omit it from the main response shape instead (see
-// internal/handler/dto/mcp.go for the template).
+// whenever a sensitive field is set but withheld from the client.
 const RedactedSecretPlaceholder = "***"
+
+// IsRedactedOrEmpty reports whether s should be treated as "no change
+// requested" in an Update request.
+func IsRedactedOrEmpty(s string) bool {
+	return s == "" || s == RedactedSecretPlaceholder
+}
+
+// PreserveIfRedacted returns existing when incoming is empty or the redacted
+// placeholder, otherwise returns incoming.
+func PreserveIfRedacted(incoming, existing string) string {
+	if IsRedactedOrEmpty(incoming) {
+		return existing
+	}
+	return incoming
+}

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -1,0 +1,45 @@
+package types
+
+import "testing"
+
+func TestIsRedactedOrEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty string is redacted-or-empty", "", true},
+		{"fixed placeholder is redacted-or-empty", RedactedSecretPlaceholder, true},
+		{"short real secret is not redacted", "ab", false},
+		{"real secret longer than placeholder is not redacted", "real-bearer-token", false},
+		{"secret containing placeholder substring is not redacted", "prefix***suffix", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsRedactedOrEmpty(tt.in); got != tt.want {
+				t.Errorf("IsRedactedOrEmpty(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPreserveIfRedacted(t *testing.T) {
+	tests := []struct {
+		name     string
+		incoming string
+		existing string
+		want     string
+	}{
+		{"empty incoming preserves existing", "", "stored-secret", "stored-secret"},
+		{"placeholder incoming preserves existing", RedactedSecretPlaceholder, "stored-secret", "stored-secret"},
+		{"real incoming replaces existing", "new-secret", "stored-secret", "new-secret"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PreserveIfRedacted(tt.incoming, tt.existing); got != tt.want {
+				t.Errorf("PreserveIfRedacted(%q, %q) = %q, want %q",
+					tt.incoming, tt.existing, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Harden tenant integration secret handling so low-privileged members cannot read raw credentials from HTTP responses.

- **Role-aware DTOs:** Viewer callers no longer receive tenant `api_key`, parser/storage/web-search credentials, or auxiliary integration details (`custom_headers`, `env_vars`, `proxy_url`, MCP URL/stdio config, model `base_url`, etc.). Owner still receives `api_key`; Admin receives redacted integration config blocks.
- **Tenant KV:** Secret-bearing `GET /tenants/kv/{web-search-config,parser-engine-config,storage-engine-config}` is Admin+ only. Admin GET/PUT responses use `***` placeholders; PUT merges with `PreserveIfRedacted` so unchanged secrets are not wiped.
- **Cross-tenant listings:** `/tenants/all` and `/tenants/search` always redact every tenant as Viewer, regardless of the caller's home-tenant role.
- **Auth payloads:** Login, switch-tenant, auto-setup, register-by-invite, OIDC callback, and `/auth/me` all use the same tenant redaction rules.
- **Initialization config:** `GET /initialization/config/:kbId` exposes `credentials.configured` metadata instead of model API keys / COS secret values; Viewer responses also omit custom model `baseUrl`.
- **Parser engine check:** `POST /system/parser-engines/check` merges redacted form values with stored tenant secrets before building overrides, so Admin "test connection" still works after masked GET responses.
- **Frontend types:** `frontend/src/api/initialization/index.ts` aligned with `credentials` metadata from GET responses.

Addresses GHSA-427r-5jrh-j4fh, GHSA-w53m-w3vg-hm2v, GHSA-qmch-634c-jpfj, and GHSA-wwx9-hj6g-rp5f.

## Commits

1. Role-aware DTOs + tenant/KV/model/MCP/web-search/init-config redaction
2. Auth login/OIDC/switch-tenant payloads + masked tenant KV PUT responses
3. KV PUT secret preservation, cross-tenant listing redaction, Viewer MCP/model tightening
4. Init-config `baseUrl` redaction for Viewer + parser-check secret merge

## Test plan

- [x] `go test ./internal/handler/dto/ -count=1`
- [x] `go test ./internal/handler/ -count=1`
- [x] `go test ./internal/types/ -count=1`
- [x] `TestPutTenantParserConfigAdminPreservesRedactedSecrets` (KV PUT round-trip)
- [x] `TestBuildConfigResponse_ViewerOmitsModelBaseURL` / `TestBuildConfigResponse_AdminKeepsModelBaseURL`
- [x] `TestParserEngineCheckOverrides_PreservesStoredSecrets`
- [ ] Manual: authenticate as Viewer and confirm `POST /auth/login`, `GET /tenants`, `GET /tenants/:id`, `GET /initialization/config/:kbId`, and secret KV keys do not return raw credentials or private endpoints
- [ ] Manual: authenticate as Admin and confirm settings pages load with redacted placeholders; save without changing secrets; parser "test connection" succeeds with unchanged `***` fields
- [ ] Manual: authenticate as Owner and confirm login/`/auth/me` still expose `api_key`