### PR TITLE
fix: correct graph and multimodal processing traces

### DIFF
--- a/frontend/src/components/knowledge-processing-timeline.vue
+++ b/frontend/src/components/knowledge-processing-timeline.vue
@@ -3,26 +3,15 @@ import { ref, reactive, onMounted, onBeforeUnmount, watch, computed, nextTick } 
 import { MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
 import { getKnowledgeSpans, reparseKnowledge, cancelKnowledgeParse, getKnowledgeDetails } from '@/api/knowledge-base/index'
-import { knowledgeSpansPayloadHasTrace } from '@/utils/knowledgeTrace'
+import {
+  groupPostprocessGraphSpans,
+  knowledgeSpansPayloadHasTrace,
+  type KnowledgeTraceNode,
+} from '@/utils/knowledgeTrace'
 import { resolveTimelineHeaderStatus } from '@/utils/knowledgeProcessingStatus'
 import type { KnowledgeProcessOverrides } from '@/types/knowledgeProcess'
 
-interface SpanNode {
-  span_id?: string
-  parent_span_id?: string
-  name: string
-  kind: string
-  status: string
-  started_at?: string | null
-  finished_at?: string | null
-  duration_ms?: number
-  error_code?: string
-  error_message?: string
-  input?: any
-  output?: any
-  metadata?: any
-  children?: SpanNode[]
-}
+type SpanNode = KnowledgeTraceNode
 
 interface LastError {
   name: string
@@ -160,7 +149,9 @@ const stages = computed<SpanNode[]>(() => {
   const children = trace?.children || []
   const byName = new Map<string, SpanNode>()
   for (const c of children) {
-    if (c && c.kind === 'stage' && c.name) byName.set(c.name, c)
+    if (c && c.kind === 'stage' && c.name) {
+      byName.set(c.name, c.name === 'postprocess' ? groupPostprocessGraphSpans(c) : c)
+    }
   }
   return STAGES.map((n) => byName.get(n) || ({ name: n, kind: 'stage', status: 'pending' } as SpanNode))
 })
@@ -195,6 +186,13 @@ function formatRelativeTime(ts: number): string {
   if (sec < 60) return t('knowledgeStages.secondsAgo', { n: sec })
   const min = Math.floor(sec / 60)
   return t('knowledgeStages.minutesAgo', { n: min })
+}
+
+// A skipped stage did not execute. Its tiny bookkeeping interval is not
+// processing time, so do not present it as (for example) multimodal time.
+function formatSpanDuration(node: SpanNode): string {
+  if (node.status === 'skipped' || node.status === 'pending') return '—'
+  return formatDuration(node.duration_ms)
 }
 
 function isPolling(status?: string): boolean {
@@ -954,6 +952,9 @@ function localizedStatus(status: string): string {
 function rowLabel(row: FlatRow): string {
   if (row.isRoot) return t('knowledgeStages.root')
   if (row.isStage) return t(`knowledgeStages.stage.${row.node.name}`)
+  if (row.node.name === 'postprocess.graph') return t('knowledgeStages.processConfig.graph')
+  const graphChunk = /^postprocess\.graph\.chunk\[(\d+)\]$/.exec(row.node.name)
+  if (graphChunk) return `${t('knowledgeStages.processConfig.graph')} #${Number(graphChunk[1]) + 1}`
   return row.node.name
 }
 
@@ -1558,7 +1559,7 @@ const processConfigLines = computed<string[]>(() => {
                     <span class="kp-running-time">{{ formatDuration(liveElapsedMs(row.node)) }}</span>
                   </template>
                   <template v-else>
-                    {{ formatDuration(row.node.duration_ms) }}
+                    {{ formatSpanDuration(row.node) }}
                   </template>
                 </div>
 
@@ -1587,8 +1588,9 @@ const processConfigLines = computed<string[]>(() => {
                       <span class="kp-bar-tip">
                         <span class="kp-bar-tip-name">{{ rowLabel(row) }}</span>
                         <span class="kp-bar-tip-sep">·</span>
-                        <span class="kp-mono">{{ formatDuration(row.node.status === 'running' ? liveElapsedMs(row.node)
-                          : row.node.duration_ms) }}</span>
+                        <span class="kp-mono">{{ row.node.status === 'running'
+                          ? formatDuration(liveElapsedMs(row.node))
+                          : formatSpanDuration(row.node) }}</span>
                         <span class="kp-bar-tip-sep">·</span>
                         <span>{{ localizedStatus(row.node.status) }}</span>
                       </span>
@@ -1674,7 +1676,7 @@ const processConfigLines = computed<string[]>(() => {
                           <span class="kp-kv-tag-live">{{ t('knowledgeStages.detail.elapsed') }}</span>
                         </template>
                         <template v-else>
-                          {{ formatDuration(selectedRow.node.duration_ms) }}
+                          {{ formatSpanDuration(selectedRow.node) }}
                         </template>
                       </span>
                     </div>
@@ -1726,7 +1728,9 @@ const processConfigLines = computed<string[]>(() => {
                       <div class="kp-breakdown-track">
                         <div class="kp-breakdown-bar" :class="['kp-bar-' + s.status]" :style="{ width: s.pct + '%' }" />
                       </div>
-                      <span class="kp-breakdown-dur kp-mono">{{ formatDuration(s.duration_ms) }}</span>
+                      <span class="kp-breakdown-dur kp-mono">{{ s.status === 'skipped' || s.status === 'pending'
+                        ? '—'
+                        : formatDuration(s.duration_ms) }}</span>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/utils/knowledgeTrace.test.ts
+++ b/frontend/src/utils/knowledgeTrace.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { groupPostprocessGraphSpans, type KnowledgeTraceNode } from './knowledgeTrace.ts'
+
+function graphChunk(index: number, overrides: Partial<KnowledgeTraceNode> = {}): KnowledgeTraceNode {
+  return {
+    span_id: `graph-${index}`,
+    parent_span_id: 'postprocess',
+    name: `postprocess.graph.chunk[${index}]`,
+    kind: 'subspan',
+    status: 'done',
+    started_at: `2026-07-21T08:00:0${index}.000Z`,
+    finished_at: `2026-07-21T08:00:0${index + 2}.000Z`,
+    duration_ms: 2000,
+    ...overrides,
+  }
+}
+
+test('groups graph chunks and reports their wall-clock duration', () => {
+  const summary: KnowledgeTraceNode = {
+    span_id: 'summary',
+    name: 'postprocess.summary',
+    kind: 'subspan',
+    status: 'done',
+  }
+  const stage: KnowledgeTraceNode = {
+    span_id: 'postprocess',
+    name: 'postprocess',
+    kind: 'stage',
+    status: 'done',
+    children: [summary, graphChunk(0), graphChunk(1)],
+  }
+
+  const grouped = groupPostprocessGraphSpans(stage)
+  assert.equal(grouped.children?.length, 2)
+  assert.equal(grouped.children?.[0], summary)
+
+  const graph = grouped.children?.[1]
+  assert.equal(graph?.name, 'postprocess.graph')
+  assert.equal(graph?.status, 'done')
+  assert.equal(graph?.duration_ms, 3000)
+  assert.equal(graph?.children?.length, 2)
+  assert.deepEqual(graph?.output, {
+    chunk_count: 2,
+    status_counts: { done: 2 },
+  })
+})
+
+test('keeps graph group live while any graph chunk is running', () => {
+  const stage: KnowledgeTraceNode = {
+    span_id: 'postprocess',
+    name: 'postprocess',
+    kind: 'stage',
+    status: 'done',
+    children: [
+      graphChunk(0),
+      graphChunk(1, { status: 'running', finished_at: null, duration_ms: undefined }),
+    ],
+  }
+
+  const graph = groupPostprocessGraphSpans(stage).children?.[0]
+  assert.equal(graph?.status, 'running')
+  assert.equal(graph?.finished_at, null)
+  assert.equal(graph?.duration_ms, undefined)
+})
+
+test('surfaces a failed graph chunk on the aggregate graph row', () => {
+  const stage: KnowledgeTraceNode = {
+    span_id: 'postprocess',
+    name: 'postprocess',
+    kind: 'stage',
+    status: 'done',
+    children: [graphChunk(0), graphChunk(1, { status: 'failed' })],
+  }
+
+  const graph = groupPostprocessGraphSpans(stage).children?.[0]
+  assert.equal(graph?.status, 'failed')
+  assert.equal(graph?.duration_ms, 3000)
+})
+
+test('keeps the aggregate running until all graph chunks are terminal', () => {
+  const stage: KnowledgeTraceNode = {
+    span_id: 'postprocess',
+    name: 'postprocess',
+    kind: 'stage',
+    status: 'done',
+    children: [
+      graphChunk(0, { status: 'failed' }),
+      graphChunk(1, { status: 'running', finished_at: null, duration_ms: undefined }),
+    ],
+  }
+
+  const graph = groupPostprocessGraphSpans(stage).children?.[0]
+  assert.equal(graph?.status, 'running')
+  assert.equal(graph?.duration_ms, undefined)
+})
+
+test('leaves postprocess unchanged when it has no graph chunks', () => {
+  const stage: KnowledgeTraceNode = {
+    span_id: 'postprocess',
+    name: 'postprocess',
+    kind: 'stage',
+    status: 'done',
+    children: [],
+  }
+
+  assert.equal(groupPostprocessGraphSpans(stage), stage)
+})

--- a/frontend/src/utils/knowledgeTrace.ts
+++ b/frontend/src/utils/knowledgeTrace.ts
@@ -5,3 +5,103 @@ export function knowledgeSpansPayloadHasTrace(
   if (!data?.trace) return false
   return !!(data.trace.span_id || (data.current_attempt ?? 0) > 0)
 }
+
+export interface KnowledgeTraceNode {
+  span_id?: string
+  parent_span_id?: string
+  name: string
+  kind: string
+  status: string
+  started_at?: string | null
+  finished_at?: string | null
+  duration_ms?: number
+  error_code?: string
+  error_message?: string
+  input?: unknown
+  output?: unknown
+  metadata?: unknown
+  children?: KnowledgeTraceNode[]
+}
+
+const graphChunkName = /^postprocess\.graph\.chunk\[(\d+)\]$/
+
+function timestamp(value?: string | null): number | null {
+  if (!value) return null
+  const parsed = Date.parse(value)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+function nodeEnd(node: KnowledgeTraceNode): number | null {
+  const finished = timestamp(node.finished_at)
+  if (finished !== null) return finished
+  const started = timestamp(node.started_at)
+  if (started !== null && typeof node.duration_ms === 'number' && node.duration_ms >= 0) {
+    return started + node.duration_ms
+  }
+  return null
+}
+
+function aggregateStatus(nodes: KnowledgeTraceNode[]): string {
+  if (nodes.some(node => node.status === 'running' || node.status === 'pending')) return 'running'
+  if (nodes.some(node => node.status === 'failed')) return 'failed'
+  if (nodes.every(node => node.status === 'skipped')) return 'skipped'
+  if (nodes.some(node => node.status === 'cancelled')) return 'cancelled'
+  return 'done'
+}
+
+/**
+ * Groups persisted postprocess.graph.chunk[i] spans into one derived graph
+ * node. The derived duration is wall-clock time from the first graph worker
+ * start to the final graph worker finish; children retain per-chunk detail.
+ */
+export function groupPostprocessGraphSpans(
+  stage: KnowledgeTraceNode,
+): KnowledgeTraceNode {
+  const children = stage.children || []
+  const graphChildren = children.filter(child => graphChunkName.test(child.name))
+  if (graphChildren.length === 0) return stage
+
+  const starts = graphChildren
+    .map(child => timestamp(child.started_at))
+    .filter((value): value is number => value !== null)
+  const ends = graphChildren
+    .map(nodeEnd)
+    .filter((value): value is number => value !== null)
+  const status = aggregateStatus(graphChildren)
+  const start = starts.length > 0 ? Math.min(...starts) : null
+  const terminal = status !== 'running'
+  const end = terminal && ends.length > 0 ? Math.max(...ends) : null
+  const counts = graphChildren.reduce<Record<string, number>>((result, child) => {
+    result[child.status] = (result[child.status] || 0) + 1
+    return result
+  }, {})
+
+  const group: KnowledgeTraceNode = {
+    span_id: `virtual:postprocess.graph:${stage.span_id || 'stage'}`,
+    parent_span_id: stage.span_id,
+    name: 'postprocess.graph',
+    kind: 'group',
+    status,
+    started_at: start === null ? null : new Date(start).toISOString(),
+    finished_at: end === null ? null : new Date(end).toISOString(),
+    duration_ms: start !== null && end !== null ? Math.max(0, end - start) : undefined,
+    input: { chunk_count: graphChildren.length },
+    output: { chunk_count: graphChildren.length, status_counts: counts },
+    children: graphChildren,
+  }
+
+  let inserted = false
+  const groupedChildren: KnowledgeTraceNode[] = []
+  for (const child of children) {
+    if (graphChunkName.test(child.name)) {
+      if (!inserted) {
+        groupedChildren.push(group)
+        inserted = true
+      }
+      continue
+    }
+    groupedChildren.push(child)
+  }
+
+  return { ...stage, children: groupedChildren }
+}

--- a/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
+++ b/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
@@ -692,7 +692,9 @@ function initFromKbInfo(kb: any) {
       customInstructions: kb.question_generation_config?.custom_instructions || '',
     },
     nodeExtractConfig: {
-      enabled: kb.extract_config?.enabled || false,
+      // This dialog exposes one graph switch, so show the effective state.
+      // The backend only runs graph extraction when both flags are enabled.
+      enabled: !!kb.extract_config?.enabled && !!kb.indexing_strategy?.graph_enabled,
       text: kb.extract_config?.text || '',
       tags: kb.extract_config?.tags || [],
       nodes: (kb.extract_config?.nodes || []).map((node: any) => ({
@@ -808,6 +810,9 @@ function applyOverridesToState(o?: KnowledgeProcessOverrides | null) {
     if (ec.custom_instructions != null) s.nodeExtractConfig.customInstructions = ec.custom_instructions
   }
   if (o.graph_enabled != null) s.graphEnabled = o.graph_enabled
+  // Older saved overrides may contain mismatched graph/extract flags. Keep
+  // the single visible switch aligned with the backend's effective state.
+  s.nodeExtractConfig.enabled = s.nodeExtractConfig.enabled && s.graphEnabled
   if (o.parser_engine_overrides && o.parser_engine_overrides.pdf_force_scanned === 'true') {
     s.pdfForceScanned = true
   } else {
@@ -905,6 +910,10 @@ const handleQuestionGenerationUpdate = (config: { enabled: boolean; questionCoun
 
 const handleNodeExtractUpdate = (config: UploadUIState['nodeExtractConfig']) => {
   uiState.value.nodeExtractConfig = { ...config }
+  // GraphSettings is the only graph switch in the upload dialog. Update both
+  // backend flags; otherwise the hidden KB default can silently override the
+  // user's checked switch and prevent graph tasks from being created.
+  uiState.value.graphEnabled = config.enabled
 }
 
 const validateBeforeConfirm = (): boolean => {

--- a/internal/application/service/knowledge_post_process.go
+++ b/internal/application/service/knowledge_post_process.go
@@ -54,6 +54,25 @@ func (s *KnowledgePostProcessService) tracker() SpanTracker {
 	return s.spanTracker
 }
 
+// finishRunningMultimodalStage closes the multimodal stage only when image
+// work really ran and is still open. The canonical stage also exists when
+// multimodal processing is disabled, but that row is already "skipped" and
+// must not be rewritten to "done" with the postprocess queueing delay as its
+// duration.
+func (s *KnowledgePostProcessService) finishRunningMultimodalStage(
+	ctx context.Context,
+	knowledgeID string,
+	attempt int,
+) {
+	mm := s.tracker().LookupStage(ctx, knowledgeID, attempt, types.StageMultimodal)
+	if mm == nil ||
+		mm.Kind != types.SpanKindStage ||
+		mm.Status != types.SpanStatusRunning {
+		return
+	}
+	s.tracker().EndSpan(ctx, mm, nil)
+}
+
 // Handle implements asynq handler for TypeKnowledgePostProcess.
 func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Task) error {
 	var payload types.KnowledgePostProcessPayload
@@ -79,15 +98,12 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 	// Close the multimodal stage span (parent enqueued it as "running"
 	// and we never see the per-image fan-in here other than by reaching
 	// post-process). If the parent skipped multimodal entirely, the
-	// stage row will already be in "skipped" state and EndSpan is a
-	// no-op for missing rows. Per-image success/failure counts are NOT
+	// stage row will already be in "skipped" state and must remain so.
+	// Per-image success/failure counts are NOT
 	// aggregated here — the frontend already walks the children when
 	// rendering the multimodal stage detail and counts them itself,
 	// avoiding an extra query path.
-	if mm := s.tracker().LookupStage(ctx, payload.KnowledgeID, attempt, types.StageMultimodal); mm != nil &&
-		mm.Kind == types.SpanKindStage {
-		s.tracker().EndSpan(ctx, mm, nil)
-	}
+	s.finishRunningMultimodalStage(ctx, payload.KnowledgeID, attempt)
 
 	postSpan := s.tracker().BeginStage(ctx, payload.KnowledgeID, attempt, types.StagePostProcess, nil)
 

--- a/internal/application/service/knowledge_post_process_trace_test.go
+++ b/internal/application/service/knowledge_post_process_trace_test.go
@@ -1,0 +1,54 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFinishRunningMultimodalStage_PreservesSkippedStage(t *testing.T) {
+	tracker, db := setupSpanTrackerTest(t)
+	ctx := context.Background()
+
+	_, attempt, err := tracker.OpenAttempt(ctx, "kid-multimodal-disabled", "")
+	require.NoError(t, err)
+	mm := tracker.BeginStage(ctx, "kid-multimodal-disabled", attempt, types.StageMultimodal, nil)
+	require.NotNil(t, mm)
+	tracker.SkipSpan(ctx, mm, "skipped")
+
+	service := &KnowledgePostProcessService{spanTracker: tracker}
+	service.finishRunningMultimodalStage(ctx, "kid-multimodal-disabled", attempt)
+
+	var row types.KnowledgeProcessingSpan
+	require.NoError(t, db.Table("knowledge_processing_spans").
+		Where("knowledge_id = ? AND attempt = ? AND name = ?",
+			"kid-multimodal-disabled", attempt, types.StageMultimodal).
+		First(&row).Error)
+	assert.Equal(t, types.SpanStatusSkipped, row.Status)
+	assert.Equal(t, int64(0), row.DurationMs)
+}
+
+func TestFinishRunningMultimodalStage_CompletesRunningStage(t *testing.T) {
+	tracker, db := setupSpanTrackerTest(t)
+	ctx := context.Background()
+
+	_, attempt, err := tracker.OpenAttempt(ctx, "kid-multimodal-enabled", "")
+	require.NoError(t, err)
+	mm := tracker.BeginStage(ctx, "kid-multimodal-enabled", attempt, types.StageMultimodal, nil)
+	require.NotNil(t, mm)
+
+	service := &KnowledgePostProcessService{spanTracker: tracker}
+	service.finishRunningMultimodalStage(ctx, "kid-multimodal-enabled", attempt)
+
+	var row types.KnowledgeProcessingSpan
+	require.NoError(t, db.Table("knowledge_processing_spans").
+		Where("knowledge_id = ? AND attempt = ? AND name = ?",
+			"kid-multimodal-enabled", attempt, types.StageMultimodal).
+		First(&row).Error)
+	assert.Equal(t, types.SpanStatusDone, row.Status)
+	assert.NotNil(t, row.FinishedAt)
+	assert.GreaterOrEqual(t, row.DurationMs, int64(0))
+}

--- a/internal/application/service/knowledge_span_tracker.go
+++ b/internal/application/service/knowledge_span_tracker.go
@@ -76,6 +76,7 @@ type Span struct {
 	ParentSpanID string
 	Name         string
 	Kind         string
+	Status       string
 	StartedAt    time.Time
 }
 
@@ -279,6 +280,7 @@ func (t *spanTracker) OpenAttempt(ctx context.Context, knowledgeID, langfuseTrac
 		SpanID:      rootID,
 		Name:        "knowledge_processing",
 		Kind:        types.SpanKindRoot,
+		Status:      types.SpanStatusRunning,
 		StartedAt:   now,
 	}, attempt, nil
 }
@@ -309,8 +311,8 @@ func (t *spanTracker) BeginStage(ctx context.Context, knowledgeID string, attemp
 		return nil
 	}
 	var (
-		rootID    string
-		existing  *types.KnowledgeProcessingSpan
+		rootID   string
+		existing *types.KnowledgeProcessingSpan
 	)
 	for i := range rows {
 		r := rows[i]
@@ -365,6 +367,7 @@ func (t *spanTracker) BeginStage(ctx context.Context, knowledgeID string, attemp
 			ParentSpanID: existing.ParentSpanID,
 			Name:         existing.Name,
 			Kind:         existing.Kind,
+			Status:       types.SpanStatusRunning,
 			StartedAt:    now,
 		}
 	}
@@ -394,6 +397,7 @@ func (t *spanTracker) BeginStage(ctx context.Context, knowledgeID string, attemp
 		ParentSpanID: rootID,
 		Name:         stage,
 		Kind:         types.SpanKindStage,
+		Status:       types.SpanStatusRunning,
 		StartedAt:    now,
 	}
 }
@@ -441,6 +445,7 @@ func (t *spanTracker) BeginSubSpan(ctx context.Context, parent *Span, name, kind
 		ParentSpanID: parent.SpanID,
 		Name:         name,
 		Kind:         kind,
+		Status:       types.SpanStatusRunning,
 		StartedAt:    now,
 	}
 }
@@ -578,6 +583,7 @@ func (t *spanTracker) LookupStage(ctx context.Context, knowledgeID string, attem
 			ParentSpanID: r.ParentSpanID,
 			Name:         r.Name,
 			Kind:         r.Kind,
+			Status:       r.Status,
 			StartedAt:    started,
 		}
 	}
@@ -611,6 +617,7 @@ func (t *spanTracker) LookupSpanByName(ctx context.Context, knowledgeID string, 
 			ParentSpanID: r.ParentSpanID,
 			Name:         r.Name,
 			Kind:         r.Kind,
+			Status:       r.Status,
 			StartedAt:    started,
 		}
 	}


### PR DESCRIPTION
## Description

This PR fixes graph and multimodal stage reporting in the knowledge-processing trace so that the displayed stages, statuses, and durations match the actual processing configuration.

### Graph trace

- Recognize `postprocess.graph.chunk[...]` trace records and group them into a separate graph-processing row.
- Calculate graph duration using the earliest start time and latest finish time instead of summing parallel tasks.
- Aggregate graph status across child tasks:
  - `running` when any task is still running.
  - `failed` when all tasks have finished and at least one failed.
  - `done` when all tasks complete successfully.
- Preserve the existing postprocess display when no graph trace records exist.
- Ensure the graph switch in the upload confirmation dialog is correctly written to the upload `process_config`.

### Multimodal trace

- Do not display bookkeeping time for skipped or pending stages.
- Preserve the canonical multimodal stage when multimodal processing is disabled, but display it as `skipped` with duration `—`.
- Restore the persisted span status when `LookupStage` loads a span across processes.
- Only allow postprocess to finish a multimodal stage when its current status is `running`.
- Prevent `skipped`, `failed`, or `cancelled` multimodal stages from being overwritten as `done`.

This PR does not change when VLM or graph-processing tasks are executed. It only fixes configuration propagation and trace status/duration reporting.

No breaking changes.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

- Added five frontend unit tests covering:
  - Parallel graph duration calculation.
  - Running graph tasks.
  - Failed graph tasks.
  - Mixed running and failed tasks.
  - Postprocess traces without graph records.
- Frontend graph trace tests pass: 5 passed, 0 failed.
- Added two Go regression tests covering:
  - A skipped multimodal stage remains `skipped` after postprocess and keeps zero duration.
  - A running multimodal stage is completed as `done` by postprocess.
- Go source files were formatted with `gofmt`.
- `git diff --check` passes.
- The Go regression tests could not be executed locally because the Windows environment has CGO disabled and no C compiler. The existing `pg_query` dependency therefore fails to provide its `Parse` and `Deparse` implementations. This is unrelated to the changes in this PR and should be validated by CI.

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

Before:
<img width="608" height="924" alt="image" src="https://github.com/user-attachments/assets/c08658ed-70cb-4e6c-926b-31787a2ef813" />

After:
<img width="597" height="925" alt="image" src="https://github.com/user-attachments/assets/99bf5edf-8a6c-4c61-b10e-66caca8f3a68" />
<img width="595" height="921" alt="image" src="https://github.com/user-attachments/assets/0ac9819b-0af8-45dd-9a05-6b7ad2474266" />





