### PR TITLE
[codex] Route inline think tags in chat stream

### DIFF
--- a/internal/application/service/chat_pipeline/chat_completion_stream.go
+++ b/internal/application/service/chat_pipeline/chat_completion_stream.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	agenttools "github.com/Tencent/WeKnora/internal/agent/tools"
 	"github.com/Tencent/WeKnora/internal/event"
 	"github.com/Tencent/WeKnora/internal/llmreference"
 	"github.com/Tencent/WeKnora/internal/llmresource"
@@ -117,6 +118,7 @@ func (p *PluginChatCompletionStream) OnEvent(ctx context.Context,
 		thinkingID := fmt.Sprintf("%s-thinking", uuid.New().String()[:8])
 		answerID := fmt.Sprintf("%s-answer", uuid.New().String()[:8])
 		thinkingOpen := false
+		inlineThinkSplitter := agenttools.NewThinkStreamSplitter()
 
 		closeThinking := func() {
 			if !thinkingOpen {
@@ -133,12 +135,53 @@ func (p *PluginChatCompletionStream) OnEvent(ctx context.Context,
 			thinkingOpen = false
 		}
 
+		emitThinking := func(content string) {
+			content = thinkingRefExpander.Feed(thinkingDecoder.Feed(content))
+			if content == "" {
+				return
+			}
+			thinkingOpen = true
+			eventBus.Emit(ctx, types.Event{
+				ID:        thinkingID,
+				Type:      types.EventType(event.EventAgentThought),
+				SessionID: chatManage.SessionID,
+				Data: event.AgentThoughtData{
+					Content: content,
+					Done:    false,
+				},
+			})
+		}
+
+		emitAnswer := func(content string, done bool) {
+			content = answerRefExpander.Feed(answerDecoder.Feed(content))
+			if content == "" && !done {
+				return
+			}
+			closeThinking()
+			eventBus.Emit(ctx, types.Event{
+				ID:        answerID,
+				Type:      types.EventType(event.EventAgentFinalAnswer),
+				SessionID: chatManage.SessionID,
+				Data: event.AgentFinalAnswerData{
+					Content: content,
+					Done:    done,
+				},
+			})
+		}
+
 		// flushDecoders drains any alias suffix the stream decoders held back to
 		// bridge references split across provider chunks. Both the normal close
 		// and the cancellation path must call this, otherwise a resource
 		// reference in flight at teardown is silently dropped (and never
 		// persisted, since the assistant message is saved from these events).
 		flushDecoders := func() {
+			thinkTail, answerTailFromThink := inlineThinkSplitter.Flush()
+			if thinkTail != "" {
+				emitThinking(thinkTail)
+			}
+			if answerTailFromThink != "" {
+				emitAnswer(answerTailFromThink, false)
+			}
 			thinkingTail := thinkingRefExpander.Feed(thinkingDecoder.Flush()) + thinkingRefExpander.Flush()
 			if thinkingTail != "" {
 				_ = eventBus.Emit(ctx, types.Event{
@@ -198,19 +241,7 @@ func (p *PluginChatCompletionStream) OnEvent(ctx context.Context,
 				}
 
 				if response.ResponseType == types.ResponseTypeThinking {
-					response.Content = thinkingRefExpander.Feed(thinkingDecoder.Feed(response.Content))
-					if response.Content != "" {
-						thinkingOpen = true
-						eventBus.Emit(ctx, types.Event{
-							ID:        thinkingID,
-							Type:      types.EventType(event.EventAgentThought),
-							SessionID: chatManage.SessionID,
-							Data: event.AgentThoughtData{
-								Content: response.Content,
-								Done:    false,
-							},
-						})
-					}
+					emitThinking(response.Content)
 					if response.Done {
 						closeThinking()
 					}
@@ -218,17 +249,11 @@ func (p *PluginChatCompletionStream) OnEvent(ctx context.Context,
 				}
 
 				if response.ResponseType == types.ResponseTypeAnswer {
-					response.Content = answerRefExpander.Feed(answerDecoder.Feed(response.Content))
-					closeThinking()
-					eventBus.Emit(ctx, types.Event{
-						ID:        answerID,
-						Type:      types.EventType(event.EventAgentFinalAnswer),
-						SessionID: chatManage.SessionID,
-						Data: event.AgentFinalAnswerData{
-							Content: response.Content,
-							Done:    response.Done,
-						},
-					})
+					thinkingPart, answerPart := inlineThinkSplitter.Feed(response.Content)
+					if thinkingPart != "" {
+						emitThinking(thinkingPart)
+					}
+					emitAnswer(answerPart, response.Done)
 				}
 			}
 		}

--- a/internal/application/service/chat_pipeline/chat_completion_stream_test.go
+++ b/internal/application/service/chat_pipeline/chat_completion_stream_test.go
@@ -44,6 +44,21 @@ func (b *syncEventBus) finalAnswerContents() []string {
 	return out
 }
 
+func (b *syncEventBus) thoughtContents() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var out []string
+	for _, evt := range b.events {
+		if evt.Type != types.EventType(event.EventAgentThought) {
+			continue
+		}
+		if data, ok := evt.Data.(event.AgentThoughtData); ok && data.Content != "" {
+			out = append(out, data.Content)
+		}
+	}
+	return out
+}
+
 // openStreamChat returns a buffered channel preloaded with chunks and never
 // closes it, so the stream plugin blocks on the channel until ctx is cancelled
 // — deterministically exercising the ctx.Done() branch.
@@ -68,6 +83,28 @@ func (m *openStreamChat) ChatStream(
 func (m *openStreamChat) GetModelName() string { return "mock" }
 func (m *openStreamChat) GetModelID() string   { return "mock" }
 
+type closedStreamChat struct {
+	chunks []types.StreamResponse
+}
+
+func (m *closedStreamChat) Chat(context.Context, []chat.Message, *chat.ChatOptions) (*types.ChatResponse, error) {
+	return nil, nil
+}
+
+func (m *closedStreamChat) ChatStream(
+	context.Context, []chat.Message, *chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	ch := make(chan types.StreamResponse, len(m.chunks))
+	for _, c := range m.chunks {
+		ch <- c
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (m *closedStreamChat) GetModelName() string { return "mock" }
+func (m *closedStreamChat) GetModelID() string   { return "mock" }
+
 // stubModelService only needs GetChatModel; the rest is unused for this test.
 type stubModelService struct {
 	interfaces.ModelService
@@ -76,6 +113,32 @@ type stubModelService struct {
 
 func (s *stubModelService) GetChatModel(context.Context, string) (chat.Chat, error) {
 	return s.model, nil
+}
+
+func TestStreamRoutesInlineThinkTagsFromAnswerChunks(t *testing.T) {
+	bus := &syncEventBus{}
+	model := &closedStreamChat{chunks: []types.StreamResponse{
+		{ResponseType: types.ResponseTypeAnswer, Content: "<thi"},
+		{ResponseType: types.ResponseTypeAnswer, Content: "nk>hidden"},
+		{ResponseType: types.ResponseTypeAnswer, Content: "</think>visible", Done: true},
+	}}
+
+	chatManage := &types.ChatManage{}
+	chatManage.SessionID = "sess-think"
+	chatManage.UserContent = "question"
+	chatManage.EventBus = bus
+
+	plugin := &PluginChatCompletionStream{modelService: &stubModelService{model: model}}
+	require.Nil(t, plugin.OnEvent(context.Background(), types.CHAT_COMPLETION_STREAM, chatManage, func() *PluginError { return nil }))
+
+	require.Eventually(t, func() bool {
+		return len(bus.finalAnswerContents()) > 0
+	}, 2*time.Second, 5*time.Millisecond)
+
+	require.Contains(t, bus.thoughtContents(), "hidden")
+	require.NotContains(t, bus.finalAnswerContents(), "<thi")
+	require.NotContains(t, bus.finalAnswerContents(), "nk>hidden")
+	require.Contains(t, bus.finalAnswerContents(), "visible")
 }
 
 // TestStreamFlushesHeldAliasOnCancel verifies that when the request is cancelled


### PR DESCRIPTION
Fixes #2179.

## Root Cause

Some OpenAI-compatible reasoning models stream inline `<think>...</think>` blocks inside `ResponseTypeAnswer` chunks instead of using WeKnora's separate `ResponseTypeThinking` channel.

`PluginChatCompletionStream` only routed native `ResponseTypeThinking` chunks to `EventAgentThought`. Answer chunks were decoded and emitted directly as final-answer events, so inline reasoning tags could leak to the client.

## Changes

- Route `ResponseTypeAnswer` content through the existing `agent/tools.ThinkStreamSplitter`.
- Emit inline think content as `EventAgentThought`, reusing the same decoder/reference expansion path as native thinking chunks.
- Keep visible answer content on `EventAgentFinalAnswer`.
- Flush the splitter on normal channel close and context cancellation so split tag suffixes are not dropped.
- Add a regression test where `<think>` is split across multiple answer chunks.

## Validation

- RED: `CGO_LDFLAGS='-lc++' go test ./internal/application/service/chat_pipeline -run TestStreamRoutesInlineThinkTagsFromAnswerChunks -count=1` failed before the fix because no thought event contained `hidden`.
- GREEN: `CGO_LDFLAGS='-lc++' go test ./internal/application/service/chat_pipeline -run TestStreamRoutesInlineThinkTagsFromAnswerChunks -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service/chat_pipeline -run TestStreamFlushesHeldAliasOnCancel -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service/chat_pipeline -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/agent/tools -run 'TestThinkStreamSplitter|TestStripThinkBlocks' -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service/chat_pipeline ./internal/agent/tools -count=1`
- `git diff --check`
