### PR TITLE
fix(service): 修复跨租户共享 KB 的 embedding 模型解析

### DIFF
--- a/internal/application/service/chunk.go
+++ b/internal/application/service/chunk.go
@@ -419,7 +419,7 @@ func (s *chunkService) DeleteGeneratedQuestion(ctx context.Context, chunkID stri
 		return fmt.Errorf("failed to create retrieve engine: %w", err)
 	}
 
-	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
+	embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, kb)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"embedding_model_id": kb.EmbeddingModelID,

--- a/internal/application/service/embedding_model_resolver.go
+++ b/internal/application/service/embedding_model_resolver.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+func getEmbeddingModelForKB(
+	ctx context.Context,
+	modelService interfaces.ModelService,
+	kb *types.KnowledgeBase,
+) (embedding.Embedder, error) {
+	if kb == nil {
+		return nil, errors.New("knowledge base cannot be nil")
+	}
+	return getEmbeddingModelForTenant(ctx, modelService, kb.EmbeddingModelID, kb.TenantID)
+}
+
+func getEmbeddingModelForKnowledge(
+	ctx context.Context,
+	modelService interfaces.ModelService,
+	knowledge *types.Knowledge,
+) (embedding.Embedder, error) {
+	if knowledge == nil {
+		return nil, errors.New("knowledge cannot be nil")
+	}
+	return getEmbeddingModelForTenant(ctx, modelService, knowledge.EmbeddingModelID, knowledge.TenantID)
+}
+
+func getEmbeddingModelForTenant(
+	ctx context.Context,
+	modelService interfaces.ModelService,
+	modelID string,
+	modelTenantID uint64,
+) (embedding.Embedder, error) {
+	currentTenantID, ok := types.TenantIDFromContext(ctx)
+	if ok && modelTenantID != 0 && modelTenantID != currentTenantID {
+		logger.Infof(ctx,
+			"Cross-tenant embedding model lookup, model ID: %s, owner tenant: %d, current tenant: %d",
+			modelID, modelTenantID, currentTenantID)
+		return modelService.GetEmbeddingModelForTenant(ctx, modelID, modelTenantID)
+	}
+	return modelService.GetEmbeddingModel(ctx, modelID)
+}

--- a/internal/application/service/embedding_model_resolver_test.go
+++ b/internal/application/service/embedding_model_resolver_test.go
@@ -1,0 +1,90 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type resolverTestModelService struct {
+	interfaces.ModelService
+
+	sameTenantModelID  string
+	crossTenantModelID string
+	crossTenantID      uint64
+}
+
+func (s *resolverTestModelService) GetEmbeddingModel(
+	_ context.Context,
+	modelID string,
+) (embedding.Embedder, error) {
+	s.sameTenantModelID = modelID
+	return resolverTestEmbedder{}, nil
+}
+
+func (s *resolverTestModelService) GetEmbeddingModelForTenant(
+	_ context.Context,
+	modelID string,
+	tenantID uint64,
+) (embedding.Embedder, error) {
+	s.crossTenantModelID = modelID
+	s.crossTenantID = tenantID
+	return resolverTestEmbedder{}, nil
+}
+
+type resolverTestEmbedder struct{}
+
+func (resolverTestEmbedder) Embed(context.Context, string) ([]float32, error) { return nil, nil }
+func (resolverTestEmbedder) BatchEmbed(context.Context, []string) ([][]float32, error) {
+	return nil, nil
+}
+func (resolverTestEmbedder) BatchEmbedWithPool(
+	context.Context,
+	embedding.Embedder,
+	[]string,
+) ([][]float32, error) {
+	return nil, nil
+}
+func (resolverTestEmbedder) GetModelName() string { return "test" }
+func (resolverTestEmbedder) GetDimensions() int   { return 3 }
+func (resolverTestEmbedder) GetModelID() string   { return "model" }
+
+func TestGetEmbeddingModelForKBUsesOwnerTenantForCrossTenant(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(10001))
+	modelSvc := &resolverTestModelService{}
+	kb := &types.KnowledgeBase{TenantID: 10000, EmbeddingModelID: "embed-owner"}
+
+	if _, err := getEmbeddingModelForKB(ctx, modelSvc, kb); err != nil {
+		t.Fatalf("getEmbeddingModelForKB returned error: %v", err)
+	}
+
+	if modelSvc.crossTenantModelID != "embed-owner" {
+		t.Fatalf("cross-tenant model ID = %q, want embed-owner", modelSvc.crossTenantModelID)
+	}
+	if modelSvc.crossTenantID != 10000 {
+		t.Fatalf("cross-tenant ID = %d, want 10000", modelSvc.crossTenantID)
+	}
+	if modelSvc.sameTenantModelID != "" {
+		t.Fatalf("same-tenant lookup was called for cross-tenant KB")
+	}
+}
+
+func TestGetEmbeddingModelForKBUsesContextTenantForSameTenant(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(10000))
+	modelSvc := &resolverTestModelService{}
+	kb := &types.KnowledgeBase{TenantID: 10000, EmbeddingModelID: "embed-owner"}
+
+	if _, err := getEmbeddingModelForKB(ctx, modelSvc, kb); err != nil {
+		t.Fatalf("getEmbeddingModelForKB returned error: %v", err)
+	}
+
+	if modelSvc.sameTenantModelID != "embed-owner" {
+		t.Fatalf("same-tenant model ID = %q, want embed-owner", modelSvc.sameTenantModelID)
+	}
+	if modelSvc.crossTenantModelID != "" {
+		t.Fatalf("cross-tenant lookup was called for same-tenant KB")
+	}
+}

--- a/internal/application/service/extract.go
+++ b/internal/application/service/extract.go
@@ -514,13 +514,6 @@ func (s *DataTableSummaryService) prepareResources(ctx context.Context, payload 
 		return nil, err
 	}
 
-	// 获取嵌入模型（用于向量化）
-	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, payload.EmbeddingModel)
-	if err != nil {
-		logger.Errorf(ctx, "failed to get embedding model: %v", err)
-		return nil, err
-	}
-
 	// Load the KB to discover its VectorStoreID binding so the factory can
 	// route to the bound store (or fall back to tenant engines if unbound).
 	kb, err := s.knowledgeBaseService.GetKnowledgeBaseByID(ctx, knowledge.KnowledgeBaseID)
@@ -528,6 +521,14 @@ func (s *DataTableSummaryService) prepareResources(ctx context.Context, payload 
 		logger.Errorf(ctx, "failed to get knowledge base for vector store lookup: %v", err)
 		return nil, err
 	}
+
+	// 获取嵌入模型（用于向量化）
+	embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, kb)
+	if err != nil {
+		logger.Errorf(ctx, "failed to get embedding model: %v", err)
+		return nil, err
+	}
+
 	var vectorStoreID *string
 	if kb != nil {
 		vectorStoreID = kb.VectorStoreID

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -453,7 +453,7 @@ func (s *ImageMultimodalService) indexChunks(ctx context.Context, payload types.
 		return
 	}
 
-	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
+	embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, kb)
 	if err != nil {
 		logger.Warnf(ctx, "[ImageMultimodal] Failed to get embedding model for indexing: %v", err)
 		return

--- a/internal/application/service/knowledge_clone_move.go
+++ b/internal/application/service/knowledge_clone_move.go
@@ -331,7 +331,7 @@ func (s *knowledgeService) CloneChunk(ctx context.Context, src, dst *types.Knowl
 	if err != nil {
 		return err
 	}
-	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, dst.EmbeddingModelID)
+	embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, dstKB)
 	if err != nil {
 		return err
 	}
@@ -601,7 +601,7 @@ func (s *knowledgeService) cloneFAQKnowledgeBase(
 	}
 
 	// Get embedding model
-	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, dstKB.EmbeddingModelID)
+	embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, dstKB)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to get embedding model: %v", err)
 		handleError(progress, err, "Failed to get embedding model")
@@ -1070,7 +1070,7 @@ func (s *knowledgeService) moveKnowledgeReuseVectors(
 		if err != nil {
 			return fmt.Errorf("failed to init retrieve engine: %w", err)
 		}
-		embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, knowledge.EmbeddingModelID)
+		embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, sourceKB)
 		if err != nil {
 			return fmt.Errorf("failed to get embedding model: %w", err)
 		}

--- a/internal/application/service/knowledge_delete.go
+++ b/internal/application/service/knowledge_delete.go
@@ -126,7 +126,7 @@ func (s *knowledgeService) DeleteKnowledge(ctx context.Context, id string) error
 				logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge delete knowledge embedding failed")
 				return err
 			}
-			embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, knowledge.EmbeddingModelID)
+			embeddingModel, err := getEmbeddingModelForKnowledge(ctx, s.modelService, knowledge)
 			if err != nil {
 				logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge delete knowledge embedding failed")
 				return err
@@ -509,11 +509,16 @@ func (s *knowledgeService) DeleteKnowledgeList(ctx context.Context, ids []string
 		// Group by EmbeddingModelID and Type
 		type groupKey struct {
 			EmbeddingModelID string
+			TenantID         uint64
 			Type             string
 		}
 		group := map[groupKey][]string{}
 		for _, knowledge := range knowledgeList {
-			key := groupKey{EmbeddingModelID: knowledge.EmbeddingModelID, Type: knowledge.Type}
+			key := groupKey{
+				EmbeddingModelID: knowledge.EmbeddingModelID,
+				TenantID:         knowledge.TenantID,
+				Type:             knowledge.Type,
+			}
 			group[key] = append(group[key], knowledge.ID)
 		}
 		for key, knowledgeIDs := range group {
@@ -524,7 +529,7 @@ func (s *knowledgeService) DeleteKnowledgeList(ctx context.Context, ids []string
 				logger.Infof(ctx, "Skipping vector store cleanup for %d knowledge entries without embedding model", len(knowledgeIDs))
 				continue
 			}
-			embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, key.EmbeddingModelID)
+			embeddingModel, err := getEmbeddingModelForTenant(ctx, s.modelService, key.EmbeddingModelID, key.TenantID)
 			if err != nil {
 				logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge get embedding model failed")
 				return err
@@ -644,7 +649,7 @@ func (s *knowledgeService) cleanupKnowledgeResources(ctx context.Context, knowle
 			logger.GetLogger(ctx).WithField("error", err).Error("Failed to init retrieve engine during cleanup")
 			cleanupErr = errors.Join(cleanupErr, err)
 		} else {
-			embeddingModel, modelErr := s.modelService.GetEmbeddingModel(ctx, knowledge.EmbeddingModelID)
+			embeddingModel, modelErr := getEmbeddingModelForKnowledge(ctx, s.modelService, knowledge)
 			if modelErr != nil {
 				logger.GetLogger(ctx).WithField("error", modelErr).Error("Failed to get embedding model during cleanup")
 				cleanupErr = errors.Join(cleanupErr, modelErr)

--- a/internal/application/service/knowledge_faq.go
+++ b/internal/application/service/knowledge_faq.go
@@ -168,7 +168,7 @@ func (s *knowledgeService) CreateFAQEntry(ctx context.Context,
 	}
 
 	// 获取embedding模型
-	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
+	embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, kb)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get embedding model: %w", err)
 	}
@@ -404,7 +404,7 @@ func (s *knowledgeService) UpdateFAQEntry(ctx context.Context,
 		return nil, err
 	}
 
-	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
+	embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, kb)
 	if err != nil {
 		return nil, err
 	}
@@ -573,7 +573,7 @@ func (s *knowledgeService) AddSimilarQuestions(ctx context.Context,
 		return nil, err
 	}
 
-	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
+	embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, kb)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/application/service/knowledge_faq_import.go
+++ b/internal/application/service/knowledge_faq_import.go
@@ -818,7 +818,7 @@ func (s *knowledgeService) executeFAQImport(ctx context.Context, taskID string, 
 	kb.EnsureDefaults()
 
 	// 获取embedding模型，用于后续清理索引
-	embeddingModel, err = s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
+	embeddingModel, err = getEmbeddingModelForKB(ctx, s.modelService, kb)
 	if err != nil {
 		return fmt.Errorf("failed to get embedding model: %w", err)
 	}
@@ -1472,7 +1472,7 @@ func (s *knowledgeService) deleteFAQChunkVectors(ctx context.Context,
 	if len(chunks) == 0 {
 		return nil
 	}
-	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
+	embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, kb)
 	if err != nil {
 		return err
 	}
@@ -1697,7 +1697,7 @@ func (s *knowledgeService) ProcessFAQImport(ctx context.Context, t *asynq.Task) 
 		logger.Infof(ctx, "Deleted unindexed chunks: %d", len(chunksDeleted))
 
 		// 删除索引数据
-		embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
+		embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, kb)
 		if err == nil {
 			retrieveEngine, err := retriever.CreateRetrieveEngineForKB(
 				ctx, s.retrieveEngine, s.ownership, tenantInfo.ID, kb.VectorStoreID)

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -278,7 +278,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	var embeddingModel embedding.Embedder
 	if kb.NeedsEmbeddingModel() {
 		var err error
-		embeddingModel, err = s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
+		embeddingModel, err = getEmbeddingModelForKB(ctx, s.modelService, kb)
 		if err != nil {
 			logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks get embedding model failed")
 			return
@@ -1162,7 +1162,7 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 			return fmt.Errorf("failed to init retrieve engine: %w", err)
 		}
 
-		embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
+		embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, kb)
 		if err != nil {
 			logger.Errorf(ctx, "Failed to get embedding model: %v", err)
 			summaryErr = err
@@ -1432,7 +1432,7 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 	resolvedModelID = kb.SummaryModelID
 
 	// Initialize embedding model and retrieval engine
-	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
+	embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, kb)
 	if err != nil {
 		exitStatus = "get_embedding_model_failed"
 		logger.Errorf(ctx, "Failed to get embedding model: %v", err)
@@ -1733,7 +1733,7 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 	}
 	resolvedModelID = kb.SummaryModelID
 
-	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
+	embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, kb)
 	if err != nil {
 		exitStatus = "get_embedding_model_failed"
 		logger.Errorf(ctx, "Failed to get embedding model: %v", err)
@@ -2372,7 +2372,7 @@ func (s *knowledgeService) updateChunkVector(ctx context.Context, kbID string, c
 	if err != nil {
 		return err
 	}
-	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, sourceKB.EmbeddingModelID)
+	embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, sourceKB)
 	if err != nil {
 		return err
 	}

--- a/internal/application/service/knowledgebase.go
+++ b/internal/application/service/knowledgebase.go
@@ -797,16 +797,25 @@ func (s *knowledgeBaseService) ProcessKBDelete(ctx context.Context, t *asynq.Tas
 			// Group knowledge by embedding model and type
 			type groupKey struct {
 				EmbeddingModelID string
+				TenantID         uint64
 				Type             string
 			}
 			embeddingGroups := make(map[groupKey][]string)
 			for _, knowledge := range knowledgeList {
-				key := groupKey{EmbeddingModelID: knowledge.EmbeddingModelID, Type: knowledge.Type}
+				key := groupKey{
+					EmbeddingModelID: knowledge.EmbeddingModelID,
+					TenantID:         knowledge.TenantID,
+					Type:             knowledge.Type,
+				}
 				embeddingGroups[key] = append(embeddingGroups[key], knowledge.ID)
 			}
 
 			for key, knowledgeGroup := range embeddingGroups {
-				embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, key.EmbeddingModelID)
+				if strings.TrimSpace(key.EmbeddingModelID) == "" {
+					logger.Infof(ctx, "Skipping vector store cleanup for %d knowledge entries without embedding model", len(knowledgeGroup))
+					continue
+				}
+				embeddingModel, err := getEmbeddingModelForTenant(ctx, s.modelService, key.EmbeddingModelID, key.TenantID)
 				if err != nil {
 					logger.Warnf(ctx, "Failed to get embedding model %s: %v", key.EmbeddingModelID, err)
 					continue

--- a/internal/application/service/knowledgebase_search.go
+++ b/internal/application/service/knowledgebase_search.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
 	apperrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/logger"
-	"github.com/Tencent/WeKnora/internal/models/embedding"
 	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
@@ -22,14 +21,7 @@ func (s *knowledgeBaseService) GetQueryEmbedding(ctx context.Context, kbID strin
 		return nil, err
 	}
 
-	currentTenantID := types.MustTenantIDFromContext(ctx)
-	var embeddingModel embedding.Embedder
-
-	if kb.TenantID != currentTenantID {
-		embeddingModel, err = s.modelService.GetEmbeddingModelForTenant(ctx, kb.EmbeddingModelID, kb.TenantID)
-	} else {
-		embeddingModel, err = s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
-	}
+	embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, kb)
 	if err != nil {
 		logger.Errorf(ctx, "GetQueryEmbedding: failed to get embedding model %s: %v", kb.EmbeddingModelID, err)
 		return nil, err
@@ -322,7 +314,6 @@ func (s *knowledgeBaseService) buildRetrievalParams(
 	params types.SearchParams,
 	matchCount int,
 ) ([]types.RetrieveParams, error) {
-	currentTenantID := types.MustTenantIDFromContext(ctx)
 	var retrieveParams []types.RetrieveParams
 
 	// Partition the group's KBs by index routing. A KB that does not have
@@ -354,7 +345,7 @@ func (s *knowledgeBaseService) buildRetrievalParams(
 		(len(faqVectorKBIDs) > 0 || len(docVectorKBIDs) > 0) {
 		logger.Info(ctx, "Vector retrieval supported, preparing vector retrieval parameters")
 
-		queryEmbedding, err := s.resolveQueryEmbedding(ctx, primary, params, currentTenantID)
+		queryEmbedding, err := s.resolveQueryEmbedding(ctx, primary, params)
 		if err != nil {
 			return nil, err
 		}
@@ -415,7 +406,6 @@ func (s *knowledgeBaseService) resolveQueryEmbedding(
 	ctx context.Context,
 	kb *types.KnowledgeBase,
 	params types.SearchParams,
-	currentTenantID uint64,
 ) ([]float32, error) {
 	if len(params.QueryEmbedding) > 0 {
 		logger.Infof(ctx, "Using pre-computed query embedding, vector length: %d", len(params.QueryEmbedding))
@@ -424,14 +414,7 @@ func (s *knowledgeBaseService) resolveQueryEmbedding(
 
 	logger.Infof(ctx, "Getting embedding model, model ID: %s", kb.EmbeddingModelID)
 
-	var embeddingModel embedding.Embedder
-	var err error
-	if kb.TenantID != currentTenantID {
-		logger.Infof(ctx, "Cross-tenant knowledge base detected, using source tenant's embedding model. KB tenant: %d, current tenant: %d", kb.TenantID, currentTenantID)
-		embeddingModel, err = s.modelService.GetEmbeddingModelForTenant(ctx, kb.EmbeddingModelID, kb.TenantID)
-	} else {
-		embeddingModel, err = s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
-	}
+	embeddingModel, err := getEmbeddingModelForKB(ctx, s.modelService, kb)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to get embedding model, model ID: %s, error: %v", kb.EmbeddingModelID, err)
 		return nil, err

--- a/internal/application/service/model.go
+++ b/internal/application/service/model.go
@@ -468,7 +468,16 @@ func (s *modelService) GetEmbeddingModelForTenant(ctx context.Context, modelId s
 
 	logger.Infof(ctx, "Getting cross-tenant embedding model: %s, source: %s, tenant: %d", model.Name, model.Source, tenantID)
 
-	appID, appSecret := s.resolveWeKnoraCloudCredentials(ctx, &model.Parameters)
+	credentialCtx := context.WithValue(ctx, types.TenantIDContextKey, tenantID)
+	credentialCtx = context.WithValue(credentialCtx, types.TenantInfoContextKey, (*types.Tenant)(nil))
+	if s.tenantService != nil {
+		if tenant, tenantErr := s.tenantService.GetTenantByID(credentialCtx, tenantID); tenantErr == nil && tenant != nil {
+			credentialCtx = context.WithValue(credentialCtx, types.TenantInfoContextKey, tenant)
+		} else if tenantErr != nil {
+			logger.Warnf(ctx, "Failed to load tenant %d for cross-tenant model credentials: %v", tenantID, tenantErr)
+		}
+	}
+	appID, appSecret := s.resolveWeKnoraCloudCredentials(credentialCtx, &model.Parameters)
 
 	embedder, err := embedding.NewEmbedder(embedding.ConfigFromModel(model, appID, appSecret), s.pooler, s.ollamaService)
 	if err != nil {

--- a/internal/application/service/tag.go
+++ b/internal/application/service/tag.go
@@ -414,7 +414,7 @@ func (s *knowledgeTagService) ProcessIndexDelete(ctx context.Context, t *asynq.T
 	}
 
 	// Get embedding model dimensions
-	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, payload.EmbeddingModelID)
+	embeddingModel, err := getEmbeddingModelForTenant(ctx, s.modelService, payload.EmbeddingModelID, payload.TenantID)
 	if err != nil {
 		logger.Warnf(ctx, "Failed to get embedding model for index cleanup: %v", err)
 		return err

--- a/internal/application/service/wiki_ingest_taxonomy.go
+++ b/internal/application/service/wiki_ingest_taxonomy.go
@@ -177,7 +177,7 @@ func (s *wikiIngestService) selectRelevantFolders(
 		return capFolders(pool, wikiTaxonomyPromptMaxPaths)
 	}
 
-	embedder, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
+	embedder, err := getEmbeddingModelForKB(ctx, s.modelService, kb)
 	if err != nil {
 		logger.Warnf(ctx, "wiki ingest: taxonomy plan embed model unavailable, feeding all folders: %v", err)
 		return capFolders(pool, wikiTaxonomyPromptMaxPaths)


### PR DESCRIPTION
## Summary

Fixes #1998

- 新增 KB/knowledge owner tenant 感知的 embedding model resolver
- 将文档处理、FAQ、删除清理、clone/move、搜索、wiki taxonomy 等路径中的 embedding 模型获取改为基于 KB/knowledge 所属租户解析
- 删除清理按 embedding model、knowledge type 和 tenant 分组，避免不同租户下相同 model ID 被混用
- 修复跨租户 `GetEmbeddingModelForTenant` 下 WeKnoraCloud 凭证仍使用当前调用租户上下文的问题

## Testing

- `git diff --check`
- `go test ./internal/application/service`
  - blocked locally: default CGO setup reports `undefined: pg_query.Parse/Deparse`
  - with `CGO_ENABLED=1`, local machine is missing `gcc`