### PR TITLE
fix(batch-reparse): use latest KB parser engine rules when no process_config

### DIFF
--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -3399,6 +3399,17 @@ func (s *knowledgeService) ProcessKnowledgeListReparse(ctx context.Context, t *a
 
 	var failed int
 	for _, id := range payload.KnowledgeIDs {
+		// When the batch reparse is triggered without an explicit process_config,
+		// drop the per-knowledge parser engine rule snapshot so that the reparse
+		// uses the knowledge base's current rules instead of the engine that was
+		// configured at upload time.
+		if payload.ProcessConfig == nil {
+			if err := s.clearStoredParserEngineRules(ctx, id); err != nil {
+				logger.Errorf(ctx, "Failed to clear stored parser engine rules for knowledge %s: %v", id, err)
+				failed++
+				continue
+			}
+		}
 		if _, err := s.ReparseKnowledge(ctx, id, payload.ProcessConfig); err != nil {
 			logger.Errorf(ctx, "Failed to reparse knowledge %s: %v", id, err)
 			failed++
@@ -3411,4 +3422,32 @@ func (s *knowledgeService) ProcessKnowledgeListReparse(ctx context.Context, t *a
 	logger.Infof(ctx, "Knowledge list reparse task finished: %d submitted, %d failed",
 		len(payload.KnowledgeIDs)-failed, failed)
 	return nil
+}
+
+// clearStoredParserEngineRules removes the parser engine rule snapshot from a
+// knowledge's metadata so that subsequent reparses resolve the engine from the
+// current knowledge base configuration instead of the upload-time snapshot.
+func (s *knowledgeService) clearStoredParserEngineRules(ctx context.Context, knowledgeID string) error {
+	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
+	k, err := s.repo.GetKnowledgeByID(ctx, tenantID, knowledgeID)
+	if err != nil {
+		return err
+	}
+	if k == nil {
+		return nil
+	}
+
+	overrides, err := k.ProcessOverrides()
+	if err != nil {
+		return err
+	}
+	if overrides == nil {
+		return nil
+	}
+
+	overrides.ParserEngineRules = nil
+	if err := k.SetProcessOverrides(overrides); err != nil {
+		return err
+	}
+	return s.repo.UpdateKnowledgeColumn(ctx, k.ID, "metadata", k.Metadata)
 }

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -3446,6 +3446,9 @@ func (s *knowledgeService) clearStoredParserEngineRules(ctx context.Context, kno
 	}
 
 	overrides.ParserEngineRules = nil
+	if overrides.ChunkingConfig != nil {
+		overrides.ChunkingConfig.ParserEngineRules = nil
+	}
 	if err := k.SetProcessOverrides(overrides); err != nil {
 		return err
 	}

--- a/internal/application/service/knowledge_process_batch_reparse_test.go
+++ b/internal/application/service/knowledge_process_batch_reparse_test.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/require"
+)
+
+type clearParserRulesRepoStub struct {
+	interfaces.KnowledgeRepository
+	knowledge     *types.Knowledge
+	updatedColumn string
+	updatedValue  interface{}
+}
+
+func (r *clearParserRulesRepoStub) GetKnowledgeByID(ctx context.Context, tenantID uint64, id string) (*types.Knowledge, error) {
+	return r.knowledge, nil
+}
+
+func (r *clearParserRulesRepoStub) UpdateKnowledgeColumn(ctx context.Context, id, column string, value interface{}) error {
+	r.updatedColumn = column
+	r.updatedValue = value
+	return nil
+}
+
+func TestClearStoredParserEngineRules_RemovesRulesAndKeepsOtherOverrides(t *testing.T) {
+	t.Parallel()
+
+	k := &types.Knowledge{
+		ID:       "k-1",
+		TenantID: 1,
+		Metadata: types.JSON(`{"process_overrides":{"parser_engine_rules":[{"file_types":["pdf"],"engine":"builtin"}],"chunking_config":{"chunk_size":1024}}}`),
+	}
+	repo := &clearParserRulesRepoStub{knowledge: k}
+	svc := &knowledgeService{repo: repo}
+
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+	err := svc.clearStoredParserEngineRules(ctx, k.ID)
+
+	require.NoError(t, err)
+	require.Equal(t, "metadata", repo.updatedColumn)
+
+	updated, err := k.ProcessOverrides()
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	require.Empty(t, updated.ParserEngineRules)
+	require.NotNil(t, updated.ChunkingConfig)
+	require.Equal(t, 1024, updated.ChunkingConfig.ChunkSize)
+}
+
+func TestClearStoredParserEngineRules_NoOverridesIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	k := &types.Knowledge{
+		ID:       "k-2",
+		TenantID: 1,
+		Metadata: nil,
+	}
+	repo := &clearParserRulesRepoStub{knowledge: k}
+	svc := &knowledgeService{repo: repo}
+
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+	err := svc.clearStoredParserEngineRules(ctx, k.ID)
+
+	require.NoError(t, err)
+	require.Empty(t, repo.updatedColumn)
+}
+
+func TestClearStoredParserEngineRules_MissingKnowledgeIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	repo := &clearParserRulesRepoStub{knowledge: nil}
+	svc := &knowledgeService{repo: repo}
+
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+	err := svc.clearStoredParserEngineRules(ctx, "missing-id")
+
+	require.NoError(t, err)
+	require.Empty(t, repo.updatedColumn)
+}

--- a/internal/application/service/knowledge_process_batch_reparse_test.go
+++ b/internal/application/service/knowledge_process_batch_reparse_test.go
@@ -32,7 +32,7 @@ func TestClearStoredParserEngineRules_RemovesRulesAndKeepsOtherOverrides(t *test
 	k := &types.Knowledge{
 		ID:       "k-1",
 		TenantID: 1,
-		Metadata: types.JSON(`{"process_overrides":{"parser_engine_rules":[{"file_types":["pdf"],"engine":"builtin"}],"chunking_config":{"chunk_size":1024}}}`),
+		Metadata: types.JSON(`{"process_overrides":{"parser_engine_rules":[{"file_types":["pdf"],"engine":"builtin"}],"chunking_config":{"chunk_size":1024,"parser_engine_rules":[{"file_types":["docx"],"engine":"docreader"}]}}}`),
 	}
 	repo := &clearParserRulesRepoStub{knowledge: k}
 	svc := &knowledgeService{repo: repo}
@@ -48,6 +48,7 @@ func TestClearStoredParserEngineRules_RemovesRulesAndKeepsOtherOverrides(t *test
 	require.NotNil(t, updated)
 	require.Empty(t, updated.ParserEngineRules)
 	require.NotNil(t, updated.ChunkingConfig)
+	require.Empty(t, updated.ChunkingConfig.ParserEngineRules)
 	require.Equal(t, 1024, updated.ChunkingConfig.ChunkSize)
 }
 


### PR DESCRIPTION
## Summary
- Clear the stored per-knowledge `parser_engine_rules` snapshot before batch reparse when no explicit `process_config` is provided.
- Preserve other stored per-upload overrides such as chunking settings.
- Add coverage for clearing parser engine rules while keeping unrelated overrides intact.

Fixes #1892

## Tests
- `go test ./internal/application/service -run TestClearStoredParserEngineRules`
- `go test ./internal/application/service`