### PR TITLE
feat(reparse): cache embedding results by content hash (#1679 - step 2)

### DIFF
--- a/internal/application/repository/content_cache.go
+++ b/internal/application/repository/content_cache.go
@@ -1,0 +1,52 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type contentCacheRepository struct {
+	db *gorm.DB
+}
+
+func NewContentCacheRepository(db *gorm.DB) interfaces.ContentCacheRepository {
+	return &contentCacheRepository{db: db}
+}
+
+func (r *contentCacheRepository) GetByKey(
+	ctx context.Context,
+	tenantID uint64,
+	cacheKind, cacheKey string,
+) (*types.ContentCacheEntry, error) {
+	var entry types.ContentCacheEntry
+	if err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND cache_kind = ? AND cache_key = ?", tenantID, cacheKind, cacheKey).
+		First(&entry).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &entry, nil
+}
+
+func (r *contentCacheRepository) Upsert(ctx context.Context, entry *types.ContentCacheEntry) error {
+	if entry == nil {
+		return nil
+	}
+	entry.UpdatedAt = time.Now()
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "tenant_id"},
+			{Name: "cache_kind"},
+			{Name: "cache_key"},
+		},
+		DoUpdates: clause.AssignmentColumns([]string{"payload", "updated_at"}),
+	}).Create(entry).Error
+}

--- a/internal/application/repository/content_cache_sqlite_test.go
+++ b/internal/application/repository/content_cache_sqlite_test.go
@@ -1,0 +1,87 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupContentCacheTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.ContentCacheEntry{}))
+	return db
+}
+
+func TestContentCacheRepository_SQLite_Miss(t *testing.T) {
+	repo := NewContentCacheRepository(setupContentCacheTestDB(t))
+
+	got, err := repo.GetByKey(context.Background(), 1, types.ContentCacheKindEmbedding, "missing")
+
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestContentCacheRepository_SQLite_UpsertGetAndOverwrite(t *testing.T) {
+	repo := NewContentCacheRepository(setupContentCacheTestDB(t))
+	ctx := context.Background()
+
+	entry := &types.ContentCacheEntry{
+		TenantID:  1,
+		CacheKind: types.ContentCacheKindEmbedding,
+		CacheKey:  "embedding:key",
+		Payload:   types.JSON(`{"value":1}`),
+	}
+	require.NoError(t, repo.Upsert(ctx, entry))
+
+	got, err := repo.GetByKey(ctx, 1, types.ContentCacheKindEmbedding, "embedding:key")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, `{"value":1}`, got.Payload.ToString())
+
+	require.NoError(t, repo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  1,
+		CacheKind: types.ContentCacheKindEmbedding,
+		CacheKey:  "embedding:key",
+		Payload:   types.JSON(`{"value":2}`),
+	}))
+
+	got, err = repo.GetByKey(ctx, 1, types.ContentCacheKindEmbedding, "embedding:key")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, `{"value":2}`, got.Payload.ToString())
+}
+
+func TestContentCacheRepository_SQLite_TenantIsolation(t *testing.T) {
+	repo := NewContentCacheRepository(setupContentCacheTestDB(t))
+	ctx := context.Background()
+
+	require.NoError(t, repo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  1,
+		CacheKind: types.ContentCacheKindEmbedding,
+		CacheKey:  "same",
+		Payload:   types.JSON(`[1]`),
+	}))
+	require.NoError(t, repo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  2,
+		CacheKind: types.ContentCacheKindEmbedding,
+		CacheKey:  "same",
+		Payload:   types.JSON(`[2]`),
+	}))
+
+	got1, err := repo.GetByKey(ctx, 1, types.ContentCacheKindEmbedding, "same")
+	require.NoError(t, err)
+	require.NotNil(t, got1)
+	assert.Equal(t, `[1]`, got1.Payload.ToString())
+
+	got2, err := repo.GetByKey(ctx, 2, types.ContentCacheKindEmbedding, "same")
+	require.NoError(t, err)
+	require.NotNil(t, got2)
+	assert.Equal(t, `[2]`, got2.Payload.ToString())
+}

--- a/internal/application/service/embedding_cache.go
+++ b/internal/application/service/embedding_cache.go
@@ -1,0 +1,173 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type embeddingCacheWrapper struct {
+	inner    embedding.Embedder
+	repo     interfaces.ContentCacheRepository
+	tenantID uint64
+}
+
+func withEmbeddingCache(
+	inner embedding.Embedder,
+	repo interfaces.ContentCacheRepository,
+	tenantID uint64,
+) embedding.Embedder {
+	if inner == nil || repo == nil {
+		return inner
+	}
+	return &embeddingCacheWrapper{inner: inner, repo: repo, tenantID: tenantID}
+}
+
+func (w *embeddingCacheWrapper) Embed(ctx context.Context, text string) ([]float32, error) {
+	embeddings, err := w.BatchEmbed(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(embeddings) == 0 {
+		return nil, nil
+	}
+	return embeddings[0], nil
+}
+
+func (w *embeddingCacheWrapper) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	return w.batchEmbed(ctx, texts, func(missTexts []string) ([][]float32, error) {
+		return w.inner.BatchEmbed(ctx, missTexts)
+	})
+}
+
+func (w *embeddingCacheWrapper) BatchEmbedWithPool(
+	ctx context.Context,
+	_ embedding.Embedder,
+	texts []string,
+) ([][]float32, error) {
+	return w.batchEmbed(ctx, texts, func(missTexts []string) ([][]float32, error) {
+		return w.inner.BatchEmbedWithPool(ctx, w, missTexts)
+	})
+}
+
+func (w *embeddingCacheWrapper) batchEmbed(
+	ctx context.Context,
+	texts []string,
+	embedMisses func([]string) ([][]float32, error),
+) ([][]float32, error) {
+	if w == nil || w.inner == nil {
+		return nil, fmt.Errorf("embedding cache wrapper is not initialized")
+	}
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	if w.repo == nil {
+		return embedMisses(texts)
+	}
+
+	out := make([][]float32, len(texts))
+	type pending struct {
+		key     string
+		text    string
+		indexes []int
+	}
+	pendingByKey := make(map[string]*pending, len(texts))
+	pendingOrder := make([]*pending, 0, len(texts))
+
+	for i, text := range texts {
+		key := embeddingCacheKey(w.inner, text)
+		var cached []float32
+		hit, err := w.get(ctx, key, &cached)
+		if err != nil {
+			logger.Warnf(ctx, "embedding cache get failed: %v", err)
+		}
+		if hit {
+			out[i] = cached
+			continue
+		}
+		item := pendingByKey[key]
+		if item == nil {
+			item = &pending{key: key, text: text}
+			pendingByKey[key] = item
+			pendingOrder = append(pendingOrder, item)
+		}
+		item.indexes = append(item.indexes, i)
+	}
+
+	if len(pendingOrder) == 0 {
+		return out, nil
+	}
+
+	missTexts := make([]string, len(pendingOrder))
+	for i, item := range pendingOrder {
+		missTexts[i] = item.text
+	}
+	missVectors, err := embedMisses(missTexts)
+	if err != nil {
+		return nil, err
+	}
+	if len(missVectors) != len(missTexts) {
+		return nil, fmt.Errorf("embedding cache wrapper: got %d embeddings for %d inputs", len(missVectors), len(missTexts))
+	}
+
+	for i, item := range pendingOrder {
+		vector := missVectors[i]
+		for _, originalIndex := range item.indexes {
+			out[originalIndex] = vector
+		}
+		if err := w.set(ctx, item.key, vector); err != nil {
+			logger.Warnf(ctx, "embedding cache upsert failed: %v", err)
+		}
+	}
+	return out, nil
+}
+
+func (w *embeddingCacheWrapper) GetModelName() string {
+	return w.inner.GetModelName()
+}
+
+func (w *embeddingCacheWrapper) GetDimensions() int {
+	return w.inner.GetDimensions()
+}
+
+func (w *embeddingCacheWrapper) GetModelID() string {
+	return w.inner.GetModelID()
+}
+
+func (w *embeddingCacheWrapper) get(ctx context.Context, key string, out any) (bool, error) {
+	entry, err := w.repo.GetByKey(ctx, w.tenantID, types.ContentCacheKindEmbedding, key)
+	if err != nil || entry == nil {
+		return false, err
+	}
+	if err := json.Unmarshal(entry.Payload, out); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (w *embeddingCacheWrapper) set(ctx context.Context, key string, vector []float32) error {
+	payload, err := json.Marshal(vector)
+	if err != nil {
+		return err
+	}
+	return w.repo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  w.tenantID,
+		CacheKind: types.ContentCacheKindEmbedding,
+		CacheKey:  key,
+		Payload:   types.JSON(payload),
+	})
+}
+
+func embeddingCacheKey(embedder embedding.Embedder, text string) string {
+	modelID := strings.TrimSpace(embedder.GetModelID())
+	if modelID == "" {
+		modelID = strings.TrimSpace(embedder.GetModelName())
+	}
+	return fmt.Sprintf("embedding:%s:%s:%d", types.ContentHash(text, ""), modelID, embedder.GetDimensions())
+}

--- a/internal/application/service/embedding_cache_test.go
+++ b/internal/application/service/embedding_cache_test.go
@@ -1,0 +1,162 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeContentCacheRepo struct {
+	mu        sync.Mutex
+	entries   map[string]*types.ContentCacheEntry
+	getErr    error
+	upsertErr error
+}
+
+func newFakeContentCacheRepo() *fakeContentCacheRepo {
+	return &fakeContentCacheRepo{entries: make(map[string]*types.ContentCacheEntry)}
+}
+
+func (r *fakeContentCacheRepo) GetByKey(
+	_ context.Context,
+	tenantID uint64,
+	cacheKind, cacheKey string,
+) (*types.ContentCacheEntry, error) {
+	if r.getErr != nil {
+		return nil, r.getErr
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry := r.entries[cacheEntryKey(tenantID, cacheKind, cacheKey)]
+	if entry == nil {
+		return nil, nil
+	}
+	copied := *entry
+	return &copied, nil
+}
+
+func (r *fakeContentCacheRepo) Upsert(_ context.Context, entry *types.ContentCacheEntry) error {
+	if r.upsertErr != nil {
+		return r.upsertErr
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	copied := *entry
+	r.entries[cacheEntryKey(entry.TenantID, entry.CacheKind, entry.CacheKey)] = &copied
+	return nil
+}
+
+func cacheEntryKey(tenantID uint64, cacheKind, cacheKey string) string {
+	return fmt.Sprintf("%d\x00%s\x00%s", tenantID, cacheKind, cacheKey)
+}
+
+type fakeEmbeddingModel struct {
+	modelID    string
+	modelName  string
+	dimensions int
+	calls      [][]string
+}
+
+func (m *fakeEmbeddingModel) Embed(ctx context.Context, text string) ([]float32, error) {
+	got, err := m.BatchEmbed(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	return got[0], nil
+}
+
+func (m *fakeEmbeddingModel) BatchEmbed(_ context.Context, texts []string) ([][]float32, error) {
+	m.calls = append(m.calls, append([]string(nil), texts...))
+	out := make([][]float32, len(texts))
+	for i, text := range texts {
+		out[i] = []float32{float32(len(text)), float32(m.dimensions)}
+	}
+	return out, nil
+}
+
+func (m *fakeEmbeddingModel) BatchEmbedWithPool(
+	ctx context.Context,
+	_ embedding.Embedder,
+	texts []string,
+) ([][]float32, error) {
+	return m.BatchEmbed(ctx, texts)
+}
+
+func (m *fakeEmbeddingModel) GetModelName() string {
+	return m.modelName
+}
+
+func (m *fakeEmbeddingModel) GetDimensions() int {
+	return m.dimensions
+}
+
+func (m *fakeEmbeddingModel) GetModelID() string {
+	return m.modelID
+}
+
+func TestEmbeddingCacheBatchDeduplicatesAndHitsSecondPass(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeContentCacheRepo()
+	inner := &fakeEmbeddingModel{modelID: "model-a", dimensions: 2}
+	cached := withEmbeddingCache(inner, repo, 1)
+
+	first, err := cached.BatchEmbed(ctx, []string{"same", "same", "other"})
+	require.NoError(t, err)
+	require.Len(t, first, 3)
+	require.Len(t, inner.calls, 1)
+	assert.Equal(t, []string{"same", "other"}, inner.calls[0])
+	assert.Equal(t, first[0], first[1])
+
+	second, err := cached.BatchEmbed(ctx, []string{"same", "same", "other"})
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	require.Len(t, inner.calls, 1, "second identical batch should be fully cached")
+}
+
+func TestEmbeddingCacheMissesOnTextModelAndDimensions(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeContentCacheRepo()
+
+	modelA := &fakeEmbeddingModel{modelID: "model-a", dimensions: 2}
+	cachedA := withEmbeddingCache(modelA, repo, 1)
+	_, err := cachedA.BatchEmbed(ctx, []string{"text"})
+	require.NoError(t, err)
+	_, err = cachedA.BatchEmbed(ctx, []string{"text"})
+	require.NoError(t, err)
+	require.Len(t, modelA.calls, 1)
+
+	_, err = cachedA.BatchEmbed(ctx, []string{"changed"})
+	require.NoError(t, err)
+	require.Len(t, modelA.calls, 2)
+
+	modelB := &fakeEmbeddingModel{modelID: "model-b", dimensions: 2}
+	_, err = withEmbeddingCache(modelB, repo, 1).BatchEmbed(ctx, []string{"text"})
+	require.NoError(t, err)
+	require.Len(t, modelB.calls, 1)
+
+	modelDim := &fakeEmbeddingModel{modelID: "model-a", dimensions: 3}
+	_, err = withEmbeddingCache(modelDim, repo, 1).BatchEmbed(ctx, []string{"text"})
+	require.NoError(t, err)
+	require.Len(t, modelDim.calls, 1)
+}
+
+func TestEmbeddingCacheFallsBackOnCacheErrors(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeContentCacheRepo()
+	repo.getErr = errors.New("cache read failed")
+	repo.upsertErr = errors.New("cache write failed")
+	inner := &fakeEmbeddingModel{modelID: "model-a", dimensions: 2}
+
+	got, err := withEmbeddingCache(inner, repo, 1).BatchEmbed(ctx, []string{"text"})
+
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Len(t, inner.calls, 1)
+}

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -66,6 +66,8 @@ type knowledgeService struct {
 	imageResolver   *docparser.ImageResolver
 	taskPendingRepo interfaces.TaskPendingOpsRepository
 
+	contentCacheRepo interfaces.ContentCacheRepository
+
 	// In-memory fallbacks for Lite mode (no Redis)
 	memFAQProgress      sync.Map // taskID -> *types.FAQImportProgress
 	memFAQRunningImport sync.Map // kbID -> *runningFAQImportInfo
@@ -96,6 +98,7 @@ func NewKnowledgeService(
 	tenantService interfaces.TenantService,
 	chunkService interfaces.ChunkService,
 	chunkRepo interfaces.ChunkRepository,
+	contentCacheRepo interfaces.ContentCacheRepository,
 	tagRepo interfaces.KnowledgeTagRepository,
 	tagService interfaces.KnowledgeTagService,
 	fileSvc interfaces.FileService,
@@ -144,6 +147,8 @@ func NewKnowledgeService(
 		taskPendingRepo: taskPendingRepo,
 		spanTracker:     spanTracker,
 		audit:           audit,
+
+		contentCacheRepo: contentCacheRepo,
 	}, nil
 }
 

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -283,6 +283,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks get embedding model failed")
 			return
 		}
+		embeddingModel = withEmbeddingCache(embeddingModel, s.contentCacheRepo, knowledge.TenantID)
 	} else {
 		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping embedding model", kb.ID)
 	}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -147,6 +147,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewKnowledgeRepository))
 	must(container.Provide(repository.NewKnowledgeSpanRepository))
 	must(container.Provide(repository.NewChunkRepository))
+	must(container.Provide(repository.NewContentCacheRepository))
 	must(container.Provide(repository.NewKnowledgeTagRepository))
 	must(container.Provide(repository.NewSessionRepository))
 	must(container.Provide(repository.NewMessageRepository))

--- a/internal/types/content_cache.go
+++ b/internal/types/content_cache.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const (
+	ContentCacheKindEmbedding = "embedding"
+)
+
+// ContentCacheEntry stores reusable deterministic processing artifacts.
+type ContentCacheEntry struct {
+	ID        string    `json:"id"         gorm:"type:varchar(36);primaryKey"`
+	TenantID  uint64    `json:"tenant_id"  gorm:"not null;uniqueIndex:idx_content_caches_key,priority:1"`
+	CacheKind string    `json:"cache_kind" gorm:"type:varchar(32);not null;uniqueIndex:idx_content_caches_key,priority:2"`
+	CacheKey  string    `json:"cache_key"  gorm:"type:varchar(255);not null;uniqueIndex:idx_content_caches_key,priority:3"`
+	Payload   JSON      `json:"payload"    gorm:"type:json;not null"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+func (ContentCacheEntry) TableName() string {
+	return "content_caches"
+}
+
+func (c *ContentCacheEntry) BeforeCreate(_ *gorm.DB) error {
+	if c.ID == "" {
+		c.ID = uuid.NewString()
+	}
+	return nil
+}

--- a/internal/types/interfaces/content_cache.go
+++ b/internal/types/interfaces/content_cache.go
@@ -1,0 +1,13 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// ContentCacheRepository persists deterministic content-processing caches.
+type ContentCacheRepository interface {
+	GetByKey(ctx context.Context, tenantID uint64, cacheKind, cacheKey string) (*types.ContentCacheEntry, error)
+	Upsert(ctx context.Context, entry *types.ContentCacheEntry) error
+}

--- a/migrations/sqlite/000002_content_caches.down.sql
+++ b/migrations/sqlite/000002_content_caches.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS content_caches;

--- a/migrations/sqlite/000002_content_caches.up.sql
+++ b/migrations/sqlite/000002_content_caches.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS content_caches (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id INTEGER NOT NULL,
+    cache_kind VARCHAR(32) NOT NULL,
+    cache_key VARCHAR(255) NOT NULL,
+    payload TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_content_caches_key
+    ON content_caches (tenant_id, cache_kind, cache_key);

--- a/migrations/versioned/000074_content_caches.down.sql
+++ b/migrations/versioned/000074_content_caches.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS content_caches;

--- a/migrations/versioned/000074_content_caches.up.sql
+++ b/migrations/versioned/000074_content_caches.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS content_caches (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id INTEGER NOT NULL,
+    cache_kind VARCHAR(32) NOT NULL,
+    cache_key VARCHAR(255) NOT NULL,
+    payload JSONB NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_content_caches_key
+    ON content_caches (tenant_id, cache_kind, cache_key);


### PR DESCRIPTION
## Description
This PR adds the first reusable artifact cache for #1679: a minimal DB-backed embedding cache.

After PR #2219 (stable chunk IDs), reparse still deletes and recreates vector indexes and calls the embedding model for every unchanged chunk. This PR introduces a `content_caches` table and wraps the embedding model so that identical `(tenant_id, normalized text, model, dimensions)` inputs can skip the embedding API on reparse.

**Scope is intentionally minimal:**
- Only adds the common cache table and repository needed by future steps
- Only caches embeddings (no VLM, Wiki, Graph, or parser artifact caching)
- Does not change reparse cleanup semantics or vector index deletion
- Does not add cache cleanup on knowledge / KB delete
- Does not update fresh-install init SQL (only versioned + sqlite migrations)

## Key Changes
- **content_caches table** with unique key `(tenant_id, cache_kind, cache_key)`
- **ContentCacheRepository** interface and implementation (`GetByKey`, `Upsert`)
- **Embedding cache wrapper** (`withEmbeddingCache`) that reuses PR1's `types.ContentHash`
- **Batch deduplication**: duplicate texts in one batch only call the real embedder once
- **Best-effort**: cache read/write errors are logged and treated as misses; indexing always succeeds
- **Wired only in `processChunks`** for the main document text chunk indexing path

## Type of Change
- [x] ✨ New feature
- [x] ⚡ Performance improvement

## Related Issue
Closes #1679 (step 2, depends on #2219)

## Testing
### Repository tests (SQLite)
- miss, upsert/get, overwrite, tenant isolation

### Embedding wrapper tests
- batch duplicate text calls real embedder once
- second identical batch is entirely served from cache
- changed text / model ID / dimensions trigger cache miss
- cache read/write errors do not fail `BatchEmbed`

### Verification commands
```bash
gofmt -l internal/...  # only touched Go files
go test ./internal/application/repository -run ContentCache
go test ./internal/application/service -run EmbeddingCache
git diff --check