### PR TITLE
feat: add source-grounded RAG citations

### DIFF
--- a/config/prompt_templates/system_prompt.yaml
+++ b/config/prompt_templates/system_prompt.yaml
@@ -23,7 +23,27 @@ templates:
       - Reply ONLY based on facts from the retrieved information, without using any prior knowledge, maintaining objectivity and accuracy
       - For complex questions, structure the answer using Markdown formatting; simple summaries do not need to be split
       - For simple answers, do not break the final answer into overly granular parts
-      - Image URLs used in results must come from the retrieved information and must not be fabricated
+      - Every factual sentence based on retrieved information MUST end with an inline citation tag using this exact format: <kb doc="..." chunk_id="..." kb_id="..." />
+      - The citation tag values MUST come from the matching <context> attributes: use doc from the context's doc attribute, chunk_id from chunk_id, and kb_id from kb_id
+      - Put citation tags on the same line as the sentence they support; do not collect citations at the end of the answer
+      - Use up to 4 citation tags per sentence when multiple contexts support the same sentence, and do not cite content that is not supported by retrieved information
+      - Retrieved information may contain images in either of these formats:
+        1. Markdown image: `![image number and title](local://.../xxx.png)`
+        2. XML image block: `<image url="local://.../xxx.png"><image_caption>image number and title</image_caption><image_ocr>optional OCR or description</image_ocr></image>`
+      - Both formats represent displayable image references from the retrieved information; use the URL and caption exactly as provided when including images in the answer
+      - Prefer image-rich answers whenever possible: for ANY user question, if the retrieved information contains images that are directly relevant to the answer's main topic, disease, sign, comparison point, diagnosis, treatment, table entry, or clinical manifestation, you SHOULD include those images together with the text answer
+      - If the user's question asks about eye fundus appearance, image appearance, clinical manifestations, differential diagnosis, comparison, "鉴别", "区别", "表现", "眼底表现", "长什么样", "图片", "图", "照片", "展示", or similar visual/appearance questions, and relevant images exist in the retrieved information, you MUST include the relevant images in the answer
+      - Do not omit relevant images merely because the user did not explicitly ask for pictures. Do not omit relevant images merely because the answer is a comparison, summary, table, differential diagnosis, or text explanation
+      - For Markdown images from retrieved information, preserve the exact image URL and use the alt text as the image caption
+      - For XML image blocks, use the `url` attribute as the image URL and use the complete text between `<image_caption>` and `</image_caption>` as the image caption
+      - Output each image title and image as exactly two consecutive Markdown lines, with the image number/title ABOVE the image, no blank line, and no trailing spaces:
+        `**image number and title** <kb doc="..." chunk_id="..." kb_id="..." />`
+        `![image number and title](local://.../xxx.png)`
+      - The image line MUST be the very next line after the title line. Do not insert an empty line, `<br>`, HTML, list item marker, or two trailing spaces after either line
+      - If the retrieved context contains a description, case note, OCR text, figure explanation, or 图点评 for that image, write a concise image description immediately below the image. The description must come from the retrieved context and must end with a citation tag
+      - Do not output the image number/title below the image, and do not duplicate the same image caption as a separate heading or paragraph
+      - Never fabricate placeholder images such as `![图片](图片地址)`, `![image](url)`, or any image URL not present in the retrieved contexts
+      - If no relevant image URL exists in the retrieved information, say that no relevant image was found; do not create a placeholder image
       - Verify that all text and images in the result come from the retrieved information; if content not found in the retrieved information has been added, it must be revised until the final answer is obtained
       - If the user's question cannot be answered, honestly inform the user and provide reasonable suggestions
 

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -57,8 +57,12 @@ ARG APK_MIRROR_ARG
 # Create a non-root user first
 RUN useradd -m -s /bin/bash appuser
 
-# First, install ca-certificates without mirror to ensure HTTPS works
-RUN apt-get update && \
+# First, install ca-certificates. Use the configured mirror here too so builds
+# do not depend on deb.debian.org being reachable from the local network.
+RUN if [ -n "$APK_MIRROR_ARG" ]; then \
+        sed -i "s@deb.debian.org@${APK_MIRROR_ARG}@g" /etc/apt/sources.list.d/debian.sources; \
+    fi && \
+    apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 

--- a/frontend/src/components/ChatCitationFloat.vue
+++ b/frontend/src/components/ChatCitationFloat.vue
@@ -1,6 +1,6 @@
 <template>
   <Teleport to="body">
-    <div v-if="float.visible" class="chat-citation-float" :style="{ top: `${float.top}px`, left: `${float.left}px` }"
+    <div v-if="float.visible" ref="floatRef" class="chat-citation-float" :style="floatStyle"
       @mouseenter="onEnter?.()" @mouseleave="onLeave?.()">
       <template v-if="float.type === 'web'">
         <div class="chat-citation-float__title">{{ float.title || float.url }}</div>
@@ -11,17 +11,30 @@
         <div class="chat-citation-float__title">{{ float.title }}</div>
         <div v-if="float.loading" class="chat-citation-float__muted">{{ loadingText }}</div>
         <div v-else-if="float.error" class="chat-citation-float__error">{{ float.error }}</div>
-        <div v-else class="chat-citation-float__body">{{ float.content }}</div>
+        <div
+          v-else
+          ref="bodyRef"
+          class="chat-citation-float__body markdown-content"
+          v-stable-html="renderedContent"
+        />
       </template>
     </div>
   </Teleport>
 </template>
 
 <script setup lang="ts">
+import { computed, nextTick, ref, watch, type CSSProperties } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { CitationFloatState } from '@/composables/useChatCitationPopover'
+import { vStableHtml } from '@/directives/stableHtml'
+import { renderCitationPreviewContent } from '@/utils/citationPreview'
+import { hydrateProtectedFileImages } from '@/utils/security'
+import {
+  computeCitationFloatPosition,
+  currentCitationViewport,
+} from '@/utils/citationFloatPosition'
 
-defineProps<{
+const props = defineProps<{
   float: CitationFloatState
   onEnter?: () => void
   onLeave?: () => void
@@ -29,6 +42,61 @@ defineProps<{
 
 const { t } = useI18n()
 const loadingText = t('common.loading')
+const floatRef = ref<HTMLElement | null>(null)
+const bodyRef = ref<HTMLElement | null>(null)
+const renderedContent = computed(() => renderCitationPreviewContent(props.float.content))
+const resolvedTop = ref(props.float.top)
+const resolvedLeft = ref(props.float.left)
+const floatStyle = computed<CSSProperties>(() => ({
+  top: `${resolvedTop.value}px`,
+  left: `${resolvedLeft.value}px`,
+}))
+
+const updateFloatPosition = async () => {
+  if (!props.float.visible) return
+  await nextTick()
+  const el = floatRef.value
+  if (!el || !props.float.anchor) {
+    resolvedTop.value = props.float.top
+    resolvedLeft.value = props.float.left
+    return
+  }
+
+  const rect = el.getBoundingClientRect()
+  const position = computeCitationFloatPosition({
+    anchor: props.float.anchor,
+    floatSize: {
+      width: rect.width || 320,
+      height: rect.height || 80,
+    },
+    viewport: currentCitationViewport(),
+    offsetY: props.float.offsetY,
+  })
+  resolvedTop.value = position.top
+  resolvedLeft.value = position.left
+}
+
+watch(renderedContent, async () => {
+  await nextTick()
+  await hydrateProtectedFileImages(bodyRef.value)
+  await updateFloatPosition()
+}, { flush: 'post' })
+
+watch(() => [
+  props.float.visible,
+  props.float.top,
+  props.float.left,
+  props.float.anchor?.top,
+  props.float.anchor?.bottom,
+  props.float.anchor?.left,
+  props.float.offsetY,
+  props.float.loading,
+  props.float.error,
+  props.float.title,
+  renderedContent.value,
+], () => {
+  void updateFloatPosition()
+}, { flush: 'post', immediate: true })
 </script>
 
 <style lang="less">

--- a/frontend/src/components/css/chat-citations.less
+++ b/frontend/src/components/css/chat-citations.less
@@ -115,7 +115,8 @@
 .chat-citation-float {
   position: absolute;
   z-index: 10000;
-  max-width: 320px;
+  width: max-content;
+  max-width: min(520px, calc(100vw - 32px));
   padding: 10px 12px;
   border-radius: 8px;
   background: var(--td-bg-color-container);
@@ -136,9 +137,58 @@
   }
 
   &__body {
-    max-height: 200px;
-    overflow-y: auto;
-    white-space: pre-wrap;
+    max-height: 280px;
+    overflow: auto;
+    white-space: normal;
+    overscroll-behavior: contain;
+  }
+
+  &__body p {
+    margin: 0 0 8px;
+  }
+
+  &__body p:last-child {
+    margin-bottom: 0;
+  }
+
+  &__body .chat-markdown-table {
+    max-width: 100%;
+    overflow-x: auto;
+    margin: 4px 0;
+  }
+
+  &__body .citation-preview-figure {
+    margin: 0 0 8px;
+  }
+
+  &__body .citation-preview-figure .markdown-image {
+    display: block;
+    margin: 0 auto;
+  }
+
+  &__body .citation-preview-figure__caption {
+    margin-top: 6px;
+    color: var(--td-text-color-secondary);
+    font-size: 11px;
+    line-height: 1.45;
+    text-align: center;
+    word-break: break-word;
+  }
+
+  &__body table {
+    width: max-content;
+    min-width: 100%;
+    border-collapse: collapse;
+    font-size: 11px;
+    line-height: 1.35;
+  }
+
+  &__body th,
+  &__body td {
+    padding: 4px 6px;
+    border: 1px solid var(--td-component-stroke);
+    vertical-align: top;
+    white-space: normal;
   }
 
   &__muted,

--- a/frontend/src/components/css/chat-markdown.less
+++ b/frontend/src/components/css/chat-markdown.less
@@ -510,7 +510,7 @@
   }
 
   :deep(.chat-markdown-table) {
-    width: fit-content;
+    width: 100%;
     max-width: 100%;
     margin: 0.875em 0 1em;
     overflow-x: auto;
@@ -521,14 +521,15 @@
   }
 
   :deep(table) {
-    word-break: initial;
+    word-break: normal;
     border-collapse: separate;
     border-spacing: 0;
     display: table;
     font-size: 14px;
     line-height: 1.55;
-    width: max-content;
-    min-width: 0;
+    width: 100%;
+    min-width: 100%;
+    table-layout: fixed;
   }
 
   :deep(table thead) {
@@ -548,7 +549,9 @@
     text-align: left;
     margin: 0;
     padding: 8px 12px;
-    white-space: nowrap;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   :deep(table tr td) {
@@ -559,6 +562,9 @@
     margin: 0;
     padding: 8px 12px;
     vertical-align: top;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   :deep(table tr th:last-child),

--- a/frontend/src/composables/useChatCitationPopover.ts
+++ b/frontend/src/composables/useChatCitationPopover.ts
@@ -2,11 +2,21 @@ import { onBeforeUnmount, onMounted, ref, watch, type Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { getChunkByIdOnly } from '@/api/knowledge-base'
 import { getEmbedChunkById } from '@/api/embed'
-import { resolveCitationChunkId, type CitationKnowledgeRef } from '@/utils/citationMarkdown'
+import {
+  resolveCitationChunkId,
+  resolveCitationReferenceContent,
+  type CitationKnowledgeRef,
+} from '@/utils/citationMarkdown'
 import {
   getCitationChunkCache,
   setCitationChunkCache,
 } from '@/utils/citationChunkCache'
+import {
+  computeCitationFloatPosition,
+  currentCitationViewport,
+  elementAnchorRect,
+  type CitationAnchorRect,
+} from '@/utils/citationFloatPosition'
 
 export { clearCitationChunkCache } from '@/utils/citationChunkCache'
 
@@ -20,6 +30,8 @@ type FloatState = {
   url: string
   loading: boolean
   error: string
+  anchor: CitationAnchorRect | null
+  offsetY: number
 }
 
 export type CitationFloatState = FloatState
@@ -54,15 +66,25 @@ export function useChatCitationPopover(
     url: '',
     loading: false,
     error: '',
+    anchor: null,
+    offsetY: 0,
   })
 
   let hoverTimer: number | null = null
   let closeTimer: number | null = null
 
   const positionFor = (el: HTMLElement, offsetY = 0) => {
-    const rect = el.getBoundingClientRect()
-    float.value.top = rect.bottom + window.scrollY + 6 + offsetY
-    float.value.left = Math.min(rect.left + window.scrollX, window.innerWidth - 320)
+    const anchor = elementAnchorRect(el)
+    const position = computeCitationFloatPosition({
+      anchor,
+      floatSize: { width: 320, height: 320 },
+      viewport: currentCitationViewport(),
+      offsetY,
+    })
+    float.value.anchor = anchor
+    float.value.offsetY = offsetY
+    float.value.top = position.top
+    float.value.left = position.left
   }
 
   const openWeb = (el: HTMLElement) => {
@@ -90,10 +112,11 @@ export function useChatCitationPopover(
     const rawChunkId = el.getAttribute('data-chunk-id') || ''
     const title = el.getAttribute('data-doc') || ''
     const kbId = el.getAttribute('data-kb-id') || ''
+    const refs = options?.getKnowledgeReferences?.()
     const chunkId = resolveCitationChunkId(
       rawChunkId,
       { doc: title, kbId },
-      options?.getKnowledgeReferences?.(),
+      refs,
     ) || rawChunkId
     if (!chunkId) return
     float.value.type = 'kb'
@@ -103,6 +126,15 @@ export function useChatCitationPopover(
     positionFor(el, 4)
 
     const scope = getCacheScope()
+    const referenceContent = resolveCitationReferenceContent(rawChunkId, { doc: title, kbId }, refs)
+    if (referenceContent) {
+      setCitationChunkCache(scope, chunkId, { content: referenceContent })
+      float.value.content = referenceContent
+      float.value.error = ''
+      float.value.loading = false
+      return
+    }
+
     const cached = getCitationChunkCache(scope, chunkId)
     if (cached) {
       float.value.content = cached.content

--- a/frontend/src/composables/useChatStreamHandler.ts
+++ b/frontend/src/composables/useChatStreamHandler.ts
@@ -249,6 +249,48 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
     return out
   }
 
+  const appendAgentAnswerEvent = (
+    message: ChatMessage,
+    content: string,
+    options: { eventId?: string; isFallback?: boolean; isError?: boolean } = {},
+  ) => {
+    const text = String(content || '')
+    if (!text.trim()) return
+
+    if (!message.agentEventStream) message.agentEventStream = []
+    if (!message._eventMap) message._eventMap = new Map()
+    const stream = message.agentEventStream as ChatMessage[]
+    const eventMap = message._eventMap as Map<string, ChatMessage>
+    const eventId = options.eventId || `answer-${Date.now()}`
+
+    let answerEvent = eventMap.get(eventId)
+    if (!answerEvent) {
+      answerEvent = {
+        type: 'answer',
+        event_id: eventId,
+        content: '',
+        done: false,
+      }
+      if (options.isFallback) answerEvent.is_fallback = true
+      if (options.isError) answerEvent.is_error = true
+      stream.push(answerEvent)
+      eventMap.set(eventId, answerEvent)
+    }
+
+    const current = String(answerEvent.content || '')
+    if (!current.includes(text)) {
+      answerEvent.content = current + text
+    }
+    answerEvent.done = true
+    if (options.isFallback) {
+      answerEvent.is_fallback = true
+      message.is_fallback = true
+    }
+    if (options.isError) answerEvent.is_error = true
+    message.content = recomposeAgentAnswer(message) || text
+    fullContent.value = String(message.content || '')
+  }
+
   const reconstructEventStreamFromSteps = (
     agentSteps: unknown[],
     messageContent: string,
@@ -742,23 +784,33 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
           }
           if (responseType === 'error' && !toolName) {
             const errorMsg = String(data.content || t('chat.processError'))
+            appendAgentAnswerEvent(message, errorMsg, {
+              eventId: `error-${String(data.id || Date.now())}`,
+              isError: true,
+            })
             message.content = errorMsg
             message.is_completed = true
             isReplying.value = false
             loading.value = false
             fullContent.value = ''
             currentAssistantMessageId.value = ''
+            onAgentAnswerDone?.(message)
             reportError(errorMsg)
             console.error('[Chat Error]', errorMsg)
           }
         } else if (responseType === 'error') {
           const errorMsg = String(data.content || t('chat.processError'))
+          appendAgentAnswerEvent(message, errorMsg, {
+            eventId: `error-${String(data.id || Date.now())}`,
+            isError: true,
+          })
           message.content = errorMsg
           message.is_completed = true
           isReplying.value = false
           loading.value = false
           fullContent.value = ''
           currentAssistantMessageId.value = ''
+          onAgentAnswerDone?.(message)
           reportError(errorMsg)
           console.error('[Chat Error]', errorMsg)
         }

--- a/frontend/src/composables/useEmbedCitationPopover.ts
+++ b/frontend/src/composables/useEmbedCitationPopover.ts
@@ -4,6 +4,17 @@ import {
   getCitationChunkCache,
   setCitationChunkCache,
 } from '@/utils/citationChunkCache'
+import {
+  resolveCitationChunkId,
+  resolveCitationReferenceContent,
+  type CitationKnowledgeRef,
+} from '@/utils/citationMarkdown'
+import {
+  computeCitationFloatPosition,
+  currentCitationViewport,
+  elementAnchorRect,
+  type CitationAnchorRect,
+} from '@/utils/citationFloatPosition'
 
 type FloatState = {
   visible: boolean
@@ -15,12 +26,19 @@ type FloatState = {
   url: string
   loading: boolean
   error: string
+  anchor: CitationAnchorRect | null
+  offsetY: number
+}
+
+type EmbedCitationPopoverOptions = {
+  getKnowledgeReferences?: () => CitationKnowledgeRef[] | null | undefined
 }
 
 export function useEmbedCitationPopover(
   rootRef: Ref<HTMLElement | null>,
   channelId: MaybeRef<string>,
   token: MaybeRef<string>,
+  options?: EmbedCitationPopoverOptions,
 ) {
   const float = ref<FloatState>({
     visible: false,
@@ -32,6 +50,8 @@ export function useEmbedCitationPopover(
     url: '',
     loading: false,
     error: '',
+    anchor: null,
+    offsetY: 0,
   })
 
   let hoverTimer: number | null = null
@@ -40,9 +60,17 @@ export function useEmbedCitationPopover(
   const getCacheScope = () => `embed:${unref(channelId)}:${unref(token)}`
 
   const positionFor = (el: HTMLElement, offsetY = 0) => {
-    const rect = el.getBoundingClientRect()
-    float.value.top = rect.bottom + window.scrollY + 6 + offsetY
-    float.value.left = Math.min(rect.left + window.scrollX, window.innerWidth - 320)
+    const anchor = elementAnchorRect(el)
+    const position = computeCitationFloatPosition({
+      anchor,
+      floatSize: { width: 320, height: 320 },
+      viewport: currentCitationViewport(),
+      offsetY,
+    })
+    float.value.anchor = anchor
+    float.value.offsetY = offsetY
+    float.value.top = position.top
+    float.value.left = position.left
   }
 
   const openWeb = (el: HTMLElement) => {
@@ -58,8 +86,11 @@ export function useEmbedCitationPopover(
   }
 
   const openKb = async (el: HTMLElement) => {
-    const chunkId = el.getAttribute('data-chunk-id') || ''
+    const rawChunkId = el.getAttribute('data-chunk-id') || ''
     const title = el.getAttribute('data-doc') || ''
+    const kbId = el.getAttribute('data-kb-id') || ''
+    const refs = options?.getKnowledgeReferences?.()
+    const chunkId = resolveCitationChunkId(rawChunkId, { doc: title, kbId }, refs) || rawChunkId
     if (!chunkId) return
     float.value.type = 'kb'
     float.value.title = title
@@ -68,6 +99,15 @@ export function useEmbedCitationPopover(
     positionFor(el, 4)
 
     const scope = getCacheScope()
+    const referenceContent = resolveCitationReferenceContent(rawChunkId, { doc: title, kbId }, refs)
+    if (referenceContent) {
+      setCitationChunkCache(scope, chunkId, { content: referenceContent })
+      float.value.content = referenceContent
+      float.value.error = ''
+      float.value.loading = false
+      return
+    }
+
     const cached = getCitationChunkCache(scope, chunkId)
     if (cached) {
       float.value.content = cached.content

--- a/frontend/src/utils/citationFloatPosition.test.mjs
+++ b/frontend/src/utils/citationFloatPosition.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import { dirname, resolve } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { createServer } from 'vite'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const root = resolve(here, '../..')
+
+async function loadPositionModule() {
+  const server = await createServer({
+    root,
+    configFile: false,
+    optimizeDeps: {
+      entries: [],
+      noDiscovery: true,
+    },
+    server: { middlewareMode: true, hmr: false },
+    resolve: {
+      alias: {
+        '@': resolve(root, 'src'),
+      },
+    },
+  })
+  try {
+    return await server.ssrLoadModule('/src/utils/citationFloatPosition.ts')
+  } finally {
+    await server.close()
+  }
+}
+
+test('places citation float above anchor when viewport space below is insufficient', async () => {
+  const { computeCitationFloatPosition } = await loadPositionModule()
+
+  const position = computeCitationFloatPosition({
+    anchor: { top: 720, bottom: 740, left: 420, width: 80 },
+    floatSize: { width: 480, height: 260 },
+    viewport: { width: 1440, height: 800, scrollX: 0, scrollY: 0 },
+    offsetY: 4,
+  })
+
+  assert.equal(position.placement, 'top')
+  assert.equal(position.top, 450)
+})
+
+test('keeps citation float below anchor when there is enough viewport space', async () => {
+  const { computeCitationFloatPosition } = await loadPositionModule()
+
+  const position = computeCitationFloatPosition({
+    anchor: { top: 120, bottom: 140, left: 420, width: 80 },
+    floatSize: { width: 480, height: 260 },
+    viewport: { width: 1440, height: 800, scrollX: 0, scrollY: 0 },
+    offsetY: 4,
+  })
+
+  assert.equal(position.placement, 'bottom')
+  assert.equal(position.top, 150)
+})

--- a/frontend/src/utils/citationFloatPosition.ts
+++ b/frontend/src/utils/citationFloatPosition.ts
@@ -1,0 +1,97 @@
+export type CitationAnchorRect = {
+  top: number
+  bottom: number
+  left: number
+  width: number
+}
+
+export type CitationFloatSize = {
+  width: number
+  height: number
+}
+
+export type CitationViewport = {
+  width: number
+  height: number
+  scrollX: number
+  scrollY: number
+}
+
+export type CitationFloatPlacement = 'bottom' | 'top' | 'clamped'
+
+export type CitationFloatPosition = {
+  top: number
+  left: number
+  placement: CitationFloatPlacement
+}
+
+const DEFAULT_GAP = 6
+const DEFAULT_PADDING = 16
+
+const clamp = (value: number, min: number, max: number) => {
+  if (max < min) return min
+  return Math.min(Math.max(value, min), max)
+}
+
+export function computeCitationFloatPosition({
+  anchor,
+  floatSize,
+  viewport,
+  offsetY = 0,
+  gap = DEFAULT_GAP,
+  padding = DEFAULT_PADDING,
+}: {
+  anchor: CitationAnchorRect
+  floatSize: CitationFloatSize
+  viewport: CitationViewport
+  offsetY?: number
+  gap?: number
+  padding?: number
+}): CitationFloatPosition {
+  const anchorTop = anchor.top + viewport.scrollY
+  const anchorBottom = anchor.bottom + viewport.scrollY
+  const visibleTop = viewport.scrollY + padding
+  const visibleBottom = viewport.scrollY + viewport.height - padding
+
+  const belowTop = anchorBottom + gap + offsetY
+  const aboveTop = anchorTop - floatSize.height - gap - offsetY
+  const belowFits = belowTop + floatSize.height <= visibleBottom
+  const aboveFits = aboveTop >= visibleTop
+
+  let top = belowTop
+  let placement: CitationFloatPlacement = 'bottom'
+  if (!belowFits && aboveFits) {
+    top = aboveTop
+    placement = 'top'
+  } else if (!belowFits) {
+    top = clamp(belowTop, visibleTop, visibleBottom - floatSize.height)
+    placement = 'clamped'
+  }
+
+  const left = clamp(
+    anchor.left + viewport.scrollX,
+    viewport.scrollX + padding,
+    viewport.scrollX + viewport.width - padding - floatSize.width,
+  )
+
+  return { top, left, placement }
+}
+
+export function currentCitationViewport(): CitationViewport {
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+    scrollX: window.scrollX,
+    scrollY: window.scrollY,
+  }
+}
+
+export function elementAnchorRect(el: HTMLElement): CitationAnchorRect {
+  const rect = el.getBoundingClientRect()
+  return {
+    top: rect.top,
+    bottom: rect.bottom,
+    left: rect.left,
+    width: rect.width,
+  }
+}

--- a/frontend/src/utils/citationMarkdown.ts
+++ b/frontend/src/utils/citationMarkdown.ts
@@ -33,12 +33,15 @@ export function stripIncompleteCitationTag(content: string): string {
 
 export type CitationKnowledgeRef = {
   id?: string
+  content?: string
+  matched_content?: string
   knowledge_id?: string
   knowledge_title?: string
   knowledge_filename?: string
   chunk_index?: number
   chunk_type?: string
   knowledge_base_id?: string
+  sub_chunk_id?: string[] | string
 }
 
 function parseTagAttributes(attrString: string): Record<string, string> {
@@ -78,6 +81,64 @@ function docTitlesMatch(a: string, b: string): boolean {
   const na = normalizeDocTitle(a)
   const nb = normalizeDocTitle(b)
   return na === nb || na.includes(nb) || nb.includes(na)
+}
+
+function referenceSubChunkIDs(ref: CitationKnowledgeRef): string[] {
+  const value = ref.sub_chunk_id
+  if (Array.isArray(value)) return value.map((id) => String(id || '').trim()).filter(Boolean)
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return []
+    try {
+      const parsed = JSON.parse(trimmed)
+      if (Array.isArray(parsed)) {
+        return parsed.map((id) => String(id || '').trim()).filter(Boolean)
+      }
+    } catch {
+      // keep raw string fallback below
+    }
+    return [trimmed]
+  }
+  return []
+}
+
+function referenceContent(ref: CitationKnowledgeRef | undefined): string {
+  if (!ref) return ''
+  return String(ref.content || ref.matched_content || '').trim()
+}
+
+function findCitationKnowledgeRef(
+  rawChunkId: string,
+  attrs: { doc?: string; kbId?: string },
+  refs?: CitationKnowledgeRef[] | null,
+): CitationKnowledgeRef | undefined {
+  const raw = String(rawChunkId || '').trim()
+  const list = (refs || []).filter((r) => r && r.chunk_type !== 'web_search')
+  if (!raw || !list.length) return undefined
+
+  const resolved = resolveCitationChunkId(raw, attrs, list)
+  const doc = (attrs.doc || '').trim()
+  const kbId = (attrs.kbId || '').trim()
+  const scoped = list.filter((r) => {
+    if (kbId && r.knowledge_base_id && r.knowledge_base_id !== kbId) return false
+    if (!doc) return true
+    return (
+      docTitlesMatch(doc, r.knowledge_title || '') ||
+      docTitlesMatch(doc, r.knowledge_filename || '')
+    )
+  })
+  const candidates = scoped.length ? scoped : list
+
+  return candidates.find((r) => r.id === resolved || r.id === raw)
+    || candidates.find((r) => referenceSubChunkIDs(r).includes(resolved) || referenceSubChunkIDs(r).includes(raw))
+}
+
+export function resolveCitationReferenceContent(
+  rawChunkId: string,
+  attrs: { doc?: string; kbId?: string },
+  refs?: CitationKnowledgeRef[] | null,
+): string {
+  return referenceContent(findCitationKnowledgeRef(rawChunkId, attrs, refs))
 }
 
 /** Map model context index (1, FAQ-1, DOC-2) to the real chunk UUID from retrieval results. */

--- a/frontend/src/utils/citationPreview.test.mjs
+++ b/frontend/src/utils/citationPreview.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict'
+import { dirname, resolve } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { createServer } from 'vite'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const root = resolve(here, '../..')
+
+async function loadCitationPreview() {
+  const server = await createServer({
+    root,
+    configFile: false,
+    optimizeDeps: {
+      entries: [],
+      noDiscovery: true,
+    },
+    server: { middlewareMode: true, hmr: false },
+    resolve: {
+      alias: {
+        '@': resolve(root, 'src'),
+      },
+    },
+  })
+  try {
+    return await server.ssrLoadModule('/src/utils/citationPreview.ts')
+  } finally {
+    await server.close()
+  }
+}
+
+test('renderCitationPreviewContent renders escaped html tables as table markup', async () => {
+  const { renderCitationPreviewContent } = await loadCitationPreview()
+  const html = renderCitationPreviewContent(
+    '&lt;table&gt;&lt;tr&gt;&lt;th&gt;指标&lt;/th&gt;&lt;td&gt;NPDR&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;',
+    { sanitizeHtml: (value) => value },
+  )
+
+  assert.match(html, /<table/)
+  assert.match(html, /<td>NPDR<\/td>/)
+  assert.doesNotMatch(html, /&lt;table/)
+})
+
+test('decodeEscapedHtmlBlocks leaves plain text comparisons escaped', async () => {
+  const { decodeEscapedHtmlBlocks } = await loadCitationPreview()
+  assert.equal(decodeEscapedHtmlBlocks('1 &lt; 2 and 3 &gt; 2'), '1 &lt; 2 and 3 &gt; 2')
+})
+
+test('renderCitationPreviewContent shows figure title from image alt under image', async () => {
+  const { renderCitationPreviewContent } = await loadCitationPreview()
+  const html = renderCitationPreviewContent(
+    '![图 3-6-3 PDR 纤维增殖](local://10000/exports/example.jpg)\n\n图点评：纤维增殖代表此处曾发生新生血管。',
+    { sanitizeHtml: (value) => value },
+  )
+
+  assert.match(html, /<figure class="citation-preview-figure">/)
+  assert.match(html, /<figcaption class="citation-preview-figure__caption">图 3-6-3 PDR 纤维增殖<\/figcaption>/)
+  assert.match(html, /图点评：纤维增殖代表此处曾发生新生血管。/)
+})
+
+test('renderCitationPreviewContent removes immediate duplicate figure title line', async () => {
+  const { renderCitationPreviewContent } = await loadCitationPreview()
+  const html = renderCitationPreviewContent(
+    [
+      '![图 3-5-1 DR 的 FFA 典型改变及静脉襻](local://10000/exports/example.jpg)',
+      '',
+      '图 3-5-1 DR 的 FFA 典型改变及静脉襻',
+      '',
+      'A. DR 的 FFA 典型改变。',
+    ].join('\n'),
+    { sanitizeHtml: (value) => value },
+  )
+
+  assert.equal((html.match(/图 3-5-1 DR 的 FFA 典型改变及静脉襻/g) || []).length, 2)
+  assert.match(html, /<figcaption class="citation-preview-figure__caption">图 3-5-1 DR 的 FFA 典型改变及静脉襻<\/figcaption>/)
+  assert.match(html, /A\. DR 的 FFA 典型改变。/)
+})

--- a/frontend/src/utils/citationPreview.ts
+++ b/frontend/src/utils/citationPreview.ts
@@ -1,0 +1,155 @@
+import {
+  createChatMarkdownRenderer,
+  renderChatMarkdown,
+} from './chatMarkdownRenderer'
+import {
+  createSafeImage,
+  escapeHTML,
+  isValidImageURL,
+  safeMarkdownToHTML,
+  sanitizeMarkdownHTML,
+} from './security'
+
+const ESCAPED_HTML_BLOCK_RE =
+  /&lt;\/?(?:table|thead|tbody|tr|th|td|div|p|br|ul|ol|li|span|strong|em|b|i|img|figure|figcaption|blockquote|h[1-6])(?:[\s/&]|&gt;)/i
+
+const HTML_ENTITY_RE = /&(?:lt|gt|amp|quot|nbsp|#39|#x27|#\d+|#x[0-9a-f]+);/gi
+const MARKDOWN_IMAGE_LINE_RE = /^(\s*)!\[([^\]]*)\]\(([^)\n]+)\)(?:\{[^}]*\})?\s*$/
+const GENERIC_IMAGE_ALT_RE = /^(?:image|img|图片|图像|截图|photo|picture)$/i
+const FIGURE_CAPTION_RE = /^(?:图|figure|fig\.?)\s*[\d一二三四五六七八九十百千]+(?:[-－–—.．]\s*[\d一二三四五六七八九十百千]+)*\s*\S+/i
+
+const citationPreviewRenderer = createChatMarkdownRenderer({
+  imageRenderer: ({ href, title, text }) => createCitationPreviewImage(href, text || '', title || ''),
+  isValidImageUrl: isValidImageURL,
+})
+
+function cleanCaptionText(value: string | null | undefined): string {
+  return String(value || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function normalizeCaptionForCompare(value: string): string {
+  return cleanCaptionText(value)
+    .replace(/[：:，,。.;；\s]+/g, '')
+    .toLowerCase()
+}
+
+function resolveFigureCaption(alt: string, title: string): string {
+  const candidates = [alt, title].map(cleanCaptionText)
+  return candidates.find((candidate) => (
+    candidate &&
+    !GENERIC_IMAGE_ALT_RE.test(candidate) &&
+    FIGURE_CAPTION_RE.test(candidate)
+  )) || ''
+}
+
+function createCitationPreviewImage(href: string, alt: string, title: string): string {
+  const image = createSafeImage(href, alt, title)
+  const caption = resolveFigureCaption(alt, title)
+  if (!image || !caption) return image
+
+  return [
+    '<figure class="citation-preview-figure">',
+    image,
+    `<figcaption class="citation-preview-figure__caption">${escapeHTML(caption)}</figcaption>`,
+    '</figure>',
+  ].join('')
+}
+
+export function normalizeCitationPreviewFigures(content: string): string {
+  if (!content || !content.includes('![')) return content
+
+  const lines = content.split(/\r?\n/)
+  const output: string[] = []
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]
+    output.push(line)
+
+    const match = line.match(MARKDOWN_IMAGE_LINE_RE)
+    if (!match) continue
+
+    const caption = resolveFigureCaption(match[2], '')
+    if (!caption) continue
+
+    let duplicateIndex = i + 1
+    while (duplicateIndex < lines.length && !lines[duplicateIndex].trim()) {
+      duplicateIndex += 1
+    }
+
+    if (
+      duplicateIndex < lines.length &&
+      normalizeCaptionForCompare(lines[duplicateIndex]) === normalizeCaptionForCompare(caption)
+    ) {
+      i = duplicateIndex
+    }
+  }
+
+  return output.join('\n')
+}
+
+function decodeEntity(entity: string): string {
+  const lower = entity.toLowerCase()
+  switch (lower) {
+    case '&lt;':
+      return '<'
+    case '&gt;':
+      return '>'
+    case '&amp;':
+      return '&'
+    case '&quot;':
+      return '"'
+    case '&#39;':
+    case '&#x27;':
+      return "'"
+    case '&nbsp;':
+      return ' '
+    default:
+      if (lower.startsWith('&#x')) {
+        const codePoint = Number.parseInt(lower.slice(3, -1), 16)
+        return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : entity
+      }
+      if (lower.startsWith('&#')) {
+        const codePoint = Number.parseInt(lower.slice(2, -1), 10)
+        return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : entity
+      }
+      return entity
+  }
+}
+
+export function decodeEscapedHtmlBlocks(content: string): string {
+  if (!ESCAPED_HTML_BLOCK_RE.test(content)) {
+    return content
+  }
+
+  let decoded = content
+  for (let i = 0; i < 3; i += 1) {
+    const next = decoded.replace(HTML_ENTITY_RE, decodeEntity)
+    if (next === decoded) break
+    decoded = next
+  }
+  return decoded
+}
+
+type CitationPreviewRenderOptions = {
+  sanitizeHtml?: (html: string) => string
+}
+
+export function renderCitationPreviewContent(
+  content: string,
+  options: CitationPreviewRenderOptions = {},
+): string {
+  const source = normalizeCitationPreviewFigures(
+    decodeEscapedHtmlBlocks(String(content || '').trim()),
+  )
+  if (!source) return ''
+
+  return renderChatMarkdown(source, {
+    renderer: citationPreviewRenderer,
+    escapeMarkdown: safeMarkdownToHTML,
+    sanitizeHtml: options.sanitizeHtml ?? sanitizeMarkdownHTML,
+    streaming: false,
+    collapseStandaloneCitations: false,
+  })
+}

--- a/frontend/src/utils/citationReferenceContent.test.mjs
+++ b/frontend/src/utils/citationReferenceContent.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import { dirname, resolve } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { createServer } from 'vite'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const root = resolve(here, '../..')
+
+async function loadCitationMarkdown() {
+  const server = await createServer({
+    root,
+    configFile: false,
+    optimizeDeps: {
+      entries: [],
+      noDiscovery: true,
+    },
+    server: { middlewareMode: true, hmr: false },
+    resolve: {
+      alias: {
+        '@': resolve(root, 'src'),
+      },
+    },
+  })
+  try {
+    return await server.ssrLoadModule('/src/utils/citationMarkdown.ts')
+  } finally {
+    await server.close()
+  }
+}
+
+test('resolveCitationReferenceContent returns merged reference content for cited parent chunk', async () => {
+  const { resolveCitationReferenceContent } = await loadCitationMarkdown()
+
+  const content = resolveCitationReferenceContent(
+    'parent-chunk',
+    { doc: '眼底病临床诊治精要.mhtml', kbId: 'kb-1' },
+    [
+      {
+        id: 'parent-chunk',
+        knowledge_base_id: 'kb-1',
+        knowledge_filename: '眼底病临床诊治精要.mhtml',
+        content: '父 chunk + 邻居 chunk 合并后的真实上下文',
+      },
+    ],
+  )
+
+  assert.equal(content, '父 chunk + 邻居 chunk 合并后的真实上下文')
+})
+
+test('resolveCitationReferenceContent can match a cited neighbor sub_chunk_id', async () => {
+  const { resolveCitationReferenceContent } = await loadCitationMarkdown()
+
+  const content = resolveCitationReferenceContent(
+    'neighbor-chunk',
+    { doc: 'guide.pdf', kbId: 'kb-1' },
+    [
+      {
+        id: 'parent-chunk',
+        knowledge_base_id: 'kb-1',
+        knowledge_filename: 'guide.pdf',
+        sub_chunk_id: ['neighbor-chunk'],
+        content: '包含 neighbor chunk 的合并上下文',
+      },
+    ],
+  )
+
+  assert.equal(content, '包含 neighbor chunk 的合并上下文')
+})

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -3354,7 +3354,7 @@ const handleAddToKnowledge = (answerEvent: any) => {
     }
 
     .chat-markdown-table {
-      width: fit-content;
+      width: 100%;
       max-width: 100%;
       overflow-x: auto;
       margin: 0 0 16px;
@@ -3366,12 +3366,13 @@ const handleAddToKnowledge = (answerEvent: any) => {
 
     table {
       display: table;
-      width: max-content;
-      min-width: 0;
+      width: 100%;
+      min-width: 100%;
       border-collapse: separate;
       border-spacing: 0;
       font-size: 13px;
       line-height: 1.55;
+      table-layout: fixed;
     }
 
     table thead {
@@ -3385,13 +3386,14 @@ const handleAddToKnowledge = (answerEvent: any) => {
       border-right: 1px solid var(--td-component-stroke);
       text-align: left;
       vertical-align: top;
+      white-space: normal;
+      overflow-wrap: anywhere;
       word-break: break-word;
     }
 
     table th {
       font-weight: 600;
       color: var(--td-text-color-primary);
-      white-space: nowrap;
     }
 
     table th:last-child,

--- a/frontend/src/views/embed/EmbedBotMessage.vue
+++ b/frontend/src/views/embed/EmbedBotMessage.vue
@@ -26,8 +26,8 @@
       </div>
     </div>
     <Teleport to="body">
-      <div v-if="citationFloat.visible" class="embed-citation-float"
-        :style="{ top: `${citationFloat.top}px`, left: `${citationFloat.left}px` }" @mouseenter="cancelCitationClose"
+      <div v-if="citationFloat.visible" ref="citationFloatRef" class="embed-citation-float"
+        :style="citationFloatStyle" @mouseenter="cancelCitationClose"
         @mouseleave="scheduleCitationClose">
         <template v-if="citationFloat.type === 'web'">
           <div class="embed-citation-float__title">{{ citationFloat.title || citationFloat.url }}</div>
@@ -38,7 +38,12 @@
           <div class="embed-citation-float__title">{{ citationFloat.title }}</div>
           <div v-if="citationFloat.loading" class="embed-citation-float__muted">…</div>
           <div v-else-if="citationFloat.error" class="embed-citation-float__error">{{ citationFloat.error }}</div>
-          <div v-else class="embed-citation-float__body">{{ citationFloat.content }}</div>
+          <div
+            v-else
+            ref="citationFloatBody"
+            class="embed-citation-float__body markdown-content"
+            v-stable-html="citationPreviewHTML"
+          />
         </template>
       </div>
     </Teleport>
@@ -67,6 +72,11 @@ import {
 import { useEmbedCitationPopover } from '@/composables/useEmbedCitationPopover'
 import { useTypewriter } from '@/composables/useTypewriter'
 import { vStableHtml } from '@/directives/stableHtml'
+import { renderCitationPreviewContent } from '@/utils/citationPreview'
+import {
+  computeCitationFloatPosition,
+  currentCitationViewport,
+} from '@/utils/citationFloatPosition'
 
 const RagPipelineProgress = defineAsyncComponent(
   () => import('@/views/chat/components/RagPipelineProgress.vue'),
@@ -126,6 +136,8 @@ const props = withDefaults(
 )
 
 const parentMd = ref<HTMLElement | null>(null)
+const citationFloatRef = ref<HTMLElement | null>(null)
+const citationFloatBody = ref<HTMLElement | null>(null)
 
 const embedChannelIdRef = computed(() => props.embedChannelId)
 const embedTokenRef = computed(() => props.embedToken)
@@ -134,6 +146,9 @@ const { float: citationFloat, rebind: rebindCitations } = useEmbedCitationPopove
   parentMd,
   embedChannelIdRef,
   embedTokenRef,
+  {
+    getKnowledgeReferences: () => props.session?.knowledge_references,
+  },
 )
 
 let citationCloseTimer: number | null = null
@@ -173,6 +188,65 @@ const hasActualContent = computed(() => {
   const text = String(props.content || props.session?.content || '')
   return text.trim().length > 0
 })
+
+const citationPreviewHTML = computed(() => renderCitationPreviewContent(citationFloat.value.content))
+const citationFloatTop = ref(citationFloat.value.top)
+const citationFloatLeft = ref(citationFloat.value.left)
+const citationFloatStyle = computed(() => ({
+  top: `${citationFloatTop.value}px`,
+  left: `${citationFloatLeft.value}px`,
+}))
+
+const updateCitationFloatPosition = async () => {
+  if (!citationFloat.value.visible) return
+  await nextTick()
+  const el = citationFloatRef.value
+  const anchor = citationFloat.value.anchor
+  if (!el || !anchor) {
+    citationFloatTop.value = citationFloat.value.top
+    citationFloatLeft.value = citationFloat.value.left
+    return
+  }
+
+  const rect = el.getBoundingClientRect()
+  const position = computeCitationFloatPosition({
+    anchor,
+    floatSize: {
+      width: rect.width || 320,
+      height: rect.height || 80,
+    },
+    viewport: currentCitationViewport(),
+    offsetY: citationFloat.value.offsetY,
+  })
+  citationFloatTop.value = position.top
+  citationFloatLeft.value = position.left
+}
+
+watch(citationPreviewHTML, async () => {
+  await nextTick()
+  const embedCtx =
+    props.embedChannelId && props.embedToken
+      ? { channelId: props.embedChannelId, token: props.embedToken }
+      : undefined
+  await hydrateProtectedFileImages(citationFloatBody.value, embedCtx)
+  await updateCitationFloatPosition()
+}, { flush: 'post' })
+
+watch(() => [
+  citationFloat.value.visible,
+  citationFloat.value.top,
+  citationFloat.value.left,
+  citationFloat.value.anchor?.top,
+  citationFloat.value.anchor?.bottom,
+  citationFloat.value.anchor?.left,
+  citationFloat.value.offsetY,
+  citationFloat.value.loading,
+  citationFloat.value.error,
+  citationFloat.value.title,
+  citationPreviewHTML.value,
+], () => {
+  void updateCitationFloatPosition()
+}, { flush: 'post', immediate: true })
 
 const hydrateImages = async () => {
   const embedCtx =
@@ -297,7 +371,8 @@ onMounted(() => {
 .embed-citation-float {
   position: absolute;
   z-index: 10000;
-  max-width: 320px;
+  width: max-content;
+  max-width: min(520px, calc(100vw - 32px));
   padding: 10px 12px;
   border-radius: 8px;
   background: var(--td-bg-color-container);
@@ -318,9 +393,40 @@ onMounted(() => {
   }
 
   &__body {
-    max-height: 200px;
-    overflow-y: auto;
-    white-space: pre-wrap;
+    max-height: 280px;
+    overflow: auto;
+    white-space: normal;
+    overscroll-behavior: contain;
+  }
+
+  &__body p {
+    margin: 0 0 8px;
+  }
+
+  &__body p:last-child {
+    margin-bottom: 0;
+  }
+
+  &__body .chat-markdown-table {
+    max-width: 100%;
+    overflow-x: auto;
+    margin: 4px 0;
+  }
+
+  &__body table {
+    width: max-content;
+    min-width: 100%;
+    border-collapse: collapse;
+    font-size: 11px;
+    line-height: 1.35;
+  }
+
+  &__body th,
+  &__body td {
+    padding: 4px 6px;
+    border: 1px solid var(--td-component-stroke);
+    vertical-align: top;
+    white-space: normal;
   }
 
   &__muted {

--- a/internal/application/service/chat_pipeline/chat_completion.go
+++ b/internal/application/service/chat_pipeline/chat_completion.go
@@ -71,6 +71,7 @@ func (p *PluginChatCompletion) OnEvent(
 		"completion_tokens": chatResponse.Usage.CompletionTokens,
 		"prompt_tokens":     chatResponse.Usage.PromptTokens,
 	})
+	warnIfAnswerMissingKBCitations(ctx, "Completion", chatManage, chatResponse.Content)
 	chatManage.ChatResponse = chatResponse
 	return next()
 }

--- a/internal/application/service/chat_pipeline/chat_completion_stream.go
+++ b/internal/application/service/chat_pipeline/chat_completion_stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Tencent/WeKnora/internal/event"
 	"github.com/Tencent/WeKnora/internal/types"
@@ -108,6 +109,9 @@ func (p *PluginChatCompletionStream) OnEvent(ctx context.Context,
 		thinkingID := fmt.Sprintf("%s-thinking", uuid.New().String()[:8])
 		answerID := fmt.Sprintf("%s-answer", uuid.New().String()[:8])
 		thinkingOpen := false
+		var answerBuilder strings.Builder
+		answerDone := false
+		terminalErrorEmitted := false
 
 		closeThinking := func() {
 			if !thinkingOpen {
@@ -122,6 +126,30 @@ func (p *PluginChatCompletionStream) OnEvent(ctx context.Context,
 				},
 			})
 			thinkingOpen = false
+		}
+
+		emitTerminalError := func(errorCode, detail string) {
+			if terminalErrorEmitted {
+				return
+			}
+			terminalErrorEmitted = true
+			closeThinking()
+			userMessage := streamErrorUserMessage(chatManage.Language, answerBuilder.Len() > 0)
+			eventBus.Emit(ctx, types.Event{
+				ID:        fmt.Sprintf("%s-error", uuid.New().String()[:8]),
+				Type:      types.EventType(event.EventError),
+				SessionID: chatManage.SessionID,
+				Data: event.ErrorData{
+					Error:     userMessage,
+					ErrorCode: errorCode,
+					Stage:     "chat_completion_stream",
+					SessionID: chatManage.SessionID,
+					Extra: map[string]interface{}{
+						"detail":   detail,
+						"terminal": true,
+					},
+				},
+			})
 		}
 
 		for {
@@ -139,6 +167,13 @@ func (p *PluginChatCompletionStream) OnEvent(ctx context.Context,
 					pipelineInfo(ctx, "Stream", "channel_close", map[string]interface{}{
 						"session_id": chatManage.SessionID,
 					})
+					if !answerDone && !terminalErrorEmitted && ctx.Err() == nil {
+						pipelineWarn(ctx, "Stream", "channel_closed_without_done", map[string]interface{}{
+							"session_id": chatManage.SessionID,
+							"answer_len": answerBuilder.Len(),
+						})
+						emitTerminalError("chat_stream_closed", "model stream closed before sending a done event")
+					}
 					return
 				}
 
@@ -147,17 +182,8 @@ func (p *PluginChatCompletionStream) OnEvent(ctx context.Context,
 						"session_id": chatManage.SessionID,
 						"error":      response.Content,
 					})
-					eventBus.Emit(ctx, types.Event{
-						ID:        fmt.Sprintf("%s-error", uuid.New().String()[:8]),
-						Type:      types.EventType(event.EventError),
-						SessionID: chatManage.SessionID,
-						Data: event.ErrorData{
-							Error:     response.Content,
-							Stage:     "chat_completion_stream",
-							SessionID: chatManage.SessionID,
-						},
-					})
-					continue
+					emitTerminalError("chat_stream_error", response.Content)
+					return
 				}
 
 				if response.ResponseType == types.ResponseTypeThinking {
@@ -181,6 +207,21 @@ func (p *PluginChatCompletionStream) OnEvent(ctx context.Context,
 
 				if response.ResponseType == types.ResponseTypeAnswer {
 					closeThinking()
+					if response.Content != "" {
+						answerBuilder.WriteString(response.Content)
+					}
+					if response.Done && strings.TrimSpace(answerBuilder.String()) == "" {
+						pipelineWarn(ctx, "Stream", "empty_answer_done", map[string]interface{}{
+							"session_id":    chatManage.SessionID,
+							"finish_reason": response.FinishReason,
+						})
+						emitTerminalError("chat_stream_empty_answer", "model stream finished without answer content")
+						return
+					}
+					if response.Done {
+						answerDone = true
+						warnIfAnswerMissingKBCitations(ctx, "Stream", chatManage, answerBuilder.String())
+					}
 					eventBus.Emit(ctx, types.Event{
 						ID:        answerID,
 						Type:      types.EventType(event.EventAgentFinalAnswer),
@@ -196,4 +237,17 @@ func (p *PluginChatCompletionStream) OnEvent(ctx context.Context,
 	}()
 
 	return next()
+}
+
+func streamErrorUserMessage(language string, hasPartialAnswer bool) string {
+	if strings.Contains(strings.ToLower(language), "chinese") || strings.HasPrefix(strings.ToLower(language), "zh") {
+		if hasPartialAnswer {
+			return "回答生成中断：模型服务暂时不可用或连接中断，请稍后重试。"
+		}
+		return "回答生成失败：模型服务暂时不可用或连接中断，请稍后重试。"
+	}
+	if hasPartialAnswer {
+		return "Answer generation was interrupted because the model service was unavailable or the connection was closed. Please try again later."
+	}
+	return "Answer generation failed because the model service was unavailable or the connection was closed. Please try again later."
 }

--- a/internal/application/service/chat_pipeline/chat_completion_stream_test.go
+++ b/internal/application/service/chat_pipeline/chat_completion_stream_test.go
@@ -1,0 +1,177 @@
+package chatpipeline
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/event"
+	"github.com/Tencent/WeKnora/internal/models/asr"
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/models/rerank"
+	"github.com/Tencent/WeKnora/internal/models/vlm"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+type streamTestChatModel struct {
+	responses []types.StreamResponse
+}
+
+func (m *streamTestChatModel) Chat(
+	context.Context,
+	[]chat.Message,
+	*chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	return nil, nil
+}
+
+func (m *streamTestChatModel) ChatStream(
+	context.Context,
+	[]chat.Message,
+	*chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	ch := make(chan types.StreamResponse, len(m.responses))
+	for _, response := range m.responses {
+		ch <- response
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (m *streamTestChatModel) GetModelName() string { return "stream-test" }
+func (m *streamTestChatModel) GetModelID() string   { return "stream-test" }
+
+type streamTestModelService struct {
+	chatModel chat.Chat
+}
+
+func (s *streamTestModelService) CreateModel(context.Context, *types.Model) error { return nil }
+func (s *streamTestModelService) GetModelByID(context.Context, string) (*types.Model, error) {
+	return nil, nil
+}
+func (s *streamTestModelService) ListModels(context.Context) ([]*types.Model, error) { return nil, nil }
+func (s *streamTestModelService) UpdateModel(context.Context, *types.Model) error    { return nil }
+func (s *streamTestModelService) DeleteModel(context.Context, string) error          { return nil }
+func (s *streamTestModelService) UpdateModelCredentials(
+	context.Context,
+	string,
+	*string,
+	*string,
+) (*types.Model, error) {
+	return nil, nil
+}
+func (s *streamTestModelService) ClearModelCredential(context.Context, string, string) error {
+	return nil
+}
+func (s *streamTestModelService) GetEmbeddingModel(context.Context, string) (embedding.Embedder, error) {
+	return nil, nil
+}
+func (s *streamTestModelService) GetEmbeddingModelForTenant(
+	context.Context,
+	string,
+	uint64,
+) (embedding.Embedder, error) {
+	return nil, nil
+}
+func (s *streamTestModelService) GetRerankModel(context.Context, string) (rerank.Reranker, error) {
+	return nil, nil
+}
+func (s *streamTestModelService) GetChatModel(context.Context, string) (chat.Chat, error) {
+	return s.chatModel, nil
+}
+func (s *streamTestModelService) GetVLMModel(context.Context, string) (vlm.VLM, error) {
+	return nil, nil
+}
+func (s *streamTestModelService) GetASRModel(context.Context, string) (asr.ASR, error) {
+	return nil, nil
+}
+
+func TestChatCompletionStreamEmptyDoneEmitsTerminalError(t *testing.T) {
+	errData := runStreamPluginAndWaitForError(t, []types.StreamResponse{
+		{
+			ResponseType: types.ResponseTypeAnswer,
+			Done:         true,
+			FinishReason: "stop",
+		},
+	})
+
+	if errData.ErrorCode != "chat_stream_empty_answer" {
+		t.Fatalf("ErrorCode = %q, want chat_stream_empty_answer", errData.ErrorCode)
+	}
+	if !strings.Contains(errData.Error, "回答生成失败") {
+		t.Fatalf("Error = %q, want Chinese failure message", errData.Error)
+	}
+}
+
+func TestChatCompletionStreamClosedWithoutDoneEmitsTerminalError(t *testing.T) {
+	errData := runStreamPluginAndWaitForError(t, []types.StreamResponse{
+		{
+			ResponseType: types.ResponseTypeAnswer,
+			Content:      "部分答案",
+			Done:         false,
+		},
+	})
+
+	if errData.ErrorCode != "chat_stream_closed" {
+		t.Fatalf("ErrorCode = %q, want chat_stream_closed", errData.ErrorCode)
+	}
+	if !strings.Contains(errData.Error, "回答生成中断") {
+		t.Fatalf("Error = %q, want Chinese interruption message", errData.Error)
+	}
+}
+
+func runStreamPluginAndWaitForError(
+	t *testing.T,
+	responses []types.StreamResponse,
+) event.ErrorData {
+	t.Helper()
+
+	bus := event.NewEventBus()
+	errCh := make(chan event.ErrorData, 1)
+	bus.On(event.EventError, func(_ context.Context, evt event.Event) error {
+		data, ok := evt.Data.(event.ErrorData)
+		if !ok {
+			t.Fatalf("unexpected error event data type %T", evt.Data)
+		}
+		errCh <- data
+		return nil
+	})
+
+	plugin := &PluginChatCompletionStream{
+		modelService: &streamTestModelService{
+			chatModel: &streamTestChatModel{responses: responses},
+		},
+	}
+	cm := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{
+			SessionID:   "session-1",
+			ChatModelID: "model-1",
+			Language:    "zh-CN",
+			SummaryConfig: types.SummaryConfig{
+				Prompt: "You are helpful.",
+			},
+		},
+		PipelineState: types.PipelineState{
+			UserContent: "你好",
+		},
+		PipelineContext: types.PipelineContext{
+			EventBus: bus.AsEventBusInterface(),
+		},
+	}
+
+	if err := plugin.OnEvent(context.Background(), types.CHAT_COMPLETION_STREAM, cm, func() *PluginError {
+		return nil
+	}); err != nil {
+		t.Fatalf("OnEvent returned error: %v", err)
+	}
+
+	select {
+	case data := <-errCh:
+		return data
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for terminal error event")
+		return event.ErrorData{}
+	}
+}

--- a/internal/application/service/chat_pipeline/common.go
+++ b/internal/application/service/chat_pipeline/common.go
@@ -62,6 +62,25 @@ func prepareChatModel(ctx context.Context, modelService interfaces.ModelService,
 	return chatModel, opt, nil
 }
 
+func answerContainsKBCitationTag(answer string) bool {
+	answer = strings.ToLower(answer)
+	return strings.Contains(answer, "<kb ") || strings.Contains(answer, "<kb/>") || strings.Contains(answer, "<kb>")
+}
+
+func warnIfAnswerMissingKBCitations(ctx context.Context, stage string, chatManage *types.ChatManage, answer string) {
+	if chatManage == nil || len(chatManage.MergeResult) == 0 || strings.TrimSpace(answer) == "" {
+		return
+	}
+	if answerContainsKBCitationTag(answer) {
+		return
+	}
+	pipelineWarn(ctx, stage, "missing_inline_citations", map[string]interface{}{
+		"session_id":       chatManage.SessionID,
+		"merge_result_cnt": len(chatManage.MergeResult),
+		"answer_len":       len(answer),
+	})
+}
+
 // prepareMessagesWithHistory prepare complete messages including history.
 // When SystemPromptOverride is set (e.g. by intent-specific prompt logic),
 // it takes precedence over the default SummaryConfig.Prompt.

--- a/internal/application/service/chat_pipeline/into_chat_message.go
+++ b/internal/application/service/chat_pipeline/into_chat_message.go
@@ -3,6 +3,7 @@ package chatpipeline
 import (
 	"context"
 	"fmt"
+	"html"
 	"strings"
 
 	"github.com/Tencent/WeKnora/internal/searchutil"
@@ -136,9 +137,11 @@ func (p *PluginIntoChatMessage) OnEvent(ctx context.Context,
 		for i, result := range faqResults {
 			passage := getEnrichedPassageForChat(ctx, result)
 			if hasHighConfidenceFAQ && i == 0 {
-				contextsBuilder.WriteString(fmt.Sprintf("<context id=\"FAQ-%d\" match=\"exact\">%s</context>\n", i+1, passage))
+				writeContextTag(&contextsBuilder, fmt.Sprintf("FAQ-%d", i+1), result, passage, contextAttr{name: "match", value: "exact"})
+				contextsBuilder.WriteString("\n")
 			} else {
-				contextsBuilder.WriteString(fmt.Sprintf("<context id=\"FAQ-%d\">%s</context>\n", i+1, passage))
+				writeContextTag(&contextsBuilder, fmt.Sprintf("FAQ-%d", i+1), result, passage)
+				contextsBuilder.WriteString("\n")
 			}
 		}
 		contextsBuilder.WriteString("</source>\n")
@@ -147,7 +150,8 @@ func (p *PluginIntoChatMessage) OnEvent(ctx context.Context,
 			contextsBuilder.WriteString("<source type=\"document\" priority=\"supplementary\">\n")
 			for i, result := range docResults {
 				passage := getEnrichedPassageForChat(ctx, result)
-				contextsBuilder.WriteString(fmt.Sprintf("<context id=\"DOC-%d\">%s</context>\n", i+1, passage))
+				writeContextTag(&contextsBuilder, fmt.Sprintf("DOC-%d", i+1), result, passage)
+				contextsBuilder.WriteString("\n")
 			}
 			contextsBuilder.WriteString("</source>")
 		}
@@ -157,7 +161,7 @@ func (p *PluginIntoChatMessage) OnEvent(ctx context.Context,
 			if i > 0 {
 				contextsBuilder.WriteString("\n")
 			}
-			contextsBuilder.WriteString(fmt.Sprintf("<context id=\"%d\">%s</context>", i+1, passage))
+			writeContextTag(&contextsBuilder, fmt.Sprintf("%d", i+1), result, passage)
 		}
 	}
 
@@ -196,6 +200,71 @@ func (p *PluginIntoChatMessage) OnEvent(ctx context.Context,
 
 	p.persistRenderedContent(ctx, chatManage)
 	return next()
+}
+
+type contextAttr struct {
+	name  string
+	value string
+}
+
+func writeContextTag(builder *strings.Builder, id string, result *types.SearchResult, passage string, extraAttrs ...contextAttr) {
+	builder.WriteString("<context")
+	writeContextAttr(builder, "id", id)
+	writeContextAttr(builder, "chunk_id", citationChunkID(id, result))
+	writeContextAttr(builder, "kb_id", citationKBID(result))
+	writeContextAttr(builder, "doc", citationDocName(id, result))
+	for _, attr := range extraAttrs {
+		writeContextAttr(builder, attr.name, attr.value)
+	}
+	builder.WriteString(">")
+	builder.WriteString(passage)
+	builder.WriteString("</context>")
+}
+
+func writeContextAttr(builder *strings.Builder, name, value string) {
+	value = strings.TrimSpace(value)
+	if name == "" || value == "" {
+		return
+	}
+	builder.WriteString(" ")
+	builder.WriteString(name)
+	builder.WriteString("=\"")
+	builder.WriteString(html.EscapeString(value))
+	builder.WriteString("\"")
+}
+
+func citationChunkID(fallback string, result *types.SearchResult) string {
+	if result == nil {
+		return fallback
+	}
+	if id := strings.TrimSpace(result.ID); id != "" {
+		return id
+	}
+	return fallback
+}
+
+func citationKBID(result *types.SearchResult) string {
+	if result == nil {
+		return ""
+	}
+	return strings.TrimSpace(result.KnowledgeBaseID)
+}
+
+func citationDocName(fallback string, result *types.SearchResult) string {
+	if result == nil {
+		return fallback
+	}
+	for _, candidate := range []string{
+		result.KnowledgeTitle,
+		result.KnowledgeFilename,
+		result.KnowledgeID,
+		fallback,
+	} {
+		if value := strings.TrimSpace(candidate); value != "" {
+			return value
+		}
+	}
+	return fallback
 }
 
 // persistRenderedContent asynchronously writes the RAG-augmented UserContent back

--- a/internal/application/service/chat_pipeline/merge.go
+++ b/internal/application/service/chat_pipeline/merge.go
@@ -38,7 +38,7 @@ func (p *PluginMerge) ActivationEvents() []types.EventType {
 //  4. Resolve parent chunks (child → parent content)
 //  5. Group by knowledge source + chunk type, merge overlapping ranges
 //  6. Populate FAQ answers
-//  7. Expand short contexts with neighboring chunks
+//  7. Expand short contexts and dangling figure contexts with neighboring chunks
 //     7.5. Re-merge overlapping ranges introduced by expansion
 //  8. Final deduplication (ID + signature + partial content overlap)
 func (p *PluginMerge) OnEvent(ctx context.Context,
@@ -82,7 +82,7 @@ func (p *PluginMerge) OnEvent(ctx context.Context,
 	// Step 6: Populate FAQ answers
 	mergedChunks = p.populateFAQAnswers(ctx, chatManage, mergedChunks)
 
-	// Step 7: Expand short contexts
+	// Step 7: Expand short contexts and dangling figure contexts
 	mergedChunks = p.expandShortContextWithNeighbors(ctx, chatManage, mergedChunks)
 
 	// Step 7.5: Re-merge overlapping ranges introduced by expansion

--- a/internal/application/service/chat_pipeline/merge_expand.go
+++ b/internal/application/service/chat_pipeline/merge_expand.go
@@ -2,19 +2,28 @@ package chatpipeline
 
 import (
 	"context"
+	"regexp"
+	"strings"
 
 	"github.com/Tencent/WeKnora/internal/types"
 )
 
-// expandShortContextWithNeighbors expands the short context with neighbors
+var (
+	markdownImagePattern      = regexp.MustCompile(`!\[([^\]]*)\]\([^)]*\)`)
+	figureContextAfterImageRE = regexp.MustCompile(`图\s*[0-9]+[-－—][0-9]+(?:[-－—][0-9]+)?|图点评|患者|说明[:：]|名称[:：]|编号[:：]`)
+)
+
+// expandShortContextWithNeighbors expands short contexts and dangling empty-alt
+// figure contexts with neighboring chunks.
 func (p *PluginMerge) expandShortContextWithNeighbors(
 	ctx context.Context,
 	chatManage *types.ChatManage,
 	results []*types.SearchResult,
 ) []*types.SearchResult {
 	const (
-		minLen = 350
-		maxLen = 850
+		minLen                  = 350
+		maxLen                  = 850
+		danglingImageNextMaxLen = 1000
 	)
 
 	if len(results) == 0 || p.chunkRepo == nil {
@@ -33,7 +42,8 @@ func (p *PluginMerge) expandShortContextWithNeighbors(
 	}
 
 	type targetInfo struct {
-		result *types.SearchResult
+		result             *types.SearchResult
+		danglingEmptyImage bool
 	}
 
 	targets := make([]targetInfo, 0)
@@ -46,16 +56,21 @@ func (p *PluginMerge) expandShortContextWithNeighbors(
 		if r.ChunkType != string(types.ChunkTypeText) {
 			continue
 		}
-		if runeLen(r.Content) >= minLen {
+		danglingEmptyImage := hasDanglingEmptyAltImage(r.Content)
+		if runeLen(r.Content) >= minLen && !danglingEmptyImage {
 			continue
 		}
-		targets = append(targets, targetInfo{result: r})
+		targets = append(targets, targetInfo{
+			result:             r,
+			danglingEmptyImage: danglingEmptyImage,
+		})
 		baseIDsSet[r.ID] = struct{}{}
 		pipelineInfo(ctx, "Merge", "need_expand", map[string]interface{}{
-			"chunk_id":   r.ID,
-			"content":    r.Content,
-			"chunk_type": r.ChunkType,
-			"len":        runeLen(r.Content),
+			"chunk_id":             r.ID,
+			"content":              r.Content,
+			"chunk_type":           r.ChunkType,
+			"len":                  runeLen(r.Content),
+			"dangling_empty_image": danglingEmptyImage,
 		})
 	}
 
@@ -125,6 +140,18 @@ func (p *PluginMerge) expandShortContextWithNeighbors(
 		p.fetchChunksIfMissing(ctx, tenantID, chunkMap, res.ID)
 		baseChunk := chunkMap[res.ID]
 		if baseChunk == nil || baseChunk.Content == "" || baseChunk.ChunkType != types.ChunkTypeText {
+			continue
+		}
+
+		if target.danglingEmptyImage && runeLen(baseChunk.Content) >= minLen {
+			p.expandDanglingEmptyAltImageWithNext(
+				ctx,
+				tenantID,
+				res,
+				baseChunk,
+				chunkMap,
+				danglingImageNextMaxLen,
+			)
 			continue
 		}
 
@@ -249,6 +276,85 @@ func (p *PluginMerge) expandShortContextWithNeighbors(
 	}
 
 	return results
+}
+
+func (p *PluginMerge) expandDanglingEmptyAltImageWithNext(
+	ctx context.Context,
+	tenantID uint64,
+	res *types.SearchResult,
+	baseChunk *types.Chunk,
+	chunkMap map[string]*types.Chunk,
+	nextMaxLen int,
+) {
+	if res == nil || baseChunk == nil || baseChunk.NextChunkID == "" {
+		return
+	}
+
+	p.fetchChunksIfMissing(ctx, tenantID, chunkMap, baseChunk.NextChunkID)
+	nextChunk := chunkMap[baseChunk.NextChunkID]
+	if nextChunk == nil ||
+		nextChunk.KnowledgeID != baseChunk.KnowledgeID ||
+		nextChunk.Content == "" ||
+		nextChunk.ChunkType != types.ChunkTypeText {
+		return
+	}
+
+	nextContent := trimRunes(nextChunk.Content, nextMaxLen)
+	if nextContent == "" {
+		return
+	}
+
+	beforeLen := runeLen(res.Content)
+	res.Content = concatNoOverlap(baseChunk.Content, nextContent)
+	if !containsID(res.SubChunkID, nextChunk.ID) {
+		res.SubChunkID = append(res.SubChunkID, nextChunk.ID)
+	}
+	res.StartAt = baseChunk.StartAt
+	res.EndAt = res.StartAt + runeLen(res.Content)
+
+	pipelineInfo(ctx, "Merge", "expand_dangling_empty_alt_image", map[string]interface{}{
+		"chunk_id":      res.ID,
+		"next_id":       nextChunk.ID,
+		"before_len":    beforeLen,
+		"after_len":     runeLen(res.Content),
+		"next_len":      runeLen(nextContent),
+		"base_content":  baseChunk.Content,
+		"after_content": res.Content,
+		"chunk_type":    res.ChunkType,
+	})
+}
+
+func hasDanglingEmptyAltImage(content string) bool {
+	matches := markdownImagePattern.FindAllStringSubmatchIndex(content, -1)
+	if len(matches) == 0 {
+		return false
+	}
+
+	last := matches[len(matches)-1]
+	if len(last) < 4 || last[2] < 0 || last[3] < 0 {
+		return false
+	}
+	if strings.TrimSpace(content[last[2]:last[3]]) != "" {
+		return false
+	}
+
+	afterImage := strings.TrimSpace(content[last[1]:])
+	if afterImage != "" && figureContextAfterImageRE.MatchString(afterImage) {
+		return false
+	}
+
+	return runeLen(content[last[0]:]) <= 500
+}
+
+func trimRunes(content string, maxLen int) string {
+	if maxLen <= 0 {
+		return ""
+	}
+	runes := []rune(content)
+	if len(runes) <= maxLen {
+		return content
+	}
+	return string(runes[:maxLen])
 }
 
 // runeLen returns the length of a string in runes

--- a/internal/application/service/chat_pipeline/merge_expand_test.go
+++ b/internal/application/service/chat_pipeline/merge_expand_test.go
@@ -1,0 +1,121 @@
+package chatpipeline
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type mergeExpandChunkRepo struct {
+	interfaces.ChunkRepository
+	chunks map[string]*types.Chunk
+}
+
+func (r *mergeExpandChunkRepo) ListChunksByID(
+	_ context.Context,
+	_ uint64,
+	ids []string,
+) ([]*types.Chunk, error) {
+	out := make([]*types.Chunk, 0, len(ids))
+	for _, id := range ids {
+		if chunk := r.chunks[id]; chunk != nil {
+			out = append(out, chunk)
+		}
+	}
+	return out, nil
+}
+
+func TestExpandContextWithNeighbors_AppendsNextChunkForDanglingEmptyAltImage(t *testing.T) {
+	baseContent := strings.Repeat("这是一段较长的视网膜静脉阻塞说明，确保长度超过普通短块阈值。", 12) +
+		"\n\n![](local://10000/exports/figure-ad.jpg)"
+	nextContent := "![图 3-3-3 视盘血管炎](local://10000/exports/figure-ef.jpg)\n\n" +
+		"患者女性，25岁。左眼视网膜中央静脉阻塞。图点评: 年轻 CRVO 的发生常与炎症相关。"
+
+	if runeLen(baseContent) < 350 {
+		t.Fatalf("test setup must use a long base chunk, got len=%d", runeLen(baseContent))
+	}
+
+	repo := &mergeExpandChunkRepo{
+		chunks: map[string]*types.Chunk{
+			"base": {
+				ID:          "base",
+				KnowledgeID: "knowledge-1",
+				Content:     baseContent,
+				ChunkType:   types.ChunkTypeText,
+				StartAt:     0,
+				EndAt:       runeLen(baseContent),
+				NextChunkID: "next",
+			},
+			"next": {
+				ID:          "next",
+				KnowledgeID: "knowledge-1",
+				Content:     nextContent,
+				ChunkType:   types.ChunkTypeText,
+				StartAt:     runeLen(baseContent),
+				EndAt:       runeLen(baseContent) + runeLen(nextContent),
+			},
+		},
+	}
+
+	merge := &PluginMerge{chunkRepo: repo}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(10000))
+	results := []*types.SearchResult{{
+		ID:          "base",
+		KnowledgeID: "knowledge-1",
+		Content:     baseContent,
+		ChunkType:   string(types.ChunkTypeText),
+		StartAt:     0,
+		EndAt:       runeLen(baseContent),
+	}}
+
+	out := merge.expandShortContextWithNeighbors(ctx, &types.ChatManage{}, results)
+	if len(out) != 1 {
+		t.Fatalf("unexpected result count: %d", len(out))
+	}
+	if !strings.Contains(out[0].Content, "图 3-3-3 视盘血管炎") {
+		t.Fatalf("expected next chunk figure title in expanded content, got: %q", out[0].Content)
+	}
+	if !containsID(out[0].SubChunkID, "next") {
+		t.Fatalf("expected next chunk id in sub chunks, got: %#v", out[0].SubChunkID)
+	}
+}
+
+func TestHasDanglingEmptyAltImage(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "empty alt image at end",
+			content: "前文\n\n![](local://img.jpg)",
+			want:    true,
+		},
+		{
+			name:    "titled image at end",
+			content: "前文\n\n![图 3-3-3 视盘血管炎](local://img.jpg)",
+			want:    false,
+		},
+		{
+			name:    "empty alt image already followed by figure context",
+			content: "![](local://img.jpg)\n\n图 3-3-3 视盘血管炎",
+			want:    false,
+		},
+		{
+			name:    "empty alt image far from tail",
+			content: "![](local://img.jpg)\n\n" + strings.Repeat("后续正文。", 130),
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasDanglingEmptyAltImage(tt.content); got != tt.want {
+				t.Fatalf("hasDanglingEmptyAltImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/application/service/chat_pipeline/plugin_test.go
+++ b/internal/application/service/chat_pipeline/plugin_test.go
@@ -73,6 +73,87 @@ func TestIntoChatMessage_WithMergeResults(t *testing.T) {
 	}
 }
 
+func TestIntoChatMessage_ContextIncludesCitationMetadata(t *testing.T) {
+	cm := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{
+			Query: "test query",
+			SummaryConfig: types.SummaryConfig{
+				ContextTemplate: "{{contexts}}",
+			},
+		},
+		PipelineState: types.PipelineState{
+			MergeResult: []*types.SearchResult{
+				{
+					ID:                "chunk-1",
+					Content:           "chunk A content",
+					KnowledgeBaseID:   "kb-1",
+					KnowledgeID:       "knowledge-1",
+					KnowledgeTitle:    "Guide",
+					KnowledgeFilename: "guide.md",
+				},
+			},
+		},
+	}
+	plugin := &PluginIntoChatMessage{messageService: nil}
+
+	err := plugin.OnEvent(context.Background(), types.INTO_CHAT_MESSAGE, cm, func() *PluginError {
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !contains(cm.RenderedContexts, `<context id="1" chunk_id="chunk-1" kb_id="kb-1" doc="Guide">`) {
+		t.Fatalf("RenderedContexts should expose citation metadata, got: %s", cm.RenderedContexts)
+	}
+}
+
+func TestIntoChatMessage_FAQAndDocumentContextsKeepCitationMetadata(t *testing.T) {
+	cm := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{
+			Query:                    "test query",
+			FAQPriorityEnabled:       true,
+			FAQDirectAnswerThreshold: 0.9,
+			SummaryConfig: types.SummaryConfig{
+				ContextTemplate: "{{contexts}}",
+			},
+		},
+		PipelineState: types.PipelineState{
+			MergeResult: []*types.SearchResult{
+				{
+					ID:              "faq-chunk",
+					Content:         "faq content",
+					KnowledgeBaseID: "kb-faq",
+					KnowledgeTitle:  "FAQ",
+					ChunkType:       string(types.ChunkTypeFAQ),
+					Score:           0.95,
+				},
+				{
+					ID:                "doc-chunk",
+					Content:           "document content",
+					KnowledgeBaseID:   "kb-doc",
+					KnowledgeFilename: "manual.pdf",
+				},
+			},
+		},
+	}
+	plugin := &PluginIntoChatMessage{messageService: nil}
+
+	err := plugin.OnEvent(context.Background(), types.INTO_CHAT_MESSAGE, cm, func() *PluginError {
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !contains(cm.RenderedContexts, `<context id="FAQ-1" chunk_id="faq-chunk" kb_id="kb-faq" doc="FAQ" match="exact">`) {
+		t.Fatalf("FAQ context should expose citation metadata, got: %s", cm.RenderedContexts)
+	}
+	if !contains(cm.RenderedContexts, `<context id="DOC-1" chunk_id="doc-chunk" kb_id="kb-doc" doc="manual.pdf">`) {
+		t.Fatalf("document context should expose citation metadata, got: %s", cm.RenderedContexts)
+	}
+}
+
 func TestIntoChatMessage_ImageDescriptionAppended(t *testing.T) {
 	cm := &types.ChatManage{
 		PipelineRequest: types.PipelineRequest{
@@ -90,6 +171,38 @@ func TestIntoChatMessage_ImageDescriptionAppended(t *testing.T) {
 	})
 	if !contains(cm.UserContent, "a cat sitting on a mat") {
 		t.Errorf("UserContent should contain image description, got: %s", cm.UserContent)
+	}
+}
+
+func TestAnswerContainsKBCitationTag(t *testing.T) {
+	tests := []struct {
+		name    string
+		answer  string
+		wantHit bool
+	}{
+		{
+			name:    "self closing kb tag",
+			answer:  `The answer is grounded. <kb doc="guide.md" chunk_id="chunk-1" />`,
+			wantHit: true,
+		},
+		{
+			name:    "no citation",
+			answer:  "The answer is grounded.",
+			wantHit: false,
+		},
+		{
+			name:    "keyboard html is not citation",
+			answer:  "Press <kbd>Enter</kbd> to continue.",
+			wantHit: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := answerContainsKBCitationTag(tt.answer); got != tt.wantHit {
+				t.Fatalf("answerContainsKBCitationTag(%q) = %v, want %v", tt.answer, got, tt.wantHit)
+			}
+		})
 	}
 }
 

--- a/internal/application/service/session_qa_helpers.go
+++ b/internal/application/service/session_qa_helpers.go
@@ -159,7 +159,7 @@ func (s *sessionService) applyAgentOverridesToChatManage(
 	customAgent.EnsureDefaults()
 
 	// Override summary config fields
-	if customAgent.Config.SystemPrompt != "" {
+	if shouldApplyCustomAgentSystemPrompt(customAgent) {
 		cm.SummaryConfig.Prompt = customAgent.Config.SystemPrompt
 		logger.Infof(ctx, "Using custom agent's system_prompt")
 	}
@@ -263,6 +263,13 @@ func (s *sessionService) applyAgentOverridesToChatManage(
 		cm.IntentPromptOverrides = customAgent.Config.IntentPrompts
 		logger.Infof(ctx, "Using custom agent's intent_prompts (%d overrides)", len(cm.IntentPromptOverrides))
 	}
+}
+
+func shouldApplyCustomAgentSystemPrompt(customAgent *types.CustomAgent) bool {
+	if customAgent == nil || strings.TrimSpace(customAgent.Config.SystemPrompt) == "" {
+		return false
+	}
+	return true
 }
 
 // restrictMentionsToAgentScope filters user-provided @mention targets (KB IDs

--- a/internal/application/service/session_qa_helpers_test.go
+++ b/internal/application/service/session_qa_helpers_test.go
@@ -1,0 +1,37 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestShouldApplyCustomAgentSystemPrompt(t *testing.T) {
+	t.Run("custom agent prompt still applies", func(t *testing.T) {
+		agent := &types.CustomAgent{
+			ID: "custom-agent",
+			Config: types.CustomAgentConfig{
+				SystemPrompt: "custom prompt",
+			},
+		}
+
+		if !shouldApplyCustomAgentSystemPrompt(agent) {
+			t.Fatal("expected custom agent prompt to apply")
+		}
+	})
+
+	t.Run("builtin quick answer saved prompt applies", func(t *testing.T) {
+		agent := &types.CustomAgent{
+			ID:        types.BuiltinQuickAnswerID,
+			IsBuiltin: true,
+			Config: types.CustomAgentConfig{
+				SystemPrompt:   "custom prompt saved from agent editor",
+				SystemPromptID: "default_kb",
+			},
+		}
+
+		if !shouldApplyCustomAgentSystemPrompt(agent) {
+			t.Fatal("expected builtin quick-answer saved prompt to apply")
+		}
+	})
+}

--- a/internal/config/prompt_template_test.go
+++ b/internal/config/prompt_template_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestDefaultKBPromptAndMigrationSeedQuickAnswerPrompt(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+
+	templates, err := loadPromptTemplates(filepath.Join(repoRoot, "config"))
+	if err != nil {
+		t.Fatalf("load prompt templates: %v", err)
+	}
+	defaultKB := FindTemplateByID(templates, "default_kb")
+	if defaultKB == nil {
+		t.Fatal("default_kb template not found")
+	}
+
+	requiredPromptRules := []string{
+		`<kb doc="..." chunk_id="..." kb_id="..." />`,
+		"Retrieved information may contain images in either of these formats",
+		"Prefer image-rich answers whenever possible",
+		`"鉴别", "区别", "表现", "眼底表现", "长什么样", "图片", "图", "照片", "展示"`,
+		"Do not omit relevant images merely because the user did not explicitly ask for pictures",
+		"Output each image title and image as exactly two consecutive Markdown lines",
+		"If the retrieved context contains a description, case note, OCR text, figure explanation, or 图点评",
+		"{{contexts}}",
+	}
+	for _, rule := range requiredPromptRules {
+		if !strings.Contains(defaultKB.Content, rule) {
+			t.Fatalf("default_kb prompt is missing rule %q", rule)
+		}
+	}
+
+	migrationPath := filepath.Join(repoRoot, "migrations", "versioned", "000065_builtin_quick_answer_default_prompt.up.sql")
+	migrationBytes, err := os.ReadFile(migrationPath)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	migration := string(migrationBytes)
+
+	requiredMigrationRules := []string{
+		"UPDATE custom_agents",
+		"builtin-quick-answer",
+		"system_prompt",
+		"system_prompt_id",
+		"default_kb",
+		`<kb doc="..." chunk_id="..." kb_id="..." />`,
+		"Prefer image-rich answers whenever possible",
+		"Output each image title and image as exactly two consecutive Markdown lines",
+		"{{contexts}}",
+	}
+	for _, rule := range requiredMigrationRules {
+		if !strings.Contains(migration, rule) {
+			t.Fatalf("quick-answer prompt migration is missing %q", rule)
+		}
+	}
+	if strings.Contains(migration, "config - 'system_prompt'") {
+		t.Fatal("quick-answer prompt migration must seed system_prompt, not remove it")
+	}
+}

--- a/internal/handler/session/agent_stream_handler.go
+++ b/internal/handler/session/agent_stream_handler.go
@@ -540,17 +540,24 @@ func (h *AgentStreamHandler) handleError(ctx context.Context, evt event.Event) e
 		return nil
 	}
 
+	h.mu.Lock()
+	content := appendTerminalErrorMessage(h.finalAnswer, data.Error)
+	h.mu.Unlock()
+
 	// Build error metadata
 	metadata := map[string]interface{}{
 		"stage": data.Stage,
 		"error": data.Error,
+	}
+	for key, value := range data.Extra {
+		metadata[key] = value
 	}
 
 	// Append error event to stream
 	if err := h.streamManager.AppendEvent(h.ctx, h.sessionID, h.assistantMessageID, interfaces.StreamEvent{
 		ID:        evt.ID,
 		Type:      types.ResponseTypeError,
-		Content:   data.Error,
+		Content:   content,
 		Done:      true,
 		Timestamp: time.Now(),
 		Data:      metadata,

--- a/internal/handler/session/agent_stream_handler_test.go
+++ b/internal/handler/session/agent_stream_handler_test.go
@@ -1,0 +1,79 @@
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/event"
+	"github.com/Tencent/WeKnora/internal/stream"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentStreamHandlerErrorIncludesPartialAnswer(t *testing.T) {
+	ctx := context.Background()
+	streamManager := stream.NewMemoryStreamManager()
+	handler := NewAgentStreamHandler(
+		ctx,
+		"session-1",
+		"message-1",
+		"request-1",
+		time.Now(),
+		&types.Message{ID: "message-1", SessionID: "session-1", Role: "assistant"},
+		streamManager,
+		event.NewEventBus(),
+	)
+
+	err := handler.handleFinalAnswer(ctx, event.Event{
+		ID:        "answer-1",
+		Type:      event.EventAgentFinalAnswer,
+		SessionID: "session-1",
+		Data: event.AgentFinalAnswerData{
+			Content: "已经生成的部分答案",
+			Done:    false,
+		},
+	})
+	require.NoError(t, err)
+
+	err = handler.handleError(ctx, event.Event{
+		ID:        "error-1",
+		Type:      event.EventError,
+		SessionID: "session-1",
+		Data: event.ErrorData{
+			Error:     "回答生成中断：模型服务暂时不可用或连接中断，请稍后重试。",
+			Stage:     "chat_completion_stream",
+			SessionID: "session-1",
+			Extra: map[string]interface{}{
+				"terminal": true,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	events, _, err := streamManager.GetEvents(ctx, "session-1", "message-1", 0)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	require.Equal(t, types.ResponseTypeAnswer, events[0].Type)
+	require.Equal(t, types.ResponseTypeError, events[1].Type)
+	require.True(t, events[1].Done)
+	require.Equal(t,
+		"已经生成的部分答案\n\n回答生成中断：模型服务暂时不可用或连接中断，请稍后重试。",
+		events[1].Content,
+	)
+	require.Equal(t, true, events[1].Data["terminal"])
+}
+
+func TestAppendTerminalErrorMessageAvoidsDuplicate(t *testing.T) {
+	msg := appendTerminalErrorMessage("已有答案\n\n生成失败", "生成失败")
+	require.Equal(t, "已有答案\n\n生成失败", msg)
+
+	msg = appendTerminalErrorMessage("", "生成失败")
+	require.Equal(t, "生成失败", msg)
+
+	msg = appendTerminalErrorMessage("已有答案", "生成失败")
+	require.Equal(t, "已有答案\n\n生成失败", msg)
+}
+
+var _ interfaces.StreamManager = (*stream.MemoryStreamManager)(nil)

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -738,6 +739,43 @@ func (h *Handler) executeQA(reqCtx *qaRequestContext, mode qaMode, generateTitle
 			}
 			return nil
 		})
+
+		streamCtx.eventBus.On(event.EventError, func(ctx context.Context, evt event.Event) error {
+			data, ok := evt.Data.(event.ErrorData)
+			if !ok {
+				return nil
+			}
+			if completionHandled {
+				return nil
+			}
+			completionHandled = true
+
+			userMessage := strings.TrimSpace(data.Error)
+			if userMessage == "" {
+				userMessage = terminalQAErrorMessage(streamCtx.asyncCtx, streamCtx.assistantMessage.Content != "")
+			}
+			streamCtx.assistantMessage.Content = appendTerminalErrorMessage(
+				streamCtx.assistantMessage.Content,
+				userMessage,
+			)
+
+			logger.Infof(streamCtx.asyncCtx, "Knowledge QA service terminated with error for session: %s", sessionID)
+			updateCtx := context.WithValue(
+				context.WithoutCancel(streamCtx.asyncCtx),
+				types.TenantIDContextKey,
+				reqCtx.session.TenantID,
+			)
+			// Do not index failed/incomplete answers into chat-history KB.
+			h.completeAssistantMessage(updateCtx, streamCtx.assistantMessage, "")
+			streamCtx.eventBus.Emit(streamCtx.asyncCtx, event.Event{
+				Type:      event.EventAgentComplete,
+				SessionID: sessionID,
+				Data: event.AgentCompleteData{
+					FinalAnswer: "",
+				},
+			})
+			return nil
+		})
 	}
 
 	// Execute QA asynchronously
@@ -795,15 +833,7 @@ func (h *Handler) executeQA(reqCtx *qaRequestContext, mode qaMode, generateTitle
 				logger.Infof(streamCtx.asyncCtx, "QA cancelled by user stop for session: %s", sessionID)
 			} else {
 				logger.ErrorWithFields(streamCtx.asyncCtx, serviceErr, nil)
-				streamCtx.eventBus.Emit(streamCtx.asyncCtx, event.Event{
-					Type:      event.EventError,
-					SessionID: sessionID,
-					Data: event.ErrorData{
-						Error:     serviceErr.Error(),
-						Stage:     stageName,
-						SessionID: sessionID,
-					},
-				})
+				h.emitTerminalQAError(streamCtx, reqCtx, mode, stageName, serviceErr)
 			}
 		}
 	}()
@@ -946,4 +976,88 @@ func (h *Handler) completeAssistantMessage(ctx context.Context, assistantMessage
 	// Use WithoutCancel so the goroutine survives after the HTTP request context is done.
 	bgCtx := context.WithoutCancel(ctx)
 	go h.messageService.IndexMessageToKB(bgCtx, userQuery, assistantMessage.Content, assistantMessage.ID, assistantMessage.SessionID)
+}
+
+func (h *Handler) emitTerminalQAError(
+	streamCtx *sseStreamContext,
+	reqCtx *qaRequestContext,
+	mode qaMode,
+	stageName string,
+	err error,
+) {
+	userMessage := terminalQAErrorMessage(streamCtx.asyncCtx, streamCtx.assistantMessage.Content != "")
+	detail := ""
+	if err != nil {
+		detail = err.Error()
+	}
+
+	if emitErr := streamCtx.eventBus.Emit(streamCtx.asyncCtx, event.Event{
+		Type:      event.EventError,
+		SessionID: reqCtx.sessionID,
+		Data: event.ErrorData{
+			Error:     userMessage,
+			ErrorCode: "qa_generation_failed",
+			Stage:     stageName,
+			SessionID: reqCtx.sessionID,
+			Query:     reqCtx.query,
+			Extra: map[string]interface{}{
+				"detail":   detail,
+				"terminal": true,
+			},
+		},
+	}); emitErr != nil {
+		logger.Errorf(streamCtx.asyncCtx, "Failed to emit terminal QA error event: %v", emitErr)
+	}
+
+	if mode != qaModeAgent || streamCtx.assistantMessage.IsCompleted {
+		return
+	}
+
+	streamCtx.assistantMessage.Content = appendTerminalErrorMessage(
+		streamCtx.assistantMessage.Content,
+		userMessage,
+	)
+	updateCtx := context.WithValue(
+		context.WithoutCancel(streamCtx.asyncCtx),
+		types.TenantIDContextKey,
+		reqCtx.session.TenantID,
+	)
+	h.completeAssistantMessage(updateCtx, streamCtx.assistantMessage, "")
+	streamCtx.eventBus.Emit(streamCtx.asyncCtx, event.Event{
+		Type:      event.EventAgentComplete,
+		SessionID: reqCtx.sessionID,
+		Data: event.AgentCompleteData{
+			FinalAnswer: "",
+			MessageID:   streamCtx.assistantMessage.ID,
+		},
+	})
+}
+
+func terminalQAErrorMessage(ctx context.Context, hasPartialAnswer bool) string {
+	lang, _ := types.LanguageFromContext(ctx)
+	if lang == "" {
+		lang = types.DefaultLanguage()
+	}
+	if strings.HasPrefix(strings.ToLower(lang), "zh") {
+		if hasPartialAnswer {
+			return "回答生成中断：模型服务暂时不可用或连接中断，请稍后重试。"
+		}
+		return "回答生成失败：模型服务暂时不可用或连接中断，请稍后重试。"
+	}
+	if hasPartialAnswer {
+		return "Answer generation was interrupted because the model service was unavailable or the connection was closed. Please try again later."
+	}
+	return "Answer generation failed because the model service was unavailable or the connection was closed. Please try again later."
+}
+
+func appendTerminalErrorMessage(content, message string) string {
+	content = strings.TrimSpace(content)
+	message = strings.TrimSpace(message)
+	if content == "" {
+		return message
+	}
+	if message == "" || strings.Contains(content, message) {
+		return content
+	}
+	return content + "\n\n" + message
 }

--- a/migrations/versioned/000065_builtin_quick_answer_default_prompt.down.sql
+++ b/migrations/versioned/000065_builtin_quick_answer_default_prompt.down.sql
@@ -1,0 +1,3 @@
+-- No-op: the previous materialized builtin quick-answer prompt cannot be
+-- reconstructed safely after the up migration aligns it with default_kb.
+-- Fresh installs still resolve builtin quick-answer through default_kb.

--- a/migrations/versioned/000065_builtin_quick_answer_default_prompt.up.sql
+++ b/migrations/versioned/000065_builtin_quick_answer_default_prompt.up.sql
@@ -1,0 +1,61 @@
+-- Seed the built-in quick-answer agent with the current default_kb prompt.
+--
+-- Fresh installs without a materialized builtin row read this same prompt from
+-- config/prompt_templates/system_prompt.yaml through system_prompt_id=default_kb.
+-- Existing installs may already have a customized builtin-quick-answer row in
+-- custom_agents.config; this migration makes that row carry the same prompt so
+-- the agent editor, quick-answer runtime, and fresh-clone defaults stay aligned.
+WITH quick_answer_prompt AS (
+  SELECT $prompt$You are WeKnora, a professional intelligent information retrieval assistant developed by Tencent. Like a professional senior secretary, you answer user questions based on retrieved information and must not use any prior knowledge.
+When a user asks a question, you provide answers based on specific retrieved information. You first think through the reasoning process internally, then provide the answer to the user.
+
+## Response Rules
+- Reply ONLY based on facts from the retrieved information, without using any prior knowledge, maintaining objectivity and accuracy
+- For complex questions, structure the answer using Markdown formatting; simple summaries do not need to be split
+- For simple answers, do not break the final answer into overly granular parts
+- Every factual sentence based on retrieved information MUST end with an inline citation tag using this exact format: <kb doc="..." chunk_id="..." kb_id="..." />
+- The citation tag values MUST come from the matching <context> attributes: use doc from the context's doc attribute, chunk_id from chunk_id, and kb_id from kb_id
+- Put citation tags on the same line as the sentence they support; do not collect citations at the end of the answer
+- Use up to 4 citation tags per sentence when multiple contexts support the same sentence, and do not cite content that is not supported by retrieved information
+- Retrieved information may contain images in either of these formats:
+  1. Markdown image: `![image number and title](local://.../xxx.png)`
+  2. XML image block: `<image url="local://.../xxx.png"><image_caption>image number and title</image_caption><image_ocr>optional OCR or description</image_ocr></image>`
+- Both formats represent displayable image references from the retrieved information; use the URL and caption exactly as provided when including images in the answer.
+- Prefer image-rich answers whenever possible: for ANY user question, if the retrieved information contains images that are directly relevant to the answer's main topic, disease, sign, comparison point, diagnosis, treatment, table entry, or clinical manifestation, you SHOULD include those images together with the text answer.
+- If the user's question asks about eye fundus appearance, image appearance, clinical manifestations, differential diagnosis, comparison, "鉴别", "区别", "表现", "眼底表现", "长什么样", "图片", "图", "照片", "展示", or similar visual/appearance questions, and relevant images exist in the retrieved information, you MUST include the relevant images in the answer.
+- Do not omit relevant images merely because the user did not explicitly ask for pictures. Do not omit relevant images merely because the answer is a comparison, summary, table, differential diagnosis, or text explanation.
+- For Markdown images from retrieved information, preserve the exact image URL and use the alt text as the image caption.
+- For XML image blocks, use the `url` attribute as the image URL and use the complete text between `<image_caption>` and `</image_caption>` as the image caption.
+- Output each image title and image as exactly two consecutive Markdown lines, with the image number/title ABOVE the image, no blank line, and no trailing spaces:
+  `**image number and title** <kb doc="..." chunk_id="..." kb_id="..." />`
+  `![image number and title](local://.../xxx.png)`
+- The image line MUST be the very next line after the title line. Do not insert an empty line, `<br>`, HTML, list item marker, or two trailing spaces after either line.
+- If the retrieved context contains a description, case note, OCR text, figure explanation, or 图点评 for that image, write a concise image description immediately below the image. The description must come from the retrieved context and must end with a citation tag.
+- Do not output the image number/title below the image, and do not duplicate the same image caption as a separate heading or paragraph.
+- Never fabricate placeholder images such as `![图片](图片地址)`, `![image](url)`, or any image URL not present in the retrieved contexts.
+- If no relevant image URL exists in the retrieved information, say that no relevant image was found; do not create a placeholder image.
+- Verify that all text and images in the result come from the retrieved information; if content not found in the retrieved information has been added, it must be revised until the final answer is obtained
+- If the user's question cannot be answered, honestly inform the user and provide reasonable suggestions
+
+## Output Format
+- Output your final result in Markdown format with images when applicable
+- Ensure the output is concise yet comprehensive, well-organized, clear, and non-repetitive
+
+## CRITICAL: Language Rule
+- ALWAYS respond in {{language}}
+
+The following is retrieved information that may or may not be relevant:
+{{contexts}}
+$prompt$::text AS system_prompt
+)
+UPDATE custom_agents
+SET config = jsonb_set(
+        jsonb_set(config, '{system_prompt}', to_jsonb(quick_answer_prompt.system_prompt), true),
+        '{system_prompt_id}', to_jsonb('default_kb'::text),
+        true
+    ),
+    updated_at = NOW()
+FROM quick_answer_prompt
+WHERE custom_agents.id = 'builtin-quick-answer'
+  AND custom_agents.is_builtin = TRUE
+  AND custom_agents.deleted_at IS NULL;

--- a/tests/default_kb_prompt_migration.test.mjs
+++ b/tests/default_kb_prompt_migration.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const promptTemplate = readFileSync(resolve(root, 'config/prompt_templates/system_prompt.yaml'), 'utf8');
+const migration = readFileSync(
+  resolve(root, 'migrations/versioned/000065_builtin_quick_answer_default_prompt.up.sql'),
+  'utf8',
+);
+
+const requiredPromptRules = [
+  '<kb doc="..." chunk_id="..." kb_id="..." />',
+  'Retrieved information may contain images in either of these formats',
+  'Prefer image-rich answers whenever possible',
+  '"鉴别", "区别", "表现", "眼底表现", "长什么样", "图片", "图", "照片", "展示"',
+  'Do not omit relevant images merely because the user did not explicitly ask for pictures',
+  'Output each image title and image as exactly two consecutive Markdown lines',
+  'If the retrieved context contains a description, case note, OCR text, figure explanation, or 图点评',
+  '{{contexts}}',
+];
+
+for (const rule of requiredPromptRules) {
+  assert.ok(promptTemplate.includes(rule), `default_kb prompt is missing rule: ${rule}`);
+}
+
+const requiredMigrationRules = [
+  'UPDATE custom_agents',
+  'builtin-quick-answer',
+  'system_prompt',
+  'system_prompt_id',
+  'default_kb',
+  '<kb doc="..." chunk_id="..." kb_id="..." />',
+  'Prefer image-rich answers whenever possible',
+  'Output each image title and image as exactly two consecutive Markdown lines',
+  '{{contexts}}',
+];
+
+for (const rule of requiredMigrationRules) {
+  assert.ok(migration.includes(rule), `quick-answer prompt migration is missing rule: ${rule}`);
+}
+
+assert.ok(
+  !migration.includes("config - 'system_prompt'"),
+  'quick-answer prompt migration must seed system_prompt, not remove it',
+);


### PR DESCRIPTION
Add inline knowledge-base citation metadata to retrieved contexts and require sentence-level <kb ... /> citations in the default prompt.

Improve citation popovers to render the actual merged context, including neighbor chunks, Markdown tables, images, and viewport-aware positioning.

Expand dangling image chunks with following context so figure titles and descriptions stay available to the model.

Persist the improved quick-answer prompt through the default_kb template and a quick-answer migration for existing builtin agent rows.

Surface terminal stream errors instead of silently stopping partial answers.

Wrap chat Markdown tables responsively and update the app Docker build mirror handling.

Add regression tests for prompt seeding, citations, citation previews, popover positioning, chunk expansion, quick-answer prompt handling, and stream errors.

<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [x] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->

## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [ ] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
