### PR TITLE
feat(reparse): content-addressed stable chunk IDs (#1679 — step 1)

### DIFF
--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -467,6 +467,14 @@ func (r *chunkRepository) DeleteChunksByKnowledgeID(ctx context.Context, tenantI
 	).Delete(&types.Chunk{}).Error
 }
 
+// PurgeSoftDeletedByKnowledgeID permanently removes chunks that were already
+// soft-deleted for the given knowledge ID. Live rows are intentionally excluded.
+func (r *chunkRepository) PurgeSoftDeletedByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) error {
+	return r.db.WithContext(ctx).Unscoped().
+		Where("tenant_id = ? AND knowledge_id = ? AND deleted_at IS NOT NULL", tenantID, knowledgeID).
+		Delete(&types.Chunk{}).Error
+}
+
 // ListImageInfoByKnowledgeIDs returns non-empty image_info values for the given knowledge IDs.
 // No chunk_type filter — collects from text, image_ocr, and image_caption chunks.
 func (r *chunkRepository) ListImageInfoByKnowledgeIDs(

--- a/internal/application/repository/chunk_sqlite_test.go
+++ b/internal/application/repository/chunk_sqlite_test.go
@@ -197,6 +197,59 @@ func TestCreateChunks_SQLite_SeqIDAfterSoftDelete(t *testing.T) {
 	assert.Equal(t, int64(5), saved[1].SeqID)
 }
 
+func TestPurgeSoftDeletedByKnowledgeID_SQLite_AllowsStableIDRecreate(t *testing.T) {
+	db := setupChunkTestDB(t)
+	repo := NewChunkRepository(db)
+	ctx := context.Background()
+
+	kbID := uuid.New().String()
+	knowledgeID := uuid.New().String()
+	liveKnowledgeID := uuid.New().String()
+	stableID := types.StableChunkID(1, knowledgeID, types.ChunkTypeText, types.ContentHash("stable content", ""), 0)
+
+	softDeleted := &types.Chunk{
+		ID:              stableID,
+		TenantID:        1,
+		KnowledgeBaseID: kbID,
+		KnowledgeID:     knowledgeID,
+		Content:         "stable content",
+		ContentHash:     types.ContentHash("stable content", ""),
+		ChunkType:       types.ChunkTypeText,
+		IsEnabled:       true,
+	}
+	liveSameKnowledge := makeChunk(kbID, knowledgeID, types.ChunkTypeText)
+	liveOtherKnowledge := makeChunk(kbID, liveKnowledgeID, types.ChunkTypeText)
+
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{softDeleted, liveSameKnowledge, liveOtherKnowledge}))
+	require.NoError(t, repo.DeleteChunk(ctx, 1, stableID))
+
+	require.NoError(t, repo.PurgeSoftDeletedByKnowledgeID(ctx, 1, knowledgeID))
+
+	var totalRows int64
+	require.NoError(t, db.Unscoped().Model(&types.Chunk{}).Count(&totalRows).Error)
+	assert.Equal(t, int64(2), totalRows, "only the already soft-deleted chunk should be purged")
+
+	var liveCount int64
+	require.NoError(t, db.Model(&types.Chunk{}).Where("knowledge_id IN ?", []string{knowledgeID, liveKnowledgeID}).Count(&liveCount).Error)
+	assert.Equal(t, int64(2), liveCount, "live chunks must not be purged")
+
+	recreated := &types.Chunk{
+		ID:              stableID,
+		TenantID:        1,
+		KnowledgeBaseID: kbID,
+		KnowledgeID:     knowledgeID,
+		Content:         "stable content",
+		ContentHash:     types.ContentHash("stable content", ""),
+		ChunkType:       types.ChunkTypeText,
+		IsEnabled:       true,
+	}
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{recreated}))
+
+	var active types.Chunk
+	require.NoError(t, db.First(&active, "id = ?", stableID).Error)
+	assert.Equal(t, "stable content", active.Content)
+}
+
 func TestUpdateChunk_SQLite_NoNOWError(t *testing.T) {
 	db := setupChunkTestDB(t)
 	ctx := context.Background()

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -383,17 +383,20 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	}
 
 	// === Parent-Child Chunking: create parent chunks first ===
+	chunkIDAllocator := types.NewChunkIDAllocator(knowledge.TenantID, knowledge.ID)
 	hasParentChild := len(options.ParentChunks) > 0
 	var parentDBChunks []*types.Chunk // indexed by ParsedParentChunk position
 	if hasParentChild {
 		parentDBChunks = make([]*types.Chunk, len(options.ParentChunks))
 		for i, pc := range options.ParentChunks {
+			chunkID, contentHash := chunkIDAllocator.Allocate(types.ChunkTypeParentText, pc.Content, "")
 			parentDBChunks[i] = &types.Chunk{
-				ID:              uuid.New().String(),
+				ID:              chunkID,
 				TenantID:        knowledge.TenantID,
 				KnowledgeID:     knowledge.ID,
 				KnowledgeBaseID: knowledge.KnowledgeBaseID,
 				Content:         pc.Content,
+				ContentHash:     contentHash,
 				ChunkIndex:      pc.Seq,
 				IsEnabled:       true,
 				CreatedAt:       time.Now(),
@@ -427,13 +430,15 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		}
 
 		// 创建主文本Chunk
+		chunkID, contentHash := chunkIDAllocator.Allocate(types.ChunkTypeText, chunkData.Content, chunkData.ContextHeader)
 		textChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              chunkID,
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
 			Content:         chunkData.Content,
 			ContextHeader:   chunkData.ContextHeader,
+			ContentHash:     contentHash,
 			ChunkIndex:      int(chunkData.Seq),
 			IsEnabled:       true,
 			CreatedAt:       time.Now(),
@@ -494,6 +499,15 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	s.beginStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
 		"chunks_planned": len(insertChunks),
 	})
+	if err := s.chunkService.GetRepository().PurgeSoftDeletedByKnowledgeID(ctx, knowledge.TenantID, knowledge.ID); err != nil {
+		knowledge.ParseStatus = types.ParseStatusFailed
+		knowledge.ErrorMessage = err.Error()
+		knowledge.UpdatedAt = time.Now()
+		s.repo.UpdateKnowledge(ctx, knowledge)
+		s.failStage(ctx, knowledge.ID, types.StageChunking,
+			werrors.ErrCodeChunkingFailed, "purge soft-deleted chunks failed", err)
+		return
+	}
 	if err := s.chunkService.CreateChunks(ctx, insertChunks); err != nil {
 		knowledge.ParseStatus = types.ParseStatusFailed
 		knowledge.ErrorMessage = err.Error()

--- a/internal/types/chunk_id.go
+++ b/internal/types/chunk_id.go
@@ -1,0 +1,92 @@
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+const stableChunkIDNamespace = "0ed67a0f-6d4d-4c9a-99ac-4c880ee62e96"
+
+// NormalizeForHash returns the canonical text used for document chunk hashing.
+// It mirrors embedding input semantics by including the context header when
+// present, while smoothing transport-only whitespace differences.
+func NormalizeForHash(content, contextHeader string) string {
+	content = normalizeHashText(content)
+	contextHeader = normalizeHashText(contextHeader)
+	if contextHeader == "" {
+		return content
+	}
+	if content == "" {
+		return contextHeader
+	}
+	return contextHeader + "\n\n" + content
+}
+
+func normalizeHashText(s string) string {
+	s = strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\r", "\n")
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+// ContentHash returns a 64-character SHA-256 hash for normalized chunk content.
+func ContentHash(content, contextHeader string) string {
+	normalized := NormalizeForHash(content, contextHeader)
+	if normalized == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(normalized))
+	return hex.EncodeToString(sum[:])
+}
+
+// StableChunkID derives a deterministic UUID-format chunk ID.
+func StableChunkID(tenantID uint64, knowledgeID string, chunkType ChunkType, contentHash string, occurrenceIndex int) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		stableChunkIDNamespace,
+		fmt.Sprintf("%d", tenantID),
+		knowledgeID,
+		string(chunkType),
+		contentHash,
+		fmt.Sprintf("%d", occurrenceIndex),
+	}, "\x00")))
+	return formatUUIDFromHash(sum)
+}
+
+func formatUUIDFromHash(sum [32]byte) string {
+	id := sum[:16]
+	id[6] = (id[6] & 0x0f) | 0x80
+	id[8] = (id[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", id[0:4], id[4:6], id[6:8], id[8:10], id[10:16])
+}
+
+// ChunkIDAllocator assigns stable IDs while disambiguating duplicate content
+// within one document by occurrence order.
+type ChunkIDAllocator struct {
+	tenantID    uint64
+	knowledgeID string
+	seen        map[string]int
+}
+
+func NewChunkIDAllocator(tenantID uint64, knowledgeID string) *ChunkIDAllocator {
+	return &ChunkIDAllocator{
+		tenantID:    tenantID,
+		knowledgeID: knowledgeID,
+		seen:        make(map[string]int),
+	}
+}
+
+// Allocate returns the stable chunk ID and content hash for a document chunk.
+func (a *ChunkIDAllocator) Allocate(chunkType ChunkType, content, contextHeader string) (string, string) {
+	if a == nil {
+		a = NewChunkIDAllocator(0, "")
+	}
+	contentHash := ContentHash(content, contextHeader)
+	key := string(chunkType) + "\x00" + contentHash
+	occurrenceIndex := a.seen[key]
+	a.seen[key] = occurrenceIndex + 1
+	return StableChunkID(a.tenantID, a.knowledgeID, chunkType, contentHash, occurrenceIndex), contentHash
+}

--- a/internal/types/chunk_id_test.go
+++ b/internal/types/chunk_id_test.go
@@ -1,0 +1,87 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeForHash(t *testing.T) {
+	assert.Equal(t, "hello\nworld", NormalizeForHash("  hello  \r\nworld\t \n", ""))
+	assert.Equal(t, "Heading\n\nhello", NormalizeForHash(" hello ", " Heading \r\n"))
+	assert.Equal(t, "Heading", NormalizeForHash("", " Heading \t"))
+	assert.Equal(t, "", NormalizeForHash(" \r\n\t ", ""))
+}
+
+func TestContentHash(t *testing.T) {
+	hash1 := ContentHash(" hello \r\nworld\t", "")
+	hash2 := ContentHash("hello\nworld", "")
+
+	require.Len(t, hash1, 64)
+	assert.Equal(t, hash1, hash2)
+	assert.Empty(t, ContentHash(" \n\t ", ""))
+	assert.NotEqual(t, ContentHash("hello", ""), ContentHash("hello", "section"))
+}
+
+func TestStableChunkID(t *testing.T) {
+	hash := ContentHash("hello", "")
+	id1 := StableChunkID(1, "knowledge-a", ChunkTypeText, hash, 0)
+	id2 := StableChunkID(1, "knowledge-a", ChunkTypeText, hash, 0)
+
+	assert.Equal(t, id1, id2)
+	assert.Len(t, id1, 36)
+	_, err := uuid.Parse(id1)
+	require.NoError(t, err)
+}
+
+func TestChunkIDAllocator_ReparseReproducible(t *testing.T) {
+	allocate := func() []string {
+		allocator := NewChunkIDAllocator(1, "knowledge-a")
+		out := make([]string, 0, 3)
+		for _, content := range []string{"hello", "hello", "world"} {
+			id, _ := allocator.Allocate(ChunkTypeText, content, "")
+			out = append(out, id)
+		}
+		return out
+	}
+
+	assert.Equal(t, allocate(), allocate())
+}
+
+func TestChunkIDAllocator_NormalizedContentKeepsSameIDAcrossReparse(t *testing.T) {
+	allocator1 := NewChunkIDAllocator(1, "knowledge-a")
+	id1, hash1 := allocator1.Allocate(ChunkTypeText, " hello  \r\nworld\t ", " # Title \r\n")
+
+	allocator2 := NewChunkIDAllocator(1, "knowledge-a")
+	id2, hash2 := allocator2.Allocate(ChunkTypeText, "hello\nworld", "# Title")
+
+	assert.Equal(t, hash1, hash2)
+	assert.Equal(t, id1, id2)
+}
+
+func TestChunkIDAllocator_DuplicateContentUsesOccurrence(t *testing.T) {
+	allocator := NewChunkIDAllocator(1, "knowledge-a")
+
+	id1, hash1 := allocator.Allocate(ChunkTypeText, "same", "")
+	id2, hash2 := allocator.Allocate(ChunkTypeText, " same \n", "")
+
+	assert.Equal(t, hash1, hash2)
+	assert.NotEqual(t, id1, id2)
+	assert.Equal(t, StableChunkID(1, "knowledge-a", ChunkTypeText, hash1, 0), id1)
+	assert.Equal(t, StableChunkID(1, "knowledge-a", ChunkTypeText, hash1, 1), id2)
+}
+
+func TestChunkIDAllocator_IsolatedByKnowledgeAndType(t *testing.T) {
+	hash := ContentHash("same", "")
+
+	assert.NotEqual(t,
+		StableChunkID(1, "knowledge-a", ChunkTypeText, hash, 0),
+		StableChunkID(1, "knowledge-b", ChunkTypeText, hash, 0),
+	)
+	assert.NotEqual(t,
+		StableChunkID(1, "knowledge-a", ChunkTypeText, hash, 0),
+		StableChunkID(1, "knowledge-a", ChunkTypeParentText, hash, 0),
+	)
+}

--- a/internal/types/interfaces/chunk.go
+++ b/internal/types/interfaces/chunk.go
@@ -64,6 +64,8 @@ type ChunkRepository interface {
 	DeleteChunks(ctx context.Context, tenantID uint64, ids []string) error
 	// DeleteChunksByKnowledgeID deletes chunks by knowledge id
 	DeleteChunksByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) error
+	// PurgeSoftDeletedByKnowledgeID permanently removes already soft-deleted chunks by knowledge id.
+	PurgeSoftDeletedByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) error
 	// DeleteByKnowledgeList deletes all chunks for a knowledge list
 	DeleteByKnowledgeList(ctx context.Context, tenantID uint64, knowledgeIDs []string) error
 	// ListImageInfoByKnowledgeIDs returns non-empty (knowledge_id, image_info) pairs for image cleanup.


### PR DESCRIPTION
What & Why
This PR implements step 1 of #1679: content-addressed stable chunk IDs.
Currently, every reparse deletes and recreates chunks with new random UUIDs. This causes 100% cache misses for embeddings, VLM results, Wiki maps, etc., even when content is unchanged.
This PR introduces deterministic, content-based chunk IDs for document-derived parent/text chunks, while keeping FAQ, manual, and clone chunks on existing UUID behavior. It also adds ContentHash and soft-delete purge handling to prevent PK conflicts.
This change is a pure foundation — it does not alter the current "delete all then recreate" reparse semantics.
Changes

New pure helpers in internal/types/: NormalizeForHash, ContentHash, StableChunkID, ChunkIDAllocator
Replace uuid.New() only for parser-generated chunks
Populate content_hash field
Add PurgeSoftDeletedByKnowledgeID to repository
Unit tests + SQLite regression test for soft-delete case

Testing

go test ./internal/types -run TestChunkID
go test ./internal/application/repository -run TestChunk
Manual reparse stability verification

Follow-up
Next PRs will build cache layers (VLM, Embedding, Wiki Map, etc.) on top of these stable IDs.