### PR TITLE
fix: 修复IM问答无法读取session的问题

### DIFF
--- a/internal/application/service/session.go
+++ b/internal/application/service/session.go
@@ -34,11 +34,13 @@ func loadSessionForRead(
 	ownerID, sessionID string,
 ) (*types.Session, error) {
 	isAdmin := types.TenantRoleFromContext(ctx).HasPermission(types.TenantRoleAdmin)
+	principal, hasPrincipal := types.PrincipalFromContext(ctx)
+	isIMRuntime := hasPrincipal && principal.Type == types.PrincipalIMUser
 
 	session, err := repo.Get(ctx, tenantID, ownerID, sessionID)
 	if err == nil {
 		imPlatform, _ := repo.GetIMPlatform(ctx, tenantID, sessionID)
-		if types.SessionRequiresAdminConsoleRead(session, imPlatform) && !isAdmin {
+		if types.SessionRequiresAdminConsoleRead(session, imPlatform) && !isAdmin && !isIMRuntime {
 			return nil, apperrors.ErrSessionNotFound
 		}
 		if imPlatform != "" {

--- a/internal/application/service/session_user_scope_test.go
+++ b/internal/application/service/session_user_scope_test.go
@@ -292,6 +292,33 @@ func TestGetSessionDeniesViewerOnIMSession(t *testing.T) {
 	require.Equal(t, "feishu", got.IMPlatform)
 }
 
+func TestGetSessionAllowsIMRuntimeToReadIMSession(t *testing.T) {
+	svc, db := newTestSessionService(t)
+	require.NoError(t, db.AutoMigrate(&testListSessionsIMChannelSession{}))
+
+	imSession := &types.Session{TenantID: 1, Title: "feishu chat"}
+	require.NoError(t, db.Create(imSession).Error)
+	require.NoError(t, db.Create(&testListSessionsIMChannelSession{
+		SessionID: imSession.ID,
+		Platform:  "feishu",
+	}).Error)
+
+	ctx := context.WithValue(
+		testSessionScopeContext(1, "system-1"),
+		types.TenantRoleContextKey,
+		types.TenantRoleViewer,
+	)
+	ctx = types.WithPrincipal(ctx, types.Principal{
+		Type: types.PrincipalIMUser,
+		ID:   "1:channel-1:feishu:open-id-1",
+	})
+
+	got, err := svc.GetSession(ctx, imSession.ID)
+	require.NoError(t, err)
+	require.Equal(t, imSession.ID, got.ID)
+	require.Equal(t, "feishu", got.IMPlatform)
+}
+
 // testListSessionsIMChannelSession lets QueryPaged's LEFT JOIN resolve against a
 // real table in the in-memory SQLite database.
 type testListSessionsIMChannelSession struct {


### PR DESCRIPTION
## 问题背景
飞书IM无法收到回复，查看日志发现，收到消息后会成功创建或找到对应会话，但紧接着读取会话时返回 `session not found`，导致机器人无法继续处理消息并回复。
<img width="3296" height="596" alt="50fff89451ab19a588418667107b93bc" src="https://github.com/user-attachments/assets/31577d20-ca7e-4cae-8262-056d547e5700" />

## 根因
新版增加了渠道会话权限管理，预期是普通用户不能看IM会话。但把机器人自己也拦住了，导致现在IM机器人无法回复。因为IM 消息处理链路使用 Viewer 租户角色运行，已有的会话读取逻辑会限制非管理员从网页控制台读取渠道托管会话。该限制同时误作用于飞书机器人内部处理消息的请求：IM 会话被识别为渠道会话，而机器人身份不是 Admin，从而读取失败。
<img width="1998" height="1348" alt="image" src="https://github.com/user-attachments/assets/e3c801cf-50ea-4eed-8fe0-653c5f5e9bd0" />

## 修复方案

识别当前请求的 `principal` 类型：

- 当请求来自内部 IM 运行时（`im_user`）时，允许读取对应的 IM 会话；
- 普通网页 Viewer 读取 IM 会话时，仍返回无权限可见的 `session not found`；
- API Key 和嵌入式会话的原有权限逻辑不变。

## 验证

- 新增 IM 运行时读取 IM 会话的回归测试；
- 保留普通 Viewer 无法读取 IM 会话的已有测试；