### PR TITLE
fix(router): allow scoped API keys to poll FAQ import progress

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -387,11 +387,14 @@ func RegisterFAQRoutes(r *gin.RouterGroup, handler *handler.FAQHandler, g *rbacG
 		// FAQ import result display status
 		faq.PUT("/import/last-result/display", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.UpdateLastImportResultDisplayStatus)
 	}
-	// FAQ import progress route (outside of knowledge-base scope) — Viewer+
-	faqImport := r.Group("/faq/import")
-	{
-		faqImport.GET("/progress/:task_id", g.Viewer(), handler.GetImportProgress)
-	}
+	// FAQ import progress route (outside of knowledge-base scope) — Viewer+.
+	// Scoped API keys that can ingest (they start the import) or retrieve may
+	// poll their own import/dry-run progress. The task is tenant-scoped by
+	// requireTaskProgressTenant, so a key only ever sees its own tenant's
+	// tasks. Declared through apiKeyRoute so the APIKeyGate doesn't fail-closed
+	// and 403 the poller with "scope does not allow this operation".
+	g.apiKeyRoute(r, http.MethodGet, "/faq/import/progress/:task_id",
+		apiKeyRetrieve(apiKeyIngest(apiKeyFullAccess())), g.Viewer(), handler.GetImportProgress)
 }
 
 // RegisterKnowledgeBaseRoutes 注册知识库相关的路由

--- a/internal/router/router_api_key_capabilities_test.go
+++ b/internal/router/router_api_key_capabilities_test.go
@@ -401,6 +401,25 @@ func TestChunkerPreviewRouteRequiresRetrieveOrIngestCapability(t *testing.T) {
 	}
 }
 
+func TestFAQImportProgressRouteRequiresRetrieveOrIngestCapability(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	g := &rbacGuards{}
+	v1 := gin.New().Group("/api/v1")
+
+	RegisterFAQRoutes(v1, &handler.FAQHandler{}, g)
+
+	policy := mustLookupAPIKeyPolicy(t, g, http.MethodGet, "/api/v1/faq/import/progress/:task_id")
+	if !policy.RequireFullAccess {
+		t.Fatal("policy should require full access without a matching capability")
+	}
+	if !policyHasCapability(policy, types.APIKeyCapabilityRetrieve) {
+		t.Fatalf("policy capabilities = %#v, want retrieve", policy.Capabilities)
+	}
+	if !policyHasCapability(policy, types.APIKeyCapabilityIngest) {
+		t.Fatalf("policy capabilities = %#v, want ingest", policy.Capabilities)
+	}
+}
+
 func mustLookupAPIKeyPolicy(
 	t *testing.T,
 	g *rbacGuards,


### PR DESCRIPTION
## Summary
- Register `/faq/import/progress/:task_id` through `apiKeyRoute` with `retrieve` or `ingest` capability instead of a plain route group.
- Scoped API keys that start FAQ imports (or have retrieve access) can poll import/dry-run progress without APIKeyGate returning 403 "scope does not allow this operation".
- Task progress remains tenant-scoped via `requireTaskProgressTenant`, so keys only see their own tenant's tasks.
- Add unit test mirroring the existing chunker preview route capability coverage.

## Test plan
- [x] `go test ./internal/router/ -run TestFAQImportProgressRouteRequiresRetrieveOrIngestCapability -count=1`
- [ ] Start FAQ import with a scoped ingest API key and poll progress until completion
- [ ] Confirm full-access and JWT session callers still reach the progress endpoint