### PR TITLE
Close references drawer when switching chat sessions

### DIFF
--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -136,7 +136,8 @@ import { clearCitationChunkCache } from '@/utils/citationChunkCache';
 import ChatReferencesDrawer from '@/components/ChatReferencesDrawer.vue';
 import { provideChatReferencesDrawer } from '@/composables/useChatReferencesDrawer';
 
-const { visible: referencesDrawerVisible } = provideChatReferencesDrawer();
+const referencesDrawer = provideChatReferencesDrawer();
+const { visible: referencesDrawerVisible } = referencesDrawer;
 
 const props = defineProps({
     session_id: { type: String, default: '' },
@@ -835,6 +836,7 @@ onMounted(async () => {
 })
 const clearData = () => {
     stopStream();
+    referencesDrawer.close();
     isReplying.value = false;
     fullContent.value = '';
     // Stop any IM-reply recovery poll for the session we're leaving/switching.


### PR DESCRIPTION
## Summary
- Close the chat references drawer when chat route/session state is cleared.
- Keep the main chat layout from carrying an open drawer state into another session.

## Validation
- cd frontend && npm run type-check