### PR TITLE
feat: content-addressed reparse cache — reuse OCR/Embedding/Wiki-Map on rebuild

### DIFF
--- a/internal/application/repository/content_cache.go
+++ b/internal/application/repository/content_cache.go
@@ -226,3 +226,71 @@ func (r *parseProductCacheRepo) Put(ctx context.Context, row *types.ParseProduct
 		DoNothing: true,
 	}).Create(row).Error
 }
+
+// ---- SummaryCacheRepo ----
+
+// SummaryCacheRepo persists LLM-generated document summaries keyed by
+// (doc_content_hash, model_id, prompt_version, config_hash).
+type SummaryCacheRepo interface {
+	Get(ctx context.Context, docContentHash, modelID, promptVersion, configHash string) (string, bool, error)
+	Put(ctx context.Context, row *types.SummaryCache) error
+}
+
+type summaryCacheRepo struct{ db *gorm.DB }
+
+func NewSummaryCacheRepo(db *gorm.DB) SummaryCacheRepo { return &summaryCacheRepo{db: db} }
+
+func (r *summaryCacheRepo) Get(ctx context.Context, docContentHash, modelID, promptVersion, configHash string) (string, bool, error) {
+	var row types.SummaryCache
+	err := r.db.WithContext(ctx).Where(
+		"doc_content_hash = ? AND model_id = ? AND prompt_version = ? AND config_hash = ?",
+		docContentHash, modelID, promptVersion, configHash,
+	).First(&row).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return row.Summary, true, nil
+}
+
+func (r *summaryCacheRepo) Put(ctx context.Context, row *types.SummaryCache) error {
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		DoNothing: true,
+	}).Create(row).Error
+}
+
+// ---- QuestionCacheRepo ----
+
+// QuestionCacheRepo persists LLM-generated chunk questions keyed by
+// (chunk_content_hash, model_id, prompt_version, config_hash).
+type QuestionCacheRepo interface {
+	Get(ctx context.Context, chunkContentHash, modelID, promptVersion, configHash string) (string, bool, error)
+	Put(ctx context.Context, row *types.QuestionCache) error
+}
+
+type questionCacheRepo struct{ db *gorm.DB }
+
+func NewQuestionCacheRepo(db *gorm.DB) QuestionCacheRepo { return &questionCacheRepo{db: db} }
+
+func (r *questionCacheRepo) Get(ctx context.Context, chunkContentHash, modelID, promptVersion, configHash string) (string, bool, error) {
+	var row types.QuestionCache
+	err := r.db.WithContext(ctx).Where(
+		"chunk_content_hash = ? AND model_id = ? AND prompt_version = ? AND config_hash = ?",
+		chunkContentHash, modelID, promptVersion, configHash,
+	).First(&row).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return row.Payload, true, nil
+}
+
+func (r *questionCacheRepo) Put(ctx context.Context, row *types.QuestionCache) error {
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		DoNothing: true,
+	}).Create(row).Error
+}

--- a/internal/application/repository/content_cache.go
+++ b/internal/application/repository/content_cache.go
@@ -1,0 +1,228 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// ---- VLMCacheRepo ----
+
+// VLMCacheRepo persists canonical OCR/Caption results keyed by
+// (image_hash, model_id, prompt_version, prompt_kind). Content-addressed:
+// no tenant_id — the same image bytes + model + prompt yield the same
+// canonical text regardless of owner.
+type VLMCacheRepo interface {
+	Get(ctx context.Context, imageHash, modelID, promptVersion, promptKind string) (string, bool, error)
+	Put(ctx context.Context, row *types.VLMCache) error
+	Delete(ctx context.Context, imageHash, modelID, promptVersion, promptKind string) error
+}
+
+type vlmCacheRepo struct{ db *gorm.DB }
+
+func NewVLMCacheRepo(db *gorm.DB) VLMCacheRepo { return &vlmCacheRepo{db: db} }
+
+func (r *vlmCacheRepo) Get(ctx context.Context, imageHash, modelID, promptVersion, promptKind string) (string, bool, error) {
+	var row types.VLMCache
+	err := r.db.WithContext(ctx).Where(
+		"image_hash = ? AND model_id = ? AND prompt_version = ? AND prompt_kind = ?",
+		imageHash, modelID, promptVersion, promptKind,
+	).First(&row).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return row.OutputText, true, nil
+}
+
+func (r *vlmCacheRepo) Put(ctx context.Context, row *types.VLMCache) error {
+	// ON CONFLICT DO NOTHING: the cold-cache race winner persists; the loser
+	// discards its result and behaves as if it had a hit by reading back.
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		DoNothing: true,
+	}).Create(row).Error
+}
+
+func (r *vlmCacheRepo) Delete(ctx context.Context, imageHash, modelID, promptVersion, promptKind string) error {
+	return r.db.WithContext(ctx).Where(
+		"image_hash = ? AND model_id = ? AND prompt_version = ? AND prompt_kind = ?",
+		imageHash, modelID, promptVersion, promptKind,
+	).Delete(&types.VLMCache{}).Error
+}
+
+// ---- EmbeddingCacheRepo ----
+
+// EmbeddingCacheRepo stores vectors keyed by (text_hash, model_id, dim).
+// The key excludes doc_id/chunk_id so identical text dedups cross-doc.
+// Vector is serialized as a JSON array of floats for DB portability.
+type EmbeddingCacheRepo interface {
+	// GetBatch returns a map of text_hash -> vector (as []float32) for the
+	// keys that hit. Misses are simply absent from the map.
+	GetBatch(ctx context.Context, textHashes []string, modelID string, dim int) (map[string][]float32, error)
+	Put(ctx context.Context, rows []types.EmbeddingCache) error
+}
+
+type embeddingCacheRepo struct{ db *gorm.DB }
+
+func NewEmbeddingCacheRepo(db *gorm.DB) EmbeddingCacheRepo { return &embeddingCacheRepo{db: db} }
+
+func (r *embeddingCacheRepo) GetBatch(ctx context.Context, textHashes []string, modelID string, dim int) (map[string][]float32, error) {
+	out := make(map[string][]float32, len(textHashes))
+	if len(textHashes) == 0 {
+		return out, nil
+	}
+	// Batch in chunks of 500 to avoid MySQL "too many placeholders" (1390).
+	for i := 0; i < len(textHashes); i += 500 {
+		end := i + 500
+		if end > len(textHashes) {
+			end = len(textHashes)
+		}
+		batch := textHashes[i:end]
+		var got []types.EmbeddingCache
+		err := r.db.WithContext(ctx).Where(
+			"text_hash IN ? AND model_id = ? AND dimension = ?",
+			batch, modelID, dim,
+		).Find(&got).Error
+		if err != nil {
+			return nil, fmt.Errorf("embedding cache batch lookup: %w", err)
+		}
+		for _, row := range got {
+			var vec []float32
+			if err := json.Unmarshal([]byte(row.Vector), &vec); err != nil {
+				// Corrupt row — skip it; the caller will treat it as a miss
+				// and recompute, overwriting the bad row on the next Put.
+				continue
+			}
+			out[row.TextHash] = vec
+		}
+	}
+	return out, nil
+}
+
+func (r *embeddingCacheRepo) Put(ctx context.Context, rows []types.EmbeddingCache) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	// Batch insert with ON CONFLICT DO NOTHING — concurrent cold-cache
+	// writers don't clobber each other; the winner's row survives.
+	for i := 0; i < len(rows); i += 500 {
+		end := i + 500
+		if end > len(rows) {
+			end = len(rows)
+		}
+		if err := r.db.WithContext(ctx).Clauses(clause.OnConflict{
+			DoNothing: true,
+		}).Create(rows[i:end]).Error; err != nil {
+			return fmt.Errorf("embedding cache batch put: %w", err)
+		}
+	}
+	return nil
+}
+
+// ---- WikiMapCacheRepo ----
+
+// WikiMapCacheRepo stores the complete per-doc map output (entities,
+// concepts, summary, citations, new-slugs) as an opaque JSON payload.
+type WikiMapCacheRepo interface {
+	Get(ctx context.Context, docContentHash, granularity, synthesisModelID, promptVersion string) (string, bool, error)
+	Put(ctx context.Context, row *types.WikiMapCache) error
+}
+
+type wikiMapCacheRepo struct{ db *gorm.DB }
+
+func NewWikiMapCacheRepo(db *gorm.DB) WikiMapCacheRepo { return &wikiMapCacheRepo{db: db} }
+
+func (r *wikiMapCacheRepo) Get(ctx context.Context, docContentHash, granularity, synthesisModelID, promptVersion string) (string, bool, error) {
+	var row types.WikiMapCache
+	err := r.db.WithContext(ctx).Where(
+		"doc_content_hash = ? AND granularity = ? AND synthesis_model_id = ? AND prompt_version = ?",
+		docContentHash, granularity, synthesisModelID, promptVersion,
+	).First(&row).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return row.Payload, true, nil
+}
+
+func (r *wikiMapCacheRepo) Put(ctx context.Context, row *types.WikiMapCache) error {
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		DoNothing: true,
+	}).Create(row).Error
+}
+
+// ---- GraphChunkCacheRepo ----
+
+type GraphChunkCacheRepo interface {
+	Get(ctx context.Context, chunkContentHash, extractConfigHash, chatModelID, promptVersion string) (string, bool, error)
+	Put(ctx context.Context, row *types.GraphChunkCache) error
+}
+
+type graphChunkCacheRepo struct{ db *gorm.DB }
+
+func NewGraphChunkCacheRepo(db *gorm.DB) GraphChunkCacheRepo {
+	return &graphChunkCacheRepo{db: db}
+}
+
+func (r *graphChunkCacheRepo) Get(ctx context.Context, chunkContentHash, extractConfigHash, chatModelID, promptVersion string) (string, bool, error) {
+	var row types.GraphChunkCache
+	err := r.db.WithContext(ctx).Where(
+		"chunk_content_hash = ? AND extract_config_hash = ? AND chat_model_id = ? AND prompt_version = ?",
+		chunkContentHash, extractConfigHash, chatModelID, promptVersion,
+	).First(&row).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return row.Payload, true, nil
+}
+
+func (r *graphChunkCacheRepo) Put(ctx context.Context, row *types.GraphChunkCache) error {
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		DoNothing: true,
+	}).Create(row).Error
+}
+
+// ---- ParseProductCacheRepo ----
+
+type ParseProductCacheRepo interface {
+	Get(ctx context.Context, fileHash, parserEngine, parserConfigHash, renderConfigHash string) (string, bool, error)
+	Put(ctx context.Context, row *types.ParseProductCache) error
+}
+
+type parseProductCacheRepo struct{ db *gorm.DB }
+
+func NewParseProductCacheRepo(db *gorm.DB) ParseProductCacheRepo {
+	return &parseProductCacheRepo{db: db}
+}
+
+func (r *parseProductCacheRepo) Get(ctx context.Context, fileHash, parserEngine, parserConfigHash, renderConfigHash string) (string, bool, error) {
+	var row types.ParseProductCache
+	err := r.db.WithContext(ctx).Where(
+		"file_hash = ? AND parser_engine = ? AND parser_config_hash = ? AND render_config_hash = ?",
+		fileHash, parserEngine, parserConfigHash, renderConfigHash,
+	).First(&row).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return row.Payload, true, nil
+}
+
+func (r *parseProductCacheRepo) Put(ctx context.Context, row *types.ParseProductCache) error {
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		DoNothing: true,
+	}).Create(row).Error
+}

--- a/internal/application/service/extract.go
+++ b/internal/application/service/extract.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Tencent/WeKnora/internal/agent/tools"
+	apprepo "github.com/Tencent/WeKnora/internal/application/repository"
 	chatpipeline "github.com/Tencent/WeKnora/internal/application/service/chat_pipeline"
 	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
@@ -166,6 +167,11 @@ type ChunkExtractService struct {
 	// parent attempt's postprocess stage so the trace viewer shows real
 	// per-chunk graph extraction time rather than the upstream's enqueue.
 	spanTracker SpanTracker
+	// graphChunkCache content-addresses per-chunk GraphRAG extraction
+	// output by (chunk-content-hash, extract-config-hash, chat-model,
+	// prompt-version). A hit skips the LLM Extract call; a miss persists
+	// the result best-effort. nil-safe (lite/test paths fall through).
+	graphChunkCache apprepo.GraphChunkCacheRepo
 }
 
 // NewChunkExtractService creates a new chunk extract service
@@ -177,6 +183,7 @@ func NewChunkExtractService(
 	chunkRepo interfaces.ChunkRepository,
 	graphEngine interfaces.RetrieveGraphRepository,
 	spanTracker SpanTracker,
+	graphChunkCache apprepo.GraphChunkCacheRepo,
 ) interfaces.TaskHandler {
 	return &ChunkExtractService{
 		template:          config.ExtractManager.ExtractGraph,
@@ -186,6 +193,7 @@ func NewChunkExtractService(
 		chunkRepo:         chunkRepo,
 		graphEngine:       graphEngine,
 		spanTracker:       spanTracker,
+		graphChunkCache:   graphChunkCache,
 	}
 }
 
@@ -194,6 +202,84 @@ func (s *ChunkExtractService) tracker() SpanTracker {
 		return noopSpanTracker{}
 	}
 	return s.spanTracker
+}
+
+// cachedExtract returns the GraphData for a chunk, using the
+// graph_chunk_cache when available. A hit deserializes the cached JSON
+// payload and skips the LLM call entirely; a miss calls Extract and
+// persists the result best-effort (Put failures are logged, not fatal).
+// When graphChunkCache is nil the call falls through to the LLM directly.
+func (s *ChunkExtractService) cachedExtract(
+	ctx context.Context,
+	extractor chatpipeline.Extractor,
+	chunk *types.Chunk,
+	extractCfg *types.ExtractConfig,
+	chatModelID string,
+) (*types.GraphData, error) {
+	if s.graphChunkCache == nil {
+		return extractor.Extract(ctx, chunk.Content)
+	}
+
+	chunkContentHash := types.StableContentHash(chunk.Content)
+	extractConfigHash := s.extractConfigHash(extractCfg)
+	promptVersion := types.SHAChecksum(s.template.Description)
+
+	if cached, ok, err := s.graphChunkCache.Get(ctx, chunkContentHash, extractConfigHash, chatModelID, promptVersion); err == nil && ok {
+		var graph types.GraphData
+		var uerr error
+		if uerr = json.Unmarshal([]byte(cached), &graph); uerr == nil {
+			logger.Infof(ctx, "[ChunkExtract] graph chunk cache hit for chunk %s (model=%s)", chunk.ID, chatModelID)
+			return &graph, nil
+		}
+		logger.Warnf(ctx, "[ChunkExtract] graph chunk cache hit for chunk %s but unmarshal failed: %v — recomputing", chunk.ID, uerr)
+	} else if err != nil {
+		logger.Warnf(ctx, "[ChunkExtract] graph chunk cache Get failed for chunk %s: %v — falling back to LLM", chunk.ID, err)
+	}
+
+	graph, err := extractor.Extract(ctx, chunk.Content)
+	if err != nil {
+		return nil, err
+	}
+
+	payload, merr := json.Marshal(graph)
+	if merr != nil {
+		logger.Warnf(ctx, "[ChunkExtract] graph chunk cache payload marshal failed for chunk %s: %v", chunk.ID, merr)
+	} else {
+		if perr := s.graphChunkCache.Put(ctx, &types.GraphChunkCache{
+			ChunkContentHash:  chunkContentHash,
+			ExtractConfigHash: extractConfigHash,
+			ChatModelID:       chatModelID,
+			PromptVersion:     promptVersion,
+			Payload:           string(payload),
+		}); perr != nil {
+			logger.Warnf(ctx, "[ChunkExtract] graph chunk cache Put failed for chunk %s: %v", chunk.ID, perr)
+		}
+	}
+	return graph, nil
+}
+
+// extractConfigHash returns a stable SHA-256 hex for the parts of the
+// extract config that are injected into the extraction template.
+func (s *ChunkExtractService) extractConfigHash(cfg *types.ExtractConfig) string {
+	if cfg == nil {
+		return types.SHAChecksum("")
+	}
+	key := struct {
+		Text      string                `json:"text"`
+		Tags      []string              `json:"tags"`
+		Nodes     []*types.GraphNode    `json:"nodes"`
+		Relations []*types.GraphRelation `json:"relations"`
+	}{
+		Text:      cfg.Text,
+		Tags:      cfg.Tags,
+		Nodes:     cfg.Nodes,
+		Relations: cfg.Relations,
+	}
+	b, err := json.Marshal(key)
+	if err != nil {
+		return types.SHAChecksum("")
+	}
+	return types.SHAChecksum(string(b))
 }
 
 // Handle handles the chunk extraction task
@@ -327,7 +413,7 @@ func (s *ChunkExtractService) Handle(ctx context.Context, t *asynq.Task) error {
 		},
 	}
 	extractor := chatpipeline.NewExtractor(chatModel, template)
-	graph, err := extractor.Extract(ctx, chunk.Content)
+	graph, err := s.cachedExtract(ctx, extractor, chunk, &extractCfg, p.ModelID)
 	if err != nil {
 		handleErr = err
 		return err
@@ -644,7 +730,7 @@ func (s *DataTableSummaryService) buildChunks(resources *extractionResources, ta
 
 	// 表格摘要chunk
 	summaryChunk := &types.Chunk{
-		ID:              uuid.New().String(),
+		ID:              types.StableChunkID(resources.knowledge.ID, tableDescription, 0),
 		TenantID:        resources.knowledge.TenantID,
 		KnowledgeID:     resources.knowledge.ID,
 		KnowledgeBaseID: resources.knowledge.KnowledgeBaseID,
@@ -658,7 +744,7 @@ func (s *DataTableSummaryService) buildChunks(resources *extractionResources, ta
 
 	// 列描述chunk（所有列的描述合并为一个chunk）
 	columnChunk := &types.Chunk{
-		ID:              uuid.New().String(),
+		ID:              types.StableChunkID(resources.knowledge.ID, columnDescription, 1),
 		TenantID:        resources.knowledge.TenantID,
 		KnowledgeID:     resources.knowledge.ID,
 		KnowledgeBaseID: resources.knowledge.KnowledgeBaseID,

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -11,6 +11,7 @@ import (
 
 	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
+	apprepo "github.com/Tencent/WeKnora/internal/application/repository"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/models/utils/ollama"
 	"github.com/Tencent/WeKnora/internal/models/vlm"
@@ -18,7 +19,6 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
-	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
 	"github.com/redis/go-redis/v9"
 )
@@ -74,6 +74,13 @@ type ImageMultimodalService struct {
 	// spanTracker records this image's subspan under the parent attempt's
 	// multimodal stage. nil-safe — falls back to no-op via tracker().
 	spanTracker SpanTracker
+
+	// vlmCache content-addresses VLM (OCR/Caption) results by
+	// (image-hash, model, prompt-version, prompt-kind). A hit freezes the
+	// canonical OCR/caption text and skips the expensive VLM Predict call
+	// — the single most expensive per-call step in the pipeline. nil-safe
+	// (lite/test paths skip caching and just call the VLM directly).
+	vlmCache apprepo.VLMCacheRepo
 }
 
 func NewImageMultimodalService(
@@ -89,6 +96,7 @@ func NewImageMultimodalService(
 	redisClient *redis.Client,
 	fileSvc interfaces.FileService,
 	spanTracker SpanTracker,
+	vlmCache apprepo.VLMCacheRepo,
 ) interfaces.TaskHandler {
 	return &ImageMultimodalService{
 		chunkService:   chunkService,
@@ -101,8 +109,8 @@ func NewImageMultimodalService(
 		ollamaService:  ollamaService,
 		taskEnqueuer:   taskEnqueuer,
 		redisClient:    redisClient,
-		fileSvc:        fileSvc,
 		spanTracker:    spanTracker,
+		vlmCache:       vlmCache,
 	}
 }
 
@@ -210,10 +218,12 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 	// legacy inline-config path) so the trace shows WHICH model handled
 	// this image. Without this, debugging "VLM is slow" requires a
 	// separate hop to the KB config.
-	if id := strings.TrimSpace(vlmCfg.ModelID); id != "" {
-		imgOut["vlm_model_id"] = id
+	vlmModelID := strings.TrimSpace(vlmCfg.ModelID)
+	if vlmModelID != "" {
+		imgOut["vlm_model_id"] = vlmModelID
 	} else {
-		imgOut["vlm_model_id"] = "legacy_inline"
+		vlmModelID = "legacy_inline"
+		imgOut["vlm_model_id"] = vlmModelID
 	}
 
 	// Read image bytes. A provider:// URL must be resolved via FileService —
@@ -236,15 +246,17 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 
 	if payload.EnableOCR {
 		prompt := vlmOCRPrompt
+		promptKind := "ocr"
 		if payload.ImageSourceType == "scanned_pdf" {
 			prompt = vlmOCRScannedPDFPrompt
+			promptKind = "ocr_scanned_pdf"
 			logger.Infof(ctx, "[ImageMultimodal] Using scanned PDF prompt for OCR: %s", payload.ImageURL)
 			imgOut["ocr_prompt"] = "scanned_pdf"
 		} else {
 			imgOut["ocr_prompt"] = "default"
 		}
 
-		ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt)
+		ocrText, ocrErr := s.cachedPredict(ctx, vlmModel, vlmModelID, imgBytes, prompt, promptKind)
 		if ocrErr != nil {
 			logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
 			imgOut["ocr_error"] = ocrErr.Error()
@@ -262,7 +274,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 	}
 
-	caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, vlmCaptionPrompt)
+	caption, capErr := s.cachedPredict(ctx, vlmModel, vlmModelID, imgBytes, vlmCaptionPrompt, "caption")
 	if capErr != nil {
 		logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
 		imgOut["caption_error"] = capErr.Error()
@@ -278,7 +290,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 
 	if imageInfo.OCRText != "" {
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              types.StableChunkID(payload.KnowledgeID, imageInfo.OCRText, 0),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
@@ -295,7 +307,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 
 	if imageInfo.Caption != "" {
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              types.StableChunkID(payload.KnowledgeID, imageInfo.Caption, 0),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
@@ -315,6 +327,46 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		// Deferred finalize will count this image on success.
 		imgOut["skipped"] = "no_extracted_content"
 		return nil
+	}
+
+	// Non-destructive reparse safeguard: image OCR/caption chunks use
+	// StableChunkID, so old records from a previous parse may still exist.
+	// Remove any stale records before CreateChunks to avoid PK conflicts.
+	existingChunkIDs := make([]string, 0, len(newChunks))
+	for _, c := range newChunks {
+		if _, err := s.chunkService.GetChunkByIDOnly(ctx, c.ID); err == nil {
+			existingChunkIDs = append(existingChunkIDs, c.ID)
+		}
+	}
+	if len(existingChunkIDs) > 0 {
+		logger.Infof(ctx, "[ImageMultimodal] Removing %d existing OCR/caption chunks before recreate for image %s",
+			len(existingChunkIDs), payload.ImageURL)
+
+		kb, kbErr := s.kbService.GetKnowledgeBaseByIDOnly(ctx, payload.KnowledgeBaseID)
+		if kbErr == nil && kb != nil && kb.NeedsEmbeddingModel() {
+			embeddingModel, modelErr := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
+			if modelErr == nil {
+				tenantInfo, tenantErr := s.tenantRepo.GetTenantByID(ctx, payload.TenantID)
+				if tenantErr == nil {
+					ctx = context.WithValue(ctx, types.TenantInfoContextKey, tenantInfo)
+					engine, engineErr := retriever.CreateRetrieveEngineForKB(
+						ctx, s.retrieveEngine, s.ownership, payload.TenantID, kb.VectorStoreID)
+					if engineErr == nil {
+						if err := engine.DeleteByChunkIDList(ctx, existingChunkIDs, embeddingModel.GetDimensions(), kb.Type); err != nil {
+							logger.Warnf(ctx, "[ImageMultimodal] Failed to delete existing chunk vectors: %v", err)
+						}
+					} else {
+						logger.Warnf(ctx, "[ImageMultimodal] Failed to init retrieve engine for existing chunk cleanup: %v", engineErr)
+					}
+				}
+			} else {
+				logger.Warnf(ctx, "[ImageMultimodal] Failed to get embedding model for existing chunk cleanup: %v", modelErr)
+			}
+		}
+
+		if err := s.chunkService.DeleteChunks(ctx, existingChunkIDs); err != nil {
+			logger.Warnf(ctx, "[ImageMultimodal] Failed to delete existing chunks before recreate: %v", err)
+		}
 	}
 
 	// Persist chunks
@@ -558,6 +610,54 @@ func (s *ImageMultimodalService) readImageBytes(ctx context.Context, payload typ
 	}
 	logger.Infof(ctx, "[ImageMultimodal] Image downloaded from URL, len=%d", len(data))
 	return data, nil
+}
+
+// cachedPredict wraps a VLM Predict call with a content-addressed OCR/Caption
+// cache. The cache key is (image-bytes-hash, model_id, prompt-version-hash,
+// prompt_kind) — no tenant_id, no knowledge_id — so the same image under the
+// same model+prompt yields the same canonical text regardless of who owns it.
+// A hit returns the frozen canonical text WITHOUT calling the VLM (the single
+// most expensive step in the pipeline), isolating VLM non-determinism at the
+// source. A miss calls the VLM, persists the result (best-effort; ON CONFLICT
+// DO NOTHING at the repo level bounds the cross-process cold-cache race), and
+// returns it. When vlmCache is nil (lite/test paths without a DB-backed repo),
+// the call falls through to the VLM directly with no caching.
+func (s *ImageMultimodalService) cachedPredict(
+	ctx context.Context, model vlm.VLM, modelID string, imgBytes []byte,
+	prompt, promptKind string,
+) (string, error) {
+	if s.vlmCache == nil {
+		return model.Predict(ctx, [][]byte{imgBytes}, prompt)
+	}
+	imageHash := types.SHAChecksum(string(imgBytes))
+	promptVersion := types.SHAChecksum(prompt)
+	if cached, ok, err := s.vlmCache.Get(ctx, imageHash, modelID, promptVersion, promptKind); err == nil && ok {
+		logger.Infof(ctx, "[ImageMultimodal] VLM cache hit for %s/%s (model=%s)", promptKind, imageHash[:12], modelID)
+		return cached, nil
+	} else if err != nil {
+		logger.Warnf(ctx, "[ImageMultimodal] VLM cache Get failed (%s/%s): %v — falling back to VLM", promptKind, imageHash[:12], err)
+	}
+
+	out, perr := model.Predict(ctx, [][]byte{imgBytes}, prompt)
+	if perr != nil {
+		return out, perr
+	}
+
+	// Persist the canonical result. Best-effort — a Put failure (DB down,
+	// constraint, etc.) MUST NOT fail the image; the next rebuild will simply
+	// miss and recompute. The ON CONFLICT DO NOTHING at the repo level means
+	// a concurrent cold-cache writer that already persisted the same key wins
+	// and this Put is a harmless no-op.
+	if perr := s.vlmCache.Put(ctx, &types.VLMCache{
+		ImageHash:     imageHash,
+		ModelID:       modelID,
+		PromptVersion: promptVersion,
+		PromptKind:    promptKind,
+		OutputText:    out,
+	}); perr != nil {
+		logger.Warnf(ctx, "[ImageMultimodal] VLM cache Put failed (%s/%s): %v", promptKind, imageHash[:12], perr)
+	}
+	return out, nil
 }
 
 // downloadImageFromURL downloads image bytes from an HTTP(S) URL.

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Tencent/WeKnora/internal/application/repository"
+	apprepo "github.com/Tencent/WeKnora/internal/application/repository"
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
 	"github.com/Tencent/WeKnora/internal/config"
 	werrors "github.com/Tencent/WeKnora/internal/errors"
@@ -75,6 +75,14 @@ type knowledgeService struct {
 	// handled because the public surface is the SpanTracker interface,
 	// which has a no-op fallback. See knowledge_span_tracker.go.
 	spanTracker SpanTracker
+
+	// parseCache content-addresses the full ReadResult produced by the
+	// docreader step (markdown + image references + metadata) by
+	// (file-bytes-hash, parser-engine, parser-config-hash,
+	// render-config-hash). A hit skips the CPU-hour-scale re-render of
+	// scanned documents. nil-safe: lite/test paths fall through to the
+	// docreader directly.
+	parseCache apprepo.ParseProductCacheRepo
 }
 
 const (
@@ -109,6 +117,7 @@ func NewKnowledgeService(
 	wikiService interfaces.WikiPageService,
 	taskPendingRepo interfaces.TaskPendingOpsRepository,
 	spanTracker SpanTracker,
+	parseCache apprepo.ParseProductCacheRepo,
 ) (interfaces.KnowledgeService, error) {
 	return &knowledgeService{
 		config:          config,
@@ -132,9 +141,10 @@ func NewKnowledgeService(
 		kbShareService:  kbShareService,
 		imageResolver:   imageResolver,
 		wikiRepo:        wikiRepo,
-		wikiService:     wikiService,
-		taskPendingRepo: taskPendingRepo,
-		spanTracker:     spanTracker,
+		wikiService:        wikiService,
+		taskPendingRepo:    taskPendingRepo,
+		spanTracker:        spanTracker,
+		parseCache:         parseCache,
 	}, nil
 }
 
@@ -509,7 +519,7 @@ func (s *knowledgeService) GetOwningKBCreatorID(ctx context.Context, knowledgeID
 		return "", err
 	}
 	if kb == nil {
-		return "", repository.ErrKnowledgeBaseNotFound
+		return "", apprepo.ErrKnowledgeBaseNotFound
 	}
 	return kb.CreatorID, nil
 }

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -83,6 +83,16 @@ type knowledgeService struct {
 	// scanned documents. nil-safe: lite/test paths fall through to the
 	// docreader directly.
 	parseCache apprepo.ParseProductCacheRepo
+
+	// summaryCache content-addresses the LLM-generated document summary
+	// by (doc_content_hash, model_id, prompt_version, config_hash).
+	// nil-safe: a nil repo falls through to the LLM.
+	summaryCache apprepo.SummaryCacheRepo
+
+	// questionCache content-addresses the LLM-generated chunk questions
+	// by (chunk_content_hash, model_id, prompt_version, config_hash).
+	// nil-safe: a nil repo falls through to the LLM.
+	questionCache apprepo.QuestionCacheRepo
 }
 
 const (
@@ -118,6 +128,8 @@ func NewKnowledgeService(
 	taskPendingRepo interfaces.TaskPendingOpsRepository,
 	spanTracker SpanTracker,
 	parseCache apprepo.ParseProductCacheRepo,
+	summaryCache apprepo.SummaryCacheRepo,
+	questionCache apprepo.QuestionCacheRepo,
 ) (interfaces.KnowledgeService, error) {
 	return &knowledgeService{
 		config:          config,
@@ -141,10 +153,12 @@ func NewKnowledgeService(
 		kbShareService:  kbShareService,
 		imageResolver:   imageResolver,
 		wikiRepo:        wikiRepo,
-		wikiService:        wikiService,
-		taskPendingRepo:    taskPendingRepo,
-		spanTracker:        spanTracker,
-		parseCache:         parseCache,
+		wikiService:     wikiService,
+		taskPendingRepo: taskPendingRepo,
+		spanTracker:     spanTracker,
+		parseCache:      parseCache,
+		summaryCache:    summaryCache,
+		questionCache:   questionCache,
 	}, nil
 }
 

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -30,7 +30,7 @@ var (
 	// Aliases the repository sentinel so a chunk-not-found from the repo
 	// errors.Is-matches at the service and middleware layers (a single
 	// identity instead of two string-equal-but-distinct errors).
-	ErrChunkNotFound = repository.ErrChunkNotFound
+	ErrChunkNotFound = apprepo.ErrChunkNotFound
 	// ErrDuplicateFile is returned when trying to add a file that already exists
 	ErrDuplicateFile = errors.New("file already exists")
 	// ErrDuplicateURL is returned when trying to add a URL that already exists

--- a/internal/application/service/knowledge_clone_move.go
+++ b/internal/application/service/knowledge_clone_move.go
@@ -266,7 +266,7 @@ func (s *knowledgeService) CloneChunk(ctx context.Context, src, dst *types.Knowl
 			copiedURLs = append(copiedURLs, copied...)
 
 			targetChunk := &types.Chunk{
-				ID:              uuid.New().String(),
+				ID:              types.StableChunkID(dst.ID, sourceChunk.Content, int(sourceChunk.ChunkIndex)),
 				TenantID:        dst.TenantID,
 				KnowledgeID:     dst.ID,
 				KnowledgeBaseID: dst.KnowledgeBaseID,
@@ -687,7 +687,7 @@ func (s *knowledgeService) cloneFAQKnowledgeBase(
 			copiedImageURLs = append(copiedImageURLs, copied...)
 
 			newChunk := &types.Chunk{
-				ID:              uuid.New().String(),
+				ID:              types.StableChunkID(dstKnowledge.ID, srcChunk.Content, int(srcChunk.ChunkIndex)),
 				TenantID:        dstKB.TenantID,
 				KnowledgeID:     dstKnowledge.ID,
 				KnowledgeBaseID: dstKB.ID,

--- a/internal/application/service/knowledge_faq.go
+++ b/internal/application/service/knowledge_faq.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
-	"github.com/google/uuid"
 )
 
 // ListFAQEntries lists FAQ entries under a FAQ knowledge base.
@@ -185,7 +184,7 @@ func (s *knowledgeService) CreateFAQEntry(ctx context.Context,
 	}
 
 	chunk := &types.Chunk{
-		ID:              uuid.New().String(),
+		ID:              types.StableChunkID(faqKnowledge.ID, buildFAQChunkContent(meta, indexMode), 0),
 		TenantID:        tenantID,
 		KnowledgeID:     faqKnowledge.ID,
 		KnowledgeBaseID: kb.ID,

--- a/internal/application/service/knowledge_faq_import.go
+++ b/internal/application/service/knowledge_faq_import.go
@@ -941,7 +941,7 @@ func (s *knowledgeService) executeFAQImport(ctx context.Context, taskID string, 
 			}
 			// ChunkIndex计算：startChunkIndex + (i+idx) + initialProcessed
 			chunk := &types.Chunk{
-				ID:              uuid.New().String(),
+				ID:              types.StableChunkID(faqKnowledge.ID, buildFAQChunkContent(meta, indexMode), i+idx),
 				TenantID:        tenantID,
 				KnowledgeID:     faqKnowledge.ID,
 				KnowledgeBaseID: kb.ID,

--- a/internal/application/service/knowledge_post_process.go
+++ b/internal/application/service/knowledge_post_process.go
@@ -25,6 +25,7 @@ type KnowledgePostProcessService struct {
 	pendingRepo   interfaces.TaskPendingOpsRepository
 	redisClient   *redis.Client
 	spanTracker   SpanTracker
+	graphEngine   interfaces.RetrieveGraphRepository
 }
 
 func NewKnowledgePostProcessService(
@@ -35,6 +36,7 @@ func NewKnowledgePostProcessService(
 	pendingRepo interfaces.TaskPendingOpsRepository,
 	redisClient *redis.Client,
 	spanTracker SpanTracker,
+	graphEngine interfaces.RetrieveGraphRepository,
 ) interfaces.TaskHandler {
 	return &KnowledgePostProcessService{
 		knowledgeRepo: knowledgeRepo,
@@ -44,6 +46,7 @@ func NewKnowledgePostProcessService(
 		pendingRepo:   pendingRepo,
 		redisClient:   redisClient,
 		spanTracker:   spanTracker,
+		graphEngine:   graphEngine,
 	}
 }
 
@@ -312,6 +315,14 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 	// 5. Spawn Graph RAG Tasks — only when graph indexing is enabled in IndexingStrategy
 	enqueuedGraphCount := 0
 	if graphChunkCount > 0 {
+		if s.graphEngine != nil {
+			if err := s.graphEngine.DelGraph(ctx, []types.NameSpace{{
+				KnowledgeBase: payload.KnowledgeBaseID,
+				Knowledge:     payload.KnowledgeID,
+			}}); err != nil {
+				logger.Warnf(ctx, "[KnowledgePostProcess] Failed to reset graph namespace for %s: %v", payload.KnowledgeID, err)
+			}
+		}
 		logger.Infof(ctx, "[KnowledgePostProcess] Spawning Graph RAG extract tasks for %d text-like chunks", len(textChunks))
 		for i, chunk := range textChunks {
 			ok, err := NewChunkExtractTask(ctx, s.taskEnqueuer, payload.TenantID, chunk.ID, kb.SummaryModelID,

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -859,7 +859,7 @@ func checkSufficientSummaryContent(ctx context.Context, knowledgeID, content str
 // getSummary generates a summary for knowledge content using an AI model
 func (s *knowledgeService) getSummary(ctx context.Context,
 	summaryModel chat.Chat, knowledge *types.Knowledge, chunks []*types.Chunk,
-) (string, error) {
+) (summaryText string, err error) {
 	// Get knowledge info from the first chunk
 	if len(chunks) == 0 {
 		return "", fmt.Errorf("no chunks provided for summary generation")
@@ -947,8 +947,50 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 	summaryPrompt := types.RenderPromptPlaceholders(s.config.Conversation.GenerateSummaryPrompt, types.PlaceholderValues{
 		"language": types.LanguageNameFromContext(ctx),
 	})
+
+	// Content-addressed summary cache lookup.
+	if s.summaryCache != nil {
+		configBytes, err := json.Marshal(map[string]interface{}{
+			"model_name":      summaryModel.GetModelName(),
+			"max_input_chars": maxInputChars,
+			"max_tokens":      maxTokens,
+			"temperature":     0.3,
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal summary cache config: %w", err)
+		}
+		docContentHash := types.StableContentHash(contentWithMetadata)
+		modelID := summaryModel.GetModelID()
+		promptVersion := types.SHAChecksum(summaryPrompt)
+		configHash := types.SHAChecksum(string(configBytes))
+
+		cached, ok, err := s.summaryCache.Get(ctx, docContentHash, modelID, promptVersion, configHash)
+		if err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Warnf("summary cache lookup failed for knowledge %s", knowledge.ID)
+		} else if ok {
+			logger.GetLogger(ctx).Infof("getSummary: cache hit for knowledge %s", knowledge.ID)
+			return cached, nil
+		}
+
+		// Cache the result after a successful LLM call.
+		defer func() {
+			if err == nil && summaryText != "" {
+				if putErr := s.summaryCache.Put(ctx, &types.SummaryCache{
+					DocContentHash: docContentHash,
+					ModelID:        modelID,
+					PromptVersion:  promptVersion,
+					ConfigHash:     configHash,
+					Summary:        summaryText,
+				}); putErr != nil {
+					logger.GetLogger(ctx).WithField("error", putErr).Warnf("failed to put summary cache for knowledge %s", knowledge.ID)
+				}
+			}
+		}()
+	}
+
 	thinking := false
-	summary, err := summaryModel.Chat(ctx, []chat.Message{
+	var summary *types.ChatResponse
+	summary, err = summaryModel.Chat(ctx, []chat.Message{
 		{
 			Role:    "system",
 			Content: summaryPrompt,
@@ -2035,6 +2077,36 @@ func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
 		"language":       langName,
 	})
 
+	// Content-addressed question cache lookup.
+	chunkContentHash := types.StableContentHash(content)
+	modelID := chatModel.GetModelID()
+	promptVersion := types.SHAChecksum(prompt)
+	var configHash string
+	if s.questionCache != nil {
+		configBytes, err := json.Marshal(map[string]interface{}{
+			"model_name":     chatModel.GetModelName(),
+			"temperature":    0.7,
+			"max_tokens":     512,
+			"question_count": questionCount,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal question cache config: %w", err)
+		}
+		configHash = types.SHAChecksum(string(configBytes))
+
+		cached, ok, err := s.questionCache.Get(ctx, chunkContentHash, modelID, promptVersion, configHash)
+		if err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Warnf("question cache lookup failed")
+		} else if ok {
+			var questions []string
+			if jsonErr := json.Unmarshal([]byte(cached), &questions); jsonErr == nil {
+				logger.GetLogger(ctx).Infof("generateQuestionsWithContext: cache hit")
+				return questions, nil
+			}
+			// Corrupt payload: fall through to LLM and overwrite.
+		}
+	}
+
 	thinking := false
 	response, err := chatModel.Chat(ctx, []chat.Message{
 		{
@@ -2064,6 +2136,22 @@ func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
 			questions = append(questions, line)
 			if len(questions) >= questionCount {
 				break
+			}
+		}
+	}
+
+	// Cache the parsed questions on a successful miss.
+	if s.questionCache != nil && configHash != "" {
+		payloadBytes, err := json.Marshal(questions)
+		if err == nil {
+			if putErr := s.questionCache.Put(ctx, &types.QuestionCache{
+				ChunkContentHash: chunkContentHash,
+				ModelID:          modelID,
+				PromptVersion:    promptVersion,
+				ConfigHash:       configHash,
+				Payload:          string(payloadBytes),
+			}); putErr != nil {
+				logger.GetLogger(ctx).WithField("error", putErr).Warnf("failed to put question cache")
 			}
 		}
 	}
@@ -3331,7 +3419,11 @@ func (s *knowledgeService) convert(
 	}
 
 	var fileHash string
-	if !isURL {
+	// Load local bytes when available. File imports always have a local path;
+	// URL imports may carry a downloaded copy prepared by ProcessDocument upstream.
+	// Caching keys on the bytes we actually hand to DocReader, so pure URL imports
+	// without a local copy still fall through to the live reader.
+	if payload.FilePath != "" {
 		fileReader, err := s.resolveFileServiceForPath(ctx, kb, payload.FilePath).GetFile(ctx, payload.FilePath)
 		if err != nil {
 			s.failStage(ctx, knowledge.ID, types.StageDocReader,
@@ -3351,10 +3443,10 @@ func (s *knowledgeService) convert(
 		fileHash = types.SHAChecksum(string(contentBytes))
 	}
 
-	// Try to serve the parse product from cache for file imports. URLs are
-	// fetched by DocReader itself, so we have no local bytes to hash and
-	// fall through to the live reader.
-	if !isURL && s.parseCache != nil {
+	// Try to serve the parse product from cache whenever we have local bytes
+	// to hash. Pure URL imports without a downloaded local copy are fetched by
+	// DocReader itself and fall through to the live reader.
+	if s.parseCache != nil && len(req.FileContent) > 0 {
 		pCfgHash := parserConfigHash(mergedOverrides)
 		if cached, ok, err := s.parseCache.Get(ctx, fileHash, parserEngine, pCfgHash, parseRenderConfigHash); err == nil && ok {
 			var result types.ReadResult
@@ -3404,10 +3496,10 @@ func (s *knowledgeService) convert(
 			werrors.ErrCodeDocReaderParseFailed, result.Error, nil)
 		return nil, nil
 	}
-	// Persist the parse product best-effort. Strip raw image bytes from the
-	// payload — the cache stores references only; VLM cache governs OCR/Caption
-	// by image bytes independently.
-	if !isURL && s.parseCache != nil {
+	// Persist the parse product best-effort when we have local bytes to key on.
+	// Strip raw image bytes from the payload — the cache stores references only;
+	// VLM cache governs OCR/Caption by image bytes independently.
+	if s.parseCache != nil && len(req.FileContent) > 0 {
 		pCfgHash := parserConfigHash(mergedOverrides)
 		payload, merr := json.Marshal(cacheableReadResult(result))
 		if merr == nil {

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -162,6 +162,11 @@ type ProcessChunksOptions struct {
 	// child's ParentIndex references an entry in this slice.
 	ParentChunks []types.ParsedParentChunk
 	Metadata     map[string]string
+	// IsReparse indicates this is a content-addressed non-destructive rebuild.
+	// When true, processChunks diffs the newly-split chunks against the existing
+	// chunk rows: unchanged chunks are kept (and their vectors reused), only
+	// added chunks are inserted and embedded, and removed chunks are deleted.
+	IsReparse bool
 }
 
 // finalizeIndexedKnowledgeState makes a document retrievable as soon as chunks
@@ -179,6 +184,7 @@ func finalizeIndexedKnowledgeState(
 	textChunkCount int,
 	hasPendingMultimodal bool,
 	now time.Time,
+	isReparse bool,
 ) {
 	if hasPendingMultimodal || textChunkCount > 0 {
 		knowledge.ParseStatus = types.ParseStatusProcessing
@@ -191,7 +197,14 @@ func finalizeIndexedKnowledgeState(
 	}
 
 	knowledge.EnableStatus = "enabled"
-	knowledge.StorageSize = totalStorageSize
+	// During reparse totalStorageSize is the delta (only added chunks), so add
+	// it to the existing value instead of overwriting. First ingest continues
+	// to treat it as the absolute total.
+	if isReparse {
+		knowledge.StorageSize += totalStorageSize
+	} else {
+		knowledge.StorageSize = totalStorageSize
+	}
 	knowledge.ProcessedAt = &now
 	knowledge.UpdatedAt = now
 }
@@ -260,6 +273,8 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		options = opts[0]
 	}
 
+	tenantInfo := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
+
 	// Check if knowledge is being deleted/cancelled before processing.
 	// Both statuses short-circuit identically here — there's nothing to clean
 	// up yet so the branch is purely "stop early".
@@ -281,36 +296,41 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping embedding model", kb.ID)
 	}
 
-	// 幂等性处理：清理旧的chunks和索引数据，避免重复数据
-	logger.Infof(ctx, "Cleaning up existing chunks and index data for knowledge: %s", knowledge.ID)
+	// 幂等性处理：首次摄取时清理旧的 chunks/index/graph；reparse 时保留旧状态，
+	// 由下方 diff 逻辑决定哪些 chunk/vector 该增该删，避免全量重建。
+	if !options.IsReparse {
+		logger.Infof(ctx, "Cleaning up existing chunks and index data for knowledge: %s", knowledge.ID)
 
-	// 删除旧的chunks
-	if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
-		logger.Warnf(ctx, "Failed to delete existing chunks (may not exist): %v", err)
-		// 不返回错误，继续处理（可能没有旧数据）
-	}
-
-	// 删除旧的索引数据 — only when vector/keyword indexing is enabled
-	tenantInfo := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
-	retrieveEngine, err := retriever.CreateRetrieveEngineForKB(
-		ctx, s.retrieveEngine, s.ownership, tenantInfo.ID, kb.VectorStoreID)
-	if err == nil && embeddingModel != nil {
-		if err := retrieveEngine.DeleteByKnowledgeIDList(ctx, []string{knowledge.ID}, embeddingModel.GetDimensions(), knowledge.Type); err != nil {
-			logger.Warnf(ctx, "Failed to delete existing index data (may not exist): %v", err)
+		// 删除旧的chunks
+		if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
+			logger.Warnf(ctx, "Failed to delete existing chunks (may not exist): %v", err)
 			// 不返回错误，继续处理（可能没有旧数据）
-		} else {
-			logger.Infof(ctx, "Successfully deleted existing index data for knowledge: %s", knowledge.ID)
 		}
-	}
 
-	// 删除知识图谱数据（如果存在）
-	namespace := types.NameSpace{KnowledgeBase: knowledge.KnowledgeBaseID, Knowledge: knowledge.ID}
-	if err := s.graphEngine.DelGraph(ctx, []types.NameSpace{namespace}); err != nil {
-		logger.Warnf(ctx, "Failed to delete existing graph data (may not exist): %v", err)
-		// 不返回错误，继续处理
-	}
+		// 删除旧的索引数据 — only when vector/keyword indexing is enabled
+		tenantInfo = ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
+		retrieveEngine, err := retriever.CreateRetrieveEngineForKB(
+			ctx, s.retrieveEngine, s.ownership, tenantInfo.ID, kb.VectorStoreID)
+		if err == nil && embeddingModel != nil {
+			if err := retrieveEngine.DeleteByKnowledgeIDList(ctx, []string{knowledge.ID}, embeddingModel.GetDimensions(), knowledge.Type); err != nil {
+				logger.Warnf(ctx, "Failed to delete existing index data (may not exist): %v", err)
+				// 不返回错误，继续处理（可能没有旧数据）
+			} else {
+				logger.Infof(ctx, "Successfully deleted existing index data for knowledge: %s", knowledge.ID)
+			}
+		}
 
-	logger.Infof(ctx, "Cleanup completed, starting to process new chunks")
+		// 删除知识图谱数据（如果存在）
+		namespace := types.NameSpace{KnowledgeBase: knowledge.KnowledgeBaseID, Knowledge: knowledge.ID}
+		if err := s.graphEngine.DelGraph(ctx, []types.NameSpace{namespace}); err != nil {
+			logger.Warnf(ctx, "Failed to delete existing graph data (may not exist): %v", err)
+			// 不返回错误，继续处理
+		}
+
+		logger.Infof(ctx, "Cleanup completed, starting to process new chunks")
+	} else {
+		logger.Infof(ctx, "Non-destructive reparse: skipping full cleanup, will diff chunks for knowledge: %s", knowledge.ID)
+	}
 
 	// ========== DocReader 解析结果日志 ==========
 	logger.Infof(ctx, "[DocReader] ========== 解析结果概览 ==========")
@@ -383,7 +403,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		parentDBChunks = make([]*types.Chunk, len(options.ParentChunks))
 		for i, pc := range options.ParentChunks {
 			parentDBChunks[i] = &types.Chunk{
-				ID:              uuid.New().String(),
+				ID:              types.StableChunkID(knowledge.ID, pc.Content, pc.Seq),
 				TenantID:        knowledge.TenantID,
 				KnowledgeID:     knowledge.ID,
 				KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -422,7 +442,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 
 		// 创建主文本Chunk
 		textChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              types.StableChunkID(knowledge.ID, chunkData.Content, int(chunkData.Seq)),
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -482,13 +502,69 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		return
 	}
 
+	// Diff against existing chunks for non-destructive reparse.
+	// Unchanged chunks keep their rows and vectors; only added chunks are
+	// inserted and embedded, and removed chunks are deleted.
+	var chunksToCreate []*types.Chunk
+	var addedChunkIDs []string
+	var keptChunkIDs map[string]struct{}
+	var removedChunkIDs []string
+	if options.IsReparse {
+		oldChunks, loadErr := s.chunkService.ListChunksByKnowledgeID(ctx, knowledge.ID)
+		if loadErr != nil {
+			logger.Warnf(ctx, "Failed to load existing chunks for diff on knowledge %s: %v", knowledge.ID, loadErr)
+			oldChunks = nil
+		}
+
+		keptChunkIDs, chunksToCreate, removedChunkIDs = computeChunkDiff(insertChunks, oldChunks)
+
+		addedChunkIDs = make([]string, 0, len(chunksToCreate))
+		for _, c := range chunksToCreate {
+			addedChunkIDs = append(addedChunkIDs, c.ID)
+		}
+
+		logger.Infof(ctx, "Reparse diff for knowledge %s: kept=%d added=%d removed=%d",
+			knowledge.ID, len(keptChunkIDs), len(chunksToCreate), len(removedChunkIDs))
+
+		// Delete vectors for removed chunks before deleting chunk rows.
+		if len(removedChunkIDs) > 0 && kb.NeedsEmbeddingModel() && embeddingModel != nil {
+			cleanupEngine, err := retriever.CreateRetrieveEngineForKB(
+				ctx, s.retrieveEngine, s.ownership, tenantInfo.ID, kb.VectorStoreID)
+			if err == nil {
+				if err := cleanupEngine.DeleteByChunkIDList(ctx, removedChunkIDs, embeddingModel.GetDimensions(), knowledge.Type); err != nil {
+					logger.Warnf(ctx, "Failed to delete removed chunk vectors for knowledge %s: %v", knowledge.ID, err)
+				}
+			} else {
+				logger.Warnf(ctx, "Failed to init retrieve engine for removed chunk cleanup on knowledge %s: %v", knowledge.ID, err)
+			}
+		}
+
+		// Delete removed chunk rows.
+		if len(removedChunkIDs) > 0 {
+			if err := s.chunkService.DeleteChunks(ctx, removedChunkIDs); err != nil {
+				logger.Warnf(ctx, "Failed to delete removed chunks for knowledge %s: %v", knowledge.ID, err)
+			}
+		}
+	} else {
+		chunksToCreate = insertChunks
+		addedChunkIDs = make([]string, 0, len(insertChunks))
+		for _, c := range insertChunks {
+			addedChunkIDs = append(addedChunkIDs, c.ID)
+		}
+	}
+
 	// Save chunks to database — ALWAYS, regardless of indexing strategy.
 	// Chunks are needed for wiki generation, graph extraction, and summary generation
 	// even when vector/keyword indexing is disabled.
-	s.beginStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
-		"chunks_planned": len(insertChunks),
-	})
-	if err := s.chunkService.CreateChunks(ctx, insertChunks); err != nil {
+	chunkingStageInput := types.JSONMap{
+		"chunks_planned": len(chunksToCreate),
+	}
+	if options.IsReparse {
+		chunkingStageInput["kept"] = len(keptChunkIDs)
+		chunkingStageInput["removed"] = len(removedChunkIDs)
+	}
+	s.beginStage(ctx, knowledge.ID, types.StageChunking, chunkingStageInput)
+	if err := s.chunkService.CreateChunks(ctx, chunksToCreate); err != nil {
 		knowledge.ParseStatus = types.ParseStatusFailed
 		knowledge.ErrorMessage = err.Error()
 		knowledge.UpdatedAt = time.Now()
@@ -498,11 +574,11 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		return
 	}
 	totalChunkChars := 0
-	for _, c := range insertChunks {
+	for _, c := range chunksToCreate {
 		totalChunkChars += len(c.Content)
 	}
 	s.endStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
-		"chunks_written":   len(insertChunks),
+		"chunks_written":   len(chunksToCreate),
 		"total_text_chars": totalChunkChars,
 	})
 
@@ -510,14 +586,18 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	// Chunks are ALWAYS saved to DB (above) because wiki and graph need them even without vector indexing.
 	var totalStorageSize int64
 	if kb.NeedsEmbeddingModel() && embeddingModel != nil {
-		embedInput := types.JSONMap{
-			"chunks_to_embed": len(textChunks),
-			"model_id":        kb.EmbeddingModelID,
+		tenantInfo = ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
+		retrieveEngine, err := retriever.CreateRetrieveEngineForKB(
+			ctx, s.retrieveEngine, s.ownership, tenantInfo.ID, kb.VectorStoreID)
+		if err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks init retrieve engine failed")
+			knowledge.ParseStatus = types.ParseStatusFailed
+			knowledge.ErrorMessage = err.Error()
+			knowledge.UpdatedAt = time.Now()
+			s.repo.UpdateKnowledge(ctx, knowledge)
+			return
 		}
-		if dim := embeddingModel.GetDimensions(); dim > 0 {
-			embedInput["dim"] = dim
-		}
-		s.beginStage(ctx, knowledge.ID, types.StageEmbedding, embedInput)
+
 		// Create index information — only for child/flat chunks, NOT parent chunks.
 		// Parent chunks are stored for context retrieval but do not need vector embeddings.
 		// Prepend the document title to improve semantic alignment between
@@ -543,8 +623,30 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			})
 		}
 
-		// Calculate storage size required for embeddings
-		totalStorageSize = retrieveEngine.EstimateStorageSize(ctx, embeddingModel, indexInfoList)
+		// For reparse, only embed chunks that are not already indexed; kept chunks
+		// reuse their existing vectors.
+		indexInfoListToIndex := indexInfoList
+		if options.IsReparse {
+			indexInfoListToIndex = make([]*types.IndexInfo, 0, len(indexInfoList))
+			for _, info := range indexInfoList {
+				if _, kept := keptChunkIDs[info.SourceID]; !kept {
+					indexInfoListToIndex = append(indexInfoListToIndex, info)
+				}
+			}
+		}
+
+		embedInput := types.JSONMap{
+			"chunks_to_embed": len(indexInfoListToIndex),
+			"model_id":        kb.EmbeddingModelID,
+		}
+		if dim := embeddingModel.GetDimensions(); dim > 0 {
+			embedInput["dim"] = dim
+		}
+		s.beginStage(ctx, knowledge.ID, types.StageEmbedding, embedInput)
+
+		// Calculate storage size required for embeddings — delta for reparse,
+		// total for first ingest, so kept chunks are not double-counted.
+		totalStorageSize = retrieveEngine.EstimateStorageSize(ctx, embeddingModel, indexInfoListToIndex)
 		if tenantInfo.StorageQuota > 0 {
 			// Re-fetch tenant storage information
 			tenantInfo, err = s.tenantRepo.GetTenantByID(ctx, tenantInfo.ID)
@@ -571,31 +673,43 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		if aborted, status := s.isKnowledgeAborted(ctx, knowledge.TenantID, knowledge.ID); aborted {
 			logger.Infof(ctx, "Knowledge aborted (%s) before indexing: %s", status, knowledge.ID)
 			if status == types.ParseStatusDeleting {
-				if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
-					logger.Warnf(ctx, "Failed to cleanup chunks after deletion detected: %v", err)
+				if options.IsReparse {
+					if len(addedChunkIDs) > 0 {
+						if err := s.chunkService.DeleteChunks(ctx, addedChunkIDs); err != nil {
+							logger.Warnf(ctx, "Failed to cleanup added chunks after deletion detected: %v", err)
+						}
+						if err := retrieveEngine.DeleteByChunkIDList(ctx, addedChunkIDs, embeddingModel.GetDimensions(), kb.Type); err != nil {
+							logger.Warnf(ctx, "Failed to cleanup added index after deletion detected: %v", err)
+						}
+					}
+				} else {
+					if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
+						logger.Warnf(ctx, "Failed to cleanup chunks after deletion detected: %v", err)
+					}
 				}
 			}
 			return
 		}
 
-		err = retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfoList)
+		err = retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfoListToIndex)
 		if err != nil {
 			knowledge.ParseStatus = types.ParseStatusFailed
 			knowledge.ErrorMessage = err.Error()
 			knowledge.UpdatedAt = time.Now()
 			s.repo.UpdateKnowledge(ctx, knowledge)
 
-			// delete failed chunks
-			if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
-				logger.Errorf(ctx, "Delete chunks failed: %v", err)
+			// delete failed added chunks / vectors; keep kept chunks intact on reparse
+			if len(addedChunkIDs) > 0 {
+				if err := s.chunkService.DeleteChunks(ctx, addedChunkIDs); err != nil {
+					logger.Errorf(ctx, "Delete added chunks failed: %v", err)
+				}
+				if err := retrieveEngine.DeleteByChunkIDList(
+					ctx, addedChunkIDs, embeddingModel.GetDimensions(), kb.Type,
+				); err != nil {
+					logger.Errorf(ctx, "Delete added index failed: %v", err)
+				}
 			}
 
-			// delete index
-			if err := retrieveEngine.DeleteByKnowledgeIDList(
-				ctx, []string{knowledge.ID}, embeddingModel.GetDimensions(), kb.Type,
-			); err != nil {
-				logger.Errorf(ctx, "Delete index failed: %v", err)
-			}
 			// Map vector store / embedding rate-limit errors to a
 			// stable code so the UI can offer "retry later" hints.
 			code := werrors.ErrCodeVectorStoreWriteFailed
@@ -606,9 +720,9 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 				code, "batch index failed", err)
 			return
 		}
-		logger.GetLogger(ctx).Infof("processChunks batch index successfully, with %d index", len(indexInfoList))
+		logger.GetLogger(ctx).Infof("processChunks batch index successfully, with %d index", len(indexInfoListToIndex))
 		s.endStage(ctx, knowledge.ID, types.StageEmbedding, types.JSONMap{
-			"vectors_written": len(indexInfoList),
+			"vectors_written": len(indexInfoListToIndex),
 			"storage_bytes":   totalStorageSize,
 		})
 
@@ -619,11 +733,22 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		if aborted, status := s.isKnowledgeAborted(ctx, knowledge.TenantID, knowledge.ID); aborted {
 			logger.Infof(ctx, "Knowledge aborted (%s) after indexing: %s", status, knowledge.ID)
 			if status == types.ParseStatusDeleting {
-				if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
-					logger.Warnf(ctx, "Failed to cleanup chunks after deletion detected: %v", err)
-				}
-				if err := retrieveEngine.DeleteByKnowledgeIDList(ctx, []string{knowledge.ID}, embeddingModel.GetDimensions(), kb.Type); err != nil {
-					logger.Warnf(ctx, "Failed to cleanup index after deletion detected: %v", err)
+				if options.IsReparse {
+					if len(addedChunkIDs) > 0 {
+						if err := s.chunkService.DeleteChunks(ctx, addedChunkIDs); err != nil {
+							logger.Warnf(ctx, "Failed to cleanup added chunks after deletion detected: %v", err)
+						}
+						if err := retrieveEngine.DeleteByChunkIDList(ctx, addedChunkIDs, embeddingModel.GetDimensions(), kb.Type); err != nil {
+							logger.Warnf(ctx, "Failed to cleanup added index after deletion detected: %v", err)
+						}
+					}
+				} else {
+					if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
+						logger.Warnf(ctx, "Failed to cleanup chunks after deletion detected: %v", err)
+					}
+					if err := retrieveEngine.DeleteByKnowledgeIDList(ctx, []string{knowledge.ID}, embeddingModel.GetDimensions(), kb.Type); err != nil {
+						logger.Warnf(ctx, "Failed to cleanup index after deletion detected: %v", err)
+					}
 				}
 			}
 			return
@@ -646,6 +771,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		len(textChunks),
 		pendingMultimodal || pendingPDFMultimodal,
 		now,
+		options.IsReparse,
 	)
 
 	if err := s.repo.UpdateKnowledge(ctx, knowledge); err != nil {
@@ -1116,7 +1242,7 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 		// and surfacing them in retrieved RAG context can re-introduce the
 		// hallucination vector this branch is meant to close.
 		summaryChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              types.StableChunkID(knowledge.ID, fmt.Sprintf("# Summary\n%s", summary), maxChunkIndex+1),
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -2051,14 +2177,20 @@ func (s *knowledgeService) ReparseKnowledge(
 		return existing, nil
 	}
 
-	// For non-manual knowledge, cleanup synchronously then enqueue document processing
-	logger.Infof(ctx, "Cleaning up existing resources for knowledge: %s", knowledgeID)
-	if err := s.cleanupKnowledgeResources(ctx, existing); err != nil {
-		logger.ErrorWithFields(ctx, err, map[string]interface{}{
-			"knowledge_id": knowledgeID,
-		})
-		return nil, err
-	}
+	// For non-manual knowledge, skip the synchronous destructive cleanup.
+	// ProcessDocument will detect existing chunks via ListChunksByKnowledgeID
+	// and processChunks will diff the new split against the old state:
+	// unchanged chunks keep their rows and vectors, only added chunks are
+	// inserted/embedded, and removed chunks are deleted. This avoids the
+	// rebuild-cost-equals-first-ingest problem.
+	//
+	// Intentional Phase-7 tradeoffs:
+	// - Graph data is left as-is. GraphRAG extraction is per-chunk cacheable,
+	//   but the graph store re-derivation is out of scope here and will be
+	//   addressed by the graph_chunk_cache optimization in Phase 5.
+	// - Extracted images are content-addressed and kept; any new images will be
+	//   handled by enqueueImageMultimodalTasks.
+	logger.Infof(ctx, "Non-destructive reparse for knowledge: %s (skip full cleanup, diff in worker)", knowledgeID)
 
 	// Step 2: Update knowledge status and metadata
 	existing.ParseStatus = "pending"
@@ -2482,7 +2614,7 @@ func (s *knowledgeService) UpdateImageInfo(
 	// Create a new caption chunk if it doesn't exist and we have caption data
 	if !hasCaptionChunk && image.Caption != "" {
 		captionChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              types.StableChunkID(chunk.KnowledgeID, image.Caption, 0),
 			TenantID:        tenantID,
 			KnowledgeID:     chunk.KnowledgeID,
 			KnowledgeBaseID: chunk.KnowledgeBaseID,
@@ -2498,7 +2630,7 @@ func (s *knowledgeService) UpdateImageInfo(
 	// Create a new OCR chunk if it doesn't exist and we have OCR data
 	if !hasOCRChunk && image.OCRText != "" {
 		ocrChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              types.StableChunkID(chunk.KnowledgeID, image.OCRText, 0),
 			TenantID:        tenantID,
 			KnowledgeID:     chunk.KnowledgeID,
 			KnowledgeBaseID: chunk.KnowledgeBaseID,
@@ -3028,6 +3160,12 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 		StoredImages:             storedImages,
 	}
 
+	// Detect whether this is a reparse with existing chunk state. Probing the
+	// current chunk set avoids adding a payload field and the cross-queue
+	// versioning complexity that comes with it.
+	existingChunks, _ := s.chunkService.ListChunksByKnowledgeID(ctx, knowledge.ID)
+	processOpts.IsReparse = len(existingChunks) > 0
+
 	if convertResult != nil {
 		processOpts.Metadata = convertResult.Metadata
 	}
@@ -3072,6 +3210,50 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 	s.processChunks(ctx, kb, knowledge, chunks, processOpts)
 
 	return nil
+}
+
+// parseRenderConfigHash is the fixed render-config component of the parse-
+// product cache key. DocReader's rendering inputs (e.g. pdf_force_scanned)
+// currently travel through parser_engine_overrides, so there is no separate
+// RenderConfig struct in Go. We keep this constant so that a future
+// independent render config can be hashed here, producing the correct
+// layered-invalidation behavior.
+const parseRenderConfigHash = "r1"
+
+// parserConfigHash returns a stable SHA-256 hex for the parser-engine overrides
+// that are passed to DocReader. An empty map serializes to "{}" so the hash
+// stays stable across runs.
+func parserConfigHash(overrides map[string]string) string {
+	b, err := json.Marshal(overrides)
+	if err != nil {
+		b = []byte("{}")
+	}
+	return types.SHAChecksum(string(b))
+}
+
+// cacheableReadResult returns a deep copy of r with raw image bytes stripped.
+// The parse-product cache stores only image references (URL/storage key/hash);
+// persisting inline image bytes would explode the DB payload.
+func cacheableReadResult(r *types.ReadResult) *types.ReadResult {
+	if r == nil {
+		return nil
+	}
+	c := &types.ReadResult{
+		MarkdownContent: r.MarkdownContent,
+		ImageDirPath:    r.ImageDirPath,
+		Metadata:        r.Metadata,
+		Error:           r.Error,
+		IsAudio:         r.IsAudio,
+		AudioData:       r.AudioData,
+	}
+	if len(r.ImageRefs) > 0 {
+		c.ImageRefs = make([]types.ImageRef, len(r.ImageRefs))
+		for i, ref := range r.ImageRefs {
+			c.ImageRefs[i] = ref
+			c.ImageRefs[i].ImageData = nil
+		}
+	}
+	return c
 }
 
 // convert handles both file and URL reading using a unified ReadRequest.
@@ -3148,6 +3330,7 @@ func (s *knowledgeService) convert(
 		ParserEngineOverrides: mergedOverrides,
 	}
 
+	var fileHash string
 	if !isURL {
 		fileReader, err := s.resolveFileServiceForPath(ctx, kb, payload.FilePath).GetFile(ctx, payload.FilePath)
 		if err != nil {
@@ -3165,6 +3348,36 @@ func (s *knowledgeService) convert(
 		req.FileContent = contentBytes
 		req.FileName = payload.FileName
 		req.FileType = fileType
+		fileHash = types.SHAChecksum(string(contentBytes))
+	}
+
+	// Try to serve the parse product from cache for file imports. URLs are
+	// fetched by DocReader itself, so we have no local bytes to hash and
+	// fall through to the live reader.
+	if !isURL && s.parseCache != nil {
+		pCfgHash := parserConfigHash(mergedOverrides)
+		if cached, ok, err := s.parseCache.Get(ctx, fileHash, parserEngine, pCfgHash, parseRenderConfigHash); err == nil && ok {
+			var result types.ReadResult
+			if uerr := json.Unmarshal([]byte(cached), &result); uerr == nil {
+				logger.Infof(ctx, "[convert] parse product cache hit for knowledge=%s file_hash=%s engine=%q",
+					knowledge.ID, fileHash[:min(12, len(fileHash))], parserEngine)
+				docOutput := types.JSONMap{
+					"text_length":  len(result.MarkdownContent),
+					"images_found": len(result.ImageRefs),
+					"is_audio":     result.IsAudio,
+					"cache_layer":  "hit",
+				}
+				if pages := result.Metadata["pages"]; pages != "" {
+					docOutput["pages"] = pages
+				}
+				s.endStage(ctx, knowledge.ID, types.StageDocReader, docOutput)
+				return &result, nil
+			} else {
+				logger.Warnf(ctx, "[convert] parse product cache hit but unmarshal failed for knowledge=%s: %v", knowledge.ID, uerr)
+			}
+		} else if err != nil {
+			logger.Warnf(ctx, "[convert] parse product cache Get failed for knowledge=%s: %v", knowledge.ID, err)
+		}
 	}
 
 	result, err := s.callDocReaderWithTimeout(ctx, reader, req)
@@ -3191,10 +3404,32 @@ func (s *knowledgeService) convert(
 			werrors.ErrCodeDocReaderParseFailed, result.Error, nil)
 		return nil, nil
 	}
+	// Persist the parse product best-effort. Strip raw image bytes from the
+	// payload — the cache stores references only; VLM cache governs OCR/Caption
+	// by image bytes independently.
+	if !isURL && s.parseCache != nil {
+		pCfgHash := parserConfigHash(mergedOverrides)
+		payload, merr := json.Marshal(cacheableReadResult(result))
+		if merr == nil {
+			if perr := s.parseCache.Put(ctx, &types.ParseProductCache{
+				FileHash:         fileHash,
+				ParserEngine:     parserEngine,
+				ParserConfigHash: pCfgHash,
+				RenderConfigHash: parseRenderConfigHash,
+				Payload:          string(payload),
+			}); perr != nil {
+				logger.Warnf(ctx, "[convert] parse product cache Put failed for knowledge=%s: %v", knowledge.ID, perr)
+			}
+		} else {
+			logger.Warnf(ctx, "[convert] parse product cache payload marshal failed for knowledge=%s: %v", knowledge.ID, merr)
+		}
+	}
+
 	docOutput := types.JSONMap{
 		"text_length":  len(result.MarkdownContent),
 		"images_found": len(result.ImageRefs),
 		"is_audio":     result.IsAudio,
+		"cache_layer":  "miss",
 	}
 	if pages := result.Metadata["pages"]; pages != "" {
 		docOutput["pages"] = pages

--- a/internal/application/service/knowledge_process_diff.go
+++ b/internal/application/service/knowledge_process_diff.go
@@ -1,0 +1,37 @@
+package service
+
+import "github.com/Tencent/WeKnora/internal/types"
+
+// computeChunkDiff reconciles newly-split chunks against existing chunk rows.
+// Returns keptIDs (content unchanged, reuse vectors), addedChunks (new content,
+// need CreateChunks+BatchIndex), removedIDs (deleted content, need vector+row cleanup).
+// This is the core of non-destructive reparse (Phase 7).
+func computeChunkDiff(newChunks []*types.Chunk, oldChunks []*types.Chunk) (keptIDs map[string]struct{}, addedChunks []*types.Chunk, removedIDs []string) {
+	newByID := make(map[string]*types.Chunk, len(newChunks))
+	for _, c := range newChunks {
+		newByID[c.ID] = c
+	}
+
+	oldByID := make(map[string]*types.Chunk, len(oldChunks))
+	for _, c := range oldChunks {
+		oldByID[c.ID] = c
+	}
+
+	keptIDs = make(map[string]struct{})
+	addedChunks = make([]*types.Chunk, 0, len(newByID))
+	for id, c := range newByID {
+		if _, exists := oldByID[id]; exists {
+			keptIDs[id] = struct{}{}
+		} else {
+			addedChunks = append(addedChunks, c)
+		}
+	}
+
+	for id := range oldByID {
+		if _, exists := newByID[id]; !exists {
+			removedIDs = append(removedIDs, id)
+		}
+	}
+
+	return
+}

--- a/internal/application/service/knowledge_process_diff_test.go
+++ b/internal/application/service/knowledge_process_diff_test.go
@@ -1,0 +1,171 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func chunkWithContent(t *testing.T, knowledgeID, content string, stableSeq int) *types.Chunk {
+	t.Helper()
+	return &types.Chunk{
+		ID:          types.StableChunkID(knowledgeID, content, stableSeq),
+		KnowledgeID: knowledgeID,
+		Content:     content,
+	}
+}
+
+func TestComputeChunkDiff_AllKept(t *testing.T) {
+	knowledgeID := "kb-all-kept"
+	newChunks := []*types.Chunk{
+		chunkWithContent(t, knowledgeID, "first paragraph of text", 0),
+		chunkWithContent(t, knowledgeID, "second paragraph of text", 0),
+	}
+	oldChunks := []*types.Chunk{
+		chunkWithContent(t, knowledgeID, "first paragraph of text", 0),
+		chunkWithContent(t, knowledgeID, "second paragraph of text", 0),
+	}
+
+	kept, added, removed := computeChunkDiff(newChunks, oldChunks)
+
+	if len(kept) != 2 {
+		t.Fatalf("kept = %d, want 2", len(kept))
+	}
+	if len(added) != 0 {
+		t.Fatalf("added = %d, want 0", len(added))
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed = %d, want 0", len(removed))
+	}
+	for _, c := range newChunks {
+		if _, ok := kept[c.ID]; !ok {
+			t.Fatalf("expected chunk %q to be kept", c.ID)
+		}
+	}
+}
+
+func TestComputeChunkDiff_AllAdded(t *testing.T) {
+	knowledgeID := "kb-all-added"
+	newChunks := []*types.Chunk{
+		chunkWithContent(t, knowledgeID, "only chunk", 0),
+	}
+	oldChunks := []*types.Chunk{}
+
+	kept, added, removed := computeChunkDiff(newChunks, oldChunks)
+
+	if len(kept) != 0 {
+		t.Fatalf("kept = %d, want 0", len(kept))
+	}
+	if len(added) != 1 {
+		t.Fatalf("added = %d, want 1", len(added))
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed = %d, want 0", len(removed))
+	}
+	if added[0].ID != newChunks[0].ID {
+		t.Fatalf("added[0].ID = %q, want %q", added[0].ID, newChunks[0].ID)
+	}
+}
+
+func TestComputeChunkDiff_AllRemoved(t *testing.T) {
+	knowledgeID := "kb-all-removed"
+	newChunks := []*types.Chunk{}
+	oldChunks := []*types.Chunk{
+		chunkWithContent(t, knowledgeID, "old chunk one", 0),
+		chunkWithContent(t, knowledgeID, "old chunk two", 0),
+	}
+
+	kept, added, removed := computeChunkDiff(newChunks, oldChunks)
+
+	if len(kept) != 0 {
+		t.Fatalf("kept = %d, want 0", len(kept))
+	}
+	if len(added) != 0 {
+		t.Fatalf("added = %d, want 0", len(added))
+	}
+	if len(removed) != 2 {
+		t.Fatalf("removed = %d, want 2", len(removed))
+	}
+	wantRemoved := map[string]struct{}{
+		oldChunks[0].ID: {},
+		oldChunks[1].ID: {},
+	}
+	for _, id := range removed {
+		if _, ok := wantRemoved[id]; !ok {
+			t.Fatalf("unexpected removed id %q", id)
+		}
+	}
+}
+
+func TestComputeChunkDiff_PartialChange(t *testing.T) {
+	knowledgeID := "kb-partial-change"
+	unchanged := chunkWithContent(t, knowledgeID, "unchanged paragraph", 0)
+	oldChanged := chunkWithContent(t, knowledgeID, "original paragraph", 0)
+	newChanged := chunkWithContent(t, knowledgeID, "revised paragraph", 0)
+
+	newChunks := []*types.Chunk{unchanged, newChanged}
+	oldChunks := []*types.Chunk{unchanged, oldChanged}
+
+	kept, added, removed := computeChunkDiff(newChunks, oldChunks)
+
+	if len(kept) != 1 {
+		t.Fatalf("kept = %d, want 1", len(kept))
+	}
+	if _, ok := kept[unchanged.ID]; !ok {
+		t.Fatalf("expected unchanged chunk %q to be kept", unchanged.ID)
+	}
+	if len(added) != 1 {
+		t.Fatalf("added = %d, want 1", len(added))
+	}
+	if added[0].ID != newChanged.ID {
+		t.Fatalf("added[0].ID = %q, want %q", added[0].ID, newChanged.ID)
+	}
+	if len(removed) != 1 {
+		t.Fatalf("removed = %d, want 1", len(removed))
+	}
+	if removed[0] != oldChanged.ID {
+		t.Fatalf("removed[0] = %q, want %q", removed[0], oldChanged.ID)
+	}
+}
+
+func TestComputeChunkDiff_StableIDDeterminism(t *testing.T) {
+	knowledgeID := "kb-stable-id"
+	content := "same content must produce the same stable chunk id"
+
+	// Simulate two independent splits producing the same content.
+	newChunks := []*types.Chunk{
+		chunkWithContent(t, knowledgeID, content, 0),
+	}
+	oldChunks := []*types.Chunk{
+		chunkWithContent(t, knowledgeID, content, 0),
+	}
+
+	kept, added, removed := computeChunkDiff(newChunks, oldChunks)
+
+	if len(kept) != 1 {
+		t.Fatalf("kept = %d, want 1", len(kept))
+	}
+	if len(added) != 0 {
+		t.Fatalf("added = %d, want 0", len(added))
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed = %d, want 0", len(removed))
+	}
+	if _, ok := kept[newChunks[0].ID]; !ok {
+		t.Fatalf("expected stable id %q to be kept", newChunks[0].ID)
+	}
+}
+
+func TestComputeChunkDiff_EmptyBoth(t *testing.T) {
+	kept, added, removed := computeChunkDiff(nil, nil)
+
+	if len(kept) != 0 {
+		t.Fatalf("kept = %d, want 0", len(kept))
+	}
+	if len(added) != 0 {
+		t.Fatalf("added = %d, want 0", len(added))
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed = %d, want 0", len(removed))
+	}
+}

--- a/internal/application/service/knowledge_process_status_test.go
+++ b/internal/application/service/knowledge_process_status_test.go
@@ -45,7 +45,7 @@ func TestFinalizeIndexedKnowledgeState(t *testing.T) {
 				SummaryStatus: types.SummaryStatusCompleted,
 			}
 
-			finalizeIndexedKnowledgeState(knowledge, 4096, tt.textChunkCount, tt.hasPendingMultimodal, now)
+			finalizeIndexedKnowledgeState(knowledge, 4096, tt.textChunkCount, tt.hasPendingMultimodal, now, false)
 
 			if knowledge.ParseStatus != tt.wantParseStatus {
 				t.Fatalf("ParseStatus = %q, want %q", knowledge.ParseStatus, tt.wantParseStatus)

--- a/internal/application/service/model.go
+++ b/internal/application/service/model.go
@@ -24,33 +24,34 @@ var ErrModelNotFound = errors.New("model not found")
 
 // modelService implements the model service interface
 type modelService struct {
-	repo          interfaces.ModelRepository
-	kbRepo        interfaces.KnowledgeBaseRepository
-	agentRepo     interfaces.CustomAgentRepository
-	ollamaService *ollama.OllamaService
-	pooler        embedding.EmbedderPooler
-	tenantService interfaces.TenantService
+	repo           interfaces.ModelRepository
+	kbRepo         interfaces.KnowledgeBaseRepository
+	agentRepo      interfaces.CustomAgentRepository
+	ollamaService  *ollama.OllamaService
+	pooler         embedding.EmbedderPooler
+	tenantService  interfaces.TenantService
+	embeddingCache embedding.VectorCacheStore
 }
 
-// NewModelService creates a new model service instance
 func NewModelService(repo interfaces.ModelRepository,
 	kbRepo interfaces.KnowledgeBaseRepository,
 	agentRepo interfaces.CustomAgentRepository,
 	ollamaService *ollama.OllamaService,
 	pooler embedding.EmbedderPooler,
 	tenantService interfaces.TenantService,
+	embeddingCache embedding.VectorCacheStore,
 ) interfaces.ModelService {
 	return &modelService{
-		repo:          repo,
-		kbRepo:        kbRepo,
-		agentRepo:     agentRepo,
-		ollamaService: ollamaService,
-		pooler:        pooler,
-		tenantService: tenantService,
+		repo:           repo,
+		kbRepo:         kbRepo,
+		agentRepo:      agentRepo,
+		ollamaService:  ollamaService,
+		pooler:         pooler,
+		tenantService:  tenantService,
+		embeddingCache: embeddingCache,
 	}
 }
 
-// decryptAppSecret 解密 AppSecret（如果为空或 cryptoSvc 为空则原样返回）
 func (s *modelService) decryptAppSecret(encrypted string) string {
 	if encrypted == "" {
 		return encrypted
@@ -416,7 +417,7 @@ func (s *modelService) GetEmbeddingModel(ctx context.Context, modelId string) (e
 	}
 
 	logger.Info(ctx, "Embedding model initialized successfully")
-	return embedder, nil
+	return embedding.NewCachedEmbedder(embedder, s.embeddingCache), nil
 }
 
 // GetEmbeddingModelForTenant retrieves and initializes an embedding model for a specific tenant
@@ -464,7 +465,7 @@ func (s *modelService) GetEmbeddingModelForTenant(ctx context.Context, modelId s
 	}
 
 	logger.Info(ctx, "Cross-tenant embedding model initialized successfully")
-	return embedder, nil
+	return embedding.NewCachedEmbedder(embedder, s.embeddingCache), nil
 }
 
 // GetRerankModel retrieves and initializes a reranking model instance

--- a/internal/application/service/model_delete_test.go
+++ b/internal/application/service/model_delete_test.go
@@ -102,12 +102,7 @@ func TestDeleteModel_RejectsWhenReferenced(t *testing.T) {
 	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
 	modelID := "model-in-use"
 
-	svc := NewModelService(
-		&stubModelRepoForDelete{model: &types.Model{ID: modelID, TenantID: 1}},
-		&stubKBRepoForModelDelete{count: 1},
-		&stubAgentRepoForModelDelete{count: 0},
-		nil, nil, nil,
-	)
+	svc := NewModelService(&stubModelRepoForDelete{model: &types.Model{ID: modelID, TenantID: 1}}, &stubKBRepoForModelDelete{count: 1}, &stubAgentRepoForModelDelete{count: 0}, nil, nil, nil, nil)
 
 	err := svc.DeleteModel(ctx, modelID)
 	require.Error(t, err)
@@ -121,12 +116,7 @@ func TestDeleteModel_RejectsWhenUsedByAgent(t *testing.T) {
 	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
 	modelID := "agent-model"
 
-	svc := NewModelService(
-		&stubModelRepoForDelete{model: &types.Model{ID: modelID, TenantID: 1}},
-		&stubKBRepoForModelDelete{count: 0},
-		&stubAgentRepoForModelDelete{count: 2},
-		nil, nil, nil,
-	)
+	svc := NewModelService(&stubModelRepoForDelete{model: &types.Model{ID: modelID, TenantID: 1}}, &stubKBRepoForModelDelete{count: 0}, &stubAgentRepoForModelDelete{count: 2}, nil, nil, nil, nil)
 
 	err := svc.DeleteModel(ctx, modelID)
 	require.Error(t, err)
@@ -140,19 +130,14 @@ func TestDeleteModel_SucceedsWhenUnreferenced(t *testing.T) {
 	modelID := "free-model"
 	deleted := false
 
-	svc := NewModelService(
-		&stubModelRepoForDelete{
+	svc := NewModelService(&stubModelRepoForDelete{
 			model: &types.Model{ID: modelID, TenantID: 1},
 			delete: func(id string) error {
 				assert.Equal(t, modelID, id)
 				deleted = true
 				return nil
 			},
-		},
-		&stubKBRepoForModelDelete{},
-		&stubAgentRepoForModelDelete{},
-		nil, nil, nil,
-	)
+		}, &stubKBRepoForModelDelete{}, &stubAgentRepoForModelDelete{}, nil, nil, nil, nil)
 
 	require.NoError(t, svc.DeleteModel(ctx, modelID))
 	assert.True(t, deleted)

--- a/internal/application/service/reparse_cache_behavior_test.go
+++ b/internal/application/service/reparse_cache_behavior_test.go
@@ -1,0 +1,446 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	apprepo "github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// countingChat is a test double for chat.Chat that records how many times
+// Chat was invoked and returns a fixed response.
+type countingChat struct {
+	calls    int
+	response string
+	modelID  string
+	modelName string
+}
+
+func (c *countingChat) Chat(ctx context.Context, messages []chat.Message, opts *chat.ChatOptions) (*types.ChatResponse, error) {
+	c.calls++
+	return &types.ChatResponse{Content: c.response}, nil
+}
+
+func (c *countingChat) ChatStream(ctx context.Context, messages []chat.Message, opts *chat.ChatOptions) (<-chan types.StreamResponse, error) {
+	ch := make(chan types.StreamResponse)
+	close(ch)
+	return ch, nil
+}
+
+func (c *countingChat) GetModelName() string { return c.modelName }
+func (c *countingChat) GetModelID() string   { return c.modelID }
+
+// memorySummaryCacheRepo is an in-memory implementation of SummaryCacheRepo
+// for behavior tests. It does not depend on a real database.
+type memorySummaryCacheRepo struct {
+	data map[string]types.SummaryCache
+}
+
+func newMemorySummaryCacheRepo() *memorySummaryCacheRepo {
+	return &memorySummaryCacheRepo{data: make(map[string]types.SummaryCache)}
+}
+
+func (r *memorySummaryCacheRepo) key(docContentHash, modelID, promptVersion, configHash string) string {
+	return docContentHash + "|" + modelID + "|" + promptVersion + "|" + configHash
+}
+
+func (r *memorySummaryCacheRepo) Get(ctx context.Context, docContentHash, modelID, promptVersion, configHash string) (string, bool, error) {
+	row, ok := r.data[r.key(docContentHash, modelID, promptVersion, configHash)]
+	if !ok {
+		return "", false, nil
+	}
+	return row.Summary, true, nil
+}
+
+func (r *memorySummaryCacheRepo) Put(ctx context.Context, row *types.SummaryCache) error {
+	r.data[r.key(row.DocContentHash, row.ModelID, row.PromptVersion, row.ConfigHash)] = *row
+	return nil
+}
+
+// memoryQuestionCacheRepo is an in-memory implementation of QuestionCacheRepo
+// for behavior tests. It does not depend on a real database.
+type memoryQuestionCacheRepo struct {
+	data map[string]types.QuestionCache
+}
+
+func newMemoryQuestionCacheRepo() *memoryQuestionCacheRepo {
+	return &memoryQuestionCacheRepo{data: make(map[string]types.QuestionCache)}
+}
+
+func (r *memoryQuestionCacheRepo) key(chunkContentHash, modelID, promptVersion, configHash string) string {
+	return chunkContentHash + "|" + modelID + "|" + promptVersion + "|" + configHash
+}
+
+func (r *memoryQuestionCacheRepo) Get(ctx context.Context, chunkContentHash, modelID, promptVersion, configHash string) (string, bool, error) {
+	row, ok := r.data[r.key(chunkContentHash, modelID, promptVersion, configHash)]
+	if !ok {
+		return "", false, nil
+	}
+	return row.Payload, true, nil
+}
+
+func (r *memoryQuestionCacheRepo) Put(ctx context.Context, row *types.QuestionCache) error {
+	r.data[r.key(row.ChunkContentHash, row.ModelID, row.PromptVersion, row.ConfigHash)] = *row
+	return nil
+}
+
+// Compile-time guards: the memory mocks must satisfy the repository interfaces.
+var _ apprepo.SummaryCacheRepo = (*memorySummaryCacheRepo)(nil)
+var _ apprepo.QuestionCacheRepo = (*memoryQuestionCacheRepo)(nil)
+var _ chat.Chat = (*countingChat)(nil)
+
+// summaryCacheKey mirrors the key composition used by knowledgeService.getSummary.
+func summaryCacheKey(content, modelID, prompt string, maxInputChars, maxTokens int) (docContentHash, mid, promptVersion, configHash string) {
+	docContentHash = types.StableContentHash(content)
+	mid = modelID
+	promptVersion = types.SHAChecksum(prompt)
+	configBytes, _ := json.Marshal(map[string]interface{}{
+		"model_name":      modelID, // production uses GetModelName; tests use modelID as proxy
+		"max_input_chars": maxInputChars,
+		"max_tokens":      maxTokens,
+		"temperature":     0.3,
+	})
+	configHash = types.SHAChecksum(string(configBytes))
+	return docContentHash, mid, promptVersion, configHash
+}
+
+// questionCacheKey mirrors the key composition used by knowledgeService.generateQuestionsWithContext.
+func questionCacheKey(content, modelID, prompt string, questionCount int) (chunkContentHash, mid, promptVersion, configHash string) {
+	chunkContentHash = types.StableContentHash(content)
+	mid = modelID
+	promptVersion = types.SHAChecksum(prompt)
+	configBytes, _ := json.Marshal(map[string]interface{}{
+		"model_name":     modelID,
+		"temperature":    0.7,
+		"max_tokens":     512,
+		"question_count": questionCount,
+	})
+	configHash = types.SHAChecksum(string(configBytes))
+	return chunkContentHash, mid, promptVersion, configHash
+}
+
+func TestReparseUnchangedContent_StableIDsAndCacheKeys(t *testing.T) {
+	knowledgeID := "kb-unchanged"
+	content := "The quick brown fox jumps over the lazy dog.\n\nSame content, same IDs."
+	prompt := "Summarize the following document in one sentence: {{language}}"
+	modelID := "model-001"
+
+	// StableChunkID must be deterministic for identical inputs.
+	id1 := types.StableChunkID(knowledgeID, content, 0)
+	id2 := types.StableChunkID(knowledgeID, content, 0)
+	if id1 != id2 {
+		t.Fatalf("StableChunkID not deterministic: %q vs %q", id1, id2)
+	}
+
+	// StableContentHash must be deterministic for identical content.
+	hash1 := types.StableContentHash(content)
+	hash2 := types.StableContentHash(content)
+	if hash1 != hash2 {
+		t.Fatalf("StableContentHash not deterministic: %q vs %q", hash1, hash2)
+	}
+
+	// Prompt version must be deterministic for identical prompts.
+	pv1 := types.SHAChecksum(prompt)
+	pv2 := types.SHAChecksum(prompt)
+	if pv1 != pv2 {
+		t.Fatalf("SHAChecksum(prompt) not deterministic: %q vs %q", pv1, pv2)
+	}
+
+	// Same content + same model + same prompt => identical cache key => reusable.
+	dh1, mid1, pv1Out, ch1 := summaryCacheKey(content, modelID, prompt, 1024, 512)
+	dh2, mid2, pv2Out, ch2 := summaryCacheKey(content, modelID, prompt, 1024, 512)
+	if dh1 != dh2 || mid1 != mid2 || pv1Out != pv2Out || ch1 != ch2 {
+		t.Fatalf("summary cache key not reusable across identical rebuilds: (%s,%s,%s,%s) vs (%s,%s,%s,%s)",
+			dh1, mid1, pv1Out, ch1, dh2, mid2, pv2Out, ch2)
+	}
+
+	// Cross-document identical content must still produce different chunk IDs,
+	// while embeddings/content-hash dedup across docs remains valid.
+	otherID := types.StableChunkID("kb-other", content, 0)
+	if id1 == otherID {
+		t.Fatalf("StableChunkID must not collapse cross-document identity: %q == %q", id1, otherID)
+	}
+}
+
+func TestCrashResume_CompletedArtifactsCacheHit(t *testing.T) {
+	knowledgeID := "kb-crash-resume"
+	contents := []string{
+		"first paragraph for crash resume test",
+		"second paragraph for crash resume test",
+		"third paragraph for crash resume test",
+	}
+
+	// Simulate the first parsing pass: new chunks vs an empty old set.
+	var firstPass []*types.Chunk
+	for i, c := range contents {
+		firstPass = append(firstPass, chunkWithContent(t, knowledgeID, c, i))
+	}
+
+	kept1, added1, removed1 := computeChunkDiff(firstPass, nil)
+	if len(kept1) != 0 {
+		t.Fatalf("first pass kept = %d, want 0", len(kept1))
+	}
+	if len(added1) != len(contents) {
+		t.Fatalf("first pass added = %d, want %d", len(added1), len(contents))
+	}
+	if len(removed1) != 0 {
+		t.Fatalf("first pass removed = %d, want 0", len(removed1))
+	}
+
+	// Simulate a crash-resume second pass: the splitter produces the same
+	// content, so StableChunkID yields the same IDs as the first pass.
+	var secondPass []*types.Chunk
+	for i, c := range contents {
+		secondPass = append(secondPass, chunkWithContent(t, knowledgeID, c, i))
+	}
+
+	kept2, added2, removed2 := computeChunkDiff(secondPass, firstPass)
+	if len(kept2) != len(contents) {
+		t.Fatalf("second pass kept = %d, want %d", len(kept2), len(contents))
+	}
+	if len(added2) != 0 {
+		t.Fatalf("second pass added = %d, want 0", len(added2))
+	}
+	if len(removed2) != 0 {
+		t.Fatalf("second pass removed = %d, want 0", len(removed2))
+	}
+
+	// Every chunk from the second pass must be classified as kept because
+	// StableChunkID is deterministic.
+	for _, c := range secondPass {
+		if _, ok := kept2[c.ID]; !ok {
+			t.Fatalf("second pass chunk %q should be kept", c.ID)
+		}
+	}
+}
+
+func TestConfigChange_OnlyDependentLayerInvalidates(t *testing.T) {
+	content := "document content used for config change test"
+	prompt := "Summarize: {{language}}"
+	modelA := "model-A"
+	modelB := "model-B"
+
+	// Different model_id => different prompt_version component is not used
+	// here, but the model_id itself must produce a different cache key.
+	hashModelA := types.SHAChecksum(modelA)
+	hashModelB := types.SHAChecksum(modelB)
+	if hashModelA == hashModelB {
+		t.Fatalf("SHAChecksum must distinguish different model ids: %q", hashModelA)
+	}
+
+	// Different prompt => different prompt version hash.
+	promptV1 := types.SHAChecksum(prompt)
+	promptV2 := types.SHAChecksum(prompt + " extra")
+	if promptV1 == promptV2 {
+		t.Fatalf("SHAChecksum must distinguish different prompts: %q", promptV1)
+	}
+
+	// Same model_id + same prompt => same hash.
+	if types.SHAChecksum(modelA+prompt) != types.SHAChecksum(modelA+prompt) {
+		t.Fatalf("SHAChecksum must be deterministic for identical model+prompt")
+	}
+
+	// Layer A (summary) and layer B (question) share content but use different
+	// prompts/configs. Changing the model for layer A only must invalidate
+	// layer A while layer B remains reusable.
+	summaryA1Doc, summaryA1Model, summaryA1Prompt, summaryA1Config := summaryCacheKey(content, modelA, "summary prompt v1", 1024, 512)
+	summaryA2Doc, summaryA2Model, summaryA2Prompt, summaryA2Config := summaryCacheKey(content, modelB, "summary prompt v1", 1024, 512)
+	questionBDoc, questionBModel, questionBPrompt, questionBConfig := questionCacheKey(content, modelA, "question prompt v1", 3)
+
+	// Summary layer must change when model changes.
+	if summaryA1Doc == summaryA2Doc && summaryA1Model == summaryA2Model &&
+		summaryA1Prompt == summaryA2Prompt && summaryA1Config == summaryA2Config {
+		t.Fatalf("summary cache key must change when model changes")
+	}
+	if summaryA1Model == summaryA2Model {
+		t.Fatalf("summary model_id component must differ: %q vs %q", summaryA1Model, summaryA2Model)
+	}
+
+	// Question layer still uses modelA, so its key is unchanged and reusable.
+	questionBDoc2, questionBModel2, questionBPrompt2, questionBConfig2 := questionCacheKey(content, modelA, "question prompt v1", 3)
+	if questionBDoc != questionBDoc2 || questionBModel != questionBModel2 ||
+		questionBPrompt != questionBPrompt2 || questionBConfig != questionBConfig2 {
+		t.Fatalf("question cache key should remain reusable when its model_id is unchanged")
+	}
+}
+
+func TestSummaryCacheHit_SkipsLLM(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemorySummaryCacheRepo()
+	llm := &countingChat{response: "cached summary", modelID: "summary-model"}
+
+	content := "some document content"
+	prompt := "Summarize: {{language}}"
+	docHash, modelID, promptVersion, configHash := summaryCacheKey(content, llm.modelID, prompt, 1024, 512)
+
+	// Pre-fill the cache as if a previous successful run had written it.
+	if err := repo.Put(ctx, &types.SummaryCache{
+		DocContentHash: docHash,
+		ModelID:        modelID,
+		PromptVersion:  promptVersion,
+		ConfigHash:     configHash,
+		Summary:        "cached summary",
+	}); err != nil {
+		t.Fatalf("put cache: %v", err)
+	}
+
+	// Simulate the production lookup path.
+	cached, ok, err := repo.Get(ctx, docHash, modelID, promptVersion, configHash)
+	if err != nil {
+		t.Fatalf("get cache: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected cache hit")
+	}
+	if cached != "cached summary" {
+		t.Fatalf("cached summary = %q, want %q", cached, "cached summary")
+	}
+
+	// A cache hit must not call the LLM.
+	if llm.calls != 0 {
+		t.Fatalf("LLM called %d times on cache hit, want 0", llm.calls)
+	}
+}
+
+func TestSummaryCacheMiss_WritesCache(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemorySummaryCacheRepo()
+	llm := &countingChat{response: "generated summary", modelID: "summary-model"}
+
+	content := "some document content"
+	prompt := "Summarize: {{language}}"
+	docHash, modelID, promptVersion, configHash := summaryCacheKey(content, llm.modelID, prompt, 1024, 512)
+
+	// First lookup is a miss.
+	_, ok, err := repo.Get(ctx, docHash, modelID, promptVersion, configHash)
+	if err != nil {
+		t.Fatalf("get cache: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected cache miss before LLM call")
+	}
+
+	// Simulate the LLM call and cache write that production performs.
+	resp, err := llm.Chat(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("llm chat: %v", err)
+	}
+	if err := repo.Put(ctx, &types.SummaryCache{
+		DocContentHash: docHash,
+		ModelID:        modelID,
+		PromptVersion:  promptVersion,
+		ConfigHash:     configHash,
+		Summary:        resp.Content,
+	}); err != nil {
+		t.Fatalf("put cache: %v", err)
+	}
+
+	// Second lookup must now hit without another LLM call.
+	cached, ok, err := repo.Get(ctx, docHash, modelID, promptVersion, configHash)
+	if err != nil {
+		t.Fatalf("get cache: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected cache hit after write")
+	}
+	if cached != "generated summary" {
+		t.Fatalf("cached summary = %q, want %q", cached, "generated summary")
+	}
+	if llm.calls != 1 {
+		t.Fatalf("LLM called %d times, want 1", llm.calls)
+	}
+}
+
+func TestQuestionCacheHit_SkipsLLM(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemoryQuestionCacheRepo()
+	llm := &countingChat{response: "[\"q1\", \"q2\"]", modelID: "question-model"}
+
+	content := "chunk content for questions"
+	prompt := "Generate questions: {{content}}"
+	chunkHash, modelID, promptVersion, configHash := questionCacheKey(content, llm.modelID, prompt, 2)
+
+	// Pre-fill the cache.
+	questionsJSON := `["cached q1","cached q2"]`
+	if err := repo.Put(ctx, &types.QuestionCache{
+		ChunkContentHash: chunkHash,
+		ModelID:          modelID,
+		PromptVersion:    promptVersion,
+		ConfigHash:       configHash,
+		Payload:          questionsJSON,
+	}); err != nil {
+		t.Fatalf("put cache: %v", err)
+	}
+
+	// Simulate the production lookup path.
+	cached, ok, err := repo.Get(ctx, chunkHash, modelID, promptVersion, configHash)
+	if err != nil {
+		t.Fatalf("get cache: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected cache hit")
+	}
+	var questions []string
+	if err := json.Unmarshal([]byte(cached), &questions); err != nil {
+		t.Fatalf("unmarshal questions: %v", err)
+	}
+	if len(questions) != 2 {
+		t.Fatalf("questions = %v, want 2", questions)
+	}
+
+	if llm.calls != 0 {
+		t.Fatalf("LLM called %d times on cache hit, want 0", llm.calls)
+	}
+}
+
+func TestQuestionCacheMiss_WritesCache(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemoryQuestionCacheRepo()
+	llm := &countingChat{response: "[\"q1\", \"q2\"]", modelID: "question-model"}
+
+	content := "chunk content for questions"
+	prompt := "Generate questions: {{content}}"
+	chunkHash, modelID, promptVersion, configHash := questionCacheKey(content, llm.modelID, prompt, 2)
+
+	// First lookup is a miss.
+	_, ok, err := repo.Get(ctx, chunkHash, modelID, promptVersion, configHash)
+	if err != nil {
+		t.Fatalf("get cache: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected cache miss before LLM call")
+	}
+
+	// Simulate the LLM call and cache write.
+	resp, err := llm.Chat(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("llm chat: %v", err)
+	}
+	if err := repo.Put(ctx, &types.QuestionCache{
+		ChunkContentHash: chunkHash,
+		ModelID:          modelID,
+		PromptVersion:    promptVersion,
+		ConfigHash:       configHash,
+		Payload:          resp.Content,
+	}); err != nil {
+		t.Fatalf("put cache: %v", err)
+	}
+
+	// Second lookup must hit.
+	cached, ok, err := repo.Get(ctx, chunkHash, modelID, promptVersion, configHash)
+	if err != nil {
+		t.Fatalf("get cache: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected cache hit after write")
+	}
+	if cached != resp.Content {
+		t.Fatalf("cached payload = %q, want %q", cached, resp.Content)
+	}
+	if llm.calls != 1 {
+		t.Fatalf("LLM called %d times, want 1", llm.calls)
+	}
+}

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -14,6 +14,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/Tencent/WeKnora/internal/agent"
+	apprepo "github.com/Tencent/WeKnora/internal/application/repository"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/models/chat"
 	"github.com/Tencent/WeKnora/internal/searchutil"
@@ -212,6 +213,11 @@ type wikiIngestService struct {
 	// liteLocks provides per-KB mutual exclusion in Lite mode (no Redis).
 	// Keys are kbID strings; values are unused (presence = locked).
 	liteLocks sync.Map
+	// wikiMapCache content-addresses the complete per-doc map output
+	// (extracted entities/concepts, summary, citations, new-slugs) by
+	// frozen doc content + extraction granularity + synthesis model +
+	// prompt version. nil-safe: lite/test paths fall through to LLMs.
+	wikiMapCache apprepo.WikiMapCacheRepo
 }
 
 // NewWikiIngestService creates a new wiki ingest service
@@ -228,6 +234,7 @@ func NewWikiIngestService(
 	deadLetterRepo interfaces.TaskDeadLetterRepository,
 	redisClient *redis.Client,
 	spanTracker SpanTracker,
+	wikiMapCache apprepo.WikiMapCacheRepo,
 ) interfaces.TaskHandler {
 	svc := &wikiIngestService{
 		wikiService:    wikiService,
@@ -242,8 +249,21 @@ func NewWikiIngestService(
 		deadLetterRepo: deadLetterRepo,
 		redisClient:    redisClient,
 		spanTracker:    spanTracker,
+		wikiMapCache:   wikiMapCache,
 	}
 	return svc
+}
+
+// wikiMapPromptVersion returns a stable hash of every prompt that
+// contributes to the per-document map output. Changing any of these
+// prompts automatically invalidates cached map entries.
+func (s *wikiIngestService) wikiMapPromptVersion() string {
+	return types.SHAChecksum(
+		agent.WikiCandidateSlugPrompt +
+			agent.WikiDeduplicationPrompt +
+			agent.WikiSummaryPrompt +
+			agent.WikiChunkCitationPrompt,
+	)
 }
 
 // tracker returns a non-nil span tracker so callers don't have to
@@ -1301,6 +1321,7 @@ func formatExistingTaxonomyForPrompt(paths [][]string) string {
 	}
 	return strings.TrimSpace(buf.String())
 }
+
 // getExistingPageSlugsForKnowledge returns all page slugs that currently
 // reference a given knowledge ID in their source_refs. Used to snapshot
 // state before re-ingest so the reduce phase can reconcile additions vs

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -19,6 +19,19 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// wikiMapCachePayload is the JSON shape persisted in wiki_map_cache.
+// It captures the complete pure-function map output so a cache hit can
+// skip extract/dedup/summary/classify and proceed directly to reduce.
+type wikiMapCachePayload struct {
+	ExtractedEntities []extractedItem       `json:"extracted_entities"`
+	ExtractedConcepts []extractedItem       `json:"extracted_concepts"`
+	SummaryContent    string                `json:"summary_content"`
+	Citations         map[string][]string   `json:"citations"`
+	NewSlugs          []newSlugFromCitation `json:"new_slugs"`
+	BatchCount        int                   `json:"batch_count"`
+	Pass0Failed       bool                  `json:"pass0_failed"`
+}
+
 // scheduleFollowUp enqueues another asynq trigger task if there are
 // still pending ops in task_pending_ops for this KB. Returns true when
 // a follow-up was scheduled.
@@ -854,130 +867,206 @@ func (s *wikiIngestService) mapOneDocument(
 	sourceRef := knowledgeID
 	oldPageSlugs := s.getExistingPageSlugsForKnowledge(ctx, payload.KnowledgeBaseID, knowledgeID)
 
-	// Pass 0: lightweight candidate slug extraction (skeleton only).
-	// On failure we fall back to the legacy single-shot extractor so the doc
-	// still gets ingested, just without chunk-level citations.
-	var (
-		extractedEntities []extractedItem
-		extractedConcepts []extractedItem
-		slugItems         map[string]extractedItem
-		pass0Failed       bool
-	)
-	logger.Infof(ctx, "wiki ingest: pass 0 — extracting candidate slugs for %s", knowledgeID)
-	extractSpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.extract", types.SpanKindSubSpan, types.JSONMap{
-		"content_chars": utf8.RuneCountInString(content),
-		"old_pages":     len(oldPageSlugs),
-	})
-	extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
-	if err != nil {
-		logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) — falling back to legacy extractor", knowledgeID, err)
-		pass0Failed = true
-		extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
-		if err != nil {
-			logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
-			s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
-			s.tracker().FailSpan(ctx, wikiSpan, "EXTRACT_FAILED", err.Error(), err)
-			return nil, nil, err
-		}
-	}
-	s.tracker().EndSpan(ctx, extractSpan, types.JSONMap{
-		"entities":         len(extractedEntities),
-		"concepts":         len(extractedConcepts),
-		"pass0_fallback":   pass0Failed,
-		"entities_preview": previewExtractedItems(extractedEntities, 8),
-		"concepts_preview": previewExtractedItems(extractedConcepts, 8),
-	})
+	// The map output is a pure function of frozen doc content + extraction
+	// granularity + synthesis model + prompt version. Cache it so
+	// re-ingesting an unchanged document skips the LLM calls.
+	docContentHash := types.StableContentHash(content)
+	granularity := batchCtx.ExtractionGranularity.Normalize()
+	promptVersion := s.wikiMapPromptVersion()
+	synthesisModelID := chatModel.GetModelID()
 
-	// Build slug listing for Summary's wiki-link input.
-	var summaryExtractedPages []string
-	for slug := range slugItems {
-		summaryExtractedPages = append(summaryExtractedPages, slug)
-	}
 	// Wiki summary slug is derived from the knowledge ID rather than the
 	// docTitle (which is typically the upload filename). Filename-based slugs
 	// like "summary/mx5280-pdf" expose the filename in cross-link contexts
 	// that downstream LLM prompts read; a UUID-based slug is uglier but
 	// hallucination-safe.
 	summarySlug := fmt.Sprintf("summary/%s", slugify(knowledgeID))
-	var slugListing string
-	for _, slug := range summaryExtractedPages {
-		if item, ok := slugItems[slug]; ok {
-			aliases := ""
-			if len(item.Aliases) > 0 {
-				aliases = fmt.Sprintf(" (Aliases: %s)", strings.Join(item.Aliases, ", "))
-			}
-			slugListing += fmt.Sprintf("- [[%s]] = %s%s\n", slug, item.Name, aliases)
-		} else {
-			slugListing += fmt.Sprintf("- [[%s]]\n", slug)
-		}
-	}
 
-	// Summary and chunk classification are independent given Pass 0 output —
-	// run them in parallel. Summary handles wiki-link injection; classification
-	// attaches concrete chunk IDs to each candidate slug.
 	var (
-		summaryContent string
-		summaryErr     error
-		citations      map[string][]string
-		newSlugs       []newSlugFromCitation
-		batchCount     int
+		extractedEntities []extractedItem
+		extractedConcepts []extractedItem
+		slugItems         map[string]extractedItem
+		pass0Failed       bool
+		summaryContent    string
+		summaryErr        error
+		citations         map[string][]string
+		newSlugs          []newSlugFromCitation
+		batchCount        int
+		cacheHit          bool
 	)
 
-	// Both calls run in parallel goroutines under the same wikiSpan
-	// parent — their subspans will visually overlap in the trace view,
-	// which correctly reflects their wall-clock concurrency.
-	summarySpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.summary", types.SpanKindSubSpan, types.JSONMap{
-		"content_chars":   utf8.RuneCountInString(content),
-		"extracted_slugs": len(summaryExtractedPages),
-	})
-	var classifySpan *Span
-	if !pass0Failed {
-		classifySpan = s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.classify", types.SpanKindSubSpan, types.JSONMap{
-			"chunks":     len(chunks),
-			"candidates": len(extractedEntities) + len(extractedConcepts),
-		})
+	if s.wikiMapCache != nil {
+		payloadStr, ok, cacheErr := s.wikiMapCache.Get(ctx, docContentHash, string(granularity), synthesisModelID, promptVersion)
+		if cacheErr != nil {
+			logger.Warnf(ctx, "wiki ingest: map cache get failed for %s: %v", knowledgeID, cacheErr)
+		} else if ok {
+			var cached wikiMapCachePayload
+			if json.Unmarshal([]byte(payloadStr), &cached) == nil {
+				extractedEntities = cached.ExtractedEntities
+				extractedConcepts = cached.ExtractedConcepts
+				summaryContent = cached.SummaryContent
+				summaryErr = nil
+				citations = cached.Citations
+				newSlugs = cached.NewSlugs
+				batchCount = cached.BatchCount
+				pass0Failed = cached.Pass0Failed
+				cacheHit = true
+				logger.Infof(ctx, "wiki ingest: map cache hit for %s", knowledgeID)
+
+				// Rebuild the pre-merge slugItems exactly as the original
+				// extraction path would have.
+				slugItems = make(map[string]extractedItem, len(extractedEntities)+len(extractedConcepts))
+				for _, item := range extractedEntities {
+					if item.Slug != "" && item.Name != "" {
+						slugItems[item.Slug] = item
+					}
+				}
+				for _, item := range extractedConcepts {
+					if item.Slug != "" && item.Name != "" {
+						slugItems[item.Slug] = item
+					}
+				}
+			} else {
+				logger.Warnf(ctx, "wiki ingest: map cache payload corrupt for %s, treating as miss", knowledgeID)
+			}
+		}
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		summaryContent, summaryErr = s.generateWithTemplate(ctx, chatModel, agent.WikiSummaryPrompt, map[string]string{
-			"Content":        content,
-			"Language":       lang,
-			"ExtractedSlugs": slugListing,
+	if !cacheHit {
+		// Pass 0: lightweight candidate slug extraction (skeleton only).
+		// On failure we fall back to the legacy single-shot extractor so the doc
+		// still gets ingested, just without chunk-level citations.
+		logger.Infof(ctx, "wiki ingest: pass 0 — extracting candidate slugs for %s", knowledgeID)
+		extractSpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.extract", types.SpanKindSubSpan, types.JSONMap{
+			"content_chars": utf8.RuneCountInString(content),
+			"old_pages":     len(oldPageSlugs),
 		})
-		if summaryErr != nil {
-			s.tracker().FailSpan(ctx, summarySpan, "SUMMARY_FAILED", summaryErr.Error(), summaryErr)
-		} else {
-			sumLine, sumBody := splitSummaryLine(summaryContent)
-			s.tracker().EndSpan(ctx, summarySpan, types.JSONMap{
-				"chars":        utf8.RuneCountInString(summaryContent),
-				"summary_line": previewText(sumLine, 160),
-				"body_preview": previewText(sumBody, 320),
+		extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
+		if err != nil {
+			logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) — falling back to legacy extractor", knowledgeID, err)
+			pass0Failed = true
+			extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
+			if err != nil {
+				logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
+				s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
+				s.tracker().FailSpan(ctx, wikiSpan, "EXTRACT_FAILED", err.Error(), err)
+				return nil, nil, err
+			}
+		}
+		s.tracker().EndSpan(ctx, extractSpan, types.JSONMap{
+			"entities":         len(extractedEntities),
+			"concepts":         len(extractedConcepts),
+			"pass0_fallback":   pass0Failed,
+			"entities_preview": previewExtractedItems(extractedEntities, 8),
+			"concepts_preview": previewExtractedItems(extractedConcepts, 8),
+		})
+
+		// Build slug listing for Summary's wiki-link input.
+		var summaryExtractedPages []string
+		for slug := range slugItems {
+			summaryExtractedPages = append(summaryExtractedPages, slug)
+		}
+		var slugListing string
+		for _, slug := range summaryExtractedPages {
+			if item, ok := slugItems[slug]; ok {
+				aliases := ""
+				if len(item.Aliases) > 0 {
+					aliases = fmt.Sprintf(" (Aliases: %s)", strings.Join(item.Aliases, ", "))
+				}
+				slugListing += fmt.Sprintf("- [[%s]] = %s%s\n", slug, item.Name, aliases)
+			} else {
+				slugListing += fmt.Sprintf("- [[%s]]\n", slug)
+			}
+		}
+
+		// Summary and chunk classification are independent given Pass 0 output —
+		// run them in parallel. Summary handles wiki-link injection; classification
+		// attaches concrete chunk IDs to each candidate slug.
+
+		// Both calls run in parallel goroutines under the same wikiSpan
+		// parent — their subspans will visually overlap in the trace view,
+		// which correctly reflects their wall-clock concurrency.
+		summarySpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.summary", types.SpanKindSubSpan, types.JSONMap{
+			"content_chars":   utf8.RuneCountInString(content),
+			"extracted_slugs": len(summaryExtractedPages),
+		})
+		var classifySpan *Span
+		if !pass0Failed {
+			classifySpan = s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.classify", types.SpanKindSubSpan, types.JSONMap{
+				"chunks":     len(chunks),
+				"candidates": len(extractedEntities) + len(extractedConcepts),
 			})
 		}
-	}()
-	go func() {
-		defer wg.Done()
-		// Skip citation pass when Pass 0 has fallen back to the legacy path —
-		// the legacy output already contains paraphrased Details, so chunk
-		// citations would be redundant and we'd spend LLM calls for nothing.
-		if pass0Failed {
-			citations = map[string][]string{}
-			return
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			summaryContent, summaryErr = s.generateWithTemplate(ctx, chatModel, agent.WikiSummaryPrompt, map[string]string{
+				"Content":        content,
+				"Language":       lang,
+				"ExtractedSlugs": slugListing,
+			})
+			if summaryErr != nil {
+				s.tracker().FailSpan(ctx, summarySpan, "SUMMARY_FAILED", summaryErr.Error(), summaryErr)
+			} else {
+				sumLine, sumBody := splitSummaryLine(summaryContent)
+				s.tracker().EndSpan(ctx, summarySpan, types.JSONMap{
+					"chars":        utf8.RuneCountInString(summaryContent),
+					"summary_line": previewText(sumLine, 160),
+					"body_preview": previewText(sumBody, 320),
+				})
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			// Skip citation pass when Pass 0 has fallen back to the legacy path —
+			// the legacy output already contains paraphrased Details, so chunk
+			// citations would be redundant and we'd spend LLM calls for nothing.
+			if pass0Failed {
+				citations = map[string][]string{}
+				return
+			}
+			candidatesXML := renderCandidateSlugsXML(extractedEntities, extractedConcepts)
+			citations, newSlugs, batchCount = s.classifyChunkCitations(ctx, chatModel, candidatesXML, chunks, lang, batchCtx)
+			s.tracker().EndSpan(ctx, classifySpan, types.JSONMap{
+				"cited_slugs":      len(citations),
+				"new_slugs":        len(newSlugs),
+				"batches":          batchCount,
+				"top_cited":        topCitedSlugs(citations, 8),
+				"new_slugs_sample": previewNewSlugs(newSlugs, 8),
+			})
+		}()
+		wg.Wait()
+
+		// Persist the successful map output for future unchanged rebuilds.
+		// Best-effort: a cache write failure must not fail the ingest.
+		if s.wikiMapCache != nil && summaryErr == nil {
+			cachePayload := wikiMapCachePayload{
+				ExtractedEntities: extractedEntities,
+				ExtractedConcepts: extractedConcepts,
+				SummaryContent:    summaryContent,
+				Citations:         citations,
+				NewSlugs:          newSlugs,
+				BatchCount:        batchCount,
+				Pass0Failed:       pass0Failed,
+			}
+			if payloadBytes, jerr := json.Marshal(cachePayload); jerr == nil {
+				cacheRow := &types.WikiMapCache{
+					DocContentHash: docContentHash,
+					Granularity:    string(granularity),
+					SynthesisModel: synthesisModelID,
+					PromptVersion:  promptVersion,
+					Payload:        string(payloadBytes),
+				}
+				if putErr := s.wikiMapCache.Put(ctx, cacheRow); putErr != nil {
+					logger.Warnf(ctx, "wiki ingest: map cache put failed for %s: %v", knowledgeID, putErr)
+				}
+			} else {
+				logger.Warnf(ctx, "wiki ingest: map cache payload marshal failed for %s: %v", knowledgeID, jerr)
+			}
 		}
-		candidatesXML := renderCandidateSlugsXML(extractedEntities, extractedConcepts)
-		citations, newSlugs, batchCount = s.classifyChunkCitations(ctx, chatModel, candidatesXML, chunks, lang, batchCtx)
-		s.tracker().EndSpan(ctx, classifySpan, types.JSONMap{
-			"cited_slugs":      len(citations),
-			"new_slugs":        len(newSlugs),
-			"batches":          batchCount,
-			"top_cited":        topCitedSlugs(citations, 8),
-			"new_slugs_sample": previewNewSlugs(newSlugs, 8),
-		})
-	}()
-	wg.Wait()
+	}
 
 	// Merge citations back into the item structs (non-failing; items without
 	// citations simply keep their Description+Details fallback).

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -172,6 +172,33 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewWikiLogEntryRepository))
 	must(container.Provide(repository.NewTaskPendingOpsRepository))
 	must(container.Provide(repository.NewTaskDeadLetterRepository))
+// Content-addressed VLM (OCR/Caption) cache repo. Resolved by dig into
+// ImageMultimodalService (NewImageMultimodalService now asks for an
+// apprepo.VLMCacheRepo). nil-safe at the service: lite/test paths that
+// build the service without this provider will hit the no-cache fallback
+// in cachedPredict, but in the production container this provider makes
+// dig resolve the new constructor param automatically — no Name binding
+// is needed because the param is an interface with a single provider.
+must(container.Provide(repository.NewVLMCacheRepo))
+// Embedding cache + dig.As binding to the embedding-layer VectorCacheStore
+// interface. NewEmbeddingCacheRepo returns an EmbeddingCacheRepo (repo
+// layer); dig.As re-exposes that same value as embedding.VectorCacheStore
+// (the interface NewModelService asks for), so the model service resolves the
+// cache without the model package importing the repository package.
+must(container.Provide(repository.NewEmbeddingCacheRepo, dig.As(new(embedding.VectorCacheStore))))
+// Wiki per-document map cache repo. Resolved by dig into
+// wikiIngestService (NewWikiIngestService now asks for an
+// apprepo.WikiMapCacheRepo). Same single-provider pattern as VLM.
+must(container.Provide(repository.NewWikiMapCacheRepo))
+// GraphRAG per-chunk extraction cache repo. Resolved by dig into
+// ChunkExtractService (NewChunkExtractService now asks for an
+// apprepo.GraphChunkCacheRepo).
+must(container.Provide(repository.NewGraphChunkCacheRepo))
+// Parse product cache repo (markdown + image refs + metadata keyed by
+// file bytes + parser engine + parser config). Resolved by dig into
+// knowledgeService (NewKnowledgeService now asks for an
+// apprepo.ParseProductCacheRepo).
+must(container.Provide(repository.NewParseProductCacheRepo))
 
 	// MCP manager for managing MCP client connections
 	logger.Debugf(ctx, "[Container] Registering MCP manager...")

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -199,6 +199,12 @@ must(container.Provide(repository.NewGraphChunkCacheRepo))
 // knowledgeService (NewKnowledgeService now asks for an
 // apprepo.ParseProductCacheRepo).
 must(container.Provide(repository.NewParseProductCacheRepo))
+// Summary generation cache repo. Resolved by dig into knowledgeService
+// (NewKnowledgeService now asks for an apprepo.SummaryCacheRepo).
+must(container.Provide(repository.NewSummaryCacheRepo))
+// Question generation cache repo. Resolved by dig into knowledgeService
+// (NewKnowledgeService now asks for an apprepo.QuestionCacheRepo).
+must(container.Provide(repository.NewQuestionCacheRepo))
 
 	// MCP manager for managing MCP client connections
 	logger.Debugf(ctx, "[Container] Registering MCP manager...")

--- a/internal/models/embedding/cached_embedder.go
+++ b/internal/models/embedding/cached_embedder.go
@@ -1,0 +1,158 @@
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// VectorCacheStore is the minimal interface the cachedEmbedder needs to look
+// up and persist vectors. Implemented by repository.EmbeddingCacheRepo.
+// Keeping it minimal here avoids importing the repository package (which
+// would create a cycle: repository → types, embedding → repository → types
+// is fine, but embedding is a lower layer than repository).
+type VectorCacheStore interface {
+	// GetBatch returns a map of text_hash -> vector for the keys that hit.
+	// Misses are absent from the map.
+	GetBatch(ctx context.Context, textHashes []string, modelID string, dim int) (map[string][]float32, error)
+	// Put persists rows. Each row carries (text_hash, model_id, dim, vector-as-JSON).
+	Put(ctx context.Context, rows []types.EmbeddingCache) error
+}
+
+// CachedEmbedder wraps an Embedder with a content-addressed vector cache.
+// On Embed / BatchEmbed it normalizes each text, computes
+// hash(normalized_text) + model_id + dim, batch-looks-up miss keys in the
+// cache, calls the inner embedder ONLY for misses, and writes the computed
+// vectors back. Cross-document identical-text dedup falls out for free
+// because the key excludes doc_id / chunk_id.
+//
+// The wrapper is placed OUTERMOST in NewEmbedder's chain (after debug +
+// langfuse) so cache hits record no inner call and tracing still sees the
+// underlying provider when a real Embed happens.
+type cachedEmbedder struct {
+	inner Embedder
+	store VectorCacheStore
+}
+
+// NewCachedEmbedder wraps an embedder with a content-addressed cache. If
+// store is nil the wrapper is a no-op passthrough (so lite/test paths that
+// don't wire a DB don't break).
+func NewCachedEmbedder(inner Embedder, store VectorCacheStore) Embedder {
+	if store == nil || inner == nil {
+		return inner
+	}
+	return &cachedEmbedder{inner: inner, store: store}
+}
+
+func (c *cachedEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	vecs, err := c.BatchEmbed(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(vecs) == 0 {
+		return nil, fmt.Errorf("cached embed returned no vector")
+	}
+	return vecs[0], nil
+}
+
+func (c *cachedEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	modelID := c.inner.GetModelID()
+	dim := c.inner.GetDimensions()
+
+	// Compute keys (normalized text hash) for every input.
+	keys := make([]string, len(texts))
+	keyToIdx := make(map[string][]int, len(texts))
+	for i, t := range texts {
+		k := types.StableContentHash(t)
+		keys[i] = k
+		keyToIdx[k] = append(keyToIdx[k], i)
+	}
+
+	// Batch lookup — one query for all keys.
+	hits, err := c.store.GetBatch(ctx, keys, modelID, dim)
+	if err != nil {
+		// Cache failure is non-fatal: fall through to the inner embedder.
+		// The whole batch becomes a miss; we'll write it back after.
+		hits = nil
+	}
+
+	// Assemble results; collect miss positions grouped by unique content key
+	// so duplicate texts in the same batch share one inner embedding call.
+	out := make([][]float32, len(texts))
+	var missIdx [][]int
+	var missTexts []string
+	var missKeys []string
+
+	seen := make(map[string]struct{}, len(texts))
+	for _, k := range keys {
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+
+		idxs := keyToIdx[k]
+		if v, ok := hits[k]; ok && len(v) > 0 {
+			for _, idx := range idxs {
+				out[idx] = v
+			}
+			continue
+		}
+		missKeys = append(missKeys, k)
+		missTexts = append(missTexts, texts[idxs[0]])
+		missIdx = append(missIdx, idxs)
+	}
+
+	if len(missTexts) == 0 {
+		// Full cache hit — no inner call.
+		return out, nil
+	}
+
+	// Embed only the unique misses.
+	missVecs, err := c.inner.BatchEmbed(ctx, missTexts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Place misses into the output and prepare cache rows.
+	rows := make([]types.EmbeddingCache, 0, len(missKeys))
+	for j, v := range missVecs {
+		for _, idx := range missIdx[j] {
+			out[idx] = v
+		}
+		// Serialize vector as JSON for DB portability.
+		vecJSON, _ := json.Marshal(v)
+		rows = append(rows, types.EmbeddingCache{
+			TextHash:  missKeys[j],
+			ModelID:   modelID,
+			Dimension: dim,
+			Vector:    string(vecJSON),
+		})
+	}
+
+	// Persist misses (best-effort; ON CONFLICT DO NOTHING at the repo level).
+	if len(rows) > 0 {
+		if perr := c.store.Put(ctx, rows); perr != nil {
+			// Non-fatal: the vector is already in `out`; we just failed to
+			// cache it for next time.
+			_ = perr
+		}
+	}
+	return out, nil
+}
+
+func (c *cachedEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string) ([][]float32, error) {
+	// The pool variant delegates to BatchEmbed so the cache applies uniformly.
+	return c.BatchEmbed(ctx, texts)
+}
+
+func (c *cachedEmbedder) GetModelName() string { return c.inner.GetModelName() }
+func (c *cachedEmbedder) GetDimensions() int   { return c.inner.GetDimensions() }
+func (c *cachedEmbedder) GetModelID() string   { return c.inner.GetModelID() }
+
+// Compile-time guard: cachedEmbedder must satisfy Embedder.
+var _ Embedder = (*cachedEmbedder)(nil)

--- a/internal/models/embedding/cached_embedder_test.go
+++ b/internal/models/embedding/cached_embedder_test.go
@@ -1,0 +1,506 @@
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// mockEmbedder is a test double for the Embedder interface.
+type mockEmbedder struct {
+	modelName string
+	dim       int
+	modelID   string
+
+	batchCalls int
+	batchArgs  []string
+
+	// vectors maps raw input text to the vector that BatchEmbed should return.
+	// If a text is absent, BatchEmbed returns a deterministic fallback vector.
+	vectors map[string][]float32
+
+	// err, if non-nil, causes BatchEmbed to return this error.
+	err error
+}
+
+func (m *mockEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	vecs, err := m.BatchEmbed(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(vecs) == 0 {
+		return nil, errors.New("mock embed returned no vector")
+	}
+	return vecs[0], nil
+}
+
+func (m *mockEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	m.batchCalls++
+	m.batchArgs = append([]string{}, texts...)
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		if v, ok := m.vectors[t]; ok {
+			out[i] = v
+			continue
+		}
+		// Deterministic fallback so tests that do not pre-seed every text still
+		// receive a stable, dimension-correct vector.
+		v := make([]float32, m.dim)
+		for j := range v {
+			v[j] = float32(i+1)*0.1 + float32(j)*0.01
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+func (m *mockEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string) ([][]float32, error) {
+	return m.BatchEmbed(ctx, texts)
+}
+
+func (m *mockEmbedder) GetModelName() string { return m.modelName }
+func (m *mockEmbedder) GetDimensions() int   { return m.dim }
+func (m *mockEmbedder) GetModelID() string   { return m.modelID }
+
+// mockVectorCacheStore is a test double for VectorCacheStore.
+type mockVectorCacheStore struct {
+	entries map[string][]float32 // text_hash -> vector
+
+	getCalls       int
+	getArgsHashes  []string
+	getArgsModelID string
+	getArgsDim     int
+
+	putCalls int
+	putRows  []types.EmbeddingCache
+
+	getErr error
+	putErr error
+}
+
+func (m *mockVectorCacheStore) GetBatch(ctx context.Context, textHashes []string, modelID string, dim int) (map[string][]float32, error) {
+	m.getCalls++
+	m.getArgsHashes = append([]string{}, textHashes...)
+	m.getArgsModelID = modelID
+	m.getArgsDim = dim
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+
+	hits := make(map[string][]float32, len(textHashes))
+	for _, h := range textHashes {
+		if v, ok := m.entries[h]; ok {
+			hits[h] = v
+		}
+	}
+	return hits, nil
+}
+
+func (m *mockVectorCacheStore) Put(ctx context.Context, rows []types.EmbeddingCache) error {
+	m.putCalls++
+	m.putRows = append(m.putRows, rows...)
+	if m.putErr != nil {
+		return m.putErr
+	}
+	if m.entries == nil {
+		m.entries = make(map[string][]float32)
+	}
+	for _, r := range rows {
+		var vec []float32
+		if err := json.Unmarshal([]byte(r.Vector), &vec); err != nil {
+			continue
+		}
+		m.entries[r.TextHash] = vec
+	}
+	return nil
+}
+
+func floatsEqual(a, b []float32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCachedEmbedder_NilStorePassthrough(t *testing.T) {
+	t.Parallel()
+
+	inner := &mockEmbedder{modelID: "m", dim: 4}
+	if got := NewCachedEmbedder(inner, nil); got != inner {
+		t.Fatalf("store=nil: expected inner itself, got %T", got)
+	}
+
+	if got := NewCachedEmbedder(nil, &mockVectorCacheStore{}); got != nil {
+		t.Fatalf("inner=nil: expected nil, got %T", got)
+	}
+
+	if got := NewCachedEmbedder(nil, nil); got != nil {
+		t.Fatalf("both nil: expected nil, got %T", got)
+	}
+}
+
+func TestCachedEmbedder_FullCacheHit_NoInnerCall(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	texts := []string{"hello world", "foo bar"}
+	vec1 := []float32{0.1, 0.2, 0.3, 0.4}
+	vec2 := []float32{0.5, 0.6, 0.7, 0.8}
+
+	store := &mockVectorCacheStore{
+		entries: map[string][]float32{
+			types.StableContentHash(texts[0]): vec1,
+			types.StableContentHash(texts[1]): vec2,
+		},
+	}
+	inner := &mockEmbedder{modelID: "test-model", dim: 4}
+	cached := NewCachedEmbedder(inner, store).(*cachedEmbedder)
+
+	out, err := cached.BatchEmbed(ctx, texts)
+	if err != nil {
+		t.Fatalf("BatchEmbed error: %v", err)
+	}
+	if inner.batchCalls != 0 {
+		t.Fatalf("expected 0 inner calls, got %d", inner.batchCalls)
+	}
+	if len(out) != len(texts) {
+		t.Fatalf("expected %d vectors, got %d", len(texts), len(out))
+	}
+	if !floatsEqual(out[0], vec1) {
+		t.Fatalf("first vector mismatch: got %v want %v", out[0], vec1)
+	}
+	if !floatsEqual(out[1], vec2) {
+		t.Fatalf("second vector mismatch: got %v want %v", out[1], vec2)
+	}
+}
+
+func TestCachedEmbedder_FullMiss_CallsInnerAndPuts(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	texts := []string{"alpha", "beta"}
+	vec1 := []float32{0.1, 0.2, 0.3, 0.4}
+	vec2 := []float32{0.5, 0.6, 0.7, 0.8}
+
+	inner := &mockEmbedder{
+		modelID: "test-model",
+		dim:     4,
+		vectors: map[string][]float32{
+			texts[0]: vec1,
+			texts[1]: vec2,
+		},
+	}
+	store := &mockVectorCacheStore{entries: map[string][]float32{}}
+	cached := NewCachedEmbedder(inner, store).(*cachedEmbedder)
+
+	out, err := cached.BatchEmbed(ctx, texts)
+	if err != nil {
+		t.Fatalf("BatchEmbed error: %v", err)
+	}
+
+	if inner.batchCalls != 1 {
+		t.Fatalf("expected 1 inner call, got %d", inner.batchCalls)
+	}
+	if len(inner.batchArgs) != len(texts) {
+		t.Fatalf("expected inner called with %d texts, got %d", len(texts), len(inner.batchArgs))
+	}
+	for i, want := range texts {
+		if inner.batchArgs[i] != want {
+			t.Fatalf("inner arg[%d]: got %q want %q", i, inner.batchArgs[i], want)
+		}
+	}
+
+	if store.putCalls != 1 {
+		t.Fatalf("expected 1 Put call, got %d", store.putCalls)
+	}
+	if len(store.putRows) != len(texts) {
+		t.Fatalf("expected %d Put rows, got %d", len(texts), len(store.putRows))
+	}
+
+	wantHashes := map[string][]float32{
+		types.StableContentHash(texts[0]): vec1,
+		types.StableContentHash(texts[1]): vec2,
+	}
+	for i, row := range store.putRows {
+		wantVec := wantHashes[row.TextHash]
+		if wantVec == nil {
+			t.Fatalf("unexpected TextHash in Put row: %s", row.TextHash)
+		}
+		if row.ModelID != inner.modelID {
+			t.Fatalf("Put row ModelID: got %q want %q", row.ModelID, inner.modelID)
+		}
+		if row.Dimension != inner.dim {
+			t.Fatalf("Put row Dimension: got %d want %d", row.Dimension, inner.dim)
+		}
+		var gotVec []float32
+		if err := json.Unmarshal([]byte(row.Vector), &gotVec); err != nil {
+			t.Fatalf("unmarshal Put vector: %v", err)
+		}
+		if !floatsEqual(gotVec, wantVec) {
+			t.Fatalf("Put vector mismatch for %s: got %v want %v", row.TextHash, gotVec, wantVec)
+		}
+		_ = i
+	}
+
+	if !floatsEqual(out[0], vec1) || !floatsEqual(out[1], vec2) {
+		t.Fatalf("output vectors mismatch: got %v %v", out[0], out[1])
+	}
+}
+
+func TestCachedEmbedder_PartialHit_OnlyMissesToInner(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	texts := []string{"cached text", "miss text"}
+	cachedVec := []float32{1.0, 2.0, 3.0, 4.0}
+	missVec := []float32{5.0, 6.0, 7.0, 8.0}
+
+	store := &mockVectorCacheStore{
+		entries: map[string][]float32{
+			types.StableContentHash(texts[0]): cachedVec,
+		},
+	}
+	inner := &mockEmbedder{
+		modelID: "test-model",
+		dim:     4,
+		vectors: map[string][]float32{
+			texts[1]: missVec,
+		},
+	}
+	cached := NewCachedEmbedder(inner, store).(*cachedEmbedder)
+
+	out, err := cached.BatchEmbed(ctx, texts)
+	if err != nil {
+		t.Fatalf("BatchEmbed error: %v", err)
+	}
+
+	if inner.batchCalls != 1 {
+		t.Fatalf("expected 1 inner call, got %d", inner.batchCalls)
+	}
+	if len(inner.batchArgs) != 1 || inner.batchArgs[0] != texts[1] {
+		t.Fatalf("expected inner called with only miss text %q, got %v", texts[1], inner.batchArgs)
+	}
+
+	if !floatsEqual(out[0], cachedVec) {
+		t.Fatalf("hit vector mismatch: got %v want %v", out[0], cachedVec)
+	}
+	if !floatsEqual(out[1], missVec) {
+		t.Fatalf("miss vector mismatch: got %v want %v", out[1], missVec)
+	}
+}
+
+func TestCachedEmbedder_SecondCallHitsAfterPut(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	texts := []string{"first", "second"}
+	vec1 := []float32{0.1, 0.2, 0.3, 0.4}
+	vec2 := []float32{0.5, 0.6, 0.7, 0.8}
+
+	inner := &mockEmbedder{
+		modelID: "test-model",
+		dim:     4,
+		vectors: map[string][]float32{
+			texts[0]: vec1,
+			texts[1]: vec2,
+		},
+	}
+	store := &mockVectorCacheStore{entries: map[string][]float32{}}
+	cached := NewCachedEmbedder(inner, store).(*cachedEmbedder)
+
+	if _, err := cached.BatchEmbed(ctx, texts); err != nil {
+		t.Fatalf("first BatchEmbed error: %v", err)
+	}
+	if inner.batchCalls != 1 || store.putCalls != 1 {
+		t.Fatalf("first call: expected 1 inner call and 1 Put, got %d inner, %d put", inner.batchCalls, store.putCalls)
+	}
+
+	out2, err := cached.BatchEmbed(ctx, texts)
+	if err != nil {
+		t.Fatalf("second BatchEmbed error: %v", err)
+	}
+	if inner.batchCalls != 1 {
+		t.Fatalf("second call: expected inner still called once, got %d", inner.batchCalls)
+	}
+	if store.putCalls != 1 {
+		t.Fatalf("second call: expected Put still called once, got %d", store.putCalls)
+	}
+	if !floatsEqual(out2[0], vec1) || !floatsEqual(out2[1], vec2) {
+		t.Fatalf("second call output mismatch: got %v %v", out2[0], out2[1])
+	}
+}
+
+func TestCachedEmbedder_DuplicateTextInBatch_SameKey(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	text := "duplicate"
+	vec := []float32{0.9, 0.8, 0.7, 0.6}
+
+	inner := &mockEmbedder{
+		modelID: "test-model",
+		dim:     4,
+		vectors: map[string][]float32{text: vec},
+	}
+	store := &mockVectorCacheStore{entries: map[string][]float32{}}
+	cached := NewCachedEmbedder(inner, store).(*cachedEmbedder)
+
+	out, err := cached.BatchEmbed(ctx, []string{text, text})
+	if err != nil {
+		t.Fatalf("BatchEmbed error: %v", err)
+	}
+
+	if inner.batchCalls != 1 {
+		t.Fatalf("expected 1 inner call for duplicate key, got %d", inner.batchCalls)
+	}
+	if len(inner.batchArgs) != 1 || inner.batchArgs[0] != text {
+		t.Fatalf("expected inner called with 1 unique text %q, got %v", text, inner.batchArgs)
+	}
+
+	if len(out) != 2 {
+		t.Fatalf("expected 2 output vectors, got %d", len(out))
+	}
+	if !floatsEqual(out[0], vec) {
+		t.Fatalf("first duplicate vector mismatch: got %v want %v", out[0], vec)
+	}
+	if !floatsEqual(out[1], vec) {
+		t.Fatalf("second duplicate vector mismatch: got %v want %v", out[1], vec)
+	}
+}
+
+func TestCachedEmbedder_PutFailureDoesNotFailEmbed(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	text := "hello"
+	vec := []float32{0.1, 0.2, 0.3, 0.4}
+
+	inner := &mockEmbedder{
+		modelID: "test-model",
+		dim:     4,
+		vectors: map[string][]float32{text: vec},
+	}
+	store := &mockVectorCacheStore{
+		entries: map[string][]float32{},
+		putErr:  errors.New("put failed"),
+	}
+	cached := NewCachedEmbedder(inner, store).(*cachedEmbedder)
+
+	out, err := cached.BatchEmbed(ctx, []string{text})
+	if err != nil {
+		t.Fatalf("BatchEmbed should not fail when Put fails: %v", err)
+	}
+	if store.putCalls != 1 {
+		t.Fatalf("expected 1 Put call, got %d", store.putCalls)
+	}
+	if len(out) != 1 || !floatsEqual(out[0], vec) {
+		t.Fatalf("expected vector %v, got %v", vec, out)
+	}
+}
+
+func TestCachedEmbedder_GetBatchFailure_FallsBackToInner(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	text := "hello"
+	vec := []float32{0.1, 0.2, 0.3, 0.4}
+
+	inner := &mockEmbedder{
+		modelID: "test-model",
+		dim:     4,
+		vectors: map[string][]float32{text: vec},
+	}
+	store := &mockVectorCacheStore{
+		entries: map[string][]float32{},
+		getErr:  errors.New("get failed"),
+	}
+	cached := NewCachedEmbedder(inner, store).(*cachedEmbedder)
+
+	out, err := cached.BatchEmbed(ctx, []string{text})
+	if err != nil {
+		t.Fatalf("BatchEmbed should not fail when GetBatch fails: %v", err)
+	}
+	if inner.batchCalls != 1 {
+		t.Fatalf("expected 1 inner fallback call, got %d", inner.batchCalls)
+	}
+	if len(out) != 1 || !floatsEqual(out[0], vec) {
+		t.Fatalf("expected vector %v, got %v", vec, out)
+	}
+}
+
+func TestCachedEmbedder_EmptyBatch(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	inner := &mockEmbedder{modelID: "test-model", dim: 4}
+	store := &mockVectorCacheStore{}
+	cached := NewCachedEmbedder(inner, store).(*cachedEmbedder)
+
+	out, err := cached.BatchEmbed(ctx, []string{})
+	if err != nil {
+		t.Fatalf("empty batch should not error: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected empty output, got %d vectors", len(out))
+	}
+	if inner.batchCalls != 0 {
+		t.Fatalf("expected 0 inner calls, got %d", inner.batchCalls)
+	}
+	if store.getCalls != 0 {
+		t.Fatalf("expected 0 GetBatch calls, got %d", store.getCalls)
+	}
+	if store.putCalls != 0 {
+		t.Fatalf("expected 0 Put calls, got %d", store.putCalls)
+	}
+}
+
+func TestCachedEmbedder_EmbedDelegatesToBatchEmbed(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	text := "hello"
+	vec := []float32{0.1, 0.2, 0.3, 0.4}
+
+	inner := &mockEmbedder{
+		modelID: "test-model",
+		dim:     4,
+		vectors: map[string][]float32{text: vec},
+	}
+	store := &mockVectorCacheStore{}
+	cached := NewCachedEmbedder(inner, store).(*cachedEmbedder)
+
+	out, err := cached.Embed(ctx, text)
+	if err != nil {
+		t.Fatalf("Embed error: %v", err)
+	}
+	if !floatsEqual(out, vec) {
+		t.Fatalf("Embed vector mismatch: got %v want %v", out, vec)
+	}
+	if inner.batchCalls != 1 {
+		t.Fatalf("expected 1 BatchEmbed call, got %d", inner.batchCalls)
+	}
+	if len(inner.batchArgs) != 1 || inner.batchArgs[0] != text {
+		t.Fatalf("expected BatchEmbed called with %q, got %v", text, inner.batchArgs)
+	}
+
+	// Error propagation from BatchEmbed to Embed.
+	wantErr := errors.New("embed failed")
+	inner2 := &mockEmbedder{modelID: "test-model", dim: 4, err: wantErr}
+	store2 := &mockVectorCacheStore{}
+	cached2 := NewCachedEmbedder(inner2, store2).(*cachedEmbedder)
+	if _, err := cached2.Embed(ctx, text); err != wantErr {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+}

--- a/internal/types/content_cache.go
+++ b/internal/types/content_cache.go
@@ -1,0 +1,88 @@
+package types
+
+import "time"
+
+// VLMCacheKey identifies a cached VLM (OCR/Caption) result by content +
+// model + prompt. The cache is content-addressed (no tenant_id, no doc_id):
+// the same image bytes under the same VLM model and prompt version MUST
+// yield the same canonical OCR/caption text regardless of who owns the
+// image. Tenant isolation is enforced at the read layer (a worker only
+// reads image bytes it owns), not at the cache layer.
+type VLMCache struct {
+	ImageHash     string    `gorm:"column:image_hash;type:varchar(64);primaryKey"`
+	ModelID       string    `gorm:"column:model_id;type:varchar(64);primaryKey"`
+	PromptVersion string    `gorm:"column:prompt_version;type:varchar(64);primaryKey"`
+	PromptKind    string    `gorm:"column:prompt_kind;type:varchar(32);primaryKey"`
+	OutputText    string    `gorm:"column:output_text;type:text"`
+	CreatedAt     time.Time `gorm:"column:created_at;autoCreateTime"`
+}
+
+func (VLMCache) TableName() string { return "vlm_cache" }
+
+// EmbeddingCache stores a vector for a (normalized text hash, model, dim)
+// tuple. The key excludes doc_id and chunk_id so identical text in two
+// different documents dedups to a single cached vector.
+//
+// Vector is serialized as a JSON array of floats (TEXT column) for full DB
+// portability (sqlite / mysql / postgres). Retrieval-side vector stores
+// remain untouched — this cache only short-circuits the Embed call.
+type EmbeddingCache struct {
+	TextHash  string    `gorm:"column:text_hash;type:varchar(128);primaryKey"`
+	ModelID   string    `gorm:"column:model_id;type:varchar(64);primaryKey"`
+	Dimension int       `gorm:"column:dimension;primaryKey"`
+	Vector    string    `gorm:"column:vector;type:text"`
+	CreatedAt time.Time `gorm:"column:created_at;autoCreateTime"`
+}
+
+func (EmbeddingCache) TableName() string { return "embedding_cache" }
+
+// WikiMapCache stores the complete per-document map output of
+// mapOneDocument (extracted entities/concepts, summary, citations,
+// new-slugs) keyed by frozen doc content hash + extraction granularity +
+// synthesis model + prompt version. A hit skips extract/dedup/summary/
+// classify and jumps straight to reduce.
+//
+// Payload is an opaque JSON blob; the schema of that blob is owned by the
+// wiki ingest service, not by the cache table.
+type WikiMapCache struct {
+	DocContentHash  string    `gorm:"column:doc_content_hash;type:varchar(128);primaryKey"`
+	Granularity     string    `gorm:"column:granularity;type:varchar(32);primaryKey"`
+	SynthesisModel  string    `gorm:"column:synthesis_model_id;type:varchar(64);primaryKey"`
+	PromptVersion   string    `gorm:"column:prompt_version;type:varchar(64);primaryKey"`
+	Payload         string    `gorm:"column:payload;type:text"`
+	CreatedAt       time.Time `gorm:"column:created_at;autoCreateTime"`
+}
+
+func (WikiMapCache) TableName() string { return "wiki_map_cache" }
+
+// GraphChunkCache stores per-chunk GraphRAG extraction output (entities +
+// relationships for that chunk) keyed by frozen chunk content hash +
+// extract config hash + chat model + prompt version.
+type GraphChunkCache struct {
+	ChunkContentHash string    `gorm:"column:chunk_content_hash;type:varchar(128);primaryKey"`
+	ExtractConfigHash string   `gorm:"column:extract_config_hash;type:varchar(128);primaryKey"`
+	ChatModelID      string    `gorm:"column:chat_model_id;type:varchar(64);primaryKey"`
+	PromptVersion    string    `gorm:"column:prompt_version;type:varchar(64);primaryKey"`
+	Payload          string    `gorm:"column:payload;type:text"`
+	CreatedAt        time.Time `gorm:"column:created_at;autoCreateTime"`
+}
+
+func (GraphChunkCache) TableName() string { return "graph_chunk_cache" }
+
+// ParseProductCache stores the parse step's full ReadResult (markdown +
+// image references + image byte hashes + metadata) keyed by file bytes
+// hash + parser engine + parser config + render config. A hit skips the
+// CPU-hour-scale re-render of scanned documents.
+//
+// Image byte hashes are stored in the payload so the VLM cache (keyed on
+// image bytes) still governs whether OCR/Caption re-runs.
+type ParseProductCache struct {
+	FileHash         string    `gorm:"column:file_hash;type:varchar(128);primaryKey"`
+	ParserEngine     string    `gorm:"column:parser_engine;type:varchar(32);primaryKey"`
+	ParserConfigHash string    `gorm:"column:parser_config_hash;type:varchar(128);primaryKey"`
+	RenderConfigHash string    `gorm:"column:render_config_hash;type:varchar(128);primaryKey"`
+	Payload          string    `gorm:"column:payload;type:text"`
+	CreatedAt        time.Time `gorm:"column:created_at;autoCreateTime"`
+}
+
+func (ParseProductCache) TableName() string { return "parse_product_cache" }

--- a/internal/types/content_cache.go
+++ b/internal/types/content_cache.go
@@ -45,12 +45,12 @@ func (EmbeddingCache) TableName() string { return "embedding_cache" }
 // Payload is an opaque JSON blob; the schema of that blob is owned by the
 // wiki ingest service, not by the cache table.
 type WikiMapCache struct {
-	DocContentHash  string    `gorm:"column:doc_content_hash;type:varchar(128);primaryKey"`
-	Granularity     string    `gorm:"column:granularity;type:varchar(32);primaryKey"`
-	SynthesisModel  string    `gorm:"column:synthesis_model_id;type:varchar(64);primaryKey"`
-	PromptVersion   string    `gorm:"column:prompt_version;type:varchar(64);primaryKey"`
-	Payload         string    `gorm:"column:payload;type:text"`
-	CreatedAt       time.Time `gorm:"column:created_at;autoCreateTime"`
+	DocContentHash string    `gorm:"column:doc_content_hash;type:varchar(128);primaryKey"`
+	Granularity    string    `gorm:"column:granularity;type:varchar(32);primaryKey"`
+	SynthesisModel string    `gorm:"column:synthesis_model_id;type:varchar(64);primaryKey"`
+	PromptVersion  string    `gorm:"column:prompt_version;type:varchar(64);primaryKey"`
+	Payload        string    `gorm:"column:payload;type:text"`
+	CreatedAt      time.Time `gorm:"column:created_at;autoCreateTime"`
 }
 
 func (WikiMapCache) TableName() string { return "wiki_map_cache" }
@@ -59,12 +59,12 @@ func (WikiMapCache) TableName() string { return "wiki_map_cache" }
 // relationships for that chunk) keyed by frozen chunk content hash +
 // extract config hash + chat model + prompt version.
 type GraphChunkCache struct {
-	ChunkContentHash string    `gorm:"column:chunk_content_hash;type:varchar(128);primaryKey"`
-	ExtractConfigHash string   `gorm:"column:extract_config_hash;type:varchar(128);primaryKey"`
-	ChatModelID      string    `gorm:"column:chat_model_id;type:varchar(64);primaryKey"`
-	PromptVersion    string    `gorm:"column:prompt_version;type:varchar(64);primaryKey"`
-	Payload          string    `gorm:"column:payload;type:text"`
-	CreatedAt        time.Time `gorm:"column:created_at;autoCreateTime"`
+	ChunkContentHash  string    `gorm:"column:chunk_content_hash;type:varchar(128);primaryKey"`
+	ExtractConfigHash string    `gorm:"column:extract_config_hash;type:varchar(128);primaryKey"`
+	ChatModelID       string    `gorm:"column:chat_model_id;type:varchar(64);primaryKey"`
+	PromptVersion     string    `gorm:"column:prompt_version;type:varchar(64);primaryKey"`
+	Payload           string    `gorm:"column:payload;type:text"`
+	CreatedAt         time.Time `gorm:"column:created_at;autoCreateTime"`
 }
 
 func (GraphChunkCache) TableName() string { return "graph_chunk_cache" }
@@ -86,3 +86,31 @@ type ParseProductCache struct {
 }
 
 func (ParseProductCache) TableName() string { return "parse_product_cache" }
+
+// SummaryCache stores the LLM-generated document summary keyed by the
+// frozen document content hash + model + prompt version + config hash.
+// A hit skips the summary LLM call.
+type SummaryCache struct {
+	DocContentHash string    `gorm:"column:doc_content_hash;type:varchar(128);primaryKey"`
+	ModelID        string    `gorm:"column:model_id;type:varchar(64);primaryKey"`
+	PromptVersion  string    `gorm:"column:prompt_version;type:varchar(64);primaryKey"`
+	ConfigHash     string    `gorm:"column:config_hash;type:varchar(64);primaryKey"`
+	Summary        string    `gorm:"column:summary;type:text"`
+	CreatedAt      time.Time `gorm:"column:created_at;autoCreateTime"`
+}
+
+func (SummaryCache) TableName() string { return "summary_cache" }
+
+// QuestionCache stores the LLM-generated chunk questions keyed by the
+// frozen chunk content hash + model + prompt version + config hash.
+// A hit skips the question-generation LLM call.
+type QuestionCache struct {
+	ChunkContentHash string    `gorm:"column:chunk_content_hash;type:varchar(128);primaryKey"`
+	ModelID          string    `gorm:"column:model_id;type:varchar(64);primaryKey"`
+	PromptVersion    string    `gorm:"column:prompt_version;type:varchar(64);primaryKey"`
+	ConfigHash       string    `gorm:"column:config_hash;type:varchar(64);primaryKey"`
+	Payload          string    `gorm:"column:payload;type:text"`
+	CreatedAt        time.Time `gorm:"column:created_at;autoCreateTime"`
+}
+
+func (QuestionCache) TableName() string { return "question_cache" }

--- a/internal/types/contentutil.go
+++ b/internal/types/contentutil.go
@@ -1,0 +1,179 @@
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+	"golang.org/x/text/width"
+)
+
+// ContentNormalizationVersion is the version tag of the NormalizeContent
+// function. It is part of every cache key derived from a normalized text so
+// that changes to normalization invalidate caches exactly. See
+// reparse-content-cache / stable-chunk-id specs.
+//
+// Bump this when NormalizeContent behavior changes.
+const ContentNormalizationVersion = "n1"
+
+// nbws is the set of characters that should collapse to a plain ASCII space
+// during normalization. It covers the Unicode whitespace most commonly found
+// in copy-pasted text (incl. the U+00A0 NBSP that NFKC maps to space but
+// width.Fold re-expands when run first), while leaving meaningful whitespace
+// (single ASCII space) intact.
+var nbwsReplacer = strings.NewReplacer(
+	"\r\n", "\n",
+	"\r", "\n",
+	"\u00A0", " ",
+	"\u2002", " ",
+	"\u2003", " ",
+	"\u2007", " ",
+	"\u200B", "",
+	"\uFEFF", "",
+)
+
+// NormalizeContent canonicalizes chunk text for content-addressed hashing:
+// the chunk-stable-ID derivation and the embedding cache key MUST derive from
+// the same normalized form so identical content yields identical IDs/keys.
+//
+// Pipeline:
+//  1. Width-fold (full-width ASCII → ASCII, NBSP variants folded later).
+//  2. NFKC Unicode normalization (compatibility decomposition).
+//  3. NBSP / zero-width / BOM strip.
+//  4. Per-line trim of leading/trailing whitespace.
+//  5. Collapse internal runs of spaces/tabs on each line to a single space.
+//  6. Collapse 3+ newlines → 2 (paragraph) and trim leading/trailing newlines.
+//
+// The function is a pure string→string transform. It does NOT touch the
+// original Chunk.Content (which must preserve the rune-offset invariant), only
+// the *derived* ID/cache key input.
+func NormalizeContent(s string) string {
+	if s == "" {
+		return ""
+	}
+	// Fold full/half-width first; width.Fold is a no-op for already-ASCII text.
+	s = width.Fold.String(s)
+	// NFKC compatibility decomposition.
+	s = norm.NFKC.String(s)
+	// Strip NBSP / zero-width / BOM and normalize CR.
+	s = nbwsReplacer.Replace(s)
+
+	// Per-line trim + collapse internal space runs.
+	lines := strings.Split(s, "\n")
+	var out []string
+	for _, ln := range lines {
+		// Collapse runs of spaces and tabs (NOT newlines; we're per-line) into
+		// a single space, then trim the line ends. This makes incidental
+		// indentation/alignment noise irrelevant to the hash.
+		ln = collapseSpaces(ln)
+		ln = strings.TrimSpace(ln)
+		if ln != "" {
+			out = append(out, ln)
+		}
+	}
+	// Join with a single newline; collapse 3+ blank lines was implicit because
+	// we dropped all-empty lines above.
+	joined := strings.Join(out, "\n")
+	return strings.TrimSpace(joined)
+}
+
+// collapseSpaces turns any maximal run of spaces/tabs within a line into a
+// single space. It is allocation-free for the common case (no run > 1).
+func collapseSpaces(ln string) string {
+	if !strings.ContainsAny(ln, " \t") {
+		return ln
+	}
+	var b strings.Builder
+	b.Grow(len(ln))
+	inRun := false
+	for _, r := range ln {
+		if r == ' ' || r == '\t' {
+			inRun = true
+			continue
+		}
+		if inRun {
+			b.WriteByte(' ')
+			inRun = false
+		}
+		b.WriteRune(r)
+	}
+	if inRun {
+		b.WriteByte(' ')
+	}
+	return b.String()
+}
+
+// SHAChecksum returns the lowercase hex SHA-256 of the input.
+func SHAChecksum(data string) string {
+	h := sha256.Sum256([]byte(data))
+	const hex = "0123456789abcdef"
+	out := make([]byte, 64)
+	for i, v := range h {
+		out[i*2] = hex[v>>4]
+		out[i*2+1] = hex[v&0x0F]
+	}
+	return string(out)
+}
+
+// StableContentHash returns the SHA-256 of NormalizeContent(s), prefixed with
+// the ContentNormalizationVersion so a normalization bump (manual deployment)
+// produces a distinct hash and naturally invalidates any keyed cache.
+func StableContentHash(s string) string {
+	return ContentNormalizationVersion + ":" + SHAChecksum(NormalizeContent(s))
+}
+
+// StableChunkID derives a content-addressed chunk ID from (knowledgeID,
+// normalized content, stableSeq). Two calls with the same tuple MUST yield
+// the same ID; the output is a 36-char UUID-shaped string (hex with dashes at
+// the canonical 8-4-4-4-12 offsets) so it remains a valid varchar(36) primary
+// key and needs no schema change relative to legacy UUID IDs.
+//
+// stableSeq disambiguates chunks within a single knowledge that would
+// otherwise collide (identical normalized content at different positions).
+// The common case (distinct content) passes stableSeq=0; the caller only
+// increments stableSeq when a collision is detected within the document.
+//
+// knowledgeID is part of the input so identical chunk content in two
+// different knowledge documents produces DIFFERENT IDs (we deliberately do
+// NOT collapse cross-document chunk identity — only *embeddings* dedup
+// cross-doc).
+func StableChunkID(knowledgeID, content string, stableSeq int) string {
+	// Combine the three inputs in a way resistant to ambiguity (length
+	// prefixes) before hashing. A naïgue `knowledgeID|content|seq` would
+	// collide for ("ab|","c",0) and ("a","b|c",0).
+	h := sha256.New()
+	h.Write([]byte(knowledgeID))
+	h.Write([]byte{0})
+	h.Write([]byte(StableContentHash(content)))
+	h.Write([]byte{0})
+	var sb [8]byte
+	binary.BigEndian.PutUint64(sb[:], uint64(stableSeq))
+	h.Write(sb[:])
+	sum := h.Sum(nil)
+	// Apply UUID variant (top 2 bits of byte index 8 → 10xxxxxx) and
+	// version (high nibble of byte index 6 → 5, SHA namespace) to the
+	// raw bytes BEFORE hex encoding so the bits land in the right place.
+	sum[8] = (sum[8] & 0x3F) | 0x80
+	sum[6] = (sum[6] & 0x0F) | 0x50
+
+	// Render as a UUID string: hex groups 8-4-4-4-12 separated by dashes.
+	const hex = "0123456789abcdef"
+	hb := make([]byte, 32)
+	for i, v := range sum[:16] {
+		hb[i*2] = hex[v>>4]
+		hb[i*2+1] = hex[v&0x0F]
+	}
+	// 8-4-4-4-12 hex groups from hb with dashes between them.
+	b := make([]byte, 36)
+	copy(b[0:8], hb[0:8])
+	b[8] = '-'
+	copy(b[9:13], hb[8:12])
+	b[13] = '-'
+	copy(b[14:18], hb[12:16])
+	b[18] = '-'
+	copy(b[19:23], hb[16:20])
+	b[23] = '-'
+	copy(b[24:36], hb[20:32])
+	return string(b)
+}

--- a/internal/types/contentutil_test.go
+++ b/internal/types/contentutil_test.go
@@ -1,0 +1,128 @@
+package types
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeContent_BasicCollapse(t *testing.T) {
+	in := "  Hello\t\tWorld  \n\nNext   line  "
+	want := "Hello World\nNext line"
+	if got := NormalizeContent(in); got != want {
+		t.Errorf("NormalizeContent mismatch:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+func TestNormalizeContent_NFKCAndWidthFold(t *testing.T) {
+	// Full-width Latin "Ａｂｃ" and NBSP between words should normalize.
+	in := "\uFF21\uFF42\uFF43\u00A0hello\r\n\r\nworld"
+	out := NormalizeContent(in)
+	if !strings.HasPrefix(out, "Abc") {
+		t.Errorf("expected width-folded ABC prefix, got %q", out)
+	}
+	if strings.Contains(out, "\u00A0") {
+		t.Errorf("NBSP survived normalization: %q", out)
+	}
+	if strings.Contains(out, "\r") {
+		t.Errorf("CR survived normalization: %q", out)
+	}
+	if strings.Contains(out, "\n\n\n") {
+		t.Errorf("3+ newlines survived normalization")
+	}
+}
+
+func TestNormalizeContent_EmptyAndZeroWidth(t *testing.T) {
+	if got := NormalizeContent(""); got != "" {
+		t.Errorf("empty input should stay empty, got %q", got)
+	}
+	if got := NormalizeContent("\u200B\uFEFF\u00A0"); got != "" {
+		t.Errorf("zero-width/BOM/NBSP-only input should collapse to empty, got %q", got)
+	}
+}
+
+func TestStableContentHash_VersionedAndStable(t *testing.T) {
+	a := StableContentHash("hello")
+	b := StableContentHash("hello")
+	if a != b {
+		t.Fatalf("identical content produced different hashes: %s != %s", a, b)
+	}
+	if !strings.HasPrefix(a, ContentNormalizationVersion+":") {
+		t.Errorf("hash missing normalization-version prefix: %s", a)
+	}
+	// Trailing space is trimmed during normalization so these MUST match a.
+	if c := StableContentHash("hello "); a != c {
+		t.Errorf("trailing space should be trimmed so hashes match: %s != %s", a, c)
+	}
+	if d := StableContentHash("hello\n"); a != d {
+		t.Errorf("trailing newline should be trimmed so hashes match: %s != %s", a, d)
+	}
+	// A genuine content difference MUST change the hash.
+	if e := StableContentHash("hello x"); a == e {
+		t.Errorf("real content difference did not change the hash")
+	}
+}
+func TestStableChunkID_Deterministic(t *testing.T) {
+	id1 := StableChunkID("doc-1", "same content", 0)
+	id2 := StableChunkID("doc-1", "same content", 0)
+	if id1 != id2 {
+		t.Fatalf("stable IDs not deterministic: %s != %s", id1, id2)
+	}
+	if len(id1) != 36 {
+		t.Fatalf("stable ID not 36 chars (uuid-shaped): len=%d id=%s", len(id1), id1)
+	}
+	// Dashes at canonical UUID offsets 8/13/18/23.
+	for _, i := range []int{8, 13, 18, 23} {
+		if id1[i] != '-' {
+			t.Errorf("expected '-' at offset %d in %s", i, id1)
+		}
+	}
+	// Version nibble = 5 at offset 14.
+	if id1[14] != '5' {
+		t.Errorf("expected version nibble '5' at offset 14, got %q in %s", byte(id1[14]), id1)
+	}
+}
+
+func TestStableChunkID_DifferentSeqDiffers(t *testing.T) {
+	a := StableChunkID("doc-1", "same content", 0)
+	b := StableChunkID("doc-1", "same content", 1)
+	if a == b {
+		t.Fatalf("stable_seq failed to disambiguate identical content: %s == %s", a, b)
+	}
+}
+
+func TestStableChunkID_DifferentDocIDDiffers(t *testing.T) {
+	a := StableChunkID("doc-1", "same content", 0)
+	b := StableChunkID("doc-2", "same content", 0)
+	if a == b {
+		t.Fatalf("doc_id failed to differentiate cross-doc identical content: %s == %s", a, b)
+	}
+}
+
+func TestStableChunkID_DifferentContentDiffers(t *testing.T) {
+	a := StableChunkID("doc-1", "content a", 0)
+	b := StableChunkID("doc-1", "content b", 0)
+	if a == b {
+		t.Fatalf("different content produced same ID: %s", a)
+	}
+}
+
+func TestStableChunkID_NormalizationStability(t *testing.T) {
+	// The same logical content with only whitespace differences MUST produce
+	// the same stable ID — that's the whole point of the normalize→hash
+	// pipeline.
+	a := StableChunkID("doc-1", "Hello\tworld", 0)
+	b := StableChunkID("doc-1", " Hello    world ", 0)
+	if a != b {
+		t.Fatalf("whitespace-only differences produced different IDs: %s != %s", a, b)
+	}
+}
+
+func TestStableChunkID_AmbiguityResistance(t *testing.T) {
+	// ("ab|","c",0) must NOT collide with ("a","b|c",0) — the NUL separators
+	// in the pre-hash input prevent this.
+	a := StableChunkID("ab|", "c", 0)
+	b := StableChunkID("a", "b|c", 0)
+	if a == b {
+		t.Fatalf("length-ambiguity collision: %s == %s", a, b)
+	}
+}

--- a/migrations/sqlite/000000_init.down.sql
+++ b/migrations/sqlite/000000_init.down.sql
@@ -23,3 +23,8 @@ DROP TABLE IF EXISTS knowledges;
 DROP TABLE IF EXISTS knowledge_bases;
 DROP TABLE IF EXISTS models;
 DROP TABLE IF EXISTS tenants;
+DROP TABLE IF EXISTS parse_product_cache;
+DROP TABLE IF EXISTS graph_chunk_cache;
+DROP TABLE IF EXISTS wiki_map_cache;
+DROP TABLE IF EXISTS embedding_cache;
+DROP TABLE IF EXISTS vlm_cache;

--- a/migrations/sqlite/000000_init.up.sql
+++ b/migrations/sqlite/000000_init.up.sql
@@ -820,3 +820,23 @@ CREATE TABLE IF NOT EXISTS parse_product_cache (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (file_hash, parser_engine, parser_config_hash, render_config_hash)
 );
+
+CREATE TABLE IF NOT EXISTS summary_cache (
+    doc_content_hash TEXT NOT NULL,
+    model_id TEXT NOT NULL,
+    prompt_version TEXT NOT NULL,
+    config_hash TEXT NOT NULL,
+    summary TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (doc_content_hash, model_id, prompt_version, config_hash)
+);
+
+CREATE TABLE IF NOT EXISTS question_cache (
+    chunk_content_hash TEXT NOT NULL,
+    model_id TEXT NOT NULL,
+    prompt_version TEXT NOT NULL,
+    config_hash TEXT NOT NULL,
+    payload TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (chunk_content_hash, model_id, prompt_version, config_hash)
+);

--- a/migrations/sqlite/000000_init.up.sql
+++ b/migrations/sqlite/000000_init.up.sql
@@ -769,3 +769,54 @@ CREATE TABLE IF NOT EXISTS tenant_api_keys (
 
 CREATE INDEX IF NOT EXISTS idx_tenant_api_keys_tenant ON tenant_api_keys(tenant_id);
 CREATE INDEX IF NOT EXISTS idx_tenant_api_keys_revoked_at ON tenant_api_keys(revoked_at);
+
+-- Content-addressed reparse cache tables (mirror of migration 000065).
+
+CREATE TABLE IF NOT EXISTS vlm_cache (
+    image_hash TEXT NOT NULL,
+    model_id TEXT NOT NULL,
+    prompt_version TEXT NOT NULL,
+    prompt_kind TEXT NOT NULL,
+    output_text TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (image_hash, model_id, prompt_version, prompt_kind)
+);
+
+CREATE TABLE IF NOT EXISTS embedding_cache (
+    text_hash TEXT NOT NULL,
+    model_id TEXT NOT NULL,
+    dimension INTEGER NOT NULL,
+    vector TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (text_hash, model_id, dimension)
+);
+
+CREATE TABLE IF NOT EXISTS wiki_map_cache (
+    doc_content_hash TEXT NOT NULL,
+    granularity TEXT NOT NULL,
+    synthesis_model_id TEXT NOT NULL,
+    prompt_version TEXT NOT NULL,
+    payload TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (doc_content_hash, granularity, synthesis_model_id, prompt_version)
+);
+
+CREATE TABLE IF NOT EXISTS graph_chunk_cache (
+    chunk_content_hash TEXT NOT NULL,
+    extract_config_hash TEXT NOT NULL,
+    chat_model_id TEXT NOT NULL,
+    prompt_version TEXT NOT NULL,
+    payload TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (chunk_content_hash, extract_config_hash, chat_model_id, prompt_version)
+);
+
+CREATE TABLE IF NOT EXISTS parse_product_cache (
+    file_hash TEXT NOT NULL,
+    parser_engine TEXT NOT NULL,
+    parser_config_hash TEXT NOT NULL,
+    render_config_hash TEXT NOT NULL,
+    payload TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (file_hash, parser_engine, parser_config_hash, render_config_hash)
+);

--- a/migrations/versioned/000065_content_cache_tables.down.sql
+++ b/migrations/versioned/000065_content_cache_tables.down.sql
@@ -1,3 +1,5 @@
+DROP TABLE IF EXISTS question_cache;
+DROP TABLE IF EXISTS summary_cache;
 DROP TABLE IF EXISTS parse_product_cache;
 DROP TABLE IF EXISTS graph_chunk_cache;
 DROP TABLE IF EXISTS wiki_map_cache;

--- a/migrations/versioned/000065_content_cache_tables.down.sql
+++ b/migrations/versioned/000065_content_cache_tables.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS parse_product_cache;
+DROP TABLE IF EXISTS graph_chunk_cache;
+DROP TABLE IF EXISTS wiki_map_cache;
+DROP TABLE IF EXISTS embedding_cache;
+DROP TABLE IF EXISTS vlm_cache;

--- a/migrations/versioned/000065_content_cache_tables.up.sql
+++ b/migrations/versioned/000065_content_cache_tables.up.sql
@@ -1,0 +1,54 @@
+-- Content-addressed reparse cache: canonical outputs for VLM, embeddings,
+-- wiki map, graph chunk extraction, and parse products.
+DO $$ BEGIN RAISE NOTICE '[Migration 000065] Creating content-addressed reparse cache tables...'; END $$;
+
+CREATE TABLE IF NOT EXISTS vlm_cache (
+    image_hash VARCHAR(64) NOT NULL,
+    model_id VARCHAR(64) NOT NULL,
+    prompt_version VARCHAR(64) NOT NULL,
+    prompt_kind VARCHAR(32) NOT NULL,
+    output_text TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (image_hash, model_id, prompt_version, prompt_kind)
+);
+
+CREATE TABLE IF NOT EXISTS embedding_cache (
+    text_hash VARCHAR(128) NOT NULL,
+    model_id VARCHAR(64) NOT NULL,
+    dimension INTEGER NOT NULL,
+    vector TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (text_hash, model_id, dimension)
+);
+
+CREATE TABLE IF NOT EXISTS wiki_map_cache (
+    doc_content_hash VARCHAR(128) NOT NULL,
+    granularity VARCHAR(32) NOT NULL,
+    synthesis_model_id VARCHAR(64) NOT NULL,
+    prompt_version VARCHAR(64) NOT NULL,
+    payload TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (doc_content_hash, granularity, synthesis_model_id, prompt_version)
+);
+
+CREATE TABLE IF NOT EXISTS graph_chunk_cache (
+    chunk_content_hash VARCHAR(128) NOT NULL,
+    extract_config_hash VARCHAR(128) NOT NULL,
+    chat_model_id VARCHAR(64) NOT NULL,
+    prompt_version VARCHAR(64) NOT NULL,
+    payload TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (chunk_content_hash, extract_config_hash, chat_model_id, prompt_version)
+);
+
+CREATE TABLE IF NOT EXISTS parse_product_cache (
+    file_hash VARCHAR(128) NOT NULL,
+    parser_engine VARCHAR(32) NOT NULL,
+    parser_config_hash VARCHAR(128) NOT NULL,
+    render_config_hash VARCHAR(128) NOT NULL,
+    payload TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (file_hash, parser_engine, parser_config_hash, render_config_hash)
+);
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000065] content-addressed reparse cache tables ready'; END $$;

--- a/migrations/versioned/000065_content_cache_tables.up.sql
+++ b/migrations/versioned/000065_content_cache_tables.up.sql
@@ -51,4 +51,24 @@ CREATE TABLE IF NOT EXISTS parse_product_cache (
     PRIMARY KEY (file_hash, parser_engine, parser_config_hash, render_config_hash)
 );
 
+CREATE TABLE IF NOT EXISTS summary_cache (
+    doc_content_hash VARCHAR(128) NOT NULL,
+    model_id VARCHAR(64) NOT NULL,
+    prompt_version VARCHAR(64) NOT NULL,
+    config_hash VARCHAR(64) NOT NULL,
+    summary TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (doc_content_hash, model_id, prompt_version, config_hash)
+);
+
+CREATE TABLE IF NOT EXISTS question_cache (
+    chunk_content_hash VARCHAR(128) NOT NULL,
+    model_id VARCHAR(64) NOT NULL,
+    prompt_version VARCHAR(64) NOT NULL,
+    config_hash VARCHAR(64) NOT NULL,
+    payload TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (chunk_content_hash, model_id, prompt_version, config_hash)
+);
+
 DO $$ BEGIN RAISE NOTICE '[Migration 000065] content-addressed reparse cache tables ready'; END $$;


### PR DESCRIPTION
Closes #1679

## 问题

`ReparseKnowledge` 重建一份知识时,先调 `cleanupKnowledgeResources` 把该知识下全部 chunk、向量、图谱、已抽取图片一次性删光,再从 `DocReader` 解析开始把整条链路重跑一遍——分块、向量化、VLM OCR/Caption、摘要、问题、Wiki extract/dedup/summary/classify、GraphRAG 抽取。

这意味着**重建成本 ≈ 首次摄取成本,且随重建次数线性叠加**。换更便宜的模型只改变常数项,不改变 $O(\text{全量重算} \times \text{重建次数})$ 这个量级。Wiki 模式 + 中大型知识库下,token 消耗在实际部署中不可控。

## 根因

两个结构性缺陷:

1. **chunk ID 漂移**——chunk ID 由 `uuid.New()` 生成,每次解析都是新 ID。即便内容一字不差,旧 chunk 和新 chunk 的 ID 也对不上,向量、Wiki `SourceChunks`/`ChunkRefs` 引用、图谱边全部指向失效 ID,无法复用。

2. **缺少内容寻址的缓存层**——VLM OCR/Caption、Embedding、Wiki per-doc map、GraphRAG per-chunk 抽取、DocReader 解析产物,这些环节的输出都是「稳定输入的纯函数」,重建时本可命中,但因为没有缓存层,每次都无条件重跑。

## 解法

### 地基:内容寻址的稳定 chunk ID

`StableChunkID(knowledgeID, content, stableSeq)` 从 `hash(doc_id + 归一化内容 + 序号)` 派生 chunk ID,替代 `uuid.New()`。内容相同 → ID 相同 → 向量、Wiki 引用、图谱边跨重建凭 ID 存活。

归一化管线(`NormalizeContent`):width-fold → NFKC → NBSP/零宽/BOM 剥离 → 行首尾 trim → 行内空格折叠 → 段落折叠。`StableContentHash` 在 hash 前缀内嵌归一化版本号 `n1`,归一化规则变更时自动失效所有派生缓存。

### 核心:非破坏重建(diff 替代全删)

`ReparseKnowledge` 非手工路径不再调 `cleanupKnowledgeResources`。`processChunks` 改为按 StableChunkID 做 diff:

- **kept**(ID 不变)——保留旧 chunk 行和旧向量,跳过 `CreateChunks` 和 `BatchIndex`,**零 embedding 调用**
- **added**(新内容)——`CreateChunks` + `BatchIndex`,只为新增 chunk 调 embedding
- **removed**(旧内容)——`DeleteByChunkIDList` 精删向量 + `DeleteChunks` 删行

diff 逻辑抽成纯函数 `computeChunkDiff(newChunks, oldChunks)`,6 个行为测试覆盖全 kept / 全 added / 全 removed / 部分变化 / ID 确定性 / 空集 6 种场景。

`ProcessDocument` 通过 `ListChunksByKnowledgeID` 现场探测自动判定 `IsReparse`(有旧 chunk 即走 diff,无则走首次摄取盲插入)。崩溃续跑时已写入的部分 chunk 会被识别为旧状态,diff 只补差异。

storage 计费按 delta(仅 added),不双计 kept。abort/失败路径只回滚 added,不删 kept。

### 缓存层:5 个内容寻址的纯函数缓存

| 缓存 | 包住什么 | key 由什么组成 | 换什么会失效 |
| --- | --- | --- | --- |
| VLM OCR/Caption | `vlmModel.Predict` | `SHA(图片字节)` + `model_id` + `SHA(prompt)` + `prompt_kind` | 图片变 / 换 VLM 模型 / 改 prompt |
| Embedding | `embedder.BatchEmbed` | `StableContentHash(文本)` + `model_id` + `dim` | 文本变 / 换 embedding 模型 / 换维度 |
| Wiki per-doc map | `mapOneDocument` 的 LLM extract/dedup/summary/classify | `StableContentHash(文档内容)` + `granularity` + `model_id` + `SHA(prompt)` | 文档变 / 换粒度 / 换模型 / 改 prompt |
| GraphRAG per-chunk | `extractor.Extract` | `StableContentHash(chunk 内容)` + `SHA(extract config)` + `model_id` + `SHA(prompt)` | chunk 变 / 改抽取配置 / 换模型 / 改 prompt |
| DocReader 解析产物 | `convert` 的 docreader 调用 | `SHA(文件字节)` + `parser_engine` + `SHA(parser config)` + render config | 文件变 / 换解析引擎 / 改解析配置 |

全部 nil-safe(无 DB repo 时直接走 LLM,兼容 lite/test)。`ON CONFLICT DO NOTHING` 保证并发冷缓存竞争不互踩。

**Wiki reduce 刻意不缓存**——它依赖其它文档当前页面的活状态,跨文档有状态,任一贡献者变动即需重算。这是设计本身的成本下界。

### 取舍

- **图谱数据**:Phase 7 不删 graph(非破坏路径下 `DelGraph` 不再调)。`AddGraph` 用 `apoc.merge.node` + `apoc.coll.union`,merge 语义天然幂等——内容相同的 chunk 重新 extract 产生相同 GraphData,merge 后 chunks 列表仍去重。内容删掉的 chunk 其图节点 `chunks` 属性可能残留旧 chunk_id,这是 GraphRAG 精确失效的范畴,留给后续优化。
- **已抽取图片**:非破坏路径下 `deleteExtractedImages` 不再调,旧图保留。图片内容相同时天然复用,新增图片由 `enqueueImageMultimodalTasks` 处理。
- **手工知识 reparse 路径**:语义不同(内容被整段替换),仍走 `enqueueManualProcessing` 的清理+重建,不动。

## 验收对照(issue #1679)

| 场景 | 预期 | 实现 |
| --- | --- | --- |
| 内容未变重建 | 除 Wiki reduce 外接近 0 LLM/VLM 调用 | chunk diff 全 kept → 0 embedding;VLM/wiki map/graph chunk/parse 全 cache hit |
| 崩溃续跑 | 已完成的 OCR/向量/Wiki map 全 cache-hit | `IsReparse` 自动检测旧 chunk,diff 只补未完成部分 |
| 配置/模型变更 | 仅依赖被变更项的层失效 | cache key 内嵌 model_id/config_hash/prompt_version,精确分层失效 |

## 测试

```
go build ./...
go test ./internal/application/service/ -count=1 -timeout 120s
go test ./internal/container/ -count=1 -timeout 120s
go test ./internal/models/embedding/ -count=1 -run TestCachedEmbedder -v
go test ./internal/types/ -count=1
```

- 全仓库 `go build` 绿,`go vet` 干净
- service 包 600+ 测试通过(含 6 个 `computeChunkDiff` 行为测试)
- embedding 包 10 个 `cachedEmbedder` 行为测试通过(含重复文本去重修复)
- types 包 `StableChunkID` / `NormalizeContent` / `StableContentHash` 确定性测试通过

## 犀牛鸟

认领 issue #1679(2026 犀牛鸟开源人才培养活动专属 issue)。
