### PR TITLE
fix(agent): polish selector capability status chips

### DIFF
--- a/frontend/src/components/AgentSelector.vue
+++ b/frontend/src/components/AgentSelector.vue
@@ -142,16 +142,22 @@
             <div class="detail-tag-group-title">{{ $t('agent.selector.capabilitiesSection') }}</div>
             <div class="detail-tags detail-tags--capabilities">
               <span class="detail-tag detail-capability-tag"
-                :class="isWebSearchReadyForAgent(activeDetail.agent) ? 'detail-tag--on' : 'detail-tag--off'">
-                <TIcon :name="isWebSearchReadyForAgent(activeDetail.agent) ? 'check' : 'close'" size="12px"
-                  class="detail-capability-icon" />
-                <span>{{ getWebSearchCapability(activeDetail.agent) }}</span>
+                :class="getWebSearchCapabilityClass(activeDetail.agent)">
+                <span class="detail-capability-icon-wrap">
+                  <TIcon :name="getWebSearchCapabilityIcon(activeDetail.agent)" size="10px"
+                    class="detail-capability-icon" />
+                </span>
+                <span class="detail-capability-name">{{ $t('agent.selector.webSearchCapability') }}</span>
+                <span class="detail-capability-state">{{ getWebSearchCapabilityState(activeDetail.agent) }}</span>
               </span>
               <span class="detail-tag detail-capability-tag"
-                :class="isImageUploadEnabledForAgent(activeDetail.agent) ? 'detail-tag--on' : 'detail-tag--off'">
-                <TIcon :name="isImageUploadEnabledForAgent(activeDetail.agent) ? 'check' : 'close'" size="12px"
-                  class="detail-capability-icon" />
-                <span>{{ getImageUploadCapability(activeDetail.agent) }}</span>
+                :class="isImageUploadEnabledForAgent(activeDetail.agent) ? 'detail-capability-tag--on' : 'detail-capability-tag--off'">
+                <span class="detail-capability-icon-wrap">
+                  <TIcon :name="isImageUploadEnabledForAgent(activeDetail.agent) ? 'check' : 'close'" size="10px"
+                    class="detail-capability-icon" />
+                </span>
+                <span class="detail-capability-name">{{ $t('agent.selector.imageUploadCapability') }}</span>
+                <span class="detail-capability-state">{{ getImageUploadCapabilityState(activeDetail.agent) }}</span>
               </span>
             </div>
           </div>
@@ -324,20 +330,28 @@ const isImageUploadEnabledForAgent = (agent: CustomAgent): boolean => {
   return config.image_upload_enabled === true;
 };
 
-const getWebSearchCapability = (agent: CustomAgent): string => {
-  if (!isWebSearchEnabledForAgent(agent)) {
-    return t('agent.capabilities.webSearchOff');
-  }
-  if (!isWebSearchReadyForAgent(agent)) {
-    return t('agent.capabilities.webSearchUnconfigured');
-  }
-  return t('agent.capabilities.webSearchOn');
+const getWebSearchCapabilityClass = (agent: CustomAgent): string => {
+  if (isWebSearchReadyForAgent(agent)) return 'detail-capability-tag--on';
+  if (isWebSearchEnabledForAgent(agent)) return 'detail-capability-tag--warning';
+  return 'detail-capability-tag--off';
 };
 
-const getImageUploadCapability = (agent: CustomAgent): string => {
+const getWebSearchCapabilityIcon = (agent: CustomAgent): string => {
+  if (isWebSearchReadyForAgent(agent)) return 'check';
+  if (isWebSearchEnabledForAgent(agent)) return 'error-circle';
+  return 'close';
+};
+
+const getWebSearchCapabilityState = (agent: CustomAgent): string => {
+  if (isWebSearchReadyForAgent(agent)) return t('agent.selector.capabilityEnabled');
+  if (isWebSearchEnabledForAgent(agent)) return t('agent.selector.capabilityUnconfigured');
+  return t('agent.selector.capabilityDisabled');
+};
+
+const getImageUploadCapabilityState = (agent: CustomAgent): string => {
   return isImageUploadEnabledForAgent(agent)
-    ? t('agent.capabilities.imageUploadOn')
-    : t('agent.capabilities.imageUploadOff');
+    ? t('agent.selector.capabilitySupported')
+    : t('agent.selector.capabilityUnsupported');
 };
 
 const getMcpCapability = (agent: CustomAgent): string => {
@@ -1002,32 +1016,86 @@ watch(activeDetail, (detail) => {
 }
 
 .detail-capability-tag {
-  gap: 4px;
-  padding: 3px 8px;
+  gap: 5px;
+  max-width: 100%;
+  padding: 3px 7px 3px 5px;
 
-  &--on {
+  .detail-capability-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     color: var(--td-text-color-secondary);
-    border-color: var(--td-component-border);
-    background: var(--td-bg-color-secondarycontainer);
-
-    .detail-capability-icon {
-      color: var(--td-text-color-primary);
-    }
+    font-weight: 500;
   }
 
-  &--off {
+  .detail-capability-state {
+    flex-shrink: 0;
+    font-size: 10px;
+    line-height: 14px;
     color: var(--td-text-color-placeholder);
-    border-style: dashed;
-    border-color: var(--td-component-stroke);
-    background: transparent;
-
-    .detail-capability-icon {
-      color: var(--td-text-color-placeholder);
-    }
   }
 }
 
+.detail-capability-tag--on {
+  border-color: rgba(0, 168, 112, 0.2);
+  background: rgba(0, 168, 112, 0.06);
+
+  .detail-capability-icon-wrap {
+    color: var(--td-success-color, #00a870);
+    background: rgba(0, 168, 112, 0.12);
+  }
+
+  .detail-capability-icon {
+    color: var(--td-success-color, #00a870);
+  }
+
+  .detail-capability-state {
+    color: var(--td-success-color, #00a870);
+  }
+}
+
+.detail-capability-tag--warning {
+  border-color: rgba(237, 123, 47, 0.22);
+  background: rgba(237, 123, 47, 0.06);
+
+  .detail-capability-icon-wrap {
+    color: var(--td-warning-color, #ed7b2f);
+    background: rgba(237, 123, 47, 0.12);
+  }
+
+  .detail-capability-icon,
+  .detail-capability-state {
+    color: var(--td-warning-color, #ed7b2f);
+  }
+}
+
+.detail-capability-tag--off {
+  border-color: var(--td-component-stroke);
+  background: var(--td-bg-color-secondarycontainer);
+
+  .detail-capability-icon-wrap {
+    color: var(--td-text-color-placeholder);
+    background: var(--td-bg-color-component, rgba(0, 0, 0, 0.04));
+  }
+
+  .detail-capability-icon {
+    color: var(--td-text-color-placeholder);
+  }
+}
+
+.detail-capability-icon-wrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
 .detail-capability-icon {
+  display: inline-flex;
   flex-shrink: 0;
   line-height: 1;
 }

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1155,6 +1155,13 @@ export default {
       configureAction: 'Configure',
       sharedNotReadyContact: 'Ask the sharing organization admin to finish setup',
       capabilitiesSection: 'Capabilities',
+      webSearchCapability: 'Web search',
+      imageUploadCapability: 'Image upload',
+      capabilityEnabled: 'On',
+      capabilityDisabled: 'Off',
+      capabilitySupported: 'Supported',
+      capabilityUnsupported: 'Unsupported',
+      capabilityUnconfigured: 'Not set',
     },
     // Built-in agent information
     builtinInfo: {

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -2170,6 +2170,13 @@ export default {
       configureAction: "구성",
       sharedNotReadyContact: "공유한 조직 관리자에게 구성을 요청하세요",
       capabilitiesSection: "능력",
+      webSearchCapability: "웹 검색",
+      imageUploadCapability: "이미지 업로드",
+      capabilityEnabled: "켜짐",
+      capabilityDisabled: "꺼짐",
+      capabilitySupported: "지원",
+      capabilityUnsupported: "미지원",
+      capabilityUnconfigured: "미구성",
     },
     // 내장 에이전트 정보
     builtinInfo: {

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -1069,6 +1069,13 @@ export default {
       configureAction: 'Configure',
       sharedNotReadyContact: 'Ask the sharing organization admin to finish setup',
       capabilitiesSection: 'Возможности',
+      webSearchCapability: 'Web search',
+      imageUploadCapability: 'Image upload',
+      capabilityEnabled: 'On',
+      capabilityDisabled: 'Off',
+      capabilitySupported: 'Supported',
+      capabilityUnsupported: 'Unsupported',
+      capabilityUnconfigured: 'Not set',
     },
     builtinInfo: {
       quickAnswer: {

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2166,6 +2166,13 @@ export default {
       configureAction: "去配置",
       sharedNotReadyContact: "请联系分享方管理员完成配置",
       capabilitiesSection: "能力",
+      webSearchCapability: "网络搜索",
+      imageUploadCapability: "图片上传",
+      capabilityEnabled: "开启",
+      capabilityDisabled: "关闭",
+      capabilitySupported: "支持",
+      capabilityUnsupported: "不支持",
+      capabilityUnconfigured: "未配置",
     },
     // 内置智能体信息
     builtinInfo: {


### PR DESCRIPTION
## Summary

- Refines the agent selector hover detail capability chips so icon, capability name, and status text are aligned as separate visual elements.
- Adds distinct ready, disabled, and unconfigured states for web search, plus supported/unsupported states for image upload.
- Adds localized selector-specific labels for zh-CN, en-US, ko-KR, and ru-RU without changing the broader agent capability labels used elsewhere.

## Validation

- `npm run type-check`
- `npm run build-only`

## Notes

The Vite build still reports the existing large chunk and mixed static/dynamic import warnings; the build completes successfully.