### PR TITLE
fix(wiki): support orphan count on sqlite

### DIFF
--- a/internal/application/repository/wiki_page.go
+++ b/internal/application/repository/wiki_page.go
@@ -36,6 +36,13 @@ func (r *wikiPageRepository) wikiCategoryRankOrder() string {
 	return "CASE WHEN COALESCE(jsonb_array_length(category_path), 0) > 0 THEN 0 ELSE 1 END ASC"
 }
 
+func (r *wikiPageRepository) wikiEmptyInLinksPredicate() string {
+	if r.db != nil && r.db.Dialector != nil && r.db.Dialector.Name() == "sqlite" {
+		return "(in_links IS NULL OR json_array_length(in_links) = 0)"
+	}
+	return "(in_links IS NULL OR in_links = '[]'::JSONB)"
+}
+
 // Create inserts a new wiki page record
 func (r *wikiPageRepository) Create(ctx context.Context, page *types.WikiPage) error {
 	return r.db.WithContext(ctx).Create(page).Error
@@ -1059,7 +1066,7 @@ func (r *wikiPageRepository) CountOrphans(ctx context.Context, kbID string) (int
 	if err := r.db.WithContext(ctx).
 		Model(&types.WikiPage{}).
 		Where("knowledge_base_id = ?", kbID).
-		Where("(in_links IS NULL OR in_links = '[]'::JSONB)").
+		Where(r.wikiEmptyInLinksPredicate()).
 		// Exclude index and log pages as they are naturally root pages
 		Where("page_type NOT IN ?", []string{types.WikiPageTypeIndex, types.WikiPageTypeLog}).
 		Count(&count).Error; err != nil {

--- a/internal/application/repository/wiki_page_test.go
+++ b/internal/application/repository/wiki_page_test.go
@@ -332,3 +332,28 @@ func TestListByTypeLight_ClampsLimit(t *testing.T) {
 	require.NoError(t, err)
 	assert.LessOrEqual(t, len(clampedEntries), 200)
 }
+
+func TestCountOrphans_SQLiteCountsEmptyInLinks(t *testing.T) {
+	db := setupWikiPagesTestDB(t)
+	repo := NewWikiPageRepository(db)
+	ctx := context.Background()
+
+	orphan := makeWikiPage("kb-orphans", "entity/orphan", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	orphan.InLinks = types.StringArray{}
+	linked := makeWikiPage("kb-orphans", "entity/linked", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	linked.InLinks = types.StringArray{"entity/source"}
+	indexPage := makeWikiPage("kb-orphans", "index", types.WikiPageTypeIndex, types.WikiPageStatusPublished)
+	indexPage.InLinks = types.StringArray{}
+	logPage := makeWikiPage("kb-orphans", "log", types.WikiPageTypeLog, types.WikiPageStatusPublished)
+	logPage.InLinks = types.StringArray{}
+	otherKB := makeWikiPage("kb-other", "entity/other", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	otherKB.InLinks = types.StringArray{}
+
+	for _, p := range []*types.WikiPage{orphan, linked, indexPage, logPage, otherKB} {
+		require.NoError(t, repo.Create(ctx, p))
+	}
+
+	got, err := repo.CountOrphans(ctx, "kb-orphans")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), got)
+}


### PR DESCRIPTION
## Summary
- make wiki orphan counting use a dialect-aware empty `in_links` predicate
- keep PostgreSQL on the existing JSONB comparison
- use SQLite JSON array length for Lite/SQLite-backed repositories
- add SQLite regression coverage for orphan counting, linked pages, system pages, and KB isolation

## Root cause
`CountOrphans` used `in_links = '[]'::JSONB` unconditionally. SQLite does not support PostgreSQL casts, so wiki stats failed with `unrecognized token: ":"` when the repository ran on SQLite.

## Testing
- `CGO_LDFLAGS='-lc++' go test ./internal/application/repository -run TestCountOrphans_SQLiteCountsEmptyInLinks -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/repository -count=1`
- `CGO_LDFLAGS='-lc++' go test ./internal/application/service -run 'Test.*Wiki|TestRemoveChunkRefs' -count=1`
- `git diff --check`
