### PR TITLE
fix(retriever): enable vector retriever support for elasticsearch v7

### DIFF
--- a/internal/application/repository/retriever/elasticsearch/v7/repository.go
+++ b/internal/application/repository/retriever/elasticsearch/v7/repository.go
@@ -188,7 +188,7 @@ func (e *elasticsearchRepository) EngineType() typesLocal.RetrieverEngineType {
 }
 
 func (e *elasticsearchRepository) Support() []typesLocal.RetrieverType {
-	return []typesLocal.RetrieverType{typesLocal.KeywordsRetrieverType}
+	return []typesLocal.RetrieverType{typesLocal.KeywordsRetrieverType, typesLocal.VectorRetrieverType}
 }
 
 // EstimateStorageSize 估算存储空间大小
@@ -590,6 +590,8 @@ func (e *elasticsearchRepository) Retrieve(ctx context.Context,
 	switch params.RetrieverType {
 	case typesLocal.KeywordsRetrieverType:
 		return e.KeywordsRetrieve(ctx, params)
+	case typesLocal.VectorRetrieverType:
+		return e.VectorRetrieve(ctx, params)
 	}
 
 	err := fmt.Errorf("invalid retriever type: %v", params.RetrieverType)

--- a/internal/types/tenant.go
+++ b/internal/types/tenant.go
@@ -21,6 +21,7 @@ var retrieverEngineMapping = map[string][]RetrieverEngineParams{
 	},
 	"elasticsearch_v7": {
 		{RetrieverType: KeywordsRetrieverType, RetrieverEngineType: ElasticsearchRetrieverEngineType},
+		{RetrieverType: VectorRetrieverType, RetrieverEngineType: ElasticsearchRetrieverEngineType},
 	},
 	"elasticsearch_v8": {
 		{RetrieverType: KeywordsRetrieverType, RetrieverEngineType: ElasticsearchRetrieverEngineType},


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
ES v7 repository already implements VectorRetrieve, but Support() only
declares KeywordsRetrieverType and the elasticsearch_v7 driver mapping
in tenant.go lacks VectorRetrieverType. This causes:
- BatchIndex skips embedding generation, writing empty vectors that
  trigger mapper_parsing_exception on dense_vector fields
- Vector retrieval routing fails at registration time

Add VectorRetrieverType to Support() and Retrieve() switch, and add
VectorRetrieverType to the elasticsearch_v7 engine mapping.

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above
