### PR TITLE
feat(im): render Yunzhijia replies as Markdown

### DIFF
--- a/internal/im/yunzhijia/adapter.go
+++ b/internal/im/yunzhijia/adapter.go
@@ -22,6 +22,9 @@ import (
 // textMessageType is the Yunzhijia message type value for plain text messages.
 const textMessageType = 2
 
+// markdownFormatType requests Yunzhijia to render Content as Markdown.
+const markdownFormatType = "markdown"
+
 // Compile-time check.
 var _ im.Adapter = (*Adapter)(nil)
 
@@ -205,6 +208,19 @@ func (a *Adapter) SendReply(ctx context.Context, incoming *im.IncomingMessage, r
 	payload := sendMessagePayload{
 		MsgType: textMessageType,
 		Content: reply.Content,
+		// WeKnora replies are authored in Markdown by default (see im.ReplyMessage.Content),
+		// so request Markdown rendering from Yunzhijia unless explicitly overridden via
+		// reply.Extra["yunzhijia_format_type"] (empty string disables the param entirely).
+		Param: &sendMessageParam{FormatType: markdownFormatType},
+	}
+	if reply.Extra != nil {
+		if formatType, ok := reply.Extra["yunzhijia_format_type"]; ok {
+			if formatType == "" {
+				payload.Param = nil
+			} else {
+				payload.Param = &sendMessageParam{FormatType: formatType}
+			}
+		}
 	}
 
 	// When groupType == 3, don't set notifyParams (per reference implementation).

--- a/internal/im/yunzhijia/adapter_test.go
+++ b/internal/im/yunzhijia/adapter_test.go
@@ -92,4 +92,46 @@ func TestSendReplyAcceptsAny2xxAndBuildsPayload(t *testing.T) {
 	if len(payload.NotifyParams) != 1 || len(payload.NotifyParams[0].Values) != 1 || payload.NotifyParams[0].Values[0] != "user" {
 		t.Fatalf("notify params = %#v", payload.NotifyParams)
 	}
+	if payload.Param == nil || payload.Param.FormatType != markdownFormatType {
+		t.Fatalf("expected markdown format param by default, got %#v", payload.Param)
+	}
+}
+
+func TestSendReplyFormatTypeOverride(t *testing.T) {
+	adapter := NewAdapter("https://www.yunzhijia.com/send", "", 10, "yunzhijia.com")
+	var payload sendMessagePayload
+	adapter.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	incoming := &im.IncomingMessage{UserID: "user"}
+
+	// Empty string explicitly disables the param.
+	if err := adapter.SendReply(context.Background(), incoming, &im.ReplyMessage{
+		Content: "answer",
+		Extra:   map[string]string{"yunzhijia_format_type": ""},
+	}); err != nil {
+		t.Fatalf("SendReply() error = %v", err)
+	}
+	if payload.Param != nil {
+		t.Fatalf("expected no param when format type overridden to empty, got %#v", payload.Param)
+	}
+
+	// Non-empty override replaces the default markdown formatType.
+	if err := adapter.SendReply(context.Background(), incoming, &im.ReplyMessage{
+		Content: "answer",
+		Extra:   map[string]string{"yunzhijia_format_type": "text"},
+	}); err != nil {
+		t.Fatalf("SendReply() error = %v", err)
+	}
+	if payload.Param == nil || payload.Param.FormatType != "text" {
+		t.Fatalf("expected overridden format type 'text', got %#v", payload.Param)
+	}
 }

--- a/internal/im/yunzhijia/types.go
+++ b/internal/im/yunzhijia/types.go
@@ -15,13 +15,20 @@ type callbackMessage struct {
 
 // sendMessagePayload is the JSON body POSTed to sendMsgUrl to reply.
 type sendMessagePayload struct {
-	MsgType      int           `json:"msgtype"`
-	Content      string        `json:"content"`
-	NotifyParams []notifyParam `json:"notifyParams,omitempty"`
+	MsgType      int               `json:"msgtype"`
+	Content      string            `json:"content"`
+	NotifyParams []notifyParam     `json:"notifyParams,omitempty"`
+	Param        *sendMessageParam `json:"param,omitempty"`
 }
 
 // notifyParam specifies recipients in a Yunzhijia send message request.
 type notifyParam struct {
 	Type   string   `json:"type"`
 	Values []string `json:"values"`
+}
+
+// sendMessageParam carries extra rendering options for a Yunzhijia reply,
+// such as requesting Markdown rendering of Content via formatType.
+type sendMessageParam struct {
+	FormatType string `json:"formatType,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Request Yunzhijia to render bot replies as Markdown by default.
- Add `param.formatType=markdown` to the Yunzhijia `sendMsgUrl` payload.
- Keep an explicit escape hatch via `reply.Extra["yunzhijia_format_type"]` so callers can override or omit the param.

## Why

WeKnora answers are authored as Markdown. Without the Yunzhijia rendering param, replies may be displayed as plain text instead of rich Markdown in Yunzhijia conversations.

Screenshot from Yunzhijia manual verification:

> The screenshot shows a Yunzhijia bot reply rendering Markdown sections, bold text, bullets, emoji, and reply actions correctly.
<img width="829" height="522" alt="image" src="https://github.com/user-attachments/assets/46d56906-6b6a-417d-8cb8-a82fff72ca42" />


## Validation

- Reviewed diff against `upstream/main`; scope is limited to `internal/im/yunzhijia`.
- Added unit coverage for the default Markdown payload param and override behavior.


