### PR TITLE
fix(api-keys): let manage_kbs keys poll KB copy progress

### DIFF
--- a/internal/router/rbac.go
+++ b/internal/router/rbac.go
@@ -258,8 +258,9 @@ func apiKeyIngest(base middleware.APIKeyRoutePolicy) middleware.APIKeyRoutePolic
 }
 
 // apiKeyManageKnowledgeBases layers the "manage_kbs" capability on top of a
-// base policy so a scoped key can manage existing KB metadata/config within
-// its KB allow-list.
+// base policy so a scoped key can manage the KB lifecycle (create/copy/
+// duplicate/update/delete + config). Existing-KB operations stay bounded by
+// the key's allow-list downstream; create has no source to bound.
 func apiKeyManageKnowledgeBases(base middleware.APIKeyRoutePolicy) middleware.APIKeyRoutePolicy {
 	return base.WithCapability(types.APIKeyCapabilityManageKnowledgeBases)
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -458,8 +458,11 @@ func RegisterKnowledgeBaseRoutes(r *gin.RouterGroup, handler *handler.KnowledgeB
 		// 创建知识库副本 — 产出新 KB，与 create 同档：JWT Contributor+，API key 需 manage_kbs 或 full-access；
 		// 且对源 KB 有 read 权限（KBAccessRead 会对限定 key 兜住源 KB）。只创建新的 KB 设置记录，不复制内容/索引/分享。
 		kbManagement.POST("/:id/duplicate", g.Contributor(), g.KBAccessRead("id"), handler.DuplicateKnowledgeBase)
-		// 获取知识库复制进度 — Viewer+；只读，retrieve OR full-access 均可轮询（租户自查）。
-		kb.GET("/copy/progress/:task_id", g.Viewer(), handler.GetKBCloneProgress)
+		// 获取知识库复制进度 — Viewer+；只读。manage_kbs（发起 copy 的 key）或
+		// retrieve 均可轮询；任务按租户隔离（requireTaskProgressTenant），key 只能
+		// 查本租户任务。
+		kb.With(apiKeyRetrieve(apiKeyManageKnowledgeBases(apiKeyFullAccess()))).
+			GET("/copy/progress/:task_id", g.Viewer(), handler.GetKBCloneProgress)
 		// 获取可移动目标知识库列表 — Viewer+ 且对 KB 有 read 权限
 		kb.GET("/:id/move-targets", g.Viewer(), g.KBAccessRead("id"), handler.ListMoveTargets)
 	}

--- a/internal/router/router_api_key_capabilities_test.go
+++ b/internal/router/router_api_key_capabilities_test.go
@@ -429,6 +429,25 @@ func TestChunkerPreviewRouteRequiresRetrieveOrIngestCapability(t *testing.T) {
 	}
 }
 
+func TestKBCloneProgressRouteRequiresRetrieveOrManageKbsCapability(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	g := &rbacGuards{}
+	v1 := gin.New().Group("/api/v1")
+
+	RegisterKnowledgeBaseRoutes(v1, &handler.KnowledgeBaseHandler{}, g)
+
+	policy := mustLookupAPIKeyPolicy(t, g, http.MethodGet, "/api/v1/knowledge-bases/copy/progress/:task_id")
+	if !policy.RequireFullAccess {
+		t.Fatal("policy should require full access without a matching capability")
+	}
+	if !policyHasCapability(policy, types.APIKeyCapabilityRetrieve) {
+		t.Fatalf("policy capabilities = %#v, want retrieve", policy.Capabilities)
+	}
+	if !policyHasCapability(policy, types.APIKeyCapabilityManageKnowledgeBases) {
+		t.Fatalf("policy capabilities = %#v, want manage_kbs", policy.Capabilities)
+	}
+}
+
 func TestFAQImportProgressRouteRequiresRetrieveOrIngestCapability(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	g := &rbacGuards{}


### PR DESCRIPTION
## Summary

- After #2068, scoped keys with only `manage_kbs` can start `POST /knowledge-bases/copy` but were still blocked at the API-key gate on `GET /knowledge-bases/copy/progress/:task_id` (which only admitted `retrieve` or full-access).
- Align the copy-progress route with the FAQ import-progress pattern: admit `manage_kbs` OR `retrieve` OR full-access. Progress remains tenant-scoped via `requireTaskProgressTenant`.
- Add a router policy test and refresh the `apiKeyManageKnowledgeBases` helper comment.

## Test plan

- [x] `go test ./internal/router/ -run 'TestKBCloneProgressRoute|TestKnowledgeBase(Lifecycle|Management)'`
- [ ] Create an API key with only `manage_kbs` (no `retrieve`), start a KB copy, and confirm progress polling succeeds