### PR TITLE
修复跨工作空间共享知识库原始文档预览失败

### DIFF
--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -56,6 +56,7 @@ type knowledgeService struct {
 	tagService      interfaces.KnowledgeTagService
 	fileSvc         interfaces.FileService
 	storageResolver interfaces.StorageBackendResolver
+	resourceCatalog interfaces.ResourceCatalog
 	modelService    interfaces.ModelService
 	task            interfaces.TaskEnqueuer
 	taskInspector   interfaces.TaskInspector
@@ -98,6 +99,7 @@ func NewKnowledgeService(
 	tagService interfaces.KnowledgeTagService,
 	fileSvc interfaces.FileService,
 	storageResolver interfaces.StorageBackendResolver,
+	resourceCatalog interfaces.ResourceCatalog,
 	modelService interfaces.ModelService,
 	task interfaces.TaskEnqueuer,
 	taskInspector interfaces.TaskInspector,
@@ -125,6 +127,7 @@ func NewKnowledgeService(
 		tagService:      tagService,
 		fileSvc:         fileSvc,
 		storageResolver: storageResolver,
+		resourceCatalog: resourceCatalog,
 		modelService:    modelService,
 		task:            task,
 		taskInspector:   taskInspector,

--- a/internal/application/service/knowledge_util.go
+++ b/internal/application/service/knowledge_util.go
@@ -310,6 +310,24 @@ func (s *knowledgeService) resolveFileService(ctx context.Context, kb *types.Kno
 // the provider inferred from the file path. This protects historical data when
 // tenant/KB config changes but files were stored under the old provider.
 func (s *knowledgeService) resolveFileServiceForPath(ctx context.Context, kb *types.KnowledgeBase, filePath string) interfaces.FileService {
+	// A resource:// reference belongs to the tenant that registered it. Shared
+	// KB requests use the viewer's effective tenant in ctx, which can otherwise
+	// select the wrong storage backend and pass the resource URL to local disk.
+	if _, ok := types.ParseResourcePath(filePath); ok && s.resourceCatalog != nil && s.storageResolver != nil && s.tenantRepo != nil {
+		resource, err := s.resourceCatalog.Resolve(ctx, filePath)
+		if err == nil && resource != nil {
+			ownerTenant, tenantErr := s.tenantRepo.GetTenantByID(ctx, resource.TenantID)
+			if tenantErr == nil && ownerTenant != nil {
+				baseDir := strings.TrimSpace(os.Getenv("LOCAL_STORAGE_BASE_DIR"))
+				if resolved, _, resolveErr := s.storageResolver.ResolveFileService(ctx, ownerTenant, resource.StorageBackendID, resource.Provider, baseDir); resolveErr == nil && resolved != nil {
+					return resolved
+				} else if resolveErr != nil {
+					logger.Warnf(ctx, "[storage] failed to resolve resource owner backend: resource=%s tenant=%d err=%v", resource.Handle, resource.TenantID, resolveErr)
+				}
+			}
+		}
+	}
+
 	if backendID, inner, ok := types.ParseStorageBackendPath(filePath); ok && s.storageResolver != nil {
 		tenant, _ := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
 		if tenant != nil {


### PR DESCRIPTION
## 修改内容

修复跨工作空间共享知识库中，其他工作空间用户打开 PDF、Word、图片等原始文件时出现“加载文档预览失败”的问题。

## 问题原因

共享用户访问文档时，权限校验虽然能够正确通过，但后端使用查看者工作空间的租户上下文解析文件存储服务。对于 resource:// 文件引用，资源实际属于知识库拥有者工作空间，导致文件路径被错误地按查看者的存储配置处理，最终返回文件不存在（HTTP 500）。

## 具体修改

- 在知识文件存储服务解析中识别 resource:// 引用。
- 通过资源目录查询资源实际所属工作空间和存储后端。
- 使用资源所属工作空间的存储配置读取文件。
- 保持普通 local://、S3、MinIO 等历史文件路径的原有处理逻辑不变。
- 同时修复文档预览和原始文件下载使用的读取链路。

## 影响范围

- 修复共享知识库用户的 PDF、Word、图片等原始文件预览和下载。
- 不改变知识库权限校验。
- 不修改数据库，不重新解析文档，不影响摘要、向量和 Wiki 数据。
- 不包含任何密钥或生产环境配置。

## 验证情况

- 已通过 git diff --check。
- 已确认服务器日志中的错误路径与该问题根因一致。
- Go 单元测试和本地构建测试可用。
