### PR TITLE
fix(knowledge): reload doc list after tag rename in manage drawer

### DIFF
--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -780,7 +780,10 @@ const onTagManageChanged = (payload?: { deletedTagId?: string }) => {
       await loadKnowledgeFiles(kbId.value);
       await loadTags(kbId.value, true);
     })();
+    return;
   }
+  resetPage();
+  loadKnowledgeFiles(kbId.value);
 };
 
 const handleKnowledgeTagChange = async (knowledgeId: string, tagIds: string[]) => {


### PR DESCRIPTION
## Description

修复"管理标签"抽屉中重命名标签后，知识库文档列表中的标签名称未实时更新的问题。

**原因**：`onTagManageChanged` 回调中，仅标签删除路径会触发 `loadKnowledgeFiles` 重新加载文档列表；标签创建/重命名路径只刷新了侧边栏标签列表（`loadTags`），文档卡片上的标签名称仍是旧值，刷新页面后才更新。

**修复**：在标签创建/重命名路径（无 `deletedTagId`）末尾补充 `resetPage()` + `loadKnowledgeFiles(kbId.value)`，使文档列表立即反映标签名称变更。

## Type of Change

- [x] 🐛 Bug fix


## Testing

1. 进入任意知识库 → 打开"管理标签"抽屉
2. 重命名某个已有标签 → 确认成功提示
3. 观察文档列表/卡片上的标签名称 → 应**立即**显示新名称，无需刷新页面
4. 同时验证标签删除后文档列表仍正常刷新（回归测试）

## Checklist
- [x] Self-reviewed the code
- [ ] `make fmt && make lint && make test` pass locally
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation

## Screenshots / Recordings

修复前：

https://github.com/user-attachments/assets/f7b934a4-c3bd-42d0-a4d8-ca2a1e2170b4


修复后：

https://github.com/user-attachments/assets/eebe7d43-e858-4f97-9c20-36528e383498

