### PR TITLE
fix(frontend): 修复聊天 Wiki 抽屉中共享 KB 图片加载

### DIFF
--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -700,7 +700,7 @@ const wikiDrawerContent = computed(() => {
 watch(wikiDrawerContent, async () => {
   await nextTick();
   if (wikiDrawerBodyRef.value) {
-    await hydrateProtectedFileImages(wikiDrawerBodyRef.value);
+    await hydrateProtectedFileImages(wikiDrawerBodyRef.value, undefined, currentWikiKbId.value);
   }
 });
 

--- a/frontend/src/views/chat/components/chatLinksNewTab.test.mjs
+++ b/frontend/src/views/chat/components/chatLinksNewTab.test.mjs
@@ -30,6 +30,13 @@ test('wiki drawer navigation and citation fallbacks open in a new tab', () => {
   assert.doesNotMatch(agentStream, /router\.push\(/)
 })
 
+test('wiki drawer hydrates protected images with the active KB context', () => {
+  assert.match(
+    agentStream,
+    /hydrateProtectedFileImages\(wikiDrawerBodyRef\.value,\s*undefined,\s*currentWikiKbId\.value\)/,
+  )
+})
+
 test('agent citations recover drawer references from retrieval tool events', () => {
   assert.match(
     agentStream,


### PR DESCRIPTION
## Summary

Fixes #2017

- 为聊天 Wiki drawer 的 protected image hydration 传入当前 Wiki KB ID
- 确保 drawer 内的 `local://` / `storage://` 图片走 KB-scoped file proxy，而不是回落到租户级 `/files`
- 增加回归测试，防止该入口再次漏传 KB 上下文

## Testing

Passed:
- `git diff --check`
- `npx --yes tsx --test src/views/chat/components/chatLinksNewTab.test.mjs`

Not completed:
- `go test ./internal/router -run "(KBScopedFiles|ServeFiles)"` blocked by existing local `pg_query` / CGO build issue.
- `src/utils/security.test.ts` not completed because frontend dependencies are not installed locally, and `npm ci` failed with `ECONNRESET`.

## Commit

- `fae86f67 fix(frontend): hydrate wiki drawer images with KB context`