### PR TITLE
fix(docreader): route mislabeled legacy DOC files correctly

### DIFF
--- a/docreader/parser/parser.py
+++ b/docreader/parser/parser.py
@@ -8,6 +8,28 @@ from docreader.parser.web_parser import WebParser
 logger = logging.getLogger(__name__)
 
 
+# OLE Compound File magic used by legacy binary Microsoft Office files.
+# Some WPS/Word documents keep this payload while being renamed to .docx.
+_OLE_COMPOUND_FILE_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+
+
+def detect_effective_file_type(file_type: str, content: bytes) -> str:
+    """Return the parser file type after checking trustworthy file magic.
+
+    OOXML ``.docx`` files are ZIP containers, while legacy ``.doc`` files
+    use the OLE Compound File format.  Word and WPS tolerate a legacy file
+    renamed to ``.docx``, so route that well-known mismatch through the DOC
+    parser instead of feeding binary OLE data to the DOCX parser.
+    """
+    normalized = file_type.lower().lstrip(".")
+    if normalized == "docx" and content.startswith(_OLE_COMPOUND_FILE_MAGIC):
+        logger.warning(
+            "Detected legacy DOC content with a DOCX extension; using DOC parser"
+        )
+        return "doc"
+    return normalized
+
+
 class Parser:
     """Document parser facade (lightweight version).
 
@@ -40,15 +62,16 @@ class Parser:
             engine or "builtin",
         )
 
-        cls = self.registry.get_parser_class(engine, file_type)
+        effective_file_type = detect_effective_file_type(file_type, content)
+        cls = self.registry.get_parser_class(engine, effective_file_type)
         logger.info(
             "Creating %s parser instance for %s file",
             cls.__name__,
-            file_type,
+            effective_file_type,
         )
         parser = cls(
             file_name=file_name,
-            file_type=file_type,
+            file_type=effective_file_type,
             **overrides,
         )
 
@@ -57,9 +80,7 @@ class Parser:
 
         if not result.content:
             logger.warning("Parser returned empty content for file: %s", file_name)
-        logger.info(
-            "Parsed file %s, content length=%d", file_name, len(result.content)
-        )
+        logger.info("Parsed file %s, content length=%d", file_name, len(result.content))
         return result
 
     def parse_url(

--- a/docreader/tests/test_parser_routing.py
+++ b/docreader/tests/test_parser_routing.py
@@ -1,0 +1,58 @@
+import unittest
+
+from docreader.models.document import Document
+from docreader.parser.base_parser import BaseParser
+from docreader.parser.parser import Parser, detect_effective_file_type
+
+
+OLE_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+
+
+class _RecordingParser(BaseParser):
+    last_file_type = ""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        type(self).last_file_type = self.file_type
+
+    def parse_into_text(self, content: bytes) -> Document:
+        return Document(content="parsed")
+
+
+class _RecordingRegistry:
+    def __init__(self):
+        self.requested_file_type = ""
+
+    def get_parser_class(self, engine: str, file_type: str):
+        self.requested_file_type = file_type
+        return _RecordingParser
+
+
+class ParserRoutingTest(unittest.TestCase):
+    def test_legacy_doc_payload_renamed_to_docx_uses_doc_parser(self):
+        registry = _RecordingRegistry()
+        parser = Parser()
+        parser.registry = registry
+
+        result = parser.parse_file(
+            "legacy.docx",
+            "docx",
+            OLE_MAGIC + b"legacy-word-payload",
+        )
+
+        self.assertEqual("parsed", result.content)
+        self.assertEqual("doc", registry.requested_file_type)
+        self.assertEqual("doc", _RecordingParser.last_file_type)
+
+    def test_real_docx_payload_keeps_docx_parser_route(self):
+        self.assertEqual(
+            "docx",
+            detect_effective_file_type(".DOCX", b"PK\x03\x04ooxml-payload"),
+        )
+
+    def test_unrelated_ole_type_is_not_reclassified(self):
+        self.assertEqual("xls", detect_effective_file_type("xls", OLE_MAGIC))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- detect the OLE Compound File signature before choosing a parser
- route legacy `.doc` payloads renamed to `.docx` through the existing DOC parser
- preserve the normal DOCX route for real OOXML/ZIP payloads
- add focused parser-routing regression tests

## Why

The attachment in #1997 is not an OOXML DOCX archive. Its bytes start with the legacy OLE/DOC signature even though its filename ends in `.docx`. Word and WPS tolerate that mismatch, but WeKnora selected parsers only from the extension and sent the file to the DOCX parser. The project already ships a DOC parser plus LibreOffice/antiword in the docreader image, so content-aware routing is the smallest robust fix.

Fixes #1997.

## Validation

- `uv run --project docreader python -m unittest docreader.tests.test_parser_routing`
- `uvx ruff check docreader/parser/parser.py docreader/tests/test_parser_routing.py`
- `uvx ruff format --check docreader/parser/parser.py docreader/tests/test_parser_routing.py`
- `git diff --check`

The complete docreader unittest discovery was also run: 106 tests passed or skipped, while 5 existing tests errored because the checkout does not contain their referenced `testdata/rag_test` fixtures.