### PR TITLE
fix(im/feishu): actually close WebSocket long connection when channel is stopped

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/joho/godotenv v1.5.1
 	github.com/ks3sdklib/aws-sdk-go v1.11.0
-	github.com/larksuite/oapi-sdk-go/v3 v3.6.1
+	github.com/larksuite/oapi-sdk-go/v3 v3.9.7
 	github.com/longbridgeapp/opencc v0.3.13
 	github.com/mark3labs/mcp-go v0.52.0
 	github.com/milvus-io/milvus/client/v2 v2.6.4

--- a/go.sum
+++ b/go.sum
@@ -2125,6 +2125,8 @@ github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0
 github.com/labstack/gommon v0.4.2/go.mod h1:QlUFxVM+SNXhDL/Z7YhocGIBYOiwB0mXm1+1bAPHPyU=
 github.com/larksuite/oapi-sdk-go/v3 v3.6.1 h1:vAdu+sX9yXNkKnKnYQeIv6yBkjP37Q1JEJHmMa2eCjQ=
 github.com/larksuite/oapi-sdk-go/v3 v3.6.1/go.mod h1:ZEplY+kwuIrj/nqw5uSCINNATcH3KdxSN7y+UxYY5fI=
+github.com/larksuite/oapi-sdk-go/v3 v3.9.7 h1:0AlevGG8zJ5uLhDuxgG4N1ULc6s7GEenV7ZRfER2R+Y=
+github.com/larksuite/oapi-sdk-go/v3 v3.9.7/go.mod h1:ZEplY+kwuIrj/nqw5uSCINNATcH3KdxSN7y+UxYY5fI=
 github.com/leaanthony/debme v1.2.1 h1:9Tgwf+kjcrbMQ4WnPcEIUcQuIZYqdWftzZkBr+i/oOc=
 github.com/leaanthony/debme v1.2.1/go.mod h1:3V+sCm5tYAgQymvSOfYQ5Xx2JCr+OXiD9Jkw3otUjiA=
 github.com/leaanthony/go-ansi-parser v1.6.1 h1:xd8bzARK3dErqkPFtoF9F3/HgN8UQk0ed1YDKpEz01A=

--- a/internal/im/feishu/factory.go
+++ b/internal/im/feishu/factory.go
@@ -42,7 +42,16 @@ func NewFactory() im.AdapterFactory {
 				}
 			}()
 
-			return adapter, wsCancel, nil
+			// stop tears down the connection for real. wsCancel alone is a
+			// no-op: the Feishu SDK's Start blocks on select{} and never
+			// observes ctx, so we must call Close() to actually close the
+			// socket and disable auto-reconnect. wsCancel is kept as a
+			// belt-and-braces fallback for the start goroutine.
+			stop := func() {
+				client.Close()
+				wsCancel()
+			}
+			return adapter, stop, nil
 
 		default:
 			return nil, nil, fmt.Errorf("unknown Feishu mode: %s", mode)

--- a/internal/im/feishu/longconn.go
+++ b/internal/im/feishu/longconn.go
@@ -53,6 +53,19 @@ func (c *LongConnClient) Start(ctx context.Context) error {
 	return c.wsClient.Start(ctx)
 }
 
+// Close tears down the WebSocket long connection.
+//
+// This is the only reliable way to stop a Feishu long connection: the SDK's
+// Start blocks on a bare select{} and neither Start, pingLoop, nor
+// receiveMessageLoop observe the passed context, so cancelling ctx alone leaves
+// the underlying socket alive and the SDK auto-reconnecting. Client.Close()
+// (added in oapi-sdk-go v3.9.7) flips autoReconnect off and calls disconnect,
+// which actually closes the socket. Callers should still cancel the start ctx
+// as a belt-and-braces fallback for the start goroutine.
+func (c *LongConnClient) Close() {
+	c.wsClient.Close()
+}
+
 // feishuLoggerAdapter bridges the Feishu SDK logger to our unified logger,
 // replacing raw SDK connection messages with a consistent format.
 type feishuLoggerAdapter struct {

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -965,6 +965,12 @@ func (s *Service) startChannelInternal(channel *IMChannel, factory AdapterFactor
 	}
 
 	s.mu.Lock()
+	// Idempotency: another goroutine may have started this channel while
+	// factory was running above (factory is called unlocked). Stop the old
+	// state before overwriting so its adapter / long connection doesn't leak.
+	if existing, ok := s.channels[channel.ID]; ok {
+		s.stopChannelLocked(channel.ID, existing)
+	}
 	s.channels[channel.ID] = &channelState{
 		Channel:      channel,
 		Adapter:      adapter,
@@ -1068,6 +1074,31 @@ func (s *Service) wsLeaderRenewLoop(ctx context.Context, channelID string) {
 				s.StopChannel(channelID)
 				return
 			}
+			// Still the leader — verify the channel is still active. A
+			// delete/disable is served by whichever instance got the HTTP
+			// request; without this check the leader would keep the long
+			// connection open until process restart. The renew interval
+			// bounds the worst-case lag.
+			ch, err := s.GetChannelByID(channelID)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				logger.Infof(context.Background(),
+					"[IM] Channel %s deleted; leader stepping down", channelID)
+				s.StopChannel(channelID)
+				return
+			}
+			if err != nil {
+				// Transient DB error — don't stop a possibly-healthy channel
+				// on a DB hiccup. Skip this round; the next renewal re-checks.
+				logger.Warnf(context.Background(),
+					"[IM] DB check failed for channel %s during leader renewal: %v (skipping this round)", channelID, err)
+				continue
+			}
+			if !ch.Enabled {
+				logger.Infof(context.Background(),
+					"[IM] Channel %s disabled; leader stepping down", channelID)
+				s.StopChannel(channelID)
+				return
+			}
 		case <-ctx.Done():
 			return
 		}
@@ -1088,6 +1119,34 @@ func (s *Service) wsLeaderRetryLoop(channel *IMChannel) {
 				return
 			}
 			if s.tryAcquireWSLeader(channel.ID) {
+				// Re-check the DB before starting: the channel may have been
+				// deleted or disabled on another instance while we waited for
+				// leadership. The in-memory `channel` is a startup snapshot and
+				// won't reflect that, so without this guard we'd resurrect a
+				// stopped channel (and reopen its long connection).
+				fresh, err := s.GetChannelByID(channel.ID)
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					// Channel was actually deleted — give up for good.
+					s.releaseWSLeader(channel.ID)
+					logger.Infof(context.Background(),
+						"[IM] Channel %s deleted while waiting for leadership; aborting leader takeover", channel.ID)
+					return
+				}
+				if err != nil {
+					// Transient DB error — don't make a destructive decision.
+					// Release the lock for this round and retry on the next tick.
+					s.releaseWSLeader(channel.ID)
+					logger.Warnf(context.Background(),
+						"[IM] DB check failed for channel %s during leader takeover: %v (will retry)", channel.ID, err)
+					continue
+				}
+				if !fresh.Enabled {
+					s.releaseWSLeader(channel.ID)
+					logger.Infof(context.Background(),
+						"[IM] Channel %s disabled while waiting for leadership; aborting leader takeover", channel.ID)
+					return
+				}
+				channel = fresh // use latest config (credentials/mode may have changed)
 				logger.Infof(context.Background(),
 					"[IM] Acquired leadership for channel %s, starting adapter", channel.ID)
 				s.mu.RLock()


### PR DESCRIPTION
Fixes #1905

## 背景

删除或禁用一个已启用的飞书 IM 渠道（websocket 模式）后，后端与飞书的 WebSocket 长连接不会被关闭，飞书服务端持续向该残留连接推送消息。当在另一个环境绑定同一个飞书机器人时，飞书会向两个环境的连接都推送消息，导致消息串流。

> 关联 issue: https://github.com/Tencent/WeKnora/issues/1905

## 根因

停止飞书渠道时只调用了 `wsCancel()`（context cancel），但这对飞书 SDK 完全无效：

- 飞书 SDK 的 `Start(ctx)` 在连接建立后用 `select{}` 永久阻塞，不监听 `ctx.Done()`；
- `pingLoop` / `receiveMessageLoop` 也都不监听 ctx，且配置了 `WithAutoReconnect(true)` 无限重连；
- 唯一能真正断开底层 socket 的是 `Client.Close()`，但 v3.6.1 没有公开的 `Close()`（`disconnect` 未导出）。

因此 `wsCancel()` 是空操作，连接保持活跃，飞书持续推送。

多实例部署下还有两个叠加问题：删除/禁用请求只命中一个实例，leader 实例收不到停止信号；非 leader 实例的 `wsLeaderRetryLoop` 会用内存中缓存的渠道对象重新拉起已删除的渠道。

## 修复方案

### 1. 连接真正关闭
- 升级 `oapi-sdk-go` v3.6.1 → v3.9.7（该版本新增公开的 `Client.Close()`，会置 `autoReconnect=false` 并 `disconnect`）。
- 给 `LongConnClient` 增加 `Close()` 方法封装 `wsClient.Close()`；factory 返回的 cleanup 改为「先 `Close()` 再 `wsCancel()` 兜底」。

### 2. 多实例协调
- `wsLeaderRetryLoop`：抢锁成功后、启动前回 DB 校验，若渠道已被删除/禁用则释放锁退出，不再重新拉起。
- `wsLeaderRenewLoop`：leader 每次续期后回 DB 校验，发现渠道被删/禁用则主动 `StopChannel` 退出，避免 leader 在删除请求打到其他实例时无感知地保持连接到进程重启。

### 3. 鲁棒性
- 上述 DB 校验区分 `gorm.ErrRecordNotFound`（渠道真被删 → 退出/停渠道）与瞬时 DB 错误（→ 跳过本轮、下轮重试），避免 DB 抖动误停健康渠道或导致 retry loop 永久退出。
- `startChannelInternal` 注册前先停掉同 ID 的旧 `channelState`，使其对并发启动路径幂等，防止 adapter / 长连接泄漏。

## 改动文件
| 文件 | 改动 |
|---|---|
| `go.mod` / `go.sum` | 飞书 SDK v3.6.1 → v3.9.7 |
| `internal/im/feishu/longconn.go` | 新增 `LongConnClient.Close()` |
| `internal/im/feishu/factory.go` | cleanup 改为先 `Close()` 再 `wsCancel()` |
| `internal/im/service.go` | `wsLeaderRetryLoop` / `wsLeaderRenewLoop` DB 校验 + 错误区分；`startChannelInternal` 幂等 |

## 测试
- `go build ./...` ✅
- `go vet ./internal/im/...` ✅
- `go test ./internal/im/...` ✅ 272 passed

## 备注
- 无接口变更；webhook 与 long-poll 模式不受影响。
- 与飞书知识库同步功能（`internal/datasource/connector/feishu`，基于 `net/http` 的 REST 客户端）完全隔离，互不影响——`Close()` 只关闭该渠道自己的 WebSocket，不触碰任何 HTTP 客户端。
- `Close()` 无法解除 SDK `select{}` / `for{}` goroutine 的阻塞，每次 start/stop 仍会泄漏约 2 个 goroutine，这是 SDK 设计层面的限制，影响可控（仅占少量内存）。
`