### PR TITLE
i18n: add dedicated batchRebuildKnowledge translation key

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -624,6 +624,7 @@ export default {
     selectAll: 'Select all',
     selectedCount: '{count} selected',
     clearSelection: 'Deselect all',
+    batchRebuildKnowledge: 'Batch rebuild knowledge',
     batchDelete: 'Delete selected',
     batchDeleteConfirmation: 'Confirm Batch Delete',
     confirmBatchDeleteDocument: 'Delete {count} selected documents? This action cannot be undone.',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -627,6 +627,7 @@ export default {
     selectAll: "전체 선택",
     selectedCount: "{count}개 선택됨",
     clearSelection: "선택 해제",
+    batchRebuildKnowledge: "일괄 재구축 지식",
     batchDelete: "선택 삭제",
     batchDeleteConfirmation: "일괄 삭제 확인",
     confirmBatchDeleteDocument: "선택한 {count}개 문서를 삭제하시겠습니까? 삭제 후 복구할 수 없습니다.",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -549,6 +549,7 @@ export default {
     selectAll: 'Выбрать все',
     selectedCount: 'Выбрано: {count}',
     clearSelection: 'Снять выделение',
+    batchRebuildKnowledge: 'Пакетная реконструкция знаний',
     batchDelete: 'Удалить выбранные',
     batchDeleteConfirmation: 'Подтверждение пакетного удаления',
     confirmBatchDeleteDocument: 'Удалить {count} выбранных документов? Это действие нельзя отменить.',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -625,6 +625,7 @@ export default {
     selectAll: "全选",
     selectedCount: "已选 {count} 项",
     clearSelection: "取消选择",
+    batchRebuildKnowledge: "批量重建知识",
     batchDelete: "批量删除",
     batchDeleteConfirmation: "批量删除确认",
     confirmBatchDeleteDocument: "确认删除选中的 {count} 个文档？删除后将无法恢复。",

--- a/frontend/src/views/knowledge/components/DocumentBatchBar.vue
+++ b/frontend/src/views/knowledge/components/DocumentBatchBar.vue
@@ -37,7 +37,7 @@ const { t } = useI18n();
             <t-button theme="default" variant="outline" size="small"
               :disabled="count === 0 || deleteLoading || reparseLoading" :loading="reparseLoading" @click.stop>
               <template #icon><t-icon name="refresh" size="14px" /></template>
-              {{ t('knowledgeBase.rebuildDocument') }}
+              {{ t('knowledgeBase.batchRebuildKnowledge') }}
             </t-button>
           </t-popconfirm>
 


### PR DESCRIPTION
 ## Description
  Add a dedicated `batchRebuildKnowledge` i18n key instead of reusing `rebuildDocument` for the batch bar.

  ## Type of Change
  - [x] 🐛 Bug fix

  ## Related Issue
  Fixes #1651

  ## Testing
  Verified all 4 locale files (zh-CN, en-US, ko-KR, ru-RU) contain the new key. The batch bar in the knowledge base UI now uses
  the dedicated label.

  ## Checklist
  - [x] Self-reviewed the code