### PR TITLE
resolved: 新增了对Mysql的支持(#1418)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,7 +154,7 @@ DISABLE_REGISTRATION=false
 OLLAMA_BASE_URL=http://host.docker.internal:11434
 
 # 存储配置
-# 主数据库类型(postgres/mysql)
+# 主数据库类型(postgres/mysql/sqlite)
 DB_DRIVER=postgres
 
 # 向量存储类型(postgres/elasticsearch_v7/elasticsearch_v8/qdrant/milvus/weaviate/doris/tencent_vectordb)
@@ -217,6 +217,13 @@ DB_PASSWORD=postgres123!@#
 
 # 数据库名称
 DB_NAME=WeKnora
+
+# 如果使用 MySQL 作为数据库，配置如下：
+# DB_HOST=127.0.0.1
+# DB_PORT=3306
+# DB_USER=weknora
+# DB_PASSWORD=weknora
+# DB_NAME=weknora
 
 # 如果使用 redis 作为流处理后端，需要配置以下参数
 # Redis用户名，Redis 6.0+ ACL 功能支持（可选）

--- a/go.mod
+++ b/go.mod
@@ -337,6 +337,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gorm.io/driver/mysql v1.6.0 // indirect
 	k8s.io/apimachinery v0.32.3 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3787,6 +3787,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/driver/mysql v1.6.0 h1:eNbLmNTpPpTOVZi8MMxCi2aaIm0ZpInbORNXDwyLGvg=
+gorm.io/driver/mysql v1.6.0/go.mod h1:D/oCC2GWK3M/dqoLxnOlaNKmXz8WNTfcS9y5ovaSqKo=
 gorm.io/driver/postgres v1.6.0 h1:2dxzU8xJ+ivvqTRph34QX+WrRaJlmfyPqXmoGVjMBa4=
 gorm.io/driver/postgres v1.6.0/go.mod h1:vUw0mrGgrTK+uPHEhAdV4sfFELrByKVGnaVRkXDhtWo=
 gorm.io/driver/sqlite v1.6.0 h1:WHRRrIiulaPiPFmDcod6prc4l2VGVWHz80KspNsxSfQ=

--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -377,7 +377,12 @@ func (r *chunkRepository) UpdateChunks(ctx context.Context, chunks []*types.Chun
 		args = append(args, id)
 	}
 
-	isPostgres := r.db.Dialector.Name() == "postgres"
+	dialectName := r.db.Dialector.Name()
+	isPostgres := dialectName == "postgres"
+	nowFunc := "NOW()"
+	if dialectName == "sqlite" {
+		nowFunc = "datetime('now')"
+	}
 
 	var sql string
 	if isPostgres {
@@ -388,7 +393,7 @@ func (r *chunkRepository) UpdateChunks(ctx context.Context, chunks []*types.Chun
 				tag_id = CASE %s END,
 				flags = (CASE %s END)::integer,
 				status = (CASE %s END)::integer,
-				updated_at = NOW()
+				updated_at = %s
 			WHERE id IN (%s)
 		`,
 			strings.Join(contentCases, " "),
@@ -396,6 +401,7 @@ func (r *chunkRepository) UpdateChunks(ctx context.Context, chunks []*types.Chun
 			strings.Join(tagIDCases, " "),
 			strings.Join(flagsCases, " "),
 			strings.Join(statusCases, " "),
+			nowFunc,
 			strings.Join(inPlaceholders, ","),
 		)
 	} else {
@@ -406,7 +412,7 @@ func (r *chunkRepository) UpdateChunks(ctx context.Context, chunks []*types.Chun
 				tag_id = CASE %s END,
 				flags = CASE %s END,
 				status = CASE %s END,
-				updated_at = datetime('now')
+				updated_at = %s
 			WHERE id IN (%s)
 		`,
 			strings.Join(contentCases, " "),
@@ -414,6 +420,7 @@ func (r *chunkRepository) UpdateChunks(ctx context.Context, chunks []*types.Chun
 			strings.Join(tagIDCases, " "),
 			strings.Join(flagsCases, " "),
 			strings.Join(statusCases, " "),
+			nowFunc,
 			strings.Join(inPlaceholders, ","),
 		)
 	}

--- a/internal/application/repository/knowledge.go
+++ b/internal/application/repository/knowledge.go
@@ -491,7 +491,6 @@ func (r *knowledgeRepository) CountKnowledgeByStatus(
 // Only returns documents from document-type knowledge bases (excludes FAQ)
 // Returns (results, hasMore, error)
 // FindByMetadataKey finds a knowledge item by a key-value pair in the metadata JSON column.
-// Uses Postgres jsonb operator: metadata->>'key' = 'value'.
 func (r *knowledgeRepository) FindByMetadataKey(
 	ctx context.Context,
 	tenantID uint64,
@@ -500,10 +499,14 @@ func (r *knowledgeRepository) FindByMetadataKey(
 	value string,
 ) (*types.Knowledge, error) {
 	var knowledge types.Knowledge
-	err := r.db.WithContext(ctx).
-		Where("tenant_id = ? AND knowledge_base_id = ? AND deleted_at IS NULL", tenantID, kbID).
-		Where("metadata->>? = ?", key, value).
-		First(&knowledge).Error
+	db := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND knowledge_base_id = ? AND deleted_at IS NULL", tenantID, kbID)
+	if r.db.Dialector.Name() == "postgres" {
+		db = db.Where("metadata->>? = ?", key, value)
+	} else {
+		db = db.Where("JSON_UNQUOTE(JSON_EXTRACT(metadata, ?)) = ?", "$."+key, value)
+	}
+	err := db.First(&knowledge).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil

--- a/internal/application/repository/message.go
+++ b/internal/application/repository/message.go
@@ -167,8 +167,12 @@ func (r *messageRepository) SearchMessagesByKeyword(
 		Select("messages.*, sessions.title as session_title").
 		Joins("INNER JOIN sessions ON sessions.id = messages.session_id AND sessions.deleted_at IS NULL").
 		Where("sessions.tenant_id = ?", tenantID).
-		Where("messages.deleted_at IS NULL").
-		Where("messages.content ILIKE ?", "%"+escapeLikeKeyword(keyword)+"%")
+		Where("messages.deleted_at IS NULL")
+	if r.db.Dialector.Name() == "postgres" {
+		query = query.Where("messages.content ILIKE ?", "%"+escapeLikeKeyword(keyword)+"%")
+	} else {
+		query = query.Where("LOWER(messages.content) LIKE LOWER(?)", "%"+escapeLikeKeyword(keyword)+"%")
+	}
 
 	if len(sessionIDs) > 0 {
 		query = query.Where("messages.session_id IN ?", sessionIDs)

--- a/internal/application/repository/organization.go
+++ b/internal/application/repository/organization.go
@@ -90,8 +90,11 @@ func (r *organizationRepository) ListSearchable(ctx context.Context, query strin
 	q := r.db.WithContext(ctx).Where("searchable = ?", true)
 	if query != "" {
 		pattern := "%" + query + "%"
-		// 支持按名称、描述或空间 ID 搜索，便于区分同名空间
-		q = q.Where("name ILIKE ? OR description ILIKE ? OR id::text ILIKE ?", pattern, pattern, pattern)
+		if r.db.Dialector.Name() == "postgres" {
+			q = q.Where("name ILIKE ? OR description ILIKE ? OR id::text ILIKE ?", pattern, pattern, pattern)
+		} else {
+			q = q.Where("LOWER(name) LIKE LOWER(?) OR LOWER(description) LIKE LOWER(?) OR CAST(id AS CHAR) LIKE LOWER(?)", pattern, pattern, pattern)
+		}
 	}
 	err := q.Order("created_at DESC").Limit(limit).Find(&orgs).Error
 	if err != nil {

--- a/internal/application/repository/user.go
+++ b/internal/application/repository/user.go
@@ -262,9 +262,13 @@ func (r *userRepository) SearchUsers(ctx context.Context, query string, limit in
 	searchPattern := "%" + query + "%"
 
 	dbQuery := r.db.WithContext(ctx).
-		Where("username ILIKE ? OR email ILIKE ?", searchPattern, searchPattern).
-		Where("is_active = ?", true).
-		Order("username ASC")
+		Where("is_active = ?", true)
+	if r.db.Dialector.Name() == "postgres" {
+		dbQuery = dbQuery.Where("username ILIKE ? OR email ILIKE ?", searchPattern, searchPattern)
+	} else {
+		dbQuery = dbQuery.Where("LOWER(username) LIKE LOWER(?) OR LOWER(email) LIKE LOWER(?)", searchPattern, searchPattern)
+	}
+	dbQuery = dbQuery.Order("username ASC")
 
 	if limit > 0 {
 		dbQuery = dbQuery.Limit(limit)

--- a/internal/application/repository/wiki_page.go
+++ b/internal/application/repository/wiki_page.go
@@ -29,10 +29,18 @@ func NewWikiPageRepository(db *gorm.DB) interfaces.WikiPageRepository {
 }
 
 func (r *wikiPageRepository) wikiCategoryRankOrder() string {
-	if r.db != nil && r.db.Dialector != nil && r.db.Dialector.Name() == "sqlite" {
-		return "CASE WHEN COALESCE(json_array_length(category_path), 0) > 0 THEN 0 ELSE 1 END ASC"
+	dbName := ""
+	if r.db != nil && r.db.Dialector != nil {
+		dbName = r.db.Dialector.Name()
 	}
-	return "CASE WHEN COALESCE(jsonb_array_length(category_path), 0) > 0 THEN 0 ELSE 1 END ASC"
+	switch dbName {
+	case "mysql":
+		return "CASE WHEN COALESCE(JSON_LENGTH(category_path), 0) > 0 THEN 0 ELSE 1 END ASC"
+	case "sqlite":
+		return "CASE WHEN COALESCE(json_array_length(category_path), 0) > 0 THEN 0 ELSE 1 END ASC"
+	default:
+		return "CASE WHEN COALESCE(jsonb_array_length(category_path), 0) > 0 THEN 0 ELSE 1 END ASC"
+	}
 }
 
 // Create inserts a new wiki page record
@@ -165,12 +173,20 @@ func (r *wikiPageRepository) List(ctx context.Context, req *types.WikiPageListRe
 		query = query.Where("status = ?", req.Status)
 	}
 	if req.Query != "" {
-		// Use PostgreSQL full-text search + ILIKE for aliases
-		query = query.Where(
-			"(to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(content, '')) @@ plainto_tsquery('simple', ?) OR aliases::text ILIKE ?)",
-			req.Query,
-			"%"+req.Query+"%",
-		)
+		if r.db.Dialector != nil && r.db.Dialector.Name() == "postgres" {
+			query = query.Where(
+				"(to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(content, '')) @@ plainto_tsquery('simple', ?) OR aliases::text ILIKE ?)",
+				req.Query,
+				"%"+req.Query+"%",
+			)
+		} else {
+			query = query.Where(
+				"(LOWER(COALESCE(title, '')) LIKE LOWER(?) OR LOWER(COALESCE(content, '')) LIKE LOWER(?) OR LOWER(COALESCE(aliases, '')) LIKE LOWER(?))",
+				"%"+req.Query+"%",
+				"%"+req.Query+"%",
+				"%"+req.Query+"%",
+			)
+		}
 	}
 	// Directory filters are pushed to SQL so the DB does the counting and
 	// pagination instead of loading every page of the type into memory. `depth`
@@ -306,6 +322,17 @@ func (r *wikiPageRepository) ListByTypeLight(
 	return entries, total, nil
 }
 
+// dialectSourceRefsCondition returns a dialect-appropriate WHERE clause for
+// matching source_refs JSON array containment. For PostgreSQL it uses the
+// @> operator and ::text for LIKE; for MySQL/SQLite it uses JSON_CONTAINS
+// and bare column for LIKE.
+func (r *wikiPageRepository) dialectSourceRefsCondition(dbName string) (containmentExpr string, likeExpr string) {
+	if dbName == "postgres" {
+		return "source_refs @> ?::jsonb", "source_refs::text LIKE ?"
+	}
+	return "JSON_CONTAINS(source_refs, ?)", "source_refs LIKE ?"
+}
+
 // ListBySourceRef retrieves all wiki pages that reference a given source knowledge ID.
 // Handles both old format ("knowledgeID") and new format ("knowledgeID|title") in source_refs JSON array.
 func (r *wikiPageRepository) ListBySourceRef(ctx context.Context, kbID string, sourceKnowledgeID string) ([]*types.WikiPage, error) {
@@ -333,8 +360,9 @@ func (r *wikiPageRepository) ListBySourceRef(ctx context.Context, kbID string, s
 	likePattern := "%" + escapeLikePattern(prefixStr) + "%"
 
 	var pages []*types.WikiPage
+	containmentExpr, likeExpr := r.dialectSourceRefsCondition(r.db.Dialector.Name())
 	if err := r.db.WithContext(ctx).
-		Where("knowledge_base_id = ? AND (source_refs @> ?::jsonb OR source_refs::text LIKE ?)",
+		Where("knowledge_base_id = ? AND ("+containmentExpr+" OR "+likeExpr+")",
 			kbID,
 			string(needle),
 			likePattern,
@@ -369,10 +397,11 @@ func (r *wikiPageRepository) ListSlugsBySourceRef(ctx context.Context, kbID stri
 	}
 	likePattern := "%" + escapeLikePattern(prefixStr) + "%"
 
+	containmentExpr, likeExpr := r.dialectSourceRefsCondition(r.db.Dialector.Name())
 	var slugs []string
 	if err := r.db.WithContext(ctx).
 		Model(&types.WikiPage{}).
-		Where("knowledge_base_id = ? AND (source_refs @> ?::jsonb OR source_refs::text LIKE ?)",
+		Where("knowledge_base_id = ? AND ("+containmentExpr+" OR "+likeExpr+")",
 			kbID,
 			string(needle),
 			likePattern,
@@ -649,7 +678,8 @@ func (r *wikiPageRepository) ListSummariesByKnowledgeIDs(
 		if err != nil {
 			return nil, fmt.Errorf("marshal kid needle: %w", err)
 		}
-		clauses = append(clauses, "source_refs @> ?::jsonb")
+		containmentExpr, likeExpr := r.dialectSourceRefsCondition(r.db.Dialector.Name())
+		clauses = append(clauses, containmentExpr)
 		args = append(args, string(needle))
 
 		prefix, err := json.Marshal(kid + "|")
@@ -660,7 +690,7 @@ func (r *wikiPageRepository) ListSummariesByKnowledgeIDs(
 		if len(prefixStr) >= 2 && prefixStr[len(prefixStr)-1] == '"' {
 			prefixStr = prefixStr[:len(prefixStr)-1]
 		}
-		clauses = append(clauses, "source_refs::text LIKE ?")
+		clauses = append(clauses, likeExpr)
 		args = append(args, "%"+escapeLikePattern(prefixStr)+"%")
 	}
 	if len(clauses) == 0 {
@@ -984,17 +1014,21 @@ func (r *wikiPageRepository) Search(ctx context.Context, kbID string, query stri
 	// alias so the DB only computes the rank once. Parameterized four
 	// times with the same regex to avoid coupling to GORM's positional
 	// arg rewriting quirks.
+	regexOp := "~*"
+	if r.db.Dialector.Name() != "postgres" {
+		regexOp = "REGEXP"
+	}
 	rankExpr := "CASE " +
-		"WHEN title ~* ? THEN 4 " +
-		"WHEN slug ~* ? THEN 3 " +
-		"WHEN summary ~* ? THEN 2 " +
-		"WHEN content ~* ? THEN 1 " +
+		"WHEN title " + regexOp + " ? THEN 4 " +
+		"WHEN slug " + regexOp + " ? THEN 3 " +
+		"WHEN summary " + regexOp + " ? THEN 2 " +
+		"WHEN content " + regexOp + " ? THEN 1 " +
 		"ELSE 0 END AS match_rank"
 
 	var pages []*types.WikiPage
 	if err := r.db.WithContext(ctx).
 		Select("*, "+rankExpr, query, query, query, query).
-		Where("knowledge_base_id = ? AND (title ~* ? OR content ~* ? OR summary ~* ? OR slug ~* ?)",
+		Where("knowledge_base_id = ? AND (title "+regexOp+" ? OR content "+regexOp+" ? OR summary "+regexOp+" ? OR slug "+regexOp+" ?)",
 			kbID, query, query, query, query).
 		Where("status != ?", "archived").
 		Order("match_rank DESC, updated_at DESC").
@@ -1034,7 +1068,7 @@ func (r *wikiPageRepository) CountOrphans(ctx context.Context, kbID string) (int
 	if err := r.db.WithContext(ctx).
 		Model(&types.WikiPage{}).
 		Where("knowledge_base_id = ?", kbID).
-		Where("(in_links IS NULL OR in_links = '[]'::JSONB)").
+		Where("(in_links IS NULL OR in_links = ?)", "[]").
 		// Exclude index and log pages as they are naturally root pages
 		Where("page_type NOT IN ?", []string{types.WikiPageTypeIndex, types.WikiPageTypeLog}).
 		Count(&count).Error; err != nil {

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -29,6 +29,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/dig"
 	"google.golang.org/grpc"
+	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -588,6 +589,32 @@ func initDatabase(cfg *config.Config) (*gorm.DB, error) {
 			os.Getenv("DB_PORT"),
 			os.Getenv("DB_NAME"),
 		)
+	case "mysql":
+		dsn := fmt.Sprintf(
+			"%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local",
+			os.Getenv("DB_USER"),
+			os.Getenv("DB_PASSWORD"),
+			os.Getenv("DB_HOST"),
+			os.Getenv("DB_PORT"),
+			os.Getenv("DB_NAME"),
+		)
+		dialector = mysql.Open(dsn)
+
+		encodedPassword := url.QueryEscape(os.Getenv("DB_PASSWORD"))
+		migrateDSN = fmt.Sprintf(
+			"mysql://%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=true&loc=Local&multiStatements=true",
+			os.Getenv("DB_USER"),
+			encodedPassword,
+			os.Getenv("DB_HOST"),
+			os.Getenv("DB_PORT"),
+			os.Getenv("DB_NAME"),
+		)
+		logger.Infof(context.Background(), "DB Config: driver=mysql user=%s host=%s port=%s dbname=%s",
+			os.Getenv("DB_USER"),
+			os.Getenv("DB_HOST"),
+			os.Getenv("DB_PORT"),
+			os.Getenv("DB_NAME"),
+		)
 	case "sqlite":
 		dbPath := os.Getenv("DB_PATH")
 		if dbPath == "" {
@@ -622,9 +649,9 @@ func initDatabase(cfg *config.Config) (*gorm.DB, error) {
 	// different name (e.g., a wrapper dialect for managed PG) would silently
 	// fall back to the SQLite path, dropping the row-level X-lock. Catching
 	// the mismatch at startup is loud and inexpensive.
-	if name := db.Dialector.Name(); name != "postgres" && name != "sqlite" {
+	if name := db.Dialector.Name(); name != "postgres" && name != "sqlite" && name != "mysql" {
 		return nil, fmt.Errorf(
-			"unsupported gorm dialector %q; expected postgres or sqlite "+
+			"unsupported gorm dialector %q; expected postgres, mysql, or sqlite "+
 				"(see vectorStoreService.isPostgres for impact)", name)
 	}
 
@@ -704,8 +731,13 @@ func resolveStorageProviderPending(db *gorm.DB) {
 	}
 	storageType = strings.ToLower(storageType)
 
+	// MySQL uses JSON_UNQUOTE(JSON_EXTRACT(...)) instead of PostgreSQL's ->>
+	providerExpr := "storage_provider_config->>'provider'"
+	if db.Dialector.Name() == "mysql" {
+		providerExpr = "JSON_UNQUOTE(JSON_EXTRACT(storage_provider_config, '$.provider'))"
+	}
 	result := db.Exec(
-		`UPDATE knowledge_bases SET storage_provider_config = ? WHERE storage_provider_config IS NOT NULL AND storage_provider_config->>'provider' = '__pending_env__'`,
+		fmt.Sprintf(`UPDATE knowledge_bases SET storage_provider_config = ? WHERE storage_provider_config IS NOT NULL AND %s = '__pending_env__'`, providerExpr),
 		fmt.Sprintf(`{"provider":"%s"}`, storageType),
 	)
 	if result.Error != nil {

--- a/internal/database/migration.go
+++ b/internal/database/migration.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
 
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/mysql"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	sqlite3migrate "github.com/golang-migrate/migrate/v4/database/sqlite3"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -104,7 +106,9 @@ func RunMigrationsWithOptions(dsn string, opts MigrationOptions) error {
 	logger.Infof(ctx, "Starting database migration...")
 
 	migrationsPath := "file://migrations/versioned"
-	if strings.HasPrefix(dsn, "sqlite3://") {
+	if strings.HasPrefix(dsn, "mysql://") {
+		migrationsPath = "file://migrations/mysql"
+	} else if strings.HasPrefix(dsn, "sqlite3://") {
 		migrationsPath = "file://migrations/sqlite"
 	}
 
@@ -300,16 +304,37 @@ func recoverFromDirtyState(ctx context.Context, m *migrate.Migrate, dirtyVersion
 
 // GetMigrationVersion returns the current migration version
 func GetMigrationVersion() (uint, bool, error) {
-	dbURL := fmt.Sprintf(
-		"postgres://%s:%s@%s:%s/%s?sslmode=disable",
-		os.Getenv("DB_USER"),
-		os.Getenv("DB_PASSWORD"),
-		os.Getenv("DB_HOST"),
-		os.Getenv("DB_PORT"),
-		os.Getenv("DB_NAME"),
-	)
+	var dbURL string
+	var migrationsPath string
 
-	migrationsPath := "file://migrations/versioned"
+	driver := os.Getenv("DB_DRIVER")
+	switch driver {
+	case "mysql":
+		dbPassword := os.Getenv("DB_PASSWORD")
+		encodedPassword := url.QueryEscape(dbPassword)
+		dbURL = fmt.Sprintf(
+			"mysql://%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=true&loc=Local",
+			os.Getenv("DB_USER"),
+			encodedPassword,
+			os.Getenv("DB_HOST"),
+			os.Getenv("DB_PORT"),
+			os.Getenv("DB_NAME"),
+		)
+		migrationsPath = "file://migrations/mysql"
+	case "sqlite":
+		migrationsPath = "file://migrations/sqlite"
+		dbURL = "sqlite3://" + os.Getenv("DB_PATH")
+	default:
+		dbURL = fmt.Sprintf(
+			"postgres://%s:%s@%s:%s/%s?sslmode=disable",
+			os.Getenv("DB_USER"),
+			os.Getenv("DB_PASSWORD"),
+			os.Getenv("DB_HOST"),
+			os.Getenv("DB_PORT"),
+			os.Getenv("DB_NAME"),
+		)
+		migrationsPath = "file://migrations/versioned"
+	}
 
 	m, err := migrate.New(migrationsPath, dbURL)
 	if err != nil {


### PR DESCRIPTION
| 文件 | 改动内容 |
|------|----------|
| `internal/container/container.go` | 新增 `gorm.io/driver/mysql` 导入；`initDatabase` 新增 `case "mysql"`（DSN 构建、迁移 DSN、日志）；启动守卫包含 `"mysql"`；`resolveStorageProviderPending` 使用 MySQL 的 `JSON_UNQUOTE(JSON_EXTRACT(...))` |
| `internal/database/migration.go` | 导入 MySQL 迁移驱动；迁移路径选择支持 `mysql://`；`GetMigrationVersion` 支持 MySQL DSN |
| `migrations/mysql/000000_init.up.sql` | 完整 MySQL schema — 43 张表（涵盖所有 PostgreSQL 和 SQLite 的表），InnoDB + utf8mb4，JSON 数据类型，外键约束 |
| `migrations/mysql/000000_init.down.sql` | 按依赖顺序删除所有表 |