### PR TITLE
feat(provider): add Requesty as an OpenAI-compatible model provider

### DIFF
--- a/client/model.go
+++ b/client/model.go
@@ -48,6 +48,7 @@ const (
 	ModelSourceSiliconFlow ModelSource = "siliconflow"  // SiliconFlow model
 	ModelSourceJina        ModelSource = "jina"         // Jina AI model
 	ModelSourceOpenRouter  ModelSource = "openrouter"   // OpenRouter model
+	ModelSourceRequesty    ModelSource = "requesty"     // Requesty model
 	ModelSourceNvidia      ModelSource = "nvidia"       // NVIDIA model
 	ModelSourceNovita      ModelSource = "novita"       // Novita AI model
 	ModelSourceAzureOpenAI ModelSource = "azure_openai" // Azure OpenAI model
@@ -63,7 +64,7 @@ func AllModelSources() []ModelSource {
 		ModelSourceLocal, ModelSourceRemote, ModelSourceAliyun, ModelSourceZhipu,
 		ModelSourceVolcengine, ModelSourceDeepseek, ModelSourceHunyuan, ModelSourceMinimax,
 		ModelSourceOpenAI, ModelSourceGemini, ModelSourceMimo, ModelSourceSiliconFlow,
-		ModelSourceJina, ModelSourceOpenRouter, ModelSourceNvidia, ModelSourceNovita,
+		ModelSourceJina, ModelSourceOpenRouter, ModelSourceRequesty, ModelSourceNvidia, ModelSourceNovita,
 		ModelSourceAzureOpenAI,
 	}
 }

--- a/docs/BUILTIN_MODELS.md
+++ b/docs/BUILTIN_MODELS.md
@@ -161,7 +161,7 @@ services:
 
 ### 方式二：直接 SQL 插入
 
-支持的 provider：`generic`（自定义）、`openai`、`aliyun`、`zhipu`、`volcengine`、`hunyuan`、`deepseek`、`minimax`、`mimo`、`siliconflow`、`jina`、`openrouter`、`gemini`、`modelscope`、`moonshot`、`qianfan`、`qiniu`、`longcat`、`gpustack`
+支持的 provider：`generic`（自定义）、`openai`、`aliyun`、`zhipu`、`volcengine`、`hunyuan`、`deepseek`、`minimax`、`mimo`、`siliconflow`、`jina`、`openrouter`、`requesty`、`gemini`、`modelscope`、`moonshot`、`qianfan`、`qiniu`、`longcat`、`gpustack`
 
 ```sql
 -- 示例：LLM 内置模型

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -16277,6 +16277,7 @@ const docTemplate = `{
                 "siliconflow",
                 "jina",
                 "openrouter",
+                "requesty",
                 "nvidia",
                 "novita",
                 "azure_openai"
@@ -16296,6 +16297,7 @@ const docTemplate = `{
                 "ModelSourceOpenAI": "OpenAI model",
                 "ModelSourceOpenRouter": "OpenRouter model",
                 "ModelSourceRemote": "Remote model",
+                "ModelSourceRequesty": "Requesty model",
                 "ModelSourceSiliconFlow": "SiliconFlow model",
                 "ModelSourceVolcengine": "Volcengine model",
                 "ModelSourceZhipu": "Zhipu model"
@@ -16315,6 +16317,7 @@ const docTemplate = `{
                 "SiliconFlow model",
                 "Jina AI model",
                 "OpenRouter model",
+                "Requesty model",
                 "NVIDIA model",
                 "Novita AI model",
                 "Azure OpenAI model"
@@ -16334,6 +16337,7 @@ const docTemplate = `{
                 "ModelSourceSiliconFlow",
                 "ModelSourceJina",
                 "ModelSourceOpenRouter",
+                "ModelSourceRequesty",
                 "ModelSourceNvidia",
                 "ModelSourceNovita",
                 "ModelSourceAzureOpenAI"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -16270,6 +16270,7 @@
                 "siliconflow",
                 "jina",
                 "openrouter",
+                "requesty",
                 "nvidia",
                 "novita",
                 "azure_openai"
@@ -16289,6 +16290,7 @@
                 "ModelSourceOpenAI": "OpenAI model",
                 "ModelSourceOpenRouter": "OpenRouter model",
                 "ModelSourceRemote": "Remote model",
+                "ModelSourceRequesty": "Requesty model",
                 "ModelSourceSiliconFlow": "SiliconFlow model",
                 "ModelSourceVolcengine": "Volcengine model",
                 "ModelSourceZhipu": "Zhipu model"
@@ -16308,6 +16310,7 @@
                 "SiliconFlow model",
                 "Jina AI model",
                 "OpenRouter model",
+                "Requesty model",
                 "NVIDIA model",
                 "Novita AI model",
                 "Azure OpenAI model"
@@ -16327,6 +16330,7 @@
                 "ModelSourceSiliconFlow",
                 "ModelSourceJina",
                 "ModelSourceOpenRouter",
+                "ModelSourceRequesty",
                 "ModelSourceNvidia",
                 "ModelSourceNovita",
                 "ModelSourceAzureOpenAI"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2095,6 +2095,7 @@ definitions:
     - siliconflow
     - jina
     - openrouter
+    - requesty
     - nvidia
     - novita
     - azure_openai
@@ -2114,6 +2115,7 @@ definitions:
       ModelSourceOpenAI: OpenAI model
       ModelSourceOpenRouter: OpenRouter model
       ModelSourceRemote: Remote model
+      ModelSourceRequesty: Requesty model
       ModelSourceSiliconFlow: SiliconFlow model
       ModelSourceVolcengine: Volcengine model
       ModelSourceZhipu: Zhipu model
@@ -2132,6 +2134,7 @@ definitions:
     - SiliconFlow model
     - Jina AI model
     - OpenRouter model
+    - Requesty model
     - NVIDIA model
     - Novita AI model
     - Azure OpenAI model
@@ -2150,6 +2153,7 @@ definitions:
     - ModelSourceSiliconFlow
     - ModelSourceJina
     - ModelSourceOpenRouter
+    - ModelSourceRequesty
     - ModelSourceNvidia
     - ModelSourceNovita
     - ModelSourceAzureOpenAI

--- a/frontend/src/components/ModelEditorDialog.vue
+++ b/frontend/src/components/ModelEditorDialog.vue
@@ -551,6 +551,16 @@ const fallbackProviderOptions = computed(() => [
     modelTypes: ['chat', 'embedding']
   },
   {
+    value: 'requesty',
+    label: t('model.editor.providers.requesty.label'),
+    defaultUrls: {
+      chat: 'https://router.requesty.ai/v1',
+      embedding: 'https://router.requesty.ai/v1'
+    },
+    description: t('model.editor.providers.requesty.description'),
+    modelTypes: ['chat', 'embedding']
+  },
+  {
     value: 'gemini',
     label: t('model.editor.providers.gemini.label'),
     defaultUrls: {

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -3951,6 +3951,10 @@ export default {
           label: 'OpenRouter',
           description: 'openai/gpt-5.2-chat, google/gemini-3-flash-preview, etc.',
         },
+        requesty: {
+          label: 'Requesty',
+          description: 'openai/gpt-4o-mini, anthropic/claude-sonnet-4-5, etc.',
+        },
         generic: {
           label: 'Custom (OpenAI-compatible)',
           description: 'Generic API endpoint',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -2941,6 +2941,10 @@ export default {
           label: "OpenRouter",
           description: "openai/gpt-5.2-chat, google/gemini-3-flash-preview 등",
         },
+        requesty: {
+          label: "Requesty",
+          description: "openai/gpt-4o-mini, anthropic/claude-sonnet-4-5 등",
+        },
         generic: {
           label: "사용자 정의 (OpenAI 호환)",
           description: "Generic API endpoint",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -2636,6 +2636,10 @@ export default {
           label: 'OpenRouter',
           description: 'openai/gpt-5.2-chat, google/gemini-3-flash-preview, etc.'
         },
+        requesty: {
+          label: 'Requesty',
+          description: 'openai/gpt-4o-mini, anthropic/claude-sonnet-4-5, etc.'
+        },
         generic: {
           label: 'Пользовательский (OpenAI-совместимый)',
           description: 'Generic API endpoint'

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2968,6 +2968,10 @@ export default {
           label: "OpenRouter",
           description: "openai/gpt-5.2-chat, google/gemini-3-flash-preview, etc.",
         },
+        requesty: {
+          label: "Requesty",
+          description: "openai/gpt-4o-mini, anthropic/claude-sonnet-4-5, etc.",
+        },
         generic: {
           label: "自定义 (OpenAI兼容接口)",
           description: "Generic API endpoint (OpenAI-compatible)",

--- a/internal/models/provider/provider.go
+++ b/internal/models/provider/provider.go
@@ -23,6 +23,8 @@ const (
 	ProviderZhipu ProviderName = "zhipu"
 	// OpenRouter
 	ProviderOpenRouter ProviderName = "openrouter"
+	// Requesty
+	ProviderRequesty ProviderName = "requesty"
 	// 硅基流动
 	ProviderSiliconFlow ProviderName = "siliconflow"
 	// Jina AI (Embedding and Rerank)
@@ -83,6 +85,7 @@ func AllProviders() []ProviderName {
 		ProviderAnthropic,
 		ProviderGemini,
 		ProviderOpenRouter,
+		ProviderRequesty,
 		ProviderJina,
 		ProviderMimo,
 		ProviderLongCat,
@@ -224,6 +227,8 @@ func DetectProvider(baseURL string) ProviderName {
 		return ProviderZhipu
 	case containsAny(baseURL, "openrouter.ai"):
 		return ProviderOpenRouter
+	case containsAny(baseURL, "router.requesty.ai", "requesty.ai"):
+		return ProviderRequesty
 	case containsAny(baseURL, "siliconflow.cn"):
 		return ProviderSiliconFlow
 	case containsAny(baseURL, "api.jina.ai"):

--- a/internal/models/provider/provider_test.go
+++ b/internal/models/provider/provider_test.go
@@ -38,6 +38,7 @@ func TestDetectProvider(t *testing.T) {
 		{"https://api.openai.com/v1", ProviderOpenAI},
 		{"https://api.anthropic.com/v1", ProviderAnthropic},
 		{"https://openrouter.ai/api/v1", ProviderOpenRouter},
+		{"https://router.requesty.ai/v1", ProviderRequesty},
 		{"https://dashscope.aliyuncs.com/compatible-mode/v1", ProviderAliyun},
 		{"https://open.bigmodel.cn/api/paas/v4", ProviderZhipu},
 		{"https://api.deepseek.com/v1", ProviderDeepSeek},
@@ -216,6 +217,38 @@ func TestZhipuProviderValidation(t *testing.T) {
 		assert.Equal(t, ProviderZhipu, info.Name)
 		assert.Equal(t, ZhipuChatBaseURL, info.GetDefaultURL(types.ModelTypeKnowledgeQA))
 		assert.Equal(t, ZhipuEmbeddingBaseURL, info.GetDefaultURL(types.ModelTypeEmbedding))
+	})
+}
+
+func TestRequestyProviderValidation(t *testing.T) {
+	p := &RequestyProvider{}
+
+	t.Run("valid config", func(t *testing.T) {
+		config := &Config{
+			APIKey:    "test-key",
+			ModelName: "openai/gpt-4o-mini",
+		}
+		err := p.ValidateConfig(config)
+		assert.NoError(t, err)
+	})
+
+	t.Run("missing API key", func(t *testing.T) {
+		config := &Config{
+			ModelName: "openai/gpt-4o-mini",
+		}
+		err := p.ValidateConfig(config)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "API key")
+	})
+
+	t.Run("info", func(t *testing.T) {
+		info := p.Info()
+		assert.Equal(t, ProviderRequesty, info.Name)
+		assert.Equal(t, "Requesty", info.DisplayName)
+		assert.Equal(t, RequestyBaseURL, info.GetDefaultURL(types.ModelTypeKnowledgeQA))
+		assert.Equal(t, RequestyBaseURL, info.GetDefaultURL(types.ModelTypeEmbedding))
+		assert.Contains(t, info.ModelTypes, types.ModelTypeKnowledgeQA)
+		assert.True(t, info.RequiresAuth)
 	})
 }
 

--- a/internal/models/provider/requesty.go
+++ b/internal/models/provider/requesty.go
@@ -1,0 +1,46 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+const (
+	RequestyBaseURL = "https://router.requesty.ai/v1"
+)
+
+// RequestyProvider 实现 Requesty 的 Provider 接口
+type RequestyProvider struct{}
+
+func init() {
+	Register(&RequestyProvider{})
+}
+
+// Info 返回 Requesty provider 的元数据
+func (p *RequestyProvider) Info() ProviderInfo {
+	return ProviderInfo{
+		Name:        ProviderRequesty,
+		DisplayName: "Requesty",
+		Description: "openai/gpt-4o-mini, anthropic/claude-sonnet-4-5, etc.",
+		DefaultURLs: map[types.ModelType]string{
+			types.ModelTypeKnowledgeQA: RequestyBaseURL,
+			types.ModelTypeEmbedding:   RequestyBaseURL,
+			types.ModelTypeVLLM:        RequestyBaseURL,
+		},
+		ModelTypes: []types.ModelType{
+			types.ModelTypeKnowledgeQA,
+			types.ModelTypeEmbedding,
+			types.ModelTypeVLLM,
+		},
+		RequiresAuth: true,
+	}
+}
+
+// ValidateConfig 验证 Requesty provider 配置
+func (p *RequestyProvider) ValidateConfig(config *Config) error {
+	if config.APIKey == "" {
+		return fmt.Errorf("API key is required for Requesty provider")
+	}
+	return nil
+}

--- a/internal/types/model.go
+++ b/internal/types/model.go
@@ -49,6 +49,7 @@ const (
 	ModelSourceSiliconFlow ModelSource = "siliconflow"  // SiliconFlow model
 	ModelSourceJina        ModelSource = "jina"         // Jina AI model
 	ModelSourceOpenRouter  ModelSource = "openrouter"   // OpenRouter model
+	ModelSourceRequesty    ModelSource = "requesty"     // Requesty model
 	ModelSourceNvidia      ModelSource = "nvidia"       // NVIDIA model
 	ModelSourceNovita      ModelSource = "novita"       // Novita AI model
 	ModelSourceAzureOpenAI ModelSource = "azure_openai" // Azure OpenAI model


### PR DESCRIPTION
Adds Requesty as a dedicated model provider, mirroring the existing OpenRouter provider. Requesty is an OpenAI-compatible LLM gateway that uses the same `provider/model` naming convention as OpenRouter (e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`).

Changes:
- `internal/models/provider/requesty.go` — `RequestyProvider` mirroring `openrouter.go` (base URL `https://router.requesty.ai/v1`, `REQUESTY_API_KEY`, `RequiresAuth`, KnowledgeQA/Embedding/VLLM URLs).
- `internal/models/provider/provider.go` — `ProviderRequesty` constant, `AllProviders()` entry, and a `DetectProvider` case for `router.requesty.ai` / `requesty.ai`.
- `internal/types/model.go` and `client/model.go` — `ModelSourceRequesty`.
- `internal/models/provider/provider_test.go` — `TestRequestyProviderValidation` and a `DetectProvider` case, mirroring the existing provider tests.
- Frontend model editor + i18n (en/zh/ko/ru) + `docs/BUILTIN_MODELS.md` provider list.
- `docs/swagger.json`, `docs/swagger.yaml`, `docs/docs.go` — added the `requesty` value to the `ModelSource` enum. These files are normally generated by `swag`; they were hand-edited to stay consistent with the enum, so please regenerate if your pipeline prefers.

Testing: `go build ./...`, `go vet ./internal/models/provider/...`, and `go test ./internal/models/provider/...` all pass; `gofmt` clean on the edited Go files. Live-tested against the real endpoint: a chat/completions call to `https://router.requesty.ai/v1` with `openai/gpt-4o-mini` returned successfully.

Docs: https://requesty.ai · https://docs.requesty.ai · https://app.requesty.ai/api-keys · https://app.requesty.ai/router/list

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
