### PR TITLE
fix(chat): emit retrieval references when citation output is disabled

### DIFF
--- a/frontend/src/components/chat/FollowUpSuggestions.vue
+++ b/frontend/src/components/chat/FollowUpSuggestions.vue
@@ -66,8 +66,10 @@ const dismiss = () => {
 @import (reference) '../css/suggested-questions.less';
 
 .follow-ups {
-  max-width: 760px;
-  margin: -4px 0 28px 46px;
+  width: 100%;
+  max-width: 600px;
+  margin: -4px 0 28px;
+  margin-right: auto;
   padding: 12px;
   border: 1px solid var(--td-component-stroke);
   border-radius: 12px;
@@ -139,7 +141,7 @@ const dismiss = () => {
 @keyframes spin { to { transform: rotate(360deg); } }
 
 .follow-up-card-enter-active {
-  transform-origin: 24px 0;
+  transform-origin: left top;
   transition:
     opacity .22s ease .04s,
     transform .28s cubic-bezier(.22, .61, .36, 1) .04s,

--- a/internal/application/service/session_knowledge_qa.go
+++ b/internal/application/service/session_knowledge_qa.go
@@ -1189,10 +1189,12 @@ func (s *sessionService) consumeFallbackStream(
 }
 
 // emitKnowledgeReferencesEvent streams retrieved chunks to the client as a
-// `references` SSE event. Must run before CHAT_COMPLETION_STREAM so citations
-// arrive while the connection is still open (complete closes the stream).
+// `references` SSE event. These references drive the retrieval-results UI and
+// remain available even when inline citations in the model answer are disabled.
+// Must run before CHAT_COMPLETION_STREAM so the event arrives while the
+// connection is still open (complete closes the stream).
 func emitKnowledgeReferencesEvent(ctx context.Context, chatManage *types.ChatManage) {
-	if chatManage == nil || !chatManage.CitationsEnabled() || chatManage.EventBus == nil || len(chatManage.MergeResult) == 0 {
+	if chatManage == nil || chatManage.EventBus == nil || len(chatManage.MergeResult) == 0 {
 		return
 	}
 	logger.Infof(ctx, "Emitting references event with %d results (pre-answer)", len(chatManage.MergeResult))

--- a/internal/application/service/session_knowledge_qa_test.go
+++ b/internal/application/service/session_knowledge_qa_test.go
@@ -52,29 +52,32 @@ type stubModelService struct {
 	modelsByID map[string]*types.Model
 }
 
-func TestEmitKnowledgeReferencesEventHonorsCitationSetting(t *testing.T) {
+func TestEmitKnowledgeReferencesEventIgnoresCitationOutputSetting(t *testing.T) {
 	bus := event.NewEventBus()
-	emitted := 0
-	bus.On(event.EventAgentReferences, func(context.Context, event.Event) error {
-		emitted++
+	var emitted []event.Event
+	bus.On(event.EventAgentReferences, func(_ context.Context, evt event.Event) error {
+		emitted = append(emitted, evt)
 		return nil
 	})
 	disabled := false
+	result := &types.SearchResult{ID: "chunk-1", KnowledgeTitle: "Doc"}
 	cm := &types.ChatManage{
 		PipelineRequest: types.PipelineRequest{CitationEnabled: &disabled},
 		PipelineState: types.PipelineState{
-			MergeResult: []*types.SearchResult{{ID: "chunk-1"}},
+			MergeResult: []*types.SearchResult{result},
 		},
 		PipelineContext: types.PipelineContext{EventBus: bus.AsEventBusInterface()},
 	}
 
 	emitKnowledgeReferencesEvent(context.Background(), cm)
-	require.Zero(t, emitted)
+	require.Len(t, emitted, 1)
+	require.Equal(t, event.EventAgentReferences, emitted[0].Type)
+	require.Equal(t, []*types.SearchResult{result}, emitted[0].Data.(event.AgentReferencesData).References)
 
 	enabled := true
 	cm.CitationEnabled = &enabled
 	emitKnowledgeReferencesEvent(context.Background(), cm)
-	require.Equal(t, 1, emitted)
+	require.Len(t, emitted, 2)
 }
 
 func (s *stubModelService) CreateModel(context.Context, *types.Model) error {


### PR DESCRIPTION
## Summary
- Stop gating the `references` SSE event on the per-agent citation output toggle so the retrieval-results UI still receives chunks when inline citations are disabled in the answer.
- Align follow-up suggestion card width and margins with the chat column, and fix enter animation transform origin.

## Test plan
- [x] `go test ./internal/application/service/ -run TestEmitKnowledgeReferencesEvent`
- [ ] Start a chat with citation output disabled on the agent; confirm the references drawer still lists retrieved chunks during streaming.
- [ ] Verify follow-up suggestion card aligns with assistant messages and animates from the top-left.