### PR TITLE
feat(quota): implement user-level storage quota with admin exemption

### DIFF
--- a/frontend/src/api/tenant/members.ts
+++ b/frontend/src/api/tenant/members.ts
@@ -17,6 +17,8 @@ export interface TenantMember {
   status: TenantMemberStatus
   invited_by?: string | null
   joined_at: string
+  storage_quota?: number
+  storage_used?: number
 }
 
 export interface ListMembersResponse {
@@ -150,4 +152,20 @@ export async function removeMember(
  */
 export async function leaveTenant(tenantId: number): Promise<SimpleResponse> {
   return (await post(`/api/v1/tenants/${tenantId}/leave`)) as unknown as SimpleResponse
+}
+
+/**
+ * Update a member's personal storage quota (bytes).
+ * Backend: PUT /api/v1/tenants/:id/members/:user_id/quota (Admin+).
+ * Pass 0 to remove the individual limit.
+ */
+export async function updateMemberQuota(
+  tenantId: number,
+  userId: string,
+  storageQuota: number,
+): Promise<SimpleResponse> {
+  return (await put(
+    `/api/v1/tenants/${tenantId}/members/${userId}/quota`,
+    { storage_quota: storageQuota },
+  )) as unknown as SimpleResponse
 }

--- a/frontend/src/components/knowledge-processing-timeline.vue
+++ b/frontend/src/components/knowledge-processing-timeline.vue
@@ -442,6 +442,19 @@ function localizedErrorSuggestion(code?: string): string {
   return fallback === 'knowledgeStages.errorCode.UNKNOWN_SUGGESTION' ? '' : fallback
 }
 
+// localizeQuotaError swaps a raw backend storage-quota message for a
+// localized, actionable hint. The user-level quota message is checked
+// first (it is a superset substring of the tenant message) so a
+// per-user limit shows "contact admin to raise your quota" while a
+// tenant-wide exhaustion shows the distinct tenant message.
+function localizeQuotaError(msg?: string): string {
+  if (!msg) return msg ?? ''
+  const lower = msg.toLowerCase()
+  if (lower.includes('user storage quota exceeded')) return t('knowledgeBase.quotaExceeded')
+  if (lower.includes('storage quota exceeded')) return t('knowledgeBase.tenantQuotaExceeded')
+  return msg
+}
+
 async function copyValue(value: any) {
   try {
     const text = typeof value === 'string' ? value : JSON.stringify(value, null, 2)
@@ -1496,7 +1509,7 @@ const processConfigLines = computed<string[]>(() => {
               </div>
               <div class="kp-last-error-suggestion">{{ localizedErrorSuggestion(data.last_error.error_code) }}</div>
               <div v-if="data.last_error.error_message" class="kp-last-error-raw kp-mono">{{
-                data.last_error.error_message }}
+                localizeQuotaError(data.last_error.error_message) }}
               </div>
             </div>
           </div>
@@ -1747,7 +1760,7 @@ const processConfigLines = computed<string[]>(() => {
                       selectedRow.node.error_code }}</span>
                   </div>
                   <pre v-if="selectedRow.node.error_message"
-                    class="kp-error-msg kp-mono">{{ selectedRow.node.error_message }}</pre>
+                    class="kp-error-msg kp-mono">{{ localizeQuotaError(selectedRow.node.error_message) }}</pre>
                 </div>
 
                 <div v-if="!selectedRow.node.span_id && !selectedRow.node.started_at" class="kp-detail-hint">

--- a/frontend/src/hooks/useKnowledgeBase.ts
+++ b/frontend/src/hooks/useKnowledgeBase.ts
@@ -164,14 +164,28 @@ export default function (knowledgeBaseId?: string) {
           MessagePlugin.info(t('knowledgeBase.uploadSuccess'));
           getKnowled({ page: 1, page_size: 35 }, currentKbId);
         } else {
-          const errorMessage = result.error?.message || result.message || t('knowledgeBase.uploadFailed');
-          MessagePlugin.error(result.code === 'duplicate_file' ? t('knowledgeBase.fileExists') : errorMessage);
+          let errorMessage = result.error?.message || result.message || t('knowledgeBase.uploadFailed');
+          if (result.code === 'duplicate_file') {
+            errorMessage = t('knowledgeBase.fileExists');
+          } else if (errorMessage?.toLowerCase().includes('user storage quota exceeded')) {
+            errorMessage = t('knowledgeBase.quotaExceeded');
+          } else if (errorMessage?.toLowerCase().includes('storage quota exceeded')) {
+            errorMessage = t('knowledgeBase.tenantQuotaExceeded');
+          }
+          MessagePlugin.error(errorMessage);
         }
         uploadInput.value.value = "";
       })
       .catch((err: any) => {
-        const errorMessage = err.error?.message || err.message || t('knowledgeBase.uploadFailed');
-        MessagePlugin.error(err.code === 'duplicate_file' ? t('knowledgeBase.fileExists') : errorMessage);
+        let errorMessage = err.error?.message || err.message || t('knowledgeBase.uploadFailed');
+        if (err.code === 'duplicate_file') {
+          errorMessage = t('knowledgeBase.fileExists');
+        } else if (errorMessage?.toLowerCase().includes('user storage quota exceeded')) {
+          errorMessage = t('knowledgeBase.quotaExceeded');
+        } else if (errorMessage?.toLowerCase().includes('storage quota exceeded')) {
+          errorMessage = t('knowledgeBase.tenantQuotaExceeded');
+        }
+        MessagePlugin.error(errorMessage);
         uploadInput.value.value = "";
       });
   };

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -450,6 +450,8 @@ export default {
     uploadFailed: 'File upload failed!',
     docActionUnsupported: 'This knowledge base type does not support this action',
     fileExists: 'File already exists',
+    quotaExceeded: 'User storage quota exceeded, please contact your tenant admin to increase the storage quota',
+    tenantQuotaExceeded: 'Tenant storage is full, please contact your tenant admin to free up or expand storage',
     uploadingMultiple: 'Uploading {total} files...',
     uploadAllSuccess: 'Successfully uploaded {count} files!',
     uploadPartialSuccess: 'Upload completed: {success} succeeded, {fail} failed',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -449,6 +449,8 @@ export default {
     uploadSuccess: "文件上传成功！",
     uploadFailed: "文件上传失败！",
     fileExists: "文件已存在",
+    quotaExceeded: "您的可用空间配额不足，请联系团队管理员扩容",
+    tenantQuotaExceeded: "团队存储空间已满，请联系团队管理员清理或扩容",
     uploadingMultiple: "正在上传 {total} 个文件...",
     uploadAllSuccess: "成功上传 {count} 个文件！",
     uploadPartialSuccess: "上传完成：成功 {success} 个，失败 {fail} 个",

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -1453,6 +1453,10 @@ const executeUploadBatch = async (
           }
           if (responseData?.code === 'duplicate_file' || responseData?.error?.code === 'duplicate_file') {
             errorMessage = t('knowledgeBase.fileExists');
+          } else if (errorMessage?.toLowerCase().includes('user storage quota exceeded')) {
+            errorMessage = t('knowledgeBase.quotaExceeded');
+          } else if (errorMessage?.toLowerCase().includes('storage quota exceeded')) {
+            errorMessage = t('knowledgeBase.tenantQuotaExceeded');
           }
           MessagePlugin.error(errorMessage);
         }
@@ -1463,6 +1467,10 @@ const executeUploadBatch = async (
         let errorMessage = error?.error?.message || error?.message || t('knowledgeBase.uploadFailed');
         if (error?.code === 'duplicate_file') {
           errorMessage = t('knowledgeBase.fileExists');
+        } else if (errorMessage?.toLowerCase().includes('user storage quota exceeded')) {
+          errorMessage = t('knowledgeBase.quotaExceeded');
+        } else if (errorMessage?.toLowerCase().includes('storage quota exceeded')) {
+          errorMessage = t('knowledgeBase.tenantQuotaExceeded');
         }
         MessagePlugin.error(errorMessage);
       }

--- a/frontend/src/views/settings/TenantMembers.vue
+++ b/frontend/src/views/settings/TenantMembers.vue
@@ -146,6 +146,7 @@
                      Icon-only with tooltip so two actions ("copy" +
                      "revoke") fit inside the actions column without
                      clipping; the full label was too wide. -->
+
                 <t-tooltip v-if="row.status === 'pending' && row.invite_url"
                   :content="$t('tenantInvitation.copyLink')" placement="top">
                   <t-button shape="square" variant="text" size="small"
@@ -351,6 +352,11 @@
               </template>
               <template #joined_at="{ row }">{{ formatDate(row.joined_at) }}</template>
               <template #actions="{ row }">
+                <t-tooltip v-if="canManage" content="修改空间限额" placement="top">
+                  <t-button theme="primary" shape="square" variant="text" size="small" @click.stop="openQuotaDialog(row)">
+                    <template #icon><t-icon name="server" /></template>
+                  </t-button>
+                </t-tooltip>
                 <t-popconfirm
                   v-if="canManage && row.user_id !== currentUserId"
                   :content="$t('tenantMember.remove.confirmBody', { name: row.username || row.email })"
@@ -364,6 +370,11 @@
                     </t-button>
                   </t-tooltip>
                 </t-popconfirm>
+              </template>
+              <template #storage="{row}">
+                <span class = "member-storage">
+                 {{ formatBytes(row.storage_used) }}/{{ (!row.storage_quota || row.storage_quota === 0 ) ? '无限制' : formatBytes(row.storage_quota)}}
+                 </span>
               </template>
             </t-table>
           </div>
@@ -507,6 +518,30 @@
         </div>
       </div>
     </t-drawer>
+    <t-dialog
+        v-model:visible="quotaDialogVisible"
+        header="修改空间限额"
+        :confirm-btn="{ content: '确定', theme: 'primary', loading: updatingQuota }"
+        :cancel-btn="'取消'"
+        @confirm="submitQuotaUpdate"
+      >
+        <div style="padding: 16px 0;">
+          <t-form :data="quotaForm" :label-width="100">
+            <t-form-item label="空间配额 (GB)" name="quotaGB">
+              <t-input-number 
+                v-model="quotaForm.quotaGB" 
+                :min="0" 
+                :max="1048576"
+                :step="1" 
+                auto-width
+              />
+              <div style="margin-left: 12px; color: var(--td-text-color-secondary); font-size: 12px;">
+                填 0 代表不限制
+              </div>
+            </t-form-item>
+          </t-form>
+        </div>
+      </t-dialog>
   </div>
 </template>
 
@@ -519,6 +554,7 @@ import {
   listMembers,
   updateMemberRole,
   removeMember,
+  updateMemberQuota,
   type TenantMember,
   type TenantRole,
 } from '@/api/tenant/members'
@@ -712,6 +748,13 @@ const roleMatrix: Record<TenantRole, RolePerm[]> = {
   ],
 }
 
+const quotaDialogVisible = ref(false)
+const updatingQuota = ref(false)
+const currentQuotaMember = ref<TenantMember | null>(null)
+const quotaForm = reactive({quotaGB:0})
+
+
+
 function roleMatrixIcon(role: TenantRole): string {
   switch (role) {
     case 'owner':
@@ -725,9 +768,49 @@ function roleMatrixIcon(role: TenantRole): string {
   }
 }
 
+function formatBytes(bytes?: number): string {
+  if (bytes === undefined || bytes === null || bytes === 0) return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+}
+
+function openQuotaDialog(row: TenantMember) {
+  currentQuotaMember.value = row
+  quotaForm.quotaGB = row.storage_quota ? Number((row.storage_quota / 1024 / 1024 / 1024).toFixed(2)) : 0
+  quotaDialogVisible.value = true
+}
+
+async function submitQuotaUpdate() {
+  if (!currentQuotaMember.value) return
+
+  updatingQuota.value = true
+  try {
+    const quotaBytes = Math.round(quotaForm.quotaGB * 1024 * 1024 * 1024)
+    if (!Number.isSafeInteger(quotaBytes)) {
+      MessagePlugin.error('输入的额度过大，超出系统安全计算范围')
+      return
+    }
+    const resp = await updateMemberQuota(activeTenantId.value, currentQuotaMember.value.user_id, quotaBytes)
+    if (resp.success) {
+      MessagePlugin.success('配额更新成功')
+      quotaDialogVisible.value = false
+      await loadMembers()
+    } else {
+      MessagePlugin.error(resp.message || '配额更新失败')
+    }
+  } catch (err: any) {
+    MessagePlugin.error(err?.message || '请求失败')
+  } finally {
+    updatingQuota.value = false
+  }
+}
+
 const columns = computed(() => [
   { colKey: 'member', title: t('tenantMember.columns.member'), ellipsis: true, minWidth: 132 },
   { colKey: 'role', title: t('tenantMember.columns.role'), width: 128 },
+  { colKey: 'storage', title: '已用/配额', width: 150 },
   { colKey: 'joined_at', title: t('tenantMember.columns.joinedAt'), width: 154 },
   { colKey: 'actions', title: t('tenantMember.columns.operations'), width: 88, align: 'left' },
 ])

--- a/internal/application/repository/tenant_member.go
+++ b/internal/application/repository/tenant_member.go
@@ -290,3 +290,31 @@ func (r *tenantMemberRepository) HasAnyMembers(ctx context.Context, tenantID uin
 	}
 	return true, nil
 }
+
+func (r *tenantMemberRepository) AdjustUserStorageUsed(ctx context.Context, userID string, tenantID uint64, delta int64) error {
+	res := r.db.WithContext(ctx).
+		Model(&types.TenantMember{}).
+		Where("user_id = ? AND tenant_id = ? AND deleted_at IS NULL", userID, tenantID).
+		UpdateColumn("storage_used", gorm.Expr("CASE WHEN storage_used + ? < 0 THEN 0 ELSE storage_used + ? END", delta, delta))
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+func (r *tenantMemberRepository) UpdateStorageQuota(ctx context.Context, userID string, tenantID uint64, quotaBytes int64) error {
+	res := r.db.WithContext(ctx).
+		Model(&types.TenantMember{}).
+		Where("user_id = ? AND tenant_id = ? AND deleted_at IS NULL", userID, tenantID).
+		Update("storage_quota", quotaBytes)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -42,29 +42,30 @@ var (
 // knowledgeService implements the knowledge service interface
 // service 实现知识服务接口
 type knowledgeService struct {
-	config          *config.Config
-	retrieveEngine  interfaces.RetrieveEngineRegistry
-	ownership       retriever.TenantStoreOwnership
-	repo            interfaces.KnowledgeRepository
-	kbService       interfaces.KnowledgeBaseService
-	tenantRepo      interfaces.TenantRepository
-	tenantService   interfaces.TenantService
-	documentReader  interfaces.DocumentReader
-	chunkService    interfaces.ChunkService
-	chunkRepo       interfaces.ChunkRepository
-	tagRepo         interfaces.KnowledgeTagRepository
-	tagService      interfaces.KnowledgeTagService
-	fileSvc         interfaces.FileService
-	storageResolver interfaces.StorageBackendResolver
-	resourceCatalog interfaces.ResourceCatalog
-	modelService    interfaces.ModelService
-	task            interfaces.TaskEnqueuer
-	taskInspector   interfaces.TaskInspector
-	graphEngine     interfaces.RetrieveGraphRepository
-	redisClient     *redis.Client
-	kbShareService  interfaces.KBShareService
-	imageResolver   *docparser.ImageResolver
-	taskPendingRepo interfaces.TaskPendingOpsRepository
+	config           *config.Config
+	retrieveEngine   interfaces.RetrieveEngineRegistry
+	ownership        retriever.TenantStoreOwnership
+	repo             interfaces.KnowledgeRepository
+	kbService        interfaces.KnowledgeBaseService
+	tenantRepo       interfaces.TenantRepository
+	tenantService    interfaces.TenantService
+	tenantMemberRepo interfaces.TenantMemberRepository
+	documentReader   interfaces.DocumentReader
+	chunkService     interfaces.ChunkService
+	chunkRepo        interfaces.ChunkRepository
+	tagRepo          interfaces.KnowledgeTagRepository
+	tagService       interfaces.KnowledgeTagService
+	fileSvc          interfaces.FileService
+	storageResolver  interfaces.StorageBackendResolver
+	resourceCatalog  interfaces.ResourceCatalog
+	modelService     interfaces.ModelService
+	task             interfaces.TaskEnqueuer
+	taskInspector    interfaces.TaskInspector
+	graphEngine      interfaces.RetrieveGraphRepository
+	redisClient      *redis.Client
+	kbShareService   interfaces.KBShareService
+	imageResolver    *docparser.ImageResolver
+	taskPendingRepo  interfaces.TaskPendingOpsRepository
 
 	// In-memory fallbacks for Lite mode (no Redis)
 	memFAQProgress      sync.Map // taskID -> *types.FAQImportProgress
@@ -94,6 +95,7 @@ func NewKnowledgeService(
 	kbService interfaces.KnowledgeBaseService,
 	tenantRepo interfaces.TenantRepository,
 	tenantService interfaces.TenantService,
+	tenantMemberRepo interfaces.TenantMemberRepository,
 	chunkService interfaces.ChunkService,
 	chunkRepo interfaces.ChunkRepository,
 	tagRepo interfaces.KnowledgeTagRepository,
@@ -117,33 +119,34 @@ func NewKnowledgeService(
 	audit interfaces.AuditLogService,
 ) (interfaces.KnowledgeService, error) {
 	return &knowledgeService{
-		config:          config,
-		repo:            repo,
-		kbService:       kbService,
-		tenantRepo:      tenantRepo,
-		tenantService:   tenantService,
-		documentReader:  documentReader,
-		chunkService:    chunkService,
-		chunkRepo:       chunkRepo,
-		tagRepo:         tagRepo,
-		tagService:      tagService,
-		fileSvc:         fileSvc,
-		storageResolver: storageResolver,
-		resourceCatalog: resourceCatalog,
-		modelService:    modelService,
-		task:            task,
-		taskInspector:   taskInspector,
-		graphEngine:     graphEngine,
-		retrieveEngine:  retrieveEngine,
-		ownership:       ownership,
-		redisClient:     redisClient,
-		kbShareService:  kbShareService,
-		imageResolver:   imageResolver,
-		wikiRepo:        wikiRepo,
-		wikiService:     wikiService,
-		taskPendingRepo: taskPendingRepo,
-		spanTracker:     spanTracker,
-		audit:           audit,
+		config:           config,
+		repo:             repo,
+		kbService:        kbService,
+		tenantRepo:       tenantRepo,
+		tenantService:    tenantService,
+		tenantMemberRepo: tenantMemberRepo,
+		documentReader:   documentReader,
+		chunkService:     chunkService,
+		chunkRepo:        chunkRepo,
+		tagRepo:          tagRepo,
+		tagService:       tagService,
+		fileSvc:          fileSvc,
+		storageResolver:  storageResolver,
+		resourceCatalog:  resourceCatalog,
+		modelService:     modelService,
+		task:             task,
+		taskInspector:    taskInspector,
+		graphEngine:      graphEngine,
+		retrieveEngine:   retrieveEngine,
+		ownership:        ownership,
+		redisClient:      redisClient,
+		kbShareService:   kbShareService,
+		imageResolver:    imageResolver,
+		wikiRepo:         wikiRepo,
+		wikiService:      wikiService,
+		taskPendingRepo:  taskPendingRepo,
+		spanTracker:      spanTracker,
+		audit:            audit,
 	}, nil
 }
 

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -23,6 +23,66 @@ import (
 	"github.com/hibiken/asynq"
 )
 
+// resolveChargeUserID determines which user should be charged for storage quota.
+// Priority: KB CreatorID (so async workers enforce the right limit) > context UserID.
+// Returns empty string if no chargeable user is found (e.g., synthetic system user).
+func resolveChargeUserID(ctx context.Context, kb *types.KnowledgeBase) string {
+	chargeUserID := ""
+	if kb != nil {
+		chargeUserID = kb.CreatorID
+	}
+	if chargeUserID == "" {
+		if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
+			chargeUserID = uid
+		}
+	}
+	return chargeUserID
+}
+
+// shouldEnforceUserQuota checks whether user-level storage quota should be enforced
+// for the current request. Returns false for Owner/Admin roles (they need to manage
+// tenant resources without personal quota limits), true for Contributors/Viewers.
+func shouldEnforceUserQuota(ctx context.Context) bool {
+	role := types.TenantRoleFromContext(ctx)
+	// Owner and Admin are exempt from personal storage quotas
+	return role != types.TenantRoleOwner && role != types.TenantRoleAdmin
+}
+
+// checkUserStorageQuota enforces user-level storage quota with admin exemption.
+// knownSize is the incoming data size in bytes; pass 0 if unknown (soft check only).
+func (s *knowledgeService) checkUserStorageQuota(
+	ctx context.Context, kb *types.KnowledgeBase, tenantID uint64, knownSize int64,
+) error {
+	// Exempt Owner and Admin roles from user quota checks
+	if !shouldEnforceUserQuota(ctx) {
+		return nil
+	}
+
+	chargeUserID := resolveChargeUserID(ctx, kb)
+	if chargeUserID == "" {
+		return nil // No chargeable user (e.g., synthetic system user)
+	}
+
+	member, err := s.tenantMemberRepo.Get(ctx, chargeUserID, tenantID)
+	if err != nil || member == nil || member.StorageQuota == 0 {
+		return nil // No quota configured or member not found
+	}
+
+	// If we have known incoming size, check if adding it would exceed quota
+	if knownSize > 0 {
+		if member.StorageUsed+knownSize > member.StorageQuota {
+			return types.NewUserStorageQuotaExceededError()
+		}
+	} else {
+		// Soft check: reject if already at/over quota
+		if member.StorageUsed >= member.StorageQuota {
+			return types.NewUserStorageQuotaExceededError()
+		}
+	}
+
+	return nil
+}
+
 // CreateKnowledgeFromFile creates a knowledge entry from an uploaded file
 func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 	kbID string, file *multipart.FileHeader, metadata map[string]string, enableMultimodel *bool, customFileName string, tagIDs []string, channel string,
@@ -101,9 +161,14 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 
 	// Check storage quota
 	tenantInfo := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
-	if tenantInfo.StorageQuota > 0 && tenantInfo.StorageUsed >= tenantInfo.StorageQuota {
+	if tenantInfo.StorageQuota > 0 && tenantInfo.StorageUsed+file.Size > tenantInfo.StorageQuota {
 		logger.Error(ctx, "Storage quota exceeded")
 		return nil, types.NewStorageQuotaExceededError()
+	}
+
+	// Check user storage quota (charge KB owner, exempt Owner/Admin roles)
+	if err := s.checkUserStorageQuota(ctx, kb, tenantID, file.Size); err != nil {
+		return nil, err
 	}
 
 	// Convert metadata to JSON format if provided
@@ -403,6 +468,12 @@ func (s *knowledgeService) CreateKnowledgeFromURL(ctx context.Context,
 		return nil, types.NewStorageQuotaExceededError()
 	}
 
+	// Check user storage quota (charge KB owner, exempt Owner/Admin roles).
+	// No size estimate available for URL fetch, so enforce soft "already over" gate.
+	if err := s.checkUserStorageQuota(ctx, kb, tenantID, 0); err != nil {
+		return nil, err
+	}
+
 	// Create knowledge record
 	logger.Info(ctx, "Creating knowledge record")
 	knowledge := &types.Knowledge{
@@ -646,6 +717,11 @@ func (s *knowledgeService) createKnowledgeFromFileURL(
 		return nil, types.NewStorageQuotaExceededError()
 	}
 
+	// Check user storage quota (charge KB owner, exempt Owner/Admin roles)
+	if err := s.checkUserStorageQuota(ctx, kb, tenantID, 0); err != nil {
+		return nil, err
+	}
+
 	// Create knowledge record
 	knowledge := &types.Knowledge{
 		ID:               uuid.New().String(),
@@ -811,6 +887,14 @@ func (s *knowledgeService) CreateKnowledgeFromManual(ctx context.Context,
 	}
 
 	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
+
+	// Check user storage quota (charge KB owner, exempt Owner/Admin roles).
+	// Actual storage size is unknown until chunking+embedding in async worker,
+	// so enforce soft "already over" gate before persisting the row.
+	if err := s.checkUserStorageQuota(ctx, kb, tenantID, 0); err != nil {
+		return nil, err
+	}
+
 	now := time.Now()
 	title := safeTitle
 	if title == "" {
@@ -921,6 +1005,14 @@ func (s *knowledgeService) createKnowledgeFromPassageInternal(ctx context.Contex
 	kb, err := s.kbService.GetKnowledgeBaseByID(ctx, kbID)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to get knowledge base: %v", err)
+		return nil, err
+	}
+
+	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
+
+	// Check user storage quota (charge KB owner, exempt Owner/Admin roles).
+	// Passage path has no known incoming size, so enforce soft "already over" gate.
+	if err := s.checkUserStorageQuota(ctx, kb, tenantID, 0); err != nil {
 		return nil, err
 	}
 

--- a/internal/application/service/knowledge_delete.go
+++ b/internal/application/service/knowledge_delete.go
@@ -197,6 +197,13 @@ func (s *knowledgeService) DeleteKnowledge(ctx context.Context, id string) error
 	if err := s.tenantRepo.AdjustStorageUsed(ctx, tenantInfo.ID, -knowledge.StorageSize); err != nil {
 		logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge update tenant storage used failed")
 	}
+	// update user's storage usage (charge KB owner when available)
+	chargeUserID := resolveChargeUserID(ctx, kb)
+	if chargeUserID != "" {
+		if err := s.tenantMemberRepo.AdjustUserStorageUsed(ctx, chargeUserID, tenantInfo.ID, -knowledge.StorageSize); err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge update user storage used failed")
+		}
+	}
 	recordKBActivity(ctx, s.audit, tenantID, knowledge.KnowledgeBaseID, types.AuditActionKnowledgeDeleted,
 		"knowledge", knowledge.ID, types.AuditOutcomeSuccess,
 		map[string]any{"title": knowledge.Title, "type": knowledge.Type})
@@ -668,6 +675,32 @@ func (s *knowledgeService) DeleteKnowledgeList(ctx context.Context, ids []string
 	if err := s.tenantRepo.AdjustStorageUsed(ctx, tenantInfo.ID, storageAdjust); err != nil {
 		logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge update tenant storage used failed")
 	}
+	// update per-user storage usage (charge KB owner when available).
+	// kbCreatorCache avoids re-querying each KB once per knowledge row in the batch.
+	kbCreatorCache := make(map[string]string) // kbID → CreatorID
+	userDeltas := make(map[string]int64)      // userID → total delta
+	for _, knowledge := range knowledgeList {
+		chargeUID, cached := kbCreatorCache[knowledge.KnowledgeBaseID]
+		if !cached {
+			if kbObj, err := s.kbService.GetKnowledgeBaseByID(ctx, knowledge.KnowledgeBaseID); err == nil && kbObj != nil {
+				chargeUID = kbObj.CreatorID
+			}
+			kbCreatorCache[knowledge.KnowledgeBaseID] = chargeUID
+		}
+		if chargeUID == "" {
+			if uid, ok := types.UserIDFromContext(ctx); ok && !types.IsSyntheticUserID(uid) {
+				chargeUID = uid
+			}
+		}
+		if chargeUID != "" {
+			userDeltas[chargeUID] -= knowledge.StorageSize
+		}
+	}
+	for uid, delta := range userDeltas {
+		if err := s.tenantMemberRepo.AdjustUserStorageUsed(ctx, uid, tenantInfo.ID, delta); err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledgeList update user storage used failed for user %s", uid)
+		}
+	}
 	byKB := make(map[string][]*types.Knowledge)
 	for i := range knowledgeList {
 		knowledge := knowledgeList[i]
@@ -756,6 +789,13 @@ func (s *knowledgeService) cleanupKnowledgeResources(ctx context.Context, knowle
 
 	// Delete extracted images after chunks are deleted
 	deleteExtractedImages(ctx, fileSvc, imageURLs)
+	// update user's storage usage (charge KB owner when available)
+	chargeUserID := resolveChargeUserID(ctx, kb)
+	if chargeUserID != "" {
+		if err := s.tenantMemberRepo.AdjustUserStorageUsed(ctx, chargeUserID, tenantInfo.ID, -knowledge.StorageSize); err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Errorf("cleanupKnowledgeResources update user storage used failed")
+		}
+	}
 
 	namespace := types.NameSpace{KnowledgeBase: knowledge.KnowledgeBaseID, Knowledge: knowledge.ID}
 	if err := s.graphEngine.DelGraph(ctx, []types.NameSpace{namespace}); err != nil {

--- a/internal/application/service/knowledge_faq_import.go
+++ b/internal/application/service/knowledge_faq_import.go
@@ -2044,6 +2044,14 @@ func (s *knowledgeService) indexFAQChunks(ctx context.Context,
 			return types.NewStorageQuotaExceededError()
 		}
 	}
+	// check user storage quota (charge KB owner when available so async workers still enforce limits)
+	chargeUserID := resolveChargeUserID(ctx, kb)
+	if chargeUserID != "" {
+		member, err := s.tenantMemberRepo.Get(ctx, chargeUserID, tenantInfo.ID)
+		if err == nil && member != nil && member.StorageQuota > 0 && member.StorageUsed+size > member.StorageQuota {
+			return types.NewUserStorageQuotaExceededError()
+		}
+	}
 
 	// 删除旧向量
 	var deleteDuration time.Duration
@@ -2057,7 +2065,6 @@ func (s *knowledgeService) indexFAQChunks(ctx context.Context,
 			logger.Debugf(ctx, "indexFAQChunks: deleted old vectors for %d chunks in %v", len(chunkIDs), deleteDuration)
 		}
 	}
-
 	// 批量索引（这里可能是性能瓶颈）
 	batchIndexStartTime := time.Now()
 	if err := retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfo); err != nil {
@@ -2075,6 +2082,13 @@ func (s *knowledgeService) indexFAQChunks(ctx context.Context,
 		adjustStartTime := time.Now()
 		if err := s.tenantRepo.AdjustStorageUsed(ctx, tenantInfo.ID, size); err == nil {
 			tenantInfo.StorageUsed += size
+		}
+		// update user's storage usage (charge KB owner when available so async workers still update usage)
+		chargeUserID := resolveChargeUserID(ctx, kb)
+		if chargeUserID != "" {
+			if err := s.tenantMemberRepo.AdjustUserStorageUsed(ctx, chargeUserID, tenantInfo.ID, size); err != nil {
+				logger.GetLogger(ctx).WithField("error", err).Errorf("indexFAQChunks update user storage used failed")
+			}
 		}
 		knowledge.StorageSize += size
 		adjustDuration := time.Since(adjustStartTime)
@@ -2137,6 +2151,15 @@ func (s *knowledgeService) deleteFAQChunkVectors(ctx context.Context,
 	}
 
 	size := retrieveEngine.EstimateStorageSize(ctx, embeddingModel, indexInfo)
+
+	// update user's storage usage (charge KB owner when available)
+	chargeUserID := resolveChargeUserID(ctx, kb)
+	if chargeUserID != "" {
+		if err := s.tenantMemberRepo.AdjustUserStorageUsed(ctx, chargeUserID, tenantInfo.ID, -size); err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Errorf("deleteFAQChunkVectors update user storage used failed")
+		}
+	}
+
 	if err := retrieveEngine.DeleteByChunkIDList(ctx, chunkIDs, embeddingModel.GetDimensions(), types.KnowledgeTypeFAQ); err != nil {
 		return err
 	}

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -99,15 +99,23 @@ func (s *knowledgeService) cloneKnowledge(
 		logger.GetLogger(ctx).WithField("error", err).Errorf("MoveKnowledge create knowledge failed")
 		return
 	}
+	if err = s.CloneChunk(ctx, src, dst); err != nil {
+		logger.GetLogger(ctx).WithField("knowledge_id", dst.ID).
+			WithField("error", err).Errorf("MoveKnowledge move chunks failed")
+		return
+	}
+
 	tenantInfo.StorageUsed += dst.StorageSize
 	if err = s.tenantRepo.AdjustStorageUsed(ctx, tenantInfo.ID, dst.StorageSize); err != nil {
 		logger.GetLogger(ctx).WithField("error", err).Errorf("MoveKnowledge update tenant storage used failed")
 		return
 	}
-	if err = s.CloneChunk(ctx, src, dst); err != nil {
-		logger.GetLogger(ctx).WithField("knowledge_id", dst.ID).
-			WithField("error", err).Errorf("MoveKnowledge move chunks failed")
-		return
+	// update user's storage usage (charge KB owner when available)
+	chargeUserID := resolveChargeUserID(ctx, targetKB)
+	if chargeUserID != "" {
+		if err := s.tenantMemberRepo.AdjustUserStorageUsed(ctx, chargeUserID, tenantInfo.ID, dst.StorageSize); err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Errorf("cloneKnowledge update user storage used failed")
+		}
 	}
 	return
 }
@@ -571,6 +579,23 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			}
 		}
 
+		// check user storage quota (charge KB owner when available so async workers still enforce limits)
+		chargeUserID := resolveChargeUserID(ctx, kb)
+		if chargeUserID != "" {
+			member, err := s.tenantMemberRepo.Get(ctx, chargeUserID, tenantInfo.ID)
+			if err == nil && member != nil && member.StorageQuota > 0 && member.StorageUsed+totalStorageSize > member.StorageQuota {
+				knowledge.ParseStatus = types.ParseStatusFailed
+				// Use the canonical English quota message so the frontend
+				// timeline (which localizes on the "storage quota exceeded"
+				// substring) can surface a translated hint instead of a raw
+				// backend string.
+				knowledge.ErrorMessage = types.NewUserStorageQuotaExceededError().Error()
+				knowledge.UpdatedAt = time.Now()
+				s.repo.UpdateKnowledge(ctx, knowledge)
+				return
+			}
+		}
+
 		// Check again before batch indexing (heavy operation).
 		// deleting → row is going away anyway, drop the chunks we just wrote.
 		// cancelled → user wants to keep what was already persisted, just stop.
@@ -698,6 +723,14 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks update tenant storage used failed")
 	}
 	logger.GetLogger(ctx).Infof("processChunks successfully")
+
+	// update user's storage usage (charge KB owner when available so async workers still update usage)
+	chargeUserID := resolveChargeUserID(ctx, kb)
+	if chargeUserID != "" {
+		if err := s.tenantMemberRepo.AdjustUserStorageUsed(ctx, chargeUserID, tenantInfo.ID, totalStorageSize); err != nil {
+			logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks update user storage used failed")
+		}
+	}
 }
 
 // defaultMaxInputChars is the default maximum characters used as input for summary generation.

--- a/internal/application/service/tenant_member.go
+++ b/internal/application/service/tenant_member.go
@@ -62,6 +62,9 @@ var (
 	// the tenant.
 	ErrAPIKeyCannotAssignOwner = errors.New("API keys cannot assign the owner role")
 
+	// ErrInvalidStorageQuota is returned when the storage quota is invalid (e.g. negative or less than used).
+	ErrInvalidStorageQuota = errors.New("invalid storage quota")
+
 	// ErrLastOwner is returned when an operation would leave the tenant
 	// without an active Owner. Demoting the last Owner or removing them
 	// is forbidden; an explicit ownership transfer must happen first.
@@ -420,4 +423,30 @@ func (s *tenantMemberService) emitRemovalAudit(
 		TargetUserID: targetUserID,
 		Outcome:      types.AuditOutcomeSuccess,
 	})
+}
+
+// UpdateMemberStorageQuota sets the personal storage quota for a user
+// within the given tenant. quotaBytes=0 means "no individual limit".
+// Validates: quotaBytes >= 0, and if quotaBytes > 0 it must be >= the
+// user's current StorageUsed.
+func (s *tenantMemberService) UpdateMemberStorageQuota(
+	ctx context.Context,
+	userID string,
+	tenantID uint64,
+	quotaBytes int64,
+) error {
+	if quotaBytes < 0 {
+		return ErrInvalidStorageQuota
+	}
+	member, err := s.repo.Get(ctx, userID, tenantID)
+	if err != nil {
+		return err
+	}
+	if member == nil {
+		return ErrMembershipNotFound
+	}
+	if quotaBytes > 0 && quotaBytes < member.StorageUsed {
+		return ErrInvalidStorageQuota
+	}
+	return s.repo.UpdateStorageQuota(ctx, userID, tenantID, quotaBytes)
 }

--- a/internal/application/service/tenant_member_test.go
+++ b/internal/application/service/tenant_member_test.go
@@ -248,6 +248,38 @@ func (r *fakeTenantMemberRepo) RemoveOwnerAtomically(
 	return nil
 }
 
+// AdjustUserStorageUsed mirrors the production repo's clamp-to-0
+// semantics: storage_used never goes negative. Delta may be negative
+// (delete) or positive (index/clone).
+func (r *fakeTenantMemberRepo) AdjustUserStorageUsed(
+	ctx context.Context, userID string, tenantID uint64, delta int64,
+) error {
+	for _, e := range r.rows {
+		if e.UserID == userID && e.TenantID == tenantID && !e.DeletedAt.Valid {
+			e.StorageUsed += delta
+			if e.StorageUsed < 0 {
+				e.StorageUsed = 0
+			}
+			return nil
+		}
+	}
+	return gormErrRecordNotFound
+}
+
+// UpdateStorageQuota updates the per-user storage quota. quotaBytes=0
+// means "no individual limit".
+func (r *fakeTenantMemberRepo) UpdateStorageQuota(
+	ctx context.Context, userID string, tenantID uint64, quotaBytes int64,
+) error {
+	for _, e := range r.rows {
+		if e.UserID == userID && e.TenantID == tenantID && !e.DeletedAt.Valid {
+			e.StorageQuota = quotaBytes
+			return nil
+		}
+	}
+	return gormErrRecordNotFound
+}
+
 // Compile-time guard so the test stays in sync with the interface.
 var _ interfaces.TenantMemberRepository = (*fakeTenantMemberRepo)(nil)
 
@@ -504,5 +536,68 @@ func TestTenantRole_HasPermission(t *testing.T) {
 		if got := c.caller.HasPermission(c.required); got != c.want {
 			t.Errorf("HasPermission(%s, %s) = %v, want %v", c.caller, c.required, got, c.want)
 		}
+	}
+}
+
+func TestTenantMemberService_UpdateMemberStorageQuota_SetsQuota(t *testing.T) {
+	svc, repo := newServiceWithRepo()
+	ctx := context.Background()
+	if _, err := svc.EnsureOwner(ctx, "u1", 1); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := svc.UpdateMemberStorageQuota(ctx, "u1", 1, 1024); err != nil {
+		t.Fatalf("UpdateMemberStorageQuota: %v", err)
+	}
+	m, err := repo.Get(ctx, "u1", 1)
+	if err != nil || m == nil {
+		t.Fatalf("Get after update: m=%v err=%v", m, err)
+	}
+	if m.StorageQuota != 1024 {
+		t.Fatalf("StorageQuota = %d, want 1024", m.StorageQuota)
+	}
+}
+
+func TestTenantMemberService_UpdateMemberStorageQuota_ZeroMeansNoLimit(t *testing.T) {
+	svc, _ := newServiceWithRepo()
+	ctx := context.Background()
+	if _, err := svc.EnsureOwner(ctx, "u1", 1); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := svc.UpdateMemberStorageQuota(ctx, "u1", 1, 0); err != nil {
+		t.Fatalf("quota=0 (no limit) should be allowed, got %v", err)
+	}
+}
+
+func TestTenantMemberService_UpdateMemberStorageQuota_RejectsNegative(t *testing.T) {
+	svc, _ := newServiceWithRepo()
+	ctx := context.Background()
+	if _, err := svc.EnsureOwner(ctx, "u1", 1); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := svc.UpdateMemberStorageQuota(ctx, "u1", 1, -1); !errors.Is(err, ErrInvalidStorageQuota) {
+		t.Fatalf("want ErrInvalidStorageQuota for negative quota, got %v", err)
+	}
+}
+
+func TestTenantMemberService_UpdateMemberStorageQuota_RejectsBelowUsed(t *testing.T) {
+	svc, repo := newServiceWithRepo()
+	ctx := context.Background()
+	if _, err := svc.EnsureOwner(ctx, "u1", 1); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Simulate the member already consuming 2048 bytes.
+	if err := repo.AdjustUserStorageUsed(ctx, "u1", 1, 2048); err != nil {
+		t.Fatalf("seed usage: %v", err)
+	}
+	// A positive quota below current usage must be rejected.
+	if err := svc.UpdateMemberStorageQuota(ctx, "u1", 1, 1024); !errors.Is(err, ErrInvalidStorageQuota) {
+		t.Fatalf("want ErrInvalidStorageQuota when quota < used, got %v", err)
+	}
+}
+
+func TestTenantMemberService_UpdateMemberStorageQuota_ReturnsNotFound(t *testing.T) {
+	svc, _ := newServiceWithRepo()
+	if err := svc.UpdateMemberStorageQuota(context.Background(), "ghost", 1, 1024); !errors.Is(err, ErrMembershipNotFound) {
+		t.Fatalf("want ErrMembershipNotFound, got %v", err)
 	}
 }

--- a/internal/handler/tenant_member.go
+++ b/internal/handler/tenant_member.go
@@ -136,11 +136,13 @@ func (h *TenantMemberHandler) ListMembers(c *gin.Context) {
 	resp := make([]types.TenantMemberResponse, 0, len(members))
 	for _, m := range members {
 		row := types.TenantMemberResponse{
-			UserID:    m.UserID,
-			Role:      m.Role,
-			Status:    m.Status,
-			InvitedBy: m.InvitedBy,
-			JoinedAt:  m.JoinedAt,
+			UserID:       m.UserID,
+			Role:         m.Role,
+			Status:       m.Status,
+			InvitedBy:    m.InvitedBy,
+			JoinedAt:     m.JoinedAt,
+			StorageQuota: m.StorageQuota,
+			StorageUsed:  m.StorageUsed,
 		}
 		if u, ok := usersByID[m.UserID]; ok && u != nil {
 			row.Email = u.Email
@@ -405,5 +407,58 @@ func (h *TenantMemberHandler) LeaveTenant(c *gin.Context) {
 		return
 	}
 
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+type updateMemberQuotaRequest struct {
+	StorageQuota *int64 `json:"storage_quota" binding:"required"`
+}
+
+// UpdateMemberQuota godoc
+// @Summary      修改成员存储配额
+// @Description  Owner/Admin 为某位成员设置个人存储配额（0=不限制）
+// @Tags         租户成员
+// @Accept       json
+// @Produce      json
+// @Param        id        path  string  true  "租户 ID"
+// @Param        user_id   path  string  true  "用户 ID"
+// @Param        request   body  updateMemberQuotaRequest  true  "配额请求"
+// @Success      200  {object}  map[string]interface{}
+// @Security     Bearer
+// @Router       /tenants/{id}/members/{user_id}/quota [put]
+func (h *TenantMemberHandler) UpdateMemberQuota(c *gin.Context) {
+	ctx := c.Request.Context()
+	tenantID, ok := parseTenantIDFromPath(c)
+	if !ok {
+		return
+	}
+	userID := strings.TrimSpace(c.Param("user_id"))
+	if userID == "" {
+		c.Error(apperrors.NewValidationError("user_id is required"))
+		return
+	}
+
+	var req updateMemberQuotaRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.Error(apperrors.NewValidationError("invalid request body").WithDetails(err.Error()))
+		return
+	}
+	if *req.StorageQuota < 0 {
+		c.Error(apperrors.NewValidationError("storage_quota must be non-negative"))
+		return
+	}
+	if err := h.memberService.UpdateMemberStorageQuota(ctx, userID, tenantID, *req.StorageQuota); err != nil {
+		switch {
+		case errors.Is(err, service.ErrMembershipNotFound):
+			c.Error(apperrors.NewNotFoundError("membership not found"))
+		case errors.Is(err, service.ErrInvalidStorageQuota):
+			c.Error(apperrors.NewValidationError(err.Error()))
+		default:
+			logger.Errorf(ctx, "UpdateMemberQuota failed: user=%s tenant=%d err=%v",
+				userID, tenantID, err)
+			c.Error(apperrors.NewInternalServerError("failed to update member quota").WithDetails(err.Error()))
+		}
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{"success": true})
 }

--- a/internal/middleware/auth_role_test.go
+++ b/internal/middleware/auth_role_test.go
@@ -139,6 +139,17 @@ func (f *fakeMemberService) RemoveMember(ctx context.Context, userID string, ten
 	return nil
 }
 
+// UpdateMemberStorageQuota is a no-op stub for the test fake. The
+// resolveTenantRole path under test never touches per-user storage
+// quota, so we don't need real in-memory accounting here; the service
+// layer quota logic has its own dedicated tests in the service
+// package.
+func (f *fakeMemberService) UpdateMemberStorageQuota(
+	ctx context.Context, userID string, tenantID uint64, quotaBytes int64,
+) error {
+	return nil
+}
+
 var _ interfaces.TenantMemberService = (*fakeMemberService)(nil)
 
 func cfgWithRBAC(enabled bool) *config.Config {

--- a/internal/router/routes_auth_tenant.go
+++ b/internal/router/routes_auth_tenant.go
@@ -112,6 +112,7 @@ func RegisterTenantRoutes(
 				g.apiKeyRoute(tenantByID, http.MethodPost, "/members", apiKeyManageMembers(apiKeyFullAccess()), g.Owner(), memberHandler.AddMember)
 				g.apiKeyRoute(tenantByID, http.MethodPut, "/members/:user_id", apiKeyManageMembers(apiKeyFullAccess()), g.Owner(), memberHandler.UpdateMemberRole)
 				g.apiKeyRoute(tenantByID, http.MethodDelete, "/members/:user_id", apiKeyManageMembers(apiKeyFullAccess()), g.Owner(), memberHandler.RemoveMember)
+				g.apiKeyRoute(tenantByID, http.MethodPut, "/members/:user_id/quota", apiKeyManageMembers(apiKeyFullAccess()), g.Admin(), memberHandler.UpdateMemberQuota)
 				tenantByID.POST("/leave", g.Viewer(), memberHandler.LeaveTenant)
 			}
 

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -44,3 +44,26 @@ func NewDuplicateURLError(knowledge *Knowledge) *DuplicateKnowledgeError {
 		Knowledge: knowledge,
 	}
 }
+
+// UserStorageQuotaExceededError represents a per-user storage quota
+// exceeded error. It is intentionally a DISTINCT type from the
+// tenant-level StorageQuotaExceededError so handlers can map them to
+// different business codes and the frontend can show targeted
+// messaging ("contact admin to raise your personal quota" vs "tenant
+// storage is full").
+type UserStorageQuotaExceededError struct {
+	Message string
+}
+
+func (e *UserStorageQuotaExceededError) Error() string {
+	return e.Message
+}
+
+// NewUserStorageQuotaExceededError creates a user storage quota exceeded
+// error. Returns the new dedicated type so callers can errors.As it
+// apart from the tenant-level quota error.
+func NewUserStorageQuotaExceededError() *UserStorageQuotaExceededError {
+	return &UserStorageQuotaExceededError{
+		Message: "User storage quota exceeded, please contact your tenant admin to increase the storage quota",
+	}
+}

--- a/internal/types/interfaces/tenant_member.go
+++ b/internal/types/interfaces/tenant_member.go
@@ -68,4 +68,13 @@ type TenantMemberRepository interface {
 	// RemoveOwnerAtomically soft-deletes an Owner row under the same
 	// lock as DemoteOwnerAtomically.
 	RemoveOwnerAtomically(ctx context.Context, userID string, tenantID uint64) error
+
+	// AdjustUserStorageUsed atomically adjusts storage_used for the given
+	// (userID, tenantID) membership. Negative delta reclaims space on delete.
+	// Clamps to 0 if the result would go negative.
+	AdjustUserStorageUsed(ctx context.Context, userID string, tenantID uint64, delta int64) error
+
+	// UpdateStorageQuota sets the personal storage quota for the given
+	// (userID, tenantID) membership. quotaBytes=0 means "no individual limit".
+	UpdateStorageQuota(ctx context.Context, userID string, tenantID uint64, quotaBytes int64) error
 }

--- a/internal/types/interfaces/tenant_member_service.go
+++ b/internal/types/interfaces/tenant_member_service.go
@@ -51,4 +51,9 @@ type TenantMemberService interface {
 	// RemoveMember soft-deletes the membership while enforcing the
 	// "cannot remove the last active Owner" invariant.
 	RemoveMember(ctx context.Context, userID string, tenantID uint64) error
+
+	// UpdateMemberStorageQuota sets the personal storage quota for a user
+	// in the tenant. Only Admin/Owner should call this.
+	// Validates: quotaBytes >= 0, quotaBytes >= member.StorageUsed (if > 0).
+	UpdateMemberStorageQuota(ctx context.Context, userID string, tenantID uint64, quotaBytes int64) error
 }

--- a/internal/types/tenant_member.go
+++ b/internal/types/tenant_member.go
@@ -104,6 +104,13 @@ type TenantMember struct {
 	CreatedAt time.Time      `json:"created_at"`
 	UpdatedAt time.Time      `json:"updated_at"`
 	DeletedAt gorm.DeletedAt `json:"deleted_at" gorm:"index"`
+	// StorageQuota is the maximum storage (bytes) this user may consume
+	// within this tenant. 0 means "no individual limit — tenant quota
+	// is the only ceiling".
+	StorageQuota int64 `json:"storage_quota" gorm:"default:0"`
+	// StorageUsed tracks how many bytes this user currently occupies
+	// within this tenant.
+	StorageUsed int64 `json:"storage_used" gorm:"default:0"`
 }
 
 // TableName binds TenantMember to the tenant_members table.
@@ -126,12 +133,14 @@ type Membership struct {
 // the model directly would leak DeletedAt/UpdatedAt and lock the DB
 // schema into the public API. Use this for `/tenants/:id/members` only.
 type TenantMemberResponse struct {
-	UserID    string             `json:"user_id"`
-	Email     string             `json:"email"`
-	Username  string             `json:"username"`
-	Avatar    string             `json:"avatar,omitempty"`
-	Role      TenantRole         `json:"role"`
-	Status    TenantMemberStatus `json:"status"`
-	InvitedBy *string            `json:"invited_by,omitempty"`
-	JoinedAt  time.Time          `json:"joined_at"`
+	UserID       string             `json:"user_id"`
+	Email        string             `json:"email"`
+	Username     string             `json:"username"`
+	Avatar       string             `json:"avatar,omitempty"`
+	Role         TenantRole         `json:"role"`
+	Status       TenantMemberStatus `json:"status"`
+	InvitedBy    *string            `json:"invited_by,omitempty"`
+	JoinedAt     time.Time          `json:"joined_at"`
+	StorageQuota int64              `json:"storage_quota"`
+	StorageUsed  int64              `json:"storage_used"`
 }

--- a/migrations/versioned/000075_member_storage_quota.down.sql
+++ b/migrations/versioned/000075_member_storage_quota.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tenant_members DROP COLUMN storage_used;
+ALTER TABLE tenant_members DROP COLUMN storage_quota;

--- a/migrations/versioned/000075_member_storage_quota.up.sql
+++ b/migrations/versioned/000075_member_storage_quota.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tenant_members ADD COLUMN storage_quota BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE tenant_members ADD COLUMN storage_used  BIGINT NOT NULL DEFAULT 0;


### PR DESCRIPTION
feat: implement user-level storage quota mechanism

<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->
key addition
* database: add storage_quota and storage _usused fields to tenant_member table
* backend api: added put  /api/v1/tenants/:id/members/:user_id/quota end point for admins to adjust user quotas
* service layer: updated all storage adjustinh and checking poins to account for tenant toaged
* fronted: added a visual edit flow in "tenant member" table to dispaly used/quota and allow admin to configure tenant limit

## Type of Change
<!-- Check applicable items -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #1653 

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
I use two account which one is tenant and one is admin.Test step is follow corresponding to screenshot below.
* 1 change the tenant stotage_quota through admin account(detect decimal input together)
* 2 upload a file whose size exceed the quota
all this test output was showed below containing ui interface and endpoint feedback 

## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<img width="1520" height="398" alt="362e408f485778ab2198ddc460d4f7a7" src="https://github.com/user-attachments/assets/0620f096-8726-4fd4-b249-26e6f29e7d90" />

<img width="1360" height="630" alt="c7daf56510cc0fedc3fa06f6e5c2bfeb" src="https://github.com/user-attachments/assets/5fb561fd-13bd-4584-a9be-5f3875e2d53c" />
sets/56467a77-444c
<img width="924" height="428" alt="4949f5c8741a554b9e0c4b95a517ff00" src="https://github.com/user-attachments/assets/76844e13-b43a-460a-ad1a-8a2bb091314d" />
-4957-951f-6e9638aafdf5" />
<img width="1052" height="146" alt="463c2060db2969ba50041a71373bce60" src="https://github.com/user-attachments/assets/18d860e5-ca43-4600-83e9-98825b837be4" />
<img width="1354" height="400" alt="5d791c1ab255eba584816c2d3fcc611d" src="https://github.com/user-attachments/assets/8d040390-ec14-466c-84c4-e54221448bb6" />


<img width="684" height="102" alt="319120220575f303b506e637a57540c5" src="https://github.com/user-attachments/assets/c224b3d4-3e95-40ec-9423-88698c692e26" />
f5-915a-801cdda64008" />
<img width="1366" height="548" alt="7558dfd6d8847e7f9e3dd9463e63d432" src="https://github.com/user-attachments/assets/78e293e3-f6bf-4346-8cac-d7e387ea76cf" />
