### PR TITLE
fix: widen knowledge processing span names

### DIFF
--- a/internal/application/repository/knowledge_span_repo_test.go
+++ b/internal/application/repository/knowledge_span_repo_test.go
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS knowledge_processing_spans (
     attempt         INTEGER     NOT NULL DEFAULT 1,
     span_id         VARCHAR(64) NOT NULL,
     parent_span_id  VARCHAR(64),
-    name            VARCHAR(64) NOT NULL,
+    name            VARCHAR(256) NOT NULL,
     kind            VARCHAR(16) NOT NULL,
     status          VARCHAR(16) NOT NULL,
     input           TEXT,

--- a/internal/application/service/knowledge_span_tracker_test.go
+++ b/internal/application/service/knowledge_span_tracker_test.go
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS knowledge_processing_spans (
     attempt         INTEGER     NOT NULL DEFAULT 1,
     span_id         VARCHAR(64) NOT NULL,
     parent_span_id  VARCHAR(64),
-    name            VARCHAR(64) NOT NULL,
+    name            VARCHAR(256) NOT NULL,
     kind            VARCHAR(16) NOT NULL,
     status          VARCHAR(16) NOT NULL,
     input           TEXT,

--- a/internal/types/knowledge_span.go
+++ b/internal/types/knowledge_span.go
@@ -86,7 +86,7 @@ type KnowledgeProcessingSpan struct {
 	Attempt      int        `gorm:"column:attempt"                   json:"attempt"`
 	SpanID       string     `gorm:"column:span_id;size:64"           json:"span_id"`
 	ParentSpanID string     `gorm:"column:parent_span_id;size:64"    json:"parent_span_id,omitempty"`
-	Name         string     `gorm:"column:name;size:64"              json:"name"`
+	Name         string     `gorm:"column:name;size:256"             json:"name"`
 	Kind         string     `gorm:"column:kind;size:16"              json:"kind"`
 	Status       string     `gorm:"column:status;size:16"            json:"status"`
 	Input        JSONMap    `gorm:"column:input;type:jsonb"          json:"input,omitempty"`

--- a/internal/types/knowledge_span_test.go
+++ b/internal/types/knowledge_span_test.go
@@ -1,0 +1,21 @@
+package types
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm/schema"
+)
+
+func TestKnowledgeProcessingSpanNameFitsWikiSummarySpan(t *testing.T) {
+	parsed, err := schema.Parse(&KnowledgeProcessingSpan{}, &sync.Map{}, schema.NamingStrategy{})
+	require.NoError(t, err)
+
+	nameField := parsed.LookUpField("Name")
+	require.NotNil(t, nameField)
+
+	summarySpanName := "postprocess.wiki.page[summary/00000000-0000-0000-0000-000000000000]"
+	assert.GreaterOrEqual(t, nameField.Size, len(summarySpanName))
+}

--- a/migrations/versioned/000066_expand_knowledge_span_name.down.sql
+++ b/migrations/versioned/000066_expand_knowledge_span_name.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE knowledge_processing_spans
+    ALTER COLUMN name TYPE VARCHAR(64) USING LEFT(name, 64);

--- a/migrations/versioned/000066_expand_knowledge_span_name.up.sql
+++ b/migrations/versioned/000066_expand_knowledge_span_name.up.sql
@@ -1,0 +1,6 @@
+DO $$ BEGIN RAISE NOTICE '[Migration 000066] Widening knowledge processing span names'; END $$;
+
+ALTER TABLE knowledge_processing_spans
+    ALTER COLUMN name TYPE VARCHAR(256);
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000066] Knowledge processing span names widened'; END $$;


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description

Wiki summary pages generate span names such as `postprocess.wiki.page[summary/<knowledge-id>]`, which are 67 characters long. The `knowledge_processing_spans.name` column and its GORM model were limited to 64 characters, causing PostgreSQL inserts to fail and leaving Wiki-enabled documents stuck in `finalizing`.

This change:

- adds migration `000066` to widen `knowledge_processing_spans.name` to `VARCHAR(256)`
- keeps the down migration safe by truncating names back to 64 characters before narrowing the column
- aligns the GORM model and SQLite test schemas with the production column width
- adds a regression test covering the actual Wiki summary span name shape

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #1941

## Testing

- `go test ./internal/types ./internal/application/repository ./internal/application/service -count=1`
- `golangci-lint run --new-from-rev=HEAD` (`0 issues`)
- PostgreSQL 16 migration check:
  - the existing `VARCHAR(64)` schema rejects the 67-character Wiki summary span name
  - migration up allows the insert and preserves all 67 characters
  - migration down restores a 64-character column and truncates the value to 64 characters

Full `make test` was also attempted. Unrelated environment-dependent tests fail because the local DocReader service is not running on `localhost:50051`, and existing Notion/remote-image tests are blocked by the current SSRF rules for `127.0.0.1`. The packages changed by this PR pass.

Full `make lint` reports existing repository-wide findings; diff-scoped lint reports no new issues.

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

Not applicable; this is a database schema fix.
