### PR TITLE
feat(frontend): improve responsive layouts for mobile, tablet, and desktop

### DIFF
--- a/frontend/src/components/AgentEmbedChannelPanel.vue
+++ b/frontend/src/components/AgentEmbedChannelPanel.vue
@@ -1549,4 +1549,54 @@ const toggleEnabled = async (ch: EmbedChannel, enabled: boolean) => {
   left: 10px;
   top: 10px;
 }
+
+@media (max-width: 720px) {
+  .im-steps {
+    gap: 6px;
+    overflow-x: auto;
+    padding-bottom: 10px;
+    scrollbar-width: none;
+  }
+
+  .im-steps::-webkit-scrollbar {
+    display: none;
+  }
+
+  .im-step {
+    flex: 0 0 auto;
+    min-width: max-content;
+  }
+
+  .setting-row,
+  .enable-row {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .setting-info {
+    max-width: 100%;
+    padding-right: 0;
+  }
+
+  .setting-control,
+  .form-number {
+    width: 100%;
+    max-width: none;
+  }
+
+  .channel-key-control,
+  .code-panel__toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .code-panel__actions {
+    justify-content: flex-end;
+  }
+
+  .snippet-tabs :deep(.t-tabs__nav-scroll) {
+    overflow-x: auto;
+  }
+}
 </style>

--- a/frontend/src/components/CreateTenantDialog.vue
+++ b/frontend/src/components/CreateTenantDialog.vue
@@ -2,7 +2,8 @@
   <!-- 自助创建新工作区弹窗。任意已登录用户均可调用 POST /api/v1/tenants
        （后端 router 已去掉 g.CrossTenant() 守卫），handler 会自动把当前
        用户 EnsureOwner 成新租户的 Owner。 -->
-  <t-dialog :visible="visible" width="480px" :on-confirm="handleSubmit" :on-close="handleClose"
+  <t-dialog class="create-tenant-dialog" :visible="visible" width="min(480px, calc(100vw - 24px))"
+    :on-confirm="handleSubmit" :on-close="handleClose"
     :confirm-btn="{ content: $t('tenant.create.submit'), loading: submitting, theme: 'primary' }"
     :cancel-btn="{ content: $t('tenant.create.cancel') }" :close-on-overlay-click="!submitting"
     :close-on-esc-keydown="!submitting" @update:visible="onVisibleUpdate">
@@ -13,18 +14,31 @@
       </span>
     </template>
 
-    <p class="create-tenant-tip">{{ $t('tenant.create.dialogSubtitle') }}</p>
+    <div class="create-tenant-content">
+      <p class="create-tenant-tip">{{ $t('tenant.create.dialogSubtitle') }}</p>
+      <div class="create-tenant-mobile-nav" aria-hidden="true">
+        <span class="create-tenant-mobile-nav__item is-active">{{ $t('tenant.editor.navBasic') }}</span>
+      </div>
 
-    <t-form ref="formRef" :data="form" :rules="formRules" label-align="top" class="create-tenant-form" @submit.prevent>
-      <t-form-item :label="$t('tenant.create.nameLabel')" name="name">
-        <t-input v-model="form.name" :placeholder="$t('tenant.create.namePlaceholder')" :maxlength="128" autofocus
-          @enter="handleSubmit" />
-      </t-form-item>
-      <t-form-item :label="$t('tenant.create.descriptionLabel')" name="description">
-        <t-textarea v-model="form.description" :placeholder="$t('tenant.create.descriptionPlaceholder')"
-          :maxlength="512" :autosize="{ minRows: 3, maxRows: 5 }" />
-      </t-form-item>
-    </t-form>
+      <section class="create-tenant-section">
+        <header class="create-tenant-section__header">
+          <h3 class="create-tenant-section__title">{{ $t('tenant.editor.basicTitle') }}</h3>
+          <p class="create-tenant-section__desc">{{ $t('tenant.editor.basicDesc') }}</p>
+        </header>
+
+        <t-form ref="formRef" :data="form" :rules="formRules" label-align="top" class="create-tenant-form"
+          @submit.prevent>
+          <t-form-item :label="$t('tenant.create.nameLabel')" name="name">
+            <t-input v-model="form.name" :placeholder="$t('tenant.create.namePlaceholder')" :maxlength="128" autofocus
+              @enter="handleSubmit" />
+          </t-form-item>
+          <t-form-item :label="$t('tenant.create.descriptionLabel')" name="description">
+            <t-textarea v-model="form.description" :placeholder="$t('tenant.create.descriptionPlaceholder')"
+              :maxlength="512" :autosize="{ minRows: 3, maxRows: 5 }" />
+          </t-form-item>
+        </t-form>
+      </section>
+    </div>
   </t-dialog>
 </template>
 
@@ -138,9 +152,123 @@ const handleSubmit = async () => {
   color: var(--td-text-color-secondary);
 }
 
+.create-tenant-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.create-tenant-mobile-nav {
+  display: none;
+}
+
+.create-tenant-section {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.create-tenant-section__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.create-tenant-section__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--td-text-color-primary);
+}
+
+.create-tenant-section__desc {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--td-text-color-secondary);
+}
+
 .create-tenant-form {
+  :deep(.t-form__controls),
+  :deep(.t-form__controls-content),
+  :deep(.t-input),
+  :deep(.t-textarea) {
+    width: 100%;
+  }
+
   :deep(.t-form__item):last-child {
     margin-bottom: 0;
+  }
+}
+
+:global(.create-tenant-dialog) {
+  max-width: calc(100vw - 24px);
+}
+
+@media (max-width: 900px) {
+  :global(.create-tenant-dialog) {
+    width: 100vw !important;
+    max-width: 100vw !important;
+    height: 100dvh;
+    max-height: 100dvh;
+    margin: 0 !important;
+    border-radius: 0 !important;
+  }
+
+  :global(.create-tenant-dialog .t-dialog__header) {
+    padding: 14px 16px 10px;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: var(--td-bg-color-container);
+  }
+
+  :global(.create-tenant-dialog .t-dialog__body) {
+    display: block;
+    max-height: calc(100dvh - 156px);
+    padding: 0 16px 16px;
+    overflow-y: auto;
+  }
+
+  :global(.create-tenant-dialog .t-dialog__footer) {
+    padding: 10px 16px max(10px, env(safe-area-inset-bottom));
+    flex-wrap: wrap;
+  }
+
+  .create-tenant-content {
+    gap: 14px;
+    padding-top: 10px;
+  }
+
+  .create-tenant-tip {
+    margin-bottom: 0;
+  }
+
+  .create-tenant-mobile-nav {
+    display: flex;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .create-tenant-mobile-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .create-tenant-mobile-nav__item {
+    display: inline-flex;
+    align-items: center;
+    min-height: 36px;
+    padding: 0 14px;
+    border-radius: 999px;
+    background: var(--td-bg-color-secondarycontainer);
+    color: var(--td-brand-color);
+    font-size: 13px;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  .create-tenant-section {
+    gap: 16px;
   }
 }
 </style>

--- a/frontend/src/components/IMChannelPanel.vue
+++ b/frontend/src/components/IMChannelPanel.vue
@@ -1368,6 +1368,55 @@ onUnmounted(() => {
   color: var(--td-text-color-secondary);
   text-align: center;
 }
+
+@media (max-width: 720px) {
+  .im-steps {
+    gap: 6px;
+    overflow-x: auto;
+    padding-bottom: 10px;
+    scrollbar-width: none;
+  }
+
+  .im-steps::-webkit-scrollbar {
+    display: none;
+  }
+
+  .im-step {
+    flex: 0 0 auto;
+    min-width: max-content;
+  }
+
+  .setting-row {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .setting-info {
+    max-width: 100%;
+    padding-right: 0;
+  }
+
+  .setting-control {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .callback-url-control,
+  .platform-link-hint {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .option-chips {
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  .qr-container {
+    width: min(200px, 68vw);
+    height: min(200px, 68vw);
+  }
+}
 </style>
 
 <style lang="less">

--- a/frontend/src/components/Input-field.vue
+++ b/frontend/src/components/Input-field.vue
@@ -2683,7 +2683,8 @@ const getImgSrc = (url: string) => {
   bottom: 60px;
   left: 50%;
   transform: translateX(-50%);
-  width: 100%;
+  width: min(800px, 95vw);
+  max-width: calc(100vw - 24px);
   display: flex;
   justify-content: center;
 
@@ -2692,6 +2693,8 @@ const getImgSrc = (url: string) => {
     bottom: auto;
     left: auto;
     transform: none;
+    width: 100%;
+    max-width: none;
     z-index: auto;
 
     .rich-input-container {
@@ -2711,7 +2714,7 @@ const getImgSrc = (url: string) => {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04), 0 8px 16px -4px rgba(0, 0, 0, 0.06);
 
   &:focus-within {
-    border-color: var(--td-brand-color, #07C05F);
+    border-color: var(--td-component-stroke, #dcdcdc);
   }
 }
 
@@ -3703,6 +3706,115 @@ const getImgSrc = (url: string) => {
   &:hover {
     color: var(--td-brand-color-active);
     text-decoration: underline;
+  }
+}
+
+@media (max-width: 960px) {
+  .answers-input {
+    bottom: max(12px, env(safe-area-inset-bottom));
+    width: min(800px, calc(100vw - 20px));
+    max-width: calc(100vw - 20px);
+  }
+
+  .rich-input-container {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    background: transparent;
+    border: 0;
+    border-radius: 10px;
+    box-shadow: none;
+  }
+  .selected-tags-inline {
+    order: 1;
+    padding: 6px 10px 4px;
+    gap: 4px;
+    border: 1px solid var(--td-component-stroke, #dcdcdc);
+    border-radius: 10px;
+  }
+
+  :deep(.t-textarea) {
+    order: 2;
+    width: 100%;
+  }
+
+  :deep(.t-textarea__inner) {
+    min-height: 92px !important;
+    max-height: 180px !important;
+    font-size: 15px;
+    line-height: 22px;
+    padding: 12px 50px 12px 12px;
+    border: 1px solid var(--td-component-stroke, #dcdcdc);
+    border-radius: 10px !important;
+    background: var(--td-bg-color-container, #fff);
+    box-shadow: 0 2px 10px rgba(15, 23, 42, 0.08);
+  }
+
+  .control-bar {
+    position: static;
+    order: -1;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 6px;
+    max-height: none;
+    padding: 0 2px;
+    background: transparent;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .control-bar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .control-left {
+    gap: 6px;
+    padding-top: 3px;
+    flex: 0 0 auto;
+    flex-wrap: nowrap;
+    min-width: max-content;
+  }
+
+  .control-right {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    z-index: 15;
+  }
+
+  .control-btn {
+    padding: 3px 3px;
+  }
+
+  .send-btn {
+    width: 34px;
+    height: 34px;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+
+    img {
+      width: 18px;
+      height: 18px;
+    }
+  }
+
+  .stop-btn {
+    width: 34px;
+    height: 34px;
+  }
+
+  .model-display {
+    margin-left: 0;
+  }
+
+  .agent-mode-text,
+  .kb-btn-text {
+    font-size: 12px;
+  }
+
+  .mention-chip__name {
+    max-width: 82px;
   }
 }
 </style>

--- a/frontend/src/components/ListSpaceSidebar.vue
+++ b/frontend/src/components/ListSpaceSidebar.vue
@@ -547,4 +547,77 @@ onBeforeUnmount(() => {
     line-height: 1.4;
   }
 }
+
+@media (max-width: 720px) {
+  .list-space-sidebar,
+  .list-space-sidebar.expanded {
+    width: 100% !important;
+    min-height: auto;
+    max-height: 54px;
+    border-bottom: 1px solid var(--td-component-stroke);
+    background: var(--td-bg-color-container);
+    z-index: 8;
+  }
+
+  .resize-handle {
+    display: none;
+  }
+
+  .icon-strip,
+  .expanded-panel {
+    width: 100%;
+    min-height: auto;
+    flex: 0 0 auto;
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 8px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    border-right: 0;
+    box-sizing: border-box;
+    scrollbar-width: none;
+  }
+
+  .icon-strip::-webkit-scrollbar,
+  .expanded-panel::-webkit-scrollbar {
+    display: none;
+  }
+
+  .icon-item-labeled {
+    width: auto;
+    min-width: 54px;
+    height: 38px;
+    padding: 5px 9px 4px;
+    border-radius: 7px;
+  }
+
+  .icon-strip-divider {
+    width: 1px;
+    height: 26px;
+    margin: 0 2px;
+  }
+
+  .sidebar-item {
+    flex: 0 0 auto;
+    min-width: max-content;
+    max-width: 184px;
+    height: 36px;
+    padding: 6px 10px;
+    box-sizing: border-box;
+
+    .item-left {
+      flex: 0 1 auto;
+    }
+
+    .item-label {
+      max-width: 118px;
+    }
+  }
+
+  .sidebar-divider,
+  .sidebar-section {
+    display: none;
+  }
+}
 </style>

--- a/frontend/src/components/ModelEditorDialog.vue
+++ b/frontend/src/components/ModelEditorDialog.vue
@@ -157,7 +157,8 @@
           <div class="form-item">
             <label class="form-label">{{ $t('model.editor.providerLabel') }}</label>
             <t-select v-model="formData.provider" :placeholder="$t('model.editor.providerPlaceholder')"
-              @change="handleProviderChange" :popup-props="{ overlayClassName: 'provider-select-popup' }">
+              @change="handleProviderChange"
+              :popup-props="{ overlayClassName: 'provider-select-popup', attach: 'body' }">
               <!--
                 show-overflow-tooltip=false: TDesign 默认在 hover 时给选项浮一个
                 完整 label 的小气泡，但这里选项本身就是双行（主名 + 描述），不会
@@ -2247,6 +2248,42 @@ const handleCancel = () => {
     font-size: 13px;
   }
 }
+
+@media (max-width: 720px) {
+  .custom-header-row,
+  .vision-toggle {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .custom-header-row {
+    .custom-header-key,
+    .custom-header-value {
+      flex: 1 1 auto;
+      width: 100%;
+    }
+
+    .custom-header-remove {
+      align-self: flex-end;
+    }
+  }
+
+  .source-options {
+    display: flex;
+    max-width: 100%;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .source-options::-webkit-scrollbar {
+    display: none;
+  }
+
+  .source-option {
+    flex: 0 0 auto;
+  }
+}
 </style>
 
 <!-- 非 scoped 样式：t-select popup 渲染到 body 下，scoped 样式无法覆盖 -->
@@ -2255,6 +2292,8 @@ const handleCancel = () => {
   min-width: 22rem;
   max-width: min(28rem, calc(100vw - 2rem));
   padding: 4px;
+  width: min(28rem, calc(100vw - 28px));
+  max-width: calc(100vw - 28px) !important;
 
   .t-select-option {
     height: auto !important;
@@ -2360,6 +2399,20 @@ const handleCancel = () => {
       overflow: hidden;
       text-overflow: ellipsis;
     }
+  }
+}
+
+@media (max-width: 720px) {
+  .provider-select-popup {
+    width: calc(100vw - 28px);
+    max-width: calc(100vw - 28px) !important;
+  }
+
+  .provider-select-popup .provider-option .provider-desc {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: unset;
+    word-break: break-word;
   }
 }
 </style>

--- a/frontend/src/components/UserMenu.vue
+++ b/frontend/src/components/UserMenu.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="user-menu" :class="{ 'user-menu--collapsed': uiStore.sidebarCollapsed }" ref="menuRef">
+  <div class="user-menu" :class="{ 'user-menu--collapsed': sidebarCollapsed }" ref="menuRef">
     <!-- 用户按钮 -->
     <div class="user-button" data-guide="user-menu" @click="toggleMenu">
       <div class="user-avatar">
         <img v-if="userAvatar" :src="userAvatar" :alt="$t('common.avatar')" />
         <span v-else class="avatar-placeholder">{{ userInitial }}</span>
       </div>
-      <template v-if="!uiStore.sidebarCollapsed">
+      <template v-if="!sidebarCollapsed">
         <div class="user-info">
           <!-- 多租户 / superuser：首行租户名，次行 username · 角色。单租户：昵称 + 邮箱。 -->
           <template v-if="showTenantIdentityLine">
@@ -225,6 +225,7 @@ const { t } = useI18n()
 const router = useRouter()
 const uiStore = useUIStore()
 const authStore = useAuthStore()
+const sidebarCollapsed = computed(() => uiStore.effectiveSidebarCollapsed)
 const { formatRole, roleIcon } = useRoleLabel()
 const { homeTenantId, isHomeTenantActive, isHomeTenant } = useHomeTenant()
 

--- a/frontend/src/components/css/channel-panel-list.less
+++ b/frontend/src/components/css/channel-panel-list.less
@@ -223,3 +223,59 @@
     min-width: 0;
   }
 }
+
+@media (max-width: 720px) {
+  .channels-header {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 8px;
+
+    .channels-title {
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+
+    .channels-count {
+      order: 2;
+    }
+
+    :deep(.t-select),
+    :deep(.t-input) {
+      width: 100%;
+    }
+  }
+
+  .channel-grid {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .channel-card {
+    align-items: flex-start;
+    min-height: 64px;
+    padding: 10px;
+
+    &--clickable .channel-card__actions:not(.channel-card__actions--spacer) {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    &__header {
+      align-items: flex-start;
+      flex-wrap: wrap;
+    }
+
+    &__actions {
+      align-self: center;
+    }
+
+    &__actions--spacer {
+      display: none;
+    }
+  }
+
+  .agent-field-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -122,6 +122,8 @@ const TRACE_DRAWER_MIN_WIDTH = 560;
 
 const timelineDrawerWidth = ref(TRACE_DRAWER_DEFAULT_WIDTH);
 const timelineDrawerResizing = ref(false);
+const viewportWidth = ref(typeof window !== 'undefined' ? window.innerWidth : 1280);
+const isCompactDrawerLayout = computed(() => viewportWidth.value <= 960);
 
 let traceResizeStartX = 0;
 let traceResizeStartWidth = 0;
@@ -175,6 +177,7 @@ function onTraceDrawerResizeEnd() {
 }
 
 function onTraceDrawerWindowResize() {
+  viewportWidth.value = window.innerWidth;
   timelineDrawerWidth.value = clampTraceDrawerWidth(timelineDrawerWidth.value);
   mainDrawerWidth.value = clampMainDrawerWidth(mainDrawerWidth.value);
 }
@@ -194,6 +197,12 @@ const MAIN_DRAWER_MIN_WIDTH = 480;
 
 const mainDrawerWidth = ref(MAIN_DRAWER_DEFAULT_WIDTH);
 const mainDrawerResizing = ref(false);
+const mainDrawerSize = computed(() =>
+  isCompactDrawerLayout.value ? `${viewportWidth.value}px` : `${mainDrawerWidth.value}px`,
+);
+const timelineDrawerSize = computed(() =>
+  isCompactDrawerLayout.value ? `${viewportWidth.value}px` : `${timelineDrawerWidth.value}px`,
+);
 
 let mainResizeStartX = 0;
 let mainResizeStartWidth = 0;
@@ -414,6 +423,7 @@ const bindDrawerScroll = () => {
 };
 
 onMounted(() => {
+  viewportWidth.value = window.innerWidth;
   loadTraceDrawerWidth();
   loadMainDrawerWidth();
   window.addEventListener('resize', onTraceDrawerWindowResize, { passive: true });
@@ -1078,12 +1088,13 @@ const handleDetailsScroll = () => {
 <template>
   <div class="doc_content" ref="mdContentWrap">
     <teleport to="body">
-      <div v-if="visible" class="doc-drawer-resize-handle" :style="{ right: `${mainDrawerWidth}px` }" role="separator"
-        aria-orientation="vertical" @mousedown.prevent="onMainDrawerResizeStart">
+      <div v-if="visible && !isCompactDrawerLayout" class="doc-drawer-resize-handle"
+        :style="{ right: `${mainDrawerWidth}px` }" role="separator" aria-orientation="vertical"
+        @mousedown.prevent="onMainDrawerResizeStart">
         <div class="doc-drawer-resize-line" />
       </div>
     </teleport>
-    <t-drawer :visible="visible" :zIndex="2000" :size="`${mainDrawerWidth}px`" attach="body" :closeBtn="true"
+    <t-drawer :visible="visible" :zIndex="2000" :size="mainDrawerSize" attach="body" :closeBtn="true"
       :footer="false" :class="['doc-main-drawer', { 'doc-main-drawer--resizing': mainDrawerResizing }]"
       @close="handleClose">
       <template #header>
@@ -1123,14 +1134,14 @@ const handleDetailsScroll = () => {
 
       <!-- 二级抽屉：完整 Langfuse-style waterfall -->
       <teleport to="body">
-        <div v-if="timelineDrawerVisible" class="trace-drawer-resize-handle"
+        <div v-if="timelineDrawerVisible && !isCompactDrawerLayout" class="trace-drawer-resize-handle"
           :style="{ right: `${timelineDrawerWidth}px` }" role="separator" aria-orientation="vertical"
           :aria-label="$t('knowledgeStages.resizeDrawer')" :title="$t('knowledgeStages.resizeDrawer')"
           @mousedown.prevent="onTraceDrawerResizeStart">
           <div class="trace-drawer-resize-line" />
         </div>
       </teleport>
-      <t-drawer :visible="timelineDrawerVisible" :zIndex="2100" :size="`${timelineDrawerWidth}px`" attach="body"
+      <t-drawer :visible="timelineDrawerVisible" :zIndex="2100" :size="timelineDrawerSize" attach="body"
         :closeBtn="false" :footer="false" :header="false" :showOverlay="true" :closeOnOverlayClick="true"
         placement="right" :class="['kp-secondary-drawer', { 'kp-secondary-drawer--resizing': timelineDrawerResizing }]"
         @close="closeTimeline">
@@ -1878,6 +1889,54 @@ const handleDetailsScroll = () => {
   gap: 4px;
   margin-top: 12px;
 }
+
+@media (max-width: 960px) {
+  .doc-drawer-header {
+    align-items: flex-start;
+    gap: 12px;
+    padding-right: 20px;
+  }
+
+  .doc-drawer-header-title {
+    white-space: normal;
+  }
+
+  .doc-detail-row,
+  .doc-content-section-head,
+  .chunk-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .doc-detail-row {
+    gap: 4px;
+  }
+
+  .doc-detail-label {
+    flex: none;
+  }
+
+  .doc-content-section-head-left {
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .view-mode-buttons,
+  .chunk-header-right {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .view-mode-buttons .view-mode-btn {
+    flex: 1 1 0;
+  }
+
+  .chunk-item,
+  .audio-player-section {
+    padding: 12px;
+  }
+}
 </style>
 
 <!-- Non-scoped padding/background overrides for the secondary drawer.
@@ -1978,5 +2037,22 @@ body:has(.t-drawer.kp-secondary-drawer--resizing) .trace-drawer-resize-line {
 
 .t-drawer.kp-secondary-drawer--resizing .t-drawer__content {
   transition: none !important;
+}
+
+@media (max-width: 960px) {
+  .t-drawer.doc-main-drawer {
+    .t-drawer__header {
+      padding: 12px 14px;
+    }
+
+    .t-drawer__body {
+      padding: 12px 14px 16px;
+    }
+  }
+
+  .doc-drawer-resize-handle,
+  .trace-drawer-resize-handle {
+    display: none;
+  }
 }
 </style>

--- a/frontend/src/components/menu.vue
+++ b/frontend/src/components/menu.vue
@@ -1,8 +1,12 @@
 <template>
-    <div class="aside_box" :class="{ 'aside_box--collapsed': uiStore.sidebarCollapsed }">
+    <div class="aside_box" :class="{
+        'aside_box--collapsed': sidebarCollapsed,
+        'aside_box--mobile': uiStore.responsiveSidebarCollapsed,
+        'aside_box--mobile-open': uiStore.responsiveSidebarCollapsed && !sidebarCollapsed
+    }">
         <!-- 展开时：Logo + 搜索/折叠按钮同行 -->
-        <div class="logo_row" v-if="!uiStore.sidebarCollapsed">
-            <div class="logo_box" @click="router.push('/platform/knowledge-bases')" style="cursor: pointer;">
+        <div class="logo_row" v-if="!sidebarCollapsed">
+            <div class="logo_box" @click="handleLogoClick" style="cursor: pointer;">
                 <img class="logo" src="@/assets/img/weknora.png" alt="">
                 <sup v-if="isLiteEdition" class="lite-badge">Lite</sup>
             </div>
@@ -50,16 +54,16 @@
         </t-tooltip>
 
         <!-- 租户选择器：仅在用户可切换租户时显示 -->
-        <TenantSelector v-if="canAccessAllTenants && !uiStore.sidebarCollapsed" />
+        <TenantSelector v-if="canAccessAllTenants && !sidebarCollapsed" />
 
         <!-- 折叠时右侧拖拽展开手柄 -->
-        <div v-if="uiStore.sidebarCollapsed" class="sidebar-drag-handle" @mousedown="onDragHandleMouseDown" />
+        <div v-if="sidebarCollapsed" class="sidebar-drag-handle" @mousedown="onDragHandleMouseDown" />
 
         <!-- 上半部分：新对话吸顶 + 知识库/智能体/共享空间/历史会话随滚动一起滚走 -->
         <div class="menu_top" ref="scrollContainer" @scroll="handleScroll">
             <!-- 全局搜索入口：点击打开命令面板（⌘K）。展开态移至顶部 logo_row 的图标按钮；
                  折叠态在此处保留为图标项 + 深色 tooltip。 -->
-            <div class="menu_box menu_box--cmdk" v-if="uiStore.sidebarCollapsed">
+            <div class="menu_box menu_box--cmdk" v-if="sidebarCollapsed">
                 <t-tooltip placement="right">
                     <template #content>
                         <span class="cmdk-tip">
@@ -76,9 +80,9 @@
                     </div>
                 </t-tooltip>
             </div>
-            <div class="menu_box" :class="{ 'menu_box--sticky': item.children && !uiStore.sidebarCollapsed }"
+            <div class="menu_box" :class="{ 'menu_box--sticky': item.children && !sidebarCollapsed }"
                 v-for="(item, index) in topMenuItems" :key="index">
-                <t-tooltip :content="item.title" placement="right" :disabled="!uiStore.sidebarCollapsed">
+                <t-tooltip :content="item.title" placement="right" :disabled="!sidebarCollapsed">
                     <div @click="handleMenuClick(item.path)" @mouseenter="mouseenteMenu(item.path)"
                         @mouseleave="mouseleaveMenu(item.path)" :data-guide="`nav-${item.path}`"
                         :class="['menu_item', item.childrenPath && item.childrenPath == currentpath ? 'menu_item_c_active' : isMenuItemActive(item.path) ? 'menu_item_active' : '']">
@@ -88,7 +92,7 @@
                                     :src="getImgSrc(item.icon == 'zhishiku' ? knowledgeIcon : item.icon == 'agent' ? agentIcon : item.icon == 'integration' ? integrationIcon : item.icon == 'organization' ? organizationIcon : item.icon == 'logout' ? logoutIcon : item.icon == 'setting' ? settingIcon : prefixIcon)"
                                     alt="">
                             </div>
-                            <template v-if="!uiStore.sidebarCollapsed">
+                            <template v-if="!sidebarCollapsed">
                                 <span class="menu_title" :title="item.title">{{ item.title }}</span>
                                 <span v-if="item.path === 'organizations' && orgStore.totalPendingJoinRequestCount > 0"
                                     class="menu-pending-badge"
@@ -110,7 +114,7 @@
             </div>
 
             <!-- 历史会话：按来源筛选后统一按日期分组展示 -->
-            <div class="submenu" v-if="!uiStore.sidebarCollapsed"
+            <div class="submenu" v-if="!sidebarCollapsed"
                 :class="{ 'submenu--scope-fallback': showSessionScopeFallback }">
                 <div v-if="showSessionScopeFallback" class="session-list-scope-fallback">
                     <SessionSourceFilter inline :emphasized="sessionScopeFilterPinned" :sources="sessionSourceOptions"
@@ -178,7 +182,7 @@
             </div>
 
             <!-- 批量管理底部操作条 -->
-            <div v-if="batchMode && !uiStore.sidebarCollapsed" class="batch-inline-footer">
+            <div v-if="batchMode && !sidebarCollapsed" class="batch-inline-footer">
                 <div class="batch-footer-left">
                     <t-checkbox :checked="isAllBatchSelected" :indeterminate="isBatchIndeterminate"
                         @change="toggleBatchSelectAll">
@@ -204,6 +208,8 @@
         </div>
 
     </div>
+    <div v-show="uiStore.responsiveSidebarCollapsed && !sidebarCollapsed" class="sidebar-mobile-backdrop"
+        @click="uiStore.closeMobileSidebar" />
 </template>
 
 <script setup lang="ts">
@@ -298,6 +304,7 @@ const authStore = useAuthStore();
 const orgStore = useOrganizationStore();
 const uiStore = useUIStore();
 const commandPaletteStore = useCommandPaletteStore();
+const sidebarCollapsed = computed(() => uiStore.effectiveSidebarCollapsed);
 
 // Platform-aware label for the ⌘K hint. navigator.platform is deprecated but
 // the alternatives (userAgentData.platform) aren't universally available yet;
@@ -1026,6 +1033,9 @@ watch([() => route.name, () => route.params], (newvalue, oldvalue) => {
         loadCurrentKbInfo((newvalue[1] as any)?.kbId as string);
     }
 });
+watch(() => route.fullPath, () => {
+    closeMobileSidebarIfNeeded()
+});
 let knowledgeIcon = ref('zhishiku-green.svg');
 let prefixIcon = ref('prefixIcon.svg');
 let logoutIcon = ref('logout.svg');
@@ -1064,6 +1074,18 @@ const getIcon = (path: string) => {
     logoutIcon.value = 'logout.svg';
 }
 getIcon(typeof route.name === 'string' ? route.name as string : (route.name ? String(route.name) : ''))
+
+function closeMobileSidebarIfNeeded() {
+    if (uiStore.responsiveSidebarCollapsed) {
+        uiStore.closeMobileSidebar()
+    }
+}
+
+const handleLogoClick = () => {
+    router.push('/platform/knowledge-bases')
+    closeMobileSidebarIfNeeded()
+}
+
 const handleMenuClick = async (path: string) => {
     if (path === 'knowledge-bases') {
         // 知识库菜单项：如果在知识库内部，跳转到当前知识库文件页；否则跳转到知识库列表
@@ -1087,6 +1109,7 @@ const handleMenuClick = async (path: string) => {
     } else {
         gotopage(path)
     }
+    closeMobileSidebarIfNeeded()
 }
 
 // 处理退出登录确认
@@ -1132,6 +1155,7 @@ const gotopage = async (path: string) => {
         }
     }
     getIcon(path)
+    closeMobileSidebarIfNeeded()
 }
 
 const getImgSrc = (url: string) => {
@@ -1949,6 +1973,54 @@ const onDragHandleMouseDown = (e: MouseEvent) => {
 
 .menu_box {
     position: relative;
+}
+
+.sidebar-mobile-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 940;
+    background: rgba(0, 0, 0, 0.36);
+    backdrop-filter: blur(1px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@media (max-width: 960px) {
+    .aside_box {
+        &.aside_box--mobile {
+            position: fixed;
+            top: 0;
+            left: 0;
+            z-index: 950;
+            height: 100dvh;
+            transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        }
+
+        &.aside_box--mobile.aside_box--collapsed {
+            transform: translateX(-100%);
+        }
+
+        &.aside_box--mobile-open {
+            width: clamp(220px, 60vw, 340px);
+            min-width: clamp(220px, 60vw, 340px);
+            max-width: calc(100vw - 56px);
+            padding: 10px 8px 8px;
+            overflow: hidden;
+            transform: translateX(0);
+        }
+    }
+
+    // Backdrop sibling selectors — must live outside .aside_box scope
+    .aside_box--mobile.aside_box--collapsed ~ .sidebar-mobile-backdrop {
+        opacity: 0;
+        pointer-events: none;
+    }
+
+    .aside_box--mobile-open ~ .sidebar-mobile-backdrop {
+        opacity: 1;
+        pointer-events: auto;
+    }
 }
 </style>
 <style lang="less">

--- a/frontend/src/components/settings/SettingDrawer.vue
+++ b/frontend/src/components/settings/SettingDrawer.vue
@@ -30,6 +30,9 @@
             <slot name="subtitle">{{ description }}</slot>
           </div>
         </div>
+        <div v-if="$slots.headerActions" class="setting-drawer__header-actions">
+          <slot name="headerActions" />
+        </div>
       </div>
     </template>
 
@@ -274,6 +277,7 @@ const handleCancel = () => {
   flex-direction: column;
   gap: 1px;
   min-width: 0;
+  flex: 1;
 }
 
 .setting-drawer__title {
@@ -290,6 +294,14 @@ const handleCancel = () => {
   font-size: 12px;
   line-height: 1.45;
   color: var(--td-text-color-secondary);
+}
+
+.setting-drawer__header-actions {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-left: auto;
 }
 
 /* ---------- Body ---------- */
@@ -470,5 +482,60 @@ const handleCancel = () => {
 
 .t-drawer.setting-drawer--resizing .t-drawer__content {
   transition: none !important;
+}
+
+@media (max-width: 900px) {
+  .t-drawer.setting-drawer .t-drawer__content-wrapper,
+  .t-drawer.setting-drawer .t-drawer__content {
+    width: min(640px, calc(100vw - 24px)) !important;
+    max-width: calc(100vw - 24px) !important;
+  }
+}
+
+@media (max-width: 720px) {
+  .setting-drawer-resize-handle {
+    display: none;
+  }
+
+  .t-drawer.setting-drawer .t-drawer__content-wrapper,
+  .t-drawer.setting-drawer .t-drawer__content {
+    width: 100vw !important;
+    max-width: 100vw !important;
+    height: 100dvh;
+  }
+
+  .setting-drawer {
+    .t-drawer__header {
+      padding: 12px 14px;
+    }
+
+    .t-drawer__body {
+      padding: 14px;
+    }
+
+    .t-drawer__footer {
+      padding: 10px 14px max(10px, env(safe-area-inset-bottom));
+    }
+  }
+
+  .setting-drawer__header {
+    align-items: flex-start;
+  }
+
+  .setting-drawer__subtitle {
+    white-space: normal;
+  }
+
+  .setting-drawer__footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .setting-drawer__footer-left,
+  .setting-drawer__footer-right {
+    width: 100%;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
 }
 </style>

--- a/frontend/src/stores/ui.ts
+++ b/frontend/src/stores/ui.ts
@@ -20,8 +20,15 @@ export const useUIStore = defineStore('ui', {
     manualEditorInitialContent: '',
     manualEditorInitialStatus: 'draft' as 'draft' | 'publish',
     manualEditorOnSuccess: null as null | ((payload: { kbId: string; knowledgeId: string; status: 'draft' | 'publish' }) => void),
-    sidebarCollapsed: localStorage.getItem('sidebar_collapsed') === 'true'
+    sidebarCollapsed: localStorage.getItem('sidebar_collapsed') === 'true',
+    responsiveSidebarCollapsed: false,
+    mobileSidebarOpen: false,
   }),
+
+  getters: {
+    effectiveSidebarCollapsed: (state) =>
+      state.responsiveSidebarCollapsed ? !state.mobileSidebarOpen : state.sidebarCollapsed,
+  },
 
   actions: {
     openSettings(section?: string, subSection?: string) {
@@ -121,18 +128,41 @@ export const useUIStore = defineStore('ui', {
     },
 
     toggleSidebar() {
+      if (this.responsiveSidebarCollapsed) {
+        this.mobileSidebarOpen = !this.mobileSidebarOpen
+        return
+      }
       this.sidebarCollapsed = !this.sidebarCollapsed
       localStorage.setItem('sidebar_collapsed', String(this.sidebarCollapsed))
     },
 
     collapseSidebar() {
+      if (this.responsiveSidebarCollapsed) {
+        this.mobileSidebarOpen = false
+        return
+      }
       this.sidebarCollapsed = true
       localStorage.setItem('sidebar_collapsed', 'true')
     },
 
     expandSidebar() {
+      if (this.responsiveSidebarCollapsed) {
+        this.mobileSidebarOpen = true
+        return
+      }
       this.sidebarCollapsed = false
       localStorage.setItem('sidebar_collapsed', 'false')
+    },
+
+    setResponsiveSidebarCollapsed(collapsed: boolean) {
+      this.responsiveSidebarCollapsed = collapsed
+      if (!collapsed) {
+        this.mobileSidebarOpen = false
+      }
+    },
+
+    closeMobileSidebar() {
+      this.mobileSidebarOpen = false
     }
   }
 })

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -5426,6 +5426,136 @@ const handleSave = async () => {
   background: rgba(0, 180, 42, 0.1);
 }
 
+@media (max-width: 900px) {
+  .settings-modal {
+    width: calc(100vw - 24px);
+    height: calc(100dvh - 24px);
+    max-height: calc(100dvh - 24px);
+  }
+
+  .settings-container {
+    flex-direction: column;
+  }
+
+  .settings-sidebar {
+    width: 100%;
+    border-right: 0;
+    border-bottom: 1px solid var(--td-component-stroke);
+  }
+
+  .sidebar-header {
+    padding: 14px 52px 10px 14px;
+  }
+
+  .settings-nav {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: 0 0 auto;
+    padding: 8px 10px 12px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+  }
+
+  .settings-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .nav-group-title {
+    display: none;
+  }
+
+  .nav-item {
+    flex: 0 0 auto;
+    margin-bottom: 0;
+    white-space: nowrap;
+  }
+
+  .nav-label {
+    flex: 0 0 auto;
+  }
+
+  .content-wrapper {
+    padding: 24px 22px 32px;
+
+    &--prompts {
+      padding-bottom: 24px;
+    }
+  }
+}
+
+@media (max-width: 720px) {
+  .settings-overlay {
+    padding: 0;
+  }
+
+  .settings-modal {
+    width: 100%;
+    height: 100dvh;
+    max-height: 100dvh;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .settings-container {
+    flex-direction: column;
+  }
+
+  .close-btn {
+    top: 10px;
+    right: 10px;
+  }
+
+  .sidebar-header {
+    padding: 12px 52px 8px 14px;
+  }
+
+  .settings-nav {
+    display: flex;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 6px 10px 10px;
+  }
+
+  .nav-group-title {
+    display: none;
+  }
+
+  .nav-item {
+    padding: 6px 10px;
+  }
+
+  .content-wrapper {
+    padding: 18px 14px 22px;
+
+    &--prompts {
+      padding-bottom: 18px;
+    }
+  }
+
+  .setting-row {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .setting-info {
+    max-width: 100%;
+    padding-right: 0;
+  }
+
+  .setting-control {
+    width: 100%;
+    min-width: 0;
+    justify-content: flex-start;
+  }
+
+  .settings-footer {
+    padding: 10px 14px max(10px, env(safe-area-inset-bottom));
+    flex-wrap: wrap;
+  }
+}
+
 </style>
 
 <!-- Non-scoped styles: TDesign teleports the popup outside this component, so

--- a/frontend/src/views/agent/AgentList.vue
+++ b/frontend/src/views/agent/AgentList.vue
@@ -2400,6 +2400,75 @@ defineExpose({
 }
 
 // 响应式布局
+@media (max-width: 720px) {
+  .agent-list-container {
+    flex-direction: column;
+    margin: 0;
+    overflow: hidden;
+  }
+
+  .agent-list-content {
+    padding: 12px 12px 0;
+  }
+
+  .agent-list-main {
+    padding: 0 0 12px;
+  }
+
+  .header {
+    margin-bottom: 12px;
+    padding-right: 0;
+
+    .header-title {
+      min-width: 0;
+    }
+
+    .title-row {
+      gap: 6px;
+    }
+
+    h2 {
+      font-size: 21px;
+      line-height: 28px;
+    }
+  }
+
+  .header-subtitle {
+    font-size: 12px;
+    line-height: 18px;
+  }
+
+  .agent-card-wrap {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .agent-card {
+    min-width: 0;
+  }
+
+  .empty-state {
+    padding: 36px 16px;
+
+    .empty-img {
+      width: 120px;
+      height: 120px;
+      margin-bottom: 14px;
+    }
+
+    .empty-txt {
+      font-size: 15px;
+      line-height: 22px;
+    }
+
+    .empty-desc {
+      text-align: center;
+      font-size: 13px;
+      line-height: 20px;
+    }
+  }
+}
+
 @media (min-width: 900px) {
   .agent-card-wrap {
     grid-template-columns: repeat(2, 1fr);

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -1,5 +1,9 @@
 <template>
-    <div class="chat" :class="{ 'is-embedded': embeddedMode, 'is-sidebar-collapsed': uiStore.sidebarCollapsed }">
+    <div class="chat" :class="{
+        'is-embedded': embeddedMode,
+        'is-sidebar-collapsed': uiStore.effectiveSidebarCollapsed,
+        'is-responsive-sidebar': uiStore.responsiveSidebarCollapsed
+    }">
         <div ref="scrollContainer" class="chat_scroll_box" @scroll="handleScroll">
             <div class="msg_list" :class="{ 'is-embedded': embeddedMode }">
                 <!-- 消息列表骨架屏 -->
@@ -866,7 +870,7 @@ onBeforeRouteUpdate((to, from, next) => {
     flex-direction: column;
     align-items: center;
     max-width: calc(100vw - 260px);
-    min-width: 400px;
+    min-width: 0;
 
     &.is-sidebar-collapsed {
         max-width: calc(100vw - 60px);
@@ -896,6 +900,8 @@ onBeforeRouteUpdate((to, from, next) => {
     &:not(.is-embedded) :deep(.answers-input) {
         position: static;
         transform: translateX(0);
+        width: 100%;
+        max-width: 100%;
 
         .t-textarea__inner {
             width: 100% !important;
@@ -906,6 +912,11 @@ onBeforeRouteUpdate((to, from, next) => {
         width: 100% !important;
         min-height: 48px !important;
         padding: 10px 14px 48px 14px;
+    }
+
+    &.is-responsive-sidebar:not(.is-embedded) {
+        max-width: 100%;
+        padding: 12px;
     }
 }
 
@@ -1123,5 +1134,30 @@ onBeforeRouteUpdate((to, from, next) => {
 .sq-fade-enter-from,
 .sq-fade-leave-to {
     opacity: 0;
+}
+
+@media (max-width: 720px) {
+    .chat:not(.is-embedded) {
+        padding: 10px 10px 12px;
+    }
+
+    .msg_list {
+        gap: 12px;
+    }
+
+    .msg-skeleton-list {
+        gap: 14px;
+        padding: 8px 0;
+    }
+
+    .input-container {
+        min-height: 108px;
+    }
+
+    .scroll-to-bottom-btn {
+        bottom: 120px;
+        width: 34px;
+        height: 34px;
+    }
 }
 </style>

--- a/frontend/src/views/creatChat/creatChat.vue
+++ b/frontend/src/views/creatChat/creatChat.vue
@@ -262,6 +262,8 @@ const handleKBEditorSuccess = (kbId: string) => {
     :deep(.answers-input) {
         position: static;
         transform: translateX(0);
+        width: 100%;
+        max-width: 100%;
     }
 }
 
@@ -363,45 +365,45 @@ const handleKBEditorSuccess = (kbId: string) => {
     }
 }
 
-@media (max-width: 1250px) and (min-width: 1045px) {
-    .answers-input {
-        transform: translateX(-329px);
+@media (max-width: 960px) {
+    .dialogue-wrap {
+        align-items: stretch;
+        justify-content: stretch;
+        min-height: 100%;
+        padding: 12px 10px max(12px, env(safe-area-inset-bottom));
+        box-sizing: border-box;
     }
 
-    :deep(.t-textarea__inner) {
-        width: 654px !important;
+    .dialogue-answers {
+        max-width: 100%;
+        min-height: 0;
+        flex: 1;
+        gap: 14px;
+        justify-content: flex-start;
+
+        :deep(.answers-input) {
+            margin-top: auto;
+            flex-shrink: 0;
+        }
+    }
+
+    .dialogue-title {
+        justify-content: center;
+        text-align: center;
+        font-size: 22px;
+        line-height: 30px;
+        margin-top: 12px;
+    }
+
+    .suggested-questions-container {
+        width: 100%;
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
+        padding: 0;
     }
 }
 
-@media (max-width: 1045px) {
-    .answers-input {
-        transform: translateX(-250px);
-    }
-
-    :deep(.t-textarea__inner) {
-        width: 500px !important;
-    }
-}
-
-@media (max-width: 750px) {
-    .answers-input {
-        transform: translateX(-250px);
-    }
-
-    :deep(.t-textarea__inner) {
-        width: 340px !important;
-    }
-}
-
-@media (max-width: 600px) {
-    .answers-input {
-        transform: translateX(-250px);
-    }
-
-    :deep(.t-textarea__inner) {
-        width: 300px !important;
-    }
-}
 </style>
 <style lang="less">
 .del-menu-popup {

--- a/frontend/src/views/integrations/IntegrationsModal.vue
+++ b/frontend/src/views/integrations/IntegrationsModal.vue
@@ -3,6 +3,11 @@
     <Transition name="modal">
       <div v-if="visible" class="settings-overlay" @click.self="handleClose">
         <div class="settings-modal">
+          <button class="close-btn" @click="handleClose" :aria-label="$t('common.close')">
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M15 5L5 15M5 5L15 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+            </svg>
+          </button>
           <div class="settings-container">
             <div class="settings-sidebar">
               <div class="sidebar-header">
@@ -24,11 +29,6 @@
             </div>
 
             <div class="settings-content">
-              <button class="close-btn" @click="handleClose" :aria-label="$t('common.close')">
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
-                  <path d="M15 5L5 15M5 5L15 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </button>
               <div class="content-wrapper" :class="{ 'content-wrapper--landing': isLandingSection }">
                 <div v-if="currentSection === 'im'" class="section">
                   <div class="section-header">
@@ -389,6 +389,108 @@ watch(
   .settings-modal {
     transform: scale(0.98);
     opacity: 0;
+  }
+}
+
+@media (max-width: 900px) {
+  .settings-modal {
+    width: calc(100vw - 24px);
+    height: calc(100dvh - 24px);
+    max-height: calc(100dvh - 24px);
+  }
+
+  .settings-container {
+    flex-direction: column;
+  }
+
+  .settings-sidebar {
+    width: 100%;
+    max-height: none;
+    border-right: 0;
+    border-bottom: 1px solid var(--td-component-stroke);
+  }
+
+  .settings-nav {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: 0 0 auto;
+    min-height: auto;
+    padding: 8px 10px 12px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+  }
+
+  .settings-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .nav-group-title {
+    display: none;
+  }
+
+  .nav-item {
+    flex: 0 0 auto;
+    margin-bottom: 0;
+    white-space: nowrap;
+  }
+
+  .nav-label {
+    flex: 0 0 auto;
+  }
+
+  .content-wrapper {
+    padding: 20px 18px 24px;
+
+    &--landing {
+      padding-right: 18px;
+    }
+  }
+}
+
+@media (max-width: 720px) {
+  .settings-overlay {
+    padding: 0;
+  }
+
+  .settings-modal {
+    width: 100%;
+    height: 100dvh;
+    max-height: 100dvh;
+    border-radius: 0;
+  }
+
+  .sidebar-header {
+    padding-right: 52px;
+  }
+
+  .settings-nav {
+    display: flex;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 6px 10px 10px;
+  }
+
+  .nav-group-title {
+    display: none;
+  }
+
+  .nav-item {
+    padding: 6px 10px;
+  }
+
+  .close-btn {
+    top: 10px;
+    right: 10px;
+  }
+
+  .content-wrapper {
+    padding: 18px 14px 24px;
+
+    &--landing {
+      padding-right: 14px;
+    }
   }
 }
 </style>

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -2345,7 +2345,9 @@ async function createNewSession(value: string): Promise<void> {
                 <div class="doc-filter-field doc-filter-field--wide">
                   <t-date-range-picker v-model="updatedTimeRange"
                     :placeholder="[$t('knowledgeBase.updatedTimeFrom'), $t('knowledgeBase.updatedTimeTo')]"
-                    :disable-date="disableFutureDate" class="doc-date-range doc-filter-field__control" clearable
+                    :disable-date="disableFutureDate"
+                    :popup-props="{ overlayClassName: 'doc-date-range-popup', attach: 'body' }"
+                    class="doc-date-range doc-filter-field__control" clearable
                     allow-input>
                     <template #prefixIcon>
                       <t-icon name="time" size="16px" />
@@ -3676,46 +3678,6 @@ async function createNewSession(value: string): Promise<void> {
   margin: 0 16px 0 4px;
 }
 
-@media (max-width: 1250px) and (min-width: 1045px) {
-  .answers-input {
-    transform: translateX(-329px);
-  }
-
-  :deep(.t-textarea__inner) {
-    width: 654px !important;
-  }
-}
-
-@media (max-width: 1045px) {
-  .answers-input {
-    transform: translateX(-250px);
-  }
-
-  :deep(.t-textarea__inner) {
-    width: 500px !important;
-  }
-}
-
-@media (max-width: 750px) {
-  .answers-input {
-    transform: translateX(-182px);
-  }
-
-  :deep(.t-textarea__inner) {
-    width: 340px !important;
-  }
-}
-
-@media (max-width: 600px) {
-  .answers-input {
-    transform: translateX(-164px);
-  }
-
-  :deep(.t-textarea__inner) {
-    width: 300px !important;
-  }
-}
-
 @keyframes contentFadeIn {
   from {
     opacity: 0;
@@ -4437,5 +4399,187 @@ async function createNewSession(value: string): Promise<void> {
 
 .del-card {
   vertical-align: middle;
+}
+
+@media (max-width: 900px) {
+  .knowledge-layout {
+    margin: 0;
+    padding: 16px 14px 12px;
+    gap: 16px;
+  }
+
+  .document-header {
+    gap: 10px;
+
+    .document-breadcrumb {
+      font-size: 18px;
+      line-height: 26px;
+    }
+
+    h2 {
+      font-size: 20px;
+      line-height: 28px;
+    }
+  }
+
+  .faq-manager-wrapper {
+    padding: 16px 0 0;
+    margin: 0;
+  }
+}
+
+@media (max-width: 720px) {
+  .knowledge-layout {
+    padding: 12px 10px 10px;
+    gap: 12px;
+  }
+
+  .document-header {
+    .document-title-row {
+      align-items: flex-start;
+    }
+
+    .document-breadcrumb {
+      flex-wrap: wrap;
+      gap: 4px;
+      font-size: 17px;
+      line-height: 24px;
+    }
+
+    .document-subtitle,
+    .parser-hint,
+    .storage-engine-warning {
+      font-size: 12px;
+      line-height: 18px;
+    }
+  }
+
+  .doc-filter-bar {
+    gap: 8px;
+    padding-bottom: 10px;
+
+    .doc-filter-field,
+    .doc-filter-field--wide {
+      width: calc(50% - 4px);
+      flex: 0 1 calc(50% - 4px);
+    }
+
+    .doc-search-input {
+      flex: 1 1 100%;
+      min-width: 100%;
+    }
+
+    .doc-filter-field--wide {
+      width: 100%;
+      flex-basis: 100%;
+    }
+
+    .doc-view-toggle {
+      order: 20;
+      flex: 0 0 auto;
+      margin-right: auto;
+    }
+
+    .doc-filter-actions {
+      order: 21;
+      display: flex;
+      flex: 1 1 auto;
+      justify-content: flex-end;
+      margin-left: 0;
+
+      :deep(.kb-upload-source-dropdown) {
+        display: flex;
+        justify-content: flex-end;
+        width: 100%;
+      }
+
+      :deep(.content-bar-icon-btn),
+      :deep(.kb-upload-source-trigger) {
+        min-width: 36px;
+        min-height: 36px;
+      }
+    }
+  }
+
+  .doc-card-list {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .knowledge-card {
+    min-width: 0;
+  }
+
+  .doc-scroll-container {
+    padding-right: 0;
+  }
+}
+
+@media (max-width: 560px) {
+  .doc-filter-bar {
+    .doc-filter-field,
+    .doc-filter-field--wide {
+      width: 100%;
+      flex-basis: 100%;
+    }
+
+    .doc-view-toggle,
+    .doc-filter-actions {
+      width: 100%;
+    }
+
+    .doc-filter-actions {
+      justify-content: stretch;
+
+      :deep(.kb-upload-source-dropdown) {
+        justify-content: stretch;
+      }
+
+      :deep(.content-bar-icon-btn),
+      :deep(.kb-upload-source-trigger) {
+        width: 100%;
+        justify-content: center;
+        border-radius: 10px;
+        background: var(--td-bg-color-secondarycontainer);
+      }
+    }
+  }
+}
+</style>
+
+<style lang="less">
+.doc-date-range-popup {
+  .t-popup__content {
+    max-width: min(720px, calc(100vw - 24px));
+  }
+}
+
+@media (max-width: 720px) {
+  .doc-date-range-popup {
+    .t-popup__content {
+      width: min(420px, calc(100vw - 20px)) !important;
+      min-width: min(420px, calc(100vw - 20px)) !important;
+      max-width: calc(100vw - 20px) !important;
+      padding: 0;
+      overflow: hidden;
+    }
+
+    .t-date-range-picker__panel,
+    .t-date-range-picker__panel--direction-row,
+    .t-date-range-picker__panel-content,
+    .t-date-range-picker__panel-content-wrapper {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+    }
+
+    .t-date-picker__panel-date {
+      width: 100%;
+    }
+
+    .t-date-picker__header {
+      flex-wrap: wrap;
+    }
+  }
 }
 </style>

--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
@@ -1895,5 +1895,133 @@ watch(
     font-weight: 500;
   }
 }
+
+@media (max-width: 900px) {
+  .settings-modal {
+    width: calc(100vw - 24px);
+    height: calc(100dvh - 24px);
+    max-height: calc(100dvh - 24px);
+  }
+
+  .settings-container {
+    flex-direction: column;
+  }
+
+  .settings-sidebar {
+    width: 100%;
+    border-right: 0;
+    border-bottom: 1px solid var(--td-component-stroke);
+  }
+
+  .sidebar-header {
+    padding: 14px 52px 10px 14px;
+  }
+
+  .settings-nav {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: 0 0 auto;
+    padding: 8px 10px 12px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+  }
+
+  .settings-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .nav-group-title {
+    display: none;
+  }
+
+  .nav-item {
+    flex: 0 0 auto;
+    margin-bottom: 0;
+    white-space: nowrap;
+  }
+
+  .nav-label {
+    flex: 0 0 auto;
+  }
+
+  .content-wrapper {
+    padding: 24px 22px;
+  }
+}
+
+@media (max-width: 720px) {
+  .settings-overlay {
+    padding: 0;
+  }
+
+  .settings-modal {
+    width: 100%;
+    height: 100dvh;
+    max-height: 100dvh;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .settings-container {
+    flex-direction: column;
+  }
+
+  .close-btn {
+    top: 10px;
+    right: 10px;
+  }
+
+  .sidebar-header {
+    padding: 12px 52px 8px 14px;
+  }
+
+  .settings-nav {
+    display: flex;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 6px 10px 10px;
+  }
+
+  .nav-group-title {
+    display: none;
+  }
+
+  .nav-item {
+    padding: 6px 10px;
+  }
+
+  .content-wrapper {
+    padding: 18px 14px 22px;
+  }
+
+  .indexing-checks {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-footer {
+    padding: 10px 14px max(10px, env(safe-area-inset-bottom));
+    flex-wrap: wrap;
+  }
+
+  .kb-multimodal-settings {
+    .setting-row {
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .setting-info {
+      max-width: 100%;
+      padding-right: 0;
+    }
+
+    .setting-control {
+      width: 100%;
+      min-width: 0;
+      justify-content: flex-start;
+    }
+  }
+}
 </style>
 

--- a/frontend/src/views/knowledge/KnowledgeBaseList.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseList.vue
@@ -2742,6 +2742,80 @@ const handleUploadFinishedEvent = (event: Event) => {
 }
 
 // 响应式布局
+@media (max-width: 720px) {
+  .kb-list-container {
+    flex-direction: column;
+    margin: 0;
+    overflow: hidden;
+  }
+
+  .kb-list-content {
+    padding: 12px 12px 0;
+  }
+
+  .kb-list-main {
+    padding: 0 0 12px;
+  }
+
+  .header {
+    margin-bottom: 12px;
+    padding-right: 0;
+
+    .header-title {
+      min-width: 0;
+    }
+
+    .title-row {
+      gap: 6px;
+    }
+
+    h2 {
+      font-size: 21px;
+      line-height: 28px;
+    }
+  }
+
+  .header-subtitle {
+    font-size: 12px;
+    line-height: 18px;
+  }
+
+  .warning-banner,
+  .upload-progress-panel {
+    margin-right: 0;
+  }
+
+  .kb-card-wrap {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .kb-card {
+    min-width: 0;
+  }
+
+  .empty-state {
+    padding: 36px 16px;
+
+    .empty-img {
+      width: 120px;
+      height: 120px;
+      margin-bottom: 14px;
+    }
+
+    .empty-txt {
+      font-size: 15px;
+      line-height: 22px;
+    }
+
+    .empty-desc {
+      text-align: center;
+      font-size: 13px;
+      line-height: 20px;
+    }
+  }
+}
+
 @media (min-width: 900px) {
   .kb-card-wrap {
     grid-template-columns: repeat(2, 1fr);

--- a/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
+++ b/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
@@ -1342,4 +1342,190 @@ const handleConfirm = () => {
 .modal-leave-to {
   opacity: 0;
 }
+
+@media (max-width: 900px) {
+  .upload-confirm-modal {
+    width: min(100vw, 100vw);
+    height: min(100dvh, 100vh);
+    border-radius: 0;
+  }
+
+  .upload-confirm-container {
+    flex-direction: column;
+  }
+
+  .files-panel {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--td-component-stroke);
+  }
+
+  .files-panel-header {
+    padding: 16px 16px 12px;
+  }
+
+  .files-list {
+    max-height: 180px;
+    padding-bottom: 8px;
+  }
+
+  .manual-source-panel,
+  .files-empty {
+    padding-bottom: 14px;
+  }
+
+  .main-header {
+    padding: 18px 52px 0 16px;
+  }
+
+  .main-body {
+    padding: 14px 16px 16px;
+  }
+
+  .overview-row {
+    grid-template-columns: minmax(84px, 108px) 1fr 20px;
+    gap: 10px;
+    padding: 14px 14px;
+  }
+}
+
+@media (max-width: 720px) {
+  .upload-confirm-overlay {
+    align-items: stretch;
+    justify-content: stretch;
+    background: var(--td-mask-active);
+    backdrop-filter: none;
+  }
+
+  .upload-confirm-modal {
+    width: 100vw;
+    height: 100dvh;
+  }
+
+  .close-btn {
+    top: 12px;
+    right: 12px;
+    width: 36px;
+    height: 36px;
+    border-radius: 999px;
+  }
+
+  .files-panel {
+    flex: none;
+    padding-top: 8px;
+    background: var(--td-bg-color-container);
+  }
+
+  .files-panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 8px 14px 12px;
+  }
+
+  .files-panel-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .files-panel-title {
+    font-size: 14px;
+    line-height: 22px;
+    width: 100%;
+  }
+
+  .files-list {
+    display: flex;
+    gap: 10px;
+    padding: 0 14px 12px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    max-height: none;
+    scroll-snap-type: x proximity;
+  }
+
+  .file-item {
+    min-width: min(260px, calc(100vw - 56px));
+    padding: 10px 12px;
+    border: 1px solid var(--td-component-stroke);
+    background: var(--td-bg-color-secondarycontainer);
+    scroll-snap-align: start;
+  }
+
+  .manual-source-panel,
+  .files-empty {
+    padding: 0 14px 14px;
+  }
+
+  .main-header {
+    padding: 14px 52px 0 14px;
+  }
+
+  .main-title {
+    font-size: 17px;
+    line-height: 24px;
+  }
+
+  .main-desc,
+  .edit-desc {
+    font-size: 12px;
+    line-height: 1.5;
+  }
+
+  .edit-title {
+    font-size: 15px;
+    line-height: 22px;
+  }
+
+  .main-body {
+    padding: 12px 14px 14px;
+  }
+
+  .overview-row {
+    grid-template-columns: 1fr 16px;
+    grid-template-areas:
+      "label chevron"
+      "value chevron";
+    align-items: start;
+    gap: 4px 10px;
+    padding: 12px 14px;
+  }
+
+  .overview-label {
+    grid-area: label;
+  }
+
+  .overview-value {
+    grid-area: value;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .overview-chevron {
+    grid-area: chevron;
+    align-self: center;
+  }
+
+  .kb-embedded-settings {
+    .setting-row--toggle {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 12px;
+    }
+
+    .setting-control {
+      width: 100%;
+    }
+  }
+
+  .modal-footer {
+    justify-content: stretch;
+    gap: 10px;
+    padding: 12px 14px calc(12px + env(safe-area-inset-bottom));
+
+    :deep(.t-button) {
+      flex: 1 1 0;
+    }
+  }
+}
 </style>

--- a/frontend/src/views/knowledge/settings/DataSourceEditorDialog.vue
+++ b/frontend/src/views/knowledge/settings/DataSourceEditorDialog.vue
@@ -960,6 +960,17 @@ const drawerConfirmText = computed(() => {
       >
     </template>
 
+    <template #headerActions>
+      <button
+        type="button"
+        class="datasource-close-btn"
+        :aria-label="t('common.close')"
+        @click="handleClose"
+      >
+        <t-icon name="close" size="18px" />
+      </button>
+    </template>
+
     <template v-if="step === 1" #footer-left>
       <t-button v-if="!isEdit" variant="outline" @click="step = 0">
         {{ t('datasource.back') }}
@@ -2268,5 +2279,26 @@ const drawerConfirmText = computed(() => {
   width: 24px;
   height: 24px;
   object-fit: contain;
+}
+
+.datasource-close-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--td-text-color-secondary);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.datasource-close-btn:hover,
+.datasource-close-btn:focus-visible {
+  background: var(--td-bg-color-secondarycontainer);
+  color: var(--td-text-color-primary);
+  outline: none;
 }
 </style>

--- a/frontend/src/views/organization/OrganizationList.vue
+++ b/frontend/src/views/organization/OrganizationList.vue
@@ -1962,6 +1962,87 @@ onUnmounted(() => {
 }
 
 // 响应式布局
+@media (max-width: 720px) {
+  .org-list-container {
+    flex-direction: column;
+    margin: 0;
+    overflow: hidden;
+  }
+
+  .org-list-content {
+    padding: 12px 12px 0;
+  }
+
+  .org-list-main {
+    padding: 0 0 12px;
+  }
+
+  .header {
+    margin-bottom: 12px;
+
+    .header-title {
+      min-width: 0;
+    }
+
+    .title-row {
+      align-items: flex-start;
+      gap: 6px;
+    }
+
+    h2 {
+      font-size: 21px;
+      line-height: 28px;
+    }
+  }
+
+  .header-actions {
+    gap: 4px;
+  }
+
+  .header-subtitle {
+    font-size: 12px;
+    line-height: 18px;
+  }
+
+  .org-card-wrap {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .org-card {
+    min-width: 0;
+  }
+
+  .empty-state {
+    padding: 36px 16px;
+
+    .empty-img {
+      width: 120px;
+      height: 120px;
+      margin-bottom: 14px;
+    }
+
+    .empty-txt {
+      font-size: 15px;
+      line-height: 22px;
+    }
+
+    .empty-desc {
+      text-align: center;
+      font-size: 13px;
+      line-height: 20px;
+    }
+
+    .empty-state-actions {
+      flex-direction: column;
+      align-items: stretch;
+      width: 100%;
+      max-width: 280px;
+      gap: 8px;
+    }
+  }
+}
+
 @media (min-width: 900px) {
   .org-card-wrap {
     grid-template-columns: repeat(2, 1fr);

--- a/frontend/src/views/organization/OrganizationSettingsModal.vue
+++ b/frontend/src/views/organization/OrganizationSettingsModal.vue
@@ -2017,11 +2017,11 @@ watch(currentSection, (section) => {
     min-width: 140px;
   }
 
-  .member-limit-input-row {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    margin-top: 8px;
+.member-limit-input-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
 
     .member-limit-hint {
       font-size: 12px;
@@ -2063,6 +2063,137 @@ watch(currentSection, (section) => {
       font-size: 13px;
       color: var(--td-text-color-placeholder);
     }
+  }
+}
+
+@media (max-width: 900px) {
+  .settings-modal {
+    width: calc(100vw - 24px);
+    height: calc(100dvh - 24px);
+    max-height: calc(100dvh - 24px);
+  }
+
+  .settings-container {
+    flex-direction: column;
+  }
+
+  .settings-sidebar {
+    width: 100%;
+    border-right: 0;
+    border-bottom: 1px solid var(--td-component-stroke);
+
+    .sidebar-header {
+      padding: 18px 56px 12px 16px;
+    }
+
+    .settings-nav {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 10px 12px;
+      overflow-x: auto;
+      overflow-y: hidden;
+      scrollbar-width: none;
+    }
+
+    .settings-nav::-webkit-scrollbar {
+      display: none;
+    }
+
+    .settings-nav .nav-item {
+      flex: 0 0 auto;
+      margin-bottom: 0;
+      white-space: nowrap;
+      padding: 8px 12px;
+    }
+
+    .settings-nav .nav-label {
+      flex: 0 0 auto;
+    }
+  }
+
+  .content-wrapper {
+    padding: 20px 18px 24px;
+  }
+
+  .setting-row {
+    flex-direction: column;
+    gap: 12px;
+
+    .setting-info,
+    .setting-control {
+      max-width: none;
+      width: 100%;
+      padding-right: 0;
+    }
+  }
+
+  .name-input-wrapper,
+  .member-limit-input-row,
+  .approval-toggle,
+  .members-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .avatar-trigger-wrap {
+    align-self: flex-start;
+  }
+
+  .invite-card .invite-code-box,
+  .invite-card .invite-link-box {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .invite-card .invite-code-actions {
+    justify-content: flex-end;
+  }
+
+  .members-list .member-item {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .members-list .member-role,
+  .members-list .member-actions {
+    margin-left: 48px;
+  }
+}
+
+@media (max-width: 720px) {
+  .settings-overlay {
+    padding: 0;
+  }
+
+  .settings-modal {
+    width: 100%;
+    height: 100dvh;
+    max-height: 100dvh;
+    border-radius: 0;
+  }
+
+  .close-btn {
+    top: 10px;
+    right: 10px;
+  }
+
+  .settings-sidebar {
+    .sidebar-header {
+      padding: 14px 52px 10px 14px;
+    }
+
+    .settings-nav {
+      padding: 6px 10px 10px;
+    }
+
+    .settings-nav .nav-item {
+      padding: 6px 10px;
+    }
+  }
+
+  .content-wrapper {
+    padding: 18px 14px 24px;
   }
 }
 

--- a/frontend/src/views/platform/index.vue
+++ b/frontend/src/views/platform/index.vue
@@ -1,5 +1,18 @@
 <template>
-    <div class="main" ref="dropzone">
+    <div class="main" :class="{ 'main--responsive-sidebar': uiStore.responsiveSidebarCollapsed }" ref="dropzone">
+        <div v-if="uiStore.responsiveSidebarCollapsed" class="mobile-topbar">
+            <button class="mobile-sidebar-icon-button" type="button" :aria-label="t('menu.expandSidebar')"
+                @click="uiStore.toggleSidebar">
+                <svg viewBox="0 0 20 20" width="20" height="20" fill="none" aria-hidden="true"
+                    xmlns="http://www.w3.org/2000/svg">
+                    <rect x="1.5" y="1.5" width="17" height="17" rx="3" stroke="currentColor" stroke-width="1.2" />
+                    <line x1="7.5" y1="1.5" x2="7.5" y2="18.5" stroke="currentColor" stroke-width="1.2" />
+                    <line x1="4" y1="7.5" x2="4" y2="12.5" stroke="currentColor" stroke-width="1.2"
+                        stroke-linecap="round" />
+                </svg>
+            </button>
+            <img class="mobile-topbar-logo" src="@/assets/img/weknora.png" alt="WEKNORA">
+        </div>
         <Menu></Menu>
         <div v-if="isRouterAlive" class="platform-route-outlet">
             <RouterView />
@@ -33,6 +46,7 @@ import GlobalInvitationBell from '@/components/GlobalInvitationBell.vue'
 import NewUserGuide from '@/components/NewUserGuide.vue'
 import { useCommandPaletteStore } from '@/stores/commandPalette'
 import { useChatResourcesStore } from '@/stores/chatResources'
+import { useUIStore } from '@/stores/ui'
 import { getKnowledgeBaseById } from '@/api/knowledge-base/index'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
@@ -41,9 +55,12 @@ let { requestMethod } = useKnowledgeBase()
 const route = useRoute();
 const router = useRouter();
 const commandPaletteStore = useCommandPaletteStore();
+const uiStore = useUIStore();
 let ismask = ref(false)
 let uploadInput = ref();
 const { t } = useI18n();
+const RESPONSIVE_SIDEBAR_QUERY = '(max-width: 960px)'
+let disposeResponsiveSidebar: (() => void) | null = null
 
 const isRouterAlive = ref(true)
 const reloadApp = () => {
@@ -205,6 +222,20 @@ const handleGlobalDrop = async (event: DragEvent) => {
 
 // 组件挂载时添加全局事件监听器
 onMounted(() => {
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+        const query = window.matchMedia(RESPONSIVE_SIDEBAR_QUERY)
+        const syncResponsiveSidebar = (matches: boolean) => {
+            uiStore.setResponsiveSidebarCollapsed(matches)
+        }
+        const handleResponsiveSidebarChange = (event: MediaQueryListEvent) => {
+            syncResponsiveSidebar(event.matches)
+        }
+        syncResponsiveSidebar(query.matches)
+        query.addEventListener('change', handleResponsiveSidebarChange)
+        disposeResponsiveSidebar = () => {
+            query.removeEventListener('change', handleResponsiveSidebarChange)
+        }
+    }
     document.addEventListener('dragenter', handleGlobalDragEnter, true);
     document.addEventListener('dragover', handleGlobalDragOver, true);
     document.addEventListener('dragleave', handleGlobalDragLeave, true);
@@ -240,6 +271,9 @@ function maybeOpenCmdkFromRoute() {
 
 // 组件卸载时移除全局事件监听器
 onUnmounted(() => {
+    disposeResponsiveSidebar?.()
+    disposeResponsiveSidebar = null
+    uiStore.setResponsiveSidebarCollapsed(false)
     document.removeEventListener('dragenter', handleGlobalDragEnter, true);
     document.removeEventListener('dragover', handleGlobalDragOver, true);
     document.removeEventListener('dragleave', handleGlobalDragLeave, true);
@@ -261,7 +295,7 @@ onUnmounted(() => {
     align-items: stretch;
     width: 100%;
     height: 100%;
-    min-width: 600px;
+    min-width: 0;
     min-height: 0;
     /* 统一整页背景，让左侧菜单与右侧内容区视觉连贯 */
     background: var(--td-bg-color-container);
@@ -275,6 +309,65 @@ onUnmounted(() => {
     display: flex;
     flex-direction: column;
     overflow: hidden;
+}
+
+@media (max-width: 960px) {
+    .main--responsive-sidebar {
+        position: relative;
+    }
+
+    .main--responsive-sidebar .platform-route-outlet {
+        padding-top: 44px;
+        box-sizing: border-box;
+    }
+
+    .mobile-topbar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 930;
+        height: 44px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--td-bg-color-container);
+        border-bottom: 1px solid var(--td-component-stroke);
+    }
+
+    .mobile-sidebar-icon-button {
+        position: absolute;
+        left: 10px;
+        top: 2px;
+        width: 40px;
+        height: 40px;
+        padding: 0;
+        border: 0;
+        border-radius: 0;
+        background: transparent;
+        box-shadow: none;
+        color: var(--td-text-color-primary);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+    }
+
+    .mobile-sidebar-icon-button:active {
+        color: var(--td-brand-color);
+    }
+
+    .mobile-topbar-logo {
+        display: block;
+        height: auto;
+        width: auto;
+        max-width: 120px;
+        object-fit: contain;
+    }
+
+    html[theme-mode="dark"] .mobile-topbar-logo {
+        filter: invert(1) hue-rotate(180deg);
+    }
 }
 
 .upload-mask {

--- a/frontend/src/views/responsive-layout.test.mjs
+++ b/frontend/src/views/responsive-layout.test.mjs
@@ -1,0 +1,235 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const read = (relativePath) => readFileSync(join(here, '..', relativePath), 'utf8')
+
+const inputFieldSource = read('components/Input-field.vue')
+const chatSource = read('views/chat/index.vue')
+const createChatSource = read('views/creatChat/creatChat.vue')
+const knowledgeBaseSource = read('views/knowledge/KnowledgeBase.vue')
+const platformSource = read('views/platform/index.vue')
+const menuSource = read('components/menu.vue')
+const listSpaceSidebarSource = read('components/ListSpaceSidebar.vue')
+const settingsSource = read('views/settings/Settings.vue')
+const integrationsSource = read('views/integrations/IntegrationsModal.vue')
+const kbEditorSource = read('views/knowledge/KnowledgeBaseEditorModal.vue')
+const agentEditorSource = read('views/agent/AgentEditorModal.vue')
+const mcpServiceDialogSource = read('views/settings/components/McpServiceDialog.vue')
+const settingDrawerSource = read('components/settings/SettingDrawer.vue')
+const channelPanelListSource = read('components/css/channel-panel-list.less')
+const createTenantDialogSource = read('components/CreateTenantDialog.vue')
+const modelEditorDialogSource = read('components/ModelEditorDialog.vue')
+const docContentSource = read('components/doc-content.vue')
+const ollamaSettingsSource = read('views/settings/OllamaSettings.vue')
+const organizationSettingsModalSource = read('views/organization/OrganizationSettingsModal.vue')
+const dataSourceEditorDialogSource = read('views/knowledge/settings/DataSourceEditorDialog.vue')
+const uploadConfirmDialogSource = read('views/knowledge/components/UploadConfirmDialog.vue')
+const uiStoreSource = read('stores/ui.ts')
+
+test('input field caps the absolute composer width to the viewport', () => {
+  assert.match(
+    inputFieldSource,
+    /\.answers-input\s*\{[\s\S]*width:\s*min\(800px,\s*(95vw|calc\(100vw - 24px\))\)/
+  )
+})
+
+test('chat surfaces avoid hard-coded breakpoint offsets for the composer', () => {
+  for (const source of [createChatSource, knowledgeBaseSource]) {
+    assert.doesNotMatch(source, /translateX\(-329px\)|translateX\(-250px\)|translateX\(-182px\)|translateX\(-164px\)/)
+    assert.doesNotMatch(source, /width:\s*(654|500|340|300)px\s*!important/)
+  }
+})
+
+test('platform shell can shrink below the legacy 600px minimum width', () => {
+  assert.doesNotMatch(platformSource, /min-width:\s*600px/)
+})
+
+test('chat surface can shrink below the legacy 400px minimum width', () => {
+  assert.doesNotMatch(chatSource, /min-width:\s*400px/)
+})
+
+test('chat page constrains the non-embedded composer to its container width', () => {
+  assert.match(
+    chatSource,
+    /&:not\(\.is-embedded\)\s*:deep\(\.answers-input\)\s*\{[\s\S]*?width:\s*100%[\s\S]*?max-width:\s*100%[\s\S]*?\.t-textarea__inner/
+  )
+})
+
+test('responsive sidebar keeps a separate mobile drawer state', () => {
+  assert.match(uiStoreSource, /mobileSidebarOpen:\s*false/)
+  assert.match(
+    uiStoreSource,
+    /effectiveSidebarCollapsed:\s*\(state\)\s*=>\s*state\.responsiveSidebarCollapsed\s*\?\s*!state\.mobileSidebarOpen\s*:\s*state\.sidebarCollapsed/
+  )
+})
+
+test('menu renders a mobile drawer/backdrop shell below the 960px breakpoint', () => {
+  assert.match(menuSource, /sidebar-mobile-backdrop/)
+  assert.match(menuSource, /aside_box--mobile-open/)
+  assert.match(menuSource, /@media\s*\(max-width:\s*960px\)/)
+})
+
+test('space sidebars collapse into a horizontal strip on narrow screens', () => {
+  assert.match(listSpaceSidebarSource, /@media\s*\(max-width:\s*720px\)/)
+  assert.match(listSpaceSidebarSource, /flex-direction:\s*row/)
+  assert.match(listSpaceSidebarSource, /overflow-x:\s*auto/)
+})
+
+test('settings-style modals have dedicated mobile breakpoints', () => {
+  for (const source of [settingsSource, integrationsSource]) {
+    assert.match(source, /@media\s*\(max-width:\s*900px\)/)
+    assert.match(source, /@media\s*\(max-width:\s*720px\)/)
+    assert.match(source, /flex-direction:\s*column/)
+  }
+})
+
+test('mobile platform shell owns a simple top bar with centered logo', () => {
+  assert.match(platformSource, /mobile-topbar/)
+  assert.match(platformSource, /mobile-sidebar-icon-button/)
+  assert.match(platformSource, /mobile-topbar-logo/)
+  assert.match(menuSource, /\.aside_box--mobile\.aside_box--collapsed\s*~\s*\.sidebar-mobile-backdrop/)
+})
+
+test('mobile chat composer places tool controls above the input surface', () => {
+  assert.match(
+    createChatSource,
+    /@media\s*\(max-width:\s*960px\)\s*\{[\s\S]*?:deep\(\.answers-input\)\s*\{[\s\S]*?margin-top:\s*auto/
+  )
+  assert.match(
+    inputFieldSource,
+    /@media\s*\(max-width:\s*960px\)\s*\{[\s\S]*?\.rich-input-container\s*\{[\s\S]*?display:\s*flex[\s\S]*?flex-direction:\s*column/
+  )
+  assert.match(
+    inputFieldSource,
+    /@media\s*\(max-width:\s*960px\)\s*\{[\s\S]*?\.control-bar\s*\{[\s\S]*?position:\s*static[\s\S]*?order:\s*-1/
+  )
+})
+
+test('chat input keeps a neutral border when focused on mobile', () => {
+  assert.match(
+    inputFieldSource,
+    /&:focus-within\s*\{[\s\S]*?border-color:\s*var\(--td-component-stroke,\s*#dcdcdc\)/
+  )
+})
+
+test('settings and integrations use horizontally scrollable mobile tabs', () => {
+  for (const source of [settingsSource, integrationsSource]) {
+    assert.match(
+      source,
+      /@media\s*\(max-width:\s*720px\)\s*\{[\s\S]*?\.settings-nav\s*\{[\s\S]*?display:\s*flex[\s\S]*?overflow-x:\s*auto/
+    )
+    assert.match(source, /@media\s*\(max-width:\s*720px\)\s*\{[\s\S]*?\.nav-group-title\s*\{[\s\S]*?display:\s*none/)
+  }
+})
+
+test('knowledge and agent editors become page-like mobile editors', () => {
+  for (const source of [kbEditorSource, agentEditorSource]) {
+    assert.match(source, /@media\s*\(max-width:\s*720px\)/)
+    assert.match(source, /height:\s*100dvh/)
+    assert.match(source, /border-radius:\s*0/)
+    assert.match(source, /\.settings-container\s*\{[\s\S]*?flex-direction:\s*column/)
+    assert.match(source, /\.settings-nav\s*\{[\s\S]*?display:\s*flex[\s\S]*?overflow-x:\s*auto/)
+    assert.match(source, /\.nav-group-title\s*\{[\s\S]*?display:\s*none/)
+  }
+})
+
+test('shared drawers and channel cards have mobile-specific layouts', () => {
+  assert.match(settingDrawerSource, /@media\s*\(max-width:\s*720px\)/)
+  assert.match(settingDrawerSource, /\.setting-drawer-resize-handle\s*\{[\s\S]*?display:\s*none/)
+  assert.match(settingDrawerSource, /\.t-drawer\.setting-drawer\s+\.t-drawer__content-wrapper,[\s\S]*?\.t-drawer\.setting-drawer\s+\.t-drawer__content\s*\{[\s\S]*?width:\s*100vw/)
+  assert.match(channelPanelListSource, /@media\s*\(max-width:\s*720px\)/)
+  assert.match(channelPanelListSource, /\.channel-grid\s*\{[\s\S]*?grid-template-columns:\s*1fr/)
+})
+
+test('create tenant dialog can occupy the mobile viewport', () => {
+  assert.match(createTenantDialogSource, /class="create-tenant-dialog"/)
+  assert.match(createTenantDialogSource, /create-tenant-mobile-nav/)
+  assert.match(createTenantDialogSource, /@media\s*\(max-width:\s*900px\)/)
+  assert.match(createTenantDialogSource, /width:\s*100vw\s*!important/)
+})
+
+test('mcp service segmented controls wrap inside the mobile drawer', () => {
+  assert.match(mcpServiceDialogSource, /@media\s*\(max-width:\s*720px\)/)
+  assert.match(
+    mcpServiceDialogSource,
+    /\.source-options\s*\{[\s\S]*?display:\s*grid[\s\S]*?grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\)/
+  )
+  assert.match(mcpServiceDialogSource, /\.source-option__label\s*\{[\s\S]*?white-space:\s*normal[\s\S]*?overflow-wrap:\s*anywhere/)
+})
+
+test('knowledge document drawers switch to full-width compact mode on mobile', () => {
+  assert.match(docContentSource, /const isCompactDrawerLayout = computed\(\(\) => viewportWidth\.value <= 960\)/)
+  assert.match(docContentSource, /:size="mainDrawerSize"/)
+  assert.match(docContentSource, /:size="timelineDrawerSize"/)
+  assert.match(docContentSource, /@media\s*\(max-width:\s*960px\)/)
+})
+
+test('model provider picker clamps dropdown width on mobile', () => {
+  assert.match(modelEditorDialogSource, /overlayClassName:\s*'provider-select-popup',\s*attach:\s*'body'/)
+  assert.match(modelEditorDialogSource, /max-width:\s*calc\(100vw - 28px\)\s*!important/)
+})
+
+test('ollama settings stack metadata above controls on narrow screens', () => {
+  assert.match(
+    ollamaSettingsSource,
+    /@media\s*\(max-width:\s*900px\)\s*\{[\s\S]*?\.setting-row,[\s\S]*?flex-direction:\s*column/
+  )
+  assert.match(
+    ollamaSettingsSource,
+    /@media\s*\(max-width:\s*900px\)\s*\{[\s\S]*?\.setting-control\s*\{[\s\S]*?width:\s*100%/
+  )
+})
+
+test('integrations modal anchors the close button at the top level', () => {
+  assert.match(integrationsSource, /<div class="settings-modal">\s*<button class="close-btn"/)
+})
+
+test('organization settings modal switches to a page-like mobile layout', () => {
+  assert.match(organizationSettingsModalSource, /@media\s*\(max-width:\s*900px\)/)
+  assert.match(organizationSettingsModalSource, /@media\s*\(max-width:\s*720px\)/)
+  assert.match(
+    organizationSettingsModalSource,
+    /\.settings-container\s*\{[\s\S]*?flex-direction:\s*column/
+  )
+  assert.match(
+    organizationSettingsModalSource,
+    /\.settings-nav\s*\{[\s\S]*?display:\s*flex[\s\S]*?overflow-x:\s*auto/
+  )
+  assert.match(
+    organizationSettingsModalSource,
+    /\.setting-row\s*\{[\s\S]*?flex-direction:\s*column/
+  )
+})
+
+test('knowledge document toolbar and upload confirmation flow adapt on mobile', () => {
+  assert.match(knowledgeBaseSource, /@media\s*\(max-width:\s*560px\)/)
+  assert.match(knowledgeBaseSource, /overlayClassName:\s*'doc-date-range-popup',\s*attach:\s*'body'/)
+  assert.match(
+    knowledgeBaseSource,
+    /\.doc-filter-actions\s*\{[\s\S]*?display:\s*flex[\s\S]*?justify-content:\s*flex-end/
+  )
+  assert.match(
+    knowledgeBaseSource,
+    /\.doc-filter-field--wide\s*\{[\s\S]*?width:\s*100%[\s\S]*?flex-basis:\s*100%/
+  )
+  assert.match(uploadConfirmDialogSource, /@media\s*\(max-width:\s*900px\)/)
+  assert.match(uploadConfirmDialogSource, /@media\s*\(max-width:\s*720px\)/)
+  assert.match(
+    uploadConfirmDialogSource,
+    /\.upload-confirm-container\s*\{[\s\S]*?flex-direction:\s*column/
+  )
+  assert.match(
+    uploadConfirmDialogSource,
+    /\.overview-row\s*\{[\s\S]*?grid-template-areas:\s*"label chevron"/
+  )
+  assert.match(knowledgeBaseSource, /\.doc-date-range-popup[\s\S]*?@media\s*\(max-width:\s*720px\)/)
+})
+
+test('knowledge datasource editor exposes a dedicated close button', () => {
+  assert.match(dataSourceEditorDialogSource, /<template #headerActions>/)
+  assert.match(dataSourceEditorDialogSource, /class="datasource-close-btn"/)
+})

--- a/frontend/src/views/settings/GeneralSettings.vue
+++ b/frontend/src/views/settings/GeneralSettings.vue
@@ -444,4 +444,41 @@ const handleFontSizeChange = (val: FontSizeKey) => {
     text-overflow: ellipsis;
   }
 }
+
+@media (max-width: 720px) {
+  .section-header {
+    margin-bottom: 20px;
+  }
+
+  .setting-row {
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px 0;
+  }
+
+  .setting-info {
+    max-width: none;
+    width: 100%;
+    padding-right: 0;
+  }
+
+  .setting-control,
+  .font-preview {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .setting-control {
+    justify-content: flex-start;
+  }
+
+  .setting-control--stacked {
+    align-items: stretch;
+  }
+
+  :deep(.t-select),
+  :deep(.t-radio-group) {
+    width: 100% !important;
+  }
+}
 </style>

--- a/frontend/src/views/settings/McpSettings.vue
+++ b/frontend/src/views/settings/McpSettings.vue
@@ -633,4 +633,19 @@ onMounted(() => {
   text-overflow: ellipsis;
   min-width: 0;
 }
+
+@media (max-width: 720px) {
+  .services-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .service-card {
+    padding: 12px;
+  }
+
+  .service-card__header {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+}
 </style>

--- a/frontend/src/views/settings/ModelSettings.vue
+++ b/frontend/src/views/settings/ModelSettings.vue
@@ -949,4 +949,23 @@ onMounted(() => {
     margin-bottom: 16px;
   }
 }
+
+@media (max-width: 720px) {
+  .model-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .model-card {
+    padding: 12px;
+  }
+
+  .model-card__header {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .model-card__action-btn {
+    opacity: 1;
+  }
+}
 </style>

--- a/frontend/src/views/settings/OllamaSettings.vue
+++ b/frontend/src/views/settings/OllamaSettings.vue
@@ -595,6 +595,62 @@ onMounted(async () => {
   }
 }
 
+@media (max-width: 900px) {
+  .section-header {
+    margin-bottom: 24px;
+  }
+
+  .setting-row,
+  .category-header,
+  .download-content .input-group {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .setting-row {
+    gap: 12px;
+  }
+
+  .setting-info {
+    padding-right: 0;
+  }
+
+  .setting-control {
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+    align-items: stretch;
+  }
+
+  .status-display,
+  .url-control-group,
+  .model-meta {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .url-control-group {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .download-content .input-group .download-btn {
+    width: 100%;
+  }
+}
+
+@media (max-width: 720px) {
+  .model-card {
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .model-meta {
+    flex-direction: column;
+    gap: 4px;
+  }
+}
+
 @keyframes spin {
   from {
     transform: rotate(0deg);

--- a/frontend/src/views/settings/ParserEngineSettings.vue
+++ b/frontend/src/views/settings/ParserEngineSettings.vue
@@ -1143,6 +1143,32 @@ onMounted(loadAll)
   font-weight: 600;
   letter-spacing: 0.02em;
 }
+
+@media (max-width: 720px) {
+  .engine-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .engine-card {
+    padding: 12px;
+  }
+
+  .setting-row {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .setting-info {
+    max-width: 100%;
+    padding-right: 0;
+  }
+
+  .setting-control {
+    width: 100%;
+    min-width: 0;
+    justify-content: flex-start;
+  }
+}
 </style>
 
 <!--

--- a/frontend/src/views/settings/Settings.vue
+++ b/frontend/src/views/settings/Settings.vue
@@ -800,4 +800,144 @@ onUnmounted(() => {
     line-height: 1.6;
   }
 }
+
+@media (max-width: 900px) {
+  .settings-overlay {
+    padding: 12px;
+  }
+
+  .settings-modal {
+    max-width: none;
+    width: 100%;
+    height: calc(100dvh - 24px);
+    max-height: calc(100dvh - 24px);
+  }
+
+  .settings-container {
+    flex-direction: column;
+  }
+
+  .settings-sidebar {
+    width: 100%;
+    max-height: none;
+    border-right: 0;
+    border-bottom: 1px solid var(--td-component-stroke);
+  }
+
+  .sidebar-header {
+    padding: 14px 14px 10px;
+  }
+
+  .settings-nav {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: 0 0 auto;
+    min-height: auto;
+    padding: 8px 10px 12px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+  }
+
+  .settings-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .nav-group-title {
+    display: none;
+  }
+
+  .nav-item {
+    flex: 0 0 auto;
+    margin-bottom: 0;
+    white-space: nowrap;
+  }
+
+  .nav-label {
+    flex: 0 0 auto;
+  }
+
+  .submenu {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex: 0 0 auto;
+    margin: 0;
+  }
+
+  .submenu-item {
+    flex: 0 0 auto;
+    margin-bottom: 0;
+    white-space: nowrap;
+  }
+
+  .content-wrapper {
+    max-width: none;
+    padding: 28px 22px 32px;
+
+    &--wide,
+    &--full {
+      padding: 24px 22px 32px;
+    }
+  }
+}
+
+@media (max-width: 720px) {
+  .settings-overlay {
+    padding: 0;
+  }
+
+  .settings-modal {
+    width: 100%;
+    height: 100dvh;
+    max-height: 100dvh;
+    border-radius: 0;
+  }
+
+  .close-btn {
+    top: 10px;
+    right: 10px;
+  }
+
+  .settings-sidebar {
+    max-height: none;
+  }
+
+  .sidebar-header {
+    padding-right: 52px;
+  }
+
+  .settings-nav {
+    display: flex;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 6px 10px 10px;
+  }
+
+  .nav-group-title {
+    display: none;
+  }
+
+  .nav-item {
+    padding: 6px 10px;
+  }
+
+  .nav-icon {
+    margin-right: 6px;
+  }
+
+  .content-wrapper {
+    padding: 22px 14px 24px;
+
+    &--wide,
+    &--full {
+      padding: 18px 14px 24px;
+    }
+  }
+
+  .role-denied {
+    padding: 40px 16px;
+  }
+}
 </style>

--- a/frontend/src/views/settings/StorageEngineSettings.vue
+++ b/frontend/src/views/settings/StorageEngineSettings.vue
@@ -1627,6 +1627,32 @@ onMounted(loadAll)
     color: var(--td-error-color);
   }
 }
+
+@media (max-width: 720px) {
+  .engine-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .engine-card {
+    padding: 12px;
+  }
+
+  .setting-row {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .setting-info {
+    max-width: 100%;
+    padding-right: 0;
+  }
+
+  .setting-control {
+    width: 100%;
+    min-width: 0;
+    justify-content: flex-start;
+  }
+}
 </style>
 
 <!--

--- a/frontend/src/views/settings/VectorStoreSettings.vue
+++ b/frontend/src/views/settings/VectorStoreSettings.vue
@@ -1275,6 +1275,21 @@ onMounted(async () => {
   &.available { color: var(--td-brand-color); }
   &.unavailable { color: var(--td-error-color); }
 }
+
+@media (max-width: 720px) {
+  .store-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .store-card {
+    padding: 12px;
+  }
+
+  .store-card__header {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+}
 </style>
 
 <!--

--- a/frontend/src/views/settings/WebSearchSettings.vue
+++ b/frontend/src/views/settings/WebSearchSettings.vue
@@ -1075,6 +1075,21 @@ onMounted(async () => {
     }
   }
 }
+
+@media (max-width: 720px) {
+  .provider-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .provider-card {
+    padding: 12px;
+  }
+
+  .provider-card__header {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+}
 </style>
 
 <!--

--- a/frontend/src/views/settings/components/McpServiceDialog.vue
+++ b/frontend/src/views/settings/components/McpServiceDialog.vue
@@ -1324,6 +1324,62 @@ const handleClose = () => {
     background: var(--td-bg-color-component);
   }
 }
+
+@media (max-width: 720px) {
+  .custom-headers-header,
+  .custom-header-row,
+  .vision-toggle {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .custom-header-key,
+  .custom-header-value {
+    flex: 1 1 auto;
+    width: 100%;
+  }
+
+  .custom-header-remove {
+    align-self: flex-end;
+  }
+
+  .source-options {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    max-width: 100%;
+    width: 100%;
+    overflow: visible;
+  }
+
+  .source-option {
+    justify-content: center;
+    width: 100%;
+    min-width: 0;
+    height: auto;
+    min-height: 32px;
+    text-align: center;
+  }
+
+  .source-option__label {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .code-import__actions {
+    justify-content: stretch;
+
+    :deep(.t-button) {
+      width: 100%;
+    }
+  }
+}
+
+@media (max-width: 360px) {
+  .source-options {
+    grid-template-columns: 1fr;
+  }
+}
 </style>
 
 <!--


### PR DESCRIPTION
## Description

本 PR 主要针对前端多端响应式体验进行集中修复与优化，重点完善移动端使用体验，同时补齐平板与桌面端在关键页面上的布局一致性。

本次修改覆盖了 issue #917 中提到的适配问题，并结合实际联调过程，对若干移动端展示与交互细节进行了进一步修正。

核心改动包括：

- 平台整体壳层移动端优化
  - 增加移动端顶部栏
  - 侧边栏在小屏下改为抽屉式展开
  - 补充独立的移动端侧边栏状态管理，优化折叠与展开逻辑

- 对话页移动端体验优化
  - 输入框区域调整到底部
  - 工具按钮移动到输入框上方，更符合移动端使用习惯
  - 去除输入框聚焦时突兀的高亮边框
  - 优化窄屏下输入区域宽度与布局约束

- 设置类页面与编辑器页面响应式重构
  - 设置页、发布集成页、知识库编辑页、智能体编辑页等页面在移动端改为更接近“页面式”展示
  - 顶部目录在移动端支持横向滚动
  - 顶层关闭按钮与导航结构在移动端做了更易点击的调整

- 知识库相关页面移动端优化
  - 文档详情抽屉在移动端改为全宽紧凑布局
  - 上传文档入口与上传确认流程针对小屏重新布局
  - 日期范围筛选弹层在移动端改为纵向单列展示，避免双日历并排导致拥挤
  - 上传相关流程（包括导入网页、上传确认等）完成移动端适配
  - 数据源编辑抽屉补充顶部关闭按钮，提升移动端返回体验

- 模型配置与设置细节修复
  - 添加模型时服务商下拉弹层不再挤压页面内容
  - Ollama 设置页在窄屏下改为上下结构，避免信息与控件横向拥挤
  - MCP 服务等相关设置项在移动端下支持合理换行与重排
  - 渠道卡片、集成配置等页面在小屏下完成布局调整

- 空间 / 组织相关页面移动端优化
  - 创建空间、组织设置等流程调整为更适合移动端的页面式布局
  - 租户与渠道相关弹窗/页面补齐移动端展示细节

- 新增响应式回归测试
  - 为关键页面的断点行为和移动端布局规则补充前端回归断言，降低后续改动带来的样式回归风险

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🧪 Test

## Related Issue

Fixes #917

## Testing

本地验证内容如下：

- 执行测试：
  - `npm test -- src/views/responsive-layout.test.mjs`
  - `npm run build`

- 手动验证：
  - 使用浏览器开发者工具切换移动端视口进行联调
  - 检查对话页、知识库、设置页、发布集成页、上传流程、编辑器页面等关键路径
  - 确认本次调整后的主要移动端页面不存在横向溢出问题
  - 验证侧边栏展开、上传操作、关闭按钮、页面切换等交互在移动端下可正常响应

补充说明：

- `vite build` 可正常通过
- 构建过程中仍存在既有的 chunk size warning，该警告为项目当前已有提示，并非本次改动引入

## Checklist

- [x] Self-reviewed the code
- [x] Added/updated tests covering the change

## Screenshots / Recordings
iPad Mini:

https://github.com/user-attachments/assets/40b79574-82d3-43da-b4eb-f2c7a175b21c

iphoneXR:

https://github.com/user-attachments/assets/e19e6356-4543-470c-aef5-5a0de231d1c6

PC端：

https://github.com/user-attachments/assets/d90f90de-f335-401f-ab49-e57b2015f9db
