### PR TITLE
feat(model): add per-request header forwarding to downstream model calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,6 +142,10 @@ TZ=Asia/Shanghai
 # 禁止新用户注册（生产环境建议设为 true）
 DISABLE_REGISTRATION=false
 
+# 请求头透传开关：开启后匹配的入站请求头会自动附加到下游模型 API 调用中。
+# 匹配规则在 config/config.yaml 的 header_forwarding.prefixes/include 中配置。
+# WEKNORA_HEADER_FORWARDING_ENABLED=false
+
 # Ollama 服务的基准 URL，用于连接本地/其他服务器上运行的 Ollama 服务
 OLLAMA_BASE_URL=http://host.docker.internal:11434
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -107,6 +107,26 @@ extract:
       Please randomly generate a text with freely chosen content, with a word count between [50-200].
 
 
+# Header forwarding configuration
+# Toggle with WEKNORA_HEADER_FORWARDING_ENABLED=true in .env
+# When enabled, matching incoming request headers are forwarded to
+# downstream model API calls (LLM, embedding, rerank, VLM) for use
+# cases like token metering, multi-tenant isolation, traceability.
+#
+# Two matching modes (both case-insensitive, OR logic):
+#   prefixes - match any header whose name starts with this string
+#   include  - match header by exact name
+header_forwarding:
+  prefixes:
+    # WeKnora's own convention: X-WeKnora-User-Id, X-WeKnora-Tenant-Id, etc.
+    - "X-WeKnora-"
+  # Exact header names to forward (case-insensitive). Use this for headers
+  # that don't follow a common prefix — e.g. from upstream gateways.
+  include: []
+  # Example:
+  # include:
+  #   - "X-WeKnora-Request-Id"
+
 # Tenant configuration
 tenant:
   # Enable cross-tenant access (can be enabled for intranet environments)

--- a/internal/application/service/model.go
+++ b/internal/application/service/model.go
@@ -406,7 +406,10 @@ func (s *modelService) GetEmbeddingModel(ctx context.Context, modelId string) (e
 
 	appID, appSecret := s.resolveWeKnoraCloudCredentials(ctx, &model.Parameters)
 
-	embedder, err := embedding.NewEmbedder(embedding.ConfigFromModel(model, appID, appSecret), s.pooler, s.ollamaService)
+	embConfig := embedding.ConfigFromModel(model, appID, appSecret)
+	embConfig.CustomHeaders = utils.MergeHeaders(embConfig.CustomHeaders, types.ForwardHeadersFromContext(ctx))
+
+	embedder, err := embedding.NewEmbedder(embConfig, s.pooler, s.ollamaService)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"model_id":   model.ID,
@@ -453,7 +456,10 @@ func (s *modelService) GetEmbeddingModelForTenant(ctx context.Context, modelId s
 
 	appID, appSecret := s.resolveWeKnoraCloudCredentials(ctx, &model.Parameters)
 
-	embedder, err := embedding.NewEmbedder(embedding.ConfigFromModel(model, appID, appSecret), s.pooler, s.ollamaService)
+	embConfig := embedding.ConfigFromModel(model, appID, appSecret)
+	embConfig.CustomHeaders = utils.MergeHeaders(embConfig.CustomHeaders, types.ForwardHeadersFromContext(ctx))
+
+	embedder, err := embedding.NewEmbedder(embConfig, s.pooler, s.ollamaService)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"model_id":   model.ID,
@@ -483,7 +489,10 @@ func (s *modelService) GetRerankModel(ctx context.Context, modelId string) (rera
 
 	appID, appSecret := s.resolveWeKnoraCloudCredentials(ctx, &model.Parameters)
 
-	reranker, err := rerank.NewReranker(rerank.ConfigFromModel(model, appID, appSecret))
+	rerankConfig := rerank.ConfigFromModel(model, appID, appSecret)
+	rerankConfig.CustomHeaders = utils.MergeHeaders(rerankConfig.CustomHeaders, types.ForwardHeadersFromContext(ctx))
+
+	reranker, err := rerank.NewReranker(rerankConfig)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"model_id":   model.ID,
@@ -526,7 +535,10 @@ func (s *modelService) GetChatModel(ctx context.Context, modelId string) (chat.C
 
 	appID, appSecret := s.resolveWeKnoraCloudCredentials(ctx, &model.Parameters)
 
-	chatModel, err := chat.NewChat(chat.ConfigFromModel(model, appID, appSecret), s.ollamaService)
+	chatConfig := chat.ConfigFromModel(model, appID, appSecret)
+	chatConfig.CustomHeaders = utils.MergeHeaders(chatConfig.CustomHeaders, types.ForwardHeadersFromContext(ctx))
+
+	chatModel, err := chat.NewChat(chatConfig, s.ollamaService)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"model_id":   model.ID,
@@ -563,7 +575,10 @@ func (s *modelService) GetVLMModel(ctx context.Context, modelId string) (vlm.VLM
 
 	appID, appSecret := s.resolveWeKnoraCloudCredentials(ctx, &model.Parameters)
 
-	vlmModel, err := vlm.NewVLM(vlm.ConfigFromModel(model, appID, appSecret), s.ollamaService)
+	vlmConfig := vlm.ConfigFromModel(model, appID, appSecret)
+	vlmConfig.CustomHeaders = utils.MergeHeaders(vlmConfig.CustomHeaders, types.ForwardHeadersFromContext(ctx))
+
+	vlmModel, err := vlm.NewVLM(vlmConfig, s.ollamaService)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"model_id":   model.ID,
@@ -601,7 +616,10 @@ func (s *modelService) GetASRModel(ctx context.Context, modelId string) (asr.ASR
 
 	logger.Infof(ctx, "Getting ASR model: %s, source: %s", model.Name, model.Source)
 
-	sttModel, err := asr.NewASR(asr.ConfigFromModel(model))
+	asrConfig := asr.ConfigFromModel(model)
+	asrConfig.CustomHeaders = utils.MergeHeaders(asrConfig.CustomHeaders, types.ForwardHeadersFromContext(ctx))
+
+	sttModel, err := asr.NewASR(asrConfig)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"model_id":   model.ID,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,46 @@ type Config struct {
 	// against window.location.origin — fine for typical single-origin
 	// deployments. Sourced from FRONTEND_BASE_URL env at startup.
 	FrontendBaseURL string `yaml:"frontend_base_url" json:"frontend_base_url"`
+	// HeaderForwarding configures per-request header forwarding to downstream
+	// model API calls (LLM, embedding, rerank, VLM). When enabled, incoming
+	// request headers matching the configured prefixes or names are
+	// automatically attached to outbound model HTTP requests for token
+	// metering, multi-tenant isolation, traceability, etc.
+	HeaderForwarding *HeaderForwardingConfig `yaml:"header_forwarding" json:"header_forwarding"`
+}
+
+// HeaderForwardingConfig controls which incoming HTTP request headers are
+// forwarded to downstream model API calls (LLM, embedding, rerank, VLM).
+type HeaderForwardingConfig struct {
+	// Enabled turns header forwarding on or off. Default: false.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Prefixes defines header name prefixes to match for forwarding.
+	// e.g. ["X-User-", "X-Tenant-", "X-Trace-"] forwards headers like
+	// "X-User-Id", "X-Tenant-Id", "X-Trace-Id". Case-insensitive match.
+	Prefixes []string `yaml:"prefixes" json:"prefixes"`
+	// Include specifies exact header names to forward (case-insensitive).
+	// e.g. ["X-Request-Id"].
+	Include []string `yaml:"include" json:"include"`
+}
+
+// ShouldForward reports whether the header with the given name should be
+// forwarded to downstream model calls. Matching is case-insensitive.
+func (c *HeaderForwardingConfig) ShouldForward(name string) bool {
+	if c == nil || !c.Enabled {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(name))
+	for _, prefix := range c.Prefixes {
+		if strings.HasPrefix(lower, strings.ToLower(strings.TrimSpace(prefix))) {
+			return true
+		}
+	}
+	for _, exact := range c.Include {
+		if lower == strings.ToLower(strings.TrimSpace(exact)) {
+			return true
+		}
+	}
+	return false
 }
 
 // AgentConfig represents the global agent settings.
@@ -563,6 +603,7 @@ func LoadConfig() (*Config, error) {
 	applyOIDCEnvOverrides(&cfg)
 	applyAgentEnvOverrides(&cfg)
 	applyKnowledgeBaseEnvOverrides(&cfg)
+	applyHeaderForwardingDefaults(&cfg)
 	applyAuthAndTenantDefaults(&cfg)
 	applyAuditDefaults(&cfg)
 
@@ -742,6 +783,17 @@ func applyKnowledgeBaseEnvOverrides(cfg *Config) {
 		if d, err := time.ParseDuration(value); err == nil && d > 0 {
 			cfg.KnowledgeBase.DocReaderCallTimeout = d
 		}
+	}
+}
+
+// applyHeaderForwardingDefaults ensures the header_forwarding section exists
+// with safe defaults and wires the WEKNORA_HEADER_FORWARDING_ENABLED env toggle.
+func applyHeaderForwardingDefaults(cfg *Config) {
+	if cfg.HeaderForwarding == nil {
+		cfg.HeaderForwarding = &HeaderForwardingConfig{}
+	}
+	if v := strings.TrimSpace(os.Getenv("WEKNORA_HEADER_FORWARDING_ENABLED")); v != "" {
+		cfg.HeaderForwarding.Enabled = strings.EqualFold(v, "true")
 	}
 }
 

--- a/internal/handler/initialization.go
+++ b/internal/handler/initialization.go
@@ -1763,7 +1763,9 @@ func (h *InitializationHandler) TestEmbeddingModel(c *gin.Context) {
 	}
 
 	model := h.buildTestModel(&req, types.ModelTypeEmbedding, types.ModelSourceRemote)
-	emb, err := embedding.NewEmbedder(embedding.ConfigFromModel(model, appID, appSecret), h.pooler, h.ollamaService)
+	embConfig := embedding.ConfigFromModel(model, appID, appSecret)
+	embConfig.CustomHeaders = utils.MergeHeaders(embConfig.CustomHeaders, types.ForwardHeadersFromContext(ctx))
+	emb, err := embedding.NewEmbedder(embConfig, h.pooler, h.ollamaService)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{"model": utils.SanitizeForLog(req.ModelName)})
 		c.JSON(http.StatusOK, gin.H{
@@ -1819,7 +1821,9 @@ func classifyConnectionError(errMsg string) string {
 func (h *InitializationHandler) checkChatModelConnection(
 	ctx context.Context, model *types.Model, appID, appSecret string,
 ) (bool, string) {
-	chatInstance, err := chat.NewChat(chat.ConfigFromModel(model, appID, appSecret), h.ollamaService)
+	chatConfig := chat.ConfigFromModel(model, appID, appSecret)
+	chatConfig.CustomHeaders = utils.MergeHeaders(chatConfig.CustomHeaders, types.ForwardHeadersFromContext(ctx))
+	chatInstance, err := chat.NewChat(chatConfig, h.ollamaService)
 	if err != nil {
 		return false, fmt.Sprintf("创建聊天实例失败: %v", err)
 	}
@@ -1855,7 +1859,9 @@ func (h *InitializationHandler) checkChatModelConnection(
 func (h *InitializationHandler) checkRerankModelConnection(
 	ctx context.Context, model *types.Model, appID, appSecret string,
 ) (bool, string) {
-	reranker, err := rerank.NewReranker(rerank.ConfigFromModel(model, appID, appSecret))
+	rerankConfig := rerank.ConfigFromModel(model, appID, appSecret)
+	rerankConfig.CustomHeaders = utils.MergeHeaders(rerankConfig.CustomHeaders, types.ForwardHeadersFromContext(ctx))
+	reranker, err := rerank.NewReranker(rerankConfig)
 	if err != nil {
 		return false, fmt.Sprintf("创建Reranker失败: %v", err)
 	}

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -256,6 +256,10 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 	mcpServiceIDs := dedupRequestStrings(append(request.MCPServiceIDs, mentionedIDsByType(request.MentionedItems, "mcp")...))
 	skillNames := dedupRequestStrings(append(request.SkillNames, mentionedIDsByType(request.MentionedItems, "skill")...))
 
+	// Inject per-request forward headers into the context so downstream model
+	// calls (LLM, embedding, rerank, VLM) can attach them to outbound requests.
+	ctx = h.injectForwardHeaders(ctx, c)
+
 	// Build request context
 	reqCtx := &qaRequestContext{
 		ctx:         ctx,
@@ -933,6 +937,28 @@ func appendQuickAnswerReasoning(msg *types.Message, content string) {
 		}}
 	}
 	msg.AgentSteps[0].ReasoningContent += content
+}
+
+// injectForwardHeaders extracts headers from the incoming request that match
+// the header_forwarding configuration and stores them in the context so
+// downstream model calls (LLM, embedding, rerank, VLM) can forward them.
+// Returns the updated context.
+func (h *Handler) injectForwardHeaders(ctx context.Context, c *gin.Context) context.Context {
+	cfg := h.config.HeaderForwarding
+	if cfg == nil || !cfg.Enabled {
+		return ctx
+	}
+	headers := make(map[string]string)
+	for key, values := range c.Request.Header {
+		if cfg.ShouldForward(key) && len(values) > 0 {
+			headers[key] = values[0]
+		}
+	}
+	if len(headers) == 0 {
+		return ctx
+	}
+	logger.Infof(ctx, "[HeaderForwarding] Forwarding %d header(s) to downstream model calls", len(headers))
+	return types.WithForwardHeaders(ctx, headers)
 }
 
 // completeAssistantMessage marks an assistant message as complete, updates it,

--- a/internal/types/const.go
+++ b/internal/types/const.go
@@ -43,6 +43,11 @@ const (
 	// the agent emits a one-shot authorization notice and continues instead of
 	// blocking until the OAuth wait times out. See IsMCPOAuthNonInteractive.
 	MCPOAuthNonInteractiveContextKey ContextKey = "MCPOAuthNonInteractive"
+	// ForwardHeadersContextKey carries per-request HTTP headers that should be
+	// forwarded to downstream model API calls (LLM, embedding, rerank, VLM).
+	// Populated by the handler from incoming request headers matching the
+	// header_forwarding configuration.
+	ForwardHeadersContextKey ContextKey = "ForwardHeaders"
 )
 
 // String returns the string representation of the context key

--- a/internal/types/context_helpers.go
+++ b/internal/types/context_helpers.go
@@ -138,6 +138,24 @@ func LanguageFromContext(ctx context.Context) (string, bool) {
 	return v, ok && v != ""
 }
 
+// ForwardHeadersFromContext extracts the per-request forward headers from ctx.
+// Returns nil when no headers were set.
+func ForwardHeadersFromContext(ctx context.Context) map[string]string {
+	v, ok := ctx.Value(ForwardHeadersContextKey).(map[string]string)
+	if !ok {
+		return nil
+	}
+	return v
+}
+
+// WithForwardHeaders attaches per-request forward headers to ctx.
+func WithForwardHeaders(ctx context.Context, headers map[string]string) context.Context {
+	if len(headers) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, ForwardHeadersContextKey, headers)
+}
+
 // LanguageNameFromContext returns the human-readable language name for use in prompts.
 // e.g. "zh-CN" -> "Chinese (Simplified)", "en-US" -> "English", "ko-KR" -> "Korean"
 // Falls back to DefaultLanguage() (WEKNORA_LANGUAGE env, then "zh-CN").

--- a/internal/utils/extraheaders.go
+++ b/internal/utils/extraheaders.go
@@ -68,6 +68,29 @@ func (t *CustomHeadersRoundTripper) RoundTrip(req *http.Request) (*http.Response
 	return base.RoundTrip(req)
 }
 
+// MergeHeaders merges extra headers into base. Reserved headers (Authorization,
+// api-key, Content-Type, etc.) in extra are always skipped. When both maps
+// define the same key, base headers take precedence (static configuration wins
+// over dynamic per-request headers). Returns base unchanged when extra is empty.
+func MergeHeaders(base, extra map[string]string) map[string]string {
+	if len(extra) == 0 {
+		return base
+	}
+	merged := make(map[string]string, len(base)+len(extra))
+	for k, v := range extra {
+		if IsReservedHeader(k) {
+			continue
+		}
+		merged[k] = v
+	}
+	// Base headers overwrite forwarded headers for the same key
+	// (static model configuration takes precedence).
+	for k, v := range base {
+		merged[k] = v
+	}
+	return merged
+}
+
 // WrapHTTPClientWithHeaders 返回一个新的 *http.Client，在原有 client 基础上注入自定义 header。
 // 如果 headers 为空则直接返回原 client，避免不必要的开销。
 func WrapHTTPClientWithHeaders(client *http.Client, headers map[string]string) *http.Client {

--- a/internal/utils/extraheaders_test.go
+++ b/internal/utils/extraheaders_test.go
@@ -89,3 +89,54 @@ func TestWrapHTTPClientWithHeaders_EmptyReturnsOriginal(t *testing.T) {
 		t.Fatalf("expected original client returned when headers empty")
 	}
 }
+
+func TestMergeHeaders(t *testing.T) {
+	// nil extra returns base unchanged
+	got := MergeHeaders(map[string]string{"X-WeKnora-User-Id": "1"}, nil)
+	if len(got) != 1 || got["X-WeKnora-User-Id"] != "1" {
+		t.Fatalf("expected base unchanged with nil extra, got %+v", got)
+	}
+
+	// empty extra returns base unchanged
+	got = MergeHeaders(map[string]string{"X-WeKnora-User-Id": "1"}, map[string]string{})
+	if len(got) != 1 || got["X-WeKnora-User-Id"] != "1" {
+		t.Fatalf("expected base unchanged with empty extra, got %+v", got)
+	}
+
+	// reserved headers in extra are skipped
+	got = MergeHeaders(map[string]string{}, map[string]string{
+		"Authorization":       "Bearer injected",
+		"Content-Type":        "text/plain",
+		"X-WeKnora-Tenant-Id": "tenant-456",
+	})
+	if got["Authorization"] != "" {
+		t.Fatalf("reserved Authorization should be skipped, got %q", got["Authorization"])
+	}
+	if got["Content-Type"] != "" {
+		t.Fatalf("reserved Content-Type should be skipped, got %q", got["Content-Type"])
+	}
+	if got["X-WeKnora-Tenant-Id"] != "tenant-456" {
+		t.Fatalf("non-reserved X-WeKnora-Tenant-Id should be present, got %q", got["X-WeKnora-Tenant-Id"])
+	}
+
+	// base takes precedence over extra for same key
+	got = MergeHeaders(
+		map[string]string{"X-WeKnora-Trace-Id": "base-value"},
+		map[string]string{"X-WeKnora-Trace-Id": "extra-value"},
+	)
+	if got["X-WeKnora-Trace-Id"] != "base-value" {
+		t.Fatalf("base should take precedence, got %q", got["X-WeKnora-Trace-Id"])
+	}
+
+	// both maps contribute
+	got = MergeHeaders(
+		map[string]string{"X-WeKnora-User-Id": "10001"},
+		map[string]string{"X-WeKnora-Tenant-Id": "20001"},
+	)
+	if got["X-WeKnora-User-Id"] != "10001" {
+		t.Fatalf("base key missing, got %+v", got)
+	}
+	if got["X-WeKnora-Tenant-Id"] != "20001" {
+		t.Fatalf("extra key missing, got %+v", got)
+	}
+}


### PR DESCRIPTION
## Description

当 WeKnora 作为内部知识库平台被多个业务系统通过 API 调用时，解决业务系统往往需要在下游模型调用中携带自定义请求头（如 `X-WeKnora-User-Id`、`X-WeKnora-Tenant-Id`）问题

### 改动内容

**新增 `header_forwarding` 配置**：
- `config/config.yaml`：配置匹配规则（`prefixes` 前缀匹配 + `include` 精确匹配）
- `.env.example`：新增 `WEKNORA_HEADER_FORWARDING_ENABLED` 开关说明

**请求头透传链路**：
- Handler 层（`qa.go`）：从 `gin.Context` 提取匹配的入站请求头，注入 context
- Model Service 层（`model.go`）：`GetChatModel` / `GetEmbeddingModel` / `GetEmbeddingModelForTenant` / `GetRerankModel` / `GetVLMModel` / `GetASRModel` 全部从 context 读取并合并 forward headers
- 已有的 `CustomHeadersRoundTripper` / `ApplyCustomHeaders` 基础设施自动生效

**安全设计**：
- `IsReservedHeader()` 白名单保护 `Authorization`、`api-key`、`Content-Type` 等不被覆盖
- 静态模型配置 `CustomHeaders` 优先级高于动态 forward headers
- 仅匹配配置的规则，防止不受控的 header 泄露

**测试**：
- 新增 `TestMergeHeaders` 覆盖 nil extra、empty extra、reserved 跳过、base 优先、双方合并五种场景

### 覆盖范围

| 下游模型 | 透传 | 调用链路 |
|---------|------|---------|
| Chat (LLM) | ✅ | `GetChatModel` |
| Chat Stream (LLM) | ✅ | `GetChatModel` |
| Embedding | ✅ | `GetEmbeddingModel` / `GetEmbeddingModelForTenant` |
| Rerank | ✅ | `GetRerankModel` |
| VLM (多模态) | ✅ | `GetVLMModel` |
| ASR (语音识别) | ✅ | `GetASRModel` |

| API 端点 | 透传 | 说明 |
|---------|------|------|
| `/sessions/{id}/knowledge-qa` | ✅ | KnowledgeQA 普通问答 |
| `/sessions/{id}/agent-qa` | ✅ | Agent 智能体问答 |
| 标题生成（异步） | ✅ | 复用 QA 请求 context |
| 图片分析（异步） | ✅ | handler 层 context |
| 附件处理 / ASR | ✅ | handler 层 context |
| `/sessions/search` | ❌ | 独立 handler，未经过 QA 链路 |
| 模型连接测试 | ❌ | 初始化测试链路 |
| IM 消息（企微/飞书/Slack 等） | ❌ | 无 HTTP 请求头来源 |

### 配置示例

```yaml
# config/config.yaml
header_forwarding:
  prefixes:
    - "X-WeKnora-"
  include: []
```

```bash
# .env
WEKNORA_HEADER_FORWARDING_ENABLED=true
```

### 调用示例

```bash
curl -X POST http://localhost:8080/api/v1/sessions/{id}/knowledge-qa \
  -H "X-WeKnora-User-Id: 10001" \
  -H "X-WeKnora-Tenant-Id: t-abc" \
  -H "Authorization: Bearer xxx" \
  -d '{"query": "你好"}'
```

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #1836

## Testing

1. 单元测试：`go test ./internal/utils/... -run TestMergeHeaders -v` 通过
2. 编译验证：`go build ./...` 通过
3. 功能验证：
   - 配置 `header_forwarding` 并在 `.env` 中开启
   - 发起 QA 请求时携带 `X-WeKnora-User-Id` 等请求头
   - 确认下游模型 API 调用中携带了对应请求头（可通过日志或网络抓包验证）
4. 安全验证：
   - 尝试覆盖 `Authorization` 头 → 被拒绝
   - 静态模型 CustomHeaders 与动态 forward headers 相同键 → 静态优先

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above
