### PR TITLE
feat(redis): support TLS for Redis connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -223,6 +223,14 @@ REDIS_DB=0
 # Redis key的前缀，用于命名空间隔离
 REDIS_PREFIX=stream:
 
+# 是否为 Redis 连接启用 TLS（适用于要求传输层加密的托管 Redis，
+# 如 AWS ElastiCache in-transit encryption、Azure Cache 等）。默认关闭。
+# REDIS_USE_TLS=false
+# 可选：用于证书校验与 SNI 的服务器名（当地址是 IP 时有用）
+# REDIS_TLS_SERVER_NAME=
+# 跳过服务器证书校验。不安全，仅用于开发或自签名证书环境，生产禁用。
+# REDIS_TLS_INSECURE_SKIP_VERIFY=false
+
 # 当使用本地存储时，文件保存的基础目录路径
 LOCAL_STORAGE_BASE_DIR=/data/files
 

--- a/internal/common/redis_tls.go
+++ b/internal/common/redis_tls.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"crypto/tls"
+	"os"
+	"strings"
+)
+
+// RedisTLSConfig builds a *tls.Config for Redis connections from environment
+// variables. It returns nil when TLS is disabled, so the result can be assigned
+// directly to redis.Options.TLSConfig or asynq.RedisClientOpt.TLSConfig (a nil
+// value keeps the existing plaintext behavior).
+//
+// Environment variables:
+//
+//	REDIS_USE_TLS                   Enable TLS when "true" (default: disabled).
+//	REDIS_TLS_SERVER_NAME          Optional server name for certificate
+//	                               verification and SNI (useful when the address
+//	                               is an IP rather than a hostname).
+//	REDIS_TLS_INSECURE_SKIP_VERIFY Skip server certificate verification when
+//	                               "true". INSECURE — intended for development or
+//	                               self-signed setups only; do not use in production.
+//
+// The server certificate is verified by default; verification is only relaxed
+// when REDIS_TLS_INSECURE_SKIP_VERIFY is explicitly set to "true".
+func RedisTLSConfig() *tls.Config {
+	if !envTrue("REDIS_USE_TLS") {
+		return nil
+	}
+
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	if serverName := strings.TrimSpace(os.Getenv("REDIS_TLS_SERVER_NAME")); serverName != "" {
+		cfg.ServerName = serverName
+	}
+	if envTrue("REDIS_TLS_INSECURE_SKIP_VERIFY") {
+		cfg.InsecureSkipVerify = true
+	}
+
+	return cfg
+}
+
+// envTrue reports whether the named environment variable is set to "true"
+// (case-insensitive, surrounding whitespace ignored).
+func envTrue(name string) bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(name)), "true")
+}

--- a/internal/common/redis_tls_test.go
+++ b/internal/common/redis_tls_test.go
@@ -1,0 +1,53 @@
+package common
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestRedisTLSConfig_DisabledByDefault(t *testing.T) {
+	// REDIS_USE_TLS unset.
+	if cfg := RedisTLSConfig(); cfg != nil {
+		t.Fatalf("expected nil tls.Config when REDIS_USE_TLS is unset, got %#v", cfg)
+	}
+
+	t.Setenv("REDIS_USE_TLS", "false")
+	if cfg := RedisTLSConfig(); cfg != nil {
+		t.Fatalf("expected nil tls.Config when REDIS_USE_TLS=false, got %#v", cfg)
+	}
+}
+
+func TestRedisTLSConfig_EnabledSecureByDefault(t *testing.T) {
+	t.Setenv("REDIS_USE_TLS", "true")
+
+	cfg := RedisTLSConfig()
+	if cfg == nil {
+		t.Fatal("expected non-nil tls.Config when REDIS_USE_TLS=true")
+	}
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Errorf("expected MinVersion TLS 1.2, got %x", cfg.MinVersion)
+	}
+	if cfg.InsecureSkipVerify {
+		t.Error("expected certificate verification to be enabled by default")
+	}
+	if cfg.ServerName != "" {
+		t.Errorf("expected empty ServerName by default, got %q", cfg.ServerName)
+	}
+}
+
+func TestRedisTLSConfig_Options(t *testing.T) {
+	t.Setenv("REDIS_USE_TLS", "TRUE") // case-insensitive
+	t.Setenv("REDIS_TLS_SERVER_NAME", "redis.example.com")
+	t.Setenv("REDIS_TLS_INSECURE_SKIP_VERIFY", "true")
+
+	cfg := RedisTLSConfig()
+	if cfg == nil {
+		t.Fatal("expected non-nil tls.Config")
+	}
+	if !cfg.InsecureSkipVerify {
+		t.Error("expected InsecureSkipVerify=true when opted in")
+	}
+	if cfg.ServerName != "redis.example.com" {
+		t.Errorf("expected ServerName redis.example.com, got %q", cfg.ServerName)
+	}
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -52,6 +52,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/application/service/file"
 	memoryService "github.com/Tencent/WeKnora/internal/application/service/memory"
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
+	"github.com/Tencent/WeKnora/internal/common"
 	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/database"
 	"github.com/Tencent/WeKnora/internal/datasource"
@@ -439,10 +440,11 @@ func initRedisClient() (*redis.Client, error) {
 	}
 
 	client := redis.NewClient(&redis.Options{
-		Addr:     redisAddr,
-		Username: os.Getenv("REDIS_USERNAME"),
-		Password: os.Getenv("REDIS_PASSWORD"),
-		DB:       db,
+		Addr:      redisAddr,
+		Username:  os.Getenv("REDIS_USERNAME"),
+		Password:  os.Getenv("REDIS_PASSWORD"),
+		DB:        db,
+		TLSConfig: common.RedisTLSConfig(),
 	})
 
 	_, err = client.Ping(context.Background()).Result()

--- a/internal/router/task.go
+++ b/internal/router/task.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Tencent/WeKnora/internal/application/service"
+	"github.com/Tencent/WeKnora/internal/common"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/middleware/asynqdl"
 	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
@@ -73,6 +74,7 @@ func getAsynqRedisClientOpt() *asynq.RedisClientOpt {
 		// WriteTimeout slightly larger to absorb head-of-line stalls.
 		WriteTimeout: time.Duration(timeoutMs*2) * time.Millisecond,
 		DB:           db,
+		TLSConfig:    common.RedisTLSConfig(),
 	}
 	return opt
 }

--- a/internal/stream/redis_manager.go
+++ b/internal/stream/redis_manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Tencent/WeKnora/internal/common"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"github.com/redis/go-redis/v9"
 )
@@ -22,10 +23,11 @@ func NewRedisStreamManager(redisAddr, redisUsername, redisPassword string,
 	redisDB int, prefix string, ttl time.Duration,
 ) (*RedisStreamManager, error) {
 	client := redis.NewClient(&redis.Options{
-		Addr:     redisAddr,
-		Username: redisUsername,
-		Password: redisPassword,
-		DB:       redisDB,
+		Addr:      redisAddr,
+		Username:  redisUsername,
+		Password:  redisPassword,
+		DB:        redisDB,
+		TLSConfig: common.RedisTLSConfig(),
 	})
 
 	// Verify connection


### PR DESCRIPTION
<!-- Title: feat(redis): support TLS for Redis connections -->

## Description

Managed Redis offerings — AWS ElastiCache (in-transit encryption), Azure Cache for Redis, GCP Memorystore, Redis Cloud — frequently require or recommend TLS. WeKnora currently constructs every Redis client with plaintext options, so it cannot connect to a TLS-only Redis endpoint.

This PR adds an **opt-in, backward-compatible** TLS layer for Redis, applied consistently at all three connection points:

- `initRedisClient` (container Redis client)
- `getAsynqRedisClientOpt` (asynq task queue)
- `NewRedisStreamManager` (stream manager)

Configuration is centralized in a single helper `common.RedisTLSConfig()` and driven by environment variables (consistent with the existing `REDIS_*` config style):

| Variable | Purpose | Default |
|---|---|---|
| `REDIS_USE_TLS` | Enable TLS | `false` (unchanged behavior) |
| `REDIS_TLS_SERVER_NAME` | ServerName for verification / SNI (useful when the address is an IP) | empty |
| `REDIS_TLS_INSECURE_SKIP_VERIFY` | Skip certificate verification — **insecure, dev/self-signed only** | `false` |

**Secure by default:** when TLS is enabled the server certificate is verified and `MinVersion` is TLS 1.2; verification is only relaxed when `REDIS_TLS_INSECURE_SKIP_VERIFY` is explicitly set to `true`. When `REDIS_USE_TLS` is unset, the helper returns `nil` and connections remain plaintext — no change for existing deployments.

A follow-up could add `REDIS_TLS_CA_FILE` (custom CA bundle) for private-CA verification without skipping checks; kept out of this PR to stay focused.

## Type of Change

- [x] ✨ New feature
- [x] 🔧 Configuration / Build / CI

## Related Issue

Closes #1929

## Testing

- Added unit tests in `internal/common/redis_tls_test.go` covering: disabled by default, enabled/secure defaults (verification on, TLS 1.2), and opted-in options (server name, skip-verify). `go test ./internal/common/` passes.
- `go build ./...` and `go vet ./internal/...` pass.
- Verified backward compatibility: with `REDIS_USE_TLS` unset the helper returns `nil`, leaving connections plaintext.

## Checklist

- [x] `go fmt` / `go vet` / `go test` pass locally (`golangci-lint` not run locally; happy to address lint feedback)
- [x] Self-reviewed the code
- [x] Added tests covering the change
- [x] Updated related documentation (`.env.example`)
- [x] No breaking changes
