### PR TITLE
feat(models): support additional thinking controls

### DIFF
--- a/frontend/src/components/ModelEditorDialog.vue
+++ b/frontend/src/components/ModelEditorDialog.vue
@@ -676,8 +676,24 @@ const applyThinkingControlFromModelData = () => {
 }
 
 const thinkingControlOptions = computed(() => {
-  const keys = ['none', 'chatTemplateKwargs', 'enableThinking', 'thinkingType'] as const
-  const values = ['none', 'chat_template_kwargs', 'enable_thinking', 'thinking_type'] as const
+  const keys = [
+    'none',
+    'chatTemplateKwargs',
+    'chatTemplateKwargsThinking',
+    'enableThinking',
+    'thinkingType',
+    'reasoningEffort',
+    'openrouterReasoning',
+  ] as const
+  const values = [
+    'none',
+    'chat_template_kwargs',
+    'chat_template_kwargs_thinking',
+    'enable_thinking',
+    'thinking_type',
+    'reasoning_effort',
+    'openrouter_reasoning',
+  ] as const
   return keys.map((key, i) => ({
     value: values[i],
     label: t(`model.editor.thinkingControl.${key}.label`),

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -3768,8 +3768,12 @@ export default {
           hint: 'Agent “Thinking mode” switch has no effect; thinking parameters are not sent in requests',
         },
         chatTemplateKwargs: {
-          label: 'chat_template_kwargs',
-          hint: 'Custom OpenAI-compatible gateways, NVIDIA NIM, vLLM / local Qwen',
+          label: 'chat_template_kwargs.enable_thinking',
+          hint: 'Sends enable_thinking inside chat_template_kwargs for local Qwen / some vLLM deployments',
+        },
+        chatTemplateKwargsThinking: {
+          label: 'chat_template_kwargs.thinking',
+          hint: 'Some vLLM / NVIDIA NIM models use the thinking boolean key',
         },
         enableThinking: {
           label: 'enable_thinking',
@@ -3778,6 +3782,14 @@ export default {
         thinkingType: {
           label: 'thinking.type',
           hint: 'Volcengine Ark; Tencent LKEAP (DeepSeek V3, etc.; default for LKEAP; use “Do not send” for R1)',
+        },
+        reasoningEffort: {
+          label: 'reasoning_effort',
+          hint: 'OpenAI-compatible reasoning models; sends medium when enabled unless extra_config overrides it',
+        },
+        openrouterReasoning: {
+          label: 'reasoning object',
+          hint: 'OpenRouter: reasoning.enabled / effort / max_tokens / exclude',
         },
       },
       dimensionHint: 'Model selected. Click "Detect Dimension" to fetch the vector dimension automatically.',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -2764,8 +2764,12 @@ export default {
           hint: "에이전트 「사고 모드」 스위치가 효과 없음, 요청에 사고 관련 매개변수를 보내지 않음",
         },
         chatTemplateKwargs: {
-          label: "chat_template_kwargs",
-          hint: "사용자 정의 OpenAI 호환, NVIDIA NIM, vLLM / 로컬 Qwen 배포",
+          label: "chat_template_kwargs.enable_thinking",
+          hint: "로컬 Qwen / 일부 vLLM 배포용으로 chat_template_kwargs 안에 enable_thinking을 보냅니다",
+        },
+        chatTemplateKwargsThinking: {
+          label: "chat_template_kwargs.thinking",
+          hint: "일부 vLLM / NVIDIA NIM 모델은 thinking 불리언 키를 사용합니다",
         },
         enableThinking: {
           label: "enable_thinking",
@@ -2774,6 +2778,14 @@ export default {
         thinkingType: {
           label: "thinking.type",
           hint: 'Volcengine Ark; Tencent LKEAP (DeepSeek V3 등, LKEAP 기본값; R1은 「전송 안 함」)',
+        },
+        reasoningEffort: {
+          label: "reasoning_effort",
+          hint: "OpenAI 호환 추론 모델; extra_config가 없으면 켤 때 medium을 보냅니다",
+        },
+        openrouterReasoning: {
+          label: "reasoning 객체",
+          hint: "OpenRouter: reasoning.enabled / effort / max_tokens / exclude",
         },
       },
       dimensionHint:

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -2462,8 +2462,12 @@ export default {
           hint: 'Переключатель «Режим размышления» агента не действует; параметры размышления не отправляются в запросе',
         },
         chatTemplateKwargs: {
-          label: 'chat_template_kwargs',
-          hint: 'Пользовательские OpenAI-совместимые шлюзы, NVIDIA NIM, vLLM / локальный Qwen',
+          label: 'chat_template_kwargs.enable_thinking',
+          hint: 'Отправляет enable_thinking внутри chat_template_kwargs для локального Qwen / некоторых vLLM-развёртываний',
+        },
+        chatTemplateKwargsThinking: {
+          label: 'chat_template_kwargs.thinking',
+          hint: 'Некоторые модели vLLM / NVIDIA NIM используют булевый ключ thinking',
         },
         enableThinking: {
           label: 'enable_thinking',
@@ -2472,6 +2476,14 @@ export default {
         thinkingType: {
           label: 'thinking.type',
           hint: 'Volcengine Ark; Tencent LKEAP (DeepSeek V3 и др.; по умолчанию для LKEAP; для R1 — «Не отправлять»)',
+        },
+        reasoningEffort: {
+          label: 'reasoning_effort',
+          hint: 'OpenAI-совместимые reasoning-модели; при включении отправляет medium, если extra_config не переопределяет',
+        },
+        openrouterReasoning: {
+          label: 'объект reasoning',
+          hint: 'OpenRouter: reasoning.enabled / effort / max_tokens / exclude',
         },
       },
       dimensionHint: 'Модель выбрана. Нажмите «Определить размерность», чтобы автоматически получить значение.',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2786,8 +2786,12 @@ export default {
           hint: "智能体「思考模式」开关不生效，不会在请求中写入思考相关参数",
         },
         chatTemplateKwargs: {
-          label: "chat_template_kwargs",
-          hint: "自定义 OpenAI 兼容、NVIDIA NIM、vLLM / 本地 Qwen 部署",
+          label: "chat_template_kwargs.enable_thinking",
+          hint: "在 chat_template_kwargs 中写入 enable_thinking，适用于本地 Qwen / 部分 vLLM 部署",
+        },
+        chatTemplateKwargsThinking: {
+          label: "chat_template_kwargs.thinking",
+          hint: "vLLM / NVIDIA NIM 部分模型使用 thinking 布尔键",
         },
         enableThinking: {
           label: "enable_thinking",
@@ -2796,6 +2800,14 @@ export default {
         thinkingType: {
           label: "thinking.type",
           hint: "火山引擎 Ark；腾讯云 LKEAP（DeepSeek V3 等，选 LKEAP 时默认此项；R1 请改「不写入」）",
+        },
+        reasoningEffort: {
+          label: "reasoning_effort",
+          hint: "OpenAI 兼容推理模型；开启时写入 medium，可通过 extra_config 覆盖强度",
+        },
+        openrouterReasoning: {
+          label: "reasoning 对象",
+          hint: "OpenRouter：reasoning.enabled / effort / max_tokens / exclude",
         },
       },
       dimensionHint: '模型已选择，点击"检测维度"按钮自动获取向量维度',

--- a/frontend/src/utils/thinkingControl.test.ts
+++ b/frontend/src/utils/thinkingControl.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { defaultThinkingControl } from './thinkingControl.ts'
+import zhCN from '../i18n/locales/zh-CN.ts'
+import { defaultThinkingControl, resolveThinkingControl } from './thinkingControl.ts'
 
 // Cases mirror internal/models/chat/provider_test.go TestResolveProvider thinking defaults.
 test('defaultThinkingControl matches backend provider adapters', () => {
@@ -33,4 +34,21 @@ test('defaultThinkingControl matches backend provider adapters', () => {
       `${provider}/${model}`,
     )
   }
+})
+
+test('resolveThinkingControl accepts extended wire formats', () => {
+  const values = [
+    'chat_template_kwargs_thinking',
+    'reasoning_effort',
+    'openrouter_reasoning',
+  ] as const
+  for (const value of values) {
+    assert.equal(resolveThinkingControl(value, 'openai', 'gpt-5'), value)
+  }
+})
+
+test('zh-CN labels distinguish chat_template_kwargs variants', () => {
+  const thinkingControl = zhCN.model.editor.thinkingControl
+  assert.equal(thinkingControl.chatTemplateKwargs.label, 'chat_template_kwargs.enable_thinking')
+  assert.equal(thinkingControl.chatTemplateKwargsThinking.label, 'chat_template_kwargs.thinking')
 })

--- a/frontend/src/utils/thinkingControl.ts
+++ b/frontend/src/utils/thinkingControl.ts
@@ -17,14 +17,20 @@ export function isLkeapDeepSeekR1Model(modelName: string): boolean {
 export type ThinkingControlValue =
   | 'none'
   | 'chat_template_kwargs'
+  | 'chat_template_kwargs_thinking'
   | 'enable_thinking'
   | 'thinking_type'
+  | 'reasoning_effort'
+  | 'openrouter_reasoning'
 
 const THINKING_CONTROL_VALUES: ThinkingControlValue[] = [
   'none',
   'chat_template_kwargs',
+  'chat_template_kwargs_thinking',
   'enable_thinking',
   'thinking_type',
+  'reasoning_effort',
+  'openrouter_reasoning',
 ]
 
 /**

--- a/internal/models/chat/provider_test.go
+++ b/internal/models/chat/provider_test.go
@@ -85,6 +85,58 @@ func TestBuildOutbound_Thinking(t *testing.T) {
 		assert.Contains(t, mustJSON(t, body), "chat_template_kwargs")
 	})
 
+	t.Run("chat_template_kwargs thinking key", func(t *testing.T) {
+		c := newOutboundChat(t, string(provider.ProviderGeneric), "step-3.7-flash",
+			map[string]string{ExtraConfigThinkingControl: "chat_template_kwargs_thinking"})
+		body, _, useRaw, err := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(false)}, true)
+		require.NoError(t, err)
+		require.True(t, useRaw)
+		js := mustJSON(t, body)
+		assert.Contains(t, js, `"chat_template_kwargs"`)
+		assert.Contains(t, js, `"thinking":false`)
+		assert.NotContains(t, js, `"enable_thinking"`)
+	})
+
+	t.Run("reasoning effort enabled", func(t *testing.T) {
+		c := newOutboundChat(t, string(provider.ProviderOpenAI), "gpt-5",
+			map[string]string{
+				ExtraConfigThinkingControl: "reasoning_effort",
+				"reasoning_effort":         "high",
+			})
+		body, _, useRaw, err := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(true)}, true)
+		require.NoError(t, err)
+		assert.False(t, useRaw)
+		assert.Contains(t, mustJSON(t, body), `"reasoning_effort":"high"`)
+	})
+
+	t.Run("reasoning effort disabled", func(t *testing.T) {
+		c := newOutboundChat(t, string(provider.ProviderOpenAI), "gpt-5",
+			map[string]string{ExtraConfigThinkingControl: "reasoning_effort"})
+		body, _, useRaw, err := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(false)}, true)
+		require.NoError(t, err)
+		assert.False(t, useRaw)
+		assert.Contains(t, mustJSON(t, body), `"reasoning_effort":"none"`)
+	})
+
+	t.Run("openrouter reasoning object", func(t *testing.T) {
+		c := newOutboundChat(t, string(provider.ProviderOpenRouter), "openai/gpt-oss-120b",
+			map[string]string{
+				ExtraConfigThinkingControl: "openrouter_reasoning",
+				"reasoning_effort":         "medium",
+				"reasoning_max_tokens":     "1024",
+				"reasoning_exclude":        "true",
+			})
+		body, _, useRaw, err := c.buildOutbound(msgs, &ChatOptions{Thinking: ptrBool(true)}, true)
+		require.NoError(t, err)
+		require.True(t, useRaw)
+		js := mustJSON(t, body)
+		assert.Contains(t, js, `"reasoning"`)
+		assert.Contains(t, js, `"enabled":true`)
+		assert.Contains(t, js, `"effort":"medium"`)
+		assert.Contains(t, js, `"max_tokens":1024`)
+		assert.Contains(t, js, `"exclude":true`)
+	})
+
 	t.Run("none keeps the standard SDK request", func(t *testing.T) {
 		c := newOutboundChat(t, string(provider.ProviderGeneric), "x",
 			map[string]string{ExtraConfigThinkingControl: "none"})

--- a/internal/models/chat/thinking.go
+++ b/internal/models/chat/thinking.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/Tencent/WeKnora/internal/models/provider"
@@ -11,7 +12,8 @@ import (
 // selecting how ChatOptions.Thinking is translated to provider HTTP fields.
 // The accepted values mirror the strings the frontend writes (see
 // ModelEditorDialog.vue): "none", "enable_thinking", "thinking_type",
-// "chat_template_kwargs".
+// "chat_template_kwargs", "chat_template_kwargs_thinking",
+// "reasoning_effort", "openrouter_reasoning".
 const ExtraConfigThinkingControl = "thinking_control"
 
 // Wire-format request bodies used by providers that express extended-thinking
@@ -35,6 +37,20 @@ type ThinkingConfig struct {
 type ThinkingChatCompletionRequest struct {
 	openai.ChatCompletionRequest
 	Thinking *ThinkingConfig `json:"thinking,omitempty"`
+}
+
+// ReasoningConfig is OpenRouter's top-level `reasoning` block.
+type ReasoningConfig struct {
+	Enabled   *bool  `json:"enabled,omitempty"`
+	Effort    string `json:"effort,omitempty"`
+	MaxTokens int    `json:"max_tokens,omitempty"`
+	Exclude   *bool  `json:"exclude,omitempty"`
+}
+
+// ReasoningChatCompletionRequest adds a provider-specific `reasoning` object.
+type ReasoningChatCompletionRequest struct {
+	openai.ChatCompletionRequest
+	Reasoning *ReasoningConfig `json:"reasoning,omitempty"`
 }
 
 // ThinkingStrategy encodes how ChatOptions.Thinking is mapped onto a provider's
@@ -103,18 +119,67 @@ func (thinkingTypeField) Apply(req *openai.ChatCompletionRequest, opts *ChatOpti
 }
 
 // chatTemplateKwargs encodes thinking via the standard request's
-// `chat_template_kwargs.enable_thinking` (vLLM / NVIDIA / generic local
-// deployments). Emits nothing when opts.Thinking is unset.
-type chatTemplateKwargs struct{}
+// `chat_template_kwargs.<key>` (vLLM / NVIDIA / generic local deployments).
+// Emits nothing when opts.Thinking is unset.
+type chatTemplateKwargs struct {
+	key string
+}
 
-func (chatTemplateKwargs) Apply(req *openai.ChatCompletionRequest, opts *ChatOptions, _ bool) (any, bool) {
+func (s chatTemplateKwargs) Apply(req *openai.ChatCompletionRequest, opts *ChatOptions, _ bool) (any, bool) {
 	if opts == nil || opts.Thinking == nil {
 		return nil, false
 	}
+	key := strings.TrimSpace(s.key)
+	if key == "" {
+		key = "enable_thinking"
+	}
 	req.ChatTemplateKwargs = map[string]interface{}{
-		"enable_thinking": *opts.Thinking,
+		key: *opts.Thinking,
 	}
 	return req, true
+}
+
+// reasoningEffort encodes thinking as top-level `reasoning_effort`. This is
+// useful for OpenAI-compatible providers that use effort values rather than an
+// explicit boolean toggle.
+type reasoningEffort struct {
+	enabledEffort  string
+	disabledEffort string
+}
+
+func (s reasoningEffort) Apply(req *openai.ChatCompletionRequest, opts *ChatOptions, _ bool) (any, bool) {
+	if opts == nil || opts.Thinking == nil {
+		return nil, false
+	}
+	if *opts.Thinking {
+		req.ReasoningEffort = defaultString(s.enabledEffort, "medium")
+	} else {
+		req.ReasoningEffort = defaultString(s.disabledEffort, "none")
+	}
+	return nil, false
+}
+
+// openRouterReasoning encodes thinking through OpenRouter's top-level
+// `reasoning` object.
+type openRouterReasoning struct {
+	effort    string
+	maxTokens int
+	exclude   *bool
+}
+
+func (s openRouterReasoning) Apply(req *openai.ChatCompletionRequest, opts *ChatOptions, _ bool) (any, bool) {
+	if opts == nil || opts.Thinking == nil {
+		return nil, false
+	}
+	enabled := *opts.Thinking
+	cfg := &ReasoningConfig{Enabled: &enabled}
+	if enabled {
+		cfg.Effort = strings.TrimSpace(s.effort)
+		cfg.MaxTokens = s.maxTokens
+		cfg.Exclude = s.exclude
+	}
+	r := ReasoningChatCompletionRequest{ChatCompletionRequest: *req, Reasoning: cfg}
+	return r, true
 }
 
 // parseThinkingOverride reads extra_config.thinking_control and returns the
@@ -134,6 +199,19 @@ func parseThinkingOverride(extraConfig map[string]string) ThinkingStrategy {
 		return enableThinking{}
 	case "thinking_type":
 		return thinkingTypeField{}
+	case "chat_template_kwargs_thinking":
+		return chatTemplateKwargs{key: "thinking"}
+	case "reasoning_effort":
+		return reasoningEffort{
+			enabledEffort:  extraConfigString(extraConfig, "reasoning_effort", "medium"),
+			disabledEffort: extraConfigString(extraConfig, "reasoning_effort_disabled", "none"),
+		}
+	case "openrouter_reasoning":
+		return openRouterReasoning{
+			effort:    extraConfigString(extraConfig, "reasoning_effort", ""),
+			maxTokens: extraConfigInt(extraConfig, "reasoning_max_tokens"),
+			exclude:   extraConfigBoolPtr(extraConfig, "reasoning_exclude"),
+		}
 	default:
 		// "chat_template_kwargs" and any unknown non-empty value.
 		return chatTemplateKwargs{}
@@ -159,14 +237,61 @@ func EffectiveThinkingControl(config *ChatConfig) string {
 }
 
 func thinkingStrategyName(strategy ThinkingStrategy) string {
-	switch strategy.(type) {
+	switch s := strategy.(type) {
 	case enableThinking:
 		return "enable_thinking"
 	case thinkingTypeField:
 		return "thinking_type"
 	case chatTemplateKwargs:
+		if s.key == "thinking" {
+			return "chat_template_kwargs_thinking"
+		}
 		return "chat_template_kwargs"
+	case reasoningEffort:
+		return "reasoning_effort"
+	case openRouterReasoning:
+		return "openrouter_reasoning"
 	default:
 		return "none"
 	}
+}
+
+func defaultString(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return strings.TrimSpace(value)
+}
+
+func extraConfigString(extraConfig map[string]string, key, fallback string) string {
+	if extraConfig == nil {
+		return fallback
+	}
+	return defaultString(extraConfig[key], fallback)
+}
+
+func extraConfigInt(extraConfig map[string]string, key string) int {
+	if extraConfig == nil {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(extraConfig[key]))
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
+}
+
+func extraConfigBoolPtr(extraConfig map[string]string, key string) *bool {
+	if extraConfig == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(extraConfig[key])
+	if raw == "" {
+		return nil
+	}
+	b, err := strconv.ParseBool(raw)
+	if err != nil {
+		return nil
+	}
+	return &b
 }

--- a/internal/models/chat/thinking_test.go
+++ b/internal/models/chat/thinking_test.go
@@ -11,6 +11,13 @@ import (
 
 func ptrBool(b bool) *bool { return &b }
 
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	body, err := json.Marshal(v)
+	require.NoError(t, err)
+	return body
+}
+
 // TestThinkingStrategy_NilThinking verifies the strategies that defer to the
 // model default emit nothing when ChatOptions.Thinking is unset.
 func TestThinkingStrategy_NilThinking(t *testing.T) {
@@ -20,6 +27,9 @@ func TestThinkingStrategy_NilThinking(t *testing.T) {
 		enableThinking{}, // not alwaysSend
 		thinkingTypeField{},
 		chatTemplateKwargs{},
+		chatTemplateKwargs{key: "thinking"},
+		reasoningEffort{},
+		openRouterReasoning{},
 	}
 	for _, s := range strategies {
 		custom, raw := s.Apply(&req, nil, true)
@@ -108,13 +118,65 @@ func TestChatTemplateKwargs(t *testing.T) {
 	assert.Contains(t, string(body), "chat_template_kwargs")
 }
 
+func TestChatTemplateKwargsThinkingKey(t *testing.T) {
+	s := chatTemplateKwargs{key: "thinking"}
+	req := openai.ChatCompletionRequest{Model: "nim-step"}
+
+	custom, raw := s.Apply(&req, &ChatOptions{Thinking: ptrBool(false)}, true)
+	require.True(t, raw)
+	out, ok := custom.(*openai.ChatCompletionRequest)
+	require.True(t, ok)
+	assert.Equal(t, false, out.ChatTemplateKwargs["thinking"])
+	assert.NotContains(t, out.ChatTemplateKwargs, "enable_thinking")
+}
+
+func TestReasoningEffort(t *testing.T) {
+	s := reasoningEffort{enabledEffort: "high", disabledEffort: "none"}
+	req := openai.ChatCompletionRequest{Model: "grok"}
+
+	custom, raw := s.Apply(&req, &ChatOptions{Thinking: ptrBool(true)}, true)
+	assert.Nil(t, custom)
+	assert.False(t, raw)
+	assert.Equal(t, "high", req.ReasoningEffort)
+
+	req = openai.ChatCompletionRequest{Model: "grok"}
+	custom, raw = s.Apply(&req, &ChatOptions{Thinking: ptrBool(false)}, true)
+	assert.Nil(t, custom)
+	assert.False(t, raw)
+	assert.Equal(t, "none", req.ReasoningEffort)
+}
+
+func TestOpenRouterReasoning(t *testing.T) {
+	s := openRouterReasoning{effort: "medium", maxTokens: 2048, exclude: ptrBool(true)}
+	req := openai.ChatCompletionRequest{Model: "openrouter/reasoner"}
+
+	custom, raw := s.Apply(&req, &ChatOptions{Thinking: ptrBool(true)}, true)
+	require.True(t, raw)
+	require.NotNil(t, custom)
+	js := string(mustMarshal(t, custom))
+	assert.Contains(t, js, `"reasoning"`)
+	assert.Contains(t, js, `"enabled":true`)
+	assert.Contains(t, js, `"effort":"medium"`)
+	assert.Contains(t, js, `"max_tokens":2048`)
+	assert.Contains(t, js, `"exclude":true`)
+
+	custom, raw = s.Apply(&req, &ChatOptions{Thinking: ptrBool(false)}, true)
+	require.True(t, raw)
+	js = string(mustMarshal(t, custom))
+	assert.Contains(t, js, `"enabled":false`)
+	assert.NotContains(t, js, `"effort"`)
+}
+
 func TestParseThinkingOverride(t *testing.T) {
 	cases := map[string]ThinkingStrategy{
-		"none":                 noThinking{},
-		"enable_thinking":      enableThinking{},
-		"thinking_type":        thinkingTypeField{},
-		"chat_template_kwargs": chatTemplateKwargs{},
-		"something-unknown":    chatTemplateKwargs{}, // legacy default-mode fallback
+		"none":                          noThinking{},
+		"enable_thinking":               enableThinking{},
+		"thinking_type":                 thinkingTypeField{},
+		"chat_template_kwargs":          chatTemplateKwargs{},
+		"chat_template_kwargs_thinking": chatTemplateKwargs{},
+		"reasoning_effort":              reasoningEffort{},
+		"openrouter_reasoning":          openRouterReasoning{},
+		"something-unknown":             chatTemplateKwargs{}, // legacy default-mode fallback
 	}
 	for value, want := range cases {
 		got := parseThinkingOverride(map[string]string{ExtraConfigThinkingControl: value})
@@ -140,5 +202,20 @@ func TestEffectiveThinkingControl(t *testing.T) {
 		Provider:    "generic",
 		ModelName:   "qwen3",
 		ExtraConfig: map[string]string{ExtraConfigThinkingControl: "none"},
+	}))
+	assert.Equal(t, "chat_template_kwargs_thinking", EffectiveThinkingControl(&ChatConfig{
+		Provider:    "generic",
+		ModelName:   "step-3.7-flash",
+		ExtraConfig: map[string]string{ExtraConfigThinkingControl: "chat_template_kwargs_thinking"},
+	}))
+	assert.Equal(t, "reasoning_effort", EffectiveThinkingControl(&ChatConfig{
+		Provider:    "openai",
+		ModelName:   "gpt-5",
+		ExtraConfig: map[string]string{ExtraConfigThinkingControl: "reasoning_effort"},
+	}))
+	assert.Equal(t, "openrouter_reasoning", EffectiveThinkingControl(&ChatConfig{
+		Provider:    "openrouter",
+		ModelName:   "openai/gpt-oss-120b",
+		ExtraConfig: map[string]string{ExtraConfigThinkingControl: "openrouter_reasoning"},
 	}))
 }


### PR DESCRIPTION
## Summary

- Add additional thinking-control request formats for chat models: `chat_template_kwargs.thinking`, top-level `reasoning_effort`, and OpenRouter `reasoning` object.
- Extend the model editor option list and i18n copy so `chat_template_kwargs.enable_thinking` and `chat_template_kwargs.thinking` are visibly distinct.
- Add backend and frontend tests covering the new request mappings and option parsing.

## Validation

- `go test ./internal/models/chat`
- `go test ./internal/models/...`
- `npm test -- src/utils/thinkingControl.test.ts`
- `npm test`
- `npm run type-check`