### PR TITLE
fix(wiki): support search on sqlite

### DIFF
--- a/internal/application/repository/wiki_page.go
+++ b/internal/application/repository/wiki_page.go
@@ -982,8 +982,10 @@ func escapeLikePattern(s string) string {
 	return replacer.Replace(s)
 }
 
-// Search performs case-insensitive POSIX regex search on wiki pages within a knowledge base.
-// The query is interpreted as a PostgreSQL regular expression (via ~*).
+// Search performs case-insensitive search on wiki pages within a knowledge base.
+// PostgreSQL interprets the query as a POSIX regular expression (via ~*);
+// SQLite falls back to a literal substring match because it has no built-in
+// equivalent regex operator.
 //
 // Results are ranked by where the query hit, highest-relevance first:
 //
@@ -1005,22 +1007,13 @@ func (r *wikiPageRepository) Search(ctx context.Context, kbID string, query stri
 		limit = 50
 	}
 
-	// CASE expression is evaluated per-row during SELECT; we order by the
-	// alias so the DB only computes the rank once. Parameterized four
-	// times with the same regex to avoid coupling to GORM's positional
-	// arg rewriting quirks.
-	rankExpr := "CASE " +
-		"WHEN title ~* ? THEN 4 " +
-		"WHEN slug ~* ? THEN 3 " +
-		"WHEN summary ~* ? THEN 2 " +
-		"WHEN content ~* ? THEN 1 " +
-		"ELSE 0 END AS match_rank"
+	rankExpr, rankArgs, whereExpr, whereArgs := r.wikiSearchExpressions(query)
 
 	var pages []*types.WikiPage
 	if err := r.db.WithContext(ctx).
-		Select("*, "+rankExpr, query, query, query, query).
-		Where("knowledge_base_id = ? AND (title ~* ? OR content ~* ? OR summary ~* ? OR slug ~* ?)",
-			kbID, query, query, query, query).
+		Select("*, "+rankExpr, rankArgs...).
+		Where("knowledge_base_id = ?", kbID).
+		Where(whereExpr, whereArgs...).
 		Where("status != ?", "archived").
 		Order("match_rank DESC, updated_at DESC").
 		Limit(limit).
@@ -1028,6 +1021,35 @@ func (r *wikiPageRepository) Search(ctx context.Context, kbID string, query stri
 		return nil, err
 	}
 	return pages, nil
+}
+
+func (r *wikiPageRepository) wikiSearchExpressions(query string) (string, []interface{}, string, []interface{}) {
+	// CASE expression is evaluated per-row during SELECT; we order by the
+	// alias so the DB only computes the rank once. Parameterized four
+	// times with the same pattern to avoid coupling to GORM's positional
+	// arg rewriting quirks.
+	if r.db != nil && r.db.Dialector != nil && r.db.Dialector.Name() == "sqlite" {
+		pattern := "%" + escapeLikePattern(strings.ToLower(query)) + "%"
+		args := []interface{}{pattern, pattern, pattern, pattern}
+		rankExpr := "CASE " +
+			"WHEN LOWER(title) LIKE ? ESCAPE '\\' THEN 4 " +
+			"WHEN LOWER(slug) LIKE ? ESCAPE '\\' THEN 3 " +
+			"WHEN LOWER(summary) LIKE ? ESCAPE '\\' THEN 2 " +
+			"WHEN LOWER(content) LIKE ? ESCAPE '\\' THEN 1 " +
+			"ELSE 0 END AS match_rank"
+		whereExpr := "(LOWER(title) LIKE ? ESCAPE '\\' OR LOWER(content) LIKE ? ESCAPE '\\' OR LOWER(summary) LIKE ? ESCAPE '\\' OR LOWER(slug) LIKE ? ESCAPE '\\')"
+		return rankExpr, args, whereExpr, args
+	}
+
+	args := []interface{}{query, query, query, query}
+	rankExpr := "CASE " +
+		"WHEN title ~* ? THEN 4 " +
+		"WHEN slug ~* ? THEN 3 " +
+		"WHEN summary ~* ? THEN 2 " +
+		"WHEN content ~* ? THEN 1 " +
+		"ELSE 0 END AS match_rank"
+	whereExpr := "(title ~* ? OR content ~* ? OR summary ~* ? OR slug ~* ?)"
+	return rankExpr, args, whereExpr, args
 }
 
 // CountByType returns page counts grouped by type for a knowledge base

--- a/internal/application/repository/wiki_page_test.go
+++ b/internal/application/repository/wiki_page_test.go
@@ -332,3 +332,38 @@ func TestListByTypeLight_ClampsLimit(t *testing.T) {
 	require.NoError(t, err)
 	assert.LessOrEqual(t, len(clampedEntries), 200)
 }
+
+func TestSearch_SQLiteRanksMatchesAndExcludesArchived(t *testing.T) {
+	db := setupWikiPagesTestDB(t)
+	repo := NewWikiPageRepository(db)
+	ctx := context.Background()
+
+	titleHit := makeWikiPage("kb-search", "entity/title-hit", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	titleHit.Title = "Alpha topic"
+	slugHit := makeWikiPage("kb-search", "entity/alpha-slug", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	slugHit.Title = "Slug page"
+	summaryHit := makeWikiPage("kb-search", "entity/summary-hit", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	summaryHit.Title = "Summary page"
+	summaryHit.Summary = "Mentions alpha in summary"
+	contentHit := makeWikiPage("kb-search", "entity/content-hit", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	contentHit.Title = "Content page"
+	contentHit.Content = "Mentions alpha in body"
+	archived := makeWikiPage("kb-search", "entity/archived", types.WikiPageTypeEntity, types.WikiPageStatusArchived)
+	archived.Title = "Alpha archived"
+	otherKB := makeWikiPage("kb-other", "entity/leaked", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	otherKB.Title = "Alpha leaked"
+
+	for _, p := range []*types.WikiPage{contentHit, summaryHit, slugHit, titleHit, archived, otherKB} {
+		require.NoError(t, repo.Create(ctx, p))
+	}
+
+	got, err := repo.Search(ctx, "kb-search", "alpha", 10)
+	require.NoError(t, err)
+	require.Len(t, got, 4)
+	assert.Equal(t, []string{
+		"entity/title-hit",
+		"entity/alpha-slug",
+		"entity/summary-hit",
+		"entity/content-hit",
+	}, []string{got[0].Slug, got[1].Slug, got[2].Slug, got[3].Slug})
+}


### PR DESCRIPTION
## Summary
- keep the existing PostgreSQL wiki search ranking based on `~*`
- add a SQLite-compatible literal substring search path using `LOWER(...) LIKE ... ESCAPE`
- preserve ranking by match location: title, slug, summary, then content
- add SQLite regression coverage for ranking, KB isolation, and archived-page exclusion

## Root cause
Wiki page search used PostgreSQL's `~*` regex operator unconditionally. SQLite-backed deployments/tests fail with `near "~": syntax error`, which breaks the wiki search endpoint and agent wiki_search tool when the repository runs on SQLite.

## Testing
- `CGO_LDFLAGS='-lc++' go test ./internal/application/repository -run TestSearch_SQLiteRanksMatchesAndExcludesArchived -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/repository -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service -run 'Test.*Wiki|TestRemoveChunkRefs' -count=1`
- `git diff --check`
