### PR TITLE
fix(im): harden DingTalk file download with SSRF checks

### DIFF
--- a/internal/im/dingtalk/adapter.go
+++ b/internal/im/dingtalk/adapter.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,6 +22,7 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/im"
 	"github.com/Tencent/WeKnora/internal/logger"
+	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
 
 // httpClient is a shared HTTP client with a reasonable timeout for DingTalk API calls.
@@ -164,8 +166,9 @@ func (a *Adapter) ParseCallback(c *gin.Context) (*im.IncomingMessage, error) {
 // messages carry only downloadCode (original quality) and pictureDownloadCode.
 // See https://open-dingtalk.github.io/developerpedia/docs/learn/bot/message/
 type fileMessageContent struct {
-	DownloadCode string `json:"downloadCode"`
-	FileName     string `json:"fileName"`
+	DownloadCode        string `json:"downloadCode"`
+	PictureDownloadCode string `json:"pictureDownloadCode"`
+	FileName            string `json:"fileName"`
 }
 
 // parseFileContent maps a DingTalk msgtype + content object to WeKnora's file
@@ -173,18 +176,35 @@ type fileMessageContent struct {
 // caller keeps its text handling. Picture messages have no fileName; the IM
 // service appends an extension after download.
 func parseFileContent(msgtype string, content json.RawMessage) (im.MessageType, string, string, bool) {
-	var c fileMessageContent
-	if len(content) > 0 {
-		_ = json.Unmarshal(content, &c)
-	}
+	var msgType im.MessageType
 	switch msgtype {
 	case "file":
-		return im.MessageTypeFile, c.FileName, c.DownloadCode, true
+		msgType = im.MessageTypeFile
 	case "picture":
-		return im.MessageTypeImage, "", c.DownloadCode, true
+		msgType = im.MessageTypeImage
 	default:
 		return "", "", "", false
 	}
+
+	var c fileMessageContent
+	if len(content) > 0 {
+		if err := json.Unmarshal(content, &c); err != nil {
+			return "", "", "", false
+		}
+	}
+	downloadCode := c.DownloadCode
+	if downloadCode == "" {
+		downloadCode = c.PictureDownloadCode
+	}
+	if downloadCode == "" {
+		return "", "", "", false
+	}
+
+	fileName := c.FileName
+	if msgType == im.MessageTypeImage {
+		fileName = ""
+	}
+	return msgType, fileName, downloadCode, true
 }
 
 // parseDownloadURL extracts the temporary downloadUrl from the response of the
@@ -227,6 +247,9 @@ func (a *Adapter) DownloadFile(ctx context.Context, msg *im.IncomingMessage) (io
 	downloadURL, err := parseDownloadURL(respBody)
 	if err != nil {
 		return nil, "", err
+	}
+	if err := validateFileDownloadURL(downloadURL); err != nil {
+		return nil, "", fmt.Errorf("download url rejected: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
@@ -287,12 +310,47 @@ func parseCallbackMessage(msg *callbackMessage) *im.IncomingMessage {
 
 // defaultFileName gives picture messages (which carry no fileName) a name with a
 // real stem derived from the message ID, mirroring the WeCom adapter. File
-// messages keep their original name.
+// messages keep their original name; if missing, fall back to the message ID so
+// post-download extension resolution can still run.
 func defaultFileName(msgType im.MessageType, fileName, msgID string) string {
-	if msgType == im.MessageTypeImage && fileName == "" {
+	if fileName != "" {
+		return fileName
+	}
+	if msgType == im.MessageTypeImage {
 		return msgID + ".png"
 	}
-	return fileName
+	return msgID
+}
+
+// allowedDingTalkDownloadHostSuffixes lists CDN/OSS host suffixes DingTalk uses
+// for temporary file download links returned by messageFiles/download.
+var allowedDingTalkDownloadHostSuffixes = []string{
+	".aliyuncs.com",
+	".dingtalk.com",
+}
+
+// validateFileDownloadURL is overridable in tests (httptest uses loopback URLs).
+var validateFileDownloadURL = defaultValidateFileDownloadURL
+
+func defaultValidateFileDownloadURL(rawURL string) error {
+	if isAllowedDingTalkDownloadHost(rawURL) {
+		return nil
+	}
+	return secutils.ValidateURLForSSRF(rawURL)
+}
+
+func isAllowedDingTalkDownloadHost(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	hostname := strings.ToLower(u.Hostname())
+	for _, suffix := range allowedDingTalkDownloadHostSuffixes {
+		if strings.HasSuffix(hostname, suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 // streamToIncoming builds an IncomingMessage from a DingTalk Stream mode

--- a/internal/im/dingtalk/adapter_test.go
+++ b/internal/im/dingtalk/adapter_test.go
@@ -54,6 +54,53 @@ func TestParseFileContent_Text(t *testing.T) {
 	}
 }
 
+func TestParseFileContent_EmptyDownloadCode(t *testing.T) {
+	_, _, _, ok := parseFileContent("file", json.RawMessage(`{"fileName":"a.pdf"}`))
+	if ok {
+		t.Errorf("expected ok=false when downloadCode is missing")
+	}
+	_, _, _, ok = parseFileContent("picture", json.RawMessage(`{}`))
+	if ok {
+		t.Errorf("expected ok=false when picture has no download code")
+	}
+}
+
+func TestParseFileContent_PictureDownloadCodeFallback(t *testing.T) {
+	content := json.RawMessage(`{"pictureDownloadCode":"pWjAks="}`)
+	msgType, fileName, downloadCode, ok := parseFileContent("picture", content)
+	if !ok {
+		t.Fatalf("expected ok=true when only pictureDownloadCode is present")
+	}
+	if msgType != im.MessageTypeImage {
+		t.Errorf("msgType = %q, want %q", msgType, im.MessageTypeImage)
+	}
+	if fileName != "" {
+		t.Errorf("fileName = %q, want empty", fileName)
+	}
+	if downloadCode != "pWjAks=" {
+		t.Errorf("downloadCode = %q, want %q", downloadCode, "pWjAks=")
+	}
+}
+
+func TestParseFileContent_InvalidJSON(t *testing.T) {
+	_, _, _, ok := parseFileContent("file", json.RawMessage(`not-json`))
+	if ok {
+		t.Errorf("expected ok=false for malformed content JSON")
+	}
+}
+
+func TestDefaultFileName(t *testing.T) {
+	if got := defaultFileName(im.MessageTypeImage, "", "pic-1"); got != "pic-1.png" {
+		t.Errorf("image default = %q, want pic-1.png", got)
+	}
+	if got := defaultFileName(im.MessageTypeFile, "spec.pdf", "m1"); got != "spec.pdf" {
+		t.Errorf("file with name = %q, want spec.pdf", got)
+	}
+	if got := defaultFileName(im.MessageTypeFile, "", "m2"); got != "m2" {
+		t.Errorf("file without name = %q, want m2", got)
+	}
+}
+
 func TestParseDownloadURL(t *testing.T) {
 	url, err := parseDownloadURL(json.RawMessage(`{"downloadUrl":"https://example.com/file?token=abc"}`))
 	if err != nil {

--- a/internal/im/dingtalk/download_test.go
+++ b/internal/im/dingtalk/download_test.go
@@ -47,6 +47,10 @@ func TestDownloadFile_EndToEnd(t *testing.T) {
 	apiBaseURL = srv.URL
 	defer func() { apiBaseURL = orig }()
 
+	origValidate := validateFileDownloadURL
+	validateFileDownloadURL = func(string) error { return nil }
+	defer func() { validateFileDownloadURL = origValidate }()
+
 	a := &Adapter{clientID: "cid", clientSecret: "sec"}
 	msg := &im.IncomingMessage{
 		MessageType: im.MessageTypeFile,
@@ -104,10 +108,56 @@ func TestDownloadFile_TempURLError(t *testing.T) {
 	apiBaseURL = srv.URL
 	defer func() { apiBaseURL = orig }()
 
+	origValidate := validateFileDownloadURL
+	validateFileDownloadURL = func(string) error { return nil }
+	defer func() { validateFileDownloadURL = origValidate }()
+
 	a := &Adapter{clientID: "cid", clientSecret: "sec"}
 	msg := &im.IncomingMessage{FileKey: "DL-CODE", FileName: "x.pdf", Extra: map[string]string{"robot_code": "rc"}}
 
 	if _, _, err := a.DownloadFile(context.Background(), msg); err == nil {
 		t.Errorf("expected error on non-200 download URL, got nil")
+	}
+}
+
+func TestDownloadFile_SSRFRejected(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.0/oauth2/accessToken":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"accessToken": "tok", "expireIn": 7200})
+		case "/v1.0/robot/messageFiles/download":
+			_ = json.NewEncoder(w).Encode(map[string]string{"downloadUrl": "http://127.0.0.1:1/internal"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	orig := apiBaseURL
+	apiBaseURL = srv.URL
+	defer func() { apiBaseURL = orig }()
+
+	a := &Adapter{clientID: "cid", clientSecret: "sec"}
+	msg := &im.IncomingMessage{FileKey: "DL-CODE", FileName: "x.pdf", Extra: map[string]string{"robot_code": "rc"}}
+
+	if _, _, err := a.DownloadFile(context.Background(), msg); err == nil {
+		t.Fatal("expected SSRF rejection error, got nil")
+	}
+}
+
+func TestIsAllowedDingTalkDownloadHost(t *testing.T) {
+	cases := []struct {
+		url   string
+		allow bool
+	}{
+		{"https://wukong-abc.oss-cn-hangzhou.aliyuncs.com/file?sig=x", true},
+		{"https://api.dingtalk.com/temp/file", true},
+		{"http://127.0.0.1:8080/file", false},
+	}
+	for _, tc := range cases {
+		if got := isAllowedDingTalkDownloadHost(tc.url); got != tc.allow {
+			t.Errorf("isAllowedDingTalkDownloadHost(%q) = %v, want %v", tc.url, got, tc.allow)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Validate DingTalk temporary download URLs against allowed CDN/OSS host suffixes (`.aliyuncs.com`, `.dingtalk.com`) and fall back to SSRF validation for other hosts before fetching file content.
- Support `pictureDownloadCode` as a fallback when `downloadCode` is missing, and reject file/image messages with no usable download code or malformed content JSON.
- Improve default file naming for file messages without `fileName`, and add unit tests for parsing, SSRF rejection, and host allowlisting.

## Test plan
- [x] `go test ./internal/im/dingtalk/...`
- [ ] Send a DingTalk picture message and confirm it ingests into the knowledge base
- [ ] Send a DingTalk file message and confirm download + ingest still works end-to-end