### PR TITLE
feat(knowledge): add folder delete to complete the folder management API

### DIFF
--- a/internal/application/repository/knowledge.go
+++ b/internal/application/repository/knowledge.go
@@ -249,6 +249,32 @@ func (r *knowledgeRepository) UpdateKnowledgeFolderPath(
 	return result.RowsAffected, nil
 }
 
+// ListKnowledgeIDsByFolderPath returns the IDs of every knowledge entry stored
+// in folderPath or any folder below it, skipping rows already mid-deletion. It
+// is the resolver behind a folder delete: the caller routes the IDs through the
+// normal knowledge delete pipeline so chunks, embeddings and files are torn down
+// instead of being orphaned by a bare folder-column wipe.
+func (r *knowledgeRepository) ListKnowledgeIDsByFolderPath(
+	ctx context.Context,
+	tenantID uint64,
+	kbID string,
+	folderPath string,
+) ([]string, error) {
+	if folderPath == "" {
+		return nil, errors.New("folder path is required")
+	}
+	var ids []string
+	if err := r.db.WithContext(ctx).
+		Model(&types.Knowledge{}).
+		Where("tenant_id = ? AND knowledge_base_id = ? AND parse_status <> ? AND (folder_path = ? OR folder_path LIKE ? ESCAPE ?)",
+			tenantID, kbID, types.ParseStatusDeleting,
+			folderPath, escapeLikeKeyword(folderPath)+"/%", likeEscapeChar).
+		Pluck("id", &ids).Error; err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
 // RenameKnowledgeFolderPath rewrites folder_path for a folder and every folder
 // below it, which is how a folder rename or move is applied. Renaming onto an
 // existing path merges the two folders. Returns the number of affected rows.

--- a/internal/application/repository/knowledge_folder_delete_test.go
+++ b/internal/application/repository/knowledge_folder_delete_test.go
@@ -1,0 +1,51 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListKnowledgeIDsByFolderPath(t *testing.T) {
+	db := setupKnowledgeTestDB(t)
+	repo := NewKnowledgeRepository(db).(*knowledgeRepository)
+	ctx := context.Background()
+
+	const tenantID = uint64(1)
+	kbID := uuid.New().String()
+
+	insertKnowledgeInFolder(t, db, tenantID, kbID, "", "readme.md") // root, out of scope
+	docsID := insertKnowledgeInFolder(t, db, tenantID, kbID, "docs", "intro.md")
+	specID := insertKnowledgeInFolder(t, db, tenantID, kbID, "docs/spec", "design.md")
+	insertKnowledgeInFolder(t, db, tenantID, kbID, "docsets", "x.md")    // prefix sibling, out of scope
+	insertKnowledgeInFolder(t, db, tenantID, kbID, "assets", "logo.png") // unrelated
+
+	// The folder itself plus its descendants; a folder that merely shares the
+	// prefix ("docsets") must not be swept in - that is what the "/%" ESCAPE
+	// predicate guards against.
+	ids, err := repo.ListKnowledgeIDsByFolderPath(ctx, tenantID, kbID, "docs")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{docsID, specID}, ids)
+
+	// A leaf folder returns just its own entry.
+	ids, err = repo.ListKnowledgeIDsByFolderPath(ctx, tenantID, kbID, "docs/spec")
+	require.NoError(t, err)
+	assert.Equal(t, []string{specID}, ids)
+
+	// Rows already mid-deletion are skipped so a retried delete never re-enqueues
+	// an entry that is already being torn down.
+	require.NoError(t, db.Exec(`UPDATE knowledges SET parse_status = ? WHERE id = ?`,
+		types.ParseStatusDeleting, specID).Error)
+	ids, err = repo.ListKnowledgeIDsByFolderPath(ctx, tenantID, kbID, "docs")
+	require.NoError(t, err)
+	assert.Equal(t, []string{docsID}, ids)
+
+	// An unknown folder is empty, not an error.
+	ids, err = repo.ListKnowledgeIDsByFolderPath(ctx, tenantID, kbID, "nope")
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -638,6 +638,21 @@ func (s *knowledgeService) RenameKnowledgeFolder(ctx context.Context,
 	return affected, nil
 }
 
+// ListKnowledgeIDsInFolder returns the IDs of every document in folderPath and
+// its subtree. The empty root path is rejected so a folder delete can never be
+// turned into a whole-knowledge-base wipe - clearing a knowledge base is what
+// ClearKnowledgeBaseContents is for.
+func (s *knowledgeService) ListKnowledgeIDsInFolder(ctx context.Context,
+	kbID string, folderPath string,
+) ([]string, error) {
+	source := types.NormalizeKnowledgeFolderPath(folderPath)
+	if source == "" {
+		return nil, werrors.NewBadRequestError("根目录不能作为文件夹删除")
+	}
+	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
+	return s.repo.ListKnowledgeIDsByFolderPath(ctx, tenantID, kbID, source)
+}
+
 // normalizeTargetFolderPath canonicalizes a caller-supplied destination folder
 // and applies the same input validation as the upload path, since the value ends
 // up rendered as sidebar tree labels.

--- a/internal/application/service/knowledge_folder_delete_test.go
+++ b/internal/application/service/knowledge_folder_delete_test.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type folderDeleteRepoStub struct {
+	interfaces.KnowledgeRepository
+
+	gotPath  string
+	listCall int
+	ids      []string
+}
+
+func (r *folderDeleteRepoStub) ListKnowledgeIDsByFolderPath(
+	_ context.Context, _ uint64, _ string, folderPath string,
+) ([]string, error) {
+	r.listCall++
+	r.gotPath = folderPath
+	return r.ids, nil
+}
+
+func TestListKnowledgeIDsInFolderNormalizesPath(t *testing.T) {
+	repo := &folderDeleteRepoStub{ids: []string{"k1", "k2"}}
+	svc := &knowledgeService{repo: repo}
+
+	ids, err := svc.ListKnowledgeIDsInFolder(folderMoveContext(), "kb-1", "/docs//spec/")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"k1", "k2"}, ids)
+	assert.Equal(t, "docs/spec", repo.gotPath, "the repository sees the canonical folder path")
+}
+
+func TestListKnowledgeIDsInFolderRejectsRoot(t *testing.T) {
+	repo := &folderDeleteRepoStub{}
+	svc := &knowledgeService{repo: repo}
+
+	// Anything that normalizes to the empty path is the knowledge base root;
+	// deleting it would wipe every document, which is ClearKnowledgeBaseContents'
+	// job, not a folder delete's.
+	for _, path := range []string{"", "   ", "/", ".."} {
+		_, err := svc.ListKnowledgeIDsInFolder(folderMoveContext(), "kb-1", path)
+		assert.Error(t, err, "root-equivalent path %q must be rejected", path)
+	}
+	assert.Equal(t, 0, repo.listCall, "a rejected root path must never reach the repository")
+}

--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -1211,6 +1211,94 @@ func (h *KnowledgeHandler) RenameKnowledgeFolder(c *gin.Context) {
 	})
 }
 
+type DeleteKnowledgeFolderRequest struct {
+	Path      string `json:"path" binding:"required"`
+	Recursive bool   `json:"recursive"`
+}
+
+// DeleteKnowledgeFolder godoc
+// @Summary      删除文件夹
+// @Description  删除一个文件夹。空文件夹或不存在的路径为空操作；文件夹内还有文档时需 recursive=true，此时子目录下所有文档会走异步删除管线一并清理（含分块、向量与文件）。根目录不可删（清空知识库另有接口）
+// @Tags         知识管理
+// @Accept       json
+// @Produce      json
+// @Param        id       path      string                        true  "知识库ID"
+// @Param        request  body      DeleteKnowledgeFolderRequest  true  "删除请求"
+// @Success      200      {object}  map[string]interface{}        "删除任务已提交"
+// @Failure      400      {object}  errors.AppError               "请求参数错误或文件夹非空"
+// @Failure      403      {object}  errors.AppError               "权限不足"
+// @Security     Bearer
+// @Security     ApiKeyAuth
+// @Router       /knowledge-bases/{id}/knowledge/folders [delete]
+func (h *KnowledgeHandler) DeleteKnowledgeFolder(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	var req DeleteKnowledgeFolderRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.Error(errors.NewBadRequestError("Invalid request parameters: " + err.Error()))
+		return
+	}
+
+	_, kbID, effectiveTenantID, permission, err := h.validateKnowledgeBaseAccess(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	if permission != types.OrgRoleAdmin && permission != types.OrgRoleEditor {
+		c.Error(errors.NewForbiddenError("No permission to delete knowledge"))
+		return
+	}
+	if err := h.requireKBOwnershipOrAdmin(c, kbID); err != nil {
+		c.Error(err)
+		return
+	}
+	ctx = context.WithValue(ctx, types.TenantIDContextKey, effectiveTenantID)
+
+	// The repository query is scoped to this tenant and KB, so every resolved id
+	// belongs to kbID - no per-id cross-KB guard is needed here.
+	ids, err := h.kgService.ListKnowledgeIDsInFolder(ctx, kbID, req.Path)
+	if err != nil {
+		if appErr, ok := errors.IsAppError(err); ok {
+			c.Error(appErr)
+			return
+		}
+		logger.ErrorWithFields(ctx, err, nil)
+		c.Error(errors.NewInternalServerError(err.Error()))
+		return
+	}
+	if len(ids) == 0 {
+		c.JSON(http.StatusOK, gin.H{
+			"success": true,
+			"data":    gin.H{"deleted_count": 0},
+		})
+		return
+	}
+	if !req.Recursive {
+		c.Error(errors.NewBadRequestError(
+			fmt.Sprintf("folder is not empty (%d documents); pass recursive=true to delete", len(ids))))
+		return
+	}
+
+	taskID, err := h.enqueueKnowledgeListDelete(ctx, effectiveTenantID, ids)
+	if err != nil {
+		logger.Errorf(ctx, "Failed to enqueue folder delete task: %v", err)
+		c.Error(errors.NewInternalServerError("Failed to enqueue folder delete task"))
+		return
+	}
+
+	logger.Infof(ctx, "Folder delete task enqueued: %s, kb_id: %s, folder: %s, count: %d",
+		taskID, secutils.SanitizeForLog(kbID), secutils.SanitizeForLog(req.Path), len(ids))
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "Folder delete task submitted",
+		"data": gin.H{
+			"task_id":       taskID,
+			"deleted_count": len(ids),
+		},
+	})
+}
+
 // dedupeKnowledgeIDs trims, drops empty and de-duplicates a batch of IDs while
 // preserving the caller's order.
 func dedupeKnowledgeIDs(raw []string) []string {

--- a/internal/router/routes_knowledge.go
+++ b/internal/router/routes_knowledge.go
@@ -76,6 +76,7 @@ func RegisterKnowledgeRoutes(r *gin.RouterGroup, handler *handler.KnowledgeHandl
 		kbRead.GET("", g.Viewer(), g.KBAccessRead("id"), handler.ListKnowledge)
 		kbRead.GET("/folders", g.Viewer(), g.KBAccessRead("id"), handler.ListKnowledgeFolders)
 		kb.PUT("/folders", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.RenameKnowledgeFolder)
+		kb.DELETE("/folders", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.DeleteKnowledgeFolder)
 		// Clearing all contents under a KB is a destructive op; gate
 		// behind Admin instead of Contributor.
 		kb.With(apiKeyFullAccess()).DELETE("", g.Admin(), g.KBAccessWrite("id"), handler.ClearKnowledgeBaseContents)

--- a/internal/types/interfaces/knowledge.go
+++ b/internal/types/interfaces/knowledge.go
@@ -99,6 +99,10 @@ type KnowledgeService interface {
 	) (int64, error)
 	// RenameKnowledgeFolder moves a folder and everything below it to a new path.
 	RenameKnowledgeFolder(ctx context.Context, kbID string, from string, to string) (int64, error)
+	// ListKnowledgeIDsInFolder returns the IDs of every document in a folder and
+	// its subtree, so a folder delete can route them through the normal delete
+	// pipeline. The empty root path is rejected.
+	ListKnowledgeIDsInFolder(ctx context.Context, kbID string, folderPath string) ([]string, error)
 	// DeleteKnowledge deletes knowledge by ID.
 	DeleteKnowledge(ctx context.Context, id string) error
 	// DeleteKnowledgeList deletes multiple knowledge entries by IDs.
@@ -280,6 +284,15 @@ type KnowledgeRepository interface {
 		from string,
 		to string,
 	) (int64, error)
+	// ListKnowledgeIDsByFolderPath returns the IDs of every entry in a folder and
+	// its descendants, so a folder delete can route them through the normal
+	// knowledge delete pipeline.
+	ListKnowledgeIDsByFolderPath(
+		ctx context.Context,
+		tenantID uint64,
+		kbID string,
+		folderPath string,
+	) ([]string, error)
 	// AminusB returns the IDs of knowledge in A that have no counterpart in B,
 	// comparing file_hash as a multiset (so duplicate-count differences and
 	// NULL/empty hashes are handled correctly, letting a clone converge).


### PR DESCRIPTION
Upstream now ships path-based knowledge folders - a folder tree with counts, rename/reparent, move-document and move-targets. The one CRUD operation missing from that set is deleting a folder, so the "browse like a file manager" view can create, rename and move folders but not remove one. This PR fills that gap.

New endpoint `DELETE /knowledge-bases/:id/knowledge/folders` with body `{ "path": "...", "recursive": bool }`, guarded by `OwnedKBOrAdmin` + `KBAccessWrite` to match the existing rename route:

- An empty or unknown folder is a no-op (`deleted_count` 0).
- A folder that still holds documents is only deleted when `recursive=true`; otherwise it returns 400 with the document count, mirroring `rm` vs `rm -r`.
- With `recursive=true` every document in the subtree is routed through the existing asynchronous delete pipeline (`enqueueKnowledgeListDelete`), so chunks, embeddings and stored files are torn down rather than orphaned by a bare folder-column wipe.
- The empty root path is rejected, so a folder delete can never turn into a whole-knowledge-base wipe - clearing a knowledge base stays the job of `ClearKnowledgeBaseContents`.

The subtree resolver reuses the same `folder_path = ? OR folder_path LIKE ?/% ESCAPE` predicate as the existing rename and skips rows already mid-deletion. Tests cover the service layer (path normalization, root rejection) and the repository on real SQLite (subtree matching, prefix-sibling exclusion so "docsets" is not swept in under "docs", deleting-status skip, unknown folder).

This replaces the entity-table folder proposal that this PR originally carried, which upstream's path-based folder implementation has since made unnecessary. Reframed as a complement to that implementation rather than a competing one.