### PR TITLE
fix(storage): align default provider fallback with STORAGE_ALLOW_LIST

### DIFF
--- a/frontend/src/stores/editorResources.ts
+++ b/frontend/src/stores/editorResources.ts
@@ -18,6 +18,27 @@ import { getTenantRetrievalConfig } from '@/api/retrieval'
 
 const CACHE_TTL_MS = 60_000
 
+export function pickUsableStorageProvider(
+  candidate: string | undefined,
+  engines: StorageEngineStatusItem[],
+  allowedProviders: string[],
+): string {
+  const provider = candidate?.trim() || ''
+  const isUsable = (name: string) => {
+    if (!name) return false
+    const status = engines.find((item) => item.name === name)
+    if (status) return status.allowed !== false && status.available !== false
+    if (engines.length > 0) return false
+    if (allowedProviders.length > 0) return allowedProviders.includes(name)
+    return false
+  }
+
+  if (isUsable(provider)) return provider
+  const fallback = engines.find((item) => item.allowed !== false && item.available !== false)?.name
+  if (fallback) return fallback
+  return allowedProviders[0] || provider || 'local'
+}
+
 type EditorResourceKey =
   | 'storageEngine'
   | 'mcpServices'
@@ -71,6 +92,14 @@ export const useEditorResourcesStore = defineStore('editorResources', () => {
       storageAllowedProviders.value = statusRes?.data?.allowed_providers ?? []
       loadedAt.value.storageEngine = Date.now()
     })
+  }
+
+  function resolveUsableStorageProvider(candidate?: string): string {
+    return pickUsableStorageProvider(
+      candidate,
+      storageStatus.value || [],
+      storageAllowedProviders.value || [],
+    )
   }
 
   async function ensureMcpServices(force = false): Promise<void> {
@@ -193,6 +222,7 @@ export const useEditorResourcesStore = defineStore('editorResources', () => {
     parserEngines,
     systemInfo,
     ensureStorageEngine,
+    resolveUsableStorageProvider,
     ensureMcpServices,
     ensureSkills,
     ensureAgentTypePresets,

--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
@@ -1020,36 +1020,19 @@ const handleAddWikiModel = () => {
 const handleStorageProviderUpdate = (value: string) => {
   if (formData.value) {
     formData.value.storageProvider = props.mode === 'create'
-      ? pickUsableStorageProvider(value || tenantDefaultStorageProvider.value)
+      ? editorResources.resolveUsableStorageProvider(value || tenantDefaultStorageProvider.value)
       : (value || tenantDefaultStorageProvider.value || 'local')
   }
-}
-
-function pickUsableStorageProvider(candidate?: string): string {
-  const provider = candidate?.trim() || ''
-  const engines = editorResources.storageStatus || []
-  const allowedProviders = editorResources.storageAllowedProviders || []
-  const isUsable = (name: string) => {
-    if (!name) return false
-    const status = engines.find((item) => item.name === name)
-    if (status) return status.allowed !== false && status.available !== false
-    if (engines.length > 0) return false
-    if (allowedProviders.length > 0) return allowedProviders.includes(name)
-    return false
-  }
-
-  if (isUsable(provider)) return provider
-  const fallback = engines.find((item) => item.allowed !== false && item.available !== false)?.name
-  if (fallback) return fallback
-  return allowedProviders[0] || provider || 'local'
 }
 
 async function loadTenantDefaultStorageProvider(force = false) {
   try {
     await editorResources.ensureStorageEngine(force)
-    tenantDefaultStorageProvider.value = pickUsableStorageProvider(editorResources.storageConfig?.default_provider)
+    tenantDefaultStorageProvider.value = editorResources.resolveUsableStorageProvider(
+      editorResources.storageConfig?.default_provider,
+    )
   } catch {
-    tenantDefaultStorageProvider.value = 'local'
+    tenantDefaultStorageProvider.value = editorResources.resolveUsableStorageProvider()
   }
 }
 
@@ -1057,7 +1040,7 @@ async function loadTenantDefaultStorageProvider(force = false) {
 function resolvedStorageProvider(): string {
   const explicit = formData.value?.storageProvider?.trim()
   if (props.mode === 'create') {
-    return pickUsableStorageProvider(explicit || tenantDefaultStorageProvider.value)
+    return editorResources.resolveUsableStorageProvider(explicit || tenantDefaultStorageProvider.value)
   }
   if (explicit) return explicit
   return tenantDefaultStorageProvider.value || 'local'

--- a/frontend/src/views/knowledge/settings/KBStorageSettings.vue
+++ b/frontend/src/views/knowledge/settings/KBStorageSettings.vue
@@ -168,10 +168,9 @@ function handleChange() {
 }
 
 function ensureAllowedProvider() {
-  const current = engineOptions.value.find(o => o.value === localProvider.value && !o.disabled)
-  if (current) return
-  const fallback = engineOptions.value.find(o => !o.disabled)?.value || defaultProvider.value || 'local'
-  localProvider.value = fallback
+  const resolved = editorResources.resolveUsableStorageProvider(localProvider.value)
+  if (resolved === localProvider.value) return
+  localProvider.value = resolved
   emit('update:storageProvider', localProvider.value)
 }
 
@@ -187,7 +186,9 @@ async function load(force = false) {
     const engines = editorResources.storageStatus
     engineStatus.value = engines
     allowedProviders.value = editorResources.storageAllowedProviders
-    defaultProvider.value = editorResources.storageConfig?.default_provider || 'local'
+    defaultProvider.value = editorResources.resolveUsableStorageProvider(
+      editorResources.storageConfig?.default_provider,
+    )
     const d = editorResources.storageConfig
     hasAnyConfig.value = !!(d?.local?.path_prefix || d?.minio?.bucket_name || d?.cos?.bucket_name || d?.tos?.bucket_name || d?.s3?.bucket_name || d?.oss?.bucket_name || d?.ks3?.bucket_name || d?.obs?.bucket_name)
     const parentUnset = !props.storageProvider

--- a/internal/application/service/knowledgebase.go
+++ b/internal/application/service/knowledgebase.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/datasource"
 	apperrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/storageallowlist"
 	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
@@ -157,11 +158,15 @@ func applyTenantDefaultStorageProvider(ctx context.Context, kb *types.KnowledgeB
 		return
 	}
 	tenant, _ := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
-	provider := "local"
+	provider := ""
 	if tenant != nil && tenant.StorageEngineConfig != nil {
-		if p := strings.ToLower(strings.TrimSpace(tenant.StorageEngineConfig.DefaultProvider)); p != "" {
-			provider = p
-		}
+		provider = strings.ToLower(strings.TrimSpace(tenant.StorageEngineConfig.DefaultProvider))
+	}
+	if provider == "" || !storageallowlist.IsAllowed(provider) {
+		provider = storageallowlist.FirstAllowed()
+	}
+	if provider == "" {
+		return
 	}
 	kb.SetStorageProvider(provider)
 }

--- a/internal/application/service/knowledgebase_pr3_test.go
+++ b/internal/application/service/knowledgebase_pr3_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
 	apperrors "github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/storageallowlist"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"github.com/stretchr/testify/assert"
@@ -165,6 +166,20 @@ func TestCreateKnowledgeBase_DefaultStorageProviderFromTenant(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "cos", kbExplicit.GetStorageProvider())
+}
+
+func TestCreateKnowledgeBase_DefaultStorageProviderRespectsAllowList(t *testing.T) {
+	t.Setenv(storageallowlist.AllowListEnv, "minio")
+	repo := newFakeKBRepo()
+	svc := newPR3KBService(repo, &fakeRegistry{registered: map[string]struct{}{}}, &fakeOwnership{})
+
+	kb, err := svc.CreateKnowledgeBase(ctxWithTenantStorage(1, ""), &types.KnowledgeBase{Name: "kb"})
+	require.NoError(t, err)
+	assert.Equal(t, "minio", kb.GetStorageProvider())
+
+	kbDisallowedDefault, err := svc.CreateKnowledgeBase(ctxWithTenantStorage(1, "local"), &types.KnowledgeBase{Name: "kb2"})
+	require.NoError(t, err)
+	assert.Equal(t, "minio", kbDisallowedDefault.GetStorageProvider())
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/handler/storage_allowlist.go
+++ b/internal/handler/storage_allowlist.go
@@ -1,68 +1,19 @@
 package handler
 
-import (
-	"os"
-	"strings"
-)
-
-const storageAllowListEnv = "STORAGE_ALLOW_LIST"
-
-var supportedStorageProviders = []string{"local", "minio", "cos", "tos", "s3", "oss", "ks3", "obs"}
+import "github.com/Tencent/WeKnora/internal/storageallowlist"
 
 func getSupportedStorageProviders() []string {
-	providers := make([]string, len(supportedStorageProviders))
-	copy(providers, supportedStorageProviders)
-	return providers
+	return storageallowlist.Supported()
 }
 
 func getAllowedStorageProviders() map[string]bool {
-	raw := strings.TrimSpace(os.Getenv(storageAllowListEnv))
-	allowed := make(map[string]bool, len(supportedStorageProviders))
-
-	if raw == "" {
-		for _, provider := range supportedStorageProviders {
-			allowed[provider] = true
-		}
-		return allowed
-	}
-
-	for _, item := range strings.FieldsFunc(raw, func(r rune) bool {
-		switch r {
-		case ',', ';', '|', '\n', '\t', ' ':
-			return true
-		default:
-			return false
-		}
-	}) {
-		provider := strings.ToLower(strings.TrimSpace(item))
-		if provider == "" {
-			continue
-		}
-		for _, supported := range supportedStorageProviders {
-			if provider == supported {
-				allowed[provider] = true
-				break
-			}
-		}
-	}
-
-	return allowed
+	return storageallowlist.AllowedMap()
 }
 
 func isStorageProviderAllowed(provider string) bool {
-	provider = strings.ToLower(strings.TrimSpace(provider))
-	if provider == "" {
-		return true
-	}
-	return getAllowedStorageProviders()[provider]
+	return storageallowlist.IsAllowed(provider)
 }
 
 func firstAllowedStorageProvider() string {
-	allowed := getAllowedStorageProviders()
-	for _, provider := range supportedStorageProviders {
-		if allowed[provider] {
-			return provider
-		}
-	}
-	return ""
+	return storageallowlist.FirstAllowed()
 }

--- a/internal/handler/system.go
+++ b/internal/handler/system.go
@@ -620,7 +620,7 @@ func (h *SystemHandler) GetStorageEngineStatus(c *gin.Context) {
 	ks3Configured := h.isKS3Configured(c)
 	obsConfigured := h.isOBSConfigured(c)
 	allowed := getAllowedStorageProviders()
-	allowedProviders := make([]string, 0, len(supportedStorageProviders))
+	allowedProviders := make([]string, 0, len(getSupportedStorageProviders()))
 	for _, provider := range getSupportedStorageProviders() {
 		if allowed[provider] {
 			allowedProviders = append(allowedProviders, provider)

--- a/internal/handler/system_storage_engine_test.go
+++ b/internal/handler/system_storage_engine_test.go
@@ -1,0 +1,92 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/storageallowlist"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetStorageEngineStatus_IncludesOBS(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv(storageallowlist.AllowListEnv, "")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/system/storage-engine-status", nil)
+
+	h := &SystemHandler{}
+	h.GetStorageEngineStatus(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Code int `json:"code"`
+		Data struct {
+			Engines []StorageEngineStatusItem `json:"engines"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, 0, resp.Code)
+
+	names := make([]string, 0, len(resp.Data.Engines))
+	obsStatus := StorageEngineStatusItem{}
+	for _, engine := range resp.Data.Engines {
+		names = append(names, engine.Name)
+		if engine.Name == "obs" {
+			obsStatus = engine
+		}
+	}
+	assert.Contains(t, names, "obs")
+	assert.True(t, obsStatus.Allowed)
+	assert.False(t, obsStatus.Available)
+}
+
+func TestGetStorageEngineStatus_OBSConfiguredFromTenant(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv(storageallowlist.AllowListEnv, "")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/system/storage-engine-status", nil)
+	tenant := &types.Tenant{
+		StorageEngineConfig: &types.StorageEngineConfig{
+			OBS: &types.OBSEngineConfig{
+				Endpoint:   "obs.example.com",
+				Region:     "cn-north-4",
+				AccessKey:  "ak",
+				SecretKey:  "sk",
+				BucketName: "bucket",
+			},
+		},
+	}
+	c.Set(types.TenantInfoContextKey.String(), tenant)
+
+	h := &SystemHandler{}
+	h.GetStorageEngineStatus(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Data struct {
+			Engines []StorageEngineStatusItem `json:"engines"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var obsStatus *StorageEngineStatusItem
+	for i := range resp.Data.Engines {
+		if resp.Data.Engines[i].Name == "obs" {
+			obsStatus = &resp.Data.Engines[i]
+			break
+		}
+	}
+	require.NotNil(t, obsStatus)
+	assert.True(t, obsStatus.Available)
+}

--- a/internal/storageallowlist/allowlist.go
+++ b/internal/storageallowlist/allowlist.go
@@ -1,0 +1,84 @@
+package storageallowlist
+
+import (
+	"os"
+	"strings"
+)
+
+const AllowListEnv = "STORAGE_ALLOW_LIST"
+
+var supported = []string{"local", "minio", "cos", "tos", "s3", "oss", "ks3", "obs"}
+
+// Supported returns the canonical storage provider names in display order.
+func Supported() []string {
+	providers := make([]string, len(supported))
+	copy(providers, supported)
+	return providers
+}
+
+// AllowedMap returns which providers are permitted by STORAGE_ALLOW_LIST.
+func AllowedMap() map[string]bool {
+	raw := strings.TrimSpace(os.Getenv(AllowListEnv))
+	allowed := make(map[string]bool, len(supported))
+
+	if raw == "" {
+		for _, provider := range supported {
+			allowed[provider] = true
+		}
+		return allowed
+	}
+
+	for _, item := range strings.FieldsFunc(raw, func(r rune) bool {
+		switch r {
+		case ',', ';', '|', '\n', '\t', ' ':
+			return true
+		default:
+			return false
+		}
+	}) {
+		provider := strings.ToLower(strings.TrimSpace(item))
+		if provider == "" {
+			continue
+		}
+		for _, name := range supported {
+			if provider == name {
+				allowed[provider] = true
+				break
+			}
+		}
+	}
+
+	return allowed
+}
+
+// IsAllowed reports whether provider is permitted. Empty provider is treated as allowed.
+func IsAllowed(provider string) bool {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return true
+	}
+	return AllowedMap()[provider]
+}
+
+// FirstAllowed returns the first supported provider allowed by STORAGE_ALLOW_LIST.
+func FirstAllowed() string {
+	allowed := AllowedMap()
+	for _, provider := range supported {
+		if allowed[provider] {
+			return provider
+		}
+	}
+	return ""
+}
+
+// AllowedList returns allowed providers in canonical order.
+func AllowedList() []string {
+	allowed := AllowedMap()
+	out := make([]string, 0, len(supported))
+	for _, provider := range supported {
+		if allowed[provider] {
+			out = append(out, provider)
+		}
+	}
+	return out
+}

--- a/internal/storageallowlist/allowlist_test.go
+++ b/internal/storageallowlist/allowlist_test.go
@@ -1,0 +1,40 @@
+package storageallowlist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllowedMap_DefaultAllowsAll(t *testing.T) {
+	t.Setenv(AllowListEnv, "")
+	allowed := AllowedMap()
+	for _, provider := range Supported() {
+		assert.True(t, allowed[provider], provider)
+	}
+}
+
+func TestAllowedMap_RespectsEnv(t *testing.T) {
+	t.Setenv(AllowListEnv, "minio,cos")
+	allowed := AllowedMap()
+	assert.True(t, allowed["minio"])
+	assert.True(t, allowed["cos"])
+	assert.False(t, allowed["local"])
+	assert.False(t, allowed["obs"])
+}
+
+func TestFirstAllowed(t *testing.T) {
+	t.Setenv(AllowListEnv, "minio")
+	assert.Equal(t, "minio", FirstAllowed())
+}
+
+func TestAllowedList(t *testing.T) {
+	t.Setenv(AllowListEnv, "obs,minio")
+	assert.Equal(t, []string{"minio", "obs"}, AllowedList())
+}
+
+func TestIsAllowed_EmptyProvider(t *testing.T) {
+	t.Setenv(AllowListEnv, "minio")
+	require.True(t, IsAllowed(""))
+}


### PR DESCRIPTION
## Summary

Follow-up patch for #2067 code review findings:

- Extract `STORAGE_ALLOW_LIST` logic into `internal/storageallowlist` and use `FirstAllowed()` in `applyTenantDefaultStorageProvider` when tenant `default_provider` is empty or disallowed (fixes API clients bypassing the frontend fix).
- Share `pickUsableStorageProvider` via `editorResources` so `KnowledgeBaseEditorModal` and `KBStorageSettings` use the same selection logic.
- Add regression tests for OBS engine status and allow-list default provider behavior.

## Test plan

- [x] `go test ./internal/storageallowlist/...`
- [x] `go test ./internal/handler/ -run TestGetStorageEngineStatus`
- [x] `go test ./internal/application/service/ -run TestCreateKnowledgeBase_DefaultStorageProvider`