### PR TITLE
fix(wiki): allow authorized wiki fixer model fallback

### DIFF
--- a/internal/application/service/session_knowledge_qa_test.go
+++ b/internal/application/service/session_knowledge_qa_test.go
@@ -50,6 +50,7 @@ func (m *captureChatModel) GetModelID() string   { return "capture" }
 type stubModelService struct {
 	chatModel  chat.Chat
 	modelsByID map[string]*types.Model
+	models     []*types.Model
 }
 
 func TestEmitKnowledgeReferencesEventIgnoresCitationOutputSetting(t *testing.T) {
@@ -89,7 +90,7 @@ func (s *stubModelService) GetModelByID(_ context.Context, id string) (*types.Mo
 }
 
 func (s *stubModelService) ListModels(context.Context) ([]*types.Model, error) {
-	return nil, nil
+	return s.models, nil
 }
 
 func (s *stubModelService) UpdateModel(context.Context, *types.Model) error {

--- a/internal/application/service/session_model_requirement_test.go
+++ b/internal/application/service/session_model_requirement_test.go
@@ -36,6 +36,30 @@ func TestResolveChatModelIDRequiresConfiguredAgentModel(t *testing.T) {
 	assert.Contains(t, err.Error(), "model_id")
 }
 
+func TestResolveChatModelIDUsesFallbackForBuiltinWikiFixer(t *testing.T) {
+	svc := &sessionService{
+		modelService: &stubModelService{
+			models: []*types.Model{
+				{
+					ID:   "default-chat",
+					Type: types.ModelTypeKnowledgeQA,
+				},
+			},
+		},
+	}
+	req := &types.QARequest{
+		Session: &types.Session{},
+		CustomAgent: &types.CustomAgent{
+			ID: types.BuiltinWikiFixerID,
+		},
+	}
+
+	modelID, err := svc.resolveChatModelID(context.Background(), req, nil, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "default-chat", modelID)
+}
+
 func TestResolveChatModelIDRejectsUnavailableConfiguredAgentModel(t *testing.T) {
 	svc := &sessionService{
 		modelService: &stubModelService{modelsByID: map[string]*types.Model{}},

--- a/internal/application/service/session_qa_helpers.go
+++ b/internal/application/service/session_qa_helpers.go
@@ -104,12 +104,16 @@ func (s *sessionService) resolveChatModelID(
 
 	if customAgent != nil {
 		configuredModelID := strings.TrimSpace(customAgent.Config.ModelID)
-		if configuredModelID == "" {
+		// The wiki fixer is invoked internally and intentionally omitted from the
+		// user-configurable agent list, so it must use the normal QA model fallback.
+		if configuredModelID == "" && customAgent.ID != types.BuiltinWikiFixerID {
 			return "", fmt.Errorf("chat model is not configured: please set model_id on agent %s", customAgent.ID)
 		}
-		model, err := s.modelService.GetModelByID(ctx, configuredModelID)
-		if err != nil || model == nil || model.Type != types.ModelTypeKnowledgeQA {
-			return "", fmt.Errorf("configured chat model %s is unavailable for agent %s", configuredModelID, customAgent.ID)
+		if configuredModelID != "" {
+			model, err := s.modelService.GetModelByID(ctx, configuredModelID)
+			if err != nil || model == nil || model.Type != types.ModelTypeKnowledgeQA {
+				return "", fmt.Errorf("configured chat model %s is unavailable for agent %s", configuredModelID, customAgent.ID)
+			}
 		}
 	}
 

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -146,18 +146,21 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 		return nil, nil, err
 	}
 
-	// The built-in wiki fixer is invoked from a KB page, not from a tenant's
-	// regular agent picker. When the KB is shared, run it in the source tenant
-	// only if the caller has edit permission, so KB-scoped models/tools resolve
-	// without granting viewers write capability.
+	// The built-in wiki fixer carries mutating Wiki tools. It is only valid for
+	// one editable Wiki KB, and shared calls run in the source tenant so
+	// KB-scoped models and tools resolve without granting viewers write access.
 	if customAgent != nil && customAgent.ID == types.BuiltinWikiFixerID {
-		if scopedAgent, scopedTenantID := h.resolveWikiFixerTenantScope(
+		scopedAgent, scopedTenantID, err := h.resolveWikiFixerTenantScope(
 			ctx,
 			customAgent,
 			c.GetUint64(types.TenantIDContextKey.String()),
 			types.TenantRoleFromContext(ctx),
 			kbIDs,
-		); scopedTenantID != 0 {
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		if scopedTenantID != 0 {
 			customAgent = scopedAgent
 			effectiveTenantID = scopedTenantID
 		}

--- a/internal/handler/session/wiki_fixer_scope.go
+++ b/internal/handler/session/wiki_fixer_scope.go
@@ -2,8 +2,13 @@ package session
 
 import (
 	"context"
+	stderrors "errors"
 
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/config"
+	apperrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/middleware"
 	"github.com/Tencent/WeKnora/internal/types"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
@@ -22,9 +27,10 @@ func (h *Handler) resolveWikiFixerTenantScope(
 	currentTenantID uint64,
 	callerTenantRole types.TenantRole,
 	kbIDs []string,
-) (*types.CustomAgent, uint64) {
+) (*types.CustomAgent, uint64, error) {
 	return resolveBuiltinWikiFixerTenantScope(
 		ctx,
+		h.config,
 		agent,
 		currentTenantID,
 		callerTenantRole,
@@ -36,45 +42,79 @@ func (h *Handler) resolveWikiFixerTenantScope(
 
 func resolveBuiltinWikiFixerTenantScope(
 	ctx context.Context,
+	cfg *config.Config,
 	agent *types.CustomAgent,
 	currentTenantID uint64,
 	callerTenantRole types.TenantRole,
 	kbIDs []string,
 	kbLookup wikiFixerKBLookup,
 	kbShare wikiFixerKBSharePermission,
-) (*types.CustomAgent, uint64) {
+) (*types.CustomAgent, uint64, error) {
 	if agent == nil || agent.ID != types.BuiltinWikiFixerID {
-		return agent, 0
+		return agent, 0, nil
 	}
-	if currentTenantID == 0 || len(kbIDs) != 1 || kbLookup == nil || kbShare == nil {
-		return agent, 0
+	if currentTenantID == 0 {
+		return agent, 0, apperrors.NewUnauthorizedError("workspace context is required for wiki fixer")
+	}
+	if len(kbIDs) != 1 {
+		return agent, 0, apperrors.NewBadRequestError("wiki fixer requires exactly one knowledge base")
+	}
+	if kbLookup == nil {
+		return agent, 0, apperrors.NewServiceUnavailableError("cannot verify wiki knowledge base")
 	}
 
 	kbID := kbIDs[0]
 	kb, err := kbLookup.GetKnowledgeBaseByIDOnly(ctx, kbID)
 	if err != nil {
 		logger.Warnf(ctx, "wiki fixer: failed to resolve KB %s for shared scope: %v", secutils.SanitizeForLog(kbID), err)
-		return agent, 0
+		if stderrors.Is(err, repository.ErrKnowledgeBaseNotFound) {
+			return agent, 0, apperrors.NewNotFoundError("knowledge base not found")
+		}
+		return agent, 0, apperrors.NewServiceUnavailableError("cannot verify wiki knowledge base")
 	}
 	if kb == nil {
 		logger.Warnf(ctx, "wiki fixer: KB %s not found for shared scope", secutils.SanitizeForLog(kbID))
-		return agent, 0
+		return agent, 0, apperrors.NewNotFoundError("knowledge base not found")
 	}
-	if kb.TenantID == 0 || kb.TenantID == currentTenantID {
-		return agent, 0
+	if !kb.IsWikiEnabled() {
+		return agent, 0, apperrors.NewBadRequestError("wiki fixer requires a wiki-enabled knowledge base")
+	}
+	if scope, ok := types.TenantAPIKeyScopeFromContext(ctx); ok &&
+		!scope.FullAccess && !scope.HasCapability(types.APIKeyCapabilityIngest) {
+		return agent, 0, apperrors.NewForbiddenError("API key requires ingest capability for wiki fixer")
+	}
+	if kb.TenantID == currentTenantID {
+		if err := middleware.EvaluateOwnershipOrRole(ctx, cfg, types.TenantRoleAdmin, kb.CreatorID, nil); err != nil {
+			return agent, 0, mapWikiFixerAccessError(err)
+		}
+		return agent, 0, nil
+	}
+	if kb.TenantID == 0 || kbShare == nil {
+		return agent, 0, apperrors.NewForbiddenError("no edit permission for wiki fixer knowledge base")
 	}
 
 	permission, isShared, err := kbShare.CheckTenantKBPermission(ctx, kb.ID, currentTenantID, callerTenantRole)
 	if err != nil {
 		logger.Warnf(ctx, "wiki fixer: failed to check shared KB %s permission: %v", secutils.SanitizeForLog(kb.ID), err)
-		return agent, 0
+		return agent, 0, apperrors.NewServiceUnavailableError("cannot verify wiki knowledge base permission")
 	}
 	if !isShared || !permission.HasPermission(types.OrgRoleEditor) {
-		return agent, 0
+		return agent, 0, apperrors.NewForbiddenError("no edit permission for wiki fixer knowledge base")
 	}
 
 	scopedAgent := *agent
 	scopedAgent.TenantID = kb.TenantID
 	logger.Infof(ctx, "wiki fixer: using shared KB source tenant %d for KB %s", kb.TenantID, secutils.SanitizeForLog(kb.ID))
-	return &scopedAgent, kb.TenantID
+	return &scopedAgent, kb.TenantID, nil
+}
+
+func mapWikiFixerAccessError(err error) error {
+	switch {
+	case stderrors.Is(err, middleware.ErrResourceNotFound):
+		return apperrors.NewNotFoundError("knowledge base not found")
+	case stderrors.Is(err, middleware.ErrOwnershipForbidden):
+		return apperrors.NewForbiddenError("no edit permission for wiki fixer knowledge base")
+	default:
+		return apperrors.NewServiceUnavailableError("cannot verify wiki knowledge base permission")
+	}
 }

--- a/internal/handler/session/wiki_fixer_scope_test.go
+++ b/internal/handler/session/wiki_fixer_scope_test.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/config"
+	apperrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/stretchr/testify/require"
 )
@@ -41,26 +44,46 @@ func (s *wikiFixerKBShareStub) CheckTenantKBPermission(
 	return s.permission, s.isShared, s.err
 }
 
+func wikiFixerKnowledgeBase(id string, tenantID uint64, creatorID string) *types.KnowledgeBase {
+	return &types.KnowledgeBase{
+		ID:        id,
+		TenantID:  tenantID,
+		CreatorID: creatorID,
+		IndexingStrategy: types.IndexingStrategy{
+			WikiEnabled: true,
+		},
+	}
+}
+
+func enforcedWikiFixerConfig() *config.Config {
+	enabled := true
+	return &config.Config{Tenant: &config.TenantConfig{EnableRBAC: &enabled}}
+}
+
+func wikiFixerUserContext(userID string, role types.TenantRole) context.Context {
+	ctx := context.WithValue(context.Background(), types.UserIDContextKey, userID)
+	return context.WithValue(ctx, types.TenantRoleContextKey, role)
+}
+
+func requireWikiFixerErrorCode(t *testing.T, err error, code apperrors.ErrorCode) {
+	t.Helper()
+	require.Error(t, err)
+	var appErr *apperrors.AppError
+	require.ErrorAs(t, err, &appErr)
+	require.Equal(t, code, appErr.Code)
+}
+
 func TestResolveBuiltinWikiFixerTenantScope_SharedEditorUsesSourceTenant(t *testing.T) {
 	agent := &types.CustomAgent{ID: types.BuiltinWikiFixerID, TenantID: 10, Name: "Wiki Fixer"}
-	kbLookup := &wikiFixerKBLookupStub{
-		kb: &types.KnowledgeBase{ID: "kb-shared", TenantID: 20, Name: "Shared KB"},
-	}
-	kbShare := &wikiFixerKBShareStub{
-		permission: types.OrgRoleEditor,
-		isShared:   true,
-	}
+	kbLookup := &wikiFixerKBLookupStub{kb: wikiFixerKnowledgeBase("kb-shared", 20, "source-owner")}
+	kbShare := &wikiFixerKBShareStub{permission: types.OrgRoleEditor, isShared: true}
 
-	gotAgent, effectiveTenantID := resolveBuiltinWikiFixerTenantScope(
-		context.Background(),
-		agent,
-		10,
-		types.TenantRoleContributor,
-		[]string{"kb-shared"},
-		kbLookup,
-		kbShare,
+	gotAgent, effectiveTenantID, err := resolveBuiltinWikiFixerTenantScope(
+		context.Background(), enforcedWikiFixerConfig(), agent, 10, types.TenantRoleContributor,
+		[]string{"kb-shared"}, kbLookup, kbShare,
 	)
 
+	require.NoError(t, err)
 	require.NotSame(t, agent, gotAgent)
 	require.Equal(t, uint64(20), gotAgent.TenantID)
 	require.Equal(t, uint64(20), effectiveTenantID)
@@ -71,107 +94,178 @@ func TestResolveBuiltinWikiFixerTenantScope_SharedEditorUsesSourceTenant(t *test
 	require.Equal(t, types.TenantRoleContributor, kbShare.checkedTenantRole)
 }
 
-func TestResolveBuiltinWikiFixerTenantScope_SharedViewerDoesNotSwitchTenant(t *testing.T) {
+func TestResolveBuiltinWikiFixerTenantScope_RejectsSharedViewer(t *testing.T) {
 	agent := &types.CustomAgent{ID: types.BuiltinWikiFixerID, TenantID: 10}
-	kbLookup := &wikiFixerKBLookupStub{
-		kb: &types.KnowledgeBase{ID: "kb-shared", TenantID: 20},
-	}
-	kbShare := &wikiFixerKBShareStub{
-		permission: types.OrgRoleViewer,
-		isShared:   true,
-	}
+	kbLookup := &wikiFixerKBLookupStub{kb: wikiFixerKnowledgeBase("kb-shared", 20, "source-owner")}
+	kbShare := &wikiFixerKBShareStub{permission: types.OrgRoleViewer, isShared: true}
 
-	gotAgent, effectiveTenantID := resolveBuiltinWikiFixerTenantScope(
-		context.Background(),
-		agent,
-		10,
-		types.TenantRoleContributor,
-		[]string{"kb-shared"},
-		kbLookup,
-		kbShare,
+	gotAgent, effectiveTenantID, err := resolveBuiltinWikiFixerTenantScope(
+		context.Background(), enforcedWikiFixerConfig(), agent, 10, types.TenantRoleContributor,
+		[]string{"kb-shared"}, kbLookup, kbShare,
 	)
 
 	require.Same(t, agent, gotAgent)
 	require.Zero(t, effectiveTenantID)
-	require.Equal(t, uint64(10), gotAgent.TenantID)
+	requireWikiFixerErrorCode(t, err, apperrors.ErrForbidden)
 }
 
-func TestResolveBuiltinWikiFixerTenantScope_IgnoresNonWikiFixerAgents(t *testing.T) {
-	agent := &types.CustomAgent{ID: "custom-agent", TenantID: 10}
-	kbLookup := &wikiFixerKBLookupStub{
-		kb: &types.KnowledgeBase{ID: "kb-shared", TenantID: 20},
-	}
-	kbShare := &wikiFixerKBShareStub{
-		permission: types.OrgRoleEditor,
-		isShared:   true,
-	}
-
-	gotAgent, effectiveTenantID := resolveBuiltinWikiFixerTenantScope(
-		context.Background(),
-		agent,
-		10,
-		types.TenantRoleContributor,
-		[]string{"kb-shared"},
-		kbLookup,
-		kbShare,
-	)
-
-	require.Same(t, agent, gotAgent)
-	require.Zero(t, effectiveTenantID)
-	require.Empty(t, kbLookup.calledWith)
-}
-
-func TestResolveBuiltinWikiFixerTenantScope_RequiresSingleKnowledgeBase(t *testing.T) {
+func TestResolveBuiltinWikiFixerTenantScope_EnforcesOwnKBWriteMatrix(t *testing.T) {
 	agent := &types.CustomAgent{ID: types.BuiltinWikiFixerID, TenantID: 10}
-	kbLookup := &wikiFixerKBLookupStub{
-		kb: &types.KnowledgeBase{ID: "kb-shared", TenantID: 20},
+	cases := []struct {
+		name     string
+		ctx      context.Context
+		wantCode apperrors.ErrorCode
+	}{
+		{
+			name: "creator",
+			ctx:  wikiFixerUserContext("creator", types.TenantRoleContributor),
+		},
+		{
+			name: "admin",
+			ctx:  wikiFixerUserContext("other-user", types.TenantRoleAdmin),
+		},
+		{
+			name:     "non-owner contributor",
+			ctx:      wikiFixerUserContext("other-user", types.TenantRoleContributor),
+			wantCode: apperrors.ErrForbidden,
+		},
 	}
 
-	gotAgent, effectiveTenantID := resolveBuiltinWikiFixerTenantScope(
-		context.Background(),
-		agent,
-		10,
-		types.TenantRoleContributor,
-		[]string{"kb-a", "kb-b"},
-		kbLookup,
-		&wikiFixerKBShareStub{permission: types.OrgRoleEditor, isShared: true},
-	)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotAgent, effectiveTenantID, err := resolveBuiltinWikiFixerTenantScope(
+				tc.ctx, enforcedWikiFixerConfig(), agent, 10, types.TenantRoleContributor,
+				[]string{"kb-own"}, &wikiFixerKBLookupStub{kb: wikiFixerKnowledgeBase("kb-own", 10, "creator")}, nil,
+			)
 
-	require.Same(t, agent, gotAgent)
-	require.Zero(t, effectiveTenantID)
-	require.Empty(t, kbLookup.calledWith)
+			if tc.wantCode != 0 {
+				require.Same(t, agent, gotAgent)
+				require.Zero(t, effectiveTenantID)
+				requireWikiFixerErrorCode(t, err, tc.wantCode)
+				return
+			}
+			require.NoError(t, err)
+			require.Same(t, agent, gotAgent)
+			require.Zero(t, effectiveTenantID)
+		})
+	}
 }
 
-func TestResolveBuiltinWikiFixerTenantScope_FallsBackOnLookupOrPermissionErrors(t *testing.T) {
+func TestResolveBuiltinWikiFixerTenantScope_RequiresWikiEnabledSingleKB(t *testing.T) {
 	agent := &types.CustomAgent{ID: types.BuiltinWikiFixerID, TenantID: 10}
 
-	t.Run("kb lookup error", func(t *testing.T) {
-		gotAgent, effectiveTenantID := resolveBuiltinWikiFixerTenantScope(
-			context.Background(),
-			agent,
-			10,
-			types.TenantRoleContributor,
-			[]string{"kb-shared"},
-			&wikiFixerKBLookupStub{err: errors.New("lookup failed")},
-			&wikiFixerKBShareStub{permission: types.OrgRoleEditor, isShared: true},
+	t.Run("multiple knowledge bases", func(t *testing.T) {
+		lookup := &wikiFixerKBLookupStub{kb: wikiFixerKnowledgeBase("kb-a", 10, "creator")}
+		gotAgent, effectiveTenantID, err := resolveBuiltinWikiFixerTenantScope(
+			wikiFixerUserContext("creator", types.TenantRoleContributor), enforcedWikiFixerConfig(), agent, 10,
+			types.TenantRoleContributor, []string{"kb-a", "kb-b"}, lookup, nil,
 		)
 
 		require.Same(t, agent, gotAgent)
 		require.Zero(t, effectiveTenantID)
+		require.Empty(t, lookup.calledWith)
+		requireWikiFixerErrorCode(t, err, apperrors.ErrBadRequest)
 	})
 
-	t.Run("permission check error", func(t *testing.T) {
-		gotAgent, effectiveTenantID := resolveBuiltinWikiFixerTenantScope(
-			context.Background(),
-			agent,
-			10,
-			types.TenantRoleContributor,
-			[]string{"kb-shared"},
-			&wikiFixerKBLookupStub{kb: &types.KnowledgeBase{ID: "kb-shared", TenantID: 20}},
+	t.Run("non wiki knowledge base", func(t *testing.T) {
+		kb := wikiFixerKnowledgeBase("kb-document", 10, "creator")
+		kb.IndexingStrategy.WikiEnabled = false
+		gotAgent, effectiveTenantID, err := resolveBuiltinWikiFixerTenantScope(
+			wikiFixerUserContext("creator", types.TenantRoleContributor), enforcedWikiFixerConfig(), agent, 10,
+			types.TenantRoleContributor, []string{"kb-document"}, &wikiFixerKBLookupStub{kb: kb}, nil,
+		)
+
+		require.Same(t, agent, gotAgent)
+		require.Zero(t, effectiveTenantID)
+		requireWikiFixerErrorCode(t, err, apperrors.ErrBadRequest)
+	})
+}
+
+func TestResolveBuiltinWikiFixerTenantScope_RequiresAPIKeyIngestCapability(t *testing.T) {
+	agent := &types.CustomAgent{ID: types.BuiltinWikiFixerID, TenantID: 10}
+	kb := wikiFixerKnowledgeBase("kb-own", 10, "creator")
+
+	t.Run("chat capability alone is denied", func(t *testing.T) {
+		ctx := types.WithTenantAPIKeyScope(context.Background(), types.TenantAPIKeyScope{
+			Capabilities: types.StringArray{string(types.APIKeyCapabilityChat)},
+		})
+		gotAgent, effectiveTenantID, err := resolveBuiltinWikiFixerTenantScope(
+			ctx, enforcedWikiFixerConfig(), agent, 10, types.TenantRoleViewer,
+			[]string{"kb-own"}, &wikiFixerKBLookupStub{kb: kb}, nil,
+		)
+
+		require.Same(t, agent, gotAgent)
+		require.Zero(t, effectiveTenantID)
+		requireWikiFixerErrorCode(t, err, apperrors.ErrForbidden)
+	})
+
+	t.Run("chat and ingest capabilities are allowed", func(t *testing.T) {
+		ctx := types.WithTenantAPIKeyScope(context.Background(), types.TenantAPIKeyScope{
+			Capabilities: types.StringArray{
+				string(types.APIKeyCapabilityChat),
+				string(types.APIKeyCapabilityIngest),
+			},
+		})
+		gotAgent, effectiveTenantID, err := resolveBuiltinWikiFixerTenantScope(
+			ctx, enforcedWikiFixerConfig(), agent, 10, types.TenantRoleViewer,
+			[]string{"kb-own"}, &wikiFixerKBLookupStub{kb: kb}, nil,
+		)
+
+		require.NoError(t, err)
+		require.Same(t, agent, gotAgent)
+		require.Zero(t, effectiveTenantID)
+	})
+}
+
+func TestResolveBuiltinWikiFixerTenantScope_FailsClosedOnLookupAndPermissionErrors(t *testing.T) {
+	agent := &types.CustomAgent{ID: types.BuiltinWikiFixerID, TenantID: 10}
+
+	t.Run("knowledge base lookup error", func(t *testing.T) {
+		gotAgent, effectiveTenantID, err := resolveBuiltinWikiFixerTenantScope(
+			context.Background(), enforcedWikiFixerConfig(), agent, 10, types.TenantRoleContributor,
+			[]string{"kb-shared"}, &wikiFixerKBLookupStub{err: errors.New("lookup failed")}, &wikiFixerKBShareStub{},
+		)
+
+		require.Same(t, agent, gotAgent)
+		require.Zero(t, effectiveTenantID)
+		requireWikiFixerErrorCode(t, err, apperrors.ErrServiceUnavailable)
+	})
+
+	t.Run("knowledge base not found", func(t *testing.T) {
+		gotAgent, effectiveTenantID, err := resolveBuiltinWikiFixerTenantScope(
+			context.Background(), enforcedWikiFixerConfig(), agent, 10, types.TenantRoleContributor,
+			[]string{"missing"}, &wikiFixerKBLookupStub{err: repository.ErrKnowledgeBaseNotFound}, &wikiFixerKBShareStub{},
+		)
+
+		require.Same(t, agent, gotAgent)
+		require.Zero(t, effectiveTenantID)
+		requireWikiFixerErrorCode(t, err, apperrors.ErrNotFound)
+	})
+
+	t.Run("shared permission check error", func(t *testing.T) {
+		gotAgent, effectiveTenantID, err := resolveBuiltinWikiFixerTenantScope(
+			context.Background(), enforcedWikiFixerConfig(), agent, 10, types.TenantRoleContributor,
+			[]string{"kb-shared"}, &wikiFixerKBLookupStub{kb: wikiFixerKnowledgeBase("kb-shared", 20, "source-owner")},
 			&wikiFixerKBShareStub{err: errors.New("permission failed")},
 		)
 
 		require.Same(t, agent, gotAgent)
 		require.Zero(t, effectiveTenantID)
+		requireWikiFixerErrorCode(t, err, apperrors.ErrServiceUnavailable)
 	})
+}
+
+func TestResolveBuiltinWikiFixerTenantScope_IgnoresNonWikiFixerAgents(t *testing.T) {
+	agent := &types.CustomAgent{ID: "custom-agent", TenantID: 10}
+	lookup := &wikiFixerKBLookupStub{kb: wikiFixerKnowledgeBase("kb-shared", 20, "source-owner")}
+
+	gotAgent, effectiveTenantID, err := resolveBuiltinWikiFixerTenantScope(
+		context.Background(), enforcedWikiFixerConfig(), agent, 10, types.TenantRoleContributor,
+		[]string{"kb-shared"}, lookup, &wikiFixerKBShareStub{permission: types.OrgRoleEditor, isShared: true},
+	)
+
+	require.NoError(t, err)
+	require.Same(t, agent, gotAgent)
+	require.Zero(t, effectiveTenantID)
+	require.Empty(t, lookup.calledWith)
 }


### PR DESCRIPTION
## Description
Restores the built-in Wiki Fixer when it has no agent-level `model_id`, using the existing QA model fallback. The internal agent is restricted to one Wiki-enabled knowledge base and an editor-capable caller, so its write-capable tools cannot be reached through generic chat by an unauthorized user.

Duplicate-work check: searched open issues and PRs for `#2110`, `builtin-wiki-fixer`, and `chat model is not configured`; no duplicate open PR was found.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test
- [ ] Configuration / Build / CI

## Related Issue
Fixes #2110

## Testing
- `gofmt -w` on the changed Go files
- `go test ./internal/application/service`
- `go test ./internal/handler/session`
- `go vet ./internal/application/service ./internal/handler/session`
- `git diff --check`
- `go test ./...` was run but is not marked passing because this Windows environment lacks project-wide dependencies and services (sqlite3 headers and DocReader), and has unrelated linker and sandbox test failures. Both affected packages pass.

## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
Not applicable (backend-only change).