### PR TITLE
fix(session): support agent_id filtering for session list

### DIFF
--- a/internal/application/repository/session.go
+++ b/internal/application/repository/session.go
@@ -157,6 +157,14 @@ func (r *sessionRepository) QueryPaged(
 		orderClause = "s.is_pinned DESC, s.pinned_at DESC, s.updated_at DESC"
 	}
 
+	sessionAgentExpr := "json_extract(s.agent_config, '$.agent_id') = ?"
+	switch r.db.Dialector.Name() {
+	case "postgres":
+		sessionAgentExpr = "s.agent_config ->> 'agent_id' = ?"
+	case "mysql":
+		sessionAgentExpr = "JSON_UNQUOTE(JSON_EXTRACT(s.agent_config, '$.agent_id')) = ?"
+	}
+
 	// Base filter shared by count and list queries.
 	applyBase := func(db *gorm.DB) *gorm.DB {
 		db = db.Where("s.tenant_id = ? AND s.deleted_at IS NULL", q.TenantID)
@@ -217,8 +225,8 @@ func (r *sessionRepository) QueryPaged(
 		}
 	}
 	applyAgent := func(db *gorm.DB) *gorm.DB {
-		if q.AgentID != "" {
-			return db.Where("ics.agent_id = ?", q.AgentID)
+		if agentID := strings.TrimSpace(q.AgentID); agentID != "" {
+			return db.Where("(ics.agent_id = ? OR "+sessionAgentExpr+")", agentID, agentID)
 		}
 		return db
 	}

--- a/internal/application/repository/session_test.go
+++ b/internal/application/repository/session_test.go
@@ -265,6 +265,36 @@ func TestSessionRepositoryQueryPagedWebExcludesAPIKeySessions(t *testing.T) {
 		"web must keep legacy tenant rows but exclude API-key sessions")
 }
 
+func TestSessionRepositoryQueryPagedFiltersWebSessionsByAgentID(t *testing.T) {
+	repo, db := newSessionRepositoryForTest(t)
+	require.NoError(t, db.AutoMigrate(&testIMChannelSession{}))
+	ctx := context.Background()
+
+	matching := createSessionForTest(t, db, 1, "alice")
+	otherAgent := createSessionForTest(t, db, 1, "alice")
+	otherTenant := createSessionForTest(t, db, 2, "alice")
+
+	_, err := repo.UpdateLastRequestState(ctx, 1, "alice", matching.ID, &types.SessionLastRequestState{
+		AgentID: "agent-target",
+	})
+	require.NoError(t, err)
+	_, err = repo.UpdateLastRequestState(ctx, 1, "alice", otherAgent.ID, &types.SessionLastRequestState{
+		AgentID: "agent-other",
+	})
+	require.NoError(t, err)
+	_, err = repo.UpdateLastRequestState(ctx, 2, "alice", otherTenant.ID, &types.SessionLastRequestState{
+		AgentID: "agent-target",
+	})
+	require.NoError(t, err)
+
+	items, total, err := repo.QueryPaged(ctx, &types.SessionListQuery{
+		TenantID: 1, UserID: "alice", Source: "web", AgentID: "agent-target", Page: 1, PageSize: 50,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.Equal(t, []string{matching.ID}, listItemIDsForTest(items))
+}
+
 func TestSessionRepositoryGetIMPlatform(t *testing.T) {
 	repo, db := newSessionRepositoryForTest(t)
 	require.NoError(t, db.AutoMigrate(&testIMChannelSession{}))

--- a/internal/handler/session/handler.go
+++ b/internal/handler/session/handler.go
@@ -202,7 +202,7 @@ func (h *Handler) GetSession(c *gin.Context) {
 // @Param        page_size  query     int     false  "每页数量"
 // @Param        keyword    query     string  false  "标题模糊搜索"
 // @Param        source     query     string  false  "来源过滤：web / embed / api / feishu / wechat / slack / ...（api、embed、IM 渠道需 Admin+）"
-// @Param        agent_id   query     string  false  "按 Agent 过滤（仅对 IM 会话生效）"
+// @Param        agent_id   query     string  false  "按 Agent 过滤"
 // @Success      200        {object}  map[string]interface{}  "会话列表"
 // @Failure      400        {object}  errors.AppError         "请求参数错误"
 // @Security     Bearer

--- a/internal/types/session.go
+++ b/internal/types/session.go
@@ -175,7 +175,8 @@ func SessionRequiresAdminConsoleRead(s *Session, imPlatform string) bool {
 // Source values: "web" (user chats, no IM/embed), "embed" / "embed:{channelID}",
 // "api" (all API-key sessions, Admin+ only), or an IM platform name
 // (e.g. "feishu", "wechat"). IM and embed sources are also Admin+ only.
-// AgentID currently only filters sessions that have an IM channel mapping.
+// AgentID filters sessions whose last request state or IM channel mapping used
+// the agent.
 type SessionListQuery struct {
 	TenantID uint64
 	UserID   string


### PR DESCRIPTION
### What changed

This fixes session list filtering by `agent_id` so it works for normal Web/API sessions as well as IM sessions.

Previously, `GET /sessions?agent_id=...` only matched `im_channel_sessions.agent_id`. Web sessions store the last selected agent in `sessions.agent_config` as `SessionLastRequestState.AgentID`, so they were never returned by an agent filter.

The repository filter now matches either:

- `im_channel_sessions.agent_id`
- `sessions.agent_config.agent_id`

The JSON expression is selected per GORM dialect for Postgres, MySQL, and SQLite.

### Root cause

The handler already accepted the `agent_id` query parameter and passed it into `SessionListQuery`, but `QueryPaged` only applied it against the IM channel mapping join. That made the API behave as if `agent_id` search was unsupported for sessions created through the regular chat flow.

### Validation

Red/green regression test:

- Added `TestSessionRepositoryQueryPagedFiltersWebSessionsByAgentID`
- Before the fix it failed with `expected: 1, actual: 0`
- After the fix it passes

Commands run:

- `CGO_LDFLAGS='-lc++' go test ./internal/application/repository -run TestSessionRepositoryQueryPagedFiltersWebSessionsByAgentID -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/repository -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service -run 'TestListSessions|TestGetSession' -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/types -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/handler/session -count=1`
- `git diff --check`

Closes #2140.
