### PR TITLE
fix(client): accumulate multiline SSE data

### DIFF
--- a/client/agent.go
+++ b/client/agent.go
@@ -119,8 +119,9 @@ func (c *Client) processAgentSSEStream(reader io.Reader, callback AgentEventCall
 		// Empty line indicates the end of an event
 		if line == "" {
 			if dataBuffer != "" {
+				data := completeSSEData(dataBuffer)
 				var streamResponse AgentStreamResponse
-				if err := json.Unmarshal([]byte(dataBuffer), &streamResponse); err != nil {
+				if err := json.Unmarshal([]byte(data), &streamResponse); err != nil {
 					return fmt.Errorf("failed to parse SSE data: %w", err)
 				}
 
@@ -148,7 +149,7 @@ func (c *Client) processAgentSSEStream(reader io.Reader, callback AgentEventCall
 
 		// Process lines with data: prefix
 		if strings.HasPrefix(line, "data:") {
-			dataBuffer = strings.TrimSpace(line[5:]) // Remove "data:" prefix
+			dataBuffer = appendSSEDataLine(dataBuffer, line)
 		}
 	}
 

--- a/client/session.go
+++ b/client/session.go
@@ -306,9 +306,10 @@ func (c *Client) KnowledgeQAStream(
 		// Empty line indicates the end of an event
 		if line == "" {
 			if dataBuffer != "" {
-				debugLogger.Debug("sse_data_processing", "data", dataBuffer, "event_type", eventType)
+				data := completeSSEData(dataBuffer)
+				debugLogger.Debug("sse_data_processing", "data", data, "event_type", eventType)
 				var streamResponse StreamResponse
-				if err := json.Unmarshal([]byte(dataBuffer), &streamResponse); err != nil {
+				if err := json.Unmarshal([]byte(data), &streamResponse); err != nil {
 					debugLogger.Debug("sse_parse_failed", "error", err)
 					return fmt.Errorf("failed to parse SSE data: %w", err)
 				}
@@ -337,7 +338,7 @@ func (c *Client) KnowledgeQAStream(
 
 		// Process lines with data: prefix
 		if strings.HasPrefix(line, "data:") {
-			dataBuffer = line[5:] // Remove "data:" prefix
+			dataBuffer = appendSSEDataLine(dataBuffer, line)
 		}
 	}
 
@@ -387,8 +388,9 @@ func (c *Client) ContinueStream(
 		// Empty line indicates the end of an event
 		if line == "" {
 			if dataBuffer != "" && eventType == "message" {
+				data := completeSSEData(dataBuffer)
 				var streamResponse StreamResponse
-				if err := json.Unmarshal([]byte(dataBuffer), &streamResponse); err != nil {
+				if err := json.Unmarshal([]byte(data), &streamResponse); err != nil {
 					return fmt.Errorf("failed to parse SSE data: %w", err)
 				}
 
@@ -398,9 +400,9 @@ func (c *Client) ContinueStream(
 				if streamResponse.ResponseType == ResponseTypeError && streamResponse.Done {
 					return NewSSEStreamError(streamResponse.Content)
 				}
-				dataBuffer = ""
-				eventType = ""
 			}
+			dataBuffer = ""
+			eventType = ""
 			continue
 		}
 
@@ -411,7 +413,7 @@ func (c *Client) ContinueStream(
 
 		// Process lines with data: prefix
 		if strings.HasPrefix(line, "data:") {
-			dataBuffer = line[5:] // Remove "data:" prefix
+			dataBuffer = appendSSEDataLine(dataBuffer, line)
 		}
 	}
 

--- a/client/sse.go
+++ b/client/sse.go
@@ -1,0 +1,15 @@
+package client
+
+import "strings"
+
+func appendSSEDataLine(buffer, line string) string {
+	data := line[5:]
+	if strings.HasPrefix(data, " ") {
+		data = data[1:]
+	}
+	return buffer + data + "\n"
+}
+
+func completeSSEData(buffer string) string {
+	return strings.TrimSuffix(buffer, "\n")
+}

--- a/client/streaming_test.go
+++ b/client/streaming_test.go
@@ -37,6 +37,79 @@ func knowledgeSSEEvent(t *testing.T, w io.Writer, resp StreamResponse, eventType
 	fmt.Fprintf(w, "data:%s\n\n", b)
 }
 
+func TestProcessAgentSSEStream_MultilineDataFrame(t *testing.T) {
+	frame := "data: {\"response_type\":\"answer\",\n" +
+		"data: \"content\":\"hello\",\"done\":false}\n\n"
+
+	c := &Client{}
+	var got *AgentStreamResponse
+	err := c.processAgentSSEStream(strings.NewReader(frame), func(resp *AgentStreamResponse) error {
+		got = resp
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("multiline SSE data frame failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("callback was not invoked")
+	}
+	if got.ResponseType != AgentResponseTypeAnswer || got.Content != "hello" {
+		t.Fatalf("response = %#v, want answer content hello", got)
+	}
+}
+
+func TestKnowledgeQAStream_MultilineDataFrame(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data:{\"response_type\":\"answer\",\n")
+		fmt.Fprint(w, "data:\"content\":\"hello\",\"done\":false}\n\n")
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	var got *StreamResponse
+	err := c.KnowledgeQAStream(context.Background(), "sess", &KnowledgeQARequest{Query: "q"},
+		func(e *StreamResponse) error {
+			got = e
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("multiline knowledge SSE data frame failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("callback was not invoked")
+	}
+	if got.ResponseType != ResponseTypeAnswer || got.Content != "hello" {
+		t.Fatalf("response = %#v, want answer content hello", got)
+	}
+}
+
+func TestContinueStream_MultilineDataFrame(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "event:message\n")
+		fmt.Fprint(w, "data:{\"response_type\":\"answer\",\n")
+		fmt.Fprint(w, "data:\"content\":\"hello\",\"done\":false}\n\n")
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	var got *StreamResponse
+	err := c.ContinueStream(context.Background(), "sess", "msg", func(e *StreamResponse) error {
+		got = e
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("multiline continue SSE data frame failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("callback was not invoked")
+	}
+	if got.ResponseType != ResponseTypeAnswer || got.Content != "hello" {
+		t.Fatalf("response = %#v, want answer content hello", got)
+	}
+}
+
 // TestProcessAgentSSEStream_DataLineLimits locks in the 4 MiB bufio.Scanner
 // cap raised from the 64 KiB default: a `references` event bundling chunk
 // contents reaches hundreds of KiB and previously errored "token too long".


### PR DESCRIPTION
## Description

Fix the Go client SSE parsers so multiple `data:` lines in the same SSE event are accumulated before JSON unmarshalling.

Previously, each `data:` line overwrote the previous buffered value. A valid multiline SSE event could therefore leave only the final JSON fragment in the buffer and fail with:

```text
failed to parse SSE data: invalid character ':' after top-level value
```

This change applies the fix to agent streaming, knowledge QA streaming, and continue-stream parsing.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2121

## Testing

```powershell
cd client
go test -count=1 ./...
```

Result:

```text
ok   github.com/Tencent/WeKnora/client
```

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

Not applicable. This is a Go client parser fix with no UI changes.