### PR TITLE
refactor(http): share SSRF-safe transport across model clients

### DIFF
--- a/internal/models/embedding/transport.go
+++ b/internal/models/embedding/transport.go
@@ -10,11 +10,11 @@ import (
 
 // sharedEmbeddingHTTPTransport keeps a single SSRF-safe connection pool for
 // all embedding clients. Embedders are recreated as model configuration changes,
-// but their outbound connections can be safely reused across client instances.
-var sharedEmbeddingHTTPTransport = func() http.RoundTripper {
-	cfg := secutils.DefaultSSRFSafeHTTPClientConfig()
-	return secutils.NewSSRFSafeHTTPClient(cfg).Transport
-}()
+// but their outbound connections can be safely reused across client instances,
+// so the transport (and its keep-alive pool) is built once at package load.
+var sharedEmbeddingHTTPTransport = secutils.NewSSRFSafeTransport(
+	secutils.DefaultSSRFSafeHTTPClientConfig(),
+)
 
 // validateEmbeddingBaseURL checks that a resolved embedding API base URL is safe
 // for outbound requests. Empty URLs are allowed (callers apply provider defaults).
@@ -30,10 +30,10 @@ func validateEmbeddingBaseURL(baseURL string) error {
 
 // newEmbeddingHTTPClient returns an HTTP client with connection-level SSRF
 // protection and redirect validation, aligned with internal/models/chat/transport.go.
+// All clients share sharedEmbeddingHTTPTransport so keep-alive connections are
+// pooled globally, while each keeps its own timeout.
 func newEmbeddingHTTPClient(timeout time.Duration) *http.Client {
 	cfg := secutils.DefaultSSRFSafeHTTPClientConfig()
 	cfg.Timeout = timeout
-	client := secutils.NewSSRFSafeHTTPClient(cfg)
-	client.Transport = sharedEmbeddingHTTPTransport
-	return client
+	return secutils.NewSSRFSafeHTTPClientWithTransport(cfg, sharedEmbeddingHTTPTransport)
 }

--- a/internal/models/rerank/transport.go
+++ b/internal/models/rerank/transport.go
@@ -18,8 +18,20 @@ func validateRerankBaseURL(baseURL string) error {
 	return nil
 }
 
+// sharedRerankHTTPTransport keeps a single SSRF-safe connection pool for all
+// rerank clients. Rerankers are recreated on every GetRerankModel call, but
+// their outbound connections can be safely reused, so the transport (and its
+// keep-alive pool) is built once at package load.
+var sharedRerankHTTPTransport = secutils.NewSSRFSafeTransport(
+	secutils.DefaultSSRFSafeHTTPClientConfig(),
+)
+
+// newRerankHTTPClient returns an HTTP client with connection-level SSRF
+// protection and redirect validation. All clients share
+// sharedRerankHTTPTransport so keep-alive connections are pooled globally,
+// while each keeps its own timeout.
 func newRerankHTTPClient(timeout time.Duration) *http.Client {
 	cfg := secutils.DefaultSSRFSafeHTTPClientConfig()
 	cfg.Timeout = timeout
-	return secutils.NewSSRFSafeHTTPClient(cfg)
+	return secutils.NewSSRFSafeHTTPClientWithTransport(cfg, sharedRerankHTTPTransport)
 }

--- a/internal/utils/security.go
+++ b/internal/utils/security.go
@@ -779,49 +779,74 @@ func stripRedirectSensitiveHeaders(req *http.Request) {
 	req.Header.Del("Api-Key")
 }
 
-// NewSSRFSafeHTTPClient creates an HTTP client that validates redirect targets against SSRF protections.
-// This prevents SSRF attacks via HTTP redirects where an attacker's server redirects to internal services.
-func NewSSRFSafeHTTPClient(config SSRFSafeHTTPClientConfig) *http.Client {
-	transport := &http.Transport{
+// NewSSRFSafeTransport builds an *http.Transport whose connections are guarded
+// by SSRFSafeDialContext. The transport carries no per-request timeout and no
+// redirect policy — those live on the *http.Client — so a single transport can
+// be shared across many clients to pool keep-alive connections globally.
+func NewSSRFSafeTransport(config SSRFSafeHTTPClientConfig) *http.Transport {
+	return &http.Transport{
 		DisableKeepAlives:  config.DisableKeepAlives,
 		DisableCompression: config.DisableCompression,
 		// Dial with SSRF protection - validates resolved IPs before connecting
 		DialContext: SSRFSafeDialContext,
 	}
+}
 
-	return &http.Client{
-		Timeout:   config.Timeout,
-		Transport: transport,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			// Check redirect count
-			if len(via) >= config.MaxRedirects {
-				return fmt.Errorf("stopped after %d redirects", config.MaxRedirects)
-			}
+// newSSRFCheckRedirect returns a CheckRedirect policy that enforces the redirect
+// count limit, strips sensitive headers on cross-host hops, and re-validates
+// every redirect target against SSRF protections.
+func newSSRFCheckRedirect(maxRedirects int) func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		// Check redirect count
+		if len(via) >= maxRedirects {
+			return fmt.Errorf("stopped after %d redirects", maxRedirects)
+		}
 
-			// Strip credentials when the redirect crosses hosts so connector
-			// tokens (e.g. Yuque X-Auth-Token) cannot leak to a third party.
-			if len(via) > 0 && !sameHTTPOrigin(via[0].URL, req.URL) {
-				stripRedirectSensitiveHeaders(req)
-			}
+		// Strip credentials when the redirect crosses hosts so connector
+		// tokens (e.g. Yuque X-Auth-Token) cannot leak to a third party.
+		if len(via) > 0 && !sameHTTPOrigin(via[0].URL, req.URL) {
+			stripRedirectSensitiveHeaders(req)
+		}
 
-			// Validate the redirect target URL for SSRF (whitelist-aware).
-			// Even whitelisted hosts must use http/https to prevent scheme-based attacks.
-			redirectScheme := strings.ToLower(req.URL.Scheme)
-			if redirectScheme != "http" && redirectScheme != "https" {
-				return fmt.Errorf("%w: invalid scheme %s", ErrSSRFRedirectBlocked, redirectScheme)
-			}
-			redirectHost := req.URL.Hostname()
-			if redirectHost != "" && IsSSRFWhitelisted(redirectHost) {
-				return nil
-			}
-			redirectURL := req.URL.String()
-			if safe, reason := isSSRFSafeURL(redirectURL); !safe {
-				return fmt.Errorf("%w: %s", ErrSSRFRedirectBlocked, reason)
-			}
-
+		// Validate the redirect target URL for SSRF (whitelist-aware).
+		// Even whitelisted hosts must use http/https to prevent scheme-based attacks.
+		redirectScheme := strings.ToLower(req.URL.Scheme)
+		if redirectScheme != "http" && redirectScheme != "https" {
+			return fmt.Errorf("%w: invalid scheme %s", ErrSSRFRedirectBlocked, redirectScheme)
+		}
+		redirectHost := req.URL.Hostname()
+		if redirectHost != "" && IsSSRFWhitelisted(redirectHost) {
 			return nil
-		},
+		}
+		redirectURL := req.URL.String()
+		if safe, reason := isSSRFSafeURL(redirectURL); !safe {
+			return fmt.Errorf("%w: %s", ErrSSRFRedirectBlocked, reason)
+		}
+
+		return nil
 	}
+}
+
+// NewSSRFSafeHTTPClientWithTransport wraps a caller-supplied transport in an
+// *http.Client carrying the given timeout and the SSRF-aware redirect policy.
+// Pass a transport from NewSSRFSafeTransport (optionally shared across clients)
+// to reuse a single connection pool while keeping per-client timeouts.
+func NewSSRFSafeHTTPClientWithTransport(
+	config SSRFSafeHTTPClientConfig, transport http.RoundTripper,
+) *http.Client {
+	return &http.Client{
+		Timeout:       config.Timeout,
+		Transport:     transport,
+		CheckRedirect: newSSRFCheckRedirect(config.MaxRedirects),
+	}
+}
+
+// NewSSRFSafeHTTPClient creates an HTTP client that validates redirect targets against SSRF protections.
+// This prevents SSRF attacks via HTTP redirects where an attacker's server redirects to internal services.
+// Each call builds a dedicated transport; callers that create many short-lived clients against the same
+// upstream should share one NewSSRFSafeTransport via NewSSRFSafeHTTPClientWithTransport instead.
+func NewSSRFSafeHTTPClient(config SSRFSafeHTTPClientConfig) *http.Client {
+	return NewSSRFSafeHTTPClientWithTransport(config, NewSSRFSafeTransport(config))
 }
 
 // SSRFSafeDialContext is a custom dial function that validates the resolved IP addresses

--- a/internal/utils/security_transport_test.go
+++ b/internal/utils/security_transport_test.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestNewSSRFSafeTransport_SharedAcrossClients verifies that a single transport
+// can back multiple clients (global connection pooling) while each client keeps
+// its own timeout and a redirect policy.
+func TestNewSSRFSafeTransport_SharedAcrossClients(t *testing.T) {
+	shared := NewSSRFSafeTransport(DefaultSSRFSafeHTTPClientConfig())
+
+	cfg := DefaultSSRFSafeHTTPClientConfig()
+	cfg.Timeout = 15 * time.Second
+	first := NewSSRFSafeHTTPClientWithTransport(cfg, shared)
+
+	cfg.Timeout = 45 * time.Second
+	second := NewSSRFSafeHTTPClientWithTransport(cfg, shared)
+
+	if first == second {
+		t.Fatal("expected distinct HTTP clients")
+	}
+	if first.Transport != second.Transport {
+		t.Fatal("expected clients to share the same transport")
+	}
+	if first.Transport != http.RoundTripper(shared) {
+		t.Fatal("expected client to use the supplied shared transport")
+	}
+	if first.Timeout != 15*time.Second {
+		t.Fatalf("unexpected first timeout: got %v, want %v", first.Timeout, 15*time.Second)
+	}
+	if second.Timeout != 45*time.Second {
+		t.Fatalf("unexpected second timeout: got %v, want %v", second.Timeout, 45*time.Second)
+	}
+	if first.CheckRedirect == nil || second.CheckRedirect == nil {
+		t.Fatal("expected SSRF redirect policy to be set on both clients")
+	}
+}
+
+// TestNewSSRFSafeHTTPClient_HasDedicatedTransport verifies the convenience
+// constructor still builds a working transport + redirect policy.
+func TestNewSSRFSafeHTTPClient_HasDedicatedTransport(t *testing.T) {
+	client := NewSSRFSafeHTTPClient(DefaultSSRFSafeHTTPClientConfig())
+	if client.Transport == nil {
+		t.Fatal("expected a transport to be set")
+	}
+	if _, ok := client.Transport.(*http.Transport); !ok {
+		t.Fatalf("expected *http.Transport, got %T", client.Transport)
+	}
+	if client.CheckRedirect == nil {
+		t.Fatal("expected SSRF redirect policy to be set")
+	}
+}


### PR DESCRIPTION
## Summary

- Extract `NewSSRFSafeTransport` and `NewSSRFSafeHTTPClientWithTransport` in `secutils` so transport construction, redirect policy, and per-client timeout can be composed cleanly.
- Refine the embedding shared-transport fix (#2201 / #2197) to stop allocating a throwaway transport on every `newEmbeddingHTTPClient` call.
- Apply the same shared-transport pattern to rerank clients, which are also recreated on every `GetRerankModel` call.

## Why

The merged fix in #2201 worked but created a full `http.Transport` per client only to immediately replace it. This refactor makes the intent explicit and reusable, while keeping SSRF dial/redirect protections and per-client timeouts unchanged.

## Safety

- Shared transport only pools TCP connections by host; API keys, custom headers, and timeouts remain per-request / per-client.
- No change to `SSRFSafeDialContext` or redirect validation semantics.

## Test plan

- [x] `go test ./internal/utils/ -count=1`
- [x] `go test ./internal/models/embedding/ -count=1`
- [x] `go test ./internal/models/rerank/ -count=1`
- [x] `go vet ./internal/utils/ ./internal/models/embedding/ ./internal/models/rerank/`