### PR TITLE
fix(web-search): polish Keenable provider integration after #1946

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -18058,7 +18058,8 @@ const docTemplate = `{
                 "tavily",
                 "ollama",
                 "baidu",
-                "searxng"
+                "searxng",
+                "keenable"
             ],
             "x-enum-varnames": [
                 "WebSearchProviderTypeBing",
@@ -18067,7 +18068,8 @@ const docTemplate = `{
                 "WebSearchProviderTypeTavily",
                 "WebSearchProviderTypeOllama",
                 "WebSearchProviderTypeBaidu",
-                "WebSearchProviderTypeSearxng"
+                "WebSearchProviderTypeSearxng",
+                "WebSearchProviderTypeKeenable"
             ]
         },
         "github_com_Tencent_WeKnora_internal_types.WikiConfig": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -18051,7 +18051,8 @@
                 "tavily",
                 "ollama",
                 "baidu",
-                "searxng"
+                "searxng",
+                "keenable"
             ],
             "x-enum-varnames": [
                 "WebSearchProviderTypeBing",
@@ -18060,7 +18061,8 @@
                 "WebSearchProviderTypeTavily",
                 "WebSearchProviderTypeOllama",
                 "WebSearchProviderTypeBaidu",
-                "WebSearchProviderTypeSearxng"
+                "WebSearchProviderTypeSearxng",
+                "WebSearchProviderTypeKeenable"
             ]
         },
         "github_com_Tencent_WeKnora_internal_types.WikiConfig": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3459,6 +3459,7 @@ definitions:
     - ollama
     - baidu
     - searxng
+    - keenable
     type: string
     x-enum-varnames:
     - WebSearchProviderTypeBing
@@ -3468,6 +3469,7 @@ definitions:
     - WebSearchProviderTypeOllama
     - WebSearchProviderTypeBaidu
     - WebSearchProviderTypeSearxng
+    - WebSearchProviderTypeKeenable
   github_com_Tencent_WeKnora_internal_types.WikiConfig:
     properties:
       extraction_granularity:

--- a/frontend/src/api/web-search-provider.ts
+++ b/frontend/src/api/web-search-provider.ts
@@ -29,6 +29,8 @@ export interface WebSearchProviderTypeInfo {
   id: string
   name: string
   requires_api_key: boolean
+  // Keyless-by-default providers that still accept an optional key (e.g. Keenable).
+  supports_optional_api_key?: boolean
   requires_engine_id?: boolean
   requires_base_url?: boolean
   supports_proxy?: boolean

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1476,6 +1476,7 @@ export default {
     proxyUrlPlaceholder: 'e.g. http://proxy.example.com:3128 (optional; http/https only)',
     proxyUrlHelp: 'Use when outbound access to the search API requires a proxy; leave empty to rely on HTTP_PROXY/HTTPS_PROXY environment variables.',
     apiKeyLabel: 'API Key',
+    apiKeyOptionalLabel: 'API Key (optional)',
     baseUrlLabel: 'Instance URL',
     baseUrlPlaceholder: 'https://searxng.example.com',
     apiKeyDescription: 'Enter the API key for the selected search provider',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -1324,6 +1324,7 @@ export default {
     proxyUrlPlaceholder: "예: http://127.0.0.1:7890 (선택 사항)",
     proxyUrlHelp: "검색 API 접근에 프록시가 필요한 경우 입력합니다. 비우면 HTTP_PROXY/HTTPS_PROXY를 사용합니다.",
     apiKeyLabel: "API 키",
+    apiKeyOptionalLabel: "API 키 (선택 사항)",
     baseUrlLabel: "인스턴스 URL",
     baseUrlPlaceholder: "https://searxng.example.com",
     apiKeyDescription: "선택한 검색 엔진의 API 키 입력",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -1383,6 +1383,7 @@ export default {
     proxyUrlPlaceholder: 'Напр. http://127.0.0.1:7890 (необязательно)',
     proxyUrlHelp: 'Укажите, если доступ к API поиска нужен через прокси; иначе используются переменные HTTP_PROXY/HTTPS_PROXY.',
     apiKeyLabel: 'API-ключ',
+    apiKeyOptionalLabel: 'API-ключ (необязательно)',
     baseUrlLabel: 'URL экземпляра',
     baseUrlPlaceholder: 'https://searxng.example.com',
     apiKeyDescription: 'Введите API-ключ выбранного провайдера поиска',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1334,6 +1334,7 @@ export default {
     proxyUrlPlaceholder: "例如 http://proxy.example.com:3128（可选，仅支持 http/https）",
     proxyUrlHelp: "若环境访问搜索 API 需代理，在此填写；留空则使用系统环境变量 HTTP(S)_PROXY。",
     apiKeyLabel: "API 密钥",
+    apiKeyOptionalLabel: "API 密钥（可选）",
     baseUrlLabel: "实例地址",
     baseUrlPlaceholder: "https://searxng.example.com",
     apiKeyDescription: "输入所选搜索引擎的 API 密钥",

--- a/frontend/src/views/settings/WebSearchSettings.vue
+++ b/frontend/src/views/settings/WebSearchSettings.vue
@@ -206,7 +206,7 @@
 
         <!-- Section 2 — 连接配置（base url / api key / engine id），仅当任意字段需要时渲染 -->
         <section
-          v-if="selectedProviderType?.requires_api_key || selectedProviderType?.requires_engine_id || selectedProviderType?.requires_base_url"
+          v-if="selectedProviderType?.requires_api_key || selectedProviderType?.supports_optional_api_key || selectedProviderType?.requires_engine_id || selectedProviderType?.requires_base_url"
           class="setting-drawer__section"
         >
           <h4 class="setting-drawer__section-title">{{ t('webSearchSettings.credentialsSection', '连接配置') }}</h4>
@@ -224,8 +224,12 @@
             子资源调用），不与本表单 submit 耦合；Create 模式下用 plain
             password input + lock prefix-icon，与 ModelEditorDialog 一致。
           -->
-          <div v-if="selectedProviderType?.requires_api_key" class="form-item">
-            <label class="form-label required">{{ t('webSearchSettings.apiKeyLabel') }}</label>
+          <div v-if="selectedProviderType?.requires_api_key || selectedProviderType?.supports_optional_api_key" class="form-item">
+            <label class="form-label" :class="{ required: selectedProviderType?.requires_api_key }">
+              {{ selectedProviderType?.supports_optional_api_key && !selectedProviderType?.requires_api_key
+                ? t('webSearchSettings.apiKeyOptionalLabel', 'API Key（可选）')
+                : t('webSearchSettings.apiKeyLabel') }}
+            </label>
             <CredentialResource
               v-if="editingProvider?.id"
               :api="credentialApi"
@@ -847,6 +851,10 @@ onMounted(async () => {
   background: rgba(70, 70, 70, 0.12);
   color: #464646;
 }
+.provider-card--keenable .provider-card__badge {
+  background: rgba(20, 158, 130, 0.12);
+  color: #149E82;
+}
 
 .provider-card__body {
   flex: 1;
@@ -1120,5 +1128,9 @@ onMounted(async () => {
 .websearch-drawer--ollama .setting-drawer__header-icon {
   background: rgba(70, 70, 70, 0.12);
   color: #464646;
+}
+.websearch-drawer--keenable .setting-drawer__header-icon {
+  background: rgba(20, 158, 130, 0.12);
+  color: #149E82;
 }
 </style>

--- a/internal/infrastructure/web_search/keenable.go
+++ b/internal/infrastructure/web_search/keenable.go
@@ -20,6 +20,9 @@ const (
 	defaultKeenableBaseURL = "https://api.keenable.ai"
 	// keenableTitle is the attribution tag Keenable segments integration traffic by.
 	keenableTitle = "WeKnora"
+	// defaultKeenableResults matches the fallback other providers use when the
+	// caller does not specify a positive maxResults.
+	defaultKeenableResults = 5
 )
 
 var (
@@ -63,6 +66,9 @@ func (p *KeenableProvider) Search(
 ) ([]*types.WebSearchResult, error) {
 	if len(query) == 0 {
 		return nil, fmt.Errorf("query is empty")
+	}
+	if maxResults <= 0 {
+		maxResults = defaultKeenableResults
 	}
 
 	// Keyless by default; a configured key switches to the authenticated path.
@@ -116,10 +122,19 @@ func (p *KeenableProvider) Search(
 		if maxResults > 0 && len(results) >= maxResults {
 			break
 		}
+		// Keenable returns both a short "description" and a longer "snippet"
+		// excerpt. Prefer the short description as the summary snippet and keep
+		// the longer excerpt as Content (used by RAG compression). Fall back to
+		// whichever is present so we never drop the only available text.
+		snippet := item.Description
+		if snippet == "" {
+			snippet = item.Snippet
+		}
 		result := &types.WebSearchResult{
 			Title:   item.Title,
 			URL:     item.URL,
-			Snippet: item.Description,
+			Snippet: snippet,
+			Content: item.Snippet,
 			Source:  "keenable",
 		}
 		if includeDate && item.PublishedAt != "" {
@@ -146,6 +161,7 @@ type keenableSearchResponse struct {
 		Title       string `json:"title"`
 		URL         string `json:"url"`
 		Description string `json:"description"`
+		Snippet     string `json:"snippet,omitempty"`
 		PublishedAt string `json:"published_at,omitempty"`
 		AcquiredAt  string `json:"acquired_at,omitempty"`
 	} `json:"results"`

--- a/internal/infrastructure/web_search/keenable_test.go
+++ b/internal/infrastructure/web_search/keenable_test.go
@@ -62,6 +62,38 @@ func TestKeenableProvider_Search_Keyless(t *testing.T) {
 	}
 }
 
+func TestKeenableProvider_Search_SnippetMapping(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"results": []map[string]any{
+				// Has both: description is the short summary, snippet the longer excerpt.
+				{"title": "T1", "url": "https://e/1", "description": "short", "snippet": "long excerpt"},
+				// Only snippet present: it must fall back into Snippet so we don't drop text.
+				{"title": "T2", "url": "https://e/2", "snippet": "only long"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := &KeenableProvider{client: srv.Client(), baseURL: srv.URL}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	results, err := p.Search(ctx, "q", 5, false)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Snippet != "short" || results[0].Content != "long excerpt" {
+		t.Errorf("result[0] snippet/content mapping wrong: %+v", results[0])
+	}
+	if results[1].Snippet != "only long" {
+		t.Errorf("result[1] should fall back to snippet when description is empty: %+v", results[1])
+	}
+}
+
 func TestKeenableProvider_Search_Keyed(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// A configured key => authenticated endpoint + X-API-Key.

--- a/internal/infrastructure/web_search/test_errors_test.go
+++ b/internal/infrastructure/web_search/test_errors_test.go
@@ -52,6 +52,20 @@ func TestEmptyTestResultsError_DuckDuckGo(t *testing.T) {
 	}
 }
 
+func TestEmptyTestResultsError_Keenable(t *testing.T) {
+	err := EmptyTestResultsError(string(types.WebSearchProviderTypeKeenable), nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "keenable returned 0 results") {
+		t.Fatalf("unexpected message: %q", msg)
+	}
+	if !strings.Contains(msg, "rate-limited") {
+		t.Fatalf("keenable message should hint at the keyless rate limit: %q", msg)
+	}
+}
+
 func TestEmptyTestResultsError_APIKeyProviders(t *testing.T) {
 	err := EmptyTestResultsError(string(types.WebSearchProviderTypeBing), nil)
 	if err == nil {

--- a/internal/types/web_search_provider.go
+++ b/internal/types/web_search_provider.go
@@ -128,6 +128,9 @@ type WebSearchProviderTypeInfo struct {
 	Name string `json:"name"`
 	// Whether the provider requires an API key
 	RequiresAPIKey bool `json:"requires_api_key"`
+	// Whether the provider accepts an optional API key (keyless by default, but a
+	// key unlocks higher limits — e.g. Keenable). Mutually exclusive with RequiresAPIKey.
+	SupportsOptionalAPIKey bool `json:"supports_optional_api_key,omitempty"`
 	// Whether the provider requires an engine ID (e.g., Google CSE)
 	RequiresEngineID bool `json:"requires_engine_id"`
 	// Whether the provider requires a user-supplied base URL (e.g., self-hosted SearXNG instance)
@@ -200,12 +203,13 @@ func GetWebSearchProviderTypes() []WebSearchProviderTypeInfo {
 			DocsURL:        "https://cloud.baidu.com/doc/AppBuilder/s/qlvEcai0p",
 		},
 		{
-			ID:             "keenable",
-			Name:           "Keenable",
-			RequiresAPIKey: false,
-			SupportsProxy:  true,
-			Description:    "Keenable web search built for AI agents (keyless by default; an optional API key lifts the rate limit)",
-			DocsURL:        "https://keenable.ai/",
+			ID:                     "keenable",
+			Name:                   "Keenable",
+			RequiresAPIKey:         false,
+			SupportsOptionalAPIKey: true,
+			SupportsProxy:          true,
+			Description:            "Keenable web search built for AI agents (keyless by default; an optional API key lifts the rate limit)",
+			DocsURL:                "https://keenable.ai/",
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up fixes for the Keenable web search provider merged in #1946:

- Add `supports_optional_api_key` provider metadata and render an optional API Key field in Web Search settings (create + edit via CredentialResource), so tenants can lift rate limits without raw API calls
- Map Keenable `description` → `Snippet` and longer `snippet` → `Content` for better RAG compression; fall back when only one field is present
- Default `maxResults` to 5 when callers pass `<= 0`, matching DuckDuckGo/SearXNG behavior
- Sync `keenable` into Swagger `WebSearchProviderType` enum
- Add Keenable brand colors in settings cards/drawer
- Add unit tests for snippet mapping and empty-result diagnostics

## Test plan

- [x] `go test ./internal/infrastructure/web_search/`
- [x] Settings → Web Search → add Keenable provider: optional API Key field visible, not required
- [x] Edit existing Keenable provider: CredentialResource allows setting/clearing API key
- [x] Test connection works keyless; with API key configured, requests hit authenticated endpoint
- [x] Agent web search returns results with snippet text available for RAG compression