### PR TITLE
[codex] Fix reparse cache for issue 1679

### DIFF
--- a/docs/issue-1679-final-test-suite.md
+++ b/docs/issue-1679-final-test-suite.md
@@ -1,0 +1,148 @@
+# Issue #1679 Final Test Suite
+
+用于验证“重建/重解析知识时复用 OCR、Embedding、Wiki Map 等缓存，避免全量重算”的最终完成状态。
+
+## 运行范围
+
+最终 PR 合并前至少运行：
+
+```powershell
+go test ./internal/types ./internal/application/repository ./internal/models/embedding ./internal/application/service/retriever ./internal/application/service
+```
+
+如果验收测试采用 opt-in build tag，运行：
+
+```powershell
+go test -tags issue1679 ./internal/types ./internal/application/repository ./internal/models/embedding ./internal/application/service/retriever ./internal/application/service
+```
+
+## A. 稳定 Chunk 身份
+
+1. 相同知识、相同 chunk 类型、相同归一化内容、相同出现序号、相同 chunking 配置，生成完全相同的 UUID 字符串。
+2. 仅空白差异不改变 chunk ID，例如 `" hello\nworld "` 与 `"hello world"` 命中同一稳定 ID。
+3. 同一文档内重复内容必须通过稳定出现序号区分，两个相同内容 chunk 不得生成同一个 ID。
+4. 修改 chunking 配置时，文本 chunk ID 应失效；VLM 图片缓存 key 不应随 chunking 配置变化失效。
+5. 父子 chunk 模式下，父 chunk 和子 chunk 都必须稳定；子 chunk 的 `ParentChunkID` 在未变内容重解析后保持一致。
+
+## B. Chunk Diff 与保留
+
+1. 初次解析写入 `A, B, C`，未变内容重解析仍为 `A, B, C` 时：
+   - 不调用整知识 `DeleteChunksByKnowledgeID`。
+   - 不软删并重插已有 chunk。
+   - `id / seq_id / content_hash / chunk_index / pre_chunk_id / next_chunk_id` 保持稳定。
+2. 重解析从 `A, B, C` 变为 `A, B2, C, D` 时：
+   - `A` 和 `C` 保留原 ID。
+   - 只新增 `B2` 和 `D`。
+   - 只删除旧 `B`。
+   - 前后链更新为 `A -> B2 -> C -> D`。
+3. 如果旧版本中同稳定 ID 的 chunk 被软删，重解析命中时应恢复或更新该行，不得因主键冲突失败。
+4. 图片 OCR / Caption chunk 也参与 diff；图片未变时 OCR / Caption chunk ID 保持稳定。
+
+## C. Embedding 缓存
+
+1. 首次索引文本 `A, B, A` 时，底层 embedding API 只应按唯一归一化文本 miss 调用，缓存写入 `A` 和 `B`。
+2. 相同文本重解析时：
+   - 仍写入当前 chunk 对应的向量索引记录。
+   - 不再次调用底层 embedding API。
+3. embedding cache key 至少包含：
+   - tenant scope
+   - embedding model ID 或有效模型名
+   - dimension
+   - 归一化 embedding 输入 hash
+4. 换 embedding model 或 dimension 时，仅 embedding cache miss；OCR / Wiki map 不应因为 embedding 配置变化失效。
+5. keyword-only 或 wiki-only KB 不应触发 embedding API 调用。
+6. 部分 cache hit、部分 miss 时，只对 miss 文本调用底层 API，并保持返回向量顺序与输入 index 顺序一致。
+
+## D. VLM OCR / Caption 缓存
+
+1. 相同图片字节、相同 VLM 模型、相同 prompt kind、相同 prompt version 重解析时：
+   - OCR 不再次调用 VLM。
+   - Caption 不再次调用 VLM。
+   - 仍能创建或保留 OCR / Caption chunk。
+2. OCR 和 Caption 必须使用不同 cache key，避免两类输出互相污染。
+3. 图片字节变化时，只重算变化图片的 OCR / Caption。
+4. VLM 输出命中缓存后，应作为冻结正典内容传给下游 chunking / embedding / wiki，避免模型随机抖动污染下游 hash。
+5. 同一文档中同一图片多处引用时，只应保存一次缓存结果，但引用关系仍指向正确父 chunk。
+
+## E. Wiki Map 缓存
+
+1. 相同冻结文档内容、相同 extraction granularity、相同 chat model、相同 prompt version、相同旧 slug 上下文时：
+   - 跳过 `postprocess.wiki.extract`。
+   - 跳过 `postprocess.wiki.summary`。
+   - 跳过 `postprocess.wiki.classify`。
+   - 直接恢复等价的 `SlugUpdate` 列表进入 reduce。
+2. Wiki reduce 不缓存；每次 ingest/reparse 仍需调用 reduce，以便反映其它文档当前贡献状态。
+3. 修改 extraction granularity、chat model 或 prompt version 时，Wiki map cache miss。
+4. 仅换 embedding model 时，Wiki map cache 应继续命中。
+5. 重解析时旧页面集合参与 cache key 或缓存输入；否则 stale slug / reparse overlap 语义会错误。
+6. 缓存恢复的 `SourceChunks` / `ChunkRefs` 必须引用当前稳定 chunk ID，并能通过 chunk repo 查到真实 chunk 内容。
+
+## F. GraphRAG Per-Chunk 缓存
+
+1. 相同 chunk 稳定 ID、相同 chunk 内容、相同 graph prompt version、相同 chat model 时，per-chunk entity/relation extraction 命中缓存。
+2. 只有变更 chunk 触发新的 graph extraction。
+3. graph merge / 全局关系汇总可以重跑，但不得重复调用未变 chunk 的 LLM 抽取。
+4. 删除 chunk 后，graph 中对应 chunk 引用必须被移除，不得残留死引用。
+
+## G. 崩溃续跑
+
+1. 模拟 OCR 已完成、embedding 未完成后任务失败；重跑时 OCR cache hit，embedding 只补缺失项。
+2. 模拟 embedding 已完成、wiki map 未完成后任务失败；重跑时 embedding cache hit，wiki map 执行一次。
+3. 模拟 wiki map 已完成、reduce 失败；重跑时 wiki map cache hit，reduce 重新执行。
+4. 所有续跑路径不得重复消耗已完成层的 LLM / VLM / embedding 调用。
+
+## H. 配置失效矩阵
+
+1. 改 embedding model：只重算 embedding。
+2. 改 VLM model 或 VLM prompt version：只重算 VLM 及其下游依赖内容。
+3. 改 chunk size / overlap：重算 chunk 与 embedding；VLM 图片缓存继续命中。
+4. 改 Wiki extraction granularity / wiki prompt version：重算 Wiki map；embedding / VLM 不受影响。
+5. 改 Wiki reduce prompt version：只重跑 reduce，不重跑 per-document map。
+6. 文件字节不变、配置不变：除 Wiki reduce 外，LLM / VLM / embedding API 调用数应接近 0。
+
+## I. 指标与断言
+
+最终验收测试应记录并断言以下计数：
+
+- `chunk_created_count`
+- `chunk_deleted_count`
+- `embedding_api_call_count`
+- `embedding_cache_hit_count`
+- `vlm_ocr_api_call_count`
+- `vlm_caption_api_call_count`
+- `wiki_extract_call_count`
+- `wiki_summary_call_count`
+- `wiki_classify_call_count`
+- `wiki_reduce_call_count`
+- `graph_chunk_extract_call_count`
+
+未变内容重解析的期望：
+
+- `chunk_deleted_count = 0`
+- `embedding_api_call_count = 0`
+- `vlm_ocr_api_call_count = 0`
+- `vlm_caption_api_call_count = 0`
+- `wiki_extract_call_count = 0`
+- `wiki_summary_call_count = 0`
+- `wiki_classify_call_count = 0`
+- `wiki_reduce_call_count >= 1`
+- `graph_chunk_extract_call_count = 0`
+
+## J. 最小验收场景
+
+准备一个包含以下内容的测试知识：
+
+- 3 个文本 chunk，其中第 1 和第 3 个内容相同，用于验证重复内容稳定序号。
+- 1 张图片，启用 OCR 和 Caption。
+- Wiki enabled。
+- Graph enabled。
+- Question generation enabled。
+
+执行顺序：
+
+1. 首次解析，记录 chunk IDs 和各层 API 调用计数。
+2. 内容不变重解析，断言可缓存层 API 调用为 0，chunk IDs 保持稳定。
+3. 只修改第二个文本 chunk，断言只重算第二个 chunk 相关 embedding / graph / wiki map 输入。
+4. 只修改 embedding model，断言只重算 embedding。
+5. 只修改 wiki granularity，断言只重算 wiki map + reduce。
+6. 只修改图片字节，断言只重算 VLM 及依赖该图片内容的下游缓存。

--- a/frontend/src/stores/uploadConfirm.ts
+++ b/frontend/src/stores/uploadConfirm.ts
@@ -15,6 +15,7 @@ export interface UploadConfirmReparseSource {
   knowledgeId: string
   fileName?: string
   fileType?: string
+  fileTypes?: string[]
   processOverrides?: KnowledgeProcessOverrides | null
 }
 

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -419,6 +419,7 @@ const batchDeleting = ref(false);
 const batchReparsing = ref(false);
 // IDs submitted for async batch reparse; hold optimistic pending until the worker updates DB.
 const pendingReparseAck = ref<Set<string>>(new Set());
+const uploadConfirmStore = useUploadConfirmStore();
 
 const applyOptimisticBatchReparse = (ids: string[]) => {
   const idSet = new Set(ids);
@@ -470,9 +471,32 @@ const confirmBatchReparse = async () => {
   if (skipped > 0) {
     MessagePlugin.warning(t('knowledgeBase.batchReparseSkippedInFlight', { count: skipped }));
   }
+  let processConfig: KnowledgeProcessOverrides | undefined;
+  if (kbInfo.value) {
+    const fileTypes = Array.from(new Set(ids
+      .map((id) => cardList.value.find((c) => c.id === id)?.file_type || '')
+      .map((fileType) => fileType.replace(/^\./, '').toLowerCase())
+      .filter(Boolean)));
+    try {
+      const result = await uploadConfirmStore.open({
+        mode: 'reparse',
+        kbInfo: kbInfo.value,
+        reparse: {
+          knowledgeId: ids[0],
+          fileName: t('knowledgeBase.selectedCount', { count: ids.length }),
+          fileTypes,
+          processOverrides: null,
+        },
+      });
+      if (result.mode !== 'reparse') return;
+      processConfig = result.processConfig;
+    } catch {
+      return;
+    }
+  }
   batchReparsing.value = true;
   try {
-    const res: any = await batchReparseKnowledge(kbId.value, ids);
+    const res: any = await batchReparseKnowledge(kbId.value, ids, processConfig);
     if (res?.success) {
       MessagePlugin.success(t('knowledgeBase.batchReparseSuccess', { count: ids.length }));
       applyOptimisticBatchReparse(ids);
@@ -1521,8 +1545,6 @@ const ensureDocumentKbReady = () => {
 
 const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'];
 const AUDIO_EXTENSIONS = ['mp3', 'wav', 'm4a', 'flac', 'ogg'];
-
-const uploadConfirmStore = useUploadConfirmStore();
 
 const getFolderUploadFileName = (file: File) => {
   const relativePath = (file as any).webkitRelativePath;

--- a/frontend/src/views/knowledge/batchReparseFlow.test.ts
+++ b/frontend/src/views/knowledge/batchReparseFlow.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+test('batch reparse confirms latest process config before enqueueing', () => {
+  const component = readFileSync(join(__dirname, 'KnowledgeBase.vue'), 'utf8')
+
+  assert.match(component, /uploadConfirmStore\.open\(\{\s*mode: 'reparse'/s)
+  assert.match(component, /processOverrides: null/)
+  assert.match(component, /processConfig = result\.processConfig/)
+  assert.match(component, /batchReparseKnowledge\(kbId\.value, ids, processConfig\)/)
+})
+
+test('reparse confirmation dialog summarizes every selected file type', () => {
+  const component = readFileSync(join(__dirname, 'components', 'UploadConfirmDialog.vue'), 'utf8')
+
+  assert.match(component, /props\.reparsePreview\?\.fileTypes/)
+  assert.match(component, /set\.add\(ext\)/)
+})
+
+test('batch reparse action opens the config dialog without a second popconfirm', () => {
+  const component = readFileSync(join(__dirname, 'components', 'DocumentBatchBar.vue'), 'utf8')
+
+  assert.match(component, /@click\.stop="emit\('reparse'\)"/)
+  assert.doesNotMatch(component, /confirmBatchReparseDocument/)
+})

--- a/frontend/src/views/knowledge/components/DocumentBatchBar.vue
+++ b/frontend/src/views/knowledge/components/DocumentBatchBar.vue
@@ -31,15 +31,12 @@ const { t } = useI18n();
           </t-button>
         </div>
         <div class="batch-bar-actions">
-          <t-popconfirm theme="warning" :content="t('knowledgeBase.confirmBatchReparseDocument', { count })"
-            :confirm-btn="{ content: t('knowledgeBase.confirmBatchReparse'), theme: 'warning' }"
-            :cancel-btn="{ content: t('common.cancel') }" placement="top" @confirm="emit('reparse')">
-            <t-button theme="default" variant="outline" size="small"
-              :disabled="count === 0 || deleteLoading || reparseLoading" :loading="reparseLoading" @click.stop>
-              <template #icon><t-icon name="refresh" size="14px" /></template>
-              {{ t('knowledgeBase.rebuildDocument') }}
-            </t-button>
-          </t-popconfirm>
+          <t-button theme="default" variant="outline" size="small"
+            :disabled="count === 0 || deleteLoading || reparseLoading" :loading="reparseLoading"
+            @click.stop="emit('reparse')">
+            <template #icon><t-icon name="refresh" size="14px" /></template>
+            {{ t('knowledgeBase.rebuildDocument') }}
+          </t-button>
 
           <t-popconfirm theme="warning" :content="t('knowledgeBase.confirmBatchDeleteDocument', { count })"
             :confirm-btn="{ content: t('knowledgeBase.confirmDelete'), theme: 'danger' }"

--- a/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
+++ b/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
@@ -435,6 +435,10 @@ const batchFileExts = computed(() => {
     }
   }
   if (props.mode === 'reparse') {
+    for (const fileType of props.reparsePreview?.fileTypes || []) {
+      const ext = fileType.toLowerCase()
+      if (ext) set.add(ext)
+    }
     const ext = (props.reparsePreview?.fileType || '').toLowerCase()
     if (ext) set.add(ext)
   }

--- a/internal/application/service/graph.go
+++ b/internal/application/service/graph.go
@@ -51,7 +51,23 @@ const (
 
 	// WeightScaleFactor Weight scaling factor to normalize weights to 1-10 range
 	WeightScaleFactor = 9.0
+
+	graphEntityPromptVersion = "v1"
 )
+
+type graphEntityCacheKey struct {
+	TenantID      uint64
+	ModelID       string
+	ModelName     string
+	PromptVersion string
+	PromptHash    string
+	ContentHash   string
+}
+
+var processGraphEntityCache = struct {
+	sync.RWMutex
+	data map[graphEntityCacheKey][]*types.Entity
+}{data: make(map[graphEntityCacheKey][]*types.Entity)}
 
 // ChunkRelation represents a relationship between two Chunks
 type ChunkRelation struct {
@@ -94,6 +110,58 @@ func (b *graphBuilder) renderGraphExtractionPrompt(ctx context.Context, template
 	})
 }
 
+func (b *graphBuilder) graphEntityCacheKey(
+	ctx context.Context,
+	chunk *types.Chunk,
+	systemPrompt string,
+) graphEntityCacheKey {
+	tenantID, _ := types.TenantIDFromContext(ctx)
+	return graphEntityCacheKey{
+		TenantID:      tenantID,
+		ModelID:       b.chatModel.GetModelID(),
+		ModelName:     b.chatModel.GetModelName(),
+		PromptVersion: graphEntityPromptVersion,
+		PromptHash:    stableStringHash(systemPrompt),
+		ContentHash:   types.StableContentHash(chunk.Content),
+	}
+}
+
+func loadGraphEntityCache(key graphEntityCacheKey) ([]*types.Entity, bool) {
+	if key.ContentHash == "" {
+		return nil, false
+	}
+	processGraphEntityCache.RLock()
+	entities, ok := processGraphEntityCache.data[key]
+	processGraphEntityCache.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	return cloneEntities(entities), true
+}
+
+func storeGraphEntityCache(key graphEntityCacheKey, entities []*types.Entity) {
+	if key.ContentHash == "" {
+		return
+	}
+	processGraphEntityCache.Lock()
+	processGraphEntityCache.data[key] = cloneEntities(entities)
+	processGraphEntityCache.Unlock()
+}
+
+func cloneEntities(entities []*types.Entity) []*types.Entity {
+	out := make([]*types.Entity, 0, len(entities))
+	for _, entity := range entities {
+		if entity == nil {
+			out = append(out, nil)
+			continue
+		}
+		cloned := *entity
+		cloned.ChunkIDs = append([]string(nil), entity.ChunkIDs...)
+		out = append(out, &cloned)
+	}
+	return out
+}
+
 // extractEntities extracts entities from text chunks
 // It uses LLM to analyze text content and identify relevant entities
 func (b *graphBuilder) extractEntities(ctx context.Context, chunk *types.Chunk) ([]*types.Entity, error) {
@@ -107,10 +175,11 @@ func (b *graphBuilder) extractEntities(ctx context.Context, chunk *types.Chunk) 
 
 	// Create prompt for entity extraction
 	thinking := false
+	systemPrompt := b.renderGraphExtractionPrompt(ctx, b.config.Conversation.ExtractEntitiesPrompt)
 	messages := []chat.Message{
 		{
 			Role:    "system",
-			Content: b.renderGraphExtractionPrompt(ctx, b.config.Conversation.ExtractEntitiesPrompt),
+			Content: systemPrompt,
 		},
 		{
 			Role:    "user",
@@ -118,22 +187,29 @@ func (b *graphBuilder) extractEntities(ctx context.Context, chunk *types.Chunk) 
 		},
 	}
 
-	// Call LLM to extract entities
-	log.Debug("Calling LLM to extract entities")
-	resp, err := b.chatModel.Chat(ctx, messages, &chat.ChatOptions{
-		Temperature: DefaultLLMTemperature,
-		Thinking:    &thinking,
-	})
-	if err != nil {
-		log.WithError(err).Error("Failed to extract entities from chunk")
-		return nil, fmt.Errorf("LLM entity extraction failed: %w", err)
-	}
-
-	// Parse JSON response
 	var extractedEntities []*types.Entity
-	if err := common.ParseLLMJsonResponse(resp.Content, &extractedEntities); err != nil {
-		log.WithError(err).Errorf("Failed to parse entity extraction response, rsp content: %s", resp.Content)
-		return nil, fmt.Errorf("failed to parse entity extraction response: %w", err)
+	cacheKey := b.graphEntityCacheKey(ctx, chunk, systemPrompt)
+	if cached, ok := loadGraphEntityCache(cacheKey); ok {
+		extractedEntities = cached
+		log.Debug("Graph entity extraction cache hit")
+	} else {
+		// Call LLM to extract entities
+		log.Debug("Calling LLM to extract entities")
+		resp, err := b.chatModel.Chat(ctx, messages, &chat.ChatOptions{
+			Temperature: DefaultLLMTemperature,
+			Thinking:    &thinking,
+		})
+		if err != nil {
+			log.WithError(err).Error("Failed to extract entities from chunk")
+			return nil, fmt.Errorf("LLM entity extraction failed: %w", err)
+		}
+
+		// Parse JSON response
+		if err := common.ParseLLMJsonResponse(resp.Content, &extractedEntities); err != nil {
+			log.WithError(err).Errorf("Failed to parse entity extraction response, rsp content: %s", resp.Content)
+			return nil, fmt.Errorf("failed to parse entity extraction response: %w", err)
+		}
+		storeGraphEntityCache(cacheKey, extractedEntities)
 	}
 	log.Infof("Extracted %d entities from chunk", len(extractedEntities))
 

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -2,11 +2,14 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
@@ -18,7 +21,6 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
-	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
 	"github.com/redis/go-redis/v9"
 )
@@ -49,6 +51,26 @@ const (
 		"</instructions>"
 	vlmCaptionPrompt = "Provide a brief and concise description of the main content of the image in Chinese"
 )
+
+const (
+	vlmOCRPromptVersion     = "v1"
+	vlmCaptionPromptVersion = "v1"
+)
+
+type vlmCacheKey struct {
+	TenantID      uint64
+	ModelID       string
+	ModelName     string
+	PromptKind    string
+	PromptVersion string
+	PromptHash    string
+	ImageHash     string
+}
+
+var processVLMCache = struct {
+	sync.RWMutex
+	data map[vlmCacheKey]string
+}{data: make(map[vlmCacheKey]string)}
 
 // ImageMultimodalService handles image:multimodal asynq tasks.
 // It reads images from storage (via FileService for provider:// URLs),
@@ -228,6 +250,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		return nil
 	}
 	imgOut["image_bytes"] = len(imgBytes)
+	imageHash := stableBytesHash(imgBytes)
 
 	imageInfo := types.ImageInfo{
 		URL:         payload.ImageURL,
@@ -244,7 +267,20 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 			imgOut["ocr_prompt"] = "default"
 		}
 
-		ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt)
+		ocrPromptKind := "ocr_default"
+		if payload.ImageSourceType == "scanned_pdf" {
+			ocrPromptKind = "ocr_scanned_pdf"
+		}
+		ocrText, ocrErr := cachedVLMPredict(
+			ctx,
+			payload.TenantID,
+			vlmModel,
+			imgBytes,
+			imageHash,
+			prompt,
+			ocrPromptKind,
+			vlmOCRPromptVersion,
+		)
 		if ocrErr != nil {
 			logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
 			imgOut["ocr_error"] = ocrErr.Error()
@@ -262,7 +298,16 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 	}
 
-	caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, vlmCaptionPrompt)
+	caption, capErr := cachedVLMPredict(
+		ctx,
+		payload.TenantID,
+		vlmModel,
+		imgBytes,
+		imageHash,
+		vlmCaptionPrompt,
+		"caption",
+		vlmCaptionPromptVersion,
+	)
 	if capErr != nil {
 		logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
 		imgOut["caption_error"] = capErr.Error()
@@ -277,12 +322,14 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 	var newChunks []*types.Chunk
 
 	if imageInfo.OCRText != "" {
+		chunkID, contentHash := stableImageChunkIdentity(payload, types.ChunkTypeImageOCR, imageInfo.OCRText, imageHash)
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              chunkID,
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
 			Content:         imageInfo.OCRText,
+			ContentHash:     contentHash,
 			ChunkType:       types.ChunkTypeImageOCR,
 			ParentChunkID:   payload.ChunkID,
 			IsEnabled:       true,
@@ -294,12 +341,14 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 	}
 
 	if imageInfo.Caption != "" {
+		chunkID, contentHash := stableImageChunkIdentity(payload, types.ChunkTypeImageCaption, imageInfo.Caption, imageHash)
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              chunkID,
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
 			Content:         imageInfo.Caption,
+			ContentHash:     contentHash,
 			ChunkType:       types.ChunkTypeImageCaption,
 			ParentChunkID:   payload.ChunkID,
 			IsEnabled:       true,
@@ -318,12 +367,12 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 	}
 
 	// Persist chunks
-	if err := s.chunkService.CreateChunks(ctx, newChunks); err != nil {
-		handleErr = fmt.Errorf("create multimodal chunks: %w", err)
+	if err := s.replaceImageChildChunks(ctx, payload, imageInfo, newChunks); err != nil {
+		handleErr = fmt.Errorf("replace multimodal chunks: %w", err)
 		return handleErr
 	}
 	for _, c := range newChunks {
-		logger.Infof(ctx, "[ImageMultimodal] Created %s chunk %s for image %s, len=%d",
+		logger.Infof(ctx, "[ImageMultimodal] Reconciled %s chunk %s for image %s, len=%d",
 			c.ChunkType, c.ID, payload.ImageURL, len(c.Content))
 	}
 
@@ -339,6 +388,149 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 	// all images are processed before triggering summary/question generation.
 	// Deferred finalize handles the parent knowledge counter.
 	return nil
+}
+
+func cachedVLMPredict(
+	ctx context.Context,
+	tenantID uint64,
+	model vlm.VLM,
+	imgBytes []byte,
+	imageHash string,
+	prompt string,
+	promptKind string,
+	promptVersion string,
+) (string, error) {
+	key := vlmCacheKey{
+		TenantID:      tenantID,
+		ModelID:       model.GetModelID(),
+		ModelName:     model.GetModelName(),
+		PromptKind:    promptKind,
+		PromptVersion: promptVersion,
+		PromptHash:    stableStringHash(prompt),
+		ImageHash:     imageHash,
+	}
+
+	processVLMCache.RLock()
+	result, ok := processVLMCache.data[key]
+	processVLMCache.RUnlock()
+	if ok {
+		return result, nil
+	}
+
+	result, err := model.Predict(ctx, [][]byte{imgBytes}, prompt)
+	if err != nil {
+		return "", err
+	}
+
+	processVLMCache.Lock()
+	processVLMCache.data[key] = result
+	processVLMCache.Unlock()
+	return result, nil
+}
+
+func stableImageChunkIdentity(
+	payload types.ImageMultimodalPayload,
+	chunkType types.ChunkType,
+	content string,
+	imageHash string,
+) (string, string) {
+	return types.StableChunkID(types.StableChunkIDSpec{
+		KnowledgeID:       payload.KnowledgeID,
+		ChunkType:         chunkType,
+		Content:           imageHash + "\n" + content,
+		Occurrence:        payload.ImageIndex,
+		ChunkingConfigKey: "image-child:" + payload.ChunkID,
+	}), types.StableContentHash(content)
+}
+
+func (s *ImageMultimodalService) replaceImageChildChunks(
+	ctx context.Context,
+	payload types.ImageMultimodalPayload,
+	imageInfo types.ImageInfo,
+	desiredChunks []*types.Chunk,
+) error {
+	existingChildren, err := s.chunkService.ListChunkByParentID(ctx, payload.TenantID, payload.ChunkID)
+	if err != nil {
+		return err
+	}
+
+	existingByID := make(map[string]*types.Chunk)
+	for _, chunk := range existingChildren {
+		if !isImageResultChunk(chunk.ChunkType) || !chunkBelongsToImage(chunk, imageInfo, payload.ImageURL) {
+			continue
+		}
+		existingByID[chunk.ID] = chunk
+	}
+
+	desiredByID := make(map[string]*types.Chunk, len(desiredChunks))
+	var chunksToCreate []*types.Chunk
+	var chunksToUpdate []*types.Chunk
+	for _, desired := range desiredChunks {
+		desiredByID[desired.ID] = desired
+		if existing, ok := existingByID[desired.ID]; ok {
+			desired.SeqID = existing.SeqID
+			desired.CreatedAt = existing.CreatedAt
+			if processChunkChanged(existing, desired) {
+				chunksToUpdate = append(chunksToUpdate, desired)
+			}
+			continue
+		}
+		chunksToCreate = append(chunksToCreate, desired)
+	}
+
+	var chunkIDsToDelete []string
+	for _, existing := range existingByID {
+		if _, ok := desiredByID[existing.ID]; !ok {
+			chunkIDsToDelete = append(chunkIDsToDelete, existing.ID)
+		}
+	}
+
+	if len(chunksToCreate) > 0 {
+		if err := s.chunkService.CreateChunks(ctx, chunksToCreate); err != nil {
+			return err
+		}
+	}
+	for _, chunk := range chunksToUpdate {
+		if err := s.chunkService.UpdateChunk(ctx, chunk); err != nil {
+			return err
+		}
+	}
+	if len(chunkIDsToDelete) > 0 {
+		if err := s.chunkService.DeleteChunks(ctx, chunkIDsToDelete); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func isImageResultChunk(chunkType types.ChunkType) bool {
+	return chunkType == types.ChunkTypeImageOCR || chunkType == types.ChunkTypeImageCaption
+}
+
+func chunkBelongsToImage(chunk *types.Chunk, imageInfo types.ImageInfo, payloadImageURL string) bool {
+	var infos []types.ImageInfo
+	if err := json.Unmarshal([]byte(chunk.ImageInfo), &infos); err != nil {
+		return false
+	}
+	for _, info := range infos {
+		if info.URL != "" && (info.URL == imageInfo.URL || info.URL == payloadImageURL) {
+			return true
+		}
+		if info.OriginalURL != "" && info.OriginalURL == imageInfo.OriginalURL {
+			return true
+		}
+	}
+	return false
+}
+
+func stableBytesHash(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func stableStringHash(data string) string {
+	return stableBytesHash([]byte(data))
 }
 
 // isFinalAsynqAttempt reports whether the current task context belongs to the

--- a/internal/application/service/image_multimodal_cache_test.go
+++ b/internal/application/service/image_multimodal_cache_test.go
@@ -1,0 +1,95 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type countingVLM struct {
+	calls     int
+	modelID   string
+	modelName string
+	result    string
+	err       error
+}
+
+func (v *countingVLM) Predict(ctx context.Context, imgBytes [][]byte, prompt string) (string, error) {
+	v.calls++
+	if v.err != nil {
+		return "", v.err
+	}
+	return v.result, nil
+}
+
+func (v *countingVLM) GetModelName() string { return v.modelName }
+func (v *countingVLM) GetModelID() string   { return v.modelID }
+
+func TestCachedVLMPredictReusesSuccessfulResult(t *testing.T) {
+	resetProcessVLMCacheForTest()
+
+	model := &countingVLM{modelID: "vlm-1", modelName: "vision", result: "ocr text"}
+	imageBytes := []byte("image-bytes")
+	imageHash := stableBytesHash(imageBytes)
+
+	first, err := cachedVLMPredict(context.Background(), 7, model, imageBytes, imageHash, "prompt", "ocr", "v1")
+	require.NoError(t, err)
+	require.Equal(t, "ocr text", first)
+
+	second, err := cachedVLMPredict(context.Background(), 7, model, imageBytes, imageHash, "prompt", "ocr", "v1")
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+	require.Equal(t, 1, model.calls)
+}
+
+func TestCachedVLMPredictMissesOnPromptKindVersionModelOrImage(t *testing.T) {
+	resetProcessVLMCacheForTest()
+
+	model := &countingVLM{modelID: "vlm-1", modelName: "vision", result: "ok"}
+	imageBytes := []byte("image-bytes")
+	imageHash := stableBytesHash(imageBytes)
+
+	_, err := cachedVLMPredict(context.Background(), 7, model, imageBytes, imageHash, "prompt", "ocr", "v1")
+	require.NoError(t, err)
+	_, err = cachedVLMPredict(context.Background(), 7, model, imageBytes, imageHash, "prompt", "caption", "v1")
+	require.NoError(t, err)
+	_, err = cachedVLMPredict(context.Background(), 7, model, imageBytes, imageHash, "prompt", "ocr", "v2")
+	require.NoError(t, err)
+
+	otherModel := &countingVLM{modelID: "vlm-2", modelName: "vision", result: "ok"}
+	_, err = cachedVLMPredict(context.Background(), 7, otherModel, imageBytes, imageHash, "prompt", "ocr", "v1")
+	require.NoError(t, err)
+
+	otherImageBytes := []byte("other-image")
+	_, err = cachedVLMPredict(context.Background(), 7, model, otherImageBytes, stableBytesHash(otherImageBytes), "prompt", "ocr", "v1")
+	require.NoError(t, err)
+
+	require.Equal(t, 4, model.calls)
+	require.Equal(t, 1, otherModel.calls)
+}
+
+func TestCachedVLMPredictDoesNotCacheFailedResult(t *testing.T) {
+	resetProcessVLMCacheForTest()
+
+	errBoom := errors.New("boom")
+	failing := &countingVLM{modelID: "vlm-1", modelName: "vision", err: errBoom}
+	imageBytes := []byte("image-bytes")
+	imageHash := stableBytesHash(imageBytes)
+
+	_, err := cachedVLMPredict(context.Background(), 7, failing, imageBytes, imageHash, "prompt", "ocr", "v1")
+	require.ErrorIs(t, err, errBoom)
+
+	retry := &countingVLM{modelID: "vlm-1", modelName: "vision", result: "ocr text"}
+	got, err := cachedVLMPredict(context.Background(), 7, retry, imageBytes, imageHash, "prompt", "ocr", "v1")
+	require.NoError(t, err)
+	require.Equal(t, "ocr text", got)
+	require.Equal(t, 1, retry.calls)
+}
+
+func resetProcessVLMCacheForTest() {
+	processVLMCache.Lock()
+	defer processVLMCache.Unlock()
+	processVLMCache.data = make(map[vlmCacheKey]string)
+}

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -196,6 +196,151 @@ func finalizeIndexedKnowledgeState(
 	knowledge.UpdatedAt = now
 }
 
+type stableChunkIDAllocator struct {
+	knowledgeID       string
+	chunkingConfigKey string
+	occurrences       map[string]int
+}
+
+func newStableChunkIDAllocator(knowledgeID, chunkingConfigKey string) *stableChunkIDAllocator {
+	return &stableChunkIDAllocator{
+		knowledgeID:       knowledgeID,
+		chunkingConfigKey: chunkingConfigKey,
+		occurrences:       make(map[string]int),
+	}
+}
+
+func (a *stableChunkIDAllocator) next(chunkType types.ChunkType, content string) (string, string) {
+	contentHash := types.StableContentHash(content)
+	occurrenceKey := string(chunkType) + "\x00" + contentHash
+	occurrence := a.occurrences[occurrenceKey]
+	a.occurrences[occurrenceKey] = occurrence + 1
+	return types.StableChunkID(types.StableChunkIDSpec{
+		KnowledgeID:       a.knowledgeID,
+		ChunkType:         chunkType,
+		Content:           content,
+		Occurrence:        occurrence,
+		ChunkingConfigKey: a.chunkingConfigKey,
+	}), contentHash
+}
+
+func (s *knowledgeService) replaceKnowledgeProcessChunks(
+	ctx context.Context,
+	knowledge *types.Knowledge,
+	desiredChunks []*types.Chunk,
+) error {
+	existingChunks, err := s.listKnowledgeProcessChunks(ctx, knowledge)
+	if err != nil {
+		return err
+	}
+
+	existingByID := make(map[string]*types.Chunk, len(existingChunks))
+	for _, chunk := range existingChunks {
+		existingByID[chunk.ID] = chunk
+	}
+
+	desiredByID := make(map[string]*types.Chunk, len(desiredChunks))
+	var chunksToCreate []*types.Chunk
+	var chunksToUpdate []*types.Chunk
+	for _, desired := range desiredChunks {
+		desiredByID[desired.ID] = desired
+		if existing, ok := existingByID[desired.ID]; ok {
+			desired.SeqID = existing.SeqID
+			desired.CreatedAt = existing.CreatedAt
+			if processChunkChanged(existing, desired) {
+				chunksToUpdate = append(chunksToUpdate, desired)
+			}
+			continue
+		}
+		chunksToCreate = append(chunksToCreate, desired)
+	}
+
+	var chunkIDsToDelete []string
+	for _, existing := range existingChunks {
+		if _, ok := desiredByID[existing.ID]; !ok {
+			chunkIDsToDelete = append(chunkIDsToDelete, existing.ID)
+		}
+	}
+
+	if len(chunksToCreate) > 0 {
+		if err := s.chunkService.CreateChunks(ctx, chunksToCreate); err != nil {
+			return err
+		}
+	}
+	for _, chunk := range chunksToUpdate {
+		if err := s.chunkService.UpdateChunk(ctx, chunk); err != nil {
+			return err
+		}
+	}
+	if len(chunkIDsToDelete) > 0 {
+		if err := s.chunkService.DeleteChunks(ctx, chunkIDsToDelete); err != nil {
+			return err
+		}
+	}
+
+	logger.Infof(ctx, "Reconciled process chunks for knowledge %s: created=%d updated=%d deleted=%d unchanged=%d",
+		knowledge.ID,
+		len(chunksToCreate),
+		len(chunksToUpdate),
+		len(chunkIDsToDelete),
+		len(desiredChunks)-len(chunksToCreate)-len(chunksToUpdate),
+	)
+	return nil
+}
+
+func (s *knowledgeService) listKnowledgeProcessChunks(
+	ctx context.Context,
+	knowledge *types.Knowledge,
+) ([]*types.Chunk, error) {
+	chunkTypes := []types.ChunkType{types.ChunkTypeText, types.ChunkTypeParentText}
+	page := &types.Pagination{Page: 1, PageSize: 1000}
+	var all []*types.Chunk
+	for {
+		chunks, total, err := s.chunkRepo.ListPagedChunksByKnowledgeID(
+			ctx,
+			knowledge.TenantID,
+			knowledge.ID,
+			page,
+			chunkTypes,
+			"",
+			"",
+			"",
+			"asc",
+			knowledge.Type,
+		)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, chunks...)
+		if int64(len(all)) >= total || len(chunks) == 0 {
+			return all, nil
+		}
+		page.Page++
+	}
+}
+
+func processChunkChanged(existing, desired *types.Chunk) bool {
+	return existing.TenantID != desired.TenantID ||
+		existing.KnowledgeID != desired.KnowledgeID ||
+		existing.KnowledgeBaseID != desired.KnowledgeBaseID ||
+		existing.Content != desired.Content ||
+		existing.ContentHash != desired.ContentHash ||
+		existing.ChunkIndex != desired.ChunkIndex ||
+		existing.IsEnabled != desired.IsEnabled ||
+		existing.Flags != desired.Flags ||
+		existing.Status != desired.Status ||
+		existing.StartAt != desired.StartAt ||
+		existing.EndAt != desired.EndAt ||
+		existing.PreChunkID != desired.PreChunkID ||
+		existing.NextChunkID != desired.NextChunkID ||
+		existing.ChunkType != desired.ChunkType ||
+		existing.ParentChunkID != desired.ParentChunkID ||
+		string(existing.RelationChunks) != string(desired.RelationChunks) ||
+		string(existing.IndirectRelationChunks) != string(desired.IndirectRelationChunks) ||
+		string(existing.Metadata) != string(desired.Metadata) ||
+		existing.ImageInfo != desired.ImageInfo
+}
+
 // buildSplitterConfig creates a SplitterConfig with fallbacks from a KnowledgeBase.
 // Defaults mirror chunker.DefaultChunkSize / DefaultChunkOverlap so behavior is
 // identical whether callers come through this path or invoke the chunker
@@ -281,14 +426,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping embedding model", kb.ID)
 	}
 
-	// 幂等性处理：清理旧的chunks和索引数据，避免重复数据
-	logger.Infof(ctx, "Cleaning up existing chunks and index data for knowledge: %s", knowledge.ID)
-
-	// 删除旧的chunks
-	if err := s.chunkService.DeleteChunksByKnowledgeID(ctx, knowledge.ID); err != nil {
-		logger.Warnf(ctx, "Failed to delete existing chunks (may not exist): %v", err)
-		// 不返回错误，继续处理（可能没有旧数据）
-	}
+	logger.Infof(ctx, "Reconciling chunks and index data for knowledge: %s", knowledge.ID)
 
 	// 删除旧的索引数据 — only when vector/keyword indexing is enabled
 	tenantInfo := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
@@ -310,7 +448,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		// 不返回错误，继续处理
 	}
 
-	logger.Infof(ctx, "Cleanup completed, starting to process new chunks")
+	logger.Infof(ctx, "Index cleanup completed, starting to process chunks")
 
 	// ========== DocReader 解析结果日志 ==========
 	logger.Infof(ctx, "[DocReader] ========== 解析结果概览 ==========")
@@ -379,15 +517,19 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	// === Parent-Child Chunking: create parent chunks first ===
 	hasParentChild := len(options.ParentChunks) > 0
 	var parentDBChunks []*types.Chunk // indexed by ParsedParentChunk position
+	chunkingConfigKey := types.StableChunkingConfigKey(kb.ChunkingConfig)
+	chunkIDAllocator := newStableChunkIDAllocator(knowledge.ID, chunkingConfigKey)
 	if hasParentChild {
 		parentDBChunks = make([]*types.Chunk, len(options.ParentChunks))
 		for i, pc := range options.ParentChunks {
+			chunkID, contentHash := chunkIDAllocator.next(types.ChunkTypeParentText, pc.Content)
 			parentDBChunks[i] = &types.Chunk{
-				ID:              uuid.New().String(),
+				ID:              chunkID,
 				TenantID:        knowledge.TenantID,
 				KnowledgeID:     knowledge.ID,
 				KnowledgeBaseID: knowledge.KnowledgeBaseID,
 				Content:         pc.Content,
+				ContentHash:     contentHash,
 				ChunkIndex:      pc.Seq,
 				IsEnabled:       true,
 				CreatedAt:       time.Now(),
@@ -421,12 +563,14 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		}
 
 		// 创建主文本Chunk
+		chunkID, contentHash := chunkIDAllocator.next(types.ChunkTypeText, chunkData.Content)
 		textChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              chunkID,
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
 			Content:         chunkData.Content,
+			ContentHash:     contentHash,
 			ContextHeader:   chunkData.ContextHeader,
 			ChunkIndex:      int(chunkData.Seq),
 			IsEnabled:       true,
@@ -488,13 +632,13 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	s.beginStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
 		"chunks_planned": len(insertChunks),
 	})
-	if err := s.chunkService.CreateChunks(ctx, insertChunks); err != nil {
+	if err := s.replaceKnowledgeProcessChunks(ctx, knowledge, insertChunks); err != nil {
 		knowledge.ParseStatus = types.ParseStatusFailed
 		knowledge.ErrorMessage = err.Error()
 		knowledge.UpdatedAt = time.Now()
 		s.repo.UpdateKnowledge(ctx, knowledge)
 		s.failStage(ctx, knowledge.ID, types.StageChunking,
-			werrors.ErrCodeChunkingFailed, "create chunks failed", err)
+			werrors.ErrCodeChunkingFailed, "replace chunks failed", err)
 		return
 	}
 	totalChunkChars := 0

--- a/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
+++ b/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
@@ -37,6 +37,8 @@ var embeddingImagePayloadPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)data:[a-z0-9.+/-]+;base64,[a-z0-9+/=]{200,}`),
 }
 
+var processEmbeddingCache = embedding.NewMemoryEmbeddingCache()
+
 // KeywordsVectorHybridRetrieveEngineService implements a hybrid retrieval engine
 // that supports both keyword-based and vector-based retrieval
 type KeywordsVectorHybridRetrieveEngineService struct {
@@ -72,7 +74,8 @@ func (v *KeywordsVectorHybridRetrieveEngineService) Index(ctx context.Context,
 	params := make(map[string]any)
 	embeddingMap := make(map[string][]float32)
 	if slices.Contains(retrieverTypes, types.VectorRetrieverType) {
-		embedding, err := embedder.Embed(ctx, sanitizeForEmbedding(ctx, indexInfo.Content))
+		cached := embedderForCacheScope(ctx, embedder)
+		embedding, err := cached.Embed(ctx, sanitizeForEmbedding(ctx, indexInfo.Content))
 		if err != nil {
 			return err
 		}
@@ -130,12 +133,13 @@ func (v *KeywordsVectorHybridRetrieveEngineService) BatchIndex(ctx context.Conte
 // embedding result on success or the last error if every attempt failed.
 func batchEmbedWithBackoff(ctx context.Context, embedder embedding.Embedder, contentList []string) ([][]float32, error) {
 	delay := embedRetryBaseDelay
+	cached := embedderForCacheScope(ctx, embedder)
 	var (
 		embeddings [][]float32
 		err        error
 	)
 	for attempt := 0; attempt < embedRetryAttempts; attempt++ {
-		embeddings, err = embedder.BatchEmbedWithPool(ctx, embedder, contentList)
+		embeddings, err = cached.BatchEmbedWithPool(ctx, cached, contentList)
 		if err == nil {
 			return embeddings, nil
 		}
@@ -150,6 +154,17 @@ func batchEmbedWithBackoff(ctx context.Context, embedder embedding.Embedder, con
 		}
 	}
 	return embeddings, err
+}
+
+func embedderForCacheScope(ctx context.Context, embedder embedding.Embedder) embedding.Embedder {
+	tenantID, ok := types.TenantIDFromContext(ctx)
+	if !ok || tenantID == 0 {
+		return embedder
+	}
+	if _, alreadyCached := embedder.(*embedding.CachedEmbedder); alreadyCached {
+		return embedder
+	}
+	return embedding.NewCachedEmbedder(embedder, processEmbeddingCache, embedding.CacheScope{TenantID: tenantID})
 }
 
 // sanitizeForEmbedding caps content length at safetyMaxChars characters so

--- a/internal/application/service/retriever/keywords_vector_hybrid_indexer_test.go
+++ b/internal/application/service/retriever/keywords_vector_hybrid_indexer_test.go
@@ -14,6 +14,7 @@ type capturingEmbedder struct {
 	embedding.Embedder
 	text       string
 	batchTexts []string
+	batchCalls int
 }
 
 func (e *capturingEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
@@ -21,11 +22,8 @@ func (e *capturingEmbedder) Embed(ctx context.Context, text string) ([]float32, 
 	return []float32{1}, nil
 }
 
-func (e *capturingEmbedder) BatchEmbedWithPool(
-	ctx context.Context,
-	model embedding.Embedder,
-	texts []string,
-) ([][]float32, error) {
+func (e *capturingEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	e.batchCalls++
 	e.batchTexts = append([]string(nil), texts...)
 	embeddings := make([][]float32, len(texts))
 	for i := range texts {
@@ -33,6 +31,18 @@ func (e *capturingEmbedder) BatchEmbedWithPool(
 	}
 	return embeddings, nil
 }
+
+func (e *capturingEmbedder) BatchEmbedWithPool(
+	ctx context.Context,
+	model embedding.Embedder,
+	texts []string,
+) ([][]float32, error) {
+	return e.BatchEmbed(ctx, texts)
+}
+
+func (e *capturingEmbedder) GetModelName() string { return "test-embedder" }
+func (e *capturingEmbedder) GetDimensions() int   { return 1 }
+func (e *capturingEmbedder) GetModelID() string   { return "model-1" }
 
 type saveOnlyRepository struct {
 	interfaces.RetrieveEngineRepository
@@ -104,6 +114,26 @@ func TestBatchIndexTruncatesOversizedEmbeddingInput(t *testing.T) {
 	}
 	if got := len([]rune(embedder.batchTexts[0])); got > safetyMaxChars {
 		t.Fatalf("embedding input length = %d, want <= %d", got, safetyMaxChars)
+	}
+}
+
+func TestBatchIndexUsesTenantScopedEmbeddingCache(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(99))
+	embedder := &capturingEmbedder{}
+	service := &KeywordsVectorHybridRetrieveEngineService{indexRepository: &saveOnlyRepository{}}
+	indexInfo := []*types.IndexInfo{{
+		Content:  "repeat me",
+		SourceID: "source-1",
+	}}
+
+	if err := service.BatchIndex(ctx, embedder, indexInfo, []types.RetrieverType{types.VectorRetrieverType}); err != nil {
+		t.Fatalf("first BatchIndex returned error: %v", err)
+	}
+	if err := service.BatchIndex(ctx, embedder, indexInfo, []types.RetrieverType{types.VectorRetrieverType}); err != nil {
+		t.Fatalf("second BatchIndex returned error: %v", err)
+	}
+	if embedder.batchCalls != 1 {
+		t.Fatalf("BatchEmbedWithPool calls = %d, want 1", embedder.batchCalls)
 	}
 }
 

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -818,6 +818,7 @@ func (s *wikiIngestService) mapOneDocument(
 		content = string([]rune(content)[:maxContentForWiki])
 	}
 	logger.Infof(ctx, "wiki ingest: doc %s chunks=%d content_len(raw=%d,truncated=%d)", knowledgeID, len(chunks), rawRuneCount, len([]rune(content)))
+	mapChatModel := newWikiMapCachedChat(chatModel, payload.TenantID, knowledgeID, payload.KnowledgeBaseID, content)
 
 	// Refuse to run LLM-based extraction when the document carries no real
 	// text — e.g. a scanned PDF whose pages were converted to images but where
@@ -868,11 +869,11 @@ func (s *wikiIngestService) mapOneDocument(
 		"content_chars": utf8.RuneCountInString(content),
 		"old_pages":     len(oldPageSlugs),
 	})
-	extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
+	extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, mapChatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
 	if err != nil {
 		logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) — falling back to legacy extractor", knowledgeID, err)
 		pass0Failed = true
-		extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
+		extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, mapChatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
 		if err != nil {
 			logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
 			s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
@@ -942,7 +943,7 @@ func (s *wikiIngestService) mapOneDocument(
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		summaryContent, summaryErr = s.generateWithTemplate(ctx, chatModel, agent.WikiSummaryPrompt, map[string]string{
+		summaryContent, summaryErr = s.generateWithTemplate(ctx, mapChatModel, agent.WikiSummaryPrompt, map[string]string{
 			"Content":        content,
 			"Language":       lang,
 			"ExtractedSlugs": slugListing,
@@ -968,7 +969,7 @@ func (s *wikiIngestService) mapOneDocument(
 			return
 		}
 		candidatesXML := renderCandidateSlugsXML(extractedEntities, extractedConcepts)
-		citations, newSlugs, batchCount = s.classifyChunkCitations(ctx, chatModel, candidatesXML, chunks, lang, batchCtx)
+		citations, newSlugs, batchCount = s.classifyChunkCitations(ctx, mapChatModel, candidatesXML, chunks, lang, batchCtx)
 		s.tracker().EndSpan(ctx, classifySpan, types.JSONMap{
 			"cited_slugs":      len(citations),
 			"new_slugs":        len(newSlugs),

--- a/internal/application/service/wiki_map_chat_cache.go
+++ b/internal/application/service/wiki_map_chat_cache.go
@@ -1,0 +1,125 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+const wikiMapPromptVersion = "v1"
+
+type wikiMapChatCacheKey struct {
+	TenantID      uint64
+	KnowledgeID   string
+	KnowledgeBaseID string
+	ModelID       string
+	ModelName     string
+	PromptVersion string
+	ContentHash   string
+	RequestHash   string
+}
+
+var processWikiMapChatCache = struct {
+	sync.RWMutex
+	data map[wikiMapChatCacheKey]*types.ChatResponse
+}{data: make(map[wikiMapChatCacheKey]*types.ChatResponse)}
+
+type wikiMapCachedChat struct {
+	base            chat.Chat
+	tenantID        uint64
+	knowledgeID     string
+	knowledgeBaseID string
+	contentHash      string
+}
+
+func newWikiMapCachedChat(
+	base chat.Chat,
+	tenantID uint64,
+	knowledgeID string,
+	knowledgeBaseID string,
+	content string,
+) chat.Chat {
+	return &wikiMapCachedChat{
+		base:            base,
+		tenantID:        tenantID,
+		knowledgeID:     knowledgeID,
+		knowledgeBaseID: knowledgeBaseID,
+		contentHash:      types.StableContentHash(content),
+	}
+}
+
+func (c *wikiMapCachedChat) Chat(
+	ctx context.Context,
+	messages []chat.Message,
+	opts *chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	key, err := c.cacheKey(messages, opts)
+	if err != nil || key.ContentHash == "" {
+		return c.base.Chat(ctx, messages, opts)
+	}
+
+	processWikiMapChatCache.RLock()
+	resp, ok := processWikiMapChatCache.data[key]
+	processWikiMapChatCache.RUnlock()
+	if ok {
+		return cloneChatResponse(resp), nil
+	}
+
+	resp, err := c.base.Chat(ctx, messages, opts)
+	if err != nil {
+		return nil, err
+	}
+	processWikiMapChatCache.Lock()
+	processWikiMapChatCache.data[key] = cloneChatResponse(resp)
+	processWikiMapChatCache.Unlock()
+	return resp, nil
+}
+
+func (c *wikiMapCachedChat) ChatStream(
+	ctx context.Context,
+	messages []chat.Message,
+	opts *chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	return c.base.ChatStream(ctx, messages, opts)
+}
+
+func (c *wikiMapCachedChat) GetModelName() string {
+	return c.base.GetModelName()
+}
+
+func (c *wikiMapCachedChat) GetModelID() string {
+	return c.base.GetModelID()
+}
+
+func (c *wikiMapCachedChat) cacheKey(messages []chat.Message, opts *chat.ChatOptions) (wikiMapChatCacheKey, error) {
+	requestBytes, err := json.Marshal(struct {
+		Messages []chat.Message    `json:"messages"`
+		Options  *chat.ChatOptions `json:"options"`
+	}{Messages: messages, Options: opts})
+	if err != nil {
+		return wikiMapChatCacheKey{}, fmt.Errorf("marshal wiki map cache request: %w", err)
+	}
+	return wikiMapChatCacheKey{
+		TenantID:        c.tenantID,
+		KnowledgeID:     c.knowledgeID,
+		KnowledgeBaseID: c.knowledgeBaseID,
+		ModelID:         c.base.GetModelID(),
+		ModelName:       c.base.GetModelName(),
+		PromptVersion:   wikiMapPromptVersion,
+		ContentHash:     c.contentHash,
+		RequestHash:     stableStringHash(string(requestBytes)),
+	}, nil
+}
+
+func cloneChatResponse(resp *types.ChatResponse) *types.ChatResponse {
+	if resp == nil {
+		return nil
+	}
+	cloned := *resp
+	cloned.ToolCalls = append([]types.LLMToolCall(nil), resp.ToolCalls...)
+	return &cloned
+}

--- a/internal/application/service/wiki_map_chat_cache_test.go
+++ b/internal/application/service/wiki_map_chat_cache_test.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+type countingChat struct {
+	calls     int
+	modelID   string
+	modelName string
+}
+
+func (c *countingChat) Chat(
+	ctx context.Context,
+	messages []chat.Message,
+	opts *chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	c.calls++
+	return &types.ChatResponse{Content: fmt.Sprintf("response-%d", c.calls)}, nil
+}
+
+func (c *countingChat) ChatStream(
+	ctx context.Context,
+	messages []chat.Message,
+	opts *chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	return nil, nil
+}
+
+func (c *countingChat) GetModelName() string { return c.modelName }
+func (c *countingChat) GetModelID() string   { return c.modelID }
+
+func TestWikiMapCachedChatReusesSameMapRequest(t *testing.T) {
+	resetProcessWikiMapChatCacheForTest()
+
+	base := &countingChat{modelID: "chat-1", modelName: "gpt"}
+	cached := newWikiMapCachedChat(base, 7, "knowledge-1", "kb-1", "same content")
+	messages := []chat.Message{{Role: "user", Content: "extract same content"}}
+
+	first, err := cached.Chat(context.Background(), messages, &chat.ChatOptions{Temperature: 0.1})
+	require.NoError(t, err)
+	second, err := cached.Chat(context.Background(), messages, &chat.ChatOptions{Temperature: 0.1})
+	require.NoError(t, err)
+
+	require.Equal(t, first.Content, second.Content)
+	require.Equal(t, 1, base.calls)
+}
+
+func TestWikiMapCachedChatMissesOnContentOrModelChange(t *testing.T) {
+	resetProcessWikiMapChatCacheForTest()
+
+	firstModel := &countingChat{modelID: "chat-1", modelName: "gpt"}
+	messages := []chat.Message{{Role: "user", Content: "extract"}}
+	cacheA := newWikiMapCachedChat(firstModel, 7, "knowledge-1", "kb-1", "content-a")
+	_, err := cacheA.Chat(context.Background(), messages, &chat.ChatOptions{Temperature: 0.1})
+	require.NoError(t, err)
+
+	cacheB := newWikiMapCachedChat(firstModel, 7, "knowledge-1", "kb-1", "content-b")
+	_, err = cacheB.Chat(context.Background(), messages, &chat.ChatOptions{Temperature: 0.1})
+	require.NoError(t, err)
+
+	secondModel := &countingChat{modelID: "chat-2", modelName: "gpt"}
+	cacheOtherModel := newWikiMapCachedChat(secondModel, 7, "knowledge-1", "kb-1", "content-a")
+	_, err = cacheOtherModel.Chat(context.Background(), messages, &chat.ChatOptions{Temperature: 0.1})
+	require.NoError(t, err)
+
+	require.Equal(t, 2, firstModel.calls)
+	require.Equal(t, 1, secondModel.calls)
+}
+
+func resetProcessWikiMapChatCacheForTest() {
+	processWikiMapChatCache.Lock()
+	defer processWikiMapChatCache.Unlock()
+	processWikiMapChatCache.data = make(map[wikiMapChatCacheKey]*types.ChatResponse)
+}

--- a/internal/handler/knowledge_batch_reparse_test.go
+++ b/internal/handler/knowledge_batch_reparse_test.go
@@ -1,0 +1,218 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hibiken/asynq"
+
+	"github.com/Tencent/WeKnora/internal/middleware"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type stubBatchReparseKBService struct {
+	interfaces.KnowledgeBaseService
+	calls int
+	kb    *types.KnowledgeBase
+	err   error
+}
+
+func (s *stubBatchReparseKBService) GetKnowledgeBaseByID(_ context.Context, _ string) (*types.KnowledgeBase, error) {
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.kb, nil
+}
+
+type stubBatchReparseKGService struct {
+	interfaces.KnowledgeService
+	calls     int
+	gotTenant uint64
+	gotIDs    []string
+	knowledge []*types.Knowledge
+	err       error
+}
+
+func (s *stubBatchReparseKGService) GetKnowledgeBatch(_ context.Context, tenantID uint64, ids []string) ([]*types.Knowledge, error) {
+	s.calls++
+	s.gotTenant = tenantID
+	s.gotIDs = append([]string(nil), ids...)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.knowledge, nil
+}
+
+type captureBatchReparseEnqueuer struct {
+	calls int
+	task  *asynq.Task
+	err   error
+}
+
+func (e *captureBatchReparseEnqueuer) Enqueue(task *asynq.Task, _ ...asynq.Option) (*asynq.TaskInfo, error) {
+	e.calls++
+	e.task = task
+	if e.err != nil {
+		return nil, e.err
+	}
+	return &asynq.TaskInfo{ID: "task-batch-reparse"}, nil
+}
+
+func newBatchReparseTestRouter(
+	kb interfaces.KnowledgeBaseService,
+	kg interfaces.KnowledgeService,
+	enqueuer interfaces.TaskEnqueuer,
+) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.ErrorHandler())
+	r.Use(func(c *gin.Context) {
+		c.Set(types.TenantIDContextKey.String(), uint64(1))
+		c.Set(types.UserIDContextKey.String(), "u-test")
+		c.Next()
+	})
+	h := &KnowledgeHandler{kbService: kb, kgService: kg, asynqClient: enqueuer}
+	r.POST("/batch-reparse", h.BatchReparseKnowledge)
+	return r
+}
+
+func doBatchReparseRequest(t *testing.T, router *gin.Engine, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/batch-reparse", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestBatchReparseKnowledge_EnqueuesDedupedIDsWithProcessConfig(t *testing.T) {
+	kb := &stubBatchReparseKBService{kb: &types.KnowledgeBase{ID: "kb-1", TenantID: 1}}
+	kg := &stubBatchReparseKGService{knowledge: []*types.Knowledge{
+		{ID: "k1", TenantID: 1, KnowledgeBaseID: "kb-1"},
+		{ID: "k2", TenantID: 1, KnowledgeBaseID: "kb-1"},
+	}}
+	enqueuer := &captureBatchReparseEnqueuer{}
+	router := newBatchReparseTestRouter(kb, kg, enqueuer)
+
+	body := map[string]any{
+		"kb_id": "kb-1",
+		"ids":   []string{" k1 ", "", "k2", "k1"},
+		"process_config": map[string]any{
+			"parser_engine_overrides": map[string]string{"pdf_force_scanned": "true"},
+		},
+	}
+
+	w := doBatchReparseRequest(t, router, body)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if kg.calls != 1 {
+		t.Fatalf("GetKnowledgeBatch calls = %d, want 1", kg.calls)
+	}
+	if kg.gotTenant != 1 {
+		t.Fatalf("GetKnowledgeBatch tenant = %d, want 1", kg.gotTenant)
+	}
+	wantIDs := []string{"k1", "k2"}
+	if !reflect.DeepEqual(kg.gotIDs, wantIDs) {
+		t.Fatalf("GetKnowledgeBatch ids = %#v, want %#v", kg.gotIDs, wantIDs)
+	}
+	if enqueuer.calls != 1 {
+		t.Fatalf("Enqueue calls = %d, want 1", enqueuer.calls)
+	}
+	if enqueuer.task.Type() != types.TypeKnowledgeListReparse {
+		t.Fatalf("task type = %q, want %q", enqueuer.task.Type(), types.TypeKnowledgeListReparse)
+	}
+
+	var payload types.KnowledgeListReparsePayload
+	if err := json.Unmarshal(enqueuer.task.Payload(), &payload); err != nil {
+		t.Fatalf("unmarshal task payload: %v", err)
+	}
+	if payload.TenantID != 1 {
+		t.Fatalf("payload tenant = %d, want 1", payload.TenantID)
+	}
+	if !reflect.DeepEqual(payload.KnowledgeIDs, wantIDs) {
+		t.Fatalf("payload ids = %#v, want %#v", payload.KnowledgeIDs, wantIDs)
+	}
+	if payload.ProcessConfig == nil || payload.ProcessConfig.ParserEngineOverrides["pdf_force_scanned"] != "true" {
+		t.Fatalf("payload process config = %#v, want parser_engine_overrides.pdf_force_scanned=true", payload.ProcessConfig)
+	}
+	if !strings.Contains(w.Body.String(), `"reparse_count":2`) {
+		t.Fatalf("response body %q does not include reparse_count=2", w.Body.String())
+	}
+}
+
+func TestBatchReparseKnowledge_RejectsKnowledgeOutsideRequestedKB(t *testing.T) {
+	kb := &stubBatchReparseKBService{kb: &types.KnowledgeBase{ID: "kb-1", TenantID: 1}}
+	kg := &stubBatchReparseKGService{knowledge: []*types.Knowledge{
+		{ID: "k1", TenantID: 1, KnowledgeBaseID: "kb-1"},
+		{ID: "k2", TenantID: 1, KnowledgeBaseID: "other-kb"},
+	}}
+	enqueuer := &captureBatchReparseEnqueuer{}
+	router := newBatchReparseTestRouter(kb, kg, enqueuer)
+
+	w := doBatchReparseRequest(t, router, map[string]any{
+		"kb_id": "kb-1",
+		"ids":   []string{"k1", "k2"},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "does not belong to knowledge base") {
+		t.Fatalf("body %q does not explain KB ownership rejection", w.Body.String())
+	}
+	if enqueuer.calls != 0 {
+		t.Fatalf("Enqueue calls = %d, want 0", enqueuer.calls)
+	}
+}
+
+func TestBatchReparseKnowledge_RejectsOversizedBatchBeforeLookupOrEnqueue(t *testing.T) {
+	kb := &stubBatchReparseKBService{
+		kb:  &types.KnowledgeBase{ID: "kb-1", TenantID: 1},
+		err: errors.New("kb lookup should not be called"),
+	}
+	kg := &stubBatchReparseKGService{}
+	enqueuer := &captureBatchReparseEnqueuer{}
+	router := newBatchReparseTestRouter(kb, kg, enqueuer)
+
+	ids := make([]string, 201)
+	for i := range ids {
+		ids[i] = "k" + strconv.Itoa(i)
+	}
+	w := doBatchReparseRequest(t, router, map[string]any{
+		"kb_id": "kb-1",
+		"ids":   ids,
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "max 200") {
+		t.Fatalf("body %q does not mention max batch size", w.Body.String())
+	}
+	if kb.calls != 0 {
+		t.Fatalf("GetKnowledgeBaseByID calls = %d, want 0", kb.calls)
+	}
+	if kg.calls != 0 {
+		t.Fatalf("GetKnowledgeBatch calls = %d, want 0", kg.calls)
+	}
+	if enqueuer.calls != 0 {
+		t.Fatalf("Enqueue calls = %d, want 0", enqueuer.calls)
+	}
+}

--- a/internal/models/embedding/cached_embedder.go
+++ b/internal/models/embedding/cached_embedder.go
@@ -1,0 +1,181 @@
+package embedding
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// CacheScope scopes embedding cache entries to an isolation boundary.
+type CacheScope struct {
+	TenantID uint64
+}
+
+type EmbeddingCacheKey struct {
+	TenantID   uint64
+	ModelID    string
+	ModelName  string
+	Dimension  int
+	TextHash   string
+}
+
+// EmbeddingCache stores vectors by deterministic embedding input keys.
+type EmbeddingCache interface {
+	Get(ctx context.Context, key EmbeddingCacheKey) ([]float32, bool, error)
+	Set(ctx context.Context, key EmbeddingCacheKey, vector []float32) error
+}
+
+// MemoryEmbeddingCache is a process-local cache useful for tests and lite mode.
+type MemoryEmbeddingCache struct {
+	mu   sync.RWMutex
+	data map[EmbeddingCacheKey][]float32
+}
+
+func NewMemoryEmbeddingCache() *MemoryEmbeddingCache {
+	return &MemoryEmbeddingCache{data: make(map[EmbeddingCacheKey][]float32)}
+}
+
+func (c *MemoryEmbeddingCache) Get(ctx context.Context, key EmbeddingCacheKey) ([]float32, bool, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	vector, ok := c.data[key]
+	if !ok {
+		return nil, false, nil
+	}
+	return cloneVector(vector), true, nil
+}
+
+func (c *MemoryEmbeddingCache) Set(ctx context.Context, key EmbeddingCacheKey, vector []float32) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data[key] = cloneVector(vector)
+	return nil
+}
+
+// CachedEmbedder wraps an Embedder and reuses vectors for identical normalized inputs.
+type CachedEmbedder struct {
+	base  Embedder
+	cache EmbeddingCache
+	scope CacheScope
+}
+
+func NewCachedEmbedder(base Embedder, cache EmbeddingCache, scope CacheScope) *CachedEmbedder {
+	return &CachedEmbedder{base: base, cache: cache, scope: scope}
+}
+
+func (e *CachedEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	vectors, err := e.BatchEmbed(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(vectors) == 0 {
+		return nil, fmt.Errorf("cached embedder returned no vector")
+	}
+	return vectors[0], nil
+}
+
+func (e *CachedEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	if e == nil || e.base == nil {
+		return nil, fmt.Errorf("cached embedder requires a base embedder")
+	}
+	if len(texts) == 0 {
+		return [][]float32{}, nil
+	}
+	if e.cache == nil {
+		return e.base.BatchEmbed(ctx, texts)
+	}
+
+	out := make([][]float32, len(texts))
+	keys := make([]EmbeddingCacheKey, len(texts))
+	missSeen := make(map[EmbeddingCacheKey]int)
+	var missTexts []string
+	var missKeys []EmbeddingCacheKey
+	for i, text := range texts {
+		key := e.cacheKey(text)
+		keys[i] = key
+		if key.TextHash == "" {
+			out[i] = []float32{}
+			continue
+		}
+		if vector, ok, err := e.cache.Get(ctx, key); err != nil {
+			return nil, err
+		} else if ok {
+			out[i] = vector
+			continue
+		}
+		if _, ok := missSeen[key]; ok {
+			continue
+		}
+		missSeen[key] = len(missTexts)
+		missKeys = append(missKeys, key)
+		missTexts = append(missTexts, types.NormalizeContentForIdentity(text))
+	}
+
+	if len(missTexts) > 0 {
+		missVectors, err := e.base.BatchEmbed(ctx, missTexts)
+		if err != nil {
+			return nil, err
+		}
+		if len(missVectors) != len(missTexts) {
+			return nil, fmt.Errorf("embedding result count %d does not match input count %d", len(missVectors), len(missTexts))
+		}
+		for i, key := range missKeys {
+			if err := e.cache.Set(ctx, key, missVectors[i]); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	for i, key := range keys {
+		if out[i] != nil || key.TextHash == "" {
+			continue
+		}
+		vector, ok, err := e.cache.Get(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, fmt.Errorf("embedding cache miss after set")
+		}
+		out[i] = vector
+	}
+
+	return out, nil
+}
+
+func (e *CachedEmbedder) GetModelName() string {
+	return e.base.GetModelName()
+}
+
+func (e *CachedEmbedder) GetDimensions() int {
+	return e.base.GetDimensions()
+}
+
+func (e *CachedEmbedder) GetModelID() string {
+	return e.base.GetModelID()
+}
+
+func (e *CachedEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string) ([][]float32, error) {
+	return e.BatchEmbed(ctx, texts)
+}
+
+func (e *CachedEmbedder) cacheKey(text string) EmbeddingCacheKey {
+	return EmbeddingCacheKey{
+		TenantID:  e.scope.TenantID,
+		ModelID:   e.base.GetModelID(),
+		ModelName: e.base.GetModelName(),
+		Dimension: e.base.GetDimensions(),
+		TextHash:  types.StableContentHash(text),
+	}
+}
+
+func cloneVector(vector []float32) []float32 {
+	if vector == nil {
+		return nil
+	}
+	out := make([]float32, len(vector))
+	copy(out, vector)
+	return out
+}

--- a/internal/models/embedding/cached_embedder_test.go
+++ b/internal/models/embedding/cached_embedder_test.go
@@ -1,0 +1,161 @@
+package embedding
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type countingEmbedder struct {
+	calls      int
+	modelID    string
+	modelName  string
+	dimensions int
+}
+
+func (e *countingEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	e.calls++
+	return []float32{float32(len(text)), float32(e.calls)}, nil
+}
+
+func (e *countingEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	e.calls++
+	out := make([][]float32, len(texts))
+	for i, text := range texts {
+		out[i] = []float32{float32(len(text)), float32(i)}
+	}
+	return out, nil
+}
+
+func (e *countingEmbedder) GetModelName() string { return e.modelName }
+func (e *countingEmbedder) GetDimensions() int   { return e.dimensions }
+func (e *countingEmbedder) GetModelID() string   { return e.modelID }
+
+func (e *countingEmbedder) BatchEmbedWithPool(
+	ctx context.Context,
+	model Embedder,
+	texts []string,
+) ([][]float32, error) {
+	return e.BatchEmbed(ctx, texts)
+}
+
+func TestCachedEmbedderBatchEmbedReusesSameTextForSameModel(t *testing.T) {
+	t.Parallel()
+
+	base := &countingEmbedder{modelID: "embed-1", modelName: "text-embedding", dimensions: 3}
+	cache := NewMemoryEmbeddingCache()
+	cached := NewCachedEmbedder(base, cache, CacheScope{TenantID: 7})
+
+	first, err := cached.BatchEmbed(context.Background(), []string{"alpha", "beta", "alpha"})
+	require.NoError(t, err)
+	require.Len(t, first, 3)
+	require.Equal(t, 1, base.calls)
+
+	second, err := cached.BatchEmbed(context.Background(), []string{" alpha ", "beta"})
+	require.NoError(t, err)
+	require.Equal(t, 1, base.calls, "second batch should be served entirely from cache")
+	require.Equal(t, first[0], second[0])
+	require.Equal(t, first[1], second[1])
+}
+
+func TestCachedEmbedderMissesWhenModelOrDimensionChanges(t *testing.T) {
+	t.Parallel()
+
+	cache := NewMemoryEmbeddingCache()
+	ctx := context.Background()
+
+	modelA := &countingEmbedder{modelID: "embed-1", modelName: "text-embedding", dimensions: 3}
+	_, err := NewCachedEmbedder(modelA, cache, CacheScope{TenantID: 7}).BatchEmbed(ctx, []string{"alpha"})
+	require.NoError(t, err)
+	require.Equal(t, 1, modelA.calls)
+
+	modelB := &countingEmbedder{modelID: "embed-2", modelName: "text-embedding", dimensions: 3}
+	_, err = NewCachedEmbedder(modelB, cache, CacheScope{TenantID: 7}).BatchEmbed(ctx, []string{"alpha"})
+	require.NoError(t, err)
+	require.Equal(t, 1, modelB.calls)
+
+	modelC := &countingEmbedder{modelID: "embed-1", modelName: "text-embedding", dimensions: 8}
+	_, err = NewCachedEmbedder(modelC, cache, CacheScope{TenantID: 7}).BatchEmbed(ctx, []string{"alpha"})
+	require.NoError(t, err)
+	require.Equal(t, 1, modelC.calls)
+}
+
+func TestCachedEmbedderPreservesInputOrderWithPartialHits(t *testing.T) {
+	t.Parallel()
+
+	cache := NewMemoryEmbeddingCache()
+	base := &countingEmbedder{modelID: "embed-1", modelName: "text-embedding", dimensions: 3}
+	cached := NewCachedEmbedder(base, cache, CacheScope{TenantID: 7})
+	ctx := context.Background()
+
+	seed, err := cached.BatchEmbed(ctx, []string{"cached"})
+	require.NoError(t, err)
+	require.Equal(t, 1, base.calls)
+
+	got, err := cached.BatchEmbed(ctx, []string{"cached", "new", "cached"})
+	require.NoError(t, err)
+	require.Equal(t, 2, base.calls)
+	require.Equal(t, seed[0], got[0])
+	require.Equal(t, seed[0], got[2])
+	require.Equal(t, []float32{3, 0}, got[1])
+}
+
+func TestCachedEmbedderDoesNotShareAcrossTenants(t *testing.T) {
+	t.Parallel()
+
+	cache := NewMemoryEmbeddingCache()
+	ctx := context.Background()
+
+	tenantA := &countingEmbedder{modelID: "embed-1", modelName: "text-embedding", dimensions: 3}
+	_, err := NewCachedEmbedder(tenantA, cache, CacheScope{TenantID: 7}).BatchEmbed(ctx, []string{"alpha"})
+	require.NoError(t, err)
+
+	tenantB := &countingEmbedder{modelID: "embed-1", modelName: "text-embedding", dimensions: 3}
+	_, err = NewCachedEmbedder(tenantB, cache, CacheScope{TenantID: 8}).BatchEmbed(ctx, []string{"alpha"})
+	require.NoError(t, err)
+	require.Equal(t, 1, tenantB.calls)
+}
+
+func TestCachedEmbedderDoesNotWriteFailedResults(t *testing.T) {
+	t.Parallel()
+
+	errBoom := fmt.Errorf("boom")
+	base := &failingEmbedder{err: errBoom}
+	cache := NewMemoryEmbeddingCache()
+	cached := NewCachedEmbedder(base, cache, CacheScope{TenantID: 7})
+
+	_, err := cached.BatchEmbed(context.Background(), []string{"alpha"})
+	require.ErrorIs(t, err, errBoom)
+
+	retry := &countingEmbedder{modelID: "embed-1", modelName: "text-embedding", dimensions: 3}
+	got, err := NewCachedEmbedder(retry, cache, CacheScope{TenantID: 7}).BatchEmbed(context.Background(), []string{"alpha"})
+	require.NoError(t, err)
+	require.Equal(t, 1, retry.calls)
+	require.Equal(t, []float32{5, 0}, got[0])
+}
+
+type failingEmbedder struct {
+	err error
+}
+
+func (e *failingEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	return nil, e.err
+}
+
+func (e *failingEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	return nil, e.err
+}
+
+func (e *failingEmbedder) GetModelName() string { return "text-embedding" }
+func (e *failingEmbedder) GetDimensions() int   { return 3 }
+func (e *failingEmbedder) GetModelID() string   { return "embed-1" }
+
+func (e *failingEmbedder) BatchEmbedWithPool(
+	ctx context.Context,
+	model Embedder,
+	texts []string,
+) ([][]float32, error) {
+	return nil, e.err
+}

--- a/internal/types/content_identity.go
+++ b/internal/types/content_identity.go
@@ -1,0 +1,60 @@
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+var stableChunkNamespace = uuid.NewSHA1(uuid.NameSpaceOID, []byte("github.com/Tencent/WeKnora/stable-chunk-id/v1"))
+
+// StableChunkIDSpec describes the deterministic identity inputs for a chunk.
+type StableChunkIDSpec struct {
+	KnowledgeID       string
+	ChunkType         ChunkType
+	Content           string
+	Occurrence        int
+	ChunkingConfigKey string
+}
+
+// NormalizeContentForIdentity trims content and collapses all whitespace runs.
+func NormalizeContentForIdentity(content string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(content)), " ")
+}
+
+// StableContentHash returns a SHA-256 hash for normalized content.
+func StableContentHash(content string) string {
+	normalized := NormalizeContentForIdentity(content)
+	if normalized == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(normalized))
+	return hex.EncodeToString(sum[:])
+}
+
+// StableChunkID returns a UUID string derived from stable chunk inputs.
+func StableChunkID(spec StableChunkIDSpec) string {
+	key := fmt.Sprintf(
+		"knowledge=%s\ntype=%s\ncontent_hash=%s\noccurrence=%d\nchunking=%s",
+		spec.KnowledgeID,
+		spec.ChunkType,
+		StableContentHash(spec.Content),
+		spec.Occurrence,
+		spec.ChunkingConfigKey,
+	)
+	return uuid.NewSHA1(stableChunkNamespace, []byte(key)).String()
+}
+
+// StableChunkingConfigKey returns a deterministic key for chunking-sensitive identity.
+func StableChunkingConfigKey(config ChunkingConfig) string {
+	bytes, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Sprintf("%+v", config)
+	}
+	sum := sha256.Sum256(bytes)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/types/stable_chunk_id_test.go
+++ b/internal/types/stable_chunk_id_test.go
@@ -1,0 +1,94 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStableChunkIDSameInputSameID(t *testing.T) {
+	t.Parallel()
+
+	spec := StableChunkIDSpec{
+		KnowledgeID:       "knowledge-1",
+		ChunkType:         ChunkTypeText,
+		Content:           " hello\nworld ",
+		Occurrence:        0,
+		ChunkingConfigKey: "token:size=512:overlap=50",
+	}
+
+	first := StableChunkID(spec)
+	second := StableChunkID(spec)
+
+	require.Equal(t, first, second)
+	require.NoError(t, uuid.Validate(first))
+}
+
+func TestStableChunkIDNormalizesWhitespace(t *testing.T) {
+	t.Parallel()
+
+	base := StableChunkIDSpec{
+		KnowledgeID:       "knowledge-1",
+		ChunkType:         ChunkTypeText,
+		Content:           "hello world",
+		Occurrence:        0,
+		ChunkingConfigKey: "token:size=512:overlap=50",
+	}
+	withWhitespace := base
+	withWhitespace.Content = " hello\n\tworld "
+
+	require.Equal(t, StableChunkID(base), StableChunkID(withWhitespace))
+}
+
+func TestStableChunkIDSeparatesDuplicateOccurrences(t *testing.T) {
+	t.Parallel()
+
+	first := StableChunkID(StableChunkIDSpec{
+		KnowledgeID:       "knowledge-1",
+		ChunkType:         ChunkTypeText,
+		Content:           "duplicate",
+		Occurrence:        0,
+		ChunkingConfigKey: "token:size=512:overlap=50",
+	})
+	second := StableChunkID(StableChunkIDSpec{
+		KnowledgeID:       "knowledge-1",
+		ChunkType:         ChunkTypeText,
+		Content:           "duplicate",
+		Occurrence:        1,
+		ChunkingConfigKey: "token:size=512:overlap=50",
+	})
+
+	require.NotEqual(t, first, second)
+	require.NoError(t, uuid.Validate(first))
+	require.NoError(t, uuid.Validate(second))
+}
+
+func TestStableChunkIDChangesWhenContentOrChunkingConfigChanges(t *testing.T) {
+	t.Parallel()
+
+	base := StableChunkIDSpec{
+		KnowledgeID:       "knowledge-1",
+		ChunkType:         ChunkTypeText,
+		Content:           "alpha",
+		Occurrence:        0,
+		ChunkingConfigKey: "token:size=512:overlap=50",
+	}
+	changedContent := base
+	changedContent.Content = "beta"
+	changedConfig := base
+	changedConfig.ChunkingConfigKey = "token:size=1024:overlap=50"
+
+	require.NotEqual(t, StableChunkID(base), StableChunkID(changedContent))
+	require.NotEqual(t, StableChunkID(base), StableChunkID(changedConfig))
+}
+
+func TestStableContentHashNormalizesEmbeddingText(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t,
+		StableContentHash(" Title\n\nBody\ttext "),
+		StableContentHash("Title Body text"),
+	)
+	require.NotEmpty(t, StableContentHash("Title Body text"))
+}


### PR DESCRIPTION
## Summary

Fixes issue #1679 by making same-content reparse avoid the major repeat-computation paths.

- Adds deterministic chunk identity and content hashing for text, parent, OCR, and caption chunks.
- Reconciles document chunks by diff instead of deleting all business chunks before every parse.
- Adds tenant/model/text scoped embedding cache and wires it into vector indexing.
- Adds tenant/model/prompt/image scoped VLM OCR and caption cache; failed VLM calls are not cached.
- Adds Wiki map-stage chat caching while leaving reduce/page reconciliation on the live model path.
- Adds GraphRAG per-chunk entity extraction caching while preserving global graph merge/build recalculation.
- Documents the final acceptance test suite for issue 1679.

## Root Cause

`ReparseKnowledge` and `processChunks` were clearing chunks, vector index data, and graph data before rebuilding. Chunk IDs were generated with random UUIDs, so identical content produced new chunk identities and broke wiki `chunk_refs`. Embedding, VLM, Wiki map, and Graph per-chunk extraction had no reusable identity keyed by content plus model/prompt configuration.

## Validation

- `git diff --check` passed.
- Target Go test command could not run in this local environment because `go`/`gofmt` are not installed.
- Attempted to install Go with `winget install GoLang.Go --silent --accept-package-agreements --accept-source-agreements`, but winget failed to update its source with `InternetOpenUrl() failed. 0x80072f7d`.

Intended test command once Go is available:

```bash
go test ./internal/types ./internal/models/embedding ./internal/application/service ./internal/application/service/retriever
```