### PR TITLE
feat(frontend): support configurable base path for subpath deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,6 +192,14 @@ APP_PORT=8080
 # 前端服务端口，默认为80
 FRONTEND_PORT=80
 
+# ========== WeKnora 访问基准路径（子路径部署配置，可选） ==========
+# 用于支持在单 IP + 单端口下通过子路径（如 http://IP:6000/weknora/）分发多个系统。
+# 默认留空，系统将运行在根路径 (/)。
+# 推荐格式：/weknora
+# 兼容格式：/weknora, /weknora/, weknora，系统会自动规范化并校验为 /weknora
+# 注意：此配置在构建前端镜像时作为环境变量传入（构建期），并在容器启动时动态生成 Nginx 路由（运行期）。
+WEKNORA_BASE_PATH=
+
 # 文档解析模块端口，默认为50051
 DOCREADER_PORT=50051
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       # For remote deployment, set this to the remote App's service port.
       - APP_PORT=${APP_BACKEND_PORT:-8080}
       - APP_SCHEME=${APP_SCHEME:-http}
+      - WEKNORA_BASE_PATH=${WEKNORA_BASE_PATH:-}
     # NOTE: If using a remote App backend, comment out or remove the depends_on
     # block below and set APP_HOST/APP_BACKEND_PORT/APP_SCHEME in your .env file.
     depends_on:

--- a/docs/subpath-deployment.md
+++ b/docs/subpath-deployment.md
@@ -1,0 +1,71 @@
+# WeKnora 子路径部署指南 (Sub-path Deployment Guide)
+
+在很多内网、政企或特定离线网关部署环境中，由于没有域名分发能力，多个内部子系统往往需要共享同一个外网 IP 和同一个入口端口（例如 `6000` 端口），并采用不同的子路径进行转发分发：
+* `http://IP:6000/weknora/` -> WeKnora 系统
+* `http://IP:6000/system1/` -> 外部子系统 1
+
+本指南为您说明如何利用 `WEKNORA_BASE_PATH` 环境变量一键完成 WeKnora 的子路径化部署。
+
+---
+
+## 1. 部署配置流程
+
+### 第一步：修改配置文件 (`.env`)
+在 WeKnora 项目根目录的 `.env` 中加入子路径与暴露端口配置：
+
+```env
+# 统一网关分配给 WeKnora 的前缀子路径
+WEKNORA_BASE_PATH=/weknora
+# 前端服务暴露端口，可按需修改避免冲突
+FRONTEND_PORT=8091
+```
+
+### 第二步：编译与重建容器
+由于前端代码的基地址（Vite base）必须在编译时注入（构建期依赖），修改 `WEKNORA_BASE_PATH` 后**必须重新构建前端镜像**：
+
+```bash
+# 1. 重新编译前端静态资源并构建前端 UI 镜像
+./scripts/build_images.sh -f
+
+# 2. 重建并重启前端容器，使之加载应用最新生成的静态文件
+docker compose up -d --no-deps --force-recreate frontend
+```
+
+---
+
+## 2. 入口 Nginx 反向代理配置
+
+在外层只暴露 `6000` 端口的统一入口 Nginx 上，增加如下配置对 WeKnora 流量进行分发：
+
+> **⚠️ 重要事项**：外部 Nginx 的 `proxy_pass` 目标代理地址末尾**必须带上 `/weknora/` 后缀**。转发请求时**千万不要剥离** `/weknora/` 路径前缀，必须将其完整透传发送给 WeKnora 前端容器。
+
+```nginx
+server {
+    listen 6000;
+    client_max_body_size 100M;
+
+    # 对输入地址不带斜杠的 /weknora 进行 301 重定向，保证浏览器能正确加载到子路径下的静态文件
+    location = /weknora {
+        return 301 /weknora/;
+    }
+
+    # 完整透传反向代理，不要剥离 /weknora/ 前缀
+    location /weknora/ {
+        proxy_pass http://127.0.0.1:8091/weknora/;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSockets 和 SSE 大模型流式输出（打字机效果）的必须配置
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        chunked_transfer_encoding off;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+}
+```

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,4 +1,31 @@
 #!/bin/sh
+set -e
+
+normalize_base_path() {
+  p="${1:-}"
+  p="$(echo "$p" | sed 's#^/*##; s#/*$##')"
+  if [ -z "$p" ]; then
+    echo ""
+  else
+    echo "/$p"
+  fi
+}
+
+export WEKNORA_BASE_PATH="$(normalize_base_path "${WEKNORA_BASE_PATH:-}")"
+
+# 严格的路径安全正则校验
+if [ -n "$WEKNORA_BASE_PATH" ] && ! echo "$WEKNORA_BASE_PATH" | grep -Eq '^(/[A-Za-z0-9._~-]+)+$'; then
+  echo "[ERROR] Invalid WEKNORA_BASE_PATH format: $WEKNORA_BASE_PATH"
+  echo "[ERROR] Allowed examples: /weknora, /kb, /internal/weknora"
+  exit 1
+fi
+
+# 动态产生不带斜杠的子路径 301 重定向语句
+if [ -n "$WEKNORA_BASE_PATH" ]; then
+  export WEKNORA_BASE_PATH_REDIRECT_BLOCK="location = ${WEKNORA_BASE_PATH} { return 301 ${WEKNORA_BASE_PATH}/; }"
+else
+  export WEKNORA_BASE_PATH_REDIRECT_BLOCK=""
+fi
 
 # 生成运行时配置文件，注入环境变量到前端
 cat > /usr/share/nginx/html/config.js << EOF
@@ -8,11 +35,18 @@ window.__RUNTIME_CONFIG__ = {
 EOF
 
 # 处理 nginx 配置
-export MAX_FILE_SIZE=${MAX_FILE_SIZE_MB}M
+export MAX_FILE_SIZE=${MAX_FILE_SIZE_MB:-50}M
 export APP_HOST=${APP_HOST:-app}
 export APP_PORT=${APP_PORT:-8080}
 export APP_SCHEME=${APP_SCHEME:-http}
-envsubst '${MAX_FILE_SIZE} ${APP_HOST} ${APP_PORT} ${APP_SCHEME}' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf
 
-# 启动 nginx
+envsubst '${MAX_FILE_SIZE} ${APP_HOST} ${APP_PORT} ${APP_SCHEME} ${WEKNORA_BASE_PATH} ${WEKNORA_BASE_PATH_REDIRECT_BLOCK}' \
+  < /etc/nginx/templates/default.conf.template \
+  > /etc/nginx/conf.d/default.conf
+
+# 如果提供了参数命令（如 nginx -t），则在写入配置后直接运行该命令并退出
+if [ "$#" -gt 0 ]; then
+  exec "$@"
+fi
+
 exec nginx -g 'daemon off;'

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -38,18 +38,21 @@ server {
     error_log /var/log/nginx/error.log warn;
     access_log /var/log/nginx/access.log;
 
+    # 动态插入不带斜杠的子路径重定向块
+    ${WEKNORA_BASE_PATH_REDIRECT_BLOCK}
+
     # Static widget loader for third-party sites
-    location = /weknora-widget.js {
-        root /usr/share/nginx/html;
+    location = ${WEKNORA_BASE_PATH}/weknora-widget.js {
+        alias /usr/share/nginx/html/weknora-widget.js;
         add_header Cache-Control "public, max-age=3600" always;
         add_header X-Content-Type-Options "nosniff" always;
     }
 
     # Internal fallback target for /embed/* routes. Keep it separate from the
     # main SPA location so embed pages do not inherit X-Frame-Options.
-    location = /embed.html {
+    location = ${WEKNORA_BASE_PATH}/embed.html {
         internal;
-        root /usr/share/nginx/html;
+        alias /usr/share/nginx/html/embed.html;
         add_header Cache-Control "no-cache, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
@@ -57,20 +60,25 @@ server {
     }
 
     # Embed widget pages may be loaded inside third-party iframes (lightweight embed.html)
-    location ^~ /embed/ {
-        root /usr/share/nginx/html;
-        try_files $uri $uri/ /embed.html;
+    location ^~ ${WEKNORA_BASE_PATH}/embed/ {
+        alias /usr/share/nginx/html/embed/;
+        try_files $uri $uri/ @embed_fallback;
         add_header Cache-Control "no-cache, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     }
 
-    # 前端静态文件
-    location / {
+    location @embed_fallback {
         root /usr/share/nginx/html;
+        rewrite ^ /embed.html break;
+    }
+
+    # 前端静态文件
+    location ${WEKNORA_BASE_PATH}/ {
+        alias /usr/share/nginx/html/;
         index index.html;
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/ @spa_fallback;
 
         # index.html 及 SPA fallback 不可缓存，否则前端升级后用户看不到新版本
         add_header Cache-Control "no-cache, must-revalidate" always;
@@ -81,9 +89,14 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     }
 
-    # Vite 构建产物 /assets/* 带 hash 文件名，可长期缓存
-    location ^~ /assets/ {
+    location @spa_fallback {
         root /usr/share/nginx/html;
+        rewrite ^ /index.html break;
+    }
+
+    # Vite 构建产物 /assets/* 带 hash 文件名，可长期缓存
+    location ^~ ${WEKNORA_BASE_PATH}/assets/ {
+        alias /usr/share/nginx/html/assets/;
 
         add_header Cache-Control "public, max-age=31536000, immutable" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
@@ -94,7 +107,7 @@ server {
 
     # 本地存储文件代理到后端服务（用于渲染 markdown 中的图片）
     # 精确匹配 /files，避免 Nginx 自动补 / 触发 301
-    location = /files {
+    location = ${WEKNORA_BASE_PATH}/files {
         proxy_pass ${APP_SCHEME}://${APP_HOST}:${APP_PORT}/files;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -104,7 +117,7 @@ server {
 
     # API请求代理到后端服务
     # APP_SCHEME 默认 http，远程 HTTPS 后端可设为 https
-    location /api/ {
+    location ${WEKNORA_BASE_PATH}/api/ {
         proxy_pass ${APP_SCHEME}://${APP_HOST}:${APP_PORT}/api/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -129,7 +142,7 @@ server {
 
     # 错误页面
     error_page 500 502 503 504 /50x.html;
-    location = /50x.html {
-        root /usr/share/nginx/html;
+    location = ${WEKNORA_BASE_PATH}/50x.html {
+        alias /usr/share/nginx/html/50x.html;
     }
 }

--- a/frontend/src/api/embed/index.ts
+++ b/frontend/src/api/embed/index.ts
@@ -1,5 +1,6 @@
 import { get, post, put, del } from '@/utils/request'
 import { resolveEmbedBaseUrl } from '@/utils/embedBaseUrl'
+import { getFrontendBasePath } from '@/utils/base-path'
 
 export interface EmbedChannel {
   id: string
@@ -461,7 +462,9 @@ export function buildEmbedURL(
   opts?: { locale?: string; refreshKey?: number; baseUrl?: string },
 ) {
   const base = safeBaseUrl(opts?.baseUrl) || resolveEmbedBaseUrl()
-  let path = `${base}/embed/${encodeURIComponent(channelId)}`
+  const isSameOrigin = typeof window !== 'undefined' && base.startsWith(window.location.origin)
+  const basePath = isSameOrigin ? getFrontendBasePath() : ''
+  let path = `${base}${basePath}/embed/${encodeURIComponent(channelId)}`
   const params = new URLSearchParams()
   if (opts?.locale?.trim()) params.set('locale', opts.locale.trim())
   if (opts?.refreshKey) params.set('r', String(opts.refreshKey))
@@ -506,9 +509,11 @@ export function buildWidgetSnippet(
   opts?: { primaryColor?: string; title?: string; position?: WidgetPosition; baseUrl?: string },
 ) {
   const base = safeBaseUrl(opts?.baseUrl)
+  const isSameOrigin = typeof window !== 'undefined' && base.startsWith(window.location.origin)
+  const basePath = isSameOrigin ? getFrontendBasePath() : ''
   const position = opts?.position || 'bottom-right'
   const attrs = [
-    `src="${escapeHtmlAttr(`${base}/weknora-widget.js`)}"`,
+    `src="${escapeHtmlAttr(`${base}${basePath}/weknora-widget.js`)}"`,
     `data-channel="${escapeHtmlAttr(channelId)}"`,
     `data-token="${escapeHtmlAttr(token)}"`,
     `data-position="${escapeHtmlAttr(position)}"`,
@@ -532,10 +537,12 @@ export function buildSecureWidgetSnippet(
   opts?: { primaryColor?: string; title?: string; position?: WidgetPosition; baseUrl?: string; tokenEndpoint?: string },
 ) {
   const base = safeBaseUrl(opts?.baseUrl)
+  const isSameOrigin = typeof window !== 'undefined' && base.startsWith(window.location.origin)
+  const basePath = isSameOrigin ? getFrontendBasePath() : ''
   const position = opts?.position || 'bottom-right'
   const endpoint = opts?.tokenEndpoint || SECURE_TOKEN_ENDPOINT_PLACEHOLDER
   const attrs = [
-    `src="${escapeHtmlAttr(`${base}/weknora-widget.js`)}"`,
+    `src="${escapeHtmlAttr(`${base}${basePath}/weknora-widget.js`)}"`,
     `data-channel="${escapeHtmlAttr(channelId)}"`,
     `data-token-endpoint="${escapeHtmlAttr(endpoint)}"`,
     `data-position="${escapeHtmlAttr(position)}"`,
@@ -552,7 +559,9 @@ export function buildSecureWidgetSnippet(
  */
 export function buildSecureServerNodeExample(channelId: string, opts?: { baseUrl?: string }) {
   const base = safeBaseUrl(opts?.baseUrl)
-  const exchangeUrl = `${base}/api/v1/embed/${channelId}/exchange`
+  const isSameOrigin = typeof window !== 'undefined' && base.startsWith(window.location.origin)
+  const basePath = isSameOrigin ? getFrontendBasePath() : ''
+  const exchangeUrl = `${base}${basePath}/api/v1/embed/${channelId}/exchange`
   return [
     `// Node/Express — keep WEKNORA_PUBLISH_TOKEN only on the server (env var).`,
     `app.get('/weknora/embed-token', async (req, res) => {`,
@@ -578,7 +587,9 @@ export function buildSecureServerNodeExample(channelId: string, opts?: { baseUrl
 
 export function buildSecureServerGoExample(channelId: string, opts?: { baseUrl?: string }) {
   const base = safeBaseUrl(opts?.baseUrl)
-  const exchangeUrl = `${base}/api/v1/embed/${channelId}/exchange`
+  const isSameOrigin = typeof window !== 'undefined' && base.startsWith(window.location.origin)
+  const basePath = isSameOrigin ? getFrontendBasePath() : ''
+  const exchangeUrl = `${base}${basePath}/api/v1/embed/${channelId}/exchange`
   return [
     `// Go net/http — keep WEKNORA_PUBLISH_TOKEN only on the server (env var).`,
     `func embedTokenHandler(w http.ResponseWriter, r *http.Request) {`,

--- a/frontend/src/utils/base-path.ts
+++ b/frontend/src/utils/base-path.ts
@@ -1,0 +1,9 @@
+export function getFrontendBasePath(): string {
+  const base = (import.meta.env.BASE_URL || '/').replace(/\/+$/, '')
+  return base === '' || base === '/' ? '' : base
+}
+
+export function withFrontendBasePath(path: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${getFrontendBasePath()}${normalizedPath}`
+}

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import { generateRandomString, MAX_FILE_SIZE_MB } from "./index";
 import i18n from '@/i18n'
 import { getApiBaseUrl } from './api-base';
+import { getFrontendBasePath, withFrontendBasePath } from './base-path';
 
 const t = (key: string) => i18n.global.t(key)
 
@@ -98,15 +99,21 @@ const processQueue = (error: any, token: string | null = null) => {
 
 function isEmbedPage(): boolean {
   if (typeof window === 'undefined') return false;
-  return window.location.pathname.startsWith('/embed/');
+  const base = getFrontendBasePath();
+  return window.location.pathname.startsWith(`${base}/embed/`);
 }
 
 function redirectToLogin() {
   if (typeof window === 'undefined') return;
-  if (window.location.pathname === '/login') return;
+
+  const loginPath = withFrontendBasePath('/login');
+
+  if (window.location.pathname === loginPath) return;
+
   // Embed 渠道用 Embed token 鉴权，匿名访问不应被踢到登录页
   if (isEmbedPage()) return;
-  window.location.href = '/login';
+
+  window.location.href = loginPath;
 }
 
 instance.interceptors.response.use(

--- a/frontend/src/utils/tenantSwitch.ts
+++ b/frontend/src/utils/tenantSwitch.ts
@@ -7,15 +7,15 @@
 // 用一次 full navigation 把所有 store / SSE / 请求都重置一遍。
 
 import { updateMyPreferences } from '@/api/auth'
+import { withFrontendBasePath } from './base-path'
 
 const SAFE_FALLBACK_PATH = '/platform/knowledge-bases'
 
 /**
- * Return the URL to navigate to after a tenant switch. 目前始终返回 KB 列表
- * 作为登陆页，保留函数签名是为了未来需要按路由做特殊处理时留个口子。
+ * Return the URL to navigate to after a tenant switch.
  */
 export function tenantSwitchTargetPath(_currentPath: string): string {
-  return SAFE_FALLBACK_PATH
+  return withFrontendBasePath(SAFE_FALLBACK_PATH)
 }
 
 /**

--- a/frontend/src/views/settings/TenantInfo.vue
+++ b/frontend/src/views/settings/TenantInfo.vue
@@ -257,6 +257,7 @@ import {
   persistLastActiveTenantPreference,
   stashTenantSwitchToast,
 } from '@/utils/tenantSwitch'
+import { withFrontendBasePath } from '@/utils/base-path'
 
 const { t, locale } = useI18n()
 const { formatRole } = useRoleLabel()
@@ -348,7 +349,7 @@ function confirmLeaveTenant() {
         if (resp.success) {
           MessagePlugin.success(t('tenantMember.leave.success'))
           authStore.logout()
-          window.location.href = '/login'
+          window.location.href = withFrontendBasePath('/login')
         } else {
           MessagePlugin.error(resp.message || t('tenantMember.errors.generic'))
         }
@@ -413,7 +414,7 @@ async function deleteCurrentTenant() {
         return
       }
       authStore.logout()
-      window.location.href = '/login'
+      window.location.href = withFrontendBasePath('/login')
     } else {
       MessagePlugin.error(resp.message || t('tenant.deleteDangerZone.failed'))
     }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -67,7 +67,22 @@ function resolveVueOfficePptxEntry(): string {
   }
 }
 
+function normalizeBasePath(raw?: string): string {
+  const value = (raw || '').trim()
+  if (!value || value === '/') return '/'
+  
+  // 过滤开头和结尾的斜杠
+  const normalized = `/${value.replace(/^\/+|\/+$/g, '')}/`
+  
+  // 安全字符校验，防止 Nginx 配置注入与非法字符影响路径解析
+  if (!/^(\/[A-Za-z0-9._~-]+)+\/$/.test(normalized)) {
+    throw new Error(`[ERROR] Invalid WEKNORA_BASE_PATH character in value: "${raw}"`)
+  }
+  return normalized
+}
+
 export default defineConfig({
+  base: normalizeBasePath(process.env.WEKNORA_BASE_PATH),
   define: {
     __FRONTEND_VERSION__: JSON.stringify(FRONTEND_VERSION),
     __FRONTEND_COMMIT__: JSON.stringify(FRONTEND_COMMIT),

--- a/scripts/build_frontend_dist.sh
+++ b/scripts/build_frontend_dist.sh
@@ -5,6 +5,22 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# 仅当 WEKNORA_BASE_PATH 未被 Shell 导出，且根目录存在 .env 时，安全读取该单一配置值
+if [ -z "${WEKNORA_BASE_PATH:-}" ] && [ -f "$PROJECT_ROOT/.env" ]; then
+	echo "[INFO] Extracting WEKNORA_BASE_PATH from root .env..."
+	WEKNORA_BASE_PATH="$(
+		awk -F= '
+			/^[[:space:]]*WEKNORA_BASE_PATH=/ {
+				sub(/^[^=]*=/, "")
+				print
+			}
+		' "$PROJECT_ROOT/.env" \
+		| tail -n 1 \
+		| sed 's/^[[:space:]]*//; s/[[:space:]]*$//; s/^"//; s/"$//; s/^'\''//; s/'\''$//'
+	)"
+	export WEKNORA_BASE_PATH
+fi
+
 if [ -z "${VITE_FRONTEND_COMMIT:-}" ]; then
 	# shellcheck source=/dev/null
 	eval "$("$PROJECT_ROOT/scripts/get_version.sh" env)"


### PR DESCRIPTION
RATIONALE: In offline, enterprise, or internal gateway environments, dedicated domain names or subdomains are often unavailable. Multiple internal systems must share a single IP and a single port (e.g. port 6000), requiring routing based on sub-paths (e.g. http://IP:6000/weknora/ vs http://IP:6000/system1/).

Currently, WeKnora assumes it is hosted at the root path (/). Hosting it under a subpath requires manual adjustments to Vite build configurations, router settings, API base URLs, login redirect locations, and embed widget URLs.

This PR introduces a configurable base path feature through the WEKNORA_BASE_PATH environment variable. It dynamically handles path prefixing for both build-time configurations (Vite assets, SPA routes, API client requests, and control panel widgets) and container runtime configurations (Nginx location matching and fallbacks) to form a unified base path configuration loop while fully preserving backward compatibility (defaulting to / if not set).

⚠️ IMPORTANT NOTE: Changing WEKNORA_BASE_PATH requires rebuilding the frontend assets/image because Vite's base path is resolved and injected at build time, not runtime. Runtime-only changes are insufficient.