### PR TITLE
refactor(frontend): extract shared document action menu and card view component

### DIFF
--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -2,7 +2,6 @@
 import { ref, onMounted, onUnmounted, watch, reactive, computed, nextTick } from "vue";
 import { MessagePlugin } from "tdesign-vue-next";
 import DocContent from "@/components/doc-content.vue";
-import KnowledgeProcessingTimeline from "@/components/knowledge-processing-timeline.vue";
 import useKnowledgeBase from '@/hooks/useKnowledgeBase';
 import { useRoute, useRouter } from 'vue-router';
 import EmptyKnowledge from '@/components/empty-knowledge.vue';
@@ -40,11 +39,11 @@ import {
 import { knowledgeSpansPayloadHasTrace } from '@/utils/knowledgeTrace';
 import FAQEntryManager from './components/FAQEntryManager.vue';
 import DocumentListView from './components/DocumentListView.vue';
+import DocumentCardView from './components/DocumentCardView.vue';
 import DocumentBatchBar from './components/DocumentBatchBar.vue';
 import KbUploadSourceDropdown from './components/KbUploadSourceDropdown.vue';
 import TagEditDialog from './components/TagEditDialog.vue';
 import KbTagManageDrawer from './components/KbTagManageDrawer.vue';
-import { useTagChipsOverflow } from '@/composables/useTagChipsOverflow';
 import type { KnowledgeProcessOverrides } from '@/types/knowledgeProcess';
 import { useUploadConfirmStore, type UploadConfirmResult } from '@/stores/uploadConfirm';
 import WikiBrowser from './wiki/WikiBrowser.vue';
@@ -56,8 +55,6 @@ import {
 } from './wikiStatusRefresh';
 import { listMoveTargets, moveKnowledge, getKnowledgeMoveProgress } from '@/api/knowledge-base';
 import { useI18n } from 'vue-i18n';
-import { formatStringDate } from '@/utils';
-import { formatFileSize } from '@/utils/files';
 import { useMarqueeSelect } from '@/hooks/useMarqueeSelect';
 import type { ParserEngineInfo } from '@/api/system';
 const route = useRoute();
@@ -335,17 +332,6 @@ function isParseInFlight(status?: string): boolean {
   return isKnowledgeParseInFlight(status);
 }
 
-// Status line shown on the card body while parse is still in flight.
-function inFlightCardStatusText(item: KnowledgeCard): string {
-  if (item.parse_status === 'finalizing') {
-    if (item.summary_status === 'pending' || item.summary_status === 'processing') {
-      return t('knowledgeBase.generatingSummary');
-    }
-    return t('knowledgeBase.statusFinalizing');
-  }
-  return t('knowledgeBase.parsingInProgress');
-}
-
 function isTraceMenuVisible(item: KnowledgeCard): boolean {
   if (!item?.id) return false;
   if (isParseInFlight(item.parse_status)) {
@@ -374,7 +360,6 @@ async function probeTraceAvailable(item: KnowledgeCard) {
 }
 
 const onCardMoreVisibleChange = (visible: boolean, item: KnowledgeCard) => {
-  onVisibleChange(visible);
   if (visible) {
     probeTraceAvailable(item);
   }
@@ -631,13 +616,6 @@ const isTagFilterActive = (tagId: string) => selectedTagIds.value.includes(tagId
 const tagEditDialogVisible = ref(false);
 const tagEditTarget = ref<KnowledgeCard | null>(null);
 
-const {
-  setupTagChipsObserver,
-  getTagLimit,
-  hasTagOverflow,
-  getOverflowCount,
-} = useTagChipsOverflow('tagItemId');
-
 function openTagEditDialog(item: KnowledgeCard) {
   tagEditTarget.value = item;
   tagEditDialogVisible.value = true;
@@ -661,43 +639,6 @@ const getTagName = (tagId?: string | number) => {
   const key = String(tagId);
   return tagMap.value[key]?.name || '';
 };
-
-const formatDocTime = (time?: string) => {
-  if (!time) return '--'
-  const formatted = formatStringDate(new Date(time))
-  return formatted.slice(2, 16) // "YY-MM-DD HH:mm"
-}
-
-const channelLabelMap: Record<string, string> = {
-  web: 'knowledgeBase.channelWeb',
-  api: 'knowledgeBase.channelApi',
-  browser_extension: 'knowledgeBase.channelBrowserExtension',
-  wechat: 'knowledgeBase.channelWechat',
-  wecom: 'knowledgeBase.channelWecom',
-  feishu: 'knowledgeBase.channelFeishu',
-  dingtalk: 'knowledgeBase.channelDingtalk',
-  slack: 'knowledgeBase.channelSlack',
-  im: 'knowledgeBase.channelIm',
-};
-
-const getChannelLabel = (channel: string) => {
-  const key = channelLabelMap[channel];
-  return key ? t(key) : t('knowledgeBase.channelUnknown');
-};
-
-// 获取知识条目的显示类型
-const getKnowledgeType = (item: any) => {
-  if (item.type === 'url') {
-    return t('knowledgeBase.typeURL') || 'URL';
-  }
-  if (item.type === 'manual') {
-    return t('knowledgeBase.typeManual');
-  }
-  if (item.file_type) {
-    return item.file_type.toUpperCase();
-  }
-  return '--';
-}
 
 const loadKnowledgeFiles = (kbIdValue: string): Promise<void> => {
   if (!kbIdValue) return Promise.resolve();
@@ -1224,132 +1165,6 @@ const openCardDetails = (item: KnowledgeCard) => {
 const openSourceDoc = (knowledgeId: string) => {
   isCardDetails.value = true;
   getCardDetails({ id: knowledgeId });
-};
-
-// 悬停知识卡片时显示详情气泡（基于卡片位置定位）
-const hoveredCardItem = ref<KnowledgeCard | null>(null);
-const cardPopoverPos = ref({ x: 0, y: 0 });
-const CARD_POPOVER_OFFSET = 12;
-const CARD_POPOVER_ESTIMATED_WIDTH = 360;
-const CARD_POPOVER_ESTIMATED_HEIGHT = 300;
-const cardHoverShowDelay = 300;
-let cardHoverTimer: ReturnType<typeof setTimeout> | null = null;
-let cardPopoverElement: HTMLElement | null = null;
-
-// 根据卡片位置计算气泡位置（优先右侧，自动避开边界）
-const calculatePopoverPositionFromCard = (cardElement: HTMLElement): { x: number; y: number } => {
-  const cardRect = cardElement.getBoundingClientRect();
-  const viewportWidth = window.innerWidth;
-  const viewportHeight = window.innerHeight;
-
-  // 获取实际气泡尺寸
-  let popoverWidth = CARD_POPOVER_ESTIMATED_WIDTH;
-  let popoverHeight = CARD_POPOVER_ESTIMATED_HEIGHT;
-
-  if (cardPopoverElement) {
-    const rect = cardPopoverElement.getBoundingClientRect();
-    if (rect.width > 0) popoverWidth = rect.width;
-    if (rect.height > 0) popoverHeight = rect.height;
-  }
-
-  let x = 0;
-  let y = 0;
-
-  // 策略1：优先尝试放在卡片右侧
-  const rightX = cardRect.right + CARD_POPOVER_OFFSET;
-  if (rightX + popoverWidth <= viewportWidth - 10) {
-    x = rightX;
-    y = cardRect.top;
-    // 确保不超出底部
-    if (y + popoverHeight > viewportHeight - 10) {
-      y = viewportHeight - popoverHeight - 10;
-    }
-    // 确保不超出顶部
-    y = Math.max(10, y);
-    return { x, y };
-  }
-
-  // 策略2：尝试放在卡片左侧
-  const leftX = cardRect.left - popoverWidth - CARD_POPOVER_OFFSET;
-  if (leftX >= 10) {
-    x = leftX;
-    y = cardRect.top;
-    // 确保不超出底部
-    if (y + popoverHeight > viewportHeight - 10) {
-      y = viewportHeight - popoverHeight - 10;
-    }
-    // 确保不超出顶部
-    y = Math.max(10, y);
-    return { x, y };
-  }
-
-  // 策略3：尝试放在卡片下方
-  const bottomY = cardRect.bottom + CARD_POPOVER_OFFSET;
-  if (bottomY + popoverHeight <= viewportHeight - 10) {
-    y = bottomY;
-    x = cardRect.left;
-    // 确保不超出右边界
-    if (x + popoverWidth > viewportWidth - 10) {
-      x = viewportWidth - popoverWidth - 10;
-    }
-    // 确保不超出左边界
-    x = Math.max(10, x);
-    return { x, y };
-  }
-
-  // 策略4：放在卡片上方
-  const topY = cardRect.top - popoverHeight - CARD_POPOVER_OFFSET;
-  y = Math.max(10, topY);
-  x = cardRect.left;
-  // 确保不超出右边界
-  if (x + popoverWidth > viewportWidth - 10) {
-    x = viewportWidth - popoverWidth - 10;
-  }
-  // 确保不超出左边界
-  x = Math.max(10, x);
-
-  return { x, y };
-};
-
-const onCardMouseEnter = (ev: MouseEvent, item: KnowledgeCard) => {
-  if (cardHoverTimer) {
-    clearTimeout(cardHoverTimer);
-    cardHoverTimer = null;
-  }
-
-  const cardElement = (ev.currentTarget as HTMLElement);
-
-  cardHoverTimer = setTimeout(() => {
-    cardHoverTimer = null;
-    hoveredCardItem.value = item;
-
-    // 基于卡片位置计算气泡位置
-    const pos = calculatePopoverPositionFromCard(cardElement);
-    cardPopoverPos.value = pos;
-
-    // 获取实际元素后精确计算
-    nextTick(() => {
-      cardPopoverElement = document.querySelector('.knowledge-card-hover-popover') as HTMLElement;
-      if (cardPopoverElement) {
-        const refinedPos = calculatePopoverPositionFromCard(cardElement);
-        cardPopoverPos.value = refinedPos;
-      }
-    });
-  }, cardHoverShowDelay);
-};
-
-// 鼠标在卡片上移动时不更新气泡位置
-const onCardMouseMove = (ev: MouseEvent) => {
-  // 保持气泡固定在卡片旁边
-};
-
-const onCardMouseLeave = () => {
-  if (cardHoverTimer) {
-    clearTimeout(cardHoverTimer);
-    cardHoverTimer = null;
-  }
-  hoveredCardItem.value = null;
-  cardPopoverElement = null;
 };
 
 const closeCardMoreMenu = (index: number) => {
@@ -1989,14 +1804,6 @@ const openKnowledgeItem = (item: KnowledgeCard) => {
   openCardDetails(item);
 };
 
-const onCardClick = (item: KnowledgeCard) => {
-  if (batchMode.value) {
-    onCardGridCheckboxChange(item.id, !selectedIds.value.has(item.id));
-    return;
-  }
-  openKnowledgeItem(item);
-};
-
 const confirmBatchDelete = async () => {
   if (batchDeleting.value || batchReparsing.value || selectedIds.value.size === 0) return;
   const ids = Array.from(selectedIds.value);
@@ -2040,9 +1847,27 @@ const confirmCancelParseKnowledge = async (item: KnowledgeCard) => {
   }
 };
 
+// Bridge card-view actions back to existing per-card handlers.
+const handleCardAction = (
+  action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'delete' | 'view-trace' | 'batch-manage',
+  item: KnowledgeCard,
+) => {
+  const idx = (cardList.value || []).findIndex((i: KnowledgeCard) => i.id === item.id);
+  if (action === 'edit') return handleManualEdit(idx, item);
+  if (action === 'reparse') {
+    if (isParseInFlight(item.parse_status)) return onReparseMenuClick(idx, item);
+    return confirmRebuildKnowledge(idx, item);
+  }
+  if (action === 'cancel-parse') return confirmCancelParseKnowledge(item);
+  if (action === 'move') return handleMoveKnowledge(item);
+  if (action === 'delete') return confirmDeleteKnowledge(idx, item);
+  if (action === 'view-trace') return handleViewTrace(idx, item);
+  if (action === 'batch-manage') return handleEnterBatchFromCard(item);
+};
+
 // Bridge list-view actions back to existing per-card handlers.
 const handleListAction = (
-  action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'delete',
+  action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'delete' | 'view-trace' | 'batch-manage',
   item: KnowledgeCard,
 ) => {
   const idx = (cardList.value || []).findIndex((i: KnowledgeCard) => i.id === item.id);
@@ -2051,6 +1876,8 @@ const handleListAction = (
   if (action === 'cancel-parse') return confirmCancelParseKnowledge(item);
   if (action === 'move') return handleMoveKnowledge(item);
   if (action === 'delete') return confirmDeleteKnowledge(idx, item);
+  if (action === 'view-trace') return handleViewTrace(idx, item);
+  if (action === 'batch-manage') return handleEnterBatchFromCard(item);
 };
 
 // Clear selection on filter/tag/kb change to avoid acting on hidden items.
@@ -2397,314 +2224,50 @@ async function createNewSession(value: string): Promise<void> {
                   </div>
                 </div>
                 <template v-else-if="cardList.length && viewMode === 'grid'">
-                  <div class="doc-card-list doc-card-list-animated">
-                    <!-- 现有文档卡片 -->
-                    <div class="knowledge-card"
-                      :class="{ 'is-selected': selectedIds.has(item.id), 'batch-mode': batchMode }"
-                      :data-select-id="item.id" v-for="(item, index) in cardList" :key="item.id"
-                      @click="onCardClick(item)" @mouseenter="onCardMouseEnter($event, item)"
-                      @mousemove="onCardMouseMove($event)" @mouseleave="onCardMouseLeave">
-                      <div class="card-content">
-                        <div class="card-content-nav">
-                          <div v-if="canEdit && batchMode" class="card-nav-check" @click.stop>
-                            <t-checkbox class="card-select-checkbox" size="small" :checked="selectedIds.has(item.id)"
-                              :title="item.file_name"
-                              @change="(checked: boolean, ctx?: { e?: Event }) => onCardGridCheckboxChange(item.id, checked, ctx)" />
-                          </div>
-                          <span class="card-content-title" :title="item.file_name">{{ item.file_name }}</span>
-                          <t-popup v-if="canEdit" v-model="item.isMore" overlayClassName="card-more"
-                            :on-visible-change="(v: boolean) => onCardMoreVisibleChange(v, item)" trigger="click"
-                            destroy-on-close placement="bottom-right">
-                            <div variant="outline" class="more-wrap" @click.stop="openMore(index)"
-                              :class="[moreIndex == index ? 'active-more' : '']">
-                              <img class="more-icon" src="@/assets/img/more.png" alt="" />
-                            </div>
-                            <template #content>
-                              <!-- Normal menu -->
-                              <div v-if="moveMenuMode === 'normal'" class="card-menu">
-                                <div v-if="item.type === 'manual'" class="card-menu-item"
-                                  @click.stop="handleManualEdit(index, item)">
-                                  <t-icon class="icon" name="edit" />
-                                  <span>{{ t('knowledgeBase.editDocument') }}</span>
-                                </div>
-                                <div v-if="isTraceMenuVisible(item)" class="card-menu-item"
-                                  @click.stop="handleViewTrace(index, item)">
-                                  <t-icon class="icon" name="chart-bar" />
-                                  <span>{{ t('knowledgeStages.viewTrace') }}</span>
-                                </div>
-                                <div v-if="isParseInFlight(item.parse_status)" class="card-menu-item"
-                                  @click.stop="onReparseMenuClick(index, item)">
-                                  <t-icon class="icon" name="refresh" />
-                                  <span>{{ t('knowledgeBase.rebuildDocument') }}</span>
-                                </div>
-                                <div v-else class="card-menu-item" @click.stop="confirmRebuildKnowledge(index, item)">
-                                  <t-icon class="icon" name="refresh" />
-                                  <span>{{ t('knowledgeBase.rebuildDocument') }}</span>
-                                </div>
-                                <t-popconfirm v-if="isParseInFlight(item.parse_status)" theme="warning"
-                                  :content="t('knowledgeBase.cancelParseConfirmBody', { title: item.file_name || item.title || item.id })"
-                                  :confirm-btn="{ content: t('knowledgeBase.cancelParse'), theme: 'danger' }"
-                                  :cancel-btn="{ content: t('common.cancel') }" placement="left"
-                                  @confirm="confirmCancelParseKnowledge(item)">
-                                  <div class="card-menu-item danger" @click.stop>
-                                    <t-icon class="icon" name="close-circle" />
-                                    <span>{{ t('knowledgeBase.cancelParse') }}</span>
-                                  </div>
-                                </t-popconfirm>
-                                <div v-if="canMutateKnowledge" class="card-menu-item"
-                                  @click.stop="handleMoveKnowledge(item)">
-                                  <t-icon class="icon" name="swap" />
-                                  <span>{{ t('knowledgeBase.moveDocument') }}</span>
-                                </div>
-                                <div v-if="canMutateKnowledge" class="card-menu-item"
-                                  @click.stop="handleEnterBatchFromCard(item)">
-                                  <t-icon class="icon" name="queue" />
-                                  <span>{{ t('menu.batchManage') }}</span>
-                                </div>
-                                <t-popconfirm theme="warning"
-                                  :content="t('knowledgeBase.confirmDeleteDocument', { fileName: item.file_name || '' })"
-                                  :confirm-btn="{ content: t('knowledgeBase.confirmDelete'), theme: 'danger' }"
-                                  :cancel-btn="{ content: t('common.cancel') }" placement="left"
-                                  @confirm="confirmDeleteKnowledge(index, item)">
-                                  <div class="card-menu-item danger" @click.stop>
-                                    <t-icon class="icon" name="delete" />
-                                    <span>{{ t('knowledgeBase.deleteDocument') }}</span>
-                                  </div>
-                                </t-popconfirm>
-                              </div>
-
-                              <!-- Move: target KB list -->
-                              <div v-else-if="moveMenuMode === 'targets'" class="card-menu move-menu">
-                                <div class="move-menu-header" @click.stop="handleMoveBack">
-                                  <t-icon name="chevron-left" size="16px" />
-                                  <span>{{ t('knowledgeBase.moveToKnowledgeBase') }}</span>
-                                </div>
-                                <div v-if="moveTargetsLoading" class="move-menu-loading">
-                                  <t-loading size="small" />
-                                </div>
-                                <div v-else-if="moveTargetKbs.length === 0" class="move-menu-empty">
-                                  {{ t('knowledgeBase.moveNoTargets') }}
-                                </div>
-                                <template v-else>
-                                  <div v-for="kb in moveTargetKbs" :key="kb.id" class="card-menu-item"
-                                    @click.stop="handleMoveSelectTarget(kb)">
-                                    <t-icon class="icon" name="root-list" />
-                                    <span class="move-target-name">{{ kb.name }}</span>
-                                    <span v-if="kb.knowledge_count !== undefined" class="move-target-count">{{
-                                      kb.knowledge_count }}</span>
-                                  </div>
-                                </template>
-                              </div>
-
-                              <!-- Move: confirm with mode selection -->
-                              <div v-else-if="moveMenuMode === 'confirm'" class="card-menu move-menu">
-                                <div class="move-menu-header" @click.stop="handleMoveBack">
-                                  <t-icon name="chevron-left" size="16px" />
-                                  <span>{{ t('knowledgeBase.moveConfirmTitle') }}</span>
-                                </div>
-                                <div class="move-confirm-body">
-                                  <div class="move-target-info">
-                                    <t-icon name="arrow-right" size="14px" />
-                                    <span>{{ moveSelectedTargetName }}</span>
-                                  </div>
-                                  <div class="move-mode-item" :class="{ active: moveMode === 'reuse_vectors' }"
-                                    @click.stop="moveMode = 'reuse_vectors'">
-                                    <t-radio :checked="moveMode === 'reuse_vectors'" />
-                                    <div class="move-mode-text">
-                                      <span class="move-mode-label">{{ t('knowledgeBase.moveModeReuseVectors') }}</span>
-                                      <span class="move-mode-desc">{{ t('knowledgeBase.moveModeReuseVectorsDesc')
-                                        }}</span>
-                                    </div>
-                                  </div>
-                                  <div class="move-mode-item" :class="{ active: moveMode === 'reparse' }"
-                                    @click.stop="moveMode = 'reparse'">
-                                    <t-radio :checked="moveMode === 'reparse'" />
-                                    <div class="move-mode-text">
-                                      <span class="move-mode-label">{{ t('knowledgeBase.moveModeReparse') }}</span>
-                                      <span class="move-mode-desc">{{ t('knowledgeBase.moveModeReparseDesc') }}</span>
-                                    </div>
-                                  </div>
-                                  <div class="move-confirm-actions">
-                                    <t-button size="small" variant="outline" @click.stop="handleMoveBack">{{
-                                      t('common.cancel') }}</t-button>
-                                    <t-button size="small" theme="primary" :loading="moveSubmitting"
-                                      @click.stop="handleMoveConfirm">{{
-                                        t('knowledgeBase.moveConfirm') }}</t-button>
-                                  </div>
-                                </div>
-                              </div>
-                            </template>
-                          </t-popup>
-                        </div>
-                        <div v-if="isParseInFlight(item.parse_status)" class="card-analyze card-analyze-trace">
-                          <t-icon name="loading" class="card-analyze-loading"></t-icon>
-                          <span class="card-analyze-txt card-analyze-trace-link" role="button" tabindex="0"
-                            :title="t('knowledgeStages.viewTrace')" @click.stop="handleViewTrace(index, item)"
-                            @keydown.enter.stop="handleViewTrace(index, item)"
-                            @keydown.space.prevent.stop="handleViewTrace(index, item)">{{
-                              inFlightCardStatusText(item) }}</span>
-                          <button type="button" class="card-analyze-trace-btn" :title="t('knowledgeStages.viewTrace')"
-                            :aria-label="t('knowledgeStages.viewTrace')" @click.stop="handleViewTrace(index, item)">
-                            <t-icon name="chart-line" />
-                          </button>
-                        </div>
-                        <div v-else-if="item.parse_status === 'failed'" class="card-analyze failure card-analyze-trace">
-                          <t-icon name="close-circle" class="card-analyze-loading failure"></t-icon>
-                          <span class="card-analyze-txt failure card-analyze-trace-link" role="button" tabindex="0"
-                            :title="t('knowledgeStages.viewTrace')" @click.stop="handleViewTrace(index, item)"
-                            @keydown.enter.stop="handleViewTrace(index, item)"
-                            @keydown.space.prevent.stop="handleViewTrace(index, item)">{{
-                              t('knowledgeBase.parsingFailed') }}</span>
-                          <button type="button" class="card-analyze-trace-btn" :title="t('knowledgeStages.viewTrace')"
-                            :aria-label="t('knowledgeStages.viewTrace')" @click.stop="handleViewTrace(index, item)">
-                            <t-icon name="chart-bar" />
-                          </button>
-                        </div>
-                        <div v-else-if="item.parse_status === 'draft'" class="card-draft">
-                          <t-tag size="small" theme="warning" variant="light-outline">{{ t('knowledgeBase.draft')
-                            }}</t-tag>
-                          <span class="card-draft-tip">{{ t('knowledgeBase.draftTip') }}</span>
-                        </div>
-                        <div
-                          v-else-if="item.parse_status === 'completed' && (item.summary_status === 'pending' || item.summary_status === 'processing')"
-                          class="card-analyze">
-                          <t-icon name="loading" class="card-analyze-loading"></t-icon>
-                          <span class="card-analyze-txt">{{ t('knowledgeBase.generatingSummary') }}</span>
-                        </div>
-                        <div v-else-if="item.parse_status === 'completed'" class="card-content-txt">
-                          {{ item.description }}
-                        </div>
-                      </div>
-                      <div class="card-bottom">
-                        <span class="card-time">{{ formatDocTime(item.updated_at) }}</span>
-                        <div class="card-bottom-right">
-                          <div v-if="tagList.length" class="card-tag-selector" @click.stop>
-                            <!-- 可编辑模式：点击打开弹窗 -->
-                            <template v-if="canEdit">
-                              <template v-if="(item.tags || []).length > 0">
-                                <t-tooltip v-if="hasTagOverflow(item.id, (item.tags || []).length)"
-                                  :content="(item.tags || []).map((t: any) => t.name).join(', ')" placement="top">
-                                  <div class="card-tag-chips"
-                                    :ref="(el: any) => setupTagChipsObserver(el, item.id, (item.tags || []).length)"
-                                    @click="openTagEditDialog(item)">
-                                    <t-tag v-for="tag in (item.tags || []).slice(0, getTagLimit(item.id))" :key="tag.id"
-                                      size="small" variant="light-outline" class="card-tag-chip">
-                                      <span class="tag-text">{{ tag.name }}</span>
-                                    </t-tag>
-                                    <span class="card-tag-overflow">+{{ getOverflowCount(item.id, (item.tags ||
-                                      []).length) }}</span>
-                                  </div>
-                                </t-tooltip>
-                                <div v-else class="card-tag-chips"
-                                  :ref="(el: any) => setupTagChipsObserver(el, item.id, (item.tags || []).length)"
-                                  @click="openTagEditDialog(item)">
-                                  <t-tag v-for="tag in (item.tags || []).slice(0, getTagLimit(item.id))" :key="tag.id"
-                                    size="small" variant="light-outline" class="card-tag-chip">
-                                    <span class="tag-text">{{ tag.name }}</span>
-                                  </t-tag>
-                                </div>
-                              </template>
-                              <span v-else class="card-tag-add" @click="openTagEditDialog(item)">
-                                <t-icon name="add" size="12px" />
-                                <span>{{ t('knowledgeBase.tagLabel') }}</span>
-                              </span>
-                            </template>
-                            <!-- 只读模式 -->
-                            <template v-else-if="(item.tags || []).length > 0">
-                              <t-tooltip v-if="hasTagOverflow(item.id, (item.tags || []).length)"
-                                :content="(item.tags || []).map((t: any) => t.name).join(', ')" placement="top">
-                                <div class="card-tag-chips"
-                                  :ref="(el: any) => setupTagChipsObserver(el, item.id, (item.tags || []).length)">
-                                  <t-tag v-for="tag in (item.tags || []).slice(0, getTagLimit(item.id))" :key="tag.id"
-                                    size="small" variant="light-outline" class="card-tag-chip">
-                                    <span class="tag-text">{{ tag.name }}</span>
-                                  </t-tag>
-                                  <span class="card-tag-overflow">+{{ getOverflowCount(item.id, (item.tags ||
-                                    []).length) }}</span>
-                                </div>
-                              </t-tooltip>
-                              <div v-else class="card-tag-chips"
-                                :ref="(el: any) => setupTagChipsObserver(el, item.id, (item.tags || []).length)">
-                                <t-tag v-for="tag in (item.tags || []).slice(0, getTagLimit(item.id))" :key="tag.id"
-                                  size="small" variant="light-outline" class="card-tag-chip">
-                                  <span class="tag-text">{{ tag.name }}</span>
-                                </t-tag>
-                              </div>
-                            </template>
-                          </div>
-                          <div class="card-type">
-                            <span>{{ getKnowledgeType(item) }}</span>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <!-- 悬停卡片时跟随鼠标的详情气泡 -->
-                  <Teleport to="body">
-                    <div v-show="hoveredCardItem" class="knowledge-card-hover-popover"
-                      :style="{ left: cardPopoverPos.x + 'px', top: cardPopoverPos.y + 'px' }">
-                      <template v-if="hoveredCardItem">
-                        <div class="card-popover-title">{{ hoveredCardItem.file_name }}</div>
-                        <div v-if="isParseInFlight(hoveredCardItem.parse_status)" class="card-popover-status parsing">
-                          <KnowledgeProcessingTimeline :knowledge-id="hoveredCardItem.id"
-                            :parse-status="hoveredCardItem.parse_status" :auto-poll="false" :compact="true" />
-                        </div>
-                        <div v-else-if="hoveredCardItem.parse_status === 'failed'" class="card-popover-status failure">
-                          <KnowledgeProcessingTimeline :knowledge-id="hoveredCardItem.id"
-                            :parse-status="hoveredCardItem.parse_status" :auto-poll="false" :compact="true" />
-                        </div>
-                        <div v-else-if="hoveredCardItem.parse_status === 'draft'" class="card-popover-status draft">
-                          {{ t('knowledgeBase.draft') }}
-                        </div>
-                        <template v-else>
-                          <div v-if="hoveredCardItem.description" class="card-popover-desc">{{
-                            hoveredCardItem.description }}</div>
-                          <div v-if="(hoveredCardItem as any).source" class="card-popover-source"
-                            :title="(hoveredCardItem as any).source">
-                            <t-icon name="link" size="12px" /> {{ (hoveredCardItem as any).source }}
-                          </div>
-                          <div class="card-popover-extra">
-                            <span v-if="(hoveredCardItem as any).created_at" class="card-popover-created">
-                              {{ t('knowledgeBase.createdAt') }}：{{ formatDocTime((hoveredCardItem as any).created_at)
-                              }}
-                            </span>
-                            <span v-if="formatFileSize((hoveredCardItem as any).file_size)" class="card-popover-size">
-                              {{ formatFileSize((hoveredCardItem as any).file_size) }}
-                            </span>
-                          </div>
-                        </template>
-                        <div class="card-popover-meta">
-                          <span class="card-popover-time">{{ t('knowledgeBase.updatedAt') }}：{{
-                            formatDocTime(hoveredCardItem.updated_at)
-                            }}</span>
-                          <span v-if="(hoveredCardItem as any).channel && (hoveredCardItem as any).channel !== 'web'"
-                            class="card-popover-channel">{{ getChannelLabel((hoveredCardItem as any).channel) }}</span>
-                          <div
-                            v-if="(hoveredCardItem as any).tags && (hoveredCardItem as any).tags.length > 0"
-                            class="card-popover-tags"
-                          >
-                            <t-tag
-                              v-for="tag in (hoveredCardItem as any).tags"
-                              :key="tag.id"
-                              size="small"
-                              variant="light-outline"
-                              class="card-popover-tag-chip"
-                            >
-                              <span class="tag-text">{{ tag.name }}</span>
-                            </t-tag>
-                          </div>
-                          <span class="card-popover-type">{{ getKnowledgeType(hoveredCardItem) }}</span>
-                        </div>
-                        <div class="card-popover-hint">{{ t('knowledgeBase.clickToViewFull') }}</div>
-                      </template>
-                    </div>
-                  </Teleport>
+                  <DocumentCardView
+                    :items="cardList"
+                    :selected-ids="selectedIds"
+                    :batch-mode="batchMode"
+                    :can-edit="canEdit"
+                    :can-mutate-knowledge="canMutateKnowledge"
+                    :trace-available-by-id="traceAvailableById"
+                    :tag-list="tagList"
+                    :move-menu-mode="moveMenuMode"
+                    :move-target-kbs="moveTargetKbs"
+                    :move-targets-loading="moveTargetsLoading"
+                    :move-selected-target-name="moveSelectedTargetName"
+                    :move-mode="moveMode"
+                    :move-submitting="moveSubmitting"
+                    @open="(item: any) => openKnowledgeItem(item)"
+                    @toggle-checkbox="onCardGridCheckboxChange"
+                    @menu-visible-change="(visible: boolean, item: any) => onCardMoreVisibleChange(visible, item)"
+                    @action="(action: any, item: any) => handleCardAction(action, item)"
+                    @tag-edit="(item: any) => openTagEditDialog(item)"
+                    @move-select-target="(kb: any) => handleMoveSelectTarget(kb)"
+                    @move-back="handleMoveBack"
+                    @move-confirm="handleMoveConfirm"
+                    @update:move-mode="(mode: any) => moveMode = mode"
+                  />
                 </template>
                 <template v-else-if="cardList.length && viewMode === 'list'">
                   <DocumentListView :items="cardList" :selected-ids="selectedIds" :tag-list="tagList"
-                    :can-edit="canEdit" @open="(item: any) => openKnowledgeItem(item)" @toggle-row="toggleSelectRow"
+                    :can-edit="canEdit" :can-mutate-knowledge="canMutateKnowledge"
+                    :trace-visible-ids="traceAvailableById"
+                    :move-menu-mode="moveMenuMode"
+                    :move-target-kbs="moveTargetKbs"
+                    :move-targets-loading="moveTargetsLoading"
+                    :move-selected-target-name="moveSelectedTargetName"
+                    :move-mode="moveMode"
+                    :move-submitting="moveSubmitting"
+                    @open="(item: any) => openKnowledgeItem(item)" @toggle-row="toggleSelectRow"
                     @toggle-all="toggleSelectAll" @action="(action: any, item: any) => handleListAction(action, item)"
-                    @tag-edit="(item: any) => openTagEditDialog(item)" />
+                    @probe-trace="(item: any) => probeTraceAvailable(item)"
+                    @tag-edit="(item: any) => openTagEditDialog(item)"
+                    @move-select-target="(kb: any) => handleMoveSelectTarget(kb)"
+                    @move-back="handleMoveBack"
+                    @move-confirm="handleMoveConfirm"
+                    @update:move-mode="(mode: any) => moveMode = mode"
+                    @reset-move-state="moveMenuMode = 'normal'" />
                 </template>
                 <template v-else-if="!docListLoading">
                   <div class="doc-empty-state">

--- a/frontend/src/views/knowledge/components/DocumentActionMenu.vue
+++ b/frontend/src/views/knowledge/components/DocumentActionMenu.vue
@@ -1,0 +1,173 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+interface KnowledgeItem {
+  id: string;
+  file_name?: string;
+  title?: string;
+  type?: string;
+  parse_status?: string;
+}
+
+const props = defineProps<{
+  item: KnowledgeItem;
+  canMutateKnowledge: boolean;
+  traceVisible: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'edit'): void;
+  (e: 'view-trace'): void;
+  (e: 'reparse'): void;
+  (e: 'cancel-parse'): void;
+  (e: 'move'): void;
+  (e: 'batch-manage'): void;
+  (e: 'delete'): void;
+}>();
+
+const { t } = useI18n();
+
+const CANCELABLE_PARSE_STATUSES = new Set(['pending', 'processing', 'finalizing']);
+
+const isParseInFlight = computed(() =>
+  CANCELABLE_PARSE_STATUSES.has(String(props.item.parse_status ?? ''))
+);
+
+const fileName = computed(() => props.item.file_name || props.item.title || props.item.id);
+</script>
+
+<template>
+  <!-- 编辑文档 -->
+  <div v-if="item.type === 'manual'" class="doc-action-menu-item" @click.stop="emit('edit')">
+    <t-icon class="icon" name="edit" />
+    <span>{{ $t('knowledgeBase.editDocument') }}</span>
+  </div>
+
+  <!-- 查看处理过程 -->
+  <div v-if="traceVisible" class="doc-action-menu-item" @click.stop="emit('view-trace')">
+    <t-icon class="icon" name="chart-bar" />
+    <span>{{ $t('knowledgeStages.viewTrace') }}</span>
+  </div>
+
+  <!-- 重建知识 (in-flight: no popconfirm, just emits) -->
+  <div v-if="isParseInFlight" class="doc-action-menu-item" @click.stop="emit('reparse')">
+    <t-icon class="icon" name="refresh" />
+    <span>{{ $t('knowledgeBase.rebuildDocument') }}</span>
+  </div>
+
+  <!-- 重建知识 (normal: with popconfirm) -->
+  <t-popconfirm v-else theme="warning"
+    :content="$t('knowledgeBase.rebuildConfirm', { fileName })"
+    :confirm-btn="{ content: $t('common.confirm'), theme: 'primary' }"
+    :cancel-btn="{ content: $t('common.cancel') }" placement="left"
+    @confirm="emit('reparse')">
+    <div class="doc-action-menu-item" @click.stop>
+      <t-icon class="icon" name="refresh" />
+      <span>{{ $t('knowledgeBase.rebuildDocument') }}</span>
+    </div>
+  </t-popconfirm>
+
+  <!-- 取消解析 -->
+  <t-popconfirm v-if="isParseInFlight" theme="warning"
+    :content="$t('knowledgeBase.cancelParseConfirmBody', { title: fileName })"
+    :confirm-btn="{ content: $t('knowledgeBase.cancelParse'), theme: 'danger' }"
+    :cancel-btn="{ content: $t('common.cancel') }" placement="left"
+    @confirm="emit('cancel-parse')">
+    <div class="doc-action-menu-item danger" @click.stop>
+      <t-icon class="icon" name="close-circle" />
+      <span>{{ $t('knowledgeBase.cancelParse') }}</span>
+    </div>
+  </t-popconfirm>
+
+  <!-- 移动到... -->
+  <div v-if="canMutateKnowledge" class="doc-action-menu-item" @click.stop="emit('move')">
+    <t-icon class="icon" name="swap" />
+    <span>{{ $t('knowledgeBase.moveDocument') }}</span>
+  </div>
+
+  <!-- 批量管理 -->
+  <div v-if="canMutateKnowledge" class="doc-action-menu-item" @click.stop="emit('batch-manage')">
+    <t-icon class="icon" name="queue" />
+    <span>{{ $t('menu.batchManage') }}</span>
+  </div>
+
+  <!-- 删除文档 -->
+  <t-popconfirm theme="warning"
+    :content="$t('knowledgeBase.confirmDeleteDocument', { fileName })"
+    :confirm-btn="{ content: $t('knowledgeBase.confirmDelete'), theme: 'danger' }"
+    :cancel-btn="{ content: $t('common.cancel') }" placement="left"
+    @confirm="emit('delete')">
+    <div class="doc-action-menu-item danger" @click.stop>
+      <t-icon class="icon" name="delete" />
+      <span>{{ $t('knowledgeBase.deleteDocument') }}</span>
+    </div>
+  </t-popconfirm>
+</template>
+
+<style scoped lang="less">
+.doc-action-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--td-text-color-primary);
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background-color 0.15s cubic-bezier(0.2, 0, 0, 1), transform 0.12s ease;
+
+  &:hover {
+    background: var(--td-bg-color-container-hover);
+  }
+
+  &:active {
+    background: var(--td-bg-color-container-active);
+    transform: scale(0.98);
+  }
+
+  .icon {
+    font-size: 16px;
+    color: var(--td-text-color-secondary);
+    transition: color 0.15s ease;
+  }
+
+  &:hover .icon {
+    color: var(--td-text-color-primary);
+  }
+
+  &.danger {
+    color: var(--td-error-color-6);
+    margin-top: 4px;
+    position: relative;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: -3px;
+      left: 8px;
+      right: 8px;
+      height: 1px;
+      background: var(--td-component-stroke);
+    }
+
+    .icon {
+      color: var(--td-error-color-6);
+    }
+
+    &:hover {
+      background: var(--td-error-color-1);
+      color: var(--td-error-color-6);
+
+      .icon {
+        color: var(--td-error-color-6);
+      }
+    }
+
+    &:active {
+      background: var(--td-error-color-2);
+    }
+  }
+}
+</style>

--- a/frontend/src/views/knowledge/components/DocumentCardView.vue
+++ b/frontend/src/views/knowledge/components/DocumentCardView.vue
@@ -1,0 +1,1221 @@
+<script setup lang="ts">
+import { ref, computed, nextTick } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { formatFileSize } from '@/utils/files';
+import { useTagChipsOverflow } from '@/composables/useTagChipsOverflow';
+import DocumentActionMenu from './DocumentActionMenu.vue';
+import KnowledgeProcessingTimeline from '@/components/knowledge-processing-timeline.vue';
+
+interface Tag {
+  id: string;
+  name: string;
+  color?: string;
+}
+
+interface KnowledgeCard {
+  id: string;
+  knowledge_base_id?: string;
+  parse_status: string;
+  summary_status?: string;
+  description?: string;
+  file_name?: string;
+  original_file_name?: string;
+  display_name?: string;
+  title?: string;
+  type?: string;
+  updated_at?: string;
+  file_type?: string;
+  isMore?: boolean;
+  metadata?: any;
+  error_message?: string;
+  tags?: Array<{ id: string; name: string; color?: string }>;
+  source?: string;
+  created_at?: string;
+  file_size?: number | string;
+  channel?: string;
+}
+
+const props = defineProps<{
+  items: KnowledgeCard[];
+  selectedIds: Set<string>;
+  batchMode: boolean;
+  canEdit: boolean;
+  canMutateKnowledge: boolean;
+  traceAvailableById: Record<string, boolean>;
+  tagList: Tag[];
+  // Move sub-flow state
+  moveMenuMode: 'normal' | 'targets' | 'confirm';
+  moveTargetKbs: any[];
+  moveTargetsLoading: boolean;
+  moveSelectedTargetName: string;
+  moveMode: 'reuse_vectors' | 'reparse';
+  moveSubmitting: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'open', item: KnowledgeCard): void;
+  (e: 'toggle-checkbox', id: string, checked: boolean, ctx?: { e?: Event }): void;
+  (e: 'menu-visible-change', visible: boolean, item: KnowledgeCard): void;
+  (e: 'action', action: 'edit' | 'view-trace' | 'reparse' | 'cancel-parse' | 'move' | 'batch-manage' | 'delete', item: KnowledgeCard): void;
+  (e: 'tag-edit', item: KnowledgeCard): void;
+  // Move sub-flow emits
+  (e: 'move-select-target', kb: any): void;
+  (e: 'move-back'): void;
+  (e: 'move-confirm'): void;
+  (e: 'update:moveMode', mode: 'reuse_vectors' | 'reparse'): void;
+}>();
+
+const { t } = useI18n();
+
+const {
+  setupTagChipsObserver,
+  getTagLimit,
+  hasTagOverflow,
+  getOverflowCount,
+} = useTagChipsOverflow('tagItemId');
+
+// --- Menu index tracking ---
+const activeMenuIndex = ref(-1);
+const openMenu = (index: number) => {
+  activeMenuIndex.value = index;
+};
+const onMenuVisibleChange = (visible: boolean, item: KnowledgeCard) => {
+  if (!visible) {
+    activeMenuIndex.value = -1;
+  }
+  emit('menu-visible-change', visible, item);
+};
+
+// --- Parse status helpers ---
+const CANCELABLE_PARSE_STATUSES = new Set(['pending', 'processing', 'finalizing']);
+const isParseInFlight = (status?: string): boolean =>
+  CANCELABLE_PARSE_STATUSES.has(String(status ?? ''));
+
+const isTraceMenuVisible = (item: KnowledgeCard): boolean => {
+  if (!item?.id) return false;
+  if (isParseInFlight(item.parse_status)) return true;
+  return props.traceAvailableById[item.id] === true;
+};
+
+const inFlightCardStatusText = (item: KnowledgeCard): string => {
+  if (item.parse_status === 'finalizing') {
+    if (item.summary_status === 'pending' || item.summary_status === 'processing') {
+      return t('knowledgeBase.generatingSummary');
+    }
+    return t('knowledgeBase.statusFinalizing');
+  }
+  return t('knowledgeBase.parsingInProgress');
+};
+
+// --- Display helpers ---
+const formatDocTime = (time?: string) => {
+  if (!time) return '--';
+  const d = new Date(time);
+  if (Number.isNaN(d.getTime())) return '--';
+  const yy = String(d.getFullYear()).slice(2);
+  const MM = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${yy}-${MM}-${dd} ${hh}:${mm}`;
+};
+
+const getKnowledgeType = (item: KnowledgeCard) => {
+  if (item.type === 'url') return t('knowledgeBase.typeURL') || 'URL';
+  if (item.type === 'manual') return t('knowledgeBase.typeManual');
+  if (item.file_type) return item.file_type.toUpperCase();
+  return '--';
+};
+
+const channelLabelMap: Record<string, string> = {
+  web: 'knowledgeBase.channelWeb',
+  api: 'knowledgeBase.channelApi',
+  browser_extension: 'knowledgeBase.channelBrowserExtension',
+  wechat: 'knowledgeBase.channelWechat',
+  wecom: 'knowledgeBase.channelWecom',
+  feishu: 'knowledgeBase.channelFeishu',
+  dingtalk: 'knowledgeBase.channelDingtalk',
+  slack: 'knowledgeBase.channelSlack',
+  im: 'knowledgeBase.channelIm',
+};
+
+const getChannelLabel = (channel: string) => {
+  const key = channelLabelMap[channel];
+  return key ? t(key) : t('knowledgeBase.channelUnknown');
+};
+
+// --- Card click handler ---
+const onCardClick = (item: KnowledgeCard) => {
+  if (props.batchMode) {
+    emit('toggle-checkbox', item.id, !props.selectedIds.has(item.id));
+    return;
+  }
+  emit('open', item);
+};
+
+// --- Hover popover ---
+const hoveredCardItem = ref<KnowledgeCard | null>(null);
+const cardPopoverPos = ref({ x: 0, y: 0 });
+const CARD_POPOVER_OFFSET = 12;
+const CARD_POPOVER_ESTIMATED_WIDTH = 360;
+const CARD_POPOVER_ESTIMATED_HEIGHT = 300;
+const cardHoverShowDelay = 300;
+let cardHoverTimer: ReturnType<typeof setTimeout> | null = null;
+let cardPopoverElement: HTMLElement | null = null;
+
+const calculatePopoverPositionFromCard = (cardElement: HTMLElement): { x: number; y: number } => {
+  const cardRect = cardElement.getBoundingClientRect();
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  let popoverWidth = CARD_POPOVER_ESTIMATED_WIDTH;
+  let popoverHeight = CARD_POPOVER_ESTIMATED_HEIGHT;
+
+  if (cardPopoverElement) {
+    const rect = cardPopoverElement.getBoundingClientRect();
+    if (rect.width > 0) popoverWidth = rect.width;
+    if (rect.height > 0) popoverHeight = rect.height;
+  }
+
+  let x = 0;
+  let y = 0;
+
+  // Strategy 1: right side
+  const rightX = cardRect.right + CARD_POPOVER_OFFSET;
+  if (rightX + popoverWidth <= viewportWidth - 10) {
+    x = rightX;
+    y = cardRect.top;
+    if (y + popoverHeight > viewportHeight - 10) y = viewportHeight - popoverHeight - 10;
+    y = Math.max(10, y);
+    return { x, y };
+  }
+
+  // Strategy 2: left side
+  const leftX = cardRect.left - popoverWidth - CARD_POPOVER_OFFSET;
+  if (leftX >= 10) {
+    x = leftX;
+    y = cardRect.top;
+    if (y + popoverHeight > viewportHeight - 10) y = viewportHeight - popoverHeight - 10;
+    y = Math.max(10, y);
+    return { x, y };
+  }
+
+  // Strategy 3: below
+  const bottomY = cardRect.bottom + CARD_POPOVER_OFFSET;
+  if (bottomY + popoverHeight <= viewportHeight - 10) {
+    y = bottomY;
+    x = cardRect.left;
+    if (x + popoverWidth > viewportWidth - 10) x = viewportWidth - popoverWidth - 10;
+    x = Math.max(10, x);
+    return { x, y };
+  }
+
+  // Strategy 4: above
+  const topY = cardRect.top - popoverHeight - CARD_POPOVER_OFFSET;
+  y = Math.max(10, topY);
+  x = cardRect.left;
+  if (x + popoverWidth > viewportWidth - 10) x = viewportWidth - popoverWidth - 10;
+  x = Math.max(10, x);
+  return { x, y };
+};
+
+const onCardMouseEnter = (ev: MouseEvent, item: KnowledgeCard) => {
+  if (cardHoverTimer) {
+    clearTimeout(cardHoverTimer);
+    cardHoverTimer = null;
+  }
+  const cardElement = (ev.currentTarget as HTMLElement);
+  cardHoverTimer = setTimeout(() => {
+    cardHoverTimer = null;
+    hoveredCardItem.value = item;
+    const pos = calculatePopoverPositionFromCard(cardElement);
+    cardPopoverPos.value = pos;
+    nextTick(() => {
+      cardPopoverElement = document.querySelector('.knowledge-card-hover-popover') as HTMLElement;
+      if (cardPopoverElement) {
+        const refinedPos = calculatePopoverPositionFromCard(cardElement);
+        cardPopoverPos.value = refinedPos;
+      }
+    });
+  }, cardHoverShowDelay);
+};
+
+const onCardMouseLeave = () => {
+  if (cardHoverTimer) {
+    clearTimeout(cardHoverTimer);
+    cardHoverTimer = null;
+  }
+  hoveredCardItem.value = null;
+  cardPopoverElement = null;
+};
+
+// --- Action handlers ---
+const handleAction = (action: 'edit' | 'view-trace' | 'reparse' | 'cancel-parse' | 'move' | 'batch-manage' | 'delete', item: KnowledgeCard) => {
+  // Don't close menu for move — it triggers the sub-flow
+  if (action !== 'move') {
+    if (item.isMore !== undefined) item.isMore = false;
+    activeMenuIndex.value = -1;
+  }
+  emit('action', action, item);
+};
+</script>
+
+<template>
+  <div class="doc-card-list doc-card-list-animated">
+    <div
+      class="knowledge-card"
+      :class="{ 'is-selected': selectedIds.has(item.id), 'batch-mode': batchMode }"
+      :data-select-id="item.id"
+      v-for="(item, index) in items"
+      :key="item.id"
+      @click="onCardClick(item)"
+      @mouseenter="onCardMouseEnter($event, item)"
+      @mouseleave="onCardMouseLeave"
+    >
+      <div class="card-content">
+        <div class="card-content-nav">
+          <div v-if="canEdit && batchMode" class="card-nav-check" @click.stop>
+            <t-checkbox
+              class="card-select-checkbox"
+              size="small"
+              :checked="selectedIds.has(item.id)"
+              :title="item.file_name"
+              @change="(checked: boolean, ctx?: { e?: Event }) => emit('toggle-checkbox', item.id, checked, ctx)"
+            />
+          </div>
+          <span class="card-content-title" :title="item.file_name">{{ item.file_name }}</span>
+          <t-popup
+            v-if="canEdit"
+            v-model="item.isMore"
+            overlayClassName="card-more"
+            :on-visible-change="(v: boolean) => onMenuVisibleChange(v, item)"
+            trigger="click"
+            destroy-on-close
+            placement="bottom-right"
+          >
+            <div
+              variant="outline"
+              class="more-wrap"
+              @click.stop="openMenu(index)"
+              :class="[activeMenuIndex === index ? 'active-more' : '']"
+            >
+              <img class="more-icon" src="@/assets/img/more.png" alt="" />
+            </div>
+            <template #content>
+              <!-- Normal menu -->
+              <div v-if="moveMenuMode === 'normal'" class="card-menu">
+                <DocumentActionMenu
+                  :item="item"
+                  :can-mutate-knowledge="canMutateKnowledge"
+                  :trace-visible="isTraceMenuVisible(item)"
+                  @edit="handleAction('edit', item)"
+                  @view-trace="handleAction('view-trace', item)"
+                  @reparse="handleAction('reparse', item)"
+                  @cancel-parse="handleAction('cancel-parse', item)"
+                  @move="handleAction('move', item)"
+                  @batch-manage="handleAction('batch-manage', item)"
+                  @delete="handleAction('delete', item)"
+                />
+              </div>
+
+              <!-- Move: target KB list -->
+              <div v-else-if="moveMenuMode === 'targets'" class="card-menu move-menu">
+                <div class="move-menu-header" @click.stop="emit('move-back')">
+                  <t-icon name="chevron-left" size="16px" />
+                  <span>{{ $t('knowledgeBase.moveToKnowledgeBase') }}</span>
+                </div>
+                <div v-if="moveTargetsLoading" class="move-menu-loading">
+                  <t-loading size="small" />
+                </div>
+                <div v-else-if="moveTargetKbs.length === 0" class="move-menu-empty">
+                  {{ $t('knowledgeBase.moveNoTargets') }}
+                </div>
+                <template v-else>
+                  <div
+                    v-for="kb in moveTargetKbs"
+                    :key="kb.id"
+                    class="card-menu-item"
+                    @click.stop="emit('move-select-target', kb)"
+                  >
+                    <t-icon class="icon" name="root-list" />
+                    <span class="move-target-name">{{ kb.name }}</span>
+                    <span v-if="kb.knowledge_count !== undefined" class="move-target-count">{{ kb.knowledge_count }}</span>
+                  </div>
+                </template>
+              </div>
+
+              <!-- Move: confirm -->
+              <div v-else-if="moveMenuMode === 'confirm'" class="card-menu move-menu">
+                <div class="move-menu-header" @click.stop="emit('move-back')">
+                  <t-icon name="chevron-left" size="16px" />
+                  <span>{{ $t('knowledgeBase.moveConfirmTitle') }}</span>
+                </div>
+                <div class="move-confirm-body">
+                  <div class="move-target-info">
+                    <t-icon name="arrow-right" size="14px" />
+                    <span>{{ moveSelectedTargetName }}</span>
+                  </div>
+                  <div
+                    class="move-mode-item"
+                    :class="{ active: moveMode === 'reuse_vectors' }"
+                    @click.stop="emit('update:moveMode', 'reuse_vectors')"
+                  >
+                    <t-radio :checked="moveMode === 'reuse_vectors'" />
+                    <div class="move-mode-text">
+                      <span class="move-mode-label">{{ $t('knowledgeBase.moveModeReuseVectors') }}</span>
+                      <span class="move-mode-desc">{{ $t('knowledgeBase.moveModeReuseVectorsDesc') }}</span>
+                    </div>
+                  </div>
+                  <div
+                    class="move-mode-item"
+                    :class="{ active: moveMode === 'reparse' }"
+                    @click.stop="emit('update:moveMode', 'reparse')"
+                  >
+                    <t-radio :checked="moveMode === 'reparse'" />
+                    <div class="move-mode-text">
+                      <span class="move-mode-label">{{ $t('knowledgeBase.moveModeReparse') }}</span>
+                      <span class="move-mode-desc">{{ $t('knowledgeBase.moveModeReparseDesc') }}</span>
+                    </div>
+                  </div>
+                  <div class="move-confirm-actions">
+                    <t-button size="small" variant="outline" @click.stop="emit('move-back')">{{
+                      $t('common.cancel')
+                    }}</t-button>
+                    <t-button size="small" theme="primary" :loading="moveSubmitting" @click.stop="emit('move-confirm')">{{
+                      $t('knowledgeBase.moveConfirm')
+                    }}</t-button>
+                  </div>
+                </div>
+              </div>
+            </template>
+          </t-popup>
+        </div>
+
+        <!-- Parse status display -->
+        <div v-if="isParseInFlight(item.parse_status)" class="card-analyze card-analyze-trace">
+          <t-icon name="loading" class="card-analyze-loading"></t-icon>
+          <span
+            class="card-analyze-txt card-analyze-trace-link"
+            role="button"
+            tabindex="0"
+            :title="$t('knowledgeStages.viewTrace')"
+            @click.stop="handleAction('view-trace', item)"
+            @keydown.enter.stop="handleAction('view-trace', item)"
+            @keydown.space.prevent.stop="handleAction('view-trace', item)"
+          >{{ inFlightCardStatusText(item) }}</span>
+          <button
+            type="button"
+            class="card-analyze-trace-btn"
+            :title="$t('knowledgeStages.viewTrace')"
+            :aria-label="$t('knowledgeStages.viewTrace')"
+            @click.stop="handleAction('view-trace', item)"
+          >
+            <t-icon name="chart-line" />
+          </button>
+        </div>
+        <div v-else-if="item.parse_status === 'failed'" class="card-analyze failure card-analyze-trace">
+          <t-icon name="close-circle" class="card-analyze-loading failure"></t-icon>
+          <span
+            class="card-analyze-txt failure card-analyze-trace-link"
+            role="button"
+            tabindex="0"
+            :title="$t('knowledgeStages.viewTrace')"
+            @click.stop="handleAction('view-trace', item)"
+            @keydown.enter.stop="handleAction('view-trace', item)"
+            @keydown.space.prevent.stop="handleAction('view-trace', item)"
+          >{{ $t('knowledgeBase.parsingFailed') }}</span>
+          <button
+            type="button"
+            class="card-analyze-trace-btn"
+            :title="$t('knowledgeStages.viewTrace')"
+            :aria-label="$t('knowledgeStages.viewTrace')"
+            @click.stop="handleAction('view-trace', item)"
+          >
+            <t-icon name="chart-bar" />
+          </button>
+        </div>
+        <div v-else-if="item.parse_status === 'draft'" class="card-draft">
+          <t-tag size="small" theme="warning" variant="light-outline">{{ $t('knowledgeBase.draft') }}</t-tag>
+          <span class="card-draft-tip">{{ $t('knowledgeBase.draftTip') }}</span>
+        </div>
+        <div
+          v-else-if="item.parse_status === 'completed' && (item.summary_status === 'pending' || item.summary_status === 'processing')"
+          class="card-analyze"
+        >
+          <t-icon name="loading" class="card-analyze-loading"></t-icon>
+          <span class="card-analyze-txt">{{ $t('knowledgeBase.generatingSummary') }}</span>
+        </div>
+        <div v-else-if="item.parse_status === 'completed'" class="card-content-txt">
+          {{ item.description }}
+        </div>
+      </div>
+
+      <div class="card-bottom">
+        <span class="card-time">{{ formatDocTime(item.updated_at) }}</span>
+        <div class="card-bottom-right">
+          <div v-if="tagList.length" class="card-tag-selector" @click.stop>
+            <!-- Editable mode -->
+            <template v-if="canEdit">
+              <template v-if="(item.tags || []).length > 0">
+                <t-tooltip
+                  v-if="hasTagOverflow(item.id, (item.tags || []).length)"
+                  :content="(item.tags || []).map((t: any) => t.name).join(', ')"
+                  placement="top"
+                >
+                  <div
+                    class="card-tag-chips"
+                    :ref="(el: any) => setupTagChipsObserver(el, item.id, (item.tags || []).length)"
+                    @click="emit('tag-edit', item)"
+                  >
+                    <t-tag v-for="tag in (item.tags || []).slice(0, getTagLimit(item.id))" :key="tag.id" size="small" variant="light-outline" class="card-tag-chip">
+                      <span class="tag-text">{{ tag.name }}</span>
+                    </t-tag>
+                    <span class="card-tag-overflow">+{{ getOverflowCount(item.id, (item.tags || []).length) }}</span>
+                  </div>
+                </t-tooltip>
+                <div
+                  v-else
+                  class="card-tag-chips"
+                  :ref="(el: any) => setupTagChipsObserver(el, item.id, (item.tags || []).length)"
+                  @click="emit('tag-edit', item)"
+                >
+                  <t-tag v-for="tag in (item.tags || []).slice(0, getTagLimit(item.id))" :key="tag.id" size="small" variant="light-outline" class="card-tag-chip">
+                    <span class="tag-text">{{ tag.name }}</span>
+                  </t-tag>
+                </div>
+              </template>
+              <span v-else class="card-tag-add" @click="emit('tag-edit', item)">
+                <t-icon name="add" size="12px" />
+                <span>{{ $t('knowledgeBase.tagLabel') }}</span>
+              </span>
+            </template>
+            <!-- Read-only mode -->
+            <template v-else-if="(item.tags || []).length > 0">
+              <t-tooltip
+                v-if="hasTagOverflow(item.id, (item.tags || []).length)"
+                :content="(item.tags || []).map((t: any) => t.name).join(', ')"
+                placement="top"
+              >
+                <div
+                  class="card-tag-chips"
+                  :ref="(el: any) => setupTagChipsObserver(el, item.id, (item.tags || []).length)"
+                >
+                  <t-tag v-for="tag in (item.tags || []).slice(0, getTagLimit(item.id))" :key="tag.id" size="small" variant="light-outline" class="card-tag-chip">
+                    <span class="tag-text">{{ tag.name }}</span>
+                  </t-tag>
+                  <span class="card-tag-overflow">+{{ getOverflowCount(item.id, (item.tags || []).length) }}</span>
+                </div>
+              </t-tooltip>
+              <div
+                v-else
+                class="card-tag-chips"
+                :ref="(el: any) => setupTagChipsObserver(el, item.id, (item.tags || []).length)"
+              >
+                <t-tag v-for="tag in (item.tags || []).slice(0, getTagLimit(item.id))" :key="tag.id" size="small" variant="light-outline" class="card-tag-chip">
+                  <span class="tag-text">{{ tag.name }}</span>
+                </t-tag>
+              </div>
+            </template>
+          </div>
+          <div class="card-type">
+            <span>{{ getKnowledgeType(item) }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Hover popover -->
+  <Teleport to="body">
+    <div
+      v-show="hoveredCardItem"
+      class="knowledge-card-hover-popover"
+      :style="{ left: cardPopoverPos.x + 'px', top: cardPopoverPos.y + 'px' }"
+    >
+      <template v-if="hoveredCardItem">
+        <div class="card-popover-title">{{ hoveredCardItem.file_name }}</div>
+        <div v-if="isParseInFlight(hoveredCardItem.parse_status)" class="card-popover-status parsing">
+          <KnowledgeProcessingTimeline
+            :knowledge-id="hoveredCardItem.id"
+            :parse-status="hoveredCardItem.parse_status"
+            :auto-poll="false"
+            :compact="true"
+          />
+        </div>
+        <div v-else-if="hoveredCardItem.parse_status === 'failed'" class="card-popover-status failure">
+          <KnowledgeProcessingTimeline
+            :knowledge-id="hoveredCardItem.id"
+            :parse-status="hoveredCardItem.parse_status"
+            :auto-poll="false"
+            :compact="true"
+          />
+        </div>
+        <div v-else-if="hoveredCardItem.parse_status === 'draft'" class="card-popover-status draft">
+          {{ $t('knowledgeBase.draft') }}
+        </div>
+        <template v-else>
+          <div v-if="hoveredCardItem.description" class="card-popover-desc">{{ hoveredCardItem.description }}</div>
+          <div v-if="(hoveredCardItem as any).source" class="card-popover-source" :title="(hoveredCardItem as any).source">
+            <t-icon name="link" size="12px" /> {{ (hoveredCardItem as any).source }}
+          </div>
+          <div class="card-popover-extra">
+            <span v-if="(hoveredCardItem as any).created_at" class="card-popover-created">
+              {{ $t('knowledgeBase.createdAt') }}：{{ formatDocTime((hoveredCardItem as any).created_at) }}
+            </span>
+            <span v-if="formatFileSize((hoveredCardItem as any).file_size)" class="card-popover-size">
+              {{ formatFileSize((hoveredCardItem as any).file_size) }}
+            </span>
+          </div>
+        </template>
+        <div class="card-popover-meta">
+          <span class="card-popover-time">{{ $t('knowledgeBase.updatedAt') }}：{{ formatDocTime(hoveredCardItem.updated_at) }}</span>
+          <span
+            v-if="(hoveredCardItem as any).channel && (hoveredCardItem as any).channel !== 'web'"
+            class="card-popover-channel"
+          >{{ getChannelLabel((hoveredCardItem as any).channel) }}</span>
+          <div v-if="(hoveredCardItem as any).tags && (hoveredCardItem as any).tags.length > 0" class="card-popover-tags">
+            <t-tag
+              v-for="tag in (hoveredCardItem as any).tags"
+              :key="tag.id"
+              size="small"
+              variant="light-outline"
+              class="card-popover-tag-chip"
+            >
+              <span class="tag-text">{{ tag.name }}</span>
+            </t-tag>
+          </div>
+          <span class="card-popover-type">{{ getKnowledgeType(hoveredCardItem) }}</span>
+        </div>
+        <div class="card-popover-hint">{{ $t('knowledgeBase.clickToViewFull') }}</div>
+      </template>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped lang="less">
+@keyframes contentFadeIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.doc-card-list {
+  box-sizing: border-box;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+  align-content: flex-start;
+  width: 100%;
+
+  &.doc-card-list-animated {
+    animation: contentFadeIn 0.32s ease-out;
+  }
+}
+
+.knowledge-card {
+  min-width: 240px;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--td-component-border);
+  height: 136px;
+  border-radius: 8px;
+  overflow: hidden;
+  box-sizing: border-box;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  background: var(--td-bg-color-container);
+  position: relative;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+
+  &:hover {
+    border-color: color-mix(in srgb, var(--td-component-stroke) 55%, var(--td-brand-color));
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.07);
+  }
+
+  .card-nav-check {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 29px;
+    margin-right: 8px;
+    cursor: pointer;
+
+    .card-select-checkbox {
+      margin: 0;
+      line-height: 0;
+
+      :deep(.t-checkbox) { align-items: center; }
+      :deep(.t-checkbox__label) { display: none !important; width: 0 !important; min-width: 0 !important; margin: 0 !important; padding: 0 !important; }
+      :deep(.t-checkbox__input) { margin: 0; }
+      :deep(.t-checkbox__input-wrapper) { margin: 0; }
+    }
+  }
+
+  .card-content {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    padding: 10px 14px 8px;
+  }
+
+  .card-analyze {
+    flex-shrink: 0;
+    height: 52px;
+    display: flex;
+    align-items: flex-start;
+  }
+
+  .card-analyze-loading {
+    display: block;
+    color: var(--td-brand-color);
+    font-size: 14px;
+    margin-top: 2px;
+  }
+
+  .card-analyze-txt {
+    color: var(--td-brand-color);
+    font-family: var(--app-font-family);
+    font-size: 11px;
+    margin-left: 8px;
+  }
+
+  .card-analyze-trace {
+    height: auto;
+    min-height: 0;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .card-analyze-trace-link {
+    cursor: pointer;
+    &:hover { text-decoration: underline; }
+  }
+
+  .card-analyze-trace-btn {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    padding: 2px;
+    border: none;
+    background: transparent;
+    color: var(--td-brand-color);
+    cursor: pointer;
+    line-height: 1;
+    border-radius: 4px;
+
+    :deep(.t-icon) { font-size: 14px; }
+    &:hover { background: var(--td-bg-color-component-hover); }
+  }
+
+  .card-analyze.failure .card-analyze-trace-btn { color: var(--td-error-color); }
+
+  .failure { color: var(--td-error-color); }
+
+  .card-content-nav {
+    flex-shrink: 0;
+    display: flex;
+    align-items: flex-start;
+    gap: 0;
+    margin-bottom: 6px;
+  }
+
+  .card-content-title {
+    flex: 1;
+    min-width: 0;
+    height: 24px;
+    line-height: 24px;
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--td-text-color-primary);
+    font-family: var(--app-font-family);
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    margin-right: 8px;
+  }
+
+  .more-wrap {
+    flex-shrink: 0;
+    display: flex;
+    width: 25px;
+    height: 25px;
+    justify-content: center;
+    align-items: center;
+    border-radius: 5px;
+    cursor: pointer;
+
+    &:hover { background: var(--td-component-stroke); }
+  }
+
+  .more-icon { width: 14px; height: 14px; }
+  .active-more { background: var(--td-component-stroke); }
+
+  .card-content-txt {
+    flex: 1;
+    min-height: 0;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    color: var(--td-text-color-secondary);
+    font-family: var(--app-font-family);
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 19px;
+  }
+
+  .card-bottom {
+    flex-shrink: 0;
+    margin-top: auto;
+    padding: 0 14px;
+    box-sizing: border-box;
+    height: 32px;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: var(--td-bg-color-container);
+    border-top: 1px solid var(--td-component-stroke);
+  }
+
+  .card-time {
+    flex-shrink: 0;
+    color: var(--td-text-color-secondary);
+    font-family: var(--app-font-family);
+    font-size: 12px;
+    font-weight: 400;
+    white-space: nowrap;
+  }
+
+  .card-type {
+    flex-shrink: 0;
+    color: var(--td-text-color-placeholder);
+    font-family: var(--app-font-family);
+    font-size: 11px;
+    font-weight: 500;
+    padding: 0;
+    background: transparent;
+    letter-spacing: 0.02em;
+  }
+}
+
+.card-bottom-right {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  overflow: hidden;
+}
+
+// --- Card menu ---
+.card-menu {
+  display: flex;
+  flex-direction: column;
+  min-width: 140px;
+  gap: 1px;
+}
+
+.card-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  cursor: pointer;
+  color: var(--td-text-color-primary);
+  transition: all 0.15s cubic-bezier(0.2, 0, 0, 1);
+  border-radius: 6px;
+  font-size: 14px;
+  line-height: 20px;
+
+  &:hover { background: var(--td-bg-color-container-hover); }
+  &:active { background: var(--td-bg-color-container-active); transform: scale(0.98); }
+
+  .icon {
+    font-size: 16px;
+    color: var(--td-text-color-secondary);
+    transition: all 0.15s cubic-bezier(0.2, 0, 0, 1);
+  }
+
+  &:hover .icon { color: var(--td-text-color-primary); }
+
+  &.danger {
+    color: var(--td-error-color-6);
+    margin-top: 4px;
+    position: relative;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: -3px;
+      left: 8px;
+      right: 8px;
+      height: 1px;
+      background: var(--td-component-stroke);
+    }
+
+    .icon { color: var(--td-error-color-6); }
+
+    &:hover {
+      background: var(--td-error-color-1);
+      color: var(--td-error-color-6);
+      .icon { color: var(--td-error-color-6); }
+    }
+
+    &:active { background: var(--td-error-color-2); }
+  }
+}
+
+// --- Move sub-menu ---
+.move-menu {
+  min-width: 220px;
+  max-width: 280px;
+  max-height: 360px;
+  overflow-y: auto;
+
+  .move-menu-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--td-text-color-primary);
+    border-bottom: 1px solid var(--td-component-stroke);
+    cursor: pointer;
+    &:hover { background: var(--td-bg-color-container-hover); }
+  }
+
+  .move-menu-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px 0;
+  }
+
+  .move-menu-empty {
+    padding: 12px 16px;
+    font-size: 12px;
+    color: var(--td-text-color-placeholder);
+    text-align: center;
+    line-height: 1.5;
+  }
+
+  .move-target-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .move-target-count {
+    font-size: 12px;
+    color: var(--td-text-color-placeholder);
+  }
+
+  .move-confirm-body {
+    padding: 8px;
+
+    .move-target-info {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 8px;
+      background: var(--td-bg-color-container-hover);
+      border-radius: 6px;
+      font-size: 13px;
+      color: var(--td-text-color-secondary);
+      margin-bottom: 8px;
+    }
+
+    .move-mode-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 6px;
+      padding: 6px 8px;
+      border-radius: 6px;
+      cursor: pointer;
+      margin-bottom: 4px;
+
+      &:hover { background: var(--td-bg-color-container-hover); }
+      &.active { background: var(--td-brand-color-light); }
+
+      .move-mode-text {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+
+        .move-mode-label {
+          font-size: 13px;
+          font-weight: 500;
+          color: var(--td-text-color-primary);
+        }
+
+        .move-mode-desc {
+          font-size: 11px;
+          color: var(--td-text-color-placeholder);
+          line-height: 1.4;
+        }
+      }
+    }
+
+    .move-confirm-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+      margin-top: 8px;
+    }
+  }
+}
+
+// --- Card draft ---
+.card-draft {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  flex-shrink: 0;
+}
+
+.card-draft-tip {
+  color: var(--td-warning-color);
+  font-size: 11px;
+}
+
+// --- Tag selector ---
+.card-tag-selector {
+  display: flex;
+  align-items: center;
+
+  .card-tag-chips {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex-wrap: nowrap;
+    cursor: pointer;
+  }
+
+  .card-tag-overflow {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 18px;
+    min-width: 18px;
+    padding: 0 5px;
+    border-radius: 999px;
+    border: 1px solid var(--td-component-stroke);
+    color: var(--td-text-color-placeholder);
+    font-size: 10px;
+    line-height: 1;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      border-color: var(--td-brand-color);
+      color: var(--td-brand-color);
+      background: var(--td-bg-color-secondarycontainer);
+    }
+  }
+
+  :deep(.t-tag) {
+    cursor: pointer;
+    max-width: 120px;
+    height: 18px;
+    line-height: 18px;
+    border-radius: 999px;
+    border-color: var(--td-component-stroke);
+    color: var(--td-text-color-secondary);
+    padding: 0 6px;
+    background: transparent;
+    transition: all 0.2s ease;
+
+    &:hover {
+      border-color: var(--td-brand-color);
+      color: var(--td-brand-color-active);
+      background: var(--td-bg-color-secondarycontainer);
+    }
+  }
+
+  .tag-text {
+    display: inline-block;
+    max-width: 80px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: middle;
+    font-size: 11px;
+  }
+
+  .card-tag-add {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    height: 18px;
+    padding: 0 6px;
+    border-radius: 999px;
+    border: 1px dashed var(--td-component-stroke);
+    color: var(--td-text-color-placeholder);
+    font-size: 11px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    .t-icon { font-size: 12px; }
+
+    &:hover {
+      border-color: var(--td-brand-color);
+      color: var(--td-brand-color-active);
+      background: var(--td-bg-color-secondarycontainer);
+      border-style: solid;
+    }
+  }
+}
+
+// --- Hover popover ---
+.knowledge-card-hover-popover {
+  position: fixed;
+  z-index: 9999;
+  pointer-events: none;
+  min-width: 220px;
+  max-width: 360px;
+  padding: 12px 14px;
+  background: var(--td-bg-color-container);
+  border: 1px solid var(--td-component-stroke);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  font-family: var(--app-font-family);
+  transition: opacity 0.15s ease;
+  will-change: transform;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  transform: translateZ(0);
+  -webkit-transform: translateZ(0);
+
+  .card-popover-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--td-text-color-primary);
+    margin-bottom: 8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .card-popover-status {
+    font-size: 12px;
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    &.parsing { color: var(--td-brand-color); }
+    &.failure { color: var(--td-error-color); }
+    &.draft { color: var(--td-warning-color); }
+  }
+
+  .card-popover-desc {
+    font-size: 12px;
+    color: var(--td-text-color-secondary);
+    line-height: 1.5;
+    margin-bottom: 8px;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 5;
+    line-clamp: 5;
+    overflow: hidden;
+  }
+
+  .card-popover-source {
+    font-size: 11px;
+    color: var(--td-brand-color);
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+  }
+
+  .card-popover-extra {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    font-size: 11px;
+    color: var(--td-text-color-secondary);
+    margin-bottom: 6px;
+  }
+
+  .card-popover-created,
+  .card-popover-size { flex-shrink: 0; }
+
+  .card-popover-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    font-size: 11px;
+    color: var(--td-text-color-secondary);
+  }
+
+  .card-popover-channel {
+    padding: 1px 6px;
+    background: var(--td-warning-color-light);
+    color: var(--td-warning-color);
+    border-radius: 4px;
+  }
+
+  .card-popover-tags {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px;
+    max-width: 100%;
+  }
+
+  .card-popover-tag-chip {
+    max-width: 120px;
+    height: 18px;
+    line-height: 18px;
+    border-radius: 999px;
+    border-color: var(--td-component-stroke);
+    color: var(--td-text-color-secondary);
+    padding: 0 6px;
+    background: transparent;
+
+    .tag-text {
+      display: inline-block;
+      max-width: 80px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      vertical-align: middle;
+      font-size: 11px;
+    }
+  }
+
+  .card-popover-type {
+    padding: 1px 6px;
+    background: var(--td-bg-color-secondarycontainer);
+    color: var(--td-text-color-secondary);
+    border-radius: 4px;
+  }
+
+  .card-popover-hint {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--td-component-stroke);
+    font-size: 11px;
+    color: var(--td-text-color-secondary);
+  }
+}
+</style>

--- a/frontend/src/views/knowledge/components/DocumentListView.vue
+++ b/frontend/src/views/knowledge/components/DocumentListView.vue
@@ -3,6 +3,7 @@ import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { formatFileSize, getFileIcon } from '@/utils/files';
 import { useTagChipsOverflow } from '@/composables/useTagChipsOverflow';
+import DocumentActionMenu from './DocumentActionMenu.vue';
 
 interface Tag {
   id: string;
@@ -30,16 +31,32 @@ const props = defineProps<{
   items: KnowledgeItem[];
   selectedIds: Set<string>;
   canEdit: boolean;
+  canMutateKnowledge: boolean;
+  traceVisibleIds: Record<string, boolean>;
   tagList: Tag[];
   loading?: boolean;
+  // Move sub-flow state
+  moveMenuMode: 'normal' | 'targets' | 'confirm';
+  moveTargetKbs: any[];
+  moveTargetsLoading: boolean;
+  moveSelectedTargetName: string;
+  moveMode: 'reuse_vectors' | 'reparse';
+  moveSubmitting: boolean;
 }>();
 
 const emit = defineEmits<{
   (e: 'open', item: KnowledgeItem): void;
   (e: 'toggle-row', id: string, checked: boolean, shiftKey: boolean): void;
   (e: 'toggle-all', checked: boolean): void;
-  (e: 'action', action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'delete', item: KnowledgeItem): void;
+  (e: 'action', action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'delete' | 'view-trace' | 'batch-manage', item: KnowledgeItem): void;
+  (e: 'probe-trace', item: KnowledgeItem): void;
   (e: 'tag-edit', item: KnowledgeItem): void;
+  // Move sub-flow emits
+  (e: 'move-select-target', kb: any): void;
+  (e: 'move-back'): void;
+  (e: 'move-confirm'): void;
+  (e: 'update:moveMode', mode: 'reuse_vectors' | 'reparse'): void;
+  (e: 'reset-move-state'): void;
 }>();
 
 const { t } = useI18n();
@@ -159,6 +176,13 @@ const onRowCheckboxChange = (item: KnowledgeItem, checked: boolean, ctx?: { e?: 
 const moreOpen = ref<string | null>(null);
 const onMoreVisible = (id: string, visible: boolean) => {
   moreOpen.value = visible ? id : null;
+  if (visible) {
+    const it = props.items.find(i => i.id === id);
+    if (it) emit('probe-trace', it);
+  } else {
+    // Reset move state when popup closes naturally
+    emit('reset-move-state');
+  }
 };
 
 // 吸顶检测：哨兵离开视口说明 header 已吸附在滚动容器顶部
@@ -180,17 +204,11 @@ onBeforeUnmount(() => {
   stickyObserver = null;
 });
 
-// Cancellable parse statuses mirror the backend CancelKnowledgeParse
-// gate: pending / processing / finalizing all surface the stop entry,
-// while completed / failed / cancelled / deleting hide it.
-const CANCELABLE_PARSE_STATUSES = new Set(['pending', 'processing', 'finalizing']);
-const canCancelParse = (item: KnowledgeItem) =>
-  CANCELABLE_PARSE_STATUSES.has(String(item.parse_status ?? ''));
-
-const isParseInFlight = (item: KnowledgeItem) => canCancelParse(item);
-
-const handleAction = (action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'delete', item: KnowledgeItem) => {
-  moreOpen.value = null;
+const handleAction = (action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'delete' | 'view-trace' | 'batch-manage', item: KnowledgeItem) => {
+  // Don't close popup for move — it triggers the move sub-flow
+  if (action !== 'move') {
+    moreOpen.value = null;
+  }
   item.isMore = false;
   emit('action', action, item);
 };
@@ -295,49 +313,79 @@ const handleAction = (action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'de
               <t-icon name="more" size="16px" />
             </button>
             <template #content>
-              <div class="row-menu">
-                <div v-if="item.type === 'manual'" class="row-menu-item" @click.stop="handleAction('edit', item)">
-                  <t-icon class="icon" name="edit" />
-                  <span>{{ t('knowledgeBase.editDocument') }}</span>
+              <!-- Normal menu -->
+              <div v-if="moveMenuMode === 'normal'" class="row-menu">
+                <DocumentActionMenu
+                  :item="item"
+                  :can-mutate-knowledge="canMutateKnowledge"
+                  :trace-visible="!!traceVisibleIds[item.id] || (item.parse_status === 'pending' || item.parse_status === 'processing' || item.parse_status === 'finalizing')"
+                  @edit="handleAction('edit', item)"
+                  @view-trace="handleAction('view-trace', item)"
+                  @reparse="handleAction('reparse', item)"
+                  @cancel-parse="handleAction('cancel-parse', item)"
+                  @move="handleAction('move', item)"
+                  @batch-manage="handleAction('batch-manage', item)"
+                  @delete="handleAction('delete', item)"
+                />
+              </div>
+
+              <!-- Move: target KB list -->
+              <div v-else-if="moveMenuMode === 'targets'" class="row-menu move-menu">
+                <div class="move-menu-header" @click.stop="emit('move-back')">
+                  <t-icon name="chevron-left" size="16px" />
+                  <span>{{ $t('knowledgeBase.moveToKnowledgeBase') }}</span>
                 </div>
-                <div v-if="isParseInFlight(item)" class="row-menu-item" @click.stop="handleAction('reparse', item)">
-                  <t-icon class="icon" name="refresh" />
-                  <span>{{ t('knowledgeBase.rebuildDocument') }}</span>
+                <div v-if="moveTargetsLoading" class="move-menu-loading">
+                  <t-loading size="small" />
                 </div>
-                <t-popconfirm v-else theme="warning"
-                  :content="t('knowledgeBase.rebuildConfirm', { fileName: item.file_name || '' })"
-                  :confirm-btn="{ content: t('common.confirm'), theme: 'primary' }"
-                  :cancel-btn="{ content: t('common.cancel') }" placement="left"
-                  @confirm="handleAction('reparse', item)">
-                  <div class="row-menu-item" @click.stop>
-                    <t-icon class="icon" name="refresh" />
-                    <span>{{ t('knowledgeBase.rebuildDocument') }}</span>
-                  </div>
-                </t-popconfirm>
-                <t-popconfirm v-if="canCancelParse(item)" theme="warning"
-                  :content="t('knowledgeBase.cancelParseConfirmBody', { title: item.file_name || item.id })"
-                  :confirm-btn="{ content: t('knowledgeBase.cancelParse'), theme: 'danger' }"
-                  :cancel-btn="{ content: t('common.cancel') }" placement="left"
-                  @confirm="handleAction('cancel-parse', item)">
-                  <div class="row-menu-item danger" @click.stop>
-                    <t-icon class="icon" name="close-circle" />
-                    <span>{{ t('knowledgeBase.cancelParse') }}</span>
-                  </div>
-                </t-popconfirm>
-                <div class="row-menu-item" @click.stop="handleAction('move', item)">
-                  <t-icon class="icon" name="swap" />
-                  <span>{{ t('knowledgeBase.moveDocument') }}</span>
+                <div v-else-if="moveTargetKbs.length === 0" class="move-menu-empty">
+                  {{ $t('knowledgeBase.moveNoTargets') }}
                 </div>
-                <t-popconfirm theme="warning"
-                  :content="t('knowledgeBase.confirmDeleteDocument', { fileName: item.file_name || '' })"
-                  :confirm-btn="{ content: t('knowledgeBase.confirmDelete'), theme: 'danger' }"
-                  :cancel-btn="{ content: t('common.cancel') }" placement="left"
-                  @confirm="handleAction('delete', item)">
-                  <div class="row-menu-item danger" @click.stop>
-                    <t-icon class="icon" name="delete" />
-                    <span>{{ t('knowledgeBase.deleteDocument') }}</span>
+                <template v-else>
+                  <div v-for="kb in moveTargetKbs" :key="kb.id" class="row-menu-item"
+                    @click.stop="emit('move-select-target', kb)">
+                    <t-icon class="icon" name="root-list" />
+                    <span class="move-target-name">{{ kb.name }}</span>
+                    <span v-if="kb.knowledge_count !== undefined" class="move-target-count">{{ kb.knowledge_count }}</span>
                   </div>
-                </t-popconfirm>
+                </template>
+              </div>
+
+              <!-- Move: confirm with mode selection -->
+              <div v-else-if="moveMenuMode === 'confirm'" class="row-menu move-menu">
+                <div class="move-menu-header" @click.stop="emit('move-back')">
+                  <t-icon name="chevron-left" size="16px" />
+                  <span>{{ $t('knowledgeBase.moveConfirmTitle') }}</span>
+                </div>
+                <div class="move-confirm-body">
+                  <div class="move-target-info">
+                    <t-icon name="arrow-right" size="14px" />
+                    <span>{{ moveSelectedTargetName }}</span>
+                  </div>
+                  <div class="move-mode-item" :class="{ active: moveMode === 'reuse_vectors' }"
+                    @click.stop="emit('update:moveMode', 'reuse_vectors')">
+                    <t-radio :checked="moveMode === 'reuse_vectors'" />
+                    <div class="move-mode-text">
+                      <span class="move-mode-label">{{ $t('knowledgeBase.moveModeReuseVectors') }}</span>
+                      <span class="move-mode-desc">{{ $t('knowledgeBase.moveModeReuseVectorsDesc') }}</span>
+                    </div>
+                  </div>
+                  <div class="move-mode-item" :class="{ active: moveMode === 'reparse' }"
+                    @click.stop="emit('update:moveMode', 'reparse')">
+                    <t-radio :checked="moveMode === 'reparse'" />
+                    <div class="move-mode-text">
+                      <span class="move-mode-label">{{ $t('knowledgeBase.moveModeReparse') }}</span>
+                      <span class="move-mode-desc">{{ $t('knowledgeBase.moveModeReparseDesc') }}</span>
+                    </div>
+                  </div>
+                  <div class="move-confirm-actions">
+                    <t-button size="small" variant="outline" @click.stop="emit('move-back')">{{
+                      $t('common.cancel') }}</t-button>
+                    <t-button size="small" theme="primary" :loading="moveSubmitting"
+                      @click.stop="emit('move-confirm')">{{
+                        $t('knowledgeBase.moveConfirm') }}</t-button>
+                  </div>
+                </div>
               </div>
             </template>
           </t-popup>
@@ -691,6 +739,117 @@ const handleAction = (action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'de
   min-width: 140px;
   gap: 2px;
   padding: 4px 6px;
+
+  &.move-menu {
+    min-width: 220px;
+    max-width: 280px;
+    max-height: 360px;
+    overflow-y: auto;
+    padding: 0;
+    gap: 0;
+  }
+}
+
+.move-menu-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--td-text-color-primary);
+  border-bottom: 1px solid var(--td-component-stroke);
+  cursor: pointer;
+
+  &:hover {
+    background: var(--td-bg-color-container-hover);
+  }
+}
+
+.move-menu-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px 0;
+}
+
+.move-menu-empty {
+  padding: 12px 16px;
+  font-size: 12px;
+  color: var(--td-text-color-placeholder);
+  text-align: center;
+  line-height: 1.5;
+}
+
+.move-target-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.move-target-count {
+  font-size: 12px;
+  color: var(--td-text-color-placeholder);
+}
+
+.move-confirm-body {
+  padding: 8px;
+
+  .move-target-info {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    background: var(--td-bg-color-container-hover);
+    border-radius: 6px;
+    font-size: 13px;
+    color: var(--td-text-color-secondary);
+    margin-bottom: 8px;
+  }
+
+  .move-mode-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    padding: 6px 8px;
+    border-radius: 6px;
+    cursor: pointer;
+    margin-bottom: 4px;
+
+    &:hover {
+      background: var(--td-bg-color-container-hover);
+    }
+
+    &.active {
+      background: var(--td-brand-color-light);
+    }
+
+    .move-mode-text {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+
+      .move-mode-label {
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--td-text-color-primary);
+      }
+
+      .move-mode-desc {
+        font-size: 11px;
+        color: var(--td-text-color-placeholder);
+        line-height: 1.4;
+      }
+    }
+  }
+
+  .move-confirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 8px;
+  }
 }
 
 .row-menu-item {


### PR DESCRIPTION
## Description

本次 PR 重构了知识库文档详情页（`/platform/knowledge-bases/:kbId`）的文档操作菜单和卡片视图，解决了卡片视图与列表视图中文档操作菜单不一致的问题。

### 背景

卡片视图（网格模式）和列表视图（表格模式）各自独立维护文档操作下拉菜单，导致两处菜单项不一致：列表视图缺少"查看处理过程"和"批量管理"两个入口，"移动到..."也缺少权限门控。

### 改动内容

1. **抽取 `DocumentActionMenu.vue`** — 共享的文档操作菜单组件。包含 7 项操作：编辑文档、查看处理过程、重建知识、取消解析、移动到...、批量管理、删除文档。菜单项可见性条件（权限、解析状态、trace 可用性）集中管理，两处视图共用，确保始终一致。

2. **抽取 `DocumentCardView.vue`** — 从前 `KnowledgeBase.vue` 约 260 行内联模板中抽出的独立卡片视图组件。包含文档卡片渲染、悬浮详情气泡、标签选择器、移动子流程（目标选择 → 确认）。

3. **完善 `DocumentListView.vue`** — 使用共享菜单组件，补齐"查看处理过程"和"批量管理"，为"移动到..."增加 `canMutateKnowledge` 权限门控，接入移动子流程（目标选择 → 确认），与卡片视图行为对齐。

4. **精简 `KnowledgeBase.vue`** — 使用 `DocumentCardView` 组件替代内联模板，清理已迁移至子组件的冗余代码和 imports。


### 架构

```mermaid
flowchart LR
    KB["<b>KnowledgeBase.vue</b><br/>━━━━━━━━━━━━━━━━━<br/>共享状态 · 桥接函数<br/>handleCardAction<br/>handleListAction"]

    KB -- "props" --> CARD
    KB -- "props" --> LIST
    CARD -- "emit(action)" --> KB
    LIST -- "emit(action)" --> KB

    subgraph CARD["<b>DocumentCardView</b> 卡片视图"]
        A1["DocumentActionMenu"]
    end

    subgraph LIST["<b>DocumentListView</b> 列表视图"]
        A2["DocumentActionMenu"]
    end

    MENU["<b>DocumentActionMenu</b><br/>━━━━━━━━━━━━━━━━━<br/>编辑 · 追踪 · 重建 · 取消<br/>移动 · 批量 · 删除"]
    A1 -.- MENU
    A2 -.- MENU

    style KB fill:#1b4332,stroke:#40916c,color:#eee
    style CARD fill:#0f3460,stroke:#1e6091,color:#eee
    style LIST fill:#0f3460,stroke:#1e6091,color:#eee
    style MENU fill:#533483,stroke:#7b2cbf,color:#eee
    style A1 fill:#3a0ca3,stroke:#7209b7,color:#eee
    style A2 fill:#3a0ca3,stroke:#7209b7,color:#eee

```

## Related Issue
Fixes #1923 

## Type of Change

- [x] 🎨 Refactor

## Testing

- `vue-tsc --build --noEmit` 类型检查通过（exit 0）
- `vite build` 生产构建通过
- 手动验证：卡片视图和列表视图的操作菜单现在展示完全一致的 7 个菜单项
- 移动子流程（目标选择 → 模式选择 → 确认）在列表视图中恢复正常工作

## Checklist

- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation

## Screenshots / Recordings



https://github.com/user-attachments/assets/d3e138c9-08ec-46f0-8299-d94ccf8599d0


