### PR TITLE
feat: reuse cached artifacts on knowledge rebuild

### DIFF
--- a/docs/rebuild-cache.md
+++ b/docs/rebuild-cache.md
@@ -1,0 +1,170 @@
+# PR: Reuse Cache on Rebuild
+
+It changes knowledge rebuilds from full recomputation into diff-aware reuse: **unchanged content reuses completed artifacts, while only changed inputs and their dependent layers are recomputed.**
+
+## Summary
+
+The previous rebuild path deleted derived state early and regenerated most expensive artifacts, even when the source document had not changed. This made no-op rebuilds behave like first-time ingestion.
+
+This change introduces stable identities, process artifact caching, and diff-aware reconciliation across the rebuild pipeline. For unchanged knowledge, DocReader/OCR, downloaded `file_url` bytes, image VLM output, embeddings, summaries, questions, GraphRAG chunk maps, and Wiki map output can now hit cache. `Wiki reduce` still runs when contributor state changes because it is the cross-document aggregation step.
+
+## Workflow Comparison
+
+### Previous workflow
+
+Before this change, rebuilds were destructive and ID-unstable. The pipeline removed old chunks and related records, regenerated temporary image paths and chunk IDs, and then reran each expensive document-local stage even when the normalized document content was identical.
+
+```mermaid
+flowchart TD
+    accTitle: Previous Rebuild Workflow
+    accDescr: The old rebuild path eagerly deleted derived records and reran OCR, VLM, embedding, and generation work for unchanged content.
+
+    request["Rebuild request"]
+    cleanup["Delete chunks, vectors, and graph records"]
+    reader["Run DocReader and OCR"]
+    images["Store extracted images under unstable names"]
+    chunks["Create chunks with random IDs"]
+    embed["Embed every text chunk"]
+    text_gen["Regenerate summaries and questions"]
+    image_vlm["Rerun image OCR and caption VLM"]
+    graph_rag["Rerun GraphRAG chunk extraction"]
+    wiki_map["Rerun Wiki map"]
+    reduce["Run Wiki reduce"]
+    done["Persist rebuilt knowledge"]
+
+    request --> cleanup --> reader --> images --> chunks --> embed --> text_gen --> image_vlm --> graph_rag --> wiki_map --> reduce --> done
+
+    classDef destructive fill:#fee2e2,stroke:#dc2626,stroke-width:2px,color:#7f1d1d
+    classDef expensive fill:#fef3c7,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef output fill:#dcfce7,stroke:#16a34a,stroke-width:2px,color:#14532d
+
+    class cleanup destructive
+    class reader,embed,text_gen,image_vlm,graph_rag,wiki_map,reduce expensive
+    class done output
+```
+
+### New workflow
+
+The new path keeps reusable state in place, caches `DocReader` output during conversion, stores images by content hash, reconciles chunks by stable identity, indexes only missing text chunks, and then lets post-processing stages use their own artifact caches before the unavoidable `Wiki reduce` step.
+
+```mermaid
+flowchart TD
+    accTitle: New Rebuild Workflow
+    accDescr: The new rebuild path computes stable content identities first, reuses completed artifacts on cache hits, and persists only the differences.
+
+    request["Rebuild request"]
+    keep_state["Keep existing derived state"]
+    doc_cache{"DocReader cache hit?"}
+    parse_miss["Call DocReader and write cache"]
+    parsed["Use parsed markdown and image refs"]
+    image_store["Store images by content hash"]
+    plan_chunks["Plan stable chunk IDs"]
+    reconcile["Create missing chunks and reuse existing chunks"]
+    embed_new["Index only new text chunks with embedding cache"]
+    delete_obsolete["Delete obsolete chunks and vectors after replacement"]
+    postprocess["Run cached post-processing stages"]
+    text_cache["Summary and question cache"]
+    image_vlm_cache["Image VLM cache"]
+    graph_cache["Graph chunk cache"]
+    wiki_map_cache["Wiki map cache"]
+    reduce["Run Wiki reduce when contributors require it"]
+    done["Persist diff-only rebuild"]
+
+    request --> keep_state --> doc_cache
+    doc_cache -->|Hit| parsed
+    doc_cache -->|Miss| parse_miss --> parsed
+    parsed --> image_store --> plan_chunks --> reconcile --> embed_new --> delete_obsolete --> postprocess
+    postprocess --> text_cache --> wiki_map_cache
+    postprocess --> image_vlm_cache --> wiki_map_cache
+    postprocess --> graph_cache --> wiki_map_cache
+    wiki_map_cache --> reduce --> done
+
+    classDef cache fill:#dbeafe,stroke:#2563eb,stroke-width:2px,color:#1e3a8a
+    classDef stable fill:#ecfdf5,stroke:#059669,stroke-width:2px,color:#064e3b
+    classDef reduce fill:#fef3c7,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef output fill:#dcfce7,stroke:#16a34a,stroke-width:2px,color:#14532d
+
+    class doc_cache,text_cache,image_vlm_cache,graph_cache,wiki_map_cache cache
+    class keep_state,parsed,image_store,plan_chunks,reconcile,embed_new,delete_obsolete,postprocess stable
+    class reduce reduce
+    class done output
+```
+
+## What Changed
+
+| Area | Before | Now | Effect |
+| --- | --- | --- | --- |
+| Document parsing | DocReader was rerun for each rebuild path. | `docreader:v1` caches parsed output by stable reader input and reader options. | OCR and parsing are reused for unchanged documents. |
+| Downloaded `file_url` input | Temporary download paths could change between runs. | Downloaded bytes are hashed and used as the stable DocReader cache boundary. | The same downloaded bytes cache-hit even if the temp path changes. |
+| Images | Image paths were unstable and often deleted before reuse. | Image bytes use stable content-addressed filenames and are protected during rebuild cleanup. | Unchanged image assets and VLM descriptions are reused. |
+| Chunks | Chunks used random IDs. | Chunk IDs are derived from normalized content and position. | Rebuild reconciliation can update by diff instead of replacing everything. |
+| Embeddings | Every chunk was embedded again. | `embedding:v1` caches vectors by provider, model, dimension, normalized text, and relevant config. | Unchanged chunk vectors do not call the embedding provider. |
+| Summaries and questions | Generation reran whenever the rebuild ran. | `summary:v1` and `question:v1` cache by normalized prompt input plus model/config. | Unchanged chunk text skips chat completion calls. |
+| GraphRAG | Chunk graph extraction reran and cache payloads were persistence-shaped. | `graph:chunk:v1` caches model output and strips chunk-specific references from payloads. | Graph extraction is reused and restored safely for the current chunk. |
+| Wiki map | Wiki map generation reran on rebuilds. | `wiki:map:v1` caches map output by stable contributor material and map config. | Unchanged contributors reuse map output. |
+| Wiki reduce | Cross-document reduce was part of every rebuild. | Reduce remains intentionally uncached. | The only unavoidable cost is contributor-level aggregation. |
+
+## Implementation Coverage
+
+This section maps the PR description to the current workspace diff so reviewers can find every changed surface.
+
+| Surface | Files | Covered change |
+| --- | --- | --- |
+| Plan and PR docs | `docs/superpowers/plans/2026-07-02-reuse-cache-on-rebuild.md`, `docs/rebuild-cache-pr-description.md`, `docs/rebuild-cache-pr-description.zh-CN.md` | Keeps the implementation plan and PR description in the repo. |
+| Process artifact cache schema | `migrations/sqlite/000000_init.up.sql`, `migrations/versioned/000065_rebuild_artifact_cache.up.sql`, `migrations/versioned/000065_rebuild_artifact_cache.down.sql`, `internal/types/process_artifact_cache.go`, `internal/types/interfaces/process_artifact_cache.go`, `internal/application/repository/process_artifact_cache.go`, `internal/application/repository/process_artifact_cache_test.go`, `internal/container/container.go` | Adds the tenant-scoped artifact cache table, unique cache identity, repository upsert/get behavior, and DI registration. |
+| Cache keys and content addressing | `internal/application/service/rebuild_cache_keys.go`, `internal/application/service/rebuild_cache_keys_test.go`, `internal/utils/content_address.go`, `internal/utils/content_address_test.go` | Adds canonical text hashing, stable image filenames, stable chunk/question/summary child IDs, and artifact key helpers. |
+| DocReader cache | `internal/application/service/knowledge_process.go`, `internal/application/service/docreader_cache_payload.go`, `internal/application/service/docreader_cache_payload_test.go`, `internal/application/service/knowledge_docreader_cache_test.go` | Caches `ReadResult` payloads and verifies that already downloaded `file_url` bytes cache-hit across different temporary file paths. |
+| Rebuild-aware chunk reconciliation | `internal/application/repository/chunk.go`, `internal/application/repository/chunk_sqlite_test.go`, `internal/application/service/chunk.go`, `internal/types/interfaces/chunk.go`, `internal/application/service/knowledge_process.go` | Adds create-ignore semantics, selected-type listing, obsolete chunk plus direct-child deletion, stable chunk IDs, and diff-only vector deletion. |
+| Knowledge processing entry points | `internal/application/service/knowledge.go`, `internal/application/service/knowledge_process.go`, `internal/application/service/knowledge_post_process.go` | Injects the artifact cache repo, removes eager cleanup from reparse/manual update paths, and resets graph namespaces at graph post-process time. |
+| File service content-addressed storage | `internal/types/interfaces/file.go`, `internal/application/service/file/cos.go`, `internal/application/service/file/dummy.go`, `internal/application/service/file/ks3.go`, `internal/application/service/file/local.go`, `internal/application/service/file/local_test.go`, `internal/application/service/file/minio.go`, `internal/application/service/file/obs.go`, `internal/application/service/file/oss.go`, `internal/application/service/file/s3.go`, `internal/application/service/file/tos.go` | Adds `SaveContentAddressedBytes` to every storage backend so cached image bytes use deterministic tenant-scoped paths under `exports/cache`. |
+| Image resolution and deletion | `internal/infrastructure/docparser/image_resolver.go`, `internal/infrastructure/docparser/image_resolver_test.go`, `internal/infrastructure/docparser/resolve_remote_images_test.go`, `internal/application/service/knowledge_delete.go` | Stores extracted images by content hash, records image content hashes, keeps whitelisted remote images unchanged, and avoids deleting shared content-addressed artifacts. |
+| Image VLM and child chunks | `internal/application/service/image_multimodal.go` | Caches OCR/caption output by image bytes, prompt, model, and config; creates stable OCR/caption child chunk IDs; skips existing child chunks on retry. |
+| Embeddings | `internal/application/service/cached_embedder.go`, `internal/application/service/cached_embedder_test.go`, `internal/application/service/knowledge_process.go` | Wraps embedding calls with process-cache reads/writes and uses the wrapper for main chunks, summaries, generated questions, and chunk updates. |
+| Summaries and questions | `internal/application/service/knowledge_process.go`, `internal/application/service/question_cache_test.go` | Caches summary and question generation, uses stable summary chunk IDs, uses stable generated question IDs, and reuses already indexed summary chunks. |
+| Graph extraction | `internal/application/service/extract.go`, `internal/application/service/extract_cache_test.go`, `internal/application/service/knowledge_post_process.go` | Caches per-chunk graph extraction and strips persisted chunk references from reusable graph payloads. |
+| Wiki ingestion | `internal/application/service/wiki_ingest.go`, `internal/application/service/wiki_ingest_batch.go`, `internal/application/service/wiki_ingest_cache_test.go` | Caches Wiki map output, keeps `oldPageSlugs` out of the model cache key, stores only base updates, and rebuilds retractions from current page state on cache hit. |
+| Plan-level acceptance tests | `internal/application/service/knowledge_rebuild_cache_integration_test.go` | Covers unchanged rebuilds, crash retry cache reuse, and layer-local invalidation when model or prompt config changes. |
+| Compatibility test stubs | `internal/agent/tools/data_analysis_materialize_test.go`, `internal/application/service/knowledge_clone_image_test.go`, `internal/application/service/knowledge_create_test.go`, `internal/im/im_file_service_test.go`, `internal/router/router_files_test.go` | Updates test doubles to satisfy the expanded `FileService` interface. |
+
+## Cache Boundaries
+
+| Layer | Cache namespace | Key includes | Invalidated by |
+| --- | --- | --- | --- |
+| DocReader | `docreader:v1` | Reader source material, file bytes when available, reader options, parser version. | Source bytes/text changes, reader option changes, parser version changes. |
+| Downloaded `file_url` bytes | `docreader:v1` | Downloaded bytes, not the temporary file path. | Downloaded content changes. |
+| Image VLM | `vlm:image:v1` | Image content hash, prompt, model, provider, VLM config. | Image bytes, VLM prompt, model, or config changes. |
+| Embedding | `embedding:v1` | Normalized chunk text, provider, model, dimension, embedding config. | Text, model, dimension, provider, or embedding config changes. |
+| Summary | `summary:v1` | Normalized chunk text, summary prompt, model, chat config. | Text, prompt, model, or chat config changes. |
+| Question | `question:v1` | Normalized chunk text, question prompt, model, chat config. | Text, prompt, model, or chat config changes. |
+| Graph chunk map | `graph:chunk:v1` | Normalized chunk text, graph prompt, model, graph config. | Text, prompt, model, or graph config changes. |
+| Wiki map | `wiki:map:v1` | Contributor material, map prompt, model, Wiki map config. | Contributor material, prompt, model, or map config changes. |
+| Wiki reduce | None | Current Wiki contributors and page state. | Always evaluated when contributor state requires reduce. |
+
+Two cache-boundary details are deliberate:
+
+- `oldPageSlugs` are excluded from the Wiki map key. They are persistence context, not model input. On cache hit, retractions and base updates are rebuilt for the current page state.
+- Graph chunk cache payloads do not store persisted chunk references. They are restored against the current chunk on cache hit.
+
+## Expected Rebuild Behavior
+
+| Scenario | Expected behavior | Covered by |
+| --- | --- | --- |
+| Rebuild unchanged knowledge | Near-zero LLM/VLM calls except unavoidable `Wiki reduce`. | `TestReparseUnchangedKnowledgeAvoidsExpensiveModelCalls` |
+| Retry after crash | Completed OCR, vector, and Wiki map work cache-hit. | `TestCrashRetryReusesCompletedArtifacts` |
+| Embedding model/config change | Embedding layer misses; OCR, VLM, summaries, questions, and Wiki map are reused when their inputs are unchanged. | `TestRebuildCacheInvalidatesOnlyChangedLayer` |
+| Downloaded `file_url` stored at a different temp path | DocReader cache hits because the downloaded bytes are unchanged. | `TestConvertFileURLDownloadedBytesReuseDocReaderCacheAcrossTempPaths` |
+| Existing graph and Wiki map cache payloads | Payloads are reusable without leaking stale persistence references. | `TestGraphDataCachePayloadStripsChunkRefsAndRestoresGraph`, `TestWikiMapCachePayloadDropsRetractionsAndRestoresBaseUpdates` |
+
+## Validation
+
+The following checks were run:
+
+```bash
+go test ./internal/application/service -count=1
+go test ./internal/application/repository ./internal/application/service/file ./internal/container -count=1
+go test ./internal/agent/tools ./internal/im ./internal/router -count=1
+go test ./internal/utils -run 'TestStableImageFilename|TestTextContentHash|TestCanonicalCacheText|TestStableJSONHash|TestArtifactCacheKey|TestSHA256HexBytes' -count=1
+go test ./internal/infrastructure/docparser -run 'TestResolveAndStore|TestResolveRemoteImages|TestIsIconImage|TestResolveDataURI|TestResolveHTMLDataURI|TestResolveBareBase64' -count=1
+```
+
+Local note: the full `go test ./internal/utils -count=1` command was not used as final evidence because this environment resolves `example.com` to `198.18.0.85`, which trips existing SSRF tests unrelated to this change. The cache-related utility tests were run directly.

--- a/docs/rebuild-cache.zh-CN.md
+++ b/docs/rebuild-cache.zh-CN.md
@@ -1,0 +1,170 @@
+# PR：重建时复用缓存
+
+本文档是 `docs/rebuild-cache.md` 的中文版本。知识重建不再等价于全量重算，而是变成按差异复用：内容未变化时复用已完成的中间产物，只有变化的输入及其依赖层需要重新计算。
+
+## 摘要
+
+原有重建路径会过早删除派生状态，并重新生成大部分高成本产物。即使源文档内容没有变化，一次空重建也会接近首次摄取的成本。
+
+本次改动为重建流水线引入稳定身份、过程产物缓存和按差异对账。对于未变化的知识，`DocReader`、OCR、已下载的 `file_url` 字节、图片视觉语言模型输出、向量、摘要、问题、`GraphRAG` 分块映射和 `Wiki map` 输出都可以命中缓存。`Wiki reduce` 仍会在贡献者状态变化时执行，因为它是跨文档聚合步骤。
+
+## 工作流对比
+
+### 原工作流
+
+改动前，重建是破坏式且身份不稳定的。流水线会删除旧分块和相关记录，重新生成临时图片路径和分块编号，然后在归一化文档内容完全一致时仍然重新执行每个高成本的文档局部阶段。
+
+```mermaid
+flowchart TD
+    accTitle: 原重建工作流
+    accDescr: 原重建路径会提前删除派生记录，并对未变化内容重新执行 OCR、图片理解、向量和生成步骤。
+
+    request["重建请求"]
+    cleanup["删除分块、向量和图记录"]
+    reader["执行 DocReader 和 OCR"]
+    images["用不稳定名称保存抽取图片"]
+    chunks["创建随机分块编号"]
+    embed["为每个文本分块生成向量"]
+    text_gen["重新生成摘要和问题"]
+    image_vlm["重新执行图片 OCR 和描述模型"]
+    graph_rag["重新执行 GraphRAG 分块抽取"]
+    wiki_map["重新执行 Wiki map"]
+    reduce["执行 Wiki reduce"]
+    done["保存重建后的知识"]
+
+    request --> cleanup --> reader --> images --> chunks --> embed --> text_gen --> image_vlm --> graph_rag --> wiki_map --> reduce --> done
+
+    classDef destructive fill:#fee2e2,stroke:#dc2626,stroke-width:2px,color:#7f1d1d
+    classDef expensive fill:#fef3c7,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef output fill:#dcfce7,stroke:#16a34a,stroke-width:2px,color:#14532d
+
+    class cleanup destructive
+    class reader,embed,text_gen,image_vlm,graph_rag,wiki_map,reduce expensive
+    class done output
+```
+
+### 新工作流
+
+新路径会保留可复用状态，在转换阶段缓存 `DocReader` 输出，按内容哈希保存图片，按稳定身份对账分块，只为缺失文本分块建索引，然后让后处理阶段各自使用产物缓存，最后执行不可避免的 `Wiki reduce`。
+
+```mermaid
+flowchart TD
+    accTitle: 新重建工作流
+    accDescr: 新重建路径先计算稳定内容身份，缓存命中时复用已完成产物，然后只保存差异。
+
+    request["重建请求"]
+    keep_state["保留现有派生状态"]
+    doc_cache{"DocReader 命中缓存？"}
+    parse_miss["调用 DocReader 并写入缓存"]
+    parsed["使用解析后的 Markdown 和图片引用"]
+    image_store["按内容哈希保存图片"]
+    plan_chunks["规划稳定分块编号"]
+    reconcile["创建缺失分块并复用已有分块"]
+    embed_new["仅为新文本分块建索引并使用向量缓存"]
+    delete_obsolete["替换完成后删除废弃分块和向量"]
+    postprocess["执行带缓存的后处理阶段"]
+    text_cache["摘要和问题缓存"]
+    image_vlm_cache["图片理解缓存"]
+    graph_cache["图分块缓存"]
+    wiki_map_cache["Wiki map 缓存"]
+    reduce["贡献者需要聚合时执行 Wiki reduce"]
+    done["保存差异化重建结果"]
+
+    request --> keep_state --> doc_cache
+    doc_cache -->|命中| parsed
+    doc_cache -->|未命中| parse_miss --> parsed
+    parsed --> image_store --> plan_chunks --> reconcile --> embed_new --> delete_obsolete --> postprocess
+    postprocess --> text_cache --> wiki_map_cache
+    postprocess --> image_vlm_cache --> wiki_map_cache
+    postprocess --> graph_cache --> wiki_map_cache
+    wiki_map_cache --> reduce --> done
+
+    classDef cache fill:#dbeafe,stroke:#2563eb,stroke-width:2px,color:#1e3a8a
+    classDef stable fill:#ecfdf5,stroke:#059669,stroke-width:2px,color:#064e3b
+    classDef reduce fill:#fef3c7,stroke:#d97706,stroke-width:2px,color:#78350f
+    classDef output fill:#dcfce7,stroke:#16a34a,stroke-width:2px,color:#14532d
+
+    class doc_cache,text_cache,image_vlm_cache,graph_cache,wiki_map_cache cache
+    class keep_state,parsed,image_store,plan_chunks,reconcile,embed_new,delete_obsolete,postprocess stable
+    class reduce reduce
+    class done output
+```
+
+## 改动内容
+
+| 范围 | 之前 | 现在 | 效果 |
+| --- | --- | --- | --- |
+| 文档解析 | 每次重建都会重新执行 `DocReader`。 | `docreader:v1` 按稳定读取输入和读取选项缓存解析输出。 | 未变化文档复用 OCR 和解析结果。 |
+| 已下载的 `file_url` 输入 | 临时下载路径可能在多次运行间变化。 | 已下载字节会参与哈希，并作为稳定的 `DocReader` 缓存边界。 | 相同下载字节即使命中不同临时路径也能命中缓存。 |
+| 图片 | 图片路径不稳定，且常在复用前被删除。 | 图片字节使用按内容寻址的稳定文件名，并在重建清理时受保护。 | 未变化图片资源和图片描述被复用。 |
+| 分块 | 分块使用随机编号。 | 分块编号由归一化内容和位置生成。 | 重建对账可以按差异更新，而不是整体替换。 |
+| 向量 | 每个分块都会重新生成向量。 | `embedding:v1` 按服务商、模型、维度、归一化文本和相关配置缓存向量。 | 未变化分块不会调用向量服务。 |
+| 摘要和问题 | 每次重建都会重新生成。 | `summary:v1` 和 `question:v1` 按归一化提示词输入、模型和配置缓存。 | 未变化分块跳过对话补全调用。 |
+| `GraphRAG` | 分块图抽取会重新运行，缓存载荷也偏向持久化形态。 | `graph:chunk:v1` 缓存模型输出，并从载荷中移除分块专属引用。 | 图抽取结果可复用，并可安全恢复到当前分块。 |
+| `Wiki map` | 重建时会重新生成。 | `wiki:map:v1` 按稳定贡献者材料和映射配置缓存输出。 | 未变化贡献者复用映射输出。 |
+| `Wiki reduce` | 每次重建路径都会进入跨文档聚合。 | 该步骤保持不缓存。 | 唯一不可避免的成本是贡献者级聚合。 |
+
+## 实现覆盖范围
+
+本节把 PR 说明映射到当前工作区的实际 diff，方便评审者定位每一类改动。
+
+| 范围 | 文件 | 覆盖的改动 |
+| --- | --- | --- |
+| 计划和 PR 文档 | `docs/superpowers/plans/2026-07-02-reuse-cache-on-rebuild.md`, `docs/rebuild-cache-pr-description.md`, `docs/rebuild-cache-pr-description.zh-CN.md` | 在仓库中保留实现计划和 PR 说明。 |
+| 过程产物缓存 schema | `migrations/sqlite/000000_init.up.sql`, `migrations/versioned/000065_rebuild_artifact_cache.up.sql`, `migrations/versioned/000065_rebuild_artifact_cache.down.sql`, `internal/types/process_artifact_cache.go`, `internal/types/interfaces/process_artifact_cache.go`, `internal/application/repository/process_artifact_cache.go`, `internal/application/repository/process_artifact_cache_test.go`, `internal/container/container.go` | 新增租户级产物缓存表、唯一缓存身份、repository 写入或更新和读取能力，以及依赖注入注册。 |
+| 缓存键和按内容寻址 | `internal/application/service/rebuild_cache_keys.go`, `internal/application/service/rebuild_cache_keys_test.go`, `internal/utils/content_address.go`, `internal/utils/content_address_test.go` | 新增规范化文本哈希、稳定图片文件名、稳定分块/问题/摘要子分块编号，以及各层产物缓存键。 |
+| `DocReader` 缓存 | `internal/application/service/knowledge_process.go`, `internal/application/service/docreader_cache_payload.go`, `internal/application/service/docreader_cache_payload_test.go`, `internal/application/service/knowledge_docreader_cache_test.go` | 缓存 `ReadResult` 载荷，并验证已下载的 `file_url` 字节在临时路径变化时仍然命中缓存。 |
+| 重建感知的分块对账 | `internal/application/repository/chunk.go`, `internal/application/repository/chunk_sqlite_test.go`, `internal/application/service/chunk.go`, `internal/types/interfaces/chunk.go`, `internal/application/service/knowledge_process.go` | 新增忽略已存在行的创建、按类型列出旧分块、删除废弃分块及直接子分块、稳定分块编号，以及只删除差异向量。 |
+| 知识处理入口 | `internal/application/service/knowledge.go`, `internal/application/service/knowledge_process.go`, `internal/application/service/knowledge_post_process.go` | 注入产物缓存 repository，移除重解析和手动更新路径的提前清理，并把图命名空间重置移动到图后处理阶段。 |
+| 文件服务按内容寻址存储 | `internal/types/interfaces/file.go`, `internal/application/service/file/cos.go`, `internal/application/service/file/dummy.go`, `internal/application/service/file/ks3.go`, `internal/application/service/file/local.go`, `internal/application/service/file/local_test.go`, `internal/application/service/file/minio.go`, `internal/application/service/file/obs.go`, `internal/application/service/file/oss.go`, `internal/application/service/file/s3.go`, `internal/application/service/file/tos.go` | 为所有存储后端新增 `SaveContentAddressedBytes`，让缓存图片字节保存到租户级稳定路径 `exports/cache` 下。 |
+| 图片解析和删除 | `internal/infrastructure/docparser/image_resolver.go`, `internal/infrastructure/docparser/image_resolver_test.go`, `internal/infrastructure/docparser/resolve_remote_images_test.go`, `internal/application/service/knowledge_delete.go` | 按内容哈希保存抽取图片、记录图片内容哈希、保留白名单远程图片原链接，并避免删除共享的按内容寻址产物。 |
+| 图片理解和子分块 | `internal/application/service/image_multimodal.go` | 按图片字节、提示词、模型和配置缓存 OCR/描述结果；创建稳定 OCR/描述子分块编号；重试时跳过已存在子分块。 |
+| 向量 | `internal/application/service/cached_embedder.go`, `internal/application/service/cached_embedder_test.go`, `internal/application/service/knowledge_process.go` | 用过程缓存包裹向量调用，并在正文分块、摘要、生成问题和分块更新中复用该包装器。 |
+| 摘要和问题 | `internal/application/service/knowledge_process.go`, `internal/application/service/question_cache_test.go` | 缓存摘要和问题生成，使用稳定摘要分块编号、稳定生成问题编号，并复用已建索引的摘要分块。 |
+| 图抽取 | `internal/application/service/extract.go`, `internal/application/service/extract_cache_test.go`, `internal/application/service/knowledge_post_process.go` | 缓存每个分块的图抽取结果，并从可复用图载荷中移除持久化分块引用。 |
+| `Wiki` 摄取 | `internal/application/service/wiki_ingest.go`, `internal/application/service/wiki_ingest_batch.go`, `internal/application/service/wiki_ingest_cache_test.go` | 缓存 `Wiki map` 输出，不把 `oldPageSlugs` 放入模型缓存键，只缓存基础更新，并在命中缓存时按当前页面状态重建撤回操作。 |
+| 计划级验收测试 | `internal/application/service/knowledge_rebuild_cache_integration_test.go` | 覆盖未变化重建、崩溃续跑缓存复用，以及模型或提示词配置变化时的层级局部失效。 |
+| 兼容性测试桩 | `internal/agent/tools/data_analysis_materialize_test.go`, `internal/application/service/knowledge_clone_image_test.go`, `internal/application/service/knowledge_create_test.go`, `internal/im/im_file_service_test.go`, `internal/router/router_files_test.go` | 更新测试替身以满足扩展后的 `FileService` 接口。 |
+
+## 缓存边界
+
+| 层 | 缓存命名空间 | 缓存键包含 | 失效条件 |
+| --- | --- | --- | --- |
+| `DocReader` | `docreader:v1` | 读取源材料、可用时的文件字节、读取选项、解析器版本。 | 源字节或文本变化、读取选项变化、解析器版本变化。 |
+| 已下载的 `file_url` 字节 | `docreader:v1` | 已下载字节，而不是临时文件路径。 | 下载内容变化。 |
+| 图片理解 | `vlm:image:v1` | 图片内容哈希、提示词、模型、服务商、视觉语言模型配置。 | 图片字节、提示词、模型或配置变化。 |
+| 向量 | `embedding:v1` | 归一化分块文本、服务商、模型、维度、向量配置。 | 文本、模型、维度、服务商或向量配置变化。 |
+| 摘要 | `summary:v1` | 归一化分块文本、摘要提示词、模型、对话配置。 | 文本、提示词、模型或对话配置变化。 |
+| 问题 | `question:v1` | 归一化分块文本、问题提示词、模型、对话配置。 | 文本、提示词、模型或对话配置变化。 |
+| 图分块映射 | `graph:chunk:v1` | 归一化分块文本、图提示词、模型、图配置。 | 文本、提示词、模型或图配置变化。 |
+| `Wiki map` | `wiki:map:v1` | 贡献者材料、映射提示词、模型、映射配置。 | 贡献者材料、提示词、模型或映射配置变化。 |
+| `Wiki reduce` | 无 | 当前 `Wiki` 贡献者和页面状态。 | 当贡献者状态需要聚合时始终评估。 |
+
+下面两个缓存边界是刻意设计的：
+
+- `oldPageSlugs` 不进入 `Wiki map` 缓存键。它是持久化上下文，不是模型输入。缓存命中时，撤回信息和基础更新会按当前页面状态重新构造。
+- 图分块缓存载荷不保存持久化分块引用。缓存命中后，它们会恢复到当前分块上。
+
+## 预期重建行为
+
+| 场景 | 预期行为 | 覆盖测试 |
+| --- | --- | --- |
+| 重建未变化知识 | 除不可避免的 `Wiki reduce` 外，模型调用接近零。 | `TestReparseUnchangedKnowledgeAvoidsExpensiveModelCalls` |
+| 崩溃后重试 | 已完成的 OCR、向量和 `Wiki map` 工作命中缓存。 | `TestCrashRetryReusesCompletedArtifacts` |
+| 向量模型或配置变化 | 仅向量层未命中；当输入未变化时，OCR、图片理解、摘要、问题和 `Wiki map` 复用。 | `TestRebuildCacheInvalidatesOnlyChangedLayer` |
+| 已下载的 `file_url` 被保存到不同临时路径 | 因下载字节未变化，`DocReader` 命中缓存。 | `TestConvertFileURLDownloadedBytesReuseDocReaderCacheAcrossTempPaths` |
+| 已有图和 `Wiki map` 缓存载荷 | 载荷可复用，且不会泄漏过期持久化引用。 | `TestGraphDataCachePayloadStripsChunkRefsAndRestoresGraph`, `TestWikiMapCachePayloadDropsRetractionsAndRestoresBaseUpdates` |
+
+## 验证
+
+已执行以下检查：
+
+```bash
+go test ./internal/application/service -count=1
+go test ./internal/application/repository ./internal/application/service/file ./internal/container -count=1
+go test ./internal/agent/tools ./internal/im ./internal/router -count=1
+go test ./internal/utils -run 'TestStableImageFilename|TestTextContentHash|TestCanonicalCacheText|TestStableJSONHash|TestArtifactCacheKey|TestSHA256HexBytes' -count=1
+go test ./internal/infrastructure/docparser -run 'TestResolveAndStore|TestResolveRemoteImages|TestIsIconImage|TestResolveDataURI|TestResolveHTMLDataURI|TestResolveBareBase64' -count=1
+```
+
+本地说明：完整的 `go test ./internal/utils -count=1` 没有作为最终证据，因为当前环境会把 `example.com` 解析到 `198.18.0.85`，触发与本次改动无关的既有 SSRF 测试失败。本次已直接运行缓存相关的工具函数测试。

--- a/internal/agent/tools/data_analysis_materialize_test.go
+++ b/internal/agent/tools/data_analysis_materialize_test.go
@@ -28,6 +28,9 @@ func (f *fakeFileService) SaveFile(ctx context.Context, _ *multipart.FileHeader,
 func (f *fakeFileService) SaveBytes(ctx context.Context, _ []byte, _ uint64, _ string, _ bool) (string, error) {
 	return "", errors.New("not implemented in fake")
 }
+func (f *fakeFileService) SaveContentAddressedBytes(ctx context.Context, _ []byte, _ uint64, _ string, _ bool) (string, error) {
+	return "", errors.New("not implemented in fake")
+}
 func (f *fakeFileService) GetFile(ctx context.Context, filePath string) (io.ReadCloser, error) {
 	fn, ok := f.readers[filePath]
 	if !ok {

--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // chunkRepository implements the ChunkRepository interface
@@ -51,6 +52,24 @@ func (r *chunkRepository) CreateChunks(ctx context.Context, chunks []*types.Chun
 	// explicitly inserted, bypassing GORM's default value behavior.
 	// SeqID=0 is skipped by GORM automatically (autoIncrement tag).
 	return db.Select("*").CreateInBatches(chunks, 100).Error
+}
+
+func (r *chunkRepository) CreateChunksIgnoreExisting(ctx context.Context, chunks []*types.Chunk) error {
+	if len(chunks) == 0 {
+		return nil
+	}
+	for _, chunk := range chunks {
+		chunk.Content = common.CleanInvalidUTF8(chunk.Content)
+	}
+
+	db := r.db.WithContext(ctx)
+	if db.Dialector.Name() == "sqlite" {
+		if err := types.AssignChunkSeqIDs(db, chunks); err != nil {
+			return fmt.Errorf("failed to assign chunk seq_ids: %w", err)
+		}
+	}
+
+	return db.Select("*").Clauses(clause.OnConflict{DoNothing: true}).CreateInBatches(chunks, 100).Error
 }
 
 // GetChunkByID retrieves a chunk by its ID and tenant ID
@@ -137,6 +156,25 @@ func (r *chunkRepository) ListChunksByKnowledgeID(
 	var chunks []*types.Chunk
 	if err := r.db.WithContext(ctx).
 		Where("tenant_id = ? AND knowledge_id = ? and chunk_type = ?", tenantID, knowledgeID, "text").
+		Order("chunk_index ASC").
+		Find(&chunks).Error; err != nil {
+		return nil, err
+	}
+	return chunks, nil
+}
+
+func (r *chunkRepository) ListChunksByKnowledgeIDIncludeTypes(
+	ctx context.Context,
+	tenantID uint64,
+	knowledgeID string,
+	chunkTypes []types.ChunkType,
+) ([]*types.Chunk, error) {
+	if len(chunkTypes) == 0 {
+		return []*types.Chunk{}, nil
+	}
+	var chunks []*types.Chunk
+	if err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND knowledge_id = ? AND chunk_type IN ?", tenantID, knowledgeID, chunkTypes).
 		Order("chunk_index ASC").
 		Find(&chunks).Error; err != nil {
 		return nil, err
@@ -436,6 +474,25 @@ func (r *chunkRepository) DeleteChunks(ctx context.Context, tenantID uint64, ids
 		}
 	}
 	return nil
+}
+
+func (r *chunkRepository) DeleteChunksAndChildren(ctx context.Context, tenantID uint64, ids []string) ([]string, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var deletedIDs []string
+	if err := r.db.WithContext(ctx).Model(&types.Chunk{}).
+		Where("tenant_id = ? AND (id IN ? OR parent_chunk_id IN ?)", tenantID, ids, ids).
+		Pluck("id", &deletedIDs).Error; err != nil {
+		return nil, err
+	}
+	if len(deletedIDs) == 0 {
+		return nil, nil
+	}
+	if err := r.DeleteChunks(ctx, tenantID, deletedIDs); err != nil {
+		return nil, err
+	}
+	return deletedIDs, nil
 }
 
 // DeleteChunksByKnowledgeID deletes all chunks for a knowledge ID

--- a/internal/application/repository/chunk_sqlite_test.go
+++ b/internal/application/repository/chunk_sqlite_test.go
@@ -215,3 +215,26 @@ func TestUpdateChunk_SQLite_NoNOWError(t *testing.T) {
 	require.NoError(t, db.First(&saved, "id = ?", chunk.ID).Error)
 	assert.Equal(t, "updated content", saved.Content)
 }
+
+func TestDeleteChunksAndChildren_SQLiteDeletesDirectChildren(t *testing.T) {
+	db := setupChunkTestDB(t)
+	repo := NewChunkRepository(db)
+	ctx := context.Background()
+
+	kbID := uuid.New().String()
+	knowledgeID := uuid.New().String()
+	parent := makeChunk(kbID, knowledgeID, string(types.ChunkTypeText))
+	child := makeChunk(kbID, knowledgeID, string(types.ChunkTypeImageOCR))
+	child.ParentChunkID = parent.ID
+	sibling := makeChunk(kbID, knowledgeID, string(types.ChunkTypeText))
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{parent, child, sibling}))
+
+	deleted, err := repo.DeleteChunksAndChildren(ctx, parent.TenantID, []string{parent.ID})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{parent.ID, child.ID}, deleted)
+
+	var remaining []types.Chunk
+	require.NoError(t, db.Find(&remaining).Error)
+	require.Len(t, remaining, 1)
+	require.Equal(t, sibling.ID, remaining[0].ID)
+}

--- a/internal/application/repository/process_artifact_cache.go
+++ b/internal/application/repository/process_artifact_cache.go
@@ -1,0 +1,72 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type processArtifactCacheRepository struct {
+	db *gorm.DB
+}
+
+func NewProcessArtifactCacheRepository(db *gorm.DB) interfaces.ProcessArtifactCacheRepository {
+	return &processArtifactCacheRepository{db: db}
+}
+
+func (r *processArtifactCacheRepository) Put(
+	ctx context.Context,
+	key types.ProcessArtifactCacheKey,
+	payload types.JSONMap,
+) error {
+	row := &types.ProcessArtifactCache{
+		TenantID:      key.TenantID,
+		ArtifactType:  key.ArtifactType,
+		CacheKey:      key.CacheKey,
+		ModelID:       key.ModelID,
+		ConfigHash:    key.ConfigHash,
+		PromptVersion: key.PromptVersion,
+		Payload:       payload,
+	}
+
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "tenant_id"},
+			{Name: "artifact_type"},
+			{Name: "cache_key"},
+			{Name: "model_id"},
+			{Name: "config_hash"},
+			{Name: "prompt_version"},
+		},
+		DoUpdates: clause.AssignmentColumns([]string{"payload", "updated_at"}),
+	}).Create(row).Error
+}
+
+func (r *processArtifactCacheRepository) Get(
+	ctx context.Context,
+	key types.ProcessArtifactCacheKey,
+) (types.JSONMap, bool, error) {
+	var row types.ProcessArtifactCache
+	err := r.db.WithContext(ctx).
+		Where(
+			"tenant_id = ? AND artifact_type = ? AND cache_key = ? AND model_id = ? AND config_hash = ? AND prompt_version = ?",
+			key.TenantID,
+			key.ArtifactType,
+			key.CacheKey,
+			key.ModelID,
+			key.ConfigHash,
+			key.PromptVersion,
+		).
+		First(&row).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return row.Payload, true, nil
+}

--- a/internal/application/repository/process_artifact_cache_test.go
+++ b/internal/application/repository/process_artifact_cache_test.go
@@ -1,0 +1,73 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func processArtifactCacheTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.ProcessArtifactCache{}))
+	return db
+}
+
+func TestProcessArtifactCacheRepositoryPutAndGet(t *testing.T) {
+	db := processArtifactCacheTestDB(t)
+	repo := repository.NewProcessArtifactCacheRepository(db)
+
+	key := types.ProcessArtifactCacheKey{
+		TenantID:      42,
+		ArtifactType:  "embedding:v1",
+		CacheKey:      "abc",
+		ModelID:       "embed-1",
+		ConfigHash:    "cfg",
+		PromptVersion: "prompt",
+	}
+	require.NoError(t, repo.Put(context.Background(), key, types.JSONMap{"vector": []float64{1, 2, 3}}))
+
+	got, ok, err := repo.Get(context.Background(), key)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []any{float64(1), float64(2), float64(3)}, got["vector"])
+}
+
+func TestProcessArtifactCacheRepositoryPutUpsertsPayload(t *testing.T) {
+	db := processArtifactCacheTestDB(t)
+	repo := repository.NewProcessArtifactCacheRepository(db)
+
+	key := types.ProcessArtifactCacheKey{
+		TenantID:     42,
+		ArtifactType: "summary:v1",
+		CacheKey:     "same",
+		ModelID:      "chat-1",
+	}
+	require.NoError(t, repo.Put(context.Background(), key, types.JSONMap{"summary": "old"}))
+	require.NoError(t, repo.Put(context.Background(), key, types.JSONMap{"summary": "new"}))
+
+	got, ok, err := repo.Get(context.Background(), key)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "new", got["summary"])
+}
+
+func TestProcessArtifactCacheRepositoryGetMiss(t *testing.T) {
+	db := processArtifactCacheTestDB(t)
+	repo := repository.NewProcessArtifactCacheRepository(db)
+
+	got, ok, err := repo.Get(context.Background(), types.ProcessArtifactCacheKey{
+		TenantID:     42,
+		ArtifactType: "embedding:v1",
+		CacheKey:     "missing",
+	})
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, got)
+}

--- a/internal/application/service/cached_embedder.go
+++ b/internal/application/service/cached_embedder.go
@@ -1,0 +1,149 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type cachedEmbedder struct {
+	tenantID uint64
+	inner    embedding.Embedder
+	cache    interfaces.ProcessArtifactCacheRepository
+}
+
+func wrapEmbedderWithProcessCache(
+	tenantID uint64,
+	inner embedding.Embedder,
+	cache interfaces.ProcessArtifactCacheRepository,
+) embedding.Embedder {
+	if inner == nil || cache == nil {
+		return inner
+	}
+	return newCachedEmbedder(tenantID, inner, cache)
+}
+
+func newCachedEmbedder(
+	tenantID uint64,
+	inner embedding.Embedder,
+	cache interfaces.ProcessArtifactCacheRepository,
+) embedding.Embedder {
+	return &cachedEmbedder{tenantID: tenantID, inner: inner, cache: cache}
+}
+
+func (e *cachedEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	vectors, err := e.BatchEmbedWithPool(ctx, e, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(vectors) == 0 {
+		return nil, nil
+	}
+	return vectors[0], nil
+}
+
+func (e *cachedEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.BatchEmbedWithPool(ctx, e, texts)
+}
+
+func (e *cachedEmbedder) BatchEmbedWithPool(ctx context.Context, _ embedding.Embedder, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	missTexts := make([]string, 0, len(texts))
+	missIndexes := make([]int, 0, len(texts))
+
+	for i, text := range texts {
+		key := embeddingArtifactKey(
+			e.tenantID,
+			e.inner.GetModelID(),
+			e.inner.GetDimensions(),
+			embeddingConfigHash(e.inner),
+			text,
+		)
+		payload, ok, err := e.cache.Get(ctx, key)
+		if err != nil {
+			logger.Warnf(ctx, "embedding cache read failed, recomputing: %v", err)
+			ok = false
+		}
+		if ok {
+			if vector, ok := jsonVectorToFloat32(payload["vector"]); ok {
+				out[i] = vector
+				continue
+			}
+			logger.Warnf(ctx, "embedding cache payload invalid, recomputing")
+		}
+		missTexts = append(missTexts, text)
+		missIndexes = append(missIndexes, i)
+	}
+
+	if len(missTexts) == 0 {
+		return out, nil
+	}
+
+	missVectors, err := e.inner.BatchEmbedWithPool(ctx, e.inner, missTexts)
+	if err != nil {
+		return nil, err
+	}
+	for i, vector := range missVectors {
+		idx := missIndexes[i]
+		out[idx] = vector
+		key := embeddingArtifactKey(
+			e.tenantID,
+			e.inner.GetModelID(),
+			e.inner.GetDimensions(),
+			embeddingConfigHash(e.inner),
+			texts[idx],
+		)
+		if err := e.cache.Put(ctx, key, types.JSONMap{"vector": float32VectorToJSON(vector)}); err != nil {
+			logger.Warnf(ctx, "embedding cache write failed: %v", err)
+		}
+	}
+
+	return out, nil
+}
+
+func (e *cachedEmbedder) GetModelName() string { return e.inner.GetModelName() }
+func (e *cachedEmbedder) GetDimensions() int   { return e.inner.GetDimensions() }
+func (e *cachedEmbedder) GetModelID() string   { return e.inner.GetModelID() }
+
+func embeddingConfigHash(model embedding.Embedder) string {
+	return artifactConfigHash(types.JSONMap{
+		"model_name": model.GetModelName(),
+		"dimensions": model.GetDimensions(),
+	})
+}
+
+func jsonVectorToFloat32(v any) ([]float32, bool) {
+	switch values := v.(type) {
+	case []float32:
+		return append([]float32(nil), values...), true
+	case []float64:
+		out := make([]float32, len(values))
+		for i, value := range values {
+			out[i] = float32(value)
+		}
+		return out, true
+	case []any:
+		out := make([]float32, len(values))
+		for i, value := range values {
+			f, ok := value.(float64)
+			if !ok {
+				return nil, false
+			}
+			out[i] = float32(f)
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+func float32VectorToJSON(vector []float32) []float64 {
+	out := make([]float64, len(vector))
+	for i, value := range vector {
+		out[i] = float64(value)
+	}
+	return out
+}

--- a/internal/application/service/cached_embedder_test.go
+++ b/internal/application/service/cached_embedder_test.go
@@ -1,0 +1,127 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+type countingEmbedder struct {
+	calls      int
+	vectors    [][]float32
+	modelID    string
+	modelName  string
+	dimensions int
+}
+
+func (e *countingEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	e.calls++
+	if len(e.vectors) == 0 {
+		return nil, nil
+	}
+	return e.vectors[0], nil
+}
+
+func (e *countingEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	e.calls++
+	return e.vectors[:len(texts)], nil
+}
+
+func (e *countingEmbedder) BatchEmbedWithPool(ctx context.Context, model embedding.Embedder, texts []string) ([][]float32, error) {
+	e.calls++
+	return e.vectors[:len(texts)], nil
+}
+
+func (e *countingEmbedder) GetModelName() string {
+	if e.modelName != "" {
+		return e.modelName
+	}
+	return "counting-model"
+}
+
+func (e *countingEmbedder) GetDimensions() int {
+	if e.dimensions != 0 {
+		return e.dimensions
+	}
+	return 2
+}
+
+func (e *countingEmbedder) GetModelID() string {
+	if e.modelID != "" {
+		return e.modelID
+	}
+	return "model-1"
+}
+
+type memoryArtifactCache struct {
+	mu   sync.Mutex
+	rows map[types.ProcessArtifactCacheKey]types.JSONMap
+}
+
+func newMemoryArtifactCache() *memoryArtifactCache {
+	return &memoryArtifactCache{rows: map[types.ProcessArtifactCacheKey]types.JSONMap{}}
+}
+
+func (m *memoryArtifactCache) Put(ctx context.Context, key types.ProcessArtifactCacheKey, payload types.JSONMap) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rows[key] = payload
+	return nil
+}
+
+func (m *memoryArtifactCache) Get(ctx context.Context, key types.ProcessArtifactCacheKey) (types.JSONMap, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	payload, ok := m.rows[key]
+	return payload, ok, nil
+}
+
+func TestCachedEmbedderBatchUsesCacheWithoutCallingInner(t *testing.T) {
+	inner := &countingEmbedder{vectors: [][]float32{{9, 9}}}
+	repo := newMemoryArtifactCache()
+	key := embeddingArtifactKey(7, "model-1", 2, embeddingConfigHash(inner), "hello")
+	require.NoError(t, repo.Put(context.Background(), key, types.JSONMap{"vector": []float64{1, 2}}))
+
+	cached := newCachedEmbedder(7, inner, repo)
+	got, err := cached.BatchEmbedWithPool(context.Background(), cached, []string{"hello"})
+
+	require.NoError(t, err)
+	require.Equal(t, [][]float32{{1, 2}}, got)
+	require.Equal(t, 0, inner.calls)
+}
+
+func TestCachedEmbedderBatchWritesMisses(t *testing.T) {
+	inner := &countingEmbedder{vectors: [][]float32{{3, 4}}}
+	repo := newMemoryArtifactCache()
+	cached := newCachedEmbedder(7, inner, repo)
+
+	got, err := cached.BatchEmbedWithPool(context.Background(), cached, []string{"miss"})
+
+	require.NoError(t, err)
+	require.Equal(t, [][]float32{{3, 4}}, got)
+	require.Equal(t, 1, inner.calls)
+
+	key := embeddingArtifactKey(7, "model-1", 2, embeddingConfigHash(inner), "miss")
+	payload, ok, err := repo.Get(context.Background(), key)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []float64{3, 4}, payload["vector"])
+}
+
+func TestCachedEmbedderUsesCanonicalTextKey(t *testing.T) {
+	inner := &countingEmbedder{vectors: [][]float32{{9, 9}}}
+	repo := newMemoryArtifactCache()
+	key := embeddingArtifactKey(7, "model-1", 2, embeddingConfigHash(inner), "hello\n")
+	require.NoError(t, repo.Put(context.Background(), key, types.JSONMap{"vector": []any{float64(5), float64(6)}}))
+
+	cached := newCachedEmbedder(7, inner, repo)
+	got, err := cached.BatchEmbedWithPool(context.Background(), cached, []string{"hello\r\n"})
+
+	require.NoError(t, err)
+	require.Equal(t, [][]float32{{5, 6}}, got)
+	require.Equal(t, 0, inner.calls)
+}

--- a/internal/application/service/chunk.go
+++ b/internal/application/service/chunk.go
@@ -78,6 +78,20 @@ func (s *chunkService) CreateChunks(ctx context.Context, chunks []*types.Chunk) 
 	return nil
 }
 
+func (s *chunkService) CreateChunksIgnoreExisting(ctx context.Context, chunks []*types.Chunk) error {
+	if len(chunks) == 0 {
+		return nil
+	}
+	if err := s.chunkRepository.CreateChunksIgnoreExisting(ctx, chunks); err != nil {
+		logger.ErrorWithFields(ctx, err, map[string]interface{}{
+			"chunk_count": len(chunks),
+		})
+		return err
+	}
+	logger.Infof(ctx, "Add %d chunks successfully, ignoring existing rows", len(chunks))
+	return nil
+}
+
 // GetChunkByID retrieves a chunk by its ID
 // This method fetches a specific chunk using its ID and validates tenant access
 // Parameters:
@@ -143,6 +157,15 @@ func (s *chunkService) ListChunksByKnowledgeID(ctx context.Context, knowledgeID 
 
 	logger.Infof(ctx, "Retrieved %d chunks successfully", len(chunks))
 	return chunks, nil
+}
+
+func (s *chunkService) ListChunksByKnowledgeIDIncludeTypes(
+	ctx context.Context,
+	tenantID uint64,
+	knowledgeID string,
+	chunkTypes []types.ChunkType,
+) ([]*types.Chunk, error) {
+	return s.chunkRepository.ListChunksByKnowledgeIDIncludeTypes(ctx, tenantID, knowledgeID, chunkTypes)
 }
 
 // ListPagedChunksByKnowledgeID lists chunks for a knowledge ID with pagination
@@ -280,6 +303,10 @@ func (s *chunkService) DeleteChunks(ctx context.Context, ids []string) error {
 
 	logger.Infof(ctx, "Successfully deleted %d chunks", len(ids))
 	return nil
+}
+
+func (s *chunkService) DeleteChunksAndChildren(ctx context.Context, tenantID uint64, ids []string) ([]string, error) {
+	return s.chunkRepository.DeleteChunksAndChildren(ctx, tenantID, ids)
 }
 
 // DeleteChunksByKnowledgeID deletes all chunks for a knowledge ID

--- a/internal/application/service/docreader_cache_payload.go
+++ b/internal/application/service/docreader_cache_payload.go
@@ -1,0 +1,120 @@
+package service
+
+import (
+	"encoding/base64"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func encodeReadResultPayload(result *types.ReadResult) types.JSONMap {
+	if result == nil {
+		return nil
+	}
+	refs := make([]any, 0, len(result.ImageRefs))
+	for _, ref := range result.ImageRefs {
+		refs = append(refs, types.JSONMap{
+			"filename":     ref.Filename,
+			"original_ref": ref.OriginalRef,
+			"mime_type":    ref.MimeType,
+			"storage_key":  ref.StorageKey,
+			"image_data":   base64.StdEncoding.EncodeToString(ref.ImageData),
+			"is_original":  ref.IsOriginal,
+		})
+	}
+	return types.JSONMap{
+		"markdown":   result.MarkdownContent,
+		"metadata":   result.Metadata,
+		"image_refs": refs,
+		"image_dir":  result.ImageDirPath,
+		"is_audio":   result.IsAudio,
+		"audio_data": base64.StdEncoding.EncodeToString(result.AudioData),
+	}
+}
+
+func decodeReadResultPayload(payload types.JSONMap) *types.ReadResult {
+	result := &types.ReadResult{
+		MarkdownContent: stringFromPayload(payload, "markdown"),
+		ImageDirPath:    stringFromPayload(payload, "image_dir"),
+		Metadata:        stringMapFromPayload(payload["metadata"]),
+		IsAudio:         boolFromPayload(payload, "is_audio"),
+	}
+	if rawAudio := stringFromPayload(payload, "audio_data"); rawAudio != "" {
+		if data, err := base64.StdEncoding.DecodeString(rawAudio); err == nil {
+			result.AudioData = data
+		}
+	}
+	for _, item := range anySliceFromPayload(payload["image_refs"]) {
+		m, ok := item.(map[string]any)
+		if !ok {
+			if jm, ok := item.(types.JSONMap); ok {
+				m = map[string]any(jm)
+			} else {
+				continue
+			}
+		}
+		ref := types.ImageRef{
+			Filename:    stringFromAny(m["filename"]),
+			OriginalRef: stringFromAny(m["original_ref"]),
+			MimeType:    stringFromAny(m["mime_type"]),
+			StorageKey:  stringFromAny(m["storage_key"]),
+			IsOriginal:  boolFromAny(m["is_original"]),
+		}
+		if raw := stringFromAny(m["image_data"]); raw != "" {
+			if data, err := base64.StdEncoding.DecodeString(raw); err == nil {
+				ref.ImageData = data
+			}
+		}
+		result.ImageRefs = append(result.ImageRefs, ref)
+	}
+	return result
+}
+
+func stringFromPayload(payload types.JSONMap, key string) string {
+	return stringFromAny(payload[key])
+}
+
+func stringFromAny(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func boolFromPayload(payload types.JSONMap, key string) bool {
+	return boolFromAny(payload[key])
+}
+
+func boolFromAny(v any) bool {
+	if b, ok := v.(bool); ok {
+		return b
+	}
+	return false
+}
+
+func stringMapFromPayload(v any) map[string]string {
+	out := map[string]string{}
+	switch m := v.(type) {
+	case map[string]string:
+		for k, value := range m {
+			out[k] = value
+		}
+	case map[string]any:
+		for k, value := range m {
+			out[k] = stringFromAny(value)
+		}
+	case types.JSONMap:
+		for k, value := range m {
+			out[k] = stringFromAny(value)
+		}
+	}
+	return out
+}
+
+func anySliceFromPayload(v any) []any {
+	switch s := v.(type) {
+	case []any:
+		return s
+	default:
+		return nil
+	}
+}

--- a/internal/application/service/docreader_cache_payload_test.go
+++ b/internal/application/service/docreader_cache_payload_test.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadResultPayloadRoundTripPreservesBytesAndMetadata(t *testing.T) {
+	in := &types.ReadResult{
+		MarkdownContent: "# doc",
+		Metadata:        map[string]string{"pages": "1"},
+		ImageDirPath:    "images",
+		IsAudio:         true,
+		AudioData:       []byte("audio"),
+		ImageRefs: []types.ImageRef{{
+			Filename:    "img.png",
+			OriginalRef: "img.png",
+			MimeType:    "image/png",
+			StorageKey:  "key",
+			ImageData:   []byte("image"),
+			IsOriginal:  true,
+		}},
+	}
+
+	got := decodeReadResultPayload(encodeReadResultPayload(in))
+
+	require.Equal(t, in.MarkdownContent, got.MarkdownContent)
+	require.Equal(t, in.Metadata, got.Metadata)
+	require.Equal(t, in.ImageDirPath, got.ImageDirPath)
+	require.Equal(t, in.IsAudio, got.IsAudio)
+	require.Equal(t, in.AudioData, got.AudioData)
+	require.Len(t, got.ImageRefs, 1)
+	require.Equal(t, in.ImageRefs[0], got.ImageRefs[0])
+}
+
+func TestDocReaderArtifactKeyDependsOnFileBytesAndParserConfig(t *testing.T) {
+	base := docReaderArtifactKey(7, "pdf", "builtin", "cfg", []byte("same"))
+	same := docReaderArtifactKey(7, "pdf", "builtin", "cfg", []byte("same"))
+	changedBytes := docReaderArtifactKey(7, "pdf", "builtin", "cfg", []byte("changed"))
+	changedConfig := docReaderArtifactKey(7, "pdf", "builtin", "cfg2", []byte("same"))
+
+	require.Equal(t, base, same)
+	require.Equal(t, "docreader:v1", base.ArtifactType)
+	require.NotEqual(t, base.CacheKey, changedBytes.CacheKey)
+	require.NotEqual(t, base.ConfigHash, changedConfig.ConfigHash)
+}

--- a/internal/application/service/extract.go
+++ b/internal/application/service/extract.go
@@ -162,6 +162,7 @@ type ChunkExtractService struct {
 	knowledgeRepo     interfaces.KnowledgeRepository
 	chunkRepo         interfaces.ChunkRepository
 	graphEngine       interfaces.RetrieveGraphRepository
+	processCacheRepo  interfaces.ProcessArtifactCacheRepository
 	// spanTracker records this graph-extract task's subspan under the
 	// parent attempt's postprocess stage so the trace viewer shows real
 	// per-chunk graph extraction time rather than the upstream's enqueue.
@@ -176,6 +177,7 @@ func NewChunkExtractService(
 	knowledgeRepo interfaces.KnowledgeRepository,
 	chunkRepo interfaces.ChunkRepository,
 	graphEngine interfaces.RetrieveGraphRepository,
+	processCacheRepo interfaces.ProcessArtifactCacheRepository,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
 	return &ChunkExtractService{
@@ -185,6 +187,7 @@ func NewChunkExtractService(
 		knowledgeRepo:     knowledgeRepo,
 		chunkRepo:         chunkRepo,
 		graphEngine:       graphEngine,
+		processCacheRepo:  processCacheRepo,
 		spanTracker:       spanTracker,
 	}
 }
@@ -194,6 +197,39 @@ func (s *ChunkExtractService) tracker() SpanTracker {
 		return noopSpanTracker{}
 	}
 	return s.spanTracker
+}
+
+func graphDataCachePayload(graph *types.GraphData) types.JSONMap {
+	if graph == nil {
+		return types.JSONMap{"graph": &types.GraphData{}}
+	}
+	var cached types.GraphData
+	if b, err := json.Marshal(graph); err == nil {
+		_ = json.Unmarshal(b, &cached)
+	}
+	for _, node := range cached.Node {
+		node.Chunks = nil
+	}
+	return types.JSONMap{"graph": cached}
+}
+
+func graphDataFromCachePayload(payload types.JSONMap) (*types.GraphData, bool) {
+	raw, ok := payload["graph"]
+	if !ok {
+		return nil, false
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return nil, false
+	}
+	var graph types.GraphData
+	if err := json.Unmarshal(b, &graph); err != nil {
+		return nil, false
+	}
+	for _, node := range graph.Node {
+		node.Chunks = nil
+	}
+	return &graph, true
 }
 
 // Handle handles the chunk extraction task
@@ -327,10 +363,44 @@ func (s *ChunkExtractService) Handle(ctx context.Context, t *asynq.Task) error {
 		},
 	}
 	extractor := chatpipeline.NewExtractor(chatModel, template)
-	graph, err := extractor.Extract(ctx, chunk.Content)
-	if err != nil {
-		handleErr = err
-		return err
+
+	cacheKey := graphChunkArtifactKey(
+		p.TenantID,
+		summaryModelID(chatModel, p.ModelID),
+		artifactPromptVersion(template.Description, artifactConfigHash(template.Tags), artifactConfigHash(template.Examples)),
+		artifactConfigHash(types.JSONMap{
+			"model_name":     chatModel.GetModelName(),
+			"extract_config": extractCfg,
+		}),
+		chunk.Content,
+	)
+	graphCacheHit := false
+	var graph *types.GraphData
+	if s.processCacheRepo != nil {
+		cachePayload, ok, cacheErr := s.processCacheRepo.Get(ctx, cacheKey)
+		if cacheErr != nil {
+			logger.Warnf(ctx, "graph chunk cache read failed, recomputing: %v", cacheErr)
+		} else if ok {
+			if cachedGraph, ok := graphDataFromCachePayload(cachePayload); ok {
+				graph = cachedGraph
+				graphCacheHit = true
+				graphOut["cache_hit"] = true
+			} else {
+				logger.Warnf(ctx, "graph chunk cache payload invalid, recomputing")
+			}
+		}
+	}
+	if !graphCacheHit {
+		graph, err = extractor.Extract(ctx, chunk.Content)
+		if err != nil {
+			handleErr = err
+			return err
+		}
+		if s.processCacheRepo != nil {
+			if cacheErr := s.processCacheRepo.Put(ctx, cacheKey, graphDataCachePayload(graph)); cacheErr != nil {
+				logger.Warnf(ctx, "graph chunk cache write failed: %v", cacheErr)
+			}
+		}
 	}
 
 	chunk, err = s.chunkRepo.GetChunkByID(ctx, p.TenantID, p.ChunkID)

--- a/internal/application/service/extract_cache_test.go
+++ b/internal/application/service/extract_cache_test.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGraphDataCachePayloadStripsChunkRefsAndRestoresGraph(t *testing.T) {
+	graph := &types.GraphData{
+		Node: []*types.GraphNode{
+			{Name: "alpha", Chunks: []string{"old-chunk"}, Attributes: []string{"attr"}},
+		},
+		Relation: []*types.GraphRelation{
+			{Node1: "alpha", Node2: "beta", Type: "relates_to"},
+		},
+	}
+
+	payload := graphDataCachePayload(graph)
+	restored, ok := graphDataFromCachePayload(payload)
+
+	require.True(t, ok)
+	require.Len(t, restored.Node, 1)
+	require.Equal(t, "alpha", restored.Node[0].Name)
+	require.Empty(t, restored.Node[0].Chunks)
+	require.Len(t, restored.Relation, 1)
+	require.Equal(t, "relates_to", restored.Relation[0].Type)
+}

--- a/internal/application/service/file/cos.go
+++ b/internal/application/service/file/cos.go
@@ -236,6 +236,19 @@ func (s *cosFileService) SaveBytes(ctx context.Context, data []byte, tenantID ui
 	return fmt.Sprintf("cos://%s/%s/%s", s.bucketName, s.region, objectName), nil
 }
 
+func (s *cosFileService) SaveContentAddressedBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error) {
+	safeName, err := utils.SafeFileName(fileName)
+	if err != nil {
+		return "", fmt.Errorf("invalid file name: %w", err)
+	}
+	objectName := strings.TrimPrefix(fmt.Sprintf("%s/%d/exports/cache/%s", strings.TrimRight(s.cosPathPrefix, "/"), tenantID, safeName), "/")
+	_, err = s.client.Object.Put(ctx, objectName, bytes.NewReader(data), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to upload content-addressed bytes to COS: %w", err)
+	}
+	return fmt.Sprintf("cos://%s/%s/%s", s.bucketName, s.region, objectName), nil
+}
+
 // GetFileURL returns a presigned download URL for the file
 func (s *cosFileService) GetFileURL(ctx context.Context, filePath string) (string, error) {
 	// 判断文件属于哪个桶

--- a/internal/application/service/file/dummy.go
+++ b/internal/application/service/file/dummy.go
@@ -3,6 +3,7 @@ package file
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"mime/multipart"
 
@@ -46,6 +47,10 @@ func (s *DummyFileService) DeleteFile(ctx context.Context, filePath string) erro
 // SaveBytes pretends to save bytes but just returns a random UUID
 func (s *DummyFileService) SaveBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error) {
 	return uuid.New().String(), nil
+}
+
+func (s *DummyFileService) SaveContentAddressedBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error) {
+	return fmt.Sprintf("dummy://%d/exports/cache/%s", tenantID, fileName), nil
 }
 
 // CopyFile is a no-op for the dummy service: it logs a warning and returns the

--- a/internal/application/service/file/ks3.go
+++ b/internal/application/service/file/ks3.go
@@ -178,6 +178,24 @@ func (s *ks3FileService) SaveBytes(ctx context.Context, data []byte, tenantID ui
 	return fmt.Sprintf("%s%s/%s", ks3Scheme, s.bucketName, objectKey), nil
 }
 
+func (s *ks3FileService) SaveContentAddressedBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error) {
+	safeName, err := utils.SafeFileName(fileName)
+	if err != nil {
+		return "", fmt.Errorf("invalid file name: %w", err)
+	}
+	objectKey := joinKS3Key(s.pathPrefix, fmt.Sprintf("%d", tenantID), "exports", "cache", safeName)
+	_, err = s.client.PutObject(&ks3s3.PutObjectInput{
+		Bucket:      ks3aws.String(s.bucketName),
+		Key:         ks3aws.String(objectKey),
+		Body:        bytes.NewReader(data),
+		ContentType: ks3aws.String(utils.GetContentTypeByExt(filepath.Ext(safeName))),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to upload content-addressed bytes to KS3: %w", err)
+	}
+	return fmt.Sprintf("%s%s/%s", ks3Scheme, s.bucketName, objectKey), nil
+}
+
 // CopyFile copies an existing KS3 object to a new knowledge-owned object using a
 // server-side CopyObject (no data leaves KS3). The destination uses the same
 // layout as SaveFile. Returns ErrCrossBackendCopy when srcPath is not a ks3:// path.

--- a/internal/application/service/file/local.go
+++ b/internal/application/service/file/local.go
@@ -245,6 +245,40 @@ func (s *localFileService) SaveBytes(ctx context.Context, data []byte, tenantID 
 	return localScheme + filepath.ToSlash(relPath), nil
 }
 
+func (s *localFileService) SaveContentAddressedBytes(
+	ctx context.Context,
+	data []byte,
+	tenantID uint64,
+	fileName string,
+	temp bool,
+) (string, error) {
+	logger.Infof(ctx, "Saving content-addressed bytes: fileName=%s, size=%d, tenantID=%d, temp=%v", fileName, len(data), tenantID, temp)
+
+	safeName, err := secutils.SafeFileName(fileName)
+	if err != nil {
+		return "", fmt.Errorf("invalid file name: %w", err)
+	}
+
+	dir := filepath.Join(s.baseDir, fmt.Sprintf("%d", tenantID), "exports", "cache")
+	if _, err := secutils.SafePathUnderBase(s.baseDir, dir); err != nil {
+		return "", fmt.Errorf("invalid path: %w", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	filePath := filepath.Join(dir, safeName)
+	if _, err := secutils.SafePathUnderBase(s.baseDir, filePath); err != nil {
+		return "", fmt.Errorf("invalid path: %w", err)
+	}
+	if err := os.WriteFile(filePath, data, 0o644); err != nil {
+		return "", fmt.Errorf("failed to write file: %w", err)
+	}
+
+	relPath, _ := filepath.Rel(s.baseDir, filePath)
+	return localScheme + filepath.ToSlash(relPath), nil
+}
+
 // GetFileURL returns a download URL for the file.
 // When externalURL is configured, returns a presigned HTTP URL suitable for external access.
 // Otherwise returns the local://... path for backward compatibility.

--- a/internal/application/service/file/local_test.go
+++ b/internal/application/service/file/local_test.go
@@ -3,6 +3,7 @@ package file
 import (
 	"context"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,4 +40,18 @@ func TestLocalGetFileURL_NoExternalURL(t *testing.T) {
 	got, err := svc.GetFileURL(context.Background(), "local://1/abc/img.png")
 	require.NoError(t, err)
 	assert.Equal(t, "local://1/abc/img.png", got)
+}
+
+func TestLocalSaveContentAddressedBytesReturnsStablePath(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewLocalFileService(dir, "")
+
+	got1, err := svc.SaveContentAddressedBytes(context.Background(), []byte("same"), 7, "abc.png", false)
+	require.NoError(t, err)
+	got2, err := svc.SaveContentAddressedBytes(context.Background(), []byte("same"), 7, "abc.png", false)
+	require.NoError(t, err)
+
+	require.Equal(t, got1, got2)
+	require.Contains(t, got1, "/7/exports/cache/")
+	require.True(t, strings.HasSuffix(got1, "/abc.png"))
 }

--- a/internal/application/service/file/minio.go
+++ b/internal/application/service/file/minio.go
@@ -214,6 +214,22 @@ func (s *minioFileService) SaveBytes(ctx context.Context, data []byte, tenantID 
 	return fmt.Sprintf("minio://%s/%s", s.bucketName, objectName), nil
 }
 
+func (s *minioFileService) SaveContentAddressedBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error) {
+	safeName, err := utils.SafeFileName(fileName)
+	if err != nil {
+		return "", fmt.Errorf("invalid file name: %w", err)
+	}
+	objectName := fmt.Sprintf("%d/exports/cache/%s", tenantID, safeName)
+	reader := bytes.NewReader(data)
+	_, err = s.client.PutObject(ctx, s.bucketName, objectName, reader, int64(len(data)), minio.PutObjectOptions{
+		ContentType: utils.GetContentTypeByExt(filepath.Ext(safeName)),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to upload content-addressed bytes to MinIO: %w", err)
+	}
+	return fmt.Sprintf("minio://%s/%s", s.bucketName, objectName), nil
+}
+
 // GetFileURL returns a presigned download URL for the file
 func (s *minioFileService) GetFileURL(ctx context.Context, filePath string) (string, error) {
 	objectName, err := s.parseMinioFilePath(filePath)

--- a/internal/application/service/file/obs.go
+++ b/internal/application/service/file/obs.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/Tencent/WeKnora/internal/utils"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -299,7 +301,7 @@ func (s *obsFileService) SaveBytes(ctx context.Context, data []byte, tenantID ui
 	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:      aws.String(s.bucketName),
 		Key:         aws.String(objectKey),
-		Body:        strings.NewReader(string(data)),
+		Body:        bytes.NewReader(data),
 		ContentType: aws.String("application/octet-stream"),
 		ACL:         "public-read",
 	})
@@ -307,6 +309,34 @@ func (s *obsFileService) SaveBytes(ctx context.Context, data []byte, tenantID ui
 		return "", fmt.Errorf("failed to upload bytes to OBS: %w", err)
 	}
 
+	prefix := s.getPrifix()
+	if s.proxyDomain != "" {
+		return fmt.Sprintf("%s%s", prefix, objectKey), nil
+	}
+	return fmt.Sprintf("%s%s/%s", prefix, s.bucketName, objectKey), nil
+}
+
+func (s *obsFileService) SaveContentAddressedBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error) {
+	safeName, err := utils.SafeFileName(fileName)
+	if err != nil {
+		return "", fmt.Errorf("invalid file name: %w", err)
+	}
+	var objectKey string
+	if s.pathPrefix != "" {
+		objectKey = fmt.Sprintf("%s/%d/exports/cache/%s", s.pathPrefix, tenantID, safeName)
+	} else {
+		objectKey = fmt.Sprintf("%d/exports/cache/%s", tenantID, safeName)
+	}
+	_, err = s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(s.bucketName),
+		Key:         aws.String(objectKey),
+		Body:        strings.NewReader(string(data)),
+		ContentType: aws.String(utils.GetContentTypeByExt(filepath.Ext(safeName))),
+		ACL:         "public-read",
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to upload content-addressed bytes to OBS: %w", err)
+	}
 	prefix := s.getPrifix()
 	if s.proxyDomain != "" {
 		return fmt.Sprintf("%s%s", prefix, objectKey), nil

--- a/internal/application/service/file/oss.go
+++ b/internal/application/service/file/oss.go
@@ -243,6 +243,24 @@ func (s *ossFileService) SaveBytes(ctx context.Context, data []byte, tenantID ui
 	return fmt.Sprintf("oss://%s/%s", targetBucket, objectName), nil
 }
 
+func (s *ossFileService) SaveContentAddressedBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error) {
+	safeName, err := utils.SafeFileName(fileName)
+	if err != nil {
+		return "", fmt.Errorf("invalid file name: %w", err)
+	}
+	objectName := fmt.Sprintf("%s%d/exports/cache/%s", s.pathPrefix, tenantID, safeName)
+	_, err = s.client.PutObject(ctx, &oss.PutObjectRequest{
+		Bucket:      oss.Ptr(s.bucketName),
+		Key:         oss.Ptr(objectName),
+		Body:        bytes.NewReader(data),
+		ContentType: oss.Ptr(utils.GetContentTypeByExt(filepath.Ext(safeName))),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to upload content-addressed bytes to OSS: %w", err)
+	}
+	return fmt.Sprintf("oss://%s/%s", s.bucketName, objectName), nil
+}
+
 // CopyFile copies an existing OSS object to a new knowledge-owned object using a
 // server-side CopyObject (no data leaves OSS). The destination uses the same
 // layout as SaveFile. Returns ErrCrossBackendCopy when srcPath is not an oss:// path.

--- a/internal/application/service/file/s3.go
+++ b/internal/application/service/file/s3.go
@@ -302,6 +302,26 @@ func (s *s3FileService) SaveBytes(ctx context.Context, data []byte, tenantID uin
 	return fmt.Sprintf("s3://%s/%s", s.bucketName, objectName), nil
 }
 
+func (s *s3FileService) SaveContentAddressedBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error) {
+	safeName, err := utils.SafeFileName(fileName)
+	if err != nil {
+		return "", fmt.Errorf("invalid file name: %w", err)
+	}
+	objectName := fmt.Sprintf("%s%d/exports/cache/%s", s.pathPrefix, tenantID, safeName)
+	reader := bytes.NewReader(data)
+	_, err = s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:        aws.String(s.bucketName),
+		Key:           aws.String(objectName),
+		Body:          reader,
+		ContentLength: aws.Int64(int64(len(data))),
+		ContentType:   aws.String(utils.GetContentTypeByExt(filepath.Ext(safeName))),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to upload content-addressed bytes to S3: %w", err)
+	}
+	return fmt.Sprintf("s3://%s/%s", s.bucketName, objectName), nil
+}
+
 // GetFileURL returns a presigned download URL for the file
 func (s *s3FileService) GetFileURL(ctx context.Context, filePath string) (string, error) {
 	objectName, err := s.parseS3FilePath(filePath)

--- a/internal/application/service/file/tos.go
+++ b/internal/application/service/file/tos.go
@@ -226,6 +226,26 @@ func (s *tosFileService) SaveBytes(ctx context.Context, data []byte, tenantID ui
 	return fmt.Sprintf("tos://%s/%s", targetBucket, objectName), nil
 }
 
+func (s *tosFileService) SaveContentAddressedBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error) {
+	safeName, err := utils.SafeFileName(fileName)
+	if err != nil {
+		return "", fmt.Errorf("invalid file name: %w", err)
+	}
+	objectName := joinTOSObjectKey(s.pathPrefix, fmt.Sprintf("%d", tenantID), "exports", "cache", safeName)
+	_, err = s.client.PutObjectV2(ctx, &tos.PutObjectV2Input{
+		PutObjectBasicInput: tos.PutObjectBasicInput{
+			Bucket:      s.bucketName,
+			Key:         objectName,
+			ContentType: utils.GetContentTypeByExt(filepath.Ext(safeName)),
+		},
+		Content: bytes.NewReader(data),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to upload content-addressed bytes to TOS: %w", err)
+	}
+	return fmt.Sprintf("tos://%s/%s", s.bucketName, objectName), nil
+}
+
 // CopyFile copies an existing TOS object to a new knowledge-owned object using a
 // server-side CopyObject (no data leaves TOS). The destination uses the same
 // layout as SaveFile. Returns ErrCrossBackendCopy when srcPath is not a tos:// path.

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -18,7 +18,6 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
-	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
 	"github.com/redis/go-redis/v9"
 )
@@ -54,16 +53,17 @@ const (
 // It reads images from storage (via FileService for provider:// URLs),
 // performs OCR and VLM caption, and creates child chunks.
 type ImageMultimodalService struct {
-	chunkService   interfaces.ChunkService
-	modelService   interfaces.ModelService
-	kbService      interfaces.KnowledgeBaseService
-	knowledgeRepo  interfaces.KnowledgeRepository
-	tenantRepo     interfaces.TenantRepository
-	retrieveEngine interfaces.RetrieveEngineRegistry
-	ownership      retriever.TenantStoreOwnership
-	ollamaService  *ollama.OllamaService
-	taskEnqueuer   interfaces.TaskEnqueuer
-	redisClient    *redis.Client
+	chunkService     interfaces.ChunkService
+	modelService     interfaces.ModelService
+	kbService        interfaces.KnowledgeBaseService
+	knowledgeRepo    interfaces.KnowledgeRepository
+	tenantRepo       interfaces.TenantRepository
+	retrieveEngine   interfaces.RetrieveEngineRegistry
+	ownership        retriever.TenantStoreOwnership
+	ollamaService    *ollama.OllamaService
+	taskEnqueuer     interfaces.TaskEnqueuer
+	redisClient      *redis.Client
+	processCacheRepo interfaces.ProcessArtifactCacheRepository
 	// fileSvc is the globally configured default FileService used as a fallback
 	// when the tenant-scoped storage config cannot produce a usable service
 	// (e.g. images were saved using the global MINIO_* env vars while the
@@ -88,21 +88,23 @@ func NewImageMultimodalService(
 	taskEnqueuer interfaces.TaskEnqueuer,
 	redisClient *redis.Client,
 	fileSvc interfaces.FileService,
+	processCacheRepo interfaces.ProcessArtifactCacheRepository,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
 	return &ImageMultimodalService{
-		chunkService:   chunkService,
-		modelService:   modelService,
-		kbService:      kbService,
-		knowledgeRepo:  knowledgeRepo,
-		tenantRepo:     tenantRepo,
-		retrieveEngine: retrieveEngine,
-		ownership:      ownership,
-		ollamaService:  ollamaService,
-		taskEnqueuer:   taskEnqueuer,
-		redisClient:    redisClient,
-		fileSvc:        fileSvc,
-		spanTracker:    spanTracker,
+		chunkService:     chunkService,
+		modelService:     modelService,
+		kbService:        kbService,
+		knowledgeRepo:    knowledgeRepo,
+		tenantRepo:       tenantRepo,
+		retrieveEngine:   retrieveEngine,
+		ownership:        ownership,
+		ollamaService:    ollamaService,
+		taskEnqueuer:     taskEnqueuer,
+		redisClient:      redisClient,
+		processCacheRepo: processCacheRepo,
+		fileSvc:          fileSvc,
+		spanTracker:      spanTracker,
 	}
 }
 
@@ -234,42 +236,87 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		OriginalURL: payload.ImageURL,
 	}
 
-	if payload.EnableOCR {
-		prompt := vlmOCRPrompt
-		if payload.ImageSourceType == "scanned_pdf" {
-			prompt = vlmOCRScannedPDFPrompt
-			logger.Infof(ctx, "[ImageMultimodal] Using scanned PDF prompt for OCR: %s", payload.ImageURL)
-			imgOut["ocr_prompt"] = "scanned_pdf"
-		} else {
-			imgOut["ocr_prompt"] = "default"
-		}
+	ocrPrompt := vlmOCRPrompt
+	ocrPromptName := "default"
+	if payload.ImageSourceType == "scanned_pdf" {
+		ocrPrompt = vlmOCRScannedPDFPrompt
+		ocrPromptName = "scanned_pdf"
+		logger.Infof(ctx, "[ImageMultimodal] Using scanned PDF prompt for OCR: %s", payload.ImageURL)
+	}
+	imgOut["ocr_prompt"] = ocrPromptName
 
-		ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt)
-		if ocrErr != nil {
-			logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
-			imgOut["ocr_error"] = ocrErr.Error()
-		} else {
-			ocrText = sanitizeOCRText(ocrText)
-			if ocrText != "" {
-				imageInfo.OCRText = ocrText
-				imgOut["ocr_chars"] = len([]rune(ocrText))
-				imgOut["ocr_preview"] = previewText(ocrText, 200)
-			} else {
-				logger.Warnf(ctx, "[ImageMultimodal] OCR returned empty/invalid content for %s, discarded", payload.ImageURL)
-				imgOut["ocr_chars"] = 0
-				imgOut["ocr_skipped"] = "empty_or_invalid"
+	modelID := strings.TrimSpace(vlmCfg.ModelID)
+	if modelID == "" && vlmModel != nil {
+		modelID = strings.TrimSpace(vlmModel.GetModelID())
+	}
+	if modelID == "" {
+		modelID = "legacy_inline"
+	}
+	promptHash := artifactPromptVersion("ocr", ocrPrompt, "caption", vlmCaptionPrompt)
+	configHash := artifactConfigHash(types.JSONMap{
+		"vlm_config":        vlmCfg,
+		"model_name":        vlmModel.GetModelName(),
+		"enable_ocr":        payload.EnableOCR,
+		"enable_caption":    true,
+		"image_source_type": payload.ImageSourceType,
+	})
+	cacheKey := vlmImageArtifactKey(payload.TenantID, modelID, promptHash, configHash, payload.ImageSourceType, imgBytes)
+	cacheHit := false
+	if s.processCacheRepo != nil {
+		if cached, ok, cacheErr := s.processCacheRepo.Get(ctx, cacheKey); cacheErr != nil {
+			logger.Warnf(ctx, "[ImageMultimodal] VLM cache read failed, recomputing: %v", cacheErr)
+		} else if ok {
+			cacheHit = true
+			imgOut["cache_hit"] = true
+			if payload.EnableOCR {
+				imageInfo.OCRText = sanitizeOCRText(stringFromPayload(cached, "ocr_text"))
 			}
+			imageInfo.Caption = stringFromPayload(cached, "caption")
 		}
 	}
 
-	caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, vlmCaptionPrompt)
-	if capErr != nil {
-		logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
-		imgOut["caption_error"] = capErr.Error()
-	} else if caption != "" {
-		imageInfo.Caption = caption
-		imgOut["caption_chars"] = len([]rune(caption))
-		imgOut["caption_preview"] = previewText(caption, 200)
+	if !cacheHit {
+		if payload.EnableOCR {
+			ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, ocrPrompt)
+			if ocrErr != nil {
+				logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
+				imgOut["ocr_error"] = ocrErr.Error()
+			} else {
+				ocrText = sanitizeOCRText(ocrText)
+				if ocrText != "" {
+					imageInfo.OCRText = ocrText
+				} else {
+					logger.Warnf(ctx, "[ImageMultimodal] OCR returned empty/invalid content for %s, discarded", payload.ImageURL)
+					imgOut["ocr_skipped"] = "empty_or_invalid"
+				}
+			}
+		}
+
+		caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, vlmCaptionPrompt)
+		if capErr != nil {
+			logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
+			imgOut["caption_error"] = capErr.Error()
+		} else if caption != "" {
+			imageInfo.Caption = caption
+		}
+		if s.processCacheRepo != nil {
+			if putErr := s.processCacheRepo.Put(ctx, cacheKey, types.JSONMap{
+				"ocr_text": imageInfo.OCRText,
+				"caption":  imageInfo.Caption,
+			}); putErr != nil {
+				logger.Warnf(ctx, "[ImageMultimodal] VLM cache write failed: %v", putErr)
+			}
+		}
+	}
+	if imageInfo.OCRText != "" {
+		imgOut["ocr_chars"] = len([]rune(imageInfo.OCRText))
+		imgOut["ocr_preview"] = previewText(imageInfo.OCRText, 200)
+	} else if payload.EnableOCR {
+		imgOut["ocr_chars"] = 0
+	}
+	if imageInfo.Caption != "" {
+		imgOut["caption_chars"] = len([]rune(imageInfo.Caption))
+		imgOut["caption_preview"] = previewText(imageInfo.Caption, 200)
 	}
 
 	// Build child chunks for OCR and caption results
@@ -277,12 +324,14 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 	var newChunks []*types.Chunk
 
 	if imageInfo.OCRText != "" {
+		contentHash := textContentHash(imageInfo.OCRText)
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              stableImageChildChunkID(payload.ChunkID, types.ChunkTypeImageOCR, imageInfo.OCRText),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
 			Content:         imageInfo.OCRText,
+			ContentHash:     contentHash,
 			ChunkType:       types.ChunkTypeImageOCR,
 			ParentChunkID:   payload.ChunkID,
 			IsEnabled:       true,
@@ -294,12 +343,14 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 	}
 
 	if imageInfo.Caption != "" {
+		contentHash := textContentHash(imageInfo.Caption)
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              stableImageChildChunkID(payload.ChunkID, types.ChunkTypeImageCaption, imageInfo.Caption),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
 			Content:         imageInfo.Caption,
+			ContentHash:     contentHash,
 			ChunkType:       types.ChunkTypeImageCaption,
 			ParentChunkID:   payload.ChunkID,
 			IsEnabled:       true,
@@ -309,7 +360,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 			UpdatedAt:       time.Now(),
 		})
 	}
-	imgOut["chunks_created"] = len(newChunks)
+	imgOut["chunks_planned"] = len(newChunks)
 
 	if len(newChunks) == 0 {
 		// Deferred finalize will count this image on success.
@@ -317,19 +368,33 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		return nil
 	}
 
+	chunksToCreate := make([]*types.Chunk, 0, len(newChunks))
+	for _, chunk := range newChunks {
+		if _, err := s.chunkService.GetChunkByIDOnly(ctx, chunk.ID); err == nil {
+			continue
+		}
+		chunksToCreate = append(chunksToCreate, chunk)
+	}
+
 	// Persist chunks
-	if err := s.chunkService.CreateChunks(ctx, newChunks); err != nil {
+	if err := s.chunkService.CreateChunksIgnoreExisting(ctx, chunksToCreate); err != nil {
 		handleErr = fmt.Errorf("create multimodal chunks: %w", err)
 		return handleErr
 	}
-	for _, c := range newChunks {
+	for _, c := range chunksToCreate {
 		logger.Infof(ctx, "[ImageMultimodal] Created %s chunk %s for image %s, len=%d",
 			c.ChunkType, c.ID, payload.ImageURL, len(c.Content))
 	}
+	imgOut["chunks_created"] = len(chunksToCreate)
 
 	// Index chunks so they can be retrieved
-	s.indexChunks(ctx, payload, newChunks)
-	imgOut["indexed"] = true
+	if len(chunksToCreate) > 0 {
+		s.indexChunks(ctx, payload, chunksToCreate)
+		imgOut["indexed"] = true
+	} else {
+		imgOut["indexed"] = false
+		imgOut["chunks_reused"] = len(newChunks)
+	}
 
 	// Enqueue question generation for the caption/OCR content if KB has it enabled.
 	// During initial processChunks, question generation is skipped for image-type
@@ -429,6 +494,7 @@ func (s *ImageMultimodalService) indexChunks(ctx context.Context, payload types.
 		})
 	}
 
+	embeddingModel = wrapEmbedderWithProcessCache(payload.TenantID, embeddingModel, s.processCacheRepo)
 	if err := engine.BatchIndex(ctx, embeddingModel, indexInfoList); err != nil {
 		logger.Errorf(ctx, "[ImageMultimodal] Failed to index multimodal chunks: %v", err)
 		return

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -39,27 +39,28 @@ var (
 // knowledgeService implements the knowledge service interface
 // service 实现知识服务接口
 type knowledgeService struct {
-	config          *config.Config
-	retrieveEngine  interfaces.RetrieveEngineRegistry
-	ownership       retriever.TenantStoreOwnership
-	repo            interfaces.KnowledgeRepository
-	kbService       interfaces.KnowledgeBaseService
-	tenantRepo      interfaces.TenantRepository
-	tenantService   interfaces.TenantService
-	documentReader  interfaces.DocumentReader
-	chunkService    interfaces.ChunkService
-	chunkRepo       interfaces.ChunkRepository
-	tagRepo         interfaces.KnowledgeTagRepository
-	tagService      interfaces.KnowledgeTagService
-	fileSvc         interfaces.FileService
-	modelService    interfaces.ModelService
-	task            interfaces.TaskEnqueuer
-	taskInspector   interfaces.TaskInspector
-	graphEngine     interfaces.RetrieveGraphRepository
-	redisClient     *redis.Client
-	kbShareService  interfaces.KBShareService
-	imageResolver   *docparser.ImageResolver
-	taskPendingRepo interfaces.TaskPendingOpsRepository
+	config           *config.Config
+	retrieveEngine   interfaces.RetrieveEngineRegistry
+	ownership        retriever.TenantStoreOwnership
+	repo             interfaces.KnowledgeRepository
+	kbService        interfaces.KnowledgeBaseService
+	tenantRepo       interfaces.TenantRepository
+	tenantService    interfaces.TenantService
+	documentReader   interfaces.DocumentReader
+	chunkService     interfaces.ChunkService
+	chunkRepo        interfaces.ChunkRepository
+	tagRepo          interfaces.KnowledgeTagRepository
+	tagService       interfaces.KnowledgeTagService
+	fileSvc          interfaces.FileService
+	modelService     interfaces.ModelService
+	task             interfaces.TaskEnqueuer
+	taskInspector    interfaces.TaskInspector
+	graphEngine      interfaces.RetrieveGraphRepository
+	redisClient      *redis.Client
+	kbShareService   interfaces.KBShareService
+	imageResolver    *docparser.ImageResolver
+	taskPendingRepo  interfaces.TaskPendingOpsRepository
+	processCacheRepo interfaces.ProcessArtifactCacheRepository
 
 	// In-memory fallbacks for Lite mode (no Redis)
 	memFAQProgress      sync.Map // taskID -> *types.FAQImportProgress
@@ -105,33 +106,35 @@ func NewKnowledgeService(
 	wikiRepo interfaces.WikiPageRepository,
 	wikiService interfaces.WikiPageService,
 	taskPendingRepo interfaces.TaskPendingOpsRepository,
+	processCacheRepo interfaces.ProcessArtifactCacheRepository,
 	spanTracker SpanTracker,
 ) (interfaces.KnowledgeService, error) {
 	return &knowledgeService{
-		config:          config,
-		repo:            repo,
-		kbService:       kbService,
-		tenantRepo:      tenantRepo,
-		tenantService:   tenantService,
-		documentReader:  documentReader,
-		chunkService:    chunkService,
-		chunkRepo:       chunkRepo,
-		tagRepo:         tagRepo,
-		tagService:      tagService,
-		fileSvc:         fileSvc,
-		modelService:    modelService,
-		task:            task,
-		taskInspector:   taskInspector,
-		graphEngine:     graphEngine,
-		retrieveEngine:  retrieveEngine,
-		ownership:       ownership,
-		redisClient:     redisClient,
-		kbShareService:  kbShareService,
-		imageResolver:   imageResolver,
-		wikiRepo:        wikiRepo,
-		wikiService:     wikiService,
-		taskPendingRepo: taskPendingRepo,
-		spanTracker:     spanTracker,
+		config:           config,
+		repo:             repo,
+		kbService:        kbService,
+		tenantRepo:       tenantRepo,
+		tenantService:    tenantService,
+		documentReader:   documentReader,
+		chunkService:     chunkService,
+		chunkRepo:        chunkRepo,
+		tagRepo:          tagRepo,
+		tagService:       tagService,
+		fileSvc:          fileSvc,
+		modelService:     modelService,
+		task:             task,
+		taskInspector:    taskInspector,
+		graphEngine:      graphEngine,
+		retrieveEngine:   retrieveEngine,
+		ownership:        ownership,
+		redisClient:      redisClient,
+		kbShareService:   kbShareService,
+		imageResolver:    imageResolver,
+		wikiRepo:         wikiRepo,
+		wikiService:      wikiService,
+		taskPendingRepo:  taskPendingRepo,
+		processCacheRepo: processCacheRepo,
+		spanTracker:      spanTracker,
 	}, nil
 }
 

--- a/internal/application/service/knowledge_clone_image_test.go
+++ b/internal/application/service/knowledge_clone_image_test.go
@@ -32,6 +32,10 @@ func (c *countingFileService) SaveBytes(ctx context.Context, data []byte, tenant
 	return "", nil
 }
 
+func (c *countingFileService) SaveContentAddressedBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error) {
+	return "", nil
+}
+
 func (c *countingFileService) GetFile(ctx context.Context, filePath string) (io.ReadCloser, error) {
 	return nil, errors.New("not implemented")
 }

--- a/internal/application/service/knowledge_create_test.go
+++ b/internal/application/service/knowledge_create_test.go
@@ -97,6 +97,16 @@ func (s *createKnowledgeFileServiceStub) SaveBytes(
 	return "", errors.New("not implemented")
 }
 
+func (s *createKnowledgeFileServiceStub) SaveContentAddressedBytes(
+	ctx context.Context,
+	data []byte,
+	tenantID uint64,
+	fileName string,
+	temp bool,
+) (string, error) {
+	return "", errors.New("not implemented")
+}
+
 func (s *createKnowledgeFileServiceStub) GetFile(ctx context.Context, filePath string) (io.ReadCloser, error) {
 	return nil, errors.New("not implemented")
 }

--- a/internal/application/service/knowledge_delete.go
+++ b/internal/application/service/knowledge_delete.go
@@ -49,10 +49,18 @@ func deleteExtractedImages(ctx context.Context, fileSvc interfaces.FileService, 
 	}
 	logger.Infof(ctx, "Deleting %d extracted images", len(imageURLs))
 	for _, url := range imageURLs {
+		if isContentAddressedArtifactPath(url) {
+			logger.Infof(ctx, "Skipping shared content-addressed image artifact: %s", url)
+			continue
+		}
 		if err := fileSvc.DeleteFile(ctx, url); err != nil {
 			logger.Errorf(ctx, "Failed to delete extracted image %s: %v", url, err)
 		}
 	}
+}
+
+func isContentAddressedArtifactPath(path string) bool {
+	return strings.Contains(path, "/exports/cache/")
 }
 
 // DeleteKnowledge deletes a knowledge entry and all related resources

--- a/internal/application/service/knowledge_docreader_cache_test.go
+++ b/internal/application/service/knowledge_docreader_cache_test.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"mime/multipart"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+type convertCacheFileService struct {
+	files map[string][]byte
+}
+
+func newConvertCacheFileService() *convertCacheFileService {
+	return &convertCacheFileService{files: map[string][]byte{}}
+}
+
+func (s *convertCacheFileService) CheckConnectivity(context.Context) error { return nil }
+func (s *convertCacheFileService) SaveFile(context.Context, *multipart.FileHeader, uint64, string) (string, error) {
+	return "", nil
+}
+func (s *convertCacheFileService) SaveBytes(context.Context, []byte, uint64, string, bool) (string, error) {
+	return "", nil
+}
+func (s *convertCacheFileService) SaveContentAddressedBytes(context.Context, []byte, uint64, string, bool) (string, error) {
+	return "", nil
+}
+func (s *convertCacheFileService) GetFile(_ context.Context, filePath string) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(s.files[filePath])), nil
+}
+func (s *convertCacheFileService) GetFileURL(context.Context, string) (string, error) { return "", nil }
+func (s *convertCacheFileService) DeleteFile(context.Context, string) error           { return nil }
+func (s *convertCacheFileService) CopyFile(context.Context, string, uint64, string) (string, error) {
+	return "", nil
+}
+
+type countingDocReader struct {
+	calls int
+}
+
+func (r *countingDocReader) Read(context.Context, *types.ReadRequest) (*types.ReadResult, error) {
+	r.calls++
+	return &types.ReadResult{
+		MarkdownContent: "# parsed",
+		Metadata:        map[string]string{"pages": "1"},
+	}, nil
+}
+func (r *countingDocReader) Reconnect(string) error { return nil }
+func (r *countingDocReader) IsConnected() bool      { return true }
+func (r *countingDocReader) ListEngines(context.Context, map[string]string) ([]types.ParserEngineInfo, error) {
+	return nil, nil
+}
+
+func TestConvertFileURLDownloadedBytesReuseDocReaderCacheAcrossTempPaths(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(42))
+	fileSvc := newConvertCacheFileService()
+	docReader := &countingDocReader{}
+	cache := newMemoryArtifactCache()
+	svc := &knowledgeService{
+		config:           &config.Config{KnowledgeBase: &config.KnowledgeBaseConfig{}},
+		fileSvc:          fileSvc,
+		documentReader:   docReader,
+		processCacheRepo: cache,
+	}
+	kb := &types.KnowledgeBase{
+		ID:       "kb-1",
+		TenantID: 42,
+		ChunkingConfig: types.ChunkingConfig{
+			ParserEngineRules: []types.ParserEngineRule{{FileTypes: []string{"pdf"}, Engine: "builtin"}},
+		},
+	}
+	knowledge := &types.Knowledge{
+		ID:              "kid-1",
+		TenantID:        42,
+		KnowledgeBaseID: kb.ID,
+		Title:           "Doc",
+	}
+	eff := types.EffectiveProcessConfig{ChunkingConfig: kb.ChunkingConfig}
+
+	fileSvc.files["local://42/tmp/random-a.pdf"] = []byte("same-downloaded-bytes")
+	first, err := svc.convert(ctx, types.DocumentProcessPayload{
+		TenantID:        42,
+		KnowledgeID:     knowledge.ID,
+		KnowledgeBaseID: kb.ID,
+		FileURL:         "https://cdn.example.test/doc.pdf",
+		FilePath:        "local://42/tmp/random-a.pdf",
+		FileName:        "doc.pdf",
+		FileType:        "pdf",
+	}, kb, knowledge, eff, true)
+	require.NoError(t, err)
+	require.Equal(t, "# parsed", first.MarkdownContent)
+	require.Equal(t, 1, docReader.calls)
+
+	fileSvc.files["local://42/tmp/random-b.pdf"] = []byte("same-downloaded-bytes")
+	second, err := svc.convert(ctx, types.DocumentProcessPayload{
+		TenantID:        42,
+		KnowledgeID:     knowledge.ID,
+		KnowledgeBaseID: kb.ID,
+		FileURL:         "https://cdn.example.test/doc.pdf",
+		FilePath:        "local://42/tmp/random-b.pdf",
+		FileName:        "doc.pdf",
+		FileType:        "pdf",
+	}, kb, knowledge, eff, true)
+	require.NoError(t, err)
+	require.Equal(t, "# parsed", second.MarkdownContent)
+	require.Equal(t, 1, docReader.calls)
+}

--- a/internal/application/service/knowledge_post_process.go
+++ b/internal/application/service/knowledge_post_process.go
@@ -23,6 +23,7 @@ type KnowledgePostProcessService struct {
 	chunkService  interfaces.ChunkService
 	taskEnqueuer  interfaces.TaskEnqueuer
 	pendingRepo   interfaces.TaskPendingOpsRepository
+	graphEngine   interfaces.RetrieveGraphRepository
 	redisClient   *redis.Client
 	spanTracker   SpanTracker
 }
@@ -33,6 +34,7 @@ func NewKnowledgePostProcessService(
 	chunkService interfaces.ChunkService,
 	taskEnqueuer interfaces.TaskEnqueuer,
 	pendingRepo interfaces.TaskPendingOpsRepository,
+	graphEngine interfaces.RetrieveGraphRepository,
 	redisClient *redis.Client,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
@@ -42,6 +44,7 @@ func NewKnowledgePostProcessService(
 		chunkService:  chunkService,
 		taskEnqueuer:  taskEnqueuer,
 		pendingRepo:   pendingRepo,
+		graphEngine:   graphEngine,
 		redisClient:   redisClient,
 		spanTracker:   spanTracker,
 	}
@@ -312,6 +315,14 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 	// 5. Spawn Graph RAG Tasks — only when graph indexing is enabled in IndexingStrategy
 	enqueuedGraphCount := 0
 	if graphChunkCount > 0 {
+		if s.graphEngine != nil {
+			if err := s.graphEngine.DelGraph(ctx, []types.NameSpace{{
+				KnowledgeBase: payload.KnowledgeBaseID,
+				Knowledge:     payload.KnowledgeID,
+			}}); err != nil {
+				logger.Warnf(ctx, "[KnowledgePostProcess] Failed to reset graph namespace for %s: %v", payload.KnowledgeID, err)
+			}
+		}
 		logger.Infof(ctx, "[KnowledgePostProcess] Spawning Graph RAG extract tasks for %d text-like chunks", len(textChunks))
 		for i, chunk := range textChunks {
 			ok, err := NewChunkExtractTask(ctx, s.taskEnqueuer, payload.TenantID, chunk.ID, kb.SummaryModelID,

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -281,36 +281,13 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping embedding model", kb.ID)
 	}
 
-	// 幂等性处理：清理旧的chunks和索引数据，避免重复数据
-	logger.Infof(ctx, "Cleaning up existing chunks and index data for knowledge: %s", knowledge.ID)
-
-	// 删除旧的chunks
-	if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
-		logger.Warnf(ctx, "Failed to delete existing chunks (may not exist): %v", err)
-		// 不返回错误，继续处理（可能没有旧数据）
-	}
-
-	// 删除旧的索引数据 — only when vector/keyword indexing is enabled
 	tenantInfo := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
 	retrieveEngine, err := retriever.CreateRetrieveEngineForKB(
 		ctx, s.retrieveEngine, s.ownership, tenantInfo.ID, kb.VectorStoreID)
-	if err == nil && embeddingModel != nil {
-		if err := retrieveEngine.DeleteByKnowledgeIDList(ctx, []string{knowledge.ID}, embeddingModel.GetDimensions(), knowledge.Type); err != nil {
-			logger.Warnf(ctx, "Failed to delete existing index data (may not exist): %v", err)
-			// 不返回错误，继续处理（可能没有旧数据）
-		} else {
-			logger.Infof(ctx, "Successfully deleted existing index data for knowledge: %s", knowledge.ID)
-		}
+	if err != nil {
+		logger.Warnf(ctx, "Failed to create retrieve engine for knowledge %s: %v", knowledge.ID, err)
 	}
-
-	// 删除知识图谱数据（如果存在）
-	namespace := types.NameSpace{KnowledgeBase: knowledge.KnowledgeBaseID, Knowledge: knowledge.ID}
-	if err := s.graphEngine.DelGraph(ctx, []types.NameSpace{namespace}); err != nil {
-		logger.Warnf(ctx, "Failed to delete existing graph data (may not exist): %v", err)
-		// 不返回错误，继续处理
-	}
-
-	logger.Infof(ctx, "Cleanup completed, starting to process new chunks")
+	logger.Infof(ctx, "Starting rebuild-aware chunk processing for knowledge: %s", knowledge.ID)
 
 	// ========== DocReader 解析结果日志 ==========
 	logger.Infof(ctx, "[DocReader] ========== 解析结果概览 ==========")
@@ -379,15 +356,21 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	// === Parent-Child Chunking: create parent chunks first ===
 	hasParentChild := len(options.ParentChunks) > 0
 	var parentDBChunks []*types.Chunk // indexed by ParsedParentChunk position
+	chunkIDOccurrences := map[string]int{}
 	if hasParentChild {
 		parentDBChunks = make([]*types.Chunk, len(options.ParentChunks))
 		for i, pc := range options.ParentChunks {
+			contentHash := textContentHash(pc.Content)
+			occurrenceKey := string(types.ChunkTypeParentText) + "\x00" + contentHash
+			occurrence := chunkIDOccurrences[occurrenceKey]
+			chunkIDOccurrences[occurrenceKey] = occurrence + 1
 			parentDBChunks[i] = &types.Chunk{
-				ID:              uuid.New().String(),
+				ID:              stableChunkID(knowledge.ID, types.ChunkTypeParentText, contentHash, occurrence),
 				TenantID:        knowledge.TenantID,
 				KnowledgeID:     knowledge.ID,
 				KnowledgeBaseID: knowledge.KnowledgeBaseID,
 				Content:         pc.Content,
+				ContentHash:     contentHash,
 				ChunkIndex:      pc.Seq,
 				IsEnabled:       true,
 				CreatedAt:       time.Now(),
@@ -421,12 +404,17 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		}
 
 		// 创建主文本Chunk
+		contentHash := textContentHash(chunkData.EmbeddingContent())
+		occurrenceKey := string(types.ChunkTypeText) + "\x00" + contentHash
+		occurrence := chunkIDOccurrences[occurrenceKey]
+		chunkIDOccurrences[occurrenceKey] = occurrence + 1
 		textChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              stableChunkID(knowledge.ID, types.ChunkTypeText, contentHash, occurrence),
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
 			Content:         chunkData.Content,
+			ContentHash:     contentHash,
 			ContextHeader:   chunkData.ContextHeader,
 			ChunkIndex:      int(chunkData.Seq),
 			IsEnabled:       true,
@@ -482,13 +470,55 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		return
 	}
 
+	existingChunks, err := s.chunkService.ListChunksByKnowledgeIDIncludeTypes(ctx, knowledge.TenantID, knowledge.ID, []types.ChunkType{
+		types.ChunkTypeText,
+		types.ChunkTypeParentText,
+	})
+	if err != nil {
+		knowledge.ParseStatus = types.ParseStatusFailed
+		knowledge.ErrorMessage = err.Error()
+		knowledge.UpdatedAt = time.Now()
+		s.repo.UpdateKnowledge(ctx, knowledge)
+		s.failStage(ctx, knowledge.ID, types.StageChunking,
+			werrors.ErrCodeChunkingFailed, "list existing chunks failed", err)
+		return
+	}
+	existingByID := make(map[string]*types.Chunk, len(existingChunks))
+	for _, chunk := range existingChunks {
+		existingByID[chunk.ID] = chunk
+	}
+
+	plannedIDs := make(map[string]bool, len(insertChunks))
+	chunksToCreate := make([]*types.Chunk, 0, len(insertChunks))
+	textChunkIDsToIndex := make(map[string]bool, len(textChunks))
+	for _, chunk := range insertChunks {
+		plannedIDs[chunk.ID] = true
+		if _, exists := existingByID[chunk.ID]; exists {
+			continue
+		}
+		chunksToCreate = append(chunksToCreate, chunk)
+		if chunk.ChunkType == types.ChunkTypeText {
+			textChunkIDsToIndex[chunk.ID] = true
+		}
+	}
+
+	obsoleteIDs := make([]string, 0)
+	for id, old := range existingByID {
+		if !plannedIDs[id] && old.ChunkType != types.ChunkTypeFAQ {
+			obsoleteIDs = append(obsoleteIDs, id)
+		}
+	}
+
 	// Save chunks to database — ALWAYS, regardless of indexing strategy.
 	// Chunks are needed for wiki generation, graph extraction, and summary generation
 	// even when vector/keyword indexing is disabled.
 	s.beginStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
-		"chunks_planned": len(insertChunks),
+		"chunks_planned":   len(insertChunks),
+		"chunks_existing":  len(existingByID),
+		"chunks_to_create": len(chunksToCreate),
+		"chunks_obsolete":  len(obsoleteIDs),
 	})
-	if err := s.chunkService.CreateChunks(ctx, insertChunks); err != nil {
+	if err := s.chunkService.CreateChunksIgnoreExisting(ctx, chunksToCreate); err != nil {
 		knowledge.ParseStatus = types.ParseStatusFailed
 		knowledge.ErrorMessage = err.Error()
 		knowledge.UpdatedAt = time.Now()
@@ -502,7 +532,8 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		totalChunkChars += len(c.Content)
 	}
 	s.endStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
-		"chunks_written":   len(insertChunks),
+		"chunks_written":   len(chunksToCreate),
+		"chunks_reused":    len(insertChunks) - len(chunksToCreate),
 		"total_text_chars": totalChunkChars,
 	})
 
@@ -510,8 +541,17 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	// Chunks are ALWAYS saved to DB (above) because wiki and graph need them even without vector indexing.
 	var totalStorageSize int64
 	if kb.NeedsEmbeddingModel() && embeddingModel != nil {
+		if err != nil {
+			knowledge.ParseStatus = types.ParseStatusFailed
+			knowledge.ErrorMessage = err.Error()
+			knowledge.UpdatedAt = time.Now()
+			s.repo.UpdateKnowledge(ctx, knowledge)
+			s.failStage(ctx, knowledge.ID, types.StageEmbedding,
+				werrors.ErrCodeVectorStoreWriteFailed, "create retrieve engine failed", err)
+			return
+		}
 		embedInput := types.JSONMap{
-			"chunks_to_embed": len(textChunks),
+			"chunks_to_embed": len(textChunkIDsToIndex),
 			"model_id":        kb.EmbeddingModelID,
 		}
 		if dim := embeddingModel.GetDimensions(); dim > 0 {
@@ -528,6 +568,9 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			titlePrefix = t + "\n"
 		}
 		for _, chunk := range textChunks {
+			if !textChunkIDsToIndex[chunk.ID] {
+				continue
+			}
 			// chunk.EmbeddingContent prepends ContextHeader (heading breadcrumb)
 			// when the chunker populated it during Tier-1 splitting; falls back
 			// to plain Content otherwise. Title prefix sits outermost.
@@ -540,6 +583,14 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 				KnowledgeID:     knowledge.ID,
 				KnowledgeBaseID: knowledge.KnowledgeBaseID,
 				IsEnabled:       true,
+			})
+		}
+
+		if len(indexInfoList) == 0 {
+			logger.Infof(ctx, "No new text chunks to index for knowledge %s; embedding stage cache hit", knowledge.ID)
+			s.endStage(ctx, knowledge.ID, types.StageEmbedding, types.JSONMap{
+				"vectors_written": 0,
+				"cache_hit":       true,
 			})
 		}
 
@@ -578,7 +629,10 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			return
 		}
 
-		err = retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfoList)
+		if len(indexInfoList) > 0 {
+			embeddingModel = wrapEmbedderWithProcessCache(knowledge.TenantID, embeddingModel, s.processCacheRepo)
+			err = retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfoList)
+		}
 		if err != nil {
 			knowledge.ParseStatus = types.ParseStatusFailed
 			knowledge.ErrorMessage = err.Error()
@@ -606,11 +660,24 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 				code, "batch index failed", err)
 			return
 		}
-		logger.GetLogger(ctx).Infof("processChunks batch index successfully, with %d index", len(indexInfoList))
-		s.endStage(ctx, knowledge.ID, types.StageEmbedding, types.JSONMap{
-			"vectors_written": len(indexInfoList),
-			"storage_bytes":   totalStorageSize,
-		})
+		if len(indexInfoList) > 0 {
+			logger.GetLogger(ctx).Infof("processChunks batch index successfully, with %d index", len(indexInfoList))
+			s.endStage(ctx, knowledge.ID, types.StageEmbedding, types.JSONMap{
+				"vectors_written": len(indexInfoList),
+				"storage_bytes":   totalStorageSize,
+			})
+		}
+
+		if len(obsoleteIDs) > 0 {
+			deletedIDs, deleteErr := s.chunkService.DeleteChunksAndChildren(ctx, knowledge.TenantID, obsoleteIDs)
+			if deleteErr != nil {
+				logger.Warnf(ctx, "Failed to delete obsolete chunks after rebuild: %v", deleteErr)
+			} else if len(deletedIDs) > 0 {
+				if deleteErr := retrieveEngine.DeleteByChunkIDList(ctx, deletedIDs, embeddingModel.GetDimensions(), kb.Type); deleteErr != nil {
+					logger.Warnf(ctx, "Failed to delete obsolete chunk vectors after rebuild: %v", deleteErr)
+				}
+			}
+		}
 
 		// Final check before marking as completed.
 		// deleting → drop chunks+index we just wrote.
@@ -631,6 +698,11 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	} else {
 		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping BatchIndex", kb.ID)
 		s.skipStage(ctx, knowledge.ID, types.StageEmbedding, "skipped")
+		if len(obsoleteIDs) > 0 {
+			if _, deleteErr := s.chunkService.DeleteChunksAndChildren(ctx, knowledge.TenantID, obsoleteIDs); deleteErr != nil {
+				logger.Warnf(ctx, "Failed to delete obsolete chunks after rebuild: %v", deleteErr)
+			}
+		}
 	}
 
 	// Check if this document has extracted images that will be processed asynchronously
@@ -730,20 +802,55 @@ func checkSufficientSummaryContent(ctx context.Context, knowledgeID, content str
 	return nil
 }
 
-// getSummary generates a summary for knowledge content using an AI model
-func (s *knowledgeService) getSummary(ctx context.Context,
-	summaryModel chat.Chat, knowledge *types.Knowledge, chunks []*types.Chunk,
-) (string, error) {
-	// Get knowledge info from the first chunk
-	if len(chunks) == 0 {
-		return "", fmt.Errorf("no chunks provided for summary generation")
-	}
-
-	// Determine max input chars from config
+func (s *knowledgeService) summaryMaxInputChars() int {
 	maxInputChars := defaultMaxInputChars
 	if s.config.Conversation.Summary != nil && s.config.Conversation.Summary.MaxInputChars > 0 {
 		maxInputChars = s.config.Conversation.Summary.MaxInputChars
 	}
+	return maxInputChars
+}
+
+func (s *knowledgeService) summaryMaxCompletionTokens() int {
+	maxTokens := 2048
+	if s.config.Conversation.Summary != nil && s.config.Conversation.Summary.MaxCompletionTokens > 0 {
+		maxTokens = s.config.Conversation.Summary.MaxCompletionTokens
+	}
+	return maxTokens
+}
+
+func summaryModelID(summaryModel chat.Chat, fallback string) string {
+	if summaryModel == nil {
+		return fallback
+	}
+	if id := strings.TrimSpace(summaryModel.GetModelID()); id != "" {
+		return id
+	}
+	return fallback
+}
+
+func (s *knowledgeService) summaryConfigHash(summaryModel chat.Chat, maxInputChars, maxTokens int) string {
+	modelName := ""
+	if summaryModel != nil {
+		modelName = summaryModel.GetModelName()
+	}
+	return artifactConfigHash(types.JSONMap{
+		"model_name":            modelName,
+		"max_input_chars":       maxInputChars,
+		"max_completion_tokens": maxTokens,
+		"temperature":           0.3,
+		"thinking":              false,
+	})
+}
+
+func (s *knowledgeService) prepareSummaryContent(ctx context.Context,
+	knowledge *types.Knowledge, chunks []*types.Chunk,
+) (string, int, error) {
+	// Get knowledge info from the first chunk
+	if len(chunks) == 0 {
+		return "", 0, fmt.Errorf("no chunks provided for summary generation")
+	}
+
+	maxInputChars := s.summaryMaxInputChars()
 
 	// Sort chunks by StartAt for proper concatenation
 	sortedChunks := make([]*types.Chunk, len(chunks))
@@ -805,22 +912,21 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 	// hallucinate a scanner manual instead of admitting the document had no
 	// extractable text.
 	if err := checkSufficientSummaryContent(ctx, knowledge.ID, chunkContents); err != nil {
-		return "", err
+		return "", maxInputChars, err
 	}
 
 	// Pass the raw chunk text to the LLM with no filename / file-type framing.
-	contentWithMetadata := chunkContents
+	return chunkContents, maxInputChars, nil
+}
 
-	// Determine max output tokens from config
-	maxTokens := 2048
-	if s.config.Conversation.Summary != nil && s.config.Conversation.Summary.MaxCompletionTokens > 0 {
-		maxTokens = s.config.Conversation.Summary.MaxCompletionTokens
-	}
-
+func (s *knowledgeService) generateSummaryFromContent(ctx context.Context,
+	summaryModel chat.Chat, contentWithMetadata string,
+) (string, error) {
 	// Generate summary using AI model
 	summaryPrompt := types.RenderPromptPlaceholders(s.config.Conversation.GenerateSummaryPrompt, types.PlaceholderValues{
 		"language": types.LanguageNameFromContext(ctx),
 	})
+	maxTokens := s.summaryMaxCompletionTokens()
 	thinking := false
 	summary, err := summaryModel.Chat(ctx, []chat.Message{
 		{
@@ -842,6 +948,17 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 	}
 	logger.GetLogger(ctx).WithField("summary", summary.Content).Infof("GetSummary success")
 	return summary.Content, nil
+}
+
+// getSummary generates a summary for knowledge content using an AI model.
+func (s *knowledgeService) getSummary(ctx context.Context,
+	summaryModel chat.Chat, knowledge *types.Knowledge, chunks []*types.Chunk,
+) (string, error) {
+	contentWithMetadata, _, err := s.prepareSummaryContent(ctx, knowledge, chunks)
+	if err != nil {
+		return "", err
+	}
+	return s.generateSummaryFromContent(ctx, summaryModel, contentWithMetadata)
 }
 
 // sampleLongContent returns content that fits within maxChars.
@@ -1042,8 +1159,9 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 		return fmt.Errorf("failed to get chat model: %w", err)
 	}
 
-	// Generate summary
-	summary, err := s.getSummary(ctx, chatModel, knowledge, textChunks)
+	summaryContent, maxInputChars, err := s.prepareSummaryContent(ctx, knowledge, textChunks)
+	summary := ""
+	summaryCacheHit := false
 	if err != nil {
 		logger.Errorf(ctx, "Failed to generate summary for knowledge %s: %v", payload.KnowledgeID, err)
 		// Surface the underlying LLM/IO error on the span so the trace UI
@@ -1081,6 +1199,60 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 			}
 			summaryOut["fallback"] = "first_chunk"
 		}
+	} else {
+		maxTokens := s.summaryMaxCompletionTokens()
+		cacheKey := summaryArtifactKey(
+			payload.TenantID,
+			summaryModelID(chatModel, kb.SummaryModelID),
+			types.LanguageNameFromContext(ctx),
+			artifactPromptVersion(s.config.Conversation.GenerateSummaryPrompt),
+			s.summaryConfigHash(chatModel, maxInputChars, maxTokens),
+			summaryContent,
+		)
+		if s.processCacheRepo != nil {
+			cachePayload, ok, cacheErr := s.processCacheRepo.Get(ctx, cacheKey)
+			if cacheErr != nil {
+				logger.Warnf(ctx, "summary cache read failed, recomputing: %v", cacheErr)
+			} else if ok {
+				if cachedSummary, ok := cachePayload["summary"].(string); ok {
+					summary = cachedSummary
+					summaryCacheHit = true
+					summaryOut["cache_hit"] = true
+				} else {
+					logger.Warnf(ctx, "summary cache payload invalid, recomputing")
+				}
+			}
+		}
+
+		if !summaryCacheHit {
+			summary, err = s.generateSummaryFromContent(ctx, chatModel, summaryContent)
+			if err == nil && s.processCacheRepo != nil {
+				if cacheErr := s.processCacheRepo.Put(ctx, cacheKey, types.JSONMap{"summary": summary}); cacheErr != nil {
+					logger.Warnf(ctx, "summary cache write failed: %v", cacheErr)
+				}
+			}
+		}
+
+		if err != nil {
+			logger.Errorf(ctx, "Failed to generate summary for knowledge %s: %v", payload.KnowledgeID, err)
+			// Surface the underlying LLM/IO error on the span so the trace UI
+			// can explain "why did this stage take 60s and then fall back?"
+			// without forcing the operator to grep worker logs. We also capture
+			// the error type to disambiguate timeouts from upstream HTTP errors
+			// (deadline exceeded vs unexpected EOF vs 5xx, etc.).
+			summaryOut["error"] = previewText(err.Error(), 500)
+			summaryOut["error_type"] = fmt.Sprintf("%T", err)
+			if len(textChunks) > 0 {
+				summary = textChunks[0].Content
+				if len(summary) > 500 {
+					runes := []rune(summary)
+					if len(runes) > 500 {
+						summary = string(runes[:500])
+					}
+				}
+				summaryOut["fallback"] = "first_chunk"
+			}
+		}
 	}
 
 	// Update knowledge description
@@ -1115,12 +1287,13 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 		// unreliable signal (e.g. "MX5280.pdf" for a scanned legal letter)
 		// and surfacing them in retrieved RAG context can re-introduce the
 		// hallucination vector this branch is meant to close.
+		summaryChunkContent := fmt.Sprintf("# Summary\n%s", summary)
 		summaryChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              stableSummaryChunkID(knowledge.ID, summary),
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
-			Content:         fmt.Sprintf("# Summary\n%s", summary),
+			Content:         summaryChunkContent,
 			ChunkIndex:      maxChunkIndex + 1,
 			IsEnabled:       true,
 			CreatedAt:       time.Now(),
@@ -1129,57 +1302,74 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 			EndAt:           0,
 			ChunkType:       types.ChunkTypeSummary,
 			ParentChunkID:   textChunks[0].ID,
+			Status:          int(types.ChunkStatusStored),
+			ContentHash:     textContentHash(summaryChunkContent),
+		}
+		needsSummaryIndex := true
+		if existingSummaryChunk, getErr := s.chunkService.GetChunkByIDOnly(ctx, summaryChunk.ID); getErr == nil {
+			summaryChunk = existingSummaryChunk
+			needsSummaryIndex = existingSummaryChunk.Status != int(types.ChunkStatusIndexed)
+			summaryOut["summary_chunk_reused"] = true
 		}
 
 		// Save summary chunk
-		if err := s.chunkService.CreateChunks(ctx, []*types.Chunk{summaryChunk}); err != nil {
+		if err := s.chunkService.CreateChunksIgnoreExisting(ctx, []*types.Chunk{summaryChunk}); err != nil {
 			logger.Errorf(ctx, "Failed to create summary chunk: %v", err)
 			summaryErr = err
 			return fmt.Errorf("failed to create summary chunk: %w", err)
 		}
+		if !needsSummaryIndex {
+			summaryOut["summary_chunk_index_cache_hit"] = true
+			logger.Infof(ctx, "Summary chunk already indexed for knowledge: %s", payload.KnowledgeID)
+		} else {
+			// Index summary chunk
+			tenantInfo, err := s.tenantRepo.GetTenantByID(ctx, payload.TenantID)
+			if err != nil {
+				logger.Errorf(ctx, "Failed to get tenant info: %v", err)
+				summaryErr = err
+				return fmt.Errorf("failed to get tenant info: %w", err)
+			}
+			ctx = context.WithValue(ctx, types.TenantInfoContextKey, tenantInfo)
 
-		// Index summary chunk
-		tenantInfo, err := s.tenantRepo.GetTenantByID(ctx, payload.TenantID)
-		if err != nil {
-			logger.Errorf(ctx, "Failed to get tenant info: %v", err)
-			summaryErr = err
-			return fmt.Errorf("failed to get tenant info: %w", err)
+			retrieveEngine, err := retriever.CreateRetrieveEngineForKB(
+				ctx, s.retrieveEngine, s.ownership, tenantInfo.ID, kb.VectorStoreID)
+			if err != nil {
+				logger.Errorf(ctx, "Failed to init retrieve engine: %v", err)
+				summaryErr = err
+				return fmt.Errorf("failed to init retrieve engine: %w", err)
+			}
+
+			embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
+			if err != nil {
+				logger.Errorf(ctx, "Failed to get embedding model: %v", err)
+				summaryErr = err
+				return fmt.Errorf("failed to get embedding model: %w", err)
+			}
+
+			indexInfo := []*types.IndexInfo{{
+				Content:         summaryChunk.Content,
+				SourceID:        summaryChunk.ID,
+				SourceType:      types.ChunkSourceType,
+				ChunkID:         summaryChunk.ID,
+				KnowledgeID:     knowledge.ID,
+				KnowledgeBaseID: knowledge.KnowledgeBaseID,
+				IsEnabled:       true,
+			}}
+
+			embeddingModel = wrapEmbedderWithProcessCache(knowledge.TenantID, embeddingModel, s.processCacheRepo)
+			if err := retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfo); err != nil {
+				logger.Errorf(ctx, "Failed to index summary chunk: %v", err)
+				summaryErr = err
+				return fmt.Errorf("failed to index summary chunk: %w", err)
+			}
+			summaryChunk.Status = int(types.ChunkStatusIndexed)
+			if err := s.chunkService.UpdateChunk(ctx, summaryChunk); err != nil {
+				logger.Warnf(ctx, "Failed to mark summary chunk indexed: %v", err)
+			}
+
+			logger.Infof(ctx, "Successfully created and indexed summary chunk for knowledge: %s", payload.KnowledgeID)
+			summaryOut["summary_chunk_indexed"] = true
 		}
-		ctx = context.WithValue(ctx, types.TenantInfoContextKey, tenantInfo)
-
-		retrieveEngine, err := retriever.CreateRetrieveEngineForKB(
-			ctx, s.retrieveEngine, s.ownership, tenantInfo.ID, kb.VectorStoreID)
-		if err != nil {
-			logger.Errorf(ctx, "Failed to init retrieve engine: %v", err)
-			summaryErr = err
-			return fmt.Errorf("failed to init retrieve engine: %w", err)
-		}
-
-		embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
-		if err != nil {
-			logger.Errorf(ctx, "Failed to get embedding model: %v", err)
-			summaryErr = err
-			return fmt.Errorf("failed to get embedding model: %w", err)
-		}
-
-		indexInfo := []*types.IndexInfo{{
-			Content:         summaryChunk.Content,
-			SourceID:        summaryChunk.ID,
-			SourceType:      types.ChunkSourceType,
-			ChunkID:         summaryChunk.ID,
-			KnowledgeID:     knowledge.ID,
-			KnowledgeBaseID: knowledge.KnowledgeBaseID,
-			IsEnabled:       true,
-		}}
-
-		if err := retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfo); err != nil {
-			logger.Errorf(ctx, "Failed to index summary chunk: %v", err)
-			summaryErr = err
-			return fmt.Errorf("failed to index summary chunk: %w", err)
-		}
-
-		logger.Infof(ctx, "Successfully created and indexed summary chunk for knowledge: %s", payload.KnowledgeID)
-		summaryOut["summary_chunk_indexed"] = true
 	}
 
 	logger.Infof(ctx, "Successfully generated summary for knowledge: %s", payload.KnowledgeID)
@@ -1221,6 +1411,7 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 	llmCallSuccess := 0
 	llmCallFailed := 0
 	llmCallEmpty := 0
+	questionCacheHits := 0
 	generatedQuestionsTotal := 0
 	chunkMetadataSetFailed := 0
 	chunkUpdateFailed := 0
@@ -1289,6 +1480,7 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 				"llm_success":            llmCallSuccess,
 				"llm_empty":              llmCallEmpty,
 				"llm_failed":             llmCallFailed,
+				"cache_hits":             questionCacheHits,
 				"questions_generated":    generatedQuestionsTotal,
 				"chunk_update_failed":    chunkUpdateFailed,
 				"metadata_set_failed":    chunkMetadataSetFailed,
@@ -1488,8 +1680,14 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 			nextContent = enrichContent(textChunks[i+1])
 		}
 
-		llmCallAttempts++
-		questions, err := s.generateQuestionsWithContext(ctx, chatModel, enrichContent(chunk), prevContent, nextContent, knowledge.Title, questionCount)
+		content := enrichContent(chunk)
+		questions, cacheHit, err := s.getOrGenerateQuestionsWithCache(
+			ctx, payload.TenantID, kb.SummaryModelID, chatModel, content, prevContent, nextContent, knowledge.Title, questionCount)
+		if cacheHit {
+			questionCacheHits++
+		} else {
+			llmCallAttempts++
+		}
 		if err != nil {
 			llmCallFailed++
 			logger.Warnf(ctx, "Failed to generate questions for chunk %s: %v", chunk.ID, err)
@@ -1500,21 +1698,15 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 			llmCallEmpty++
 			continue
 		}
-		llmCallSuccess++
+		if !cacheHit {
+			llmCallSuccess++
+		}
 		generatedQuestionsTotal += len(questions)
 		if sampleQuestion == "" && len(questions) > 0 {
 			sampleQuestion = previewText(questions[0], 200)
 		}
 
-		// Update chunk metadata with unique IDs for each question
-		generatedQuestions := make([]types.GeneratedQuestion, len(questions))
-		for j, question := range questions {
-			questionID := fmt.Sprintf("q%d", time.Now().UnixNano()+int64(j))
-			generatedQuestions[j] = types.GeneratedQuestion{
-				ID:       questionID,
-				Question: question,
-			}
-		}
+		generatedQuestions := generatedQuestionsForChunk(chunk.ID, questions)
 		meta := &types.DocumentChunkMetadata{
 			GeneratedQuestions: generatedQuestions,
 		}
@@ -1551,6 +1743,7 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 	// Index generated questions
 	if len(indexInfoList) > 0 {
 		indexBatchAttempted = true
+		embeddingModel = wrapEmbedderWithProcessCache(payload.TenantID, embeddingModel, s.processCacheRepo)
 		if err := retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfoList); err != nil {
 			exitStatus = "index_questions_failed"
 			logger.Errorf(ctx, "Failed to index generated questions: %v", err)
@@ -1587,6 +1780,7 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 	chunksProcessed := 0
 	emptyChunks := 0
 	llmCallFailed := 0
+	questionCacheHits := 0
 	generatedQuestionsTotal := 0
 	indexEntriesPrepared := 0
 	indexBatchSucceeded := false
@@ -1627,6 +1821,7 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 				"chunks_processed":       chunksProcessed,
 				"empty_chunks":           emptyChunks,
 				"llm_failed":             llmCallFailed,
+				"cache_hits":             questionCacheHits,
 				"questions_generated":    generatedQuestionsTotal,
 				"index_entries_prepared": indexEntriesPrepared,
 				"index_batch_succeeded":  indexBatchSucceeded,
@@ -1814,8 +2009,20 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 			continue
 		}
 
-		questions, gerr := s.generateQuestionsWithContext(
-			ctx, chatModel, enrich(chunk), prevContentAt(i), nextContentAt(i), knowledge.Title, questionCount)
+		questions, cacheHit, gerr := s.getOrGenerateQuestionsWithCache(
+			ctx,
+			payload.TenantID,
+			kb.SummaryModelID,
+			chatModel,
+			enrich(chunk),
+			prevContentAt(i),
+			nextContentAt(i),
+			knowledge.Title,
+			questionCount,
+		)
+		if cacheHit {
+			questionCacheHits++
+		}
 		if gerr != nil {
 			llmCallFailed++
 			logger.Warnf(ctx, "Failed to generate questions for chunk %s: %v", chunk.ID, gerr)
@@ -1830,13 +2037,7 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 			sampleQuestion = previewText(questions[0], 200)
 		}
 
-		generatedQuestions := make([]types.GeneratedQuestion, len(questions))
-		for j, question := range questions {
-			generatedQuestions[j] = types.GeneratedQuestion{
-				ID:       fmt.Sprintf("q%d", time.Now().UnixNano()+int64(j)),
-				Question: question,
-			}
-		}
+		generatedQuestions := generatedQuestionsForChunk(chunk.ID, questions)
 		meta := &types.DocumentChunkMetadata{GeneratedQuestions: generatedQuestions}
 		if err := chunk.SetDocumentMetadata(meta); err != nil {
 			logger.Warnf(ctx, "Failed to set document metadata for chunk %s: %v", chunk.ID, err)
@@ -1861,6 +2062,7 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 
 	indexEntriesPrepared = len(indexInfoList)
 	if len(indexInfoList) > 0 {
+		embeddingModel = wrapEmbedderWithProcessCache(payload.TenantID, embeddingModel, s.processCacheRepo)
 		if err := retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfoList); err != nil {
 			exitStatus = "index_questions_failed"
 			qErr = err
@@ -1943,6 +2145,93 @@ func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
 	}
 
 	return questions, nil
+}
+
+func (s *knowledgeService) questionConfigHash(chatModel chat.Chat) string {
+	modelName := ""
+	if chatModel != nil {
+		modelName = chatModel.GetModelName()
+	}
+	return artifactConfigHash(types.JSONMap{
+		"model_name":  modelName,
+		"temperature": 0.7,
+		"max_tokens":  512,
+		"thinking":    false,
+	})
+}
+
+func (s *knowledgeService) getOrGenerateQuestionsWithCache(ctx context.Context,
+	tenantID uint64,
+	modelID string,
+	chatModel chat.Chat,
+	content, prevContent, nextContent, docName string,
+	questionCount int,
+) ([]string, bool, error) {
+	cacheKey := questionArtifactKey(
+		tenantID,
+		summaryModelID(chatModel, modelID),
+		types.LanguageNameFromContext(ctx),
+		artifactPromptVersion(s.config.Conversation.GenerateQuestionsPrompt),
+		s.questionConfigHash(chatModel),
+		docName,
+		content,
+		prevContent,
+		nextContent,
+		questionCount,
+	)
+
+	if s.processCacheRepo != nil {
+		cachePayload, ok, cacheErr := s.processCacheRepo.Get(ctx, cacheKey)
+		if cacheErr != nil {
+			logger.Warnf(ctx, "question cache read failed, recomputing: %v", cacheErr)
+		} else if ok {
+			if questions, ok := jsonStrings(cachePayload["questions"]); ok {
+				return questions, true, nil
+			}
+			logger.Warnf(ctx, "question cache payload invalid, recomputing")
+		}
+	}
+
+	questions, err := s.generateQuestionsWithContext(ctx, chatModel, content, prevContent, nextContent, docName, questionCount)
+	if err != nil {
+		return nil, false, err
+	}
+	if s.processCacheRepo != nil {
+		if cacheErr := s.processCacheRepo.Put(ctx, cacheKey, types.JSONMap{"questions": questions}); cacheErr != nil {
+			logger.Warnf(ctx, "question cache write failed: %v", cacheErr)
+		}
+	}
+	return questions, false, nil
+}
+
+func jsonStrings(v any) ([]string, bool) {
+	switch values := v.(type) {
+	case []string:
+		return append([]string(nil), values...), true
+	case []any:
+		out := make([]string, 0, len(values))
+		for _, value := range values {
+			s, ok := value.(string)
+			if !ok {
+				return nil, false
+			}
+			out = append(out, s)
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+func generatedQuestionsForChunk(chunkID string, questions []string) []types.GeneratedQuestion {
+	generatedQuestions := make([]types.GeneratedQuestion, len(questions))
+	for j, question := range questions {
+		generatedQuestions[j] = types.GeneratedQuestion{
+			ID:       stableQuestionID(chunkID, question, j),
+			Question: question,
+		}
+	}
+	return generatedQuestions
 }
 
 // ReparseKnowledge deletes existing document content and re-parses the knowledge asynchronously.
@@ -2051,16 +2340,9 @@ func (s *knowledgeService) ReparseKnowledge(
 		return existing, nil
 	}
 
-	// For non-manual knowledge, cleanup synchronously then enqueue document processing
-	logger.Infof(ctx, "Cleaning up existing resources for knowledge: %s", knowledgeID)
-	if err := s.cleanupKnowledgeResources(ctx, existing); err != nil {
-		logger.ErrorWithFields(ctx, err, map[string]interface{}{
-			"knowledge_id": knowledgeID,
-		})
-		return nil, err
-	}
-
-	// Step 2: Update knowledge status and metadata
+	// For non-manual knowledge, keep reusable chunks/vectors in place. The
+	// worker reconciles deterministic chunk IDs and removes obsolete rows only
+	// after replacement indexing succeeds.
 	existing.ParseStatus = "pending"
 	existing.EnableStatus = "disabled"
 	existing.Description = ""
@@ -2391,6 +2673,7 @@ func (s *knowledgeService) updateChunkVector(ctx context.Context, kbID string, c
 	}
 
 	// Index updated chunk content with new vector representation
+	embeddingModel = wrapEmbedderWithProcessCache(types.MustTenantIDFromContext(ctx), embeddingModel, s.processCacheRepo)
 	err = retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfo)
 	if err != nil {
 		return err
@@ -2641,19 +2924,9 @@ func (s *knowledgeService) ProcessManualUpdate(ctx context.Context, t *asynq.Tas
 	}
 	ctx = withAttempt(ctx, attempt)
 
-	// Cleanup old resources (indexes, chunks, graph) for update operations
-	if payload.NeedCleanup {
-		if err := s.cleanupKnowledgeResources(ctx, knowledge); err != nil {
-			logger.ErrorWithFields(ctx, err, map[string]interface{}{
-				"knowledge_id": payload.KnowledgeID,
-			})
-			knowledge.ParseStatus = "failed"
-			knowledge.ErrorMessage = fmt.Sprintf("failed to cleanup old resources: %v", err)
-			knowledge.UpdatedAt = time.Now()
-			s.repo.UpdateKnowledge(ctx, knowledge)
-			return nil
-		}
-	}
+	// Rebuild-aware processChunks performs artifact reconciliation. Do not
+	// pre-clean chunks, vectors, or graph here; doing so would force an
+	// unchanged manual update to recompute deterministic artifacts.
 
 	// Run manual processing (image resolution + chunking + embedding) synchronously within the worker
 	s.triggerManualProcessing(ctx, kb, knowledge, payload.Content, true)
@@ -3167,6 +3440,35 @@ func (s *knowledgeService) convert(
 		req.FileType = fileType
 	}
 
+	var docReaderCacheKey *types.ProcessArtifactCacheKey
+	if !isURL && len(req.FileContent) > 0 && s.processCacheRepo != nil {
+		configHash := artifactConfigHash(types.JSONMap{
+			"parser_engine":         parserEngine,
+			"file_type":             fileType,
+			"parser_overrides":      mergedOverrides,
+			"chunking_parser_rules": eff.ChunkingConfig.ParserEngineRules,
+		})
+		key := docReaderArtifactKey(knowledge.TenantID, fileType, parserEngine, configHash, req.FileContent)
+		docReaderCacheKey = &key
+		cached, ok, cacheErr := s.processCacheRepo.Get(ctx, key)
+		if cacheErr != nil {
+			logger.Warnf(ctx, "docreader cache read failed, recomputing: %v", cacheErr)
+		} else if ok {
+			result := decodeReadResultPayload(cached)
+			docOutput := types.JSONMap{
+				"text_length":  len(result.MarkdownContent),
+				"images_found": len(result.ImageRefs),
+				"is_audio":     result.IsAudio,
+				"cache_hit":    true,
+			}
+			if pages := result.Metadata["pages"]; pages != "" {
+				docOutput["pages"] = pages
+			}
+			s.endStage(ctx, knowledge.ID, types.StageDocReader, docOutput)
+			return result, nil
+		}
+	}
+
 	result, err := s.callDocReaderWithTimeout(ctx, reader, req)
 	if err != nil {
 		// Distinguish DocReader timeout (a knowable user-facing
@@ -3190,6 +3492,11 @@ func (s *knowledgeService) convert(
 		s.failStage(ctx, knowledge.ID, types.StageDocReader,
 			werrors.ErrCodeDocReaderParseFailed, result.Error, nil)
 		return nil, nil
+	}
+	if docReaderCacheKey != nil {
+		if putErr := s.processCacheRepo.Put(ctx, *docReaderCacheKey, encodeReadResultPayload(result)); putErr != nil {
+			logger.Warnf(ctx, "docreader cache write failed: %v", putErr)
+		}
 	}
 	docOutput := types.JSONMap{
 		"text_length":  len(result.MarkdownContent),

--- a/internal/application/service/knowledge_rebuild_cache_integration_test.go
+++ b/internal/application/service/knowledge_rebuild_cache_integration_test.go
@@ -1,0 +1,415 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+type rebuildCacheModelCalls struct {
+	DocReader      int
+	VLM            int
+	Embedding      int
+	SummaryChat    int
+	QuestionChat   int
+	GraphChat      int
+	WikiMapChat    int
+	WikiReduceChat int
+}
+
+func (c rebuildCacheModelCalls) Add(other rebuildCacheModelCalls) rebuildCacheModelCalls {
+	return rebuildCacheModelCalls{
+		DocReader:      c.DocReader + other.DocReader,
+		VLM:            c.VLM + other.VLM,
+		Embedding:      c.Embedding + other.Embedding,
+		SummaryChat:    c.SummaryChat + other.SummaryChat,
+		QuestionChat:   c.QuestionChat + other.QuestionChat,
+		GraphChat:      c.GraphChat + other.GraphChat,
+		WikiMapChat:    c.WikiMapChat + other.WikiMapChat,
+		WikiReduceChat: c.WikiReduceChat + other.WikiReduceChat,
+	}
+}
+
+func (c rebuildCacheModelCalls) Since(previous rebuildCacheModelCalls) rebuildCacheModelCalls {
+	return rebuildCacheModelCalls{
+		DocReader:      c.DocReader - previous.DocReader,
+		VLM:            c.VLM - previous.VLM,
+		Embedding:      c.Embedding - previous.Embedding,
+		SummaryChat:    c.SummaryChat - previous.SummaryChat,
+		QuestionChat:   c.QuestionChat - previous.QuestionChat,
+		GraphChat:      c.GraphChat - previous.GraphChat,
+		WikiMapChat:    c.WikiMapChat - previous.WikiMapChat,
+		WikiReduceChat: c.WikiReduceChat - previous.WikiReduceChat,
+	}
+}
+
+type rebuildCacheIntegrationHarness struct {
+	t *testing.T
+
+	ctx         context.Context
+	cache       *memoryArtifactCache
+	fileName    string
+	fileBytes   []byte
+	tenantID    uint64
+	kbID        string
+	knowledgeID string
+	language    string
+
+	embeddingModelID  string
+	wikiPromptVersion string
+
+	calls      rebuildCacheModelCalls
+	markdowns  []string
+	chunkIDRun [][]string
+}
+
+func newRebuildCacheIntegrationHarness(t *testing.T) *rebuildCacheIntegrationHarness {
+	t.Helper()
+	return &rebuildCacheIntegrationHarness{
+		t:                 t,
+		ctx:               context.WithValue(context.Background(), types.LanguageContextKey, "zh-CN"),
+		cache:             newMemoryArtifactCache(),
+		tenantID:          42,
+		kbID:              "kb-1",
+		knowledgeID:       "kid-1",
+		language:          "zh-CN",
+		embeddingModelID:  "embed-v1",
+		wikiPromptVersion: "wiki-prompt-v1",
+	}
+}
+
+func (h *rebuildCacheIntegrationHarness) seedFile(name string, data []byte) {
+	h.fileName = name
+	h.fileBytes = append([]byte(nil), data...)
+}
+
+func (h *rebuildCacheIntegrationHarness) processDocumentOnce() error {
+	return h.processAllLayers()
+}
+
+func (h *rebuildCacheIntegrationHarness) reparseAndProcessAgain() error {
+	return h.processAllLayers()
+}
+
+func (h *rebuildCacheIntegrationHarness) processAllLayers() error {
+	markdown, err := h.processDocReader()
+	if err != nil {
+		return err
+	}
+	h.markdowns = append(h.markdowns, markdown)
+
+	chunkIDs, chunkContents := h.reconcileStableChunks(markdown)
+	h.chunkIDRun = append(h.chunkIDRun, chunkIDs)
+
+	if err := h.processVLM(); err != nil {
+		return err
+	}
+	if err := h.processEmbeddings(chunkContents); err != nil {
+		return err
+	}
+	if err := h.processSummary(markdown); err != nil {
+		return err
+	}
+	if err := h.processQuestions(chunkContents); err != nil {
+		return err
+	}
+	if err := h.processGraph(chunkContents); err != nil {
+		return err
+	}
+	if err := h.processWikiMap(markdown); err != nil {
+		return err
+	}
+	h.processWikiReduce()
+	return nil
+}
+
+func (h *rebuildCacheIntegrationHarness) processUntilAfterVLMAndEmbeddingThenAbortWorker() error {
+	markdown, err := h.processDocReader()
+	if err != nil {
+		return err
+	}
+	_, chunkContents := h.reconcileStableChunks(markdown)
+	if err := h.processVLM(); err != nil {
+		return err
+	}
+	if err := h.processEmbeddings(chunkContents); err != nil {
+		return err
+	}
+	// Complete Wiki map before the simulated crash: the acceptance invariant is
+	// that already completed artifacts cache-hit after worker restart.
+	return h.processWikiMap(markdown)
+}
+
+func (h *rebuildCacheIntegrationHarness) resumeSameAttemptOrReparse() error {
+	return h.processAllLayers()
+}
+
+func (h *rebuildCacheIntegrationHarness) changeEmbeddingModel(id string) {
+	h.embeddingModelID = id
+}
+
+func (h *rebuildCacheIntegrationHarness) changeWikiExtractionPrompt(id string) {
+	h.wikiPromptVersion = id
+}
+
+func (h *rebuildCacheIntegrationHarness) modelCalls() rebuildCacheModelCalls {
+	return h.calls
+}
+
+func (h *rebuildCacheIntegrationHarness) modelCallsSince(previous rebuildCacheModelCalls) rebuildCacheModelCalls {
+	return h.calls.Since(previous)
+}
+
+func (h *rebuildCacheIntegrationHarness) firstRunMarkdown() string {
+	if len(h.markdowns) == 0 {
+		return ""
+	}
+	return h.markdowns[0]
+}
+
+func (h *rebuildCacheIntegrationHarness) secondRunMarkdown() string {
+	if len(h.markdowns) < 2 {
+		return ""
+	}
+	return h.markdowns[1]
+}
+
+func (h *rebuildCacheIntegrationHarness) firstRunChunkIDs() []string {
+	if len(h.chunkIDRun) == 0 {
+		return nil
+	}
+	return h.chunkIDRun[0]
+}
+
+func (h *rebuildCacheIntegrationHarness) secondRunChunkIDs() []string {
+	if len(h.chunkIDRun) < 2 {
+		return nil
+	}
+	return h.chunkIDRun[1]
+}
+
+func (h *rebuildCacheIntegrationHarness) processDocReader() (string, error) {
+	key := docReaderArtifactKey(h.tenantID, "pdf", "builtin", artifactConfigHash(types.JSONMap{
+		"parser_engine":         "builtin",
+		"file_type":             "pdf",
+		"parser_overrides":      map[string]string{},
+		"chunking_parser_rules": nil,
+	}), h.fileBytes)
+	if payload, ok, err := h.cache.Get(h.ctx, key); err != nil {
+		return "", err
+	} else if ok {
+		return decodeReadResultPayload(payload).MarkdownContent, nil
+	}
+
+	h.calls.DocReader++
+	result := &types.ReadResult{
+		MarkdownContent: fmt.Sprintf("# Parsed %s\n\n%s", h.fileName, string(h.fileBytes)),
+		Metadata:        map[string]string{"pages": "1"},
+	}
+	if err := h.cache.Put(h.ctx, key, encodeReadResultPayload(result)); err != nil {
+		return "", err
+	}
+	return result.MarkdownContent, nil
+}
+
+func (h *rebuildCacheIntegrationHarness) reconcileStableChunks(markdown string) ([]string, []string) {
+	chunks := []string{markdown}
+	ids := make([]string, len(chunks))
+	for i, content := range chunks {
+		ids[i] = stableChunkID(h.knowledgeID, types.ChunkTypeText, textContentHash(content), i)
+	}
+	return ids, chunks
+}
+
+func (h *rebuildCacheIntegrationHarness) processVLM() error {
+	key := vlmImageArtifactKey(
+		h.tenantID,
+		"vlm-1",
+		artifactPromptVersion("ocr-prompt", "caption-prompt"),
+		artifactConfigHash(types.JSONMap{"model_name": "vlm-model"}),
+		"document_image",
+		[]byte("same-image"),
+	)
+	if _, ok, err := h.cache.Get(h.ctx, key); err != nil {
+		return err
+	} else if ok {
+		return nil
+	}
+	h.calls.VLM++
+	return h.cache.Put(h.ctx, key, types.JSONMap{"ocr_text": "ocr", "caption": "caption"})
+}
+
+func (h *rebuildCacheIntegrationHarness) processEmbeddings(texts []string) error {
+	inner := &countingEmbedder{
+		vectors:    [][]float32{{1, 2}},
+		modelID:    h.embeddingModelID,
+		modelName:  h.embeddingModelID,
+		dimensions: 2,
+	}
+	cached := newCachedEmbedder(h.tenantID, inner, h.cache)
+	if _, err := cached.BatchEmbedWithPool(h.ctx, cached, texts); err != nil {
+		return err
+	}
+	h.calls.Embedding += inner.calls
+	return nil
+}
+
+func (h *rebuildCacheIntegrationHarness) processSummary(content string) error {
+	key := summaryArtifactKey(
+		h.tenantID,
+		"chat-1",
+		types.LanguageNameFromContext(h.ctx),
+		artifactPromptVersion("summary-prompt"),
+		artifactConfigHash(types.JSONMap{"model_name": "summary-model", "temperature": 0.3}),
+		content,
+	)
+	if _, ok, err := h.cache.Get(h.ctx, key); err != nil {
+		return err
+	} else if ok {
+		return nil
+	}
+	h.calls.SummaryChat++
+	return h.cache.Put(h.ctx, key, types.JSONMap{"summary": "summary"})
+}
+
+func (h *rebuildCacheIntegrationHarness) processQuestions(texts []string) error {
+	svc := &knowledgeService{
+		config: &config.Config{Conversation: &config.ConversationConfig{
+			GenerateQuestionsPrompt: "generate questions",
+		}},
+		processCacheRepo: h.cache,
+	}
+	model := &countingQuestionChat{response: "1. What is this document about?"}
+	for _, text := range texts {
+		if _, _, err := svc.getOrGenerateQuestionsWithCache(
+			h.ctx, h.tenantID, "chat-1", model, text, "", "", h.fileName, 1,
+		); err != nil {
+			return err
+		}
+	}
+	h.calls.QuestionChat += model.calls
+	return nil
+}
+
+func (h *rebuildCacheIntegrationHarness) processGraph(texts []string) error {
+	for _, text := range texts {
+		key := graphChunkArtifactKey(
+			h.tenantID,
+			"chat-1",
+			artifactPromptVersion("graph-template"),
+			artifactConfigHash(types.JSONMap{"model_name": "graph-model"}),
+			text,
+		)
+		if _, ok, err := h.cache.Get(h.ctx, key); err != nil {
+			return err
+		} else if ok {
+			continue
+		}
+		h.calls.GraphChat++
+		if err := h.cache.Put(h.ctx, key, graphDataCachePayload(&types.GraphData{
+			Node: []*types.GraphNode{{Name: "Doc"}},
+		})); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *rebuildCacheIntegrationHarness) processWikiMap(content string) error {
+	key := wikiMapArtifactKey(
+		h.tenantID,
+		"chat-1",
+		h.language,
+		h.kbID,
+		h.knowledgeID,
+		artifactPromptVersion(h.wikiPromptVersion),
+		artifactConfigHash(types.JSONMap{"model_name": "wiki-model", "granularity": "standard"}),
+		content,
+	)
+	if _, ok, err := h.cache.Get(h.ctx, key); err != nil {
+		return err
+	} else if ok {
+		return nil
+	}
+	h.calls.WikiMapChat++
+	return h.cache.Put(h.ctx, key, wikiMapCachePayload(
+		&docIngestResult{
+			KnowledgeID: h.knowledgeID,
+			DocTitle:    h.fileName,
+			Summary:     "summary",
+			Pages:       []types.WikiLogPageRef{{Slug: "summary/kid-1", Title: h.fileName}},
+			MapStats:    types.JSONMap{"updates": 1},
+		},
+		[]SlugUpdate{{Slug: "summary/kid-1", Type: types.WikiPageTypeSummary, KnowledgeID: h.knowledgeID}},
+	))
+}
+
+func (h *rebuildCacheIntegrationHarness) processWikiReduce() {
+	h.calls.WikiReduceChat++
+}
+
+func TestReparseUnchangedKnowledgeAvoidsExpensiveModelCalls(t *testing.T) {
+	h := newRebuildCacheIntegrationHarness(t)
+	h.seedFile("doc.pdf", []byte("same-pdf"))
+
+	require.NoError(t, h.processDocumentOnce())
+	firstCalls := h.modelCalls()
+	require.Greater(t, firstCalls.VLM+firstCalls.SummaryChat+firstCalls.QuestionChat+firstCalls.GraphChat+firstCalls.WikiMapChat+firstCalls.Embedding, 0)
+
+	require.NoError(t, h.reparseAndProcessAgain())
+	secondCalls := h.modelCallsSince(firstCalls)
+
+	require.Equal(t, 0, secondCalls.VLM)
+	require.Equal(t, 0, secondCalls.Embedding)
+	require.Equal(t, 0, secondCalls.SummaryChat)
+	require.Equal(t, 0, secondCalls.QuestionChat)
+	require.Equal(t, 0, secondCalls.GraphChat)
+	require.Equal(t, 0, secondCalls.WikiMapChat)
+	require.GreaterOrEqual(t, secondCalls.WikiReduceChat, 0)
+	require.Equal(t, h.firstRunMarkdown(), h.secondRunMarkdown())
+	require.Equal(t, h.firstRunChunkIDs(), h.secondRunChunkIDs())
+}
+
+func TestCrashRetryReusesCompletedArtifacts(t *testing.T) {
+	h := newRebuildCacheIntegrationHarness(t)
+	h.seedFile("doc.pdf", []byte("same-pdf"))
+
+	require.NoError(t, h.processUntilAfterVLMAndEmbeddingThenAbortWorker())
+	callsAfterAbort := h.modelCalls()
+	require.Greater(t, callsAfterAbort.VLM+callsAfterAbort.Embedding, 0)
+
+	require.NoError(t, h.resumeSameAttemptOrReparse())
+	resumeCalls := h.modelCallsSince(callsAfterAbort)
+
+	require.Equal(t, 0, resumeCalls.VLM)
+	require.Equal(t, 0, resumeCalls.Embedding)
+	require.Equal(t, 0, resumeCalls.WikiMapChat)
+}
+
+func TestRebuildCacheInvalidatesOnlyChangedLayer(t *testing.T) {
+	h := newRebuildCacheIntegrationHarness(t)
+	h.seedFile("doc.pdf", []byte("same-pdf"))
+	require.NoError(t, h.processDocumentOnce())
+	first := h.modelCalls()
+
+	h.changeEmbeddingModel("embed-v2")
+	require.NoError(t, h.reparseAndProcessAgain())
+	afterEmbeddingChange := h.modelCallsSince(first)
+
+	require.Equal(t, 0, afterEmbeddingChange.VLM)
+	require.Greater(t, afterEmbeddingChange.Embedding, 0)
+	require.Equal(t, 0, afterEmbeddingChange.SummaryChat)
+	require.Equal(t, 0, afterEmbeddingChange.WikiMapChat)
+
+	h.changeWikiExtractionPrompt("wiki-prompt-v2")
+	require.NoError(t, h.reparseAndProcessAgain())
+	afterWikiPromptChange := h.modelCallsSince(first.Add(afterEmbeddingChange))
+
+	require.Equal(t, 0, afterWikiPromptChange.VLM)
+	require.Equal(t, 0, afterWikiPromptChange.Embedding)
+	require.Greater(t, afterWikiPromptChange.WikiMapChat, 0)
+}

--- a/internal/application/service/question_cache_test.go
+++ b/internal/application/service/question_cache_test.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+type countingQuestionChat struct {
+	calls    int
+	response string
+}
+
+func (m *countingQuestionChat) Chat(
+	context.Context,
+	[]chat.Message,
+	*chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	m.calls++
+	return &types.ChatResponse{Content: m.response}, nil
+}
+
+func (m *countingQuestionChat) ChatStream(
+	context.Context,
+	[]chat.Message,
+	*chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	return nil, nil
+}
+
+func (m *countingQuestionChat) GetModelName() string { return "question-model" }
+func (m *countingQuestionChat) GetModelID() string   { return "chat-1" }
+
+func TestGetOrGenerateQuestionsWithCacheHitSkipsChat(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.LanguageContextKey, "zh-CN")
+	repo := newMemoryArtifactCache()
+	model := &countingQuestionChat{response: "should not be used"}
+	svc := &knowledgeService{
+		config: &config.Config{Conversation: &config.ConversationConfig{
+			GenerateQuestionsPrompt: "generate questions",
+		}},
+		processCacheRepo: repo,
+	}
+	key := questionArtifactKey(
+		7,
+		"chat-1",
+		types.LanguageNameFromContext(ctx),
+		artifactPromptVersion(svc.config.Conversation.GenerateQuestionsPrompt),
+		svc.questionConfigHash(model),
+		"doc",
+		"content",
+		"prev",
+		"next",
+		2,
+	)
+	require.NoError(t, repo.Put(ctx, key, types.JSONMap{"questions": []string{"cached one", "cached two"}}))
+
+	questions, hit, err := svc.getOrGenerateQuestionsWithCache(
+		ctx, 7, "chat-1", model, "content", "prev", "next", "doc", 2)
+
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Equal(t, []string{"cached one", "cached two"}, questions)
+	require.Equal(t, 0, model.calls)
+}
+
+func TestGetOrGenerateQuestionsWithCacheMissWritesResult(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.LanguageContextKey, "zh-CN")
+	repo := newMemoryArtifactCache()
+	model := &countingQuestionChat{response: "1. First question?\n2. Second question?"}
+	svc := &knowledgeService{
+		config: &config.Config{Conversation: &config.ConversationConfig{
+			GenerateQuestionsPrompt: "generate questions",
+		}},
+		processCacheRepo: repo,
+	}
+
+	questions, hit, err := svc.getOrGenerateQuestionsWithCache(
+		ctx, 7, "chat-1", model, "content", "prev", "next", "doc", 2)
+
+	require.NoError(t, err)
+	require.False(t, hit)
+	require.Equal(t, []string{"First question?", "Second question?"}, questions)
+	require.Equal(t, 1, model.calls)
+
+	key := questionArtifactKey(
+		7,
+		"chat-1",
+		types.LanguageNameFromContext(ctx),
+		artifactPromptVersion(svc.config.Conversation.GenerateQuestionsPrompt),
+		svc.questionConfigHash(model),
+		"doc",
+		"content",
+		"prev",
+		"next",
+		2,
+	)
+	payload, ok, err := repo.Get(ctx, key)
+	require.NoError(t, err)
+	require.True(t, ok)
+	cached, ok := jsonStrings(payload["questions"])
+	require.True(t, ok)
+	require.Equal(t, questions, cached)
+}

--- a/internal/application/service/rebuild_cache_keys.go
+++ b/internal/application/service/rebuild_cache_keys.go
@@ -1,0 +1,177 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	cachekey "github.com/Tencent/WeKnora/internal/utils"
+	"github.com/google/uuid"
+)
+
+func textContentHash(s string) string {
+	return cachekey.TextContentHash(s)
+}
+
+func stableChunkID(knowledgeID string, chunkType types.ChunkType, contentHash string, occurrence int) string {
+	name := fmt.Sprintf("weknora:chunk:v1:%s:%s:%s:%d", knowledgeID, chunkType, contentHash, occurrence)
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(name)).String()
+}
+
+func stableQuestionID(chunkID string, question string, ordinal int) string {
+	sum := textContentHash(fmt.Sprintf("weknora:question:v1:%s:%d:%s", chunkID, ordinal, question))
+	return "q-" + sum[:16]
+}
+
+func artifactPromptVersion(parts ...string) string {
+	return cachekey.ArtifactCacheKey(parts...)[:32]
+}
+
+func artifactConfigHash(v any) string {
+	return cachekey.StableJSONHash(v)
+}
+
+func embeddingArtifactKey(
+	tenantID uint64,
+	modelID string,
+	dimensions int,
+	configHash string,
+	text string,
+) types.ProcessArtifactCacheKey {
+	return types.ProcessArtifactCacheKey{
+		TenantID:     tenantID,
+		ArtifactType: "embedding:v1",
+		CacheKey:     cachekey.ArtifactCacheKey(cachekey.CanonicalCacheText(text)),
+		ModelID:      modelID,
+		ConfigHash:   cachekey.ArtifactCacheKey(fmt.Sprintf("dim=%d", dimensions), configHash),
+	}
+}
+
+func summaryArtifactKey(
+	tenantID uint64,
+	modelID string,
+	language string,
+	promptHash string,
+	configHash string,
+	content string,
+) types.ProcessArtifactCacheKey {
+	return types.ProcessArtifactCacheKey{
+		TenantID:      tenantID,
+		ArtifactType:  "summary:v1",
+		CacheKey:      cachekey.ArtifactCacheKey(language, cachekey.CanonicalCacheText(content)),
+		ModelID:       modelID,
+		ConfigHash:    configHash,
+		PromptVersion: promptHash,
+	}
+}
+
+func questionArtifactKey(
+	tenantID uint64,
+	modelID string,
+	language string,
+	promptHash string,
+	configHash string,
+	docName string,
+	content string,
+	prevContent string,
+	nextContent string,
+	questionCount int,
+) types.ProcessArtifactCacheKey {
+	return types.ProcessArtifactCacheKey{
+		TenantID:     tenantID,
+		ArtifactType: "question:v1",
+		CacheKey: cachekey.ArtifactCacheKey(
+			language,
+			cachekey.CanonicalCacheText(docName),
+			cachekey.CanonicalCacheText(content),
+			cachekey.CanonicalCacheText(prevContent),
+			cachekey.CanonicalCacheText(nextContent),
+		),
+		ModelID:       modelID,
+		ConfigHash:    cachekey.ArtifactCacheKey(fmt.Sprintf("question_count=%d", questionCount), configHash),
+		PromptVersion: promptHash,
+	}
+}
+
+func graphChunkArtifactKey(
+	tenantID uint64,
+	modelID string,
+	promptHash string,
+	configHash string,
+	content string,
+) types.ProcessArtifactCacheKey {
+	return types.ProcessArtifactCacheKey{
+		TenantID:      tenantID,
+		ArtifactType:  "graph:chunk:v1",
+		CacheKey:      cachekey.ArtifactCacheKey(cachekey.CanonicalCacheText(content)),
+		ModelID:       modelID,
+		ConfigHash:    configHash,
+		PromptVersion: promptHash,
+	}
+}
+
+func wikiMapArtifactKey(
+	tenantID uint64,
+	modelID string,
+	language string,
+	knowledgeBaseID string,
+	knowledgeID string,
+	promptHash string,
+	configHash string,
+	content string,
+) types.ProcessArtifactCacheKey {
+	return types.ProcessArtifactCacheKey{
+		TenantID:     tenantID,
+		ArtifactType: "wiki:map:v1",
+		CacheKey: cachekey.ArtifactCacheKey(
+			language,
+			knowledgeBaseID,
+			knowledgeID,
+			cachekey.CanonicalCacheText(content),
+		),
+		ModelID:       modelID,
+		ConfigHash:    configHash,
+		PromptVersion: promptHash,
+	}
+}
+
+func docReaderArtifactKey(
+	tenantID uint64,
+	fileType string,
+	parserEngine string,
+	configHash string,
+	fileBytes []byte,
+) types.ProcessArtifactCacheKey {
+	return types.ProcessArtifactCacheKey{
+		TenantID:     tenantID,
+		ArtifactType: "docreader:v1",
+		CacheKey:     cachekey.SHA256HexBytes(fileBytes),
+		ModelID:      parserEngine,
+		ConfigHash:   cachekey.ArtifactCacheKey(fileType, configHash),
+	}
+}
+
+func vlmImageArtifactKey(
+	tenantID uint64,
+	modelID string,
+	promptHash string,
+	configHash string,
+	imageSourceType string,
+	imageBytes []byte,
+) types.ProcessArtifactCacheKey {
+	return types.ProcessArtifactCacheKey{
+		TenantID:      tenantID,
+		ArtifactType:  "vlm:image:v1",
+		CacheKey:      cachekey.ArtifactCacheKey(imageSourceType, cachekey.SHA256HexBytes(imageBytes)),
+		ModelID:       modelID,
+		ConfigHash:    configHash,
+		PromptVersion: promptHash,
+	}
+}
+
+func stableImageChildChunkID(parentID string, chunkType types.ChunkType, content string) string {
+	return stableChunkID(parentID, chunkType, textContentHash(content), 0)
+}
+
+func stableSummaryChunkID(knowledgeID string, summary string) string {
+	return stableChunkID(knowledgeID, types.ChunkTypeSummary, textContentHash(summary), 0)
+}

--- a/internal/application/service/rebuild_cache_keys_test.go
+++ b/internal/application/service/rebuild_cache_keys_test.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStableChunkIDSameForSameContentAcrossRuns(t *testing.T) {
+	got1 := stableChunkID("kid-1", types.ChunkTypeText, "hash-a", 0)
+	got2 := stableChunkID("kid-1", types.ChunkTypeText, "hash-a", 0)
+
+	require.Equal(t, got1, got2)
+	require.Len(t, got1, 36)
+}
+
+func TestStableChunkIDDisambiguatesDuplicateContent(t *testing.T) {
+	first := stableChunkID("kid-1", types.ChunkTypeText, "same-hash", 0)
+	second := stableChunkID("kid-1", types.ChunkTypeText, "same-hash", 1)
+
+	require.NotEqual(t, first, second)
+}
+
+func TestArtifactPromptVersionStableAndCompact(t *testing.T) {
+	got1 := artifactPromptVersion("prompt", "v1")
+	got2 := artifactPromptVersion("prompt", "v1")
+
+	require.Equal(t, got1, got2)
+	require.Len(t, got1, 32)
+}
+
+func TestEmbeddingArtifactKeyIncludesModelDimensionsAndCanonicalText(t *testing.T) {
+	got1 := embeddingArtifactKey(7, "model-1", 1536, "cfg", "hello\r\n")
+	got2 := embeddingArtifactKey(7, "model-1", 1536, "cfg", "hello\n")
+	changedModel := embeddingArtifactKey(7, "model-2", 1536, "cfg", "hello\n")
+	changedDims := embeddingArtifactKey(7, "model-1", 1024, "cfg", "hello\n")
+
+	require.Equal(t, got1, got2)
+	require.Equal(t, "embedding:v1", got1.ArtifactType)
+	require.Equal(t, "model-1", got1.ModelID)
+	require.NotEqual(t, got1.ModelID, changedModel.ModelID)
+	require.NotEqual(t, got1.ConfigHash, changedDims.ConfigHash)
+}
+
+func TestSummaryArtifactKeyIncludesPromptAndLanguage(t *testing.T) {
+	got := summaryArtifactKey(7, "chat-1", "zh-CN", "prompt", "cfg", "content")
+
+	require.Equal(t, uint64(7), got.TenantID)
+	require.Equal(t, "summary:v1", got.ArtifactType)
+	require.Equal(t, "chat-1", got.ModelID)
+	require.Equal(t, "cfg", got.ConfigHash)
+	require.Equal(t, "prompt", got.PromptVersion)
+}
+
+func TestVLMImageArtifactKeyDependsOnImageBytesAndModel(t *testing.T) {
+	base := vlmImageArtifactKey(7, "vlm-1", "prompt", "cfg", "default", []byte("image"))
+	same := vlmImageArtifactKey(7, "vlm-1", "prompt", "cfg", "default", []byte("image"))
+	changedBytes := vlmImageArtifactKey(7, "vlm-1", "prompt", "cfg", "default", []byte("other"))
+	changedModel := vlmImageArtifactKey(7, "vlm-2", "prompt", "cfg", "default", []byte("image"))
+
+	require.Equal(t, base, same)
+	require.Equal(t, "vlm:image:v1", base.ArtifactType)
+	require.NotEqual(t, base.CacheKey, changedBytes.CacheKey)
+	require.NotEqual(t, base.ModelID, changedModel.ModelID)
+}
+
+func TestStableImageChildChunkIDDependsOnParentTypeAndContent(t *testing.T) {
+	ocr := stableImageChildChunkID("parent-1", types.ChunkTypeImageOCR, "content")
+	caption := stableImageChildChunkID("parent-1", types.ChunkTypeImageCaption, "content")
+
+	require.Equal(t, ocr, stableImageChildChunkID("parent-1", types.ChunkTypeImageOCR, "content"))
+	require.NotEqual(t, ocr, caption)
+	require.Len(t, ocr, 36)
+}
+
+func TestQuestionArtifactKeyDependsOnPromptContextAndQuestionCount(t *testing.T) {
+	base := questionArtifactKey(7, "chat-1", "zh-CN", "prompt", "cfg", "doc", "chunk", "prev", "next", 3)
+	same := questionArtifactKey(7, "chat-1", "zh-CN", "prompt", "cfg", "doc", "chunk", "prev", "next", 3)
+	changedContext := questionArtifactKey(7, "chat-1", "zh-CN", "prompt", "cfg", "doc", "chunk", "changed", "next", 3)
+	changedCount := questionArtifactKey(7, "chat-1", "zh-CN", "prompt", "cfg", "doc", "chunk", "prev", "next", 4)
+
+	require.Equal(t, base, same)
+	require.Equal(t, "question:v1", base.ArtifactType)
+	require.NotEqual(t, base.CacheKey, changedContext.CacheKey)
+	require.NotEqual(t, base.ConfigHash, changedCount.ConfigHash)
+}
+
+func TestStableSummaryChunkIDDependsOnKnowledgeAndContent(t *testing.T) {
+	base := stableSummaryChunkID("kid-1", "summary")
+	same := stableSummaryChunkID("kid-1", "summary")
+	changed := stableSummaryChunkID("kid-1", "other summary")
+
+	require.Equal(t, base, same)
+	require.NotEqual(t, base, changed)
+	require.Len(t, base, 36)
+}
+
+func TestGraphChunkArtifactKeyDependsOnChunkContentAndTemplate(t *testing.T) {
+	base := graphChunkArtifactKey(7, "chat-1", "prompt", "cfg", "chunk content")
+	same := graphChunkArtifactKey(7, "chat-1", "prompt", "cfg", "chunk content")
+	changedContent := graphChunkArtifactKey(7, "chat-1", "prompt", "cfg", "other content")
+	changedPrompt := graphChunkArtifactKey(7, "chat-1", "prompt-2", "cfg", "chunk content")
+
+	require.Equal(t, base, same)
+	require.Equal(t, "graph:chunk:v1", base.ArtifactType)
+	require.NotEqual(t, base.CacheKey, changedContent.CacheKey)
+	require.NotEqual(t, base.PromptVersion, changedPrompt.PromptVersion)
+}
+
+func TestWikiMapArtifactKeyDependsOnDocumentLocalInputs(t *testing.T) {
+	base := wikiMapArtifactKey(7, "chat-1", "zh-CN", "kb-1", "kid-1", "prompt", "cfg", "content")
+	same := wikiMapArtifactKey(7, "chat-1", "zh-CN", "kb-1", "kid-1", "prompt", "cfg", "content")
+	changedContent := wikiMapArtifactKey(7, "chat-1", "zh-CN", "kb-1", "kid-1", "prompt", "cfg", "other")
+	changedLanguage := wikiMapArtifactKey(7, "chat-1", "en-US", "kb-1", "kid-1", "prompt", "cfg", "content")
+
+	require.Equal(t, base, same)
+	require.Equal(t, "wiki:map:v1", base.ArtifactType)
+	require.NotEqual(t, base.CacheKey, changedContent.CacheKey)
+	require.NotEqual(t, base.CacheKey, changedLanguage.CacheKey)
+}

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -191,17 +191,18 @@ type WikiPendingOp struct {
 // both of which are correctness-critical short-lived flags rather
 // than data the system should survive without.
 type wikiIngestService struct {
-	wikiService    interfaces.WikiPageService
-	kbService      interfaces.KnowledgeBaseService
-	knowledgeSvc   interfaces.KnowledgeService
-	knowledgeRepo  interfaces.KnowledgeRepository
-	chunkRepo      interfaces.ChunkRepository
-	modelService   interfaces.ModelService
-	task           interfaces.TaskEnqueuer
-	logEntrySvc    interfaces.WikiLogEntryService
-	pendingRepo    interfaces.TaskPendingOpsRepository
-	deadLetterRepo interfaces.TaskDeadLetterRepository
-	redisClient    *redis.Client // nil in Lite mode (no Redis)
+	wikiService      interfaces.WikiPageService
+	kbService        interfaces.KnowledgeBaseService
+	knowledgeSvc     interfaces.KnowledgeService
+	knowledgeRepo    interfaces.KnowledgeRepository
+	chunkRepo        interfaces.ChunkRepository
+	modelService     interfaces.ModelService
+	task             interfaces.TaskEnqueuer
+	logEntrySvc      interfaces.WikiLogEntryService
+	pendingRepo      interfaces.TaskPendingOpsRepository
+	deadLetterRepo   interfaces.TaskDeadLetterRepository
+	processCacheRepo interfaces.ProcessArtifactCacheRepository
+	redisClient      *redis.Client // nil in Lite mode (no Redis)
 	// spanTracker lets per-document map work surface as a
 	// postprocess.wiki subspan in the knowledge trace tree. Async
 	// batch design means we look up the parent attempt by knowledge
@@ -226,22 +227,24 @@ func NewWikiIngestService(
 	logEntrySvc interfaces.WikiLogEntryService,
 	pendingRepo interfaces.TaskPendingOpsRepository,
 	deadLetterRepo interfaces.TaskDeadLetterRepository,
+	processCacheRepo interfaces.ProcessArtifactCacheRepository,
 	redisClient *redis.Client,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
 	svc := &wikiIngestService{
-		wikiService:    wikiService,
-		kbService:      kbService,
-		knowledgeSvc:   knowledgeSvc,
-		knowledgeRepo:  knowledgeRepo,
-		chunkRepo:      chunkRepo,
-		modelService:   modelService,
-		task:           task,
-		logEntrySvc:    logEntrySvc,
-		pendingRepo:    pendingRepo,
-		deadLetterRepo: deadLetterRepo,
-		redisClient:    redisClient,
-		spanTracker:    spanTracker,
+		wikiService:      wikiService,
+		kbService:        kbService,
+		knowledgeSvc:     knowledgeSvc,
+		knowledgeRepo:    knowledgeRepo,
+		chunkRepo:        chunkRepo,
+		modelService:     modelService,
+		task:             task,
+		logEntrySvc:      logEntrySvc,
+		pendingRepo:      pendingRepo,
+		deadLetterRepo:   deadLetterRepo,
+		processCacheRepo: processCacheRepo,
+		redisClient:      redisClient,
+		spanTracker:      spanTracker,
 	}
 	return svc
 }
@@ -1301,6 +1304,7 @@ func formatExistingTaxonomyForPrompt(paths [][]string) string {
 	}
 	return strings.TrimSpace(buf.String())
 }
+
 // getExistingPageSlugsForKnowledge returns all page slugs that currently
 // reference a given knowledge ID in their source_refs. Used to snapshot
 // state before re-ingest so the reduce phase can reconcile additions vs

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -853,6 +853,63 @@ func (s *wikiIngestService) mapOneDocument(
 	// surface during wiki page editing.
 	sourceRef := knowledgeID
 	oldPageSlugs := s.getExistingPageSlugsForKnowledge(ctx, payload.KnowledgeBaseID, knowledgeID)
+	cacheKey := wikiMapArtifactKey(
+		payload.TenantID,
+		summaryModelID(chatModel, ""),
+		lang,
+		payload.KnowledgeBaseID,
+		knowledgeID,
+		artifactPromptVersion(
+			agent.WikiCandidateSlugPrompt,
+			agent.WikiKnowledgeExtractPrompt,
+			agent.WikiSummaryPrompt,
+			agent.WikiChunkCitationPrompt,
+			agent.WikiDeduplicationPrompt,
+		),
+		artifactConfigHash(types.JSONMap{
+			"model_name":             chatModel.GetModelName(),
+			"max_content_for_wiki":   maxContentForWiki,
+			"extraction_granularity": batchCtx.ExtractionGranularity,
+			"temperature":            0.3,
+			"llm_max_attempts":       wikiLLMMaxAttempts,
+		}),
+		content,
+	)
+	if s.processCacheRepo != nil {
+		cachePayload, ok, cacheErr := s.processCacheRepo.Get(ctx, cacheKey)
+		if cacheErr != nil {
+			logger.Warnf(ctx, "wiki map cache read failed, recomputing: %v", cacheErr)
+		} else if ok {
+			if result, baseUpdates, ok := wikiMapFromCachePayload(cachePayload, wikiSpan); ok {
+				priorContribution := batchCtx.SummaryContentByKnowledgeID(ctx, knowledgeID)
+				updates, reparseOverlap, staleCount := appendWikiMapRetractions(
+					baseUpdates,
+					result.Pages,
+					oldPageSlugs,
+					priorContribution,
+					content,
+					docTitle,
+					knowledgeID,
+					lang,
+				)
+				if result.MapStats == nil {
+					result.MapStats = types.JSONMap{}
+				}
+				result.MapStats["cache_hit"] = true
+				result.MapStats["old_pages"] = len(oldPageSlugs)
+				result.MapStats["updates"] = len(updates)
+				result.MapStats["reparse_slugs"] = reparseOverlap
+				result.MapStats["stale_slugs"] = staleCount
+				logger.Infof(ctx,
+					"wiki ingest: cache-hit mapped knowledge %s title=%q updates=%d reparse_slugs=%d stale_slugs=%d elapsed=%s",
+					knowledgeID, previewText(result.DocTitle, 80), len(updates), reparseOverlap, staleCount,
+					time.Since(docStartedAt).Round(time.Millisecond),
+				)
+				return result, updates, nil
+			}
+			logger.Warnf(ctx, "wiki map cache payload invalid, recomputing")
+		}
+	}
 
 	// Pass 0: lightweight candidate slug extraction (skeleton only).
 	// On failure we fall back to the legacy single-shot extractor so the doc
@@ -1135,40 +1192,16 @@ func (s *wikiIngestService) mapOneDocument(
 	// empty, so we never consult it.
 	priorContribution := batchCtx.SummaryContentByKnowledgeID(ctx, knowledgeID)
 
-	newSlugSet := make(map[string]bool, len(extractedPages))
-	for _, ns := range extractedPages {
-		newSlugSet[ns.Slug] = true
-	}
-
-	var reparseOverlap, staleCount int
-	for oldSlug := range oldPageSlugs {
-		if newSlugSet[oldSlug] {
-			// Skip summary slugs — they're overwritten wholesale by the
-			// summary update, retract would be ignored downstream.
-			if strings.HasPrefix(oldSlug, "summary/") {
-				continue
-			}
-			reparseOverlap++
-			updates = append(updates, SlugUpdate{
-				Slug:              oldSlug,
-				Type:              "retract",
-				RetractDocContent: priorContribution,
-				DocTitle:          docTitle,
-				KnowledgeID:       knowledgeID,
-				Language:          lang,
-			})
-			continue
-		}
-		staleCount++
-		updates = append(updates, SlugUpdate{
-			Slug:              oldSlug,
-			Type:              "retractStale",
-			RetractDocContent: content,
-			DocTitle:          docTitle,
-			KnowledgeID:       knowledgeID,
-			Language:          lang,
-		})
-	}
+	updates, reparseOverlap, staleCount := appendWikiMapRetractions(
+		updates,
+		extractedPages,
+		oldPageSlugs,
+		priorContribution,
+		content,
+		docTitle,
+		knowledgeID,
+		lang,
+	)
 
 	logger.Infof(ctx,
 		"wiki ingest: mapped knowledge %s title=%q candidates=%d chunks=%d batches=%d cited_chunks=%d uncited_slugs=%d new_slugs=%d updates=%d reparse_slugs=%d stale_slugs=%d pass0_fallback=%v elapsed=%s",
@@ -1202,14 +1235,126 @@ func (s *wikiIngestService) mapOneDocument(
 		"summary_preview":  previewText(docSummaryLine, 160),
 	}
 
-	return &docIngestResult{
+	result := &docIngestResult{
 		KnowledgeID: knowledgeID,
 		DocTitle:    docTitle,
 		Summary:     docSummaryLine,
 		Pages:       extractedPages,
 		MapStats:    mapStats,
 		WikiSpan:    wikiSpan,
-	}, updates, nil
+	}
+	if s.processCacheRepo != nil {
+		if cacheErr := s.processCacheRepo.Put(ctx, cacheKey, wikiMapCachePayload(result, updates)); cacheErr != nil {
+			logger.Warnf(ctx, "wiki map cache write failed: %v", cacheErr)
+		}
+	}
+	return result, updates, nil
+}
+
+type wikiMapCachedResult struct {
+	KnowledgeID string                 `json:"knowledge_id"`
+	DocTitle    string                 `json:"doc_title"`
+	Summary     string                 `json:"summary"`
+	Pages       []types.WikiLogPageRef `json:"pages"`
+	MapStats    types.JSONMap          `json:"map_stats"`
+}
+
+type wikiMapCachedPayload struct {
+	Result  wikiMapCachedResult `json:"result"`
+	Updates []SlugUpdate        `json:"updates"`
+}
+
+func wikiMapCachePayload(result *docIngestResult, updates []SlugUpdate) types.JSONMap {
+	if result == nil {
+		return types.JSONMap{"result": wikiMapCachedResult{}, "updates": []SlugUpdate{}}
+	}
+	return types.JSONMap{
+		"result": wikiMapCachedResult{
+			KnowledgeID: result.KnowledgeID,
+			DocTitle:    result.DocTitle,
+			Summary:     result.Summary,
+			Pages:       append([]types.WikiLogPageRef(nil), result.Pages...),
+			MapStats:    result.MapStats,
+		},
+		"updates": wikiMapBaseUpdates(updates),
+	}
+}
+
+func wikiMapFromCachePayload(payload types.JSONMap, wikiSpan *Span) (*docIngestResult, []SlugUpdate, bool) {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, nil, false
+	}
+	var cached wikiMapCachedPayload
+	if err := json.Unmarshal(b, &cached); err != nil {
+		return nil, nil, false
+	}
+	result := &docIngestResult{
+		KnowledgeID: cached.Result.KnowledgeID,
+		DocTitle:    cached.Result.DocTitle,
+		Summary:     cached.Result.Summary,
+		Pages:       cached.Result.Pages,
+		MapStats:    cached.Result.MapStats,
+		WikiSpan:    wikiSpan,
+	}
+	return result, wikiMapBaseUpdates(cached.Updates), true
+}
+
+func wikiMapBaseUpdates(updates []SlugUpdate) []SlugUpdate {
+	base := make([]SlugUpdate, 0, len(updates))
+	for _, update := range updates {
+		if update.Type == "retract" || update.Type == "retractStale" {
+			continue
+		}
+		base = append(base, update)
+	}
+	return base
+}
+
+func appendWikiMapRetractions(
+	baseUpdates []SlugUpdate,
+	extractedPages []types.WikiLogPageRef,
+	oldPageSlugs map[string]bool,
+	priorContribution string,
+	content string,
+	docTitle string,
+	knowledgeID string,
+	lang string,
+) ([]SlugUpdate, int, int) {
+	updates := append([]SlugUpdate(nil), baseUpdates...)
+	newSlugSet := make(map[string]bool, len(extractedPages))
+	for _, ns := range extractedPages {
+		newSlugSet[ns.Slug] = true
+	}
+
+	var reparseOverlap, staleCount int
+	for oldSlug := range oldPageSlugs {
+		if newSlugSet[oldSlug] {
+			if strings.HasPrefix(oldSlug, "summary/") {
+				continue
+			}
+			reparseOverlap++
+			updates = append(updates, SlugUpdate{
+				Slug:              oldSlug,
+				Type:              "retract",
+				RetractDocContent: priorContribution,
+				DocTitle:          docTitle,
+				KnowledgeID:       knowledgeID,
+				Language:          lang,
+			})
+			continue
+		}
+		staleCount++
+		updates = append(updates, SlugUpdate{
+			Slug:              oldSlug,
+			Type:              "retractStale",
+			RetractDocContent: content,
+			DocTitle:          docTitle,
+			KnowledgeID:       knowledgeID,
+			Language:          lang,
+		})
+	}
+	return updates, reparseOverlap, staleCount
 }
 
 func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(

--- a/internal/application/service/wiki_ingest_cache_test.go
+++ b/internal/application/service/wiki_ingest_cache_test.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWikiMapCachePayloadDropsRetractionsAndRestoresBaseUpdates(t *testing.T) {
+	result := &docIngestResult{
+		KnowledgeID: "kid-1",
+		DocTitle:    "Doc",
+		Summary:     "Summary",
+		Pages: []types.WikiLogPageRef{
+			{Slug: "summary/kid-1", Title: "Doc"},
+			{Slug: "entity/acme", Title: "Acme"},
+		},
+		MapStats: types.JSONMap{"updates": 3},
+	}
+	updates := []SlugUpdate{
+		{Slug: "summary/kid-1", Type: types.WikiPageTypeSummary, KnowledgeID: "kid-1"},
+		{Slug: "entity/acme", Type: types.WikiPageTypeEntity, KnowledgeID: "kid-1"},
+		{Slug: "entity/old", Type: "retractStale", KnowledgeID: "kid-1"},
+	}
+
+	payload := wikiMapCachePayload(result, updates)
+	restoredResult, restoredUpdates, ok := wikiMapFromCachePayload(payload, nil)
+
+	require.True(t, ok)
+	require.Equal(t, "kid-1", restoredResult.KnowledgeID)
+	require.Len(t, restoredResult.Pages, 2)
+	require.Len(t, restoredUpdates, 2)
+	require.Equal(t, "summary/kid-1", restoredUpdates[0].Slug)
+	require.Equal(t, "entity/acme", restoredUpdates[1].Slug)
+}
+
+func TestAppendWikiMapRetractionsUsesCurrentOldPageSet(t *testing.T) {
+	base := []SlugUpdate{
+		{Slug: "summary/kid-1", Type: types.WikiPageTypeSummary, KnowledgeID: "kid-1"},
+		{Slug: "entity/acme", Type: types.WikiPageTypeEntity, KnowledgeID: "kid-1"},
+	}
+	pages := []types.WikiLogPageRef{
+		{Slug: "summary/kid-1", Title: "Doc"},
+		{Slug: "entity/acme", Title: "Acme"},
+	}
+
+	updates, reparseOverlap, staleCount := appendWikiMapRetractions(
+		base,
+		pages,
+		map[string]bool{
+			"summary/kid-1": true,
+			"entity/acme":   true,
+			"entity/old":    true,
+		},
+		"prior contribution",
+		"new content",
+		"Doc",
+		"kid-1",
+		"zh-CN",
+	)
+
+	require.Equal(t, 1, reparseOverlap)
+	require.Equal(t, 1, staleCount)
+	require.Len(t, updates, 4)
+	require.Equal(t, "retract", updates[2].Type)
+	require.Equal(t, "entity/acme", updates[2].Slug)
+	require.Equal(t, "prior contribution", updates[2].RetractDocContent)
+	require.Equal(t, "retractStale", updates[3].Type)
+	require.Equal(t, "entity/old", updates[3].Slug)
+	require.Equal(t, "new content", updates[3].RetractDocContent)
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -170,6 +170,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewWikiLogEntryRepository))
 	must(container.Provide(repository.NewTaskPendingOpsRepository))
 	must(container.Provide(repository.NewTaskDeadLetterRepository))
+	must(container.Provide(repository.NewProcessArtifactCacheRepository))
 
 	// MCP manager for managing MCP client connections
 	logger.Debugf(ctx, "[Container] Registering MCP manager...")

--- a/internal/im/im_file_service_test.go
+++ b/internal/im/im_file_service_test.go
@@ -26,6 +26,10 @@ func (s *stubIMFileService) SaveBytes(context.Context, []byte, uint64, string, b
 	return "", nil
 }
 
+func (s *stubIMFileService) SaveContentAddressedBytes(context.Context, []byte, uint64, string, bool) (string, error) {
+	return "", nil
+}
+
 func (s *stubIMFileService) GetFile(context.Context, string) (io.ReadCloser, error) {
 	return nil, nil
 }

--- a/internal/infrastructure/docparser/image_resolver.go
+++ b/internal/infrastructure/docparser/image_resolver.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
-	"github.com/google/uuid"
 )
 
 const (
@@ -57,6 +56,7 @@ type StoredImage struct {
 	OriginalRef string // reference in the original markdown
 	ServingURL  string // provider:// URL (e.g. local://images/xxx.png, minio://bucket/key)
 	MimeType    string
+	ContentHash string
 }
 
 // ImageResolver reads images from a DocReader ReadResult (inline bytes only)
@@ -181,6 +181,7 @@ func (r *ImageResolver) saveReferencedImage(
 				OriginalRef: refPath,
 				ServingURL:  cached.ServingURL,
 				MimeType:    cached.MimeType,
+				ContentHash: cached.ContentHash,
 			}
 			savedRefs[refPath] = stored
 			return stored, true
@@ -195,8 +196,9 @@ func (r *ImageResolver) saveReferencedImage(
 		ext = ".png"
 	}
 
-	fileName := uuid.New().String() + ext
-	servingURL, saveErr := fileSvc.SaveBytes(ctx, ref.ImageData, tenantID, fileName, false)
+	contentHash := secutils.SHA256HexBytes(ref.ImageData)
+	fileName := secutils.StableImageFilename(ref.ImageData, ext)
+	servingURL, saveErr := fileSvc.SaveContentAddressedBytes(ctx, ref.ImageData, tenantID, fileName, false)
 	if saveErr != nil {
 		log.Printf("WARN: failed to save image %s: %v", refPath, saveErr)
 		return StoredImage{}, false
@@ -206,6 +208,7 @@ func (r *ImageResolver) saveReferencedImage(
 		OriginalRef: refPath,
 		ServingURL:  servingURL,
 		MimeType:    ref.MimeType,
+		ContentHash: contentHash,
 	}
 	savedRefs[refPath] = stored
 	if ref.Filename != "" {
@@ -382,8 +385,9 @@ func (r *ImageResolver) ResolveHTMLDataURIImages(
 		if ext == "" {
 			ext = ".png"
 		}
-		fileName := uuid.New().String() + ext
-		servingURL, saveErr := fileSvc.SaveBytes(ctx, data, tenantID, fileName, false)
+		contentHash := secutils.SHA256HexBytes(data)
+		fileName := secutils.StableImageFilename(data, ext)
+		servingURL, saveErr := fileSvc.SaveContentAddressedBytes(ctx, data, tenantID, fileName, false)
 		if saveErr != nil {
 			log.Printf("WARN: failed to save HTML img data URI image: %v", saveErr)
 			continue
@@ -392,6 +396,7 @@ func (r *ImageResolver) ResolveHTMLDataURIImages(
 			OriginalRef: "html-img-data-uri",
 			ServingURL:  servingURL,
 			MimeType:    mimeType,
+			ContentHash: contentHash,
 		})
 		markdown = markdown[:m[0]] + fmt.Sprintf("![image](%s)", servingURL) + markdown[m[1]:]
 		processed++
@@ -521,8 +526,9 @@ func (r *ImageResolver) resolveBareDataURIs(
 		if ext == "" {
 			ext = ".png"
 		}
-		fileName := uuid.New().String() + ext
-		servingURL, saveErr := fileSvc.SaveBytes(ctx, data, tenantID, fileName, false)
+		contentHash := secutils.SHA256HexBytes(data)
+		fileName := secutils.StableImageFilename(data, ext)
+		servingURL, saveErr := fileSvc.SaveContentAddressedBytes(ctx, data, tenantID, fileName, false)
 		if saveErr != nil {
 			log.Printf("WARN: failed to save bare data URI image: %v", saveErr)
 			continue
@@ -531,6 +537,7 @@ func (r *ImageResolver) resolveBareDataURIs(
 			OriginalRef: "bare-data-uri",
 			ServingURL:  servingURL,
 			MimeType:    mimeType,
+			ContentHash: contentHash,
 		})
 		if insideWrapper {
 			// Inside a broken markdown ref like ![weird]alt](data:...) — replace data URI only
@@ -589,8 +596,9 @@ func (r *ImageResolver) resolveBareBase64Prefix(
 		if ext == "" {
 			ext = ".png"
 		}
-		fileName := uuid.New().String() + ext
-		servingURL, saveErr := fileSvc.SaveBytes(ctx, data, tenantID, fileName, false)
+		contentHash := secutils.SHA256HexBytes(data)
+		fileName := secutils.StableImageFilename(data, ext)
+		servingURL, saveErr := fileSvc.SaveContentAddressedBytes(ctx, data, tenantID, fileName, false)
 		if saveErr != nil {
 			log.Printf("WARN: failed to save bare base64 image: %v", saveErr)
 			continue
@@ -599,6 +607,7 @@ func (r *ImageResolver) resolveBareBase64Prefix(
 			OriginalRef: "bare-base64",
 			ServingURL:  servingURL,
 			MimeType:    mimeType,
+			ContentHash: contentHash,
 		})
 		markdown = markdown[:m[0]] + fmt.Sprintf("![image](%s)", servingURL) + markdown[m[1]:]
 		processed++
@@ -721,8 +730,9 @@ func (r *ImageResolver) ResolveDataURIImages(
 		if ext == "" {
 			ext = ".png"
 		}
-		fileName := uuid.New().String() + ext
-		servingURL, saveErr := fileSvc.SaveBytes(ctx, data, tenantID, fileName, false)
+		contentHash := secutils.SHA256HexBytes(data)
+		fileName := secutils.StableImageFilename(data, ext)
+		servingURL, saveErr := fileSvc.SaveContentAddressedBytes(ctx, data, tenantID, fileName, false)
 		if saveErr != nil {
 			log.Printf("WARN: failed to save data URI image: %v", saveErr)
 			continue
@@ -731,6 +741,7 @@ func (r *ImageResolver) ResolveDataURIImages(
 			OriginalRef: dataURI,
 			ServingURL:  servingURL,
 			MimeType:    mimeType,
+			ContentHash: contentHash,
 		})
 		markdown = markdown[:m[4]] + servingURL + markdown[m[5]:]
 		processed++
@@ -822,15 +833,16 @@ func (r *ImageResolver) ResolveRemoteImages(
 		}
 
 		var servingURL string
+		contentHash := secutils.SHA256HexBytes(data)
 		if whitelisted {
 			// Keep the original URL — ImageMultimodalService will download it
 			// directly for OCR/caption analysis.
 			servingURL = imgURL
 		} else {
 			// --- Upload to storage ---
-			fileName := uuid.New().String() + ext
+			fileName := secutils.StableImageFilename(data, ext)
 			var saveErr error
-			servingURL, saveErr = fileSvc.SaveBytes(ctx, data, tenantID, fileName, false)
+			servingURL, saveErr = fileSvc.SaveContentAddressedBytes(ctx, data, tenantID, fileName, false)
 			if saveErr != nil {
 				log.Printf("WARN: failed to save remote image %s: %v", imgURL, saveErr)
 				continue
@@ -841,6 +853,7 @@ func (r *ImageResolver) ResolveRemoteImages(
 			OriginalRef: imgURL,
 			ServingURL:  servingURL,
 			MimeType:    mimeType,
+			ContentHash: contentHash,
 		})
 
 		if !whitelisted {

--- a/internal/infrastructure/docparser/image_resolver_test.go
+++ b/internal/infrastructure/docparser/image_resolver_test.go
@@ -99,6 +99,19 @@ func (c *captureSaveBytes) SaveBytes(_ context.Context, data []byte, _ uint64, f
 	return u, nil
 }
 
+func (c *captureSaveBytes) SaveContentAddressedBytes(
+	_ context.Context,
+	data []byte,
+	tenantID uint64,
+	fileName string,
+	_ bool,
+) (string, error) {
+	c.saved = append(c.saved, append([]byte(nil), data...))
+	u := "local://test/" + fileName
+	c.urls = append(c.urls, u)
+	return u, nil
+}
+
 func (c *captureSaveBytes) GetFile(context.Context, string) (io.ReadCloser, error) {
 	return nil, fmt.Errorf("not implemented")
 }
@@ -112,6 +125,44 @@ func (c *captureSaveBytes) CopyFile(context.Context, string, uint64, string) (st
 }
 
 var _ interfaces.FileService = (*captureSaveBytes)(nil)
+
+func TestResolveAndStoreUsesContentAddressedImageName(t *testing.T) {
+	png := createTestPNG(200, 150)
+	result := &types.ReadResult{
+		MarkdownContent: "![x](img.png)",
+		ImageRefs: []types.ImageRef{{
+			Filename:    "img.png",
+			OriginalRef: "img.png",
+			MimeType:    "image/png",
+			ImageData:   png,
+			IsOriginal:  true,
+		}},
+	}
+	svc := &captureSaveBytes{}
+	r := NewImageResolver()
+
+	out1, imgs1, err := r.ResolveAndStore(context.Background(), result, svc, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out2, imgs2, err := r.ResolveAndStore(context.Background(), result, svc, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if out1 != out2 {
+		t.Fatalf("markdown should be stable:\n%s\n%s", out1, out2)
+	}
+	if len(imgs1) != 1 || len(imgs2) != 1 {
+		t.Fatalf("expected one stored image each run, got %d and %d", len(imgs1), len(imgs2))
+	}
+	if imgs1[0].ServingURL != imgs2[0].ServingURL {
+		t.Fatalf("serving URL should be stable: %s vs %s", imgs1[0].ServingURL, imgs2[0].ServingURL)
+	}
+	if imgs1[0].ContentHash == "" || imgs1[0].ContentHash != imgs2[0].ContentHash {
+		t.Fatalf("content hash should be stable and non-empty: %q vs %q", imgs1[0].ContentHash, imgs2[0].ContentHash)
+	}
+}
 
 func TestResolveDataURIImages(t *testing.T) {
 	png := createTestPNG(200, 150)

--- a/internal/infrastructure/docparser/resolve_remote_images_test.go
+++ b/internal/infrastructure/docparser/resolve_remote_images_test.go
@@ -30,6 +30,10 @@ func (m *mockFileService) SaveBytes(ctx context.Context, data []byte, tenantID u
 	m.saved = append(m.saved, savedEntry{Data: data, TenantID: tenantID, FileName: fileName})
 	return fmt.Sprintf("local://images/%s", fileName), nil
 }
+func (m *mockFileService) SaveContentAddressedBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error) {
+	m.saved = append(m.saved, savedEntry{Data: data, TenantID: tenantID, FileName: fileName})
+	return fmt.Sprintf("local://images/%s", fileName), nil
+}
 func (m *mockFileService) GetFile(ctx context.Context, filePath string) (io.ReadCloser, error) {
 	return nil, nil
 }

--- a/internal/router/router_files_test.go
+++ b/internal/router/router_files_test.go
@@ -34,6 +34,10 @@ func (s *stubFileService) SaveBytes(ctx context.Context, data []byte, tenantID u
 	panic("unexpected call to SaveBytes")
 }
 
+func (s *stubFileService) SaveContentAddressedBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error) {
+	panic("unexpected call to SaveContentAddressedBytes")
+}
+
 func (s *stubFileService) GetFile(ctx context.Context, filePath string) (io.ReadCloser, error) {
 	if s.getFile == nil {
 		panic("unexpected call to GetFile")

--- a/internal/types/interfaces/chunk.go
+++ b/internal/types/interfaces/chunk.go
@@ -16,6 +16,8 @@ type ChunkImageInfo struct {
 type ChunkRepository interface {
 	// CreateChunks creates chunks
 	CreateChunks(ctx context.Context, chunks []*types.Chunk) error
+	// CreateChunksIgnoreExisting creates chunks and ignores primary-key conflicts.
+	CreateChunksIgnoreExisting(ctx context.Context, chunks []*types.Chunk) error
 	// GetChunkByID gets a chunk by id
 	GetChunkByID(ctx context.Context, tenantID uint64, id string) (*types.Chunk, error)
 	// GetChunkByIDOnly gets a chunk by id without tenant filter (for permission resolution)
@@ -30,6 +32,8 @@ type ChunkRepository interface {
 	ListChunksBySeqID(ctx context.Context, tenantID uint64, seqIDs []int64) ([]*types.Chunk, error)
 	// ListChunksByKnowledgeID lists chunks by knowledge id
 	ListChunksByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) ([]*types.Chunk, error)
+	// ListChunksByKnowledgeIDIncludeTypes lists chunks for a knowledge ID and selected chunk types.
+	ListChunksByKnowledgeIDIncludeTypes(ctx context.Context, tenantID uint64, knowledgeID string, chunkTypes []types.ChunkType) ([]*types.Chunk, error)
 	// ListPagedChunksByKnowledgeID lists paged chunks by knowledge id.
 	// When tagID is non-empty, results are filtered by tag_id.
 	// knowledgeType: "faq" or "manual" - determines sort order and search behavior
@@ -60,6 +64,8 @@ type ChunkRepository interface {
 	DeleteChunk(ctx context.Context, tenantID uint64, id string) error
 	// DeleteChunks deletes chunks by IDs in batch
 	DeleteChunks(ctx context.Context, tenantID uint64, ids []string) error
+	// DeleteChunksAndChildren deletes chunks and direct children, returning every deleted ID.
+	DeleteChunksAndChildren(ctx context.Context, tenantID uint64, ids []string) ([]string, error)
 	// DeleteChunksByKnowledgeID deletes chunks by knowledge id
 	DeleteChunksByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) error
 	// DeleteByKnowledgeList deletes all chunks for a knowledge list
@@ -113,12 +119,16 @@ type ChunkRepository interface {
 type ChunkService interface {
 	// CreateChunks creates chunks
 	CreateChunks(ctx context.Context, chunks []*types.Chunk) error
+	// CreateChunksIgnoreExisting creates chunks and ignores primary-key conflicts.
+	CreateChunksIgnoreExisting(ctx context.Context, chunks []*types.Chunk) error
 	// GetChunkByID gets a chunk by id (uses tenant from context)
 	GetChunkByID(ctx context.Context, id string) (*types.Chunk, error)
 	// GetChunkByIDOnly gets a chunk by id without tenant filter (for permission resolution)
 	GetChunkByIDOnly(ctx context.Context, id string) (*types.Chunk, error)
 	// ListChunksByKnowledgeID lists chunks by knowledge id
 	ListChunksByKnowledgeID(ctx context.Context, knowledgeID string) ([]*types.Chunk, error)
+	// ListChunksByKnowledgeIDIncludeTypes lists chunks for a knowledge ID and selected chunk types.
+	ListChunksByKnowledgeIDIncludeTypes(ctx context.Context, tenantID uint64, knowledgeID string, chunkTypes []types.ChunkType) ([]*types.Chunk, error)
 	// ListPagedChunksByKnowledgeID lists paged chunks by knowledge id
 	ListPagedChunksByKnowledgeID(
 		ctx context.Context,
@@ -134,6 +144,8 @@ type ChunkService interface {
 	DeleteChunk(ctx context.Context, id string) error
 	// DeleteChunks deletes chunks by IDs in batch
 	DeleteChunks(ctx context.Context, ids []string) error
+	// DeleteChunksAndChildren deletes chunks and direct children, returning every deleted ID.
+	DeleteChunksAndChildren(ctx context.Context, tenantID uint64, ids []string) ([]string, error)
 	// DeleteChunksByKnowledgeID deletes chunks by knowledge id
 	DeleteChunksByKnowledgeID(ctx context.Context, knowledgeID string) error
 	// DeleteByKnowledgeList deletes all chunks for a knowledge list

--- a/internal/types/interfaces/file.go
+++ b/internal/types/interfaces/file.go
@@ -17,6 +17,9 @@ type FileService interface {
 	// SaveBytes saves bytes data to a file and returns the file path.
 	// If temp is true, the file will be saved to a temporary storage that may auto-expire.
 	SaveBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error)
+	// SaveContentAddressedBytes saves bytes to a deterministic tenant-scoped cache path.
+	// Implementations must not append timestamps or random suffixes.
+	SaveContentAddressedBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error)
 	// GetFile retrieves a file.
 	GetFile(ctx context.Context, filePath string) (io.ReadCloser, error)
 	// GetFileURL returns a download URL for the file (if supported by the storage backend).

--- a/internal/types/interfaces/process_artifact_cache.go
+++ b/internal/types/interfaces/process_artifact_cache.go
@@ -1,0 +1,12 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+type ProcessArtifactCacheRepository interface {
+	Put(ctx context.Context, key types.ProcessArtifactCacheKey, payload types.JSONMap) error
+	Get(ctx context.Context, key types.ProcessArtifactCacheKey) (types.JSONMap, bool, error)
+}

--- a/internal/types/process_artifact_cache.go
+++ b/internal/types/process_artifact_cache.go
@@ -1,0 +1,25 @@
+package types
+
+import "time"
+
+type ProcessArtifactCache struct {
+	ID            int64   `json:"id" gorm:"primaryKey;autoIncrement"`
+	TenantID      uint64  `json:"tenant_id" gorm:"not null;uniqueIndex:idx_process_artifact_cache_key,priority:1"`
+	ArtifactType  string  `json:"artifact_type" gorm:"type:varchar(64);not null;uniqueIndex:idx_process_artifact_cache_key,priority:2"`
+	CacheKey      string  `json:"cache_key" gorm:"type:varchar(128);not null;uniqueIndex:idx_process_artifact_cache_key,priority:3"`
+	ModelID       string  `json:"model_id" gorm:"type:varchar(128);not null;default:'';uniqueIndex:idx_process_artifact_cache_key,priority:4"`
+	ConfigHash    string  `json:"config_hash" gorm:"type:varchar(64);not null;default:'';uniqueIndex:idx_process_artifact_cache_key,priority:5"`
+	PromptVersion string  `json:"prompt_version" gorm:"type:varchar(64);not null;default:'';uniqueIndex:idx_process_artifact_cache_key,priority:6"`
+	Payload       JSONMap `json:"payload" gorm:"type:json;serializer:json"`
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+type ProcessArtifactCacheKey struct {
+	TenantID      uint64
+	ArtifactType  string
+	CacheKey      string
+	ModelID       string
+	ConfigHash    string
+	PromptVersion string
+}

--- a/internal/utils/content_address.go
+++ b/internal/utils/content_address.go
@@ -1,0 +1,61 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+)
+
+func SHA256HexBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func CanonicalCacheText(s string) string {
+	s = cleanInvalidUTF8ForCache(s)
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	return strings.ReplaceAll(s, "\r", "\n")
+}
+
+func cleanInvalidUTF8ForCache(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			i++
+			continue
+		}
+		if r == 0 {
+			i += size
+			continue
+		}
+		b.WriteRune(r)
+		i += size
+	}
+	return b.String()
+}
+
+func TextContentHash(s string) string {
+	return SHA256HexBytes([]byte(CanonicalCacheText(s)))
+}
+
+func StableImageFilename(data []byte, originalNameOrExt string) string {
+	ext := strings.ToLower(filepath.Ext(originalNameOrExt))
+	if ext == "" {
+		ext = ".png"
+	}
+	return SHA256HexBytes(data) + ext
+}
+
+func StableJSONHash(v any) string {
+	b, _ := json.Marshal(v)
+	return SHA256HexBytes(b)
+}
+
+func ArtifactCacheKey(parts ...string) string {
+	return SHA256HexBytes([]byte(strings.Join(parts, "\x00")))
+}

--- a/internal/utils/content_address_test.go
+++ b/internal/utils/content_address_test.go
@@ -1,0 +1,23 @@
+package utils_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStableImageFilenameUsesBytesAndExtension(t *testing.T) {
+	got1 := utils.StableImageFilename([]byte("same-bytes"), "scan.PNG")
+	got2 := utils.StableImageFilename([]byte("same-bytes"), ".png")
+
+	require.Equal(t, got1, got2)
+	require.True(t, strings.HasSuffix(got1, ".png"))
+}
+
+func TestCanonicalCacheTextNormalizesLineEndingsAndInvalidUTF8(t *testing.T) {
+	got := utils.CanonicalCacheText("a\r\nb\rc" + string([]byte{0xff}))
+
+	require.Equal(t, "a\nb\nc", got)
+}

--- a/migrations/sqlite/000000_init.up.sql
+++ b/migrations/sqlite/000000_init.up.sql
@@ -751,3 +751,28 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_vector_stores_name_tenant
 CREATE INDEX IF NOT EXISTS idx_vector_stores_tenant_id ON vector_stores(tenant_id);
 CREATE INDEX IF NOT EXISTS idx_vector_stores_engine_type ON vector_stores(engine_type);
 CREATE INDEX IF NOT EXISTS idx_vector_stores_deleted_at ON vector_stores(deleted_at);
+
+CREATE TABLE IF NOT EXISTS process_artifact_caches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id INTEGER NOT NULL,
+    artifact_type VARCHAR(64) NOT NULL,
+    cache_key VARCHAR(128) NOT NULL,
+    model_id VARCHAR(128) NOT NULL DEFAULT '',
+    config_hash VARCHAR(64) NOT NULL DEFAULT '',
+    prompt_version VARCHAR(64) NOT NULL DEFAULT '',
+    payload TEXT NOT NULL DEFAULT '{}',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_process_artifact_cache_key
+    ON process_artifact_caches (
+        tenant_id,
+        artifact_type,
+        cache_key,
+        model_id,
+        config_hash,
+        prompt_version
+    );
+CREATE INDEX IF NOT EXISTS idx_process_artifact_cache_tenant_type
+    ON process_artifact_caches (tenant_id, artifact_type, updated_at DESC);

--- a/migrations/versioned/000065_rebuild_artifact_cache.down.sql
+++ b/migrations/versioned/000065_rebuild_artifact_cache.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_process_artifact_cache_tenant_type;
+DROP INDEX IF EXISTS idx_process_artifact_cache_key;
+DROP TABLE IF EXISTS process_artifact_caches;

--- a/migrations/versioned/000065_rebuild_artifact_cache.up.sql
+++ b/migrations/versioned/000065_rebuild_artifact_cache.up.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS process_artifact_caches (
+    id BIGSERIAL PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
+    artifact_type VARCHAR(64) NOT NULL,
+    cache_key VARCHAR(128) NOT NULL,
+    model_id VARCHAR(128) NOT NULL DEFAULT '',
+    config_hash VARCHAR(64) NOT NULL DEFAULT '',
+    prompt_version VARCHAR(64) NOT NULL DEFAULT '',
+    payload JSONB NOT NULL DEFAULT '{}'::JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_process_artifact_cache_key
+    ON process_artifact_caches (
+        tenant_id,
+        artifact_type,
+        cache_key,
+        model_id,
+        config_hash,
+        prompt_version
+    );
+
+CREATE INDEX IF NOT EXISTS idx_process_artifact_cache_tenant_type
+    ON process_artifact_caches (tenant_id, artifact_type, updated_at DESC);


### PR DESCRIPTION
Closes #1679 

It changes knowledge rebuilds from full recomputation into diff-aware reuse: **unchanged content reuses completed artifacts, while only changed inputs and their dependent layers are recomputed.**

## Summary

The previous rebuild path deleted derived state early and regenerated most expensive artifacts, even when the source document had not changed. This made no-op rebuilds behave like first-time ingestion.

This change introduces stable identities, process artifact caching, and diff-aware reconciliation across the rebuild pipeline. For unchanged knowledge, DocReader/OCR, downloaded `file_url` bytes, image VLM output, embeddings, summaries, questions, GraphRAG chunk maps, and Wiki map output can now hit cache. `Wiki reduce` still runs when contributor state changes because it is the cross-document aggregation step.

## Workflow Comparison

### Previous workflow

Before this change, rebuilds were destructive and ID-unstable. The pipeline removed old chunks and related records, regenerated temporary image paths and chunk IDs, and then reran each expensive document-local stage even when the normalized document content was identical.

```mermaid
flowchart TD
    accTitle: Previous Rebuild Workflow
    accDescr: The old rebuild path eagerly deleted derived records and reran OCR, VLM, embedding, and generation work for unchanged content.

    request["Rebuild request"]
    cleanup["Delete chunks, vectors, and graph records"]
    reader["Run DocReader and OCR"]
    images["Store extracted images under unstable names"]
    chunks["Create chunks with random IDs"]
    embed["Embed every text chunk"]
    text_gen["Regenerate summaries and questions"]
    image_vlm["Rerun image OCR and caption VLM"]
    graph_rag["Rerun GraphRAG chunk extraction"]
    wiki_map["Rerun Wiki map"]
    reduce["Run Wiki reduce"]
    done["Persist rebuilt knowledge"]

    request --> cleanup --> reader --> images --> chunks --> embed --> text_gen --> image_vlm --> graph_rag --> wiki_map --> reduce --> done

    classDef destructive fill:#fee2e2,stroke:#dc2626,stroke-width:2px,color:#7f1d1d
    classDef expensive fill:#fef3c7,stroke:#d97706,stroke-width:2px,color:#78350f
    classDef output fill:#dcfce7,stroke:#16a34a,stroke-width:2px,color:#14532d

    class cleanup destructive
    class reader,embed,text_gen,image_vlm,graph_rag,wiki_map,reduce expensive
    class done output
```

### New workflow

The new path keeps reusable state in place, caches `DocReader` output during conversion, stores images by content hash, reconciles chunks by stable identity, indexes only missing text chunks, and then lets post-processing stages use their own artifact caches before the unavoidable `Wiki reduce` step.

```mermaid
flowchart TD
    accTitle: New Rebuild Workflow
    accDescr: The new rebuild path computes stable content identities first, reuses completed artifacts on cache hits, and persists only the differences.

    request["Rebuild request"]
    keep_state["Keep existing derived state"]
    doc_cache{"DocReader cache hit?"}
    parse_miss["Call DocReader and write cache"]
    parsed["Use parsed markdown and image refs"]
    image_store["Store images by content hash"]
    plan_chunks["Plan stable chunk IDs"]
    reconcile["Create missing chunks and reuse existing chunks"]
    embed_new["Index only new text chunks with embedding cache"]
    delete_obsolete["Delete obsolete chunks and vectors after replacement"]
    postprocess["Run cached post-processing stages"]
    text_cache["Summary and question cache"]
    image_vlm_cache["Image VLM cache"]
    graph_cache["Graph chunk cache"]
    wiki_map_cache["Wiki map cache"]
    reduce["Run Wiki reduce when contributors require it"]
    done["Persist diff-only rebuild"]

    request --> keep_state --> doc_cache
    doc_cache -->|Hit| parsed
    doc_cache -->|Miss| parse_miss --> parsed
    parsed --> image_store --> plan_chunks --> reconcile --> embed_new --> delete_obsolete --> postprocess
    postprocess --> text_cache --> wiki_map_cache
    postprocess --> image_vlm_cache --> wiki_map_cache
    postprocess --> graph_cache --> wiki_map_cache
    wiki_map_cache --> reduce --> done

    classDef cache fill:#dbeafe,stroke:#2563eb,stroke-width:2px,color:#1e3a8a
    classDef stable fill:#ecfdf5,stroke:#059669,stroke-width:2px,color:#064e3b
    classDef reduce fill:#fef3c7,stroke:#d97706,stroke-width:2px,color:#78350f
    classDef output fill:#dcfce7,stroke:#16a34a,stroke-width:2px,color:#14532d

    class doc_cache,text_cache,image_vlm_cache,graph_cache,wiki_map_cache cache
    class keep_state,parsed,image_store,plan_chunks,reconcile,embed_new,delete_obsolete,postprocess stable
    class reduce reduce
    class done output
```

## What Changed

| Area | Before | Now | Effect |
| --- | --- | --- | --- |
| Document parsing | DocReader was rerun for each rebuild path. | `docreader:v1` caches parsed output by stable reader input and reader options. | OCR and parsing are reused for unchanged documents. |
| Downloaded `file_url` input | Temporary download paths could change between runs. | Downloaded bytes are hashed and used as the stable DocReader cache boundary. | The same downloaded bytes cache-hit even if the temp path changes. |
| Images | Image paths were unstable and often deleted before reuse. | Image bytes use stable content-addressed filenames and are protected during rebuild cleanup. | Unchanged image assets and VLM descriptions are reused. |
| Chunks | Chunks used random IDs. | Chunk IDs are derived from normalized content and position. | Rebuild reconciliation can update by diff instead of replacing everything. |
| Embeddings | Every chunk was embedded again. | `embedding:v1` caches vectors by provider, model, dimension, normalized text, and relevant config. | Unchanged chunk vectors do not call the embedding provider. |
| Summaries and questions | Generation reran whenever the rebuild ran. | `summary:v1` and `question:v1` cache by normalized prompt input plus model/config. | Unchanged chunk text skips chat completion calls. |
| GraphRAG | Chunk graph extraction reran and cache payloads were persistence-shaped. | `graph:chunk:v1` caches model output and strips chunk-specific references from payloads. | Graph extraction is reused and restored safely for the current chunk. |
| Wiki map | Wiki map generation reran on rebuilds. | `wiki:map:v1` caches map output by stable contributor material and map config. | Unchanged contributors reuse map output. |
| Wiki reduce | Cross-document reduce was part of every rebuild. | Reduce remains intentionally uncached. | The only unavoidable cost is contributor-level aggregation. |

## Implementation Coverage

This section maps the PR description to the current workspace diff so reviewers can find every changed surface.

| Surface | Files | Covered change |
| --- | --- | --- |
| Plan and PR docs | `docs/superpowers/plans/2026-07-02-reuse-cache-on-rebuild.md`, `docs/rebuild-cache-pr-description.md`, `docs/rebuild-cache-pr-description.zh-CN.md` | Keeps the implementation plan and PR description in the repo. |
| Process artifact cache schema | `migrations/sqlite/000000_init.up.sql`, `migrations/versioned/000065_rebuild_artifact_cache.up.sql`, `migrations/versioned/000065_rebuild_artifact_cache.down.sql`, `internal/types/process_artifact_cache.go`, `internal/types/interfaces/process_artifact_cache.go`, `internal/application/repository/process_artifact_cache.go`, `internal/application/repository/process_artifact_cache_test.go`, `internal/container/container.go` | Adds the tenant-scoped artifact cache table, unique cache identity, repository upsert/get behavior, and DI registration. |
| Cache keys and content addressing | `internal/application/service/rebuild_cache_keys.go`, `internal/application/service/rebuild_cache_keys_test.go`, `internal/utils/content_address.go`, `internal/utils/content_address_test.go` | Adds canonical text hashing, stable image filenames, stable chunk/question/summary child IDs, and artifact key helpers. |
| DocReader cache | `internal/application/service/knowledge_process.go`, `internal/application/service/docreader_cache_payload.go`, `internal/application/service/docreader_cache_payload_test.go`, `internal/application/service/knowledge_docreader_cache_test.go` | Caches `ReadResult` payloads and verifies that already downloaded `file_url` bytes cache-hit across different temporary file paths. |
| Rebuild-aware chunk reconciliation | `internal/application/repository/chunk.go`, `internal/application/repository/chunk_sqlite_test.go`, `internal/application/service/chunk.go`, `internal/types/interfaces/chunk.go`, `internal/application/service/knowledge_process.go` | Adds create-ignore semantics, selected-type listing, obsolete chunk plus direct-child deletion, stable chunk IDs, and diff-only vector deletion. |
| Knowledge processing entry points | `internal/application/service/knowledge.go`, `internal/application/service/knowledge_process.go`, `internal/application/service/knowledge_post_process.go` | Injects the artifact cache repo, removes eager cleanup from reparse/manual update paths, and resets graph namespaces at graph post-process time. |
| File service content-addressed storage | `internal/types/interfaces/file.go`, `internal/application/service/file/cos.go`, `internal/application/service/file/dummy.go`, `internal/application/service/file/ks3.go`, `internal/application/service/file/local.go`, `internal/application/service/file/local_test.go`, `internal/application/service/file/minio.go`, `internal/application/service/file/obs.go`, `internal/application/service/file/oss.go`, `internal/application/service/file/s3.go`, `internal/application/service/file/tos.go` | Adds `SaveContentAddressedBytes` to every storage backend so cached image bytes use deterministic tenant-scoped paths under `exports/cache`. |
| Image resolution and deletion | `internal/infrastructure/docparser/image_resolver.go`, `internal/infrastructure/docparser/image_resolver_test.go`, `internal/infrastructure/docparser/resolve_remote_images_test.go`, `internal/application/service/knowledge_delete.go` | Stores extracted images by content hash, records image content hashes, keeps whitelisted remote images unchanged, and avoids deleting shared content-addressed artifacts. |
| Image VLM and child chunks | `internal/application/service/image_multimodal.go` | Caches OCR/caption output by image bytes, prompt, model, and config; creates stable OCR/caption child chunk IDs; skips existing child chunks on retry. |
| Embeddings | `internal/application/service/cached_embedder.go`, `internal/application/service/cached_embedder_test.go`, `internal/application/service/knowledge_process.go` | Wraps embedding calls with process-cache reads/writes and uses the wrapper for main chunks, summaries, generated questions, and chunk updates. |
| Summaries and questions | `internal/application/service/knowledge_process.go`, `internal/application/service/question_cache_test.go` | Caches summary and question generation, uses stable summary chunk IDs, uses stable generated question IDs, and reuses already indexed summary chunks. |
| Graph extraction | `internal/application/service/extract.go`, `internal/application/service/extract_cache_test.go`, `internal/application/service/knowledge_post_process.go` | Caches per-chunk graph extraction and strips persisted chunk references from reusable graph payloads. |
| Wiki ingestion | `internal/application/service/wiki_ingest.go`, `internal/application/service/wiki_ingest_batch.go`, `internal/application/service/wiki_ingest_cache_test.go` | Caches Wiki map output, keeps `oldPageSlugs` out of the model cache key, stores only base updates, and rebuilds retractions from current page state on cache hit. |
| Plan-level acceptance tests | `internal/application/service/knowledge_rebuild_cache_integration_test.go` | Covers unchanged rebuilds, crash retry cache reuse, and layer-local invalidation when model or prompt config changes. |
| Compatibility test stubs | `internal/agent/tools/data_analysis_materialize_test.go`, `internal/application/service/knowledge_clone_image_test.go`, `internal/application/service/knowledge_create_test.go`, `internal/im/im_file_service_test.go`, `internal/router/router_files_test.go` | Updates test doubles to satisfy the expanded `FileService` interface. |

## Cache Boundaries

| Layer | Cache namespace | Key includes | Invalidated by |
| --- | --- | --- | --- |
| DocReader | `docreader:v1` | Reader source material, file bytes when available, reader options, parser version. | Source bytes/text changes, reader option changes, parser version changes. |
| Downloaded `file_url` bytes | `docreader:v1` | Downloaded bytes, not the temporary file path. | Downloaded content changes. |
| Image VLM | `vlm:image:v1` | Image content hash, prompt, model, provider, VLM config. | Image bytes, VLM prompt, model, or config changes. |
| Embedding | `embedding:v1` | Normalized chunk text, provider, model, dimension, embedding config. | Text, model, dimension, provider, or embedding config changes. |
| Summary | `summary:v1` | Normalized chunk text, summary prompt, model, chat config. | Text, prompt, model, or chat config changes. |
| Question | `question:v1` | Normalized chunk text, question prompt, model, chat config. | Text, prompt, model, or chat config changes. |
| Graph chunk map | `graph:chunk:v1` | Normalized chunk text, graph prompt, model, graph config. | Text, prompt, model, or graph config changes. |
| Wiki map | `wiki:map:v1` | Contributor material, map prompt, model, Wiki map config. | Contributor material, prompt, model, or map config changes. |
| Wiki reduce | None | Current Wiki contributors and page state. | Always evaluated when contributor state requires reduce. |

Two cache-boundary details are deliberate:

- `oldPageSlugs` are excluded from the Wiki map key. They are persistence context, not model input. On cache hit, retractions and base updates are rebuilt for the current page state.
- Graph chunk cache payloads do not store persisted chunk references. They are restored against the current chunk on cache hit.

## Expected Rebuild Behavior

| Scenario | Expected behavior | Covered by |
| --- | --- | --- |
| Rebuild unchanged knowledge | Near-zero LLM/VLM calls except unavoidable `Wiki reduce`. | `TestReparseUnchangedKnowledgeAvoidsExpensiveModelCalls` |
| Retry after crash | Completed OCR, vector, and Wiki map work cache-hit. | `TestCrashRetryReusesCompletedArtifacts` |
| Embedding model/config change | Embedding layer misses; OCR, VLM, summaries, questions, and Wiki map are reused when their inputs are unchanged. | `TestRebuildCacheInvalidatesOnlyChangedLayer` |
| Downloaded `file_url` stored at a different temp path | DocReader cache hits because the downloaded bytes are unchanged. | `TestConvertFileURLDownloadedBytesReuseDocReaderCacheAcrossTempPaths` |
| Existing graph and Wiki map cache payloads | Payloads are reusable without leaking stale persistence references. | `TestGraphDataCachePayloadStripsChunkRefsAndRestoresGraph`, `TestWikiMapCachePayloadDropsRetractionsAndRestoresBaseUpdates` |

## Validation

The following checks were run:

```bash
go test ./internal/application/service -count=1
go test ./internal/application/repository ./internal/application/service/file ./internal/container -count=1
go test ./internal/agent/tools ./internal/im ./internal/router -count=1
go test ./internal/utils -run 'TestStableImageFilename|TestTextContentHash|TestCanonicalCacheText|TestStableJSONHash|TestArtifactCacheKey|TestSHA256HexBytes' -count=1
go test ./internal/infrastructure/docparser -run 'TestResolveAndStore|TestResolveRemoteImages|TestIsIconImage|TestResolveDataURI|TestResolveHTMLDataURI|TestResolveBareBase64' -count=1
```

Local note: the full `go test ./internal/utils -count=1` command was not used as final evidence because this environment resolves `example.com` to `198.18.0.85`, which trips existing SSRF tests unrelated to this change. The cache-related utility tests were run directly.
