### PR TITLE
fix(wiki): bound processing span names

### DIFF
--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -1637,7 +1637,7 @@ func (s *wikiIngestService) reduceSlugUpdates(
 			contributors = append(contributors, kid)
 			if pageSpan == nil {
 				if sp, ok := kidToWikiSpan[kid]; ok && sp != nil {
-					pageSpan = s.tracker().BeginSubSpan(ctx, sp, fmt.Sprintf("postprocess.wiki.page[%s]", slug), types.SpanKindSubSpan, types.JSONMap{
+					pageSpan = s.tracker().BeginSubSpan(ctx, sp, wikiPageSpanName(slug), types.SpanKindSubSpan, types.JSONMap{
 						"slug":         slug,
 						"updates":      len(updates),
 						"contributors": contributors,
@@ -1965,6 +1965,21 @@ func (s *wikiIngestService) reduceSlugUpdates(
 	}
 
 	return false, "", additionFailed, nil
+}
+
+const maxKnowledgeProcessingSpanNameRunes = 64
+
+func wikiPageSpanName(slug string) string {
+	const prefix = "postprocess.wiki.page["
+	const truncatedSuffix = "…]"
+
+	name := prefix + slug + "]"
+	if len([]rune(name)) <= maxKnowledgeProcessingSpanNameRunes {
+		return name
+	}
+
+	maxSlugRunes := maxKnowledgeProcessingSpanNameRunes - len([]rune(prefix)) - len([]rune(truncatedSuffix))
+	return prefix + string([]rune(slug)[:maxSlugRunes]) + truncatedSuffix
 }
 
 // mergeChunkRefs unions the chunk IDs currently on the page with the ones

--- a/internal/application/service/wiki_ingest_test.go
+++ b/internal/application/service/wiki_ingest_test.go
@@ -61,6 +61,27 @@ func TestTruncateString(t *testing.T) {
 	}
 }
 
+func TestWikiPageSpanName(t *testing.T) {
+	t.Run("keeps short slugs intact", func(t *testing.T) {
+		const slug = "concept/retrieval-augmented-generation"
+		want := "postprocess.wiki.page[" + slug + "]"
+		if got := wikiPageSpanName(slug); got != want {
+			t.Fatalf("wikiPageSpanName(%q) = %q, want %q", slug, got, want)
+		}
+	})
+
+	t.Run("truncates long slugs within the database limit", func(t *testing.T) {
+		slug := "concept/" + strings.Repeat("long-page-name-", 8)
+		got := wikiPageSpanName(slug)
+		if length := len([]rune(got)); length > maxKnowledgeProcessingSpanNameRunes {
+			t.Fatalf("span name length = %d, want at most %d", length, maxKnowledgeProcessingSpanNameRunes)
+		}
+		if !strings.HasPrefix(got, "postprocess.wiki.page[") || !strings.HasSuffix(got, "…]") {
+			t.Fatalf("unexpected truncated span name %q", got)
+		}
+	})
+}
+
 func TestAppendUnique(t *testing.T) {
 	arr := types.StringArray{"a", "b"}
 


### PR DESCRIPTION
## Description

Bounds wiki page processing-span names to the database's 64-character limit while retaining the stage prefix and a truncation marker. This prevents long wiki slugs from dropping trace records.

## Type of Change

- [x] Bug fix

## Related Issue

Fixes #1996

## Testing

- Full internal application service test suite passed

## Checklist

- [x] Self-reviewed the code
- [x] Added tests covering the change
- [x] No documentation update is needed
- [x] No breaking change