### PR TITLE
feat(chat): STR-312 OpenRouter xhigh 추론 설정 추가

### DIFF
--- a/internal/models/chat/provider_test.go
+++ b/internal/models/chat/provider_test.go
@@ -136,6 +136,22 @@ func TestBuildOutbound_Thinking(t *testing.T) {
 		_, ok := body.(*openai.ChatCompletionRequest)
 		assert.True(t, ok)
 	})
+
+	t.Run("openrouter reasoning effort uses nested reasoning field", func(t *testing.T) {
+		c := newOutboundChat(t, string(provider.ProviderOpenRouter), "deepseek/deepseek-v4-flash",
+			map[string]string{
+				ExtraConfigThinkingControl: "thinking_type",
+				ExtraConfigReasoningEffort: "xhigh",
+			})
+		body, _, useRaw, err := c.buildOutbound(msgs, nil, true)
+		require.NoError(t, err)
+		require.True(t, useRaw)
+		js := mustJSON(t, body)
+		assert.Contains(t, js, `"model":"deepseek/deepseek-v4-flash"`)
+		assert.Contains(t, js, `"reasoning":{"effort":"xhigh"}`)
+		assert.NotContains(t, js, `"thinking"`)
+		assert.NotContains(t, js, "reasoning_effort")
+	})
 }
 
 // TestBuildOutbound_ShapeRequest covers the param-shaping providers that used

--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -96,6 +96,13 @@ func NewRemoteAPIChat(chatConfig *ChatConfig) (*RemoteAPIChat, error) {
 		}
 	}
 
+	thinkingOverride := parseThinkingOverride(chatConfig.ExtraConfig)
+	if providerName == provider.ProviderOpenRouter {
+		if effort := parseOpenRouterReasoningEffort(chatConfig.ExtraConfig); effort != "" {
+			thinkingOverride = openRouterReasoningEffort{effort: effort}
+		}
+	}
+
 	return &RemoteAPIChat{
 		modelName:        modelName,
 		client:           openai.NewClientWithConfig(config),
@@ -107,7 +114,7 @@ func NewRemoteAPIChat(chatConfig *ChatConfig) (*RemoteAPIChat, error) {
 		appSecret:        chatConfig.AppSecret,
 		customHeaders:    chatConfig.CustomHeaders,
 		adapter:          resolveProvider(providerName, modelName),
-		thinkingOverride: parseThinkingOverride(chatConfig.ExtraConfig),
+		thinkingOverride: thinkingOverride,
 	}, nil
 }
 

--- a/internal/models/chat/thinking.go
+++ b/internal/models/chat/thinking.go
@@ -14,6 +14,10 @@ import (
 // "chat_template_kwargs".
 const ExtraConfigThinkingControl = "thinking_control"
 
+// ExtraConfigReasoningEffort is the model parameters.extra_config key for
+// OpenRouter's nested `reasoning.effort` request option.
+const ExtraConfigReasoningEffort = "reasoning_effort"
+
 // Wire-format request bodies used by providers that express extended-thinking
 // through a non-standard top-level field. They embed the standard OpenAI
 // request so all other fields are marshalled unchanged.
@@ -35,6 +39,21 @@ type ThinkingConfig struct {
 type ThinkingChatCompletionRequest struct {
 	openai.ChatCompletionRequest
 	Thinking *ThinkingConfig `json:"thinking,omitempty"`
+}
+
+// OpenRouterReasoningConfig is OpenRouter's `{ "reasoning": { "effort": ... } }`
+// block. OpenRouter accepts efforts such as "high" and "xhigh" on models that
+// advertise them.
+type OpenRouterReasoningConfig struct {
+	Effort string `json:"effort"`
+}
+
+// OpenRouterReasoningChatCompletionRequest adds OpenRouter's nested reasoning
+// object. This must go through raw HTTP because the OpenAI SDK only exposes the
+// different top-level `reasoning_effort` field.
+type OpenRouterReasoningChatCompletionRequest struct {
+	openai.ChatCompletionRequest
+	Reasoning *OpenRouterReasoningConfig `json:"reasoning,omitempty"`
 }
 
 // ThinkingStrategy encodes how ChatOptions.Thinking is mapped onto a provider's
@@ -117,6 +136,23 @@ func (chatTemplateKwargs) Apply(req *openai.ChatCompletionRequest, opts *ChatOpt
 	return req, true
 }
 
+// openRouterReasoningEffort pins OpenRouter's model-level reasoning budget.
+// Unlike ChatOptions.Thinking, this is configured on the model and is sent even
+// when the caller does not pass an explicit per-request thinking flag.
+type openRouterReasoningEffort struct {
+	effort string
+}
+
+func (s openRouterReasoningEffort) Apply(req *openai.ChatCompletionRequest, _ *ChatOptions, _ bool) (any, bool) {
+	effort := normalizeReasoningEffort(s.effort)
+	if effort == "" {
+		return nil, false
+	}
+	r := OpenRouterReasoningChatCompletionRequest{ChatCompletionRequest: *req}
+	r.Reasoning = &OpenRouterReasoningConfig{Effort: effort}
+	return r, true
+}
+
 // parseThinkingOverride reads extra_config.thinking_control and returns the
 // strategy it selects, or nil when unset (the provider adapter's default
 // strategy then applies). An unrecognized non-empty value falls back to
@@ -140,6 +176,17 @@ func parseThinkingOverride(extraConfig map[string]string) ThinkingStrategy {
 	}
 }
 
+func parseOpenRouterReasoningEffort(extraConfig map[string]string) string {
+	if extraConfig == nil {
+		return ""
+	}
+	return normalizeReasoningEffort(extraConfig[ExtraConfigReasoningEffort])
+}
+
+func normalizeReasoningEffort(effort string) string {
+	return strings.ToLower(strings.TrimSpace(effort))
+}
+
 // EffectiveThinkingControl reports the provider field that will carry
 // ChatOptions.Thinking. It intentionally shares the same adapter/override
 // resolution as the real request path so diagnostics do not guess from the
@@ -148,18 +195,23 @@ func EffectiveThinkingControl(config *ChatConfig) string {
 	if config == nil {
 		return "none"
 	}
-	if override := parseThinkingOverride(config.ExtraConfig); override != nil {
-		return thinkingStrategyName(override)
-	}
 	providerName := provider.ProviderName(config.Provider)
 	if providerName == "" {
 		providerName = provider.DetectProvider(config.BaseURL)
+	}
+	if providerName == provider.ProviderOpenRouter && parseOpenRouterReasoningEffort(config.ExtraConfig) != "" {
+		return "reasoning_effort"
+	}
+	if override := parseThinkingOverride(config.ExtraConfig); override != nil {
+		return thinkingStrategyName(override)
 	}
 	return thinkingStrategyName(resolveProvider(providerName, config.ModelName).Thinking())
 }
 
 func thinkingStrategyName(strategy ThinkingStrategy) string {
 	switch strategy.(type) {
+	case openRouterReasoningEffort:
+		return "reasoning_effort"
 	case enableThinking:
 		return "enable_thinking"
 	case thinkingTypeField:

--- a/internal/models/chat/thinking_test.go
+++ b/internal/models/chat/thinking_test.go
@@ -108,6 +108,23 @@ func TestChatTemplateKwargs(t *testing.T) {
 	assert.Contains(t, string(body), "chat_template_kwargs")
 }
 
+func TestOpenRouterReasoningEffort(t *testing.T) {
+	s := openRouterReasoningEffort{effort: " xhigh "}
+	req := openai.ChatCompletionRequest{Model: "deepseek/deepseek-v4-flash"}
+
+	custom, raw := s.Apply(&req, nil, true)
+	require.True(t, raw)
+	out, ok := custom.(OpenRouterReasoningChatCompletionRequest)
+	require.True(t, ok)
+	require.NotNil(t, out.Reasoning)
+	assert.Equal(t, "xhigh", out.Reasoning.Effort)
+
+	body, err := json.Marshal(custom)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"reasoning":{"effort":"xhigh"}`)
+	assert.NotContains(t, string(body), "reasoning_effort")
+}
+
 func TestParseThinkingOverride(t *testing.T) {
 	cases := map[string]ThinkingStrategy{
 		"none":                 noThinking{},
@@ -126,6 +143,14 @@ func TestParseThinkingOverride(t *testing.T) {
 	assert.Nil(t, parseThinkingOverride(map[string]string{ExtraConfigThinkingControl: ""}))
 }
 
+func TestParseOpenRouterReasoningEffort(t *testing.T) {
+	assert.Equal(t, "xhigh", parseOpenRouterReasoningEffort(map[string]string{
+		ExtraConfigReasoningEffort: " XHIGH ",
+	}))
+	assert.Empty(t, parseOpenRouterReasoningEffort(nil))
+	assert.Empty(t, parseOpenRouterReasoningEffort(map[string]string{}))
+}
+
 func TestEffectiveThinkingControl(t *testing.T) {
 	assert.Equal(t, "enable_thinking", EffectiveThinkingControl(&ChatConfig{
 		Provider:  "aliyun",
@@ -140,5 +165,13 @@ func TestEffectiveThinkingControl(t *testing.T) {
 		Provider:    "generic",
 		ModelName:   "qwen3",
 		ExtraConfig: map[string]string{ExtraConfigThinkingControl: "none"},
+	}))
+	assert.Equal(t, "reasoning_effort", EffectiveThinkingControl(&ChatConfig{
+		Provider:  "openrouter",
+		ModelName: "deepseek/deepseek-v4-flash",
+		ExtraConfig: map[string]string{
+			ExtraConfigThinkingControl: "thinking_type",
+			ExtraConfigReasoningEffort: "xhigh",
+		},
 	}))
 }


### PR DESCRIPTION
## Description

- Add `extra_config.reasoning_effort` support for OpenRouter chat models.
- Send OpenRouter's nested `reasoning: { "effort": "xhigh" }` payload through the raw HTTP path, instead of the SDK's top-level `reasoning_effort` field.
- Update effective thinking-control diagnostics and tests for `deepseek/deepseek-v4-flash` with `xhigh`.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

STR-312 (Multica)

## Testing

- `go test ./internal/models/chat`
- `go test ./internal/models/...`

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A - backend request-shaping change only.
