### PR TITLE
fix(im): ingest DingTalk file/image messages into knowledge base

### DIFF
--- a/internal/im/dingtalk/adapter.go
+++ b/internal/im/dingtalk/adapter.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/open-dingtalk/dingtalk-stream-sdk-go/chatbot"
 
 	"github.com/Tencent/WeKnora/internal/im"
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -24,6 +25,9 @@ import (
 
 // httpClient is a shared HTTP client with a reasonable timeout for DingTalk API calls.
 var httpClient = &http.Client{Timeout: 15 * time.Second}
+
+// apiBaseURL is the DingTalk OpenAPI host. Overridable in tests.
+var apiBaseURL = "https://api.dingtalk.com"
 
 // minCardUpdateInterval is the minimum time between consecutive card streaming updates.
 const minCardUpdateInterval = 500 * time.Millisecond
@@ -33,8 +37,9 @@ const dingtalkConvTypeGroup = "2"
 
 // Compile-time checks.
 var (
-	_ im.Adapter      = (*Adapter)(nil)
-	_ im.StreamSender = (*Adapter)(nil)
+	_ im.Adapter        = (*Adapter)(nil)
+	_ im.StreamSender   = (*Adapter)(nil)
+	_ im.FileDownloader = (*Adapter)(nil)
 )
 
 // Adapter implements im.Adapter for DingTalk.
@@ -114,19 +119,20 @@ func (a *Adapter) VerifyCallback(c *gin.Context) error {
 
 // DingTalk callback message structure.
 type callbackMessage struct {
-	ConversationID   string       `json:"conversationId"`
-	ConversationType string       `json:"conversationType"`
-	MsgID            string       `json:"msgId"`
-	Msgtype          string       `json:"msgtype"`
-	Text             *textContent `json:"text"`
-	SenderNick       string       `json:"senderNick"`
-	SenderStaffId    string       `json:"senderStaffId"`
-	SenderID         string       `json:"senderId"`
-	SessionWebhook   string       `json:"sessionWebhook"`
-	RobotCode        string       `json:"robotCode"`
-	AtUsers          []atUser     `json:"atUsers"`
-	IsInAtList       bool         `json:"isInAtList"`
-	ChatbotCorpId    string       `json:"chatbotCorpId"`
+	ConversationID   string          `json:"conversationId"`
+	ConversationType string          `json:"conversationType"`
+	MsgID            string          `json:"msgId"`
+	Msgtype          string          `json:"msgtype"`
+	Text             *textContent    `json:"text"`
+	Content          json.RawMessage `json:"content"`
+	SenderNick       string          `json:"senderNick"`
+	SenderStaffId    string          `json:"senderStaffId"`
+	SenderID         string          `json:"senderId"`
+	SessionWebhook   string          `json:"sessionWebhook"`
+	RobotCode        string          `json:"robotCode"`
+	AtUsers          []atUser        `json:"atUsers"`
+	IsInAtList       bool            `json:"isInAtList"`
+	ChatbotCorpId    string          `json:"chatbotCorpId"`
 }
 
 type textContent struct {
@@ -153,6 +159,92 @@ func (a *Adapter) ParseCallback(c *gin.Context) (*im.IncomingMessage, error) {
 	return parseCallbackMessage(&msg), nil
 }
 
+// fileMessageContent is the `content` object DingTalk sends for file and
+// picture messages. File messages carry fileName/spaceId/fileId; picture
+// messages carry only downloadCode (original quality) and pictureDownloadCode.
+// See https://open-dingtalk.github.io/developerpedia/docs/learn/bot/message/
+type fileMessageContent struct {
+	DownloadCode string `json:"downloadCode"`
+	FileName     string `json:"fileName"`
+}
+
+// parseFileContent maps a DingTalk msgtype + content object to WeKnora's file
+// message fields. Returns ok=false for non-file/picture message types so the
+// caller keeps its text handling. Picture messages have no fileName; the IM
+// service appends an extension after download.
+func parseFileContent(msgtype string, content json.RawMessage) (im.MessageType, string, string, bool) {
+	var c fileMessageContent
+	if len(content) > 0 {
+		_ = json.Unmarshal(content, &c)
+	}
+	switch msgtype {
+	case "file":
+		return im.MessageTypeFile, c.FileName, c.DownloadCode, true
+	case "picture":
+		return im.MessageTypeImage, "", c.DownloadCode, true
+	default:
+		return "", "", "", false
+	}
+}
+
+// parseDownloadURL extracts the temporary downloadUrl from the response of the
+// robot/messageFiles/download API.
+func parseDownloadURL(raw json.RawMessage) (string, error) {
+	var r struct {
+		DownloadURL string `json:"downloadUrl"`
+	}
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return "", fmt.Errorf("parse download response: %w", err)
+	}
+	if r.DownloadURL == "" {
+		return "", fmt.Errorf("download response has no downloadUrl: %s", string(raw))
+	}
+	return r.DownloadURL, nil
+}
+
+// DownloadFile downloads a file/picture the user sent to the robot. DingTalk
+// does not deliver the bytes directly: the callback carries a downloadCode that
+// is exchanged for a temporary downloadUrl via robot/messageFiles/download,
+// which is then fetched. robotCode comes from the callback (webhook mode) or the
+// app client ID (stream mode). Implements im.FileDownloader (issue #1771).
+func (a *Adapter) DownloadFile(ctx context.Context, msg *im.IncomingMessage) (io.ReadCloser, string, error) {
+	downloadCode := msg.FileKey
+	if downloadCode == "" {
+		return nil, "", fmt.Errorf("no downloadCode in message")
+	}
+	robotCode := msg.Extra["robot_code"]
+	if robotCode == "" {
+		robotCode = a.clientID
+	}
+
+	respBody, err := a.dingtalkAPI(ctx, http.MethodPost, "/v1.0/robot/messageFiles/download", map[string]string{
+		"robotCode":    robotCode,
+		"downloadCode": downloadCode,
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("request download url: %w", err)
+	}
+	downloadURL, err := parseDownloadURL(respBody)
+	if err != nil {
+		return nil, "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("create download request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("download file: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, "", fmt.Errorf("download file returned %d: %s", resp.StatusCode, string(body))
+	}
+	return resp.Body, msg.FileName, nil
+}
+
 func parseCallbackMessage(msg *callbackMessage) *im.IncomingMessage {
 	chatType := im.ChatTypeDirect
 	chatID := ""
@@ -166,24 +258,91 @@ func parseCallbackMessage(msg *callbackMessage) *im.IncomingMessage {
 		userID = msg.SenderID
 	}
 
-	content := ""
-	if msg.Text != nil {
-		content = strings.TrimSpace(msg.Text.Content)
+	extra := map[string]string{
+		"session_webhook": msg.SessionWebhook,
+	}
+	incoming := &im.IncomingMessage{
+		Platform:  im.PlatformDingtalk,
+		UserID:    userID,
+		UserName:  msg.SenderNick,
+		ChatID:    chatID,
+		ChatType:  chatType,
+		MessageID: msg.MsgID,
+		Extra:     extra,
 	}
 
-	return &im.IncomingMessage{
-		Platform:    im.PlatformDingtalk,
-		UserID:      userID,
-		UserName:    msg.SenderNick,
-		ChatID:      chatID,
-		ChatType:    chatType,
-		MessageID:   msg.MsgID,
-		MessageType: im.MessageTypeText,
-		Content:     content,
-		Extra: map[string]string{
-			"session_webhook": msg.SessionWebhook,
-		},
+	if msgType, fileName, downloadCode, ok := parseFileContent(msg.Msgtype, msg.Content); ok {
+		incoming.MessageType = msgType
+		incoming.FileName = defaultFileName(msgType, fileName, msg.MsgID)
+		incoming.FileKey = downloadCode
+		extra["robot_code"] = msg.RobotCode
+	} else {
+		incoming.MessageType = im.MessageTypeText
+		if msg.Text != nil {
+			incoming.Content = strings.TrimSpace(msg.Text.Content)
+		}
 	}
+	return incoming
+}
+
+// defaultFileName gives picture messages (which carry no fileName) a name with a
+// real stem derived from the message ID, mirroring the WeCom adapter. File
+// messages keep their original name.
+func defaultFileName(msgType im.MessageType, fileName, msgID string) string {
+	if msgType == im.MessageTypeImage && fileName == "" {
+		return msgID + ".png"
+	}
+	return fileName
+}
+
+// streamToIncoming builds an IncomingMessage from a DingTalk Stream mode
+// callback. The Stream SDK does not expose robotCode, so file messages fall back
+// to the app client ID (which is the robotCode for enterprise internal robots).
+func streamToIncoming(data *chatbot.BotCallbackDataModel, fallbackRobotCode string) *im.IncomingMessage {
+	chatType := im.ChatTypeDirect
+	chatID := ""
+	if data.ConversationType == dingtalkConvTypeGroup {
+		chatType = im.ChatTypeGroup
+		chatID = data.ConversationId
+	}
+
+	userID := data.SenderStaffId
+	if userID == "" {
+		userID = data.SenderId
+	}
+
+	extra := map[string]string{
+		"session_webhook": data.SessionWebhook,
+	}
+	incoming := &im.IncomingMessage{
+		Platform:  im.PlatformDingtalk,
+		UserID:    userID,
+		UserName:  data.SenderNick,
+		ChatID:    chatID,
+		ChatType:  chatType,
+		MessageID: data.MsgId,
+		Extra:     extra,
+	}
+
+	// data.Content is a decoded interface{}; re-marshal it to JSON so the same
+	// parseFileContent helper used by the webhook path can read it.
+	var contentRaw json.RawMessage
+	if data.Content != nil {
+		if b, err := json.Marshal(data.Content); err == nil {
+			contentRaw = b
+		}
+	}
+
+	if msgType, fileName, downloadCode, ok := parseFileContent(data.Msgtype, contentRaw); ok {
+		incoming.MessageType = msgType
+		incoming.FileName = defaultFileName(msgType, fileName, data.MsgId)
+		incoming.FileKey = downloadCode
+		extra["robot_code"] = fallbackRobotCode
+	} else {
+		incoming.MessageType = im.MessageTypeText
+		incoming.Content = strings.TrimSpace(data.Text.Content)
+	}
+	return incoming
 }
 
 // ── Send reply ──
@@ -310,7 +469,7 @@ func (a *Adapter) getAccessToken(ctx context.Context) (string, error) {
 	jsonBody, _ := json.Marshal(body)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		"https://api.dingtalk.com/v1.0/oauth2/accessToken",
+		apiBaseURL+"/v1.0/oauth2/accessToken",
 		bytes.NewReader(jsonBody))
 	if err != nil {
 		return "", err
@@ -358,7 +517,7 @@ func (a *Adapter) dingtalkAPI(ctx context.Context, method, path string, body int
 		return nil, fmt.Errorf("marshal body: %w", err)
 	}
 
-	url := "https://api.dingtalk.com" + path
+	url := apiBaseURL + path
 	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(jsonBody))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)

--- a/internal/im/dingtalk/adapter_test.go
+++ b/internal/im/dingtalk/adapter_test.go
@@ -1,0 +1,196 @@
+package dingtalk
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/open-dingtalk/dingtalk-stream-sdk-go/chatbot"
+
+	"github.com/Tencent/WeKnora/internal/im"
+)
+
+// Compile-time check: the adapter must implement FileDownloader so the IM
+// service dispatches file messages to it (issue #1771).
+var _ im.FileDownloader = (*Adapter)(nil)
+
+func TestParseFileContent_File(t *testing.T) {
+	content := json.RawMessage(`{"spaceId":"223573","fileName":"foobar.zip","downloadCode":"LJYYbw==","fileId":"117848"}`)
+	msgType, fileName, downloadCode, ok := parseFileContent("file", content)
+	if !ok {
+		t.Fatalf("expected ok=true for file message")
+	}
+	if msgType != im.MessageTypeFile {
+		t.Errorf("msgType = %q, want %q", msgType, im.MessageTypeFile)
+	}
+	if fileName != "foobar.zip" {
+		t.Errorf("fileName = %q, want %q", fileName, "foobar.zip")
+	}
+	if downloadCode != "LJYYbw==" {
+		t.Errorf("downloadCode = %q, want %q", downloadCode, "LJYYbw==")
+	}
+}
+
+func TestParseFileContent_Picture(t *testing.T) {
+	content := json.RawMessage(`{"pictureDownloadCode":"pWjAks=","downloadCode":"mIofJE0E"}`)
+	msgType, fileName, downloadCode, ok := parseFileContent("picture", content)
+	if !ok {
+		t.Fatalf("expected ok=true for picture message")
+	}
+	if msgType != im.MessageTypeImage {
+		t.Errorf("msgType = %q, want %q", msgType, im.MessageTypeImage)
+	}
+	if fileName != "" {
+		t.Errorf("fileName = %q, want empty (pipeline appends extension)", fileName)
+	}
+	if downloadCode != "mIofJE0E" {
+		t.Errorf("downloadCode = %q, want %q", downloadCode, "mIofJE0E")
+	}
+}
+
+func TestParseFileContent_Text(t *testing.T) {
+	_, _, _, ok := parseFileContent("text", nil)
+	if ok {
+		t.Errorf("expected ok=false for text message")
+	}
+}
+
+func TestParseDownloadURL(t *testing.T) {
+	url, err := parseDownloadURL(json.RawMessage(`{"downloadUrl":"https://example.com/file?token=abc"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if url != "https://example.com/file?token=abc" {
+		t.Errorf("url = %q, want %q", url, "https://example.com/file?token=abc")
+	}
+}
+
+func TestParseDownloadURL_Missing(t *testing.T) {
+	_, err := parseDownloadURL(json.RawMessage(`{}`))
+	if err == nil {
+		t.Errorf("expected error when downloadUrl is missing")
+	}
+}
+
+func TestParseCallbackMessage_File(t *testing.T) {
+	msg := &callbackMessage{
+		MsgID:            "m1",
+		Msgtype:          "file",
+		RobotCode:        "robot-123",
+		SenderStaffId:    "staff-1",
+		SenderNick:       "Alice",
+		ConversationType: "1",
+		Content:          json.RawMessage(`{"fileName":"spec.pdf","downloadCode":"CODE1","spaceId":"s1"}`),
+	}
+	got := parseCallbackMessage(msg)
+	if got.MessageType != im.MessageTypeFile {
+		t.Errorf("MessageType = %q, want %q", got.MessageType, im.MessageTypeFile)
+	}
+	if got.FileName != "spec.pdf" {
+		t.Errorf("FileName = %q, want %q", got.FileName, "spec.pdf")
+	}
+	if got.FileKey != "CODE1" {
+		t.Errorf("FileKey = %q, want %q", got.FileKey, "CODE1")
+	}
+	if got.Extra["robot_code"] != "robot-123" {
+		t.Errorf("Extra[robot_code] = %q, want %q", got.Extra["robot_code"], "robot-123")
+	}
+}
+
+func TestParseCallbackMessage_Picture(t *testing.T) {
+	msg := &callbackMessage{
+		MsgID:     "pic-1",
+		Msgtype:   "picture",
+		RobotCode: "robot-123",
+		Content:   json.RawMessage(`{"downloadCode":"PCODE"}`),
+	}
+	got := parseCallbackMessage(msg)
+	if got.MessageType != im.MessageTypeImage {
+		t.Errorf("MessageType = %q, want %q", got.MessageType, im.MessageTypeImage)
+	}
+	// Pictures carry no filename; derive one from the message ID so the KB entry
+	// has a real stem (matches the WeCom adapter behavior).
+	if got.FileName != "pic-1.png" {
+		t.Errorf("FileName = %q, want %q", got.FileName, "pic-1.png")
+	}
+	if got.FileKey != "PCODE" {
+		t.Errorf("FileKey = %q, want %q", got.FileKey, "PCODE")
+	}
+}
+
+func TestParseCallbackMessage_TextStillWorks(t *testing.T) {
+	msg := &callbackMessage{
+		MsgID:         "m2",
+		Msgtype:       "text",
+		SenderStaffId: "staff-1",
+		Text:          &textContent{Content: "  hello  "},
+	}
+	got := parseCallbackMessage(msg)
+	if got.MessageType != im.MessageTypeText {
+		t.Errorf("MessageType = %q, want %q", got.MessageType, im.MessageTypeText)
+	}
+	if got.Content != "hello" {
+		t.Errorf("Content = %q, want %q", got.Content, "hello")
+	}
+}
+
+func TestStreamToIncoming_File(t *testing.T) {
+	data := &chatbot.BotCallbackDataModel{
+		MsgId:            "m3",
+		Msgtype:          "file",
+		SenderStaffId:    "staff-2",
+		SenderNick:       "Bob",
+		ConversationType: "1",
+		Content: map[string]interface{}{
+			"fileName":     "notes.docx",
+			"downloadCode": "CODE2",
+		},
+	}
+	got := streamToIncoming(data, "client-app-key")
+	if got.MessageType != im.MessageTypeFile {
+		t.Errorf("MessageType = %q, want %q", got.MessageType, im.MessageTypeFile)
+	}
+	if got.FileName != "notes.docx" {
+		t.Errorf("FileName = %q, want %q", got.FileName, "notes.docx")
+	}
+	if got.FileKey != "CODE2" {
+		t.Errorf("FileKey = %q, want %q", got.FileKey, "CODE2")
+	}
+	// Stream mode has no robotCode field; fall back to the app client ID.
+	if got.Extra["robot_code"] != "client-app-key" {
+		t.Errorf("Extra[robot_code] = %q, want %q", got.Extra["robot_code"], "client-app-key")
+	}
+}
+
+func TestStreamToIncoming_Picture(t *testing.T) {
+	data := &chatbot.BotCallbackDataModel{
+		MsgId:   "spic-1",
+		Msgtype: "picture",
+		Content: map[string]interface{}{"downloadCode": "SPCODE"},
+	}
+	got := streamToIncoming(data, "client-app-key")
+	if got.MessageType != im.MessageTypeImage {
+		t.Errorf("MessageType = %q, want %q", got.MessageType, im.MessageTypeImage)
+	}
+	if got.FileName != "spic-1.png" {
+		t.Errorf("FileName = %q, want %q", got.FileName, "spic-1.png")
+	}
+	if got.FileKey != "SPCODE" {
+		t.Errorf("FileKey = %q, want %q", got.FileKey, "SPCODE")
+	}
+}
+
+func TestStreamToIncoming_TextStillWorks(t *testing.T) {
+	data := &chatbot.BotCallbackDataModel{
+		MsgId:         "m4",
+		Msgtype:       "text",
+		SenderStaffId: "staff-2",
+		Text:          chatbot.BotCallbackDataTextModel{Content: " hi "},
+	}
+	got := streamToIncoming(data, "client-app-key")
+	if got.MessageType != im.MessageTypeText {
+		t.Errorf("MessageType = %q, want %q", got.MessageType, im.MessageTypeText)
+	}
+	if got.Content != "hi" {
+		t.Errorf("Content = %q, want %q", got.Content, "hi")
+	}
+}

--- a/internal/im/dingtalk/download_test.go
+++ b/internal/im/dingtalk/download_test.go
@@ -1,0 +1,113 @@
+package dingtalk
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/im"
+)
+
+// TestDownloadFile_EndToEnd drives the full DownloadFile orchestration against a
+// fake DingTalk OpenAPI: access-token fetch → messageFiles/download (downloadCode
+// → temporary downloadUrl) → GET the temp URL for the bytes. This covers the HTTP
+// path that the pure-function unit tests deliberately skip (issue #1771).
+func TestDownloadFile_EndToEnd(t *testing.T) {
+	fileBytes := []byte("%PDF-1.7 fake product spec bytes")
+
+	var downloadReq map[string]string
+	var tokenSeen string
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.0/oauth2/accessToken":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"accessToken": "tok-abc",
+				"expireIn":    7200,
+			})
+		case "/v1.0/robot/messageFiles/download":
+			tokenSeen = r.Header.Get("x-acs-dingtalk-access-token")
+			_ = json.NewDecoder(r.Body).Decode(&downloadReq)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"downloadUrl": srv.URL + "/temp/file",
+			})
+		case "/temp/file":
+			_, _ = w.Write(fileBytes)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	orig := apiBaseURL
+	apiBaseURL = srv.URL
+	defer func() { apiBaseURL = orig }()
+
+	a := &Adapter{clientID: "cid", clientSecret: "sec"}
+	msg := &im.IncomingMessage{
+		MessageType: im.MessageTypeFile,
+		FileKey:     "DL-CODE",
+		FileName:    "spec.pdf",
+		Extra:       map[string]string{"robot_code": "rc-1"},
+	}
+
+	reader, name, err := a.DownloadFile(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("DownloadFile error: %v", err)
+	}
+	defer reader.Close()
+
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(got) != string(fileBytes) {
+		t.Errorf("downloaded bytes = %q, want %q", got, fileBytes)
+	}
+	if name != "spec.pdf" {
+		t.Errorf("resolved name = %q, want %q", name, "spec.pdf")
+	}
+	if tokenSeen != "tok-abc" {
+		t.Errorf("download request auth header = %q, want %q", tokenSeen, "tok-abc")
+	}
+	if downloadReq["robotCode"] != "rc-1" {
+		t.Errorf("robotCode sent = %q, want %q", downloadReq["robotCode"], "rc-1")
+	}
+	if downloadReq["downloadCode"] != "DL-CODE" {
+		t.Errorf("downloadCode sent = %q, want %q", downloadReq["downloadCode"], "DL-CODE")
+	}
+}
+
+// TestDownloadFile_TempURLError verifies a non-200 from the temporary download
+// URL surfaces as an error rather than silently returning empty content.
+func TestDownloadFile_TempURLError(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.0/oauth2/accessToken":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"accessToken": "tok", "expireIn": 7200})
+		case "/v1.0/robot/messageFiles/download":
+			_ = json.NewEncoder(w).Encode(map[string]string{"downloadUrl": srv.URL + "/temp/gone"})
+		case "/temp/gone":
+			http.Error(w, "expired", http.StatusForbidden)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	orig := apiBaseURL
+	apiBaseURL = srv.URL
+	defer func() { apiBaseURL = orig }()
+
+	a := &Adapter{clientID: "cid", clientSecret: "sec"}
+	msg := &im.IncomingMessage{FileKey: "DL-CODE", FileName: "x.pdf", Extra: map[string]string{"robot_code": "rc"}}
+
+	if _, _, err := a.DownloadFile(context.Background(), msg); err == nil {
+		t.Errorf("expected error on non-200 download URL, got nil")
+	}
+}

--- a/internal/im/dingtalk/longconn.go
+++ b/internal/im/dingtalk/longconn.go
@@ -2,7 +2,6 @@ package dingtalk
 
 import (
 	"context"
-	"strings"
 
 	"github.com/open-dingtalk/dingtalk-stream-sdk-go/chatbot"
 	dtsdk "github.com/open-dingtalk/dingtalk-stream-sdk-go/client"
@@ -59,33 +58,7 @@ func (c *LongConnClient) Close() {
 }
 
 func (c *LongConnClient) onChatBotMessage(ctx context.Context, data *chatbot.BotCallbackDataModel) ([]byte, error) {
-	chatType := im.ChatTypeDirect
-	chatID := ""
-	if data.ConversationType == dingtalkConvTypeGroup {
-		chatType = im.ChatTypeGroup
-		chatID = data.ConversationId
-	}
-
-	userID := data.SenderStaffId
-	if userID == "" {
-		userID = data.SenderId
-	}
-
-	content := strings.TrimSpace(data.Text.Content)
-
-	incoming := &im.IncomingMessage{
-		Platform:    im.PlatformDingtalk,
-		UserID:      userID,
-		UserName:    data.SenderNick,
-		ChatID:      chatID,
-		ChatType:    chatType,
-		MessageID:   data.MsgId,
-		MessageType: im.MessageTypeText,
-		Content:     content,
-		Extra: map[string]string{
-			"session_webhook": data.SessionWebhook,
-		},
-	}
+	incoming := streamToIncoming(data, c.clientID)
 
 	if err := c.handler(ctx, incoming); err != nil {
 		logger.Errorf(ctx, "[DingTalk] Handle message error: %v", err)


### PR DESCRIPTION
## Description

The DingTalk adapter only ever classified incoming messages as **text** and did not implement the `FileDownloader` interface. As a result, files a user sent to the DingTalk bot were **never saved** to the channel's configured knowledge base — even when a "文件保存知识库" (file knowledge base) was set. The same agent worked on the WeCom bot, which does implement both, making the gap DingTalk-specific.

This PR gives the DingTalk adapter file-message capability, mirroring the existing WeCom behavior but using DingTalk's own mechanism:

- **Message classification** — parse `file` / `picture` `msgtype`s in **both** the webhook (`parseCallbackMessage`) and stream (`streamToIncoming`) paths, setting `MessageTypeFile`/`MessageTypeImage`, `FileName`, `FileKey` (= `downloadCode`), and `robot_code`. Text handling is unchanged.
- **File download** — implement `DownloadFile`: exchange the `downloadCode` for a temporary URL via `POST /v1.0/robot/messageFiles/download`, then fetch the bytes. No AES decryption is needed (unlike WeCom). Reuses the adapter's existing `getAccessToken` / `dingtalkAPI` helpers.
- **robotCode source** — from the callback in webhook mode; falls back to the app client ID in stream mode (which is the robotCode for enterprise internal robots, since the Stream SDK does not expose it).
- **Picture naming** — pictures carry no filename, so they get a `MsgID`-derived name (`<msgId>.png`), mirroring the WeCom adapter.

The shared IM ingestion pipeline (`handleFileMessage` → `processFileToKnowledgeBase` → `CreateKnowledgeFromFile`) is untouched; only the DingTalk adapter's contract with it (classify file messages + implement `FileDownloader`) is fulfilled.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #1771

## Testing

- **Unit tests** (`adapter_test.go`) — file/picture/text classification for both webhook and stream paths; `parseFileContent` and `parseDownloadURL` edge cases; picture `MsgID.png` naming.
- **In-process E2E** (`download_test.go`) — `DownloadFile` driven end-to-end against an `httptest` fake DingTalk OpenAPI: access-token → `messageFiles/download` (downloadCode → temporary URL) → fetch bytes; plus a non-200 temp-URL error case. (A test seam, `apiBaseURL`, was added so the OpenAPI host is overridable.)
- **Real DingTalk bot** — verified end-to-end on a live enterprise internal robot (stream mode): sending a document file to the bot now downloads it and stores it in the configured knowledge base; logs show `msgtype=file` and `[IM] File saved to knowledge base`.
- `gofmt` and `go vet ./internal/im/dingtalk/` are clean; `go test ./internal/im/dingtalk/` passes.

## Checklist
- [x] `make fmt` (gofmt clean) and `make test` (affected `internal/im/...` packages) pass locally — `make lint` not run (`golangci-lint` not installed in the local env)
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.) — not applicable; no config surface change (the file-KB UI already exists)
- [x] Breaking changes are clearly called out in the description above (none)

## Screenshots / Recordings
<img width="590" height="1278" alt="IMG_6503" src="https://github.com/user-attachments/assets/a990ed9b-c0ee-4baf-be4b-ebd9a446da30" />
