### PR TITLE
feat(knowledge-list): show Wiki badge on knowledge base cards

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2314,6 +2314,7 @@ export default {
       knowledgeGraph: 'Knowledge Graph',
       multimodal: 'Multimodal',
       questionGeneration: 'Question Generation',
+      wiki: 'Wiki',
     },
     processing: 'Processing import task',
     processingDocuments: 'Processing {count} documents',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -3210,6 +3210,7 @@ export default {
       knowledgeGraph: "지식 그래프 활성화됨",
       multimodal: "멀티모달 활성화됨",
       questionGeneration: "질문 생성 활성화됨",
+      wiki: "Wiki",
     },
     messages: {
       deleted: "삭제됨",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -2659,7 +2659,8 @@ export default {
     features: {
       knowledgeGraph: 'Граф знаний включен',
       multimodal: 'Мультимодальность включена',
-      questionGeneration: 'Генерация вопросов включена'
+      questionGeneration: 'Генерация вопросов включена',
+      wiki: 'Wiki',
     },
     processing: 'Обработка задачи импорта',
     processingDocuments: 'Обработка {count} документов',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -3229,6 +3229,7 @@ export default {
       knowledgeGraph: "知识图谱",
       multimodal: "多模态",
       questionGeneration: "问题生成",
+      wiki: "Wiki",
     },
     messages: {
       deleted: "已删除",

--- a/frontend/src/views/knowledge/KnowledgeBaseList.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseList.vue
@@ -200,7 +200,10 @@
               </button>
               <!-- 卡片头部 -->
               <div class="card-header">
-                <span class="card-title" :title="kb.name">{{ kb.name }}</span>
+                <span class="card-title" :title="kb.name">
+                  <KbWikiBadge v-if="isWikiKb(kb)" />
+                  <span class="card-title-text">{{ kb.name }}</span>
+                </span>
                 <!-- The card menu always exists when the card is visible: pin
                      is now per-user and available to anyone who can see the KB
                      (backend route only requires KB read access). Settings /
@@ -296,7 +299,10 @@
               </button>
               <!-- 卡片头部 -->
               <div class="card-header">
-                <span class="card-title" :title="kb.name">{{ kb.name }}</span>
+                <span class="card-title" :title="kb.name">
+                  <KbWikiBadge v-if="isWikiKb(kb)" />
+                  <span class="card-title-text">{{ kb.name }}</span>
+                </span>
                 <t-tooltip :content="$t('knowledgeList.menu.viewDetails')" placement="top">
                   <button type="button" class="shared-detail-trigger" @click.stop="openSharedDetailFromAll(kb)"
                     :aria-label="$t('knowledgeList.menu.viewDetails')">
@@ -424,7 +430,10 @@
               </button>
               <!-- 卡片头部 -->
               <div class="card-header">
-                <span class="card-title" :title="kb.name">{{ kb.name }}</span>
+                <span class="card-title" :title="kb.name">
+                  <KbWikiBadge v-if="isWikiKb(kb)" />
+                  <span class="card-title-text">{{ kb.name }}</span>
+                </span>
                 <!-- See the matching block in the "all" tab template for why
                      this is no longer gated by canManageKBCard. -->
                 <t-popup v-model="kb.showMore" overlayClassName="card-more-popup"
@@ -570,7 +579,10 @@
             }" @click="handleSharedKbClick(shared)">
               <!-- 卡片头部 -->
               <div class="card-header">
-                <span class="card-title" :title="shared.knowledge_base.name">{{ shared.knowledge_base.name }}</span>
+                <span class="card-title" :title="shared.knowledge_base.name">
+                  <KbWikiBadge v-if="isWikiKb(shared.knowledge_base)" />
+                  <span class="card-title-text">{{ shared.knowledge_base.name }}</span>
+                </span>
                 <t-tooltip v-if="!shared.is_mine" :content="$t('knowledgeList.menu.viewDetails')" placement="top">
                   <button type="button" class="shared-detail-trigger" @click.stop="openSharedDetail(shared)"
                     :aria-label="$t('knowledgeList.menu.viewDetails')">
@@ -771,6 +783,7 @@ import { useOrganizationStore } from '@/stores/organization'
 import { listOrganizationSharedKnowledgeBases, type SharedKnowledgeBase, type OrganizationSharedKnowledgeBaseItem, type SourceFromAgentInfo } from '@/api/organization'
 import { mergeAllScopeKnowledgeBases, type OwnedKnowledgeBase, type SharedKnowledgeBaseLike } from './kbListMerge'
 import KnowledgeBaseEditorModal from './KnowledgeBaseEditorModal.vue'
+import KbWikiBadge from './components/KbWikiBadge.vue'
 import ShareKnowledgeBaseDialog from '@/components/ShareKnowledgeBaseDialog.vue'
 import ListSpaceSidebar from '@/components/ListSpaceSidebar.vue'
 import ResourceOriginBadge from '@/components/ResourceOriginBadge.vue'
@@ -1505,6 +1518,9 @@ const isInitialized = (kb: KB) => {
   if (needsEmbedding && (!kb.embedding_model_id || kb.embedding_model_id === '')) return false
   return true
 }
+
+const isWikiKb = (kb: { indexing_strategy?: { wiki_enabled?: boolean } } | null | undefined) =>
+  !!kb?.indexing_strategy?.wiki_enabled
 
 // 计算是否有未初始化的知识库
 const hasUninitializedKbs = computed(() => {
@@ -2415,7 +2431,15 @@ const handleUploadFinishedEvent = (event: Event) => {
     text-overflow: ellipsis;
     display: flex;
     align-items: center;
-    gap: 5px;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .card-title-text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .card-more-btn {

--- a/frontend/src/views/knowledge/components/KbWikiBadge.vue
+++ b/frontend/src/views/knowledge/components/KbWikiBadge.vue
@@ -1,0 +1,43 @@
+<template>
+  <t-tooltip :content="t('knowledgeList.features.wiki')" placement="top">
+    <span class="kb-wiki-badge" role="img" :aria-label="t('knowledgeList.features.wiki')">
+      <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M12 7v14" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" />
+        <path d="M16 12h2" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" />
+        <path d="M16 8h2" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" />
+        <path
+          d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <path d="M6 12h2" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" />
+        <path d="M6 8h2" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </span>
+  </t-tooltip>
+</template>
+
+<script setup lang="ts">
+// Icon: Lucide "book-open-text" (ISC) — https://lucide.dev/icons/book-open-text
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+</script>
+
+<style scoped lang="less">
+.kb-wiki-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--td-text-color-secondary);
+
+  svg {
+    width: 15px;
+    height: 15px;
+    display: block;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- Add a `KbWikiBadge` component (Lucide `book-open-text` icon) shown beside the card title when `indexing_strategy.wiki_enabled` is true
- Apply the badge across all knowledge base list card templates (mine, shared, and space views)
- Add `knowledgeList.features.wiki` i18n strings for the tooltip

## Test plan
- [ ] Open the knowledge base list and confirm Wiki-enabled KBs show the book icon next to the title
- [ ] Confirm non-Wiki KBs do not show the icon
- [ ] Hover the icon and verify the "Wiki" tooltip appears
- [ ] Check shared / space-scoped KB cards render the badge when Wiki is enabled
- [ ] Verify long KB names still truncate correctly with the icon present