### PR TITLE
Add knowledge base duplicate flow

### DIFF
--- a/client/knowledgebase.go
+++ b/client/knowledgebase.go
@@ -241,6 +241,17 @@ type CopyKnowledgeBaseResponse struct {
 	Message  string `json:"message"`
 }
 
+type DuplicateKnowledgeBaseRequest struct {
+	TargetID string `json:"target_id,omitempty"`
+}
+
+type DuplicateKnowledgeBaseResponse struct {
+	SourceID      string        `json:"source_id"`
+	TargetID      string        `json:"target_id"`
+	Message       string        `json:"message"`
+	KnowledgeBase KnowledgeBase `json:"knowledge_base"`
+}
+
 // KBCloneProgress represents the progress of a knowledge base clone task
 type KBCloneProgress struct {
 	TaskID    string `json:"task_id"`
@@ -453,6 +464,31 @@ func (c *Client) CopyKnowledgeBase(ctx context.Context, request *CopyKnowledgeBa
 	var response struct {
 		Success bool                      `json:"success"`
 		Data    CopyKnowledgeBaseResponse `json:"data"`
+	}
+
+	if err := parseResponse(resp, &response); err != nil {
+		return nil, err
+	}
+
+	return &response.Data, nil
+}
+
+// DuplicateKnowledgeBase creates a settings-only duplicate and returns the new knowledge base info.
+func (c *Client) DuplicateKnowledgeBase(
+	ctx context.Context,
+	knowledgeBaseID string,
+	request *DuplicateKnowledgeBaseRequest,
+) (*DuplicateKnowledgeBaseResponse, error) {
+	path := fmt.Sprintf("/api/v1/knowledge-bases/%s/duplicate", knowledgeBaseID)
+
+	resp, err := c.doRequest(ctx, http.MethodPost, path, request, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool                           `json:"success"`
+		Data    DuplicateKnowledgeBaseResponse `json:"data"`
 	}
 
 	if err := parseResponse(resp, &response); err != nil {

--- a/client/knowledgebase.go
+++ b/client/knowledgebase.go
@@ -241,10 +241,6 @@ type CopyKnowledgeBaseResponse struct {
 	Message  string `json:"message"`
 }
 
-type DuplicateKnowledgeBaseRequest struct {
-	TargetID string `json:"target_id,omitempty"`
-}
-
 type DuplicateKnowledgeBaseResponse struct {
 	SourceID      string        `json:"source_id"`
 	TargetID      string        `json:"target_id"`
@@ -477,11 +473,10 @@ func (c *Client) CopyKnowledgeBase(ctx context.Context, request *CopyKnowledgeBa
 func (c *Client) DuplicateKnowledgeBase(
 	ctx context.Context,
 	knowledgeBaseID string,
-	request *DuplicateKnowledgeBaseRequest,
 ) (*DuplicateKnowledgeBaseResponse, error) {
 	path := fmt.Sprintf("/api/v1/knowledge-bases/%s/duplicate", knowledgeBaseID)
 
-	resp, err := c.doRequest(ctx, http.MethodPost, path, request, nil)
+	resp, err := c.doRequest(ctx, http.MethodPost, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/knowledgebase_duplicate_test.go
+++ b/client/knowledgebase_duplicate_test.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDuplicateKnowledgeBase(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/knowledge-bases/kb-1/duplicate" {
+			t.Fatalf("path = %s, want /api/v1/knowledge-bases/kb-1/duplicate", r.URL.Path)
+		}
+		if r.ContentLength > 0 {
+			t.Fatalf("expected empty request body, got content-length=%d", r.ContentLength)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": true,
+			"data": map[string]interface{}{
+				"source_id": "kb-1",
+				"target_id": "kb-2",
+				"message":   "Knowledge base duplicate created",
+				"knowledge_base": map[string]interface{}{
+					"id":   "kb-2",
+					"name": "Source Copy",
+					"type": "document",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, WithAPIKey("sk-test"))
+	resp, err := c.DuplicateKnowledgeBase(context.Background(), "kb-1")
+	if err != nil {
+		t.Fatalf("DuplicateKnowledgeBase() error = %v", err)
+	}
+	if resp.SourceID != "kb-1" {
+		t.Fatalf("SourceID = %q, want kb-1", resp.SourceID)
+	}
+	if resp.TargetID != "kb-2" {
+		t.Fatalf("TargetID = %q, want kb-2", resp.TargetID)
+	}
+	if resp.KnowledgeBase.ID != "kb-2" {
+		t.Fatalf("KnowledgeBase.ID = %q, want kb-2", resp.KnowledgeBase.ID)
+	}
+	if resp.KnowledgeBase.Name != "Source Copy" {
+		t.Fatalf("KnowledgeBase.Name = %q, want Source Copy", resp.KnowledgeBase.Name)
+	}
+}

--- a/docs/api/knowledge-base.md
+++ b/docs/api/knowledge-base.md
@@ -22,6 +22,7 @@
 | GET    | `/knowledge-bases/:id/hybrid-search`      | 混合搜索（兼容旧客户端，需 JSON 请求体）  |
 | POST   | `/knowledge-bases/copy`                   | 拷贝知识库（异步任务）   |
 | GET    | `/knowledge-bases/copy/progress/:task_id` | 获取拷贝进度             |
+| POST   | `/knowledge-bases/:id/duplicate`          | 创建知识库副本（仅设置） |
 | GET    | `/knowledge-bases/:id/move-targets`       | 获取可迁移目标知识库列表 |
 
 ## POST `/knowledge-bases` - 创建知识库
@@ -528,6 +529,77 @@ curl --location 'http://localhost:8080/api/v1/knowledge-bases/copy/progress/kb_c
     "success": true
 }
 ```
+
+## POST `/knowledge-bases/:id/duplicate` - 创建知识库副本
+
+同步创建一个**仅包含设置**的新知识库副本。会复制分块、模型、索引策略、Wiki/FAQ 配置等设置字段，但**不会**复制知识条目、分块内容、FAQ 条目、Wiki 页面、向量/关键词索引、数据源绑定、分享关系或置顶状态。
+
+与 `POST /knowledge-bases/copy` 的区别：
+
+| 能力 | `/duplicate` | `/copy` |
+| ---- | ------------ | ------- |
+| 执行方式 | 同步，立即返回新 KB | 异步任务，需轮询 progress |
+| 复制内容 | 仅设置 | 设置 + 全部知识内容 |
+| 新 KB ID | 服务端自动生成 UUID | 可指定已有目标库或新建 |
+
+**权限**：需要 `Contributor+`，且对源知识库至少有 `Viewer` 读权限（路由层 `KBAccessRead`）。源知识库必须属于调用者所在租户，否则返回 `403 Forbidden`。
+
+**命名规则**：新 KB 名称在源名称后追加本地化后缀（依据 `Accept-Language` 或 `WEKNORA_LANGUAGE`），例如中文 `原名 副本`、英文 `Original Name Copy`；若同名已存在则递增为 `原名 副本 2`、`Original Name Copy 2` 等。
+
+**路径参数**:
+
+| 字段 | 类型   | 说明        |
+| ---- | ------ | ----------- |
+| id   | string | 源知识库 ID |
+
+**请求**:
+
+```curl
+curl --location 'http://localhost:8080/api/v1/knowledge-bases/kb-00000001/duplicate' \
+--header 'Authorization: Bearer <token>' \
+--header 'Accept-Language: zh-CN' \
+--request POST
+```
+
+**响应**（HTTP 201）:
+
+```json
+{
+    "success": true,
+    "data": {
+        "source_id": "kb-00000001",
+        "target_id": "kb-00000002",
+        "message": "Knowledge base duplicate created",
+        "knowledge_base": {
+            "id": "kb-00000002",
+            "name": "产品文档 副本",
+            "type": "document",
+            "description": "…",
+            "embedding_model_id": "embed-1",
+            "chunking_config": {},
+            "knowledge_count": 0,
+            "chunk_count": 0
+        }
+    }
+}
+```
+
+**响应字段（`data`）**:
+
+| 字段            | 类型   | 说明                         |
+| --------------- | ------ | ---------------------------- |
+| source_id       | string | 源知识库 ID                  |
+| target_id       | string | 新创建的知识库 ID            |
+| message         | string | 操作结果描述                 |
+| knowledge_base  | object | 新副本的完整知识库对象       |
+
+**常见错误**:
+
+| 场景                 | HTTP | 说明 |
+| -------------------- | ---- | ---- |
+| 源知识库不存在       | 404  | `Source knowledge base not found` |
+| 源库属于其他租户     | 403  | `No permission to duplicate this knowledge base` |
+| 向量存储绑定无效     | 400  | 源库绑定的 vector store 不可用 |
 
 ## GET `/knowledge-bases/:id/move-targets` - 获取可迁移目标知识库列表
 

--- a/frontend/src/api/knowledge-base/index.ts
+++ b/frontend/src/api/knowledge-base/index.ts
@@ -135,8 +135,8 @@ export function copyKnowledgeBase(data: { source_id: string; target_id?: string 
   return post(`/api/v1/knowledge-bases/copy`, data);
 }
 
-export function duplicateKnowledgeBase(id: string, data: { target_id?: string } = {}) {
-  return post(`/api/v1/knowledge-bases/${id}/duplicate`, data);
+export function duplicateKnowledgeBase(id: string) {
+  return post(`/api/v1/knowledge-bases/${id}/duplicate`);
 }
 
 // 获取可移动目标知识库列表（同类型、同Embedding模型）

--- a/frontend/src/api/knowledge-base/index.ts
+++ b/frontend/src/api/knowledge-base/index.ts
@@ -135,6 +135,10 @@ export function copyKnowledgeBase(data: { source_id: string; target_id?: string 
   return post(`/api/v1/knowledge-bases/copy`, data);
 }
 
+export function duplicateKnowledgeBase(id: string, data: { target_id?: string } = {}) {
+  return post(`/api/v1/knowledge-bases/${id}/duplicate`, data);
+}
+
 // 获取可移动目标知识库列表（同类型、同Embedding模型）
 export function listMoveTargets(sourceKbId: string) {
   return get(`/api/v1/knowledge-bases/${sourceKbId}/move-targets`);

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2262,6 +2262,7 @@ export default {
     },
     menu: {
       viewDetails: 'View Details',
+      duplicate: 'Duplicate',
     },
     pin: {
       pin: 'Pin to Top',
@@ -2282,6 +2283,8 @@ export default {
     messages: {
       deleted: 'Knowledge base deleted',
       deleteFailed: 'Failed to delete knowledge base',
+      duplicateSuccess: 'Knowledge base duplicate created (content not included)',
+      duplicateFailed: 'Failed to create knowledge base duplicate',
       file: 'File',
       knowledgeBase: 'Knowledge Base',
       noResult: 'No results',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -3165,6 +3165,7 @@ export default {
     },
     menu: {
       viewDetails: "세부 사항을 확인하세요",
+      duplicate: "복제",
     },
     pin: {
       pin: "상단 고정",
@@ -3215,6 +3216,8 @@ export default {
     messages: {
       deleted: "삭제됨",
       deleteFailed: "삭제 실패",
+      duplicateSuccess: "지식베이스 복제본이 생성되었습니다(콘텐츠 제외)",
+      duplicateFailed: "지식베이스 복제본 생성 실패",
       file: "파일",
       knowledgeBase: "지식베이스",
       noResult: "결과 없음",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -2652,6 +2652,8 @@ export default {
     messages: {
       deleted: 'База знаний удалена',
       deleteFailed: 'Не удалось удалить базу знаний',
+      duplicateSuccess: 'Дубликат базы знаний создан (без содержимого)',
+      duplicateFailed: 'Не удалось создать дубликат базы знаний',
       file: '文件',
       knowledgeBase: '知识库',
       noResult: '无结果'
@@ -2694,7 +2696,8 @@ export default {
     },
     emptyShared: 'No collaborative knowledge bases yet. Join a shared space to access knowledge bases from others.',
     menu: {
-      viewDetails: 'View Details'
+      viewDetails: 'View Details',
+      duplicate: 'Duplicate'
     },
     detail: {
       title: 'Shared Knowledge Base',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -3184,6 +3184,7 @@ export default {
     },
     menu: {
       viewDetails: "查看详情",
+      duplicate: "创建副本",
     },
     pin: {
       pin: "置顶",
@@ -3234,6 +3235,8 @@ export default {
     messages: {
       deleted: "已删除",
       deleteFailed: "删除失败",
+      duplicateSuccess: "知识库副本已创建（不包含知识内容）",
+      duplicateFailed: "创建知识库副本失败",
       file: "文件",
       knowledgeBase: "知识库",
       noResult: "无结果",

--- a/frontend/src/views/knowledge/KnowledgeBaseList.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseList.vue
@@ -219,6 +219,11 @@
                         <t-icon class="menu-icon" :name="kb.is_pinned ? 'pin-filled' : 'pin'" />
                         <span>{{ kb.is_pinned ? $t('knowledgeList.pin.unpin') : $t('knowledgeList.pin.pin') }}</span>
                       </div>
+                      <div v-if="canDuplicateKBCard(kb)" class="popup-menu-item"
+                        @click.stop="handleDuplicateById(kb.id)">
+                        <t-icon class="menu-icon" name="file-copy" />
+                        <span>{{ $t('knowledgeList.menu.duplicate') }}</span>
+                      </div>
                       <template v-if="canManageKBCard(kb)">
                         <div class="popup-menu-item" @click.stop="handleSettingsById(kb.id)">
                           <t-icon class="menu-icon" name="setting" />
@@ -447,6 +452,10 @@
                       <div class="popup-menu-item" @click.stop="handleTogglePin(kb)">
                         <t-icon class="menu-icon" :name="kb.is_pinned ? 'pin-filled' : 'pin'" />
                         <span>{{ kb.is_pinned ? $t('knowledgeList.pin.unpin') : $t('knowledgeList.pin.pin') }}</span>
+                      </div>
+                      <div v-if="canDuplicateKBCard(kb)" class="popup-menu-item" @click.stop="handleDuplicate(kb)">
+                        <t-icon class="menu-icon" name="file-copy" />
+                        <span>{{ $t('knowledgeList.menu.duplicate') }}</span>
                       </div>
                       <template v-if="canManageKBCard(kb)">
                         <div class="popup-menu-item" @click.stop="handleSettings(kb)">
@@ -774,7 +783,7 @@
 import { onMounted, onUnmounted, ref, computed, watch, nextTick } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { MessagePlugin, Icon as TIcon } from 'tdesign-vue-next'
-import { deleteKnowledgeBase, togglePinKnowledgeBase } from '@/api/knowledge-base'
+import { deleteKnowledgeBase, duplicateKnowledgeBase, togglePinKnowledgeBase } from '@/api/knowledge-base'
 import { useChatResourcesStore } from '@/stores/chatResources'
 import { formatStringDate } from '@/utils/index'
 import { useUIStore } from '@/stores/ui'
@@ -1348,6 +1357,10 @@ function canManageKBCard(kb: KB): boolean {
   return authStore.hasRole('admin')
 }
 
+function canDuplicateKBCard(kb: any): boolean {
+  return authStore.hasRole('contributor') && kb.isMine !== false
+}
+
 // isMyKb 仅用于卡片右下角徽章在「我创建」与「同租户其他成员创建」之间切换。
 // 与 canManageKBCard 不同：管理权限有 admin 兜底，徽章纯粹按创建者匹配。
 // creator_id 为空（PR 5 RBAC 迁移之前的老 KB）一律按 tenant 处理——避免把
@@ -1417,6 +1430,33 @@ const handleTogglePinById = async (id: string) => {
     }
   } catch {
     MessagePlugin.error(t('knowledgeList.pin.failed'))
+  }
+}
+
+const handleDuplicate = async (kb: KB) => {
+  kb.showMore = false
+  await duplicateKB(kb.id)
+}
+
+const handleDuplicateById = async (id: string) => {
+  await duplicateKB(id)
+}
+
+const duplicateKB = async (id: string) => {
+  try {
+    const res: any = await duplicateKnowledgeBase(id)
+    if (res?.success) {
+      const newKbId = res.data?.target_id || res.data?.knowledge_base?.id
+      MessagePlugin.success(t('knowledgeList.messages.duplicateSuccess'))
+      await fetchList(true)
+      if (newKbId) {
+        triggerHighlightFlash(newKbId)
+      }
+    } else {
+      MessagePlugin.error(res?.message || t('knowledgeList.messages.duplicateFailed'))
+    }
+  } catch (e: any) {
+    MessagePlugin.error(e?.message || t('knowledgeList.messages.duplicateFailed'))
   }
 }
 

--- a/internal/agent/tools/query_knowledge_graph_test.go
+++ b/internal/agent/tools/query_knowledge_graph_test.go
@@ -83,6 +83,14 @@ func (s *stubKnowledgeBaseService) CopyKnowledgeBase(
 	return nil, nil, nil
 }
 
+func (s *stubKnowledgeBaseService) DuplicateKnowledgeBase(
+	context.Context,
+	string,
+	string,
+) (*types.KnowledgeBase, error) {
+	return nil, nil
+}
+
 func (s *stubKnowledgeBaseService) GetRepository() interfaces.KnowledgeBaseRepository {
 	return nil
 }

--- a/internal/agent/tools/query_knowledge_graph_test.go
+++ b/internal/agent/tools/query_knowledge_graph_test.go
@@ -86,7 +86,6 @@ func (s *stubKnowledgeBaseService) CopyKnowledgeBase(
 func (s *stubKnowledgeBaseService) DuplicateKnowledgeBase(
 	context.Context,
 	string,
-	string,
 ) (*types.KnowledgeBase, error) {
 	return nil, nil
 }

--- a/internal/application/service/datasource_service_test.go
+++ b/internal/application/service/datasource_service_test.go
@@ -103,7 +103,7 @@ func (s *processSyncKBService) ResolveEmbeddingModelKeys(context.Context, []*typ
 func (s *processSyncKBService) CopyKnowledgeBase(context.Context, string, string) (*types.KnowledgeBase, *types.KnowledgeBase, error) {
 	return nil, nil, nil
 }
-func (s *processSyncKBService) DuplicateKnowledgeBase(context.Context, string, string) (*types.KnowledgeBase, error) {
+func (s *processSyncKBService) DuplicateKnowledgeBase(context.Context, string) (*types.KnowledgeBase, error) {
 	return nil, nil
 }
 func (s *processSyncKBService) GetRepository() interfaces.KnowledgeBaseRepository { return nil }

--- a/internal/application/service/datasource_service_test.go
+++ b/internal/application/service/datasource_service_test.go
@@ -103,6 +103,9 @@ func (s *processSyncKBService) ResolveEmbeddingModelKeys(context.Context, []*typ
 func (s *processSyncKBService) CopyKnowledgeBase(context.Context, string, string) (*types.KnowledgeBase, *types.KnowledgeBase, error) {
 	return nil, nil, nil
 }
+func (s *processSyncKBService) DuplicateKnowledgeBase(context.Context, string, string) (*types.KnowledgeBase, error) {
+	return nil, nil
+}
 func (s *processSyncKBService) GetRepository() interfaces.KnowledgeBaseRepository { return nil }
 func (s *processSyncKBService) ProcessKBDelete(context.Context, *asynq.Task) error {
 	return nil

--- a/internal/application/service/knowledgebase.go
+++ b/internal/application/service/knowledgebase.go
@@ -1035,10 +1035,8 @@ func (s *knowledgeBaseService) CopyKnowledgeBase(ctx context.Context,
 func (s *knowledgeBaseService) DuplicateKnowledgeBase(
 	ctx context.Context,
 	srcKB string,
-	targetID string,
 ) (*types.KnowledgeBase, error) {
 	srcKB = strings.TrimSpace(srcKB)
-	targetID = strings.TrimSpace(targetID)
 	if srcKB == "" {
 		return nil, apperrors.NewBadRequestError("source knowledge base ID cannot be empty")
 	}
@@ -1055,11 +1053,7 @@ func (s *knowledgeBaseService) DuplicateKnowledgeBase(
 	if err != nil {
 		return nil, err
 	}
-	if targetID != "" {
-		targetKB.ID = targetID
-	} else {
-		targetKB.ID = uuid.New().String()
-	}
+	targetKB.ID = uuid.New().String()
 	targetKB.TenantID = tenantID
 	targetKB.Name = s.buildDuplicateKnowledgeBaseName(ctx, tenantID, sourceKB.Name)
 	targetKB.CreatorID = ""
@@ -1095,20 +1089,54 @@ func (s *knowledgeBaseService) DuplicateKnowledgeBase(
 	return targetKB, nil
 }
 
+func duplicateKBCopySuffix(locale string) string {
+	locale = strings.ToLower(locale)
+	switch {
+	case strings.HasPrefix(locale, "zh"):
+		return " 副本"
+	case strings.HasPrefix(locale, "ko"):
+		return " 사본"
+	case strings.HasPrefix(locale, "ru"):
+		return " копия"
+	default:
+		return " Copy"
+	}
+}
+
+func duplicateKBDefaultName(locale string) string {
+	locale = strings.ToLower(locale)
+	switch {
+	case strings.HasPrefix(locale, "zh"):
+		return "知识库"
+	case strings.HasPrefix(locale, "ko"):
+		return "지식베이스"
+	case strings.HasPrefix(locale, "ru"):
+		return "База знаний"
+	default:
+		return "Knowledge Base"
+	}
+}
+
 func (s *knowledgeBaseService) buildDuplicateKnowledgeBaseName(
 	ctx context.Context,
 	tenantID uint64,
 	sourceName string,
 ) string {
+	locale, ok := types.LanguageFromContext(ctx)
+	if !ok {
+		locale = types.DefaultLanguage()
+	}
+	suffix := duplicateKBCopySuffix(locale)
+
 	baseName := strings.TrimSpace(sourceName)
 	if baseName == "" {
-		baseName = "知识库"
+		baseName = duplicateKBDefaultName(locale)
 	}
 
 	kbs, err := s.repo.ListKnowledgeBasesByTenantID(ctx, tenantID)
 	if err != nil {
 		logger.Warnf(ctx, "List tenant knowledge bases failed while building duplicate name: %v", err)
-		return baseName + " 副本"
+		return baseName + suffix
 	}
 
 	existing := make(map[string]struct{}, len(kbs))
@@ -1119,12 +1147,12 @@ func (s *knowledgeBaseService) buildDuplicateKnowledgeBaseName(
 		existing[kb.Name] = struct{}{}
 	}
 
-	candidate := baseName + " 副本"
+	candidate := baseName + suffix
 	if _, ok := existing[candidate]; !ok {
 		return candidate
 	}
 	for i := 2; ; i++ {
-		candidate = fmt.Sprintf("%s 副本 %d", baseName, i)
+		candidate = fmt.Sprintf("%s%s %d", baseName, suffix, i)
 		if _, ok := existing[candidate]; !ok {
 			return candidate
 		}

--- a/internal/application/service/knowledgebase.go
+++ b/internal/application/service/knowledgebase.go
@@ -1028,3 +1028,120 @@ func (s *knowledgeBaseService) CopyKnowledgeBase(ctx context.Context,
 	}
 	return sourceKB, targetKB, nil
 }
+
+// DuplicateKnowledgeBase creates a new KB from the source KB's settings only.
+// Runtime/content state is deliberately reset so this path never copies
+// knowledge entries, chunks, FAQ content, wiki pages, indexes, shares or pins.
+func (s *knowledgeBaseService) DuplicateKnowledgeBase(
+	ctx context.Context,
+	srcKB string,
+	targetID string,
+) (*types.KnowledgeBase, error) {
+	srcKB = strings.TrimSpace(srcKB)
+	targetID = strings.TrimSpace(targetID)
+	if srcKB == "" {
+		return nil, apperrors.NewBadRequestError("source knowledge base ID cannot be empty")
+	}
+
+	tenantID := types.MustTenantIDFromContext(ctx)
+	sourceKB, err := s.repo.GetKnowledgeBaseByIDAndTenant(ctx, srcKB, tenantID)
+	if err != nil {
+		logger.Errorf(ctx, "Get source knowledge base failed: %v", err)
+		return nil, err
+	}
+	sourceKB.EnsureDefaults()
+
+	targetKB, err := cloneKnowledgeBaseConfiguration(sourceKB)
+	if err != nil {
+		return nil, err
+	}
+	if targetID != "" {
+		targetKB.ID = targetID
+	} else {
+		targetKB.ID = uuid.New().String()
+	}
+	targetKB.TenantID = tenantID
+	targetKB.Name = s.buildDuplicateKnowledgeBaseName(ctx, tenantID, sourceKB.Name)
+	targetKB.CreatorID = ""
+	if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
+		targetKB.CreatorID = uid
+	}
+	now := time.Now()
+	targetKB.CreatedAt = now
+	targetKB.UpdatedAt = now
+	targetKB.DeletedAt.Valid = false
+	targetKB.DeletedAt.Time = time.Time{}
+	targetKB.IsTemporary = false
+	targetKB.IsPinned = false
+	targetKB.PinnedAt = nil
+	targetKB.KnowledgeCount = 0
+	targetKB.ChunkCount = 0
+	targetKB.IsProcessing = false
+	targetKB.ProcessingCount = 0
+	targetKB.ShareCount = 0
+	targetKB.CreatorName = ""
+	targetKB.EnsureDefaults()
+	targetKB.Normalize()
+
+	if targetKB.HasVectorStore() {
+		if err := s.validateVectorStoreBinding(ctx, tenantID, *targetKB.VectorStoreID); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := s.repo.CreateKnowledgeBase(ctx, targetKB); err != nil {
+		return nil, err
+	}
+	return targetKB, nil
+}
+
+func (s *knowledgeBaseService) buildDuplicateKnowledgeBaseName(
+	ctx context.Context,
+	tenantID uint64,
+	sourceName string,
+) string {
+	baseName := strings.TrimSpace(sourceName)
+	if baseName == "" {
+		baseName = "知识库"
+	}
+
+	kbs, err := s.repo.ListKnowledgeBasesByTenantID(ctx, tenantID)
+	if err != nil {
+		logger.Warnf(ctx, "List tenant knowledge bases failed while building duplicate name: %v", err)
+		return baseName + " 副本"
+	}
+
+	existing := make(map[string]struct{}, len(kbs))
+	for _, kb := range kbs {
+		if kb == nil {
+			continue
+		}
+		existing[kb.Name] = struct{}{}
+	}
+
+	candidate := baseName + " 副本"
+	if _, ok := existing[candidate]; !ok {
+		return candidate
+	}
+	for i := 2; ; i++ {
+		candidate = fmt.Sprintf("%s 副本 %d", baseName, i)
+		if _, ok := existing[candidate]; !ok {
+			return candidate
+		}
+	}
+}
+
+func cloneKnowledgeBaseConfiguration(sourceKB *types.KnowledgeBase) (*types.KnowledgeBase, error) {
+	if sourceKB == nil {
+		return nil, apperrors.NewBadRequestError("source knowledge base cannot be empty")
+	}
+	data, err := json.Marshal(sourceKB)
+	if err != nil {
+		return nil, err
+	}
+	var targetKB types.KnowledgeBase
+	if err := json.Unmarshal(data, &targetKB); err != nil {
+		return nil, err
+	}
+	return &targetKB, nil
+}

--- a/internal/application/service/knowledgebase_pr3_test.go
+++ b/internal/application/service/knowledgebase_pr3_test.go
@@ -423,10 +423,10 @@ func TestDuplicateKnowledgeBase_CreatesSettingsOnlyDuplicate(t *testing.T) {
 	svc := newPR3KBService(repo, &fakeRegistry{}, &fakeOwnership{})
 	ctx := context.WithValue(ctxWithTenant(1), types.UserIDContextKey, "copy-user")
 
-	target, err := svc.DuplicateKnowledgeBase(ctx, "src", "copy-id")
+	target, err := svc.DuplicateKnowledgeBase(ctx, "src")
 	require.NoError(t, err)
 
-	require.Equal(t, "copy-id", target.ID)
+	require.NotEmpty(t, target.ID)
 	assert.Equal(t, uint64(1), target.TenantID)
 	assert.Equal(t, "copy-user", target.CreatorID)
 	assert.Equal(t, "Source KB 副本", target.Name)
@@ -456,7 +456,7 @@ func TestDuplicateKnowledgeBase_CreatesSettingsOnlyDuplicate(t *testing.T) {
 	assert.Zero(t, target.ProcessingCount)
 	assert.Zero(t, target.ShareCount)
 	assert.Empty(t, target.CreatorName)
-	require.Same(t, target, repo.rows["copy-id"])
+	require.Same(t, target, repo.rows[target.ID])
 }
 
 func TestDuplicateKnowledgeBase_UsesDistinctNameWhenDuplicateExists(t *testing.T) {
@@ -475,8 +475,25 @@ func TestDuplicateKnowledgeBase_UsesDistinctNameWhenDuplicateExists(t *testing.T
 	}
 	svc := newPR3KBService(repo, &fakeRegistry{}, &fakeOwnership{})
 
-	target, err := svc.DuplicateKnowledgeBase(ctxWithTenant(1), "src", "copy-id")
+	target, err := svc.DuplicateKnowledgeBase(ctxWithTenant(1), "src")
 	require.NoError(t, err)
 
 	assert.Equal(t, "Source KB 副本 2", target.Name)
+}
+
+func TestDuplicateKnowledgeBase_UsesLocalizedEnglishSuffix(t *testing.T) {
+	repo := newFakeKBRepo()
+	repo.rows["src"] = &types.KnowledgeBase{
+		ID:       "src",
+		Name:     "Source KB",
+		Type:     types.KnowledgeBaseTypeDocument,
+		TenantID: 1,
+	}
+	svc := newPR3KBService(repo, &fakeRegistry{}, &fakeOwnership{})
+	ctx := context.WithValue(ctxWithTenant(1), types.LanguageContextKey, "en-US")
+
+	target, err := svc.DuplicateKnowledgeBase(ctx, "src")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Source KB Copy", target.Name)
 }

--- a/internal/application/service/knowledgebase_pr3_test.go
+++ b/internal/application/service/knowledgebase_pr3_test.go
@@ -95,8 +95,14 @@ func (r *fakeKBRepo) GetKnowledgeBaseByIDs(_ context.Context, _ []string) ([]*ty
 func (r *fakeKBRepo) ListKnowledgeBases(_ context.Context) ([]*types.KnowledgeBase, error) {
 	return nil, nil
 }
-func (r *fakeKBRepo) ListKnowledgeBasesByTenantID(_ context.Context, _ uint64) ([]*types.KnowledgeBase, error) {
-	return nil, nil
+func (r *fakeKBRepo) ListKnowledgeBasesByTenantID(_ context.Context, tenantID uint64) ([]*types.KnowledgeBase, error) {
+	rows := make([]*types.KnowledgeBase, 0, len(r.rows))
+	for _, kb := range r.rows {
+		if kb != nil && kb.TenantID == tenantID {
+			rows = append(rows, kb)
+		}
+	}
+	return rows, nil
 }
 func (r *fakeKBRepo) UpdateKnowledgeBase(_ context.Context, _ *types.KnowledgeBase) error {
 	return nil
@@ -364,4 +370,113 @@ func TestCopyKnowledgeBase_Defenses(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "different vector stores")
 	})
+}
+
+func TestDuplicateKnowledgeBase_CreatesSettingsOnlyDuplicate(t *testing.T) {
+	repo := newFakeKBRepo()
+	source := &types.KnowledgeBase{
+		ID:          "src",
+		Name:        "Source KB",
+		Type:        types.KnowledgeBaseTypeDocument,
+		Description: "source description",
+		TenantID:    1,
+		CreatorID:   "source-owner",
+		IsTemporary: true,
+		ChunkingConfig: types.ChunkingConfig{
+			ChunkSize:    800,
+			ChunkOverlap: 80,
+			Separators:   []string{"\n\n", "."},
+			ParserEngineRules: []types.ParserEngineRule{{
+				FileTypes: []string{"pdf"},
+				Engine:    "docreader",
+			}},
+		},
+		ImageProcessingConfig: types.ImageProcessingConfig{ModelID: "vlm-image"},
+		EmbeddingModelID:      "embed-1",
+		SummaryModelID:        "summary-1",
+		VLMConfig:             types.VLMConfig{Enabled: true, ModelID: "vlm-1"},
+		ASRConfig:             types.ASRConfig{Enabled: true, ModelID: "asr-1", Language: "zh"},
+		StorageProviderConfig: &types.StorageProviderConfig{Provider: "local"},
+		ExtractConfig: &types.ExtractConfig{
+			Enabled: true,
+			Text:    "extract entities",
+			Tags:    []string{"product"},
+			Nodes:   []*types.GraphNode{{Name: "Product"}},
+		},
+		QuestionGenerationConfig: &types.QuestionGenerationConfig{Enabled: true, QuestionCount: 5},
+		WikiConfig:               &types.WikiConfig{SynthesisModelID: "wiki-llm", MaxPagesPerIngest: 12},
+		IndexingStrategy: types.IndexingStrategy{
+			VectorEnabled:  true,
+			KeywordEnabled: true,
+			WikiEnabled:    true,
+			GraphEnabled:   true,
+		},
+		IsPinned:        true,
+		KnowledgeCount:  9,
+		ChunkCount:      27,
+		IsProcessing:    true,
+		ProcessingCount: 2,
+		ShareCount:      3,
+		CreatorName:     "Source Owner",
+	}
+	repo.rows["src"] = source
+	svc := newPR3KBService(repo, &fakeRegistry{}, &fakeOwnership{})
+	ctx := context.WithValue(ctxWithTenant(1), types.UserIDContextKey, "copy-user")
+
+	target, err := svc.DuplicateKnowledgeBase(ctx, "src", "copy-id")
+	require.NoError(t, err)
+
+	require.Equal(t, "copy-id", target.ID)
+	assert.Equal(t, uint64(1), target.TenantID)
+	assert.Equal(t, "copy-user", target.CreatorID)
+	assert.Equal(t, "Source KB 副本", target.Name)
+	assert.Equal(t, source.Description, target.Description)
+	assert.Equal(t, source.ChunkingConfig, target.ChunkingConfig)
+	assert.Equal(t, source.ImageProcessingConfig, target.ImageProcessingConfig)
+	assert.Equal(t, source.EmbeddingModelID, target.EmbeddingModelID)
+	assert.Equal(t, source.SummaryModelID, target.SummaryModelID)
+	assert.Equal(t, source.VLMConfig, target.VLMConfig)
+	assert.Equal(t, source.ASRConfig, target.ASRConfig)
+	require.NotNil(t, target.StorageProviderConfig)
+	assert.Equal(t, "local", target.StorageProviderConfig.Provider)
+	require.NotNil(t, target.ExtractConfig)
+	assert.Equal(t, source.ExtractConfig.Text, target.ExtractConfig.Text)
+	require.NotNil(t, target.QuestionGenerationConfig)
+	assert.Equal(t, 5, target.QuestionGenerationConfig.QuestionCount)
+	require.NotNil(t, target.WikiConfig)
+	assert.Equal(t, "wiki-llm", target.WikiConfig.SynthesisModelID)
+	assert.Equal(t, source.IndexingStrategy, target.IndexingStrategy)
+
+	assert.False(t, target.IsTemporary)
+	assert.False(t, target.IsPinned)
+	assert.Nil(t, target.PinnedAt)
+	assert.Zero(t, target.KnowledgeCount)
+	assert.Zero(t, target.ChunkCount)
+	assert.False(t, target.IsProcessing)
+	assert.Zero(t, target.ProcessingCount)
+	assert.Zero(t, target.ShareCount)
+	assert.Empty(t, target.CreatorName)
+	require.Same(t, target, repo.rows["copy-id"])
+}
+
+func TestDuplicateKnowledgeBase_UsesDistinctNameWhenDuplicateExists(t *testing.T) {
+	repo := newFakeKBRepo()
+	repo.rows["src"] = &types.KnowledgeBase{
+		ID:       "src",
+		Name:     "Source KB",
+		Type:     types.KnowledgeBaseTypeDocument,
+		TenantID: 1,
+	}
+	repo.rows["existing-copy"] = &types.KnowledgeBase{
+		ID:       "existing-copy",
+		Name:     "Source KB 副本",
+		Type:     types.KnowledgeBaseTypeDocument,
+		TenantID: 1,
+	}
+	svc := newPR3KBService(repo, &fakeRegistry{}, &fakeOwnership{})
+
+	target, err := svc.DuplicateKnowledgeBase(ctxWithTenant(1), "src", "copy-id")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Source KB 副本 2", target.Name)
 }

--- a/internal/handler/knowledgebase.go
+++ b/internal/handler/knowledgebase.go
@@ -936,6 +936,17 @@ type CopyKnowledgeBaseResponse struct {
 	Message  string `json:"message"`
 }
 
+type DuplicateKnowledgeBaseRequest struct {
+	TargetID string `json:"target_id"`
+}
+
+type DuplicateKnowledgeBaseResponse struct {
+	SourceID      string      `json:"source_id"`
+	TargetID      string      `json:"target_id"`
+	Message       string      `json:"message"`
+	KnowledgeBase interface{} `json:"knowledge_base"`
+}
+
 // CopyKnowledgeBase godoc
 // @Summary      复制知识库
 // @Description  将一个知识库的内容复制到另一个知识库（异步任务）
@@ -1110,6 +1121,80 @@ func (h *KnowledgeBaseHandler) CopyKnowledgeBase(c *gin.Context) {
 			SourceID: req.SourceID,
 			TargetID: req.TargetID,
 			Message:  "Knowledge base copy task started",
+		},
+	})
+}
+
+// DuplicateKnowledgeBase godoc
+// @Summary      创建知识库副本
+// @Description  创建一个只包含设置的新知识库副本，不复制知识、FAQ 内容、分块、索引、Wiki 页面、分享或置顶状态
+// @Tags         知识库
+// @Accept       json
+// @Produce      json
+// @Param        id       path      string                         true   "源知识库 ID"
+// @Param        request  body      DuplicateKnowledgeBaseRequest  false  "创建副本请求"
+// @Success      201      {object}  map[string]interface{}         "创建后的知识库副本"
+// @Failure      400      {object}  errors.AppError                 "请求参数错误"
+// @Security     Bearer
+// @Router       /knowledge-bases/{id}/duplicate [post]
+func (h *KnowledgeBaseHandler) DuplicateKnowledgeBase(c *gin.Context) {
+	ctx := c.Request.Context()
+	sourceID := c.Param("id")
+	if sourceID == "" {
+		c.Error(apperrors.NewBadRequestError("Knowledge base ID cannot be empty"))
+		return
+	}
+	var req DuplicateKnowledgeBaseRequest
+	if c.Request.Body != nil && c.Request.ContentLength != 0 {
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.Error(apperrors.NewBadRequestError("Invalid request parameters").WithDetails(err.Error()))
+			return
+		}
+	}
+
+	callerTenantID := c.GetUint64(types.TenantIDContextKey.String())
+	sourceKB, err := h.service.GetKnowledgeBaseByID(ctx, sourceID)
+	if err != nil {
+		if stderrors.Is(err, repository.ErrKnowledgeBaseNotFound) {
+			c.Error(errors.NewNotFoundError("Source knowledge base not found"))
+			return
+		}
+		logger.ErrorWithFields(ctx, err, nil)
+		c.Error(errors.NewInternalServerError(err.Error()))
+		return
+	}
+	if sourceKB.TenantID != callerTenantID {
+		logger.Warnf(ctx,
+			"Knowledge base duplicate rejected: source belongs to another tenant, source_id: %s, caller_tenant: %d, kb_tenant: %d",
+			secutils.SanitizeForLog(sourceID), callerTenantID, sourceKB.TenantID)
+		c.Error(errors.NewForbiddenError("No permission to duplicate this knowledge base"))
+		return
+	}
+
+	targetKB, err := h.service.DuplicateKnowledgeBase(ctx, sourceID, req.TargetID)
+	if err != nil {
+		if appErr, ok := apperrors.IsAppError(err); ok {
+			c.Error(appErr)
+			return
+		}
+		if stderrors.Is(err, repository.ErrKnowledgeBaseNotFound) {
+			c.Error(errors.NewNotFoundError("Source knowledge base not found"))
+			return
+		}
+		logger.ErrorWithFields(ctx, err, nil)
+		c.Error(errors.NewInternalServerError(err.Error()))
+		return
+	}
+
+	logger.Infof(ctx, "Knowledge base duplicate created, source: %s, target: %s",
+		secutils.SanitizeForLog(sourceID), secutils.SanitizeForLog(targetKB.ID))
+	c.JSON(http.StatusCreated, gin.H{
+		"success": true,
+		"data": DuplicateKnowledgeBaseResponse{
+			SourceID:      sourceID,
+			TargetID:      targetKB.ID,
+			Message:       "Knowledge base duplicate created",
+			KnowledgeBase: buildKBResponse(targetKB, h.resolveKBStoreView(ctx, targetKB, callerTenantID), nil),
 		},
 	})
 }

--- a/internal/handler/knowledgebase.go
+++ b/internal/handler/knowledgebase.go
@@ -936,10 +936,6 @@ type CopyKnowledgeBaseResponse struct {
 	Message  string `json:"message"`
 }
 
-type DuplicateKnowledgeBaseRequest struct {
-	TargetID string `json:"target_id"`
-}
-
 type DuplicateKnowledgeBaseResponse struct {
 	SourceID      string      `json:"source_id"`
 	TargetID      string      `json:"target_id"`
@@ -1131,9 +1127,8 @@ func (h *KnowledgeBaseHandler) CopyKnowledgeBase(c *gin.Context) {
 // @Tags         知识库
 // @Accept       json
 // @Produce      json
-// @Param        id       path      string                         true   "源知识库 ID"
-// @Param        request  body      DuplicateKnowledgeBaseRequest  false  "创建副本请求"
-// @Success      201      {object}  map[string]interface{}         "创建后的知识库副本"
+// @Param        id       path      string                  true  "源知识库 ID"
+// @Success      201      {object}  map[string]interface{}  "创建后的知识库副本"
 // @Failure      400      {object}  errors.AppError                 "请求参数错误"
 // @Security     Bearer
 // @Router       /knowledge-bases/{id}/duplicate [post]
@@ -1143,13 +1138,6 @@ func (h *KnowledgeBaseHandler) DuplicateKnowledgeBase(c *gin.Context) {
 	if sourceID == "" {
 		c.Error(apperrors.NewBadRequestError("Knowledge base ID cannot be empty"))
 		return
-	}
-	var req DuplicateKnowledgeBaseRequest
-	if c.Request.Body != nil && c.Request.ContentLength != 0 {
-		if err := c.ShouldBindJSON(&req); err != nil {
-			c.Error(apperrors.NewBadRequestError("Invalid request parameters").WithDetails(err.Error()))
-			return
-		}
 	}
 
 	callerTenantID := c.GetUint64(types.TenantIDContextKey.String())
@@ -1171,7 +1159,7 @@ func (h *KnowledgeBaseHandler) DuplicateKnowledgeBase(c *gin.Context) {
 		return
 	}
 
-	targetKB, err := h.service.DuplicateKnowledgeBase(ctx, sourceID, req.TargetID)
+	targetKB, err := h.service.DuplicateKnowledgeBase(ctx, sourceID)
 	if err != nil {
 		if appErr, ok := apperrors.IsAppError(err); ok {
 			c.Error(appErr)

--- a/internal/handler/knowledgebase_copy_preflight_test.go
+++ b/internal/handler/knowledgebase_copy_preflight_test.go
@@ -9,50 +9,32 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	apperrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/middleware"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 )
 
-// handler.CopyKnowledgeBase pre-flight tests.
-//
-// The async clone worker (service.CopyKnowledgeBase) re-applies the same
-// embedding-model and store-binding defenses as defense in depth, but the
-// handler-level pre-flight is the one that surfaces 400 to the API caller
-// synchronously instead of inside Asynq progress polling. These tests pin
-// the synchronous behavior so a future refactor that drops the pre-flight
-// fails loudly here rather than silently degrading UX.
-
-// stubKBCopyService provides only the two methods the Copy handler reaches
-// for (GetKnowledgeBaseByID twice). Other interface methods stay nil so any
-// accidental new call panics rather than silently succeeding.
+// stubKBCopyService provides only the methods the duplicate handler reaches.
+// Other interface methods stay embedded so accidental new calls panic in tests.
 type stubKBCopyService struct {
 	interfaces.KnowledgeBaseService
-	byID func(ctx context.Context, id string) (*types.KnowledgeBase, error)
+	byID      func(ctx context.Context, id string) (*types.KnowledgeBase, error)
+	duplicate func(ctx context.Context, sourceID, targetID string) (*types.KnowledgeBase, error)
 }
 
 func (s *stubKBCopyService) GetKnowledgeBaseByID(ctx context.Context, id string) (*types.KnowledgeBase, error) {
 	return s.byID(ctx, id)
 }
 
-// stubEnqueuer records whether Enqueue was invoked. The whole point of the
-// pre-flight is to short-circuit *before* enqueue, so the test fails if
-// enqueue ran for a mismatched clone.
-type stubEnqueuer struct {
-	calls int
+func (s *stubKBCopyService) DuplicateKnowledgeBase(
+	ctx context.Context,
+	sourceID string,
+	targetID string,
+) (*types.KnowledgeBase, error) {
+	return s.duplicate(ctx, sourceID, targetID)
 }
 
-func (s *stubEnqueuer) Enqueue(_ interface{}, _ ...interface{}) (*stubEnqueueInfo, error) {
-	s.calls++
-	return &stubEnqueueInfo{ID: "x"}, nil
-}
-
-// stubEnqueueInfo is a stand-in for asynq.TaskInfo so the test does not need
-// to construct one.
-type stubEnqueueInfo struct{ ID string }
-
-func newCopyPreflightRouter(svc interfaces.KnowledgeBaseService) (*gin.Engine, *stubEnqueuer) {
+func newDuplicateRouter(svc interfaces.KnowledgeBaseService) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	r.Use(middleware.ErrorHandler())
@@ -61,120 +43,75 @@ func newCopyPreflightRouter(svc interfaces.KnowledgeBaseService) (*gin.Engine, *
 		c.Set(types.UserIDContextKey.String(), "u-test")
 		c.Next()
 	})
-	enq := &stubEnqueuer{}
-	// The real handler reaches into h.asynqClient.Enqueue with the asynq
-	// task type. We do not exercise the enqueue path in these tests — every
-	// case here either short-circuits at pre-flight or returns 4xx earlier.
-	// Leaving asynqClient nil would panic if enqueue ran, which is exactly
-	// the regression we want to catch.
 	h := &KnowledgeBaseHandler{service: svc}
-	r.POST("/knowledge-bases/copy", h.CopyKnowledgeBase)
-	return r, enq
+	r.POST("/knowledge-bases/:id/duplicate", h.DuplicateKnowledgeBase)
+	return r
 }
 
-func storeIDPtr(s string) *string { return &s }
-
-func TestCopyHandlerPreflight_DifferentEmbeddingModel(t *testing.T) {
+func TestDuplicateHandler_ReturnsCreatedKnowledgeBase(t *testing.T) {
+	var gotSourceID, gotTargetID string
 	svc := &stubKBCopyService{
 		byID: func(_ context.Context, id string) (*types.KnowledgeBase, error) {
-			switch id {
-			case "src":
-				return &types.KnowledgeBase{
-					ID: "src", TenantID: 1, EmbeddingModelID: "embed-A",
-				}, nil
-			case "dst":
-				return &types.KnowledgeBase{
-					ID: "dst", TenantID: 1, EmbeddingModelID: "embed-B",
-				}, nil
+			if id != "src" {
+				t.Fatalf("handler should only load the source KB, got id=%s", id)
 			}
-			return nil, nil
+			return &types.KnowledgeBase{ID: "src", TenantID: 1, Name: "Source"}, nil
+		},
+		duplicate: func(_ context.Context, sourceID, targetID string) (*types.KnowledgeBase, error) {
+			gotSourceID, gotTargetID = sourceID, targetID
+			return &types.KnowledgeBase{
+				ID:        "copy-id",
+				TenantID:  1,
+				Name:      "Source",
+				CreatorID: "u-test",
+			}, nil
 		},
 	}
-	r, _ := newCopyPreflightRouter(svc)
+	r := newDuplicateRouter(svc)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/knowledge-bases/copy",
-		strings.NewReader(`{"source_id":"src","target_id":"dst"}`))
+	req := httptest.NewRequest(http.MethodPost, "/knowledge-bases/src/duplicate",
+		strings.NewReader(`{"target_id":"copy-id"}`))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for embedding-model mismatch, got %d body=%s", w.Code, w.Body.String())
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for duplicate, got %d body=%s", w.Code, w.Body.String())
 	}
-	if !strings.Contains(w.Body.String(), "different embedding models") {
-		t.Fatalf("expected embedding-model error message, got %s", w.Body.String())
+	if gotSourceID != "src" || gotTargetID != "copy-id" {
+		t.Fatalf("duplicate service called with source=%q target=%q", gotSourceID, gotTargetID)
+	}
+	body := w.Body.String()
+	for _, want := range []string{`"source_id":"src"`, `"target_id":"copy-id"`, `"knowledge_base"`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("response missing %s: %s", want, body)
+		}
 	}
 }
 
-func TestCopyHandlerPreflight_DifferentVectorStore(t *testing.T) {
+func TestDuplicateHandler_RejectsCrossTenantSource(t *testing.T) {
+	calledDuplicate := false
 	svc := &stubKBCopyService{
 		byID: func(_ context.Context, id string) (*types.KnowledgeBase, error) {
-			switch id {
-			case "src":
-				return &types.KnowledgeBase{
-					ID: "src", TenantID: 1, EmbeddingModelID: "embed-A",
-					VectorStoreID: storeIDPtr("store-A"),
-				}, nil
-			case "dst":
-				return &types.KnowledgeBase{
-					ID: "dst", TenantID: 1, EmbeddingModelID: "embed-A",
-					VectorStoreID: storeIDPtr("store-B"),
-				}, nil
-			}
+			return &types.KnowledgeBase{ID: id, TenantID: 2, Name: "Shared"}, nil
+		},
+		duplicate: func(_ context.Context, _, _ string) (*types.KnowledgeBase, error) {
+			calledDuplicate = true
 			return nil, nil
 		},
 	}
-	r, _ := newCopyPreflightRouter(svc)
+	r := newDuplicateRouter(svc)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/knowledge-bases/copy",
-		strings.NewReader(`{"source_id":"src","target_id":"dst"}`))
+	req := httptest.NewRequest(http.MethodPost, "/knowledge-bases/src/duplicate",
+		strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for store mismatch, got %d body=%s", w.Code, w.Body.String())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for cross-tenant source, got %d body=%s", w.Code, w.Body.String())
 	}
-	if !strings.Contains(w.Body.String(), "different vector stores") {
-		t.Fatalf("expected store-mismatch error message, got %s", w.Body.String())
-	}
-	if strings.Contains(w.Body.String(), "Phase 4") {
-		t.Fatalf("error message must not leak internal roadmap labels: %s", w.Body.String())
+	if calledDuplicate {
+		t.Fatal("duplicate service must not be called when source KB is outside the caller tenant")
 	}
 }
-
-func TestCopyHandlerPreflight_OneSideNilStore(t *testing.T) {
-	svc := &stubKBCopyService{
-		byID: func(_ context.Context, id string) (*types.KnowledgeBase, error) {
-			switch id {
-			case "src":
-				return &types.KnowledgeBase{
-					ID: "src", TenantID: 1, EmbeddingModelID: "embed-A",
-					VectorStoreID: nil,
-				}, nil
-			case "dst":
-				return &types.KnowledgeBase{
-					ID: "dst", TenantID: 1, EmbeddingModelID: "embed-A",
-					VectorStoreID: storeIDPtr("store-A"),
-				}, nil
-			}
-			return nil, nil
-		},
-	}
-	r, _ := newCopyPreflightRouter(svc)
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/knowledge-bases/copy",
-		strings.NewReader(`{"source_id":"src","target_id":"dst"}`))
-	req.Header.Set("Content-Type", "application/json")
-	r.ServeHTTP(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 when one side is env-store and the other is DB-store, got %d body=%s",
-			w.Code, w.Body.String())
-	}
-}
-
-// compile-time guard against accidentally dropping the apperrors import
-// from the file — if the pre-flight refactor goes away, this fails too.
-var _ = apperrors.NewBadRequestError

--- a/internal/handler/knowledgebase_copy_preflight_test.go
+++ b/internal/handler/knowledgebase_copy_preflight_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,6 +10,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	apperrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/middleware"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
@@ -19,7 +22,7 @@ import (
 type stubKBCopyService struct {
 	interfaces.KnowledgeBaseService
 	byID      func(ctx context.Context, id string) (*types.KnowledgeBase, error)
-	duplicate func(ctx context.Context, sourceID, targetID string) (*types.KnowledgeBase, error)
+	duplicate func(ctx context.Context, sourceID string) (*types.KnowledgeBase, error)
 }
 
 func (s *stubKBCopyService) GetKnowledgeBaseByID(ctx context.Context, id string) (*types.KnowledgeBase, error) {
@@ -29,9 +32,8 @@ func (s *stubKBCopyService) GetKnowledgeBaseByID(ctx context.Context, id string)
 func (s *stubKBCopyService) DuplicateKnowledgeBase(
 	ctx context.Context,
 	sourceID string,
-	targetID string,
 ) (*types.KnowledgeBase, error) {
-	return s.duplicate(ctx, sourceID, targetID)
+	return s.duplicate(ctx, sourceID)
 }
 
 func newDuplicateRouter(svc interfaces.KnowledgeBaseService) *gin.Engine {
@@ -49,7 +51,7 @@ func newDuplicateRouter(svc interfaces.KnowledgeBaseService) *gin.Engine {
 }
 
 func TestDuplicateHandler_ReturnsCreatedKnowledgeBase(t *testing.T) {
-	var gotSourceID, gotTargetID string
+	var gotSourceID string
 	svc := &stubKBCopyService{
 		byID: func(_ context.Context, id string) (*types.KnowledgeBase, error) {
 			if id != "src" {
@@ -57,12 +59,12 @@ func TestDuplicateHandler_ReturnsCreatedKnowledgeBase(t *testing.T) {
 			}
 			return &types.KnowledgeBase{ID: "src", TenantID: 1, Name: "Source"}, nil
 		},
-		duplicate: func(_ context.Context, sourceID, targetID string) (*types.KnowledgeBase, error) {
-			gotSourceID, gotTargetID = sourceID, targetID
+		duplicate: func(_ context.Context, sourceID string) (*types.KnowledgeBase, error) {
+			gotSourceID = sourceID
 			return &types.KnowledgeBase{
 				ID:        "copy-id",
 				TenantID:  1,
-				Name:      "Source",
+				Name:      "Source Copy",
 				CreatorID: "u-test",
 			}, nil
 		},
@@ -70,16 +72,14 @@ func TestDuplicateHandler_ReturnsCreatedKnowledgeBase(t *testing.T) {
 	r := newDuplicateRouter(svc)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/knowledge-bases/src/duplicate",
-		strings.NewReader(`{"target_id":"copy-id"}`))
-	req.Header.Set("Content-Type", "application/json")
+	req := httptest.NewRequest(http.MethodPost, "/knowledge-bases/src/duplicate", nil)
 	r.ServeHTTP(w, req)
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201 for duplicate, got %d body=%s", w.Code, w.Body.String())
 	}
-	if gotSourceID != "src" || gotTargetID != "copy-id" {
-		t.Fatalf("duplicate service called with source=%q target=%q", gotSourceID, gotTargetID)
+	if gotSourceID != "src" {
+		t.Fatalf("duplicate service called with source=%q", gotSourceID)
 	}
 	body := w.Body.String()
 	for _, want := range []string{`"source_id":"src"`, `"target_id":"copy-id"`, `"knowledge_base"`} {
@@ -95,7 +95,7 @@ func TestDuplicateHandler_RejectsCrossTenantSource(t *testing.T) {
 		byID: func(_ context.Context, id string) (*types.KnowledgeBase, error) {
 			return &types.KnowledgeBase{ID: id, TenantID: 2, Name: "Shared"}, nil
 		},
-		duplicate: func(_ context.Context, _, _ string) (*types.KnowledgeBase, error) {
+		duplicate: func(_ context.Context, _ string) (*types.KnowledgeBase, error) {
 			calledDuplicate = true
 			return nil, nil
 		},
@@ -103,9 +103,7 @@ func TestDuplicateHandler_RejectsCrossTenantSource(t *testing.T) {
 	r := newDuplicateRouter(svc)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/knowledge-bases/src/duplicate",
-		strings.NewReader(`{}`))
-	req.Header.Set("Content-Type", "application/json")
+	req := httptest.NewRequest(http.MethodPost, "/knowledge-bases/src/duplicate", nil)
 	r.ServeHTTP(w, req)
 
 	if w.Code != http.StatusForbidden {
@@ -113,5 +111,73 @@ func TestDuplicateHandler_RejectsCrossTenantSource(t *testing.T) {
 	}
 	if calledDuplicate {
 		t.Fatal("duplicate service must not be called when source KB is outside the caller tenant")
+	}
+}
+
+func TestDuplicateHandler_SourceNotFound(t *testing.T) {
+	calledDuplicate := false
+	svc := &stubKBCopyService{
+		byID: func(_ context.Context, _ string) (*types.KnowledgeBase, error) {
+			return nil, repository.ErrKnowledgeBaseNotFound
+		},
+		duplicate: func(_ context.Context, _ string) (*types.KnowledgeBase, error) {
+			calledDuplicate = true
+			return nil, nil
+		},
+	}
+	r := newDuplicateRouter(svc)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/knowledge-bases/missing/duplicate", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing source, got %d body=%s", w.Code, w.Body.String())
+	}
+	if calledDuplicate {
+		t.Fatal("duplicate service must not be called when source KB is missing")
+	}
+}
+
+func TestDuplicateHandler_PropagatesServiceAppError(t *testing.T) {
+	svc := &stubKBCopyService{
+		byID: func(_ context.Context, _ string) (*types.KnowledgeBase, error) {
+			return &types.KnowledgeBase{ID: "src", TenantID: 1, Name: "Source"}, nil
+		},
+		duplicate: func(_ context.Context, _ string) (*types.KnowledgeBase, error) {
+			return nil, apperrors.NewBadRequestError("invalid vector store binding")
+		},
+	}
+	r := newDuplicateRouter(svc)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/knowledge-bases/src/duplicate", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for service app error, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "invalid vector store binding") {
+		t.Fatalf("expected service error message in body: %s", w.Body.String())
+	}
+}
+
+func TestDuplicateHandler_ServiceUnexpectedError(t *testing.T) {
+	svc := &stubKBCopyService{
+		byID: func(_ context.Context, _ string) (*types.KnowledgeBase, error) {
+			return &types.KnowledgeBase{ID: "src", TenantID: 1, Name: "Source"}, nil
+		},
+		duplicate: func(_ context.Context, _ string) (*types.KnowledgeBase, error) {
+			return nil, errors.New("database unavailable")
+		},
+	}
+	r := newDuplicateRouter(svc)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/knowledge-bases/src/duplicate", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for unexpected service error, got %d body=%s", w.Code, w.Body.String())
 	}
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -428,6 +428,8 @@ func RegisterKnowledgeBaseRoutes(r *gin.RouterGroup, handler *handler.KnowledgeB
 		kb.GET("/:id/hybrid-search", g.Viewer(), g.KBAccessRead("id"), handler.HybridSearch)
 		// 拷贝知识库 — Contributor+ (副本归调用者所有；不需要原 KB 的所有权)
 		kbgrp.POST("/copy", g.Contributor(), handler.CopyKnowledgeBase)
+		// 创建知识库副本 — Contributor+ 且对源 KB 有 read 权限；只创建新的 KB 设置记录，不复制内容/索引/分享。
+		kbgrp.POST("/:id/duplicate", g.Contributor(), g.KBAccessRead("id"), handler.DuplicateKnowledgeBase)
 		// 获取知识库复制进度 — Viewer+
 		kb.GET("/copy/progress/:task_id", g.Viewer(), handler.GetKBCloneProgress)
 		// 获取可移动目标知识库列表 — Viewer+ 且对 KB 有 read 权限

--- a/internal/router/router_api_key_capabilities_test.go
+++ b/internal/router/router_api_key_capabilities_test.go
@@ -179,7 +179,7 @@ func TestKnowledgeBaseManagementRoutesDeclareManageKBsCapability(t *testing.T) {
 	}
 }
 
-func TestKnowledgeBaseCreateAndCopyRemainDefaultDenyForAPIKeys(t *testing.T) {
+func TestKnowledgeBaseCreateAndCopyRoutesRemainDefaultDenyForAPIKeys(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	g := &rbacGuards{}
 	v1 := gin.New().Group("/api/v1")
@@ -192,6 +192,7 @@ func TestKnowledgeBaseCreateAndCopyRemainDefaultDenyForAPIKeys(t *testing.T) {
 	}{
 		{http.MethodPost, "/api/v1/knowledge-bases"},
 		{http.MethodPost, "/api/v1/knowledge-bases/copy"},
+		{http.MethodPost, "/api/v1/knowledge-bases/:id/duplicate"},
 	}
 
 	for _, tc := range cases {

--- a/internal/types/interfaces/knowledgebase.go
+++ b/internal/types/interfaces/knowledgebase.go
@@ -116,6 +116,12 @@ type KnowledgeBaseService interface {
 	//   - Possible errors such as not existing, insufficient permissions, etc.
 	CopyKnowledgeBase(ctx context.Context, src string, dst string) (*types.KnowledgeBase, *types.KnowledgeBase, error)
 
+	// DuplicateKnowledgeBase creates a new settings-only knowledge base duplicate.
+	// It does not copy knowledge entries, chunks, FAQ rows, wiki pages, indexes,
+	// data sources, shares, pins, or task state. targetID is optional; when empty
+	// a new UUID is generated.
+	DuplicateKnowledgeBase(ctx context.Context, src string, targetID string) (*types.KnowledgeBase, error)
+
 	// GetRepository gets the knowledge base repository
 	// Parameters:
 	//   - ctx: Context with authentication and request information

--- a/internal/types/interfaces/knowledgebase.go
+++ b/internal/types/interfaces/knowledgebase.go
@@ -118,9 +118,8 @@ type KnowledgeBaseService interface {
 
 	// DuplicateKnowledgeBase creates a new settings-only knowledge base duplicate.
 	// It does not copy knowledge entries, chunks, FAQ rows, wiki pages, indexes,
-	// data sources, shares, pins, or task state. targetID is optional; when empty
-	// a new UUID is generated.
-	DuplicateKnowledgeBase(ctx context.Context, src string, targetID string) (*types.KnowledgeBase, error)
+	// data sources, shares, pins, or task state. A new UUID is always generated.
+	DuplicateKnowledgeBase(ctx context.Context, src string) (*types.KnowledgeBase, error)
 
 	// GetRepository gets the knowledge base repository
 	// Parameters:


### PR DESCRIPTION
## Summary

- Add a new settings-only knowledge base duplicate API at `POST /api/v1/knowledge-bases/:id/duplicate` while preserving the existing async `/knowledge-bases/copy` semantics.
- Reset content/runtime state on duplicates and generate distinguishable names such as `原名 副本` and `原名 副本 2`.
- Add SDK and knowledge list UI support with localized menu and status messages.

## Validation

- `go test ./internal/application/service ./internal/handler ./internal/router ./internal/agent/tools`
- `cd client && go test ./...`
- `cd frontend && npm run type-check`
- `cd frontend && npm test`
- `git diff --check`