### PR TITLE
feat(quota): implement user-level storage quota

### DIFF
--- a/frontend/src/api/tenant/members.ts
+++ b/frontend/src/api/tenant/members.ts
@@ -17,6 +17,8 @@ export interface TenantMember {
   status: TenantMemberStatus
   invited_by?: string | null
   joined_at: string
+  storage_quota?: number
+  storage_used?: number
 }
 
 export interface ListMembersResponse {
@@ -150,4 +152,20 @@ export async function removeMember(
  */
 export async function leaveTenant(tenantId: number): Promise<SimpleResponse> {
   return (await post(`/api/v1/tenants/${tenantId}/leave`)) as unknown as SimpleResponse
+}
+
+/**
+ * Update a member's personal storage quota (bytes).
+ * Backend: PUT /api/v1/tenants/:id/members/:user_id/quota (Admin+).
+ * Pass 0 to remove the individual limit.
+ */
+export async function updateMemberQuota(
+  tenantId: number,
+  userId: string,
+  storageQuota: number,
+): Promise<SimpleResponse> {
+  return (await put(
+    `/api/v1/tenants/${tenantId}/members/${userId}/quota`,
+    { storage_quota: storageQuota },
+  )) as unknown as SimpleResponse
 }

--- a/frontend/src/components/knowledge-processing-timeline.vue
+++ b/frontend/src/components/knowledge-processing-timeline.vue
@@ -1600,7 +1600,7 @@ const processConfigLines = computed<string[]>(() => {
               </div>
               <div class="kp-last-error-suggestion">{{ localizedErrorSuggestion(data.last_error.error_code) }}</div>
               <div v-if="data.last_error.error_message" class="kp-last-error-raw kp-mono">{{
-                data.last_error.error_message }}
+                data.last_error.error_message?.toLowerCase().includes('storage quota exceeded') ? t('knowledgeBase.quotaExceeded') : data.last_error.error_message }}
               </div>
             </div>
             </div>
@@ -1746,7 +1746,7 @@ const processConfigLines = computed<string[]>(() => {
                       selectedRow.node.error_code }}</span>
                   </div>
                   <pre v-if="selectedRow.node.error_message"
-                    class="kp-error-msg kp-mono">{{ selectedRow.node.error_message }}</pre>
+                    class="kp-error-msg kp-mono">{{ selectedRow.node.error_message?.toLowerCase().includes('storage quota exceeded') ? t('knowledgeBase.quotaExceeded') : selectedRow.node.error_message }}</pre>
                 </div>
 
                 <div v-if="!selectedRow.node.span_id && !selectedRow.node.started_at" class="kp-detail-hint">

--- a/frontend/src/hooks/useKnowledgeBase.ts
+++ b/frontend/src/hooks/useKnowledgeBase.ts
@@ -163,14 +163,24 @@ export default function (knowledgeBaseId?: string) {
           MessagePlugin.info(t('knowledgeBase.uploadSuccess'));
           getKnowled({ page: 1, page_size: 35 }, currentKbId);
         } else {
-          const errorMessage = result.error?.message || result.message || t('knowledgeBase.uploadFailed');
-          MessagePlugin.error(result.code === 'duplicate_file' ? t('knowledgeBase.fileExists') : errorMessage);
+          let errorMessage = result.error?.message || result.message || t('knowledgeBase.uploadFailed');
+          if (result.code === 'duplicate_file') {
+            errorMessage = t('knowledgeBase.fileExists');
+          } else if (errorMessage?.toLowerCase().includes('storage quota exceeded')) {
+            errorMessage = t('knowledgeBase.quotaExceeded');
+          }
+          MessagePlugin.error(errorMessage);
         }
         uploadInput.value.value = "";
       })
       .catch((err: any) => {
-        const errorMessage = err.error?.message || err.message || t('knowledgeBase.uploadFailed');
-        MessagePlugin.error(err.code === 'duplicate_file' ? t('knowledgeBase.fileExists') : errorMessage);
+        let errorMessage = err.error?.message || err.message || t('knowledgeBase.uploadFailed');
+        if (err.code === 'duplicate_file') {
+          errorMessage = t('knowledgeBase.fileExists');
+        } else if (errorMessage?.toLowerCase().includes('storage quota exceeded')) {
+          errorMessage = t('knowledgeBase.quotaExceeded');
+        }
+        MessagePlugin.error(errorMessage);
         uploadInput.value.value = "";
       });
   };

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -395,6 +395,7 @@ export default {
     uploadFailed: 'File upload failed!',
     docActionUnsupported: 'This knowledge base type does not support this action',
     fileExists: 'File already exists',
+    quotaExceeded: 'User storage quota exceeded, please contact your tenant admin to increase the storage quota',
     uploadingMultiple: 'Uploading {total} files...',
     uploadAllSuccess: 'Successfully uploaded {count} files!',
     uploadPartialSuccess: 'Upload completed: {success} succeeded, {fail} failed',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -394,6 +394,7 @@ export default {
     uploadSuccess: "文件上传成功！",
     uploadFailed: "文件上传失败！",
     fileExists: "文件已存在",
+    quotaExceeded: "您的可用空间配额不足，请联系团队管理员扩容",
     uploadingMultiple: "正在上传 {total} 个文件...",
     uploadAllSuccess: "成功上传 {count} 个文件！",
     uploadPartialSuccess: "上传完成：成功 {success} 个，失败 {fail} 个",

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -1483,6 +1483,8 @@ const executeUploadBatch = async (
           }
           if (responseData?.code === 'duplicate_file' || responseData?.error?.code === 'duplicate_file') {
             errorMessage = t('knowledgeBase.fileExists');
+          } else if (errorMessage?.toLowerCase().includes('storage quota exceeded')) {
+            errorMessage = t('knowledgeBase.quotaExceeded');
           }
           MessagePlugin.error(errorMessage);
         }
@@ -1493,6 +1495,8 @@ const executeUploadBatch = async (
         let errorMessage = error?.error?.message || error?.message || t('knowledgeBase.uploadFailed');
         if (error?.code === 'duplicate_file') {
           errorMessage = t('knowledgeBase.fileExists');
+        } else if (errorMessage?.toLowerCase().includes('storage quota exceeded')) {
+          errorMessage = t('knowledgeBase.quotaExceeded');
         }
         MessagePlugin.error(errorMessage);
       }

--- a/frontend/src/views/settings/TenantMembers.vue
+++ b/frontend/src/views/settings/TenantMembers.vue
@@ -146,6 +146,7 @@
                      Icon-only with tooltip so two actions ("copy" +
                      "revoke") fit inside the actions column without
                      clipping; the full label was too wide. -->
+
                 <t-tooltip v-if="row.status === 'pending' && row.invite_url"
                   :content="$t('tenantInvitation.copyLink')" placement="top">
                   <t-button shape="square" variant="text" size="small"
@@ -351,6 +352,11 @@
               </template>
               <template #joined_at="{ row }">{{ formatDate(row.joined_at) }}</template>
               <template #actions="{ row }">
+                <t-tooltip v-if="canManage" content="修改空间限额" placement="top">
+                  <t-button theme="primary" shape="square" variant="text" size="small" @click.stop="openQuotaDialog(row)">
+                    <template #icon><t-icon name="server" /></template>
+                  </t-button>
+                </t-tooltip>
                 <t-popconfirm
                   v-if="canManage && row.user_id !== currentUserId"
                   :content="$t('tenantMember.remove.confirmBody', { name: row.username || row.email })"
@@ -364,6 +370,11 @@
                     </t-button>
                   </t-tooltip>
                 </t-popconfirm>
+              </template>
+              <template #storage="{row}">
+                <span class = "member-storage">
+                 {{ formatBytes(row.storage_used) }}/{{ (!row.storage_quota || row.storage_quota === 0 ) ? '无限制' : formatBytes(row.storage_quota)}}
+                 </span>
               </template>
             </t-table>
           </div>
@@ -507,6 +518,30 @@
         </div>
       </div>
     </t-drawer>
+    <t-dialog
+        v-model:visible="quotaDialogVisible"
+        header="修改空间限额"
+        :confirm-btn="{ content: '确定', theme: 'primary', loading: updatingQuota }"
+        :cancel-btn="'取消'"
+        @confirm="submitQuotaUpdate"
+      >
+        <div style="padding: 16px 0;">
+          <t-form :data="quotaForm" :label-width="100">
+            <t-form-item label="空间配额 (GB)" name="quotaGB">
+              <t-input-number 
+                v-model="quotaForm.quotaGB" 
+                :min="0" 
+                :max="1048576"
+                :step="1" 
+                auto-width
+              />
+              <div style="margin-left: 12px; color: var(--td-text-color-secondary); font-size: 12px;">
+                填 0 代表不限制
+              </div>
+            </t-form-item>
+          </t-form>
+        </div>
+      </t-dialog>
   </div>
 </template>
 
@@ -519,6 +554,7 @@ import {
   listMembers,
   updateMemberRole,
   removeMember,
+  updateMemberQuota,
   type TenantMember,
   type TenantRole,
 } from '@/api/tenant/members'
@@ -712,6 +748,13 @@ const roleMatrix: Record<TenantRole, RolePerm[]> = {
   ],
 }
 
+const quotaDialogVisible = ref(false)
+const updatingQuota = ref(false)
+const currentQuotaMember = ref<TenantMember | null>(null)
+const quotaForm = reactive({quotaGB:0})
+
+
+
 function roleMatrixIcon(role: TenantRole): string {
   switch (role) {
     case 'owner':
@@ -725,9 +768,49 @@ function roleMatrixIcon(role: TenantRole): string {
   }
 }
 
+function formatBytes(bytes?: number): string {
+  if (bytes === undefined || bytes === null || bytes === 0) return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+}
+
+function openQuotaDialog(row: TenantMember) {
+  currentQuotaMember.value = row
+  quotaForm.quotaGB = row.storage_quota ? Number((row.storage_quota / 1024 / 1024 / 1024).toFixed(2)) : 0
+  quotaDialogVisible.value = true
+}
+
+async function submitQuotaUpdate() {
+  if (!currentQuotaMember.value) return
+
+  updatingQuota.value = true
+  try {
+    const quotaBytes = Math.round(quotaForm.quotaGB * 1024 * 1024 * 1024)
+    if (!Number.isSafeInteger(quotaBytes)) {
+      MessagePlugin.error('输入的额度过大，超出系统安全计算范围')
+      return
+    }
+    const resp = await updateMemberQuota(activeTenantId.value, currentQuotaMember.value.user_id, quotaBytes)
+    if (resp.success) {
+      MessagePlugin.success('配额更新成功')
+      quotaDialogVisible.value = false
+      await loadMembers()
+    } else {
+      MessagePlugin.error(resp.message || '配额更新失败')
+    }
+  } catch (err: any) {
+    MessagePlugin.error(err?.message || '请求失败')
+  } finally {
+    updatingQuota.value = false
+  }
+}
+
 const columns = computed(() => [
   { colKey: 'member', title: t('tenantMember.columns.member'), ellipsis: true, minWidth: 132 },
   { colKey: 'role', title: t('tenantMember.columns.role'), width: 128 },
+  { colKey: 'storage', title: '已用/配额', width: 150 },
   { colKey: 'joined_at', title: t('tenantMember.columns.joinedAt'), width: 154 },
   { colKey: 'actions', title: t('tenantMember.columns.operations'), width: 88, align: 'left' },
 ])

--- a/internal/application/repository/tenant_member.go
+++ b/internal/application/repository/tenant_member.go
@@ -290,3 +290,31 @@ func (r *tenantMemberRepository) HasAnyMembers(ctx context.Context, tenantID uin
 	}
 	return true, nil
 }
+
+func (r *tenantMemberRepository) AdjustUserStorageUsed(ctx context.Context, userID string, tenantID uint64, delta int64) error {
+	res := r.db.WithContext(ctx).
+		Model(&types.TenantMember{}).
+		Where("user_id = ? AND tenant_id = ? AND deleted_at IS NULL", userID, tenantID).
+		UpdateColumn("storage_used", gorm.Expr("CASE WHEN storage_used + ? < 0 THEN 0 ELSE storage_used + ? END", delta, delta))
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+func (r *tenantMemberRepository) UpdateStorageQuota(ctx context.Context, userID string, tenantID uint64, quotaBytes int64) error {
+	res := r.db.WithContext(ctx).
+		Model(&types.TenantMember{}).
+		Where("user_id = ? AND tenant_id = ? AND deleted_at IS NULL", userID, tenantID).
+		Update("storage_quota", quotaBytes)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -39,27 +39,28 @@ var (
 // knowledgeService implements the knowledge service interface
 // service 实现知识服务接口
 type knowledgeService struct {
-	config          *config.Config
-	retrieveEngine  interfaces.RetrieveEngineRegistry
-	ownership       retriever.TenantStoreOwnership
-	repo            interfaces.KnowledgeRepository
-	kbService       interfaces.KnowledgeBaseService
-	tenantRepo      interfaces.TenantRepository
-	tenantService   interfaces.TenantService
-	documentReader  interfaces.DocumentReader
-	chunkService    interfaces.ChunkService
-	chunkRepo       interfaces.ChunkRepository
-	tagRepo         interfaces.KnowledgeTagRepository
-	tagService      interfaces.KnowledgeTagService
-	fileSvc         interfaces.FileService
-	modelService    interfaces.ModelService
-	task            interfaces.TaskEnqueuer
-	taskInspector   interfaces.TaskInspector
-	graphEngine     interfaces.RetrieveGraphRepository
-	redisClient     *redis.Client
-	kbShareService  interfaces.KBShareService
-	imageResolver   *docparser.ImageResolver
-	taskPendingRepo interfaces.TaskPendingOpsRepository
+	config           *config.Config
+	retrieveEngine   interfaces.RetrieveEngineRegistry
+	ownership        retriever.TenantStoreOwnership
+	repo             interfaces.KnowledgeRepository
+	kbService        interfaces.KnowledgeBaseService
+	tenantRepo       interfaces.TenantRepository
+	tenantService    interfaces.TenantService
+	tenantMemberRepo interfaces.TenantMemberRepository
+	documentReader   interfaces.DocumentReader
+	chunkService     interfaces.ChunkService
+	chunkRepo        interfaces.ChunkRepository
+	tagRepo          interfaces.KnowledgeTagRepository
+	tagService       interfaces.KnowledgeTagService
+	fileSvc          interfaces.FileService
+	modelService     interfaces.ModelService
+	task             interfaces.TaskEnqueuer
+	taskInspector    interfaces.TaskInspector
+	graphEngine      interfaces.RetrieveGraphRepository
+	redisClient      *redis.Client
+	kbShareService   interfaces.KBShareService
+	imageResolver    *docparser.ImageResolver
+	taskPendingRepo  interfaces.TaskPendingOpsRepository
 
 	// In-memory fallbacks for Lite mode (no Redis)
 	memFAQProgress      sync.Map // taskID -> *types.FAQImportProgress
@@ -88,6 +89,7 @@ func NewKnowledgeService(
 	kbService interfaces.KnowledgeBaseService,
 	tenantRepo interfaces.TenantRepository,
 	tenantService interfaces.TenantService,
+	tenantMemberRepo interfaces.TenantMemberRepository,
 	chunkService interfaces.ChunkService,
 	chunkRepo interfaces.ChunkRepository,
 	tagRepo interfaces.KnowledgeTagRepository,
@@ -111,8 +113,9 @@ func NewKnowledgeService(
 		config:          config,
 		repo:            repo,
 		kbService:       kbService,
-		tenantRepo:      tenantRepo,
-		tenantService:   tenantService,
+		tenantRepo:       tenantRepo,
+		tenantService:    tenantService,
+		tenantMemberRepo: tenantMemberRepo,
 		documentReader:  documentReader,
 		chunkService:    chunkService,
 		chunkRepo:       chunkRepo,

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -101,9 +101,17 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 
 	// Check storage quota
 	tenantInfo := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
-	if tenantInfo.StorageQuota > 0 && tenantInfo.StorageUsed >= tenantInfo.StorageQuota {
+	if tenantInfo.StorageQuota > 0 && tenantInfo.StorageUsed+file.Size > tenantInfo.StorageQuota {
 		logger.Error(ctx, "Storage quota exceeded")
 		return nil, types.NewStorageQuotaExceededError()
+	}
+
+	// check user storage quota
+	if userID, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(userID) {
+		member, err := s.tenantMemberRepo.Get(ctx, userID, tenantID)
+		if err == nil && member != nil && member.StorageQuota > 0 && member.StorageUsed+file.Size > member.StorageQuota {
+			return nil, types.NewUserStorageQuotaExceededError()
+		}
 	}
 
 	// Convert metadata to JSON format if provided
@@ -379,6 +387,14 @@ func (s *knowledgeService) CreateKnowledgeFromURL(ctx context.Context,
 		return nil, types.NewStorageQuotaExceededError()
 	}
 
+	// check user storage quota
+	if userID, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(userID) {
+		member, err := s.tenantMemberRepo.Get(ctx, userID, tenantID)
+		if err == nil && member != nil && member.StorageQuota > 0 && member.StorageUsed >= member.StorageQuota {
+			return nil, types.NewUserStorageQuotaExceededError()
+		}
+	}
+
 	// Create knowledge record
 	logger.Info(ctx, "Creating knowledge record")
 	knowledge := &types.Knowledge{
@@ -599,6 +615,14 @@ func (s *knowledgeService) createKnowledgeFromFileURL(
 	if tenantInfo.StorageQuota > 0 && tenantInfo.StorageUsed >= tenantInfo.StorageQuota {
 		logger.Error(ctx, "Storage quota exceeded")
 		return nil, types.NewStorageQuotaExceededError()
+	}
+
+	// check user storage quota
+	if userID, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(userID) {
+		member, err := s.tenantMemberRepo.Get(ctx, userID, tenantID)
+		if err == nil && member != nil && member.StorageQuota > 0 && member.StorageUsed >= member.StorageQuota {
+			return nil, types.NewUserStorageQuotaExceededError()
+		}
 	}
 
 	// Create knowledge record

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -23,6 +23,66 @@ import (
 	"github.com/hibiken/asynq"
 )
 
+// resolveChargeUserID determines which user should be charged for storage quota.
+// Priority: KB CreatorID (so async workers enforce the right limit) > context UserID.
+// Returns empty string if no chargeable user is found (e.g., synthetic system user).
+func resolveChargeUserID(ctx context.Context, kb *types.KnowledgeBase) string {
+	chargeUserID := ""
+	if kb != nil {
+		chargeUserID = kb.CreatorID
+	}
+	if chargeUserID == "" {
+		if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
+			chargeUserID = uid
+		}
+	}
+	return chargeUserID
+}
+
+// shouldEnforceUserQuota checks whether user-level storage quota should be enforced
+// for the current request. Returns false for Owner/Admin roles (they need to manage
+// tenant resources without personal quota limits), true for Contributors/Viewers.
+func shouldEnforceUserQuota(ctx context.Context) bool {
+	role := types.TenantRoleFromContext(ctx)
+	// Owner and Admin are exempt from personal storage quotas
+	return role != types.TenantRoleOwner && role != types.TenantRoleAdmin
+}
+
+// checkUserStorageQuota enforces user-level storage quota with admin exemption.
+// knownSize is the incoming data size in bytes; pass 0 if unknown (soft check only).
+func (s *knowledgeService) checkUserStorageQuota(
+	ctx context.Context, kb *types.KnowledgeBase, tenantID uint64, knownSize int64,
+) error {
+	// Exempt Owner and Admin roles from user quota checks
+	if !shouldEnforceUserQuota(ctx) {
+		return nil
+	}
+
+	chargeUserID := resolveChargeUserID(ctx, kb)
+	if chargeUserID == "" {
+		return nil // No chargeable user (e.g., synthetic system user)
+	}
+
+	member, err := s.tenantMemberRepo.Get(ctx, chargeUserID, tenantID)
+	if err != nil || member == nil || member.StorageQuota == 0 {
+		return nil // No quota configured or member not found
+	}
+
+	// If we have known incoming size, check if adding it would exceed quota
+	if knownSize > 0 {
+		if member.StorageUsed+knownSize > member.StorageQuota {
+			return types.NewUserStorageQuotaExceededError()
+		}
+	} else {
+		// Soft check: reject if already at/over quota
+		if member.StorageUsed >= member.StorageQuota {
+			return types.NewUserStorageQuotaExceededError()
+		}
+	}
+
+	return nil
+}
+
 // CreateKnowledgeFromFile creates a knowledge entry from an uploaded file
 func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 	kbID string, file *multipart.FileHeader, metadata map[string]string, enableMultimodel *bool, customFileName string, tagID string, channel string,
@@ -106,12 +166,9 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 		return nil, types.NewStorageQuotaExceededError()
 	}
 
-	// check user storage quota
-	if userID, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(userID) {
-		member, err := s.tenantMemberRepo.Get(ctx, userID, tenantID)
-		if err == nil && member != nil && member.StorageQuota > 0 && member.StorageUsed+file.Size > member.StorageQuota {
-			return nil, types.NewUserStorageQuotaExceededError()
-		}
+	// Check user storage quota (charge KB owner, exempt Owner/Admin roles)
+	if err := s.checkUserStorageQuota(ctx, kb, tenantID, file.Size); err != nil {
+		return nil, err
 	}
 
 	// Convert metadata to JSON format if provided
@@ -387,12 +444,10 @@ func (s *knowledgeService) CreateKnowledgeFromURL(ctx context.Context,
 		return nil, types.NewStorageQuotaExceededError()
 	}
 
-	// check user storage quota
-	if userID, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(userID) {
-		member, err := s.tenantMemberRepo.Get(ctx, userID, tenantID)
-		if err == nil && member != nil && member.StorageQuota > 0 && member.StorageUsed >= member.StorageQuota {
-			return nil, types.NewUserStorageQuotaExceededError()
-		}
+	// Check user storage quota (charge KB owner, exempt Owner/Admin roles).
+	// No size estimate available for URL fetch, so enforce soft "already over" gate.
+	if err := s.checkUserStorageQuota(ctx, kb, tenantID, 0); err != nil {
+		return nil, err
 	}
 
 	// Create knowledge record
@@ -617,12 +672,9 @@ func (s *knowledgeService) createKnowledgeFromFileURL(
 		return nil, types.NewStorageQuotaExceededError()
 	}
 
-	// check user storage quota
-	if userID, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(userID) {
-		member, err := s.tenantMemberRepo.Get(ctx, userID, tenantID)
-		if err == nil && member != nil && member.StorageQuota > 0 && member.StorageUsed >= member.StorageQuota {
-			return nil, types.NewUserStorageQuotaExceededError()
-		}
+	// Check user storage quota (charge KB owner, exempt Owner/Admin roles)
+	if err := s.checkUserStorageQuota(ctx, kb, tenantID, 0); err != nil {
+		return nil, err
 	}
 
 	// Create knowledge record
@@ -769,6 +821,14 @@ func (s *knowledgeService) CreateKnowledgeFromManual(ctx context.Context,
 	}
 
 	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
+
+	// Check user storage quota (charge KB owner, exempt Owner/Admin roles).
+	// Actual storage size is unknown until chunking+embedding in async worker,
+	// so enforce soft "already over" gate before persisting the row.
+	if err := s.checkUserStorageQuota(ctx, kb, tenantID, 0); err != nil {
+		return nil, err
+	}
+
 	now := time.Now()
 	title := safeTitle
 	if title == "" {
@@ -858,6 +918,14 @@ func (s *knowledgeService) createKnowledgeFromPassageInternal(ctx context.Contex
 	kb, err := s.kbService.GetKnowledgeBaseByID(ctx, kbID)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to get knowledge base: %v", err)
+		return nil, err
+	}
+
+	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
+
+	// Check user storage quota (charge KB owner, exempt Owner/Admin roles).
+	// Passage path has no known incoming size, so enforce soft "already over" gate.
+	if err := s.checkUserStorageQuota(ctx, kb, tenantID, 0); err != nil {
 		return nil, err
 	}
 

--- a/internal/application/service/knowledge_create_test.go
+++ b/internal/application/service/knowledge_create_test.go
@@ -136,7 +136,7 @@ func TestCreateKnowledgeFromFileDoesNotPersistWhenStorageSaveFails(t *testing.T)
 		nil,
 		nil,
 		"",
-		"",
+		nil,
 		"",
 		nil,
 	)
@@ -167,7 +167,7 @@ func TestCreateKnowledgeFromFilePersistsStoredFilePathOnCreate(t *testing.T) {
 		nil,
 		nil,
 		"",
-		"",
+		nil,
 		"",
 		nil,
 	)
@@ -201,7 +201,7 @@ func TestCreateKnowledgeFromFileDeletesStoredFileWhenCreateFails(t *testing.T) {
 		nil,
 		nil,
 		"",
-		"",
+		nil,
 		"",
 		nil,
 	)
@@ -239,7 +239,7 @@ func TestCreateKnowledgeFromFile_PersistsProcessOverrides(t *testing.T) {
 		map[string]string{"source": "test"},
 		nil,
 		"",
-		"",
+		nil,
 		"",
 		overrides,
 	)

--- a/internal/application/service/knowledge_delete.go
+++ b/internal/application/service/knowledge_delete.go
@@ -595,11 +595,18 @@ func (s *knowledgeService) DeleteKnowledgeList(ctx context.Context, ids []string
 			logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge update tenant storage used failed")
 		}
 		// update per-user storage usage (charge KB owner when available)
-		userDeltas := make(map[string]int64) // userID → total delta
+		// kbCreatorCache reuses the KB objects already loaded above
+		// (kbFileServices / wiki cleanup loop) so we don't re-query
+		// the DB once per knowledge row in the batch.
+		kbCreatorCache := make(map[string]string) // kbID → CreatorID
+		userDeltas := make(map[string]int64)      // userID → total delta
 		for _, knowledge := range knowledgeList {
-			chargeUID := ""
-			if kbObj, err := s.kbService.GetKnowledgeBaseByID(ctx, knowledge.KnowledgeBaseID); err == nil && kbObj != nil {
-				chargeUID = kbObj.CreatorID
+			chargeUID, cached := kbCreatorCache[knowledge.KnowledgeBaseID]
+			if !cached {
+				if kbObj, err := s.kbService.GetKnowledgeBaseByID(ctx, knowledge.KnowledgeBaseID); err == nil && kbObj != nil {
+					chargeUID = kbObj.CreatorID
+				}
+				kbCreatorCache[knowledge.KnowledgeBaseID] = chargeUID
 			}
 			if chargeUID == "" {
 				if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {

--- a/internal/application/service/knowledge_delete.go
+++ b/internal/application/service/knowledge_delete.go
@@ -169,6 +169,21 @@ func (s *knowledgeService) DeleteKnowledge(ctx context.Context, id string) error
 		if err := s.tenantRepo.AdjustStorageUsed(ctx, tenantInfo.ID, -knowledge.StorageSize); err != nil {
 			logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge update tenant storage used failed")
 		}
+		// update user's storage usage (charge KB owner when available)
+		chargeUserID := ""
+		if kb != nil {
+			chargeUserID = kb.CreatorID
+		}
+		if chargeUserID == "" {
+			if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
+				chargeUserID = uid
+			}
+		}
+		if chargeUserID != "" {
+			if err := s.tenantMemberRepo.AdjustUserStorageUsed(ctx, chargeUserID, tenantInfo.ID, -knowledge.StorageSize); err != nil {
+				logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge update user storage used failed")
+			}
+		}
 		return nil
 	})
 
@@ -579,6 +594,27 @@ func (s *knowledgeService) DeleteKnowledgeList(ctx context.Context, ids []string
 		if err := s.tenantRepo.AdjustStorageUsed(ctx, tenantInfo.ID, storageAdjust); err != nil {
 			logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge update tenant storage used failed")
 		}
+		// update per-user storage usage (charge KB owner when available)
+		userDeltas := make(map[string]int64) // userID → total delta
+		for _, knowledge := range knowledgeList {
+			chargeUID := ""
+			if kbObj, err := s.kbService.GetKnowledgeBaseByID(ctx, knowledge.KnowledgeBaseID); err == nil && kbObj != nil {
+				chargeUID = kbObj.CreatorID
+			}
+			if chargeUID == "" {
+				if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
+					chargeUID = uid
+				}
+			}
+			if chargeUID != "" {
+				userDeltas[chargeUID] -= knowledge.StorageSize
+			}
+		}
+		for uid, delta := range userDeltas {
+			if err := s.tenantMemberRepo.AdjustUserStorageUsed(ctx, uid, tenantInfo.ID, delta); err != nil {
+				logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledgeList update user storage used failed for user %s", uid)
+			}
+		}
 		return nil
 	})
 
@@ -670,6 +706,21 @@ func (s *knowledgeService) cleanupKnowledgeResources(ctx context.Context, knowle
 
 	// Delete extracted images after chunks are deleted
 	deleteExtractedImages(ctx, fileSvc, imageURLs)
+	// update user's storage usage (charge KB owner when available)
+	chargeUserID := ""
+	if kb != nil {
+		chargeUserID = kb.CreatorID
+	}
+	if chargeUserID == "" {
+		if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
+			chargeUserID = uid
+		}
+	}
+	if chargeUserID != "" {
+		if err := s.tenantMemberRepo.AdjustUserStorageUsed(ctx, chargeUserID, tenantInfo.ID, -knowledge.StorageSize); err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Errorf("cleanupKnowledgeResources update user storage used failed")
+		}
+	}
 
 	namespace := types.NameSpace{KnowledgeBase: knowledge.KnowledgeBaseID, Knowledge: knowledge.ID}
 	if err := s.graphEngine.DelGraph(ctx, []types.NameSpace{namespace}); err != nil {

--- a/internal/application/service/knowledge_faq_import.go
+++ b/internal/application/service/knowledge_faq_import.go
@@ -1397,6 +1397,19 @@ func (s *knowledgeService) indexFAQChunks(ctx context.Context,
 			return types.NewStorageQuotaExceededError()
 		}
 	}
+	// check user storage quota (charge KB owner when available so async workers still enforce limits)
+	chargeUserID := kb.CreatorID
+	if chargeUserID == "" {
+		if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
+			chargeUserID = uid
+		}
+	}
+	if chargeUserID != "" {
+		member, err := s.tenantMemberRepo.Get(ctx, chargeUserID, tenantInfo.ID)
+		if err == nil && member != nil && member.StorageQuota > 0 && member.StorageUsed+size > member.StorageQuota {
+			return types.NewUserStorageQuotaExceededError()
+		}
+	}
 
 	// 删除旧向量
 	var deleteDuration time.Duration
@@ -1410,7 +1423,6 @@ func (s *knowledgeService) indexFAQChunks(ctx context.Context,
 			logger.Debugf(ctx, "indexFAQChunks: deleted old vectors for %d chunks in %v", len(chunkIDs), deleteDuration)
 		}
 	}
-
 	// 批量索引（这里可能是性能瓶颈）
 	batchIndexStartTime := time.Now()
 	if err := retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfo); err != nil {
@@ -1424,6 +1436,18 @@ func (s *knowledgeService) indexFAQChunks(ctx context.Context,
 		adjustStartTime := time.Now()
 		if err := s.tenantRepo.AdjustStorageUsed(ctx, tenantInfo.ID, size); err == nil {
 			tenantInfo.StorageUsed += size
+		}
+		// update user's storage usage (charge KB owner when available so async workers still update usage)
+		chargeUserID := kb.CreatorID
+		if chargeUserID == "" {
+			if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
+				chargeUserID = uid
+			}
+		}
+		if chargeUserID != "" {
+			if err := s.tenantMemberRepo.AdjustUserStorageUsed(ctx, chargeUserID, tenantInfo.ID, size); err != nil {
+				logger.GetLogger(ctx).WithField("error", err).Errorf("indexFAQChunks update user storage used failed")
+			}
 		}
 		knowledge.StorageSize += size
 		adjustDuration := time.Since(adjustStartTime)
@@ -1486,6 +1510,20 @@ func (s *knowledgeService) deleteFAQChunkVectors(ctx context.Context,
 	}
 
 	size := retrieveEngine.EstimateStorageSize(ctx, embeddingModel, indexInfo)
+
+	// update user's storage usage (charge KB owner when available)
+	chargeUserID := kb.CreatorID
+	if chargeUserID == "" {
+		if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
+			chargeUserID = uid
+		}
+	}
+	if chargeUserID != "" {
+		if err := s.tenantMemberRepo.AdjustUserStorageUsed(ctx, chargeUserID, tenantInfo.ID, -size); err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Errorf("deleteFAQChunkVectors update user storage used failed")
+		}
+	}
+
 	if err := retrieveEngine.DeleteByChunkIDList(ctx, chunkIDs, embeddingModel.GetDimensions(), types.KnowledgeTypeFAQ); err != nil {
 		return err
 	}

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -99,15 +99,28 @@ func (s *knowledgeService) cloneKnowledge(
 		logger.GetLogger(ctx).WithField("error", err).Errorf("MoveKnowledge create knowledge failed")
 		return
 	}
+	if err = s.CloneChunk(ctx, src, dst); err != nil {
+		logger.GetLogger(ctx).WithField("knowledge_id", dst.ID).
+			WithField("error", err).Errorf("MoveKnowledge move chunks failed")
+		return
+	}
+
 	tenantInfo.StorageUsed += dst.StorageSize
 	if err = s.tenantRepo.AdjustStorageUsed(ctx, tenantInfo.ID, dst.StorageSize); err != nil {
 		logger.GetLogger(ctx).WithField("error", err).Errorf("MoveKnowledge update tenant storage used failed")
 		return
 	}
-	if err = s.CloneChunk(ctx, src, dst); err != nil {
-		logger.GetLogger(ctx).WithField("knowledge_id", dst.ID).
-			WithField("error", err).Errorf("MoveKnowledge move chunks failed")
-		return
+	// update user's storage usage (charge KB owner when available)
+	chargeUserID := targetKB.CreatorID
+	if chargeUserID == "" {
+		if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
+			chargeUserID = uid
+		}
+	}
+	if chargeUserID != "" {
+		if err := s.tenantMemberRepo.AdjustUserStorageUsed(ctx, chargeUserID, tenantInfo.ID, dst.StorageSize); err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Errorf("cloneKnowledge update user storage used failed")
+		}
 	}
 	return
 }
@@ -565,6 +578,24 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			}
 		}
 
+		// check user storage quota (charge KB owner when available so async workers still enforce limits)
+		chargeUserID := kb.CreatorID
+		if chargeUserID == "" {
+			if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
+				chargeUserID = uid
+			}
+		}
+		if chargeUserID != "" {
+			member, err := s.tenantMemberRepo.Get(ctx, chargeUserID, tenantInfo.ID)
+			if err == nil && member != nil && member.StorageQuota > 0 && member.StorageUsed+totalStorageSize > member.StorageQuota {
+				knowledge.ParseStatus = types.ParseStatusFailed
+				knowledge.ErrorMessage = "用户存储空间配额不足"
+				knowledge.UpdatedAt = time.Now()
+				s.repo.UpdateKnowledge(ctx, knowledge)
+				return
+			}
+		}
+
 		// Check again before batch indexing (heavy operation).
 		// deleting → row is going away anyway, drop the chunks we just wrote.
 		// cancelled → user wants to keep what was already persisted, just stop.
@@ -691,6 +722,19 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks update tenant storage used failed")
 	}
 	logger.GetLogger(ctx).Infof("processChunks successfully")
+
+	// update user's storage usage (charge KB owner when available so async workers still update usage)
+	chargeUserID := kb.CreatorID
+	if chargeUserID == "" {
+		if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
+			chargeUserID = uid
+		}
+	}
+	if chargeUserID != "" {
+		if err := s.tenantMemberRepo.AdjustUserStorageUsed(ctx, chargeUserID, tenantInfo.ID, totalStorageSize); err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks update user storage used failed")
+		}
+	}
 }
 
 // defaultMaxInputChars is the default maximum characters used as input for summary generation.

--- a/internal/application/service/tenant_member.go
+++ b/internal/application/service/tenant_member.go
@@ -53,6 +53,9 @@ var (
 	// ErrInvalidTenantRole is returned when the caller passes a role
 	// value that is not one of the four defined TenantRole constants.
 	ErrInvalidTenantRole = errors.New("invalid tenant role")
+	
+	// ErrInvalidStorageQuota is returned when the storage quota is invalid (e.g. negative or less than used).
+	ErrInvalidStorageQuota = errors.New("invalid storage quota")
 
 	// ErrLastOwner is returned when an operation would leave the tenant
 	// without an active Owner. Demoting the last Owner or removing them
@@ -391,4 +394,30 @@ func (s *tenantMemberService) emitRemovalAudit(
 		TargetUserID: targetUserID,
 		Outcome:      types.AuditOutcomeSuccess,
 	})
+}
+
+// UpdateMemberStorageQuota sets the personal storage quota for a user
+// within the given tenant. quotaBytes=0 means "no individual limit".
+// Validates: quotaBytes >= 0, and if quotaBytes > 0 it must be >= the
+// user's current StorageUsed.
+func (s *tenantMemberService) UpdateMemberStorageQuota(
+	ctx context.Context,
+	userID string,
+	tenantID uint64,
+	quotaBytes int64,
+) error {
+	if quotaBytes < 0 {
+		return ErrInvalidStorageQuota
+	}
+	member, err := s.repo.Get(ctx, userID, tenantID)
+	if err != nil {
+		return err
+	}
+	if member == nil {
+		return ErrMembershipNotFound
+	}
+	if quotaBytes > 0 && quotaBytes < member.StorageUsed {
+		return ErrInvalidStorageQuota
+	}
+	return s.repo.UpdateStorageQuota(ctx, userID, tenantID, quotaBytes)
 }

--- a/internal/application/service/tenant_member_test.go
+++ b/internal/application/service/tenant_member_test.go
@@ -248,6 +248,38 @@ func (r *fakeTenantMemberRepo) RemoveOwnerAtomically(
 	return nil
 }
 
+// AdjustUserStorageUsed mirrors the production repo's clamp-to-0
+// semantics: storage_used never goes negative. Delta may be negative
+// (delete) or positive (index/clone).
+func (r *fakeTenantMemberRepo) AdjustUserStorageUsed(
+	ctx context.Context, userID string, tenantID uint64, delta int64,
+) error {
+	for _, e := range r.rows {
+		if e.UserID == userID && e.TenantID == tenantID && !e.DeletedAt.Valid {
+			e.StorageUsed += delta
+			if e.StorageUsed < 0 {
+				e.StorageUsed = 0
+			}
+			return nil
+		}
+	}
+	return gormErrRecordNotFound
+}
+
+// UpdateStorageQuota updates the per-user storage quota. quotaBytes=0
+// means "no individual limit".
+func (r *fakeTenantMemberRepo) UpdateStorageQuota(
+	ctx context.Context, userID string, tenantID uint64, quotaBytes int64,
+) error {
+	for _, e := range r.rows {
+		if e.UserID == userID && e.TenantID == tenantID && !e.DeletedAt.Valid {
+			e.StorageQuota = quotaBytes
+			return nil
+		}
+	}
+	return gormErrRecordNotFound
+}
+
 // Compile-time guard so the test stays in sync with the interface.
 var _ interfaces.TenantMemberRepository = (*fakeTenantMemberRepo)(nil)
 

--- a/internal/handler/tenant_member.go
+++ b/internal/handler/tenant_member.go
@@ -136,11 +136,13 @@ func (h *TenantMemberHandler) ListMembers(c *gin.Context) {
 	resp := make([]types.TenantMemberResponse, 0, len(members))
 	for _, m := range members {
 		row := types.TenantMemberResponse{
-			UserID:    m.UserID,
-			Role:      m.Role,
-			Status:    m.Status,
-			InvitedBy: m.InvitedBy,
-			JoinedAt:  m.JoinedAt,
+			UserID:       m.UserID,
+			Role:         m.Role,
+			Status:       m.Status,
+			InvitedBy:    m.InvitedBy,
+			JoinedAt:     m.JoinedAt,
+			StorageQuota: m.StorageQuota,
+			StorageUsed:  m.StorageUsed,
 		}
 		if u, ok := usersByID[m.UserID]; ok && u != nil {
 			row.Email = u.Email
@@ -401,5 +403,58 @@ func (h *TenantMemberHandler) LeaveTenant(c *gin.Context) {
 		return
 	}
 
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+type updateMemberQuotaRequest struct {
+	StorageQuota *int64 `json:"storage_quota" binding:"required"`
+}
+
+// UpdateMemberQuota godoc
+// @Summary      修改成员存储配额
+// @Description  Owner/Admin 为某位成员设置个人存储配额（0=不限制）
+// @Tags         租户成员
+// @Accept       json
+// @Produce      json
+// @Param        id        path  string  true  "租户 ID"
+// @Param        user_id   path  string  true  "用户 ID"
+// @Param        request   body  updateMemberQuotaRequest  true  "配额请求"
+// @Success      200  {object}  map[string]interface{}
+// @Security     Bearer
+// @Router       /tenants/{id}/members/{user_id}/quota [put]
+func (h *TenantMemberHandler) UpdateMemberQuota(c *gin.Context) {
+	ctx := c.Request.Context()
+	tenantID, ok := parseTenantIDFromPath(c)
+	if !ok {
+		return
+	}
+	userID := strings.TrimSpace(c.Param("user_id"))
+	if userID == "" {
+		c.Error(apperrors.NewValidationError("user_id is required"))
+		return
+	}
+
+	var req updateMemberQuotaRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.Error(apperrors.NewValidationError("invalid request body").WithDetails(err.Error()))
+		return
+	}
+	if *req.StorageQuota < 0 {
+		c.Error(apperrors.NewValidationError("storage_quota must be non-negative"))
+		return
+	}
+	if err := h.memberService.UpdateMemberStorageQuota(ctx, userID, tenantID, *req.StorageQuota); err != nil {
+		switch {
+		case errors.Is(err, service.ErrMembershipNotFound):
+			c.Error(apperrors.NewNotFoundError("membership not found"))
+		case errors.Is(err, service.ErrInvalidStorageQuota):
+			c.Error(apperrors.NewValidationError(err.Error()))
+		default:
+			logger.Errorf(ctx, "UpdateMemberQuota failed: user=%s tenant=%d err=%v",
+				userID, tenantID, err)
+			c.Error(apperrors.NewInternalServerError("failed to update member quota").WithDetails(err.Error()))
+		}
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{"success": true})
 }

--- a/internal/middleware/auth_role_test.go
+++ b/internal/middleware/auth_role_test.go
@@ -24,9 +24,9 @@ type fakeMemberService struct {
 		TenantID uint64
 		Role     types.TenantRole
 	}
-	failGet     error
-	failHasAny  error
-	failAdd     error
+	failGet    error
+	failHasAny error
+	failAdd    error
 	// 阻止 auto-promote 把 hasAny 翻面：默认 AddMember 成功也会写入 members map。
 }
 
@@ -129,6 +129,17 @@ func (f *fakeMemberService) UpdateRole(
 	return nil
 }
 func (f *fakeMemberService) RemoveMember(ctx context.Context, userID string, tenantID uint64) error {
+	return nil
+}
+
+// UpdateMemberStorageQuota is a no-op stub for the test fake. The
+// resolveTenantRole path under test never touches per-user storage
+// quota, so we don't need real in-memory accounting here; the service
+// layer quota logic has its own dedicated tests in the service
+// package.
+func (f *fakeMemberService) UpdateMemberStorageQuota(
+	ctx context.Context, userID string, tenantID uint64, quotaBytes int64,
+) error {
 	return nil
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -579,6 +579,7 @@ func RegisterTenantRoutes(
 				tenantByID.POST("/members", g.Owner(), memberHandler.AddMember)
 				tenantByID.PUT("/members/:user_id", g.Owner(), memberHandler.UpdateMemberRole)
 				tenantByID.DELETE("/members/:user_id", g.Owner(), memberHandler.RemoveMember)
+				tenantByID.PUT("/members/:user_id/quota", g.Admin(), memberHandler.UpdateMemberQuota)
 				tenantByID.POST("/leave", g.Viewer(), memberHandler.LeaveTenant)
 			}
 

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -44,3 +44,10 @@ func NewDuplicateURLError(knowledge *Knowledge) *DuplicateKnowledgeError {
 		Knowledge: knowledge,
 	}
 }
+
+// NewUserStorageQuotaExceededError creates a user storage quota exceeded error
+func NewUserStorageQuotaExceededError() *StorageQuotaExceededError {
+	return &StorageQuotaExceededError{
+		Message: "User storage quota exceeded, please contact your tenant admin to increase the storage quota",
+	}
+}

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -45,9 +45,25 @@ func NewDuplicateURLError(knowledge *Knowledge) *DuplicateKnowledgeError {
 	}
 }
 
-// NewUserStorageQuotaExceededError creates a user storage quota exceeded error
-func NewUserStorageQuotaExceededError() *StorageQuotaExceededError {
-	return &StorageQuotaExceededError{
+// UserStorageQuotaExceededError represents a per-user storage quota
+// exceeded error. It is intentionally a DISTINCT type from the
+// tenant-level StorageQuotaExceededError so handlers can map them to
+// different business codes and the frontend can show targeted
+// messaging ("contact admin to raise your personal quota" vs "tenant
+// storage is full").
+type UserStorageQuotaExceededError struct {
+	Message string
+}
+
+func (e *UserStorageQuotaExceededError) Error() string {
+	return e.Message
+}
+
+// NewUserStorageQuotaExceededError creates a user storage quota exceeded
+// error. Returns the new dedicated type so callers can errors.As it
+// apart from the tenant-level quota error.
+func NewUserStorageQuotaExceededError() *UserStorageQuotaExceededError {
+	return &UserStorageQuotaExceededError{
 		Message: "User storage quota exceeded, please contact your tenant admin to increase the storage quota",
 	}
 }

--- a/internal/types/interfaces/tenant_member.go
+++ b/internal/types/interfaces/tenant_member.go
@@ -68,4 +68,13 @@ type TenantMemberRepository interface {
 	// RemoveOwnerAtomically soft-deletes an Owner row under the same
 	// lock as DemoteOwnerAtomically.
 	RemoveOwnerAtomically(ctx context.Context, userID string, tenantID uint64) error
+
+	// AdjustUserStorageUsed atomically adjusts storage_used for the given
+	// (userID, tenantID) membership. Negative delta reclaims space on delete.
+	// Clamps to 0 if the result would go negative.
+	AdjustUserStorageUsed(ctx context.Context, userID string, tenantID uint64, delta int64) error
+
+	// UpdateStorageQuota sets the personal storage quota for the given
+	// (userID, tenantID) membership. quotaBytes=0 means "no individual limit".
+	UpdateStorageQuota(ctx context.Context, userID string, tenantID uint64, quotaBytes int64) error
 }

--- a/internal/types/interfaces/tenant_member_service.go
+++ b/internal/types/interfaces/tenant_member_service.go
@@ -51,4 +51,9 @@ type TenantMemberService interface {
 	// RemoveMember soft-deletes the membership while enforcing the
 	// "cannot remove the last active Owner" invariant.
 	RemoveMember(ctx context.Context, userID string, tenantID uint64) error
+
+	// UpdateMemberStorageQuota sets the personal storage quota for a user
+	// in the tenant. Only Admin/Owner should call this.
+	// Validates: quotaBytes >= 0, quotaBytes >= member.StorageUsed (if > 0).
+	UpdateMemberStorageQuota(ctx context.Context, userID string, tenantID uint64, quotaBytes int64) error
 }

--- a/internal/types/tenant_member.go
+++ b/internal/types/tenant_member.go
@@ -104,6 +104,13 @@ type TenantMember struct {
 	CreatedAt time.Time      `json:"created_at"`
 	UpdatedAt time.Time      `json:"updated_at"`
 	DeletedAt gorm.DeletedAt `json:"deleted_at" gorm:"index"`
+	// StorageQuota is the maximum storage (bytes) this user may consume
+	// within this tenant. 0 means "no individual limit — tenant quota
+	// is the only ceiling".
+	StorageQuota int64 `json:"storage_quota" gorm:"default:0"`
+	// StorageUsed tracks how many bytes this user currently occupies
+	// within this tenant.
+	StorageUsed int64 `json:"storage_used" gorm:"default:0"`
 }
 
 // TableName binds TenantMember to the tenant_members table.
@@ -133,5 +140,7 @@ type TenantMemberResponse struct {
 	Role      TenantRole         `json:"role"`
 	Status    TenantMemberStatus `json:"status"`
 	InvitedBy *string            `json:"invited_by,omitempty"`
-	JoinedAt  time.Time          `json:"joined_at"`
+	JoinedAt     time.Time          `json:"joined_at"`
+	StorageQuota int64              `json:"storage_quota"`
+	StorageUsed  int64              `json:"storage_used"`
 }

--- a/migrations/versioned/000060_member_storage_quota.down.sql
+++ b/migrations/versioned/000060_member_storage_quota.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tenant_members DROP COLUMN storage_used;
+ALTER TABLE tenant_members DROP COLUMN storage_quota;

--- a/migrations/versioned/000060_member_storage_quota.up.sql
+++ b/migrations/versioned/000060_member_storage_quota.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tenant_members ADD COLUMN storage_quota BIGINT DEFAULT 0;
+ALTER TABLE tenant_members ADD COLUMN storage_used  BIGINT DEFAULT 0;

--- a/migrations/versioned/000060_member_storage_quota.up.sql
+++ b/migrations/versioned/000060_member_storage_quota.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE tenant_members ADD COLUMN storage_quota BIGINT DEFAULT 0;
-ALTER TABLE tenant_members ADD COLUMN storage_used  BIGINT DEFAULT 0;
+ALTER TABLE tenant_members ADD COLUMN storage_quota BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE tenant_members ADD COLUMN storage_used  BIGINT NOT NULL DEFAULT 0;


### PR DESCRIPTION
feat: implement user-level storage quota mechanism

<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->
key addition
* database: add storage_quota and storage _usused fields to tenant_member table
* backend api: added put  /api/v1/tenants/:id/members/:user_id/quota end point for admins to adjust user quotas
* service layer: updated all storage adjustinh and checking poins to account for tenant toaged
* fronted: added a visual edit flow in "tenant member" table to dispaly used/quota and allow admin to configure tenant limit

## Type of Change
<!-- Check applicable items -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #1653 

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
I use two account which one is tenant and one is admin.Test step is follow corresponding to screenshot below.
* 1 change the tenant stotage_quota through admin account(detect decimal input together)
* 2 upload a file whose size exceed the quota
all this test output was showed below containing ui interface and endpoint feedback 

## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<img width="1520" height="398" alt="362e408f485778ab2198ddc460d4f7a7" src="https://github.com/user-attachments/assets/0620f096-8726-4fd4-b249-26e6f29e7d90" />

<img width="1360" height="630" alt="c7daf56510cc0fedc3fa06f6e5c2bfeb" src="https://github.com/user-attachments/assets/5fb561fd-13bd-4584-a9be-5f3875e2d53c" />
sets/56467a77-444c
<img width="924" height="428" alt="4949f5c8741a554b9e0c4b95a517ff00" src="https://github.com/user-attachments/assets/76844e13-b43a-460a-ad1a-8a2bb091314d" />
-4957-951f-6e9638aafdf5" />
<img width="1052" height="146" alt="463c2060db2969ba50041a71373bce60" src="https://github.com/user-attachments/assets/18d860e5-ca43-4600-83e9-98825b837be4" />
<img width="1354" height="400" alt="5d791c1ab255eba584816c2d3fcc611d" src="https://github.com/user-attachments/assets/8d040390-ec14-466c-84c4-e54221448bb6" />


<img width="684" height="102" alt="319120220575f303b506e637a57540c5" src="https://github.com/user-attachments/assets/c224b3d4-3e95-40ec-9423-88698c692e26" />
f5-915a-801cdda64008" />
<img width="1366" height="548" alt="7558dfd6d8847e7f9e3dd9463e63d432" src="https://github.com/user-attachments/assets/78e293e3-f6bf-4346-8cac-d7e387ea76cf" />
