### PR TITLE
fix(frontend): prevent white screen from corrupted localStorage

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -27,6 +27,11 @@ initFont();
 
 const app = createApp(App);
 
+// 全局错误处理：捕获未处理的组件错误，防止白屏
+app.config.errorHandler = (err, instance, info) => {
+  console.error("[WeKnora] Unhandled Vue error:", err, "\nComponent:", instance, "\nInfo:", info);
+};
+
 app.use(TDesign);
 app.use(createPinia());
 app.use(router);

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -112,15 +112,25 @@ const defaultSettings: Settings = {
 
 /** Keep builtin agent id and isAgentEnabled in sync after localStorage reload. */
 function loadAndReconcileSettings(): Settings {
-  const loaded = JSON.parse(
-    localStorage.getItem("WeKnora_settings") || JSON.stringify(defaultSettings),
-  ) as Settings;
+  let loaded: Settings;
+  try {
+    const raw = localStorage.getItem("WeKnora_settings");
+    loaded = raw ? (JSON.parse(raw) as Settings) : { ...defaultSettings };
+  } catch (e) {
+    console.error("[settings] Failed to parse WeKnora_settings from localStorage, resetting to defaults:", e);
+    localStorage.removeItem("WeKnora_settings");
+    return { ...defaultSettings };
+  }
   loaded.selectedTags ||= [];
   loaded.selectedMCPServices ||= [];
   loaded.selectedSkills ||= loaded.selectedTools || [];
   loaded.selectedFileKbMap ||= {};
   if (reconcileBuiltinAgentMode(loaded)) {
-    localStorage.setItem("WeKnora_settings", JSON.stringify(loaded));
+    try {
+      localStorage.setItem("WeKnora_settings", JSON.stringify(loaded));
+    } catch {
+      /* quota exceeded — non-critical */
+    }
   }
   return loaded;
 }


### PR DESCRIPTION
## Description

SPA 页面在数据库迁移或后端重启后可能出现白屏，根因是 `stores/settings.ts` 中 `loadAndReconcileSettings()` 对 `WeKnora_settings` 执行 `JSON.parse` 时未包裹 try/catch。当 localStorage 中的数据因格式损坏、配额截断或 schema 漂移导致解析失败时，异常会直接传播至 Pinia store 初始化，进而使 `App.vue` 无法挂载，用户看到空白页面。

此外，整个前端缺少 `app.config.errorHandler` 全局错误处理，任何未捕获的组件异常都会导致渲染中断而无任何恢复 UI。

**Changes:**
- `frontend/src/stores/settings.ts`: 给 `loadAndReconcileSettings()` 的 `JSON.parse` 加 try/catch，解析失败时清除损坏的 `WeKnora_settings` 并回退到 `defaultSettings`；`localStorage.setItem` 写回也加了 try/catch 防止配额溢出
- `frontend/src/main.ts`: 注册 `app.config.errorHandler` 捕获未处理的 Vue 组件错误，防止静默白屏

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #1786

## Testing

1. 在浏览器 DevTools 中手动将 `WeKnora_settings` 的值改为非法 JSON（如 `{broken`），刷新页面 → 页面正常加载（不再白屏），控制台输出 `[settings] Failed to parse WeKnora_settings...` 错误日志，`WeKnora_settings` 被自动清除并恢复为默认值
2. 正常登录使用后，`WeKnora_settings` 写入和读取行为与修复前一致
3. 模拟组件内未捕获异常（如在某个组件 onMounted 中 throw），确认 `app.config.errorHandler` 在控制台输出错误信息，页面不白屏

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

修复前：

https://github.com/user-attachments/assets/23c43181-24e0-4dd7-8b4e-21404484c6f7

修复后：


https://github.com/user-attachments/assets/b577bfec-0688-4494-bb29-55ba4cb6ab00


