### PR TITLE
fix(search): harden tag scope resolution after #1907

### DIFF
--- a/internal/application/service/session_agent_qa.go
+++ b/internal/application/service/session_agent_qa.go
@@ -304,7 +304,7 @@ func (s *sessionService) buildAgentConfig(
 	// Build search targets using agent's tenant (handler has validated access for shared agent)
 	searchTargets, err := s.buildSearchTargets(ctx, agentTenantID, agentConfig.KnowledgeBases, agentConfig.KnowledgeIDs, req.TagScopes)
 	if err != nil {
-		logger.Warnf(ctx, "Failed to build search targets for agent: %v", err)
+		return nil, fmt.Errorf("build search targets: %w", err)
 	}
 	agentConfig.SearchTargets = searchTargets
 	logger.Infof(ctx, "Agent search targets built: %d targets", len(searchTargets))

--- a/internal/application/service/session_knowledge_qa.go
+++ b/internal/application/service/session_knowledge_qa.go
@@ -89,7 +89,7 @@ func (s *sessionService) KnowledgeQA(
 	// Build unified search targets (computed once, used throughout pipeline)
 	searchTargets, err := s.buildSearchTargets(ctx, retrievalTenantID, knowledgeBaseIDs, knowledgeIDs, req.TagScopes)
 	if err != nil {
-		logger.Warnf(ctx, "Failed to build search targets: %v", err)
+		return fmt.Errorf("build search targets: %w", err)
 	}
 
 	// Create chat management object with session settings
@@ -455,7 +455,10 @@ func (s *sessionService) buildSearchTargets(
 
 	kbByID := make(map[string]*types.KnowledgeBase)
 	if len(kbIDsToFetch) > 0 {
-		kbs, _ := s.knowledgeBaseService.GetKnowledgeBasesByIDsOnly(ctx, kbIDsToFetch)
+		kbs, kbFetchErr := s.knowledgeBaseService.GetKnowledgeBasesByIDsOnly(ctx, kbIDsToFetch)
+		if kbFetchErr != nil {
+			logger.Warnf(ctx, "Failed to fetch knowledge bases for search targets: %v", kbFetchErr)
+		}
 		for _, kb := range kbs {
 			if kb != nil {
 				kbByID[kb.ID] = kb
@@ -553,11 +556,14 @@ func (s *sessionService) buildSearchTargets(
 		kb := kbByID[kbID]
 		explicitKnowledgeIDs := uniqueNonEmptyStrings(kbToKnowledgeIDs[kbID])
 
-		if kb != nil && kb.Type != types.KnowledgeBaseTypeFAQ {
+		useDocumentTagResolution := kb == nil || kb.Type != types.KnowledgeBaseTypeFAQ
+		if kb == nil {
+			logger.Warnf(ctx, "Knowledge base metadata missing for tag scope, kb_id=%s, using document tag resolution", kbID)
+		}
+		if useDocumentTagResolution {
 			tagKnowledgeIDs, err := s.knowledgeService.ListKnowledgeIDsByTagIDs(ctx, kbTenant, kbID, tagIDs)
 			if err != nil {
-				logger.Warnf(ctx, "Failed to resolve knowledge IDs for tag scope, kb_id=%s: %v", kbID, err)
-				continue
+				return nil, fmt.Errorf("resolve knowledge IDs for tag scope kb_id=%s: %w", kbID, err)
 			}
 			if len(explicitKnowledgeIDs) > 0 {
 				tagKnowledgeIDs = intersectStrings(tagKnowledgeIDs, explicitKnowledgeIDs)
@@ -800,7 +806,7 @@ func (s *sessionService) SearchKnowledge(ctx context.Context,
 	// Build unified search targets (computed once, used throughout pipeline)
 	searchTargets, err := s.buildSearchTargets(ctx, tenantID, knowledgeBaseIDs, knowledgeIDs, tagScopes)
 	if err != nil {
-		logger.Warnf(ctx, "Failed to build search targets: %v", err)
+		return nil, fmt.Errorf("build search targets: %w", err)
 	}
 
 	if len(searchTargets) == 0 {

--- a/internal/application/service/session_tag_targets_test.go
+++ b/internal/application/service/session_tag_targets_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/Tencent/WeKnora/internal/types"
@@ -168,4 +169,87 @@ func TestBuildSearchTargets_FAQTagScopeKeepsIndexTagFilter(t *testing.T) {
 	assert.Equal(t, "faq-kb", targets[0].KnowledgeBaseID)
 	assert.ElementsMatch(t, []string{"tag-a", "tag-b"}, targets[0].TagIDs)
 	assert.False(t, targets[0].DisableDirectLoad)
+}
+
+func TestBuildSearchTargets_FullKBWithTagScopeSkipsFullKBTarget(t *testing.T) {
+	svc := newTagTargetSessionService()
+
+	targets, err := svc.buildSearchTargets(
+		tagTargetContext(),
+		100,
+		[]string{"doc-kb"},
+		nil,
+		[]types.TagScope{{KnowledgeBaseID: "doc-kb", TagIDs: []string{"tag-a"}}},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, types.SearchTargetTypeKnowledge, targets[0].Type)
+	assert.NotEqual(t, types.SearchTargetTypeKnowledgeBase, targets[0].Type)
+}
+
+func TestBuildSearchTargets_DocumentTagScopeWithMissingKBMetadata(t *testing.T) {
+	svc := &sessionService{
+		knowledgeBaseService: &tagTargetKnowledgeBaseService{kbs: map[string]*types.KnowledgeBase{}},
+		knowledgeService: &tagTargetKnowledgeService{
+			knowledges: []*types.Knowledge{
+				{ID: "doc-1", TenantID: 100, KnowledgeBaseID: "doc-kb"},
+				{ID: "doc-3", TenantID: 100, KnowledgeBaseID: "doc-kb"},
+			},
+			tagIDs: map[string][]string{
+				"doc-1": {"tag-a"},
+				"doc-3": {"tag-a"},
+			},
+		},
+	}
+
+	targets, err := svc.buildSearchTargets(
+		tagTargetContext(),
+		100,
+		[]string{"doc-kb"},
+		nil,
+		[]types.TagScope{{KnowledgeBaseID: "doc-kb", TagIDs: []string{"tag-a"}}},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, types.SearchTargetTypeKnowledge, targets[0].Type)
+	assert.ElementsMatch(t, []string{"doc-1", "doc-3"}, targets[0].KnowledgeIDs)
+	assert.True(t, targets[0].DisableDirectLoad)
+}
+
+type tagTargetKnowledgeServiceWithError struct {
+	tagTargetKnowledgeService
+	listErr error
+}
+
+func (s *tagTargetKnowledgeServiceWithError) ListKnowledgeIDsByTagIDs(
+	ctx context.Context,
+	tenantID uint64,
+	kbID string,
+	tagIDs []string,
+) ([]string, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.tagTargetKnowledgeService.ListKnowledgeIDsByTagIDs(ctx, tenantID, kbID, tagIDs)
+}
+
+func TestBuildSearchTargets_DocumentTagScopeResolutionError(t *testing.T) {
+	base := newTagTargetSessionService()
+	base.knowledgeService = &tagTargetKnowledgeServiceWithError{
+		tagTargetKnowledgeService: *base.knowledgeService.(*tagTargetKnowledgeService),
+		listErr:                   fmt.Errorf("database unavailable"),
+	}
+
+	_, err := base.buildSearchTargets(
+		tagTargetContext(),
+		100,
+		[]string{"doc-kb"},
+		nil,
+		[]types.TagScope{{KnowledgeBaseID: "doc-kb", TagIDs: []string{"tag-a"}}},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database unavailable")
 }

--- a/internal/handler/session/helpers.go
+++ b/internal/handler/session/helpers.go
@@ -98,12 +98,11 @@ func tagScopesFromMentionedItems(items []MentionedItemRequest) []types.TagScope 
 	return scopes
 }
 
-// mergeTagScopesFromRequestIDs supplements tag scopes built from mentioned_items
-// with bare tag_ids when the client did not send kb_id on each tag mention.
-// Orphan tag IDs are attached to the sole knowledge_base_id when unambiguous.
-func mergeTagScopesFromRequestIDs(scopes []types.TagScope, tagIDs, kbIDs []string) []types.TagScope {
+// orphanTagIDsForScope returns tag IDs from the request that are not already
+// covered by scoped mentions.
+func orphanTagIDsForScope(tagIDs []string, scopes []types.TagScope) []string {
 	if len(tagIDs) == 0 {
-		return scopes
+		return nil
 	}
 	covered := make(map[string]bool)
 	for _, scope := range scopes {
@@ -117,6 +116,25 @@ func mergeTagScopesFromRequestIDs(scopes []types.TagScope, tagIDs, kbIDs []strin
 			orphan = append(orphan, id)
 		}
 	}
+	return orphan
+}
+
+// validateUnscopedTagIDs rejects bare tag_ids that cannot be attached to a KB.
+func validateUnscopedTagIDs(orphan []string, kbIDs []string) error {
+	if len(orphan) == 0 {
+		return nil
+	}
+	if len(kbIDs) == 1 {
+		return nil
+	}
+	return fmt.Errorf("tag_ids must be scoped via mentioned_items or exactly one knowledge_base_id")
+}
+
+// mergeTagScopesFromRequestIDs supplements tag scopes built from mentioned_items
+// with bare tag_ids when the client did not send kb_id on each tag mention.
+// Orphan tag IDs are attached to the sole knowledge_base_id when unambiguous.
+func mergeTagScopesFromRequestIDs(scopes []types.TagScope, tagIDs, kbIDs []string) []types.TagScope {
+	orphan := orphanTagIDsForScope(tagIDs, scopes)
 	if len(orphan) == 0 {
 		return scopes
 	}

--- a/internal/handler/session/helpers_test.go
+++ b/internal/handler/session/helpers_test.go
@@ -44,3 +44,11 @@ func TestMergeTagScopesFromRequestIDs_AmbiguousKBIgnored(t *testing.T) {
 	scopes := mergeTagScopesFromRequestIDs(nil, []string{"tag-9"}, []string{"kb-1", "kb-2"})
 	assert.Empty(t, scopes)
 }
+
+func TestValidateUnscopedTagIDs(t *testing.T) {
+	assert.NoError(t, validateUnscopedTagIDs(nil, nil))
+	assert.NoError(t, validateUnscopedTagIDs(nil, []string{"kb-1", "kb-2"}))
+	assert.NoError(t, validateUnscopedTagIDs([]string{"tag-9"}, []string{"kb-1"}))
+	assert.Error(t, validateUnscopedTagIDs([]string{"tag-9"}, []string{"kb-1", "kb-2"}))
+	assert.Error(t, validateUnscopedTagIDs([]string{"tag-9"}, nil))
+}

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -250,11 +250,12 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 	//      had memory enabled in practice, keep that behaviour.
 	enableMemory := h.resolveEnableMemory(ctx, request.EnableMemory)
 
-	tagScopes := mergeTagScopesFromRequestIDs(
-		tagScopesFromMentionedItems(request.MentionedItems),
-		dedupRequestStrings(request.TagIDs),
-		secutils.SanitizeForLogArray(kbIDs),
-	)
+	mentionScopes := tagScopesFromMentionedItems(request.MentionedItems)
+	requestTagIDs := dedupRequestStrings(request.TagIDs)
+	if err := validateUnscopedTagIDs(orphanTagIDsForScope(requestTagIDs, mentionScopes), secutils.SanitizeForLogArray(kbIDs)); err != nil {
+		return nil, nil, errors.NewBadRequestError(err.Error())
+	}
+	tagScopes := mergeTagScopesFromRequestIDs(mentionScopes, requestTagIDs, secutils.SanitizeForLogArray(kbIDs))
 	tagIDs := dedupRequestStrings(append(request.TagIDs, mentionedIDsByType(request.MentionedItems, "tag")...))
 	mcpServiceIDs := dedupRequestStrings(append(request.MCPServiceIDs, mentionedIDsByType(request.MentionedItems, "mcp")...))
 	skillNames := dedupRequestStrings(append(request.SkillNames, mentionedIDsByType(request.MentionedItems, "skill")...))
@@ -522,11 +523,14 @@ func (h *Handler) SearchKnowledge(c *gin.Context) {
 		}
 	}
 
-	tagScopes := mergeTagScopesFromRequestIDs(
-		tagScopesFromMentionedItems(request.MentionedItems),
-		dedupRequestStrings(request.TagIDs),
-		secutils.SanitizeForLogArray(knowledgeBaseIDs),
-	)
+	mentionScopes := tagScopesFromMentionedItems(request.MentionedItems)
+	requestTagIDs := dedupRequestStrings(request.TagIDs)
+	if err := validateUnscopedTagIDs(orphanTagIDsForScope(requestTagIDs, mentionScopes), secutils.SanitizeForLogArray(knowledgeBaseIDs)); err != nil {
+		logger.Error(ctx, err.Error())
+		c.Error(errors.NewBadRequestError(err.Error()))
+		return
+	}
+	tagScopes := mergeTagScopesFromRequestIDs(mentionScopes, requestTagIDs, secutils.SanitizeForLogArray(knowledgeBaseIDs))
 
 	if len(knowledgeBaseIDs) == 0 && len(request.KnowledgeIDs) == 0 && len(tagScopes) == 0 {
 		logger.Error(ctx, "No knowledge base IDs, knowledge IDs, or tag scopes provided")


### PR DESCRIPTION
## Summary
- propagate tag scope resolution errors instead of silently returning empty search targets
- default missing knowledge base metadata to document tag relation lookup
- reject ambiguous bare `tag_ids` when multiple or no knowledge bases are in scope
- add regression coverage for tag-scoped search target behavior

## Root cause
The tag filtering changes from #1907 could lose intended search scope in edge cases: knowledge base metadata lookup failures were ignored, document tag resolution errors were logged and skipped, and bare `tag_ids` could be ambiguous when the request covered more than one knowledge base.

## Impact
Requests with invalid or ambiguous tag scope now fail early with a clear error instead of producing incomplete retrieval results. Document knowledge bases still resolve tag filters through knowledge IDs, including when KB metadata is unavailable.

## Validation
- `git diff --check origin/main..HEAD`
- `go test ./internal/application/service ./internal/handler/session`