### PR TITLE
fix: refresh pending join request counts after review

### DIFF
--- a/frontend/src/views/organization/OrganizationSettingsModal.test.mjs
+++ b/frontend/src/views/organization/OrganizationSettingsModal.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const source = readFileSync(new URL('./OrganizationSettingsModal.vue', import.meta.url), 'utf8')
+
+test('reviewing join requests refreshes local and cached global organization data', () => {
+  assert.match(
+    source,
+    /const refreshOrganizationAfterReview = async \(\) => \{\s*await Promise\.all\(\[\s*fetchOrgDetail\(\),\s*orgStore\.fetchOrganizations\(\{ force: true \}\)\s*\]\)\s*\}/
+  )
+
+  const refreshCalls = source.match(/await refreshOrganizationAfterReview\(\)/g) ?? []
+  assert.equal(refreshCalls.length, 2)
+})

--- a/frontend/src/views/organization/OrganizationSettingsModal.vue
+++ b/frontend/src/views/organization/OrganizationSettingsModal.vue
@@ -1071,6 +1071,17 @@ const fetchJoinRequests = async () => {
   }
 }
 
+/**
+ * 审批结果会同时影响设置弹窗、空间卡片和全局侧栏中的待审批数量。
+ * 后两处读取的是 organization store，因此必须绕过列表缓存并同步最新计数。
+ */
+const refreshOrganizationAfterReview = async () => {
+  await Promise.all([
+    fetchOrgDetail(),
+    orgStore.fetchOrganizations({ force: true })
+  ])
+}
+
 const handleApproveRequest = async (req: JoinRequestResponse) => {
   if (!props.orgId) return
   reviewingRequestId.value = req.id
@@ -1080,7 +1091,7 @@ const handleApproveRequest = async (req: JoinRequestResponse) => {
     if (res.success) {
       MessagePlugin.success(t('organization.settings.approveSuccess'))
       joinRequests.value = joinRequests.value.filter(r => r.id !== req.id)
-      await fetchOrgDetail()
+      await refreshOrganizationAfterReview()
     } else {
       MessagePlugin.error(res.message || t('organization.settings.reviewFailed'))
     }
@@ -1099,7 +1110,7 @@ const handleRejectRequest = async (req: JoinRequestResponse) => {
     if (res.success) {
       MessagePlugin.success(t('organization.settings.rejectSuccess'))
       joinRequests.value = joinRequests.value.filter(r => r.id !== req.id)
-      await fetchOrgDetail()
+      await refreshOrganizationAfterReview()
     } else {
       MessagePlugin.error(res.message || t('organization.settings.reviewFailed'))
     }


### PR DESCRIPTION
## Description

Fix stale pending join request counts after an administrator approves or rejects a membership request.

Previously, the approval dialog refreshed only its local organization data. The shared-space cards and sidebar read from the global organization store, which could continue displaying the old count because the organization list is cached for 60 seconds.

This change:

- Refreshes the current organization details after a request is reviewed.
- Force-refreshes the global organization list with `{ force: true }` to bypass the cache.
- Keeps the approval dialog, shared-space cards, and sidebar pending counts synchronized.
- Adds a regression test covering both approval and rejection handlers.

This change does not introduce any breaking changes.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

- Ran:

  `node --test frontend/src/views/organization/OrganizationSettingsModal.test.mjs`

- Verified that the regression test passes.
- Verified that both approval and rejection handlers refresh the current organization details.
- Verified that the global organization list is refreshed with `{ force: true }`.

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A — Pictures cannot prove the effect of this change.

