### PR TITLE
fix: OBS incorrectly selectable and MinIO submission fails when STORAGE_ALLOW_LIST is set

### DIFF
--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
@@ -960,7 +960,21 @@ const handleStorageProviderUpdate = (value: string) => {
 async function loadTenantDefaultStorageProvider(force = false) {
   try {
     await editorResources.ensureStorageEngine(force)
-    tenantDefaultStorageProvider.value = editorResources.storageConfig?.default_provider || 'local'
+    const rawDefault = editorResources.storageConfig?.default_provider || 'local'
+    const engines = editorResources.storageStatus
+    // Check whether the tenant's configured default is permitted by STORAGE_ALLOW_LIST.
+    // If not, substitute the first allowed engine so the form is never pre-filled with a
+    // provider the backend would reject — even when the storage tab is never visited.
+    const isAllowed = (name: string) => {
+      const e = engines.find(en => en.name === name)
+      return !!e && e.allowed !== false
+    }
+    tenantDefaultStorageProvider.value = isAllowed(rawDefault)
+      ? rawDefault
+      // prefer allowed + available; fall back to allowed-only if nothing is configured yet
+      : (engines.find(e => e.allowed !== false && e.available)?.name
+         ?? engines.find(e => e.allowed !== false)?.name
+         ?? rawDefault)
   } catch {
     tenantDefaultStorageProvider.value = 'local'
   }

--- a/frontend/src/views/knowledge/settings/KBStorageSettings.vue
+++ b/frontend/src/views/knowledge/settings/KBStorageSettings.vue
@@ -79,78 +79,35 @@ const allowedProviders = ref<string[]>([])
 const hasAnyConfig = ref(false)
 
 const engineOptions = computed(() => {
-  const statusMap: Record<string, boolean> = {}
-  const allowedMap: Record<string, boolean> = {}
-  for (const e of engineStatus.value) {
-    statusMap[e.name] = e.available
-    allowedMap[e.name] = e.allowed !== false
+  // UI display metadata keyed by provider name.
+  // When adding a new provider to the backend (storage_allowlist.go → supportedStorageProviders),
+  // add a matching entry here. Unknown providers fall back to an uppercase name and the
+  // backend-supplied description so the UI degrades gracefully rather than hiding the engine.
+  const meta: Record<string, { label: string; desc: string }> = {
+    local: { label: t('kbSettings.storage.engineLocal'), desc: t('kbSettings.storage.engineLocalDesc') },
+    minio: { label: 'MinIO',                             desc: t('kbSettings.storage.engineMinioDesc') },
+    cos:   { label: t('kbSettings.storage.engineCos'),   desc: t('kbSettings.storage.engineCosDesc') },
+    tos:   { label: t('kbSettings.storage.engineTos'),   desc: t('kbSettings.storage.engineTosDesc') },
+    s3:    { label: t('kbSettings.storage.engineS3'),    desc: t('kbSettings.storage.engineS3Desc') },
+    oss:   { label: t('kbSettings.storage.engineOss'),   desc: t('kbSettings.storage.engineOssDesc') },
+    ks3:   { label: t('kbSettings.storage.engineKs3'),   desc: t('kbSettings.storage.engineKs3Desc') },
+    obs:   { label: t('kbSettings.storage.engineObs'),   desc: t('kbSettings.storage.engineObsDesc') },
   }
-  return [
-    {
-      value: 'local',
-      label: t('kbSettings.storage.engineLocal'),
-      desc: t('kbSettings.storage.engineLocalDesc'),
-      allowed: allowedMap.local !== false,
-      available: statusMap.local !== false,
-      disabled: allowedMap.local === false,
-    },
-    {
-      value: 'minio',
-      label: 'MinIO',
-      desc: t('kbSettings.storage.engineMinioDesc'),
-      allowed: allowedMap.minio !== false,
-      available: statusMap.minio,
-      disabled: allowedMap.minio === false || statusMap.minio === false,
-    },
-    {
-      value: 'cos',
-      label: t('kbSettings.storage.engineCos'),
-      desc: t('kbSettings.storage.engineCosDesc'),
-      allowed: allowedMap.cos !== false,
-      available: statusMap.cos,
-      disabled: allowedMap.cos === false || statusMap.cos === false,
-    },
-    {
-      value: 'tos',
-      label: t('kbSettings.storage.engineTos'),
-      desc: t('kbSettings.storage.engineTosDesc'),
-      allowed: allowedMap.tos !== false,
-      available: statusMap.tos,
-      disabled: allowedMap.tos === false || statusMap.tos === false,
-    },
-    {
-      value: 's3',
-      label: t('kbSettings.storage.engineS3'),
-      desc: t('kbSettings.storage.engineS3Desc'),
-      allowed: allowedMap.s3 !== false,
-      available: statusMap.s3,
-      disabled: allowedMap.s3 === false || statusMap.s3 === false,
-    },
-    {
-      value: 'oss',
-      label: t('kbSettings.storage.engineOss'),
-      desc: t('kbSettings.storage.engineOssDesc'),
-      allowed: allowedMap.oss !== false,
-      available: statusMap.oss,
-      disabled: allowedMap.oss === false || statusMap.oss === false,
-    },
-    {
-      value: 'ks3',
-      label: t('kbSettings.storage.engineKs3'),
-      desc: t('kbSettings.storage.engineKs3Desc'),
-      allowed: allowedMap.ks3 !== false,
-      available: statusMap.ks3,
-      disabled: allowedMap.ks3 === false || statusMap.ks3 === false,
-    },
-    {
-      value: 'obs',
-      label: t('kbSettings.storage.engineObs'),
-      desc: t('kbSettings.storage.engineObsDesc'),
-      allowed: allowedMap.obs !== false,
-      available: statusMap.obs,
-      disabled: allowedMap.obs === false || statusMap.obs === false,
-    },
-  ]
+  // Derive options directly from the backend status response so this list never
+  // drifts out of sync with supportedStorageProviders on the backend.
+  return engineStatus.value.map(e => {
+    const { label, desc } = meta[e.name] ?? { label: e.name.toUpperCase(), desc: e.description }
+    const isAllowed = e.allowed !== false
+    return {
+      value: e.name,
+      label,
+      desc,
+      allowed: isAllowed,
+      available: e.available,
+      // disabled when not allowed by STORAGE_ALLOW_LIST OR not yet configured
+      disabled: !isAllowed || !e.available,
+    }
+  })
 })
 
 const showGoSettings = computed(() =>

--- a/internal/application/service/file/factory.go
+++ b/internal/application/service/file/factory.go
@@ -103,12 +103,23 @@ func NewFileServiceFromStorageConfig(
 		return svc, p, err
 
 	case "obs":
-		obsEndpoint := strings.TrimSpace(os.Getenv("OBS_ENDPOINT"))
-		obsRegion := strings.TrimSpace(os.Getenv("OBS_REGION"))
-		obsAccessKey := strings.TrimSpace(os.Getenv("OBS_ACCESS_KEY"))
-		obsSecretKey := strings.TrimSpace(os.Getenv("OBS_SECRET_KEY"))
-		obsBucketName := strings.TrimSpace(os.Getenv("OBS_BUCKET_NAME"))
-		obsPathPrefix := strings.TrimSpace(os.Getenv("OBS_PATH_PREFIX"))
+		var obsEndpoint, obsRegion, obsAccessKey, obsSecretKey, obsBucketName, obsPathPrefix string
+		// prefer tenant config; fall back to env vars (mirrors MinIO behaviour)
+		if sec != nil && sec.OBS != nil && sec.OBS.Endpoint != "" && sec.OBS.AccessKey != "" && sec.OBS.SecretKey != "" && sec.OBS.BucketName != "" {
+			obsEndpoint = strings.TrimSpace(sec.OBS.Endpoint)
+			obsRegion = strings.TrimSpace(sec.OBS.Region)
+			obsAccessKey = strings.TrimSpace(sec.OBS.AccessKey)
+			obsSecretKey = strings.TrimSpace(sec.OBS.SecretKey)
+			obsBucketName = strings.TrimSpace(sec.OBS.BucketName)
+			obsPathPrefix = strings.TrimSpace(sec.OBS.PathPrefix)
+		} else {
+			obsEndpoint = strings.TrimSpace(os.Getenv("OBS_ENDPOINT"))
+			obsRegion = strings.TrimSpace(os.Getenv("OBS_REGION"))
+			obsAccessKey = strings.TrimSpace(os.Getenv("OBS_ACCESS_KEY"))
+			obsSecretKey = strings.TrimSpace(os.Getenv("OBS_SECRET_KEY"))
+			obsBucketName = strings.TrimSpace(os.Getenv("OBS_BUCKET_NAME"))
+			obsPathPrefix = strings.TrimSpace(os.Getenv("OBS_PATH_PREFIX"))
+		}
 		if obsPathPrefix == "" {
 			obsPathPrefix = "weknora/"
 		}

--- a/internal/handler/system.go
+++ b/internal/handler/system.go
@@ -551,6 +551,14 @@ func (h *SystemHandler) isOBSConfigured(c *gin.Context) bool {
 	return false
 }
 
+// isOBSEnvAvailable checks whether OBS env vars are set.
+func (h *SystemHandler) isOBSEnvAvailable() bool {
+	return os.Getenv("OBS_ENDPOINT") != "" &&
+		os.Getenv("OBS_ACCESS_KEY") != "" &&
+		os.Getenv("OBS_SECRET_KEY") != "" &&
+		os.Getenv("OBS_BUCKET_NAME") != ""
+}
+
 // isTOSEnvAvailable checks whether TOS env vars are set.
 func (h *SystemHandler) isTOSEnvAvailable() bool {
 	return os.Getenv("TOS_ENDPOINT") != "" &&
@@ -591,6 +599,7 @@ func (h *SystemHandler) GetStorageEngineStatus(c *gin.Context) {
 	ossConfigured := h.isOSSConfigured(c)
 	ks3Configured := h.isKS3Configured(c)
 	obsConfigured := h.isOBSConfigured(c)
+	obsEnvAvailable := h.isOBSEnvAvailable()
 	allowed := getAllowedStorageProviders()
 
 	// avail and desc are keyed by provider name and must stay in sync with
@@ -605,7 +614,7 @@ func (h *SystemHandler) GetStorageEngineStatus(c *gin.Context) {
 		"s3":    s3Configured,
 		"oss":   ossConfigured,
 		"ks3":   ks3Configured,
-		"obs":   obsConfigured,
+		"obs":   obsConfigured || obsEnvAvailable,
 	}
 	desc := map[string]string{
 		"local": "本地文件系统存储，仅适合单机部署",

--- a/internal/handler/system.go
+++ b/internal/handler/system.go
@@ -540,6 +540,17 @@ func (h *SystemHandler) isKS3Configured(c *gin.Context) bool {
 	return false
 }
 
+// isOBSConfigured checks whether OBS connection info is available from tenant config.
+func (h *SystemHandler) isOBSConfigured(c *gin.Context) bool {
+	if v, exists := c.Get(types.TenantInfoContextKey.String()); exists {
+		if tenant, ok := v.(*types.Tenant); ok && tenant != nil && tenant.StorageEngineConfig != nil && tenant.StorageEngineConfig.OBS != nil {
+			obsConf := tenant.StorageEngineConfig.OBS
+			return obsConf.Endpoint != "" && obsConf.Region != "" && obsConf.AccessKey != "" && obsConf.SecretKey != "" && obsConf.BucketName != ""
+		}
+	}
+	return false
+}
+
 // isTOSEnvAvailable checks whether TOS env vars are set.
 func (h *SystemHandler) isTOSEnvAvailable() bool {
 	return os.Getenv("TOS_ENDPOINT") != "" &&
@@ -551,7 +562,7 @@ func (h *SystemHandler) isTOSEnvAvailable() bool {
 
 // StorageEngineStatusItem describes one storage engine's availability and description.
 type StorageEngineStatusItem struct {
-	Name        string `json:"name"` // "local", "minio", "cos", "tos", "s3", "oss", "ks3"
+	Name        string `json:"name"` // one of supportedStorageProviders: "local", "minio", "cos", "tos", "s3", "oss", "ks3", "obs"
 	Allowed     bool   `json:"allowed"`
 	Available   bool   `json:"available"`   // whether the engine can be used
 	Description string `json:"description"` // short description for UI
@@ -579,22 +590,48 @@ func (h *SystemHandler) GetStorageEngineStatus(c *gin.Context) {
 	s3Configured := h.isS3Configured(c)
 	ossConfigured := h.isOSSConfigured(c)
 	ks3Configured := h.isKS3Configured(c)
+	obsConfigured := h.isOBSConfigured(c)
 	allowed := getAllowedStorageProviders()
+
+	// avail and desc are keyed by provider name and must stay in sync with
+	// supportedStorageProviders. When adding a new provider to that slice,
+	// add a matching entry here — a missing entry will surface as available=false
+	// with an empty description rather than silently disappearing from the list.
+	avail := map[string]bool{
+		"local": true,
+		"minio": minioConfigured || minioEnvAvailable,
+		"cos":   cosConfigured,
+		"tos":   tosConfigured,
+		"s3":    s3Configured,
+		"oss":   ossConfigured,
+		"ks3":   ks3Configured,
+		"obs":   obsConfigured,
+	}
+	desc := map[string]string{
+		"local": "本地文件系统存储，仅适合单机部署",
+		"minio": "S3 兼容的自托管对象存储，适合内网和私有云部署",
+		"cos":   "腾讯云对象存储服务，适合公有云部署，支持 CDN 加速",
+		"tos":   "火山引擎对象存储服务，适合公有云部署",
+		"s3":    "AWS S3 与兼容对象存储服务，适合公有云与混合云部署",
+		"oss":   "阿里云对象存储服务，适合公有云部署，支持 S3 兼容协议",
+		"ks3":   "金山云对象存储服务，适合公有云部署",
+		"obs":   "华为云对象存储服务，适合公有云部署",
+	}
+
 	allowedProviders := make([]string, 0, len(supportedStorageProviders))
+	engines := make([]StorageEngineStatusItem, 0, len(supportedStorageProviders))
 	for _, provider := range getSupportedStorageProviders() {
 		if allowed[provider] {
 			allowedProviders = append(allowedProviders, provider)
 		}
+		engines = append(engines, StorageEngineStatusItem{
+			Name:        provider,
+			Allowed:     allowed[provider],
+			Available:   avail[provider],
+			Description: desc[provider],
+		})
 	}
-	engines := []StorageEngineStatusItem{
-		{Name: "local", Allowed: allowed["local"], Available: true, Description: "本地文件系统存储，仅适合单机部署"},
-		{Name: "minio", Allowed: allowed["minio"], Available: minioConfigured || minioEnvAvailable, Description: "S3 兼容的自托管对象存储，适合内网和私有云部署"},
-		{Name: "cos", Allowed: allowed["cos"], Available: cosConfigured, Description: "腾讯云对象存储服务，适合公有云部署，支持 CDN 加速"},
-		{Name: "tos", Allowed: allowed["tos"], Available: tosConfigured, Description: "火山引擎对象存储服务，适合公有云部署"},
-		{Name: "s3", Allowed: allowed["s3"], Available: s3Configured, Description: "AWS S3 与兼容对象存储服务，适合公有云与混合云部署"},
-		{Name: "oss", Allowed: allowed["oss"], Available: ossConfigured, Description: "阿里云对象存储服务，适合公有云部署，支持 S3 兼容协议"},
-		{Name: "ks3", Allowed: allowed["ks3"], Available: ks3Configured, Description: "金山云对象存储服务，适合公有云部署"},
-	}
+
 	c.JSON(200, gin.H{
 		"code": 0,
 		"msg":  "success",


### PR DESCRIPTION
## Description

When `STORAGE_ALLOW_LIST=minio` is configured, two bugs appear in the "Create Knowledge Base" dialog:

1. **Huawei Cloud OBS appears as a selectable option** — it should be disabled.
2. **Submitting without visiting the Storage tab throws** `storage provider is not allowed by STORAGE_ALLOW_LIST` — even when MinIO is correctly listed in the allow list.

---

### Root causes

**Bug 1 — Backend: `obs` missing from the engine status response**

`GetStorageEngineStatus` built its `engines` slice as a hardcoded array that omitted `obs` entirely, despite `obs` being present in `supportedStorageProviders`. The frontend therefore never received `obs.allowed = false`, and `isOBSConfigured()` did not exist.

**Bug 1 — Frontend cascade: missing engine treated as "allowed"**

With `obs` absent from the response, `allowedMap.obs` was `undefined`. The disabled check `allowedMap.obs === false` evaluated to `false`, so OBS was treated as selectable.

**Bug 2 — Create-mode form pre-filled with a disallowed provider**

`loadTenantDefaultStorageProvider()` set `tenantDefaultStorageProvider` to the raw `storageConfig.default_provider` (e.g. `'local'`) without checking whether that value was permitted by `STORAGE_ALLOW_LIST`. In create mode, `formData.storageProvider` was initialised directly from this value. If the user submitted without ever opening the Storage tab — which is where `KBStorageSettings` mounts and `ensureAllowedProvider()` runs to correct the value — the form would send `provider: "local"`, which the backend correctly rejects.

---

### Fixes

**`internal/handler/system.go`**
- Added `isOBSConfigured()` (mirrors `isKS3Configured`).
- Replaced the hardcoded `engines` slice with a loop over `getSupportedStorageProviders()` backed by `avail` / `desc` maps. `supportedStorageProviders` is now the single source of truth — the status response is always in sync with it. A provider missing from the maps degrades gracefully (shown as unavailable) rather than disappearing silently.
- Fixed the `StorageEngineStatusItem.Name` field comment.

**`frontend/src/views/knowledge/settings/KBStorageSettings.vue`**
- Replaced the 8-entry hardcoded `engineOptions` array with `engineStatus.value.map(...)`. Options are derived entirely from the backend response; the frontend only maintains a `meta` map for i18n labels/descriptions. `allowed` / `available` / `disabled` are driven by the backend, eliminating drift.

**`frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue`**
- `loadTenantDefaultStorageProvider()` now validates the tenant default against `STORAGE_ALLOW_LIST` immediately after loading engine status. If the default is not permitted, it substitutes the first allowed + available engine (falling back to allowed-only if none is configured yet). This ensures `formData.storageProvider` is always a valid value from the moment the dialog opens, regardless of whether the Storage tab is visited.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🎨 Refactor

## Related Issue

Fixes #

## Testing

1. Set `STORAGE_ALLOW_LIST=minio` and restart the service.
2. Call `GET /api/v1/system/storage-engine-status` — confirm `obs` is present with `allowed: false`.
3. Open "Create Knowledge Base":
   - **Storage tab**: MinIO is selectable; OBS is disabled/grayed out.
   - **Without visiting the Storage tab**: fill in a name and click Create — succeeds with no error.
4. Set `STORAGE_ALLOW_LIST=` (empty, allow all) and configure OBS credentials — OBS becomes selectable.

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [ ] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

| Before | After |
|---|---|
| OBS appears selectable under `STORAGE_ALLOW_LIST=minio` | OBS is disabled |
| Submitting without visiting Storage tab throws an allow-list error | Submits successfully regardless of which tab was visited |