### PR TITLE
fix(session): validate QA input before retrieval

### DIFF
--- a/internal/application/service/session_agent_qa.go
+++ b/internal/application/service/session_agent_qa.go
@@ -23,6 +23,10 @@ func (s *sessionService) AgentQA(
 	req *types.QARequest,
 	eventBus *event.EventBus,
 ) error {
+	if err := validateQAQuery(req.Query); err != nil {
+		return err
+	}
+
 	sessionID := req.Session.ID
 	sessionJSON, err := json.Marshal(req.Session)
 	if err != nil {

--- a/internal/application/service/session_knowledge_qa.go
+++ b/internal/application/service/session_knowledge_qa.go
@@ -25,6 +25,10 @@ func (s *sessionService) KnowledgeQA(
 	req *types.QARequest,
 	eventBus *event.EventBus,
 ) error {
+	if err := validateQAQuery(req.Query); err != nil {
+		return err
+	}
+
 	logger.Infof(
 		ctx,
 		"Knowledge base question answering parameters, session ID: %s, query: %s, webSearchEnabled: %v",

--- a/internal/application/service/session_qa_helpers.go
+++ b/internal/application/service/session_qa_helpers.go
@@ -7,11 +7,19 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/utils"
 )
 
 // ---------------------------------------------------------------------------
 // Shared QA helpers: KB resolution, model resolution, retrieval tenant
 // ---------------------------------------------------------------------------
+
+func validateQAQuery(query string) error {
+	if _, valid := utils.ValidateInput(query); !valid {
+		return fmt.Errorf("user query contains invalid content")
+	}
+	return nil
+}
 
 // resolveKnowledgeBases resolves the effective knowledge base IDs and knowledge IDs
 // for a QA request. Priority:

--- a/internal/application/service/session_query_validation_test.go
+++ b/internal/application/service/session_query_validation_test.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/event"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKnowledgeQARejectsInvalidQueryBeforeSetup(t *testing.T) {
+	svc := &sessionService{}
+
+	err := svc.KnowledgeQA(context.Background(), &types.QARequest{
+		Session: &types.Session{},
+		Query:   "invalid\x00query",
+	}, event.NewEventBus())
+
+	require.EqualError(t, err, "user query contains invalid content")
+}
+
+func TestAgentQARejectsInvalidQueryBeforeSetup(t *testing.T) {
+	svc := &sessionService{}
+
+	err := svc.AgentQA(context.Background(), &types.QARequest{
+		Session:     &types.Session{},
+		Query:       "invalid\x00query",
+		CustomAgent: &types.CustomAgent{},
+	}, event.NewEventBus())
+
+	require.EqualError(t, err, "user query contains invalid content")
+}

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -107,6 +107,10 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 		logger.Error(ctx, "Query content is empty")
 		return nil, nil, errors.NewBadRequestError("Query content cannot be empty")
 	}
+	if _, valid := secutils.ValidateInput(request.Query); !valid {
+		logger.Error(ctx, "Query content contains invalid characters")
+		return nil, nil, errors.NewBadRequestError("Query content contains invalid characters")
+	}
 	if h.suggestionService != nil && request.SuggestionAttribution != nil {
 		if err := h.suggestionService.ValidateAttribution(ctx, sessionID, request.Query, request.SuggestionAttribution); err != nil {
 			return nil, nil, errors.NewBadRequestError("invalid suggestion attribution")

--- a/internal/handler/session/qa_validation_test.go
+++ b/internal/handler/session/qa_validation_test.go
@@ -1,0 +1,25 @@
+package session
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseQARequestRejectsInvalidQuery(t *testing.T) {
+	body, err := json.Marshal(CreateKnowledgeQARequest{Query: "invalid\x00query"})
+	require.NoError(t, err)
+
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("POST", "/sessions/session-1/knowledge-qa", bytes.NewReader(body))
+	ctx.Params = gin.Params{{Key: "session_id", Value: "session-1"}}
+
+	_, _, err = (&Handler{}).parseQARequest(ctx, "test")
+
+	require.ErrorContains(t, err, "invalid characters")
+}


### PR DESCRIPTION
## Description
Rejects invalid QA queries in request parsing before session lookup, attachment processing, retrieval, and re-ranking. The same validation is also applied at the service boundary for non-HTTP callers, while the existing prompt-construction validation remains as defense in depth.

Duplicate-work check: searched open issues and PRs for `#2057`, `QA query validation`, and `re-ranking`; no duplicate open PR was found.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test
- [ ] Configuration / Build / CI

## Related Issue
Fixes #2057

## Testing
- `gofmt -w` on the changed Go files
- `go test ./internal/application/service`
- `go test ./internal/handler/session`
- `go vet ./internal/application/service ./internal/handler/session`
- `git diff --check`
- `go test ./...` was attempted, but the local execution process was interrupted before a result; it is not marked passing.

## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
Not applicable (backend-only change).