### PR TITLE
fix(files): serve shared KB images via KB-scoped file proxy

### DIFF
--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -84,7 +84,7 @@ mermaid.initialize({
     topPadding: 50
   }
 });
-const props = defineProps(["visible", "details", "knowledgeType", "sourceInfo", "canEditKB", "parse_status"]);
+const props = defineProps(["visible", "details", "knowledgeType", "sourceInfo", "canEditKB", "parse_status", "kbId"]);
 const emit = defineEmits(["closeDoc", "getDoc", "questionDeleted"]);
 
 const hasTimelineSpans = ref(false);
@@ -618,7 +618,7 @@ const runMarkdownPostRenderPipeline = async () => {
   if (!renderRoot) {
     return;
   }
-  await hydrateProtectedFileImages(renderRoot);
+  await hydrateProtectedFileImages(renderRoot, undefined, props.kbId);
   const images = renderRoot?.querySelectorAll?.('img.markdown-image') as NodeListOf<HTMLImageElement> | undefined;
   if (images) {
     images.forEach(async item => {

--- a/frontend/src/utils/security.ts
+++ b/frontend/src/utils/security.ts
@@ -430,6 +430,7 @@ function applyHydratedProtectedImage(root: ParentNode, sourceURL: string, blobUR
 export async function hydrateProtectedFileImages(
   root: ParentNode | null | undefined,
   embed?: { channelId: string; token: string },
+  kbId?: string,
 ): Promise<void> {
   if (!root || typeof window === 'undefined') {
     return;
@@ -466,9 +467,16 @@ export async function hydrateProtectedFileImages(
     img.dataset.authHydrated = '1';
 
     const isProviderScheme = isProviderFileURL(sourceURL);
+    // When a KB context is known, route through the KB-scoped proxy. It is
+    // authorized via RequireKBAccess (own / org-shared / agent-visible) and
+    // serves objects owned by the KB's source tenant — so images in a shared
+    // KB (local://<owner-tenant>/...) load for the borrowing tenant, which the
+    // tenant-scoped /files route rejects as a cross-tenant path.
     const fileProxyBase = embed
       ? `/api/v1/embed/${embed.channelId}/files`
-      : '/files';
+      : kbId
+        ? `/api/v1/knowledge-bases/${encodeURIComponent(kbId)}/files`
+        : '/files';
     const requestURL = isProviderScheme
       ? `${fileProxyBase}?${new URLSearchParams({ file_path: sourceURL }).toString()}`
       : sourceURL;
@@ -476,6 +484,7 @@ export async function hydrateProtectedFileImages(
     const isProxyRequest =
       requestURL.includes('file_path=') &&
       (requestURL.startsWith('/files?') ||
+        /^\/api\/v1\/knowledge-bases\/[^/]+\/files\?/.test(requestURL) ||
         /^\/api\/v1\/embed\/[^/]+\/files\?/.test(requestURL));
     if (!isProxyRequest) {
       img.dataset.authHydrated = '0';

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -2291,7 +2291,7 @@ async function createNewSession(value: string): Promise<void> {
       </template>
 
       <!-- DocContent drawer (shared by documents tab and wiki source refs) -->
-      <DocContent ref="docContentRef" :visible="isCardDetails" :details="details" :canEditKB="canEdit"
+      <DocContent ref="docContentRef" :visible="isCardDetails" :details="details" :canEditKB="canEdit" :kbId="kbId"
         @closeDoc="closeDoc" @getDoc="getDoc">
       </DocContent>
     </div>

--- a/frontend/src/views/knowledge/wiki/WikiBrowser.vue
+++ b/frontend/src/views/knowledge/wiki/WikiBrowser.vue
@@ -1385,7 +1385,7 @@ function closeImagePreview() {
 watch(graphDrawerContent, async () => {
   await nextTick()
   if (drawerBodyRef.value) {
-    await hydrateProtectedFileImages(drawerBodyRef.value)
+    await hydrateProtectedFileImages(drawerBodyRef.value, undefined, props.knowledgeBaseId)
   }
 })
 
@@ -1896,7 +1896,7 @@ const indexHasMore = computed(() => {
 watch(renderedContent, async () => {
   await nextTick()
   if (readerBodyRef.value) {
-    await hydrateProtectedFileImages(readerBodyRef.value)
+    await hydrateProtectedFileImages(readerBodyRef.value, undefined, props.knowledgeBaseId)
   }
 })
 
@@ -1906,7 +1906,7 @@ watch(renderedContent, async () => {
 watch(renderedIndexMarkdown, async () => {
   await nextTick()
   if (indexBodyRef.value) {
-    await hydrateProtectedFileImages(indexBodyRef.value)
+    await hydrateProtectedFileImages(indexBodyRef.value, undefined, props.knowledgeBaseId)
   }
 })
 
@@ -4449,7 +4449,7 @@ watch(() => props.view, (v) => {
   } else if (v === 'browser') {
     nextTick(async () => {
       if (readerBodyRef.value && renderedContent.value) {
-        await hydrateProtectedFileImages(readerBodyRef.value)
+        await hydrateProtectedFileImages(readerBodyRef.value, undefined, props.knowledgeBaseId)
       }
     })
   }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -213,6 +213,10 @@ func NewRouter(params RouterParams) *gin.Engine {
 		RegisterTenantRoutes(v1, params.TenantHandler, params.TenantMemberHandler, params.TenantInvitationHandler, params.AuditLogHandler, rbacGuards)
 		RegisterMyInvitationRoutes(v1, params.TenantInvitationHandler)
 		RegisterKnowledgeBaseRoutes(v1, params.KBHandler, rbacGuards)
+		// KB-scoped image proxy: lets tenants render images embedded in
+		// org-shared / agent-visible KB content, which the tenant-scoped
+		// /files route cannot serve because it enforces same-tenant paths.
+		serveKBScopedFiles(v1, rbacGuards, params.TenantService, params.FileService)
 		RegisterKnowledgeTagRoutes(v1, params.TagHandler, rbacGuards)
 		RegisterKnowledgeRoutes(v1, params.KnowledgeHandler, rbacGuards)
 		RegisterFAQRoutes(v1, params.FAQHandler, rbacGuards)
@@ -1567,6 +1571,142 @@ func serveFiles(r getRouteRegistrar, globalFileService interfaces.FileService) {
 	// attributed to a key's KB allow-list, so API keys are denied outright
 	// (embed routes use their own /embed/.../files handler).
 	r.GET("/files", middleware.DenyAPIKeyPrincipal(), newFileServeHandler(globalFileService))
+}
+
+// serveKBScopedFiles registers the KB-scoped file proxy used to render images
+// embedded in a knowledge base's content (chunks / wiki pages). Unlike the
+// tenant-scoped /files route — which enforces file_path.tenant == caller.tenant
+// and therefore cannot serve objects owned by another tenant — this route is
+// gated by RequireKBAccess. That guard resolves org-shared / agent-visible KBs
+// and rewrites the request context's tenant ID to the KB's *owner* (source)
+// tenant, so images stored under the owner tenant (local://<owner>/exports/...)
+// become reachable by tenants that legitimately share the KB, while still
+// enforcing that the requested path belongs to that owner tenant.
+//
+// Route:
+//   - GET /api/v1/knowledge-bases/:id/files?file_path=<provider://...>
+func serveKBScopedFiles(
+	r *gin.RouterGroup,
+	g *rbacGuards,
+	tenantService interfaces.TenantService,
+	globalFileService interfaces.FileService,
+) {
+	logger.Infof(context.Background(), "[Router] Serving KB-scoped files from /knowledge-bases/:id/files")
+	// API keys are denied outright (as on /files): a signed URL's tenant/KB
+	// scope cannot authorize serving an arbitrary file_path under the owner
+	// tenant, and this route deliberately crosses the caller's own tenant.
+	r.GET("/knowledge-bases/:id/files",
+		middleware.DenyAPIKeyPrincipal(),
+		g.Viewer(),
+		g.KBAccessRead("id"),
+		newKBScopedFileServeHandler(tenantService, globalFileService),
+	)
+}
+
+// newKBScopedFileServeHandler builds the handler backing serveKBScopedFiles.
+// The effective (owner) tenant is taken from the request context, which
+// RequireKBAccess has already rewritten to the KB's source tenant. The owner
+// tenant's storage config is loaded via TenantService so the file is fetched
+// from the backend that actually holds it — the caller's own storage config is
+// irrelevant here.
+func newKBScopedFileServeHandler(
+	tenantService interfaces.TenantService,
+	globalFileService interfaces.FileService,
+) gin.HandlerFunc {
+	baseDir := os.Getenv("LOCAL_STORAGE_BASE_DIR")
+	if baseDir == "" {
+		baseDir = "/data/files"
+	}
+	absDir, _ := filepath.Abs(baseDir)
+
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+
+		filePath := strings.TrimSpace(c.Query("file_path"))
+		if filePath == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "missing required parameter: file_path"})
+			return
+		}
+		if strings.Contains(filePath, "..") {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid file path"})
+			return
+		}
+
+		// RequireKBAccess rewrote the request context tenant ID to the KB's
+		// owner (source) tenant for shared KBs; for own KBs it equals the
+		// caller's tenant. Either way it is the tenant that owns this KB's
+		// storage objects, so the requested path must belong to it.
+		ownerTenantID, ok := types.TenantIDFromContext(ctx)
+		if !ok || ownerTenantID == 0 {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized: tenant context missing"})
+			return
+		}
+
+		if err := secutils.ValidateStoragePathTenant(filePath, ownerTenantID); err != nil {
+			logger.Warnf(ctx, "[Router] /knowledge-bases/:id/files denied path not owned by KB tenant: owner_tenant_id=%d file_path=%q err=%v",
+				ownerTenantID, filePath, err)
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden: file path not accessible"})
+			return
+		}
+
+		tenant, err := tenantService.GetTenantByID(ctx, ownerTenantID)
+		if err != nil || tenant == nil {
+			logger.Warnf(ctx, "[Router] /knowledge-bases/:id/files owner tenant lookup failed: owner_tenant_id=%d err=%v",
+				ownerTenantID, err)
+			c.Status(http.StatusNotFound)
+			return
+		}
+
+		provider := types.ParseProviderScheme(filePath)
+
+		var (
+			fileSvc          interfaces.FileService
+			resolvedProvider string
+		)
+		if tenant.StorageEngineConfig != nil {
+			fileSvc, resolvedProvider, err = filesvc.NewFileServiceFromStorageConfig(provider, tenant.StorageEngineConfig, absDir)
+		} else {
+			err = http.ErrMissingFile
+		}
+		if err != nil {
+			globalStorageType := strings.ToLower(strings.TrimSpace(os.Getenv("STORAGE_TYPE")))
+			if globalStorageType == "" {
+				globalStorageType = "local"
+			}
+			if provider == globalStorageType && globalFileService != nil {
+				fileSvc = globalFileService
+				resolvedProvider = globalStorageType
+			} else {
+				logger.Warnf(ctx, "[Router] /knowledge-bases/:id/files resolve file service failed: owner_tenant_id=%d provider=%s global_storage_type=%s err=%v",
+					ownerTenantID, provider, globalStorageType, err)
+				c.Status(http.StatusBadRequest)
+				return
+			}
+		}
+
+		reader, err := fileSvc.GetFile(ctx, filePath)
+		if err != nil {
+			logger.Warnf(ctx, "[Router] /knowledge-bases/:id/files get file failed: owner_tenant_id=%d provider=%s path=%q err=%v",
+				ownerTenantID, resolvedProvider, filePath, err)
+			c.Status(http.StatusNotFound)
+			return
+		}
+		defer reader.Close()
+
+		contentType, inline := secutils.SafeContentTypeByFilename(filePath)
+		c.Header("Content-Type", contentType)
+		c.Header("X-Content-Type-Options", "nosniff")
+		if !inline {
+			c.Header("Content-Disposition", "attachment")
+		}
+		// Cross-tenant shared content — keep it private so shared proxies /
+		// CDNs do not cache one tenant's view for another.
+		c.Header("Cache-Control", "private, max-age=86400")
+		c.Status(http.StatusOK)
+		if _, err := io.Copy(c.Writer, reader); err != nil {
+			logger.Warnf(ctx, "[Router] /knowledge-bases/:id/files write response failed: %v", err)
+		}
+	}
 }
 
 // servePresignedFiles serves files via HMAC-signed URLs without requiring authentication.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1642,8 +1642,8 @@ func newKBScopedFileServeHandler(
 			return
 		}
 
-		if err := secutils.ValidateStoragePathTenant(filePath, ownerTenantID); err != nil {
-			logger.Warnf(ctx, "[Router] /knowledge-bases/:id/files denied path not owned by KB tenant: owner_tenant_id=%d file_path=%q err=%v",
+		if err := secutils.ValidateKBScopedStoragePath(filePath, ownerTenantID); err != nil {
+			logger.Warnf(ctx, "[Router] /knowledge-bases/:id/files denied path not allowed for KB proxy: owner_tenant_id=%d file_path=%q err=%v",
 				ownerTenantID, filePath, err)
 			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden: file path not accessible"})
 			return

--- a/internal/router/router_files_test.go
+++ b/internal/router/router_files_test.go
@@ -179,6 +179,111 @@ func TestServeFilesRejectsAPIKeyPrincipal(t *testing.T) {
 	}
 }
 
+// newKBScopedFilesTestEngine wires newKBScopedFileServeHandler behind a
+// middleware that injects effectiveTenantID into the request context, mirroring
+// what RequireKBAccess does after resolving an org-shared KB to its source
+// tenant. This lets the handler be exercised without the full RBAC stack.
+func newKBScopedFilesTestEngine(
+	effectiveTenantID uint64,
+	tenantSvc interfaces.TenantService,
+	global interfaces.FileService,
+) *gin.Engine {
+	engine := gin.New()
+	engine.GET("/knowledge-bases/:id/files",
+		func(c *gin.Context) {
+			ctx := context.WithValue(c.Request.Context(), types.TenantIDContextKey, effectiveTenantID)
+			c.Request = c.Request.WithContext(ctx)
+			c.Next()
+		},
+		newKBScopedFileServeHandler(tenantSvc, global),
+	)
+	return engine
+}
+
+// A tenant whose owner-tenant (10008) storage objects are requested by a
+// borrowing tenant via a shared KB: the effective tenant in context is the
+// owner, so the path validates and the file is served.
+func TestKBScopedFilesServesOwnerTenantPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("STORAGE_TYPE", "local")
+
+	const ownerTenantID = uint64(10008)
+	var requestedPath string
+	engine := newKBScopedFilesTestEngine(
+		ownerTenantID,
+		&stubTenantService{get: func(_ context.Context, id uint64) (*types.Tenant, error) {
+			return &types.Tenant{ID: id}, nil
+		}},
+		&stubFileService{getFile: func(_ context.Context, filePath string) (io.ReadCloser, error) {
+			requestedPath = filePath
+			return io.NopCloser(strings.NewReader("shared-body")), nil
+		}},
+	)
+
+	filePath := "local://10008/exports/img.jpg"
+	req := httptest.NewRequest(http.MethodGet, "/knowledge-bases/kb-1/files?file_path="+url.QueryEscape(filePath), nil)
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, req)
+
+	if got, want := recorder.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d body=%s", got, want, recorder.Body.String())
+	}
+	if requestedPath != filePath {
+		t.Fatalf("requested path = %q, want %q", requestedPath, filePath)
+	}
+	if body := recorder.Body.String(); body != "shared-body" {
+		t.Fatalf("body = %q, want %q", body, "shared-body")
+	}
+}
+
+// The path must belong to the effective (owner) tenant. A path pointing at a
+// different tenant than the resolved KB owner is still rejected, so the guard
+// cannot be used to reach arbitrary tenants' files.
+func TestKBScopedFilesRejectsPathNotOwnedByKBTenant(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("STORAGE_TYPE", "local")
+
+	const ownerTenantID = uint64(10008)
+	engine := newKBScopedFilesTestEngine(
+		ownerTenantID,
+		&stubTenantService{get: func(_ context.Context, id uint64) (*types.Tenant, error) {
+			t.Fatalf("GetTenantByID should not be called for mismatched path, got %d", id)
+			return nil, nil
+		}},
+		&stubFileService{getFile: func(_ context.Context, filePath string) (io.ReadCloser, error) {
+			t.Fatalf("GetFile should not be called for mismatched path, got %q", filePath)
+			return nil, nil
+		}},
+	)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/knowledge-bases/kb-1/files?file_path="+url.QueryEscape("local://9999/exports/other.jpg"), nil)
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, req)
+
+	if got, want := recorder.Code, http.StatusForbidden; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+}
+
+func TestKBScopedFilesRequiresFilePath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	engine := newKBScopedFilesTestEngine(
+		10008,
+		&stubTenantService{},
+		&stubFileService{},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/knowledge-bases/kb-1/files", nil)
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, req)
+
+	if got, want := recorder.Code, http.StatusBadRequest; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+}
+
 func TestServeFilesForcesActiveContentDownload(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	t.Setenv("STORAGE_TYPE", "local")

--- a/internal/router/router_files_test.go
+++ b/internal/router/router_files_test.go
@@ -266,6 +266,35 @@ func TestKBScopedFilesRejectsPathNotOwnedByKBTenant(t *testing.T) {
 	}
 }
 
+// KB-scoped proxy is for embedded exports/ images only; raw knowledge uploads
+// must use /knowledge/:id/download even when the tenant matches.
+func TestKBScopedFilesRejectsNonExportsPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("STORAGE_TYPE", "local")
+
+	const ownerTenantID = uint64(10008)
+	engine := newKBScopedFilesTestEngine(
+		ownerTenantID,
+		&stubTenantService{get: func(_ context.Context, id uint64) (*types.Tenant, error) {
+			t.Fatalf("GetTenantByID should not be called for non-exports path, got %d", id)
+			return nil, nil
+		}},
+		&stubFileService{getFile: func(_ context.Context, filePath string) (io.ReadCloser, error) {
+			t.Fatalf("GetFile should not be called for non-exports path, got %q", filePath)
+			return nil, nil
+		}},
+	)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/knowledge-bases/kb-1/files?file_path="+url.QueryEscape("local://10008/knowledge-id/123.pdf"), nil)
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, req)
+
+	if got, want := recorder.Code, http.StatusForbidden; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+}
+
 func TestKBScopedFilesRequiresFilePath(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/utils/presign.go
+++ b/internal/utils/presign.go
@@ -95,9 +95,16 @@ func VerifyFileURLSig(filePath string, tenantID uint64, expiresStr, sig string) 
 	return hmac.Equal([]byte(expected), []byte(sig))
 }
 
+// kbScopedExportsSegment is the only storage prefix served by the KB-scoped
+// file proxy. Embedded wiki/chunk images land under exports/; raw knowledge
+// uploads use {tenant}/{knowledgeID}/... and are served via
+// /knowledge/{id}/download instead.
+const kbScopedExportsSegment = "exports"
+
 // ValidateStoragePathTenant ensures the tenant segment embedded in a provider://
 // storage path matches the authenticated caller's tenant. Cross-tenant access
-// must use /api/v1/files/presigned with an HMAC bound to the resource owner.
+// for arbitrary tenant paths uses /api/v1/files/presigned with an HMAC bound to
+// the resource owner; KB-scoped shared rendering uses ValidateKBScopedStoragePath.
 func ValidateStoragePathTenant(filePath string, tenantID uint64) error {
 	pathTenant := ParseTenantIDFromStoragePath(filePath)
 	if pathTenant == 0 {
@@ -107,6 +114,46 @@ func ValidateStoragePathTenant(filePath string, tenantID uint64) error {
 		return fmt.Errorf("storage path tenant mismatch")
 	}
 	return nil
+}
+
+// ValidateKBScopedStoragePath is used by GET /knowledge-bases/:id/files. It
+// requires the path to belong to the KB owner tenant and to live under the
+// exports/ namespace used for embedded images (SaveBytes / multimodal output).
+// This prevents borrowers with shared-KB read access from using the proxy to
+// fetch arbitrary owner-tenant objects such as raw knowledge uploads.
+func ValidateKBScopedStoragePath(filePath string, tenantID uint64) error {
+	if err := ValidateStoragePathTenant(filePath, tenantID); err != nil {
+		return err
+	}
+	if !storagePathHasExportsScope(filePath, tenantID) {
+		return fmt.Errorf("storage path is outside KB-scoped exports namespace")
+	}
+	return nil
+}
+
+// storagePathHasExportsScope reports whether tenantID appears next to an
+// exports segment in either canonical layout:
+//   - {tenant}/exports/...  (local, minio, s3, most cloud backends)
+//   - exports/{tenant}/...  (OSS temp-bucket layout)
+func storagePathHasExportsScope(filePath string, tenantID uint64) bool {
+	_, rest, ok := strings.Cut(filePath, "://")
+	if !ok {
+		return false
+	}
+	tenantSeg := strconv.FormatUint(tenantID, 10)
+	parts := strings.Split(rest, "/")
+	for i, part := range parts {
+		if part != tenantSeg {
+			continue
+		}
+		if i+1 < len(parts) && parts[i+1] == kbScopedExportsSegment {
+			return true
+		}
+		if i > 0 && parts[i-1] == kbScopedExportsSegment {
+			return true
+		}
+	}
+	return false
 }
 
 // ParseTenantIDFromStoragePath extracts the tenant ID from a provider:// storage path.

--- a/internal/utils/presign_test.go
+++ b/internal/utils/presign_test.go
@@ -92,6 +92,18 @@ func TestValidateStoragePathTenant(t *testing.T) {
 	assert.Error(t, ValidateStoragePathTenant("local://docs/example.txt", 42))
 }
 
+func TestValidateKBScopedStoragePath(t *testing.T) {
+	const tenantID uint64 = 10008
+
+	assert.NoError(t, ValidateKBScopedStoragePath("local://10008/exports/img.jpg", tenantID))
+	assert.NoError(t, ValidateKBScopedStoragePath("minio://bucket/10008/exports/uuid.png", tenantID))
+	assert.NoError(t, ValidateKBScopedStoragePath("oss://bucket/exports/10008/uuid.png", tenantID))
+
+	assert.Error(t, ValidateKBScopedStoragePath("local://10008/knowledge-id/123.pdf", tenantID))
+	assert.Error(t, ValidateKBScopedStoragePath("local://9999/exports/img.jpg", tenantID))
+	assert.Error(t, ValidateKBScopedStoragePath("local://10008/other/img.jpg", tenantID))
+}
+
 func TestParseTenantIDFromStoragePath(t *testing.T) {
 	tests := []struct {
 		path string


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/knowledge-bases/:id/files` as a KB-scoped image proxy, gated by `RequireKBAccess` and owner-tenant path validation, so borrowing tenants can load images embedded in org-shared / agent-visible KB content.
- Route frontend protected-image hydration through the KB-scoped proxy when `kbId` is known (`DocContent`, `WikiBrowser`, `KnowledgeBase`).
- Deny API-key principals on the new route (same policy as `/files`) and add router tests for owner-tenant serve, cross-tenant path rejection, and missing `file_path`.

## Test plan

- [x] `go test ./internal/router/... -run TestKBScopedFiles`
- [ ] Open a wiki page or chunk preview in a **borrowed** org-shared KB and confirm embedded `local://<owner-tenant>/...` images render
- [ ] Confirm own-tenant KB images still load via the new KB-scoped route
- [ ] Verify `/files` behavior is unchanged for non-KB contexts
- [ ] Confirm API keys cannot access `/api/v1/knowledge-bases/:id/files`