### PR TITLE
fix: propagate chunking strategy to parent-child splitter configs

### DIFF
--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -226,7 +226,11 @@ func buildSplitterConfigFromChunking(cc types.ChunkingConfig) chunker.SplitterCo
 }
 
 // buildParentChildConfigs derives parent and child SplitterConfig from ChunkingConfig.
-// The base config (already validated with defaults) is used for separators.
+// The base config (already validated with defaults) is used for separators and
+// the splitting strategy. Strategy must be propagated: an empty Strategy resolves
+// to the legacy tier (see resolveChainWithProfile), which never runs the heading
+// splitter, so parent-child chunks would silently lose heading alignment and
+// ContextHeader breadcrumbs regardless of the configured strategy.
 func buildParentChildConfigs(cc types.ChunkingConfig, base chunker.SplitterConfig) (parent, child chunker.SplitterConfig) {
 	parentSize := cc.ParentChunkSize
 	if parentSize <= 0 {
@@ -240,11 +244,13 @@ func buildParentChildConfigs(cc types.ChunkingConfig, base chunker.SplitterConfi
 		ChunkSize:    parentSize,
 		ChunkOverlap: base.ChunkOverlap, // reuse configured overlap for parents
 		Separators:   base.Separators,
+		Strategy:     base.Strategy,
 	}
 	child = chunker.SplitterConfig{
 		ChunkSize:    childSize,
 		ChunkOverlap: childSize / 5, // ~20% overlap for child chunks
 		Separators:   base.Separators,
+		Strategy:     base.Strategy,
 	}
 	return
 }

--- a/internal/application/service/knowledge_process_config_test.go
+++ b/internal/application/service/knowledge_process_config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	werrors "github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/infrastructure/chunker"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/stretchr/testify/require"
 )
@@ -347,4 +348,33 @@ func TestMergeParserEngineOverrides(t *testing.T) {
 		"k2": "v2",
 		"k3": "v3",
 	}, merged)
+}
+
+func TestBuildParentChildConfigs_PropagatesStrategy(t *testing.T) {
+	t.Parallel()
+
+	base := chunker.SplitterConfig{
+		ChunkSize:    1000,
+		ChunkOverlap: 100,
+		Separators:   []string{"\n\n", "\n"},
+		Strategy:     chunker.StrategyAuto,
+	}
+	cc := types.ChunkingConfig{
+		EnableParentChild: true,
+		ParentChunkSize:   4096,
+		ChildChunkSize:    512,
+	}
+
+	parent, child := buildParentChildConfigs(cc, base)
+
+	require.Equal(t, chunker.StrategyAuto, parent.Strategy,
+		"parent splitting must honour the configured strategy; empty resolves to the legacy tier")
+	require.Equal(t, chunker.StrategyAuto, child.Strategy,
+		"child splitting must honour the configured strategy; empty resolves to the legacy tier")
+	require.Equal(t, 4096, parent.ChunkSize)
+	require.Equal(t, 512, child.ChunkSize)
+	require.Equal(t, base.ChunkOverlap, parent.ChunkOverlap)
+	require.Equal(t, 512/5, child.ChunkOverlap)
+	require.Equal(t, base.Separators, parent.Separators)
+	require.Equal(t, base.Separators, child.Separators)
 }


### PR DESCRIPTION
## Description

When parent-child chunking is enabled, the configured chunking `strategy` (`auto` / `heading` / `heuristic`) is silently ignored: `buildParentChildConfigs` only copies `ChunkSize`, `ChunkOverlap` and `Separators` into the parent/child `SplitterConfig`s and drops `base.Strategy`. Because `resolveChainWithProfile` treats an empty strategy as the legacy tier (backwards compatibility for pre-strategy configs), parent-child mode always runs the legacy recursive splitter — chunks are not heading-aligned and child embeddings never get their `ContextHeader` breadcrumbs, with no error or warning.

The intent clearly was for strategy to reach the parent-child path:

- `SplitParentChild`'s docstring says "Child splitting honours childCfg.Strategy".
- `mergeBreadcrumbs` exists solely to merge parent/child heading breadcrumbs, which the legacy tier never produces.
- The flat path (`buildSplitterConfigFromChunking`) already propagates `Strategy`.

Timeline: parent-child chunking landed in b3334990 (before the strategy system existed), and the 3-tier strategy system landed in ae6fde23 without updating `buildParentChildConfigs` — so the omission is an oversight, masked by the "empty == legacy" fallback.

**Fix:** copy `base.Strategy` into both the parent and the child `SplitterConfig`, and extend the function comment to explain why the propagation matters.

Note: `TokenLimit`/`Languages` are also not propagated, but that is left out intentionally — the embedding token cap arguably should not shrink parent chunks (parents are never embedded), so it deserves its own discussion.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #

## Testing

- Added `TestBuildParentChildConfigs_PropagatesStrategy` covering strategy propagation to both configs plus the existing size/overlap/separator behaviour.
- `go build ./internal/application/service/` and `go test ./internal/application/service/ -run 'TestBuildParentChildConfigs|TestResolveProcessConfig'` pass locally (10/10).
- Reproduction: create a KB with `enable_parent_child: true` and `strategy: "heading"`, upload a Markdown document with `##` sections, then inspect chunks (e.g. via `POST /api/v1/chunker/preview` vs actual ingestion) — before this fix child chunks are split by size only and carry no heading breadcrumb; after it they align to headings and `EmbeddingContent()` includes the breadcrumb.

## Checklist

- [ ] `make fmt && make lint && make test` pass locally (ran `gofmt`, `go build` and the targeted service tests; full make targets not run in this environment)
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A (backend chunking behaviour)
