### PR TITLE
fix(frontend): pin nginx base image by digest for old-host compatibility

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,12 @@
 # Production image. Build static assets on the host first:
 #   ./scripts/build_frontend_dist.sh
-FROM nginx:stable-alpine
+#
+# Base image pinned by digest for reproducibility. Do NOT switch back to the
+# floating `nginx:stable-alpine` tag: it drifts with every stable release and a
+# newer Alpine base (3.24+) fails to start on old hosts such as CentOS 7
+# (kernel 3.10 + old libseccomp), which broke v0.7.0. This digest is
+# nginx 1.30.3 / Alpine 3.23.5, the same base as the working v0.6.3 image.
+FROM nginx:1.30.3-alpine@sha256:0d3b80406a13a767339fbe2f41406d6c7da727ab89cf8fae399e81f780f814d1
 
 COPY dist /usr/share/nginx/html
 


### PR DESCRIPTION
## Summary
- The frontend image uses the floating `nginx:stable-alpine` tag, which drifts with every nginx stable release.
- A newer Alpine base (3.24+) fails to start on old hosts such as CentOS 7 (kernel 3.10 + old libseccomp). This broke v0.7.0.
- Pin the base image by digest to `nginx:1.30.3-alpine` (Alpine 3.23.5) — the same base as the working v0.6.3 image — for reproducible builds and old-host compatibility.

## Changes
- `frontend/Dockerfile`: replace the floating tag with a digest-pinned `FROM`, plus a comment explaining why not to revert to the floating tag.

## Test plan
- [ ] `docker build` the frontend image succeeds.
- [ ] Container starts and serves the SPA on an old host (e.g. CentOS 7).