### PR TITLE
fix(security): close open GHSA findings from security triage

### DIFF
--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -649,7 +649,8 @@ const wikiDrawerContent = computed(() => {
     return `<a href="#" class="wiki-content-link citation-wiki" data-slug="${escapeHtml(slug)}">${escapeHtml(display)}</a>`;
   });
 
-  return wrapChatMarkdownTables(marked.parse(preprocessed, { breaks: true, async: false }) as string);
+  const html = marked.parse(preprocessed, { breaks: true, async: false }) as string;
+  return sanitizeMarkdownHTML(wrapChatMarkdownTables(html));
 });
 
 watch(wikiDrawerContent, async () => {

--- a/frontend/src/views/knowledge/wiki/WikiBrowser.vue
+++ b/frontend/src/views/knowledge/wiki/WikiBrowser.vue
@@ -699,7 +699,7 @@ import { useI18n } from 'vue-i18n'
 import { marked } from 'marked'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { RecycleScroller } from 'vue-virtual-scroller'
-import { hydrateProtectedFileImages } from '@/utils/security'
+import { hydrateProtectedFileImages, sanitizeMarkdownHTML } from '@/utils/security'
 import picturePreview from '@/components/picture-preview.vue'
 import WikiFolderActions from './WikiFolderActions.vue'
 import { createSessions } from '@/api/chat'
@@ -1398,8 +1398,8 @@ function renderMarkdown(content: string): string {
     return `<a href="#" class="wiki-content-link" data-slug="${slug}">${display}</a>`
   })
 
-  // Use marked to render the markdown to HTML
-  return marked.parse(preprocessed, { breaks: true, async: false }) as string
+  const html = marked.parse(preprocessed, { breaks: true, async: false }) as string
+  return sanitizeMarkdownHTML(html)
 }
 
 async function openGraphDrawer(slug: string) {

--- a/internal/application/service/user.go
+++ b/internal/application/service/user.go
@@ -27,11 +27,6 @@ import (
 	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
 
-type oidcAuthorizationState struct {
-	Nonce       string `json:"nonce"`
-	RedirectURI string `json:"redirect_uri,omitempty"`
-}
-
 var (
 	jwtSecretOnce sync.Once
 	jwtSecret     string
@@ -367,7 +362,7 @@ func (s *userService) GetOIDCAuthorizationURL(ctx context.Context, redirectURI s
 		return nil, fmt.Errorf("failed to generate state: %w", err)
 	}
 
-	state, err := encodeOIDCAuthorizationState(&oidcAuthorizationState{
+	state, err := secutils.SignOIDCState(&secutils.OIDCStatePayload{
 		Nonce:       nonce,
 		RedirectURI: strings.TrimSpace(redirectURI),
 	})
@@ -394,6 +389,7 @@ func (s *userService) GetOIDCAuthorizationURL(ctx context.Context, redirectURI s
 		ProviderDisplayName: cfg.ProviderDisplayName,
 		AuthorizationURL:    authURL,
 		State:               state,
+		Nonce:               nonce,
 	}, nil
 }
 
@@ -592,7 +588,13 @@ func (s *userService) ChangePassword(ctx context.Context, userID string, oldPass
 	user.PasswordHash = string(hashedPassword)
 	user.UpdatedAt = time.Now()
 
-	return s.userRepo.UpdateUser(ctx, user)
+	if err := s.userRepo.UpdateUser(ctx, user); err != nil {
+		return err
+	}
+
+	// Invalidate every outstanding session so a stolen token cannot
+	// survive a password rotation.
+	return s.tokenRepo.RevokeTokensByUserID(ctx, userID)
 }
 
 // ValidatePassword validates user password
@@ -1205,14 +1207,6 @@ func generateRandomString(length int) (string, error) {
 		return "", err
 	}
 	return base64.RawURLEncoding.EncodeToString(buffer), nil
-}
-
-func encodeOIDCAuthorizationState(state *oidcAuthorizationState) (string, error) {
-	payload, err := json.Marshal(state)
-	if err != nil {
-		return "", err
-	}
-	return base64.RawURLEncoding.EncodeToString(payload), nil
 }
 
 func decodeJWTClaims(token string) (map[string]interface{}, error) {

--- a/internal/datasource/connector/notion/client.go
+++ b/internal/datasource/connector/notion/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/datasource"
 	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/utils"
 )
 
 // notionClient wraps the Notion API with rate limiting and retry logic.
@@ -378,6 +379,9 @@ const maxDownloadSize = 100 * 1024 * 1024 // 100MB — prevent OOM from oversize
 // DownloadFile downloads a file from the given URL (typically an S3 signed URL).
 // Does not go through the rate limiter since it's not a Notion API call.
 func (c *notionClient) DownloadFile(ctx context.Context, fileURL string) ([]byte, error) {
+	if err := utils.ValidateURLForSSRF(fileURL); err != nil {
+		return nil, fmt.Errorf("attachment URL rejected: %w", err)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create download request: %w", err)

--- a/internal/datasource/connector/notion/client_test.go
+++ b/internal/datasource/connector/notion/client_test.go
@@ -347,3 +347,17 @@ func TestClientQueryDatabaseAll(t *testing.T) {
 
 // Ensure time import is used (referenced by fakeNotion indirectly via time.Time in types).
 var _ = time.Now
+
+func TestDownloadFile_RejectsLoopbackURL(t *testing.T) {
+	secutils.ResetSSRFWhitelistForTest()
+	t.Cleanup(secutils.ResetSSRFWhitelistForTest)
+
+	client, err := newClient("test-token", "https://api.notion.com")
+	if err != nil {
+		t.Fatalf("newClient: %v", err)
+	}
+	_, err = client.DownloadFile(context.Background(), "http://127.0.0.1/secret")
+	if err == nil {
+		t.Fatal("expected loopback attachment URL to be rejected")
+	}
+}

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -20,6 +20,9 @@ import (
 	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
 
+const oidcNonceCookieName = "weknora_oidc_nonce"
+const oidcNonceCookieMaxAge = 600
+
 // AuthHandler implements HTTP request handlers for user authentication
 // Provides functionality for user registration, login, logout, and token management
 // through the REST API endpoints
@@ -249,6 +252,14 @@ func (h *AuthHandler) GetOIDCAuthorizationURL(c *gin.Context) {
 		return
 	}
 
+	// Bind the state nonce to this browser so an attacker cannot replay
+	// their own authorization code into a victim's callback.
+	if resp.Nonce != "" {
+		secure := c.Request.TLS != nil || strings.EqualFold(c.GetHeader("X-Forwarded-Proto"), "https")
+		c.SetSameSite(http.SameSiteLaxMode)
+		c.SetCookie(oidcNonceCookieName, resp.Nonce, oidcNonceCookieMaxAge, "/", "", secure, true)
+	}
+
 	c.JSON(http.StatusOK, resp)
 }
 
@@ -301,12 +312,14 @@ func (h *AuthHandler) OIDCRedirectCallback(c *gin.Context) {
 	}
 
 	state := strings.TrimSpace(c.Query("state"))
-	decodedState, err := decodeOIDCState(state)
+	decodedState, err := decodeOIDCState(state, c.Request)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to decode OIDC state: %v", err)
 		c.Redirect(http.StatusFound, frontendRedirectURI+"#oidc_error="+urlQueryEscape("invalid_state"))
 		return
 	}
+	// One-time use: clear the binding cookie as soon as it is checked.
+	c.SetCookie(oidcNonceCookieName, "", -1, "/", "", false, true)
 
 	code := strings.TrimSpace(c.Query("code"))
 	if code == "" {
@@ -344,23 +357,26 @@ func encodeOIDCCallbackPayload(resp *types.OIDCCallbackResponse) (string, error)
 }
 
 type oidcStatePayload struct {
-	Nonce       string `json:"nonce"`
-	RedirectURI string `json:"redirect_uri,omitempty"`
+	Nonce       string
+	RedirectURI string
 }
 
-func decodeOIDCState(raw string) (*oidcStatePayload, error) {
-	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(raw))
+func decodeOIDCState(raw string, req *http.Request) (*oidcStatePayload, error) {
+	payload, err := secutils.VerifyOIDCState(raw)
 	if err != nil {
 		return nil, err
 	}
-	var payload oidcStatePayload
-	if err := json.Unmarshal(decoded, &payload); err != nil {
-		return nil, err
+	cookieNonce, err := req.Cookie(oidcNonceCookieName)
+	if err != nil || cookieNonce == nil || strings.TrimSpace(cookieNonce.Value) == "" {
+		return nil, errors.NewValidationError("oidc nonce cookie missing")
 	}
-	if strings.TrimSpace(payload.RedirectURI) == "" {
-		return nil, errors.NewValidationError("state.redirect_uri is required")
+	if cookieNonce.Value != payload.Nonce {
+		return nil, errors.NewValidationError("oidc nonce mismatch")
 	}
-	return &payload, nil
+	return &oidcStatePayload{
+		Nonce:       payload.Nonce,
+		RedirectURI: strings.TrimSpace(payload.RedirectURI),
+	}, nil
 }
 
 func urlQueryEscape(value string) string {
@@ -713,6 +729,7 @@ func (h *AuthHandler) SwitchTenant(c *gin.Context) {
 
 	c.JSON(http.StatusOK, dto.NewAuthLoginResponse(resp))
 }
+
 // @Summary      自动初始化（Lite 桌面版）
 // @Description  Lite 版专用：首次启动时自动创建默认用户和租户并返回令牌，后续启动直接签发令牌，免除手动注册/登录流程
 // @Tags         认证

--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -16,8 +16,10 @@ import (
 	"github.com/Tencent/WeKnora/internal/agent/tools"
 	"github.com/Tencent/WeKnora/internal/application/repository"
 	"github.com/Tencent/WeKnora/internal/application/service"
+	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/middleware"
 	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
@@ -29,6 +31,7 @@ import (
 
 // KnowledgeHandler processes HTTP requests related to knowledge resources
 type KnowledgeHandler struct {
+	cfg               *config.Config
 	kgService         interfaces.KnowledgeService
 	kbService         interfaces.KnowledgeBaseService
 	kbShareService    interfaces.KBShareService
@@ -39,6 +42,7 @@ type KnowledgeHandler struct {
 
 // NewKnowledgeHandler creates a new knowledge handler instance
 func NewKnowledgeHandler(
+	cfg *config.Config,
 	kgService interfaces.KnowledgeService,
 	kbService interfaces.KnowledgeBaseService,
 	kbShareService interfaces.KBShareService,
@@ -47,6 +51,7 @@ func NewKnowledgeHandler(
 	spanRepo repository.KnowledgeSpanRepository,
 ) *KnowledgeHandler {
 	return &KnowledgeHandler{
+		cfg:               cfg,
 		kgService:         kgService,
 		kbService:         kbService,
 		kbShareService:    kbShareService,
@@ -54,6 +59,32 @@ func NewKnowledgeHandler(
 		asynqClient:       asynqClient,
 		spanRepo:          spanRepo,
 	}
+}
+
+// requireKBOwnershipOrAdmin enforces the same "KB creator OR Admin+" matrix
+// used by OwnedKBOrAdmin for routes whose KB id comes from the request body.
+func (h *KnowledgeHandler) requireKBOwnershipOrAdmin(c *gin.Context, kbID string) error {
+	creator, err := resolveKBCreatorByKBID(c, h.kbService, kbID)
+	evalErr := middleware.EvaluateOwnershipOrRole(
+		c.Request.Context(),
+		h.cfg,
+		types.TenantRoleAdmin,
+		creator,
+		err,
+	)
+	if evalErr == nil {
+		return nil
+	}
+	if goerrors.Is(evalErr, middleware.ErrResourceNotFound) {
+		return errors.NewNotFoundError("knowledge base not found")
+	}
+	if goerrors.Is(evalErr, middleware.ErrOwnershipForbidden) {
+		return errors.NewForbiddenError("No permission to operate on this knowledge base")
+	}
+	logger.ErrorWithFields(c.Request.Context(), evalErr, map[string]interface{}{
+		"kb_id": secutils.SanitizeForLog(kbID),
+	})
+	return errors.NewInternalServerError("cannot verify knowledge base ownership")
 }
 
 // validateKnowledgeBaseAccess validates access permissions to a knowledge base
@@ -1046,6 +1077,10 @@ func (h *KnowledgeHandler) BatchDeleteKnowledge(c *gin.Context) {
 	}
 	if permission != types.OrgRoleAdmin && permission != types.OrgRoleEditor {
 		c.Error(errors.NewForbiddenError("No permission to delete knowledge"))
+		return
+	}
+	if err := h.requireKBOwnershipOrAdmin(c, kbID); err != nil {
+		c.Error(err)
 		return
 	}
 	ctx = context.WithValue(ctx, types.TenantIDContextKey, effectiveTenantID)
@@ -2057,6 +2092,10 @@ func (h *KnowledgeHandler) MoveKnowledge(c *gin.Context) {
 		c.Error(errors.NewForbiddenError("No permission to access source knowledge base"))
 		return
 	}
+	if err := h.requireKBOwnershipOrAdmin(c, req.SourceKBID); err != nil {
+		c.Error(err)
+		return
+	}
 
 	// Validate target KB
 	targetKB, err := h.kbService.GetKnowledgeBaseByID(ctx, req.TargetKBID)
@@ -2070,6 +2109,10 @@ func (h *KnowledgeHandler) MoveKnowledge(c *gin.Context) {
 	}
 	if targetKB.TenantID != tenantID.(uint64) {
 		c.Error(errors.NewForbiddenError("No permission to access target knowledge base"))
+		return
+	}
+	if err := h.requireKBOwnershipOrAdmin(c, req.TargetKBID); err != nil {
+		c.Error(err)
 		return
 	}
 

--- a/internal/handler/organization.go
+++ b/internal/handler/organization.go
@@ -1870,6 +1870,8 @@ func (h *OrganizationHandler) SearchTenantsForInvite(c *gin.Context) {
 	// 1) Match users by query and group by TenantID. We over-fetch so the
 	//    de-duplication after filtering "already a member" tenants still
 	//    leaves us with enough candidates to fill `limit`.
+	//    User PII (email/username) is intentionally omitted from results:
+	//    org admins only need tenant identity to send an invite.
 	users, err := h.userService.SearchUsers(ctx, query, limit*3+20)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to search users: %v", err)
@@ -1902,11 +1904,7 @@ func (h *OrganizationHandler) SearchTenantsForInvite(c *gin.Context) {
 		seen[u.TenantID] = &entry{
 			idx: len(seen),
 			candidate: types.TenantInviteCandidate{
-				TenantID:                u.TenantID,
-				RepresentativeUserID:    u.ID,
-				RepresentativeUsername:  u.Username,
-				RepresentativeEmail:     u.Email,
-				RepresentativeAvatar:    u.Avatar,
+				TenantID: u.TenantID,
 			},
 		}
 	}

--- a/internal/handler/rbac_lookups.go
+++ b/internal/handler/rbac_lookups.go
@@ -247,6 +247,35 @@ func (h *WikiPageHandler) KBCreatorLookupFromKBPath(c *gin.Context) (string, err
 	return kb.CreatorID, nil
 }
 
+// resolveKBCreatorByKBID resolves a KB id to CreatorID, scoped to the
+// caller's tenant. Used by cross-KB handlers whose body carries kb_id
+// instead of a URL param (batch-delete, move, etc.).
+func resolveKBCreatorByKBID(
+	c *gin.Context,
+	kbService interfaces.KnowledgeBaseService,
+	kbID string,
+) (string, error) {
+	ctx := c.Request.Context()
+	tenantID, ok := types.TenantIDFromContext(ctx)
+	if !ok {
+		return "", errors.New("tenant context missing")
+	}
+	kb, err := kbService.GetKnowledgeBaseByID(ctx, kbID)
+	if err != nil {
+		if errors.Is(err, apprepo.ErrKnowledgeBaseNotFound) {
+			return "", middleware.ErrResourceNotFound
+		}
+		return "", err
+	}
+	if kb == nil {
+		return "", middleware.ErrResourceNotFound
+	}
+	if kb.TenantID != tenantID {
+		return "", middleware.ErrResourceNotFound
+	}
+	return kb.CreatorID, nil
+}
+
 // resolveKBCreatorByKnowledgeID is the shared body for the knowledge /
 // chunk lookups. The service-layer chain helper does the tenant-scoped
 // fetch (knowledge -> KB) and returns repository sentinel errors;

--- a/internal/handler/system.go
+++ b/internal/handler/system.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strconv"
@@ -634,14 +635,35 @@ func sanitizeStorageCheckError(err error) string {
 	}
 }
 
+// storageEndpointHost extracts the hostname from a storage endpoint string.
+// Endpoints may be bare host:port, hostnames, or full URLs with a scheme
+// (e.g. "http://127.0.0.1:9000" for S3-compatible stores).
+func storageEndpointHost(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return ""
+	}
+	if strings.Contains(endpoint, "://") {
+		if u, err := url.Parse(endpoint); err == nil {
+			if h := u.Hostname(); h != "" {
+				return h
+			}
+		}
+	}
+	if host, _, err := net.SplitHostPort(endpoint); err == nil {
+		return host
+	}
+	return endpoint
+}
+
 // isBlockedStorageEndpoint checks whether a storage endpoint resolves to a dangerous
 // address (cloud metadata, loopback, link-local). Unlike the stricter isSSRFSafeURL,
 // this allows private IPs since MinIO is commonly deployed on internal networks.
 // It also respects the SSRF_WHITELIST environment variable for whitelisted hosts.
 func isBlockedStorageEndpoint(endpoint string) (bool, string) {
-	host, _, err := net.SplitHostPort(endpoint)
-	if err != nil {
-		host = endpoint
+	host := storageEndpointHost(endpoint)
+	if host == "" {
+		return true, "无效的地址"
 	}
 
 	// Check SSRF whitelist first – whitelisted hosts bypass the block check.

--- a/internal/handler/system_storage_ssrf_test.go
+++ b/internal/handler/system_storage_ssrf_test.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStorageEndpointHost(t *testing.T) {
+	tests := []struct {
+		endpoint string
+		want     string
+	}{
+		{"127.0.0.1:9000", "127.0.0.1"},
+		{"http://127.0.0.1:9000", "127.0.0.1"},
+		{"https://127.0.0.1:9000", "127.0.0.1"},
+		{"minio.internal:9000", "minio.internal"},
+		{"https://s3.amazonaws.com", "s3.amazonaws.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.endpoint, func(t *testing.T) {
+			assert.Equal(t, tt.want, storageEndpointHost(tt.endpoint))
+		})
+	}
+}
+
+func TestIsBlockedStorageEndpoint_SchemePrefixedLoopback(t *testing.T) {
+	for _, endpoint := range []string{
+		"http://127.0.0.1:9000",
+		"https://127.0.0.1:9000",
+		"127.0.0.1:9000",
+	} {
+		t.Run(endpoint, func(t *testing.T) {
+			blocked, reason := isBlockedStorageEndpoint(endpoint)
+			assert.True(t, blocked, "expected loopback endpoint to be blocked")
+			assert.NotEmpty(t, reason)
+		})
+	}
+}

--- a/internal/handler/tenant_invitation.go
+++ b/internal/handler/tenant_invitation.go
@@ -219,13 +219,18 @@ func (h *TenantInvitationHandler) ListTenantInvitations(c *gin.Context) {
 	}
 
 	usersByID := h.hydrateUsers(c, rows)
+	showShareLinks := types.TenantRoleFromContext(ctx).HasPermission(types.TenantRoleOwner)
 	resp := make([]types.TenantInvitationResponse, 0, len(rows))
 	for _, inv := range rows {
 		// Within the tenant view we don't bother hydrating tenant name
 		// (the caller already knows the tenant). Pass an empty map.
-		// Use ...WithLink so management UI can re-display invite_url
-		// for pending share-link rows (re-copy without revoking).
-		resp = append(resp, h.projectInvitationWithLink(inv, usersByID, nil))
+		// Share-link URLs embed the registration token — only Owners may
+		// re-copy them; other roles see metadata without invite_url.
+		if showShareLinks {
+			resp = append(resp, h.projectInvitationWithLink(inv, usersByID, nil))
+		} else {
+			resp = append(resp, projectInvitation(inv, usersByID, nil))
+		}
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,

--- a/internal/middleware/rbac.go
+++ b/internal/middleware/rbac.go
@@ -248,6 +248,54 @@ func rbacEnforcementEnabled(cfg *config.Config) bool {
 	return cfg != nil && cfg.Tenant.IsRBACEnforced()
 }
 
+// ErrOwnershipForbidden is returned by EvaluateOwnershipOrRole when the
+// caller is neither the resource creator nor meets the minimum role.
+var ErrOwnershipForbidden = errors.New("rbac: ownership or role insufficient")
+
+// EvaluateOwnershipOrRole applies the same decision matrix as
+// RequireOwnershipOrRole for handlers that resolve creator_id out-of-band
+// (e.g. KB id carried in a JSON body rather than a URL param).
+//
+// Returns nil when access is allowed. ErrResourceNotFound means the
+// handler should issue its own 404. ErrOwnershipForbidden maps to 403.
+// Any other error is a transient lookup failure (503).
+func EvaluateOwnershipOrRole(
+	ctx context.Context,
+	cfg *config.Config,
+	min types.TenantRole,
+	creatorID string,
+	lookupErr error,
+) error {
+	role := types.TenantRoleFromContext(ctx)
+	if role.HasPermission(min) {
+		return nil
+	}
+	if IsCrossTenantSuperuser(ctx, cfg) {
+		return nil
+	}
+	if !rbacEnforcementEnabled(cfg) {
+		uid, _ := types.UserIDFromContext(ctx)
+		logger.Warnf(ctx,
+			"[rbac] ownership/role would be checked (enforcement off, lookup skipped): user=%s have=%s need=%s",
+			uid, role, min)
+		return nil
+	}
+	if errors.Is(lookupErr, ErrResourceNotFound) {
+		return ErrResourceNotFound
+	}
+	if lookupErr != nil {
+		return lookupErr
+	}
+	uid, _ := types.UserIDFromContext(ctx)
+	if creatorID != "" && creatorID == uid {
+		return nil
+	}
+	logger.Warnf(ctx,
+		"[rbac] ownership/role insufficient: user=%s have=%s need=%s creator=%q",
+		uid, role, min, creatorID)
+	return ErrOwnershipForbidden
+}
+
 // isCrossTenantSuperuser was moved to access.go (renamed to
 // IsCrossTenantSuperuser, exported, and made flag-aware) so the same
 // helper backs the X-Tenant-ID gate in auth.go and the RequireRole /

--- a/internal/types/user.go
+++ b/internal/types/user.go
@@ -19,6 +19,7 @@ import (
 //  1. Add a *T field below + JSON tag (snake_case, must match the front-end key).
 //  2. Extend the merge logic in service.UserService.UpdateUserPreferences.
 //  3. Surface the new knob in the frontend settings store.
+//
 // No DB DDL is required — preferences is a single jsonb column.
 type UserPreferences struct {
 	// EnableMemory mirrors the "开启记忆功能" switch in General Settings.
@@ -143,6 +144,9 @@ type OIDCAuthURLResponse struct {
 	ProviderDisplayName string `json:"provider_display_name,omitempty"`
 	AuthorizationURL    string `json:"authorization_url,omitempty"`
 	State               string `json:"state,omitempty"`
+	// Nonce is bound to an HttpOnly cookie on /auth/oidc/url and verified
+	// on callback; omitted from JSON so clients cannot replay it alone.
+	Nonce string `json:"-"`
 }
 
 type OIDCConfigResponse struct {

--- a/internal/utils/oidc_state.go
+++ b/internal/utils/oidc_state.go
@@ -1,0 +1,106 @@
+package utils
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const oidcStateMaxAge = 10 * time.Minute
+
+// OIDCStatePayload is the signed OIDC authorization state carried in the
+// redirect URL and validated on callback.
+type OIDCStatePayload struct {
+	Nonce       string `json:"nonce"`
+	RedirectURI string `json:"redirect_uri,omitempty"`
+	IssuedAt    int64  `json:"iat"`
+}
+
+var (
+	oidcStateSecretOnce sync.Once
+	oidcStateSecret     string
+)
+
+func oidcStateSigningKey() string {
+	oidcStateSecretOnce.Do(func() {
+		if envSecret := strings.TrimSpace(os.Getenv("JWT_SECRET")); envSecret != "" {
+			oidcStateSecret = envSecret
+			return
+		}
+		randomBytes := make([]byte, 32)
+		if _, err := rand.Read(randomBytes); err != nil {
+			panic(fmt.Sprintf("failed to generate OIDC state signing key: %v", err))
+		}
+		oidcStateSecret = base64.StdEncoding.EncodeToString(randomBytes)
+	})
+	return oidcStateSecret
+}
+
+// SignOIDCState returns a tamper-evident state token: base64url(payload).base64url(hmac).
+func SignOIDCState(payload *OIDCStatePayload) (string, error) {
+	if payload == nil {
+		return "", errors.New("oidc state payload is required")
+	}
+	if strings.TrimSpace(payload.Nonce) == "" {
+		return "", errors.New("oidc state nonce is required")
+	}
+	if strings.TrimSpace(payload.RedirectURI) == "" {
+		return "", errors.New("oidc state redirect_uri is required")
+	}
+	if payload.IssuedAt == 0 {
+		payload.IssuedAt = time.Now().Unix()
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal oidc state: %w", err)
+	}
+	mac := hmac.New(sha256.New, []byte(oidcStateSigningKey()))
+	mac.Write(raw)
+	sig := mac.Sum(nil)
+	return base64.RawURLEncoding.EncodeToString(raw) + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// VerifyOIDCState validates the HMAC and freshness of a state token.
+func VerifyOIDCState(raw string) (*OIDCStatePayload, error) {
+	raw = strings.TrimSpace(raw)
+	parts := strings.Split(raw, ".")
+	if len(parts) != 2 {
+		return nil, errors.New("invalid oidc state format")
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("decode oidc state payload: %w", err)
+	}
+	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode oidc state signature: %w", err)
+	}
+	mac := hmac.New(sha256.New, []byte(oidcStateSigningKey()))
+	mac.Write(payloadBytes)
+	if !hmac.Equal(mac.Sum(nil), sigBytes) {
+		return nil, errors.New("oidc state signature mismatch")
+	}
+	var payload OIDCStatePayload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return nil, fmt.Errorf("unmarshal oidc state: %w", err)
+	}
+	if strings.TrimSpace(payload.RedirectURI) == "" {
+		return nil, errors.New("state.redirect_uri is required")
+	}
+	if payload.IssuedAt == 0 {
+		return nil, errors.New("state.iat is required")
+	}
+	issuedAt := time.Unix(payload.IssuedAt, 0)
+	if time.Since(issuedAt) > oidcStateMaxAge || time.Until(issuedAt) > time.Minute {
+		return nil, errors.New("oidc state expired or invalid timestamp")
+	}
+	return &payload, nil
+}

--- a/internal/utils/oidc_state_test.go
+++ b/internal/utils/oidc_state_test.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSignAndVerifyOIDCState(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-oidc-state-secret")
+	oidcStateSecretOnce = sync.Once{}
+	oidcStateSecret = ""
+
+	state, err := SignOIDCState(&OIDCStatePayload{
+		Nonce:       "nonce-abc",
+		RedirectURI: "http://localhost:5173/login",
+		IssuedAt:    time.Now().Unix(),
+	})
+	if err != nil {
+		t.Fatalf("SignOIDCState: %v", err)
+	}
+	got, err := VerifyOIDCState(state)
+	if err != nil {
+		t.Fatalf("VerifyOIDCState: %v", err)
+	}
+	if got.Nonce != "nonce-abc" || got.RedirectURI != "http://localhost:5173/login" {
+		t.Fatalf("unexpected payload: %+v", got)
+	}
+}
+
+func TestVerifyOIDCStateRejectsTamperedPayload(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-oidc-state-secret")
+	oidcStateSecretOnce = sync.Once{}
+	oidcStateSecret = ""
+
+	state, err := SignOIDCState(&OIDCStatePayload{
+		Nonce:       "nonce-abc",
+		RedirectURI: "http://localhost:5173/login",
+		IssuedAt:    time.Now().Unix(),
+	})
+	if err != nil {
+		t.Fatalf("SignOIDCState: %v", err)
+	}
+	parts := strings.Split(state, ".")
+	tampered := parts[0] + ".AAAA"
+	if _, err := VerifyOIDCState(tampered); err == nil {
+		t.Fatal("expected tampered state to be rejected")
+	}
+}

--- a/internal/utils/security.go
+++ b/internal/utils/security.go
@@ -754,6 +754,24 @@ func DefaultSSRFSafeHTTPClientConfig() SSRFSafeHTTPClientConfig {
 // ErrSSRFRedirectBlocked is returned when a redirect target is blocked due to SSRF protection
 var ErrSSRFRedirectBlocked = fmt.Errorf("redirect blocked: target URL failed SSRF validation")
 
+// sameHTTPOrigin reports whether two URLs share scheme and host (port-aware).
+func sameHTTPOrigin(a, b *url.URL) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return strings.EqualFold(a.Scheme, b.Scheme) && strings.EqualFold(a.Host, b.Host)
+}
+
+// stripRedirectSensitiveHeaders removes credentials that must not follow a
+// cross-host redirect (Go only strips Authorization/Cookie by default).
+func stripRedirectSensitiveHeaders(req *http.Request) {
+	req.Header.Del("Authorization")
+	req.Header.Del("Cookie")
+	req.Header.Del("X-Auth-Token")
+	req.Header.Del("X-Api-Key")
+	req.Header.Del("Api-Key")
+}
+
 // NewSSRFSafeHTTPClient creates an HTTP client that validates redirect targets against SSRF protections.
 // This prevents SSRF attacks via HTTP redirects where an attacker's server redirects to internal services.
 func NewSSRFSafeHTTPClient(config SSRFSafeHTTPClientConfig) *http.Client {
@@ -771,6 +789,12 @@ func NewSSRFSafeHTTPClient(config SSRFSafeHTTPClientConfig) *http.Client {
 			// Check redirect count
 			if len(via) >= config.MaxRedirects {
 				return fmt.Errorf("stopped after %d redirects", config.MaxRedirects)
+			}
+
+			// Strip credentials when the redirect crosses hosts so connector
+			// tokens (e.g. Yuque X-Auth-Token) cannot leak to a third party.
+			if len(via) > 0 && !sameHTTPOrigin(via[0].URL, req.URL) {
+				stripRedirectSensitiveHeaders(req)
 			}
 
 			// Validate the redirect target URL for SSRF (whitelist-aware).

--- a/internal/utils/security_redirect_test.go
+++ b/internal/utils/security_redirect_test.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestSSRFSafeClientStripsAuthTokenOnCrossHostRedirect(t *testing.T) {
+	t.Setenv("SSRF_WHITELIST", "127.0.0.1,::1,localhost")
+	ResetSSRFWhitelistForTest()
+	t.Cleanup(ResetSSRFWhitelistForTest)
+
+	var gotToken string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotToken = r.Header.Get("X-Auth-Token")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer attacker.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/start", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL, http.StatusFound)
+	})
+	origin := httptest.NewServer(mux)
+	defer origin.Close()
+
+	client := NewSSRFSafeHTTPClient(SSRFSafeHTTPClientConfig{
+		Timeout:      5 * time.Second,
+		MaxRedirects: 5,
+	})
+	req, err := http.NewRequest(http.MethodGet, origin.URL+"/start", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("X-Auth-Token", "super-secret-yuque-token")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	resp.Body.Close()
+
+	if gotToken != "" {
+		t.Fatalf("X-Auth-Token leaked on cross-host redirect: %q", gotToken)
+	}
+}

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -10,6 +10,7 @@ RUN pip install --no-cache-dir -e .
 ENV MCP_HOST=0.0.0.0
 ENV MCP_PORT=8000
 ENV WEKNORA_BASE_URL=http://app:8080/api/v1
+# Set MCP_SERVER_AUTH_TOKEN at runtime; HTTP transport refuses to start without it.
 
 EXPOSE 8000
 

--- a/mcp-server/main.py
+++ b/mcp-server/main.py
@@ -68,8 +68,9 @@ def parse_arguments():
   python main.py --verbose          # 启用详细日志
   
 环境变量:
-  WEKNORA_BASE_URL    WeKnora API 基础 URL (默认: http://localhost:8080/api/v1)
-  WEKNORA_API_KEY     WeKnora API 密钥
+  WEKNORA_BASE_URL       WeKnora API 基础 URL (默认: http://localhost:8080/api/v1)
+  WEKNORA_API_KEY        WeKnora API 密钥
+  MCP_SERVER_AUTH_TOKEN  SSE/HTTP 传输必填，客户端通过 Authorization: Bearer 传递
         """,
     )
 
@@ -91,8 +92,8 @@ def parse_arguments():
     )
     parser.add_argument(
         "--host",
-        default=os.getenv("MCP_HOST", "0.0.0.0"),
-        help="Bind host for network transports (default: 0.0.0.0)",
+        default=os.getenv("MCP_HOST", "127.0.0.1"),
+        help="Bind host for network transports (default: 127.0.0.1)",
     )
     parser.add_argument(
         "--port",

--- a/mcp-server/weknora_mcp_server.py
+++ b/mcp-server/weknora_mcp_server.py
@@ -12,6 +12,8 @@ import json
 import logging
 import os
 import re
+import secrets
+import sys
 from typing import Any, Dict
 
 import urllib3
@@ -35,6 +37,63 @@ try:
 except ValueError:
     logger.warning("WEKNORA_CHAT_TIMEOUT is not a valid integer; falling back to 300s.")
     WEKNORA_CHAT_TIMEOUT = 300
+
+
+def network_transport_auth_token() -> str:
+    """Shared secret clients must present for SSE/HTTP transports."""
+    return os.getenv("MCP_SERVER_AUTH_TOKEN", "").strip()
+
+
+def require_network_transport_auth(transport: str) -> str:
+    """SSE/HTTP must not start without a configured auth token."""
+    token = network_transport_auth_token()
+    if transport in ("sse", "http") and not token:
+        logger.error(
+            "MCP_SERVER_AUTH_TOKEN is required for %s transport. "
+            "Set a strong shared secret; clients must send "
+            "Authorization: Bearer <token> or X-MCP-Auth-Token.",
+            transport,
+        )
+        sys.exit(1)
+    return token
+
+
+class MCPAuthMiddleware:
+    """ASGI middleware that gates network MCP transports behind a shared secret."""
+
+    def __init__(self, app, token: str):
+        self.app = app
+        self.token = token
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = {
+            k.decode("latin-1").lower(): v.decode("latin-1")
+            for k, v in scope.get("headers", [])
+        }
+        provided = ""
+        auth = headers.get("authorization", "")
+        if auth.lower().startswith("bearer "):
+            provided = auth[7:].strip()
+        elif "x-mcp-auth-token" in headers:
+            provided = headers["x-mcp-auth-token"]
+
+        if not provided or not secrets.compare_digest(provided, self.token):
+            body = b'{"error":"unauthorized"}'
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 401,
+                    "headers": [[b"content-type", b"application/json"]],
+                }
+            )
+            await send({"type": "http.response.body", "body": body})
+            return
+
+        await self.app(scope, receive, send)
 
 
 class WeKnoraClient:
@@ -1283,6 +1342,7 @@ async def run_stdio():
 
 async def run_sse(host: str, port: int):
     """Run the MCP server using SSE transport (legacy MCP clients)"""
+    auth_token = require_network_transport_auth("sse")
     try:
         from mcp.server.sse import SseServerTransport
         from starlette.applications import Starlette
@@ -1307,6 +1367,7 @@ async def run_sse(host: str, port: int):
             Mount("/messages/", app=sse.handle_post_message),
         ]
     )
+    starlette_app = MCPAuthMiddleware(starlette_app, auth_token)
 
     logger.info("Starting SSE MCP server on %s:%d", host, port)
     logger.info("SSE endpoint:  http://%s:%d/sse", host, port)
@@ -1317,6 +1378,7 @@ async def run_sse(host: str, port: int):
 
 async def run_http(host: str, port: int):
     """Run the MCP server using Streamable HTTP transport (MCP 2025-03-26 spec)"""
+    auth_token = require_network_transport_auth("http")
     try:
         from contextlib import asynccontextmanager
         from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
@@ -1344,6 +1406,7 @@ async def run_http(host: str, port: int):
         routes=[Mount("/", app=session_manager.handle_request)],
         lifespan=lifespan,
     )
+    starlette_app = MCPAuthMiddleware(starlette_app, auth_token)
 
     logger.info("Starting Streamable HTTP MCP server on %s:%d", host, port)
     logger.info("MCP endpoint:  http://%s:%d/mcp", host, port)
@@ -1373,8 +1436,8 @@ def main():
     )
     parser.add_argument(
         "--host",
-        default=os.getenv("MCP_HOST", "0.0.0.0"),
-        help="Bind host for network transports (default: 0.0.0.0)",
+        default=os.getenv("MCP_HOST", "127.0.0.1"),
+        help="Bind host for network transports (default: 127.0.0.1)",
     )
     parser.add_argument(
         "--port",


### PR DESCRIPTION
## Summary

### Access control & session hardening
- Restrict share-link `invite_url` to Owner role only; lower-privilege tenant members no longer receive registration tokens via `GET /tenants/:id/invitations`
- Revoke all access/refresh tokens on password change so stolen sessions cannot survive credential rotation
- Harden OIDC callback: HMAC-signed state, 10-minute expiry, and HttpOnly nonce cookie binding to prevent forged-state session fixation
- Redact user PII from organization invite search results (tenant id/name only)
- Enforce KB creator-or-Admin ownership on `POST /knowledge/batch-delete` and `POST /knowledge/move`

### SSRF & outbound request hardening
- Strip connector auth headers (`X-Auth-Token`, etc.) on cross-host HTTP redirects in the SSRF-safe client
- Fix storage engine connectivity check bypass for scheme-prefixed loopback endpoints (e.g. `http://127.0.0.1:9000`)
- Validate Notion external attachment URLs with `ValidateURLForSSRF` before download

### Frontend & MCP exposure
- Sanitize wiki page markdown HTML via DOMPurify in WikiBrowser and agent wiki drawer (stored XSS)
- Require `MCP_SERVER_AUTH_TOKEN` for SSE/HTTP MCP transports; default bind to `127.0.0.1` for CLI

## Test plan

- [x] `go test ./internal/utils/... ./internal/middleware/... ./internal/handler/... ./internal/application/service/...`
- [x] `go test ./internal/handler/ -run StorageEndpoint`
- [x] `go test ./internal/datasource/connector/notion/ -run DownloadFile`
- [ ] Verify Viewer cannot see `invite_url` in tenant invitation list; Owner still can
- [ ] Change password and confirm prior access/refresh tokens are rejected
- [ ] Complete OIDC login via `/auth/oidc/url` → IdP → callback (cookie-bound flow)
- [ ] Confirm Contributor cannot batch-delete or move documents in a coworker's KB
- [ ] Confirm org invite search returns tenant names without user emails
- [ ] Confirm wiki page with raw `<script>` in content does not execute in browser
- [ ] Confirm MCP HTTP transport rejects requests without `Authorization: Bearer <MCP_SERVER_AUTH_TOKEN>`
- [ ] Confirm `POST /system/storage-engine-check` blocks `http://127.0.0.1:9000` S3 endpoint (Admin)