### PR TITLE
fix(frontend): make chat input responsive on mobile

### DIFF
--- a/docs/issue-917-responsive-chat-input.md
+++ b/docs/issue-917-responsive-chat-input.md
@@ -1,0 +1,40 @@
+# Issue 917: Responsive chat input
+
+## Scope
+
+This change keeps the existing chat input behavior and visual language while
+removing desktop-only width assumptions that caused horizontal overflow on
+phone-sized viewports.
+
+- The chat route and platform shell can now shrink to the viewport.
+- The new-chat page no longer applies fixed `translateX` offsets or hard-coded
+  textarea widths at smaller breakpoints.
+- The knowledge-base chat entry point uses the same container-driven sizing, so
+  switching into a knowledge base does not reintroduce the old fixed offsets.
+- The input container remains capped at 800px on larger screens and becomes
+  container-driven below 960px.
+- Mobile controls use smaller spacing and a shorter textarea range so the input
+  does not dominate a phone viewport.
+
+## Regression matrix
+
+Before opening the PR, verify the authenticated chat route at:
+
+| Viewport | Expected result |
+| --- | --- |
+| 360 × 800 | No horizontal scrollbar; input and controls stay within the viewport |
+| 390 × 844 | No horizontal scrollbar; input remains centered with 12px side padding |
+| 768 × 1024 | Input uses available width without fixed offsets |
+| 1440 × 900 | Existing centered, max-800px desktop input is preserved |
+
+The same four viewport checks should be captured for the new-chat route. The
+screenshots belong in the PR description so reviewers can compare the narrow
+and desktop behavior directly.
+
+## Verification commands
+
+```bash
+pnpm --dir frontend test -- src/components/responsiveChatLayout.test.mjs
+pnpm --dir frontend type-check
+pnpm --dir frontend build-only
+```

--- a/frontend/src/components/Input-field.vue
+++ b/frontend/src/components/Input-field.vue
@@ -2753,6 +2753,7 @@ const getImgSrc = (url: string) => {
   position: relative;
   width: 100%;
   max-width: 800px;
+  box-sizing: border-box;
   background: var(--td-bg-color-container, #FFF);
   border-radius: 12px;
   border: 1px solid var(--td-component-stroke, #dcdcdc);
@@ -2950,6 +2951,34 @@ const getImgSrc = (url: string) => {
     font-size: 16px;
     font-weight: 400;
     line-height: 24px;
+  }
+}
+
+@media (max-width: 959px) {
+  .rich-input-container {
+    max-width: none;
+  }
+
+  :deep(.t-textarea__inner) {
+    min-height: 96px !important;
+    max-height: 160px !important;
+    padding: 10px 12px 48px 12px;
+  }
+
+  .control-bar {
+    left: 10px;
+    right: 10px;
+    bottom: 10px;
+    gap: 4px;
+  }
+
+  .control-left {
+    gap: 4px;
+  }
+
+  .control-btn {
+    padding-left: 6px;
+    padding-right: 6px;
   }
 }
 

--- a/frontend/src/components/responsiveChatLayout.test.mjs
+++ b/frontend/src/components/responsiveChatLayout.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const readSource = (relativePath) => readFile(resolve(frontendRoot, relativePath), 'utf8');
+
+test('chat shell can shrink below phone viewport width', async () => {
+  const source = await readSource('views/chat/index.vue');
+
+  assert.match(source, /width:\s*100%;\s*[\s\S]{0,120}max-width:\s*calc\(100vw - 260px\);\s*[\s\S]{0,80}min-width:\s*0;/);
+  assert.match(source, /@media\s*\(max-width:\s*959px\)[\s\S]{0,220}max-width:\s*100%;/);
+});
+
+test('platform shell does not impose a desktop minimum width on mobile', async () => {
+  const source = await readSource('views/platform/index.vue');
+
+  assert.match(source, /\.main\s*\{[\s\S]{0,180}min-width:\s*0;/);
+});
+
+test('new-chat layout uses container-driven sizing on narrow screens', async () => {
+  const source = await readSource('views/creatChat/creatChat.vue');
+
+  assert.doesNotMatch(source, /@media\s*\(max-width:\s*(?:1250|1045|750|600)px\)[\s\S]{0,180}translateX\(-250px\)/);
+  assert.match(source, /@media\s*\(max-width:\s*959px\)[\s\S]{0,260}max-width:\s*100%;/);
+});
+
+test('knowledge-base chat input does not restore fixed mobile widths', async () => {
+  const source = await readSource('views/knowledge/KnowledgeBase.vue');
+
+  assert.doesNotMatch(source, /@media\s*\(max-width:\s*(?:1250|1045|750|600)px\)[\s\S]{0,180}translateX\(-/);
+  assert.match(source, /@media\s*\(max-width:\s*959px\)[\s\S]{0,220}width:\s*100% !important;/);
+});

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -1015,8 +1015,9 @@ onBeforeRouteUpdate((to, from, next) => {
     display: flex;
     flex-direction: column;
     align-items: center;
+    width: 100%;
     max-width: calc(100vw - 260px);
-    min-width: 400px;
+    min-width: 0;
 
     &.is-sidebar-collapsed {
         max-width: calc(100vw - 60px);
@@ -1069,6 +1070,20 @@ onBeforeRouteUpdate((to, from, next) => {
         width: 100% !important;
         min-height: 48px !important;
         padding: 10px 14px 48px 14px;
+    }
+
+    @media (max-width: 959px) {
+        padding: 12px;
+        max-width: 100%;
+        align-items: stretch;
+
+        &.is-sidebar-collapsed {
+            max-width: 100%;
+        }
+
+        &.is-embedded {
+            padding: 0;
+        }
     }
 }
 

--- a/frontend/src/views/creatChat/creatChat.vue
+++ b/frontend/src/views/creatChat/creatChat.vue
@@ -258,6 +258,7 @@ const handleKBEditorSuccess = (kbId: string) => {
     width: 100%;
     max-width: 800px;
     gap: 24px;
+    box-sizing: border-box;
 
     :deep(.answers-input) {
         position: static;
@@ -363,43 +364,15 @@ const handleKBEditorSuccess = (kbId: string) => {
     }
 }
 
-@media (max-width: 1250px) and (min-width: 1045px) {
-    .answers-input {
-        transform: translateX(-329px);
+@media (max-width: 959px) {
+    .dialogue-wrap {
+        width: 100%;
+        padding: 0 12px;
+        box-sizing: border-box;
     }
 
-    :deep(.t-textarea__inner) {
-        width: 654px !important;
-    }
-}
-
-@media (max-width: 1045px) {
-    .answers-input {
-        transform: translateX(-250px);
-    }
-
-    :deep(.t-textarea__inner) {
-        width: 500px !important;
-    }
-}
-
-@media (max-width: 750px) {
-    .answers-input {
-        transform: translateX(-250px);
-    }
-
-    :deep(.t-textarea__inner) {
-        width: 340px !important;
-    }
-}
-
-@media (max-width: 600px) {
-    .answers-input {
-        transform: translateX(-250px);
-    }
-
-    :deep(.t-textarea__inner) {
-        width: 300px !important;
+    .dialogue-answers {
+        max-width: 100%;
     }
 }
 </style>

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -3307,43 +3307,14 @@ async function createNewSession(value: string): Promise<void> {
   margin: 0 16px 0 4px;
 }
 
-@media (max-width: 1250px) and (min-width: 1045px) {
+@media (max-width: 959px) {
   .answers-input {
-    transform: translateX(-329px);
+    width: 100%;
+    box-sizing: border-box;
   }
 
   :deep(.t-textarea__inner) {
-    width: 654px !important;
-  }
-}
-
-@media (max-width: 1045px) {
-  .answers-input {
-    transform: translateX(-250px);
-  }
-
-  :deep(.t-textarea__inner) {
-    width: 500px !important;
-  }
-}
-
-@media (max-width: 750px) {
-  .answers-input {
-    transform: translateX(-182px);
-  }
-
-  :deep(.t-textarea__inner) {
-    width: 340px !important;
-  }
-}
-
-@media (max-width: 600px) {
-  .answers-input {
-    transform: translateX(-164px);
-  }
-
-  :deep(.t-textarea__inner) {
-    width: 300px !important;
+    width: 100% !important;
   }
 }
 

--- a/frontend/src/views/platform/index.vue
+++ b/frontend/src/views/platform/index.vue
@@ -259,7 +259,7 @@ onUnmounted(() => {
     align-items: stretch;
     width: 100%;
     height: 100%;
-    min-width: 600px;
+    min-width: 0;
     min-height: 0;
     /* 统一整页背景，让左侧菜单与右侧内容区视觉连贯 */
     background: var(--td-bg-color-container);


### PR DESCRIPTION
## Summary

Fixes #917.

This PR makes the existing chat input layout container-driven on phone and tablet viewports without introducing a global responsive redesign.

## Root cause

Several desktop-only constraints could force horizontal overflow or shift the input off-screen on narrow viewports:

- the chat route used `min-width: 400px`;
- the platform shell used `min-width: 600px`;
- the new-chat and knowledge-base views applied fixed `translateX(...)` offsets and textarea widths at smaller breakpoints.

## Changes

- allow the platform shell and chat route to shrink below desktop widths;
- keep the desktop input capped at 800px while using available container width on mobile/tablet;
- remove fixed mobile offsets from the new-chat and knowledge-base entry points;
- tune mobile textarea height, control spacing, and side padding;
- add source-level regression guards for the four affected layout surfaces;
- document the 360px, 390px, 768px, and 1440px validation matrix.

## Validation

- `node --test frontend/src/components/responsiveChatLayout.test.mjs` (4 tests passed)
- `git diff --check` passed
- `pnpm --dir frontend type-check` and `pnpm --dir frontend build-only` still need to be run in a normal local dependency environment; the bundled pnpm could not install dependencies from the WSL UNC path.

## Manual verification requested

Please review the chat route, new-chat route, and knowledge-base chat entry point at 360px, 390px, 768px, and desktop width. The expected result is no horizontal overflow, no shifted input, and unchanged desktop centering.