### PR TITLE
feat(reparse): reuse chunks and processing artifacts

### DIFF
--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -42,7 +42,7 @@ func (r *chunkRepository) CreateChunks(ctx context.Context, chunks []*types.Chun
 		chunk.Content = common.CleanInvalidUTF8(chunk.Content)
 	}
 
-	db := r.db.WithContext(ctx)
+	db := DBFromContext(ctx, r.db)
 
 	// SQLite doesn't support autoIncrement on non-PK columns,
 	// so we must pre-assign SeqIDs manually (safe: single connection).
@@ -101,7 +101,7 @@ func (r *chunkRepository) ListChunksByID(
 	ctx context.Context, tenantID uint64, ids []string,
 ) ([]*types.Chunk, error) {
 	var chunks []*types.Chunk
-	if err := r.db.WithContext(ctx).
+	if err := DBFromContext(ctx, r.db).
 		Where("tenant_id = ? AND id IN ?", tenantID, ids).
 		Find(&chunks).Error; err != nil {
 		return nil, err
@@ -144,6 +144,20 @@ func (r *chunkRepository) ListChunksByKnowledgeID(
 	var chunks []*types.Chunk
 	if err := r.db.WithContext(ctx).
 		Where("tenant_id = ? AND knowledge_id = ? and chunk_type = ?", tenantID, knowledgeID, "text").
+		Order("chunk_index ASC").
+		Find(&chunks).Error; err != nil {
+		return nil, err
+	}
+	return chunks, nil
+}
+
+// ListAllChunksByKnowledgeID lists all chunk types for a knowledge ID.
+func (r *chunkRepository) ListAllChunksByKnowledgeID(
+	ctx context.Context, tenantID uint64, knowledgeID string,
+) ([]*types.Chunk, error) {
+	var chunks []*types.Chunk
+	if err := DBFromContext(ctx, r.db).
+		Where("tenant_id = ? AND knowledge_id = ?", tenantID, knowledgeID).
 		Order("chunk_index ASC").
 		Find(&chunks).Error; err != nil {
 		return nil, err
@@ -421,6 +435,47 @@ func (r *chunkRepository) UpdateChunks(ctx context.Context, chunks []*types.Chun
 	return r.db.WithContext(ctx).Exec(sql, args...).Error
 }
 
+// UpdateChunksForReparse updates fields owned by reparsing while preserving stable identity fields.
+func (r *chunkRepository) UpdateChunksForReparse(
+	ctx context.Context,
+	tenantID uint64,
+	chunks []*types.Chunk,
+) error {
+	if len(chunks) == 0 {
+		return nil
+	}
+
+	return DBFromContext(ctx, r.db).Transaction(func(tx *gorm.DB) error {
+		for _, chunk := range chunks {
+			updates := map[string]any{
+				"knowledge_base_id": chunk.KnowledgeBaseID,
+				"content":           common.CleanInvalidUTF8(chunk.Content),
+				"content_hash":      chunk.ContentHash,
+				"chunk_index":       chunk.ChunkIndex,
+				"is_enabled":        chunk.IsEnabled,
+				"status":            chunk.Status,
+				"start_at":          chunk.StartAt,
+				"end_at":            chunk.EndAt,
+				"pre_chunk_id":      chunk.PreChunkID,
+				"next_chunk_id":     chunk.NextChunkID,
+				"parent_chunk_id":   chunk.ParentChunkID,
+				"metadata":          chunk.Metadata,
+				"updated_at":        chunk.UpdatedAt,
+			}
+			result := tx.Model(&types.Chunk{}).
+				Where("tenant_id = ? AND id = ?", tenantID, chunk.ID).
+				Updates(updates)
+			if result.Error != nil {
+				return result.Error
+			}
+			if result.RowsAffected != 1 {
+				return fmt.Errorf("expected to update one active chunk %q for tenant %d, updated %d", chunk.ID, tenantID, result.RowsAffected)
+			}
+		}
+		return nil
+	})
+}
+
 // DeleteChunk deletes a chunk by its ID
 func (r *chunkRepository) DeleteChunk(ctx context.Context, tenantID uint64, id string) error {
 	return r.db.WithContext(ctx).Where("tenant_id = ? AND id = ?", tenantID, id).Delete(&types.Chunk{}).Error
@@ -439,6 +494,28 @@ func (r *chunkRepository) DeleteChunks(ctx context.Context, tenantID uint64, ids
 			end = len(ids)
 		}
 		if err := r.db.WithContext(ctx).Where("tenant_id = ? AND id IN ?", tenantID, ids[i:end]).Delete(&types.Chunk{}).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// HardDeleteChunks permanently deletes chunks by IDs in batches.
+func (r *chunkRepository) HardDeleteChunks(ctx context.Context, tenantID uint64, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	const batchSize = 5000
+	for i := 0; i < len(ids); i += batchSize {
+		end := i + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		if err := DBFromContext(ctx, r.db).
+			Unscoped().
+			Where("tenant_id = ? AND id IN ?", tenantID, ids[i:end]).
+			Delete(&types.Chunk{}).Error; err != nil {
 			return err
 		}
 	}

--- a/internal/application/repository/chunk_sqlite_test.go
+++ b/internal/application/repository/chunk_sqlite_test.go
@@ -215,3 +215,64 @@ func TestUpdateChunk_SQLite_NoNOWError(t *testing.T) {
 	require.NoError(t, db.First(&saved, "id = ?", chunk.ID).Error)
 	assert.Equal(t, "updated content", saved.Content)
 }
+
+func TestReparseRepositoryOperations(t *testing.T) {
+	db := setupChunkTestDB(t)
+	repo := NewChunkRepository(db)
+	ctx := context.Background()
+	knowledgeID := uuid.New().String()
+	kbID := uuid.New().String()
+
+	text := makeChunk(kbID, knowledgeID, types.ChunkTypeText)
+	text.ID = "stable-text"
+	text.Metadata = types.JSON(`{"questions":["q1"]}`)
+	parent := makeChunk(kbID, knowledgeID, types.ChunkTypeParentText)
+	parent.ID = "stable-parent"
+	otherTenant := makeChunk(kbID, knowledgeID, types.ChunkTypeText)
+	otherTenant.ID = "other-tenant"
+	otherTenant.TenantID = 2
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{text, parent, otherTenant}))
+
+	all, err := repo.ListAllChunksByKnowledgeID(ctx, 1, knowledgeID)
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+
+	seqID := text.SeqID
+	text.ChunkIndex = 9
+	text.PreChunkID = "before"
+	text.Status = int(types.ChunkStatusIndexed)
+	require.NoError(t, repo.UpdateChunksForReparse(ctx, 1, []*types.Chunk{text}))
+
+	saved, err := repo.GetChunkByID(ctx, 1, text.ID)
+	require.NoError(t, err)
+	assert.Equal(t, seqID, saved.SeqID)
+	assert.Equal(t, 9, saved.ChunkIndex)
+	assert.Equal(t, "before", saved.PreChunkID)
+	assert.JSONEq(t, `{"questions":["q1"]}`, saved.Metadata.ToString())
+
+	require.NoError(t, repo.HardDeleteChunks(ctx, 1, []string{text.ID}))
+	recreated := makeChunk(kbID, knowledgeID, types.ChunkTypeText)
+	recreated.ID = text.ID
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{recreated}))
+
+	other, err := repo.GetChunkByID(ctx, 2, otherTenant.ID)
+	require.NoError(t, err)
+	assert.Equal(t, otherTenant.ID, other.ID)
+}
+
+func TestUpdateChunksForReparse_RequiresTenantScopedActiveRow(t *testing.T) {
+	db := setupChunkTestDB(t)
+	repo := NewChunkRepository(db)
+	ctx := context.Background()
+
+	chunk := makeChunk(uuid.New().String(), uuid.New().String(), types.ChunkTypeText)
+	chunk.TenantID = 2
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{chunk}))
+
+	chunk.ChunkIndex = 9
+	require.Error(t, repo.UpdateChunksForReparse(ctx, 1, []*types.Chunk{chunk}))
+
+	saved, err := repo.GetChunkByID(ctx, 2, chunk.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, saved.ChunkIndex)
+}

--- a/internal/application/repository/knowledge.go
+++ b/internal/application/repository/knowledge.go
@@ -61,7 +61,7 @@ func (r *knowledgeRepository) GetKnowledgeByID(
 	id string,
 ) (*types.Knowledge, error) {
 	var knowledge types.Knowledge
-	if err := r.db.WithContext(ctx).Where("tenant_id = ? AND id = ?", tenantID, id).First(&knowledge).Error; err != nil {
+	if err := DBFromContext(ctx, r.db).Where("tenant_id = ? AND id = ?", tenantID, id).First(&knowledge).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrKnowledgeNotFound
 		}
@@ -181,8 +181,83 @@ func (r *knowledgeRepository) ListPagedKnowledgeByKnowledgeBaseID(
 
 // UpdateKnowledge updates knowledge
 func (r *knowledgeRepository) UpdateKnowledge(ctx context.Context, knowledge *types.Knowledge) error {
-	err := r.db.WithContext(ctx).Omit(omitFieldsOnUpdate...).Save(knowledge).Error
+	err := DBFromContext(ctx, r.db).Omit(omitFieldsOnUpdate...).Save(knowledge).Error
 	return err
+}
+
+// UpdateKnowledgeAndTenantStorage persists a knowledge's new storage total and
+// its tenant's exact storage delta in one transaction. Repeating a completed
+// update is idempotent because the delta is derived from the persisted total.
+func (r *knowledgeRepository) UpdateKnowledgeAndTenantStorage(
+	ctx context.Context,
+	knowledge *types.Knowledge,
+) (int64, error) {
+	var delta int64
+	err := DBFromContext(ctx, r.db).Transaction(func(tx *gorm.DB) error {
+		var current struct {
+			StorageSize int64 `gorm:"column:storage_size"`
+		}
+		if err := tx.Model(&types.Knowledge{}).
+			Select("storage_size").
+			Where("tenant_id = ? AND id = ?", knowledge.TenantID, knowledge.ID).
+			Take(&current).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrKnowledgeNotFound
+			}
+			return err
+		}
+
+		delta = knowledge.StorageSize - current.StorageSize
+		if err := tx.Omit(omitFieldsOnUpdate...).Save(knowledge).Error; err != nil {
+			return err
+		}
+		if delta == 0 {
+			return nil
+		}
+
+		result := tx.Table("tenants").
+			Where("id = ?", knowledge.TenantID).
+			UpdateColumn("storage_used", gorm.Expr(
+				"CASE WHEN storage_used + ? < 0 THEN 0 ELSE storage_used + ? END",
+				delta,
+				delta,
+			))
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 1 {
+			return ErrTenantNotFound
+		}
+		return nil
+	})
+	return delta, err
+}
+
+// WithKnowledgeReconciliation serializes destructive reconciliation for one
+// knowledge row across workers sharing the database. The transaction is placed
+// in the callback context so SQLite uses the same single connection for its
+// callback writes while PostgreSQL and MySQL retain the row lock.
+func (r *knowledgeRepository) WithKnowledgeReconciliation(
+	ctx context.Context,
+	tenantID uint64,
+	knowledgeID string,
+	fn func(context.Context) error,
+) error {
+	if fn == nil {
+		return nil
+	}
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		result := tx.Model(&types.Knowledge{}).
+			Where("tenant_id = ? AND id = ?", tenantID, knowledgeID).
+			UpdateColumn("updated_at", time.Now())
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 1 {
+			return ErrKnowledgeNotFound
+		}
+		return fn(withReconciliationDB(ctx, tx))
+	})
 }
 
 // UpdateKnowledgeBatch updates knowledge items in batch

--- a/internal/application/repository/knowledge_reconciliation_test.go
+++ b/internal/application/repository/knowledge_reconciliation_test.go
@@ -1,0 +1,176 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const tenantsStorageTestDDL = `
+CREATE TABLE IF NOT EXISTS tenants (
+    id INTEGER PRIMARY KEY,
+    storage_quota BIGINT NOT NULL DEFAULT 0,
+    storage_used BIGINT NOT NULL DEFAULT 0
+);
+`
+
+func setupKnowledgeReconciliationDB(t *testing.T, dsn string) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(knowledgesTestDDL).Error)
+	require.NoError(t, db.Exec(tenantsStorageTestDDL).Error)
+	return db
+}
+
+func seedKnowledgeStorage(t *testing.T, db *gorm.DB, storageSize, storageUsed, storageQuota int64) string {
+	t.Helper()
+	id := uuid.New().String()
+	require.NoError(t, db.Exec(
+		`INSERT INTO tenants (id, storage_quota, storage_used) VALUES (1, ?, ?)`,
+		storageQuota,
+		storageUsed,
+	).Error)
+	require.NoError(t, db.Exec(`
+		INSERT INTO knowledges (
+			id, tenant_id, knowledge_base_id, type, title, source, parse_status, storage_size
+		) VALUES (?, 1, ?, 'document', 'storage-test', 'file', 'processing', ?)
+	`, id, uuid.New().String(), storageSize).Error)
+	return id
+}
+
+func TestUpdateKnowledgeAndTenantStorageRollsBackAndRetriesIdempotently(t *testing.T) {
+	db := setupKnowledgeReconciliationDB(t, "file:"+uuid.New().String()+"?mode=memory&cache=shared")
+	repo := NewKnowledgeRepository(db).(*knowledgeRepository)
+	id := seedKnowledgeStorage(t, db, 100, 500, 1_000)
+
+	knowledge, err := repo.GetKnowledgeByID(context.Background(), 1, id)
+	require.NoError(t, err)
+	knowledge.StorageSize = 200
+	knowledge.Title = "updated"
+
+	adjustErr := errors.New("injected tenant adjustment failure")
+	require.NoError(t, db.Callback().Update().Before("gorm:update").Register(
+		"test:fail_tenant_storage_adjustment",
+		func(tx *gorm.DB) {
+			if tx.Statement.Table == "tenants" {
+				tx.AddError(adjustErr)
+			}
+		},
+	))
+
+	_, err = repo.UpdateKnowledgeAndTenantStorage(context.Background(), knowledge)
+	require.ErrorIs(t, err, adjustErr)
+
+	var persistedStorage, tenantUsed int64
+	require.NoError(t, db.Raw("SELECT storage_size FROM knowledges WHERE id = ?", id).Scan(&persistedStorage).Error)
+	require.NoError(t, db.Raw("SELECT storage_used FROM tenants WHERE id = 1").Scan(&tenantUsed).Error)
+	assert.EqualValues(t, 100, persistedStorage)
+	assert.EqualValues(t, 500, tenantUsed)
+
+	require.NoError(t, db.Callback().Update().Remove("test:fail_tenant_storage_adjustment"))
+	delta, err := repo.UpdateKnowledgeAndTenantStorage(context.Background(), knowledge)
+	require.NoError(t, err)
+	assert.EqualValues(t, 100, delta)
+
+	delta, err = repo.UpdateKnowledgeAndTenantStorage(context.Background(), knowledge)
+	require.NoError(t, err)
+	assert.Zero(t, delta)
+
+	require.NoError(t, db.Raw("SELECT storage_size FROM knowledges WHERE id = ?", id).Scan(&persistedStorage).Error)
+	require.NoError(t, db.Raw("SELECT storage_used FROM tenants WHERE id = 1").Scan(&tenantUsed).Error)
+	assert.EqualValues(t, 200, persistedStorage)
+	assert.EqualValues(t, 600, tenantUsed)
+}
+
+func TestWithKnowledgeReconciliationSerializesOverlappingAttempts(t *testing.T) {
+	dbPath := filepath.ToSlash(filepath.Join(t.TempDir(), "reconciliation.db"))
+	dsn := "file:" + dbPath + "?_busy_timeout=5000&_journal_mode=WAL"
+	db1 := setupKnowledgeReconciliationDB(t, dsn)
+	db2 := setupKnowledgeReconciliationDB(t, dsn)
+	for _, db := range []*gorm.DB{db1, db2} {
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, sqlDB.Close()) })
+	}
+
+	id := seedKnowledgeStorage(t, db1, 100, 500, 1_000)
+	repo1 := NewKnowledgeRepository(db1).(*knowledgeRepository)
+	repo2 := NewKnowledgeRepository(db2).(*knowledgeRepository)
+
+	var resource atomic.Value
+	resource.Store("old")
+	firstPassedCheck := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondEntered := make(chan struct{})
+	firstDone := make(chan error, 1)
+	secondDone := make(chan error, 1)
+
+	go func() {
+		firstDone <- repo1.WithKnowledgeReconciliation(
+			context.Background(), 1, id,
+			func(context.Context) error {
+				close(firstPassedCheck)
+				<-releaseFirst
+				resource.Store("deleted-by-first")
+				return nil
+			},
+		)
+	}()
+	<-firstPassedCheck
+
+	go func() {
+		secondDone <- repo2.WithKnowledgeReconciliation(
+			context.Background(), 1, id,
+			func(context.Context) error {
+				close(secondEntered)
+				resource.Store("newer-attempt")
+				return nil
+			},
+		)
+	}()
+
+	select {
+	case <-secondEntered:
+		t.Fatal("newer attempt entered while the first attempt held the knowledge reconciliation lock")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+	require.NoError(t, <-firstDone)
+	require.NoError(t, <-secondDone)
+	assert.Equal(t, "newer-attempt", resource.Load())
+}
+
+func TestWithKnowledgeReconciliationSharesTransactionWithCallbackWrites(t *testing.T) {
+	db := setupKnowledgeReconciliationDB(t, "file:"+uuid.New().String()+"?mode=memory&cache=shared")
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	id := seedKnowledgeStorage(t, db, 100, 500, 1_000)
+	repo := NewKnowledgeRepository(db).(*knowledgeRepository)
+	knowledge, err := repo.GetKnowledgeByID(context.Background(), 1, id)
+	require.NoError(t, err)
+	knowledge.Title = "written-under-reconciliation-lock"
+
+	require.NoError(t, repo.WithKnowledgeReconciliation(
+		context.Background(), 1, id,
+		func(ctx context.Context) error {
+			return repo.UpdateKnowledge(ctx, knowledge)
+		},
+	))
+
+	persisted, err := repo.GetKnowledgeByID(context.Background(), 1, id)
+	require.NoError(t, err)
+	assert.Equal(t, "written-under-reconciliation-lock", persisted.Title)
+}

--- a/internal/application/repository/knowledge_span_repo.go
+++ b/internal/application/repository/knowledge_span_repo.go
@@ -106,7 +106,7 @@ func (r *knowledgeSpanRepository) Upsert(ctx context.Context, row *types.Knowled
 
 func (r *knowledgeSpanRepository) NextAttempt(ctx context.Context, knowledgeID string) (int, error) {
 	var max int
-	err := r.db.WithContext(ctx).Model(&types.KnowledgeProcessingSpan{}).
+	err := DBFromContext(ctx, r.db).Model(&types.KnowledgeProcessingSpan{}).
 		Where("knowledge_id = ?", knowledgeID).
 		Select("COALESCE(MAX(attempt), 0)").
 		Row().Scan(&max)
@@ -118,7 +118,7 @@ func (r *knowledgeSpanRepository) NextAttempt(ctx context.Context, knowledgeID s
 
 func (r *knowledgeSpanRepository) LatestAttempt(ctx context.Context, knowledgeID string) (int, error) {
 	var max int
-	err := r.db.WithContext(ctx).Model(&types.KnowledgeProcessingSpan{}).
+	err := DBFromContext(ctx, r.db).Model(&types.KnowledgeProcessingSpan{}).
 		Where("knowledge_id = ?", knowledgeID).
 		Select("COALESCE(MAX(attempt), 0)").
 		Row().Scan(&max)

--- a/internal/application/repository/processing_artifact.go
+++ b/internal/application/repository/processing_artifact.go
@@ -17,6 +17,8 @@ var (
 	processingArtifactHashPattern  = regexp.MustCompile(`^[0-9a-f]{64}$`)
 )
 
+const processingArtifactBatchSize = 500
+
 type processingArtifactRepository struct {
 	db *gorm.DB
 }
@@ -45,6 +47,53 @@ func (r *processingArtifactRepository) Get(
 	return &artifact, nil
 }
 
+func (r *processingArtifactRepository) GetMany(
+	ctx context.Context,
+	keys []types.ProcessingArtifactKey,
+) (map[types.ProcessingArtifactKey]*types.ProcessingArtifact, error) {
+	result := make(map[types.ProcessingArtifactKey]*types.ProcessingArtifact, len(keys))
+	type keyGroup struct {
+		tenantID   uint64
+		stage      string
+		keyVersion uint16
+	}
+	groups := make(map[keyGroup]map[string]struct{})
+	for _, key := range keys {
+		group := keyGroup{tenantID: key.TenantID, stage: key.Stage, keyVersion: key.KeyVersion}
+		if groups[group] == nil {
+			groups[group] = make(map[string]struct{})
+		}
+		groups[group][key.InputFingerprint] = struct{}{}
+	}
+
+	for group, fingerprints := range groups {
+		values := make([]string, 0, len(fingerprints))
+		for fingerprint := range fingerprints {
+			values = append(values, fingerprint)
+		}
+		for start := 0; start < len(values); start += processingArtifactBatchSize {
+			end := min(start+processingArtifactBatchSize, len(values))
+			var artifacts []*types.ProcessingArtifact
+			if err := r.db.WithContext(ctx).
+				Where("tenant_id = ? AND stage = ? AND key_version = ?", group.tenantID, group.stage, group.keyVersion).
+				Where("input_fingerprint IN ?", values[start:end]).
+				Find(&artifacts).Error; err != nil {
+				return nil, err
+			}
+			for _, artifact := range artifacts {
+				key := types.ProcessingArtifactKey{
+					TenantID:         artifact.TenantID,
+					Stage:            artifact.Stage,
+					KeyVersion:       artifact.KeyVersion,
+					InputFingerprint: artifact.InputFingerprint,
+				}
+				result[key] = artifact
+			}
+		}
+	}
+	return result, nil
+}
+
 func (r *processingArtifactRepository) PutIfAbsent(
 	ctx context.Context,
 	artifact *types.ProcessingArtifact,
@@ -63,6 +112,29 @@ func (r *processingArtifactRepository) PutIfAbsent(
 		DoNothing: true,
 	}).Create(artifact)
 	return result.RowsAffected == 1, result.Error
+}
+
+func (r *processingArtifactRepository) PutManyIfAbsent(
+	ctx context.Context,
+	artifacts []*types.ProcessingArtifact,
+) error {
+	if len(artifacts) == 0 {
+		return nil
+	}
+	for _, artifact := range artifacts {
+		if err := validateProcessingArtifact(artifact); err != nil {
+			return err
+		}
+	}
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "tenant_id"},
+			{Name: "stage"},
+			{Name: "key_version"},
+			{Name: "input_fingerprint"},
+		},
+		DoNothing: true,
+	}).CreateInBatches(artifacts, processingArtifactBatchSize).Error
 }
 
 func (r *processingArtifactRepository) DeleteByID(ctx context.Context, tenantID, id uint64) error {

--- a/internal/application/repository/processing_artifact.go
+++ b/internal/application/repository/processing_artifact.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
@@ -45,6 +46,24 @@ func (r *processingArtifactRepository) Get(
 		return nil, err
 	}
 	return &artifact, nil
+}
+
+func (r *processingArtifactRepository) ListExpired(
+	ctx context.Context,
+	cutoff time.Time,
+	afterID uint64,
+	limit int,
+) ([]*types.ProcessingArtifact, error) {
+	var artifacts []*types.ProcessingArtifact
+	if err := r.db.WithContext(ctx).
+		Select("id", "tenant_id", "stage", "object_path", "size_bytes").
+		Where("created_at < ? AND id > ?", cutoff, afterID).
+		Order("id ASC").
+		Limit(limit).
+		Find(&artifacts).Error; err != nil {
+		return nil, err
+	}
+	return artifacts, nil
 }
 
 func (r *processingArtifactRepository) GetMany(
@@ -138,9 +157,18 @@ func (r *processingArtifactRepository) PutManyIfAbsent(
 }
 
 func (r *processingArtifactRepository) DeleteByID(ctx context.Context, tenantID, id uint64) error {
-	return r.db.WithContext(ctx).
+	_, err := r.DeleteByIDWithResult(ctx, tenantID, id)
+	return err
+}
+
+func (r *processingArtifactRepository) DeleteByIDWithResult(
+	ctx context.Context,
+	tenantID, id uint64,
+) (bool, error) {
+	result := r.db.WithContext(ctx).
 		Where("tenant_id = ? AND id = ?", tenantID, id).
-		Delete(&types.ProcessingArtifact{}).Error
+		Delete(&types.ProcessingArtifact{})
+	return result.RowsAffected == 1, result.Error
 }
 
 func validateProcessingArtifact(artifact *types.ProcessingArtifact) error {

--- a/internal/application/repository/processing_artifact.go
+++ b/internal/application/repository/processing_artifact.go
@@ -1,0 +1,103 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+var (
+	processingArtifactStagePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+	processingArtifactHashPattern  = regexp.MustCompile(`^[0-9a-f]{64}$`)
+)
+
+type processingArtifactRepository struct {
+	db *gorm.DB
+}
+
+func NewProcessingArtifactRepository(db *gorm.DB) interfaces.ProcessingArtifactRepository {
+	return &processingArtifactRepository{db: db}
+}
+
+func (r *processingArtifactRepository) Get(
+	ctx context.Context,
+	key types.ProcessingArtifactKey,
+) (*types.ProcessingArtifact, error) {
+	var artifact types.ProcessingArtifact
+	err := r.db.WithContext(ctx).
+		Where(
+			"tenant_id = ? AND stage = ? AND key_version = ? AND input_fingerprint = ?",
+			key.TenantID, key.Stage, key.KeyVersion, key.InputFingerprint,
+		).
+		First(&artifact).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, types.ErrProcessingArtifactNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &artifact, nil
+}
+
+func (r *processingArtifactRepository) PutIfAbsent(
+	ctx context.Context,
+	artifact *types.ProcessingArtifact,
+) (bool, error) {
+	if err := validateProcessingArtifact(artifact); err != nil {
+		return false, err
+	}
+
+	result := r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "tenant_id"},
+			{Name: "stage"},
+			{Name: "key_version"},
+			{Name: "input_fingerprint"},
+		},
+		DoNothing: true,
+	}).Create(artifact)
+	return result.RowsAffected == 1, result.Error
+}
+
+func (r *processingArtifactRepository) DeleteByID(ctx context.Context, tenantID, id uint64) error {
+	return r.db.WithContext(ctx).
+		Where("tenant_id = ? AND id = ?", tenantID, id).
+		Delete(&types.ProcessingArtifact{}).Error
+}
+
+func validateProcessingArtifact(artifact *types.ProcessingArtifact) error {
+	if artifact == nil {
+		return errors.New("processing artifact must not be nil")
+	}
+	if artifact.TenantID == 0 {
+		return errors.New("processing artifact tenant ID must not be zero")
+	}
+	if !processingArtifactStagePattern.MatchString(artifact.Stage) {
+		return fmt.Errorf("invalid processing artifact stage %q", artifact.Stage)
+	}
+	if artifact.KeyVersion == 0 {
+		return errors.New("processing artifact key version must not be zero")
+	}
+	if !processingArtifactHashPattern.MatchString(artifact.InputFingerprint) {
+		return errors.New("processing artifact input fingerprint must be 64 lowercase hex characters")
+	}
+	if !processingArtifactHashPattern.MatchString(artifact.ContentSHA256) {
+		return errors.New("processing artifact content SHA-256 must be 64 lowercase hex characters")
+	}
+	if artifact.SizeBytes < 0 {
+		return errors.New("processing artifact size must not be negative")
+	}
+	if artifact.ObjectPath == "" && artifact.Payload == nil {
+		return errors.New("inline processing artifact payload must not be nil")
+	}
+	if artifact.ObjectPath != "" && artifact.Payload != nil {
+		return errors.New("object processing artifact payload must be nil")
+	}
+	return nil
+}

--- a/internal/application/repository/processing_artifact_test.go
+++ b/internal/application/repository/processing_artifact_test.go
@@ -1,0 +1,263 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const processingArtifactsTestDDL = `
+CREATE TABLE processing_artifacts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id INTEGER NOT NULL,
+    stage VARCHAR(64) NOT NULL,
+    key_version INTEGER NOT NULL,
+    input_fingerprint CHAR(64) NOT NULL,
+    payload BLOB NULL,
+    object_path TEXT NOT NULL DEFAULT '',
+    content_sha256 CHAR(64) NOT NULL,
+    size_bytes BIGINT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, stage, key_version, input_fingerprint)
+);
+`
+
+func setupProcessingArtifactTestDBs(t *testing.T) (*gorm.DB, *gorm.DB) {
+	t.Helper()
+	dbPath := filepath.ToSlash(filepath.Join(t.TempDir(), "processing-artifacts.db"))
+	dsn := fmt.Sprintf("file:%s?_busy_timeout=5000&_journal_mode=WAL", dbPath)
+
+	open := func() *gorm.DB {
+		db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+		require.NoError(t, err)
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		sqlDB.SetMaxOpenConns(1)
+		t.Cleanup(func() { require.NoError(t, sqlDB.Close()) })
+		return db
+	}
+
+	first := open()
+	require.NoError(t, first.Exec(processingArtifactsTestDDL).Error)
+	return first, open()
+}
+
+func processingArtifact(tenantID uint64, stage string, keyVersion uint16, fingerprint, payload string) *types.ProcessingArtifact {
+	return &types.ProcessingArtifact{
+		TenantID:         tenantID,
+		Stage:            stage,
+		KeyVersion:       keyVersion,
+		InputFingerprint: fingerprint,
+		Payload:          []byte(payload),
+		ContentSHA256:    strings.Repeat("a", 64),
+		SizeBytes:        int64(len(payload)),
+	}
+}
+
+func artifactKey(artifact *types.ProcessingArtifact) types.ProcessingArtifactKey {
+	return types.ProcessingArtifactKey{
+		TenantID:         artifact.TenantID,
+		Stage:            artifact.Stage,
+		KeyVersion:       artifact.KeyVersion,
+		InputFingerprint: artifact.InputFingerprint,
+	}
+}
+
+func TestProcessingArtifactPutIfAbsentConverges(t *testing.T) {
+	db1, db2 := setupProcessingArtifactTestDBs(t)
+	repositories := []interface {
+		PutIfAbsent(context.Context, *types.ProcessingArtifact) (bool, error)
+		Get(context.Context, types.ProcessingArtifactKey) (*types.ProcessingArtifact, error)
+	}{
+		NewProcessingArtifactRepository(db1),
+		NewProcessingArtifactRepository(db2),
+	}
+	artifacts := []*types.ProcessingArtifact{
+		processingArtifact(7, "chunking", 1, strings.Repeat("1", 64), "winner-one"),
+		processingArtifact(7, "chunking", 1, strings.Repeat("1", 64), "winner-two-with-more-bytes"),
+	}
+	artifacts[1].ContentSHA256 = strings.Repeat("b", 64)
+
+	start := make(chan struct{})
+	type putResult struct {
+		candidate int
+		created   bool
+		err       error
+	}
+	results := make(chan putResult, len(repositories))
+	var ready sync.WaitGroup
+	var wg sync.WaitGroup
+	ready.Add(len(repositories))
+	for i := range repositories {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ready.Done()
+			<-start
+			wasCreated, err := repositories[i].PutIfAbsent(context.Background(), artifacts[i])
+			results <- putResult{candidate: i, created: wasCreated, err: err}
+		}(i)
+	}
+	ready.Wait()
+	close(start)
+	wg.Wait()
+	close(results)
+
+	createdCount := 0
+	var winner *types.ProcessingArtifact
+	for result := range results {
+		require.NoError(t, result.err)
+		if result.created {
+			createdCount++
+			winner = artifacts[result.candidate]
+		}
+	}
+	require.Equal(t, 1, createdCount)
+	require.NotNil(t, winner)
+
+	key := artifactKey(artifacts[0])
+	var persistedID uint64
+	for i, repo := range repositories {
+		persisted, err := repo.Get(context.Background(), key)
+		require.NoError(t, err)
+		assert.Equal(t, winner.Payload, persisted.Payload)
+		assert.Equal(t, winner.ContentSHA256, persisted.ContentSHA256)
+		assert.Equal(t, winner.SizeBytes, persisted.SizeBytes)
+		if i == 0 {
+			persistedID = persisted.ID
+		} else {
+			assert.Equal(t, persistedID, persisted.ID)
+		}
+	}
+}
+
+func TestProcessingArtifactRepositoryScopesByFullKey(t *testing.T) {
+	db, _ := setupProcessingArtifactTestDBs(t)
+	repo := NewProcessingArtifactRepository(db)
+	fingerprint := strings.Repeat("2", 64)
+	fingerprintVariant := processingArtifact(7, "chunking", 1, strings.Repeat("7", 64), "fingerprint-variant")
+	fingerprintVariant.ContentSHA256 = strings.Repeat("b", 64)
+	artifacts := []*types.ProcessingArtifact{
+		processingArtifact(7, "chunking", 1, fingerprint, "tenant-seven"),
+		processingArtifact(8, "chunking", 1, fingerprint, "tenant-eight"),
+		processingArtifact(7, "embedding", 1, fingerprint, "embedding"),
+		processingArtifact(7, "chunking", 2, fingerprint, "version-two"),
+		fingerprintVariant,
+	}
+
+	for _, artifact := range artifacts {
+		created, err := repo.PutIfAbsent(context.Background(), artifact)
+		require.NoError(t, err)
+		require.True(t, created)
+	}
+
+	for _, want := range artifacts {
+		got, err := repo.Get(context.Background(), artifactKey(want))
+		require.NoError(t, err)
+		assert.Equal(t, want.Payload, got.Payload)
+		assert.Equal(t, want.TenantID, got.TenantID)
+		assert.Equal(t, want.Stage, got.Stage)
+		assert.Equal(t, want.KeyVersion, got.KeyVersion)
+		assert.Equal(t, want.InputFingerprint, got.InputFingerprint)
+		assert.Equal(t, want.ContentSHA256, got.ContentSHA256)
+		assert.Equal(t, want.SizeBytes, got.SizeBytes)
+	}
+}
+
+func TestProcessingArtifactDeleteByIDRequiresTenant(t *testing.T) {
+	db, _ := setupProcessingArtifactTestDBs(t)
+	repo := NewProcessingArtifactRepository(db)
+	artifact := processingArtifact(7, "chunking", 1, strings.Repeat("3", 64), "protected")
+	created, err := repo.PutIfAbsent(context.Background(), artifact)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	stored, err := repo.Get(context.Background(), artifactKey(artifact))
+	require.NoError(t, err)
+	require.NoError(t, repo.DeleteByID(context.Background(), 8, stored.ID))
+	_, err = repo.Get(context.Background(), artifactKey(artifact))
+	require.NoError(t, err)
+
+	require.NoError(t, repo.DeleteByID(context.Background(), 7, stored.ID))
+	_, err = repo.Get(context.Background(), artifactKey(artifact))
+	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+}
+
+func TestProcessingArtifactPutIfAbsentValidatesImmutableFields(t *testing.T) {
+	db, _ := setupProcessingArtifactTestDBs(t)
+	repo := NewProcessingArtifactRepository(db)
+	valid := processingArtifact(7, "chunking", 1, strings.Repeat("4", 64), "inline")
+
+	tests := map[string]func(*types.ProcessingArtifact){
+		"zero tenant":            func(a *types.ProcessingArtifact) { a.TenantID = 0 },
+		"invalid stage":          func(a *types.ProcessingArtifact) { a.Stage = "Chunking" },
+		"zero key version":       func(a *types.ProcessingArtifact) { a.KeyVersion = 0 },
+		"invalid fingerprint":    func(a *types.ProcessingArtifact) { a.InputFingerprint = strings.Repeat("A", 64) },
+		"invalid content hash":   func(a *types.ProcessingArtifact) { a.ContentSHA256 = strings.Repeat("g", 64) },
+		"negative size":          func(a *types.ProcessingArtifact) { a.SizeBytes = -1 },
+		"inline without payload": func(a *types.ProcessingArtifact) { a.Payload = nil },
+		"object with payload":    func(a *types.ProcessingArtifact) { a.ObjectPath = "tenant/7/artifact" },
+	}
+
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			artifact := *valid
+			artifact.Payload = append([]byte(nil), valid.Payload...)
+			mutate(&artifact)
+			created, err := repo.PutIfAbsent(context.Background(), &artifact)
+			assert.False(t, created)
+			assert.Error(t, err)
+		})
+	}
+
+	created, err := repo.PutIfAbsent(context.Background(), nil)
+	assert.False(t, created)
+	assert.Error(t, err)
+
+	emptyInline := processingArtifact(7, "chunking", 1, strings.Repeat("8", 64), "")
+	emptyInline.Payload = []byte{}
+	require.NotNil(t, emptyInline.Payload)
+	created, err = repo.PutIfAbsent(context.Background(), emptyInline)
+	require.NoError(t, err)
+	assert.True(t, created)
+
+	emptyObject := processingArtifact(7, "chunking", 1, strings.Repeat("9", 64), "")
+	emptyObject.Payload = []byte{}
+	emptyObject.ObjectPath = "tenant/7/invalid-empty-object"
+	created, err = repo.PutIfAbsent(context.Background(), emptyObject)
+	assert.False(t, created)
+	assert.Error(t, err)
+
+	objectArtifact := processingArtifact(7, "chunking", 1, strings.Repeat("5", 64), "")
+	objectArtifact.Payload = nil
+	objectArtifact.ObjectPath = "tenant/7/artifact"
+	objectArtifact.SizeBytes = 42
+	created, err = repo.PutIfAbsent(context.Background(), objectArtifact)
+	require.NoError(t, err)
+	assert.True(t, created)
+}
+
+func TestProcessingArtifactGetMapsOnlyRecordNotFound(t *testing.T) {
+	db, _ := setupProcessingArtifactTestDBs(t)
+	repo := NewProcessingArtifactRepository(db)
+	key := types.ProcessingArtifactKey{
+		TenantID:         7,
+		Stage:            "chunking",
+		KeyVersion:       1,
+		InputFingerprint: strings.Repeat("6", 64),
+	}
+
+	_, err := repo.Get(context.Background(), key)
+	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+	assert.False(t, errors.Is(err, gorm.ErrRecordNotFound))
+}

--- a/internal/application/repository/processing_artifact_test.go
+++ b/internal/application/repository/processing_artifact_test.go
@@ -174,6 +174,70 @@ func TestProcessingArtifactRepositoryScopesByFullKey(t *testing.T) {
 	}
 }
 
+func TestProcessingArtifactRepositoryBatchPutAndGetPreservesWinners(t *testing.T) {
+	db, _ := setupProcessingArtifactTestDBs(t)
+	repo := NewProcessingArtifactRepository(db)
+	batchRepo, ok := repo.(interface {
+		GetMany(context.Context, []types.ProcessingArtifactKey) (
+			map[types.ProcessingArtifactKey]*types.ProcessingArtifact, error,
+		)
+		PutManyIfAbsent(context.Context, []*types.ProcessingArtifact) error
+	})
+	require.True(t, ok)
+
+	winner := processingArtifact(7, "embedding.vector", 1, strings.Repeat("1", 64), "winner")
+	created, err := repo.PutIfAbsent(context.Background(), winner)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	loser := processingArtifact(7, "embedding.vector", 1, strings.Repeat("1", 64), "loser")
+	loser.ContentSHA256 = strings.Repeat("b", 64)
+	otherTenant := processingArtifact(8, "embedding.vector", 1, strings.Repeat("1", 64), "tenant-eight")
+	otherStage := processingArtifact(7, "vlm.markdown", 1, strings.Repeat("2", 64), "other-stage")
+	require.NoError(t, batchRepo.PutManyIfAbsent(
+		context.Background(),
+		[]*types.ProcessingArtifact{loser, otherTenant, otherStage},
+	))
+
+	missing := types.ProcessingArtifactKey{
+		TenantID: 7, Stage: "embedding.vector", KeyVersion: 1,
+		InputFingerprint: strings.Repeat("f", 64),
+	}
+	got, err := batchRepo.GetMany(context.Background(), []types.ProcessingArtifactKey{
+		artifactKey(winner), artifactKey(otherTenant), artifactKey(otherStage), missing,
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, []byte("winner"), got[artifactKey(winner)].Payload)
+	assert.Equal(t, []byte("tenant-eight"), got[artifactKey(otherTenant)].Payload)
+	assert.Equal(t, []byte("other-stage"), got[artifactKey(otherStage)].Payload)
+	assert.NotContains(t, got, missing)
+}
+
+func TestProcessingArtifactRepositoryGetManyChunksLargeInputs(t *testing.T) {
+	db, _ := setupProcessingArtifactTestDBs(t)
+	repo := NewProcessingArtifactRepository(db)
+	batchRepo, ok := repo.(interface {
+		GetMany(context.Context, []types.ProcessingArtifactKey) (
+			map[types.ProcessingArtifactKey]*types.ProcessingArtifact, error,
+		)
+	})
+	require.True(t, ok)
+
+	keys := make([]types.ProcessingArtifactKey, 33_000)
+	for i := range keys {
+		keys[i] = types.ProcessingArtifactKey{
+			TenantID:         7,
+			Stage:            "embedding.vector",
+			KeyVersion:       1,
+			InputFingerprint: fmt.Sprintf("%064x", i),
+		}
+	}
+	got, err := batchRepo.GetMany(context.Background(), keys)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
 func TestProcessingArtifactDeleteByIDRequiresTenant(t *testing.T) {
 	db, _ := setupProcessingArtifactTestDBs(t)
 	repo := NewProcessingArtifactRepository(db)

--- a/internal/application/repository/processing_artifact_test.go
+++ b/internal/application/repository/processing_artifact_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/stretchr/testify/assert"
@@ -324,4 +326,83 @@ func TestProcessingArtifactGetMapsOnlyRecordNotFound(t *testing.T) {
 	_, err := repo.Get(context.Background(), key)
 	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
 	assert.False(t, errors.Is(err, gorm.ErrRecordNotFound))
+}
+
+func TestProcessingArtifactListExpiredUsesCutoffAndIDPagination(t *testing.T) {
+	db, _ := setupProcessingArtifactTestDBs(t)
+	repo := NewProcessingArtifactRepository(db)
+	cutoff := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+
+	artifacts := []*types.ProcessingArtifact{
+		processingArtifact(7, "chunking", 1, strings.Repeat("a", 64), "first-old"),
+		processingArtifact(8, "chunking", 1, strings.Repeat("b", 64), "second-old"),
+		processingArtifact(7, "embedding.vector", 1, strings.Repeat("c", 64), "third-old"),
+		processingArtifact(9, "chunking", 1, strings.Repeat("d", 64), "at-cutoff"),
+		processingArtifact(7, "chunking", 2, strings.Repeat("e", 64), "new"),
+	}
+	for _, artifact := range artifacts {
+		created, err := repo.PutIfAbsent(context.Background(), artifact)
+		require.NoError(t, err)
+		require.True(t, created)
+	}
+	for index, artifact := range artifacts {
+		createdAt := cutoff.Add(-time.Hour)
+		if index == 3 {
+			createdAt = cutoff
+		}
+		if index == 4 {
+			createdAt = cutoff.Add(time.Hour)
+		}
+		require.NoError(t, db.Model(&types.ProcessingArtifact{}).
+			Where("id = ?", artifact.ID).
+			Update("created_at", createdAt).Error)
+	}
+
+	firstPage, err := repo.ListExpired(context.Background(), cutoff, 0, 2)
+	require.NoError(t, err)
+	require.Len(t, firstPage, 2)
+	assert.Equal(t, []uint64{artifacts[0].ID, artifacts[1].ID}, []uint64{firstPage[0].ID, firstPage[1].ID})
+	for _, artifact := range firstPage {
+		assert.Nil(t, artifact.Payload)
+		assert.NotZero(t, artifact.TenantID)
+		assert.NotEmpty(t, artifact.Stage)
+		assert.NotZero(t, artifact.SizeBytes)
+	}
+
+	secondPage, err := repo.ListExpired(context.Background(), cutoff, firstPage[1].ID, 2)
+	require.NoError(t, err)
+	require.Len(t, secondPage, 1)
+	assert.Equal(t, artifacts[2].ID, secondPage[0].ID)
+}
+
+func TestProcessingArtifactMigrationsIncludeAllTenantRetentionIndex(t *testing.T) {
+	root := filepath.Join("..", "..", "..")
+	upPaths := []string{
+		"migrations/versioned/000069_processing_artifacts.up.sql",
+		"migrations/sqlite/000001_processing_artifacts.up.sql",
+		"migrations/mysql/00-init-db.sql",
+		"migrations/paradedb/00-init-db.sql",
+	}
+	for _, path := range upPaths {
+		t.Run(path, func(t *testing.T) {
+			content, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(path)))
+			require.NoError(t, err)
+			sql := strings.ToLower(string(content))
+			assert.Contains(t, sql, "idx_processing_artifacts_created_id")
+			assert.Contains(t, sql, "processing_artifacts (created_at, id)")
+			assert.Contains(t, sql, "idx_processing_artifacts_tenant_created")
+		})
+	}
+
+	for _, path := range []string{
+		"migrations/versioned/000069_processing_artifacts.down.sql",
+		"migrations/sqlite/000001_processing_artifacts.down.sql",
+	} {
+		t.Run(path, func(t *testing.T) {
+			content, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(path)))
+			require.NoError(t, err)
+			sql := strings.ToLower(string(content))
+			assert.Contains(t, sql, "drop index if exists idx_processing_artifacts_created_id")
+		})
+	}
 }

--- a/internal/application/repository/reconciliation_context.go
+++ b/internal/application/repository/reconciliation_context.go
@@ -1,0 +1,29 @@
+package repository
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+type reconciliationDBContextKey struct{}
+
+func withReconciliationDB(ctx context.Context, db *gorm.DB) context.Context {
+	return context.WithValue(ctx, reconciliationDBContextKey{}, db)
+}
+
+// DBFromContext returns the reconciliation transaction when one owns the
+// current callback, otherwise it returns the repository's regular handle.
+func DBFromContext(ctx context.Context, fallback *gorm.DB) *gorm.DB {
+	if db, ok := ctx.Value(reconciliationDBContextKey{}).(*gorm.DB); ok && db != nil {
+		return db.WithContext(ctx)
+	}
+	return fallback.WithContext(ctx)
+}
+
+// IsReconciliationTransaction reports whether ctx carries the transaction
+// that serializes a destructive knowledge reconciliation.
+func IsReconciliationTransaction(ctx context.Context) bool {
+	_, ok := ctx.Value(reconciliationDBContextKey{}).(*gorm.DB)
+	return ok
+}

--- a/internal/application/repository/retriever/neo4j/graph_ownership.go
+++ b/internal/application/repository/retriever/neo4j/graph_ownership.go
@@ -1,0 +1,829 @@
+package neo4j
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j"
+)
+
+const graphOwnershipSchemaVersion = 1
+
+type graphOwnershipVersionValue struct {
+	Nodes     []graphOwnershipVersionNode     `json:"nodes"`
+	Relations []graphOwnershipVersionRelation `json:"relations"`
+}
+
+type graphOwnershipVersionNode struct {
+	Name       string   `json:"name"`
+	Attributes []string `json:"attributes"`
+}
+
+type graphOwnershipVersionRelation struct {
+	Node1 string `json:"node1"`
+	Node2 string `json:"node2"`
+	Type  string `json:"type"`
+}
+
+func graphOwnershipVersion(graph *types.GraphData) (string, error) {
+	if graph == nil {
+		return "", fmt.Errorf("graph must not be nil")
+	}
+	value := graphOwnershipVersionValue{
+		Nodes:     make([]graphOwnershipVersionNode, 0, len(graph.Node)),
+		Relations: make([]graphOwnershipVersionRelation, 0, len(graph.Relation)),
+	}
+	nodeNames := make(map[string]struct{}, len(graph.Node))
+	for _, node := range graph.Node {
+		if node == nil {
+			return "", fmt.Errorf("graph contains a nil node")
+		}
+		nodeNames[node.Name] = struct{}{}
+		attributes := append([]string(nil), node.Attributes...)
+		sort.Strings(attributes)
+		value.Nodes = append(value.Nodes, graphOwnershipVersionNode{
+			Name:       node.Name,
+			Attributes: attributes,
+		})
+	}
+	sort.Slice(value.Nodes, func(i, j int) bool {
+		return value.Nodes[i].Name < value.Nodes[j].Name
+	})
+	for _, relation := range graph.Relation {
+		if relation == nil {
+			return "", fmt.Errorf("graph contains a nil relation")
+		}
+		if _, exists := nodeNames[relation.Node1]; !exists {
+			return "", fmt.Errorf("graph relation references unknown node %q", relation.Node1)
+		}
+		if _, exists := nodeNames[relation.Node2]; !exists {
+			return "", fmt.Errorf("graph relation references unknown node %q", relation.Node2)
+		}
+		value.Relations = append(value.Relations, graphOwnershipVersionRelation{
+			Node1: relation.Node1,
+			Node2: relation.Node2,
+			Type:  relation.Type,
+		})
+	}
+	sort.Slice(value.Relations, func(i, j int) bool {
+		left, right := value.Relations[i], value.Relations[j]
+		if left.Node1 != right.Node1 {
+			return left.Node1 < right.Node1
+		}
+		if left.Type != right.Type {
+			return left.Type < right.Type
+		}
+		return left.Node2 < right.Node2
+	})
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("encode graph ownership version: %w", err)
+	}
+	digest := sha256.Sum256(payload)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+// FenceGraphAttempt prevents older extraction tasks from publishing after reconciliation starts.
+func (n *Neo4jRepository) FenceGraphAttempt(
+	ctx context.Context,
+	namespace types.NameSpace,
+	attempt int,
+) error {
+	if n.driver == nil && n.writeTransaction == nil {
+		logger.Warnf(ctx, "NOT SUPPORT RETRIEVE GRAPH")
+		return nil
+	}
+	if err := n.validateGraphChunkOperation(namespace, nil); err != nil {
+		return err
+	}
+	if attempt < 0 {
+		return fmt.Errorf("graph attempt must not be negative")
+	}
+	if err := n.ensureGraphOwnershipSchema(ctx); err != nil {
+		return err
+	}
+
+	return n.runGraphWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		query := `
+			MERGE (state:GRAPH_OWNERSHIP_STATE {kg: $knowledge_id})
+			ON CREATE SET state.version = 0,
+				state.revision = 0,
+				state.attempt = 0,
+				state.dirty = false,
+				state.deleting = false,
+				state.deletion_token = null
+			CALL apoc.lock.nodes([state])
+			CALL apoc.util.validate(
+				coalesce(state.attempt, 0) > $attempt,
+				'graph attempt superseded',
+				[]
+			)
+			SET state.attempt = CASE
+					WHEN coalesce(state.attempt, 0) < $attempt THEN $attempt
+					ELSE coalesce(state.attempt, 0)
+				END,
+				state.revision = coalesce(state.revision, 0) + 1
+			RETURN state
+		`
+		if _, err := tx.Run(ctx, query, map[string]any{
+			"knowledge_id": namespace.Knowledge,
+			"attempt":      attempt,
+		}); err != nil {
+			return nil, fmt.Errorf("failed to fence graph attempt: %w", err)
+		}
+		return nil, nil
+	})
+}
+
+// RecoverGraphNamespace finishes an interrupted full deletion before graph publication resumes.
+func (n *Neo4jRepository) RecoverGraphNamespace(
+	ctx context.Context,
+	namespace types.NameSpace,
+) error {
+	if n.driver == nil && n.graphRecoveryRequired == nil {
+		logger.Warnf(ctx, "NOT SUPPORT RETRIEVE GRAPH")
+		return nil
+	}
+	if err := n.validateGraphChunkOperation(namespace, nil); err != nil {
+		return err
+	}
+	required, err := n.needsGraphNamespaceRecovery(ctx, namespace)
+	if err != nil {
+		return err
+	}
+	if !required {
+		return nil
+	}
+	return n.DelGraph(ctx, []types.NameSpace{namespace})
+}
+
+func (n *Neo4jRepository) needsGraphNamespaceRecovery(
+	ctx context.Context,
+	namespace types.NameSpace,
+) (bool, error) {
+	if n.graphRecoveryRequired != nil {
+		return n.graphRecoveryRequired(ctx, namespace)
+	}
+	session := n.driver.NewSession(ctx, graphRecoverySessionConfig())
+	defer session.Close(ctx)
+
+	value, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		result, err := tx.Run(ctx, `
+			OPTIONAL MATCH (state:GRAPH_OWNERSHIP_STATE {kg: $knowledge_id})
+			RETURN coalesce(state.dirty, false) OR coalesce(state.deleting, false) AS required
+		`, map[string]any{"knowledge_id": namespace.Knowledge})
+		if err != nil {
+			return nil, err
+		}
+		record, err := result.Single(ctx)
+		if err != nil {
+			return nil, err
+		}
+		required, _, err := neo4j.GetRecordValue[bool](record, "required")
+		return required, err
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to inspect graph namespace recovery state: %w", err)
+	}
+	required, ok := value.(bool)
+	if !ok {
+		return false, fmt.Errorf("graph namespace recovery state has unexpected type %T", value)
+	}
+	return required, nil
+}
+
+func graphRecoverySessionConfig() neo4j.SessionConfig {
+	return neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite}
+}
+
+// ReplaceGraphChunk atomically replaces one chunk's graph contribution.
+func (n *Neo4jRepository) ReplaceGraphChunk(
+	ctx context.Context,
+	namespace types.NameSpace,
+	chunkID string,
+	attempt int,
+	graph *types.GraphData,
+) error {
+	if n.driver == nil && n.writeTransaction == nil {
+		logger.Warnf(ctx, "NOT SUPPORT RETRIEVE GRAPH")
+		return nil
+	}
+	if err := n.validateGraphChunkOperation(namespace, []string{chunkID}); err != nil {
+		return err
+	}
+	if graph == nil {
+		return fmt.Errorf("graph must not be nil")
+	}
+	if attempt < 0 {
+		return fmt.Errorf("graph attempt must not be negative")
+	}
+	if err := n.ensureGraphOwnershipSchema(ctx); err != nil {
+		return err
+	}
+	graphVersion, err := graphOwnershipVersion(graph)
+	if err != nil {
+		return err
+	}
+	if err := n.prepareGraphOwnershipNamespace(ctx, namespace); err != nil {
+		return err
+	}
+
+	return n.runGraphWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		if err := n.lockGraphOwnershipNamespace(ctx, tx, namespace); err != nil {
+			return nil, err
+		}
+		if err := n.ensureGraphChunkOwner(ctx, tx, namespace, chunkID, attempt); err != nil {
+			return nil, err
+		}
+		if err := n.retractGraphChunks(
+			ctx, tx, namespace, []string{chunkID}, graphVersion, attempt,
+		); err != nil {
+			return nil, err
+		}
+		if err := n.addOwnedGraph(ctx, tx, namespace, chunkID, attempt, graphVersion, graph); err != nil {
+			return nil, err
+		}
+		if err := n.markGraphChunkVersion(ctx, tx, namespace, chunkID, attempt, graphVersion); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+}
+
+// DelGraphChunks retracts graph contributions for removed chunks.
+func (n *Neo4jRepository) DelGraphChunks(
+	ctx context.Context,
+	namespace types.NameSpace,
+	chunkIDs []string,
+) error {
+	if len(chunkIDs) == 0 {
+		return nil
+	}
+	if n.driver == nil && n.writeTransaction == nil {
+		logger.Warnf(ctx, "NOT SUPPORT RETRIEVE GRAPH")
+		return nil
+	}
+	if err := n.validateGraphChunkOperation(namespace, chunkIDs); err != nil {
+		return err
+	}
+	if err := n.ensureGraphOwnershipSchema(ctx); err != nil {
+		return err
+	}
+	if err := n.prepareGraphOwnershipNamespace(ctx, namespace); err != nil {
+		return err
+	}
+
+	return n.runGraphWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		if err := n.lockGraphOwnershipNamespace(ctx, tx, namespace); err != nil {
+			return nil, err
+		}
+		if err := n.retractGraphChunks(ctx, tx, namespace, chunkIDs, "", 0); err != nil {
+			return nil, err
+		}
+		if err := n.deleteGraphChunkOwners(ctx, tx, namespace, chunkIDs); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+}
+
+func (n *Neo4jRepository) ensureGraphOwnershipSchema(ctx context.Context) error {
+	n.ownershipSchemaMu.Lock()
+	defer n.ownershipSchemaMu.Unlock()
+	if n.ownershipSchemaReady {
+		return nil
+	}
+
+	err := n.runGraphWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		queries := []string{
+			`CREATE CONSTRAINT weknora_graph_ownership_state_kg IF NOT EXISTS
+			 FOR (state:GRAPH_OWNERSHIP_STATE) REQUIRE state.kg IS UNIQUE`,
+			`CREATE CONSTRAINT weknora_graph_chunk_owner_identity IF NOT EXISTS
+			 FOR (owner:GRAPH_CHUNK_OWNER) REQUIRE (owner.kg, owner.chunk_id) IS UNIQUE`,
+			`CREATE CONSTRAINT weknora_graph_entity_identity IF NOT EXISTS
+			 FOR (entity:GRAPH_ENTITY) REQUIRE (entity.kg, entity.name) IS UNIQUE`,
+		}
+		for _, query := range queries {
+			if _, err := tx.Run(ctx, query, nil); err != nil {
+				return nil, fmt.Errorf("failed to initialize graph ownership schema: %w", err)
+			}
+		}
+		return nil, nil
+	})
+	if err != nil {
+		return err
+	}
+	n.ownershipSchemaReady = true
+	return nil
+}
+
+func (n *Neo4jRepository) runGraphWrite(
+	ctx context.Context,
+	work neo4j.ManagedTransactionWork,
+) error {
+	if n.writeTransaction != nil {
+		return n.writeTransaction(ctx, work)
+	}
+	session := n.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close(ctx)
+	_, err := session.ExecuteWrite(ctx, work)
+	return err
+}
+
+func (n *Neo4jRepository) prepareGraphOwnershipNamespace(
+	ctx context.Context,
+	namespace types.NameSpace,
+) error {
+	return n.runGraphWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		if err := n.purgeLegacyRelationships(ctx, tx, namespace); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+}
+
+func (n *Neo4jRepository) purgeLegacyRelationships(
+	ctx context.Context,
+	tx neo4j.ManagedTransaction,
+	namespace types.NameSpace,
+) error {
+	query := `
+		OPTIONAL MATCH (existing:GRAPH_OWNERSHIP_STATE {kg: $knowledge_id})
+		CALL {
+			WITH existing
+			WITH existing
+			WHERE existing IS NOT NULL
+				AND coalesce(existing.version, 0) >= $schema_version
+			CALL apoc.util.validate(
+				coalesce(existing.deleting, false),
+				'graph namespace deletion in progress',
+				[]
+			)
+			RETURN existing AS state, 0 AS migrated
+			UNION
+			WITH existing
+			WITH existing
+			WHERE existing IS NULL
+				OR coalesce(existing.version, 0) < $schema_version
+			MERGE (state:GRAPH_OWNERSHIP_STATE {kg: $knowledge_id})
+			ON CREATE SET state.version = 0,
+				state.revision = 0,
+				state.attempt = 0,
+				state.dirty = false,
+				state.deleting = false,
+				state.deletion_token = null
+			SET state.revision = coalesce(state.revision, 0) + 1
+			WITH state
+			CALL apoc.util.validate(
+				coalesce(state.deleting, false),
+				'graph namespace deletion in progress',
+				[]
+			)
+			WITH state
+			WHERE coalesce(state.version, 0) < $schema_version
+			OPTIONAL MATCH (entity:` + n.Label(namespace) + ` {kg: $knowledge_id})
+			WITH state, entity.name AS entity_name,
+				[node IN collect(entity) WHERE node IS NOT NULL] AS duplicates
+			WITH state, entity_name, duplicates,
+				reduce(
+					chunks = [],
+					duplicate IN duplicates |
+						apoc.coll.union(chunks, coalesce(duplicate.chunks, []))
+				) AS chunks,
+				reduce(
+					attributes = [],
+					duplicate IN duplicates |
+						apoc.coll.union(attributes, coalesce(duplicate.attributes, []))
+				) AS attributes
+			CALL {
+				WITH duplicates, chunks, attributes
+				WITH duplicates, chunks, attributes WHERE size(duplicates) > 0
+				CALL apoc.refactor.mergeNodes(
+					duplicates,
+					{properties: 'discard', mergeRels: true, produceSelfRel: false}
+				) YIELD node
+				SET node.chunks = chunks,
+					node.attributes = attributes,
+					node.legacy_attributes = attributes,
+					node.legacy_attribute_chunks = chunks
+				RETURN node
+				UNION
+				WITH duplicates, chunks, attributes
+				WITH duplicates WHERE size(duplicates) = 0
+				RETURN null AS node
+			}
+			WITH state, [entity IN collect(node) WHERE entity IS NOT NULL] AS entities
+			FOREACH (entity IN entities | SET entity:GRAPH_ENTITY)
+			CALL {
+				WITH state, entities
+				UNWIND entities AS entity
+				UNWIND coalesce(entity.chunks, []) AS chunk_id
+				WITH state, entity, chunk_id
+				WHERE chunk_id IS NOT NULL AND trim(chunk_id) <> ''
+				MERGE (owner:GRAPH_CHUNK_OWNER {
+					kg: $knowledge_id,
+					chunk_id: chunk_id
+				})
+				ON CREATE SET owner.revision = 0
+				SET owner.initialized = true,
+					owner.graph_version = 'legacy',
+					owner.attempt = coalesce(state.attempt, 0)
+				MERGE (owner)-[contribution:GRAPH_NODE_CONTRIBUTION]->(entity)
+				SET contribution.attributes = []
+				RETURN count(*) AS backfilled
+			}
+			WITH state, size(entities) AS labeled, backfilled
+			OPTIONAL MATCH (n:` + n.Label(namespace) + ` {kg: $knowledge_id})-[r]-(m:` + n.Label(namespace) + ` {kg: $knowledge_id})
+			WHERE r.chunks IS NULL
+			WITH state, labeled,
+				[relation IN collect(DISTINCT r) WHERE relation IS NOT NULL] AS relationships
+			FOREACH (relation IN relationships | DELETE relation)
+			SET state.version = $schema_version
+			RETURN labeled + size(relationships) AS migrated
+		}
+		RETURN state, migrated
+	`
+	params := map[string]any{
+		"knowledge_id":   namespace.Knowledge,
+		"schema_version": graphOwnershipSchemaVersion,
+	}
+	if _, err := tx.Run(ctx, query, params); err != nil {
+		return fmt.Errorf("failed to delete legacy relationships: %w", err)
+	}
+	return nil
+}
+
+func (n *Neo4jRepository) lockGraphOwnershipNamespace(
+	ctx context.Context,
+	tx neo4j.ManagedTransaction,
+	namespace types.NameSpace,
+) error {
+	query := `
+		MATCH (state:GRAPH_OWNERSHIP_STATE {kg: $knowledge_id})
+		CALL apoc.lock.read.nodes([state])
+		CALL apoc.util.validate(
+			coalesce(state.deleting, false),
+			'graph namespace deletion in progress',
+			[]
+		)
+		RETURN state
+	`
+	if _, err := tx.Run(ctx, query, map[string]any{
+		"knowledge_id": namespace.Knowledge,
+	}); err != nil {
+		return fmt.Errorf("failed to lock graph ownership namespace: %w", err)
+	}
+	return nil
+}
+
+func (n *Neo4jRepository) ensureGraphChunkOwner(
+	ctx context.Context,
+	tx neo4j.ManagedTransaction,
+	namespace types.NameSpace,
+	chunkID string,
+	attempt int,
+) error {
+	query := `
+		MATCH (state:GRAPH_OWNERSHIP_STATE {kg: $knowledge_id})
+		WITH state WHERE coalesce(state.attempt, 0) = $attempt
+		MERGE (owner:GRAPH_CHUNK_OWNER {kg: $knowledge_id, chunk_id: $chunk_id})
+		ON CREATE SET owner.graph_version = '', owner.initialized = false, owner.revision = 0
+		SET owner.revision = coalesce(owner.revision, 0) + 1,
+			owner.attempt = $attempt
+	`
+	if _, err := tx.Run(ctx, query, map[string]any{
+		"knowledge_id": namespace.Knowledge,
+		"chunk_id":     chunkID,
+		"attempt":      attempt,
+	}); err != nil {
+		return fmt.Errorf("failed to ensure graph chunk owner: %w", err)
+	}
+	return nil
+}
+
+func (n *Neo4jRepository) retractGraphChunks(
+	ctx context.Context,
+	tx neo4j.ManagedTransaction,
+	namespace types.NameSpace,
+	chunkIDs []string,
+	graphVersion string,
+	attempt int,
+) error {
+	ownerGuard := ""
+	params := map[string]any{"knowledge_id": namespace.Knowledge, "chunk_ids": chunkIDs}
+	if graphVersion != "" {
+		ownerGuard = `
+			MATCH (state:GRAPH_OWNERSHIP_STATE {kg: $knowledge_id})
+			WITH state WHERE coalesce(state.attempt, 0) = $attempt
+			MATCH (owner:GRAPH_CHUNK_OWNER {kg: $knowledge_id, chunk_id: $chunk_id})
+			WITH owner
+			WHERE owner.attempt = $attempt
+				AND owner.initialized = true
+				AND coalesce(owner.graph_version, '') <> $graph_version
+		`
+		params["chunk_id"] = chunkIDs[0]
+		params["graph_version"] = graphVersion
+		params["attempt"] = attempt
+	}
+	relationQuery := ownerGuard + `
+		MATCH (n:` + n.Label(namespace) + ` {kg: $knowledge_id})-[r]-(m:` + n.Label(namespace) + ` {kg: $knowledge_id})
+		WHERE any(ownerID IN coalesce(r.chunks, []) WHERE ownerID IN $chunk_ids)
+		WITH DISTINCT r
+		SET r.chunks = [ownerID IN coalesce(r.chunks, []) WHERE NOT (ownerID IN $chunk_ids)]
+		WITH r WHERE size(r.chunks) = 0
+		DELETE r
+	`
+	if _, err := tx.Run(ctx, relationQuery, params); err != nil {
+		return fmt.Errorf("failed to retract relationship ownership: %w", err)
+	}
+
+	contributionOwnerMatch := ownerGuard
+	if graphVersion == "" {
+		contributionOwnerMatch = `
+			MATCH (owner:GRAPH_CHUNK_OWNER {kg: $knowledge_id})
+			WHERE owner.chunk_id IN $chunk_ids
+		`
+	}
+	attributeQuery := contributionOwnerMatch + `
+		MATCH (owner)-[contribution:GRAPH_NODE_CONTRIBUTION]->(node:` + n.Label(namespace) + ` {kg: $knowledge_id})
+		SET node.legacy_attribute_chunks = [
+			legacyID IN coalesce(node.legacy_attribute_chunks, [])
+			WHERE NOT (legacyID IN $chunk_ids)
+		]
+		DELETE contribution
+		WITH DISTINCT node
+		OPTIONAL MATCH (:GRAPH_CHUNK_OWNER)-[remaining:GRAPH_NODE_CONTRIBUTION]->(node)
+		WITH node,
+			[attributes IN collect(remaining.attributes) WHERE attributes IS NOT NULL] AS attribute_sets,
+			CASE
+				WHEN size(coalesce(node.legacy_attribute_chunks, [])) > 0
+				THEN coalesce(node.legacy_attributes, [])
+				ELSE []
+			END AS legacy_attributes
+		SET node.attributes = reduce(
+			attributes = legacy_attributes,
+			values IN attribute_sets | apoc.coll.union(attributes, values)
+		),
+			node.legacy_attributes = CASE
+				WHEN size(coalesce(node.legacy_attribute_chunks, [])) = 0 THEN null
+				ELSE node.legacy_attributes
+			END,
+			node.legacy_attribute_chunks = CASE
+				WHEN size(coalesce(node.legacy_attribute_chunks, [])) = 0 THEN null
+				ELSE node.legacy_attribute_chunks
+			END
+	`
+	if _, err := tx.Run(ctx, attributeQuery, params); err != nil {
+		return fmt.Errorf("failed to retract node attribute ownership: %w", err)
+	}
+
+	nodeQuery := ownerGuard + `
+		MATCH (n:` + n.Label(namespace) + ` {kg: $knowledge_id})
+		WHERE any(ownerID IN coalesce(n.chunks, []) WHERE ownerID IN $chunk_ids)
+		SET n.chunks = [ownerID IN coalesce(n.chunks, []) WHERE NOT (ownerID IN $chunk_ids)]
+		WITH n WHERE size(n.chunks) = 0
+		DETACH DELETE n
+	`
+	if _, err := tx.Run(ctx, nodeQuery, params); err != nil {
+		return fmt.Errorf("failed to retract node ownership: %w", err)
+	}
+	return nil
+}
+
+func (n *Neo4jRepository) addOwnedGraph(
+	ctx context.Context,
+	tx neo4j.ManagedTransaction,
+	namespace types.NameSpace,
+	chunkID string,
+	attempt int,
+	graphVersion string,
+	graph *types.GraphData,
+) error {
+	ownerGuard := `
+		MATCH (state:GRAPH_OWNERSHIP_STATE {kg: $knowledge_id})
+		WITH state WHERE coalesce(state.attempt, 0) = $attempt
+		MATCH (owner:GRAPH_CHUNK_OWNER {kg: $knowledge_id, chunk_id: $chunk_id})
+		WITH owner WHERE owner.attempt = $attempt
+			AND coalesce(owner.graph_version, '') <> $graph_version
+	`
+	nodeQuery := ownerGuard + `
+		UNWIND $data AS row
+		CALL apoc.merge.node(row.labels, {name: row.name, kg: row.knowledge_id}, {}, {}) YIELD node
+		SET node.chunks = apoc.coll.union(coalesce(node.chunks, []), row.chunks)
+		MERGE (owner)-[contribution:GRAPH_NODE_CONTRIBUTION]->(node)
+		SET contribution.attributes = row.attributes
+		WITH node
+		OPTIONAL MATCH (:GRAPH_CHUNK_OWNER)-[remaining:GRAPH_NODE_CONTRIBUTION]->(node)
+		WITH node,
+			[attributes IN collect(remaining.attributes) WHERE attributes IS NOT NULL] AS attribute_sets,
+			CASE
+				WHEN size(coalesce(node.legacy_attribute_chunks, [])) > 0
+				THEN coalesce(node.legacy_attributes, [])
+				ELSE []
+			END AS legacy_attributes
+		SET node.attributes = reduce(
+			attributes = legacy_attributes,
+			values IN attribute_sets | apoc.coll.union(attributes, values)
+		)
+		RETURN distinct 'done' AS result
+	`
+	nodeData := make([]map[string]any, 0, len(graph.Node))
+	for _, node := range graph.Node {
+		nodeData = append(nodeData, map[string]any{
+			"name":         node.Name,
+			"knowledge_id": namespace.Knowledge,
+			"attributes":   node.Attributes,
+			"chunks":       []string{chunkID},
+			"labels":       n.ownershipLabels(namespace),
+		})
+	}
+	nodeParams := map[string]any{
+		"data":          nodeData,
+		"knowledge_id":  namespace.Knowledge,
+		"chunk_id":      chunkID,
+		"attempt":       attempt,
+		"graph_version": graphVersion,
+	}
+	if _, err := tx.Run(ctx, nodeQuery, nodeParams); err != nil {
+		return fmt.Errorf("failed to create nodes: %w", err)
+	}
+
+	relationQuery := ownerGuard + `
+		UNWIND $data AS row
+		CALL apoc.merge.node(row.source_labels, {name: row.source, kg: row.knowledge_id}, {}, {}) YIELD node as source
+		CALL apoc.merge.node(row.target_labels, {name: row.target, kg: row.knowledge_id}, {}, {}) YIELD node as target
+		CALL apoc.lock.nodes(
+			CASE
+				WHEN elementId(source) < elementId(target) THEN [source, target]
+				ELSE [target, source]
+			END
+		)
+		CALL apoc.merge.relationship(source, row.type, {}, {}, target) YIELD rel
+		SET rel.chunks = apoc.coll.union(coalesce(rel.chunks, []), row.chunks)
+		RETURN distinct 'done'
+	`
+	relationData := make([]map[string]any, 0, len(graph.Relation))
+	for _, relation := range graph.Relation {
+		relationData = append(relationData, map[string]any{
+			"source":        relation.Node1,
+			"target":        relation.Node2,
+			"knowledge_id":  namespace.Knowledge,
+			"type":          relation.Type,
+			"chunks":        []string{chunkID},
+			"source_labels": n.ownershipLabels(namespace),
+			"target_labels": n.ownershipLabels(namespace),
+		})
+	}
+	relationParams := map[string]any{
+		"data":          relationData,
+		"knowledge_id":  namespace.Knowledge,
+		"chunk_id":      chunkID,
+		"attempt":       attempt,
+		"graph_version": graphVersion,
+	}
+	if _, err := tx.Run(ctx, relationQuery, relationParams); err != nil {
+		return fmt.Errorf("failed to create relationships: %w", err)
+	}
+	return nil
+}
+
+func (n *Neo4jRepository) markGraphChunkVersion(
+	ctx context.Context,
+	tx neo4j.ManagedTransaction,
+	namespace types.NameSpace,
+	chunkID string,
+	attempt int,
+	graphVersion string,
+) error {
+	query := `
+		MATCH (state:GRAPH_OWNERSHIP_STATE {kg: $knowledge_id})
+		WITH state WHERE coalesce(state.attempt, 0) = $attempt
+		MATCH (owner:GRAPH_CHUNK_OWNER {kg: $knowledge_id, chunk_id: $chunk_id})
+		WITH owner WHERE owner.attempt = $attempt
+		SET owner.graph_version = $graph_version,
+			owner.initialized = true
+	`
+	if _, err := tx.Run(ctx, query, map[string]any{
+		"knowledge_id":  namespace.Knowledge,
+		"chunk_id":      chunkID,
+		"attempt":       attempt,
+		"graph_version": graphVersion,
+	}); err != nil {
+		return fmt.Errorf("failed to mark graph chunk version: %w", err)
+	}
+	return nil
+}
+
+func (n *Neo4jRepository) deleteGraphChunkOwners(
+	ctx context.Context,
+	tx neo4j.ManagedTransaction,
+	namespace types.NameSpace,
+	chunkIDs []string,
+) error {
+	query := `
+		MATCH (owner:GRAPH_CHUNK_OWNER {kg: $knowledge_id})
+		WHERE owner.chunk_id IN $chunk_ids
+		DETACH DELETE owner
+	`
+	if _, err := tx.Run(ctx, query, map[string]any{
+		"knowledge_id": namespace.Knowledge,
+		"chunk_ids":    chunkIDs,
+	}); err != nil {
+		return fmt.Errorf("failed to delete graph chunk owners: %w", err)
+	}
+	return nil
+}
+
+func (n *Neo4jRepository) beginGraphNamespaceDeletion(
+	ctx context.Context,
+	namespace types.NameSpace,
+	deletionToken string,
+) error {
+	return n.runGraphWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		query := `
+			MERGE (state:GRAPH_OWNERSHIP_STATE {kg: $knowledge_id})
+			ON CREATE SET state.version = 0,
+				state.revision = 0,
+				state.attempt = 0,
+				state.dirty = false
+			SET state.deleting = true,
+				state.dirty = true,
+				state.deletion_token = $deletion_token,
+				state.revision = coalesce(state.revision, 0) + 1
+			WITH state
+			OPTIONAL MATCH (owner:GRAPH_CHUNK_OWNER {kg: $knowledge_id})
+			OPTIONAL MATCH (owner)-[ownership:GRAPH_NODE_CONTRIBUTION]->()
+			WITH state,
+				collect(DISTINCT ownership) AS ownerships,
+				collect(DISTINCT owner) AS owners
+			FOREACH (ownership IN ownerships | DELETE ownership)
+			FOREACH (owner IN owners | DELETE owner)
+			RETURN state
+		`
+		if _, err := tx.Run(ctx, query, map[string]any{
+			"knowledge_id":   namespace.Knowledge,
+			"deletion_token": deletionToken,
+		}); err != nil {
+			return nil, fmt.Errorf("failed to begin graph namespace deletion: %w", err)
+		}
+		return nil, nil
+	})
+}
+
+func (n *Neo4jRepository) finishGraphNamespaceDeletion(
+	ctx context.Context,
+	namespace types.NameSpace,
+	deletionToken string,
+	succeeded bool,
+) error {
+	return n.runGraphWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		query := `
+			MATCH (state:GRAPH_OWNERSHIP_STATE {
+				kg: $knowledge_id,
+				deletion_token: $deletion_token
+			})
+			SET state.dirty = NOT $succeeded,
+				state.deleting = NOT $succeeded,
+				state.deletion_token = CASE
+					WHEN $succeeded THEN null
+					ELSE state.deletion_token
+				END,
+				state.version = CASE
+					WHEN $succeeded THEN 0
+					ELSE state.version
+				END,
+				state.revision = coalesce(state.revision, 0) + 1
+			RETURN state
+		`
+		if _, err := tx.Run(ctx, query, map[string]any{
+			"knowledge_id":   namespace.Knowledge,
+			"deletion_token": deletionToken,
+			"succeeded":      succeeded,
+		}); err != nil {
+			return nil, fmt.Errorf("failed to finish graph namespace deletion: %w", err)
+		}
+		return nil, nil
+	})
+}
+
+func (n *Neo4jRepository) validateGraphChunkOperation(
+	namespace types.NameSpace,
+	chunkIDs []string,
+) error {
+	if strings.TrimSpace(namespace.Knowledge) == "" || n.Label(namespace) == "" {
+		return fmt.Errorf("graph namespace must not be empty")
+	}
+	for _, chunkID := range chunkIDs {
+		if strings.TrimSpace(chunkID) == "" {
+			return fmt.Errorf("graph chunk ID must not be empty")
+		}
+	}
+	return nil
+}

--- a/internal/application/repository/retriever/neo4j/repository.go
+++ b/internal/application/repository/retriever/neo4j/repository.go
@@ -2,19 +2,29 @@ package neo4j
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/google/uuid"
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j"
 )
 
+const graphEntityLabel = "GRAPH_ENTITY"
+
 // Neo4jRepository is a repository for Neo4j
 type Neo4jRepository struct {
-	driver     neo4j.Driver
-	nodePrefix string
+	driver                neo4j.Driver
+	nodePrefix            string
+	writeTransaction      func(context.Context, neo4j.ManagedTransactionWork) error
+	graphRecoveryRequired func(context.Context, types.NameSpace) (bool, error)
+
+	ownershipSchemaMu    sync.Mutex
+	ownershipSchemaReady bool
 }
 
 // NewNeo4jRepository creates a new Neo4j repository
@@ -42,6 +52,11 @@ func (n *Neo4jRepository) Label(namespace types.NameSpace) string {
 	return strings.Join(labels, ":")
 }
 
+func (n *Neo4jRepository) ownershipLabels(namespace types.NameSpace) []string {
+	labels := append([]string(nil), n.Labels(namespace)...)
+	return append(labels, graphEntityLabel)
+}
+
 // AddGraph adds a graph to the Neo4j repository
 func (n *Neo4jRepository) AddGraph(ctx context.Context, namespace types.NameSpace, graphs []*types.GraphData) error {
 	if n.driver == nil {
@@ -66,7 +81,7 @@ func (n *Neo4jRepository) addGraph(ctx context.Context, namespace types.NameSpac
 		node_import_query := `
 			UNWIND $data AS row
 			CALL apoc.merge.node(row.labels, {name: row.name, kg: row.knowledge_id}, row.props, {}) YIELD node
-			SET node.chunks = apoc.coll.union(node.chunks, row.chunks)
+			SET node.chunks = apoc.coll.union(coalesce(node.chunks, []), row.chunks)
 			RETURN distinct 'done' AS result
 		`
 		nodeData := []map[string]interface{}{}
@@ -76,7 +91,7 @@ func (n *Neo4jRepository) addGraph(ctx context.Context, namespace types.NameSpac
 				"knowledge_id": namespace.Knowledge,
 				"props":        map[string][]string{"attributes": node.Attributes},
 				"chunks":       node.Chunks,
-				"labels":       n.Labels(namespace),
+				"labels":       n.ownershipLabels(namespace),
 			})
 		}
 		if _, err := tx.Run(ctx, node_import_query, map[string]interface{}{"data": nodeData}); err != nil {
@@ -88,7 +103,8 @@ func (n *Neo4jRepository) addGraph(ctx context.Context, namespace types.NameSpac
 			UNWIND $data AS row
 			CALL apoc.merge.node(row.source_labels, {name: row.source, kg: row.knowledge_id}, {}, {}) YIELD node as source
 			CALL apoc.merge.node(row.target_labels, {name: row.target, kg: row.knowledge_id}, {}, {}) YIELD node as target
-			CALL apoc.merge.relationship(source, row.type, {}, row.attributes, target) YIELD rel
+			CALL apoc.merge.relationship(source, row.type, {}, {}, target) YIELD rel
+			SET rel.chunks = apoc.coll.union(coalesce(rel.chunks, []), row.chunks)
 			RETURN distinct 'done'
 		`
 		relData := []map[string]interface{}{}
@@ -98,8 +114,9 @@ func (n *Neo4jRepository) addGraph(ctx context.Context, namespace types.NameSpac
 				"target":        rel.Node2,
 				"knowledge_id":  namespace.Knowledge,
 				"type":          rel.Type,
-				"source_labels": n.Labels(namespace),
-				"target_labels": n.Labels(namespace),
+				"chunks":        rel.Chunks,
+				"source_labels": n.ownershipLabels(namespace),
+				"target_labels": n.ownershipLabels(namespace),
 			})
 		}
 		if _, err := tx.Run(ctx, rel_import_query, map[string]interface{}{"data": relData}); err != nil {
@@ -116,48 +133,135 @@ func (n *Neo4jRepository) addGraph(ctx context.Context, namespace types.NameSpac
 
 // DelGraph deletes a graph from the Neo4j repository
 func (n *Neo4jRepository) DelGraph(ctx context.Context, namespaces []types.NameSpace) error {
-	if n.driver == nil {
+	if n.driver == nil && n.writeTransaction == nil {
 		logger.Warnf(ctx, "NOT SUPPORT RETRIEVE GRAPH")
 		return nil
 	}
-	session := n.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
-	defer session.Close(ctx)
+	if err := n.ensureGraphOwnershipSchema(ctx); err != nil {
+		return err
+	}
+	for _, namespace := range namespaces {
+		if err := n.validateGraphChunkOperation(namespace, nil); err != nil {
+			return err
+		}
+		deletionToken := uuid.NewString()
+		if err := n.beginGraphNamespaceDeletion(ctx, namespace, deletionToken); err != nil {
+			return err
+		}
+		deleteErr := n.deleteGraphNamespaceData(ctx, namespace, deletionToken)
+		finishErr := n.finishGraphNamespaceDeletion(ctx, namespace, deletionToken, deleteErr == nil)
+		if deleteErr != nil || finishErr != nil {
+			return errors.Join(deleteErr, finishErr)
+		}
+	}
+	return nil
+}
 
-	result, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
-		for _, namespace := range namespaces {
-			labelExpr := n.Label(namespace)
+func (n *Neo4jRepository) deleteGraphNamespaceData(
+	ctx context.Context,
+	namespace types.NameSpace,
+	deletionToken string,
+) error {
+	labelExpr := n.Label(namespace)
+	return n.runGraphWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		deleteRelsQuery := `
+			CALL apoc.periodic.iterate(
+				"MATCH (n:` + labelExpr + ` {kg: $knowledge_id})-[r]-(m:` + labelExpr + ` {kg: $knowledge_id})
+				 RETURN DISTINCT r",
+				"MATCH (state:GRAPH_OWNERSHIP_STATE {kg: $knowledge_id})
+				 CALL apoc.util.validate(
+					coalesce(state.deletion_token, '') <> $deletion_token,
+					'graph namespace deletion superseded',
+					[]
+				 )
+				 DELETE r",
+				{
+					batchSize: 1000,
+					parallel: false,
+					retries: 3,
+					params: {
+						knowledge_id: $knowledge_id,
+						deletion_token: $deletion_token
+					}
+				}
+			) YIELD total, failedOperations, failedBatches, errorMessages, wasTerminated
+			MATCH (state:GRAPH_OWNERSHIP_STATE {kg: $knowledge_id})
+			CALL apoc.util.validate(
+				coalesce(state.deletion_token, '') <> $deletion_token,
+				'graph namespace deletion superseded',
+				[]
+			)
+			WITH total, failedOperations, failedBatches, errorMessages, wasTerminated
+			CALL apoc.util.validate(
+				failedOperations > 0 OR failedBatches > 0 OR coalesce(wasTerminated, false),
+				'graph relationship batch deletion failed',
+				[]
+			)
+			RETURN total
+		`
+		if err := runConsumedGraphQuery(ctx, tx, deleteRelsQuery, map[string]any{
+			"knowledge_id":   namespace.Knowledge,
+			"deletion_token": deletionToken,
+		}); err != nil {
+			return nil, fmt.Errorf("failed to delete relationships: %w", err)
+		}
 
-			deleteRelsQuery := `
-				CALL apoc.periodic.iterate(
-					"MATCH (n:` + labelExpr + ` {kg: $knowledge_id})-[r]-(m:` + labelExpr + ` {kg: $knowledge_id}) RETURN r",
-					"DELETE r",
-					{batchSize: 1000, parallel: true, params: {knowledge_id: $knowledge_id}}
-				) YIELD batches, total
-				RETURN total
-        	`
-			if _, err := tx.Run(ctx, deleteRelsQuery, map[string]interface{}{"knowledge_id": namespace.Knowledge}); err != nil {
-				return nil, fmt.Errorf("failed to delete relationships: %v", err)
-			}
-
-			deleteNodesQuery := `
-				CALL apoc.periodic.iterate(
-					"MATCH (n:` + labelExpr + ` {kg: $knowledge_id}) RETURN n",
-					"DELETE n",
-					{batchSize: 1000, parallel: true, params: {knowledge_id: $knowledge_id}}
-				) YIELD batches, total
-				RETURN total
-        	`
-			if _, err := tx.Run(ctx, deleteNodesQuery, map[string]interface{}{"knowledge_id": namespace.Knowledge}); err != nil {
-				return nil, fmt.Errorf("failed to delete nodes: %v", err)
-			}
+		deleteNodesQuery := `
+			CALL apoc.periodic.iterate(
+				"MATCH (n:` + labelExpr + ` {kg: $knowledge_id}) RETURN n",
+				"MATCH (state:GRAPH_OWNERSHIP_STATE {kg: $knowledge_id})
+				 CALL apoc.util.validate(
+					coalesce(state.deletion_token, '') <> $deletion_token,
+					'graph namespace deletion superseded',
+					[]
+				 )
+				 DETACH DELETE n",
+				{
+					batchSize: 1000,
+					parallel: false,
+					retries: 3,
+					params: {
+						knowledge_id: $knowledge_id,
+						deletion_token: $deletion_token
+					}
+				}
+			) YIELD total, failedOperations, failedBatches, errorMessages, wasTerminated
+			MATCH (state:GRAPH_OWNERSHIP_STATE {kg: $knowledge_id})
+			CALL apoc.util.validate(
+				coalesce(state.deletion_token, '') <> $deletion_token,
+				'graph namespace deletion superseded',
+				[]
+			)
+			WITH total, failedOperations, failedBatches, errorMessages, wasTerminated
+			CALL apoc.util.validate(
+				failedOperations > 0 OR failedBatches > 0 OR coalesce(wasTerminated, false),
+				'graph node batch deletion failed',
+				[]
+			)
+			RETURN total
+		`
+		if err := runConsumedGraphQuery(ctx, tx, deleteNodesQuery, map[string]any{
+			"knowledge_id":   namespace.Knowledge,
+			"deletion_token": deletionToken,
+		}); err != nil {
+			return nil, fmt.Errorf("failed to delete nodes: %w", err)
 		}
 		return nil, nil
 	})
-	if err != nil {
+}
+
+func runConsumedGraphQuery(
+	ctx context.Context,
+	tx neo4j.ManagedTransaction,
+	query string,
+	params map[string]any,
+) error {
+	result, err := tx.Run(ctx, query, params)
+	if err != nil || result == nil {
 		return err
 	}
-	logger.Infof(ctx, "delete graph result: %v", result)
-	return nil
+	_, err = result.Consume(ctx)
+	return err
 }
 
 // SearchNode searches for nodes in the Neo4j repository

--- a/internal/application/repository/retriever/neo4j/repository_test.go
+++ b/internal/application/repository/retriever/neo4j/repository_test.go
@@ -1,0 +1,521 @@
+package neo4j
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	driver "github.com/neo4j/neo4j-go-driver/v6/neo4j"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordedGraphQuery struct {
+	cypher string
+	params map[string]any
+}
+
+type recordingGraphTransaction struct {
+	queries []recordedGraphQuery
+	errAt   int
+	err     error
+}
+
+func (tx *recordingGraphTransaction) Run(
+	_ context.Context,
+	cypher string,
+	params map[string]any,
+) (driver.Result, error) {
+	tx.queries = append(tx.queries, recordedGraphQuery{cypher: cypher, params: params})
+	if tx.errAt > 0 && len(tx.queries) == tx.errAt {
+		return nil, tx.err
+	}
+	return nil, nil
+}
+
+func TestEnsureGraphOwnershipSchemaCreatesConstraintsOnce(t *testing.T) {
+	tx := &recordingGraphTransaction{}
+	writeCalls := 0
+	repository := &Neo4jRepository{
+		writeTransaction: func(ctx context.Context, work driver.ManagedTransactionWork) error {
+			writeCalls++
+			_, err := work(tx)
+			return err
+		},
+	}
+
+	require.NoError(t, repository.ensureGraphOwnershipSchema(context.Background()))
+	require.NoError(t, repository.ensureGraphOwnershipSchema(context.Background()))
+
+	assert.Equal(t, 1, writeCalls)
+	require.Len(t, tx.queries, 3)
+	assert.Contains(t, tx.queries[0].cypher, "GRAPH_OWNERSHIP_STATE")
+	assert.Contains(t, tx.queries[0].cypher, "REQUIRE state.kg IS UNIQUE")
+	assert.Contains(t, tx.queries[1].cypher, "GRAPH_CHUNK_OWNER")
+	assert.Contains(t, tx.queries[1].cypher, "REQUIRE (owner.kg, owner.chunk_id) IS UNIQUE")
+	assert.Contains(t, tx.queries[2].cypher, "GRAPH_ENTITY")
+	assert.Contains(t, tx.queries[2].cypher, "REQUIRE (entity.kg, entity.name) IS UNIQUE")
+}
+
+func TestEnsureGraphChunkOwnerSerializesReplacementAndTracksInitialization(t *testing.T) {
+	tx := &recordingGraphTransaction{}
+	repository := &Neo4jRepository{nodePrefix: "ENTITY"}
+
+	err := repository.ensureGraphChunkOwner(
+		context.Background(),
+		tx,
+		types.NameSpace{Knowledge: "knowledge-1"},
+		"chunk-1",
+		7,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, tx.queries, 1)
+	assert.Contains(t, tx.queries[0].cypher, "owner.initialized = false")
+	assert.Contains(t, tx.queries[0].cypher, "owner.revision = 0")
+	assert.Contains(t, tx.queries[0].cypher,
+		"SET owner.revision = coalesce(owner.revision, 0) + 1")
+	assert.Contains(t, tx.queries[0].cypher, "coalesce(state.attempt, 0) = $attempt")
+	assert.Contains(t, tx.queries[0].cypher, "owner.attempt = $attempt")
+	assert.Equal(t, 7, tx.queries[0].params["attempt"])
+}
+
+func TestFenceGraphAttemptAdvancesNamespaceGeneration(t *testing.T) {
+	tx := &recordingGraphTransaction{}
+	repository := &Neo4jRepository{
+		nodePrefix:           "ENTITY",
+		ownershipSchemaReady: true,
+		writeTransaction: func(ctx context.Context, work driver.ManagedTransactionWork) error {
+			_, err := work(tx)
+			return err
+		},
+	}
+
+	err := repository.FenceGraphAttempt(
+		context.Background(),
+		types.NameSpace{KnowledgeBase: "kb-1", Knowledge: "knowledge-1"},
+		11,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, tx.queries, 1)
+	assert.Contains(t, tx.queries[0].cypher, "apoc.lock.nodes([state])")
+	assert.NotContains(t, tx.queries[0].cypher, "apoc.lock.write.nodes")
+	assert.Contains(t, tx.queries[0].cypher,
+		"coalesce(state.attempt, 0) > $attempt")
+	assert.Contains(t, tx.queries[0].cypher, "graph attempt superseded")
+	assert.Contains(t, tx.queries[0].cypher, "coalesce(state.attempt, 0) < $attempt")
+	assert.Contains(t, tx.queries[0].cypher, "THEN $attempt")
+	assert.Less(t,
+		strings.Index(tx.queries[0].cypher, "apoc.lock.nodes([state])"),
+		strings.Index(tx.queries[0].cypher, "coalesce(state.attempt, 0) > $attempt"),
+	)
+	assert.Equal(t, 11, tx.queries[0].params["attempt"])
+}
+
+func TestReplaceGraphChunkRetractsAndAddsOwnershipInOneTransaction(t *testing.T) {
+	tx := &recordingGraphTransaction{}
+	writeCalls := 0
+	repository := &Neo4jRepository{
+		nodePrefix:           "ENTITY",
+		ownershipSchemaReady: true,
+		writeTransaction: func(ctx context.Context, work driver.ManagedTransactionWork) error {
+			writeCalls++
+			_, err := work(tx)
+			return err
+		},
+	}
+	graph := &types.GraphData{
+		Node: []*types.GraphNode{
+			{Name: "Alpha", Chunks: []string{"wrong-owner"}, Attributes: []string{"person"}},
+			{Name: "Beta"},
+		},
+		Relation: []*types.GraphRelation{
+			{Node1: "Alpha", Node2: "Beta", Type: "knows", Chunks: []string{"wrong-owner"}},
+		},
+	}
+
+	err := repository.ReplaceGraphChunk(
+		context.Background(),
+		types.NameSpace{KnowledgeBase: "kb-1", Knowledge: "knowledge-1"},
+		"current-chunk",
+		13,
+		graph,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, writeCalls)
+	require.Len(t, tx.queries, 9)
+	assert.Contains(t, tx.queries[0].cypher, "GRAPH_OWNERSHIP_STATE")
+	assert.Contains(t, tx.queries[0].cypher, "coalesce(state.version, 0) < $schema_version")
+	assert.Contains(t, tx.queries[0].cypher, "r.chunks IS NULL")
+	assert.Contains(t, tx.queries[0].cypher, "apoc.refactor.mergeNodes")
+	assert.Contains(t, tx.queries[0].cypher,
+		"apoc.coll.union(chunks, coalesce(duplicate.chunks, []))")
+	assert.Contains(t, tx.queries[0].cypher,
+		"apoc.coll.union(attributes, coalesce(duplicate.attributes, []))")
+	assert.Contains(t, tx.queries[0].cypher, "SET node.chunks = chunks")
+	assert.Contains(t, tx.queries[0].cypher, "node.attributes = attributes")
+	assert.Contains(t, tx.queries[0].cypher, "node.legacy_attributes = attributes")
+	assert.Contains(t, tx.queries[0].cypher, "node.legacy_attribute_chunks = chunks")
+	assert.Contains(t, tx.queries[0].cypher, "MERGE (owner:GRAPH_CHUNK_OWNER {")
+	assert.Contains(t, tx.queries[0].cypher, "chunk_id: chunk_id")
+	assert.Contains(t, tx.queries[0].cypher, "owner.initialized = true")
+	assert.Contains(t, tx.queries[0].cypher, "owner.graph_version = 'legacy'")
+	assert.Contains(t, tx.queries[0].cypher, "WITH state, entity, chunk_id")
+	assert.Contains(t, tx.queries[0].cypher, "owner.attempt = coalesce(state.attempt, 0)")
+	assert.Contains(t, tx.queries[0].cypher,
+		"MERGE (owner)-[contribution:GRAPH_NODE_CONTRIBUTION]->(entity)")
+	assert.Contains(t, tx.queries[0].cypher, "SET contribution.attributes = []")
+	assert.Contains(t, tx.queries[0].cypher, "SET entity:GRAPH_ENTITY")
+	assert.Less(t,
+		strings.Index(tx.queries[0].cypher, "apoc.refactor.mergeNodes"),
+		strings.Index(tx.queries[0].cypher, "SET entity:GRAPH_ENTITY"),
+	)
+	assert.Less(t,
+		strings.Index(tx.queries[0].cypher, "state.version >= $schema_version"),
+		strings.Index(tx.queries[0].cypher, "SET state.revision"),
+	)
+	assert.Contains(t, tx.queries[0].cypher, "WITH state, labeled,")
+	assert.Contains(t, tx.queries[0].cypher, "[relation IN collect(DISTINCT r)")
+	assert.Contains(t, tx.queries[1].cypher, "apoc.lock.read.nodes([state])")
+	assert.Contains(t, tx.queries[2].cypher, "GRAPH_CHUNK_OWNER")
+	assert.Contains(t, tx.queries[3].cypher, "owner.initialized = true")
+	assert.Contains(t, tx.queries[3].cypher, "coalesce(owner.graph_version, '') <> $graph_version")
+	assert.Contains(t, tx.queries[4].cypher, "owner.initialized = true")
+	assert.Contains(t, tx.queries[4].cypher, "GRAPH_NODE_CONTRIBUTION")
+	assert.Contains(t, tx.queries[4].cypher, "DELETE contribution")
+	assert.Contains(t, tx.queries[4].cypher, "remaining.attributes")
+	assert.Contains(t, tx.queries[4].cypher, "node.legacy_attribute_chunks")
+	assert.Contains(t, tx.queries[4].cypher, "node.legacy_attributes")
+	assert.Contains(t, tx.queries[5].cypher, "owner.initialized = true")
+	assert.Contains(t, tx.queries[6].cypher, "coalesce(owner.graph_version, '') <> $graph_version")
+	assert.Contains(t, tx.queries[7].cypher, "coalesce(owner.graph_version, '') <> $graph_version")
+	assert.Less(t, strings.Index(tx.queries[3].cypher, "owner.graph_version"), strings.Index(tx.queries[3].cypher, "MATCH (n:"))
+	assert.Less(t, strings.Index(tx.queries[5].cypher, "owner.graph_version"), strings.Index(tx.queries[5].cypher, "MATCH (n:"))
+	assert.Less(t, strings.Index(tx.queries[6].cypher, "owner.graph_version"), strings.Index(tx.queries[6].cypher, "UNWIND $data"))
+	assert.Less(t, strings.Index(tx.queries[7].cypher, "owner.graph_version"), strings.Index(tx.queries[7].cypher, "UNWIND $data"))
+	assert.Contains(t, tx.queries[3].cypher, "coalesce(r.chunks, [])")
+	assert.Contains(t, tx.queries[3].cypher, "DELETE r")
+	assert.Contains(t, tx.queries[5].cypher, "coalesce(n.chunks, [])")
+	assert.Contains(t, tx.queries[5].cypher, "DETACH DELETE n")
+	assert.Contains(t, tx.queries[6].cypher, "MERGE (owner)-[contribution:GRAPH_NODE_CONTRIBUTION]->(node)")
+	assert.Contains(t, tx.queries[6].cypher, "SET contribution.attributes = row.attributes")
+	assert.Contains(t, tx.queries[6].cypher, "remaining.attributes")
+	assert.Contains(t, tx.queries[6].cypher, "node.legacy_attributes")
+	assert.Contains(t, tx.queries[6].cypher, "apoc.coll.union(coalesce(node.chunks, []), row.chunks)")
+	assert.Contains(t, tx.queries[7].cypher, "CALL apoc.lock.nodes(")
+	assert.Contains(t, tx.queries[7].cypher, "elementId(source) < elementId(target)")
+	assert.Contains(t, tx.queries[7].cypher, "apoc.coll.union(coalesce(rel.chunks, []), row.chunks)")
+	assert.Contains(t, tx.queries[8].cypher, "SET owner.graph_version = $graph_version")
+	assert.Contains(t, tx.queries[8].cypher, "owner.initialized = true")
+	for _, index := range []int{2, 3, 4, 5, 6, 7, 8} {
+		assert.Equal(t, 13, tx.queries[index].params["attempt"])
+	}
+	for _, index := range []int{3, 4, 5, 6, 7, 8} {
+		assert.Contains(t, tx.queries[index].cypher, "coalesce(state.attempt, 0) = $attempt")
+		assert.Contains(t, tx.queries[index].cypher, "owner.attempt = $attempt")
+	}
+
+	nodeRows, ok := tx.queries[6].params["data"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, nodeRows, 2)
+	assert.Equal(t, []string{"current-chunk"}, nodeRows[0]["chunks"])
+	assert.Equal(t, []string{"person"}, nodeRows[0]["attributes"])
+	assert.Contains(t, nodeRows[0]["labels"], "GRAPH_ENTITY")
+	relationRows, ok := tx.queries[7].params["data"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, relationRows, 1)
+	assert.Equal(t, []string{"current-chunk"}, relationRows[0]["chunks"])
+	assert.Equal(t, []string{"current-chunk"}, tx.queries[3].params["chunk_ids"])
+}
+
+func TestReplaceGraphChunkStopsBeforePublishingAfterRetractionFailure(t *testing.T) {
+	want := errors.New("neo4j unavailable")
+	tx := &recordingGraphTransaction{errAt: 4, err: want}
+	repository := &Neo4jRepository{
+		nodePrefix:           "ENTITY",
+		ownershipSchemaReady: true,
+		writeTransaction: func(ctx context.Context, work driver.ManagedTransactionWork) error {
+			_, err := work(tx)
+			return err
+		},
+	}
+
+	err := repository.ReplaceGraphChunk(
+		context.Background(),
+		types.NameSpace{KnowledgeBase: "kb-1", Knowledge: "knowledge-1"},
+		"chunk-1",
+		3,
+		&types.GraphData{},
+	)
+
+	require.ErrorIs(t, err, want)
+	assert.Len(t, tx.queries, 4)
+}
+
+func TestDelGraphChunksRetractsSharedOwnershipBeforeDeletingOwnerlessData(t *testing.T) {
+	tx := &recordingGraphTransaction{}
+	repository := &Neo4jRepository{
+		nodePrefix:           "ENTITY",
+		ownershipSchemaReady: true,
+		writeTransaction: func(ctx context.Context, work driver.ManagedTransactionWork) error {
+			_, err := work(tx)
+			return err
+		},
+	}
+
+	err := repository.DelGraphChunks(
+		context.Background(),
+		types.NameSpace{KnowledgeBase: "kb-1", Knowledge: "knowledge-1"},
+		[]string{"chunk-1", "chunk-2"},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, tx.queries, 6)
+	assert.Contains(t, tx.queries[0].cypher, "coalesce(state.version, 0) < $schema_version")
+	assert.Contains(t, tx.queries[0].cypher, "r.chunks IS NULL")
+	assert.Contains(t, tx.queries[1].cypher, "apoc.lock.read.nodes([state])")
+	assert.Contains(t, tx.queries[2].cypher, "NOT (ownerID IN $chunk_ids)")
+	assert.Contains(t, tx.queries[2].cypher, "size(r.chunks) = 0")
+	assert.Contains(t, tx.queries[2].cypher, "WITH DISTINCT r")
+	assert.Less(t,
+		strings.Index(tx.queries[2].cypher, "WITH DISTINCT r"),
+		strings.Index(tx.queries[2].cypher, "SET r.chunks"),
+	)
+	assert.Contains(t, tx.queries[3].cypher, "GRAPH_NODE_CONTRIBUTION")
+	assert.Contains(t, tx.queries[3].cypher, "remaining.attributes")
+	assert.Contains(t, tx.queries[4].cypher, "NOT (ownerID IN $chunk_ids)")
+	assert.Contains(t, tx.queries[4].cypher, "size(n.chunks) = 0")
+	assert.Contains(t, tx.queries[5].cypher, "DETACH DELETE owner")
+	for _, query := range tx.queries {
+		assert.False(t, strings.Contains(query.cypher, "apoc.periodic.iterate"))
+	}
+	assert.Equal(t, []string{"chunk-1", "chunk-2"}, tx.queries[2].params["chunk_ids"])
+}
+
+func TestRecoverGraphNamespaceDeletesOnlyDirtyNamespace(t *testing.T) {
+	namespace := types.NameSpace{KnowledgeBase: "kb-1", Knowledge: "knowledge-1"}
+
+	t.Run("clean", func(t *testing.T) {
+		writeCalls := 0
+		repository := &Neo4jRepository{
+			graphRecoveryRequired: func(context.Context, types.NameSpace) (bool, error) {
+				return false, nil
+			},
+			writeTransaction: func(context.Context, driver.ManagedTransactionWork) error {
+				writeCalls++
+				return nil
+			},
+		}
+
+		require.NoError(t, repository.RecoverGraphNamespace(context.Background(), namespace))
+		assert.Zero(t, writeCalls)
+	})
+
+	t.Run("dirty", func(t *testing.T) {
+		var transactions []*recordingGraphTransaction
+		repository := &Neo4jRepository{
+			nodePrefix:           "ENTITY",
+			ownershipSchemaReady: true,
+			graphRecoveryRequired: func(context.Context, types.NameSpace) (bool, error) {
+				return true, nil
+			},
+			writeTransaction: func(ctx context.Context, work driver.ManagedTransactionWork) error {
+				tx := &recordingGraphTransaction{}
+				transactions = append(transactions, tx)
+				_, err := work(tx)
+				return err
+			},
+		}
+
+		require.NoError(t, repository.RecoverGraphNamespace(context.Background(), namespace))
+		require.Len(t, transactions, 3)
+		assert.Contains(t, transactions[0].queries[0].cypher, "state.deleting = true")
+		assert.Contains(t, transactions[1].queries[0].cypher, "DELETE r")
+		assert.Equal(t, true, transactions[2].queries[0].params["succeeded"])
+	})
+}
+
+func TestGraphRecoveryRoutesStateCheckToWriter(t *testing.T) {
+	assert.Equal(t, driver.AccessModeWrite, graphRecoverySessionConfig().AccessMode)
+}
+
+func TestGraphOwnershipVersionIgnoresOrderingAndCurrentOwnership(t *testing.T) {
+	first := &types.GraphData{
+		Node: []*types.GraphNode{
+			{Name: "B", Chunks: []string{"chunk-1"}, Attributes: []string{"z", "a"}},
+			{Name: "A", Chunks: []string{"chunk-1"}},
+		},
+		Relation: []*types.GraphRelation{
+			{Node1: "B", Node2: "A", Type: "z", Chunks: []string{"chunk-1"}},
+			{Node1: "A", Node2: "B", Type: "a", Chunks: []string{"chunk-1"}},
+		},
+	}
+	second := &types.GraphData{
+		Node: []*types.GraphNode{
+			{Name: "A", Chunks: []string{"chunk-2"}},
+			{Name: "B", Chunks: []string{"chunk-2"}, Attributes: []string{"a", "z"}},
+		},
+		Relation: []*types.GraphRelation{
+			{Node1: "A", Node2: "B", Type: "a", Chunks: []string{"chunk-2"}},
+			{Node1: "B", Node2: "A", Type: "z", Chunks: []string{"chunk-2"}},
+		},
+	}
+
+	firstVersion, err := graphOwnershipVersion(first)
+	require.NoError(t, err)
+	secondVersion, err := graphOwnershipVersion(second)
+	require.NoError(t, err)
+	assert.Equal(t, firstVersion, secondVersion)
+}
+
+func TestGraphOwnershipVersionChangesWithGraphSemantics(t *testing.T) {
+	base := &types.GraphData{
+		Node: []*types.GraphNode{
+			{Name: "A", Attributes: []string{"person"}},
+			{Name: "B"},
+		},
+		Relation: []*types.GraphRelation{{Node1: "A", Node2: "B", Type: "knows"}},
+	}
+	changed := &types.GraphData{
+		Node: []*types.GraphNode{
+			{Name: "A", Attributes: []string{"organization"}},
+			{Name: "B"},
+		},
+		Relation: []*types.GraphRelation{{Node1: "A", Node2: "B", Type: "works_with"}},
+	}
+
+	baseVersion, err := graphOwnershipVersion(base)
+	require.NoError(t, err)
+	changedVersion, err := graphOwnershipVersion(changed)
+	require.NoError(t, err)
+	assert.NotEqual(t, baseVersion, changedVersion)
+}
+
+func TestGraphOwnershipVersionRejectsRelationWithUnknownEndpoint(t *testing.T) {
+	_, err := graphOwnershipVersion(&types.GraphData{
+		Node: []*types.GraphNode{{Name: "A"}},
+		Relation: []*types.GraphRelation{{
+			Node1: "A",
+			Node2: "B",
+			Type:  "knows",
+		}},
+	})
+
+	require.ErrorContains(t, err, "unknown node")
+}
+
+func TestDelGraphInvalidatesOwnersBeforeBatchDeletionAndClearsStateAfterward(t *testing.T) {
+	var transactions []*recordingGraphTransaction
+	repository := &Neo4jRepository{
+		nodePrefix:           "ENTITY",
+		ownershipSchemaReady: true,
+		writeTransaction: func(ctx context.Context, work driver.ManagedTransactionWork) error {
+			tx := &recordingGraphTransaction{}
+			transactions = append(transactions, tx)
+			_, err := work(tx)
+			return err
+		},
+	}
+
+	err := repository.DelGraph(context.Background(), []types.NameSpace{{
+		KnowledgeBase: "kb-1",
+		Knowledge:     "knowledge-1",
+	}})
+
+	require.NoError(t, err)
+	require.Len(t, transactions, 3)
+	require.Len(t, transactions[0].queries, 1)
+	assert.Contains(t, transactions[0].queries[0].cypher, "state.deletion_token = $deletion_token")
+	assert.Contains(t, transactions[0].queries[0].cypher, "DELETE ownership")
+	assert.Contains(t, transactions[0].queries[0].cypher, "DELETE owner")
+	token, ok := transactions[0].queries[0].params["deletion_token"].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, token)
+	require.Len(t, transactions[1].queries, 2)
+	assert.Contains(t, transactions[1].queries[0].cypher, "RETURN DISTINCT r")
+	assert.Contains(t, transactions[1].queries[0].cypher, "DELETE r")
+	assert.Contains(t, transactions[1].queries[0].cypher, "failedOperations")
+	assert.Contains(t, transactions[1].queries[0].cypher, "failedBatches")
+	assert.Contains(t, transactions[1].queries[0].cypher, "wasTerminated")
+	assert.Contains(t, transactions[1].queries[0].cypher, "apoc.util.validate")
+	assert.Contains(t, transactions[1].queries[0].cypher, "parallel: false")
+	assert.GreaterOrEqual(t,
+		strings.Count(transactions[1].queries[0].cypher,
+			"coalesce(state.deletion_token, '') <> $deletion_token"),
+		2,
+	)
+	assert.Contains(t, transactions[1].queries[1].cypher, "DETACH DELETE n")
+	assert.GreaterOrEqual(t,
+		strings.Count(transactions[1].queries[1].cypher,
+			"coalesce(state.deletion_token, '') <> $deletion_token"),
+		2,
+	)
+	assert.Equal(t, token, transactions[1].queries[0].params["deletion_token"])
+	assert.Equal(t, token, transactions[1].queries[1].params["deletion_token"])
+	require.Len(t, transactions[2].queries, 1)
+	assert.Contains(t, transactions[2].queries[0].cypher, "GRAPH_OWNERSHIP_STATE")
+	assert.Contains(t, transactions[2].queries[0].cypher, "state.dirty")
+	assert.Contains(t, transactions[2].queries[0].cypher, "deletion_token: $deletion_token")
+	assert.Equal(t, token, transactions[2].queries[0].params["deletion_token"])
+	assert.Equal(t, true, transactions[2].queries[0].params["succeeded"])
+}
+
+func TestDelGraphKeepsDeletionStateWhenBatchDeletionFails(t *testing.T) {
+	want := errors.New("batch delete failed")
+	var transactions []*recordingGraphTransaction
+	repository := &Neo4jRepository{
+		nodePrefix:           "ENTITY",
+		ownershipSchemaReady: true,
+		writeTransaction: func(ctx context.Context, work driver.ManagedTransactionWork) error {
+			writeCalls := len(transactions) + 1
+			tx := &recordingGraphTransaction{}
+			if writeCalls == 2 {
+				tx.errAt = 1
+				tx.err = want
+			}
+			transactions = append(transactions, tx)
+			_, err := work(tx)
+			return err
+		},
+	}
+
+	err := repository.DelGraph(context.Background(), []types.NameSpace{{
+		KnowledgeBase: "kb-1",
+		Knowledge:     "knowledge-1",
+	}})
+
+	require.ErrorIs(t, err, want)
+	require.Len(t, transactions, 3)
+	require.Len(t, transactions[2].queries, 1)
+	assert.Equal(t, false, transactions[2].queries[0].params["succeeded"])
+	assert.Contains(t, transactions[2].queries[0].cypher, "state.dirty")
+	assert.Contains(t, transactions[2].queries[0].cypher, "deletion_token: $deletion_token")
+}
+
+func TestDelGraphRetrySupersedesAbandonedDeletionToken(t *testing.T) {
+	var beginTokens []string
+	repository := &Neo4jRepository{
+		nodePrefix:           "ENTITY",
+		ownershipSchemaReady: true,
+		writeTransaction: func(ctx context.Context, work driver.ManagedTransactionWork) error {
+			tx := &recordingGraphTransaction{}
+			_, err := work(tx)
+			if err == nil && len(tx.queries) == 1 &&
+				strings.Contains(tx.queries[0].cypher, "DELETE ownership") {
+				beginTokens = append(beginTokens, tx.queries[0].params["deletion_token"].(string))
+			}
+			return err
+		},
+	}
+	namespace := types.NameSpace{KnowledgeBase: "kb-1", Knowledge: "knowledge-1"}
+
+	require.NoError(t, repository.DelGraph(context.Background(), []types.NameSpace{namespace}))
+	require.NoError(t, repository.DelGraph(context.Background(), []types.NameSpace{namespace}))
+
+	require.Len(t, beginTokens, 2)
+	assert.NotEqual(t, beginTokens[0], beginTokens[1])
+}

--- a/internal/application/repository/retriever/postgres/repository.go
+++ b/internal/application/repository/retriever/postgres/repository.go
@@ -98,7 +98,23 @@ func (g *pgRepository) BatchSave(
 	for i := range indexInfoList {
 		indexInfoDBList[i] = toDBVectorEmbedding(indexInfoList[i], additionalParams)
 	}
-	err := g.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(indexInfoDBList).Error
+	err := g.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "source_id"},
+			{Name: "source_type"},
+		},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"chunk_id",
+			"knowledge_id",
+			"knowledge_base_id",
+			"tag_id",
+			"content",
+			"dimension",
+			"embedding",
+			"is_enabled",
+			"updated_at",
+		}),
+	}).Create(indexInfoDBList).Error
 	if err != nil {
 		logger.GetLogger(ctx).Errorf("[Postgres] Batch save failed: %v", err)
 		return err

--- a/internal/application/repository/retriever/postgres/repository_test.go
+++ b/internal/application/repository/retriever/postgres/repository_test.go
@@ -1,0 +1,54 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestBatchSaveReplacesSameSourceWithoutDelete(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&pgVector{}))
+	require.NoError(t, db.Exec(
+		"CREATE UNIQUE INDEX embeddings_unique_source ON embeddings(source_id, source_type)",
+	).Error)
+
+	deleteCalls := 0
+	require.NoError(t, db.Callback().Delete().Before("gorm:delete").Register(
+		"test:count_vector_deletes",
+		func(*gorm.DB) { deleteCalls++ },
+	))
+
+	repo := &pgRepository{db: db}
+	first := &types.IndexInfo{
+		SourceID:        "stable-source",
+		SourceType:      types.ChunkSourceType,
+		ChunkID:         "stable-source",
+		KnowledgeID:     "knowledge-1",
+		KnowledgeBaseID: "kb-1",
+		Content:         "old payload",
+		IsEnabled:       true,
+	}
+	second := *first
+	second.Content = "new title and context payload"
+
+	require.NoError(t, repo.BatchSave(context.Background(), []*types.IndexInfo{first}, map[string]any{
+		"embedding": map[string][]float32{first.SourceID: {1, 2, 3}},
+	}))
+	require.NoError(t, repo.BatchSave(context.Background(), []*types.IndexInfo{&second}, map[string]any{
+		"embedding": map[string][]float32{second.SourceID: {4, 5, 6}},
+	}))
+
+	var rows []pgVector
+	require.NoError(t, db.Find(&rows).Error)
+	require.Len(t, rows, 1)
+	assert.Equal(t, second.Content, rows[0].Content)
+	assert.Equal(t, []float32{4, 5, 6}, rows[0].Embedding.Slice())
+	assert.Zero(t, deleteCalls, "replacement must use one atomic upsert, not a pre-delete")
+}

--- a/internal/application/repository/retriever/sqlite/repository.go
+++ b/internal/application/repository/retriever/sqlite/repository.go
@@ -7,6 +7,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/Tencent/WeKnora/internal/application/repository"
 	"github.com/Tencent/WeKnora/internal/common"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
@@ -34,6 +35,11 @@ type sqliteEmbedding struct {
 }
 
 func (sqliteEmbedding) TableName() string { return "lite_embeddings" }
+
+type sqliteEmbeddingSource struct {
+	sourceID   string
+	sourceType int
+}
 
 type sqliteRepository struct {
 	db        *gorm.DB
@@ -106,23 +112,43 @@ func vecTableName(dim int) string {
 }
 
 func (r *sqliteRepository) ensureVecTable(dim int) {
-	if dim <= 0 || r.vecTables[dim] {
-		return
+	if err := r.ensureVecTableWithDB(r.db, dim); err != nil {
+		logger.GetLogger(context.Background()).Errorf("[SQLite] Failed to create vec0 table for dim %d: %v", dim, err)
+	}
+}
+
+func (r *sqliteRepository) ensureVecTableWithDB(db *gorm.DB, dim int) error {
+	if dim <= 0 {
+		return nil
 	}
 	tbl := vecTableName(dim)
+	ready, err := validateCachedVecTable(r.vecTables, dim, func() (bool, error) {
+		var count int64
+		err := db.Raw(
+			"SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?",
+			tbl,
+		).Scan(&count).Error
+		return count > 0, err
+	})
+	if err != nil {
+		return err
+	}
+	if ready {
+		return nil
+	}
 	createSQL := fmt.Sprintf(
 		`CREATE VIRTUAL TABLE IF NOT EXISTS %s USING vec0(embedding float[%d] distance_metric=cosine)`,
 		tbl, dim,
 	)
-	if err := r.db.Exec(createSQL).Error; err != nil {
+	if err := db.Exec(createSQL).Error; err != nil {
 		if strings.Contains(err.Error(), "already exists") {
 			r.vecTables[dim] = true
-			return
+			return nil
 		}
-		logger.GetLogger(context.Background()).Errorf("[SQLite] Failed to create vec0 table for dim %d: %v", dim, err)
-		return
+		return err
 	}
 	r.vecTables[dim] = true
+	return nil
 }
 
 func (r *sqliteRepository) ensureExistingVecTables() {
@@ -142,19 +168,7 @@ func (r *sqliteRepository) Support() []types.RetrieverType {
 }
 
 func (r *sqliteRepository) Save(ctx context.Context, indexInfo *types.IndexInfo, params map[string]any) error {
-	row := toSQLiteEmbedding(indexInfo)
-	emb := extractEmbedding(params, indexInfo.SourceID)
-	if len(emb) > 0 {
-		row.Dimension = len(emb)
-	}
-	if err := r.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(row).Error; err != nil {
-		return err
-	}
-	r.syncFTS5Insert(ctx, row)
-	if len(emb) > 0 && row.ID > 0 {
-		r.insertVec(ctx, row.ID, row.Dimension, emb)
-	}
-	return nil
+	return r.BatchSave(ctx, []*types.IndexInfo{indexInfo}, params)
 }
 
 func (r *sqliteRepository) BatchSave(ctx context.Context, indexInfoList []*types.IndexInfo, params map[string]any) error {
@@ -171,13 +185,72 @@ func (r *sqliteRepository) BatchSave(ctx context.Context, indexInfoList []*types
 			rows[i].Dimension = len(emb)
 		}
 	}
-	if err := r.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(rows).Error; err != nil {
+	db := repository.DBFromContext(ctx, r.db)
+	sourceIDs := make([]string, 0, len(rows))
+	for _, row := range rows {
+		sourceIDs = append(sourceIDs, row.SourceID)
+	}
+	var previousRows []sqliteEmbedding
+	if err := db.Where("source_id IN ?", sourceIDs).Find(&previousRows).Error; err != nil {
 		return err
 	}
+	previousBySource := make(map[sqliteEmbeddingSource]sqliteEmbedding, len(previousRows))
+	for _, row := range previousRows {
+		previousBySource[sqliteEmbeddingSource{sourceID: row.SourceID, sourceType: row.SourceType}] = row
+	}
+
+	if err := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "source_id"},
+			{Name: "source_type"},
+		},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"chunk_id",
+			"knowledge_id",
+			"knowledge_base_id",
+			"tag_id",
+			"content",
+			"dimension",
+			"is_enabled",
+			"updated_at",
+		}),
+	}).Create(rows).Error; err != nil {
+		return err
+	}
+
+	var persistedRows []sqliteEmbedding
+	if err := db.Where("source_id IN ?", sourceIDs).Find(&persistedRows).Error; err != nil {
+		return err
+	}
+	persistedBySource := make(map[sqliteEmbeddingSource]sqliteEmbedding, len(persistedRows))
+	for _, row := range persistedRows {
+		persistedBySource[sqliteEmbeddingSource{sourceID: row.SourceID, sourceType: row.SourceType}] = row
+	}
 	for i, row := range rows {
-		r.syncFTS5Insert(ctx, row)
+		persisted, found := persistedBySource[sqliteEmbeddingSource{sourceID: row.SourceID, sourceType: row.SourceType}]
+		if !found {
+			return fmt.Errorf("sqlite embedding upsert did not return source %q", row.SourceID)
+		}
+		row.ID = persisted.ID
+		if err := r.syncFTS5Insert(ctx, row); err != nil {
+			return err
+		}
 		if len(embs[i]) > 0 && row.ID > 0 {
-			r.insertVec(ctx, row.ID, row.Dimension, embs[i])
+			previous, existed := previousBySource[sqliteEmbeddingSource{sourceID: row.SourceID, sourceType: row.SourceType}]
+			if existed && previous.Dimension > 0 && previous.Dimension == row.Dimension {
+				if err := r.updateVec(ctx, row.ID, row.Dimension, embs[i]); err != nil {
+					return err
+				}
+				continue
+			}
+			if err := r.insertVec(ctx, row.ID, row.Dimension, embs[i]); err != nil {
+				return err
+			}
+			if existed && previous.Dimension > 0 {
+				if err := r.deleteVec(ctx, previous.ID, previous.Dimension); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return nil
@@ -192,24 +265,39 @@ func (r *sqliteRepository) EstimateStorageSize(_ context.Context, indexInfoList 
 }
 
 func (r *sqliteRepository) DeleteByChunkIDList(ctx context.Context, chunkIDList []string, _ int, _ string) error {
+	db := repository.DBFromContext(ctx, r.db)
 	var rows []sqliteEmbedding
-	r.db.WithContext(ctx).Where("chunk_id IN ?", chunkIDList).Find(&rows)
-	r.deleteRowsAndVecs(ctx, rows)
-	return r.db.WithContext(ctx).Where("chunk_id IN ?", chunkIDList).Delete(&sqliteEmbedding{}).Error
+	if err := db.Where("chunk_id IN ?", chunkIDList).Find(&rows).Error; err != nil {
+		return err
+	}
+	if err := r.deleteRowsAndVecs(ctx, rows); err != nil {
+		return err
+	}
+	return db.Where("chunk_id IN ?", chunkIDList).Delete(&sqliteEmbedding{}).Error
 }
 
 func (r *sqliteRepository) DeleteBySourceIDList(ctx context.Context, sourceIDList []string, _ int, _ string) error {
+	db := repository.DBFromContext(ctx, r.db)
 	var rows []sqliteEmbedding
-	r.db.WithContext(ctx).Where("source_id IN ?", sourceIDList).Find(&rows)
-	r.deleteRowsAndVecs(ctx, rows)
-	return r.db.WithContext(ctx).Where("source_id IN ?", sourceIDList).Delete(&sqliteEmbedding{}).Error
+	if err := db.Where("source_id IN ?", sourceIDList).Find(&rows).Error; err != nil {
+		return err
+	}
+	if err := r.deleteRowsAndVecs(ctx, rows); err != nil {
+		return err
+	}
+	return db.Where("source_id IN ?", sourceIDList).Delete(&sqliteEmbedding{}).Error
 }
 
 func (r *sqliteRepository) DeleteByKnowledgeIDList(ctx context.Context, knowledgeIDList []string, _ int, _ string) error {
+	db := repository.DBFromContext(ctx, r.db)
 	var rows []sqliteEmbedding
-	r.db.WithContext(ctx).Where("knowledge_id IN ?", knowledgeIDList).Find(&rows)
-	r.deleteRowsAndVecs(ctx, rows)
-	return r.db.WithContext(ctx).Where("knowledge_id IN ?", knowledgeIDList).Delete(&sqliteEmbedding{}).Error
+	if err := db.Where("knowledge_id IN ?", knowledgeIDList).Find(&rows).Error; err != nil {
+		return err
+	}
+	if err := r.deleteRowsAndVecs(ctx, rows); err != nil {
+		return err
+	}
+	return db.Where("knowledge_id IN ?", knowledgeIDList).Delete(&sqliteEmbedding{}).Error
 }
 
 func (r *sqliteRepository) CopyIndices(ctx context.Context,
@@ -494,17 +582,37 @@ func extractEmbedding(params map[string]any, sourceID string) []float32 {
 	return embMap[sourceID]
 }
 
-func (r *sqliteRepository) insertVec(_ context.Context, rowID uint, dim int, emb []float32) {
-	r.ensureVecTable(dim)
+func (r *sqliteRepository) insertVec(ctx context.Context, rowID uint, dim int, emb []float32) error {
+	db := repository.DBFromContext(ctx, r.db)
+	if err := r.ensureVecTableWithDB(db, dim); err != nil {
+		return err
+	}
 	blob, err := sqlite_vec.SerializeFloat32(emb)
 	if err != nil {
-		return
+		return err
 	}
 	sql := fmt.Sprintf("INSERT INTO %s(rowid, embedding) VALUES (?, ?)", vecTableName(dim))
-	r.db.Exec(sql, rowID, blob)
+	return db.Exec(sql, rowID, blob).Error
 }
 
-func (r *sqliteRepository) deleteRowsAndVecs(_ context.Context, rows []sqliteEmbedding) {
+func (r *sqliteRepository) updateVec(ctx context.Context, rowID uint, dim int, emb []float32) error {
+	blob, err := sqlite_vec.SerializeFloat32(emb)
+	if err != nil {
+		return err
+	}
+	return repository.DBFromContext(ctx, r.db).
+		Exec(fmt.Sprintf("UPDATE %s SET embedding = ? WHERE rowid = ?", vecTableName(dim)), blob, rowID).Error
+}
+
+func (r *sqliteRepository) deleteVec(ctx context.Context, rowID uint, dim int) error {
+	if dim <= 0 || !r.vecTables[dim] {
+		return nil
+	}
+	return repository.DBFromContext(ctx, r.db).
+		Exec(fmt.Sprintf("DELETE FROM %s WHERE rowid = ?", vecTableName(dim)), rowID).Error
+}
+
+func (r *sqliteRepository) deleteRowsAndVecs(ctx context.Context, rows []sqliteEmbedding) error {
 	dimIDs := make(map[int][]uint)
 	for _, row := range rows {
 		if row.Dimension > 0 {
@@ -512,17 +620,19 @@ func (r *sqliteRepository) deleteRowsAndVecs(_ context.Context, rows []sqliteEmb
 		}
 	}
 	for dim, ids := range dimIDs {
-		if !r.vecTables[dim] {
-			continue
-		}
-		tbl := vecTableName(dim)
 		for _, id := range ids {
-			r.db.Exec(fmt.Sprintf("DELETE FROM %s WHERE rowid = ?", tbl), id)
+			if err := r.deleteVec(ctx, id, dim); err != nil {
+				return err
+			}
 		}
 	}
 	for _, row := range rows {
-		r.db.Exec("DELETE FROM lite_embeddings_fts WHERE rowid = ?", row.ID)
+		if err := repository.DBFromContext(ctx, r.db).
+			Exec("DELETE FROM lite_embeddings_fts WHERE rowid = ?", row.ID).Error; err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func (r *sqliteRepository) copyVec(_ context.Context, srcID, dstID uint, dim int) {
@@ -536,13 +646,14 @@ func (r *sqliteRepository) copyVec(_ context.Context, srcID, dstID uint, dim int
 	), dstID, srcID)
 }
 
-func (r *sqliteRepository) syncFTS5Insert(_ context.Context, row *sqliteEmbedding) {
+func (r *sqliteRepository) syncFTS5Insert(ctx context.Context, row *sqliteEmbedding) error {
 	if row.ID == 0 {
-		return
+		return nil
 	}
 	tokenizedContent := tokenizeCJKBigram(row.Content)
-	sql := `INSERT INTO lite_embeddings_fts(rowid, content, source_id, chunk_id, knowledge_id, knowledge_base_id) VALUES(?, ?, ?, ?, ?, ?)`
-	r.db.Exec(sql, row.ID, tokenizedContent, row.SourceID, row.ChunkID, row.KnowledgeID, row.KnowledgeBaseID)
+	sql := `INSERT OR REPLACE INTO lite_embeddings_fts(rowid, content, source_id, chunk_id, knowledge_id, knowledge_base_id) VALUES(?, ?, ?, ?, ?, ?)`
+	return repository.DBFromContext(ctx, r.db).
+		Exec(sql, row.ID, tokenizedContent, row.SourceID, row.ChunkID, row.KnowledgeID, row.KnowledgeBaseID).Error
 }
 
 type whereClause struct {

--- a/internal/application/repository/retriever/sqlite/repository_test.go
+++ b/internal/application/repository/retriever/sqlite/repository_test.go
@@ -1,0 +1,54 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	sqlite_vec "github.com/asg017/sqlite-vec-go-bindings/cgo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestBatchSaveReplacesSameSource(t *testing.T) {
+	sqlite_vec.Auto()
+	t.Cleanup(sqlite_vec.Cancel)
+
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	repo := NewSQLiteRetrieveEngineRepository(db).(*sqliteRepository)
+
+	first := &types.IndexInfo{
+		SourceID:        "stable-source",
+		SourceType:      types.ChunkSourceType,
+		ChunkID:         "stable-source",
+		KnowledgeID:     "knowledge-1",
+		KnowledgeBaseID: "kb-1",
+		Content:         "old payload",
+		IsEnabled:       true,
+	}
+	second := *first
+	second.Content = "new title and context payload"
+
+	require.NoError(t, repo.BatchSave(context.Background(), []*types.IndexInfo{first}, map[string]any{
+		"embedding": map[string][]float32{first.SourceID: {1, 2, 3}},
+	}))
+	require.NoError(t, repo.BatchSave(context.Background(), []*types.IndexInfo{&second}, map[string]any{
+		"embedding": map[string][]float32{second.SourceID: {4, 5, 6}},
+	}))
+
+	var rows []sqliteEmbedding
+	require.NoError(t, db.Find(&rows).Error)
+	require.Len(t, rows, 1)
+	assert.Equal(t, second.Content, rows[0].Content)
+	assert.Equal(t, 3, rows[0].Dimension)
+
+	var vectorJSON string
+	require.NoError(t, db.Raw(
+		"SELECT vec_to_json(embedding) FROM vec_embeddings_3 WHERE rowid = ?",
+		rows[0].ID,
+	).Scan(&vectorJSON).Error)
+	assert.JSONEq(t, `[4, 5, 6]`, vectorJSON)
+}

--- a/internal/application/repository/retriever/sqlite/vec_table_cache.go
+++ b/internal/application/repository/retriever/sqlite/vec_table_cache.go
@@ -1,0 +1,23 @@
+package sqlite
+
+// validateCachedVecTable confirms that a cached vec table still exists in the
+// current database view. Transactional DDL may roll back after the cache was
+// populated, in which case the entry is evicted so the caller can recreate it.
+func validateCachedVecTable(
+	cache map[int]bool,
+	dimension int,
+	exists func() (bool, error),
+) (bool, error) {
+	if !cache[dimension] {
+		return false, nil
+	}
+	present, err := exists()
+	if err != nil {
+		return false, err
+	}
+	if !present {
+		delete(cache, dimension)
+		return false, nil
+	}
+	return true, nil
+}

--- a/internal/application/repository/retriever/sqlite/vec_table_cache_test.go
+++ b/internal/application/repository/retriever/sqlite/vec_table_cache_test.go
@@ -1,0 +1,35 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCachedVecTableAllowsRetryAfterRolledBackDDL(t *testing.T) {
+	const dimension = 1536
+	cache := map[int]bool{dimension: true}
+
+	ready, err := validateCachedVecTable(cache, dimension, func() (bool, error) {
+		return false, nil
+	})
+	require.NoError(t, err)
+	assert.False(t, ready)
+	assert.False(t, cache[dimension], "rolled-back table must be evicted from the cache")
+
+	ready, err = validateCachedVecTable(cache, dimension, func() (bool, error) {
+		t.Fatal("uncached retry must proceed directly to table creation")
+		return false, nil
+	})
+	require.NoError(t, err)
+	assert.False(t, ready)
+
+	cache[dimension] = true
+	ready, err = validateCachedVecTable(cache, dimension, func() (bool, error) {
+		return true, nil
+	})
+	require.NoError(t, err)
+	assert.True(t, ready)
+	assert.True(t, cache[dimension])
+}

--- a/internal/application/repository/retriever/tencentvectordb/repository.go
+++ b/internal/application/repository/retriever/tencentvectordb/repository.go
@@ -67,6 +67,12 @@ func (r *repository) Support() []types.RetrieverType {
 	return []types.RetrieverType{types.KeywordsRetrieverType, types.VectorRetrieverType}
 }
 
+// PhysicalIndexNamespace reports the collection that owns vectors for a
+// dimension. Explicit collection configuration is shared across dimensions.
+func (r *repository) PhysicalIndexNamespace(dimension int, _ string) string {
+	return r.collectionName(dimension)
+}
+
 func (r *repository) Save(ctx context.Context, indexInfo *types.IndexInfo, params map[string]any) error {
 	return r.BatchSave(ctx, []*types.IndexInfo{indexInfo}, params)
 }

--- a/internal/application/service/chat_artifact_cache.go
+++ b/internal/application/service/chat_artifact_cache.go
@@ -1,0 +1,288 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+const chatArtifactCodecVersion byte = 1
+
+var (
+	errChatArtifactProvider = errors.New("chat artifact provider failed")
+	errChatArtifactStore    = errors.New("chat artifact store failed")
+	errChatArtifactCodec    = errors.New("chat artifact codec failed")
+)
+
+func isChatArtifactPipelineError(err error) bool {
+	return errors.Is(err, errChatArtifactStore) || errors.Is(err, errChatArtifactCodec)
+}
+
+type chatArtifactRequest struct {
+	tenantID             uint64
+	stage                string
+	keyVersion           uint16
+	model                chat.Chat
+	modelRevision        string
+	messages             []chat.Message
+	options              *chat.ChatOptions
+	promptVersion        string
+	canonicalizerVersion string
+	valuePolicy          chatArtifactValuePolicy
+}
+
+type chatArtifactValuePolicy struct {
+	canonicalize func(string) (value string, cacheable bool, err error)
+	validate     func(string) error
+}
+
+func newChatArtifactKey(request chatArtifactRequest) (types.ProcessingArtifactKey, error) {
+	if err := validateChatArtifactRequest(request); err != nil {
+		return types.ProcessingArtifactKey{}, err
+	}
+
+	messages, err := json.Marshal(request.messages)
+	if err != nil {
+		return types.ProcessingArtifactKey{}, fmt.Errorf("%w: encode messages: %w", errChatArtifactCodec, err)
+	}
+	options, err := json.Marshal(request.options)
+	if err != nil {
+		return types.ProcessingArtifactKey{}, fmt.Errorf("%w: encode options: %w", errChatArtifactCodec, err)
+	}
+
+	return types.NewProcessingArtifactKey(
+		request.tenantID,
+		request.stage,
+		request.keyVersion,
+		[]byte(request.model.GetModelID()),
+		[]byte(request.model.GetModelName()),
+		[]byte(request.modelRevision),
+		messages,
+		options,
+		[]byte(request.promptVersion),
+		[]byte(request.canonicalizerVersion),
+	)
+}
+
+func validateChatArtifactRequest(request chatArtifactRequest) error {
+	if strings.TrimSpace(request.stage) == "" {
+		return errors.New("chat artifact stage must not be empty")
+	}
+	if request.keyVersion == 0 {
+		return errors.New("chat artifact key version must not be zero")
+	}
+	if request.model == nil {
+		return errors.New("chat artifact model must not be nil")
+	}
+	if strings.TrimSpace(request.modelRevision) == "" {
+		return errors.New("chat artifact model revision must not be empty")
+	}
+	if request.options == nil {
+		return errors.New("chat artifact options must not be nil")
+	}
+	if strings.TrimSpace(request.promptVersion) == "" {
+		return errors.New("chat artifact prompt version must not be empty")
+	}
+	if strings.TrimSpace(request.canonicalizerVersion) == "" {
+		return errors.New("chat artifact canonicalizer version must not be empty")
+	}
+	return nil
+}
+
+func chatArtifactModelRevision(model *types.Model) (string, error) {
+	if model == nil || strings.TrimSpace(model.ID) == "" || strings.TrimSpace(model.Name) == "" || model.UpdatedAt.IsZero() {
+		return "", errors.New("chat artifact model is incomplete")
+	}
+	endpoint, err := normalizeChatArtifactEndpoint(model.Parameters.BaseURL)
+	if err != nil {
+		return "", err
+	}
+	if len(model.Parameters.CustomHeaders) > 0 {
+		return "", errors.New("chat artifact model has unsupported custom headers")
+	}
+
+	extra, err := canonicalChatArtifactExtraConfig(model.Parameters.ExtraConfig)
+	if err != nil {
+		return "", err
+	}
+	descriptor := strings.Join([]string{
+		model.ID,
+		model.Name,
+		string(model.Type),
+		strings.ToLower(string(model.Source)),
+		endpoint,
+		strings.ToLower(strings.TrimSpace(model.Parameters.InterfaceType)),
+		strings.TrimSpace(model.Parameters.ParameterSize),
+		strings.ToLower(strings.TrimSpace(model.Parameters.Provider)),
+		fmt.Sprintf("%t", model.Parameters.SupportsVision),
+		extra,
+		model.UpdatedAt.UTC().Format(time.RFC3339Nano),
+	}, "\x00")
+	digest := sha256.Sum256([]byte(descriptor))
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func normalizeChatArtifactEndpoint(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	if strings.TrimSpace(raw) != raw {
+		return "", errors.New("invalid chat artifact endpoint")
+	}
+	endpoint, err := url.Parse(raw)
+	if err != nil || endpoint.Scheme == "" || endpoint.Host == "" || endpoint.User != nil ||
+		endpoint.RawQuery != "" || endpoint.Fragment != "" || endpoint.Opaque != "" {
+		return "", errors.New("invalid chat artifact endpoint")
+	}
+	endpoint.Scheme = strings.ToLower(endpoint.Scheme)
+	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
+		return "", errors.New("invalid chat artifact endpoint")
+	}
+	endpoint.Host = strings.ToLower(endpoint.Host)
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/")
+	return endpoint.String(), nil
+}
+
+func canonicalChatArtifactExtraConfig(extraConfig map[string]string) (string, error) {
+	if len(extraConfig) == 0 {
+		return "", nil
+	}
+	allowed := map[string]struct{}{
+		"api_version":                   {},
+		"remote_model_name":             {},
+		chat.ExtraConfigThinkingControl: {},
+	}
+	keys := make([]string, 0, len(extraConfig))
+	for key := range extraConfig {
+		if _, ok := allowed[key]; !ok {
+			return "", errors.New("chat artifact model has unsupported extra config")
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		value := extraConfig[key]
+		if !utf8.ValidString(value) {
+			return "", errors.New("chat artifact model has invalid extra config")
+		}
+		parts = append(parts, key+"="+value)
+	}
+	return strings.Join(parts, "\x00"), nil
+}
+
+func encodeChatArtifactCompletion(completion string) ([]byte, error) {
+	if !utf8.ValidString(completion) {
+		return nil, fmt.Errorf("%w: completion is not valid UTF-8", errChatArtifactCodec)
+	}
+	payload := make([]byte, 1+len(completion))
+	payload[0] = chatArtifactCodecVersion
+	copy(payload[1:], completion)
+	return payload, nil
+}
+
+func decodeChatArtifactCompletion(payload []byte) (string, error) {
+	if len(payload) == 0 || payload[0] != chatArtifactCodecVersion {
+		return "", fmt.Errorf("%w: unsupported or missing version", errChatArtifactCodec)
+	}
+	completion := string(payload[1:])
+	if !utf8.ValidString(completion) {
+		return "", fmt.Errorf("%w: completion is not valid UTF-8", errChatArtifactCodec)
+	}
+	return completion, nil
+}
+
+func completeChatArtifact(
+	ctx context.Context,
+	store interfaces.ProcessingArtifactStore,
+	request chatArtifactRequest,
+) (string, bool, bool, error) {
+	var key types.ProcessingArtifactKey
+	if store != nil {
+		var err error
+		key, err = newChatArtifactKey(request)
+		if err != nil {
+			return "", false, false, err
+		}
+		payload, hit, err := store.Get(ctx, key)
+		if err != nil {
+			return "", false, false, fmt.Errorf("%w: get: %w", errChatArtifactStore, err)
+		}
+		if hit {
+			completion, decodeErr := decodeChatArtifactCompletion(payload)
+			if decodeErr == nil && validateChatArtifactValue(request.valuePolicy, completion) == nil {
+				return completion, true, false, nil
+			}
+		}
+	}
+
+	completion, err := callChatArtifactProvider(ctx, request)
+	if err != nil {
+		return "", false, true, err
+	}
+	completion, cacheable, err := canonicalizeChatArtifactValue(request.valuePolicy, completion)
+	if err != nil {
+		return "", false, true, err
+	}
+	if store == nil || !cacheable {
+		return completion, false, true, nil
+	}
+	payload, err := encodeChatArtifactCompletion(completion)
+	if err != nil {
+		return "", false, true, err
+	}
+	canonical, _, err := store.PutIfAbsent(ctx, key, payload)
+	if err != nil {
+		return "", false, true, fmt.Errorf("%w: put: %w", errChatArtifactStore, err)
+	}
+	canonicalCompletion, err := decodeChatArtifactCompletion(canonical)
+	if err != nil || validateChatArtifactValue(request.valuePolicy, canonicalCompletion) != nil {
+		return completion, false, true, nil
+	}
+	return canonicalCompletion, false, true, nil
+}
+
+func canonicalizeChatArtifactValue(policy chatArtifactValuePolicy, completion string) (string, bool, error) {
+	if policy.canonicalize == nil {
+		return completion, true, nil
+	}
+	value, cacheable, err := policy.canonicalize(completion)
+	if err != nil {
+		return "", false, fmt.Errorf("%w: canonicalize completion: %w", errChatArtifactCodec, err)
+	}
+	return value, cacheable, nil
+}
+
+func validateChatArtifactValue(policy chatArtifactValuePolicy, value string) error {
+	if policy.validate == nil {
+		return nil
+	}
+	return policy.validate(value)
+}
+
+func callChatArtifactProvider(ctx context.Context, request chatArtifactRequest) (string, error) {
+	if request.model == nil {
+		return "", fmt.Errorf("%w: model must not be nil", errChatArtifactProvider)
+	}
+	response, err := request.model.Chat(ctx, request.messages, request.options)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", errChatArtifactProvider, err)
+	}
+	if response == nil {
+		return "", fmt.Errorf("%w: model returned nil response", errChatArtifactProvider)
+	}
+	return response.Content, nil
+}

--- a/internal/application/service/chat_artifact_cache.go
+++ b/internal/application/service/chat_artifact_cache.go
@@ -226,6 +226,9 @@ func completeChatArtifact(
 			if decodeErr == nil && validateChatArtifactValue(request.valuePolicy, completion) == nil {
 				return completion, true, false, nil
 			}
+			if err := store.Invalidate(ctx, key, payload); err != nil {
+				return "", false, false, fmt.Errorf("%w: invalidate: %w", errChatArtifactStore, err)
+			}
 		}
 	}
 
@@ -250,6 +253,9 @@ func completeChatArtifact(
 	}
 	canonicalCompletion, err := decodeChatArtifactCompletion(canonical)
 	if err != nil || validateChatArtifactValue(request.valuePolicy, canonicalCompletion) != nil {
+		if invalidateErr := store.Invalidate(ctx, key, canonical); invalidateErr != nil {
+			return "", false, true, fmt.Errorf("%w: invalidate: %w", errChatArtifactStore, invalidateErr)
+		}
 		return completion, false, true, nil
 	}
 	return canonicalCompletion, false, true, nil

--- a/internal/application/service/chat_artifact_cache_test.go
+++ b/internal/application/service/chat_artifact_cache_test.go
@@ -1,0 +1,443 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type chatArtifactFakeStore struct {
+	values       map[types.ProcessingArtifactKey][]byte
+	getErr       error
+	putErr       error
+	putCanonical []byte
+	getCalls     int
+	putCalls     int
+}
+
+func newChatArtifactFakeStore() *chatArtifactFakeStore {
+	return &chatArtifactFakeStore{values: make(map[types.ProcessingArtifactKey][]byte)}
+}
+
+func (s *chatArtifactFakeStore) Get(
+	_ context.Context,
+	key types.ProcessingArtifactKey,
+) ([]byte, bool, error) {
+	s.getCalls++
+	if s.getErr != nil {
+		return nil, false, s.getErr
+	}
+	value, ok := s.values[key]
+	return append([]byte(nil), value...), ok, nil
+}
+
+func (s *chatArtifactFakeStore) PutIfAbsent(
+	_ context.Context,
+	key types.ProcessingArtifactKey,
+	value []byte,
+) ([]byte, bool, error) {
+	s.putCalls++
+	if s.putErr != nil {
+		return nil, false, s.putErr
+	}
+	if s.putCanonical != nil {
+		return append([]byte(nil), s.putCanonical...), false, nil
+	}
+	if canonical, ok := s.values[key]; ok {
+		return append([]byte(nil), canonical...), false, nil
+	}
+	s.values[key] = append([]byte(nil), value...)
+	return append([]byte(nil), value...), true, nil
+}
+
+type chatArtifactFakeModel struct {
+	modelID     string
+	modelName   string
+	response    *types.ChatResponse
+	err         error
+	calls       int
+	gotMessages []chat.Message
+	gotOptions  *chat.ChatOptions
+}
+
+func (m *chatArtifactFakeModel) Chat(
+	_ context.Context,
+	messages []chat.Message,
+	opts *chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	m.calls++
+	m.gotMessages = messages
+	m.gotOptions = opts
+	return m.response, m.err
+}
+
+func (m *chatArtifactFakeModel) ChatStream(
+	context.Context,
+	[]chat.Message,
+	*chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *chatArtifactFakeModel) GetModelName() string { return m.modelName }
+func (m *chatArtifactFakeModel) GetModelID() string   { return m.modelID }
+
+func TestNewChatArtifactKeyInvalidatesCompleteRequest(t *testing.T) {
+	request := testChatArtifactRequest(&chatArtifactFakeModel{modelID: "model-1", modelName: "chat"})
+
+	baseKey, err := newChatArtifactKey(request)
+	require.NoError(t, err)
+	assert.Equal(t, "chat.summary", baseKey.Stage)
+	assert.Equal(t, uint16(1), baseKey.KeyVersion)
+
+	stableKey, err := newChatArtifactKey(request)
+	require.NoError(t, err)
+	assert.Equal(t, baseKey, stableKey)
+
+	tests := []struct {
+		name   string
+		mutate func(*chatArtifactRequest)
+	}{
+		{name: "tenant", mutate: func(r *chatArtifactRequest) { r.tenantID++ }},
+		{name: "stage", mutate: func(r *chatArtifactRequest) { r.stage = "chat.questions" }},
+		{name: "key version", mutate: func(r *chatArtifactRequest) { r.keyVersion++ }},
+		{name: "model ID", mutate: func(r *chatArtifactRequest) {
+			r.model = &chatArtifactFakeModel{modelID: "model-2", modelName: "chat"}
+		}},
+		{name: "model name", mutate: func(r *chatArtifactRequest) {
+			r.model = &chatArtifactFakeModel{modelID: "model-1", modelName: "other"}
+		}},
+		{name: "model revision", mutate: func(r *chatArtifactRequest) { r.modelRevision = "revision-2" }},
+		{name: "message ordering", mutate: func(r *chatArtifactRequest) {
+			r.messages[0], r.messages[1] = r.messages[1], r.messages[0]
+		}},
+		{name: "message content", mutate: func(r *chatArtifactRequest) { r.messages[1].Content = "other" }},
+		{name: "options", mutate: func(r *chatArtifactRequest) { r.options.Temperature = 0.2 }},
+		{name: "prompt version", mutate: func(r *chatArtifactRequest) { r.promptVersion = "summary-v2" }},
+		{name: "canonicalizer version", mutate: func(r *chatArtifactRequest) {
+			r.canonicalizerVersion = "completion-v2"
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changed := cloneChatArtifactRequest(request)
+			tt.mutate(&changed)
+
+			changedKey, err := newChatArtifactKey(changed)
+			require.NoError(t, err)
+			assert.NotEqual(t, baseKey, changedKey)
+		})
+	}
+}
+
+func TestNewChatArtifactKeyRejectsIncompleteIdentity(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*chatArtifactRequest)
+	}{
+		{name: "empty stage", mutate: func(r *chatArtifactRequest) { r.stage = " " }},
+		{name: "zero key version", mutate: func(r *chatArtifactRequest) { r.keyVersion = 0 }},
+		{name: "missing model", mutate: func(r *chatArtifactRequest) { r.model = nil }},
+		{name: "missing model revision", mutate: func(r *chatArtifactRequest) { r.modelRevision = " " }},
+		{name: "missing options", mutate: func(r *chatArtifactRequest) { r.options = nil }},
+		{name: "missing prompt version", mutate: func(r *chatArtifactRequest) { r.promptVersion = " " }},
+		{name: "missing canonicalizer version", mutate: func(r *chatArtifactRequest) {
+			r.canonicalizerVersion = " "
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := cloneChatArtifactRequest(testChatArtifactRequest(&chatArtifactFakeModel{modelID: "model-1"}))
+			tt.mutate(&request)
+			_, err := newChatArtifactKey(request)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestChatArtifactModelRevisionIsSecretFreeAndInvalidatesEffectiveConfig(t *testing.T) {
+	model := &types.Model{
+		ID:        "model-1",
+		Name:      "chat-model",
+		Type:      types.ModelTypeKnowledgeQA,
+		Source:    types.ModelSourceRemote,
+		UpdatedAt: time.Date(2026, 7, 18, 8, 30, 0, 0, time.UTC),
+		Parameters: types.ModelParameters{
+			BaseURL:        "https://API.example.com/v1/",
+			APIKey:         "first-api-key",
+			AppID:          "first-app-id",
+			AppSecret:      "first-app-secret",
+			InterfaceType:  "openai",
+			ParameterSize:  "70B",
+			Provider:       "generic",
+			SupportsVision: true,
+			ExtraConfig: map[string]string{
+				"api_version":       "2026-01-01",
+				"remote_model_name": "deployed-chat",
+				"thinking_control":  "enabled",
+			},
+		},
+	}
+
+	base, err := chatArtifactModelRevision(model)
+	require.NoError(t, err)
+
+	credentialsChanged := *model
+	credentialsChanged.Parameters = model.Parameters
+	credentialsChanged.Parameters.APIKey = "second-api-key"
+	credentialsChanged.Parameters.AppID = "second-app-id"
+	credentialsChanged.Parameters.AppSecret = "second-app-secret"
+	credentialsRevision, err := chatArtifactModelRevision(&credentialsChanged)
+	require.NoError(t, err)
+	assert.Equal(t, base, credentialsRevision)
+
+	endpointNormalized := *model
+	endpointNormalized.Parameters = model.Parameters
+	endpointNormalized.Parameters.BaseURL = "https://api.example.com/v1"
+	normalizedRevision, err := chatArtifactModelRevision(&endpointNormalized)
+	require.NoError(t, err)
+	assert.Equal(t, base, normalizedRevision)
+
+	for _, tt := range []struct {
+		name   string
+		mutate func(*types.Model)
+	}{
+		{name: "model name", mutate: func(m *types.Model) { m.Name = "other" }},
+		{name: "provider", mutate: func(m *types.Model) { m.Parameters.Provider = "anthropic" }},
+		{name: "endpoint", mutate: func(m *types.Model) { m.Parameters.BaseURL = "https://api.example.com/v2" }},
+		{name: "remote model", mutate: func(m *types.Model) { m.Parameters.ExtraConfig["remote_model_name"] = "other" }},
+		{name: "updated at", mutate: func(m *types.Model) { m.UpdatedAt = m.UpdatedAt.Add(time.Second) }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			changed := cloneChatArtifactModel(model)
+			tt.mutate(changed)
+			revision, err := chatArtifactModelRevision(changed)
+			require.NoError(t, err)
+			assert.NotEqual(t, base, revision)
+		})
+	}
+}
+
+func TestChatArtifactModelRevisionRejectsUnsafeConfigurationWithoutLeakingSecrets(t *testing.T) {
+	const secret = "very-secret-password"
+	model := &types.Model{
+		ID:   "model-1",
+		Name: "chat-model",
+		Parameters: types.ModelParameters{
+			BaseURL:       "https://user:" + secret + "@api.example.com/v1?token=private",
+			CustomHeaders: map[string]string{"X-Gateway-Token": secret},
+		},
+	}
+
+	_, err := chatArtifactModelRevision(model)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), secret)
+	assert.NotContains(t, err.Error(), "token=private")
+}
+
+func TestChatArtifactCompletionCodecRoundTripAndRejectsMalformedPayload(t *testing.T) {
+	encoded, err := encodeChatArtifactCompletion("completed text")
+	require.NoError(t, err)
+	decoded, err := decodeChatArtifactCompletion(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, "completed text", decoded)
+
+	for _, payload := range [][]byte{nil, {99}, {chatArtifactCodecVersion, 0xff}} {
+		_, err := decodeChatArtifactCompletion(payload)
+		assert.ErrorIs(t, err, errChatArtifactCodec)
+	}
+}
+
+func TestCompleteChatArtifactWithoutStoreCallsProviderUnchanged(t *testing.T) {
+	model := &chatArtifactFakeModel{
+		modelID:  "model-1",
+		response: &types.ChatResponse{Content: "fresh completion"},
+	}
+	request := testChatArtifactRequest(model)
+
+	completion, hit, providerCalled, err := completeChatArtifact(context.Background(), nil, request)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.True(t, providerCalled)
+	assert.Equal(t, "fresh completion", completion)
+	assert.Equal(t, 1, model.calls)
+	assert.Same(t, request.options, model.gotOptions)
+	assert.True(t, reflect.DeepEqual(request.messages, model.gotMessages))
+}
+
+func TestCompleteChatArtifactHitSkipsProvider(t *testing.T) {
+	store := newChatArtifactFakeStore()
+	model := &chatArtifactFakeModel{modelID: "model-1", response: &types.ChatResponse{Content: "fresh"}}
+	request := testChatArtifactRequest(model)
+	key, err := newChatArtifactKey(request)
+	require.NoError(t, err)
+	store.values[key], err = encodeChatArtifactCompletion("cached")
+	require.NoError(t, err)
+
+	completion, hit, providerCalled, err := completeChatArtifact(context.Background(), store, request)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.False(t, providerCalled)
+	assert.Equal(t, "cached", completion)
+	assert.Zero(t, model.calls)
+	assert.Equal(t, 1, store.getCalls)
+	assert.Zero(t, store.putCalls)
+}
+
+func TestCompleteChatArtifactMissReturnsPutIfAbsentWinner(t *testing.T) {
+	store := newChatArtifactFakeStore()
+	winner, err := encodeChatArtifactCompletion("canonical winner")
+	require.NoError(t, err)
+	store.putCanonical = winner
+	model := &chatArtifactFakeModel{modelID: "model-1", response: &types.ChatResponse{Content: "losing completion"}}
+
+	completion, hit, providerCalled, err := completeChatArtifact(context.Background(), store, testChatArtifactRequest(model))
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.True(t, providerCalled)
+	assert.Equal(t, "canonical winner", completion)
+	assert.Equal(t, 1, model.calls)
+	assert.Equal(t, 1, store.getCalls)
+	assert.Equal(t, 1, store.putCalls)
+}
+
+func TestCompleteChatArtifactMalformedHitRecomputes(t *testing.T) {
+	store := newChatArtifactFakeStore()
+	model := &chatArtifactFakeModel{modelID: "model-1", response: &types.ChatResponse{Content: "fresh completion"}}
+	request := testChatArtifactRequest(model)
+	key, err := newChatArtifactKey(request)
+	require.NoError(t, err)
+	store.values[key] = []byte{99}
+	store.putCanonical, err = encodeChatArtifactCompletion("canonical repair")
+	require.NoError(t, err)
+
+	completion, hit, providerCalled, err := completeChatArtifact(context.Background(), store, request)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.True(t, providerCalled)
+	assert.Equal(t, "canonical repair", completion)
+	assert.Equal(t, 1, model.calls)
+	assert.Equal(t, 1, store.putCalls)
+}
+
+func TestCompleteChatArtifactWrapsProviderAndStoreErrorsDistinctly(t *testing.T) {
+	providerErr := errors.New("provider unavailable")
+	model := &chatArtifactFakeModel{modelID: "model-1", err: providerErr}
+	_, _, providerCalled, err := completeChatArtifact(context.Background(), nil, testChatArtifactRequest(model))
+	assert.ErrorIs(t, err, errChatArtifactProvider)
+	assert.ErrorIs(t, err, providerErr)
+	assert.True(t, providerCalled)
+
+	t.Run("get", func(t *testing.T) {
+		storeErr := errors.New("get failed")
+		store := newChatArtifactFakeStore()
+		store.getErr = storeErr
+		model := &chatArtifactFakeModel{modelID: "model-1", response: &types.ChatResponse{Content: "fresh"}}
+
+		_, _, providerCalled, err := completeChatArtifact(context.Background(), store, testChatArtifactRequest(model))
+		assert.ErrorIs(t, err, errChatArtifactStore)
+		assert.ErrorIs(t, err, storeErr)
+		assert.False(t, providerCalled)
+		assert.Zero(t, model.calls)
+	})
+
+	t.Run("put", func(t *testing.T) {
+		storeErr := errors.New("put failed")
+		store := newChatArtifactFakeStore()
+		store.putErr = storeErr
+		model := &chatArtifactFakeModel{modelID: "model-1", response: &types.ChatResponse{Content: "fresh"}}
+
+		_, _, providerCalled, err := completeChatArtifact(context.Background(), store, testChatArtifactRequest(model))
+		assert.ErrorIs(t, err, errChatArtifactStore)
+		assert.ErrorIs(t, err, storeErr)
+		assert.True(t, providerCalled)
+		assert.Equal(t, 1, model.calls)
+	})
+}
+
+func TestIsChatArtifactPipelineError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "store", err: fmt.Errorf("wrapped: %w", errChatArtifactStore), want: true},
+		{name: "codec", err: fmt.Errorf("wrapped: %w", errChatArtifactCodec), want: true},
+		{name: "provider", err: fmt.Errorf("wrapped: %w", errChatArtifactProvider), want: false},
+		{name: "other", err: errors.New("other"), want: false},
+		{name: "nil", err: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isChatArtifactPipelineError(tt.err))
+		})
+	}
+}
+
+func testChatArtifactRequest(model chat.Chat) chatArtifactRequest {
+	thinking := true
+	parallel := false
+	return chatArtifactRequest{
+		tenantID:      7,
+		stage:         "chat.summary",
+		keyVersion:    1,
+		model:         model,
+		modelRevision: "model-revision-1",
+		messages: []chat.Message{
+			{Role: "system", Content: "summarize"},
+			{Role: "user", Content: "document"},
+		},
+		options: &chat.ChatOptions{
+			Temperature:         0.1,
+			TopP:                0.9,
+			Seed:                3,
+			MaxTokens:           100,
+			MaxCompletionTokens: 80,
+			FrequencyPenalty:    0.2,
+			PresencePenalty:     0.3,
+			Thinking:            &thinking,
+			Tools: []chat.Tool{{
+				Type: "function",
+				Function: chat.FunctionDef{
+					Name:       "lookup",
+					Parameters: json.RawMessage(`{"type":"object"}`),
+				},
+			}},
+			ToolChoice:        "auto",
+			ParallelToolCalls: &parallel,
+			Format:            json.RawMessage(`{"type":"json_object"}`),
+		},
+		promptVersion:        "summary-v1",
+		canonicalizerVersion: "completion-v1",
+	}
+}
+
+func cloneChatArtifactRequest(request chatArtifactRequest) chatArtifactRequest {
+	cloned := request
+	cloned.messages = append([]chat.Message(nil), request.messages...)
+	if request.options != nil {
+		options := *request.options
+		cloned.options = &options
+	}
+	return cloned
+}
+
+func cloneChatArtifactModel(model *types.Model) *types.Model {
+	cloned := *model
+	cloned.Parameters = model.Parameters
+	cloned.Parameters.ExtraConfig = make(map[string]string, len(model.Parameters.ExtraConfig))
+	for key, value := range model.Parameters.ExtraConfig {
+		cloned.Parameters.ExtraConfig[key] = value
+	}
+	return &cloned
+}

--- a/internal/application/service/chat_artifact_cache_test.go
+++ b/internal/application/service/chat_artifact_cache_test.go
@@ -16,12 +16,16 @@ import (
 )
 
 type chatArtifactFakeStore struct {
-	values       map[types.ProcessingArtifactKey][]byte
-	getErr       error
-	putErr       error
-	putCanonical []byte
-	getCalls     int
-	putCalls     int
+	values                        map[types.ProcessingArtifactKey][]byte
+	getErr                        error
+	putErr                        error
+	invalidateErr                 error
+	putCanonical                  []byte
+	clearPutCanonicalOnInvalidate bool
+	getCalls                      int
+	putCalls                      int
+	invalidated                   []types.ProcessingArtifactKey
+	observed                      [][]byte
 }
 
 func newChatArtifactFakeStore() *chatArtifactFakeStore {
@@ -57,6 +61,23 @@ func (s *chatArtifactFakeStore) PutIfAbsent(
 	}
 	s.values[key] = append([]byte(nil), value...)
 	return append([]byte(nil), value...), true, nil
+}
+
+func (s *chatArtifactFakeStore) Invalidate(
+	_ context.Context,
+	key types.ProcessingArtifactKey,
+	observed []byte,
+) error {
+	s.invalidated = append(s.invalidated, key)
+	s.observed = append(s.observed, append([]byte(nil), observed...))
+	if s.invalidateErr != nil {
+		return s.invalidateErr
+	}
+	delete(s.values, key)
+	if s.clearPutCanonicalOnInvalidate {
+		s.putCanonical = nil
+	}
+	return nil
 }
 
 type chatArtifactFakeModel struct {
@@ -327,6 +348,64 @@ func TestCompleteChatArtifactMalformedHitRecomputes(t *testing.T) {
 	assert.Equal(t, "canonical repair", completion)
 	assert.Equal(t, 1, model.calls)
 	assert.Equal(t, 1, store.putCalls)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+	assert.Equal(t, [][]byte{{99}}, store.observed)
+}
+
+func TestCompleteChatArtifactStopsBeforeProviderWhenInvalidationFails(t *testing.T) {
+	store := newChatArtifactFakeStore()
+	store.invalidateErr = errors.New("invalidate failed")
+	model := &chatArtifactFakeModel{modelID: "model-1", response: &types.ChatResponse{Content: "fresh completion"}}
+	request := testChatArtifactRequest(model)
+	key, err := newChatArtifactKey(request)
+	require.NoError(t, err)
+	store.values[key] = []byte{99}
+
+	_, _, providerCalled, err := completeChatArtifact(context.Background(), store, request)
+	assert.ErrorIs(t, err, store.invalidateErr)
+	assert.False(t, providerCalled)
+	assert.Zero(t, model.calls)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+}
+
+func TestCompleteChatArtifactInvalidatesInvalidConcurrentWinner(t *testing.T) {
+	store := newChatArtifactFakeStore()
+	store.putCanonical = []byte{99}
+	model := &chatArtifactFakeModel{modelID: "model-1", response: &types.ChatResponse{Content: "fresh completion"}}
+	request := testChatArtifactRequest(model)
+	key, err := newChatArtifactKey(request)
+	require.NoError(t, err)
+
+	completion, hit, providerCalled, err := completeChatArtifact(context.Background(), store, request)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.True(t, providerCalled)
+	assert.Equal(t, "fresh completion", completion)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+	assert.Equal(t, [][]byte{{99}}, store.observed)
+}
+
+func TestCompleteChatArtifactInvalidatesSemanticallyInvalidHit(t *testing.T) {
+	store := newChatArtifactFakeStore()
+	model := &chatArtifactFakeModel{modelID: "model-1", response: &types.ChatResponse{Content: "fresh completion"}}
+	request := testChatArtifactRequest(model)
+	request.valuePolicy.validate = func(value string) error {
+		if value == "cached completion" {
+			return errors.New("cached completion is invalid")
+		}
+		return nil
+	}
+	key, err := newChatArtifactKey(request)
+	require.NoError(t, err)
+	store.values[key], err = encodeChatArtifactCompletion("cached completion")
+	require.NoError(t, err)
+
+	completion, hit, providerCalled, err := completeChatArtifact(context.Background(), store, request)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.True(t, providerCalled)
+	assert.Equal(t, "fresh completion", completion)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
 }
 
 func TestCompleteChatArtifactWrapsProviderAndStoreErrorsDistinctly(t *testing.T) {

--- a/internal/application/service/docreader_artifact_cache.go
+++ b/internal/application/service/docreader_artifact_cache.go
@@ -463,52 +463,67 @@ func readDocReaderArtifact(
 	store interfaces.ProcessingArtifactStore,
 	request docReaderArtifactRequest,
 ) (*types.ReadResult, bool, error) {
+	result, hit, _, err := readDocReaderArtifactWithCacheStatus(ctx, store, request)
+	return result, hit, err
+}
+
+func readDocReaderArtifactWithCacheStatus(
+	ctx context.Context,
+	store interfaces.ProcessingArtifactStore,
+	request docReaderArtifactRequest,
+) (*types.ReadResult, bool, string, error) {
 	if request.read == nil {
-		return nil, false, errors.New("DocReader artifact reader must not be nil")
+		return nil, false, "bypass", errors.New("DocReader artifact reader must not be nil")
 	}
 	if request.readRequest == nil {
-		return nil, false, errors.New("DocReader artifact request must not be nil")
+		return nil, false, "bypass", errors.New("DocReader artifact request must not be nil")
 	}
 	if store == nil {
 		result, err := callDocReaderArtifactProvider(ctx, request)
-		return result, false, err
+		return result, false, "bypass", err
 	}
 
 	key, eligible, err := newDocReaderArtifactKey(request)
 	if err != nil {
-		return nil, false, err
+		return nil, false, "bypass", err
 	}
 	if !eligible {
 		result, err := callDocReaderArtifactProvider(ctx, request)
-		return result, false, err
+		return result, false, "bypass", err
 	}
 
 	cached, hit, err := store.Get(ctx, key)
 	if err != nil {
-		return nil, false, fmt.Errorf("%w: get: %w", errDocReaderArtifactStore, err)
+		return nil, false, "miss", fmt.Errorf("%w: get: %w", errDocReaderArtifactStore, err)
 	}
 	if hit {
 		if result, decodeErr := decodeDocReaderArtifact(cached); decodeErr == nil {
-			return result, true, nil
+			return result, true, "hit", nil
+		}
+		if err := store.Invalidate(ctx, key, cached); err != nil {
+			return nil, false, "miss", fmt.Errorf("%w: invalidate: %w", errDocReaderArtifactStore, err)
 		}
 	}
 
 	fresh, err := callDocReaderArtifactProvider(ctx, request)
 	if err != nil || fresh.Error != "" || fresh.IsAudio || len(fresh.AudioData) > 0 {
-		return fresh, false, err
+		return fresh, false, "miss", err
 	}
 	payload, err := encodeDocReaderArtifact(fresh)
 	if err != nil {
-		return nil, false, err
+		return nil, false, "miss", err
 	}
 	canonical, _, err := store.PutIfAbsent(ctx, key, payload)
 	if err != nil {
-		return nil, false, fmt.Errorf("%w: put: %w", errDocReaderArtifactStore, err)
+		return nil, false, "miss", fmt.Errorf("%w: put: %w", errDocReaderArtifactStore, err)
 	}
 	if winner, decodeErr := decodeDocReaderArtifact(canonical); decodeErr == nil {
-		return winner, false, nil
+		return winner, false, "miss", nil
 	}
-	return fresh, false, nil
+	if err := store.Invalidate(ctx, key, canonical); err != nil {
+		return nil, false, "miss", fmt.Errorf("%w: invalidate: %w", errDocReaderArtifactStore, err)
+	}
+	return fresh, false, "miss", nil
 }
 
 func callDocReaderArtifactProvider(

--- a/internal/application/service/docreader_artifact_cache.go
+++ b/internal/application/service/docreader_artifact_cache.go
@@ -1,0 +1,526 @@
+package service
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/infrastructure/docparser"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+const (
+	docReaderArtifactStage           = "docreader.parse"
+	docReaderArtifactKeyVersion      = uint16(1)
+	docReaderArtifactCodecVersion    = byte(1)
+	docReaderArtifactRenderVersionV1 = "1"
+)
+
+var (
+	errDocReaderArtifactProvider = errors.New("DocReader artifact provider failed")
+	errDocReaderArtifactStore    = errors.New("DocReader artifact store failed")
+	errDocReaderArtifactCodec    = errors.New("DocReader artifact codec failed")
+)
+
+type docReaderArtifactRequest struct {
+	tenantID       uint64
+	sourcePath     string
+	read           func(context.Context, *types.ReadRequest) (*types.ReadResult, error)
+	readerIdentity string
+	renderVersion  string
+	readRequest    *types.ReadRequest
+}
+
+type docReaderArtifactOverride struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type docReaderArtifactPayload struct {
+	MarkdownContent string                   `json:"markdown_content"`
+	ImageRefs       []docReaderArtifactImage `json:"image_refs,omitempty"`
+	Metadata        map[string]string        `json:"metadata,omitempty"`
+}
+
+type docReaderArtifactImage struct {
+	Filename    string `json:"filename,omitempty"`
+	OriginalRef string `json:"original_ref,omitempty"`
+	MimeType    string `json:"mime_type,omitempty"`
+	ImageData   []byte `json:"image_data,omitempty"`
+	IsOriginal  bool   `json:"is_original,omitempty"`
+}
+
+type docReaderArtifactOverrideKind uint8
+
+const (
+	docReaderArtifactOverrideCredential docReaderArtifactOverrideKind = iota
+	docReaderArtifactOverrideEndpoint
+	docReaderArtifactOverrideBoolean
+	docReaderArtifactOverrideString
+)
+
+type docReaderArtifactOverrideSpec struct {
+	kind    docReaderArtifactOverrideKind
+	engines map[string]struct{}
+}
+
+var docReaderArtifactKnownEngines = docReaderArtifactStringSet(
+	"builtin", "markitdown", "mineru", "mineru_cloud", "opendataloader",
+	"paddleocr_vl", "paddleocr_vl_cloud", "simple", "weknoracloud",
+)
+
+var docReaderArtifactOverrideSpecs = map[string]docReaderArtifactOverrideSpec{
+	"mineru_api_key":           newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideCredential, "mineru_cloud", "opendataloader"),
+	"paddleocr_vl_cloud_token": newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideCredential, "paddleocr_vl_cloud"),
+
+	"mineru_endpoint":             newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideEndpoint, "mineru"),
+	"mineru_vlm_server_url":       newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideEndpoint, "mineru"),
+	"odl_hybrid_url":              newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideEndpoint, "opendataloader"),
+	"paddleocr_vl_endpoint":       newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideEndpoint, "paddleocr_vl"),
+	"paddleocr_vl_cloud_base_url": newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideEndpoint, "paddleocr_vl_cloud"),
+
+	"mineru_enable_formula":                    newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideBoolean, "mineru"),
+	"mineru_enable_table":                      newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideBoolean, "mineru"),
+	"mineru_enable_ocr":                        newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideBoolean, "mineru"),
+	"mineru_cloud_enable_formula":              newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideBoolean, "mineru_cloud"),
+	"mineru_cloud_enable_table":                newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideBoolean, "mineru_cloud"),
+	"mineru_cloud_enable_ocr":                  newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideBoolean, "mineru_cloud"),
+	"odl_hybrid_fallback":                      newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideBoolean, "opendataloader"),
+	"odl_markdown_with_html":                   newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideBoolean, "opendataloader"),
+	"paddleocr_vl_use_seal_recognition":        newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideBoolean, "paddleocr_vl"),
+	"paddleocr_vl_use_chart_recognition":       newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideBoolean, "paddleocr_vl"),
+	"paddleocr_vl_cloud_use_seal_recognition":  newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideBoolean, "paddleocr_vl_cloud"),
+	"paddleocr_vl_cloud_use_chart_recognition": newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideBoolean, "paddleocr_vl_cloud"),
+	"pdf_force_scanned":                        newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideBoolean, "builtin"),
+
+	"mineru_model":             newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideString, "mineru"),
+	"mineru_language":          newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideString, "mineru"),
+	"mineru_cloud_model":       newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideString, "mineru_cloud"),
+	"mineru_cloud_language":    newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideString, "mineru_cloud"),
+	"odl_hybrid":               newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideString, "opendataloader"),
+	"odl_hybrid_mode":          newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideString, "opendataloader"),
+	"paddleocr_vl_cloud_model": newDocReaderArtifactOverrideSpec(docReaderArtifactOverrideString, "paddleocr_vl_cloud"),
+}
+
+var docReaderArtifactAudioExtensions = map[string]struct{}{
+	".aac":  {},
+	".amr":  {},
+	".flac": {},
+	".m4a":  {},
+	".mp3":  {},
+	".ogg":  {},
+	".opus": {},
+	".wav":  {},
+	".wma":  {},
+}
+
+func newDocReaderArtifactKey(
+	request docReaderArtifactRequest,
+) (types.ProcessingArtifactKey, bool, error) {
+	if request.readRequest == nil {
+		return types.ProcessingArtifactKey{}, false, errors.New("DocReader artifact request must not be nil")
+	}
+	if !isDocReaderArtifactCacheable(request) {
+		return types.ProcessingArtifactKey{}, false, nil
+	}
+
+	engine := effectiveDocReaderArtifactEngine(
+		request.readRequest.ParserEngine,
+		request.readRequest.FileType,
+	)
+	readerIdentity := ""
+	if docReaderArtifactEngineUsesSharedReader(engine) {
+		readerIdentity = strings.TrimSpace(request.readerIdentity)
+		if readerIdentity == "" {
+			return types.ProcessingArtifactKey{}, false, nil
+		}
+	}
+	overrides, eligible, err := canonicalDocReaderArtifactOverrides(
+		engine,
+		request.readRequest.FileType,
+		request.readRequest.ParserEngineOverrides,
+	)
+	if err != nil || !eligible {
+		return types.ProcessingArtifactKey{}, eligible, err
+	}
+
+	contentDigest := sha256.Sum256(request.readRequest.FileContent)
+	key, err := types.NewProcessingArtifactKey(
+		request.tenantID,
+		docReaderArtifactStage,
+		docReaderArtifactKeyVersion,
+		contentDigest[:],
+		[]byte(engine),
+		[]byte(readerIdentity),
+		[]byte(strings.ToLower(strings.TrimSpace(request.readRequest.FileType))),
+		[]byte(strings.TrimSpace(filepath.Base(request.readRequest.FileName))),
+		[]byte(request.readRequest.Title),
+		overrides,
+		[]byte(request.renderVersion),
+	)
+	if err != nil {
+		return types.ProcessingArtifactKey{}, false, err
+	}
+	return key, true, nil
+}
+
+func isDocReaderArtifactCacheable(request docReaderArtifactRequest) bool {
+	readRequest := request.readRequest
+	if readRequest == nil || request.sourcePath == "" || len(readRequest.FileContent) == 0 {
+		return false
+	}
+	if strings.TrimSpace(request.renderVersion) == "" || strings.TrimSpace(readRequest.URL) != "" {
+		return false
+	}
+	if isTemporaryDocReaderArtifactPath(request.sourcePath) {
+		return false
+	}
+	fileType := strings.ToLower(strings.TrimSpace(readRequest.FileType))
+	if strings.HasPrefix(fileType, "audio/") || IsAudioType(fileType) {
+		return false
+	}
+	_, audio := docReaderArtifactAudioExtensions[strings.ToLower(filepath.Ext(readRequest.FileName))]
+	return !audio
+}
+
+func isTemporaryDocReaderArtifactPath(path string) bool {
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return true
+	}
+	temporaryRoot, err := filepath.Abs(os.TempDir())
+	if err != nil {
+		return true
+	}
+	relative, err := filepath.Rel(temporaryRoot, absolutePath)
+	if err != nil {
+		return false
+	}
+	return relative == "." || (relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)))
+}
+
+func canonicalDocReaderArtifactOverrides(
+	parserEngine string,
+	fileType string,
+	overrides map[string]string,
+) ([]byte, bool, error) {
+	engine := effectiveDocReaderArtifactEngine(parserEngine, fileType)
+	_, knownEngine := docReaderArtifactKnownEngines[engine]
+	if !knownEngine && len(overrides) > 0 {
+		return nil, false, nil
+	}
+
+	canonical := make([]docReaderArtifactOverride, 0, len(overrides))
+	for key, value := range overrides {
+		key = strings.ToLower(strings.TrimSpace(key))
+		spec, knownOverride := docReaderArtifactOverrideSpecs[key]
+		if !knownOverride {
+			if docReaderArtifactUnknownOverrideAffectsEngine(engine, key) {
+				return nil, false, nil
+			}
+			continue
+		}
+		if !docReaderArtifactOverrideIsEffective(engine, fileType, key, spec) {
+			continue
+		}
+		if spec.kind == docReaderArtifactOverrideCredential {
+			continue
+		}
+
+		switch spec.kind {
+		case docReaderArtifactOverrideEndpoint:
+			normalized, ok := normalizeDocReaderArtifactEndpoint(value)
+			if !ok {
+				return nil, false, nil
+			}
+			value = normalized
+		case docReaderArtifactOverrideBoolean:
+			value = strings.ToLower(strings.TrimSpace(value))
+		case docReaderArtifactOverrideString:
+			value = strings.TrimSpace(value)
+		default:
+			return nil, false, nil
+		}
+		canonical = append(canonical, docReaderArtifactOverride{Key: key, Value: value})
+	}
+
+	sort.Slice(canonical, func(i, j int) bool { return canonical[i].Key < canonical[j].Key })
+	encoded, err := json.Marshal(canonical)
+	if err != nil {
+		return nil, false, fmt.Errorf("%w: canonicalize overrides: %w", errDocReaderArtifactCodec, err)
+	}
+	return encoded, true, nil
+}
+
+func effectiveDocReaderArtifactEngine(parserEngine, fileType string) string {
+	engine := normalizeDocReaderArtifactEngine(parserEngine)
+	if engine != "" {
+		return engine
+	}
+	if docparser.IsSimpleFormat(fileType) {
+		return "simple"
+	}
+	return "builtin"
+}
+
+func normalizeDocReaderArtifactEngine(engine string) string {
+	return strings.ToLower(strings.TrimSpace(engine))
+}
+
+func docReaderArtifactEngineUsesSharedReader(engine string) bool {
+	switch engine {
+	case "simple", "mineru", "mineru_cloud", "paddleocr_vl", "paddleocr_vl_cloud", "weknoracloud":
+		return false
+	default:
+		return true
+	}
+}
+
+type docReaderArtifactIdentityProvider interface {
+	ArtifactIdentity() string
+}
+
+func docReaderArtifactReaderIdentity(reader interfaces.DocReader) string {
+	provider, ok := reader.(docReaderArtifactIdentityProvider)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(provider.ArtifactIdentity())
+}
+
+func docReaderArtifactStringSet(keys ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		set[key] = struct{}{}
+	}
+	return set
+}
+
+func newDocReaderArtifactOverrideSpec(
+	kind docReaderArtifactOverrideKind,
+	engines ...string,
+) docReaderArtifactOverrideSpec {
+	return docReaderArtifactOverrideSpec{kind: kind, engines: docReaderArtifactStringSet(engines...)}
+}
+
+func docReaderArtifactOverrideIsEffective(
+	engine string,
+	fileType string,
+	key string,
+	spec docReaderArtifactOverrideSpec,
+) bool {
+	if engine == "builtin" && key == "pdf_force_scanned" &&
+		strings.TrimPrefix(strings.ToLower(strings.TrimSpace(fileType)), ".") != "pdf" {
+		return false
+	}
+	_, ok := spec.engines[engine]
+	return ok
+}
+
+func docReaderArtifactUnknownOverrideAffectsEngine(engine, key string) bool {
+	switch engine {
+	case "mineru":
+		return strings.HasPrefix(key, "mineru_") && !strings.HasPrefix(key, "mineru_cloud_")
+	case "mineru_cloud":
+		return strings.HasPrefix(key, "mineru_cloud_")
+	case "paddleocr_vl":
+		return strings.HasPrefix(key, "paddleocr_vl_") && !strings.HasPrefix(key, "paddleocr_vl_cloud_")
+	case "paddleocr_vl_cloud":
+		return strings.HasPrefix(key, "paddleocr_vl_cloud_")
+	case "opendataloader":
+		return strings.HasPrefix(key, "odl_")
+	case "builtin":
+		namespace := docReaderArtifactOverrideNamespace(key)
+		return namespace == "" || namespace == "pdf_"
+	case "markitdown":
+		return docReaderArtifactOverrideNamespace(key) == ""
+	default:
+		return false
+	}
+}
+
+func docReaderArtifactOverrideNamespace(key string) string {
+	for _, prefix := range []string{"mineru_cloud_", "mineru_", "paddleocr_vl_cloud_", "paddleocr_vl_", "odl_", "pdf_"} {
+		if strings.HasPrefix(key, prefix) {
+			return prefix
+		}
+	}
+	return ""
+}
+
+func normalizeDocReaderArtifactEndpoint(raw string) (string, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if raw != trimmed {
+		return "", false
+	}
+	endpoint, err := url.Parse(trimmed)
+	if err != nil || endpoint.Scheme == "" || endpoint.Host == "" {
+		return "", false
+	}
+	endpoint.Scheme = strings.ToLower(endpoint.Scheme)
+	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
+		return "", false
+	}
+	endpoint.Host = strings.ToLower(endpoint.Host)
+	if endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" {
+		return "", false
+	}
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/")
+	return endpoint.String(), true
+}
+
+func encodeDocReaderArtifact(result *types.ReadResult) ([]byte, error) {
+	if result == nil {
+		return nil, fmt.Errorf("%w: result must not be nil", errDocReaderArtifactCodec)
+	}
+	payload := docReaderArtifactPayload{
+		MarkdownContent: result.MarkdownContent,
+		Metadata:        result.Metadata,
+		ImageRefs:       make([]docReaderArtifactImage, len(result.ImageRefs)),
+	}
+	for i, image := range result.ImageRefs {
+		payload.ImageRefs[i] = docReaderArtifactImage{
+			Filename:    image.Filename,
+			OriginalRef: image.OriginalRef,
+			MimeType:    image.MimeType,
+			ImageData:   image.ImageData,
+			IsOriginal:  image.IsOriginal,
+		}
+	}
+
+	var compressed bytes.Buffer
+	compressed.WriteByte(docReaderArtifactCodecVersion)
+	writer := gzip.NewWriter(&compressed)
+	if err := json.NewEncoder(writer).Encode(payload); err != nil {
+		_ = writer.Close()
+		return nil, fmt.Errorf("%w: encode: %w", errDocReaderArtifactCodec, err)
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("%w: close compressor: %w", errDocReaderArtifactCodec, err)
+	}
+	return compressed.Bytes(), nil
+}
+
+func decodeDocReaderArtifact(payload []byte) (*types.ReadResult, error) {
+	if len(payload) < 2 || payload[0] != docReaderArtifactCodecVersion {
+		return nil, fmt.Errorf("%w: unsupported or missing version", errDocReaderArtifactCodec)
+	}
+	reader, err := gzip.NewReader(bytes.NewReader(payload[1:]))
+	if err != nil {
+		return nil, fmt.Errorf("%w: decompress: %w", errDocReaderArtifactCodec, err)
+	}
+	var cached docReaderArtifactPayload
+	decoder := json.NewDecoder(reader)
+	decodeErr := decoder.Decode(&cached)
+	if decodeErr == nil {
+		var trailing json.RawMessage
+		trailingErr := decoder.Decode(&trailing)
+		switch {
+		case errors.Is(trailingErr, io.EOF):
+		case trailingErr == nil:
+			decodeErr = errors.New("multiple JSON values")
+		default:
+			decodeErr = trailingErr
+		}
+	}
+	closeErr := reader.Close()
+	if decodeErr != nil {
+		return nil, fmt.Errorf("%w: decode: %w", errDocReaderArtifactCodec, decodeErr)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("%w: close decompressor: %w", errDocReaderArtifactCodec, closeErr)
+	}
+	result := &types.ReadResult{
+		MarkdownContent: cached.MarkdownContent,
+		Metadata:        cached.Metadata,
+		ImageRefs:       make([]types.ImageRef, len(cached.ImageRefs)),
+	}
+	for i, image := range cached.ImageRefs {
+		result.ImageRefs[i] = types.ImageRef{
+			Filename:    image.Filename,
+			OriginalRef: image.OriginalRef,
+			MimeType:    image.MimeType,
+			ImageData:   image.ImageData,
+			IsOriginal:  image.IsOriginal,
+		}
+	}
+	return result, nil
+}
+
+func readDocReaderArtifact(
+	ctx context.Context,
+	store interfaces.ProcessingArtifactStore,
+	request docReaderArtifactRequest,
+) (*types.ReadResult, bool, error) {
+	if request.read == nil {
+		return nil, false, errors.New("DocReader artifact reader must not be nil")
+	}
+	if request.readRequest == nil {
+		return nil, false, errors.New("DocReader artifact request must not be nil")
+	}
+	if store == nil {
+		result, err := callDocReaderArtifactProvider(ctx, request)
+		return result, false, err
+	}
+
+	key, eligible, err := newDocReaderArtifactKey(request)
+	if err != nil {
+		return nil, false, err
+	}
+	if !eligible {
+		result, err := callDocReaderArtifactProvider(ctx, request)
+		return result, false, err
+	}
+
+	cached, hit, err := store.Get(ctx, key)
+	if err != nil {
+		return nil, false, fmt.Errorf("%w: get: %w", errDocReaderArtifactStore, err)
+	}
+	if hit {
+		if result, decodeErr := decodeDocReaderArtifact(cached); decodeErr == nil {
+			return result, true, nil
+		}
+	}
+
+	fresh, err := callDocReaderArtifactProvider(ctx, request)
+	if err != nil || fresh.Error != "" || fresh.IsAudio || len(fresh.AudioData) > 0 {
+		return fresh, false, err
+	}
+	payload, err := encodeDocReaderArtifact(fresh)
+	if err != nil {
+		return nil, false, err
+	}
+	canonical, _, err := store.PutIfAbsent(ctx, key, payload)
+	if err != nil {
+		return nil, false, fmt.Errorf("%w: put: %w", errDocReaderArtifactStore, err)
+	}
+	if winner, decodeErr := decodeDocReaderArtifact(canonical); decodeErr == nil {
+		return winner, false, nil
+	}
+	return fresh, false, nil
+}
+
+func callDocReaderArtifactProvider(
+	ctx context.Context,
+	request docReaderArtifactRequest,
+) (*types.ReadResult, error) {
+	result, err := request.read(ctx, request.readRequest)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errDocReaderArtifactProvider, err)
+	}
+	if result == nil {
+		return nil, fmt.Errorf("%w: reader returned nil result", errDocReaderArtifactProvider)
+	}
+	return result, nil
+}

--- a/internal/application/service/docreader_artifact_cache_test.go
+++ b/internal/application/service/docreader_artifact_cache_test.go
@@ -38,13 +38,16 @@ func (r *docReaderArtifactFakeReader) ListEngines(
 }
 
 type docReaderArtifactFakeStore struct {
-	values       map[types.ProcessingArtifactKey][]byte
-	getErr       error
-	putErr       error
-	putCanonical []byte
-	hasCanonical bool
-	getCalls     int
-	putCalls     int
+	values        map[types.ProcessingArtifactKey][]byte
+	getErr        error
+	putErr        error
+	invalidateErr error
+	putCanonical  []byte
+	hasCanonical  bool
+	getCalls      int
+	putCalls      int
+	invalidated   []types.ProcessingArtifactKey
+	observed      [][]byte
 }
 
 func newDocReaderArtifactFakeStore() *docReaderArtifactFakeStore {
@@ -80,6 +83,20 @@ func (s *docReaderArtifactFakeStore) PutIfAbsent(
 	}
 	s.values[key] = append([]byte(nil), value...)
 	return append([]byte(nil), value...), true, nil
+}
+
+func (s *docReaderArtifactFakeStore) Invalidate(
+	_ context.Context,
+	key types.ProcessingArtifactKey,
+	observed []byte,
+) error {
+	s.invalidated = append(s.invalidated, key)
+	s.observed = append(s.observed, append([]byte(nil), observed...))
+	if s.invalidateErr != nil {
+		return s.invalidateErr
+	}
+	delete(s.values, key)
+	return nil
 }
 
 func TestNewDocReaderArtifactKeyStabilityAndInvalidation(t *testing.T) {
@@ -469,6 +486,11 @@ func TestReadDocReaderArtifactMalformedPayloadFallsBackToFreshResult(t *testing.
 		assert.False(t, hit)
 		assert.Equal(t, "fresh", result.MarkdownContent)
 		assert.Equal(t, 1, reader.calls)
+		key, keyEligible, keyErr := newDocReaderArtifactKey(testDocReaderArtifactRequest(reader))
+		require.NoError(t, keyErr)
+		require.True(t, keyEligible)
+		assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+		assert.Equal(t, [][]byte{[]byte("malformed")}, store.observed)
 	})
 
 	t.Run("concurrent winner", func(t *testing.T) {
@@ -484,7 +506,30 @@ func TestReadDocReaderArtifactMalformedPayloadFallsBackToFreshResult(t *testing.
 		assert.False(t, hit)
 		assert.Equal(t, "fresh", result.MarkdownContent)
 		assert.Equal(t, 1, reader.calls)
+		key, keyEligible, keyErr := newDocReaderArtifactKey(testDocReaderArtifactRequest(reader))
+		require.NoError(t, keyErr)
+		require.True(t, keyEligible)
+		assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+		assert.Equal(t, [][]byte{[]byte("malformed")}, store.observed)
 	})
+}
+
+func TestReadDocReaderArtifactStopsWhenInvalidationFails(t *testing.T) {
+	store := newDocReaderArtifactFakeStore()
+	store.invalidateErr = errors.New("invalidate failed")
+	reader := &docReaderArtifactFakeReader{result: testDocReaderResult("fresh")}
+	request := testDocReaderArtifactRequest(reader)
+	key, eligible, err := newDocReaderArtifactKey(request)
+	require.NoError(t, err)
+	require.True(t, eligible)
+	store.values[key] = []byte("malformed")
+
+	result, hit, err := readDocReaderArtifact(context.Background(), store, request)
+	assert.ErrorIs(t, err, store.invalidateErr)
+	assert.Nil(t, result)
+	assert.False(t, hit)
+	assert.Zero(t, reader.calls)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
 }
 
 func TestReadDocReaderArtifactDistinguishesStoreErrors(t *testing.T) {

--- a/internal/application/service/docreader_artifact_cache_test.go
+++ b/internal/application/service/docreader_artifact_cache_test.go
@@ -1,0 +1,554 @@
+package service
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type docReaderArtifactFakeReader struct {
+	result   *types.ReadResult
+	err      error
+	calls    int
+	identity string
+}
+
+func (r *docReaderArtifactFakeReader) Read(context.Context, *types.ReadRequest) (*types.ReadResult, error) {
+	r.calls++
+	return r.result, r.err
+}
+
+func (r *docReaderArtifactFakeReader) Reconnect(string) error { return nil }
+func (r *docReaderArtifactFakeReader) IsConnected() bool      { return true }
+func (r *docReaderArtifactFakeReader) ArtifactIdentity() string {
+	return r.identity
+}
+func (r *docReaderArtifactFakeReader) ListEngines(
+	context.Context, map[string]string,
+) ([]types.ParserEngineInfo, error) {
+	return nil, nil
+}
+
+type docReaderArtifactFakeStore struct {
+	values       map[types.ProcessingArtifactKey][]byte
+	getErr       error
+	putErr       error
+	putCanonical []byte
+	hasCanonical bool
+	getCalls     int
+	putCalls     int
+}
+
+func newDocReaderArtifactFakeStore() *docReaderArtifactFakeStore {
+	return &docReaderArtifactFakeStore{values: make(map[types.ProcessingArtifactKey][]byte)}
+}
+
+func (s *docReaderArtifactFakeStore) Get(
+	_ context.Context,
+	key types.ProcessingArtifactKey,
+) ([]byte, bool, error) {
+	s.getCalls++
+	if s.getErr != nil {
+		return nil, false, s.getErr
+	}
+	value, ok := s.values[key]
+	return append([]byte(nil), value...), ok, nil
+}
+
+func (s *docReaderArtifactFakeStore) PutIfAbsent(
+	_ context.Context,
+	key types.ProcessingArtifactKey,
+	value []byte,
+) ([]byte, bool, error) {
+	s.putCalls++
+	if s.putErr != nil {
+		return nil, false, s.putErr
+	}
+	if s.hasCanonical {
+		return append([]byte(nil), s.putCanonical...), false, nil
+	}
+	if canonical, ok := s.values[key]; ok {
+		return append([]byte(nil), canonical...), false, nil
+	}
+	s.values[key] = append([]byte(nil), value...)
+	return append([]byte(nil), value...), true, nil
+}
+
+func TestNewDocReaderArtifactKeyStabilityAndInvalidation(t *testing.T) {
+	base := testDocReaderArtifactRequest(&docReaderArtifactFakeReader{})
+	base.readRequest.ParserEngineOverrides = map[string]string{
+		"mineru_enable_ocr": "true",
+		"mineru_language":   "zh",
+	}
+
+	baseKey, eligible, err := newDocReaderArtifactKey(base)
+	require.NoError(t, err)
+	require.True(t, eligible)
+	stableKey, eligible, err := newDocReaderArtifactKey(base)
+	require.NoError(t, err)
+	require.True(t, eligible)
+	assert.Equal(t, baseKey, stableKey)
+	assert.Equal(t, "docreader.parse", baseKey.Stage)
+	assert.Equal(t, uint16(1), baseKey.KeyVersion)
+
+	reordered := base
+	reordered.readRequest = cloneDocReaderReadRequest(base.readRequest)
+	reordered.readRequest.ParserEngineOverrides = map[string]string{
+		"mineru_language":   "zh",
+		"mineru_enable_ocr": "true",
+	}
+	reorderedKey, eligible, err := newDocReaderArtifactKey(reordered)
+	require.NoError(t, err)
+	require.True(t, eligible)
+	assert.Equal(t, baseKey, reorderedKey)
+
+	tests := []struct {
+		name   string
+		mutate func(*docReaderArtifactRequest)
+	}{
+		{name: "file bytes", mutate: func(r *docReaderArtifactRequest) { r.readRequest.FileContent = []byte("other") }},
+		{name: "parser engine", mutate: func(r *docReaderArtifactRequest) { r.readRequest.ParserEngine = "opendataloader" }},
+		{name: "file type", mutate: func(r *docReaderArtifactRequest) { r.readRequest.FileType = "docx" }},
+		{name: "file name", mutate: func(r *docReaderArtifactRequest) { r.readRequest.FileName = "renamed.pdf" }},
+		{name: "title", mutate: func(r *docReaderArtifactRequest) { r.readRequest.Title = "Other title" }},
+		{name: "render version", mutate: func(r *docReaderArtifactRequest) { r.renderVersion = "2" }},
+		{name: "effective override", mutate: func(r *docReaderArtifactRequest) {
+			r.readRequest.ParserEngineOverrides["mineru_language"] = "en"
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changed := base
+			changed.readRequest = cloneDocReaderReadRequest(base.readRequest)
+			tt.mutate(&changed)
+			changedKey, eligible, err := newDocReaderArtifactKey(changed)
+			require.NoError(t, err)
+			require.True(t, eligible)
+			assert.NotEqual(t, baseKey, changedKey)
+		})
+	}
+}
+
+func TestNewDocReaderArtifactKeyUsesEffectiveDefaultEngine(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		fileName       string
+		fileType       string
+		explicitEngine string
+	}{
+		{name: "simple format", fileName: "document.md", fileType: "md", explicitEngine: "simple"},
+		{name: "non-simple format", fileName: "document.pdf", fileType: "pdf", explicitEngine: "builtin"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			implicit := testDocReaderArtifactRequest(&docReaderArtifactFakeReader{})
+			implicit.readRequest.FileName = test.fileName
+			implicit.readRequest.FileType = test.fileType
+			implicit.readRequest.ParserEngine = ""
+			explicit := implicit
+			explicit.readRequest = cloneDocReaderReadRequest(implicit.readRequest)
+			explicit.readRequest.ParserEngine = test.explicitEngine
+
+			implicitKey, eligible, err := newDocReaderArtifactKey(implicit)
+			require.NoError(t, err)
+			require.True(t, eligible)
+			explicitKey, eligible, err := newDocReaderArtifactKey(explicit)
+			require.NoError(t, err)
+			require.True(t, eligible)
+			assert.Equal(t, explicitKey, implicitKey)
+		})
+	}
+}
+
+func TestNormalizeDocReaderArtifactEngineMatchesReaderRouting(t *testing.T) {
+	assert.Equal(t, "mineru", normalizeDocReaderArtifactEngine(" MINERU "))
+	assert.Empty(t, normalizeDocReaderArtifactEngine("  "))
+}
+
+func TestNewDocReaderArtifactKeyRequiresSharedReaderIdentity(t *testing.T) {
+	request := testDocReaderArtifactRequest(&docReaderArtifactFakeReader{})
+	request.readRequest.ParserEngine = "builtin"
+	request.readerIdentity = ""
+
+	_, eligible, err := newDocReaderArtifactKey(request)
+	require.NoError(t, err)
+	assert.False(t, eligible)
+
+	request.readerIdentity = "http:https://docreader-one.example.com"
+	first, eligible, err := newDocReaderArtifactKey(request)
+	require.NoError(t, err)
+	require.True(t, eligible)
+
+	request.readerIdentity = "http:https://docreader-two.example.com"
+	second, eligible, err := newDocReaderArtifactKey(request)
+	require.NoError(t, err)
+	require.True(t, eligible)
+	assert.NotEqual(t, first, second)
+}
+
+func TestDocReaderArtifactOverridesProtectSecretsAndFailClosed(t *testing.T) {
+	base := testDocReaderArtifactRequest(&docReaderArtifactFakeReader{})
+	base.readRequest.ParserEngineOverrides = map[string]string{
+		"mineru_api_key":        "first-secret",
+		"mineru_endpoint":       "HTTPS://EXAMPLE.com/api/",
+		"mineru_model":          "pipeline",
+		"paddleocr_vl_endpoint": "https://paddle.example.com/v1",
+	}
+
+	baseKey, eligible, err := newDocReaderArtifactKey(base)
+	require.NoError(t, err)
+	require.True(t, eligible)
+
+	credentialsChanged := base
+	credentialsChanged.readRequest = cloneDocReaderReadRequest(base.readRequest)
+	credentialsChanged.readRequest.ParserEngineOverrides["mineru_api_key"] = "second-secret"
+	credentialsChanged.readRequest.ParserEngineOverrides["paddleocr_vl_endpoint"] =
+		"https://other-paddle.example.com/v2"
+	credentialsKey, eligible, err := newDocReaderArtifactKey(credentialsChanged)
+	require.NoError(t, err)
+	require.True(t, eligible)
+	assert.Equal(t, baseKey, credentialsKey)
+
+	canonical, eligible, err := canonicalDocReaderArtifactOverrides(
+		base.readRequest.ParserEngine,
+		base.readRequest.FileType,
+		base.readRequest.ParserEngineOverrides,
+	)
+	require.NoError(t, err)
+	require.True(t, eligible)
+	assert.NotContains(t, string(canonical), "first-secret")
+	assert.Contains(t, string(canonical), "https://example.com/api")
+	assert.NotContains(t, string(canonical), "paddle.example.com")
+
+	unknown := base
+	unknown.readRequest = cloneDocReaderReadRequest(base.readRequest)
+	unknown.readRequest.ParserEngineOverrides["mineru_new_parser_knob"] = "value"
+	_, eligible, err = newDocReaderArtifactKey(unknown)
+	require.NoError(t, err)
+	assert.False(t, eligible)
+
+	unrelatedUnknown := base
+	unrelatedUnknown.readRequest = cloneDocReaderReadRequest(base.readRequest)
+	unrelatedUnknown.readRequest.ParserEngineOverrides["paddleocr_vl_new_parser_knob"] = "value"
+	unrelatedKey, eligible, err := newDocReaderArtifactKey(unrelatedUnknown)
+	require.NoError(t, err)
+	require.True(t, eligible)
+	assert.Equal(t, baseKey, unrelatedKey)
+
+	unsafeEndpoint := base
+	unsafeEndpoint.readRequest = cloneDocReaderReadRequest(base.readRequest)
+	unsafeEndpoint.readRequest.ParserEngineOverrides["mineru_endpoint"] = "file:///tmp/parser"
+	_, eligible, err = newDocReaderArtifactKey(unsafeEndpoint)
+	require.NoError(t, err)
+	assert.False(t, eligible)
+}
+
+func TestDocReaderArtifactNonEquivalentEndpointBypassesCache(t *testing.T) {
+	for _, endpoint := range []string{
+		"https://user:password@example.com/api",
+		"https://example.com/api?route=private",
+		"https://example.com/api#private",
+		" https://example.com/api",
+		"https://example.com/api ",
+	} {
+		request := testDocReaderArtifactRequest(&docReaderArtifactFakeReader{})
+		request.readRequest.ParserEngineOverrides = map[string]string{"mineru_endpoint": endpoint}
+
+		_, eligible, err := newDocReaderArtifactKey(request)
+		require.NoError(t, err)
+		assert.False(t, eligible)
+	}
+}
+
+func TestDocReaderArtifactOpenDataLoaderIgnoresMinerUEndpoint(t *testing.T) {
+	base := testDocReaderArtifactRequest(&docReaderArtifactFakeReader{})
+	base.readRequest.ParserEngine = "opendataloader"
+	base.readerIdentity = "grpc:docreader:50051"
+
+	baseKey, eligible, err := newDocReaderArtifactKey(base)
+	require.NoError(t, err)
+	require.True(t, eligible)
+
+	changed := base
+	changed.readRequest = cloneDocReaderReadRequest(base.readRequest)
+	changed.readRequest.ParserEngineOverrides = map[string]string{
+		"mineru_endpoint": "https://example.com/api?ignored=true",
+	}
+	changedKey, eligible, err := newDocReaderArtifactKey(changed)
+	require.NoError(t, err)
+	require.True(t, eligible)
+	assert.Equal(t, baseKey, changedKey)
+}
+
+func TestNewDocReaderArtifactKeyBypassesUnstableInputs(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*docReaderArtifactRequest)
+	}{
+		{name: "URL", mutate: func(r *docReaderArtifactRequest) { r.readRequest.URL = "https://example.com/document" }},
+		{name: "temporary path", mutate: func(r *docReaderArtifactRequest) {
+			r.sourcePath = filepath.Join(os.TempDir(), "upload", "document.pdf")
+		}},
+		{name: "audio file type", mutate: func(r *docReaderArtifactRequest) { r.readRequest.FileType = "audio/mpeg" }},
+		{name: "audio extension file type", mutate: func(r *docReaderArtifactRequest) {
+			r.readRequest.FileType = "mp3"
+			r.readRequest.FileName = ""
+		}},
+		{name: "audio extension", mutate: func(r *docReaderArtifactRequest) { r.readRequest.FileName = "recording.mp3" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := testDocReaderArtifactRequest(&docReaderArtifactFakeReader{})
+			tt.mutate(&request)
+			_, eligible, err := newDocReaderArtifactKey(request)
+			require.NoError(t, err)
+			assert.False(t, eligible)
+		})
+	}
+}
+
+func TestDocReaderArtifactCodecRoundTripDropsUnsafeFields(t *testing.T) {
+	original := &types.ReadResult{
+		MarkdownContent: "# Parsed",
+		Metadata:        map[string]string{"pages": "2"},
+		ImageDirPath:    "/tmp/docreader-images",
+		Error:           "must not persist",
+		IsAudio:         true,
+		AudioData:       []byte("audio"),
+		ImageRefs: []types.ImageRef{{
+			Filename:    "page-1.png",
+			OriginalRef: "images/page-1.png",
+			MimeType:    "image/png",
+			StorageKey:  "tenant-bound/key",
+			ImageData:   []byte("image-bytes"),
+			IsOriginal:  true,
+		}},
+	}
+
+	payload, err := encodeDocReaderArtifact(original)
+	require.NoError(t, err)
+	require.NotEmpty(t, payload)
+	assert.Equal(t, byte(1), payload[0])
+
+	decoded, err := decodeDocReaderArtifact(payload)
+	require.NoError(t, err)
+	assert.Equal(t, original.MarkdownContent, decoded.MarkdownContent)
+	assert.Equal(t, original.Metadata, decoded.Metadata)
+	require.Len(t, decoded.ImageRefs, 1)
+	assert.Equal(t, original.ImageRefs[0].Filename, decoded.ImageRefs[0].Filename)
+	assert.Equal(t, original.ImageRefs[0].OriginalRef, decoded.ImageRefs[0].OriginalRef)
+	assert.Equal(t, original.ImageRefs[0].MimeType, decoded.ImageRefs[0].MimeType)
+	assert.Equal(t, original.ImageRefs[0].ImageData, decoded.ImageRefs[0].ImageData)
+	assert.True(t, decoded.ImageRefs[0].IsOriginal)
+	assert.Empty(t, decoded.ImageRefs[0].StorageKey)
+	assert.Empty(t, decoded.Error)
+	assert.Empty(t, decoded.ImageDirPath)
+	assert.False(t, decoded.IsAudio)
+	assert.Empty(t, decoded.AudioData)
+}
+
+func TestDecodeDocReaderArtifactRejectsTrailingJSONValue(t *testing.T) {
+	var payload bytes.Buffer
+	payload.WriteByte(docReaderArtifactCodecVersion)
+	writer := gzip.NewWriter(&payload)
+	_, err := writer.Write([]byte(`{"markdown_content":"first"}{"markdown_content":"second"}`))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	_, err = decodeDocReaderArtifact(payload.Bytes())
+	assert.ErrorIs(t, err, errDocReaderArtifactCodec)
+}
+
+func TestReadDocReaderArtifactCachesSuccessfulResult(t *testing.T) {
+	store := newDocReaderArtifactFakeStore()
+	reader := &docReaderArtifactFakeReader{result: testDocReaderResult("fresh")}
+	request := testDocReaderArtifactRequest(reader)
+
+	first, hit, err := readDocReaderArtifact(context.Background(), store, request)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, "fresh", first.MarkdownContent)
+
+	reader.result = testDocReaderResult("unexpected")
+	second, hit, err := readDocReaderArtifact(context.Background(), store, request)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, "fresh", second.MarkdownContent)
+	assert.Equal(t, 1, reader.calls)
+	assert.Equal(t, 1, store.putCalls)
+}
+
+func TestReadDocReaderArtifactBypassCallsReaderWithoutStore(t *testing.T) {
+	store := newDocReaderArtifactFakeStore()
+	reader := &docReaderArtifactFakeReader{result: testDocReaderResult("fresh")}
+	request := testDocReaderArtifactRequest(reader)
+	request.readRequest.URL = "https://example.com/document"
+
+	result, hit, err := readDocReaderArtifact(context.Background(), store, request)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, "fresh", result.MarkdownContent)
+	assert.Equal(t, 1, reader.calls)
+	assert.Zero(t, store.getCalls)
+	assert.Zero(t, store.putCalls)
+}
+
+func TestReadDocReaderArtifactDoesNotCacheFailuresOrAudio(t *testing.T) {
+	t.Run("provider error", func(t *testing.T) {
+		store := newDocReaderArtifactFakeStore()
+		providerErr := errors.New("reader unavailable")
+		reader := &docReaderArtifactFakeReader{err: providerErr}
+
+		_, _, err := readDocReaderArtifact(context.Background(), store, testDocReaderArtifactRequest(reader))
+		assert.ErrorIs(t, err, errDocReaderArtifactProvider)
+		assert.ErrorContains(t, err, providerErr.Error())
+		assert.Zero(t, store.putCalls)
+	})
+
+	t.Run("result error", func(t *testing.T) {
+		store := newDocReaderArtifactFakeStore()
+		reader := &docReaderArtifactFakeReader{result: &types.ReadResult{Error: "parse failed"}}
+
+		result, hit, err := readDocReaderArtifact(context.Background(), store, testDocReaderArtifactRequest(reader))
+		require.NoError(t, err)
+		assert.False(t, hit)
+		assert.Equal(t, "parse failed", result.Error)
+		assert.Zero(t, store.putCalls)
+	})
+
+	t.Run("audio result", func(t *testing.T) {
+		store := newDocReaderArtifactFakeStore()
+		reader := &docReaderArtifactFakeReader{result: &types.ReadResult{IsAudio: true, AudioData: []byte("audio")}}
+
+		result, hit, err := readDocReaderArtifact(context.Background(), store, testDocReaderArtifactRequest(reader))
+		require.NoError(t, err)
+		assert.False(t, hit)
+		assert.True(t, result.IsAudio)
+		assert.Zero(t, store.putCalls)
+	})
+}
+
+func TestReadDocReaderArtifactUsesValidConcurrentWinner(t *testing.T) {
+	store := newDocReaderArtifactFakeStore()
+	winner, err := encodeDocReaderArtifact(testDocReaderResult("winner"))
+	require.NoError(t, err)
+	store.putCanonical = winner
+	store.hasCanonical = true
+	reader := &docReaderArtifactFakeReader{result: testDocReaderResult("fresh")}
+
+	result, hit, err := readDocReaderArtifact(
+		context.Background(), store, testDocReaderArtifactRequest(reader),
+	)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, "winner", result.MarkdownContent)
+	assert.Equal(t, 1, reader.calls)
+}
+
+func TestReadDocReaderArtifactMalformedPayloadFallsBackToFreshResult(t *testing.T) {
+	t.Run("hit", func(t *testing.T) {
+		store := newDocReaderArtifactFakeStore()
+		reader := &docReaderArtifactFakeReader{result: testDocReaderResult("fresh")}
+		request := testDocReaderArtifactRequest(reader)
+		key, eligible, err := newDocReaderArtifactKey(request)
+		require.NoError(t, err)
+		require.True(t, eligible)
+		store.values[key] = []byte("malformed")
+
+		result, hit, err := readDocReaderArtifact(context.Background(), store, request)
+		require.NoError(t, err)
+		assert.False(t, hit)
+		assert.Equal(t, "fresh", result.MarkdownContent)
+		assert.Equal(t, 1, reader.calls)
+	})
+
+	t.Run("concurrent winner", func(t *testing.T) {
+		store := newDocReaderArtifactFakeStore()
+		store.putCanonical = []byte("malformed")
+		store.hasCanonical = true
+		reader := &docReaderArtifactFakeReader{result: testDocReaderResult("fresh")}
+
+		result, hit, err := readDocReaderArtifact(
+			context.Background(), store, testDocReaderArtifactRequest(reader),
+		)
+		require.NoError(t, err)
+		assert.False(t, hit)
+		assert.Equal(t, "fresh", result.MarkdownContent)
+		assert.Equal(t, 1, reader.calls)
+	})
+}
+
+func TestReadDocReaderArtifactDistinguishesStoreErrors(t *testing.T) {
+	t.Run("get", func(t *testing.T) {
+		storeErr := errors.New("get failed")
+		store := newDocReaderArtifactFakeStore()
+		store.getErr = storeErr
+		reader := &docReaderArtifactFakeReader{result: testDocReaderResult("fresh")}
+
+		_, _, err := readDocReaderArtifact(context.Background(), store, testDocReaderArtifactRequest(reader))
+		assert.ErrorIs(t, err, errDocReaderArtifactStore)
+		assert.ErrorContains(t, err, storeErr.Error())
+		assert.Zero(t, reader.calls)
+	})
+
+	t.Run("put", func(t *testing.T) {
+		storeErr := errors.New("put failed")
+		store := newDocReaderArtifactFakeStore()
+		store.putErr = storeErr
+		reader := &docReaderArtifactFakeReader{result: testDocReaderResult("fresh")}
+
+		_, _, err := readDocReaderArtifact(context.Background(), store, testDocReaderArtifactRequest(reader))
+		assert.ErrorIs(t, err, errDocReaderArtifactStore)
+		assert.ErrorContains(t, err, storeErr.Error())
+		assert.Equal(t, 1, reader.calls)
+	})
+}
+
+func testDocReaderArtifactRequest(reader *docReaderArtifactFakeReader) docReaderArtifactRequest {
+	return docReaderArtifactRequest{
+		tenantID:       7,
+		sourcePath:     filepath.Join("knowledge", "document.pdf"),
+		read:           reader.Read,
+		readerIdentity: "test:docreader",
+		renderVersion:  "1",
+		readRequest: &types.ReadRequest{
+			FileContent:  []byte("document bytes"),
+			FileName:     "document.pdf",
+			FileType:     "pdf",
+			Title:        "Document title",
+			ParserEngine: "mineru",
+		},
+	}
+}
+
+func cloneDocReaderReadRequest(request *types.ReadRequest) *types.ReadRequest {
+	clone := *request
+	clone.FileContent = append([]byte(nil), request.FileContent...)
+	clone.ParserEngineOverrides = make(map[string]string, len(request.ParserEngineOverrides))
+	for key, value := range request.ParserEngineOverrides {
+		clone.ParserEngineOverrides[key] = value
+	}
+	return &clone
+}
+
+func testDocReaderResult(markdown string) *types.ReadResult {
+	return &types.ReadResult{
+		MarkdownContent: markdown,
+		Metadata:        map[string]string{"pages": "1"},
+		ImageRefs: []types.ImageRef{{
+			Filename:    "page.png",
+			OriginalRef: "images/page.png",
+			MimeType:    "image/png",
+			ImageData:   []byte("image"),
+		}},
+	}
+}

--- a/internal/application/service/embedding_artifact_cache.go
+++ b/internal/application/service/embedding_artifact_cache.go
@@ -319,6 +319,12 @@ func (e *embeddingArtifactEmbedder) load(
 	if err == nil {
 		err = e.validateVector(vector)
 	}
+	if err != nil {
+		if invalidateErr := e.store.Invalidate(ctx, key, payload); invalidateErr != nil {
+			return nil, false, fmt.Errorf("invalidate embedding artifact: %w", invalidateErr)
+		}
+		return nil, false, nil
+	}
 	return vector, true, err
 }
 
@@ -355,7 +361,10 @@ func (e *embeddingArtifactEmbedder) loadMany(
 			err = e.validateVector(vector)
 		}
 		if err != nil {
-			return nil, err
+			if invalidateErr := e.store.Invalidate(ctx, key, payload); invalidateErr != nil {
+				return nil, fmt.Errorf("invalidate embedding artifact: %w", invalidateErr)
+			}
+			continue
 		}
 		result[key] = vector
 	}
@@ -377,10 +386,16 @@ func (e *embeddingArtifactEmbedder) freeze(
 	}
 	decoded, err := decodeEmbeddingVector(canonical, e.inner.GetDimensions())
 	if err != nil {
-		return nil, err
+		if invalidateErr := e.store.Invalidate(ctx, key, canonical); invalidateErr != nil {
+			return nil, fmt.Errorf("invalidate embedding artifact: %w", invalidateErr)
+		}
+		return vector, nil
 	}
 	if err := e.validateVector(decoded); err != nil {
-		return nil, err
+		if invalidateErr := e.store.Invalidate(ctx, key, canonical); invalidateErr != nil {
+			return nil, fmt.Errorf("invalidate embedding artifact: %w", invalidateErr)
+		}
+		return vector, nil
 	}
 	return decoded, nil
 }
@@ -424,7 +439,11 @@ func (e *embeddingArtifactEmbedder) freezeMany(
 			err = e.validateVector(vector)
 		}
 		if err != nil {
-			return nil, err
+			if invalidateErr := e.store.Invalidate(ctx, key, payload); invalidateErr != nil {
+				return nil, fmt.Errorf("invalidate embedding artifact: %w", invalidateErr)
+			}
+			result[key] = append([]float32(nil), vectors[key]...)
+			continue
 		}
 		result[key] = vector
 	}

--- a/internal/application/service/embedding_artifact_cache.go
+++ b/internal/application/service/embedding_artifact_cache.go
@@ -1,0 +1,448 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+const (
+	embeddingArtifactStage                       = "embedding.vector"
+	embeddingArtifactKeyVersion           uint16 = 1
+	embeddingArtifactCodecVersion         byte   = 1
+	embeddingArtifactNormalizationVersion        = "embedding-text-v1"
+	embeddingArtifactHeaderSize                  = 5
+)
+
+type embeddingArtifactKeyRequest struct {
+	tenantID             uint64
+	modelID              string
+	modelName            string
+	modelRevision        string
+	dimensions           int
+	normalizationVersion string
+	text                 string
+}
+
+type embeddingArtifactEmbedder struct {
+	inner         embedding.Embedder
+	store         interfaces.ProcessingArtifactStore
+	tenantID      uint64
+	modelRevision string
+}
+
+func newEmbeddingArtifactEmbedder(
+	inner embedding.Embedder,
+	store interfaces.ProcessingArtifactStore,
+	tenantID uint64,
+	modelRevision string,
+) embedding.Embedder {
+	if inner == nil {
+		return nil
+	}
+	return &embeddingArtifactEmbedder{
+		inner:         inner,
+		store:         store,
+		tenantID:      tenantID,
+		modelRevision: modelRevision,
+	}
+}
+
+func normalizeEmbeddingArtifactText(text string) string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	return strings.TrimSpace(text)
+}
+
+func newEmbeddingArtifactKey(
+	request embeddingArtifactKeyRequest,
+) (types.ProcessingArtifactKey, string, error) {
+	if request.dimensions <= 0 {
+		return types.ProcessingArtifactKey{}, "", errors.New("embedding artifact dimensions must be positive")
+	}
+	if strings.TrimSpace(request.normalizationVersion) == "" {
+		return types.ProcessingArtifactKey{}, "", errors.New("embedding artifact normalization version must not be empty")
+	}
+	if strings.TrimSpace(request.modelRevision) == "" {
+		return types.ProcessingArtifactKey{}, "", errors.New("embedding artifact model revision must not be empty")
+	}
+
+	normalized := normalizeEmbeddingArtifactText(request.text)
+	key, err := types.NewProcessingArtifactKey(
+		request.tenantID,
+		embeddingArtifactStage,
+		embeddingArtifactKeyVersion,
+		[]byte(request.modelID),
+		[]byte(request.modelName),
+		[]byte(request.modelRevision),
+		[]byte(strconv.Itoa(request.dimensions)),
+		[]byte(request.normalizationVersion),
+		[]byte(normalized),
+	)
+	return key, normalized, err
+}
+
+func embeddingModelRevision(model *types.Model) (string, error) {
+	if model == nil {
+		return "", errors.New("embedding artifact model must not be nil")
+	}
+	endpoint, err := url.Parse(model.Parameters.BaseURL)
+	if err != nil {
+		return "", errors.New("invalid embedding artifact endpoint URL")
+	}
+	endpoint.User = nil
+	endpoint.RawQuery = ""
+	endpoint.Fragment = ""
+	endpoint.Scheme = strings.ToLower(endpoint.Scheme)
+	endpoint.Host = strings.ToLower(endpoint.Host)
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/")
+
+	params := model.Parameters.EmbeddingParameters
+	extra := model.Parameters.ExtraConfig
+	descriptor := strings.Join([]string{
+		model.ID,
+		model.Name,
+		strings.ToLower(string(model.Source)),
+		strings.ToLower(strings.TrimSpace(model.Parameters.Provider)),
+		endpoint.String(),
+		strconv.Itoa(params.Dimension),
+		strconv.Itoa(params.TruncatePromptTokens),
+		strconv.FormatBool(params.SupportsDimensionOverride),
+		extra["api_version"],
+		strings.TrimSpace(extra["remote_model_name"]),
+		model.UpdatedAt.UTC().Format(time.RFC3339Nano),
+	}, "\x00")
+	digest := sha256.Sum256([]byte(descriptor))
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func encodeEmbeddingVector(vector []float32) ([]byte, error) {
+	if uint64(len(vector)) > uint64(^uint32(0)) {
+		return nil, errors.New("embedding artifact vector is too large")
+	}
+	payload := make([]byte, embeddingArtifactHeaderSize+len(vector)*4)
+	payload[0] = embeddingArtifactCodecVersion
+	binary.BigEndian.PutUint32(payload[1:embeddingArtifactHeaderSize], uint32(len(vector)))
+	for i, value := range vector {
+		binary.BigEndian.PutUint32(payload[embeddingArtifactHeaderSize+i*4:], math.Float32bits(value))
+	}
+	return payload, nil
+}
+
+func decodeEmbeddingVector(payload []byte, expectedDimensions int) ([]float32, error) {
+	if len(payload) < embeddingArtifactHeaderSize {
+		return nil, errors.New("invalid embedding artifact payload")
+	}
+	if payload[0] != embeddingArtifactCodecVersion {
+		return nil, fmt.Errorf("unsupported embedding artifact codec version %d", payload[0])
+	}
+	count := uint64(binary.BigEndian.Uint32(payload[1:embeddingArtifactHeaderSize]))
+	if count > uint64((int(^uint(0)>>1)-embeddingArtifactHeaderSize)/4) ||
+		uint64(len(payload)) != uint64(embeddingArtifactHeaderSize)+count*4 {
+		return nil, errors.New("invalid embedding artifact payload length")
+	}
+	if expectedDimensions > 0 && count != uint64(expectedDimensions) {
+		return nil, fmt.Errorf("embedding artifact has %d dimensions, expected %d", count, expectedDimensions)
+	}
+
+	vector := make([]float32, int(count))
+	for i := range vector {
+		vector[i] = math.Float32frombits(binary.BigEndian.Uint32(payload[embeddingArtifactHeaderSize+i*4:]))
+	}
+	return vector, nil
+}
+
+func (e *embeddingArtifactEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	if e.store == nil || e.inner.GetDimensions() <= 0 || !isDocumentEmbedding(ctx) {
+		return e.inner.Embed(ctx, text)
+	}
+
+	key, normalized, err := e.key(text)
+	if err != nil {
+		return nil, err
+	}
+	if vector, hit, err := e.load(ctx, key); err != nil || hit {
+		return vector, err
+	}
+
+	vector, err := e.inner.Embed(ctx, normalized)
+	if err != nil {
+		return nil, err
+	}
+	if err := e.validateVector(vector); err != nil {
+		return nil, err
+	}
+	return e.freeze(ctx, key, vector)
+}
+
+func (e *embeddingArtifactEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.batchEmbed(ctx, texts, e.inner.BatchEmbed)
+}
+
+func (e *embeddingArtifactEmbedder) BatchEmbedWithPool(
+	ctx context.Context,
+	_ embedding.Embedder,
+	texts []string,
+) ([][]float32, error) {
+	provider := func(ctx context.Context, misses []string) ([][]float32, error) {
+		return e.inner.BatchEmbedWithPool(ctx, e.inner, misses)
+	}
+	return e.batchEmbed(ctx, texts, provider)
+}
+
+func (e *embeddingArtifactEmbedder) batchEmbed(
+	ctx context.Context,
+	texts []string,
+	provider func(context.Context, []string) ([][]float32, error),
+) ([][]float32, error) {
+	if e.store == nil || e.inner.GetDimensions() <= 0 || !isDocumentEmbedding(ctx) {
+		return provider(ctx, texts)
+	}
+	if len(texts) == 0 {
+		return [][]float32{}, nil
+	}
+
+	keys := make([]types.ProcessingArtifactKey, len(texts))
+	uniqueIndexes := make(map[types.ProcessingArtifactKey]int, len(texts))
+	uniqueKeys := make([]types.ProcessingArtifactKey, 0, len(texts))
+	uniqueTexts := make([]string, 0, len(texts))
+
+	for i, text := range texts {
+		key, normalized, err := e.key(text)
+		if err != nil {
+			return nil, err
+		}
+		keys[i] = key
+		if _, exists := uniqueIndexes[key]; exists {
+			continue
+		}
+
+		uniqueIndex := len(uniqueKeys)
+		uniqueIndexes[key] = uniqueIndex
+		uniqueKeys = append(uniqueKeys, key)
+		uniqueTexts = append(uniqueTexts, normalized)
+	}
+
+	cached, err := e.loadMany(ctx, uniqueKeys)
+	if err != nil {
+		return nil, err
+	}
+	uniqueVectors := make([][]float32, len(uniqueKeys))
+	missIndexes := make([]int, 0, len(uniqueKeys))
+	for i, key := range uniqueKeys {
+		if vector, hit := cached[key]; hit {
+			uniqueVectors[i] = vector
+		} else {
+			missIndexes = append(missIndexes, i)
+		}
+	}
+
+	if len(missIndexes) > 0 {
+		missTexts := make([]string, len(missIndexes))
+		for i, uniqueIndex := range missIndexes {
+			missTexts[i] = uniqueTexts[uniqueIndex]
+		}
+		missVectors, err := provider(ctx, missTexts)
+		if err != nil {
+			return nil, err
+		}
+		if len(missVectors) != len(missIndexes) {
+			return nil, fmt.Errorf(
+				"embedding provider returned %d embeddings for %d inputs",
+				len(missVectors), len(missIndexes),
+			)
+		}
+		for _, vector := range missVectors {
+			if err := e.validateVector(vector); err != nil {
+				return nil, err
+			}
+		}
+		misses := make(map[types.ProcessingArtifactKey][]float32, len(missIndexes))
+		for i, uniqueIndex := range missIndexes {
+			misses[uniqueKeys[uniqueIndex]] = missVectors[i]
+		}
+		canonical, err := e.freezeMany(ctx, misses)
+		if err != nil {
+			return nil, err
+		}
+		for _, uniqueIndex := range missIndexes {
+			uniqueVectors[uniqueIndex] = canonical[uniqueKeys[uniqueIndex]]
+		}
+	}
+
+	result := make([][]float32, len(texts))
+	for i, key := range keys {
+		result[i] = append([]float32(nil), uniqueVectors[uniqueIndexes[key]]...)
+	}
+	return result, nil
+}
+
+func isDocumentEmbedding(ctx context.Context) bool {
+	document, _ := ctx.Value(types.EmbedDocumentContextKey).(bool)
+	query, _ := ctx.Value(types.EmbedQueryContextKey).(bool)
+	return document && !query
+}
+
+func (e *embeddingArtifactEmbedder) key(text string) (types.ProcessingArtifactKey, string, error) {
+	return newEmbeddingArtifactKey(embeddingArtifactKeyRequest{
+		tenantID:             e.tenantID,
+		modelID:              e.inner.GetModelID(),
+		modelName:            e.inner.GetModelName(),
+		modelRevision:        e.modelRevision,
+		dimensions:           e.inner.GetDimensions(),
+		normalizationVersion: embeddingArtifactNormalizationVersion,
+		text:                 text,
+	})
+}
+
+func (e *embeddingArtifactEmbedder) load(
+	ctx context.Context,
+	key types.ProcessingArtifactKey,
+) ([]float32, bool, error) {
+	payload, hit, err := e.store.Get(ctx, key)
+	if err != nil || !hit {
+		return nil, hit, err
+	}
+	vector, err := decodeEmbeddingVector(payload, e.inner.GetDimensions())
+	if err == nil {
+		err = e.validateVector(vector)
+	}
+	return vector, true, err
+}
+
+func (e *embeddingArtifactEmbedder) loadMany(
+	ctx context.Context,
+	keys []types.ProcessingArtifactKey,
+) (map[types.ProcessingArtifactKey][]float32, error) {
+	result := make(map[types.ProcessingArtifactKey][]float32, len(keys))
+	batchStore, ok := e.store.(interfaces.ProcessingArtifactBatchStore)
+	if !ok {
+		for _, key := range keys {
+			vector, hit, err := e.load(ctx, key)
+			if err != nil {
+				return nil, err
+			}
+			if hit {
+				result[key] = vector
+			}
+		}
+		return result, nil
+	}
+
+	payloads, err := batchStore.GetMany(ctx, keys)
+	if err != nil {
+		return nil, err
+	}
+	for _, key := range keys {
+		payload, hit := payloads[key]
+		if !hit {
+			continue
+		}
+		vector, err := decodeEmbeddingVector(payload, e.inner.GetDimensions())
+		if err == nil {
+			err = e.validateVector(vector)
+		}
+		if err != nil {
+			return nil, err
+		}
+		result[key] = vector
+	}
+	return result, nil
+}
+
+func (e *embeddingArtifactEmbedder) freeze(
+	ctx context.Context,
+	key types.ProcessingArtifactKey,
+	vector []float32,
+) ([]float32, error) {
+	payload, err := encodeEmbeddingVector(vector)
+	if err != nil {
+		return nil, err
+	}
+	canonical, _, err := e.store.PutIfAbsent(ctx, key, payload)
+	if err != nil {
+		return nil, err
+	}
+	decoded, err := decodeEmbeddingVector(canonical, e.inner.GetDimensions())
+	if err != nil {
+		return nil, err
+	}
+	if err := e.validateVector(decoded); err != nil {
+		return nil, err
+	}
+	return decoded, nil
+}
+
+func (e *embeddingArtifactEmbedder) freezeMany(
+	ctx context.Context,
+	vectors map[types.ProcessingArtifactKey][]float32,
+) (map[types.ProcessingArtifactKey][]float32, error) {
+	result := make(map[types.ProcessingArtifactKey][]float32, len(vectors))
+	batchStore, ok := e.store.(interfaces.ProcessingArtifactBatchStore)
+	if !ok {
+		for key, vector := range vectors {
+			canonical, err := e.freeze(ctx, key, vector)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = canonical
+		}
+		return result, nil
+	}
+
+	payloads := make(map[types.ProcessingArtifactKey][]byte, len(vectors))
+	for key, vector := range vectors {
+		payload, err := encodeEmbeddingVector(vector)
+		if err != nil {
+			return nil, err
+		}
+		payloads[key] = payload
+	}
+	canonical, err := batchStore.PutManyIfAbsent(ctx, payloads)
+	if err != nil {
+		return nil, err
+	}
+	for key := range vectors {
+		payload, ok := canonical[key]
+		if !ok {
+			return nil, errors.New("processing artifact batch store omitted a canonical embedding")
+		}
+		vector, err := decodeEmbeddingVector(payload, e.inner.GetDimensions())
+		if err == nil {
+			err = e.validateVector(vector)
+		}
+		if err != nil {
+			return nil, err
+		}
+		result[key] = vector
+	}
+	return result, nil
+}
+
+func (e *embeddingArtifactEmbedder) validateVector(vector []float32) error {
+	if dimensions := e.inner.GetDimensions(); dimensions > 0 && len(vector) != dimensions {
+		return fmt.Errorf("embedding provider returned %d dimensions, expected %d", len(vector), dimensions)
+	}
+	for _, value := range vector {
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return errors.New("embedding provider returned a non-finite vector value")
+		}
+	}
+	return nil
+}
+
+func (e *embeddingArtifactEmbedder) GetModelName() string { return e.inner.GetModelName() }
+func (e *embeddingArtifactEmbedder) GetDimensions() int   { return e.inner.GetDimensions() }
+func (e *embeddingArtifactEmbedder) GetModelID() string   { return e.inner.GetModelID() }

--- a/internal/application/service/embedding_artifact_cache_test.go
+++ b/internal/application/service/embedding_artifact_cache_test.go
@@ -14,18 +14,22 @@ import (
 )
 
 type embeddingArtifactFakeStore struct {
-	values       map[types.ProcessingArtifactKey][]byte
-	getErr       error
-	putErr       error
-	putCanonical []byte
-	getCalls     int
-	putCalls     int
+	values        map[types.ProcessingArtifactKey][]byte
+	getErr        error
+	putErr        error
+	invalidateErr error
+	putCanonical  []byte
+	getCalls      int
+	putCalls      int
+	invalidated   []types.ProcessingArtifactKey
+	observed      [][]byte
 }
 
 type embeddingArtifactBatchFakeStore struct {
 	*embeddingArtifactFakeStore
-	getManyCalls int
-	putManyCalls int
+	getManyCalls     int
+	putManyCalls     int
+	putManyCanonical map[types.ProcessingArtifactKey][]byte
 }
 
 func newEmbeddingArtifactBatchFakeStore() *embeddingArtifactBatchFakeStore {
@@ -55,6 +59,10 @@ func (s *embeddingArtifactBatchFakeStore) PutManyIfAbsent(
 	s.putManyCalls++
 	result := make(map[types.ProcessingArtifactKey][]byte, len(values))
 	for key, value := range values {
+		if canonical, ok := s.putManyCanonical[key]; ok {
+			result[key] = append([]byte(nil), canonical...)
+			continue
+		}
 		if _, ok := s.values[key]; !ok {
 			s.values[key] = append([]byte(nil), value...)
 		}
@@ -96,6 +104,20 @@ func (s *embeddingArtifactFakeStore) PutIfAbsent(
 	}
 	s.values[key] = append([]byte(nil), value...)
 	return append([]byte(nil), value...), true, nil
+}
+
+func (s *embeddingArtifactFakeStore) Invalidate(
+	_ context.Context,
+	key types.ProcessingArtifactKey,
+	observed []byte,
+) error {
+	s.invalidated = append(s.invalidated, key)
+	s.observed = append(s.observed, append([]byte(nil), observed...))
+	if s.invalidateErr != nil {
+		return s.invalidateErr
+	}
+	delete(s.values, key)
+	return nil
 }
 
 type embeddingArtifactFakeEmbedder struct {
@@ -235,7 +257,7 @@ func TestEmbeddingArtifactBatchPartialHitsDeduplicatesMissesAndRestoresOrder(t *
 		modelID: "model-1", modelName: "text-embedding", dimensions: 2,
 		batchResults: [][]float32{{2, 20}, {3, 30}},
 	}
-	wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+	wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1").(*embeddingArtifactEmbedder)
 
 	hitKey, _, err := newEmbeddingArtifactKey(embeddingArtifactKeyRequest{
 		tenantID: 7, modelID: "model-1", modelName: "text-embedding", modelRevision: "revision-1",
@@ -387,10 +409,64 @@ func TestEmbeddingArtifactRejectsNonFinitePutIfAbsentWinner(t *testing.T) {
 	require.NoError(t, err)
 	store.putCanonical = winner
 	inner := &embeddingArtifactFakeEmbedder{dimensions: 1, batchResults: [][]float32{{1}}}
-	wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+	wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1").(*embeddingArtifactEmbedder)
 
-	_, err = wrapped.BatchEmbed(documentEmbeddingContext(), []string{"one"})
-	assert.ErrorContains(t, err, "non-finite")
+	key, _, err := wrapped.key("one")
+	require.NoError(t, err)
+	got, err := wrapped.BatchEmbed(documentEmbeddingContext(), []string{"one"})
+	require.NoError(t, err)
+	assert.Equal(t, [][]float32{{1}}, got)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+	assert.Equal(t, [][]byte{winner}, store.observed)
+}
+
+func TestEmbeddingArtifactBatchInvalidatesNonFiniteConcurrentWinner(t *testing.T) {
+	store := newEmbeddingArtifactBatchFakeStore()
+	winner, err := encodeEmbeddingVector([]float32{float32(math.NaN())})
+	require.NoError(t, err)
+	inner := &embeddingArtifactFakeEmbedder{dimensions: 1, batchResults: [][]float32{{1}}}
+	wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1").(*embeddingArtifactEmbedder)
+	key, _, err := wrapped.key("one")
+	require.NoError(t, err)
+	store.putManyCanonical = map[types.ProcessingArtifactKey][]byte{key: winner}
+
+	got, err := wrapped.BatchEmbed(documentEmbeddingContext(), []string{"one"})
+	require.NoError(t, err)
+	assert.Equal(t, [][]float32{{1}}, got)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+	assert.Equal(t, [][]byte{winner}, store.observed)
+}
+
+func TestEmbeddingArtifactInvalidationFailureStopsSingleAndBatchFallbacks(t *testing.T) {
+	t.Run("single", func(t *testing.T) {
+		store := newEmbeddingArtifactFakeStore()
+		store.invalidateErr = errors.New("invalidate failed")
+		inner := &embeddingArtifactFakeEmbedder{dimensions: 1, batchResults: [][]float32{{1}}}
+		wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1").(*embeddingArtifactEmbedder)
+		key, _, err := wrapped.key("one")
+		require.NoError(t, err)
+		store.values[key] = []byte("corrupt")
+
+		_, err = wrapped.Embed(documentEmbeddingContext(), "one")
+		assert.ErrorIs(t, err, store.invalidateErr)
+		assert.Empty(t, inner.embedCalls)
+		assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+	})
+
+	t.Run("batch", func(t *testing.T) {
+		store := newEmbeddingArtifactBatchFakeStore()
+		store.invalidateErr = errors.New("invalidate failed")
+		inner := &embeddingArtifactFakeEmbedder{dimensions: 1, batchResults: [][]float32{{1}}}
+		wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1").(*embeddingArtifactEmbedder)
+		key, _, err := wrapped.key("one")
+		require.NoError(t, err)
+		store.values[key] = []byte("corrupt")
+
+		_, err = wrapped.BatchEmbed(documentEmbeddingContext(), []string{"one"})
+		assert.ErrorIs(t, err, store.invalidateErr)
+		assert.Empty(t, inner.batchCalls)
+		assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+	})
 }
 
 func TestEmbeddingArtifactEmbedReusesDocumentsAndBypassesUnmarkedInputs(t *testing.T) {

--- a/internal/application/service/embedding_artifact_cache_test.go
+++ b/internal/application/service/embedding_artifact_cache_test.go
@@ -1,0 +1,459 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type embeddingArtifactFakeStore struct {
+	values       map[types.ProcessingArtifactKey][]byte
+	getErr       error
+	putErr       error
+	putCanonical []byte
+	getCalls     int
+	putCalls     int
+}
+
+type embeddingArtifactBatchFakeStore struct {
+	*embeddingArtifactFakeStore
+	getManyCalls int
+	putManyCalls int
+}
+
+func newEmbeddingArtifactBatchFakeStore() *embeddingArtifactBatchFakeStore {
+	return &embeddingArtifactBatchFakeStore{
+		embeddingArtifactFakeStore: newEmbeddingArtifactFakeStore(),
+	}
+}
+
+func (s *embeddingArtifactBatchFakeStore) GetMany(
+	_ context.Context,
+	keys []types.ProcessingArtifactKey,
+) (map[types.ProcessingArtifactKey][]byte, error) {
+	s.getManyCalls++
+	result := make(map[types.ProcessingArtifactKey][]byte, len(keys))
+	for _, key := range keys {
+		if value, ok := s.values[key]; ok {
+			result[key] = append([]byte(nil), value...)
+		}
+	}
+	return result, nil
+}
+
+func (s *embeddingArtifactBatchFakeStore) PutManyIfAbsent(
+	_ context.Context,
+	values map[types.ProcessingArtifactKey][]byte,
+) (map[types.ProcessingArtifactKey][]byte, error) {
+	s.putManyCalls++
+	result := make(map[types.ProcessingArtifactKey][]byte, len(values))
+	for key, value := range values {
+		if _, ok := s.values[key]; !ok {
+			s.values[key] = append([]byte(nil), value...)
+		}
+		result[key] = append([]byte(nil), s.values[key]...)
+	}
+	return result, nil
+}
+
+func newEmbeddingArtifactFakeStore() *embeddingArtifactFakeStore {
+	return &embeddingArtifactFakeStore{values: make(map[types.ProcessingArtifactKey][]byte)}
+}
+
+func (s *embeddingArtifactFakeStore) Get(
+	_ context.Context,
+	key types.ProcessingArtifactKey,
+) ([]byte, bool, error) {
+	s.getCalls++
+	if s.getErr != nil {
+		return nil, false, s.getErr
+	}
+	value, ok := s.values[key]
+	return append([]byte(nil), value...), ok, nil
+}
+
+func (s *embeddingArtifactFakeStore) PutIfAbsent(
+	_ context.Context,
+	key types.ProcessingArtifactKey,
+	value []byte,
+) ([]byte, bool, error) {
+	s.putCalls++
+	if s.putErr != nil {
+		return nil, false, s.putErr
+	}
+	if s.putCanonical != nil {
+		return append([]byte(nil), s.putCanonical...), false, nil
+	}
+	if canonical, ok := s.values[key]; ok {
+		return append([]byte(nil), canonical...), false, nil
+	}
+	s.values[key] = append([]byte(nil), value...)
+	return append([]byte(nil), value...), true, nil
+}
+
+type embeddingArtifactFakeEmbedder struct {
+	modelID      string
+	modelName    string
+	dimensions   int
+	batchResults [][]float32
+	err          error
+	embedCalls   []string
+	batchCalls   [][]string
+	poolCalls    int
+	poolModel    embedding.Embedder
+}
+
+func (e *embeddingArtifactFakeEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
+	e.embedCalls = append(e.embedCalls, text)
+	if e.err != nil {
+		return nil, e.err
+	}
+	if len(e.batchResults) == 0 {
+		return nil, nil
+	}
+	return append([]float32(nil), e.batchResults[0]...), nil
+}
+
+func (e *embeddingArtifactFakeEmbedder) BatchEmbed(_ context.Context, texts []string) ([][]float32, error) {
+	e.batchCalls = append(e.batchCalls, append([]string(nil), texts...))
+	if e.err != nil {
+		return nil, e.err
+	}
+	return cloneEmbeddingVectors(e.batchResults), nil
+}
+
+func (e *embeddingArtifactFakeEmbedder) BatchEmbedWithPool(
+	ctx context.Context,
+	model embedding.Embedder,
+	texts []string,
+) ([][]float32, error) {
+	e.poolCalls++
+	e.poolModel = model
+	return model.BatchEmbed(ctx, texts)
+}
+
+func (e *embeddingArtifactFakeEmbedder) GetModelName() string { return e.modelName }
+func (e *embeddingArtifactFakeEmbedder) GetDimensions() int   { return e.dimensions }
+func (e *embeddingArtifactFakeEmbedder) GetModelID() string   { return e.modelID }
+
+func cloneEmbeddingVectors(vectors [][]float32) [][]float32 {
+	result := make([][]float32, len(vectors))
+	for i := range vectors {
+		result[i] = append([]float32(nil), vectors[i]...)
+	}
+	return result
+}
+
+func documentEmbeddingContext() context.Context {
+	return context.WithValue(context.Background(), types.EmbedDocumentContextKey, true)
+}
+
+func TestNewEmbeddingArtifactKeyNormalizesAndScopesInputs(t *testing.T) {
+	base := embeddingArtifactKeyRequest{
+		tenantID:             7,
+		modelID:              "model-1",
+		modelName:            "text-embedding",
+		modelRevision:        "2026-07-16T10:00:00Z",
+		dimensions:           3,
+		normalizationVersion: "embedding-text-v1",
+		text:                 "  alpha\r\nbeta\r  ",
+	}
+
+	baseKey, normalized, err := newEmbeddingArtifactKey(base)
+	require.NoError(t, err)
+	assert.Equal(t, "alpha\nbeta", normalized)
+	assert.Equal(t, "embedding.vector", baseKey.Stage)
+	assert.Equal(t, uint16(1), baseKey.KeyVersion)
+
+	stable := base
+	stable.text = "alpha\nbeta"
+	stableKey, stableText, err := newEmbeddingArtifactKey(stable)
+	require.NoError(t, err)
+	assert.Equal(t, "alpha\nbeta", stableText)
+	assert.Equal(t, baseKey, stableKey)
+
+	tests := []struct {
+		name   string
+		mutate func(*embeddingArtifactKeyRequest)
+	}{
+		{name: "tenant", mutate: func(r *embeddingArtifactKeyRequest) { r.tenantID++ }},
+		{name: "model ID", mutate: func(r *embeddingArtifactKeyRequest) { r.modelID = "model-2" }},
+		{name: "model name", mutate: func(r *embeddingArtifactKeyRequest) { r.modelName = "other" }},
+		{name: "model revision", mutate: func(r *embeddingArtifactKeyRequest) { r.modelRevision = "revision-2" }},
+		{name: "dimensions", mutate: func(r *embeddingArtifactKeyRequest) { r.dimensions++ }},
+		{name: "normalizer", mutate: func(r *embeddingArtifactKeyRequest) { r.normalizationVersion = "embedding-text-v2" }},
+		{name: "text", mutate: func(r *embeddingArtifactKeyRequest) { r.text = "other" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changed := base
+			tt.mutate(&changed)
+			key, _, err := newEmbeddingArtifactKey(changed)
+			require.NoError(t, err)
+			assert.NotEqual(t, baseKey, key)
+		})
+	}
+}
+
+func TestNewEmbeddingArtifactKeyRejectsMissingModelRevision(t *testing.T) {
+	_, _, err := newEmbeddingArtifactKey(embeddingArtifactKeyRequest{
+		tenantID:             7,
+		modelID:              "model-1",
+		modelName:            "text-embedding",
+		dimensions:           2,
+		normalizationVersion: embeddingArtifactNormalizationVersion,
+		text:                 "text",
+	})
+	assert.Error(t, err)
+}
+
+func TestEmbeddingVectorCodecRoundTripAndRejectsInvalidPayload(t *testing.T) {
+	encoded, err := encodeEmbeddingVector([]float32{1.25, -2.5, 0})
+	require.NoError(t, err)
+	decoded, err := decodeEmbeddingVector(encoded, 3)
+	require.NoError(t, err)
+	assert.Equal(t, []float32{1.25, -2.5, 0}, decoded)
+
+	_, err = decodeEmbeddingVector([]byte{99, 0, 0, 0, 0}, 0)
+	assert.Error(t, err)
+	_, err = decodeEmbeddingVector(encoded[:len(encoded)-1], 3)
+	assert.Error(t, err)
+	_, err = decodeEmbeddingVector(encoded, 2)
+	assert.Error(t, err)
+}
+
+func TestEmbeddingArtifactBatchPartialHitsDeduplicatesMissesAndRestoresOrder(t *testing.T) {
+	store := newEmbeddingArtifactFakeStore()
+	inner := &embeddingArtifactFakeEmbedder{
+		modelID: "model-1", modelName: "text-embedding", dimensions: 2,
+		batchResults: [][]float32{{2, 20}, {3, 30}},
+	}
+	wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+
+	hitKey, _, err := newEmbeddingArtifactKey(embeddingArtifactKeyRequest{
+		tenantID: 7, modelID: "model-1", modelName: "text-embedding", modelRevision: "revision-1",
+		dimensions: 2, normalizationVersion: embeddingArtifactNormalizationVersion, text: "hit",
+	})
+	require.NoError(t, err)
+	store.values[hitKey], err = encodeEmbeddingVector([]float32{1, 10})
+	require.NoError(t, err)
+
+	got, err := wrapped.BatchEmbed(documentEmbeddingContext(), []string{
+		" hit ", "miss\r\none", "miss\r\none", "miss two", "hit",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, [][]float32{{1, 10}, {2, 20}, {2, 20}, {3, 30}, {1, 10}}, got)
+	assert.Equal(t, [][]string{{"miss\none", "miss two"}}, inner.batchCalls)
+	assert.Equal(t, 2, store.putCalls)
+}
+
+func TestEmbeddingArtifactBatchUsesBulkStoreOperations(t *testing.T) {
+	store := newEmbeddingArtifactBatchFakeStore()
+	inner := &embeddingArtifactFakeEmbedder{
+		modelID: "model-1", modelName: "text-embedding", dimensions: 2,
+		batchResults: [][]float32{{2, 20}, {3, 30}},
+	}
+	wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+
+	hitKey, _, err := newEmbeddingArtifactKey(embeddingArtifactKeyRequest{
+		tenantID: 7, modelID: "model-1", modelName: "text-embedding", modelRevision: "revision-1",
+		dimensions: 2, normalizationVersion: embeddingArtifactNormalizationVersion, text: "hit",
+	})
+	require.NoError(t, err)
+	store.values[hitKey], err = encodeEmbeddingVector([]float32{1, 10})
+	require.NoError(t, err)
+
+	got, err := wrapped.BatchEmbed(documentEmbeddingContext(), []string{
+		"hit", "miss one", "miss one", "miss two",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, [][]float32{{1, 10}, {2, 20}, {2, 20}, {3, 30}}, got)
+	assert.Equal(t, 1, store.getManyCalls)
+	assert.Equal(t, 1, store.putManyCalls)
+	assert.Zero(t, store.getCalls)
+	assert.Zero(t, store.putCalls)
+}
+
+func TestEmbeddingArtifactBatchHandlesEmptyInput(t *testing.T) {
+	store := newEmbeddingArtifactFakeStore()
+	inner := &embeddingArtifactFakeEmbedder{dimensions: 2}
+	wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+
+	got, err := wrapped.BatchEmbed(documentEmbeddingContext(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+	assert.Empty(t, inner.batchCalls)
+	assert.Zero(t, store.getCalls)
+}
+
+func TestEmbeddingArtifactBatchRejectsWrongProviderCountWithoutStorage(t *testing.T) {
+	store := newEmbeddingArtifactFakeStore()
+	inner := &embeddingArtifactFakeEmbedder{dimensions: 2, batchResults: [][]float32{{1, 2}}}
+	wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+
+	_, err := wrapped.BatchEmbed(documentEmbeddingContext(), []string{"one", "two"})
+	assert.ErrorContains(t, err, "returned 1 embeddings for 2 inputs")
+	assert.Zero(t, store.putCalls)
+}
+
+func TestEmbeddingArtifactUnknownDimensionsBypassesCache(t *testing.T) {
+	store := newEmbeddingArtifactFakeStore()
+	inner := &embeddingArtifactFakeEmbedder{
+		modelID: "model-1", modelName: "text-embedding", dimensions: 0,
+		batchResults: [][]float32{{1, 2}},
+	}
+	wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+
+	_, err := wrapped.BatchEmbed(documentEmbeddingContext(), []string{"text"})
+	require.NoError(t, err)
+	_, err = wrapped.BatchEmbed(documentEmbeddingContext(), []string{"text"})
+	require.NoError(t, err)
+	assert.Len(t, inner.batchCalls, 2)
+	assert.Zero(t, store.getCalls)
+	assert.Zero(t, store.putCalls)
+}
+
+func TestEmbeddingArtifactRejectsNonFiniteVectorWithoutStorage(t *testing.T) {
+	for _, value := range []float32{float32(math.NaN()), float32(math.Inf(1)), float32(math.Inf(-1))} {
+		store := newEmbeddingArtifactFakeStore()
+		inner := &embeddingArtifactFakeEmbedder{dimensions: 1, batchResults: [][]float32{{value}}}
+		wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+
+		_, err := wrapped.BatchEmbed(documentEmbeddingContext(), []string{"text"})
+		assert.ErrorContains(t, err, "non-finite")
+		assert.Zero(t, store.putCalls)
+	}
+}
+
+func TestEmbeddingArtifactBatchProviderAndStoreErrorsPropagate(t *testing.T) {
+	t.Run("provider error is not stored", func(t *testing.T) {
+		store := newEmbeddingArtifactFakeStore()
+		providerErr := errors.New("provider unavailable")
+		inner := &embeddingArtifactFakeEmbedder{dimensions: 2, err: providerErr}
+		wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+
+		_, err := wrapped.BatchEmbed(documentEmbeddingContext(), []string{"one"})
+		assert.ErrorIs(t, err, providerErr)
+		assert.Zero(t, store.putCalls)
+	})
+
+	t.Run("get error", func(t *testing.T) {
+		storeErr := errors.New("get failed")
+		store := newEmbeddingArtifactFakeStore()
+		store.getErr = storeErr
+		inner := &embeddingArtifactFakeEmbedder{dimensions: 2}
+		wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+
+		_, err := wrapped.BatchEmbed(documentEmbeddingContext(), []string{"one"})
+		assert.ErrorIs(t, err, storeErr)
+		assert.Empty(t, inner.batchCalls)
+	})
+
+	t.Run("put error", func(t *testing.T) {
+		storeErr := errors.New("put failed")
+		store := newEmbeddingArtifactFakeStore()
+		store.putErr = storeErr
+		inner := &embeddingArtifactFakeEmbedder{dimensions: 2, batchResults: [][]float32{{1, 2}}}
+		wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+
+		_, err := wrapped.BatchEmbed(documentEmbeddingContext(), []string{"one"})
+		assert.ErrorIs(t, err, storeErr)
+	})
+}
+
+func TestEmbeddingArtifactBatchUsesPutIfAbsentWinner(t *testing.T) {
+	store := newEmbeddingArtifactFakeStore()
+	winner, err := encodeEmbeddingVector([]float32{9, 9})
+	require.NoError(t, err)
+	store.putCanonical = winner
+	inner := &embeddingArtifactFakeEmbedder{dimensions: 2, batchResults: [][]float32{{1, 2}}}
+	wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+
+	got, err := wrapped.BatchEmbed(documentEmbeddingContext(), []string{"one"})
+	require.NoError(t, err)
+	assert.Equal(t, [][]float32{{9, 9}}, got)
+}
+
+func TestEmbeddingArtifactRejectsNonFinitePutIfAbsentWinner(t *testing.T) {
+	store := newEmbeddingArtifactFakeStore()
+	winner, err := encodeEmbeddingVector([]float32{float32(math.NaN())})
+	require.NoError(t, err)
+	store.putCanonical = winner
+	inner := &embeddingArtifactFakeEmbedder{dimensions: 1, batchResults: [][]float32{{1}}}
+	wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+
+	_, err = wrapped.BatchEmbed(documentEmbeddingContext(), []string{"one"})
+	assert.ErrorContains(t, err, "non-finite")
+}
+
+func TestEmbeddingArtifactEmbedReusesDocumentsAndBypassesUnmarkedInputs(t *testing.T) {
+	store := newEmbeddingArtifactFakeStore()
+	inner := &embeddingArtifactFakeEmbedder{dimensions: 2, batchResults: [][]float32{{1, 2}}}
+	wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+
+	first, err := wrapped.Embed(documentEmbeddingContext(), " doc\r\ntext ")
+	require.NoError(t, err)
+	second, err := wrapped.Embed(documentEmbeddingContext(), "doc\ntext")
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	assert.Equal(t, []string{"doc\ntext"}, inner.embedCalls)
+
+	_, err = wrapped.Embed(context.Background(), " doc\r\ntext ")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"doc\ntext", " doc\r\ntext "}, inner.embedCalls)
+}
+
+func TestEmbeddingArtifactBypassesQueryInputs(t *testing.T) {
+	store := newEmbeddingArtifactFakeStore()
+	inner := &embeddingArtifactFakeEmbedder{dimensions: 2, batchResults: [][]float32{{1, 2}}}
+	wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+	ctx := context.WithValue(documentEmbeddingContext(), types.EmbedQueryContextKey, true)
+
+	_, err := wrapped.Embed(ctx, "query")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"query"}, inner.embedCalls)
+	assert.Zero(t, store.getCalls)
+	assert.Zero(t, store.putCalls)
+}
+
+func TestEmbeddingArtifactBatchWithPoolDelegatesMissesToInnerWithoutRecursion(t *testing.T) {
+	store := newEmbeddingArtifactFakeStore()
+	inner := &embeddingArtifactFakeEmbedder{
+		dimensions: 2, batchResults: [][]float32{{1, 2}, {3, 4}},
+	}
+	wrapped := newEmbeddingArtifactEmbedder(inner, store, 7, "revision-1")
+
+	got, err := wrapped.BatchEmbedWithPool(documentEmbeddingContext(), wrapped, []string{" one ", "two"})
+	require.NoError(t, err)
+	assert.Equal(t, [][]float32{{1, 2}, {3, 4}}, got)
+	assert.Equal(t, 1, inner.poolCalls)
+	assert.True(t, reflect.ValueOf(inner.poolModel).Pointer() == reflect.ValueOf(inner).Pointer())
+	assert.Equal(t, [][]string{{"one", "two"}}, inner.batchCalls)
+
+	_, err = wrapped.BatchEmbedWithPool(context.Background(), wrapped, []string{" query "})
+	require.NoError(t, err)
+	assert.Equal(t, 2, inner.poolCalls)
+	assert.True(t, reflect.ValueOf(inner.poolModel).Pointer() == reflect.ValueOf(inner).Pointer())
+}
+
+func TestEmbeddingArtifactPreservesModelMetadataAndNilStoreDelegates(t *testing.T) {
+	inner := &embeddingArtifactFakeEmbedder{
+		modelID: "model-1", modelName: "text-embedding", dimensions: 2,
+		batchResults: [][]float32{{1, 2}},
+	}
+	wrapped := newEmbeddingArtifactEmbedder(inner, nil, 7, "revision-1")
+
+	assert.Equal(t, inner.modelID, wrapped.GetModelID())
+	assert.Equal(t, inner.modelName, wrapped.GetModelName())
+	assert.Equal(t, inner.dimensions, wrapped.GetDimensions())
+	_, err := wrapped.BatchEmbed(documentEmbeddingContext(), []string{" original\r\n "})
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{{" original\r\n "}}, inner.batchCalls)
+}

--- a/internal/application/service/embedding_artifact_integration_test.go
+++ b/internal/application/service/embedding_artifact_integration_test.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/application/service/retriever"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/require"
+)
+
+type embeddingArtifactIndexRepository struct {
+	interfaces.RetrieveEngineRepository
+}
+
+func (r *embeddingArtifactIndexRepository) BatchSave(
+	context.Context,
+	[]*types.IndexInfo,
+	map[string]any,
+) error {
+	return nil
+}
+
+func TestEmbeddingArtifactBatchIndexReusesTextAcrossKnowledgeItems(t *testing.T) {
+	store := newEmbeddingArtifactFakeStore()
+	provider := &embeddingArtifactFakeEmbedder{
+		modelID: "model-1", modelName: "text-embedding", dimensions: 2,
+		batchResults: [][]float32{{1, 2}},
+	}
+	embedder := newEmbeddingArtifactEmbedder(provider, store, 7, "revision-1")
+	engine := retriever.NewKVHybridRetrieveEngine(
+		&embeddingArtifactIndexRepository{},
+		types.PostgresRetrieverEngineType,
+	)
+
+	for _, info := range []*types.IndexInfo{
+		{SourceID: "chunk-1", ChunkID: "chunk-1", KnowledgeID: "knowledge-1", Content: " shared\r\ntext "},
+		{SourceID: "chunk-2", ChunkID: "chunk-2", KnowledgeID: "knowledge-2", Content: "shared\ntext"},
+	} {
+		err := engine.BatchIndex(
+			context.Background(),
+			embedder,
+			[]*types.IndexInfo{info},
+			[]types.RetrieverType{types.VectorRetrieverType},
+		)
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, [][]string{{"shared\ntext"}}, provider.batchCalls)
+	require.Equal(t, 1, store.putCalls)
+}

--- a/internal/application/service/embedding_artifact_model_test.go
+++ b/internal/application/service/embedding_artifact_model_test.go
@@ -1,0 +1,141 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	secutils "github.com/Tencent/WeKnora/internal/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmbeddingModelRevisionTracksEffectiveConfigWithoutSecrets(t *testing.T) {
+	base := &types.Model{
+		ID: "embedding-1", Name: "text-embedding", Source: types.ModelSourceRemote,
+		UpdatedAt: time.Date(2026, 7, 16, 10, 30, 0, 0, time.UTC),
+		Parameters: types.ModelParameters{
+			BaseURL:       "https://user:password@example.com/v1?token=secret#private",
+			APIKey:        "first-secret",
+			Provider:      "openai",
+			CustomHeaders: map[string]string{"Authorization": "secret"},
+			EmbeddingParameters: types.EmbeddingParameters{
+				Dimension: 1536, TruncatePromptTokens: 512, SupportsDimensionOverride: true,
+			},
+		},
+	}
+	baseRevision, err := embeddingModelRevision(base)
+	require.NoError(t, err)
+
+	credentialsChanged := *base
+	credentialsChanged.Parameters = base.Parameters
+	credentialsChanged.Parameters.APIKey = "second-secret"
+	credentialsChanged.Parameters.AppSecret = "other-secret"
+	credentialsChanged.Parameters.CustomHeaders = map[string]string{"Authorization": "other"}
+	credentialsChanged.Parameters.ExtraConfig = map[string]string{"api_secret": "not-an-identity"}
+	credentialsChanged.Parameters.BaseURL = "https://other:credentials@example.com/v1?key=other#fragment"
+	credentialsRevision, err := embeddingModelRevision(&credentialsChanged)
+	require.NoError(t, err)
+	require.Equal(t, baseRevision, credentialsRevision)
+
+	for _, tt := range []struct {
+		name   string
+		mutate func(*types.Model)
+	}{
+		{name: "source", mutate: func(m *types.Model) { m.Source = types.ModelSourceLocal }},
+		{name: "provider", mutate: func(m *types.Model) { m.Parameters.Provider = "nvidia" }},
+		{name: "endpoint", mutate: func(m *types.Model) { m.Parameters.BaseURL = "https://example.com/v2" }},
+		{name: "dimensions", mutate: func(m *types.Model) { m.Parameters.EmbeddingParameters.Dimension = 768 }},
+		{name: "truncate", mutate: func(m *types.Model) { m.Parameters.EmbeddingParameters.TruncatePromptTokens = 256 }},
+		{name: "dimension policy", mutate: func(m *types.Model) {
+			m.Parameters.EmbeddingParameters.SupportsDimensionOverride = false
+		}},
+		{name: "API version", mutate: func(m *types.Model) {
+			m.Parameters.ExtraConfig = map[string]string{"api_version": "2027-01-01"}
+		}},
+		{name: "remote model name", mutate: func(m *types.Model) {
+			m.Parameters.ExtraConfig = map[string]string{"remote_model_name": "other-model"}
+		}},
+		{name: "updated at", mutate: func(m *types.Model) { m.UpdatedAt = m.UpdatedAt.Add(time.Second) }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			changed := *base
+			changed.Parameters = base.Parameters
+			tt.mutate(&changed)
+			revision, err := embeddingModelRevision(&changed)
+			require.NoError(t, err)
+			require.NotEqual(t, baseRevision, revision)
+		})
+	}
+}
+
+func TestEmbeddingModelRevisionPreservesRuntimeAPIVersionWhitespace(t *testing.T) {
+	model := &types.Model{
+		ID: "embedding-1", Name: "text-embedding", Source: types.ModelSourceRemote,
+		UpdatedAt:  time.Date(2026, 7, 16, 10, 30, 0, 0, time.UTC),
+		Parameters: types.ModelParameters{ExtraConfig: map[string]string{"api_version": "2024-10-21"}},
+	}
+	plain, err := embeddingModelRevision(model)
+	require.NoError(t, err)
+	model.Parameters.ExtraConfig["api_version"] = " 2024-10-21 "
+	spaced, err := embeddingModelRevision(model)
+	require.NoError(t, err)
+	require.NotEqual(t, plain, spaced)
+}
+
+type embeddingArtifactModelRepository struct {
+	interfaces.ModelRepository
+	model     *types.Model
+	tenantIDs []uint64
+}
+
+func (r *embeddingArtifactModelRepository) GetByID(
+	_ context.Context,
+	tenantID uint64,
+	_ string,
+) (*types.Model, error) {
+	r.tenantIDs = append(r.tenantIDs, tenantID)
+	return r.model, nil
+}
+
+func TestModelServiceWrapsEmbeddingArtifactsWithEffectiveTenantAndRevision(t *testing.T) {
+	t.Setenv("SSRF_WHITELIST", "127.0.0.1")
+	secutils.ResetSSRFWhitelistForTest()
+	t.Cleanup(secutils.ResetSSRFWhitelistForTest)
+
+	updatedAt := time.Date(2026, 7, 16, 10, 30, 0, 0, time.UTC)
+	repo := &embeddingArtifactModelRepository{model: &types.Model{
+		ID:       "embedding-1",
+		TenantID: types.DefaultBuiltinModelTenantID,
+		Name:     "text-embedding",
+		Type:     types.ModelTypeEmbedding,
+		Source:   types.ModelSourceRemote,
+		Status:   types.ModelStatusActive,
+		Parameters: types.ModelParameters{
+			BaseURL:             "http://127.0.0.1/v1",
+			Provider:            "openai",
+			EmbeddingParameters: types.EmbeddingParameters{Dimension: 2},
+		},
+		UpdatedAt: updatedAt,
+	}}
+	store := newEmbeddingArtifactFakeStore()
+	svc := NewModelService(repo, nil, nil, nil, nil, nil, store)
+
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(7))
+	local, err := svc.GetEmbeddingModel(ctx, repo.model.ID)
+	require.NoError(t, err)
+	localCache, ok := local.(*embeddingArtifactEmbedder)
+	require.True(t, ok)
+	require.Equal(t, uint64(7), localCache.tenantID)
+	expectedRevision, err := embeddingModelRevision(repo.model)
+	require.NoError(t, err)
+	require.Equal(t, expectedRevision, localCache.modelRevision)
+
+	shared, err := svc.GetEmbeddingModelForTenant(ctx, repo.model.ID, 9)
+	require.NoError(t, err)
+	sharedCache, ok := shared.(*embeddingArtifactEmbedder)
+	require.True(t, ok)
+	require.Equal(t, uint64(9), sharedCache.tenantID)
+	require.Equal(t, []uint64{7, 9}, repo.tenantIDs)
+}

--- a/internal/application/service/extract.go
+++ b/internal/application/service/extract.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/Tencent/WeKnora/internal/agent/tools"
-	chatpipeline "github.com/Tencent/WeKnora/internal/application/service/chat_pipeline"
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
 	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -164,6 +163,7 @@ type ChunkExtractService struct {
 	knowledgeRepo     interfaces.KnowledgeRepository
 	chunkRepo         interfaces.ChunkRepository
 	graphEngine       interfaces.RetrieveGraphRepository
+	artifactStore     interfaces.ProcessingArtifactStore
 	// spanTracker records this graph-extract task's subspan under the
 	// parent attempt's postprocess stage so the trace viewer shows real
 	// per-chunk graph extraction time rather than the upstream's enqueue.
@@ -178,6 +178,7 @@ func NewChunkExtractService(
 	knowledgeRepo interfaces.KnowledgeRepository,
 	chunkRepo interfaces.ChunkRepository,
 	graphEngine interfaces.RetrieveGraphRepository,
+	artifactStore interfaces.ProcessingArtifactStore,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
 	return &ChunkExtractService{
@@ -187,6 +188,7 @@ func NewChunkExtractService(
 		knowledgeRepo:     knowledgeRepo,
 		chunkRepo:         chunkRepo,
 		graphEngine:       graphEngine,
+		artifactStore:     artifactStore,
 		spanTracker:       spanTracker,
 	}
 }
@@ -329,12 +331,42 @@ func (s *ChunkExtractService) Handle(ctx context.Context, t *asynq.Task) error {
 			},
 		},
 	}
-	extractor := chatpipeline.NewExtractor(chatModel, template)
-	graph, err := extractor.Extract(ctx, chunk.Content)
+	artifactStore := s.artifactStore
+	modelRevision := ""
+	if artifactStore != nil {
+		model, modelErr := s.modelService.GetModelByID(ctx, p.ModelID)
+		if modelErr != nil {
+			logger.Warnf(ctx, "graph artifact cache disabled for model %s: failed to load model revision: %v",
+				p.ModelID, modelErr)
+			artifactStore = nil
+		} else if modelRevision, modelErr = chatArtifactModelRevision(model); modelErr != nil {
+			logger.Warnf(ctx, "graph artifact cache disabled for model %s: %v", p.ModelID, modelErr)
+			artifactStore = nil
+		}
+	}
+	graph, cacheHit, providerCalled, err := extractGraphArtifact(
+		ctx,
+		artifactStore,
+		p.TenantID,
+		chunk.ID,
+		chatModel,
+		modelRevision,
+		template,
+		chunk.Content,
+	)
 	if err != nil {
 		handleErr = err
 		return err
 	}
+	graphOut["cache_hit"] = cacheHit
+	if artifactStore == nil {
+		graphOut["cache_status"] = "bypass"
+	} else if cacheHit {
+		graphOut["cache_status"] = "hit"
+	} else {
+		graphOut["cache_status"] = "miss"
+	}
+	graphOut["provider_called"] = providerCalled
 
 	chunk, err = s.chunkRepo.GetChunkByID(ctx, p.TenantID, p.ChunkID)
 	if err != nil {
@@ -343,12 +375,11 @@ func (s *ChunkExtractService) Handle(ctx context.Context, t *asynq.Task) error {
 		return nil
 	}
 
-	for _, node := range graph.Node {
-		node.Chunks = []string{chunk.ID}
-	}
-	if err = s.graphEngine.AddGraph(ctx,
+	if err = s.graphEngine.ReplaceGraphChunk(ctx,
 		types.NameSpace{KnowledgeBase: chunk.KnowledgeBaseID, Knowledge: chunk.KnowledgeID},
-		[]*types.GraphData{graph},
+		chunk.ID,
+		p.Attempt,
+		graph,
 	); err != nil {
 		logger.Errorf(ctx, "failed to add graph: %v", err)
 		handleErr = err

--- a/internal/application/service/extract_graph_cache_test.go
+++ b/internal/application/service/extract_graph_cache_test.go
@@ -1,0 +1,220 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type graphCacheModelService struct {
+	interfaces.ModelService
+	chatModel *chatArtifactFakeModel
+	model     *types.Model
+}
+
+func (s *graphCacheModelService) GetChatModel(context.Context, string) (chat.Chat, error) {
+	return s.chatModel, nil
+}
+
+func (s *graphCacheModelService) GetModelByID(context.Context, string) (*types.Model, error) {
+	return s.model, nil
+}
+
+type graphCacheChunkRepository struct {
+	interfaces.ChunkRepository
+	chunk     *types.Chunk
+	calls     int
+	failAfter int
+	err       error
+}
+
+func (r *graphCacheChunkRepository) GetChunkByID(context.Context, uint64, string) (*types.Chunk, error) {
+	r.calls++
+	if r.failAfter > 0 && r.calls > r.failAfter {
+		return nil, r.err
+	}
+	copy := *r.chunk
+	return &copy, nil
+}
+
+type graphCacheKnowledgeBaseRepository struct {
+	interfaces.KnowledgeBaseRepository
+	kb *types.KnowledgeBase
+}
+
+func (r *graphCacheKnowledgeBaseRepository) GetKnowledgeBaseByID(
+	context.Context,
+	string,
+) (*types.KnowledgeBase, error) {
+	return r.kb, nil
+}
+
+type graphCacheRepository struct {
+	interfaces.RetrieveGraphRepository
+	graphs   []*types.GraphData
+	attempts []int
+}
+
+func (r *graphCacheRepository) AddGraph(
+	_ context.Context,
+	_ types.NameSpace,
+	graphs []*types.GraphData,
+) error {
+	return errors.New("legacy AddGraph must not be used by the chunk extraction worker")
+}
+
+func (r *graphCacheRepository) ReplaceGraphChunk(
+	_ context.Context,
+	_ types.NameSpace,
+	_ string,
+	attempt int,
+	graph *types.GraphData,
+) error {
+	r.attempts = append(r.attempts, attempt)
+	r.graphs = append(r.graphs, graph)
+	return nil
+}
+
+func TestChunkExtractServiceReusesGraphArtifact(t *testing.T) {
+	service, modelService, chunkRepo, graphRepo, _ := newGraphCacheChunkExtractService()
+	task := newGraphCacheExtractTask(t)
+
+	require.NoError(t, service.Handle(context.Background(), task))
+	require.NoError(t, service.Handle(context.Background(), task))
+
+	assert.Equal(t, 1, modelService.chatModel.calls)
+	assert.Equal(t, 4, chunkRepo.calls)
+	require.Len(t, graphRepo.graphs, 2)
+	assert.Equal(t, []int{3, 3}, graphRepo.attempts)
+	for _, graph := range graphRepo.graphs {
+		require.Len(t, graph.Node, 2)
+		require.Len(t, graph.Relation, 1)
+		assert.Equal(t, []string{"chunk-1"}, graph.Node[0].Chunks)
+		assert.Equal(t, []string{"chunk-1"}, graph.Relation[0].Chunks)
+	}
+}
+
+func TestChunkExtractServiceBypassesCacheForUnsafeModelRevision(t *testing.T) {
+	service, modelService, _, graphRepo, store := newGraphCacheChunkExtractService()
+	modelService.model.UpdatedAt = time.Time{}
+	task := newGraphCacheExtractTask(t)
+
+	require.NoError(t, service.Handle(context.Background(), task))
+	require.NoError(t, service.Handle(context.Background(), task))
+
+	assert.Equal(t, 2, modelService.chatModel.calls)
+	assert.Zero(t, store.getCalls)
+	assert.Zero(t, store.putCalls)
+	assert.Len(t, graphRepo.graphs, 2)
+}
+
+func TestChunkExtractServiceStoreFailureDoesNotWriteGraph(t *testing.T) {
+	service, modelService, _, graphRepo, store := newGraphCacheChunkExtractService()
+	want := errors.New("store unavailable")
+	store.getErr = want
+
+	err := service.Handle(context.Background(), newGraphCacheExtractTask(t))
+
+	require.ErrorIs(t, err, want)
+	assert.Zero(t, modelService.chatModel.calls)
+	assert.Empty(t, graphRepo.graphs)
+}
+
+func TestChunkExtractServiceDoesNotWriteGraphAfterChunkDisappears(t *testing.T) {
+	service, modelService, chunkRepo, graphRepo, store := newGraphCacheChunkExtractService()
+	chunkRepo.failAfter = 1
+	chunkRepo.err = sql.ErrNoRows
+
+	err := service.Handle(context.Background(), newGraphCacheExtractTask(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, modelService.chatModel.calls)
+	assert.Equal(t, 1, store.putCalls)
+	assert.Empty(t, graphRepo.graphs)
+}
+
+func TestNewChunkExtractServiceInjectsArtifactStore(t *testing.T) {
+	store := newChatArtifactFakeStore()
+
+	handler := NewChunkExtractService(
+		&config.Config{ExtractManager: &config.ExtractManagerConfig{}},
+		nil, nil, nil, nil, nil, store, nil,
+	)
+
+	service, ok := handler.(*ChunkExtractService)
+	require.True(t, ok)
+	assert.Same(t, store, service.artifactStore)
+}
+
+func newGraphCacheChunkExtractService() (
+	*ChunkExtractService,
+	*graphCacheModelService,
+	*graphCacheChunkRepository,
+	*graphCacheRepository,
+	*chatArtifactFakeStore,
+) {
+	modelService := &graphCacheModelService{
+		chatModel: &chatArtifactFakeModel{
+			modelID:   "model-1",
+			modelName: "chat",
+			response: &types.ChatResponse{Content: `[
+				{"entity":"Alpha","entity_attributes":["person"]},
+				{"entity":"Beta","entity_attributes":["person"]},
+				{"entity1":"Alpha","entity2":"Beta","relation":"knows"}
+			]`},
+		},
+		model: &types.Model{
+			ID:        "model-1",
+			Name:      "chat",
+			UpdatedAt: time.Unix(100, 0),
+		},
+	}
+	chunkRepo := &graphCacheChunkRepository{chunk: &types.Chunk{
+		ID:              "chunk-1",
+		TenantID:        7,
+		KnowledgeID:     "knowledge-1",
+		KnowledgeBaseID: "kb-1",
+		Content:         "same content",
+	}}
+	graphRepo := &graphCacheRepository{}
+	store := newChatArtifactFakeStore()
+	return &ChunkExtractService{
+		template: &types.PromptTemplateStructured{
+			Description: "Extract entities using these relation tags: %s",
+		},
+		modelService: modelService,
+		knowledgeBaseRepo: &graphCacheKnowledgeBaseRepository{kb: &types.KnowledgeBase{
+			ID: "kb-1",
+			ExtractConfig: &types.ExtractConfig{
+				Enabled: true,
+				Tags:    []string{"knows"},
+			},
+		}},
+		chunkRepo:     chunkRepo,
+		graphEngine:   graphRepo,
+		artifactStore: store,
+	}, modelService, chunkRepo, graphRepo, store
+}
+
+func newGraphCacheExtractTask(t *testing.T) *asynq.Task {
+	t.Helper()
+	payload, err := json.Marshal(types.ExtractChunkPayload{
+		TenantID: 7,
+		ChunkID:  "chunk-1",
+		ModelID:  "model-1",
+		Attempt:  3,
+	})
+	require.NoError(t, err)
+	return asynq.NewTask(types.TypeChunkExtract, payload)
+}

--- a/internal/application/service/file/backend_scoped.go
+++ b/internal/application/service/file/backend_scoped.go
@@ -26,6 +26,10 @@ func NewBackendScopedFileService(backendID string, inner interfaces.FileService)
 	return &backendScopedFileService{backendID: backendID, inner: inner}
 }
 
+func (s *backendScopedFileService) StorageBackendID() string {
+	return s.backendID
+}
+
 func (s *backendScopedFileService) unwrap(path string) (string, error) {
 	id, inner, ok := types.ParseStorageBackendPath(path)
 	if !ok {

--- a/internal/application/service/file/cos.go
+++ b/internal/application/service/file/cos.go
@@ -132,9 +132,9 @@ func (s *cosFileService) GetFile(ctx context.Context, filePathUrl string) (io.Re
 	}
 	resp, err := s.client.Object.Get(ctx, objectName, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get file from COS: %w", err)
+		return nil, fmt.Errorf("failed to get file from COS: %w", normalizeObjectReadError(err))
 	}
-	return resp.Body, nil
+	return normalizeObjectReadCloser(resp.Body), nil
 }
 
 // DeleteFile removes a file from COS storage

--- a/internal/application/service/file/dummy.go
+++ b/internal/application/service/file/dummy.go
@@ -1,19 +1,23 @@
 package file
 
 import (
+	"bytes"
 	"context"
-	"errors"
 	"io"
+	"io/fs"
 	"mime/multipart"
+	"sync"
 
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"github.com/google/uuid"
 )
 
-// DummyFileService is a no-op implementation of the FileService interface
-// used for testing or when file storage is not required
-type DummyFileService struct{}
+// DummyFileService keeps byte objects in memory for tests and no-storage modes.
+type DummyFileService struct {
+	mu      sync.Mutex
+	objects map[string][]byte
+}
 
 // CheckConnectivity always succeeds for the dummy service.
 func (s *DummyFileService) CheckConnectivity(ctx context.Context) error {
@@ -22,7 +26,7 @@ func (s *DummyFileService) CheckConnectivity(ctx context.Context) error {
 
 // NewDummyFileService creates a new instance of DummyFileService
 func NewDummyFileService() interfaces.FileService {
-	return &DummyFileService{}
+	return &DummyFileService{objects: make(map[string][]byte)}
 }
 
 // SaveFile pretends to save a file but just returns a random UUID
@@ -33,19 +37,34 @@ func (s *DummyFileService) SaveFile(ctx context.Context,
 	return uuid.New().String(), nil
 }
 
-// GetFile always returns an error as dummy service doesn't store files
+// GetFile returns a cloned view of a byte object saved by SaveBytes.
 func (s *DummyFileService) GetFile(ctx context.Context, filePath string) (io.ReadCloser, error) {
-	return nil, errors.New("not implemented")
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, ok := s.objects[filePath]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	return io.NopCloser(bytes.NewReader(bytes.Clone(data))), nil
 }
 
-// DeleteFile is a no-op operation that always succeeds
 func (s *DummyFileService) DeleteFile(ctx context.Context, filePath string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.objects, filePath)
 	return nil
 }
 
-// SaveBytes pretends to save bytes but just returns a random UUID
+// SaveBytes creates a uniquely owned in-memory object.
 func (s *DummyFileService) SaveBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error) {
-	return uuid.New().String(), nil
+	path := "dummy://" + uuid.New().String()
+	s.mu.Lock()
+	if s.objects == nil {
+		s.objects = make(map[string][]byte)
+	}
+	s.objects[path] = bytes.Clone(data)
+	s.mu.Unlock()
+	return path, nil
 }
 
 // CopyFile is a no-op for the dummy service: it logs a warning and returns the

--- a/internal/application/service/file/factory.go
+++ b/internal/application/service/file/factory.go
@@ -11,6 +11,15 @@ import (
 	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
 
+type obsStorageConfig struct {
+	endpoint   string
+	region     string
+	accessKey  string
+	secretKey  string
+	bucketName string
+	pathPrefix string
+}
+
 // NewFileServiceFromStorageConfig builds a provider-specific FileService from tenant storage config.
 // provider can be empty; in that case it falls back to sec.DefaultProvider.
 // Returns the resolved provider name together with the service.
@@ -103,44 +112,18 @@ func NewFileServiceFromStorageConfig(
 		return svc, p, err
 
 	case "obs":
-		obsEndpoint, obsRegion, obsAccessKey := "", "", ""
-		obsSecretKey, obsBucketName, obsPathPrefix := "", "", ""
-		if sec != nil && sec.OBS != nil {
-			obsEndpoint = strings.TrimSpace(sec.OBS.Endpoint)
-			obsRegion = strings.TrimSpace(sec.OBS.Region)
-			obsAccessKey = strings.TrimSpace(sec.OBS.AccessKey)
-			obsSecretKey = strings.TrimSpace(sec.OBS.SecretKey)
-			obsBucketName = strings.TrimSpace(sec.OBS.BucketName)
-			obsPathPrefix = strings.TrimSpace(sec.OBS.PathPrefix)
+		config, err := resolveOBSStorageConfig(sec)
+		if err != nil {
+			return nil, p, err
 		}
-		if obsEndpoint == "" {
-			obsEndpoint = strings.TrimSpace(os.Getenv("OBS_ENDPOINT"))
-		}
-		if obsRegion == "" {
-			obsRegion = strings.TrimSpace(os.Getenv("OBS_REGION"))
-		}
-		if obsAccessKey == "" {
-			obsAccessKey = strings.TrimSpace(os.Getenv("OBS_ACCESS_KEY"))
-		}
-		if obsSecretKey == "" {
-			obsSecretKey = strings.TrimSpace(os.Getenv("OBS_SECRET_KEY"))
-		}
-		if obsBucketName == "" {
-			obsBucketName = strings.TrimSpace(os.Getenv("OBS_BUCKET_NAME"))
-		}
-		if obsPathPrefix == "" {
-			obsPathPrefix = strings.TrimSpace(os.Getenv("OBS_PATH_PREFIX"))
-		}
-		if obsPathPrefix == "" {
-			obsPathPrefix = "weknora/"
-		}
-		if obsEndpoint == "" || obsAccessKey == "" || obsSecretKey == "" || obsBucketName == "" {
-			return nil, p, fmt.Errorf("incomplete obs config")
-		}
-		if obsRegion == "" {
-			obsRegion = "cn-north-4"
-		}
-		svc, err := NewObsFileService(obsEndpoint, obsRegion, obsAccessKey, obsSecretKey, obsBucketName, obsPathPrefix)
+		svc, err := NewObsFileService(
+			config.endpoint,
+			config.region,
+			config.accessKey,
+			config.secretKey,
+			config.bucketName,
+			config.pathPrefix,
+		)
 		return svc, p, err
 
 	case "oss":
@@ -181,4 +164,46 @@ func NewFileServiceFromStorageConfig(
 	default:
 		return nil, p, fmt.Errorf("unsupported provider %q", p)
 	}
+}
+
+func resolveOBSStorageConfig(sec *types.StorageEngineConfig) (obsStorageConfig, error) {
+	var config obsStorageConfig
+	if sec != nil && sec.OBS != nil {
+		config = obsStorageConfig{
+			endpoint:   strings.TrimSpace(sec.OBS.Endpoint),
+			region:     strings.TrimSpace(sec.OBS.Region),
+			accessKey:  strings.TrimSpace(sec.OBS.AccessKey),
+			secretKey:  strings.TrimSpace(sec.OBS.SecretKey),
+			bucketName: strings.TrimSpace(sec.OBS.BucketName),
+			pathPrefix: strings.TrimSpace(sec.OBS.PathPrefix),
+		}
+	}
+	if config.endpoint == "" {
+		config.endpoint = strings.TrimSpace(os.Getenv("OBS_ENDPOINT"))
+	}
+	if config.region == "" {
+		config.region = strings.TrimSpace(os.Getenv("OBS_REGION"))
+	}
+	if config.accessKey == "" {
+		config.accessKey = strings.TrimSpace(os.Getenv("OBS_ACCESS_KEY"))
+	}
+	if config.secretKey == "" {
+		config.secretKey = strings.TrimSpace(os.Getenv("OBS_SECRET_KEY"))
+	}
+	if config.bucketName == "" {
+		config.bucketName = strings.TrimSpace(os.Getenv("OBS_BUCKET_NAME"))
+	}
+	if config.pathPrefix == "" {
+		config.pathPrefix = strings.TrimSpace(os.Getenv("OBS_PATH_PREFIX"))
+	}
+	if config.endpoint == "" || config.accessKey == "" || config.secretKey == "" || config.bucketName == "" {
+		return obsStorageConfig{}, fmt.Errorf("incomplete obs config")
+	}
+	if config.region == "" {
+		config.region = "cn-north-4"
+	}
+	if config.pathPrefix == "" {
+		config.pathPrefix = "weknora/"
+	}
+	return config, nil
 }

--- a/internal/application/service/file/factory_test.go
+++ b/internal/application/service/file/factory_test.go
@@ -1,0 +1,71 @@
+package file
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveOBSStorageConfigPrefersTenantConfig(t *testing.T) {
+	t.Setenv("OBS_ENDPOINT", "https://global.example.com")
+	t.Setenv("OBS_REGION", "global-region")
+	t.Setenv("OBS_ACCESS_KEY", "global-access-key")
+	t.Setenv("OBS_SECRET_KEY", "global-secret-key")
+	t.Setenv("OBS_BUCKET_NAME", "global-bucket")
+	t.Setenv("OBS_PATH_PREFIX", "global-prefix/")
+
+	config, err := resolveOBSStorageConfig(&types.StorageEngineConfig{
+		OBS: &types.OBSEngineConfig{
+			Endpoint:   "https://tenant.example.com",
+			Region:     "tenant-region",
+			AccessKey:  "tenant-access-key",
+			SecretKey:  "tenant-secret-key",
+			BucketName: "tenant-bucket",
+			PathPrefix: "tenant-prefix/",
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://tenant.example.com", config.endpoint)
+	assert.Equal(t, "tenant-region", config.region)
+	assert.Equal(t, "tenant-access-key", config.accessKey)
+	assert.Equal(t, "tenant-secret-key", config.secretKey)
+	assert.Equal(t, "tenant-bucket", config.bucketName)
+	assert.Equal(t, "tenant-prefix/", config.pathPrefix)
+}
+
+func TestResolveOBSStorageConfigFillsMissingTenantFieldsFromGlobalConfig(t *testing.T) {
+	t.Setenv("OBS_ENDPOINT", "https://global.example.com")
+	t.Setenv("OBS_REGION", "global-region")
+	t.Setenv("OBS_ACCESS_KEY", "global-access-key")
+	t.Setenv("OBS_SECRET_KEY", "global-secret-key")
+	t.Setenv("OBS_BUCKET_NAME", "global-bucket")
+
+	config, err := resolveOBSStorageConfig(&types.StorageEngineConfig{
+		OBS: &types.OBSEngineConfig{Endpoint: "https://tenant.example.com"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://tenant.example.com", config.endpoint)
+	assert.Equal(t, "global-region", config.region)
+	assert.Equal(t, "global-access-key", config.accessKey)
+	assert.Equal(t, "global-secret-key", config.secretKey)
+	assert.Equal(t, "global-bucket", config.bucketName)
+}
+
+func TestResolveOBSStorageConfigAppliesGlobalDefaultsWithoutTenantOBSConfig(t *testing.T) {
+	t.Setenv("OBS_ENDPOINT", "https://global.example.com")
+	t.Setenv("OBS_REGION", "")
+	t.Setenv("OBS_ACCESS_KEY", "global-access-key")
+	t.Setenv("OBS_SECRET_KEY", "global-secret-key")
+	t.Setenv("OBS_BUCKET_NAME", "global-bucket")
+	t.Setenv("OBS_PATH_PREFIX", "")
+
+	config, err := resolveOBSStorageConfig(nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "cn-north-4", config.region)
+	assert.Equal(t, "weknora/", config.pathPrefix)
+}

--- a/internal/application/service/file/ks3.go
+++ b/internal/application/service/file/ks3.go
@@ -224,10 +224,10 @@ func (s *ks3FileService) GetFile(ctx context.Context, filePath string) (io.ReadC
 		Key:    ks3aws.String(objectKey),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get file from KS3: %w", err)
+		return nil, fmt.Errorf("failed to get file from KS3: %w", normalizeObjectReadError(err))
 	}
 
-	return resp.Body, nil
+	return normalizeObjectReadCloser(resp.Body), nil
 }
 
 func (s *ks3FileService) DeleteFile(ctx context.Context, filePath string) error {

--- a/internal/application/service/file/local.go
+++ b/internal/application/service/file/local.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
+	"github.com/google/uuid"
 )
 
 // localFileService implements the FileService interface for local file system storage
@@ -231,14 +232,13 @@ func (s *localFileService) SaveBytes(ctx context.Context, data []byte, tenantID 
 		return "", fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	// Generate unique filename using timestamp
+	// A successful SaveBytes call must own a path no other call can reuse.
 	ext := filepath.Ext(safeName)
 	baseName := safeName[:len(safeName)-len(ext)]
-	uniqueFileName := fmt.Sprintf("%s_%d%s", baseName, time.Now().UnixNano(), ext)
+	uniqueFileName := fmt.Sprintf("%s_%s%s", baseName, uuid.New().String(), ext)
 	filePath := filepath.Join(dir, uniqueFileName)
 
-	// Write data to file
-	if err := os.WriteFile(filePath, data, 0o644); err != nil {
+	if err := writeNewLocalObject(filePath, data); err != nil {
 		logger.Errorf(ctx, "Failed to write file: %v", err)
 		return "", fmt.Errorf("failed to write file: %w", err)
 	}
@@ -246,6 +246,27 @@ func (s *localFileService) SaveBytes(ctx context.Context, data []byte, tenantID 
 	logger.Infof(ctx, "Bytes data saved successfully: %s", filePath)
 	relPath, _ := filepath.Rel(s.baseDir, filePath)
 	return localScheme + filepath.ToSlash(relPath), nil
+}
+
+func writeNewLocalObject(path string, data []byte) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return err
+	}
+	written, writeErr := file.Write(data)
+	if writeErr == nil && written != len(data) {
+		writeErr = io.ErrShortWrite
+	}
+	closeErr := file.Close()
+	if writeErr != nil {
+		_ = os.Remove(path)
+		return writeErr
+	}
+	if closeErr != nil {
+		_ = os.Remove(path)
+		return closeErr
+	}
+	return nil
 }
 
 // GetFileURL returns a download URL for the file.

--- a/internal/application/service/file/metadata.go
+++ b/internal/application/service/file/metadata.go
@@ -1,0 +1,80 @@
+package file
+
+import (
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type storageProvider interface {
+	StorageProvider() string
+}
+
+type storedPathMapper interface {
+	CanonicalStoredPath(string) string
+	ServiceStoredPath(string) string
+}
+
+// StorageProvider returns optional, non-secret provider identity advertised by a file service.
+func StorageProvider(service interfaces.FileService) string {
+	provider, ok := service.(storageProvider)
+	if !ok {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(provider.StorageProvider()))
+}
+
+// CanonicalStoredPath maps a service-returned path to its stable persisted form when supported.
+func CanonicalStoredPath(service interfaces.FileService, path string) string {
+	mapper, ok := service.(storedPathMapper)
+	if !ok {
+		return path
+	}
+	return mapper.CanonicalStoredPath(path)
+}
+
+// ServiceStoredPath maps a stable persisted path to the form expected by the service when supported.
+func ServiceStoredPath(service interfaces.FileService, path string) string {
+	mapper, ok := service.(storedPathMapper)
+	if !ok {
+		return path
+	}
+	return mapper.ServiceStoredPath(path)
+}
+
+func (*localFileService) StorageProvider() string { return "local" }
+func (*minioFileService) StorageProvider() string { return "minio" }
+func (*cosFileService) StorageProvider() string   { return "cos" }
+func (*tosFileService) StorageProvider() string   { return "tos" }
+func (*s3FileService) StorageProvider() string    { return "s3" }
+func (*obsFileService) StorageProvider() string   { return "obs" }
+func (*ossFileService) StorageProvider() string   { return "oss" }
+func (*ks3FileService) StorageProvider() string   { return "ks3" }
+func (*DummyFileService) StorageProvider() string { return "dummy" }
+
+func (s *obsFileService) CanonicalStoredPath(path string) string {
+	proxyDomain := strings.TrimRight(strings.TrimSpace(s.proxyDomain), "/")
+	bucketName := strings.TrimSpace(s.bucketName)
+	if proxyDomain == "" || bucketName == "" || !strings.HasPrefix(path, proxyDomain+"/") {
+		return path
+	}
+	objectKey := strings.TrimPrefix(path, proxyDomain+"/")
+	if objectKey == "" {
+		return path
+	}
+	return "obs://" + bucketName + "/" + objectKey
+}
+
+func (s *obsFileService) ServiceStoredPath(path string) string {
+	proxyDomain := strings.TrimRight(strings.TrimSpace(s.proxyDomain), "/")
+	bucketName := strings.TrimSpace(s.bucketName)
+	canonicalPrefix := "obs://" + bucketName + "/"
+	if proxyDomain == "" || bucketName == "" || !strings.HasPrefix(path, canonicalPrefix) {
+		return path
+	}
+	objectKey := strings.TrimPrefix(path, canonicalPrefix)
+	if objectKey == "" {
+		return path
+	}
+	return proxyDomain + "/" + objectKey
+}

--- a/internal/application/service/file/metadata.go
+++ b/internal/application/service/file/metadata.go
@@ -10,6 +10,10 @@ type storageProvider interface {
 	StorageProvider() string
 }
 
+type storageBackendIdentity interface {
+	StorageBackendID() string
+}
+
 type storedPathMapper interface {
 	CanonicalStoredPath(string) string
 	ServiceStoredPath(string) string
@@ -22,6 +26,16 @@ func StorageProvider(service interfaces.FileService) string {
 		return ""
 	}
 	return strings.ToLower(strings.TrimSpace(provider.StorageProvider()))
+}
+
+// StorageBackendID returns the concrete storage instance advertised by a
+// backend-scoped service.
+func StorageBackendID(service interfaces.FileService) string {
+	backend, ok := service.(storageBackendIdentity)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(backend.StorageBackendID())
 }
 
 // CanonicalStoredPath maps a service-returned path to its stable persisted form when supported.

--- a/internal/application/service/file/metadata_test.go
+++ b/internal/application/service/file/metadata_test.go
@@ -1,0 +1,54 @@
+package file
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+)
+
+type fileServiceWithoutMetadata struct {
+	interfaces.FileService
+}
+
+func TestBuiltInFileServicesExposeStorageProvider(t *testing.T) {
+	services := map[string]interfaces.FileService{
+		"local": &localFileService{},
+		"minio": &minioFileService{},
+		"cos":   &cosFileService{},
+		"tos":   &tosFileService{},
+		"s3":    &s3FileService{},
+		"obs":   &obsFileService{},
+		"oss":   &ossFileService{},
+		"ks3":   &ks3FileService{},
+		"dummy": &DummyFileService{},
+	}
+
+	for want, service := range services {
+		t.Run(want, func(t *testing.T) {
+			assert.Equal(t, want, StorageProvider(service))
+		})
+	}
+}
+
+func TestStorageProviderIsOptional(t *testing.T) {
+	service := fileServiceWithoutMetadata{FileService: &DummyFileService{}}
+
+	assert.Empty(t, StorageProvider(service))
+}
+
+func TestOBSStoredPathMappingUsesAdapterState(t *testing.T) {
+	service := &obsFileService{
+		bucketName:  "tenant-bucket",
+		proxyDomain: "https://files.example.com/obs",
+	}
+	proxyPath := "https://files.example.com/obs/weknora/7/object.bin"
+	canonicalPath := "obs://tenant-bucket/weknora/7/object.bin"
+
+	assert.Equal(t, canonicalPath, CanonicalStoredPath(service, proxyPath))
+	assert.Equal(t, proxyPath, ServiceStoredPath(service, canonicalPath))
+	assert.Equal(t, "https://cdn.example.com/object.bin", CanonicalStoredPath(
+		service,
+		"https://cdn.example.com/object.bin",
+	))
+}

--- a/internal/application/service/file/metadata_test.go
+++ b/internal/application/service/file/metadata_test.go
@@ -37,6 +37,13 @@ func TestStorageProviderIsOptional(t *testing.T) {
 	assert.Empty(t, StorageProvider(service))
 }
 
+func TestBackendScopedServiceExposesStorageBackendID(t *testing.T) {
+	service := NewBackendScopedFileService("backend-a", &DummyFileService{})
+
+	assert.Equal(t, "backend-a", StorageBackendID(service))
+	assert.Empty(t, StorageBackendID(&DummyFileService{}))
+}
+
 func TestOBSStoredPathMappingUsesAdapterState(t *testing.T) {
 	service := &obsFileService{
 		bucketName:  "tenant-bucket",

--- a/internal/application/service/file/minio.go
+++ b/internal/application/service/file/minio.go
@@ -146,9 +146,9 @@ func (s *minioFileService) GetFile(ctx context.Context, filePath string) (io.Rea
 	}
 	obj, err := s.client.GetObject(ctx, s.bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get file from MinIO: %w", err)
+		return nil, fmt.Errorf("failed to get file from MinIO: %w", normalizeObjectReadError(err))
 	}
-	return obj, nil
+	return normalizeObjectReadCloser(obj), nil
 }
 
 // DeleteFile deletes a file

--- a/internal/application/service/file/object_errors.go
+++ b/internal/application/service/file/object_errors.go
@@ -1,0 +1,67 @@
+package file
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"strings"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/tencentyun/cos-go-sdk-v5"
+	"github.com/volcengine/ve-tos-golang-sdk/v2/tos"
+)
+
+func normalizeObjectReadError(err error) error {
+	if err == nil || errors.Is(err, fs.ErrNotExist) || !isObjectNotFoundError(err) {
+		return err
+	}
+	return errors.Join(fs.ErrNotExist, err)
+}
+
+func isObjectNotFoundError(err error) bool {
+	switch strings.ToLower(objectErrorCode(err)) {
+	case "nosuchkey", "nosuchobject", "objectnotfound", "nosuchfile":
+		return true
+	default:
+		return false
+	}
+}
+
+func objectErrorCode(err error) string {
+	var minioErrorPointer *minio.ErrorResponse
+	if errors.As(err, &minioErrorPointer) {
+		return minioErrorPointer.Code
+	}
+	var minioError minio.ErrorResponse
+	if errors.As(err, &minioError) {
+		return minioError.Code
+	}
+	var cosError *cos.ErrorResponse
+	if errors.As(err, &cosError) {
+		return cosError.Code
+	}
+	var tosError *tos.TosServerError
+	if errors.As(err, &tosError) {
+		return tosError.Code
+	}
+	var errorCoder interface{ ErrorCode() string }
+	if errors.As(err, &errorCoder) {
+		return errorCoder.ErrorCode()
+	}
+	var coder interface{ Code() string }
+	if errors.As(err, &coder) {
+		return coder.Code()
+	}
+	return ""
+}
+
+type normalizingObjectReadCloser struct{ io.ReadCloser }
+
+func (r normalizingObjectReadCloser) Read(data []byte) (int, error) {
+	n, err := r.ReadCloser.Read(data)
+	return n, normalizeObjectReadError(err)
+}
+
+func normalizeObjectReadCloser(reader io.ReadCloser) io.ReadCloser {
+	return normalizingObjectReadCloser{ReadCloser: reader}
+}

--- a/internal/application/service/file/object_errors_test.go
+++ b/internal/application/service/file/object_errors_test.go
@@ -1,0 +1,154 @@
+package file
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"net/http"
+	"testing"
+
+	aliyunoss "github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	ks3awserr "github.com/ks3sdklib/aws-sdk-go/aws/awserr"
+	"github.com/minio/minio-go/v7"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tencentyun/cos-go-sdk-v5"
+	"github.com/volcengine/ve-tos-golang-sdk/v2/tos"
+)
+
+func TestNormalizeObjectReadErrorRecognizesProviderAbsence(t *testing.T) {
+	tests := map[string]error{
+		"minio": minio.ErrorResponse{Code: "NoSuchKey", StatusCode: http.StatusNotFound},
+		"minio pointer": &minio.ErrorResponse{
+			Code: "NoSuchKey", StatusCode: http.StatusNotFound,
+		},
+		"s3":  &types.NoSuchKey{},
+		"obs": &types.NoSuchKey{},
+		"cos": &cos.ErrorResponse{
+			Code:     "NoSuchKey",
+			Response: &http.Response{StatusCode: http.StatusNotFound},
+		},
+		"tos": &tos.TosServerError{
+			RequestInfo: tos.RequestInfo{StatusCode: http.StatusNotFound},
+			Code:        "NoSuchKey",
+		},
+		"oss": &aliyunoss.ServiceError{Code: "NoSuchKey", StatusCode: http.StatusNotFound},
+		"ks3": ks3awserr.NewRequestFailure(
+			ks3awserr.New("NoSuchKey", "missing", nil),
+			http.StatusNotFound,
+			"request-id",
+		),
+	}
+
+	for provider, providerErr := range tests {
+		t.Run(provider, func(t *testing.T) {
+			err := normalizeObjectReadError(providerErr)
+			assert.ErrorIs(t, err, fs.ErrNotExist)
+			assert.ErrorIs(t, err, providerErr)
+		})
+	}
+}
+
+func TestNormalizeObjectReadErrorKeepsTransientErrorsDistinct(t *testing.T) {
+	tests := map[string]error{
+		"transport": errors.New("connection reset"),
+		"minio":     minio.ErrorResponse{Code: "InternalError", StatusCode: http.StatusInternalServerError},
+		"s3":        &smithy.GenericAPIError{Code: "InternalError", Message: "retry"},
+		"obs":       &smithy.GenericAPIError{Code: "InternalError", Message: "retry"},
+		"cos": &cos.ErrorResponse{
+			Code:     "InternalError",
+			Response: &http.Response{StatusCode: http.StatusInternalServerError},
+		},
+		"tos": &tos.TosServerError{
+			RequestInfo: tos.RequestInfo{StatusCode: http.StatusInternalServerError},
+			Code:        "InternalError",
+		},
+		"oss": &aliyunoss.ServiceError{Code: "InternalError", StatusCode: http.StatusInternalServerError},
+		"ks3": ks3awserr.NewRequestFailure(
+			ks3awserr.New("InternalError", "retry", nil),
+			http.StatusInternalServerError,
+			"request-id",
+		),
+	}
+
+	for provider, providerErr := range tests {
+		t.Run(provider, func(t *testing.T) {
+			err := normalizeObjectReadError(providerErr)
+			assert.False(t, errors.Is(err, fs.ErrNotExist))
+			assert.ErrorIs(t, err, providerErr)
+		})
+	}
+}
+
+func TestNormalizeObjectReadErrorRequiresObjectAbsenceSemantics(t *testing.T) {
+	tests := []struct {
+		name         string
+		code         string
+		status       int
+		wantNotExist bool
+	}{
+		{name: "object code", code: "NoSuchKey", status: http.StatusNotFound, wantNotExist: true},
+		{name: "object code without status", code: "NoSuchObject", wantNotExist: true},
+		{name: "bucket missing", code: "NoSuchBucket", status: http.StatusNotFound},
+		{name: "unknown 404", status: http.StatusNotFound},
+		{name: "access masked 404", code: "AccessDenied", status: http.StatusNotFound},
+		{name: "generic not found code", code: "NotFound", status: http.StatusNotFound},
+		{name: "server error", code: "InternalError", status: http.StatusInternalServerError},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			providerErr := &genericClassifierError{code: test.code, status: test.status}
+			err := normalizeObjectReadError(providerErr)
+			assert.Equal(t, test.wantNotExist, errors.Is(err, fs.ErrNotExist))
+			assert.ErrorIs(t, err, providerErr)
+		})
+	}
+}
+
+func TestNormalizingObjectReaderNormalizesLazyAbsence(t *testing.T) {
+	tests := []struct {
+		name         string
+		providerErr  error
+		wantNotExist bool
+	}{
+		{
+			name:         "object missing",
+			providerErr:  minio.ErrorResponse{Code: "NoSuchKey", StatusCode: http.StatusNotFound},
+			wantNotExist: true,
+		},
+		{
+			name:        "unknown 404",
+			providerErr: &genericClassifierError{status: http.StatusNotFound},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reader := normalizeObjectReadCloser(&fileErrorReadCloser{readErr: test.providerErr})
+			_, err := reader.Read(make([]byte, 1))
+			require.Error(t, err)
+			assert.Equal(t, test.wantNotExist, errors.Is(err, fs.ErrNotExist))
+			assert.ErrorIs(t, err, test.providerErr)
+			require.NoError(t, reader.Close())
+		})
+	}
+}
+
+type genericClassifierError struct {
+	code   string
+	status int
+}
+
+func (e *genericClassifierError) Error() string       { return "generic provider error" }
+func (e *genericClassifierError) ErrorCode() string   { return e.code }
+func (e *genericClassifierError) HTTPStatusCode() int { return e.status }
+
+type fileErrorReadCloser struct{ readErr error }
+
+func (r *fileErrorReadCloser) Read([]byte) (int, error) { return 0, r.readErr }
+func (r *fileErrorReadCloser) Close() error             { return nil }
+
+var _ io.ReadCloser = (*fileErrorReadCloser)(nil)

--- a/internal/application/service/file/obs.go
+++ b/internal/application/service/file/obs.go
@@ -190,10 +190,10 @@ func (s *obsFileService) GetFile(ctx context.Context, filePath string) (io.ReadC
 		Key:    aws.String(objectKey),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get file from OBS: %w", err)
+		return nil, fmt.Errorf("failed to get file from OBS: %w", normalizeObjectReadError(err))
 	}
 
-	return output.Body, nil
+	return normalizeObjectReadCloser(output.Body), nil
 }
 
 func (s *obsFileService) DeleteFile(ctx context.Context, filePath string) error {

--- a/internal/application/service/file/oss.go
+++ b/internal/application/service/file/oss.go
@@ -297,10 +297,10 @@ func (s *ossFileService) GetFile(ctx context.Context, filePath string) (io.ReadC
 		Key:    oss.Ptr(objectName),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get file from OSS: %w", err)
+		return nil, fmt.Errorf("failed to get file from OSS: %w", normalizeObjectReadError(err))
 	}
 
-	return resp.Body, nil
+	return normalizeObjectReadCloser(resp.Body), nil
 }
 
 // DeleteFile removes a file from OSS.

--- a/internal/application/service/file/s3.go
+++ b/internal/application/service/file/s3.go
@@ -244,10 +244,10 @@ func (s *s3FileService) GetFile(ctx context.Context, filePath string) (io.ReadCl
 		Key:    aws.String(objectName),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get file from S3: %w", err)
+		return nil, fmt.Errorf("failed to get file from S3: %w", normalizeObjectReadError(err))
 	}
 
-	return resp.Body, nil
+	return normalizeObjectReadCloser(resp.Body), nil
 }
 
 // DeleteFile deletes a file

--- a/internal/application/service/file/save_bytes_contract_test.go
+++ b/internal/application/service/file/save_bytes_contract_test.go
@@ -1,0 +1,108 @@
+package file
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteNewLocalObjectNeverOverwritesExistingPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "candidate.bin")
+	require.NoError(t, os.WriteFile(path, []byte("winner"), 0o644))
+
+	err := writeNewLocalObject(path, []byte("candidate"))
+	require.Error(t, err)
+	stored, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, []byte("winner"), stored)
+}
+
+func TestLocalSaveBytesCreatesUniqueIndependentObjects(t *testing.T) {
+	service := NewLocalFileService(t.TempDir(), "")
+	const callers = 32
+
+	start := make(chan struct{})
+	paths := make(chan string, callers)
+	errs := make(chan error, callers)
+	var ready sync.WaitGroup
+	ready.Add(callers)
+	for i := range callers {
+		go func() {
+			ready.Done()
+			<-start
+			path, err := service.SaveBytes(context.Background(), []byte{byte(i)}, 7, "artifact.bin", false)
+			paths <- path
+			errs <- err
+		}()
+	}
+	ready.Wait()
+	close(start)
+
+	seen := make(map[string]struct{}, callers)
+	for range callers {
+		require.NoError(t, <-errs)
+		path := <-paths
+		assert.NotContains(t, seen, path)
+		seen[path] = struct{}{}
+	}
+	require.Len(t, seen, callers)
+	for path := range seen {
+		require.NoError(t, service.DeleteFile(context.Background(), path))
+	}
+}
+
+func TestDummySaveBytesCreatesReadableIndependentlyDeletableObject(t *testing.T) {
+	service := NewDummyFileService()
+	first := []byte("first")
+	second := []byte("second")
+
+	firstPath, err := service.SaveBytes(context.Background(), first, 7, "artifact.bin", false)
+	require.NoError(t, err)
+	secondPath, err := service.SaveBytes(context.Background(), second, 7, "artifact.bin", false)
+	require.NoError(t, err)
+	require.NotEqual(t, firstPath, secondPath)
+
+	firstReader, err := service.GetFile(context.Background(), firstPath)
+	require.NoError(t, err)
+	firstBytes, err := io.ReadAll(firstReader)
+	require.NoError(t, err)
+	require.NoError(t, firstReader.Close())
+	assert.Equal(t, first, firstBytes)
+
+	require.NoError(t, service.DeleteFile(context.Background(), firstPath))
+	_, err = service.GetFile(context.Background(), firstPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	secondReader, err := service.GetFile(context.Background(), secondPath)
+	require.NoError(t, err)
+	secondBytes, err := io.ReadAll(secondReader)
+	require.NoError(t, err)
+	require.NoError(t, secondReader.Close())
+	assert.True(t, bytes.Equal(second, secondBytes))
+}
+
+func TestDummyFileServiceZeroValueSupportsSaveBytes(t *testing.T) {
+	var service DummyFileService
+	want := []byte("zero-value")
+
+	path, err := service.SaveBytes(context.Background(), want, 7, "artifact.bin", false)
+	require.NoError(t, err)
+
+	reader, err := service.GetFile(context.Background(), path)
+	require.NoError(t, err)
+	got, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	assert.Equal(t, want, got)
+
+	require.NoError(t, service.DeleteFile(context.Background(), path))
+	_, err = service.GetFile(context.Background(), path)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/internal/application/service/file/tos.go
+++ b/internal/application/service/file/tos.go
@@ -277,9 +277,9 @@ func (s *tosFileService) GetFile(ctx context.Context, filePath string) (io.ReadC
 		Key:    objectName,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get file from TOS: %w", err)
+		return nil, fmt.Errorf("failed to get file from TOS: %w", normalizeObjectReadError(err))
 	}
-	return output.Content, nil
+	return normalizeObjectReadCloser(output.Content), nil
 }
 
 func (s *tosFileService) DeleteFile(ctx context.Context, filePath string) error {

--- a/internal/application/service/generated_question_cache.go
+++ b/internal/application/service/generated_question_cache.go
@@ -1,0 +1,212 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+const generatedQuestionBindingVersion = "generated-question-binding-v1"
+
+func generatedQuestionArtifactPolicy(questionCount int) chatArtifactValuePolicy {
+	return chatArtifactValuePolicy{
+		canonicalize: func(completion string) (string, bool, error) {
+			questions := parseGeneratedQuestions(completion, questionCount)
+			value, err := json.Marshal(questions)
+			return string(value), len(questions) > 0, err
+		},
+		validate: func(value string) error {
+			questions, err := decodeGeneratedQuestionArtifact(value)
+			if err != nil {
+				return err
+			}
+			if len(questions) == 0 || len(questions) > questionCount {
+				return fmt.Errorf("generated question artifact has invalid question count")
+			}
+			return nil
+		},
+	}
+}
+
+func decodeGeneratedQuestionArtifact(value string) ([]string, error) {
+	var questions []string
+	if err := json.Unmarshal([]byte(value), &questions); err != nil {
+		return nil, err
+	}
+	for _, question := range questions {
+		if strings.TrimSpace(question) == "" {
+			return nil, fmt.Errorf("generated question artifact contains an empty question")
+		}
+	}
+	return questions, nil
+}
+
+func parseGeneratedQuestions(completion string, questionCount int) []string {
+	questions := make([]string, 0, questionCount)
+	for _, line := range strings.Split(completion, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		line = strings.TrimSpace(strings.TrimLeft(line, "0123456789.-*) "))
+		if len(line) <= 5 {
+			continue
+		}
+		questions = append(questions, line)
+		if len(questions) >= questionCount {
+			break
+		}
+	}
+	return questions
+}
+
+func buildGeneratedQuestions(chunkID string, questions []string) []types.GeneratedQuestion {
+	occurrences := make(map[string]int)
+	generated := make([]types.GeneratedQuestion, 0, len(questions))
+	for _, question := range questions {
+		question = strings.TrimSpace(question)
+		if question == "" {
+			continue
+		}
+		normalized := types.NormalizeChunkContent(question)
+		occurrence := occurrences[normalized]
+		occurrences[normalized] = occurrence + 1
+		digest := sha256.Sum256([]byte(strings.Join([]string{
+			generatedQuestionBindingVersion,
+			chunkID,
+			normalized,
+			strconv.Itoa(occurrence),
+		}, "\x00")))
+		generated = append(generated, types.GeneratedQuestion{
+			ID:       "q" + hex.EncodeToString(digest[:12]),
+			Question: question,
+		})
+	}
+	return generated
+}
+
+func generatedQuestionsFromMetadata(metadata types.JSON) ([]types.GeneratedQuestion, error) {
+	if len(metadata) == 0 {
+		return nil, nil
+	}
+	var value struct {
+		GeneratedQuestions []types.GeneratedQuestion `json:"generated_questions"`
+	}
+	if err := json.Unmarshal(metadata, &value); err != nil {
+		return nil, err
+	}
+	return value.GeneratedQuestions, nil
+}
+
+func withGeneratedQuestions(metadata types.JSON, questions []types.GeneratedQuestion) (types.JSON, error) {
+	fields := make(map[string]json.RawMessage)
+	if len(metadata) > 0 {
+		if err := json.Unmarshal(metadata, &fields); err != nil {
+			return nil, err
+		}
+	}
+	if fields == nil {
+		fields = make(map[string]json.RawMessage)
+	}
+	encoded, err := json.Marshal(questions)
+	if err != nil {
+		return nil, err
+	}
+	fields["generated_questions"] = encoded
+	result, err := json.Marshal(fields)
+	return types.JSON(result), err
+}
+
+func staleGeneratedQuestionSourceIDs(
+	chunkID string,
+	oldQuestions, desiredQuestions []types.GeneratedQuestion,
+) []string {
+	desired := make(map[string]struct{}, len(desiredQuestions))
+	for _, question := range desiredQuestions {
+		desired[question.ID] = struct{}{}
+	}
+	stale := make([]string, 0)
+	for _, question := range oldQuestions {
+		if _, ok := desired[question.ID]; !ok && question.ID != "" {
+			stale = append(stale, chunkID+"-"+question.ID)
+		}
+	}
+	return stale
+}
+
+type generatedQuestionUpdate struct {
+	chunk        *types.Chunk
+	metadata     types.JSON
+	oldQuestions []types.GeneratedQuestion
+	newQuestions []types.GeneratedQuestion
+}
+
+type generatedQuestionIndexReconciler interface {
+	DeleteBySourceIDList(context.Context, []string, int, string) error
+}
+
+func prepareGeneratedQuestionUpdate(
+	chunk *types.Chunk,
+	knowledge *types.Knowledge,
+	questions []string,
+) (generatedQuestionUpdate, []*types.IndexInfo, error) {
+	oldQuestions, err := generatedQuestionsFromMetadata(chunk.Metadata)
+	if err != nil {
+		return generatedQuestionUpdate{}, nil, fmt.Errorf("parse chunk %s metadata: %w", chunk.ID, err)
+	}
+	newQuestions := buildGeneratedQuestions(chunk.ID, questions)
+	metadata, err := withGeneratedQuestions(chunk.Metadata, newQuestions)
+	if err != nil {
+		return generatedQuestionUpdate{}, nil, fmt.Errorf("update chunk %s metadata: %w", chunk.ID, err)
+	}
+	update := generatedQuestionUpdate{
+		chunk:        chunk,
+		metadata:     metadata,
+		oldQuestions: oldQuestions,
+		newQuestions: newQuestions,
+	}
+	indexInfo := make([]*types.IndexInfo, 0, len(newQuestions))
+	for _, question := range newQuestions {
+		indexInfo = append(indexInfo, &types.IndexInfo{
+			Content:         question.Question,
+			SourceID:        chunk.ID + "-" + question.ID,
+			SourceType:      types.ChunkSourceType,
+			ChunkID:         chunk.ID,
+			KnowledgeID:     knowledge.ID,
+			KnowledgeBaseID: knowledge.KnowledgeBaseID,
+			IsEnabled:       true,
+		})
+	}
+	return update, indexInfo, nil
+}
+
+func (s *knowledgeService) applyGeneratedQuestionUpdates(
+	ctx context.Context,
+	retrieveEngine generatedQuestionIndexReconciler,
+	embeddingModel embedding.Embedder,
+	kb *types.KnowledgeBase,
+	updates []generatedQuestionUpdate,
+) error {
+	for _, update := range updates {
+		stale := staleGeneratedQuestionSourceIDs(update.chunk.ID, update.oldQuestions, update.newQuestions)
+		if len(stale) > 0 {
+			if err := retrieveEngine.DeleteBySourceIDList(
+				ctx, stale, embeddingModel.GetDimensions(), kb.Type,
+			); err != nil {
+				return fmt.Errorf("delete stale generated questions for chunk %s: %w", update.chunk.ID, err)
+			}
+		}
+		update.chunk.Metadata = update.metadata
+		if err := s.chunkService.UpdateChunk(ctx, update.chunk); err != nil {
+			return fmt.Errorf("update generated questions for chunk %s: %w", update.chunk.ID, err)
+		}
+	}
+	return nil
+}

--- a/internal/application/service/generated_question_cache_test.go
+++ b/internal/application/service/generated_question_cache_test.go
@@ -1,0 +1,193 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type generatedQuestionChunkService struct {
+	interfaces.ChunkService
+	events *[]string
+	err    error
+}
+
+func (s generatedQuestionChunkService) UpdateChunk(_ context.Context, _ *types.Chunk) error {
+	*s.events = append(*s.events, "update")
+	return s.err
+}
+
+type generatedQuestionReconciler struct {
+	events  *[]string
+	deleted []string
+	err     error
+}
+
+func (r *generatedQuestionReconciler) DeleteBySourceIDList(
+	_ context.Context, sourceIDs []string, _ int, _ string,
+) error {
+	*r.events = append(*r.events, "delete")
+	r.deleted = append([]string(nil), sourceIDs...)
+	return r.err
+}
+
+func TestGenerateQuestionsWithContextReusesChatArtifact(t *testing.T) {
+	store := newChatArtifactFakeStore()
+	model := &chatArtifactFakeModel{
+		modelID:   "question-model",
+		modelName: "question-model",
+		response:  &types.ChatResponse{Content: "1. What is stable caching?\n2. How are retries handled?"},
+	}
+	svc := &knowledgeService{
+		config: &config.Config{Conversation: &config.ConversationConfig{
+			GenerateQuestionsPrompt: "Create {{question_count}} questions for {{content}} {{context}} {{doc_name}} in {{language}}.",
+		}},
+		artifactStore: store,
+	}
+	ctx := context.WithValue(context.Background(), types.LanguageContextKey, "en")
+	ctx = context.WithValue(ctx, types.TenantIDContextKey, uint64(7))
+
+	first, firstHit, firstProviderCall, err := svc.generateQuestionsWithContext(
+		ctx, model, "revision-1", "current", "previous", "next", "Document", 2, "Be concise.")
+	require.NoError(t, err)
+	second, secondHit, secondProviderCall, err := svc.generateQuestionsWithContext(
+		ctx, model, "revision-1", "current", "previous", "next", "Document", 2, "Be concise.")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"What is stable caching?", "How are retries handled?"}, first)
+	assert.Equal(t, first, second)
+	assert.False(t, firstHit)
+	assert.True(t, secondHit)
+	assert.True(t, firstProviderCall)
+	assert.False(t, secondProviderCall)
+	assert.Equal(t, 1, model.calls)
+}
+
+func TestGenerateQuestionsWithContextDoesNotCacheUnparseableCompletion(t *testing.T) {
+	store := newChatArtifactFakeStore()
+	model := &chatArtifactFakeModel{
+		modelID:   "question-model",
+		modelName: "question-model",
+		response:  &types.ChatResponse{Content: "1. no"},
+	}
+	svc := &knowledgeService{
+		config: &config.Config{Conversation: &config.ConversationConfig{
+			GenerateQuestionsPrompt: "Create questions for {{content}}.",
+		}},
+		artifactStore: store,
+	}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(7))
+
+	first, firstHit, firstProviderCall, err := svc.generateQuestionsWithContext(
+		ctx, model, "revision-1", "current", "", "", "Document", 2, "")
+	require.NoError(t, err)
+	second, secondHit, secondProviderCall, err := svc.generateQuestionsWithContext(
+		ctx, model, "revision-1", "current", "", "", "Document", 2, "")
+	require.NoError(t, err)
+
+	assert.Empty(t, first)
+	assert.Empty(t, second)
+	assert.False(t, firstHit)
+	assert.False(t, secondHit)
+	assert.True(t, firstProviderCall)
+	assert.True(t, secondProviderCall)
+	assert.Equal(t, 2, model.calls)
+	assert.Zero(t, store.putCalls)
+}
+
+func TestBuildGeneratedQuestionsUsesStableOccurrenceAwareIDs(t *testing.T) {
+	questions := []string{" Same question? ", "Same question?", "Different question?"}
+	first := buildGeneratedQuestions("chunk-1", questions)
+	second := buildGeneratedQuestions("chunk-1", questions)
+	otherChunk := buildGeneratedQuestions("chunk-2", questions)
+
+	require.Len(t, first, 3)
+	assert.Equal(t, first, second)
+	assert.NotEqual(t, first[0].ID, first[1].ID)
+	assert.NotEqual(t, first[0].ID, otherChunk[0].ID)
+	assert.Equal(t, "Same question?", first[0].Question)
+}
+
+func TestWithGeneratedQuestionsPreservesUnrelatedMetadata(t *testing.T) {
+	original := types.JSON(`{"_weknora_embedding_fingerprint":"keep","nested":{"answer":42},"generated_questions":[{"id":"old","question":"Old?"}]}`)
+	questions := []types.GeneratedQuestion{{ID: "new", Question: "New?"}}
+
+	updated, err := withGeneratedQuestions(original, questions)
+	require.NoError(t, err)
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(updated, &fields))
+	assert.JSONEq(t, `"keep"`, string(fields[types.ChunkEmbeddingFingerprintMetadataKey]))
+	assert.JSONEq(t, `{"answer":42}`, string(fields["nested"]))
+	assert.JSONEq(t, `[{"id":"new","question":"New?"}]`, string(fields["generated_questions"]))
+}
+
+func TestWithGeneratedQuestionsAcceptsNullMetadata(t *testing.T) {
+	questions := []types.GeneratedQuestion{{ID: "new", Question: "New?"}}
+
+	updated, err := withGeneratedQuestions(types.JSON(`null`), questions)
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"generated_questions":[{"id":"new","question":"New?"}]}`, string(updated))
+}
+
+func TestStaleGeneratedQuestionSourceIDs(t *testing.T) {
+	old := []types.GeneratedQuestion{{ID: "random-old", Question: "Old?"}, {ID: "keep", Question: "Keep?"}}
+	desired := []types.GeneratedQuestion{{ID: "keep", Question: "Keep?"}, {ID: "new", Question: "New?"}}
+
+	assert.Equal(t, []string{"chunk-1-random-old"}, staleGeneratedQuestionSourceIDs("chunk-1", old, desired))
+}
+
+func TestApplyGeneratedQuestionUpdatesDeletesStaleIndexBeforePublishingMetadata(t *testing.T) {
+	events := []string{}
+	chunk := &types.Chunk{ID: "chunk-1", Metadata: types.JSON(`{"generated_questions":[{"id":"old","question":"Old?"}],"keep":true}`)}
+	newQuestions := []types.GeneratedQuestion{{ID: "stable", Question: "New question?"}}
+	metadata, err := withGeneratedQuestions(chunk.Metadata, newQuestions)
+	require.NoError(t, err)
+	update := generatedQuestionUpdate{
+		chunk:        chunk,
+		metadata:     metadata,
+		oldQuestions: []types.GeneratedQuestion{{ID: "old", Question: "Old?"}},
+		newQuestions: newQuestions,
+	}
+	reconciler := &generatedQuestionReconciler{events: &events}
+	svc := &knowledgeService{chunkService: generatedQuestionChunkService{events: &events}}
+
+	err = svc.applyGeneratedQuestionUpdates(
+		context.Background(), reconciler, &embeddingArtifactFakeEmbedder{dimensions: 3},
+		&types.KnowledgeBase{Type: "document"}, []generatedQuestionUpdate{update},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"delete", "update"}, events)
+	assert.Equal(t, []string{"chunk-1-old"}, reconciler.deleted)
+	assert.JSONEq(t, string(metadata), string(chunk.Metadata))
+}
+
+func TestApplyGeneratedQuestionUpdatesKeepsOldMetadataWhenStaleDeleteFails(t *testing.T) {
+	events := []string{}
+	original := types.JSON(`{"generated_questions":[{"id":"old","question":"Old?"}],"keep":true}`)
+	chunk := &types.Chunk{ID: "chunk-1", Metadata: append(types.JSON(nil), original...)}
+	newQuestions := []types.GeneratedQuestion{{ID: "stable", Question: "New question?"}}
+	metadata, err := withGeneratedQuestions(chunk.Metadata, newQuestions)
+	require.NoError(t, err)
+	deleteErr := errors.New("delete failed")
+	svc := &knowledgeService{chunkService: generatedQuestionChunkService{events: &events}}
+
+	err = svc.applyGeneratedQuestionUpdates(
+		context.Background(), &generatedQuestionReconciler{events: &events, err: deleteErr},
+		&embeddingArtifactFakeEmbedder{dimensions: 3}, &types.KnowledgeBase{Type: "document"},
+		[]generatedQuestionUpdate{{
+			chunk: chunk, metadata: metadata,
+			oldQuestions: []types.GeneratedQuestion{{ID: "old"}}, newQuestions: newQuestions,
+		}},
+	)
+	assert.ErrorIs(t, err, deleteErr)
+	assert.Equal(t, []string{"delete"}, events)
+	assert.Equal(t, original, chunk.Metadata)
+}

--- a/internal/application/service/graph_artifact_cache.go
+++ b/internal/application/service/graph_artifact_cache.go
@@ -269,13 +269,9 @@ func completeGraphArtifact(
 		if decodeErr == nil {
 			return graph, true, false, nil
 		}
-
-		graph, providerErr := provider(ctx)
-		if providerErr != nil {
-			return nil, false, true, providerErr
+		if err := store.Invalidate(ctx, key, payload); err != nil {
+			return nil, false, false, fmt.Errorf("invalidate graph artifact: %w", err)
 		}
-		canonical, canonicalErr := canonicalizeGraphArtifact(graph, chunkID)
-		return canonical, false, true, canonicalErr
 	}
 
 	graph, err := provider(ctx)
@@ -292,6 +288,17 @@ func completeGraphArtifact(
 	}
 	canonical, err := decodeGraphArtifact(winner, chunkID)
 	if err != nil {
+		if invalidateErr := store.Invalidate(ctx, key, winner); invalidateErr != nil {
+			return nil, false, true, fmt.Errorf("invalidate graph artifact: %w", invalidateErr)
+		}
+		winner, _, putErr := store.PutIfAbsent(ctx, key, candidate)
+		if putErr != nil {
+			return nil, false, true, fmt.Errorf("put graph artifact repair: %w", putErr)
+		}
+		canonical, err = decodeGraphArtifact(winner, chunkID)
+		if err == nil {
+			return canonical, false, true, nil
+		}
 		canonical, err = decodeGraphArtifact(candidate, chunkID)
 	}
 	return canonical, false, true, err

--- a/internal/application/service/graph_artifact_cache.go
+++ b/internal/application/service/graph_artifact_cache.go
@@ -1,0 +1,352 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	chatpipeline "github.com/Tencent/WeKnora/internal/application/service/chat_pipeline"
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+const (
+	graphArtifactStage         = "chat.graph-extraction"
+	graphArtifactKeyVersion    = uint16(1)
+	graphArtifactCodecVersion  = uint8(1)
+	graphArtifactPromptVersion = "graph-extraction-v1"
+	graphArtifactCanonicalizer = "graph-data-v1"
+)
+
+type graphArtifactRequest struct {
+	tenantID             uint64
+	model                chat.Chat
+	modelRevision        string
+	messages             []chat.Message
+	options              *chat.ChatOptions
+	promptVersion        string
+	canonicalizerVersion string
+}
+
+func newGraphArtifactKey(request graphArtifactRequest) (types.ProcessingArtifactKey, error) {
+	if len(request.messages) != 2 ||
+		request.messages[0].Role != "system" || strings.TrimSpace(request.messages[0].Content) == "" ||
+		request.messages[1].Role != "user" || strings.TrimSpace(request.messages[1].Content) == "" {
+		return types.ProcessingArtifactKey{}, errors.New("graph artifact extraction messages are incomplete")
+	}
+	return newChatArtifactKey(chatArtifactRequest{
+		tenantID:             request.tenantID,
+		stage:                graphArtifactStage,
+		keyVersion:           graphArtifactKeyVersion,
+		model:                request.model,
+		modelRevision:        request.modelRevision,
+		messages:             request.messages,
+		options:              request.options,
+		promptVersion:        request.promptVersion,
+		canonicalizerVersion: request.canonicalizerVersion,
+	})
+}
+
+type graphArtifactValue struct {
+	Version   uint8                   `json:"version"`
+	Nodes     []graphArtifactNode     `json:"nodes"`
+	Relations []graphArtifactRelation `json:"relations"`
+}
+
+type graphArtifactNode struct {
+	Name       string   `json:"name"`
+	Attributes []string `json:"attributes"`
+}
+
+type graphArtifactRelation struct {
+	Node1 string `json:"node1"`
+	Node2 string `json:"node2"`
+	Type  string `json:"type"`
+}
+
+func encodeGraphArtifact(graph *types.GraphData) ([]byte, error) {
+	value, err := canonicalGraphArtifact(graph)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode graph artifact: %w", err)
+	}
+	return payload, nil
+}
+
+func decodeGraphArtifact(payload []byte, chunkID string) (*types.GraphData, error) {
+	if strings.TrimSpace(chunkID) == "" || !utf8.ValidString(chunkID) {
+		return nil, errors.New("graph artifact chunk ID must not be empty")
+	}
+	if !utf8.Valid(payload) {
+		return nil, errors.New("graph artifact payload is not valid UTF-8")
+	}
+
+	var value graphArtifactValue
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&value); err != nil {
+		return nil, fmt.Errorf("decode graph artifact: %w", err)
+	}
+	if err := ensureGraphArtifactEOF(decoder); err != nil {
+		return nil, err
+	}
+	if value.Version != graphArtifactCodecVersion {
+		return nil, fmt.Errorf("unsupported graph artifact version %d", value.Version)
+	}
+	if value.Nodes == nil || value.Relations == nil {
+		return nil, errors.New("graph artifact payload is incomplete")
+	}
+
+	graph := &types.GraphData{
+		Node:     make([]*types.GraphNode, 0, len(value.Nodes)),
+		Relation: make([]*types.GraphRelation, 0, len(value.Relations)),
+	}
+	for _, node := range value.Nodes {
+		graph.Node = append(graph.Node, &types.GraphNode{
+			Name:       node.Name,
+			Attributes: append([]string(nil), node.Attributes...),
+		})
+	}
+	for _, relation := range value.Relations {
+		graph.Relation = append(graph.Relation, &types.GraphRelation{
+			Node1: relation.Node1,
+			Node2: relation.Node2,
+			Type:  relation.Type,
+		})
+	}
+	canonical, err := canonicalGraphArtifact(graph)
+	if err != nil {
+		return nil, fmt.Errorf("validate graph artifact: %w", err)
+	}
+	return bindGraphArtifact(canonical, chunkID), nil
+}
+
+func bindGraphArtifact(value graphArtifactValue, chunkID string) *types.GraphData {
+	graph := &types.GraphData{
+		Node:     make([]*types.GraphNode, 0, len(value.Nodes)),
+		Relation: make([]*types.GraphRelation, 0, len(value.Relations)),
+	}
+	for _, node := range value.Nodes {
+		graph.Node = append(graph.Node, &types.GraphNode{
+			Name:       node.Name,
+			Chunks:     []string{chunkID},
+			Attributes: append([]string(nil), node.Attributes...),
+		})
+	}
+	for _, relation := range value.Relations {
+		graph.Relation = append(graph.Relation, &types.GraphRelation{
+			Node1:  relation.Node1,
+			Node2:  relation.Node2,
+			Type:   relation.Type,
+			Chunks: []string{chunkID},
+		})
+	}
+	return graph
+}
+
+func canonicalGraphArtifact(graph *types.GraphData) (graphArtifactValue, error) {
+	if graph == nil {
+		return graphArtifactValue{}, errors.New("graph artifact graph must not be nil")
+	}
+
+	value := graphArtifactValue{
+		Version:   graphArtifactCodecVersion,
+		Nodes:     make([]graphArtifactNode, 0, len(graph.Node)),
+		Relations: make([]graphArtifactRelation, 0, len(graph.Relation)),
+	}
+	nodeNames := make(map[string]struct{}, len(graph.Node))
+	for _, node := range graph.Node {
+		if node == nil || strings.TrimSpace(node.Name) == "" || !utf8.ValidString(node.Name) {
+			return graphArtifactValue{}, errors.New("graph artifact contains an invalid node")
+		}
+		if _, exists := nodeNames[node.Name]; exists {
+			return graphArtifactValue{}, fmt.Errorf("graph artifact contains duplicate node %q", node.Name)
+		}
+		nodeNames[node.Name] = struct{}{}
+		attributes := append([]string(nil), node.Attributes...)
+		for _, attribute := range attributes {
+			if !utf8.ValidString(attribute) {
+				return graphArtifactValue{}, errors.New("graph artifact contains an invalid node attribute")
+			}
+		}
+		sort.Strings(attributes)
+		value.Nodes = append(value.Nodes, graphArtifactNode{Name: node.Name, Attributes: attributes})
+	}
+	sort.Slice(value.Nodes, func(i, j int) bool { return value.Nodes[i].Name < value.Nodes[j].Name })
+
+	relationKeys := make(map[string]struct{}, len(graph.Relation))
+	for _, relation := range graph.Relation {
+		if relation == nil || strings.TrimSpace(relation.Node1) == "" ||
+			strings.TrimSpace(relation.Node2) == "" || strings.TrimSpace(relation.Type) == "" ||
+			!utf8.ValidString(relation.Node1) || !utf8.ValidString(relation.Node2) ||
+			!utf8.ValidString(relation.Type) {
+			return graphArtifactValue{}, errors.New("graph artifact contains an invalid relation")
+		}
+		if relation.Node1 == relation.Node2 {
+			return graphArtifactValue{}, errors.New("graph artifact contains a self relation")
+		}
+		if _, exists := nodeNames[relation.Node1]; !exists {
+			return graphArtifactValue{}, fmt.Errorf("graph artifact relation references unknown node %q", relation.Node1)
+		}
+		if _, exists := nodeNames[relation.Node2]; !exists {
+			return graphArtifactValue{}, fmt.Errorf("graph artifact relation references unknown node %q", relation.Node2)
+		}
+		key := relation.Node1 + "\x00" + relation.Type + "\x00" + relation.Node2
+		if _, exists := relationKeys[key]; exists {
+			continue
+		}
+		relationKeys[key] = struct{}{}
+		value.Relations = append(value.Relations, graphArtifactRelation{
+			Node1: relation.Node1,
+			Node2: relation.Node2,
+			Type:  relation.Type,
+		})
+	}
+	sort.Slice(value.Relations, func(i, j int) bool {
+		left, right := value.Relations[i], value.Relations[j]
+		if left.Node1 != right.Node1 {
+			return left.Node1 < right.Node1
+		}
+		if left.Type != right.Type {
+			return left.Type < right.Type
+		}
+		return left.Node2 < right.Node2
+	})
+	return value, nil
+}
+
+func ensureGraphArtifactEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return errors.New("decode graph artifact: trailing JSON value")
+		}
+		return fmt.Errorf("decode graph artifact: %w", err)
+	}
+	return nil
+}
+
+func completeGraphArtifact(
+	ctx context.Context,
+	store interfaces.ProcessingArtifactStore,
+	request graphArtifactRequest,
+	chunkID string,
+	provider func(context.Context) (*types.GraphData, error),
+) (*types.GraphData, bool, bool, error) {
+	if provider == nil {
+		return nil, false, false, errors.New("graph artifact provider must not be nil")
+	}
+
+	if store == nil {
+		graph, err := provider(ctx)
+		if err != nil {
+			return nil, false, true, err
+		}
+		canonical, err := canonicalizeGraphArtifact(graph, chunkID)
+		return canonical, false, true, err
+	}
+
+	key, err := newGraphArtifactKey(request)
+	if err != nil {
+		return nil, false, false, err
+	}
+	payload, hit, err := store.Get(ctx, key)
+	if err != nil {
+		return nil, false, false, fmt.Errorf("get graph artifact: %w", err)
+	}
+	if hit {
+		graph, decodeErr := decodeGraphArtifact(payload, chunkID)
+		if decodeErr == nil {
+			return graph, true, false, nil
+		}
+
+		graph, providerErr := provider(ctx)
+		if providerErr != nil {
+			return nil, false, true, providerErr
+		}
+		canonical, canonicalErr := canonicalizeGraphArtifact(graph, chunkID)
+		return canonical, false, true, canonicalErr
+	}
+
+	graph, err := provider(ctx)
+	if err != nil {
+		return nil, false, true, err
+	}
+	candidate, err := encodeGraphArtifact(graph)
+	if err != nil {
+		return nil, false, true, err
+	}
+	winner, _, err := store.PutIfAbsent(ctx, key, candidate)
+	if err != nil {
+		return nil, false, true, fmt.Errorf("put graph artifact: %w", err)
+	}
+	canonical, err := decodeGraphArtifact(winner, chunkID)
+	if err != nil {
+		canonical, err = decodeGraphArtifact(candidate, chunkID)
+	}
+	return canonical, false, true, err
+}
+
+func canonicalizeGraphArtifact(graph *types.GraphData, chunkID string) (*types.GraphData, error) {
+	payload, err := encodeGraphArtifact(graph)
+	if err != nil {
+		return nil, err
+	}
+	return decodeGraphArtifact(payload, chunkID)
+}
+
+func extractGraphArtifact(
+	ctx context.Context,
+	store interfaces.ProcessingArtifactStore,
+	tenantID uint64,
+	chunkID string,
+	model chat.Chat,
+	modelRevision string,
+	template *types.PromptTemplateStructured,
+	content string,
+) (*types.GraphData, bool, bool, error) {
+	if model == nil {
+		return nil, false, false, errors.New("graph artifact model must not be nil")
+	}
+	if template == nil {
+		return nil, false, false, errors.New("graph artifact template must not be nil")
+	}
+
+	formatter := chatpipeline.NewFormater()
+	messages := chatpipeline.NewQAPromptGenerator(formatter, template).Render(ctx, content)
+	thinking := false
+	options := &chat.ChatOptions{
+		Temperature: 0.3,
+		MaxTokens:   4096,
+		Thinking:    &thinking,
+	}
+	request := graphArtifactRequest{
+		tenantID:             tenantID,
+		model:                model,
+		modelRevision:        modelRevision,
+		messages:             messages,
+		options:              options,
+		promptVersion:        graphArtifactPromptVersion,
+		canonicalizerVersion: graphArtifactCanonicalizer,
+	}
+	return completeGraphArtifact(ctx, store, request, chunkID, func(ctx context.Context) (*types.GraphData, error) {
+		response, err := model.Chat(ctx, messages, options)
+		if err != nil {
+			return nil, err
+		}
+		if response == nil {
+			return nil, errors.New("graph extraction model returned a nil response")
+		}
+		return formatter.ParseGraph(ctx, response.Content)
+	})
+}

--- a/internal/application/service/graph_artifact_cache_test.go
+++ b/internal/application/service/graph_artifact_cache_test.go
@@ -305,8 +305,12 @@ func TestCompleteGraphArtifactMissUsesPutIfAbsentWinner(t *testing.T) {
 
 func TestCompleteGraphArtifactMissFallsBackWhenConcurrentWinnerIsCorrupt(t *testing.T) {
 	request := testGraphArtifactRequest()
+	key, err := newGraphArtifactKey(request)
+	require.NoError(t, err)
 	store := newChatArtifactFakeStore()
 	store.putCanonical = []byte(`{`)
+	store.clearPutCanonicalOnInvalidate = true
+	providerCalls := 0
 
 	graph, cacheHit, providerCalled, err := completeGraphArtifact(
 		context.Background(),
@@ -314,6 +318,7 @@ func TestCompleteGraphArtifactMissFallsBackWhenConcurrentWinnerIsCorrupt(t *test
 		request,
 		"current-chunk",
 		func(context.Context) (*types.GraphData, error) {
+			providerCalls++
 			return &types.GraphData{Node: []*types.GraphNode{{Name: "Candidate"}}}, nil
 		},
 	)
@@ -324,14 +329,33 @@ func TestCompleteGraphArtifactMissFallsBackWhenConcurrentWinnerIsCorrupt(t *test
 	require.Len(t, graph.Node, 1)
 	assert.Equal(t, "Candidate", graph.Node[0].Name)
 	assert.Equal(t, []string{"current-chunk"}, graph.Node[0].Chunks)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+	assert.Equal(t, [][]byte{[]byte(`{`)}, store.observed)
+	assert.Equal(t, 2, store.putCalls)
+	assert.Equal(t, 1, providerCalls)
+
+	graph, cacheHit, providerCalled, err = completeGraphArtifact(
+		context.Background(), store, request, "current-chunk",
+		func(context.Context) (*types.GraphData, error) {
+			providerCalls++
+			return &types.GraphData{Node: []*types.GraphNode{{Name: "Unexpected"}}}, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.True(t, cacheHit)
+	assert.False(t, providerCalled)
+	assert.Equal(t, 1, providerCalls)
+	require.Len(t, graph.Node, 1)
+	assert.Equal(t, "Candidate", graph.Node[0].Name)
 }
 
-func TestCompleteGraphArtifactCorruptHitRecomputesWithoutReusingWinner(t *testing.T) {
+func TestCompleteGraphArtifactCorruptHitRecomputesAndRepublishes(t *testing.T) {
 	request := testGraphArtifactRequest()
 	key, err := newGraphArtifactKey(request)
 	require.NoError(t, err)
 	store := newChatArtifactFakeStore()
 	store.values[key] = []byte(`{`)
+	providerCalls := 0
 
 	graph, cacheHit, providerCalled, err := completeGraphArtifact(
 		context.Background(),
@@ -339,6 +363,7 @@ func TestCompleteGraphArtifactCorruptHitRecomputesWithoutReusingWinner(t *testin
 		request,
 		"current-chunk",
 		func(context.Context) (*types.GraphData, error) {
+			providerCalls++
 			return &types.GraphData{Node: []*types.GraphNode{{Name: "Fresh"}}}, nil
 		},
 	)
@@ -348,7 +373,49 @@ func TestCompleteGraphArtifactCorruptHitRecomputesWithoutReusingWinner(t *testin
 	assert.True(t, providerCalled)
 	require.Len(t, graph.Node, 1)
 	assert.Equal(t, "Fresh", graph.Node[0].Name)
-	assert.Zero(t, store.putCalls, "immutable corrupt winners cannot be replaced in this stage")
+	assert.Equal(t, 1, store.putCalls)
+	assert.Equal(t, 1, providerCalls)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+	assert.Equal(t, [][]byte{[]byte(`{`)}, store.observed)
+
+	graph, cacheHit, providerCalled, err = completeGraphArtifact(
+		context.Background(), store, request, "current-chunk",
+		func(context.Context) (*types.GraphData, error) {
+			providerCalls++
+			return &types.GraphData{Node: []*types.GraphNode{{Name: "Unexpected"}}}, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.True(t, cacheHit)
+	assert.False(t, providerCalled)
+	assert.Equal(t, 1, providerCalls)
+	require.Len(t, graph.Node, 1)
+	assert.Equal(t, "Fresh", graph.Node[0].Name)
+}
+
+func TestCompleteGraphArtifactStopsWhenInvalidationFails(t *testing.T) {
+	request := testGraphArtifactRequest()
+	key, err := newGraphArtifactKey(request)
+	require.NoError(t, err)
+	store := newChatArtifactFakeStore()
+	store.values[key] = []byte(`{`)
+	store.invalidateErr = errors.New("invalidate failed")
+	providerCalls := 0
+
+	graph, cacheHit, providerCalled, err := completeGraphArtifact(
+		context.Background(), store, request, "current-chunk",
+		func(context.Context) (*types.GraphData, error) {
+			providerCalls++
+			return &types.GraphData{Node: []*types.GraphNode{{Name: "Fresh"}}}, nil
+		},
+	)
+
+	assert.ErrorIs(t, err, store.invalidateErr)
+	assert.Nil(t, graph)
+	assert.False(t, cacheHit)
+	assert.False(t, providerCalled)
+	assert.Zero(t, providerCalls)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
 }
 
 func TestCompleteGraphArtifactBypassDoesNotRequireCacheIdentity(t *testing.T) {

--- a/internal/application/service/graph_artifact_cache_test.go
+++ b/internal/application/service/graph_artifact_cache_test.go
@@ -1,0 +1,471 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGraphArtifactKeyCoversExtractionInputs(t *testing.T) {
+	base := testGraphArtifactRequest()
+	baseKey, err := newGraphArtifactKey(base)
+	require.NoError(t, err)
+	assert.Equal(t, "chat.graph-extraction", baseKey.Stage)
+	assert.Equal(t, uint16(1), baseKey.KeyVersion)
+
+	tests := []struct {
+		name   string
+		mutate func(*graphArtifactRequest)
+	}{
+		{name: "tenant", mutate: func(r *graphArtifactRequest) { r.tenantID++ }},
+		{name: "model", mutate: func(r *graphArtifactRequest) {
+			r.model = &chatArtifactFakeModel{modelID: "model-2", modelName: "chat"}
+		}},
+		{name: "model revision", mutate: func(r *graphArtifactRequest) { r.modelRevision = "revision-2" }},
+		{name: "chunk content", mutate: func(r *graphArtifactRequest) { r.messages[1].Content = "other" }},
+		{name: "effective prompt", mutate: func(r *graphArtifactRequest) { r.messages[0].Content = "other" }},
+		{name: "options", mutate: func(r *graphArtifactRequest) { r.options.MaxTokens++ }},
+		{name: "prompt version", mutate: func(r *graphArtifactRequest) { r.promptVersion = "graph-prompt-v2" }},
+		{name: "canonicalizer version", mutate: func(r *graphArtifactRequest) {
+			r.canonicalizerVersion = "graph-v2"
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := testGraphArtifactRequest()
+			tt.mutate(&request)
+			key, keyErr := newGraphArtifactKey(request)
+			require.NoError(t, keyErr)
+			assert.NotEqual(t, baseKey, key)
+		})
+	}
+}
+
+func TestNewGraphArtifactKeyRejectsIncompleteExtractionMessages(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*graphArtifactRequest)
+	}{
+		{name: "missing messages", mutate: func(r *graphArtifactRequest) { r.messages = nil }},
+		{name: "missing system prompt", mutate: func(r *graphArtifactRequest) { r.messages[0].Content = "" }},
+		{name: "wrong system role", mutate: func(r *graphArtifactRequest) { r.messages[0].Role = "user" }},
+		{name: "wrong user role", mutate: func(r *graphArtifactRequest) { r.messages[1].Role = "system" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := testGraphArtifactRequest()
+			tt.mutate(&request)
+			_, err := newGraphArtifactKey(request)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestGraphArtifactCodecIsDeterministicAndRebindsNodeOwnership(t *testing.T) {
+	first := &types.GraphData{
+		Text: "source text",
+		Node: []*types.GraphNode{
+			{Name: "Beta", Chunks: []string{"old-chunk"}, Attributes: []string{"z", "a"}},
+			{Name: "Alpha", Chunks: []string{"other-chunk"}},
+		},
+		Relation: []*types.GraphRelation{
+			{Node1: "Beta", Node2: "Alpha", Type: "knows"},
+		},
+	}
+	second := &types.GraphData{
+		Node: []*types.GraphNode{
+			{Name: "Alpha"},
+			{Name: "Beta", Attributes: []string{"a", "z"}},
+		},
+		Relation: []*types.GraphRelation{
+			{Node1: "Beta", Node2: "Alpha", Type: "knows"},
+		},
+	}
+
+	firstPayload, err := encodeGraphArtifact(first)
+	require.NoError(t, err)
+	secondPayload, err := encodeGraphArtifact(second)
+	require.NoError(t, err)
+	assert.Equal(t, firstPayload, secondPayload)
+
+	decoded, err := decodeGraphArtifact(firstPayload, "current-chunk")
+	require.NoError(t, err)
+	assert.Empty(t, decoded.Text)
+	assert.Equal(t, []*types.GraphNode{
+		{Name: "Alpha", Chunks: []string{"current-chunk"}},
+		{Name: "Beta", Chunks: []string{"current-chunk"}, Attributes: []string{"a", "z"}},
+	}, decoded.Node)
+	assert.Equal(t, []*types.GraphRelation{
+		{Node1: "Beta", Node2: "Alpha", Type: "knows", Chunks: []string{"current-chunk"}},
+	}, decoded.Relation)
+
+	assert.Equal(t, []string{"old-chunk"}, first.Node[0].Chunks, "encoding must not mutate provider output")
+	assert.Equal(t, []string{"z", "a"}, first.Node[0].Attributes)
+}
+
+func TestGraphArtifactCodecRebindsRelationOwnership(t *testing.T) {
+	graph := &types.GraphData{
+		Node: []*types.GraphNode{
+			{Name: "Alpha"},
+			{Name: "Beta"},
+		},
+		Relation: []*types.GraphRelation{
+			{Node1: "Alpha", Node2: "Beta", Type: "knows", Chunks: []string{"old-chunk"}},
+		},
+	}
+
+	payload, err := encodeGraphArtifact(graph)
+	require.NoError(t, err)
+	assert.NotContains(t, string(payload), "old-chunk")
+
+	decoded, err := decodeGraphArtifact(payload, "current-chunk")
+	require.NoError(t, err)
+	require.Len(t, decoded.Relation, 1)
+	assert.Equal(t, []string{"current-chunk"}, decoded.Relation[0].Chunks)
+	assert.Equal(t, []string{"old-chunk"}, graph.Relation[0].Chunks, "encoding must not mutate provider output")
+}
+
+func TestGraphArtifactCodecRejectsSelfRelation(t *testing.T) {
+	_, err := encodeGraphArtifact(&types.GraphData{
+		Node: []*types.GraphNode{{Name: "Alpha"}},
+		Relation: []*types.GraphRelation{
+			{Node1: "Alpha", Node2: "Alpha", Type: "knows"},
+		},
+	})
+	require.ErrorContains(t, err, "self relation")
+}
+
+func TestGraphArtifactCodecValidatesSemanticGraph(t *testing.T) {
+	tests := []struct {
+		name  string
+		graph *types.GraphData
+	}{
+		{name: "nil graph"},
+		{name: "nil node", graph: &types.GraphData{Node: []*types.GraphNode{nil}}},
+		{name: "empty node", graph: &types.GraphData{Node: []*types.GraphNode{{Name: " "}}}},
+		{name: "duplicate node", graph: &types.GraphData{Node: []*types.GraphNode{{Name: "A"}, {Name: "A"}}}},
+		{name: "nil relation", graph: &types.GraphData{Relation: []*types.GraphRelation{nil}}},
+		{name: "incomplete relation", graph: &types.GraphData{
+			Node:     []*types.GraphNode{{Name: "A"}, {Name: "B"}},
+			Relation: []*types.GraphRelation{{Node1: "A", Node2: "B"}},
+		}},
+		{name: "unknown relation endpoint", graph: &types.GraphData{
+			Node:     []*types.GraphNode{{Name: "A"}},
+			Relation: []*types.GraphRelation{{Node1: "A", Node2: "B", Type: "knows"}},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := encodeGraphArtifact(tt.graph)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestGraphArtifactCodecDeduplicatesRelationsAcceptedByParser(t *testing.T) {
+	graph := &types.GraphData{
+		Node: []*types.GraphNode{{Name: "A"}, {Name: "B"}},
+		Relation: []*types.GraphRelation{
+			{Node1: "A", Node2: "B", Type: "knows"},
+			{Node1: "A", Node2: "B", Type: "knows"},
+		},
+	}
+
+	payload, err := encodeGraphArtifact(graph)
+	require.NoError(t, err)
+	decoded, err := decodeGraphArtifact(payload, "chunk")
+	require.NoError(t, err)
+	assert.Len(t, decoded.Relation, 1)
+}
+
+func TestDecodeGraphArtifactCanonicalizesPersistedRelationOrderAndDuplicates(t *testing.T) {
+	payload := []byte(`{
+		"version":1,
+		"nodes":[{"name":"B","attributes":[]},{"name":"A","attributes":[]}],
+		"relations":[
+			{"node1":"B","node2":"A","type":"z"},
+			{"node1":"A","node2":"B","type":"a"},
+			{"node1":"A","node2":"B","type":"a"}
+		]
+	}`)
+
+	graph, err := decodeGraphArtifact(payload, "chunk")
+	require.NoError(t, err)
+	require.Len(t, graph.Node, 2)
+	assert.Equal(t, "A", graph.Node[0].Name)
+	require.Len(t, graph.Relation, 2)
+	assert.Equal(t, "A", graph.Relation[0].Node1)
+	assert.Equal(t, "B", graph.Relation[1].Node1)
+}
+
+func TestGraphArtifactCodecCachesEmptyGraph(t *testing.T) {
+	payload, err := encodeGraphArtifact(&types.GraphData{})
+	require.NoError(t, err)
+
+	graph, err := decodeGraphArtifact(payload, "current-chunk")
+	require.NoError(t, err)
+	assert.Empty(t, graph.Node)
+	assert.Empty(t, graph.Relation)
+}
+
+func TestDecodeGraphArtifactRejectsMalformedPayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		chunkID string
+	}{
+		{name: "invalid JSON", payload: `{`, chunkID: "chunk"},
+		{name: "unknown field", payload: `{"version":1,"nodes":[],"relations":[],"extra":true}`, chunkID: "chunk"},
+		{name: "trailing value", payload: `{"version":1,"nodes":[],"relations":[]} {}`, chunkID: "chunk"},
+		{name: "unsupported version", payload: `{"version":2,"nodes":[],"relations":[]}`, chunkID: "chunk"},
+		{name: "missing nodes", payload: `{"version":1,"relations":[]}`, chunkID: "chunk"},
+		{name: "missing relations", payload: `{"version":1,"nodes":[]}`, chunkID: "chunk"},
+		{name: "empty chunk ownership", payload: `{"version":1,"nodes":[],"relations":[]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := decodeGraphArtifact([]byte(tt.payload), tt.chunkID)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestDecodeGraphArtifactRejectsInvalidUTF8(t *testing.T) {
+	payload := append([]byte(`{"version":1,"nodes":[{"name":"`), 0xff)
+	payload = append(payload, []byte(`","attributes":[]}],"relations":[]}`)...)
+
+	_, err := decodeGraphArtifact(payload, "chunk")
+	require.ErrorContains(t, err, "UTF-8")
+}
+
+func TestCompleteGraphArtifactHitSkipsProviderAndRebindsOwnership(t *testing.T) {
+	request := testGraphArtifactRequest()
+	key, err := newGraphArtifactKey(request)
+	require.NoError(t, err)
+	payload, err := encodeGraphArtifact(&types.GraphData{
+		Node: []*types.GraphNode{{Name: "Alpha"}},
+	})
+	require.NoError(t, err)
+	store := newChatArtifactFakeStore()
+	store.values[key] = payload
+	providerCalls := 0
+
+	graph, cacheHit, providerCalled, err := completeGraphArtifact(
+		context.Background(),
+		store,
+		request,
+		"current-chunk",
+		func(context.Context) (*types.GraphData, error) {
+			providerCalls++
+			return nil, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.True(t, cacheHit)
+	assert.False(t, providerCalled)
+	assert.Zero(t, providerCalls)
+	require.Len(t, graph.Node, 1)
+	assert.Equal(t, []string{"current-chunk"}, graph.Node[0].Chunks)
+	assert.Zero(t, store.putCalls)
+}
+
+func TestCompleteGraphArtifactMissUsesPutIfAbsentWinner(t *testing.T) {
+	request := testGraphArtifactRequest()
+	winner, err := encodeGraphArtifact(&types.GraphData{
+		Node: []*types.GraphNode{{Name: "Winner"}},
+	})
+	require.NoError(t, err)
+	store := newChatArtifactFakeStore()
+	store.putCanonical = winner
+
+	graph, cacheHit, providerCalled, err := completeGraphArtifact(
+		context.Background(),
+		store,
+		request,
+		"current-chunk",
+		func(context.Context) (*types.GraphData, error) {
+			return &types.GraphData{Node: []*types.GraphNode{{Name: "Candidate"}}}, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, cacheHit)
+	assert.True(t, providerCalled)
+	require.Len(t, graph.Node, 1)
+	assert.Equal(t, "Winner", graph.Node[0].Name)
+	assert.Equal(t, []string{"current-chunk"}, graph.Node[0].Chunks)
+	assert.Equal(t, 1, store.putCalls)
+}
+
+func TestCompleteGraphArtifactMissFallsBackWhenConcurrentWinnerIsCorrupt(t *testing.T) {
+	request := testGraphArtifactRequest()
+	store := newChatArtifactFakeStore()
+	store.putCanonical = []byte(`{`)
+
+	graph, cacheHit, providerCalled, err := completeGraphArtifact(
+		context.Background(),
+		store,
+		request,
+		"current-chunk",
+		func(context.Context) (*types.GraphData, error) {
+			return &types.GraphData{Node: []*types.GraphNode{{Name: "Candidate"}}}, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, cacheHit)
+	assert.True(t, providerCalled)
+	require.Len(t, graph.Node, 1)
+	assert.Equal(t, "Candidate", graph.Node[0].Name)
+	assert.Equal(t, []string{"current-chunk"}, graph.Node[0].Chunks)
+}
+
+func TestCompleteGraphArtifactCorruptHitRecomputesWithoutReusingWinner(t *testing.T) {
+	request := testGraphArtifactRequest()
+	key, err := newGraphArtifactKey(request)
+	require.NoError(t, err)
+	store := newChatArtifactFakeStore()
+	store.values[key] = []byte(`{`)
+
+	graph, cacheHit, providerCalled, err := completeGraphArtifact(
+		context.Background(),
+		store,
+		request,
+		"current-chunk",
+		func(context.Context) (*types.GraphData, error) {
+			return &types.GraphData{Node: []*types.GraphNode{{Name: "Fresh"}}}, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, cacheHit)
+	assert.True(t, providerCalled)
+	require.Len(t, graph.Node, 1)
+	assert.Equal(t, "Fresh", graph.Node[0].Name)
+	assert.Zero(t, store.putCalls, "immutable corrupt winners cannot be replaced in this stage")
+}
+
+func TestCompleteGraphArtifactBypassDoesNotRequireCacheIdentity(t *testing.T) {
+	request := testGraphArtifactRequest()
+	request.model = nil
+	request.modelRevision = ""
+
+	graph, cacheHit, providerCalled, err := completeGraphArtifact(
+		context.Background(),
+		nil,
+		request,
+		"current-chunk",
+		func(context.Context) (*types.GraphData, error) {
+			return &types.GraphData{Node: []*types.GraphNode{{Name: "Fresh"}}}, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, cacheHit)
+	assert.True(t, providerCalled)
+	assert.Equal(t, []string{"current-chunk"}, graph.Node[0].Chunks)
+}
+
+func TestCompleteGraphArtifactPropagatesFailures(t *testing.T) {
+	request := testGraphArtifactRequest()
+	t.Run("get", func(t *testing.T) {
+		want := errors.New("get failed")
+		store := newChatArtifactFakeStore()
+		store.getErr = want
+		_, _, providerCalled, err := completeGraphArtifact(
+			context.Background(), store, request, "chunk",
+			func(context.Context) (*types.GraphData, error) {
+				t.Fatal("provider must not run after a store read failure")
+				return nil, nil
+			},
+		)
+		require.ErrorIs(t, err, want)
+		assert.False(t, providerCalled)
+	})
+	t.Run("put", func(t *testing.T) {
+		want := errors.New("put failed")
+		store := newChatArtifactFakeStore()
+		store.putErr = want
+		_, _, providerCalled, err := completeGraphArtifact(
+			context.Background(), store, request, "chunk",
+			func(context.Context) (*types.GraphData, error) { return &types.GraphData{}, nil },
+		)
+		require.ErrorIs(t, err, want)
+		assert.True(t, providerCalled)
+	})
+	t.Run("provider", func(t *testing.T) {
+		want := errors.New("provider failed")
+		_, _, providerCalled, err := completeGraphArtifact(
+			context.Background(), newChatArtifactFakeStore(), request, "chunk",
+			func(context.Context) (*types.GraphData, error) { return nil, want },
+		)
+		require.ErrorIs(t, err, want)
+		assert.True(t, providerCalled)
+	})
+}
+
+func TestExtractGraphArtifactReusesAcrossCurrentChunkOwnership(t *testing.T) {
+	model := &chatArtifactFakeModel{
+		modelID:   "model-1",
+		modelName: "chat",
+		response: &types.ChatResponse{Content: `[
+			{"entity":"Alpha","entity_attributes":["person"]},
+			{"entity":"Beta","entity_attributes":["person"]},
+			{"entity1":"Alpha","entity2":"Beta","relation":"knows"}
+		]`},
+	}
+	store := newChatArtifactFakeStore()
+	template := &types.PromptTemplateStructured{
+		Description: "Extract entities using these relation tags: %s",
+		Tags:        []string{"knows"},
+	}
+
+	first, firstHit, firstProviderCalled, err := extractGraphArtifact(
+		context.Background(), store, 7, "chunk-1", model, "revision-1", template, "same content",
+	)
+	require.NoError(t, err)
+	second, secondHit, secondProviderCalled, err := extractGraphArtifact(
+		context.Background(), store, 7, "chunk-2", model, "revision-1", template, "same content",
+	)
+	require.NoError(t, err)
+
+	assert.False(t, firstHit)
+	assert.True(t, firstProviderCalled)
+	assert.True(t, secondHit)
+	assert.False(t, secondProviderCalled)
+	assert.Equal(t, 1, model.calls)
+	assert.Equal(t, []string{"chunk-1"}, first.Node[0].Chunks)
+	assert.Equal(t, []string{"chunk-1"}, first.Relation[0].Chunks)
+	assert.Equal(t, []string{"chunk-2"}, second.Node[0].Chunks)
+	assert.Equal(t, []string{"chunk-2"}, second.Relation[0].Chunks)
+	require.NotNil(t, model.gotOptions.Thinking)
+	assert.False(t, *model.gotOptions.Thinking)
+	assert.Equal(t, 0.3, model.gotOptions.Temperature)
+	assert.Equal(t, 4096, model.gotOptions.MaxTokens)
+}
+
+func testGraphArtifactRequest() graphArtifactRequest {
+	thinking := false
+	return graphArtifactRequest{
+		tenantID:      7,
+		model:         &chatArtifactFakeModel{modelID: "model-1", modelName: "chat"},
+		modelRevision: "revision-1",
+		messages: []chat.Message{
+			{Role: "system", Content: "extract graph"},
+			{Role: "user", Content: "chunk content"},
+		},
+		options: &chat.ChatOptions{
+			Temperature: 0.3,
+			MaxTokens:   4096,
+			Thinking:    &thinking,
+		},
+		promptVersion:        "graph-prompt-v1",
+		canonicalizerVersion: "graph-v1",
+	}
+}

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -25,6 +25,12 @@ import (
 )
 
 const (
+	vlmOCRDefaultPromptVersion     = "ocr-default-v1"
+	vlmOCRScannedPromptVersion     = "ocr-scanned-pdf-v1"
+	vlmCaptionPromptVersion        = "caption-v1"
+	vlmOCRCanonicalizerVersion     = "ocr-sanitizer-v1"
+	vlmCaptionCanonicalizerVersion = "caption-trim-space-v1"
+
 	vlmOCRPrompt = "<system_prompt>\n" +
 		"You are an OCR assistant. Your task is to extract all body text content from this document image and output in pure Markdown format.\n" +
 		"</system_prompt>\n\n" +
@@ -83,7 +89,8 @@ type ImageMultimodalService struct {
 
 	// spanTracker records this image's subspan under the parent attempt's
 	// multimodal stage. nil-safe — falls back to no-op via tracker().
-	spanTracker SpanTracker
+	spanTracker   SpanTracker
+	artifactStore interfaces.ProcessingArtifactStore
 }
 
 func NewImageMultimodalService(
@@ -100,6 +107,7 @@ func NewImageMultimodalService(
 	fileSvc interfaces.FileService,
 	storageResolver interfaces.StorageBackendResolver,
 	spanTracker SpanTracker,
+	artifactStore interfaces.ProcessingArtifactStore,
 ) interfaces.TaskHandler {
 	return &ImageMultimodalService{
 		chunkService:    chunkService,
@@ -115,6 +123,7 @@ func NewImageMultimodalService(
 		fileSvc:         fileSvc,
 		storageResolver: storageResolver,
 		spanTracker:     spanTracker,
+		artifactStore:   artifactStore,
 	}
 }
 
@@ -218,7 +227,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 	}()
 
-	vlmModel, vlmCfg, err := s.resolveVLM(ctx, payload.KnowledgeBaseID, payload.KnowledgeID)
+	vlmModel, vlmCfg, modelRevision, err := s.resolveVLM(ctx, payload.KnowledgeBaseID, payload.KnowledgeID)
 	if err != nil {
 		handleErr = fmt.Errorf("resolve VLM: %w", err)
 		return handleErr
@@ -253,8 +262,10 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 
 	if payload.EnableOCR {
 		prompt := vlmOCRPrompt
+		promptVersion := vlmOCRDefaultPromptVersion
 		if payload.ImageSourceType == "scanned_pdf" {
 			prompt = vlmOCRScannedPDFPrompt
+			promptVersion = vlmOCRScannedPromptVersion
 			logger.Infof(ctx, "[ImageMultimodal] Using scanned PDF prompt for OCR: %s", payload.ImageURL)
 			imgOut["ocr_prompt"] = "scanned_pdf"
 		} else {
@@ -262,12 +273,27 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 		prompt = types.AppendCustomPromptInstructions(prompt, vlmCfg.CustomInstructions, "image_ocr")
 
-		ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt)
+		ocrText, cacheHit, ocrErr := predictVLMArtifact(ctx, s.artifactStore, vlmArtifactRequest{
+			tenantID:             payload.TenantID,
+			imageBytes:           imgBytes,
+			model:                vlmModel,
+			modelRevision:        modelRevision,
+			config:               vlmCfg,
+			prompt:               prompt,
+			promptVersion:        promptVersion,
+			resultKind:           vlmArtifactOCR,
+			canonicalizerVersion: vlmOCRCanonicalizerVersion,
+			canonicalize:         sanitizeOCRText,
+		})
 		if ocrErr != nil {
+			if errors.Is(ocrErr, errVLMArtifactStore) {
+				handleErr = fmt.Errorf("cache OCR result: %w", ocrErr)
+				return handleErr
+			}
 			logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
 			imgOut["ocr_error"] = ocrErr.Error()
 		} else {
-			ocrText = sanitizeOCRText(ocrText)
+			imgOut["ocr_cache_hit"] = cacheHit
 			if ocrText != "" {
 				imageInfo.OCRText = ocrText
 				imgOut["ocr_chars"] = len([]rune(ocrText))
@@ -280,53 +306,38 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 	}
 
-	caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, buildVLMCaptionPrompt(ctx, vlmCfg))
-	if capErr != nil {
-		logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
-		imgOut["caption_error"] = capErr.Error()
-	} else if caption != "" {
-		imageInfo.Caption = caption
-		imgOut["caption_chars"] = len([]rune(caption))
-		imgOut["caption_preview"] = previewText(caption, 200)
-	}
-
-	// Build child chunks for OCR and caption results
-	imageInfoJSON, _ := json.Marshal([]types.ImageInfo{imageInfo})
-	var newChunks []*types.Chunk
-
-	if imageInfo.OCRText != "" {
-		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
-			TenantID:        payload.TenantID,
-			KnowledgeID:     payload.KnowledgeID,
-			KnowledgeBaseID: payload.KnowledgeBaseID,
-			Content:         imageInfo.OCRText,
-			ChunkType:       types.ChunkTypeImageOCR,
-			ParentChunkID:   payload.ChunkID,
-			IsEnabled:       true,
-			Flags:           types.ChunkFlagRecommended,
-			ImageInfo:       string(imageInfoJSON),
-			CreatedAt:       time.Now(),
-			UpdatedAt:       time.Now(),
+	if payload.EnableCaption {
+		captionPrompt := buildVLMCaptionPrompt(ctx, vlmCfg)
+		caption, cacheHit, capErr := predictVLMArtifact(ctx, s.artifactStore, vlmArtifactRequest{
+			tenantID:             payload.TenantID,
+			imageBytes:           imgBytes,
+			model:                vlmModel,
+			modelRevision:        modelRevision,
+			config:               vlmCfg,
+			prompt:               captionPrompt,
+			promptVersion:        vlmCaptionPromptVersion,
+			resultKind:           vlmArtifactCaption,
+			canonicalizerVersion: vlmCaptionCanonicalizerVersion,
+			canonicalize:         strings.TrimSpace,
 		})
+		if capErr != nil {
+			if errors.Is(capErr, errVLMArtifactStore) {
+				handleErr = fmt.Errorf("cache caption result: %w", capErr)
+				return handleErr
+			}
+			logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
+			imgOut["caption_error"] = capErr.Error()
+		} else {
+			imgOut["caption_cache_hit"] = cacheHit
+			if caption != "" {
+				imageInfo.Caption = caption
+				imgOut["caption_chars"] = len([]rune(caption))
+				imgOut["caption_preview"] = previewText(caption, 200)
+			}
+		}
 	}
 
-	if imageInfo.Caption != "" {
-		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
-			TenantID:        payload.TenantID,
-			KnowledgeID:     payload.KnowledgeID,
-			KnowledgeBaseID: payload.KnowledgeBaseID,
-			Content:         imageInfo.Caption,
-			ChunkType:       types.ChunkTypeImageCaption,
-			ParentChunkID:   payload.ChunkID,
-			IsEnabled:       true,
-			Flags:           types.ChunkFlagRecommended,
-			ImageInfo:       string(imageInfoJSON),
-			CreatedAt:       time.Now(),
-			UpdatedAt:       time.Now(),
-		})
-	}
+	newChunks := buildImageMultimodalChunks(payload, imageInfo, time.Now())
 	imgOut["chunks_created"] = len(newChunks)
 
 	if len(newChunks) == 0 {
@@ -357,6 +368,50 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 	// all images are processed before triggering summary/question generation.
 	// Deferred finalize handles the parent knowledge counter.
 	return nil
+}
+
+func buildImageMultimodalChunks(
+	payload types.ImageMultimodalPayload,
+	imageInfo types.ImageInfo,
+	now time.Time,
+) []*types.Chunk {
+	imageInfoJSON, _ := json.Marshal([]types.ImageInfo{imageInfo})
+	var chunks []*types.Chunk
+
+	if imageInfo.OCRText != "" {
+		chunks = append(chunks, &types.Chunk{
+			ID:              uuid.New().String(),
+			TenantID:        payload.TenantID,
+			KnowledgeID:     payload.KnowledgeID,
+			KnowledgeBaseID: payload.KnowledgeBaseID,
+			Content:         imageInfo.OCRText,
+			ChunkType:       types.ChunkTypeImageOCR,
+			ParentChunkID:   payload.ChunkID,
+			IsEnabled:       true,
+			Flags:           types.ChunkFlagRecommended,
+			ImageInfo:       string(imageInfoJSON),
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		})
+	}
+
+	if imageInfo.Caption != "" {
+		chunks = append(chunks, &types.Chunk{
+			ID:              uuid.New().String(),
+			TenantID:        payload.TenantID,
+			KnowledgeID:     payload.KnowledgeID,
+			KnowledgeBaseID: payload.KnowledgeBaseID,
+			Content:         imageInfo.Caption,
+			ChunkType:       types.ChunkTypeImageCaption,
+			ParentChunkID:   payload.ChunkID,
+			IsEnabled:       true,
+			Flags:           types.ChunkFlagRecommended,
+			ImageInfo:       string(imageInfoJSON),
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		})
+	}
+	return chunks
 }
 
 // shouldDropOrphanedMultimodal reports whether the task should exit without
@@ -508,13 +563,17 @@ func (s *ImageMultimodalService) indexChunks(ctx context.Context, payload types.
 // resolveVLM creates a vlm.VLM instance for the given knowledge base,
 // supporting both new-style (ModelID) and legacy (inline BaseURL) configs.
 // Per-upload process_overrides on the knowledge entry take precedence over KB defaults.
-func (s *ImageMultimodalService) resolveVLM(ctx context.Context, kbID, knowledgeID string) (vlm.VLM, types.VLMConfig, error) {
+func (s *ImageMultimodalService) resolveVLM(
+	ctx context.Context,
+	kbID string,
+	knowledgeID string,
+) (vlm.VLM, types.VLMConfig, string, error) {
 	kb, err := s.kbService.GetKnowledgeBaseByIDOnly(ctx, kbID)
 	if err != nil {
-		return nil, types.VLMConfig{}, fmt.Errorf("get knowledge base %s: %w", kbID, err)
+		return nil, types.VLMConfig{}, "", fmt.Errorf("get knowledge base %s: %w", kbID, err)
 	}
 	if kb == nil {
-		return nil, types.VLMConfig{}, fmt.Errorf("knowledge base %s not found", kbID)
+		return nil, types.VLMConfig{}, "", fmt.Errorf("knowledge base %s not found", kbID)
 	}
 
 	var processOverrides *types.KnowledgeProcessOverrides
@@ -525,18 +584,25 @@ func (s *ImageMultimodalService) resolveVLM(ctx context.Context, kbID, knowledge
 	}
 	vlmCfg := ResolveProcessConfig(kb, processOverrides).VLMConfig
 	if !vlmCfg.IsEnabled() {
-		return nil, types.VLMConfig{}, fmt.Errorf("VLM is not enabled for knowledge base %s", kbID)
+		return nil, types.VLMConfig{}, "", fmt.Errorf("VLM is not enabled for knowledge base %s", kbID)
 	}
 
 	// New-style: resolve model through ModelService
 	if vlmCfg.ModelID != "" {
+		modelConfig, err := s.modelService.GetModelByID(ctx, vlmCfg.ModelID)
+		if err != nil {
+			return nil, types.VLMConfig{}, "", err
+		}
+		if modelConfig == nil {
+			return nil, types.VLMConfig{}, "", fmt.Errorf("VLM model %s not found", vlmCfg.ModelID)
+		}
 		model, err := s.modelService.GetVLMModel(ctx, vlmCfg.ModelID)
-		return model, vlmCfg, err
+		return model, vlmCfg, modelConfig.UpdatedAt.UTC().Format(time.RFC3339Nano), err
 	}
 
 	// Legacy: create VLM from inline config
 	model, err := vlm.NewVLMFromLegacyConfig(vlmCfg, s.ollamaService)
-	return model, vlmCfg, err
+	return model, vlmCfg, "", err
 }
 
 // resolveFileServiceForPayload resolves tenant/KB scoped file service for reading provider:// URLs.

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -294,6 +294,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 			imgOut["ocr_error"] = ocrErr.Error()
 		} else {
 			imgOut["ocr_cache_hit"] = cacheHit
+			imgOut["ocr_cache_status"] = processingArtifactTraceCacheStatus(s.artifactStore != nil, cacheHit)
 			if ocrText != "" {
 				imageInfo.OCRText = ocrText
 				imgOut["ocr_chars"] = len([]rune(ocrText))
@@ -329,6 +330,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 			imgOut["caption_error"] = capErr.Error()
 		} else {
 			imgOut["caption_cache_hit"] = cacheHit
+			imgOut["caption_cache_status"] = processingArtifactTraceCacheStatus(s.artifactStore != nil, cacheHit)
 			if caption != "" {
 				imageInfo.Caption = caption
 				imgOut["caption_chars"] = len([]rune(caption))

--- a/internal/application/service/image_multimodal_chunks_test.go
+++ b/internal/application/service/image_multimodal_chunks_test.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildImageMultimodalChunksRebindsToCurrentParent(t *testing.T) {
+	imageInfo := types.ImageInfo{
+		URL:     "provider://bucket/image.png",
+		OCRText: "canonical OCR",
+		Caption: "canonical caption",
+	}
+	now := time.Date(2026, 7, 16, 9, 0, 0, 0, time.UTC)
+
+	first := buildImageMultimodalChunks(types.ImageMultimodalPayload{
+		TenantID:        7,
+		KnowledgeID:     "knowledge-1",
+		KnowledgeBaseID: "kb-1",
+		ChunkID:         "parent-v1",
+	}, imageInfo, now)
+	second := buildImageMultimodalChunks(types.ImageMultimodalPayload{
+		TenantID:        7,
+		KnowledgeID:     "knowledge-1",
+		KnowledgeBaseID: "kb-1",
+		ChunkID:         "parent-v2",
+	}, imageInfo, now)
+
+	require.Len(t, first, 2)
+	require.Len(t, second, 2)
+	for _, chunk := range first {
+		assert.Equal(t, "parent-v1", chunk.ParentChunkID)
+		assert.Equal(t, now, chunk.CreatedAt)
+		assert.Equal(t, now, chunk.UpdatedAt)
+	}
+	for _, chunk := range second {
+		assert.Equal(t, "parent-v2", chunk.ParentChunkID)
+		assert.NotEqual(t, first[0].ID, chunk.ID)
+	}
+	assert.Equal(t, types.ChunkTypeImageOCR, first[0].ChunkType)
+	assert.Equal(t, types.ChunkTypeImageCaption, first[1].ChunkType)
+}
+
+func TestBuildImageMultimodalChunksSkipsEmptyResults(t *testing.T) {
+	chunks := buildImageMultimodalChunks(types.ImageMultimodalPayload{
+		TenantID: 7,
+		ChunkID:  "parent",
+	}, types.ImageInfo{}, time.Now())
+
+	assert.Empty(t, chunks)
+}

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -57,6 +57,7 @@ type knowledgeService struct {
 	fileSvc         interfaces.FileService
 	storageResolver interfaces.StorageBackendResolver
 	modelService    interfaces.ModelService
+	artifactStore   interfaces.ProcessingArtifactStore
 	task            interfaces.TaskEnqueuer
 	taskInspector   interfaces.TaskInspector
 	graphEngine     interfaces.RetrieveGraphRepository
@@ -99,6 +100,7 @@ func NewKnowledgeService(
 	fileSvc interfaces.FileService,
 	storageResolver interfaces.StorageBackendResolver,
 	modelService interfaces.ModelService,
+	artifactStore interfaces.ProcessingArtifactStore,
 	task interfaces.TaskEnqueuer,
 	taskInspector interfaces.TaskInspector,
 	graphEngine interfaces.RetrieveGraphRepository,
@@ -126,6 +128,7 @@ func NewKnowledgeService(
 		fileSvc:         fileSvc,
 		storageResolver: storageResolver,
 		modelService:    modelService,
+		artifactStore:   artifactStore,
 		task:            task,
 		taskInspector:   taskInspector,
 		graphEngine:     graphEngine,

--- a/internal/application/service/knowledge_chunk_reuse.go
+++ b/internal/application/service/knowledge_chunk_reuse.go
@@ -1,0 +1,298 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Tencent/WeKnora/internal/infrastructure/docparser"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+type chunkReusePlan struct {
+	Create          []*types.Chunk
+	Update          []*types.Chunk
+	Index           []*types.Chunk
+	Reuse           []*types.Chunk
+	Delete          []*types.Chunk
+	DeleteGenerated []*types.Chunk
+}
+
+type chunkReconcileOps struct {
+	Create       func(context.Context, []*types.Chunk) error
+	Index        func(context.Context, []*types.Chunk) error
+	Update       func(context.Context, []*types.Chunk) error
+	DeleteVector func(context.Context, []string) error
+	DeleteImages func(context.Context) error
+	HardDelete   func(context.Context, []string) error
+}
+
+func executeChunkReconciliation(
+	ctx context.Context,
+	plan *chunkReusePlan,
+	ops chunkReconcileOps,
+) error {
+	if err := ops.Create(ctx, plan.Create); err != nil {
+		return err
+	}
+	if err := ops.Index(ctx, plan.Index); err != nil {
+		createdIDs := chunkIDs(plan.Create)
+		_ = ops.DeleteVector(ctx, createdIDs)
+		_ = ops.HardDelete(ctx, createdIDs)
+		return err
+	}
+	if err := ops.Update(ctx, plan.Update); err != nil {
+		return err
+	}
+
+	stale := append([]*types.Chunk{}, plan.Delete...)
+	stale = append(stale, plan.DeleteGenerated...)
+	staleIDs := chunkIDs(stale)
+	if err := ops.DeleteVector(ctx, staleIDs); err != nil {
+		return err
+	}
+	if ops.DeleteImages != nil {
+		if err := ops.DeleteImages(ctx); err != nil {
+			return err
+		}
+	}
+	return ops.HardDelete(ctx, staleIDs)
+}
+
+func reparseStorageDelta(newTotal, previousTotal int64) int64 {
+	return newTotal - previousTotal
+}
+
+func staleExtractedImageURLs(
+	ctx context.Context,
+	plan *chunkReusePlan,
+	storedImages []docparser.StoredImage,
+) []string {
+	imageInfos := make([]string, 0, len(plan.Delete)+len(plan.DeleteGenerated))
+	for _, chunk := range append(append([]*types.Chunk{}, plan.Delete...), plan.DeleteGenerated...) {
+		if chunk != nil && chunk.ImageInfo != "" {
+			imageInfos = append(imageInfos, chunk.ImageInfo)
+		}
+	}
+
+	currentURLs := make(map[string]struct{}, len(storedImages))
+	for _, image := range storedImages {
+		if image.ServingURL != "" {
+			currentURLs[image.ServingURL] = struct{}{}
+		}
+	}
+
+	staleURLs := collectImageURLs(ctx, imageInfos)
+	filtered := staleURLs[:0]
+	for _, url := range staleURLs {
+		if _, current := currentURLs[url]; !current {
+			filtered = append(filtered, url)
+		}
+	}
+	return filtered
+}
+
+func buildStableDocumentChunks(
+	knowledge *types.Knowledge,
+	parsedChunks []types.ParsedChunk,
+	parsedParents []types.ParsedParentChunk,
+) ([]*types.Chunk, []*types.Chunk) {
+	allocator := types.NewChunkIDAllocator(knowledge.ID)
+	parents := make([]*types.Chunk, 0, len(parsedParents))
+	for _, parsedParent := range parsedParents {
+		id, contentHash := allocator.Next(types.ChunkTypeParentText, parsedParent.Content)
+		parents = append(parents, &types.Chunk{
+			ID:              id,
+			TenantID:        knowledge.TenantID,
+			KnowledgeID:     knowledge.ID,
+			KnowledgeBaseID: knowledge.KnowledgeBaseID,
+			Content:         parsedParent.Content,
+			ContentHash:     contentHash,
+			ChunkIndex:      parsedParent.Seq,
+			IsEnabled:       true,
+			StartAt:         parsedParent.Start,
+			EndAt:           parsedParent.End,
+			ChunkType:       types.ChunkTypeParentText,
+		})
+	}
+	linkAdjacentChunks(parents)
+
+	text := make([]*types.Chunk, 0, len(parsedChunks))
+	for index, parsedChunk := range parsedChunks {
+		if types.NormalizeChunkContent(parsedChunk.Content) == "" {
+			continue
+		}
+
+		id, contentHash := allocator.Next(types.ChunkTypeText, parsedChunk.Content)
+		chunk := &types.Chunk{
+			ID:              id,
+			TenantID:        knowledge.TenantID,
+			KnowledgeID:     knowledge.ID,
+			KnowledgeBaseID: knowledge.KnowledgeBaseID,
+			Content:         parsedChunk.Content,
+			ContentHash:     contentHash,
+			ContextHeader:   parsedChunk.ContextHeader,
+			ChunkIndex:      parsedChunk.Seq,
+			IsEnabled:       true,
+			StartAt:         parsedChunk.Start,
+			EndAt:           parsedChunk.End,
+			ChunkType:       types.ChunkTypeText,
+		}
+		if parsedChunk.ParentIndex >= 0 && parsedChunk.ParentIndex < len(parents) {
+			chunk.ParentChunkID = parents[parsedChunk.ParentIndex].ID
+		}
+
+		parsedChunks[index].ChunkID = chunk.ID
+		text = append(text, chunk)
+	}
+	if len(parents) == 0 {
+		linkAdjacentChunks(text)
+	}
+
+	desired := make([]*types.Chunk, 0, len(parents)+len(text))
+	desired = append(desired, parents...)
+	desired = append(desired, text...)
+	return desired, text
+}
+
+func setDesiredEmbeddingFingerprints(chunks []*types.Chunk, modelKey string, dimensions int, title string) error {
+	for _, chunk := range chunks {
+		if chunk == nil {
+			continue
+		}
+		fingerprint := types.EmbeddingFingerprint(
+			modelKey,
+			dimensions,
+			types.EmbeddingInput(title, chunk.ContextHeader, chunk.Content),
+		)
+		metadata, err := types.WithChunkEmbeddingFingerprint(chunk.Metadata, fingerprint)
+		if err != nil {
+			return fmt.Errorf("set chunk %q embedding fingerprint: %w", chunk.ID, err)
+		}
+		chunk.Metadata = metadata
+	}
+	return nil
+}
+
+func planChunkReuse(desired, existing []*types.Chunk, indexingEnabled bool) (*chunkReusePlan, error) {
+	plan := &chunkReusePlan{}
+	existingByID := make(map[string]*types.Chunk, len(existing))
+	for _, chunk := range existing {
+		if chunk != nil {
+			existingByID[chunk.ID] = chunk
+		}
+	}
+
+	desiredByID := make(map[string]struct{}, len(desired))
+	for _, chunk := range desired {
+		if chunk == nil {
+			continue
+		}
+		desiredByID[chunk.ID] = struct{}{}
+
+		existingChunk, found := existingByID[chunk.ID]
+		if !found {
+			plan.Create = append(plan.Create, chunk)
+			if indexingEnabled && chunk.ChunkType == types.ChunkTypeText {
+				plan.Index = append(plan.Index, chunk)
+			}
+			continue
+		}
+
+		var desiredFingerprint string
+		if indexingEnabled && chunk.ChunkType == types.ChunkTypeText {
+			var err error
+			desiredFingerprint, err = embeddingFingerprint(chunk.Metadata)
+			if err != nil {
+				return nil, err
+			}
+		}
+		copyReparseOwnedFields(chunk, existingChunk)
+		if indexingEnabled && chunk.ChunkType == types.ChunkTypeText {
+			metadata, err := types.WithChunkEmbeddingFingerprint(chunk.Metadata, desiredFingerprint)
+			if err != nil {
+				return nil, fmt.Errorf("preserve chunk %q metadata: %w", chunk.ID, err)
+			}
+			chunk.Metadata = metadata
+		}
+		plan.Update = append(plan.Update, chunk)
+
+		if !indexingEnabled || chunk.ChunkType != types.ChunkTypeText {
+			continue
+		}
+		if existingChunk.Status == int(types.ChunkStatusIndexed) &&
+			types.ChunkEmbeddingFingerprint(existingChunk.Metadata) == desiredFingerprint {
+			plan.Reuse = append(plan.Reuse, chunk)
+			continue
+		}
+		plan.Index = append(plan.Index, chunk)
+	}
+
+	for _, chunk := range existing {
+		if chunk == nil {
+			continue
+		}
+		if isGeneratedChunk(chunk.ChunkType) {
+			plan.DeleteGenerated = append(plan.DeleteGenerated, chunk)
+			continue
+		}
+		if _, found := desiredByID[chunk.ID]; !found && isBaseChunk(chunk.ChunkType) {
+			plan.Delete = append(plan.Delete, chunk)
+		}
+	}
+
+	return plan, nil
+}
+
+func chunkIDs(chunks []*types.Chunk) []string {
+	ids := make([]string, 0, len(chunks))
+	for _, chunk := range chunks {
+		if chunk != nil {
+			ids = append(ids, chunk.ID)
+		}
+	}
+	return ids
+}
+
+func linkAdjacentChunks(chunks []*types.Chunk) {
+	for index := 1; index < len(chunks); index++ {
+		chunks[index-1].NextChunkID = chunks[index].ID
+		chunks[index].PreChunkID = chunks[index-1].ID
+	}
+}
+
+func embeddingFingerprint(metadata types.JSON) (string, error) {
+	values, err := metadata.Map()
+	if err != nil {
+		return "", fmt.Errorf("read desired embedding fingerprint: %w", err)
+	}
+	fingerprint, _ := values[types.ChunkEmbeddingFingerprintMetadataKey].(string)
+	return fingerprint, nil
+}
+
+func copyReparseOwnedFields(desired, existing *types.Chunk) {
+	desired.SeqID = existing.SeqID
+	desired.CreatedAt = existing.CreatedAt
+	desired.Flags = existing.Flags
+	desired.Status = existing.Status
+	desired.RelationChunks = append(types.JSON(nil), existing.RelationChunks...)
+	desired.IndirectRelationChunks = append(types.JSON(nil), existing.IndirectRelationChunks...)
+	desired.ImageInfo = existing.ImageInfo
+	desired.Metadata = append(types.JSON(nil), existing.Metadata...)
+}
+
+func isBaseChunk(chunkType types.ChunkType) bool {
+	return chunkType == types.ChunkTypeText || chunkType == types.ChunkTypeParentText
+}
+
+func isGeneratedChunk(chunkType types.ChunkType) bool {
+	switch chunkType {
+	case types.ChunkTypeSummary,
+		types.ChunkTypeImageOCR,
+		types.ChunkTypeImageCaption,
+		types.ChunkTypeEntity,
+		types.ChunkTypeRelationship:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/application/service/knowledge_chunk_reuse.go
+++ b/internal/application/service/knowledge_chunk_reuse.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/infrastructure/docparser"
 	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
 )
 
 type chunkReusePlan struct {
@@ -23,6 +24,7 @@ type chunkReconcileOps struct {
 	Update       func(context.Context, []*types.Chunk) error
 	DeleteVector func(context.Context, []string) error
 	DeleteImages func(context.Context) error
+	DeleteGraph  func(context.Context, []string) error
 	HardDelete   func(context.Context, []string) error
 }
 
@@ -52,6 +54,11 @@ func executeChunkReconciliation(
 	}
 	if ops.DeleteImages != nil {
 		if err := ops.DeleteImages(ctx); err != nil {
+			return err
+		}
+	}
+	if ops.DeleteGraph != nil {
+		if err := ops.DeleteGraph(ctx, graphContributorChunkIDs(stale)); err != nil {
 			return err
 		}
 	}
@@ -251,6 +258,51 @@ func chunkIDs(chunks []*types.Chunk) []string {
 		}
 	}
 	return ids
+}
+
+func graphContributorChunkIDs(chunks []*types.Chunk) []string {
+	ids := make([]string, 0, len(chunks))
+	for _, chunk := range chunks {
+		if chunk == nil {
+			continue
+		}
+		switch chunk.ChunkType {
+		case types.ChunkTypeText, types.ChunkTypeImageOCR, types.ChunkTypeImageCaption:
+			ids = append(ids, chunk.ID)
+		}
+	}
+	return ids
+}
+
+func cleanupReparseGraph(
+	ctx context.Context,
+	repository interfaces.RetrieveGraphRepository,
+	namespace types.NameSpace,
+	attempt int,
+	graphEnabled bool,
+	staleChunkIDs []string,
+) error {
+	if err := repository.FenceGraphAttempt(ctx, namespace, attempt); err != nil {
+		return err
+	}
+	if !graphEnabled {
+		return repository.DelGraph(ctx, []types.NameSpace{namespace})
+	}
+	if err := repository.RecoverGraphNamespace(ctx, namespace); err != nil {
+		return err
+	}
+	if len(staleChunkIDs) == 0 {
+		return nil
+	}
+	return repository.DelGraphChunks(ctx, namespace, staleChunkIDs)
+}
+
+func effectiveKnowledgeGraphEnabled(kb *types.KnowledgeBase, knowledge *types.Knowledge) bool {
+	var overrides *types.KnowledgeProcessOverrides
+	if knowledge != nil {
+		overrides, _ = knowledge.ProcessOverrides()
+	}
+	return ResolveProcessConfig(kb, overrides).GraphEnabled
 }
 
 func linkAdjacentChunks(chunks []*types.Chunk) {

--- a/internal/application/service/knowledge_chunk_reuse_test.go
+++ b/internal/application/service/knowledge_chunk_reuse_test.go
@@ -1,0 +1,179 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildStableDocumentChunksAssignsStableLinksAndHashes(t *testing.T) {
+	knowledge := &types.Knowledge{ID: "knowledge-1", TenantID: 1, KnowledgeBaseID: "kb-1"}
+	parsed := []types.ParsedChunk{
+		{Content: "child one", ContextHeader: "Section A", Seq: 2, Start: 10, End: 19, ParentIndex: 0},
+		{Content: "child two", Seq: 3, Start: 20, End: 29, ParentIndex: 1},
+	}
+	parents := []types.ParsedParentChunk{
+		{Content: "parent one", Seq: 0, Start: 0, End: 9},
+		{Content: "parent two", Seq: 1, Start: 10, End: 29},
+	}
+
+	desired, text := buildStableDocumentChunks(knowledge, parsed, parents)
+
+	require.Len(t, desired, 4)
+	require.Len(t, text, 2)
+	assert.Equal(t, types.ChunkTypeParentText, desired[0].ChunkType)
+	assert.Equal(t, types.ChunkTypeParentText, desired[1].ChunkType)
+	assert.Equal(t, desired[1].ID, desired[0].NextChunkID)
+	assert.Equal(t, desired[0].ID, desired[1].PreChunkID)
+	assert.Equal(t, desired[0].ID, text[0].ParentChunkID)
+	assert.Equal(t, desired[1].ID, text[1].ParentChunkID)
+	assert.Equal(t, text[0].ID, parsed[0].ChunkID)
+	assert.Equal(t, text[1].ID, parsed[1].ChunkID)
+	assert.Equal(t, "Section A", text[0].ContextHeader)
+
+	for _, chunk := range desired {
+		assert.Equal(t, types.ChunkContentHash(chunk.Content), chunk.ContentHash)
+	}
+
+	againParsed := []types.ParsedChunk{
+		{Content: "child one", ContextHeader: "Section A", Seq: 2, Start: 10, End: 19, ParentIndex: 0},
+		{Content: "child two", Seq: 3, Start: 20, End: 29, ParentIndex: 1},
+	}
+	again, _ := buildStableDocumentChunks(knowledge, againParsed, parents)
+	assert.Equal(t, chunkIDs(desired), chunkIDs(again))
+
+	flatParsed := []types.ParsedChunk{{Content: "alpha", Seq: 0}, {Content: "beta", Seq: 1}}
+	_, flatText := buildStableDocumentChunks(knowledge, flatParsed, nil)
+	assert.Equal(t, flatText[1].ID, flatText[0].NextChunkID)
+	assert.Equal(t, flatText[0].ID, flatText[1].PreChunkID)
+}
+
+func TestPlanChunkReuseSeparatesReuseIndexAndCleanup(t *testing.T) {
+	knowledge := &types.Knowledge{ID: "knowledge-1", TenantID: 1, KnowledgeBaseID: "kb-1", Title: "Doc"}
+	desired, text := buildStableDocumentChunks(knowledge, []types.ParsedChunk{
+		{Content: "alpha", Seq: 0},
+		{Content: "beta", Seq: 1},
+	}, nil)
+	require.NoError(t, setDesiredEmbeddingFingerprints(text, "model-1", 1536, knowledge.Title))
+
+	alphaOld := cloneChunk(desired[0])
+	alphaOld.SeqID = 9
+	alphaOld.CreatedAt = time.Unix(123, 0).UTC()
+	alphaOld.Flags = types.ChunkFlagRecommended
+	alphaOld.RelationChunks = types.JSON(`["relationship-1"]`)
+	alphaOld.IndirectRelationChunks = types.JSON(`["relationship-2"]`)
+	alphaOld.ImageInfo = `[{"url":"image-1"}]`
+	alphaOld.Status = int(types.ChunkStatusIndexed)
+	alphaOld.Metadata = types.JSON(`{"questions":["q1"],"_weknora_embedding_fingerprint":"` +
+		types.ChunkEmbeddingFingerprint(desired[0].Metadata) + `"}`)
+	betaOld := cloneChunk(desired[1])
+	betaOld.Status = int(types.ChunkStatusStored)
+	stale := &types.Chunk{ID: "stale", ChunkType: types.ChunkTypeText}
+	summary := &types.Chunk{ID: "summary", ChunkType: types.ChunkTypeSummary}
+
+	plan, err := planChunkReuse(desired, []*types.Chunk{alphaOld, betaOld, stale, summary}, true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{alphaOld.ID}, chunkIDs(plan.Reuse))
+	assert.Equal(t, []string{betaOld.ID}, chunkIDs(plan.Index))
+	assert.Equal(t, []string{"stale"}, chunkIDs(plan.Delete))
+	assert.Equal(t, []string{"summary"}, chunkIDs(plan.DeleteGenerated))
+
+	assert.Equal(t, alphaOld.SeqID, desired[0].SeqID)
+	assert.Equal(t, alphaOld.CreatedAt, desired[0].CreatedAt)
+	assert.Equal(t, alphaOld.Flags, desired[0].Flags)
+	assert.Equal(t, alphaOld.RelationChunks, desired[0].RelationChunks)
+	assert.Equal(t, alphaOld.IndirectRelationChunks, desired[0].IndirectRelationChunks)
+	assert.Equal(t, alphaOld.ImageInfo, desired[0].ImageInfo)
+	assert.Equal(t, alphaOld.Status, desired[0].Status)
+	assert.Equal(t, betaOld.Status, desired[1].Status)
+	values, err := desired[0].Metadata.Map()
+	require.NoError(t, err)
+	assert.Equal(t, []any{"q1"}, values["questions"])
+	assert.Equal(t, types.ChunkEmbeddingFingerprint(alphaOld.Metadata), types.ChunkEmbeddingFingerprint(desired[0].Metadata))
+}
+
+func TestPlanChunkReuseIndexesOnlyChangedFingerprint(t *testing.T) {
+	knowledge := &types.Knowledge{ID: "knowledge-1", TenantID: 1, KnowledgeBaseID: "kb-1", Title: "Doc"}
+	desired, text := buildStableDocumentChunks(knowledge, []types.ParsedChunk{
+		{Content: "alpha", Seq: 0},
+		{Content: "beta", Seq: 1},
+	}, nil)
+	require.NoError(t, setDesiredEmbeddingFingerprints(text, "model-1", 1536, knowledge.Title))
+
+	existing := []*types.Chunk{cloneChunk(desired[0]), cloneChunk(desired[1])}
+	for _, chunk := range existing {
+		chunk.Status = int(types.ChunkStatusIndexed)
+	}
+	require.NoError(t, setDesiredEmbeddingFingerprints([]*types.Chunk{desired[1]}, "model-2", 1536, knowledge.Title))
+
+	plan, err := planChunkReuse(desired, existing, true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{desired[0].ID}, chunkIDs(plan.Reuse))
+	assert.Equal(t, []string{desired[1].ID}, chunkIDs(plan.Index))
+}
+
+func TestPlanChunkReuseWithoutIndexingPreservesExistingMetadata(t *testing.T) {
+	desired := []*types.Chunk{{ID: "stable", ChunkType: types.ChunkTypeText}}
+	existing := cloneChunk(desired[0])
+	existing.Metadata = types.JSON("  {\n" +
+		`    "questions": ["q1"],` + "\n" +
+		`    "_weknora_embedding_fingerprint": "keep",` + "\n" +
+		`    "nested": {"answer": 42}` + "\n" +
+		"  }")
+	original := append(types.JSON(nil), existing.Metadata...)
+	originalValues, err := original.Map()
+	require.NoError(t, err)
+
+	plan, err := planChunkReuse(desired, []*types.Chunk{existing}, false)
+
+	require.NoError(t, err)
+	require.Len(t, plan.Update, 1)
+	assert.Equal(t, original, desired[0].Metadata)
+	updatedValues, err := desired[0].Metadata.Map()
+	require.NoError(t, err)
+	assert.Equal(t, originalValues, updatedValues)
+}
+
+func TestPlanChunkReuseWithoutIndexingPreservesMalformedExistingMetadata(t *testing.T) {
+	desired := []*types.Chunk{{ID: "stable", ChunkType: types.ChunkTypeText}}
+	existing := cloneChunk(desired[0])
+	existing.Metadata = types.JSON(`{`)
+
+	plan, err := planChunkReuse(desired, []*types.Chunk{existing}, false)
+
+	require.NoError(t, err)
+	require.Len(t, plan.Update, 1)
+	assert.Equal(t, types.JSON(`{`), desired[0].Metadata)
+}
+
+func TestPlanChunkReuseClassifiesGeneratedAndLeavesUnrelatedChunks(t *testing.T) {
+	generated := []*types.Chunk{
+		{ID: "summary", ChunkType: types.ChunkTypeSummary},
+		{ID: "ocr", ChunkType: types.ChunkTypeImageOCR},
+		{ID: "caption", ChunkType: types.ChunkTypeImageCaption},
+		{ID: "entity", ChunkType: types.ChunkTypeEntity},
+		{ID: "relationship", ChunkType: types.ChunkTypeRelationship},
+		{ID: "faq", ChunkType: types.ChunkTypeFAQ},
+	}
+
+	plan, err := planChunkReuse(nil, generated, true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"summary", "ocr", "caption", "entity", "relationship"}, chunkIDs(plan.DeleteGenerated))
+	assert.Empty(t, plan.Delete)
+	assert.Empty(t, plan.Create)
+	assert.Empty(t, plan.Update)
+}
+
+func TestSetDesiredEmbeddingFingerprintsRejectsInvalidMetadata(t *testing.T) {
+	err := setDesiredEmbeddingFingerprints([]*types.Chunk{{Content: "alpha", Metadata: types.JSON(`{`)}}, "model-1", 1536, "Doc")
+	require.Error(t, err)
+}
+
+func cloneChunk(chunk *types.Chunk) *types.Chunk {
+	cloned := *chunk
+	cloned.Metadata = append(types.JSON(nil), chunk.Metadata...)
+	return &cloned
+}

--- a/internal/application/service/knowledge_clone_image_test.go
+++ b/internal/application/service/knowledge_clone_image_test.go
@@ -20,6 +20,7 @@ type countingFileService struct {
 	copiedFrom  []string
 	failOnURL   string // when non-empty, CopyFile returns an error for this srcPath
 	deleteCalls int
+	deleteErr   error
 }
 
 func (c *countingFileService) CheckConnectivity(ctx context.Context) error { return nil }
@@ -42,7 +43,7 @@ func (c *countingFileService) GetFileURL(ctx context.Context, filePath string) (
 
 func (c *countingFileService) DeleteFile(ctx context.Context, filePath string) error {
 	c.deleteCalls++
-	return nil
+	return c.deleteErr
 }
 
 func (c *countingFileService) CopyFile(ctx context.Context, srcPath string, tenantID uint64, knowledgeID string) (string, error) {

--- a/internal/application/service/knowledge_delete.go
+++ b/internal/application/service/knowledge_delete.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io/fs"
 	"strings"
 	"time"
 
@@ -53,6 +55,17 @@ func deleteExtractedImages(ctx context.Context, fileSvc interfaces.FileService, 
 			logger.Errorf(ctx, "Failed to delete extracted image %s: %v", url, err)
 		}
 	}
+}
+
+// deleteExtractedImagesStrict removes stale image objects before their source
+// chunk rows are hard-deleted, so a failed delete remains retryable.
+func deleteExtractedImagesStrict(ctx context.Context, fileSvc interfaces.FileService, imageURLs []string) error {
+	for _, url := range imageURLs {
+		if err := fileSvc.DeleteFile(ctx, url); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("delete extracted image %s: %w", url, err)
+		}
+	}
+	return nil
 }
 
 // DeleteKnowledge deletes a knowledge entry and all related resources

--- a/internal/application/service/knowledge_docreader_artifact_cache_test.go
+++ b/internal/application/service/knowledge_docreader_artifact_cache_test.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type docReaderArtifactFileService struct {
+	interfaces.FileService
+	content []byte
+}
+
+func (s docReaderArtifactFileService) GetFile(context.Context, string) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(s.content)), nil
+}
+
+func TestConvertReusesDocReaderArtifact(t *testing.T) {
+	store := newDocReaderArtifactFakeStore()
+	reader := &docReaderArtifactFakeReader{
+		result:   testDocReaderResult("first parse"),
+		identity: "http:https://docreader-one.example.com",
+	}
+	service := &knowledgeService{
+		documentReader: reader,
+		fileSvc:        docReaderArtifactFileService{content: []byte("document bytes")},
+		artifactStore:  store,
+	}
+	payload := types.DocumentProcessPayload{
+		TenantID: 7,
+		FilePath: "knowledge/document.pdf",
+		FileName: "document.pdf",
+		FileType: "pdf",
+	}
+	kb := &types.KnowledgeBase{ID: "kb-1"}
+	knowledge := &types.Knowledge{ID: "knowledge-1", TenantID: 7, Title: "Document"}
+	effective := types.EffectiveProcessConfig{ChunkingConfig: types.ChunkingConfig{
+		ParserEngineRules: []types.ParserEngineRule{{FileTypes: []string{"pdf"}, Engine: "builtin"}},
+	}}
+
+	first, err := service.convert(context.Background(), payload, kb, knowledge, effective, false)
+	require.NoError(t, err)
+	require.Equal(t, "first parse", first.MarkdownContent)
+
+	reader.result = testDocReaderResult("second parse")
+	second, err := service.convert(context.Background(), payload, kb, knowledge, effective, false)
+	require.NoError(t, err)
+	assert.Equal(t, "first parse", second.MarkdownContent)
+	assert.Equal(t, 1, reader.calls)
+	assert.Equal(t, 1, store.putCalls)
+}
+
+func TestConvertInvalidatesDocReaderArtifactWhenReaderIdentityChanges(t *testing.T) {
+	store := newDocReaderArtifactFakeStore()
+	reader := &docReaderArtifactFakeReader{
+		result:   testDocReaderResult("first parse"),
+		identity: "http:https://docreader-one.example.com",
+	}
+	service := &knowledgeService{
+		documentReader: reader,
+		fileSvc:        docReaderArtifactFileService{content: []byte("document bytes")},
+		artifactStore:  store,
+	}
+	payload := types.DocumentProcessPayload{
+		TenantID: 7,
+		FilePath: "knowledge/document.pdf",
+		FileName: "document.pdf",
+		FileType: "pdf",
+	}
+	kb := &types.KnowledgeBase{ID: "kb-1"}
+	knowledge := &types.Knowledge{ID: "knowledge-1", TenantID: 7, Title: "Document"}
+	effective := types.EffectiveProcessConfig{ChunkingConfig: types.ChunkingConfig{
+		ParserEngineRules: []types.ParserEngineRule{{FileTypes: []string{"pdf"}, Engine: "builtin"}},
+	}}
+
+	first, err := service.convert(context.Background(), payload, kb, knowledge, effective, false)
+	require.NoError(t, err)
+	require.Equal(t, "first parse", first.MarkdownContent)
+
+	reader.identity = "http:https://docreader-two.example.com"
+	reader.result = testDocReaderResult("second parse")
+	second, err := service.convert(context.Background(), payload, kb, knowledge, effective, false)
+	require.NoError(t, err)
+	assert.Equal(t, "second parse", second.MarkdownContent)
+	assert.Equal(t, 2, reader.calls)
+}
+
+func TestConvertDocReaderArtifactInvalidationAndBypass(t *testing.T) {
+	t.Run("parser change invalidates", func(t *testing.T) {
+		store := newDocReaderArtifactFakeStore()
+		reader := &docReaderArtifactFakeReader{
+			result:   testDocReaderResult("parsed"),
+			identity: "test:docreader",
+		}
+		service := &knowledgeService{
+			documentReader: reader,
+			fileSvc:        docReaderArtifactFileService{content: []byte("document bytes")},
+			artifactStore:  store,
+		}
+		payload := types.DocumentProcessPayload{TenantID: 7, FilePath: "knowledge/document.pdf", FileName: "document.pdf", FileType: "pdf"}
+		kb := &types.KnowledgeBase{ID: "kb-1"}
+		knowledge := &types.Knowledge{ID: "knowledge-1", TenantID: 7}
+		builtin := types.EffectiveProcessConfig{ChunkingConfig: types.ChunkingConfig{ParserEngineRules: []types.ParserEngineRule{{FileTypes: []string{"pdf"}, Engine: "builtin"}}}}
+		changed := types.EffectiveProcessConfig{ChunkingConfig: types.ChunkingConfig{ParserEngineRules: []types.ParserEngineRule{{FileTypes: []string{"pdf"}, Engine: "opendataloader"}}}}
+
+		_, err := service.convert(context.Background(), payload, kb, knowledge, builtin, false)
+		require.NoError(t, err)
+		_, err = service.convert(context.Background(), payload, kb, knowledge, changed, false)
+		require.NoError(t, err)
+		assert.Equal(t, 2, reader.calls)
+	})
+
+	for _, test := range []struct {
+		name      string
+		withStore bool
+		fileURL   string
+	}{
+		{name: "nil store", withStore: false},
+		{name: "downloaded temporary URL", withStore: true, fileURL: "https://example.com/document.pdf"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			reader := &docReaderArtifactFakeReader{result: testDocReaderResult("parsed")}
+			service := &knowledgeService{
+				documentReader: reader,
+				fileSvc:        docReaderArtifactFileService{content: []byte("document bytes")},
+			}
+			if test.withStore {
+				service.artifactStore = newDocReaderArtifactFakeStore()
+			}
+			payload := types.DocumentProcessPayload{TenantID: 7, FilePath: "knowledge/document.pdf", FileName: "document.pdf", FileType: "pdf", FileURL: test.fileURL}
+			kb := &types.KnowledgeBase{ID: "kb-1"}
+			knowledge := &types.Knowledge{ID: "knowledge-1", TenantID: 7}
+			effective := types.EffectiveProcessConfig{ChunkingConfig: types.ChunkingConfig{ParserEngineRules: []types.ParserEngineRule{{FileTypes: []string{"pdf"}, Engine: "builtin"}}}}
+
+			_, err := service.convert(context.Background(), payload, kb, knowledge, effective, false)
+			require.NoError(t, err)
+			_, err = service.convert(context.Background(), payload, kb, knowledge, effective, false)
+			require.NoError(t, err)
+			assert.Equal(t, 2, reader.calls)
+		})
+	}
+}

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -730,6 +730,22 @@ const imageDominatedTextThreshold = 200
 // chunk's raw content (which would just be a bare image reference).
 var errInsufficientSummaryContent = errors.New("insufficient text content for summary generation")
 
+const (
+	summaryArtifactStage                = "chat.summary"
+	summaryArtifactKeyVersion    uint16 = 1
+	summaryPromptVersion                = "summary-prompt-v1"
+	summaryCanonicalizerVersion         = "summary-completion-v1"
+	questionArtifactStage               = "chat.questions"
+	questionArtifactKeyVersion   uint16 = 1
+	questionPromptVersion               = "questions-prompt-v1"
+	questionCanonicalizerVersion        = "questions-parser-v1"
+)
+
+func stableSummaryChunkID(knowledgeID string) string {
+	id, _ := types.NewChunkIDAllocator(knowledgeID).Next(types.ChunkTypeSummary, "")
+	return id
+}
+
 // checkSufficientSummaryContent returns errInsufficientSummaryContent if the
 // given content does not carry enough real text (after stripping image markup)
 // for an LLM summary call, and logs a warning at the call site. Returns nil
@@ -751,11 +767,11 @@ func checkSufficientSummaryContent(ctx context.Context, knowledgeID, content str
 
 // getSummary generates a summary for knowledge content using an AI model
 func (s *knowledgeService) getSummary(ctx context.Context,
-	summaryModel chat.Chat, knowledge *types.Knowledge, chunks []*types.Chunk,
-) (string, error) {
+	summaryModel chat.Chat, modelRevision string, knowledge *types.Knowledge, chunks []*types.Chunk,
+) (string, bool, error) {
 	// Get knowledge info from the first chunk
 	if len(chunks) == 0 {
-		return "", fmt.Errorf("no chunks provided for summary generation")
+		return "", false, fmt.Errorf("no chunks provided for summary generation")
 	}
 
 	// Determine max input chars from config
@@ -824,7 +840,7 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 	// hallucinate a scanner manual instead of admitting the document had no
 	// extractable text.
 	if err := checkSufficientSummaryContent(ctx, knowledge.ID, chunkContents); err != nil {
-		return "", err
+		return "", false, err
 	}
 
 	// Pass the raw chunk text to the LLM with no filename / file-type framing.
@@ -841,7 +857,7 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 		"language": types.LanguageNameFromContext(ctx),
 	})
 	thinking := false
-	summary, err := summaryModel.Chat(ctx, []chat.Message{
+	messages := []chat.Message{
 		{
 			Role:    "system",
 			Content: summaryPrompt,
@@ -850,17 +866,50 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 			Role:    "user",
 			Content: contentWithMetadata,
 		},
-	}, &chat.ChatOptions{
+	}
+	options := &chat.ChatOptions{
 		Temperature: 0.3,
 		MaxTokens:   maxTokens,
 		Thinking:    &thinking,
+	}
+	store := s.artifactStore
+	if strings.TrimSpace(modelRevision) == "" {
+		store = nil
+	}
+	summary, hit, _, err := completeChatArtifact(ctx, store, chatArtifactRequest{
+		tenantID:             knowledge.TenantID,
+		stage:                summaryArtifactStage,
+		keyVersion:           summaryArtifactKeyVersion,
+		model:                summaryModel,
+		modelRevision:        modelRevision,
+		messages:             messages,
+		options:              options,
+		promptVersion:        summaryPromptVersion,
+		canonicalizerVersion: summaryCanonicalizerVersion,
 	})
 	if err != nil {
 		logger.GetLogger(ctx).WithField("error", err).Errorf("GetSummary failed")
-		return "", err
+		return "", false, err
 	}
-	logger.GetLogger(ctx).WithField("summary", summary.Content).Infof("GetSummary success")
-	return summary.Content, nil
+	logger.GetLogger(ctx).WithField("summary", summary).Infof("GetSummary success")
+	return summary, hit, nil
+}
+
+func (s *knowledgeService) resolveChatArtifactRevision(ctx context.Context, modelID string) string {
+	if s.artifactStore == nil {
+		return ""
+	}
+	model, err := s.modelService.GetModelByID(ctx, modelID)
+	if err != nil {
+		logger.Warnf(ctx, "Chat artifact cache disabled for model %s: failed to load model revision: %v", modelID, err)
+		return ""
+	}
+	revision, err := chatArtifactModelRevision(model)
+	if err != nil {
+		logger.Warnf(ctx, "Chat artifact cache disabled for model %s: %v", modelID, err)
+		return ""
+	}
+	return revision
 }
 
 // sampleLongContent returns content that fits within maxChars.
@@ -1062,7 +1111,9 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 	}
 
 	// Generate summary
-	summary, err := s.getSummary(ctx, chatModel, knowledge, textChunks)
+	modelRevision := s.resolveChatArtifactRevision(ctx, kb.SummaryModelID)
+	summary, summaryCacheHit, err := s.getSummary(ctx, chatModel, modelRevision, knowledge, textChunks)
+	summaryOut["summary_cache_hit"] = summaryCacheHit
 	if err != nil {
 		logger.Errorf(ctx, "Failed to generate summary for knowledge %s: %v", payload.KnowledgeID, err)
 		// Surface the underlying LLM/IO error on the span so the trace UI
@@ -1072,6 +1123,11 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 		// (deadline exceeded vs unexpected EOF vs 5xx, etc.).
 		summaryOut["error"] = previewText(err.Error(), 500)
 		summaryOut["error_type"] = fmt.Sprintf("%T", err)
+		if isChatArtifactPipelineError(err) {
+			markSummaryFailed()
+			summaryErr = err
+			return fmt.Errorf("summary artifact pipeline failed: %w", err)
+		}
 		// For the insufficient-content case (scanned PDF without OCR, etc.)
 		// we deliberately do NOT fall back to the first chunk's raw content,
 		// since that chunk is typically just a bare markdown image reference
@@ -1134,12 +1190,14 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 		// unreliable signal (e.g. "MX5280.pdf" for a scanned legal letter)
 		// and surfacing them in retrieved RAG context can re-introduce the
 		// hallucination vector this branch is meant to close.
+		summaryContent := fmt.Sprintf("# Summary\n%s", summary)
 		summaryChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              stableSummaryChunkID(knowledge.ID),
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
-			Content:         fmt.Sprintf("# Summary\n%s", summary),
+			Content:         summaryContent,
+			ContentHash:     types.ChunkContentHash(summaryContent),
 			ChunkIndex:      maxChunkIndex + 1,
 			IsEnabled:       true,
 			CreatedAt:       time.Now(),
@@ -1150,11 +1208,26 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 			ParentChunkID:   textChunks[0].ID,
 		}
 
-		// Save summary chunk
-		if err := s.chunkService.CreateChunks(ctx, []*types.Chunk{summaryChunk}); err != nil {
-			logger.Errorf(ctx, "Failed to create summary chunk: %v", err)
-			summaryErr = err
-			return fmt.Errorf("failed to create summary chunk: %w", err)
+		// Reuse the deterministic row when a downstream failure retries this task.
+		existingSummary, getErr := s.chunkRepo.GetChunkByID(ctx, knowledge.TenantID, summaryChunk.ID)
+		if getErr == nil {
+			summaryChunk.SeqID = existingSummary.SeqID
+			summaryChunk.CreatedAt = existingSummary.CreatedAt
+			if err := s.chunkService.UpdateChunk(ctx, summaryChunk); err != nil {
+				logger.Errorf(ctx, "Failed to update summary chunk: %v", err)
+				summaryErr = err
+				return fmt.Errorf("failed to update summary chunk: %w", err)
+			}
+		} else if errors.Is(getErr, ErrChunkNotFound) {
+			if err := s.chunkService.CreateChunks(ctx, []*types.Chunk{summaryChunk}); err != nil {
+				logger.Errorf(ctx, "Failed to create summary chunk: %v", err)
+				summaryErr = err
+				return fmt.Errorf("failed to create summary chunk: %w", err)
+			}
+		} else {
+			logger.Errorf(ctx, "Failed to inspect summary chunk: %v", getErr)
+			summaryErr = getErr
+			return fmt.Errorf("failed to inspect summary chunk: %w", getErr)
 		}
 
 		// Index summary chunk
@@ -1240,6 +1313,7 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 	llmCallSuccess := 0
 	llmCallFailed := 0
 	llmCallEmpty := 0
+	questionCacheHits := 0
 	generatedQuestionsTotal := 0
 	chunkMetadataSetFailed := 0
 	chunkUpdateFailed := 0
@@ -1277,7 +1351,7 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 	defer func() {
 		logger.Infof(
 			ctx,
-			"Question generation stats: knowledge=%s kb=%s retry=%d/%d status=%s elapsed=%s chunks(total=%d,text=%d,empty_text=%d) llm(attempt=%d,success=%d,empty=%d,failed=%d) generated_questions=%d chunk_update_failed=%d metadata_set_failed=%d index(prepared=%d,attempted=%v,succeeded=%v)",
+			"Question generation stats: knowledge=%s kb=%s retry=%d/%d status=%s elapsed=%s chunks(total=%d,text=%d,empty_text=%d) llm(attempt=%d,success=%d,empty=%d,failed=%d) cache_hits=%d generated_questions=%d chunk_update_failed=%d metadata_set_failed=%d index(prepared=%d,attempted=%v,succeeded=%v)",
 			payload.KnowledgeID,
 			payload.KnowledgeBaseID,
 			retryCount,
@@ -1291,6 +1365,7 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 			llmCallSuccess,
 			llmCallEmpty,
 			llmCallFailed,
+			questionCacheHits,
 			generatedQuestionsTotal,
 			chunkUpdateFailed,
 			chunkMetadataSetFailed,
@@ -1308,6 +1383,7 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 				"llm_success":            llmCallSuccess,
 				"llm_empty":              llmCallEmpty,
 				"llm_failed":             llmCallFailed,
+				"question_cache_hits":    questionCacheHits,
 				"questions_generated":    generatedQuestionsTotal,
 				"chunk_update_failed":    chunkUpdateFailed,
 				"metadata_set_failed":    chunkMetadataSetFailed,
@@ -1442,6 +1518,7 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 		return fmt.Errorf("failed to get chat model: %w", err)
 	}
 	resolvedModelID = kb.SummaryModelID
+	modelRevision := s.resolveChatArtifactRevision(ctx, kb.SummaryModelID)
 
 	// Initialize embedding model and retrieval engine
 	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
@@ -1496,6 +1573,7 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 
 	// Generate questions for each chunk with context
 	var indexInfoList []*types.IndexInfo
+	var questionUpdates []generatedQuestionUpdate
 	for i, chunk := range textChunks {
 		if strings.TrimSpace(chunk.Content) == "" {
 			emptyContentChunks++
@@ -1511,63 +1589,53 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 			nextContent = enrichContent(textChunks[i+1])
 		}
 
-		llmCallAttempts++
-		questions, err := s.generateQuestionsWithContext(ctx, chatModel, enrichContent(chunk), prevContent, nextContent,
+		questions, cacheHit, providerCalled, err := s.generateQuestionsWithContext(ctx, chatModel, modelRevision, enrichContent(chunk), prevContent, nextContent,
 			knowledge.Title, questionCount, customInstructions)
+		if providerCalled {
+			llmCallAttempts++
+		}
 		if err != nil {
-			llmCallFailed++
+			if isChatArtifactPipelineError(err) {
+				if providerCalled {
+					llmCallSuccess++
+				}
+				exitStatus = "question_artifact_failed"
+				qErr = err
+				logger.Errorf(ctx, "Question artifact pipeline failed for chunk %s: %v", chunk.ID, err)
+				return fmt.Errorf("question artifact pipeline failed for chunk %s: %w", chunk.ID, err)
+			}
+			if providerCalled {
+				llmCallFailed++
+			}
 			logger.Warnf(ctx, "Failed to generate questions for chunk %s: %v", chunk.ID, err)
 			continue
 		}
+		if cacheHit {
+			questionCacheHits++
+		}
 
 		if len(questions) == 0 {
-			llmCallEmpty++
+			if providerCalled {
+				llmCallEmpty++
+			}
 			continue
 		}
-		llmCallSuccess++
+		if providerCalled {
+			llmCallSuccess++
+		}
 		generatedQuestionsTotal += len(questions)
 		if sampleQuestion == "" && len(questions) > 0 {
 			sampleQuestion = previewText(questions[0], 200)
 		}
 
-		// Update chunk metadata with unique IDs for each question
-		generatedQuestions := make([]types.GeneratedQuestion, len(questions))
-		for j, question := range questions {
-			questionID := fmt.Sprintf("q%d", time.Now().UnixNano()+int64(j))
-			generatedQuestions[j] = types.GeneratedQuestion{
-				ID:       questionID,
-				Question: question,
-			}
-		}
-		meta := &types.DocumentChunkMetadata{
-			GeneratedQuestions: generatedQuestions,
-		}
-		if err := chunk.SetDocumentMetadata(meta); err != nil {
+		update, entries, err := prepareGeneratedQuestionUpdate(chunk, knowledge, questions)
+		if err != nil {
 			chunkMetadataSetFailed++
-			logger.Warnf(ctx, "Failed to set document metadata for chunk %s: %v", chunk.ID, err)
+			logger.Warnf(ctx, "Failed to prepare generated questions for chunk %s: %v", chunk.ID, err)
 			continue
 		}
-
-		// Update chunk in database
-		if err := s.chunkService.UpdateChunk(ctx, chunk); err != nil {
-			chunkUpdateFailed++
-			logger.Warnf(ctx, "Failed to update chunk %s: %v", chunk.ID, err)
-			continue
-		}
-
-		// Create index entries for generated questions
-		for _, gq := range generatedQuestions {
-			sourceID := fmt.Sprintf("%s-%s", chunk.ID, gq.ID)
-			indexInfoList = append(indexInfoList, &types.IndexInfo{
-				Content:         gq.Question,
-				SourceID:        sourceID,
-				SourceType:      types.ChunkSourceType,
-				ChunkID:         chunk.ID,
-				KnowledgeID:     knowledge.ID,
-				KnowledgeBaseID: knowledge.KnowledgeBaseID,
-				IsEnabled:       true,
-			})
-		}
+		questionUpdates = append(questionUpdates, update)
+		indexInfoList = append(indexInfoList, entries...)
 		logger.Debugf(ctx, "Generated %d questions for chunk %s", len(questions), chunk.ID)
 	}
 	indexEntriesPrepared = len(indexInfoList)
@@ -1582,6 +1650,12 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 		}
 		indexBatchSucceeded = true
 		logger.Infof(ctx, "Successfully indexed %d generated questions for knowledge: %s", len(indexInfoList), payload.KnowledgeID)
+	}
+	if err := s.applyGeneratedQuestionUpdates(ctx, retrieveEngine, embeddingModel, kb, questionUpdates); err != nil {
+		exitStatus = "update_questions_failed"
+		chunkUpdateFailed++
+		logger.Errorf(ctx, "Failed to publish generated questions: %v", err)
+		return fmt.Errorf("failed to publish generated questions: %w", err)
 	}
 
 	return nil
@@ -1611,6 +1685,8 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 	chunksProcessed := 0
 	emptyChunks := 0
 	llmCallFailed := 0
+	chunkMetadataSetFailed := 0
+	questionCacheHits := 0
 	generatedQuestionsTotal := 0
 	indexEntriesPrepared := 0
 	indexBatchSucceeded := false
@@ -1638,8 +1714,9 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 	}()
 	defer func() {
 		logger.Infof(ctx,
-			"Question generation (batch) stats: knowledge=%s batch=%d chunks(in_batch=%d,processed=%d,empty=%d) llm_failed=%d retry=%d/%d status=%s elapsed=%s generated_questions=%d index(entries=%d,succeeded=%v)",
+			"Question generation (batch) stats: knowledge=%s batch=%d chunks(in_batch=%d,processed=%d,empty=%d) llm_failed=%d metadata_set_failed=%d cache_hits=%d retry=%d/%d status=%s elapsed=%s generated_questions=%d index(entries=%d,succeeded=%v)",
 			payload.KnowledgeID, payload.BatchIndex, chunksInBatch, chunksProcessed, emptyChunks, llmCallFailed,
+			chunkMetadataSetFailed, questionCacheHits,
 			retryCount, maxRetry, exitStatus, time.Since(taskStartedAt).Round(time.Millisecond),
 			generatedQuestionsTotal, indexEntriesPrepared, indexBatchSucceeded,
 		)
@@ -1651,6 +1728,8 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 				"chunks_processed":       chunksProcessed,
 				"empty_chunks":           emptyChunks,
 				"llm_failed":             llmCallFailed,
+				"metadata_set_failed":    chunkMetadataSetFailed,
+				"question_cache_hits":    questionCacheHits,
 				"questions_generated":    generatedQuestionsTotal,
 				"index_entries_prepared": indexEntriesPrepared,
 				"index_batch_succeeded":  indexBatchSucceeded,
@@ -1744,6 +1823,7 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 		return fmt.Errorf("failed to get chat model: %w", err)
 	}
 	resolvedModelID = kb.SummaryModelID
+	modelRevision := s.resolveChatArtifactRevision(ctx, kb.SummaryModelID)
 
 	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
 	if err != nil {
@@ -1836,19 +1916,31 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 	}
 
 	var indexInfoList []*types.IndexInfo
+	var questionUpdates []generatedQuestionUpdate
 	for i, chunk := range batchChunks {
 		if chunk == nil || strings.TrimSpace(chunk.Content) == "" {
 			emptyChunks++
 			continue
 		}
 
-		questions, gerr := s.generateQuestionsWithContext(
-			ctx, chatModel, enrich(chunk), prevContentAt(i), nextContentAt(i), knowledge.Title, questionCount,
+		questions, cacheHit, providerCalled, gerr := s.generateQuestionsWithContext(
+			ctx, chatModel, modelRevision, enrich(chunk), prevContentAt(i), nextContentAt(i), knowledge.Title, questionCount,
 			customInstructions)
 		if gerr != nil {
-			llmCallFailed++
+			if isChatArtifactPipelineError(gerr) {
+				exitStatus = "question_artifact_failed"
+				qErr = gerr
+				logger.Errorf(ctx, "Question artifact pipeline failed for chunk %s: %v", chunk.ID, gerr)
+				return fmt.Errorf("question artifact pipeline failed for chunk %s: %w", chunk.ID, gerr)
+			}
+			if providerCalled {
+				llmCallFailed++
+			}
 			logger.Warnf(ctx, "Failed to generate questions for chunk %s: %v", chunk.ID, gerr)
 			continue
+		}
+		if cacheHit {
+			questionCacheHits++
 		}
 		if len(questions) == 0 {
 			continue
@@ -1859,33 +1951,14 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 			sampleQuestion = previewText(questions[0], 200)
 		}
 
-		generatedQuestions := make([]types.GeneratedQuestion, len(questions))
-		for j, question := range questions {
-			generatedQuestions[j] = types.GeneratedQuestion{
-				ID:       fmt.Sprintf("q%d", time.Now().UnixNano()+int64(j)),
-				Question: question,
-			}
-		}
-		meta := &types.DocumentChunkMetadata{GeneratedQuestions: generatedQuestions}
-		if err := chunk.SetDocumentMetadata(meta); err != nil {
-			logger.Warnf(ctx, "Failed to set document metadata for chunk %s: %v", chunk.ID, err)
+		update, entries, err := prepareGeneratedQuestionUpdate(chunk, knowledge, questions)
+		if err != nil {
+			chunkMetadataSetFailed++
+			logger.Warnf(ctx, "Failed to prepare generated questions for chunk %s: %v", chunk.ID, err)
 			continue
 		}
-		if err := s.chunkService.UpdateChunk(ctx, chunk); err != nil {
-			logger.Warnf(ctx, "Failed to update chunk %s: %v", chunk.ID, err)
-			continue
-		}
-		for _, gq := range generatedQuestions {
-			indexInfoList = append(indexInfoList, &types.IndexInfo{
-				Content:         gq.Question,
-				SourceID:        fmt.Sprintf("%s-%s", chunk.ID, gq.ID),
-				SourceType:      types.ChunkSourceType,
-				ChunkID:         chunk.ID,
-				KnowledgeID:     knowledge.ID,
-				KnowledgeBaseID: knowledge.KnowledgeBaseID,
-				IsEnabled:       true,
-			})
-		}
+		questionUpdates = append(questionUpdates, update)
+		indexInfoList = append(indexInfoList, entries...)
 	}
 
 	indexEntriesPrepared = len(indexInfoList)
@@ -1900,21 +1973,27 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 		logger.Infof(ctx, "Indexed %d generated questions for knowledge=%s batch=%d",
 			len(indexInfoList), payload.KnowledgeID, payload.BatchIndex)
 	}
+	if err := s.applyGeneratedQuestionUpdates(ctx, retrieveEngine, embeddingModel, kb, questionUpdates); err != nil {
+		exitStatus = "update_questions_failed"
+		qErr = err
+		logger.Errorf(ctx, "Failed to publish generated questions for batch %d: %v", payload.BatchIndex, err)
+		return fmt.Errorf("failed to publish generated questions: %w", err)
+	}
 	return nil
 }
 
 // generateQuestionsWithContext generates questions for a chunk with surrounding context
 func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
-	chatModel chat.Chat, content, prevContent, nextContent, docName string, questionCount int,
+	chatModel chat.Chat, modelRevision, content, prevContent, nextContent, docName string, questionCount int,
 	customInstructions string,
-) ([]string, error) {
+) ([]string, bool, bool, error) {
 	if content == "" || questionCount <= 0 {
-		return nil, nil
+		return nil, false, false, nil
 	}
 
 	prompt := strings.TrimSpace(s.config.Conversation.GenerateQuestionsPrompt)
 	if prompt == "" {
-		return nil, fmt.Errorf("generate questions prompt not configured")
+		return nil, false, false, fmt.Errorf("generate questions prompt not configured")
 	}
 
 	// Build context section
@@ -1941,39 +2020,41 @@ func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
 	prompt = types.AppendCustomPromptInstructions(prompt, customInstructions, "question_generation")
 
 	thinking := false
-	response, err := chatModel.Chat(ctx, []chat.Message{
+	messages := []chat.Message{
 		{
 			Role:    "user",
 			Content: prompt,
 		},
-	}, &chat.ChatOptions{
+	}
+	options := &chat.ChatOptions{
 		Temperature: 0.7,
 		MaxTokens:   512,
 		Thinking:    &thinking,
+	}
+	store := s.artifactStore
+	if strings.TrimSpace(modelRevision) == "" {
+		store = nil
+	}
+	completion, hit, providerCalled, err := completeChatArtifact(ctx, store, chatArtifactRequest{
+		tenantID:             types.MustTenantIDFromContext(ctx),
+		stage:                questionArtifactStage,
+		keyVersion:           questionArtifactKeyVersion,
+		model:                chatModel,
+		modelRevision:        modelRevision,
+		messages:             messages,
+		options:              options,
+		promptVersion:        questionPromptVersion,
+		canonicalizerVersion: questionCanonicalizerVersion,
+		valuePolicy:          generatedQuestionArtifactPolicy(questionCount),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate questions: %w", err)
+		return nil, false, providerCalled, fmt.Errorf("failed to generate questions: %w", err)
 	}
-
-	// Parse response
-	lines := strings.Split(response.Content, "\n")
-	questions := make([]string, 0, questionCount)
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		line = strings.TrimLeft(line, "0123456789.-*) ")
-		line = strings.TrimSpace(line)
-		if line != "" && len(line) > 5 {
-			questions = append(questions, line)
-			if len(questions) >= questionCount {
-				break
-			}
-		}
+	questions, err := decodeGeneratedQuestionArtifact(completion)
+	if err != nil {
+		return nil, false, providerCalled, fmt.Errorf("decode generated question artifact: %w", err)
 	}
-
-	return questions, nil
+	return questions, hit, providerCalled, nil
 }
 
 // ReparseKnowledge schedules asynchronous reparsing. Manual knowledge retains its

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -573,6 +573,23 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 					DeleteImages: func(ctx context.Context) error {
 						return deleteExtractedImagesStrict(ctx, s.resolveFileService(ctx, kb), staleImageURLs)
 					},
+					DeleteGraph: func(ctx context.Context, ids []string) error {
+						if err := checkReconciliationAbort(ctx, "graph cleanup"); err != nil {
+							return err
+						}
+						namespace := types.NameSpace{
+							KnowledgeBase: knowledge.KnowledgeBaseID,
+							Knowledge:     knowledge.ID,
+						}
+						return cleanupReparseGraph(
+							ctx,
+							s.graphEngine,
+							namespace,
+							attemptFromCtx(ctx),
+							effectiveKnowledgeGraphEnabled(kb, knowledge),
+							ids,
+						)
+					},
 					HardDelete: func(ctx context.Context, ids []string) error {
 						if len(ids) == 0 {
 							return nil
@@ -596,14 +613,6 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 					); err != nil {
 						return err
 					}
-				}
-
-				if err := checkReconciliationAbort(reconcileCtx, "graph cleanup"); err != nil {
-					return err
-				}
-				namespace := types.NameSpace{KnowledgeBase: knowledge.KnowledgeBaseID, Knowledge: knowledge.ID}
-				if err := s.graphEngine.DelGraph(reconcileCtx, []types.NameSpace{namespace}); err != nil {
-					return err
 				}
 
 				knowledge.EmbeddingModelID = kb.EmbeddingModelID

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -1123,6 +1123,9 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 	modelRevision := s.resolveChatArtifactRevision(ctx, kb.SummaryModelID)
 	summary, summaryCacheHit, err := s.getSummary(ctx, chatModel, modelRevision, knowledge, textChunks)
 	summaryOut["summary_cache_hit"] = summaryCacheHit
+	summaryOut["summary_cache_status"] = processingArtifactTraceCacheStatus(
+		s.artifactStore != nil && strings.TrimSpace(modelRevision) != "", summaryCacheHit,
+	)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to generate summary for knowledge %s: %v", payload.KnowledgeID, err)
 		// Surface the underlying LLM/IO error on the span so the trace UI
@@ -3287,7 +3290,7 @@ func (s *knowledgeService) convert(
 		// outlive the source fetch semantics through the parse cache.
 		sourcePath = ""
 	}
-	result, cacheHit, err := readDocReaderArtifact(ctx, s.artifactStore, docReaderArtifactRequest{
+	result, cacheHit, cacheStatus, err := readDocReaderArtifactWithCacheStatus(ctx, s.artifactStore, docReaderArtifactRequest{
 		tenantID:   payload.TenantID,
 		sourcePath: sourcePath,
 		read: func(callCtx context.Context, callReq *types.ReadRequest) (*types.ReadResult, error) {
@@ -3321,10 +3324,11 @@ func (s *knowledgeService) convert(
 		return nil, nil
 	}
 	docOutput := types.JSONMap{
-		"text_length":         len(result.MarkdownContent),
-		"images_found":        len(result.ImageRefs),
-		"is_audio":            result.IsAudio,
-		"docreader_cache_hit": cacheHit,
+		"text_length":            len(result.MarkdownContent),
+		"images_found":           len(result.ImageRefs),
+		"is_audio":               result.IsAudio,
+		"docreader_cache_hit":    cacheHit,
+		"docreader_cache_status": cacheStatus,
 	}
 	if pages := result.Metadata["pages"]; pages != "" {
 		docOutput["pages"] = pages

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -3146,6 +3146,7 @@ func (s *knowledgeService) convert(
 	if isURL {
 		parserEngine = eff.ChunkingConfig.ResolveParserEngine("url")
 	}
+	parserEngine = normalizeDocReaderArtifactEngine(parserEngine)
 
 	logger.Infof(ctx, "[convert] kb=%s fileType=%s isURL=%v engine=%q rules=%+v",
 		kb.ID, fileType, isURL, parserEngine, eff.ChunkingConfig.ParserEngineRules)
@@ -3190,7 +3191,22 @@ func (s *knowledgeService) convert(
 		req.FileType = fileType
 	}
 
-	result, err := s.callDocReaderWithTimeout(ctx, reader, req)
+	sourcePath := payload.FilePath
+	if payload.FileURL != "" {
+		// FileURL imports are downloaded into temporary storage and must not
+		// outlive the source fetch semantics through the parse cache.
+		sourcePath = ""
+	}
+	result, cacheHit, err := readDocReaderArtifact(ctx, s.artifactStore, docReaderArtifactRequest{
+		tenantID:   payload.TenantID,
+		sourcePath: sourcePath,
+		read: func(callCtx context.Context, callReq *types.ReadRequest) (*types.ReadResult, error) {
+			return s.callDocReaderWithTimeout(callCtx, reader, callReq)
+		},
+		readerIdentity: docReaderArtifactReaderIdentity(reader),
+		renderVersion:  docReaderArtifactRenderVersionV1,
+		readRequest:    req,
+	})
 	if err != nil {
 		// Distinguish DocReader timeout (a knowable user-facing
 		// failure) from generic read errors so the UI can suggest
@@ -3215,9 +3231,10 @@ func (s *knowledgeService) convert(
 		return nil, nil
 	}
 	docOutput := types.JSONMap{
-		"text_length":  len(result.MarkdownContent),
-		"images_found": len(result.ImageRefs),
-		"is_audio":     result.IsAudio,
+		"text_length":         len(result.MarkdownContent),
+		"images_found":        len(result.ImageRefs),
+		"is_audio":            result.IsAudio,
+		"docreader_cache_hit": cacheHit,
 	}
 	if pages := result.Metadata["pages"]; pages != "" {
 		docOutput["pages"] = pages

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -164,6 +164,23 @@ type ProcessChunksOptions struct {
 	Metadata     map[string]string
 }
 
+type knowledgeCommitOps struct {
+	Persist  func() error
+	Finalize func()
+	Enqueue  func()
+}
+
+func executeKnowledgeCommit(ops knowledgeCommitOps) error {
+	if err := ops.Persist(); err != nil {
+		return err
+	}
+	if ops.Finalize != nil {
+		ops.Finalize()
+	}
+	ops.Enqueue()
+	return nil
+}
+
 // finalizeIndexedKnowledgeState makes a document retrievable as soon as chunks
 // and indexes are persisted (enable_status=enabled), but it deliberately does
 // NOT mark the row completed when enrichment is still expected. Whenever the
@@ -266,17 +283,29 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		options = opts[0]
 	}
 
-	// Check if knowledge is being deleted/cancelled before processing.
-	// Both statuses short-circuit identically here — there's nothing to clean
-	// up yet so the branch is purely "stop early".
-	if aborted, status := s.isKnowledgeAborted(ctx, knowledge.TenantID, knowledge.ID); aborted {
-		logger.Infof(ctx, "Knowledge aborted (%s), skipping chunk processing: %s", status, knowledge.ID)
+	reconciliationAborted := errors.New("chunk reconciliation aborted")
+	checkReconciliationAbort := func(checkCtx context.Context, checkpoint string) error {
+		attempt := attemptFromCtx(checkCtx)
+		if attemptSuperseded(checkCtx, s.tracker(), knowledge.ID, attempt) {
+			logger.Infof(checkCtx, "Knowledge attempt %d superseded at %s, skipping chunk reconciliation: %s",
+				attempt, checkpoint, knowledge.ID)
+			return reconciliationAborted
+		}
+		if aborted, status := s.isKnowledgeAborted(checkCtx, knowledge.TenantID, knowledge.ID); aborted {
+			logger.Infof(checkCtx, "Knowledge aborted (%s) at %s, skipping chunk reconciliation: %s",
+				status, checkpoint, knowledge.ID)
+			return reconciliationAborted
+		}
+		return nil
+	}
+	if err := checkReconciliationAbort(ctx, "start"); err != nil {
 		return
 	}
 
 	// Get embedding model for vectorization — only needed when vector/keyword indexing is enabled
+	indexingEnabled := kb.NeedsEmbeddingModel()
 	var embeddingModel embedding.Embedder
-	if kb.NeedsEmbeddingModel() {
+	if indexingEnabled {
 		var err error
 		embeddingModel, err = s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
 		if err != nil {
@@ -287,36 +316,30 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping embedding model", kb.ID)
 	}
 
-	// 幂等性处理：清理旧的chunks和索引数据，避免重复数据
-	logger.Infof(ctx, "Cleaning up existing chunks and index data for knowledge: %s", knowledge.ID)
-
-	// 删除旧的chunks
-	if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
-		logger.Warnf(ctx, "Failed to delete existing chunks (may not exist): %v", err)
-		// 不返回错误，继续处理（可能没有旧数据）
-	}
-
-	// 删除旧的索引数据 — only when vector/keyword indexing is enabled
 	tenantInfo := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
-	retrieveEngine, err := retriever.CreateRetrieveEngineForKB(
-		ctx, s.retrieveEngine, s.ownership, tenantInfo.ID, kb.VectorStoreID)
-	if err == nil && embeddingModel != nil {
-		if err := retrieveEngine.DeleteByKnowledgeIDList(ctx, []string{knowledge.ID}, embeddingModel.GetDimensions(), knowledge.Type); err != nil {
-			logger.Warnf(ctx, "Failed to delete existing index data (may not exist): %v", err)
-			// 不返回错误，继续处理（可能没有旧数据）
-		} else {
-			logger.Infof(ctx, "Successfully deleted existing index data for knowledge: %s", knowledge.ID)
+	oldEmbeddingModelID := knowledge.EmbeddingModelID
+	modelChanged := oldEmbeddingModelID != "" && oldEmbeddingModelID != kb.EmbeddingModelID
+	var oldEmbeddingModel embedding.Embedder
+	if modelChanged {
+		var err error
+		oldEmbeddingModel, err = s.modelService.GetEmbeddingModel(ctx, oldEmbeddingModelID)
+		if err != nil {
+			logger.GetLogger(ctx).WithField("error", err).
+				Errorf("processChunks get previous embedding model failed")
+			return
 		}
 	}
 
-	// 删除知识图谱数据（如果存在）
-	namespace := types.NameSpace{KnowledgeBase: knowledge.KnowledgeBaseID, Knowledge: knowledge.ID}
-	if err := s.graphEngine.DelGraph(ctx, []types.NameSpace{namespace}); err != nil {
-		logger.Warnf(ctx, "Failed to delete existing graph data (may not exist): %v", err)
-		// 不返回错误，继续处理
+	var retrieveEngine *retriever.CompositeRetrieveEngine
+	if indexingEnabled || modelChanged {
+		var err error
+		retrieveEngine, err = retriever.CreateRetrieveEngineForKB(
+			ctx, s.retrieveEngine, s.ownership, tenantInfo.ID, kb.VectorStoreID)
+		if err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks create retrieve engine failed")
+			return
+		}
 	}
-
-	logger.Infof(ctx, "Cleanup completed, starting to process new chunks")
 
 	// ========== DocReader 解析结果日志 ==========
 	logger.Infof(ctx, "[DocReader] ========== 解析结果概览 ==========")
@@ -367,179 +390,26 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	}
 	logger.Infof(ctx, "[DocReader] ========== 解析结果概览结束 ==========")
 
-	// Create chunk objects from proto chunks
-	maxSeq := 0
-
-	// 统计图片相关的子Chunk数量，用于扩展insertChunks的容量
-	imageChunkCount := 0
-	for _, chunkData := range chunks {
-		if len(chunkData.Images) > 0 {
-			// 为每个图片的OCR和Caption分别创建一个Chunk
-			imageChunkCount += len(chunkData.Images) * 2
+	desiredChunks, textChunks := buildStableDocumentChunks(knowledge, chunks, options.ParentChunks)
+	if indexingEnabled {
+		modelKey := kb.EmbeddingModelID
+		if modelKey == "" {
+			modelKey = embeddingModel.GetModelID()
 		}
-		if int(chunkData.Seq) > maxSeq {
-			maxSeq = int(chunkData.Seq)
+		if modelKey == "" {
+			modelKey = embeddingModel.GetModelName()
 		}
-	}
-
-	// === Parent-Child Chunking: create parent chunks first ===
-	hasParentChild := len(options.ParentChunks) > 0
-	var parentDBChunks []*types.Chunk // indexed by ParsedParentChunk position
-	if hasParentChild {
-		parentDBChunks = make([]*types.Chunk, len(options.ParentChunks))
-		for i, pc := range options.ParentChunks {
-			parentDBChunks[i] = &types.Chunk{
-				ID:              uuid.New().String(),
-				TenantID:        knowledge.TenantID,
-				KnowledgeID:     knowledge.ID,
-				KnowledgeBaseID: knowledge.KnowledgeBaseID,
-				Content:         pc.Content,
-				ChunkIndex:      pc.Seq,
-				IsEnabled:       true,
-				CreatedAt:       time.Now(),
-				UpdatedAt:       time.Now(),
-				StartAt:         pc.Start,
-				EndAt:           pc.End,
-				ChunkType:       types.ChunkTypeParentText,
-			}
-		}
-		// Set prev/next links for parent chunks
-		for i := range parentDBChunks {
-			if i > 0 {
-				parentDBChunks[i-1].NextChunkID = parentDBChunks[i].ID
-				parentDBChunks[i].PreChunkID = parentDBChunks[i-1].ID
-			}
-		}
-		logger.Infof(ctx, "Created %d parent chunks for parent-child strategy", len(parentDBChunks))
-	}
-
-	// 重新分配容量，考虑图片相关的Chunk + parent chunks
-	parentCount := len(options.ParentChunks)
-	insertChunks := make([]*types.Chunk, 0, len(chunks)+imageChunkCount+parentCount)
-	// Add parent chunks first (they go into DB but NOT into the vector index)
-	if hasParentChild {
-		insertChunks = append(insertChunks, parentDBChunks...)
-	}
-
-	for idx, chunkData := range chunks {
-		if strings.TrimSpace(chunkData.Content) == "" {
-			continue
-		}
-
-		// 创建主文本Chunk
-		textChunk := &types.Chunk{
-			ID:              uuid.New().String(),
-			TenantID:        knowledge.TenantID,
-			KnowledgeID:     knowledge.ID,
-			KnowledgeBaseID: knowledge.KnowledgeBaseID,
-			Content:         chunkData.Content,
-			ContextHeader:   chunkData.ContextHeader,
-			ChunkIndex:      int(chunkData.Seq),
-			IsEnabled:       true,
-			CreatedAt:       time.Now(),
-			UpdatedAt:       time.Now(),
-			StartAt:         int(chunkData.Start),
-			EndAt:           int(chunkData.End),
-			ChunkType:       types.ChunkTypeText,
-		}
-
-		// Wire up ParentChunkID for child chunks
-		if hasParentChild && chunkData.ParentIndex >= 0 && chunkData.ParentIndex < len(parentDBChunks) {
-			textChunk.ParentChunkID = parentDBChunks[chunkData.ParentIndex].ID
-		}
-
-		chunks[idx].ChunkID = textChunk.ID
-		insertChunks = append(insertChunks, textChunk)
-	}
-
-	// Sort chunks by index for proper ordering
-	sort.Slice(insertChunks, func(i, j int) bool {
-		return insertChunks[i].ChunkIndex < insertChunks[j].ChunkIndex
-	})
-
-	// 仅为文本类型的Chunk设置前后关系（child chunks only, parents already linked above）
-	textChunks := make([]*types.Chunk, 0, len(chunks))
-	for _, chunk := range insertChunks {
-		if chunk.ChunkType == types.ChunkTypeText && chunk.ParentChunkID != "" {
-			// This is a child chunk in parent-child mode
-			textChunks = append(textChunks, chunk)
-		} else if chunk.ChunkType == types.ChunkTypeText && !hasParentChild {
-			// Normal flat chunk (no parent-child mode)
-			textChunks = append(textChunks, chunk)
+		if err := setDesiredEmbeddingFingerprints(textChunks, modelKey, embeddingModel.GetDimensions(), knowledge.Title); err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks set embedding fingerprints failed")
+			return
 		}
 	}
 
-	// 设置文本Chunk之间的前后关系 (skip if parent-child, children don't need prev/next links)
-	if !hasParentChild {
-		for i, chunk := range textChunks {
-			if i > 0 {
-				textChunks[i-1].NextChunkID = chunk.ID
-			}
-			if i < len(textChunks)-1 {
-				textChunks[i+1].PreChunkID = chunk.ID
-			}
-		}
-	}
-
-	// Check if knowledge is being deleted/cancelled before writing chunks.
-	// Nothing has been persisted yet, so both branches just bail.
-	if aborted, status := s.isKnowledgeAborted(ctx, knowledge.TenantID, knowledge.ID); aborted {
-		logger.Infof(ctx, "Knowledge aborted (%s), skipping chunk write: %s", status, knowledge.ID)
-		return
-	}
-
-	// Save chunks to database — ALWAYS, regardless of indexing strategy.
-	// Chunks are needed for wiki generation, graph extraction, and summary generation
-	// even when vector/keyword indexing is disabled.
-	s.beginStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
-		"chunks_planned": len(insertChunks),
-	})
-	if err := s.chunkService.CreateChunks(ctx, insertChunks); err != nil {
-		knowledge.ParseStatus = types.ParseStatusFailed
-		knowledge.ErrorMessage = err.Error()
-		knowledge.UpdatedAt = time.Now()
-		s.repo.UpdateKnowledge(ctx, knowledge)
-		s.failStage(ctx, knowledge.ID, types.StageChunking,
-			werrors.ErrCodeChunkingFailed, "create chunks failed", err)
-		return
-	}
-	totalChunkChars := 0
-	for _, c := range insertChunks {
-		totalChunkChars += len(c.Content)
-	}
-	s.endStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
-		"chunks_written":   len(insertChunks),
-		"total_text_chars": totalChunkChars,
-	})
-
-	// Create index information and perform vector indexing — only when vector/keyword is enabled.
-	// Chunks are ALWAYS saved to DB (above) because wiki and graph need them even without vector indexing.
-	var totalStorageSize int64
-	if kb.NeedsEmbeddingModel() && embeddingModel != nil {
-		embedInput := types.JSONMap{
-			"chunks_to_embed": len(textChunks),
-			"model_id":        kb.EmbeddingModelID,
-		}
-		if dim := embeddingModel.GetDimensions(); dim > 0 {
-			embedInput["dim"] = dim
-		}
-		s.beginStage(ctx, knowledge.ID, types.StageEmbedding, embedInput)
-		// Create index information — only for child/flat chunks, NOT parent chunks.
-		// Parent chunks are stored for context retrieval but do not need vector embeddings.
-		// Prepend the document title to improve semantic alignment between
-		// question-style queries and statement-style chunk content.
-		indexInfoList := make([]*types.IndexInfo, 0, len(textChunks))
-		titlePrefix := ""
-		if t := strings.TrimSpace(knowledge.Title); t != "" {
-			titlePrefix = t + "\n"
-		}
-		for _, chunk := range textChunks {
-			// chunk.EmbeddingContent prepends ContextHeader (heading breadcrumb)
-			// when the chunker populated it during Tier-1 splitting; falls back
-			// to plain Content otherwise. Title prefix sits outermost.
-			indexContent := titlePrefix + chunk.EmbeddingContent()
-			indexInfoList = append(indexInfoList, &types.IndexInfo{
-				Content:         indexContent,
+	indexInfosFor := func(indexedChunks []*types.Chunk) []*types.IndexInfo {
+		indexInfos := make([]*types.IndexInfo, 0, len(indexedChunks))
+		for _, chunk := range indexedChunks {
+			indexInfos = append(indexInfos, &types.IndexInfo{
+				Content:         types.EmbeddingInput(knowledge.Title, chunk.ContextHeader, chunk.Content),
 				SourceID:        chunk.ID,
 				SourceType:      types.ChunkSourceType,
 				ChunkID:         chunk.ID,
@@ -548,95 +418,69 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 				IsEnabled:       true,
 			})
 		}
+		return indexInfos
+	}
 
-		// Calculate storage size required for embeddings
-		totalStorageSize = retrieveEngine.EstimateStorageSize(ctx, embeddingModel, indexInfoList)
-		if tenantInfo.StorageQuota > 0 {
-			// Re-fetch tenant storage information
-			tenantInfo, err = s.tenantRepo.GetTenantByID(ctx, tenantInfo.ID)
-			if err != nil {
-				knowledge.ParseStatus = types.ParseStatusFailed
-				knowledge.ErrorMessage = err.Error()
-				knowledge.UpdatedAt = time.Now()
-				s.repo.UpdateKnowledge(ctx, knowledge)
-				return
-			}
-			// Check if there's enough storage quota available
-			if tenantInfo.StorageUsed+totalStorageSize > tenantInfo.StorageQuota {
-				knowledge.ParseStatus = types.ParseStatusFailed
-				knowledge.ErrorMessage = "存储空间不足"
-				knowledge.UpdatedAt = time.Now()
-				s.repo.UpdateKnowledge(ctx, knowledge)
-				return
-			}
-		}
-
-		// Check again before batch indexing (heavy operation).
-		// deleting → row is going away anyway, drop the chunks we just wrote.
-		// cancelled → user wants to keep what was already persisted, just stop.
-		if aborted, status := s.isKnowledgeAborted(ctx, knowledge.TenantID, knowledge.ID); aborted {
-			logger.Infof(ctx, "Knowledge aborted (%s) before indexing: %s", status, knowledge.ID)
-			if status == types.ParseStatusDeleting {
-				if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
-					logger.Warnf(ctx, "Failed to cleanup chunks after deletion detected: %v", err)
-				}
-			}
-			return
-		}
-
-		err = retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfoList)
+	var totalStorageSize int64
+	if indexingEnabled {
+		totalStorageSize = retrieveEngine.EstimateStorageSize(ctx, embeddingModel, indexInfosFor(textChunks))
+	}
+	var err error
+	storageDelta := reparseStorageDelta(totalStorageSize, knowledge.StorageSize)
+	if tenantInfo.StorageQuota > 0 && storageDelta > 0 {
+		tenantInfo, err = s.tenantRepo.GetTenantByID(ctx, tenantInfo.ID)
 		if err != nil {
 			knowledge.ParseStatus = types.ParseStatusFailed
 			knowledge.ErrorMessage = err.Error()
 			knowledge.UpdatedAt = time.Now()
 			s.repo.UpdateKnowledge(ctx, knowledge)
-
-			// delete failed chunks
-			if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
-				logger.Errorf(ctx, "Delete chunks failed: %v", err)
-			}
-
-			// delete index
-			if err := retrieveEngine.DeleteByKnowledgeIDList(
-				ctx, []string{knowledge.ID}, embeddingModel.GetDimensions(), kb.Type,
-			); err != nil {
-				logger.Errorf(ctx, "Delete index failed: %v", err)
-			}
-			// Map vector store / embedding rate-limit errors to a
-			// stable code so the UI can offer "retry later" hints.
-			code := werrors.ErrCodeVectorStoreWriteFailed
-			if isLikelyRateLimitError(err) {
-				code = werrors.ErrCodeEmbeddingRateLimit
-			}
-			s.failStage(ctx, knowledge.ID, types.StageEmbedding,
-				code, "batch index failed", err)
 			return
 		}
-		logger.GetLogger(ctx).Infof("processChunks batch index successfully, with %d index", len(indexInfoList))
-		s.endStage(ctx, knowledge.ID, types.StageEmbedding, types.JSONMap{
-			"vectors_written": len(indexInfoList),
-			"storage_bytes":   totalStorageSize,
-		})
-
-		// Final check before marking as completed.
-		// deleting → drop chunks+index we just wrote.
-		// cancelled → keep persisted data; the row stays in cancelled status
-		// and downstream stages skip via the entry guards.
-		if aborted, status := s.isKnowledgeAborted(ctx, knowledge.TenantID, knowledge.ID); aborted {
-			logger.Infof(ctx, "Knowledge aborted (%s) after indexing: %s", status, knowledge.ID)
-			if status == types.ParseStatusDeleting {
-				if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
-					logger.Warnf(ctx, "Failed to cleanup chunks after deletion detected: %v", err)
-				}
-				if err := retrieveEngine.DeleteByKnowledgeIDList(ctx, []string{knowledge.ID}, embeddingModel.GetDimensions(), kb.Type); err != nil {
-					logger.Warnf(ctx, "Failed to cleanup index after deletion detected: %v", err)
-				}
-			}
+		if tenantInfo.StorageUsed+storageDelta > tenantInfo.StorageQuota {
+			knowledge.ParseStatus = types.ParseStatusFailed
+			knowledge.ErrorMessage = "存储空间不足"
+			knowledge.UpdatedAt = time.Now()
+			s.repo.UpdateKnowledge(ctx, knowledge)
 			return
 		}
-	} else {
-		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping BatchIndex", kb.ID)
-		s.skipStage(ctx, knowledge.ID, types.StageEmbedding, "skipped")
+	}
+
+	totalChunkChars := 0
+	for _, chunk := range textChunks {
+		totalChunkChars += len(chunk.Content)
+	}
+	s.beginStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
+		"chunks_planned": len(desiredChunks),
+	})
+	if indexingEnabled {
+		embedInput := types.JSONMap{
+			// The exact reuse count is only known after the per-knowledge
+			// reconciliation lock is acquired; the completed stage records it.
+			"chunks_to_embed": len(textChunks),
+			"model_id":        kb.EmbeddingModelID,
+		}
+		if dim := embeddingModel.GetDimensions(); dim > 0 {
+			embedInput["dim"] = dim
+		}
+		s.beginStage(ctx, knowledge.ID, types.StageEmbedding, embedInput)
+	}
+
+	var (
+		plan           *chunkReusePlan
+		updates        []*types.Chunk
+		staleImageURLs []string
+		created        map[string]struct{}
+	)
+	isCreatedCleanup := func(ids []string) bool {
+		if len(ids) != len(created) {
+			return false
+		}
+		for _, id := range ids {
+			if _, found := created[id]; !found {
+				return false
+			}
+		}
+		return true
 	}
 
 	// Check if this document has extracted images that will be processed asynchronously
@@ -645,41 +489,189 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	pendingMultimodal := isImage && options.EnableMultimodel && len(options.StoredImages) > 0
 	pendingPDFMultimodal := !isImage && !isVideo && options.EnableMultimodel && len(options.StoredImages) > 0
 
-	now := time.Now()
-	finalizeIndexedKnowledgeState(
-		knowledge,
-		totalStorageSize,
-		len(textChunks),
-		pendingMultimodal || pendingPDFMultimodal,
-		now,
-	)
+	indexStarted := false
+	indexSucceeded := false
+	err = executeKnowledgeCommit(knowledgeCommitOps{
+		Persist: func() error {
+			return s.repo.WithKnowledgeReconciliation(ctx, knowledge.TenantID, knowledge.ID, func(reconcileCtx context.Context) error {
+				if err := checkReconciliationAbort(reconcileCtx, "reconciliation lock"); err != nil {
+					return err
+				}
+				existingChunks, err := s.chunkRepo.ListAllChunksByKnowledgeID(reconcileCtx, knowledge.TenantID, knowledge.ID)
+				if err != nil {
+					return err
+				}
+				plan, err = planChunkReuse(desiredChunks, existingChunks, indexingEnabled)
+				if err != nil {
+					return err
+				}
+				for _, chunk := range plan.Create {
+					if indexingEnabled && chunk.ChunkType == types.ChunkTypeText {
+						chunk.Status = int(types.ChunkStatusStored)
+					}
+				}
+				if !indexingEnabled {
+					for _, chunk := range textChunks {
+						chunk.Status = int(types.ChunkStatusDefault)
+					}
+				}
+				updates = append([]*types.Chunk{}, plan.Create...)
+				updates = append(updates, plan.Update...)
+				staleImageURLs = staleExtractedImageURLs(reconcileCtx, plan, options.StoredImages)
+				created = make(map[string]struct{}, len(plan.Create))
+				for _, chunk := range plan.Create {
+					created[chunk.ID] = struct{}{}
+				}
+				if err := executeChunkReconciliation(reconcileCtx, plan, chunkReconcileOps{
+					Create: func(ctx context.Context, chunks []*types.Chunk) error {
+						if err := checkReconciliationAbort(ctx, "create"); err != nil {
+							return err
+						}
+						if len(chunks) == 0 {
+							return nil
+						}
+						return s.chunkService.CreateChunks(ctx, chunks)
+					},
+					Index: func(ctx context.Context, chunks []*types.Chunk) error {
+						if err := checkReconciliationAbort(ctx, "index"); err != nil {
+							return err
+						}
+						if len(chunks) == 0 {
+							return nil
+						}
+						indexStarted = true
+						if err := retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfosFor(chunks)); err != nil {
+							return err
+						}
+						for _, chunk := range chunks {
+							chunk.Status = int(types.ChunkStatusIndexed)
+						}
+						indexSucceeded = true
+						return nil
+					},
+					Update: func(ctx context.Context, _ []*types.Chunk) error {
+						if err := checkReconciliationAbort(ctx, "update"); err != nil {
+							return err
+						}
+						now := time.Now()
+						for _, chunk := range updates {
+							chunk.UpdatedAt = now
+						}
+						return s.chunkRepo.UpdateChunksForReparse(ctx, knowledge.TenantID, updates)
+					},
+					DeleteVector: func(ctx context.Context, ids []string) error {
+						if !isCreatedCleanup(ids) {
+							if err := checkReconciliationAbort(ctx, "stale cleanup"); err != nil {
+								return err
+							}
+						}
+						if !indexingEnabled || len(ids) == 0 {
+							return nil
+						}
+						return retrieveEngine.DeleteByChunkIDList(ctx, ids, embeddingModel.GetDimensions(), kb.Type)
+					},
+					DeleteImages: func(ctx context.Context) error {
+						return deleteExtractedImagesStrict(ctx, s.resolveFileService(ctx, kb), staleImageURLs)
+					},
+					HardDelete: func(ctx context.Context, ids []string) error {
+						if len(ids) == 0 {
+							return nil
+						}
+						return s.chunkRepo.HardDeleteChunks(ctx, knowledge.TenantID, ids)
+					},
+				}); err != nil {
+					return err
+				}
 
-	if err := s.repo.UpdateKnowledge(ctx, knowledge); err != nil {
-		logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks update knowledge failed")
-	}
+				if modelChanged && indexingEnabled {
+					if err := checkReconciliationAbort(reconcileCtx, "previous model cleanup"); err != nil {
+						return err
+					}
+					if err := retrieveEngine.DeletePreviousModelVectors(
+						reconcileCtx,
+						[]string{knowledge.ID},
+						oldEmbeddingModel.GetDimensions(),
+						embeddingModel.GetDimensions(),
+						kb.Type,
+					); err != nil {
+						return err
+					}
+				}
 
-	// Enqueue multimodal tasks for images (async, non-blocking)
-	if options.EnableMultimodel && len(options.StoredImages) > 0 {
-		s.beginStage(ctx, knowledge.ID, types.StageMultimodal, types.JSONMap{
-			"image_count":    len(options.StoredImages),
-			"enable_ocr":     true,
-			"enable_caption": true,
-		})
-		s.enqueueImageMultimodalTasks(ctx, knowledge, kb, options.StoredImages, chunks, options.Metadata)
-	} else {
-		s.skipStage(ctx, knowledge.ID, types.StageMultimodal, "skipped")
-		// If there are no multimodal tasks, enqueue the post process task immediately
-		lang, _ := types.LanguageFromContext(ctx)
-		postProcessPayload := types.KnowledgePostProcessPayload{
-			TenantID:        knowledge.TenantID,
-			KnowledgeID:     knowledge.ID,
-			KnowledgeBaseID: knowledge.KnowledgeBaseID,
-			Language:        lang,
-			Attempt:         attemptFromCtx(ctx),
-		}
-		langfuse.InjectTracing(ctx, &postProcessPayload)
-		payloadBytes, err := json.Marshal(postProcessPayload)
-		if err == nil {
+				if err := checkReconciliationAbort(reconcileCtx, "graph cleanup"); err != nil {
+					return err
+				}
+				namespace := types.NameSpace{KnowledgeBase: knowledge.KnowledgeBaseID, Knowledge: knowledge.ID}
+				if err := s.graphEngine.DelGraph(reconcileCtx, []types.NameSpace{namespace}); err != nil {
+					return err
+				}
+
+				knowledge.EmbeddingModelID = kb.EmbeddingModelID
+				finalizeIndexedKnowledgeState(
+					knowledge,
+					totalStorageSize,
+					len(textChunks),
+					pendingMultimodal || pendingPDFMultimodal,
+					time.Now(),
+				)
+				storageDelta, err = s.repo.UpdateKnowledgeAndTenantStorage(reconcileCtx, knowledge)
+				return err
+			})
+		},
+		Finalize: func() {
+			if indexingEnabled {
+				embeddingReuse := "miss"
+				switch {
+				case len(textChunks) == 0 || len(plan.Reuse) == len(textChunks):
+					embeddingReuse = "hit"
+				case len(plan.Reuse) > 0:
+					embeddingReuse = "partial"
+				}
+				s.endStage(ctx, knowledge.ID, types.StageEmbedding, types.JSONMap{
+					"vectors_reused":  len(plan.Reuse),
+					"vectors_written": len(plan.Index),
+					"embedding_reuse": embeddingReuse,
+					"storage_bytes":   totalStorageSize,
+				})
+			} else {
+				logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping BatchIndex", kb.ID)
+				s.skipStage(ctx, knowledge.ID, types.StageEmbedding, "skipped")
+			}
+			s.endStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
+				"chunks_created":   len(plan.Create),
+				"chunks_updated":   len(plan.Update),
+				"chunks_reused":    len(plan.Reuse),
+				"chunks_deleted":   len(plan.Delete) + len(plan.DeleteGenerated),
+				"total_text_chars": totalChunkChars,
+			})
+		},
+		Enqueue: func() {
+			// Enqueue multimodal tasks for images (async, non-blocking)
+			if options.EnableMultimodel && len(options.StoredImages) > 0 {
+				s.beginStage(ctx, knowledge.ID, types.StageMultimodal, types.JSONMap{
+					"image_count":    len(options.StoredImages),
+					"enable_ocr":     true,
+					"enable_caption": true,
+				})
+				s.enqueueImageMultimodalTasks(ctx, knowledge, kb, options.StoredImages, chunks, options.Metadata)
+				return
+			}
+
+			s.skipStage(ctx, knowledge.ID, types.StageMultimodal, "skipped")
+			lang, _ := types.LanguageFromContext(ctx)
+			postProcessPayload := types.KnowledgePostProcessPayload{
+				TenantID:        knowledge.TenantID,
+				KnowledgeID:     knowledge.ID,
+				KnowledgeBaseID: knowledge.KnowledgeBaseID,
+				Language:        lang,
+				Attempt:         attemptFromCtx(ctx),
+			}
+			langfuse.InjectTracing(ctx, &postProcessPayload)
+			payloadBytes, err := json.Marshal(postProcessPayload)
+			if err != nil {
+				logger.Errorf(ctx, "Failed to marshal knowledge post process payload: %v", err)
+				return
+			}
 			task := asynq.NewTask(types.TypeKnowledgePostProcess, payloadBytes,
 				knowledgePostProcessTaskOptions()...)
 			if _, err := s.task.Enqueue(task); err != nil {
@@ -687,16 +679,36 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			} else {
 				logger.Infof(ctx, "Enqueued knowledge post process task for %s", knowledge.ID)
 			}
-		} else {
-			logger.Errorf(ctx, "Failed to marshal knowledge post process payload: %v", err)
+		},
+	})
+	if err != nil {
+		if errors.Is(err, reconciliationAborted) {
+			return
 		}
+		if err := checkReconciliationAbort(ctx, "failure status"); err != nil {
+			return
+		}
+		_ = s.repo.UpdateKnowledgeColumns(ctx, knowledge.ID, map[string]interface{}{
+			"parse_status":  types.ParseStatusFailed,
+			"error_message": err.Error(),
+			"updated_at":    time.Now(),
+		})
+		if indexingEnabled && indexStarted && !indexSucceeded {
+			code := werrors.ErrCodeVectorStoreWriteFailed
+			if isLikelyRateLimitError(err) {
+				code = werrors.ErrCodeEmbeddingRateLimit
+			}
+			s.failStage(ctx, knowledge.ID, types.StageEmbedding, code, "batch index failed", err)
+		} else {
+			s.failStage(ctx, knowledge.ID, types.StageChunking, werrors.ErrCodeChunkingFailed, "reconcile chunks failed", err)
+			if indexingEnabled && !indexStarted {
+				s.skipStage(ctx, knowledge.ID, types.StageEmbedding, "skipped")
+			}
+		}
+		logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks update knowledge failed")
+		return
 	}
-
-	// Update tenant's storage usage
-	tenantInfo.StorageUsed += totalStorageSize
-	if err := s.tenantRepo.AdjustStorageUsed(ctx, tenantInfo.ID, totalStorageSize); err != nil {
-		logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks update tenant storage used failed")
-	}
+	tenantInfo.StorageUsed += storageDelta
 	logger.GetLogger(ctx).Infof("processChunks successfully")
 }
 
@@ -1964,8 +1976,8 @@ func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
 	return questions, nil
 }
 
-// ReparseKnowledge deletes existing document content and re-parses the knowledge asynchronously.
-// This method reuses the logic from UpdateManualKnowledge for resource cleanup and async parsing.
+// ReparseKnowledge schedules asynchronous reparsing. Manual knowledge retains its
+// cleanup path, while document knowledge is reconciled non-destructively by the worker.
 func (s *knowledgeService) ReparseKnowledge(
 	ctx context.Context,
 	knowledgeID string,
@@ -2070,21 +2082,13 @@ func (s *knowledgeService) ReparseKnowledge(
 		return existing, nil
 	}
 
-	// For non-manual knowledge, cleanup synchronously then enqueue document processing
-	logger.Infof(ctx, "Cleaning up existing resources for knowledge: %s", knowledgeID)
-	if err := s.cleanupKnowledgeResources(ctx, existing); err != nil {
-		logger.ErrorWithFields(ctx, err, map[string]interface{}{
-			"knowledge_id": knowledgeID,
-		})
-		return nil, err
-	}
-
-	// Step 2: Update knowledge status and metadata
+	// Non-manual reparses retain current chunks, vectors, graph data, storage,
+	// and the previous embedding model until the worker safely reconciles them.
+	// Step 2: Update knowledge status and metadata.
 	existing.ParseStatus = "pending"
 	existing.EnableStatus = "disabled"
 	existing.Description = ""
 	existing.ProcessedAt = nil
-	existing.EmbeddingModelID = kb.EmbeddingModelID
 	// Reset the enrichment counter so a leftover value from a previous
 	// attempt cannot block the new finalizing transition later. This must
 	// be an explicit column write: UpdateKnowledge (full-row Save) omits

--- a/internal/application/service/knowledge_reparse_flow_test.go
+++ b/internal/application/service/knowledge_reparse_flow_test.go
@@ -1,0 +1,231 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/infrastructure/docparser"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteChunkReconciliation(t *testing.T) {
+	t.Run("unchanged indexed chunk skips indexing and reports reuse", func(t *testing.T) {
+		desired := []*types.Chunk{{ID: "unchanged", ChunkType: types.ChunkTypeText}}
+		require.NoError(t, setDesiredEmbeddingFingerprints(desired, "model-1", 1536, "Document"))
+
+		existing := []*types.Chunk{cloneChunk(desired[0])}
+		existing[0].Status = int(types.ChunkStatusIndexed)
+		plan, err := planChunkReuse(desired, existing, true)
+		require.NoError(t, err)
+		require.Len(t, plan.Reuse, 1)
+
+		indexed := -1
+		err = executeChunkReconciliation(context.Background(), plan, chunkReconcileOps{
+			Create: func(context.Context, []*types.Chunk) error { return nil },
+			Index: func(_ context.Context, chunks []*types.Chunk) error {
+				indexed = len(chunks)
+				return nil
+			},
+			Update:       func(context.Context, []*types.Chunk) error { return nil },
+			DeleteVector: func(context.Context, []string) error { return nil },
+			HardDelete:   func(context.Context, []string) error { return nil },
+		})
+
+		require.NoError(t, err)
+		assert.Zero(t, indexed)
+	})
+
+	t.Run("changed fingerprint indexes only the changed chunk", func(t *testing.T) {
+		desired := []*types.Chunk{{ID: "changed", ChunkType: types.ChunkTypeText}}
+		require.NoError(t, setDesiredEmbeddingFingerprints(desired, "model-new", 1536, "Document"))
+
+		existing := []*types.Chunk{cloneChunk(desired[0])}
+		existing[0].Status = int(types.ChunkStatusIndexed)
+		require.NoError(t, setDesiredEmbeddingFingerprints(existing, "model-old", 1536, "Document"))
+		plan, err := planChunkReuse(desired, existing, true)
+		require.NoError(t, err)
+
+		var indexed []string
+		err = executeChunkReconciliation(context.Background(), plan, chunkReconcileOps{
+			Create: func(context.Context, []*types.Chunk) error { return nil },
+			Index: func(_ context.Context, chunks []*types.Chunk) error {
+				indexed = chunkIDs(chunks)
+				return nil
+			},
+			Update:       func(context.Context, []*types.Chunk) error { return nil },
+			DeleteVector: func(context.Context, []string) error { return nil },
+			HardDelete:   func(context.Context, []string) error { return nil },
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"changed"}, indexed)
+	})
+
+	t.Run("index failure rolls back only rows created by the attempt", func(t *testing.T) {
+		indexErr := errors.New("index failed")
+		plan := &chunkReusePlan{
+			Create: []*types.Chunk{{ID: "created"}},
+			Index:  []*types.Chunk{{ID: "created"}},
+			Delete: []*types.Chunk{{ID: "stale-existing"}},
+		}
+		var vectorDeletes, hardDeletes []string
+
+		err := executeChunkReconciliation(context.Background(), plan, chunkReconcileOps{
+			Create: func(context.Context, []*types.Chunk) error { return nil },
+			Index:  func(context.Context, []*types.Chunk) error { return indexErr },
+			Update: func(context.Context, []*types.Chunk) error {
+				t.Fatal("update must not run after failed indexing")
+				return nil
+			},
+			DeleteVector: func(_ context.Context, ids []string) error {
+				vectorDeletes = append(vectorDeletes, ids...)
+				return nil
+			},
+			HardDelete: func(_ context.Context, ids []string) error {
+				hardDeletes = append(hardDeletes, ids...)
+				return nil
+			},
+		})
+
+		require.ErrorIs(t, err, indexErr)
+		assert.Equal(t, []string{"created"}, vectorDeletes)
+		assert.Equal(t, []string{"created"}, hardDeletes)
+		assert.NotContains(t, hardDeletes, "stale-existing")
+	})
+
+	t.Run("success promotes desired rows before stale cleanup", func(t *testing.T) {
+		plan := &chunkReusePlan{
+			Create:          []*types.Chunk{{ID: "created"}},
+			Index:           []*types.Chunk{{ID: "created"}},
+			Update:          []*types.Chunk{{ID: "existing"}},
+			Delete:          []*types.Chunk{{ID: "stale"}},
+			DeleteGenerated: []*types.Chunk{{ID: "generated"}},
+		}
+		var calls []string
+
+		err := executeChunkReconciliation(context.Background(), plan, chunkReconcileOps{
+			Create: func(context.Context, []*types.Chunk) error {
+				calls = append(calls, "create")
+				return nil
+			},
+			Index: func(context.Context, []*types.Chunk) error {
+				calls = append(calls, "index")
+				return nil
+			},
+			Update: func(context.Context, []*types.Chunk) error {
+				calls = append(calls, "update")
+				return nil
+			},
+			DeleteVector: func(_ context.Context, ids []string) error {
+				calls = append(calls, "delete-vector")
+				assert.Equal(t, []string{"stale", "generated"}, ids)
+				return nil
+			},
+			DeleteImages: func(context.Context) error {
+				calls = append(calls, "delete-images")
+				return nil
+			},
+			HardDelete: func(_ context.Context, ids []string) error {
+				calls = append(calls, "hard-delete")
+				assert.Equal(t, []string{"stale", "generated"}, ids)
+				return nil
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{
+			"create", "index", "update", "delete-vector", "delete-images", "hard-delete",
+		}, calls)
+	})
+
+	t.Run("image deletion failure preserves rows for retry", func(t *testing.T) {
+		imageErr := errors.New("object storage unavailable")
+		plan := &chunkReusePlan{Delete: []*types.Chunk{{ID: "stale-image-row"}}}
+		hardDeleteCalls := 0
+		imageDeleteCalls := 0
+		failImages := true
+		ops := chunkReconcileOps{
+			Create:       func(context.Context, []*types.Chunk) error { return nil },
+			Index:        func(context.Context, []*types.Chunk) error { return nil },
+			Update:       func(context.Context, []*types.Chunk) error { return nil },
+			DeleteVector: func(context.Context, []string) error { return nil },
+			DeleteImages: func(context.Context) error {
+				imageDeleteCalls++
+				if failImages {
+					return imageErr
+				}
+				return nil
+			},
+			HardDelete: func(context.Context, []string) error {
+				hardDeleteCalls++
+				return nil
+			},
+		}
+
+		err := executeChunkReconciliation(context.Background(), plan, ops)
+		require.ErrorIs(t, err, imageErr)
+		assert.Zero(t, hardDeleteCalls, "source rows must remain as durable retry state")
+
+		failImages = false
+		require.NoError(t, executeChunkReconciliation(context.Background(), plan, ops))
+		assert.Equal(t, 2, imageDeleteCalls)
+		assert.Equal(t, 1, hardDeleteCalls)
+	})
+}
+
+func TestReparseStorageDelta(t *testing.T) {
+	assert.EqualValues(t, 300, reparseStorageDelta(800, 500))
+	assert.EqualValues(t, -200, reparseStorageDelta(300, 500))
+}
+
+func TestExecuteKnowledgeCommitStopsAfterPersistFailure(t *testing.T) {
+	persistErr := errors.New("persist failed")
+	enqueued := false
+	finalized := false
+
+	err := executeKnowledgeCommit(knowledgeCommitOps{
+		Persist: func() error { return persistErr },
+		Enqueue: func() {
+			enqueued = true
+		},
+		Finalize: func() {
+			finalized = true
+		},
+	})
+
+	require.ErrorIs(t, err, persistErr)
+	assert.False(t, enqueued)
+	assert.False(t, finalized)
+}
+
+func TestReparseStaleImageURLsExcludeCurrentServingURLs(t *testing.T) {
+	plan := &chunkReusePlan{
+		Delete: []*types.Chunk{{
+			ID:        "stale",
+			ImageInfo: `[{"url":"local://images/reused.png"},{"url":"local://images/stale.png"}]`,
+		}},
+		DeleteGenerated: []*types.Chunk{{
+			ID:        "generated",
+			ImageInfo: `[{"url":"local://images/generated.png"}]`,
+		}},
+	}
+	stored := []docparser.StoredImage{{ServingURL: "local://images/reused.png"}}
+
+	urls := staleExtractedImageURLs(context.Background(), plan, stored)
+
+	assert.ElementsMatch(t, []string{
+		"local://images/stale.png",
+		"local://images/generated.png",
+	}, urls)
+}
+
+func TestDeleteExtractedImagesStrictTreatsMissingObjectAsDeleted(t *testing.T) {
+	fileSvc := &countingFileService{deleteErr: fs.ErrNotExist}
+
+	require.NoError(t, deleteExtractedImagesStrict(context.Background(), fileSvc, []string{"local://images/stale.png"}))
+	assert.Equal(t, 1, fileSvc.deleteCalls)
+}

--- a/internal/application/service/knowledge_reparse_flow_test.go
+++ b/internal/application/service/knowledge_reparse_flow_test.go
@@ -8,9 +8,146 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/infrastructure/docparser"
 	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type reparseGraphRepository struct {
+	interfaces.RetrieveGraphRepository
+	fullDeletes    int
+	preciseDeletes [][]string
+	fencedAttempts []int
+	calls          []string
+	fenceErr       error
+	recoveryErr    error
+}
+
+func (r *reparseGraphRepository) FenceGraphAttempt(
+	_ context.Context,
+	_ types.NameSpace,
+	attempt int,
+) error {
+	r.calls = append(r.calls, "fence")
+	r.fencedAttempts = append(r.fencedAttempts, attempt)
+	return r.fenceErr
+}
+
+func (r *reparseGraphRepository) RecoverGraphNamespace(
+	_ context.Context,
+	_ types.NameSpace,
+) error {
+	r.calls = append(r.calls, "recover")
+	return r.recoveryErr
+}
+
+func (r *reparseGraphRepository) DelGraph(context.Context, []types.NameSpace) error {
+	r.calls = append(r.calls, "full-delete")
+	r.fullDeletes++
+	return nil
+}
+
+func (r *reparseGraphRepository) DelGraphChunks(
+	_ context.Context,
+	_ types.NameSpace,
+	ids []string,
+) error {
+	r.calls = append(r.calls, "precise-delete")
+	r.preciseDeletes = append(r.preciseDeletes, append([]string(nil), ids...))
+	return nil
+}
+
+func TestCleanupReparseGraphSelectsPreciseOrFullRetraction(t *testing.T) {
+	namespace := types.NameSpace{KnowledgeBase: "kb-1", Knowledge: "knowledge-1"}
+	t.Run("enabled with stale chunks", func(t *testing.T) {
+		repository := &reparseGraphRepository{}
+		require.NoError(t, cleanupReparseGraph(
+			context.Background(), repository, namespace, 7, true, []string{"chunk-1"},
+		))
+		assert.Equal(t, []int{7}, repository.fencedAttempts)
+		assert.Equal(t, []string{"fence", "recover", "precise-delete"}, repository.calls)
+		assert.Zero(t, repository.fullDeletes)
+		assert.Equal(t, [][]string{{"chunk-1"}}, repository.preciseDeletes)
+	})
+	t.Run("enabled without stale chunks", func(t *testing.T) {
+		repository := &reparseGraphRepository{}
+		require.NoError(t, cleanupReparseGraph(
+			context.Background(), repository, namespace, 8, true, nil,
+		))
+		assert.Equal(t, []int{8}, repository.fencedAttempts)
+		assert.Equal(t, []string{"fence", "recover"}, repository.calls)
+		assert.Zero(t, repository.fullDeletes)
+		assert.Empty(t, repository.preciseDeletes)
+	})
+	t.Run("disabled", func(t *testing.T) {
+		repository := &reparseGraphRepository{}
+		require.NoError(t, cleanupReparseGraph(
+			context.Background(), repository, namespace, 9, false, nil,
+		))
+		assert.Equal(t, []int{9}, repository.fencedAttempts)
+		assert.Equal(t, []string{"fence", "full-delete"}, repository.calls)
+		assert.Equal(t, 1, repository.fullDeletes)
+		assert.Empty(t, repository.preciseDeletes)
+	})
+	t.Run("fence failure prevents cleanup", func(t *testing.T) {
+		want := errors.New("fence unavailable")
+		repository := &reparseGraphRepository{fenceErr: want}
+
+		err := cleanupReparseGraph(
+			context.Background(), repository, namespace, 10, true, []string{"chunk-1"},
+		)
+
+		require.ErrorIs(t, err, want)
+		assert.Equal(t, []string{"fence"}, repository.calls)
+		assert.Zero(t, repository.fullDeletes)
+		assert.Empty(t, repository.preciseDeletes)
+	})
+	t.Run("recovery failure prevents cleanup", func(t *testing.T) {
+		want := errors.New("recovery failed")
+		repository := &reparseGraphRepository{recoveryErr: want}
+
+		err := cleanupReparseGraph(
+			context.Background(), repository, namespace, 11, true, []string{"chunk-1"},
+		)
+
+		require.ErrorIs(t, err, want)
+		assert.Equal(t, []string{"fence", "recover"}, repository.calls)
+		assert.Zero(t, repository.fullDeletes)
+		assert.Empty(t, repository.preciseDeletes)
+	})
+}
+
+func TestEffectiveKnowledgeGraphEnabledUsesProcessOverrides(t *testing.T) {
+	t.Run("override disables enabled KB graph", func(t *testing.T) {
+		disabled := false
+		knowledge := &types.Knowledge{}
+		require.NoError(t, knowledge.SetProcessOverrides(&types.KnowledgeProcessOverrides{
+			GraphEnabled: &disabled,
+		}))
+		kb := &types.KnowledgeBase{
+			IndexingStrategy: types.IndexingStrategy{GraphEnabled: true},
+			ExtractConfig:    &types.ExtractConfig{Enabled: true},
+		}
+
+		assert.False(t, effectiveKnowledgeGraphEnabled(kb, knowledge))
+	})
+
+	t.Run("override enables disabled KB graph", func(t *testing.T) {
+		enabled := true
+		knowledge := &types.Knowledge{}
+		require.NoError(t, knowledge.SetProcessOverrides(&types.KnowledgeProcessOverrides{
+			GraphEnabled: &enabled,
+			ExtractConfig: &types.ExtractConfig{
+				Enabled: true,
+			},
+		}))
+		kb := &types.KnowledgeBase{
+			ExtractConfig: &types.ExtractConfig{},
+		}
+
+		assert.True(t, effectiveKnowledgeGraphEnabled(kb, knowledge))
+	})
+}
 
 func TestExecuteChunkReconciliation(t *testing.T) {
 	t.Run("unchanged indexed chunk skips indexing and reports reuse", func(t *testing.T) {
@@ -102,8 +239,8 @@ func TestExecuteChunkReconciliation(t *testing.T) {
 			Create:          []*types.Chunk{{ID: "created"}},
 			Index:           []*types.Chunk{{ID: "created"}},
 			Update:          []*types.Chunk{{ID: "existing"}},
-			Delete:          []*types.Chunk{{ID: "stale"}},
-			DeleteGenerated: []*types.Chunk{{ID: "generated"}},
+			Delete:          []*types.Chunk{{ID: "stale", ChunkType: types.ChunkTypeText}},
+			DeleteGenerated: []*types.Chunk{{ID: "generated", ChunkType: types.ChunkTypeSummary}},
 		}
 		var calls []string
 
@@ -129,6 +266,11 @@ func TestExecuteChunkReconciliation(t *testing.T) {
 				calls = append(calls, "delete-images")
 				return nil
 			},
+			DeleteGraph: func(_ context.Context, ids []string) error {
+				calls = append(calls, "delete-graph")
+				assert.Equal(t, []string{"stale"}, ids)
+				return nil
+			},
 			HardDelete: func(_ context.Context, ids []string) error {
 				calls = append(calls, "hard-delete")
 				assert.Equal(t, []string{"stale", "generated"}, ids)
@@ -138,8 +280,34 @@ func TestExecuteChunkReconciliation(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, []string{
-			"create", "index", "update", "delete-vector", "delete-images", "hard-delete",
+			"create", "index", "update", "delete-vector", "delete-images", "delete-graph", "hard-delete",
 		}, calls)
+	})
+
+	t.Run("graph deletion failure preserves stale rows for retry", func(t *testing.T) {
+		graphErr := errors.New("graph unavailable")
+		plan := &chunkReusePlan{Delete: []*types.Chunk{
+			{ID: "stale-text", ChunkType: types.ChunkTypeText},
+			{ID: "stale-parent", ChunkType: types.ChunkTypeParentText},
+		}}
+		hardDeleteCalls := 0
+		err := executeChunkReconciliation(context.Background(), plan, chunkReconcileOps{
+			Create:       func(context.Context, []*types.Chunk) error { return nil },
+			Index:        func(context.Context, []*types.Chunk) error { return nil },
+			Update:       func(context.Context, []*types.Chunk) error { return nil },
+			DeleteVector: func(context.Context, []string) error { return nil },
+			DeleteGraph: func(_ context.Context, ids []string) error {
+				assert.Equal(t, []string{"stale-text"}, ids)
+				return graphErr
+			},
+			HardDelete: func(context.Context, []string) error {
+				hardDeleteCalls++
+				return nil
+			},
+		})
+
+		require.ErrorIs(t, err, graphErr)
+		assert.Zero(t, hardDeleteCalls)
 	})
 
 	t.Run("image deletion failure preserves rows for retry", func(t *testing.T) {

--- a/internal/application/service/knowledge_summary_test.go
+++ b/internal/application/service/knowledge_summary_test.go
@@ -4,7 +4,19 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type summaryArtifactChunkRepo struct{ interfaces.ChunkRepository }
+
+func (summaryArtifactChunkRepo) ListChunksByParentIDs(context.Context, uint64, []string) ([]*types.Chunk, error) {
+	return nil, nil
+}
 
 // TestCheckSufficientSummaryContent verifies the gate that prevents getSummary
 // from calling the LLM (and ProcessSummaryGeneration from creating a summary
@@ -41,8 +53,8 @@ func TestCheckSufficientSummaryContent(t *testing.T) {
 			wantError: true,
 		},
 		{
-			name: "scanned PDF with empty <image> wrapper rejected",
-			content: `<image url="x"><image_original>![a](x)</image_original></image>`,
+			name:      "scanned PDF with empty <image> wrapper rejected",
+			content:   `<image url="x"><image_original>![a](x)</image_original></image>`,
 			wantError: true,
 		},
 		{
@@ -102,4 +114,68 @@ func TestCheckSufficientSummaryContent_ThresholdOverride(t *testing.T) {
 	if !errors.Is(err, errInsufficientSummaryContent) {
 		t.Fatalf("tightened threshold: expected errInsufficientSummaryContent, got %v", err)
 	}
+}
+
+func TestGetSummaryReusesSuccessfulChatArtifact(t *testing.T) {
+	store := newChatArtifactFakeStore()
+	model := &chatArtifactFakeModel{
+		modelID:   "summary-model",
+		modelName: "summary-model",
+		response:  &types.ChatResponse{Content: "cached summary"},
+	}
+	svc := &knowledgeService{
+		config: &config.Config{Conversation: &config.ConversationConfig{
+			GenerateSummaryPrompt: "Summarize in {{language}}.",
+		}},
+		chunkRepo:     summaryArtifactChunkRepo{},
+		artifactStore: store,
+	}
+	ctx := context.WithValue(context.Background(), types.LanguageContextKey, "en")
+	knowledge := &types.Knowledge{ID: "knowledge-1", TenantID: 7}
+	chunks := []*types.Chunk{{ID: "chunk-1", Content: "This document contains enough useful text.", StartAt: 0}}
+
+	first, firstHit, err := svc.getSummary(ctx, model, "revision-1", knowledge, chunks)
+	require.NoError(t, err)
+	second, secondHit, err := svc.getSummary(ctx, model, "revision-1", knowledge, chunks)
+	require.NoError(t, err)
+
+	assert.Equal(t, "cached summary", first)
+	assert.Equal(t, first, second)
+	assert.False(t, firstHit)
+	assert.True(t, secondHit)
+	assert.Equal(t, 1, model.calls)
+	assert.Equal(t, 1, store.putCalls)
+}
+
+func TestGetSummaryBypassesArtifactWithoutSafeModelRevision(t *testing.T) {
+	store := newChatArtifactFakeStore()
+	model := &chatArtifactFakeModel{
+		modelID:   "summary-model",
+		modelName: "summary-model",
+		response:  &types.ChatResponse{Content: "fresh summary"},
+	}
+	svc := &knowledgeService{
+		config: &config.Config{Conversation: &config.ConversationConfig{
+			GenerateSummaryPrompt: "Summarize.",
+		}},
+		chunkRepo:     summaryArtifactChunkRepo{},
+		artifactStore: store,
+	}
+	knowledge := &types.Knowledge{ID: "knowledge-1", TenantID: 7}
+	chunks := []*types.Chunk{{ID: "chunk-1", Content: "This document contains enough useful text.", StartAt: 0}}
+
+	_, hit, err := svc.getSummary(context.Background(), model, "", knowledge, chunks)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, 1, model.calls)
+	assert.Zero(t, store.getCalls)
+	assert.Zero(t, store.putCalls)
+}
+
+func TestStableSummaryChunkIDIgnoresCompletionVariance(t *testing.T) {
+	first := stableSummaryChunkID("knowledge-1")
+	second := stableSummaryChunkID("knowledge-1")
+	assert.Equal(t, first, second)
+	assert.NotEmpty(t, first)
+	assert.NotEqual(t, first, stableSummaryChunkID("knowledge-2"))
 }

--- a/internal/application/service/knowledgebase_search.go
+++ b/internal/application/service/knowledgebase_search.go
@@ -35,7 +35,8 @@ func (s *knowledgeBaseService) GetQueryEmbedding(ctx context.Context, kbID strin
 		return nil, err
 	}
 
-	return embeddingModel.Embed(ctx, queryText)
+	embedCtx := context.WithValue(ctx, types.EmbedQueryContextKey, true)
+	return embeddingModel.Embed(embedCtx, queryText)
 }
 
 // ResolveEmbeddingModelKeys resolves embedding model IDs to their actual model
@@ -438,7 +439,8 @@ func (s *knowledgeBaseService) resolveQueryEmbedding(
 	logger.Infof(ctx, "Embedding model retrieved: %v", embeddingModel)
 
 	logger.Info(ctx, "Starting to generate query embedding")
-	queryEmbedding, err := embeddingModel.Embed(ctx, params.QueryText)
+	embedCtx := context.WithValue(ctx, types.EmbedQueryContextKey, true)
+	queryEmbedding, err := embeddingModel.Embed(embedCtx, params.QueryText)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to embed query text, query text: %s, error: %v", params.QueryText, err)
 		return nil, err

--- a/internal/application/service/knowledgebase_search_embedding_context_test.go
+++ b/internal/application/service/knowledgebase_search_embedding_context_test.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/require"
+)
+
+type queryContextEmbedder struct {
+	embedding.Embedder
+	query bool
+}
+
+func (e *queryContextEmbedder) Embed(ctx context.Context, _ string) ([]float32, error) {
+	e.query, _ = ctx.Value(types.EmbedQueryContextKey).(bool)
+	return []float32{1}, nil
+}
+
+type queryContextModelService struct {
+	interfaces.ModelService
+	embedder embedding.Embedder
+}
+
+func (s *queryContextModelService) GetEmbeddingModel(context.Context, string) (embedding.Embedder, error) {
+	return s.embedder, nil
+}
+
+func (s *queryContextModelService) GetEmbeddingModelForTenant(
+	context.Context, string, uint64,
+) (embedding.Embedder, error) {
+	return s.embedder, nil
+}
+
+type queryContextKBRepository struct {
+	interfaces.KnowledgeBaseRepository
+	kb *types.KnowledgeBase
+}
+
+func (r *queryContextKBRepository) GetKnowledgeBaseByID(
+	context.Context, string,
+) (*types.KnowledgeBase, error) {
+	return r.kb, nil
+}
+
+func TestKnowledgeBaseQueryEmbeddingMarksQueryContext(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(7))
+	embedder := &queryContextEmbedder{}
+	kb := &types.KnowledgeBase{ID: "kb-1", TenantID: 7, EmbeddingModelID: "model-1"}
+	service := &knowledgeBaseService{
+		repo:         &queryContextKBRepository{kb: kb},
+		modelService: &queryContextModelService{embedder: embedder},
+	}
+
+	_, err := service.GetQueryEmbedding(ctx, kb.ID, "first query")
+	require.NoError(t, err)
+	require.True(t, embedder.query)
+
+	embedder.query = false
+	_, err = service.resolveQueryEmbedding(ctx, kb, types.SearchParams{QueryText: "fallback query"}, 7)
+	require.NoError(t, err)
+	require.True(t, embedder.query)
+}

--- a/internal/application/service/model.go
+++ b/internal/application/service/model.go
@@ -30,6 +30,7 @@ type modelService struct {
 	ollamaService *ollama.OllamaService
 	pooler        embedding.EmbedderPooler
 	tenantService interfaces.TenantService
+	artifactStore interfaces.ProcessingArtifactStore
 }
 
 // NewModelService creates a new model service instance
@@ -39,6 +40,7 @@ func NewModelService(repo interfaces.ModelRepository,
 	ollamaService *ollama.OllamaService,
 	pooler embedding.EmbedderPooler,
 	tenantService interfaces.TenantService,
+	artifactStore interfaces.ProcessingArtifactStore,
 ) interfaces.ModelService {
 	return &modelService{
 		repo:          repo,
@@ -47,6 +49,7 @@ func NewModelService(repo interfaces.ModelRepository,
 		ollamaService: ollamaService,
 		pooler:        pooler,
 		tenantService: tenantService,
+		artifactStore: artifactStore,
 	}
 }
 
@@ -433,7 +436,16 @@ func (s *modelService) GetEmbeddingModel(ctx context.Context, modelId string) (e
 	}
 
 	logger.Info(ctx, "Embedding model initialized successfully")
-	return embedder, nil
+	revision, err := embeddingModelRevision(model)
+	if err != nil {
+		return nil, err
+	}
+	return newEmbeddingArtifactEmbedder(
+		embedder,
+		s.artifactStore,
+		types.MustTenantIDFromContext(ctx),
+		revision,
+	), nil
 }
 
 // GetEmbeddingModelForTenant retrieves and initializes an embedding model for a specific tenant
@@ -481,7 +493,16 @@ func (s *modelService) GetEmbeddingModelForTenant(ctx context.Context, modelId s
 	}
 
 	logger.Info(ctx, "Cross-tenant embedding model initialized successfully")
-	return embedder, nil
+	revision, err := embeddingModelRevision(model)
+	if err != nil {
+		return nil, err
+	}
+	return newEmbeddingArtifactEmbedder(
+		embedder,
+		s.artifactStore,
+		tenantID,
+		revision,
+	), nil
 }
 
 // GetRerankModel retrieves and initializes a reranking model instance

--- a/internal/application/service/model_builtin_management_test.go
+++ b/internal/application/service/model_builtin_management_test.go
@@ -27,7 +27,7 @@ func TestUpdateBuiltinModel_RequiresSystemAdmin(t *testing.T) {
 			updated = true
 			return nil
 		},
-	}, nil, nil, nil, nil, nil)
+	}, nil, nil, nil, nil, nil, nil)
 
 	err := svc.UpdateModel(builtinModelContext(false), &types.Model{ID: stored.ID})
 	require.Error(t, err)
@@ -50,7 +50,7 @@ func TestUpdateBuiltinModel_SystemAdminCreatesRuntimeOverride(t *testing.T) {
 			saved = &copy
 			return nil
 		},
-	}, nil, nil, nil, nil, nil)
+	}, nil, nil, nil, nil, nil, nil)
 
 	input := &types.Model{ID: stored.ID, Name: "edited"}
 	require.NoError(t, svc.UpdateModel(builtinModelContext(true), input))
@@ -65,7 +65,7 @@ func TestUpdateBuiltinModelCredentials_SystemAdminOnly(t *testing.T) {
 
 	t.Run("tenant admin denied", func(t *testing.T) {
 		stored := &types.Model{ID: "builtin-chat", TenantID: 10000, IsBuiltin: true}
-		svc := NewModelService(&stubModelRepoForDelete{model: stored}, nil, nil, nil, nil, nil)
+		svc := NewModelService(&stubModelRepoForDelete{model: stored}, nil, nil, nil, nil, nil, nil)
 		_, err := svc.UpdateModelCredentials(builtinModelContext(false), stored.ID, &newKey, nil)
 		require.Error(t, err)
 		appErr, ok := apperrors.IsAppError(err)
@@ -86,7 +86,7 @@ func TestUpdateBuiltinModelCredentials_SystemAdminOnly(t *testing.T) {
 				saved = &copy
 				return nil
 			},
-		}, nil, nil, nil, nil, nil)
+		}, nil, nil, nil, nil, nil, nil)
 
 		updated, err := svc.UpdateModelCredentials(
 			builtinModelContext(true), stored.ID, &newKey, nil,

--- a/internal/application/service/model_delete_test.go
+++ b/internal/application/service/model_delete_test.go
@@ -112,7 +112,7 @@ func TestDeleteModel_RejectsWhenReferenced(t *testing.T) {
 		&stubModelRepoForDelete{model: &types.Model{ID: modelID, TenantID: 1}},
 		&stubKBRepoForModelDelete{count: 1},
 		&stubAgentRepoForModelDelete{count: 0},
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 
 	err := svc.DeleteModel(ctx, modelID)
@@ -131,7 +131,7 @@ func TestDeleteModel_RejectsWhenUsedByAgent(t *testing.T) {
 		&stubModelRepoForDelete{model: &types.Model{ID: modelID, TenantID: 1}},
 		&stubKBRepoForModelDelete{count: 0},
 		&stubAgentRepoForModelDelete{count: 2},
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 
 	err := svc.DeleteModel(ctx, modelID)
@@ -157,7 +157,7 @@ func TestDeleteModel_SucceedsWhenUnreferenced(t *testing.T) {
 		},
 		&stubKBRepoForModelDelete{},
 		&stubAgentRepoForModelDelete{},
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 
 	require.NoError(t, svc.DeleteModel(ctx, modelID))

--- a/internal/application/service/processing_artifact.go
+++ b/internal/application/service/processing_artifact.go
@@ -28,6 +28,13 @@ type processingArtifactStore struct {
 	newFileService   processingArtifactFileServiceFactory
 }
 
+type processingArtifactBatchRepository interface {
+	GetMany(ctx context.Context, keys []types.ProcessingArtifactKey) (
+		map[types.ProcessingArtifactKey]*types.ProcessingArtifact, error,
+	)
+	PutManyIfAbsent(ctx context.Context, artifacts []*types.ProcessingArtifact) error
+}
+
 type processingArtifactFileServiceFactory func(
 	provider string,
 	storageConfig *types.StorageEngineConfig,
@@ -78,6 +85,45 @@ func (s *processingArtifactStore) Get(
 		return nil, false, fmt.Errorf("get processing artifact manifest: %w", err)
 	}
 	return s.readArtifact(ctx, key, artifact)
+}
+
+func (s *processingArtifactStore) GetMany(
+	ctx context.Context,
+	keys []types.ProcessingArtifactKey,
+) (map[types.ProcessingArtifactKey][]byte, error) {
+	result := make(map[types.ProcessingArtifactKey][]byte, len(keys))
+	batchRepository, ok := s.repository.(processingArtifactBatchRepository)
+	if !ok {
+		for _, key := range keys {
+			value, hit, err := s.Get(ctx, key)
+			if err != nil {
+				return nil, err
+			}
+			if hit {
+				result[key] = value
+			}
+		}
+		return result, nil
+	}
+
+	artifacts, err := batchRepository.GetMany(ctx, keys)
+	if err != nil {
+		return nil, fmt.Errorf("get processing artifact manifests: %w", err)
+	}
+	for _, key := range keys {
+		artifact, ok := artifacts[key]
+		if !ok {
+			continue
+		}
+		value, hit, err := s.readArtifact(ctx, key, artifact)
+		if err != nil {
+			return nil, err
+		}
+		if hit {
+			result[key] = value
+		}
+	}
+	return result, nil
 }
 
 func (s *processingArtifactStore) PutIfAbsent(
@@ -166,6 +212,91 @@ func (s *processingArtifactStore) PutIfAbsent(
 		"processing artifact contention did not converge after %d attempts",
 		processingArtifactPutAttempts,
 	)
+}
+
+func (s *processingArtifactStore) PutManyIfAbsent(
+	ctx context.Context,
+	values map[types.ProcessingArtifactKey][]byte,
+) (map[types.ProcessingArtifactKey][]byte, error) {
+	result := make(map[types.ProcessingArtifactKey][]byte, len(values))
+	batchRepository, ok := s.repository.(processingArtifactBatchRepository)
+	if !ok {
+		return s.putManySequential(ctx, values)
+	}
+
+	inlineValues := make(map[types.ProcessingArtifactKey][]byte, len(values))
+	artifacts := make([]*types.ProcessingArtifact, 0, len(values))
+	for key, value := range values {
+		if len(value) > ProcessingArtifactInlineLimit {
+			canonical, _, err := s.PutIfAbsent(ctx, key, value)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = canonical
+			continue
+		}
+
+		candidate := cloneProcessingArtifactValue(value)
+		inlineValues[key] = candidate
+		artifacts = append(artifacts, &types.ProcessingArtifact{
+			TenantID:         key.TenantID,
+			Stage:            key.Stage,
+			KeyVersion:       key.KeyVersion,
+			InputFingerprint: key.InputFingerprint,
+			Payload:          cloneProcessingArtifactValue(candidate),
+			ContentSHA256:    processingArtifactSHA256(candidate),
+			SizeBytes:        int64(len(candidate)),
+		})
+	}
+	if len(artifacts) == 0 {
+		return result, nil
+	}
+	if err := batchRepository.PutManyIfAbsent(ctx, artifacts); err != nil {
+		return nil, fmt.Errorf("put processing artifact manifests: %w", err)
+	}
+
+	keys := make([]types.ProcessingArtifactKey, 0, len(inlineValues))
+	for key := range inlineValues {
+		keys = append(keys, key)
+	}
+	winners, err := batchRepository.GetMany(ctx, keys)
+	if err != nil {
+		return nil, fmt.Errorf("get winning processing artifact manifests: %w", err)
+	}
+	for key, candidate := range inlineValues {
+		winner, ok := winners[key]
+		if ok {
+			canonical, hit, readErr := s.readArtifact(ctx, key, winner)
+			if readErr != nil {
+				return nil, readErr
+			}
+			if hit {
+				result[key] = canonical
+				continue
+			}
+		}
+		canonical, _, putErr := s.PutIfAbsent(ctx, key, candidate)
+		if putErr != nil {
+			return nil, putErr
+		}
+		result[key] = canonical
+	}
+	return result, nil
+}
+
+func (s *processingArtifactStore) putManySequential(
+	ctx context.Context,
+	values map[types.ProcessingArtifactKey][]byte,
+) (map[types.ProcessingArtifactKey][]byte, error) {
+	result := make(map[types.ProcessingArtifactKey][]byte, len(values))
+	for key, value := range values {
+		canonical, _, err := s.PutIfAbsent(ctx, key, value)
+		if err != nil {
+			return nil, err
+		}
+		result[key] = canonical
+	}
+	return result, nil
 }
 
 func (s *processingArtifactStore) readArtifact(

--- a/internal/application/service/processing_artifact.go
+++ b/internal/application/service/processing_artifact.go
@@ -1,0 +1,397 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/url"
+	"os"
+	"strings"
+
+	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+const (
+	ProcessingArtifactInlineLimit = 1 << 20
+	processingArtifactPutAttempts = 3
+)
+
+type processingArtifactStore struct {
+	repository       interfaces.ProcessingArtifactRepository
+	tenantRepository interfaces.TenantRepository
+	fileService      interfaces.FileService
+	newFileService   processingArtifactFileServiceFactory
+}
+
+type processingArtifactFileServiceFactory func(
+	provider string,
+	storageConfig *types.StorageEngineConfig,
+	localBaseDir string,
+) (interfaces.FileService, string, error)
+
+type processingArtifactFileServiceResolver struct {
+	service  interfaces.FileService
+	provider string
+}
+
+func NewProcessingArtifactStore(
+	repository interfaces.ProcessingArtifactRepository,
+	tenantRepository interfaces.TenantRepository,
+	fileService interfaces.FileService,
+) interfaces.ProcessingArtifactStore {
+	return newProcessingArtifactStore(
+		repository,
+		tenantRepository,
+		fileService,
+		filesvc.NewFileServiceFromStorageConfig,
+	)
+}
+
+func newProcessingArtifactStore(
+	repository interfaces.ProcessingArtifactRepository,
+	tenantRepository interfaces.TenantRepository,
+	fileService interfaces.FileService,
+	newFileService processingArtifactFileServiceFactory,
+) *processingArtifactStore {
+	return &processingArtifactStore{
+		repository:       repository,
+		tenantRepository: tenantRepository,
+		fileService:      fileService,
+		newFileService:   newFileService,
+	}
+}
+
+func (s *processingArtifactStore) Get(
+	ctx context.Context,
+	key types.ProcessingArtifactKey,
+) ([]byte, bool, error) {
+	artifact, err := s.repository.Get(ctx, key)
+	if errors.Is(err, types.ErrProcessingArtifactNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("get processing artifact manifest: %w", err)
+	}
+	return s.readArtifact(ctx, key, artifact)
+}
+
+func (s *processingArtifactStore) PutIfAbsent(
+	ctx context.Context,
+	key types.ProcessingArtifactKey,
+	value []byte,
+) ([]byte, bool, error) {
+	candidate := cloneProcessingArtifactValue(value)
+	hash := processingArtifactSHA256(candidate)
+
+	for attempt := 0; attempt < processingArtifactPutAttempts; attempt++ {
+		artifact := &types.ProcessingArtifact{
+			TenantID:         key.TenantID,
+			Stage:            key.Stage,
+			KeyVersion:       key.KeyVersion,
+			InputFingerprint: key.InputFingerprint,
+			ContentSHA256:    hash,
+			SizeBytes:        int64(len(candidate)),
+		}
+
+		var candidateResolver processingArtifactFileServiceResolver
+		if len(candidate) <= ProcessingArtifactInlineLimit {
+			artifact.Payload = cloneProcessingArtifactValue(candidate)
+		} else {
+			var err error
+			candidateResolver, err = s.resolveFileService(ctx, key.TenantID, "")
+			if err != nil {
+				return nil, false, err
+			}
+			artifact.ObjectPath, err = candidateResolver.service.SaveBytes(
+				ctx,
+				candidate,
+				key.TenantID,
+				"processing-artifact-"+hash+".bin",
+				false,
+			)
+			if err != nil {
+				return nil, false, fmt.Errorf("save processing artifact object: %w", err)
+			}
+			if artifact.ObjectPath == "" {
+				return nil, false, errors.New("save processing artifact object returned an empty path")
+			}
+			artifact.ObjectPath = filesvc.CanonicalStoredPath(candidateResolver.service, artifact.ObjectPath)
+		}
+
+		created, err := s.repository.PutIfAbsent(ctx, artifact)
+		if err != nil {
+			return nil, false, fmt.Errorf("put processing artifact manifest: %w", err)
+		}
+		if created {
+			return cloneProcessingArtifactValue(candidate), true, nil
+		}
+
+		winner, err := s.repository.Get(ctx, key)
+		if errors.Is(err, types.ErrProcessingArtifactNotFound) {
+			s.deleteCandidate(ctx, artifact.ObjectPath, candidateResolver)
+			continue
+		}
+		if err != nil {
+			s.deleteCandidate(ctx, artifact.ObjectPath, candidateResolver)
+			return nil, false, fmt.Errorf("get winning processing artifact manifest: %w", err)
+		}
+		if artifact.ObjectPath != "" {
+			if winner == nil {
+				s.deleteCandidate(ctx, artifact.ObjectPath, candidateResolver)
+				return nil, false, errors.New("processing artifact repository returned a nil winner")
+			}
+			// Equality is only observable after the insert loses; detecting it
+			// earlier would require a cross-call path registry in FileService.
+			if artifact.ObjectPath == winner.ObjectPath {
+				return nil, false, errors.New("FileService SaveBytes path uniqueness contract violated")
+			}
+			s.deleteCandidate(ctx, artifact.ObjectPath, candidateResolver)
+		}
+
+		canonical, hit, err := s.readArtifact(ctx, key, winner)
+		if err != nil {
+			return nil, false, err
+		}
+		if hit {
+			return canonical, false, nil
+		}
+	}
+
+	return nil, false, fmt.Errorf(
+		"processing artifact contention did not converge after %d attempts",
+		processingArtifactPutAttempts,
+	)
+}
+
+func (s *processingArtifactStore) readArtifact(
+	ctx context.Context,
+	key types.ProcessingArtifactKey,
+	artifact *types.ProcessingArtifact,
+) ([]byte, bool, error) {
+	if artifact == nil {
+		return nil, false, errors.New("processing artifact repository returned a nil manifest")
+	}
+
+	if artifact.ObjectPath == "" {
+		if artifact.Payload == nil || !processingArtifactValueMatches(artifact, artifact.Payload) {
+			return s.evictCorrupt(ctx, key, artifact, nil)
+		}
+		return cloneProcessingArtifactValue(artifact.Payload), true, nil
+	}
+
+	if artifact.Payload != nil || artifact.SizeBytes < 0 || artifact.SizeBytes == int64(^uint64(0)>>1) {
+		return s.evictCorrupt(ctx, key, artifact, nil)
+	}
+
+	resolver, err := s.resolveFileService(ctx, key.TenantID, types.InferStorageFromFilePath(artifact.ObjectPath))
+	if err != nil {
+		return nil, false, err
+	}
+	authoritative := processingArtifactServiceOwnsPath(resolver, artifact.ObjectPath)
+	servicePath := filesvc.ServiceStoredPath(resolver.service, artifact.ObjectPath)
+	reader, err := resolver.service.GetFile(ctx, servicePath)
+	if errors.Is(err, fs.ErrNotExist) && authoritative {
+		return s.evictCorrupt(ctx, key, artifact, &resolver)
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("read processing artifact object: %w", err)
+	}
+	if reader == nil {
+		return nil, false, errors.New("processing artifact file service returned a nil reader")
+	}
+
+	value, readErr := io.ReadAll(io.LimitReader(reader, artifact.SizeBytes+1))
+	closeErr := reader.Close()
+	if errors.Is(readErr, fs.ErrNotExist) && authoritative {
+		return s.evictCorrupt(ctx, key, artifact, &resolver)
+	}
+	if readErr != nil {
+		return nil, false, fmt.Errorf("read processing artifact object: %w", readErr)
+	}
+	if closeErr != nil {
+		return nil, false, fmt.Errorf("close processing artifact object: %w", closeErr)
+	}
+	if !processingArtifactValueMatches(artifact, value) {
+		if !authoritative {
+			return nil, false, errors.New("processing artifact object verification failed through non-authoritative file service")
+		}
+		return s.evictCorrupt(ctx, key, artifact, &resolver)
+	}
+	return cloneProcessingArtifactValue(value), true, nil
+}
+
+func (s *processingArtifactStore) evictCorrupt(
+	ctx context.Context,
+	key types.ProcessingArtifactKey,
+	artifact *types.ProcessingArtifact,
+	resolver *processingArtifactFileServiceResolver,
+) ([]byte, bool, error) {
+	if err := s.repository.DeleteByID(ctx, key.TenantID, artifact.ID); err != nil {
+		return nil, false, fmt.Errorf("evict corrupt processing artifact manifest: %w", err)
+	}
+	if artifact.ObjectPath != "" {
+		if resolver == nil {
+			resolved, err := s.resolveFileService(
+				ctx,
+				key.TenantID,
+				types.InferStorageFromFilePath(artifact.ObjectPath),
+			)
+			if err == nil {
+				resolver = &resolved
+			}
+		}
+		if resolver != nil && processingArtifactServiceOwnsPath(*resolver, artifact.ObjectPath) {
+			_ = resolver.service.DeleteFile(ctx, filesvc.ServiceStoredPath(resolver.service, artifact.ObjectPath))
+		}
+	}
+	return nil, false, nil
+}
+
+func (s *processingArtifactStore) resolveFileService(
+	ctx context.Context,
+	tenantID uint64,
+	provider string,
+) (processingArtifactFileServiceResolver, error) {
+	tenant, ok := types.TenantInfoFromContext(ctx)
+	if !ok || tenant.ID != tenantID {
+		if s.tenantRepository == nil {
+			tenant = nil
+		} else {
+			var err error
+			tenant, err = s.tenantRepository.GetTenantByID(ctx, tenantID)
+			if err != nil {
+				return processingArtifactFileServiceResolver{}, fmt.Errorf("get processing artifact tenant: %w", err)
+			}
+		}
+	}
+
+	if tenant == nil || tenant.StorageEngineConfig == nil {
+		return s.globalFileServiceResolver()
+	}
+
+	if strings.TrimSpace(provider) == "" {
+		provider = tenant.StorageEngineConfig.DefaultProvider
+	}
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if !processingArtifactProviderConfigured(tenant.StorageEngineConfig, provider) {
+		return s.globalFileServiceResolver()
+	}
+	service, resolvedProvider, err := s.newFileService(
+		provider,
+		tenant.StorageEngineConfig,
+		strings.TrimSpace(os.Getenv("LOCAL_STORAGE_BASE_DIR")),
+	)
+	if err != nil {
+		return processingArtifactFileServiceResolver{}, fmt.Errorf("resolve processing artifact file service: %w", err)
+	}
+	provider = filesvc.StorageProvider(service)
+	if provider == "" {
+		provider = resolvedProvider
+	}
+	return processingArtifactFileServiceResolver{service: service, provider: provider}, nil
+}
+
+func (s *processingArtifactStore) globalFileService() (interfaces.FileService, error) {
+	if s.fileService == nil {
+		return nil, errors.New("processing artifact file service is not configured")
+	}
+	return s.fileService, nil
+}
+
+func (s *processingArtifactStore) globalFileServiceResolver() (processingArtifactFileServiceResolver, error) {
+	service, err := s.globalFileService()
+	if err != nil {
+		return processingArtifactFileServiceResolver{}, err
+	}
+	return processingArtifactFileServiceResolver{
+		service:  service,
+		provider: filesvc.StorageProvider(service),
+	}, nil
+}
+
+func processingArtifactProviderConfigured(config *types.StorageEngineConfig, provider string) bool {
+	if config == nil || provider == "" {
+		return false
+	}
+	switch provider {
+	case "local":
+		return true
+	case "minio":
+		return config.MinIO != nil
+	case "cos":
+		return config.COS != nil
+	case "tos":
+		return config.TOS != nil
+	case "s3":
+		return config.S3 != nil
+	case "oss":
+		return config.OSS != nil
+	case "ks3":
+		return config.KS3 != nil
+	case "obs":
+		return config.OBS != nil
+	default:
+		return false
+	}
+}
+
+func processingArtifactServiceOwnsPath(
+	resolver processingArtifactFileServiceResolver,
+	path string,
+) bool {
+	canonicalPath := filesvc.CanonicalStoredPath(resolver.service, path)
+	scheme := processingArtifactPathScheme(canonicalPath)
+	if scheme == "http" || scheme == "https" {
+		return false
+	}
+	if scheme == "" {
+		return resolver.provider == "local"
+	}
+	return resolver.provider == scheme
+}
+
+func processingArtifactPathScheme(path string) string {
+	path = strings.TrimSpace(path)
+	if len(path) >= 3 && isASCIIAlpha(path[0]) && path[1] == ':' && (path[2] == '\\' || path[2] == '/') {
+		return ""
+	}
+	parsed, err := url.Parse(path)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(parsed.Scheme)
+}
+
+func isASCIIAlpha(value byte) bool {
+	return value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z'
+}
+
+func (s *processingArtifactStore) deleteCandidate(
+	ctx context.Context,
+	path string,
+	resolver processingArtifactFileServiceResolver,
+) {
+	if path != "" && resolver.service != nil {
+		_ = resolver.service.DeleteFile(ctx, filesvc.ServiceStoredPath(resolver.service, path))
+	}
+}
+
+func processingArtifactValueMatches(artifact *types.ProcessingArtifact, value []byte) bool {
+	return artifact.SizeBytes == int64(len(value)) &&
+		artifact.ContentSHA256 == processingArtifactSHA256(value)
+}
+
+func processingArtifactSHA256(value []byte) string {
+	return fmt.Sprintf("%x", sha256.Sum256(value))
+}
+
+func cloneProcessingArtifactValue(value []byte) []byte {
+	clone := make([]byte, len(value))
+	copy(clone, value)
+	return clone
+}

--- a/internal/application/service/processing_artifact.go
+++ b/internal/application/service/processing_artifact.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
 	"github.com/Tencent/WeKnora/internal/types"
@@ -17,15 +19,43 @@ import (
 )
 
 const (
-	ProcessingArtifactInlineLimit = 1 << 20
-	processingArtifactPutAttempts = 3
+	ProcessingArtifactInlineLimit           = 1 << 20
+	ProcessingArtifactMaxPayload            = 64 << 20
+	processingArtifactPutAttempts           = 3
+	processingArtifactObjectReferencePrefix = "processing-artifact:v1:"
 )
+
+var errProcessingArtifactObjectNotOwned = errors.New("processing artifact object is not authoritatively owned")
+
+type processingArtifactPurgeFailure struct {
+	kind string
+	err  error
+}
+
+func (e *processingArtifactPurgeFailure) Error() string {
+	return e.err.Error()
+}
+
+func (e *processingArtifactPurgeFailure) Unwrap() error {
+	return e.err
+}
+
+func (e *processingArtifactPurgeFailure) ProcessingArtifactFailureKind() string {
+	return e.kind
+}
+
+func newProcessingArtifactPurgeFailure(kind string, err error) error {
+	return &processingArtifactPurgeFailure{kind: kind, err: err}
+}
 
 type processingArtifactStore struct {
 	repository       interfaces.ProcessingArtifactRepository
 	tenantRepository interfaces.TenantRepository
 	fileService      interfaces.FileService
 	newFileService   processingArtifactFileServiceFactory
+	storageResolver  interfaces.StorageBackendResolver
+	maxPayloadBytes  int
+	counters         interfaces.ProcessingArtifactCounterRegistry
 }
 
 type processingArtifactBatchRepository interface {
@@ -35,15 +65,40 @@ type processingArtifactBatchRepository interface {
 	PutManyIfAbsent(ctx context.Context, artifacts []*types.ProcessingArtifact) error
 }
 
+type processingArtifactWriteProgress struct {
+	durable  bool
+	complete bool
+}
+
 type processingArtifactFileServiceFactory func(
 	provider string,
 	storageConfig *types.StorageEngineConfig,
 	localBaseDir string,
 ) (interfaces.FileService, string, error)
 
+type processingArtifactHistoricalStorageResolver interface {
+	ResolveHistoricalFileService(
+		ctx context.Context,
+		tenant *types.Tenant,
+		backendID, localBaseDir string,
+	) (interfaces.FileService, string, error)
+}
+
 type processingArtifactFileServiceResolver struct {
-	service  interfaces.FileService
-	provider string
+	service   interfaces.FileService
+	provider  string
+	backendID string
+}
+
+type processingArtifactPurgeResolverKey struct {
+	tenantID  uint64
+	provider  string
+	backendID string
+}
+
+type processingArtifactPurgeResolverResult struct {
+	resolver processingArtifactFileServiceResolver
+	err      error
 }
 
 func NewProcessingArtifactStore(
@@ -51,11 +106,56 @@ func NewProcessingArtifactStore(
 	tenantRepository interfaces.TenantRepository,
 	fileService interfaces.FileService,
 ) interfaces.ProcessingArtifactStore {
-	return newProcessingArtifactStore(
+	return NewProcessingArtifactStoreWithMaxPayloadAndCounterRegistry(
+		repository, tenantRepository, fileService, ProcessingArtifactMaxPayload, NewProcessingArtifactCounterRegistry(),
+	)
+}
+
+func NewProcessingArtifactStoreWithMaxPayload(
+	repository interfaces.ProcessingArtifactRepository,
+	tenantRepository interfaces.TenantRepository,
+	fileService interfaces.FileService,
+	maxPayloadBytes int,
+) interfaces.ProcessingArtifactStore {
+	return NewProcessingArtifactStoreWithMaxPayloadAndCounterRegistry(
+		repository, tenantRepository, fileService, maxPayloadBytes, NewProcessingArtifactCounterRegistry(),
+	)
+}
+
+func NewProcessingArtifactStoreWithMaxPayloadAndCounterRegistry(
+	repository interfaces.ProcessingArtifactRepository,
+	tenantRepository interfaces.TenantRepository,
+	fileService interfaces.FileService,
+	maxPayloadBytes int,
+	counters interfaces.ProcessingArtifactCounterRegistry,
+) interfaces.ProcessingArtifactStore {
+	return newProcessingArtifactStoreWithDependencies(
 		repository,
 		tenantRepository,
 		fileService,
 		filesvc.NewFileServiceFromStorageConfig,
+		nil,
+		maxPayloadBytes,
+		counters,
+	)
+}
+
+func NewProcessingArtifactStoreWithDependencies(
+	repository interfaces.ProcessingArtifactRepository,
+	tenantRepository interfaces.TenantRepository,
+	fileService interfaces.FileService,
+	storageResolver interfaces.StorageBackendResolver,
+	maxPayloadBytes int,
+	counters interfaces.ProcessingArtifactCounterRegistry,
+) interfaces.ProcessingArtifactStore {
+	return newProcessingArtifactStoreWithDependencies(
+		repository,
+		tenantRepository,
+		fileService,
+		filesvc.NewFileServiceFromStorageConfig,
+		storageResolver,
+		maxPayloadBytes,
+		counters,
 	)
 }
 
@@ -64,16 +164,67 @@ func newProcessingArtifactStore(
 	tenantRepository interfaces.TenantRepository,
 	fileService interfaces.FileService,
 	newFileService processingArtifactFileServiceFactory,
+	maxPayloadBytes ...int,
 ) *processingArtifactStore {
+	maxPayload := ProcessingArtifactMaxPayload
+	if len(maxPayloadBytes) > 0 && maxPayloadBytes[0] > 0 {
+		maxPayload = maxPayloadBytes[0]
+	}
+	return newProcessingArtifactStoreWithCounterRegistry(
+		repository, tenantRepository, fileService, newFileService, maxPayload, NewProcessingArtifactCounterRegistry(),
+	)
+}
+
+func newProcessingArtifactStoreWithCounterRegistry(
+	repository interfaces.ProcessingArtifactRepository,
+	tenantRepository interfaces.TenantRepository,
+	fileService interfaces.FileService,
+	newFileService processingArtifactFileServiceFactory,
+	maxPayloadBytes int,
+	counters interfaces.ProcessingArtifactCounterRegistry,
+) *processingArtifactStore {
+	return newProcessingArtifactStoreWithDependencies(
+		repository, tenantRepository, fileService, newFileService, nil, maxPayloadBytes, counters,
+	)
+}
+
+func newProcessingArtifactStoreWithDependencies(
+	repository interfaces.ProcessingArtifactRepository,
+	tenantRepository interfaces.TenantRepository,
+	fileService interfaces.FileService,
+	newFileService processingArtifactFileServiceFactory,
+	storageResolver interfaces.StorageBackendResolver,
+	maxPayloadBytes int,
+	counters interfaces.ProcessingArtifactCounterRegistry,
+) *processingArtifactStore {
+	maxPayload := ProcessingArtifactMaxPayload
+	if maxPayloadBytes > 0 {
+		maxPayload = maxPayloadBytes
+	}
+	if counters == nil {
+		counters = NewProcessingArtifactCounterRegistry()
+	}
 	return &processingArtifactStore{
 		repository:       repository,
 		tenantRepository: tenantRepository,
 		fileService:      fileService,
 		newFileService:   newFileService,
+		storageResolver:  storageResolver,
+		maxPayloadBytes:  maxPayload,
+		counters:         counters,
 	}
 }
 
 func (s *processingArtifactStore) Get(
+	ctx context.Context,
+	key types.ProcessingArtifactKey,
+) ([]byte, bool, error) {
+	value, hit, err := s.get(ctx, key)
+	s.recordLookup(key.Stage, hit, err)
+	return value, hit, err
+}
+
+func (s *processingArtifactStore) get(
 	ctx context.Context,
 	key types.ProcessingArtifactKey,
 ) ([]byte, bool, error) {
@@ -94,11 +245,13 @@ func (s *processingArtifactStore) GetMany(
 	result := make(map[types.ProcessingArtifactKey][]byte, len(keys))
 	batchRepository, ok := s.repository.(processingArtifactBatchRepository)
 	if !ok {
-		for _, key := range keys {
-			value, hit, err := s.Get(ctx, key)
+		for index, key := range keys {
+			value, hit, err := s.get(ctx, key)
 			if err != nil {
+				s.recordLookupErrors(keys[index:])
 				return nil, err
 			}
+			s.recordLookup(key.Stage, hit, nil)
 			if hit {
 				result[key] = value
 			}
@@ -108,17 +261,21 @@ func (s *processingArtifactStore) GetMany(
 
 	artifacts, err := batchRepository.GetMany(ctx, keys)
 	if err != nil {
+		s.recordLookupErrors(keys)
 		return nil, fmt.Errorf("get processing artifact manifests: %w", err)
 	}
-	for _, key := range keys {
+	for index, key := range keys {
 		artifact, ok := artifacts[key]
 		if !ok {
+			s.recordLookup(key.Stage, false, nil)
 			continue
 		}
 		value, hit, err := s.readArtifact(ctx, key, artifact)
 		if err != nil {
+			s.recordLookupErrors(keys[index:])
 			return nil, err
 		}
+		s.recordLookup(key.Stage, hit, nil)
 		if hit {
 			result[key] = value
 		}
@@ -131,6 +288,19 @@ func (s *processingArtifactStore) PutIfAbsent(
 	key types.ProcessingArtifactKey,
 	value []byte,
 ) ([]byte, bool, error) {
+	canonical, created, err := s.putIfAbsent(ctx, key, value)
+	s.recordWrite(key.Stage, err)
+	return canonical, created, err
+}
+
+func (s *processingArtifactStore) putIfAbsent(
+	ctx context.Context,
+	key types.ProcessingArtifactKey,
+	value []byte,
+) ([]byte, bool, error) {
+	if err := s.validatePayloadSize(value); err != nil {
+		return nil, false, err
+	}
 	candidate := cloneProcessingArtifactValue(value)
 	hash := processingArtifactSHA256(candidate)
 
@@ -149,7 +319,7 @@ func (s *processingArtifactStore) PutIfAbsent(
 			artifact.Payload = cloneProcessingArtifactValue(candidate)
 		} else {
 			var err error
-			candidateResolver, err = s.resolveFileService(ctx, key.TenantID, "")
+			candidateResolver, err = s.resolveFileService(ctx, key.TenantID, "", "")
 			if err != nil {
 				return nil, false, err
 			}
@@ -166,7 +336,8 @@ func (s *processingArtifactStore) PutIfAbsent(
 			if artifact.ObjectPath == "" {
 				return nil, false, errors.New("save processing artifact object returned an empty path")
 			}
-			artifact.ObjectPath = filesvc.CanonicalStoredPath(candidateResolver.service, artifact.ObjectPath)
+			objectPath := filesvc.CanonicalStoredPath(candidateResolver.service, artifact.ObjectPath)
+			artifact.ObjectPath = processingArtifactObjectReference(objectPath)
 		}
 
 		created, err := s.repository.PutIfAbsent(ctx, artifact)
@@ -218,21 +389,40 @@ func (s *processingArtifactStore) PutManyIfAbsent(
 	ctx context.Context,
 	values map[types.ProcessingArtifactKey][]byte,
 ) (map[types.ProcessingArtifactKey][]byte, error) {
+	canonical, progress, err := s.putManyIfAbsent(ctx, values)
+	s.recordBatchWrites(values, progress)
+	if err != nil {
+		return nil, err
+	}
+	return canonical, nil
+}
+
+func (s *processingArtifactStore) putManyIfAbsent(
+	ctx context.Context,
+	values map[types.ProcessingArtifactKey][]byte,
+) (map[types.ProcessingArtifactKey][]byte, map[types.ProcessingArtifactKey]processingArtifactWriteProgress, error) {
+	progress := make(map[types.ProcessingArtifactKey]processingArtifactWriteProgress, len(values))
+	for _, value := range values {
+		if err := s.validatePayloadSize(value); err != nil {
+			return nil, progress, err
+		}
+	}
 	result := make(map[types.ProcessingArtifactKey][]byte, len(values))
 	batchRepository, ok := s.repository.(processingArtifactBatchRepository)
 	if !ok {
-		return s.putManySequential(ctx, values)
+		return s.putManySequential(ctx, values, progress)
 	}
 
 	inlineValues := make(map[types.ProcessingArtifactKey][]byte, len(values))
 	artifacts := make([]*types.ProcessingArtifact, 0, len(values))
 	for key, value := range values {
 		if len(value) > ProcessingArtifactInlineLimit {
-			canonical, _, err := s.PutIfAbsent(ctx, key, value)
+			canonical, _, err := s.putIfAbsent(ctx, key, value)
 			if err != nil {
-				return nil, err
+				return nil, progress, err
 			}
 			result[key] = canonical
+			progress[key] = processingArtifactWriteProgress{durable: true, complete: true}
 			continue
 		}
 
@@ -249,10 +439,13 @@ func (s *processingArtifactStore) PutManyIfAbsent(
 		})
 	}
 	if len(artifacts) == 0 {
-		return result, nil
+		return result, progress, nil
 	}
 	if err := batchRepository.PutManyIfAbsent(ctx, artifacts); err != nil {
-		return nil, fmt.Errorf("put processing artifact manifests: %w", err)
+		return nil, progress, fmt.Errorf("put processing artifact manifests: %w", err)
+	}
+	for key := range inlineValues {
+		progress[key] = processingArtifactWriteProgress{durable: true}
 	}
 
 	keys := make([]types.ProcessingArtifactKey, 0, len(inlineValues))
@@ -261,42 +454,267 @@ func (s *processingArtifactStore) PutManyIfAbsent(
 	}
 	winners, err := batchRepository.GetMany(ctx, keys)
 	if err != nil {
-		return nil, fmt.Errorf("get winning processing artifact manifests: %w", err)
+		return nil, progress, fmt.Errorf("get winning processing artifact manifests: %w", err)
 	}
 	for key, candidate := range inlineValues {
 		winner, ok := winners[key]
 		if ok {
 			canonical, hit, readErr := s.readArtifact(ctx, key, winner)
 			if readErr != nil {
-				return nil, readErr
+				return nil, progress, readErr
 			}
 			if hit {
 				result[key] = canonical
+				progress[key] = processingArtifactWriteProgress{durable: true, complete: true}
 				continue
 			}
 		}
-		canonical, _, putErr := s.PutIfAbsent(ctx, key, candidate)
+		canonical, _, putErr := s.putIfAbsent(ctx, key, candidate)
 		if putErr != nil {
-			return nil, putErr
+			return nil, progress, putErr
 		}
 		result[key] = canonical
+		progress[key] = processingArtifactWriteProgress{durable: true, complete: true}
+	}
+	return result, progress, nil
+}
+
+func (s *processingArtifactStore) Invalidate(
+	ctx context.Context,
+	key types.ProcessingArtifactKey,
+	observed []byte,
+) error {
+	evicted, err := s.invalidate(ctx, key, observed)
+	if err != nil {
+		s.counters.Record(key.Stage, "error")
+	} else if evicted {
+		s.counters.Record(key.Stage, "evicted")
+	}
+	return err
+}
+
+func (s *processingArtifactStore) invalidate(
+	ctx context.Context,
+	key types.ProcessingArtifactKey,
+	observed []byte,
+) (bool, error) {
+	artifact, err := s.repository.Get(ctx, key)
+	if errors.Is(err, types.ErrProcessingArtifactNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("get processing artifact manifest for invalidation: %w", err)
+	}
+	if artifact == nil {
+		return false, errors.New("processing artifact repository returned a nil manifest")
+	}
+	if artifact.ContentSHA256 != processingArtifactSHA256(observed) {
+		return false, nil
+	}
+
+	var resolver processingArtifactFileServiceResolver
+	var objectPath string
+	if artifact.ObjectPath != "" {
+		resolver, objectPath, err = s.resolveOwnedObject(ctx, key.TenantID, artifact.ObjectPath)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	if artifact.ObjectPath != "" {
+		if err := resolver.service.DeleteFile(ctx, filesvc.ServiceStoredPath(resolver.service, objectPath)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return false, fmt.Errorf("delete processing artifact object: %w", err)
+		}
+	}
+	removed, err := s.repository.DeleteByIDWithResult(ctx, key.TenantID, artifact.ID)
+	if err != nil {
+		return false, fmt.Errorf("delete processing artifact manifest: %w", err)
+	}
+	return removed, nil
+}
+
+func (s *processingArtifactStore) PurgeExpired(
+	ctx context.Context,
+	cutoff time.Time,
+	batchSize int,
+) (types.ProcessingArtifactPurgeResult, error) {
+	if batchSize <= 0 {
+		return types.ProcessingArtifactPurgeResult{}, errors.New("processing artifact purge batch size must be positive")
+	}
+
+	var result types.ProcessingArtifactPurgeResult
+	var representative error
+	var afterID uint64
+	resolvers := make(map[processingArtifactPurgeResolverKey]processingArtifactPurgeResolverResult)
+	for {
+		artifacts, err := s.repository.ListExpired(ctx, cutoff, afterID, batchSize)
+		if err != nil {
+			return result, newProcessingArtifactPurgeFailure(
+				"manifest_list",
+				fmt.Errorf("list expired processing artifacts: %w", err),
+			)
+		}
+		if len(artifacts) == 0 {
+			break
+		}
+
+		pageAdvanced := false
+		for _, artifact := range artifacts {
+			if artifact == nil {
+				result.Failed++
+				if representative == nil {
+					representative = newProcessingArtifactPurgeFailure(
+						"manifest_invalid",
+						errors.New("processing artifact repository returned a nil expired manifest"),
+					)
+				}
+				continue
+			}
+			afterID = artifact.ID
+			pageAdvanced = true
+			result.Scanned++
+			removed, err := s.purgeExpiredArtifact(ctx, artifact, resolvers)
+			if err != nil {
+				result.Failed++
+				s.counters.Record(artifact.Stage, "error")
+				if representative == nil {
+					representative = err
+				}
+				continue
+			}
+			if removed {
+				result.Deleted++
+				result.DeletedBytes += artifact.SizeBytes
+				s.counters.Record(artifact.Stage, "evicted")
+			}
+		}
+		if !pageAdvanced {
+			return result, fmt.Errorf("purge expired processing artifacts (%d failures): %w", result.Failed, representative)
+		}
+		if len(artifacts) < batchSize {
+			break
+		}
+	}
+	if representative != nil {
+		return result, fmt.Errorf("purge expired processing artifacts (%d failures): %w", result.Failed, representative)
 	}
 	return result, nil
+}
+
+func (s *processingArtifactStore) purgeExpiredArtifact(
+	ctx context.Context,
+	artifact *types.ProcessingArtifact,
+	resolvers map[processingArtifactPurgeResolverKey]processingArtifactPurgeResolverResult,
+) (bool, error) {
+	if artifact.ObjectPath != "" {
+		objectPath, ok := processingArtifactObjectPath(artifact.ObjectPath)
+		if !ok {
+			return false, newProcessingArtifactPurgeFailure("ownership", errProcessingArtifactObjectNotOwned)
+		}
+		resolver, err := s.resolvePurgeFileService(ctx, artifact.TenantID, objectPath, resolvers)
+		if err != nil {
+			return false, newProcessingArtifactPurgeFailure("storage_resolve", err)
+		}
+		if !processingArtifactServiceOwnsPath(resolver, objectPath) {
+			return false, newProcessingArtifactPurgeFailure("ownership", errProcessingArtifactObjectNotOwned)
+		}
+		if err := resolver.service.DeleteFile(ctx, filesvc.ServiceStoredPath(resolver.service, objectPath)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return false, newProcessingArtifactPurgeFailure(
+				"object_delete",
+				fmt.Errorf("delete processing artifact object: %w", err),
+			)
+		}
+	}
+	removed, err := s.repository.DeleteByIDWithResult(ctx, artifact.TenantID, artifact.ID)
+	if err != nil {
+		return false, newProcessingArtifactPurgeFailure(
+			"manifest_delete",
+			fmt.Errorf("delete processing artifact manifest: %w", err),
+		)
+	}
+	return removed, nil
+}
+
+func (s *processingArtifactStore) resolvePurgeFileService(
+	ctx context.Context,
+	tenantID uint64,
+	objectPath string,
+	resolvers map[processingArtifactPurgeResolverKey]processingArtifactPurgeResolverResult,
+) (processingArtifactFileServiceResolver, error) {
+	provider := strings.ToLower(strings.TrimSpace(types.InferStorageFromFilePath(objectPath)))
+	backendID, _, _ := types.ParseStorageBackendPath(objectPath)
+	key := processingArtifactPurgeResolverKey{tenantID: tenantID, provider: provider, backendID: backendID}
+	if cached, ok := resolvers[key]; ok {
+		return cached.resolver, cached.err
+	}
+	resolver, err := s.resolveFileServiceForPath(ctx, tenantID, objectPath)
+	resolvers[key] = processingArtifactPurgeResolverResult{resolver: resolver, err: err}
+	return resolver, err
+}
+
+func (s *processingArtifactStore) validatePayloadSize(value []byte) error {
+	if len(value) > s.maxPayloadBytes {
+		return errors.New("processing artifact payload exceeds configured maximum")
+	}
+	return nil
 }
 
 func (s *processingArtifactStore) putManySequential(
 	ctx context.Context,
 	values map[types.ProcessingArtifactKey][]byte,
-) (map[types.ProcessingArtifactKey][]byte, error) {
+	progress map[types.ProcessingArtifactKey]processingArtifactWriteProgress,
+) (map[types.ProcessingArtifactKey][]byte, map[types.ProcessingArtifactKey]processingArtifactWriteProgress, error) {
 	result := make(map[types.ProcessingArtifactKey][]byte, len(values))
 	for key, value := range values {
-		canonical, _, err := s.PutIfAbsent(ctx, key, value)
+		canonical, _, err := s.putIfAbsent(ctx, key, value)
 		if err != nil {
-			return nil, err
+			return nil, progress, err
 		}
 		result[key] = canonical
+		progress[key] = processingArtifactWriteProgress{durable: true, complete: true}
 	}
-	return result, nil
+	return result, progress, nil
+}
+
+func (s *processingArtifactStore) recordLookup(stage string, hit bool, err error) {
+	if err != nil {
+		s.counters.Record(stage, "error")
+		return
+	}
+	if hit {
+		s.counters.Record(stage, "hit")
+		return
+	}
+	s.counters.Record(stage, "miss")
+}
+
+func (s *processingArtifactStore) recordLookupErrors(keys []types.ProcessingArtifactKey) {
+	for _, key := range keys {
+		s.counters.Record(key.Stage, "error")
+	}
+}
+
+func (s *processingArtifactStore) recordWrite(stage string, err error) {
+	if err != nil {
+		s.counters.Record(stage, "error")
+		return
+	}
+	s.counters.Record(stage, "write")
+}
+
+func (s *processingArtifactStore) recordBatchWrites(
+	values map[types.ProcessingArtifactKey][]byte,
+	progress map[types.ProcessingArtifactKey]processingArtifactWriteProgress,
+) {
+	for key := range values {
+		state := progress[key]
+		if state.durable {
+			s.counters.Record(key.Stage, "write")
+		}
+		if !state.complete {
+			s.counters.Record(key.Stage, "error")
+		}
+	}
 }
 
 func (s *processingArtifactStore) readArtifact(
@@ -319,12 +737,16 @@ func (s *processingArtifactStore) readArtifact(
 		return s.evictCorrupt(ctx, key, artifact, nil)
 	}
 
-	resolver, err := s.resolveFileService(ctx, key.TenantID, types.InferStorageFromFilePath(artifact.ObjectPath))
+	objectPath, ok := processingArtifactObjectPath(artifact.ObjectPath)
+	if !ok {
+		return nil, false, errProcessingArtifactObjectNotOwned
+	}
+	resolver, err := s.resolveFileServiceForPath(ctx, key.TenantID, objectPath)
 	if err != nil {
 		return nil, false, err
 	}
-	authoritative := processingArtifactServiceOwnsPath(resolver, artifact.ObjectPath)
-	servicePath := filesvc.ServiceStoredPath(resolver.service, artifact.ObjectPath)
+	authoritative := processingArtifactServiceOwnsPath(resolver, objectPath)
+	servicePath := filesvc.ServiceStoredPath(resolver.service, objectPath)
 	reader, err := resolver.service.GetFile(ctx, servicePath)
 	if errors.Is(err, fs.ErrNotExist) && authoritative {
 		return s.evictCorrupt(ctx, key, artifact, &resolver)
@@ -362,23 +784,35 @@ func (s *processingArtifactStore) evictCorrupt(
 	artifact *types.ProcessingArtifact,
 	resolver *processingArtifactFileServiceResolver,
 ) ([]byte, bool, error) {
-	if err := s.repository.DeleteByID(ctx, key.TenantID, artifact.ID); err != nil {
+	if artifact.ObjectPath != "" {
+		objectPath, ok := processingArtifactObjectPath(artifact.ObjectPath)
+		if !ok {
+			return nil, false, errProcessingArtifactObjectNotOwned
+		}
+		if resolver == nil {
+			resolved, err := s.resolveFileServiceForPath(ctx, key.TenantID, objectPath)
+			if err != nil {
+				return nil, false, err
+			}
+			resolver = &resolved
+		}
+		if !processingArtifactServiceOwnsPath(*resolver, objectPath) {
+			return nil, false, errProcessingArtifactObjectNotOwned
+		}
+		if err := resolver.service.DeleteFile(
+			ctx,
+			filesvc.ServiceStoredPath(resolver.service, objectPath),
+		); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return nil, false, fmt.Errorf("delete corrupt processing artifact object: %w", err)
+		}
+	}
+
+	removed, err := s.repository.DeleteByIDWithResult(ctx, key.TenantID, artifact.ID)
+	if err != nil {
 		return nil, false, fmt.Errorf("evict corrupt processing artifact manifest: %w", err)
 	}
-	if artifact.ObjectPath != "" {
-		if resolver == nil {
-			resolved, err := s.resolveFileService(
-				ctx,
-				key.TenantID,
-				types.InferStorageFromFilePath(artifact.ObjectPath),
-			)
-			if err == nil {
-				resolver = &resolved
-			}
-		}
-		if resolver != nil && processingArtifactServiceOwnsPath(*resolver, artifact.ObjectPath) {
-			_ = resolver.service.DeleteFile(ctx, filesvc.ServiceStoredPath(resolver.service, artifact.ObjectPath))
-		}
+	if removed {
+		s.counters.Record(key.Stage, "evicted")
 	}
 	return nil, false, nil
 }
@@ -386,6 +820,7 @@ func (s *processingArtifactStore) evictCorrupt(
 func (s *processingArtifactStore) resolveFileService(
 	ctx context.Context,
 	tenantID uint64,
+	backendID string,
 	provider string,
 ) (processingArtifactFileServiceResolver, error) {
 	tenant, ok := types.TenantInfoFromContext(ctx)
@@ -399,6 +834,30 @@ func (s *processingArtifactStore) resolveFileService(
 				return processingArtifactFileServiceResolver{}, fmt.Errorf("get processing artifact tenant: %w", err)
 			}
 		}
+	}
+
+	if tenant != nil && s.storageResolver != nil {
+		localBaseDir := strings.TrimSpace(os.Getenv("LOCAL_STORAGE_BASE_DIR"))
+		var service interfaces.FileService
+		var resolvedProvider string
+		var err error
+		if historical, ok := s.storageResolver.(processingArtifactHistoricalStorageResolver); ok && backendID != "" {
+			service, resolvedProvider, err = historical.ResolveHistoricalFileService(
+				ctx, tenant, backendID, localBaseDir,
+			)
+		} else {
+			service, resolvedProvider, err = s.storageResolver.ResolveFileService(
+				ctx, tenant, backendID, provider, localBaseDir,
+			)
+		}
+		if err != nil {
+			return processingArtifactFileServiceResolver{}, fmt.Errorf("resolve processing artifact file service: %w", err)
+		}
+		return processingArtifactFileServiceResolver{
+			service:   service,
+			provider:  strings.ToLower(strings.TrimSpace(resolvedProvider)),
+			backendID: filesvc.StorageBackendID(service),
+		}, nil
 	}
 
 	if tenant == nil || tenant.StorageEngineConfig == nil {
@@ -427,6 +886,34 @@ func (s *processingArtifactStore) resolveFileService(
 	return processingArtifactFileServiceResolver{service: service, provider: provider}, nil
 }
 
+func (s *processingArtifactStore) resolveFileServiceForPath(
+	ctx context.Context,
+	tenantID uint64,
+	objectPath string,
+) (processingArtifactFileServiceResolver, error) {
+	backendID, _, _ := types.ParseStorageBackendPath(objectPath)
+	return s.resolveFileService(ctx, tenantID, backendID, types.InferStorageFromFilePath(objectPath))
+}
+
+func (s *processingArtifactStore) resolveOwnedObject(
+	ctx context.Context,
+	tenantID uint64,
+	reference string,
+) (processingArtifactFileServiceResolver, string, error) {
+	objectPath, ok := processingArtifactObjectPath(reference)
+	if !ok {
+		return processingArtifactFileServiceResolver{}, "", errProcessingArtifactObjectNotOwned
+	}
+	resolver, err := s.resolveFileServiceForPath(ctx, tenantID, objectPath)
+	if err != nil {
+		return processingArtifactFileServiceResolver{}, "", err
+	}
+	if !processingArtifactServiceOwnsPath(resolver, objectPath) {
+		return processingArtifactFileServiceResolver{}, "", errProcessingArtifactObjectNotOwned
+	}
+	return resolver, objectPath, nil
+}
+
 func (s *processingArtifactStore) globalFileService() (interfaces.FileService, error) {
 	if s.fileService == nil {
 		return nil, errors.New("processing artifact file service is not configured")
@@ -440,8 +927,9 @@ func (s *processingArtifactStore) globalFileServiceResolver() (processingArtifac
 		return processingArtifactFileServiceResolver{}, err
 	}
 	return processingArtifactFileServiceResolver{
-		service:  service,
-		provider: filesvc.StorageProvider(service),
+		service:   service,
+		provider:  filesvc.StorageProvider(service),
+		backendID: filesvc.StorageBackendID(service),
 	}, nil
 }
 
@@ -476,6 +964,9 @@ func processingArtifactServiceOwnsPath(
 	path string,
 ) bool {
 	canonicalPath := filesvc.CanonicalStoredPath(resolver.service, path)
+	if backendID, _, ok := types.ParseStorageBackendPath(canonicalPath); ok {
+		return backendID != "" && backendID == resolver.backendID
+	}
 	scheme := processingArtifactPathScheme(canonicalPath)
 	if scheme == "http" || scheme == "https" {
 		return false
@@ -484,6 +975,23 @@ func processingArtifactServiceOwnsPath(
 		return resolver.provider == "local"
 	}
 	return resolver.provider == scheme
+}
+
+func processingArtifactObjectReference(objectPath string) string {
+	return processingArtifactObjectReferencePrefix +
+		base64.RawURLEncoding.EncodeToString([]byte(objectPath))
+}
+
+func processingArtifactObjectPath(reference string) (string, bool) {
+	if !strings.HasPrefix(reference, processingArtifactObjectReferencePrefix) {
+		return "", false
+	}
+	encoded := strings.TrimPrefix(reference, processingArtifactObjectReferencePrefix)
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil || len(decoded) == 0 || processingArtifactObjectReference(string(decoded)) != reference {
+		return "", false
+	}
+	return string(decoded), true
 }
 
 func processingArtifactPathScheme(path string) string {
@@ -507,8 +1015,8 @@ func (s *processingArtifactStore) deleteCandidate(
 	path string,
 	resolver processingArtifactFileServiceResolver,
 ) {
-	if path != "" && resolver.service != nil {
-		_ = resolver.service.DeleteFile(ctx, filesvc.ServiceStoredPath(resolver.service, path))
+	if objectPath, ok := processingArtifactObjectPath(path); ok && resolver.service != nil {
+		_ = resolver.service.DeleteFile(ctx, filesvc.ServiceStoredPath(resolver.service, objectPath))
 	}
 }
 

--- a/internal/application/service/processing_artifact_counter.go
+++ b/internal/application/service/processing_artifact_counter.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+const (
+	processingArtifactOutcomeHit = iota
+	processingArtifactOutcomeMiss
+	processingArtifactOutcomeError
+	processingArtifactOutcomeEvicted
+	processingArtifactOutcomeWrite
+	processingArtifactOutcomeCount
+)
+
+var processingArtifactOutcomes = [...]string{
+	"hit",
+	"miss",
+	"error",
+	"evicted",
+	"write",
+}
+
+type processingArtifactStageCounters struct {
+	values [processingArtifactOutcomeCount]atomic.Uint64
+}
+
+type processingArtifactCounterRegistry struct {
+	stages sync.Map
+}
+
+func NewProcessingArtifactCounterRegistry() interfaces.ProcessingArtifactCounterRegistry {
+	return &processingArtifactCounterRegistry{}
+}
+
+func (r *processingArtifactCounterRegistry) Record(stage, outcome string) {
+	if !types.IsValidProcessingArtifactStage(stage) {
+		return
+	}
+	index := processingArtifactOutcomeIndex(outcome)
+	if index < 0 {
+		return
+	}
+	current, _ := r.stages.LoadOrStore(stage, &processingArtifactStageCounters{})
+	current.(*processingArtifactStageCounters).values[index].Add(1)
+}
+
+func (r *processingArtifactCounterRegistry) Snapshot() []types.ProcessingArtifactCounter {
+	counters := make([]types.ProcessingArtifactCounter, 0)
+	r.stages.Range(func(stage, value any) bool {
+		for index, outcome := range processingArtifactOutcomes {
+			if count := value.(*processingArtifactStageCounters).values[index].Load(); count > 0 {
+				counters = append(counters, types.ProcessingArtifactCounter{
+					Stage: stage.(string), Outcome: outcome, Count: count,
+				})
+			}
+		}
+		return true
+	})
+	sort.Slice(counters, func(i, j int) bool {
+		if counters[i].Stage != counters[j].Stage {
+			return counters[i].Stage < counters[j].Stage
+		}
+		return processingArtifactOutcomeIndex(counters[i].Outcome) < processingArtifactOutcomeIndex(counters[j].Outcome)
+	})
+	return counters
+}
+
+func processingArtifactOutcomeIndex(outcome string) int {
+	for index, candidate := range processingArtifactOutcomes {
+		if outcome == candidate {
+			return index
+		}
+	}
+	return -1
+}
+
+func processingArtifactTraceCacheStatus(cacheAttempted, hit bool) string {
+	if !cacheAttempted {
+		return "bypass"
+	}
+	if hit {
+		return "hit"
+	}
+	return "miss"
+}

--- a/internal/application/service/processing_artifact_counter_test.go
+++ b/internal/application/service/processing_artifact_counter_test.go
@@ -1,0 +1,559 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type processingArtifactCounterGetErrorRepository struct {
+	interfaces.ProcessingArtifactRepository
+	err error
+}
+
+func (r processingArtifactCounterGetErrorRepository) Get(context.Context, types.ProcessingArtifactKey) (*types.ProcessingArtifact, error) {
+	return nil, r.err
+}
+
+type processingArtifactCounterBatchGetErrorRepository struct {
+	interfaces.ProcessingArtifactRepository
+	err error
+}
+
+type processingArtifactCounterBatchPutErrorRepository struct {
+	interfaces.ProcessingArtifactRepository
+	err error
+}
+
+func (r processingArtifactCounterBatchPutErrorRepository) GetMany(
+	ctx context.Context,
+	keys []types.ProcessingArtifactKey,
+) (map[types.ProcessingArtifactKey]*types.ProcessingArtifact, error) {
+	return r.ProcessingArtifactRepository.(interface {
+		GetMany(context.Context, []types.ProcessingArtifactKey) (map[types.ProcessingArtifactKey]*types.ProcessingArtifact, error)
+	}).GetMany(ctx, keys)
+}
+
+func (r processingArtifactCounterBatchPutErrorRepository) PutManyIfAbsent(
+	context.Context,
+	[]*types.ProcessingArtifact,
+) error {
+	return r.err
+}
+
+type processingArtifactCounterBatchWinnerReadErrorRepository struct {
+	interfaces.ProcessingArtifactRepository
+	err error
+}
+
+func (r processingArtifactCounterBatchWinnerReadErrorRepository) GetMany(
+	context.Context,
+	[]types.ProcessingArtifactKey,
+) (map[types.ProcessingArtifactKey]*types.ProcessingArtifact, error) {
+	return nil, r.err
+}
+
+func (r processingArtifactCounterBatchWinnerReadErrorRepository) PutManyIfAbsent(
+	ctx context.Context,
+	artifacts []*types.ProcessingArtifact,
+) error {
+	return r.ProcessingArtifactRepository.(interface {
+		PutManyIfAbsent(context.Context, []*types.ProcessingArtifact) error
+	}).PutManyIfAbsent(ctx, artifacts)
+}
+
+type processingArtifactCounterSequentialPutFailureRepository struct {
+	interfaces.ProcessingArtifactRepository
+	mu         sync.Mutex
+	putCount   int
+	successKey types.ProcessingArtifactKey
+	failureKey types.ProcessingArtifactKey
+	failure    error
+}
+
+func (r *processingArtifactCounterSequentialPutFailureRepository) PutIfAbsent(
+	ctx context.Context,
+	artifact *types.ProcessingArtifact,
+) (bool, error) {
+	r.mu.Lock()
+	r.putCount++
+	putCount := r.putCount
+	r.mu.Unlock()
+	if putCount == 2 {
+		r.mu.Lock()
+		r.failureKey = types.ProcessingArtifactKey{
+			TenantID: artifact.TenantID, Stage: artifact.Stage,
+			KeyVersion: artifact.KeyVersion, InputFingerprint: artifact.InputFingerprint,
+		}
+		r.mu.Unlock()
+		return false, r.failure
+	}
+	created, err := r.ProcessingArtifactRepository.PutIfAbsent(ctx, artifact)
+	if err == nil {
+		r.mu.Lock()
+		r.successKey = types.ProcessingArtifactKey{
+			TenantID: artifact.TenantID, Stage: artifact.Stage,
+			KeyVersion: artifact.KeyVersion, InputFingerprint: artifact.InputFingerprint,
+		}
+		r.mu.Unlock()
+	}
+	return created, err
+}
+
+func (r *processingArtifactCounterSequentialPutFailureRepository) outcomeKeys() (types.ProcessingArtifactKey, types.ProcessingArtifactKey) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.successKey, r.failureKey
+}
+
+type processingArtifactCounterInvalidationBarrierRepository struct {
+	interfaces.ProcessingArtifactRepository
+	entered chan<- struct{}
+	release <-chan struct{}
+}
+
+func (r processingArtifactCounterInvalidationBarrierRepository) Get(
+	ctx context.Context,
+	key types.ProcessingArtifactKey,
+) (*types.ProcessingArtifact, error) {
+	artifact, err := r.ProcessingArtifactRepository.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	r.entered <- struct{}{}
+	<-r.release
+	return artifact, nil
+}
+
+func (r processingArtifactCounterInvalidationBarrierRepository) DeleteByIDWithResult(
+	ctx context.Context,
+	tenantID, id uint64,
+) (bool, error) {
+	return r.ProcessingArtifactRepository.DeleteByIDWithResult(ctx, tenantID, id)
+}
+
+func (r processingArtifactCounterBatchGetErrorRepository) GetMany(
+	context.Context,
+	[]types.ProcessingArtifactKey,
+) (map[types.ProcessingArtifactKey]*types.ProcessingArtifact, error) {
+	return nil, r.err
+}
+
+func (r processingArtifactCounterBatchGetErrorRepository) PutManyIfAbsent(
+	context.Context,
+	[]*types.ProcessingArtifact,
+) error {
+	return r.err
+}
+
+func newProcessingArtifactCounterStore(
+	t *testing.T,
+	repository interfaces.ProcessingArtifactRepository,
+) (interfaces.ProcessingArtifactStore, interfaces.ProcessingArtifactCounterRegistry) {
+	t.Helper()
+	registry := NewProcessingArtifactCounterRegistry()
+	return NewProcessingArtifactStoreWithMaxPayloadAndCounterRegistry(
+		repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7}},
+		newArtifactFakeFileService(),
+		ProcessingArtifactMaxPayload,
+		registry,
+	), registry
+}
+
+func processingArtifactCounterValue(
+	counters []types.ProcessingArtifactCounter,
+	stage, outcome string,
+) uint64 {
+	for _, counter := range counters {
+		if counter.Stage == stage && counter.Outcome == outcome {
+			return counter.Count
+		}
+	}
+	return 0
+}
+
+func processingArtifactCounterKey(t *testing.T, stage, suffix string) types.ProcessingArtifactKey {
+	t.Helper()
+	key, err := types.NewProcessingArtifactKey(7, stage, 1, []byte(suffix))
+	require.NoError(t, err)
+	return key
+}
+
+func TestProcessingArtifactCountersRecordSingleGetOutcomes(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	store, registry := newProcessingArtifactCounterStore(t, state.repository)
+	key := processingArtifactServiceKey(t, "counter-single-hit")
+	_, _, err := store.PutIfAbsent(context.Background(), key, []byte("value"))
+	require.NoError(t, err)
+	_, hit, err := store.Get(context.Background(), key)
+	require.NoError(t, err)
+	require.True(t, hit)
+	_, hit, err = store.Get(context.Background(), processingArtifactServiceKey(t, "counter-single-miss"))
+	require.NoError(t, err)
+	assert.False(t, hit)
+
+	counters := registry.Snapshot()
+	assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, key.Stage, "hit"))
+	assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, key.Stage, "miss"))
+	assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, key.Stage, "write"))
+}
+
+func TestProcessingArtifactCountersRecordGetErrors(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "counter-get-error")
+	store, registry := newProcessingArtifactCounterStore(t, processingArtifactCounterGetErrorRepository{
+		ProcessingArtifactRepository: state.repository,
+		err:                          errors.New("repository unavailable"),
+	})
+
+	_, _, err := store.Get(context.Background(), key)
+	require.Error(t, err)
+	assert.Equal(t, uint64(1), processingArtifactCounterValue(registry.Snapshot(), key.Stage, "error"))
+}
+
+func TestProcessingArtifactCountersRecordBatchRequestedCardinality(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	store, registry := newProcessingArtifactCounterStore(t, state.repository)
+	hitKey := processingArtifactServiceKey(t, "counter-batch-hit")
+	missKey := processingArtifactServiceKey(t, "counter-batch-miss")
+	_, _, err := store.PutIfAbsent(context.Background(), hitKey, []byte("value"))
+	require.NoError(t, err)
+
+	batchStore := store.(interfaces.ProcessingArtifactBatchStore)
+	values, err := batchStore.GetMany(context.Background(), []types.ProcessingArtifactKey{hitKey, missKey, hitKey})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("value"), values[hitKey])
+	counters := registry.Snapshot()
+	assert.Equal(t, uint64(2), processingArtifactCounterValue(counters, hitKey.Stage, "hit"))
+	assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, hitKey.Stage, "miss"))
+}
+
+func TestProcessingArtifactCountersRecordBatchFailureForEveryUnresolvedKey(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "counter-batch-error")
+	store, registry := newProcessingArtifactCounterStore(t, processingArtifactCounterBatchGetErrorRepository{
+		ProcessingArtifactRepository: state.repository,
+		err:                          errors.New("repository unavailable"),
+	})
+
+	batchStore := store.(interfaces.ProcessingArtifactBatchStore)
+	_, err := batchStore.GetMany(context.Background(), []types.ProcessingArtifactKey{key, key})
+	require.Error(t, err)
+	assert.Equal(t, uint64(2), processingArtifactCounterValue(registry.Snapshot(), key.Stage, "error"))
+}
+
+func TestProcessingArtifactCountersDoNotDoubleCountSequentialFallback(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "counter-sequential-fallback")
+	store, registry := newProcessingArtifactCounterStore(t, struct {
+		interfaces.ProcessingArtifactRepository
+	}{state.repository})
+	_, _, err := store.PutIfAbsent(context.Background(), key, []byte("value"))
+	require.NoError(t, err)
+
+	batchStore := store.(interfaces.ProcessingArtifactBatchStore)
+	_, err = batchStore.GetMany(context.Background(), []types.ProcessingArtifactKey{key})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), processingArtifactCounterValue(registry.Snapshot(), key.Stage, "hit"))
+}
+
+func TestProcessingArtifactCountersRecordOnlyEffectiveInvalidations(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "counter-invalidation")
+	seedProcessingArtifact(t, state.repository, key, []byte("observed"), "", 8, artifactSHA([]byte("observed")))
+	store, registry := newProcessingArtifactCounterStore(t, state.repository)
+
+	require.NoError(t, store.Invalidate(context.Background(), key, []byte("different")))
+	require.NoError(t, store.Invalidate(context.Background(), key, []byte("observed")))
+	require.NoError(t, store.Invalidate(context.Background(), key, []byte("observed")))
+	assert.Equal(t, uint64(1), processingArtifactCounterValue(registry.Snapshot(), key.Stage, "evicted"))
+}
+
+func TestProcessingArtifactCountersDoNotDoubleCountConcurrentInvalidations(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "counter-concurrent-invalidation")
+	seedProcessingArtifact(t, state.repository, key, []byte("observed"), "", 8, artifactSHA([]byte("observed")))
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{}, 2)
+	store, registry := newProcessingArtifactCounterStore(t, processingArtifactCounterInvalidationBarrierRepository{
+		ProcessingArtifactRepository: state.repository,
+		entered:                      entered,
+		release:                      release,
+	})
+
+	var group sync.WaitGroup
+	errs := make(chan error, 2)
+	for range 2 {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			errs <- store.Invalidate(context.Background(), key, []byte("observed"))
+		}()
+	}
+	<-entered
+	<-entered
+	release <- struct{}{}
+	release <- struct{}{}
+	group.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, uint64(1), processingArtifactCounterValue(registry.Snapshot(), key.Stage, "evicted"))
+}
+
+func TestProcessingArtifactCountersWriteOnlyForSuccessfulCanonicalValues(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "counter-write")
+	store, registry := newProcessingArtifactCounterStore(t, state.repository)
+
+	_, _, err := store.PutIfAbsent(context.Background(), key, []byte("value"))
+	require.NoError(t, err)
+	_, _, err = store.PutIfAbsent(context.Background(), key, make([]byte, ProcessingArtifactMaxPayload+1))
+	require.Error(t, err)
+	counters := registry.Snapshot()
+	assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, key.Stage, "write"))
+	assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, key.Stage, "error"))
+}
+
+func TestProcessingArtifactCountersRecordBatchWritesPerSuppliedKey(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	store, registry := newProcessingArtifactCounterStore(t, state.repository)
+	first := processingArtifactServiceKey(t, "counter-batch-write-first")
+	second := processingArtifactServiceKey(t, "counter-batch-write-second")
+
+	batchStore := store.(interfaces.ProcessingArtifactBatchStore)
+	_, err := batchStore.PutManyIfAbsent(context.Background(), map[types.ProcessingArtifactKey][]byte{
+		first:  []byte("first"),
+		second: []byte("second"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), processingArtifactCounterValue(registry.Snapshot(), first.Stage, "write"))
+}
+
+func TestProcessingArtifactCountersRecordBatchWriteErrorsWithoutWrites(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	store, registry := newProcessingArtifactCounterStore(t, state.repository)
+	first := processingArtifactServiceKey(t, "counter-batch-error-first")
+	second := processingArtifactServiceKey(t, "counter-batch-error-second")
+
+	batchStore := store.(interfaces.ProcessingArtifactBatchStore)
+	_, err := batchStore.PutManyIfAbsent(context.Background(), map[types.ProcessingArtifactKey][]byte{
+		first:  make([]byte, ProcessingArtifactMaxPayload+1),
+		second: []byte("second"),
+	})
+	require.Error(t, err)
+	counters := registry.Snapshot()
+	assert.Equal(t, uint64(2), processingArtifactCounterValue(counters, first.Stage, "error"))
+	assert.Zero(t, processingArtifactCounterValue(counters, first.Stage, "write"))
+}
+
+func TestProcessingArtifactCountersPreserveMixedBatchWriteProgress(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	large := processingArtifactCounterKey(t, "counter.mixed.large", "large")
+	inline := processingArtifactCounterKey(t, "counter.mixed.inline", "inline")
+	store, registry := newProcessingArtifactCounterStore(t, processingArtifactCounterBatchPutErrorRepository{
+		ProcessingArtifactRepository: state.repository,
+		err:                          errors.New("inline batch failed"),
+	})
+
+	_, err := store.(interfaces.ProcessingArtifactBatchStore).PutManyIfAbsent(context.Background(), map[types.ProcessingArtifactKey][]byte{
+		large:  bytes.Repeat([]byte("x"), ProcessingArtifactInlineLimit+1),
+		inline: []byte("inline"),
+	})
+	require.Error(t, err)
+	counters := registry.Snapshot()
+	assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, large.Stage, "write"))
+	assert.Zero(t, processingArtifactCounterValue(counters, large.Stage, "error"))
+	assert.Zero(t, processingArtifactCounterValue(counters, inline.Stage, "write"))
+	assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, inline.Stage, "error"))
+}
+
+func TestProcessingArtifactCountersPreserveSequentialFallbackWriteProgress(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	repository := &processingArtifactCounterSequentialPutFailureRepository{
+		ProcessingArtifactRepository: state.repository,
+		failure:                      errors.New("second put failed"),
+	}
+	store, registry := newProcessingArtifactCounterStore(t, repository)
+	first := processingArtifactCounterKey(t, "counter.sequential.first", "first")
+	second := processingArtifactCounterKey(t, "counter.sequential.second", "second")
+
+	_, err := store.(interfaces.ProcessingArtifactBatchStore).PutManyIfAbsent(context.Background(), map[types.ProcessingArtifactKey][]byte{
+		first:  []byte("first"),
+		second: []byte("second"),
+	})
+	require.Error(t, err)
+	successKey, failureKey := repository.outcomeKeys()
+	require.NotEmpty(t, successKey.Stage)
+	require.NotEmpty(t, failureKey.Stage)
+	counters := registry.Snapshot()
+	assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, successKey.Stage, "write"))
+	assert.Zero(t, processingArtifactCounterValue(counters, successKey.Stage, "error"))
+	assert.Zero(t, processingArtifactCounterValue(counters, failureKey.Stage, "write"))
+	assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, failureKey.Stage, "error"))
+}
+
+func TestProcessingArtifactCountersRecordDurableInlineWritesBeforeWinnerReadFailure(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	first := processingArtifactCounterKey(t, "counter.winner.first", "first")
+	second := processingArtifactCounterKey(t, "counter.winner.second", "second")
+	store, registry := newProcessingArtifactCounterStore(t, processingArtifactCounterBatchWinnerReadErrorRepository{
+		ProcessingArtifactRepository: state.repository,
+		err:                          errors.New("winner read failed"),
+	})
+
+	_, err := store.(interfaces.ProcessingArtifactBatchStore).PutManyIfAbsent(context.Background(), map[types.ProcessingArtifactKey][]byte{
+		first:  []byte("first"),
+		second: []byte("second"),
+	})
+	require.Error(t, err)
+	counters := registry.Snapshot()
+	for _, key := range []types.ProcessingArtifactKey{first, second} {
+		assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, key.Stage, "write"))
+		assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, key.Stage, "error"))
+	}
+}
+
+func TestProcessingArtifactCountersRecordStructuralRepairs(t *testing.T) {
+	t.Run("single", func(t *testing.T) {
+		state := newProcessingArtifactTestStore(t)
+		key := processingArtifactCounterKey(t, "counter.repair.single", "single")
+		seedProcessingArtifact(t, state.repository, key, []byte("corrupt"), "", 7, artifactSHA([]byte("different")))
+		store, registry := newProcessingArtifactCounterStore(t, state.repository)
+
+		_, hit, err := store.Get(context.Background(), key)
+		require.NoError(t, err)
+		assert.False(t, hit)
+		counters := registry.Snapshot()
+		assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, key.Stage, "miss"))
+		assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, key.Stage, "evicted"))
+		assert.Zero(t, processingArtifactCounterValue(counters, key.Stage, "error"))
+	})
+
+	t.Run("duplicate batch", func(t *testing.T) {
+		state := newProcessingArtifactTestStore(t)
+		key := processingArtifactCounterKey(t, "counter.repair.duplicate", "duplicate")
+		seedProcessingArtifact(t, state.repository, key, []byte("corrupt"), "", 7, artifactSHA([]byte("different")))
+		store, registry := newProcessingArtifactCounterStore(t, state.repository)
+
+		_, err := store.(interfaces.ProcessingArtifactBatchStore).GetMany(context.Background(), []types.ProcessingArtifactKey{key, key})
+		require.NoError(t, err)
+		counters := registry.Snapshot()
+		assert.Equal(t, uint64(2), processingArtifactCounterValue(counters, key.Stage, "miss"))
+		assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, key.Stage, "evicted"))
+		assert.Zero(t, processingArtifactCounterValue(counters, key.Stage, "error"))
+	})
+
+	t.Run("concurrent", func(t *testing.T) {
+		state := newProcessingArtifactTestStore(t)
+		key := processingArtifactCounterKey(t, "counter.repair.concurrent", "concurrent")
+		seedProcessingArtifact(t, state.repository, key, []byte("corrupt"), "", 7, artifactSHA([]byte("different")))
+		entered := make(chan struct{}, 2)
+		release := make(chan struct{}, 2)
+		store, registry := newProcessingArtifactCounterStore(t, processingArtifactCounterInvalidationBarrierRepository{
+			ProcessingArtifactRepository: state.repository,
+			entered:                      entered,
+			release:                      release,
+		})
+
+		var group sync.WaitGroup
+		errs := make(chan error, 2)
+		for range 2 {
+			group.Add(1)
+			go func() {
+				defer group.Done()
+				_, _, err := store.Get(context.Background(), key)
+				errs <- err
+			}()
+		}
+		<-entered
+		<-entered
+		release <- struct{}{}
+		release <- struct{}{}
+		group.Wait()
+		close(errs)
+		for err := range errs {
+			require.NoError(t, err)
+		}
+		counters := registry.Snapshot()
+		assert.Equal(t, uint64(2), processingArtifactCounterValue(counters, key.Stage, "miss"))
+		assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, key.Stage, "evicted"))
+		assert.Zero(t, processingArtifactCounterValue(counters, key.Stage, "error"))
+	})
+
+	t.Run("delete failure", func(t *testing.T) {
+		state := newProcessingArtifactTestStore(t)
+		key := processingArtifactCounterKey(t, "counter.repair.failure", "failure")
+		seedProcessingArtifact(t, state.repository, key, []byte("corrupt"), "", 7, artifactSHA([]byte("different")))
+		store, registry := newProcessingArtifactCounterStore(t, &artifactDeleteErrorRepository{
+			ProcessingArtifactRepository: state.repository,
+			err:                          errors.New("delete failed"),
+		})
+
+		_, _, err := store.Get(context.Background(), key)
+		require.Error(t, err)
+		counters := registry.Snapshot()
+		assert.Equal(t, uint64(1), processingArtifactCounterValue(counters, key.Stage, "error"))
+		assert.Zero(t, processingArtifactCounterValue(counters, key.Stage, "evicted"))
+	})
+}
+
+func TestProcessingArtifactCounterSnapshotIsImmutable(t *testing.T) {
+	registry := NewProcessingArtifactCounterRegistry()
+	registry.Record("chunking", "hit")
+	first := registry.Snapshot()
+	require.Len(t, first, 1)
+	first[0].Count = 0
+	second := registry.Snapshot()
+	assert.Equal(t, uint64(1), processingArtifactCounterValue(second, "chunking", "hit"))
+}
+
+func TestProcessingArtifactCountersRejectInvalidLabels(t *testing.T) {
+	registry := NewProcessingArtifactCounterRegistry()
+	registry.Record("invalid stage", "hit")
+	registry.Record("chunking", "unknown")
+	assert.Empty(t, registry.Snapshot())
+}
+
+func TestProcessingArtifactCountersAreSafeForConcurrentRecording(t *testing.T) {
+	registry := NewProcessingArtifactCounterRegistry()
+	const workers = 32
+	const recordsPerWorker = 100
+	var group sync.WaitGroup
+	stopSnapshots := make(chan struct{})
+	var snapshots sync.WaitGroup
+	snapshots.Add(1)
+	go func() {
+		defer snapshots.Done()
+		for {
+			select {
+			case <-stopSnapshots:
+				return
+			default:
+				_ = registry.Snapshot()
+			}
+		}
+	}()
+	for range workers {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			for range recordsPerWorker {
+				registry.Record("chunking", "hit")
+			}
+		}()
+	}
+	group.Wait()
+	close(stopSnapshots)
+	snapshots.Wait()
+	assert.Equal(t, uint64(workers*recordsPerWorker), processingArtifactCounterValue(registry.Snapshot(), "chunking", "hit"))
+}

--- a/internal/application/service/processing_artifact_operations_test.go
+++ b/internal/application/service/processing_artifact_operations_test.go
@@ -1,0 +1,474 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"sync"
+	"testing"
+	"time"
+
+	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type processingArtifactInvalidator interface {
+	Invalidate(context.Context, types.ProcessingArtifactKey, []byte) error
+}
+
+type historicalArtifactStorageResolver struct {
+	backendID string
+	service   interfaces.FileService
+}
+
+func (r historicalArtifactStorageResolver) ResolveFileService(
+	context.Context,
+	*types.Tenant,
+	string,
+	string,
+	string,
+) (interfaces.FileService, string, error) {
+	return nil, "", errors.New("storage backend is not active")
+}
+
+func (r historicalArtifactStorageResolver) ResolveHistoricalFileService(
+	_ context.Context,
+	_ *types.Tenant,
+	backendID, _ string,
+) (interfaces.FileService, string, error) {
+	if backendID != r.backendID {
+		return nil, "", errors.New("storage backend not found")
+	}
+	return filesvc.NewBackendScopedFileService(backendID, r.service), "cos", nil
+}
+
+func (r historicalArtifactStorageResolver) ResolveBackend(
+	context.Context,
+	*types.Tenant,
+	string,
+	string,
+) (*types.StorageBackend, error) {
+	return nil, nil
+}
+
+func requireProcessingArtifactInvalidator(t *testing.T, store interfaces.ProcessingArtifactStore) processingArtifactInvalidator {
+	t.Helper()
+	invalidator, ok := store.(processingArtifactInvalidator)
+	require.True(t, ok, "processing artifact store must support exact-key invalidation")
+	return invalidator
+}
+
+func TestProcessingArtifactStoreInvalidatesTenantScopedInlineManifest(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "invalidate-inline")
+	otherTenantKey := key
+	otherTenantKey.TenantID++
+	for _, candidate := range []struct {
+		key   types.ProcessingArtifactKey
+		value []byte
+	}{
+		{key: key, value: []byte("tenant-seven")},
+		{key: otherTenantKey, value: []byte("tenant-eight")},
+	} {
+		_, created, err := state.store.PutIfAbsent(context.Background(), candidate.key, candidate.value)
+		require.NoError(t, err)
+		require.True(t, created)
+	}
+
+	require.NoError(t, requireProcessingArtifactInvalidator(t, state.store).Invalidate(context.Background(), key, []byte("tenant-seven")))
+	_, hit, err := state.store.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	value, hit, err := state.store.Get(context.Background(), otherTenantKey)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, []byte("tenant-eight"), value)
+}
+
+func TestProcessingArtifactStoreInvalidationIsIdempotentForMissingKey(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "invalidate-missing")
+
+	err := requireProcessingArtifactInvalidator(t, state.store).Invalidate(context.Background(), key, []byte("missing"))
+	require.NoError(t, err)
+}
+
+func TestProcessingArtifactStoreInvalidatesObjectThroughItsOriginalStorageBackend(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "invalidation-original-backend")
+	backendA := newArtifactFakeFileService()
+	backendB := newArtifactFakeFileService()
+	path := "cos://shared-key"
+	backendA.objects[path] = []byte("cached")
+	backendB.objects[path] = []byte("user file")
+	defaultBackendID := "backend-b"
+	tenant := &types.Tenant{ID: key.TenantID, DefaultStorageBackendID: &defaultBackendID}
+	store := newProcessingArtifactStoreWithDependencies(
+		state.repository,
+		&artifactTenantRepository{tenant: tenant},
+		state.files,
+		filesvc.NewFileServiceFromStorageConfig,
+		&artifactStorageBackendResolver{services: map[string]interfaces.FileService{
+			"backend-a": backendA,
+			"backend-b": backendB,
+		}},
+		ProcessingArtifactMaxPayload,
+		NewProcessingArtifactCounterRegistry(),
+	)
+	seedProcessingArtifact(
+		t,
+		state.repository,
+		key,
+		nil,
+		types.BuildStorageBackendPath("backend-a", path),
+		int64(len("cached")),
+		artifactSHA([]byte("cached")),
+	)
+
+	require.NoError(t, requireProcessingArtifactInvalidator(t, store).Invalidate(
+		context.Background(),
+		key,
+		[]byte("cached"),
+	))
+
+	_, _, objectsA := backendA.snapshot()
+	_, _, objectsB := backendB.snapshot()
+	assert.NotContains(t, objectsA, path)
+	assert.Equal(t, []byte("user file"), objectsB[path])
+}
+
+func TestProcessingArtifactStoreReadsAndPurgesObjectAfterBackendRetirementRace(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	backend := newArtifactFakeFileService()
+	backendID := "backend-a"
+	path := "cos://cached-object"
+	want := []byte("cached")
+	backend.objects[path] = bytes.Clone(want)
+	key := processingArtifactServiceKey(t, "retired-storage-backend")
+	seedProcessingArtifact(
+		t,
+		state.repository,
+		key,
+		nil,
+		types.BuildStorageBackendPath(backendID, path),
+		int64(len(want)),
+		artifactSHA(want),
+	)
+	store := newProcessingArtifactStoreWithDependencies(
+		state.repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: key.TenantID}},
+		state.files,
+		filesvc.NewFileServiceFromStorageConfig,
+		historicalArtifactStorageResolver{backendID: backendID, service: backend},
+		ProcessingArtifactMaxPayload,
+		NewProcessingArtifactCounterRegistry(),
+	)
+
+	value, hit, err := store.Get(context.Background(), key)
+
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, want, value)
+
+	result, err := store.PurgeExpired(context.Background(), time.Now().Add(time.Hour), 10)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), result.Deleted)
+	_, _, objects := backend.snapshot()
+	assert.NotContains(t, objects, path)
+	_, err = state.repository.Get(context.Background(), key)
+	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+}
+
+func TestProcessingArtifactStoreInvalidatesOwnedObjectAndKeepsNonAuthoritativeObject(t *testing.T) {
+	t.Run("owned", func(t *testing.T) {
+		state := newProcessingArtifactTestStore(t)
+		key := processingArtifactServiceKey(t, "invalidate-object")
+		value := bytes.Repeat([]byte("o"), ProcessingArtifactInlineLimit+1)
+		_, created, err := state.store.PutIfAbsent(context.Background(), key, value)
+		require.NoError(t, err)
+		require.True(t, created)
+		artifact, err := state.repository.Get(context.Background(), key)
+		require.NoError(t, err)
+		objectPath, ok := processingArtifactObjectPath(artifact.ObjectPath)
+		require.True(t, ok)
+
+		require.NoError(t, requireProcessingArtifactInvalidator(t, state.store).Invalidate(context.Background(), key, value))
+		_, err = state.repository.Get(context.Background(), key)
+		assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+		_, deletes, objects := state.files.snapshot()
+		assert.Equal(t, []string{objectPath}, deletes)
+		assert.NotContains(t, objects, objectPath)
+	})
+
+	t.Run("non-authoritative", func(t *testing.T) {
+		state := newProcessingArtifactTestStore(t)
+		key := processingArtifactServiceKey(t, "invalidate-non-authoritative")
+		path := "minio://historical-bucket/object"
+		state.files.objects[path] = []byte("historical")
+		seedProcessingArtifact(t, state.repository, key, nil, path, 10, artifactSHA([]byte("historical")))
+		store := NewProcessingArtifactStore(
+			state.repository,
+			&artifactTenantRepository{tenant: &types.Tenant{ID: key.TenantID}},
+			artifactMetadataFileService{FileService: state.files, provider: "local"},
+		)
+
+		err := requireProcessingArtifactInvalidator(t, store).Invalidate(context.Background(), key, []byte("historical"))
+		require.ErrorContains(t, err, "not authoritatively owned")
+		_, err = state.repository.Get(context.Background(), key)
+		require.NoError(t, err)
+		_, deletes, objects := state.files.snapshot()
+		assert.Empty(t, deletes)
+		assert.Equal(t, []byte("historical"), objects[path])
+	})
+
+	t.Run("same-provider path without artifact ownership reference", func(t *testing.T) {
+		state := newProcessingArtifactTestStore(t)
+		key := processingArtifactServiceKey(t, "invalidate-unowned-local")
+		path := "local://7/exports/user-document.bin"
+		state.files.objects[path] = []byte("user document")
+		seedProcessingArtifactReference(
+			t,
+			state.repository,
+			key,
+			nil,
+			path,
+			int64(len(state.files.objects[path])),
+			artifactSHA(state.files.objects[path]),
+		)
+
+		err := requireProcessingArtifactInvalidator(t, state.store).Invalidate(
+			context.Background(), key, state.files.objects[path],
+		)
+
+		require.ErrorContains(t, err, "not authoritatively owned")
+		_, manifestErr := state.repository.Get(context.Background(), key)
+		require.NoError(t, manifestErr)
+		_, deletes, objects := state.files.snapshot()
+		assert.Empty(t, deletes)
+		assert.Equal(t, []byte("user document"), objects[path])
+	})
+}
+
+func TestProcessingArtifactStoreInvalidationKeepsManifestWhenObjectDeleteFails(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "invalidate-object-delete-failure")
+	path := "local://tenant-7/object"
+	state.files.objects[path] = []byte("object")
+	state.files.deleteErrors[path] = errors.New("delete object failed")
+	seedProcessingArtifact(t, state.repository, key, nil, path, 6, artifactSHA([]byte("object")))
+
+	err := requireProcessingArtifactInvalidator(t, state.store).Invalidate(context.Background(), key, []byte("object"))
+	assert.ErrorIs(t, err, state.files.deleteErrors[path])
+	_, manifestErr := state.repository.Get(context.Background(), key)
+	require.NoError(t, manifestErr)
+	_, deletes, objects := state.files.snapshot()
+	assert.Equal(t, []string{path}, deletes)
+	assert.Equal(t, []byte("object"), objects[path])
+}
+
+func TestProcessingArtifactStoreInvalidationDeletesObjectBeforeManifest(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "invalidate-manifest-delete-failure")
+	path := "local://tenant-7/object"
+	state.files.objects[path] = []byte("object")
+	seedProcessingArtifact(t, state.repository, key, nil, path, 6, artifactSHA([]byte("object")))
+	deleteErr := errors.New("delete manifest failed")
+	store := NewProcessingArtifactStore(
+		&artifactDeleteErrorRepository{ProcessingArtifactRepository: state.repository, err: deleteErr},
+		&artifactTenantRepository{tenant: &types.Tenant{ID: key.TenantID}},
+		state.files,
+	)
+
+	err := requireProcessingArtifactInvalidator(t, store).Invalidate(context.Background(), key, []byte("object"))
+	assert.ErrorIs(t, err, deleteErr)
+	_, err = state.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	_, deletes, objects := state.files.snapshot()
+	assert.Equal(t, []string{path}, deletes)
+	assert.NotContains(t, objects, path)
+}
+
+func TestProcessingArtifactStoreRejectsOversizedCandidatesBeforeMutation(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	oversized := bytes.Repeat([]byte("x"), 64<<20+1)
+
+	_, created, err := state.store.PutIfAbsent(
+		context.Background(), processingArtifactServiceKey(t, "oversized-single"), oversized,
+	)
+	require.Error(t, err)
+	assert.False(t, created)
+	saves, deletes, objects := state.files.snapshot()
+	assert.Empty(t, saves)
+	assert.Empty(t, deletes)
+	assert.Empty(t, objects)
+
+	batchStore := state.store.(interfaces.ProcessingArtifactBatchStore)
+	_, err = batchStore.PutManyIfAbsent(context.Background(), map[types.ProcessingArtifactKey][]byte{
+		processingArtifactServiceKey(t, "oversized-batch"): oversized,
+		processingArtifactServiceKey(t, "small-batch"):     []byte("small"),
+	})
+	require.Error(t, err)
+	_, err = state.repository.Get(context.Background(), processingArtifactServiceKey(t, "small-batch"))
+	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+	saves, deletes, objects = state.files.snapshot()
+	assert.Empty(t, saves)
+	assert.Empty(t, deletes)
+	assert.Empty(t, objects)
+}
+
+func TestProcessingArtifactStoreAcceptsDefaultMaximumPayload(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	value := bytes.Repeat([]byte("x"), ProcessingArtifactMaxPayload)
+
+	canonical, created, err := state.store.PutIfAbsent(
+		context.Background(), processingArtifactServiceKey(t, "default-maximum"), value,
+	)
+	require.NoError(t, err)
+	assert.True(t, created)
+	assert.Equal(t, value, canonical)
+	saves, _, _ := state.files.snapshot()
+	assert.Len(t, saves, 1)
+}
+
+func TestProcessingArtifactStoreHonorsConfiguredMaximumPayload(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	store := NewProcessingArtifactStoreWithMaxPayload(
+		state.repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7}},
+		state.files,
+		2,
+	)
+
+	_, created, err := store.PutIfAbsent(
+		context.Background(), processingArtifactServiceKey(t, "configured-maximum"), []byte("ok"),
+	)
+	require.NoError(t, err)
+	assert.True(t, created)
+	_, created, err = store.PutIfAbsent(
+		context.Background(), processingArtifactServiceKey(t, "configured-oversized"), []byte("big"),
+	)
+	require.Error(t, err)
+	assert.False(t, created)
+}
+
+func TestProcessingArtifactStoreInvalidationPreservesNewerWinner(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "invalidation-newer-winner")
+	observed := bytes.Repeat([]byte("o"), ProcessingArtifactInlineLimit+1)
+	_, created, err := state.store.PutIfAbsent(context.Background(), key, observed)
+	require.NoError(t, err)
+	require.True(t, created)
+	old, err := state.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	oldObjectPath, ok := processingArtifactObjectPath(old.ObjectPath)
+	require.True(t, ok)
+	require.NoError(t, state.files.DeleteFile(context.Background(), oldObjectPath))
+	require.NoError(t, state.repository.DeleteByID(context.Background(), key.TenantID, old.ID))
+
+	healthy := bytes.Repeat([]byte("h"), ProcessingArtifactInlineLimit+2)
+	_, created, err = state.store.PutIfAbsent(context.Background(), key, healthy)
+	require.NoError(t, err)
+	require.True(t, created)
+	current, err := state.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	currentObjectPath, ok := processingArtifactObjectPath(current.ObjectPath)
+	require.True(t, ok)
+
+	require.NoError(t, requireProcessingArtifactInvalidator(t, state.store).Invalidate(context.Background(), key, observed))
+	value, hit, err := state.store.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, healthy, value)
+	_, deletes, objects := state.files.snapshot()
+	assert.NotContains(t, deletes, currentObjectPath)
+	assert.Contains(t, objects, currentObjectPath)
+}
+
+func TestProcessingArtifactStoreInvalidationTreatsMissingObjectAsCleaned(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "invalidation-missing-object")
+	path := "local://tenant-7/missing-object"
+	state.files.deleteErrors[path] = fs.ErrNotExist
+	seedProcessingArtifact(t, state.repository, key, nil, path, 6, artifactSHA([]byte("object")))
+
+	require.NoError(t, requireProcessingArtifactInvalidator(t, state.store).Invalidate(context.Background(), key, []byte("object")))
+	_, err := state.repository.Get(context.Background(), key)
+	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+}
+
+func TestProcessingArtifactStoreInvalidationAllowsConcurrentObservedGeneration(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "invalidation-concurrent")
+	path := "local://tenant-7/concurrent-object"
+	state.files.objects[path] = []byte("object")
+	state.files.missingDeleteErr = true
+	seedProcessingArtifact(t, state.repository, key, nil, path, 6, artifactSHA([]byte("object")))
+
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{}, 2)
+	store := NewProcessingArtifactStore(
+		&artifactInvalidationBarrierRepository{
+			ProcessingArtifactRepository: state.repository,
+			entered:                      entered,
+			release:                      release,
+		},
+		&artifactTenantRepository{tenant: &types.Tenant{ID: key.TenantID}},
+		state.files,
+	)
+	invalidator := requireProcessingArtifactInvalidator(t, store)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- invalidator.Invalidate(context.Background(), key, []byte("object"))
+		}()
+	}
+	<-entered
+	<-entered
+	release <- struct{}{}
+	release <- struct{}{}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		assert.NoError(t, err)
+	}
+
+	_, err := state.repository.Get(context.Background(), key)
+	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+	_, deletes, objects := state.files.snapshot()
+	assert.Len(t, deletes, 2)
+	assert.NotContains(t, objects, path)
+}
+
+func TestProcessingArtifactStoreInvalidationRepairsMissingObjectAfterManifestDeleteFailure(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "invalidation-manifest-repair")
+	path := "local://tenant-7/manifest-repair"
+	state.files.objects[path] = []byte("object")
+	seedProcessingArtifact(t, state.repository, key, nil, path, 6, artifactSHA([]byte("object")))
+	deleteErr := errors.New("delete manifest failed")
+	store := NewProcessingArtifactStore(
+		&artifactDeleteErrorRepository{ProcessingArtifactRepository: state.repository, err: deleteErr},
+		&artifactTenantRepository{tenant: &types.Tenant{ID: key.TenantID}},
+		state.files,
+	)
+
+	err := requireProcessingArtifactInvalidator(t, store).Invalidate(context.Background(), key, []byte("object"))
+	assert.ErrorIs(t, err, deleteErr)
+	_, _, objects := state.files.snapshot()
+	assert.NotContains(t, objects, path)
+
+	value, hit, err := state.store.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	_, err = state.repository.Get(context.Background(), key)
+	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+}

--- a/internal/application/service/processing_artifact_retention_runner.go
+++ b/internal/application/service/processing_artifact_retention_runner.go
@@ -1,0 +1,212 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+const processingArtifactRetentionStartupDelay = 10 * time.Minute
+
+type ProcessingArtifactRetentionRunner struct {
+	service       interfaces.ProcessingArtifactRetentionService
+	counters      interfaces.ProcessingArtifactCounterRegistry
+	retentionDays int
+	batchSize     int
+	interval      time.Duration
+	invalid       bool
+
+	mu      sync.Mutex
+	stopCh  chan struct{}
+	doneCh  chan struct{}
+	started bool
+	stopped bool
+}
+
+func NewProcessingArtifactRetentionRunner(
+	cfg *config.Config,
+	service interfaces.ProcessingArtifactRetentionService,
+	counters interfaces.ProcessingArtifactCounterRegistry,
+) *ProcessingArtifactRetentionRunner {
+	retentionDays, batchSize, intervalHours := 0, 100, 24
+	invalid := false
+	if cfg != nil && cfg.ProcessingArtifact != nil {
+		batchSize = cfg.ProcessingArtifact.CleanupBatchSize
+		if processingArtifactRetentionSettingsValid(
+			cfg.ProcessingArtifact.RetentionDays,
+			cfg.ProcessingArtifact.CleanupIntervalHours,
+		) {
+			retentionDays = cfg.ProcessingArtifact.RetentionDays
+			intervalHours = cfg.ProcessingArtifact.CleanupIntervalHours
+		} else {
+			invalid = true
+		}
+	}
+	return &ProcessingArtifactRetentionRunner{
+		service:       service,
+		counters:      counters,
+		retentionDays: retentionDays,
+		batchSize:     batchSize,
+		interval:      time.Duration(intervalHours) * time.Hour,
+		invalid:       invalid,
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+	}
+}
+
+func (r *ProcessingArtifactRetentionRunner) Start(ctx context.Context) {
+	if r == nil || r.service == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.stopped || r.started {
+		r.mu.Unlock()
+		return
+	}
+	r.started = true
+	if r.invalid {
+		close(r.doneCh)
+		r.mu.Unlock()
+		logger.Warnf(ctx, "[processing-artifact-retention] disabled due to invalid duration settings")
+		return
+	}
+	r.mu.Unlock()
+	if r.retentionDays == 0 {
+		logger.Infof(ctx, "[processing-artifact-retention] purge disabled; counter reporting remains active")
+		go r.loop()
+		return
+	}
+	logger.Infof(ctx,
+		"[processing-artifact-retention] starting sweep: retention_days=%d cleanup_interval_hours=%d cleanup_batch_size=%d",
+		r.retentionDays, int(r.interval/time.Hour), r.batchSize,
+	)
+	go r.loop()
+}
+
+func (r *ProcessingArtifactRetentionRunner) Stop() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	if !r.stopped {
+		r.stopped = true
+		close(r.stopCh)
+		if !r.started {
+			close(r.doneCh)
+		}
+	}
+	doneCh := r.doneCh
+	r.mu.Unlock()
+	<-doneCh
+}
+
+func (r *ProcessingArtifactRetentionRunner) loop() {
+	defer close(r.doneCh)
+	startupTimer := time.NewTimer(processingArtifactRetentionStartupDelay)
+	defer startupTimer.Stop()
+	select {
+	case <-startupTimer.C:
+	case <-r.stopCh:
+		return
+	}
+
+	r.runOnce()
+	if r.interval <= 0 {
+		logger.Warnf(context.Background(), "[processing-artifact-retention] invalid cleanup interval")
+		return
+	}
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			r.runOnce()
+		case <-r.stopCh:
+			return
+		}
+	}
+}
+
+func (r *ProcessingArtifactRetentionRunner) runOnce() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	r.reportCounters(ctx)
+
+	if r.invalid {
+		logger.Warnf(ctx, "[processing-artifact-retention] invalid duration settings")
+		return
+	}
+	if r.retentionDays == 0 {
+		return
+	}
+	cutoff, ok := processingArtifactRetentionCutoff(time.Now(), r.retentionDays)
+	if !ok {
+		logger.Warnf(ctx, "[processing-artifact-retention] invalid retention_days=%d", r.retentionDays)
+		return
+	}
+	result, err := r.service.PurgeExpired(
+		ctx,
+		cutoff,
+		r.batchSize,
+	)
+	if err != nil {
+		logger.GetLogger(ctx).WithField(
+			"failure_kind", processingArtifactRetentionFailureKind(err),
+		).Warnf(
+			"[processing-artifact-retention] sweep incomplete: retention_days=%d cleanup_batch_size=%d scanned=%d deleted=%d failed=%d deleted_bytes=%d",
+			r.retentionDays, r.batchSize, result.Scanned, result.Deleted, result.Failed, result.DeletedBytes,
+		)
+		return
+	}
+	logger.Infof(ctx,
+		"[processing-artifact-retention] sweep complete: retention_days=%d cleanup_batch_size=%d scanned=%d deleted=%d failed=%d deleted_bytes=%d",
+		r.retentionDays, r.batchSize, result.Scanned, result.Deleted, result.Failed, result.DeletedBytes,
+	)
+}
+
+type processingArtifactFailureKindError interface {
+	ProcessingArtifactFailureKind() string
+}
+
+func processingArtifactRetentionFailureKind(err error) string {
+	var classified processingArtifactFailureKindError
+	if !errors.As(err, &classified) {
+		return "unknown"
+	}
+	switch kind := classified.ProcessingArtifactFailureKind(); kind {
+	case "manifest_list", "manifest_invalid", "storage_resolve", "ownership", "object_delete", "manifest_delete":
+		return kind
+	default:
+		return "unknown"
+	}
+}
+
+func (r *ProcessingArtifactRetentionRunner) reportCounters(ctx context.Context) {
+	if r.counters == nil {
+		return
+	}
+	for _, counter := range r.counters.Snapshot() {
+		logger.GetLogger(ctx).WithFields(logger.Fields{
+			"stage":   counter.Stage,
+			"outcome": counter.Outcome,
+			"count":   counter.Count,
+		}).Info("[processing-artifact-counter]")
+	}
+}
+
+func processingArtifactRetentionSettingsValid(retentionDays, intervalHours int) bool {
+	return retentionDays >= 0 && retentionDays <= config.MaxProcessingArtifactRetentionDays &&
+		intervalHours > 0 && intervalHours <= config.MaxProcessingArtifactCleanupIntervalHours
+}
+
+func processingArtifactRetentionCutoff(now time.Time, retentionDays int) (time.Time, bool) {
+	if retentionDays < 0 || retentionDays > config.MaxProcessingArtifactRetentionDays {
+		return time.Time{}, false
+	}
+	return now.Add(-time.Duration(retentionDays) * 24 * time.Hour), true
+}

--- a/internal/application/service/processing_artifact_retention_runner_test.go
+++ b/internal/application/service/processing_artifact_retention_runner_test.go
@@ -1,0 +1,344 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type processingArtifactPurgeCountingService struct {
+	interfaces.ProcessingArtifactRetentionService
+	calls       atomic.Int64
+	err         error
+	mu          sync.Mutex
+	batchSize   int
+	deadlineSet bool
+	deadline    time.Time
+}
+
+type processingArtifactSnapshotRegistry struct {
+	snapshotCalls atomic.Int64
+	counters      []types.ProcessingArtifactCounter
+}
+
+type classifiedProcessingArtifactPurgeError struct {
+	kind    string
+	message string
+}
+
+func (e classifiedProcessingArtifactPurgeError) Error() string {
+	return e.message
+}
+
+func (e classifiedProcessingArtifactPurgeError) ProcessingArtifactFailureKind() string {
+	return e.kind
+}
+
+func (r *processingArtifactSnapshotRegistry) Record(string, string) {}
+
+func (r *processingArtifactSnapshotRegistry) Snapshot() []types.ProcessingArtifactCounter {
+	r.snapshotCalls.Add(1)
+	return append([]types.ProcessingArtifactCounter(nil), r.counters...)
+}
+
+func (s *processingArtifactPurgeCountingService) PurgeExpired(ctx context.Context, _ time.Time, batchSize int) (types.ProcessingArtifactPurgeResult, error) {
+	s.calls.Add(1)
+	deadline, deadlineSet := ctx.Deadline()
+	s.mu.Lock()
+	s.batchSize = batchSize
+	s.deadline = deadline
+	s.deadlineSet = deadlineSet
+	s.mu.Unlock()
+	return types.ProcessingArtifactPurgeResult{}, s.err
+}
+
+func TestProcessingArtifactRetentionRunnerDisabledAndStopIsIdempotent(t *testing.T) {
+	svc := &processingArtifactPurgeCountingService{}
+	runner := &ProcessingArtifactRetentionRunner{
+		service:       svc,
+		retentionDays: 0,
+		batchSize:     1,
+		interval:      time.Millisecond,
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+	}
+	runner.Start(context.Background())
+	select {
+	case <-runner.doneCh:
+		t.Fatal("counter reporting must remain active when retention is disabled")
+	default:
+	}
+	runner.Stop()
+	runner.Stop()
+	assert.Zero(t, svc.calls.Load())
+}
+
+func TestProcessingArtifactRetentionRunnerReportsSharedCountersWithRetentionEnabledAndDisabled(t *testing.T) {
+	var output bytes.Buffer
+	previousFormat, hadFormat := os.LookupEnv("LOG_FORMAT")
+	t.Setenv("LOG_FORMAT", "%msg")
+	logger.ConfigureFromEnv()
+	logger.SetOutput(&output)
+	logger.SetLogLevel(logger.LevelInfo)
+	t.Cleanup(func() {
+		if hadFormat {
+			require.NoError(t, os.Setenv("LOG_FORMAT", previousFormat))
+		} else {
+			require.NoError(t, os.Unsetenv("LOG_FORMAT"))
+		}
+		logger.ConfigureFromEnv()
+	})
+
+	for _, retentionDays := range []int{30, 0} {
+		t.Run(fmt.Sprintf("retention_days_%d", retentionDays), func(t *testing.T) {
+			output.Reset()
+			svc := &processingArtifactPurgeCountingService{}
+			counters := &processingArtifactSnapshotRegistry{
+				counters: []types.ProcessingArtifactCounter{
+					{Stage: "chunking", Outcome: "hit", Count: 3},
+				},
+			}
+			runner := NewProcessingArtifactRetentionRunner(
+				&config.Config{ProcessingArtifact: &config.ProcessingArtifactConfig{
+					RetentionDays:        retentionDays,
+					CleanupIntervalHours: 24,
+					CleanupBatchSize:     17,
+				}},
+				svc,
+				counters,
+			)
+
+			runner.runOnce()
+
+			assert.Equal(t, int64(1), counters.snapshotCalls.Load())
+			if retentionDays == 0 {
+				assert.Zero(t, svc.calls.Load())
+			} else {
+				assert.Equal(t, int64(1), svc.calls.Load())
+			}
+			var counterLine string
+			for _, line := range strings.Split(output.String(), "\n") {
+				if strings.Contains(line, "[processing-artifact-counter]") {
+					counterLine = line
+					break
+				}
+			}
+			require.NotEmpty(t, counterLine)
+			assert.Contains(t, counterLine, "stage=chunking")
+			assert.Contains(t, counterLine, "outcome=hit")
+			assert.Contains(t, counterLine, "count=3")
+			for _, forbidden := range []string{
+				"retention_days", "cleanup_batch_size", "scanned", "deleted", "failed", "deleted_bytes",
+			} {
+				assert.NotContains(t, counterLine, forbidden)
+			}
+		})
+	}
+}
+
+func TestProcessingArtifactRetentionRunnerUsesConfiguredBatchAndTimeout(t *testing.T) {
+	svc := &processingArtifactPurgeCountingService{}
+	runner := &ProcessingArtifactRetentionRunner{
+		service:       svc,
+		retentionDays: 30,
+		batchSize:     17,
+		interval:      time.Hour,
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+	}
+	before := time.Now()
+	runner.runOnce()
+	assert.Equal(t, int64(1), svc.calls.Load())
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	assert.Equal(t, 17, svc.batchSize)
+	assert.True(t, svc.deadlineSet)
+	assert.WithinDuration(t, before.Add(30*time.Second), svc.deadline, time.Second)
+}
+
+func TestProcessingArtifactRetentionRunnerLogsOnlyClassifiedFailureKind(t *testing.T) {
+	var output bytes.Buffer
+	previousFormat, hadFormat := os.LookupEnv("LOG_FORMAT")
+	t.Setenv("LOG_FORMAT", "%msg")
+	logger.ConfigureFromEnv()
+	logger.SetOutput(&output)
+	logger.SetLogLevel(logger.LevelInfo)
+	t.Cleanup(func() {
+		if hadFormat {
+			require.NoError(t, os.Setenv("LOG_FORMAT", previousFormat))
+		} else {
+			require.NoError(t, os.Unsetenv("LOG_FORMAT"))
+		}
+		logger.ConfigureFromEnv()
+	})
+	svc := &processingArtifactPurgeCountingService{
+		err: classifiedProcessingArtifactPurgeError{
+			kind:    "object_delete",
+			message: "secret object path",
+		},
+	}
+	runner := &ProcessingArtifactRetentionRunner{
+		service:       svc,
+		retentionDays: 30,
+		batchSize:     1,
+		interval:      time.Hour,
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+	}
+
+	runner.runOnce()
+
+	assert.Contains(t, output.String(), "failure_kind=object_delete")
+	assert.NotContains(t, output.String(), "secret object path")
+}
+
+func TestProcessingArtifactRetentionRunnerStartAndStopAreIdempotent(t *testing.T) {
+	svc := &processingArtifactPurgeCountingService{}
+	runner := &ProcessingArtifactRetentionRunner{
+		service:       svc,
+		retentionDays: 30,
+		batchSize:     1,
+		interval:      time.Hour,
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+	}
+	runner.Start(context.Background())
+	runner.Start(context.Background())
+	runner.Stop()
+	runner.Stop()
+	assert.Zero(t, svc.calls.Load())
+}
+
+func TestProcessingArtifactRetentionRunnerStopBeforeStartIsTerminal(t *testing.T) {
+	svc := &processingArtifactPurgeCountingService{}
+	runner := &ProcessingArtifactRetentionRunner{
+		service:       svc,
+		retentionDays: 30,
+		batchSize:     1,
+		interval:      time.Hour,
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+	}
+	runner.Stop()
+	runner.Start(context.Background())
+	select {
+	case <-runner.doneCh:
+	default:
+		t.Fatal("Stop before Start must keep the runner terminal")
+	}
+	assert.Zero(t, svc.calls.Load())
+}
+
+func TestProcessingArtifactRetentionRunnerConcurrentStartStopIsTerminal(t *testing.T) {
+	svc := &processingArtifactPurgeCountingService{}
+	runner := &ProcessingArtifactRetentionRunner{
+		service:       svc,
+		retentionDays: 30,
+		batchSize:     1,
+		interval:      time.Hour,
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+	}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			runner.Start(context.Background())
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			runner.Stop()
+		}()
+	}
+	close(start)
+	wg.Wait()
+	select {
+	case <-runner.doneCh:
+	default:
+		runner.Stop()
+		t.Fatal("concurrent Stop must make the runner terminal")
+	}
+	runner.Start(context.Background())
+	assert.Zero(t, svc.calls.Load())
+}
+
+func TestProcessingArtifactRetentionRunnerDisablesUnrepresentableDurations(t *testing.T) {
+	for _, artifactConfig := range []*config.ProcessingArtifactConfig{
+		{
+			RetentionDays:        config.MaxProcessingArtifactRetentionDays + 1,
+			CleanupIntervalHours: 24,
+			CleanupBatchSize:     100,
+		},
+		{
+			RetentionDays:        30,
+			CleanupIntervalHours: config.MaxProcessingArtifactCleanupIntervalHours + 1,
+			CleanupBatchSize:     100,
+		},
+	} {
+		svc := &processingArtifactPurgeCountingService{}
+		runner := NewProcessingArtifactRetentionRunner(
+			&config.Config{ProcessingArtifact: artifactConfig},
+			svc,
+			&processingArtifactSnapshotRegistry{},
+		)
+		runner.runOnce()
+		assert.Zero(t, svc.calls.Load())
+		assert.Equal(t, 24*time.Hour, runner.interval)
+	}
+}
+
+func TestProcessingArtifactRetentionRunnerContinuesOnCadenceAfterError(t *testing.T) {
+	svc := &processingArtifactPurgeCountingService{err: errors.New("purge failed")}
+	runner := &ProcessingArtifactRetentionRunner{
+		service:       svc,
+		retentionDays: 30,
+		batchSize:     1,
+		interval:      20 * time.Millisecond,
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+	}
+	runner.mu.Lock()
+	runner.started = true
+	runner.mu.Unlock()
+	go runner.runLoopWithoutStartupDelay()
+	time.Sleep(70 * time.Millisecond)
+	runner.Stop()
+	assert.GreaterOrEqual(t, svc.calls.Load(), int64(2))
+}
+
+func (r *ProcessingArtifactRetentionRunner) runLoopWithoutStartupDelay() {
+	defer close(r.doneCh)
+	r.runOnce()
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			r.runOnce()
+		case <-r.stopCh:
+			return
+		}
+	}
+}
+
+func TestProcessingArtifactRetentionRunnerProductionStartupDelay(t *testing.T) {
+	assert.Equal(t, 10*time.Minute, processingArtifactRetentionStartupDelay)
+}

--- a/internal/application/service/processing_artifact_retention_test.go
+++ b/internal/application/service/processing_artifact_retention_test.go
@@ -1,0 +1,474 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type processingArtifactRetainer interface {
+	PurgeExpired(context.Context, time.Time, int) (types.ProcessingArtifactPurgeResult, error)
+}
+
+func requireProcessingArtifactRetainer(t *testing.T, store interfaces.ProcessingArtifactStore) processingArtifactRetainer {
+	t.Helper()
+	retainer, ok := store.(processingArtifactRetainer)
+	require.True(t, ok, "processing artifact store must support retention")
+	return retainer
+}
+
+func setProcessingArtifactCreatedAt(t *testing.T, state processingArtifactTestStore, artifact *types.ProcessingArtifact, createdAt time.Time) {
+	t.Helper()
+	require.NoError(t, state.db.Model(&types.ProcessingArtifact{}).
+		Where("id = ?", artifact.ID).
+		Update("created_at", createdAt).Error)
+}
+
+func TestProcessingArtifactRetentionDeletesInlineAndOwnedObject(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	cutoff := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	inlineKey := processingArtifactServiceKey(t, "retention-inline")
+	_, created, err := state.store.PutIfAbsent(context.Background(), inlineKey, []byte("inline"))
+	require.NoError(t, err)
+	require.True(t, created)
+	objectKey := processingArtifactServiceKey(t, "retention-object")
+	objectPath := "local://tenant-7/retention-object"
+	state.files.objects[objectPath] = []byte("object")
+	object := seedProcessingArtifact(t, state.repository, objectKey, nil, objectPath, 6, artifactSHA([]byte("object")))
+	inlineManifest, err := state.repository.Get(context.Background(), inlineKey)
+	require.NoError(t, err)
+	setProcessingArtifactCreatedAt(t, state, inlineManifest, cutoff.Add(-time.Hour))
+	setProcessingArtifactCreatedAt(t, state, object, cutoff.Add(-time.Hour))
+
+	result, err := requireProcessingArtifactRetainer(t, state.store).PurgeExpired(context.Background(), cutoff, 1)
+	require.NoError(t, err)
+	assert.Equal(t, types.ProcessingArtifactPurgeResult{Scanned: 2, Deleted: 2, DeletedBytes: 12}, result)
+	_, err = state.repository.Get(context.Background(), inlineKey)
+	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+	_, err = state.repository.Get(context.Background(), objectKey)
+	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+	_, deletes, objects := state.files.snapshot()
+	assert.Equal(t, []string{objectPath}, deletes)
+	assert.NotContains(t, objects, objectPath)
+}
+
+func TestProcessingArtifactRetentionKeepsRetryStateForUnownedAndFailedObjects(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	cutoff := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	nonAuthoritativeKey := processingArtifactServiceKey(t, "retention-unowned")
+	nonAuthoritative := seedProcessingArtifact(t, state.repository, nonAuthoritativeKey, nil, "minio://historical/object", 4, artifactSHA([]byte("data")))
+	failedObjectKey := processingArtifactServiceKey(t, "retention-object-failure")
+	failedPath := "local://tenant-7/retention-object-failure"
+	state.files.objects[failedPath] = []byte("data")
+	state.files.deleteErrors[failedPath] = errors.New("delete failed")
+	failedObject := seedProcessingArtifact(t, state.repository, failedObjectKey, nil, failedPath, 4, artifactSHA([]byte("data")))
+	setProcessingArtifactCreatedAt(t, state, nonAuthoritative, cutoff.Add(-time.Hour))
+	setProcessingArtifactCreatedAt(t, state, failedObject, cutoff.Add(-time.Hour))
+
+	result, err := requireProcessingArtifactRetainer(t, state.store).PurgeExpired(context.Background(), cutoff, 100)
+	require.Error(t, err)
+	assert.Equal(t, "ownership", processingArtifactRetentionFailureKind(err))
+	assert.Equal(t, types.ProcessingArtifactPurgeResult{Scanned: 2, Failed: 2}, result)
+	_, err = state.repository.Get(context.Background(), nonAuthoritativeKey)
+	require.NoError(t, err)
+	_, err = state.repository.Get(context.Background(), failedObjectKey)
+	require.NoError(t, err)
+}
+
+func TestProcessingArtifactRetentionPreservesSameProviderPathWithoutArtifactOwnershipReference(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	cutoff := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	key := processingArtifactServiceKey(t, "retention-unowned-local")
+	path := "local://7/exports/user-document.bin"
+	state.files.objects[path] = []byte("user document")
+	artifact := seedProcessingArtifactReference(
+		t,
+		state.repository,
+		key,
+		nil,
+		path,
+		int64(len(state.files.objects[path])),
+		artifactSHA(state.files.objects[path]),
+	)
+	setProcessingArtifactCreatedAt(t, state, artifact, cutoff.Add(-time.Hour))
+
+	result, err := requireProcessingArtifactRetainer(t, state.store).PurgeExpired(
+		context.Background(), cutoff, 100,
+	)
+
+	require.ErrorContains(t, err, "not authoritatively owned")
+	assert.Equal(t, types.ProcessingArtifactPurgeResult{Scanned: 1, Failed: 1}, result)
+	_, manifestErr := state.repository.Get(context.Background(), key)
+	require.NoError(t, manifestErr)
+	_, deletes, objects := state.files.snapshot()
+	assert.Empty(t, deletes)
+	assert.Equal(t, []byte("user document"), objects[path])
+}
+
+func TestProcessingArtifactRetentionTreatsMissingObjectAsCleanedAndAdvancesPastFailure(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	cutoff := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	failedKey := processingArtifactServiceKey(t, "retention-poison")
+	failed := seedProcessingArtifact(t, state.repository, failedKey, []byte("failed"), "", 6, artifactSHA([]byte("failed")))
+	missingKey := processingArtifactServiceKey(t, "retention-missing")
+	missingPath := "local://tenant-7/retention-missing"
+	state.files.missingDeleteErr = true
+	missing := seedProcessingArtifact(t, state.repository, missingKey, nil, missingPath, 7, artifactSHA([]byte("missing")))
+	goodKey := processingArtifactServiceKey(t, "retention-good")
+	good := seedProcessingArtifact(t, state.repository, goodKey, []byte("good"), "", 4, artifactSHA([]byte("good")))
+	for _, artifact := range []*types.ProcessingArtifact{failed, missing, good} {
+		setProcessingArtifactCreatedAt(t, state, artifact, cutoff.Add(-time.Hour))
+	}
+
+	store := NewProcessingArtifactStore(
+		&artifactDeleteErrorForIDRepository{ProcessingArtifactRepository: state.repository, id: failed.ID, err: errors.New("poison row")},
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7}}, state.files,
+	)
+	result, err := requireProcessingArtifactRetainer(t, store).PurgeExpired(context.Background(), cutoff, 1)
+	require.Error(t, err)
+	assert.Equal(t, "manifest_delete", processingArtifactRetentionFailureKind(err))
+	assert.Equal(t, types.ProcessingArtifactPurgeResult{Scanned: 3, Deleted: 2, Failed: 1, DeletedBytes: 11}, result)
+	_, err = state.repository.Get(context.Background(), failedKey)
+	require.NoError(t, err)
+	for _, key := range []types.ProcessingArtifactKey{missingKey, goodKey} {
+		_, err = state.repository.Get(context.Background(), key)
+		assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+	}
+	_, deletes, _ := state.files.snapshot()
+	assert.Equal(t, []string{missingPath}, deletes)
+}
+
+type artifactDeleteErrorForIDRepository struct {
+	interfaces.ProcessingArtifactRepository
+	id  uint64
+	err error
+}
+
+func (r *artifactDeleteErrorForIDRepository) DeleteByIDWithResult(ctx context.Context, tenantID, id uint64) (bool, error) {
+	if id == r.id {
+		return false, r.err
+	}
+	return r.ProcessingArtifactRepository.DeleteByIDWithResult(ctx, tenantID, id)
+}
+
+func TestProcessingArtifactRetentionRejectsInvalidBatchSize(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	_, err := requireProcessingArtifactRetainer(t, state.store).PurgeExpired(context.Background(), time.Now(), 0)
+	assert.Error(t, err)
+}
+
+func TestProcessingArtifactRetentionCachesTenantProviderResolversPerSweep(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	cutoff := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	tenants := &retentionTenantRepository{tenants: map[uint64]*types.Tenant{
+		7: {ID: 7, StorageEngineConfig: &types.StorageEngineConfig{DefaultProvider: "minio", MinIO: &types.MinIOEngineConfig{}}},
+		8: {ID: 8, StorageEngineConfig: &types.StorageEngineConfig{DefaultProvider: "local", Local: &types.LocalEngineConfig{}}},
+	}}
+	factoryCalls := make(map[string]int)
+	store := newProcessingArtifactStore(state.repository, tenants, state.files, func(provider string, _ *types.StorageEngineConfig, _ string) (interfaces.FileService, string, error) {
+		factoryCalls[provider]++
+		return artifactMetadataFileService{FileService: state.files, provider: provider}, provider, nil
+	})
+	for index, candidate := range []struct {
+		tenantID uint64
+		path     string
+	}{
+		{7, "minio://tenant-7/first"},
+		{7, "minio://tenant-7/second"},
+		{8, "local://tenant-8/third"},
+	} {
+		key := processingArtifactServiceKey(t, fmt.Sprintf("retention-resolver-%d", index))
+		key.TenantID = candidate.tenantID
+		state.files.objects[candidate.path] = []byte("value")
+		artifact := seedProcessingArtifact(t, state.repository, key, nil, candidate.path, 5, artifactSHA([]byte("value")))
+		setProcessingArtifactCreatedAt(t, state, artifact, cutoff.Add(-time.Hour))
+	}
+
+	result, err := store.PurgeExpired(context.Background(), cutoff, 1)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(3), result.Deleted)
+	assert.Equal(t, map[string]int{"minio": 1, "local": 1}, factoryCalls)
+	assert.Equal(t, map[uint64]int{7: 1, 8: 1}, tenants.calls)
+}
+
+func TestProcessingArtifactRetentionSeparatesBackendsForSameProvider(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	cutoff := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	backendA := newArtifactFakeFileService()
+	backendB := newArtifactFakeFileService()
+	defaultBackendID := "backend-b"
+	tenant := &types.Tenant{ID: 7, DefaultStorageBackendID: &defaultBackendID}
+	store := newProcessingArtifactStoreWithDependencies(
+		state.repository,
+		&artifactTenantRepository{tenant: tenant},
+		state.files,
+		filesvc.NewFileServiceFromStorageConfig,
+		&artifactStorageBackendResolver{services: map[string]interfaces.FileService{
+			"backend-a": backendA,
+			"backend-b": backendB,
+		}},
+		ProcessingArtifactMaxPayload,
+		NewProcessingArtifactCounterRegistry(),
+	)
+	for index, candidate := range []struct {
+		backendID string
+		service   *artifactFakeFileService
+	}{
+		{backendID: "backend-a", service: backendA},
+		{backendID: "backend-b", service: backendB},
+	} {
+		key := processingArtifactServiceKey(t, fmt.Sprintf("retention-backend-%d", index))
+		path := fmt.Sprintf("cos://shared/%d", index)
+		candidate.service.objects[path] = []byte("value")
+		artifact := seedProcessingArtifact(
+			t,
+			state.repository,
+			key,
+			nil,
+			types.BuildStorageBackendPath(candidate.backendID, path),
+			5,
+			artifactSHA([]byte("value")),
+		)
+		setProcessingArtifactCreatedAt(t, state, artifact, cutoff.Add(-time.Hour))
+	}
+
+	result, err := store.PurgeExpired(context.Background(), cutoff, 1)
+
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), result.Deleted)
+	_, deletesA, _ := backendA.snapshot()
+	_, deletesB, _ := backendB.snapshot()
+	assert.Equal(t, []string{"cos://shared/0"}, deletesA)
+	assert.Equal(t, []string{"cos://shared/1"}, deletesB)
+}
+
+func TestProcessingArtifactRetentionCachesResolverFailuresPerSweep(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	cutoff := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	tenants := &retentionTenantRepository{err: errors.New("tenant lookup failed")}
+	store := newProcessingArtifactStore(state.repository, tenants, state.files, nil)
+	for index := 0; index < 2; index++ {
+		key := processingArtifactServiceKey(t, fmt.Sprintf("retention-resolver-error-%d", index))
+		artifact := seedProcessingArtifact(t, state.repository, key, nil, fmt.Sprintf("minio://tenant-7/%d", index), 1, artifactSHA([]byte("x")))
+		setProcessingArtifactCreatedAt(t, state, artifact, cutoff.Add(-time.Hour))
+	}
+
+	result, err := store.PurgeExpired(context.Background(), cutoff, 1)
+	require.Error(t, err)
+	assert.Equal(t, "storage_resolve", processingArtifactRetentionFailureKind(err))
+	assert.Equal(t, uint64(2), result.Failed)
+	assert.Equal(t, map[uint64]int{7: 1}, tenants.calls)
+}
+
+func TestProcessingArtifactRetentionBoundsErrorPayload(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	cutoff := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	for index := 0; index < 10; index++ {
+		key := processingArtifactServiceKey(t, fmt.Sprintf("retention-error-%d", index))
+		artifact := seedProcessingArtifact(t, state.repository, key, nil, fmt.Sprintf("minio://historical/%d", index), 1, artifactSHA([]byte("x")))
+		setProcessingArtifactCreatedAt(t, state, artifact, cutoff.Add(-time.Hour))
+	}
+
+	result, err := requireProcessingArtifactRetainer(t, state.store).PurgeExpired(context.Background(), cutoff, 2)
+	require.Error(t, err)
+	assert.Equal(t, uint64(10), result.Failed)
+	assert.Equal(t, 1, strings.Count(err.Error(), "not authoritatively owned"))
+}
+
+func TestProcessingArtifactRetentionStopsOnNilManifestPage(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	repository := &retentionNilPageRepository{ProcessingArtifactRepository: state.repository}
+	store := NewProcessingArtifactStore(repository, &artifactTenantRepository{tenant: &types.Tenant{ID: 7}}, state.files)
+
+	result, err := requireProcessingArtifactRetainer(t, store).PurgeExpired(context.Background(), time.Now(), 1)
+	require.Error(t, err)
+	assert.Equal(t, "manifest_invalid", processingArtifactRetentionFailureKind(err))
+	assert.Equal(t, uint64(1), result.Failed)
+	assert.Equal(t, 1, repository.calls)
+}
+
+func TestProcessingArtifactRetentionClassifiesManifestListFailure(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	repository := &retentionListErrorRepository{
+		ProcessingArtifactRepository: state.repository,
+		err:                          errors.New("list failed"),
+	}
+	store := NewProcessingArtifactStore(
+		repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7}},
+		state.files,
+	)
+
+	_, err := requireProcessingArtifactRetainer(t, store).PurgeExpired(context.Background(), time.Now(), 1)
+
+	require.Error(t, err)
+	assert.Equal(t, "manifest_list", processingArtifactRetentionFailureKind(err))
+}
+
+func TestProcessingArtifactRetentionClassifiesObjectDeleteFailure(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	cutoff := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	key := processingArtifactServiceKey(t, "retention-object-delete-failure")
+	path := "local://tenant-7/retention-object-delete-failure"
+	state.files.objects[path] = []byte("data")
+	state.files.deleteErrors[path] = errors.New("delete failed")
+	artifact := seedProcessingArtifact(t, state.repository, key, nil, path, 4, artifactSHA([]byte("data")))
+	setProcessingArtifactCreatedAt(t, state, artifact, cutoff.Add(-time.Hour))
+
+	_, err := requireProcessingArtifactRetainer(t, state.store).PurgeExpired(context.Background(), cutoff, 1)
+
+	require.Error(t, err)
+	assert.Equal(t, "object_delete", processingArtifactRetentionFailureKind(err))
+}
+
+func TestProcessingArtifactRetentionContinuesPastNilManifestInPage(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "retention-nil-mixed")
+	artifact := seedProcessingArtifact(t, state.repository, key, []byte("valid"), "", 5, artifactSHA([]byte("valid")))
+	repository := &retentionMixedPageRepository{
+		ProcessingArtifactRepository: state.repository,
+		artifacts:                    []*types.ProcessingArtifact{nil, artifact},
+	}
+	store := NewProcessingArtifactStore(repository, &artifactTenantRepository{tenant: &types.Tenant{ID: 7}}, state.files)
+
+	result, err := requireProcessingArtifactRetainer(t, store).PurgeExpired(context.Background(), time.Now(), 2)
+	require.Error(t, err)
+	assert.Equal(t, types.ProcessingArtifactPurgeResult{Scanned: 1, Deleted: 1, Failed: 1, DeletedBytes: 5}, result)
+	assert.Equal(t, 2, repository.calls)
+	_, err = state.repository.Get(context.Background(), key)
+	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+}
+
+func TestProcessingArtifactRetentionPreservesConcurrentReplacementByOldID(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	cutoff := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	key := processingArtifactServiceKey(t, "retention-replacement")
+	old := seedProcessingArtifact(t, state.repository, key, []byte("old"), "", 3, artifactSHA([]byte("old")))
+	setProcessingArtifactCreatedAt(t, state, old, cutoff.Add(-time.Hour))
+	replacement := &types.ProcessingArtifact{
+		TenantID: key.TenantID, Stage: key.Stage, KeyVersion: key.KeyVersion, InputFingerprint: key.InputFingerprint,
+		Payload: []byte("new"), ContentSHA256: artifactSHA([]byte("new")), SizeBytes: 3,
+	}
+	store := NewProcessingArtifactStore(
+		&retentionReplacementRepository{ProcessingArtifactRepository: state.repository, oldID: old.ID, replacement: replacement},
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7}}, state.files,
+	)
+
+	result, err := requireProcessingArtifactRetainer(t, store).PurgeExpired(context.Background(), cutoff, 1)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), result.Deleted)
+	current, err := state.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("new"), current.Payload)
+}
+
+func TestProcessingArtifactRetentionRecordsEvictedAndErrorCounters(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	cutoff := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	registry := NewProcessingArtifactCounterRegistry()
+	store := NewProcessingArtifactStoreWithMaxPayloadAndCounterRegistry(
+		state.repository, &artifactTenantRepository{tenant: &types.Tenant{ID: 7}}, state.files, ProcessingArtifactMaxPayload, registry,
+	)
+	goodKey := processingArtifactServiceKey(t, "retention-counter-good")
+	good := seedProcessingArtifact(t, state.repository, goodKey, []byte("good"), "", 4, artifactSHA([]byte("good")))
+	badKey := processingArtifactServiceKey(t, "retention-counter-bad")
+	bad := seedProcessingArtifact(t, state.repository, badKey, nil, "minio://historical/counter", 1, artifactSHA([]byte("x")))
+	setProcessingArtifactCreatedAt(t, state, good, cutoff.Add(-time.Hour))
+	setProcessingArtifactCreatedAt(t, state, bad, cutoff.Add(-time.Hour))
+
+	_, err := requireProcessingArtifactRetainer(t, store).PurgeExpired(context.Background(), cutoff, 100)
+	require.Error(t, err)
+	counts := make(map[string]uint64)
+	for _, counter := range registry.Snapshot() {
+		counts[counter.Outcome] += counter.Count
+	}
+	assert.Equal(t, uint64(1), counts["evicted"])
+	assert.Equal(t, uint64(1), counts["error"])
+}
+
+type retentionTenantRepository struct {
+	interfaces.TenantRepository
+	tenants map[uint64]*types.Tenant
+	calls   map[uint64]int
+	err     error
+}
+
+func (r *retentionTenantRepository) GetTenantByID(_ context.Context, tenantID uint64) (*types.Tenant, error) {
+	if r.calls == nil {
+		r.calls = make(map[uint64]int)
+	}
+	r.calls[tenantID]++
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.tenants[tenantID], nil
+}
+
+type retentionNilPageRepository struct {
+	interfaces.ProcessingArtifactRepository
+	calls int
+}
+
+type retentionListErrorRepository struct {
+	interfaces.ProcessingArtifactRepository
+	err error
+}
+
+func (r *retentionListErrorRepository) ListExpired(
+	context.Context,
+	time.Time,
+	uint64,
+	int,
+) ([]*types.ProcessingArtifact, error) {
+	return nil, r.err
+}
+
+type retentionMixedPageRepository struct {
+	interfaces.ProcessingArtifactRepository
+	artifacts []*types.ProcessingArtifact
+	calls     int
+}
+
+func (r *retentionMixedPageRepository) ListExpired(context.Context, time.Time, uint64, int) ([]*types.ProcessingArtifact, error) {
+	r.calls++
+	if r.calls == 1 {
+		return r.artifacts, nil
+	}
+	return nil, nil
+}
+
+func (r *retentionNilPageRepository) ListExpired(context.Context, time.Time, uint64, int) ([]*types.ProcessingArtifact, error) {
+	r.calls++
+	if r.calls == 1 {
+		return []*types.ProcessingArtifact{nil}, nil
+	}
+	return nil, errors.New("unexpected repeated expired-artifact page")
+}
+
+type retentionReplacementRepository struct {
+	interfaces.ProcessingArtifactRepository
+	oldID       uint64
+	replacement *types.ProcessingArtifact
+	replaced    bool
+}
+
+func (r *retentionReplacementRepository) DeleteByIDWithResult(ctx context.Context, tenantID, id uint64) (bool, error) {
+	if id != r.oldID || r.replaced {
+		return r.ProcessingArtifactRepository.DeleteByIDWithResult(ctx, tenantID, id)
+	}
+	r.replaced = true
+	if _, err := r.ProcessingArtifactRepository.DeleteByIDWithResult(ctx, tenantID, id); err != nil {
+		return false, err
+	}
+	_, err := r.ProcessingArtifactRepository.PutIfAbsent(ctx, r.replacement)
+	return false, err
+}

--- a/internal/application/service/processing_artifact_test.go
+++ b/internal/application/service/processing_artifact_test.go
@@ -1,0 +1,1476 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"mime/multipart"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const processingArtifactServiceTestDDL = `
+CREATE TABLE processing_artifacts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id INTEGER NOT NULL,
+    stage VARCHAR(64) NOT NULL,
+    key_version INTEGER NOT NULL,
+    input_fingerprint CHAR(64) NOT NULL,
+    payload BLOB NULL,
+    object_path TEXT NOT NULL DEFAULT '',
+    content_sha256 CHAR(64) NOT NULL,
+    size_bytes BIGINT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, stage, key_version, input_fingerprint)
+);`
+
+type artifactFakeFileService struct {
+	mu           sync.Mutex
+	objects      map[string][]byte
+	getErrors    map[string]error
+	streamErrors map[string]error
+	closeErrors  map[string]error
+	readers      map[string]io.Reader
+	saves        []string
+	deletes      []string
+	events       []string
+	savePath     string
+	saveStarted  chan struct{}
+	saveRelease  chan struct{}
+}
+
+type artifactMetadataFileService struct {
+	interfaces.FileService
+	provider       string
+	canonicalPaths map[string]string
+	servicePaths   map[string]string
+}
+
+func (s artifactMetadataFileService) StorageProvider() string { return s.provider }
+
+func (s artifactMetadataFileService) CanonicalStoredPath(path string) string {
+	if mapped := s.canonicalPaths[path]; mapped != "" {
+		return mapped
+	}
+	return path
+}
+
+func (s artifactMetadataFileService) ServiceStoredPath(path string) string {
+	if mapped := s.servicePaths[path]; mapped != "" {
+		return mapped
+	}
+	return path
+}
+
+type artifactFileServiceWithoutMetadata struct {
+	interfaces.FileService
+}
+
+func newArtifactFakeFileService() *artifactFakeFileService {
+	return &artifactFakeFileService{
+		objects:      make(map[string][]byte),
+		getErrors:    make(map[string]error),
+		streamErrors: make(map[string]error),
+		closeErrors:  make(map[string]error),
+		readers:      make(map[string]io.Reader),
+	}
+}
+
+func (f *artifactFakeFileService) StorageProvider() string { return "local" }
+
+func (f *artifactFakeFileService) CheckConnectivity(context.Context) error { return nil }
+
+func (f *artifactFakeFileService) SaveFile(context.Context, *multipart.FileHeader, uint64, string) (string, error) {
+	return "", errors.New("unexpected SaveFile call")
+}
+
+func (f *artifactFakeFileService) SaveBytes(
+	_ context.Context,
+	data []byte,
+	tenantID uint64,
+	fileName string,
+	_ bool,
+) (string, error) {
+	f.mu.Lock()
+	path := fmt.Sprintf("local://tenant-%d/artifact-%d-%s", tenantID, len(f.saves)+1, fileName)
+	if f.savePath != "" {
+		path = f.savePath
+	} else {
+		f.objects[path] = bytes.Clone(data)
+	}
+	f.saves = append(f.saves, path)
+	started, release := f.saveStarted, f.saveRelease
+	f.mu.Unlock()
+	if started != nil {
+		started <- struct{}{}
+	}
+	if release != nil {
+		<-release
+	}
+	return path, nil
+}
+
+func (f *artifactFakeFileService) GetFile(_ context.Context, path string) (io.ReadCloser, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.getErrors[path]; err != nil {
+		return nil, err
+	}
+	var reader io.Reader
+	if configured := f.readers[path]; configured != nil {
+		reader = configured
+	} else if err := f.streamErrors[path]; err != nil {
+		reader = artifactErrorReader{err: err}
+	} else {
+		data, ok := f.objects[path]
+		if !ok {
+			return nil, fs.ErrNotExist
+		}
+		reader = bytes.NewReader(bytes.Clone(data))
+	}
+	return &artifactTrackedReadCloser{
+		Reader:   reader,
+		closeErr: f.closeErrors[path],
+		onClose: func() {
+			f.mu.Lock()
+			f.events = append(f.events, "close:"+path)
+			f.mu.Unlock()
+		},
+	}, nil
+}
+
+type artifactErrorReader struct{ err error }
+
+func (r artifactErrorReader) Read([]byte) (int, error) { return 0, r.err }
+
+type artifactTrackedReadCloser struct {
+	io.Reader
+	closeErr error
+	onClose  func()
+}
+
+func (r *artifactTrackedReadCloser) Close() error {
+	if r.onClose != nil {
+		r.onClose()
+	}
+	return r.closeErr
+}
+
+func (f *artifactFakeFileService) GetFileURL(context.Context, string) (string, error) {
+	return "", errors.New("unexpected GetFileURL call")
+}
+
+func (f *artifactFakeFileService) DeleteFile(_ context.Context, path string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deletes = append(f.deletes, path)
+	f.events = append(f.events, "delete:"+path)
+	delete(f.objects, path)
+	return nil
+}
+
+func (f *artifactFakeFileService) eventSnapshot() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.events...)
+}
+
+func (f *artifactFakeFileService) CopyFile(context.Context, string, uint64, string) (string, error) {
+	return "", errors.New("unexpected CopyFile call")
+}
+
+func (f *artifactFakeFileService) snapshot() (saves, deletes []string, objects map[string][]byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	objects = make(map[string][]byte, len(f.objects))
+	for path, data := range f.objects {
+		objects[path] = bytes.Clone(data)
+	}
+	return append([]string(nil), f.saves...), append([]string(nil), f.deletes...), objects
+}
+
+type artifactTenantRepository struct {
+	interfaces.TenantRepository
+	mu       sync.Mutex
+	tenant   *types.Tenant
+	err      error
+	getCalls int
+}
+
+type corruptWinnerRepository struct {
+	interfaces.ProcessingArtifactRepository
+	mu       sync.Mutex
+	attempts int
+}
+
+type artifactPutBarrierRepository struct {
+	interfaces.ProcessingArtifactRepository
+	arrived chan struct{}
+	release <-chan struct{}
+}
+
+func (r *artifactPutBarrierRepository) PutIfAbsent(
+	ctx context.Context,
+	artifact *types.ProcessingArtifact,
+) (bool, error) {
+	r.arrived <- struct{}{}
+	<-r.release
+	return r.ProcessingArtifactRepository.PutIfAbsent(ctx, artifact)
+}
+
+type artifactPutErrorRepository struct {
+	interfaces.ProcessingArtifactRepository
+	err error
+}
+
+func (r *artifactPutErrorRepository) PutIfAbsent(context.Context, *types.ProcessingArtifact) (bool, error) {
+	return false, r.err
+}
+
+type artifactGetErrorRepository struct {
+	interfaces.ProcessingArtifactRepository
+	err error
+}
+
+func (r *artifactGetErrorRepository) Get(context.Context, types.ProcessingArtifactKey) (*types.ProcessingArtifact, error) {
+	return nil, r.err
+}
+
+type artifactDeleteErrorRepository struct {
+	interfaces.ProcessingArtifactRepository
+	err error
+}
+
+func (r *artifactDeleteErrorRepository) DeleteByID(context.Context, uint64, uint64) error {
+	return r.err
+}
+
+type artifactCountingReader struct {
+	mu    sync.Mutex
+	count int
+}
+
+func (r *artifactCountingReader) Read(data []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i := range data {
+		data[i] = 'x'
+	}
+	r.count += len(data)
+	return len(data), nil
+}
+
+func (r *artifactCountingReader) bytesRead() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.count
+}
+
+func (r *corruptWinnerRepository) PutIfAbsent(
+	ctx context.Context,
+	candidate *types.ProcessingArtifact,
+) (bool, error) {
+	r.mu.Lock()
+	r.attempts++
+	r.mu.Unlock()
+	corrupt := *candidate
+	corrupt.Payload = []byte("corrupt-winner")
+	corrupt.ObjectPath = ""
+	corrupt.SizeBytes = int64(len(corrupt.Payload))
+	corrupt.ContentSHA256 = artifactSHA([]byte("different"))
+	_, err := r.ProcessingArtifactRepository.PutIfAbsent(ctx, &corrupt)
+	return false, err
+}
+
+func (r *corruptWinnerRepository) attemptCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.attempts
+}
+
+func (r *artifactTenantRepository) GetTenantByID(context.Context, uint64) (*types.Tenant, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.getCalls++
+	return r.tenant, r.err
+}
+
+func (r *artifactTenantRepository) calls() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.getCalls
+}
+
+type processingArtifactTestStore struct {
+	store      interfaces.ProcessingArtifactStore
+	repository interfaces.ProcessingArtifactRepository
+	db         *gorm.DB
+	files      *artifactFakeFileService
+}
+
+func newProcessingArtifactTestStore(t *testing.T) processingArtifactTestStore {
+	t.Helper()
+	dbPath := filepath.ToSlash(filepath.Join(t.TempDir(), "processing-artifacts.db"))
+	dsn := fmt.Sprintf("file:%s?_busy_timeout=5000&_journal_mode=WAL", dbPath)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(4)
+	t.Cleanup(func() { require.NoError(t, sqlDB.Close()) })
+	require.NoError(t, db.Exec(processingArtifactServiceTestDDL).Error)
+
+	repo := repository.NewProcessingArtifactRepository(db)
+	files := newArtifactFakeFileService()
+	tenantRepo := &artifactTenantRepository{tenant: &types.Tenant{ID: 7}}
+	return processingArtifactTestStore{
+		store:      NewProcessingArtifactStore(repo, tenantRepo, files),
+		repository: repo,
+		db:         db,
+		files:      files,
+	}
+}
+
+func processingArtifactServiceKey(t *testing.T, suffix string) types.ProcessingArtifactKey {
+	t.Helper()
+	key, err := types.NewProcessingArtifactKey(7, "chunking", 1, []byte(suffix))
+	require.NoError(t, err)
+	return key
+}
+
+func artifactSHA(data []byte) string {
+	return fmt.Sprintf("%x", sha256.Sum256(data))
+}
+
+func seedProcessingArtifact(
+	t *testing.T,
+	repo interfaces.ProcessingArtifactRepository,
+	key types.ProcessingArtifactKey,
+	payload []byte,
+	objectPath string,
+	size int64,
+	hash string,
+) *types.ProcessingArtifact {
+	t.Helper()
+	row := &types.ProcessingArtifact{
+		TenantID:         key.TenantID,
+		Stage:            key.Stage,
+		KeyVersion:       key.KeyVersion,
+		InputFingerprint: key.InputFingerprint,
+		Payload:          bytes.Clone(payload),
+		ObjectPath:       objectPath,
+		ContentSHA256:    hash,
+		SizeBytes:        size,
+	}
+	created, err := repo.PutIfAbsent(context.Background(), row)
+	require.NoError(t, err)
+	require.True(t, created)
+	return row
+}
+
+func TestProcessingArtifactStoreKeepsSmallValuesInline(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "inline-limit")
+	want := bytes.Repeat([]byte("a"), ProcessingArtifactInlineLimit)
+
+	canonical, created, err := testStore.store.PutIfAbsent(context.Background(), key, want)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.Equal(t, want, canonical)
+	saves, _, _ := testStore.files.snapshot()
+	assert.Empty(t, saves)
+
+	row, err := testStore.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.Equal(t, want, row.Payload)
+	assert.Empty(t, row.ObjectPath)
+	assert.Equal(t, int64(len(want)), row.SizeBytes)
+	assert.Equal(t, artifactSHA(want), row.ContentSHA256)
+
+	canonical[0] = 'x'
+	got, hit, err := testStore.store.Get(context.Background(), key)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Equal(t, want, got)
+	got[0] = 'y'
+	again, hit, err := testStore.store.Get(context.Background(), key)
+	require.NoError(t, err)
+	require.True(t, hit)
+	assert.Equal(t, want, again)
+}
+
+func TestProcessingArtifactStoreKeepsEmptyValueInline(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "empty-inline")
+
+	canonical, created, err := testStore.store.PutIfAbsent(context.Background(), key, nil)
+	require.NoError(t, err)
+	require.True(t, created)
+	assert.NotNil(t, canonical)
+	assert.Empty(t, canonical)
+
+	row, err := testStore.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.NotNil(t, row.Payload)
+	value, hit, err := testStore.store.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.NotNil(t, value)
+	assert.Empty(t, value)
+}
+
+func TestProcessingArtifactStoreStoresLargeValuesByManifest(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "limit-plus-one")
+	want := bytes.Repeat([]byte("b"), ProcessingArtifactInlineLimit+1)
+
+	canonical, created, err := testStore.store.PutIfAbsent(context.Background(), key, want)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.Equal(t, want, canonical)
+
+	saves, _, objects := testStore.files.snapshot()
+	require.Len(t, saves, 1)
+	assert.Equal(t, want, objects[saves[0]])
+	row, err := testStore.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.Nil(t, row.Payload)
+	assert.Equal(t, saves[0], row.ObjectPath)
+	assert.Equal(t, int64(len(want)), row.SizeBytes)
+	assert.Equal(t, artifactSHA(want), row.ContentSHA256)
+	assert.Contains(t, filepath.Base(row.ObjectPath), artifactSHA(want))
+}
+
+func TestProcessingArtifactStoreConcurrentDifferentValuesReturnWinner(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		large bool
+	}{
+		{name: "inline"},
+		{name: "large", large: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testStore := newProcessingArtifactTestStore(t)
+			putRelease := make(chan struct{})
+			barrierRepository := &artifactPutBarrierRepository{
+				ProcessingArtifactRepository: testStore.repository,
+				arrived:                      make(chan struct{}, 2),
+				release:                      putRelease,
+			}
+			testStore.store = NewProcessingArtifactStore(
+				barrierRepository,
+				&artifactTenantRepository{tenant: &types.Tenant{ID: 7}},
+				testStore.files,
+			)
+			key := processingArtifactServiceKey(t, "concurrent-"+tc.name)
+			values := [][]byte{[]byte("candidate-one"), []byte("candidate-two")}
+			if tc.large {
+				values = [][]byte{
+					bytes.Repeat([]byte("c"), ProcessingArtifactInlineLimit+1),
+					bytes.Repeat([]byte("d"), ProcessingArtifactInlineLimit+2),
+				}
+				release := make(chan struct{})
+				testStore.files.saveStarted = make(chan struct{}, 2)
+				testStore.files.saveRelease = release
+				t.Cleanup(func() {
+					select {
+					case <-release:
+					default:
+						close(release)
+					}
+				})
+			}
+
+			type result struct {
+				canonical []byte
+				created   bool
+				err       error
+			}
+			start := make(chan struct{})
+			results := make(chan result, len(values))
+			var ready sync.WaitGroup
+			ready.Add(len(values))
+			for _, value := range values {
+				value := bytes.Clone(value)
+				go func() {
+					ready.Done()
+					<-start
+					canonical, created, err := testStore.store.PutIfAbsent(context.Background(), key, value)
+					results <- result{canonical: canonical, created: created, err: err}
+				}()
+			}
+			ready.Wait()
+			close(start)
+			if tc.large {
+				<-testStore.files.saveStarted
+				<-testStore.files.saveStarted
+				close(testStore.files.saveRelease)
+			}
+			<-barrierRepository.arrived
+			<-barrierRepository.arrived
+			close(putRelease)
+
+			got := make([]result, 0, len(values))
+			for range values {
+				got = append(got, <-results)
+			}
+			createdCount := 0
+			for _, result := range got {
+				require.NoError(t, result.err)
+				if result.created {
+					createdCount++
+				}
+				require.Equal(t, got[0].canonical, result.canonical)
+			}
+			require.Equal(t, 1, createdCount)
+			assert.True(t, bytes.Equal(got[0].canonical, values[0]) || bytes.Equal(got[0].canonical, values[1]))
+
+			got[0].canonical[0] ^= 0xff
+			stored, hit, err := testStore.store.Get(context.Background(), key)
+			require.NoError(t, err)
+			require.True(t, hit)
+			assert.Equal(t, got[1].canonical, stored)
+
+			if tc.large {
+				saves, deletes, objects := testStore.files.snapshot()
+				require.Len(t, saves, 2)
+				require.Len(t, deletes, 1)
+				row, err := testStore.repository.Get(context.Background(), key)
+				require.NoError(t, err)
+				assert.Equal(t, deletes[0], func() string {
+					if saves[0] == row.ObjectPath {
+						return saves[1]
+					}
+					return saves[0]
+				}())
+				assert.Contains(t, objects, row.ObjectPath)
+				assert.NotContains(t, objects, deletes[0])
+			}
+		})
+	}
+}
+
+func TestProcessingArtifactStoreEvictsCorruptInlineValue(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "corrupt-inline")
+	seedProcessingArtifact(t, testStore.repository, key, []byte("bad"), "", 99, artifactSHA([]byte("other")))
+
+	value, hit, err := testStore.store.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	_, err = testStore.repository.Get(context.Background(), key)
+	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+
+	want := []byte("repaired")
+	canonical, created, err := testStore.store.PutIfAbsent(context.Background(), key, want)
+	require.NoError(t, err)
+	assert.True(t, created)
+	assert.Equal(t, want, canonical)
+}
+
+func TestProcessingArtifactStoreEvictsMissingOrCorruptObject(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		missing       bool
+		missingStream bool
+	}{
+		{name: "missing", missing: true},
+		{name: "missing while reading", missingStream: true},
+		{name: "wrong hash"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testStore := newProcessingArtifactTestStore(t)
+			key := processingArtifactServiceKey(t, "corrupt-object-"+tc.name)
+			path := "local://tenant-7/old-object"
+			expected := []byte("expected")
+			if tc.missingStream {
+				testStore.files.streamErrors[path] = fs.ErrNotExist
+			} else if !tc.missing {
+				testStore.files.objects[path] = []byte("wrong")
+			}
+			seedProcessingArtifact(t, testStore.repository, key, nil, path, int64(len(expected)), artifactSHA(expected))
+
+			value, hit, err := testStore.store.Get(context.Background(), key)
+			require.NoError(t, err)
+			assert.False(t, hit)
+			assert.Nil(t, value)
+			_, err = testStore.repository.Get(context.Background(), key)
+			assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+			_, deletes, _ := testStore.files.snapshot()
+			assert.Equal(t, []string{path}, deletes)
+			if tc.missingStream {
+				assert.Equal(t, []string{"close:" + path, "delete:" + path}, testStore.files.eventSnapshot())
+			}
+		})
+	}
+}
+
+func TestProcessingArtifactStoreKeepsManifestOnTransientReadError(t *testing.T) {
+	for _, duringRead := range []bool{false, true} {
+		name := "get file"
+		if duringRead {
+			name = "read"
+		}
+		t.Run(name, func(t *testing.T) {
+			testStore := newProcessingArtifactTestStore(t)
+			key := processingArtifactServiceKey(t, "transient-"+name)
+			path := "local://tenant-7/transient"
+			transportErr := errors.New("storage transport unavailable")
+			if duringRead {
+				testStore.files.streamErrors[path] = transportErr
+			} else {
+				testStore.files.getErrors[path] = transportErr
+			}
+			seedProcessingArtifact(t, testStore.repository, key, nil, path, 10, artifactSHA([]byte("0123456789")))
+
+			value, hit, err := testStore.store.Get(context.Background(), key)
+			assert.ErrorIs(t, err, transportErr)
+			assert.False(t, hit)
+			assert.Nil(t, value)
+			_, err = testStore.repository.Get(context.Background(), key)
+			require.NoError(t, err)
+			_, deletes, _ := testStore.files.snapshot()
+			assert.Empty(t, deletes)
+		})
+	}
+}
+
+func TestProcessingArtifactStoreUsesMatchingContextTenantBeforeRepository(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	tenantRepo := &artifactTenantRepository{err: errors.New("tenant lookup must not run")}
+	store := NewProcessingArtifactStore(testStore.repository, tenantRepo, testStore.files)
+	ctx := context.WithValue(context.Background(), types.TenantInfoContextKey, &types.Tenant{ID: 7})
+	key := processingArtifactServiceKey(t, "context-tenant")
+	want := bytes.Repeat([]byte("e"), ProcessingArtifactInlineLimit+1)
+
+	canonical, created, err := store.PutIfAbsent(ctx, key, want)
+	require.NoError(t, err)
+	assert.True(t, created)
+	assert.Equal(t, want, canonical)
+	assert.Zero(t, tenantRepo.calls())
+}
+
+func TestProcessingArtifactStoreInfersReadProviderFromObjectPath(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	baseDir := t.TempDir()
+	t.Setenv("LOCAL_STORAGE_BASE_DIR", baseDir)
+	localConfig := &types.StorageEngineConfig{
+		DefaultProvider: "local",
+		Local:           &types.LocalEngineConfig{},
+	}
+	localService, _, err := filesvc.NewFileServiceFromStorageConfig("local", localConfig, baseDir)
+	require.NoError(t, err)
+	want := []byte("historical-object")
+	path, err := localService.SaveBytes(context.Background(), want, 7, "processing-artifact-history.bin", false)
+	require.NoError(t, err)
+
+	key := processingArtifactServiceKey(t, "provider-change")
+	seedProcessingArtifact(t, testStore.repository, key, nil, path, int64(len(want)), artifactSHA(want))
+	tenant := &types.Tenant{ID: 7, StorageEngineConfig: &types.StorageEngineConfig{
+		DefaultProvider: "minio",
+	}}
+	store := NewProcessingArtifactStore(testStore.repository, &artifactTenantRepository{tenant: tenant}, testStore.files)
+
+	got, hit, err := store.Get(context.Background(), key)
+	require.NoError(t, err)
+	require.True(t, hit)
+	assert.Equal(t, want, got)
+	_, _, fallbackObjects := testStore.files.snapshot()
+	assert.Empty(t, fallbackObjects)
+}
+
+func TestProcessingArtifactStoreFallsBackForEmptyTenantStorageConfig(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	store := NewProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7, StorageEngineConfig: &types.StorageEngineConfig{}}},
+		testStore.files,
+	)
+	want := bytes.Repeat([]byte("f"), ProcessingArtifactInlineLimit+1)
+
+	canonical, created, err := store.PutIfAbsent(
+		context.Background(),
+		processingArtifactServiceKey(t, "empty-storage-config"),
+		want,
+	)
+	require.NoError(t, err)
+	assert.True(t, created)
+	assert.Equal(t, want, canonical)
+	saves, _, _ := testStore.files.snapshot()
+	assert.Len(t, saves, 1)
+}
+
+func TestProcessingArtifactStoreUsesConfiguredTenantDefaultForWrites(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	baseDir := t.TempDir()
+	t.Setenv("LOCAL_STORAGE_BASE_DIR", baseDir)
+	tenant := &types.Tenant{ID: 7, StorageEngineConfig: &types.StorageEngineConfig{
+		DefaultProvider: "local",
+		Local:           &types.LocalEngineConfig{},
+	}}
+	store := NewProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: tenant},
+		testStore.files,
+	)
+	key := processingArtifactServiceKey(t, "configured-write-provider")
+	want := bytes.Repeat([]byte("p"), ProcessingArtifactInlineLimit+1)
+
+	canonical, created, err := store.PutIfAbsent(context.Background(), key, want)
+	require.NoError(t, err)
+	assert.True(t, created)
+	assert.Equal(t, want, canonical)
+	fallbackSaves, _, _ := testStore.files.snapshot()
+	assert.Empty(t, fallbackSaves)
+	row, err := testStore.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(row.ObjectPath, "local://"))
+	got, hit, err := store.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, want, got)
+}
+
+func TestProcessingArtifactStoreFallsBackWhenInferredProviderIsMissingFromConfig(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "missing-inferred-provider")
+	path := "minio://historical-bucket/artifact"
+	want := []byte("historical-global-object")
+	testStore.files.objects[path] = bytes.Clone(want)
+	seedProcessingArtifact(t, testStore.repository, key, nil, path, int64(len(want)), artifactSHA(want))
+	tenant := &types.Tenant{ID: 7, StorageEngineConfig: &types.StorageEngineConfig{
+		DefaultProvider: "local",
+		Local:           &types.LocalEngineConfig{},
+	}}
+	store := NewProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: tenant},
+		testStore.files,
+	)
+
+	got, hit, err := store.Get(context.Background(), key)
+	require.NoError(t, err)
+	require.True(t, hit)
+	assert.Equal(t, want, got)
+}
+
+func TestProcessingArtifactStoreKeepsManifestWhenGlobalFallbackCannotReadInferredProvider(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "historical-minio-global-local")
+	path := "minio://historical-bucket/artifact"
+	seedProcessingArtifact(t, testStore.repository, key, nil, path, 10, artifactSHA([]byte("0123456789")))
+	store := NewProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7, StorageEngineConfig: &types.StorageEngineConfig{
+			DefaultProvider: "local",
+			Local:           &types.LocalEngineConfig{},
+		}}},
+		testStore.files,
+	)
+
+	value, hit, err := store.Get(context.Background(), key)
+
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	_, err = testStore.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	_, deletes, _ := testStore.files.snapshot()
+	assert.Empty(t, deletes)
+}
+
+func TestProcessingArtifactStoreGlobalFallbackAuthorityUsesAdapterProvider(t *testing.T) {
+	for name, config := range map[string]*types.StorageEngineConfig{
+		"nil config":   nil,
+		"empty config": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			testStore := newProcessingArtifactTestStore(t)
+			key := processingArtifactServiceKey(t, "global-local-minio-mismatch-"+name)
+			path := "minio://historical-bucket/artifact"
+			seedProcessingArtifact(t, testStore.repository, key, nil, path, 10, artifactSHA([]byte("0123456789")))
+			global := artifactMetadataFileService{FileService: testStore.files, provider: "local"}
+			store := NewProcessingArtifactStore(
+				testStore.repository,
+				&artifactTenantRepository{tenant: &types.Tenant{ID: 7, StorageEngineConfig: config}},
+				global,
+			)
+
+			value, hit, err := store.Get(context.Background(), key)
+
+			assert.ErrorIs(t, err, fs.ErrNotExist)
+			assert.False(t, hit)
+			assert.Nil(t, value)
+			_, err = testStore.repository.Get(context.Background(), key)
+			require.NoError(t, err)
+			_, deletes, _ := testStore.files.snapshot()
+			assert.Empty(t, deletes)
+		})
+	}
+}
+
+func TestProcessingArtifactStoreMatchingGlobalProviderEvictsMissingObject(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "global-minio-match")
+	path := "minio://historical-bucket/artifact"
+	seedProcessingArtifact(t, testStore.repository, key, nil, path, 10, artifactSHA([]byte("0123456789")))
+	global := artifactMetadataFileService{FileService: testStore.files, provider: "minio"}
+	store := NewProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7}},
+		global,
+	)
+
+	value, hit, err := store.Get(context.Background(), key)
+
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	_, err = testStore.repository.Get(context.Background(), key)
+	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+	_, deletes, _ := testStore.files.snapshot()
+	assert.Equal(t, []string{path}, deletes)
+}
+
+func TestProcessingArtifactStoreUnknownGlobalProviderKeepsInferredManifest(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "unknown-global-minio")
+	path := "minio://historical-bucket/artifact"
+	seedProcessingArtifact(t, testStore.repository, key, nil, path, 10, artifactSHA([]byte("0123456789")))
+	global := artifactFileServiceWithoutMetadata{FileService: testStore.files}
+	store := NewProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7}},
+		global,
+	)
+
+	value, hit, err := store.Get(context.Background(), key)
+
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	_, err = testStore.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+}
+
+func TestProcessingArtifactStoreDoesNotAssignGenericHTTPSPathToGlobalProvider(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "generic-https-global")
+	path := "https://files.example.com/object.bin"
+	seedProcessingArtifact(t, testStore.repository, key, nil, path, 10, artifactSHA([]byte("0123456789")))
+	global := artifactMetadataFileService{FileService: testStore.files, provider: "local"}
+	store := NewProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7}},
+		global,
+	)
+
+	value, hit, err := store.Get(context.Background(), key)
+
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	_, err = testStore.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+}
+
+func TestProcessingArtifactStoreAdapterMappingProvesProxyPathOwnership(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "global-obs-proxy-ownership")
+	proxyPath := "https://files.example.com/obs/weknora/7/object.bin"
+	canonicalPath := "obs://global-bucket/weknora/7/object.bin"
+	seedProcessingArtifact(t, testStore.repository, key, nil, proxyPath, 10, artifactSHA([]byte("0123456789")))
+	global := artifactMetadataFileService{
+		FileService:    testStore.files,
+		provider:       "obs",
+		canonicalPaths: map[string]string{proxyPath: canonicalPath},
+	}
+	store := NewProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7}},
+		global,
+	)
+
+	value, hit, err := store.Get(context.Background(), key)
+
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	_, err = testStore.repository.Get(context.Background(), key)
+	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+}
+
+func TestProcessingArtifactStoreOwnershipUsesCanonicalGenericScheme(t *testing.T) {
+	tests := []struct {
+		name           string
+		path           string
+		provider       string
+		canonicalPaths map[string]string
+		authoritative  bool
+	}{
+		{name: "custom URI through local", path: "custom://bucket/object", provider: "local"},
+		{name: "mixed-case custom URI through custom", path: "CuStOm://bucket/object", provider: "custom", authoritative: true},
+		{name: "dummy URI through local", path: "dummy://object", provider: "local"},
+		{name: "dummy URI through dummy", path: "dummy://object", provider: "dummy", authoritative: true},
+		{name: "bare path through minio", path: "legacy/object.bin", provider: "minio"},
+		{name: "bare path through custom", path: "legacy/object.bin", provider: "custom"},
+		{name: "bare path through local", path: "legacy/object.bin", provider: "local", authoritative: true},
+		{name: "absolute path through local", path: "/data/files/object.bin", provider: "local", authoritative: true},
+		{name: "Windows path through local", path: `C:\data\files\object.bin`, provider: "local", authoritative: true},
+		{name: "local URI through local", path: "local://tenant/object.bin", provider: "local", authoritative: true},
+		{name: "COS HTTPS through cos", path: "https://bucket.cos.ap-guangzhou.myqcloud.com/object.bin", provider: "cos"},
+		{
+			name:           "OBS HTTPS mapped to OBS URI",
+			path:           "https://files.example.com/obs/object.bin",
+			provider:       "obs",
+			canonicalPaths: map[string]string{"https://files.example.com/obs/object.bin": "obs://bucket/object.bin"},
+			authoritative:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testStore := newProcessingArtifactTestStore(t)
+			key := processingArtifactServiceKey(t, "generic-ownership-"+tt.name)
+			seedProcessingArtifact(t, testStore.repository, key, nil, tt.path, 10, artifactSHA([]byte("0123456789")))
+			global := artifactMetadataFileService{
+				FileService:    testStore.files,
+				provider:       tt.provider,
+				canonicalPaths: tt.canonicalPaths,
+			}
+			store := NewProcessingArtifactStore(
+				testStore.repository,
+				&artifactTenantRepository{tenant: &types.Tenant{ID: 7}},
+				global,
+			)
+
+			value, hit, err := store.Get(context.Background(), key)
+
+			assert.False(t, hit)
+			assert.Nil(t, value)
+			_, manifestErr := testStore.repository.Get(context.Background(), key)
+			if tt.authoritative {
+				require.NoError(t, err)
+				assert.ErrorIs(t, manifestErr, types.ErrProcessingArtifactNotFound)
+				return
+			}
+			assert.ErrorIs(t, err, fs.ErrNotExist)
+			require.NoError(t, manifestErr)
+		})
+	}
+}
+
+func TestProcessingArtifactStoreGlobalOBSWriteUsesAdapterMetadata(t *testing.T) {
+	for name, config := range map[string]*types.StorageEngineConfig{
+		"nil config":   nil,
+		"empty config": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			testStore := newProcessingArtifactTestStore(t)
+			proxyPath := "https://files.example.com/obs/weknora/7/object.bin"
+			canonicalPath := "obs://global-bucket/weknora/7/object.bin"
+			want := bytes.Repeat([]byte("o"), ProcessingArtifactInlineLimit+1)
+			testStore.files.savePath = proxyPath
+			testStore.files.objects[proxyPath] = bytes.Clone(want)
+			global := artifactMetadataFileService{
+				FileService:    testStore.files,
+				provider:       "obs",
+				canonicalPaths: map[string]string{proxyPath: canonicalPath},
+				servicePaths:   map[string]string{canonicalPath: proxyPath},
+			}
+			store := NewProcessingArtifactStore(
+				testStore.repository,
+				&artifactTenantRepository{tenant: &types.Tenant{ID: 7, StorageEngineConfig: config}},
+				global,
+			)
+			key := processingArtifactServiceKey(t, "global-obs-write-"+name)
+
+			_, created, err := store.PutIfAbsent(context.Background(), key, want)
+
+			require.NoError(t, err)
+			assert.True(t, created)
+			row, err := testStore.repository.Get(context.Background(), key)
+			require.NoError(t, err)
+			assert.Equal(t, canonicalPath, row.ObjectPath)
+			got, hit, err := store.Get(context.Background(), key)
+			require.NoError(t, err)
+			assert.True(t, hit)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestProcessingArtifactStoreGlobalOBSMapsReadAndDeleteAfterTenantDefaultChange(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "global-obs-provider-change")
+	proxyPath := "https://files.example.com/obs/weknora/7/object.bin"
+	canonicalPath := "obs://global-bucket/weknora/7/object.bin"
+	want := []byte("global-obs-object")
+	testStore.files.objects[proxyPath] = bytes.Clone(want)
+	seedProcessingArtifact(t, testStore.repository, key, nil, canonicalPath, int64(len(want)), artifactSHA(want))
+	global := artifactMetadataFileService{
+		FileService:    testStore.files,
+		provider:       "obs",
+		canonicalPaths: map[string]string{proxyPath: canonicalPath},
+		servicePaths:   map[string]string{canonicalPath: proxyPath},
+	}
+	store := NewProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7, StorageEngineConfig: &types.StorageEngineConfig{
+			DefaultProvider: "local",
+			Local:           &types.LocalEngineConfig{},
+		}}},
+		global,
+	)
+
+	got, hit, err := store.Get(context.Background(), key)
+	require.NoError(t, err)
+	require.True(t, hit)
+	assert.Equal(t, want, got)
+
+	testStore.files.mu.Lock()
+	testStore.files.objects[proxyPath] = []byte("corrupt")
+	testStore.files.mu.Unlock()
+	value, hit, err := store.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	_, deletes, _ := testStore.files.snapshot()
+	assert.Equal(t, []string{proxyPath}, deletes)
+}
+
+func TestProcessingArtifactStoreEvictsMissingObjectThroughEmptyConfigGlobalFallback(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "empty-config-global-missing")
+	path := "historical-object"
+	seedProcessingArtifact(t, testStore.repository, key, nil, path, 10, artifactSHA([]byte("0123456789")))
+	store := NewProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7, StorageEngineConfig: &types.StorageEngineConfig{}}},
+		testStore.files,
+	)
+
+	value, hit, err := store.Get(context.Background(), key)
+
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	_, err = testStore.repository.Get(context.Background(), key)
+	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+	_, deletes, _ := testStore.files.snapshot()
+	assert.Equal(t, []string{path}, deletes)
+}
+
+func TestProcessingArtifactStoreEvictsMissingObjectFromConfiguredProvider(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "configured-provider-missing")
+	path := "minio://tenant-bucket/object"
+	seedProcessingArtifact(t, testStore.repository, key, nil, path, 10, artifactSHA([]byte("0123456789")))
+	tenant := &types.Tenant{ID: 7, StorageEngineConfig: &types.StorageEngineConfig{
+		DefaultProvider: "minio",
+		MinIO:           &types.MinIOEngineConfig{},
+	}}
+	store := newProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: tenant},
+		testStore.files,
+		func(provider string, _ *types.StorageEngineConfig, _ string) (interfaces.FileService, string, error) {
+			assert.Equal(t, "minio", provider)
+			return artifactMetadataFileService{FileService: testStore.files, provider: provider}, provider, nil
+		},
+	)
+
+	value, hit, err := store.Get(context.Background(), key)
+
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	_, err = testStore.repository.Get(context.Background(), key)
+	assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+	_, deletes, _ := testStore.files.snapshot()
+	assert.Equal(t, []string{path}, deletes)
+}
+
+func TestProcessingArtifactStorePersistsCanonicalOBSProxyPath(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	tenant := &types.Tenant{ID: 7, StorageEngineConfig: &types.StorageEngineConfig{
+		DefaultProvider: "obs",
+		OBS: &types.OBSEngineConfig{
+			BucketName: "tenant-bucket",
+			PathPrefix: "weknora/artifacts",
+		},
+	}}
+	proxyPath := "https://files.example.com/obs/weknora/artifacts/7/object.bin"
+	canonicalPath := "obs://tenant-bucket/weknora/artifacts/7/object.bin"
+	testStore.files.savePath = proxyPath
+	service := artifactMetadataFileService{
+		FileService:    testStore.files,
+		provider:       "obs",
+		canonicalPaths: map[string]string{proxyPath: canonicalPath},
+		servicePaths:   map[string]string{canonicalPath: proxyPath},
+	}
+	store := newProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: tenant},
+		service,
+		func(provider string, config *types.StorageEngineConfig, _ string) (interfaces.FileService, string, error) {
+			assert.Equal(t, "obs", provider)
+			assert.Same(t, tenant.StorageEngineConfig, config)
+			return service, provider, nil
+		},
+	)
+
+	_, created, err := store.PutIfAbsent(
+		context.Background(),
+		processingArtifactServiceKey(t, "obs-proxy-manifest"),
+		bytes.Repeat([]byte("o"), ProcessingArtifactInlineLimit+1),
+	)
+
+	require.NoError(t, err)
+	assert.True(t, created)
+	row, err := testStore.repository.Get(context.Background(), processingArtifactServiceKey(t, "obs-proxy-manifest"))
+	require.NoError(t, err)
+	assert.Equal(t, canonicalPath, row.ObjectPath)
+}
+
+func TestProcessingArtifactStoreResolvesCanonicalOBSPathAfterDefaultProviderChange(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "obs-provider-change")
+	path := "obs://tenant-bucket/weknora/artifacts/7/object.bin"
+	want := []byte("historical-obs-object")
+	testStore.files.objects[path] = bytes.Clone(want)
+	seedProcessingArtifact(t, testStore.repository, key, nil, path, int64(len(want)), artifactSHA(want))
+	tenant := &types.Tenant{ID: 7, StorageEngineConfig: &types.StorageEngineConfig{
+		DefaultProvider: "local",
+		Local:           &types.LocalEngineConfig{},
+		OBS:             &types.OBSEngineConfig{BucketName: "tenant-bucket"},
+	}}
+	store := newProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: tenant},
+		testStore.files,
+		func(provider string, config *types.StorageEngineConfig, _ string) (interfaces.FileService, string, error) {
+			assert.Equal(t, "obs", provider)
+			assert.Same(t, tenant.StorageEngineConfig, config)
+			return artifactMetadataFileService{FileService: testStore.files, provider: provider}, provider, nil
+		},
+	)
+
+	got, hit, err := store.Get(context.Background(), key)
+
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, want, got)
+}
+
+func TestProcessingArtifactStoreReadsCanonicalOBSPathThroughProxyFileService(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "obs-proxy-read")
+	canonicalPath := "obs://tenant-bucket/weknora/artifacts/7/object.bin"
+	proxyPath := "https://files.example.com/obs/weknora/artifacts/7/object.bin"
+	want := []byte("proxy-backed-obs-object")
+	testStore.files.objects[proxyPath] = bytes.Clone(want)
+	service := artifactMetadataFileService{
+		FileService:  testStore.files,
+		provider:     "obs",
+		servicePaths: map[string]string{canonicalPath: proxyPath},
+	}
+	seedProcessingArtifact(
+		t, testStore.repository, key, nil, canonicalPath, int64(len(want)), artifactSHA(want),
+	)
+	tenant := &types.Tenant{ID: 7, StorageEngineConfig: &types.StorageEngineConfig{
+		DefaultProvider: "obs",
+		OBS:             &types.OBSEngineConfig{BucketName: "tenant-bucket"},
+	}}
+	store := newProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: tenant},
+		service,
+		func(provider string, config *types.StorageEngineConfig, _ string) (interfaces.FileService, string, error) {
+			return service, provider, nil
+		},
+	)
+
+	got, hit, err := store.Get(context.Background(), key)
+
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, want, got)
+}
+
+func TestProcessingArtifactStoreDeletesCanonicalOBSLoserThroughProxyFileService(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "obs-proxy-loser")
+	seedProcessingArtifact(
+		t, testStore.repository, key, []byte("existing-winner"), "",
+		int64(len("existing-winner")), artifactSHA([]byte("existing-winner")),
+	)
+	proxyPath := "https://files.example.com/obs/weknora/artifacts/7/loser.bin"
+	canonicalPath := "obs://tenant-bucket/weknora/artifacts/7/loser.bin"
+	testStore.files.savePath = proxyPath
+	service := artifactMetadataFileService{
+		FileService:    testStore.files,
+		provider:       "obs",
+		canonicalPaths: map[string]string{proxyPath: canonicalPath},
+		servicePaths:   map[string]string{canonicalPath: proxyPath},
+	}
+	repository := &artifactGetErrorRepository{
+		ProcessingArtifactRepository: testStore.repository,
+		err:                          errors.New("winner read unavailable"),
+	}
+	tenant := &types.Tenant{ID: 7, StorageEngineConfig: &types.StorageEngineConfig{
+		DefaultProvider: "obs",
+		OBS:             &types.OBSEngineConfig{BucketName: "tenant-bucket"},
+	}}
+	store := newProcessingArtifactStore(
+		repository,
+		&artifactTenantRepository{tenant: tenant},
+		service,
+		func(provider string, config *types.StorageEngineConfig, _ string) (interfaces.FileService, string, error) {
+			return service, provider, nil
+		},
+	)
+
+	_, created, err := store.PutIfAbsent(
+		context.Background(), key, bytes.Repeat([]byte("g"), ProcessingArtifactInlineLimit+1),
+	)
+
+	require.Error(t, err)
+	assert.False(t, created)
+	_, deletes, _ := testStore.files.snapshot()
+	assert.Equal(t, []string{proxyPath}, deletes)
+}
+
+func TestProcessingArtifactStoreEvictsInvalidObjectSizeWithoutReading(t *testing.T) {
+	for name, size := range map[string]int64{
+		"negative":  -1,
+		"max int64": int64(^uint64(0) >> 1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			testStore := newProcessingArtifactTestStore(t)
+			key := processingArtifactServiceKey(t, "invalid-size-"+name)
+			path := "local://tenant-7/invalid-size"
+			require.NoError(t, testStore.db.Exec(
+				`INSERT INTO processing_artifacts
+		(tenant_id, stage, key_version, input_fingerprint, payload, object_path, content_sha256, size_bytes)
+		VALUES (?, ?, ?, ?, NULL, ?, ?, ?)`,
+				key.TenantID, key.Stage, key.KeyVersion, key.InputFingerprint, path, strings.Repeat("a", 64), size,
+			).Error)
+			testStore.files.getErrors[path] = errors.New("must not read invalid manifest")
+
+			value, hit, err := testStore.store.Get(context.Background(), key)
+			require.NoError(t, err)
+			assert.False(t, hit)
+			assert.Nil(t, value)
+			_, err = testStore.repository.Get(context.Background(), key)
+			assert.ErrorIs(t, err, types.ErrProcessingArtifactNotFound)
+		})
+	}
+}
+
+func TestProcessingArtifactStoreStopsAfterThreeCorruptWinnerRaces(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	racingRepository := &corruptWinnerRepository{ProcessingArtifactRepository: testStore.repository}
+	store := NewProcessingArtifactStore(
+		racingRepository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7}},
+		testStore.files,
+	)
+
+	canonical, created, err := store.PutIfAbsent(
+		context.Background(),
+		processingArtifactServiceKey(t, "repeated-corrupt-winner"),
+		[]byte("candidate"),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "contention did not converge after 3 attempts")
+	assert.False(t, created)
+	assert.Nil(t, canonical)
+	assert.Equal(t, 3, racingRepository.attemptCount())
+}
+
+func TestProcessingArtifactStoreKeepsCandidateOnAmbiguousInsertError(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "ambiguous-insert")
+	seedProcessingArtifact(
+		t, testStore.repository, key, []byte("existing-winner"), "",
+		int64(len("existing-winner")), artifactSHA([]byte("existing-winner")),
+	)
+	repository := &artifactPutErrorRepository{
+		ProcessingArtifactRepository: testStore.repository,
+		err:                          errors.New("commit result unavailable"),
+	}
+	store := NewProcessingArtifactStore(
+		repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7}},
+		testStore.files,
+	)
+
+	_, created, err := store.PutIfAbsent(
+		context.Background(),
+		key,
+		bytes.Repeat([]byte("z"), ProcessingArtifactInlineLimit+1),
+	)
+	require.Error(t, err)
+	assert.False(t, created)
+	saves, deletes, objects := testStore.files.snapshot()
+	require.Len(t, saves, 1)
+	assert.Empty(t, deletes)
+	assert.Contains(t, objects, saves[0])
+}
+
+func TestProcessingArtifactStoreDeletesKnownLoserOnWinnerReadError(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "ambiguous-winner-read")
+	seedProcessingArtifact(
+		t, testStore.repository, key, []byte("existing-winner"), "",
+		int64(len("existing-winner")), artifactSHA([]byte("existing-winner")),
+	)
+	repository := &artifactGetErrorRepository{
+		ProcessingArtifactRepository: testStore.repository,
+		err:                          errors.New("winner read unavailable"),
+	}
+	store := NewProcessingArtifactStore(
+		repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7}},
+		testStore.files,
+	)
+
+	_, created, err := store.PutIfAbsent(
+		context.Background(),
+		key,
+		bytes.Repeat([]byte("g"), ProcessingArtifactInlineLimit+1),
+	)
+	require.Error(t, err)
+	assert.False(t, created)
+	saves, deletes, objects := testStore.files.snapshot()
+	require.Len(t, saves, 1)
+	assert.Equal(t, []string{saves[0]}, deletes)
+	assert.NotContains(t, objects, saves[0])
+}
+
+func TestProcessingArtifactStoreRejectsReusedSaveBytesPath(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "reused-save-path")
+	path := "local://tenant-7/shared-path"
+	winner := bytes.Repeat([]byte("w"), ProcessingArtifactInlineLimit+1)
+	testStore.files.objects[path] = bytes.Clone(winner)
+	seedProcessingArtifact(t, testStore.repository, key, nil, path, int64(len(winner)), artifactSHA(winner))
+	testStore.files.savePath = path
+
+	canonical, created, err := testStore.store.PutIfAbsent(
+		context.Background(),
+		key,
+		bytes.Repeat([]byte("c"), ProcessingArtifactInlineLimit+1),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SaveBytes path uniqueness contract")
+	assert.False(t, created)
+	assert.Nil(t, canonical)
+	_, deletes, objects := testStore.files.snapshot()
+	assert.Empty(t, deletes)
+	assert.Contains(t, objects, path)
+}
+
+func TestProcessingArtifactStoreClosesReaderBeforeEvictingObject(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "close-before-evict")
+	path := "local://tenant-7/corrupt"
+	testStore.files.objects[path] = []byte("corrupt")
+	seedProcessingArtifact(t, testStore.repository, key, nil, path, int64(len("expected")), artifactSHA([]byte("expected")))
+
+	value, hit, err := testStore.store.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	assert.Equal(t, []string{"close:" + path, "delete:" + path}, testStore.files.eventSnapshot())
+}
+
+func TestProcessingArtifactStoreKeepsManifestOnCloseError(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "close-error")
+	path := "local://tenant-7/close-error"
+	want := []byte("valid-object")
+	closeErr := errors.New("close transport error")
+	testStore.files.objects[path] = bytes.Clone(want)
+	testStore.files.closeErrors[path] = closeErr
+	seedProcessingArtifact(t, testStore.repository, key, nil, path, int64(len(want)), artifactSHA(want))
+
+	value, hit, err := testStore.store.Get(context.Background(), key)
+	assert.ErrorIs(t, err, closeErr)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	_, err = testStore.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	_, deletes, _ := testStore.files.snapshot()
+	assert.Empty(t, deletes)
+}
+
+func TestProcessingArtifactStoreBoundsObjectReadAtSizePlusOne(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "bounded-read")
+	path := "local://tenant-7/unbounded-source"
+	reader := &artifactCountingReader{}
+	testStore.files.readers[path] = reader
+	seedProcessingArtifact(t, testStore.repository, key, nil, path, 4, artifactSHA([]byte("xxxx")))
+
+	value, hit, err := testStore.store.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	assert.Equal(t, 5, reader.bytesRead())
+}
+
+func TestProcessingArtifactStoreDoesNotDeleteObjectWhenManifestEvictionFails(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "delete-row-fails")
+	path := "local://tenant-7/corrupt-protected"
+	testStore.files.objects[path] = []byte("corrupt")
+	seedProcessingArtifact(t, testStore.repository, key, nil, path, int64(len("expected")), artifactSHA([]byte("expected")))
+	deleteErr := errors.New("delete row failed")
+	store := NewProcessingArtifactStore(
+		&artifactDeleteErrorRepository{ProcessingArtifactRepository: testStore.repository, err: deleteErr},
+		&artifactTenantRepository{tenant: &types.Tenant{ID: 7}},
+		testStore.files,
+	)
+
+	value, hit, err := store.Get(context.Background(), key)
+	assert.ErrorIs(t, err, deleteErr)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	_, deletes, objects := testStore.files.snapshot()
+	assert.Empty(t, deletes)
+	assert.Contains(t, objects, path)
+}
+
+func TestProcessingArtifactStoreRepairsCorruptWinnerWithRealRepositoryRetry(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "real-repair-retry")
+	seedProcessingArtifact(t, testStore.repository, key, []byte("corrupt"), "", 99, artifactSHA([]byte("different")))
+	want := []byte("repaired")
+
+	canonical, created, err := testStore.store.PutIfAbsent(context.Background(), key, want)
+	require.NoError(t, err)
+	assert.True(t, created)
+	assert.Equal(t, want, canonical)
+	stored, hit, err := testStore.store.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, want, stored)
+}

--- a/internal/application/service/processing_artifact_test.go
+++ b/internal/application/service/processing_artifact_test.go
@@ -31,27 +31,29 @@ CREATE TABLE processing_artifacts (
     stage VARCHAR(64) NOT NULL,
     key_version INTEGER NOT NULL,
     input_fingerprint CHAR(64) NOT NULL,
-    payload BLOB NULL,
-    object_path TEXT NOT NULL DEFAULT '',
-    content_sha256 CHAR(64) NOT NULL,
+	payload BLOB NULL,
+	object_path TEXT NOT NULL DEFAULT '',
+	content_sha256 CHAR(64) NOT NULL,
     size_bytes BIGINT NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE (tenant_id, stage, key_version, input_fingerprint)
 );`
 
 type artifactFakeFileService struct {
-	mu           sync.Mutex
-	objects      map[string][]byte
-	getErrors    map[string]error
-	streamErrors map[string]error
-	closeErrors  map[string]error
-	readers      map[string]io.Reader
-	saves        []string
-	deletes      []string
-	events       []string
-	savePath     string
-	saveStarted  chan struct{}
-	saveRelease  chan struct{}
+	mu               sync.Mutex
+	objects          map[string][]byte
+	getErrors        map[string]error
+	streamErrors     map[string]error
+	closeErrors      map[string]error
+	readers          map[string]io.Reader
+	deleteErrors     map[string]error
+	missingDeleteErr bool
+	saves            []string
+	deletes          []string
+	events           []string
+	savePath         string
+	saveStarted      chan struct{}
+	saveRelease      chan struct{}
 }
 
 type artifactMetadataFileService struct {
@@ -81,6 +83,50 @@ type artifactFileServiceWithoutMetadata struct {
 	interfaces.FileService
 }
 
+type artifactDeleteHookFileService struct {
+	interfaces.FileService
+	onDelete func(context.Context, string) error
+}
+
+type artifactStorageBackendResolver struct {
+	services map[string]interfaces.FileService
+}
+
+func (r *artifactStorageBackendResolver) ResolveFileService(
+	_ context.Context,
+	tenant *types.Tenant,
+	backendID string,
+	_ string,
+	_ string,
+) (interfaces.FileService, string, error) {
+	if backendID == "" && tenant != nil && tenant.DefaultStorageBackendID != nil {
+		backendID = *tenant.DefaultStorageBackendID
+	}
+	service := r.services[backendID]
+	if service == nil {
+		return nil, "", errors.New("storage backend not found")
+	}
+	return filesvc.NewBackendScopedFileService(backendID, service), "cos", nil
+}
+
+func (r *artifactStorageBackendResolver) ResolveBackend(
+	context.Context,
+	*types.Tenant,
+	string,
+	string,
+) (*types.StorageBackend, error) {
+	return nil, nil
+}
+
+func (s artifactDeleteHookFileService) StorageProvider() string { return "local" }
+
+func (s artifactDeleteHookFileService) DeleteFile(ctx context.Context, path string) error {
+	if err := s.FileService.DeleteFile(ctx, path); err != nil {
+		return err
+	}
+	return s.onDelete(ctx, path)
+}
+
 func newArtifactFakeFileService() *artifactFakeFileService {
 	return &artifactFakeFileService{
 		objects:      make(map[string][]byte),
@@ -88,6 +134,7 @@ func newArtifactFakeFileService() *artifactFakeFileService {
 		streamErrors: make(map[string]error),
 		closeErrors:  make(map[string]error),
 		readers:      make(map[string]io.Reader),
+		deleteErrors: make(map[string]error),
 	}
 }
 
@@ -180,6 +227,12 @@ func (f *artifactFakeFileService) DeleteFile(_ context.Context, path string) err
 	defer f.mu.Unlock()
 	f.deletes = append(f.deletes, path)
 	f.events = append(f.events, "delete:"+path)
+	if err := f.deleteErrors[path]; err != nil {
+		return err
+	}
+	if _, ok := f.objects[path]; !ok && f.missingDeleteErr {
+		return fs.ErrNotExist
+	}
 	delete(f.objects, path)
 	return nil
 }
@@ -258,6 +311,26 @@ type artifactDeleteErrorRepository struct {
 
 func (r *artifactDeleteErrorRepository) DeleteByID(context.Context, uint64, uint64) error {
 	return r.err
+}
+
+func (r *artifactDeleteErrorRepository) DeleteByIDWithResult(context.Context, uint64, uint64) (bool, error) {
+	return false, r.err
+}
+
+type artifactInvalidationBarrierRepository struct {
+	interfaces.ProcessingArtifactRepository
+	entered chan<- struct{}
+	release <-chan struct{}
+}
+
+func (r *artifactInvalidationBarrierRepository) Get(
+	ctx context.Context,
+	key types.ProcessingArtifactKey,
+) (*types.ProcessingArtifact, error) {
+	artifact, err := r.ProcessingArtifactRepository.Get(ctx, key)
+	r.entered <- struct{}{}
+	<-r.release
+	return artifact, err
 }
 
 type artifactCountingReader struct {
@@ -367,13 +440,29 @@ func seedProcessingArtifact(
 	hash string,
 ) *types.ProcessingArtifact {
 	t.Helper()
+	if objectPath != "" {
+		objectPath = processingArtifactObjectReference(objectPath)
+	}
+	return seedProcessingArtifactReference(t, repo, key, payload, objectPath, size, hash)
+}
+
+func seedProcessingArtifactReference(
+	t *testing.T,
+	repo interfaces.ProcessingArtifactRepository,
+	key types.ProcessingArtifactKey,
+	payload []byte,
+	objectReference string,
+	size int64,
+	hash string,
+) *types.ProcessingArtifact {
+	t.Helper()
 	row := &types.ProcessingArtifact{
 		TenantID:         key.TenantID,
 		Stage:            key.Stage,
 		KeyVersion:       key.KeyVersion,
 		InputFingerprint: key.InputFingerprint,
 		Payload:          bytes.Clone(payload),
-		ObjectPath:       objectPath,
+		ObjectPath:       objectReference,
 		ContentSHA256:    hash,
 		SizeBytes:        size,
 	}
@@ -535,10 +624,12 @@ func TestProcessingArtifactStoreStoresLargeValuesByManifest(t *testing.T) {
 	row, err := testStore.repository.Get(context.Background(), key)
 	require.NoError(t, err)
 	assert.Nil(t, row.Payload)
-	assert.Equal(t, saves[0], row.ObjectPath)
+	objectPath, ok := processingArtifactObjectPath(row.ObjectPath)
+	require.True(t, ok)
+	assert.Equal(t, saves[0], objectPath)
 	assert.Equal(t, int64(len(want)), row.SizeBytes)
 	assert.Equal(t, artifactSHA(want), row.ContentSHA256)
-	assert.Contains(t, filepath.Base(row.ObjectPath), artifactSHA(want))
+	assert.Contains(t, filepath.Base(objectPath), artifactSHA(want))
 }
 
 func TestProcessingArtifactStoreConcurrentDifferentValuesReturnWinner(t *testing.T) {
@@ -637,13 +728,15 @@ func TestProcessingArtifactStoreConcurrentDifferentValuesReturnWinner(t *testing
 				require.Len(t, deletes, 1)
 				row, err := testStore.repository.Get(context.Background(), key)
 				require.NoError(t, err)
+				objectPath, ok := processingArtifactObjectPath(row.ObjectPath)
+				require.True(t, ok)
 				assert.Equal(t, deletes[0], func() string {
-					if saves[0] == row.ObjectPath {
+					if saves[0] == objectPath {
 						return saves[1]
 					}
 					return saves[0]
 				}())
-				assert.Contains(t, objects, row.ObjectPath)
+				assert.Contains(t, objects, objectPath)
 				assert.NotContains(t, objects, deletes[0])
 			}
 		})
@@ -825,7 +918,9 @@ func TestProcessingArtifactStoreUsesConfiguredTenantDefaultForWrites(t *testing.
 	assert.Empty(t, fallbackSaves)
 	row, err := testStore.repository.Get(context.Background(), key)
 	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(row.ObjectPath, "local://"))
+	objectPath, ok := processingArtifactObjectPath(row.ObjectPath)
+	require.True(t, ok)
+	assert.True(t, strings.HasPrefix(objectPath, "local://"))
 	got, hit, err := store.Get(context.Background(), key)
 	require.NoError(t, err)
 	assert.True(t, hit)
@@ -1092,7 +1187,9 @@ func TestProcessingArtifactStoreGlobalOBSWriteUsesAdapterMetadata(t *testing.T) 
 			assert.True(t, created)
 			row, err := testStore.repository.Get(context.Background(), key)
 			require.NoError(t, err)
-			assert.Equal(t, canonicalPath, row.ObjectPath)
+			objectPath, ok := processingArtifactObjectPath(row.ObjectPath)
+			require.True(t, ok)
+			assert.Equal(t, canonicalPath, objectPath)
 			got, hit, err := store.Get(context.Background(), key)
 			require.NoError(t, err)
 			assert.True(t, hit)
@@ -1231,7 +1328,9 @@ func TestProcessingArtifactStorePersistsCanonicalOBSProxyPath(t *testing.T) {
 	assert.True(t, created)
 	row, err := testStore.repository.Get(context.Background(), processingArtifactServiceKey(t, "obs-proxy-manifest"))
 	require.NoError(t, err)
-	assert.Equal(t, canonicalPath, row.ObjectPath)
+	objectPath, ok := processingArtifactObjectPath(row.ObjectPath)
+	require.True(t, ok)
+	assert.Equal(t, canonicalPath, objectPath)
 }
 
 func TestProcessingArtifactStoreResolvesCanonicalOBSPathAfterDefaultProviderChange(t *testing.T) {
@@ -1355,7 +1454,8 @@ func TestProcessingArtifactStoreEvictsInvalidObjectSizeWithoutReading(t *testing
 				`INSERT INTO processing_artifacts
 		(tenant_id, stage, key_version, input_fingerprint, payload, object_path, content_sha256, size_bytes)
 		VALUES (?, ?, ?, ?, NULL, ?, ?, ?)`,
-				key.TenantID, key.Stage, key.KeyVersion, key.InputFingerprint, path, strings.Repeat("a", 64), size,
+				key.TenantID, key.Stage, key.KeyVersion, key.InputFingerprint,
+				processingArtifactObjectReference(path), strings.Repeat("a", 64), size,
 			).Error)
 			testStore.files.getErrors[path] = errors.New("must not read invalid manifest")
 
@@ -1487,6 +1587,136 @@ func TestProcessingArtifactStoreClosesReaderBeforeEvictingObject(t *testing.T) {
 	assert.Equal(t, []string{"close:" + path, "delete:" + path}, testStore.files.eventSnapshot())
 }
 
+func TestProcessingArtifactStoreKeepsCorruptObjectManifestWhenOwnershipIsNotAuthoritative(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "corrupt-non-authoritative")
+	path := "minio://historical-bucket/corrupt"
+	testStore.files.objects[path] = []byte("corrupt")
+	require.NoError(t, testStore.db.Exec(
+		`INSERT INTO processing_artifacts
+		(tenant_id, stage, key_version, input_fingerprint, payload, object_path, content_sha256, size_bytes)
+		VALUES (?, ?, ?, ?, NULL, ?, ?, ?)`,
+		key.TenantID, key.Stage, key.KeyVersion, key.InputFingerprint,
+		processingArtifactObjectReference(path), artifactSHA([]byte("expected")), -1,
+	).Error)
+	store := NewProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: key.TenantID}},
+		artifactMetadataFileService{FileService: testStore.files, provider: "local"},
+	)
+
+	value, hit, err := store.Get(context.Background(), key)
+	require.ErrorContains(t, err, "not authoritatively owned")
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	_, err = testStore.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	_, deletes, objects := testStore.files.snapshot()
+	assert.Empty(t, deletes)
+	assert.Contains(t, objects, path)
+}
+
+func TestProcessingArtifactStoreKeepsCorruptObjectManifestWhenResolutionFails(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "corrupt-resolution-failure")
+	path := "local://tenant-7/corrupt"
+	testStore.files.objects[path] = []byte("corrupt")
+	require.NoError(t, testStore.db.Exec(
+		`INSERT INTO processing_artifacts
+		(tenant_id, stage, key_version, input_fingerprint, payload, object_path, content_sha256, size_bytes)
+		VALUES (?, ?, ?, ?, NULL, ?, ?, ?)`,
+		key.TenantID, key.Stage, key.KeyVersion, key.InputFingerprint,
+		processingArtifactObjectReference(path), artifactSHA([]byte("expected")), -1,
+	).Error)
+	resolveErr := errors.New("tenant lookup failed")
+	store := NewProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{err: resolveErr},
+		testStore.files,
+	)
+
+	value, hit, err := store.Get(context.Background(), key)
+	assert.ErrorIs(t, err, resolveErr)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	_, err = testStore.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	_, deletes, objects := testStore.files.snapshot()
+	assert.Empty(t, deletes)
+	assert.Contains(t, objects, path)
+}
+
+func TestProcessingArtifactStoreKeepsCorruptObjectManifestWhenObjectDeleteFails(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "corrupt-object-delete-failure")
+	path := "local://tenant-7/corrupt"
+	testStore.files.objects[path] = []byte("corrupt")
+	deleteErr := errors.New("object delete failed")
+	testStore.files.deleteErrors[path] = deleteErr
+	seedProcessingArtifact(
+		t, testStore.repository, key, nil, path,
+		int64(len("expected")), artifactSHA([]byte("expected")),
+	)
+
+	value, hit, err := testStore.store.Get(context.Background(), key)
+	assert.ErrorIs(t, err, deleteErr)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	_, err = testStore.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	_, deletes, objects := testStore.files.snapshot()
+	assert.Equal(t, []string{path}, deletes)
+	assert.Contains(t, objects, path)
+}
+
+func TestProcessingArtifactStoreCorruptObjectEvictionPreservesNewerWinner(t *testing.T) {
+	testStore := newProcessingArtifactTestStore(t)
+	key := processingArtifactServiceKey(t, "corrupt-object-newer-winner")
+	path := "local://tenant-7/corrupt"
+	testStore.files.objects[path] = []byte("corrupt")
+	old := seedProcessingArtifact(
+		t, testStore.repository, key, nil, path,
+		int64(len("expected")), artifactSHA([]byte("expected")),
+	)
+	replacement := &types.ProcessingArtifact{
+		TenantID:         key.TenantID,
+		Stage:            key.Stage,
+		KeyVersion:       key.KeyVersion,
+		InputFingerprint: key.InputFingerprint,
+		Payload:          []byte("new"),
+		ContentSHA256:    artifactSHA([]byte("new")),
+		SizeBytes:        3,
+	}
+	oldRemovedByHook := false
+	fileService := artifactDeleteHookFileService{
+		FileService: testStore.files,
+		onDelete: func(ctx context.Context, _ string) error {
+			removed, err := testStore.repository.DeleteByIDWithResult(ctx, key.TenantID, old.ID)
+			if err != nil {
+				return err
+			}
+			oldRemovedByHook = removed
+			_, err = testStore.repository.PutIfAbsent(ctx, replacement)
+			return err
+		},
+	}
+	store := NewProcessingArtifactStore(
+		testStore.repository,
+		&artifactTenantRepository{tenant: &types.Tenant{ID: key.TenantID}},
+		fileService,
+	)
+
+	value, hit, err := store.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Nil(t, value)
+	current, err := testStore.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.NotEqual(t, old.ID, current.ID)
+	assert.Equal(t, []byte("new"), current.Payload)
+	assert.True(t, oldRemovedByHook, "object deletion must happen before deleting the captured old manifest")
+}
+
 func TestProcessingArtifactStoreKeepsManifestOnCloseError(t *testing.T) {
 	testStore := newProcessingArtifactTestStore(t)
 	key := processingArtifactServiceKey(t, "close-error")
@@ -1522,7 +1752,7 @@ func TestProcessingArtifactStoreBoundsObjectReadAtSizePlusOne(t *testing.T) {
 	assert.Equal(t, 5, reader.bytesRead())
 }
 
-func TestProcessingArtifactStoreDoesNotDeleteObjectWhenManifestEvictionFails(t *testing.T) {
+func TestProcessingArtifactStoreDeletesObjectBeforeManifestEviction(t *testing.T) {
 	testStore := newProcessingArtifactTestStore(t)
 	key := processingArtifactServiceKey(t, "delete-row-fails")
 	path := "local://tenant-7/corrupt-protected"
@@ -1540,8 +1770,10 @@ func TestProcessingArtifactStoreDoesNotDeleteObjectWhenManifestEvictionFails(t *
 	assert.False(t, hit)
 	assert.Nil(t, value)
 	_, deletes, objects := testStore.files.snapshot()
-	assert.Empty(t, deletes)
-	assert.Contains(t, objects, path)
+	assert.Equal(t, []string{path}, deletes)
+	assert.NotContains(t, objects, path)
+	_, manifestErr := testStore.repository.Get(context.Background(), key)
+	require.NoError(t, manifestErr)
 }
 
 func TestProcessingArtifactStoreRepairsCorruptWinnerWithRealRepositoryRetry(t *testing.T) {

--- a/internal/application/service/processing_artifact_test.go
+++ b/internal/application/service/processing_artifact_test.go
@@ -414,6 +414,91 @@ func TestProcessingArtifactStoreKeepsSmallValuesInline(t *testing.T) {
 	assert.Equal(t, want, again)
 }
 
+func TestProcessingArtifactStoreBatchOperationsPreserveCanonicalValues(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	batchStore, ok := state.store.(interface {
+		GetMany(context.Context, []types.ProcessingArtifactKey) (
+			map[types.ProcessingArtifactKey][]byte, error,
+		)
+		PutManyIfAbsent(context.Context, map[types.ProcessingArtifactKey][]byte) (
+			map[types.ProcessingArtifactKey][]byte, error,
+		)
+	})
+	require.True(t, ok)
+
+	winnerKey := processingArtifactServiceKey(t, "batch-winner")
+	newKey := processingArtifactServiceKey(t, "batch-new")
+	missingKey := processingArtifactServiceKey(t, "batch-missing")
+	_, created, err := state.store.PutIfAbsent(context.Background(), winnerKey, []byte("winner"))
+	require.NoError(t, err)
+	require.True(t, created)
+
+	canonical, err := batchStore.PutManyIfAbsent(context.Background(), map[types.ProcessingArtifactKey][]byte{
+		winnerKey: []byte("loser"),
+		newKey:    []byte("new-value"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("winner"), canonical[winnerKey])
+	assert.Equal(t, []byte("new-value"), canonical[newKey])
+
+	got, err := batchStore.GetMany(
+		context.Background(),
+		[]types.ProcessingArtifactKey{winnerKey, newKey, missingKey},
+	)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, []byte("winner"), got[winnerKey])
+	assert.Equal(t, []byte("new-value"), got[newKey])
+	assert.NotContains(t, got, missingKey)
+}
+
+func TestProcessingArtifactStoreBatchRepairsCorruptWinner(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	batchStore := state.store.(interfaces.ProcessingArtifactBatchStore)
+	key := processingArtifactServiceKey(t, "batch-corrupt-winner")
+	seedProcessingArtifact(
+		t,
+		state.repository,
+		key,
+		[]byte("corrupt"),
+		"",
+		int64(len("corrupt")),
+		artifactSHA([]byte("different")),
+	)
+
+	canonical, err := batchStore.PutManyIfAbsent(context.Background(), map[types.ProcessingArtifactKey][]byte{
+		key: []byte("replacement"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("replacement"), canonical[key])
+
+	artifact, err := state.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("replacement"), artifact.Payload)
+	assert.Equal(t, artifactSHA([]byte("replacement")), artifact.ContentSHA256)
+}
+
+func TestProcessingArtifactStoreBatchFallsBackForLargeValues(t *testing.T) {
+	state := newProcessingArtifactTestStore(t)
+	batchStore := state.store.(interfaces.ProcessingArtifactBatchStore)
+	key := processingArtifactServiceKey(t, "batch-large-value")
+	value := bytes.Repeat([]byte("x"), ProcessingArtifactInlineLimit+1)
+
+	canonical, err := batchStore.PutManyIfAbsent(context.Background(), map[types.ProcessingArtifactKey][]byte{
+		key: value,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, value, canonical[key])
+
+	artifact, err := state.repository.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.Nil(t, artifact.Payload)
+	assert.NotEmpty(t, artifact.ObjectPath)
+	saves, deletes, _ := state.files.snapshot()
+	assert.Len(t, saves, 1)
+	assert.Empty(t, deletes)
+}
+
 func TestProcessingArtifactStoreKeepsEmptyValueInline(t *testing.T) {
 	testStore := newProcessingArtifactTestStore(t)
 	key := processingArtifactServiceKey(t, "empty-inline")

--- a/internal/application/service/processing_artifact_trace_test.go
+++ b/internal/application/service/processing_artifact_trace_test.go
@@ -1,0 +1,13 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessingArtifactTraceCacheStatus(t *testing.T) {
+	assert.Equal(t, "bypass", processingArtifactTraceCacheStatus(false, false))
+	assert.Equal(t, "miss", processingArtifactTraceCacheStatus(true, false))
+	assert.Equal(t, "hit", processingArtifactTraceCacheStatus(true, true))
+}

--- a/internal/application/service/retriever/composite.go
+++ b/internal/application/service/retriever/composite.go
@@ -27,6 +27,10 @@ type CompositeRetrieveEngine struct {
 	engineInfos []*engineInfo
 }
 
+type physicalIndexNamespaceProvider interface {
+	PhysicalIndexNamespace(dimension int, knowledgeType string) string
+}
+
 // Retrieve performs retrieval operations by delegating to the appropriate engine
 // based on the retriever type specified in the parameters
 func (c *CompositeRetrieveEngine) Retrieve(ctx context.Context,
@@ -295,6 +299,38 @@ func (c *CompositeRetrieveEngine) DeleteByKnowledgeIDList(ctx context.Context,
 			return err
 		}
 		return nil
+	})
+}
+
+// DeletePreviousModelVectors removes the old model's vectors only when a
+// backend declares a distinct physical namespace for the old dimension. Shared
+// stores (such as PostgreSQL) are already replaced by the stable source-ID
+// upsert, so a knowledge-wide delete would remove the replacement as well.
+func (c *CompositeRetrieveEngine) DeletePreviousModelVectors(
+	ctx context.Context,
+	knowledgeIDList []string,
+	previousDimension int,
+	currentDimension int,
+	knowledgeType string,
+) error {
+	if previousDimension == currentDimension {
+		return nil
+	}
+	return c.concurrentExecWithError(ctx, func(ctx context.Context, engineInfo *engineInfo) error {
+		provider, ok := engineInfo.retrieveEngine.(physicalIndexNamespaceProvider)
+		if !ok {
+			return nil
+		}
+		if provider.PhysicalIndexNamespace(previousDimension, knowledgeType) ==
+			provider.PhysicalIndexNamespace(currentDimension, knowledgeType) {
+			return nil
+		}
+		return engineInfo.retrieveEngine.DeleteByKnowledgeIDList(
+			ctx,
+			knowledgeIDList,
+			previousDimension,
+			knowledgeType,
+		)
 	})
 }
 

--- a/internal/application/service/retriever/composite_model_cleanup_test.go
+++ b/internal/application/service/retriever/composite_model_cleanup_test.go
@@ -1,0 +1,72 @@
+package retriever
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/application/repository/retriever/tencentvectordb"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeletePreviousModelVectorsRespectsPhysicalNamespace(t *testing.T) {
+	shared := &mockEngineService{
+		engineType: types.PostgresRetrieverEngineType,
+		namespace:  func(int, string) string { return "embeddings" },
+	}
+	dimensionScoped := &mockEngineService{
+		engineType: types.QdrantRetrieverEngineType,
+		namespace: func(dimension int, _ string) string {
+			return fmt.Sprintf("vectors_%d", dimension)
+		},
+	}
+	engine := &CompositeRetrieveEngine{engineInfos: []*engineInfo{
+		{retrieveEngine: shared},
+		{retrieveEngine: dimensionScoped},
+	}}
+
+	require.NoError(t, engine.DeletePreviousModelVectors(
+		context.Background(), []string{"knowledge-1"}, 768, 1536, "document",
+	))
+	assert.Empty(t, shared.knowledgeDeletes, "shared namespace cleanup would delete the replacement")
+	assert.Equal(t, []int{768}, dimensionScoped.knowledgeDeletes)
+}
+
+func TestDeletePreviousModelVectorsSkipsEqualDimensionModelChange(t *testing.T) {
+	dimensionScoped := &mockEngineService{
+		engineType: types.QdrantRetrieverEngineType,
+		namespace: func(dimension int, _ string) string {
+			return fmt.Sprintf("vectors_%d", dimension)
+		},
+	}
+	engine := &CompositeRetrieveEngine{engineInfos: []*engineInfo{{retrieveEngine: dimensionScoped}}}
+
+	require.NoError(t, engine.DeletePreviousModelVectors(
+		context.Background(), []string{"knowledge-1"}, 1536, 1536, "document",
+	))
+	assert.Empty(t, dimensionScoped.knowledgeDeletes)
+}
+
+func TestTencentVectorDBPhysicalNamespaceUsesDimensionSuffixByDefault(t *testing.T) {
+	indexRepo := tencentvectordb.NewTencentVectorDBRetrieveEngineRepository(nil, "", nil)
+	service := NewKVHybridRetrieveEngine(indexRepo, types.TencentVectorDBRetrieverEngineType).(*KeywordsVectorHybridRetrieveEngineService)
+
+	assert.NotEqual(t,
+		service.PhysicalIndexNamespace(768, "document"),
+		service.PhysicalIndexNamespace(1536, "document"),
+	)
+}
+
+func TestTencentVectorDBPhysicalNamespaceTreatsConfiguredCollectionAsShared(t *testing.T) {
+	indexRepo := tencentvectordb.NewTencentVectorDBRetrieveEngineRepository(nil, "", &types.IndexConfig{
+		CollectionName: "custom_collection",
+	})
+	service := NewKVHybridRetrieveEngine(indexRepo, types.TencentVectorDBRetrieverEngineType).(*KeywordsVectorHybridRetrieveEngineService)
+
+	assert.Equal(t,
+		service.PhysicalIndexNamespace(768, "document"),
+		service.PhysicalIndexNamespace(1536, "document"),
+	)
+}

--- a/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
+++ b/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
@@ -2,12 +2,14 @@ package retriever
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"slices"
 	"strings"
 	"time"
 	"unicode/utf8"
 
+	"github.com/Tencent/WeKnora/internal/application/repository"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/models/embedding"
 	"github.com/Tencent/WeKnora/internal/models/utils"
@@ -57,6 +59,27 @@ func (v *KeywordsVectorHybridRetrieveEngineService) EngineType() types.Retriever
 	return v.engineType
 }
 
+// PhysicalIndexNamespace identifies engines whose index storage is split by
+// embedding dimension. Callers may safely delete the prior namespace only when
+// this value changes; all other engines are treated as shared namespaces.
+func (v *KeywordsVectorHybridRetrieveEngineService) PhysicalIndexNamespace(
+	dimension int,
+	knowledgeType string,
+) string {
+	if provider, ok := v.indexRepository.(physicalIndexNamespaceProvider); ok {
+		return provider.PhysicalIndexNamespace(dimension, knowledgeType)
+	}
+	switch v.engineType {
+	case types.QdrantRetrieverEngineType,
+		types.MilvusRetrieverEngineType,
+		types.WeaviateRetrieverEngineType,
+		types.DorisRetrieverEngineType:
+		return fmt.Sprintf("%s:%d", v.engineType, dimension)
+	default:
+		return string(v.engineType)
+	}
+}
+
 // Retrieve performs retrieval based on the provided parameters
 func (v *KeywordsVectorHybridRetrieveEngineService) Retrieve(ctx context.Context,
 	params types.RetrieveParams,
@@ -103,6 +126,9 @@ func (v *KeywordsVectorHybridRetrieveEngineService) BatchIndex(ctx context.Conte
 
 		batchSize := 40
 		chunks := utils.ChunkSlice(indexInfoList, batchSize)
+		if repository.IsReconciliationTransaction(ctx) {
+			return v.sequentialBatchSave(ctx, chunks, embeddings, batchSize)
+		}
 
 		// Use concurrent batch saving for better performance
 		// Limit concurrency to avoid overwhelming the backend
@@ -118,6 +144,9 @@ func (v *KeywordsVectorHybridRetrieveEngineService) BatchIndex(ctx context.Conte
 
 	// For non-vector retrieval, use concurrent batch saving as well
 	chunks := utils.ChunkSlice(indexInfoList, 10)
+	if repository.IsReconciliationTransaction(ctx) {
+		return v.sequentialBatchSaveNoEmbedding(ctx, chunks)
+	}
 	const maxConcurrency = 5
 	if len(chunks) <= maxConcurrency {
 		return v.concurrentBatchSaveNoEmbedding(ctx, chunks)
@@ -196,6 +225,26 @@ func (v *KeywordsVectorHybridRetrieveEngineService) concurrentBatchSave(
 	return g.Wait()
 }
 
+func (v *KeywordsVectorHybridRetrieveEngineService) sequentialBatchSave(
+	ctx context.Context,
+	chunks [][]*types.IndexInfo,
+	embeddings [][]float32,
+	batchSize int,
+) error {
+	for i, indexChunk := range chunks {
+		params := make(map[string]any)
+		embeddingMap := make(map[string][]float32)
+		for j, indexInfo := range indexChunk {
+			embeddingMap[indexInfo.SourceID] = embeddings[i*batchSize+j]
+		}
+		params["embedding"] = embeddingMap
+		if err := v.indexRepository.BatchSave(ctx, indexChunk, params); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // boundedConcurrentBatchSave saves batches with bounded concurrency using semaphore pattern
 func (v *KeywordsVectorHybridRetrieveEngineService) boundedConcurrentBatchSave(
 	ctx context.Context,
@@ -241,6 +290,18 @@ func (v *KeywordsVectorHybridRetrieveEngineService) concurrentBatchSaveNoEmbeddi
 		})
 	}
 	return g.Wait()
+}
+
+func (v *KeywordsVectorHybridRetrieveEngineService) sequentialBatchSaveNoEmbedding(
+	ctx context.Context,
+	chunks [][]*types.IndexInfo,
+) error {
+	for _, indexChunk := range chunks {
+		if err := v.indexRepository.BatchSave(ctx, indexChunk, map[string]any{}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // boundedConcurrentBatchSaveNoEmbedding saves batches with bounded concurrency without embeddings

--- a/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
+++ b/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
@@ -95,7 +95,8 @@ func (v *KeywordsVectorHybridRetrieveEngineService) Index(ctx context.Context,
 	params := make(map[string]any)
 	embeddingMap := make(map[string][]float32)
 	if slices.Contains(retrieverTypes, types.VectorRetrieverType) {
-		embedding, err := embedder.Embed(ctx, sanitizeForEmbedding(ctx, indexInfo.Content))
+		embedCtx := context.WithValue(ctx, types.EmbedDocumentContextKey, true)
+		embedding, err := embedder.Embed(embedCtx, sanitizeForEmbedding(ctx, indexInfo.Content))
 		if err != nil {
 			return err
 		}
@@ -115,11 +116,12 @@ func (v *KeywordsVectorHybridRetrieveEngineService) BatchIndex(ctx context.Conte
 	}
 
 	if slices.Contains(retrieverTypes, types.VectorRetrieverType) {
+		embedCtx := context.WithValue(ctx, types.EmbedDocumentContextKey, true)
 		var contentList []string
 		for _, indexInfo := range indexInfoList {
 			contentList = append(contentList, sanitizeForEmbedding(ctx, indexInfo.Content))
 		}
-		embeddings, err := batchEmbedWithBackoff(ctx, embedder, contentList)
+		embeddings, err := batchEmbedWithBackoff(embedCtx, embedder, contentList)
 		if err != nil {
 			return err
 		}

--- a/internal/application/service/retriever/keywords_vector_hybrid_indexer_test.go
+++ b/internal/application/service/retriever/keywords_vector_hybrid_indexer_test.go
@@ -20,10 +20,12 @@ type capturingEmbedder struct {
 	embedding.Embedder
 	text       string
 	batchTexts []string
+	document   bool
 }
 
 func (e *capturingEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
 	e.text = text
+	e.document, _ = ctx.Value(types.EmbedDocumentContextKey).(bool)
 	return []float32{1}, nil
 }
 
@@ -33,6 +35,7 @@ func (e *capturingEmbedder) BatchEmbedWithPool(
 	texts []string,
 ) ([][]float32, error) {
 	e.batchTexts = append([]string(nil), texts...)
+	e.document, _ = ctx.Value(types.EmbedDocumentContextKey).(bool)
 	embeddings := make([][]float32, len(texts))
 	for i := range texts {
 		embeddings[i] = []float32{1}
@@ -98,6 +101,9 @@ func TestIndexRemovesInlineImagePayloadBeforeEmbedding(t *testing.T) {
 		t.Fatalf("Index returned error: %v", err)
 	}
 	assertImagePayloadRemoved(t, embedder.text, payload)
+	if !embedder.document {
+		t.Fatal("Index must mark document embedding context")
+	}
 }
 
 func TestBatchIndexRemovesInlineImagePayloadBeforeEmbedding(t *testing.T) {
@@ -118,6 +124,9 @@ func TestBatchIndexRemovesInlineImagePayloadBeforeEmbedding(t *testing.T) {
 		t.Fatalf("expected one embedding input, got %d", len(embedder.batchTexts))
 	}
 	assertImagePayloadRemoved(t, embedder.batchTexts[0], payload)
+	if !embedder.document {
+		t.Fatal("BatchIndex must mark document embedding context")
+	}
 }
 
 func TestBatchIndexTruncatesOversizedEmbeddingInput(t *testing.T) {

--- a/internal/application/service/retriever/keywords_vector_hybrid_indexer_test.go
+++ b/internal/application/service/retriever/keywords_vector_hybrid_indexer_test.go
@@ -3,11 +3,17 @@ package retriever
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/Tencent/WeKnora/internal/application/repository"
 	"github.com/Tencent/WeKnora/internal/models/embedding"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/google/uuid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 type capturingEmbedder struct {
@@ -36,6 +42,33 @@ func (e *capturingEmbedder) BatchEmbedWithPool(
 
 type saveOnlyRepository struct {
 	interfaces.RetrieveEngineRepository
+}
+
+type concurrentSaveRepository struct {
+	saveOnlyRepository
+	mu        sync.Mutex
+	active    int
+	maxActive int
+}
+
+func (r *concurrentSaveRepository) BatchSave(
+	context.Context,
+	[]*types.IndexInfo,
+	map[string]any,
+) error {
+	r.mu.Lock()
+	r.active++
+	if r.active > r.maxActive {
+		r.maxActive = r.active
+	}
+	r.mu.Unlock()
+
+	time.Sleep(20 * time.Millisecond)
+
+	r.mu.Lock()
+	r.active--
+	r.mu.Unlock()
+	return nil
 }
 
 func (r *saveOnlyRepository) Save(ctx context.Context, indexInfo *types.IndexInfo, params map[string]any) error {
@@ -104,6 +137,38 @@ func TestBatchIndexTruncatesOversizedEmbeddingInput(t *testing.T) {
 	}
 	if got := len([]rune(embedder.batchTexts[0])); got > safetyMaxChars {
 		t.Fatalf("embedding input length = %d, want <= %d", got, safetyMaxChars)
+	}
+}
+
+func TestBatchIndexSerializesWritesInsideKnowledgeReconciliation(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	if err := db.AutoMigrate(&types.Knowledge{}); err != nil {
+		t.Fatalf("migrate knowledge: %v", err)
+	}
+	knowledge := &types.Knowledge{ID: uuid.NewString(), TenantID: 1, KnowledgeBaseID: uuid.NewString()}
+	if err := db.Create(knowledge).Error; err != nil {
+		t.Fatalf("create knowledge: %v", err)
+	}
+
+	repo := repository.NewKnowledgeRepository(db)
+	indexRepo := &concurrentSaveRepository{}
+	service := &KeywordsVectorHybridRetrieveEngineService{indexRepository: indexRepo}
+	infos := make([]*types.IndexInfo, 41)
+	for i := range infos {
+		infos[i] = &types.IndexInfo{SourceID: uuid.NewString(), Content: "indexed"}
+	}
+
+	err = repo.WithKnowledgeReconciliation(context.Background(), knowledge.TenantID, knowledge.ID, func(ctx context.Context) error {
+		return service.BatchIndex(ctx, &capturingEmbedder{}, infos, []types.RetrieverType{types.VectorRetrieverType})
+	})
+	if err != nil {
+		t.Fatalf("batch index under reconciliation: %v", err)
+	}
+	if indexRepo.maxActive != 1 {
+		t.Fatalf("concurrent batch writes inside reconciliation = %d, want 1", indexRepo.maxActive)
 	}
 }
 

--- a/internal/application/service/retriever/registry_test.go
+++ b/internal/application/service/retriever/registry_test.go
@@ -16,7 +16,9 @@ import (
 // mockEngineService is a minimal mock for testing registry operations.
 // Only EngineType() is meaningful; all other methods are no-ops.
 type mockEngineService struct {
-	engineType types.RetrieverEngineType
+	engineType       types.RetrieverEngineType
+	namespace        func(int, string) string
+	knowledgeDeletes []int
 }
 
 func (m *mockEngineService) EngineType() types.RetrieverEngineType { return m.engineType }
@@ -42,8 +44,16 @@ func (m *mockEngineService) DeleteByChunkIDList(_ context.Context, _ []string, _
 func (m *mockEngineService) DeleteBySourceIDList(_ context.Context, _ []string, _ int, _ string) error {
 	return nil
 }
-func (m *mockEngineService) DeleteByKnowledgeIDList(_ context.Context, _ []string, _ int, _ string) error {
+
+func (m *mockEngineService) DeleteByKnowledgeIDList(_ context.Context, _ []string, dimension int, _ string) error {
+	m.knowledgeDeletes = append(m.knowledgeDeletes, dimension)
 	return nil
+}
+func (m *mockEngineService) PhysicalIndexNamespace(dimension int, knowledgeType string) string {
+	if m.namespace == nil {
+		return ""
+	}
+	return m.namespace(dimension, knowledgeType)
 }
 func (m *mockEngineService) BatchUpdateChunkEnabledStatus(_ context.Context, _ map[string]bool) error {
 	return nil

--- a/internal/application/service/storagebackend.go
+++ b/internal/application/service/storagebackend.go
@@ -255,6 +255,37 @@ func (s *StorageBackendService) ResolveFileService(ctx context.Context, tenant *
 	return filesvc.NewFileServiceFromStorageConfig(provider, tenant.StorageEngineConfig, localBaseDir)
 }
 
+// ResolveHistoricalFileService resolves an exact backend for internal artifact
+// reads and cleanup, including after the backend has been disabled or soft-deleted.
+func (s *StorageBackendService) ResolveHistoricalFileService(
+	ctx context.Context,
+	tenant *types.Tenant,
+	backendID, localBaseDir string,
+) (interfaces.FileService, string, error) {
+	if tenant == nil || tenant.ID == 0 {
+		return nil, "", fmt.Errorf("workspace context missing")
+	}
+	if strings.TrimSpace(backendID) == "" {
+		return nil, "", fmt.Errorf("storage backend ID missing")
+	}
+	var backend types.StorageBackend
+	if err := s.db.WithContext(ctx).Unscoped().
+		Where("tenant_id = ? AND id = ?", tenant.ID, backendID).
+		First(&backend).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, "", fmt.Errorf("storage backend not found")
+		}
+		return nil, "", err
+	}
+	inner, provider, err := filesvc.NewFileServiceFromStorageConfig(
+		backend.Provider, backend.ToStorageEngineConfig(), localBaseDir,
+	)
+	if err != nil {
+		return nil, provider, err
+	}
+	return filesvc.NewBackendScopedFileService(backend.ID, inner), provider, nil
+}
+
 func validateStorageBackendEndpoint(backend *types.StorageBackend) error {
 	if backend.Provider == "local" || (backend.Provider == "minio" && backend.Config.Mode == "docker") {
 		return nil

--- a/internal/application/service/storagebackend_test.go
+++ b/internal/application/service/storagebackend_test.go
@@ -40,3 +40,29 @@ func TestStorageBackendResolverScopesPathsAndTenant(t *testing.T) {
 	_, _, err = resolver.ResolveFileService(context.Background(), &types.Tenant{ID: 8}, backend.ID, "local", t.TempDir())
 	require.Error(t, err)
 }
+
+func TestStorageBackendResolverRestoresSoftDeletedBackendForArtifacts(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.StorageBackend{}))
+	repo := repository.NewStorageBackendRepository(db)
+	backend := &types.StorageBackend{TenantID: 7, Name: "Retired", Provider: "local"}
+	require.NoError(t, repo.Create(context.Background(), backend))
+	require.NoError(t, repo.Delete(context.Background(), backend.TenantID, backend.ID))
+	resolver := service.NewStorageBackendService(repo, db)
+	tenant := &types.Tenant{ID: backend.TenantID}
+
+	_, _, err = resolver.ResolveFileService(
+		context.Background(), tenant, backend.ID, backend.Provider, t.TempDir(),
+	)
+	require.Error(t, err)
+
+	fileService, provider, err := resolver.ResolveHistoricalFileService(
+		context.Background(), tenant, backend.ID, t.TempDir(),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, backend.Provider, provider)
+	path, err := fileService.SaveBytes(context.Background(), []byte("artifact"), backend.TenantID, "artifact.bin", false)
+	require.NoError(t, err)
+	assert.Contains(t, path, "storage://"+backend.ID+"/")
+}

--- a/internal/application/service/vlm_artifact_cache.go
+++ b/internal/application/service/vlm_artifact_cache.go
@@ -149,7 +149,13 @@ func predictVLMArtifact(
 		return "", false, fmt.Errorf("%w: get: %w", errVLMArtifactStore, err)
 	}
 	if hit {
-		return string(value), true, nil
+		cached := string(value)
+		if request.canonicalize(cached) == cached {
+			return cached, true, nil
+		}
+		if err := store.Invalidate(ctx, key, value); err != nil {
+			return "", false, fmt.Errorf("%w: invalidate: %w", errVLMArtifactStore, err)
+		}
 	}
 
 	valueText, err := request.model.Predict(ctx, [][]byte{request.imageBytes}, request.prompt)
@@ -163,5 +169,12 @@ func predictVLMArtifact(
 	if err != nil {
 		return "", false, fmt.Errorf("%w: put: %w", errVLMArtifactStore, err)
 	}
-	return string(canonical), false, nil
+	canonicalText := string(canonical)
+	if request.canonicalize(canonicalText) != canonicalText {
+		if err := store.Invalidate(ctx, key, canonical); err != nil {
+			return "", false, fmt.Errorf("%w: invalidate: %w", errVLMArtifactStore, err)
+		}
+		return valueText, false, nil
+	}
+	return canonicalText, false, nil
 }

--- a/internal/application/service/vlm_artifact_cache.go
+++ b/internal/application/service/vlm_artifact_cache.go
@@ -1,0 +1,167 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/models/vlm"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+const vlmArtifactKeyVersion uint16 = 1
+
+var (
+	errVLMArtifactProvider = errors.New("VLM artifact provider failed")
+	errVLMArtifactStore    = errors.New("VLM artifact store failed")
+)
+
+type vlmArtifactResultKind string
+
+const (
+	vlmArtifactOCR     vlmArtifactResultKind = "vlm.ocr"
+	vlmArtifactCaption vlmArtifactResultKind = "vlm.caption"
+)
+
+type vlmArtifactRequest struct {
+	tenantID             uint64
+	imageBytes           []byte
+	model                vlm.VLM
+	modelRevision        string
+	config               types.VLMConfig
+	prompt               string
+	promptVersion        string
+	resultKind           vlmArtifactResultKind
+	canonicalizerVersion string
+	canonicalize         func(string) string
+}
+
+func newVLMArtifactKey(request vlmArtifactRequest) (types.ProcessingArtifactKey, error) {
+	if err := validateVLMArtifactRequest(request); err != nil {
+		return types.ProcessingArtifactKey{}, err
+	}
+
+	imageDigest := sha256.Sum256(request.imageBytes)
+	promptDigest := sha256.Sum256([]byte(request.prompt))
+	modelDigest, err := vlmArtifactModelDigest(request.model, request.modelRevision, request.config)
+	if err != nil {
+		return types.ProcessingArtifactKey{}, err
+	}
+
+	return types.NewProcessingArtifactKey(
+		request.tenantID,
+		string(request.resultKind),
+		vlmArtifactKeyVersion,
+		imageDigest[:],
+		modelDigest[:],
+		promptDigest[:],
+		[]byte(request.promptVersion),
+		[]byte(request.canonicalizerVersion),
+	)
+}
+
+func validateVLMArtifactRequest(request vlmArtifactRequest) error {
+	if request.model == nil {
+		return errors.New("VLM artifact model must not be nil")
+	}
+	if request.resultKind != vlmArtifactOCR && request.resultKind != vlmArtifactCaption {
+		return errors.New("invalid VLM artifact result kind")
+	}
+	if strings.TrimSpace(request.promptVersion) == "" {
+		return errors.New("VLM artifact prompt version must not be empty")
+	}
+	if strings.TrimSpace(request.canonicalizerVersion) == "" {
+		return errors.New("VLM artifact canonicalizer version must not be empty")
+	}
+	if request.canonicalize == nil {
+		return errors.New("VLM artifact canonicalizer must not be nil")
+	}
+	return nil
+}
+
+func vlmArtifactModelDigest(
+	model vlm.VLM,
+	modelRevision string,
+	config types.VLMConfig,
+) ([sha256.Size]byte, error) {
+	if modelID := strings.TrimSpace(model.GetModelID()); modelID != "" {
+		descriptor := strings.Join([]string{
+			"model-id",
+			modelID,
+			strings.TrimSpace(model.GetModelName()),
+			strings.TrimSpace(modelRevision),
+		}, "\x00")
+		return sha256.Sum256([]byte(descriptor)), nil
+	}
+
+	endpoint, err := url.Parse(config.BaseURL)
+	if err != nil {
+		return [sha256.Size]byte{}, errors.New("invalid VLM artifact endpoint URL")
+	}
+	endpoint.User = nil
+	endpoint.RawQuery = ""
+	endpoint.Fragment = ""
+	endpoint.Scheme = strings.ToLower(endpoint.Scheme)
+	endpoint.Host = strings.ToLower(endpoint.Host)
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/")
+
+	interfaceType := strings.ToLower(strings.TrimSpace(config.InterfaceType))
+	if interfaceType == "" {
+		interfaceType = "openai"
+	}
+	modelName := strings.TrimSpace(model.GetModelName())
+	if modelName == "" {
+		modelName = strings.TrimSpace(config.ModelName)
+	}
+	descriptor := strings.Join([]string{interfaceType, modelName, endpoint.String()}, "\x00")
+	return sha256.Sum256([]byte(descriptor)), nil
+}
+
+func predictVLMArtifact(
+	ctx context.Context,
+	store interfaces.ProcessingArtifactStore,
+	request vlmArtifactRequest,
+) (string, bool, error) {
+	if err := validateVLMArtifactRequest(request); err != nil {
+		return "", false, err
+	}
+	if store == nil {
+		value, err := request.model.Predict(ctx, [][]byte{request.imageBytes}, request.prompt)
+		if err != nil {
+			return "", false, fmt.Errorf("%w: %w", errVLMArtifactProvider, err)
+		}
+		if request.canonicalize != nil {
+			value = request.canonicalize(value)
+		}
+		return value, false, nil
+	}
+
+	key, err := newVLMArtifactKey(request)
+	if err != nil {
+		return "", false, err
+	}
+	value, hit, err := store.Get(ctx, key)
+	if err != nil {
+		return "", false, fmt.Errorf("%w: get: %w", errVLMArtifactStore, err)
+	}
+	if hit {
+		return string(value), true, nil
+	}
+
+	valueText, err := request.model.Predict(ctx, [][]byte{request.imageBytes}, request.prompt)
+	if err != nil {
+		return "", false, fmt.Errorf("%w: %w", errVLMArtifactProvider, err)
+	}
+	if request.canonicalize != nil {
+		valueText = request.canonicalize(valueText)
+	}
+	canonical, _, err := store.PutIfAbsent(ctx, key, []byte(valueText))
+	if err != nil {
+		return "", false, fmt.Errorf("%w: put: %w", errVLMArtifactStore, err)
+	}
+	return string(canonical), false, nil
+}

--- a/internal/application/service/vlm_artifact_cache_test.go
+++ b/internal/application/service/vlm_artifact_cache_test.go
@@ -29,13 +29,16 @@ func (m *vlmArtifactFakeModel) GetModelName() string { return m.modelName }
 func (m *vlmArtifactFakeModel) GetModelID() string   { return m.modelID }
 
 type vlmArtifactFakeStore struct {
-	values       map[types.ProcessingArtifactKey][]byte
-	getErr       error
-	putErr       error
-	putCanonical []byte
-	hasCanonical bool
-	getCalls     int
-	putCalls     int
+	values        map[types.ProcessingArtifactKey][]byte
+	getErr        error
+	putErr        error
+	invalidateErr error
+	putCanonical  []byte
+	hasCanonical  bool
+	getCalls      int
+	putCalls      int
+	invalidated   []types.ProcessingArtifactKey
+	observed      [][]byte
 }
 
 func newVLMArtifactFakeStore() *vlmArtifactFakeStore {
@@ -71,6 +74,20 @@ func (s *vlmArtifactFakeStore) PutIfAbsent(
 	}
 	s.values[key] = append([]byte(nil), value...)
 	return append([]byte(nil), value...), true, nil
+}
+
+func (s *vlmArtifactFakeStore) Invalidate(
+	_ context.Context,
+	key types.ProcessingArtifactKey,
+	observed []byte,
+) error {
+	s.invalidated = append(s.invalidated, key)
+	s.observed = append(s.observed, append([]byte(nil), observed...))
+	if s.invalidateErr != nil {
+		return s.invalidateErr
+	}
+	delete(s.values, key)
+	return nil
 }
 
 func TestNewVLMArtifactKeyStabilityAndInvalidation(t *testing.T) {
@@ -321,6 +338,58 @@ func TestPredictVLMArtifactUsesEmptyPutIfAbsentWinner(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, hit)
 	assert.Empty(t, got)
+}
+
+func TestPredictVLMArtifactInvalidatesNonCanonicalHitBeforeProvider(t *testing.T) {
+	store := newVLMArtifactFakeStore()
+	model := &vlmArtifactFakeModel{modelID: "model-1", result: "fresh"}
+	request := testVLMArtifactRequest(model)
+	request.canonicalize = strings.TrimSpace
+	key, err := newVLMArtifactKey(request)
+	require.NoError(t, err)
+	store.values[key] = []byte(" stale ")
+
+	got, hit, err := predictVLMArtifact(context.Background(), store, request)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, "fresh", got)
+	assert.Equal(t, 1, model.calls)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+	assert.Equal(t, [][]byte{[]byte(" stale ")}, store.observed)
+}
+
+func TestPredictVLMArtifactStopsBeforeProviderWhenInvalidationFails(t *testing.T) {
+	store := newVLMArtifactFakeStore()
+	store.invalidateErr = errors.New("invalidate failed")
+	model := &vlmArtifactFakeModel{modelID: "model-1", result: "fresh"}
+	request := testVLMArtifactRequest(model)
+	request.canonicalize = strings.TrimSpace
+	key, err := newVLMArtifactKey(request)
+	require.NoError(t, err)
+	store.values[key] = []byte(" stale ")
+
+	_, _, err = predictVLMArtifact(context.Background(), store, request)
+	assert.ErrorIs(t, err, store.invalidateErr)
+	assert.Zero(t, model.calls)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+}
+
+func TestPredictVLMArtifactInvalidatesNonCanonicalConcurrentWinner(t *testing.T) {
+	store := newVLMArtifactFakeStore()
+	store.putCanonical = []byte(" stale ")
+	store.hasCanonical = true
+	model := &vlmArtifactFakeModel{modelID: "model-1", result: "fresh"}
+	request := testVLMArtifactRequest(model)
+	request.canonicalize = strings.TrimSpace
+	key, err := newVLMArtifactKey(request)
+	require.NoError(t, err)
+
+	got, hit, err := predictVLMArtifact(context.Background(), store, request)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, "fresh", got)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+	assert.Equal(t, [][]byte{[]byte(" stale ")}, store.observed)
 }
 
 func testVLMArtifactRequest(model vlm.VLM) vlmArtifactRequest {

--- a/internal/application/service/vlm_artifact_cache_test.go
+++ b/internal/application/service/vlm_artifact_cache_test.go
@@ -1,0 +1,337 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/vlm"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type vlmArtifactFakeModel struct {
+	modelID   string
+	modelName string
+	result    string
+	err       error
+	calls     int
+}
+
+func (m *vlmArtifactFakeModel) Predict(context.Context, [][]byte, string) (string, error) {
+	m.calls++
+	return m.result, m.err
+}
+
+func (m *vlmArtifactFakeModel) GetModelName() string { return m.modelName }
+func (m *vlmArtifactFakeModel) GetModelID() string   { return m.modelID }
+
+type vlmArtifactFakeStore struct {
+	values       map[types.ProcessingArtifactKey][]byte
+	getErr       error
+	putErr       error
+	putCanonical []byte
+	hasCanonical bool
+	getCalls     int
+	putCalls     int
+}
+
+func newVLMArtifactFakeStore() *vlmArtifactFakeStore {
+	return &vlmArtifactFakeStore{values: make(map[types.ProcessingArtifactKey][]byte)}
+}
+
+func (s *vlmArtifactFakeStore) Get(
+	_ context.Context,
+	key types.ProcessingArtifactKey,
+) ([]byte, bool, error) {
+	s.getCalls++
+	if s.getErr != nil {
+		return nil, false, s.getErr
+	}
+	value, ok := s.values[key]
+	return append([]byte(nil), value...), ok, nil
+}
+
+func (s *vlmArtifactFakeStore) PutIfAbsent(
+	_ context.Context,
+	key types.ProcessingArtifactKey,
+	value []byte,
+) ([]byte, bool, error) {
+	s.putCalls++
+	if s.putErr != nil {
+		return nil, false, s.putErr
+	}
+	if s.hasCanonical {
+		return append([]byte(nil), s.putCanonical...), false, nil
+	}
+	if canonical, ok := s.values[key]; ok {
+		return append([]byte(nil), canonical...), false, nil
+	}
+	s.values[key] = append([]byte(nil), value...)
+	return append([]byte(nil), value...), true, nil
+}
+
+func TestNewVLMArtifactKeyStabilityAndInvalidation(t *testing.T) {
+	base := vlmArtifactRequest{
+		tenantID:             7,
+		imageBytes:           []byte("image"),
+		model:                &vlmArtifactFakeModel{modelID: "model-1", modelName: "vision"},
+		prompt:               "read the image",
+		promptVersion:        "ocr-default-v1",
+		resultKind:           vlmArtifactOCR,
+		canonicalizerVersion: "ocr-sanitizer-v1",
+		canonicalize:         strings.TrimSpace,
+	}
+
+	baseKey, err := newVLMArtifactKey(base)
+	require.NoError(t, err)
+	stableKey, err := newVLMArtifactKey(base)
+	require.NoError(t, err)
+	assert.Equal(t, baseKey, stableKey)
+	assert.Equal(t, "vlm.ocr", baseKey.Stage)
+	assert.Equal(t, uint16(1), baseKey.KeyVersion)
+
+	tests := []struct {
+		name   string
+		mutate func(*vlmArtifactRequest)
+	}{
+		{name: "image bytes", mutate: func(r *vlmArtifactRequest) { r.imageBytes = []byte("other-image") }},
+		{name: "model identity", mutate: func(r *vlmArtifactRequest) {
+			r.model = &vlmArtifactFakeModel{modelID: "model-2", modelName: "vision"}
+		}},
+		{name: "model revision", mutate: func(r *vlmArtifactRequest) { r.modelRevision = "2026-07-16T10:00:00Z" }},
+		{name: "prompt content", mutate: func(r *vlmArtifactRequest) { r.prompt = "describe the image" }},
+		{name: "prompt version", mutate: func(r *vlmArtifactRequest) { r.promptVersion = "ocr-default-v2" }},
+		{name: "result kind", mutate: func(r *vlmArtifactRequest) { r.resultKind = vlmArtifactCaption }},
+		{name: "canonicalizer version", mutate: func(r *vlmArtifactRequest) { r.canonicalizerVersion = "ocr-sanitizer-v2" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changed := base
+			tt.mutate(&changed)
+			changedKey, err := newVLMArtifactKey(changed)
+			require.NoError(t, err)
+			assert.NotEqual(t, baseKey, changedKey)
+		})
+	}
+}
+
+func TestNewVLMArtifactKeyLegacyIdentityExcludesCredentials(t *testing.T) {
+	request := vlmArtifactRequest{
+		tenantID:   7,
+		imageBytes: []byte("image"),
+		model:      &vlmArtifactFakeModel{modelName: "legacy-vision"},
+		config: types.VLMConfig{
+			ModelName:     "legacy-vision",
+			BaseURL:       "https://user:password@example.com/v1?api_key=secret#fragment",
+			APIKey:        "first-secret",
+			InterfaceType: "openai",
+		},
+		prompt:               "read the image",
+		promptVersion:        "ocr-default-v1",
+		resultKind:           vlmArtifactOCR,
+		canonicalizerVersion: "ocr-sanitizer-v1",
+		canonicalize:         strings.TrimSpace,
+	}
+
+	baseKey, err := newVLMArtifactKey(request)
+	require.NoError(t, err)
+
+	credentialsChanged := request
+	credentialsChanged.config.APIKey = "second-secret"
+	credentialsChanged.config.BaseURL = "https://other:credentials@example.com/v1?token=other#private"
+	credentialsKey, err := newVLMArtifactKey(credentialsChanged)
+	require.NoError(t, err)
+	assert.Equal(t, baseKey, credentialsKey)
+
+	endpointChanged := request
+	endpointChanged.config.BaseURL = "https://example.com/v2"
+	endpointKey, err := newVLMArtifactKey(endpointChanged)
+	require.NoError(t, err)
+	assert.NotEqual(t, baseKey, endpointKey)
+
+	for _, tt := range []struct {
+		name   string
+		mutate func(*vlmArtifactRequest)
+	}{
+		{name: "interface type", mutate: func(r *vlmArtifactRequest) { r.config.InterfaceType = "ollama" }},
+		{name: "model name", mutate: func(r *vlmArtifactRequest) {
+			r.model = &vlmArtifactFakeModel{modelName: "other-vision"}
+		}},
+		{name: "endpoint host", mutate: func(r *vlmArtifactRequest) {
+			r.config.BaseURL = "https://other.example.com/v1"
+		}},
+		{name: "endpoint scheme", mutate: func(r *vlmArtifactRequest) {
+			r.config.BaseURL = "http://example.com/v1"
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			changed := request
+			tt.mutate(&changed)
+			changedKey, err := newVLMArtifactKey(changed)
+			require.NoError(t, err)
+			assert.NotEqual(t, baseKey, changedKey)
+		})
+	}
+}
+
+func TestNewVLMArtifactKeyRejectsIncompleteCanonicalizationIdentity(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*vlmArtifactRequest)
+	}{
+		{name: "empty prompt version", mutate: func(r *vlmArtifactRequest) { r.promptVersion = " " }},
+		{name: "empty canonicalizer version", mutate: func(r *vlmArtifactRequest) { r.canonicalizerVersion = " " }},
+		{name: "missing canonicalizer", mutate: func(r *vlmArtifactRequest) { r.canonicalize = nil }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := testVLMArtifactRequest(&vlmArtifactFakeModel{modelID: "model-1"})
+			tt.mutate(&request)
+			_, err := newVLMArtifactKey(request)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestNewVLMArtifactKeyDoesNotExposeInvalidLegacyURL(t *testing.T) {
+	const secret = "very-secret-password"
+	request := testVLMArtifactRequest(&vlmArtifactFakeModel{modelName: "legacy-vision"})
+	request.config.BaseURL = "https://user:" + secret + "%zz@example.com/v1?token=private"
+
+	_, err := newVLMArtifactKey(request)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), secret)
+	assert.NotContains(t, err.Error(), "token=private")
+}
+
+func TestPredictVLMArtifactCachesCanonicalResult(t *testing.T) {
+	store := newVLMArtifactFakeStore()
+	model := &vlmArtifactFakeModel{modelID: "model-1", modelName: "vision", result: "  generated text  "}
+	request := testVLMArtifactRequest(model)
+	request.canonicalize = strings.TrimSpace
+
+	first, hit, err := predictVLMArtifact(context.Background(), store, request)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, "generated text", first)
+
+	second, hit, err := predictVLMArtifact(context.Background(), store, request)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, model.calls)
+	assert.Equal(t, 1, store.putCalls)
+}
+
+func TestPredictVLMArtifactWithoutStoreUsesProviderDirectly(t *testing.T) {
+	model := &vlmArtifactFakeModel{modelID: "model-1", result: "  generated text  "}
+	request := testVLMArtifactRequest(model)
+
+	got, hit, err := predictVLMArtifact(context.Background(), nil, request)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, "generated text", got)
+	assert.Equal(t, 1, model.calls)
+}
+
+func TestPredictVLMArtifactCachesSuccessfulEmptyResult(t *testing.T) {
+	store := newVLMArtifactFakeStore()
+	model := &vlmArtifactFakeModel{modelID: "model-1", result: "no text"}
+	request := testVLMArtifactRequest(model)
+	request.canonicalize = func(string) string { return "" }
+
+	first, hit, err := predictVLMArtifact(context.Background(), store, request)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Empty(t, first)
+
+	second, hit, err := predictVLMArtifact(context.Background(), store, request)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Empty(t, second)
+	assert.Equal(t, 1, model.calls)
+	assert.Equal(t, 1, store.putCalls)
+}
+
+func TestPredictVLMArtifactDoesNotCacheProviderError(t *testing.T) {
+	providerErr := errors.New("provider unavailable")
+	store := newVLMArtifactFakeStore()
+	model := &vlmArtifactFakeModel{modelID: "model-1", err: providerErr}
+
+	_, _, err := predictVLMArtifact(context.Background(), store, testVLMArtifactRequest(model))
+	assert.ErrorIs(t, err, errVLMArtifactProvider)
+	assert.ErrorContains(t, err, providerErr.Error())
+	assert.Equal(t, 1, model.calls)
+	assert.Zero(t, store.putCalls)
+}
+
+func TestPredictVLMArtifactPropagatesStoreErrors(t *testing.T) {
+	t.Run("get", func(t *testing.T) {
+		storeErr := errors.New("get failed")
+		store := newVLMArtifactFakeStore()
+		store.getErr = storeErr
+		model := &vlmArtifactFakeModel{modelID: "model-1", result: "text"}
+
+		_, _, err := predictVLMArtifact(context.Background(), store, testVLMArtifactRequest(model))
+		assert.ErrorIs(t, err, errVLMArtifactStore)
+		assert.ErrorContains(t, err, storeErr.Error())
+		assert.Zero(t, model.calls)
+		assert.Zero(t, store.putCalls)
+	})
+
+	t.Run("put", func(t *testing.T) {
+		storeErr := errors.New("put failed")
+		store := newVLMArtifactFakeStore()
+		store.putErr = storeErr
+		model := &vlmArtifactFakeModel{modelID: "model-1", result: "text"}
+
+		_, _, err := predictVLMArtifact(context.Background(), store, testVLMArtifactRequest(model))
+		assert.ErrorIs(t, err, errVLMArtifactStore)
+		assert.ErrorContains(t, err, storeErr.Error())
+		assert.Equal(t, 1, model.calls)
+		assert.Equal(t, 1, store.putCalls)
+	})
+}
+
+func TestPredictVLMArtifactUsesPutIfAbsentWinner(t *testing.T) {
+	store := newVLMArtifactFakeStore()
+	store.putCanonical = []byte("canonical winner")
+	store.hasCanonical = true
+	model := &vlmArtifactFakeModel{modelID: "model-1", result: "losing result"}
+
+	got, hit, err := predictVLMArtifact(context.Background(), store, testVLMArtifactRequest(model))
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, "canonical winner", got)
+	assert.Equal(t, 1, model.calls)
+	assert.Equal(t, 1, store.putCalls)
+}
+
+func TestPredictVLMArtifactUsesEmptyPutIfAbsentWinner(t *testing.T) {
+	store := newVLMArtifactFakeStore()
+	store.hasCanonical = true
+	model := &vlmArtifactFakeModel{modelID: "model-1", result: "losing result"}
+
+	got, hit, err := predictVLMArtifact(context.Background(), store, testVLMArtifactRequest(model))
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Empty(t, got)
+}
+
+func testVLMArtifactRequest(model vlm.VLM) vlmArtifactRequest {
+	return vlmArtifactRequest{
+		tenantID:             7,
+		imageBytes:           []byte("image"),
+		model:                model,
+		prompt:               "read the image",
+		promptVersion:        "ocr-default-v1",
+		resultKind:           vlmArtifactOCR,
+		canonicalizerVersion: "ocr-sanitizer-v1",
+		canonicalize:         strings.TrimSpace,
+	}
+}

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -306,6 +307,7 @@ type wikiIngestService struct {
 	knowledgeRepo  interfaces.KnowledgeRepository
 	chunkRepo      interfaces.ChunkRepository
 	modelService   interfaces.ModelService
+	artifactStore  interfaces.ProcessingArtifactStore
 	task           interfaces.TaskEnqueuer
 	logEntrySvc    interfaces.WikiLogEntryService
 	pendingRepo    interfaces.TaskPendingOpsRepository
@@ -335,6 +337,7 @@ func NewWikiIngestService(
 	knowledgeRepo interfaces.KnowledgeRepository,
 	chunkRepo interfaces.ChunkRepository,
 	modelService interfaces.ModelService,
+	artifactStore interfaces.ProcessingArtifactStore,
 	task interfaces.TaskEnqueuer,
 	logEntrySvc interfaces.WikiLogEntryService,
 	pendingRepo interfaces.TaskPendingOpsRepository,
@@ -349,6 +352,7 @@ func NewWikiIngestService(
 		knowledgeRepo:  knowledgeRepo,
 		chunkRepo:      chunkRepo,
 		modelService:   modelService,
+		artifactStore:  artifactStore,
 		task:           task,
 		logEntrySvc:    logEntrySvc,
 		pendingRepo:    pendingRepo,
@@ -1751,14 +1755,16 @@ func formatExistingTaxonomyForPrompt(paths [][]string) string {
 // a defense-in-depth measure: an old buggy ingest that mistakenly
 // stamped a system page with a knowledge ref would otherwise show up
 // in the reparse "old set" and confuse the reduce stage.
-func (s *wikiIngestService) getExistingPageSlugsForKnowledge(ctx context.Context, kbID, knowledgeID string) map[string]bool {
+func (s *wikiIngestService) getExistingPageSlugsForKnowledge(
+	ctx context.Context,
+	kbID, knowledgeID string,
+) (map[string]bool, error) {
 	slugs, err := s.wikiService.ListSlugsBySourceRef(ctx, kbID, knowledgeID)
 	if err != nil {
-		logger.Warnf(ctx, "wiki ingest: ListSlugsBySourceRef(%s) failed: %v", knowledgeID, err)
-		return nil
+		return nil, err
 	}
 	if len(slugs) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make(map[string]bool, len(slugs))
 	for _, slug := range slugs {
@@ -1769,7 +1775,7 @@ func (s *wikiIngestService) getExistingPageSlugsForKnowledge(ctx context.Context
 		}
 		out[slug] = true
 	}
-	return out
+	return out, nil
 }
 
 // retractStalePages handles pages that were previously linked to this document
@@ -2070,57 +2076,29 @@ func (s *wikiIngestService) deduplicateExtractedBatch(
 	chatModel chat.Chat,
 	kbID string,
 	entities, concepts []extractedItem,
-) ([]extractedItem, []extractedItem) {
+) ([]extractedItem, []extractedItem, wikiMapDedupContext, bool) {
+	dedupContext := wikiMapDedupContext{
+		Entities:                    cloneWikiMapItems(entities),
+		Concepts:                    cloneWikiMapItems(concepts),
+		CandidateFingerprint:        wikiDedupCandidateFingerprint(nil),
+		ReducedCandidateFingerprint: wikiDedupCandidateFingerprint(nil),
+	}
 	if len(entities) == 0 && len(concepts) == 0 {
-		return entities, concepts
+		return entities, concepts, dedupContext, true
 	}
 	if s.wikiService == nil {
-		return entities, concepts
+		return entities, concepts, finalizeWikiMapDedupContext(dedupContext, nil, entities, concepts), true
 	}
 
 	// Build the candidate set: for each new item, ask the repo for
 	// the top-K trigram-similar pages and union the results. Dedup by
 	// slug as we go so the prompt only carries each candidate once.
-	candidatePages := make(map[string]*types.WikiPageLite)
-	probe := func(item extractedItem) {
-		queries := make([]string, 0, 1+len(item.Aliases))
-		if item.Name != "" {
-			queries = append(queries, item.Name)
-		}
-		for _, alias := range item.Aliases {
-			if alias != "" {
-				queries = append(queries, alias)
-			}
-		}
-		for _, q := range queries {
-			pages, err := s.wikiService.FindSimilarPages(ctx, kbID, q,
-				[]string{types.WikiPageTypeEntity, types.WikiPageTypeConcept},
-				dedupCandidateTopK)
-			if err != nil {
-				logger.Warnf(ctx, "wiki ingest: dedup FindSimilarPages(%q) failed: %v", q, err)
-				continue
-			}
-			for _, p := range pages {
-				if p == nil || p.Slug == "" {
-					continue
-				}
-				if _, ok := candidatePages[p.Slug]; !ok {
-					candidatePages[p.Slug] = p
-				}
-			}
-		}
-	}
-	for _, e := range entities {
-		probe(e)
-	}
-	for _, c := range concepts {
-		probe(c)
-	}
+	candidatePages, complete := s.findWikiDedupCandidates(ctx, kbID, entities, concepts)
+	dedupContext.CandidateSlugs = wikiDedupCandidateSlugs(candidatePages)
+	dedupContext.CandidateFingerprint = wikiDedupCandidateFingerprint(candidatePages)
 	if len(candidatePages) == 0 {
-		// No similar existing pages — nothing to merge against. The
-		// items pass through unchanged.
 		logger.Infof(ctx, "wiki ingest: no similar existing pages found for %d new items", len(entities)+len(concepts))
-		return entities, concepts
+		return entities, concepts, finalizeWikiMapDedupContext(dedupContext, candidatePages, entities, concepts), complete
 	}
 	logger.Infof(ctx, "wiki ingest: %d similar existing pages selected for %d new items",
 		len(candidatePages), len(entities)+len(concepts))
@@ -2130,7 +2108,7 @@ func (s *wikiIngestService) deduplicateExtractedBatch(
 		writeDedupItemXML(&existingBuf, p.Slug, p.Title, p.PageType, []string(p.Aliases))
 	}
 	if existingBuf.Len() == 0 {
-		return entities, concepts
+		return entities, concepts, finalizeWikiMapDedupContext(dedupContext, candidatePages, entities, concepts), complete
 	}
 
 	var newBuf strings.Builder
@@ -2147,7 +2125,7 @@ func (s *wikiIngestService) deduplicateExtractedBatch(
 	})
 	if err != nil {
 		logger.Warnf(ctx, "wiki ingest: deduplication LLM call failed: %v", err)
-		return entities, concepts
+		return entities, concepts, dedupContext, false
 	}
 
 	dedupeJSON = cleanLLMJSON(dedupeJSON)
@@ -2155,13 +2133,13 @@ func (s *wikiIngestService) deduplicateExtractedBatch(
 	var dedupeResult struct {
 		Merges map[string]string `json:"merges"`
 	}
-	if err := json.Unmarshal([]byte(dedupeJSON), &dedupeResult); err != nil {
+	if err := unmarshalRequiredJSONObject(dedupeJSON, &dedupeResult, "merges"); err != nil {
 		logger.Warnf(ctx, "wiki ingest: failed to parse dedup JSON: %v\nRaw: %s", err, dedupeJSON)
-		return entities, concepts
+		return entities, concepts, dedupContext, false
 	}
 
 	if len(dedupeResult.Merges) == 0 {
-		return entities, concepts
+		return entities, concepts, finalizeWikiMapDedupContext(dedupContext, candidatePages, entities, concepts), complete
 	}
 
 	// Build the existing-slug set from the candidate map: anything not
@@ -2182,11 +2160,6 @@ func (s *wikiIngestService) deduplicateExtractedBatch(
 		srcSlash := strings.Index(srcSlug, "/")
 		dstSlash := strings.Index(dstSlug, "/")
 		if srcSlash <= 0 || dstSlash <= 0 {
-			// A type-prefixed slug must look like "entity/foo" or
-			// "concept/bar". An LLM that emits an un-prefixed slug
-			// here is hallucinating; reject rather than fall through
-			// the prefix-equality check (which would treat both empty
-			// prefixes as a match).
 			logger.Warnf(ctx, "wiki ingest: dedup rejected %s → %s (missing type prefix)", srcSlug, dstSlug)
 			return false
 		}
@@ -2198,21 +2171,292 @@ func (s *wikiIngestService) deduplicateExtractedBatch(
 		}
 		return true
 	}
+	inputSlugs := make(map[string]struct{}, len(entities)+len(concepts))
+	for _, item := range entities {
+		inputSlugs[item.Slug] = struct{}{}
+	}
+	for _, item := range concepts {
+		inputSlugs[item.Slug] = struct{}{}
+	}
+	validMerges := make(map[string]string, len(dedupeResult.Merges))
+	for srcSlug, dstSlug := range dedupeResult.Merges {
+		if _, ok := inputSlugs[srcSlug]; !ok {
+			complete = false
+			logger.Warnf(ctx, "wiki ingest: dedup rejected %s → %s (source slug was not extracted)", srcSlug, dstSlug)
+			continue
+		}
+		if !validMerge(srcSlug, dstSlug) {
+			complete = false
+			continue
+		}
+		validMerges[srcSlug] = dstSlug
+	}
 
 	for i, item := range entities {
-		if existingSlug, ok := dedupeResult.Merges[item.Slug]; ok && validMerge(item.Slug, existingSlug) {
+		if existingSlug, ok := validMerges[item.Slug]; ok {
 			logger.Infof(ctx, "wiki ingest: dedup merge %s → %s", item.Slug, existingSlug)
 			entities[i].Slug = existingSlug
 		}
 	}
 	for i, item := range concepts {
-		if existingSlug, ok := dedupeResult.Merges[item.Slug]; ok && validMerge(item.Slug, existingSlug) {
+		if existingSlug, ok := validMerges[item.Slug]; ok {
 			logger.Infof(ctx, "wiki ingest: dedup merge %s → %s", item.Slug, existingSlug)
 			concepts[i].Slug = existingSlug
 		}
 	}
 
-	return entities, concepts
+	entities = coalesceExtractedItemsBySlug(entities)
+	concepts = coalesceExtractedItemsBySlug(concepts)
+	return entities, concepts, finalizeWikiMapDedupContext(dedupContext, candidatePages, entities, concepts), complete
+}
+
+func finalizeWikiMapDedupContext(
+	context wikiMapDedupContext,
+	candidates map[string]*types.WikiPageLite,
+	entities, concepts []extractedItem,
+) wikiMapDedupContext {
+	reducedCandidates := make(map[string]*types.WikiPageLite, len(candidates))
+	for slug, page := range candidates {
+		clone := *page
+		clone.Aliases = append(types.StringArray(nil), page.Aliases...)
+		reducedCandidates[slug] = &clone
+	}
+	context.OutputPageFingerprints = make(map[string]string)
+	apply := func(items []extractedItem, pageType string) {
+		for _, item := range items {
+			if page, exists := reducedCandidates[item.Slug]; exists {
+				for _, alias := range item.Aliases {
+					page.Aliases = appendUnique(page.Aliases, alias)
+				}
+				continue
+			}
+			page := &types.WikiPageLite{
+				Slug: item.Slug, Title: item.Name, PageType: pageType,
+				Aliases: append(types.StringArray(nil), item.Aliases...),
+			}
+			context.OutputPageFingerprints[item.Slug] = wikiDedupPageFingerprint(page)
+		}
+	}
+	apply(entities, types.WikiPageTypeEntity)
+	apply(concepts, types.WikiPageTypeConcept)
+	context.ReducedCandidateFingerprint = wikiDedupCandidateFingerprint(reducedCandidates)
+	if len(context.OutputPageFingerprints) == 0 {
+		context.OutputPageFingerprints = nil
+	}
+	return context
+}
+
+func coalesceExtractedItemsBySlug(items []extractedItem) []extractedItem {
+	coalesced := make([]extractedItem, 0, len(items))
+	positions := make(map[string]int, len(items))
+	for _, item := range items {
+		position, exists := positions[item.Slug]
+		if !exists {
+			item.Aliases = append([]string(nil), item.Aliases...)
+			item.SourceChunks = append([]string(nil), item.SourceChunks...)
+			positions[item.Slug] = len(coalesced)
+			coalesced = append(coalesced, item)
+			continue
+		}
+
+		current := &coalesced[position]
+		if item.Name != current.Name {
+			current.Aliases = appendUniqueWikiMapString(current.Aliases, item.Name)
+		}
+		for _, alias := range item.Aliases {
+			current.Aliases = appendUniqueWikiMapString(current.Aliases, alias)
+		}
+		current.Description = joinDistinctWikiMapText(current.Description, item.Description)
+		current.Details = joinDistinctWikiMapText(current.Details, item.Details)
+		for _, chunkID := range item.SourceChunks {
+			current.SourceChunks = appendUniqueWikiMapString(current.SourceChunks, chunkID)
+		}
+	}
+	return coalesced
+}
+
+func appendUniqueWikiMapString(values []string, value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return values
+	}
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+func joinDistinctWikiMapText(existing, addition string) string {
+	if strings.TrimSpace(addition) == "" || existing == addition {
+		return existing
+	}
+	if strings.TrimSpace(existing) == "" {
+		return addition
+	}
+	return existing + "\n" + addition
+}
+
+func (s *wikiIngestService) findWikiDedupCandidates(
+	ctx context.Context,
+	kbID string,
+	entities, concepts []extractedItem,
+) (map[string]*types.WikiPageLite, bool) {
+	candidatePages := make(map[string]*types.WikiPageLite)
+	complete := true
+	probe := func(item extractedItem) {
+		queries := make([]string, 0, 1+len(item.Aliases))
+		if item.Name != "" {
+			queries = append(queries, item.Name)
+		}
+		for _, alias := range item.Aliases {
+			if alias != "" {
+				queries = append(queries, alias)
+			}
+		}
+		for _, q := range queries {
+			pages, err := s.wikiService.FindSimilarPages(ctx, kbID, q,
+				[]string{types.WikiPageTypeEntity, types.WikiPageTypeConcept},
+				dedupCandidateTopK)
+			if err != nil {
+				complete = false
+				logger.Warnf(ctx, "wiki ingest: dedup FindSimilarPages(%q) failed: %v", q, err)
+				continue
+			}
+			for _, p := range pages {
+				if p == nil || p.Slug == "" {
+					continue
+				}
+				if p.Slug == item.Slug {
+					continue
+				}
+				if _, ok := candidatePages[p.Slug]; !ok {
+					candidatePages[p.Slug] = p
+				}
+			}
+		}
+	}
+	for _, e := range entities {
+		probe(e)
+	}
+	for _, c := range concepts {
+		probe(c)
+	}
+	return candidatePages, complete
+}
+
+func wikiDedupCandidateFingerprint(pages map[string]*types.WikiPageLite) string {
+	type candidate struct {
+		Slug, Title, PageType string
+		Aliases               []string
+	}
+	items := make([]candidate, 0, len(pages))
+	for _, page := range pages {
+		aliases := append([]string(nil), page.Aliases...)
+		sort.Strings(aliases)
+		items = append(items, candidate{page.Slug, page.Title, page.PageType, aliases})
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Slug < items[j].Slug })
+	encoded, _ := json.Marshal(items)
+	digest := sha256.Sum256(encoded)
+	return fmt.Sprintf("%x", digest[:])
+}
+
+func wikiDedupPageFingerprint(page *types.WikiPageLite) string {
+	return wikiDedupCandidateFingerprint(map[string]*types.WikiPageLite{page.Slug: page})
+}
+
+func wikiDedupCandidateSlugs(pages map[string]*types.WikiPageLite) []string {
+	slugs := make([]string, 0, len(pages))
+	for slug := range pages {
+		slugs = append(slugs, slug)
+	}
+	sort.Strings(slugs)
+	return slugs
+}
+
+func wikiPageSlugFingerprint(slugs map[string]bool) string {
+	ordered := make([]string, 0, len(slugs))
+	for slug := range slugs {
+		ordered = append(ordered, slug)
+	}
+	sort.Strings(ordered)
+	encoded, _ := json.Marshal(ordered)
+	digest := sha256.Sum256(encoded)
+	return fmt.Sprintf("%x", digest[:])
+}
+
+func wikiMapArtifactOutputSlugs(summarySlug string, value wikiMapArtifactValue) map[string]struct{} {
+	slugs := make(map[string]struct{}, len(value.Entities)+len(value.Concepts)+1)
+	slugs[summarySlug] = struct{}{}
+	for _, item := range value.Entities {
+		slugs[item.Slug] = struct{}{}
+	}
+	for _, item := range value.Concepts {
+		slugs[item.Slug] = struct{}{}
+	}
+	return slugs
+}
+
+func (s *wikiIngestService) wikiMapArtifactStateCurrent(
+	ctx context.Context,
+	kbID, summarySlug string,
+	oldPageSlugs map[string]bool,
+	value wikiMapArtifactValue,
+) bool {
+	expectedSlugs := wikiMapArtifactOutputSlugs(summarySlug, value)
+	if len(expectedSlugs) != len(oldPageSlugs) {
+		return false
+	}
+	for slug := range expectedSlugs {
+		if !oldPageSlugs[slug] {
+			return false
+		}
+	}
+	return s.wikiMapArtifactDedupStateCurrent(ctx, kbID, summarySlug, value)
+}
+
+func (s *wikiIngestService) wikiMapArtifactDedupStateCurrent(
+	ctx context.Context,
+	kbID, summarySlug string,
+	value wikiMapArtifactValue,
+) bool {
+	expectedSlugs := wikiMapArtifactOutputSlugs(summarySlug, value)
+	candidates, complete := s.findWikiDedupCandidates(
+		ctx, kbID, value.DedupContext.Entities, value.DedupContext.Concepts,
+	)
+	storedCandidates := make(map[string]struct{}, len(value.DedupContext.CandidateSlugs))
+	for _, slug := range value.DedupContext.CandidateSlugs {
+		storedCandidates[slug] = struct{}{}
+	}
+	for slug := range candidates {
+		_, outputSlug := expectedSlugs[slug]
+		_, originalCandidate := storedCandidates[slug]
+		if outputSlug && !originalCandidate {
+			expectedFingerprint, ok := value.DedupContext.OutputPageFingerprints[slug]
+			if !ok || wikiDedupPageFingerprint(candidates[slug]) != expectedFingerprint {
+				return false
+			}
+			delete(candidates, slug)
+		}
+	}
+	if !complete {
+		return false
+	}
+	fingerprint := wikiDedupCandidateFingerprint(candidates)
+	return fingerprint == value.DedupContext.CandidateFingerprint ||
+		(value.DedupContext.ReducedCandidateFingerprint != "" &&
+			fingerprint == value.DedupContext.ReducedCandidateFingerprint)
+}
+
+func (s *wikiIngestService) wikiMapConcurrentWinnerCurrent(
+	ctx context.Context,
+	kbID, summarySlug string,
+	winner, computed wikiMapArtifactValue,
+) bool {
+	return winner.PreviousSlugsFingerprint != "" &&
+		winner.PreviousSlugsFingerprint == computed.PreviousSlugsFingerprint &&
+		s.wikiMapArtifactDedupStateCurrent(ctx, kbID, summarySlug, winner)
 }
 
 // generateWithTemplate executes a prompt template and calls the LLM with

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -3,7 +3,9 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -304,6 +306,17 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 		exitStatus = "get_chat_model_failed"
 		return fmt.Errorf("wiki ingest: get chat model: %w", err)
 	}
+	modelRevision := ""
+	if s.artifactStore != nil {
+		model, modelErr := s.modelService.GetModelByID(ctx, synthesisModelID)
+		if modelErr != nil {
+			logger.Warnf(ctx, "wiki ingest: map cache bypassed because model metadata is unavailable: %v", modelErr)
+		} else if revision, revisionErr := chatArtifactModelRevision(model); revisionErr != nil {
+			logger.Warnf(ctx, "wiki ingest: map cache bypassed because model revision is unsafe: %v", revisionErr)
+		} else {
+			modelRevision = revision
+		}
+	}
 
 	// Resolve per-KB tunables once. WikiConfig.IngestBatchSize /
 	// IngestMapParallel / IngestReduceParallel let operators on
@@ -489,7 +502,7 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 			mapMu.Unlock()
 
 			logger.Infof(mapCtx, "wiki ingest: processing document '%s' (%s)", op.DocTitle, op.KnowledgeID)
-			result, updates, err := s.mapOneDocument(mapCtx, chatModel, payload, op, batchCtx)
+			result, updates, err := s.mapOneDocument(mapCtx, chatModel, modelRevision, payload, op, batchCtx)
 			if err != nil {
 				mapMu.Lock()
 				ingestFailed++
@@ -1080,6 +1093,7 @@ func (s *wikiIngestService) ProcessWikiFinalize(ctx context.Context, t *asynq.Ta
 func (s *wikiIngestService) mapOneDocument(
 	ctx context.Context,
 	chatModel chat.Chat,
+	modelRevision string,
 	payload WikiIngestPayload,
 	op WikiPendingOp,
 	batchCtx *WikiBatchContext,
@@ -1119,6 +1133,7 @@ func (s *wikiIngestService) mapOneDocument(
 		s.tracker().SkipSpan(ctx, wikiSpan, "no_chunks")
 		return nil, nil, nil
 	}
+	chunks = canonicalWikiMapChunkOrder(chunks)
 
 	content := reconstructEnrichedContent(ctx, s.chunkRepo, payload.TenantID, chunks)
 	rawRuneCount := len([]rune(content))
@@ -1160,144 +1175,189 @@ func (s *wikiIngestService) mapOneDocument(
 	// does not leak into citation strings that downstream LLM prompts may
 	// surface during wiki page editing.
 	sourceRef := knowledgeID
-	oldPageSlugs := s.getExistingPageSlugsForKnowledge(ctx, payload.KnowledgeBaseID, knowledgeID)
-
-	// Pass 0: lightweight candidate slug extraction (skeleton only).
-	// On failure we fall back to the legacy single-shot extractor so the doc
-	// still gets ingested, just without chunk-level citations.
-	var (
-		extractedEntities []extractedItem
-		extractedConcepts []extractedItem
-		slugItems         map[string]extractedItem
-		pass0Failed       bool
+	oldPageSlugs, oldPageSlugsErr := s.getExistingPageSlugsForKnowledge(
+		ctx, payload.KnowledgeBaseID, knowledgeID,
 	)
-	logger.Infof(ctx, "wiki ingest: pass 0 — extracting candidate slugs for %s", knowledgeID)
-	extractSpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.extract", types.SpanKindSubSpan, types.JSONMap{
-		"content_chars": utf8.RuneCountInString(content),
-		"old_pages":     len(oldPageSlugs),
-	})
-	extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
-	if err != nil {
-		logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) — falling back to legacy extractor", knowledgeID, err)
-		pass0Failed = true
-		extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
-		if err != nil {
-			logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
-			s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
-			s.tracker().FailSpan(ctx, wikiSpan, "EXTRACT_FAILED", err.Error(), err)
-			return nil, nil, err
-		}
+	oldPageSlugsComplete := oldPageSlugsErr == nil
+	if oldPageSlugsErr != nil {
+		logger.Warnf(ctx, "wiki ingest: ListSlugsBySourceRef(%s) failed: %v", knowledgeID, oldPageSlugsErr)
 	}
-	s.tracker().EndSpan(ctx, extractSpan, types.JSONMap{
-		"entities":         len(extractedEntities),
-		"concepts":         len(extractedConcepts),
-		"pass0_fallback":   pass0Failed,
-		"entities_preview": previewExtractedItems(extractedEntities, 8),
-		"concepts_preview": previewExtractedItems(extractedConcepts, 8),
-	})
 
-	// Build slug listing for Summary's wiki-link input.
-	var summaryExtractedPages []string
-	for slug := range slugItems {
-		summaryExtractedPages = append(summaryExtractedPages, slug)
+	mapRequest := wikiMapArtifactRequest{
+		tenantID:               payload.TenantID,
+		knowledgeBaseID:        payload.KnowledgeBaseID,
+		knowledgeID:            knowledgeID,
+		modelID:                chatModel.GetModelID(),
+		modelName:              chatModel.GetModelName(),
+		modelRevision:          modelRevision,
+		content:                content,
+		chunks:                 chunks,
+		language:               lang,
+		granularity:            batchCtx.ExtractionGranularity.Normalize(),
+		contentInstructions:    batchCtx.ContentInstructions,
+		extractionInstructions: batchCtx.ExtractionInstructions,
+		promptSuiteVersion:     wikiMapPromptSuiteVersion,
+		canonicalizerVersion:   wikiMapCanonicalizerVersion,
 	}
+	computeMap := func() (wikiMapArtifactValue, bool, error) {
+		var (
+			extractedEntities []extractedItem
+			extractedConcepts []extractedItem
+			slugItems         map[string]extractedItem
+			pass0Failed       bool
+			dedupComplete     bool
+			dedupContext      wikiMapDedupContext
+		)
+		logger.Infof(ctx, "wiki ingest: pass 0 — extracting candidate slugs for %s", knowledgeID)
+		extractSpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.extract", types.SpanKindSubSpan, types.JSONMap{
+			"content_chars": utf8.RuneCountInString(content),
+			"old_pages":     len(oldPageSlugs),
+		})
+		extractedEntities, extractedConcepts, slugItems, dedupContext, dedupComplete, err = s.extractCandidateSlugs(
+			ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx,
+		)
+		if err != nil {
+			logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) — falling back to legacy extractor", knowledgeID, err)
+			pass0Failed = true
+			extractedEntities, extractedConcepts, slugItems, _, _, err = s.extractEntitiesAndConceptsNoUpsert(
+				ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx,
+			)
+			if err != nil {
+				logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
+				s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
+				return wikiMapArtifactValue{}, false, err
+			}
+		}
+		s.tracker().EndSpan(ctx, extractSpan, types.JSONMap{
+			"entities":         len(extractedEntities),
+			"concepts":         len(extractedConcepts),
+			"pass0_fallback":   pass0Failed,
+			"entities_preview": previewExtractedItems(extractedEntities, 8),
+			"concepts_preview": previewExtractedItems(extractedConcepts, 8),
+		})
+
+		summaryExtractedPages := make([]string, 0, len(slugItems))
+		for slug := range slugItems {
+			summaryExtractedPages = append(summaryExtractedPages, slug)
+		}
+		sort.Strings(summaryExtractedPages)
+		var slugListing strings.Builder
+		for _, slug := range summaryExtractedPages {
+			item := slugItems[slug]
+			aliases := ""
+			if len(item.Aliases) > 0 {
+				aliases = fmt.Sprintf(" (Aliases: %s)", strings.Join(item.Aliases, ", "))
+			}
+			fmt.Fprintf(&slugListing, "- [[%s]] = %s%s\n", slug, item.Name, aliases)
+		}
+
+		var (
+			summaryContent   string
+			summaryErr       error
+			citations        map[string][]string
+			newSlugs         []newSlugFromCitation
+			batchCount       int
+			citationComplete = true
+		)
+		summarySpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.summary", types.SpanKindSubSpan, types.JSONMap{
+			"content_chars":   utf8.RuneCountInString(content),
+			"extracted_slugs": len(summaryExtractedPages),
+		})
+		var classifySpan *Span
+		if !pass0Failed {
+			classifySpan = s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.classify", types.SpanKindSubSpan, types.JSONMap{
+				"chunks": len(chunks), "candidates": len(extractedEntities) + len(extractedConcepts),
+			})
+		}
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			summaryContent, summaryErr = s.generateWithTemplate(ctx, chatModel, agent.WikiSummaryPrompt, map[string]string{
+				"Content": content, "Language": lang, "ExtractedSlugs": slugListing.String(),
+				"CustomInstructions": batchCtx.ContentInstructions, "InstructionScope": "wiki_content",
+			})
+			if summaryErr != nil {
+				s.tracker().FailSpan(ctx, summarySpan, "SUMMARY_FAILED", summaryErr.Error(), summaryErr)
+				return
+			}
+			sumLine, sumBody := splitSummaryLine(summaryContent)
+			s.tracker().EndSpan(ctx, summarySpan, types.JSONMap{
+				"chars": utf8.RuneCountInString(summaryContent), "summary_line": previewText(sumLine, 160),
+				"body_preview": previewText(sumBody, 320),
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			if pass0Failed {
+				citations = map[string][]string{}
+				citationComplete = false
+				return
+			}
+			candidatesXML := renderCandidateSlugsXML(extractedEntities, extractedConcepts)
+			citations, newSlugs, batchCount, citationComplete = s.classifyChunkCitations(
+				ctx, chatModel, candidatesXML,
+				wikiCandidateSlugSet(extractedEntities, extractedConcepts), chunks, lang, batchCtx,
+			)
+			s.tracker().EndSpan(ctx, classifySpan, types.JSONMap{
+				"cited_slugs": len(citations), "new_slugs": len(newSlugs), "batches": batchCount,
+				"top_cited": topCitedSlugs(citations, 8), "new_slugs_sample": previewNewSlugs(newSlugs, 8),
+			})
+		}()
+		wg.Wait()
+		if summaryErr != nil {
+			return wikiMapArtifactValue{}, false, fmt.Errorf("generate summary: %w", summaryErr)
+		}
+		if !hasUsableWikiMapSummary(summaryContent) {
+			return wikiMapArtifactValue{}, false, errors.New("generate summary: empty response")
+		}
+		extractedEntities, extractedConcepts, uncited := mergeCitationsIntoItems(
+			extractedEntities, extractedConcepts, citations, newSlugs,
+		)
+		return wikiMapArtifactValue{
+			Entities: extractedEntities, Concepts: extractedConcepts, SummaryContent: summaryContent,
+			PreviousSlugsFingerprint: wikiPageSlugFingerprint(oldPageSlugs),
+			Pass0Fallback:            pass0Failed, CitationBatches: batchCount, UncitedSlugs: uncited,
+			NewSlugCount: len(newSlugs),
+			DedupContext: dedupContext,
+		}, !pass0Failed && oldPageSlugsComplete && dedupComplete && citationComplete, nil
+	}
+	summarySlug := fmt.Sprintf("summary/%s", slugify(knowledgeID))
+	mapValue, mapCacheHit, mapCacheStatus, err := completeWikiMapArtifact(
+		ctx, s.artifactStore, mapRequest,
+		func(value wikiMapArtifactValue) bool {
+			return oldPageSlugsComplete && s.wikiMapArtifactStateCurrent(
+				ctx, payload.KnowledgeBaseID, summarySlug, oldPageSlugs, value,
+			)
+		},
+		func(winner, computed wikiMapArtifactValue) bool {
+			return oldPageSlugsComplete && s.wikiMapConcurrentWinnerCurrent(
+				ctx, payload.KnowledgeBaseID, summarySlug, winner, computed,
+			)
+		},
+		computeMap,
+	)
+	if err != nil {
+		s.tracker().FailSpan(ctx, wikiSpan, "MAP_FAILED", err.Error(), err)
+		return nil, nil, err
+	}
+	extractedEntities := mapValue.Entities
+	extractedConcepts := mapValue.Concepts
+	summaryContent := mapValue.SummaryContent
+	pass0Failed := mapValue.Pass0Fallback
+	batchCount := mapValue.CitationBatches
+	uncited := mapValue.UncitedSlugs
+	newSlugCount := mapValue.NewSlugCount
+
 	// Wiki summary slug is derived from the knowledge ID rather than the
 	// docTitle (which is typically the upload filename). Filename-based slugs
 	// like "summary/mx5280-pdf" expose the filename in cross-link contexts
 	// that downstream LLM prompts read; a UUID-based slug is uglier but
 	// hallucination-safe.
-	summarySlug := fmt.Sprintf("summary/%s", slugify(knowledgeID))
-	var slugListing string
-	for _, slug := range summaryExtractedPages {
-		if item, ok := slugItems[slug]; ok {
-			aliases := ""
-			if len(item.Aliases) > 0 {
-				aliases = fmt.Sprintf(" (Aliases: %s)", strings.Join(item.Aliases, ", "))
-			}
-			slugListing += fmt.Sprintf("- [[%s]] = %s%s\n", slug, item.Name, aliases)
-		} else {
-			slugListing += fmt.Sprintf("- [[%s]]\n", slug)
-		}
-	}
-
-	// Summary and chunk classification are independent given Pass 0 output —
-	// run them in parallel. Summary handles wiki-link injection; classification
-	// attaches concrete chunk IDs to each candidate slug.
-	var (
-		summaryContent string
-		summaryErr     error
-		citations      map[string][]string
-		newSlugs       []newSlugFromCitation
-		batchCount     int
-	)
-
-	// Both calls run in parallel goroutines under the same wikiSpan
-	// parent — their subspans will visually overlap in the trace view,
-	// which correctly reflects their wall-clock concurrency.
-	summarySpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.summary", types.SpanKindSubSpan, types.JSONMap{
-		"content_chars":   utf8.RuneCountInString(content),
-		"extracted_slugs": len(summaryExtractedPages),
-	})
-	var classifySpan *Span
-	if !pass0Failed {
-		classifySpan = s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.classify", types.SpanKindSubSpan, types.JSONMap{
-			"chunks":     len(chunks),
-			"candidates": len(extractedEntities) + len(extractedConcepts),
-		})
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		summaryContent, summaryErr = s.generateWithTemplate(ctx, chatModel, agent.WikiSummaryPrompt, map[string]string{
-			"Content":            content,
-			"Language":           lang,
-			"ExtractedSlugs":     slugListing,
-			"CustomInstructions": batchCtx.ContentInstructions,
-			"InstructionScope":   "wiki_content",
-		})
-		if summaryErr != nil {
-			s.tracker().FailSpan(ctx, summarySpan, "SUMMARY_FAILED", summaryErr.Error(), summaryErr)
-		} else {
-			sumLine, sumBody := splitSummaryLine(summaryContent)
-			s.tracker().EndSpan(ctx, summarySpan, types.JSONMap{
-				"chars":        utf8.RuneCountInString(summaryContent),
-				"summary_line": previewText(sumLine, 160),
-				"body_preview": previewText(sumBody, 320),
-			})
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		// Skip citation pass when Pass 0 has fallen back to the legacy path —
-		// the legacy output already contains paraphrased Details, so chunk
-		// citations would be redundant and we'd spend LLM calls for nothing.
-		if pass0Failed {
-			citations = map[string][]string{}
-			return
-		}
-		candidatesXML := renderCandidateSlugsXML(extractedEntities, extractedConcepts)
-		citations, newSlugs, batchCount = s.classifyChunkCitations(ctx, chatModel, candidatesXML, chunks, lang, batchCtx)
-		s.tracker().EndSpan(ctx, classifySpan, types.JSONMap{
-			"cited_slugs":      len(citations),
-			"new_slugs":        len(newSlugs),
-			"batches":          batchCount,
-			"top_cited":        topCitedSlugs(citations, 8),
-			"new_slugs_sample": previewNewSlugs(newSlugs, 8),
-		})
-	}()
-	wg.Wait()
-
-	// Merge citations back into the item structs (non-failing; items without
-	// citations simply keep their Description+Details fallback).
-	var uncited int
-	extractedEntities, extractedConcepts, uncited = mergeCitationsIntoItems(extractedEntities, extractedConcepts, citations, newSlugs)
-
-	// Rebuild slugItems so stale entries (for slugs that did not survive the
+	// Build slugItems so stale entries (for slugs that did not survive the
 	// merge) and brand-new slugs discovered by the citation pass are both
 	// reflected in summaryExtractedPages tracking.
-	slugItems = make(map[string]extractedItem, len(extractedEntities)+len(extractedConcepts))
+	slugItems := make(map[string]extractedItem, len(extractedEntities)+len(extractedConcepts))
 	for _, item := range extractedEntities {
 		if item.Slug != "" && item.Name != "" {
 			slugItems[item.Slug] = item
@@ -1325,8 +1385,8 @@ func (s *wikiIngestService) mapOneDocument(
 
 	// Count total distinct chunks cited across all slugs for logging.
 	citedChunkSet := make(map[string]bool)
-	for _, ids := range citations {
-		for _, id := range ids {
+	for _, item := range append(append([]extractedItem(nil), extractedEntities...), extractedConcepts...) {
+		for _, id := range item.SourceChunks {
 			citedChunkSet[id] = true
 		}
 	}
@@ -1339,23 +1399,6 @@ func (s *wikiIngestService) mapOneDocument(
 	var docSummaryLine string
 	var docSummary string
 
-	if summaryErr != nil {
-		// Summary is the headline artifact of an ingested document — a
-		// document with no summary page is half-ingested and leaves the
-		// entity/concept updates hanging without a root to link back to
-		// from the index. Historically we just logged and moved on,
-		// which meant a single transient 504 permanently dropped the
-		// summary page for that document.
-		//
-		// Returning an error here sends the op to failedOps (see the
-		// map-phase loop in ProcessWikiIngest), which requeueFailedOps
-		// appends back onto the pending list so the next batch retries.
-		// The internal retries in generateWithTemplate already exhaust
-		// the LLM's own transient-error budget before we give up here.
-		logger.Errorf(ctx, "wiki ingest: generate summary failed for %s, will requeue: %v", knowledgeID, summaryErr)
-		s.tracker().FailSpan(ctx, wikiSpan, "SUMMARY_FAILED", summaryErr.Error(), summaryErr)
-		return nil, nil, fmt.Errorf("generate summary: %w", summaryErr)
-	}
 	sumLine, sumBody := splitSummaryLine(summaryContent)
 	if sumBody == "" {
 		sumBody = summaryContent
@@ -1483,7 +1526,7 @@ func (s *wikiIngestService) mapOneDocument(
 	logger.Infof(ctx,
 		"wiki ingest: mapped knowledge %s title=%q candidates=%d chunks=%d batches=%d cited_chunks=%d uncited_slugs=%d new_slugs=%d updates=%d reparse_slugs=%d stale_slugs=%d pass0_fallback=%v elapsed=%s",
 		knowledgeID, previewText(docTitle, 80),
-		len(slugItems), len(chunks), batchCount, len(citedChunkSet), uncited, len(newSlugs),
+		len(slugItems), len(chunks), batchCount, len(citedChunkSet), uncited, newSlugCount,
 		len(updates), reparseOverlap, staleCount, pass0Failed,
 		time.Since(docStartedAt).Round(time.Millisecond),
 	)
@@ -1501,7 +1544,7 @@ func (s *wikiIngestService) mapOneDocument(
 		"candidate_slugs":  len(slugItems),
 		"cited_chunks":     len(citedChunkSet),
 		"uncited_slugs":    uncited,
-		"new_slugs":        len(newSlugs),
+		"new_slugs":        newSlugCount,
 		"updates":          len(updates),
 		"reparse_slugs":    reparseOverlap,
 		"stale_slugs":      staleCount,
@@ -1509,6 +1552,8 @@ func (s *wikiIngestService) mapOneDocument(
 		"summary_chars":    utf8.RuneCountInString(docSummary),
 		"pass0_fallback":   pass0Failed,
 		"classify_batches": batchCount,
+		"map_cache_hit":    mapCacheHit,
+		"map_cache_status": mapCacheStatus,
 		"summary_preview":  previewText(docSummaryLine, 160),
 	}
 
@@ -1529,7 +1574,7 @@ func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 	content, lang string,
 	oldPageSlugs map[string]bool,
 	batchCtx *WikiBatchContext,
-) ([]extractedItem, []extractedItem, map[string]extractedItem, error) {
+) ([]extractedItem, []extractedItem, map[string]extractedItem, wikiMapDedupContext, bool, error) {
 	// Only entity/* and concept/* slugs are relevant for LLM slug-continuity —
 	// summary slugs are code-generated from the knowledge ID and never appear
 	// in the extraction output, so including them just wastes tokens and risks
@@ -1557,7 +1602,7 @@ func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 		"InstructionScope":   "wiki_extraction",
 	})
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("combined extraction failed: %w", err)
+		return nil, nil, nil, wikiMapDedupContext{}, false, fmt.Errorf("combined extraction failed: %w", err)
 	}
 
 	extractionJSON = cleanLLMJSON(extractionJSON)
@@ -1565,7 +1610,7 @@ func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 	var result combinedExtraction
 	if err := json.Unmarshal([]byte(extractionJSON), &result); err != nil {
 		logger.Warnf(ctx, "wiki ingest: failed to parse combined extraction JSON: %v\nRaw: %s", err, extractionJSON)
-		return nil, nil, nil, fmt.Errorf("parse combined extraction JSON: %w", err)
+		return nil, nil, nil, wikiMapDedupContext{}, false, fmt.Errorf("parse combined extraction JSON: %w", err)
 	}
 
 	// Dedup pre-filter is dispatched against the wiki page repo via
@@ -1573,7 +1618,9 @@ func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 	// lands the dedup pre-filter degrades to "no dedup" which is the
 	// safe default — the LLM merge call simply doesn't get a candidate
 	// list and the items pass through unchanged.
-	result.Entities, result.Concepts = s.deduplicateExtractedBatch(
+	var dedupComplete bool
+	var dedupContext wikiMapDedupContext
+	result.Entities, result.Concepts, dedupContext, dedupComplete = s.deduplicateExtractedBatch(
 		ctx, chatModel, kbID, result.Entities, result.Concepts,
 	)
 
@@ -1589,7 +1636,7 @@ func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 		}
 	}
 
-	return result.Entities, result.Concepts, slugItems, nil
+	return result.Entities, result.Concepts, slugItems, dedupContext, dedupComplete, nil
 }
 
 // reduceSlugUpdates returns:

--- a/internal/application/service/wiki_ingest_cite.go
+++ b/internal/application/service/wiki_ingest_cite.go
@@ -35,6 +35,23 @@ type citationBatchResult struct {
 	NewSlugs  []newSlugFromCitation `json:"new_slugs"`
 }
 
+func unmarshalRequiredJSONObject(raw string, target any, requiredFields ...string) error {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &object); err != nil {
+		return err
+	}
+	if object == nil {
+		return fmt.Errorf("expected JSON object")
+	}
+	for _, field := range requiredFields {
+		value, ok := object[field]
+		if !ok || strings.TrimSpace(string(value)) == "null" {
+			return fmt.Errorf("missing required JSON field %q", field)
+		}
+	}
+	return json.Unmarshal([]byte(raw), target)
+}
+
 // newSlugFromCitation is the shape of an entry in the "new_slugs" array of
 // WikiChunkCitationPrompt. Mirrors extractedItem but also carries a "type"
 // tag because this prompt emits entities and concepts in a single array.
@@ -46,6 +63,48 @@ type newSlugFromCitation struct {
 	Description  string   `json:"description"`
 	Details      string   `json:"details"`
 	SourceChunks []string `json:"source_chunks"`
+}
+
+func isCompleteNewSlugFromCitation(value newSlugFromCitation) bool {
+	kind := strings.ToLower(strings.TrimSpace(value.Type))
+	if kind != types.WikiPageTypeEntity && kind != types.WikiPageTypeConcept {
+		return false
+	}
+	if strings.TrimSpace(value.Name) == "" || strings.TrimSpace(value.Slug) == "" ||
+		strings.TrimSpace(value.Description) == "" || strings.TrimSpace(value.Details) == "" ||
+		len(value.SourceChunks) == 0 {
+		return false
+	}
+	prefix := kind + "/"
+	return strings.HasPrefix(value.Slug, prefix) && strings.TrimSpace(strings.TrimPrefix(value.Slug, prefix)) != ""
+}
+
+func isCompleteExtractedCandidate(value extractedItem, kind string) bool {
+	if strings.TrimSpace(value.Name) == "" || strings.TrimSpace(value.Slug) == "" ||
+		strings.TrimSpace(value.Description) == "" || strings.TrimSpace(value.Details) == "" {
+		return false
+	}
+	prefix := kind + "/"
+	return strings.HasPrefix(value.Slug, prefix) && strings.TrimSpace(strings.TrimPrefix(value.Slug, prefix)) != ""
+}
+
+func sameNewSlugMetadata(left, right newSlugFromCitation) bool {
+	if strings.ToLower(strings.TrimSpace(left.Type)) != strings.ToLower(strings.TrimSpace(right.Type)) ||
+		left.Name != right.Name || left.Slug != right.Slug ||
+		left.Description != right.Description || left.Details != right.Details ||
+		len(left.Aliases) != len(right.Aliases) {
+		return false
+	}
+	leftAliases := append([]string(nil), left.Aliases...)
+	rightAliases := append([]string(nil), right.Aliases...)
+	sort.Strings(leftAliases)
+	sort.Strings(rightAliases)
+	for i := range leftAliases {
+		if leftAliases[i] != rightAliases[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // citationPipelineOutcome carries the raw numbers produced by the Pass
@@ -66,8 +125,8 @@ type citationPipelineOutcome struct {
 // this pass explicitly does NOT ask the LLM to paraphrase full facts per item;
 // those will come from the chunk-citation pass instead.
 //
-// Returns (entities, concepts, slugItems, error). On LLM or parse failure it
-// returns an error — the caller can then fall back to the legacy extractor.
+// On LLM or parse failure it returns an error so the caller can fall back to
+// the legacy extractor. The final bool reports whether the result is cacheable.
 func (s *wikiIngestService) extractCandidateSlugs(
 	ctx context.Context,
 	chatModel chat.Chat,
@@ -75,7 +134,7 @@ func (s *wikiIngestService) extractCandidateSlugs(
 	content, lang string,
 	oldPageSlugs map[string]bool,
 	batchCtx *WikiBatchContext,
-) ([]extractedItem, []extractedItem, map[string]extractedItem, error) {
+) ([]extractedItem, []extractedItem, map[string]extractedItem, wikiMapDedupContext, bool, error) {
 	var prevSlugsText string
 	if len(oldPageSlugs) > 0 {
 		var sb strings.Builder
@@ -102,18 +161,32 @@ func (s *wikiIngestService) extractCandidateSlugs(
 		"InstructionScope":    "wiki_extraction",
 	})
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("candidate slug extraction failed: %w", err)
+		return nil, nil, nil, wikiMapDedupContext{}, false, fmt.Errorf("candidate slug extraction failed: %w", err)
 	}
 
 	raw = cleanLLMJSON(raw)
 
 	var result combinedExtraction
-	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+	if err := unmarshalRequiredJSONObject(raw, &result, "entities", "concepts"); err != nil {
 		logger.Warnf(ctx, "wiki ingest: failed to parse candidate slug JSON: %v\nRaw: %s", err, raw)
-		return nil, nil, nil, fmt.Errorf("parse candidate slug JSON: %w", err)
+		return nil, nil, nil, wikiMapDedupContext{}, false, fmt.Errorf("parse candidate slug JSON: %w", err)
+	}
+	for _, item := range result.Entities {
+		if !isCompleteExtractedCandidate(item, types.WikiPageTypeEntity) {
+			return nil, nil, nil, wikiMapDedupContext{}, false,
+				fmt.Errorf("parse candidate slug JSON: invalid entity candidate %q", item.Slug)
+		}
+	}
+	for _, item := range result.Concepts {
+		if !isCompleteExtractedCandidate(item, types.WikiPageTypeConcept) {
+			return nil, nil, nil, wikiMapDedupContext{}, false,
+				fmt.Errorf("parse candidate slug JSON: invalid concept candidate %q", item.Slug)
+		}
 	}
 
-	result.Entities, result.Concepts = s.deduplicateExtractedBatch(
+	var dedupComplete bool
+	var dedupContext wikiMapDedupContext
+	result.Entities, result.Concepts, dedupContext, dedupComplete = s.deduplicateExtractedBatch(
 		ctx, chatModel, kbID, result.Entities, result.Concepts,
 	)
 
@@ -129,7 +202,7 @@ func (s *wikiIngestService) extractCandidateSlugs(
 		}
 	}
 
-	return result.Entities, result.Concepts, slugItems, nil
+	return result.Entities, result.Concepts, slugItems, dedupContext, dedupComplete, nil
 }
 
 // chunkBatch groups chunks that will be sent in a single WikiChunkCitationPrompt call.
@@ -164,13 +237,7 @@ func splitChunksIntoCitationBatches(chunks []*types.Chunk) []chunkBatch {
 		return nil
 	}
 
-	// Preserve document order for human-readable citation
-	sort.Slice(filtered, func(i, j int) bool {
-		if filtered[i].ChunkIndex == filtered[j].ChunkIndex {
-			return filtered[i].StartAt < filtered[j].StartAt
-		}
-		return filtered[i].ChunkIndex < filtered[j].ChunkIndex
-	})
+	filtered = canonicalWikiMapChunkOrder(filtered)
 
 	var batches []chunkBatch
 	current := chunkBatch{aliasToID: make(map[string]string)}
@@ -244,6 +311,17 @@ func renderCandidateSlugsXML(entities, concepts []extractedItem) string {
 	return sb.String()
 }
 
+func wikiCandidateSlugSet(entities, concepts []extractedItem) map[string]struct{} {
+	slugs := make(map[string]struct{}, len(entities)+len(concepts))
+	for _, item := range entities {
+		slugs[item.Slug] = struct{}{}
+	}
+	for _, item := range concepts {
+		slugs[item.Slug] = struct{}{}
+	}
+	return slugs
+}
+
 // renderChunksXML formats one batch's chunks into the <chunks> block, using
 // per-batch aliases (c000, c001, ...) instead of raw UUIDs.
 func renderChunksXML(batch chunkBatch) string {
@@ -272,27 +350,29 @@ func renderChunksXML(batch chunkBatch) string {
 // batches are merged into a single slug → union(chunk_id) map, and any
 // "new_slugs" that Pass 0 missed are collected separately.
 //
-// Returns (citations, newSlugs, batchCount). citations is keyed by slug and
-// contains real chunk UUIDs (already translated from batch aliases). newSlugs
-// likewise carry real chunk UUIDs in SourceChunks.
+// citations is keyed by slug and contains real chunk UUIDs (already translated
+// from batch aliases). newSlugs likewise carry real chunk UUIDs in SourceChunks.
+// The final bool reports whether every batch produced a complete response.
 func (s *wikiIngestService) classifyChunkCitations(
 	ctx context.Context,
 	chatModel chat.Chat,
 	candidatesXML string,
+	candidateSlugs map[string]struct{},
 	chunks []*types.Chunk,
 	lang string,
 	batchCtx *WikiBatchContext,
-) (map[string][]string, []newSlugFromCitation, int) {
+) (map[string][]string, []newSlugFromCitation, int, bool) {
 	batches := splitChunksIntoCitationBatches(chunks)
 	if len(batches) == 0 || strings.TrimSpace(candidatesXML) == "" {
-		return map[string][]string{}, nil, 0
+		return map[string][]string{}, nil, 0, true
 	}
 
 	// Merge state. Using sets keyed by (slug, chunkID) to dedup across
 	// batches; order is re-imposed from chunk ChunkIndex at the end.
 	var mu sync.Mutex
 	citationSet := make(map[string]map[string]bool) // slug → set of real chunk IDs
-	var newSlugsAll []newSlugFromCitation
+	newSlugsByBatch := make([][]newSlugFromCitation, len(batches))
+	complete := true
 
 	eg, ectx := errgroup.WithContext(ctx)
 	eg.SetLimit(maxCitationBatchConcurrency)
@@ -308,13 +388,19 @@ func (s *wikiIngestService) classifyChunkCitations(
 				"Language":       lang,
 			})
 			if err != nil {
+				mu.Lock()
+				complete = false
+				mu.Unlock()
 				logger.Warnf(ectx, "wiki ingest: citation batch %d failed: %v", batchIdx, err)
 				return nil // don't abort peer batches
 			}
 			raw = cleanLLMJSON(raw)
 
 			var parsed citationBatchResult
-			if jerr := json.Unmarshal([]byte(raw), &parsed); jerr != nil {
+			if jerr := unmarshalRequiredJSONObject(raw, &parsed, "citations", "new_slugs"); jerr != nil {
+				mu.Lock()
+				complete = false
+				mu.Unlock()
 				logger.Warnf(ectx, "wiki ingest: citation batch %d parse failed: %v\nRaw: %s", batchIdx, jerr, raw)
 				return nil
 			}
@@ -325,6 +411,11 @@ func (s *wikiIngestService) classifyChunkCitations(
 
 			for slug, aliasList := range parsed.Citations {
 				if slug == "" {
+					complete = false
+					continue
+				}
+				if _, ok := candidateSlugs[slug]; !ok {
+					complete = false
 					continue
 				}
 				set, ok := citationSet[slug]
@@ -335,6 +426,7 @@ func (s *wikiIngestService) classifyChunkCitations(
 				for _, alias := range aliasList {
 					realID, known := batch.aliasToID[alias]
 					if !known {
+						complete = false
 						logger.Warnf(ectx, "wiki ingest: citation batch %d referenced unknown chunk alias %q for slug %s", batchIdx, alias, slug)
 						continue
 					}
@@ -343,27 +435,84 @@ func (s *wikiIngestService) classifyChunkCitations(
 			}
 
 			for _, ns := range parsed.NewSlugs {
-				if ns.Slug == "" || ns.Name == "" {
+				_, rediscoveredCandidate := candidateSlugs[ns.Slug]
+				if rediscoveredCandidate {
+					complete = false
+				} else if !isCompleteNewSlugFromCitation(ns) {
+					complete = false
+					continue
+				}
+				if len(ns.SourceChunks) == 0 {
+					complete = false
 					continue
 				}
 				real := make([]string, 0, len(ns.SourceChunks))
+				seenReal := make(map[string]struct{}, len(ns.SourceChunks))
 				for _, alias := range ns.SourceChunks {
-					if id, ok := batch.aliasToID[alias]; ok {
-						real = append(real, id)
+					id, ok := batch.aliasToID[alias]
+					if !ok {
+						complete = false
+						logger.Warnf(ectx, "wiki ingest: citation batch %d referenced unknown chunk alias %q for new slug %s", batchIdx, alias, ns.Slug)
+						continue
 					}
+					if _, seen := seenReal[id]; seen {
+						continue
+					}
+					seenReal[id] = struct{}{}
+					real = append(real, id)
+				}
+				if len(real) == 0 {
+					complete = false
+					continue
+				}
+				if rediscoveredCandidate {
+					set := citationSet[ns.Slug]
+					if set == nil {
+						set = make(map[string]bool)
+						citationSet[ns.Slug] = set
+					}
+					for _, id := range real {
+						set[id] = true
+					}
+					continue
 				}
 				ns.SourceChunks = real
-				newSlugsAll = append(newSlugsAll, ns)
+				newSlugsByBatch[batchIdx] = append(newSlugsByBatch[batchIdx], ns)
 			}
 			return nil
 		})
 	}
 	_ = eg.Wait()
 
-	// Build a stable chunk-order so the final citations come out in document order.
-	chunkOrder := make(map[string]int, len(chunks))
+	// Build the same stable document order used by the map artifact layout.
+	type chunkPosition struct {
+		index, startAt int
+		content        string
+		chunkType      types.ChunkType
+		id             string
+	}
+	chunkOrder := make(map[string]chunkPosition, len(chunks))
 	for _, c := range chunks {
-		chunkOrder[c.ID] = c.ChunkIndex
+		if c == nil {
+			continue
+		}
+		chunkOrder[c.ID] = chunkPosition{c.ChunkIndex, c.StartAt, c.Content, c.ChunkType, c.ID}
+	}
+	lessChunkID := func(leftID, rightID string) bool {
+		left, right := chunkOrder[leftID], chunkOrder[rightID]
+		if left.index != right.index {
+			return left.index < right.index
+		}
+		if left.startAt != right.startAt {
+			return left.startAt < right.startAt
+		}
+		if left.content != right.content {
+			return left.content < right.content
+		}
+		if left.chunkType != right.chunkType {
+			return left.chunkType < right.chunkType
+		}
+		return left.id < right.id
 	}
 
 	out := make(map[string][]string, len(citationSet))
@@ -373,12 +522,30 @@ func (s *wikiIngestService) classifyChunkCitations(
 			ids = append(ids, id)
 		}
 		sort.SliceStable(ids, func(i, j int) bool {
-			return chunkOrder[ids[i]] < chunkOrder[ids[j]]
+			return lessChunkID(ids[i], ids[j])
 		})
 		out[slug] = ids
 	}
 
-	return out, newSlugsAll, len(batches)
+	newSlugsAll := make([]newSlugFromCitation, 0)
+	newSlugMetadata := make(map[string]newSlugFromCitation)
+	for _, batchSlugs := range newSlugsByBatch {
+		for _, ns := range batchSlugs {
+			sort.SliceStable(ns.SourceChunks, func(i, j int) bool {
+				return lessChunkID(ns.SourceChunks[i], ns.SourceChunks[j])
+			})
+			if previous, ok := newSlugMetadata[ns.Slug]; ok {
+				if !sameNewSlugMetadata(previous, ns) {
+					complete = false
+				}
+			} else {
+				newSlugMetadata[ns.Slug] = ns
+			}
+			newSlugsAll = append(newSlugsAll, ns)
+		}
+	}
+
+	return out, newSlugsAll, len(batches), complete
 }
 
 // resolveCitedChunks loads the content of every chunk referenced by the

--- a/internal/application/service/wiki_map_artifact_cache.go
+++ b/internal/application/service/wiki_map_artifact_cache.go
@@ -145,6 +145,9 @@ func completeWikiMapArtifact(
 		} else {
 			cacheStatus = wikiMapCacheStatusStale
 		}
+		if err := store.Invalidate(ctx, key, payload); err != nil {
+			return wikiMapArtifactValue{}, false, cacheStatus, fmt.Errorf("invalidate wiki map artifact: %w", err)
+		}
 	}
 
 	value, cacheable, err := compute()
@@ -153,9 +156,6 @@ func completeWikiMapArtifact(
 	}
 	if !cacheable {
 		return value, false, wikiMapCacheStatusUncacheable, nil
-	}
-	if hit {
-		return value, false, cacheStatus, nil
 	}
 	encoded, err := encodeWikiMapArtifact(value, request.chunks)
 	if err != nil {
@@ -167,10 +167,41 @@ func completeWikiMapArtifact(
 	}
 	canonicalValue, decodeErr := decodeWikiMapArtifact(canonical, request.chunks)
 	if decodeErr != nil {
-		return value, false, wikiMapCacheStatusCorrupt, nil
+		if err := store.Invalidate(ctx, key, canonical); err != nil {
+			return wikiMapArtifactValue{}, false, wikiMapCacheStatusCorrupt, fmt.Errorf("invalidate wiki map artifact: %w", err)
+		}
+		canonical, _, err = store.PutIfAbsent(ctx, key, encoded)
+		if err != nil {
+			return wikiMapArtifactValue{}, false, wikiMapCacheStatusCorrupt, fmt.Errorf("put wiki map artifact repair: %w", err)
+		}
+		canonicalValue, decodeErr = decodeWikiMapArtifact(canonical, request.chunks)
+		if decodeErr != nil {
+			return value, false, wikiMapCacheStatusCorrupt, nil
+		}
+		if isConcurrentWinnerCurrent != nil && !isConcurrentWinnerCurrent(canonicalValue, value) {
+			return value, false, wikiMapCacheStatusCorrupt, nil
+		}
+		return canonicalValue, false, wikiMapCacheStatusCorrupt, nil
 	}
 	if !created && isConcurrentWinnerCurrent != nil && !isConcurrentWinnerCurrent(canonicalValue, value) {
-		return value, false, wikiMapCacheStatusStale, nil
+		if err := store.Invalidate(ctx, key, canonical); err != nil {
+			return wikiMapArtifactValue{}, false, wikiMapCacheStatusStale, fmt.Errorf("invalidate wiki map artifact: %w", err)
+		}
+		canonical, created, err = store.PutIfAbsent(ctx, key, encoded)
+		if err != nil {
+			return wikiMapArtifactValue{}, false, wikiMapCacheStatusStale, fmt.Errorf("put wiki map artifact repair: %w", err)
+		}
+		canonicalValue, decodeErr = decodeWikiMapArtifact(canonical, request.chunks)
+		if decodeErr != nil {
+			return value, false, wikiMapCacheStatusCorrupt, nil
+		}
+		if !created && !isConcurrentWinnerCurrent(canonicalValue, value) {
+			return value, false, wikiMapCacheStatusStale, nil
+		}
+		return canonicalValue, false, wikiMapCacheStatusStale, nil
+	}
+	if hit {
+		return canonicalValue, false, cacheStatus, nil
 	}
 	return canonicalValue, false, wikiMapCacheStatusStored, nil
 }

--- a/internal/application/service/wiki_map_artifact_cache.go
+++ b/internal/application/service/wiki_map_artifact_cache.go
@@ -1,0 +1,612 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/Tencent/WeKnora/internal/agent"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+const (
+	wikiMapArtifactStage         = "wiki.map.document"
+	wikiMapArtifactKeyVersion    = uint16(1)
+	wikiMapArtifactSchemaVersion = uint8(2)
+
+	wikiMapPromptSuiteVersion   = "wiki-map-prompts-v1"
+	wikiMapCanonicalizerVersion = "wiki-map-canonicalizer-v1"
+	wikiMapChatOptionsVersion   = "temperature=0.3;thinking=false"
+
+	wikiMapCacheStatusBypass      = "bypass"
+	wikiMapCacheStatusHit         = "hit"
+	wikiMapCacheStatusMiss        = "miss"
+	wikiMapCacheStatusStored      = "stored"
+	wikiMapCacheStatusCorrupt     = "corrupt"
+	wikiMapCacheStatusStale       = "stale"
+	wikiMapCacheStatusUncacheable = "uncacheable"
+)
+
+type wikiMapArtifactRequest struct {
+	tenantID               uint64
+	knowledgeBaseID        string
+	knowledgeID            string
+	modelID                string
+	modelName              string
+	modelRevision          string
+	content                string
+	chunks                 []*types.Chunk
+	language               string
+	granularity            types.WikiExtractionGranularity
+	contentInstructions    string
+	extractionInstructions string
+	promptSuiteVersion     string
+	canonicalizerVersion   string
+}
+
+type wikiMapArtifactValue struct {
+	Entities                 []extractedItem
+	Concepts                 []extractedItem
+	SummaryContent           string
+	PreviousSlugsFingerprint string
+	Pass0Fallback            bool
+	CitationBatches          int
+	UncitedSlugs             int
+	NewSlugCount             int
+	DedupContext             wikiMapDedupContext
+}
+
+type wikiMapDedupContext struct {
+	Entities                    []extractedItem
+	Concepts                    []extractedItem
+	CandidateSlugs              []string
+	CandidateFingerprint        string
+	ReducedCandidateFingerprint string
+	OutputPageFingerprints      map[string]string
+}
+
+type wikiMapCanonicalChunk struct {
+	Content    string          `json:"content"`
+	ChunkIndex int             `json:"chunk_index"`
+	StartAt    int             `json:"start_at"`
+	ChunkType  types.ChunkType `json:"chunk_type"`
+	ID         string          `json:"-"`
+}
+
+type wikiMapArtifactItem struct {
+	Name           string   `json:"name"`
+	Slug           string   `json:"slug"`
+	Aliases        []string `json:"aliases,omitempty"`
+	Description    string   `json:"description,omitempty"`
+	Details        string   `json:"details,omitempty"`
+	SourceOrdinals []int    `json:"source_ordinals,omitempty"`
+}
+
+type wikiMapArtifactPayload struct {
+	Version                  uint8                 `json:"version"`
+	ChunkFingerprints        []string              `json:"chunk_fingerprints"`
+	Entities                 []wikiMapArtifactItem `json:"entities,omitempty"`
+	Concepts                 []wikiMapArtifactItem `json:"concepts,omitempty"`
+	SummaryContent           string                `json:"summary_content"`
+	PreviousSlugsFingerprint string                `json:"previous_slugs_fingerprint,omitempty"`
+	Pass0Fallback            bool                  `json:"pass0_fallback,omitempty"`
+	CitationBatches          int                   `json:"citation_batches,omitempty"`
+	UncitedSlugs             int                   `json:"uncited_slugs,omitempty"`
+	NewSlugCount             int                   `json:"new_slug_count,omitempty"`
+	DedupEntities            []wikiMapArtifactItem `json:"dedup_entities,omitempty"`
+	DedupConcepts            []wikiMapArtifactItem `json:"dedup_concepts,omitempty"`
+	DedupCandidateSlugs      []string              `json:"dedup_candidate_slugs,omitempty"`
+	DedupFingerprint         string                `json:"dedup_fingerprint"`
+	DedupReducedFingerprint  string                `json:"dedup_reduced_fingerprint,omitempty"`
+	DedupOutputFingerprints  map[string]string     `json:"dedup_output_fingerprints,omitempty"`
+}
+
+func hasUsableWikiMapSummary(raw string) bool {
+	summary, content := splitSummaryLine(raw)
+	return strings.TrimSpace(summary) != "" || strings.TrimSpace(content) != ""
+}
+
+func completeWikiMapArtifact(
+	ctx context.Context,
+	store interfaces.ProcessingArtifactStore,
+	request wikiMapArtifactRequest,
+	isCurrent func(wikiMapArtifactValue) bool,
+	isConcurrentWinnerCurrent func(winner, computed wikiMapArtifactValue) bool,
+	compute func() (wikiMapArtifactValue, bool, error),
+) (wikiMapArtifactValue, bool, string, error) {
+	if store == nil || strings.TrimSpace(request.modelRevision) == "" {
+		value, _, err := compute()
+		return value, false, wikiMapCacheStatusBypass, err
+	}
+
+	key, err := newWikiMapArtifactKey(request)
+	if err != nil {
+		value, _, computeErr := compute()
+		return value, false, wikiMapCacheStatusBypass, computeErr
+	}
+	payload, hit, err := store.Get(ctx, key)
+	if err != nil {
+		return wikiMapArtifactValue{}, false, "", fmt.Errorf("get wiki map artifact: %w", err)
+	}
+	cacheStatus := wikiMapCacheStatusMiss
+	if hit {
+		value, decodeErr := decodeWikiMapArtifact(payload, request.chunks)
+		if decodeErr == nil && (isCurrent == nil || isCurrent(value)) {
+			return value, true, wikiMapCacheStatusHit, nil
+		}
+		if decodeErr != nil {
+			cacheStatus = wikiMapCacheStatusCorrupt
+		} else {
+			cacheStatus = wikiMapCacheStatusStale
+		}
+	}
+
+	value, cacheable, err := compute()
+	if err != nil {
+		return wikiMapArtifactValue{}, false, cacheStatus, err
+	}
+	if !cacheable {
+		return value, false, wikiMapCacheStatusUncacheable, nil
+	}
+	if hit {
+		return value, false, cacheStatus, nil
+	}
+	encoded, err := encodeWikiMapArtifact(value, request.chunks)
+	if err != nil {
+		return value, false, wikiMapCacheStatusUncacheable, nil
+	}
+	canonical, created, err := store.PutIfAbsent(ctx, key, encoded)
+	if err != nil {
+		return wikiMapArtifactValue{}, false, cacheStatus, fmt.Errorf("put wiki map artifact: %w", err)
+	}
+	canonicalValue, decodeErr := decodeWikiMapArtifact(canonical, request.chunks)
+	if decodeErr != nil {
+		return value, false, wikiMapCacheStatusCorrupt, nil
+	}
+	if !created && isConcurrentWinnerCurrent != nil && !isConcurrentWinnerCurrent(canonicalValue, value) {
+		return value, false, wikiMapCacheStatusStale, nil
+	}
+	return canonicalValue, false, wikiMapCacheStatusStored, nil
+}
+
+func newWikiMapArtifactKey(request wikiMapArtifactRequest) (types.ProcessingArtifactKey, error) {
+	if strings.TrimSpace(request.modelID) == "" || strings.TrimSpace(request.modelName) == "" {
+		return types.ProcessingArtifactKey{}, errors.New("wiki map artifact model identity must not be empty")
+	}
+	if strings.TrimSpace(request.modelRevision) == "" {
+		return types.ProcessingArtifactKey{}, errors.New("wiki map artifact model revision must not be empty")
+	}
+	if strings.TrimSpace(request.knowledgeBaseID) == "" || strings.TrimSpace(request.knowledgeID) == "" {
+		return types.ProcessingArtifactKey{}, errors.New("wiki map artifact knowledge scope must not be empty")
+	}
+	if strings.TrimSpace(request.promptSuiteVersion) == "" || strings.TrimSpace(request.canonicalizerVersion) == "" {
+		return types.ProcessingArtifactKey{}, errors.New("wiki map artifact versions must not be empty")
+	}
+	if !utf8.ValidString(request.content) || !utf8.ValidString(request.contentInstructions) ||
+		!utf8.ValidString(request.extractionInstructions) {
+		return types.ProcessingArtifactKey{}, errors.New("wiki map artifact input is not valid UTF-8")
+	}
+
+	layout, err := canonicalWikiMapChunks(request.chunks)
+	if err != nil {
+		return types.ProcessingArtifactKey{}, err
+	}
+	encodedLayout, err := json.Marshal(layout)
+	if err != nil {
+		return types.ProcessingArtifactKey{}, fmt.Errorf("encode wiki map chunk layout: %w", err)
+	}
+
+	return types.NewProcessingArtifactKey(
+		request.tenantID,
+		wikiMapArtifactStage,
+		wikiMapArtifactKeyVersion,
+		[]byte(request.knowledgeBaseID),
+		[]byte(request.knowledgeID),
+		[]byte(request.modelID),
+		[]byte(request.modelName),
+		[]byte(request.modelRevision),
+		[]byte(request.content),
+		encodedLayout,
+		[]byte(request.language),
+		[]byte(request.granularity.Normalize()),
+		[]byte(request.contentInstructions),
+		[]byte(request.extractionInstructions),
+		[]byte(request.promptSuiteVersion),
+		wikiMapPromptDigest(),
+		[]byte(request.canonicalizerVersion),
+		[]byte(wikiMapChatOptionsVersion),
+	)
+}
+
+func wikiMapPromptDigest() []byte {
+	prompts, _ := json.Marshal([]string{
+		agent.WikiCandidateSlugPrompt,
+		agent.WikiKnowledgeExtractPrompt,
+		agent.WikiDeduplicationPrompt,
+		agent.WikiSummaryPrompt,
+		agent.WikiChunkCitationPrompt,
+		agent.WikiGranularityGuidanceFocused,
+		agent.WikiGranularityGuidanceStandard,
+		agent.WikiGranularityGuidanceExhaustive,
+	})
+	digest := sha256.Sum256(prompts)
+	return digest[:]
+}
+
+func encodeWikiMapArtifact(value wikiMapArtifactValue, chunks []*types.Chunk) ([]byte, error) {
+	layout, err := canonicalWikiMapChunks(chunks)
+	if err != nil {
+		return nil, err
+	}
+	idToOrdinal := make(map[string]int, len(layout))
+	for ordinal, chunk := range layout {
+		if chunk.ID == "" {
+			return nil, errors.New("wiki map artifact chunk ID must not be empty")
+		}
+		if _, exists := idToOrdinal[chunk.ID]; exists {
+			return nil, fmt.Errorf("wiki map artifact duplicate chunk ID %q", chunk.ID)
+		}
+		idToOrdinal[chunk.ID] = ordinal
+	}
+
+	if !hasUsableWikiMapSummary(value.SummaryContent) {
+		return nil, errors.New("wiki map artifact summary must not be empty")
+	}
+	if !utf8.ValidString(value.SummaryContent) {
+		return nil, errors.New("wiki map artifact summary is not valid UTF-8")
+	}
+	seenSlugs := make(map[string]struct{}, len(value.Entities)+len(value.Concepts))
+	encodeItems := func(items []extractedItem, kind string) ([]wikiMapArtifactItem, error) {
+		encoded := make([]wikiMapArtifactItem, 0, len(items))
+		for _, item := range items {
+			if err := validateWikiMapExtractedItem(item, kind); err != nil {
+				return nil, err
+			}
+			if _, exists := seenSlugs[item.Slug]; exists {
+				return nil, fmt.Errorf("wiki map artifact contains duplicate slug %q", item.Slug)
+			}
+			seenSlugs[item.Slug] = struct{}{}
+			ordinals := make([]int, 0, len(item.SourceChunks))
+			seenOrdinals := make(map[int]struct{}, len(item.SourceChunks))
+			for _, chunkID := range item.SourceChunks {
+				ordinal, ok := idToOrdinal[chunkID]
+				if !ok {
+					return nil, fmt.Errorf("wiki map artifact references unknown chunk %q", chunkID)
+				}
+				if _, exists := seenOrdinals[ordinal]; exists {
+					return nil, fmt.Errorf("wiki map artifact contains duplicate source chunk %q", chunkID)
+				}
+				seenOrdinals[ordinal] = struct{}{}
+				ordinals = append(ordinals, ordinal)
+			}
+			encoded = append(encoded, wikiMapArtifactItem{
+				Name:           item.Name,
+				Slug:           item.Slug,
+				Aliases:        append([]string(nil), item.Aliases...),
+				Description:    item.Description,
+				Details:        item.Details,
+				SourceOrdinals: ordinals,
+			})
+		}
+		for i := range encoded {
+			sort.Strings(encoded[i].Aliases)
+			sort.Ints(encoded[i].SourceOrdinals)
+		}
+		sort.Slice(encoded, func(i, j int) bool {
+			if encoded[i].Slug != encoded[j].Slug {
+				return encoded[i].Slug < encoded[j].Slug
+			}
+			return encoded[i].Name < encoded[j].Name
+		})
+		return encoded, nil
+	}
+
+	entities, err := encodeItems(value.Entities, types.WikiPageTypeEntity)
+	if err != nil {
+		return nil, err
+	}
+	concepts, err := encodeItems(value.Concepts, types.WikiPageTypeConcept)
+	if err != nil {
+		return nil, err
+	}
+	seenSlugs = make(map[string]struct{}, len(value.DedupContext.Entities)+len(value.DedupContext.Concepts))
+	dedupEntities, err := encodeItems(value.DedupContext.Entities, types.WikiPageTypeEntity)
+	if err != nil {
+		return nil, err
+	}
+	dedupConcepts, err := encodeItems(value.DedupContext.Concepts, types.WikiPageTypeConcept)
+	if err != nil {
+		return nil, err
+	}
+	dedupCandidateSlugs, err := canonicalWikiMapCandidateSlugs(value.DedupContext.CandidateSlugs)
+	if err != nil {
+		return nil, err
+	}
+	dedupOutputFingerprints, err := canonicalWikiMapPageFingerprints(value.DedupContext.OutputPageFingerprints)
+	if err != nil {
+		return nil, err
+	}
+	payload := wikiMapArtifactPayload{
+		Version:                  wikiMapArtifactSchemaVersion,
+		ChunkFingerprints:        wikiMapChunkFingerprints(layout),
+		Entities:                 entities,
+		Concepts:                 concepts,
+		SummaryContent:           value.SummaryContent,
+		PreviousSlugsFingerprint: value.PreviousSlugsFingerprint,
+		Pass0Fallback:            value.Pass0Fallback,
+		CitationBatches:          value.CitationBatches,
+		UncitedSlugs:             value.UncitedSlugs,
+		NewSlugCount:             value.NewSlugCount,
+		DedupEntities:            dedupEntities,
+		DedupConcepts:            dedupConcepts,
+		DedupCandidateSlugs:      dedupCandidateSlugs,
+		DedupFingerprint:         value.DedupContext.CandidateFingerprint,
+		DedupReducedFingerprint:  value.DedupContext.ReducedCandidateFingerprint,
+		DedupOutputFingerprints:  dedupOutputFingerprints,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("encode wiki map artifact: %w", err)
+	}
+	return encoded, nil
+}
+
+func decodeWikiMapArtifact(payload []byte, chunks []*types.Chunk) (wikiMapArtifactValue, error) {
+	if !utf8.Valid(payload) {
+		return wikiMapArtifactValue{}, errors.New("wiki map artifact payload is not valid UTF-8")
+	}
+	var stored wikiMapArtifactPayload
+	if err := json.Unmarshal(payload, &stored); err != nil {
+		return wikiMapArtifactValue{}, fmt.Errorf("decode wiki map artifact: %w", err)
+	}
+	if stored.Version != wikiMapArtifactSchemaVersion {
+		return wikiMapArtifactValue{}, fmt.Errorf("unsupported wiki map artifact version %d", stored.Version)
+	}
+	layout, err := canonicalWikiMapChunks(chunks)
+	if err != nil {
+		return wikiMapArtifactValue{}, err
+	}
+	if !sameWikiMapFingerprints(stored.ChunkFingerprints, wikiMapChunkFingerprints(layout)) {
+		return wikiMapArtifactValue{}, errors.New("wiki map artifact chunk layout does not match")
+	}
+
+	if !hasUsableWikiMapSummary(stored.SummaryContent) {
+		return wikiMapArtifactValue{}, errors.New("wiki map artifact summary must not be empty")
+	}
+	if !utf8.ValidString(stored.SummaryContent) {
+		return wikiMapArtifactValue{}, errors.New("wiki map artifact summary is not valid UTF-8")
+	}
+	seenSlugs := make(map[string]struct{}, len(stored.Entities)+len(stored.Concepts))
+	decodeItems := func(items []wikiMapArtifactItem, kind string) ([]extractedItem, error) {
+		decoded := make([]extractedItem, 0, len(items))
+		for _, item := range items {
+			sourceChunks := make([]string, 0, len(item.SourceOrdinals))
+			seenOrdinals := make(map[int]struct{}, len(item.SourceOrdinals))
+			for _, ordinal := range item.SourceOrdinals {
+				if ordinal < 0 || ordinal >= len(layout) || layout[ordinal].ID == "" {
+					return nil, fmt.Errorf("wiki map artifact source ordinal %d is invalid", ordinal)
+				}
+				if _, exists := seenOrdinals[ordinal]; exists {
+					return nil, fmt.Errorf("wiki map artifact source ordinal %d is duplicated", ordinal)
+				}
+				seenOrdinals[ordinal] = struct{}{}
+				sourceChunks = append(sourceChunks, layout[ordinal].ID)
+			}
+			decodedItem := extractedItem{
+				Name:         item.Name,
+				Slug:         item.Slug,
+				Aliases:      append([]string(nil), item.Aliases...),
+				Description:  item.Description,
+				Details:      item.Details,
+				SourceChunks: sourceChunks,
+			}
+			if err := validateWikiMapExtractedItem(decodedItem, kind); err != nil {
+				return nil, err
+			}
+			if _, exists := seenSlugs[decodedItem.Slug]; exists {
+				return nil, fmt.Errorf("wiki map artifact contains duplicate slug %q", decodedItem.Slug)
+			}
+			seenSlugs[decodedItem.Slug] = struct{}{}
+			decoded = append(decoded, decodedItem)
+		}
+		return decoded, nil
+	}
+
+	entities, err := decodeItems(stored.Entities, types.WikiPageTypeEntity)
+	if err != nil {
+		return wikiMapArtifactValue{}, err
+	}
+	concepts, err := decodeItems(stored.Concepts, types.WikiPageTypeConcept)
+	if err != nil {
+		return wikiMapArtifactValue{}, err
+	}
+	seenSlugs = make(map[string]struct{}, len(stored.DedupEntities)+len(stored.DedupConcepts))
+	dedupEntities, err := decodeItems(stored.DedupEntities, types.WikiPageTypeEntity)
+	if err != nil {
+		return wikiMapArtifactValue{}, err
+	}
+	dedupConcepts, err := decodeItems(stored.DedupConcepts, types.WikiPageTypeConcept)
+	if err != nil {
+		return wikiMapArtifactValue{}, err
+	}
+	dedupCandidateSlugs, err := canonicalWikiMapCandidateSlugs(stored.DedupCandidateSlugs)
+	if err != nil {
+		return wikiMapArtifactValue{}, err
+	}
+	dedupOutputFingerprints, err := canonicalWikiMapPageFingerprints(stored.DedupOutputFingerprints)
+	if err != nil {
+		return wikiMapArtifactValue{}, err
+	}
+	return wikiMapArtifactValue{
+		Entities:                 entities,
+		Concepts:                 concepts,
+		SummaryContent:           stored.SummaryContent,
+		PreviousSlugsFingerprint: stored.PreviousSlugsFingerprint,
+		Pass0Fallback:            stored.Pass0Fallback,
+		CitationBatches:          stored.CitationBatches,
+		UncitedSlugs:             stored.UncitedSlugs,
+		NewSlugCount:             stored.NewSlugCount,
+		DedupContext: wikiMapDedupContext{
+			Entities: dedupEntities, Concepts: dedupConcepts,
+			CandidateSlugs:              dedupCandidateSlugs,
+			CandidateFingerprint:        stored.DedupFingerprint,
+			ReducedCandidateFingerprint: stored.DedupReducedFingerprint,
+			OutputPageFingerprints:      dedupOutputFingerprints,
+		},
+	}, nil
+}
+
+func canonicalWikiMapCandidateSlugs(slugs []string) ([]string, error) {
+	canonical := append([]string(nil), slugs...)
+	sort.Strings(canonical)
+	for i, slug := range canonical {
+		if strings.TrimSpace(slug) == "" || !utf8.ValidString(slug) {
+			return nil, errors.New("wiki map artifact dedup candidate slug is invalid")
+		}
+		if i > 0 && canonical[i-1] == slug {
+			return nil, fmt.Errorf("wiki map artifact duplicate dedup candidate slug %q", slug)
+		}
+	}
+	return canonical, nil
+}
+
+func canonicalWikiMapPageFingerprints(fingerprints map[string]string) (map[string]string, error) {
+	if len(fingerprints) == 0 {
+		return nil, nil
+	}
+	canonical := make(map[string]string, len(fingerprints))
+	for slug, fingerprint := range fingerprints {
+		if strings.TrimSpace(slug) == "" || !utf8.ValidString(slug) ||
+			strings.TrimSpace(fingerprint) == "" || !utf8.ValidString(fingerprint) {
+			return nil, errors.New("wiki map artifact output page fingerprint is invalid")
+		}
+		canonical[slug] = fingerprint
+	}
+	return canonical, nil
+}
+
+func canonicalWikiMapChunks(chunks []*types.Chunk) ([]wikiMapCanonicalChunk, error) {
+	canonical := make([]wikiMapCanonicalChunk, 0, len(chunks))
+	seenIDs := make(map[string]struct{}, len(chunks))
+	seenDescriptors := make(map[string]struct{}, len(chunks))
+	for _, chunk := range canonicalWikiMapChunkOrder(chunks) {
+		if chunk == nil || chunk.Content == "" {
+			continue
+		}
+		if chunk.ChunkType != "" && chunk.ChunkType != types.ChunkTypeText {
+			continue
+		}
+		if !utf8.ValidString(chunk.Content) {
+			return nil, errors.New("wiki map artifact chunk content is not valid UTF-8")
+		}
+		if strings.TrimSpace(chunk.ID) == "" {
+			return nil, errors.New("wiki map artifact chunk ID must not be empty")
+		}
+		if _, exists := seenIDs[chunk.ID]; exists {
+			return nil, fmt.Errorf("wiki map artifact duplicate chunk ID %q", chunk.ID)
+		}
+		seenIDs[chunk.ID] = struct{}{}
+		descriptor, err := json.Marshal(struct {
+			Content    string          `json:"content"`
+			ChunkIndex int             `json:"chunk_index"`
+			StartAt    int             `json:"start_at"`
+			ChunkType  types.ChunkType `json:"chunk_type"`
+		}{chunk.Content, chunk.ChunkIndex, chunk.StartAt, chunk.ChunkType})
+		if err != nil {
+			return nil, fmt.Errorf("encode wiki map chunk descriptor: %w", err)
+		}
+		if _, exists := seenDescriptors[string(descriptor)]; exists {
+			return nil, errors.New("wiki map artifact contains an ambiguous chunk layout")
+		}
+		seenDescriptors[string(descriptor)] = struct{}{}
+		canonical = append(canonical, wikiMapCanonicalChunk{
+			ID:         chunk.ID,
+			Content:    chunk.Content,
+			ChunkIndex: chunk.ChunkIndex,
+			StartAt:    chunk.StartAt,
+			ChunkType:  chunk.ChunkType,
+		})
+	}
+	return canonical, nil
+}
+
+func canonicalWikiMapChunkOrder(chunks []*types.Chunk) []*types.Chunk {
+	ordered := append([]*types.Chunk(nil), chunks...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		left, right := ordered[i], ordered[j]
+		if left == nil || right == nil {
+			return left != nil
+		}
+		if left.ChunkIndex != right.ChunkIndex {
+			return left.ChunkIndex < right.ChunkIndex
+		}
+		if left.StartAt != right.StartAt {
+			return left.StartAt < right.StartAt
+		}
+		if left.Content != right.Content {
+			return left.Content < right.Content
+		}
+		if left.ChunkType != right.ChunkType {
+			return left.ChunkType < right.ChunkType
+		}
+		return left.ID < right.ID
+	})
+	return ordered
+}
+
+func validateWikiMapExtractedItem(item extractedItem, kind string) error {
+	if !isCompleteExtractedCandidate(item, kind) {
+		return fmt.Errorf("wiki map artifact contains incomplete %s item %q", kind, item.Slug)
+	}
+	values := append([]string{item.Name, item.Slug, item.Description, item.Details}, item.Aliases...)
+	values = append(values, item.SourceChunks...)
+	for _, value := range values {
+		if !utf8.ValidString(value) {
+			return errors.New("wiki map artifact item is not valid UTF-8")
+		}
+	}
+	return nil
+}
+
+func cloneWikiMapItems(items []extractedItem) []extractedItem {
+	cloned := make([]extractedItem, len(items))
+	for i, item := range items {
+		cloned[i] = item
+		cloned[i].Aliases = append([]string(nil), item.Aliases...)
+		cloned[i].SourceChunks = append([]string(nil), item.SourceChunks...)
+	}
+	return cloned
+}
+
+func wikiMapChunkFingerprints(chunks []wikiMapCanonicalChunk) []string {
+	fingerprints := make([]string, 0, len(chunks))
+	for _, chunk := range chunks {
+		descriptor, _ := json.Marshal(struct {
+			Content    string          `json:"content"`
+			ChunkIndex int             `json:"chunk_index"`
+			StartAt    int             `json:"start_at"`
+			ChunkType  types.ChunkType `json:"chunk_type"`
+		}{chunk.Content, chunk.ChunkIndex, chunk.StartAt, chunk.ChunkType})
+		digest := sha256.Sum256(descriptor)
+		fingerprints = append(fingerprints, fmt.Sprintf("%x", digest[:]))
+	}
+	return fingerprints
+}
+
+func sameWikiMapFingerprints(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/application/service/wiki_map_artifact_cache_test.go
+++ b/internal/application/service/wiki_map_artifact_cache_test.go
@@ -1,0 +1,379 @@
+package service
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/agent"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWikiMapPromptDigestCoversInjectedGuidance(t *testing.T) {
+	prompts, err := json.Marshal([]string{
+		agent.WikiCandidateSlugPrompt,
+		agent.WikiKnowledgeExtractPrompt,
+		agent.WikiDeduplicationPrompt,
+		agent.WikiSummaryPrompt,
+		agent.WikiChunkCitationPrompt,
+		agent.WikiGranularityGuidanceFocused,
+		agent.WikiGranularityGuidanceStandard,
+		agent.WikiGranularityGuidanceExhaustive,
+	})
+	require.NoError(t, err)
+	want := sha256.Sum256(prompts)
+
+	assert.Equal(t, want[:], wikiMapPromptDigest())
+}
+
+func TestWikiMapArtifactKeyInvalidatesCanonicalInputs(t *testing.T) {
+	request := testWikiMapArtifactRequest()
+	base, err := newWikiMapArtifactKey(request)
+	require.NoError(t, err)
+	assert.Equal(t, wikiMapArtifactStage, base.Stage)
+
+	stable, err := newWikiMapArtifactKey(request)
+	require.NoError(t, err)
+	assert.Equal(t, base, stable)
+
+	tests := []struct {
+		name   string
+		mutate func(*wikiMapArtifactRequest)
+	}{
+		{name: "tenant", mutate: func(r *wikiMapArtifactRequest) { r.tenantID++ }},
+		{name: "knowledge base", mutate: func(r *wikiMapArtifactRequest) { r.knowledgeBaseID += " changed" }},
+		{name: "knowledge", mutate: func(r *wikiMapArtifactRequest) { r.knowledgeID += " changed" }},
+		{name: "model ID", mutate: func(r *wikiMapArtifactRequest) { r.modelID += " changed" }},
+		{name: "model name", mutate: func(r *wikiMapArtifactRequest) { r.modelName += " changed" }},
+		{name: "content", mutate: func(r *wikiMapArtifactRequest) { r.content += " changed" }},
+		{name: "chunk content", mutate: func(r *wikiMapArtifactRequest) { r.chunks[0].Content += " changed" }},
+		{name: "chunk index", mutate: func(r *wikiMapArtifactRequest) { r.chunks[0].ChunkIndex++ }},
+		{name: "chunk start", mutate: func(r *wikiMapArtifactRequest) { r.chunks[0].StartAt++ }},
+		{name: "language", mutate: func(r *wikiMapArtifactRequest) { r.language = "English" }},
+		{name: "granularity", mutate: func(r *wikiMapArtifactRequest) { r.granularity = types.WikiExtractionExhaustive }},
+		{name: "content instructions", mutate: func(r *wikiMapArtifactRequest) { r.contentInstructions += " changed" }},
+		{name: "extraction instructions", mutate: func(r *wikiMapArtifactRequest) { r.extractionInstructions += " changed" }},
+		{name: "model revision", mutate: func(r *wikiMapArtifactRequest) { r.modelRevision += " changed" }},
+		{name: "prompt suite", mutate: func(r *wikiMapArtifactRequest) { r.promptSuiteVersion += " changed" }},
+		{name: "canonicalizer", mutate: func(r *wikiMapArtifactRequest) { r.canonicalizerVersion += " changed" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changed := testWikiMapArtifactRequest()
+			tt.mutate(&changed)
+			key, keyErr := newWikiMapArtifactKey(changed)
+			require.NoError(t, keyErr)
+			assert.NotEqual(t, base, key)
+		})
+	}
+}
+
+func TestWikiMapArtifactRejectsBlankOrMissingSummary(t *testing.T) {
+	request := testWikiMapArtifactRequest()
+
+	for _, summary := range []string{" \t\n", "SUMMARY:", "SUMMARY：\n"} {
+		t.Run("invalid summary on encode", func(t *testing.T) {
+			_, err := encodeWikiMapArtifact(
+				wikiMapArtifactValue{SummaryContent: summary}, request.chunks,
+			)
+			require.Error(t, err)
+		})
+	}
+
+	t.Run("missing summary on decode", func(t *testing.T) {
+		encoded, err := encodeWikiMapArtifact(
+			wikiMapArtifactValue{SummaryContent: "SUMMARY: valid"}, request.chunks,
+		)
+		require.NoError(t, err)
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(encoded, &payload))
+		delete(payload, "summary_content")
+		encoded, err = json.Marshal(payload)
+		require.NoError(t, err)
+
+		_, err = decodeWikiMapArtifact(encoded, request.chunks)
+		require.Error(t, err)
+	})
+
+	t.Run("semantically empty summary on decode", func(t *testing.T) {
+		encoded, err := encodeWikiMapArtifact(
+			wikiMapArtifactValue{SummaryContent: "SUMMARY: valid"}, request.chunks,
+		)
+		require.NoError(t, err)
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(encoded, &payload))
+		payload["summary_content"] = "SUMMARY:"
+		encoded, err = json.Marshal(payload)
+		require.NoError(t, err)
+
+		_, err = decodeWikiMapArtifact(encoded, request.chunks)
+		require.Error(t, err)
+	})
+}
+
+func TestWikiMapArtifactCodecRemovesAndRebindsChunkOwnership(t *testing.T) {
+	oldChunks := testWikiMapChunks("old-chunk-1", "old-chunk-2")
+	value := wikiMapArtifactValue{
+		Entities: []extractedItem{{
+			Name:         "Acme",
+			Slug:         "entity/acme",
+			Description:  "Company",
+			Details:      "Company details",
+			SourceChunks: []string{"old-chunk-2"},
+		}},
+		Concepts: []extractedItem{{
+			Name:         "RAG",
+			Slug:         "concept/rag",
+			Description:  "Method",
+			Details:      "Method details",
+			SourceChunks: []string{"old-chunk-1", "old-chunk-2"},
+		}},
+		SummaryContent:  "SUMMARY: document summary",
+		CitationBatches: 1,
+	}
+
+	payload, err := encodeWikiMapArtifact(value, oldChunks)
+	require.NoError(t, err)
+	assert.False(t, bytes.Contains(payload, []byte("old-chunk-1")))
+	assert.False(t, bytes.Contains(payload, []byte("old-chunk-2")))
+
+	currentChunks := testWikiMapChunks("current-chunk-1", "current-chunk-2")
+	got, err := decodeWikiMapArtifact(payload, currentChunks)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"current-chunk-2"}, got.Entities[0].SourceChunks)
+	assert.Equal(t, []string{"current-chunk-1", "current-chunk-2"}, got.Concepts[0].SourceChunks)
+	assert.Equal(t, value.SummaryContent, got.SummaryContent)
+}
+
+func TestWikiMapArtifactCodecRejectsInvalidOwnership(t *testing.T) {
+	chunks := testWikiMapChunks("chunk-1", "chunk-2")
+	_, err := encodeWikiMapArtifact(wikiMapArtifactValue{
+		Entities: []extractedItem{{
+			Name: "Acme", Slug: "entity/acme", Description: "desc", Details: "details",
+			SourceChunks: []string{"foreign-chunk"},
+		}},
+		SummaryContent: "SUMMARY: valid",
+	}, chunks)
+	require.Error(t, err)
+
+	_, err = encodeWikiMapArtifact(wikiMapArtifactValue{
+		Entities: []extractedItem{{
+			Name: "Acme", Slug: "entity/acme", Description: "desc", Details: "details",
+			SourceChunks: []string{"chunk-1", "chunk-1"},
+		}},
+		SummaryContent: "SUMMARY: valid",
+	}, chunks)
+	require.Error(t, err)
+
+	payload, err := encodeWikiMapArtifact(wikiMapArtifactValue{
+		Entities: []extractedItem{{
+			Name: "Acme", Slug: "entity/acme", Description: "desc", Details: "details",
+			SourceChunks: []string{"chunk-2"},
+		}},
+		SummaryContent: "SUMMARY: valid",
+	}, chunks)
+	require.NoError(t, err)
+	_, err = decodeWikiMapArtifact(payload, chunks[:1])
+	require.Error(t, err)
+
+	changedLayout := testWikiMapChunks("current-1", "current-2")
+	changedLayout[1].Content = "different content"
+	_, err = decodeWikiMapArtifact(payload, changedLayout)
+	require.Error(t, err)
+
+	var duplicateOrdinal wikiMapArtifactPayload
+	require.NoError(t, json.Unmarshal(payload, &duplicateOrdinal))
+	duplicateOrdinal.Entities[0].SourceOrdinals = []int{1, 1}
+	encodedDuplicate, err := json.Marshal(duplicateOrdinal)
+	require.NoError(t, err)
+	_, err = decodeWikiMapArtifact(encodedDuplicate, chunks)
+	require.Error(t, err)
+}
+
+func TestWikiMapArtifactRejectsAmbiguousChunkLayouts(t *testing.T) {
+	duplicateID := testWikiMapArtifactRequest()
+	duplicateID.chunks[1].ID = duplicateID.chunks[0].ID
+	_, err := newWikiMapArtifactKey(duplicateID)
+	require.Error(t, err)
+
+	duplicateDescriptor := testWikiMapArtifactRequest()
+	duplicateDescriptor.chunks[1].ChunkIndex = duplicateDescriptor.chunks[0].ChunkIndex
+	duplicateDescriptor.chunks[1].StartAt = duplicateDescriptor.chunks[0].StartAt
+	duplicateDescriptor.chunks[1].Content = duplicateDescriptor.chunks[0].Content
+	duplicateDescriptor.chunks[1].ChunkType = duplicateDescriptor.chunks[0].ChunkType
+	_, err = newWikiMapArtifactKey(duplicateDescriptor)
+	require.Error(t, err)
+}
+
+func TestCanonicalWikiMapChunkOrderStabilizesPositionTies(t *testing.T) {
+	alpha := &types.Chunk{
+		ID: "chunk-alpha", Content: "alpha", ChunkIndex: 0, StartAt: 0, ChunkType: types.ChunkTypeText,
+	}
+	beta := &types.Chunk{
+		ID: "chunk-beta", Content: "beta", ChunkIndex: 0, StartAt: 0, ChunkType: types.ChunkTypeText,
+	}
+
+	first := canonicalWikiMapChunkOrder([]*types.Chunk{beta, alpha})
+	second := canonicalWikiMapChunkOrder([]*types.Chunk{alpha, beta})
+	require.Len(t, first, 2)
+	require.Len(t, second, 2)
+	assert.Equal(t, []string{"chunk-alpha", "chunk-beta"}, []string{first[0].ID, first[1].ID})
+	assert.Equal(t, []string{"chunk-alpha", "chunk-beta"}, []string{second[0].ID, second[1].ID})
+	assert.Equal(t, reconstructContent(first), reconstructContent(second))
+}
+
+func TestWikiMapArtifactCodecRejectsSemanticallyInvalidItems(t *testing.T) {
+	chunks := testWikiMapChunks("chunk-1", "chunk-2")
+	_, err := encodeWikiMapArtifact(wikiMapArtifactValue{
+		Entities:       []extractedItem{{Name: " ", Slug: "entity/acme", Description: "desc", Details: "details"}},
+		SummaryContent: "SUMMARY: valid",
+	}, chunks)
+	require.Error(t, err)
+
+	_, err = encodeWikiMapArtifact(wikiMapArtifactValue{
+		Entities: []extractedItem{
+			{Name: "Acme", Slug: "entity/acme", Description: "desc", Details: "details"},
+			{Name: "Other", Slug: "entity/acme", Description: "desc", Details: "details"},
+		},
+		SummaryContent: "SUMMARY: valid",
+	}, chunks)
+	require.Error(t, err)
+
+	for _, value := range []wikiMapArtifactValue{
+		{
+			Entities:       []extractedItem{{Name: "Acme", Slug: "concept/acme", Description: "desc", Details: "details"}},
+			SummaryContent: "SUMMARY: valid",
+		},
+		{
+			Concepts:       []extractedItem{{Name: "RAG", Slug: "entity/rag", Description: "desc", Details: "details"}},
+			SummaryContent: "SUMMARY: valid",
+		},
+		{
+			Entities:       []extractedItem{{Name: "Acme", Slug: "entity/acme", Details: "details"}},
+			SummaryContent: "SUMMARY: valid",
+		},
+		{
+			Entities:       []extractedItem{{Name: "Acme", Slug: "entity/acme", Description: "desc"}},
+			SummaryContent: "SUMMARY: valid",
+		},
+	} {
+		_, err = encodeWikiMapArtifact(value, chunks)
+		require.Error(t, err)
+	}
+
+	valid, err := encodeWikiMapArtifact(wikiMapArtifactValue{
+		Entities:       []extractedItem{{Name: "Acme", Slug: "entity/acme", Description: "desc", Details: "details"}},
+		SummaryContent: "SUMMARY: valid",
+	}, chunks)
+	require.NoError(t, err)
+	var payload wikiMapArtifactPayload
+	require.NoError(t, json.Unmarshal(valid, &payload))
+	payload.Entities[0].Name = " "
+	invalidItem, err := json.Marshal(payload)
+	require.NoError(t, err)
+	_, err = decodeWikiMapArtifact(invalidItem, chunks)
+	require.Error(t, err)
+
+	require.NoError(t, json.Unmarshal(valid, &payload))
+	payload.Entities[0].Slug = "concept/acme"
+	invalidItem, err = json.Marshal(payload)
+	require.NoError(t, err)
+	_, err = decodeWikiMapArtifact(invalidItem, chunks)
+	require.Error(t, err)
+
+	require.NoError(t, json.Unmarshal(valid, &payload))
+	payload.Entities[0].Description = ""
+	invalidItem, err = json.Marshal(payload)
+	require.NoError(t, err)
+	_, err = decodeWikiMapArtifact(invalidItem, chunks)
+	require.Error(t, err)
+
+	invalidUTF8 := append([]byte(nil), valid...)
+	invalidUTF8[len(invalidUTF8)-2] = 0xff
+	_, err = decodeWikiMapArtifact(invalidUTF8, chunks)
+	require.Error(t, err)
+}
+
+func TestWikiMapArtifactCodecIsCanonical(t *testing.T) {
+	chunks := testWikiMapChunks("chunk-1", "chunk-2")
+	first, err := encodeWikiMapArtifact(wikiMapArtifactValue{
+		Entities: []extractedItem{
+			{Name: "Beta", Slug: "entity/beta", Aliases: []string{"B", "Beta"}, Description: "desc", Details: "details", SourceChunks: []string{"chunk-2", "chunk-1"}},
+			{Name: "Acme", Slug: "entity/acme", Description: "desc", Details: "details", SourceChunks: []string{"chunk-1"}},
+		},
+		SummaryContent: "SUMMARY: valid",
+	}, chunks)
+	require.NoError(t, err)
+	second, err := encodeWikiMapArtifact(wikiMapArtifactValue{
+		Entities: []extractedItem{
+			{Name: "Acme", Slug: "entity/acme", Description: "desc", Details: "details", SourceChunks: []string{"chunk-1"}},
+			{Name: "Beta", Slug: "entity/beta", Aliases: []string{"Beta", "B"}, Description: "desc", Details: "details", SourceChunks: []string{"chunk-1", "chunk-2"}},
+		},
+		SummaryContent: "SUMMARY: valid",
+	}, chunks)
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+}
+
+func TestWikiMapArtifactCodecPreservesDedupCandidateSlugs(t *testing.T) {
+	chunks := testWikiMapChunks("chunk-1")
+	value := wikiMapArtifactValue{
+		SummaryContent: "SUMMARY: valid",
+		DedupContext: wikiMapDedupContext{
+			Entities: []extractedItem{{
+				Name: "Acme", Slug: "entity/acme", Description: "desc", Details: "details",
+			}},
+			CandidateSlugs:              []string{"entity/zeta", "entity/alpha"},
+			CandidateFingerprint:        "fingerprint",
+			ReducedCandidateFingerprint: "reduced-fingerprint",
+			OutputPageFingerprints: map[string]string{
+				"entity/acme": "page-fingerprint",
+			},
+		},
+	}
+
+	encoded, err := encodeWikiMapArtifact(value, chunks)
+	require.NoError(t, err)
+	decoded, err := decodeWikiMapArtifact(encoded, chunks)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"entity/alpha", "entity/zeta"}, decoded.DedupContext.CandidateSlugs)
+	assert.Equal(t, "reduced-fingerprint", decoded.DedupContext.ReducedCandidateFingerprint)
+	assert.Equal(t, map[string]string{"entity/acme": "page-fingerprint"}, decoded.DedupContext.OutputPageFingerprints)
+}
+
+func testWikiMapArtifactRequest() wikiMapArtifactRequest {
+	return wikiMapArtifactRequest{
+		tenantID:               11,
+		knowledgeBaseID:        "kb-1",
+		knowledgeID:            "knowledge-1",
+		modelID:                "model-1",
+		modelName:              "chat-model",
+		modelRevision:          "revision-1",
+		content:                "canonical document",
+		chunks:                 testWikiMapChunks("chunk-1", "chunk-2"),
+		language:               "Simplified Chinese",
+		granularity:            types.WikiExtractionStandard,
+		contentInstructions:    "content instruction",
+		extractionInstructions: "extraction instruction",
+		promptSuiteVersion:     wikiMapPromptSuiteVersion,
+		canonicalizerVersion:   wikiMapCanonicalizerVersion,
+	}
+}
+
+func testWikiMapChunks(ids ...string) []*types.Chunk {
+	chunks := make([]*types.Chunk, 0, len(ids))
+	for i, id := range ids {
+		chunks = append(chunks, &types.Chunk{
+			ID:         id,
+			Content:    "content " + id[len(id)-1:],
+			ChunkIndex: i,
+			StartAt:    i * 10,
+			ChunkType:  types.ChunkTypeText,
+		})
+	}
+	return chunks
+}

--- a/internal/application/service/wiki_map_artifact_integration_test.go
+++ b/internal/application/service/wiki_map_artifact_integration_test.go
@@ -157,12 +157,15 @@ func (m *wikiMapOutOfOrderCitationChat) GetModelName() string { return "chat-mod
 func (m *wikiMapOutOfOrderCitationChat) GetModelID() string   { return "model-1" }
 
 type wikiMapArtifactFakeStore struct {
-	mu       sync.Mutex
-	values   map[types.ProcessingArtifactKey][]byte
-	getErr   error
-	putErr   error
-	getCalls int
-	putCalls int
+	mu            sync.Mutex
+	values        map[types.ProcessingArtifactKey][]byte
+	getErr        error
+	putErr        error
+	invalidateErr error
+	getCalls      int
+	putCalls      int
+	invalidated   []types.ProcessingArtifactKey
+	observed      [][]byte
 }
 
 func newWikiMapArtifactFakeStore() *wikiMapArtifactFakeStore {
@@ -196,6 +199,22 @@ func (s *wikiMapArtifactFakeStore) PutIfAbsent(
 	}
 	s.values[key] = append([]byte(nil), value...)
 	return append([]byte(nil), value...), true, nil
+}
+
+func (s *wikiMapArtifactFakeStore) Invalidate(
+	_ context.Context,
+	key types.ProcessingArtifactKey,
+	observed []byte,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.invalidated = append(s.invalidated, key)
+	s.observed = append(s.observed, append([]byte(nil), observed...))
+	if s.invalidateErr != nil {
+		return s.invalidateErr
+	}
+	delete(s.values, key)
+	return nil
 }
 
 func TestCompleteWikiMapArtifactReusesAndRebindsCurrentChunks(t *testing.T) {
@@ -258,10 +277,25 @@ func TestCompleteWikiMapArtifactRecomputesCorruptHit(t *testing.T) {
 	assert.Equal(t, wikiMapCacheStatusCorrupt, status)
 	assert.Equal(t, "fresh", got.SummaryContent)
 	assert.Equal(t, 1, computed)
-	assert.Zero(t, store.putCalls)
+	assert.Equal(t, 1, store.putCalls)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+	assert.Equal(t, [][]byte{[]byte(`{"version":99}`)}, store.observed)
+
+	got, hit, status, err = completeWikiMapArtifact(
+		context.Background(), store, request, nil, nil,
+		func() (wikiMapArtifactValue, bool, error) {
+			computed++
+			return wikiMapArtifactValue{SummaryContent: "unexpected"}, true, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, wikiMapCacheStatusHit, status)
+	assert.Equal(t, "fresh", got.SummaryContent)
+	assert.Equal(t, 1, computed)
 }
 
-func TestCompleteWikiMapArtifactRecomputesStaleHitWithoutRepublishing(t *testing.T) {
+func TestCompleteWikiMapArtifactRecomputesAndRepublishesStaleHit(t *testing.T) {
 	store := newWikiMapArtifactFakeStore()
 	request := testWikiMapArtifactRequest()
 	key, err := newWikiMapArtifactKey(request)
@@ -292,8 +326,54 @@ func TestCompleteWikiMapArtifactRecomputesStaleHitWithoutRepublishing(t *testing
 	assert.Equal(t, wikiMapCacheStatusStale, status)
 	assert.Equal(t, "fresh", got.SummaryContent)
 	assert.Equal(t, 1, computed)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+	assert.Equal(t, [][]byte{stale}, store.observed)
 	assert.Equal(t, 1, validated)
-	assert.Zero(t, store.putCalls)
+	assert.Equal(t, 1, store.putCalls)
+
+	got, hit, status, err = completeWikiMapArtifact(
+		context.Background(), store, request,
+		func(value wikiMapArtifactValue) bool {
+			validated++
+			return value.SummaryContent != "stale"
+		},
+		nil,
+		func() (wikiMapArtifactValue, bool, error) {
+			computed++
+			return wikiMapArtifactValue{SummaryContent: "unexpected"}, true, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, wikiMapCacheStatusHit, status)
+	assert.Equal(t, "fresh", got.SummaryContent)
+	assert.Equal(t, 1, computed)
+	assert.Equal(t, 2, validated)
+}
+
+func TestCompleteWikiMapArtifactStopsWhenInvalidationFails(t *testing.T) {
+	request := testWikiMapArtifactRequest()
+	key, err := newWikiMapArtifactKey(request)
+	require.NoError(t, err)
+	store := newWikiMapArtifactFakeStore()
+	store.invalidateErr = errors.New("invalidate failed")
+	store.values[key] = []byte(`{"version":99}`)
+	computed := 0
+
+	value, hit, status, err := completeWikiMapArtifact(
+		context.Background(), store, request, nil, nil,
+		func() (wikiMapArtifactValue, bool, error) {
+			computed++
+			return wikiMapArtifactValue{SummaryContent: "fallback"}, true, nil
+		},
+	)
+
+	assert.ErrorIs(t, err, store.invalidateErr)
+	assert.Equal(t, wikiMapArtifactValue{}, value)
+	assert.False(t, hit)
+	assert.Equal(t, wikiMapCacheStatusCorrupt, status)
+	assert.Zero(t, computed)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
 }
 
 func TestCompleteWikiMapArtifactPropagatesStoreErrorsAndSkipsUncacheableResults(t *testing.T) {
@@ -378,19 +458,107 @@ func TestCompleteWikiMapArtifactConcurrentMissesConverge(t *testing.T) {
 }
 
 type wikiMapConcurrentWinnerStore struct {
-	winner []byte
+	winner        []byte
+	invalidateErr error
+	invalidated   []types.ProcessingArtifactKey
+	observed      [][]byte
+	published     bool
+	putCalls      int
 }
 
-func (s wikiMapConcurrentWinnerStore) Get(
+type wikiMapRepairWinnerSequenceStore struct {
+	winners     [][]byte
+	putCalls    int
+	invalidated [][]byte
+}
+
+func (s *wikiMapRepairWinnerSequenceStore) Get(
 	context.Context, types.ProcessingArtifactKey,
 ) ([]byte, bool, error) {
 	return nil, false, nil
 }
 
-func (s wikiMapConcurrentWinnerStore) PutIfAbsent(
-	context.Context, types.ProcessingArtifactKey, []byte,
+func (s *wikiMapRepairWinnerSequenceStore) PutIfAbsent(
+	_ context.Context, _ types.ProcessingArtifactKey, _ []byte,
 ) ([]byte, bool, error) {
+	winner := s.winners[s.putCalls]
+	s.putCalls++
+	return append([]byte(nil), winner...), false, nil
+}
+
+func (s *wikiMapRepairWinnerSequenceStore) Invalidate(
+	_ context.Context, _ types.ProcessingArtifactKey, observed []byte,
+) error {
+	s.invalidated = append(s.invalidated, append([]byte(nil), observed...))
+	return nil
+}
+
+func TestCompleteWikiMapArtifactRejectsStaleWinnerAfterCorruptRepair(t *testing.T) {
+	request := testWikiMapArtifactRequest()
+	stale, err := encodeWikiMapArtifact(
+		wikiMapArtifactValue{SummaryContent: "stale"}, request.chunks,
+	)
+	require.NoError(t, err)
+	store := &wikiMapRepairWinnerSequenceStore{
+		winners: [][]byte{[]byte(`{"version":99}`), stale},
+	}
+	computed := 0
+	validated := 0
+
+	got, hit, status, err := completeWikiMapArtifact(
+		context.Background(),
+		store,
+		request,
+		nil,
+		func(winner, _ wikiMapArtifactValue) bool {
+			validated++
+			return winner.SummaryContent == "fresh"
+		},
+		func() (wikiMapArtifactValue, bool, error) {
+			computed++
+			return wikiMapArtifactValue{SummaryContent: "fresh"}, true, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, wikiMapCacheStatusCorrupt, status)
+	assert.Equal(t, "fresh", got.SummaryContent)
+	assert.Equal(t, 1, computed)
+	assert.Equal(t, 1, validated)
+	assert.Equal(t, 2, store.putCalls)
+	assert.Equal(t, [][]byte{[]byte(`{"version":99}`)}, store.invalidated)
+}
+
+func (s *wikiMapConcurrentWinnerStore) Get(
+	context.Context, types.ProcessingArtifactKey,
+) ([]byte, bool, error) {
+	if s.published {
+		return append([]byte(nil), s.winner...), true, nil
+	}
+	return nil, false, nil
+}
+
+func (s *wikiMapConcurrentWinnerStore) PutIfAbsent(
+	_ context.Context, _ types.ProcessingArtifactKey, candidate []byte,
+) ([]byte, bool, error) {
+	s.putCalls++
+	if len(s.invalidated) > 0 {
+		s.winner = append([]byte(nil), candidate...)
+		s.published = true
+		return append([]byte(nil), candidate...), true, nil
+	}
 	return append([]byte(nil), s.winner...), false, nil
+}
+
+func (s *wikiMapConcurrentWinnerStore) Invalidate(
+	_ context.Context,
+	key types.ProcessingArtifactKey,
+	observed []byte,
+) error {
+	s.invalidated = append(s.invalidated, key)
+	s.observed = append(s.observed, append([]byte(nil), observed...))
+	return s.invalidateErr
 }
 
 func TestCompleteWikiMapArtifactKeepsFreshValueWhenConcurrentWinnerIsStale(t *testing.T) {
@@ -401,8 +569,11 @@ func TestCompleteWikiMapArtifactKeepsFreshValueWhenConcurrentWinnerIsStale(t *te
 	require.NoError(t, err)
 	computed := 0
 
+	store := &wikiMapConcurrentWinnerStore{winner: winner}
+	key, err := newWikiMapArtifactKey(request)
+	require.NoError(t, err)
 	got, hit, status, err := completeWikiMapArtifact(
-		context.Background(), wikiMapConcurrentWinnerStore{winner: winner}, request,
+		context.Background(), store, request,
 		nil,
 		func(winner, _ wikiMapArtifactValue) bool { return winner.SummaryContent == "fresh" },
 		func() (wikiMapArtifactValue, bool, error) {
@@ -414,6 +585,22 @@ func TestCompleteWikiMapArtifactKeepsFreshValueWhenConcurrentWinnerIsStale(t *te
 	require.NoError(t, err)
 	assert.False(t, hit)
 	assert.Equal(t, wikiMapCacheStatusStale, status)
+	assert.Equal(t, "fresh", got.SummaryContent)
+	assert.Equal(t, 1, computed)
+	assert.Equal(t, [][]byte{winner}, store.observed)
+	assert.Equal(t, []types.ProcessingArtifactKey{key}, store.invalidated)
+	assert.Equal(t, 2, store.putCalls)
+
+	got, hit, status, err = completeWikiMapArtifact(
+		context.Background(), store, request, nil, nil,
+		func() (wikiMapArtifactValue, bool, error) {
+			computed++
+			return wikiMapArtifactValue{SummaryContent: "unexpected"}, true, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, wikiMapCacheStatusHit, status)
 	assert.Equal(t, "fresh", got.SummaryContent)
 	assert.Equal(t, 1, computed)
 }
@@ -437,7 +624,7 @@ func TestCompleteWikiMapArtifactConcurrentInitialMissUsesCanonicalWinner(t *test
 	require.NoError(t, err)
 
 	got, hit, status, err := completeWikiMapArtifact(
-		context.Background(), wikiMapConcurrentWinnerStore{winner: winner}, request,
+		context.Background(), &wikiMapConcurrentWinnerStore{winner: winner}, request,
 		func(value wikiMapArtifactValue) bool {
 			return service.wikiMapArtifactStateCurrent(
 				context.Background(), "kb-1", "summary/knowledge-1", oldSlugs, value,

--- a/internal/application/service/wiki_map_artifact_integration_test.go
+++ b/internal/application/service/wiki_map_artifact_integration_test.go
@@ -1,0 +1,1162 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type wikiMapChunkRepository struct {
+	interfaces.ChunkRepository
+	chunks []*types.Chunk
+}
+
+func (r *wikiMapChunkRepository) ListChunksByKnowledgeID(context.Context, uint64, string) ([]*types.Chunk, error) {
+	return r.chunks, nil
+}
+
+func (r *wikiMapChunkRepository) ListChunksByParentIDs(context.Context, uint64, []string) ([]*types.Chunk, error) {
+	return nil, nil
+}
+
+type wikiMapKnowledgeService struct {
+	interfaces.KnowledgeService
+	knowledge *types.Knowledge
+}
+
+func (s *wikiMapKnowledgeService) GetKnowledgeByIDOnly(context.Context, string) (*types.Knowledge, error) {
+	return s.knowledge, nil
+}
+
+type wikiMapPageService struct {
+	interfaces.WikiPageService
+	slugs             []string
+	slugsErr          error
+	candidates        []*types.WikiPageLite
+	candidatesByQuery map[string][]*types.WikiPageLite
+}
+
+func (s wikiMapPageService) ListSlugsBySourceRef(context.Context, string, string) ([]string, error) {
+	return s.slugs, s.slugsErr
+}
+
+func (s wikiMapPageService) FindSimilarPages(
+	_ context.Context, _ string, query string, _ []string, _ int,
+) ([]*types.WikiPageLite, error) {
+	if s.candidatesByQuery != nil {
+		return s.candidatesByQuery[query], nil
+	}
+	return s.candidates, nil
+}
+
+type wikiMapNoCallChat struct{ t *testing.T }
+
+func (m *wikiMapNoCallChat) Chat(context.Context, []chat.Message, *chat.ChatOptions) (*types.ChatResponse, error) {
+	m.t.Fatal("map cache hit called chat model")
+	return nil, nil
+}
+
+func (m *wikiMapNoCallChat) ChatStream(context.Context, []chat.Message, *chat.ChatOptions) (<-chan types.StreamResponse, error) {
+	m.t.Fatal("map cache hit called streaming chat model")
+	return nil, nil
+}
+
+func (m *wikiMapNoCallChat) GetModelName() string { return "chat-model" }
+func (m *wikiMapNoCallChat) GetModelID() string   { return "model-1" }
+
+type wikiMapRoutingChat struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (m *wikiMapRoutingChat) Chat(
+	_ context.Context, messages []chat.Message, _ *chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	m.mu.Lock()
+	m.calls++
+	m.mu.Unlock()
+	if len(messages) > 0 && strings.Contains(messages[0].Content, "<available_wiki_pages>") {
+		return &types.ChatResponse{Content: "SUMMARY: Document summary\nSummary body"}, nil
+	}
+	return &types.ChatResponse{Content: `{"entities":[],"concepts":[]}`}, nil
+}
+
+func (m *wikiMapRoutingChat) ChatStream(
+	context.Context, []chat.Message, *chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *wikiMapRoutingChat) GetModelName() string { return "chat-model" }
+func (m *wikiMapRoutingChat) GetModelID() string   { return "model-1" }
+
+type wikiMapEmptySummaryChat struct{ summary string }
+
+func (m *wikiMapEmptySummaryChat) Chat(
+	_ context.Context, messages []chat.Message, _ *chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	if len(messages) > 0 && strings.Contains(messages[0].Content, "<available_wiki_pages>") {
+		return &types.ChatResponse{Content: m.summary}, nil
+	}
+	return &types.ChatResponse{Content: `{"entities":[],"concepts":[]}`}, nil
+}
+
+func (m *wikiMapEmptySummaryChat) ChatStream(
+	context.Context, []chat.Message, *chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *wikiMapEmptySummaryChat) GetModelName() string { return "chat-model" }
+func (m *wikiMapEmptySummaryChat) GetModelID() string   { return "model-1" }
+
+type wikiMapOutOfOrderCitationChat struct{}
+
+func (m *wikiMapOutOfOrderCitationChat) Chat(
+	_ context.Context, messages []chat.Message, _ *chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	prompt := ""
+	if len(messages) > 0 {
+		prompt = messages[0].Content
+	}
+	if strings.Contains(prompt, "first-batch-marker") {
+		time.Sleep(50 * time.Millisecond)
+		return &types.ChatResponse{Content: `{
+			"citations":{},
+			"new_slugs":[{
+				"type":"entity","name":"Beta First","slug":"entity/beta",
+				"description":"first description","details":"first details","source_chunks":["c000"]
+			}]
+		}`}, nil
+	}
+	return &types.ChatResponse{Content: `{
+		"citations":{},
+		"new_slugs":[{
+			"type":"entity","name":"Beta Second","slug":"entity/beta",
+			"description":"second description","details":"second details","source_chunks":["c000"]
+		}]
+	}`}, nil
+}
+
+func (m *wikiMapOutOfOrderCitationChat) ChatStream(
+	context.Context, []chat.Message, *chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *wikiMapOutOfOrderCitationChat) GetModelName() string { return "chat-model" }
+func (m *wikiMapOutOfOrderCitationChat) GetModelID() string   { return "model-1" }
+
+type wikiMapArtifactFakeStore struct {
+	mu       sync.Mutex
+	values   map[types.ProcessingArtifactKey][]byte
+	getErr   error
+	putErr   error
+	getCalls int
+	putCalls int
+}
+
+func newWikiMapArtifactFakeStore() *wikiMapArtifactFakeStore {
+	return &wikiMapArtifactFakeStore{values: make(map[types.ProcessingArtifactKey][]byte)}
+}
+
+func (s *wikiMapArtifactFakeStore) Get(_ context.Context, key types.ProcessingArtifactKey) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getCalls++
+	if s.getErr != nil {
+		return nil, false, s.getErr
+	}
+	value, ok := s.values[key]
+	return append([]byte(nil), value...), ok, nil
+}
+
+func (s *wikiMapArtifactFakeStore) PutIfAbsent(
+	_ context.Context,
+	key types.ProcessingArtifactKey,
+	value []byte,
+) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.putCalls++
+	if s.putErr != nil {
+		return nil, false, s.putErr
+	}
+	if canonical, ok := s.values[key]; ok {
+		return append([]byte(nil), canonical...), false, nil
+	}
+	s.values[key] = append([]byte(nil), value...)
+	return append([]byte(nil), value...), true, nil
+}
+
+func TestCompleteWikiMapArtifactReusesAndRebindsCurrentChunks(t *testing.T) {
+	store := newWikiMapArtifactFakeStore()
+	firstRequest := testWikiMapArtifactRequest()
+	computed := 0
+	first, hit, status, err := completeWikiMapArtifact(
+		context.Background(), store, firstRequest, nil, nil,
+		func() (wikiMapArtifactValue, bool, error) {
+			computed++
+			return wikiMapArtifactValue{
+				Entities: []extractedItem{{
+					Name: "Acme", Slug: "entity/acme", Description: "desc", Details: "details",
+					SourceChunks: []string{"chunk-2"},
+				}},
+				SummaryContent: "SUMMARY: cached",
+			}, true, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, wikiMapCacheStatusStored, status)
+	assert.Equal(t, []string{"chunk-2"}, first.Entities[0].SourceChunks)
+
+	secondRequest := testWikiMapArtifactRequest()
+	secondRequest.chunks = testWikiMapChunks("current-1", "current-2")
+	second, hit, status, err := completeWikiMapArtifact(
+		context.Background(), store, secondRequest, nil, nil,
+		func() (wikiMapArtifactValue, bool, error) {
+			t.Fatal("cache hit called compute")
+			return wikiMapArtifactValue{}, false, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, wikiMapCacheStatusHit, status)
+	assert.Equal(t, []string{"current-2"}, second.Entities[0].SourceChunks)
+	assert.Equal(t, 1, computed)
+	assert.Equal(t, 2, store.getCalls)
+	assert.Equal(t, 1, store.putCalls)
+}
+
+func TestCompleteWikiMapArtifactRecomputesCorruptHit(t *testing.T) {
+	store := newWikiMapArtifactFakeStore()
+	request := testWikiMapArtifactRequest()
+	key, err := newWikiMapArtifactKey(request)
+	require.NoError(t, err)
+	store.values[key] = []byte(`{"version":99}`)
+
+	computed := 0
+	got, hit, status, err := completeWikiMapArtifact(
+		context.Background(), store, request, nil, nil,
+		func() (wikiMapArtifactValue, bool, error) {
+			computed++
+			return wikiMapArtifactValue{SummaryContent: "fresh"}, true, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, wikiMapCacheStatusCorrupt, status)
+	assert.Equal(t, "fresh", got.SummaryContent)
+	assert.Equal(t, 1, computed)
+	assert.Zero(t, store.putCalls)
+}
+
+func TestCompleteWikiMapArtifactRecomputesStaleHitWithoutRepublishing(t *testing.T) {
+	store := newWikiMapArtifactFakeStore()
+	request := testWikiMapArtifactRequest()
+	key, err := newWikiMapArtifactKey(request)
+	require.NoError(t, err)
+	stale, err := encodeWikiMapArtifact(
+		wikiMapArtifactValue{SummaryContent: "stale"}, request.chunks,
+	)
+	require.NoError(t, err)
+	store.values[key] = stale
+	computed := 0
+	validated := 0
+
+	got, hit, status, err := completeWikiMapArtifact(
+		context.Background(), store, request,
+		func(value wikiMapArtifactValue) bool {
+			validated++
+			return value.SummaryContent != "stale"
+		},
+		nil,
+		func() (wikiMapArtifactValue, bool, error) {
+			computed++
+			return wikiMapArtifactValue{SummaryContent: "fresh"}, true, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, wikiMapCacheStatusStale, status)
+	assert.Equal(t, "fresh", got.SummaryContent)
+	assert.Equal(t, 1, computed)
+	assert.Equal(t, 1, validated)
+	assert.Zero(t, store.putCalls)
+}
+
+func TestCompleteWikiMapArtifactPropagatesStoreErrorsAndSkipsUncacheableResults(t *testing.T) {
+	request := testWikiMapArtifactRequest()
+
+	getErr := errors.New("get failed")
+	store := newWikiMapArtifactFakeStore()
+	store.getErr = getErr
+	_, _, _, err := completeWikiMapArtifact(
+		context.Background(), store, request, nil, nil,
+		func() (wikiMapArtifactValue, bool, error) {
+			t.Fatal("store read error called compute")
+			return wikiMapArtifactValue{}, false, nil
+		},
+	)
+	require.ErrorIs(t, err, getErr)
+
+	store = newWikiMapArtifactFakeStore()
+	got, hit, status, err := completeWikiMapArtifact(
+		context.Background(), store, request, nil, nil,
+		func() (wikiMapArtifactValue, bool, error) {
+			return wikiMapArtifactValue{SummaryContent: "fallback"}, false, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, wikiMapCacheStatusUncacheable, status)
+	assert.Equal(t, "fallback", got.SummaryContent)
+	assert.Zero(t, store.putCalls)
+
+	store = newWikiMapArtifactFakeStore()
+	request.modelRevision = ""
+	_, _, status, err = completeWikiMapArtifact(
+		context.Background(), store, request, nil, nil,
+		func() (wikiMapArtifactValue, bool, error) {
+			return wikiMapArtifactValue{SummaryContent: "bypass"}, true, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, wikiMapCacheStatusBypass, status)
+	assert.Zero(t, store.getCalls)
+	assert.Zero(t, store.putCalls)
+}
+
+func TestCompleteWikiMapArtifactConcurrentMissesConverge(t *testing.T) {
+	store := newWikiMapArtifactFakeStore()
+	request := testWikiMapArtifactRequest()
+	start := make(chan struct{})
+	results := make(chan string, 2)
+	errors := make(chan error, 2)
+	var ready sync.WaitGroup
+	ready.Add(2)
+	for _, summary := range []string{"first", "second"} {
+		summary := summary
+		go func() {
+			ready.Done()
+			<-start
+			value, _, _, err := completeWikiMapArtifact(
+				context.Background(), store, request, nil, nil,
+				func() (wikiMapArtifactValue, bool, error) {
+					return wikiMapArtifactValue{SummaryContent: summary}, true, nil
+				},
+			)
+			if err != nil {
+				errors <- err
+				return
+			}
+			results <- value.SummaryContent
+		}()
+	}
+	ready.Wait()
+	close(start)
+	first := <-results
+	second := <-results
+	select {
+	case err := <-errors:
+		require.NoError(t, err)
+	default:
+	}
+	assert.Equal(t, first, second)
+	assert.Contains(t, []string{"first", "second"}, first)
+}
+
+type wikiMapConcurrentWinnerStore struct {
+	winner []byte
+}
+
+func (s wikiMapConcurrentWinnerStore) Get(
+	context.Context, types.ProcessingArtifactKey,
+) ([]byte, bool, error) {
+	return nil, false, nil
+}
+
+func (s wikiMapConcurrentWinnerStore) PutIfAbsent(
+	context.Context, types.ProcessingArtifactKey, []byte,
+) ([]byte, bool, error) {
+	return append([]byte(nil), s.winner...), false, nil
+}
+
+func TestCompleteWikiMapArtifactKeepsFreshValueWhenConcurrentWinnerIsStale(t *testing.T) {
+	request := testWikiMapArtifactRequest()
+	winner, err := encodeWikiMapArtifact(
+		wikiMapArtifactValue{SummaryContent: "stale"}, request.chunks,
+	)
+	require.NoError(t, err)
+	computed := 0
+
+	got, hit, status, err := completeWikiMapArtifact(
+		context.Background(), wikiMapConcurrentWinnerStore{winner: winner}, request,
+		nil,
+		func(winner, _ wikiMapArtifactValue) bool { return winner.SummaryContent == "fresh" },
+		func() (wikiMapArtifactValue, bool, error) {
+			computed++
+			return wikiMapArtifactValue{SummaryContent: "fresh"}, true, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, wikiMapCacheStatusStale, status)
+	assert.Equal(t, "fresh", got.SummaryContent)
+	assert.Equal(t, 1, computed)
+}
+
+func TestCompleteWikiMapArtifactConcurrentInitialMissUsesCanonicalWinner(t *testing.T) {
+	request := testWikiMapArtifactRequest()
+	winner, err := encodeWikiMapArtifact(wikiMapArtifactValue{
+		SummaryContent: "canonical",
+		DedupContext: wikiMapDedupContext{
+			CandidateFingerprint: wikiDedupCandidateFingerprint(nil),
+		},
+	}, request.chunks)
+	require.NoError(t, err)
+	service := &wikiIngestService{wikiService: wikiMapPageService{}}
+	oldSlugs := map[string]bool(nil)
+	previousFingerprint := wikiPageSlugFingerprint(oldSlugs)
+	winnerValue, err := decodeWikiMapArtifact(winner, request.chunks)
+	require.NoError(t, err)
+	winnerValue.PreviousSlugsFingerprint = previousFingerprint
+	winner, err = encodeWikiMapArtifact(winnerValue, request.chunks)
+	require.NoError(t, err)
+
+	got, hit, status, err := completeWikiMapArtifact(
+		context.Background(), wikiMapConcurrentWinnerStore{winner: winner}, request,
+		func(value wikiMapArtifactValue) bool {
+			return service.wikiMapArtifactStateCurrent(
+				context.Background(), "kb-1", "summary/knowledge-1", oldSlugs, value,
+			)
+		},
+		func(winner, computed wikiMapArtifactValue) bool {
+			return service.wikiMapConcurrentWinnerCurrent(
+				context.Background(), "kb-1", "summary/knowledge-1", winner, computed,
+			)
+		},
+		func() (wikiMapArtifactValue, bool, error) {
+			return wikiMapArtifactValue{
+				SummaryContent:           "local",
+				PreviousSlugsFingerprint: previousFingerprint,
+				DedupContext: wikiMapDedupContext{
+					CandidateFingerprint: wikiDedupCandidateFingerprint(nil),
+				},
+			}, true, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, wikiMapCacheStatusStored, status)
+	assert.Equal(t, "canonical", got.SummaryContent)
+}
+
+func TestMapOneDocumentReusesArtifactAndRebindsCurrentChunks(t *testing.T) {
+	store := newWikiMapArtifactFakeStore()
+	oldChunks := testWikiMapChunks("old-chunk-1", "old-chunk-2")
+	content := reconstructContent(oldChunks)
+	request := testWikiMapArtifactRequest()
+	request.content = content
+	request.chunks = oldChunks
+	request.language = types.LanguageLocaleName("zh-CN")
+	key, err := newWikiMapArtifactKey(request)
+	require.NoError(t, err)
+	payload, err := encodeWikiMapArtifact(wikiMapArtifactValue{
+		Entities: []extractedItem{{
+			Name: "Acme", Slug: "entity/acme", Description: "Company", Details: "Company details",
+			SourceChunks: []string{"old-chunk-2"},
+		}},
+		SummaryContent:  "SUMMARY: Cached document\nCached body",
+		CitationBatches: 1,
+		DedupContext: wikiMapDedupContext{
+			Entities: []extractedItem{{
+				Name: "Acme", Slug: "entity/acme", Description: "Company", Details: "Company details",
+			}},
+			CandidateFingerprint: wikiDedupCandidateFingerprint(nil),
+		},
+	}, oldChunks)
+	require.NoError(t, err)
+	store.values[key] = payload
+
+	currentChunks := testWikiMapChunks("current-chunk-1", "current-chunk-2")
+	service := &wikiIngestService{
+		chunkRepo:    &wikiMapChunkRepository{chunks: currentChunks},
+		knowledgeSvc: &wikiMapKnowledgeService{knowledge: &types.Knowledge{ID: "knowledge-1", Title: "Document"}},
+		wikiService: wikiMapPageService{slugs: []string{
+			"summary/knowledge-1", "entity/acme",
+		}},
+		artifactStore: store,
+	}
+	batchCtx := &WikiBatchContext{
+		ExtractionGranularity:       types.WikiExtractionStandard,
+		ContentInstructions:         "content instruction",
+		ExtractionInstructions:      "extraction instruction",
+		SummaryContentByKnowledgeID: func(context.Context, string) string { return "" },
+	}
+
+	result, updates, err := service.mapOneDocument(
+		context.Background(), &wikiMapNoCallChat{t: t}, "revision-1",
+		WikiIngestPayload{TenantID: 11, KnowledgeBaseID: "kb-1"},
+		WikiPendingOp{Op: WikiOpIngest, KnowledgeID: "knowledge-1", Language: "zh-CN"},
+		batchCtx,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, true, result.MapStats["map_cache_hit"])
+	assert.Equal(t, wikiMapCacheStatusHit, result.MapStats["map_cache_status"])
+
+	var entityUpdate *SlugUpdate
+	for i := range updates {
+		if updates[i].Slug == "entity/acme" {
+			entityUpdate = &updates[i]
+			break
+		}
+	}
+	require.NotNil(t, entityUpdate)
+	assert.Equal(t, []string{"current-chunk-2"}, entityUpdate.SourceChunks)
+	assert.Equal(t, []string{"current-chunk-2"}, entityUpdate.Item.SourceChunks)
+	for _, update := range updates {
+		assert.NotContains(t, update.SourceChunks, "old-chunk-1")
+		assert.NotContains(t, update.SourceChunks, "old-chunk-2")
+	}
+}
+
+func TestMapOneDocumentDoesNotCacheWhenPreviousSlugLookupFails(t *testing.T) {
+	store := newWikiMapArtifactFakeStore()
+	service := &wikiIngestService{
+		chunkRepo:     &wikiMapChunkRepository{chunks: testWikiMapChunks("chunk-1", "chunk-2")},
+		knowledgeSvc:  &wikiMapKnowledgeService{knowledge: &types.Knowledge{ID: "knowledge-1", Title: "Document"}},
+		wikiService:   wikiMapPageService{slugsErr: errors.New("lookup failed")},
+		artifactStore: store,
+	}
+	batchCtx := &WikiBatchContext{
+		ExtractionGranularity:       types.WikiExtractionStandard,
+		SummaryContentByKnowledgeID: func(context.Context, string) string { return "" },
+	}
+
+	result, _, err := service.mapOneDocument(
+		context.Background(), &wikiMapRoutingChat{}, "revision-1",
+		WikiIngestPayload{TenantID: 11, KnowledgeBaseID: "kb-1"},
+		WikiPendingOp{Op: WikiOpIngest, KnowledgeID: "knowledge-1", Language: "en-US"},
+		batchCtx,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, wikiMapCacheStatusUncacheable, result.MapStats["map_cache_status"])
+	assert.Zero(t, store.putCalls)
+}
+
+func TestMapOneDocumentReusesSummaryOnlyArtifact(t *testing.T) {
+	store := newWikiMapArtifactFakeStore()
+	service := &wikiIngestService{
+		chunkRepo:     &wikiMapChunkRepository{chunks: testWikiMapChunks("chunk-1", "chunk-2")},
+		knowledgeSvc:  &wikiMapKnowledgeService{knowledge: &types.Knowledge{ID: "knowledge-1", Title: "Document"}},
+		wikiService:   wikiMapPageService{slugs: []string{"summary/knowledge-1"}},
+		artifactStore: store,
+	}
+	batchCtx := &WikiBatchContext{
+		ExtractionGranularity:       types.WikiExtractionStandard,
+		SummaryContentByKnowledgeID: func(context.Context, string) string { return "" },
+	}
+	payload := WikiIngestPayload{TenantID: 11, KnowledgeBaseID: "kb-1"}
+	op := WikiPendingOp{Op: WikiOpIngest, KnowledgeID: "knowledge-1", Language: "en-US"}
+
+	first, _, err := service.mapOneDocument(
+		context.Background(), &wikiMapRoutingChat{}, "revision-1", payload, op, batchCtx,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	assert.Equal(t, wikiMapCacheStatusStored, first.MapStats["map_cache_status"])
+
+	second, _, err := service.mapOneDocument(
+		context.Background(), &wikiMapNoCallChat{t: t}, "revision-1", payload, op, batchCtx,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	assert.Equal(t, true, second.MapStats["map_cache_hit"])
+	assert.Equal(t, wikiMapCacheStatusHit, second.MapStats["map_cache_status"])
+}
+
+func TestMapOneDocumentRejectsBlankSummary(t *testing.T) {
+	for _, summary := range []string{" \t\n", "SUMMARY:", "SUMMARY：\n"} {
+		t.Run(summary, func(t *testing.T) {
+			store := newWikiMapArtifactFakeStore()
+			service := &wikiIngestService{
+				chunkRepo:     &wikiMapChunkRepository{chunks: testWikiMapChunks("chunk-1", "chunk-2")},
+				knowledgeSvc:  &wikiMapKnowledgeService{knowledge: &types.Knowledge{ID: "knowledge-1", Title: "Document"}},
+				wikiService:   wikiMapPageService{},
+				artifactStore: store,
+			}
+			batchCtx := &WikiBatchContext{
+				ExtractionGranularity:       types.WikiExtractionStandard,
+				SummaryContentByKnowledgeID: func(context.Context, string) string { return "" },
+			}
+
+			result, updates, err := service.mapOneDocument(
+				context.Background(), &wikiMapEmptySummaryChat{summary: summary}, "revision-1",
+				WikiIngestPayload{TenantID: 11, KnowledgeBaseID: "kb-1"},
+				WikiPendingOp{Op: WikiOpIngest, KnowledgeID: "knowledge-1", Language: "en-US"},
+				batchCtx,
+			)
+
+			require.Error(t, err)
+			assert.Nil(t, result)
+			assert.Empty(t, updates)
+			assert.Zero(t, store.putCalls)
+		})
+	}
+}
+
+func TestNewWikiIngestServiceInjectsArtifactStore(t *testing.T) {
+	store := newWikiMapArtifactFakeStore()
+	handler := NewWikiIngestService(
+		nil, nil, nil, nil, nil, nil, store, nil, nil, nil, nil, nil, nil,
+	)
+	service, ok := handler.(*wikiIngestService)
+	require.True(t, ok)
+	assert.Same(t, store, service.artifactStore)
+}
+
+func TestWikiMapArtifactStateRejectsChangedWikiDependencies(t *testing.T) {
+	value := wikiMapArtifactValue{
+		Entities: []extractedItem{{Name: "Acme", Slug: "entity/acme"}},
+		DedupContext: wikiMapDedupContext{
+			Entities:             []extractedItem{{Name: "Acme", Slug: "entity/acme"}},
+			CandidateFingerprint: wikiDedupCandidateFingerprint(nil),
+		},
+	}
+	oldSlugs := map[string]bool{"summary/knowledge-1": true, "entity/acme": true}
+	service := &wikiIngestService{wikiService: wikiMapPageService{}}
+	assert.True(t, service.wikiMapArtifactStateCurrent(
+		context.Background(), "kb-1", "summary/knowledge-1", oldSlugs, value,
+	))
+	service.wikiService = wikiMapPageService{candidates: []*types.WikiPageLite{{
+		Slug: "entity/acme", Title: "Acme", PageType: types.WikiPageTypeEntity,
+	}}}
+	assert.True(t, service.wikiMapArtifactStateCurrent(
+		context.Background(), "kb-1", "summary/knowledge-1", oldSlugs, value,
+	))
+
+	service.wikiService = wikiMapPageService{candidates: []*types.WikiPageLite{{
+		Slug: "entity/existing", Title: "Existing", PageType: types.WikiPageTypeEntity,
+	}}}
+	assert.False(t, service.wikiMapArtifactStateCurrent(
+		context.Background(), "kb-1", "summary/knowledge-1", oldSlugs, value,
+	))
+
+	delete(oldSlugs, "entity/acme")
+	service.wikiService = wikiMapPageService{}
+	assert.False(t, service.wikiMapArtifactStateCurrent(
+		context.Background(), "kb-1", "summary/knowledge-1", oldSlugs, value,
+	))
+}
+
+func TestWikiMapArtifactStateIgnoresOnlyNewSiblingPages(t *testing.T) {
+	pageA := &types.WikiPageLite{Slug: "entity/a", Title: "A", PageType: types.WikiPageTypeEntity}
+	pageB := &types.WikiPageLite{Slug: "entity/b", Title: "B", PageType: types.WikiPageTypeEntity}
+	oldSlugs := map[string]bool{
+		"summary/knowledge-1": true,
+		"entity/a":            true,
+		"entity/b":            true,
+	}
+	service := &wikiIngestService{wikiService: wikiMapPageService{candidatesByQuery: map[string][]*types.WikiPageLite{
+		"A": {pageB},
+		"B": {pageA},
+	}}}
+	value := wikiMapArtifactValue{
+		Entities: []extractedItem{{Name: "A", Slug: "entity/a"}, {Name: "B", Slug: "entity/b"}},
+		DedupContext: wikiMapDedupContext{
+			Entities:                    []extractedItem{{Name: "A", Slug: "entity/a"}, {Name: "B", Slug: "entity/b"}},
+			CandidateFingerprint:        wikiDedupCandidateFingerprint(nil),
+			ReducedCandidateFingerprint: wikiDedupCandidateFingerprint(nil),
+			OutputPageFingerprints: map[string]string{
+				"entity/a": wikiDedupPageFingerprint(pageA),
+				"entity/b": wikiDedupPageFingerprint(pageB),
+			},
+		},
+	}
+
+	assert.True(t, service.wikiMapArtifactStateCurrent(
+		context.Background(), "kb-1", "summary/knowledge-1", oldSlugs, value,
+	))
+	pageB.Title = "B changed"
+	assert.False(t, service.wikiMapArtifactStateCurrent(
+		context.Background(), "kb-1", "summary/knowledge-1", oldSlugs, value,
+	))
+	pageB.Title = "B"
+
+	value.DedupContext.CandidateSlugs = []string{"entity/b"}
+	value.DedupContext.CandidateFingerprint = wikiDedupCandidateFingerprint(
+		map[string]*types.WikiPageLite{"entity/b": pageB},
+	)
+	value.DedupContext.ReducedCandidateFingerprint = value.DedupContext.CandidateFingerprint
+	assert.True(t, service.wikiMapArtifactStateCurrent(
+		context.Background(), "kb-1", "summary/knowledge-1", oldSlugs, value,
+	))
+
+	pageB.Title = "B changed"
+	assert.False(t, service.wikiMapArtifactStateCurrent(
+		context.Background(), "kb-1", "summary/knowledge-1", oldSlugs, value,
+	))
+}
+
+func TestWikiMapArtifactStateAcceptsPreAndPostReduceCandidateState(t *testing.T) {
+	before := &types.WikiPageLite{
+		Slug: "entity/existing", Title: "Existing", PageType: types.WikiPageTypeEntity,
+	}
+	after := &types.WikiPageLite{
+		Slug: "entity/existing", Title: "Existing", PageType: types.WikiPageTypeEntity,
+		Aliases: types.StringArray{"Acme"},
+	}
+	value := wikiMapArtifactValue{
+		Entities: []extractedItem{{Name: "Acme", Slug: "entity/existing", Aliases: []string{"Acme"}}},
+		DedupContext: wikiMapDedupContext{
+			Entities:                    []extractedItem{{Name: "Acme", Slug: "entity/acme", Aliases: []string{"Acme"}}},
+			CandidateSlugs:              []string{"entity/existing"},
+			CandidateFingerprint:        wikiDedupPageFingerprint(before),
+			ReducedCandidateFingerprint: wikiDedupPageFingerprint(after),
+		},
+	}
+	oldSlugs := map[string]bool{"summary/knowledge-1": true, "entity/existing": true}
+
+	for _, candidate := range []*types.WikiPageLite{before, after} {
+		service := &wikiIngestService{wikiService: wikiMapPageService{candidates: []*types.WikiPageLite{candidate}}}
+		assert.True(t, service.wikiMapArtifactStateCurrent(
+			context.Background(), "kb-1", "summary/knowledge-1", oldSlugs, value,
+		))
+	}
+
+	changed := *after
+	changed.Title = "Externally renamed"
+	service := &wikiIngestService{wikiService: wikiMapPageService{candidates: []*types.WikiPageLite{&changed}}}
+	assert.False(t, service.wikiMapArtifactStateCurrent(
+		context.Background(), "kb-1", "summary/knowledge-1", oldSlugs, value,
+	))
+}
+
+func TestFindWikiDedupCandidatesExcludesOnlyCurrentItemSlug(t *testing.T) {
+	existingB := &types.WikiPageLite{
+		Slug: "entity/b", Title: "B", PageType: types.WikiPageTypeEntity,
+	}
+	service := &wikiIngestService{wikiService: wikiMapPageService{
+		candidatesByQuery: map[string][]*types.WikiPageLite{
+			"A": {existingB},
+			"B": {existingB},
+		},
+	}}
+
+	candidates, complete := service.findWikiDedupCandidates(
+		context.Background(), "kb-1",
+		[]extractedItem{{Name: "A", Slug: "entity/a"}, {Name: "B", Slug: "entity/b"}},
+		nil,
+	)
+
+	assert.True(t, complete)
+	assert.Equal(t, map[string]*types.WikiPageLite{"entity/b": existingB}, candidates)
+}
+
+func TestDeduplicateExtractedBatchDoesNotCacheRejectedMerges(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{name: "invalid target type", response: `{"merges":{"entity/new":"concept/existing"}}`},
+		{name: "unknown source", response: `{"merges":{"entity/unknown":"entity/existing"}}`},
+		{name: "null object", response: `null`},
+		{name: "empty object", response: `{}`},
+		{name: "missing merges", response: `{"other":{}}`},
+		{name: "null merges", response: `{"merges":null}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &wikiIngestService{wikiService: wikiMapPageService{
+				candidates: []*types.WikiPageLite{
+					{Slug: "entity/existing", Title: "Existing entity", PageType: types.WikiPageTypeEntity},
+					{Slug: "concept/existing", Title: "Existing concept", PageType: types.WikiPageTypeConcept},
+				},
+			}}
+			model := &templateCaptureChatModel{response: tt.response}
+
+			entities, concepts, _, complete := service.deduplicateExtractedBatch(
+				context.Background(), model, "kb-1",
+				[]extractedItem{{Name: "New", Slug: "entity/new"}}, nil,
+			)
+
+			assert.False(t, complete)
+			assert.Equal(t, []extractedItem{{Name: "New", Slug: "entity/new"}}, entities)
+			assert.Empty(t, concepts)
+		})
+	}
+}
+
+func TestDeduplicateExtractedBatchCoalescesManyToOneMerges(t *testing.T) {
+	service := &wikiIngestService{wikiService: wikiMapPageService{candidates: []*types.WikiPageLite{{
+		Slug: "entity/existing", Title: "Existing entity", PageType: types.WikiPageTypeEntity,
+	}}}}
+	model := &templateCaptureChatModel{response: `{"merges":{
+		"entity/alpha":"entity/existing",
+		"entity/beta":"entity/existing"
+	}}`}
+
+	entities, concepts, dedupContext, complete := service.deduplicateExtractedBatch(
+		context.Background(), model, "kb-1",
+		[]extractedItem{
+			{Name: "Alpha", Slug: "entity/alpha", Aliases: []string{"A"}, Description: "alpha description", Details: "alpha details"},
+			{Name: "Beta", Slug: "entity/beta", Aliases: []string{"B"}, Description: "beta description", Details: "beta details"},
+		}, nil,
+	)
+
+	assert.True(t, complete)
+	assert.Empty(t, concepts)
+	require.Len(t, entities, 1)
+	assert.Equal(t, "entity/existing", entities[0].Slug)
+	assert.Equal(t, "Alpha", entities[0].Name)
+	assert.ElementsMatch(t, []string{"A", "B", "Beta"}, entities[0].Aliases)
+	assert.Contains(t, entities[0].Description, "alpha description")
+	assert.Contains(t, entities[0].Description, "beta description")
+	assert.Contains(t, entities[0].Details, "alpha details")
+	assert.Contains(t, entities[0].Details, "beta details")
+	assert.Len(t, dedupContext.Entities, 2)
+
+	entities, _, _ = mergeCitationsIntoItems(
+		entities, nil, map[string][]string{"entity/existing": {"chunk-1"}}, nil,
+	)
+	encoded, err := encodeWikiMapArtifact(wikiMapArtifactValue{
+		Entities: entities, SummaryContent: "SUMMARY: valid", DedupContext: dedupContext,
+	}, testWikiMapChunks("chunk-1"))
+	require.NoError(t, err)
+	decoded, err := decodeWikiMapArtifact(encoded, testWikiMapChunks("current-1"))
+	require.NoError(t, err)
+	require.Len(t, decoded.Entities, 1)
+	assert.Equal(t, []string{"current-1"}, decoded.Entities[0].SourceChunks)
+}
+
+func TestClassifyChunkCitationsDoesNotCacheUnknownAliases(t *testing.T) {
+	service := &wikiIngestService{}
+	model := &templateCaptureChatModel{response: `{
+		"citations":{"entity/acme":["c999"]},
+		"new_slugs":[{
+			"type":"entity","name":"Beta","slug":"entity/beta",
+			"description":"desc","details":"details","source_chunks":["c999"]
+		}]
+	}`}
+
+	_, newSlugs, _, complete := service.classifyChunkCitations(
+		context.Background(), model, "- entity/acme", testWikiCandidateSlugSet("entity/acme"),
+		testWikiMapChunks("chunk-1"),
+		"English", &WikiBatchContext{},
+	)
+
+	assert.False(t, complete)
+	assert.Empty(t, newSlugs)
+}
+
+func TestClassifyChunkCitationsKeepsOnlyValidAliasesFromCompleteNewSlug(t *testing.T) {
+	service := &wikiIngestService{}
+	model := &templateCaptureChatModel{response: `{
+		"citations":{},
+		"new_slugs":[{
+			"type":"entity","name":"Beta","slug":"entity/beta",
+			"description":"desc","details":"details","source_chunks":["c000","c999"]
+		}]
+	}`}
+
+	_, newSlugs, _, complete := service.classifyChunkCitations(
+		context.Background(), model, "- entity/acme", testWikiCandidateSlugSet("entity/acme"),
+		testWikiMapChunks("chunk-1"),
+		"English", &WikiBatchContext{},
+	)
+
+	assert.False(t, complete)
+	require.Len(t, newSlugs, 1)
+	assert.Equal(t, []string{"chunk-1"}, newSlugs[0].SourceChunks)
+}
+
+func TestClassifyChunkCitationsDeduplicatesNewSlugAliases(t *testing.T) {
+	service := &wikiIngestService{}
+	model := &templateCaptureChatModel{response: `{
+		"citations":{},
+		"new_slugs":[{
+			"type":"entity","name":"Beta","slug":"entity/beta",
+			"description":"desc","details":"details","source_chunks":["c000","c000"]
+		}]
+	}`}
+
+	_, newSlugs, _, complete := service.classifyChunkCitations(
+		context.Background(), model, "- entity/acme", testWikiCandidateSlugSet("entity/acme"),
+		testWikiMapChunks("chunk-1"), "English", &WikiBatchContext{},
+	)
+
+	assert.True(t, complete)
+	require.Len(t, newSlugs, 1)
+	assert.Equal(t, []string{"chunk-1"}, newSlugs[0].SourceChunks)
+}
+
+func TestClassifyChunkCitationsDoesNotCacheIncompleteNewSlugs(t *testing.T) {
+	tests := []struct {
+		name    string
+		newSlug string
+	}{
+		{name: "missing type", newSlug: `{"name":"Beta","slug":"entity/beta","description":"desc","details":"details","source_chunks":["c000"]}`},
+		{name: "type prefix mismatch", newSlug: `{"type":"concept","name":"Beta","slug":"entity/beta","description":"desc","details":"details","source_chunks":["c000"]}`},
+		{name: "missing description", newSlug: `{"type":"entity","name":"Beta","slug":"entity/beta","details":"details","source_chunks":["c000"]}`},
+		{name: "missing details", newSlug: `{"type":"entity","name":"Beta","slug":"entity/beta","description":"desc","source_chunks":["c000"]}`},
+		{name: "missing source chunks", newSlug: `{"type":"entity","name":"Beta","slug":"entity/beta","description":"desc","details":"details"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &wikiIngestService{}
+			model := &templateCaptureChatModel{response: `{"citations":{},"new_slugs":[` + tt.newSlug + `]}`}
+
+			_, newSlugs, _, complete := service.classifyChunkCitations(
+				context.Background(), model, "- entity/acme", testWikiCandidateSlugSet("entity/acme"),
+				testWikiMapChunks("chunk-1"),
+				"English", &WikiBatchContext{},
+			)
+
+			assert.False(t, complete)
+			assert.Empty(t, newSlugs)
+		})
+	}
+}
+
+func TestExtractCandidateSlugsRejectsIncompleteResponses(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{name: "null object", response: `null`},
+		{name: "empty object", response: `{}`},
+		{name: "missing entities", response: `{"concepts":[]}`},
+		{name: "missing concepts", response: `{"entities":[]}`},
+		{name: "null entities", response: `{"entities":null,"concepts":[]}`},
+		{name: "null concepts", response: `{"entities":[],"concepts":null}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &wikiIngestService{}
+			model := &templateCaptureChatModel{response: tt.response}
+
+			_, _, _, _, complete, err := service.extractCandidateSlugs(
+				context.Background(), model, "kb-1", "document", "English", nil,
+				&WikiBatchContext{},
+			)
+
+			require.Error(t, err)
+			assert.False(t, complete)
+		})
+	}
+}
+
+func TestExtractCandidateSlugsRejectsInvalidItems(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{
+			name:     "entity with concept prefix",
+			response: `{"entities":[{"name":"A","slug":"concept/a","description":"desc","details":"details"}],"concepts":[]}`,
+		},
+		{
+			name:     "concept with entity prefix",
+			response: `{"entities":[],"concepts":[{"name":"A","slug":"entity/a","description":"desc","details":"details"}]}`,
+		},
+		{
+			name:     "missing description",
+			response: `{"entities":[{"name":"A","slug":"entity/a","details":"details"}],"concepts":[]}`,
+		},
+		{
+			name:     "missing details",
+			response: `{"entities":[{"name":"A","slug":"entity/a","description":"desc"}],"concepts":[]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &wikiIngestService{}
+			model := &templateCaptureChatModel{response: tt.response}
+
+			_, _, _, _, complete, err := service.extractCandidateSlugs(
+				context.Background(), model, "kb-1", "document", "English", nil,
+				&WikiBatchContext{},
+			)
+
+			require.Error(t, err)
+			assert.False(t, complete)
+		})
+	}
+}
+
+func TestClassifyChunkCitationsRejectsUnknownCandidateSlugs(t *testing.T) {
+	service := &wikiIngestService{}
+	model := &templateCaptureChatModel{response: `{
+		"citations":{"entity/unknown":["c000"]},
+		"new_slugs":[]
+	}`}
+
+	citations, _, _, complete := service.classifyChunkCitations(
+		context.Background(), model, "- entity/acme", testWikiCandidateSlugSet("entity/acme"),
+		testWikiMapChunks("chunk-1"),
+		"English", &WikiBatchContext{},
+	)
+
+	assert.False(t, complete)
+	assert.NotContains(t, citations, "entity/unknown")
+}
+
+func TestClassifyChunkCitationsRecoversRediscoveredCandidateReferences(t *testing.T) {
+	service := &wikiIngestService{}
+	model := &templateCaptureChatModel{response: `{
+		"citations":{},
+		"new_slugs":[{
+			"type":"entity","name":"Acme","slug":"entity/acme",
+			"description":"desc","details":"details","source_chunks":["c000"]
+		}]
+	}`}
+
+	citations, newSlugs, _, complete := service.classifyChunkCitations(
+		context.Background(), model, "- entity/acme", testWikiCandidateSlugSet("entity/acme"),
+		testWikiMapChunks("chunk-1"), "English", &WikiBatchContext{},
+	)
+
+	assert.False(t, complete)
+	assert.Equal(t, []string{"chunk-1"}, citations["entity/acme"])
+	assert.Empty(t, newSlugs)
+}
+
+func TestClassifyChunkCitationsRecoversRediscoveredCandidateWithIncompleteMetadata(t *testing.T) {
+	service := &wikiIngestService{}
+	model := &templateCaptureChatModel{response: `{
+		"citations":{},
+		"new_slugs":[{"slug":"entity/acme","source_chunks":["c000"]}]
+	}`}
+
+	citations, newSlugs, _, complete := service.classifyChunkCitations(
+		context.Background(), model, "- entity/acme", testWikiCandidateSlugSet("entity/acme"),
+		testWikiMapChunks("chunk-1"), "English", &WikiBatchContext{},
+	)
+
+	assert.False(t, complete)
+	assert.Equal(t, []string{"chunk-1"}, citations["entity/acme"])
+	assert.Empty(t, newSlugs)
+}
+
+func TestClassifyChunkCitationsOrdersEqualIndexesByDocumentPosition(t *testing.T) {
+	chunks := []*types.Chunk{
+		{ID: "chunk-late", ChunkIndex: 0, StartAt: 100, ChunkType: types.ChunkTypeText, Content: "late"},
+		{ID: "chunk-early", ChunkIndex: 0, StartAt: 0, ChunkType: types.ChunkTypeText, Content: "early"},
+	}
+	service := &wikiIngestService{}
+	model := &templateCaptureChatModel{response: `{
+		"citations":{"entity/acme":["c000","c001"]},
+		"new_slugs":[]
+	}`}
+
+	for range 50 {
+		citations, _, _, complete := service.classifyChunkCitations(
+			context.Background(), model, "- entity/acme", testWikiCandidateSlugSet("entity/acme"),
+			chunks, "English", &WikiBatchContext{},
+		)
+
+		assert.True(t, complete)
+		assert.Equal(t, []string{"chunk-early", "chunk-late"}, citations["entity/acme"])
+	}
+}
+
+func TestSplitChunksIntoCitationBatchesCanonicalizesPositionTies(t *testing.T) {
+	alpha := &types.Chunk{
+		ID: "chunk-alpha", Content: "alpha", ChunkIndex: 0, StartAt: 0, ChunkType: types.ChunkTypeText,
+	}
+	beta := &types.Chunk{
+		ID: "chunk-beta", Content: "beta", ChunkIndex: 0, StartAt: 0, ChunkType: types.ChunkTypeText,
+	}
+
+	for _, chunks := range [][]*types.Chunk{{beta, alpha}, {alpha, beta}} {
+		batches := splitChunksIntoCitationBatches(chunks)
+		require.Len(t, batches, 1)
+		assert.Equal(t, "chunk-alpha", batches[0].aliasToID["c000"])
+		assert.Equal(t, "chunk-beta", batches[0].aliasToID["c001"])
+	}
+}
+
+func TestClassifyChunkCitationsDeterministicallyMergesConflictingNewSlugs(t *testing.T) {
+	chunks := []*types.Chunk{
+		{
+			ID: "chunk-first", ChunkIndex: 0, ChunkType: types.ChunkTypeText,
+			Content: "first-batch-marker" + strings.Repeat("a", maxRunesPerCitationBatch),
+		},
+		{
+			ID: "chunk-second", ChunkIndex: 1, ChunkType: types.ChunkTypeText,
+			Content: "second-batch-marker" + strings.Repeat("b", maxRunesPerCitationBatch),
+		},
+	}
+	service := &wikiIngestService{}
+
+	_, newSlugs, batchCount, complete := service.classifyChunkCitations(
+		context.Background(), &wikiMapOutOfOrderCitationChat{}, "- entity/acme",
+		testWikiCandidateSlugSet("entity/acme"), chunks, "English", &WikiBatchContext{},
+	)
+	entities, _, _ := mergeCitationsIntoItems(nil, nil, nil, newSlugs)
+
+	assert.Equal(t, 2, batchCount)
+	assert.False(t, complete)
+	require.Len(t, entities, 1)
+	assert.Equal(t, "Beta First", entities[0].Name)
+	assert.Equal(t, "first description", entities[0].Description)
+	assert.Equal(t, []string{"chunk-first", "chunk-second"}, entities[0].SourceChunks)
+}
+
+func TestClassifyChunkCitationsDoesNotCacheIncompleteResponses(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{name: "null object", response: `null`},
+		{name: "empty object", response: `{}`},
+		{name: "missing citations", response: `{"new_slugs":[]}`},
+		{name: "missing new slugs", response: `{"citations":{}}`},
+		{name: "null citations", response: `{"citations":null,"new_slugs":[]}`},
+		{name: "null new slugs", response: `{"citations":{},"new_slugs":null}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &wikiIngestService{}
+			model := &templateCaptureChatModel{response: tt.response}
+
+			_, _, _, complete := service.classifyChunkCitations(
+				context.Background(), model, "- entity/acme", testWikiCandidateSlugSet("entity/acme"),
+				testWikiMapChunks("chunk-1"),
+				"English", &WikiBatchContext{},
+			)
+
+			assert.False(t, complete)
+		})
+	}
+}
+
+func testWikiCandidateSlugSet(slugs ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(slugs))
+	for _, slug := range slugs {
+		set[slug] = struct{}{}
+	}
+	return set
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,28 +18,106 @@ import (
 
 // Config 应用程序总配置
 type Config struct {
-	Conversation    *ConversationConfig    `yaml:"conversation"     json:"conversation"`
-	Server          *ServerConfig          `yaml:"server"           json:"server"`
-	KnowledgeBase   *KnowledgeBaseConfig   `yaml:"knowledge_base"   json:"knowledge_base"`
-	Tenant          *TenantConfig          `yaml:"tenant"           json:"tenant"`
-	Auth            *AuthConfig            `yaml:"auth"             json:"auth"`
-	Audit           *AuditConfig           `yaml:"audit"            json:"audit"`
-	OIDCAuth        *OIDCAuthConfig        `yaml:"oidc_auth"        json:"oidc_auth"`
-	Models          []ModelConfig          `yaml:"models"           json:"models"`
-	VectorDatabase  *VectorDatabaseConfig  `yaml:"vector_database"  json:"vector_database"`
-	DocReader       *DocReaderConfig       `yaml:"docreader"        json:"docreader"`
-	StreamManager   *StreamManagerConfig   `yaml:"stream_manager"   json:"stream_manager"`
-	ExtractManager  *ExtractManagerConfig  `yaml:"extract"          json:"extract"`
-	WebSearch       *WebSearchConfig       `yaml:"web_search"       json:"web_search"`
-	PromptTemplates *PromptTemplatesConfig `yaml:"prompt_templates" json:"prompt_templates"`
-	IM              *IMConfig              `yaml:"im"               json:"im"`
-	Agent           *AgentConfig           `yaml:"agent"            json:"agent"`
+	Conversation       *ConversationConfig       `yaml:"conversation"     json:"conversation"`
+	Server             *ServerConfig             `yaml:"server"           json:"server"`
+	KnowledgeBase      *KnowledgeBaseConfig      `yaml:"knowledge_base"   json:"knowledge_base"`
+	Tenant             *TenantConfig             `yaml:"tenant"           json:"tenant"`
+	Auth               *AuthConfig               `yaml:"auth"             json:"auth"`
+	Audit              *AuditConfig              `yaml:"audit"            json:"audit"`
+	OIDCAuth           *OIDCAuthConfig           `yaml:"oidc_auth"        json:"oidc_auth"`
+	Models             []ModelConfig             `yaml:"models"           json:"models"`
+	VectorDatabase     *VectorDatabaseConfig     `yaml:"vector_database"  json:"vector_database"`
+	DocReader          *DocReaderConfig          `yaml:"docreader"        json:"docreader"`
+	StreamManager      *StreamManagerConfig      `yaml:"stream_manager"   json:"stream_manager"`
+	ExtractManager     *ExtractManagerConfig     `yaml:"extract"          json:"extract"`
+	WebSearch          *WebSearchConfig          `yaml:"web_search"       json:"web_search"`
+	PromptTemplates    *PromptTemplatesConfig    `yaml:"prompt_templates" json:"prompt_templates"`
+	IM                 *IMConfig                 `yaml:"im"               json:"im"`
+	Agent              *AgentConfig              `yaml:"agent"            json:"agent"`
+	ProcessingArtifact *ProcessingArtifactConfig `yaml:"processing_artifact" json:"processing_artifact"`
 	// FrontendBaseURL is the externally-visible origin of the SPA, used
 	// to compose absolute share-link URLs. Empty falls back to a host-
 	// relative URL ("/register?token=…") which the SPA then resolves
 	// against window.location.origin — fine for typical single-origin
 	// deployments. Sourced from FRONTEND_BASE_URL env at startup.
 	FrontendBaseURL string `yaml:"frontend_base_url" json:"frontend_base_url"`
+}
+
+const (
+	DefaultProcessingArtifactMaxPayloadBytes  = 64 << 20
+	maxProcessingArtifactDuration             = time.Duration(1<<63 - 1)
+	MaxProcessingArtifactCleanupIntervalHours = int(maxProcessingArtifactDuration / time.Hour)
+	MaxProcessingArtifactRetentionDays        = int(maxProcessingArtifactDuration / (24 * time.Hour))
+)
+
+type ProcessingArtifactConfig struct {
+	MaxPayloadBytes      int `yaml:"max_payload_bytes" json:"max_payload_bytes"`
+	RetentionDays        int `yaml:"retention_days" json:"retention_days"`
+	CleanupIntervalHours int `yaml:"cleanup_interval_hours" json:"cleanup_interval_hours"`
+	CleanupBatchSize     int `yaml:"cleanup_batch_size" json:"cleanup_batch_size"`
+
+	maxPayloadBytesSet      bool
+	retentionDaysSet        bool
+	cleanupIntervalHoursSet bool
+	cleanupBatchSizeSet     bool
+}
+
+func (c *ProcessingArtifactConfig) UnmarshalYAML(node *yaml.Node) error {
+	var value struct {
+		MaxPayloadBytes      *int `yaml:"max_payload_bytes"`
+		RetentionDays        *int `yaml:"retention_days"`
+		CleanupIntervalHours *int `yaml:"cleanup_interval_hours"`
+		CleanupBatchSize     *int `yaml:"cleanup_batch_size"`
+	}
+	if err := node.Decode(&value); err != nil {
+		return err
+	}
+	if value.MaxPayloadBytes != nil {
+		c.MaxPayloadBytes = *value.MaxPayloadBytes
+		c.maxPayloadBytesSet = true
+	}
+	if value.RetentionDays != nil {
+		c.RetentionDays = *value.RetentionDays
+		c.retentionDaysSet = true
+	}
+	if value.CleanupIntervalHours != nil {
+		c.CleanupIntervalHours = *value.CleanupIntervalHours
+		c.cleanupIntervalHoursSet = true
+	}
+	if value.CleanupBatchSize != nil {
+		c.CleanupBatchSize = *value.CleanupBatchSize
+		c.cleanupBatchSizeSet = true
+	}
+	return nil
+}
+
+func (c *ProcessingArtifactConfig) UnmarshalJSON(data []byte) error {
+	var value struct {
+		MaxPayloadBytes      *int `json:"max_payload_bytes"`
+		RetentionDays        *int `json:"retention_days"`
+		CleanupIntervalHours *int `json:"cleanup_interval_hours"`
+		CleanupBatchSize     *int `json:"cleanup_batch_size"`
+	}
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	if value.MaxPayloadBytes != nil {
+		c.MaxPayloadBytes = *value.MaxPayloadBytes
+		c.maxPayloadBytesSet = true
+	}
+	if value.RetentionDays != nil {
+		c.RetentionDays = *value.RetentionDays
+		c.retentionDaysSet = true
+	}
+	if value.CleanupIntervalHours != nil {
+		c.CleanupIntervalHours = *value.CleanupIntervalHours
+		c.cleanupIntervalHoursSet = true
+	}
+	if value.CleanupBatchSize != nil {
+		c.CleanupBatchSize = *value.CleanupBatchSize
+		c.cleanupBatchSizeSet = true
+	}
+	return nil
 }
 
 // AgentConfig represents the global agent settings.
@@ -534,6 +613,12 @@ func LoadConfig() (*Config, error) {
 	}); err != nil {
 		return nil, fmt.Errorf("unable to decode config into struct: %w", err)
 	}
+	if cfg.ProcessingArtifact != nil {
+		cfg.ProcessingArtifact.maxPayloadBytesSet = viper.IsSet("processing_artifact.max_payload_bytes")
+		cfg.ProcessingArtifact.retentionDaysSet = viper.IsSet("processing_artifact.retention_days")
+		cfg.ProcessingArtifact.cleanupIntervalHoursSet = viper.IsSet("processing_artifact.cleanup_interval_hours")
+		cfg.ProcessingArtifact.cleanupBatchSizeSet = viper.IsSet("processing_artifact.cleanup_batch_size")
+	}
 	fmt.Printf("Using configuration file: %s\n", viper.ConfigFileUsed())
 
 	// 加载提示词模板（从目录或配置文件）
@@ -582,6 +667,9 @@ func LoadConfig() (*Config, error) {
 	applyKnowledgeBaseEnvOverrides(&cfg)
 	applyAuthAndTenantDefaults(&cfg)
 	applyAuditDefaults(&cfg)
+	if err := applyProcessingArtifactDefaults(&cfg); err != nil {
+		return nil, err
+	}
 
 	if err := ValidateConfig(&cfg); err != nil {
 		return nil, err
@@ -642,6 +730,24 @@ func ValidateConfig(cfg *Config) error {
 	if cfg.Audit != nil && cfg.Audit.RetentionDays < 0 {
 		errs = append(errs, fmt.Sprintf("audit.retention_days must be >= 0 (got %d); use 0 to disable purge",
 			cfg.Audit.RetentionDays))
+	}
+	if cfg.ProcessingArtifact != nil && cfg.ProcessingArtifact.MaxPayloadBytes <= 0 {
+		errs = append(errs, "processing_artifact.max_payload_bytes must be > 0")
+	}
+	if cfg.ProcessingArtifact != nil && cfg.ProcessingArtifact.RetentionDays < 0 {
+		errs = append(errs, "processing_artifact.retention_days must be >= 0")
+	}
+	if cfg.ProcessingArtifact != nil && cfg.ProcessingArtifact.CleanupIntervalHours <= 0 {
+		errs = append(errs, "processing_artifact.cleanup_interval_hours must be > 0")
+	}
+	if cfg.ProcessingArtifact != nil && cfg.ProcessingArtifact.CleanupIntervalHours > MaxProcessingArtifactCleanupIntervalHours {
+		errs = append(errs, fmt.Sprintf("processing_artifact.cleanup_interval_hours must be <= %d", MaxProcessingArtifactCleanupIntervalHours))
+	}
+	if cfg.ProcessingArtifact != nil && cfg.ProcessingArtifact.RetentionDays > MaxProcessingArtifactRetentionDays {
+		errs = append(errs, fmt.Sprintf("processing_artifact.retention_days must be <= %d", MaxProcessingArtifactRetentionDays))
+	}
+	if cfg.ProcessingArtifact != nil && (cfg.ProcessingArtifact.CleanupBatchSize < 1 || cfg.ProcessingArtifact.CleanupBatchSize > 1000) {
+		errs = append(errs, "processing_artifact.cleanup_batch_size must be between 1 and 1000")
 	}
 
 	if cfg.Conversation != nil {
@@ -916,6 +1022,55 @@ func applyAuditDefaults(cfg *Config) {
 			cfg.Audit.RetentionDays = n
 		}
 	}
+}
+
+func applyProcessingArtifactDefaults(cfg *Config) error {
+	if cfg.ProcessingArtifact == nil {
+		cfg.ProcessingArtifact = &ProcessingArtifactConfig{
+			MaxPayloadBytes:      DefaultProcessingArtifactMaxPayloadBytes,
+			RetentionDays:        30,
+			CleanupIntervalHours: 24,
+			CleanupBatchSize:     100,
+		}
+	} else {
+		if !cfg.ProcessingArtifact.maxPayloadBytesSet {
+			cfg.ProcessingArtifact.MaxPayloadBytes = DefaultProcessingArtifactMaxPayloadBytes
+		}
+		if !cfg.ProcessingArtifact.retentionDaysSet {
+			cfg.ProcessingArtifact.RetentionDays = 30
+		}
+		if !cfg.ProcessingArtifact.cleanupIntervalHoursSet {
+			cfg.ProcessingArtifact.CleanupIntervalHours = 24
+		}
+		if !cfg.ProcessingArtifact.cleanupBatchSizeSet {
+			cfg.ProcessingArtifact.CleanupBatchSize = 100
+		}
+	}
+	overrides := []struct {
+		name string
+		set  func(int)
+	}{
+		{"WEKNORA_PROCESSING_ARTIFACT_MAX_PAYLOAD_BYTES", func(value int) { cfg.ProcessingArtifact.MaxPayloadBytes = value }},
+		{"WEKNORA_PROCESSING_ARTIFACT_RETENTION_DAYS", func(value int) { cfg.ProcessingArtifact.RetentionDays = value }},
+		{"WEKNORA_PROCESSING_ARTIFACT_CLEANUP_INTERVAL_HOURS", func(value int) { cfg.ProcessingArtifact.CleanupIntervalHours = value }},
+		{"WEKNORA_PROCESSING_ARTIFACT_CLEANUP_BATCH_SIZE", func(value int) { cfg.ProcessingArtifact.CleanupBatchSize = value }},
+	}
+	for _, override := range overrides {
+		rawValue, ok := os.LookupEnv(override.name)
+		if !ok {
+			continue
+		}
+		value := strings.TrimSpace(rawValue)
+		if value == "" {
+			return fmt.Errorf("invalid %s: value must not be blank", override.name)
+		}
+		parsed, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("invalid %s: %w", override.name, err)
+		}
+		override.set(parsed)
+	}
+	return nil
 }
 
 // into actual prompt text content. Only xxx_id fields are used;

--- a/internal/config/processing_artifact_test.go
+++ b/internal/config/processing_artifact_test.go
@@ -1,0 +1,145 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestProcessingArtifactConfigSupportsYAMLJSONAndEnvironment(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg := &Config{}
+		require.NoError(t, applyProcessingArtifactDefaults(cfg))
+		assert.Equal(t, 64<<20, cfg.ProcessingArtifact.MaxPayloadBytes)
+		assert.Equal(t, 30, cfg.ProcessingArtifact.RetentionDays)
+		assert.Equal(t, 24, cfg.ProcessingArtifact.CleanupIntervalHours)
+		assert.Equal(t, 100, cfg.ProcessingArtifact.CleanupBatchSize)
+	})
+
+	t.Run("yaml and json", func(t *testing.T) {
+		for _, decode := range []struct {
+			data   []byte
+			decode func([]byte, *Config) error
+		}{
+			{[]byte("processing_artifact:\n  max_payload_bytes: 3\n"), func(data []byte, cfg *Config) error { return yaml.Unmarshal(data, cfg) }},
+			{[]byte(`{"processing_artifact":{"max_payload_bytes":3}}`), func(data []byte, cfg *Config) error { return json.Unmarshal(data, cfg) }},
+		} {
+			cfg := &Config{}
+			require.NoError(t, decode.decode(decode.data, cfg))
+			require.NoError(t, applyProcessingArtifactDefaults(cfg))
+			assert.Equal(t, 3, cfg.ProcessingArtifact.MaxPayloadBytes)
+			assert.Equal(t, 30, cfg.ProcessingArtifact.RetentionDays)
+			assert.Equal(t, 24, cfg.ProcessingArtifact.CleanupIntervalHours)
+			assert.Equal(t, 100, cfg.ProcessingArtifact.CleanupBatchSize)
+		}
+	})
+
+	t.Run("explicit zero retention is preserved", func(t *testing.T) {
+		cfg := &Config{}
+		require.NoError(t, yaml.Unmarshal([]byte("processing_artifact:\n  max_payload_bytes: 3\n  retention_days: 0\n"), cfg))
+		require.NoError(t, applyProcessingArtifactDefaults(cfg))
+		assert.Equal(t, 0, cfg.ProcessingArtifact.RetentionDays)
+		assert.Equal(t, 24, cfg.ProcessingArtifact.CleanupIntervalHours)
+		assert.Equal(t, 100, cfg.ProcessingArtifact.CleanupBatchSize)
+	})
+
+	t.Run("retention-only section keeps payload default", func(t *testing.T) {
+		for _, decode := range []struct {
+			data   []byte
+			decode func([]byte, *Config) error
+		}{
+			{[]byte("processing_artifact:\n  retention_days: 0\n"), func(data []byte, cfg *Config) error { return yaml.Unmarshal(data, cfg) }},
+			{[]byte(`{"processing_artifact":{"retention_days":0}}`), func(data []byte, cfg *Config) error { return json.Unmarshal(data, cfg) }},
+		} {
+			cfg := &Config{}
+			require.NoError(t, decode.decode(decode.data, cfg))
+			require.NoError(t, applyProcessingArtifactDefaults(cfg))
+			assert.Equal(t, DefaultProcessingArtifactMaxPayloadBytes, cfg.ProcessingArtifact.MaxPayloadBytes)
+			assert.Equal(t, 0, cfg.ProcessingArtifact.RetentionDays)
+			require.NoError(t, ValidateConfig(cfg))
+		}
+	})
+
+	t.Run("environment overrides file", func(t *testing.T) {
+		t.Setenv("WEKNORA_PROCESSING_ARTIFACT_MAX_PAYLOAD_BYTES", "5")
+		t.Setenv("WEKNORA_PROCESSING_ARTIFACT_RETENTION_DAYS", "0")
+		t.Setenv("WEKNORA_PROCESSING_ARTIFACT_CLEANUP_INTERVAL_HOURS", "3")
+		t.Setenv("WEKNORA_PROCESSING_ARTIFACT_CLEANUP_BATCH_SIZE", "999")
+		cfg := &Config{ProcessingArtifact: &ProcessingArtifactConfig{MaxPayloadBytes: 3, RetentionDays: 1, CleanupIntervalHours: 2, CleanupBatchSize: 4}}
+		require.NoError(t, applyProcessingArtifactDefaults(cfg))
+		assert.Equal(t, 5, cfg.ProcessingArtifact.MaxPayloadBytes)
+		assert.Equal(t, 0, cfg.ProcessingArtifact.RetentionDays)
+		assert.Equal(t, 3, cfg.ProcessingArtifact.CleanupIntervalHours)
+		assert.Equal(t, 999, cfg.ProcessingArtifact.CleanupBatchSize)
+	})
+}
+
+func TestProcessingArtifactConfigRejectsInvalidPayloadLimits(t *testing.T) {
+	for _, value := range []int{0, -1} {
+		err := ValidateConfig(&Config{ProcessingArtifact: &ProcessingArtifactConfig{MaxPayloadBytes: value}})
+		assert.Error(t, err)
+	}
+
+	for _, data := range [][]byte{
+		[]byte("processing_artifact:\n  max_payload_bytes: 0\n"),
+		[]byte(`{"processing_artifact":{"max_payload_bytes":-1}}`),
+	} {
+		cfg := &Config{}
+		if data[0] == '{' {
+			require.NoError(t, json.Unmarshal(data, cfg))
+		} else {
+			require.NoError(t, yaml.Unmarshal(data, cfg))
+		}
+		require.NoError(t, applyProcessingArtifactDefaults(cfg))
+		assert.Error(t, ValidateConfig(cfg))
+	}
+
+	t.Setenv("WEKNORA_PROCESSING_ARTIFACT_MAX_PAYLOAD_BYTES", "invalid")
+	assert.Error(t, applyProcessingArtifactDefaults(&Config{}))
+}
+
+func TestProcessingArtifactConfigRejectsInvalidRetentionSettings(t *testing.T) {
+	for _, cfg := range []*ProcessingArtifactConfig{
+		{MaxPayloadBytes: 1, RetentionDays: -1, CleanupIntervalHours: 24, CleanupBatchSize: 100},
+		{MaxPayloadBytes: 1, RetentionDays: 30, CleanupIntervalHours: 0, CleanupBatchSize: 100},
+		{MaxPayloadBytes: 1, RetentionDays: 30, CleanupIntervalHours: 24, CleanupBatchSize: 0},
+		{MaxPayloadBytes: 1, RetentionDays: 30, CleanupIntervalHours: 24, CleanupBatchSize: 1001},
+	} {
+		assert.Error(t, ValidateConfig(&Config{ProcessingArtifact: cfg}))
+	}
+
+	valid := &ProcessingArtifactConfig{
+		MaxPayloadBytes:      DefaultProcessingArtifactMaxPayloadBytes,
+		RetentionDays:        MaxProcessingArtifactRetentionDays,
+		CleanupIntervalHours: MaxProcessingArtifactCleanupIntervalHours,
+		CleanupBatchSize:     100,
+	}
+	assert.NoError(t, ValidateConfig(&Config{ProcessingArtifact: valid}))
+	for _, cfg := range []*ProcessingArtifactConfig{
+		{MaxPayloadBytes: 1, RetentionDays: MaxProcessingArtifactRetentionDays + 1, CleanupIntervalHours: 24, CleanupBatchSize: 100},
+		{MaxPayloadBytes: 1, RetentionDays: 30, CleanupIntervalHours: MaxProcessingArtifactCleanupIntervalHours + 1, CleanupBatchSize: 100},
+	} {
+		assert.Error(t, ValidateConfig(&Config{ProcessingArtifact: cfg}))
+	}
+
+	for _, name := range []string{
+		"WEKNORA_PROCESSING_ARTIFACT_RETENTION_DAYS",
+		"WEKNORA_PROCESSING_ARTIFACT_CLEANUP_INTERVAL_HOURS",
+		"WEKNORA_PROCESSING_ARTIFACT_CLEANUP_BATCH_SIZE",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(name, "invalid")
+			assert.Error(t, applyProcessingArtifactDefaults(&Config{}))
+		})
+	}
+
+	for _, value := range []string{"", "   "} {
+		t.Run("blank override", func(t *testing.T) {
+			t.Setenv("WEKNORA_PROCESSING_ARTIFACT_RETENTION_DAYS", value)
+			assert.Error(t, applyProcessingArtifactDefaults(&Config{}))
+		})
+	}
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -97,8 +97,42 @@ func registerProcessingArtifactRepository(container *dig.Container) {
 	must(container.Provide(repository.NewProcessingArtifactRepository))
 }
 
+func registerProcessingArtifactCounterRegistry(container *dig.Container) {
+	must(container.Provide(service.NewProcessingArtifactCounterRegistry))
+}
+
+type processingArtifactStoreParams struct {
+	dig.In
+
+	Config           *config.Config
+	Repository       interfaces.ProcessingArtifactRepository
+	TenantRepository interfaces.TenantRepository
+	FileService      interfaces.FileService
+	StorageResolver  interfaces.StorageBackendResolver
+	Counters         interfaces.ProcessingArtifactCounterRegistry
+}
+
 func registerProcessingArtifactStore(container *dig.Container) {
-	must(container.Provide(service.NewProcessingArtifactStore))
+	must(container.Provide(func(params processingArtifactStoreParams) interfaces.ProcessingArtifactStore {
+		return service.NewProcessingArtifactStoreWithDependencies(
+			params.Repository,
+			params.TenantRepository,
+			params.FileService,
+			params.StorageResolver,
+			params.Config.ProcessingArtifact.MaxPayloadBytes,
+			params.Counters,
+		)
+	}))
+}
+
+func registerProcessingArtifactRetentionService(container *dig.Container) {
+	must(container.Provide(func(store interfaces.ProcessingArtifactStore) (interfaces.ProcessingArtifactRetentionService, error) {
+		retention, ok := store.(interfaces.ProcessingArtifactRetentionService)
+		if !ok {
+			return nil, fmt.Errorf("processing artifact store does not support retention")
+		}
+		return retention, nil
+	}))
 }
 
 // BuildContainer constructs the dependency injection container
@@ -157,6 +191,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewKnowledgeSpanRepository))
 	must(container.Provide(repository.NewChunkRepository))
 	registerProcessingArtifactRepository(container)
+	registerProcessingArtifactCounterRegistry(container)
 	must(container.Provide(repository.NewKnowledgeTagRepository))
 	must(container.Provide(repository.NewSessionRepository))
 	must(container.Provide(repository.NewMessageRepository))
@@ -206,6 +241,8 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(service.NewSpanTracker))
 	must(container.Provide(service.NewChunkService))
 	registerProcessingArtifactStore(container)
+	registerProcessingArtifactRetentionService(container)
+	must(container.Provide(service.NewProcessingArtifactRetentionRunner))
 	must(container.Provide(service.NewKnowledgeTagService))
 	must(container.Provide(embedding.NewBatchEmbedder))
 	must(container.Provide(service.NewModelService))
@@ -323,6 +360,8 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	logger.Debugf(ctx, "[Container] Data source sync framework registered")
 	must(container.Invoke(startAuditLogRetention))
 	logger.Debugf(ctx, "[Container] Audit log retention runner registered")
+	must(container.Invoke(startProcessingArtifactRetention))
+	logger.Debugf(ctx, "[Container] Processing artifact retention runner registered")
 	must(container.Provide(service.NewHousekeepingService))
 	must(container.Invoke(startHousekeepingService))
 	logger.Debugf(ctx, "[Container] Knowledge housekeeping runner registered")
@@ -1617,6 +1656,17 @@ func startAuditLogRetention(
 ) {
 	runner.Start(context.Background())
 	cleaner.RegisterWithName("AuditLogRetentionRunner", func() error {
+		runner.Stop()
+		return nil
+	})
+}
+
+func startProcessingArtifactRetention(
+	runner *service.ProcessingArtifactRetentionRunner,
+	cleaner interfaces.ResourceCleaner,
+) {
+	runner.Start(context.Background())
+	cleaner.RegisterWithName("ProcessingArtifactRetentionRunner", func() error {
 		runner.Stop()
 		return nil
 	})

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -93,6 +93,14 @@ import (
 	wgrpc "github.com/weaviate/weaviate-go-client/v5/weaviate/grpc"
 )
 
+func registerProcessingArtifactRepository(container *dig.Container) {
+	must(container.Provide(repository.NewProcessingArtifactRepository))
+}
+
+func registerProcessingArtifactStore(container *dig.Container) {
+	must(container.Provide(service.NewProcessingArtifactStore))
+}
+
 // BuildContainer constructs the dependency injection container
 // Registers all components, services, repositories and handlers needed by the application
 // Creates a fully configured application container with proper dependency resolution
@@ -148,6 +156,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewKnowledgeRepository))
 	must(container.Provide(repository.NewKnowledgeSpanRepository))
 	must(container.Provide(repository.NewChunkRepository))
+	registerProcessingArtifactRepository(container)
 	must(container.Provide(repository.NewKnowledgeTagRepository))
 	must(container.Provide(repository.NewSessionRepository))
 	must(container.Provide(repository.NewMessageRepository))
@@ -196,6 +205,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(service.NewKnowledgeService))
 	must(container.Provide(service.NewSpanTracker))
 	must(container.Provide(service.NewChunkService))
+	registerProcessingArtifactStore(container)
 	must(container.Provide(service.NewKnowledgeTagService))
 	must(container.Provide(embedding.NewBatchEmbedder))
 	must(container.Provide(service.NewModelService))

--- a/internal/container/processing_artifact_test.go
+++ b/internal/container/processing_artifact_test.go
@@ -1,0 +1,37 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/application/service/file"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/dig"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type processingArtifactTenantRepository struct {
+	interfaces.TenantRepository
+}
+
+func TestProcessingArtifactProvidersResolveStore(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.ProcessingArtifact{}))
+
+	c := dig.New()
+	require.NoError(t, c.Provide(func() *gorm.DB { return db }))
+	require.NoError(t, c.Provide(func() interfaces.TenantRepository {
+		return &processingArtifactTenantRepository{}
+	}))
+	require.NoError(t, c.Provide(file.NewDummyFileService))
+
+	registerProcessingArtifactRepository(c)
+	registerProcessingArtifactStore(c)
+
+	require.NoError(t, c.Invoke(func(store interfaces.ProcessingArtifactStore) {
+		require.NotNil(t, store)
+	}))
+}

--- a/internal/container/processing_artifact_test.go
+++ b/internal/container/processing_artifact_test.go
@@ -1,9 +1,11 @@
 package container
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Tencent/WeKnora/internal/application/service/file"
+	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"github.com/stretchr/testify/require"
@@ -16,6 +18,27 @@ type processingArtifactTenantRepository struct {
 	interfaces.TenantRepository
 }
 
+type processingArtifactStorageResolver struct{}
+
+func (*processingArtifactStorageResolver) ResolveFileService(
+	context.Context,
+	*types.Tenant,
+	string,
+	string,
+	string,
+) (interfaces.FileService, string, error) {
+	return nil, "", nil
+}
+
+func (*processingArtifactStorageResolver) ResolveBackend(
+	context.Context,
+	*types.Tenant,
+	string,
+	string,
+) (*types.StorageBackend, error) {
+	return nil, nil
+}
+
 func TestProcessingArtifactProvidersResolveStore(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
@@ -26,12 +49,35 @@ func TestProcessingArtifactProvidersResolveStore(t *testing.T) {
 	require.NoError(t, c.Provide(func() interfaces.TenantRepository {
 		return &processingArtifactTenantRepository{}
 	}))
+	require.NoError(t, c.Provide(func() *config.Config {
+		return &config.Config{ProcessingArtifact: &config.ProcessingArtifactConfig{MaxPayloadBytes: 2}}
+	}))
 	require.NoError(t, c.Provide(file.NewDummyFileService))
+	require.NoError(t, c.Provide(func() interfaces.StorageBackendResolver {
+		return &processingArtifactStorageResolver{}
+	}))
 
 	registerProcessingArtifactRepository(c)
+	registerProcessingArtifactCounterRegistry(c)
 	registerProcessingArtifactStore(c)
+	registerProcessingArtifactRetentionService(c)
 
-	require.NoError(t, c.Invoke(func(store interfaces.ProcessingArtifactStore) {
+	require.NoError(t, c.Invoke(func(
+		store interfaces.ProcessingArtifactStore,
+		counters interfaces.ProcessingArtifactCounterRegistry,
+		retention interfaces.ProcessingArtifactRetentionService,
+	) {
 		require.NotNil(t, store)
+		require.NotNil(t, counters)
+		require.Same(t, store, retention)
+		key, keyErr := types.NewProcessingArtifactKey(1, "chunking", 1, []byte("configured-limit"))
+		require.NoError(t, keyErr)
+		_, created, putErr := store.PutIfAbsent(context.Background(), key, []byte("ok"))
+		require.NoError(t, putErr)
+		require.True(t, created)
+		_, created, putErr = store.PutIfAbsent(context.Background(), key, []byte("big"))
+		require.Error(t, putErr)
+		require.False(t, created)
+		require.NotEmpty(t, counters.Snapshot())
 	}))
 }

--- a/internal/infrastructure/docparser/artifact_identity_test.go
+++ b/internal/infrastructure/docparser/artifact_identity_test.go
@@ -1,0 +1,23 @@
+package docparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPDocumentReaderArtifactIdentityTracksReconnect(t *testing.T) {
+	reader, err := NewHTTPDocumentReader("https://docreader-one.example.com/")
+	require.NoError(t, err)
+	first := reader.ArtifactIdentity()
+	require.NotEmpty(t, first)
+
+	require.NoError(t, reader.Reconnect("https://docreader-two.example.com/"))
+	assert.NotEqual(t, first, reader.ArtifactIdentity())
+}
+
+func TestGRPCDocumentReaderArtifactIdentityUsesAddress(t *testing.T) {
+	reader := &GRPCDocumentReader{addr: "docreader:50051"}
+	assert.NotEmpty(t, reader.ArtifactIdentity())
+}

--- a/internal/infrastructure/docparser/grpc_parser.go
+++ b/internal/infrastructure/docparser/grpc_parser.go
@@ -96,6 +96,13 @@ func (p *GRPCDocumentReader) IsConnected() bool {
 	return p.conn != nil
 }
 
+// ArtifactIdentity identifies the current remote parser endpoint for cache invalidation.
+func (p *GRPCDocumentReader) ArtifactIdentity() string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return "grpc:" + p.addr
+}
+
 func (p *GRPCDocumentReader) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/infrastructure/docparser/http_parser.go
+++ b/internal/infrastructure/docparser/http_parser.go
@@ -85,6 +85,11 @@ func (p *HTTPDocumentReader) base() string {
 	return p.baseURL
 }
 
+// ArtifactIdentity identifies the current remote parser endpoint for cache invalidation.
+func (p *HTTPDocumentReader) ArtifactIdentity() string {
+	return "http:" + p.base()
+}
+
 func (p *HTTPDocumentReader) Reconnect(addr string) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/searchutil/imageinfo.go
+++ b/internal/searchutil/imageinfo.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/Tencent/WeKnora/internal/types"
@@ -56,10 +57,7 @@ func CollectImageInfoByChunkIDs(
 			aggMap[targetID] = agg
 		}
 		for _, info := range infos {
-			key := info.URL
-			if key == "" {
-				key = info.OriginalURL
-			}
+			key := imageInfoKey(info)
 			if key == "" {
 				continue
 			}
@@ -67,13 +65,7 @@ func CollectImageInfoByChunkIDs(
 			if !exists {
 				agg.byURL[key] = info
 			} else {
-				if info.OCRText != "" {
-					existing.OCRText = info.OCRText
-				}
-				if info.Caption != "" {
-					existing.Caption = info.Caption
-				}
-				agg.byURL[key] = existing
+				agg.byURL[key] = mergeImageInfo(existing, info)
 			}
 		}
 	}
@@ -110,11 +102,7 @@ func CollectImageInfoByChunkIDs(
 		if len(agg.byURL) == 0 {
 			continue
 		}
-		merged := make([]types.ImageInfo, 0, len(agg.byURL))
-		for _, info := range agg.byURL {
-			merged = append(merged, info)
-		}
-		data, err := json.Marshal(merged)
+		data, err := json.Marshal(sortedImageInfos(agg.byURL))
 		if err != nil {
 			continue
 		}
@@ -167,32 +155,70 @@ func MergeImageInfoJSON(perChunk map[string]string) string {
 	if len(perChunk) == 0 {
 		return ""
 	}
-	seen := make(map[string]bool)
-	var all []types.ImageInfo
+	byURL := make(map[string]types.ImageInfo)
 	for _, raw := range perChunk {
 		var infos []types.ImageInfo
 		if err := json.Unmarshal([]byte(raw), &infos); err != nil {
 			continue
 		}
 		for _, info := range infos {
-			key := info.URL
+			key := imageInfoKey(info)
 			if key == "" {
-				key = info.OriginalURL
+				continue
 			}
-			if key != "" && !seen[key] {
-				seen[key] = true
-				all = append(all, info)
+			if existing, ok := byURL[key]; ok {
+				byURL[key] = mergeImageInfo(existing, info)
+			} else {
+				byURL[key] = info
 			}
 		}
 	}
-	if len(all) == 0 {
+	if len(byURL) == 0 {
 		return ""
 	}
-	data, err := json.Marshal(all)
+	data, err := json.Marshal(sortedImageInfos(byURL))
 	if err != nil {
 		return ""
 	}
 	return string(data)
+}
+
+func imageInfoKey(info types.ImageInfo) string {
+	if info.URL != "" {
+		return info.URL
+	}
+	return info.OriginalURL
+}
+
+func mergeImageInfo(left, right types.ImageInfo) types.ImageInfo {
+	left.URL = stableNonEmptyString(left.URL, right.URL)
+	left.OriginalURL = stableNonEmptyString(left.OriginalURL, right.OriginalURL)
+	left.StartPos = min(left.StartPos, right.StartPos)
+	left.EndPos = min(left.EndPos, right.EndPos)
+	left.Caption = stableNonEmptyString(left.Caption, right.Caption)
+	left.OCRText = stableNonEmptyString(left.OCRText, right.OCRText)
+	return left
+}
+
+func stableNonEmptyString(left, right string) string {
+	if len(right) > len(left) || (len(right) == len(left) && right != "" && right < left) {
+		return right
+	}
+	return left
+}
+
+func sortedImageInfos(byURL map[string]types.ImageInfo) []types.ImageInfo {
+	keys := make([]string, 0, len(byURL))
+	for key := range byURL {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	infos := make([]types.ImageInfo, 0, len(keys))
+	for _, key := range keys {
+		infos = append(infos, byURL[key])
+	}
+	return infos
 }
 
 // EnrichContentWithImageInfo embeds image info as XML tags into text content.

--- a/internal/searchutil/imageinfo_stability_test.go
+++ b/internal/searchutil/imageinfo_stability_test.go
@@ -1,0 +1,70 @@
+package searchutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/require"
+)
+
+type imageInfoChunkRepository struct {
+	interfaces.ChunkRepository
+	children []*types.Chunk
+}
+
+func (r imageInfoChunkRepository) ListChunksByParentIDs(
+	context.Context,
+	uint64,
+	[]string,
+) ([]*types.Chunk, error) {
+	return r.children, nil
+}
+
+func TestMergeImageInfoJSONStableAcrossInputOrder(t *testing.T) {
+	forward := map[string]string{
+		"chunk": `[{"url":"b","caption":"caption-b"},{"url":"a","caption":"caption-z","ocr_text":"ocr-a"},{"url":"a","caption":"caption-a","ocr_text":"ocr-z"}]`,
+	}
+	reverse := map[string]string{
+		"chunk": `[{"url":"a","caption":"caption-a","ocr_text":"ocr-z"},{"url":"a","caption":"caption-z","ocr_text":"ocr-a"},{"url":"b","caption":"caption-b"}]`,
+	}
+
+	got := MergeImageInfoJSON(forward)
+	require.Equal(t, got, MergeImageInfoJSON(reverse))
+	require.JSONEq(t, `[
+		{"url":"a","original_url":"","start_pos":0,"end_pos":0,"caption":"caption-a","ocr_text":"ocr-a"},
+		{"url":"b","original_url":"","start_pos":0,"end_pos":0,"caption":"caption-b","ocr_text":""}
+	]`, got)
+}
+
+func TestCollectImageInfoByChunkIDsStableAcrossChildOrder(t *testing.T) {
+	first := &types.Chunk{
+		ChunkType:     types.ChunkTypeImageCaption,
+		ParentChunkID: "parent",
+		ImageInfo:     `[{"url":"image","caption":"caption-z","ocr_text":"ocr-a"}]`,
+	}
+	second := &types.Chunk{
+		ChunkType:     types.ChunkTypeImageOCR,
+		ParentChunkID: "parent",
+		ImageInfo:     `[{"url":"image","caption":"caption-a","ocr_text":"ocr-z"}]`,
+	}
+
+	forward := CollectImageInfoByChunkIDs(
+		context.Background(),
+		imageInfoChunkRepository{children: []*types.Chunk{first, second}},
+		1,
+		[]string{"parent"},
+	)
+	reverse := CollectImageInfoByChunkIDs(
+		context.Background(),
+		imageInfoChunkRepository{children: []*types.Chunk{second, first}},
+		1,
+		[]string{"parent"},
+	)
+
+	require.Equal(t, forward, reverse)
+	require.JSONEq(t, `[
+		{"url":"image","original_url":"","start_pos":0,"end_pos":0,"caption":"caption-a","ocr_text":"ocr-a"}
+	]`, forward["parent"])
+}

--- a/internal/types/chunk_identity.go
+++ b/internal/types/chunk_identity.go
@@ -1,0 +1,115 @@
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const (
+	chunkIdentityVersion                 = "chunk-id:v1"
+	embeddingFingerprintVersion          = "embedding:v1"
+	ChunkEmbeddingFingerprintMetadataKey = "_weknora_embedding_fingerprint"
+)
+
+type ChunkIDAllocator struct {
+	knowledgeID string
+	occurrences map[string]int
+}
+
+func NewChunkIDAllocator(knowledgeID string) *ChunkIDAllocator {
+	return &ChunkIDAllocator{knowledgeID: knowledgeID, occurrences: make(map[string]int)}
+}
+
+func NormalizeChunkContent(content string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r", "\n")
+	return strings.TrimSpace(content)
+}
+
+func ChunkContentHash(content string) string {
+	return sha256Hex([]byte(NormalizeChunkContent(content)))
+}
+
+func (a *ChunkIDAllocator) Next(chunkType ChunkType, content string) (string, string) {
+	contentHash := ChunkContentHash(content)
+	occurrenceKey := string(chunkType) + "\x00" + contentHash
+	occurrence := a.occurrences[occurrenceKey]
+	a.occurrences[occurrenceKey] = occurrence + 1
+
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		chunkIdentityVersion,
+		a.knowledgeID,
+		string(chunkType),
+		contentHash,
+		strconv.Itoa(occurrence),
+	}, "\x00")))
+	idBytes := append([]byte(nil), sum[:16]...)
+	idBytes[6] = (idBytes[6] & 0x0f) | 0x50
+	idBytes[8] = (idBytes[8] & 0x3f) | 0x80
+	id, err := uuid.FromBytes(idBytes)
+	if err != nil {
+		panic(err)
+	}
+	return id.String(), contentHash
+}
+
+func EmbeddingInput(title, contextHeader, content string) string {
+	body := NormalizeChunkContent(content)
+	if contextHeader != "" {
+		body = contextHeader + "\n\n" + body
+	}
+	if title = strings.TrimSpace(title); title != "" {
+		body = title + "\n" + body
+	}
+	return body
+}
+
+func EmbeddingFingerprint(modelKey string, dimensions int, input string) string {
+	return sha256Hex([]byte(strings.Join([]string{
+		embeddingFingerprintVersion,
+		modelKey,
+		strconv.Itoa(dimensions),
+		input,
+	}, "\x00")))
+}
+
+func ChunkEmbeddingFingerprint(metadata JSON) string {
+	values, err := metadata.Map()
+	if err != nil {
+		return ""
+	}
+	fingerprint, _ := values[ChunkEmbeddingFingerprintMetadataKey].(string)
+	return fingerprint
+}
+
+func WithChunkEmbeddingFingerprint(metadata JSON, fingerprint string) (JSON, error) {
+	values := make(map[string]json.RawMessage)
+	if len(metadata) > 0 {
+		err := json.Unmarshal(metadata, &values)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if values == nil {
+		values = make(map[string]json.RawMessage)
+	}
+
+	fingerprintData, err := json.Marshal(fingerprint)
+	if err != nil {
+		return nil, err
+	}
+	values[ChunkEmbeddingFingerprintMetadataKey] = fingerprintData
+
+	data, err := json.Marshal(values)
+	return JSON(data), err
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/types/chunk_identity_test.go
+++ b/internal/types/chunk_identity_test.go
@@ -1,0 +1,88 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeChunkContentCanonicalizesWhitespace(t *testing.T) {
+	assert.Equal(t, "alpha\nbeta", NormalizeChunkContent("  alpha\r\nbeta  "))
+	assert.Equal(t, "alpha\nbeta", NormalizeChunkContent("alpha\rbeta"))
+}
+
+func TestChunkIDAllocatorIsStableAndDisambiguatesDuplicates(t *testing.T) {
+	first := NewChunkIDAllocator("knowledge-1")
+	id1, hash1 := first.Next(ChunkTypeText, "  alpha\r\n")
+	id2, hash2 := first.Next(ChunkTypeText, "alpha\n")
+
+	second := NewChunkIDAllocator("knowledge-1")
+	again1, againHash1 := second.Next(ChunkTypeText, "alpha\n")
+	again2, againHash2 := second.Next(ChunkTypeText, "alpha\r\n")
+
+	assert.Len(t, id1, 36)
+	assert.NotEqual(t, id1, id2)
+	assert.Equal(t, id1, again1)
+	assert.Equal(t, id2, again2)
+	assert.Equal(t, hash1, hash2)
+	assert.Equal(t, hash1, againHash1)
+	assert.Equal(t, hash2, againHash2)
+}
+
+func TestChunkIDAllocatorDoesNotChurnAfterUnrelatedInsertion(t *testing.T) {
+	before := NewChunkIDAllocator("knowledge-1")
+	alphaBefore, _ := before.Next(ChunkTypeText, "alpha")
+	betaBefore, _ := before.Next(ChunkTypeText, "beta")
+
+	after := NewChunkIDAllocator("knowledge-1")
+	_, _ = after.Next(ChunkTypeText, "inserted")
+	alphaAfter, _ := after.Next(ChunkTypeText, "alpha")
+	betaAfter, _ := after.Next(ChunkTypeText, "beta")
+
+	assert.Equal(t, alphaBefore, alphaAfter)
+	assert.Equal(t, betaBefore, betaAfter)
+}
+
+func TestEmbeddingFingerprintIncludesEffectiveInputs(t *testing.T) {
+	baseInput := EmbeddingInput("Document", "# Heading", " body ")
+	base := EmbeddingFingerprint("model-1", 1536, baseInput)
+
+	assert.NotEqual(t, base, EmbeddingFingerprint("model-2", 1536, baseInput))
+	assert.NotEqual(t, base, EmbeddingFingerprint("model-1", 3072, baseInput))
+	assert.NotEqual(t, base, EmbeddingFingerprint("model-1", 1536,
+		EmbeddingInput("Other", "# Heading", " body ")))
+	assert.NotEqual(t, base, EmbeddingFingerprint("model-1", 1536,
+		EmbeddingInput("Document", "# Other", " body ")))
+}
+
+func TestWithChunkEmbeddingFingerprintPreservesMetadata(t *testing.T) {
+	metadata, err := json.Marshal(map[string]any{"questions": []string{"q1"}})
+	require.NoError(t, err)
+
+	updated, err := WithChunkEmbeddingFingerprint(JSON(metadata), "fingerprint")
+	require.NoError(t, err)
+	assert.Equal(t, "fingerprint", ChunkEmbeddingFingerprint(updated))
+
+	values, err := updated.Map()
+	require.NoError(t, err)
+	assert.Equal(t, []any{"q1"}, values["questions"])
+}
+
+func TestWithChunkEmbeddingFingerprintInitializesNullMetadata(t *testing.T) {
+	updated, err := WithChunkEmbeddingFingerprint(JSON("null"), "fingerprint")
+	require.NoError(t, err)
+	assert.Equal(t, "fingerprint", ChunkEmbeddingFingerprint(updated))
+	assert.JSONEq(t, `{"_weknora_embedding_fingerprint":"fingerprint"}`, string(updated))
+}
+
+func TestWithChunkEmbeddingFingerprintPreservesLargeNumberTokens(t *testing.T) {
+	metadata := JSON(`{"document_id":9007199254740993}`)
+
+	updated, err := WithChunkEmbeddingFingerprint(metadata, "fingerprint")
+	require.NoError(t, err)
+
+	assert.Contains(t, string(updated), `"document_id":9007199254740993`)
+	assert.Equal(t, "fingerprint", ChunkEmbeddingFingerprint(updated))
+}

--- a/internal/types/const.go
+++ b/internal/types/const.go
@@ -29,6 +29,8 @@ const (
 	SessionTenantIDContextKey ContextKey = "SessionTenantID"
 	// EmbedQueryContextKey is the context key for embedding query text
 	EmbedQueryContextKey ContextKey = "EmbedQuery"
+	// EmbedDocumentContextKey marks text that will be persisted in a retrieval index.
+	EmbedDocumentContextKey ContextKey = "EmbedDocument"
 	// LanguageContextKey is the context key for user language preference (e.g. "zh-CN", "en-US")
 	LanguageContextKey ContextKey = "Language"
 	// EmbedVisitorContextKey is the anonymous visitor id for embed OAuth isolation.

--- a/internal/types/extract_graph.go
+++ b/internal/types/extract_graph.go
@@ -23,9 +23,10 @@ type GraphNode struct {
 
 // GraphRelation represents the relation of the graph
 type GraphRelation struct {
-	Node1 string `json:"node1,omitempty"`
-	Node2 string `json:"node2,omitempty"`
-	Type  string `json:"type,omitempty"`
+	Node1  string   `json:"node1,omitempty"`
+	Node2  string   `json:"node2,omitempty"`
+	Type   string   `json:"type,omitempty"`
+	Chunks []string `json:"chunks,omitempty"`
 }
 
 type GraphData struct {

--- a/internal/types/interfaces/chunk.go
+++ b/internal/types/interfaces/chunk.go
@@ -30,6 +30,8 @@ type ChunkRepository interface {
 	ListChunksBySeqID(ctx context.Context, tenantID uint64, seqIDs []int64) ([]*types.Chunk, error)
 	// ListChunksByKnowledgeID lists chunks by knowledge id
 	ListChunksByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) ([]*types.Chunk, error)
+	// ListAllChunksByKnowledgeID lists all chunk types by knowledge id.
+	ListAllChunksByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) ([]*types.Chunk, error)
 	// ListPagedChunksByKnowledgeID lists paged chunks by knowledge id.
 	// When tagID is non-empty, results are filtered by tag_id.
 	// knowledgeType: "faq" or "manual" - determines sort order and search behavior
@@ -56,10 +58,14 @@ type ChunkRepository interface {
 	UpdateChunk(ctx context.Context, chunk *types.Chunk) error
 	// UpdateChunks updates chunks in batch
 	UpdateChunks(ctx context.Context, chunks []*types.Chunk) error
+	// UpdateChunksForReparse updates the fields owned by reparsing while preserving stable identity fields.
+	UpdateChunksForReparse(ctx context.Context, tenantID uint64, chunks []*types.Chunk) error
 	// DeleteChunk deletes a chunk
 	DeleteChunk(ctx context.Context, tenantID uint64, id string) error
 	// DeleteChunks deletes chunks by IDs in batch
 	DeleteChunks(ctx context.Context, tenantID uint64, ids []string) error
+	// HardDeleteChunks permanently deletes chunks by IDs in batch.
+	HardDeleteChunks(ctx context.Context, tenantID uint64, ids []string) error
 	// DeleteChunksByKnowledgeID deletes chunks by knowledge id
 	DeleteChunksByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) error
 	// DeleteByKnowledgeList deletes all chunks for a knowledge list

--- a/internal/types/interfaces/file.go
+++ b/internal/types/interfaces/file.go
@@ -14,10 +14,13 @@ type FileService interface {
 	CheckConnectivity(ctx context.Context) error
 	// SaveFile saves a file.
 	SaveFile(ctx context.Context, file *multipart.FileHeader, tenantID uint64, knowledgeID string) (string, error)
-	// SaveBytes saves bytes data to a file and returns the file path.
+	// SaveBytes saves bytes data to a new independently deletable object and
+	// returns its unique path. Successful calls must never overwrite or reuse
+	// the path of any other successful SaveBytes call.
 	// If temp is true, the file will be saved to a temporary storage that may auto-expire.
 	SaveBytes(ctx context.Context, data []byte, tenantID uint64, fileName string, temp bool) (string, error)
-	// GetFile retrieves a file.
+	// GetFile retrieves a file. Missing objects return an error wrapping fs.ErrNotExist,
+	// whether absence is detected here or by the returned reader.
 	GetFile(ctx context.Context, filePath string) (io.ReadCloser, error)
 	// GetFileURL returns a download URL for the file (if supported by the storage backend).
 	GetFileURL(ctx context.Context, filePath string) (string, error)

--- a/internal/types/interfaces/knowledge.go
+++ b/internal/types/interfaces/knowledge.go
@@ -217,6 +217,12 @@ type KnowledgeRepository interface {
 		tenantID uint64, kbID string, page *types.Pagination, filter types.KnowledgeListFilter,
 	) ([]*types.Knowledge, int64, error)
 	UpdateKnowledge(ctx context.Context, knowledge *types.Knowledge) error
+	// UpdateKnowledgeAndTenantStorage atomically persists a knowledge's storage
+	// total and applies the exact delta to its tenant usage.
+	UpdateKnowledgeAndTenantStorage(ctx context.Context, knowledge *types.Knowledge) (int64, error)
+	// WithKnowledgeReconciliation serializes a destructive reconciliation for one
+	// knowledge item and provides its transaction through the callback context.
+	WithKnowledgeReconciliation(ctx context.Context, tenantID uint64, knowledgeID string, fn func(context.Context) error) error
 	// UpdateKnowledgeBatch updates knowledge items in batch
 	UpdateKnowledgeBatch(ctx context.Context, knowledgeList []*types.Knowledge) error
 	DeleteKnowledge(ctx context.Context, tenantID uint64, id string) error

--- a/internal/types/interfaces/processing_artifact.go
+++ b/internal/types/interfaces/processing_artifact.go
@@ -2,18 +2,22 @@ package interfaces
 
 import (
 	"context"
+	"time"
 
 	"github.com/Tencent/WeKnora/internal/types"
 )
 
 type ProcessingArtifactRepository interface {
 	Get(ctx context.Context, key types.ProcessingArtifactKey) (*types.ProcessingArtifact, error)
+	ListExpired(ctx context.Context, cutoff time.Time, afterID uint64, limit int) ([]*types.ProcessingArtifact, error)
 	PutIfAbsent(ctx context.Context, artifact *types.ProcessingArtifact) (created bool, err error)
 	DeleteByID(ctx context.Context, tenantID, id uint64) error
+	DeleteByIDWithResult(ctx context.Context, tenantID, id uint64) (removed bool, err error)
 }
 
 type ProcessingArtifactStore interface {
 	Get(ctx context.Context, key types.ProcessingArtifactKey) (value []byte, hit bool, err error)
+	Invalidate(ctx context.Context, key types.ProcessingArtifactKey, observed []byte) error
 	PutIfAbsent(ctx context.Context, key types.ProcessingArtifactKey, value []byte) (
 		canonical []byte, created bool, err error,
 	)
@@ -27,4 +31,13 @@ type ProcessingArtifactBatchStore interface {
 	PutManyIfAbsent(ctx context.Context, values map[types.ProcessingArtifactKey][]byte) (
 		canonical map[types.ProcessingArtifactKey][]byte, err error,
 	)
+}
+
+type ProcessingArtifactCounterRegistry interface {
+	Record(stage, outcome string)
+	Snapshot() []types.ProcessingArtifactCounter
+}
+
+type ProcessingArtifactRetentionService interface {
+	PurgeExpired(ctx context.Context, cutoff time.Time, batchSize int) (types.ProcessingArtifactPurgeResult, error)
 }

--- a/internal/types/interfaces/processing_artifact.go
+++ b/internal/types/interfaces/processing_artifact.go
@@ -1,0 +1,20 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+type ProcessingArtifactRepository interface {
+	Get(ctx context.Context, key types.ProcessingArtifactKey) (*types.ProcessingArtifact, error)
+	PutIfAbsent(ctx context.Context, artifact *types.ProcessingArtifact) (created bool, err error)
+	DeleteByID(ctx context.Context, tenantID, id uint64) error
+}
+
+type ProcessingArtifactStore interface {
+	Get(ctx context.Context, key types.ProcessingArtifactKey) (value []byte, hit bool, err error)
+	PutIfAbsent(ctx context.Context, key types.ProcessingArtifactKey, value []byte) (
+		canonical []byte, created bool, err error,
+	)
+}

--- a/internal/types/interfaces/processing_artifact.go
+++ b/internal/types/interfaces/processing_artifact.go
@@ -18,3 +18,13 @@ type ProcessingArtifactStore interface {
 		canonical []byte, created bool, err error,
 	)
 }
+
+type ProcessingArtifactBatchStore interface {
+	ProcessingArtifactStore
+	GetMany(ctx context.Context, keys []types.ProcessingArtifactKey) (
+		values map[types.ProcessingArtifactKey][]byte, err error,
+	)
+	PutManyIfAbsent(ctx context.Context, values map[types.ProcessingArtifactKey][]byte) (
+		canonical map[types.ProcessingArtifactKey][]byte, err error,
+	)
+}

--- a/internal/types/interfaces/retriever_graph.go
+++ b/internal/types/interfaces/retriever_graph.go
@@ -10,6 +10,20 @@ import (
 type RetrieveGraphRepository interface {
 	// AddGraph adds a graph to the repository
 	AddGraph(ctx context.Context, namespace types.NameSpace, graphs []*types.GraphData) error
+	// FenceGraphAttempt prevents older extraction tasks from publishing after reconciliation starts.
+	FenceGraphAttempt(ctx context.Context, namespace types.NameSpace, attempt int) error
+	// RecoverGraphNamespace completes an interrupted full namespace deletion.
+	RecoverGraphNamespace(ctx context.Context, namespace types.NameSpace) error
+	// ReplaceGraphChunk atomically replaces one chunk's graph ownership.
+	ReplaceGraphChunk(
+		ctx context.Context,
+		namespace types.NameSpace,
+		chunkID string,
+		attempt int,
+		graph *types.GraphData,
+	) error
+	// DelGraphChunks retracts graph ownership for removed chunks.
+	DelGraphChunks(ctx context.Context, namespace types.NameSpace, chunkIDs []string) error
 	// DelGraph deletes a graph from the repository
 	DelGraph(ctx context.Context, namespace []types.NameSpace) error
 	// SearchNode searches for nodes in the repository

--- a/internal/types/processing_artifact.go
+++ b/internal/types/processing_artifact.go
@@ -1,0 +1,76 @@
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"regexp"
+	"time"
+)
+
+const processingArtifactFingerprintDomain = "weknora-processing-artifact-input-v1"
+
+var (
+	processingArtifactStagePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+	ErrProcessingArtifactNotFound  = errors.New("processing artifact not found")
+)
+
+type ProcessingArtifactKey struct {
+	TenantID         uint64
+	Stage            string
+	KeyVersion       uint16
+	InputFingerprint string
+}
+
+func NewProcessingArtifactKey(tenantID uint64, stage string, keyVersion uint16, inputParts ...[]byte) (ProcessingArtifactKey, error) {
+	if tenantID == 0 {
+		return ProcessingArtifactKey{}, errors.New("processing artifact tenant ID must not be zero")
+	}
+	if !processingArtifactStagePattern.MatchString(stage) {
+		return ProcessingArtifactKey{}, fmt.Errorf("invalid processing artifact stage %q", stage)
+	}
+	if keyVersion == 0 {
+		return ProcessingArtifactKey{}, errors.New("processing artifact key version must not be zero")
+	}
+	if len(inputParts) == 0 {
+		return ProcessingArtifactKey{}, errors.New("processing artifact input parts must not be empty")
+	}
+
+	hash := sha256.New()
+	writeProcessingArtifactFingerprintPart(hash, []byte(processingArtifactFingerprintDomain))
+	for _, inputPart := range inputParts {
+		writeProcessingArtifactFingerprintPart(hash, inputPart)
+	}
+
+	return ProcessingArtifactKey{
+		TenantID:         tenantID,
+		Stage:            stage,
+		KeyVersion:       keyVersion,
+		InputFingerprint: hex.EncodeToString(hash.Sum(nil)),
+	}, nil
+}
+
+func writeProcessingArtifactFingerprintPart(hasher hash.Hash, part []byte) {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(part)))
+	_, _ = hasher.Write(length[:])
+	_, _ = hasher.Write(part)
+}
+
+type ProcessingArtifact struct {
+	ID               uint64    `gorm:"primaryKey"`
+	TenantID         uint64    `gorm:"not null;uniqueIndex:idx_processing_artifacts_key,priority:1"`
+	Stage            string    `gorm:"size:64;not null;uniqueIndex:idx_processing_artifacts_key,priority:2"`
+	KeyVersion       uint16    `gorm:"not null;uniqueIndex:idx_processing_artifacts_key,priority:3"`
+	InputFingerprint string    `gorm:"size:64;not null;uniqueIndex:idx_processing_artifacts_key,priority:4"`
+	Payload          []byte    `gorm:"type:bytea"`
+	ObjectPath       string    `gorm:"type:text;not null;default:''"`
+	ContentSHA256    string    `gorm:"size:64;not null"`
+	SizeBytes        int64     `gorm:"not null"`
+	CreatedAt        time.Time `gorm:"not null"`
+}
+
+func (ProcessingArtifact) TableName() string { return "processing_artifacts" }

--- a/internal/types/processing_artifact.go
+++ b/internal/types/processing_artifact.go
@@ -25,11 +25,28 @@ type ProcessingArtifactKey struct {
 	InputFingerprint string
 }
 
+type ProcessingArtifactCounter struct {
+	Stage   string `json:"stage"`
+	Outcome string `json:"outcome"`
+	Count   uint64 `json:"count"`
+}
+
+type ProcessingArtifactPurgeResult struct {
+	Scanned      uint64 `json:"scanned"`
+	Deleted      uint64 `json:"deleted"`
+	Failed       uint64 `json:"failed"`
+	DeletedBytes int64  `json:"deleted_bytes"`
+}
+
+func IsValidProcessingArtifactStage(stage string) bool {
+	return processingArtifactStagePattern.MatchString(stage)
+}
+
 func NewProcessingArtifactKey(tenantID uint64, stage string, keyVersion uint16, inputParts ...[]byte) (ProcessingArtifactKey, error) {
 	if tenantID == 0 {
 		return ProcessingArtifactKey{}, errors.New("processing artifact tenant ID must not be zero")
 	}
-	if !processingArtifactStagePattern.MatchString(stage) {
+	if !IsValidProcessingArtifactStage(stage) {
 		return ProcessingArtifactKey{}, fmt.Errorf("invalid processing artifact stage %q", stage)
 	}
 	if keyVersion == 0 {

--- a/internal/types/processing_artifact_test.go
+++ b/internal/types/processing_artifact_test.go
@@ -1,0 +1,56 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewProcessingArtifactKeyIsTenantStageAndVersionScoped(t *testing.T) {
+	base, err := NewProcessingArtifactKey(7, "embedding", 1, []byte("model-a"), []byte("hello"))
+	require.NoError(t, err)
+	same, err := NewProcessingArtifactKey(7, "embedding", 1, []byte("model-a"), []byte("hello"))
+	require.NoError(t, err)
+	otherTenant, _ := NewProcessingArtifactKey(8, "embedding", 1, []byte("model-a"), []byte("hello"))
+	otherStage, _ := NewProcessingArtifactKey(7, "vlm.ocr", 1, []byte("model-a"), []byte("hello"))
+	otherVersion, _ := NewProcessingArtifactKey(7, "embedding", 2, []byte("model-a"), []byte("hello"))
+
+	assert.Equal(t, base, same)
+	assert.NotEqual(t, base.TenantID, otherTenant.TenantID)
+	assert.NotEqual(t, base.Stage, otherStage.Stage)
+	assert.NotEqual(t, base.KeyVersion, otherVersion.KeyVersion)
+	assert.Equal(t, base.InputFingerprint, otherTenant.InputFingerprint)
+	assert.Equal(t, base.InputFingerprint, otherStage.InputFingerprint)
+	assert.Equal(t, base.InputFingerprint, otherVersion.InputFingerprint)
+	assert.Regexp(t, `^[0-9a-f]{64}$`, base.InputFingerprint)
+}
+
+func TestNewProcessingArtifactKeyUsesLengthPrefixedParts(t *testing.T) {
+	a, err := NewProcessingArtifactKey(7, "embedding", 1, []byte("ab"), []byte("c"))
+	require.NoError(t, err)
+	b, err := NewProcessingArtifactKey(7, "embedding", 1, []byte("a"), []byte("bc"))
+	require.NoError(t, err)
+	assert.NotEqual(t, a.InputFingerprint, b.InputFingerprint)
+}
+
+func TestNewProcessingArtifactKeyRejectsInvalidScope(t *testing.T) {
+	_, err := NewProcessingArtifactKey(0, "embedding", 1, []byte("x"))
+	assert.Error(t, err)
+	_, err = NewProcessingArtifactKey(1, "Embedding Secret", 1, []byte("x"))
+	assert.Error(t, err)
+	_, err = NewProcessingArtifactKey(1, "embedding", 0, []byte("x"))
+	assert.Error(t, err)
+}
+
+func TestNewProcessingArtifactKeyHasStableDomainSeparatedFingerprint(t *testing.T) {
+	key, err := NewProcessingArtifactKey(7, "embedding", 1, []byte("model-a"), []byte("hello"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "af92c53e8683f7ed5f93f7ea9c7ba574d9976a0928ade4ba470d53e5dd2c3510", key.InputFingerprint)
+}
+
+func TestNewProcessingArtifactKeyRejectsZeroInputParts(t *testing.T) {
+	_, err := NewProcessingArtifactKey(1, "embedding", 1)
+	assert.Error(t, err)
+}

--- a/migrations/mysql/00-init-db.sql
+++ b/migrations/mysql/00-init-db.sql
@@ -222,3 +222,6 @@ CREATE TABLE processing_artifacts (
 
 CREATE INDEX idx_processing_artifacts_tenant_created
     ON processing_artifacts (tenant_id, created_at);
+
+CREATE INDEX idx_processing_artifacts_created_id
+    ON processing_artifacts (created_at, id);

--- a/migrations/mysql/00-init-db.sql
+++ b/migrations/mysql/00-init-db.sql
@@ -204,3 +204,21 @@ CREATE TABLE chunks (
 CREATE INDEX idx_chunks_tenant_knowledge ON chunks(tenant_id, knowledge_id);
 CREATE INDEX idx_chunks_parent_id ON chunks(parent_chunk_id);
 CREATE INDEX idx_chunks_chunk_type ON chunks(chunk_type);
+
+CREATE TABLE processing_artifacts (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    tenant_id BIGINT UNSIGNED NOT NULL,
+    stage VARCHAR(64) NOT NULL,
+    key_version INTEGER NOT NULL,
+    input_fingerprint CHAR(64) NOT NULL,
+    payload LONGBLOB NULL,
+    object_path VARCHAR(2048) NOT NULL DEFAULT '',
+    content_sha256 CHAR(64) NOT NULL,
+    size_bytes BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_processing_artifacts_key
+        UNIQUE (tenant_id, stage, key_version, input_fingerprint)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE INDEX idx_processing_artifacts_tenant_created
+    ON processing_artifacts (tenant_id, created_at);

--- a/migrations/paradedb/00-init-db.sql
+++ b/migrations/paradedb/00-init-db.sql
@@ -184,6 +184,24 @@ CREATE INDEX IF NOT EXISTS idx_chunks_tenant_kg ON chunks(tenant_id, knowledge_i
 CREATE INDEX IF NOT EXISTS idx_chunks_parent_id ON chunks(parent_chunk_id);
 CREATE INDEX IF NOT EXISTS idx_chunks_chunk_type ON chunks(chunk_type);
 
+CREATE TABLE IF NOT EXISTS processing_artifacts (
+    id BIGSERIAL PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
+    stage VARCHAR(64) NOT NULL,
+    key_version INTEGER NOT NULL,
+    input_fingerprint CHAR(64) NOT NULL,
+    payload BYTEA NULL,
+    object_path TEXT NOT NULL DEFAULT '',
+    content_sha256 CHAR(64) NOT NULL,
+    size_bytes BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_processing_artifacts_key
+        UNIQUE (tenant_id, stage, key_version, input_fingerprint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_processing_artifacts_tenant_created
+    ON processing_artifacts (tenant_id, created_at);
+
 CREATE TABLE IF NOT EXISTS embeddings (
     id SERIAL PRIMARY KEY,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,

--- a/migrations/paradedb/00-init-db.sql
+++ b/migrations/paradedb/00-init-db.sql
@@ -202,6 +202,9 @@ CREATE TABLE IF NOT EXISTS processing_artifacts (
 CREATE INDEX IF NOT EXISTS idx_processing_artifacts_tenant_created
     ON processing_artifacts (tenant_id, created_at);
 
+CREATE INDEX IF NOT EXISTS idx_processing_artifacts_created_id
+    ON processing_artifacts (created_at, id);
+
 CREATE TABLE IF NOT EXISTS embeddings (
     id SERIAL PRIMARY KEY,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,

--- a/migrations/sqlite/000001_processing_artifacts.down.sql
+++ b/migrations/sqlite/000001_processing_artifacts.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_processing_artifacts_tenant_created;
+DROP TABLE IF EXISTS processing_artifacts;

--- a/migrations/sqlite/000001_processing_artifacts.down.sql
+++ b/migrations/sqlite/000001_processing_artifacts.down.sql
@@ -1,2 +1,3 @@
 DROP INDEX IF EXISTS idx_processing_artifacts_tenant_created;
+DROP INDEX IF EXISTS idx_processing_artifacts_created_id;
 DROP TABLE IF EXISTS processing_artifacts;

--- a/migrations/sqlite/000001_processing_artifacts.up.sql
+++ b/migrations/sqlite/000001_processing_artifacts.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS processing_artifacts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id INTEGER NOT NULL,
+    stage VARCHAR(64) NOT NULL,
+    key_version INTEGER NOT NULL,
+    input_fingerprint CHAR(64) NOT NULL,
+    payload BLOB NULL,
+    object_path TEXT NOT NULL DEFAULT '',
+    content_sha256 CHAR(64) NOT NULL,
+    size_bytes BIGINT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_processing_artifacts_key
+        UNIQUE (tenant_id, stage, key_version, input_fingerprint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_processing_artifacts_tenant_created
+    ON processing_artifacts (tenant_id, created_at);

--- a/migrations/sqlite/000001_processing_artifacts.up.sql
+++ b/migrations/sqlite/000001_processing_artifacts.up.sql
@@ -15,3 +15,6 @@ CREATE TABLE IF NOT EXISTS processing_artifacts (
 
 CREATE INDEX IF NOT EXISTS idx_processing_artifacts_tenant_created
     ON processing_artifacts (tenant_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_processing_artifacts_created_id
+    ON processing_artifacts (created_at, id);

--- a/migrations/versioned/000069_processing_artifacts.down.sql
+++ b/migrations/versioned/000069_processing_artifacts.down.sql
@@ -1,6 +1,7 @@
 DO $$ BEGIN RAISE NOTICE '[Migration 000066 down] Dropping processing_artifacts...'; END $$;
 
 DROP INDEX IF EXISTS idx_processing_artifacts_tenant_created;
+DROP INDEX IF EXISTS idx_processing_artifacts_created_id;
 DROP TABLE IF EXISTS processing_artifacts;
 
 DO $$ BEGIN RAISE NOTICE '[Migration 000066 down] processing_artifacts dropped'; END $$;

--- a/migrations/versioned/000069_processing_artifacts.down.sql
+++ b/migrations/versioned/000069_processing_artifacts.down.sql
@@ -1,0 +1,6 @@
+DO $$ BEGIN RAISE NOTICE '[Migration 000066 down] Dropping processing_artifacts...'; END $$;
+
+DROP INDEX IF EXISTS idx_processing_artifacts_tenant_created;
+DROP TABLE IF EXISTS processing_artifacts;
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000066 down] processing_artifacts dropped'; END $$;

--- a/migrations/versioned/000069_processing_artifacts.up.sql
+++ b/migrations/versioned/000069_processing_artifacts.up.sql
@@ -18,4 +18,7 @@ CREATE TABLE IF NOT EXISTS processing_artifacts (
 CREATE INDEX IF NOT EXISTS idx_processing_artifacts_tenant_created
     ON processing_artifacts (tenant_id, created_at);
 
+CREATE INDEX IF NOT EXISTS idx_processing_artifacts_created_id
+    ON processing_artifacts (created_at, id);
+
 DO $$ BEGIN RAISE NOTICE '[Migration 000066] processing_artifacts ready'; END $$;

--- a/migrations/versioned/000069_processing_artifacts.up.sql
+++ b/migrations/versioned/000069_processing_artifacts.up.sql
@@ -1,0 +1,21 @@
+DO $$ BEGIN RAISE NOTICE '[Migration 000066] Creating processing_artifacts...'; END $$;
+
+CREATE TABLE IF NOT EXISTS processing_artifacts (
+    id BIGSERIAL PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
+    stage VARCHAR(64) NOT NULL,
+    key_version INTEGER NOT NULL,
+    input_fingerprint CHAR(64) NOT NULL,
+    payload BYTEA NULL,
+    object_path TEXT NOT NULL DEFAULT '',
+    content_sha256 CHAR(64) NOT NULL,
+    size_bytes BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_processing_artifacts_key
+        UNIQUE (tenant_id, stage, key_version, input_fingerprint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_processing_artifacts_tenant_created
+    ON processing_artifacts (tenant_id, created_at);
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000066] processing_artifacts ready'; END $$;


### PR DESCRIPTION
## Summary

- reuse unchanged indexed chunk vectors during knowledge reparse with stable, knowledge-scoped identities
- provide a tenant-scoped durable processing artifact store with atomic put-if-absent semantics
- reuse canonical VLM OCR, caption, document embedding, DocReader, summary, generated-question, Wiki map, and GraphRAG extraction artifacts
- preserve current-run ownership when cached artifacts are rebound to chunks, knowledge items, and graph namespaces
- add corruption repair, payload limits, lifecycle counters, trace status, and scheduled retention for processing artifacts
- keep dynamic reduce/publication work live where cross-document state must not be cached

## Why

Knowledge reparse previously removed existing chunks and indexes before rebuilding them, repeating expensive provider work and creating a destructive failure window. The new reconciliation flow preserves reusable results when normalized inputs and effective provider identities still match, while correctly invalidating changed content, model configuration, prompts, and output contracts.

The shared artifact layer freezes only successful ownership-free outputs. Every cache hit is validated and rebound to the current run, so reuse does not leak tenant, document, chunk, or graph ownership. Retry ordering and atomic winner semantics keep concurrent workers convergent without publishing partial state.

## Implementation

### Incremental chunk and embedding reuse

- derive stable chunk identities from knowledge scope and normalized content
- preserve indexed chunks only when content and effective embedding configuration match
- batch artifact reads and writes to avoid per-chunk database round trips
- deduplicate repeated text within a batch and restore the original result order
- validate cached and provider vectors for count, dimensions, and finite values
- reindex desired chunks before deleting stale vectors, images, graph ownership, and rows
- safely replace existing SQLite vectors when a stable source ID is reused

### Processing artifact foundation

- key artifacts by tenant, stage, key version, and SHA-256 input fingerprint
- store small payloads inline and spill larger values to object storage through verified manifests
- enforce tenant-scoped access, configured payload limits, hash validation, corruption eviction, and atomic put-if-absent winners
- support PostgreSQL, MySQL, SQLite/Lite, and ParadeDB startup paths
- preserve the existing single-value path as the compatibility and large-object fallback

### VLM and DocReader reuse

- key OCR and caption outputs by image bytes, effective non-secret model identity, prompt semantics, result kind, and canonicalizer version
- cache stable non-URL DocReader results by file bytes, effective reader identity, normalized metadata, parser overrides, and codec versions
- serialize ownership-free parse results with versioned streaming JSON and gzip
- bypass unstable URL, temporary, audio, ambiguous-reader, and unknown-override inputs
- rebind fresh child chunks and current-run storage metadata on every hit
- expose cache status through existing tracing metadata without logging content or cache keys

### Chat and Wiki reuse

- key summaries and generated questions by exact rendered inputs, complete chat options, language, instructions, and non-secret model revision
- generate stable summary chunk IDs and deterministic occurrence-aware question IDs
- preserve unrelated metadata and publish desired question vectors before removing stale legacy IDs
- cache complete per-document Wiki map output while keeping reduce, taxonomy, publication, and finalization live
- validate entity schema, citations, source ordinals, slugs, dedup dependencies, UTF-8, and deterministic layout at the codec boundary

### GraphRAG extraction reuse

- key extraction artifacts by tenant, chunk content, exact rendered messages and options, prompt/canonicalizer versions, and effective non-secret model revision
- store canonical ownership-free nodes and relationships, then bind the current chunk ID on decode
- replace one chunk's graph contribution atomically instead of appending duplicate ownership
- track node and relationship ownership by chunk so stale chunks can be retracted precisely
- fence graph writes by processing attempt to prevent superseded tasks from publishing
- migrate legacy namespace data before ownership-aware replacement
- recover interrupted namespace deletion before incremental cleanup
- serialize full namespace deletion with tokens and dirty-state recovery
- retain shared graph entities until their final contributing chunk is removed
- expose hit, miss, bypass, and provider-call status through the existing extraction span

### Lifecycle operations and retention

- invalidate malformed cached values with observed-content compare semantics so concurrent repairs are not deleted
- repair corrupt concurrent winners while preserving the current provider result as a safe fallback
- encode authoritative object references and verify backend ownership before reads or deletion
- resolve exact historical storage backends for internal artifact reads and cleanup after disablement or soft deletion
- expose per-stage hit, miss, write, eviction, and error counters plus cache-status trace fields
- purge expired manifests and owned objects in bounded ID-ordered batches
- make retention interval, retention days, batch size, and maximum payload configurable with validated defaults and environment overrides
- retain failed cleanup entries for a later sweep and classify operational failures without exposing cached content or keys

## Scope

This PR implements:

1. stable-ID chunk and embedding reuse within one knowledge item
2. tenant-scoped durable processing artifacts
3. VLM OCR and caption reuse
4. cross-document embedding reuse within the same tenant
5. DocReader parse artifact reuse for stable non-URL files
6. summary and generated-question reuse with deterministic current-run bindings
7. complete per-document Wiki map reuse with live dynamic-state validation and reduce
8. GraphRAG extraction reuse with ownership-aware replacement, attempt fencing, and precise stale cleanup
9. processing artifact validation, repair, observability, and scheduled retention

Administrative cache inspection/purge APIs and external dashboards remain follow-up work for #1679.

## Validation

- `go test -tags sqlite_fts5 -count=1 ./internal/types ./internal/application/repository ./internal/application/repository/retriever/postgres ./internal/application/repository/retriever/sqlite ./internal/application/repository/retriever/tencentvectordb ./internal/application/service/file ./internal/application/service/retriever ./internal/application/service ./internal/container`
- `CGO_LDFLAGS=-lssp go test -count=1 ./internal/config ./internal/types ./internal/application/repository ./internal/application/service/file ./internal/application/service`
- focused repeated and race tests for processing artifacts, storage backends, VLM, embeddings, DocReader, chat enrichment, Wiki map, and graph extraction reuse
- `go vet ./internal/config ./internal/types ./internal/application/repository ./internal/application/service/file ./internal/application/service`
- `gofmt`
- `git diff --check`

Related to #1679.