### PR TITLE
fix(security): block refresh tokens as bearer and sandbox MCP uploads

### DIFF
--- a/internal/application/service/user.go
+++ b/internal/application/service/user.go
@@ -858,10 +858,17 @@ func (s *userService) ValidateToken(ctx context.Context, tokenString string) (*t
 		return nil, 0, errors.New("invalid user ID in token")
 	}
 
+	if isRefreshTokenClaims(claims) {
+		return nil, 0, errors.New("refresh token cannot be used as access token")
+	}
+
 	// Check if token is revoked
 	tokenRecord, err := s.tokenRepo.GetTokenByValue(ctx, tokenString)
 	if err != nil || tokenRecord == nil || tokenRecord.IsRevoked {
 		return nil, 0, errors.New("token is revoked")
+	}
+	if tokenRecord.TokenType == "refresh_token" {
+		return nil, 0, errors.New("refresh token cannot be used as access token")
 	}
 
 	user, err := s.userRepo.GetUserByID(ctx, userID)
@@ -875,6 +882,34 @@ func (s *userService) ValidateToken(ctx context.Context, tokenString string) (*t
 	activeTenantID := tenantIDFromClaims(claims, user.TenantID)
 
 	return user, activeTenantID, nil
+}
+
+func isRefreshTokenClaims(claims jwt.MapClaims) bool {
+	tokenType, ok := claims["type"].(string)
+	return ok && tokenType == "refresh"
+}
+
+func userIDFromSignedToken(tokenString string) (string, error) {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return []byte(getJwtSecret()), nil
+	}, jwt.WithoutClaimsValidation())
+	if err != nil || token == nil || !token.Valid {
+		return "", errors.New("invalid token")
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return "", errors.New("invalid token claims")
+	}
+
+	userID, ok := claims["user_id"].(string)
+	if !ok || strings.TrimSpace(userID) == "" {
+		return "", errors.New("invalid user ID in token")
+	}
+	return userID, nil
 }
 
 // tenantIDFromClaims pulls the active tenant ID out of a parsed JWT
@@ -956,6 +991,18 @@ func (s *userService) RefreshToken(
 
 	// Generate new tokens
 	return s.GenerateTokens(ctx, user)
+}
+
+// Logout invalidates every outstanding session for the user identified by
+// the presented JWT. Access and refresh tokens are both accepted so clients
+// can end the session without refreshing first; expired tokens are allowed
+// so logout still works after the access token TTL.
+func (s *userService) Logout(ctx context.Context, tokenString string) error {
+	userID, err := userIDFromSignedToken(tokenString)
+	if err != nil {
+		return err
+	}
+	return s.tokenRepo.RevokeTokensByUserID(ctx, userID)
 }
 
 // RevokeToken revokes a token

--- a/internal/application/service/user.go
+++ b/internal/application/service/user.go
@@ -978,6 +978,9 @@ func (s *userService) RefreshToken(
 	if err != nil || tokenRecord == nil || tokenRecord.IsRevoked {
 		return "", "", errors.New("refresh token is revoked")
 	}
+	if tokenRecord.TokenType != "refresh_token" {
+		return "", "", errors.New("not a refresh token")
+	}
 
 	// Get user
 	user, err := s.userRepo.GetUserByID(ctx, userID)

--- a/internal/application/service/user_auth_token_test.go
+++ b/internal/application/service/user_auth_token_test.go
@@ -1,0 +1,194 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func init() {
+	_ = os.Setenv("JWT_SECRET", "test-jwt-secret-for-user-auth-token-tests")
+}
+
+type stubAuthTokenRepo struct {
+	tokens         map[string]*types.AuthToken
+	revokedUserIDs []string
+}
+
+func (s *stubAuthTokenRepo) CreateToken(context.Context, *types.AuthToken) error { return nil }
+func (s *stubAuthTokenRepo) GetTokenByValue(_ context.Context, tokenValue string) (*types.AuthToken, error) {
+	token, ok := s.tokens[tokenValue]
+	if !ok {
+		return nil, errors.New("token not found")
+	}
+	return token, nil
+}
+func (s *stubAuthTokenRepo) GetTokensByUserID(context.Context, string) ([]*types.AuthToken, error) {
+	return nil, nil
+}
+func (s *stubAuthTokenRepo) UpdateToken(context.Context, *types.AuthToken) error { return nil }
+func (s *stubAuthTokenRepo) DeleteToken(context.Context, string) error           { return nil }
+func (s *stubAuthTokenRepo) DeleteExpiredTokens(context.Context) error           { return nil }
+func (s *stubAuthTokenRepo) RevokeTokensByUserID(_ context.Context, userID string) error {
+	s.revokedUserIDs = append(s.revokedUserIDs, userID)
+	return nil
+}
+
+type stubUserRepoForAuth struct {
+	users map[string]*types.User
+}
+
+func (s *stubUserRepoForAuth) CreateUser(context.Context, *types.User) error { return nil }
+func (s *stubUserRepoForAuth) GetUserByID(_ context.Context, id string) (*types.User, error) {
+	user, ok := s.users[id]
+	if !ok {
+		return nil, errors.New("user not found")
+	}
+	return user, nil
+}
+func (s *stubUserRepoForAuth) GetUsersByIDs(context.Context, []string) (map[string]*types.User, error) {
+	return nil, nil
+}
+func (s *stubUserRepoForAuth) GetUserByEmail(context.Context, string) (*types.User, error) {
+	return nil, nil
+}
+func (s *stubUserRepoForAuth) GetUserByUsername(context.Context, string) (*types.User, error) {
+	return nil, nil
+}
+func (s *stubUserRepoForAuth) GetUserByTenantID(context.Context, uint64) (*types.User, error) {
+	return nil, nil
+}
+func (s *stubUserRepoForAuth) UpdateUser(context.Context, *types.User) error { return nil }
+func (s *stubUserRepoForAuth) DeleteUser(context.Context, string) error      { return nil }
+func (s *stubUserRepoForAuth) ListUsers(context.Context, int, int) ([]*types.User, error) {
+	return nil, nil
+}
+func (s *stubUserRepoForAuth) ListSystemAdmins(context.Context, int, int) ([]*types.User, int64, error) {
+	return nil, 0, nil
+}
+func (s *stubUserRepoForAuth) RevokeSystemAdmin(context.Context, string, string) (*types.User, error) {
+	return nil, nil
+}
+func (s *stubUserRepoForAuth) SearchUsers(context.Context, string, int) ([]*types.User, error) {
+	return nil, nil
+}
+
+func newAuthTestUserService(tokenRepo *stubAuthTokenRepo) *userService {
+	return &userService{
+		userRepo: &stubUserRepoForAuth{
+			users: map[string]*types.User{
+				"user-1": {ID: "user-1", TenantID: 1},
+			},
+		},
+		tokenRepo: tokenRepo,
+	}
+}
+
+func signTestJWT(claims jwt.MapClaims) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString([]byte(getJwtSecret()))
+	if err != nil {
+		panic(err)
+	}
+	return signed
+}
+
+func TestValidateTokenRejectsRefreshToken(t *testing.T) {
+	ctx := context.Background()
+	tokenRepo := &stubAuthTokenRepo{tokens: map[string]*types.AuthToken{}}
+	svc := newAuthTestUserService(tokenRepo)
+
+	refreshJWT := signTestJWT(jwt.MapClaims{
+		"user_id": "user-1",
+		"type":    "refresh",
+		"exp":     time.Now().Add(time.Hour).Unix(),
+	})
+	tokenRepo.tokens[refreshJWT] = &types.AuthToken{
+		UserID:    "user-1",
+		Token:     refreshJWT,
+		TokenType: "refresh_token",
+	}
+
+	_, _, err := svc.ValidateToken(ctx, refreshJWT)
+	if err == nil || err.Error() != "refresh token cannot be used as access token" {
+		t.Fatalf("ValidateToken(refresh JWT) err = %v, want refresh rejection", err)
+	}
+
+	legacyRefresh := signTestJWT(jwt.MapClaims{
+		"user_id": "user-1",
+		"exp":     time.Now().Add(time.Hour).Unix(),
+	})
+	tokenRepo.tokens[legacyRefresh] = &types.AuthToken{
+		UserID:    "user-1",
+		Token:     legacyRefresh,
+		TokenType: "refresh_token",
+	}
+
+	_, _, err = svc.ValidateToken(ctx, legacyRefresh)
+	if err == nil || err.Error() != "refresh token cannot be used as access token" {
+		t.Fatalf("ValidateToken(legacy refresh in DB) err = %v, want refresh rejection", err)
+	}
+}
+
+func TestRefreshTokenRejectsAccessTokenRecord(t *testing.T) {
+	ctx := context.Background()
+	tokenRepo := &stubAuthTokenRepo{tokens: map[string]*types.AuthToken{}}
+	svc := newAuthTestUserService(tokenRepo)
+
+	refreshJWT := signTestJWT(jwt.MapClaims{
+		"user_id": "user-1",
+		"type":    "refresh",
+		"exp":     time.Now().Add(time.Hour).Unix(),
+	})
+	tokenRepo.tokens[refreshJWT] = &types.AuthToken{
+		UserID:    "user-1",
+		Token:     refreshJWT,
+		TokenType: "access_token",
+	}
+
+	_, _, err := svc.RefreshToken(ctx, refreshJWT)
+	if err == nil || err.Error() != "not a refresh token" {
+		t.Fatalf("RefreshToken(access token record) err = %v, want not a refresh token", err)
+	}
+}
+
+func TestLogoutRevokesAllUserTokens(t *testing.T) {
+	ctx := context.Background()
+	tokenRepo := &stubAuthTokenRepo{tokens: map[string]*types.AuthToken{}}
+	svc := newAuthTestUserService(tokenRepo)
+
+	expiredAccess := signTestJWT(jwt.MapClaims{
+		"user_id": "user-1",
+		"type":    "access",
+		"exp":     time.Now().Add(-time.Hour).Unix(),
+	})
+
+	if err := svc.Logout(ctx, expiredAccess); err != nil {
+		t.Fatalf("Logout(expired access token) err = %v", err)
+	}
+	if len(tokenRepo.revokedUserIDs) != 1 || tokenRepo.revokedUserIDs[0] != "user-1" {
+		t.Fatalf("RevokeTokensByUserID calls = %v, want [user-1]", tokenRepo.revokedUserIDs)
+	}
+}
+
+func TestUserIDFromSignedTokenAcceptsExpiredToken(t *testing.T) {
+	expired := signTestJWT(jwt.MapClaims{
+		"user_id": "user-1",
+		"type":    "access",
+		"exp":     time.Now().Add(-time.Hour).Unix(),
+	})
+
+	userID, err := userIDFromSignedToken(expired)
+	if err != nil {
+		t.Fatalf("userIDFromSignedToken(expired) err = %v", err)
+	}
+	if userID != "user-1" {
+		t.Fatalf("userIDFromSignedToken(expired) = %q, want user-1", userID)
+	}
+}

--- a/internal/application/service/user_jwt_test.go
+++ b/internal/application/service/user_jwt_test.go
@@ -6,6 +6,25 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
+func TestIsRefreshTokenClaims(t *testing.T) {
+	cases := []struct {
+		name   string
+		claims jwt.MapClaims
+		want   bool
+	}{
+		{name: "refresh", claims: jwt.MapClaims{"type": "refresh"}, want: true},
+		{name: "access", claims: jwt.MapClaims{"type": "access"}, want: false},
+		{name: "missing type", claims: jwt.MapClaims{"user_id": "u1"}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRefreshTokenClaims(tc.claims); got != tc.want {
+				t.Fatalf("isRefreshTokenClaims(%v) = %v, want %v", tc.claims, got, tc.want)
+			}
+		})
+	}
+}
+
 // tenantIDFromClaims is the JWT->tenant-id projection used by
 // userService.ValidateToken. It must:
 //   - prefer the claim when present (so /auth/switch-tenant takes effect)

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -427,8 +427,9 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 
 	token := tokenParts[1]
 
-	// Revoke token
-	err := h.userService.RevokeToken(ctx, token)
+	// Revoke every outstanding session for this user so refresh tokens
+	// cannot keep working after logout.
+	err := h.userService.Logout(ctx, token)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to revoke token: %v", err)
 		appErr := errors.NewInternalServerError("Logout failed").WithDetails(err.Error())

--- a/internal/types/interfaces/user.go
+++ b/internal/types/interfaces/user.go
@@ -61,6 +61,9 @@ type UserService interface {
 	RefreshToken(ctx context.Context, refreshToken string) (accessToken, newRefreshToken string, err error)
 	// RevokeToken revokes a token
 	RevokeToken(ctx context.Context, token string) error
+	// Logout revokes every outstanding access/refresh token for the user
+	// identified by the presented JWT.
+	Logout(ctx context.Context, token string) error
 	// GetCurrentUser gets current user from context
 	GetCurrentUser(ctx context.Context) (*types.User, error)
 	// SearchUsers searches users by username or email

--- a/mcp-server/test_file_path_security.py
+++ b/mcp-server/test_file_path_security.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import os
+import tempfile
+import unittest
+
+from upload_paths import resolve_upload_file_path
+
+
+class ResolveUploadFilePathTest(unittest.TestCase):
+    def setUp(self):
+        self._old_transport = os.environ.get("MCP_TRANSPORT")
+        self._old_roots = os.environ.get("MCP_ALLOWED_UPLOAD_DIRS")
+
+    def tearDown(self):
+        if self._old_transport is None:
+            os.environ.pop("MCP_TRANSPORT", None)
+        else:
+            os.environ["MCP_TRANSPORT"] = self._old_transport
+        if self._old_roots is None:
+            os.environ.pop("MCP_ALLOWED_UPLOAD_DIRS", None)
+        else:
+            os.environ["MCP_ALLOWED_UPLOAD_DIRS"] = self._old_roots
+
+    def test_network_transport_blocks_path_outside_cwd(self):
+        os.environ["MCP_TRANSPORT"] = "http"
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            allowed = os.path.join(tmp, "note.txt")
+            with open(allowed, "w", encoding="utf-8") as handle:
+                handle.write("ok")
+
+            resolved = resolve_upload_file_path("note.txt")
+            self.assertEqual(resolved, os.path.realpath(allowed))
+
+            with self.assertRaises(ValueError):
+                resolve_upload_file_path("/etc/passwd")
+
+    def test_explicit_allowed_roots(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ["MCP_ALLOWED_UPLOAD_DIRS"] = tmp
+            allowed = os.path.join(tmp, "doc.md")
+            with open(allowed, "w", encoding="utf-8") as handle:
+                handle.write("hello")
+
+            resolved = resolve_upload_file_path(os.path.join(tmp, "doc.md"))
+            self.assertEqual(resolved, os.path.realpath(allowed))
+
+            outside = tempfile.NamedTemporaryFile(delete=False)
+            try:
+                outside.write(b"secret")
+                outside.close()
+                with self.assertRaises(ValueError):
+                    resolve_upload_file_path(outside.name)
+            finally:
+                os.unlink(outside.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp-server/test_file_path_security.py
+++ b/mcp-server/test_file_path_security.py
@@ -3,15 +3,17 @@ import os
 import tempfile
 import unittest
 
-from upload_paths import resolve_upload_file_path
+from upload_paths import clear_active_transport, resolve_upload_file_path, set_active_transport
 
 
 class ResolveUploadFilePathTest(unittest.TestCase):
     def setUp(self):
         self._old_transport = os.environ.get("MCP_TRANSPORT")
         self._old_roots = os.environ.get("MCP_ALLOWED_UPLOAD_DIRS")
+        os.environ.pop("MCP_TRANSPORT", None)
 
     def tearDown(self):
+        clear_active_transport()
         if self._old_transport is None:
             os.environ.pop("MCP_TRANSPORT", None)
         else:
@@ -23,6 +25,21 @@ class ResolveUploadFilePathTest(unittest.TestCase):
 
     def test_network_transport_blocks_path_outside_cwd(self):
         os.environ["MCP_TRANSPORT"] = "http"
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            allowed = os.path.join(tmp, "note.txt")
+            with open(allowed, "w", encoding="utf-8") as handle:
+                handle.write("ok")
+
+            resolved = resolve_upload_file_path("note.txt")
+            self.assertEqual(resolved, os.path.realpath(allowed))
+
+            with self.assertRaises(ValueError):
+                resolve_upload_file_path("/etc/passwd")
+
+    def test_active_transport_without_env_blocks_path_outside_cwd(self):
+        """CLI --transport http sets active transport without MCP_TRANSPORT env."""
+        set_active_transport("http")
         with tempfile.TemporaryDirectory() as tmp:
             os.chdir(tmp)
             allowed = os.path.join(tmp, "note.txt")

--- a/mcp-server/upload_paths.py
+++ b/mcp-server/upload_paths.py
@@ -3,7 +3,27 @@
 from __future__ import annotations
 
 import os
-from typing import List
+from typing import List, Optional
+
+_active_transport: Optional[str] = None
+
+
+def set_active_transport(transport: str) -> None:
+    """Record the transport selected at server startup (CLI or run_* entry)."""
+    global _active_transport
+    _active_transport = transport.strip().lower()
+
+
+def clear_active_transport() -> None:
+    """Reset startup transport override (for tests)."""
+    global _active_transport
+    _active_transport = None
+
+
+def _current_transport() -> str:
+    if _active_transport is not None:
+        return _active_transport
+    return os.getenv("MCP_TRANSPORT", "stdio").strip().lower()
 
 
 def _path_within_root(resolved_path: str, root: str) -> bool:
@@ -22,7 +42,7 @@ def _allowed_upload_roots() -> List[str]:
     if raw:
         return [os.path.realpath(part.strip()) for part in raw.split(",") if part.strip()]
 
-    transport = os.getenv("MCP_TRANSPORT", "stdio").strip().lower()
+    transport = _current_transport()
     if transport in ("sse", "http"):
         return [os.path.realpath(os.getcwd())]
     return []

--- a/mcp-server/upload_paths.py
+++ b/mcp-server/upload_paths.py
@@ -1,0 +1,46 @@
+"""Local file path validation for MCP upload tools."""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+
+def _path_within_root(resolved_path: str, root: str) -> bool:
+    root = os.path.realpath(root)
+    resolved_path = os.path.realpath(resolved_path)
+    try:
+        common = os.path.commonpath([root, resolved_path])
+    except ValueError:
+        return False
+    return common == root
+
+
+def _allowed_upload_roots() -> List[str]:
+    """Return directories local files may be read from for upload tools."""
+    raw = os.getenv("MCP_ALLOWED_UPLOAD_DIRS", "").strip()
+    if raw:
+        return [os.path.realpath(part.strip()) for part in raw.split(",") if part.strip()]
+
+    transport = os.getenv("MCP_TRANSPORT", "stdio").strip().lower()
+    if transport in ("sse", "http"):
+        return [os.path.realpath(os.getcwd())]
+    return []
+
+
+def resolve_upload_file_path(file_path: str) -> str:
+    """Resolve and validate a local file path for create_knowledge_from_file."""
+    raw = (file_path or "").strip()
+    if not raw:
+        raise ValueError("file path is required")
+    if "\x00" in raw:
+        raise ValueError("file path contains invalid characters")
+
+    resolved = os.path.realpath(raw)
+    if not os.path.isfile(resolved):
+        raise ValueError(f"file not found: {file_path}")
+
+    roots = _allowed_upload_roots()
+    if roots and not any(_path_within_root(resolved, root) for root in roots):
+        raise ValueError("file path is outside allowed upload directories")
+    return resolved

--- a/mcp-server/weknora_mcp_server.py
+++ b/mcp-server/weknora_mcp_server.py
@@ -23,7 +23,7 @@ import requests
 from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 from requests.exceptions import RequestException
-from upload_paths import resolve_upload_file_path
+from upload_paths import resolve_upload_file_path, set_active_transport
 
 # Set up logging configuration for the MCP server
 logging.basicConfig(level=logging.INFO)
@@ -1338,12 +1338,14 @@ def _init_options() -> InitializationOptions:
 
 async def run_stdio():
     """Run the MCP server using stdio transport"""
+    set_active_transport("stdio")
     async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
         await app.run(read_stream, write_stream, _init_options())
 
 
 async def run_sse(host: str, port: int):
     """Run the MCP server using SSE transport (legacy MCP clients)"""
+    set_active_transport("sse")
     auth_token = require_network_transport_auth("sse")
     try:
         from mcp.server.sse import SseServerTransport
@@ -1380,6 +1382,7 @@ async def run_sse(host: str, port: int):
 
 async def run_http(host: str, port: int):
     """Run the MCP server using Streamable HTTP transport (MCP 2025-03-26 spec)"""
+    set_active_transport("http")
     auth_token = require_network_transport_auth("http")
     try:
         from contextlib import asynccontextmanager

--- a/mcp-server/weknora_mcp_server.py
+++ b/mcp-server/weknora_mcp_server.py
@@ -23,6 +23,7 @@ import requests
 from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 from requests.exceptions import RequestException
+from upload_paths import resolve_upload_file_path
 
 # Set up logging configuration for the MCP server
 logging.basicConfig(level=logging.INFO)
@@ -260,7 +261,8 @@ class WeKnoraClient:
         self, kb_id: str, file_path: str, enable_multimodel: bool = True
     ) -> Dict:
         """Create knowledge from a local file with optional multimodal processing"""
-        with open(file_path, "rb") as f:
+        safe_path = resolve_upload_file_path(file_path)
+        with open(safe_path, "rb") as f:
             files = {"file": f}
             data = {"enable_multimodel": str(enable_multimodel).lower()}
             # Temporarily remove Content-Type header for multipart/form-data request


### PR DESCRIPTION
## Summary
- Reject refresh JWTs in `ValidateToken` (both `type` claim and DB `TokenType` checks) so they cannot be used as Bearer access tokens.
- Reject refresh attempts in `RefreshToken` when the DB record is not `refresh_token` (defense in depth).
- Change `/auth/logout` to revoke all outstanding sessions for the user via `Logout()`, closing the post-logout refresh-token reuse gap (GHSA-gqrq-cc7h-hw65 / GHSA-vv8w-pv7q-48vv).
- Sandbox `create_knowledge_from_file` with `upload_paths.py`: network MCP transports (SSE/HTTP) default to the process working directory; operators can widen scope via `MCP_ALLOWED_UPLOAD_DIRS` (GHSA-8rhc-7p86-99h3).
- Apply upload sandbox when transport is selected via CLI (`--transport http/sse`), not only when `MCP_TRANSPORT` is set in the environment.
- Add service-layer auth tests for refresh-token rejection, logout revocation, and expired-token logout handling.

## Test plan
- [x] `go test ./internal/application/service/ -run 'TestValidateTokenRejectsRefreshToken|TestRefreshTokenRejectsAccessTokenRecord|TestLogoutRevokesAllUserTokens|TestUserIDFromSignedTokenAcceptsExpiredToken|TestIsRefreshTokenClaims'`
- [x] `cd mcp-server && python3 -m unittest test_file_path_security.py`
- [ ] Manual: login → call API with refresh token as `Authorization: Bearer` → expect 401
- [ ] Manual: login → logout with access token → refresh token no longer works as Bearer or via `/auth/refresh`
- [ ] Manual: MCP HTTP transport rejects `create_knowledge_from_file` paths outside cwd / `MCP_ALLOWED_UPLOAD_DIRS`
- [ ] Manual: `python main.py --transport http` applies upload sandbox without `MCP_TRANSPORT` env