### PR TITLE
fix(frontend): load complete TDesign styles

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,7 +5,7 @@ import router from "./router";
 import "./assets/fonts.css";
 import TDesign from "tdesign-vue-next";
 // 引入组件库的少量全局样式变量
-import "tdesign-vue-next/es/style/index.css";
+import "tdesign-vue-next/dist/tdesign.css";
 import "@/assets/theme/theme.css";
 import "@/assets/dropdown-menu.less";
 import "@/components/css/chat-hljs-dark.less";

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -184,7 +184,8 @@
           </div>
 
           <div class="form-content">
-            <t-form ref="formRef" :data="formData" :rules="formRules" @submit="handleLogin" layout="vertical">
+            <t-form ref="formRef" :data="formData" :rules="formRules" @submit="handleLogin" layout="vertical"
+              label-align="top">
               <t-form-item :label="$t('auth.email')" name="email">
                 <t-input v-model="formData.email" :placeholder="$t('auth.emailPlaceholder')" type="text"
                   autocomplete="email" size="large" :disabled="loading" />
@@ -267,7 +268,7 @@
 
           <div class="form-content">
             <t-form ref="registerFormRef" :data="registerData" :rules="registerRules" @submit="handleRegister"
-              layout="vertical">
+              layout="vertical" label-align="top">
               <t-form-item :label="$t('auth.username')" name="username">
                 <t-input v-model="registerData.username" :placeholder="$t('auth.usernamePlaceholder')" size="large"
                   :disabled="loading" />


### PR DESCRIPTION
## Summary

Fixes a login/register layout regression where TDesign form controls rendered close to native browser styles and labels/inputs/buttons became visibly misaligned.

## Root Cause

The app entry imported `tdesign-vue-next/es/style/index.css`, which did not reliably include the complete packaged TDesign component styles in the production build. When those styles were missing, TDesign form and button components lost their expected layout rules.

## Changes

- Load the complete packaged TDesign stylesheet from `tdesign-vue-next/dist/tdesign.css`.
- Explicitly align login and register form labels to the top, matching the existing vertical form layout.

## Before

![Login layout regression](https://gist.githubusercontent.com/jacentsao/237fd20bde71e695bee09f178a4c36d0/raw/tdesign-login-layout-regression.svg)

## Validation

- `npm run build-only`
