### PR TITLE
fix(search): validate hybrid search query text

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -18253,6 +18253,7 @@ const docTemplate = `{
                     }
                 },
                 "query_text": {
+                    "description": "QueryText is required unless query_embedding is provided, keyword matching is disabled,\nand vector matching remains enabled.",
                     "type": "string"
                 },
                 "scope_tag_ids": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -18246,6 +18246,7 @@
                     }
                 },
                 "query_text": {
+                    "description": "QueryText is required unless query_embedding is provided, keyword matching is disabled,\nand vector matching remains enabled.",
                     "type": "string"
                 },
                 "scope_tag_ids": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2949,6 +2949,9 @@ definitions:
           type: number
         type: array
       query_text:
+        description: |-
+          QueryText is required unless query_embedding is provided, keyword matching is disabled,
+          and vector matching remains enabled.
         type: string
       scope_tag_ids:
         items:

--- a/internal/handler/knowledgebase.go
+++ b/internal/handler/knowledgebase.go
@@ -302,6 +302,11 @@ func (h *KnowledgeBaseHandler) HybridSearch(c *gin.Context) {
 		c.Error(apperrors.NewBadRequestError("Invalid request parameters").WithDetails(err.Error()))
 		return
 	}
+	precomputedVectorOnly := len(req.QueryEmbedding) > 0 && req.DisableKeywordsMatch && !req.DisableVectorMatch
+	if strings.TrimSpace(req.QueryText) == "" && !precomputedVectorOnly {
+		_ = c.Error(apperrors.NewBadRequestError("query_text is required"))
+		return
+	}
 
 	logger.Infof(ctx, "Executing hybrid search, knowledge base ID: %s, query: %s, effectiveTenantID: %d",
 		secutils.SanitizeForLog(id), secutils.SanitizeForLog(req.QueryText), effectiveTenantID)

--- a/internal/handler/knowledgebase_hybrid_search_test.go
+++ b/internal/handler/knowledgebase_hybrid_search_test.go
@@ -1,0 +1,134 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Tencent/WeKnora/internal/middleware"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type hybridSearchTestService struct {
+	interfaces.KnowledgeBaseService
+	searchCalls  int
+	searchParams types.SearchParams
+}
+
+func (s *hybridSearchTestService) GetKnowledgeBaseByID(_ context.Context, id string) (*types.KnowledgeBase, error) {
+	return &types.KnowledgeBase{ID: id, TenantID: 1}, nil
+}
+
+func (s *hybridSearchTestService) HybridSearch(
+	_ context.Context,
+	_ string,
+	params types.SearchParams,
+) ([]*types.SearchResult, error) {
+	s.searchCalls++
+	s.searchParams = params
+	return []*types.SearchResult{}, nil
+}
+
+func newHybridSearchTestRouter(svc interfaces.KnowledgeBaseService) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(middleware.ErrorHandler())
+	router.Use(func(c *gin.Context) {
+		c.Set(types.TenantIDContextKey.String(), uint64(1))
+		c.Set(types.UserIDContextKey.String(), "u-test")
+		c.Next()
+	})
+	handler := &KnowledgeBaseHandler{service: svc}
+	router.POST("/knowledge-bases/:id/hybrid-search", handler.HybridSearch)
+	return router
+}
+
+func TestHybridSearchRejectsMissingQueryText(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing field", body: `{}`},
+		{name: "empty field", body: `{"query_text":""}`},
+		{name: "whitespace field", body: `{"query_text":"   "}`},
+		{name: "wrong field name", body: `{"query":"MiniMax"}`},
+		{name: "embedding with keyword matching", body: `{"query_embedding":[0.1]}`},
+		{
+			name: "embedding with all matching disabled",
+			body: `{"query_embedding":[0.1],"disable_keywords_match":true,"disable_vector_match":true}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &hybridSearchTestService{}
+			response := performHybridSearchRequest(svc, tt.body)
+
+			if response.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d body=%s", response.Code, response.Body.String())
+			}
+			if svc.searchCalls != 0 {
+				t.Fatalf("invalid request reached HybridSearch %d time(s)", svc.searchCalls)
+			}
+			if !strings.Contains(response.Body.String(), `"code":1000`) {
+				t.Fatalf("expected bad-request envelope, got %s", response.Body.String())
+			}
+		})
+	}
+}
+
+func TestHybridSearchAcceptsQueryText(t *testing.T) {
+	svc := &hybridSearchTestService{}
+	response := performHybridSearchRequest(svc, `{"query_text":"MiniMax","match_count":3}`)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", response.Code, response.Body.String())
+	}
+	if svc.searchCalls != 1 {
+		t.Fatalf("expected one HybridSearch call, got %d", svc.searchCalls)
+	}
+	if svc.searchParams.QueryText != "MiniMax" {
+		t.Fatalf("query text = %q, want MiniMax", svc.searchParams.QueryText)
+	}
+	if svc.searchParams.MatchCount != 3 {
+		t.Fatalf("match count = %d, want 3", svc.searchParams.MatchCount)
+	}
+}
+
+func TestHybridSearchAcceptsPrecomputedVectorWithoutQueryText(t *testing.T) {
+	svc := &hybridSearchTestService{}
+	response := performHybridSearchRequest(
+		svc,
+		`{"query_embedding":[0.1,0.2],"disable_keywords_match":true}`,
+	)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", response.Code, response.Body.String())
+	}
+	if svc.searchCalls != 1 {
+		t.Fatalf("expected one HybridSearch call, got %d", svc.searchCalls)
+	}
+	if len(svc.searchParams.QueryEmbedding) != 2 {
+		t.Fatalf("query embedding length = %d, want 2", len(svc.searchParams.QueryEmbedding))
+	}
+	if !svc.searchParams.DisableKeywordsMatch || svc.searchParams.DisableVectorMatch {
+		t.Fatalf("expected vector-only params, got %+v", svc.searchParams)
+	}
+}
+
+func performHybridSearchRequest(svc interfaces.KnowledgeBaseService, body string) *httptest.ResponseRecorder {
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/knowledge-bases/kb-1/hybrid-search",
+		strings.NewReader(body),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	newHybridSearchTestRouter(svc).ServeHTTP(response, request)
+	return response
+}

--- a/internal/types/search.go
+++ b/internal/types/search.go
@@ -186,6 +186,8 @@ type SearchResult struct {
 
 // SearchParams represents the search parameters
 type SearchParams struct {
+	// QueryText is required unless query_embedding is provided, keyword matching is disabled,
+	// and vector matching remains enabled.
 	QueryText            string    `json:"query_text"`
 	QueryEmbedding       []float32 `json:"query_embedding,omitempty"`
 	VectorThreshold      float64   `json:"vector_threshold"`


### PR DESCRIPTION
## Description

Reject hybrid-search requests whose documented `query_text` value is missing, empty, or whitespace-only before search or embedding is invoked. Preserve the supported precomputed-vector-only request shape when `query_embedding` is present, keyword matching is disabled, and vector matching remains enabled.

This also documents the conditional requirement in generated Swagger output and adds handler-level regression coverage for missing, empty, misspelled, valid text, and precomputed-vector-only requests.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test
- [ ] Configuration / Build / CI

## Related Issue

Fixes #2176

## Testing

- `go test ./internal/types ./internal/handler -count=1`
- `go test -race ./internal/handler -run '^TestHybridSearch(RejectsMissingQueryText|AcceptsQueryText|AcceptsPrecomputedVectorWithoutQueryText)$' -count=1`
- `go vet ./internal/types ./internal/handler`
- `golangci-lint run --new-from-rev=origin/main ./internal/handler ./internal/types`
- `git diff --check`

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above (none)

## Screenshots / Recordings

Not applicable; this changes API validation only.
