### PR TITLE
fix(wiki): support source ref lookups on sqlite

### DIFF
--- a/internal/application/repository/wiki_page.go
+++ b/internal/application/repository/wiki_page.go
@@ -43,6 +43,40 @@ func (r *wikiPageRepository) wikiEmptyInLinksPredicate() string {
 	return "(in_links IS NULL OR in_links = '[]'::JSONB)"
 }
 
+func (r *wikiPageRepository) wikiSourceRefPredicate(sourceKnowledgeID string) (string, []interface{}, error) {
+	if r.db != nil && r.db.Dialector != nil && r.db.Dialector.Name() == "sqlite" {
+		return `EXISTS (
+			SELECT 1 FROM json_each(wiki_pages.source_refs) AS source_ref
+			WHERE source_ref.value = ? OR source_ref.value LIKE ? ESCAPE '\'
+		)`, []interface{}{sourceKnowledgeID, escapeLikePattern(sourceKnowledgeID+"|") + "%"}, nil
+	}
+
+	// Build the JSON needle safely so arbitrary IDs cannot break out of the
+	// quoted string (e.g. ids containing quotes or backslashes).
+	needle, err := json.Marshal([]string{sourceKnowledgeID})
+	if err != nil {
+		return "", nil, fmt.Errorf("marshal source ref needle: %w", err)
+	}
+
+	// For the "knowledgeID|title" prefix form, match against the JSON-encoded
+	// value: json.Marshal escapes special chars so the LIKE pattern is safe.
+	prefix, err := json.Marshal(sourceKnowledgeID + "|")
+	if err != nil {
+		return "", nil, fmt.Errorf("marshal source ref prefix: %w", err)
+	}
+	// prefix is a JSON string including the surrounding quotes; e.g. "abc|".
+	// We strip the trailing quote so LIKE can continue into the title portion.
+	prefixStr := string(prefix)
+	if len(prefixStr) >= 2 && prefixStr[len(prefixStr)-1] == '"' {
+		prefixStr = prefixStr[:len(prefixStr)-1]
+	}
+	// Escape LIKE metacharacters in the already-JSON-escaped prefix, then wrap
+	// with %...% to match anywhere in the serialized JSON array.
+	likePattern := "%" + escapeLikePattern(prefixStr) + "%"
+
+	return "source_refs @> ?::jsonb OR source_refs::text LIKE ? ESCAPE '\\'", []interface{}{string(needle), likePattern}, nil
+}
+
 // Create inserts a new wiki page record
 func (r *wikiPageRepository) Create(ctx context.Context, page *types.WikiPage) error {
 	return r.db.WithContext(ctx).Create(page).Error
@@ -317,36 +351,15 @@ func (r *wikiPageRepository) ListByTypeLight(
 // ListBySourceRef retrieves all wiki pages that reference a given source knowledge ID.
 // Handles both old format ("knowledgeID") and new format ("knowledgeID|title") in source_refs JSON array.
 func (r *wikiPageRepository) ListBySourceRef(ctx context.Context, kbID string, sourceKnowledgeID string) ([]*types.WikiPage, error) {
-	// Build the JSON needle safely so arbitrary IDs cannot break out of the
-	// quoted string (e.g. ids containing quotes or backslashes).
-	needle, err := json.Marshal([]string{sourceKnowledgeID})
+	predicate, args, err := r.wikiSourceRefPredicate(sourceKnowledgeID)
 	if err != nil {
-		return nil, fmt.Errorf("marshal source ref needle: %w", err)
+		return nil, err
 	}
-
-	// For the "knowledgeID|title" prefix form, match against the JSON-encoded
-	// value: json.Marshal escapes special chars so the LIKE pattern is safe.
-	prefix, err := json.Marshal(sourceKnowledgeID + "|")
-	if err != nil {
-		return nil, fmt.Errorf("marshal source ref prefix: %w", err)
-	}
-	// prefix is a JSON string including the surrounding quotes; e.g. "abc|".
-	// We strip the trailing quote so LIKE can continue into the title portion.
-	prefixStr := string(prefix)
-	if len(prefixStr) >= 2 && prefixStr[len(prefixStr)-1] == '"' {
-		prefixStr = prefixStr[:len(prefixStr)-1]
-	}
-	// Escape LIKE metacharacters in the already-JSON-escaped prefix, then wrap
-	// with %…% to match anywhere in the serialized JSON array.
-	likePattern := "%" + escapeLikePattern(prefixStr) + "%"
 
 	var pages []*types.WikiPage
 	if err := r.db.WithContext(ctx).
-		Where("knowledge_base_id = ? AND (source_refs @> ?::jsonb OR source_refs::text LIKE ?)",
-			kbID,
-			string(needle),
-			likePattern,
-		).
+		Where("knowledge_base_id = ?", kbID).
+		Where("("+predicate+")", args...).
 		Find(&pages).Error; err != nil {
 		return nil, err
 	}
@@ -363,28 +376,16 @@ func (r *wikiPageRepository) ListBySourceRef(ctx context.Context, kbID string, s
 // containment branch and idx_wiki_pages_source_refs_text for the legacy
 // text-LIKE branch — both added in migration 000041.
 func (r *wikiPageRepository) ListSlugsBySourceRef(ctx context.Context, kbID string, sourceKnowledgeID string) ([]string, error) {
-	needle, err := json.Marshal([]string{sourceKnowledgeID})
+	predicate, args, err := r.wikiSourceRefPredicate(sourceKnowledgeID)
 	if err != nil {
-		return nil, fmt.Errorf("marshal source ref needle: %w", err)
+		return nil, err
 	}
-	prefix, err := json.Marshal(sourceKnowledgeID + "|")
-	if err != nil {
-		return nil, fmt.Errorf("marshal source ref prefix: %w", err)
-	}
-	prefixStr := string(prefix)
-	if len(prefixStr) >= 2 && prefixStr[len(prefixStr)-1] == '"' {
-		prefixStr = prefixStr[:len(prefixStr)-1]
-	}
-	likePattern := "%" + escapeLikePattern(prefixStr) + "%"
 
 	var slugs []string
 	if err := r.db.WithContext(ctx).
 		Model(&types.WikiPage{}).
-		Where("knowledge_base_id = ? AND (source_refs @> ?::jsonb OR source_refs::text LIKE ?)",
-			kbID,
-			string(needle),
-			likePattern,
-		).
+		Where("knowledge_base_id = ?", kbID).
+		Where("("+predicate+")", args...).
 		Pluck("slug", &slugs).Error; err != nil {
 		return nil, err
 	}
@@ -653,10 +654,9 @@ func (r *wikiPageRepository) ListSummariesByKnowledgeIDs(
 		return nil, nil
 	}
 
-	// Build a JSONB containment-OR with one needle per knowledge id,
-	// plus a single text-LIKE OR over the legacy prefix forms. The
-	// containment branches each get their own GIN index probe; the
-	// LIKE branch falls back to the text fulltext GIN.
+	// Build a dialect-aware source_refs OR with one predicate per knowledge id.
+	// PostgreSQL uses JSONB containment plus the legacy text prefix match;
+	// SQLite uses json_each over the stored JSON array.
 	type row struct {
 		Content    string            `gorm:"column:content"`
 		SourceRefs types.StringArray `gorm:"column:source_refs"`
@@ -677,23 +677,12 @@ func (r *wikiPageRepository) ListSummariesByKnowledgeIDs(
 		if kid == "" {
 			continue
 		}
-		needle, err := json.Marshal([]string{kid})
+		predicate, predicateArgs, err := r.wikiSourceRefPredicate(kid)
 		if err != nil {
-			return nil, fmt.Errorf("marshal kid needle: %w", err)
+			return nil, err
 		}
-		clauses = append(clauses, "source_refs @> ?::jsonb")
-		args = append(args, string(needle))
-
-		prefix, err := json.Marshal(kid + "|")
-		if err != nil {
-			return nil, fmt.Errorf("marshal kid prefix: %w", err)
-		}
-		prefixStr := string(prefix)
-		if len(prefixStr) >= 2 && prefixStr[len(prefixStr)-1] == '"' {
-			prefixStr = prefixStr[:len(prefixStr)-1]
-		}
-		clauses = append(clauses, "source_refs::text LIKE ?")
-		args = append(args, "%"+escapeLikePattern(prefixStr)+"%")
+		clauses = append(clauses, "("+predicate+")")
+		args = append(args, predicateArgs...)
 	}
 	if len(clauses) == 0 {
 		return nil, nil

--- a/internal/application/repository/wiki_page.go
+++ b/internal/application/repository/wiki_page.go
@@ -978,8 +978,10 @@ func escapeLikePattern(s string) string {
 	return replacer.Replace(s)
 }
 
-// Search performs case-insensitive POSIX regex search on wiki pages within a knowledge base.
-// The query is interpreted as a PostgreSQL regular expression (via ~*).
+// Search performs case-insensitive search on wiki pages within a knowledge base.
+// PostgreSQL interprets the query as a POSIX regular expression (via ~*);
+// SQLite falls back to a literal substring match because it has no built-in
+// equivalent regex operator.
 //
 // Results are ranked by where the query hit, highest-relevance first:
 //
@@ -1001,22 +1003,13 @@ func (r *wikiPageRepository) Search(ctx context.Context, kbID string, query stri
 		limit = 50
 	}
 
-	// CASE expression is evaluated per-row during SELECT; we order by the
-	// alias so the DB only computes the rank once. Parameterized four
-	// times with the same regex to avoid coupling to GORM's positional
-	// arg rewriting quirks.
-	rankExpr := "CASE " +
-		"WHEN title ~* ? THEN 4 " +
-		"WHEN slug ~* ? THEN 3 " +
-		"WHEN summary ~* ? THEN 2 " +
-		"WHEN content ~* ? THEN 1 " +
-		"ELSE 0 END AS match_rank"
+	rankExpr, rankArgs, whereExpr, whereArgs := r.wikiSearchExpressions(query)
 
 	var pages []*types.WikiPage
 	if err := r.db.WithContext(ctx).
-		Select("*, "+rankExpr, query, query, query, query).
-		Where("knowledge_base_id = ? AND (title ~* ? OR content ~* ? OR summary ~* ? OR slug ~* ?)",
-			kbID, query, query, query, query).
+		Select("*, "+rankExpr, rankArgs...).
+		Where("knowledge_base_id = ?", kbID).
+		Where(whereExpr, whereArgs...).
 		Where("status != ?", "archived").
 		Order("match_rank DESC, updated_at DESC").
 		Limit(limit).
@@ -1024,6 +1017,35 @@ func (r *wikiPageRepository) Search(ctx context.Context, kbID string, query stri
 		return nil, err
 	}
 	return pages, nil
+}
+
+func (r *wikiPageRepository) wikiSearchExpressions(query string) (string, []interface{}, string, []interface{}) {
+	// CASE expression is evaluated per-row during SELECT; we order by the
+	// alias so the DB only computes the rank once. Parameterized four
+	// times with the same pattern to avoid coupling to GORM's positional
+	// arg rewriting quirks.
+	if r.db != nil && r.db.Dialector != nil && r.db.Dialector.Name() == "sqlite" {
+		pattern := "%" + escapeLikePattern(strings.ToLower(query)) + "%"
+		args := []interface{}{pattern, pattern, pattern, pattern}
+		rankExpr := "CASE " +
+			"WHEN LOWER(title) LIKE ? ESCAPE '\\' THEN 4 " +
+			"WHEN LOWER(slug) LIKE ? ESCAPE '\\' THEN 3 " +
+			"WHEN LOWER(summary) LIKE ? ESCAPE '\\' THEN 2 " +
+			"WHEN LOWER(content) LIKE ? ESCAPE '\\' THEN 1 " +
+			"ELSE 0 END AS match_rank"
+		whereExpr := "(LOWER(title) LIKE ? ESCAPE '\\' OR LOWER(content) LIKE ? ESCAPE '\\' OR LOWER(summary) LIKE ? ESCAPE '\\' OR LOWER(slug) LIKE ? ESCAPE '\\')"
+		return rankExpr, args, whereExpr, args
+	}
+
+	args := []interface{}{query, query, query, query}
+	rankExpr := "CASE " +
+		"WHEN title ~* ? THEN 4 " +
+		"WHEN slug ~* ? THEN 3 " +
+		"WHEN summary ~* ? THEN 2 " +
+		"WHEN content ~* ? THEN 1 " +
+		"ELSE 0 END AS match_rank"
+	whereExpr := "(title ~* ? OR content ~* ? OR summary ~* ? OR slug ~* ?)"
+	return rankExpr, args, whereExpr, args
 }
 
 // CountByType returns page counts grouped by type for a knowledge base

--- a/internal/application/repository/wiki_page_test.go
+++ b/internal/application/repository/wiki_page_test.go
@@ -424,3 +424,38 @@ func TestCountOrphans_SQLiteCountsEmptyInLinks(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), got)
 }
+
+func TestSearch_SQLiteRanksMatchesAndExcludesArchived(t *testing.T) {
+	db := setupWikiPagesTestDB(t)
+	repo := NewWikiPageRepository(db)
+	ctx := context.Background()
+
+	titleHit := makeWikiPage("kb-search", "entity/title-hit", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	titleHit.Title = "Alpha topic"
+	slugHit := makeWikiPage("kb-search", "entity/alpha-slug", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	slugHit.Title = "Slug page"
+	summaryHit := makeWikiPage("kb-search", "entity/summary-hit", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	summaryHit.Title = "Summary page"
+	summaryHit.Summary = "Mentions alpha in summary"
+	contentHit := makeWikiPage("kb-search", "entity/content-hit", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	contentHit.Title = "Content page"
+	contentHit.Content = "Mentions alpha in body"
+	archived := makeWikiPage("kb-search", "entity/archived", types.WikiPageTypeEntity, types.WikiPageStatusArchived)
+	archived.Title = "Alpha archived"
+	otherKB := makeWikiPage("kb-other", "entity/leaked", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	otherKB.Title = "Alpha leaked"
+
+	for _, p := range []*types.WikiPage{contentHit, summaryHit, slugHit, titleHit, archived, otherKB} {
+		require.NoError(t, repo.Create(ctx, p))
+	}
+
+	got, err := repo.Search(ctx, "kb-search", "alpha", 10)
+	require.NoError(t, err)
+	require.Len(t, got, 4)
+	assert.Equal(t, []string{
+		"entity/title-hit",
+		"entity/alpha-slug",
+		"entity/summary-hit",
+		"entity/content-hit",
+	}, []string{got[0].Slug, got[1].Slug, got[2].Slug, got[3].Slug})
+}

--- a/internal/application/repository/wiki_page_test.go
+++ b/internal/application/repository/wiki_page_test.go
@@ -306,6 +306,73 @@ func TestListByTypeLight_EmptyType_ReturnsZero(t *testing.T) {
 	assert.Empty(t, entries)
 }
 
+func TestListBySourceRef_SQLiteMatchesExactAndTitledRefs(t *testing.T) {
+	db := setupWikiPagesTestDB(t)
+	repo := NewWikiPageRepository(db)
+	ctx := context.Background()
+
+	exact := makeWikiPage("kb-src", "summary/exact", types.WikiPageTypeSummary, types.WikiPageStatusPublished)
+	exact.SourceRefs = types.StringArray{"knowledge-1"}
+	titled := makeWikiPage("kb-src", "entity/titled", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	titled.SourceRefs = types.StringArray{"knowledge-1|Doc title"}
+	otherKB := makeWikiPage("kb-other", "entity/leaked", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	otherKB.SourceRefs = types.StringArray{"knowledge-1"}
+	prefixOnly := makeWikiPage("kb-src", "entity/prefix-only", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	prefixOnly.SourceRefs = types.StringArray{"knowledge-10|Different"}
+	escapedLike := makeWikiPage("kb-src", "entity/escaped-like", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	escapedLike.SourceRefs = types.StringArray{"knowledge_2|Doc title"}
+	likeNeighbor := makeWikiPage("kb-src", "entity/like-neighbor", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	likeNeighbor.SourceRefs = types.StringArray{"knowledgeX2|Different"}
+
+	for _, p := range []*types.WikiPage{exact, titled, otherKB, prefixOnly, escapedLike, likeNeighbor} {
+		require.NoError(t, repo.Create(ctx, p))
+	}
+
+	pages, err := repo.ListBySourceRef(ctx, "kb-src", "knowledge-1")
+	require.NoError(t, err)
+	require.Len(t, pages, 2)
+	assert.ElementsMatch(t, []string{"summary/exact", "entity/titled"}, []string{pages[0].Slug, pages[1].Slug})
+
+	slugs, err := repo.ListSlugsBySourceRef(ctx, "kb-src", "knowledge-1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"summary/exact", "entity/titled"}, slugs)
+
+	escapedPages, err := repo.ListBySourceRef(ctx, "kb-src", "knowledge_2")
+	require.NoError(t, err)
+	require.Len(t, escapedPages, 1)
+	assert.Equal(t, "entity/escaped-like", escapedPages[0].Slug)
+}
+
+func TestListSummariesByKnowledgeIDs_SQLiteMatchesSourceRefs(t *testing.T) {
+	db := setupWikiPagesTestDB(t)
+	repo := NewWikiPageRepository(db)
+	ctx := context.Background()
+
+	exact := makeWikiPage("kb-src", "summary/exact", types.WikiPageTypeSummary, types.WikiPageStatusPublished)
+	exact.Content = "exact summary"
+	exact.SourceRefs = types.StringArray{"knowledge-1"}
+	titled := makeWikiPage("kb-src", "summary/titled", types.WikiPageTypeSummary, types.WikiPageStatusPublished)
+	titled.Content = "titled summary"
+	titled.SourceRefs = types.StringArray{"knowledge-2|Doc title"}
+	entity := makeWikiPage("kb-src", "entity/not-summary", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	entity.SourceRefs = types.StringArray{"knowledge-1"}
+	archived := makeWikiPage("kb-src", "summary/archived", types.WikiPageTypeSummary, types.WikiPageStatusArchived)
+	archived.SourceRefs = types.StringArray{"knowledge-3"}
+	otherKB := makeWikiPage("kb-other", "summary/leaked", types.WikiPageTypeSummary, types.WikiPageStatusPublished)
+	otherKB.SourceRefs = types.StringArray{"knowledge-1"}
+
+	for _, p := range []*types.WikiPage{exact, titled, entity, archived, otherKB} {
+		require.NoError(t, repo.Create(ctx, p))
+	}
+
+	got, err := repo.ListSummariesByKnowledgeIDs(ctx, "kb-src", []string{"knowledge-1", "knowledge-2", "knowledge-3"})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"knowledge-1": "exact summary",
+		"knowledge-2": "titled summary",
+	}, got)
+}
+
 // TestListByTypeLight_ClampsLimit verifies the [1, 200] clamp. We don't
 // want a client passing limit=100000 and forcing the DB to return a
 // multi-MB response.


### PR DESCRIPTION
## Summary
- make wiki source_ref lookups dialect-aware so SQLite/Lite mode does not execute PostgreSQL-only JSONB operators
- reuse the same predicate for page lookup, slug lookup, and summary lookup paths
- add SQLite regression coverage for exact refs, legacy titled refs, LIKE metacharacters, KB isolation, and summary-only filtering

## Root cause
ListBySourceRef, ListSlugsBySourceRef, and ListSummariesByKnowledgeIDs used PostgreSQL-only JSONB syntax unconditionally. In SQLite-backed environments this fails with `unrecognized token: "@"`, which breaks wiki delete/retract and re-ingest source-ref reconciliation paths.

## Testing
- `CGO_LDFLAGS='-lc++' go test ./internal/application/repository -run 'TestListBySourceRef_SQLiteMatchesExactAndTitledRefs|TestListSummariesByKnowledgeIDs_SQLiteMatchesSourceRefs' -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/repository -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service -run 'Test.*Wiki|TestRemoveChunkRefs' -count=1`
- `git diff --check`
