### PR TITLE
fix(wiki): strip internal chunk aliases from page content

### DIFF
--- a/internal/agent/prompts_wiki.go
+++ b/internal/agent/prompts_wiki.go
@@ -318,10 +318,10 @@ Now apply the instructions above to the chunks and output ONLY the JSON.`
 // WikiPageModifyPrompt updates an existing wiki page with new additions and removes stale/deleted information in a single pass.
 const WikiPageModifyPrompt = `You are a wiki editor tasked with updating an existing wiki page. You must process a set of NEW information to add, AND/OR a set of deleted documents whose exclusive contributions must be REMOVED.
 
-### STRICT CITATION & MERGE RULES (CRITICAL):
-1. **Preserve Citations:** When merging new information with existing content, you MUST strictly preserve all existing inline chunk citations (e.g., [c003]). 
-2. **Mandatory Tracing:** Any newly added factual claim, entity, or numerical data MUST be followed by an inline citation to the appropriate new source chunk (e.g., [c003]). 
-3. **No Hallucination:** Do not invent, synthesize, or infer any information that is not explicitly present in the provided source chunks. If the new chunks clearly and directly supersede or contradict existing content, update the main text to reflect the newer cited information AND add a brief "Contradictions / Updates" section summarizing the change. If the conflict is ambiguous, unresolved, or not directly supported by the provided chunks, do not overwrite the existing content; instead, add only a "Contradictions / Updates" section describing the conflict with citations.
+### SOURCE GROUNDING & MERGE RULES (CRITICAL):
+1. **No Inline Chunk IDs:** Chunk aliases such as [c003] are internal processing metadata. NEVER output them in the page body or summary, and remove any legacy inline chunk aliases from existing content while editing. Source associations are stored separately by the system.
+2. **Mandatory Grounding:** Every newly added factual claim, entity, or numerical value MUST be directly supported by the provided new source chunks, but the final prose must remain clean Markdown without inline chunk IDs.
+3. **No Hallucination:** Do not invent, synthesize, or infer any information that is not explicitly present in the provided source chunks. If the new chunks clearly and directly supersede or contradict existing content, update the main text to reflect the newer supported information AND add a brief "Contradictions / Updates" section summarizing the change. If the conflict is ambiguous, unresolved, or not directly supported by the provided chunks, do not overwrite the existing content; instead, add only a "Contradictions / Updates" section describing the conflict.
 
 <page_metadata>
   <slug>{{.PageSlug}}</slug>

--- a/internal/agent/prompts_wiki_test.go
+++ b/internal/agent/prompts_wiki_test.go
@@ -123,3 +123,21 @@ func TestWikiChunkCitationPrompt_PreservesPlaceholders(t *testing.T) {
 		}
 	}
 }
+
+func TestWikiPageModifyPrompt_HidesInternalChunkAliases(t *testing.T) {
+	for _, guidance := range []string{
+		"NEVER output them in the page body or summary",
+		"Source associations are stored separately by the system",
+		"clean Markdown without inline chunk IDs",
+	} {
+		if !strings.Contains(WikiPageModifyPrompt, guidance) {
+			t.Errorf("WikiPageModifyPrompt missing chunk-alias guidance %q", guidance)
+		}
+	}
+
+	for _, obsolete := range []string{"Preserve Citations", "followed by an inline citation"} {
+		if strings.Contains(WikiPageModifyPrompt, obsolete) {
+			t.Errorf("WikiPageModifyPrompt still contains obsolete inline-citation rule %q", obsolete)
+		}
+	}
+}

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -1877,7 +1877,10 @@ func (s *wikiIngestService) reduceSlugUpdates(
 			}
 		}
 
-		existingContent := page.Content
+		// Older generated pages may still contain short chunk aliases such as
+		// [c003]. They are internal ingest metadata; keep the editor context
+		// clean so a subsequent update cannot copy them into rewritten prose.
+		existingContent := stripWikiInlineChunkCitations(page.Content)
 		if !exists || existingContent == "" {
 			existingContent = "(New page)"
 		}

--- a/internal/application/service/wiki_page.go
+++ b/internal/application/service/wiki_page.go
@@ -21,6 +21,24 @@ import (
 // wikiLinkRegex matches [[wiki-link]] syntax in markdown content
 var wikiLinkRegex = regexp.MustCompile(`\[\[([^\]]+)\]\]`)
 
+// wikiInlineChunkCitationRegex matches internal short aliases emitted by the
+// wiki ingest prompt while it classifies supporting chunks. The stable source
+// relationship lives in WikiPage.ChunkRefs, so these aliases have no meaning
+// to readers and must not leak into generated Markdown.
+var wikiInlineChunkCitationRegex = regexp.MustCompile(`[ \t]*\[c\d{3,}(?:\s*[,;]\s*c\d{3,})*\]`)
+
+func stripWikiInlineChunkCitations(content string) string {
+	return wikiInlineChunkCitationRegex.ReplaceAllString(content, "")
+}
+
+func stripWikiPageInlineChunkCitations(page *types.WikiPage) {
+	if page == nil {
+		return
+	}
+	page.Content = stripWikiInlineChunkCitations(page.Content)
+	page.Summary = stripWikiInlineChunkCitations(page.Summary)
+}
+
 // wikiPageService implements the WikiPageService interface
 type wikiPageService struct {
 	repo            interfaces.WikiPageRepository
@@ -64,6 +82,7 @@ func (s *wikiPageService) CreatePage(ctx context.Context, page *types.WikiPage) 
 	if page.Version == 0 {
 		page.Version = 1
 	}
+	stripWikiPageInlineChunkCitations(page)
 
 	// Parse outbound links from content
 	page.OutLinks = s.parseOutLinks(page.Content)
@@ -101,6 +120,7 @@ func (s *wikiPageService) UpdatePage(ctx context.Context, page *types.WikiPage) 
 	if err != nil {
 		return nil, fmt.Errorf("get existing page: %w", err)
 	}
+	stripWikiPageInlineChunkCitations(page)
 
 	oldOutLinks := existing.OutLinks
 
@@ -183,7 +203,7 @@ func (s *wikiPageService) UpdateAutoLinkedContent(ctx context.Context, page *typ
 
 	oldOutLinks := existing.OutLinks
 
-	existing.Content = page.Content
+	existing.Content = stripWikiInlineChunkCitations(page.Content)
 	existing.OutLinks = s.parseOutLinks(existing.Content)
 	existing.UpdatedAt = time.Now()
 
@@ -199,12 +219,22 @@ func (s *wikiPageService) UpdateAutoLinkedContent(ctx context.Context, page *typ
 
 // GetPageBySlug retrieves a wiki page by its slug
 func (s *wikiPageService) GetPageBySlug(ctx context.Context, kbID string, slug string) (*types.WikiPage, error) {
-	return s.repo.GetBySlug(ctx, kbID, slug)
+	page, err := s.repo.GetBySlug(ctx, kbID, slug)
+	if err != nil {
+		return nil, err
+	}
+	stripWikiPageInlineChunkCitations(page)
+	return page, nil
 }
 
 // GetPageByID retrieves a wiki page by its ID
 func (s *wikiPageService) GetPageByID(ctx context.Context, id string) (*types.WikiPage, error) {
-	return s.repo.GetByID(ctx, id)
+	page, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	stripWikiPageInlineChunkCitations(page)
+	return page, nil
 }
 
 // ListPages lists wiki pages with optional filtering and pagination
@@ -214,6 +244,7 @@ func (s *wikiPageService) ListPages(ctx context.Context, req *types.WikiPageList
 		return nil, err
 	}
 	for _, page := range pages {
+		stripWikiPageInlineChunkCitations(page)
 		normalizeWikiHierarchy(page)
 	}
 

--- a/internal/application/service/wiki_page_test.go
+++ b/internal/application/service/wiki_page_test.go
@@ -6,6 +6,22 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 )
 
+func TestStripWikiInlineChunkCitations(t *testing.T) {
+	input := "[**橡皮障夹**](#)**钳**\n\n夹钳是用于夹持橡皮障夹的专用器械[c003]。手柄便于操作 [c003]。多个来源[c003, c1000]。"
+	want := "[**橡皮障夹**](#)**钳**\n\n夹钳是用于夹持橡皮障夹的专用器械。手柄便于操作。多个来源。"
+
+	if got := stripWikiInlineChunkCitations(input); got != want {
+		t.Fatalf("stripWikiInlineChunkCitations() = %q, want %q", got, want)
+	}
+}
+
+func TestStripWikiInlineChunkCitationsPreservesOrdinaryMarkdown(t *testing.T) {
+	input := "保留 [citation]、[C003]、[c12] 和 [[concept/c003|页面链接]]。"
+	if got := stripWikiInlineChunkCitations(input); got != input {
+		t.Fatalf("stripWikiInlineChunkCitations() changed ordinary Markdown: %q", got)
+	}
+}
+
 func TestParseOutLinks(t *testing.T) {
 	svc := &wikiPageService{}
 


### PR DESCRIPTION
## Summary
- Stop wiki page modify prompts from requiring inline `[cNNN]` chunk aliases in reader-facing Markdown; source associations remain in `ChunkRefs`.
- Strip legacy inline chunk aliases on wiki page create/update/read paths and when feeding existing content into batch ingest reduce prompts.
- Add unit tests for the stripper regex and updated prompt guidance.

## Test plan
- [x] `go test ./internal/agent/... ./internal/application/service/... -run 'TestStripWiki|TestWikiPageModify|TestWikiChunk'`
- [ ] Regenerate a wiki page from ingest and confirm body/summary contain no `[c003]`-style aliases
- [ ] Open an older page that still has legacy aliases and verify they are removed on read/update