### PR TITLE
fix(embedding): reuse SSRF-safe HTTP transport

### DIFF
--- a/internal/models/embedding/transport.go
+++ b/internal/models/embedding/transport.go
@@ -8,6 +8,14 @@ import (
 	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
 
+// sharedEmbeddingHTTPTransport keeps a single SSRF-safe connection pool for
+// all embedding clients. Embedders are recreated as model configuration changes,
+// but their outbound connections can be safely reused across client instances.
+var sharedEmbeddingHTTPTransport = func() http.RoundTripper {
+	cfg := secutils.DefaultSSRFSafeHTTPClientConfig()
+	return secutils.NewSSRFSafeHTTPClient(cfg).Transport
+}()
+
 // validateEmbeddingBaseURL checks that a resolved embedding API base URL is safe
 // for outbound requests. Empty URLs are allowed (callers apply provider defaults).
 func validateEmbeddingBaseURL(baseURL string) error {
@@ -25,5 +33,7 @@ func validateEmbeddingBaseURL(baseURL string) error {
 func newEmbeddingHTTPClient(timeout time.Duration) *http.Client {
 	cfg := secutils.DefaultSSRFSafeHTTPClientConfig()
 	cfg.Timeout = timeout
-	return secutils.NewSSRFSafeHTTPClient(cfg)
+	client := secutils.NewSSRFSafeHTTPClient(cfg)
+	client.Transport = sharedEmbeddingHTTPTransport
+	return client
 }

--- a/internal/models/embedding/transport_test.go
+++ b/internal/models/embedding/transport_test.go
@@ -3,7 +3,31 @@ package embedding
 import (
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestNewEmbeddingHTTPClient_ReusesTransport(t *testing.T) {
+	firstTimeout := 15 * time.Second
+	secondTimeout := 45 * time.Second
+	first := newEmbeddingHTTPClient(firstTimeout)
+	second := newEmbeddingHTTPClient(secondTimeout)
+
+	if first == second {
+		t.Fatal("expected distinct HTTP clients")
+	}
+	if first.Transport != second.Transport {
+		t.Fatal("expected embedding HTTP clients to share a transport")
+	}
+	if first.Transport != sharedEmbeddingHTTPTransport {
+		t.Fatal("expected embedding HTTP client to use the shared transport")
+	}
+	if first.Timeout != firstTimeout {
+		t.Fatalf("unexpected first client timeout: got %v, want %v", first.Timeout, firstTimeout)
+	}
+	if second.Timeout != secondTimeout {
+		t.Fatalf("unexpected second client timeout: got %v, want %v", second.Timeout, secondTimeout)
+	}
+}
 
 func TestValidateEmbeddingBaseURL_RejectsLoopback(t *testing.T) {
 	err := validateEmbeddingBaseURL("http://169.254.169.254/latest/meta-data")


### PR DESCRIPTION
## Description

- reuse one SSRF-safe `http.Transport` across embedding HTTP clients
- keep a separate `http.Client` for each embedder so provider timeouts and redirect handling remain isolated
- add regression coverage for shared transport identity and independent client timeouts

The embedding service recreates embedders as model configuration is resolved. Previously every embedder received a new transport and therefore a separate idle connection pool. Reusing the transport allows keep-alive connections to be pooled globally without caching model configuration or credentials.

## Type of Change

- [x] Bug fix
- [x] Test

## Related Issue

Fixes #2197

## Testing

- `go test ./internal/models/embedding -count=1`
- `go test -race ./internal/models/embedding -count=1`
- `go test ./internal/application/service -run '^$' -count=1`
- `go vet ./internal/models/embedding`
- `git diff --check`

The Go checks were run under Linux because the repository's `pg_query_go` dependency does not expose `Parse`/`Deparse` on Windows.

## Checklist

- [x] Targeted code is formatted and linted with `gofmt` and `go vet`
- [x] Self-reviewed the code
- [x] Added tests covering the change
- [x] No documentation update is required for this internal connection-pool fix
- [x] No breaking changes
