### PR TITLE
fix(im): harden Yunzhijia image download after #2214

### DIFF
--- a/frontend/src/components/IMChannelPanel.vue
+++ b/frontend/src/components/IMChannelPanel.vue
@@ -1034,13 +1034,11 @@ async function handleSave() {
       return;
     }
     if (formData.value.platform === 'yunzhijia') {
+      // normalize fills in the default allowed host suffix, so only the send URL
+      // needs explicit validation here.
       normalizeYunzhijiaCredentials();
       if (!String(formData.value.credentials.send_msg_url || '').trim()) {
         MessagePlugin.warning(t('agentEditor.im.yunzhijiaSendMsgUrlRequired'));
-        return;
-      }
-      if (!String(formData.value.credentials.allowed_webhook_host_suffix || '').trim()) {
-        MessagePlugin.warning(t('agentEditor.im.yunzhijiaAllowedHostSuffixRequired'));
         return;
       }
     }

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -5985,9 +5985,7 @@ export default {
       yunzhijiaTimeoutHint: 'Timeout for sending replies via Send Message URL, default 10 seconds',
       yunzhijiaAllowedHostSuffix: 'Allowed Host Suffix',
       yunzhijiaAllowedHostSuffixHint: 'Restrict Send Message URL host to this suffix for security (e.g. yunzhijia.com)',
-      yunzhijiaRequiredCredentials: 'Enter the Send Message URL and allowed host suffix',
       yunzhijiaSendMsgUrlRequired: 'Enter the Send Message URL from Yunzhijia robot settings',
-      yunzhijiaAllowedHostSuffixRequired: 'Enter the allowed host suffix',
       mattermostModeHint: 'Mattermost only supports Webhook mode (outgoing webhook + bot token).',
       mattermostPostToMain: 'Post replies in channel timeline',
       mattermostPostToMainHint:

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -5916,9 +5916,7 @@ export default {
       yunzhijiaTimeoutHint: "메시지 전송 URL을 통한 응답 전송 타임아웃, 기본 10초",
       yunzhijiaAllowedHostSuffix: "허용 호스트 접미사",
       yunzhijiaAllowedHostSuffixHint: "보안을 위해 메시지 전송 URL 호스트를 이 접미사로 제한 (예: yunzhijia.com)",
-      yunzhijiaRequiredCredentials: "메시지 전송 URL과 허용 호스트 접미사를 입력하세요",
       yunzhijiaSendMsgUrlRequired: "Yunzhijia 로봇 설정의 메시지 전송 URL을 입력하세요",
-      yunzhijiaAllowedHostSuffixRequired: "허용 호스트 접미사를 입력하세요",
       mattermostModeHint: "Mattermost는 Webhook(아웃고잉 웹훅 + 봇 토큰)만 지원합니다.",
       mattermostPostToMain: "답변을 채널 메인 타임라인에 표시",
       mattermostPostToMainHint:

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -5488,9 +5488,7 @@ export default {
       yunzhijiaTimeoutHint: 'Таймаут отправки ответов через URL отправки сообщений, по умолчанию 10 секунд',
       yunzhijiaAllowedHostSuffix: 'Допустимый суффикс хоста',
       yunzhijiaAllowedHostSuffixHint: 'Ограничить хост URL отправки сообщений этим суффиксом для безопасности (напр. yunzhijia.com)',
-      yunzhijiaRequiredCredentials: 'Укажите URL отправки сообщений и допустимый суффикс хоста',
       yunzhijiaSendMsgUrlRequired: 'Укажите URL отправки сообщений из настроек робота Yunzhijia',
-      yunzhijiaAllowedHostSuffixRequired: 'Укажите допустимый суффикс хоста',
       mattermostModeHint: 'Mattermost поддерживает только режим Webhook (исходящий вебхук + токен бота).',
       mattermostPostToMain: 'Ответы в основной ленте канала',
       mattermostPostToMainHint:

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -5969,9 +5969,7 @@ export default {
       yunzhijiaTimeoutHint: "通过发送消息地址回复的超时时间，默认 10 秒",
       yunzhijiaAllowedHostSuffix: "允许的主机后缀",
       yunzhijiaAllowedHostSuffixHint: "限制发送消息地址的目标域名后缀，提升安全性（如 yunzhijia.com）",
-      yunzhijiaRequiredCredentials: "请填写发送消息地址和允许的主机后缀",
       yunzhijiaSendMsgUrlRequired: "请填写云之家机器人设置中的发送消息地址",
-      yunzhijiaAllowedHostSuffixRequired: "请填写允许的主机后缀",
       mattermostModeHint: "Mattermost 仅支持 Webhook（出站 Webhook + Bot Token）。",
       mattermostPostToMain: "回复显示在频道主时间线",
       mattermostPostToMainHint:

--- a/internal/im/yunzhijia/adapter.go
+++ b/internal/im/yunzhijia/adapter.go
@@ -41,6 +41,16 @@ var validateDownloadFileURL = func(rawURL string) error {
 	return err
 }
 
+// maxDownloadFileSize caps the size of a file downloaded from Yunzhijia and read
+// into memory, to avoid unbounded memory usage from a large/malicious response.
+const maxDownloadFileSize = 32 << 20 // 32 MiB
+
+// maxDownloadRedirects limits how many redirects DownloadFile follows manually.
+// The shared httpClient disables automatic redirects (SSRF safety), but the
+// Yunzhijia download endpoint may 302 to a signed URL, so we follow a single hop
+// while re-validating the target host stays within the allowed suffix.
+const maxDownloadRedirects = 1
+
 // Adapter implements im.Adapter for Yunzhijia (云之家).
 type Adapter struct {
 	sendMsgURL               string
@@ -355,17 +365,12 @@ func (a *Adapter) DownloadFile(ctx context.Context, msg *im.IncomingMessage) (io
 		return nil, "", fmt.Errorf("download url rejected: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	resp, err := a.fetchDownload(ctx, downloadURL, accessToken)
 	if err != nil {
-		return nil, "", fmt.Errorf("create download request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+accessToken)
-	resp, err := a.httpClient.Do(req)
-	if err != nil {
-		return nil, "", fmt.Errorf("download file: %w", err)
+		return nil, "", err
 	}
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		resp.Body.Close()
 		return nil, "", fmt.Errorf("download file returned %d: %s", resp.StatusCode, string(body))
 	}
@@ -375,7 +380,87 @@ func (a *Adapter) DownloadFile(ctx context.Context, msg *im.IncomingMessage) (io
 		fileName = fileID
 	}
 	fileName = resolveDownloadFileName(fileName, resp)
-	return resp.Body, fileName, nil
+	return newLimitedReadCloser(resp.Body, maxDownloadFileSize), fileName, nil
+}
+
+// fetchDownload performs the download request, following at most maxDownloadRedirects
+// redirects. Each redirect target is re-validated against the allowed host suffix so
+// the request cannot be redirected off the trusted domain. The bearer token is only
+// sent on the initial request and never forwarded across a redirect.
+func (a *Adapter) fetchDownload(ctx context.Context, downloadURL, accessToken string) (*http.Response, error) {
+	currentURL := downloadURL
+	for redirects := 0; ; redirects++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, currentURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("create download request: %w", err)
+		}
+		if redirects == 0 {
+			req.Header.Set("Authorization", "Bearer "+accessToken)
+		}
+		resp, err := a.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("download file: %w", err)
+		}
+		if resp.StatusCode < http.StatusMultipleChoices || resp.StatusCode >= http.StatusBadRequest {
+			return resp, nil
+		}
+
+		// Redirect (3xx): re-validate the target before following.
+		location := strings.TrimSpace(resp.Header.Get("Location"))
+		resp.Body.Close()
+		if redirects >= maxDownloadRedirects {
+			return nil, fmt.Errorf("download file: too many redirects")
+		}
+		if location == "" {
+			return nil, fmt.Errorf("download file: redirect without Location")
+		}
+		resolved, err := resolveRedirectURL(currentURL, location)
+		if err != nil {
+			return nil, fmt.Errorf("download file: invalid redirect location: %w", err)
+		}
+		if err := validateDownloadFileURL(resolved); err != nil {
+			return nil, fmt.Errorf("download redirect rejected: %w", err)
+		}
+		currentURL = resolved
+	}
+}
+
+func resolveRedirectURL(base, location string) (string, error) {
+	baseURL, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	locURL, err := url.Parse(location)
+	if err != nil {
+		return "", err
+	}
+	return baseURL.ResolveReference(locURL).String(), nil
+}
+
+// newLimitedReadCloser wraps rc so that reading more than limit bytes returns an
+// error instead of silently truncating, while Close still closes the underlying body.
+func newLimitedReadCloser(rc io.ReadCloser, limit int64) io.ReadCloser {
+	return &limitedReadCloser{r: io.LimitReader(rc, limit+1), body: rc, limit: limit}
+}
+
+type limitedReadCloser struct {
+	r     io.Reader
+	body  io.Closer
+	limit int64
+	read  int64
+}
+
+func (l *limitedReadCloser) Read(p []byte) (int, error) {
+	n, err := l.r.Read(p)
+	l.read += int64(n)
+	if l.read > l.limit {
+		return n, fmt.Errorf("yunzhijia file exceeds max download size of %d bytes", l.limit)
+	}
+	return n, err
+}
+
+func (l *limitedReadCloser) Close() error {
+	return l.body.Close()
 }
 
 func buildDownloadFileURL(fileID string) string {

--- a/internal/im/yunzhijia/adapter_test.go
+++ b/internal/im/yunzhijia/adapter_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -289,6 +290,120 @@ func TestDownloadFile(t *testing.T) {
 	}
 	if string(body) != "image-bytes" || fileName != "message.png" {
 		t.Fatalf("body=%q fileName=%q", string(body), fileName)
+	}
+}
+
+func TestDownloadFileFollowsSingleRedirect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/oauth2_v12/auth/getAppAccessToken":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"accessToken":"token-1","expireIn":7136},"error":null,"errorCode":0,"success":true}`))
+		case "/gateway/docrest/doc/file/downloadfileOpen":
+			http.Redirect(w, r, "/cdn/file-1", http.StatusFound)
+		case "/cdn/file-1":
+			// Bearer token must NOT be forwarded across the redirect.
+			if r.Header.Get("Authorization") != "" {
+				t.Fatalf("Authorization forwarded to redirect target: %q", r.Header.Get("Authorization"))
+			}
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte("image-bytes"))
+		default:
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	oldAuthURL := yunzhijiaAuthURL
+	oldBaseURL := yunzhijiaDownloadFileBaseURL
+	oldValidator := validateDownloadFileURL
+	yunzhijiaAuthURL = server.URL + "/api/oauth2_v12/auth/getAppAccessToken"
+	yunzhijiaDownloadFileBaseURL = server.URL + "/gateway/docrest/doc/file/downloadfileOpen"
+	validateDownloadFileURL = func(string) error { return nil }
+	defer func() {
+		yunzhijiaAuthURL = oldAuthURL
+		yunzhijiaDownloadFileBaseURL = oldBaseURL
+		validateDownloadFileURL = oldValidator
+	}()
+
+	adapter := NewAdapter("https://www.yunzhijia.com/send", "", "app-id", "app-secret", 10, "yunzhijia.com")
+	adapter.httpClient = noRedirectClient(server)
+	reader, _, err := adapter.DownloadFile(context.Background(), &im.IncomingMessage{FileKey: "file-1", FileName: "message.png"})
+	if err != nil {
+		t.Fatalf("DownloadFile() error = %v", err)
+	}
+	defer reader.Close()
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(body) != "image-bytes" {
+		t.Fatalf("body = %q", string(body))
+	}
+}
+
+// noRedirectClient returns a client bound to the test server transport that does
+// not auto-follow redirects, mirroring the production adapter's CheckRedirect.
+func noRedirectClient(server *httptest.Server) *http.Client {
+	client := server.Client()
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return client
+}
+
+func TestDownloadFileRejectsRedirectOffAllowedHost(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/oauth2_v12/auth/getAppAccessToken":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"accessToken":"token-1","expireIn":7136},"error":null,"errorCode":0,"success":true}`))
+		case "/gateway/docrest/doc/file/downloadfileOpen":
+			http.Redirect(w, r, "https://evil.example.com/steal", http.StatusFound)
+		default:
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	oldAuthURL := yunzhijiaAuthURL
+	oldBaseURL := yunzhijiaDownloadFileBaseURL
+	oldValidator := validateDownloadFileURL
+	yunzhijiaAuthURL = server.URL + "/api/oauth2_v12/auth/getAppAccessToken"
+	yunzhijiaDownloadFileBaseURL = server.URL + "/gateway/docrest/doc/file/downloadfileOpen"
+	// Allow the test server host but reject anything off-host, mimicking the
+	// real yunzhijia.com suffix check for redirect targets.
+	validateDownloadFileURL = func(rawURL string) error {
+		if strings.Contains(rawURL, "evil.example.com") {
+			return fmt.Errorf("host not allowed")
+		}
+		return nil
+	}
+	defer func() {
+		yunzhijiaAuthURL = oldAuthURL
+		yunzhijiaDownloadFileBaseURL = oldBaseURL
+		validateDownloadFileURL = oldValidator
+	}()
+
+	adapter := NewAdapter("https://www.yunzhijia.com/send", "", "app-id", "app-secret", 10, "yunzhijia.com")
+	adapter.httpClient = noRedirectClient(server)
+	_, _, err := adapter.DownloadFile(context.Background(), &im.IncomingMessage{FileKey: "file-1"})
+	if err == nil || !strings.Contains(err.Error(), "redirect rejected") {
+		t.Fatalf("DownloadFile() error = %v, want redirect rejected", err)
+	}
+}
+
+func TestLimitedReadCloserEnforcesMaxSize(t *testing.T) {
+	reader := newLimitedReadCloser(io.NopCloser(strings.NewReader("0123456789")), 4)
+	defer reader.Close()
+	if _, err := io.ReadAll(reader); err == nil || !strings.Contains(err.Error(), "max download size") {
+		t.Fatalf("read error = %v, want max download size error", err)
+	}
+
+	ok := newLimitedReadCloser(io.NopCloser(strings.NewReader("1234")), 4)
+	defer ok.Close()
+	if got, err := io.ReadAll(ok); err != nil || string(got) != "1234" {
+		t.Fatalf("read got=%q err=%v, want full read within limit", string(got), err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up hardening for #2214 (Yunzhijia WebSocket image messages):

- Manually follow at most one download redirect while re-validating the target stays within the `yunzhijia.com` host suffix; the bearer token is only sent on the initial request and never forwarded across a redirect.
- Cap in-memory download size at 32 MiB via a limited read-closer that errors instead of silently truncating.
- Remove dead frontend host-suffix validation (normalize always fills the default) and drop unused i18n keys.

## Test plan

- [x] `go test ./internal/im/yunzhijia/...`
- [x] `go vet ./internal/im/yunzhijia/...`
- [ ] Verify Yunzhijia image download works against the real `downloadfileOpen` endpoint (confirm whether it returns 200 directly or 302 to a signed URL)