### PR TITLE
fix:修复了重建/恢复时的全量重建

### DIFF
--- a/internal/application/service/content_cache.go
+++ b/internal/application/service/content_cache.go
@@ -1,0 +1,130 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Cache is a nil-safe Redis-backed cache used for content-addressed caching
+// across VLM, embedding, and wiki map layers. When rdb is nil (Lite mode)
+// all operations are no-ops that report miss / no-op silently.
+type Cache struct {
+	rdb *redis.Client
+}
+
+// NewCache creates a new Cache. rdb may be nil (Lite mode).
+func NewCache(rdb *redis.Client) *Cache {
+	return &Cache{rdb: rdb}
+}
+
+func (c *Cache) Available() bool { return c.rdb != nil }
+
+// Get returns the cached string value and true on hit.
+func (c *Cache) Get(ctx context.Context, key string) (string, bool) {
+	if c.rdb == nil {
+		return "", false
+	}
+	val, err := c.rdb.Get(ctx, key).Result()
+	if err != nil {
+		return "", false
+	}
+	return val, true
+}
+
+// Set stores a string value. A zero ttl means no expiry.
+func (c *Cache) Set(ctx context.Context, key, value string, ttl time.Duration) error {
+	if c.rdb == nil {
+		return nil
+	}
+	return c.rdb.Set(ctx, key, value, ttl).Err()
+}
+
+// GetJSON deserialises the cached JSON value into dest. Returns true on hit.
+func (c *Cache) GetJSON(ctx context.Context, key string, dest any) (bool, error) {
+	if c.rdb == nil {
+		return false, nil
+	}
+	raw, err := c.rdb.Get(ctx, key).Bytes()
+	if err != nil {
+		return false, nil
+	}
+	if err := json.Unmarshal(raw, dest); err != nil {
+		return false, fmt.Errorf("cache deserialise %s: %w", key, err)
+	}
+	return true, nil
+}
+
+// SetJSON serialises val as JSON and stores it. Zero ttl means no expiry.
+func (c *Cache) SetJSON(ctx context.Context, key string, val any, ttl time.Duration) error {
+	if c.rdb == nil {
+		return nil
+	}
+	raw, err := json.Marshal(val)
+	if err != nil {
+		return fmt.Errorf("cache serialise %s: %w", key, err)
+	}
+	return c.rdb.Set(ctx, key, raw, ttl).Err()
+}
+
+// Del removes one or more keys.
+func (c *Cache) Del(ctx context.Context, keys ...string) error {
+	if c.rdb == nil || len(keys) == 0 {
+		return nil
+	}
+	return c.rdb.Del(ctx, keys...).Err()
+}
+
+// DelByPattern removes all keys matching a glob pattern.
+func (c *Cache) DelByPattern(ctx context.Context, pattern string) error {
+	if c.rdb == nil {
+		return nil
+	}
+	iter := c.rdb.Scan(ctx, 0, pattern, 0).Iterator()
+	for iter.Next(ctx) {
+		if err := c.rdb.Del(ctx, iter.Val()).Err(); err != nil {
+			return err
+		}
+	}
+	return iter.Err()
+}
+
+// Close closes the underlying redis connection.
+func (c *Cache) Close() error {
+	if c.rdb == nil {
+		return nil
+	}
+	return c.rdb.Close()
+}
+
+// ---------------------------------------------------------------------------
+// Cache key builders
+// ---------------------------------------------------------------------------
+
+const (
+	vlmCachePrefix       = "vlm:"
+	embeddingCachePrefix = "emb:"
+	wikiMapCachePrefix   = "wiki:map:"
+)
+
+// VLMCacheKey builds the Redis key for a VLM result.
+// Format: vlm:{imgHexHash}:{modelID}:{promptSHA}
+func VLMCacheKey(imgHash, modelID, promptHash string) string {
+	return vlmCachePrefix + imgHash + ":" + modelID + ":" + promptHash
+}
+
+// EmbeddingCacheKey builds the Redis key for an embedding vector.
+// Format: emb:{contentSHA}:{modelID}:{dim}
+func EmbeddingCacheKey(contentHash, modelID string, dims int) string {
+	return embeddingCachePrefix + contentHash + ":" + modelID + ":" + strconv.Itoa(dims)
+}
+
+// WikiMapCacheKey builds the Redis key for a wiki per-doc map result.
+// Format: wiki:map:{docContentSHA}:{granularity}:{modelID}:{promptSHA}
+func WikiMapCacheKey(contentHash, granularity, modelID, promptHash string) string {
+	return wikiMapCachePrefix + contentHash + ":" + granularity + ":" + modelID + ":" + promptHash
+}

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -19,7 +19,6 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
-	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
 	"github.com/redis/go-redis/v9"
 )
@@ -85,6 +84,10 @@ type ImageMultimodalService struct {
 	// the knowledge base's currently configured one.
 	resourceCatalog interfaces.ResourceCatalog
 
+	// cache provides content-addressed caching for VLM results (OCR/caption).
+	// nil-safe: when redis is unavailable all operations are no-ops.
+	cache *Cache
+
 	// spanTracker records this image's subspan under the parent attempt's
 	// multimodal stage. nil-safe — falls back to no-op via tracker().
 	spanTracker SpanTracker
@@ -117,6 +120,7 @@ func NewImageMultimodalService(
 		ollamaService:   ollamaService,
 		taskEnqueuer:    taskEnqueuer,
 		redisClient:     redisClient,
+		cache:           NewCache(redisClient),
 		fileSvc:         fileSvc,
 		storageResolver: storageResolver,
 		resourceCatalog: resourceCatalog,
@@ -252,6 +256,14 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 	}
 	imgOut["image_bytes"] = len(imgBytes)
 
+	// VLM cache key material: content hash of image bytes + model id
+	imgHash := secutils.ContentHash(string(imgBytes))
+	vlmModelID := strings.TrimSpace(vlmModel.GetModelID())
+	if vlmModelID == "" {
+		vlmModelID = "unknown"
+	}
+	imgOut["img_hash"] = imgHash[:16]
+
 	imageInfo := types.ImageInfo{
 		URL:         payload.ImageURL,
 		OriginalURL: payload.ImageURL,
@@ -268,7 +280,22 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 		prompt = types.AppendCustomPromptInstructions(prompt, vlmCfg.CustomInstructions, "image_ocr")
 
-		ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt)
+		ocrPromptHash := secutils.ContentHash(prompt)
+		ocrCacheKey := VLMCacheKey(imgHash, vlmModelID, ocrPromptHash)
+		var ocrText string
+		var ocrErr error
+		if cached, hit := s.cache.Get(ctx, ocrCacheKey); hit {
+			ocrText = cached
+			ocrErr = nil
+			imgOut["ocr_cache_hit"] = true
+			logger.Infof(ctx, "[ImageMultimodal] OCR cache HIT for %s", payload.ImageURL)
+		} else {
+			ocrText, ocrErr = vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt)
+			if ocrErr == nil && ocrText != "" {
+				s.cache.Set(ctx, ocrCacheKey, ocrText, 0)
+				imgOut["ocr_cached"] = true
+			}
+		}
 		if ocrErr != nil {
 			logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
 			imgOut["ocr_error"] = ocrErr.Error()
@@ -286,7 +313,23 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 	}
 
-	caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, buildVLMCaptionPrompt(ctx, vlmCfg))
+	captionPrompt := buildVLMCaptionPrompt(ctx, vlmCfg)
+	captionPromptHash := secutils.ContentHash(captionPrompt)
+	capCacheKey := VLMCacheKey(imgHash, vlmModelID, captionPromptHash)
+	var caption string
+	var capErr error
+	if cached, hit := s.cache.Get(ctx, capCacheKey); hit {
+		caption = cached
+		capErr = nil
+		imgOut["caption_cache_hit"] = true
+		logger.Infof(ctx, "[ImageMultimodal] Caption cache HIT for %s", payload.ImageURL)
+	} else {
+		caption, capErr = vlmModel.Predict(ctx, [][]byte{imgBytes}, captionPrompt)
+		if capErr == nil && caption != "" {
+			s.cache.Set(ctx, capCacheKey, caption, 0)
+			imgOut["caption_cached"] = true
+		}
+	}
 	if capErr != nil {
 		logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
 		imgOut["caption_error"] = capErr.Error()
@@ -302,7 +345,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 
 	if imageInfo.OCRText != "" {
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              secutils.ImageChunkID(payload.ChunkID, "ocr", imageInfo.OCRText),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
@@ -319,7 +362,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 
 	if imageInfo.Caption != "" {
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              secutils.ImageChunkID(payload.ChunkID, "caption", imageInfo.Caption),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -25,6 +25,7 @@ import (
 	secutils "github.com/Tencent/WeKnora/internal/utils"
 	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
+	"github.com/redis/go-redis/v9"
 )
 
 func (s *knowledgeService) cloneKnowledge(
@@ -389,7 +390,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		parentDBChunks = make([]*types.Chunk, len(options.ParentChunks))
 		for i, pc := range options.ParentChunks {
 			parentDBChunks[i] = &types.Chunk{
-				ID:              uuid.New().String(),
+				ID:              secutils.ChunkID(knowledge.ID, pc.Content, pc.Seq, types.ChunkTypeParentText),
 				TenantID:        knowledge.TenantID,
 				KnowledgeID:     knowledge.ID,
 				KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -428,7 +429,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 
 		// 创建主文本Chunk
 		textChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              secutils.ChunkID(knowledge.ID, chunkData.Content, int(chunkData.Seq), types.ChunkTypeText),
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -584,7 +585,11 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			return
 		}
 
-		err = retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfoList)
+		attachCtx := ctx
+		if s.redisClient != nil {
+			attachCtx = retriever.ContextWithEmbeddingCache(ctx, &redisEmbedCache{rdb: s.redisClient})
+		}
+		err = retrieveEngine.BatchIndex(attachCtx, embeddingModel, indexInfoList)
 		if err != nil {
 			knowledge.ParseStatus = types.ParseStatusFailed
 			knowledge.ErrorMessage = err.Error()
@@ -1123,7 +1128,7 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 		// and surfacing them in retrieved RAG context can re-introduce the
 		// hallucination vector this branch is meant to close.
 		summaryChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              secutils.ChunkID(knowledge.ID, summary, 0, types.ChunkTypeSummary),
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -2501,7 +2506,7 @@ func (s *knowledgeService) UpdateImageInfo(
 	// Create a new caption chunk if it doesn't exist and we have caption data
 	if !hasCaptionChunk && image.Caption != "" {
 		captionChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              secutils.ImageChunkID(chunk.ID, "caption", image.Caption),
 			TenantID:        tenantID,
 			KnowledgeID:     chunk.KnowledgeID,
 			KnowledgeBaseID: chunk.KnowledgeBaseID,
@@ -2517,7 +2522,7 @@ func (s *knowledgeService) UpdateImageInfo(
 	// Create a new OCR chunk if it doesn't exist and we have OCR data
 	if !hasOCRChunk && image.OCRText != "" {
 		ocrChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              secutils.ImageChunkID(chunk.ID, "ocr", image.OCRText),
 			TenantID:        tenantID,
 			KnowledgeID:     chunk.KnowledgeID,
 			KnowledgeBaseID: chunk.KnowledgeBaseID,
@@ -3431,4 +3436,29 @@ func (s *knowledgeService) ProcessKnowledgeListReparse(ctx context.Context, t *a
 	logger.Infof(ctx, "Knowledge list reparse task finished: %d submitted, %d failed",
 		len(payload.KnowledgeIDs)-failed, failed)
 	return nil
+}
+
+// redisEmbedCache adapts a raw *redis.Client to the retriever.EmbeddingCache
+// interface so the embedding cache can be threaded via context without
+// modifying the RetrieveEngineService interface.
+type redisEmbedCache struct {
+	rdb *redis.Client
+}
+
+func (c *redisEmbedCache) Get(ctx context.Context, key string) (string, bool) {
+	if c.rdb == nil {
+		return "", false
+	}
+	val, err := c.rdb.Get(ctx, key).Result()
+	if err != nil {
+		return "", false
+	}
+	return val, true
+}
+
+func (c *redisEmbedCache) Set(ctx context.Context, key, value string) error {
+	if c.rdb == nil {
+		return nil
+	}
+	return c.rdb.Set(ctx, key, value, 0).Err()
 }

--- a/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
+++ b/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
@@ -2,6 +2,10 @@ package retriever
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"regexp"
 	"slices"
 	"strings"
@@ -35,6 +39,28 @@ var embeddingImagePayloadPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?is)!\[[^\]]*\]\(\s*data:image/[a-z0-9.+-]+;base64,[^)]+\)`),
 	regexp.MustCompile(`(?i)data:image/[a-z0-9.+-]+;base64,[a-z0-9+/=]{200,}`),
 	regexp.MustCompile(`(?i)data:[a-z0-9.+/-]+;base64,[a-z0-9+/=]{200,}`),
+}
+
+// embedCacheContextKey is the context key for an optional embedding cache.
+// When set, BatchIndex checks the cache before calling the embedding API.
+type embedCacheContextKey struct{}
+
+// EmbeddingCache is the minimal interface the retriever needs to cache
+// embedding vectors. Implementations are provided by the service layer.
+type EmbeddingCache interface {
+	Get(ctx context.Context, key string) (string, bool)
+	Set(ctx context.Context, key, value string) error
+}
+
+// ContextWithEmbeddingCache attaches an embedding cache to ctx.
+func ContextWithEmbeddingCache(ctx context.Context, c EmbeddingCache) context.Context {
+	return context.WithValue(ctx, embedCacheContextKey{}, c)
+}
+
+// EmbeddingCacheFromContext extracts the embedding cache from ctx (nil if unset).
+func EmbeddingCacheFromContext(ctx context.Context) EmbeddingCache {
+	c, _ := ctx.Value(embedCacheContextKey{}).(EmbeddingCache)
+	return c
 }
 
 // KeywordsVectorHybridRetrieveEngineService implements a hybrid retrieval engine
@@ -96,7 +122,11 @@ func (v *KeywordsVectorHybridRetrieveEngineService) BatchIndex(ctx context.Conte
 		for _, indexInfo := range indexInfoList {
 			contentList = append(contentList, sanitizeForEmbedding(ctx, indexInfo.Content))
 		}
-		embeddings, err := batchEmbedWithBackoff(ctx, embedder, contentList)
+
+		modelID := embedder.GetModelID()
+		dim := embedder.GetDimensions()
+		cache := EmbeddingCacheFromContext(ctx)
+		embeddings, err := cachedBatchEmbed(ctx, cache, embedder, modelID, dim, contentList)
 		if err != nil {
 			return err
 		}
@@ -150,6 +180,74 @@ func batchEmbedWithBackoff(ctx context.Context, embedder embedding.Embedder, con
 		}
 	}
 	return embeddings, err
+}
+
+// cachedBatchEmbed wraps batchEmbedWithBackoff with an LRU-style content-
+// addressed cache. When cache is nil it passes through directly.
+// For each content string the cache key is:
+//
+//	emb:{SHA256(content)}:{modelID}:{dim}
+//
+// Hits skip the embedding API; misses are fetched in bulk and stored.
+func cachedBatchEmbed(ctx context.Context, cache EmbeddingCache, embedder embedding.Embedder,
+	modelID string, dim int, contentList []string,
+) ([][]float32, error) {
+	if cache == nil {
+		return batchEmbedWithBackoff(ctx, embedder, contentList)
+	}
+
+	// 1. Partition: determine which contents are cached.
+	results := make([][]float32, len(contentList))
+	var missIdx []int
+	var missContent []string
+	for i, content := range contentList {
+		key := embedCacheKey(content, modelID, dim)
+		if cached, hit := cache.Get(ctx, key); hit {
+			var emb []float32
+			if err := json.Unmarshal([]byte(cached), &emb); err != nil {
+				logger.Warnf(ctx, "embedding cache deserialise error for key %s: %v, re-embedding", key, err)
+				missIdx = append(missIdx, i)
+				missContent = append(missContent, content)
+			} else {
+				results[i] = emb
+			}
+		} else {
+			missIdx = append(missIdx, i)
+			missContent = append(missContent, content)
+		}
+	}
+
+	// All cached → fast path.
+	if len(missContent) == 0 {
+		return results, nil
+	}
+
+	logger.Infof(ctx, "embedding cache: %d hits, %d misses (fetching %d)", len(results)-len(missContent), len(missContent), len(missContent))
+
+	// 2. Fetch misses from API.
+	missEmb, err := batchEmbedWithBackoff(ctx, embedder, missContent)
+	if err != nil {
+		return nil, err
+	}
+
+	// 3. Stitch and store in cache.
+	for j, i := range missIdx {
+		results[i] = missEmb[j]
+		key := embedCacheKey(missContent[j], modelID, dim)
+		if raw, err := json.Marshal(missEmb[j]); err == nil {
+			if setErr := cache.Set(ctx, key, string(raw)); setErr != nil {
+				logger.Warnf(ctx, "embedding cache set error for key %s: %v", key, setErr)
+			}
+		}
+	}
+	return results, nil
+}
+
+// embedCacheKey builds the Redis key for an embedding vector.
+func embedCacheKey(content, modelID string, dim int) string {
+	h := sha256.Sum256([]byte(content))
+	contentHash := hex.EncodeToString(h[:])
+	return "emb:" + contentHash + ":" + modelID + ":" + fmt.Sprintf("%d", dim)
 }
 
 // sanitizeForEmbedding caps content length at safetyMaxChars characters so

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -311,6 +311,7 @@ type wikiIngestService struct {
 	pendingRepo    interfaces.TaskPendingOpsRepository
 	deadLetterRepo interfaces.TaskDeadLetterRepository
 	redisClient    *redis.Client // nil in Lite mode (no Redis)
+	cache          *Cache
 	// spanTracker lets per-document map work surface as a
 	// postprocess.wiki subspan in the knowledge trace tree. Async
 	// batch design means we look up the parent attempt by knowledge
@@ -354,6 +355,7 @@ func NewWikiIngestService(
 		pendingRepo:    pendingRepo,
 		deadLetterRepo: deadLetterRepo,
 		redisClient:    redisClient,
+		cache:          NewCache(redisClient),
 		spanTracker:    spanTracker,
 	}
 	return svc

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/models/chat"
 	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
+	secutils "github.com/Tencent/WeKnora/internal/utils"
 	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
 	"golang.org/x/sync/errgroup"
@@ -1162,6 +1163,34 @@ func (s *wikiIngestService) mapOneDocument(
 	sourceRef := knowledgeID
 	oldPageSlugs := s.getExistingPageSlugsForKnowledge(ctx, payload.KnowledgeBaseID, knowledgeID)
 
+	// --- Wiki per-doc map cache ---
+	// If the document content + config is unchanged, reuse the prior LLM
+	// extraction (entities/concepts/summary/citations) and skip all LLM
+	// calls. This is the primary mechanism that makes wiki rebuilds cheap.
+	var cachedMap *wikiMapCacheData
+	var cacheKey string
+	if s.cache.Available() {
+		modelID := chatModel.GetModelID()
+		if modelID == "" {
+			modelID = "unknown"
+		}
+		promptHash := secutils.MultiFieldHash(
+			agent.WikiCandidateSlugPrompt,
+			agent.WikiSummaryPrompt,
+			agent.WikiChunkCitationPrompt,
+		)
+		granularity := string(batchCtx.ExtractionGranularity)
+		contentForHash := content + "\x00" + batchCtx.ContentInstructions + "\x00" + batchCtx.ExtractionInstructions
+		contentHash := secutils.ContentHash(contentForHash)
+		cacheKey = WikiMapCacheKey(contentHash, granularity, modelID, promptHash)
+
+		var cached wikiMapCacheData
+		if hit, err := s.cache.GetJSON(ctx, cacheKey, &cached); err == nil && hit {
+			cachedMap = &cached
+			logger.Infof(ctx, "wiki ingest: wiki map cache HIT for %s", knowledgeID)
+		}
+	}
+
 	// Pass 0: lightweight candidate slug extraction (skeleton only).
 	// On failure we fall back to the legacy single-shot extractor so the doc
 	// still gets ingested, just without chunk-level citations.
@@ -1171,58 +1200,7 @@ func (s *wikiIngestService) mapOneDocument(
 		slugItems         map[string]extractedItem
 		pass0Failed       bool
 	)
-	logger.Infof(ctx, "wiki ingest: pass 0 — extracting candidate slugs for %s", knowledgeID)
-	extractSpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.extract", types.SpanKindSubSpan, types.JSONMap{
-		"content_chars": utf8.RuneCountInString(content),
-		"old_pages":     len(oldPageSlugs),
-	})
-	extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
-	if err != nil {
-		logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) — falling back to legacy extractor", knowledgeID, err)
-		pass0Failed = true
-		extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
-		if err != nil {
-			logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
-			s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
-			s.tracker().FailSpan(ctx, wikiSpan, "EXTRACT_FAILED", err.Error(), err)
-			return nil, nil, err
-		}
-	}
-	s.tracker().EndSpan(ctx, extractSpan, types.JSONMap{
-		"entities":         len(extractedEntities),
-		"concepts":         len(extractedConcepts),
-		"pass0_fallback":   pass0Failed,
-		"entities_preview": previewExtractedItems(extractedEntities, 8),
-		"concepts_preview": previewExtractedItems(extractedConcepts, 8),
-	})
 
-	// Build slug listing for Summary's wiki-link input.
-	var summaryExtractedPages []string
-	for slug := range slugItems {
-		summaryExtractedPages = append(summaryExtractedPages, slug)
-	}
-	// Wiki summary slug is derived from the knowledge ID rather than the
-	// docTitle (which is typically the upload filename). Filename-based slugs
-	// like "summary/mx5280-pdf" expose the filename in cross-link contexts
-	// that downstream LLM prompts read; a UUID-based slug is uglier but
-	// hallucination-safe.
-	summarySlug := fmt.Sprintf("summary/%s", slugify(knowledgeID))
-	var slugListing string
-	for _, slug := range summaryExtractedPages {
-		if item, ok := slugItems[slug]; ok {
-			aliases := ""
-			if len(item.Aliases) > 0 {
-				aliases = fmt.Sprintf(" (Aliases: %s)", strings.Join(item.Aliases, ", "))
-			}
-			slugListing += fmt.Sprintf("- [[%s]] = %s%s\n", slug, item.Name, aliases)
-		} else {
-			slugListing += fmt.Sprintf("- [[%s]]\n", slug)
-		}
-	}
-
-	// Summary and chunk classification are independent given Pass 0 output —
-	// run them in parallel. Summary handles wiki-link injection; classification
-	// attaches concrete chunk IDs to each candidate slug.
 	var (
 		summaryContent string
 		summaryErr     error
@@ -1230,64 +1208,138 @@ func (s *wikiIngestService) mapOneDocument(
 		newSlugs       []newSlugFromCitation
 		batchCount     int
 	)
+	summarySlug := fmt.Sprintf("summary/%s", slugify(knowledgeID))
 
-	// Both calls run in parallel goroutines under the same wikiSpan
-	// parent — their subspans will visually overlap in the trace view,
-	// which correctly reflects their wall-clock concurrency.
-	summarySpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.summary", types.SpanKindSubSpan, types.JSONMap{
-		"content_chars":   utf8.RuneCountInString(content),
-		"extracted_slugs": len(summaryExtractedPages),
-	})
-	var classifySpan *Span
-	if !pass0Failed {
-		classifySpan = s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.classify", types.SpanKindSubSpan, types.JSONMap{
-			"chunks":     len(chunks),
-			"candidates": len(extractedEntities) + len(extractedConcepts),
+	if cachedMap != nil {
+		// Fully cached: reuse entities, concepts, summary, citations.
+		extractedEntities = cachedMap.Entities
+		extractedConcepts = cachedMap.Concepts
+		summaryContent = cachedMap.SummaryContent
+		citations = cachedMap.Citations
+		slugItems = make(map[string]extractedItem, len(extractedEntities)+len(extractedConcepts))
+		for _, item := range extractedEntities {
+			if item.Slug != "" && item.Name != "" {
+				slugItems[item.Slug] = item
+			}
+		}
+		for _, item := range extractedConcepts {
+			if item.Slug != "" && item.Name != "" {
+				slugItems[item.Slug] = item
+			}
+		}
+		logger.Infof(ctx, "wiki ingest: reused cached map for %s (ent=%d, con=%d)", knowledgeID, len(extractedEntities), len(extractedConcepts))
+	} else {
+		logger.Infof(ctx, "wiki ingest: pass 0 — extracting candidate slugs for %s", knowledgeID)
+		extractSpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.extract", types.SpanKindSubSpan, types.JSONMap{
+			"content_chars": utf8.RuneCountInString(content),
+			"old_pages":     len(oldPageSlugs),
 		})
-	}
+		extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
+		if err != nil {
+			logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) — falling back to legacy extractor", knowledgeID, err)
+			pass0Failed = true
+			extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
+			if err != nil {
+				logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
+				s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
+				s.tracker().FailSpan(ctx, wikiSpan, "EXTRACT_FAILED", err.Error(), err)
+				return nil, nil, err
+			}
+		}
+		s.tracker().EndSpan(ctx, extractSpan, types.JSONMap{
+			"entities":         len(extractedEntities),
+			"concepts":         len(extractedConcepts),
+			"pass0_fallback":   pass0Failed,
+			"entities_preview": previewExtractedItems(extractedEntities, 8),
+			"concepts_preview": previewExtractedItems(extractedConcepts, 8),
+		})
 
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		summaryContent, summaryErr = s.generateWithTemplate(ctx, chatModel, agent.WikiSummaryPrompt, map[string]string{
-			"Content":            content,
-			"Language":           lang,
-			"ExtractedSlugs":     slugListing,
-			"CustomInstructions": batchCtx.ContentInstructions,
-			"InstructionScope":   "wiki_content",
+		// Build slug listing for Summary's wiki-link input.
+		var summaryExtractedPages []string
+		for slug := range slugItems {
+			summaryExtractedPages = append(summaryExtractedPages, slug)
+		}
+		var slugListing string
+		for _, slug := range summaryExtractedPages {
+			if item, ok := slugItems[slug]; ok {
+				aliases := ""
+				if len(item.Aliases) > 0 {
+					aliases = fmt.Sprintf(" (Aliases: %s)", strings.Join(item.Aliases, ", "))
+				}
+				slugListing += fmt.Sprintf("- [[%s]] = %s%s\n", slug, item.Name, aliases)
+			} else {
+				slugListing += fmt.Sprintf("- [[%s]]\n", slug)
+			}
+		}
+
+		// Both calls run in parallel goroutines under the same wikiSpan
+		// parent — their subspans will visually overlap in the trace view,
+		// which correctly reflects their wall-clock concurrency.
+		summarySpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.summary", types.SpanKindSubSpan, types.JSONMap{
+			"content_chars":   utf8.RuneCountInString(content),
+			"extracted_slugs": len(summaryExtractedPages),
 		})
-		if summaryErr != nil {
-			s.tracker().FailSpan(ctx, summarySpan, "SUMMARY_FAILED", summaryErr.Error(), summaryErr)
-		} else {
-			sumLine, sumBody := splitSummaryLine(summaryContent)
-			s.tracker().EndSpan(ctx, summarySpan, types.JSONMap{
-				"chars":        utf8.RuneCountInString(summaryContent),
-				"summary_line": previewText(sumLine, 160),
-				"body_preview": previewText(sumBody, 320),
+		var classifySpan *Span
+		if !pass0Failed {
+			classifySpan = s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.classify", types.SpanKindSubSpan, types.JSONMap{
+				"chunks":     len(chunks),
+				"candidates": len(extractedEntities) + len(extractedConcepts),
 			})
 		}
-	}()
-	go func() {
-		defer wg.Done()
-		// Skip citation pass when Pass 0 has fallen back to the legacy path —
-		// the legacy output already contains paraphrased Details, so chunk
-		// citations would be redundant and we'd spend LLM calls for nothing.
-		if pass0Failed {
-			citations = map[string][]string{}
-			return
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			summaryContent, summaryErr = s.generateWithTemplate(ctx, chatModel, agent.WikiSummaryPrompt, map[string]string{
+				"Content":            content,
+				"Language":           lang,
+				"ExtractedSlugs":     slugListing,
+				"CustomInstructions": batchCtx.ContentInstructions,
+				"InstructionScope":   "wiki_content",
+			})
+			if summaryErr != nil {
+				s.tracker().FailSpan(ctx, summarySpan, "SUMMARY_FAILED", summaryErr.Error(), summaryErr)
+			} else {
+				sumLine, sumBody := splitSummaryLine(summaryContent)
+				s.tracker().EndSpan(ctx, summarySpan, types.JSONMap{
+					"chars":        utf8.RuneCountInString(summaryContent),
+					"summary_line": previewText(sumLine, 160),
+					"body_preview": previewText(sumBody, 320),
+				})
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if pass0Failed {
+				citations = map[string][]string{}
+				return
+			}
+			candidatesXML := renderCandidateSlugsXML(extractedEntities, extractedConcepts)
+			citations, newSlugs, batchCount = s.classifyChunkCitations(ctx, chatModel, candidatesXML, chunks, lang, batchCtx)
+			s.tracker().EndSpan(ctx, classifySpan, types.JSONMap{
+				"cited_slugs":      len(citations),
+				"new_slugs":        len(newSlugs),
+				"batches":          batchCount,
+				"top_cited":        topCitedSlugs(citations, 8),
+				"new_slugs_sample": previewNewSlugs(newSlugs, 8),
+			})
+		}()
+		wg.Wait()
+
+		// Store results in wiki map cache for future rebuilds.
+		if cacheKey != "" {
+			cacheData := wikiMapCacheData{
+				Entities:       extractedEntities,
+				Concepts:       extractedConcepts,
+				SummaryContent: summaryContent,
+				Citations:      citations,
+			}
+			if err := s.cache.SetJSON(ctx, cacheKey, cacheData, 24*time.Hour); err != nil {
+				logger.Warnf(ctx, "wiki ingest: failed to cache wiki map for %s: %v", knowledgeID, err)
+			}
 		}
-		candidatesXML := renderCandidateSlugsXML(extractedEntities, extractedConcepts)
-		citations, newSlugs, batchCount = s.classifyChunkCitations(ctx, chatModel, candidatesXML, chunks, lang, batchCtx)
-		s.tracker().EndSpan(ctx, classifySpan, types.JSONMap{
-			"cited_slugs":      len(citations),
-			"new_slugs":        len(newSlugs),
-			"batches":          batchCount,
-			"top_cited":        topCitedSlugs(citations, 8),
-			"new_slugs_sample": previewNewSlugs(newSlugs, 8),
-		})
-	}()
-	wg.Wait()
+	}
 
 	// Merge citations back into the item structs (non-failing; items without
 	// citations simply keep their Description+Details fallback).
@@ -2012,4 +2064,14 @@ func mergeChunkRefs(current types.StringArray, additions []SlugUpdate) types.Str
 		}
 	}
 	return out
+}
+
+// wikiMapCacheData holds the LLM-dependent output of mapOneDocument
+// that is safe to reuse across rebuilds when the document content and
+// wiki configuration has not changed.
+type wikiMapCacheData struct {
+	Entities       []extractedItem     `json:"entities"`
+	Concepts       []extractedItem     `json:"concepts"`
+	SummaryContent string              `json:"summary_content"`
+	Citations      map[string][]string `json:"citations"`
 }

--- a/internal/utils/contenthash.go
+++ b/internal/utils/contenthash.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"strings"
+)
+
+const nullByte = 0
+
+// ChunkID generates a deterministic content-addressed chunk ID.
+// Same (knowledgeID, normalized content, seq, chunkType) always yields the same ID.
+func ChunkID(knowledgeID string, content string, seq int, chunkType string) string {
+	h := sha256.New()
+	h.Write([]byte(knowledgeID))
+	h.Write([]byte{nullByte})
+	h.Write([]byte(strings.TrimSpace(content)))
+	h.Write([]byte{nullByte})
+	h.Write([]byte(strconv.Itoa(seq)))
+	h.Write([]byte{nullByte})
+	h.Write([]byte(chunkType))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ImageChunkID generates a deterministic ID for image sub-chunks (OCR / caption).
+// parentChunkID must itself be deterministic (content-addressed).
+func ImageChunkID(parentChunkID string, subType string, content string) string {
+	h := sha256.New()
+	h.Write([]byte(parentChunkID))
+	h.Write([]byte{nullByte})
+	h.Write([]byte(subType))
+	h.Write([]byte{nullByte})
+	h.Write([]byte(strings.TrimSpace(content)))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ContentHash returns a hex SHA-256 of the input string.
+func ContentHash(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// MultiFieldHash returns a hex SHA-256 of all fields joined with null bytes.
+func MultiFieldHash(fields ...string) string {
+	h := sha256.New()
+	for i, f := range fields {
+		if i > 0 {
+			h.Write([]byte{nullByte})
+		}
+		h.Write([]byte(f))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}


### PR DESCRIPTION
## Description
重建缓存架构设计

知识库重建(Reparse)时执行全量重烧:重复调用 VLM OCR/Caption、Embedding API 和 Wiki LLM 提取，即使文档内容未变也产生大量浪费。

方案：
内容寻址缓存 + 统一失效策略，将重建从「全量重烧」退化为「diff + 只补差异」。

5 层缓存：

层：Chunk ID(地基)
文件：utils/contenthash.go
Key 格式：SHA256(knowledgeID + content + seq + type)
粒度：内容不变 → ID 不变 → 下游引用存活

层：VLM
文件：image_multimodal.go
Key 格式：vlm:{imgHash}:{modelID}:{promptSHA}
粒度：图片 + 模型 + prompt 不变 → 零 VLM 调用

层：Embedding
文件：keywords_vector_hybrid_indexer.go
Key 格式：emb:{contentSHA}:{modelID}:{dim}
粒度：内容 + 模型 + 维度不变 → 零 API 调用

层：Wiki Map
文件：wiki_ingest_batch.go
Key 格式：wiki:map:{docSHA}:{granularity}:{modelID}:{promptSHA}
粒度：内容 + 配置不变 → 跳过 extract/summary/classify

层：缓存基础设施
文件：content_cache.go
Key 格式：通用 Get/Set/GetJSON/SetJSON
粒度：nil-safe Lite 模式

统一失效：
所有 key 内嵌模型 ID / 配置 / prompt 版本:
- 换 VLM 模型 → 仅 VLM 层 miss → 重新 OCR/Caption
- 换 Embedding 模型 → 仅 Embedding 层 miss → VLM/Wiki 仍 hit
- 改 chunk size → chunk 边界变 → 新 chunk ID → embedding 层 miss
- 改 Wiki prompt → 仅 wiki map 层 miss

唯一不可消除成本:首次摄取的 VLM + Embedding + Wiki LLM 调用，以及贡献者编辑 wiki 页面触发的 reduce。

文件变更：

文件：internal/utils/contenthash.go
状态：新增
说明：ChunkID / ContentHash / MultiFieldHash 纯函数

文件：internal/application/service/content_cache.go
状态：新增
说明：nil-safe Redis 缓存 + 3 种 key 构造器

文件：internal/application/service/knowledge_process.go
状态：修改
说明：6 处 uuid.New()→ChunkID; 嵌入缓存 context 注入

文件：internal/application/service/image_multimodal.go
状态：修改
说明：新增 cache 字段; OCR/Caption 前检查 vlm:... 缓存

文件：internal/application/service/retriever/keywords_vector_hybrid_indexer.go
状态：修改
说明：新增 EmbeddingCache 接口 + cachedBatchEmbed; BatchIndex 自动缓存

文件：internal/application/service/wiki_ingest.go
状态：修改
说明：新增 cache 字段

文件：internal/application/service/wiki_ingest_batch.go
状态：修改
说明：新增 wikiMapCacheData; mapOneDocument 检查 wiki map 缓存

已知限制：
internal/utils/inject.go 依赖 CGo 包 pg_query_go, 在 CGO_ENABLED=0 环境下阻塞全项目编译。建议为该文件添加 //go:build cgo 编译约束。

## Related Issue
Fixes #1679 
