### PR TITLE
fix(redis): harden TLS tests and surface TLS config at startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -229,6 +229,7 @@ REDIS_PREFIX=stream:
 # 可选：用于证书校验与 SNI 的服务器名（当地址是 IP 时有用）
 # REDIS_TLS_SERVER_NAME=
 # 跳过服务器证书校验。不安全，仅用于开发或自签名证书环境，生产禁用。
+# 私有 CA 签发的证书目前无法通过自定义 CA 文件校验，只能临时使用 skip-verify（开发环境）。
 # REDIS_TLS_INSECURE_SKIP_VERIFY=false
 
 # 当使用本地存储时，文件保存的基础目录路径

--- a/internal/common/redis_tls_test.go
+++ b/internal/common/redis_tls_test.go
@@ -5,8 +5,16 @@ import (
 	"testing"
 )
 
+func resetRedisTLSEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("REDIS_USE_TLS", "")
+	t.Setenv("REDIS_TLS_SERVER_NAME", "")
+	t.Setenv("REDIS_TLS_INSECURE_SKIP_VERIFY", "")
+}
+
 func TestRedisTLSConfig_DisabledByDefault(t *testing.T) {
-	// REDIS_USE_TLS unset.
+	resetRedisTLSEnv(t)
+
 	if cfg := RedisTLSConfig(); cfg != nil {
 		t.Fatalf("expected nil tls.Config when REDIS_USE_TLS is unset, got %#v", cfg)
 	}
@@ -18,6 +26,7 @@ func TestRedisTLSConfig_DisabledByDefault(t *testing.T) {
 }
 
 func TestRedisTLSConfig_EnabledSecureByDefault(t *testing.T) {
+	resetRedisTLSEnv(t)
 	t.Setenv("REDIS_USE_TLS", "true")
 
 	cfg := RedisTLSConfig()
@@ -36,6 +45,7 @@ func TestRedisTLSConfig_EnabledSecureByDefault(t *testing.T) {
 }
 
 func TestRedisTLSConfig_Options(t *testing.T) {
+	resetRedisTLSEnv(t)
 	t.Setenv("REDIS_USE_TLS", "TRUE") // case-insensitive
 	t.Setenv("REDIS_TLS_SERVER_NAME", "redis.example.com")
 	t.Setenv("REDIS_TLS_INSECURE_SKIP_VERIFY", "true")

--- a/internal/runtime/startup.go
+++ b/internal/runtime/startup.go
@@ -89,6 +89,8 @@ var startupEnvVars = []envVarSpec{
 	// Cache / queue
 	{name: "REDIS_ADDR"},
 	{name: "REDIS_PASSWORD", sensitive: true},
+	{name: "REDIS_USE_TLS"},
+	{name: "REDIS_TLS_SERVER_NAME"},
 	// Object storage
 	{name: "STORAGE_TYPE"},
 	{name: "MINIO_ENDPOINT"},
@@ -136,6 +138,10 @@ func LogStartupEnv(ctx context.Context) {
 		logger.Warnf(ctx,
 			"[startup-env] SYSTEM_AES_KEY is set but %d bytes long; AES-256 requires exactly 32 bytes — encryption is DISABLED",
 			len(k))
+	}
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("REDIS_TLS_INSECURE_SKIP_VERIFY")), "true") {
+		logger.Warn(ctx,
+			"[startup-env] REDIS_TLS_INSECURE_SKIP_VERIFY=true — Redis TLS certificate verification is DISABLED; do not use in production")
 	}
 }
 


### PR DESCRIPTION
## Summary
- 修复 `redis_tls_test` 受宿主机环境变量污染导致误报失败的问题（每个测试开头显式 reset TLS 相关 env）
- 启动日志增加 `REDIS_USE_TLS` / `REDIS_TLS_SERVER_NAME` 输出，并在开启 `REDIS_TLS_INSECURE_SKIP_VERIFY` 时打印 warning
- `.env.example` 补充私有 CA 场景说明

Follow-up to #1930 / code review findings.

## Test plan
- [x] `REDIS_USE_TLS=true go test ./internal/common/ -run TestRedisTLS -v` 通过
- [x] `go test ./internal/runtime/ -count=1` 通过