### PR TITLE
fix(search): apply tag filters to knowledge search

### DIFF
--- a/client/agent.go
+++ b/client/agent.go
@@ -16,8 +16,10 @@ import (
 type MentionedItem struct {
 	ID     string `json:"id"`
 	Name   string `json:"name"`
-	Type   string `json:"type"`    // "kb" for knowledge base, "file" for file
+	Type   string `json:"type"`    // "kb", "file", "tag", "mcp", or "skill"
 	KBType string `json:"kb_type"` // "document" or "faq" (only for kb type)
+	KBID   string `json:"kb_id"`   // Parent knowledge base for file/tag mentions
+	KBName string `json:"kb_name"` // Display name for parent KB
 }
 
 // AgentQARequest agent Q&A request payload.

--- a/client/session.go
+++ b/client/session.go
@@ -435,10 +435,12 @@ func (c *Client) StopSession(ctx context.Context, sessionID string, messageID st
 
 // SearchKnowledgeRequest knowledge search request
 type SearchKnowledgeRequest struct {
-	Query            string   `json:"query"`                        // Query content
-	KnowledgeBaseID  string   `json:"knowledge_base_id,omitempty"`  // Single knowledge base ID (for backward compatibility)
-	KnowledgeBaseIDs []string `json:"knowledge_base_ids,omitempty"` // Knowledge base IDs (multi-KB support)
-	KnowledgeIDs     []string `json:"knowledge_ids,omitempty"`      // Specific knowledge (file) IDs
+	Query            string          `json:"query"`                        // Query content
+	KnowledgeBaseID  string          `json:"knowledge_base_id,omitempty"`  // Single knowledge base ID (for backward compatibility)
+	KnowledgeBaseIDs []string        `json:"knowledge_base_ids,omitempty"` // Knowledge base IDs (multi-KB support)
+	KnowledgeIDs     []string        `json:"knowledge_ids,omitempty"`      // Specific knowledge (file) IDs
+	TagIDs           []string        `json:"tag_ids,omitempty"`            // Tag IDs for filtering within a single KB
+	MentionedItems   []MentionedItem `json:"mentioned_items,omitempty"`    // Optional scoped tag mentions
 }
 
 // SearchKnowledgeResponse search results response

--- a/internal/application/service/chat_pipeline/search.go
+++ b/internal/application/service/chat_pipeline/search.go
@@ -469,7 +469,7 @@ func (p *PluginSearch) searchSingleTarget(
 ) {
 	searchKnowledgeIDs := t.KnowledgeIDs
 
-	if t.Type == types.SearchTargetTypeKnowledge {
+	if t.Type == types.SearchTargetTypeKnowledge && !t.DisableDirectLoad {
 		directResults, skippedIDs := p.tryDirectChunkLoading(ctx, chatManage.TenantID, t.KnowledgeIDs)
 
 		if len(directResults) > 0 {

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -669,6 +669,17 @@ func (s *knowledgeService) SetKnowledgeTags(ctx context.Context, knowledgeID str
 	return s.repo.SetKnowledgeTags(ctx, knowledgeID, tagIDs)
 }
 
+// ListKnowledgeIDsByTagIDs returns document knowledge IDs carrying any of the
+// specified KB-local tags.
+func (s *knowledgeService) ListKnowledgeIDsByTagIDs(
+	ctx context.Context,
+	tenantID uint64,
+	kbID string,
+	tagIDs []string,
+) ([]string, error) {
+	return s.repo.ListIDsByTagIDs(ctx, tenantID, kbID, tagIDs)
+}
+
 // validateKnowledgeTagIDs ensures every tag exists and belongs to the given knowledge base.
 func (s *knowledgeService) validateKnowledgeTagIDs(
 	ctx context.Context,

--- a/internal/application/service/session_knowledge_qa.go
+++ b/internal/application/service/session_knowledge_qa.go
@@ -434,6 +434,7 @@ func (s *sessionService) buildSearchTargets(
 	tagScopes []types.TagScope,
 ) (types.SearchTargets, error) {
 	var targets types.SearchTargets
+	tagIDsByKB := mergeTagScopesByKB(tagScopes)
 
 	// Build a map from KB ID to TenantID for all KBs we need to process
 	kbTenantMap := make(map[string]uint64)
@@ -443,39 +444,60 @@ func (s *sessionService) buildSearchTargets(
 
 	// First pass: batch-fetch KBs, then resolve tenant per ID (tenant scope already set by caller)
 	callerTenantRole := types.TenantRoleFromContext(ctx)
-	if len(knowledgeBaseIDs) > 0 {
-		kbs, _ := s.knowledgeBaseService.GetKnowledgeBasesByIDsOnly(ctx, knowledgeBaseIDs)
-		kbByID := make(map[string]*types.KnowledgeBase, len(kbs))
+	kbIDsToFetch := append([]string(nil), knowledgeBaseIDs...)
+	for kbID := range tagIDsByKB {
+		kbIDsToFetch = append(kbIDsToFetch, kbID)
+	}
+	kbIDsToFetch = uniqueNonEmptyStrings(kbIDsToFetch)
+
+	kbByID := make(map[string]*types.KnowledgeBase)
+	if len(kbIDsToFetch) > 0 {
+		kbs, _ := s.knowledgeBaseService.GetKnowledgeBasesByIDsOnly(ctx, kbIDsToFetch)
 		for _, kb := range kbs {
 			if kb != nil {
 				kbByID[kb.ID] = kb
 			}
 		}
-		userID, _ := types.UserIDFromContext(ctx)
-		for _, kbID := range knowledgeBaseIDs {
-			fullKBSet[kbID] = true
-			kb := kbByID[kbID]
-			if kb == nil {
-				kbTenantMap[kbID] = tenantID
-			} else if kb.TenantID == tenantID {
-				kbTenantMap[kbID] = tenantID
-			} else if s.kbShareService != nil && userID != "" {
-				hasAccess, _ := s.kbShareService.HasTenantKBPermission(ctx, kbID, tenantID, callerTenantRole, types.OrgRoleViewer)
-				if hasAccess {
-					kbTenantMap[kbID] = kb.TenantID
-				} else {
-					kbTenantMap[kbID] = tenantID
-				}
+	}
+	userID, _ := types.UserIDFromContext(ctx)
+	resolveKBTenant := func(kbID string) uint64 {
+		if kbTenantMap[kbID] != 0 {
+			return kbTenantMap[kbID]
+		}
+		kb := kbByID[kbID]
+		if kb == nil {
+			kbTenantMap[kbID] = tenantID
+		} else if kb.TenantID == tenantID {
+			kbTenantMap[kbID] = tenantID
+		} else if s.kbShareService != nil && userID != "" {
+			hasAccess, _ := s.kbShareService.HasTenantKBPermission(ctx, kbID, tenantID, callerTenantRole, types.OrgRoleViewer)
+			if hasAccess {
+				kbTenantMap[kbID] = kb.TenantID
 			} else {
 				kbTenantMap[kbID] = tenantID
+			}
+		} else {
+			kbTenantMap[kbID] = tenantID
+		}
+		return kbTenantMap[kbID]
+	}
+
+	if len(knowledgeBaseIDs) > 0 {
+		for _, kbID := range knowledgeBaseIDs {
+			fullKBSet[kbID] = true
+			kbTenant := resolveKBTenant(kbID)
+			if len(tagIDsByKB[kbID]) > 0 {
+				continue
 			}
 			targets = append(targets, &types.SearchTarget{
 				Type:            types.SearchTargetTypeKnowledgeBase,
 				KnowledgeBaseID: kbID,
-				TenantID:        kbTenantMap[kbID],
+				TenantID:        kbTenant,
 			})
 		}
 	}
+
+	kbToKnowledgeIDs := make(map[string][]string)
 
 	// Process individual knowledge IDs (include shared KB files the user has access to)
 	if len(knowledgeIDs) > 0 {
@@ -487,7 +509,6 @@ func (s *sessionService) buildSearchTargets(
 
 		// Group knowledge IDs by their KB, excluding those already covered by full KB search
 		// Also track KB tenant IDs from knowledge items
-		kbToKnowledgeIDs := make(map[string][]string)
 		for _, k := range knowledgeList {
 			if k == nil || k.KnowledgeBaseID == "" {
 				continue
@@ -496,8 +517,8 @@ func (s *sessionService) buildSearchTargets(
 			if kbTenantMap[k.KnowledgeBaseID] == 0 {
 				kbTenantMap[k.KnowledgeBaseID] = k.TenantID
 			}
-			// Skip if this KB is already fully searched
-			if fullKBSet[k.KnowledgeBaseID] {
+			// Skip if this KB is already fully searched without a tag scope.
+			if fullKBSet[k.KnowledgeBaseID] && len(tagIDsByKB[k.KnowledgeBaseID]) == 0 {
 				continue
 			}
 			kbToKnowledgeIDs[k.KnowledgeBaseID] = append(kbToKnowledgeIDs[k.KnowledgeBaseID], k.ID)
@@ -505,6 +526,9 @@ func (s *sessionService) buildSearchTargets(
 
 		// Create SearchTargetTypeKnowledge targets for each KB with specific files
 		for kbID, kidList := range kbToKnowledgeIDs {
+			if len(tagIDsByKB[kbID]) > 0 {
+				continue
+			}
 			kbTenant := kbTenantMap[kbID]
 			if kbTenant == 0 {
 				kbTenant = tenantID // fallback
@@ -518,58 +542,106 @@ func (s *sessionService) buildSearchTargets(
 		}
 	}
 
-	if len(tagScopes) > 0 {
-		tagKBIDs := make([]string, 0, len(tagScopes))
-		for _, scope := range tagScopes {
-			if scope.KnowledgeBaseID != "" && !fullKBSet[scope.KnowledgeBaseID] {
-				tagKBIDs = append(tagKBIDs, scope.KnowledgeBaseID)
-			}
+	for kbID, tagIDs := range tagIDsByKB {
+		if kbID == "" || len(tagIDs) == 0 {
+			continue
 		}
-		kbByID := make(map[string]*types.KnowledgeBase, len(tagKBIDs))
-		if len(tagKBIDs) > 0 {
-			if kbs, err := s.knowledgeBaseService.GetKnowledgeBasesByIDsOnly(ctx, tagKBIDs); err == nil {
-				for _, kb := range kbs {
-					if kb != nil {
-						kbByID[kb.ID] = kb
-					}
-				}
-			}
-		}
-		userID, _ := types.UserIDFromContext(ctx)
-		for _, scope := range tagScopes {
-			if scope.KnowledgeBaseID == "" || len(scope.TagIDs) == 0 || fullKBSet[scope.KnowledgeBaseID] {
+		kbTenant := resolveKBTenant(kbID)
+		kb := kbByID[kbID]
+		explicitKnowledgeIDs := uniqueNonEmptyStrings(kbToKnowledgeIDs[kbID])
+
+		if kb != nil && kb.Type != types.KnowledgeBaseTypeFAQ {
+			tagKnowledgeIDs, err := s.knowledgeService.ListKnowledgeIDsByTagIDs(ctx, kbTenant, kbID, tagIDs)
+			if err != nil {
+				logger.Warnf(ctx, "Failed to resolve knowledge IDs for tag scope, kb_id=%s: %v", kbID, err)
 				continue
 			}
-			kbTenant := kbTenantMap[scope.KnowledgeBaseID]
-			if kbTenant == 0 {
-				kb := kbByID[scope.KnowledgeBaseID]
-				if kb == nil || kb.TenantID == tenantID {
-					kbTenant = tenantID
-				} else if s.kbShareService != nil && userID != "" {
-					hasAccess, _ := s.kbShareService.HasTenantKBPermission(ctx, scope.KnowledgeBaseID, tenantID, callerTenantRole, types.OrgRoleViewer)
-					if hasAccess {
-						kbTenant = kb.TenantID
-					} else {
-						kbTenant = tenantID
-					}
-				} else {
-					kbTenant = tenantID
-				}
-				kbTenantMap[scope.KnowledgeBaseID] = kbTenant
+			if len(explicitKnowledgeIDs) > 0 {
+				tagKnowledgeIDs = intersectStrings(tagKnowledgeIDs, explicitKnowledgeIDs)
+			}
+			tagKnowledgeIDs = uniqueNonEmptyStrings(tagKnowledgeIDs)
+			if len(tagKnowledgeIDs) == 0 {
+				continue
 			}
 			targets = append(targets, &types.SearchTarget{
-				Type:            types.SearchTargetTypeKnowledgeBase,
-				KnowledgeBaseID: scope.KnowledgeBaseID,
-				TenantID:        kbTenant,
-				TagIDs:          append([]string(nil), scope.TagIDs...),
+				Type:              types.SearchTargetTypeKnowledge,
+				KnowledgeBaseID:   kbID,
+				TenantID:          kbTenant,
+				KnowledgeIDs:      tagKnowledgeIDs,
+				DisableDirectLoad: true,
 			})
+			continue
 		}
+
+		target := &types.SearchTarget{
+			Type:            types.SearchTargetTypeKnowledgeBase,
+			KnowledgeBaseID: kbID,
+			TenantID:        kbTenant,
+			TagIDs:          append([]string(nil), tagIDs...),
+		}
+		if len(explicitKnowledgeIDs) > 0 {
+			target.Type = types.SearchTargetTypeKnowledge
+			target.KnowledgeIDs = explicitKnowledgeIDs
+			target.DisableDirectLoad = true
+		}
+		targets = append(targets, target)
 	}
 
 	logger.Infof(ctx, "Built %d search targets: %d full KB, %d partial/tag KB, kbTenantMap=%v",
 		len(targets), len(knowledgeBaseIDs), len(targets)-len(knowledgeBaseIDs), kbTenantMap)
 
 	return targets, nil
+}
+
+func mergeTagScopesByKB(scopes []types.TagScope) map[string][]string {
+	byKB := make(map[string][]string)
+	seen := make(map[string]map[string]bool)
+	for _, scope := range scopes {
+		if scope.KnowledgeBaseID == "" {
+			continue
+		}
+		if seen[scope.KnowledgeBaseID] == nil {
+			seen[scope.KnowledgeBaseID] = make(map[string]bool)
+		}
+		for _, tagID := range scope.TagIDs {
+			if tagID == "" || seen[scope.KnowledgeBaseID][tagID] {
+				continue
+			}
+			seen[scope.KnowledgeBaseID][tagID] = true
+			byKB[scope.KnowledgeBaseID] = append(byKB[scope.KnowledgeBaseID], tagID)
+		}
+	}
+	return byKB
+}
+
+func uniqueNonEmptyStrings(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+func intersectStrings(left []string, right []string) []string {
+	if len(left) == 0 || len(right) == 0 {
+		return nil
+	}
+	rightSet := make(map[string]bool, len(right))
+	for _, value := range right {
+		rightSet[value] = true
+	}
+	out := make([]string, 0)
+	for _, value := range left {
+		if rightSet[value] {
+			out = append(out, value)
+		}
+	}
+	return out
 }
 
 // KnowledgeQAByEvent processes knowledge QA through a series of events in the pipeline
@@ -709,11 +781,11 @@ func (s *sessionService) KnowledgeQAByEvent(ctx context.Context,
 // knowledgeBaseIDs: list of knowledge base IDs to search (supports multi-KB)
 // knowledgeIDs: list of specific knowledge (file) IDs to search
 func (s *sessionService) SearchKnowledge(ctx context.Context,
-	knowledgeBaseIDs []string, knowledgeIDs []string, query string,
+	knowledgeBaseIDs []string, knowledgeIDs []string, tagScopes []types.TagScope, query string,
 ) ([]*types.SearchResult, error) {
 	logger.Info(ctx, "Start knowledge base search without LLM summary")
-	logger.Infof(ctx, "Knowledge base search parameters, knowledge base IDs: %v, knowledge IDs: %v, query: %s",
-		knowledgeBaseIDs, knowledgeIDs, query)
+	logger.Infof(ctx, "Knowledge base search parameters, knowledge base IDs: %v, knowledge IDs: %v, tag scopes: %d, query: %s",
+		knowledgeBaseIDs, knowledgeIDs, len(tagScopes), query)
 
 	// Get tenant ID from context
 	tenantID, ok := types.TenantIDFromContext(ctx)
@@ -723,7 +795,7 @@ func (s *sessionService) SearchKnowledge(ctx context.Context,
 	}
 
 	// Build unified search targets (computed once, used throughout pipeline)
-	searchTargets, err := s.buildSearchTargets(ctx, tenantID, knowledgeBaseIDs, knowledgeIDs, nil)
+	searchTargets, err := s.buildSearchTargets(ctx, tenantID, knowledgeBaseIDs, knowledgeIDs, tagScopes)
 	if err != nil {
 		logger.Warnf(ctx, "Failed to build search targets: %v", err)
 	}

--- a/internal/application/service/session_tag_targets_test.go
+++ b/internal/application/service/session_tag_targets_test.go
@@ -1,0 +1,171 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type tagTargetKnowledgeBaseService struct {
+	interfaces.KnowledgeBaseService
+	kbs map[string]*types.KnowledgeBase
+}
+
+func (s *tagTargetKnowledgeBaseService) GetKnowledgeBasesByIDsOnly(
+	_ context.Context,
+	ids []string,
+) ([]*types.KnowledgeBase, error) {
+	out := make([]*types.KnowledgeBase, 0, len(ids))
+	for _, id := range ids {
+		if kb := s.kbs[id]; kb != nil {
+			out = append(out, kb)
+		}
+	}
+	return out, nil
+}
+
+type tagTargetKnowledgeService struct {
+	interfaces.KnowledgeService
+	knowledges []*types.Knowledge
+	tagIDs     map[string][]string
+}
+
+func (s *tagTargetKnowledgeService) GetKnowledgeBatchWithSharedAccess(
+	_ context.Context,
+	_ uint64,
+	ids []string,
+) ([]*types.Knowledge, error) {
+	allowed := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		allowed[id] = true
+	}
+	out := make([]*types.Knowledge, 0)
+	for _, knowledge := range s.knowledges {
+		if allowed[knowledge.ID] {
+			out = append(out, knowledge)
+		}
+	}
+	return out, nil
+}
+
+func (s *tagTargetKnowledgeService) ListKnowledgeIDsByTagIDs(
+	_ context.Context,
+	_ uint64,
+	kbID string,
+	tagIDs []string,
+) ([]string, error) {
+	allowedTags := make(map[string]bool, len(tagIDs))
+	for _, tagID := range tagIDs {
+		allowedTags[tagID] = true
+	}
+	out := make([]string, 0)
+	for knowledgeID, tags := range s.tagIDs {
+		if !knowledgeBelongsToKB(s.knowledges, knowledgeID, kbID) {
+			continue
+		}
+		for _, tagID := range tags {
+			if allowedTags[tagID] {
+				out = append(out, knowledgeID)
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func knowledgeBelongsToKB(knowledges []*types.Knowledge, knowledgeID string, kbID string) bool {
+	for _, knowledge := range knowledges {
+		if knowledge.ID == knowledgeID && knowledge.KnowledgeBaseID == kbID {
+			return true
+		}
+	}
+	return false
+}
+
+func newTagTargetSessionService() *sessionService {
+	return &sessionService{
+		knowledgeBaseService: &tagTargetKnowledgeBaseService{
+			kbs: map[string]*types.KnowledgeBase{
+				"doc-kb": {ID: "doc-kb", TenantID: 100, Type: types.KnowledgeBaseTypeDocument},
+				"faq-kb": {ID: "faq-kb", TenantID: 100, Type: types.KnowledgeBaseTypeFAQ},
+			},
+		},
+		knowledgeService: &tagTargetKnowledgeService{
+			knowledges: []*types.Knowledge{
+				{ID: "doc-1", TenantID: 100, KnowledgeBaseID: "doc-kb"},
+				{ID: "doc-2", TenantID: 100, KnowledgeBaseID: "doc-kb"},
+				{ID: "doc-3", TenantID: 100, KnowledgeBaseID: "doc-kb"},
+			},
+			tagIDs: map[string][]string{
+				"doc-1": {"tag-a"},
+				"doc-2": {"tag-b"},
+				"doc-3": {"tag-a", "tag-b"},
+			},
+		},
+	}
+}
+
+func tagTargetContext() context.Context {
+	return context.WithValue(context.Background(), types.TenantIDContextKey, uint64(100))
+}
+
+func TestBuildSearchTargets_DocumentTagScopeResolvesKnowledgeIDs(t *testing.T) {
+	svc := newTagTargetSessionService()
+
+	targets, err := svc.buildSearchTargets(
+		tagTargetContext(),
+		100,
+		[]string{"doc-kb"},
+		nil,
+		[]types.TagScope{{KnowledgeBaseID: "doc-kb", TagIDs: []string{"tag-a"}}},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, types.SearchTargetTypeKnowledge, targets[0].Type)
+	assert.Equal(t, "doc-kb", targets[0].KnowledgeBaseID)
+	assert.ElementsMatch(t, []string{"doc-1", "doc-3"}, targets[0].KnowledgeIDs)
+	assert.Empty(t, targets[0].TagIDs)
+	assert.True(t, targets[0].DisableDirectLoad)
+}
+
+func TestBuildSearchTargets_DocumentTagScopeIntersectsExplicitKnowledgeIDs(t *testing.T) {
+	svc := newTagTargetSessionService()
+
+	targets, err := svc.buildSearchTargets(
+		tagTargetContext(),
+		100,
+		[]string{"doc-kb"},
+		[]string{"doc-2", "doc-3"},
+		[]types.TagScope{{KnowledgeBaseID: "doc-kb", TagIDs: []string{"tag-a"}}},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, types.SearchTargetTypeKnowledge, targets[0].Type)
+	assert.Equal(t, []string{"doc-3"}, targets[0].KnowledgeIDs)
+	assert.True(t, targets[0].DisableDirectLoad)
+}
+
+func TestBuildSearchTargets_FAQTagScopeKeepsIndexTagFilter(t *testing.T) {
+	svc := newTagTargetSessionService()
+
+	targets, err := svc.buildSearchTargets(
+		tagTargetContext(),
+		100,
+		[]string{"faq-kb"},
+		nil,
+		[]types.TagScope{{KnowledgeBaseID: "faq-kb", TagIDs: []string{"tag-a", "tag-b"}}},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, types.SearchTargetTypeKnowledgeBase, targets[0].Type)
+	assert.Equal(t, "faq-kb", targets[0].KnowledgeBaseID)
+	assert.ElementsMatch(t, []string{"tag-a", "tag-b"}, targets[0].TagIDs)
+	assert.False(t, targets[0].DisableDirectLoad)
+}

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -519,22 +519,29 @@ func (h *Handler) SearchKnowledge(c *gin.Context) {
 		}
 	}
 
-	if len(knowledgeBaseIDs) == 0 && len(request.KnowledgeIDs) == 0 {
-		logger.Error(ctx, "No knowledge base IDs or knowledge IDs provided")
-		c.Error(errors.NewBadRequestError("At least one knowledge_base_id, knowledge_base_ids or knowledge_ids must be provided"))
+	tagScopes := mergeTagScopesFromRequestIDs(
+		tagScopesFromMentionedItems(request.MentionedItems),
+		dedupRequestStrings(request.TagIDs),
+		secutils.SanitizeForLogArray(knowledgeBaseIDs),
+	)
+
+	if len(knowledgeBaseIDs) == 0 && len(request.KnowledgeIDs) == 0 && len(tagScopes) == 0 {
+		logger.Error(ctx, "No knowledge base IDs, knowledge IDs, or tag scopes provided")
+		c.Error(errors.NewBadRequestError("At least one knowledge_base_id, knowledge_base_ids, knowledge_ids, or scoped tag must be provided"))
 		return
 	}
 
 	logger.Infof(
 		ctx,
-		"Knowledge search request, knowledge base IDs: %v, knowledge IDs: %v, query: %s",
+		"Knowledge search request, knowledge base IDs: %v, knowledge IDs: %v, tag scopes: %d, query: %s",
 		secutils.SanitizeForLogArray(knowledgeBaseIDs),
 		secutils.SanitizeForLogArray(request.KnowledgeIDs),
+		len(tagScopes),
 		secutils.SanitizeForLog(request.Query),
 	)
 
 	// Directly call knowledge retrieval service without LLM summarization
-	searchResults, err := h.sessionService.SearchKnowledge(ctx, knowledgeBaseIDs, request.KnowledgeIDs, request.Query)
+	searchResults, err := h.sessionService.SearchKnowledge(ctx, knowledgeBaseIDs, request.KnowledgeIDs, tagScopes, request.Query)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(errors.NewInternalServerError(err.Error()))

--- a/internal/handler/session/types.go
+++ b/internal/handler/session/types.go
@@ -80,10 +80,12 @@ type AttachmentUpload struct {
 
 // SearchKnowledgeRequest defines the request structure for searching knowledge without LLM summarization
 type SearchKnowledgeRequest struct {
-	Query            string   `json:"query"              binding:"required"` // Query text to search for
-	KnowledgeBaseID  string   `json:"knowledge_base_id"`                     // Single knowledge base ID (for backward compatibility)
-	KnowledgeBaseIDs []string `json:"knowledge_base_ids"`                    // IDs of knowledge bases to search (multi-KB support)
-	KnowledgeIDs     []string `json:"knowledge_ids"`                         // IDs of specific knowledge (files) to search
+	Query            string                 `json:"query"              binding:"required"` // Query text to search for
+	KnowledgeBaseID  string                 `json:"knowledge_base_id"`                     // Single knowledge base ID (for backward compatibility)
+	KnowledgeBaseIDs []string               `json:"knowledge_base_ids"`                    // IDs of knowledge bases to search (multi-KB support)
+	KnowledgeIDs     []string               `json:"knowledge_ids"`                         // IDs of specific knowledge (files) to search
+	TagIDs           []string               `json:"tag_ids"`                               // Tag IDs for filtering within a single KB
+	MentionedItems   []MentionedItemRequest `json:"mentioned_items"`                       // Optional scoped tag mentions
 }
 
 // StopSessionRequest represents the stop session request

--- a/internal/im/cmd_search.go
+++ b/internal/im/cmd_search.go
@@ -84,7 +84,7 @@ func (c *SearchCommand) Execute(ctx context.Context, cmdCtx *CommandContext, arg
 		}
 	}
 
-	results, err := c.sessionService.SearchKnowledge(ctx, kbIDs, nil, query)
+	results, err := c.sessionService.SearchKnowledge(ctx, kbIDs, nil, nil, query)
 	if err != nil {
 		return nil, fmt.Errorf("search knowledge: %w", err)
 	}

--- a/internal/types/chat_manage.go
+++ b/internal/types/chat_manage.go
@@ -168,11 +168,12 @@ func (c *ChatManage) Clone() *ChatManage {
 			tagIDsCopy := make([]string, len(t.TagIDs))
 			copy(tagIDsCopy, t.TagIDs)
 			searchTargets[i] = &SearchTarget{
-				Type:            t.Type,
-				KnowledgeBaseID: t.KnowledgeBaseID,
-				TenantID:        t.TenantID,
-				KnowledgeIDs:    kidsCopy,
-				TagIDs:          tagIDsCopy,
+				Type:              t.Type,
+				KnowledgeBaseID:   t.KnowledgeBaseID,
+				TenantID:          t.TenantID,
+				KnowledgeIDs:      kidsCopy,
+				TagIDs:            tagIDsCopy,
+				DisableDirectLoad: t.DisableDirectLoad,
 			}
 		}
 	}

--- a/internal/types/interfaces/knowledge.go
+++ b/internal/types/interfaces/knowledge.go
@@ -69,6 +69,9 @@ type KnowledgeService interface {
 	GetKnowledgeBatch(ctx context.Context, tenantID uint64, ids []string) ([]*types.Knowledge, error)
 	// GetKnowledgeBatchWithSharedAccess retrieves knowledge by IDs including items from shared KBs the user has access to.
 	GetKnowledgeBatchWithSharedAccess(ctx context.Context, tenantID uint64, ids []string) ([]*types.Knowledge, error)
+	// ListKnowledgeIDsByTagIDs returns document knowledge IDs carrying any of
+	// the specified KB-local tags.
+	ListKnowledgeIDsByTagIDs(ctx context.Context, tenantID uint64, kbID string, tagIDs []string) ([]string, error)
 	// ListKnowledgeByKnowledgeBaseID lists all knowledge under a knowledge base.
 	ListKnowledgeByKnowledgeBaseID(ctx context.Context, kbID string) ([]*types.Knowledge, error)
 	// ListPagedKnowledgeByKnowledgeBaseID lists all knowledge under a knowledge base

--- a/internal/types/interfaces/session.go
+++ b/internal/types/interfaces/session.go
@@ -54,7 +54,7 @@ type SessionService interface {
 	// SearchKnowledge performs knowledge-based search, without summarization
 	// knowledgeBaseIDs: list of knowledge base IDs to search (supports multi-KB)
 	// knowledgeIDs: list of specific knowledge (file) IDs to search
-	SearchKnowledge(ctx context.Context, knowledgeBaseIDs []string, knowledgeIDs []string, query string) ([]*types.SearchResult, error)
+	SearchKnowledge(ctx context.Context, knowledgeBaseIDs []string, knowledgeIDs []string, tagScopes []types.TagScope, query string) ([]*types.SearchResult, error)
 	// AgentQA performs agent-based question answering with conversation history and streaming support.
 	AgentQA(ctx context.Context, req *types.QARequest, eventBus *event.EventBus) error
 }

--- a/internal/types/search.go
+++ b/internal/types/search.go
@@ -36,6 +36,11 @@ type SearchTarget struct {
 	KnowledgeIDs []string `json:"knowledge_ids,omitempty"`
 	// TagIDs limits retrieval to chunks/documents carrying any of these KB-local tags.
 	TagIDs []string `json:"tag_ids,omitempty"`
+	// DisableDirectLoad forces the target through retrieval even when it is
+	// represented as specific knowledge IDs. Tag-derived document scopes need
+	// this so tag filtering limits the candidate documents without loading every
+	// matching document chunk as context.
+	DisableDirectLoad bool `json:"disable_direct_load,omitempty"`
 }
 
 // SearchTargets is a list of search targets, pre-computed at request entry point


### PR DESCRIPTION
## Summary
- wire tag filters into the knowledge search API request path
- resolve document KB tag scopes through knowledge_tag_relations into knowledge IDs while keeping FAQ tag filters on the index tag_id path
- avoid direct chunk loading for tag-derived document targets so tagged documents are still retrieved by query relevance

## Tests
- go test ./internal/handler/session ./internal/application/service ./internal/application/service/chat_pipeline ./internal/im
- (cd client && go test ./...)
- git diff --check

## Notes
- Full `go test ./...` still has unrelated environment failures: docreader/client requires localhost:50051, and notion connector tests currently fail SSRF validation for 127.0.0.1.