### PR TITLE
fix(compose): let PDF render parallelism follow CPU-aware code default

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -283,8 +283,9 @@ services:
       - DOCREADER_ODL_MARKDOWN_WITH_HTML=${DOCREADER_ODL_MARKDOWN_WITH_HTML:-false}
       # ========== PDF 渲染 ==========
       - DOCREADER_PDF_RENDER_MAX_WORKERS=${DOCREADER_PDF_RENDER_MAX_WORKERS:-1}
-      # 单个 PDF 内部扫描页渲染并行进程数（pdfium 非线程安全；默认随 CPU min(4,cpu)）
-      - DOCREADER_PDF_RENDER_PARALLELISM=${DOCREADER_PDF_RENDER_PARALLELISM:-4}
+      # 单个 PDF 内部扫描页渲染并行进程数（pdfium 非线程安全）。留空走代码默认 min(4,cpu)，
+      # 避免在低核容器上过度并行（写死数值会覆盖 CPU 感知逻辑）。
+      - DOCREADER_PDF_RENDER_PARALLELISM=${DOCREADER_PDF_RENDER_PARALLELISM:-}
       - DOCREADER_PDF_RENDER_DPI=${DOCREADER_PDF_RENDER_DPI:-200}
       # JPEG 质量（代码默认 85；compose 此前误写 90，已对齐）
       - DOCREADER_PDF_JPEG_QUALITY=${DOCREADER_PDF_JPEG_QUALITY:-85}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,8 @@ services:
       - GIN_MODE=${GIN_MODE:-release}
       # 时区，默认为Asia/Shanghai
       - TZ=${TZ:-Asia/Shanghai}
-      # 系统默认语言，默认为en-US，优先级为：Accept-Language 请求头 > 此环境变量 > 内置默认值 (en-US)
+      # 文档处理语言（问题/摘要生成）。优先级：此环境变量（部署级覆盖，非空即生效）
+      # > Accept-Language 请求头 > 内置默认值 (zh-CN)。留空则跟随请求方 Accept-Language。
       - WEKNORA_LANGUAGE=${WEKNORA_LANGUAGE:-}
       # gin 信任的代理 CIDR（逗号分隔）；显式设为空字符串则禁用代理信任。
       # 默认信任 loopback + 私网段（容器网络内 nginx 已覆盖）
@@ -427,8 +428,9 @@ services:
       - DOCREADER_ODL_MARKDOWN_WITH_HTML=${DOCREADER_ODL_MARKDOWN_WITH_HTML:-false}
       # ========== PDF 渲染 ==========
       - DOCREADER_PDF_RENDER_MAX_WORKERS=${DOCREADER_PDF_RENDER_MAX_WORKERS:-1}
-      # 单个 PDF 内部扫描页渲染并行进程数（pdfium 非线程安全；默认随 CPU min(4,cpu)）
-      - DOCREADER_PDF_RENDER_PARALLELISM=${DOCREADER_PDF_RENDER_PARALLELISM:-4}
+      # 单个 PDF 内部扫描页渲染并行进程数（pdfium 非线程安全）。留空走代码默认 min(4,cpu)，
+      # 避免在低核容器上过度并行（写死数值会覆盖 CPU 感知逻辑）。
+      - DOCREADER_PDF_RENDER_PARALLELISM=${DOCREADER_PDF_RENDER_PARALLELISM:-}
       - DOCREADER_PDF_RENDER_DPI=${DOCREADER_PDF_RENDER_DPI:-200}
       # JPEG 质量（代码默认 85；compose 此前误写 90，已对齐）
       - DOCREADER_PDF_JPEG_QUALITY=${DOCREADER_PDF_JPEG_QUALITY:-85}

--- a/docreader/README.md
+++ b/docreader/README.md
@@ -82,7 +82,7 @@ docreader:
 - `DOCREADER_MARKITDOWN_MAX_WORKERS`: MarkItDown 解析的最大并发数（默认：1，设为 0 可关闭限流）
 - `DOCREADER_PDF_RENDER_MAX_WORKERS`: 扫描 PDF 渲染为图片的最大并发数（默认：1，设为 0 可关闭限流）
 - `DOCREADER_PDF_RENDER_DPI`: 扫描 PDF 渲染 DPI（默认：200）
-- `DOCREADER_PDF_JPEG_QUALITY`: 扫描 PDF 输出 JPEG 质量（默认：90，范围会自动限制在 1-95）
+- `DOCREADER_PDF_JPEG_QUALITY`: 扫描 PDF 输出 JPEG 质量（默认：85，范围会自动限制在 1-95）
 
 ### OCR / VLM
 


### PR DESCRIPTION
## Summary
- Stop hardcoding `DOCREADER_PDF_RENDER_PARALLELISM=4` in `docker-compose.yml` and `docker-compose.dev.yml`, so deployments fall back to the code default `min(4, cpu)` and avoid over-parallelizing on low-core containers.
- Clarify `WEKNORA_LANGUAGE` precedence in compose comments (deployment override when non-empty, otherwise `Accept-Language`, then built-in `zh-CN`).
- Align `docreader/README.md` JPEG quality default documentation with the actual default of 85.

## Test plan
- [ ] `docker compose config` renders without errors for both compose files
- [ ] DocReader starts with empty `DOCREADER_PDF_RENDER_PARALLELISM` and uses CPU-aware default on a low-core host
- [ ] Setting `DOCREADER_PDF_RENDER_PARALLELISM` explicitly in `.env` still overrides the default