### PR TITLE
fix(client): accumulate multi-line SSE data frames

### DIFF
--- a/client/agent.go
+++ b/client/agent.go
@@ -146,9 +146,15 @@ func (c *Client) processAgentSSEStream(reader io.Reader, callback AgentEventCall
 			continue
 		}
 
-		// Process lines with data: prefix
+		// Process lines with data: prefix. Multiple data lines in one event
+		// are joined with newlines per the SSE spec.
 		if strings.HasPrefix(line, "data:") {
-			dataBuffer = strings.TrimSpace(line[5:]) // Remove "data:" prefix
+			payload := strings.TrimSpace(line[5:])
+			if dataBuffer == "" {
+				dataBuffer = payload
+			} else {
+				dataBuffer += "\n" + payload
+			}
 		}
 	}
 

--- a/client/session.go
+++ b/client/session.go
@@ -337,7 +337,12 @@ func (c *Client) KnowledgeQAStream(
 
 		// Process lines with data: prefix
 		if strings.HasPrefix(line, "data:") {
-			dataBuffer = line[5:] // Remove "data:" prefix
+			payload := strings.TrimSpace(line[5:])
+			if dataBuffer == "" {
+				dataBuffer = payload
+			} else {
+				dataBuffer += "\n" + payload
+			}
 		}
 	}
 
@@ -411,7 +416,12 @@ func (c *Client) ContinueStream(
 
 		// Process lines with data: prefix
 		if strings.HasPrefix(line, "data:") {
-			dataBuffer = line[5:] // Remove "data:" prefix
+			payload := strings.TrimSpace(line[5:])
+			if dataBuffer == "" {
+				dataBuffer = payload
+			} else {
+				dataBuffer += "\n" + payload
+			}
 		}
 	}
 

--- a/client/streaming_test.go
+++ b/client/streaming_test.go
@@ -263,6 +263,73 @@ func TestKnowledgeQAStream_TerminalErrorEndsStream(t *testing.T) {
 	}
 }
 
+func TestProcessAgentSSEStream_MultilineDataFrame(t *testing.T) {
+	frame := "data: {\"response_type\":\"answer\",\n" +
+		"data: \"content\":\"hello\",\"done\":false}\n\n"
+	c := &Client{}
+	var got *AgentStreamResponse
+	err := c.processAgentSSEStream(strings.NewReader(frame), func(resp *AgentStreamResponse) error {
+		got = resp
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("multiline SSE data frame failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected callback invocation")
+	}
+	if got.ResponseType != AgentResponseTypeAnswer || got.Content != "hello" || got.Done {
+		t.Fatalf("got %+v, want answer/hello/done=false", got)
+	}
+}
+
+func TestKnowledgeQAStream_MultilineDataFrame(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: {\"response_type\":\"answer\",\n"+
+			"data: \"content\":\"hello\",\"done\":false}\n\n")
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	var got *StreamResponse
+	err := c.KnowledgeQAStream(context.Background(), "sess", &KnowledgeQARequest{Query: "q"},
+		func(resp *StreamResponse) error {
+			got = resp
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("multiline knowledge SSE data frame failed: %v", err)
+	}
+	if got == nil || got.ResponseType != ResponseTypeAnswer || got.Content != "hello" || got.Done {
+		t.Fatalf("got %+v, want answer/hello/done=false", got)
+	}
+}
+
+func TestContinueStream_MultilineDataFrame(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "event:message\n"+
+			"data: {\"response_type\":\"answer\",\n"+
+			"data: \"content\":\"hello\",\"done\":false}\n\n")
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	var got *StreamResponse
+	err := c.ContinueStream(context.Background(), "sess", "msg",
+		func(resp *StreamResponse) error {
+			got = resp
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("multiline continue SSE data frame failed: %v", err)
+	}
+	if got == nil || got.ResponseType != ResponseTypeAnswer || got.Content != "hello" || got.Done {
+		t.Fatalf("got %+v, want answer/hello/done=false", got)
+	}
+}
+
 // TestSearchResult_DecodesReferenceIndexes guards the KB and chunk-hierarchy
 // fields used by the CLI's bounded reference projection.
 func TestSearchResult_DecodesReferenceIndexes(t *testing.T) {


### PR DESCRIPTION
## Summary
- SSE parsers in the Go client overwritten `dataBuffer` on each `data:` line, so multi-line frames failed JSON decode.
- Accumulate lines (joined with `\n`) in `processAgentSSEStream`, `KnowledgeQAStream`, and `ContinueStream`.
- Add regression tests for all three paths.

## Test plan
- [ ] `cd client && go test -count=1 ./...`
- [x] New tests cover multiline agent / knowledge / continue streams

Fixes #2121