### PR TITLE
feat(reparse): cache VLM OCR and caption results (#1679 — step 3)

### DIFF
--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -467,6 +467,14 @@ func (r *chunkRepository) DeleteChunksByKnowledgeID(ctx context.Context, tenantI
 	).Delete(&types.Chunk{}).Error
 }
 
+// PurgeSoftDeletedByKnowledgeID permanently removes chunks that were already
+// soft-deleted for the given knowledge ID. Live rows are intentionally excluded.
+func (r *chunkRepository) PurgeSoftDeletedByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) error {
+	return r.db.WithContext(ctx).Unscoped().
+		Where("tenant_id = ? AND knowledge_id = ? AND deleted_at IS NOT NULL", tenantID, knowledgeID).
+		Delete(&types.Chunk{}).Error
+}
+
 // ListImageInfoByKnowledgeIDs returns non-empty image_info values for the given knowledge IDs.
 // No chunk_type filter — collects from text, image_ocr, and image_caption chunks.
 func (r *chunkRepository) ListImageInfoByKnowledgeIDs(

--- a/internal/application/repository/chunk_sqlite_test.go
+++ b/internal/application/repository/chunk_sqlite_test.go
@@ -197,6 +197,59 @@ func TestCreateChunks_SQLite_SeqIDAfterSoftDelete(t *testing.T) {
 	assert.Equal(t, int64(5), saved[1].SeqID)
 }
 
+func TestPurgeSoftDeletedByKnowledgeID_SQLite_AllowsStableIDRecreate(t *testing.T) {
+	db := setupChunkTestDB(t)
+	repo := NewChunkRepository(db)
+	ctx := context.Background()
+
+	kbID := uuid.New().String()
+	knowledgeID := uuid.New().String()
+	liveKnowledgeID := uuid.New().String()
+	stableID := types.StableChunkID(1, knowledgeID, types.ChunkTypeText, types.ContentHash("stable content", ""), 0)
+
+	softDeleted := &types.Chunk{
+		ID:              stableID,
+		TenantID:        1,
+		KnowledgeBaseID: kbID,
+		KnowledgeID:     knowledgeID,
+		Content:         "stable content",
+		ContentHash:     types.ContentHash("stable content", ""),
+		ChunkType:       types.ChunkTypeText,
+		IsEnabled:       true,
+	}
+	liveSameKnowledge := makeChunk(kbID, knowledgeID, types.ChunkTypeText)
+	liveOtherKnowledge := makeChunk(kbID, liveKnowledgeID, types.ChunkTypeText)
+
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{softDeleted, liveSameKnowledge, liveOtherKnowledge}))
+	require.NoError(t, repo.DeleteChunk(ctx, 1, stableID))
+
+	require.NoError(t, repo.PurgeSoftDeletedByKnowledgeID(ctx, 1, knowledgeID))
+
+	var totalRows int64
+	require.NoError(t, db.Unscoped().Model(&types.Chunk{}).Count(&totalRows).Error)
+	assert.Equal(t, int64(2), totalRows, "only the already soft-deleted chunk should be purged")
+
+	var liveCount int64
+	require.NoError(t, db.Model(&types.Chunk{}).Where("knowledge_id IN ?", []string{knowledgeID, liveKnowledgeID}).Count(&liveCount).Error)
+	assert.Equal(t, int64(2), liveCount, "live chunks must not be purged")
+
+	recreated := &types.Chunk{
+		ID:              stableID,
+		TenantID:        1,
+		KnowledgeBaseID: kbID,
+		KnowledgeID:     knowledgeID,
+		Content:         "stable content",
+		ContentHash:     types.ContentHash("stable content", ""),
+		ChunkType:       types.ChunkTypeText,
+		IsEnabled:       true,
+	}
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{recreated}))
+
+	var active types.Chunk
+	require.NoError(t, db.First(&active, "id = ?", stableID).Error)
+	assert.Equal(t, "stable content", active.Content)
+}
+
 func TestUpdateChunk_SQLite_NoNOWError(t *testing.T) {
 	db := setupChunkTestDB(t)
 	ctx := context.Background()

--- a/internal/application/repository/content_cache.go
+++ b/internal/application/repository/content_cache.go
@@ -1,0 +1,52 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type contentCacheRepository struct {
+	db *gorm.DB
+}
+
+func NewContentCacheRepository(db *gorm.DB) interfaces.ContentCacheRepository {
+	return &contentCacheRepository{db: db}
+}
+
+func (r *contentCacheRepository) GetByKey(
+	ctx context.Context,
+	tenantID uint64,
+	cacheKind, cacheKey string,
+) (*types.ContentCacheEntry, error) {
+	var entry types.ContentCacheEntry
+	if err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND cache_kind = ? AND cache_key = ?", tenantID, cacheKind, cacheKey).
+		First(&entry).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &entry, nil
+}
+
+func (r *contentCacheRepository) Upsert(ctx context.Context, entry *types.ContentCacheEntry) error {
+	if entry == nil {
+		return nil
+	}
+	entry.UpdatedAt = time.Now()
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "tenant_id"},
+			{Name: "cache_kind"},
+			{Name: "cache_key"},
+		},
+		DoUpdates: clause.AssignmentColumns([]string{"payload", "updated_at"}),
+	}).Create(entry).Error
+}

--- a/internal/application/repository/content_cache_sqlite_test.go
+++ b/internal/application/repository/content_cache_sqlite_test.go
@@ -1,0 +1,87 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupContentCacheTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.ContentCacheEntry{}))
+	return db
+}
+
+func TestContentCacheRepository_SQLite_Miss(t *testing.T) {
+	repo := NewContentCacheRepository(setupContentCacheTestDB(t))
+
+	got, err := repo.GetByKey(context.Background(), 1, types.ContentCacheKindEmbedding, "missing")
+
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestContentCacheRepository_SQLite_UpsertGetAndOverwrite(t *testing.T) {
+	repo := NewContentCacheRepository(setupContentCacheTestDB(t))
+	ctx := context.Background()
+
+	entry := &types.ContentCacheEntry{
+		TenantID:  1,
+		CacheKind: types.ContentCacheKindEmbedding,
+		CacheKey:  "embedding:key",
+		Payload:   types.JSON(`{"value":1}`),
+	}
+	require.NoError(t, repo.Upsert(ctx, entry))
+
+	got, err := repo.GetByKey(ctx, 1, types.ContentCacheKindEmbedding, "embedding:key")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, `{"value":1}`, got.Payload.ToString())
+
+	require.NoError(t, repo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  1,
+		CacheKind: types.ContentCacheKindEmbedding,
+		CacheKey:  "embedding:key",
+		Payload:   types.JSON(`{"value":2}`),
+	}))
+
+	got, err = repo.GetByKey(ctx, 1, types.ContentCacheKindEmbedding, "embedding:key")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, `{"value":2}`, got.Payload.ToString())
+}
+
+func TestContentCacheRepository_SQLite_TenantIsolation(t *testing.T) {
+	repo := NewContentCacheRepository(setupContentCacheTestDB(t))
+	ctx := context.Background()
+
+	require.NoError(t, repo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  1,
+		CacheKind: types.ContentCacheKindEmbedding,
+		CacheKey:  "same",
+		Payload:   types.JSON(`[1]`),
+	}))
+	require.NoError(t, repo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  2,
+		CacheKind: types.ContentCacheKindEmbedding,
+		CacheKey:  "same",
+		Payload:   types.JSON(`[2]`),
+	}))
+
+	got1, err := repo.GetByKey(ctx, 1, types.ContentCacheKindEmbedding, "same")
+	require.NoError(t, err)
+	require.NotNil(t, got1)
+	assert.Equal(t, `[1]`, got1.Payload.ToString())
+
+	got2, err := repo.GetByKey(ctx, 2, types.ContentCacheKindEmbedding, "same")
+	require.NoError(t, err)
+	require.NotNil(t, got2)
+	assert.Equal(t, `[2]`, got2.Payload.ToString())
+}

--- a/internal/application/service/embedding_cache.go
+++ b/internal/application/service/embedding_cache.go
@@ -1,0 +1,173 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type embeddingCacheWrapper struct {
+	inner    embedding.Embedder
+	repo     interfaces.ContentCacheRepository
+	tenantID uint64
+}
+
+func withEmbeddingCache(
+	inner embedding.Embedder,
+	repo interfaces.ContentCacheRepository,
+	tenantID uint64,
+) embedding.Embedder {
+	if inner == nil || repo == nil {
+		return inner
+	}
+	return &embeddingCacheWrapper{inner: inner, repo: repo, tenantID: tenantID}
+}
+
+func (w *embeddingCacheWrapper) Embed(ctx context.Context, text string) ([]float32, error) {
+	embeddings, err := w.BatchEmbed(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(embeddings) == 0 {
+		return nil, nil
+	}
+	return embeddings[0], nil
+}
+
+func (w *embeddingCacheWrapper) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	return w.batchEmbed(ctx, texts, func(missTexts []string) ([][]float32, error) {
+		return w.inner.BatchEmbed(ctx, missTexts)
+	})
+}
+
+func (w *embeddingCacheWrapper) BatchEmbedWithPool(
+	ctx context.Context,
+	_ embedding.Embedder,
+	texts []string,
+) ([][]float32, error) {
+	return w.batchEmbed(ctx, texts, func(missTexts []string) ([][]float32, error) {
+		return w.inner.BatchEmbedWithPool(ctx, w, missTexts)
+	})
+}
+
+func (w *embeddingCacheWrapper) batchEmbed(
+	ctx context.Context,
+	texts []string,
+	embedMisses func([]string) ([][]float32, error),
+) ([][]float32, error) {
+	if w == nil || w.inner == nil {
+		return nil, fmt.Errorf("embedding cache wrapper is not initialized")
+	}
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	if w.repo == nil {
+		return embedMisses(texts)
+	}
+
+	out := make([][]float32, len(texts))
+	type pending struct {
+		key     string
+		text    string
+		indexes []int
+	}
+	pendingByKey := make(map[string]*pending, len(texts))
+	pendingOrder := make([]*pending, 0, len(texts))
+
+	for i, text := range texts {
+		key := embeddingCacheKey(w.inner, text)
+		var cached []float32
+		hit, err := w.get(ctx, key, &cached)
+		if err != nil {
+			logger.Warnf(ctx, "embedding cache get failed: %v", err)
+		}
+		if hit {
+			out[i] = cached
+			continue
+		}
+		item := pendingByKey[key]
+		if item == nil {
+			item = &pending{key: key, text: text}
+			pendingByKey[key] = item
+			pendingOrder = append(pendingOrder, item)
+		}
+		item.indexes = append(item.indexes, i)
+	}
+
+	if len(pendingOrder) == 0 {
+		return out, nil
+	}
+
+	missTexts := make([]string, len(pendingOrder))
+	for i, item := range pendingOrder {
+		missTexts[i] = item.text
+	}
+	missVectors, err := embedMisses(missTexts)
+	if err != nil {
+		return nil, err
+	}
+	if len(missVectors) != len(missTexts) {
+		return nil, fmt.Errorf("embedding cache wrapper: got %d embeddings for %d inputs", len(missVectors), len(missTexts))
+	}
+
+	for i, item := range pendingOrder {
+		vector := missVectors[i]
+		for _, originalIndex := range item.indexes {
+			out[originalIndex] = vector
+		}
+		if err := w.set(ctx, item.key, vector); err != nil {
+			logger.Warnf(ctx, "embedding cache upsert failed: %v", err)
+		}
+	}
+	return out, nil
+}
+
+func (w *embeddingCacheWrapper) GetModelName() string {
+	return w.inner.GetModelName()
+}
+
+func (w *embeddingCacheWrapper) GetDimensions() int {
+	return w.inner.GetDimensions()
+}
+
+func (w *embeddingCacheWrapper) GetModelID() string {
+	return w.inner.GetModelID()
+}
+
+func (w *embeddingCacheWrapper) get(ctx context.Context, key string, out any) (bool, error) {
+	entry, err := w.repo.GetByKey(ctx, w.tenantID, types.ContentCacheKindEmbedding, key)
+	if err != nil || entry == nil {
+		return false, err
+	}
+	if err := json.Unmarshal(entry.Payload, out); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (w *embeddingCacheWrapper) set(ctx context.Context, key string, vector []float32) error {
+	payload, err := json.Marshal(vector)
+	if err != nil {
+		return err
+	}
+	return w.repo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  w.tenantID,
+		CacheKind: types.ContentCacheKindEmbedding,
+		CacheKey:  key,
+		Payload:   types.JSON(payload),
+	})
+}
+
+func embeddingCacheKey(embedder embedding.Embedder, text string) string {
+	modelID := strings.TrimSpace(embedder.GetModelID())
+	if modelID == "" {
+		modelID = strings.TrimSpace(embedder.GetModelName())
+	}
+	return fmt.Sprintf("embedding:%s:%s:%d", types.ContentHash(text, ""), modelID, embedder.GetDimensions())
+}

--- a/internal/application/service/embedding_cache_test.go
+++ b/internal/application/service/embedding_cache_test.go
@@ -1,0 +1,162 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeContentCacheRepo struct {
+	mu        sync.Mutex
+	entries   map[string]*types.ContentCacheEntry
+	getErr    error
+	upsertErr error
+}
+
+func newFakeContentCacheRepo() *fakeContentCacheRepo {
+	return &fakeContentCacheRepo{entries: make(map[string]*types.ContentCacheEntry)}
+}
+
+func (r *fakeContentCacheRepo) GetByKey(
+	_ context.Context,
+	tenantID uint64,
+	cacheKind, cacheKey string,
+) (*types.ContentCacheEntry, error) {
+	if r.getErr != nil {
+		return nil, r.getErr
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry := r.entries[cacheEntryKey(tenantID, cacheKind, cacheKey)]
+	if entry == nil {
+		return nil, nil
+	}
+	copied := *entry
+	return &copied, nil
+}
+
+func (r *fakeContentCacheRepo) Upsert(_ context.Context, entry *types.ContentCacheEntry) error {
+	if r.upsertErr != nil {
+		return r.upsertErr
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	copied := *entry
+	r.entries[cacheEntryKey(entry.TenantID, entry.CacheKind, entry.CacheKey)] = &copied
+	return nil
+}
+
+func cacheEntryKey(tenantID uint64, cacheKind, cacheKey string) string {
+	return fmt.Sprintf("%d\x00%s\x00%s", tenantID, cacheKind, cacheKey)
+}
+
+type fakeEmbeddingModel struct {
+	modelID    string
+	modelName  string
+	dimensions int
+	calls      [][]string
+}
+
+func (m *fakeEmbeddingModel) Embed(ctx context.Context, text string) ([]float32, error) {
+	got, err := m.BatchEmbed(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	return got[0], nil
+}
+
+func (m *fakeEmbeddingModel) BatchEmbed(_ context.Context, texts []string) ([][]float32, error) {
+	m.calls = append(m.calls, append([]string(nil), texts...))
+	out := make([][]float32, len(texts))
+	for i, text := range texts {
+		out[i] = []float32{float32(len(text)), float32(m.dimensions)}
+	}
+	return out, nil
+}
+
+func (m *fakeEmbeddingModel) BatchEmbedWithPool(
+	ctx context.Context,
+	_ embedding.Embedder,
+	texts []string,
+) ([][]float32, error) {
+	return m.BatchEmbed(ctx, texts)
+}
+
+func (m *fakeEmbeddingModel) GetModelName() string {
+	return m.modelName
+}
+
+func (m *fakeEmbeddingModel) GetDimensions() int {
+	return m.dimensions
+}
+
+func (m *fakeEmbeddingModel) GetModelID() string {
+	return m.modelID
+}
+
+func TestEmbeddingCacheBatchDeduplicatesAndHitsSecondPass(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeContentCacheRepo()
+	inner := &fakeEmbeddingModel{modelID: "model-a", dimensions: 2}
+	cached := withEmbeddingCache(inner, repo, 1)
+
+	first, err := cached.BatchEmbed(ctx, []string{"same", "same", "other"})
+	require.NoError(t, err)
+	require.Len(t, first, 3)
+	require.Len(t, inner.calls, 1)
+	assert.Equal(t, []string{"same", "other"}, inner.calls[0])
+	assert.Equal(t, first[0], first[1])
+
+	second, err := cached.BatchEmbed(ctx, []string{"same", "same", "other"})
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	require.Len(t, inner.calls, 1, "second identical batch should be fully cached")
+}
+
+func TestEmbeddingCacheMissesOnTextModelAndDimensions(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeContentCacheRepo()
+
+	modelA := &fakeEmbeddingModel{modelID: "model-a", dimensions: 2}
+	cachedA := withEmbeddingCache(modelA, repo, 1)
+	_, err := cachedA.BatchEmbed(ctx, []string{"text"})
+	require.NoError(t, err)
+	_, err = cachedA.BatchEmbed(ctx, []string{"text"})
+	require.NoError(t, err)
+	require.Len(t, modelA.calls, 1)
+
+	_, err = cachedA.BatchEmbed(ctx, []string{"changed"})
+	require.NoError(t, err)
+	require.Len(t, modelA.calls, 2)
+
+	modelB := &fakeEmbeddingModel{modelID: "model-b", dimensions: 2}
+	_, err = withEmbeddingCache(modelB, repo, 1).BatchEmbed(ctx, []string{"text"})
+	require.NoError(t, err)
+	require.Len(t, modelB.calls, 1)
+
+	modelDim := &fakeEmbeddingModel{modelID: "model-a", dimensions: 3}
+	_, err = withEmbeddingCache(modelDim, repo, 1).BatchEmbed(ctx, []string{"text"})
+	require.NoError(t, err)
+	require.Len(t, modelDim.calls, 1)
+}
+
+func TestEmbeddingCacheFallsBackOnCacheErrors(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeContentCacheRepo()
+	repo.getErr = errors.New("cache read failed")
+	repo.upsertErr = errors.New("cache write failed")
+	inner := &fakeEmbeddingModel{modelID: "model-a", dimensions: 2}
+
+	got, err := withEmbeddingCache(inner, repo, 1).BatchEmbed(ctx, []string{"text"})
+
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Len(t, inner.calls, 1)
+}

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,7 +21,6 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
-	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
 	"github.com/redis/go-redis/v9"
 )
@@ -48,6 +49,8 @@ const (
 		"5. Output ONLY the extracted text content. Do NOT include any HTML tags, reasoning, or unrelated comments.\n" +
 		"6. If there is absolutely no recognizable text content in the image, reply ONLY with: No text content.\n" +
 		"</instructions>"
+	vlmCacheModeOCR     = "ocr"
+	vlmCacheModeCaption = "caption"
 )
 
 func buildVLMCaptionPrompt(ctx context.Context, cfg types.VLMConfig) string {
@@ -57,6 +60,31 @@ func buildVLMCaptionPrompt(ctx context.Context, cfg types.VLMConfig) string {
 	}
 	prompt := fmt.Sprintf("Provide a brief and concise description of the main content of the image in %s.", language)
 	return types.AppendCustomPromptInstructions(prompt, cfg.CustomInstructions, "image_description")
+}
+
+func resolvedVLMCacheModelID(cfg types.VLMConfig) string {
+	if id := strings.TrimSpace(cfg.ModelID); id != "" {
+		return id
+	}
+	return "legacy_inline"
+}
+
+func vlmCacheKey(imageBytes []byte, modelID, mode, prompt string) string {
+	return fmt.Sprintf("vlm:%s:%s:%s:%s",
+		sha256Hex(imageBytes),
+		strings.TrimSpace(modelID),
+		mode,
+		sha256StringHex(prompt),
+	)
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func sha256StringHex(s string) string {
+	return sha256Hex([]byte(s))
 }
 
 // ImageMultimodalService handles image:multimodal asynq tasks.
@@ -73,6 +101,8 @@ type ImageMultimodalService struct {
 	ollamaService  *ollama.OllamaService
 	taskEnqueuer   interfaces.TaskEnqueuer
 	redisClient    *redis.Client
+
+	contentCacheRepo interfaces.ContentCacheRepository
 	// fileSvc is the globally configured default FileService used as a fallback
 	// when the tenant-scoped storage config cannot produce a usable service
 	// (e.g. images were saved using the global MINIO_* env vars while the
@@ -101,26 +131,28 @@ func NewImageMultimodalService(
 	ollamaService *ollama.OllamaService,
 	taskEnqueuer interfaces.TaskEnqueuer,
 	redisClient *redis.Client,
+	contentCacheRepo interfaces.ContentCacheRepository,
 	fileSvc interfaces.FileService,
 	storageResolver interfaces.StorageBackendResolver,
 	resourceCatalog interfaces.ResourceCatalog,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
 	return &ImageMultimodalService{
-		chunkService:    chunkService,
-		modelService:    modelService,
-		kbService:       kbService,
-		knowledgeRepo:   knowledgeRepo,
-		tenantRepo:      tenantRepo,
-		retrieveEngine:  retrieveEngine,
-		ownership:       ownership,
-		ollamaService:   ollamaService,
-		taskEnqueuer:    taskEnqueuer,
-		redisClient:     redisClient,
-		fileSvc:         fileSvc,
-		storageResolver: storageResolver,
-		resourceCatalog: resourceCatalog,
-		spanTracker:     spanTracker,
+		chunkService:     chunkService,
+		modelService:     modelService,
+		kbService:        kbService,
+		knowledgeRepo:    knowledgeRepo,
+		tenantRepo:       tenantRepo,
+		retrieveEngine:   retrieveEngine,
+		ownership:        ownership,
+		ollamaService:    ollamaService,
+		taskEnqueuer:     taskEnqueuer,
+		redisClient:      redisClient,
+		contentCacheRepo: contentCacheRepo,
+		fileSvc:          fileSvc,
+		storageResolver:  storageResolver,
+		resourceCatalog:  resourceCatalog,
+		spanTracker:      spanTracker,
 	}
 }
 
@@ -131,6 +163,54 @@ func (s *ImageMultimodalService) tracker() SpanTracker {
 		return noopSpanTracker{}
 	}
 	return s.spanTracker
+}
+
+func (s *ImageMultimodalService) getOrComputeVLMResult(
+	ctx context.Context,
+	tenantID uint64,
+	cacheKind string,
+	mode string,
+	modelID string,
+	imageBytes []byte,
+	prompt string,
+	compute func() (string, error),
+) (string, bool, error) {
+	key := vlmCacheKey(imageBytes, modelID, mode, prompt)
+	if s.contentCacheRepo != nil {
+		entry, err := s.contentCacheRepo.GetByKey(ctx, tenantID, cacheKind, key)
+		if err != nil {
+			logger.Warnf(ctx, "[ImageMultimodal] VLM cache get failed kind=%s mode=%s: %v", cacheKind, mode, err)
+		} else if entry != nil {
+			var cached string
+			if err := json.Unmarshal(entry.Payload, &cached); err != nil {
+				logger.Warnf(ctx, "[ImageMultimodal] VLM cache decode failed kind=%s mode=%s: %v", cacheKind, mode, err)
+			} else {
+				return cached, true, nil
+			}
+		}
+	}
+
+	result, err := compute()
+	if err != nil {
+		return "", false, err
+	}
+	if s.contentCacheRepo == nil {
+		return result, false, nil
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		logger.Warnf(ctx, "[ImageMultimodal] VLM cache encode failed kind=%s mode=%s: %v", cacheKind, mode, err)
+		return result, false, nil
+	}
+	if err := s.contentCacheRepo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  tenantID,
+		CacheKind: cacheKind,
+		CacheKey:  key,
+		Payload:   types.JSON(payload),
+	}); err != nil {
+		logger.Warnf(ctx, "[ImageMultimodal] VLM cache upsert failed kind=%s mode=%s: %v", cacheKind, mode, err)
+	}
+	return result, false, nil
 }
 
 // Handle implements asynq handler for TypeImageMultimodal.
@@ -268,12 +348,27 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 		prompt = types.AppendCustomPromptInstructions(prompt, vlmCfg.CustomInstructions, "image_ocr")
 
-		ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt)
+		ocrText, cacheHit, ocrErr := s.getOrComputeVLMResult(
+			ctx,
+			payload.TenantID,
+			types.ContentCacheKindImageOCR,
+			vlmCacheModeOCR,
+			resolvedVLMCacheModelID(vlmCfg),
+			imgBytes,
+			prompt,
+			func() (string, error) {
+				text, err := vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt)
+				if err != nil {
+					return "", err
+				}
+				return sanitizeOCRText(text), nil
+			},
+		)
 		if ocrErr != nil {
 			logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
 			imgOut["ocr_error"] = ocrErr.Error()
 		} else {
-			ocrText = sanitizeOCRText(ocrText)
+			imgOut["ocr_cache_hit"] = cacheHit
 			if ocrText != "" {
 				imageInfo.OCRText = ocrText
 				imgOut["ocr_chars"] = len([]rune(ocrText))
@@ -286,14 +381,29 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 	}
 
-	caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, buildVLMCaptionPrompt(ctx, vlmCfg))
+	captionPrompt := buildVLMCaptionPrompt(ctx, vlmCfg)
+	caption, captionCacheHit, capErr := s.getOrComputeVLMResult(
+		ctx,
+		payload.TenantID,
+		types.ContentCacheKindImageCaption,
+		vlmCacheModeCaption,
+		resolvedVLMCacheModelID(vlmCfg),
+		imgBytes,
+		captionPrompt,
+		func() (string, error) {
+			return vlmModel.Predict(ctx, [][]byte{imgBytes}, captionPrompt)
+		},
+	)
 	if capErr != nil {
 		logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
 		imgOut["caption_error"] = capErr.Error()
-	} else if caption != "" {
-		imageInfo.Caption = caption
-		imgOut["caption_chars"] = len([]rune(caption))
-		imgOut["caption_preview"] = previewText(caption, 200)
+	} else {
+		imgOut["caption_cache_hit"] = captionCacheHit
+		if caption != "" {
+			imageInfo.Caption = caption
+			imgOut["caption_chars"] = len([]rune(caption))
+			imgOut["caption_preview"] = previewText(caption, 200)
+		}
 	}
 
 	// Build child chunks for OCR and caption results
@@ -302,7 +412,13 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 
 	if imageInfo.OCRText != "" {
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID: types.StableImageChildChunkID(
+				payload.TenantID,
+				payload.KnowledgeID,
+				payload.ChunkID,
+				types.ChunkTypeImageOCR,
+				imageInfo.OCRText,
+			),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
@@ -319,7 +435,13 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 
 	if imageInfo.Caption != "" {
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID: types.StableImageChildChunkID(
+				payload.TenantID,
+				payload.KnowledgeID,
+				payload.ChunkID,
+				types.ChunkTypeImageCaption,
+				imageInfo.Caption,
+			),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
@@ -342,6 +464,10 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 	}
 
 	// Persist chunks
+	if err := s.chunkService.GetRepository().PurgeSoftDeletedByKnowledgeID(ctx, payload.TenantID, payload.KnowledgeID); err != nil {
+		handleErr = fmt.Errorf("purge soft-deleted multimodal chunks: %w", err)
+		return handleErr
+	}
 	if err := s.chunkService.CreateChunks(ctx, newChunks); err != nil {
 		handleErr = fmt.Errorf("create multimodal chunks: %w", err)
 		return handleErr

--- a/internal/application/service/image_multimodal_cache_test.go
+++ b/internal/application/service/image_multimodal_cache_test.go
@@ -1,0 +1,151 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVLMCacheSecondPassSkipsCompute(t *testing.T) {
+	ctx := context.Background()
+	svc := &ImageMultimodalService{contentCacheRepo: newFakeContentCacheRepo()}
+	calls := 0
+	compute := func() (string, error) {
+		calls++
+		return "caption", nil
+	}
+
+	first, hit, err := svc.getOrComputeVLMResult(
+		ctx, 1, types.ContentCacheKindImageCaption, vlmCacheModeCaption, "vlm-a", []byte("image"), "prompt", compute,
+	)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, "caption", first)
+
+	second, hit, err := svc.getOrComputeVLMResult(
+		ctx, 1, types.ContentCacheKindImageCaption, vlmCacheModeCaption, "vlm-a", []byte("image"), "prompt", compute,
+	)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, "caption", second)
+	assert.Equal(t, 1, calls)
+}
+
+func TestVLMCacheOCRAndCaptionAreIndependent(t *testing.T) {
+	ctx := context.Background()
+	svc := &ImageMultimodalService{contentCacheRepo: newFakeContentCacheRepo()}
+	ocrCalls := 0
+	captionCalls := 0
+
+	_, _, err := svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-a", []byte("image"), "prompt", func() (string, error) {
+			ocrCalls++
+			return "ocr", nil
+		})
+	require.NoError(t, err)
+	_, _, err = svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageCaption, vlmCacheModeCaption,
+		"vlm-a", []byte("image"), "prompt", func() (string, error) {
+			captionCalls++
+			return "caption", nil
+		})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, ocrCalls)
+	assert.Equal(t, 1, captionCalls)
+}
+
+func TestVLMCacheInvalidatesOnImageModelAndPrompt(t *testing.T) {
+	ctx := context.Background()
+	svc := &ImageMultimodalService{contentCacheRepo: newFakeContentCacheRepo()}
+	calls := 0
+	compute := func() (string, error) {
+		calls++
+		return "ocr", nil
+	}
+
+	_, _, err := svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-a", []byte("image-a"), "prompt-a", compute)
+	require.NoError(t, err)
+	_, _, err = svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-a", []byte("image-b"), "prompt-a", compute)
+	require.NoError(t, err)
+	_, _, err = svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-b", []byte("image-a"), "prompt-a", compute)
+	require.NoError(t, err)
+	_, _, err = svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-a", []byte("image-a"), "prompt-b", compute)
+	require.NoError(t, err)
+
+	assert.Equal(t, 4, calls)
+}
+
+func TestVLMCacheDoesNotWriteErrors(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeContentCacheRepo()
+	svc := &ImageMultimodalService{contentCacheRepo: repo}
+	calls := 0
+
+	_, _, err := svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-a", []byte("image"), "prompt", func() (string, error) {
+			calls++
+			return "", errors.New("vlm failed")
+		})
+	require.Error(t, err)
+	assert.Empty(t, repo.entries)
+
+	got, hit, err := svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-a", []byte("image"), "prompt", func() (string, error) {
+			calls++
+			return "ocr", nil
+		})
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, "ocr", got)
+	assert.Equal(t, 2, calls)
+}
+
+func TestVLMCacheStoresEmptySuccess(t *testing.T) {
+	ctx := context.Background()
+	svc := &ImageMultimodalService{contentCacheRepo: newFakeContentCacheRepo()}
+	calls := 0
+	compute := func() (string, error) {
+		calls++
+		return "", nil
+	}
+
+	_, hit, err := svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageCaption, vlmCacheModeCaption,
+		"vlm-a", []byte("image"), "prompt", compute)
+	require.NoError(t, err)
+	assert.False(t, hit)
+
+	got, hit, err := svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageCaption, vlmCacheModeCaption,
+		"vlm-a", []byte("image"), "prompt", compute)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Empty(t, got)
+	assert.Equal(t, 1, calls)
+}
+
+func TestVLMCacheFallsBackOnCacheErrors(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeContentCacheRepo()
+	repo.getErr = errors.New("cache read failed")
+	repo.upsertErr = errors.New("cache write failed")
+	svc := &ImageMultimodalService{contentCacheRepo: repo}
+	calls := 0
+
+	got, hit, err := svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-a", []byte("image"), "prompt", func() (string, error) {
+			calls++
+			return "ocr", nil
+		})
+
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, "ocr", got)
+	assert.Equal(t, 1, calls)
+}

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -66,6 +66,8 @@ type knowledgeService struct {
 	imageResolver   *docparser.ImageResolver
 	taskPendingRepo interfaces.TaskPendingOpsRepository
 
+	contentCacheRepo interfaces.ContentCacheRepository
+
 	// In-memory fallbacks for Lite mode (no Redis)
 	memFAQProgress      sync.Map // taskID -> *types.FAQImportProgress
 	memFAQRunningImport sync.Map // kbID -> *runningFAQImportInfo
@@ -96,6 +98,7 @@ func NewKnowledgeService(
 	tenantService interfaces.TenantService,
 	chunkService interfaces.ChunkService,
 	chunkRepo interfaces.ChunkRepository,
+	contentCacheRepo interfaces.ContentCacheRepository,
 	tagRepo interfaces.KnowledgeTagRepository,
 	tagService interfaces.KnowledgeTagService,
 	fileSvc interfaces.FileService,
@@ -144,6 +147,8 @@ func NewKnowledgeService(
 		taskPendingRepo: taskPendingRepo,
 		spanTracker:     spanTracker,
 		audit:           audit,
+
+		contentCacheRepo: contentCacheRepo,
 	}, nil
 }
 

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -383,17 +383,20 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	}
 
 	// === Parent-Child Chunking: create parent chunks first ===
+	chunkIDAllocator := types.NewChunkIDAllocator(knowledge.TenantID, knowledge.ID)
 	hasParentChild := len(options.ParentChunks) > 0
 	var parentDBChunks []*types.Chunk // indexed by ParsedParentChunk position
 	if hasParentChild {
 		parentDBChunks = make([]*types.Chunk, len(options.ParentChunks))
 		for i, pc := range options.ParentChunks {
+			chunkID, contentHash := chunkIDAllocator.Allocate(types.ChunkTypeParentText, pc.Content, "")
 			parentDBChunks[i] = &types.Chunk{
-				ID:              uuid.New().String(),
+				ID:              chunkID,
 				TenantID:        knowledge.TenantID,
 				KnowledgeID:     knowledge.ID,
 				KnowledgeBaseID: knowledge.KnowledgeBaseID,
 				Content:         pc.Content,
+				ContentHash:     contentHash,
 				ChunkIndex:      pc.Seq,
 				IsEnabled:       true,
 				CreatedAt:       time.Now(),
@@ -427,13 +430,15 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		}
 
 		// 创建主文本Chunk
+		chunkID, contentHash := chunkIDAllocator.Allocate(types.ChunkTypeText, chunkData.Content, chunkData.ContextHeader)
 		textChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              chunkID,
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
 			Content:         chunkData.Content,
 			ContextHeader:   chunkData.ContextHeader,
+			ContentHash:     contentHash,
 			ChunkIndex:      int(chunkData.Seq),
 			IsEnabled:       true,
 			CreatedAt:       time.Now(),
@@ -494,6 +499,15 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	s.beginStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
 		"chunks_planned": len(insertChunks),
 	})
+	if err := s.chunkService.GetRepository().PurgeSoftDeletedByKnowledgeID(ctx, knowledge.TenantID, knowledge.ID); err != nil {
+		knowledge.ParseStatus = types.ParseStatusFailed
+		knowledge.ErrorMessage = err.Error()
+		knowledge.UpdatedAt = time.Now()
+		s.repo.UpdateKnowledge(ctx, knowledge)
+		s.failStage(ctx, knowledge.ID, types.StageChunking,
+			werrors.ErrCodeChunkingFailed, "purge soft-deleted chunks failed", err)
+		return
+	}
 	if err := s.chunkService.CreateChunks(ctx, insertChunks); err != nil {
 		knowledge.ParseStatus = types.ParseStatusFailed
 		knowledge.ErrorMessage = err.Error()

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -283,6 +283,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks get embedding model failed")
 			return
 		}
+		embeddingModel = withEmbeddingCache(embeddingModel, s.contentCacheRepo, knowledge.TenantID)
 	} else {
 		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping embedding model", kb.ID)
 	}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -147,6 +147,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewKnowledgeRepository))
 	must(container.Provide(repository.NewKnowledgeSpanRepository))
 	must(container.Provide(repository.NewChunkRepository))
+	must(container.Provide(repository.NewContentCacheRepository))
 	must(container.Provide(repository.NewKnowledgeTagRepository))
 	must(container.Provide(repository.NewSessionRepository))
 	must(container.Provide(repository.NewMessageRepository))

--- a/internal/types/chunk_id.go
+++ b/internal/types/chunk_id.go
@@ -1,0 +1,92 @@
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+const stableChunkIDNamespace = "0ed67a0f-6d4d-4c9a-99ac-4c880ee62e96"
+
+// NormalizeForHash returns the canonical text used for document chunk hashing.
+// It mirrors embedding input semantics by including the context header when
+// present, while smoothing transport-only whitespace differences.
+func NormalizeForHash(content, contextHeader string) string {
+	content = normalizeHashText(content)
+	contextHeader = normalizeHashText(contextHeader)
+	if contextHeader == "" {
+		return content
+	}
+	if content == "" {
+		return contextHeader
+	}
+	return contextHeader + "\n\n" + content
+}
+
+func normalizeHashText(s string) string {
+	s = strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\r", "\n")
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+// ContentHash returns a 64-character SHA-256 hash for normalized chunk content.
+func ContentHash(content, contextHeader string) string {
+	normalized := NormalizeForHash(content, contextHeader)
+	if normalized == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(normalized))
+	return hex.EncodeToString(sum[:])
+}
+
+// StableChunkID derives a deterministic UUID-format chunk ID.
+func StableChunkID(tenantID uint64, knowledgeID string, chunkType ChunkType, contentHash string, occurrenceIndex int) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		stableChunkIDNamespace,
+		fmt.Sprintf("%d", tenantID),
+		knowledgeID,
+		string(chunkType),
+		contentHash,
+		fmt.Sprintf("%d", occurrenceIndex),
+	}, "\x00")))
+	return formatUUIDFromHash(sum)
+}
+
+func formatUUIDFromHash(sum [32]byte) string {
+	id := sum[:16]
+	id[6] = (id[6] & 0x0f) | 0x80
+	id[8] = (id[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", id[0:4], id[4:6], id[6:8], id[8:10], id[10:16])
+}
+
+// ChunkIDAllocator assigns stable IDs while disambiguating duplicate content
+// within one document by occurrence order.
+type ChunkIDAllocator struct {
+	tenantID    uint64
+	knowledgeID string
+	seen        map[string]int
+}
+
+func NewChunkIDAllocator(tenantID uint64, knowledgeID string) *ChunkIDAllocator {
+	return &ChunkIDAllocator{
+		tenantID:    tenantID,
+		knowledgeID: knowledgeID,
+		seen:        make(map[string]int),
+	}
+}
+
+// Allocate returns the stable chunk ID and content hash for a document chunk.
+func (a *ChunkIDAllocator) Allocate(chunkType ChunkType, content, contextHeader string) (string, string) {
+	if a == nil {
+		a = NewChunkIDAllocator(0, "")
+	}
+	contentHash := ContentHash(content, contextHeader)
+	key := string(chunkType) + "\x00" + contentHash
+	occurrenceIndex := a.seen[key]
+	a.seen[key] = occurrenceIndex + 1
+	return StableChunkID(a.tenantID, a.knowledgeID, chunkType, contentHash, occurrenceIndex), contentHash
+}

--- a/internal/types/chunk_id.go
+++ b/internal/types/chunk_id.go
@@ -56,6 +56,26 @@ func StableChunkID(tenantID uint64, knowledgeID string, chunkType ChunkType, con
 	return formatUUIDFromHash(sum)
 }
 
+// StableImageChildChunkID derives a deterministic ID for image OCR/caption child chunks.
+func StableImageChildChunkID(
+	tenantID uint64,
+	knowledgeID string,
+	parentChunkID string,
+	chunkType ChunkType,
+	canonicalText string,
+) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		stableChunkIDNamespace,
+		"image_child",
+		fmt.Sprintf("%d", tenantID),
+		knowledgeID,
+		parentChunkID,
+		string(chunkType),
+		ContentHash(canonicalText, ""),
+	}, "\x00")))
+	return formatUUIDFromHash(sum)
+}
+
 func formatUUIDFromHash(sum [32]byte) string {
 	id := sum[:16]
 	id[6] = (id[6] & 0x0f) | 0x80

--- a/internal/types/chunk_id_test.go
+++ b/internal/types/chunk_id_test.go
@@ -1,0 +1,87 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeForHash(t *testing.T) {
+	assert.Equal(t, "hello\nworld", NormalizeForHash("  hello  \r\nworld\t \n", ""))
+	assert.Equal(t, "Heading\n\nhello", NormalizeForHash(" hello ", " Heading \r\n"))
+	assert.Equal(t, "Heading", NormalizeForHash("", " Heading \t"))
+	assert.Equal(t, "", NormalizeForHash(" \r\n\t ", ""))
+}
+
+func TestContentHash(t *testing.T) {
+	hash1 := ContentHash(" hello \r\nworld\t", "")
+	hash2 := ContentHash("hello\nworld", "")
+
+	require.Len(t, hash1, 64)
+	assert.Equal(t, hash1, hash2)
+	assert.Empty(t, ContentHash(" \n\t ", ""))
+	assert.NotEqual(t, ContentHash("hello", ""), ContentHash("hello", "section"))
+}
+
+func TestStableChunkID(t *testing.T) {
+	hash := ContentHash("hello", "")
+	id1 := StableChunkID(1, "knowledge-a", ChunkTypeText, hash, 0)
+	id2 := StableChunkID(1, "knowledge-a", ChunkTypeText, hash, 0)
+
+	assert.Equal(t, id1, id2)
+	assert.Len(t, id1, 36)
+	_, err := uuid.Parse(id1)
+	require.NoError(t, err)
+}
+
+func TestChunkIDAllocator_ReparseReproducible(t *testing.T) {
+	allocate := func() []string {
+		allocator := NewChunkIDAllocator(1, "knowledge-a")
+		out := make([]string, 0, 3)
+		for _, content := range []string{"hello", "hello", "world"} {
+			id, _ := allocator.Allocate(ChunkTypeText, content, "")
+			out = append(out, id)
+		}
+		return out
+	}
+
+	assert.Equal(t, allocate(), allocate())
+}
+
+func TestChunkIDAllocator_NormalizedContentKeepsSameIDAcrossReparse(t *testing.T) {
+	allocator1 := NewChunkIDAllocator(1, "knowledge-a")
+	id1, hash1 := allocator1.Allocate(ChunkTypeText, " hello  \r\nworld\t ", " # Title \r\n")
+
+	allocator2 := NewChunkIDAllocator(1, "knowledge-a")
+	id2, hash2 := allocator2.Allocate(ChunkTypeText, "hello\nworld", "# Title")
+
+	assert.Equal(t, hash1, hash2)
+	assert.Equal(t, id1, id2)
+}
+
+func TestChunkIDAllocator_DuplicateContentUsesOccurrence(t *testing.T) {
+	allocator := NewChunkIDAllocator(1, "knowledge-a")
+
+	id1, hash1 := allocator.Allocate(ChunkTypeText, "same", "")
+	id2, hash2 := allocator.Allocate(ChunkTypeText, " same \n", "")
+
+	assert.Equal(t, hash1, hash2)
+	assert.NotEqual(t, id1, id2)
+	assert.Equal(t, StableChunkID(1, "knowledge-a", ChunkTypeText, hash1, 0), id1)
+	assert.Equal(t, StableChunkID(1, "knowledge-a", ChunkTypeText, hash1, 1), id2)
+}
+
+func TestChunkIDAllocator_IsolatedByKnowledgeAndType(t *testing.T) {
+	hash := ContentHash("same", "")
+
+	assert.NotEqual(t,
+		StableChunkID(1, "knowledge-a", ChunkTypeText, hash, 0),
+		StableChunkID(1, "knowledge-b", ChunkTypeText, hash, 0),
+	)
+	assert.NotEqual(t,
+		StableChunkID(1, "knowledge-a", ChunkTypeText, hash, 0),
+		StableChunkID(1, "knowledge-a", ChunkTypeParentText, hash, 0),
+	)
+}

--- a/internal/types/chunk_id_test.go
+++ b/internal/types/chunk_id_test.go
@@ -85,3 +85,27 @@ func TestChunkIDAllocator_IsolatedByKnowledgeAndType(t *testing.T) {
 		StableChunkID(1, "knowledge-a", ChunkTypeParentText, hash, 0),
 	)
 }
+
+func TestStableImageChildChunkID(t *testing.T) {
+	id1 := StableImageChildChunkID(1, "knowledge-a", "parent-a", ChunkTypeImageOCR, "text")
+	id2 := StableImageChildChunkID(1, "knowledge-a", "parent-a", ChunkTypeImageOCR, " text ")
+
+	assert.Equal(t, id1, id2)
+	assert.Len(t, id1, 36)
+	_, err := uuid.Parse(id1)
+	require.NoError(t, err)
+}
+
+func TestStableImageChildChunkID_IsolatedByModeAndContent(t *testing.T) {
+	id := StableImageChildChunkID(1, "knowledge-a", "parent-a", ChunkTypeImageOCR, "same")
+
+	assert.NotEqual(t, id,
+		StableImageChildChunkID(1, "knowledge-a", "parent-a", ChunkTypeImageCaption, "same"),
+	)
+	assert.NotEqual(t, id,
+		StableImageChildChunkID(1, "knowledge-a", "parent-a", ChunkTypeImageOCR, "changed"),
+	)
+	assert.NotEqual(t, id,
+		StableImageChildChunkID(1, "knowledge-a", "parent-b", ChunkTypeImageOCR, "same"),
+	)
+}

--- a/internal/types/content_cache.go
+++ b/internal/types/content_cache.go
@@ -8,7 +8,9 @@ import (
 )
 
 const (
-	ContentCacheKindEmbedding = "embedding"
+	ContentCacheKindEmbedding    = "embedding"
+	ContentCacheKindImageOCR     = "image_ocr"
+	ContentCacheKindImageCaption = "image_caption"
 )
 
 // ContentCacheEntry stores reusable deterministic processing artifacts.

--- a/internal/types/content_cache.go
+++ b/internal/types/content_cache.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const (
+	ContentCacheKindEmbedding = "embedding"
+)
+
+// ContentCacheEntry stores reusable deterministic processing artifacts.
+type ContentCacheEntry struct {
+	ID        string    `json:"id"         gorm:"type:varchar(36);primaryKey"`
+	TenantID  uint64    `json:"tenant_id"  gorm:"not null;uniqueIndex:idx_content_caches_key,priority:1"`
+	CacheKind string    `json:"cache_kind" gorm:"type:varchar(32);not null;uniqueIndex:idx_content_caches_key,priority:2"`
+	CacheKey  string    `json:"cache_key"  gorm:"type:varchar(255);not null;uniqueIndex:idx_content_caches_key,priority:3"`
+	Payload   JSON      `json:"payload"    gorm:"type:json;not null"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+func (ContentCacheEntry) TableName() string {
+	return "content_caches"
+}
+
+func (c *ContentCacheEntry) BeforeCreate(_ *gorm.DB) error {
+	if c.ID == "" {
+		c.ID = uuid.NewString()
+	}
+	return nil
+}

--- a/internal/types/interfaces/chunk.go
+++ b/internal/types/interfaces/chunk.go
@@ -64,6 +64,8 @@ type ChunkRepository interface {
 	DeleteChunks(ctx context.Context, tenantID uint64, ids []string) error
 	// DeleteChunksByKnowledgeID deletes chunks by knowledge id
 	DeleteChunksByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) error
+	// PurgeSoftDeletedByKnowledgeID permanently removes already soft-deleted chunks by knowledge id.
+	PurgeSoftDeletedByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) error
 	// DeleteByKnowledgeList deletes all chunks for a knowledge list
 	DeleteByKnowledgeList(ctx context.Context, tenantID uint64, knowledgeIDs []string) error
 	// ListImageInfoByKnowledgeIDs returns non-empty (knowledge_id, image_info) pairs for image cleanup.

--- a/internal/types/interfaces/content_cache.go
+++ b/internal/types/interfaces/content_cache.go
@@ -1,0 +1,13 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// ContentCacheRepository persists deterministic content-processing caches.
+type ContentCacheRepository interface {
+	GetByKey(ctx context.Context, tenantID uint64, cacheKind, cacheKey string) (*types.ContentCacheEntry, error)
+	Upsert(ctx context.Context, entry *types.ContentCacheEntry) error
+}

--- a/migrations/sqlite/000002_content_caches.down.sql
+++ b/migrations/sqlite/000002_content_caches.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS content_caches;

--- a/migrations/sqlite/000002_content_caches.up.sql
+++ b/migrations/sqlite/000002_content_caches.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS content_caches (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id INTEGER NOT NULL,
+    cache_kind VARCHAR(32) NOT NULL,
+    cache_key VARCHAR(255) NOT NULL,
+    payload TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_content_caches_key
+    ON content_caches (tenant_id, cache_kind, cache_key);

--- a/migrations/versioned/000074_content_caches.down.sql
+++ b/migrations/versioned/000074_content_caches.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS content_caches;

--- a/migrations/versioned/000074_content_caches.up.sql
+++ b/migrations/versioned/000074_content_caches.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS content_caches (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id INTEGER NOT NULL,
+    cache_kind VARCHAR(32) NOT NULL,
+    cache_key VARCHAR(255) NOT NULL,
+    payload JSONB NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_content_caches_key
+    ON content_caches (tenant_id, cache_kind, cache_key);


### PR DESCRIPTION
## Description
This PR adds the next small cache layer for #1679: VLM OCR/caption result reuse inside image multimodal processing.

It reuses the `ContentCacheRepository` introduced in PR2 to cache successful OCR and caption outputs by content-addressed image input and effective VLM configuration. Cached output is treated as **canonical text** and used to generate stable child chunk IDs, preventing VLM output jitter from destabilizing downstream embeddings and wiki/graph references.

**Stacked on**: #XXXX (PR2)

**Scope remains minimal**: no parser cache, Wiki cache, GraphRAG cache, delete cleanup, or migration changes.

## Type of Change
- [x] ✨ New feature
- [x] ⚡ Performance improvement

## Related Issue
Fixes #1679 (step 3)

## Testing
### Unit Tests Added
- **Stable child chunk IDs**: same parent/mode/text → same ID; OCR vs caption isolation; text change → ID change.
- **VLM cache behavior**:
  - second pass of same image → cache hit, zero VLM calls
  - OCR and caption caches are independent
  - image bytes, model ID, OCR prompt (default/scanned/custom instructions), caption prompt changes all trigger cache miss
  - VLM error → no cache write; next run retries
  - empty non-error VLM result is cached

### Commands Run Locally
```bash
gofmt -w touched files   # clean
go test ./internal/types -run 'ChunkID|Image'   # pass
git diff --check         # pass