### PR TITLE
feat(knowledge): upsert file uploads by first-line hash_id

### DIFF
--- a/docs/api/knowledge.md
+++ b/docs/api/knowledge.md
@@ -58,6 +58,28 @@
 
 `process_config` 可选字段包括：`parser_engine_rules`、`chunking_config`、`enable_multimodel`、`vlm_config`、`asr_config`、`question_generation_config`、`graph_enabled`、`extract_config`。若同时传 `enable_multimodel` 与 `process_config.enable_multimodel`，以 `process_config` 为准。
 
+### 文档身份 `hash_id`（文本文件 upsert）
+
+对 `md` / `markdown` / `txt` / `csv` / `json` / `html` / `mhtml`，若**正文第一行**声明稳定身份，系统会按该身份做新增或更新，而不是仅凭文件名/内容哈希新建：
+
+```text
+hash_id = alarm-policy
+
+# 告警策略
+...
+```
+
+也支持 `# hash_id = alarm-policy`（Markdown 注释风格）与 `hash_id=alarm-policy`。
+
+| 情况 | 行为 |
+| ---- | ---- |
+| 库内无同 `hash_id` | 新建，并写入 `metadata.hash_id` |
+| 已有同 `hash_id`，内容未变 | 返回 `409 duplicate_file`（与现有内容去重一致） |
+| 已有同 `hash_id`，内容已变 | 删除旧条目后创建新条目（覆盖更新） |
+| 未声明 `hash_id` | 保持原行为：相同内容哈希视为重复 |
+
+`hash_id` 会写入知识条目的 `metadata.hash_id`，便于 OpenClaw / CLI / API 反复同步同一篇文档。
+
 **请求**:
 
 ```curl

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -76,6 +76,10 @@ type knowledgeService struct {
 	// handled because the public surface is the SpanTracker interface,
 	// which has a no-op fallback. See knowledge_span_tracker.go.
 	spanTracker SpanTracker
+
+	// deleteKnowledgeHook overrides DeleteKnowledge for unit tests of the
+	// hash_id upsert path. Production code leaves this nil.
+	deleteKnowledgeHook func(ctx context.Context, id string) error
 }
 
 const (

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -76,27 +76,69 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 		return nil, err
 	}
 
-	// Check if file already exists
 	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
-	logger.Infof(ctx, "Checking if file exists, tenant ID: %d", tenantID)
-	exists, existingKnowledge, err := s.repo.CheckKnowledgeExists(ctx, tenantID, kbID, &types.KnowledgeCheckParams{
-		Type:     "file",
-		FileName: fileName,
-		FileSize: file.Size,
-		FileHash: hash,
-	})
+
+	// Stable document identity from first line: "hash_id = <id>".
+	// When present, re-uploads with the same id replace the previous entry
+	// instead of creating a duplicate (content-hash dedupe still applies when
+	// the bytes are unchanged).
+	docHashID, err := extractDocumentHashID(file, fileName)
 	if err != nil {
-		logger.Errorf(ctx, "Failed to check knowledge existence: %v", err)
+		logger.Errorf(ctx, "Failed to extract document hash_id: %v", err)
 		return nil, err
 	}
-	if exists {
-		logger.Infof(ctx, "File already exists: %s", fileName)
-		// Update creation time for existing knowledge
-		if err := s.repo.UpdateKnowledgeColumn(ctx, existingKnowledge.ID, "created_at", time.Now()); err != nil {
-			logger.Errorf(ctx, "Failed to update existing knowledge: %v", err)
+	if docHashID != "" {
+		if metadata == nil {
+			metadata = make(map[string]string)
+		}
+		metadata[types.MetadataHashIDKey] = docHashID
+		logger.Infof(ctx, "Document hash_id declared: %s", docHashID)
+
+		existingByHashID, err := s.repo.FindByMetadataKey(ctx, tenantID, kbID, types.MetadataHashIDKey, docHashID)
+		if err != nil {
+			logger.Errorf(ctx, "Failed to look up knowledge by hash_id: %v", err)
 			return nil, err
 		}
-		return existingKnowledge, types.NewDuplicateFileError(existingKnowledge)
+		if existingByHashID != nil {
+			if existingByHashID.FileHash == hash {
+				logger.Infof(ctx, "File already exists for hash_id=%s (identical content): %s", docHashID, fileName)
+				if err := s.repo.UpdateKnowledgeColumn(ctx, existingByHashID.ID, "created_at", time.Now()); err != nil {
+					logger.Errorf(ctx, "Failed to update existing knowledge: %v", err)
+					return nil, err
+				}
+				return existingByHashID, types.NewDuplicateFileError(existingByHashID)
+			}
+			logger.Infof(ctx, "Updating knowledge %s for hash_id=%s (content changed)", existingByHashID.ID, docHashID)
+			deleteFn := s.DeleteKnowledge
+			if s.deleteKnowledgeHook != nil {
+				deleteFn = s.deleteKnowledgeHook
+			}
+			if err := deleteFn(ctx, existingByHashID.ID); err != nil {
+				logger.Errorf(ctx, "Failed to delete existing knowledge for hash_id upsert: %v", err)
+				return nil, err
+			}
+		}
+	} else {
+		// Legacy path: identical content (by file hash) is treated as a duplicate.
+		logger.Infof(ctx, "Checking if file exists, tenant ID: %d", tenantID)
+		exists, existingKnowledge, err := s.repo.CheckKnowledgeExists(ctx, tenantID, kbID, &types.KnowledgeCheckParams{
+			Type:     "file",
+			FileName: fileName,
+			FileSize: file.Size,
+			FileHash: hash,
+		})
+		if err != nil {
+			logger.Errorf(ctx, "Failed to check knowledge existence: %v", err)
+			return nil, err
+		}
+		if exists {
+			logger.Infof(ctx, "File already exists: %s", fileName)
+			if err := s.repo.UpdateKnowledgeColumn(ctx, existingKnowledge.ID, "created_at", time.Now()); err != nil {
+				logger.Errorf(ctx, "Failed to update existing knowledge: %v", err)
+				return nil, err
+			}
+			return existingKnowledge, types.NewDuplicateFileError(existingKnowledge)
+		}
 	}
 
 	// Check storage quota

--- a/internal/application/service/knowledge_create_test.go
+++ b/internal/application/service/knowledge_create_test.go
@@ -21,6 +21,13 @@ type createKnowledgeFileRepoStub struct {
 	createCalls      int
 	createErr        error
 	createdKnowledge *types.Knowledge
+
+	byHashID            map[string]*types.Knowledge
+	findByHashIDCalls   int
+	checkExistsCalls    int
+	updateColumnCalls   int
+	duplicateKnowledge  *types.Knowledge
+	checkExistsFileHash string
 }
 
 func (r *createKnowledgeFileRepoStub) CheckKnowledgeExists(
@@ -29,7 +36,35 @@ func (r *createKnowledgeFileRepoStub) CheckKnowledgeExists(
 	kbID string,
 	params *types.KnowledgeCheckParams,
 ) (bool, *types.Knowledge, error) {
+	r.checkExistsCalls++
+	if r.duplicateKnowledge != nil && (r.checkExistsFileHash == "" || r.checkExistsFileHash == params.FileHash) {
+		return true, r.duplicateKnowledge, nil
+	}
 	return false, nil, nil
+}
+
+func (r *createKnowledgeFileRepoStub) FindByMetadataKey(
+	ctx context.Context,
+	tenantID uint64,
+	kbID string,
+	key string,
+	value string,
+) (*types.Knowledge, error) {
+	r.findByHashIDCalls++
+	if r.byHashID == nil {
+		return nil, nil
+	}
+	return r.byHashID[value], nil
+}
+
+func (r *createKnowledgeFileRepoStub) UpdateKnowledgeColumn(
+	ctx context.Context,
+	id string,
+	column string,
+	value interface{},
+) error {
+	r.updateColumnCalls++
+	return nil
 }
 
 func (r *createKnowledgeFileRepoStub) CreateKnowledge(ctx context.Context, knowledge *types.Knowledge) error {
@@ -267,6 +302,127 @@ func TestCreateKnowledgeFromFile_PersistsProcessOverrides(t *testing.T) {
 	metadataMap, err := repo.createdKnowledge.Metadata.Map()
 	require.NoError(t, err)
 	require.Equal(t, "test", metadataMap["source"])
+}
+
+func TestCreateKnowledgeFromFile_PersistsHashIDFromFirstLine(t *testing.T) {
+	t.Parallel()
+
+	repo := &createKnowledgeFileRepoStub{}
+	fileSvc := &createKnowledgeFileServiceStub{}
+	task := &createKnowledgeTaskEnqueuerStub{}
+	svc := &knowledgeService{
+		repo:      repo,
+		kbService: &createKnowledgeFileKBServiceStub{kb: &types.KnowledgeBase{ID: "kb-1"}},
+		fileSvc:   fileSvc,
+		task:      task,
+	}
+
+	content := "hash_id = alarm-policy\n\n# 告警策略\n"
+	knowledge, err := svc.CreateKnowledgeFromFile(
+		newCreateKnowledgeFileContext(),
+		"kb-1",
+		newMultipartFileHeader(t, "告警策略.md", content),
+		nil,
+		nil,
+		"",
+		nil,
+		"",
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, knowledge)
+	require.Equal(t, 1, repo.findByHashIDCalls)
+	require.Zero(t, repo.checkExistsCalls)
+	require.Equal(t, 1, repo.createCalls)
+
+	metadataMap, err := repo.createdKnowledge.Metadata.Map()
+	require.NoError(t, err)
+	require.Equal(t, "alarm-policy", metadataMap[types.MetadataHashIDKey])
+}
+
+func TestCreateKnowledgeFromFile_HashIDIdenticalContentIsDuplicate(t *testing.T) {
+	t.Parallel()
+
+	content := "hash_id = alarm-policy\nbody"
+	fh := newMultipartFileHeader(t, "告警策略.md", content)
+	hash, err := calculateFileHash(fh)
+	require.NoError(t, err)
+
+	existing := &types.Knowledge{ID: "k-existing", FileHash: hash, FileName: "告警策略.md"}
+	repo := &createKnowledgeFileRepoStub{
+		byHashID: map[string]*types.Knowledge{"alarm-policy": existing},
+	}
+	svc := &knowledgeService{
+		repo:      repo,
+		kbService: &createKnowledgeFileKBServiceStub{kb: &types.KnowledgeBase{ID: "kb-1"}},
+		fileSvc:   &createKnowledgeFileServiceStub{},
+	}
+
+	knowledge, err := svc.CreateKnowledgeFromFile(
+		newCreateKnowledgeFileContext(),
+		"kb-1",
+		newMultipartFileHeader(t, "告警策略.md", content),
+		nil,
+		nil,
+		"",
+		nil,
+		"",
+		nil,
+	)
+
+	require.Error(t, err)
+	var dup *types.DuplicateKnowledgeError
+	require.ErrorAs(t, err, &dup)
+	require.Equal(t, existing, knowledge)
+	require.Zero(t, repo.createCalls)
+	require.Equal(t, 1, repo.updateColumnCalls)
+}
+
+func TestCreateKnowledgeFromFile_HashIDContentChangeReplaces(t *testing.T) {
+	t.Parallel()
+
+	existing := &types.Knowledge{ID: "k-old", FileHash: "old-hash", FileName: "告警策略.md"}
+	repo := &createKnowledgeFileRepoStub{
+		byHashID: map[string]*types.Knowledge{"alarm-policy": existing},
+	}
+	fileSvc := &createKnowledgeFileServiceStub{}
+	task := &createKnowledgeTaskEnqueuerStub{}
+	var deletedID string
+	svc := &knowledgeService{
+		repo:      repo,
+		kbService: &createKnowledgeFileKBServiceStub{kb: &types.KnowledgeBase{ID: "kb-1"}},
+		fileSvc:   fileSvc,
+		task:      task,
+		deleteKnowledgeHook: func(ctx context.Context, id string) error {
+			deletedID = id
+			delete(repo.byHashID, "alarm-policy")
+			return nil
+		},
+	}
+
+	content := "hash_id = alarm-policy\nupdated body"
+	knowledge, err := svc.CreateKnowledgeFromFile(
+		newCreateKnowledgeFileContext(),
+		"kb-1",
+		newMultipartFileHeader(t, "告警策略.md", content),
+		nil,
+		nil,
+		"",
+		nil,
+		"",
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, knowledge)
+	require.Equal(t, "k-old", deletedID)
+	require.Equal(t, 1, repo.createCalls)
+	require.NotEqual(t, "k-old", knowledge.ID)
+
+	metadataMap, err := repo.createdKnowledge.Metadata.Map()
+	require.NoError(t, err)
+	require.Equal(t, "alarm-policy", metadataMap[types.MetadataHashIDKey])
 }
 
 func newCreateKnowledgeFileContext() context.Context {

--- a/internal/application/service/knowledge_hash_id_test.go
+++ b/internal/application/service/knowledge_hash_id_test.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractDocumentHashID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		filename string
+		content  string
+		want     string
+	}{
+		{
+			name:     "plain assignment",
+			filename: "告警策略.md",
+			content:  "hash_id = alarm-policy\n\n# 告警策略\n",
+			want:     "alarm-policy",
+		},
+		{
+			name:     "no spaces around equals",
+			filename: "doc.md",
+			content:  "hash_id=docs/alert.md\nbody",
+			want:     "docs/alert.md",
+		},
+		{
+			name:     "markdown comment style",
+			filename: "doc.md",
+			content:  "# hash_id = alarm-policy\n# Title\n",
+			want:     "alarm-policy",
+		},
+		{
+			name:     "utf8 bom prefix",
+			filename: "doc.txt",
+			content:  "\ufeffhash_id = bom-id\nhello",
+			want:     "bom-id",
+		},
+		{
+			name:     "crlf line ending",
+			filename: "doc.md",
+			content:  "hash_id = crlf-id\r\nrest",
+			want:     "crlf-id",
+		},
+		{
+			name:     "missing declaration",
+			filename: "doc.md",
+			content:  "# Title\nhash_id = later\n",
+			want:     "",
+		},
+		{
+			name:     "binary extension skipped",
+			filename: "doc.pdf",
+			content:  "hash_id = should-ignore\n",
+			want:     "",
+		},
+		{
+			name:     "empty file",
+			filename: "doc.md",
+			content:  "",
+			want:     "",
+		},
+		{
+			name:     "only hash_id line",
+			filename: "doc.md",
+			content:  "hash_id = solo",
+			want:     "solo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fh := newMultipartFileHeader(t, tt.filename, tt.content)
+			got, err := extractDocumentHashID(fh, tt.filename)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSupportsDocumentHashID(t *testing.T) {
+	t.Parallel()
+	assert.True(t, supportsDocumentHashID("a.md"))
+	assert.True(t, supportsDocumentHashID("a.markdown"))
+	assert.True(t, supportsDocumentHashID("a.TXT"))
+	assert.False(t, supportsDocumentHashID("a.pdf"))
+	assert.False(t, supportsDocumentHashID("a.docx"))
+}

--- a/internal/application/service/knowledge_util.go
+++ b/internal/application/service/knowledge_util.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bufio"
 	"context"
 	"crypto/md5"
 	"encoding/hex"
@@ -9,8 +10,10 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -18,6 +21,15 @@ import (
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
+
+// documentHashIDLine matches the first-line identity declaration:
+//
+//	hash_id = alarm-policy
+//	hash_id=alarm-policy
+//	# hash_id = alarm-policy
+var documentHashIDLine = regexp.MustCompile(`(?i)^\s*(?:#\s*)?hash_id\s*=\s*(\S+)\s*$`)
+
+const maxDocumentHashIDLen = 128
 
 // isValidFileType checks if a file type is supported
 func isValidFileType(filename string) bool {
@@ -67,6 +79,56 @@ func calculateFileHash(file *multipart.FileHeader) (string, error) {
 	}
 
 	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// supportsDocumentHashID reports whether the file type can declare a stable
+// identity via a first-line "hash_id = ..." marker. Binary formats are skipped
+// because their "first line" is not author-controlled text.
+func supportsDocumentHashID(filename string) bool {
+	switch strings.ToLower(getFileType(filename)) {
+	case "md", "markdown", "txt", "csv", "json", "html", "mhtml":
+		return true
+	default:
+		return false
+	}
+}
+
+// extractDocumentHashID reads the first line of a text upload and, when it
+// declares "hash_id = <id>", returns that id. Empty string means no identity
+// declaration (caller keeps legacy create / content-hash dedupe behavior).
+func extractDocumentHashID(file *multipart.FileHeader, filename string) (string, error) {
+	if file == nil || !supportsDocumentHashID(filename) {
+		return "", nil
+	}
+
+	f, err := file.Open()
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	reader := bufio.NewReader(f)
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	line = strings.TrimRight(line, "\r\n")
+	// UTF-8 BOM is common in editor-saved markdown; strip before matching.
+	line = strings.TrimPrefix(line, "\ufeff")
+
+	matches := documentHashIDLine.FindStringSubmatch(line)
+	if len(matches) != 2 {
+		return "", nil
+	}
+	hashID := strings.TrimSpace(matches[1])
+	if hashID == "" || utf8.RuneCountInString(hashID) > maxDocumentHashIDLen {
+		return "", nil
+	}
+	// Reject values that would be unsafe in metadata / logs.
+	if safe, ok := secutils.ValidateInput(hashID); !ok || safe != hashID {
+		return "", nil
+	}
+	return hashID, nil
 }
 
 func calculateStr(strList ...string) string {

--- a/internal/types/knowledge.go
+++ b/internal/types/knowledge.go
@@ -16,6 +16,12 @@ const (
 	KnowledgeTypeFAQ = "faq"
 )
 
+// MetadataHashIDKey is the knowledge.metadata key that stores a stable document
+// identity declared on the first line of an uploaded text file
+// (e.g. "hash_id = alarm-policy"). Used to upsert on re-upload instead of
+// creating a duplicate entry when content changes.
+const MetadataHashIDKey = "hash_id"
+
 // Channel constants identify through which channel a knowledge entry was ingested.
 // Aligned with Message.Channel values ("web", "api", "im") but allows finer granularity.
 const (


### PR DESCRIPTION
## Summary
- Text uploads (`md` / `txt` / `csv` / `json` / `html` / `mhtml`) can declare a stable identity on the **first line**: `hash_id = <id>` (also `# hash_id = <id>`).
- Same `hash_id` + unchanged content → existing `409 duplicate_file` behavior.
- Same `hash_id` + changed content → delete-then-recreate (upsert), so docs like `告警策略.md` can be re-uploaded without spawning duplicates.
- Identity is stored in `metadata.hash_id`; API docs updated.

## Test plan
- [ ] Upload a markdown file whose first line is `hash_id = alarm-policy` → creates one knowledge entry with `metadata.hash_id`.
- [ ] Re-upload the identical file → `409 duplicate_file`, no second entry.
- [ ] Change body, keep the same `hash_id` line, re-upload → old entry replaced, retrieval reflects new content.
- [ ] Upload without `hash_id` → legacy content-hash dedupe unchanged.
- [ ] `go test ./internal/application/service/ -run 'TestExtractDocumentHashID|TestSupportsDocumentHashID|TestCreateKnowledgeFromFile'`


Made with [Cursor](https://cursor.com)