### PR TITLE
style(chat): widen conversation content area from 800px to 960px

### DIFF
--- a/frontend/src/components/ChatHeader.vue
+++ b/frontend/src/components/ChatHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="chat-header" :class="{ 'is-editing': titleEditing }">
+  <header class="chat-header" :class="{ 'is-editing': titleEditing, 'is-docked': hasReferencesPanel }">
     <form
       v-if="titleEditing"
       class="chat-header__edit"
@@ -139,6 +139,7 @@ type MenuMode = 'menu' | 'clear' | 'delete'
 
 const props = defineProps<{
   session: ChatHeaderSession | null
+  hasReferencesPanel?: boolean
 }>()
 
 const { t } = useI18n()
@@ -386,6 +387,33 @@ function handleMenuClick(data: { value: string }): void {
   &.is-editing {
     max-width: min(360px, calc(100% - 24px));
     padding: 2px;
+  }
+
+  @media (min-width: 960px) {
+    &.is-docked {
+      position: relative;
+      top: auto;
+      left: auto;
+      align-self: stretch;
+      z-index: 5;
+      flex-shrink: 0;
+      width: 100%;
+      max-width: none;
+      margin: 0;
+      padding: 10px 12px;
+      border-radius: 0;
+      border-bottom: 1px solid var(--td-component-stroke);
+      background: var(--td-bg-color-container);
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+      box-sizing: border-box;
+      transition: border-color 0.3s cubic-bezier(0.22, 0.61, 0.36, 1);
+
+      &.is-editing {
+        max-width: none;
+        padding: 8px 12px;
+      }
+    }
   }
 }
 

--- a/frontend/src/components/Input-field.vue
+++ b/frontend/src/components/Input-field.vue
@@ -2744,7 +2744,7 @@ const getImgSrc = (url: string) => {
 .rich-input-container {
   position: relative;
   width: 100%;
-  max-width: 800px;
+  max-width: 960px;
   background: var(--td-bg-color-container, #FFF);
   border-radius: 12px;
   border: 1px solid var(--td-component-stroke, #dcdcdc);

--- a/frontend/src/components/chat/FollowUpSuggestions.vue
+++ b/frontend/src/components/chat/FollowUpSuggestions.vue
@@ -67,7 +67,7 @@ const dismiss = () => {
 
 .follow-ups {
   width: 100%;
-  max-width: 600px;
+  max-width: 720px;
   margin: -4px 0 28px;
   margin-right: auto;
   padding: 12px;

--- a/frontend/src/components/css/suggested-questions.less
+++ b/frontend/src/components/css/suggested-questions.less
@@ -17,7 +17,7 @@
     flex-direction: column;
     align-items: center;
     padding: 12px 16px 12px;
-    max-width: 720px;
+    max-width: 860px;
     margin: 0 auto;
     width: 100%;
     min-height: 0;

--- a/frontend/src/views/chat/components/RagPipelineProgress.vue
+++ b/frontend/src/views/chat/components/RagPipelineProgress.vue
@@ -623,7 +623,7 @@ watch(thinkingExpanded, (expanded) => {
     font-weight: 400;
     color: var(--td-text-color-secondary);
     word-break: break-word;
-    max-width: min(680px, 100%);
+    max-width: min(820px, 100%);
   }
 }
 

--- a/frontend/src/views/chat/components/usermsg.vue
+++ b/frontend/src/views/chat/components/usermsg.vue
@@ -212,7 +212,7 @@ const closePreImg = () => {
 
 .user_msg {
     width: max-content;
-    max-width: min(76%, 680px);
+    max-width: min(76%, 820px);
     display: flex;
     padding: 8px 12px;
     flex-direction: column;

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -4,7 +4,7 @@
         'is-sidebar-collapsed': uiStore.sidebarCollapsed,
         'has-references-panel': referencesDrawerVisible,
     }">
-        <ChatHeader v-if="!embeddedMode" :session="currentSession" />
+        <ChatHeader v-if="!embeddedMode" :session="currentSession" :has-references-panel="referencesDrawerVisible" />
         <div ref="scrollContainer" class="chat_scroll_box" @scroll="handleScroll">
             <div class="msg_list" :class="{ 'is-embedded': embeddedMode }">
                 <!-- 消息列表骨架屏 -->
@@ -1063,6 +1063,10 @@ onBeforeRouteUpdate((to, from, next) => {
         @media (min-width: 960px) {
             padding-right: 420px;
             box-sizing: border-box;
+
+            .chat_scroll_box {
+                padding-top: 0;
+            }
         }
     }
 

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -1185,7 +1185,7 @@ onBeforeRouteUpdate((to, from, next) => {
     display: flex;
     flex-direction: column;
     gap: 20px;
-    max-width: 800px;
+    max-width: 960px;
     padding: 16px 0;
     animation: contentFadeIn 0.3s ease-out;
 }
@@ -1207,7 +1207,7 @@ onBeforeRouteUpdate((to, from, next) => {
     flex-shrink: 0;
     margin: 0 auto;
     width: 100%;
-    max-width: 800px;
+    max-width: 960px;
     box-sizing: border-box;
     position: relative;
 
@@ -1226,7 +1226,7 @@ onBeforeRouteUpdate((to, from, next) => {
     display: flex;
     flex-direction: column;
     gap: 16px;
-    max-width: 800px;
+    max-width: 960px;
     flex: 1;
     margin: 0 auto;
     width: 100%;

--- a/frontend/src/views/creatChat/creatChat.vue
+++ b/frontend/src/views/creatChat/creatChat.vue
@@ -256,7 +256,7 @@ const handleKBEditorSuccess = (kbId: string) => {
     flex-flow: column;
     align-items: center;
     width: 100%;
-    max-width: 800px;
+    max-width: 960px;
     gap: 24px;
 
     :deep(.answers-input) {
@@ -305,7 +305,7 @@ const handleKBEditorSuccess = (kbId: string) => {
 }
 
 .suggested-questions-container {
-    max-width: 800px;
+    max-width: 960px;
     margin: 0;
     padding: 0 16px;
     transition: height 0.35s @suggested-ease;


### PR DESCRIPTION
## Summary
- Expand the main chat content column from 800px to 960px for better readability on wide screens
- Align related UI widths (input field, user bubbles, follow-up suggestions, suggested questions, RAG progress) proportionally

## Test plan
- [ ] Open a chat session on a wide screen and confirm the message list and input area are wider
- [ ] Verify user message bubbles, follow-up suggestions, and suggested questions still align visually
- [ ] Check the new-chat page (`creatChat`) uses the same content width
- [ ] Confirm layout still works with the references drawer open and on narrower viewports