### PR TITLE
fix(helm): enable Neo4j client when deployed

### DIFF
--- a/helm/templates/app.yaml
+++ b/helm/templates/app.yaml
@@ -128,6 +128,8 @@ spec:
               value: {{ .Values.app.env.ENABLE_GRAPH_RAG | quote }}
             {{- if .Values.neo4j.enabled }}
             # Neo4j configuration (for GraphRAG)
+            - name: NEO4J_ENABLE
+              value: "true"
             - name: NEO4J_URI
               value: "bolt://neo4j:7687"
             - name: NEO4J_USERNAME


### PR DESCRIPTION
## Description

The Helm chart deploys Neo4j and injects its URI and credentials when `neo4j.enabled=true`. However, the application initializes the Neo4j client only when the `NEO4J_ENABLE` environment variable is set to `true`.

This change injects `NEO4J_ENABLE=true` into the application container whenever the chart-managed Neo4j deployment is enabled.

Without this environment variable, Neo4j may be running successfully while graph storage and retrieval remain disabled in the application.

This change is backward-compatible and does not affect deployments where Neo4j is disabled.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [x] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

- Ran `git diff --check` successfully.
- Reviewed the staged diff and confirmed that only `NEO4J_ENABLE=true` was added.
- Confirmed that the environment variable is inside the existing `neo4j.enabled` conditional block.
- Helm lint and template rendering were not run locally.

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation
- [x] This change introduces no breaking changes

## Screenshots / Recordings

N/A — this change does not affect the user interface.

## Screenshots / Recordings

<img width="738" height="547" alt="image" src="https://github.com/user-attachments/assets/ce66aacb-05a5-4af2-8d28-df33a0cdf5db" />
