### PR TITLE
fix(tasks): detach KB deletion queue cleanup from request ctx

### DIFF
--- a/internal/application/service/knowledgebase.go
+++ b/internal/application/service/knowledgebase.go
@@ -731,7 +731,16 @@ func (s *knowledgeBaseService) DeleteKnowledgeBase(ctx context.Context, id strin
 	// Stop both ephemeral queue work and durable wiki operations that target
 	// the now-deleted KB. ProcessKBDelete repeats this with document IDs and
 	// performs one final scrub after heavy cleanup to close enqueue races.
-	s.cleanupTasksForKnowledgeBase(ctx, id, nil, nil)
+	//
+	// Run detached with a bounded timeout so a disconnecting API client cannot
+	// truncate this best-effort scrub mid-scan, matching ProcessKBDelete's
+	// cleanup semantics. The KB row is already soft-deleted, so the async
+	// delete task remains the durable backstop even if this pass is cut short.
+	kbCleanupCtx, cancelKBCleanup := context.WithTimeout(
+		context.WithoutCancel(ctx), kbTaskCleanupTimeout,
+	)
+	s.cleanupTasksForKnowledgeBase(kbCleanupCtx, id, nil, nil)
+	cancelKBCleanup()
 
 	// Step 1b: Remove all organization shares for this KB so org settings no longer show them
 	if s.shareRepo != nil {
@@ -744,7 +753,11 @@ func (s *knowledgeBaseService) DeleteKnowledgeBase(ctx context.Context, id strin
 	// schedules and in-flight sync logs do not keep running against a deleted KB.
 	dataSourceIDs := s.deleteDataSourcesForKnowledgeBase(ctx, id)
 	if len(dataSourceIDs) > 0 {
-		s.cancelTasksForKnowledgeBase(ctx, id, nil, dataSourceIDs)
+		dsCancelCtx, cancelDSCancel := context.WithTimeout(
+			context.WithoutCancel(ctx), kbTaskCleanupTimeout,
+		)
+		s.cancelTasksForKnowledgeBase(dsCancelCtx, id, nil, dataSourceIDs)
+		cancelDSCancel()
 	}
 
 	// Step 2: Enqueue async task for heavy cleanup operations


### PR DESCRIPTION
## Summary

- Run the synchronous best-effort queue scrub in `DeleteKnowledgeBase` with `context.WithoutCancel` and `kbTaskCleanupTimeout`, so an API client disconnect cannot truncate task cancellation mid-scan.
- Apply the same detached timeout to the data-source task cancellation pass in the same handler.
- Aligns API-path cleanup semantics with the existing `ProcessKBDelete` defer scrub introduced in #2202.

## Context

Follow-up to #2202 / #2055. The main queue scan still runs inside the async `kb:delete` task (2h budget); this change only hardens the immediate best-effort scrub on the delete API path.

## Test plan

- [x] `go build ./internal/application/service/`
- [x] `go test ./internal/application/service -run 'KnowledgeBase|KBTask|KBDelete|WikiDeleted' -count=1`