### PR TITLE
fix(im): load channel sessions without web scope

### DIFF
--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -1489,7 +1489,7 @@ func (s *Service) HandleMessage(ctx context.Context, msg *IncomingMessage, chann
 	}
 
 	// 4. Get the WeKnora session
-	session, err := s.sessionService.GetSession(sessionCtx, channelSession.SessionID)
+	session, err := s.sessionService.GetSessionByID(sessionCtx, tenantID, channelSession.SessionID)
 	if err != nil {
 		// The underlying session may have been deleted from the UI while the
 		// ChannelSession mapping still exists (GORM soft-delete does not trigger
@@ -1506,7 +1506,7 @@ func (s *Service) HandleMessage(ctx context.Context, msg *IncomingMessage, chann
 			if err != nil {
 				return fmt.Errorf("resolve session (retry): %w", err)
 			}
-			session, err = s.sessionService.GetSession(sessionCtx, channelSession.SessionID)
+			session, err = s.sessionService.GetSessionByID(sessionCtx, tenantID, channelSession.SessionID)
 			if err != nil {
 				return fmt.Errorf("get session (retry): %w", err)
 			}


### PR DESCRIPTION
## Summary
- Load IM channel sessions by tenant and session ID inside the IM message pipeline.
- Keep Web console session reads on the scoped `GetSession` path.

## Root cause
IM message handling creates or resolves an `im_channel_sessions` mapping, then immediately loads the underlying WeKnora session. Recent session read scoping treats IM-origin sessions as channel-managed rows, so using `GetSession` from the IM internal pipeline can reject the newly mapped session as `session not found` for the synthetic IM viewer context.

## Impact
This prevents IM adapters from dropping inbound messages after creating or recycling a channel session. Web/API console access rules remain unchanged.

## Validation
- `git diff --check`
- Deployed the same fix to a dev instance and confirmed Yunzhijia WebSocket reconnects and `/health` returns OK.
