### PR TITLE
fix(cli): include shared resources in discovery commands

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -26,6 +26,9 @@ CLI history before v0.3 is recorded in the project root
   (a directly-executable argv array — no shell-splitting or quoting).
 
 ### Added
+- `kb list` and `agent list` now include shared-space resources by default;
+  `--owned` and `--shared` restrict the source, and shared rows expose space
+  and effective-permission metadata.
 - `chat` / `session ask --reference` includes indexed citations, while
   `--verbose` includes reasoning, tools, and lifecycle events. MCP `chat` /
   `session_ask` expose the same controls through `reference` / `verbose` inputs.
@@ -52,6 +55,8 @@ CLI history before v0.3 is recorded in the project root
   reference payloads.
 
 ### Fixed
+- KB name resolution, `search kb`, project linking, pin-state enrichment, and
+  MCP `kb_list` / `agent_list` now discover shared-space resources consistently.
 - Streaming SDK calls are no longer cut off by the client's default 30-second
   timeout (explicit `WithTimeout` values remain honored), and SSE data lines
   up to 4 MiB are accepted.

--- a/cli/README.md
+++ b/cli/README.md
@@ -224,7 +224,7 @@ against the whole envelope, so reach into list items with `.data[]`:
 ```bash
 weknora kb list --format json                              # {"ok":true,"data":[{"id":"kb_x",…}],"meta":{"count":1,…}}
 weknora kb list --shared --format json                     # shared-space KBs only
-weknora kb list --owned --format json                      # current-tenant KBs only
+weknora kb list --owned --format json                      # current-workspace KBs only
 weknora agent list --shared --format json                  # shared-space agents only
 weknora kb view kb_x --format json                         # {"ok":true,"data":{"id":"kb_x","name":"Eng",…}}
 weknora kb list --format json --jq '.data[] | {id, name}'  # project listed fields out of each item
@@ -232,7 +232,7 @@ weknora kb list --format json --jq '.data[].id'            # ids only
 weknora kb list --format json --jq '.meta.count'           # number returned
 ```
 
-`kb list` combines current-tenant and shared-space KBs by default. Shared rows
+`kb list` combines current-workspace and shared-space KBs by default. Shared rows
 carry `is_shared:true` plus `organization_id`, `org_name`, `permission`, and
 `source_tenant_id`; `--owned` and `--shared` are mutually exclusive filters.
 `agent list` follows the same source-selection and metadata rules.

--- a/cli/README.md
+++ b/cli/README.md
@@ -223,11 +223,19 @@ against the whole envelope, so reach into list items with `.data[]`:
 
 ```bash
 weknora kb list --format json                              # {"ok":true,"data":[{"id":"kb_x",…}],"meta":{"count":1,…}}
+weknora kb list --shared --format json                     # shared-space KBs only
+weknora kb list --owned --format json                      # current-tenant KBs only
+weknora agent list --shared --format json                  # shared-space agents only
 weknora kb view kb_x --format json                         # {"ok":true,"data":{"id":"kb_x","name":"Eng",…}}
 weknora kb list --format json --jq '.data[] | {id, name}'  # project listed fields out of each item
 weknora kb list --format json --jq '.data[].id'            # ids only
 weknora kb list --format json --jq '.meta.count'           # number returned
 ```
+
+`kb list` combines current-tenant and shared-space KBs by default. Shared rows
+carry `is_shared:true` plus `organization_id`, `org_name`, `permission`, and
+`source_tenant_id`; `--owned` and `--shared` are mutually exclusive filters.
+`agent list` follows the same source-selection and metadata rules.
 
 `--format ndjson` is also accepted for streaming list commands; each
 element is emitted as its own JSON line. `--format json` is the default

--- a/cli/cmd/agent/list.go
+++ b/cli/cmd/agent/list.go
@@ -65,12 +65,12 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			return runList(c.Context(), opts, fopts, cli)
 		},
 	}
-	cmd.Flags().BoolVar(&opts.Owned, "owned", false, "Only show agents in the current tenant")
+	cmd.Flags().BoolVar(&opts.Owned, "owned", false, "Only show agents in the current workspace")
 	cmd.Flags().BoolVar(&opts.Shared, "shared", false, "Only show agents received through shared spaces")
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 30, "Maximum results to return — client-side cap; meta.has_more/total_count report the full size (1..10000)")
 	cmdutil.AddFormatFlag(cmd, agentListFields...)
 	cmdutil.SetAgentHelp(cmd, cmdutil.AgentHelp{
-		UsedFor:  "List current-tenant and shared-space agents visible to the active profile. Use --owned or --shared to restrict the source.",
+		UsedFor:  "List current-workspace and shared-space agents visible to the active profile. Use --owned or --shared to restrict the source.",
 		Examples: []string{"weknora agent list --format json", "weknora agent list --shared --format json"},
 		Output:   "envelope.data is an array of Agent objects; is_shared identifies shared rows and shared rows include org_name, permission, and source_tenant_id",
 	})
@@ -135,7 +135,7 @@ func runList(ctx context.Context, opts *ListOptions, fopts *cmdutil.FormatOption
 
 	if len(items) == 0 {
 		if opts.Owned {
-			fmt.Fprintln(iostreams.IO.Out, "(no current-tenant agents)")
+			fmt.Fprintln(iostreams.IO.Out, "(no current-workspace agents)")
 			return nil
 		}
 		if opts.Shared {

--- a/cli/cmd/agent/list.go
+++ b/cli/cmd/agent/list.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Tencent/WeKnora/cli/internal/iostreams"
 	"github.com/Tencent/WeKnora/cli/internal/output"
 	"github.com/Tencent/WeKnora/cli/internal/text"
-	sdk "github.com/Tencent/WeKnora/client"
 )
 
 // agentListFields enumerates the fields surfaced for `--format json` discovery
@@ -22,16 +21,19 @@ import (
 var agentListFields = []string{
 	"id", "name", "description", "avatar",
 	"is_builtin", "tenant_id", "created_by",
+	"is_shared", "organization_id", "org_name", "permission", "source_tenant_id", "shared_at", "disabled_by_me",
 	"created_at", "updated_at",
 }
 
 // ListService is the narrow SDK surface this command depends on.
 type ListService interface {
-	ListAgents(ctx context.Context) ([]sdk.Agent, error)
+	cmdutil.VisibleAgentLister
 }
 
 // ListOptions captures `agent list` filter flag state.
 type ListOptions struct {
+	Owned  bool
+	Shared bool
 	// Limit caps the returned slice client-side. 0 = no cap, 1..10000 = explicit.
 	// The agent list SDK is unpaginated; --all-pages is intentionally not
 	// exposed because it would be a no-op.
@@ -43,7 +45,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	opts := &ListOptions{}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List custom agents visible to the active tenant",
+		Short: "List agents visible to the active profile",
 		Args:  cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
 			fopts, err := cmdutil.CheckFormatFlag(c)
@@ -63,12 +65,14 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			return runList(c.Context(), opts, fopts, cli)
 		},
 	}
+	cmd.Flags().BoolVar(&opts.Owned, "owned", false, "Only show agents in the current tenant")
+	cmd.Flags().BoolVar(&opts.Shared, "shared", false, "Only show agents received through shared spaces")
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 30, "Maximum results to return — client-side cap; meta.has_more/total_count report the full size (1..10000)")
 	cmdutil.AddFormatFlag(cmd, agentListFields...)
 	cmdutil.SetAgentHelp(cmd, cmdutil.AgentHelp{
-		UsedFor:  "List custom agents visible to the active tenant. The SDK returns all agents in one call (no server-side pagination); meta.count reflects the full tenant set, --limit caps client-side.",
-		Examples: []string{"weknora agent list --format json", "weknora agent list --limit 10 --format json"},
-		Output:   "envelope.data is an array of Agent objects with id, name, is_builtin; meta.total_count is the full tenant set and meta.has_more=true means --limit truncated it (raise --limit to get the rest)",
+		UsedFor:  "List current-tenant and shared-space agents visible to the active profile. Use --owned or --shared to restrict the source.",
+		Examples: []string{"weknora agent list --format json", "weknora agent list --shared --format json"},
+		Output:   "envelope.data is an array of Agent objects; is_shared identifies shared rows and shared rows include org_name, permission, and source_tenant_id",
 	})
 	return cmd
 }
@@ -79,6 +83,10 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 func validateListOpts(opts *ListOptions) error {
 	if opts == nil {
 		return nil
+	}
+	if opts.Owned && opts.Shared {
+		return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
+			"--owned and --shared are mutually exclusive")
 	}
 	if opts.Limit < 1 || opts.Limit > 10000 {
 		return &cmdutil.Error{
@@ -96,12 +104,12 @@ func runList(ctx context.Context, opts *ListOptions, fopts *cmdutil.FormatOption
 	if err := validateListOpts(opts); err != nil {
 		return err
 	}
-	items, err := svc.ListAgents(ctx)
+	items, err := cmdutil.ListVisibleAgents(ctx, svc, !opts.Shared, !opts.Owned)
 	if err != nil {
 		return cmdutil.WrapHTTP(err, "list agents")
 	}
 	if items == nil {
-		items = []sdk.Agent{} // ensure JSON [] not null
+		items = []cmdutil.VisibleAgent{} // ensure JSON [] not null
 	}
 	// Default sort: updated_at desc - most recently-edited agents surface
 	// first. Mirrors kb list / doc list behavior.
@@ -126,20 +134,37 @@ func runList(ctx context.Context, opts *ListOptions, fopts *cmdutil.FormatOption
 	}
 
 	if len(items) == 0 {
+		if opts.Owned {
+			fmt.Fprintln(iostreams.IO.Out, "(no current-tenant agents)")
+			return nil
+		}
+		if opts.Shared {
+			fmt.Fprintln(iostreams.IO.Out, "(no shared agents)")
+			return nil
+		}
 		fmt.Fprintln(iostreams.IO.Out, "(no agents)")
 		return nil
 	}
 
 	tw := tabwriter.NewWriter(iostreams.IO.Out, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "ID\tNAME\tBUILTIN\tUPDATED")
+	fmt.Fprintln(tw, "ID\tNAME\tSOURCE\tACCESS\tBUILTIN\tUPDATED")
 	now := time.Now()
 	for _, a := range items {
 		name := text.Truncate(40, a.Name)
+		source := "owned"
+		access := "-"
+		if a.IsShared {
+			source = "shared"
+			if a.OrgName != "" {
+				source = "shared:" + text.Truncate(24, a.OrgName)
+			}
+			access = a.Permission
+		}
 		builtin := "-"
 		if a.IsBuiltin {
 			builtin = "yes"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", a.ID, name, builtin, text.FuzzyAgo(now, a.UpdatedAt))
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", a.ID, name, source, access, builtin, text.FuzzyAgo(now, a.UpdatedAt))
 	}
 	return tw.Flush()
 }

--- a/cli/cmd/agent/list_test.go
+++ b/cli/cmd/agent/list_test.go
@@ -15,12 +15,18 @@ import (
 )
 
 type fakeListSvc struct {
-	items []sdk.Agent
-	err   error
+	items     []sdk.Agent
+	shared    []sdk.SharedAgentInfo
+	err       error
+	sharedErr error
 }
 
 func (f *fakeListSvc) ListAgents(_ context.Context) ([]sdk.Agent, error) {
 	return f.items, f.err
+}
+
+func (f *fakeListSvc) ListSharedAgents(_ context.Context) ([]sdk.SharedAgentInfo, error) {
+	return f.shared, f.sharedErr
 }
 
 func TestList_Empty_Text(t *testing.T) {
@@ -64,10 +70,46 @@ func TestList_NonEmpty_Text_RendersColumns(t *testing.T) {
 		t.Fatalf("runList: %v", err)
 	}
 	got := out.String()
-	for _, w := range []string{"ID", "NAME", "BUILTIN", "ag_a", "Research", "yes", "ag_b", "Triage"} {
+	for _, w := range []string{"ID", "NAME", "SOURCE", "ACCESS", "BUILTIN", "ag_a", "Research", "owned", "yes", "ag_b", "Triage"} {
 		if !strings.Contains(got, w) {
 			t.Errorf("output missing %q in:\n%s", w, got)
 		}
+	}
+}
+
+func TestList_DefaultIncludesSharedAgents(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	now := time.Now()
+	sharedAgent := sdk.Agent{ID: "ag_shared", Name: "Partner Agent", UpdatedAt: now}
+	svc := &fakeListSvc{
+		items: []sdk.Agent{{ID: "ag_owned", Name: "Own Agent", UpdatedAt: now.Add(-time.Hour)}},
+		shared: []sdk.SharedAgentInfo{{
+			Agent: &sharedAgent, OrgName: "Partners", Permission: "viewer", SourceTenantID: 42,
+		}},
+	}
+	if err := runList(context.Background(), &ListOptions{Limit: 30}, &cmdutil.FormatOptions{Mode: cmdutil.FormatJSON}, svc); err != nil {
+		t.Fatalf("runList: %v", err)
+	}
+	var env struct {
+		Data []cmdutil.VisibleAgent `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(env.Data) != 2 || !env.Data[0].IsShared || env.Data[0].OrgName != "Partners" {
+		t.Fatalf("unexpected merged agents: %+v", env.Data)
+	}
+}
+
+func TestList_OwnedAndSharedRejected(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	err := runList(context.Background(), &ListOptions{Owned: true, Shared: true, Limit: 30}, &cmdutil.FormatOptions{Mode: cmdutil.FormatJSON}, &fakeListSvc{})
+	if err == nil {
+		t.Fatal("expected mutually-exclusive flag error")
+	}
+	var typed *cmdutil.Error
+	if !errors.As(err, &typed) || typed.Code != cmdutil.CodeInputInvalidArgument {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/cli/cmd/kb/list.go
+++ b/cli/cmd/kb/list.go
@@ -32,7 +32,7 @@ var kbListFields = []string{
 // ListOptions captures `kb list` filter flag state.
 type ListOptions struct {
 	Pinned bool // --pinned: client-side filter to KBs with IsPinned == true
-	Owned  bool // --owned: only current-tenant KBs
+	Owned  bool // --owned: only current-workspace KBs
 	Shared bool // --shared: only KBs received through shared spaces
 	// Limit caps the returned slice client-side. 0 = no cap, 1..10000 = explicit.
 	// The KB list SDK is unpaginated; --all-pages is intentionally not exposed
@@ -51,7 +51,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List knowledge bases visible to the active profile",
-		Long: `List current-tenant and shared-space knowledge bases visible to the active
+		Long: `List current-workspace and shared-space knowledge bases visible to the active
 profile, sorted by most recently updated. Pass --owned or --shared to restrict
 the source, and --pinned to restrict to pinned KBs.`,
 		Args: cobra.NoArgs,
@@ -75,12 +75,12 @@ the source, and --pinned to restrict to pinned KBs.`,
 		},
 	}
 	cmd.Flags().BoolVar(&opts.Pinned, "pinned", false, "Only show pinned knowledge bases")
-	cmd.Flags().BoolVar(&opts.Owned, "owned", false, "Only show knowledge bases in the current tenant")
+	cmd.Flags().BoolVar(&opts.Owned, "owned", false, "Only show knowledge bases in the current workspace")
 	cmd.Flags().BoolVar(&opts.Shared, "shared", false, "Only show knowledge bases received through shared spaces")
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 30, "Maximum results to return — client-side cap; meta.has_more/total_count report the full size (1..10000)")
 	cmdutil.AddFormatFlag(cmd, kbListFields...)
 	cmdutil.SetAgentHelp(cmd, cmdutil.AgentHelp{
-		UsedFor:  "List current-tenant and shared-space knowledge bases visible to the active profile. Use --owned or --shared to restrict the source.",
+		UsedFor:  "List current-workspace and shared-space knowledge bases visible to the active profile. Use --owned or --shared to restrict the source.",
 		Examples: []string{"weknora kb list --format json", "weknora kb list --shared --format json"},
 		Output:   "envelope.data is an array of KnowledgeBase objects; is_shared identifies shared rows and shared rows include organization_id, org_name, permission, and source_tenant_id; meta.total_count is the full selected set",
 	})
@@ -153,7 +153,7 @@ func runList(ctx context.Context, opts *ListOptions, fopts *cmdutil.FormatOption
 			return nil
 		}
 		if opts.Owned {
-			fmt.Fprintln(iostreams.IO.Out, "(no current-tenant knowledge bases)")
+			fmt.Fprintln(iostreams.IO.Out, "(no current-workspace knowledge bases)")
 			return nil
 		}
 		if opts.Shared {

--- a/cli/cmd/kb/list.go
+++ b/cli/cmd/kb/list.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Tencent/WeKnora/cli/internal/iostreams"
 	"github.com/Tencent/WeKnora/cli/internal/output"
 	"github.com/Tencent/WeKnora/cli/internal/text"
-	sdk "github.com/Tencent/WeKnora/client"
 )
 
 // kbListFields enumerates the fields surfaced for `--format json` discovery on
@@ -23,6 +22,7 @@ import (
 var kbListFields = []string{
 	"id", "name", "type", "description",
 	"is_temporary", "is_pinned",
+	"is_shared", "organization_id", "org_name", "permission", "source_tenant_id", "shared_at",
 	"embedding_model_id", "summary_model_id",
 	"knowledge_count", "chunk_count",
 	"is_processing", "processing_count",
@@ -32,6 +32,8 @@ var kbListFields = []string{
 // ListOptions captures `kb list` filter flag state.
 type ListOptions struct {
 	Pinned bool // --pinned: client-side filter to KBs with IsPinned == true
+	Owned  bool // --owned: only current-tenant KBs
+	Shared bool // --shared: only KBs received through shared spaces
 	// Limit caps the returned slice client-side. 0 = no cap, 1..10000 = explicit.
 	// The KB list SDK is unpaginated; --all-pages is intentionally not exposed
 	// because it would be a no-op.
@@ -40,7 +42,7 @@ type ListOptions struct {
 
 // ListService is the narrow SDK surface this command depends on.
 type ListService interface {
-	ListKnowledgeBases(ctx context.Context) ([]sdk.KnowledgeBase, error)
+	cmdutil.VisibleKBLister
 }
 
 // NewCmdList builds `weknora kb list`.
@@ -49,8 +51,10 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List knowledge bases visible to the active profile",
-		Long:  `List knowledge bases visible to the active profile, sorted by most recently updated. Pass --pinned to restrict to pinned KBs.`,
-		Args:  cobra.NoArgs,
+		Long: `List current-tenant and shared-space knowledge bases visible to the active
+profile, sorted by most recently updated. Pass --owned or --shared to restrict
+the source, and --pinned to restrict to pinned KBs.`,
+		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
 			fopts, err := cmdutil.CheckFormatFlag(c)
 			if err != nil {
@@ -71,12 +75,14 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&opts.Pinned, "pinned", false, "Only show pinned knowledge bases")
+	cmd.Flags().BoolVar(&opts.Owned, "owned", false, "Only show knowledge bases in the current tenant")
+	cmd.Flags().BoolVar(&opts.Shared, "shared", false, "Only show knowledge bases received through shared spaces")
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 30, "Maximum results to return — client-side cap; meta.has_more/total_count report the full size (1..10000)")
 	cmdutil.AddFormatFlag(cmd, kbListFields...)
 	cmdutil.SetAgentHelp(cmd, cmdutil.AgentHelp{
-		UsedFor:  "List knowledge bases in the current tenant. --format json emits the standard envelope {ok, data:[...], meta:{count}, profile}.",
-		Examples: []string{"weknora kb list --format json"},
-		Output:   "envelope.data is an array of KnowledgeBase objects with id, name, is_pinned, type, embedding_model_id; meta.total_count is the full tenant set and meta.has_more=true means --limit truncated it (raise --limit to get the rest)",
+		UsedFor:  "List current-tenant and shared-space knowledge bases visible to the active profile. Use --owned or --shared to restrict the source.",
+		Examples: []string{"weknora kb list --format json", "weknora kb list --shared --format json"},
+		Output:   "envelope.data is an array of KnowledgeBase objects; is_shared identifies shared rows and shared rows include organization_id, org_name, permission, and source_tenant_id; meta.total_count is the full selected set",
 	})
 	return cmd
 }
@@ -85,6 +91,10 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 // (so a bad value surfaces as exit 5, not an auth error) and at runList's top
 // for direct callers; idempotent.
 func validateListOpts(opts *ListOptions) error {
+	if opts.Owned && opts.Shared {
+		return cmdutil.NewError(cmdutil.CodeInputInvalidArgument,
+			"--owned and --shared are mutually exclusive")
+	}
 	if opts.Limit < 1 || opts.Limit > 10000 {
 		return &cmdutil.Error{
 			Code:    cmdutil.CodeInputInvalidArgument,
@@ -98,12 +108,12 @@ func runList(ctx context.Context, opts *ListOptions, fopts *cmdutil.FormatOption
 	if err := validateListOpts(opts); err != nil {
 		return err
 	}
-	items, err := svc.ListKnowledgeBases(ctx)
+	items, err := cmdutil.ListVisibleKnowledgeBases(ctx, svc, !opts.Shared, !opts.Owned)
 	if err != nil {
 		return cmdutil.WrapHTTP(err, "list knowledge bases")
 	}
 	if items == nil {
-		items = []sdk.KnowledgeBase{} // ensure JSON [] not null
+		items = []cmdutil.VisibleKnowledgeBase{} // ensure JSON [] not null
 	}
 	if opts.Pinned {
 		filtered := items[:0]
@@ -142,18 +152,35 @@ func runList(ctx context.Context, opts *ListOptions, fopts *cmdutil.FormatOption
 			fmt.Fprintln(iostreams.IO.Out, "(no pinned knowledge bases)")
 			return nil
 		}
+		if opts.Owned {
+			fmt.Fprintln(iostreams.IO.Out, "(no current-tenant knowledge bases)")
+			return nil
+		}
+		if opts.Shared {
+			fmt.Fprintln(iostreams.IO.Out, "(no shared knowledge bases)")
+			return nil
+		}
 		fmt.Fprintln(iostreams.IO.Out, "(no knowledge bases)")
 		return nil
 	}
 
 	tw := tabwriter.NewWriter(iostreams.IO.Out, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "ID\tNAME\tDOCS\tUPDATED")
+	fmt.Fprintln(tw, "ID\tNAME\tSOURCE\tACCESS\tDOCS\tUPDATED")
 	now := time.Now()
 	for _, kb := range items {
 		name := text.Truncate(40, kb.Name)
+		source := "owned"
+		access := "-"
+		if kb.IsShared {
+			source = "shared"
+			if kb.OrgName != "" {
+				source = "shared:" + text.Truncate(24, kb.OrgName)
+			}
+			access = kb.Permission
+		}
 		docs := text.Pluralize(int(kb.KnowledgeCount), "doc")
 		updated := text.FuzzyAgo(now, kb.UpdatedAt)
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", kb.ID, name, docs, updated)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", kb.ID, name, source, access, docs, updated)
 	}
 	return tw.Flush()
 }

--- a/cli/cmd/kb/list_test.go
+++ b/cli/cmd/kb/list_test.go
@@ -9,18 +9,31 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/Tencent/WeKnora/cli/internal/cmdutil"
 	"github.com/Tencent/WeKnora/cli/internal/iostreams"
 	sdk "github.com/Tencent/WeKnora/client"
 )
 
 type fakeListSvc struct {
-	items []sdk.KnowledgeBase
-	err   error
+	items       []sdk.KnowledgeBase
+	shared      []sdk.SharedKnowledgeBaseInfo
+	err         error
+	sharedErr   error
+	ownedCalls  int
+	sharedCalls int
 }
 
 func (f *fakeListSvc) ListKnowledgeBases(ctx context.Context) ([]sdk.KnowledgeBase, error) {
+	f.ownedCalls++
 	return f.items, f.err
+}
+
+func (f *fakeListSvc) ListSharedKnowledgeBases(ctx context.Context) ([]sdk.SharedKnowledgeBaseInfo, error) {
+	f.sharedCalls++
+	return f.shared, f.sharedErr
 }
 
 func TestList_Empty_Text(t *testing.T) {
@@ -65,11 +78,60 @@ func TestList_NonEmpty_Text_RenderColumns(t *testing.T) {
 		t.Fatalf("runList: %v", err)
 	}
 	got := out.String()
-	for _, want := range []string{"ID", "NAME", "DOCS", "UPDATED", "kb1", "Marketing", "5 docs", "kb2", "Engineering", "1 doc"} {
+	for _, want := range []string{"ID", "NAME", "SOURCE", "ACCESS", "DOCS", "UPDATED", "kb1", "Marketing", "owned", "5 docs", "kb2", "Engineering", "1 doc"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q in:\n%s", want, got)
 		}
 	}
+}
+
+func TestList_DefaultMergesOwnedAndShared(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	now := time.Now()
+	sharedKB := sdk.KnowledgeBase{ID: "kb-shared", Name: "Partner Docs", KnowledgeCount: 2, UpdatedAt: now}
+	svc := &fakeListSvc{
+		items: []sdk.KnowledgeBase{{ID: "kb-owned", Name: "Team Docs", UpdatedAt: now.Add(-time.Hour)}},
+		shared: []sdk.SharedKnowledgeBaseInfo{{
+			KnowledgeBase: &sharedKB, OrganizationID: "org-1", OrgName: "Partners",
+			Permission: "viewer", SourceTenantID: 42, SharedAt: now.Add(-24 * time.Hour),
+		}},
+	}
+	require.NoError(t, runList(context.Background(), &ListOptions{Limit: 30}, &cmdutil.FormatOptions{Mode: cmdutil.FormatJSON}, svc))
+	var env struct {
+		Data []cmdutil.VisibleKnowledgeBase `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	require.Len(t, env.Data, 2)
+	assert.Equal(t, "kb-shared", env.Data[0].ID)
+	assert.True(t, env.Data[0].IsShared)
+	assert.Equal(t, "Partners", env.Data[0].OrgName)
+	assert.Equal(t, "viewer", env.Data[0].Permission)
+	assert.Equal(t, "kb-owned", env.Data[1].ID)
+	assert.False(t, env.Data[1].IsShared)
+}
+
+func TestList_SourceFiltersOnlyCallSelectedEndpoint(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	sharedKB := sdk.KnowledgeBase{ID: "kb-shared", Name: "Shared"}
+
+	ownedSvc := &fakeListSvc{items: []sdk.KnowledgeBase{{ID: "kb-owned"}}}
+	require.NoError(t, runList(context.Background(), &ListOptions{Owned: true, Limit: 30}, &cmdutil.FormatOptions{Mode: cmdutil.FormatJSON}, ownedSvc))
+	assert.Equal(t, 1, ownedSvc.ownedCalls)
+	assert.Zero(t, ownedSvc.sharedCalls)
+
+	sharedSvc := &fakeListSvc{shared: []sdk.SharedKnowledgeBaseInfo{{KnowledgeBase: &sharedKB}}}
+	require.NoError(t, runList(context.Background(), &ListOptions{Shared: true, Limit: 30}, &cmdutil.FormatOptions{Mode: cmdutil.FormatJSON}, sharedSvc))
+	assert.Zero(t, sharedSvc.ownedCalls)
+	assert.Equal(t, 1, sharedSvc.sharedCalls)
+}
+
+func TestList_OwnedAndSharedRejected(t *testing.T) {
+	_, _ = iostreams.SetForTest(t)
+	err := runList(context.Background(), &ListOptions{Owned: true, Shared: true, Limit: 30}, &cmdutil.FormatOptions{Mode: cmdutil.FormatJSON}, &fakeListSvc{})
+	require.Error(t, err)
+	var typed *cmdutil.Error
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, cmdutil.CodeInputInvalidArgument, typed.Code)
 }
 
 func TestList_JSON_JQProjection(t *testing.T) {

--- a/cli/cmd/kb/pin.go
+++ b/cli/cmd/kb/pin.go
@@ -27,7 +27,7 @@ type PinOptions struct {
 // list-ordering preference, surfaced where the user sees it — in `kb list`),
 // so the list is the canonical source.
 type PinService interface {
-	ListKnowledgeBases(ctx context.Context) ([]sdk.KnowledgeBase, error)
+	cmdutil.VisibleKBLister
 	TogglePinKnowledgeBase(ctx context.Context, id string) (*sdk.KnowledgeBase, error)
 }
 
@@ -90,14 +90,14 @@ func runPin(ctx context.Context, opts *PinOptions, fopts *cmdutil.FormatOptions,
 	// Read the current pin state from the list (the canonical per-user pin
 	// source); the single-KB GET doesn't carry it. This makes pin/unpin
 	// idempotent: we toggle only when the state actually needs to change.
-	kbs, err := svc.ListKnowledgeBases(ctx)
+	kbs, err := cmdutil.ListVisibleKnowledgeBases(ctx, svc, true, true)
 	if err != nil {
 		return cmdutil.WrapHTTP(err, "list knowledge bases")
 	}
 	var current *sdk.KnowledgeBase
 	for i := range kbs {
 		if kbs[i].ID == id {
-			current = &kbs[i]
+			current = &kbs[i].KnowledgeBase
 			break
 		}
 	}

--- a/cli/cmd/kb/pin_test.go
+++ b/cli/cmd/kb/pin_test.go
@@ -36,6 +36,10 @@ func (f *fakePinSvc) ListKnowledgeBases(_ context.Context) ([]sdk.KnowledgeBase,
 	return []sdk.KnowledgeBase{c}, nil
 }
 
+func (f *fakePinSvc) ListSharedKnowledgeBases(_ context.Context) ([]sdk.SharedKnowledgeBaseInfo, error) {
+	return nil, nil
+}
+
 func (f *fakePinSvc) TogglePinKnowledgeBase(_ context.Context, id string) (*sdk.KnowledgeBase, error) {
 	f.toggleCalled = true
 	if f.toggleErr != nil {

--- a/cli/cmd/kb/view.go
+++ b/cli/cmd/kb/view.go
@@ -31,7 +31,7 @@ type ViewOptions struct{}
 // doesn't carry per-user pin state — pin is a per-user list concept).
 type ViewService interface {
 	GetKnowledgeBase(ctx context.Context, id string) (*sdk.KnowledgeBase, error)
-	ListKnowledgeBases(ctx context.Context) ([]sdk.KnowledgeBase, error)
+	cmdutil.VisibleKBLister
 }
 
 // NewCmdView builds `weknora kb view <id>`.
@@ -77,7 +77,7 @@ func runView(ctx context.Context, opts *ViewOptions, fopts *cmdutil.FormatOption
 	// always read false here. Enrich it from the list (the canonical pin
 	// source) so the field is accurate. Best-effort: a list error leaves the
 	// (unstamped) value rather than failing the view.
-	if kbs, lerr := svc.ListKnowledgeBases(ctx); lerr == nil {
+	if kbs, lerr := cmdutil.ListVisibleKnowledgeBases(ctx, svc, true, true); lerr == nil {
 		for i := range kbs {
 			if kbs[i].ID == id {
 				kb.IsPinned = kbs[i].IsPinned

--- a/cli/cmd/kb/view_test.go
+++ b/cli/cmd/kb/view_test.go
@@ -31,6 +31,10 @@ func (f *fakeGetSvc) ListKnowledgeBases(ctx context.Context) ([]sdk.KnowledgeBas
 	return []sdk.KnowledgeBase{*f.kb}, nil
 }
 
+func (f *fakeGetSvc) ListSharedKnowledgeBases(ctx context.Context) ([]sdk.SharedKnowledgeBaseInfo, error) {
+	return nil, nil
+}
+
 func TestGet_OK_Text(t *testing.T) {
 	out, _ := iostreams.SetForTest(t)
 	svc := &fakeGetSvc{kb: &sdk.KnowledgeBase{

--- a/cli/cmd/link/link.go
+++ b/cli/cmd/link/link.go
@@ -207,8 +207,8 @@ func resolveKB(ctx context.Context, opts *Options, f *cmdutil.Factory) (string, 
 // promptForKB lists available knowledge bases on stderr, then asks the user
 // for an id or name. Resolved against the listed set so a typed name is
 // converted to the canonical id.
-func promptForKB(ctx context.Context, svc cmdutil.KBLister, f *cmdutil.Factory) (string, string, error) {
-	kbs, err := svc.ListKnowledgeBases(ctx)
+func promptForKB(ctx context.Context, svc cmdutil.VisibleKBLister, f *cmdutil.Factory) (string, string, error) {
+	kbs, err := cmdutil.ListVisibleKnowledgeBases(ctx, svc, true, true)
 	if err != nil {
 		return "", "", cmdutil.WrapHTTP(err, "list knowledge bases")
 	}
@@ -217,7 +217,15 @@ func promptForKB(ctx context.Context, svc cmdutil.KBLister, f *cmdutil.Factory) 
 	}
 	fmt.Fprintln(iostreams.IO.Err, "Available knowledge bases:")
 	for _, kb := range kbs {
-		fmt.Fprintf(iostreams.IO.Err, "  %s  %s\n", kb.ID, kb.Name)
+		suffix := ""
+		if kb.IsShared {
+			suffix = "  [shared"
+			if kb.OrgName != "" {
+				suffix += ":" + kb.OrgName
+			}
+			suffix += "]"
+		}
+		fmt.Fprintf(iostreams.IO.Err, "  %s  %s%s\n", kb.ID, kb.Name, suffix)
 	}
 	p := f.Prompter()
 	answer, err := p.Input("Knowledge base id or name", "")

--- a/cli/cmd/link/link_test.go
+++ b/cli/cmd/link/link_test.go
@@ -35,6 +35,10 @@ func fakeKBServer(t *testing.T, kbs []sdk.KnowledgeBase) *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(sdk.KnowledgeBaseListResponse{Success: true, Data: kbs})
 	})
+	mux.HandleFunc("/api/v1/shared-knowledge-bases", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true, "data": []any{}})
+	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv

--- a/cli/cmd/search/kb.go
+++ b/cli/cmd/search/kb.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Tencent/WeKnora/cli/internal/iostreams"
 	"github.com/Tencent/WeKnora/cli/internal/output"
 	"github.com/Tencent/WeKnora/cli/internal/text"
-	sdk "github.com/Tencent/WeKnora/client"
 )
 
 // kbSearchFields enumerates the fields surfaced for `--format json` discovery on
@@ -21,6 +20,7 @@ import (
 var kbSearchFields = []string{
 	"id", "name", "type", "description",
 	"is_temporary", "is_pinned",
+	"is_shared", "organization_id", "org_name", "permission", "source_tenant_id", "shared_at",
 	"embedding_model_id", "summary_model_id",
 	"knowledge_count", "chunk_count",
 	"is_processing", "processing_count",
@@ -36,7 +36,7 @@ type KBSearchOptions struct {
 // Server has no fuzzy-KB-name endpoint; the CLI filters ListKnowledgeBases
 // client-side. Acceptable because tenants typically have ≪ 1000 KBs.
 type KBSearchService interface {
-	ListKnowledgeBases(ctx context.Context) ([]sdk.KnowledgeBase, error)
+	cmdutil.VisibleKBLister
 }
 
 // NewCmdKB builds `weknora search kb "<query>"` - substring + case-insensitive
@@ -83,13 +83,13 @@ content, use ` + "`weknora search chunks`" + `.`,
 		UsedFor:       "Find knowledge bases by name or description (client-side case-insensitive substring match). Results come with meta.count; use --limit to cap. For searching content inside a KB, use 'search chunks' instead.",
 		RequiredFlags: []string{"<query> (positional)"},
 		Examples:      []string{`weknora search kb "engineering" --format json`},
-		Output:   "envelope.data is an array of KnowledgeBase objects with id, name, knowledge_count; meta.count is the returned count; meta.has_more=true if more matched than --limit",
+		Output:        "envelope.data is an array of KnowledgeBase objects with id, name, knowledge_count; meta.count is the returned count; meta.has_more=true if more matched than --limit",
 	})
 	return cmd
 }
 
 func runKBSearch(ctx context.Context, opts *KBSearchOptions, fopts *cmdutil.FormatOptions, svc KBSearchService) error {
-	items, err := svc.ListKnowledgeBases(ctx)
+	items, err := cmdutil.ListVisibleKnowledgeBases(ctx, svc, true, true)
 	if err != nil {
 		return cmdutil.WrapHTTP(err, "list knowledge bases")
 	}
@@ -101,7 +101,7 @@ func runKBSearch(ctx context.Context, opts *KBSearchOptions, fopts *cmdutil.Form
 
 	if fopts.WantsJSON() {
 		if matches == nil {
-			matches = []sdk.KnowledgeBase{}
+			matches = []cmdutil.VisibleKnowledgeBase{}
 		}
 		meta := &output.Meta{Count: output.IntPtr(len(matches)), HasMore: truncated}
 		return fopts.Emit(iostreams.IO.Out, matches, meta)
@@ -111,10 +111,17 @@ func runKBSearch(ctx context.Context, opts *KBSearchOptions, fopts *cmdutil.Form
 		return nil
 	}
 	tw := tabwriter.NewWriter(iostreams.IO.Out, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "ID\tNAME\tDOCS")
+	fmt.Fprintln(tw, "ID\tNAME\tSOURCE\tDOCS")
 	for _, kb := range matches {
 		name := text.Truncate(50, kb.Name)
-		fmt.Fprintf(tw, "%s\t%s\t%s\n", kb.ID, name, text.Pluralize(int(kb.KnowledgeCount), "doc"))
+		source := "owned"
+		if kb.IsShared {
+			source = "shared"
+			if kb.OrgName != "" {
+				source = "shared:" + text.Truncate(24, kb.OrgName)
+			}
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", kb.ID, name, source, text.Pluralize(int(kb.KnowledgeCount), "doc"))
 	}
 	return tw.Flush()
 }
@@ -122,9 +129,9 @@ func runKBSearch(ctx context.Context, opts *KBSearchOptions, fopts *cmdutil.Form
 // filterKBs returns the KBs whose name or description contains q (case-
 // insensitive), sorted by name length so the most-likely match shows
 // first. Ties broken alphabetically for determinism.
-func filterKBs(items []sdk.KnowledgeBase, q string) []sdk.KnowledgeBase {
+func filterKBs(items []cmdutil.VisibleKnowledgeBase, q string) []cmdutil.VisibleKnowledgeBase {
 	needle := strings.ToLower(q)
-	out := make([]sdk.KnowledgeBase, 0, len(items))
+	out := make([]cmdutil.VisibleKnowledgeBase, 0, len(items))
 	for _, kb := range items {
 		if text.ContainsFold(needle, kb.Name, kb.Description) {
 			out = append(out, kb)

--- a/cli/cmd/search/kb_test.go
+++ b/cli/cmd/search/kb_test.go
@@ -16,12 +16,18 @@ import (
 )
 
 type fakeKBSearchSvc struct {
-	items []sdk.KnowledgeBase
-	err   error
+	items     []sdk.KnowledgeBase
+	shared    []sdk.SharedKnowledgeBaseInfo
+	err       error
+	sharedErr error
 }
 
 func (f *fakeKBSearchSvc) ListKnowledgeBases(_ context.Context) ([]sdk.KnowledgeBase, error) {
 	return f.items, f.err
+}
+
+func (f *fakeKBSearchSvc) ListSharedKnowledgeBases(_ context.Context) ([]sdk.SharedKnowledgeBaseInfo, error) {
+	return f.shared, f.sharedErr
 }
 
 func TestKBSearch_Substring(t *testing.T) {
@@ -45,6 +51,17 @@ func TestKBSearch_CaseInsensitive(t *testing.T) {
 	}}
 	require.NoError(t, runKBSearch(context.Background(), &KBSearchOptions{Query: "engineering", Limit: 20}, &cmdutil.FormatOptions{Mode: cmdutil.FormatText}, svc))
 	assert.Contains(t, out.String(), "kb1")
+}
+
+func TestKBSearch_IncludesShared(t *testing.T) {
+	out, _ := iostreams.SetForTest(t)
+	sharedKB := sdk.KnowledgeBase{ID: "kb-shared", Name: "Partner Marketing"}
+	svc := &fakeKBSearchSvc{shared: []sdk.SharedKnowledgeBaseInfo{{
+		KnowledgeBase: &sharedKB, OrgName: "Partners", Permission: "viewer",
+	}}}
+	require.NoError(t, runKBSearch(context.Background(), &KBSearchOptions{Query: "partner", Limit: 20}, &cmdutil.FormatOptions{Mode: cmdutil.FormatText}, svc))
+	assert.Contains(t, out.String(), "kb-shared")
+	assert.Contains(t, out.String(), "shared:Partners")
 }
 
 func TestKBSearch_MatchesDescription(t *testing.T) {

--- a/cli/internal/cmdutil/agent.go
+++ b/cli/internal/cmdutil/agent.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/Tencent/WeKnora/client"
 )
 
-// VisibleAgentLister enumerates current-tenant and shared-space agents.
+// VisibleAgentLister enumerates current-workspace and shared-space agents.
 type VisibleAgentLister interface {
 	ListAgents(ctx context.Context) ([]sdk.Agent, error)
 	ListSharedAgents(ctx context.Context) ([]sdk.SharedAgentInfo, error)
@@ -26,7 +26,7 @@ type VisibleAgent struct {
 	DisabledByMe   bool       `json:"disabled_by_me,omitempty"`
 }
 
-// ListVisibleAgents combines current-tenant and shared-space agents. Owned
+// ListVisibleAgents combines current-workspace and shared-space agents. Owned
 // rows win if the same ID is ever returned by both endpoints.
 func ListVisibleAgents(
 	ctx context.Context, lister VisibleAgentLister, includeOwned, includeShared bool,

--- a/cli/internal/cmdutil/agent.go
+++ b/cli/internal/cmdutil/agent.go
@@ -1,0 +1,87 @@
+package cmdutil
+
+import (
+	"context"
+	"time"
+
+	sdk "github.com/Tencent/WeKnora/client"
+)
+
+// VisibleAgentLister enumerates current-tenant and shared-space agents.
+type VisibleAgentLister interface {
+	ListAgents(ctx context.Context) ([]sdk.Agent, error)
+	ListSharedAgents(ctx context.Context) ([]sdk.SharedAgentInfo, error)
+}
+
+// VisibleAgent flattens shared-space metadata onto the ordinary Agent shape.
+type VisibleAgent struct {
+	sdk.Agent
+	IsShared       bool       `json:"is_shared,omitempty"`
+	ShareID        string     `json:"share_id,omitempty"`
+	OrganizationID string     `json:"organization_id,omitempty"`
+	OrgName        string     `json:"org_name,omitempty"`
+	Permission     string     `json:"permission,omitempty"`
+	SourceTenantID uint64     `json:"source_tenant_id,omitempty"`
+	SharedAt       *time.Time `json:"shared_at,omitempty"`
+	DisabledByMe   bool       `json:"disabled_by_me,omitempty"`
+}
+
+// ListVisibleAgents combines current-tenant and shared-space agents. Owned
+// rows win if the same ID is ever returned by both endpoints.
+func ListVisibleAgents(
+	ctx context.Context, lister VisibleAgentLister, includeOwned, includeShared bool,
+) ([]VisibleAgent, error) {
+	var owned []sdk.Agent
+	var shared []sdk.SharedAgentInfo
+	if includeOwned {
+		var err error
+		owned, err = lister.ListAgents(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if includeShared {
+		var err error
+		shared, err = lister.ListSharedAgents(ctx)
+		if err != nil {
+			if includeOwned && ClassifyHTTPError(err) == CodeResourceNotFound {
+				shared = nil
+			} else {
+				return nil, err
+			}
+		}
+	}
+
+	items := make([]VisibleAgent, 0, len(owned)+len(shared))
+	seen := make(map[string]struct{}, len(owned)+len(shared))
+	for _, agent := range owned {
+		items = append(items, VisibleAgent{Agent: agent})
+		if agent.ID != "" {
+			seen[agent.ID] = struct{}{}
+		}
+	}
+	for _, info := range shared {
+		if info.Agent == nil {
+			continue
+		}
+		if _, ok := seen[info.Agent.ID]; info.Agent.ID != "" && ok {
+			continue
+		}
+		sharedAt := info.SharedAt
+		items = append(items, VisibleAgent{
+			Agent:          *info.Agent,
+			IsShared:       true,
+			ShareID:        info.ShareID,
+			OrganizationID: info.OrganizationID,
+			OrgName:        info.OrgName,
+			Permission:     info.Permission,
+			SourceTenantID: info.SourceTenantID,
+			SharedAt:       &sharedAt,
+			DisabledByMe:   info.DisabledByMe,
+		})
+		if info.Agent.ID != "" {
+			seen[info.Agent.ID] = struct{}{}
+		}
+	}
+	return items, nil
+}

--- a/cli/internal/cmdutil/factory_test.go
+++ b/cli/internal/cmdutil/factory_test.go
@@ -304,6 +304,10 @@ func fakeKBServer(t *testing.T, kbs []sdk.KnowledgeBase) *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(sdk.KnowledgeBaseListResponse{Success: true, Data: kbs})
 	})
+	mux.HandleFunc("/api/v1/shared-knowledge-bases", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true, "data": []any{}})
+	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv

--- a/cli/internal/cmdutil/kb.go
+++ b/cli/internal/cmdutil/kb.go
@@ -2,8 +2,10 @@ package cmdutil
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
+	"time"
 
 	sdk "github.com/Tencent/WeKnora/client"
 )
@@ -25,12 +27,136 @@ type KBLister interface {
 	ListKnowledgeBases(ctx context.Context) ([]sdk.KnowledgeBase, error)
 }
 
+// SharedKBLister is the SDK surface for knowledge bases made visible through
+// a shared space.
+type SharedKBLister interface {
+	ListSharedKnowledgeBases(ctx context.Context) ([]sdk.SharedKnowledgeBaseInfo, error)
+}
+
+// VisibleKBLister can enumerate both current-tenant and cross-tenant shared
+// knowledge bases. The production SDK client implements this interface.
+type VisibleKBLister interface {
+	KBLister
+	SharedKBLister
+}
+
+// VisibleKnowledgeBase is the flattened representation used by CLI discovery
+// commands. Owned rows retain the KnowledgeBase wire shape; shared rows add
+// is_shared=true plus the space and effective-permission metadata needed to
+// explain why the active profile can see them.
+type VisibleKnowledgeBase struct {
+	sdk.KnowledgeBase
+	IsShared       bool       `json:"is_shared,omitempty"`
+	ShareID        string     `json:"share_id,omitempty"`
+	OrganizationID string     `json:"organization_id,omitempty"`
+	OrgName        string     `json:"org_name,omitempty"`
+	Permission     string     `json:"permission,omitempty"`
+	SourceTenantID uint64     `json:"source_tenant_id,omitempty"`
+	SharedAt       *time.Time `json:"shared_at,omitempty"`
+}
+
+// UnmarshalJSON handles KnowledgeBase's custom unmarshaller explicitly. Without
+// this method, the anonymous embedded type's UnmarshalJSON is promoted and the
+// sharing metadata is silently discarded when MCP/test clients decode output.
+func (kb *VisibleKnowledgeBase) UnmarshalJSON(data []byte) error {
+	var base sdk.KnowledgeBase
+	if err := json.Unmarshal(data, &base); err != nil {
+		return err
+	}
+	var sharing struct {
+		IsShared       bool       `json:"is_shared"`
+		ShareID        string     `json:"share_id"`
+		OrganizationID string     `json:"organization_id"`
+		OrgName        string     `json:"org_name"`
+		Permission     string     `json:"permission"`
+		SourceTenantID uint64     `json:"source_tenant_id"`
+		SharedAt       *time.Time `json:"shared_at"`
+	}
+	if err := json.Unmarshal(data, &sharing); err != nil {
+		return err
+	}
+	kb.KnowledgeBase = base
+	kb.IsShared = sharing.IsShared
+	kb.ShareID = sharing.ShareID
+	kb.OrganizationID = sharing.OrganizationID
+	kb.OrgName = sharing.OrgName
+	kb.Permission = sharing.Permission
+	kb.SourceTenantID = sharing.SourceTenantID
+	kb.SharedAt = sharing.SharedAt
+	return nil
+}
+
+// ListVisibleKnowledgeBases combines current-tenant and shared-space KBs.
+// Callers choose which sources to include so `kb list --owned` and `--shared`
+// avoid unnecessary requests. Owned rows win defensively if an API ever
+// returns the same KB from both endpoints.
+func ListVisibleKnowledgeBases(
+	ctx context.Context, lister VisibleKBLister, includeOwned, includeShared bool,
+) ([]VisibleKnowledgeBase, error) {
+	var owned []sdk.KnowledgeBase
+	var shared []sdk.SharedKnowledgeBaseInfo
+
+	if includeOwned {
+		var err error
+		owned, err = lister.ListKnowledgeBases(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if includeShared {
+		var err error
+		shared, err = lister.ListSharedKnowledgeBases(ctx)
+		if err != nil {
+			// Preserve compatibility with servers predating the shared-list
+			// endpoint when this is an aggregate discovery call. An explicit
+			// --shared request still surfaces the 404.
+			if includeOwned && ClassifyHTTPError(err) == CodeResourceNotFound {
+				shared = nil
+			} else {
+				return nil, err
+			}
+		}
+	}
+
+	items := make([]VisibleKnowledgeBase, 0, len(owned)+len(shared))
+	seen := make(map[string]struct{}, len(owned)+len(shared))
+	for _, kb := range owned {
+		items = append(items, VisibleKnowledgeBase{KnowledgeBase: kb})
+		if kb.ID != "" {
+			seen[kb.ID] = struct{}{}
+		}
+	}
+	for _, info := range shared {
+		if info.KnowledgeBase == nil {
+			continue
+		}
+		if _, ok := seen[info.KnowledgeBase.ID]; info.KnowledgeBase.ID != "" && ok {
+			continue
+		}
+		sharedAt := info.SharedAt
+		items = append(items, VisibleKnowledgeBase{
+			KnowledgeBase:  *info.KnowledgeBase,
+			IsShared:       true,
+			ShareID:        info.ShareID,
+			OrganizationID: info.OrganizationID,
+			OrgName:        info.OrgName,
+			Permission:     info.Permission,
+			SourceTenantID: info.SourceTenantID,
+			SharedAt:       &sharedAt,
+		})
+		if info.KnowledgeBase.ID != "" {
+			seen[info.KnowledgeBase.ID] = struct{}{}
+		}
+	}
+	return items, nil
+}
+
 // ResolveKBFlag interprets a raw --kb value (id or name) and returns the
 // canonical id. Pass-through when raw already looks like an id; otherwise
 // list and match by name. Shared by every command that takes a --kb flag
 // directly (search chunks/docs, doc download, link …) so the id-or-name
 // policy never drifts.
-func ResolveKBFlag(ctx context.Context, lister KBLister, raw string) (string, error) {
+func ResolveKBFlag(ctx context.Context, lister VisibleKBLister, raw string) (string, error) {
 	if IsKBID(raw) {
 		return raw, nil
 	}
@@ -40,15 +166,25 @@ func ResolveKBFlag(ctx context.Context, lister KBLister, raw string) (string, er
 // ResolveKBNameToID looks up a knowledge base by name and returns its ID.
 // Used by `link` and `Factory.ResolveKB` - a single lookup so the match
 // policy (currently exact case-sensitive) lives in one place.
-func ResolveKBNameToID(ctx context.Context, lister KBLister, name string) (string, error) {
-	kbs, err := lister.ListKnowledgeBases(ctx)
+func ResolveKBNameToID(ctx context.Context, lister VisibleKBLister, name string) (string, error) {
+	kbs, err := ListVisibleKnowledgeBases(ctx, lister, true, true)
 	if err != nil {
 		return "", WrapHTTP(err, "list knowledge bases")
 	}
+	matches := make([]VisibleKnowledgeBase, 0, 1)
 	for _, kb := range kbs {
 		if kb.Name == name {
-			return kb.ID, nil
+			matches = append(matches, kb)
 		}
 	}
-	return "", NewError(CodeKBNotFound, fmt.Sprintf("knowledge base not found: %s", name))
+	switch len(matches) {
+	case 1:
+		return matches[0].ID, nil
+	case 0:
+		return "", NewError(CodeKBNotFound, fmt.Sprintf("knowledge base not found: %s", name))
+	default:
+		return "", NewError(CodeInputInvalidArgument,
+			fmt.Sprintf("%q matches %d visible knowledge bases; pass the UUID instead", name, len(matches))).
+			WithHint("run `weknora kb list` to inspect ids and sharing metadata")
+	}
 }

--- a/cli/internal/cmdutil/kb.go
+++ b/cli/internal/cmdutil/kb.go
@@ -33,7 +33,7 @@ type SharedKBLister interface {
 	ListSharedKnowledgeBases(ctx context.Context) ([]sdk.SharedKnowledgeBaseInfo, error)
 }
 
-// VisibleKBLister can enumerate both current-tenant and cross-tenant shared
+// VisibleKBLister can enumerate both current-workspace and cross-tenant shared
 // knowledge bases. The production SDK client implements this interface.
 type VisibleKBLister interface {
 	KBLister
@@ -86,7 +86,7 @@ func (kb *VisibleKnowledgeBase) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// ListVisibleKnowledgeBases combines current-tenant and shared-space KBs.
+// ListVisibleKnowledgeBases combines current-workspace and shared-space KBs.
 // Callers choose which sources to include so `kb list --owned` and `--shared`
 // avoid unnecessary requests. Owned rows win defensively if an API ever
 // returns the same KB from both endpoints.

--- a/cli/internal/cmdutil/kb_test.go
+++ b/cli/internal/cmdutil/kb_test.go
@@ -1,0 +1,46 @@
+package cmdutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/Tencent/WeKnora/client"
+)
+
+type fakeVisibleKBLister struct {
+	owned  []sdk.KnowledgeBase
+	shared []sdk.SharedKnowledgeBaseInfo
+}
+
+func (f *fakeVisibleKBLister) ListKnowledgeBases(context.Context) ([]sdk.KnowledgeBase, error) {
+	return f.owned, nil
+}
+
+func (f *fakeVisibleKBLister) ListSharedKnowledgeBases(context.Context) ([]sdk.SharedKnowledgeBaseInfo, error) {
+	return f.shared, nil
+}
+
+func TestResolveKBNameToIDFindsSharedKnowledgeBase(t *testing.T) {
+	sharedKB := sdk.KnowledgeBase{ID: "shared-id", Name: "Partner Docs"}
+	id, err := ResolveKBNameToID(context.Background(), &fakeVisibleKBLister{
+		shared: []sdk.SharedKnowledgeBaseInfo{{KnowledgeBase: &sharedKB}},
+	}, "Partner Docs")
+	require.NoError(t, err)
+	assert.Equal(t, "shared-id", id)
+}
+
+func TestResolveKBNameToIDRejectsCrossTenantAmbiguity(t *testing.T) {
+	sharedKB := sdk.KnowledgeBase{ID: "shared-id", Name: "Docs"}
+	_, err := ResolveKBNameToID(context.Background(), &fakeVisibleKBLister{
+		owned:  []sdk.KnowledgeBase{{ID: "owned-id", Name: "Docs"}},
+		shared: []sdk.SharedKnowledgeBaseInfo{{KnowledgeBase: &sharedKB}},
+	}, "Docs")
+	require.Error(t, err)
+	var typed *Error
+	require.True(t, errors.As(err, &typed))
+	assert.Equal(t, CodeInputInvalidArgument, typed.Code)
+}

--- a/cli/internal/mcp/tools.go
+++ b/cli/internal/mcp/tools.go
@@ -153,7 +153,7 @@ type kbListOutput struct {
 func addKBList(server *mcpsdk.Server, svc knowledgeBaseService) {
 	mcpsdk.AddTool(server, &mcpsdk.Tool{
 		Name:        "kb_list",
-		Description: "List all current-tenant and shared-space knowledge bases visible to the active WeKnora profile. No arguments. Shared items carry is_shared=true plus org_name, permission, and source_tenant_id.",
+		Description: "List all current-workspace and shared-space knowledge bases visible to the active WeKnora profile. No arguments. Shared items carry is_shared=true plus org_name, permission, and source_tenant_id.",
 		Annotations: &mcpsdk.ToolAnnotations{
 			Title:           "List Knowledge Bases",
 			DestructiveHint: bptr(false),
@@ -526,7 +526,7 @@ type agentListOutput struct {
 func addAgentList(server *mcpsdk.Server, svc agentService) {
 	mcpsdk.AddTool(server, &mcpsdk.Tool{
 		Name:        "agent_list",
-		Description: "List current-tenant and shared-space agents visible to the active profile. Shared items carry is_shared=true plus org_name, permission, and source_tenant_id; use an id with session_ask.",
+		Description: "List current-workspace and shared-space agents visible to the active profile. Shared items carry is_shared=true plus org_name, permission, and source_tenant_id; use an id with session_ask.",
 		Annotations: &mcpsdk.ToolAnnotations{
 			Title:           "List Custom Agents",
 			DestructiveHint: bptr(false),

--- a/cli/internal/mcp/tools.go
+++ b/cli/internal/mcp/tools.go
@@ -78,7 +78,7 @@ func marshalToString(v any) string {
 // them all; *sdk.Client satisfies the union implicitly.
 
 type knowledgeBaseService interface {
-	ListKnowledgeBases(ctx context.Context) ([]sdk.KnowledgeBase, error)
+	cmdutil.VisibleKBLister
 	GetKnowledgeBase(ctx context.Context, id string) (*sdk.KnowledgeBase, error)
 }
 
@@ -95,7 +95,7 @@ type chatService interface {
 }
 
 type agentService interface {
-	ListAgents(ctx context.Context) ([]sdk.Agent, error)
+	cmdutil.VisibleAgentLister
 	GetAgent(ctx context.Context, agentID string) (*sdk.Agent, error)
 	AgentQAStreamWithRequest(ctx context.Context, sessionID string, req *sdk.AgentQARequest, cb sdk.AgentEventCallback) error
 }
@@ -147,13 +147,13 @@ func registerTools(server *mcpsdk.Server, svc ServiceClient) {
 type kbListInput struct{}
 
 type kbListOutput struct {
-	Items []sdk.KnowledgeBase `json:"items"`
+	Items []cmdutil.VisibleKnowledgeBase `json:"items"`
 }
 
 func addKBList(server *mcpsdk.Server, svc knowledgeBaseService) {
 	mcpsdk.AddTool(server, &mcpsdk.Tool{
 		Name:        "kb_list",
-		Description: "List all knowledge bases visible to the active WeKnora tenant. No arguments. Returns items[]: each item carries id, name, description, knowledge_count, is_pinned, updated_at - useful for selecting a kb_id to pass to other tools.",
+		Description: "List all current-tenant and shared-space knowledge bases visible to the active WeKnora profile. No arguments. Shared items carry is_shared=true plus org_name, permission, and source_tenant_id.",
 		Annotations: &mcpsdk.ToolAnnotations{
 			Title:           "List Knowledge Bases",
 			DestructiveHint: bptr(false),
@@ -162,12 +162,12 @@ func addKBList(server *mcpsdk.Server, svc knowledgeBaseService) {
 			OpenWorldHint:   bptr(false),
 		},
 	}, func(ctx context.Context, _ *mcpsdk.CallToolRequest, _ kbListInput) (*mcpsdk.CallToolResult, any, error) {
-		items, err := svc.ListKnowledgeBases(ctx)
+		items, err := cmdutil.ListVisibleKnowledgeBases(ctx, svc, true, true)
 		if err != nil {
 			return toolErrorResult(cmdutil.WrapHTTP(err, "list knowledge bases")), nil, nil
 		}
 		if items == nil {
-			items = []sdk.KnowledgeBase{}
+			items = []cmdutil.VisibleKnowledgeBase{}
 		}
 		return successResult(kbListOutput{Items: items}), nil, nil
 	})
@@ -520,13 +520,13 @@ func addChat(server *mcpsdk.Server, svc chatService) {
 type agentListInput struct{}
 
 type agentListOutput struct {
-	Items []sdk.Agent `json:"items"`
+	Items []cmdutil.VisibleAgent `json:"items"`
 }
 
 func addAgentList(server *mcpsdk.Server, svc agentService) {
 	mcpsdk.AddTool(server, &mcpsdk.Tool{
 		Name:        "agent_list",
-		Description: "List the tenant's custom agents. Returns items[] with id, name, description, is_builtin - use to discover an agent_id before session_ask.",
+		Description: "List current-tenant and shared-space agents visible to the active profile. Shared items carry is_shared=true plus org_name, permission, and source_tenant_id; use an id with session_ask.",
 		Annotations: &mcpsdk.ToolAnnotations{
 			Title:           "List Custom Agents",
 			DestructiveHint: bptr(false),
@@ -535,12 +535,12 @@ func addAgentList(server *mcpsdk.Server, svc agentService) {
 			OpenWorldHint:   bptr(false),
 		},
 	}, func(ctx context.Context, _ *mcpsdk.CallToolRequest, _ agentListInput) (*mcpsdk.CallToolResult, any, error) {
-		items, err := svc.ListAgents(ctx)
+		items, err := cmdutil.ListVisibleAgents(ctx, svc, true, true)
 		if err != nil {
 			return toolErrorResult(cmdutil.WrapHTTP(err, "list agents")), nil, nil
 		}
 		if items == nil {
-			items = []sdk.Agent{}
+			items = []cmdutil.VisibleAgent{}
 		}
 		return successResult(agentListOutput{Items: items}), nil, nil
 	})

--- a/cli/internal/mcp/tools_test.go
+++ b/cli/internal/mcp/tools_test.go
@@ -20,36 +20,41 @@ import (
 // Each method records the last call args; per-test setup populates the
 // return values it wants to assert against.
 type fakeSvc struct {
-	listKBs        []sdk.KnowledgeBase
-	listKBsErr     error
-	getKB          *sdk.KnowledgeBase
-	getKBErr       error
-	listDocs       []sdk.Knowledge
-	listDocsTotal  int64
-	listDocsErr    error
-	getDoc         *sdk.Knowledge
-	getDocErr      error
-	openDocName    string
-	openDocBody    io.ReadCloser
-	openDocErr     error
-	hybridResults  []*sdk.SearchResult
-	hybridErr      error
-	createSess     *sdk.Session
-	createSessErr  error
-	kbStreamEvents []*sdk.StreamResponse
-	kbStreamErr    error
-	agents         []sdk.Agent
-	agentsErr      error
-	agent          *sdk.Agent
-	agentErr       error
-	agentEvents    []*sdk.AgentStreamResponse
-	agentStreamErr error
-	chunks         []sdk.Chunk
-	chunksTotal    int64
-	chunksErr      error
+	listKBs          []sdk.KnowledgeBase
+	listKBsErr       error
+	listSharedKBs    []sdk.SharedKnowledgeBaseInfo
+	listSharedKBsErr error
+	getKB            *sdk.KnowledgeBase
+	getKBErr         error
+	listDocs         []sdk.Knowledge
+	listDocsTotal    int64
+	listDocsErr      error
+	getDoc           *sdk.Knowledge
+	getDocErr        error
+	openDocName      string
+	openDocBody      io.ReadCloser
+	openDocErr       error
+	hybridResults    []*sdk.SearchResult
+	hybridErr        error
+	createSess       *sdk.Session
+	createSessErr    error
+	kbStreamEvents   []*sdk.StreamResponse
+	kbStreamErr      error
+	agents           []sdk.Agent
+	agentsErr        error
+	sharedAgents     []sdk.SharedAgentInfo
+	sharedAgentsErr  error
+	agent            *sdk.Agent
+	agentErr         error
+	agentEvents      []*sdk.AgentStreamResponse
+	agentStreamErr   error
+	chunks           []sdk.Chunk
+	chunksTotal      int64
+	chunksErr        error
 	// Captured args:
 	calls struct {
 		listKBs       int
+		listSharedKBs int
 		kbViewID      string
 		docListKBID   string
 		docListFilter sdk.KnowledgeListFilter
@@ -73,6 +78,10 @@ type fakeSvc struct {
 func (f *fakeSvc) ListKnowledgeBases(_ context.Context) ([]sdk.KnowledgeBase, error) {
 	f.calls.listKBs++
 	return f.listKBs, f.listKBsErr
+}
+func (f *fakeSvc) ListSharedKnowledgeBases(_ context.Context) ([]sdk.SharedKnowledgeBaseInfo, error) {
+	f.calls.listSharedKBs++
+	return f.listSharedKBs, f.listSharedKBsErr
 }
 func (f *fakeSvc) GetKnowledgeBase(_ context.Context, id string) (*sdk.KnowledgeBase, error) {
 	f.calls.kbViewID = id
@@ -114,6 +123,9 @@ func (f *fakeSvc) KnowledgeQAStream(_ context.Context, sess string, req *sdk.Kno
 func (f *fakeSvc) ListAgents(_ context.Context) ([]sdk.Agent, error) {
 	f.calls.agentListN++
 	return f.agents, f.agentsErr
+}
+func (f *fakeSvc) ListSharedAgents(_ context.Context) ([]sdk.SharedAgentInfo, error) {
+	return f.sharedAgents, f.sharedAgentsErr
 }
 func (f *fakeSvc) GetAgent(_ context.Context, id string) (*sdk.Agent, error) {
 	f.calls.agentViewID = id
@@ -235,11 +247,15 @@ func TestTool_SessionAsk_NotAgentInvoke(t *testing.T) {
 }
 
 func TestTool_KBList(t *testing.T) {
-	svc := &fakeSvc{listKBs: []sdk.KnowledgeBase{{ID: "kb1", Name: "Marketing"}}}
+	sharedKB := sdk.KnowledgeBase{ID: "kb2", Name: "Partner Docs"}
+	svc := &fakeSvc{
+		listKBs:       []sdk.KnowledgeBase{{ID: "kb1", Name: "Marketing"}},
+		listSharedKBs: []sdk.SharedKnowledgeBaseInfo{{KnowledgeBase: &sharedKB, OrgName: "Partners", Permission: "viewer"}},
+	}
 	c, _ := newTestServer(t, svc)
 	var out kbListOutput
 	callTool(t, c, "kb_list", map[string]any{}, &out)
-	if len(out.Items) != 1 || out.Items[0].ID != "kb1" {
+	if len(out.Items) != 2 || out.Items[0].ID != "kb1" || out.Items[1].ID != "kb2" || !out.Items[1].IsShared {
 		t.Errorf("got %+v", out)
 	}
 }
@@ -531,11 +547,15 @@ func TestTool_Chat_ExistingSessionSkipsCreate(t *testing.T) {
 }
 
 func TestTool_AgentList(t *testing.T) {
-	svc := &fakeSvc{agents: []sdk.Agent{{ID: "ag1", Name: "Research"}}}
+	sharedAgent := sdk.Agent{ID: "ag2", Name: "Partner Research"}
+	svc := &fakeSvc{
+		agents:       []sdk.Agent{{ID: "ag1", Name: "Research"}},
+		sharedAgents: []sdk.SharedAgentInfo{{Agent: &sharedAgent, OrgName: "Partners", Permission: "viewer"}},
+	}
 	c, _ := newTestServer(t, svc)
 	var out agentListOutput
 	callTool(t, c, "agent_list", map[string]any{}, &out)
-	if len(out.Items) != 1 || out.Items[0].ID != "ag1" {
+	if len(out.Items) != 2 || out.Items[0].ID != "ag1" || out.Items[1].ID != "ag2" || !out.Items[1].IsShared {
 		t.Errorf("got %+v", out)
 	}
 }

--- a/cli/skills/weknora-rag-search/SKILL.md
+++ b/cli/skills/weknora-rag-search/SKILL.md
@@ -45,7 +45,7 @@ one wastes turns or returns the wrong shape. Use the decision table.
   If none resolves it's exit 1 (`local.kb_id_required`); a bad name is exit 1
   (`local.kb_not_found`). Resolve names with `weknora kb list` / `search kb`;
   both include shared-space KBs. If the same name exists in multiple visible
-  tenants, pass the UUID shown by `kb list`.
+  workspaces, pass the UUID shown by `kb list`.
   (`search kb` / `search sessions` take no `--kb`.)
 - `chat` / `session ask` return one buffered JSON envelope with answer
   events by default. Add `--reference` for indexed citations and `--verbose`

--- a/cli/skills/weknora-rag-search/SKILL.md
+++ b/cli/skills/weknora-rag-search/SKILL.md
@@ -32,7 +32,8 @@ one wastes turns or returns the wrong shape. Use the decision table.
 2. **`chat` vs `session ask`.** `chat` = plain KB RAG Q&A. `session ask --agent
    <id>` = invoke a *configured custom agent* (it may scope its own KBs, call
    tools, do web search). If the user set up an agent for this, prefer it
-   (`weknora agent list` to find ids); otherwise `chat`.
+   (`weknora agent list` to find ids, including shared-space agents); otherwise
+   `chat`.
 3. **One-shot vs multi-turn.** Both `chat` and `session ask` return a
    `data.session_id` in default JSON output. Pass `--session <id>` on the next
    call to continue the conversation. In NDJSON mode, read it from `init`.
@@ -42,8 +43,10 @@ one wastes turns or returns the wrong shape. Use the decision table.
 - `chat`, `search chunks`, `search docs` need a KB: pass `--kb <id-or-name>`, or
   set `WEKNORA_KB_ID`, or `weknora link` the directory (resolved in that order).
   If none resolves it's exit 1 (`local.kb_id_required`); a bad name is exit 1
-  (`local.kb_not_found`). Resolve names with `weknora kb list` / `search kb`.
-  (`search kb` / `search sessions` are tenant-wide and take no `--kb`.)
+  (`local.kb_not_found`). Resolve names with `weknora kb list` / `search kb`;
+  both include shared-space KBs. If the same name exists in multiple visible
+  tenants, pass the UUID shown by `kb list`.
+  (`search kb` / `search sessions` take no `--kb`.)
 - `chat` / `session ask` return one buffered JSON envelope with answer
   events by default. Add `--reference` for indexed citations and `--verbose`
   for execution detail; use `--format ndjson` for raw events or `--format

--- a/client/organization.go
+++ b/client/organization.go
@@ -128,22 +128,27 @@ type JoinRequestResponse struct {
 
 // SharedKnowledgeBaseInfo represents a shared knowledge base
 type SharedKnowledgeBaseInfo struct {
-	ShareID        string    `json:"share_id"`
-	OrganizationID string    `json:"organization_id"`
-	OrgName        string    `json:"org_name"`
-	Permission     string    `json:"permission"`
-	SourceTenantID uint64    `json:"source_tenant_id"`
-	SharedAt       time.Time `json:"shared_at"`
+	KnowledgeBase  *KnowledgeBase `json:"knowledge_base"`
+	ShareID        string         `json:"share_id"`
+	OrganizationID string         `json:"organization_id"`
+	OrgName        string         `json:"org_name"`
+	Permission     string         `json:"permission"`
+	SourceTenantID uint64         `json:"source_tenant_id"`
+	SharedAt       time.Time      `json:"shared_at"`
 }
 
 // SharedAgentInfo represents a shared agent
 type SharedAgentInfo struct {
-	ShareID        string    `json:"share_id"`
-	OrganizationID string    `json:"organization_id"`
-	OrgName        string    `json:"org_name"`
-	Permission     string    `json:"permission"`
-	SourceTenantID uint64    `json:"source_tenant_id"`
-	SharedAt       time.Time `json:"shared_at"`
+	Agent            *Agent    `json:"agent"`
+	ShareID          string    `json:"share_id"`
+	OrganizationID   string    `json:"organization_id"`
+	OrgName          string    `json:"org_name"`
+	Permission       string    `json:"permission"`
+	SourceTenantID   uint64    `json:"source_tenant_id"`
+	SharedAt         time.Time `json:"shared_at"`
+	SharedByUserID   string    `json:"shared_by_user_id,omitempty"`
+	SharedByUsername string    `json:"shared_by_username,omitempty"`
+	DisabledByMe     bool      `json:"disabled_by_me"`
 }
 
 // UserInfo represents user information for API responses

--- a/client/organization_shared_test.go
+++ b/client/organization_shared_test.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListSharedKnowledgeBasesDecodesNestedKnowledgeBase(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/shared-knowledge-bases" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"success":true,
+			"data":[{
+				"knowledge_base":{"id":"kb-shared","name":"Partner Docs","knowledge_count":3},
+				"share_id":"share-1","organization_id":"org-1","org_name":"Partners",
+				"permission":"viewer","source_tenant_id":42,"shared_at":"2026-07-08T00:00:00Z"
+			}]
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	items, err := NewClient(srv.URL).ListSharedKnowledgeBases(context.Background())
+	if err != nil {
+		t.Fatalf("ListSharedKnowledgeBases: %v", err)
+	}
+	if len(items) != 1 || items[0].KnowledgeBase == nil {
+		t.Fatalf("expected one nested knowledge base, got %+v", items)
+	}
+	if items[0].KnowledgeBase.ID != "kb-shared" || items[0].KnowledgeBase.Name != "Partner Docs" {
+		t.Fatalf("unexpected knowledge base: %+v", items[0].KnowledgeBase)
+	}
+	if items[0].OrgName != "Partners" || items[0].Permission != "viewer" {
+		t.Fatalf("unexpected sharing metadata: %+v", items[0])
+	}
+}
+
+func TestListSharedAgentsDecodesNestedAgent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/shared-agents" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"success":true,
+			"data":[{
+				"agent":{"id":"ag-shared","name":"Partner Agent"},
+				"share_id":"share-1","organization_id":"org-1","org_name":"Partners",
+				"permission":"viewer","source_tenant_id":42,"shared_at":"2026-07-08T00:00:00Z"
+			}]
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	items, err := NewClient(srv.URL).ListSharedAgents(context.Background())
+	if err != nil {
+		t.Fatalf("ListSharedAgents: %v", err)
+	}
+	if len(items) != 1 || items[0].Agent == nil {
+		t.Fatalf("expected one nested agent, got %+v", items)
+	}
+	if items[0].Agent.ID != "ag-shared" || items[0].OrgName != "Partners" {
+		t.Fatalf("unexpected shared agent: %+v", items[0])
+	}
+}

--- a/internal/application/service/kbshare.go
+++ b/internal/application/service/kbshare.go
@@ -27,7 +27,7 @@ var (
 // in this org, with what role" rather than "is this user". The 3-D cap
 // inside CheckTenantKBPermission encodes:
 //
-//   effective = min(share.Permission, tenant_org_role, tenant_role_cap)
+//	effective = min(share.Permission, tenant_org_role, tenant_role_cap)
 //
 // where tenant_role_cap pins tenant Viewers to OrgRoleViewer regardless
 // of what the org-level grant said. That keeps the tenant RBAC promise
@@ -313,6 +313,29 @@ func (s *kbShareService) ListSharedKnowledgeBases(ctx context.Context, tenantID 
 	result := make([]*types.SharedKnowledgeBaseInfo, 0, len(kbInfoMap))
 	for _, info := range kbInfoMap {
 		result = append(result, info)
+	}
+
+	// Pins belong to the caller's active tenant, even when the KB itself is
+	// owned by another tenant. Stamp the same per-user state returned by the
+	// ordinary KB list so merged clients can apply --pinned and make pin/unpin
+	// idempotent for shared KBs as well.
+	if userID, ok := types.UserIDFromContext(ctx); ok && userID != "" && len(result) > 0 {
+		pins, err := s.kbRepo.ListUserKBPinIDs(ctx, tenantID, userID)
+		if err != nil {
+			logger.Warnf(ctx, "ListSharedKnowledgeBases: failed to load pins for tenant=%d user=%s: %v",
+				tenantID, userID, err)
+		} else {
+			for _, info := range result {
+				if info == nil || info.KnowledgeBase == nil {
+					continue
+				}
+				if ts, pinned := pins[info.KnowledgeBase.ID]; pinned {
+					info.KnowledgeBase.IsPinned = true
+					t := ts
+					info.KnowledgeBase.PinnedAt = &t
+				}
+			}
+		}
 	}
 
 	return result, nil

--- a/internal/handler/organization.go
+++ b/internal/handler/organization.go
@@ -1303,6 +1303,7 @@ func (h *OrganizationHandler) ListSharedKnowledgeBases(c *gin.Context) {
 		c.Error(apperrors.NewInternalServerError("Failed to list shared knowledge bases"))
 		return
 	}
+	sharedKBs = filterSharedKnowledgeBasesForAPIKeyScope(ctx, sharedKBs)
 
 	// Each row goes through sharedKBRow so the embedded KnowledgeBase
 	// payload runs SharedStoreDisplay() before serialization. This is
@@ -1320,6 +1321,22 @@ func (h *OrganizationHandler) ListSharedKnowledgeBases(c *gin.Context) {
 		"data":    rows,
 		"total":   len(rows),
 	})
+}
+
+func filterSharedKnowledgeBasesForAPIKeyScope(
+	ctx context.Context, sharedKBs []*types.SharedKnowledgeBaseInfo,
+) []*types.SharedKnowledgeBaseInfo {
+	scope, ok := types.TenantAPIKeyScopeFromContext(ctx)
+	if !ok || !scope.IsKnowledgeBaseRestricted() {
+		return sharedKBs
+	}
+	filtered := make([]*types.SharedKnowledgeBaseInfo, 0, len(sharedKBs))
+	for _, info := range sharedKBs {
+		if info != nil && info.KnowledgeBase != nil && scope.AllowsKnowledgeBase(info.KnowledgeBase.ID) {
+			filtered = append(filtered, info)
+		}
+	}
+	return filtered
 }
 
 // ShareAgent shares an agent to an organization

--- a/internal/handler/organization_api_key_scope_test.go
+++ b/internal/handler/organization_api_key_scope_test.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterSharedKnowledgeBasesForAPIKeyScope(t *testing.T) {
+	sharedKBs := []*types.SharedKnowledgeBaseInfo{
+		{KnowledgeBase: &types.KnowledgeBase{ID: "kb-allowed"}},
+		{KnowledgeBase: &types.KnowledgeBase{ID: "kb-blocked"}},
+		nil,
+		{},
+	}
+
+	t.Run("JWT callers keep the complete list", func(t *testing.T) {
+		assert.Equal(t, sharedKBs, filterSharedKnowledgeBasesForAPIKeyScope(context.Background(), sharedKBs))
+	})
+
+	t.Run("unrestricted API keys keep the complete list", func(t *testing.T) {
+		ctx := types.WithTenantAPIKeyScope(context.Background(), types.TenantAPIKeyScope{KeyID: 1})
+		assert.Equal(t, sharedKBs, filterSharedKnowledgeBasesForAPIKeyScope(ctx, sharedKBs))
+	})
+
+	t.Run("KB-restricted API keys only see allowed shared KBs", func(t *testing.T) {
+		ctx := types.WithTenantAPIKeyScope(context.Background(), types.TenantAPIKeyScope{
+			KeyID:            1,
+			KnowledgeBaseIDs: types.StringArray{"kb-allowed"},
+		})
+		assert.Equal(t, sharedKBs[:1], filterSharedKnowledgeBasesForAPIKeyScope(ctx, sharedKBs))
+	})
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1303,9 +1303,9 @@ func RegisterOrganizationRoutes(r *gin.RouterGroup, orgHandler *handler.Organiza
 	}
 
 	// Shared knowledge bases route — Viewer+
-	g.apiKeyRoute(r, http.MethodGet, "/shared-knowledge-bases", apiKeyManageSpaces(apiKeyFullAccess()), g.Viewer(), orgHandler.ListSharedKnowledgeBases)
+	g.apiKeyRoute(r, http.MethodGet, "/shared-knowledge-bases", apiKeyRetrieve(apiKeyFullAccess()), g.Viewer(), orgHandler.ListSharedKnowledgeBases)
 	// Shared agents route — Viewer+
-	g.apiKeyRoute(r, http.MethodGet, "/shared-agents", apiKeyManageSpaces(apiKeyFullAccess()), g.Viewer(), orgHandler.ListSharedAgents)
+	g.apiKeyRoute(r, http.MethodGet, "/shared-agents", apiKeyReadAgents(apiKeyManageAgents(apiKeyChat(apiKeyFullAccess()))), g.Viewer(), orgHandler.ListSharedAgents)
 	// "Disable by me" 是空间级偏好（写到 tenant_disabled_shared_agents），
 	// 影响整个空间在会话下拉里看到的 agent 列表。任何 Viewer 改这个表就
 	// 等于替整个空间做决定 — 必须 Admin+ 才允许调整。

--- a/internal/router/router_api_key_capabilities_test.go
+++ b/internal/router/router_api_key_capabilities_test.go
@@ -368,8 +368,6 @@ func TestOrganizationRoutesDeclareManageSpacesCapability(t *testing.T) {
 		{http.MethodPost, "/api/v1/organizations/:id/invite-code"},
 		{http.MethodGet, "/api/v1/organizations/:id/members"},
 		{http.MethodPut, "/api/v1/organizations/:id/members/:tenant_id"},
-		{http.MethodGet, "/api/v1/shared-knowledge-bases"},
-		{http.MethodGet, "/api/v1/shared-agents"},
 		{http.MethodPost, "/api/v1/shared-agents/disabled"},
 	}
 
@@ -409,6 +407,35 @@ func TestOrganizationRoutesDeclareManageSpacesCapability(t *testing.T) {
 				t.Fatalf("share route must not be granted by any capability: %#v", policy.Capabilities)
 			}
 		})
+	}
+}
+
+func TestSharedResourceDiscoveryRoutesMatchPrimaryReadCapabilities(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	g := &rbacGuards{}
+	v1 := gin.New().Group("/api/v1")
+	RegisterOrganizationRoutes(v1, &handler.OrganizationHandler{}, g)
+
+	kbPolicy := mustLookupAPIKeyPolicy(t, g, http.MethodGet, "/api/v1/shared-knowledge-bases")
+	if !policyHasCapability(kbPolicy, types.APIKeyCapabilityRetrieve) {
+		t.Fatalf("shared KB policy capabilities = %#v, want retrieve", kbPolicy.Capabilities)
+	}
+	if policyHasCapability(kbPolicy, types.APIKeyCapabilityManageSpaces) {
+		t.Fatalf("shared KB discovery must not require manage_spaces: %#v", kbPolicy.Capabilities)
+	}
+
+	agentPolicy := mustLookupAPIKeyPolicy(t, g, http.MethodGet, "/api/v1/shared-agents")
+	for _, capability := range []types.APIKeyCapability{
+		types.APIKeyCapabilityReadAgents,
+		types.APIKeyCapabilityManageAgents,
+		types.APIKeyCapabilityChat,
+	} {
+		if !policyHasCapability(agentPolicy, capability) {
+			t.Fatalf("shared agent policy capabilities = %#v, want %s", agentPolicy.Capabilities, capability)
+		}
+	}
+	if policyHasCapability(agentPolicy, types.APIKeyCapabilityManageSpaces) {
+		t.Fatalf("shared agent discovery must not require manage_spaces: %#v", agentPolicy.Capabilities)
 	}
 }
 


### PR DESCRIPTION
## Description

Fix CLI discovery so resources received through shared spaces are handled consistently with resources in the active workspace.

The change makes `kb list` and `agent list` merge current-workspace and shared-space resources by default. It adds mutually exclusive `--owned` and `--shared` filters and includes sharing metadata on shared rows.

Rebased onto the latest `main` (`7807dee4`); conflicts resolved and the fix aligned with current CLI/security conventions.

It also fixes related owned-only paths:

- KB name resolution used by chat, search, document commands, agent configuration, and project linking
- `search kb`
- interactive project linking
- `kb pin`, `kb unpin`, and `kb view` pin-state enrichment
- MCP `kb_list` and `agent_list`
- Go SDK decoding of nested shared knowledge bases and agents

The backend shared-KB service now stamps per-user pin state for shared KBs. Read-only shared discovery routes use the same API-key capabilities as their primary list counterparts, and a scoped key's `knowledge_base_ids` allow-list is enforced against shared KBs as well.

### User-visible behavior

```bash
# Current workspace + shared spaces (new default)
weknora kb list
weknora agent list

# Current workspace only
weknora kb list --owned
weknora agent list --owned

# Shared spaces only
weknora kb list --shared
weknora agent list --shared
```

Shared JSON rows include fields such as:

```json
{
  "is_shared": true,
  "organization_id": "...",
  "org_name": "Partner Space",
  "permission": "viewer",
  "source_tenant_id": 42
}
```

When multiple visible KBs have the same name, name resolution now returns `input.invalid_argument` and asks the caller to pass a UUID.

### Compatibility

This intentionally expands the default list result set. Consumers that require the previous current-workspace-only behavior should pass `--owned`.

Owned JSON rows preserve their previous shape because sharing fields use `omitempty`. Aggregate discovery treats a missing shared endpoint (404) as an older-server compatibility case, while explicit `--shared` calls still report the error.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

> Maintainer note: although owned-row JSON remains compatible, the default result set is intentionally broader. Please classify this as a breaking change if the CLI's list-scope semantics require a major-version boundary.

## Related Issue

Fixes #1958

Related to, but distinct from, #1950: that issue targets the standalone Python MCP server, while this PR updates the Go CLI's embedded MCP server.

## Testing

The following suites pass:

```bash
cd cli
go test ./...

cd ../client
go test ./...

cd ..
go test ./internal/handler ./internal/router ./internal/application/service
```

Coverage added for:

- default owned + shared merging
- `--owned` / `--shared` filtering and mutual exclusion
- shared-resource metadata in CLI and MCP output
- shared KB search and name resolution
- cross-tenant duplicate-name ambiguity
- nested SDK response decoding
- API-key capability declarations for shared discovery
- API-key `knowledge_base_ids` scope filtering applied to shared KBs
- compatibility with servers that do not expose shared-list endpoints

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, CLI skill, and changelog)
- [x] Default list-scope behavior is clearly called out above

> `make fmt && make lint && make test` is left unchecked intentionally — verification was run as `go test` / `go vet` on the affected modules rather than that make-target combination.

## Screenshots / Recordings

Not applicable — CLI/API behavior only.
