### PR TITLE
[codex] Confirm config for batch reparse

### DIFF
--- a/frontend/src/stores/uploadConfirm.ts
+++ b/frontend/src/stores/uploadConfirm.ts
@@ -15,6 +15,7 @@ export interface UploadConfirmReparseSource {
   knowledgeId: string
   fileName?: string
   fileType?: string
+  fileTypes?: string[]
   processOverrides?: KnowledgeProcessOverrides | null
 }
 

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -419,6 +419,7 @@ const batchDeleting = ref(false);
 const batchReparsing = ref(false);
 // IDs submitted for async batch reparse; hold optimistic pending until the worker updates DB.
 const pendingReparseAck = ref<Set<string>>(new Set());
+const uploadConfirmStore = useUploadConfirmStore();
 
 const applyOptimisticBatchReparse = (ids: string[]) => {
   const idSet = new Set(ids);
@@ -470,9 +471,32 @@ const confirmBatchReparse = async () => {
   if (skipped > 0) {
     MessagePlugin.warning(t('knowledgeBase.batchReparseSkippedInFlight', { count: skipped }));
   }
+  let processConfig: KnowledgeProcessOverrides | undefined;
+  if (kbInfo.value) {
+    const fileTypes = Array.from(new Set(ids
+      .map((id) => cardList.value.find((c) => c.id === id)?.file_type || '')
+      .map((fileType) => fileType.replace(/^\./, '').toLowerCase())
+      .filter(Boolean)));
+    try {
+      const result = await uploadConfirmStore.open({
+        mode: 'reparse',
+        kbInfo: kbInfo.value,
+        reparse: {
+          knowledgeId: ids[0],
+          fileName: t('knowledgeBase.selectedCount', { count: ids.length }),
+          fileTypes,
+          processOverrides: null,
+        },
+      });
+      if (result.mode !== 'reparse') return;
+      processConfig = result.processConfig;
+    } catch {
+      return;
+    }
+  }
   batchReparsing.value = true;
   try {
-    const res: any = await batchReparseKnowledge(kbId.value, ids);
+    const res: any = await batchReparseKnowledge(kbId.value, ids, processConfig);
     if (res?.success) {
       MessagePlugin.success(t('knowledgeBase.batchReparseSuccess', { count: ids.length }));
       applyOptimisticBatchReparse(ids);
@@ -1521,8 +1545,6 @@ const ensureDocumentKbReady = () => {
 
 const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'];
 const AUDIO_EXTENSIONS = ['mp3', 'wav', 'm4a', 'flac', 'ogg'];
-
-const uploadConfirmStore = useUploadConfirmStore();
 
 const getFolderUploadFileName = (file: File) => {
   const relativePath = (file as any).webkitRelativePath;

--- a/frontend/src/views/knowledge/batchReparseFlow.test.ts
+++ b/frontend/src/views/knowledge/batchReparseFlow.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+test('batch reparse confirms latest process config before enqueueing', () => {
+  const component = readFileSync(join(__dirname, 'KnowledgeBase.vue'), 'utf8')
+
+  assert.match(component, /uploadConfirmStore\.open\(\{\s*mode: 'reparse'/s)
+  assert.match(component, /processOverrides: null/)
+  assert.match(component, /processConfig = result\.processConfig/)
+  assert.match(component, /batchReparseKnowledge\(kbId\.value, ids, processConfig\)/)
+})
+
+test('reparse confirmation dialog summarizes every selected file type', () => {
+  const component = readFileSync(join(__dirname, 'components', 'UploadConfirmDialog.vue'), 'utf8')
+
+  assert.match(component, /props\.reparsePreview\?\.fileTypes/)
+  assert.match(component, /set\.add\(ext\)/)
+})
+
+test('batch reparse action opens the config dialog without a second popconfirm', () => {
+  const component = readFileSync(join(__dirname, 'components', 'DocumentBatchBar.vue'), 'utf8')
+
+  assert.match(component, /@click\.stop="emit\('reparse'\)"/)
+  assert.doesNotMatch(component, /confirmBatchReparseDocument/)
+})

--- a/frontend/src/views/knowledge/components/DocumentBatchBar.vue
+++ b/frontend/src/views/knowledge/components/DocumentBatchBar.vue
@@ -31,15 +31,12 @@ const { t } = useI18n();
           </t-button>
         </div>
         <div class="batch-bar-actions">
-          <t-popconfirm theme="warning" :content="t('knowledgeBase.confirmBatchReparseDocument', { count })"
-            :confirm-btn="{ content: t('knowledgeBase.confirmBatchReparse'), theme: 'warning' }"
-            :cancel-btn="{ content: t('common.cancel') }" placement="top" @confirm="emit('reparse')">
-            <t-button theme="default" variant="outline" size="small"
-              :disabled="count === 0 || deleteLoading || reparseLoading" :loading="reparseLoading" @click.stop>
-              <template #icon><t-icon name="refresh" size="14px" /></template>
-              {{ t('knowledgeBase.rebuildDocument') }}
-            </t-button>
-          </t-popconfirm>
+          <t-button theme="default" variant="outline" size="small"
+            :disabled="count === 0 || deleteLoading || reparseLoading" :loading="reparseLoading"
+            @click.stop="emit('reparse')">
+            <template #icon><t-icon name="refresh" size="14px" /></template>
+            {{ t('knowledgeBase.rebuildDocument') }}
+          </t-button>
 
           <t-popconfirm theme="warning" :content="t('knowledgeBase.confirmBatchDeleteDocument', { count })"
             :confirm-btn="{ content: t('knowledgeBase.confirmDelete'), theme: 'danger' }"

--- a/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
+++ b/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
@@ -435,6 +435,10 @@ const batchFileExts = computed(() => {
     }
   }
   if (props.mode === 'reparse') {
+    for (const fileType of props.reparsePreview?.fileTypes || []) {
+      const ext = fileType.toLowerCase()
+      if (ext) set.add(ext)
+    }
     const ext = (props.reparsePreview?.fileType || '').toLowerCase()
     if (ext) set.add(ext)
   }

--- a/internal/handler/knowledge_batch_reparse_test.go
+++ b/internal/handler/knowledge_batch_reparse_test.go
@@ -1,0 +1,218 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hibiken/asynq"
+
+	"github.com/Tencent/WeKnora/internal/middleware"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type stubBatchReparseKBService struct {
+	interfaces.KnowledgeBaseService
+	calls int
+	kb    *types.KnowledgeBase
+	err   error
+}
+
+func (s *stubBatchReparseKBService) GetKnowledgeBaseByID(_ context.Context, _ string) (*types.KnowledgeBase, error) {
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.kb, nil
+}
+
+type stubBatchReparseKGService struct {
+	interfaces.KnowledgeService
+	calls     int
+	gotTenant uint64
+	gotIDs    []string
+	knowledge []*types.Knowledge
+	err       error
+}
+
+func (s *stubBatchReparseKGService) GetKnowledgeBatch(_ context.Context, tenantID uint64, ids []string) ([]*types.Knowledge, error) {
+	s.calls++
+	s.gotTenant = tenantID
+	s.gotIDs = append([]string(nil), ids...)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.knowledge, nil
+}
+
+type captureBatchReparseEnqueuer struct {
+	calls int
+	task  *asynq.Task
+	err   error
+}
+
+func (e *captureBatchReparseEnqueuer) Enqueue(task *asynq.Task, _ ...asynq.Option) (*asynq.TaskInfo, error) {
+	e.calls++
+	e.task = task
+	if e.err != nil {
+		return nil, e.err
+	}
+	return &asynq.TaskInfo{ID: "task-batch-reparse"}, nil
+}
+
+func newBatchReparseTestRouter(
+	kb interfaces.KnowledgeBaseService,
+	kg interfaces.KnowledgeService,
+	enqueuer interfaces.TaskEnqueuer,
+) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.ErrorHandler())
+	r.Use(func(c *gin.Context) {
+		c.Set(types.TenantIDContextKey.String(), uint64(1))
+		c.Set(types.UserIDContextKey.String(), "u-test")
+		c.Next()
+	})
+	h := &KnowledgeHandler{kbService: kb, kgService: kg, asynqClient: enqueuer}
+	r.POST("/batch-reparse", h.BatchReparseKnowledge)
+	return r
+}
+
+func doBatchReparseRequest(t *testing.T, router *gin.Engine, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/batch-reparse", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestBatchReparseKnowledge_EnqueuesDedupedIDsWithProcessConfig(t *testing.T) {
+	kb := &stubBatchReparseKBService{kb: &types.KnowledgeBase{ID: "kb-1", TenantID: 1}}
+	kg := &stubBatchReparseKGService{knowledge: []*types.Knowledge{
+		{ID: "k1", TenantID: 1, KnowledgeBaseID: "kb-1"},
+		{ID: "k2", TenantID: 1, KnowledgeBaseID: "kb-1"},
+	}}
+	enqueuer := &captureBatchReparseEnqueuer{}
+	router := newBatchReparseTestRouter(kb, kg, enqueuer)
+
+	body := map[string]any{
+		"kb_id": "kb-1",
+		"ids":   []string{" k1 ", "", "k2", "k1"},
+		"process_config": map[string]any{
+			"parser_engine_overrides": map[string]string{"pdf_force_scanned": "true"},
+		},
+	}
+
+	w := doBatchReparseRequest(t, router, body)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if kg.calls != 1 {
+		t.Fatalf("GetKnowledgeBatch calls = %d, want 1", kg.calls)
+	}
+	if kg.gotTenant != 1 {
+		t.Fatalf("GetKnowledgeBatch tenant = %d, want 1", kg.gotTenant)
+	}
+	wantIDs := []string{"k1", "k2"}
+	if !reflect.DeepEqual(kg.gotIDs, wantIDs) {
+		t.Fatalf("GetKnowledgeBatch ids = %#v, want %#v", kg.gotIDs, wantIDs)
+	}
+	if enqueuer.calls != 1 {
+		t.Fatalf("Enqueue calls = %d, want 1", enqueuer.calls)
+	}
+	if enqueuer.task.Type() != types.TypeKnowledgeListReparse {
+		t.Fatalf("task type = %q, want %q", enqueuer.task.Type(), types.TypeKnowledgeListReparse)
+	}
+
+	var payload types.KnowledgeListReparsePayload
+	if err := json.Unmarshal(enqueuer.task.Payload(), &payload); err != nil {
+		t.Fatalf("unmarshal task payload: %v", err)
+	}
+	if payload.TenantID != 1 {
+		t.Fatalf("payload tenant = %d, want 1", payload.TenantID)
+	}
+	if !reflect.DeepEqual(payload.KnowledgeIDs, wantIDs) {
+		t.Fatalf("payload ids = %#v, want %#v", payload.KnowledgeIDs, wantIDs)
+	}
+	if payload.ProcessConfig == nil || payload.ProcessConfig.ParserEngineOverrides["pdf_force_scanned"] != "true" {
+		t.Fatalf("payload process config = %#v, want parser_engine_overrides.pdf_force_scanned=true", payload.ProcessConfig)
+	}
+	if !strings.Contains(w.Body.String(), `"reparse_count":2`) {
+		t.Fatalf("response body %q does not include reparse_count=2", w.Body.String())
+	}
+}
+
+func TestBatchReparseKnowledge_RejectsKnowledgeOutsideRequestedKB(t *testing.T) {
+	kb := &stubBatchReparseKBService{kb: &types.KnowledgeBase{ID: "kb-1", TenantID: 1}}
+	kg := &stubBatchReparseKGService{knowledge: []*types.Knowledge{
+		{ID: "k1", TenantID: 1, KnowledgeBaseID: "kb-1"},
+		{ID: "k2", TenantID: 1, KnowledgeBaseID: "other-kb"},
+	}}
+	enqueuer := &captureBatchReparseEnqueuer{}
+	router := newBatchReparseTestRouter(kb, kg, enqueuer)
+
+	w := doBatchReparseRequest(t, router, map[string]any{
+		"kb_id": "kb-1",
+		"ids":   []string{"k1", "k2"},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "does not belong to knowledge base") {
+		t.Fatalf("body %q does not explain KB ownership rejection", w.Body.String())
+	}
+	if enqueuer.calls != 0 {
+		t.Fatalf("Enqueue calls = %d, want 0", enqueuer.calls)
+	}
+}
+
+func TestBatchReparseKnowledge_RejectsOversizedBatchBeforeLookupOrEnqueue(t *testing.T) {
+	kb := &stubBatchReparseKBService{
+		kb:  &types.KnowledgeBase{ID: "kb-1", TenantID: 1},
+		err: errors.New("kb lookup should not be called"),
+	}
+	kg := &stubBatchReparseKGService{}
+	enqueuer := &captureBatchReparseEnqueuer{}
+	router := newBatchReparseTestRouter(kb, kg, enqueuer)
+
+	ids := make([]string, 201)
+	for i := range ids {
+		ids[i] = "k" + strconv.Itoa(i)
+	}
+	w := doBatchReparseRequest(t, router, map[string]any{
+		"kb_id": "kb-1",
+		"ids":   ids,
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "max 200") {
+		t.Fatalf("body %q does not mention max batch size", w.Body.String())
+	}
+	if kb.calls != 0 {
+		t.Fatalf("GetKnowledgeBaseByID calls = %d, want 0", kb.calls)
+	}
+	if kg.calls != 0 {
+		t.Fatalf("GetKnowledgeBatch calls = %d, want 0", kg.calls)
+	}
+	if enqueuer.calls != 0 {
+		t.Fatalf("Enqueue calls = %d, want 0", enqueuer.calls)
+	}
+}


### PR DESCRIPTION
## Summary

Refs #1651 and #1892.

This PR keeps the existing batch reparse capability, but closes two contribution gaps around it:

- Adds handler-level regression coverage for `POST /api/v1/knowledge/batch-reparse`, including ID trimming/deduplication, task payload propagation, KB ownership validation, and max batch size rejection.
- Reuses the existing reparse/upload configuration confirmation dialog before batch reparse is submitted, so batch reparse sends the confirmed latest `process_config` instead of silently reusing stale per-document parsing overrides.
- Lets the reparse confirmation dialog summarize multiple selected file types and removes the extra batch-bar popconfirm to avoid a double-confirm flow.
- Adds frontend regression tests for the batch reparse config-confirmation flow.

## Validation

- `npm test` in `frontend`: 139 tests passed.
- `git diff --check`: passed, with only existing CRLF conversion warnings.

## Known local validation gaps

- `go test ./internal/handler -run BatchReparseKnowledge -count=1` could not be run locally because the current Windows environment does not have the `go` executable installed.
- `npm run type-check` currently fails on pre-existing repository-wide TypeScript errors unrelated to this change, including API response generics and Vue macro import conflicts.