### PR TITLE
fix(knowledge): align processing timeline status with knowledge row

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,6 +43,7 @@
         "less": "^4.6.4",
         "less-loader": "^12.3.2",
         "npm-run-all2": "^8.0.4",
+        "tsx": "^4.23.1",
         "typescript": "~6.0.3",
         "vite": "^7.3.5",
         "vue-tsc": "^3.2.8"
@@ -4857,6 +4858,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.10"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://mirrors.tencent.com/npm/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typescript": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "build-only": "vite build",
     "type-check": "vue-tsc --build",
-    "test": "node --test"
+    "test": "tsx --test"
   },
   "dependencies": {
     "@microsoft/fetch-event-source": "^2.0.1",
@@ -48,6 +48,7 @@
     "less": "^4.6.4",
     "less-loader": "^12.3.2",
     "npm-run-all2": "^8.0.4",
+    "tsx": "^4.23.1",
     "typescript": "~6.0.3",
     "vite": "^7.3.5",
     "vue-tsc": "^3.2.8"

--- a/frontend/src/components/knowledge-processing-timeline.vue
+++ b/frontend/src/components/knowledge-processing-timeline.vue
@@ -4,6 +4,7 @@ import { MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
 import { getKnowledgeSpans, reparseKnowledge, cancelKnowledgeParse, getKnowledgeDetails } from '@/api/knowledge-base/index'
 import { knowledgeSpansPayloadHasTrace } from '@/utils/knowledgeTrace'
+import { resolveTimelineHeaderStatus } from '@/utils/knowledgeProcessingStatus'
 import type { KnowledgeProcessOverrides } from '@/types/knowledgeProcess'
 
 interface SpanNode {
@@ -373,8 +374,13 @@ async function fetchSpans(opts: { manual?: boolean } = {}) {
       }
       for (const stage of data.value.trace?.children || []) autoExpand(stage)
       expandedRows.value = expanded
-      const traceStatus = data.value.trace?.status || data.value.parse_status || 'running'
-      attemptStatuses.set(data.value.attempt, traceStatus)
+      const latestAttempt = data.value.latest_attempt || data.value.attempt || 0
+      const tabStatus = resolveTimelineHeaderStatus({
+        parseStatus: data.value.parse_status,
+        traceStatus: data.value.trace?.status,
+        isLatestAttempt: data.value.attempt === latestAttempt,
+      }) || 'running'
+      attemptStatuses.set(data.value.attempt, tabStatus)
       ensureAttemptStatuses()
       emit('update:hasSpans', knowledgeSpansPayloadHasTrace(data.value))
     } else {
@@ -411,7 +417,11 @@ function ensureAttemptStatuses() {
     getKnowledgeSpans(props.knowledgeId, n)
       .then((res: any) => {
         if (res?.success && res.data?.trace) {
-          attemptStatuses.set(n, res.data.trace.status || res.data.parse_status || 'running')
+          attemptStatuses.set(n, resolveTimelineHeaderStatus({
+            parseStatus: res.data.parse_status,
+            traceStatus: res.data.trace?.status,
+            isLatestAttempt: n === latest,
+          }) || 'running')
         }
       })
       .catch(() => { })
@@ -1128,36 +1138,18 @@ const viewingLatestAttempt = computed<boolean>(() => {
   return active === latest
 })
 
-// Project the knowledge-level parse_status onto the trace-span status
-// vocabulary localizedStatus() speaks, so the header badge reads the
-// same whether it comes from the root span or from parse_status.
-// 'finalizing' keeps its own label ("优化中") to match the doc card.
-function parseStatusToTraceStatus(s?: string): string {
-  switch (s) {
-    case 'completed':
-      return 'done'
-    case 'processing':
-      return 'running'
-    case 'finalizing':
-      return 'finalizing'
-    default:
-      return s || ''
-  }
-}
-
 // The authoritative status for the header badge. During the async
 // post-pipeline window (summary / question / graph / wiki), the latest
 // attempt's ROOT span closes — so trace.status reads 'done' — while
-// those subspans keep running and the row is still 'finalizing'.
-// Trusting trace.status there flashes "已完成" mid-wiki even though the
-// doc card (and LIVE badge) still say "优化中". Prefer parse_status while
-// it is non-terminal on the latest attempt so all three agree.
+// those subspans can still be running or can later make the knowledge fail.
+// The latest knowledge row is therefore authoritative for ALL statuses,
+// including terminal ones. Historical attempts keep their own root status.
 const headerStatus = computed(() => {
-  const parseStatus = data.value?.parse_status
-  if (viewingLatestAttempt.value && isPolling(parseStatus)) {
-    return parseStatusToTraceStatus(parseStatus)
-  }
-  return data.value?.trace?.status || parseStatusToTraceStatus(parseStatus)
+  return resolveTimelineHeaderStatus({
+    parseStatus: data.value?.parse_status,
+    traceStatus: data.value?.trace?.status,
+    isLatestAttempt: viewingLatestAttempt.value,
+  })
 })
 
 const headerStatusText = computed(() => {
@@ -1181,6 +1173,10 @@ const headerStatusTheme = computed(() => {
       return 'default'
   }
 })
+
+const showLastError = computed(() =>
+  Boolean(data.value?.last_error && data.value?.parse_status === 'failed'),
+)
 
 const stagesStatDisplay = computed(() => {
   const total = stages.value.length
@@ -1235,7 +1231,7 @@ watch(
   () => {
     emit('update:summary', {
       totalMs: totalMs.value,
-      status: data.value?.trace?.status || data.value?.parse_status || '',
+      status: headerStatus.value,
       stageIndex: currentStageIndex.value,
       stageTotal: stages.value.length,
       stageLabel: currentStageLabel.value,
@@ -1486,6 +1482,22 @@ const processConfigLines = computed<string[]>(() => {
                 }}</span>
             </button>
           </div>
+
+          <div v-if="showLastError && data?.last_error" class="kp-last-error" role="alert">
+            <div class="kp-last-error-bar" />
+            <div class="kp-last-error-body">
+              <div class="kp-last-error-row">
+                <span class="kp-last-error-glyph">!</span>
+                <span class="kp-last-error-title">{{ localizedErrorTitle(data.last_error.error_code) }}</span>
+                <span v-if="data.last_error.error_code" class="kp-last-error-code kp-mono">{{ data.last_error.error_code
+                  }}</span>
+              </div>
+              <div class="kp-last-error-suggestion">{{ localizedErrorSuggestion(data.last_error.error_code) }}</div>
+              <div v-if="data.last_error.error_message" class="kp-last-error-raw kp-mono">{{
+                data.last_error.error_message }}
+              </div>
+            </div>
+          </div>
         </div>
 
         <!-- ============== BODY (Waterfall) ============== -->
@@ -1587,22 +1599,6 @@ const processConfigLines = computed<string[]>(() => {
                   </template>
                 </div>
               </div>
-            </div>
-
-            <div v-if="data?.last_error && data?.parse_status === 'failed'" class="kp-last-error">
-            <div class="kp-last-error-bar" />
-            <div class="kp-last-error-body">
-              <div class="kp-last-error-row">
-                <span class="kp-last-error-glyph">!</span>
-                <span class="kp-last-error-title">{{ localizedErrorTitle(data.last_error.error_code) }}</span>
-                <span v-if="data.last_error.error_code" class="kp-last-error-code kp-mono">{{ data.last_error.error_code
-                  }}</span>
-              </div>
-              <div class="kp-last-error-suggestion">{{ localizedErrorSuggestion(data.last_error.error_code) }}</div>
-              <div v-if="data.last_error.error_message" class="kp-last-error-raw kp-mono">{{
-                data.last_error.error_message }}
-              </div>
-            </div>
             </div>
             </div>
           </template>
@@ -2058,7 +2054,7 @@ const processConfigLines = computed<string[]>(() => {
   transition: background 150ms ease, border-color 150ms ease, color 150ms ease;
 }
 
-.kp-attempt:hover {
+.kp-attempt:not(.kp-attempt-active):hover {
   background: var(--td-bg-color-secondarycontainer);
   border-color: var(--td-text-color-placeholder);
   color: var(--td-text-color-primary);
@@ -2070,7 +2066,14 @@ const processConfigLines = computed<string[]>(() => {
   border-color: var(--td-brand-color);
 }
 
-.kp-attempt-active .kp-attempt-glyph {
+.kp-attempt-active:hover {
+  background: var(--td-brand-color);
+  color: var(--td-text-color-anti);
+  border-color: var(--td-brand-color);
+}
+
+.kp-attempt-active .kp-attempt-glyph,
+.kp-attempt-active:hover .kp-attempt-glyph {
   color: var(--td-text-color-anti) !important;
 }
 
@@ -2614,9 +2617,9 @@ const processConfigLines = computed<string[]>(() => {
   background: var(--td-text-color-placeholder);
 }
 
-/* Last error block */
+/* Last error block — pinned in the header so long trace trees don't bury it */
 .kp-last-error {
-  margin: 14px 20px 4px;
+  margin: 10px 0 0;
   display: flex;
   background: var(--td-error-color-light);
   border-radius: var(--td-radius-medium);

--- a/frontend/src/components/knowledge-processing-timeline.vue
+++ b/frontend/src/components/knowledge-processing-timeline.vue
@@ -1224,9 +1224,10 @@ const primaryHeadTitle = computed(() => props.docTitle || t('knowledgeStages.tit
 watch(
   [
     () => totalMs.value,
-    () => data.value?.parse_status,
+    () => headerStatus.value,
     () => currentStageIndex.value,
     () => currentStageLabel.value,
+    () => stages.value.length,
   ],
   () => {
     emit('update:summary', {

--- a/frontend/src/utils/knowledgeProcessingStatus.test.mjs
+++ b/frontend/src/utils/knowledgeProcessingStatus.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  parseStatusToTimelineStatus,
+  resolveTimelineHeaderStatus,
+} from './knowledgeProcessingStatus.ts'
+
+test('latest attempt uses failed knowledge status even when root span is done', () => {
+  assert.equal(resolveTimelineHeaderStatus({
+    parseStatus: 'failed',
+    traceStatus: 'done',
+    isLatestAttempt: true,
+  }), 'failed')
+})
+
+test('latest attempt keeps finalizing distinct from a completed root span', () => {
+  assert.equal(resolveTimelineHeaderStatus({
+    parseStatus: 'finalizing',
+    traceStatus: 'done',
+    isLatestAttempt: true,
+  }), 'finalizing')
+})
+
+test('historical attempt keeps its own root status', () => {
+  assert.equal(resolveTimelineHeaderStatus({
+    parseStatus: 'failed',
+    traceStatus: 'done',
+    isLatestAttempt: false,
+  }), 'done')
+})
+
+test('parse status maps completed and processing into timeline vocabulary', () => {
+  assert.equal(parseStatusToTimelineStatus('completed'), 'done')
+  assert.equal(parseStatusToTimelineStatus('processing'), 'running')
+})

--- a/frontend/src/utils/knowledgeProcessingStatus.ts
+++ b/frontend/src/utils/knowledgeProcessingStatus.ts
@@ -1,0 +1,34 @@
+export type TimelineStatusInput = {
+  parseStatus?: string
+  traceStatus?: string
+  isLatestAttempt: boolean
+}
+
+/**
+ * Convert the knowledge-level parse status to the span status vocabulary used
+ * by the processing timeline.
+ */
+export function parseStatusToTimelineStatus(status?: string): string {
+  switch (status) {
+    case 'completed':
+      return 'done'
+    case 'processing':
+      return 'running'
+    default:
+      return status || ''
+  }
+}
+
+/**
+ * The knowledge row is authoritative for the latest attempt. The root span
+ * only describes the main parse pipeline and may already be `done` while
+ * asynchronous enrichment is still running or has subsequently failed.
+ * Historical attempts have no matching knowledge-row snapshot, so they keep
+ * their own persisted root-span status.
+ */
+export function resolveTimelineHeaderStatus(input: TimelineStatusInput): string {
+  if (input.isLatestAttempt) {
+    return parseStatusToTimelineStatus(input.parseStatus) || input.traceStatus || ''
+  }
+  return input.traceStatus || parseStatusToTimelineStatus(input.parseStatus)
+}

--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -680,16 +680,18 @@ func (h *KnowledgeHandler) GetKnowledgeSpans(c *gin.Context) {
 
 	rows := []types.KnowledgeProcessingSpan{}
 	currentAttempt := 0
+	latestAttempt := 0
 	if h.spanRepo != nil {
-		if requestedAttempt == 0 {
-			latest, lerr := h.spanRepo.LatestAttempt(ctx, knowledge.ID)
-			if lerr != nil {
-				logger.Warnf(ctx, "spans LatestAttempt failed for %s: %v", knowledge.ID, lerr)
-			} else {
-				currentAttempt = latest
-			}
+		latest, lerr := h.spanRepo.LatestAttempt(ctx, knowledge.ID)
+		if lerr != nil {
+			logger.Warnf(ctx, "spans LatestAttempt failed for %s: %v", knowledge.ID, lerr)
 		} else {
+			latestAttempt = latest
+		}
+		if requestedAttempt > 0 {
 			currentAttempt = requestedAttempt
+		} else {
+			currentAttempt = latestAttempt
 		}
 		if currentAttempt > 0 {
 			rows, err = h.spanRepo.ListByAttempt(ctx, knowledge.ID, currentAttempt)
@@ -713,6 +715,8 @@ func (h *KnowledgeHandler) GetKnowledgeSpans(c *gin.Context) {
 
 	resp := gin.H{
 		"knowledge_id":    knowledge.ID,
+		"attempt":         currentAttempt,
+		"latest_attempt":  latestAttempt,
 		"parse_status":    knowledge.ParseStatus,
 		"current_attempt": currentAttempt,
 		"current_stage":   currentStageName,
@@ -720,10 +724,27 @@ func (h *KnowledgeHandler) GetKnowledgeSpans(c *gin.Context) {
 	}
 	if lastErr != nil {
 		resp["last_error"] = gin.H{
-			"stage":       lastErr.Name,
-			"code":        lastErr.ErrorCode,
-			"message":     lastErr.ErrorMessage,
-			"finished_at": lastErr.FinishedAt,
+			"stage":         lastErr.Name,
+			"code":          lastErr.ErrorCode,
+			"message":       lastErr.ErrorMessage,
+			"name":          lastErr.Name,
+			"error_code":    lastErr.ErrorCode,
+			"error_message": lastErr.ErrorMessage,
+			"finished_at":   lastErr.FinishedAt,
+		}
+	} else if currentAttempt == latestAttempt && knowledge.ParseStatus == types.ParseStatusFailed && knowledge.ErrorMessage != "" {
+		// The knowledge row can be failed by recovery/dead-letter paths after
+		// the main root span has already closed. Surface that authoritative
+		// failure reason instead of leaving the detail drawer with a red status
+		// but no explanation.
+		resp["last_error"] = gin.H{
+			"stage":         "knowledge_processing",
+			"code":          "UNKNOWN",
+			"message":       knowledge.ErrorMessage,
+			"name":          "knowledge_processing",
+			"error_code":    "UNKNOWN",
+			"error_message": knowledge.ErrorMessage,
+			"finished_at":   knowledge.UpdatedAt,
 		}
 	}
 	c.JSON(http.StatusOK, gin.H{

--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -722,35 +722,54 @@ func (h *KnowledgeHandler) GetKnowledgeSpans(c *gin.Context) {
 		"current_stage":   currentStageName,
 		"trace":           tree,
 	}
-	if lastErr != nil {
-		resp["last_error"] = gin.H{
-			"stage":         lastErr.Name,
-			"code":          lastErr.ErrorCode,
-			"message":       lastErr.ErrorMessage,
-			"name":          lastErr.Name,
-			"error_code":    lastErr.ErrorCode,
-			"error_message": lastErr.ErrorMessage,
-			"finished_at":   lastErr.FinishedAt,
-		}
-	} else if currentAttempt == latestAttempt && knowledge.ParseStatus == types.ParseStatusFailed && knowledge.ErrorMessage != "" {
-		// The knowledge row can be failed by recovery/dead-letter paths after
-		// the main root span has already closed. Surface that authoritative
-		// failure reason instead of leaving the detail drawer with a red status
-		// but no explanation.
-		resp["last_error"] = gin.H{
-			"stage":         "knowledge_processing",
-			"code":          "UNKNOWN",
-			"message":       knowledge.ErrorMessage,
-			"name":          "knowledge_processing",
-			"error_code":    "UNKNOWN",
-			"error_message": knowledge.ErrorMessage,
-			"finished_at":   knowledge.UpdatedAt,
-		}
+	if lastError := knowledgeSpansLastError(
+		currentAttempt,
+		latestAttempt,
+		knowledge.ParseStatus,
+		knowledge.ErrorMessage,
+		knowledge.UpdatedAt,
+		lastErr,
+	); lastError != nil {
+		resp["last_error"] = lastError
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"data":    resp,
 	})
+}
+
+// knowledgeSpansLastError builds the last_error payload for GetKnowledgeSpans.
+// Span failures win when present; otherwise a failed knowledge row without a
+// matching span error (recovery / dead-letter paths) surfaces ErrorMessage.
+func knowledgeSpansLastError(
+	currentAttempt, latestAttempt int,
+	parseStatus, knowledgeErrorMessage string,
+	knowledgeUpdatedAt time.Time,
+	spanFailure *types.KnowledgeProcessingSpan,
+) gin.H {
+	if spanFailure != nil {
+		return gin.H{
+			"stage":         spanFailure.Name,
+			"code":          spanFailure.ErrorCode,
+			"message":       spanFailure.ErrorMessage,
+			"name":          spanFailure.Name,
+			"error_code":    spanFailure.ErrorCode,
+			"error_message": spanFailure.ErrorMessage,
+			"finished_at":   spanFailure.FinishedAt,
+		}
+	}
+	if currentAttempt != latestAttempt || parseStatus != types.ParseStatusFailed || knowledgeErrorMessage == "" {
+		return nil
+	}
+	return gin.H{
+		"stage":         "knowledge_processing",
+		"code":          "UNKNOWN",
+		"message":       knowledgeErrorMessage,
+		"name":          "knowledge_processing",
+		"error_code":    "UNKNOWN",
+		"error_message": knowledgeErrorMessage,
+		"finished_at":   knowledgeUpdatedAt,
+	}
 }
 
 // buildSpanTree assembles a flat list of span rows into a parent-child

--- a/internal/handler/knowledge_spans_test.go
+++ b/internal/handler/knowledge_spans_test.go
@@ -122,3 +122,42 @@ func TestBuildSpanTree_LastFailureSurfaces(t *testing.T) {
 		"last_error must point at the actually-failed span, not the cascade-cancelled downstream")
 	a.Equal("DOCREADER_TIMEOUT", lastFail.ErrorCode)
 }
+
+func TestKnowledgeSpansLastError_PrefersSpanFailure(t *testing.T) {
+	now := time.Now()
+	spanFail := &types.KnowledgeProcessingSpan{
+		Name:         types.StageDocReader,
+		ErrorCode:    "DOCREADER_TIMEOUT",
+		ErrorMessage: "slow",
+		FinishedAt:   &now,
+	}
+
+	got := knowledgeSpansLastError(2, 2, types.ParseStatusFailed, "recovery blew up", now, spanFail)
+	a := assert.New(t)
+	a.Equal(types.StageDocReader, got["name"])
+	a.Equal("DOCREADER_TIMEOUT", got["error_code"])
+	a.Equal("slow", got["error_message"])
+}
+
+func TestKnowledgeSpansLastError_RecoveryFallbackUsesKnowledgeMessage(t *testing.T) {
+	now := time.Now()
+	got := knowledgeSpansLastError(2, 2, types.ParseStatusFailed, "wiki ingest timed out", now, nil)
+	a := assert.New(t)
+	a.NotNil(got)
+	a.Equal("knowledge_processing", got["name"])
+	a.Equal("UNKNOWN", got["error_code"])
+	a.Equal("wiki ingest timed out", got["error_message"])
+	a.Equal(now, got["finished_at"])
+}
+
+func TestKnowledgeSpansLastError_SkipsRecoveryFallbackForHistoricalAttempt(t *testing.T) {
+	now := time.Now()
+	got := knowledgeSpansLastError(1, 2, types.ParseStatusFailed, "wiki ingest timed out", now, nil)
+	assert.Nil(t, got)
+}
+
+func TestKnowledgeSpansLastError_SkipsRecoveryFallbackWithoutMessage(t *testing.T) {
+	now := time.Now()
+	got := knowledgeSpansLastError(2, 2, types.ParseStatusFailed, "", now, nil)
+	assert.Nil(t, got)
+}


### PR DESCRIPTION
## Summary
- Extract `resolveTimelineHeaderStatus` so the timeline header, attempt tabs, and summary all treat the latest knowledge `parse_status` as authoritative (fixes false "已完成" / green checkmarks when the root span is `done` but enrichment failed or is still finalizing).
- Extend `GetKnowledgeSpans` with `attempt`, `latest_attempt`, normalized `last_error` fields, and a fallback when recovery/dead-letter paths fail the knowledge row without a span error.
- Pin failure details in the timeline header, fix active attempt-tab hover styles, and add unit tests for status resolution.

## Test plan
- [ ] Upload a document and confirm the timeline header stays on "优化中" while post-pipeline enrichment runs, then switches to "已完成" when `parse_status` is `completed`.
- [ ] Trigger a late failure (e.g. wiki/graph enrichment) and verify the header and latest attempt tab show failed status with the error block visible at the top.
- [ ] Switch between historical attempts and confirm older tabs keep their own root-span status instead of the current knowledge status.
- [ ] Hover attempt tabs and confirm the active tab keeps brand-color background and a visible checkmark icon.
- [ ] `cd frontend && node --test src/utils/knowledgeProcessingStatus.test.mjs` (with project TS loader if configured in CI)