### PR TITLE
feat: add backend support for knowledge folders

### DIFF
--- a/docs/api/knowledge.md
+++ b/docs/api/knowledge.md
@@ -11,9 +11,14 @@
 | POST   | `/knowledge-bases/:id/knowledge/manual`    | 创建手工 Markdown 知识                     |
 | GET    | `/knowledge-bases/:id/knowledge`           | 列出知识库下的知识（支持分页/筛选）         |
 | DELETE | `/knowledge-bases/:id/knowledge`           | 清空知识库下的所有知识（异步任务）         |
+| GET    | `/knowledge-bases/:id/folders`             | 列出知识库目录                             |
+| POST   | `/knowledge-bases/:id/folders`             | 创建知识库目录                             |
+| PUT    | `/knowledge-bases/:id/folders/:folder_id`  | 重命名知识库目录                           |
+| DELETE | `/knowledge-bases/:id/folders/:folder_id`  | 删除空目录                                 |
 | GET    | `/knowledge/batch`                         | 按 ID 列表批量获取知识                     |
 | GET    | `/knowledge/:id`                           | 获取知识详情                               |
 | PUT    | `/knowledge/:id`                           | 更新知识（标题/描述/标签等）               |
+| PUT    | `/knowledge/:id/folder`                    | 移动单条知识到目录                         |
 | DELETE | `/knowledge/:id`                           | 删除单条知识                               |
 | PUT    | `/knowledge/manual/:id`                    | 更新手工 Markdown 知识                     |
 | POST   | `/knowledge/:id/reparse`                   | 重新解析知识（异步）                       |
@@ -30,6 +35,7 @@
 > **公共说明**：
 > - 路径中的 `:id`（知识库路径下）为**知识库 ID**，`/knowledge/:id` 中的 `:id` 为**知识 ID**。
 > - 所有写操作（创建、更新、删除、迁移、重新解析、取消解析）需要当前用户在知识库所属组织内具有 `editor` 或 `admin` 权限；清空知识库内容仅 KB **所有者**（admin 且租户匹配）可操作。
+> - 目录接口使用 `folder_id` 关联知识条目；空字符串或 `__root__` 表示根目录。目录删除仅支持空目录，不会递归删除子目录或知识。
 > - 关键状态字段：`parse_status` 取值 `pending` / `processing` / `finalizing` / `completed` / `failed` / `cancelled`；`enable_status` 取值 `enabled` / `disabled`。
 > - `processing` 指 DocReader / 分块 / 向量化阶段；`finalizing` 指主解析已完成、仍在执行摘要 / 问题生成 / 图谱抽取等索引优化任务；只有当全部子任务到达终态后才进入 `completed`。
 > - `cancelled` 表示解析被用户主动取消，可通过 `reparse` 重新触发。`pending` / `processing` / `finalizing` 这三种状态都可通过 `cancel-parse` 终止。
@@ -273,6 +279,7 @@ curl --location 'http://localhost:8080/api/v1/knowledge-bases/kb-00000001/knowle
 | `file_type`    | string  | -    | 按单个文件扩展名过滤（如 `pdf`）；特殊值 `manual` / `url` 命中 `type` 列                              |
 | `parse_status` | string  | -    | 按解析状态过滤：`pending` / `processing` / `completed` / `failed`                                    |
 | `source`       | string  | -    | 按来源/渠道过滤：`web` / `api` / `browser_extension` / `feishu` / `notion` / `yuque` / `wechat` 等； 特殊值 `manual` / `url` 命中 `type` 列 |
+| `folder_id`    | string  | -    | 按目录过滤；传 `__root__` 查询根目录下知识，不传则不过滤目录                                         |
 | `start_time`   | string  | -    | 更新时间起点，接受 RFC3339 (`2024-05-01T00:00:00+08:00`) 或 `YYYY-MM-DD HH:MM:SS` / `YYYY-MM-DD`     |
 | `end_time`     | string  | -    | 更新时间终点，格式同 `start_time`                                                                   |
 
@@ -322,6 +329,138 @@ curl --location 'http://localhost:8080/api/v1/knowledge-bases/kb-00000001/knowle
     "success": true
 }
 ```
+
+## GET `/knowledge-bases/:id/folders` - 列出知识库目录
+
+列出指定父目录下的直接子目录，不递归展开。`parent_id` 为空或 `__root__` 时返回根目录。
+
+**查询参数**:
+
+| 字段        | 类型   | 默认       | 说明                    |
+| ----------- | ------ | ---------- | ----------------------- |
+| `parent_id` | string | `__root__` | 父目录 ID，根目录可传空 |
+
+**请求**:
+
+```curl
+curl --location 'http://localhost:8080/api/v1/knowledge-bases/kb-00000001/folders?parent_id=__root__' \
+--header 'X-API-Key: sk-xxxxx'
+```
+
+**响应**:
+
+```json
+{
+    "success": true,
+    "data": {
+        "folders": [
+            {
+                "id": "folder-00000001",
+                "tenant_id": 1,
+                "knowledge_base_id": "kb-00000001",
+                "parent_id": "",
+                "name": "产品文档",
+                "path": "产品文档",
+                "depth": 0,
+                "sort_order": 0,
+                "knowledge_count": 3,
+                "has_children": true,
+                "created_at": "2025-08-12T12:00:00+08:00",
+                "updated_at": "2025-08-12T12:00:00+08:00",
+                "deleted_at": null
+            }
+        ]
+    }
+}
+```
+
+## POST `/knowledge-bases/:id/folders` - 创建知识库目录
+
+在知识库内创建一个空目录。同一父目录下目录名不可重复，目录名不能包含 `/` 或 `\`。
+
+**请求体**:
+
+| 字段        | 类型   | 必填 | 说明                                  |
+| ----------- | ------ | ---- | ------------------------------------- |
+| `name`      | string | 是   | 目录名                                |
+| `parent_id` | string | 否   | 父目录 ID；空字符串或 `__root__` 为根 |
+
+**请求**:
+
+```curl
+curl --location 'http://localhost:8080/api/v1/knowledge-bases/kb-00000001/folders' \
+--header 'X-API-Key: sk-xxxxx' \
+--header 'Content-Type: application/json' \
+--data '{
+    "name": "产品文档",
+    "parent_id": "__root__"
+}'
+```
+
+**响应**（HTTP 201）: 返回创建后的目录对象，字段同列表接口中的单个 `folder`。
+
+## PUT `/knowledge-bases/:id/folders/:folder_id` - 重命名知识库目录
+
+当前版本仅支持重命名目录，不移动目录层级。
+
+**请求体**:
+
+| 字段   | 类型   | 必填 | 说明   |
+| ------ | ------ | ---- | ------ |
+| `name` | string | 是   | 新名称 |
+
+**请求**:
+
+```curl
+curl --location --request PUT 'http://localhost:8080/api/v1/knowledge-bases/kb-00000001/folders/folder-00000001' \
+--header 'X-API-Key: sk-xxxxx' \
+--header 'Content-Type: application/json' \
+--data '{
+    "name": "售前资料"
+}'
+```
+
+**响应**: 返回更新后的目录对象。
+
+## DELETE `/knowledge-bases/:id/folders/:folder_id` - 删除空目录
+
+仅当目录没有子目录、且没有直接关联知识时可以删除；非空目录会返回 409。
+
+```curl
+curl --location --request DELETE 'http://localhost:8080/api/v1/knowledge-bases/kb-00000001/folders/folder-00000001' \
+--header 'X-API-Key: sk-xxxxx'
+```
+
+**响应**:
+
+```json
+{
+    "success": true
+}
+```
+
+## PUT `/knowledge/:id/folder` - 移动单条知识到目录
+
+移动单条知识到同一知识库下的指定目录。`folder_id` 为空字符串或 `__root__` 时移动到根目录。
+
+**请求体**:
+
+| 字段        | 类型   | 必填 | 说明         |
+| ----------- | ------ | ---- | ------------ |
+| `folder_id` | string | 否   | 目标目录 ID  |
+
+**请求**:
+
+```curl
+curl --location --request PUT 'http://localhost:8080/api/v1/knowledge/4c4e7c1a-09cf-485b-a7b5-24b8cdc5acf5/folder' \
+--header 'X-API-Key: sk-xxxxx' \
+--header 'Content-Type: application/json' \
+--data '{
+    "folder_id": "folder-00000001"
+}'
+```
+
+**响应**: 返回移动后的知识对象，包含最新 `folder_id`。
 
 ## DELETE `/knowledge-bases/:id/knowledge` - 清空知识库下的所有知识
 

--- a/internal/application/repository/knowledge.go
+++ b/internal/application/repository/knowledge.go
@@ -137,6 +137,9 @@ func applyKnowledgeListFilter(query *gorm.DB, filter types.KnowledgeListFilter) 
 	if filter.ParseStatus != "" {
 		query = query.Where("parse_status = ?", filter.ParseStatus)
 	}
+	if filter.FolderID != nil {
+		query = query.Where("folder_id = ?", *filter.FolderID)
+	}
 	if !filter.UpdatedFrom.IsZero() {
 		query = query.Where("updated_at >= ?", filter.UpdatedFrom)
 	}

--- a/internal/application/repository/knowledge_finalize_test.go
+++ b/internal/application/repository/knowledge_finalize_test.go
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS knowledges (
     id VARCHAR(36) PRIMARY KEY,
     tenant_id INTEGER NOT NULL,
     knowledge_base_id VARCHAR(36) NOT NULL,
+    folder_id VARCHAR(36) NOT NULL DEFAULT '',
     type VARCHAR(50) NOT NULL DEFAULT '',
     title VARCHAR(255) NOT NULL DEFAULT '',
     description TEXT,

--- a/internal/application/repository/knowledge_folder.go
+++ b/internal/application/repository/knowledge_folder.go
@@ -1,0 +1,309 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"gorm.io/gorm"
+)
+
+var ErrKnowledgeFolderNotFound = errors.New("knowledge folder not found")
+var ErrKnowledgeFolderExists = errors.New("knowledge folder already exists")
+var ErrKnowledgeFolderNotEmpty = errors.New("knowledge folder is not empty")
+
+type knowledgeFolderRepository struct {
+	db *gorm.DB
+}
+
+// NewKnowledgeFolderRepository creates a knowledge folder repository.
+func NewKnowledgeFolderRepository(db *gorm.DB) interfaces.KnowledgeFolderRepository {
+	return &knowledgeFolderRepository{db: db}
+}
+
+func (r *knowledgeFolderRepository) ListByParent(
+	ctx context.Context,
+	tenantID uint64,
+	kbID string,
+	parentID string,
+) ([]*types.KnowledgeFolder, error) {
+	var folders []*types.KnowledgeFolder
+	err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND knowledge_base_id = ? AND parent_id = ?", tenantID, kbID, parentID).
+		Order("sort_order ASC, name ASC, created_at ASC").
+		Find(&folders).Error
+	if err != nil {
+		return nil, err
+	}
+	if len(folders) == 0 {
+		return folders, nil
+	}
+	if err := r.attachKnowledgeCounts(ctx, tenantID, kbID, folders); err != nil {
+		return nil, err
+	}
+	if err := r.MarkHasChildren(ctx, tenantID, kbID, folders); err != nil {
+		return nil, err
+	}
+	return folders, nil
+}
+
+func (r *knowledgeFolderRepository) GetByID(
+	ctx context.Context,
+	tenantID uint64,
+	kbID string,
+	folderID string,
+) (*types.KnowledgeFolder, error) {
+	var folder types.KnowledgeFolder
+	err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND knowledge_base_id = ? AND id = ?", tenantID, kbID, folderID).
+		First(&folder).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrKnowledgeFolderNotFound
+	}
+	return &folder, err
+}
+
+func (r *knowledgeFolderRepository) GetByParentAndName(
+	ctx context.Context,
+	tenantID uint64,
+	kbID string,
+	parentID string,
+	name string,
+) (*types.KnowledgeFolder, error) {
+	var folder types.KnowledgeFolder
+	err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND knowledge_base_id = ? AND parent_id = ? AND name = ?", tenantID, kbID, parentID, name).
+		First(&folder).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrKnowledgeFolderNotFound
+	}
+	return &folder, err
+}
+
+func (r *knowledgeFolderRepository) Create(ctx context.Context, folder *types.KnowledgeFolder) error {
+	err := r.db.WithContext(ctx).Create(folder).Error
+	if isUniqueConstraintError(err) {
+		return ErrKnowledgeFolderExists
+	}
+	return err
+}
+
+func (r *knowledgeFolderRepository) Update(ctx context.Context, folder *types.KnowledgeFolder) error {
+	err := r.db.WithContext(ctx).Save(folder).Error
+	if isUniqueConstraintError(err) {
+		return ErrKnowledgeFolderExists
+	}
+	return err
+}
+
+func (r *knowledgeFolderRepository) UpdateWithDescendantPaths(
+	ctx context.Context,
+	folder *types.KnowledgeFolder,
+	oldPath string,
+) error {
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Save(folder).Error; err != nil {
+			return err
+		}
+		if oldPath == "" || oldPath == folder.Path {
+			return nil
+		}
+		return updateDescendantFolderPaths(ctx, tx, folder, oldPath)
+	})
+	if isUniqueConstraintError(err) {
+		return ErrKnowledgeFolderExists
+	}
+	return err
+}
+
+func (r *knowledgeFolderRepository) Delete(ctx context.Context, tenantID uint64, kbID string, folderID string) error {
+	res := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND knowledge_base_id = ? AND id = ?", tenantID, kbID, folderID).
+		Delete(&types.KnowledgeFolder{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrKnowledgeFolderNotFound
+	}
+	return nil
+}
+
+func (r *knowledgeFolderRepository) DeleteEmpty(ctx context.Context, tenantID uint64, kbID string, folderID string) error {
+	now := time.Now()
+	res := r.db.WithContext(ctx).
+		Model(&types.KnowledgeFolder{}).
+		Where("tenant_id = ? AND knowledge_base_id = ? AND id = ?", tenantID, kbID, folderID).
+		Where(
+			`NOT EXISTS (
+				SELECT 1 FROM knowledge_folders child
+				WHERE child.tenant_id = ?
+					AND child.knowledge_base_id = ?
+					AND child.parent_id = knowledge_folders.id
+					AND child.deleted_at IS NULL
+			)`,
+			tenantID,
+			kbID,
+		).
+		Where(
+			`NOT EXISTS (
+				SELECT 1 FROM knowledges k
+				WHERE k.tenant_id = ?
+					AND k.knowledge_base_id = ?
+					AND k.folder_id = knowledge_folders.id
+					AND k.deleted_at IS NULL
+			)`,
+			tenantID,
+			kbID,
+		).
+		Updates(map[string]interface{}{
+			"deleted_at": now,
+			"updated_at": now,
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected > 0 {
+		return nil
+	}
+	if _, err := r.GetByID(ctx, tenantID, kbID, folderID); err != nil {
+		return err
+	}
+	return ErrKnowledgeFolderNotEmpty
+}
+
+func (r *knowledgeFolderRepository) CountKnowledgeByParents(
+	ctx context.Context,
+	tenantID uint64,
+	kbID string,
+	folderIDs []string,
+) (map[string]int64, error) {
+	counts := make(map[string]int64, len(folderIDs))
+	if len(folderIDs) == 0 {
+		return counts, nil
+	}
+	type row struct {
+		FolderID string
+		Count    int64
+	}
+	var rows []row
+	err := r.db.WithContext(ctx).
+		Model(&types.Knowledge{}).
+		Select("folder_id, COUNT(*) AS count").
+		Where("tenant_id = ? AND knowledge_base_id = ? AND folder_id IN ?", tenantID, kbID, folderIDs).
+		Group("folder_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		counts[r.FolderID] = r.Count
+	}
+	return counts, nil
+}
+
+func (r *knowledgeFolderRepository) MarkHasChildren(
+	ctx context.Context,
+	tenantID uint64,
+	kbID string,
+	folders []*types.KnowledgeFolder,
+) error {
+	if len(folders) == 0 {
+		return nil
+	}
+	parentIDs := make([]string, 0, len(folders))
+	for _, folder := range folders {
+		parentIDs = append(parentIDs, folder.ID)
+	}
+	type row struct {
+		ParentID string
+		Count    int64
+	}
+	var rows []row
+	err := r.db.WithContext(ctx).
+		Model(&types.KnowledgeFolder{}).
+		Select("parent_id, COUNT(*) AS count").
+		Where("tenant_id = ? AND knowledge_base_id = ? AND parent_id IN ?", tenantID, kbID, parentIDs).
+		Group("parent_id").
+		Scan(&rows).Error
+	if err != nil {
+		return err
+	}
+	hasChildren := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		hasChildren[r.ParentID] = r.Count > 0
+	}
+	for _, folder := range folders {
+		folder.HasChildren = hasChildren[folder.ID]
+	}
+	return nil
+}
+
+func (r *knowledgeFolderRepository) attachKnowledgeCounts(
+	ctx context.Context,
+	tenantID uint64,
+	kbID string,
+	folders []*types.KnowledgeFolder,
+) error {
+	folderIDs := make([]string, 0, len(folders))
+	for _, folder := range folders {
+		folderIDs = append(folderIDs, folder.ID)
+	}
+	counts, err := r.CountKnowledgeByParents(ctx, tenantID, kbID, folderIDs)
+	if err != nil {
+		return err
+	}
+	for _, folder := range folders {
+		folder.KnowledgeCount = counts[folder.ID]
+	}
+	return nil
+}
+
+func updateDescendantFolderPaths(
+	ctx context.Context,
+	tx *gorm.DB,
+	folder *types.KnowledgeFolder,
+	oldPath string,
+) error {
+	oldPrefix := oldPath + "/"
+	newPrefix := folder.Path + "/"
+
+	var descendants []*types.KnowledgeFolder
+	if err := tx.WithContext(ctx).
+		Where(
+			`tenant_id = ? AND knowledge_base_id = ? AND path LIKE ? ESCAPE '\'`,
+			folder.TenantID,
+			folder.KnowledgeBaseID,
+			escapeKnowledgeFolderPathLikePattern(oldPrefix)+"%",
+		).
+		Find(&descendants).Error; err != nil {
+		return err
+	}
+	for _, descendant := range descendants {
+		descendant.Path = newPrefix + strings.TrimPrefix(descendant.Path, oldPrefix)
+		if err := tx.Save(descendant).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func escapeKnowledgeFolderPathLikePattern(pattern string) string {
+	pattern = strings.ReplaceAll(pattern, `\`, `\\`)
+	pattern = strings.ReplaceAll(pattern, `%`, `\%`)
+	pattern = strings.ReplaceAll(pattern, `_`, `\_`)
+	return pattern
+}
+
+func isUniqueConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "duplicate key") ||
+		strings.Contains(msg, "UNIQUE constraint failed") ||
+		strings.Contains(msg, "Duplicate entry")
+}

--- a/internal/application/service/knowledge_folder.go
+++ b/internal/application/service/knowledge_folder.go
@@ -1,0 +1,225 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	werrors "github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+const maxKnowledgeFolderDepth = 10
+
+var (
+	ErrKnowledgeFolderNameRequired = errors.New("folder name is required")
+	ErrKnowledgeFolderInvalidName  = errors.New("folder name cannot contain path separators")
+	ErrKnowledgeFolderExists       = repository.ErrKnowledgeFolderExists
+	ErrKnowledgeFolderNotFound     = repository.ErrKnowledgeFolderNotFound
+	ErrKnowledgeFolderNotEmpty     = repository.ErrKnowledgeFolderNotEmpty
+	ErrKnowledgeFolderTooDeep      = errors.New("folder depth exceeds limit")
+)
+
+type knowledgeFolderService struct {
+	folderRepo interfaces.KnowledgeFolderRepository
+	kgRepo     interfaces.KnowledgeRepository
+}
+
+// NewKnowledgeFolderService creates a document folder service.
+func NewKnowledgeFolderService(
+	folderRepo interfaces.KnowledgeFolderRepository,
+	kgRepo interfaces.KnowledgeRepository,
+) interfaces.KnowledgeFolderService {
+	return &knowledgeFolderService{
+		folderRepo: folderRepo,
+		kgRepo:     kgRepo,
+	}
+}
+
+func (s *knowledgeFolderService) ListFolders(ctx context.Context, kbID string, parentID string) ([]*types.KnowledgeFolder, error) {
+	tenantID, err := tenantIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	parentID = normalizeKnowledgeFolderID(parentID)
+	if parentID != "" {
+		if _, err := s.folderRepo.GetByID(ctx, tenantID, kbID, parentID); err != nil {
+			return nil, err
+		}
+	}
+	return s.folderRepo.ListByParent(ctx, tenantID, kbID, parentID)
+}
+
+func (s *knowledgeFolderService) CreateFolder(ctx context.Context, kbID string, parentID string, name string) (*types.KnowledgeFolder, error) {
+	tenantID, err := tenantIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	parentID = normalizeKnowledgeFolderID(parentID)
+	name, err = normalizeKnowledgeFolderName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	parentPath := ""
+	depth := 0
+	if parentID != "" {
+		parent, err := s.folderRepo.GetByID(ctx, tenantID, kbID, parentID)
+		if err != nil {
+			return nil, err
+		}
+		parentPath = parent.Path
+		depth = parent.Depth + 1
+	}
+	if depth >= maxKnowledgeFolderDepth {
+		return nil, ErrKnowledgeFolderTooDeep
+	}
+	if err := s.ensureFolderNameAvailable(ctx, tenantID, kbID, parentID, name, ""); err != nil {
+		return nil, err
+	}
+
+	folder := &types.KnowledgeFolder{
+		TenantID:        tenantID,
+		KnowledgeBaseID: kbID,
+		ParentID:        parentID,
+		Name:            name,
+		Path:            joinKnowledgeFolderPath(parentPath, name),
+		Depth:           depth,
+	}
+	if err := s.folderRepo.Create(ctx, folder); err != nil {
+		return nil, err
+	}
+	return folder, nil
+}
+
+func (s *knowledgeFolderService) RenameFolder(ctx context.Context, kbID string, folderID string, name string) (*types.KnowledgeFolder, error) {
+	tenantID, err := tenantIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	folderID = normalizeKnowledgeFolderID(folderID)
+	if folderID == "" {
+		return nil, ErrKnowledgeFolderNotFound
+	}
+	name, err = normalizeKnowledgeFolderName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	folder, err := s.folderRepo.GetByID(ctx, tenantID, kbID, folderID)
+	if err != nil {
+		return nil, err
+	}
+	parentPath := ""
+	if folder.ParentID != "" {
+		parent, err := s.folderRepo.GetByID(ctx, tenantID, kbID, folder.ParentID)
+		if err != nil {
+			return nil, err
+		}
+		parentPath = parent.Path
+	}
+	if err := s.ensureFolderNameAvailable(ctx, tenantID, kbID, folder.ParentID, name, folder.ID); err != nil {
+		return nil, err
+	}
+	oldPath := folder.Path
+	folder.Name = name
+	folder.Path = joinKnowledgeFolderPath(parentPath, name)
+	if err := s.folderRepo.UpdateWithDescendantPaths(ctx, folder, oldPath); err != nil {
+		return nil, err
+	}
+	return folder, nil
+}
+
+func (s *knowledgeFolderService) DeleteEmptyFolder(ctx context.Context, kbID string, folderID string) error {
+	tenantID, err := tenantIDFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	folderID = normalizeKnowledgeFolderID(folderID)
+	if folderID == "" {
+		return ErrKnowledgeFolderNotFound
+	}
+	if _, err := s.folderRepo.GetByID(ctx, tenantID, kbID, folderID); err != nil {
+		return err
+	}
+	return s.folderRepo.DeleteEmpty(ctx, tenantID, kbID, folderID)
+}
+
+func (s *knowledgeFolderService) MoveKnowledgeToFolder(ctx context.Context, knowledgeID string, folderID string) (*types.Knowledge, error) {
+	tenantID, err := tenantIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	knowledge, err := s.kgRepo.GetKnowledgeByID(ctx, tenantID, knowledgeID)
+	if err != nil {
+		return nil, err
+	}
+	folderID = normalizeKnowledgeFolderID(folderID)
+	if folderID != "" {
+		if _, err := s.folderRepo.GetByID(ctx, tenantID, knowledge.KnowledgeBaseID, folderID); err != nil {
+			return nil, err
+		}
+	}
+	if err := s.kgRepo.UpdateKnowledgeColumn(ctx, knowledge.ID, "folder_id", folderID); err != nil {
+		return nil, err
+	}
+	knowledge.FolderID = folderID
+	return knowledge, nil
+}
+
+func (s *knowledgeFolderService) ensureFolderNameAvailable(
+	ctx context.Context,
+	tenantID uint64,
+	kbID string,
+	parentID string,
+	name string,
+	currentID string,
+) error {
+	existing, err := s.folderRepo.GetByParentAndName(ctx, tenantID, kbID, parentID, name)
+	if errors.Is(err, ErrKnowledgeFolderNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if existing.ID != currentID {
+		return ErrKnowledgeFolderExists
+	}
+	return nil
+}
+
+func tenantIDFromContext(ctx context.Context) (uint64, error) {
+	tenantID, ok := ctx.Value(types.TenantIDContextKey).(uint64)
+	if !ok || tenantID == 0 {
+		return 0, werrors.NewUnauthorizedError("Tenant ID not found in context")
+	}
+	return tenantID, nil
+}
+
+func normalizeKnowledgeFolderID(folderID string) string {
+	folderID = strings.TrimSpace(folderID)
+	if folderID == types.KnowledgeFolderRootID {
+		return ""
+	}
+	return folderID
+}
+
+func normalizeKnowledgeFolderName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", ErrKnowledgeFolderNameRequired
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return "", ErrKnowledgeFolderInvalidName
+	}
+	return name, nil
+}
+
+func joinKnowledgeFolderPath(parentPath string, name string) string {
+	if parentPath == "" {
+		return name
+	}
+	return parentPath + "/" + name
+}

--- a/internal/application/service/knowledge_folder_test.go
+++ b/internal/application/service/knowledge_folder_test.go
@@ -1,0 +1,215 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupKnowledgeFolderServiceTest(t *testing.T) (*knowledgeFolderService, interfaces.KnowledgeRepository, context.Context) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.Knowledge{}, &types.KnowledgeFolder{}))
+
+	kgRepo := repository.NewKnowledgeRepository(db)
+	folderRepo := repository.NewKnowledgeFolderRepository(db)
+	svc := NewKnowledgeFolderService(folderRepo, kgRepo).(*knowledgeFolderService)
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(10000))
+	return svc, kgRepo, ctx
+}
+
+func TestKnowledgeFolderCreateListAndDuplicate(t *testing.T) {
+	t.Parallel()
+
+	svc, _, ctx := setupKnowledgeFolderServiceTest(t)
+
+	root, err := svc.CreateFolder(ctx, "kb-1", "", "Product Docs")
+	require.NoError(t, err)
+	require.Equal(t, "Product Docs", root.Name)
+	require.Equal(t, "", root.ParentID)
+	require.Equal(t, "Product Docs", root.Path)
+
+	child, err := svc.CreateFolder(ctx, "kb-1", root.ID, "API")
+	require.NoError(t, err)
+	require.Equal(t, root.ID, child.ParentID)
+	require.Equal(t, "Product Docs/API", child.Path)
+
+	_, err = svc.CreateFolder(ctx, "kb-1", root.ID, "API")
+	require.ErrorIs(t, err, ErrKnowledgeFolderExists)
+
+	folders, err := svc.ListFolders(ctx, "kb-1", root.ID)
+	require.NoError(t, err)
+	require.Len(t, folders, 1)
+	require.Equal(t, child.ID, folders[0].ID)
+}
+
+func TestKnowledgeFolderMoveKnowledgeAndFilter(t *testing.T) {
+	t.Parallel()
+
+	svc, kgRepo, ctx := setupKnowledgeFolderServiceTest(t)
+	folder, err := svc.CreateFolder(ctx, "kb-1", "", "Guides")
+	require.NoError(t, err)
+
+	inFolder := &types.Knowledge{
+		ID:              "k-in",
+		TenantID:        10000,
+		KnowledgeBaseID: "kb-1",
+		Type:            "document",
+		Title:           "in folder",
+		Source:          "manual",
+	}
+	root := &types.Knowledge{
+		ID:              "k-root",
+		TenantID:        10000,
+		KnowledgeBaseID: "kb-1",
+		Type:            "document",
+		Title:           "root",
+		Source:          "manual",
+	}
+	require.NoError(t, kgRepo.CreateKnowledge(ctx, inFolder))
+	require.NoError(t, kgRepo.CreateKnowledge(ctx, root))
+
+	moved, err := svc.MoveKnowledgeToFolder(ctx, "k-in", folder.ID)
+	require.NoError(t, err)
+	require.Equal(t, folder.ID, moved.FolderID)
+
+	result, total, err := kgRepo.ListPagedKnowledgeByKnowledgeBaseID(
+		ctx,
+		10000,
+		"kb-1",
+		&types.Pagination{Page: 1, PageSize: 20},
+		types.KnowledgeListFilter{FolderID: &folder.ID},
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.Len(t, result, 1)
+	require.Equal(t, "k-in", result[0].ID)
+
+	rootFolder := ""
+	rootResult, rootTotal, err := kgRepo.ListPagedKnowledgeByKnowledgeBaseID(
+		ctx,
+		10000,
+		"kb-1",
+		&types.Pagination{Page: 1, PageSize: 20},
+		types.KnowledgeListFilter{FolderID: &rootFolder},
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rootTotal)
+	require.Len(t, rootResult, 1)
+	require.Equal(t, "k-root", rootResult[0].ID)
+}
+
+func TestKnowledgeFolderRenameUpdatesDescendantPaths(t *testing.T) {
+	t.Parallel()
+
+	svc, _, ctx := setupKnowledgeFolderServiceTest(t)
+	root, err := svc.CreateFolder(ctx, "kb-1", "", "Products")
+	require.NoError(t, err)
+	child, err := svc.CreateFolder(ctx, "kb-1", root.ID, "Docs")
+	require.NoError(t, err)
+	grandchild, err := svc.CreateFolder(ctx, "kb-1", child.ID, "v2")
+	require.NoError(t, err)
+
+	renamed, err := svc.RenameFolder(ctx, "kb-1", root.ID, "Items")
+	require.NoError(t, err)
+	require.Equal(t, "Items", renamed.Path)
+
+	children, err := svc.ListFolders(ctx, "kb-1", renamed.ID)
+	require.NoError(t, err)
+	require.Len(t, children, 1)
+	require.Equal(t, child.ID, children[0].ID)
+	require.Equal(t, "Items/Docs", children[0].Path)
+
+	grandchildren, err := svc.ListFolders(ctx, "kb-1", child.ID)
+	require.NoError(t, err)
+	require.Len(t, grandchildren, 1)
+	require.Equal(t, grandchild.ID, grandchildren[0].ID)
+	require.Equal(t, "Items/Docs/v2", grandchildren[0].Path)
+}
+
+func TestKnowledgeFolderRenameEscapesLikeWildcards(t *testing.T) {
+	t.Parallel()
+
+	svc, _, ctx := setupKnowledgeFolderServiceTest(t)
+	wildcardRoot, err := svc.CreateFolder(ctx, "kb-1", "", "Sale 50% Off")
+	require.NoError(t, err)
+	wildcardChild, err := svc.CreateFolder(ctx, "kb-1", wildcardRoot.ID, "Docs")
+	require.NoError(t, err)
+	underscoreRoot, err := svc.CreateFolder(ctx, "kb-1", "", "SKU_A")
+	require.NoError(t, err)
+	underscoreChild, err := svc.CreateFolder(ctx, "kb-1", underscoreRoot.ID, "Specs")
+	require.NoError(t, err)
+
+	percentLookalike, err := svc.CreateFolder(ctx, "kb-1", "", "Sale 50X Off")
+	require.NoError(t, err)
+	percentLookalikeChild, err := svc.CreateFolder(ctx, "kb-1", percentLookalike.ID, "Other")
+	require.NoError(t, err)
+	underscoreLookalike, err := svc.CreateFolder(ctx, "kb-1", "", "SKUBA")
+	require.NoError(t, err)
+	underscoreLookalikeChild, err := svc.CreateFolder(ctx, "kb-1", underscoreLookalike.ID, "Other")
+	require.NoError(t, err)
+
+	_, err = svc.RenameFolder(ctx, "kb-1", wildcardRoot.ID, "Discount 50% Off")
+	require.NoError(t, err)
+	_, err = svc.RenameFolder(ctx, "kb-1", underscoreRoot.ID, "SKU_Main")
+	require.NoError(t, err)
+
+	wildcardChildren, err := svc.ListFolders(ctx, "kb-1", wildcardRoot.ID)
+	require.NoError(t, err)
+	require.Len(t, wildcardChildren, 1)
+	require.Equal(t, wildcardChild.ID, wildcardChildren[0].ID)
+	require.Equal(t, "Discount 50% Off/Docs", wildcardChildren[0].Path)
+
+	underscoreChildren, err := svc.ListFolders(ctx, "kb-1", underscoreRoot.ID)
+	require.NoError(t, err)
+	require.Len(t, underscoreChildren, 1)
+	require.Equal(t, underscoreChild.ID, underscoreChildren[0].ID)
+	require.Equal(t, "SKU_Main/Specs", underscoreChildren[0].Path)
+
+	percentLookalikeChildren, err := svc.ListFolders(ctx, "kb-1", percentLookalike.ID)
+	require.NoError(t, err)
+	require.Len(t, percentLookalikeChildren, 1)
+	require.Equal(t, percentLookalikeChild.ID, percentLookalikeChildren[0].ID)
+	require.Equal(t, "Sale 50X Off/Other", percentLookalikeChildren[0].Path)
+
+	underscoreLookalikeChildren, err := svc.ListFolders(ctx, "kb-1", underscoreLookalike.ID)
+	require.NoError(t, err)
+	require.Len(t, underscoreLookalikeChildren, 1)
+	require.Equal(t, underscoreLookalikeChild.ID, underscoreLookalikeChildren[0].ID)
+	require.Equal(t, "SKUBA/Other", underscoreLookalikeChildren[0].Path)
+}
+
+func TestKnowledgeFolderDeleteRequiresEmptyFolder(t *testing.T) {
+	t.Parallel()
+
+	svc, kgRepo, ctx := setupKnowledgeFolderServiceTest(t)
+	folder, err := svc.CreateFolder(ctx, "kb-1", "", "Archive")
+	require.NoError(t, err)
+	require.NoError(t, kgRepo.CreateKnowledge(ctx, &types.Knowledge{
+		ID:              "k-archive",
+		TenantID:        10000,
+		KnowledgeBaseID: "kb-1",
+		FolderID:        folder.ID,
+		Type:            "document",
+		Title:           "archive",
+		Source:          "manual",
+	}))
+
+	err = svc.DeleteEmptyFolder(ctx, "kb-1", folder.ID)
+	require.ErrorIs(t, err, ErrKnowledgeFolderNotEmpty)
+
+	_, err = svc.MoveKnowledgeToFolder(ctx, "k-archive", types.KnowledgeFolderRootID)
+	require.NoError(t, err)
+	require.NoError(t, svc.DeleteEmptyFolder(ctx, "kb-1", folder.ID))
+
+	_, err = svc.ListFolders(ctx, "kb-1", folder.ID)
+	require.True(t, errors.Is(err, ErrKnowledgeFolderNotFound))
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -144,6 +144,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewAuditLogRepository))
 	must(container.Provide(repository.NewKnowledgeBaseRepository))
 	must(container.Provide(repository.NewKnowledgeRepository))
+	must(container.Provide(repository.NewKnowledgeFolderRepository))
 	must(container.Provide(repository.NewKnowledgeSpanRepository))
 	must(container.Provide(repository.NewChunkRepository))
 	must(container.Provide(repository.NewKnowledgeTagRepository))
@@ -191,6 +192,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(service.NewKBShareService)) // KBShareService must be registered before KnowledgeService and KnowledgeTagService
 	must(container.Provide(service.NewAgentShareService))
 	must(container.Provide(service.NewKnowledgeService))
+	must(container.Provide(service.NewKnowledgeFolderService))
 	must(container.Provide(service.NewSpanTracker))
 	must(container.Provide(service.NewChunkService))
 	must(container.Provide(service.NewKnowledgeTagService))

--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -33,6 +33,7 @@ import (
 type KnowledgeHandler struct {
 	cfg               *config.Config
 	kgService         interfaces.KnowledgeService
+	folderService     interfaces.KnowledgeFolderService
 	kbService         interfaces.KnowledgeBaseService
 	kbShareService    interfaces.KBShareService
 	agentShareService interfaces.AgentShareService
@@ -44,6 +45,7 @@ type KnowledgeHandler struct {
 func NewKnowledgeHandler(
 	cfg *config.Config,
 	kgService interfaces.KnowledgeService,
+	folderService interfaces.KnowledgeFolderService,
 	kbService interfaces.KnowledgeBaseService,
 	kbShareService interfaces.KBShareService,
 	agentShareService interfaces.AgentShareService,
@@ -53,6 +55,7 @@ func NewKnowledgeHandler(
 	return &KnowledgeHandler{
 		cfg:               cfg,
 		kgService:         kgService,
+		folderService:     folderService,
 		kbService:         kbService,
 		kbShareService:    kbShareService,
 		agentShareService: agentShareService,
@@ -872,6 +875,7 @@ func buildSpanTree(knowledgeID string, attempt int, rows []types.KnowledgeProces
 // @Param        file_type     query     string  false  "文件类型筛选"
 // @Param        parse_status  query     string  false  "解析状态筛选 (pending/processing/completed/failed)"
 // @Param        source        query     string  false  "来源/渠道筛选 (web/api/feishu/notion/yuque/wechat/...，或 manual/url 按 type 过滤)"
+// @Param        folder_id     query     string  false  "目录ID筛选，__root__ 表示根目录"
 // @Param        start_time    query     string  false  "更新时间起点，RFC3339 格式"
 // @Param        end_time      query     string  false  "更新时间终点，RFC3339 格式"
 // @Success      200        {object}  map[string]interface{}  "知识列表"
@@ -908,6 +912,7 @@ func (h *KnowledgeHandler) ListKnowledge(c *gin.Context) {
 		FileType:    c.Query("file_type"),
 		ParseStatus: c.Query("parse_status"),
 		Source:      c.Query("source"),
+		FolderID:    normalizeKnowledgeFolderQuery(c.Query("folder_id")),
 	}
 	if raw := c.Query("start_time"); raw != "" {
 		t, err := parseFilterTime(raw)
@@ -926,15 +931,20 @@ func (h *KnowledgeHandler) ListKnowledge(c *gin.Context) {
 		filter.UpdatedTo = t
 	}
 
+	folderIDLog := ""
+	if filter.FolderID != nil {
+		folderIDLog = *filter.FolderID
+	}
 	logger.Infof(
 		ctx,
-		"Retrieving knowledge list under knowledge base, kb_id=%s tag_ids=%s keyword=%s file_type=%s parse_status=%s source=%s start_time=%s end_time=%s page=%d page_size=%d effectiveTenantID=%d",
+		"Retrieving knowledge list under knowledge base, kb_id=%s tag_ids=%s keyword=%s file_type=%s parse_status=%s source=%s folder_id=%s start_time=%s end_time=%s page=%d page_size=%d effectiveTenantID=%d",
 		secutils.SanitizeForLog(kbID),
 		secutils.SanitizeForLog(strings.Join(filter.TagIDs, ",")),
 		secutils.SanitizeForLog(filter.Keyword),
 		secutils.SanitizeForLog(filter.FileType),
 		secutils.SanitizeForLog(filter.ParseStatus),
 		secutils.SanitizeForLog(filter.Source),
+		secutils.SanitizeForLog(folderIDLog),
 		secutils.SanitizeForLog(c.Query("start_time")),
 		secutils.SanitizeForLog(c.Query("end_time")),
 		pagination.Page,

--- a/internal/handler/knowledge_folder.go
+++ b/internal/handler/knowledge_folder.go
@@ -1,0 +1,215 @@
+package handler
+
+import (
+	"context"
+	goerrors "errors"
+	"net/http"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/application/service"
+	apperrors "github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/gin-gonic/gin"
+)
+
+// ListKnowledgeFolders godoc
+// @Summary      List document folders
+// @Description  List direct child folders under parent_id. Use parent_id=__root__ or empty for the root level.
+// @Tags         知识管理
+// @Produce      json
+// @Param        id         path   string  true   "知识库ID"
+// @Param        parent_id  query  string  false  "父目录ID，__root__ 表示根目录"
+// @Success      200  {object}  map[string]interface{}
+// @Security     Bearer
+// @Security     ApiKeyAuth
+// @Router       /knowledge-bases/{id}/folders [get]
+func (h *KnowledgeHandler) ListKnowledgeFolders(c *gin.Context) {
+	ctx := c.Request.Context()
+	_, kbID, effectiveTenantID, _, err := h.validateKnowledgeBaseAccess(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	ctx = withEffectiveTenantID(ctx, effectiveTenantID)
+
+	folders, err := h.folderService.ListFolders(ctx, kbID, c.Query("parent_id"))
+	if err != nil {
+		h.handleKnowledgeFolderError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": gin.H{"folders": folders}})
+}
+
+// CreateKnowledgeFolder godoc
+// @Summary      Create document folder
+// @Description  Create an empty document-management folder under parent_id.
+// @Tags         知识管理
+// @Accept       json
+// @Produce      json
+// @Param        id       path  string                              true  "知识库ID"
+// @Param        request  body  types.KnowledgeFolderCreateRequest  true  "目录信息"
+// @Success      201  {object}  map[string]interface{}
+// @Security     Bearer
+// @Security     ApiKeyAuth
+// @Router       /knowledge-bases/{id}/folders [post]
+func (h *KnowledgeHandler) CreateKnowledgeFolder(c *gin.Context) {
+	ctx := c.Request.Context()
+	_, kbID, effectiveTenantID, _, err := h.validateKnowledgeBaseAccess(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	ctx = withEffectiveTenantID(ctx, effectiveTenantID)
+
+	var req types.KnowledgeFolderCreateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.Error(apperrors.NewValidationError("invalid folder request").WithDetails(err.Error()))
+		return
+	}
+	folder, err := h.folderService.CreateFolder(ctx, kbID, req.ParentID, req.Name)
+	if err != nil {
+		h.handleKnowledgeFolderError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"success": true, "data": folder})
+}
+
+// UpdateKnowledgeFolder godoc
+// @Summary      Rename document folder
+// @Description  Rename a document-management folder. Moving folders is intentionally out of scope for the first PR.
+// @Tags         知识管理
+// @Accept       json
+// @Produce      json
+// @Param        id         path  string                              true  "知识库ID"
+// @Param        folder_id  path  string                              true  "目录ID"
+// @Param        request    body  types.KnowledgeFolderUpdateRequest  true  "目录信息"
+// @Success      200  {object}  map[string]interface{}
+// @Security     Bearer
+// @Security     ApiKeyAuth
+// @Router       /knowledge-bases/{id}/folders/{folder_id} [put]
+func (h *KnowledgeHandler) UpdateKnowledgeFolder(c *gin.Context) {
+	ctx := c.Request.Context()
+	_, kbID, effectiveTenantID, _, err := h.validateKnowledgeBaseAccess(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	ctx = withEffectiveTenantID(ctx, effectiveTenantID)
+
+	var req types.KnowledgeFolderUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.Error(apperrors.NewValidationError("invalid folder request").WithDetails(err.Error()))
+		return
+	}
+	folderID := c.Param("folder_id")
+	folder, err := h.folderService.RenameFolder(ctx, kbID, folderID, req.Name)
+	if err != nil {
+		h.handleKnowledgeFolderError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": folder})
+}
+
+// DeleteKnowledgeFolder godoc
+// @Summary      Delete empty document folder
+// @Description  Delete a folder only when it has no child folders and no direct documents.
+// @Tags         知识管理
+// @Produce      json
+// @Param        id         path  string  true  "知识库ID"
+// @Param        folder_id  path  string  true  "目录ID"
+// @Success      200  {object}  map[string]interface{}
+// @Security     Bearer
+// @Security     ApiKeyAuth
+// @Router       /knowledge-bases/{id}/folders/{folder_id} [delete]
+func (h *KnowledgeHandler) DeleteKnowledgeFolder(c *gin.Context) {
+	ctx := c.Request.Context()
+	_, kbID, effectiveTenantID, _, err := h.validateKnowledgeBaseAccess(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	ctx = withEffectiveTenantID(ctx, effectiveTenantID)
+
+	folderID := c.Param("folder_id")
+	if err := h.folderService.DeleteEmptyFolder(ctx, kbID, folderID); err != nil {
+		h.handleKnowledgeFolderError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+// MoveKnowledgeToFolder godoc
+// @Summary      Move knowledge to folder
+// @Description  Move a single knowledge item to a folder. Empty folder_id or __root__ moves it to root.
+// @Tags         知识管理
+// @Accept       json
+// @Produce      json
+// @Param        id       path  string                            true  "知识ID"
+// @Param        request  body  types.KnowledgeFolderMoveRequest  true  "目标目录"
+// @Success      200  {object}  map[string]interface{}
+// @Security     Bearer
+// @Security     ApiKeyAuth
+// @Router       /knowledge/{id}/folder [put]
+func (h *KnowledgeHandler) MoveKnowledgeToFolder(c *gin.Context) {
+	knowledgeID := c.Param("id")
+	if strings.TrimSpace(knowledgeID) == "" {
+		c.Error(apperrors.NewValidationError("knowledge id is required"))
+		return
+	}
+
+	var req types.KnowledgeFolderMoveRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.Error(apperrors.NewValidationError("invalid folder move request").WithDetails(err.Error()))
+		return
+	}
+	_, effCtx, err := h.resolveKnowledgeAndValidateKBAccess(c, knowledgeID, types.OrgRoleEditor)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	knowledge, err := h.folderService.MoveKnowledgeToFolder(effCtx, knowledgeID, req.FolderID)
+	if err != nil {
+		h.handleKnowledgeFolderError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": knowledge})
+}
+
+func (h *KnowledgeHandler) handleKnowledgeFolderError(c *gin.Context, err error) {
+	switch {
+	case goerrors.Is(err, service.ErrKnowledgeFolderNameRequired):
+		c.Error(apperrors.NewValidationError("folder name is required"))
+	case goerrors.Is(err, service.ErrKnowledgeFolderInvalidName):
+		c.Error(apperrors.NewValidationError("folder name cannot contain path separators"))
+	case goerrors.Is(err, service.ErrKnowledgeFolderTooDeep):
+		c.Error(apperrors.NewValidationError("folder depth exceeds limit"))
+	case goerrors.Is(err, service.ErrKnowledgeFolderExists):
+		c.Error(apperrors.NewConflictError("folder already exists"))
+	case goerrors.Is(err, service.ErrKnowledgeFolderNotEmpty):
+		c.Error(apperrors.NewConflictError("folder is not empty"))
+	case goerrors.Is(err, service.ErrKnowledgeFolderNotFound):
+		c.Error(apperrors.NewNotFoundError("folder not found"))
+	case goerrors.Is(err, repository.ErrKnowledgeNotFound):
+		c.Error(apperrors.NewNotFoundError("knowledge not found"))
+	default:
+		logger.ErrorWithFields(c.Request.Context(), err, nil)
+		c.Error(apperrors.NewInternalServerError("knowledge folder operation failed").WithDetails(err.Error()))
+	}
+}
+
+func normalizeKnowledgeFolderQuery(raw string) *string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	folderID := strings.TrimSpace(raw)
+	if folderID == types.KnowledgeFolderRootID {
+		folderID = ""
+	}
+	return &folderID
+}
+
+func withEffectiveTenantID(ctx context.Context, tenantID uint64) context.Context {
+	return context.WithValue(ctx, types.TenantIDContextKey, tenantID)
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -317,6 +317,17 @@ func RegisterKnowledgeRoutes(r *gin.RouterGroup, handler *handler.KnowledgeHandl
 		kb.With(apiKeyFullAccess()).DELETE("", g.Admin(), g.KBAccessWrite("id"), handler.ClearKnowledgeBaseContents)
 	}
 
+	// 文档目录路由（URL :id is the KB id）。目录本身是 KB 内容组织结构：
+	// 读取需要 retrieve，创建/重命名/删除需要 ingest + KB write。
+	folders := g.apiKeyGroup(r.Group("/knowledge-bases/:id/folders"), apiKeyIngest(apiKeyFullAccess()))
+	foldersRead := folders.With(apiKeyRetrieve(apiKeyFullAccess()))
+	{
+		foldersRead.GET("", g.Viewer(), g.KBAccessRead("id"), handler.ListKnowledgeFolders)
+		folders.POST("", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.CreateKnowledgeFolder)
+		folders.PUT("/:folder_id", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.UpdateKnowledgeFolder)
+		folders.DELETE("/:folder_id", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.DeleteKnowledgeFolder)
+	}
+
 	// 知识路由组（URL :id is a knowledge id; the guard walks it to the parent KB）
 	kgrp := r.Group("/knowledge")
 	k := g.apiKeyGroup(kgrp, apiKeyIngest(apiKeyFullAccess()))
@@ -332,6 +343,7 @@ func RegisterKnowledgeRoutes(r *gin.RouterGroup, handler *handler.KnowledgeHandl
 		kRead.GET("/:id/stages", g.Viewer(), g.KBAccessReadFromKnowledgeIDParam("id"), handler.GetKnowledgeSpans)
 		kRead.GET("/:id/spans", g.Viewer(), g.KBAccessReadFromKnowledgeIDParam("id"), handler.GetKnowledgeSpans)
 		k.DELETE("/:id", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.DeleteKnowledge)
+		k.PUT("/:id/folder", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.MoveKnowledgeToFolder)
 		k.PUT("/:id", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.UpdateKnowledge)
 		k.PUT("/manual/:id", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.UpdateManualKnowledge)
 		k.POST("/:id/reparse", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.ReparseKnowledge)

--- a/internal/types/interfaces/knowledge_folder.go
+++ b/internal/types/interfaces/knowledge_folder.go
@@ -1,0 +1,30 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// KnowledgeFolderService manages document folders under a knowledge base.
+type KnowledgeFolderService interface {
+	ListFolders(ctx context.Context, kbID string, parentID string) ([]*types.KnowledgeFolder, error)
+	CreateFolder(ctx context.Context, kbID string, parentID string, name string) (*types.KnowledgeFolder, error)
+	RenameFolder(ctx context.Context, kbID string, folderID string, name string) (*types.KnowledgeFolder, error)
+	DeleteEmptyFolder(ctx context.Context, kbID string, folderID string) error
+	MoveKnowledgeToFolder(ctx context.Context, knowledgeID string, folderID string) (*types.Knowledge, error)
+}
+
+// KnowledgeFolderRepository persists document folders.
+type KnowledgeFolderRepository interface {
+	ListByParent(ctx context.Context, tenantID uint64, kbID string, parentID string) ([]*types.KnowledgeFolder, error)
+	GetByID(ctx context.Context, tenantID uint64, kbID string, folderID string) (*types.KnowledgeFolder, error)
+	GetByParentAndName(ctx context.Context, tenantID uint64, kbID string, parentID string, name string) (*types.KnowledgeFolder, error)
+	Create(ctx context.Context, folder *types.KnowledgeFolder) error
+	Update(ctx context.Context, folder *types.KnowledgeFolder) error
+	UpdateWithDescendantPaths(ctx context.Context, folder *types.KnowledgeFolder, oldPath string) error
+	Delete(ctx context.Context, tenantID uint64, kbID string, folderID string) error
+	DeleteEmpty(ctx context.Context, tenantID uint64, kbID string, folderID string) error
+	CountKnowledgeByParents(ctx context.Context, tenantID uint64, kbID string, folderIDs []string) (map[string]int64, error)
+	MarkHasChildren(ctx context.Context, tenantID uint64, kbID string, folders []*types.KnowledgeFolder) error
+}

--- a/internal/types/knowledge.go
+++ b/internal/types/knowledge.go
@@ -100,6 +100,9 @@ type KnowledgeListFilter struct {
 	// The special values "manual" and "url" are routed to the `type` column to match
 	// FileType semantics, so callers can filter "manually created" / "URL imported" entries.
 	Source string
+	// FolderID filters by exact document folder placement. nil means no folder
+	// filter; pointer to "" means root-level documents.
+	FolderID *string
 	// UpdatedFrom, when non-zero, keeps rows with updated_at >= UpdatedFrom.
 	UpdatedFrom time.Time
 	// UpdatedTo, when non-zero, keeps rows with updated_at <= UpdatedTo.
@@ -116,6 +119,8 @@ type Knowledge struct {
 	TenantID uint64 `json:"tenant_id"`
 	// ID of the knowledge base
 	KnowledgeBaseID string `json:"knowledge_base_id"`
+	// FolderID is the document-management folder containing this knowledge.
+	FolderID string `json:"folder_id" gorm:"type:varchar(36);index;default:''"`
 	// Tags holds the tags associated with this knowledge (populated on query, not persisted directly).
 	Tags []*KnowledgeTag `json:"tags"               gorm:"-"`
 	// Type of the knowledge

--- a/internal/types/knowledge_folder.go
+++ b/internal/types/knowledge_folder.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const KnowledgeFolderRootID = "__root__"
+
+// KnowledgeFolder is a document-management directory inside a document KB.
+type KnowledgeFolder struct {
+	ID              string         `json:"id" gorm:"type:varchar(36);primaryKey"`
+	TenantID        uint64         `json:"tenant_id"`
+	KnowledgeBaseID string         `json:"knowledge_base_id"`
+	ParentID        string         `json:"parent_id" gorm:"type:varchar(36);default:''"`
+	Name            string         `json:"name" gorm:"type:varchar(255);not null"`
+	Path            string         `json:"path" gorm:"type:varchar(1024);default:''"`
+	Depth           int            `json:"depth" gorm:"default:0"`
+	SortOrder       int            `json:"sort_order" gorm:"default:0"`
+	KnowledgeCount  int64          `json:"knowledge_count" gorm:"-"`
+	HasChildren     bool           `json:"has_children" gorm:"-"`
+	CreatedAt       time.Time      `json:"created_at"`
+	UpdatedAt       time.Time      `json:"updated_at"`
+	DeletedAt       gorm.DeletedAt `json:"deleted_at" gorm:"index"`
+}
+
+// BeforeCreate assigns a stable UUID when the caller did not provide one.
+func (f *KnowledgeFolder) BeforeCreate(tx *gorm.DB) error {
+	if f.ID == "" {
+		f.ID = uuid.New().String()
+	}
+	return nil
+}
+
+// KnowledgeFolderCreateRequest is the body for creating a document folder.
+type KnowledgeFolderCreateRequest struct {
+	ParentID string `json:"parent_id"`
+	Name     string `json:"name" binding:"required"`
+}
+
+// KnowledgeFolderUpdateRequest is the body for renaming a document folder.
+type KnowledgeFolderUpdateRequest struct {
+	Name string `json:"name" binding:"required"`
+}
+
+// KnowledgeFolderMoveRequest is the body for moving a knowledge row to a folder.
+type KnowledgeFolderMoveRequest struct {
+	FolderID string `json:"folder_id"`
+}

--- a/migrations/versioned/000066_knowledge_folders.down.sql
+++ b/migrations/versioned/000066_knowledge_folders.down.sql
@@ -1,0 +1,9 @@
+-- Rollback: 000066_knowledge_folders
+
+DROP INDEX IF EXISTS idx_knowledges_folder_id;
+ALTER TABLE knowledges DROP COLUMN IF EXISTS folder_id;
+
+DROP INDEX IF EXISTS idx_knowledge_folders_deleted_at;
+DROP INDEX IF EXISTS idx_knowledge_folders_parent;
+DROP INDEX IF EXISTS idx_knowledge_folders_parent_name;
+DROP TABLE IF EXISTS knowledge_folders;

--- a/migrations/versioned/000066_knowledge_folders.up.sql
+++ b/migrations/versioned/000066_knowledge_folders.up.sql
@@ -1,0 +1,35 @@
+-- Migration: 000066_knowledge_folders
+-- Description: Add document knowledge folder hierarchy.
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000066] Applying knowledge folder schema'; END $$;
+
+CREATE TABLE IF NOT EXISTS knowledge_folders (
+    id                VARCHAR(36) PRIMARY KEY,
+    tenant_id         BIGINT NOT NULL,
+    knowledge_base_id VARCHAR(36) NOT NULL,
+    parent_id         VARCHAR(36) NOT NULL DEFAULT '',
+    name              VARCHAR(255) NOT NULL,
+    path              VARCHAR(1024) NOT NULL DEFAULT '',
+    depth             INT NOT NULL DEFAULT 0,
+    sort_order        INT NOT NULL DEFAULT 0,
+    created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    deleted_at        TIMESTAMP WITH TIME ZONE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_knowledge_folders_parent_name
+    ON knowledge_folders (knowledge_base_id, parent_id, name)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_folders_parent
+    ON knowledge_folders (knowledge_base_id, parent_id);
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_folders_deleted_at
+    ON knowledge_folders (deleted_at);
+
+ALTER TABLE knowledges ADD COLUMN IF NOT EXISTS folder_id VARCHAR(36) NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_knowledges_folder_id
+    ON knowledges (tenant_id, knowledge_base_id, folder_id);
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000066] knowledge folder schema applied successfully'; END $$;


### PR DESCRIPTION
## Summary
- add a document knowledge folder schema and backend CRUD APIs
- add folder_id on knowledge rows, list filtering by folder_id, and single-document folder move
- keep this as a small backend-only phase: no frontend folder tree, upload mapping, recursive delete, or folder-scoped QA yet

## Related issues
- Related to #1311
- Related to #1943

## Testing
- go test ./internal/application/service -run TestKnowledgeFolder -count=1
- go test ./internal/application/repository ./internal/application/service ./internal/handler ./internal/router
- git diff --check

## Notes
- Directory delete is intentionally empty-only.
- The root folder is represented by an empty folder_id; API callers may pass __root__ for root filtering/moves.
- Folder rename updates descendant paths and escapes LIKE wildcards when selecting descendants.