### PR TITLE
fix: storage engine config retrieval and default provider fallback handling

### DIFF
--- a/client/system.go
+++ b/client/system.go
@@ -34,6 +34,7 @@ type ParserEngine struct {
 // StorageEngineStatusItem describes one storage engine's availability
 type StorageEngineStatusItem struct {
 	Name        string `json:"name"`
+	Allowed     bool   `json:"allowed"`
 	Available   bool   `json:"available"`
 	Description string `json:"description"`
 }
@@ -41,6 +42,7 @@ type StorageEngineStatusItem struct {
 // StorageEngineStatusResponse is the response for storage engine status
 type StorageEngineStatusResponse struct {
 	Engines           []StorageEngineStatusItem `json:"engines"`
+	AllowedProviders  []string                  `json:"allowed_providers"`
 	MinioEnvAvailable bool                      `json:"minio_env_available"`
 }
 

--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
@@ -953,14 +953,35 @@ const handleAddWikiModel = () => {
 
 const handleStorageProviderUpdate = (value: string) => {
   if (formData.value) {
-    formData.value.storageProvider = value || tenantDefaultStorageProvider.value || 'local'
+    formData.value.storageProvider = props.mode === 'create'
+      ? pickUsableStorageProvider(value || tenantDefaultStorageProvider.value)
+      : (value || tenantDefaultStorageProvider.value || 'local')
   }
+}
+
+function pickUsableStorageProvider(candidate?: string): string {
+  const provider = candidate?.trim() || ''
+  const engines = editorResources.storageStatus || []
+  const allowedProviders = editorResources.storageAllowedProviders || []
+  const isUsable = (name: string) => {
+    if (!name) return false
+    const status = engines.find((item) => item.name === name)
+    if (status) return status.allowed !== false && status.available !== false
+    if (engines.length > 0) return false
+    if (allowedProviders.length > 0) return allowedProviders.includes(name)
+    return false
+  }
+
+  if (isUsable(provider)) return provider
+  const fallback = engines.find((item) => item.allowed !== false && item.available !== false)?.name
+  if (fallback) return fallback
+  return allowedProviders[0] || provider || 'local'
 }
 
 async function loadTenantDefaultStorageProvider(force = false) {
   try {
     await editorResources.ensureStorageEngine(force)
-    tenantDefaultStorageProvider.value = editorResources.storageConfig?.default_provider || 'local'
+    tenantDefaultStorageProvider.value = pickUsableStorageProvider(editorResources.storageConfig?.default_provider)
   } catch {
     tenantDefaultStorageProvider.value = 'local'
   }
@@ -969,6 +990,9 @@ async function loadTenantDefaultStorageProvider(force = false) {
 /** Resolved storage provider for create payload (never silently default to local before tenant config loads). */
 function resolvedStorageProvider(): string {
   const explicit = formData.value?.storageProvider?.trim()
+  if (props.mode === 'create') {
+    return pickUsableStorageProvider(explicit || tenantDefaultStorageProvider.value)
+  }
   if (explicit) return explicit
   return tenantDefaultStorageProvider.value || 'local'
 }

--- a/frontend/src/views/knowledge/settings/KBStorageSettings.vue
+++ b/frontend/src/views/knowledge/settings/KBStorageSettings.vue
@@ -79,76 +79,78 @@ const allowedProviders = ref<string[]>([])
 const hasAnyConfig = ref(false)
 
 const engineOptions = computed(() => {
-  const statusMap: Record<string, boolean> = {}
-  const allowedMap: Record<string, boolean> = {}
-  for (const e of engineStatus.value) {
-    statusMap[e.name] = e.available
-    allowedMap[e.name] = e.allowed !== false
+  const statusByName = new Map(engineStatus.value.map((engine) => [engine.name, engine]))
+  const allowedSet = new Set(allowedProviders.value)
+  const hasStatus = engineStatus.value.length > 0
+  const hasAllowedList = allowedProviders.value.length > 0
+  const resolveState = (name: string, fallbackAvailable = false) => {
+    const status = statusByName.get(name)
+    const allowed = status?.allowed ?? (hasAllowedList ? allowedSet.has(name) : !hasStatus)
+    const available = status?.available ?? fallbackAvailable
+    return {
+      allowed,
+      available,
+      disabled: !allowed || !available,
+    }
   }
+
+  const local = resolveState('local', true)
+  const minio = resolveState('minio')
+  const cos = resolveState('cos')
+  const tos = resolveState('tos')
+  const s3 = resolveState('s3')
+  const oss = resolveState('oss')
+  const ks3 = resolveState('ks3')
+  const obs = resolveState('obs')
+
   return [
     {
       value: 'local',
       label: t('kbSettings.storage.engineLocal'),
       desc: t('kbSettings.storage.engineLocalDesc'),
-      allowed: allowedMap.local !== false,
-      available: statusMap.local !== false,
-      disabled: allowedMap.local === false,
+      ...local,
     },
     {
       value: 'minio',
       label: 'MinIO',
       desc: t('kbSettings.storage.engineMinioDesc'),
-      allowed: allowedMap.minio !== false,
-      available: statusMap.minio,
-      disabled: allowedMap.minio === false || statusMap.minio === false,
+      ...minio,
     },
     {
       value: 'cos',
       label: t('kbSettings.storage.engineCos'),
       desc: t('kbSettings.storage.engineCosDesc'),
-      allowed: allowedMap.cos !== false,
-      available: statusMap.cos,
-      disabled: allowedMap.cos === false || statusMap.cos === false,
+      ...cos,
     },
     {
       value: 'tos',
       label: t('kbSettings.storage.engineTos'),
       desc: t('kbSettings.storage.engineTosDesc'),
-      allowed: allowedMap.tos !== false,
-      available: statusMap.tos,
-      disabled: allowedMap.tos === false || statusMap.tos === false,
+      ...tos,
     },
     {
       value: 's3',
       label: t('kbSettings.storage.engineS3'),
       desc: t('kbSettings.storage.engineS3Desc'),
-      allowed: allowedMap.s3 !== false,
-      available: statusMap.s3,
-      disabled: allowedMap.s3 === false || statusMap.s3 === false,
+      ...s3,
     },
     {
       value: 'oss',
       label: t('kbSettings.storage.engineOss'),
       desc: t('kbSettings.storage.engineOssDesc'),
-      allowed: allowedMap.oss !== false,
-      available: statusMap.oss,
-      disabled: allowedMap.oss === false || statusMap.oss === false,
+      ...oss,
     },
     {
       value: 'ks3',
       label: t('kbSettings.storage.engineKs3'),
       desc: t('kbSettings.storage.engineKs3Desc'),
-      allowed: allowedMap.ks3 !== false,
-      available: statusMap.ks3,
-      disabled: allowedMap.ks3 === false || statusMap.ks3 === false,
+      ...ks3,
     },
     {
       value: 'obs',
       label: t('kbSettings.storage.engineObs'),
       desc: t('kbSettings.storage.engineObsDesc'),
-      allowed: allowedMap.obs !== false,
-      available: statusMap.obs,
-      disabled: allowedMap.obs === false || statusMap.obs === false,
+      ...obs,
     },
   ]
 })

--- a/internal/handler/system.go
+++ b/internal/handler/system.go
@@ -540,6 +540,17 @@ func (h *SystemHandler) isKS3Configured(c *gin.Context) bool {
 	return false
 }
 
+// isOBSConfigured checks whether OBS connection info is available from tenant config or env.
+func (h *SystemHandler) isOBSConfigured(c *gin.Context) bool {
+	if v, exists := c.Get(types.TenantInfoContextKey.String()); exists {
+		if tenant, ok := v.(*types.Tenant); ok && tenant != nil && tenant.StorageEngineConfig != nil && tenant.StorageEngineConfig.OBS != nil {
+			obsConf := tenant.StorageEngineConfig.OBS
+			return obsConf.Endpoint != "" && obsConf.Region != "" && obsConf.AccessKey != "" && obsConf.SecretKey != "" && obsConf.BucketName != ""
+		}
+	}
+	return h.isOBSEnvAvailable()
+}
+
 // isTOSEnvAvailable checks whether TOS env vars are set.
 func (h *SystemHandler) isTOSEnvAvailable() bool {
 	return os.Getenv("TOS_ENDPOINT") != "" &&
@@ -549,9 +560,18 @@ func (h *SystemHandler) isTOSEnvAvailable() bool {
 		os.Getenv("TOS_BUCKET_NAME") != ""
 }
 
+// isOBSEnvAvailable checks whether OBS env vars are set.
+func (h *SystemHandler) isOBSEnvAvailable() bool {
+	return os.Getenv("OBS_ENDPOINT") != "" &&
+		os.Getenv("OBS_REGION") != "" &&
+		os.Getenv("OBS_ACCESS_KEY") != "" &&
+		os.Getenv("OBS_SECRET_KEY") != "" &&
+		os.Getenv("OBS_BUCKET_NAME") != ""
+}
+
 // StorageEngineStatusItem describes one storage engine's availability and description.
 type StorageEngineStatusItem struct {
-	Name        string `json:"name"` // "local", "minio", "cos", "tos", "s3", "oss", "ks3"
+	Name        string `json:"name"` // "local", "minio", "cos", "tos", "s3", "oss", "ks3", "obs"
 	Allowed     bool   `json:"allowed"`
 	Available   bool   `json:"available"`   // whether the engine can be used
 	Description string `json:"description"` // short description for UI
@@ -579,6 +599,7 @@ func (h *SystemHandler) GetStorageEngineStatus(c *gin.Context) {
 	s3Configured := h.isS3Configured(c)
 	ossConfigured := h.isOSSConfigured(c)
 	ks3Configured := h.isKS3Configured(c)
+	obsConfigured := h.isOBSConfigured(c)
 	allowed := getAllowedStorageProviders()
 	allowedProviders := make([]string, 0, len(supportedStorageProviders))
 	for _, provider := range getSupportedStorageProviders() {
@@ -594,6 +615,7 @@ func (h *SystemHandler) GetStorageEngineStatus(c *gin.Context) {
 		{Name: "s3", Allowed: allowed["s3"], Available: s3Configured, Description: "AWS S3 与兼容对象存储服务，适合公有云与混合云部署"},
 		{Name: "oss", Allowed: allowed["oss"], Available: ossConfigured, Description: "阿里云对象存储服务，适合公有云部署，支持 S3 兼容协议"},
 		{Name: "ks3", Allowed: allowed["ks3"], Available: ks3Configured, Description: "金山云对象存储服务，适合公有云部署"},
+		{Name: "obs", Allowed: allowed["obs"], Available: obsConfigured, Description: "华为云对象存储服务，适合公有云部署"},
 	}
 	c.JSON(200, gin.H{
 		"code": 0,


### PR DESCRIPTION
## Description
fix: Fix /api/v1/tenants/kv/storage-engine-config API not returning Huawei Cloud OBS config, causing the Huawei Cloud OBS option in the knowledge base creation dialog to not display the unavailable indicator correctly

fix: Fix when tenant's default_provider is empty, it falls back to 'local', but 'local' is not in the allowed list, causing knowledge base creation to fail with error: Storage provider is not allowed by STORAGE_ALLOW_LIST

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #

## Testing
fix-1
1. Click "Create Knowledge Base" on the knowledge base page
2. Click "Storage Engine" -> the dropdown list shows Huawei OBS (not actually configured)
3. After the fix, Huawei OBS is correctly displayed as unavailable in the dropdown list

fix-2
1. Configure STORAGE_ALLOW_LIST with only Minio, then restart the backend service
2. Click "Create Knowledge Base" on the knowledge base page
3. Fill in only the basic information, and the user has never configured storage engine info on the system settings page
4. Click "Save" and get the error: Storage provider is not allowed by STORAGE_ALLOW_LIST
5. After the fix, clicking "Save" successfully creates the knowledge base

## Checklist
- [x] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above
