### PR TITLE
fix: reconcile orphaned finalizing knowledge

### DIFF
--- a/internal/application/service/knowledge_housekeeping.go
+++ b/internal/application/service/knowledge_housekeeping.go
@@ -131,8 +131,10 @@ func (h *HousekeepingService) runSweep(ctx context.Context) {
 	// consume LLM compute via enrichment subtasks (summary/question/graph),
 	// and the same stall modes (subtask worker dies, retry budget exhausted
 	// without decrementing the counter) leave the row hanging just as
-	// visibly. Housekeeping promotes both states to 'failed' once the
-	// span heartbeat is older than the threshold.
+	// visibly. Housekeeping fails genuinely stuck work, but reconciles the
+	// narrower orphaned-finalizing case to completed when the latest attempt
+	// is already terminal and no queue or durable pending op still owns the
+	// remaining counter slots.
 	var candidates []types.Knowledge
 	if err := h.db.WithContext(ctx).
 		Where("parse_status IN ? AND updated_at < ?",
@@ -156,23 +158,47 @@ func (h *HousekeepingService) runSweep(ctx context.Context) {
 	stuck, queueSkipped := h.filterOutQueued(ctx, stuck)
 
 	if len(stuck) > 0 {
-		stuckIDs := make([]string, 0, len(stuck))
-		for _, k := range stuck {
-			stuckIDs = append(stuckIDs, k.ID)
+		completedIDs, failedIDs, pendingOpSkipped := h.splitRecoverableFinalizing(ctx, stuck)
+		if len(completedIDs) > 0 {
+			now := time.Now()
+			res := h.db.WithContext(ctx).Model(&types.Knowledge{}).
+				Where("id IN ? AND parse_status = ? AND pending_subtasks_count > 0",
+					completedIDs, types.ParseStatusFinalizing).
+				Updates(map[string]interface{}{
+					"parse_status":           types.ParseStatusCompleted,
+					"pending_subtasks_count": 0,
+					"processed_at":           now,
+					"updated_at":             now,
+				})
+			if res.Error != nil {
+				logger.Warnf(ctx, "[Housekeeping] finalizing reconciliation failed: %v", res.Error)
+			} else if res.RowsAffected > 0 {
+				logger.Infof(ctx, "[Housekeeping] reconciled %d orphaned finalizing knowledge rows to completed",
+					res.RowsAffected)
+				h.cancelOpenSpans(ctx, completedIDs, "TASK_ORPHANED", "finalizing reconciled by housekeeping")
+			}
 		}
-		res := h.db.WithContext(ctx).Model(&types.Knowledge{}).
-			Where("id IN ? AND parse_status IN ?", stuckIDs,
-				[]string{types.ParseStatusProcessing, types.ParseStatusFinalizing}).
-			Updates(map[string]interface{}{
-				"parse_status":           types.ParseStatusFailed,
-				"error_message":          "task stuck in processing > " + threshold.String() + ", recovered by housekeeping",
-				"pending_subtasks_count": 0,
-			})
-		if res.Error != nil {
-			logger.Warnf(ctx, "[Housekeeping] knowledge sweep update failed: %v", res.Error)
-		} else if res.RowsAffected > 0 {
-			logger.Infof(ctx, "[Housekeeping] recovered %d stuck knowledge rows (threshold=%s)",
-				res.RowsAffected, threshold)
+		if len(failedIDs) > 0 {
+			res := h.db.WithContext(ctx).Model(&types.Knowledge{}).
+				Where("id IN ? AND parse_status IN ?", failedIDs,
+					[]string{types.ParseStatusProcessing, types.ParseStatusFinalizing}).
+				Updates(map[string]interface{}{
+					"parse_status":           types.ParseStatusFailed,
+					"error_message":          "task stuck in processing > " + threshold.String() + ", recovered by housekeeping",
+					"pending_subtasks_count": 0,
+				})
+			if res.Error != nil {
+				logger.Warnf(ctx, "[Housekeeping] knowledge sweep update failed: %v", res.Error)
+			} else if res.RowsAffected > 0 {
+				logger.Infof(ctx, "[Housekeeping] recovered %d stuck knowledge rows (threshold=%s)",
+					res.RowsAffected, threshold)
+				h.cancelOpenSpans(ctx, failedIDs, "TASK_STUCK", "task stuck in processing > "+threshold.String()+", recovered by housekeeping")
+			}
+		}
+		if pendingOpSkipped > 0 {
+			logger.Infof(ctx,
+				"[Housekeeping] %d finalizing candidate(s) skipped — durable pending ops still exist",
+				pendingOpSkipped)
 		}
 	}
 	if spanSkipped > 0 {
@@ -205,6 +231,98 @@ func (h *HousekeepingService) runSweep(ctx context.Context) {
 		logger.Warnf(ctx, "[Housekeeping] summary sweep failed: %v", resSummary.Error)
 	} else if resSummary.RowsAffected > 0 {
 		logger.Infof(ctx, "[Housekeeping] recovered %d stuck summary rows", resSummary.RowsAffected)
+	}
+}
+
+func (h *HousekeepingService) splitRecoverableFinalizing(
+	ctx context.Context, candidates []types.Knowledge,
+) (completedIDs, failedIDs []string, pendingOpSkipped int) {
+	for _, k := range candidates {
+		if k.ParseStatus == types.ParseStatusFinalizing && k.PendingSubtasksCount > 0 {
+			if h.hasPendingOpsForKnowledge(ctx, k.ID) {
+				pendingOpSkipped++
+				continue
+			}
+			if h.latestAttemptTerminal(ctx, k.ID) {
+				completedIDs = append(completedIDs, k.ID)
+				continue
+			}
+		}
+		failedIDs = append(failedIDs, k.ID)
+	}
+	return completedIDs, failedIDs, pendingOpSkipped
+}
+
+func (h *HousekeepingService) hasPendingOpsForKnowledge(ctx context.Context, knowledgeID string) bool {
+	if knowledgeID == "" {
+		return false
+	}
+	if !h.db.Migrator().HasTable("task_pending_ops") {
+		return false
+	}
+	var n int64
+	if err := h.db.WithContext(ctx).
+		Table("task_pending_ops").
+		Where("dedup_key = ?", knowledgeID).
+		Count(&n).Error; err != nil {
+		logger.Warnf(ctx, "[Housekeeping] pending-op query failed for %s: %v", knowledgeID, err)
+		return true
+	}
+	return n > 0
+}
+
+func (h *HousekeepingService) latestAttemptTerminal(ctx context.Context, knowledgeID string) bool {
+	if knowledgeID == "" {
+		return false
+	}
+	var latest struct {
+		Attempt int `gorm:"column:attempt"`
+	}
+	if err := h.db.WithContext(ctx).
+		Table("knowledge_processing_spans").
+		Select("COALESCE(MAX(attempt), 0) AS attempt").
+		Where("knowledge_id = ?", knowledgeID).
+		Scan(&latest).Error; err != nil {
+		logger.Warnf(ctx, "[Housekeeping] latest attempt query failed for %s: %v", knowledgeID, err)
+		return false
+	}
+	if latest.Attempt <= 0 {
+		return false
+	}
+	var openCount int64
+	if err := h.db.WithContext(ctx).
+		Table("knowledge_processing_spans").
+		Where("knowledge_id = ? AND attempt = ? AND status IN ?",
+			knowledgeID, latest.Attempt,
+			[]string{types.SpanStatusPending, types.SpanStatusRunning}).
+		Count(&openCount).Error; err != nil {
+		logger.Warnf(ctx, "[Housekeeping] latest attempt open span query failed for %s attempt=%d: %v",
+			knowledgeID, latest.Attempt, err)
+		return false
+	}
+	return openCount == 0
+}
+
+func (h *HousekeepingService) cancelOpenSpans(ctx context.Context, knowledgeIDs []string, code, reason string) {
+	if len(knowledgeIDs) == 0 {
+		return
+	}
+	now := time.Now()
+	res := h.db.WithContext(ctx).
+		Table("knowledge_processing_spans").
+		Where("knowledge_id IN ? AND status IN ?", knowledgeIDs,
+			[]string{types.SpanStatusPending, types.SpanStatusRunning}).
+		Updates(map[string]interface{}{
+			"status":        types.SpanStatusCancelled,
+			"error_code":    code,
+			"error_message": reason,
+			"finished_at":   now,
+			"updated_at":    now,
+		})
+	if res.Error != nil {
+		logger.Warnf(ctx, "[Housekeeping] open span reconciliation failed: %v", res.Error)
+	} else if res.RowsAffected > 0 {
+		logger.Infof(ctx, "[Housekeeping] cancelled %d orphaned open span rows", res.RowsAffected)
 	}
 }
 

--- a/internal/application/service/knowledge_housekeeping_test.go
+++ b/internal/application/service/knowledge_housekeeping_test.go
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS knowledges (
     type            TEXT NOT NULL DEFAULT 'document',
     embedding_model_id TEXT NOT NULL DEFAULT '',
     storage_size    BIGINT NOT NULL DEFAULT 0,
+    processed_at    DATETIME,
     created_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
     deleted_at      DATETIME
@@ -68,12 +69,25 @@ CREATE TABLE IF NOT EXISTS knowledge_processing_spans (
 );
 `
 
+const housekeepingPendingOpsDDL = `
+CREATE TABLE IF NOT EXISTS task_pending_ops (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_type   VARCHAR(64) NOT NULL,
+    scope       VARCHAR(64) NOT NULL,
+    scope_id    VARCHAR(128) NOT NULL,
+    op          VARCHAR(64) NOT NULL,
+    dedup_key   VARCHAR(128) NOT NULL DEFAULT '',
+    payload     TEXT NOT NULL DEFAULT '{}'
+);
+`
+
 func setupHousekeepingDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.Exec(knowledgeTestDDL).Error)
 	require.NoError(t, db.Exec(housekeepingSpansDDL).Error)
+	require.NoError(t, db.Exec(housekeepingPendingOpsDDL).Error)
 	return db
 }
 
@@ -88,12 +102,38 @@ func insertKnowledge(t *testing.T, db *gorm.DB, id, status string, updatedAt tim
 	).Error)
 }
 
+func insertKnowledgeWithPending(t *testing.T, db *gorm.DB, id, status string, pending int, updatedAt time.Time) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`INSERT INTO knowledges (id, parse_status, pending_subtasks_count, updated_at) VALUES (?, ?, ?, ?)`,
+		id, status, pending, updatedAt,
+	).Error)
+}
+
 func insertSpan(t *testing.T, db *gorm.DB, kid string, attempt int, spanID, status string, updatedAt time.Time) {
 	t.Helper()
 	require.NoError(t, db.Exec(
 		`INSERT INTO knowledge_processing_spans (knowledge_id, attempt, span_id, name, kind, status, updated_at)
 		 VALUES (?, ?, ?, 'docreader', 'stage', ?, ?)`,
 		kid, attempt, spanID, status, updatedAt,
+	).Error)
+}
+
+func insertNamedSpan(t *testing.T, db *gorm.DB, kid string, attempt int, spanID, name, kind, status string, updatedAt time.Time) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`INSERT INTO knowledge_processing_spans (knowledge_id, attempt, span_id, name, kind, status, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		kid, attempt, spanID, name, kind, status, updatedAt,
+	).Error)
+}
+
+func insertPendingOp(t *testing.T, db *gorm.DB, knowledgeID string) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`INSERT INTO task_pending_ops (task_type, scope, scope_id, op, dedup_key, payload)
+		 VALUES ('wiki:ingest', 'knowledge_base', 'kb', 'ingest', ?, '{}')`,
+		knowledgeID,
 	).Error)
 }
 
@@ -211,17 +251,70 @@ func TestHousekeeping_NoFalseKill_TasksStillQueued(t *testing.T) {
 	stale := time.Now().Add(-3 * time.Hour)
 	// finalizing + stale knowledge + stale span: span-only heuristics
 	// would flag this as stuck, but the queue still holds its subtasks.
-	insertKnowledge(t, db, "kid-backlogged", types.ParseStatusFinalizing, stale)
+	insertKnowledgeWithPending(t, db, "kid-backlogged", types.ParseStatusFinalizing, 1, stale)
 	insertSpan(t, db, "kid-backlogged", 1, "post-1", types.SpanStatusRunning, stale)
 
 	svc.runSweep(context.Background())
 
 	var status string
+	var pending int
 	require.NoError(t, db.Raw(
-		`SELECT parse_status FROM knowledges WHERE id = ?`, "kid-backlogged",
-	).Row().Scan(&status))
+		`SELECT parse_status, pending_subtasks_count FROM knowledges WHERE id = ?`, "kid-backlogged",
+	).Row().Scan(&status, &pending))
 	assert.Equal(t, types.ParseStatusFinalizing, status,
 		"finalizing row with tasks still queued must NOT be flipped to failed")
+	assert.Equal(t, 1, pending)
+}
+
+// TestHousekeeping_ReconcilesOrphanedFinalizingToCompleted covers the
+// user-visible #1794 case: the latest attempt is already terminal and no
+// queue task references the knowledge, but a stale finalizing counter and
+// historical running span keep the UI stuck in "optimizing".
+func TestHousekeeping_ReconcilesOrphanedFinalizingToCompleted(t *testing.T) {
+	db := setupHousekeepingDB(t)
+	svc := newHousekeepingSvcForTest(db)
+	stale := time.Now().Add(-3 * time.Hour)
+	insertKnowledgeWithPending(t, db, "kid-orphan", types.ParseStatusFinalizing, 5, stale)
+	insertNamedSpan(t, db, "kid-orphan", 1, "wiki-old", "postprocess.wiki", types.SpanKindSubSpan, types.SpanStatusRunning, stale)
+	insertNamedSpan(t, db, "kid-orphan", 2, "root", "knowledge_processing", types.SpanKindRoot, types.SpanStatusDone, stale)
+	insertNamedSpan(t, db, "kid-orphan", 2, "post", types.StagePostProcess, types.SpanKindStage, types.SpanStatusDone, stale)
+
+	svc.runSweep(context.Background())
+
+	var status string
+	var pending int
+	require.NoError(t, db.Raw(
+		`SELECT parse_status, pending_subtasks_count FROM knowledges WHERE id = ?`, "kid-orphan",
+	).Row().Scan(&status, &pending))
+	assert.Equal(t, types.ParseStatusCompleted, status)
+	assert.Equal(t, 0, pending)
+
+	var oldStatus, oldCode string
+	require.NoError(t, db.Raw(
+		`SELECT status, error_code FROM knowledge_processing_spans WHERE knowledge_id = ? AND span_id = ?`,
+		"kid-orphan", "wiki-old",
+	).Row().Scan(&oldStatus, &oldCode))
+	assert.Equal(t, types.SpanStatusCancelled, oldStatus)
+	assert.Equal(t, "TASK_ORPHANED", oldCode)
+}
+
+func TestHousekeeping_PreservesFinalizingWithPendingOp(t *testing.T) {
+	db := setupHousekeepingDB(t)
+	svc := newHousekeepingSvcForTest(db)
+	stale := time.Now().Add(-3 * time.Hour)
+	insertKnowledgeWithPending(t, db, "kid-pending-op", types.ParseStatusFinalizing, 1, stale)
+	insertPendingOp(t, db, "kid-pending-op")
+	insertNamedSpan(t, db, "kid-pending-op", 2, "root", "knowledge_processing", types.SpanKindRoot, types.SpanStatusDone, stale)
+
+	svc.runSweep(context.Background())
+
+	var status string
+	var pending int
+	require.NoError(t, db.Raw(
+		`SELECT parse_status, pending_subtasks_count FROM knowledges WHERE id = ?`, "kid-pending-op",
+	).Row().Scan(&status, &pending))
+	assert.Equal(t, types.ParseStatusFinalizing, status)
+	assert.Equal(t, 1, pending)
 }
 
 // TestHousekeeping_QueueProbeError_FailsSafe confirms the fail-safe


### PR DESCRIPTION
## Summary
  Fixes #1794.
  Fixes knowledge rows that can stay stuck in `finalizing` with a non-zero `pending_subtasks_count` even though the latest processing attempt has already finished.

  When housekeeping finds an old `finalizing` knowledge row, it now distinguishes between:

  - real pending work, such as queued tasks or durable `task_pending_ops`
  - orphaned finalizing state, where no task owns the remaining pending counter and the latest attempt is already terminal.
 
 For the orphaned case, housekeeping reconciles the knowledge to `completed`, resets `pending_subtasks_count` to `0`, and marks stale open spans as `cancelled` with `TASK_ORPHANED`.

  ## Validation

  - Ran `go test ./internal/application/service -run
  TestHousekeeping -count=1`
  - Manually constructed a stuck local row:
    - `parse_status = finalizing`
    - `pending_subtasks_count = 5`
    - stale span heartbeat
    - latest attempt terminal
    - no pending ops
  - Confirmed housekeeping restored it to:
    - `parse_status = completed`
    - `pending_subtasks_count = 0`
  - Confirmed logs showed:
    - `reconciled 1 orphaned finalizing knowledge rows to
    completed`
    - `cancelled 1 orphaned open span rows`