### PR TITLE
[codex] feat: add multilevel knowledge folders and scoped QA

### DIFF
--- a/frontend/src/api/agent/index.ts
+++ b/frontend/src/api/agent/index.ts
@@ -351,12 +351,14 @@ export interface SuggestedQuestion {
 // 根据智能体关联的知识库范围返回推荐问题，用于前端对话面板快捷提问
 export function getSuggestedQuestions(
   agentId: string,
-  params?: { knowledge_base_ids?: string[]; knowledge_ids?: string[]; tag_ids?: string[]; limit?: number }
+  params?: { knowledge_base_ids?: string[]; knowledge_ids?: string[]; tag_ids?: string[]; folder_ids?: string[]; folder_scopes?: Array<{knowledge_base_id:string;folder_ids:string[]}>; limit?: number }
 ) {
   const query = new URLSearchParams();
   if (params?.knowledge_base_ids?.length) query.set('knowledge_base_ids', params.knowledge_base_ids.join(','));
   if (params?.knowledge_ids?.length) query.set('knowledge_ids', params.knowledge_ids.join(','));
   if (params?.tag_ids?.length) query.set('tag_ids', params.tag_ids.join(','));
+  if (params?.folder_ids?.length) query.set('folder_ids', params.folder_ids.join(','));
+  if (params?.folder_scopes?.length) query.set('folder_scopes', JSON.stringify(params.folder_scopes));
   if (params?.limit) query.set('limit', String(params.limit));
   const qs = query.toString();
   return get<{ data: { questions: SuggestedQuestion[] } }>(`/api/v1/agents/${agentId}/suggested-questions${qs ? '?' + qs : ''}`);

--- a/frontend/src/api/chat/streame.ts
+++ b/frontend/src/api/chat/streame.ts
@@ -36,7 +36,7 @@ export function useStream() {
   let renderTimer: number | null = null
 
   // 启动流式请求
-  const startStream = async (params: { session_id: any; query: any; knowledge_base_ids?: string[]; knowledge_ids?: string[]; tag_ids?: string[]; agent_enabled?: boolean; agent_id?: string; web_search_enabled?: boolean; enable_memory?: boolean; summary_model_id?: string; mcp_service_ids?: string[]; skill_names?: string[]; mentioned_items?: Array<{id: string; name: string; type: string; kb_type?: string; kb_id?: string; kb_name?: string; service_id?: string; skill_name?: string}>; images?: Array<{data: string}>; attachment_uploads?: Array<{data: string; file_name: string; file_size: number}>; suggestion_attribution?: { suggestion_set_id: string; question_id: string }; method: string; url: string; embed_token?: string; embed_session_sig?: string; embed_visitor_id?: string }) => {
+  const startStream = async (params: { session_id: any; query: any; knowledge_base_ids?: string[]; knowledge_ids?: string[]; tag_ids?: string[]; folder_scopes?: Array<{ knowledge_base_id: string; folder_ids: string[] }>; agent_enabled?: boolean; agent_id?: string; web_search_enabled?: boolean; enable_memory?: boolean; summary_model_id?: string; mcp_service_ids?: string[]; skill_names?: string[]; mentioned_items?: Array<{id: string; name: string; type: string; kb_type?: string; kb_id?: string; kb_name?: string; service_id?: string; skill_name?: string}>; images?: Array<{data: string}>; attachment_uploads?: Array<{data: string; file_name: string; file_size: number}>; suggestion_attribution?: { suggestion_set_id: string; question_id: string }; method: string; url: string; embed_token?: string; embed_session_sig?: string; embed_visitor_id?: string }) => {
     const myGeneration = ++streamGeneration
     // 重置状态
     output.value = '';
@@ -120,6 +120,9 @@ export function useStream() {
       }
       if (params.tag_ids !== undefined && params.tag_ids.length > 0) {
         postBody.tag_ids = params.tag_ids;
+      }
+      if (params.folder_scopes !== undefined && params.folder_scopes.length > 0) {
+        postBody.folder_scopes = params.folder_scopes;
       }
       // Include mentioned_items if provided (for displaying @mentions in chat)
       if (params.mentioned_items !== undefined && params.mentioned_items.length > 0) {

--- a/frontend/src/api/knowledge-base/index.ts
+++ b/frontend/src/api/knowledge-base/index.ts
@@ -176,6 +176,7 @@ export function uploadKnowledgeFile(
   data: {
     file: File
     tag_ids?: string[]
+    folder_id?: string
     fileName?: string
     process_config?: KnowledgeProcessOverrides | string
     [key: string]: any
@@ -197,11 +198,42 @@ export function uploadKnowledgeFile(
   return postUpload(`/api/v1/knowledge-bases/${kbId}/knowledge/file`, formData, onProgress);
 }
 
+export interface KnowledgeFolder {
+  id: string;
+  tenant_id: number;
+  knowledge_base_id: string;
+  parent_id: string;
+  name: string;
+  ancestors?: KnowledgeFolder[];
+  direct_knowledge_count: number;
+  total_knowledge_count: number;
+  child_folder_count: number;
+  has_children: boolean;
+}
+
+export interface FolderScope { knowledge_base_id: string; folder_ids: string[] }
+
+export function listKnowledgeFolders(kbId: string, params: { parent_id?: string; page?: number; page_size?: number; keyword?: string; agent_id?: string } = {}) {
+  const query = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => { if (value !== undefined && value !== '') query.set(key, String(value)); });
+  const suffix = query.toString() ? `?${query.toString()}` : '';
+  return get(`/api/v1/knowledge-bases/${kbId}/folders${suffix}`);
+}
+export function getKnowledgeFolder(kbId: string, folderId: string, options?: { agent_id?: string }) {
+  const query = options?.agent_id ? `?agent_id=${encodeURIComponent(options.agent_id)}` : '';
+  return get(`/api/v1/knowledge-bases/${kbId}/folders/${folderId}${query}`);
+}
+export function createKnowledgeFolder(kbId: string, data: { name: string; parent_id: string }) { return post(`/api/v1/knowledge-bases/${kbId}/folders`, data); }
+export function updateKnowledgeFolder(kbId: string, folderId: string, data: { name?: string; parent_id?: string }) { return put(`/api/v1/knowledge-bases/${kbId}/folders/${folderId}`, data); }
+export function deleteKnowledgeFolder(kbId: string, folderId: string) { return del(`/api/v1/knowledge-bases/${kbId}/folders/${folderId}`); }
+export function ensureKnowledgeFolderPaths(kbId: string, data: { parent_id?: string; paths: Array<{ client_key: string; segments: string[] }> }) { return post(`/api/v1/knowledge-bases/${kbId}/folders/ensure-paths`, data); }
+export function moveKnowledgeToFolder(kbId: string, data: { knowledge_ids: string[]; folder_id: string }) { return put(`/api/v1/knowledge-bases/${kbId}/knowledge/folder`, data); }
+
 // 从URL创建知识
 // data.tag_ids: 可选，指定知识所属的多个标签 ID
 export function createKnowledgeFromURL(
   kbId: string,
-  data: { url: string; enable_multimodel?: boolean; tag_ids?: string[]; process_config?: KnowledgeProcessOverrides },
+  data: { url: string; enable_multimodel?: boolean; tag_ids?: string[]; folder_id?: string; process_config?: KnowledgeProcessOverrides },
 ) {
   return post(`/api/v1/knowledge-bases/${kbId}/knowledge/url`, data);
 }
@@ -215,6 +247,7 @@ export function createManualKnowledge(
     content: string
     status: string
     tag_ids?: string[]
+    folder_id?: string
     process_config?: KnowledgeProcessOverrides
   },
 ) {
@@ -233,6 +266,9 @@ export function listKnowledgeFiles(
     source?: string;
     start_time?: string;
     end_time?: string;
+    folder_id?: string;
+    include_descendants?: boolean;
+    agent_id?: string;
   },
 ) {
   const query = new URLSearchParams();
@@ -245,6 +281,9 @@ export function listKnowledgeFiles(
   if (params.source) query.append('source', params.source);
   if (params.start_time) query.append('start_time', params.start_time);
   if (params.end_time) query.append('end_time', params.end_time);
+  if (params.folder_id !== undefined) query.append('folder_id', params.folder_id);
+  if (params.include_descendants !== undefined) query.append('include_descendants', String(params.include_descendants));
+  if (params.agent_id) query.append('agent_id', params.agent_id);
   const qs = query.toString();
   return get(`/api/v1/knowledge-bases/${kbId}/knowledge?${qs}`);
 }

--- a/frontend/src/components/Input-field.vue
+++ b/frontend/src/components/Input-field.vue
@@ -7,7 +7,7 @@ import { MessagePlugin } from "tdesign-vue-next";
 import { useSettingsStore } from '@/stores/settings';
 import { useUIStore } from '@/stores/ui';
 import { useMenuStore } from '@/stores/menu';
-import { listKnowledgeBases, searchKnowledge, batchQueryKnowledge, listKnowledgeTags } from '@/api/knowledge-base';
+import { listKnowledgeBases, searchKnowledge, batchQueryKnowledge, listKnowledgeTags, listKnowledgeFolders } from '@/api/knowledge-base';
 import { listMCPServices, type MCPService } from '@/api/mcp-service';
 import { stopSession } from '@/api/chat';
 import { useOrganizationStore } from '@/stores/organization';
@@ -42,6 +42,7 @@ import {
 } from '@/utils/agent-readiness';
 import { formatLocalizedList } from '@/utils/format-list';
 import type { MentionItem, MentionItemType, MentionRequestItem } from '@/types/mention';
+import { filterFolderMentionKnowledgeBases } from '@/utils/knowledgeFolders';
 
 const route = useRoute();
 const router = useRouter();
@@ -505,6 +506,7 @@ const isWebSearchEnabled = computed(() => settingsStore.isWebSearchEnabled);
 const selectedKbIds = computed(() => settingsStore.settings.selectedKnowledgeBases || []);
 const selectedFileIds = computed(() => settingsStore.settings.selectedFiles || []);
 const selectedTags = computed(() => settingsStore.settings.selectedTags || []);
+const selectedFolders = computed(() => settingsStore.settings.selectedFolders || []);
 const selectedMCPServiceIds = computed(() => settingsStore.settings.selectedMCPServices || []);
 const selectedSkillNames = computed(() => settingsStore.settings.selectedSkills || []);
 
@@ -629,8 +631,9 @@ const allSelectedItems = computed(() => {
     description: tag.kbName || '',
     isAgentConfigured: false,
   }));
+	const folders = selectedFolders.value.map((folder:any) => ({ ...folder, type:'folder' as const, description:folder.kbName || '', isAgentConfigured:false }));
 
-  return [...agentConfiguredKbs, ...userSelectedKbs, ...files, ...tags, ...selectedMCPItems.value, ...skillMentionItems.value];
+  return [...agentConfiguredKbs, ...userSelectedKbs, ...folders, ...files, ...tags, ...selectedMCPItems.value, ...skillMentionItems.value];
 });
 
 // 移除选中项（智能体配置的项也可以移除）
@@ -641,6 +644,8 @@ const removeSelectedItem = (item: MentionItem) => {
     settingsStore.removeFile(item.id);
   } else if (item.type === 'tag') {
     settingsStore.removeTag(item.id, item.kbId);
+	} else if (item.type === 'folder') {
+	  settingsStore.removeFolder(item.id, item.kbId);
   } else if (item.type === 'mcp') {
     settingsStore.removeMCPService(item.id);
   } else if (item.type === 'skill') {
@@ -1157,6 +1162,7 @@ const loadMentionItems = async (q: string, resetIndex = true, append = false) =>
   // 根据智能体的 kb_selection_mode 过滤知识库；选中共享智能体时使用该租户下的知识库，否则使用本租户 + 共享给自己的
   let kbItems: any[] = [];
   let tagItems: MentionItem[] = [];
+	let folderItems: MentionItem[] = [];
   let mcpItems: MentionItem[] = [];
   let skillItems: MentionItem[] = [];
   if (!append) {
@@ -1268,6 +1274,17 @@ const loadMentionItems = async (q: string, resetIndex = true, append = false) =>
       };
     }));
     mentionGroupCounts.value.kb = kbItems.length;
+	try {
+	  const sourceTenantId = settingsStore.selectedAgentSourceTenantId;
+	  const agentId = selectedAgentId.value;
+	  const folderKbs = filterFolderMentionKnowledgeBases(availableKbs, mentionAllowedKbIds.value);
+	  const folderResults = await Promise.all(folderKbs.map(async (kb:any) => {
+		const res:any = await listKnowledgeFolders(kb.id,{page:1,page_size:20,keyword:q.trim()||undefined,...(sourceTenantId&&agentId?{agent_id:agentId}:{})});
+		const payload=res?.data?.data||res?.data||[];
+		return (Array.isArray(payload)?payload:[]).map((folder:any)=>({id:folder.id,name:folder.name,type:'folder' as const,kbId:kb.id,kbName:kb.name,count:folder.total_knowledge_count,description:[...(folder.ancestors||[]).map((a:any)=>a.name),folder.name].join(' / ')}));
+	  }));
+	  folderItems=folderResults.flat();mentionGroupCounts.value.folder=folderItems.length;
+	} catch(e){console.error('[Mention] listKnowledgeFolders error:',e);folderItems=[];}
 
     const tagKeyword = q.trim();
     const tagSources = availableKbs;
@@ -1417,7 +1434,7 @@ const loadMentionItems = async (q: string, resetIndex = true, append = false) =>
     // Append file items to existing list
     mentionItems.value = [...mentionItems.value, ...fileItems];
   } else {
-    mentionItems.value = [...kbItems, ...tagItems, ...mcpItems, ...skillItems, ...fileItems];
+    mentionItems.value = [...kbItems, ...folderItems, ...tagItems, ...mcpItems, ...skillItems, ...fileItems];
   }
   console.log('[Mention] Total items:', mentionItems.value.length, { kbItems: kbItems.length, fileItems: fileItems.length, tagItems: tagItems.length, mcpItems: mcpItems.length, skillItems: skillItems.length });
 
@@ -1638,6 +1655,8 @@ const onMentionSelect = (item: any) => {
     if (item.kbId) {
       settingsStore.addTag({ id: item.id, name: item.name, kbId: item.kbId, kbName: item.kbName });
     }
+	} else if (item.type === 'folder') {
+	  if (item.kbId) settingsStore.addFolder({id:item.id,name:item.name,kbId:item.kbId,kbName:item.kbName});
   } else if (item.type === 'mcp') {
     settingsStore.addMCPService(item.id);
   } else if (item.type === 'skill') {

--- a/frontend/src/components/MentionSelector.vue
+++ b/frontend/src/components/MentionSelector.vue
@@ -314,6 +314,7 @@ const fileItems = computed(() => props.items.filter(item => item.type === 'file'
 
 const mentionGroupDefs = computed<Array<{ type: MentionItemType; label: string; icon: string }>>(() => [
   { type: 'kb', label: t('common.knowledgeBase'), icon: 'folder' },
+	{ type: 'folder', label: t('knowledgeFolder.folders'), icon: 'folder-open' },
   { type: 'tag', label: '标签', icon: 'tag' },
   { type: 'mcp', label: 'MCP', icon: 'tools' },
   { type: 'skill', label: 'Skills', icon: 'bookmark' },

--- a/frontend/src/components/manual-knowledge-editor.vue
+++ b/frontend/src/components/manual-knowledge-editor.vue
@@ -619,6 +619,7 @@ const handleSave = async (targetStatus: ManualStatus) => {
       content: string
       status: string
       tag_ids?: string[]
+	  folder_id?: string
       process_config?: KnowledgeProcessOverrides
     } = {
       title: form.title.trim(),
@@ -628,6 +629,7 @@ const handleSave = async (targetStatus: ManualStatus) => {
     if (tagIdsToUpload && tagIdsToUpload.length > 0) {
       payload.tag_ids = tagIdsToUpload
     }
+	if (mode.value === 'create') payload.folder_id = uiStore.manualEditorFolderId || ''
 
     if (targetStatus === 'publish') {
       let kbInfo: any

--- a/frontend/src/hooks/useKnowledgeBase.ts
+++ b/frontend/src/hooks/useKnowledgeBase.ts
@@ -50,6 +50,9 @@ export default function (knowledgeBaseId?: string) {
       source?: string;
       start_time?: string;
       end_time?: string;
+      folder_id?: string;
+      include_descendants?: boolean;
+      agent_id?: string;
     } = { page: 1, page_size: 35 },
     kbId?: string,
   ): Promise<void> => {

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1,4 +1,8 @@
 export default {
+  knowledgeFolder: {
+    folders: 'Folders', root: 'Root', newFolder: 'New folder', rename: 'Rename', move: 'Move', ask: 'Ask this folder', delete: 'Delete',
+    moveDocuments: 'Move to folder', includeDescendants: 'Include subfolders', currentFolder: 'Current folder', emptyRequired: 'Only empty folders can be deleted', loadMore: 'Load more folders',
+  },
   menu: {
     knowledgeBase: 'Knowledge Base',
     agents: 'Agents',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1,4 +1,8 @@
 export default {
+  knowledgeFolder: {
+    folders: '文件夹', root: '根目录', newFolder: '新建文件夹', rename: '重命名', move: '移动', ask: '对该文件夹提问', delete: '删除',
+    moveDocuments: '移动到文件夹', includeDescendants: '包含子目录', currentFolder: '当前目录', emptyRequired: '仅可删除空文件夹', loadMore: '加载更多文件夹',
+  },
   menu: {
     knowledgeBase: "知识库",
     agents: "智能体",

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -5,6 +5,11 @@ import { getApiBaseUrl } from "@/utils/api-base";
 import { updateMyPreferences, type UserPreferences } from "@/api/auth";
 import { isAgentStreamAgentId } from "@/utils/agent-mode";
 import { loadAndReconcileSettings } from "@/stores/settingsStorage";
+import {
+  removeFolderSelection,
+  restoreFolderSelections,
+  serializeFolderScopes,
+} from "@/utils/knowledgeFolders";
 
 // 定义设置接口
 interface Settings {
@@ -17,6 +22,7 @@ interface Settings {
   selectedFiles: string[]; // 当前选中的文件ID列表
   selectedFileKbMap: Record<string, string>; // 文件ID -> 知识库ID，用于刷新后带 kb_id 拉取共享知识库文件
   selectedTags: Array<{ id: string; name: string; kbId: string; kbName?: string }>;
+  selectedFolders: Array<{ id: string; name: string; kbId: string; kbName?: string }>;
   selectedMCPServices: string[];
   selectedSkills: string[];
   selectedTools?: string[];
@@ -87,6 +93,7 @@ const defaultSettings: Settings = {
   selectedFiles: [], // 默认为空数组
   selectedFileKbMap: {},  // 文件ID -> 知识库ID
   selectedTags: [],
+  selectedFolders: [],
   selectedMCPServices: [],
   selectedSkills: [],
   modelConfig: {
@@ -422,6 +429,17 @@ export const useSettingsStore = defineStore("settings", {
       localStorage.setItem("WeKnora_settings", JSON.stringify(this.settings));
     },
 
+	addFolder(folder: { id: string; name: string; kbId: string; kbName?: string }) {
+	  if (!this.settings.selectedFolders) this.settings.selectedFolders = [];
+	  if (!this.settings.selectedFolders.some(item => item.id === folder.id && item.kbId === folder.kbId)) this.settings.selectedFolders.push(folder);
+	  localStorage.setItem("WeKnora_settings", JSON.stringify(this.settings));
+	},
+	removeFolder(folderId: string, kbId?: string) {
+	  this.settings.selectedFolders = removeFolderSelection(this.settings.selectedFolders || [], folderId, kbId);
+	  localStorage.setItem("WeKnora_settings", JSON.stringify(this.settings));
+	},
+	clearFolders() { this.settings.selectedFolders = []; localStorage.setItem("WeKnora_settings", JSON.stringify(this.settings)); },
+
     addMCPService(serviceId: string) {
       if (!this.settings.selectedMCPServices) this.settings.selectedMCPServices = [];
       if (!this.settings.selectedMCPServices.includes(serviceId)) {
@@ -470,13 +488,17 @@ export const useSettingsStore = defineStore("settings", {
       const selectedKBs = this.getSelectedKnowledgeBases();
       const selectedFiles = this.getSelectedFiles();
       const tags = this.settings.selectedTags || [];
+      const folders = this.settings.selectedFolders || [];
       const tagIds = [...new Set(tags.map((t) => t.id).filter(Boolean))];
       const tagKbIds = [...new Set(tags.map((t) => t.kbId).filter(Boolean))];
+      // Folder KBs are carried only by folder_scopes. Adding them here would
+      // make a folder-only choice look like an explicit whole-KB selection.
       const kbIds = [...new Set([...selectedKBs, ...tagKbIds])];
       return {
         knowledge_base_ids: kbIds.length > 0 ? kbIds : undefined,
         knowledge_ids: selectedFiles.length > 0 ? selectedFiles : undefined,
         tag_ids: tagIds.length > 0 ? tagIds : undefined,
+        folder_scopes: serializeFolderScopes(folders),
         limit,
       };
     },
@@ -499,6 +521,7 @@ export const useSettingsStore = defineStore("settings", {
       this.settings.selectedFiles = [];
       this.settings.selectedFileKbMap = {};
       this.settings.selectedTags = [];
+      this.settings.selectedFolders = [];
       this.settings.selectedMCPServices = [];
       this.settings.selectedSkills = [];
       localStorage.setItem("WeKnora_settings", JSON.stringify(this.settings));
@@ -579,6 +602,9 @@ export const useSettingsStore = defineStore("settings", {
           const existing = this.settings.selectedTags || [];
           this.settings.selectedTags = existing.filter(tag => state.tag_ids?.includes(tag.id));
         }
+        if (Array.isArray(state.mentioned_items) || Array.isArray(state.folder_scopes)) {
+          this.settings.selectedFolders = restoreFolderSelections(state.mentioned_items, state.folder_scopes);
+        }
         if (Array.isArray(state.mcp_service_ids)) {
           this.settings.selectedMCPServices = [...state.mcp_service_ids];
         } else if (Array.isArray(state.mentioned_items)) {
@@ -621,6 +647,7 @@ export interface SessionLastRequestStatePayload {
   knowledge_base_ids?: string[];
   knowledge_ids?: string[];
   tag_ids?: string[];
+  folder_scopes?: Array<{ knowledge_base_id: string; folder_ids: string[] }>;
   mcp_service_ids?: string[];
   skill_names?: string[];
   mentioned_items?: Array<{

--- a/frontend/src/stores/ui.ts
+++ b/frontend/src/stores/ui.ts
@@ -15,6 +15,7 @@ export const useUIStore = defineStore('ui', {
     manualEditorVisible: false,
     manualEditorMode: 'create' as 'create' | 'edit',
     manualEditorKBId: null as string | null,
+    manualEditorFolderId: '' as string,
     manualEditorKnowledgeId: null as string | null,
     manualEditorInitialTitle: '',
     manualEditorInitialContent: '',
@@ -70,6 +71,7 @@ export const useUIStore = defineStore('ui', {
     openManualEditor(options: {
       mode?: 'create' | 'edit'
       kbId?: string | null
+	  folderId?: string
       knowledgeId?: string | null
       title?: string
       content?: string
@@ -78,6 +80,7 @@ export const useUIStore = defineStore('ui', {
     } = {}) {
       this.manualEditorMode = options.mode || 'create'
       this.manualEditorKBId = options.kbId ?? null
+	  this.manualEditorFolderId = options.folderId || ''
       this.manualEditorKnowledgeId = options.knowledgeId ?? null
       this.manualEditorInitialTitle = options.title || ''
       this.manualEditorInitialContent = options.content || ''
@@ -89,6 +92,7 @@ export const useUIStore = defineStore('ui', {
     closeManualEditor() {
       this.manualEditorVisible = false
       this.manualEditorKnowledgeId = null
+	  this.manualEditorFolderId = ''
       this.manualEditorInitialContent = ''
       this.manualEditorInitialTitle = ''
       this.manualEditorInitialStatus = 'draft'
@@ -136,4 +140,3 @@ export const useUIStore = defineStore('ui', {
     }
   }
 })
-

--- a/frontend/src/types/mention.ts
+++ b/frontend/src/types/mention.ts
@@ -1,4 +1,4 @@
-export type MentionItemType = 'kb' | 'file' | 'tag' | 'mcp' | 'skill';
+export type MentionItemType = 'kb' | 'file' | 'folder' | 'tag' | 'mcp' | 'skill';
 
 export interface MentionItem {
   id: string;

--- a/frontend/src/utils/knowledgeFolders.test.ts
+++ b/frontend/src/utils/knowledgeFolders.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  dedupeFolderPaths,
+  filterFolderMentionKnowledgeBases,
+  flattenFolderPages,
+  folderIDFromQuery,
+  mapFilesToFolderIDs,
+  mergeFolderPage,
+  parseRelativeFolderFiles,
+  removeFolderSelection,
+  restoreFolderSelections,
+  runWithConcurrency,
+  serializeFolderScopes,
+} from './knowledgeFolders.ts';
+
+function relativeFile(name: string, path: string) {
+  const file = new File(['x'], name) as File & { webkitRelativePath: string };
+  Object.defineProperty(file, 'webkitRelativePath', { value: path });
+  return file;
+}
+
+describe('knowledge folder upload helpers', () => {
+  it('parses, deduplicates and maps webkitRelativePath folders', () => {
+    const a = relativeFile('a.md', 'project/docs/a.md');
+    const b = relativeFile('b.md', 'project/docs/b.md');
+    const c = relativeFile('c.md', 'project/src/c.md');
+    const parsed = parseRelativeFolderFiles([a,b,c]);
+    assert.deepEqual(parsed.map(item => item.segments), [['project','docs'],['project','docs'],['project','src']]);
+    const paths = dedupeFolderPaths(parsed);
+    assert.equal(paths.length, 2);
+    const mapped = mapFilesToFolderIDs(parsed, paths.map((path,index) => ({ client_key:path.client_key, folder_id:`f-${index}` })));
+    assert.equal(mapped.get(a), mapped.get(b));
+    assert.notEqual(mapped.get(c), mapped.get(a));
+  });
+
+  it('caps upload concurrency', async () => {
+    let active=0, peak=0;
+    const tasks = Array.from({length:12},(_,index) => async () => { active++;peak=Math.max(peak,active);await Promise.resolve();active--;return index; });
+    const results = await runWithConcurrency(tasks,4);
+    assert.equal(results.every(result => result.status==='fulfilled'), true);
+    assert.ok(peak <= 4);
+  });
+});
+
+describe('knowledge folder selection helpers', () => {
+  const folders = [
+    { id: 'folder-a', name: 'A', kbId: 'kb-1' },
+    { id: 'folder-a', name: 'A duplicate', kbId: 'kb-1' },
+    { id: 'folder-b', name: 'B', kbId: 'kb-1' },
+    { id: 'folder-a', name: 'A in another KB', kbId: 'kb-2' },
+  ];
+
+  it('serializes folder scopes by KB and deduplicates folder IDs', () => {
+    assert.deepEqual(serializeFolderScopes(folders), [
+      { knowledge_base_id: 'kb-1', folder_ids: ['folder-a', 'folder-b'] },
+      { knowledge_base_id: 'kb-2', folder_ids: ['folder-a'] },
+    ]);
+    assert.equal(serializeFolderScopes([]), undefined);
+  });
+
+  it('removes only the requested folder selection', () => {
+    assert.deepEqual(removeFolderSelection(folders, 'folder-a', 'kb-1'), [folders[2], folders[3]]);
+  });
+
+  it('restores named mentions and falls back to folder scopes', () => {
+    assert.deepEqual(restoreFolderSelections([
+      { id: 'folder-a', name: 'Plans', type: 'folder', kb_id: 'kb-1', kb_name: 'KB' },
+      { id: 'folder-a', name: 'Plans', type: 'folder', kb_id: 'kb-1', kb_name: 'KB' },
+      { id: 'tag-a', name: 'Tag', type: 'tag', kb_id: 'kb-1' },
+    ], [{ knowledge_base_id: 'ignored', folder_ids: ['ignored'] }]), [
+      { id: 'folder-a', name: 'Plans', kbId: 'kb-1', kbName: 'KB' },
+      { id: 'ignored', name: 'ignored', kbId: 'ignored' },
+    ]);
+    assert.deepEqual(restoreFolderSelections([], [
+      { knowledge_base_id: 'kb-1', folder_ids: ['folder-a', 'folder-a', 'folder-b'] },
+    ]), [
+      { id: 'folder-a', name: 'folder-a', kbId: 'kb-1' },
+      { id: 'folder-b', name: 'folder-b', kbId: 'kb-1' },
+    ]);
+  });
+
+  it('filters folder mention KBs to the agent scope and excludes FAQ KBs', () => {
+    const available = [
+      { id: 'kb-1', type: 'document' },
+      { id: 'kb-2', type: 'document' },
+      { id: 'kb-faq', type: 'faq' },
+    ];
+    assert.deepEqual(filterFolderMentionKnowledgeBases(available, new Set(['kb-2', 'kb-faq'])), [available[1]]);
+  });
+});
+
+describe('knowledge folder tree helpers', () => {
+  it('merges lazy pages without duplicating folders and flattens expanded paths', () => {
+    const first = mergeFolderPage(undefined, [
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B old' },
+    ], 1, 3);
+    const root = mergeFolderPage(first, [
+      { id: 'b', name: 'B' },
+      { id: 'c', name: 'C' },
+    ], 2, 3);
+    const child = mergeFolderPage(undefined, [{ id: 'a-1', name: 'A1' }], 1, 2);
+    const rows = flattenFolderPages(new Map([['', root], ['a', child]]), new Set(['a']));
+    assert.deepEqual(rows, [
+      { kind: 'folder', folder: { id: 'a', name: 'A' }, depth: 0 },
+      { kind: 'folder', folder: { id: 'a-1', name: 'A1' }, depth: 1 },
+      { kind: 'more', parentId: 'a', depth: 1 },
+      { kind: 'folder', folder: { id: 'b', name: 'B' }, depth: 0 },
+      { kind: 'folder', folder: { id: 'c', name: 'C' }, depth: 0 },
+    ]);
+  });
+
+  it('normalizes URL folder_id values for root restoration', () => {
+    assert.equal(folderIDFromQuery('folder-a'), 'folder-a');
+    assert.equal(folderIDFromQuery('root'), '');
+    assert.equal(folderIDFromQuery(['folder-a']), '');
+    assert.equal(folderIDFromQuery(undefined), '');
+  });
+});

--- a/frontend/src/utils/knowledgeFolders.ts
+++ b/frontend/src/utils/knowledgeFolders.ts
@@ -1,0 +1,165 @@
+export interface RelativeFolderFile { file: File; clientKey: string; segments: string[] }
+
+export interface FolderSelection {
+  id: string;
+  name: string;
+  kbId: string;
+  kbName?: string;
+}
+
+export interface FolderScope {
+  knowledge_base_id: string;
+  folder_ids: string[];
+}
+
+export interface FolderMentionState {
+  id: string;
+  name?: string;
+  type: string;
+  kb_id?: string;
+  kb_name?: string;
+}
+
+export interface FolderPage<T> {
+  items: T[];
+  page: number;
+  total: number;
+  loading: boolean;
+}
+
+export type FolderTreeRow<T> =
+  | { kind: 'folder'; folder: T; depth: number }
+  | { kind: 'more'; parentId: string; depth: number };
+
+export function folderIDFromQuery(value: unknown): string {
+  return typeof value === 'string' && value !== 'root' ? value : '';
+}
+
+export function serializeFolderScopes(folders: FolderSelection[]): FolderScope[] | undefined {
+  const grouped = new Map<string, Set<string>>();
+  for (const folder of folders) {
+    if (!folder.kbId || !folder.id) continue;
+    const ids = grouped.get(folder.kbId) || new Set<string>();
+    ids.add(folder.id);
+    grouped.set(folder.kbId, ids);
+  }
+  if (!grouped.size) return undefined;
+  return [...grouped].map(([knowledge_base_id, folderIds]) => ({
+    knowledge_base_id,
+    folder_ids: [...folderIds],
+  }));
+}
+
+export function removeFolderSelection(
+  folders: FolderSelection[],
+  folderId: string,
+  kbId?: string,
+): FolderSelection[] {
+  return folders.filter(folder => !(folder.id === folderId && (!kbId || folder.kbId === kbId)));
+}
+
+export function restoreFolderSelections(
+  mentionedItems?: FolderMentionState[],
+  folderScopes?: FolderScope[],
+): FolderSelection[] {
+  const mentions: FolderSelection[] = (mentionedItems || [])
+    .filter(item => item.type === 'folder' && item.id && item.kb_id)
+    .map(item => ({
+      id: item.id,
+      name: item.name || item.id,
+      kbId: item.kb_id!,
+      kbName: item.kb_name,
+    }));
+  const fallback: FolderSelection[] = (folderScopes || []).flatMap(scope =>
+    (scope.folder_ids || []).map(id => ({ id, name: id, kbId: scope.knowledge_base_id })),
+  );
+  const unique = new Map<string, FolderSelection>(mentions.map(folder => [`${folder.kbId}\u0000${folder.id}`, folder]));
+  for (const folder of fallback) {
+    const key = `${folder.kbId}\u0000${folder.id}`;
+    if (!unique.has(key)) unique.set(key, folder);
+  }
+  return [...unique.values()];
+}
+
+export function filterFolderMentionKnowledgeBases<T extends { id: string; type?: string }>(
+  knowledgeBases: T[],
+  allowedKbIds: ReadonlySet<string> | null,
+): T[] {
+  return knowledgeBases.filter(kb =>
+    kb.type !== 'faq' && (!allowedKbIds || allowedKbIds.has(String(kb.id))),
+  );
+}
+
+export function mergeFolderPage<T extends { id: string }>(
+  current: FolderPage<T> | undefined,
+  nextItems: T[],
+  page: number,
+  total: number | undefined,
+  reset = false,
+): FolderPage<T> {
+  const prior = reset ? [] : current?.items || [];
+  const byId = new Map([...prior, ...nextItems].map(folder => [folder.id, folder]));
+  return {
+    items: [...byId.values()],
+    page,
+    total: Number(total ?? byId.size),
+    loading: false,
+  };
+}
+
+export function flattenFolderPages<T extends { id: string }>(
+  pages: ReadonlyMap<string, FolderPage<T>>,
+  expanded: ReadonlySet<string>,
+  rootParentId = '',
+): FolderTreeRow<T>[] {
+  const result: FolderTreeRow<T>[] = [];
+  const walk = (parentId: string, depth: number) => {
+    const state = pages.get(parentId);
+    for (const folder of state?.items || []) {
+      result.push({ kind: 'folder', folder, depth });
+      if (expanded.has(folder.id)) walk(folder.id, depth + 1);
+    }
+    if (state && state.items.length < state.total) result.push({ kind: 'more', parentId, depth });
+  };
+  walk(rootParentId, 0);
+  return result;
+}
+
+export function parseRelativeFolderFiles(files: File[]): RelativeFolderFile[] {
+  return files.map((file, index) => {
+    const relativePath = (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name;
+    const parts = relativePath.split('/').filter(Boolean);
+    return { file, clientKey: `path-${index}`, segments: parts.slice(0, -1) };
+  });
+}
+
+export function dedupeFolderPaths(items: RelativeFolderFile[]): Array<{ client_key: string; segments: string[] }> {
+  const unique = new Map<string, { client_key: string; segments: string[] }>();
+  for (const item of items) {
+    if (!item.segments.length) continue;
+    const key = JSON.stringify(item.segments);
+    if (!unique.has(key)) unique.set(key, { client_key: key, segments: item.segments });
+  }
+  return [...unique.values()];
+}
+
+export function mapFilesToFolderIDs(items: RelativeFolderFile[], ensured: Array<{ client_key: string; folder_id: string }>): Map<File, string> {
+  const byKey = new Map(ensured.map(item => [item.client_key, item.folder_id]));
+  const result = new Map<File, string>();
+  for (const item of items) result.set(item.file, item.segments.length ? (byKey.get(JSON.stringify(item.segments)) || '') : '');
+  return result;
+}
+
+export async function runWithConcurrency<T>(tasks: Array<() => Promise<T>>, limit = 4): Promise<PromiseSettledResult<T>[]> {
+  const results: PromiseSettledResult<T>[] = new Array(tasks.length);
+  let cursor = 0;
+  async function worker() {
+    while (cursor < tasks.length) {
+      const index = cursor++;
+      try { results[index] = { status: 'fulfilled', value: await tasks[index]() }; }
+      catch (reason) { results[index] = { status: 'rejected', reason }; }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, tasks.length) }, worker));
+  return results;
+}

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -728,6 +728,17 @@ const sendMsg = async (value, modelId = '', mentionedItems = [], imageFiles = []
     const kbIds = [...kbIdSet];
     const knowledgeIds = [...fileIdSet];
     const tagIds = [...new Set((mentionedItems || []).filter(item => item.type === 'tag' && item.id).map(item => item.id))];
+    const selectedFolders = props.embeddedMode ? [] : (useSettingsStoreInstance.settings.selectedFolders || []);
+    const mentionedFolders = (mentionedItems || [])
+        .filter(item => item.type === 'folder' && item.id && (item.kb_id || item.kbId))
+        .map(item => ({ id: item.id, kbId: item.kb_id || item.kbId }));
+    const folderMap = new Map();
+    for (const folder of [...selectedFolders, ...mentionedFolders]) {
+        if (!folder.kbId) continue;
+        if (!folderMap.has(folder.kbId)) folderMap.set(folder.kbId, new Set());
+        folderMap.get(folder.kbId).add(folder.id);
+    }
+    const folderScopes = [...folderMap].map(([knowledge_base_id, ids]) => ({ knowledge_base_id, folder_ids: [...ids] }));
     const mcpServiceIds = [...new Set((mentionedItems || []).filter(item => item.type === 'mcp' && item.id).map(item => item.id))];
     const skillNames = [...new Set((mentionedItems || []).filter(item => item.type === 'skill' && item.id).map(item => item.skill_name || item.id))];
 
@@ -753,6 +764,7 @@ const sendMsg = async (value, modelId = '', mentionedItems = [], imageFiles = []
         mcp_service_ids: requestMcpServiceIds,
         skill_names: requestSkillNames,
         tag_ids: tagIds,
+        folder_scopes: folderScopes,
         mentioned_items: mentionedItems,
         images: imageAttachments.length > 0 ? imageAttachments : undefined,
         attachment_uploads: attachmentUploads.length > 0 ? attachmentUploads : undefined,

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -15,6 +15,7 @@ import { useOrganizationStore } from '@/stores/organization';
 import { useAuthStore } from '@/stores/auth';
 import { useChatResourcesStore } from '@/stores/chatResources';
 import { useEditorResourcesStore } from '@/stores/editorResources';
+import { useSettingsStore } from '@/stores/settings';
 import KnowledgeBaseEditorModal from './KnowledgeBaseEditorModal.vue';
 const usemenuStore = useMenuStore();
 const uiStore = useUIStore();
@@ -22,6 +23,7 @@ const orgStore = useOrganizationStore();
 const authStore = useAuthStore();
 const chatResources = useChatResourcesStore();
 const editorResources = useEditorResourcesStore();
+const settingsStore = useSettingsStore();
 const router = useRouter();
 import {
   batchQueryKnowledge,
@@ -35,12 +37,19 @@ import {
   batchReparseKnowledge,
   getKnowledgeSpans,
   getKnowledgeDetails,
+  ensureKnowledgeFolderPaths,
+  moveKnowledgeToFolder,
+  getKnowledgeFolder,
 } from "@/api/knowledge-base/index";
+import { dedupeFolderPaths, folderIDFromQuery, mapFilesToFolderIDs, parseRelativeFolderFiles, runWithConcurrency } from '@/utils/knowledgeFolders';
 import { knowledgeSpansPayloadHasTrace } from '@/utils/knowledgeTrace';
 import FAQEntryManager from './components/FAQEntryManager.vue';
 import DocumentListView from './components/DocumentListView.vue';
 import DocumentCardView from './components/DocumentCardView.vue';
 import DocumentBatchBar from './components/DocumentBatchBar.vue';
+import KnowledgeFolderTree from './components/KnowledgeFolderTree.vue';
+import KnowledgeFolderPicker from './components/KnowledgeFolderPicker.vue';
+import type { KnowledgeFolder } from '@/api/knowledge-base';
 import KbUploadSourceDropdown from './components/KbUploadSourceDropdown.vue';
 import TagEditDialog from './components/TagEditDialog.vue';
 import KbTagManageDrawer from './components/KbTagManageDrawer.vue';
@@ -57,10 +66,43 @@ import { listMoveTargets, moveKnowledge, getKnowledgeMoveProgress } from '@/api/
 import { useI18n } from 'vue-i18n';
 import { useMarqueeSelect } from '@/hooks/useMarqueeSelect';
 import type { ParserEngineInfo } from '@/api/system';
+import { BUILTIN_QUICK_ANSWER_ID } from '@/api/agent';
 const route = useRoute();
 const { t } = useI18n();
 const kbId = computed(() => (route.params as any).kbId as string || '');
+const accessAgentId = computed(() => typeof route.query.agent_id === 'string' ? route.query.agent_id : '');
+const accessSourceTenantId = computed(() => typeof route.query.source_tenant_id === 'string' ? route.query.source_tenant_id : '');
 const kbInfo = ref<any>(null);
+const currentFolderId = ref(folderIDFromQuery(route.query.folder_id));
+const currentFolderPath = ref<KnowledgeFolder[]>([]);
+const folderTreeRef = ref<InstanceType<typeof KnowledgeFolderTree>|null>(null);
+watch([kbId,currentFolderId,accessAgentId], async ([id,folderId]) => {
+  if (!id || !folderId) { currentFolderPath.value=[];return; }
+  try { const res:any=await getKnowledgeFolder(id,folderId,{agent_id:accessAgentId.value||undefined});const folder=res?.data;currentFolderPath.value=folder?[...(folder.ancestors||[]),folder]:[]; } catch { currentFolderPath.value=[]; }
+},{immediate:true});
+watch(() => route.query.folder_id, (value) => {
+  const next = folderIDFromQuery(value);
+  if (next !== currentFolderId.value) { currentFolderId.value = next; resetPage(); void loadKnowledgeFiles(kbId.value); }
+});
+const includeFolderDescendants = ref(true);
+const selectFolder = async (folderId: string) => {
+  currentFolderId.value = folderId;
+  selectedIds.value.clear();
+  await router.replace({ query: { ...route.query, folder_id: folderId || 'root' } });
+  resetPage();
+  await loadKnowledgeFiles(kbId.value);
+};
+const askFolder = async (folder: KnowledgeFolder) => {
+  // "Ask this folder" establishes a folder-only knowledge scope. Leaving a
+  // stale whole-KB selection in place would intentionally supersede folders
+  // in the backend and answer from more documents than the user requested.
+  settingsStore.selectAgent(
+    accessAgentId.value || BUILTIN_QUICK_ANSWER_ID,
+    accessAgentId.value ? accessSourceTenantId.value || null : null,
+  );
+  settingsStore.addFolder({ id: folder.id, name: folder.name, kbId: kbId.value, kbName: kbInfo.value?.name });
+  await router.push('/platform/creatChat');
+};
 const uploadSourceRef = ref<InstanceType<typeof KbUploadSourceDropdown> | null>(null);
 const uploading = ref(false);
 const kbLoading = ref(false);
@@ -403,6 +445,23 @@ const selectedIds = ref<Set<string>>(new Set());
 let lastSelectedIndex = -1;
 const batchDeleting = ref(false);
 const batchReparsing = ref(false);
+const folderMoveVisible = ref(false);
+const mobileFolderDrawerVisible = ref(false);
+const folderMoveTarget = ref('');
+const folderMoveKnowledgeIDs = ref<string[]>([]);
+const folderMoving = ref(false);
+const openFolderMove = (knowledgeIDs: string[]) => {
+  folderMoveKnowledgeIDs.value = [...new Set(knowledgeIDs.filter(Boolean))];
+  folderMoveTarget.value = currentFolderId.value;
+  folderMoveVisible.value = folderMoveKnowledgeIDs.value.length > 0;
+};
+const confirmFolderMove = async () => {
+  if (folderMoveKnowledgeIDs.value.length===0 || folderMoving.value) return;
+  folderMoving.value=true;
+  try { await moveKnowledgeToFolder(kbId.value,{knowledge_ids:folderMoveKnowledgeIDs.value,folder_id:folderMoveTarget.value});MessagePlugin.success(t('common.success'));folderMoveVisible.value=false;folderMoveKnowledgeIDs.value=[];clearSelection();await loadKnowledgeFiles(kbId.value);await folderTreeRef.value?.refresh(); }
+  catch(error:any){MessagePlugin.error(error?.message||t('common.operationFailed'));}
+  finally{folderMoving.value=false;}
+};
 // IDs submitted for async batch reparse; hold optimistic pending until the worker updates DB.
 const pendingReparseAck = ref<Set<string>>(new Set());
 
@@ -558,6 +617,9 @@ const disableFutureDate = { after: new Date(new Date().setHours(23, 59, 59, 999)
 const filterParams = computed(() => {
   const [start, end] = updatedTimeRange.value || [];
   return {
+	 folder_id: currentFolderId.value || 'root',
+	 include_descendants: !!docSearchKeyword.value && includeFolderDescendants.value,
+	 agent_id: accessAgentId.value || undefined,
     tag_ids: selectedTagIds.value.length > 0 ? selectedTagIds.value.join(',') : undefined,
     keyword: docSearchKeyword.value ? docSearchKeyword.value.trim() : undefined,
     file_type: selectedFileType.value || undefined,
@@ -1403,51 +1465,35 @@ const executeUploadBatch = async (
     return !!relativePath && relativePath.split('/').length > 2;
   });
 
-  for (const file of files) {
-    try {
+  const parsedPaths = parseRelativeFolderFiles(files);
+  let folderByFile = new Map<File,string>();
+  const paths = dedupeFolderPaths(parsedPaths);
+  if (paths.length > 0) {
+    const ensured:any = await ensureKnowledgeFolderPaths(targetKbId, { parent_id: currentFolderId.value, paths });
+    folderByFile = mapFilesToFolderIDs(parsedPaths, ensured?.data || []);
+  }
+  const tasks = files.map(file => async () => {
       const uploadData: {
         file: File
         tag_ids?: string[]
         fileName?: string
+        folder_id?: string
         process_config?: KnowledgeProcessOverrides
       } = { file, tag_ids: tagIdsToUpload };
 
-      const fileName = getFolderUploadFileName(file);
-      if (fileName) uploadData.fileName = fileName;
+      uploadData.folder_id = folderByFile.get(file) || currentFolderId.value;
       if (options.processConfig) {
         uploadData.process_config = options.processConfig;
       }
 
       const responseData: any = await uploadKnowledgeFile(targetKbId, uploadData);
       const isSuccess = responseData?.success || responseData?.code === 200 || responseData?.status === 'success' || (!responseData?.error && responseData);
-      if (isSuccess) {
-        successCount++;
-      } else {
-        failCount++;
-        if (totalCount === 1) {
-          let errorMessage = t('knowledgeBase.uploadFailed');
-          if (responseData?.error?.message) {
-            errorMessage = responseData.error.message;
-          } else if (responseData?.message) {
-            errorMessage = responseData.message;
-          }
-          if (responseData?.code === 'duplicate_file' || responseData?.error?.code === 'duplicate_file') {
-            errorMessage = t('knowledgeBase.fileExists');
-          }
-          MessagePlugin.error(errorMessage);
-        }
-      }
-    } catch (error: any) {
-      failCount++;
-      if (totalCount === 1) {
-        let errorMessage = error?.error?.message || error?.message || t('knowledgeBase.uploadFailed');
-        if (error?.code === 'duplicate_file') {
-          errorMessage = t('knowledgeBase.fileExists');
-        }
-        MessagePlugin.error(errorMessage);
-      }
-    }
-  }
+      if (!isSuccess) throw responseData;
+      return responseData;
+  });
+  const settled = await runWithConcurrency(tasks, 4);
+  successCount = settled.filter(result => result.status === 'fulfilled').length;
+  failCount = settled.length - successCount;
 
   if (successCount > 0) {
     window.dispatchEvent(new CustomEvent('knowledgeFileUploaded', {
@@ -1471,6 +1517,7 @@ const executeUrlImport = async (url: string, processConfig?: KnowledgeProcessOve
     const responseData: any = await createKnowledgeFromURL(targetKbId, {
       url,
       tag_ids: tagIdsToUpload,
+	  folder_id: currentFolderId.value,
       process_config: processConfig,
     });
     window.dispatchEvent(new CustomEvent('knowledgeFileUploaded', {
@@ -1559,6 +1606,7 @@ const handleManualCreate = () => {
   uiStore.openManualEditor({
     mode: 'create',
     kbId: kbId.value,
+	folderId: currentFolderId.value,
     status: 'draft',
     onSuccess: manualEditorSuccess,
   });
@@ -1853,7 +1901,7 @@ const confirmCancelParseKnowledge = async (item: KnowledgeCard) => {
 
 // Bridge card-view actions back to existing per-card handlers.
 const handleCardAction = (
-  action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'delete' | 'view-trace' | 'batch-manage',
+  action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'move-folder' | 'delete' | 'view-trace' | 'batch-manage',
   item: KnowledgeCard,
 ) => {
   const idx = (cardList.value || []).findIndex((i: KnowledgeCard) => i.id === item.id);
@@ -1864,6 +1912,7 @@ const handleCardAction = (
   }
   if (action === 'cancel-parse') return confirmCancelParseKnowledge(item);
   if (action === 'move') return handleMoveKnowledge(item);
+  if (action === 'move-folder') return openFolderMove([item.id]);
   if (action === 'delete') return confirmDeleteKnowledge(idx, item);
   if (action === 'view-trace') return handleViewTrace(idx, item);
   if (action === 'batch-manage') return handleEnterBatchFromCard(item);
@@ -1871,7 +1920,7 @@ const handleCardAction = (
 
 // Bridge list-view actions back to existing per-card handlers.
 const handleListAction = (
-  action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'delete' | 'view-trace' | 'batch-manage',
+  action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'move-folder' | 'delete' | 'view-trace' | 'batch-manage',
   item: KnowledgeCard,
 ) => {
   const idx = (cardList.value || []).findIndex((i: KnowledgeCard) => i.id === item.id);
@@ -1879,6 +1928,7 @@ const handleListAction = (
   if (action === 'reparse') return confirmRebuildKnowledge(idx, item);
   if (action === 'cancel-parse') return confirmCancelParseKnowledge(item);
   if (action === 'move') return handleMoveKnowledge(item);
+  if (action === 'move-folder') return openFolderMove([item.id]);
   if (action === 'delete') return confirmDeleteKnowledge(idx, item);
   if (action === 'view-trace') return handleViewTrace(idx, item);
   if (action === 'batch-manage') return handleEnterBatchFromCard(item);
@@ -2045,8 +2095,12 @@ async function createNewSession(value: string): Promise<void> {
       <template v-if="activeKbTab === 'documents' || !isWiki">
         <div class="knowledge-main">
           <div class="tag-content">
+            <div class="desktop-folder-tree"><KnowledgeFolderTree ref="folderTreeRef" v-if="kbId" :kb-id="kbId" :model-value="currentFolderId" :can-edit="canEdit" :agent-id="accessAgentId"
+              @update:model-value="selectFolder" @ask="askFolder" @changed="loadKnowledgeFiles(kbId)" /></div>
             <div class="doc-card-area">
+			  <nav class="folder-breadcrumb" :aria-label="t('knowledgeFolder.currentFolder')"><button @click="selectFolder('')">{{ t('knowledgeFolder.root') }}</button><template v-for="folder in currentFolderPath" :key="folder.id"><t-icon name="chevron-right"/><button @click="selectFolder(folder.id)">{{ folder.name }}</button></template></nav>
               <div class="doc-filter-bar">
+				<t-button class="mobile-folder-trigger" shape="square" variant="outline" :title="t('knowledgeFolder.folders')" @click="mobileFolderDrawerVisible=true"><t-icon name="folder" /></t-button>
                 <t-input v-model.trim="docSearchKeyword" :placeholder="$t('knowledgeBase.docSearchPlaceholder')"
                   clearable class="doc-search-input" @clear="loadKnowledgeFiles(kbId)"
                   @enter="loadKnowledgeFiles(kbId)">
@@ -2054,6 +2108,7 @@ async function createNewSession(value: string): Promise<void> {
                     <t-icon name="search" size="16px" />
                   </template>
                 </t-input>
+				<t-checkbox v-if="docSearchKeyword" v-model="includeFolderDescendants" @change="loadKnowledgeFiles(kbId)">{{ t('knowledgeFolder.includeDescendants') }}</t-checkbox>
                 <div class="doc-filter-bar__filters">
                 <t-popup v-model:visible="tagFilterPanelVisible" trigger="click" placement="bottom-left"
                   overlay-class-name="tag-filter-popup" :overlay-inner-style="{ padding: 0 }">
@@ -2284,11 +2339,16 @@ async function createNewSession(value: string): Promise<void> {
                 </template>
               </div>
               <div class="doc-batch-bar-anchor" v-show="batchMode || selectedIds.size > 0">
+                <t-button v-if="selectedIds.size>0" variant="outline" @click="openFolderMove([...selectedIds])"><template #icon><t-icon name="folder-move" /></template>{{ t('knowledgeFolder.moveDocuments') }}</t-button>
                 <DocumentBatchBar :count="selectedIds.size" :delete-loading="batchDeleting"
                   :reparse-loading="batchReparsing" :visible="batchMode || selectedIds.size > 0"
                   @cancel="handleBatchCancel" @delete="confirmBatchDelete" @reparse="confirmBatchReparse" />
               </div>
+			  <t-dialog v-model:visible="folderMoveVisible" :header="t('knowledgeFolder.moveDocuments')" :confirm-btn="{content:t('common.confirm'),loading:folderMoving}" @confirm="confirmFolderMove">
+				<KnowledgeFolderPicker v-if="folderMoveVisible" v-model="folderMoveTarget" :kb-id="kbId" />
+			  </t-dialog>
             </div>
+			<t-drawer v-model:visible="mobileFolderDrawerVisible" placement="left" :header="t('knowledgeFolder.folders')" size="min(86vw, 320px)"><KnowledgeFolderTree v-if="kbId" :kb-id="kbId" :model-value="currentFolderId" :can-edit="canEdit" :agent-id="accessAgentId" @update:model-value="(id:string)=>{mobileFolderDrawerVisible=false;selectFolder(id)}" @ask="askFolder" /></t-drawer>
           </div>
         </div>
       </template>
@@ -2345,7 +2405,7 @@ async function createNewSession(value: string): Promise<void> {
 
 .tag-more-popup .tag-menu {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
 }
 
 .tag-more-popup .tag-menu-item {
@@ -2662,6 +2722,27 @@ async function createNewSession(value: string): Promise<void> {
   background: transparent;
 }
 
+.desktop-folder-tree { display: flex; min-height: 0; }
+.mobile-folder-trigger { display: none; }
+.folder-breadcrumb { height:36px;display:flex;align-items:center;gap:4px;overflow:hidden;flex:none; }
+.folder-breadcrumb button { border:0;background:transparent;color:var(--td-text-color-secondary);cursor:pointer;max-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap; }
+.folder-breadcrumb button:last-child { color:var(--td-text-color-primary);font-weight:500; }
+@media (max-width: 760px) {
+  :global(.main) {
+    width: 100vw;
+    min-width: 0;
+  }
+
+  .knowledge-layout {
+    margin: 0;
+    padding: 16px 12px 0;
+    gap: 12px;
+  }
+
+  .desktop-folder-tree { display: none; }
+  .mobile-folder-trigger { display: inline-flex; }
+}
+
 .doc-card-area {
   flex: 1;
   display: flex;
@@ -2719,13 +2800,8 @@ async function createNewSession(value: string): Promise<void> {
   }
 
   @media (min-width: 1280px) {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    gap: 12px;
-
     &__filters {
-      flex: 0 1 auto;
+      flex-wrap: wrap;
       overflow-x: visible;
     }
   }

--- a/frontend/src/views/knowledge/KnowledgeBaseList.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseList.vue
@@ -1476,12 +1476,24 @@ const handleShareSuccess = () => {
 const handleSharedKbClick = (sharedKb: SharedKnowledgeBase) => {
   pins.touchRecent('kb', sharedKb.knowledge_base.id)
   // 跳转到共享知识库详情页
-  router.push(`/platform/knowledge-bases/${sharedKb.knowledge_base.id}`)
+  const source = (sharedKb as SharedKbDetailItem).source_from_agent
+  router.push({
+    path: `/platform/knowledge-bases/${sharedKb.knowledge_base.id}`,
+    query: source ? {
+      agent_id: source.agent_id,
+      source_tenant_id: String(sharedKb.source_tenant_id),
+    } : undefined,
+  })
 }
 
 // 处理"全部"Tab 中的共享知识库卡片点击（直接进入知识库）
 const handleSharedKbClickFromAll = (kb: any) => {
   pins.touchRecent('kb', kb.id)
+  const shared = sharedKbs.value.find(item => item.knowledge_base.id === kb.id)
+  if (shared) {
+    handleSharedKbClick(shared)
+    return
+  }
   router.push(`/platform/knowledge-bases/${kb.id}`)
 }
 
@@ -1520,7 +1532,7 @@ const agentKbStrategyText = (mode: string) => {
 // 从右侧面板进入知识库
 const goToSharedKbFromPanel = () => {
   if (currentSharedKbForDetail.value) {
-    router.push(`/platform/knowledge-bases/${currentSharedKbForDetail.value.knowledge_base.id}`)
+    handleSharedKbClick(currentSharedKbForDetail.value)
     closeSharedDetailPanel()
   }
 }

--- a/frontend/src/views/knowledge/components/DocumentActionMenu.vue
+++ b/frontend/src/views/knowledge/components/DocumentActionMenu.vue
@@ -22,6 +22,7 @@ const emit = defineEmits<{
   (e: 'reparse'): void;
   (e: 'cancel-parse'): void;
   (e: 'move'): void;
+  (e: 'move-folder'): void;
   (e: 'batch-manage'): void;
   (e: 'delete'): void;
 }>();
@@ -84,6 +85,11 @@ const fileName = computed(() => props.item.file_name || props.item.title || prop
   <div v-if="canMutateKnowledge" class="doc-action-menu-item" @click.stop="emit('move')">
     <t-icon class="icon" name="swap" />
     <span>{{ $t('knowledgeBase.moveDocument') }}</span>
+  </div>
+
+  <div v-if="canMutateKnowledge" class="doc-action-menu-item" @click.stop="emit('move-folder')">
+    <t-icon class="icon" name="folder-move" />
+    <span>{{ $t('knowledgeFolder.moveDocuments') }}</span>
   </div>
 
   <!-- 批量管理 -->

--- a/frontend/src/views/knowledge/components/DocumentCardView.vue
+++ b/frontend/src/views/knowledge/components/DocumentCardView.vue
@@ -56,7 +56,7 @@ const emit = defineEmits<{
   (e: 'open', item: KnowledgeCard): void;
   (e: 'toggle-checkbox', id: string, checked: boolean, ctx?: { e?: Event }): void;
   (e: 'menu-visible-change', visible: boolean, item: KnowledgeCard): void;
-  (e: 'action', action: 'edit' | 'view-trace' | 'reparse' | 'cancel-parse' | 'move' | 'batch-manage' | 'delete', item: KnowledgeCard): void;
+  (e: 'action', action: 'edit' | 'view-trace' | 'reparse' | 'cancel-parse' | 'move' | 'move-folder' | 'batch-manage' | 'delete', item: KnowledgeCard): void;
   (e: 'tag-edit', item: KnowledgeCard): void;
   // Move sub-flow emits
   (e: 'move-select-target', kb: any): void;
@@ -250,7 +250,7 @@ const onCardMouseLeave = () => {
 };
 
 // --- Action handlers ---
-const handleAction = (action: 'edit' | 'view-trace' | 'reparse' | 'cancel-parse' | 'move' | 'batch-manage' | 'delete', item: KnowledgeCard) => {
+const handleAction = (action: 'edit' | 'view-trace' | 'reparse' | 'cancel-parse' | 'move' | 'move-folder' | 'batch-manage' | 'delete', item: KnowledgeCard) => {
   // Don't close menu for move — it triggers the sub-flow
   if (action !== 'move') {
     if (item.isMore !== undefined) item.isMore = false;
@@ -313,6 +313,7 @@ const handleAction = (action: 'edit' | 'view-trace' | 'reparse' | 'cancel-parse'
                   @reparse="handleAction('reparse', item)"
                   @cancel-parse="handleAction('cancel-parse', item)"
                   @move="handleAction('move', item)"
+                  @move-folder="handleAction('move-folder', item)"
                   @batch-manage="handleAction('batch-manage', item)"
                   @delete="handleAction('delete', item)"
                 />

--- a/frontend/src/views/knowledge/components/DocumentListView.vue
+++ b/frontend/src/views/knowledge/components/DocumentListView.vue
@@ -48,7 +48,7 @@ const emit = defineEmits<{
   (e: 'open', item: KnowledgeItem): void;
   (e: 'toggle-row', id: string, checked: boolean, shiftKey: boolean): void;
   (e: 'toggle-all', checked: boolean): void;
-  (e: 'action', action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'delete' | 'view-trace' | 'batch-manage', item: KnowledgeItem): void;
+  (e: 'action', action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'move-folder' | 'delete' | 'view-trace' | 'batch-manage', item: KnowledgeItem): void;
   (e: 'probe-trace', item: KnowledgeItem): void;
   (e: 'tag-edit', item: KnowledgeItem): void;
   // Move sub-flow emits
@@ -204,7 +204,7 @@ onBeforeUnmount(() => {
   stickyObserver = null;
 });
 
-const handleAction = (action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'delete' | 'view-trace' | 'batch-manage', item: KnowledgeItem) => {
+const handleAction = (action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'move-folder' | 'delete' | 'view-trace' | 'batch-manage', item: KnowledgeItem) => {
   // Don't close popup for move — it triggers the move sub-flow
   if (action !== 'move') {
     moreOpen.value = null;
@@ -324,6 +324,7 @@ const handleAction = (action: 'edit' | 'reparse' | 'cancel-parse' | 'move' | 'de
                   @reparse="handleAction('reparse', item)"
                   @cancel-parse="handleAction('cancel-parse', item)"
                   @move="handleAction('move', item)"
+                  @move-folder="handleAction('move-folder', item)"
                   @batch-manage="handleAction('batch-manage', item)"
                   @delete="handleAction('delete', item)"
                 />

--- a/frontend/src/views/knowledge/components/KnowledgeFolderPicker.vue
+++ b/frontend/src/views/knowledge/components/KnowledgeFolderPicker.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { listKnowledgeFolders, type KnowledgeFolder } from '@/api/knowledge-base';
+import { flattenFolderPages, mergeFolderPage, type FolderPage, type FolderTreeRow } from '@/utils/knowledgeFolders';
+
+const PAGE_SIZE = 50;
+const props = withDefaults(defineProps<{
+  kbId: string;
+  modelValue: string;
+  disabledIds?: string[];
+}>(), { disabledIds: () => [] });
+const emit = defineEmits<{ 'update:modelValue': [value: string] }>();
+const { t } = useI18n();
+
+type PageState = FolderPage<KnowledgeFolder>;
+type PickerRow = FolderTreeRow<KnowledgeFolder>;
+
+const pages = ref(new Map<string, PageState>());
+const expanded = ref(new Set<string>());
+const disabled = computed(() => new Set(props.disabledIds));
+
+const responsePage = (response: any) => response?.data || {};
+
+async function load(parentId = '', reset = false) {
+  const current = pages.value.get(parentId);
+  if (current?.loading) return;
+  if (!reset && current && current.items.length >= current.total) return;
+  const page = reset ? 1 : (current?.page || 0) + 1;
+  pages.value.set(parentId, { items: reset ? [] : current?.items || [], page: page - 1, total: current?.total || 0, loading: true });
+  pages.value = new Map(pages.value);
+  try {
+    const response: any = await listKnowledgeFolders(props.kbId, { parent_id: parentId, page, page_size: PAGE_SIZE });
+    const result = responsePage(response);
+    const nextItems = Array.isArray(result.data) ? result.data : [];
+    pages.value.set(parentId, mergeFolderPage(current, nextItems, page, result.total, reset));
+  } finally {
+    const state = pages.value.get(parentId);
+    if (state?.loading) pages.value.set(parentId, { ...state, loading: false });
+    pages.value = new Map(pages.value);
+  }
+}
+
+const rows = computed<PickerRow[]>(() => flattenFolderPages(pages.value, expanded.value));
+
+async function toggle(folder: KnowledgeFolder) {
+  if (!folder.has_children) return;
+  if (expanded.value.has(folder.id)) expanded.value.delete(folder.id);
+  else {
+    expanded.value.add(folder.id);
+    await load(folder.id);
+  }
+  expanded.value = new Set(expanded.value);
+}
+
+function select(folderId: string) {
+  if (!disabled.value.has(folderId)) emit('update:modelValue', folderId);
+}
+
+watch(() => props.kbId, () => {
+  pages.value = new Map();
+  expanded.value = new Set();
+  void load('', true);
+});
+onMounted(() => void load('', true));
+</script>
+
+<template>
+  <div class="folder-picker" role="tree" :aria-label="t('knowledgeFolder.folders')">
+    <button class="picker-row" :class="{ active: modelValue === '' }" role="treeitem" @click="select('')">
+      <span class="picker-expand" />
+      <t-icon name="home" />
+      <span class="picker-name">{{ t('knowledgeFolder.root') }}</span>
+    </button>
+    <template v-for="(row, index) in rows" :key="row.kind === 'folder' ? row.folder.id : `more-${row.parentId}-${index}`">
+      <button v-if="row.kind === 'folder'" class="picker-row"
+        :class="{ active: modelValue === row.folder.id, disabled: disabled.has(row.folder.id) }"
+        :style="{ paddingLeft: `${8 + row.depth * 18}px` }" role="treeitem"
+        :aria-disabled="disabled.has(row.folder.id)" @click="select(row.folder.id)">
+        <span class="picker-expand" @click.stop="toggle(row.folder)">
+          <t-icon v-if="row.folder.has_children" :name="expanded.has(row.folder.id) ? 'chevron-down' : 'chevron-right'" />
+        </span>
+        <t-icon name="folder" />
+        <span class="picker-name">{{ row.folder.name }}</span>
+        <span class="picker-count">{{ row.folder.total_knowledge_count }}</span>
+      </button>
+      <t-button v-else class="picker-more" variant="text" size="small"
+        :loading="pages.get(row.parentId)?.loading" :style="{ marginLeft: `${26 + row.depth * 18}px` }"
+        @click="load(row.parentId)">
+        {{ t('knowledgeFolder.loadMore') }}
+      </t-button>
+    </template>
+    <div v-if="pages.get('')?.loading && !pages.get('')?.items.length" class="picker-loading"><t-loading size="small" /></div>
+  </div>
+</template>
+
+<style scoped>
+.folder-picker{height:min(52vh,420px);overflow:auto;border:1px solid var(--td-component-stroke);background:var(--td-bg-color-container)}
+.picker-row{width:100%;height:36px;display:flex;align-items:center;gap:7px;border:0;background:transparent;color:var(--td-text-color-primary);font:inherit;text-align:left;padding:0 8px;cursor:pointer}
+.picker-row:hover,.picker-row.active{background:var(--td-bg-color-container-hover)}.picker-row.active{color:var(--td-brand-color)}.picker-row.disabled{opacity:.45;cursor:not-allowed}
+.picker-expand{width:18px;height:24px;display:flex;align-items:center;justify-content:center;flex:none}.picker-name{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}.picker-count{font-size:12px;color:var(--td-text-color-placeholder)}
+.picker-more{display:flex;margin-top:2px;margin-bottom:2px}.picker-loading{height:56px;display:flex;align-items:center;justify-content:center}
+</style>

--- a/frontend/src/views/knowledge/components/KnowledgeFolderTree.vue
+++ b/frontend/src/views/knowledge/components/KnowledgeFolderTree.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { MessagePlugin } from 'tdesign-vue-next';
+import { createKnowledgeFolder, deleteKnowledgeFolder, listKnowledgeFolders, updateKnowledgeFolder, type KnowledgeFolder } from '@/api/knowledge-base';
+import { useI18n } from 'vue-i18n';
+import KnowledgeFolderPicker from './KnowledgeFolderPicker.vue';
+import { flattenFolderPages, mergeFolderPage, type FolderPage, type FolderTreeRow } from '@/utils/knowledgeFolders';
+
+const props = defineProps<{ kbId:string; modelValue:string; canEdit:boolean; agentId?:string }>();
+const emit = defineEmits<{ 'update:modelValue':[value:string]; ask:[folder:KnowledgeFolder]; changed:[] }>();
+const { t } = useI18n();
+const PAGE_SIZE = 50;
+type PageState = FolderPage<KnowledgeFolder>;
+type Row = FolderTreeRow<KnowledgeFolder>;
+const pages = ref(new Map<string,PageState>());
+const expanded = ref(new Set<string>());
+const editorVisible=ref(false), editorName=ref(''), editorParent=ref(''), editorTarget=ref<KnowledgeFolder|null>(null);
+const moveVisible=ref(false), moveTarget=ref(''), movingFolder=ref<KnowledgeFolder|null>(null);
+
+async function load(parentId='', reset=false) {
+  const current=pages.value.get(parentId);
+  if(current?.loading)return;
+  if(!reset&&current&&current.items.length>=current.total)return;
+  const page=reset?1:(current?.page||0)+1;
+  pages.value.set(parentId,{items:reset?[]:current?.items||[],page:page-1,total:current?.total||0,loading:true});pages.value=new Map(pages.value);
+  try {
+    const res:any=await listKnowledgeFolders(props.kbId,{parent_id:parentId,page,page_size:PAGE_SIZE,agent_id:props.agentId});
+    const result=res?.data||{};const next=Array.isArray(result.data)?result.data:[];
+    pages.value.set(parentId,mergeFolderPage(current,next,page,result.total,reset));
+  } finally { const state=pages.value.get(parentId);if(state?.loading)pages.value.set(parentId,{...state,loading:false});pages.value=new Map(pages.value); }
+}
+const rows=computed<Row[]>(()=>flattenFolderPages(pages.value,expanded.value));
+async function toggle(folder:KnowledgeFolder){if(!folder.has_children)return;if(expanded.value.has(folder.id))expanded.value.delete(folder.id);else{expanded.value.add(folder.id);await load(folder.id)};expanded.value=new Set(expanded.value)}
+function openCreate(parent=''){editorTarget.value=null;editorParent.value=parent;editorName.value='';editorVisible.value=true}
+function openRename(folder:KnowledgeFolder){editorTarget.value=folder;editorParent.value=folder.parent_id;editorName.value=folder.name;editorVisible.value=true}
+async function save(){if(!editorName.value.trim())return;try{if(editorTarget.value)await updateKnowledgeFolder(props.kbId,editorTarget.value.id,{name:editorName.value});else await createKnowledgeFolder(props.kbId,{name:editorName.value,parent_id:editorParent.value});editorVisible.value=false;await load(editorParent.value,true);emit('changed')}catch(error:any){MessagePlugin.error(error?.message||String(error))}}
+async function remove(folder:KnowledgeFolder){try{await deleteKnowledgeFolder(props.kbId,folder.id);await load(folder.parent_id,true);if(props.modelValue===folder.id)emit('update:modelValue','');emit('changed')}catch(error:any){MessagePlugin.error(error?.message||t('knowledgeFolder.emptyRequired'))}}
+function openMove(folder:KnowledgeFolder){movingFolder.value=folder;moveTarget.value=folder.parent_id;moveVisible.value=true}
+async function saveMove(){if(!movingFolder.value)return;try{await updateKnowledgeFolder(props.kbId,movingFolder.value.id,{parent_id:moveTarget.value});moveVisible.value=false;await load(movingFolder.value.parent_id,true);await load(moveTarget.value,true);emit('changed')}catch(error:any){MessagePlugin.error(error?.message||String(error))}}
+function folderMenuOptions(){const ask={content:t('knowledgeFolder.ask'),value:'ask'};return props.canEdit?[{content:t('knowledgeFolder.newFolder'),value:'create'},{content:t('knowledgeFolder.rename'),value:'rename'},{content:t('knowledgeFolder.move'),value:'move'},ask,{content:t('knowledgeFolder.delete'),value:'delete'}]:[ask]}
+function menu(folder:KnowledgeFolder,data:any){const action=data?.value||data;if(action==='create')openCreate(folder.id);if(action==='rename')openRename(folder);if(action==='move')openMove(folder);if(action==='ask')emit('ask',folder);if(action==='delete')remove(folder)}
+async function refresh(){const parents=['',...expanded.value];await Promise.all(parents.map(parent=>load(parent,true)))}
+watch(()=>[props.kbId,props.agentId],()=>{pages.value=new Map();expanded.value=new Set();void load('',true)});
+onMounted(()=>void load('',true));
+defineExpose({ refresh });
+</script>
+<template>
+  <aside class="folder-tree" :aria-label="t('knowledgeFolder.folders')">
+    <div class="folder-tree__header"><strong>{{ t('knowledgeFolder.folders') }}</strong><t-button v-if="canEdit" shape="square" variant="text" size="small" :title="t('knowledgeFolder.newFolder')" @click="openCreate('')"><t-icon name="folder-add" /></t-button></div>
+    <button class="folder-row" :class="{active:modelValue===''}" @click="emit('update:modelValue','')"><span class="folder-indent"/><t-icon name="home"/><span class="folder-name">{{ t('knowledgeFolder.root') }}</span></button>
+    <template v-for="(row,index) in rows" :key="row.kind==='folder'?row.folder.id:`more-${row.parentId}-${index}`">
+      <div v-if="row.kind==='folder'" class="folder-row" :class="{active:modelValue===row.folder.id}" :style="{paddingLeft:`${8+row.depth*18}px`}" @click="emit('update:modelValue',row.folder.id)">
+        <button class="folder-expand" :disabled="!row.folder.has_children" :title="row.folder.name" @click.stop="toggle(row.folder)"><t-icon :name="row.folder.has_children?(expanded.has(row.folder.id)?'chevron-down':'chevron-right'):''"/></button><t-icon name="folder"/><span class="folder-name">{{ row.folder.name }}</span><span class="folder-count">{{ row.folder.total_knowledge_count }}</span>
+        <t-dropdown trigger="click" :options="folderMenuOptions()" @click="(data:any)=>menu(row.folder,data)"><t-button shape="square" variant="text" size="small" @click.stop><t-icon name="more"/></t-button></t-dropdown>
+      </div>
+      <t-button v-else variant="text" size="small" :loading="pages.get(row.parentId)?.loading" :style="{marginLeft:`${26+row.depth*18}px`}" @click="load(row.parentId)">{{ t('knowledgeFolder.loadMore') }}</t-button>
+    </template>
+    <t-dialog v-model:visible="editorVisible" :header="editorTarget?t('knowledgeFolder.rename'):t('knowledgeFolder.newFolder')" :confirm-btn="t('common.confirm')" @confirm="save"><t-input v-model="editorName" :maxlength="100" autofocus /></t-dialog>
+	<t-dialog v-model:visible="moveVisible" :header="t('knowledgeFolder.move')" :confirm-btn="t('common.confirm')" @confirm="saveMove"><KnowledgeFolderPicker v-if="moveVisible" v-model="moveTarget" :kb-id="kbId" :disabled-ids="movingFolder?[movingFolder.id]:[]" /></t-dialog>
+  </aside>
+</template>
+<style scoped>
+.folder-tree{box-sizing:border-box;width:240px;min-width:200px;border-right:1px solid var(--td-component-stroke);padding:10px 8px;overflow:auto;background:var(--td-bg-color-container)}.folder-tree__header{height:36px;display:flex;align-items:center;justify-content:space-between;padding:0 6px}.folder-row{box-sizing:border-box;width:100%;height:34px;display:flex;align-items:center;gap:7px;border:0;background:transparent;color:var(--td-text-color-primary);font:inherit;text-align:left;padding:0 8px;cursor:pointer}.folder-row:hover,.folder-row.active{background:var(--td-bg-color-container-hover)}.folder-row.active{color:var(--td-brand-color)}.folder-expand{width:18px;height:24px;border:0;background:transparent;padding:0;flex:none}.folder-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}.folder-count{font-size:12px;color:var(--td-text-color-placeholder)}.folder-indent{width:18px}@media(max-width:760px){.folder-tree{width:100%;max-width:100%;height:100%}}
+</style>

--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -956,9 +956,22 @@ func (r *chunkRepository) FAQChunkDiff(
 	return chunksToAdd, chunksToDelete, nil
 }
 
+const maxKnowledgeIDsPerChunkQuery = 500
+
+func chunkKnowledgeIDBatches(ids []string) [][]string {
+	if len(ids) == 0 {
+		return nil
+	}
+	batches := make([][]string, 0, (len(ids)+maxKnowledgeIDsPerChunkQuery-1)/maxKnowledgeIDsPerChunkQuery)
+	for start := 0; start < len(ids); start += maxKnowledgeIDsPerChunkQuery {
+		end := min(start+maxKnowledgeIDsPerChunkQuery, len(ids))
+		batches = append(batches, ids[start:end])
+	}
+	return batches
+}
+
 // ListRecommendedFAQChunks lists FAQ chunks with the recommended flag set.
-// Filter by kbIDs and/or knowledgeIDs (OR relationship). At least one must be non-empty.
-// Returns up to `limit` chunks sorted by updated_at descending.
+// KB and knowledge filters use AND semantics when both are present.
 func (r *chunkRepository) ListRecommendedFAQChunks(
 	ctx context.Context,
 	tenantID uint64,
@@ -972,35 +985,43 @@ func (r *chunkRepository) ListRecommendedFAQChunks(
 	if len(kbIDs) == 0 && len(knowledgeIDs) == 0 {
 		return nil, nil
 	}
-	var chunks []*types.Chunk
-	query := r.db.WithContext(ctx).
-		Select("id, knowledge_id, knowledge_base_id, chunk_type, metadata, flags, updated_at").
-		Where("tenant_id = ? AND chunk_type = ? AND status IN ? AND is_enabled = ? AND flags & ? != 0",
-			tenantID, types.ChunkTypeFAQ, []int{int(types.ChunkStatusIndexed), int(types.ChunkStatusDefault)}, true, int(types.ChunkFlagRecommended))
-	if len(knowledgeIDs) > 0 {
-		// 指定了具体知识文档，直接按 knowledge_id 过滤（忽略 kbIDs）
-		query = query.Where("knowledge_id IN ?", knowledgeIDs)
-	} else {
-		query = query.Where("knowledge_base_id IN ?", kbIDs)
-	}
-
 	orderClause := "RANDOM()"
 	if r.db.Dialector.Name() == "mysql" {
 		orderClause = "RAND()"
 	}
-
-	if err := query.
-		Order(orderClause).
-		Limit(limit).
-		Find(&chunks).Error; err != nil {
-		return nil, err
+	baseQuery := func() *gorm.DB {
+		query := r.db.WithContext(ctx).
+			Select("id, knowledge_id, knowledge_base_id, chunk_type, metadata, flags, updated_at").
+			Where("tenant_id = ? AND chunk_type = ? AND status IN ? AND is_enabled = ? AND flags & ? != 0",
+				tenantID, types.ChunkTypeFAQ, []int{int(types.ChunkStatusIndexed), int(types.ChunkStatusDefault)}, true, int(types.ChunkFlagRecommended))
+		if len(kbIDs) > 0 {
+			query = query.Where("knowledge_base_id IN ?", kbIDs)
+		}
+		return query
+	}
+	var chunks []*types.Chunk
+	if len(knowledgeIDs) == 0 {
+		if err := baseQuery().Order(orderClause).Limit(limit).Find(&chunks).Error; err != nil {
+			return nil, err
+		}
+		return chunks, nil
+	}
+	for _, batch := range chunkKnowledgeIDBatches(knowledgeIDs) {
+		var batchChunks []*types.Chunk
+		if err := baseQuery().Where("knowledge_id IN ?", batch).
+			Order(orderClause).Limit(limit - len(chunks)).Find(&batchChunks).Error; err != nil {
+			return nil, err
+		}
+		chunks = append(chunks, batchChunks...)
+		if len(chunks) >= limit {
+			break
+		}
 	}
 	return chunks, nil
 }
 
 // ListRecentDocumentChunksWithQuestions lists recent document chunks that have generated questions.
-// Filter by kbIDs and/or knowledgeIDs (OR relationship). At least one must be non-empty.
-// Returns up to `limit` chunks sorted by updated_at descending.
+// KB and knowledge filters use AND semantics when both are present.
 func (r *chunkRepository) ListRecentDocumentChunksWithQuestions(
 	ctx context.Context,
 	tenantID uint64,
@@ -1014,54 +1035,45 @@ func (r *chunkRepository) ListRecentDocumentChunksWithQuestions(
 	if len(kbIDs) == 0 && len(knowledgeIDs) == 0 {
 		return nil, nil
 	}
-	var chunks []*types.Chunk
-
-	baseQuery := r.db.WithContext(ctx).
-		Select("id, knowledge_id, knowledge_base_id, chunk_type, metadata, updated_at").
-		Where("tenant_id = ? AND chunk_type = ? AND status IN ? AND is_enabled = ?",
-			tenantID, types.ChunkTypeText, []int{int(types.ChunkStatusIndexed), int(types.ChunkStatusDefault)}, true)
-
-	if len(kbIDs) > 0 && len(knowledgeIDs) > 0 {
-		baseQuery = baseQuery.Where("knowledge_base_id IN ? OR knowledge_id IN ?", kbIDs, knowledgeIDs)
-	} else if len(knowledgeIDs) > 0 {
-		// 指定了具体知识文档，直接按 knowledge_id 过滤（忽略 kbIDs）
-		baseQuery = baseQuery.Where("knowledge_id IN ?", knowledgeIDs)
-	} else if len(kbIDs) > 0 {
-		baseQuery = baseQuery.Where("knowledge_base_id IN ?", kbIDs)
-	}
-
 	orderClause := "RANDOM()"
 	if r.db.Dialector.Name() == "mysql" {
 		orderClause = "RAND()"
 	}
 
-	// Query chunks that have non-empty generated_questions in metadata
-	switch r.db.Name() {
-	case "postgres":
-		if err := baseQuery.
-			Where("metadata IS NOT NULL AND metadata::text != '{}' AND jsonb_array_length(COALESCE(metadata->'generated_questions', '[]'::jsonb)) > 0").
-			Order(orderClause).
-			Limit(limit).
-			Find(&chunks).Error; err != nil {
-			return nil, err
+	baseQuery := func() *gorm.DB {
+		query := r.db.WithContext(ctx).
+			Select("id, knowledge_id, knowledge_base_id, chunk_type, metadata, updated_at").
+			Where("tenant_id = ? AND chunk_type = ? AND status IN ? AND is_enabled = ?",
+				tenantID, types.ChunkTypeText, []int{int(types.ChunkStatusIndexed), int(types.ChunkStatusDefault)}, true)
+		if len(kbIDs) > 0 {
+			query = query.Where("knowledge_base_id IN ?", kbIDs)
 		}
-	case "mysql":
-		if err := baseQuery.
-			Where("metadata IS NOT NULL AND JSON_LENGTH(JSON_EXTRACT(metadata, '$.generated_questions')) > 0").
-			Order(orderClause).
-			Limit(limit).
-			Find(&chunks).Error; err != nil {
-			return nil, err
-		}
-	default: // sqlite
-		if err := baseQuery.
-			Where("metadata IS NOT NULL AND json_array_length(json_extract(metadata, '$.generated_questions')) > 0").
-			Order(orderClause).
-			Limit(limit).
-			Find(&chunks).Error; err != nil {
-			return nil, err
+		switch r.db.Name() {
+		case "postgres":
+			return query.Where("metadata IS NOT NULL AND metadata::text != '{}' AND jsonb_array_length(COALESCE(metadata->'generated_questions', '[]'::jsonb)) > 0")
+		case "mysql":
+			return query.Where("metadata IS NOT NULL AND JSON_LENGTH(JSON_EXTRACT(metadata, '$.generated_questions')) > 0")
+		default:
+			return query.Where("metadata IS NOT NULL AND json_array_length(json_extract(metadata, '$.generated_questions')) > 0")
 		}
 	}
-
+	var chunks []*types.Chunk
+	if len(knowledgeIDs) == 0 {
+		if err := baseQuery().Order(orderClause).Limit(limit).Find(&chunks).Error; err != nil {
+			return nil, err
+		}
+		return chunks, nil
+	}
+	for _, batch := range chunkKnowledgeIDBatches(knowledgeIDs) {
+		var batchChunks []*types.Chunk
+		if err := baseQuery().Where("knowledge_id IN ?", batch).
+			Order(orderClause).Limit(limit - len(chunks)).Find(&batchChunks).Error; err != nil {
+			return nil, err
+		}
+		chunks = append(chunks, batchChunks...)
+		if len(chunks) >= limit {
+			break
+		}
+	}
 	return chunks, nil
 }

--- a/internal/application/repository/chunk_suggestion_batch_test.go
+++ b/internal/application/repository/chunk_suggestion_batch_test.go
@@ -1,0 +1,29 @@
+package repository
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChunkKnowledgeIDBatchesBoundSuggestedQuestionQueries(t *testing.T) {
+	ids := make([]string, 1201)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("knowledge-%04d", i)
+	}
+
+	batches := chunkKnowledgeIDBatches(ids)
+	require.Len(t, batches, 3)
+	require.Len(t, batches[0], maxKnowledgeIDsPerChunkQuery)
+	require.Len(t, batches[1], maxKnowledgeIDsPerChunkQuery)
+	require.Len(t, batches[2], 201)
+
+	flattened := make([]string, 0, len(ids))
+	for _, batch := range batches {
+		require.LessOrEqual(t, len(batch), maxKnowledgeIDsPerChunkQuery)
+		flattened = append(flattened, batch...)
+	}
+	require.Equal(t, ids, flattened)
+	require.Nil(t, chunkKnowledgeIDBatches(nil))
+}

--- a/internal/application/repository/knowledge.go
+++ b/internal/application/repository/knowledge.go
@@ -12,6 +12,7 @@ import (
 )
 
 var ErrKnowledgeNotFound = errors.New("knowledge not found")
+var ErrKnowledgeFolderScopeMismatch = errors.New("knowledge folder does not belong to knowledge base")
 
 // escapeLikeKeyword escapes SQL LIKE wildcards (%, _) in a keyword
 // so they are treated as literal characters.
@@ -36,7 +37,7 @@ func escapeLikeKeyword(keyword string) string {
 // counter jump back up and never reach zero (the "stuck
 // pending_subtasks_count / never promoted to completed" bug). Omitting
 // the column here means Save can never touch it.
-var omitFieldsOnUpdate = []string{"DeletedAt", "PendingSubtasksCount"}
+var omitFieldsOnUpdate = []string{"DeletedAt", "PendingSubtasksCount", "FolderID"}
 
 // knowledgeRepository implements knowledge base and knowledge repository interface
 type knowledgeRepository struct {
@@ -50,8 +51,29 @@ func NewKnowledgeRepository(db *gorm.DB) interfaces.KnowledgeRepository {
 
 // CreateKnowledge creates knowledge
 func (r *knowledgeRepository) CreateKnowledge(ctx context.Context, knowledge *types.Knowledge) error {
+	if err := r.ValidateKnowledgeFolder(ctx, knowledge.TenantID, knowledge.KnowledgeBaseID, knowledge.FolderID); err != nil {
+		return err
+	}
 	err := r.db.WithContext(ctx).Create(knowledge).Error
 	return err
+}
+
+func (r *knowledgeRepository) ValidateKnowledgeFolder(
+	ctx context.Context, tenantID uint64, kbID, folderID string,
+) error {
+	if folderID == "" {
+		return nil
+	}
+	var count int64
+	if err := r.db.WithContext(ctx).Model(&types.KnowledgeFolder{}).
+		Where("id = ? AND tenant_id = ? AND knowledge_base_id = ?", folderID, tenantID, kbID).
+		Count(&count).Error; err != nil {
+		return err
+	}
+	if count != 1 {
+		return ErrKnowledgeFolderScopeMismatch
+	}
+	return nil
 }
 
 // GetKnowledgeByID gets knowledge
@@ -98,6 +120,13 @@ func (r *knowledgeRepository) ListKnowledgeByKnowledgeBaseID(
 // KnowledgeListFilter to a GORM query. Tenant / knowledge base scoping must be
 // applied by the caller before invoking this helper.
 func applyKnowledgeListFilter(query *gorm.DB, filter types.KnowledgeListFilter) *gorm.DB {
+	if filter.FolderSet {
+		if filter.IncludeDescendants && filter.FolderID != "" {
+			query = query.Where("knowledges.folder_id IN (SELECT descendant_id FROM knowledge_folder_closure WHERE ancestor_id = ?)", filter.FolderID)
+		} else {
+			query = query.Where("knowledges.folder_id = ?", filter.FolderID)
+		}
+	}
 	if len(filter.TagIDs) > 0 {
 		query = query.Where(
 			"knowledges.id IN (SELECT knowledge_id FROM knowledge_tag_relations WHERE tag_id IN (?))",
@@ -191,6 +220,42 @@ func (r *knowledgeRepository) UpdateKnowledgeBatch(ctx context.Context, knowledg
 		return nil
 	}
 	return r.db.Debug().WithContext(ctx).Omit(omitFieldsOnUpdate...).Save(knowledgeList).Error
+}
+
+func (r *knowledgeRepository) UpdateKnowledgeFolderBatch(ctx context.Context, tenantID uint64, kbID string, knowledgeIDs []string, folderID string) (int64, error) {
+	result := r.db.WithContext(ctx).Model(&types.Knowledge{}).Where("tenant_id = ? AND knowledge_base_id = ? AND id IN ?", tenantID, kbID, knowledgeIDs).Update("folder_id", folderID)
+	return result.RowsAffected, result.Error
+}
+
+func (r *knowledgeRepository) ListIDsByFolderIDs(ctx context.Context, tenantID uint64, kbID string, folderIDs []string) ([]string, error) {
+	folderIDs = uniqueStrings(folderIDs)
+	if len(folderIDs) == 0 {
+		return nil, nil
+	}
+	var folderCount int64
+	if err := r.db.WithContext(ctx).Model(&types.KnowledgeFolder{}).Where("tenant_id = ? AND knowledge_base_id = ? AND id IN ?", tenantID, kbID, folderIDs).Count(&folderCount).Error; err != nil {
+		return nil, err
+	}
+	if folderCount != int64(len(folderIDs)) {
+		return nil, ErrKnowledgeFolderScopeMismatch
+	}
+	var ids []string
+	err := r.db.WithContext(ctx).Model(&types.Knowledge{}).Distinct("knowledges.id").Joins("JOIN knowledge_folder_closure c ON c.descendant_id = knowledges.folder_id").Where("knowledges.tenant_id = ? AND knowledges.knowledge_base_id = ? AND c.ancestor_id IN ?", tenantID, kbID, folderIDs).Pluck("knowledges.id", &ids).Error
+	return ids, err
+}
+
+func uniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != "" {
+			if _, ok := seen[value]; !ok {
+				seen[value] = struct{}{}
+				result = append(result, value)
+			}
+		}
+	}
+	return result
 }
 
 // DeleteKnowledge deletes knowledge

--- a/internal/application/repository/knowledge_folder.go
+++ b/internal/application/repository/knowledge_folder.go
@@ -1,0 +1,477 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+var (
+	ErrKnowledgeFolderNotFound = errors.New("knowledge folder not found")
+	ErrKnowledgeFolderNotEmpty = errors.New("knowledge folder is not empty")
+	ErrKnowledgeFolderCycle    = errors.New("knowledge folder cycle")
+	ErrKnowledgeFolderTooDeep  = errors.New("knowledge folder exceeds maximum depth")
+	ErrKnowledgeFolderConflict = errors.New("knowledge folder name already exists")
+	ErrKnowledgeFolderScope    = errors.New("knowledge folder scope mismatch")
+)
+
+type knowledgeFolderRepository struct{ db *gorm.DB }
+
+const maxKnowledgeFolderMoveBatchSize = 500
+
+func NewKnowledgeFolderRepository(db *gorm.DB) interfaces.KnowledgeFolderRepository {
+	return &knowledgeFolderRepository{db: db}
+}
+
+func folderScope(db *gorm.DB, tenantID uint64, kbID string) *gorm.DB {
+	return db.Where("tenant_id = ? AND knowledge_base_id = ?", tenantID, kbID)
+}
+
+func (r *knowledgeFolderRepository) getRow(db *gorm.DB, tenantID uint64, kbID, id string) (*types.KnowledgeFolder, error) {
+	var folder types.KnowledgeFolder
+	if err := folderScope(db.Model(&types.KnowledgeFolder{}), tenantID, kbID).Where("id = ?", id).Take(&folder).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrKnowledgeFolderNotFound
+		}
+		return nil, err
+	}
+	return &folder, nil
+}
+
+func (r *knowledgeFolderRepository) ancestors(db *gorm.DB, tenantID uint64, kbID, id string) ([]*types.KnowledgeFolder, error) {
+	var result []*types.KnowledgeFolder
+	err := db.Model(&types.KnowledgeFolder{}).
+		Joins("JOIN knowledge_folder_closure c ON c.ancestor_id = knowledge_folders.id").
+		Where("c.descendant_id = ? AND c.depth > 0 AND knowledge_folders.tenant_id = ? AND knowledge_folders.knowledge_base_id = ?", id, tenantID, kbID).
+		Order("c.depth DESC").Find(&result).Error
+	return result, err
+}
+
+func (r *knowledgeFolderRepository) ancestorsByDescendant(
+	db *gorm.DB, tenantID uint64, kbID string, descendantIDs []string,
+) (map[string][]*types.KnowledgeFolder, error) {
+	result := make(map[string][]*types.KnowledgeFolder, len(descendantIDs))
+	if len(descendantIDs) == 0 {
+		return result, nil
+	}
+	type ancestorRow struct {
+		DescendantID    string
+		ID              string
+		TenantID        uint64
+		KnowledgeBaseID string
+		ParentID        string
+		Name            string
+		CreatedAt       time.Time
+		UpdatedAt       time.Time
+	}
+	var rows []ancestorRow
+	err := db.Table("knowledge_folder_closure c").
+		Select("c.descendant_id, f.id, f.tenant_id, f.knowledge_base_id, f.parent_id, f.name, f.created_at, f.updated_at").
+		Joins("JOIN knowledge_folders f ON f.id = c.ancestor_id").
+		Where("c.descendant_id IN ? AND c.depth > 0 AND f.tenant_id = ? AND f.knowledge_base_id = ?", descendantIDs, tenantID, kbID).
+		Order("c.descendant_id ASC, c.depth DESC").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		result[row.DescendantID] = append(result[row.DescendantID], &types.KnowledgeFolder{
+			ID: row.ID, TenantID: row.TenantID, KnowledgeBaseID: row.KnowledgeBaseID,
+			ParentID: row.ParentID, Name: row.Name, CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt,
+		})
+	}
+	return result, nil
+}
+
+func translateKnowledgeFolderWriteError(err error) error {
+	if err == nil || errors.Is(err, ErrKnowledgeFolderConflict) {
+		return err
+	}
+	message := strings.ToLower(err.Error())
+	if (errors.Is(err, gorm.ErrDuplicatedKey) || strings.Contains(message, "duplicate") || strings.Contains(message, "unique")) &&
+		(strings.Contains(message, "knowledge_folders") || strings.Contains(message, "knowledge_folder_sibling")) {
+		return fmt.Errorf("%w: %v", ErrKnowledgeFolderConflict, err)
+	}
+	return err
+}
+
+func (r *knowledgeFolderRepository) enrich(ctx context.Context, tenantID uint64, kbID string, folders []*types.KnowledgeFolder) ([]*types.KnowledgeFolderView, error) {
+	views := make([]*types.KnowledgeFolderView, len(folders))
+	if len(folders) == 0 {
+		return views, nil
+	}
+	ids := make([]string, len(folders))
+	byID := make(map[string]*types.KnowledgeFolderView, len(folders))
+	for i, f := range folders {
+		ids[i] = f.ID
+		views[i] = &types.KnowledgeFolderView{KnowledgeFolder: *f}
+		byID[f.ID] = views[i]
+	}
+	type countRow struct {
+		ID    string
+		Count int64
+	}
+	var direct, children, totals []countRow
+	db := r.db.WithContext(ctx)
+	if err := db.Model(&types.Knowledge{}).Select("folder_id AS id, COUNT(*) AS count").Where("tenant_id = ? AND knowledge_base_id = ? AND folder_id IN ?", tenantID, kbID, ids).Group("folder_id").Scan(&direct).Error; err != nil {
+		return nil, err
+	}
+	if err := db.Model(&types.KnowledgeFolder{}).Select("parent_id AS id, COUNT(*) AS count").Where("tenant_id = ? AND knowledge_base_id = ? AND parent_id IN ?", tenantID, kbID, ids).Group("parent_id").Scan(&children).Error; err != nil {
+		return nil, err
+	}
+	if err := db.Table("knowledge_folder_closure c").Select("c.ancestor_id AS id, COUNT(k.id) AS count").Joins("LEFT JOIN knowledges k ON k.folder_id = c.descendant_id AND k.tenant_id = ? AND k.knowledge_base_id = ? AND k.deleted_at IS NULL", tenantID, kbID).Where("c.ancestor_id IN ?", ids).Group("c.ancestor_id").Scan(&totals).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range direct {
+		byID[row.ID].DirectKnowledgeCount = row.Count
+	}
+	for _, row := range children {
+		byID[row.ID].ChildFolderCount = row.Count
+	}
+	for _, row := range totals {
+		byID[row.ID].TotalKnowledgeCount = row.Count
+	}
+	for _, view := range views {
+		view.HasChildren = view.ChildFolderCount > 0
+	}
+	return views, nil
+}
+
+func (r *knowledgeFolderRepository) List(ctx context.Context, tenantID uint64, kbID, parentID, keyword string, page *types.Pagination) ([]*types.KnowledgeFolderView, int64, error) {
+	q := folderScope(r.db.WithContext(ctx).Model(&types.KnowledgeFolder{}), tenantID, kbID)
+	if keyword = strings.TrimSpace(keyword); keyword != "" {
+		q = q.Where("LOWER(name) LIKE ?", "%"+strings.ToLower(escapeLikeKeyword(keyword))+"%")
+	} else {
+		q = q.Where("parent_id = ?", parentID)
+	}
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	var folders []*types.KnowledgeFolder
+	if err := q.Order("name ASC, id ASC").Offset(page.Offset()).Limit(page.Limit()).Find(&folders).Error; err != nil {
+		return nil, 0, err
+	}
+	views, err := r.enrich(ctx, tenantID, kbID, folders)
+	if err != nil {
+		return nil, 0, err
+	}
+	if keyword != "" {
+		folderIDs := make([]string, len(folders))
+		for i, folder := range folders {
+			folderIDs[i] = folder.ID
+		}
+		paths, pathErr := r.ancestorsByDescendant(r.db.WithContext(ctx), tenantID, kbID, folderIDs)
+		if pathErr != nil {
+			return nil, 0, pathErr
+		}
+		for _, view := range views {
+			view.Ancestors = paths[view.ID]
+		}
+	}
+	return views, total, nil
+}
+
+func (r *knowledgeFolderRepository) Get(ctx context.Context, tenantID uint64, kbID, folderID string) (*types.KnowledgeFolderView, error) {
+	folder, err := r.getRow(r.db.WithContext(ctx), tenantID, kbID, folderID)
+	if err != nil {
+		return nil, err
+	}
+	views, err := r.enrich(ctx, tenantID, kbID, []*types.KnowledgeFolder{folder})
+	if err != nil {
+		return nil, err
+	}
+	views[0].Ancestors, err = r.ancestors(r.db.WithContext(ctx), tenantID, kbID, folderID)
+	return views[0], err
+}
+
+func (r *knowledgeFolderRepository) createTx(tx *gorm.DB, tenantID uint64, kbID, parentID, name string) (*types.KnowledgeFolder, error) {
+	if parentID != "" {
+		if _, err := r.getRow(tx, tenantID, kbID, parentID); err != nil {
+			return nil, err
+		}
+	}
+	var duplicate int64
+	if err := folderScope(tx.Model(&types.KnowledgeFolder{}), tenantID, kbID).Where("parent_id = ? AND name = ?", parentID, name).Count(&duplicate).Error; err != nil {
+		return nil, err
+	}
+	if duplicate > 0 {
+		return nil, ErrKnowledgeFolderConflict
+	}
+	depth := 1
+	if parentID != "" {
+		var maxDepth int
+		if err := tx.Model(&types.KnowledgeFolderClosure{}).Where("descendant_id = ?", parentID).Select("COALESCE(MAX(depth), 0)").Scan(&maxDepth).Error; err != nil {
+			return nil, err
+		}
+		depth = maxDepth + 2
+	}
+	if depth > types.MaxKnowledgeFolderDepth {
+		return nil, ErrKnowledgeFolderTooDeep
+	}
+	folder := &types.KnowledgeFolder{ID: uuid.NewString(), TenantID: tenantID, KnowledgeBaseID: kbID, ParentID: parentID, Name: name, CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	if err := tx.Create(folder).Error; err != nil {
+		return nil, translateKnowledgeFolderWriteError(err)
+	}
+	links := []types.KnowledgeFolderClosure{{AncestorID: folder.ID, DescendantID: folder.ID, Depth: 0}}
+	if parentID != "" {
+		var ancestors []types.KnowledgeFolderClosure
+		if err := tx.Where("descendant_id = ?", parentID).Find(&ancestors).Error; err != nil {
+			return nil, err
+		}
+		for _, a := range ancestors {
+			links = append(links, types.KnowledgeFolderClosure{AncestorID: a.AncestorID, DescendantID: folder.ID, Depth: a.Depth + 1})
+		}
+	}
+	if err := tx.Create(&links).Error; err != nil {
+		return nil, err
+	}
+	return folder, nil
+}
+
+func (r *knowledgeFolderRepository) Create(ctx context.Context, tenantID uint64, kbID, parentID, name string) (folder *types.KnowledgeFolder, err error) {
+	err = r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error { folder, err = r.createTx(tx, tenantID, kbID, parentID, name); return err })
+	return
+}
+
+func (r *knowledgeFolderRepository) Update(ctx context.Context, tenantID uint64, kbID, folderID string, name, parentID *string) (folder *types.KnowledgeFolder, err error) {
+	err = r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		folder, err = r.getRow(tx, tenantID, kbID, folderID)
+		if err != nil {
+			return err
+		}
+		newName, newParent := folder.Name, folder.ParentID
+		if name != nil {
+			newName = *name
+		}
+		if parentID != nil {
+			newParent = *parentID
+		}
+		if newParent == folderID {
+			return ErrKnowledgeFolderCycle
+		}
+		if newParent != "" {
+			if _, err = r.getRow(tx, tenantID, kbID, newParent); err != nil {
+				return err
+			}
+			var n int64
+			if err = tx.Model(&types.KnowledgeFolderClosure{}).Where("ancestor_id = ? AND descendant_id = ?", folderID, newParent).Count(&n).Error; err != nil {
+				return err
+			}
+			if n > 0 {
+				return ErrKnowledgeFolderCycle
+			}
+		}
+		var duplicate int64
+		if err = folderScope(tx.Model(&types.KnowledgeFolder{}), tenantID, kbID).Where("parent_id = ? AND name = ? AND id <> ?", newParent, newName, folderID).Count(&duplicate).Error; err != nil {
+			return err
+		}
+		if duplicate > 0 {
+			return ErrKnowledgeFolderConflict
+		}
+		if newParent != folder.ParentID {
+			var subtreeDepth, parentDepth int
+			if err = tx.Model(&types.KnowledgeFolderClosure{}).Where("ancestor_id = ?", folderID).Select("COALESCE(MAX(depth), 0)").Scan(&subtreeDepth).Error; err != nil {
+				return err
+			}
+			if newParent != "" {
+				if err = tx.Model(&types.KnowledgeFolderClosure{}).Where("descendant_id = ?", newParent).Select("COALESCE(MAX(depth), 0) + 1").Scan(&parentDepth).Error; err != nil {
+					return err
+				}
+			}
+			if parentDepth+1+subtreeDepth > types.MaxKnowledgeFolderDepth {
+				return ErrKnowledgeFolderTooDeep
+			}
+			var descendants, ancestors []types.KnowledgeFolderClosure
+			if err = tx.Where("ancestor_id = ?", folderID).Find(&descendants).Error; err != nil {
+				return err
+			}
+			if err = tx.Where("descendant_id = ? AND ancestor_id <> ?", folderID, folderID).Find(&ancestors).Error; err != nil {
+				return err
+			}
+			descIDs := make([]string, len(descendants))
+			ancIDs := make([]string, len(ancestors))
+			for i, v := range descendants {
+				descIDs[i] = v.DescendantID
+			}
+			for i, v := range ancestors {
+				ancIDs[i] = v.AncestorID
+			}
+			if len(ancIDs) > 0 {
+				for _, descendantBatch := range knowledgeFolderMoveBatches(descIDs) {
+					if err = tx.Where("ancestor_id IN ? AND descendant_id IN ?", ancIDs, descendantBatch).Delete(&types.KnowledgeFolderClosure{}).Error; err != nil {
+						return err
+					}
+				}
+			}
+			if newParent != "" {
+				var newAncestors []types.KnowledgeFolderClosure
+				if err = tx.Where("descendant_id = ?", newParent).Find(&newAncestors).Error; err != nil {
+					return err
+				}
+				for _, descendantBatch := range closureBatches(descendants) {
+					links := make([]types.KnowledgeFolderClosure, 0, len(newAncestors)*len(descendantBatch))
+					for _, a := range newAncestors {
+						for _, d := range descendantBatch {
+							links = append(links, types.KnowledgeFolderClosure{AncestorID: a.AncestorID, DescendantID: d.DescendantID, Depth: a.Depth + 1 + d.Depth})
+						}
+					}
+					if len(links) > 0 {
+						if err = tx.CreateInBatches(&links, maxKnowledgeFolderMoveBatchSize).Error; err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+		folder.Name, folder.ParentID, folder.UpdatedAt = newName, newParent, time.Now()
+		return translateKnowledgeFolderWriteError(
+			tx.Model(folder).Select("name", "parent_id", "updated_at").Updates(folder).Error,
+		)
+	})
+	return
+}
+
+func (r *knowledgeFolderRepository) Delete(ctx context.Context, tenantID uint64, kbID, folderID string) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if _, err := r.getRow(tx, tenantID, kbID, folderID); err != nil {
+			return err
+		}
+		var files, children int64
+		if err := tx.Model(&types.Knowledge{}).Where("tenant_id = ? AND knowledge_base_id = ? AND folder_id = ?", tenantID, kbID, folderID).Count(&files).Error; err != nil {
+			return err
+		}
+		if err := folderScope(tx.Model(&types.KnowledgeFolder{}), tenantID, kbID).Where("parent_id = ?", folderID).Count(&children).Error; err != nil {
+			return err
+		}
+		if files+children > 0 {
+			return ErrKnowledgeFolderNotEmpty
+		}
+		if err := tx.Where("ancestor_id = ? OR descendant_id = ?", folderID, folderID).Delete(&types.KnowledgeFolderClosure{}).Error; err != nil {
+			return err
+		}
+		return folderScope(tx, tenantID, kbID).Where("id = ?", folderID).Delete(&types.KnowledgeFolder{}).Error
+	})
+}
+
+func (r *knowledgeFolderRepository) EnsurePaths(ctx context.Context, tenantID uint64, kbID, parentID string, paths []types.EnsureFolderPath) (results []types.EnsureFolderPathResult, err error) {
+	err = r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if parentID != "" {
+			if _, e := r.getRow(tx, tenantID, kbID, parentID); e != nil {
+				return e
+			}
+		}
+		cache := map[string]string{}
+		for _, path := range paths {
+			current := parentID
+			for _, segment := range path.Segments {
+				key := current + "\x00" + segment
+				if id := cache[key]; id != "" {
+					current = id
+					continue
+				}
+				var existing types.KnowledgeFolder
+				e := folderScope(tx.Model(&types.KnowledgeFolder{}), tenantID, kbID).Where("parent_id = ? AND name = ?", current, segment).Take(&existing).Error
+				if e == nil {
+					current = existing.ID
+				} else if errors.Is(e, gorm.ErrRecordNotFound) {
+					created, e := r.createTx(tx, tenantID, kbID, current, segment)
+					if e != nil {
+						return e
+					}
+					current = created.ID
+				} else {
+					return e
+				}
+				cache[key] = current
+			}
+			results = append(results, types.EnsureFolderPathResult{ClientKey: path.ClientKey, FolderID: current})
+		}
+		return nil
+	})
+	return
+}
+
+func (r *knowledgeFolderRepository) MoveKnowledge(ctx context.Context, tenantID uint64, kbID string, knowledgeIDs []string, folderID string) error {
+	unique := make([]string, 0, len(knowledgeIDs))
+	seen := map[string]struct{}{}
+	for _, id := range knowledgeIDs {
+		if id != "" {
+			if _, ok := seen[id]; !ok {
+				seen[id] = struct{}{}
+				unique = append(unique, id)
+			}
+		}
+	}
+	if len(unique) == 0 {
+		return nil
+	}
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if folderID != "" {
+			if _, err := r.getRow(tx, tenantID, kbID, folderID); err != nil {
+				return err
+			}
+		}
+		var found int64
+		for _, batch := range knowledgeFolderMoveBatches(unique) {
+			var batchCount int64
+			if err := tx.Model(&types.Knowledge{}).
+				Where("tenant_id = ? AND knowledge_base_id = ? AND id IN ?", tenantID, kbID, batch).
+				Count(&batchCount).Error; err != nil {
+				return err
+			}
+			found += batchCount
+		}
+		if found != int64(len(unique)) {
+			return fmt.Errorf("%w: requested %d knowledge rows, found %d", ErrKnowledgeFolderScope, len(unique), found)
+		}
+		for _, batch := range knowledgeFolderMoveBatches(unique) {
+			if err := tx.Model(&types.Knowledge{}).
+				Where("tenant_id = ? AND knowledge_base_id = ? AND id IN ?", tenantID, kbID, batch).
+				Update("folder_id", folderID).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func knowledgeFolderMoveBatches(ids []string) [][]string {
+	if len(ids) == 0 {
+		return nil
+	}
+	batches := make([][]string, 0, (len(ids)+maxKnowledgeFolderMoveBatchSize-1)/maxKnowledgeFolderMoveBatchSize)
+	for start := 0; start < len(ids); start += maxKnowledgeFolderMoveBatchSize {
+		end := min(start+maxKnowledgeFolderMoveBatchSize, len(ids))
+		batches = append(batches, ids[start:end])
+	}
+	return batches
+}
+
+func closureBatches(links []types.KnowledgeFolderClosure) [][]types.KnowledgeFolderClosure {
+	if len(links) == 0 {
+		return nil
+	}
+	batches := make([][]types.KnowledgeFolderClosure, 0, (len(links)+maxKnowledgeFolderMoveBatchSize-1)/maxKnowledgeFolderMoveBatchSize)
+	for start := 0; start < len(links); start += maxKnowledgeFolderMoveBatchSize {
+		end := min(start+maxKnowledgeFolderMoveBatchSize, len(links))
+		batches = append(batches, links[start:end])
+	}
+	return batches
+}
+
+func (r *knowledgeFolderRepository) ListKnowledgeIDsRecursive(ctx context.Context, tenantID uint64, kbID string, folderIDs []string) ([]string, error) {
+	if len(folderIDs) == 0 {
+		return nil, nil
+	}
+	var ids []string
+	err := r.db.WithContext(ctx).Model(&types.Knowledge{}).Distinct("knowledges.id").Joins("JOIN knowledge_folder_closure c ON c.descendant_id = knowledges.folder_id").Joins("JOIN knowledge_folders f ON f.id = c.ancestor_id AND f.tenant_id = knowledges.tenant_id AND f.knowledge_base_id = knowledges.knowledge_base_id").Where("knowledges.tenant_id = ? AND knowledges.knowledge_base_id = ? AND c.ancestor_id IN ?", tenantID, kbID, folderIDs).Pluck("knowledges.id", &ids).Error
+	return ids, err
+}

--- a/internal/application/repository/knowledge_folder_test.go
+++ b/internal/application/repository/knowledge_folder_test.go
@@ -1,0 +1,198 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupKnowledgeFolderDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.KnowledgeFolder{}, &types.KnowledgeFolderClosure{}, &types.Knowledge{}))
+	return db
+}
+
+func TestKnowledgeFolderClosureCreateMoveAndCycle(t *testing.T) {
+	db := setupKnowledgeFolderDB(t)
+	repo := NewKnowledgeFolderRepository(db).(*knowledgeFolderRepository)
+	ctx := context.Background()
+
+	a, err := repo.Create(ctx, 1, "kb-1", "", "A")
+	require.NoError(t, err)
+	b, err := repo.Create(ctx, 1, "kb-1", a.ID, "B")
+	require.NoError(t, err)
+	c, err := repo.Create(ctx, 1, "kb-1", b.ID, "C")
+	require.NoError(t, err)
+	d, err := repo.Create(ctx, 1, "kb-1", "", "D")
+	require.NoError(t, err)
+
+	var depth int
+	require.NoError(t, db.Model(&types.KnowledgeFolderClosure{}).Select("depth").Where("ancestor_id = ? AND descendant_id = ?", a.ID, c.ID).Scan(&depth).Error)
+	assert.Equal(t, 2, depth)
+
+	newParent := d.ID
+	_, err = repo.Update(ctx, 1, "kb-1", b.ID, nil, &newParent)
+	require.NoError(t, err)
+	var oldLinks int64
+	require.NoError(t, db.Model(&types.KnowledgeFolderClosure{}).Where("ancestor_id = ? AND descendant_id IN ?", a.ID, []string{b.ID, c.ID}).Count(&oldLinks).Error)
+	assert.Zero(t, oldLinks)
+	require.NoError(t, db.Model(&types.KnowledgeFolderClosure{}).Select("depth").Where("ancestor_id = ? AND descendant_id = ?", d.ID, c.ID).Scan(&depth).Error)
+	assert.Equal(t, 2, depth)
+
+	cycleParent := c.ID
+	_, err = repo.Update(ctx, 1, "kb-1", d.ID, nil, &cycleParent)
+	assert.ErrorIs(t, err, ErrKnowledgeFolderCycle)
+}
+
+func TestKnowledgeFolderDepthConflictCountsAndDelete(t *testing.T) {
+	db := setupKnowledgeFolderDB(t)
+	repo := NewKnowledgeFolderRepository(db).(*knowledgeFolderRepository)
+	ctx := context.Background()
+	parent := ""
+	var first *types.KnowledgeFolder
+	for i := 1; i <= types.MaxKnowledgeFolderDepth; i++ {
+		folder, err := repo.Create(ctx, 1, "kb-1", parent, fmt.Sprintf("level-%02d", i))
+		require.NoError(t, err)
+		if first == nil {
+			first = folder
+		}
+		parent = folder.ID
+	}
+	_, err := repo.Create(ctx, 1, "kb-1", parent, "too-deep")
+	assert.ErrorIs(t, err, ErrKnowledgeFolderTooDeep)
+	_, err = repo.Create(ctx, 1, "kb-1", "", first.Name)
+	assert.ErrorIs(t, err, ErrKnowledgeFolderConflict)
+
+	doc := &types.Knowledge{ID: "doc-1", TenantID: 1, KnowledgeBaseID: "kb-1", FolderID: parent, Type: "file", Title: "doc", Source: "doc", ParseStatus: "completed", EnableStatus: "enabled"}
+	require.NoError(t, db.Create(doc).Error)
+	view, err := repo.Get(ctx, 1, "kb-1", first.ID)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, view.TotalKnowledgeCount)
+	assert.EqualValues(t, 0, view.DirectKnowledgeCount)
+	assert.True(t, view.HasChildren)
+	assert.ErrorIs(t, repo.Delete(ctx, 1, "kb-1", first.ID), ErrKnowledgeFolderNotEmpty)
+	assert.ErrorIs(t, repo.Delete(ctx, 1, "kb-1", parent), ErrKnowledgeFolderNotEmpty)
+}
+
+func TestKnowledgeFolderEnsurePathsAndScopedBatchMove(t *testing.T) {
+	db := setupKnowledgeFolderDB(t)
+	repo := NewKnowledgeFolderRepository(db).(*knowledgeFolderRepository)
+	ctx := context.Background()
+	paths := []types.EnsureFolderPath{{ClientKey: "one", Segments: []string{"src", "api"}}, {ClientKey: "two", Segments: []string{"src", "web"}}, {ClientKey: "again", Segments: []string{"src", "api"}}}
+	result, err := repo.EnsurePaths(ctx, 1, "kb-1", "", paths)
+	require.NoError(t, err)
+	require.Len(t, result, 3)
+	assert.Equal(t, result[0].FolderID, result[2].FolderID)
+	var folders int64
+	require.NoError(t, db.Model(&types.KnowledgeFolder{}).Count(&folders).Error)
+	assert.EqualValues(t, 3, folders)
+
+	require.NoError(t, db.Create(&types.Knowledge{ID: "doc-1", TenantID: 1, KnowledgeBaseID: "kb-1", Type: "file", Title: "one", Source: "one", ParseStatus: "completed", EnableStatus: "enabled"}).Error)
+	require.NoError(t, db.Create(&types.Knowledge{ID: "doc-2", TenantID: 1, KnowledgeBaseID: "kb-2", Type: "file", Title: "two", Source: "two", ParseStatus: "completed", EnableStatus: "enabled"}).Error)
+	err = repo.MoveKnowledge(ctx, 1, "kb-1", []string{"doc-1", "doc-2"}, result[0].FolderID)
+	assert.True(t, errors.Is(err, ErrKnowledgeFolderScope))
+	var folderID string
+	require.NoError(t, db.Model(&types.Knowledge{}).Select("folder_id").Where("id = ?", "doc-1").Scan(&folderID).Error)
+	assert.Empty(t, folderID, "validation must happen before the batch update")
+	require.NoError(t, repo.MoveKnowledge(ctx, 1, "kb-1", []string{"doc-1"}, result[0].FolderID))
+	require.NoError(t, db.Model(&types.Knowledge{}).Select("folder_id").Where("id = ?", "doc-1").Scan(&folderID).Error)
+	assert.Equal(t, result[0].FolderID, folderID)
+}
+
+func TestKnowledgeFolderMoveBatchesBoundSQLParameters(t *testing.T) {
+	ids := make([]string, maxKnowledgeFolderMoveBatchSize*2+1)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("doc-%04d", i)
+	}
+	batches := knowledgeFolderMoveBatches(ids)
+	require.Len(t, batches, 3)
+	assert.Len(t, batches[0], maxKnowledgeFolderMoveBatchSize)
+	assert.Len(t, batches[1], maxKnowledgeFolderMoveBatchSize)
+	assert.Len(t, batches[2], 1)
+	assert.Equal(t, ids, append(append(append([]string{}, batches[0]...), batches[1]...), batches[2]...))
+}
+
+func TestKnowledgeFolderKeywordSearchReturnsAncestorPaths(t *testing.T) {
+	db := setupKnowledgeFolderDB(t)
+	repo := NewKnowledgeFolderRepository(db).(*knowledgeFolderRepository)
+	ctx := context.Background()
+
+	root, err := repo.Create(ctx, 1, "kb-1", "", "Root")
+	require.NoError(t, err)
+	parent, err := repo.Create(ctx, 1, "kb-1", root.ID, "Parent")
+	require.NoError(t, err)
+	child, err := repo.Create(ctx, 1, "kb-1", parent.ID, "Needle")
+	require.NoError(t, err)
+	_, err = repo.Create(ctx, 2, "kb-1", "", "Foreign Needle")
+	require.NoError(t, err)
+
+	rows, total, err := repo.List(ctx, 1, "kb-1", "", "needle", &types.Pagination{Page: 1, PageSize: 20})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.Len(t, rows, 1)
+	require.Equal(t, child.ID, rows[0].ID)
+	require.Len(t, rows[0].Ancestors, 2)
+	require.Equal(t, []string{root.ID, parent.ID}, []string{rows[0].Ancestors[0].ID, rows[0].Ancestors[1].ID})
+}
+
+func TestTranslateKnowledgeFolderUniqueViolation(t *testing.T) {
+	err := errors.New(`UNIQUE constraint failed: knowledge_folders.tenant_id, knowledge_folders.knowledge_base_id, knowledge_folders.parent_id, knowledge_folders.name`)
+	require.ErrorIs(t, translateKnowledgeFolderWriteError(err), ErrKnowledgeFolderConflict)
+
+	unrelated := errors.New(`UNIQUE constraint failed: users.email`)
+	require.Same(t, unrelated, translateKnowledgeFolderWriteError(unrelated))
+}
+
+func TestKnowledgeListFolderFiltering(t *testing.T) {
+	db := setupKnowledgeFolderDB(t)
+	folderRepo := NewKnowledgeFolderRepository(db).(*knowledgeFolderRepository)
+	knowledgeRepo := NewKnowledgeRepository(db).(*knowledgeRepository)
+	ctx := context.Background()
+
+	parent, err := folderRepo.Create(ctx, 1, "kb-1", "", "Parent")
+	require.NoError(t, err)
+	child, err := folderRepo.Create(ctx, 1, "kb-1", parent.ID, "Child")
+	require.NoError(t, err)
+	sibling, err := folderRepo.Create(ctx, 1, "kb-1", "", "Sibling")
+	require.NoError(t, err)
+
+	documents := []*types.Knowledge{
+		{ID: "root", TenantID: 1, KnowledgeBaseID: "kb-1", FolderID: "", Type: "file", Title: "root report", FileName: "root.txt", Source: "root", ParseStatus: "completed", EnableStatus: "enabled"},
+		{ID: "parent", TenantID: 1, KnowledgeBaseID: "kb-1", FolderID: parent.ID, Type: "file", Title: "parent report", FileName: "parent.txt", Source: "parent", ParseStatus: "completed", EnableStatus: "enabled"},
+		{ID: "child", TenantID: 1, KnowledgeBaseID: "kb-1", FolderID: child.ID, Type: "file", Title: "child report", FileName: "child.txt", Source: "child", ParseStatus: "completed", EnableStatus: "enabled"},
+		{ID: "sibling", TenantID: 1, KnowledgeBaseID: "kb-1", FolderID: sibling.ID, Type: "file", Title: "unrelated", FileName: "sibling.txt", Source: "sibling", ParseStatus: "completed", EnableStatus: "enabled"},
+	}
+	require.NoError(t, db.Create(&documents).Error)
+	page := &types.Pagination{Page: 1, PageSize: 20}
+
+	rows, total, err := knowledgeRepo.ListPagedKnowledgeByKnowledgeBaseID(ctx, 1, "kb-1", page, types.KnowledgeListFilter{})
+	require.NoError(t, err)
+	require.EqualValues(t, 4, total)
+	require.Len(t, rows, 4)
+
+	rows, total, err = knowledgeRepo.ListPagedKnowledgeByKnowledgeBaseID(ctx, 1, "kb-1", page, types.KnowledgeListFilter{FolderSet: true})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.Equal(t, "root", rows[0].ID)
+
+	rows, total, err = knowledgeRepo.ListPagedKnowledgeByKnowledgeBaseID(ctx, 1, "kb-1", page, types.KnowledgeListFilter{FolderSet: true, FolderID: parent.ID})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.Equal(t, "parent", rows[0].ID)
+
+	rows, total, err = knowledgeRepo.ListPagedKnowledgeByKnowledgeBaseID(ctx, 1, "kb-1", page, types.KnowledgeListFilter{
+		FolderSet: true, FolderID: parent.ID, IncludeDescendants: true, Keyword: "child",
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.Equal(t, "child", rows[0].ID)
+}

--- a/internal/application/service/custom_agent.go
+++ b/internal/application/service/custom_agent.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/agent/tools"
 	"github.com/Tencent/WeKnora/internal/application/repository"
+	apperrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
@@ -557,7 +558,11 @@ func (s *customAgentService) getSuggestedQuestions(
 			})
 			return s.truncateQuestions(result, limit), nil
 		}
-		knowledgeIDs = mergeUniqueStrings(knowledgeIDs, resolved)
+		if len(knowledgeIDs) > 0 {
+			knowledgeIDs = intersectStrings(knowledgeIDs, resolved)
+		} else {
+			knowledgeIDs = mergeUniqueStrings(nil, resolved)
+		}
 		if len(knowledgeIDs) == 0 {
 			return s.truncateQuestions(result, limit), nil
 		}
@@ -778,6 +783,201 @@ func (s *customAgentService) getSuggestedQuestions(
 	}
 
 	return s.truncateQuestions(result, limit), nil
+}
+
+// GetSuggestedQuestionsWithFolders expands folder subtrees before delegating
+// to the established knowledge-ID suggestion path.
+func (s *customAgentService) GetSuggestedQuestionsWithFolders(ctx context.Context, agentID string, kbIDs, knowledgeIDs, tagIDs []string, limit int, folderScopes []types.FolderScope) ([]types.SuggestedQuestion, error) {
+	return s.getSuggestedQuestionsWithFolders(ctx, agentID, kbIDs, knowledgeIDs, tagIDs, limit, folderScopes, true)
+}
+
+// GetKnowledgeSuggestedQuestionsWithFolders returns folder-scoped candidates
+// without mixing in curated starter prompts.
+func (s *customAgentService) GetKnowledgeSuggestedQuestionsWithFolders(ctx context.Context, agentID string, kbIDs, knowledgeIDs, tagIDs []string, limit int, folderScopes []types.FolderScope) ([]types.SuggestedQuestion, error) {
+	return s.getSuggestedQuestionsWithFolders(ctx, agentID, kbIDs, knowledgeIDs, tagIDs, limit, folderScopes, false)
+}
+
+func (s *customAgentService) getSuggestedQuestionsWithFolders(ctx context.Context, agentID string, kbIDs, knowledgeIDs, tagIDs []string, limit int, folderScopes []types.FolderScope, includeCurated bool) ([]types.SuggestedQuestion, error) {
+	if len(folderScopes) == 0 {
+		return s.getSuggestedQuestions(ctx, agentID, kbIDs, knowledgeIDs, tagIDs, limit, includeCurated)
+	}
+	tenantID, ok := types.TenantIDFromContext(ctx)
+	if !ok {
+		return nil, ErrInvalidTenantID
+	}
+	authKBIDs := append([]string(nil), kbIDs...)
+	for _, scope := range folderScopes {
+		authKBIDs = append(authKBIDs, scope.KnowledgeBaseID)
+	}
+	if err := types.AuthorizeTenantAPIKeyKnowledgeTargets(ctx, authKBIDs, knowledgeIDs); err != nil {
+		return nil, err
+	}
+	agent, err := s.GetAgentByID(ctx, agentID)
+	if err != nil {
+		return nil, err
+	}
+	folderIDsByKB := mergeFolderScopesByKB(folderScopes)
+	fullKBSet := make(map[string]bool, len(kbIDs))
+	for _, kbID := range mergeUniqueStrings(nil, kbIDs) {
+		fullKBSet[kbID] = true
+	}
+	folderKnowledgeIDsByKB := make(map[string][]string, len(folderIDsByKB))
+	for kbID, folderIDs := range folderIDsByKB {
+		if !agentAllowsKnowledgeBase(agent, kbID) {
+			return nil, apperrors.NewForbiddenError("folder knowledge base is outside the agent scope")
+		}
+		kb, err := s.kbService.GetKnowledgeBaseByID(ctx, kbID)
+		if err != nil {
+			return nil, err
+		}
+		if kb == nil {
+			return nil, apperrors.NewBadRequestError("folder knowledge base not found")
+		}
+		if kb.Type == types.KnowledgeBaseTypeFAQ {
+			return nil, apperrors.NewBadRequestError("folders are not available for FAQ knowledge bases")
+		}
+		if kb.TenantID != tenantID {
+			if s.kbShareService == nil {
+				return nil, apperrors.NewForbiddenError("no permission to access folder knowledge base")
+			}
+			allowed, accessErr := s.kbShareService.HasTenantKBPermission(
+				ctx,
+				kbID,
+				tenantID,
+				types.TenantRoleFromContext(ctx),
+				types.OrgRoleViewer,
+			)
+			if accessErr != nil {
+				return nil, accessErr
+			}
+			if !allowed {
+				return nil, apperrors.NewForbiddenError("no permission to access folder knowledge base")
+			}
+		}
+		ids, err := s.knowledgeRepo.ListIDsByFolderIDs(ctx, kb.TenantID, kbID, folderIDs)
+		if err != nil {
+			if errors.Is(err, repository.ErrKnowledgeFolderScopeMismatch) {
+				return nil, apperrors.NewBadRequestError("folder does not belong to the knowledge base")
+			}
+			return nil, err
+		}
+		folderKnowledgeIDsByKB[kbID] = mergeUniqueStrings(nil, ids)
+	}
+
+	explicitByKB := make(map[string][]string)
+	for _, knowledgeID := range mergeUniqueStrings(nil, knowledgeIDs) {
+		knowledge, err := s.knowledgeRepo.GetKnowledgeByIDOnly(ctx, knowledgeID)
+		if err == nil && knowledge != nil && knowledge.KnowledgeBaseID != "" {
+			explicitByKB[knowledge.KnowledgeBaseID] = append(explicitByKB[knowledge.KnowledgeBaseID], knowledge.ID)
+		}
+	}
+
+	// A single global knowledge-ID filter cannot represent "all of KB A plus a
+	// folder in KB B". Query unrestricted KBs together, then query every
+	// document-constrained KB independently and merge the suggestions. This also
+	// prevents an empty folder from becoming an unrestricted KB query.
+	scopedKBs := make(map[string]bool, len(folderIDsByKB))
+	for kbID := range folderIDsByKB {
+		if !fullKBSet[kbID] {
+			scopedKBs[kbID] = true
+		}
+	}
+	fullKBsWithoutExplicitDocs := make([]string, 0, len(kbIDs))
+	type suggestionQuery struct {
+		kbIDs        []string
+		knowledgeIDs []string
+	}
+	queries := make([]suggestionQuery, 0, len(folderIDsByKB)+len(explicitByKB)+1)
+	for _, kbID := range mergeUniqueStrings(nil, kbIDs) {
+		if scopedKBs[kbID] {
+			continue
+		}
+		if len(knowledgeIDs) > 0 {
+			if explicitIDs := mergeUniqueStrings(nil, explicitByKB[kbID]); len(explicitIDs) > 0 {
+				queries = append(queries, suggestionQuery{kbIDs: []string{kbID}, knowledgeIDs: explicitIDs})
+			}
+		} else {
+			fullKBsWithoutExplicitDocs = append(fullKBsWithoutExplicitDocs, kbID)
+		}
+	}
+	if len(fullKBsWithoutExplicitDocs) > 0 {
+		queries = append(queries, suggestionQuery{kbIDs: fullKBsWithoutExplicitDocs})
+	}
+	for kbID, folderKnowledgeIDs := range folderKnowledgeIDsByKB {
+		if fullKBSet[kbID] {
+			continue
+		}
+		resolved := folderKnowledgeIDs
+		if len(knowledgeIDs) > 0 {
+			resolved = intersectStrings(explicitByKB[kbID], folderKnowledgeIDs)
+		}
+		if len(resolved) > 0 {
+			queries = append(queries, suggestionQuery{kbIDs: []string{kbID}, knowledgeIDs: mergeUniqueStrings(nil, resolved)})
+		}
+	}
+
+	if len(queries) == 0 {
+		if !includeCurated {
+			return []types.SuggestedQuestion{}, nil
+		}
+		agent, err := s.GetAgentByID(ctx, agentID)
+		if err != nil {
+			return nil, err
+		}
+		return s.truncateQuestions(agentConfiguredSuggestions(agent), limit), nil
+	}
+
+	merged := make([]types.SuggestedQuestion, 0, limit)
+	seen := make(map[string]bool)
+	for _, query := range queries {
+		questions, err := s.getSuggestedQuestions(ctx, agentID, query.kbIDs, query.knowledgeIDs, tagIDs, limit, includeCurated)
+		if err != nil {
+			return nil, err
+		}
+		for _, question := range questions {
+			if question.Question == "" || seen[question.Question] {
+				continue
+			}
+			seen[question.Question] = true
+			merged = append(merged, question)
+		}
+	}
+	return s.truncateQuestions(merged, limit), nil
+}
+
+func agentAllowsKnowledgeBase(agent *types.CustomAgent, kbID string) bool {
+	if agent == nil || kbID == "" {
+		return false
+	}
+	switch agent.Config.KBSelectionMode {
+	case "all":
+		return true
+	case "none":
+		return false
+	}
+	for _, allowedKBID := range agent.Config.KnowledgeBases {
+		if allowedKBID == kbID {
+			return true
+		}
+	}
+	return false
+}
+
+func agentConfiguredSuggestions(agent *types.CustomAgent) []types.SuggestedQuestion {
+	if agent == nil || agent.Config.QuestionSuggestions == nil {
+		return nil
+	}
+	starters := agent.Config.QuestionSuggestions.Starters
+	if !starters.Enabled || (starters.Mode != types.SuggestionModeCurated && starters.Mode != types.SuggestionModeHybrid) {
+		return nil
+	}
+	result := make([]types.SuggestedQuestion, 0, len(starters.Items))
+	for _, prompt := range starters.Items {
+		if prompt = strings.TrimSpace(prompt); prompt != "" {
+			result = append(result, types.SuggestedQuestion{Question: prompt, Source: "agent_config"})
+		}
+	}
+	return result
 }
 
 func (s *customAgentService) resolveKnowledgeIDsFromTags(

--- a/internal/application/service/custom_agent_api_key_scope_test.go
+++ b/internal/application/service/custom_agent_api_key_scope_test.go
@@ -45,3 +45,18 @@ func TestGetSuggestedQuestionsRejectsTagIDsForRestrictedKey(t *testing.T) {
 		t.Fatal("expected forbidden for tag_ids under KB-restricted key")
 	}
 }
+
+func TestGetSuggestedQuestionsWithFoldersEnforcesAPIKeyKnowledgeBaseScope(t *testing.T) {
+	ctx := types.WithTenantAPIKeyScope(context.Background(), types.TenantAPIKeyScope{
+		KnowledgeBaseIDs: types.StringArray{"kb-1"},
+	})
+	ctx = context.WithValue(ctx, types.TenantIDContextKey, uint64(1))
+
+	svc := &customAgentService{}
+	_, err := svc.GetSuggestedQuestionsWithFolders(ctx, "agent-1", nil, nil, nil, 6, []types.FolderScope{{
+		KnowledgeBaseID: "kb-2", FolderIDs: []string{"folder-1"},
+	}})
+	if err == nil {
+		t.Fatal("expected forbidden for an out-of-scope folder knowledge base")
+	}
+}

--- a/internal/application/service/custom_agent_folder_suggestions_test.go
+++ b/internal/application/service/custom_agent_folder_suggestions_test.go
@@ -1,0 +1,301 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	apperrors "github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type folderSuggestionAgentRepo struct {
+	interfaces.CustomAgentRepository
+	agent *types.CustomAgent
+}
+
+func (r *folderSuggestionAgentRepo) GetAgentByID(context.Context, string, uint64) (*types.CustomAgent, error) {
+	return r.agent, nil
+}
+
+type folderSuggestionKBService struct {
+	interfaces.KnowledgeBaseService
+	kbs map[string]*types.KnowledgeBase
+}
+
+func (s *folderSuggestionKBService) GetKnowledgeBaseByID(_ context.Context, id string) (*types.KnowledgeBase, error) {
+	return s.kbs[id], nil
+}
+
+func (s *folderSuggestionKBService) GetKnowledgeBasesByIDsOnly(_ context.Context, ids []string) ([]*types.KnowledgeBase, error) {
+	result := make([]*types.KnowledgeBase, 0, len(ids))
+	for _, id := range ids {
+		if kb := s.kbs[id]; kb != nil {
+			result = append(result, kb)
+		}
+	}
+	return result, nil
+}
+
+type folderSuggestionKnowledgeRepo struct {
+	interfaces.KnowledgeRepository
+	byFolder map[string][]string
+	byID     map[string]*types.Knowledge
+	byTag    map[string][]string
+}
+
+func (r *folderSuggestionKnowledgeRepo) ListIDsByFolderIDs(_ context.Context, _ uint64, kbID string, _ []string) ([]string, error) {
+	return append([]string(nil), r.byFolder[kbID]...), nil
+}
+
+func (r *folderSuggestionKnowledgeRepo) GetKnowledgeByIDOnly(_ context.Context, id string) (*types.Knowledge, error) {
+	return r.byID[id], nil
+}
+
+func (r *folderSuggestionKnowledgeRepo) ListIDsByTagIDs(_ context.Context, _ uint64, kbID string, _ []string) ([]string, error) {
+	return append([]string(nil), r.byTag[kbID]...), nil
+}
+
+type folderSuggestionTagRepo struct {
+	interfaces.KnowledgeTagRepository
+	tags []*types.KnowledgeTag
+}
+
+func (r *folderSuggestionTagRepo) GetByIDs(context.Context, uint64, []string) ([]*types.KnowledgeTag, error) {
+	return r.tags, nil
+}
+
+type folderSuggestionChunkRepo struct {
+	interfaces.ChunkRepository
+	documentCalls []folderSuggestionChunkCall
+}
+
+type folderSuggestionChunkCall struct {
+	kbIDs        []string
+	knowledgeIDs []string
+}
+
+func (r *folderSuggestionChunkRepo) ListRecommendedFAQChunks(context.Context, uint64, []string, []string, int) ([]*types.Chunk, error) {
+	return nil, nil
+}
+
+func (r *folderSuggestionChunkRepo) ListRecentDocumentChunksWithQuestions(
+	_ context.Context, _ uint64, kbIDs, knowledgeIDs []string, _ int,
+) ([]*types.Chunk, error) {
+	r.documentCalls = append(r.documentCalls, folderSuggestionChunkCall{
+		kbIDs: append([]string(nil), kbIDs...), knowledgeIDs: append([]string(nil), knowledgeIDs...),
+	})
+	if len(kbIDs) != 1 {
+		return nil, nil
+	}
+	chunk := &types.Chunk{KnowledgeBaseID: kbIDs[0]}
+	switch kbIDs[0] {
+	case "kb-full":
+		if len(knowledgeIDs) != 0 {
+			return nil, nil
+		}
+		chunk.ID, chunk.KnowledgeID = "chunk-full", "doc-full"
+		if err := chunk.SetDocumentMetadata(&types.DocumentChunkMetadata{
+			GeneratedQuestions: []types.GeneratedQuestion{{Question: "Question from the full KB?"}},
+		}); err != nil {
+			panic(err)
+		}
+	case "kb-folder":
+		if len(knowledgeIDs) != 1 || knowledgeIDs[0] != "doc-folder" {
+			return nil, nil
+		}
+		chunk.ID, chunk.KnowledgeID = "chunk-folder", "doc-folder"
+		if err := chunk.SetDocumentMetadata(&types.DocumentChunkMetadata{
+			GeneratedQuestions: []types.GeneratedQuestion{{Question: "Question from the folder?"}},
+		}); err != nil {
+			panic(err)
+		}
+	default:
+		return nil, nil
+	}
+	return []*types.Chunk{chunk}, nil
+}
+
+func newFolderSuggestionService(folderKnowledgeIDs []string) (*customAgentService, *folderSuggestionChunkRepo) {
+	chunkRepo := &folderSuggestionChunkRepo{}
+	return &customAgentService{
+		repo: &folderSuggestionAgentRepo{agent: &types.CustomAgent{
+			ID: "agent-1", TenantID: 1,
+			Config: types.CustomAgentConfig{
+				AgentMode:       types.AgentModeQuickAnswer,
+				KBSelectionMode: "selected",
+				KnowledgeBases:  []string{"kb-full", "kb-folder"},
+				QuestionSuggestions: &types.QuestionSuggestionConfig{
+					Starters: types.StarterSuggestionConfig{
+						Enabled: true,
+						Mode:    types.SuggestionModeHybrid,
+						Items:   []string{"Agent prompt?"},
+						Count:   10,
+					},
+				},
+			},
+		}},
+		chunkRepo: chunkRepo,
+		kbService: &folderSuggestionKBService{kbs: map[string]*types.KnowledgeBase{
+			"kb-full":   {ID: "kb-full", TenantID: 1, Type: types.KnowledgeBaseTypeDocument},
+			"kb-folder": {ID: "kb-folder", TenantID: 1, Type: types.KnowledgeBaseTypeDocument},
+		}},
+		knowledgeRepo: &folderSuggestionKnowledgeRepo{
+			byFolder: map[string][]string{"kb-folder": folderKnowledgeIDs},
+			byID: map[string]*types.Knowledge{
+				"doc-folder": {ID: "doc-folder", TenantID: 1, KnowledgeBaseID: "kb-folder"},
+				"doc-full":   {ID: "doc-full", TenantID: 1, KnowledgeBaseID: "kb-full"},
+			},
+			byTag: map[string][]string{},
+		},
+	}, chunkRepo
+}
+
+func folderSuggestionContext() context.Context {
+	return context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+}
+
+func TestGetSuggestedQuestionsWithFoldersKeepsWholeKBAndFolderScopesIndependent(t *testing.T) {
+	svc, chunkRepo := newFolderSuggestionService([]string{"doc-folder"})
+	questions, err := svc.GetSuggestedQuestionsWithFolders(
+		folderSuggestionContext(), "agent-1",
+		[]string{"kb-full"}, nil, nil, 10,
+		[]types.FolderScope{{KnowledgeBaseID: "kb-folder", FolderIDs: []string{"folder-1"}}},
+	)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"Agent prompt?", "Question from the full KB?", "Question from the folder?"}, suggestedQuestionTexts(questions))
+	require.Len(t, chunkRepo.documentCalls, 2)
+	assert.ElementsMatch(t, []folderSuggestionChunkCall{
+		{kbIDs: []string{"kb-full"}},
+		{kbIDs: []string{"kb-folder"}, knowledgeIDs: []string{"doc-folder"}},
+	}, chunkRepo.documentCalls)
+}
+
+func TestGetSuggestedQuestionsWithFoldersExplicitWholeKBSupersedesFolder(t *testing.T) {
+	svc, chunkRepo := newFolderSuggestionService(nil)
+	questions, err := svc.GetSuggestedQuestionsWithFolders(
+		folderSuggestionContext(), "agent-1", []string{"kb-folder"}, nil, nil, 10,
+		[]types.FolderScope{{KnowledgeBaseID: "kb-folder", FolderIDs: []string{"empty-folder"}}},
+	)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"Agent prompt?"}, suggestedQuestionTexts(questions))
+	require.Len(t, chunkRepo.documentCalls, 1)
+	assert.Equal(t, []string{"kb-folder"}, chunkRepo.documentCalls[0].kbIDs)
+	assert.Empty(t, chunkRepo.documentCalls[0].knowledgeIDs)
+}
+
+func TestGetSuggestedQuestionsWithFoldersDoesNotWidenEmptyFolder(t *testing.T) {
+	svc, chunkRepo := newFolderSuggestionService(nil)
+	questions, err := svc.GetSuggestedQuestionsWithFolders(
+		folderSuggestionContext(), "agent-1", nil, nil, nil, 10,
+		[]types.FolderScope{{KnowledgeBaseID: "kb-folder", FolderIDs: []string{"empty-folder"}}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Agent prompt?"}, suggestedQuestionTexts(questions))
+	assert.Empty(t, chunkRepo.documentCalls)
+}
+
+func TestGetKnowledgeSuggestedQuestionsWithFoldersExcludesCuratedStarters(t *testing.T) {
+	svc, chunkRepo := newFolderSuggestionService([]string{"doc-folder"})
+	questions, err := svc.GetKnowledgeSuggestedQuestionsWithFolders(
+		folderSuggestionContext(), "agent-1", nil, nil, nil, 10,
+		[]types.FolderScope{{KnowledgeBaseID: "kb-folder", FolderIDs: []string{"folder-1"}}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Question from the folder?"}, suggestedQuestionTexts(questions))
+	require.Len(t, chunkRepo.documentCalls, 1)
+	assert.Equal(t, []string{"doc-folder"}, chunkRepo.documentCalls[0].knowledgeIDs)
+}
+
+func TestGetKnowledgeSuggestedQuestionsWithFoldersDoesNotWidenEmptyFolder(t *testing.T) {
+	svc, chunkRepo := newFolderSuggestionService(nil)
+	questions, err := svc.GetKnowledgeSuggestedQuestionsWithFolders(
+		folderSuggestionContext(), "agent-1", nil, nil, nil, 10,
+		[]types.FolderScope{{KnowledgeBaseID: "kb-folder", FolderIDs: []string{"empty-folder"}}},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, questions)
+	assert.Empty(t, chunkRepo.documentCalls)
+}
+
+func TestGetKnowledgeSuggestedQuestionsWithFoldersIntersectsExplicitKnowledge(t *testing.T) {
+	svc, chunkRepo := newFolderSuggestionService([]string{"doc-folder"})
+	questions, err := svc.GetKnowledgeSuggestedQuestionsWithFolders(
+		folderSuggestionContext(), "agent-1", nil, []string{"doc-full"}, nil, 10,
+		[]types.FolderScope{{KnowledgeBaseID: "kb-folder", FolderIDs: []string{"folder-1"}}},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, questions)
+	assert.Empty(t, chunkRepo.documentCalls)
+}
+
+func TestGetKnowledgeSuggestedQuestionsWithFoldersIntersectsFolderTagAndExplicitKnowledge(t *testing.T) {
+	svc, chunkRepo := newFolderSuggestionService([]string{"doc-folder"})
+	svc.tagRepo = &folderSuggestionTagRepo{tags: []*types.KnowledgeTag{{
+		ID: "tag-1", TenantID: 1, KnowledgeBaseID: "kb-folder",
+	}}}
+	svc.knowledgeRepo.(*folderSuggestionKnowledgeRepo).byTag["kb-folder"] = []string{"doc-folder"}
+	questions, err := svc.GetKnowledgeSuggestedQuestionsWithFolders(
+		folderSuggestionContext(), "agent-1", nil, []string{"doc-folder", "doc-full"}, []string{"tag-1"}, 10,
+		[]types.FolderScope{{KnowledgeBaseID: "kb-folder", FolderIDs: []string{"folder-1"}}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Question from the folder?"}, suggestedQuestionTexts(questions))
+	require.Len(t, chunkRepo.documentCalls, 1)
+	assert.Equal(t, []string{"doc-folder"}, chunkRepo.documentCalls[0].knowledgeIDs)
+}
+
+func TestGetSuggestedQuestionsWithFoldersRejectsKBOutsideAgentScope(t *testing.T) {
+	svc, _ := newFolderSuggestionService([]string{"doc-folder"})
+	svc.repo = &folderSuggestionAgentRepo{agent: &types.CustomAgent{
+		ID: "agent-1", TenantID: 1,
+		Config: types.CustomAgentConfig{
+			AgentMode:       types.AgentModeQuickAnswer,
+			KBSelectionMode: "selected",
+			KnowledgeBases:  []string{"kb-full"},
+		},
+	}}
+
+	_, err := svc.GetSuggestedQuestionsWithFolders(
+		folderSuggestionContext(), "agent-1", nil, nil, nil, 10,
+		[]types.FolderScope{{KnowledgeBaseID: "kb-folder", FolderIDs: []string{"folder-1"}}},
+	)
+	require.Error(t, err)
+	var appErr *apperrors.AppError
+	require.ErrorAs(t, err, &appErr)
+	assert.Equal(t, apperrors.ErrForbidden, appErr.Code)
+}
+
+func TestGetSuggestedQuestionsWithFoldersRejectsUnreadableSharedKB(t *testing.T) {
+	svc, _ := newFolderSuggestionService([]string{"doc-folder"})
+	svc.repo = &folderSuggestionAgentRepo{agent: &types.CustomAgent{
+		ID: "agent-1", TenantID: 1,
+		Config: types.CustomAgentConfig{
+			AgentMode:       types.AgentModeQuickAnswer,
+			KBSelectionMode: "selected",
+			KnowledgeBases:  []string{"kb-foreign"},
+		},
+	}}
+	svc.kbService = &folderSuggestionKBService{kbs: map[string]*types.KnowledgeBase{
+		"kb-foreign": {ID: "kb-foreign", TenantID: 9, Type: types.KnowledgeBaseTypeDocument},
+	}}
+
+	_, err := svc.GetSuggestedQuestionsWithFolders(
+		folderSuggestionContext(), "agent-1", nil, nil, nil, 10,
+		[]types.FolderScope{{KnowledgeBaseID: "kb-foreign", FolderIDs: []string{"folder-1"}}},
+	)
+	require.Error(t, err)
+	var appErr *apperrors.AppError
+	require.ErrorAs(t, err, &appErr)
+	assert.Equal(t, apperrors.ErrForbidden, appErr.Code)
+}
+
+func suggestedQuestionTexts(questions []types.SuggestedQuestion) []string {
+	result := make([]string, 0, len(questions))
+	for _, question := range questions {
+		result = append(result, question.Question)
+	}
+	return result
+}

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -23,6 +23,19 @@ import (
 	"github.com/hibiken/asynq"
 )
 
+func knowledgeFolderIDFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(types.KnowledgeFolderIDContextKey).(string)
+	return id
+}
+
+func (s *knowledgeService) validateKnowledgeFolderTarget(ctx context.Context, tenantID uint64, kbID string) error {
+	folderID := knowledgeFolderIDFromContext(ctx)
+	if folderID == "" {
+		return nil
+	}
+	return s.repo.ValidateKnowledgeFolder(ctx, tenantID, kbID, folderID)
+}
+
 // CreateKnowledgeFromFile creates a knowledge entry from an uploaded file
 func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 	kbID string, file *multipart.FileHeader, metadata map[string]string, enableMultimodel *bool, customFileName string, tagIDs []string, channel string,
@@ -78,6 +91,9 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 
 	// Check if file already exists
 	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
+	if err := s.validateKnowledgeFolderTarget(ctx, tenantID, kbID); err != nil {
+		return nil, err
+	}
 	logger.Infof(ctx, "Checking if file exists, tenant ID: %d", tenantID)
 	exists, existingKnowledge, err := s.repo.CheckKnowledgeExists(ctx, tenantID, kbID, &types.KnowledgeCheckParams{
 		Type:     "file",
@@ -188,6 +204,7 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 		ID:               uuid.New().String(),
 		TenantID:         tenantID,
 		KnowledgeBaseID:  kbID,
+		FolderID:         knowledgeFolderIDFromContext(ctx),
 		Type:             "file",
 		Channel:          defaultChannel(channel),
 		Title:            safeFilename,
@@ -354,6 +371,9 @@ func (s *knowledgeService) CreateKnowledgeFromURL(ctx context.Context,
 
 	// Check if URL already exists in the knowledge base
 	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
+	if err := s.validateKnowledgeFolderTarget(ctx, tenantID, kbID); err != nil {
+		return nil, err
+	}
 	logger.Infof(ctx, "Checking if URL exists, tenant ID: %d", tenantID)
 	fileHash := calculateStr(url)
 	exists, existingKnowledge, err := s.repo.CheckKnowledgeExists(ctx, tenantID, kbID, &types.KnowledgeCheckParams{
@@ -390,6 +410,7 @@ func (s *knowledgeService) CreateKnowledgeFromURL(ctx context.Context,
 		ID:               uuid.New().String(),
 		TenantID:         tenantID,
 		KnowledgeBaseID:  kbID,
+		FolderID:         knowledgeFolderIDFromContext(ctx),
 		Type:             "url",
 		Channel:          defaultChannel(channel),
 		Title:            title,
@@ -583,6 +604,9 @@ func (s *knowledgeService) createKnowledgeFromFileURL(
 
 	// Check for duplicate (by URL hash)
 	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
+	if err := s.validateKnowledgeFolderTarget(ctx, tenantID, kbID); err != nil {
+		return nil, err
+	}
 	fileHash := calculateStr(fileURL)
 	exists, existingKnowledge, err := s.repo.CheckKnowledgeExists(ctx, tenantID, kbID, &types.KnowledgeCheckParams{
 		Type:     "file_url",
@@ -616,6 +640,7 @@ func (s *knowledgeService) createKnowledgeFromFileURL(
 		ID:               uuid.New().String(),
 		TenantID:         tenantID,
 		KnowledgeBaseID:  kbID,
+		FolderID:         knowledgeFolderIDFromContext(ctx),
 		Type:             "file_url",
 		Channel:          defaultChannel(channel),
 		Title:            title,
@@ -760,6 +785,9 @@ func (s *knowledgeService) CreateKnowledgeFromManual(ctx context.Context,
 	}
 
 	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
+	if err := s.validateKnowledgeFolderTarget(ctx, tenantID, kbID); err != nil {
+		return nil, err
+	}
 	now := time.Now()
 	title := safeTitle
 	if title == "" {
@@ -772,6 +800,7 @@ func (s *knowledgeService) CreateKnowledgeFromManual(ctx context.Context,
 	knowledge := &types.Knowledge{
 		TenantID:         tenantID,
 		KnowledgeBaseID:  kbID,
+		FolderID:         knowledgeFolderIDFromContext(ctx),
 		Type:             types.KnowledgeTypeManual,
 		Channel:          defaultChannel(channel),
 		Title:            title,
@@ -856,6 +885,10 @@ func (s *knowledgeService) createKnowledgeFromPassageInternal(ctx context.Contex
 		logger.Errorf(ctx, "Failed to get knowledge base: %v", err)
 		return nil, err
 	}
+	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
+	if err := s.validateKnowledgeFolderTarget(ctx, tenantID, kbID); err != nil {
+		return nil, err
+	}
 
 	// Create knowledge record
 	if syncMode {
@@ -865,8 +898,9 @@ func (s *knowledgeService) createKnowledgeFromPassageInternal(ctx context.Contex
 	}
 	knowledge := &types.Knowledge{
 		ID:               uuid.New().String(),
-		TenantID:         ctx.Value(types.TenantIDContextKey).(uint64),
+		TenantID:         tenantID,
 		KnowledgeBaseID:  kbID,
+		FolderID:         knowledgeFolderIDFromContext(ctx),
 		Type:             "passage",
 		Channel:          defaultChannel(channel),
 		ParseStatus:      "pending",

--- a/internal/application/service/knowledge_create_test.go
+++ b/internal/application/service/knowledge_create_test.go
@@ -21,6 +21,19 @@ type createKnowledgeFileRepoStub struct {
 	createCalls      int
 	createErr        error
 	createdKnowledge *types.Knowledge
+	validateCalls    int
+	validateErr      error
+	checkCalls       int
+}
+
+func (r *createKnowledgeFileRepoStub) ValidateKnowledgeFolder(
+	ctx context.Context,
+	tenantID uint64,
+	kbID string,
+	folderID string,
+) error {
+	r.validateCalls++
+	return r.validateErr
 }
 
 func (r *createKnowledgeFileRepoStub) CheckKnowledgeExists(
@@ -29,6 +42,7 @@ func (r *createKnowledgeFileRepoStub) CheckKnowledgeExists(
 	kbID string,
 	params *types.KnowledgeCheckParams,
 ) (bool, *types.Knowledge, error) {
+	r.checkCalls++
 	return false, nil, nil
 }
 
@@ -154,6 +168,42 @@ func TestCreateKnowledgeFromFileDoesNotPersistWhenStorageSaveFails(t *testing.T)
 	require.Nil(t, knowledge)
 	require.Equal(t, 1, fileSvc.saveCalls)
 	require.Zero(t, repo.createCalls)
+}
+
+func TestCreateKnowledgeFromFileRejectsInvalidFolderBeforeStorage(t *testing.T) {
+	t.Parallel()
+
+	folderErr := errors.New("folder belongs to another knowledge base")
+	repo := &createKnowledgeFileRepoStub{validateErr: folderErr}
+	fileSvc := &createKnowledgeFileServiceStub{}
+	task := &createKnowledgeTaskEnqueuerStub{}
+	svc := &knowledgeService{
+		repo:      repo,
+		kbService: &createKnowledgeFileKBServiceStub{kb: &types.KnowledgeBase{ID: "kb-1"}},
+		fileSvc:   fileSvc,
+		task:      task,
+	}
+	ctx := context.WithValue(newCreateKnowledgeFileContext(), types.KnowledgeFolderIDContextKey, "foreign-folder")
+
+	knowledge, err := svc.CreateKnowledgeFromFile(
+		ctx,
+		"kb-1",
+		newMultipartFileHeader(t, "doc.txt", "hello"),
+		nil,
+		nil,
+		"",
+		nil,
+		"",
+		nil,
+	)
+
+	require.ErrorIs(t, err, folderErr)
+	require.Nil(t, knowledge)
+	require.Equal(t, 1, repo.validateCalls)
+	require.Zero(t, repo.checkCalls)
+	require.Zero(t, fileSvc.saveCalls)
+	require.Zero(t, repo.createCalls)
+	require.Zero(t, task.calls)
 }
 
 func TestCreateKnowledgeFromFilePersistsStoredFilePathOnCreate(t *testing.T) {

--- a/internal/application/service/knowledge_folder.go
+++ b/internal/application/service/knowledge_folder.go
@@ -1,0 +1,161 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	werrors "github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type knowledgeFolderService struct {
+	repo interfaces.KnowledgeFolderRepository
+	kb   interfaces.KnowledgeBaseService
+}
+
+func NewKnowledgeFolderService(repo interfaces.KnowledgeFolderRepository, kb interfaces.KnowledgeBaseService) interfaces.KnowledgeFolderService {
+	return &knowledgeFolderService{repo: repo, kb: kb}
+}
+
+func validateKnowledgeFolderName(value string) (string, error) {
+	name := strings.TrimSpace(value)
+	if utf8.RuneCountInString(name) < 1 || utf8.RuneCountInString(name) > 100 {
+		return "", werrors.NewBadRequestError("folder name must contain 1 to 100 characters")
+	}
+	if name == "." || name == ".." || strings.ContainsAny(name, "/\\") {
+		return "", werrors.NewBadRequestError("folder name contains invalid characters")
+	}
+	for _, r := range name {
+		if unicode.IsControl(r) {
+			return "", werrors.NewBadRequestError("folder name contains control characters")
+		}
+	}
+	return name, nil
+}
+
+func (s *knowledgeFolderService) scope(ctx context.Context, kbID string) (uint64, error) {
+	kb, err := s.kb.GetKnowledgeBaseByID(ctx, kbID)
+	if err != nil {
+		return 0, err
+	}
+	if kb.Type != types.KnowledgeBaseTypeDocument {
+		return 0, werrors.NewBadRequestError("folders are only available for document knowledge bases")
+	}
+	return kb.TenantID, nil
+}
+func mapFolderError(err error) error {
+	switch {
+	case errors.Is(err, repository.ErrKnowledgeFolderNotFound):
+		return werrors.NewNotFoundError("folder not found")
+	case errors.Is(err, repository.ErrKnowledgeFolderNotEmpty):
+		return werrors.NewConflictError("folder must be empty before deletion")
+	case errors.Is(err, repository.ErrKnowledgeFolderCycle):
+		return werrors.NewConflictError("a folder cannot be moved into itself or its descendant")
+	case errors.Is(err, repository.ErrKnowledgeFolderTooDeep):
+		return werrors.NewBadRequestError("folder hierarchy cannot exceed 20 levels")
+	case errors.Is(err, repository.ErrKnowledgeFolderConflict):
+		return werrors.NewConflictError("a folder with this name already exists")
+	case errors.Is(err, repository.ErrKnowledgeFolderScope):
+		return werrors.NewBadRequestError("folder or knowledge does not belong to this knowledge base")
+	default:
+		return err
+	}
+}
+func (s *knowledgeFolderService) List(ctx context.Context, kbID, parentID, keyword string, page *types.Pagination) (*types.PageResult, error) {
+	tenant, err := s.scope(ctx, kbID)
+	if err != nil {
+		return nil, err
+	}
+	if parentID != "" {
+		if _, err = s.repo.Get(ctx, tenant, kbID, parentID); err != nil {
+			return nil, mapFolderError(err)
+		}
+	}
+	rows, total, err := s.repo.List(ctx, tenant, kbID, parentID, keyword, page)
+	if err != nil {
+		return nil, mapFolderError(err)
+	}
+	return types.NewPageResult(total, page, rows), nil
+}
+func (s *knowledgeFolderService) Get(ctx context.Context, kbID, id string) (*types.KnowledgeFolderView, error) {
+	tenant, err := s.scope(ctx, kbID)
+	if err != nil {
+		return nil, err
+	}
+	v, err := s.repo.Get(ctx, tenant, kbID, id)
+	return v, mapFolderError(err)
+}
+func (s *knowledgeFolderService) Create(ctx context.Context, kbID, parentID, name string) (*types.KnowledgeFolder, error) {
+	tenant, err := s.scope(ctx, kbID)
+	if err != nil {
+		return nil, err
+	}
+	name, err = validateKnowledgeFolderName(name)
+	if err != nil {
+		return nil, err
+	}
+	v, err := s.repo.Create(ctx, tenant, kbID, parentID, name)
+	return v, mapFolderError(err)
+}
+func (s *knowledgeFolderService) Update(ctx context.Context, kbID, id string, name, parentID *string) (*types.KnowledgeFolder, error) {
+	tenant, err := s.scope(ctx, kbID)
+	if err != nil {
+		return nil, err
+	}
+	if name != nil {
+		n, e := validateKnowledgeFolderName(*name)
+		if e != nil {
+			return nil, e
+		}
+		name = &n
+	}
+	v, err := s.repo.Update(ctx, tenant, kbID, id, name, parentID)
+	return v, mapFolderError(err)
+}
+func (s *knowledgeFolderService) Delete(ctx context.Context, kbID, id string) error {
+	tenant, err := s.scope(ctx, kbID)
+	if err != nil {
+		return err
+	}
+	return mapFolderError(s.repo.Delete(ctx, tenant, kbID, id))
+}
+func (s *knowledgeFolderService) EnsurePaths(ctx context.Context, kbID, parentID string, paths []types.EnsureFolderPath) ([]types.EnsureFolderPathResult, error) {
+	tenant, err := s.scope(ctx, kbID)
+	if err != nil {
+		return nil, err
+	}
+	if len(paths) == 0 {
+		return []types.EnsureFolderPathResult{}, nil
+	}
+	for i := range paths {
+		if paths[i].ClientKey == "" {
+			return nil, werrors.NewBadRequestError("client_key is required")
+		}
+		if len(paths[i].Segments) == 0 {
+			return nil, werrors.NewBadRequestError("segments cannot be empty")
+		}
+		for j := range paths[i].Segments {
+			paths[i].Segments[j], err = validateKnowledgeFolderName(paths[i].Segments[j])
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	v, err := s.repo.EnsurePaths(ctx, tenant, kbID, parentID, paths)
+	return v, mapFolderError(err)
+}
+func (s *knowledgeFolderService) MoveKnowledge(ctx context.Context, kbID string, ids []string, folderID string) error {
+	tenant, err := s.scope(ctx, kbID)
+	if err != nil {
+		return err
+	}
+	if len(ids) == 0 {
+		return werrors.NewBadRequestError("knowledge_ids cannot be empty")
+	}
+	return mapFolderError(s.repo.MoveKnowledge(ctx, tenant, kbID, ids, folderID))
+}

--- a/internal/application/service/knowledge_folder_test.go
+++ b/internal/application/service/knowledge_folder_test.go
@@ -1,0 +1,113 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	apperrors "github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/require"
+)
+
+type folderServiceKBStub struct {
+	interfaces.KnowledgeBaseService
+	kb  *types.KnowledgeBase
+	err error
+}
+
+func (s *folderServiceKBStub) GetKnowledgeBaseByID(context.Context, string) (*types.KnowledgeBase, error) {
+	return s.kb, s.err
+}
+
+type folderServiceRepoStub struct {
+	interfaces.KnowledgeFolderRepository
+	createCalls int
+	updateCalls int
+	tenantID    uint64
+	parentID    string
+	name        string
+	err         error
+}
+
+func (s *folderServiceRepoStub) Create(_ context.Context, tenantID uint64, _ string, parentID, name string) (*types.KnowledgeFolder, error) {
+	s.createCalls++
+	s.tenantID, s.parentID, s.name = tenantID, parentID, name
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &types.KnowledgeFolder{ID: "folder-1", TenantID: tenantID, ParentID: parentID, Name: name}, nil
+}
+
+func (s *folderServiceRepoStub) Update(_ context.Context, tenantID uint64, _ string, _ string, name, parentID *string) (*types.KnowledgeFolder, error) {
+	s.updateCalls++
+	s.tenantID = tenantID
+	if name != nil {
+		s.name = *name
+	}
+	if parentID != nil {
+		s.parentID = *parentID
+	}
+	return &types.KnowledgeFolder{ID: "folder-1", TenantID: tenantID, ParentID: s.parentID, Name: s.name}, s.err
+}
+
+func TestValidateKnowledgeFolderName(t *testing.T) {
+	t.Parallel()
+
+	valid, err := validateKnowledgeFolderName("  Quarterly reports  ")
+	require.NoError(t, err)
+	require.Equal(t, "Quarterly reports", valid)
+
+	invalid := []string{"", "   ", ".", "..", "a/b", `a\b`, "line\nbreak", strings.Repeat("x", 101)}
+	for _, name := range invalid {
+		_, err := validateKnowledgeFolderName(name)
+		require.Error(t, err, "name %q should be rejected", name)
+		var appErr *apperrors.AppError
+		require.ErrorAs(t, err, &appErr)
+		require.Equal(t, apperrors.ErrBadRequest, appErr.Code)
+	}
+}
+
+func TestKnowledgeFolderServiceCreateAndRenameNormalizeNames(t *testing.T) {
+	t.Parallel()
+	repo := &folderServiceRepoStub{}
+	svc := NewKnowledgeFolderService(repo, &folderServiceKBStub{kb: &types.KnowledgeBase{
+		ID: "kb-1", TenantID: 42, Type: types.KnowledgeBaseTypeDocument,
+	}})
+
+	folder, err := svc.Create(context.Background(), "kb-1", "parent-1", "  Reports  ")
+	require.NoError(t, err)
+	require.Equal(t, "Reports", folder.Name)
+	require.EqualValues(t, 42, repo.tenantID)
+	require.Equal(t, "parent-1", repo.parentID)
+
+	name := "  Renamed  "
+	parent := "parent-2"
+	folder, err = svc.Update(context.Background(), "kb-1", "folder-1", &name, &parent)
+	require.NoError(t, err)
+	require.Equal(t, "Renamed", folder.Name)
+	require.Equal(t, "parent-2", folder.ParentID)
+	require.Equal(t, 1, repo.updateCalls)
+}
+
+func TestKnowledgeFolderServiceRejectsFAQAndMapsConflict(t *testing.T) {
+	t.Parallel()
+	faqRepo := &folderServiceRepoStub{}
+	faqSvc := NewKnowledgeFolderService(faqRepo, &folderServiceKBStub{kb: &types.KnowledgeBase{
+		ID: "faq-1", TenantID: 7, Type: types.KnowledgeBaseTypeFAQ,
+	}})
+	_, err := faqSvc.Create(context.Background(), "faq-1", "", "Folder")
+	require.Error(t, err)
+	require.Zero(t, faqRepo.createCalls)
+
+	conflictRepo := &folderServiceRepoStub{err: repository.ErrKnowledgeFolderConflict}
+	docSvc := NewKnowledgeFolderService(conflictRepo, &folderServiceKBStub{kb: &types.KnowledgeBase{
+		ID: "kb-1", TenantID: 7, Type: types.KnowledgeBaseTypeDocument,
+	}})
+	_, err = docSvc.Create(context.Background(), "kb-1", "", "Folder")
+	var appErr *apperrors.AppError
+	require.ErrorAs(t, err, &appErr)
+	require.Equal(t, apperrors.ErrConflict, appErr.Code)
+}

--- a/internal/application/service/knowledgebase_search.go
+++ b/internal/application/service/knowledgebase_search.go
@@ -12,6 +12,24 @@ import (
 	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
 
+// Keep document filters below common SQL parameter and vector-store expression
+// limits. Folder scopes can resolve to hundreds of thousands of documents; the
+// composite retriever executes these batches with bounded concurrency and the
+// caller performs one final fusion/truncation across all batch results.
+const maxKnowledgeIDsPerRetrieve = 500
+
+func splitKnowledgeIDBatches(ids []string) [][]string {
+	if len(ids) == 0 {
+		return [][]string{nil}
+	}
+	batches := make([][]string, 0, (len(ids)+maxKnowledgeIDsPerRetrieve-1)/maxKnowledgeIDsPerRetrieve)
+	for start := 0; start < len(ids); start += maxKnowledgeIDsPerRetrieve {
+		end := min(start+maxKnowledgeIDsPerRetrieve, len(ids))
+		batches = append(batches, ids[start:end])
+	}
+	return batches
+}
+
 // GetQueryEmbedding computes the query embedding using the embedding model
 // associated with the given knowledge base. Callers can pre-compute and reuse
 // the result across multiple KBs that share the same embedding model to avoid
@@ -193,7 +211,7 @@ func (s *knowledgeBaseService) HybridSearch(ctx context.Context,
 		Input: map[string]interface{}{
 			"query_text":             params.QueryText,
 			"kb_ids":                 searchKBIDs,
-			"knowledge_ids":          params.KnowledgeIDs,
+			"knowledge_id_count":     len(params.KnowledgeIDs),
 			"tag_ids":                params.TagIDs,
 			"match_count":            matchCount,
 			"vector_threshold":       params.VectorThreshold,
@@ -203,9 +221,9 @@ func (s *knowledgeBaseService) HybridSearch(ctx context.Context,
 			"group_count":            len(groups),
 		},
 		Metadata: map[string]interface{}{
-			"primary_kb_id":      kb.ID,
-			"primary_kb_type":    string(kb.Type),
-			"embedding_model_id": kb.EmbeddingModelID,
+			"primary_kb_id":       kb.ID,
+			"primary_kb_type":     string(kb.Type),
+			"embedding_model_id":  kb.EmbeddingModelID,
 			"has_query_embedding": len(params.QueryEmbedding) > 0,
 		},
 	})
@@ -359,17 +377,19 @@ func (s *knowledgeBaseService) buildRetrievalParams(
 		}
 
 		appendVectorParams := func(kbIDs []string, knowledgeType string) {
-			retrieveParams = append(retrieveParams, types.RetrieveParams{
-				Query:            params.QueryText,
-				Embedding:        queryEmbedding,
-				KnowledgeBaseIDs: kbIDs,
-				TopK:             matchCount,
-				Threshold:        params.VectorThreshold,
-				RetrieverType:    types.VectorRetrieverType,
-				KnowledgeIDs:     params.KnowledgeIDs,
-				TagIDs:           params.TagIDs,
-				KnowledgeType:    knowledgeType,
-			})
+			for _, knowledgeIDBatch := range splitKnowledgeIDBatches(params.KnowledgeIDs) {
+				retrieveParams = append(retrieveParams, types.RetrieveParams{
+					Query:            params.QueryText,
+					Embedding:        queryEmbedding,
+					KnowledgeBaseIDs: kbIDs,
+					TopK:             matchCount,
+					Threshold:        params.VectorThreshold,
+					RetrieverType:    types.VectorRetrieverType,
+					KnowledgeIDs:     knowledgeIDBatch,
+					TagIDs:           params.TagIDs,
+					KnowledgeType:    knowledgeType,
+				})
+			}
 		}
 
 		// Document KBs use the default vector index; FAQ KBs use the FAQ
@@ -389,15 +409,17 @@ func (s *knowledgeBaseService) buildRetrievalParams(
 	if retrieveEngine.SupportRetriever(types.KeywordsRetrieverType) && !params.DisableKeywordsMatch &&
 		len(docKeywordKBIDs) > 0 {
 		logger.Info(ctx, "Keyword retrieval supported, preparing keyword retrieval parameters")
-		retrieveParams = append(retrieveParams, types.RetrieveParams{
-			Query:            params.QueryText,
-			KnowledgeBaseIDs: docKeywordKBIDs,
-			TopK:             matchCount,
-			Threshold:        params.KeywordThreshold,
-			RetrieverType:    types.KeywordsRetrieverType,
-			KnowledgeIDs:     params.KnowledgeIDs,
-			TagIDs:           params.TagIDs,
-		})
+		for _, knowledgeIDBatch := range splitKnowledgeIDBatches(params.KnowledgeIDs) {
+			retrieveParams = append(retrieveParams, types.RetrieveParams{
+				Query:            params.QueryText,
+				KnowledgeBaseIDs: docKeywordKBIDs,
+				TopK:             matchCount,
+				Threshold:        params.KeywordThreshold,
+				RetrieverType:    types.KeywordsRetrieverType,
+				KnowledgeIDs:     knowledgeIDBatch,
+				TagIDs:           params.TagIDs,
+			})
+		}
 		logger.Info(ctx, "Keyword retrieval parameters setup completed")
 	}
 

--- a/internal/application/service/knowledgebase_search_folder_batch_test.go
+++ b/internal/application/service/knowledgebase_search_folder_batch_test.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitKnowledgeIDBatchesBoundsFolderRetrievalParameters(t *testing.T) {
+	ids := make([]string, 1201)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("knowledge-%04d", i)
+	}
+
+	batches := splitKnowledgeIDBatches(ids)
+	require.Len(t, batches, 3)
+	require.Len(t, batches[0], maxKnowledgeIDsPerRetrieve)
+	require.Len(t, batches[1], maxKnowledgeIDsPerRetrieve)
+	require.Len(t, batches[2], 201)
+
+	flattened := make([]string, 0, len(ids))
+	for _, batch := range batches {
+		require.LessOrEqual(t, len(batch), maxKnowledgeIDsPerRetrieve)
+		flattened = append(flattened, batch...)
+	}
+	require.Equal(t, ids, flattened)
+	require.Equal(t, [][]string{nil}, splitKnowledgeIDBatches(nil))
+}

--- a/internal/application/service/message_suggestion.go
+++ b/internal/application/service/message_suggestion.go
@@ -28,6 +28,10 @@ type messageSuggestionService struct {
 	customAgentService interfaces.CustomAgentService
 }
 
+type folderAwareKnowledgeSuggestionService interface {
+	GetKnowledgeSuggestedQuestionsWithFolders(ctx context.Context, agentID string, kbIDs, knowledgeIDs, tagIDs []string, limit int, folderScopes []types.FolderScope) ([]types.SuggestedQuestion, error)
+}
+
 func NewMessageSuggestionService(
 	repo interfaces.MessageSuggestionRepository,
 	messageService interfaces.MessageService,
@@ -349,14 +353,32 @@ func (s *messageSuggestionService) generateFromKnowledge(
 	if message.AgentTenantID != 0 {
 		knowledgeCtx = context.WithValue(knowledgeCtx, types.TenantIDContextKey, message.AgentTenantID)
 	}
-	candidates, err := s.customAgentService.GetKnowledgeSuggestedQuestions(
-		knowledgeCtx,
-		message.AgentID,
-		message.ExecutionContext.KnowledgeBaseIDs,
-		message.ExecutionContext.KnowledgeIDs,
-		message.ExecutionContext.TagIDs,
-		count,
-	)
+	var candidates []types.SuggestedQuestion
+	var err error
+	if len(message.ExecutionContext.FolderScopes) > 0 {
+		folderService, ok := s.customAgentService.(folderAwareKnowledgeSuggestionService)
+		if !ok {
+			return nil, errors.New("custom agent service does not support folder-scoped knowledge suggestions")
+		}
+		candidates, err = folderService.GetKnowledgeSuggestedQuestionsWithFolders(
+			knowledgeCtx,
+			message.AgentID,
+			message.ExecutionContext.KnowledgeBaseIDs,
+			message.ExecutionContext.KnowledgeIDs,
+			message.ExecutionContext.TagIDs,
+			count,
+			message.ExecutionContext.FolderScopes,
+		)
+	} else {
+		candidates, err = s.customAgentService.GetKnowledgeSuggestedQuestions(
+			knowledgeCtx,
+			message.AgentID,
+			message.ExecutionContext.KnowledgeBaseIDs,
+			message.ExecutionContext.KnowledgeIDs,
+			message.ExecutionContext.TagIDs,
+			count,
+		)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/application/service/message_suggestion_test.go
+++ b/internal/application/service/message_suggestion_test.go
@@ -1,10 +1,32 @@
 package service
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type folderAwareKnowledgeSuggestionStub struct {
+	interfaces.CustomAgentService
+	called       bool
+	folderScopes []types.FolderScope
+}
+
+func (s *folderAwareKnowledgeSuggestionStub) GetKnowledgeSuggestedQuestionsWithFolders(
+	_ context.Context,
+	_ string,
+	_, _, _ []string,
+	_ int,
+	folderScopes []types.FolderScope,
+) ([]types.SuggestedQuestion, error) {
+	s.called = true
+	s.folderScopes = append([]types.FolderScope(nil), folderScopes...)
+	return []types.SuggestedQuestion{{Question: "Folder question?", Source: "document", KnowledgeBaseID: "kb-1"}}, nil
+}
 
 func TestParseGeneratedSuggestionsFiltersAndDeduplicates(t *testing.T) {
 	content := "```json\n{\"questions\":[" +
@@ -55,4 +77,23 @@ func TestAnswerEndsWithQuestion(t *testing.T) {
 	if !answerEndsWithQuestion("需要我继续展开吗？\n<kb>1</kb>") {
 		t.Fatal("question before a trailing citation was not detected")
 	}
+}
+
+func TestGenerateFromKnowledgeUsesFolderAwarePath(t *testing.T) {
+	stub := &folderAwareKnowledgeSuggestionStub{}
+	service := &messageSuggestionService{customAgentService: stub}
+	scopes := []types.FolderScope{{KnowledgeBaseID: "kb-1", FolderIDs: []string{"folder-1"}}}
+	items, err := service.generateFromKnowledge(context.Background(), &types.Message{
+		AgentID: "agent-1",
+		ExecutionContext: types.MessageExecutionContext{
+			KnowledgeBaseIDs: []string{"kb-1"},
+			FolderScopes:     scopes,
+		},
+	}, 3)
+	require.NoError(t, err)
+	assert.True(t, stub.called)
+	assert.Equal(t, scopes, stub.folderScopes)
+	require.Len(t, items, 1)
+	assert.Equal(t, "Folder question?", items[0].Text)
+	assert.Equal(t, []string{"kb-1"}, items[0].KnowledgeBaseIDs)
 }

--- a/internal/application/service/retriever/composite.go
+++ b/internal/application/service/retriever/composite.go
@@ -27,6 +27,8 @@ type CompositeRetrieveEngine struct {
 	engineInfos []*engineInfo
 }
 
+const maxConcurrentRetrieveParams = 4
+
 // Retrieve performs retrieval operations by delegating to the appropriate engine
 // based on the retriever type specified in the parameters
 func (c *CompositeRetrieveEngine) Retrieve(ctx context.Context,
@@ -133,21 +135,30 @@ func concurrentRetrieve(
 	retrieveParams []types.RetrieveParams,
 	fn func(ctx context.Context, param types.RetrieveParams, results *[]*types.RetrieveResult, mu *sync.Mutex) error,
 ) ([]*types.RetrieveResult, error) {
+	if len(retrieveParams) == 0 {
+		return nil, nil
+	}
 	var results []*types.RetrieveResult
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 	errCh := make(chan error, len(retrieveParams))
-
-	for _, param := range retrieveParams {
+	jobs := make(chan types.RetrieveParams)
+	workerCount := min(maxConcurrentRetrieveParams, len(retrieveParams))
+	for range workerCount {
 		wg.Add(1)
-		p := param // Create local copy for safe use in closure
 		go func() {
 			defer wg.Done()
-			if err := fn(ctx, p, &results, &mu); err != nil {
-				errCh <- err
+			for param := range jobs {
+				if err := fn(ctx, param, &results, &mu); err != nil {
+					errCh <- err
+				}
 			}
 		}()
 	}
+	for _, param := range retrieveParams {
+		jobs <- param
+	}
+	close(jobs)
 
 	wg.Wait()
 	close(errCh)

--- a/internal/application/service/retriever/composite_bounded_test.go
+++ b/internal/application/service/retriever/composite_bounded_test.go
@@ -1,0 +1,40 @@
+package retriever
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcurrentRetrieveUsesBoundedWorkerPool(t *testing.T) {
+	params := make([]types.RetrieveParams, 25)
+	var active atomic.Int32
+	var maximum atomic.Int32
+	var completed atomic.Int32
+
+	_, err := concurrentRetrieve(context.Background(), params,
+		func(_ context.Context, _ types.RetrieveParams, _ *[]*types.RetrieveResult, _ *sync.Mutex) error {
+			current := active.Add(1)
+			for {
+				observed := maximum.Load()
+				if current <= observed || maximum.CompareAndSwap(observed, current) {
+					break
+				}
+			}
+			time.Sleep(5 * time.Millisecond)
+			active.Add(-1)
+			completed.Add(1)
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.EqualValues(t, len(params), completed.Load())
+	require.LessOrEqual(t, maximum.Load(), int32(maxConcurrentRetrieveParams))
+	require.Greater(t, maximum.Load(), int32(1))
+}

--- a/internal/application/service/session_agent_qa.go
+++ b/internal/application/service/session_agent_qa.go
@@ -301,8 +301,15 @@ func (s *sessionService) buildAgentConfig(
 		logger.Infof(ctx, "No knowledge bases specified for agent, running in pure agent mode")
 	}
 
+	// Folder scopes constrain agent-default KBs. A KB the user explicitly
+	// selected as a whole remains unrestricted, matching ordinary RAG.
+	fullKBs := fullKnowledgeBasesForFolderScopes(
+		agentConfig.KnowledgeBases,
+		req.KnowledgeBaseIDs,
+		req.FolderScopes,
+	)
 	// Build search targets using agent's tenant (handler has validated access for shared agent)
-	searchTargets, err := s.buildSearchTargets(ctx, agentTenantID, agentConfig.KnowledgeBases, agentConfig.KnowledgeIDs, req.TagScopes)
+	searchTargets, err := s.buildSearchTargets(ctx, agentTenantID, fullKBs, agentConfig.KnowledgeIDs, req.TagScopes, req.FolderScopes)
 	if err != nil {
 		return nil, fmt.Errorf("build search targets: %w", err)
 	}
@@ -314,6 +321,32 @@ func (s *sessionService) buildAgentConfig(
 	}
 
 	return agentConfig, nil
+}
+
+func fullKnowledgeBasesForFolderScopes(
+	resolvedKBIDs []string,
+	explicitWholeKBIDs []string,
+	folderScopes []types.FolderScope,
+) []string {
+	explicit := make(map[string]bool, len(explicitWholeKBIDs))
+	for _, kbID := range explicitWholeKBIDs {
+		if kbID != "" {
+			explicit[kbID] = true
+		}
+	}
+	constrained := make(map[string]bool, len(folderScopes))
+	for _, scope := range folderScopes {
+		if scope.KnowledgeBaseID != "" && !explicit[scope.KnowledgeBaseID] {
+			constrained[scope.KnowledgeBaseID] = true
+		}
+	}
+	result := make([]string, 0, len(resolvedKBIDs))
+	for _, kbID := range resolvedKBIDs {
+		if kbID != "" && !constrained[kbID] {
+			result = append(result, kbID)
+		}
+	}
+	return result
 }
 
 // applyPerRequestSkillScope narrows the agent's skill whitelist to the @Skill

--- a/internal/application/service/session_knowledge_qa.go
+++ b/internal/application/service/session_knowledge_qa.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -87,7 +88,7 @@ func (s *sessionService) KnowledgeQA(
 	retrievalTenantID := s.resolveRetrievalTenantID(ctx, req)
 
 	// Build unified search targets (computed once, used throughout pipeline)
-	searchTargets, err := s.buildSearchTargets(ctx, retrievalTenantID, knowledgeBaseIDs, knowledgeIDs, req.TagScopes)
+	searchTargets, err := s.buildSearchTargets(ctx, retrievalTenantID, knowledgeBaseIDs, knowledgeIDs, req.TagScopes, req.FolderScopes)
 	if err != nil {
 		return fmt.Errorf("build search targets: %w", err)
 	}
@@ -435,9 +436,15 @@ func (s *sessionService) buildSearchTargets(
 	knowledgeBaseIDs []string,
 	knowledgeIDs []string,
 	tagScopes []types.TagScope,
+	folderScopeArg ...[]types.FolderScope,
 ) (types.SearchTargets, error) {
 	var targets types.SearchTargets
 	tagIDsByKB := mergeTagScopesByKB(tagScopes)
+	var folderScopes []types.FolderScope
+	if len(folderScopeArg) > 0 {
+		folderScopes = folderScopeArg[0]
+	}
+	folderIDsByKB := mergeFolderScopesByKB(folderScopes)
 
 	// Build a map from KB ID to TenantID for all KBs we need to process
 	kbTenantMap := make(map[string]uint64)
@@ -449,6 +456,9 @@ func (s *sessionService) buildSearchTargets(
 	callerTenantRole := types.TenantRoleFromContext(ctx)
 	kbIDsToFetch := append([]string(nil), knowledgeBaseIDs...)
 	for kbID := range tagIDsByKB {
+		kbIDsToFetch = append(kbIDsToFetch, kbID)
+	}
+	for kbID := range folderIDsByKB {
 		kbIDsToFetch = append(kbIDsToFetch, kbID)
 	}
 	kbIDsToFetch = uniqueNonEmptyStrings(kbIDsToFetch)
@@ -504,15 +514,45 @@ func (s *sessionService) buildSearchTargets(
 	}
 
 	kbToKnowledgeIDs := make(map[string][]string)
+	explicitKnowledgeIDs := uniqueNonEmptyStrings(knowledgeIDs)
+	explicitSet := make(map[string]bool, len(explicitKnowledgeIDs))
+	for _, id := range explicitKnowledgeIDs {
+		explicitSet[id] = true
+	}
+	// A full-KB selection supersedes its folder scope. Otherwise expand all
+	// selected folders recursively; multiple folders naturally form a union.
+	folderAllowedByKB := make(map[string]map[string]bool)
+	for kbID, folderIDs := range folderIDsByKB {
+		if fullKBSet[kbID] {
+			continue
+		}
+		folderKnowledgeIDs, err := s.knowledgeService.GetRepository().ListIDsByFolderIDs(ctx, resolveKBTenant(kbID), kbID, folderIDs)
+		if err != nil {
+			return nil, fmt.Errorf("resolve knowledge IDs for folder scope kb_id=%s: %w", kbID, err)
+		}
+		folderAllowedByKB[kbID] = make(map[string]bool, len(folderKnowledgeIDs))
+		for _, id := range folderKnowledgeIDs {
+			folderAllowedByKB[kbID][id] = true
+		}
+	}
 
-	// Process individual knowledge IDs (include shared KB files the user has access to)
-	if len(knowledgeIDs) > 0 {
-		knowledgeList, err := s.knowledgeService.GetKnowledgeBatchWithSharedAccess(ctx, tenantID, knowledgeIDs)
+	// Resolve only caller-supplied knowledge IDs through the shared-access
+	// authorization path. Folder-derived IDs already came from a tenant- and
+	// KB-scoped closure query; passing a very large folder through this lookup
+	// again would create a huge IN list (and an N+1 fallback for shared KBs).
+	explicitKB := make(map[string]bool)
+	if len(explicitKnowledgeIDs) > 0 {
+		knowledgeList, err := s.knowledgeService.GetKnowledgeBatchWithSharedAccess(ctx, tenantID, explicitKnowledgeIDs)
 		if err != nil {
 			logger.Warnf(ctx, "Failed to get knowledge batch for search targets: %v", err)
 			return targets, nil // Return what we have, don't fail
 		}
 
+		for _, k := range knowledgeList {
+			if k != nil {
+				explicitKB[k.KnowledgeBaseID] = true
+			}
+		}
 		// Group knowledge IDs by their KB, excluding those already covered by full KB search
 		// Also track KB tenant IDs from knowledge items
 		for _, k := range knowledgeList {
@@ -529,23 +569,49 @@ func (s *sessionService) buildSearchTargets(
 			}
 			kbToKnowledgeIDs[k.KnowledgeBaseID] = append(kbToKnowledgeIDs[k.KnowledgeBaseID], k.ID)
 		}
+	}
 
-		// Create SearchTargetTypeKnowledge targets for each KB with specific files
-		for kbID, kidList := range kbToKnowledgeIDs {
-			if len(tagIDsByKB[kbID]) > 0 {
-				continue
+	// Apply folder scopes after explicit-file authorization. Within the same KB,
+	// explicit files intersect the recursive folder result. With no explicit file
+	// in that KB, the recursive folder result becomes the complete target set.
+	for kbID, allowed := range folderAllowedByKB {
+		if explicitKB[kbID] {
+			filtered := make([]string, 0, len(kbToKnowledgeIDs[kbID]))
+			for _, id := range kbToKnowledgeIDs[kbID] {
+				if explicitSet[id] && allowed[id] {
+					filtered = append(filtered, id)
+				}
 			}
-			kbTenant := kbTenantMap[kbID]
-			if kbTenant == 0 {
-				kbTenant = tenantID // fallback
-			}
-			targets = append(targets, &types.SearchTarget{
-				Type:            types.SearchTargetTypeKnowledge,
-				KnowledgeBaseID: kbID,
-				TenantID:        kbTenant,
-				KnowledgeIDs:    kidList,
-			})
+			kbToKnowledgeIDs[kbID] = filtered
+			continue
 		}
+		folderIDs := make([]string, 0, len(allowed))
+		for id := range allowed {
+			folderIDs = append(folderIDs, id)
+		}
+		// Stabilize target order for deterministic batching and tests.
+		sort.Strings(folderIDs)
+		kbToKnowledgeIDs[kbID] = folderIDs
+	}
+
+	// Create SearchTargetTypeKnowledge targets for each KB with specific files.
+	for kbID, kidList := range kbToKnowledgeIDs {
+		kidList = uniqueNonEmptyStrings(kidList)
+		kbToKnowledgeIDs[kbID] = kidList
+		if len(kidList) == 0 || len(tagIDsByKB[kbID]) > 0 {
+			continue
+		}
+		kbTenant := kbTenantMap[kbID]
+		if kbTenant == 0 {
+			kbTenant = resolveKBTenant(kbID)
+		}
+		targets = append(targets, &types.SearchTarget{
+			Type:              types.SearchTargetTypeKnowledge,
+			KnowledgeBaseID:   kbID,
+			TenantID:          kbTenant,
+			KnowledgeIDs:      kidList,
+			DisableDirectLoad: folderAllowedByKB[kbID] != nil,
+		})
 	}
 
 	for kbID, tagIDs := range tagIDsByKB {
@@ -600,6 +666,19 @@ func (s *sessionService) buildSearchTargets(
 		len(targets), len(knowledgeBaseIDs), len(targets)-len(knowledgeBaseIDs), kbTenantMap)
 
 	return targets, nil
+}
+
+func mergeFolderScopesByKB(scopes []types.FolderScope) map[string][]string {
+	result := make(map[string][]string)
+	for _, scope := range scopes {
+		if scope.KnowledgeBaseID != "" {
+			result[scope.KnowledgeBaseID] = append(result[scope.KnowledgeBaseID], scope.FolderIDs...)
+		}
+	}
+	for kbID, ids := range result {
+		result[kbID] = uniqueNonEmptyStrings(ids)
+	}
+	return result
 }
 
 func mergeTagScopesByKB(scopes []types.TagScope) map[string][]string {
@@ -791,6 +870,7 @@ func (s *sessionService) KnowledgeQAByEvent(ctx context.Context,
 // knowledgeIDs: list of specific knowledge (file) IDs to search
 func (s *sessionService) SearchKnowledge(ctx context.Context,
 	knowledgeBaseIDs []string, knowledgeIDs []string, tagScopes []types.TagScope, query string,
+	folderScopeArg ...[]types.FolderScope,
 ) ([]*types.SearchResult, error) {
 	logger.Info(ctx, "Start knowledge base search without LLM summary")
 	logger.Infof(ctx, "Knowledge base search parameters, knowledge base IDs: %v, knowledge IDs: %v, tag scopes: %d, query: %s",
@@ -804,7 +884,7 @@ func (s *sessionService) SearchKnowledge(ctx context.Context,
 	}
 
 	// Build unified search targets (computed once, used throughout pipeline)
-	searchTargets, err := s.buildSearchTargets(ctx, tenantID, knowledgeBaseIDs, knowledgeIDs, tagScopes)
+	searchTargets, err := s.buildSearchTargets(ctx, tenantID, knowledgeBaseIDs, knowledgeIDs, tagScopes, folderScopeArg...)
 	if err != nil {
 		return nil, fmt.Errorf("build search targets: %w", err)
 	}

--- a/internal/application/service/session_qa_helpers.go
+++ b/internal/application/service/session_qa_helpers.go
@@ -27,7 +27,7 @@ func (s *sessionService) resolveKnowledgeBases(
 	requestedKBIDs := append([]string(nil), req.KnowledgeBaseIDs...)
 	customAgent := req.CustomAgent
 
-	hasExplicitMention := len(kbIDs) > 0 || len(knowledgeIDs) > 0 || len(req.TagScopes) > 0
+	hasExplicitMention := len(kbIDs) > 0 || len(knowledgeIDs) > 0 || len(req.TagScopes) > 0 || len(req.FolderScopes) > 0
 	if customAgent != nil {
 		logger.Infof(ctx, "KB resolution: hasExplicitMention=%v, RetrieveKBOnlyWhenMentioned=%v, KBSelectionMode=%s",
 			hasExplicitMention, customAgent.Config.RetrieveKBOnlyWhenMentioned, customAgent.Config.KBSelectionMode)
@@ -40,6 +40,10 @@ func (s *sessionService) resolveKnowledgeBases(
 		if customAgent != nil && req.Session != nil && req.Session.TenantID != customAgent.TenantID {
 			kbIDs, knowledgeIDs = s.restrictMentionsToAgentScope(ctx, customAgent, req.Session.TenantID, kbIDs, knowledgeIDs)
 			req.TagScopes = s.restrictTagScopesToAgentScope(ctx, customAgent, req.Session.TenantID, req.TagScopes)
+			req.FolderScopes = s.restrictFolderScopesToAgentScope(ctx, customAgent, req.Session.TenantID, req.FolderScopes)
+		}
+		if customAgent != nil && req.Session != nil {
+			req.FolderScopes = s.restrictFolderScopesToAgentScope(ctx, customAgent, req.Session.TenantID, req.FolderScopes)
 		}
 	} else if customAgent != nil && customAgent.Config.RetrieveKBOnlyWhenMentioned {
 		kbIDs = nil
@@ -57,6 +61,24 @@ func (s *sessionService) resolveKnowledgeBases(
 		return nil, nil, err
 	}
 	return kbIDs, knowledgeIDs, nil
+}
+
+func (s *sessionService) restrictFolderScopesToAgentScope(ctx context.Context, agent *types.CustomAgent, sessionTenantID uint64, scopes []types.FolderScope) []types.FolderScope {
+	if len(scopes) == 0 {
+		return nil
+	}
+	allowed := s.resolveKnowledgeBasesFromAgent(ctx, agent, sessionTenantID)
+	set := make(map[string]bool, len(allowed))
+	for _, id := range allowed {
+		set[id] = true
+	}
+	result := make([]types.FolderScope, 0, len(scopes))
+	for _, scope := range scopes {
+		if set[scope.KnowledgeBaseID] {
+			result = append(result, scope)
+		}
+	}
+	return result
 }
 
 func (s *sessionService) restrictTagScopesToAgentScope(

--- a/internal/application/service/session_tag_targets_test.go
+++ b/internal/application/service/session_tag_targets_test.go
@@ -33,6 +33,35 @@ type tagTargetKnowledgeService struct {
 	interfaces.KnowledgeService
 	knowledges []*types.Knowledge
 	tagIDs     map[string][]string
+	folderIDs  map[string][]string
+}
+
+type folderTargetRepository struct {
+	interfaces.KnowledgeRepository
+	service *tagTargetKnowledgeService
+}
+
+func (r *folderTargetRepository) ListIDsByFolderIDs(_ context.Context, _ uint64, kbID string, folderIDs []string) ([]string, error) {
+	allowed := map[string]bool{}
+	for _, id := range folderIDs {
+		allowed[id] = true
+	}
+	var out []string
+	for knowledgeID, folders := range r.service.folderIDs {
+		if !knowledgeBelongsToKB(r.service.knowledges, knowledgeID, kbID) {
+			continue
+		}
+		for _, folderID := range folders {
+			if allowed[folderID] {
+				out = append(out, knowledgeID)
+				break
+			}
+		}
+	}
+	return out, nil
+}
+func (s *tagTargetKnowledgeService) GetRepository() interfaces.KnowledgeRepository {
+	return &folderTargetRepository{service: s}
 }
 
 func (s *tagTargetKnowledgeService) GetKnowledgeBatchWithSharedAccess(
@@ -106,8 +135,89 @@ func newTagTargetSessionService() *sessionService {
 				"doc-2": {"tag-b"},
 				"doc-3": {"tag-a", "tag-b"},
 			},
+			folderIDs: map[string][]string{"doc-1": {"folder-a"}, "doc-2": {"folder-b"}, "doc-3": {"folder-a", "folder-child"}},
 		},
 	}
+}
+
+func TestBuildSearchTargets_FolderUnionAndExplicitIntersection(t *testing.T) {
+	svc := newTagTargetSessionService()
+	targets, err := svc.buildSearchTargets(tagTargetContext(), 100, nil, nil, nil, []types.FolderScope{{KnowledgeBaseID: "doc-kb", FolderIDs: []string{"folder-a", "folder-b"}}})
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.ElementsMatch(t, []string{"doc-1", "doc-2", "doc-3"}, targets[0].KnowledgeIDs)
+	targets, err = svc.buildSearchTargets(tagTargetContext(), 100, nil, []string{"doc-2", "doc-3"}, nil, []types.FolderScope{{KnowledgeBaseID: "doc-kb", FolderIDs: []string{"folder-a"}}})
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, []string{"doc-3"}, targets[0].KnowledgeIDs)
+}
+
+func TestBuildSearchTargets_ExplicitWholeKBSupersedesFolderScope(t *testing.T) {
+	svc := newTagTargetSessionService()
+	targets, err := svc.buildSearchTargets(
+		tagTargetContext(),
+		100,
+		[]string{"doc-kb"},
+		nil,
+		nil,
+		[]types.FolderScope{{KnowledgeBaseID: "doc-kb", FolderIDs: []string{"folder-a"}}},
+	)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, types.SearchTargetTypeKnowledgeBase, targets[0].Type)
+	assert.Equal(t, "doc-kb", targets[0].KnowledgeBaseID)
+	assert.Empty(t, targets[0].KnowledgeIDs)
+}
+
+func TestFullKnowledgeBasesForFolderScopesPreservesExplicitWholeKB(t *testing.T) {
+	resolved := []string{"kb-explicit", "kb-default", "kb-unscoped"}
+	scopes := []types.FolderScope{
+		{KnowledgeBaseID: "kb-explicit", FolderIDs: []string{"folder-a"}},
+		{KnowledgeBaseID: "kb-default", FolderIDs: []string{"folder-b"}},
+	}
+
+	assert.Equal(t,
+		[]string{"kb-explicit", "kb-unscoped"},
+		fullKnowledgeBasesForFolderScopes(resolved, []string{"kb-explicit"}, scopes),
+	)
+	assert.Equal(t,
+		[]string{"kb-unscoped"},
+		fullKnowledgeBasesForFolderScopes(resolved, nil, scopes),
+	)
+}
+
+func TestBuildSearchTargets_FolderAndTagIntersect(t *testing.T) {
+	svc := newTagTargetSessionService()
+	targets, err := svc.buildSearchTargets(tagTargetContext(), 100, nil, nil, []types.TagScope{{KnowledgeBaseID: "doc-kb", TagIDs: []string{"tag-b"}}}, []types.FolderScope{{KnowledgeBaseID: "doc-kb", FolderIDs: []string{"folder-a"}}})
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, []string{"doc-3"}, targets[0].KnowledgeIDs)
+}
+
+func TestResolveKnowledgeBasesTreatsFolderAsExplicitAndRestrictsSharedAgentScope(t *testing.T) {
+	svc := newTagTargetSessionService()
+	agent := &types.CustomAgent{
+		ID: "shared-agent", TenantID: 200,
+		Config: types.CustomAgentConfig{
+			KBSelectionMode:             "selected",
+			KnowledgeBases:              []string{"doc-kb"},
+			RetrieveKBOnlyWhenMentioned: true,
+		},
+	}
+	req := &types.QARequest{
+		Session:     &types.Session{ID: "session-1", TenantID: 100},
+		CustomAgent: agent,
+		FolderScopes: []types.FolderScope{
+			{KnowledgeBaseID: "doc-kb", FolderIDs: []string{"folder-a"}},
+			{KnowledgeBaseID: "blocked-kb", FolderIDs: []string{"folder-x"}},
+		},
+	}
+
+	kbIDs, knowledgeIDs, err := svc.resolveKnowledgeBases(tagTargetContext(), req)
+	require.NoError(t, err)
+	assert.Empty(t, kbIDs, "folder mention is the explicit retrieval target, not the full KB")
+	assert.Empty(t, knowledgeIDs)
+	require.Equal(t, []types.FolderScope{{KnowledgeBaseID: "doc-kb", FolderIDs: []string{"folder-a"}}}, req.FolderScopes)
 }
 
 func tagTargetContext() context.Context {

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -145,6 +145,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewAuditLogRepository))
 	must(container.Provide(repository.NewKnowledgeBaseRepository))
 	must(container.Provide(repository.NewKnowledgeRepository))
+	must(container.Provide(repository.NewKnowledgeFolderRepository))
 	must(container.Provide(repository.NewKnowledgeSpanRepository))
 	must(container.Provide(repository.NewChunkRepository))
 	must(container.Provide(repository.NewKnowledgeTagRepository))
@@ -193,6 +194,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(service.NewKBShareService)) // KBShareService must be registered before KnowledgeService and KnowledgeTagService
 	must(container.Provide(service.NewAgentShareService))
 	must(container.Provide(service.NewKnowledgeService))
+	must(container.Provide(service.NewKnowledgeFolderService))
 	must(container.Provide(service.NewSpanTracker))
 	must(container.Provide(service.NewChunkService))
 	must(container.Provide(service.NewKnowledgeTagService))
@@ -338,6 +340,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(handler.NewAuditLogHandler))
 	must(container.Provide(handler.NewKnowledgeBaseHandler))
 	must(container.Provide(handler.NewKnowledgeHandler))
+	must(container.Provide(handler.NewKnowledgeFolderHandler))
 	must(container.Provide(handler.NewChunkHandler))
 	must(container.Provide(handler.NewFAQHandler))
 	must(container.Provide(handler.NewTagHandler))

--- a/internal/handler/custom_agent.go
+++ b/internal/handler/custom_agent.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"strings"
@@ -606,6 +607,32 @@ func (h *CustomAgentHandler) GetSuggestedQuestions(c *gin.Context) {
 			}
 		}
 	}
+	var folderScopes []types.FolderScope
+	if raw := strings.TrimSpace(c.Query("folder_scopes")); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &folderScopes); err != nil {
+			c.Error(errors.NewBadRequestError("invalid folder_scopes"))
+			return
+		}
+	}
+	var folderIDs []string
+	if raw := strings.TrimSpace(c.Query("folder_ids")); raw != "" {
+		for _, id := range strings.Split(raw, ",") {
+			if trimmed := strings.TrimSpace(id); trimmed != "" {
+				folderIDs = append(folderIDs, trimmed)
+			}
+		}
+		if len(kbIDs) != 1 {
+			c.Error(errors.NewBadRequestError("folder_ids requires exactly one knowledge_base_id"))
+			return
+		}
+		folderScopes = append(folderScopes, types.FolderScope{
+			KnowledgeBaseID: kbIDs[0],
+			FolderIDs:       folderIDs,
+		})
+		// In this shorthand knowledge_base_ids identifies the folder's parent
+		// KB; it is not an additional whole-KB selection.
+		kbIDs = nil
+	}
 
 	limit := 6
 	if limitStr := c.Query("limit"); limitStr != "" {
@@ -617,7 +644,19 @@ func (h *CustomAgentHandler) GetSuggestedQuestions(c *gin.Context) {
 	logger.Infof(ctx, "Getting suggested questions for agent %s, kbIDs: %v, tagIDs: %v, limit: %d",
 		secutils.SanitizeForLog(id), kbIDs, tagIDs, limit)
 
-	questions, err := h.service.GetSuggestedQuestions(ctx, id, kbIDs, knowledgeIDs, tagIDs, limit)
+	var questions []types.SuggestedQuestion
+	var err error
+	if len(folderScopes) > 0 {
+		if svc, ok := h.service.(interface {
+			GetSuggestedQuestionsWithFolders(context.Context, string, []string, []string, []string, int, []types.FolderScope) ([]types.SuggestedQuestion, error)
+		}); ok {
+			questions, err = svc.GetSuggestedQuestionsWithFolders(ctx, id, kbIDs, knowledgeIDs, tagIDs, limit, folderScopes)
+		} else {
+			questions, err = h.service.GetSuggestedQuestions(ctx, id, kbIDs, knowledgeIDs, tagIDs, limit)
+		}
+	} else {
+		questions, err = h.service.GetSuggestedQuestions(ctx, id, kbIDs, knowledgeIDs, tagIDs, limit)
+	}
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"agent_id": id,

--- a/internal/handler/custom_agent_api_key_scope_test.go
+++ b/internal/handler/custom_agent_api_key_scope_test.go
@@ -15,7 +15,23 @@ import (
 
 type suggestedQuestionsAgentService struct {
 	interfaces.CustomAgentService
-	err error
+	err          error
+	folderScopes []types.FolderScope
+	kbIDs        []string
+}
+
+func (s *suggestedQuestionsAgentService) GetSuggestedQuestionsWithFolders(
+	_ context.Context,
+	_ string,
+	kbIDs []string,
+	_ []string,
+	_ []string,
+	_ int,
+	folderScopes []types.FolderScope,
+) ([]types.SuggestedQuestion, error) {
+	s.kbIDs = kbIDs
+	s.folderScopes = folderScopes
+	return nil, s.err
 }
 
 func (s *suggestedQuestionsAgentService) GetSuggestedQuestions(
@@ -27,6 +43,56 @@ func (s *suggestedQuestionsAgentService) GetSuggestedQuestions(
 	int,
 ) ([]types.SuggestedQuestion, error) {
 	return nil, s.err
+}
+
+func TestGetSuggestedQuestionsAcceptsSingleKBFolderIDs(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.ErrorHandler())
+	service := &suggestedQuestionsAgentService{}
+	h := &CustomAgentHandler{service: service}
+	r.GET("/agents/:id/suggested-questions", h.GetSuggestedQuestions)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/agents/agent-1/suggested-questions?knowledge_base_ids=kb-1&folder_ids=folder-a,folder-b",
+		nil,
+	)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if len(service.folderScopes) != 1 || service.folderScopes[0].KnowledgeBaseID != "kb-1" {
+		t.Fatalf("folder scopes = %#v", service.folderScopes)
+	}
+	if len(service.kbIDs) != 0 {
+		t.Fatalf("folder_ids shorthand must not also select the whole KB: %#v", service.kbIDs)
+	}
+	if got := service.folderScopes[0].FolderIDs; len(got) != 2 || got[0] != "folder-a" || got[1] != "folder-b" {
+		t.Fatalf("folder ids = %#v", got)
+	}
+}
+
+func TestGetSuggestedQuestionsRejectsAmbiguousFolderIDs(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.ErrorHandler())
+	h := &CustomAgentHandler{service: &suggestedQuestionsAgentService{}}
+	r.GET("/agents/:id/suggested-questions", h.GetSuggestedQuestions)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/agents/agent-1/suggested-questions?knowledge_base_ids=kb-1,kb-2&folder_ids=folder-a",
+		nil,
+	)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
 }
 
 func TestGetSuggestedQuestionsPreservesAppErrorStatus(t *testing.T) {

--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -241,6 +241,14 @@ func (h *KnowledgeHandler) handleDuplicateKnowledgeError(c *gin.Context,
 	return false
 }
 
+func handleKnowledgeFolderScopeError(c *gin.Context, err error) bool {
+	if goerrors.Is(err, repository.ErrKnowledgeFolderScopeMismatch) {
+		c.Error(errors.NewBadRequestError("folder does not belong to this knowledge base"))
+		return true
+	}
+	return false
+}
+
 // enqueueKnowledgeListDelete enqueues an async batch-delete task for the
 // given knowledge IDs and returns the asynq task ID.
 func (h *KnowledgeHandler) enqueueKnowledgeListDelete(
@@ -405,10 +413,14 @@ func (h *KnowledgeHandler) CreateKnowledgeFromFile(c *gin.Context) {
 	channel := c.PostForm("channel")
 
 	// Create knowledge entry from the file
+	ctx = context.WithValue(ctx, types.KnowledgeFolderIDContextKey, c.PostForm("folder_id"))
 	knowledge, err := h.kgService.CreateKnowledgeFromFile(ctx, kbID, file, metadata, enableMultimodel, customFileName, tagIDs, channel, processOverrides)
 	// Check for duplicate knowledge error
 	if err != nil {
 		if h.handleDuplicateKnowledgeError(c, err, knowledge, "file") {
+			return
+		}
+		if handleKnowledgeFolderScopeError(c, err) {
 			return
 		}
 		if appErr, ok := errors.IsAppError(err); ok {
@@ -474,6 +486,7 @@ func (h *KnowledgeHandler) CreateKnowledgeFromURL(c *gin.Context) {
 		TagIDs           []string                         `json:"tag_ids"`
 		Channel          string                           `json:"channel"`
 		ProcessConfig    *types.KnowledgeProcessOverrides `json:"process_config"`
+		FolderID         string                           `json:"folder_id"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		logger.Error(ctx, "Failed to parse URL request", err)
@@ -501,12 +514,16 @@ func (h *KnowledgeHandler) CreateKnowledgeFromURL(c *gin.Context) {
 	)
 
 	// Create knowledge entry from the URL
+	ctx = context.WithValue(ctx, types.KnowledgeFolderIDContextKey, req.FolderID)
 	knowledge, err := h.kgService.CreateKnowledgeFromURL(
 		ctx, kbID, req.URL, req.FileName, req.FileType, req.EnableMultimodel, req.Title, req.TagIDs, req.Channel, req.ProcessConfig,
 	)
 	// Check for duplicate knowledge error
 	if err != nil {
 		if h.handleDuplicateKnowledgeError(c, err, knowledge, "url") {
+			return
+		}
+		if handleKnowledgeFolderScopeError(c, err) {
 			return
 		}
 		if appErr, ok := errors.IsAppError(err); ok {
@@ -568,8 +585,12 @@ func (h *KnowledgeHandler) CreateManualKnowledge(c *gin.Context) {
 		return
 	}
 
+	ctx = context.WithValue(ctx, types.KnowledgeFolderIDContextKey, req.FolderID)
 	knowledge, err := h.kgService.CreateKnowledgeFromManual(ctx, kbID, &req, req.Channel)
 	if err != nil {
+		if handleKnowledgeFolderScopeError(c, err) {
+			return
+		}
 		if appErr, ok := errors.IsAppError(err); ok {
 			c.Error(appErr)
 			return
@@ -908,6 +929,13 @@ func (h *KnowledgeHandler) ListKnowledge(c *gin.Context) {
 		FileType:    c.Query("file_type"),
 		ParseStatus: c.Query("parse_status"),
 		Source:      c.Query("source"),
+	}
+	if folderID, ok := c.GetQuery("folder_id"); ok {
+		filter.FolderSet = true
+		if folderID != "root" {
+			filter.FolderID = folderID
+		}
+		filter.IncludeDescendants = c.Query("include_descendants") == "true"
 	}
 	if raw := c.Query("start_time"); raw != "" {
 		t, err := parseFilterTime(raw)

--- a/internal/handler/knowledge_folder.go
+++ b/internal/handler/knowledge_folder.go
@@ -1,0 +1,126 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/gin-gonic/gin"
+)
+
+type KnowledgeFolderHandler struct {
+	service interfaces.KnowledgeFolderService
+}
+
+func NewKnowledgeFolderHandler(service interfaces.KnowledgeFolderService) *KnowledgeFolderHandler {
+	return &KnowledgeFolderHandler{service: service}
+}
+
+func (h *KnowledgeFolderHandler) List(c *gin.Context) {
+	var page types.Pagination
+	if err := c.ShouldBindQuery(&page); err != nil {
+		c.Error(errors.NewBadRequestError("invalid pagination"))
+		return
+	}
+	result, err := h.service.List(c.Request.Context(), c.Param("id"), c.Query("parent_id"), c.Query("keyword"), &page)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
+}
+func (h *KnowledgeFolderHandler) Get(c *gin.Context) {
+	result, err := h.service.Get(c.Request.Context(), c.Param("id"), c.Param("folder_id"))
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
+}
+
+type createFolderRequest struct {
+	Name     string `json:"name" binding:"required"`
+	ParentID string `json:"parent_id"`
+}
+
+func (h *KnowledgeFolderHandler) Create(c *gin.Context) {
+	var req createFolderRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.Error(errors.NewBadRequestError(err.Error()))
+		return
+	}
+	result, err := h.service.Create(c.Request.Context(), c.Param("id"), req.ParentID, req.Name)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"success": true, "data": result})
+}
+
+type updateFolderRequest struct {
+	Name     *string `json:"name"`
+	ParentID *string `json:"parent_id"`
+}
+
+func (h *KnowledgeFolderHandler) Update(c *gin.Context) {
+	var req updateFolderRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.Error(errors.NewBadRequestError(err.Error()))
+		return
+	}
+	if req.Name == nil && req.ParentID == nil {
+		c.Error(errors.NewBadRequestError("name or parent_id is required"))
+		return
+	}
+	result, err := h.service.Update(c.Request.Context(), c.Param("id"), c.Param("folder_id"), req.Name, req.ParentID)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
+}
+func (h *KnowledgeFolderHandler) Delete(c *gin.Context) {
+	if err := h.service.Delete(c.Request.Context(), c.Param("id"), c.Param("folder_id")); err != nil {
+		c.Error(err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+type ensurePathsRequest struct {
+	ParentID string                   `json:"parent_id"`
+	Paths    []types.EnsureFolderPath `json:"paths" binding:"required"`
+}
+
+func (h *KnowledgeFolderHandler) EnsurePaths(c *gin.Context) {
+	var req ensurePathsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.Error(errors.NewBadRequestError(err.Error()))
+		return
+	}
+	result, err := h.service.EnsurePaths(c.Request.Context(), c.Param("id"), req.ParentID, req.Paths)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
+}
+
+type moveKnowledgeFolderRequest struct {
+	KnowledgeIDs []string `json:"knowledge_ids" binding:"required"`
+	FolderID     string   `json:"folder_id"`
+}
+
+func (h *KnowledgeFolderHandler) MoveKnowledge(c *gin.Context) {
+	var req moveKnowledgeFolderRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.Error(errors.NewBadRequestError(err.Error()))
+		return
+	}
+	if err := h.service.MoveKnowledge(c.Request.Context(), c.Param("id"), req.KnowledgeIDs, req.FolderID); err != nil {
+		c.Error(err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}

--- a/internal/handler/knowledge_folder_test.go
+++ b/internal/handler/knowledge_folder_test.go
@@ -1,0 +1,142 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type folderHandlerServiceStub struct {
+	interfaces.KnowledgeFolderService
+	method       string
+	kbID         string
+	folderID     string
+	parentID     string
+	keyword      string
+	name         string
+	page         types.Pagination
+	paths        []types.EnsureFolderPath
+	knowledgeIDs []string
+}
+
+func (s *folderHandlerServiceStub) List(_ context.Context, kbID, parentID, keyword string, page *types.Pagination) (*types.PageResult, error) {
+	s.method, s.kbID, s.parentID, s.keyword, s.page = "list", kbID, parentID, keyword, *page
+	return &types.PageResult{Total: 1, Page: page.GetPage(), PageSize: page.GetPageSize(), Data: []*types.KnowledgeFolderView{}}, nil
+}
+func (s *folderHandlerServiceStub) Get(_ context.Context, kbID, folderID string) (*types.KnowledgeFolderView, error) {
+	s.method, s.kbID, s.folderID = "get", kbID, folderID
+	return &types.KnowledgeFolderView{KnowledgeFolder: types.KnowledgeFolder{ID: folderID, KnowledgeBaseID: kbID}}, nil
+}
+func (s *folderHandlerServiceStub) Create(_ context.Context, kbID, parentID, name string) (*types.KnowledgeFolder, error) {
+	s.method, s.kbID, s.parentID, s.name = "create", kbID, parentID, name
+	return &types.KnowledgeFolder{ID: "created", KnowledgeBaseID: kbID, ParentID: parentID, Name: name}, nil
+}
+func (s *folderHandlerServiceStub) Update(_ context.Context, kbID, folderID string, name, parentID *string) (*types.KnowledgeFolder, error) {
+	s.method, s.kbID, s.folderID = "update", kbID, folderID
+	if name != nil {
+		s.name = *name
+	}
+	if parentID != nil {
+		s.parentID = *parentID
+	}
+	return &types.KnowledgeFolder{ID: folderID, KnowledgeBaseID: kbID, ParentID: s.parentID, Name: s.name}, nil
+}
+func (s *folderHandlerServiceStub) Delete(_ context.Context, kbID, folderID string) error {
+	s.method, s.kbID, s.folderID = "delete", kbID, folderID
+	return nil
+}
+func (s *folderHandlerServiceStub) EnsurePaths(_ context.Context, kbID, parentID string, paths []types.EnsureFolderPath) ([]types.EnsureFolderPathResult, error) {
+	s.method, s.kbID, s.parentID, s.paths = "ensure", kbID, parentID, paths
+	return []types.EnsureFolderPathResult{{ClientKey: paths[0].ClientKey, FolderID: "leaf"}}, nil
+}
+func (s *folderHandlerServiceStub) MoveKnowledge(_ context.Context, kbID string, knowledgeIDs []string, folderID string) error {
+	s.method, s.kbID, s.folderID, s.knowledgeIDs = "move", kbID, folderID, knowledgeIDs
+	return nil
+}
+
+func newFolderHandlerRouter(service interfaces.KnowledgeFolderService) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h := NewKnowledgeFolderHandler(service)
+	r.GET("/knowledge-bases/:id/folders", h.List)
+	r.POST("/knowledge-bases/:id/folders", h.Create)
+	r.POST("/knowledge-bases/:id/folders/ensure-paths", h.EnsurePaths)
+	r.GET("/knowledge-bases/:id/folders/:folder_id", h.Get)
+	r.PUT("/knowledge-bases/:id/folders/:folder_id", h.Update)
+	r.DELETE("/knowledge-bases/:id/folders/:folder_id", h.Delete)
+	r.PUT("/knowledge-bases/:id/knowledge/folder", h.MoveKnowledge)
+	return r
+}
+
+func performFolderRequest(t *testing.T, router http.Handler, method, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var payload []byte
+	if body != nil {
+		var err error
+		payload, err = json.Marshal(body)
+		require.NoError(t, err)
+	}
+	req := httptest.NewRequest(method, path, bytes.NewReader(payload))
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func TestKnowledgeFolderHandlerContracts(t *testing.T) {
+	service := &folderHandlerServiceStub{}
+	router := newFolderHandlerRouter(service)
+
+	response := performFolderRequest(t, router, http.MethodGet, "/knowledge-bases/kb-1/folders?parent_id=parent-1&keyword=report&page=3&page_size=25", nil)
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, "list", service.method)
+	require.Equal(t, "parent-1", service.parentID)
+	require.Equal(t, "report", service.keyword)
+	require.Equal(t, types.Pagination{Page: 3, PageSize: 25}, service.page)
+
+	response = performFolderRequest(t, router, http.MethodPost, "/knowledge-bases/kb-1/folders", map[string]any{"name": "Reports", "parent_id": "parent-1"})
+	require.Equal(t, http.StatusCreated, response.Code)
+	require.Equal(t, "create", service.method)
+	require.Equal(t, "Reports", service.name)
+
+	response = performFolderRequest(t, router, http.MethodGet, "/knowledge-bases/kb-1/folders/folder-1", nil)
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, "get", service.method)
+	require.Equal(t, "folder-1", service.folderID)
+
+	response = performFolderRequest(t, router, http.MethodPut, "/knowledge-bases/kb-1/folders/folder-1", map[string]any{"name": "Renamed", "parent_id": "parent-2"})
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, "update", service.method)
+	require.Equal(t, "Renamed", service.name)
+	require.Equal(t, "parent-2", service.parentID)
+
+	response = performFolderRequest(t, router, http.MethodPost, "/knowledge-bases/kb-1/folders/ensure-paths", map[string]any{
+		"parent_id": "parent-1", "paths": []map[string]any{{"client_key": "docs", "segments": []string{"2026", "Q3"}}},
+	})
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, "ensure", service.method)
+	require.Len(t, service.paths, 1)
+	require.Equal(t, []string{"2026", "Q3"}, service.paths[0].Segments)
+
+	response = performFolderRequest(t, router, http.MethodPut, "/knowledge-bases/kb-1/knowledge/folder", map[string]any{
+		"knowledge_ids": []string{"doc-1", "doc-2"}, "folder_id": "folder-2",
+	})
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, "move", service.method)
+	require.Equal(t, []string{"doc-1", "doc-2"}, service.knowledgeIDs)
+	require.Equal(t, "folder-2", service.folderID)
+
+	response = performFolderRequest(t, router, http.MethodDelete, "/knowledge-bases/kb-1/folders/folder-1", nil)
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, "delete", service.method)
+}

--- a/internal/handler/knowledge_folder_upload_test.go
+++ b/internal/handler/knowledge_folder_upload_test.go
@@ -1,0 +1,74 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type folderUploadKnowledgeServiceStub struct {
+	interfaces.KnowledgeService
+	folderID string
+	kbID     string
+}
+
+func (s *folderUploadKnowledgeServiceStub) CreateKnowledgeFromFile(
+	ctx context.Context,
+	kbID string,
+	_ *multipart.FileHeader,
+	_ map[string]string,
+	_ *bool,
+	_ string,
+	_ []string,
+	_ string,
+	_ *types.KnowledgeProcessOverrides,
+) (*types.Knowledge, error) {
+	s.kbID = kbID
+	s.folderID, _ = ctx.Value(types.KnowledgeFolderIDContextKey).(string)
+	return &types.Knowledge{ID: "doc-1", KnowledgeBaseID: kbID, FolderID: s.folderID, Title: "document.txt"}, nil
+}
+
+type folderUploadKBServiceStub struct {
+	interfaces.KnowledgeBaseService
+}
+
+func (s *folderUploadKBServiceStub) GetKnowledgeBaseByID(context.Context, string) (*types.KnowledgeBase, error) {
+	return &types.KnowledgeBase{ID: "kb-1", TenantID: 9, Type: types.KnowledgeBaseTypeDocument}, nil
+}
+
+func TestCreateKnowledgeFromFileForwardsFolderID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	knowledgeService := &folderUploadKnowledgeServiceStub{}
+	h := NewKnowledgeHandler(nil, knowledgeService, &folderUploadKBServiceStub{}, nil, nil, nil, nil)
+	router := gin.New()
+	router.POST("/knowledge-bases/:id/knowledge/file", func(c *gin.Context) {
+		c.Set(types.TenantIDContextKey.String(), uint64(9))
+		h.CreateKnowledgeFromFile(c)
+	})
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	filePart, err := writer.CreateFormFile("file", "document.txt")
+	require.NoError(t, err)
+	_, err = filePart.Write([]byte("folder upload"))
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteField("folder_id", "folder-7"))
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/knowledge-bases/kb-1/knowledge/file", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, "kb-1", knowledgeService.kbID)
+	require.Equal(t, "folder-7", knowledgeService.folderID)
+}

--- a/internal/handler/session/helpers.go
+++ b/internal/handler/session/helpers.go
@@ -98,6 +98,62 @@ func tagScopesFromMentionedItems(items []MentionedItemRequest) []types.TagScope 
 	return scopes
 }
 
+func folderScopesFromMentionedItems(items []MentionedItemRequest) []types.FolderScope {
+	byKB := make(map[string][]string)
+	seen := make(map[string]map[string]bool)
+	for _, item := range items {
+		if item.Type != "folder" || item.ID == "" || item.KBID == "" {
+			continue
+		}
+		if seen[item.KBID] == nil {
+			seen[item.KBID] = make(map[string]bool)
+		}
+		if !seen[item.KBID][item.ID] {
+			seen[item.KBID][item.ID] = true
+			byKB[item.KBID] = append(byKB[item.KBID], item.ID)
+		}
+	}
+	result := make([]types.FolderScope, 0, len(byKB))
+	for kbID, ids := range byKB {
+		result = append(result, types.FolderScope{KnowledgeBaseID: kbID, FolderIDs: ids})
+	}
+	return result
+}
+
+func mergeFolderScopes(scopeGroups ...[]types.FolderScope) []types.FolderScope {
+	result := make([]types.FolderScope, 0)
+	indexByKB := make(map[string]int)
+	seenByKB := make(map[string]map[string]bool)
+	for _, scopes := range scopeGroups {
+		for _, scope := range scopes {
+			if scope.KnowledgeBaseID == "" {
+				continue
+			}
+			index, exists := indexByKB[scope.KnowledgeBaseID]
+			if !exists {
+				index = len(result)
+				indexByKB[scope.KnowledgeBaseID] = index
+				seenByKB[scope.KnowledgeBaseID] = make(map[string]bool)
+				result = append(result, types.FolderScope{KnowledgeBaseID: scope.KnowledgeBaseID})
+			}
+			for _, folderID := range scope.FolderIDs {
+				if folderID == "" || seenByKB[scope.KnowledgeBaseID][folderID] {
+					continue
+				}
+				seenByKB[scope.KnowledgeBaseID][folderID] = true
+				result[index].FolderIDs = append(result[index].FolderIDs, folderID)
+			}
+		}
+	}
+	filtered := result[:0]
+	for _, scope := range result {
+		if len(scope.FolderIDs) > 0 {
+			filtered = append(filtered, scope)
+		}
+	}
+	return filtered
+}
+
 // orphanTagIDsForScope returns tag IDs from the request that are not already
 // covered by scoped mentions.
 func orphanTagIDsForScope(tagIDs []string, scopes []types.TagScope) []string {

--- a/internal/handler/session/helpers_test.go
+++ b/internal/handler/session/helpers_test.go
@@ -52,3 +52,20 @@ func TestValidateUnscopedTagIDs(t *testing.T) {
 	assert.Error(t, validateUnscopedTagIDs([]string{"tag-9"}, []string{"kb-1", "kb-2"}))
 	assert.Error(t, validateUnscopedTagIDs([]string{"tag-9"}, nil))
 }
+
+func TestMergeFolderScopesGroupsByKBAndDeduplicatesRequestAndMentions(t *testing.T) {
+	scopes := mergeFolderScopes(
+		[]types.FolderScope{
+			{KnowledgeBaseID: "kb-1", FolderIDs: []string{"folder-a", "folder-a"}},
+			{KnowledgeBaseID: "kb-2", FolderIDs: []string{"folder-c"}},
+		},
+		[]types.FolderScope{
+			{KnowledgeBaseID: "kb-1", FolderIDs: []string{"folder-a", "folder-b"}},
+			{KnowledgeBaseID: "", FolderIDs: []string{"ignored"}},
+		},
+	)
+	assert.Equal(t, []types.FolderScope{
+		{KnowledgeBaseID: "kb-1", FolderIDs: []string{"folder-a", "folder-b"}},
+		{KnowledgeBaseID: "kb-2", FolderIDs: []string{"folder-c"}},
+	}, scopes)
+}

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -33,6 +33,7 @@ type qaRequestContext struct {
 	knowledgeBaseIDs      []string
 	knowledgeIDs          []string
 	tagScopes             []types.TagScope
+	folderScopes          []types.FolderScope
 	tagIDs                []string
 	mcpServiceIDs         []string
 	skillNames            []string
@@ -66,6 +67,7 @@ func (rc *qaRequestContext) buildQARequest() *types.QARequest {
 		KnowledgeBaseIDs:   rc.knowledgeBaseIDs,
 		KnowledgeIDs:       rc.knowledgeIDs,
 		TagScopes:          rc.tagScopes,
+		FolderScopes:       rc.folderScopes,
 		MCPServiceIDs:      rc.mcpServiceIDs,
 		SkillNames:         rc.skillNames,
 		ImageURLs:          imageURLs,
@@ -136,7 +138,12 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 
 	// Merge @mentioned items into knowledge_base_ids and knowledge_ids
 	kbIDs, knowledgeIDs := mergeKnowledgeTargets(request.KnowledgeBaseIDs, request.KnowledgeIds, request.MentionedItems)
-	if err := types.AuthorizeTenantAPIKeyKnowledgeTargets(ctx, kbIDs, knowledgeIDs); err != nil {
+	folderScopes := mergeFolderScopes(request.FolderScopes, folderScopesFromMentionedItems(request.MentionedItems))
+	authorizationKBIDs := append([]string(nil), kbIDs...)
+	for _, scope := range folderScopes {
+		authorizationKBIDs = append(authorizationKBIDs, scope.KnowledgeBaseID)
+	}
+	if err := types.AuthorizeTenantAPIKeyKnowledgeTargets(ctx, authorizationKBIDs, knowledgeIDs); err != nil {
 		return nil, nil, err
 	}
 
@@ -274,6 +281,7 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 		secutils.SanitizeForLogArray(kbIDs),
 		secutils.SanitizeForLogArray(knowledgeIDs),
 		secutils.SanitizeForLogArray(tagIDs),
+		folderScopes,
 		secutils.SanitizeForLogArray(mcpServiceIDs),
 		secutils.SanitizeForLogArray(skillNames),
 		request.WebSearchEnabled,
@@ -303,6 +311,7 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 		knowledgeBaseIDs:      secutils.SanitizeForLogArray(kbIDs),
 		knowledgeIDs:          secutils.SanitizeForLogArray(knowledgeIDs),
 		tagScopes:             tagScopes,
+		folderScopes:          folderScopes,
 		tagIDs:                secutils.SanitizeForLogArray(tagIDs),
 		mcpServiceIDs:         secutils.SanitizeForLogArray(mcpServiceIDs),
 		skillNames:            secutils.SanitizeForLogArray(skillNames),
@@ -330,6 +339,7 @@ func buildMessageExecutionContext(
 	knowledgeBaseIDs []string,
 	knowledgeIDs []string,
 	tagIDs []string,
+	folderScopes []types.FolderScope,
 	mcpServiceIDs []string,
 	skillNames []string,
 	webSearchEnabled bool,
@@ -343,6 +353,7 @@ func buildMessageExecutionContext(
 		KnowledgeBaseIDs: knowledgeBaseIDs,
 		KnowledgeIDs:     knowledgeIDs,
 		TagIDs:           tagIDs,
+		FolderScopes:     folderScopes,
 		MCPServiceIDs:    mcpServiceIDs,
 		SkillNames:       skillNames,
 		WebSearchEnabled: webSearchEnabled,
@@ -376,12 +387,14 @@ func buildMessageExecutionContext(
 		KnowledgeBaseIDs    []string                        `json:"knowledge_base_ids,omitempty"`
 		KnowledgeIDs        []string                        `json:"knowledge_ids,omitempty"`
 		TagIDs              []string                        `json:"tag_ids,omitempty"`
+		FolderScopes        []types.FolderScope             `json:"folder_scopes,omitempty"`
 		ModelID             string                          `json:"model_id,omitempty"`
 	}{
 		QuestionSuggestions: snapshot.QuestionSuggestions,
 		KnowledgeBaseIDs:    knowledgeBaseIDs,
 		KnowledgeIDs:        knowledgeIDs,
 		TagIDs:              tagIDs,
+		FolderScopes:        folderScopes,
 		ModelID:             modelID,
 	}
 	if encoded, err := json.Marshal(hashInput); err == nil {
@@ -625,13 +638,18 @@ func (h *Handler) SearchKnowledge(c *gin.Context) {
 		return
 	}
 	tagScopes := mergeTagScopesFromRequestIDs(mentionScopes, requestTagIDs, secutils.SanitizeForLogArray(knowledgeBaseIDs))
+	folderScopes := mergeFolderScopes(request.FolderScopes, folderScopesFromMentionedItems(request.MentionedItems))
 
-	if len(knowledgeBaseIDs) == 0 && len(request.KnowledgeIDs) == 0 && len(tagScopes) == 0 {
+	if len(knowledgeBaseIDs) == 0 && len(request.KnowledgeIDs) == 0 && len(tagScopes) == 0 && len(folderScopes) == 0 {
 		logger.Error(ctx, "No knowledge base IDs, knowledge IDs, or tag scopes provided")
 		c.Error(errors.NewBadRequestError("At least one knowledge_base_id, knowledge_base_ids, knowledge_ids, or scoped tag must be provided"))
 		return
 	}
-	if err := types.AuthorizeTenantAPIKeyKnowledgeTargets(ctx, knowledgeBaseIDs, request.KnowledgeIDs); err != nil {
+	authKBIDs := append([]string(nil), knowledgeBaseIDs...)
+	for _, scope := range folderScopes {
+		authKBIDs = append(authKBIDs, scope.KnowledgeBaseID)
+	}
+	if err := types.AuthorizeTenantAPIKeyKnowledgeTargets(ctx, authKBIDs, request.KnowledgeIDs); err != nil {
 		c.Error(err)
 		return
 	}
@@ -646,7 +664,7 @@ func (h *Handler) SearchKnowledge(c *gin.Context) {
 	)
 
 	// Directly call knowledge retrieval service without LLM summarization
-	searchResults, err := h.sessionService.SearchKnowledge(ctx, knowledgeBaseIDs, request.KnowledgeIDs, tagScopes, request.Query)
+	searchResults, err := h.sessionService.SearchKnowledge(ctx, knowledgeBaseIDs, request.KnowledgeIDs, tagScopes, request.Query, folderScopes)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(errors.NewInternalServerError(err.Error()))
@@ -1020,6 +1038,7 @@ func (h *Handler) persistLastRequestState(parentCtx context.Context, reqCtx *qaR
 		KnowledgeBaseIDs: reqCtx.knowledgeBaseIDs,
 		KnowledgeIDs:     reqCtx.knowledgeIDs,
 		TagIDs:           reqCtx.tagIDs,
+		FolderScopes:     reqCtx.folderScopes,
 		MCPServiceIDs:    reqCtx.mcpServiceIDs,
 		SkillNames:       reqCtx.skillNames,
 		MentionedItems:   reqCtx.mentionedItems,

--- a/internal/handler/session/qa_execution_context_test.go
+++ b/internal/handler/session/qa_execution_context_test.go
@@ -1,0 +1,43 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateKnowledgeQARequestDecodesFolderScopesAndSuggestionAttribution(t *testing.T) {
+	var request CreateKnowledgeQARequest
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"query":"What changed?",
+		"folder_scopes":[{"knowledge_base_id":"kb-1","folder_ids":["folder-1"]}],
+		"suggestion_attribution":{"suggestion_set_id":"set-1","question_id":"question-1"}
+	}`), &request))
+	assert.Equal(t, []types.FolderScope{{KnowledgeBaseID: "kb-1", FolderIDs: []string{"folder-1"}}}, request.FolderScopes)
+	require.NotNil(t, request.SuggestionAttribution)
+	assert.Equal(t, "set-1", request.SuggestionAttribution.SuggestionSetID)
+	assert.Equal(t, "question-1", request.SuggestionAttribution.QuestionID)
+}
+
+func TestBuildMessageExecutionContextStoresAndHashesFolderScopes(t *testing.T) {
+	agent := &types.CustomAgent{ID: "agent-1", TenantID: 7, Config: types.CustomAgentConfig{ModelID: "model-1"}}
+	scopes := []types.FolderScope{{KnowledgeBaseID: "kb-1", FolderIDs: []string{"folder-1"}}}
+	snapshot, agentID, tenantID, modelID := buildMessageExecutionContext(
+		context.Background(), agent, 0, "", []string{"kb-1"}, nil, []string{"tag-1"}, scopes, nil, nil, false,
+	)
+	assert.Equal(t, scopes, snapshot.FolderScopes)
+	assert.Equal(t, "agent-1", agentID)
+	assert.Equal(t, uint64(7), tenantID)
+	assert.Equal(t, "model-1", modelID)
+	assert.NotEmpty(t, snapshot.AgentConfigHash)
+
+	otherSnapshot, _, _, _ := buildMessageExecutionContext(
+		context.Background(), agent, 0, "", []string{"kb-1"}, nil, []string{"tag-1"},
+		[]types.FolderScope{{KnowledgeBaseID: "kb-1", FolderIDs: []string{"folder-2"}}}, nil, nil, false,
+	)
+	assert.NotEqual(t, snapshot.AgentConfigHash, otherSnapshot.AgentConfigHash)
+}

--- a/internal/handler/session/types.go
+++ b/internal/handler/session/types.go
@@ -52,6 +52,7 @@ type CreateKnowledgeQARequest struct {
 	MCPServiceIDs    []string               `json:"mcp_service_ids"`                       // Per-request MCP services selected via @mention
 	SkillNames       []string               `json:"skill_names"`                           // Per-request Skills selected via @mention
 	TagIDs           []string               `json:"tag_ids"`                               // @mentioned tag IDs (display/debug; scoped via MentionedItems)
+	FolderScopes     []types.FolderScope    `json:"folder_scopes"`                         // Recursive folder scopes
 	MentionedItems   []MentionedItemRequest `json:"mentioned_items"`                       // @mentioned knowledge bases and files
 	DisableTitle     bool                   `json:"disable_title"`                         // Whether to disable auto title generation
 	// EnableMemory is the per-request override for the memory feature.
@@ -86,6 +87,7 @@ type SearchKnowledgeRequest struct {
 	KnowledgeBaseIDs []string               `json:"knowledge_base_ids"`                    // IDs of knowledge bases to search (multi-KB support)
 	KnowledgeIDs     []string               `json:"knowledge_ids"`                         // IDs of specific knowledge (files) to search
 	TagIDs           []string               `json:"tag_ids"`                               // Tag IDs for filtering within a single KB
+	FolderScopes     []types.FolderScope    `json:"folder_scopes"`                         // Recursive folder scopes
 	MentionedItems   []MentionedItemRequest `json:"mentioned_items"`                       // Optional scoped tag mentions
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -49,6 +49,7 @@ type RouterParams struct {
 	AgentShareService            interfaces.AgentShareService
 	KBHandler                    *handler.KnowledgeBaseHandler
 	KnowledgeHandler             *handler.KnowledgeHandler
+	KnowledgeFolderHandler       *handler.KnowledgeFolderHandler
 	TenantHandler                *handler.TenantHandler
 	TenantService                interfaces.TenantService
 	TenantAPIKeyService          interfaces.TenantAPIKeyService
@@ -219,6 +220,7 @@ func NewRouter(params RouterParams) *gin.Engine {
 		// /files route cannot serve because it enforces same-tenant paths.
 		serveKBScopedFiles(v1, rbacGuards, params.TenantService, params.FileService)
 		RegisterKnowledgeTagRoutes(v1, params.TagHandler, rbacGuards)
+		RegisterKnowledgeFolderRoutes(v1, params.KnowledgeFolderHandler, rbacGuards)
 		RegisterKnowledgeRoutes(v1, params.KnowledgeHandler, rbacGuards)
 		RegisterFAQRoutes(v1, params.FAQHandler, rbacGuards)
 		RegisterChunkRoutes(v1, params.ChunkHandler, rbacGuards)
@@ -253,6 +255,25 @@ func NewRouter(params RouterParams) *gin.Engine {
 	}
 
 	return r
+}
+
+// RegisterKnowledgeFolderRoutes exposes document-folder subresources. Reads
+// accept Viewer access; every mutation uses the same ownership and Editor
+// checks as document ingestion.
+func RegisterKnowledgeFolderRoutes(r *gin.RouterGroup, h *handler.KnowledgeFolderHandler, g *rbacGuards) {
+	if h == nil {
+		return
+	}
+	group := g.apiKeyGroup(r.Group("/knowledge-bases/:id/folders"), apiKeyIngest(apiKeyFullAccess()))
+	read := group.With(apiKeyRetrieve(apiKeyFullAccess()))
+	read.GET("", g.Viewer(), g.KBAccessRead("id"), h.List)
+	read.GET("/:folder_id", g.Viewer(), g.KBAccessRead("id"), h.Get)
+	group.POST("", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), h.Create)
+	group.POST("/ensure-paths", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), h.EnsurePaths)
+	group.PUT("/:folder_id", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), h.Update)
+	group.DELETE("/:folder_id", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), h.Delete)
+	knowledge := g.apiKeyGroup(r.Group("/knowledge-bases/:id/knowledge"), apiKeyIngest(apiKeyFullAccess()))
+	knowledge.PUT("/folder", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), h.MoveKnowledge)
 }
 
 // RegisterChunkerDebugRoutes wires the read-only chunker preview endpoint

--- a/internal/router/router_api_key_capabilities_test.go
+++ b/internal/router/router_api_key_capabilities_test.go
@@ -237,6 +237,7 @@ func TestKnowledgeReadRoutesDeclareRetrieveCapability(t *testing.T) {
 	RegisterChatRoutes(v1, &sessionhandler.Handler{}, g)
 	RegisterInitializationRoutes(v1, &handler.InitializationHandler{}, g)
 	RegisterWikiPageRoutes(v1, &handler.WikiPageHandler{}, g)
+	RegisterKnowledgeFolderRoutes(v1, handler.NewKnowledgeFolderHandler(nil), g)
 
 	cases := []struct {
 		method string
@@ -252,6 +253,8 @@ func TestKnowledgeReadRoutesDeclareRetrieveCapability(t *testing.T) {
 		{http.MethodPost, "/api/v1/knowledge-search"},
 		{http.MethodGet, "/api/v1/initialization/config/:kbId"},
 		{http.MethodGet, "/api/v1/knowledgebase/:kb_id/wiki/pages"},
+		{http.MethodGet, "/api/v1/knowledge-bases/:id/folders"},
+		{http.MethodGet, "/api/v1/knowledge-bases/:id/folders/:folder_id"},
 	}
 
 	for _, tc := range cases {

--- a/internal/router/router_knowledge_folder_test.go
+++ b/internal/router/router_knowledge_folder_test.go
@@ -1,0 +1,223 @@
+package router
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	apprepo "github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/handler"
+	"github.com/Tencent/WeKnora/internal/middleware"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type folderRouteServiceStub struct {
+	interfaces.KnowledgeFolderService
+}
+
+func (s *folderRouteServiceStub) List(
+	_ context.Context, _ string, _ string, _ string, page *types.Pagination,
+) (*types.PageResult, error) {
+	return types.NewPageResult(0, page, []*types.KnowledgeFolderView{}), nil
+}
+
+func (s *folderRouteServiceStub) Create(
+	_ context.Context, kbID string, parentID string, name string,
+) (*types.KnowledgeFolder, error) {
+	return &types.KnowledgeFolder{
+		ID: "folder-created", KnowledgeBaseID: kbID, ParentID: parentID, Name: name,
+	}, nil
+}
+
+type folderRouteKBShareStub struct {
+	interfaces.KBShareService
+	permission types.OrgMemberRole
+	source     uint64
+}
+
+func (s *folderRouteKBShareStub) CheckTenantKBPermission(
+	context.Context, string, uint64, types.TenantRole,
+) (types.OrgMemberRole, bool, error) {
+	return s.permission, true, nil
+}
+
+func (s *folderRouteKBShareStub) GetKBSourceTenant(context.Context, string) (uint64, error) {
+	return s.source, nil
+}
+
+func newKnowledgeFolderRouteTestEngine(
+	t *testing.T,
+	callerTenantID uint64,
+	role types.TenantRole,
+	userID string,
+	kbLookup *stubWikiKBLookup,
+	shareService interfaces.KBShareService,
+	apiKeyScope *types.TenantAPIKeyScope,
+) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	enabled := true
+	guards := &rbacGuards{
+		cfg:            &config.Config{Tenant: &config.TenantConfig{EnableRBAC: &enabled}},
+		kbService:      kbLookup,
+		kbShareService: shareService,
+	}
+	guards.kbCreator = func(c *gin.Context) (string, error) {
+		kb, err := kbLookup.GetKnowledgeBaseByID(c.Request.Context(), c.Param("id"))
+		if err != nil {
+			if err == apprepo.ErrKnowledgeBaseNotFound {
+				return "", middleware.ErrResourceNotFound
+			}
+			return "", err
+		}
+		tenantID, _ := types.TenantIDFromContext(c.Request.Context())
+		if kb.TenantID != tenantID {
+			return "", middleware.ErrResourceNotFound
+		}
+		return kb.CreatorID, nil
+	}
+
+	r := gin.New()
+	r.Use(middleware.ErrorHandler())
+	r.Use(func(c *gin.Context) {
+		ctx := context.WithValue(c.Request.Context(), types.TenantIDContextKey, callerTenantID)
+		ctx = context.WithValue(ctx, types.TenantRoleContextKey, role)
+		ctx = context.WithValue(ctx, types.UserIDContextKey, userID)
+		if apiKeyScope != nil {
+			ctx = types.WithTenantAPIKeyScope(ctx, *apiKeyScope)
+		}
+		c.Request = c.Request.WithContext(ctx)
+		c.Set(types.TenantIDContextKey.String(), callerTenantID)
+		c.Next()
+	})
+
+	h := handler.NewKnowledgeFolderHandler(&folderRouteServiceStub{})
+	RegisterKnowledgeFolderRoutes(r.Group("/api/v1"), h, guards)
+	return r
+}
+
+func performKnowledgeFolderRouteRequest(
+	t *testing.T, engine http.Handler, method string, path string, body string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(method, path, strings.NewReader(body))
+	if body != "" {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	engine.ServeHTTP(recorder, request)
+	return recorder
+}
+
+func TestKnowledgeFolderRoutesEnforceViewerAndSharedEditorPermissions(t *testing.T) {
+	ownedKBs := &stubWikiKBLookup{kbs: map[string]*types.KnowledgeBase{
+		"kb-owned": {ID: "kb-owned", TenantID: 1, CreatorID: "owner"},
+	}}
+
+	t.Run("viewer can read owned folders", func(t *testing.T) {
+		engine := newKnowledgeFolderRouteTestEngine(t, 1, types.TenantRoleViewer, "viewer", ownedKBs, nil, nil)
+		response := performKnowledgeFolderRouteRequest(t, engine, http.MethodGet, "/api/v1/knowledge-bases/kb-owned/folders", "")
+		require.Equal(t, http.StatusOK, response.Code, "body=%s", response.Body.String())
+	})
+
+	t.Run("viewer cannot create owned folders", func(t *testing.T) {
+		engine := newKnowledgeFolderRouteTestEngine(t, 1, types.TenantRoleViewer, "viewer", ownedKBs, nil, nil)
+		response := performKnowledgeFolderRouteRequest(t, engine, http.MethodPost, "/api/v1/knowledge-bases/kb-owned/folders", `{"name":"Reports","parent_id":""}`)
+		require.Equal(t, http.StatusForbidden, response.Code, "body=%s", response.Body.String())
+	})
+
+	sharedKBs := &stubWikiKBLookup{kbs: map[string]*types.KnowledgeBase{
+		"kb-shared": {ID: "kb-shared", TenantID: 9, CreatorID: "source-owner"},
+	}}
+
+	t.Run("shared viewer can read folders", func(t *testing.T) {
+		share := &folderRouteKBShareStub{permission: types.OrgRoleViewer, source: 9}
+		engine := newKnowledgeFolderRouteTestEngine(t, 1, types.TenantRoleViewer, "viewer", sharedKBs, share, nil)
+		response := performKnowledgeFolderRouteRequest(t, engine, http.MethodGet, "/api/v1/knowledge-bases/kb-shared/folders", "")
+		require.Equal(t, http.StatusOK, response.Code, "body=%s", response.Body.String())
+	})
+
+	t.Run("read-only share cannot create folders", func(t *testing.T) {
+		share := &folderRouteKBShareStub{permission: types.OrgRoleViewer, source: 9}
+		engine := newKnowledgeFolderRouteTestEngine(t, 1, types.TenantRoleContributor, "contributor", sharedKBs, share, nil)
+		response := performKnowledgeFolderRouteRequest(t, engine, http.MethodPost, "/api/v1/knowledge-bases/kb-shared/folders", `{"name":"Reports","parent_id":""}`)
+		require.Equal(t, http.StatusForbidden, response.Code, "body=%s", response.Body.String())
+	})
+
+	t.Run("editable share can create folders", func(t *testing.T) {
+		share := &folderRouteKBShareStub{permission: types.OrgRoleEditor, source: 9}
+		engine := newKnowledgeFolderRouteTestEngine(t, 1, types.TenantRoleContributor, "contributor", sharedKBs, share, nil)
+		response := performKnowledgeFolderRouteRequest(t, engine, http.MethodPost, "/api/v1/knowledge-bases/kb-shared/folders", `{"name":"Reports","parent_id":""}`)
+		require.Equal(t, http.StatusCreated, response.Code, "body=%s", response.Body.String())
+	})
+}
+
+func TestKnowledgeFolderRoutesRejectCrossTenantAndOutOfScopeAPIKeys(t *testing.T) {
+	foreignKBs := &stubWikiKBLookup{kbs: map[string]*types.KnowledgeBase{
+		"kb-foreign": {ID: "kb-foreign", TenantID: 9, CreatorID: "source-owner"},
+	}}
+	engine := newKnowledgeFolderRouteTestEngine(t, 1, types.TenantRoleViewer, "viewer", foreignKBs, nil, nil)
+	response := performKnowledgeFolderRouteRequest(t, engine, http.MethodGet, "/api/v1/knowledge-bases/kb-foreign/folders", "")
+	require.Equal(t, http.StatusForbidden, response.Code, "body=%s", response.Body.String())
+
+	ownedKBs := &stubWikiKBLookup{kbs: map[string]*types.KnowledgeBase{
+		"kb-allowed": {ID: "kb-allowed", TenantID: 1},
+		"kb-other":   {ID: "kb-other", TenantID: 1},
+	}}
+	scope := &types.TenantAPIKeyScope{
+		KnowledgeBaseIDs: types.StringArray{"kb-allowed"},
+		Capabilities:     types.StringArray{string(types.APIKeyCapabilityIngest), string(types.APIKeyCapabilityRetrieve)},
+	}
+	engine = newKnowledgeFolderRouteTestEngine(t, 1, types.TenantRoleViewer, "", ownedKBs, nil, scope)
+	for _, test := range []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{http.MethodGet, "/api/v1/knowledge-bases/kb-other/folders", ""},
+		{http.MethodPost, "/api/v1/knowledge-bases/kb-other/folders", `{"name":"Reports","parent_id":""}`},
+		{http.MethodPut, "/api/v1/knowledge-bases/kb-other/knowledge/folder", `{"knowledge_ids":["doc-1"],"folder_id":""}`},
+	} {
+		response = performKnowledgeFolderRouteRequest(t, engine, test.method, test.path, test.body)
+		require.Equal(t, http.StatusForbidden, response.Code, "%s %s body=%s", test.method, test.path, response.Body.String())
+	}
+}
+
+func TestKnowledgeFolderRoutesDeclareAPIKeyCapabilities(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	guards := &rbacGuards{}
+	RegisterKnowledgeFolderRoutes(
+		gin.New().Group("/api/v1"),
+		handler.NewKnowledgeFolderHandler(&folderRouteServiceStub{}),
+		guards,
+	)
+
+	for _, path := range []string{
+		"/api/v1/knowledge-bases/:id/folders",
+		"/api/v1/knowledge-bases/:id/folders/:folder_id",
+	} {
+		policy := mustLookupAPIKeyPolicy(t, guards, http.MethodGet, path)
+		require.True(t, policyHasCapability(policy, types.APIKeyCapabilityRetrieve))
+	}
+
+	for _, route := range []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/v1/knowledge-bases/:id/folders"},
+		{http.MethodPost, "/api/v1/knowledge-bases/:id/folders/ensure-paths"},
+		{http.MethodPut, "/api/v1/knowledge-bases/:id/folders/:folder_id"},
+		{http.MethodDelete, "/api/v1/knowledge-bases/:id/folders/:folder_id"},
+		{http.MethodPut, "/api/v1/knowledge-bases/:id/knowledge/folder"},
+	} {
+		policy := mustLookupAPIKeyPolicy(t, guards, route.method, route.path)
+		require.True(t, policyHasCapability(policy, types.APIKeyCapabilityIngest))
+	}
+}

--- a/internal/types/const.go
+++ b/internal/types/const.go
@@ -5,7 +5,8 @@ type ContextKey string
 
 const (
 	// TenantIDContextKey is the context key for tenant ID
-	TenantIDContextKey ContextKey = "TenantID"
+	TenantIDContextKey          ContextKey = "TenantID"
+	KnowledgeFolderIDContextKey ContextKey = "KnowledgeFolderID"
 	// TenantInfoContextKey is the context key for tenant information
 	TenantInfoContextKey ContextKey = "TenantInfo"
 	// RequestIDContextKey is the context key for request ID

--- a/internal/types/interfaces/knowledge.go
+++ b/internal/types/interfaces/knowledge.go
@@ -205,6 +205,9 @@ type KnowledgeService interface {
 // KnowledgeRepository defines the interface for knowledge repositories.
 type KnowledgeRepository interface {
 	CreateKnowledge(ctx context.Context, knowledge *types.Knowledge) error
+	// ValidateKnowledgeFolder verifies that a non-root folder belongs to the
+	// same tenant and knowledge base as the knowledge being created.
+	ValidateKnowledgeFolder(ctx context.Context, tenantID uint64, kbID, folderID string) error
 	GetKnowledgeByID(ctx context.Context, tenantID uint64, id string) (*types.Knowledge, error)
 	// GetKnowledgeByIDOnly returns knowledge by ID without tenant filter (for permission resolution).
 	GetKnowledgeByIDOnly(ctx context.Context, id string) (*types.Knowledge, error)
@@ -268,10 +271,13 @@ type KnowledgeRepository interface {
 	SearchKnowledgeInScopes(ctx context.Context, scopes []types.KnowledgeSearchScope, keyword string, offset, limit int, fileTypes []string) ([]*types.Knowledge, bool, int64, error)
 	// ListIDsByTagIDs returns all knowledge IDs that have any of the specified tag IDs (OR semantics).
 	ListIDsByTagIDs(ctx context.Context, tenantID uint64, kbID string, tagIDs []string) ([]string, error)
+	ListIDsByFolderIDs(ctx context.Context, tenantID uint64, kbID string, folderIDs []string) ([]string, error)
 	// SetKnowledgeTags replaces all tags for a single knowledge entry (deletes old, inserts new).
 	SetKnowledgeTags(ctx context.Context, knowledgeID string, tagIDs []string) error
 	// GetKnowledgeTags returns tags for multiple knowledge IDs.
 	GetKnowledgeTags(ctx context.Context, knowledgeIDs []string) (map[string][]*types.KnowledgeTag, error)
+	// UpdateKnowledgeFolderBatch moves all requested rows in one scoped UPDATE.
+	UpdateKnowledgeFolderBatch(ctx context.Context, tenantID uint64, kbID string, knowledgeIDs []string, folderID string) (int64, error)
 	// DeleteKnowledgeTagRelations deletes all tag relations for a knowledge entry.
 	DeleteKnowledgeTagRelations(ctx context.Context, knowledgeID string) error
 }

--- a/internal/types/interfaces/knowledge_folder.go
+++ b/internal/types/interfaces/knowledge_folder.go
@@ -1,0 +1,28 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+type KnowledgeFolderRepository interface {
+	List(ctx context.Context, tenantID uint64, kbID, parentID, keyword string, page *types.Pagination) ([]*types.KnowledgeFolderView, int64, error)
+	Get(ctx context.Context, tenantID uint64, kbID, folderID string) (*types.KnowledgeFolderView, error)
+	Create(ctx context.Context, tenantID uint64, kbID, parentID, name string) (*types.KnowledgeFolder, error)
+	Update(ctx context.Context, tenantID uint64, kbID, folderID string, name, parentID *string) (*types.KnowledgeFolder, error)
+	Delete(ctx context.Context, tenantID uint64, kbID, folderID string) error
+	EnsurePaths(ctx context.Context, tenantID uint64, kbID, parentID string, paths []types.EnsureFolderPath) ([]types.EnsureFolderPathResult, error)
+	MoveKnowledge(ctx context.Context, tenantID uint64, kbID string, knowledgeIDs []string, folderID string) error
+	ListKnowledgeIDsRecursive(ctx context.Context, tenantID uint64, kbID string, folderIDs []string) ([]string, error)
+}
+
+type KnowledgeFolderService interface {
+	List(ctx context.Context, kbID, parentID, keyword string, page *types.Pagination) (*types.PageResult, error)
+	Get(ctx context.Context, kbID, folderID string) (*types.KnowledgeFolderView, error)
+	Create(ctx context.Context, kbID, parentID, name string) (*types.KnowledgeFolder, error)
+	Update(ctx context.Context, kbID, folderID string, name, parentID *string) (*types.KnowledgeFolder, error)
+	Delete(ctx context.Context, kbID, folderID string) error
+	EnsurePaths(ctx context.Context, kbID, parentID string, paths []types.EnsureFolderPath) ([]types.EnsureFolderPathResult, error)
+	MoveKnowledge(ctx context.Context, kbID string, knowledgeIDs []string, folderID string) error
+}

--- a/internal/types/interfaces/session.go
+++ b/internal/types/interfaces/session.go
@@ -54,7 +54,7 @@ type SessionService interface {
 	// SearchKnowledge performs knowledge-based search, without summarization
 	// knowledgeBaseIDs: list of knowledge base IDs to search (supports multi-KB)
 	// knowledgeIDs: list of specific knowledge (file) IDs to search
-	SearchKnowledge(ctx context.Context, knowledgeBaseIDs []string, knowledgeIDs []string, tagScopes []types.TagScope, query string) ([]*types.SearchResult, error)
+	SearchKnowledge(ctx context.Context, knowledgeBaseIDs []string, knowledgeIDs []string, tagScopes []types.TagScope, query string, folderScopes ...[]types.FolderScope) ([]*types.SearchResult, error)
 	// AgentQA performs agent-based question answering with conversation history and streaming support.
 	AgentQA(ctx context.Context, req *types.QARequest, eventBus *event.EventBus) error
 }

--- a/internal/types/knowledge.go
+++ b/internal/types/knowledge.go
@@ -88,6 +88,12 @@ const (
 // KnowledgeListFilter aggregates optional filters for listing knowledge entries
 // under a knowledge base. Empty / zero fields mean "no filter on that dimension".
 type KnowledgeListFilter struct {
+	// FolderID filters by folder. When FolderSet is false, no folder filter is
+	// applied. An empty FolderID with FolderSet=true means the virtual root.
+	FolderID  string
+	FolderSet bool
+	// IncludeDescendants expands FolderID through knowledge_folder_closure.
+	IncludeDescendants bool
 	// TagIDs filters by multiple tags (OR semantics: match any of the given tags).
 	TagIDs []string
 	// Keyword performs a LIKE match on file_name / title when non-empty.
@@ -116,6 +122,8 @@ type Knowledge struct {
 	TenantID uint64 `json:"tenant_id"`
 	// ID of the knowledge base
 	KnowledgeBaseID string `json:"knowledge_base_id"`
+	// FolderID is empty for the virtual root. A knowledge belongs to exactly one folder.
+	FolderID string `json:"folder_id" gorm:"type:varchar(36);not null;default:''"`
 	// Tags holds the tags associated with this knowledge (populated on query, not persisted directly).
 	Tags []*KnowledgeTag `json:"tags"               gorm:"-"`
 	// Type of the knowledge
@@ -211,6 +219,13 @@ type ManualKnowledgePayload struct {
 	TagIDs        []string                   `json:"tag_ids"`
 	Channel       string                     `json:"channel"`
 	ProcessConfig *KnowledgeProcessOverrides `json:"process_config,omitempty"`
+	FolderID      string                     `json:"folder_id,omitempty"`
+}
+
+// FolderScope limits retrieval to one or more recursive folder subtrees in a KB.
+type FolderScope struct {
+	KnowledgeBaseID string   `json:"knowledge_base_id"`
+	FolderIDs       []string `json:"folder_ids"`
 }
 
 // KnowledgeSearchScope defines a (tenant_id, knowledge_base_id) scope for knowledge search (e.g. own KBs + shared KBs).

--- a/internal/types/knowledge_folder.go
+++ b/internal/types/knowledge_folder.go
@@ -1,0 +1,47 @@
+package types
+
+import "time"
+
+const MaxKnowledgeFolderDepth = 20
+
+// KnowledgeFolder is a persisted directory. The root directory is virtual and
+// represented by an empty parent/folder ID, never by a row in this table.
+type KnowledgeFolder struct {
+	ID              string    `json:"id" gorm:"type:varchar(36);primaryKey"`
+	TenantID        uint64    `json:"tenant_id" gorm:"not null;uniqueIndex:idx_knowledge_folder_sibling,priority:1"`
+	KnowledgeBaseID string    `json:"knowledge_base_id" gorm:"type:varchar(36);not null;uniqueIndex:idx_knowledge_folder_sibling,priority:2"`
+	ParentID        string    `json:"parent_id" gorm:"type:varchar(36);not null;default:'';uniqueIndex:idx_knowledge_folder_sibling,priority:3"`
+	Name            string    `json:"name" gorm:"type:varchar(100);not null;uniqueIndex:idx_knowledge_folder_sibling,priority:4"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+func (KnowledgeFolder) TableName() string { return "knowledge_folders" }
+
+type KnowledgeFolderClosure struct {
+	AncestorID   string `json:"ancestor_id" gorm:"type:varchar(36);primaryKey"`
+	DescendantID string `json:"descendant_id" gorm:"type:varchar(36);primaryKey"`
+	Depth        int    `json:"depth" gorm:"not null"`
+}
+
+func (KnowledgeFolderClosure) TableName() string { return "knowledge_folder_closure" }
+
+// KnowledgeFolderView is returned by folder list/detail APIs.
+type KnowledgeFolderView struct {
+	KnowledgeFolder
+	Ancestors            []*KnowledgeFolder `json:"ancestors,omitempty" gorm:"-"`
+	DirectKnowledgeCount int64              `json:"direct_knowledge_count" gorm:"-"`
+	TotalKnowledgeCount  int64              `json:"total_knowledge_count" gorm:"-"`
+	ChildFolderCount     int64              `json:"child_folder_count" gorm:"-"`
+	HasChildren          bool               `json:"has_children" gorm:"-"`
+}
+
+type EnsureFolderPath struct {
+	ClientKey string   `json:"client_key" binding:"required"`
+	Segments  []string `json:"segments" binding:"required"`
+}
+
+type EnsureFolderPathResult struct {
+	ClientKey string `json:"client_key"`
+	FolderID  string `json:"folder_id"`
+}

--- a/internal/types/message.go
+++ b/internal/types/message.go
@@ -26,7 +26,7 @@ type History struct {
 type MentionedItem struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`
-	Type      string `json:"type"`       // "kb", "file", "tag", "mcp", "skill"
+	Type      string `json:"type"`       // "kb", "file", "folder", "tag", "mcp", "skill"
 	KBType    string `json:"kb_type"`    // "document" or "faq" (only for kb type)
 	KBID      string `json:"kb_id"`      // Parent knowledge base for file/tag mentions
 	KBName    string `json:"kb_name"`    // Display name for parent KB
@@ -247,6 +247,7 @@ type MessageExecutionContext struct {
 	KnowledgeBaseIDs      []string                  `json:"knowledge_base_ids,omitempty"`
 	KnowledgeIDs          []string                  `json:"knowledge_ids,omitempty"`
 	TagIDs                []string                  `json:"tag_ids,omitempty"`
+	FolderScopes          []FolderScope             `json:"folder_scopes,omitempty"`
 	MCPServiceIDs         []string                  `json:"mcp_service_ids,omitempty"`
 	SkillNames            []string                  `json:"skill_names,omitempty"`
 	WebSearchEnabled      bool                      `json:"web_search_enabled"`

--- a/internal/types/message_execution_context_test.go
+++ b/internal/types/message_execution_context_test.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageExecutionContextRoundTripsFolderScopes(t *testing.T) {
+	want := []FolderScope{{KnowledgeBaseID: "kb-1", FolderIDs: []string{"folder-a", "folder-b"}}}
+	context := MessageExecutionContext{FolderScopes: want}
+	encoded, err := context.Value()
+	require.NoError(t, err)
+
+	var decoded MessageExecutionContext
+	require.NoError(t, decoded.Scan(encoded))
+	assert.Equal(t, want, decoded.FolderScopes)
+}
+
+func TestMessageExecutionContextScansLegacyPayloadWithoutFolderScopes(t *testing.T) {
+	var context MessageExecutionContext
+	require.NoError(t, context.Scan(`{"knowledge_base_ids":["kb-1"],"tag_ids":["tag-1"]}`))
+	assert.Equal(t, []string{"kb-1"}, context.KnowledgeBaseIDs)
+	assert.Equal(t, []string{"tag-1"}, context.TagIDs)
+	assert.Empty(t, context.FolderScopes)
+}

--- a/internal/types/qa_request.go
+++ b/internal/types/qa_request.go
@@ -12,6 +12,7 @@ type QARequest struct {
 	KnowledgeBaseIDs   []string           // Knowledge base IDs to search (from request + @mentions)
 	KnowledgeIDs       []string           // Specific knowledge (file) IDs to search
 	TagScopes          []TagScope         // Tag-constrained KB scopes from @mentions
+	FolderScopes       []FolderScope      // Recursive folder-constrained KB scopes
 	MCPServiceIDs      []string           // Per-request MCP service IDs from @mentions
 	SkillNames         []string           // Per-request preloaded skill names from @mentions
 	ImageURLs          []string           // Image URLs for multimodal input

--- a/internal/types/session.go
+++ b/internal/types/session.go
@@ -205,6 +205,7 @@ type SessionLastRequestState struct {
 	KnowledgeBaseIDs []string       `json:"knowledge_base_ids,omitempty"`
 	KnowledgeIDs     []string       `json:"knowledge_ids,omitempty"`
 	TagIDs           []string       `json:"tag_ids,omitempty"`
+	FolderScopes     []FolderScope  `json:"folder_scopes,omitempty"`
 	MCPServiceIDs    []string       `json:"mcp_service_ids,omitempty"`
 	SkillNames       []string       `json:"skill_names,omitempty"`
 	MentionedItems   MentionedItems `json:"mentioned_items,omitempty"`

--- a/internal/types/session_folder_state_test.go
+++ b/internal/types/session_folder_state_test.go
@@ -1,0 +1,47 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionLastRequestStateScansFolderScopesAndFolderMentions(t *testing.T) {
+	payload := `{
+		"agent_id":"agent-1",
+		"folder_scopes":[{"knowledge_base_id":"kb-1","folder_ids":["folder-a","folder-b"]}],
+		"mentioned_items":[{"id":"folder-a","name":"Plans","type":"folder","kb_id":"kb-1","kb_name":"Documents"}]
+	}`
+	var state SessionLastRequestState
+	require.NoError(t, state.Scan([]byte(payload)))
+	require.Equal(t, []FolderScope{{KnowledgeBaseID: "kb-1", FolderIDs: []string{"folder-a", "folder-b"}}}, state.FolderScopes)
+	require.Len(t, state.MentionedItems, 1)
+	assert.Equal(t, "folder", state.MentionedItems[0].Type)
+	assert.Equal(t, "folder-a", state.MentionedItems[0].ID)
+	assert.Equal(t, "kb-1", state.MentionedItems[0].KBID)
+
+	encoded, err := state.Value()
+	require.NoError(t, err)
+	bytes, ok := encoded.([]byte)
+	require.True(t, ok)
+	var roundTrip map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(bytes, &roundTrip))
+	assert.Contains(t, roundTrip, "folder_scopes")
+	assert.Contains(t, roundTrip, "mentioned_items")
+}
+
+func TestSessionLastRequestStateKeepsLegacyPayloadCompatible(t *testing.T) {
+	var state SessionLastRequestState
+	require.NoError(t, state.Scan(`{"agent_id":"legacy-agent","knowledge_base_ids":["kb-1"],"web_search_enabled":true}`))
+	assert.Equal(t, "legacy-agent", state.AgentID)
+	assert.Equal(t, []string{"kb-1"}, state.KnowledgeBaseIDs)
+	assert.True(t, state.WebSearchEnabled)
+	assert.Empty(t, state.FolderScopes)
+
+	// The column previously held unrelated agent-config shapes. Scanning those
+	// values remains best-effort and must never fail an old session read.
+	require.NoError(t, state.Scan(`{"unknown_legacy_field":{"enabled":true}}`))
+	require.NoError(t, state.Scan(`not-json`))
+}

--- a/migrations/mysql/00-init-db.sql
+++ b/migrations/mysql/00-init-db.sql
@@ -1,6 +1,8 @@
 DROP TABLE IF EXISTS tenants;
 DROP TABLE IF EXISTS models;
 DROP TABLE IF EXISTS knowledge_bases;
+DROP TABLE IF EXISTS knowledge_folder_closure;
+DROP TABLE IF EXISTS knowledge_folders;
 DROP TABLE IF EXISTS knowledges;
 DROP TABLE IF EXISTS sessions;
 DROP TABLE IF EXISTS messages;
@@ -63,6 +65,7 @@ CREATE TABLE knowledges (
     id VARCHAR(36) PRIMARY KEY,
     tenant_id INT NOT NULL,
     knowledge_base_id VARCHAR(36) NOT NULL,
+    folder_id VARCHAR(36) NOT NULL DEFAULT '',
     type VARCHAR(50) NOT NULL,
     title VARCHAR(255) NOT NULL,
     description TEXT,
@@ -85,6 +88,23 @@ CREATE TABLE knowledges (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE INDEX idx_knowledges_tenant_id ON knowledges(tenant_id, knowledge_base_id);
+CREATE INDEX idx_knowledges_folder ON knowledges(tenant_id, knowledge_base_id, folder_id);
+
+CREATE TABLE knowledge_folders (
+    id VARCHAR(36) PRIMARY KEY, tenant_id BIGINT NOT NULL, knowledge_base_id VARCHAR(36) NOT NULL,
+    parent_id VARCHAR(36) NOT NULL DEFAULT '', name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_knowledge_folder_sibling (tenant_id, knowledge_base_id, parent_id, name),
+    KEY idx_knowledge_folders_parent (tenant_id, knowledge_base_id, parent_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+CREATE TABLE knowledge_folder_closure (
+    ancestor_id VARCHAR(36) NOT NULL, descendant_id VARCHAR(36) NOT NULL, depth INT NOT NULL,
+    PRIMARY KEY (ancestor_id, descendant_id),
+    KEY idx_kfc_ancestor (ancestor_id, depth, descendant_id),
+    KEY idx_kfc_descendant (descendant_id, depth, ancestor_id),
+    CHECK (depth >= 0)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE sessions (
     id VARCHAR(36) PRIMARY KEY,

--- a/migrations/paradedb/00-init-db.sql
+++ b/migrations/paradedb/00-init-db.sql
@@ -77,6 +77,7 @@ CREATE TABLE IF NOT EXISTS knowledges (
     id VARCHAR(36) PRIMARY KEY DEFAULT uuid_generate_v4(),
     tenant_id INTEGER NOT NULL,
     knowledge_base_id VARCHAR(36) NOT NULL,
+    folder_id VARCHAR(36) NOT NULL DEFAULT '',
     type VARCHAR(50) NOT NULL,
     title VARCHAR(255) NOT NULL,
     description TEXT,
@@ -103,6 +104,22 @@ CREATE INDEX IF NOT EXISTS idx_knowledges_tenant_id ON knowledges(tenant_id);
 CREATE INDEX IF NOT EXISTS idx_knowledges_base_id ON knowledges(knowledge_base_id);
 CREATE INDEX IF NOT EXISTS idx_knowledges_parse_status ON knowledges(parse_status);
 CREATE INDEX IF NOT EXISTS idx_knowledges_enable_status ON knowledges(enable_status);
+CREATE INDEX IF NOT EXISTS idx_knowledges_folder ON knowledges(tenant_id, knowledge_base_id, folder_id);
+
+CREATE TABLE IF NOT EXISTS knowledge_folders (
+    id VARCHAR(36) PRIMARY KEY DEFAULT uuid_generate_v4(), tenant_id BIGINT NOT NULL,
+    knowledge_base_id VARCHAR(36) NOT NULL, parent_id VARCHAR(36) NOT NULL DEFAULT '', name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, knowledge_base_id, parent_id, name)
+);
+CREATE INDEX IF NOT EXISTS idx_knowledge_folders_parent ON knowledge_folders(tenant_id, knowledge_base_id, parent_id);
+CREATE TABLE IF NOT EXISTS knowledge_folder_closure (
+    ancestor_id VARCHAR(36) NOT NULL, descendant_id VARCHAR(36) NOT NULL, depth INTEGER NOT NULL CHECK (depth >= 0),
+    PRIMARY KEY (ancestor_id, descendant_id)
+);
+CREATE INDEX IF NOT EXISTS idx_kfc_ancestor ON knowledge_folder_closure(ancestor_id, depth, descendant_id);
+CREATE INDEX IF NOT EXISTS idx_kfc_descendant ON knowledge_folder_closure(descendant_id, depth, ancestor_id);
 
 -- Create session table
 CREATE TABLE IF NOT EXISTS sessions (

--- a/migrations/sqlite/000000_init.down.sql
+++ b/migrations/sqlite/000000_init.down.sql
@@ -11,6 +11,7 @@ DROP TABLE IF EXISTS organizations;
 DROP TABLE IF EXISTS custom_agents;
 DROP TABLE IF EXISTS mcp_tool_approvals;
 DROP TABLE IF EXISTS mcp_services;
+DROP TABLE IF EXISTS knowledge_tag_relations;
 DROP TABLE IF EXISTS knowledge_tags;
 DROP TABLE IF EXISTS auth_tokens;
 DROP TABLE IF EXISTS audit_logs;

--- a/migrations/sqlite/000000_init.up.sql
+++ b/migrations/sqlite/000000_init.up.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS tenants (
     credentials TEXT DEFAULT NULL,
     chat_history_config TEXT,
     retrieval_config TEXT,
+    api_principal_config TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     deleted_at DATETIME
@@ -64,6 +65,8 @@ CREATE TABLE IF NOT EXISTS knowledge_bases (
     extract_config TEXT NULL DEFAULT NULL,
     faq_config TEXT,
     question_generation_config TEXT NULL,
+    wiki_config TEXT NULL,
+    indexing_strategy TEXT NULL,
     is_temporary BOOLEAN NOT NULL DEFAULT 0,
     is_pinned INTEGER NOT NULL DEFAULT 0,
     pinned_at DATETIME NULL,
@@ -103,6 +106,7 @@ CREATE TABLE IF NOT EXISTS knowledges (
     summary_status VARCHAR(32) DEFAULT 'none',
     last_faq_import_result TEXT DEFAULT NULL,
     channel VARCHAR(50) NOT NULL DEFAULT 'web',
+    pending_subtasks_count INTEGER NOT NULL DEFAULT 0,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     processed_at DATETIME,
@@ -163,6 +167,7 @@ CREATE TABLE IF NOT EXISTS messages (
     agent_steps TEXT DEFAULT NULL,
     mentioned_items TEXT DEFAULT '[]',
     images TEXT DEFAULT '[]',
+    attachments TEXT DEFAULT '[]',
     is_completed BOOLEAN NOT NULL DEFAULT 0,
     is_fallback BOOLEAN NOT NULL DEFAULT 0,
     channel VARCHAR(50) NOT NULL DEFAULT '',
@@ -277,6 +282,7 @@ CREATE TABLE IF NOT EXISTS users (
     tenant_id INTEGER,
     is_active BOOLEAN NOT NULL DEFAULT 1,
     can_access_all_tenants BOOLEAN NOT NULL DEFAULT 0,
+    is_system_admin BOOLEAN NOT NULL DEFAULT 0,
     -- Per-user JSON preferences (memory toggle, future UI knobs).
     -- SQLite has no JSONB; store as TEXT and let GORM (de)serialise via
     -- the driver.Valuer / sql.Scanner methods on types.UserPreferences.
@@ -290,6 +296,22 @@ CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
 CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 CREATE INDEX IF NOT EXISTS idx_users_tenant_id ON users(tenant_id);
 CREATE INDEX IF NOT EXISTS idx_users_deleted_at ON users(deleted_at);
+CREATE INDEX IF NOT EXISTS idx_users_is_system_admin ON users(is_system_admin);
+
+CREATE TABLE IF NOT EXISTS system_settings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    key VARCHAR(128) NOT NULL UNIQUE,
+    value TEXT NOT NULL,
+    value_type VARCHAR(16) NOT NULL,
+    category VARCHAR(32) NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    is_secret BOOLEAN NOT NULL DEFAULT 0,
+    requires_restart BOOLEAN NOT NULL DEFAULT 0,
+    last_modified_by VARCHAR(36) NOT NULL DEFAULT '',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_system_settings_category ON system_settings(category);
 
 CREATE TABLE IF NOT EXISTS auth_tokens (
     id VARCHAR(36) PRIMARY KEY,
@@ -431,6 +453,16 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_knowledge_tags_kb_name ON knowledge_tags(t
 CREATE INDEX IF NOT EXISTS idx_knowledge_tags_kb ON knowledge_tags(tenant_id, knowledge_base_id);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_knowledge_tags_seq_id ON knowledge_tags(seq_id);
 
+CREATE TABLE IF NOT EXISTS knowledge_tag_relations (
+    knowledge_id VARCHAR(36) NOT NULL,
+    tag_id VARCHAR(36) NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (knowledge_id, tag_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ktr_knowledge ON knowledge_tag_relations(knowledge_id);
+CREATE INDEX IF NOT EXISTS idx_ktr_tag ON knowledge_tag_relations(tag_id);
+
 CREATE TABLE IF NOT EXISTS mcp_services (
     id VARCHAR(36) PRIMARY KEY,
     tenant_id INTEGER NOT NULL,
@@ -488,6 +520,8 @@ CREATE TABLE IF NOT EXISTS mcp_oauth_tokens (
     id VARCHAR(36) PRIMARY KEY,
     tenant_id INTEGER NOT NULL,
     user_id VARCHAR(64) NOT NULL,
+    principal_type VARCHAR(32) NOT NULL DEFAULT 'web_user',
+    principal_id VARCHAR(512) NOT NULL DEFAULT '',
     service_id VARCHAR(36) NOT NULL,
     access_token TEXT,
     refresh_token TEXT,
@@ -498,9 +532,10 @@ CREATE TABLE IF NOT EXISTS mcp_oauth_tokens (
     FOREIGN KEY (service_id) REFERENCES mcp_services(id) ON DELETE CASCADE
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_oauth_tokens_tenant_user_svc ON mcp_oauth_tokens(tenant_id, user_id, service_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_oauth_tokens_tenant_principal_svc ON mcp_oauth_tokens(tenant_id, principal_type, principal_id, service_id);
 CREATE INDEX IF NOT EXISTS idx_mcp_oauth_tokens_service_id ON mcp_oauth_tokens(service_id);
 CREATE INDEX IF NOT EXISTS idx_mcp_oauth_tokens_user_id ON mcp_oauth_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_mcp_oauth_tokens_principal ON mcp_oauth_tokens(principal_type, principal_id);
 
 CREATE TABLE IF NOT EXISTS custom_agents (
     id VARCHAR(36) NOT NULL,

--- a/migrations/sqlite/000001_knowledge_folders.down.sql
+++ b/migrations/sqlite/000001_knowledge_folders.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_knowledges_folder;
+ALTER TABLE knowledges DROP COLUMN folder_id;
+DROP TABLE IF EXISTS knowledge_folder_closure;
+DROP TABLE IF EXISTS knowledge_folders;

--- a/migrations/sqlite/000001_knowledge_folders.up.sql
+++ b/migrations/sqlite/000001_knowledge_folders.up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS knowledge_folders (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id INTEGER NOT NULL,
+    knowledge_base_id VARCHAR(36) NOT NULL,
+    parent_id VARCHAR(36) NOT NULL DEFAULT '',
+    name VARCHAR(100) NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, knowledge_base_id, parent_id, name)
+);
+CREATE INDEX IF NOT EXISTS idx_knowledge_folders_parent ON knowledge_folders(tenant_id, knowledge_base_id, parent_id);
+CREATE TABLE IF NOT EXISTS knowledge_folder_closure (
+    ancestor_id VARCHAR(36) NOT NULL,
+    descendant_id VARCHAR(36) NOT NULL,
+    depth INTEGER NOT NULL CHECK (depth >= 0),
+    PRIMARY KEY (ancestor_id, descendant_id)
+);
+CREATE INDEX IF NOT EXISTS idx_kfc_ancestor ON knowledge_folder_closure(ancestor_id, depth, descendant_id);
+CREATE INDEX IF NOT EXISTS idx_kfc_descendant ON knowledge_folder_closure(descendant_id, depth, ancestor_id);
+ALTER TABLE knowledges ADD COLUMN folder_id VARCHAR(36) NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_knowledges_folder ON knowledges(tenant_id, knowledge_base_id, folder_id);

--- a/migrations/versioned/000000_init.down.sql
+++ b/migrations/versioned/000000_init.down.sql
@@ -18,7 +18,15 @@ DROP INDEX IF EXISTS idx_sessions_tenant_id;
 -- Drop sessions table
 DROP TABLE IF EXISTS sessions;
 
+-- Drop document-folder hierarchy tables
+DROP INDEX IF EXISTS idx_kfc_descendant;
+DROP INDEX IF EXISTS idx_kfc_ancestor;
+DROP TABLE IF EXISTS knowledge_folder_closure;
+DROP INDEX IF EXISTS idx_knowledge_folders_parent;
+DROP TABLE IF EXISTS knowledge_folders;
+
 -- Drop indexes for knowledges
+DROP INDEX IF EXISTS idx_knowledges_folder;
 DROP INDEX IF EXISTS idx_knowledges_tenant_id;
 DROP INDEX IF EXISTS idx_knowledges_base_id;
 DROP INDEX IF EXISTS idx_knowledges_parse_status;

--- a/migrations/versioned/000000_init.up.sql
+++ b/migrations/versioned/000000_init.up.sql
@@ -97,6 +97,7 @@ CREATE TABLE IF NOT EXISTS knowledges (
     id VARCHAR(36) PRIMARY KEY DEFAULT uuid_generate_v4(),
     tenant_id INTEGER NOT NULL,
     knowledge_base_id VARCHAR(36) NOT NULL,
+    folder_id VARCHAR(36) NOT NULL DEFAULT '',
     type VARCHAR(50) NOT NULL,
     title VARCHAR(255) NOT NULL,
     description TEXT,
@@ -123,6 +124,30 @@ CREATE INDEX IF NOT EXISTS idx_knowledges_tenant_id ON knowledges(tenant_id);
 CREATE INDEX IF NOT EXISTS idx_knowledges_base_id ON knowledges(knowledge_base_id);
 CREATE INDEX IF NOT EXISTS idx_knowledges_parse_status ON knowledges(parse_status);
 CREATE INDEX IF NOT EXISTS idx_knowledges_enable_status ON knowledges(enable_status);
+CREATE INDEX IF NOT EXISTS idx_knowledges_folder ON knowledges(tenant_id, knowledge_base_id, folder_id);
+
+-- Create document-folder hierarchy tables. The root folder is virtual;
+-- first-level folders use an empty parent_id.
+CREATE TABLE IF NOT EXISTS knowledge_folders (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
+    knowledge_base_id VARCHAR(36) NOT NULL,
+    parent_id VARCHAR(36) NOT NULL DEFAULT '',
+    name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_knowledge_folder_sibling UNIQUE (tenant_id, knowledge_base_id, parent_id, name)
+);
+CREATE INDEX IF NOT EXISTS idx_knowledge_folders_parent ON knowledge_folders(tenant_id, knowledge_base_id, parent_id);
+
+CREATE TABLE IF NOT EXISTS knowledge_folder_closure (
+    ancestor_id VARCHAR(36) NOT NULL,
+    descendant_id VARCHAR(36) NOT NULL,
+    depth INTEGER NOT NULL CHECK (depth >= 0),
+    PRIMARY KEY (ancestor_id, descendant_id)
+);
+CREATE INDEX IF NOT EXISTS idx_kfc_ancestor ON knowledge_folder_closure(ancestor_id, depth, descendant_id);
+CREATE INDEX IF NOT EXISTS idx_kfc_descendant ON knowledge_folder_closure(descendant_id, depth, ancestor_id);
 
 -- Create session table
 DO $$ BEGIN RAISE NOTICE '[Migration 000000] Creating table: sessions'; END $$;

--- a/migrations/versioned/000068_knowledge_folders.down.sql
+++ b/migrations/versioned/000068_knowledge_folders.down.sql
@@ -1,0 +1,5 @@
+-- Remove folder metadata without deleting knowledge rows.
+DROP INDEX IF EXISTS idx_knowledges_folder;
+ALTER TABLE knowledges DROP COLUMN IF EXISTS folder_id;
+DROP TABLE IF EXISTS knowledge_folder_closure;
+DROP TABLE IF EXISTS knowledge_folders;

--- a/migrations/versioned/000068_knowledge_folders.up.sql
+++ b/migrations/versioned/000068_knowledge_folders.up.sql
@@ -1,0 +1,24 @@
+-- Add multilevel knowledge folder support.
+CREATE TABLE IF NOT EXISTS knowledge_folders (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
+    knowledge_base_id VARCHAR(36) NOT NULL,
+    parent_id VARCHAR(36) NOT NULL DEFAULT '',
+    name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_knowledge_folder_sibling UNIQUE (tenant_id, knowledge_base_id, parent_id, name)
+);
+CREATE INDEX IF NOT EXISTS idx_knowledge_folders_parent ON knowledge_folders(tenant_id, knowledge_base_id, parent_id);
+
+CREATE TABLE IF NOT EXISTS knowledge_folder_closure (
+    ancestor_id VARCHAR(36) NOT NULL,
+    descendant_id VARCHAR(36) NOT NULL,
+    depth INTEGER NOT NULL CHECK (depth >= 0),
+    PRIMARY KEY (ancestor_id, descendant_id)
+);
+CREATE INDEX IF NOT EXISTS idx_kfc_ancestor ON knowledge_folder_closure(ancestor_id, depth, descendant_id);
+CREATE INDEX IF NOT EXISTS idx_kfc_descendant ON knowledge_folder_closure(descendant_id, depth, ancestor_id);
+
+ALTER TABLE knowledges ADD COLUMN IF NOT EXISTS folder_id VARCHAR(36) NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_knowledges_folder ON knowledges(tenant_id, knowledge_base_id, folder_id);


### PR DESCRIPTION
## Description

This PR implements multilevel knowledge folders and recursively scoped folder QA across the complete WeKnora stack.

- Adds `knowledge_folders`, the folder closure table, and `knowledges.folder_id` to PostgreSQL, SQLite, MySQL, and ParadeDB initialization/migration paths. The virtual root remains unpersisted, existing knowledge stays at the root, and down migrations preserve knowledge records.
- Adds folder CRUD, lazy paginated children/search, ancestor paths, recursive counts, idempotent `ensure-paths`, cycle and 20-level depth protection, empty-only deletion, and bounded batch knowledge moves.
- Adds folder-aware file, URL, and manual knowledge ingestion, directory upload, direct/recursive list filtering, and the existing authorization and tenant/knowledge-base boundary checks.
- Propagates recursive folder scopes through ordinary RAG, Agent QA, shared agents, API keys, `SearchKnowledge`, suggested questions, message history, and session restoration. Folder scopes compose with tags and explicit knowledge IDs using the existing intersection semantics.
- Adds the Vue lazy folder tree, breadcrumbs, move picker, directory upload mapping, folder mentions, folder-scoped chat entry, and responsive mobile drawer.
- Protects large installations through 500-ID query batching, bounded retrieval concurrency, bulk updates, and folder path loading without N+1 queries.

Public API and request contracts added or extended by this change include the knowledge-base folder subresource APIs, `folder_id`, `include_descendants`, `folder_scopes`, the `folder_ids` suggested-question shorthand, and folder-type `mentioned_items`.

This differs from the currently open related implementations by covering the full end-to-end workflow, including folder QA, directory upload, permissions, session restoration, performance protection, and authenticated desktop/mobile acceptance.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [x] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Closes #1311

Related work: #1862, #1963

## Testing

Passed:

- Focused uncached Go tests for the folder repository and service, retriever, session handler, router, and types.
- `SSRF_WHITELIST_EXTRA=example.com go test ./internal/handler`.
- Frontend test suite: 165 tests passed.
- `npm run type-check`.
- `npm run build` (only the existing chunk-size and dynamic-import warnings).
- `git diff --check` and staged diff validation.
- Fresh SQLite bootstrap plus folder up/down migration; an inserted knowledge row remained intact after the down migration.
- Authenticated desktop and `390x844` mobile browser acceptance, including folder tree/breadcrumb behavior, document movement and directory upload flows, and real folder-scoped chat persistence.

The default `go test ./...` was also run. Its remaining failures require services or network behavior unavailable in the current local environment:

- DocReader is not running at `localhost:50051`.
- Notion/docparser local test servers are rejected by the SSRF policy.
- `example.com` resolves here to the restricted `198.18.0.0/15` range; the corresponding handler tests pass when `example.com` is added to `SSRF_WHITELIST_EXTRA`, as shown above.

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

Authenticated browser acceptance was completed on desktop and at the `390x844` mobile viewport. The recordings cover the lazy multilevel tree, breadcrumbs, folder-scoped documents, the responsive folder drawer, and folder scope restoration on the chat screen.

### Desktop

[weknora-pr2044-desktop.webm](https://github.com/user-attachments/assets/e4a19739-ad0b-4ec4-b6a9-1625e0b17f33)

### Mobile (`390x844`)

[weknora-pr2044-mobile.webm](https://github.com/user-attachments/assets/08c13f00-d9ab-4c6e-98a6-e5c5855fb94a)

The recordings are attached to this PR and are not committed to the repository.
