### PR TITLE
fix(knowledge): 复用未变化的文档重解析结果

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ All notable changes to this project will be documented in this file.
 - **IMPROVED**: **Model management** — deletion blocked when model is referenced by KB or agent; optional embedding-model descriptions in i18n.
 - **IMPROVED**: **Tencent VectorDB** — replica count configurable via env; collection compatibility hardened.
 - **IMPROVED**: **Performance** — compile-once regexps in SQL validation, LLM-JSON fence parsing, and sandbox command substitution.
+- **IMPROVED**: **Knowledge reparse** — unchanged document chunks, image OCR/caption outputs, and Wiki map results now reuse cache entries so reparsing only reruns embeddings or LLM/VLM work when content, model, prompt, or processing config changes (#1679).
 - **IMPROVED**: **Frontend build** — streamlined Docker frontend build via `scripts/build_frontend_dist.sh`; embed entry (`embed.html`) separated from main SPA.
 - **IMPROVED**: **Auth** — session resource caches cleared on logout to prevent cross-user leakage.
 

--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -159,6 +159,24 @@ func (r *chunkRepository) ListChunksByKnowledgeID(
 	return chunks, nil
 }
 
+// ListDocumentChunksForReuse lists existing document chunks that can be matched
+// or retired during a reparse. It intentionally includes rows whose
+// content_hash is still empty so pre-upgrade chunks can either be matched by a
+// freshly-computed hash or removed as stale instead of being left as duplicates.
+func (r *chunkRepository) ListDocumentChunksForReuse(
+	ctx context.Context, tenantID uint64, knowledgeID string,
+) ([]*types.Chunk, error) {
+	var chunks []*types.Chunk
+	if err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND knowledge_id = ? AND chunk_type IN ?",
+			tenantID, knowledgeID, []types.ChunkType{types.ChunkTypeText, types.ChunkTypeParentText}).
+		Order("chunk_index ASC").
+		Find(&chunks).Error; err != nil {
+		return nil, err
+	}
+	return chunks, nil
+}
+
 // ListPagedChunksByKnowledgeID lists chunks for a knowledge ID with pagination
 func (r *chunkRepository) ListPagedChunksByKnowledgeID(
 	ctx context.Context,

--- a/internal/application/repository/chunk_sqlite_test.go
+++ b/internal/application/repository/chunk_sqlite_test.go
@@ -331,3 +331,35 @@ func TestListRecentDocumentChunksWithQuestions_UnionsExplicitKBAndKnowledge(t *t
 	require.Len(t, got, 2)
 	assert.ElementsMatch(t, []string{fromExplicitKB.ID, fromExplicitDocument.ID}, []string{got[0].ID, got[1].ID})
 }
+
+func TestListDocumentChunksForReuse_SQLite(t *testing.T) {
+	db := setupChunkTestDB(t)
+	repo := NewChunkRepository(db)
+	ctx := context.Background()
+
+	kbID := uuid.New().String()
+	knowledgeID := uuid.New().String()
+	reusable := makeChunk(kbID, knowledgeID, types.ChunkTypeText)
+	reusable.ContentHash = types.CalculateDocumentChunkContentHash(reusable.Content, "", reusable.ChunkType, "embed-a", "chunking-a")
+	parent := makeChunk(kbID, knowledgeID, types.ChunkTypeParentText)
+	parent.ContentHash = types.CalculateDocumentChunkContentHash(parent.Content, "", parent.ChunkType, "embed-a", "chunking-a")
+	noHash := makeChunk(kbID, knowledgeID, types.ChunkTypeText)
+	noHash.Content = "legacy content without hash"
+	faq := makeChunk(kbID, knowledgeID, types.ChunkTypeFAQ)
+	faq.ContentHash = "faq-hash"
+	otherKnowledge := makeChunk(kbID, uuid.New().String(), types.ChunkTypeText)
+	otherKnowledge.ContentHash = "other-hash"
+
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{reusable, parent, noHash, faq, otherKnowledge}))
+
+	got, err := repo.ListDocumentChunksForReuse(ctx, 1, knowledgeID)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	ids := map[string]bool{}
+	for _, chunk := range got {
+		ids[chunk.ID] = true
+	}
+	assert.True(t, ids[reusable.ID])
+	assert.True(t, ids[parent.ID])
+	assert.True(t, ids[noHash.ID])
+}

--- a/internal/application/service/cache_fingerprint.go
+++ b/internal/application/service/cache_fingerprint.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func calculateMultimodalContentHash(imageBytes []byte, modelID, prompt string, chunkType types.ChunkType) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte("multimodal-vlm-v1\x00"))
+	_, _ = h.Write([]byte(chunkType))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(modelID)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(prompt)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write(imageBytes)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func calculateWikiMapCacheFingerprint(content, lang, synthesisModelID string, granularity types.WikiExtractionGranularity, contentInstructions, extractionInstructions string) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte("wiki-map-v2\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(content)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(lang)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(synthesisModelID)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(granularity.Normalize()))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(contentInstructions)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(extractionInstructions)))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+type wikiMapCacheEntry struct {
+	Fingerprint     string                   `json:"fingerprint"`
+	SummaryContent  string                   `json:"summary_content"`
+	Entities        []extractedItem          `json:"entities"`
+	Concepts        []extractedItem          `json:"concepts"`
+	SlugItems       map[string]extractedItem `json:"slug_items"`
+	Citations       map[string][]string      `json:"citations"`
+	NewSlugs        []newSlugFromCitation    `json:"new_slugs"`
+	Pass0Failed     bool                     `json:"pass0_failed"`
+	ClassifyBatches int                      `json:"classify_batches"`
+}
+
+func wikiMapCacheFromMetadata(metadata types.JSON, fingerprint string) (*wikiMapCacheEntry, bool) {
+	if len(metadata) == 0 || strings.TrimSpace(fingerprint) == "" {
+		return nil, false
+	}
+	var envelope struct {
+		MapCache wikiMapCacheEntry `json:"map_cache"`
+	}
+	if err := json.Unmarshal(metadata, &envelope); err != nil {
+		return nil, false
+	}
+	if envelope.MapCache.Fingerprint != fingerprint || strings.TrimSpace(envelope.MapCache.SummaryContent) == "" {
+		return nil, false
+	}
+	if envelope.MapCache.SlugItems == nil {
+		envelope.MapCache.SlugItems = map[string]extractedItem{}
+	}
+	if envelope.MapCache.Citations == nil {
+		envelope.MapCache.Citations = map[string][]string{}
+	}
+	return &envelope.MapCache, true
+}
+
+func metadataWithWikiMapCache(existing types.JSON, cache wikiMapCacheEntry) types.JSON {
+	var metadata map[string]interface{}
+	if len(existing) > 0 {
+		_ = json.Unmarshal(existing, &metadata)
+	}
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+	}
+	metadata["map_cache"] = cache
+	b, _ := json.Marshal(metadata)
+	return types.JSON(b)
+}

--- a/internal/application/service/cache_fingerprint.go
+++ b/internal/application/service/cache_fingerprint.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Tencent/WeKnora/internal/types"
@@ -36,6 +38,92 @@ func calculateWikiMapCacheFingerprint(content, lang, synthesisModelID string, gr
 	_, _ = h.Write([]byte(strings.TrimSpace(contentInstructions)))
 	_, _ = h.Write([]byte("\x00"))
 	_, _ = h.Write([]byte(strings.TrimSpace(extractionInstructions)))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func calculateSummaryCacheFingerprint(joinedChunkContents, chatModelID, prompt string, maxTokens int, language string) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte("summary-v1\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(joinedChunkContents)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(chatModelID)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(prompt)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(fmt.Sprintf("%d", maxTokens)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(language)))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func calculateQuestionCacheFingerprint(
+	chunkContent, prevContent, nextContent, title string,
+	questionCount int,
+	chatModelID, prompt, customInstructions, language string,
+) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte("question-v1\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(chunkContent)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(prevContent)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(nextContent)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(title)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(fmt.Sprintf("%d", questionCount)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(chatModelID)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(prompt)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(customInstructions)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(language)))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func calculateGraphExtractFingerprint(chunkContent, modelID, promptDescription, customInstructions string, tags []string) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte("graph-extract-v1\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(chunkContent)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(modelID)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(promptDescription)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(customInstructions)))
+	_, _ = h.Write([]byte("\x00"))
+	sorted := append([]string(nil), tags...)
+	sort.Strings(sorted)
+	_, _ = h.Write([]byte(strings.Join(sorted, "\x1f")))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func calculateParseCacheFingerprint(fileHash, parserEngine, fileType, url string, overrides map[string]string) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte("parse-v1\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(fileHash)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(parserEngine)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(fileType)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(url)))
+	_, _ = h.Write([]byte("\x00"))
+	if len(overrides) > 0 {
+		keys := make([]string, 0, len(overrides))
+		for k := range overrides {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			_, _ = h.Write([]byte(k))
+			_, _ = h.Write([]byte("="))
+			_, _ = h.Write([]byte(overrides[k]))
+			_, _ = h.Write([]byte("\x1f"))
+		}
+	}
 	return hex.EncodeToString(h.Sum(nil))
 }
 
@@ -82,6 +170,88 @@ func metadataWithWikiMapCache(existing types.JSON, cache wikiMapCacheEntry) type
 		metadata = map[string]interface{}{}
 	}
 	metadata["map_cache"] = cache
+	b, _ := json.Marshal(metadata)
+	return types.JSON(b)
+}
+
+type parseCacheEntry struct {
+	Fingerprint string           `json:"fingerprint"`
+	Result      *types.ReadResult `json:"result"`
+}
+
+type summaryCacheEntry struct {
+	Fingerprint string `json:"fingerprint"`
+	Text        string `json:"text"`
+}
+
+func parseCacheFromKnowledgeMetadata(metadata types.JSON, fingerprint string) (*types.ReadResult, bool) {
+	if len(metadata) == 0 || strings.TrimSpace(fingerprint) == "" {
+		return nil, false
+	}
+	var envelope struct {
+		ParseCache parseCacheEntry `json:"parse_cache"`
+	}
+	if err := json.Unmarshal(metadata, &envelope); err != nil {
+		return nil, false
+	}
+	if envelope.ParseCache.Fingerprint != fingerprint || envelope.ParseCache.Result == nil {
+		return nil, false
+	}
+	if strings.TrimSpace(envelope.ParseCache.Result.MarkdownContent) == "" && len(envelope.ParseCache.Result.ImageRefs) == 0 {
+		return nil, false
+	}
+	return envelope.ParseCache.Result, true
+}
+
+func knowledgeMetadataWithParseCache(existing types.JSON, fingerprint string, result *types.ReadResult) types.JSON {
+	var metadata map[string]interface{}
+	if len(existing) > 0 {
+		_ = json.Unmarshal(existing, &metadata)
+	}
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+	}
+	// Drop inline image bytes from cache to keep metadata small; storage keys/refs remain.
+	cached := *result
+	if len(cached.ImageRefs) > 0 {
+		refs := make([]types.ImageRef, len(cached.ImageRefs))
+		for i, ref := range cached.ImageRefs {
+			refs[i] = ref
+			refs[i].ImageData = nil
+		}
+		cached.ImageRefs = refs
+	}
+	cached.AudioData = nil
+	metadata["parse_cache"] = parseCacheEntry{Fingerprint: fingerprint, Result: &cached}
+	b, _ := json.Marshal(metadata)
+	return types.JSON(b)
+}
+
+func summaryCacheFromKnowledgeMetadata(metadata types.JSON, fingerprint string) (string, bool) {
+	if len(metadata) == 0 || strings.TrimSpace(fingerprint) == "" {
+		return "", false
+	}
+	var envelope struct {
+		SummaryCache summaryCacheEntry `json:"summary_cache"`
+	}
+	if err := json.Unmarshal(metadata, &envelope); err != nil {
+		return "", false
+	}
+	if envelope.SummaryCache.Fingerprint != fingerprint || strings.TrimSpace(envelope.SummaryCache.Text) == "" {
+		return "", false
+	}
+	return envelope.SummaryCache.Text, true
+}
+
+func knowledgeMetadataWithSummaryCache(existing types.JSON, fingerprint, text string) types.JSON {
+	var metadata map[string]interface{}
+	if len(existing) > 0 {
+		_ = json.Unmarshal(existing, &metadata)
+	}
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+	}
+	metadata["summary_cache"] = summaryCacheEntry{Fingerprint: fingerprint, Text: text}
 	b, _ := json.Marshal(metadata)
 	return types.JSON(b)
 }

--- a/internal/application/service/cache_fingerprint_test.go
+++ b/internal/application/service/cache_fingerprint_test.go
@@ -1,0 +1,54 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestCalculateMultimodalContentHash_InvalidatesByModelPromptAndImage(t *testing.T) {
+	base := calculateMultimodalContentHash([]byte("same-image"), "vlm-a", "prompt-a", types.ChunkTypeImageOCR)
+	if base == "" {
+		t.Fatal("multimodal hash is empty")
+	}
+	if got := calculateMultimodalContentHash([]byte("same-image"), "vlm-a", "prompt-a", types.ChunkTypeImageOCR); got != base {
+		t.Fatalf("same image/model/prompt should reuse hash: %s != %s", got, base)
+	}
+	if got := calculateMultimodalContentHash([]byte("changed-image"), "vlm-a", "prompt-a", types.ChunkTypeImageOCR); got == base {
+		t.Fatal("image bytes changes must invalidate multimodal cache")
+	}
+	if got := calculateMultimodalContentHash([]byte("same-image"), "vlm-b", "prompt-a", types.ChunkTypeImageOCR); got == base {
+		t.Fatal("VLM model changes must invalidate multimodal cache")
+	}
+	if got := calculateMultimodalContentHash([]byte("same-image"), "vlm-a", "prompt-b", types.ChunkTypeImageOCR); got == base {
+		t.Fatal("prompt changes must invalidate multimodal cache")
+	}
+	if got := calculateMultimodalContentHash([]byte("same-image"), "vlm-a", "prompt-a", types.ChunkTypeImageCaption); got == base {
+		t.Fatal("chunk type changes must invalidate multimodal cache")
+	}
+}
+
+func TestWikiMapCacheFingerprint_InvalidatesByContentModelAndGranularity(t *testing.T) {
+	base := calculateWikiMapCacheFingerprint("content", "zh-CN", "model-a", types.WikiExtractionStandard, "content-instr", "extract-instr")
+	if base == "" {
+		t.Fatal("wiki map cache fingerprint is empty")
+	}
+	if got := calculateWikiMapCacheFingerprint("content", "zh-CN", "model-a", types.WikiExtractionStandard, "content-instr", "extract-instr"); got != base {
+		t.Fatalf("same content/model/config should reuse fingerprint: %s != %s", got, base)
+	}
+	if got := calculateWikiMapCacheFingerprint("changed", "zh-CN", "model-a", types.WikiExtractionStandard, "content-instr", "extract-instr"); got == base {
+		t.Fatal("content changes must invalidate wiki map cache")
+	}
+	if got := calculateWikiMapCacheFingerprint("content", "zh-CN", "model-b", types.WikiExtractionStandard, "content-instr", "extract-instr"); got == base {
+		t.Fatal("synthesis model changes must invalidate wiki map cache")
+	}
+	if got := calculateWikiMapCacheFingerprint("content", "zh-CN", "model-a", types.WikiExtractionFocused, "content-instr", "extract-instr"); got == base {
+		t.Fatal("extraction granularity changes must invalidate wiki map cache")
+	}
+	if got := calculateWikiMapCacheFingerprint("content", "zh-CN", "model-a", types.WikiExtractionStandard, "other-content", "extract-instr"); got == base {
+		t.Fatal("content instructions changes must invalidate wiki map cache")
+	}
+	if got := calculateWikiMapCacheFingerprint("content", "zh-CN", "model-a", types.WikiExtractionStandard, "content-instr", "other-extract"); got == base {
+		t.Fatal("extraction instructions changes must invalidate wiki map cache")
+	}
+}

--- a/internal/application/service/cache_fingerprint_test.go
+++ b/internal/application/service/cache_fingerprint_test.go
@@ -52,3 +52,46 @@ func TestWikiMapCacheFingerprint_InvalidatesByContentModelAndGranularity(t *test
 		t.Fatal("extraction instructions changes must invalidate wiki map cache")
 	}
 }
+
+func TestSummaryQuestionGraphParseFingerprints_InvalidateIndependently(t *testing.T) {
+	sum := calculateSummaryCacheFingerprint("chunks", "model-a", "prompt-a", 2048, "zh")
+	if calculateSummaryCacheFingerprint("chunks", "model-a", "prompt-a", 2048, "zh") != sum {
+		t.Fatal("summary fingerprint unstable")
+	}
+	if calculateSummaryCacheFingerprint("chunks", "model-b", "prompt-a", 2048, "zh") == sum {
+		t.Fatal("summary model change must invalidate")
+	}
+	if calculateSummaryCacheFingerprint("chunks", "model-a", "prompt-b", 2048, "zh") == sum {
+		t.Fatal("summary prompt change must invalidate")
+	}
+
+	q := calculateQuestionCacheFingerprint("c", "p", "n", "title", 3, "m", "prompt", "instr", "zh")
+	if calculateQuestionCacheFingerprint("c", "p", "n", "title", 3, "m", "prompt", "instr", "zh") != q {
+		t.Fatal("question fingerprint unstable")
+	}
+	if calculateQuestionCacheFingerprint("c2", "p", "n", "title", 3, "m", "prompt", "instr", "zh") == q {
+		t.Fatal("question content change must invalidate")
+	}
+	if calculateQuestionCacheFingerprint("c", "p", "n", "title", 3, "m", "prompt", "other", "zh") == q {
+		t.Fatal("question instructions change must invalidate")
+	}
+
+	g := calculateGraphExtractFingerprint("chunk", "model", "desc", "instr", []string{"b", "a"})
+	if calculateGraphExtractFingerprint("chunk", "model", "desc", "instr", []string{"a", "b"}) != g {
+		t.Fatal("graph tags order must not matter")
+	}
+	if calculateGraphExtractFingerprint("chunk", "model", "desc", "other", []string{"a", "b"}) == g {
+		t.Fatal("graph instructions change must invalidate")
+	}
+
+	p := calculateParseCacheFingerprint("filehash", "engine", "pdf", "", map[string]string{"k": "v"})
+	if calculateParseCacheFingerprint("filehash", "engine", "pdf", "", map[string]string{"k": "v"}) != p {
+		t.Fatal("parse fingerprint unstable")
+	}
+	if calculateParseCacheFingerprint("filehash2", "engine", "pdf", "", map[string]string{"k": "v"}) == p {
+		t.Fatal("file hash change must invalidate parse cache")
+	}
+	if calculateParseCacheFingerprint("filehash", "other-engine", "pdf", "", map[string]string{"k": "v"}) == p {
+		t.Fatal("parser engine change must invalidate parse cache")
+	}
+}

--- a/internal/application/service/extract.go
+++ b/internal/application/service/extract.go
@@ -331,6 +331,34 @@ func (s *ChunkExtractService) Handle(ctx context.Context, t *asynq.Task) error {
 		return nil
 	}
 
+	promptDescription := types.AppendCustomPromptInstructions(
+		s.template.Description, extractCfg.CustomInstructions, "graph_extraction")
+	graphFP := calculateGraphExtractFingerprint(
+		chunk.Content, p.ModelID, promptDescription, extractCfg.CustomInstructions, extractCfg.Tags,
+	)
+	if meta, _ := chunk.DocumentMetadata(); meta != nil &&
+		meta.GraphExtractFingerprint == graphFP && meta.GraphPayload != nil {
+		// Cache hit: rematerialize without LLM / model resolve.
+		graph := meta.GraphPayload
+		for _, node := range graph.Node {
+			if node != nil {
+				node.Chunks = []string{chunk.ID}
+			}
+		}
+		if err = s.graphEngine.AddGraph(ctx,
+			types.NameSpace{KnowledgeBase: chunk.KnowledgeBaseID, Knowledge: chunk.KnowledgeID},
+			[]*types.GraphData{graph},
+		); err != nil {
+			logger.Errorf(ctx, "failed to add cached graph: %v", err)
+			handleErr = err
+			return err
+		}
+		graphOut["graph_cache_hit"] = true
+		graphOut["nodes_added"] = len(graph.Node)
+		graphOut["relations_added"] = len(graph.Relation)
+		return nil
+	}
+
 	chatModel, err := s.modelService.GetChatModel(ctx, p.ModelID)
 	if err != nil {
 		logger.Errorf(ctx, "failed to get chat model: %v", err)
@@ -339,9 +367,8 @@ func (s *ChunkExtractService) Handle(ctx context.Context, t *asynq.Task) error {
 	}
 
 	template := &types.PromptTemplateStructured{
-		Description: types.AppendCustomPromptInstructions(
-			s.template.Description, extractCfg.CustomInstructions, "graph_extraction"),
-		Tags: extractCfg.Tags,
+		Description: promptDescription,
+		Tags:        extractCfg.Tags,
 		Examples: []types.GraphData{
 			{
 				Text:     extractCfg.Text,
@@ -374,6 +401,18 @@ func (s *ChunkExtractService) Handle(ctx context.Context, t *asynq.Task) error {
 		logger.Errorf(ctx, "failed to add graph: %v", err)
 		handleErr = err
 		return err
+	}
+	// Persist extract cache on the chunk so reparse / rematerialize can skip LLM.
+	meta, _ := chunk.DocumentMetadata()
+	if meta == nil {
+		meta = &types.DocumentChunkMetadata{}
+	}
+	meta.GraphExtractFingerprint = graphFP
+	meta.GraphPayload = graph
+	if uerr := chunk.SetDocumentMetadata(meta); uerr != nil {
+		logger.Warnf(ctx, "failed to set graph cache metadata for chunk %s: %v", chunk.ID, uerr)
+	} else if uerr := s.chunkRepo.UpdateChunk(ctx, chunk); uerr != nil {
+		logger.Warnf(ctx, "failed to update chunk graph cache for %s: %v", chunk.ID, uerr)
 	}
 	graphOut["nodes_added"] = len(graph.Node)
 	graphOut["relations_added"] = len(graph.Relation)

--- a/internal/application/service/graph_rematerialize.go
+++ b/internal/application/service/graph_rematerialize.go
@@ -1,0 +1,10 @@
+package service
+
+// shouldWipeGraphForRematerialize reports whether the knowledge graph namespace
+// must be cleared before postprocess graph tasks rematerialize. Matches the
+// policy in processChunks: wipe on true full rebuild or when stale chunks
+// were deleted (orphans would otherwise remain because the engine has no
+// per-chunk delete API).
+func shouldWipeGraphForRematerialize(reusedChunkCount, staleDeleteCount int) bool {
+	return reusedChunkCount == 0 || staleDeleteCount > 0
+}

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -19,7 +19,6 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
-	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
 	"github.com/redis/go-redis/v9"
 )
@@ -345,7 +344,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 
 	if imageInfo.OCRText != "" && !ocrCacheHit {
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              types.StableDocumentChunkID(payload.KnowledgeID, ocrContentHash, types.ChunkIDRoleImageOCR),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
@@ -363,7 +362,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 
 	if imageInfo.Caption != "" && !captionCacheHit {
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              types.StableDocumentChunkID(payload.KnowledgeID, captionContentHash, types.ChunkIDRoleImageCaption),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -133,6 +133,25 @@ func (s *ImageMultimodalService) tracker() SpanTracker {
 	return s.spanTracker
 }
 
+func multimodalModelCacheID(vlmCfg types.VLMConfig) string {
+	if id := strings.TrimSpace(vlmCfg.ModelID); id != "" {
+		return id
+	}
+	return "legacy_inline"
+}
+
+func findCachedMultimodalChunk(chunks []*types.Chunk, chunkType types.ChunkType, contentHash string) *types.Chunk {
+	for _, ch := range chunks {
+		if ch == nil || ch.ChunkType != chunkType || ch.ContentHash == "" {
+			continue
+		}
+		if ch.ContentHash == contentHash {
+			return ch
+		}
+	}
+	return nil
+}
+
 // Handle implements asynq handler for TypeImageMultimodal.
 func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) error {
 	var payload types.ImageMultimodalPayload
@@ -233,11 +252,8 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 	// legacy inline-config path) so the trace shows WHICH model handled
 	// this image. Without this, debugging "VLM is slow" requires a
 	// separate hop to the KB config.
-	if id := strings.TrimSpace(vlmCfg.ModelID); id != "" {
-		imgOut["vlm_model_id"] = id
-	} else {
-		imgOut["vlm_model_id"] = "legacy_inline"
-	}
+	vlmCacheModelID := multimodalModelCacheID(vlmCfg)
+	imgOut["vlm_model_id"] = vlmCacheModelID
 
 	// Read image bytes. A provider:// URL must be resolved via FileService —
 	// it must NEVER be handed to the HTTP downloader (which would fail with
@@ -257,50 +273,77 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		OriginalURL: payload.ImageURL,
 	}
 
-	if payload.EnableOCR {
-		prompt := vlmOCRPrompt
-		if payload.ImageSourceType == "scanned_pdf" {
-			prompt = vlmOCRScannedPDFPrompt
-			logger.Infof(ctx, "[ImageMultimodal] Using scanned PDF prompt for OCR: %s", payload.ImageURL)
-			imgOut["ocr_prompt"] = "scanned_pdf"
-		} else {
-			imgOut["ocr_prompt"] = "default"
-		}
-		prompt = types.AppendCustomPromptInstructions(prompt, vlmCfg.CustomInstructions, "image_ocr")
+	existingChildren, childErr := s.chunkService.ListChunkByParentID(ctx, payload.TenantID, payload.ChunkID)
+	if childErr != nil {
+		logger.Warnf(ctx, "[ImageMultimodal] Failed to list existing image children for %s: %v", payload.ChunkID, childErr)
+	}
+	ocrPrompt := vlmOCRPrompt
+	ocrPromptKind := "default"
+	if payload.ImageSourceType == "scanned_pdf" {
+		ocrPrompt = vlmOCRScannedPDFPrompt
+		ocrPromptKind = "scanned_pdf"
+	}
+	ocrPrompt = types.AppendCustomPromptInstructions(ocrPrompt, vlmCfg.CustomInstructions, "image_ocr")
+	captionPrompt := buildVLMCaptionPrompt(ctx, vlmCfg)
+	ocrContentHash := calculateMultimodalContentHash(imgBytes, vlmCacheModelID, ocrPrompt, types.ChunkTypeImageOCR)
+	captionContentHash := calculateMultimodalContentHash(imgBytes, vlmCacheModelID, captionPrompt, types.ChunkTypeImageCaption)
+	ocrCacheHit := false
+	captionCacheHit := false
 
-		ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt)
-		if ocrErr != nil {
-			logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
-			imgOut["ocr_error"] = ocrErr.Error()
+	if payload.EnableOCR {
+		if ocrPromptKind == "scanned_pdf" {
+			logger.Infof(ctx, "[ImageMultimodal] Using scanned PDF prompt for OCR: %s", payload.ImageURL)
+		}
+		imgOut["ocr_prompt"] = ocrPromptKind
+		if cached := findCachedMultimodalChunk(existingChildren, types.ChunkTypeImageOCR, ocrContentHash); cached != nil {
+			imageInfo.OCRText = cached.Content
+			ocrCacheHit = true
+			imgOut["ocr_cache_hit"] = true
+			imgOut["ocr_chars"] = len([]rune(cached.Content))
+			imgOut["ocr_preview"] = previewText(cached.Content, 200)
 		} else {
-			ocrText = sanitizeOCRText(ocrText)
-			if ocrText != "" {
-				imageInfo.OCRText = ocrText
-				imgOut["ocr_chars"] = len([]rune(ocrText))
-				imgOut["ocr_preview"] = previewText(ocrText, 200)
+			ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, ocrPrompt)
+			if ocrErr != nil {
+				logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
+				imgOut["ocr_error"] = ocrErr.Error()
 			} else {
-				logger.Warnf(ctx, "[ImageMultimodal] OCR returned empty/invalid content for %s, discarded", payload.ImageURL)
-				imgOut["ocr_chars"] = 0
-				imgOut["ocr_skipped"] = "empty_or_invalid"
+				ocrText = sanitizeOCRText(ocrText)
+				if ocrText != "" {
+					imageInfo.OCRText = ocrText
+					imgOut["ocr_chars"] = len([]rune(ocrText))
+					imgOut["ocr_preview"] = previewText(ocrText, 200)
+				} else {
+					logger.Warnf(ctx, "[ImageMultimodal] OCR returned empty/invalid content for %s, discarded", payload.ImageURL)
+					imgOut["ocr_chars"] = 0
+					imgOut["ocr_skipped"] = "empty_or_invalid"
+				}
 			}
 		}
 	}
 
-	caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, buildVLMCaptionPrompt(ctx, vlmCfg))
-	if capErr != nil {
-		logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
-		imgOut["caption_error"] = capErr.Error()
-	} else if caption != "" {
-		imageInfo.Caption = caption
-		imgOut["caption_chars"] = len([]rune(caption))
-		imgOut["caption_preview"] = previewText(caption, 200)
+	if cached := findCachedMultimodalChunk(existingChildren, types.ChunkTypeImageCaption, captionContentHash); cached != nil {
+		imageInfo.Caption = cached.Content
+		captionCacheHit = true
+		imgOut["caption_cache_hit"] = true
+		imgOut["caption_chars"] = len([]rune(cached.Content))
+		imgOut["caption_preview"] = previewText(cached.Content, 200)
+	} else {
+		caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, captionPrompt)
+		if capErr != nil {
+			logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
+			imgOut["caption_error"] = capErr.Error()
+		} else if caption != "" {
+			imageInfo.Caption = caption
+			imgOut["caption_chars"] = len([]rune(caption))
+			imgOut["caption_preview"] = previewText(caption, 200)
+		}
 	}
 
 	// Build child chunks for OCR and caption results
 	imageInfoJSON, _ := json.Marshal([]types.ImageInfo{imageInfo})
 	var newChunks []*types.Chunk
 
-	if imageInfo.OCRText != "" {
+	if imageInfo.OCRText != "" && !ocrCacheHit {
 		newChunks = append(newChunks, &types.Chunk{
 			ID:              uuid.New().String(),
 			TenantID:        payload.TenantID,
@@ -312,12 +355,13 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 			IsEnabled:       true,
 			Flags:           types.ChunkFlagRecommended,
 			ImageInfo:       string(imageInfoJSON),
+			ContentHash:     ocrContentHash,
 			CreatedAt:       time.Now(),
 			UpdatedAt:       time.Now(),
 		})
 	}
 
-	if imageInfo.Caption != "" {
+	if imageInfo.Caption != "" && !captionCacheHit {
 		newChunks = append(newChunks, &types.Chunk{
 			ID:              uuid.New().String(),
 			TenantID:        payload.TenantID,
@@ -329,6 +373,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 			IsEnabled:       true,
 			Flags:           types.ChunkFlagRecommended,
 			ImageInfo:       string(imageInfoJSON),
+			ContentHash:     captionContentHash,
 			CreatedAt:       time.Now(),
 			UpdatedAt:       time.Now(),
 		})

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -409,13 +409,10 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	}
 	existingByHash := reusableChunksByHash(existingReusableChunks)
 
-	// 删除知识图谱数据（如果存在）
-	namespace := types.NameSpace{KnowledgeBase: knowledge.KnowledgeBaseID, Knowledge: knowledge.ID}
-	if err := s.graphEngine.DelGraph(ctx, []types.NameSpace{namespace}); err != nil {
-		logger.Warnf(ctx, "Failed to delete existing graph data (may not exist): %v", err)
-		// 不返回错误，继续处理
-	}
-
+	// Graph data is no longer wiped here. Full wipes only happen when no text
+	// chunks are reused (true full rebuild) or when graph rematerialize decides
+	// a rebuild is required — see ensureGraphMaterialized. This keeps GraphRAG
+	// extract cache hits possible across reparses of unchanged content.
 	logger.Infof(ctx, "Incremental cleanup prepared, starting to process new chunks")
 
 	// ========== DocReader 解析结果日志 ==========
@@ -488,8 +485,9 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	if hasParentChild {
 		parentDBChunks = make([]*types.Chunk, len(options.ParentChunks))
 		for i, pc := range options.ParentChunks {
+			parentHash := types.CalculateDocumentChunkContentHash(pc.Content, "", types.ChunkTypeParentText, kb.EmbeddingModelID, chunkingFingerprint)
 			parentDBChunks[i] = &types.Chunk{
-				ID:              uuid.New().String(),
+				ID:              types.StableDocumentChunkID(knowledge.ID, parentHash, types.ChunkIDRoleParentText),
 				TenantID:        knowledge.TenantID,
 				KnowledgeID:     knowledge.ID,
 				KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -501,7 +499,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 				StartAt:         pc.Start,
 				EndAt:           pc.End,
 				ChunkType:       types.ChunkTypeParentText,
-				ContentHash:     types.CalculateDocumentChunkContentHash(pc.Content, "", types.ChunkTypeParentText, kb.EmbeddingModelID, chunkingFingerprint),
+				ContentHash:     parentHash,
 			}
 		}
 		// Set prev/next links for parent chunks
@@ -528,8 +526,9 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		}
 
 		// 创建主文本Chunk
+		textHash := types.CalculateDocumentChunkContentHash(chunkData.Content, chunkData.ContextHeader, types.ChunkTypeText, kb.EmbeddingModelID, chunkingFingerprint)
 		textChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              types.StableDocumentChunkID(knowledge.ID, textHash, types.ChunkIDRoleText),
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -542,7 +541,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			StartAt:         int(chunkData.Start),
 			EndAt:           int(chunkData.End),
 			ChunkType:       types.ChunkTypeText,
-			ContentHash:     types.CalculateDocumentChunkContentHash(chunkData.Content, chunkData.ContextHeader, types.ChunkTypeText, kb.EmbeddingModelID, chunkingFingerprint),
+			ContentHash:     textHash,
 		}
 
 		// Wire up ParentChunkID for child chunks
@@ -623,6 +622,16 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	for _, chunk := range textChunks {
 		if !reusedChunkIDs[chunk.ID] {
 			newTextChunks = append(newTextChunks, chunk)
+		}
+	}
+
+	// Clear graph when the text-chunk set changed (full rebuild or stale deletes).
+	// Unchanged reparses keep the graph so extract cache hits can skip LLM.
+	// When wiped, subsequent graph tasks re-AddGraph from cached payloads or re-extract.
+	if s.graphEngine != nil && shouldWipeGraphForRematerialize(len(reusedChunkIDs), len(chunksToDelete)) {
+		namespace := types.NameSpace{KnowledgeBase: knowledge.KnowledgeBaseID, Knowledge: knowledge.ID}
+		if err := s.graphEngine.DelGraph(ctx, []types.NameSpace{namespace}); err != nil {
+			logger.Warnf(ctx, "Failed to delete graph data before rematerialize (may not exist): %v", err)
 		}
 	}
 
@@ -949,18 +958,15 @@ func sortChunksForSummary(chunks []*types.Chunk) []*types.Chunk {
 	return sorted
 }
 
-// getSummary generates a summary for knowledge content using an AI model
-func (s *knowledgeService) getSummary(ctx context.Context,
-	summaryModel chat.Chat, knowledge *types.Knowledge, chunks []*types.Chunk,
-) (string, error) {
-	// Get knowledge info from the first chunk
+// buildSummaryUserContent reconstructs the exact user-message text that will be
+// sent to the summary LLM. Fingerprint generation MUST call this (not a
+// simplified join) so cache hits match real Chat inputs.
+func (s *knowledgeService) buildSummaryUserContent(ctx context.Context, knowledge *types.Knowledge, chunks []*types.Chunk) (string, int, error) {
 	if len(chunks) == 0 {
-		return "", fmt.Errorf("no chunks provided for summary generation")
+		return "", 0, fmt.Errorf("no chunks provided for summary generation")
 	}
-
-	// Determine max input chars from config
 	maxInputChars := defaultMaxInputChars
-	if s.config.Conversation.Summary != nil && s.config.Conversation.Summary.MaxInputChars > 0 {
+	if s.config != nil && s.config.Conversation.Summary != nil && s.config.Conversation.Summary.MaxInputChars > 0 {
 		maxInputChars = s.config.Conversation.Summary.MaxInputChars
 	}
 
@@ -1001,35 +1007,33 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 			}
 		}
 	}
-
-	// Collect image_info from image_ocr/image_caption children and enrich
-	chunkIDs := make([]string, len(sortedChunks))
-	for i, c := range sortedChunks {
-		chunkIDs[i] = c.ID
-	}
-	imageInfoMap := searchutil.CollectImageInfoByChunkIDs(ctx, s.chunkRepo, knowledge.TenantID, chunkIDs)
-	mergedImageInfo := searchutil.MergeImageInfoJSON(imageInfoMap)
-	if mergedImageInfo != "" {
-		// For image-dominated documents (e.g. a docx whose only payload is a
-		// single embedded picture, or a screenshot-only file), captions alone
-		// often carry too little signal — the real content lives in OCR text.
-		// Detect that case by measuring the document's real (non-image-markup)
-		// text BEFORE enrichment, and switch to full enrichment (caption + OCR)
-		// when the body is essentially empty. Text-heavy documents stay on the
-		// caption-only path to avoid OCR noise (page headers/footers/watermarks
-		// from many figures diluting the main topic).
-		if realTextRuneCount(chunkContents) < imageDominatedTextThreshold {
-			// Caption + OCR (no URL/original wrappers — those are pure noise
-			// for the summary LLM and have been observed to trigger the
-			// "image reference with no extracted text" refusal heuristic).
-			chunkContents = searchutil.EnrichContentCaptionAndOCR(chunkContents, mergedImageInfo)
-		} else {
-			chunkContents = searchutil.EnrichContentCaptionOnly(chunkContents, mergedImageInfo)
+	if s.chunkRepo != nil && knowledge != nil {
+		chunkIDs := make([]string, len(sortedChunks))
+		for i, c := range sortedChunks {
+			chunkIDs[i] = c.ID
+		}
+		imageInfoMap := searchutil.CollectImageInfoByChunkIDs(ctx, s.chunkRepo, knowledge.TenantID, chunkIDs)
+		mergedImageInfo := searchutil.MergeImageInfoJSON(imageInfoMap)
+		if mergedImageInfo != "" {
+			if realTextRuneCount(chunkContents) < imageDominatedTextThreshold {
+				chunkContents = searchutil.EnrichContentCaptionAndOCR(chunkContents, mergedImageInfo)
+			} else {
+				chunkContents = searchutil.EnrichContentCaptionOnly(chunkContents, mergedImageInfo)
+			}
 		}
 	}
-
-	// Apply length limit: sample long content to fit within maxInputChars
 	chunkContents = sampleLongContent(chunkContents, maxInputChars)
+	return chunkContents, maxInputChars, nil
+}
+
+// getSummary generates a summary for knowledge content using an AI model
+func (s *knowledgeService) getSummary(ctx context.Context,
+	summaryModel chat.Chat, knowledge *types.Knowledge, chunks []*types.Chunk,
+) (string, error) {
+	chunkContents, maxInputChars, err := s.buildSummaryUserContent(ctx, knowledge, chunks)
+	if err != nil {
+		return "", err
+	}
 
 	logger.GetLogger(ctx).Infof("getSummary: content length=%d chars (max=%d) for knowledge %s",
 		len([]rune(chunkContents)), maxInputChars, knowledge.ID)
@@ -1291,18 +1295,44 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 		return textChunks[i].ChunkIndex < textChunks[j].ChunkIndex
 	})
 
-	// Initialize chat model for summary
-	chatModel, err := s.modelService.GetChatModel(ctx, kb.SummaryModelID)
-	if err != nil {
-		logger.Errorf(ctx, "Failed to get chat model: %v", err)
-		markSummaryFailed()
-		summaryErr = err
-		return fmt.Errorf("failed to get chat model: %w", err)
+	// Summary fingerprint: skip Chat when the exact LLM inputs are unchanged.
+	maxTokensForFP := 2048
+	if s.config.Conversation.Summary != nil && s.config.Conversation.Summary.MaxCompletionTokens > 0 {
+		maxTokensForFP = s.config.Conversation.Summary.MaxCompletionTokens
+	}
+	summaryPromptForFP := types.RenderPromptPlaceholders(s.config.Conversation.GenerateSummaryPrompt, types.PlaceholderValues{
+		"language": types.LanguageNameFromContext(ctx),
+	})
+	userContentForFP, _, buildErr := s.buildSummaryUserContent(ctx, knowledge, textChunks)
+	if buildErr != nil {
+		logger.Warnf(ctx, "Failed to build summary fingerprint content: %v", buildErr)
+		userContentForFP = ""
+	}
+	summaryFP := calculateSummaryCacheFingerprint(
+		userContentForFP,
+		kb.SummaryModelID,
+		summaryPromptForFP,
+		maxTokensForFP,
+		types.LanguageNameFromContext(ctx),
+	)
+	var summary string
+	if cachedSummary, ok := summaryCacheFromKnowledgeMetadata(knowledge.Metadata, summaryFP); ok {
+		summaryOut["summary_cache_hit"] = true
+		summary = cachedSummary
+		logger.Infof(ctx, "summary cache hit for knowledge %s", payload.KnowledgeID)
+		err = nil
+	} else {
+		chatModel, modelErr := s.modelService.GetChatModel(ctx, kb.SummaryModelID)
+		if modelErr != nil {
+			logger.Errorf(ctx, "Failed to get chat model: %v", modelErr)
+			markSummaryFailed()
+			summaryErr = modelErr
+			return fmt.Errorf("failed to get chat model: %w", modelErr)
+		}
+		summary, err = s.getSummary(ctx, chatModel, knowledge, textChunks)
 	}
 
-	// Generate summary
 	summaryMetadataVersion := string(knowledge.CustomMetadata)
-	summary, err := s.getSummary(ctx, chatModel, knowledge, textChunks)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to generate summary for knowledge %s: %v", payload.KnowledgeID, err)
 		// Surface the underlying LLM/IO error on the span so the trace UI
@@ -1362,6 +1392,9 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 	knowledge.Description = summary
 	knowledge.SummaryStatus = types.SummaryStatusCompleted
 	knowledge.UpdatedAt = time.Now()
+	if strings.TrimSpace(summary) != "" && summaryFP != "" {
+		knowledge.Metadata = knowledgeMetadataWithSummaryCache(knowledge.Metadata, summaryFP, summary)
+	}
 	summaryOut["summary_chars"] = len([]rune(summary))
 	// Preview the generated summary on the span output so the trace
 	// viewer can show "this is what the LLM produced" at a glance,
@@ -1377,6 +1410,15 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 	// Create summary chunk and index it — only when RAG indexing is enabled.
 	// Wiki-only KBs don't need summary chunks in the vector index.
 	if strings.TrimSpace(summary) != "" && kb.NeedsEmbeddingModel() {
+		// Cache hit with existing summary chunk: skip re-create / re-embed.
+		if summaryOut["summary_cache_hit"] == true {
+			for _, c := range chunks {
+				if c != nil && c.ChunkType == types.ChunkTypeSummary && c.ContentHash == summaryFP {
+					summaryOut["summary_chunk_reused"] = true
+					return nil
+				}
+			}
+		}
 		// Get max chunk index
 		maxChunkIndex := 0
 		for _, chunk := range chunks {
@@ -1390,12 +1432,13 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 		// unreliable signal (e.g. "MX5280.pdf" for a scanned legal letter)
 		// and surfacing them in retrieved RAG context can re-introduce the
 		// hallucination vector this branch is meant to close.
+		summaryContent := fmt.Sprintf("# Summary\n%s", summary)
 		summaryChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              types.StableDocumentChunkID(knowledge.ID, summaryFP, types.ChunkIDRoleSummary),
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
-			Content:         fmt.Sprintf("# Summary\n%s", summary),
+			Content:         summaryContent,
 			ChunkIndex:      maxChunkIndex + 1,
 			IsEnabled:       true,
 			CreatedAt:       time.Now(),
@@ -1404,6 +1447,7 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 			EndAt:           0,
 			ChunkType:       types.ChunkTypeSummary,
 			ParentChunkID:   textChunks[0].ID,
+			ContentHash:     summaryFP,
 		}
 
 		// Save summary chunk
@@ -1768,6 +1812,21 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 		}
 
 		generationRevision := chunk.ContentRevision
+		promptForFP := strings.TrimSpace(s.config.Conversation.GenerateQuestionsPrompt)
+		qgFP := calculateQuestionCacheFingerprint(
+			enrichContent(chunk), prevContent, nextContent, knowledge.Title, questionCount,
+			kb.SummaryModelID, promptForFP, customInstructions, types.LanguageNameFromContext(ctx),
+		)
+		if existingMeta, _ := chunk.DocumentMetadata(); existingMeta != nil &&
+			existingMeta.QuestionCacheFingerprint == qgFP && len(existingMeta.GeneratedQuestions) > 0 {
+			llmCallSuccess++
+			generatedQuestionsTotal += len(existingMeta.GeneratedQuestions)
+			if sampleQuestion == "" {
+				sampleQuestion = previewText(existingMeta.GeneratedQuestions[0].Question, 200)
+			}
+			continue
+		}
+
 		llmCallAttempts++
 		questions, err := s.generateQuestionsWithContext(ctx, chatModel, enrichContent(chunk), prevContent, nextContent,
 			knowledge.Title, questionCount, customInstructions)
@@ -1805,7 +1864,9 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 			}
 		}
 		meta := &types.DocumentChunkMetadata{
-			GeneratedQuestions: generatedQuestions, GeneratedQuestionsRevision: chunk.ContentRevision,
+			GeneratedQuestions:         generatedQuestions,
+			GeneratedQuestionsRevision: chunk.ContentRevision,
+			QuestionCacheFingerprint:   qgFP,
 		}
 		if err := chunk.SetDocumentMetadata(meta); err != nil {
 			chunkMetadataSetFailed++
@@ -2108,6 +2169,22 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 		}
 
 		generationRevision := chunk.ContentRevision
+		promptForFP := strings.TrimSpace(s.config.Conversation.GenerateQuestionsPrompt)
+		qgFP := calculateQuestionCacheFingerprint(
+			enrich(chunk), prevContentAt(i), nextContentAt(i), knowledge.Title, questionCount,
+			kb.SummaryModelID, promptForFP, customInstructions, types.LanguageNameFromContext(ctx),
+		)
+		if existingMeta, _ := chunk.DocumentMetadata(); existingMeta != nil &&
+			existingMeta.QuestionCacheFingerprint == qgFP && len(existingMeta.GeneratedQuestions) > 0 {
+			// Cache hit: questions already persisted and indexed from a prior run.
+			chunksProcessed++
+			generatedQuestionsTotal += len(existingMeta.GeneratedQuestions)
+			if sampleQuestion == "" {
+				sampleQuestion = previewText(existingMeta.GeneratedQuestions[0].Question, 200)
+			}
+			continue
+		}
+
 		questions, gerr := s.generateQuestionsWithContext(
 			ctx, chatModel, enrich(chunk), prevContentAt(i), nextContentAt(i), knowledge.Title, questionCount,
 			customInstructions)
@@ -2141,7 +2218,9 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 			}
 		}
 		meta := &types.DocumentChunkMetadata{
-			GeneratedQuestions: generatedQuestions, GeneratedQuestionsRevision: chunk.ContentRevision,
+			GeneratedQuestions:         generatedQuestions,
+			GeneratedQuestionsRevision: chunk.ContentRevision,
+			QuestionCacheFingerprint:   qgFP,
 		}
 		if err := chunk.SetDocumentMetadata(meta); err != nil {
 			logger.Warnf(ctx, "Failed to set document metadata for chunk %s: %v", chunk.ID, err)
@@ -3711,6 +3790,24 @@ func (s *knowledgeService) convert(
 		req.FileType = fileType
 	}
 
+	parseFP := calculateParseCacheFingerprint(
+		knowledge.FileHash, parserEngine, fileType, payload.URL, mergedOverrides,
+	)
+	if cachedResult, ok := parseCacheFromKnowledgeMetadata(knowledge.Metadata, parseFP); ok {
+		docOutput := types.JSONMap{
+			"text_length":     len(cachedResult.MarkdownContent),
+			"images_found":    len(cachedResult.ImageRefs),
+			"is_audio":        cachedResult.IsAudio,
+			"parse_cache_hit": true,
+		}
+		if pages := cachedResult.Metadata["pages"]; pages != "" {
+			docOutput["pages"] = pages
+		}
+		s.endStage(ctx, knowledge.ID, types.StageDocReader, docOutput)
+		logger.Infof(ctx, "[convert] parse cache hit kb=%s knowledge=%s engine=%q", kb.ID, knowledge.ID, parserEngine)
+		return cachedResult, nil
+	}
+
 	result, err := s.callDocReaderWithTimeout(ctx, reader, req)
 	if err != nil {
 		// Distinguish DocReader timeout (a knowable user-facing
@@ -3742,6 +3839,12 @@ func (s *knowledgeService) convert(
 	}
 	if pages := result.Metadata["pages"]; pages != "" {
 		docOutput["pages"] = pages
+	}
+	if parseFP != "" {
+		knowledge.Metadata = knowledgeMetadataWithParseCache(knowledge.Metadata, parseFP, result)
+		if uerr := s.repo.UpdateKnowledge(ctx, knowledge); uerr != nil {
+			logger.Warnf(ctx, "[convert] failed to persist parse cache for %s: %v", knowledge.ID, uerr)
+		}
 	}
 	s.endStage(ctx, knowledge.ID, types.StageDocReader, docOutput)
 	return result, nil

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -224,6 +224,95 @@ func buildSplitterConfigFromChunking(cc types.ChunkingConfig) chunker.SplitterCo
 	return chunkCfg
 }
 
+func documentChunkReuseFingerprint(kb *types.KnowledgeBase, options ProcessChunksOptions) string {
+	if kb == nil {
+		return ""
+	}
+	payload := struct {
+		ChunkingConfig types.ChunkingConfig `json:"chunking_config"`
+		ParentChild    bool                 `json:"parent_child"`
+	}{
+		ChunkingConfig: kb.ChunkingConfig,
+		ParentChild:    len(options.ParentChunks) > 0,
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Sprintf("fallback:%+v:%t", kb.ChunkingConfig, len(options.ParentChunks) > 0)
+	}
+	return string(b)
+}
+
+func reusableChunksByHash(chunks []*types.Chunk) map[string][]*types.Chunk {
+	byHash := make(map[string][]*types.Chunk, len(chunks))
+	for _, chunk := range chunks {
+		if chunk == nil || chunk.ContentHash == "" {
+			continue
+		}
+		byHash[chunk.ContentHash] = append(byHash[chunk.ContentHash], chunk)
+	}
+	return byHash
+}
+
+func popReusableChunk(byHash map[string][]*types.Chunk, candidate *types.Chunk) *types.Chunk {
+	if candidate == nil || candidate.ContentHash == "" {
+		return nil
+	}
+	list := byHash[candidate.ContentHash]
+	for len(list) > 0 {
+		existing := list[0]
+		list = list[1:]
+		byHash[candidate.ContentHash] = list
+		if existing != nil && existing.ChunkType == candidate.ChunkType {
+			return existing
+		}
+	}
+	return nil
+}
+
+func rewireReusedChunkRelationships(
+	insertChunks []*types.Chunk,
+	parentChunks []*types.Chunk,
+	textChunks []*types.Chunk,
+	hasParentChild bool,
+	reusedIDRemap map[string]string,
+) {
+	for _, chunk := range insertChunks {
+		if chunk == nil {
+			continue
+		}
+		if remappedParentID, ok := reusedIDRemap[chunk.ParentChunkID]; ok {
+			chunk.ParentChunkID = remappedParentID
+		}
+		chunk.PreChunkID = ""
+		chunk.NextChunkID = ""
+	}
+	for i, chunk := range parentChunks {
+		if chunk == nil {
+			continue
+		}
+		if i > 0 && parentChunks[i-1] != nil {
+			chunk.PreChunkID = parentChunks[i-1].ID
+		}
+		if i < len(parentChunks)-1 && parentChunks[i+1] != nil {
+			chunk.NextChunkID = parentChunks[i+1].ID
+		}
+	}
+	if hasParentChild {
+		return
+	}
+	for i, chunk := range textChunks {
+		if chunk == nil {
+			continue
+		}
+		if i > 0 && textChunks[i-1] != nil {
+			chunk.PreChunkID = textChunks[i-1].ID
+		}
+		if i < len(textChunks)-1 && textChunks[i+1] != nil {
+			chunk.NextChunkID = textChunks[i+1].ID
+		}
+	}
+}
+
 // buildParentChildConfigs derives parent and child SplitterConfig from ChunkingConfig.
 // The base config (already validated with defaults) is used for separators and
 // the splitting strategy. Strategy must be propagated: an empty Strategy resolves
@@ -286,27 +375,39 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping embedding model", kb.ID)
 	}
 
-	// 幂等性处理：清理旧的chunks和索引数据，避免重复数据
-	logger.Infof(ctx, "Cleaning up existing chunks and index data for knowledge: %s", knowledge.ID)
+	chunkingFingerprint := documentChunkReuseFingerprint(kb, options)
 
-	// 删除旧的chunks
-	if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
-		logger.Warnf(ctx, "Failed to delete existing chunks (may not exist): %v", err)
-		// 不返回错误，继续处理（可能没有旧数据）
-	}
-
-	// 删除旧的索引数据 — only when vector/keyword indexing is enabled
+	// Prepare existing chunks/index for incremental reparse. Do NOT delete all
+	// chunks or vectors up front: unchanged content should keep its chunk ID and
+	// vector entry so reparse can avoid redundant embedding/model calls.
 	tenantInfo := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
 	retrieveEngine, err := retriever.CreateRetrieveEngineForKB(
 		ctx, s.retrieveEngine, s.ownership, tenantInfo.ID, kb.VectorStoreID)
-	if err == nil && embeddingModel != nil {
-		if err := retrieveEngine.DeleteByKnowledgeIDList(ctx, []string{knowledge.ID}, embeddingModel.GetDimensions(), knowledge.Type); err != nil {
-			logger.Warnf(ctx, "Failed to delete existing index data (may not exist): %v", err)
-			// 不返回错误，继续处理（可能没有旧数据）
-		} else {
-			logger.Infof(ctx, "Successfully deleted existing index data for knowledge: %s", knowledge.ID)
+	if err != nil {
+		logger.Warnf(ctx, "Failed to resolve retrieve engine before incremental reparse: %v", err)
+		if kb.NeedsEmbeddingModel() {
+			knowledge.ParseStatus = types.ParseStatusFailed
+			knowledge.ErrorMessage = err.Error()
+			knowledge.UpdatedAt = time.Now()
+			s.repo.UpdateKnowledge(ctx, knowledge)
+			s.failStage(ctx, knowledge.ID, types.StageEmbedding,
+				werrors.ErrCodeVectorStoreWriteFailed, "resolve retrieve engine failed", err)
+			return
 		}
 	}
+	existingReusableChunks, err := s.chunkService.GetRepository().ListDocumentChunksForReuse(ctx, tenantInfo.ID, knowledge.ID)
+	if err != nil {
+		logger.Warnf(ctx, "Failed to list reusable chunks for knowledge %s: %v", knowledge.ID, err)
+		existingReusableChunks = nil
+	}
+	for _, chunk := range existingReusableChunks {
+		if chunk != nil && chunk.ContentHash == "" {
+			chunk.ContentHash = types.CalculateDocumentChunkContentHash(
+				chunk.Content, chunk.ContextHeader, chunk.ChunkType, kb.EmbeddingModelID, chunkingFingerprint,
+			)
+		}
+	}
+	existingByHash := reusableChunksByHash(existingReusableChunks)
 
 	// 删除知识图谱数据（如果存在）
 	namespace := types.NameSpace{KnowledgeBase: knowledge.KnowledgeBaseID, Knowledge: knowledge.ID}
@@ -315,7 +416,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		// 不返回错误，继续处理
 	}
 
-	logger.Infof(ctx, "Cleanup completed, starting to process new chunks")
+	logger.Infof(ctx, "Incremental cleanup prepared, starting to process new chunks")
 
 	// ========== DocReader 解析结果日志 ==========
 	logger.Infof(ctx, "[DocReader] ========== 解析结果概览 ==========")
@@ -400,6 +501,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 				StartAt:         pc.Start,
 				EndAt:           pc.End,
 				ChunkType:       types.ChunkTypeParentText,
+				ContentHash:     types.CalculateDocumentChunkContentHash(pc.Content, "", types.ChunkTypeParentText, kb.EmbeddingModelID, chunkingFingerprint),
 			}
 		}
 		// Set prev/next links for parent chunks
@@ -440,6 +542,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			StartAt:         int(chunkData.Start),
 			EndAt:           int(chunkData.End),
 			ChunkType:       types.ChunkTypeText,
+			ContentHash:     types.CalculateDocumentChunkContentHash(chunkData.Content, chunkData.ContextHeader, types.ChunkTypeText, kb.EmbeddingModelID, chunkingFingerprint),
 		}
 
 		// Wire up ParentChunkID for child chunks
@@ -480,34 +583,109 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		}
 	}
 
+	chunksToCreate := make([]*types.Chunk, 0, len(insertChunks))
+	chunksToUpdate := make([]*types.Chunk, 0)
+	reusedChunkIDs := make(map[string]bool)
+	reusedIDRemap := make(map[string]string)
+	for _, chunk := range insertChunks {
+		if existing := popReusableChunk(existingByHash, chunk); existing != nil {
+			oldID := chunk.ID
+			chunk.ID = existing.ID
+			chunk.SeqID = existing.SeqID
+			chunk.CreatedAt = existing.CreatedAt
+			reusedChunkIDs[existing.ID] = true
+			reusedIDRemap[oldID] = existing.ID
+			if chunk.ChunkType == types.ChunkTypeText {
+				for idx := range chunks {
+					if chunks[idx].ChunkID == oldID {
+						chunks[idx].ChunkID = existing.ID
+						break
+					}
+				}
+			}
+			chunksToUpdate = append(chunksToUpdate, chunk)
+			continue
+		}
+		chunksToCreate = append(chunksToCreate, chunk)
+	}
+	rewireReusedChunkRelationships(insertChunks, parentDBChunks, textChunks, hasParentChild, reusedIDRemap)
+
+	chunksToDelete := make([]string, 0)
+	for _, chunkList := range existingByHash {
+		for _, chunk := range chunkList {
+			if chunk != nil && !reusedChunkIDs[chunk.ID] {
+				chunksToDelete = append(chunksToDelete, chunk.ID)
+			}
+		}
+	}
+
+	newTextChunks := make([]*types.Chunk, 0, len(textChunks))
+	for _, chunk := range textChunks {
+		if !reusedChunkIDs[chunk.ID] {
+			newTextChunks = append(newTextChunks, chunk)
+		}
+	}
+
 	// Check if knowledge is being deleted/cancelled before writing chunks.
-	// Nothing has been persisted yet, so both branches just bail.
+	// Nothing new has been persisted yet, so both branches just bail.
 	if aborted, status := s.isKnowledgeAborted(ctx, knowledge.TenantID, knowledge.ID); aborted {
 		logger.Infof(ctx, "Knowledge aborted (%s), skipping chunk write: %s", status, knowledge.ID)
 		return
 	}
 
-	// Save chunks to database — ALWAYS, regardless of indexing strategy.
-	// Chunks are needed for wiki generation, graph extraction, and summary generation
-	// even when vector/keyword indexing is disabled.
+	// Save only new/changed chunks. Reused chunks keep their IDs and vectors; their
+	// ordering links are refreshed below so partial reparses do not leave stale
+	// prev/next pointers around newly-created neighbors.
 	s.beginStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
 		"chunks_planned": len(insertChunks),
+		"chunks_reused":  len(reusedChunkIDs),
 	})
-	if err := s.chunkService.CreateChunks(ctx, insertChunks); err != nil {
-		knowledge.ParseStatus = types.ParseStatusFailed
-		knowledge.ErrorMessage = err.Error()
-		knowledge.UpdatedAt = time.Now()
-		s.repo.UpdateKnowledge(ctx, knowledge)
-		s.failStage(ctx, knowledge.ID, types.StageChunking,
-			werrors.ErrCodeChunkingFailed, "create chunks failed", err)
-		return
+	if len(chunksToDelete) > 0 {
+		if err := s.chunkService.DeleteChunks(ctx, chunksToDelete); err != nil {
+			knowledge.ParseStatus = types.ParseStatusFailed
+			knowledge.ErrorMessage = err.Error()
+			knowledge.UpdatedAt = time.Now()
+			s.repo.UpdateKnowledge(ctx, knowledge)
+			s.failStage(ctx, knowledge.ID, types.StageChunking,
+				werrors.ErrCodeChunkingFailed, "delete stale chunks failed", err)
+			return
+		}
+		if retrieveEngine != nil && embeddingModel != nil {
+			if err := retrieveEngine.DeleteByChunkIDList(ctx, chunksToDelete, embeddingModel.GetDimensions(), knowledge.Type); err != nil {
+				logger.Warnf(ctx, "Failed to delete stale index data: %v", err)
+			}
+		}
+	}
+	if len(chunksToCreate) > 0 {
+		if err := s.chunkService.CreateChunks(ctx, chunksToCreate); err != nil {
+			knowledge.ParseStatus = types.ParseStatusFailed
+			knowledge.ErrorMessage = err.Error()
+			knowledge.UpdatedAt = time.Now()
+			s.repo.UpdateKnowledge(ctx, knowledge)
+			s.failStage(ctx, knowledge.ID, types.StageChunking,
+				werrors.ErrCodeChunkingFailed, "create chunks failed", err)
+			return
+		}
+	}
+	for _, chunk := range chunksToUpdate {
+		if err := s.chunkService.UpdateChunk(ctx, chunk); err != nil {
+			knowledge.ParseStatus = types.ParseStatusFailed
+			knowledge.ErrorMessage = err.Error()
+			knowledge.UpdatedAt = time.Now()
+			s.repo.UpdateKnowledge(ctx, knowledge)
+			s.failStage(ctx, knowledge.ID, types.StageChunking,
+				werrors.ErrCodeChunkingFailed, "update reused chunks failed", err)
+			return
+		}
 	}
 	totalChunkChars := 0
 	for _, c := range insertChunks {
 		totalChunkChars += len(c.Content)
 	}
 	s.endStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
-		"chunks_written":   len(insertChunks),
+		"chunks_written":   len(chunksToCreate),
+		"chunks_reused":    len(reusedChunkIDs),
+		"chunks_deleted":   len(chunksToDelete),
 		"total_text_chars": totalChunkChars,
 	})
 
@@ -516,7 +694,8 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	var totalStorageSize int64
 	if kb.NeedsEmbeddingModel() && embeddingModel != nil {
 		embedInput := types.JSONMap{
-			"chunks_to_embed": len(textChunks),
+			"chunks_to_embed": len(newTextChunks),
+			"chunks_reused":   len(textChunks) - len(newTextChunks),
 			"model_id":        kb.EmbeddingModelID,
 		}
 		if dim := embeddingModel.GetDimensions(); dim > 0 {
@@ -527,8 +706,8 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		// Parent chunks are stored for context retrieval but do not need vector embeddings.
 		// Prepend the document title to improve semantic alignment between
 		// question-style queries and statement-style chunk content.
-		indexInfoList := make([]*types.IndexInfo, 0, len(textChunks))
-		for _, chunk := range textChunks {
+		indexInfoList := make([]*types.IndexInfo, 0, len(newTextChunks))
+		for _, chunk := range newTextChunks {
 			// chunk.EmbeddingContent prepends ContextHeader (heading breadcrumb)
 			// when the chunker populated it during Tier-1 splitting; falls back
 			// to plain Content otherwise. The document title sits outermost;
@@ -543,6 +722,16 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 				KnowledgeBaseID: knowledge.KnowledgeBaseID,
 				IsEnabled:       true,
 			})
+		}
+
+		if len(indexInfoList) == 0 {
+			logger.Infof(ctx, "processChunks reused all %d text chunk vectors", len(textChunks))
+			s.endStage(ctx, knowledge.ID, types.StageEmbedding, types.JSONMap{
+				"vectors_written": 0,
+				"vectors_reused":  len(textChunks),
+				"storage_bytes":   0,
+			})
+			goto afterEmbedding
 		}
 
 		// Calculate storage size required for embeddings
@@ -611,6 +800,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		logger.GetLogger(ctx).Infof("processChunks batch index successfully, with %d index", len(indexInfoList))
 		s.endStage(ctx, knowledge.ID, types.StageEmbedding, types.JSONMap{
 			"vectors_written": len(indexInfoList),
+			"vectors_reused":  len(textChunks) - len(newTextChunks),
 			"storage_bytes":   totalStorageSize,
 		})
 
@@ -635,6 +825,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		s.skipStage(ctx, knowledge.ID, types.StageEmbedding, "skipped")
 	}
 
+afterEmbedding:
 	// Check if this document has extracted images that will be processed asynchronously
 	isImage := IsImageType(knowledge.FileType)
 	isVideo := IsVideoType(knowledge.FileType)
@@ -2350,14 +2541,12 @@ func (s *knowledgeService) ReparseKnowledge(
 		return existing, nil
 	}
 
-	// For non-manual knowledge, cleanup synchronously then enqueue document processing
-	logger.Infof(ctx, "Cleaning up existing resources for knowledge: %s", knowledgeID)
-	if err := s.cleanupKnowledgeResources(ctx, existing); err != nil {
-		logger.ErrorWithFields(ctx, err, map[string]interface{}{
-			"knowledge_id": knowledgeID,
-		})
-		return nil, err
-	}
+	// For non-manual knowledge, keep existing chunks/vector entries until the
+	// worker has parsed the new content. processChunks now performs an
+	// incremental diff: unchanged chunks are reused, stale chunks are removed,
+	// and only new/changed chunks are embedded. Cleaning everything here would
+	// make every reparse a cache miss.
+	logger.Infof(ctx, "Preserving existing resources for incremental reparse: %s", knowledgeID)
 
 	// Step 2: Update knowledge status and metadata
 	resetKnowledgeForReparse(existing, kb)

--- a/internal/application/service/knowledge_process_test.go
+++ b/internal/application/service/knowledge_process_test.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRewireReusedChunkRelationships(t *testing.T) {
+	parent := &types.Chunk{ID: "new-parent", ChunkType: types.ChunkTypeParentText}
+	child := &types.Chunk{ID: "child", ChunkType: types.ChunkTypeText, ParentChunkID: "new-parent"}
+	first := &types.Chunk{ID: "first", ChunkType: types.ChunkTypeText, NextChunkID: "new-reused"}
+	reused := &types.Chunk{ID: "old-reused", ChunkType: types.ChunkTypeText, PreChunkID: "first"}
+
+	rewireReusedChunkRelationships(
+		[]*types.Chunk{parent, child, first, reused},
+		[]*types.Chunk{parent},
+		[]*types.Chunk{first, reused},
+		false,
+		map[string]string{"new-parent": "old-parent", "new-reused": "old-reused"},
+	)
+
+	assert.Equal(t, "old-parent", child.ParentChunkID)
+	assert.Equal(t, "old-reused", first.NextChunkID)
+	assert.Equal(t, "first", reused.PreChunkID)
+	assert.Empty(t, first.PreChunkID)
+	assert.Empty(t, reused.NextChunkID)
+}

--- a/internal/application/service/reparse_cache_acceptance_test.go
+++ b/internal/application/service/reparse_cache_acceptance_test.go
@@ -1,0 +1,124 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldWipeGraphForRematerialize(t *testing.T) {
+	assert.False(t, shouldWipeGraphForRematerialize(3, 0), "unchanged reparse must keep graph")
+	assert.True(t, shouldWipeGraphForRematerialize(0, 0), "full rebuild wipes graph")
+	assert.True(t, shouldWipeGraphForRematerialize(2, 1), "stale deletes require wipe to avoid orphans")
+	assert.True(t, shouldWipeGraphForRematerialize(0, 5), "full rebuild with deletes wipes")
+}
+
+func TestSummaryFingerprint_MatchesBuildSummaryUserContent(t *testing.T) {
+	svc := &knowledgeService{}
+	knowledge := &types.Knowledge{ID: "k1", TenantID: 1}
+	chunks := []*types.Chunk{
+		{ID: "c1", Content: "Hello world section one.", StartAt: 0, ChunkType: types.ChunkTypeText},
+		{ID: "c2", Content: "Section two continues.", StartAt: 24, ChunkType: types.ChunkTypeText},
+	}
+	user1, _, err := svc.buildSummaryUserContent(context.Background(), knowledge, chunks)
+	require.NoError(t, err)
+	user2, _, err := svc.buildSummaryUserContent(context.Background(), knowledge, chunks)
+	require.NoError(t, err)
+	assert.Equal(t, user1, user2)
+
+	fp1 := calculateSummaryCacheFingerprint(user1, "model-a", "prompt-a", 2048, "zh")
+	fp2 := calculateSummaryCacheFingerprint(user2, "model-a", "prompt-a", 2048, "zh")
+	assert.Equal(t, fp1, fp2)
+	assert.NotEqual(t, fp1, calculateSummaryCacheFingerprint(user1+"x", "model-a", "prompt-a", 2048, "zh"))
+	assert.NotEqual(t, fp1, calculateSummaryCacheFingerprint(user1, "model-b", "prompt-a", 2048, "zh"))
+}
+
+func TestSummaryCacheRoundTrip_Metadata(t *testing.T) {
+	fp := calculateSummaryCacheFingerprint("body", "m", "p", 100, "en")
+	meta := knowledgeMetadataWithSummaryCache(nil, fp, "cached summary text")
+	got, ok := summaryCacheFromKnowledgeMetadata(meta, fp)
+	require.True(t, ok)
+	assert.Equal(t, "cached summary text", got)
+	_, ok = summaryCacheFromKnowledgeMetadata(meta, "other")
+	assert.False(t, ok)
+}
+
+func TestParseCacheRoundTrip_Metadata(t *testing.T) {
+	fp := calculateParseCacheFingerprint("filehash", "engine", "pdf", "", map[string]string{"a": "1"})
+	result := &types.ReadResult{MarkdownContent: "# title\nbody", ImageRefs: []types.ImageRef{{Filename: "a.png", StorageKey: "k"}}}
+	meta := knowledgeMetadataWithParseCache(nil, fp, result)
+	got, ok := parseCacheFromKnowledgeMetadata(meta, fp)
+	require.True(t, ok)
+	assert.Equal(t, "# title\nbody", got.MarkdownContent)
+	require.Len(t, got.ImageRefs, 1)
+	assert.Equal(t, "k", got.ImageRefs[0].StorageKey)
+	assert.Nil(t, got.ImageRefs[0].ImageData, "inline image bytes must not be stored in metadata cache")
+}
+
+func TestQuestionCacheMetadata_HitSkipsWhenFingerprintMatches(t *testing.T) {
+	chunk := &types.Chunk{ID: "c1", Content: "body", ChunkType: types.ChunkTypeText}
+	fp := calculateQuestionCacheFingerprint("body", "", "", "title", 3, "model", "prompt", "instr", "zh")
+	require.NoError(t, chunk.SetDocumentMetadata(&types.DocumentChunkMetadata{
+		GeneratedQuestions:       []types.GeneratedQuestion{{ID: "q1", Question: "What?"}},
+		QuestionCacheFingerprint: fp,
+	}))
+	meta, err := chunk.DocumentMetadata()
+	require.NoError(t, err)
+	assert.Equal(t, fp, meta.QuestionCacheFingerprint)
+	assert.Len(t, meta.GeneratedQuestions, 1)
+
+	// Same inputs → same fp → hit
+	assert.Equal(t, fp, calculateQuestionCacheFingerprint("body", "", "", "title", 3, "model", "prompt", "instr", "zh"))
+	// Instruction change → miss
+	assert.NotEqual(t, fp, calculateQuestionCacheFingerprint("body", "", "", "title", 3, "model", "prompt", "other", "zh"))
+}
+
+func TestGraphExtractCacheMetadata_PayloadRoundTrip(t *testing.T) {
+	chunk := &types.Chunk{ID: "c1", Content: "entity text", ChunkType: types.ChunkTypeText}
+	fp := calculateGraphExtractFingerprint("entity text", "model", "desc", "instr", []string{"tag"})
+	payload := &types.GraphData{
+		Node:     []*types.GraphNode{{Name: "Alice", Chunks: []string{"c1"}}},
+		Relation: []*types.GraphRelation{{Node1: "Alice", Node2: "Bob", Type: "knows"}},
+	}
+	require.NoError(t, chunk.SetDocumentMetadata(&types.DocumentChunkMetadata{
+		GraphExtractFingerprint: fp,
+		GraphPayload:            payload,
+	}))
+	meta, err := chunk.DocumentMetadata()
+	require.NoError(t, err)
+	require.NotNil(t, meta.GraphPayload)
+	assert.Equal(t, fp, meta.GraphExtractFingerprint)
+	assert.Equal(t, "Alice", meta.GraphPayload.Node[0].Name)
+	// hit condition used by extract.go
+	assert.True(t, meta.GraphExtractFingerprint == fp && meta.GraphPayload != nil)
+}
+
+func TestStableIDs_AllowContentAddressedReuseAcrossRuns(t *testing.T) {
+	hash := types.CalculateDocumentChunkContentHash("same", "", types.ChunkTypeText, "emb", "chunking")
+	id1 := types.StableDocumentChunkID("doc-1", hash, types.ChunkIDRoleText)
+	id2 := types.StableDocumentChunkID("doc-1", hash, types.ChunkIDRoleText)
+	assert.Equal(t, id1, id2)
+}
+
+// TestReparseAcceptance_LayerChecklist documents the #1679 acceptance gates
+// covered by unit tests in this package. End-to-end processChunks+asynq wiring
+// is integration-heavy; each expensive layer is proven via fingerprint stability
+// + metadata hit conditions that the production handlers consult before Chat/VLM.
+func TestReparseAcceptance_LayerChecklist(t *testing.T) {
+	// M1/M2 text chunk + stable ID
+	TestStableIDs_AllowContentAddressedReuseAcrossRuns(t)
+	// M5 summary
+	TestSummaryFingerprint_MatchesBuildSummaryUserContent(t)
+	TestSummaryCacheRoundTrip_Metadata(t)
+	// M6 question
+	TestQuestionCacheMetadata_HitSkipsWhenFingerprintMatches(t)
+	// M7 graph
+	TestShouldWipeGraphForRematerialize(t)
+	TestGraphExtractCacheMetadata_PayloadRoundTrip(t)
+	// M8 parse
+	TestParseCacheRoundTrip_Metadata(t)
+	// M3 multimodal + M4 wiki map + layered invalidation already in cache_fingerprint_test.go
+}

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -1298,9 +1298,10 @@ type SlugUpdate struct {
 	KnowledgeID       string
 	SourceRef         string
 	Language          string
-	SummaryBody       string // For summary
-	SummaryLine       string // For summary
-	RetractDocContent string // For retract / retractStale
+	SummaryBody       string     // For summary
+	SummaryLine       string     // For summary
+	PageMetadata      types.JSON // For summary bookkeeping/cache metadata
+	RetractDocContent string     // For retract / retractStale
 	// SourceChunks lists the chunk IDs (within KnowledgeID) that substantively
 	// support this update. Mirrors Item.SourceChunks for convenience — the
 	// Reduce phase reads from here to avoid an extra field hop.

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -512,7 +512,7 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 			mapMu.Unlock()
 
 			logger.Infof(mapCtx, "wiki ingest: processing document '%s' (%s)", op.DocTitle, op.KnowledgeID)
-			result, updates, err := s.mapOneDocument(mapCtx, chatModel, payload, op, batchCtx)
+			result, updates, err := s.mapOneDocument(mapCtx, chatModel, synthesisModelID, payload, op, batchCtx)
 			if err != nil {
 				mapMu.Lock()
 				ingestFailed++
@@ -1151,6 +1151,7 @@ func (s *wikiIngestService) ProcessWikiFinalize(ctx context.Context, t *asynq.Ta
 func (s *wikiIngestService) mapOneDocument(
 	ctx context.Context,
 	chatModel chat.Chat,
+	synthesisModelID string,
 	payload WikiIngestPayload,
 	op WikiPendingOp,
 	batchCtx *WikiBatchContext,
@@ -1232,6 +1233,25 @@ func (s *wikiIngestService) mapOneDocument(
 	// surface during wiki page editing.
 	sourceRef := knowledgeID
 	oldPageSlugs := s.getExistingPageSlugsForKnowledge(ctx, payload.KnowledgeBaseID, knowledgeID)
+	summarySlug := fmt.Sprintf("summary/%s", slugify(knowledgeID))
+	granularity := types.WikiExtractionStandard
+	if batchCtx != nil {
+		granularity = batchCtx.ExtractionGranularity.Normalize()
+	}
+	contentInstructions := ""
+	extractionInstructions := ""
+	if batchCtx != nil {
+		contentInstructions = batchCtx.ContentInstructions
+		extractionInstructions = batchCtx.ExtractionInstructions
+	}
+	wikiMapFingerprint := calculateWikiMapCacheFingerprint(content, lang, synthesisModelID, granularity, contentInstructions, extractionInstructions)
+	var cachedMap *wikiMapCacheEntry
+	if existingSummary, getErr := s.wikiService.GetPageBySlug(ctx, payload.KnowledgeBaseID, summarySlug); getErr == nil && existingSummary != nil {
+		if cache, ok := wikiMapCacheFromMetadata(existingSummary.PageMetadata, wikiMapFingerprint); ok {
+			cachedMap = cache
+			logger.Infof(ctx, "wiki ingest: map cache hit for knowledge %s", knowledgeID)
+		}
+	}
 
 	// Pass 0: lightweight candidate slug extraction (skeleton only).
 	// On failure we fall back to the legacy single-shot extractor so the doc
@@ -1246,23 +1266,32 @@ func (s *wikiIngestService) mapOneDocument(
 	extractSpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.extract", types.SpanKindSubSpan, types.JSONMap{
 		"content_chars": utf8.RuneCountInString(content),
 		"old_pages":     len(oldPageSlugs),
+		"cache_hit":     cachedMap != nil,
 	})
-	extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
-	if err != nil {
-		logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) — falling back to legacy extractor", knowledgeID, err)
-		pass0Failed = true
-		extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
+	if cachedMap != nil {
+		extractedEntities = cachedMap.Entities
+		extractedConcepts = cachedMap.Concepts
+		slugItems = cachedMap.SlugItems
+		pass0Failed = cachedMap.Pass0Failed
+	} else {
+		extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
 		if err != nil {
-			logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
-			s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
-			s.tracker().FailSpan(ctx, wikiSpan, "EXTRACT_FAILED", err.Error(), err)
-			return nil, nil, err
+			logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) — falling back to legacy extractor", knowledgeID, err)
+			pass0Failed = true
+			extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
+			if err != nil {
+				logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
+				s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
+				s.tracker().FailSpan(ctx, wikiSpan, "EXTRACT_FAILED", err.Error(), err)
+				return nil, nil, err
+			}
 		}
 	}
 	s.tracker().EndSpan(ctx, extractSpan, types.JSONMap{
 		"entities":         len(extractedEntities),
 		"concepts":         len(extractedConcepts),
 		"pass0_fallback":   pass0Failed,
+		"cache_hit":        cachedMap != nil,
 		"entities_preview": previewExtractedItems(extractedEntities, 8),
 		"concepts_preview": previewExtractedItems(extractedConcepts, 8),
 	})
@@ -1272,12 +1301,6 @@ func (s *wikiIngestService) mapOneDocument(
 	for slug := range slugItems {
 		summaryExtractedPages = append(summaryExtractedPages, slug)
 	}
-	// Wiki summary slug is derived from the knowledge ID rather than the
-	// docTitle (which is typically the upload filename). Filename-based slugs
-	// like "summary/mx5280-pdf" expose the filename in cross-link contexts
-	// that downstream LLM prompts read; a UUID-based slug is uglier but
-	// hallucination-safe.
-	summarySlug := fmt.Sprintf("summary/%s", slugify(knowledgeID))
 	var slugListing string
 	for _, slug := range summaryExtractedPages {
 		if item, ok := slugItems[slug]; ok {
@@ -1321,13 +1344,17 @@ func (s *wikiIngestService) mapOneDocument(
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		summaryContent, summaryErr = s.generateWithTemplate(ctx, chatModel, agent.WikiSummaryPrompt, map[string]string{
-			"Content":            content,
-			"Language":           lang,
-			"ExtractedSlugs":     slugListing,
-			"CustomInstructions": batchCtx.ContentInstructions,
-			"InstructionScope":   "wiki_content",
-		})
+		if cachedMap != nil {
+			summaryContent = cachedMap.SummaryContent
+		} else {
+			summaryContent, summaryErr = s.generateWithTemplate(ctx, chatModel, agent.WikiSummaryPrompt, map[string]string{
+				"Content":            content,
+				"Language":           lang,
+				"ExtractedSlugs":     slugListing,
+				"CustomInstructions": contentInstructions,
+				"InstructionScope":   "wiki_content",
+			})
+		}
 		if summaryErr != nil {
 			s.tracker().FailSpan(ctx, summarySpan, "SUMMARY_FAILED", summaryErr.Error(), summaryErr)
 		} else {
@@ -1341,6 +1368,12 @@ func (s *wikiIngestService) mapOneDocument(
 	}()
 	go func() {
 		defer wg.Done()
+		if cachedMap != nil {
+			citations = cachedMap.Citations
+			newSlugs = cachedMap.NewSlugs
+			batchCount = cachedMap.ClassifyBatches
+			return
+		}
 		// Skip citation pass when Pass 0 has fallen back to the legacy path —
 		// the legacy output already contains paraphrased Details, so chunk
 		// citations would be redundant and we'd spend LLM calls for nothing.
@@ -1438,15 +1471,27 @@ func (s *wikiIngestService) mapOneDocument(
 	if strings.TrimSpace(docSummary) == "" {
 		docSummary = sumLine
 	}
+	mapCacheMetadata := metadataWithWikiMapCache(nil, wikiMapCacheEntry{
+		Fingerprint:     wikiMapFingerprint,
+		SummaryContent:  summaryContent,
+		Entities:        extractedEntities,
+		Concepts:        extractedConcepts,
+		SlugItems:       slugItems,
+		Citations:       citations,
+		NewSlugs:        newSlugs,
+		Pass0Failed:     pass0Failed,
+		ClassifyBatches: batchCount,
+	})
 	updates = append(updates, SlugUpdate{
-		Slug:        summarySlug,
-		Type:        types.WikiPageTypeSummary,
-		DocTitle:    docTitle,
-		KnowledgeID: knowledgeID,
-		SourceRef:   sourceRef,
-		Language:    lang,
-		SummaryLine: sumLine,
-		SummaryBody: sumBody,
+		Slug:         summarySlug,
+		Type:         types.WikiPageTypeSummary,
+		DocTitle:     docTitle,
+		KnowledgeID:  knowledgeID,
+		SourceRef:    sourceRef,
+		Language:     lang,
+		SummaryLine:  sumLine,
+		SummaryBody:  sumBody,
+		PageMetadata: mapCacheMetadata,
 	})
 	extractedPages = append(extractedPages, wikiIngestPageRef{Slug: summarySlug, Title: docTitle})
 
@@ -1580,6 +1625,7 @@ func (s *wikiIngestService) mapOneDocument(
 		"pass0_fallback":   pass0Failed,
 		"classify_batches": batchCount,
 		"summary_preview":  previewText(docSummaryLine, 160),
+		"map_cache_hit":    cachedMap != nil,
 	}
 
 	return &docIngestResult{
@@ -1816,6 +1862,9 @@ func (s *wikiIngestService) reduceSlugUpdates(
 		page.Summary = summaryUpdate.SummaryLine
 		page.PageType = types.WikiPageTypeSummary
 		page.SourceRefs = appendUnique(page.SourceRefs, summaryUpdate.SourceRef)
+		if len(summaryUpdate.PageMetadata) > 0 {
+			page.PageMetadata = summaryUpdate.PageMetadata
+		}
 		// Summary pages don't carry chunk-level citations (they are document-
 		// level synopses generated from the whole content). Clear any stale
 		// chunk refs that may remain if this slug was once an entity page

--- a/internal/types/chunk.go
+++ b/internal/types/chunk.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -210,6 +211,29 @@ func (c *Chunk) EmbeddingContent() string {
 		return body
 	}
 	return c.ContextHeader + "\n\n" + body
+}
+
+
+// ChunkID roles for StableDocumentChunkID — keep types from colliding when
+// content hashes happen to match across roles.
+const (
+	ChunkIDRoleText         = "text"
+	ChunkIDRoleParentText   = "parent_text"
+	ChunkIDRoleSummary      = "summary"
+	ChunkIDRoleImageOCR     = "image_ocr"
+	ChunkIDRoleImageCaption = "image_caption"
+)
+
+// StableDocumentChunkID returns a UUID-shaped ID derived from knowledgeID,
+// contentHash and role. Same inputs always produce the same ID so reparses can
+// recreate chunks with stable references even when no prior row is reused.
+func StableDocumentChunkID(knowledgeID, contentHash, role string) string {
+	sum := sha256.Sum256([]byte("chunk-id-v1\x00" + knowledgeID + "\x00" + contentHash + "\x00" + role))
+	var u [16]byte
+	copy(u[:], sum[:16])
+	u[6] = (u[6] & 0x0f) | 0x40 // UUID version 4
+	u[8] = (u[8] & 0x3f) | 0x80 // RFC 4122 variant
+	return uuid.UUID(u).String()
 }
 
 // CalculateDocumentChunkContentHash returns a stable hash for non-FAQ document

--- a/internal/types/chunk.go
+++ b/internal/types/chunk.go
@@ -3,6 +3,8 @@
 package types
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 	"time"
 
@@ -208,6 +210,32 @@ func (c *Chunk) EmbeddingContent() string {
 		return body
 	}
 	return c.ContextHeader + "\n\n" + body
+}
+
+// CalculateDocumentChunkContentHash returns a stable hash for non-FAQ document
+// chunks. The hash intentionally includes the persisted content, embedding
+// context, chunk type, and indexing-relevant model/config identifiers so a
+// reparse can safely reuse unchanged chunks while invalidating cache entries
+// when the embedding input or chunking mode changes.
+func CalculateDocumentChunkContentHash(
+	content string,
+	contextHeader string,
+	chunkType ChunkType,
+	embeddingModelID string,
+	chunkingFingerprint string,
+) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte("document-chunk-v1\x00"))
+	_, _ = h.Write([]byte(chunkType))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(contextHeader)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(content)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(embeddingModelID)))
+	_, _ = h.Write([]byte("\x00"))
+	_, _ = h.Write([]byte(strings.TrimSpace(chunkingFingerprint)))
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // AssignChunkSeqIDs assigns sequential SeqIDs to a batch of chunks that have SeqID == 0.

--- a/internal/types/chunk_id_test.go
+++ b/internal/types/chunk_id_test.go
@@ -1,0 +1,21 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStableDocumentChunkID_DeterministicAndUUIDShaped(t *testing.T) {
+	a := StableDocumentChunkID("kb-doc-1", "hash-aaa", ChunkIDRoleText)
+	b := StableDocumentChunkID("kb-doc-1", "hash-aaa", ChunkIDRoleText)
+	assert.Equal(t, a, b)
+	_, err := uuid.Parse(a)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, a, StableDocumentChunkID("kb-doc-2", "hash-aaa", ChunkIDRoleText))
+	assert.NotEqual(t, a, StableDocumentChunkID("kb-doc-1", "hash-bbb", ChunkIDRoleText))
+	assert.NotEqual(t, a, StableDocumentChunkID("kb-doc-1", "hash-aaa", ChunkIDRoleParentText))
+}

--- a/internal/types/faq.go
+++ b/internal/types/faq.go
@@ -57,6 +57,15 @@ type DocumentChunkMetadata struct {
 	GeneratedQuestions []GeneratedQuestion `json:"generated_questions,omitempty"`
 	// GeneratedQuestionsRevision ties the questions to Chunk.ContentRevision.
 	GeneratedQuestionsRevision int `json:"generated_questions_revision,omitempty"`
+	// QuestionCacheFingerprint is the fingerprint of inputs used to generate
+	// GeneratedQuestions. Matching fingerprint on reparse skips Chat.
+	QuestionCacheFingerprint string `json:"question_cache_fingerprint,omitempty"`
+	// GraphExtractFingerprint is the fingerprint of inputs used for GraphRAG
+	// extract on this chunk.
+	GraphExtractFingerprint string `json:"graph_extract_fingerprint,omitempty"`
+	// GraphPayload caches the last successful GraphData so rematerialize can
+	// re-AddGraph without calling the LLM.
+	GraphPayload *GraphData `json:"graph_payload,omitempty"`
 }
 
 // IsQuestionCurrent reports whether a generated question was authored for the

--- a/internal/types/faq_test.go
+++ b/internal/types/faq_test.go
@@ -99,7 +99,7 @@ func TestCalculateFAQContentHash_TraditionalSimplifiedInvariant(t *testing.T) {
 		Answers:          []string{"请联系客服"},
 	}
 	meta2 := &FAQChunkMetadata{
-		StandardQuestion: "如何退款", // simplified
+		StandardQuestion: "如何退款",            // simplified
 		Answers:          []string{"請聯繫客服"}, // traditional in answers — answers only sanitize, not normalize
 	}
 
@@ -176,5 +176,38 @@ func TestCalculateFAQContentHash_FullWidthHalfWidthInvariant(t *testing.T) {
 	if hashFull != hashHalf {
 		t.Errorf("Hash should be fullwidth/halfwidth invariant:\n  fullwidth: %s\n  halfwidth: %s",
 			hashFull, hashHalf)
+	}
+}
+
+func TestCalculateDocumentChunkContentHash_ReusesUnchangedEmbeddingInput(t *testing.T) {
+	hash1 := CalculateDocumentChunkContentHash(
+		"  same content  ",
+		"Heading > Section",
+		ChunkTypeText,
+		"embed-model-a",
+		"chunk-size=512",
+	)
+	hash2 := CalculateDocumentChunkContentHash(
+		"same content",
+		"Heading > Section",
+		ChunkTypeText,
+		"embed-model-a",
+		"chunk-size=512",
+	)
+	if hash1 == "" {
+		t.Fatal("document chunk hash is empty")
+	}
+	if hash1 != hash2 {
+		t.Fatalf("expected whitespace-normalized equivalent inputs to reuse hash: %s != %s", hash1, hash2)
+	}
+
+	changedModel := CalculateDocumentChunkContentHash("same content", "Heading > Section", ChunkTypeText, "embed-model-b", "chunk-size=512")
+	if hash1 == changedModel {
+		t.Fatal("embedding model changes must invalidate document chunk reuse")
+	}
+
+	changedChunking := CalculateDocumentChunkContentHash("same content", "Heading > Section", ChunkTypeText, "embed-model-a", "chunk-size=1024")
+	if hash1 == changedChunking {
+		t.Fatal("chunking config changes must invalidate document chunk reuse")
 	}
 }

--- a/internal/types/interfaces/chunk.go
+++ b/internal/types/interfaces/chunk.go
@@ -30,6 +30,9 @@ type ChunkRepository interface {
 	ListChunksBySeqID(ctx context.Context, tenantID uint64, seqIDs []int64) ([]*types.Chunk, error)
 	// ListChunksByKnowledgeID lists chunks by knowledge id
 	ListChunksByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) ([]*types.Chunk, error)
+	// ListDocumentChunksForReuse lists active document chunks for incremental
+	// reparse diffing and vector reuse.
+	ListDocumentChunksForReuse(ctx context.Context, tenantID uint64, knowledgeID string) ([]*types.Chunk, error)
 	// ListPagedChunksByKnowledgeID lists paged chunks by knowledge id.
 	// When tagIDs is non-empty, results are filtered by tag_id (OR semantics).
 	// knowledgeType: "faq" or "manual" - determines sort order and search behavior


### PR DESCRIPTION
## 摘要

Fixes #1679.

本 PR 修复知识文档重解析时，未变化内容仍会被重复处理的问题。

在现有实现中，文档 reparse 流程会先清理旧的 chunks / vectors，再基于新的解析结果重新生成全部下游数据。即使文档内容没有变化，或只有少量内容发生变化，系统也无法识别哪些 chunks 可以安全复用，因此会重复执行 chunk 构建、embedding、多模态图片 OCR/caption、Wiki map 阶段生成等成本较高的处理。

这会带来两个主要问题：

1. 重复执行昂贵处理

   对未变化内容重新 embedding 或重新执行多模态 / Wiki 处理，会显著增加重解析耗时和模型调用成本。

2. 过早删除旧数据

   旧 chunks / vectors 在新解析结果完成 diff 前就被清理，导致系统无法基于旧结果做增量判断，也增加了重解析过程中数据关系被破坏的风险。

## 根因分析

问题的根因是 reparse 流程缺少稳定的“可复用性判断”。

当前逻辑主要基于一次完整重建来处理文档：

1. 文档触发重新解析。
2. 系统清理旧 chunks 和相关 vectors。
3. 基于新解析结果重新生成 chunks。
4. 对所有 chunks 重新执行 embedding / OCR / caption / Wiki map 等后续处理。
5. 重新写入新的 chunks 和向量索引。

这种流程没有保存并比较“内容 + 处理配置”的稳定标识，因此无法判断某个新 chunk 是否等价于旧 chunk。

仅比较文本内容本身也不够，因为 chunk 的最终处理结果还会受到上下文和配置影响，例如：

- chunk 类型
- chunking 配置
- embedding 模型
- 图片内容
- VLM 模型
- OCR / caption prompt
- Wiki map 阶段的语言、模型和抽取粒度

如果这些输入没有变化，则对应的下游产物可以复用；如果其中任意关键输入变化，则必须重新处理。原实现缺少这样的 fingerprint 机制，因此只能选择全量重建。

此外，旧 chunks 在 diff 前被删除，也使得新旧结果之间无法建立可靠映射。这样不仅无法复用旧向量索引，也会导致 `parent_id`、`prev_id`、`next_id` 等 chunk 关系只能重新生成，无法稳定继承未变化 chunks 的已有持久化结果。

## 解决方案

本 PR 将文档 reparse 从“先删除、再全量重建”调整为“先解析、再 diff、最后按需更新”的增量复用流程。

新的流程如下：

1. 保留旧 chunks 和 vectors，不在 reparse 开始时提前删除。
2. 完成新的文档解析结果生成。
3. 为新旧 chunks 计算稳定的 cache fingerprint。
4. 根据 fingerprint 判断哪些 chunks 可以复用。
5. 对未变化 chunks 复用已有持久化结果和向量索引。
6. 只对新增或变化 chunks 执行重新处理。
7. 在新结果确定后删除 stale chunks / vectors。
8. 最后刷新复用 chunks 的 `parent_id`、`prev_id`、`next_id` 等关系指针。

## 主要变更

### 文本 chunk 增量复用

为文档 chunks 增加 cache fingerprint，用于判断 chunk 是否可以复用。

fingerprint 会纳入影响 embedding 结果的关键输入，包括：

- chunk 内容
- chunk 上下文
- chunk 类型
- embedding 模型
- chunking 配置

当这些输入保持不变时，reparse 会复用旧 chunk 及其向量索引，避免重新 embedding。

### 多模态图片结果复用

图片类 chunks 的处理结果不仅取决于图片本身，也取决于多模态模型和 prompt 配置。

本 PR 为图片 OCR/caption chunks 增加 fingerprint，纳入：

- 图片内容
- VLM 模型
- prompt
- chunk 类型

当图片内容和处理配置没有变化时，reparse 会复用已有 OCR/caption 结果，避免重复调用多模态处理流程。

### Wiki map 阶段结果复用

Wiki ingestion 的 map 阶段也可能产生重复计算。

本 PR 为 Wiki map 阶段生成结果增加 fingerprint，纳入：

- 重建后的输入内容
- 语言
- 合成模型
- 抽取粒度
- chunk 类型

当这些输入未变化时，可以复用已有 map 阶段 chunks，减少重复生成成本。

### 延后删除 stale 数据

旧 chunks / vectors 不再在 reparse 开始时立即删除。

新的流程会先完成解析和 diff，确认哪些 chunks 已经过期后，再删除 stale chunks / vectors。这样可以确保：

- 未变化 chunks 可以被正确匹配和复用
- 旧向量索引不会被提前删除
- reparse 过程中数据状态更安全
- 删除操作只作用于确认为过期的数据

### 关系指针刷新

复用 chunks 后，旧 chunk ID 和新解析结构之间需要重新建立关系。

本 PR 在完成 ID 重映射后刷新：

- `parent_id`
- `prev_id`
- `next_id`

这样可以避免复用旧 chunk 时保留过期关系指针，确保新的 chunk 结构仍然正确表达文档层级和顺序关系。

### Repository 查询能力

新增按文档和 cache fingerprint 查询 chunks 的 repository 能力，使 service 层可以在 reparse diff 阶段查找可复用的旧 chunks。

## 测试

本 PR 补充了以下测试覆盖：

- 文档 reparse 时复用未变化 chunks
- cache fingerprint 在输入不变时保持稳定
- cache fingerprint 在关键配置变化时正确失效
- 多模态图片 cache fingerprint 行为
- Wiki map 阶段 cache fingerprint 行为
- repository 按文档和 fingerprint 查询 chunks
- FAQ chunk 元数据行为

已执行：

- `go test ./internal/application/service/...`
- `CGO_CFLAGS="-O2 -g -IE:\\hermes\\oss-contrib\\work\\tools\\sqlite-amalgamation" go test ./internal/application/repository/...`
- `go test ./internal/types/...`
