### PR TITLE
fix(faq): guard against division by zero in import timing logs

### DIFF
--- a/internal/application/service/knowledge_faq_import.go
+++ b/internal/application/service/knowledge_faq_import.go
@@ -1059,6 +1059,10 @@ func (s *knowledgeService) executeFAQImport(ctx context.Context, taskID string, 
 	}
 
 	totalDuration := time.Since(totalStartTime)
+	var avgPerEntry time.Duration
+	if actualProcessed > 0 {
+		avgPerEntry = totalDuration / time.Duration(actualProcessed)
+	}
 	logger.Infof(
 		ctx,
 		"FAQ import task %s: all batches completed, processed: %d entries (skipped: %d) in %v, avg: %v per entry",
@@ -1066,7 +1070,7 @@ func (s *knowledgeService) executeFAQImport(ctx context.Context, taskID string, 
 		actualProcessed,
 		skippedCount,
 		totalDuration,
-		totalDuration/time.Duration(actualProcessed),
+		avgPerEntry,
 	)
 
 	return nil
@@ -1417,8 +1421,12 @@ func (s *knowledgeService) indexFAQChunks(ctx context.Context,
 		return err
 	}
 	batchIndexDuration := time.Since(batchIndexStartTime)
+	var avgPerEntry time.Duration
+	if len(indexInfo) > 0 {
+		avgPerEntry = batchIndexDuration / time.Duration(len(indexInfo))
+	}
 	logger.Debugf(ctx, "indexFAQChunks: batch indexed %d index info entries in %v (avg: %v per entry)",
-		len(indexInfo), batchIndexDuration, batchIndexDuration/time.Duration(len(indexInfo)))
+		len(indexInfo), batchIndexDuration, avgPerEntry)
 
 	if adjustStorage && size > 0 {
 		adjustStartTime := time.Now()


### PR DESCRIPTION
## Summary
- 在 FAQ 导入完成日志和 batch index 日志中，避免 `actualProcessed` / `len(indexInfo)` 为 0 时除零 panic

## Test plan
- [ ] FAQ 导入任务全部跳过时，日志正常输出
- [ ] `indexFAQChunks` 在空 `indexInfo` 时不再 panic

