### PR TITLE
fix: stabilize top-k retrieval ordering

### DIFF
--- a/internal/application/service/chat_pipeline/filter_top_k.go
+++ b/internal/application/service/chat_pipeline/filter_top_k.go
@@ -2,6 +2,7 @@ package chatpipeline
 
 import (
 	"context"
+	"sort"
 
 	"github.com/Tencent/WeKnora/internal/types"
 )
@@ -38,6 +39,7 @@ func (p *PluginFilterTopK) OnEvent(ctx context.Context,
 	})
 
 	filterTopK := func(searchResult []*types.SearchResult, topK int) []*types.SearchResult {
+		sortSearchResultsDeterministically(searchResult)
 		if topK > 0 && len(searchResult) > topK {
 			pipelineInfo(ctx, "FilterTopK", "filter", map[string]interface{}{
 				"before": len(searchResult),
@@ -66,4 +68,32 @@ func (p *PluginFilterTopK) OnEvent(ctx context.Context,
 		"search_cnt": len(chatManage.SearchResult),
 	})
 	return next()
+}
+
+// sortSearchResultsDeterministically restores the global relevance order after
+// merge stages group results through maps. Stable tie-breakers keep identical
+// requests reproducible before TopK truncation.
+func sortSearchResultsDeterministically(results []*types.SearchResult) {
+	sort.SliceStable(results, func(i, j int) bool {
+		left, right := results[i], results[j]
+		if left == nil || right == nil {
+			return left != nil
+		}
+		if left.Score != right.Score {
+			return left.Score > right.Score
+		}
+		if left.KnowledgeID != right.KnowledgeID {
+			return left.KnowledgeID < right.KnowledgeID
+		}
+		if left.ChunkType != right.ChunkType {
+			return left.ChunkType < right.ChunkType
+		}
+		if left.StartAt != right.StartAt {
+			return left.StartAt < right.StartAt
+		}
+		if left.EndAt != right.EndAt {
+			return left.EndAt < right.EndAt
+		}
+		return left.ID < right.ID
+	})
 }

--- a/internal/application/service/chat_pipeline/filter_top_k_test.go
+++ b/internal/application/service/chat_pipeline/filter_top_k_test.go
@@ -1,0 +1,68 @@
+package chatpipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginFilterTopKSortsMergeResultsBeforeTruncation(t *testing.T) {
+	chatManage := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{RerankTopK: 3},
+		PipelineState: types.PipelineState{
+			MergeResult: []*types.SearchResult{
+				{ID: "low", KnowledgeID: "doc-c", Score: 0.2},
+				{ID: "high", KnowledgeID: "doc-a", Score: 0.9},
+				{ID: "medium", KnowledgeID: "doc-b", Score: 0.5},
+				{ID: "second", KnowledgeID: "doc-d", Score: 0.8},
+			},
+		},
+	}
+
+	plugin := &PluginFilterTopK{}
+	err := plugin.OnEvent(
+		context.Background(),
+		types.FILTER_TOP_K,
+		chatManage,
+		func() *PluginError { return nil },
+	)
+
+	require.Nil(t, err)
+	require.Len(t, chatManage.MergeResult, 3)
+	assert.Equal(t, []string{"high", "second", "medium"}, searchResultIDs(chatManage.MergeResult))
+}
+
+func TestPluginFilterTopKUsesDeterministicTieBreakers(t *testing.T) {
+	chatManage := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{RerankTopK: 10},
+		PipelineState: types.PipelineState{
+			MergeResult: []*types.SearchResult{
+				{ID: "chunk-b", KnowledgeID: "doc-b", ChunkType: "text", StartAt: 10, EndAt: 20, Score: 0.8},
+				{ID: "chunk-c", KnowledgeID: "doc-a", ChunkType: "summary", StartAt: 0, EndAt: 10, Score: 0.8},
+				{ID: "chunk-a", KnowledgeID: "doc-a", ChunkType: "text", StartAt: 0, EndAt: 10, Score: 0.8},
+			},
+		},
+	}
+
+	plugin := &PluginFilterTopK{}
+	err := plugin.OnEvent(
+		context.Background(),
+		types.FILTER_TOP_K,
+		chatManage,
+		func() *PluginError { return nil },
+	)
+
+	require.Nil(t, err)
+	assert.Equal(t, []string{"chunk-c", "chunk-a", "chunk-b"}, searchResultIDs(chatManage.MergeResult))
+}
+
+func searchResultIDs(results []*types.SearchResult) []string {
+	ids := make([]string, 0, len(results))
+	for _, result := range results {
+		ids = append(ids, result.ID)
+	}
+	return ids
+}


### PR DESCRIPTION
## Description

Ensure retrieval results are globally ordered by final relevance score before TopK truncation. When scores tie, deterministic fields are used as stable tie-breakers so identical requests return the same result order.

The merge pipeline groups results through Go maps. Map iteration order is unspecified, so the merged slice could arrive in a different order on each request. `PluginFilterTopK` previously truncated that slice directly, allowing lower-scored chunks to displace more relevant chunks and producing nondeterministic answers.

This change:

- sorts merged and reranked results by score descending before truncation
- applies deterministic tie-breakers for equal scores
- adds regression coverage for relevance ordering and stable ties

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

No linked issue.

## Testing

- `go test ./internal/application/service/chat_pipeline -count=1`
- `go test ./internal/application/service/chat_pipeline -run TestPluginFilterTopK -count=20`
- Rebuilt and restarted WeKnora Lite, then sent the same knowledge-search request 20 times: one unique result order across all responses, with scores descending in every response.

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (not required; no public contract changed)
- [x] Breaking changes are clearly called out in the description above (none)

## Screenshots / Recordings

Not applicable; no UI changes.