### PR TITLE
feat: add Keenable as a configurable web search provider

### DIFF
--- a/frontend/src/api/web-search-provider.ts
+++ b/frontend/src/api/web-search-provider.ts
@@ -5,7 +5,7 @@ export interface WebSearchProviderEntity {
   id?: string
   tenant_id?: number
   name: string
-  provider: 'bing' | 'google' | 'duckduckgo' | 'tavily' | 'ollama' | 'baidu' | 'searxng'
+  provider: 'bing' | 'google' | 'duckduckgo' | 'tavily' | 'ollama' | 'baidu' | 'searxng' | 'keenable'
   description?: string
   parameters: {
     // api_key is never returned by the server in this shape; it lives behind

--- a/internal/application/service/web_search_provider.go
+++ b/internal/application/service/web_search_provider.go
@@ -135,7 +135,8 @@ func isValidProviderType(provider types.WebSearchProviderType) bool {
 		types.WebSearchProviderTypeTavily,
 		types.WebSearchProviderTypeOllama,
 		types.WebSearchProviderTypeBaidu,
-		types.WebSearchProviderTypeSearxng:
+		types.WebSearchProviderTypeSearxng,
+		types.WebSearchProviderTypeKeenable:
 		return true
 	default:
 		return false
@@ -170,6 +171,8 @@ func validateProviderParameters(provider types.WebSearchProviderType, params typ
 		}
 	case types.WebSearchProviderTypeDuckDuckGo:
 		// No API key required
+	case types.WebSearchProviderTypeKeenable:
+		// No API key required (keyless by default; an optional key lifts the rate limit)
 	case types.WebSearchProviderTypeSearxng:
 		if err := infra_web_search.ValidateSearxngBaseURL(params.BaseURL); err != nil {
 			return err

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -1335,6 +1335,7 @@ func registerWebSearchProviders(registry *infra_web_search.Registry) {
 	registry.Register("ollama", infra_web_search.NewOllamaProvider)
 	registry.Register("baidu", infra_web_search.NewBaiduProvider)
 	registry.Register("searxng", infra_web_search.NewSearxngProvider)
+	registry.Register("keenable", infra_web_search.NewKeenableProvider)
 }
 
 // registerIMAdapterFactories registers adapter factories for each IM platform

--- a/internal/infrastructure/web_search/keenable.go
+++ b/internal/infrastructure/web_search/keenable.go
@@ -1,0 +1,152 @@
+package web_search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+const (
+	// defaultKeenableBaseURL is the hardcoded Keenable API base URL.
+	// Not configurable by tenants — prevents SSRF.
+	defaultKeenableBaseURL = "https://api.keenable.ai"
+	// keenableTitle is the attribution tag Keenable segments integration traffic by.
+	keenableTitle = "WeKnora"
+)
+
+var (
+	defaultKeenableTimeout = 15 * time.Second
+)
+
+// KeenableProvider implements web search using the Keenable Search API.
+// Keyless by default: with no API key it calls the public endpoint
+// (rate-limited); a key switches to the authenticated endpoint and lifts the cap.
+type KeenableProvider struct {
+	client  *http.Client
+	baseURL string
+	apiKey  string
+}
+
+// NewKeenableProvider creates a new Keenable provider from parameters.
+// The API key is optional; Keenable works keyless against the public endpoint.
+func NewKeenableProvider(params types.WebSearchProviderParameters) (interfaces.WebSearchProvider, error) {
+	client, err := NewSearchHTTPClient(defaultKeenableTimeout, params.ProxyURL)
+	if err != nil {
+		return nil, err
+	}
+	return &KeenableProvider{
+		client:  client,
+		baseURL: defaultKeenableBaseURL,
+		apiKey:  params.APIKey,
+	}, nil
+}
+
+// Name returns the provider name
+func (p *KeenableProvider) Name() string {
+	return "keenable"
+}
+
+// Search performs a web search using the Keenable Search API.
+func (p *KeenableProvider) Search(
+	ctx context.Context,
+	query string,
+	maxResults int,
+	includeDate bool,
+) ([]*types.WebSearchResult, error) {
+	if len(query) == 0 {
+		return nil, fmt.Errorf("query is empty")
+	}
+
+	// Keyless by default; a configured key switches to the authenticated path.
+	path := "/v1/search/public"
+	if p.apiKey != "" {
+		path = "/v1/search"
+	}
+	endpoint := p.baseURL + path
+	logger.Infof(ctx, "[WebSearch][Keenable] query=%q maxResults=%d url=%s", query, maxResults, endpoint)
+
+	bodyBytes, err := json.Marshal(keenableSearchRequest{Query: query, Mode: "pro"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Keenable-Title", keenableTitle)
+	if p.apiKey != "" {
+		req.Header.Set("X-API-Key", p.apiKey)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		logger.Warnf(ctx, "[WebSearch][Keenable] API returned status %d: %s", resp.StatusCode, string(respBody))
+		return nil, fmt.Errorf("keenable API returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var respData keenableSearchResponse
+	if err := json.Unmarshal(respBody, &respData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	results := make([]*types.WebSearchResult, 0, len(respData.Results))
+	for _, item := range respData.Results {
+		if maxResults > 0 && len(results) >= maxResults {
+			break
+		}
+		result := &types.WebSearchResult{
+			Title:   item.Title,
+			URL:     item.URL,
+			Snippet: item.Description,
+			Source:  "keenable",
+		}
+		if includeDate && item.PublishedAt != "" {
+			if t, err := time.Parse(time.RFC3339, item.PublishedAt); err == nil {
+				result.PublishedAt = &t
+			}
+		}
+		results = append(results, result)
+	}
+	logger.Infof(ctx, "[WebSearch][Keenable] returned %d results", len(results))
+	return results, nil
+}
+
+// keenableSearchRequest defines the request body for the Keenable search API.
+type keenableSearchRequest struct {
+	Query string `json:"query"`
+	Mode  string `json:"mode"`
+}
+
+// keenableSearchResponse defines the response structure for the Keenable search API.
+type keenableSearchResponse struct {
+	Query   string `json:"query"`
+	Results []struct {
+		Title       string `json:"title"`
+		URL         string `json:"url"`
+		Description string `json:"description"`
+		PublishedAt string `json:"published_at,omitempty"`
+		AcquiredAt  string `json:"acquired_at,omitempty"`
+	} `json:"results"`
+}

--- a/internal/infrastructure/web_search/keenable_test.go
+++ b/internal/infrastructure/web_search/keenable_test.go
@@ -1,0 +1,110 @@
+package web_search
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestKeenableProvider_Search_Keyless(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No key configured => keyless public endpoint, no X-API-Key.
+		if r.URL.Path != "/v1/search/public" {
+			t.Errorf("path = %q, want /v1/search/public", r.URL.Path)
+		}
+		if got := r.Header.Get("X-API-Key"); got != "" {
+			t.Errorf("X-API-Key = %q, want empty for keyless", got)
+		}
+		if got := r.Header.Get("X-Keenable-Title"); got != "WeKnora" {
+			t.Errorf("X-Keenable-Title = %q, want WeKnora", got)
+		}
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["query"] != "hello" || body["mode"] != "pro" {
+			t.Errorf("body = %v, want query=hello mode=pro", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"query": "hello",
+			"results": []map[string]any{
+				{"title": "T1", "url": "https://e/1", "description": "d1", "published_at": "2026-05-01T00:00:00Z"},
+				{"title": "T2", "url": "https://e/2", "description": "d2"},
+				{"title": "T3", "url": "https://e/3", "description": "d3"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := &KeenableProvider{client: srv.Client(), baseURL: srv.URL}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	results, err := p.Search(ctx, "hello", 2, true)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (maxResults trim), got %d", len(results))
+	}
+	if results[0].Source != "keenable" {
+		t.Errorf("source = %q, want keenable", results[0].Source)
+	}
+	if results[0].Snippet != "d1" || results[0].URL != "https://e/1" {
+		t.Errorf("unexpected first result: %+v", results[0])
+	}
+	if results[0].PublishedAt == nil {
+		t.Errorf("expected PublishedAt to be set on the first result")
+	}
+}
+
+func TestKeenableProvider_Search_Keyed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// A configured key => authenticated endpoint + X-API-Key.
+		if r.URL.Path != "/v1/search" {
+			t.Errorf("path = %q, want /v1/search", r.URL.Path)
+		}
+		if got := r.Header.Get("X-API-Key"); got != "keen_test" {
+			t.Errorf("X-API-Key = %q, want keen_test", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"results": []map[string]any{}})
+	}))
+	defer srv.Close()
+
+	p := &KeenableProvider{client: srv.Client(), baseURL: srv.URL, apiKey: "keen_test"}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := p.Search(ctx, "hi", 5, false); err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+}
+
+func TestKeenableProvider_Search_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"rate limited"}`))
+	}))
+	defer srv.Close()
+
+	p := &KeenableProvider{client: srv.Client(), baseURL: srv.URL}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := p.Search(ctx, "x", 5, false); err == nil {
+		t.Fatal("expected an error for a non-200 response")
+	}
+}
+
+func TestKeenableProvider_Name(t *testing.T) {
+	p, err := NewKeenableProvider(types.WebSearchProviderParameters{})
+	if err != nil {
+		t.Fatalf("NewKeenableProvider (keyless): %v", err)
+	}
+	if p.Name() != "keenable" {
+		t.Errorf("Name() = %q, want keenable", p.Name())
+	}
+}

--- a/internal/infrastructure/web_search/test_errors.go
+++ b/internal/infrastructure/web_search/test_errors.go
@@ -31,6 +31,10 @@ func EmptyTestResultsError(providerType string, provider any) error {
 		)
 	case types.WebSearchProviderTypeDuckDuckGo:
 		return fmt.Errorf("duckduckgo returned 0 results; verify network connectivity and proxy settings")
+	case types.WebSearchProviderTypeKeenable:
+		return fmt.Errorf(
+			"keenable returned 0 results; keyless requests are rate-limited, so verify network connectivity or set an API key to lift the cap",
+		)
 	default:
 		return fmt.Errorf("search returned 0 results, please verify your API key and configuration")
 	}

--- a/internal/types/web_search_provider.go
+++ b/internal/types/web_search_provider.go
@@ -22,6 +22,7 @@ const (
 	WebSearchProviderTypeOllama     WebSearchProviderType = "ollama"
 	WebSearchProviderTypeBaidu      WebSearchProviderType = "baidu"
 	WebSearchProviderTypeSearxng    WebSearchProviderType = "searxng"
+	WebSearchProviderTypeKeenable   WebSearchProviderType = "keenable"
 )
 
 // WebSearchProviderEntity represents a configured web search provider instance for a tenant.
@@ -197,6 +198,14 @@ func GetWebSearchProviderTypes() []WebSearchProviderTypeInfo {
 			RequiresAPIKey: true,
 			Description:    "Baidu AI Search (requires API key from Baidu Cloud)",
 			DocsURL:        "https://cloud.baidu.com/doc/AppBuilder/s/qlvEcai0p",
+		},
+		{
+			ID:             "keenable",
+			Name:           "Keenable",
+			RequiresAPIKey: false,
+			SupportsProxy:  true,
+			Description:    "Keenable web search built for AI agents (keyless by default; an optional API key lifts the rate limit)",
+			DocsURL:        "https://keenable.ai/",
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Adds **Keenable** as a new web search provider alongside the existing DuckDuckGo / Bing / Google / Tavily / Ollama / Baidu / SearXNG providers, following the same pattern as the Tavily provider (#849).

Keenable is a web search API built for AI agents. Unlike the key-required providers, it is **keyless by default**: with no API key it calls the public endpoint (rate-limited), and an optional key only lifts the cap. So it slots in next to DuckDuckGo / SearXNG as a zero-config option.

## Changes

- `internal/infrastructure/web_search/keenable.go` (new): `KeenableProvider` implementing `interfaces.WebSearchProvider`. Keyless requests hit `/v1/search/public`; a configured key switches to `/v1/search` with an `X-API-Key` header. Base URL is hardcoded (SSRF-safe), proxy is honored, attribution via `X-Keenable-Title`.
- `internal/container/container.go`: registered `keenable` in the provider registry.
- `internal/types/web_search_provider.go`: added the `keenable` provider type and its `/types` metadata (`requires_api_key: false`).
- `internal/application/service/web_search_provider.go`: added `keenable` to the valid types and parameter validation (no required key, like DuckDuckGo).
- `internal/infrastructure/web_search/test_errors.go`: keyless-appropriate empty-result diagnostic.
- `frontend/src/api/web-search-provider.ts`: extended the provider union type.
- Unit tests: keyless vs keyed endpoint, attribution header, `maxResults` trim, result mapping, error status, provider name.

`gofmt`, `go vet`, and `go test ./internal/infrastructure/web_search/` all pass.