### PR TITLE
fix: prevent API keys from assigning owner role

### DIFF
--- a/internal/application/service/tenant_invitation.go
+++ b/internal/application/service/tenant_invitation.go
@@ -151,6 +151,9 @@ func (s *tenantInvitationService) Create(
 	if !role.IsValid() {
 		return nil, ErrInvalidTenantRole
 	}
+	if err := rejectAPIKeyOwnerAssignment(ctx, role); err != nil {
+		return nil, err
+	}
 	// Reject early if the invitee is already an active member; the
 	// handler renders this as "they're already in" rather than the
 	// generic conflict.
@@ -471,6 +474,9 @@ func (s *tenantInvitationService) CreateShareLink(
 ) (*types.TenantInvitation, string, error) {
 	if !role.IsValid() {
 		return nil, "", ErrInvalidTenantRole
+	}
+	if err := rejectAPIKeyOwnerAssignment(ctx, role); err != nil {
+		return nil, "", err
 	}
 	token, err := generateShareLinkToken()
 	if err != nil {

--- a/internal/application/service/tenant_invitation_test.go
+++ b/internal/application/service/tenant_invitation_test.go
@@ -232,6 +232,22 @@ func TestInvitationService_Create_RejectsInvalidRole(t *testing.T) {
 	}
 }
 
+func TestInvitationService_Create_APIKeyCannotInviteOwner(t *testing.T) {
+	svc, repo, _ := newInvitationSvc()
+	ctx := types.WithTenantAPIKeyScope(context.Background(), types.TenantAPIKeyScope{
+		KeyID:        1,
+		Capabilities: types.StringArray{string(types.APIKeyCapabilityManageMembers)},
+	})
+
+	_, err := svc.Create(ctx, 1, "u-bob", types.TenantRoleOwner, nil, "")
+	if !errors.Is(err, ErrAPIKeyCannotAssignOwner) {
+		t.Fatalf("want ErrAPIKeyCannotAssignOwner, got %v", err)
+	}
+	if len(repo.rows) != 0 {
+		t.Fatalf("API key owner invitation must not be persisted, got %d rows", len(repo.rows))
+	}
+}
+
 func TestInvitationService_Create_RejectsAlreadyActiveMember(t *testing.T) {
 	svc, _, memberSvc := newInvitationSvc()
 	ctx := context.Background()
@@ -458,6 +474,22 @@ func TestInvitationService_CreateShareLink_RejectsInvalidRole(t *testing.T) {
 		context.Background(), 1, types.TenantRole("magician"), nil, "")
 	if !errors.Is(err, ErrInvalidTenantRole) {
 		t.Fatalf("want ErrInvalidTenantRole, got %v", err)
+	}
+}
+
+func TestInvitationService_CreateShareLink_APIKeyCannotAssignOwner(t *testing.T) {
+	svc, repo, _ := newInvitationSvc()
+	ctx := types.WithTenantAPIKeyScope(context.Background(), types.TenantAPIKeyScope{
+		KeyID:        1,
+		Capabilities: types.StringArray{string(types.APIKeyCapabilityManageMembers)},
+	})
+
+	_, _, err := svc.CreateShareLink(ctx, 1, types.TenantRoleOwner, nil, "")
+	if !errors.Is(err, ErrAPIKeyCannotAssignOwner) {
+		t.Fatalf("want ErrAPIKeyCannotAssignOwner, got %v", err)
+	}
+	if len(repo.rows) != 0 {
+		t.Fatalf("API key owner invite link must not be persisted, got %d rows", len(repo.rows))
 	}
 }
 

--- a/internal/application/service/tenant_member.go
+++ b/internal/application/service/tenant_member.go
@@ -54,6 +54,14 @@ var (
 	// value that is not one of the four defined TenantRole constants.
 	ErrInvalidTenantRole = errors.New("invalid tenant role")
 
+	// ErrAPIKeyCannotAssignOwner is returned when an API-key principal
+	// attempts to persist the Owner role through member or invitation
+	// management. manage_members deliberately excludes ownership transfer:
+	// a machine principal may manage lower roles, but must never mint a
+	// durable human Owner who could subsequently manage API keys or delete
+	// the tenant.
+	ErrAPIKeyCannotAssignOwner = errors.New("API keys cannot assign the owner role")
+
 	// ErrLastOwner is returned when an operation would leave the tenant
 	// without an active Owner. Demoting the last Owner or removing them
 	// is forbidden; an explicit ownership transfer must happen first.
@@ -111,6 +119,21 @@ func auditActor(ctx context.Context) string {
 	return uid
 }
 
+// rejectAPIKeyOwnerAssignment is the service-layer boundary shared by
+// direct membership writes and both invitation creation paths. Route RBAC
+// intentionally defers API-key authorization to APIKeyGate, so checking the
+// authenticated principal in the service is required to preserve the
+// manage_members "no ownership transfer" contract across every caller.
+func rejectAPIKeyOwnerAssignment(ctx context.Context, role types.TenantRole) error {
+	if role != types.TenantRoleOwner {
+		return nil
+	}
+	if _, ok := types.TenantAPIKeyScopeFromContext(ctx); ok {
+		return ErrAPIKeyCannotAssignOwner
+	}
+	return nil
+}
+
 // AddMember inserts a new active membership row. Returns
 // ErrMembershipAlreadyExists if the user is already an active member of
 // the tenant, and ErrInvalidTenantRole for unknown roles.
@@ -123,6 +146,9 @@ func (s *tenantMemberService) AddMember(
 ) (*types.TenantMember, error) {
 	if !role.IsValid() {
 		return nil, ErrInvalidTenantRole
+	}
+	if err := rejectAPIKeyOwnerAssignment(ctx, role); err != nil {
+		return nil, err
 	}
 	existing, err := s.repo.Get(ctx, userID, tenantID)
 	if err != nil {
@@ -272,6 +298,9 @@ func (s *tenantMemberService) UpdateRole(
 ) error {
 	if !newRole.IsValid() {
 		return ErrInvalidTenantRole
+	}
+	if err := rejectAPIKeyOwnerAssignment(ctx, newRole); err != nil {
+		return err
 	}
 	current, err := s.repo.Get(ctx, userID, tenantID)
 	if err != nil {

--- a/internal/application/service/tenant_member_test.go
+++ b/internal/application/service/tenant_member_test.go
@@ -268,6 +268,22 @@ func TestTenantMemberService_AddMember_RejectsInvalidRole(t *testing.T) {
 	}
 }
 
+func TestTenantMemberService_AddMember_APIKeyCannotAssignOwner(t *testing.T) {
+	svc, repo := newServiceWithRepo()
+	ctx := types.WithTenantAPIKeyScope(context.Background(), types.TenantAPIKeyScope{
+		KeyID:        1,
+		Capabilities: types.StringArray{string(types.APIKeyCapabilityManageMembers)},
+	})
+
+	_, err := svc.AddMember(ctx, "u1", 1, types.TenantRoleOwner, nil)
+	if !errors.Is(err, ErrAPIKeyCannotAssignOwner) {
+		t.Fatalf("want ErrAPIKeyCannotAssignOwner, got %v", err)
+	}
+	if len(repo.rows) != 0 {
+		t.Fatalf("API key owner assignment must not create a membership, got %d rows", len(repo.rows))
+	}
+}
+
 func TestTenantMemberService_AddMember_RejectsDuplicate(t *testing.T) {
 	svc, _ := newServiceWithRepo()
 	ctx := context.Background()
@@ -323,6 +339,30 @@ func TestTenantMemberService_UpdateRole_BlocksDemotingLastOwner(t *testing.T) {
 	err := svc.UpdateRole(ctx, "owner", 1, types.TenantRoleAdmin)
 	if !errors.Is(err, ErrLastOwner) {
 		t.Fatalf("want ErrLastOwner when demoting last owner, got %v", err)
+	}
+}
+
+func TestTenantMemberService_UpdateRole_APIKeyCannotPromoteOwner(t *testing.T) {
+	svc, _ := newServiceWithRepo()
+	humanCtx := context.Background()
+	if _, err := svc.AddMember(humanCtx, "u1", 1, types.TenantRoleAdmin, nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	apiKeyCtx := types.WithTenantAPIKeyScope(humanCtx, types.TenantAPIKeyScope{
+		KeyID:        1,
+		Capabilities: types.StringArray{string(types.APIKeyCapabilityManageMembers)},
+	})
+
+	err := svc.UpdateRole(apiKeyCtx, "u1", 1, types.TenantRoleOwner)
+	if !errors.Is(err, ErrAPIKeyCannotAssignOwner) {
+		t.Fatalf("want ErrAPIKeyCannotAssignOwner, got %v", err)
+	}
+	member, getErr := svc.GetMembership(humanCtx, "u1", 1)
+	if getErr != nil {
+		t.Fatalf("get membership: %v", getErr)
+	}
+	if member == nil || member.Role != types.TenantRoleAdmin {
+		t.Fatalf("API key promotion must leave role unchanged, got %+v", member)
 	}
 }
 

--- a/internal/handler/tenant_invitation.go
+++ b/internal/handler/tenant_invitation.go
@@ -295,6 +295,8 @@ func (h *TenantInvitationHandler) CreateInvitation(c *gin.Context) {
 		switch {
 		case errors.Is(err, service.ErrInvalidTenantRole):
 			c.Error(apperrors.NewValidationError(err.Error()))
+		case errors.Is(err, service.ErrAPIKeyCannotAssignOwner):
+			c.Error(apperrors.NewForbiddenError(err.Error()))
 		case errors.Is(err, service.ErrPendingInvitationExists):
 			c.Error(apperrors.NewConflictError(err.Error()))
 		case errors.Is(err, service.ErrAlreadyMember):

--- a/internal/handler/tenant_invite_link.go
+++ b/internal/handler/tenant_invite_link.go
@@ -1,12 +1,14 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"os"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/Tencent/WeKnora/internal/application/service"
 	"github.com/Tencent/WeKnora/internal/config"
 	apperrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -88,6 +90,10 @@ func (h *TenantInvitationHandler) CreateInviteLink(c *gin.Context) {
 
 	inv, _, err := h.invitationService.CreateShareLink(ctx, tenantID, req.Role, invitedBy, req.Message)
 	if err != nil {
+		if errors.Is(err, service.ErrAPIKeyCannotAssignOwner) {
+			c.Error(apperrors.NewForbiddenError(err.Error()))
+			return
+		}
 		logger.Errorf(ctx, "CreateShareLink failed: tenant=%d err=%v", tenantID, err)
 		c.Error(apperrors.NewInternalServerError("failed to create share link").WithDetails(err.Error()))
 		return

--- a/internal/handler/tenant_member.go
+++ b/internal/handler/tenant_member.go
@@ -239,6 +239,8 @@ func (h *TenantMemberHandler) AddMember(c *gin.Context) {
 		switch {
 		case errors.Is(err, service.ErrInvalidTenantRole):
 			c.Error(apperrors.NewValidationError(err.Error()))
+		case errors.Is(err, service.ErrAPIKeyCannotAssignOwner):
+			c.Error(apperrors.NewForbiddenError(err.Error()))
 		case errors.Is(err, service.ErrMembershipAlreadyExists):
 			// 409 reads better than 400 here: the request was syntactically
 			// fine, the conflict is semantic ("already a member").
@@ -312,6 +314,8 @@ func (h *TenantMemberHandler) UpdateMemberRole(c *gin.Context) {
 			c.Error(apperrors.NewConflictError(err.Error()))
 		case errors.Is(err, service.ErrInvalidTenantRole):
 			c.Error(apperrors.NewValidationError(err.Error()))
+		case errors.Is(err, service.ErrAPIKeyCannotAssignOwner):
+			c.Error(apperrors.NewForbiddenError(err.Error()))
 		default:
 			logger.Errorf(ctx, "UpdateRole failed: user=%s tenant=%d err=%v",
 				userID, tenantID, err)


### PR DESCRIPTION
## Description

API keys with the `manage_members` capability could assign the `owner` role through tenant member and invitation APIs.

API-key principals are authorized by the API key capability gate and intentionally bypass the JWT role hierarchy. The affected service methods previously validated that `owner` was a recognized tenant role, but did not distinguish API-key callers from authenticated human users. As a result, an API key could create a persistent human Owner who could subsequently perform ownership-only operations such as managing API keys or deleting the tenant.

This change adds a shared service-layer guard that prevents any API-key principal from assigning the `owner` role through:

- Direct member creation via `POST /tenants/:id/members`
- Member role updates via `PUT /tenants/:id/members/:user_id`
- Regular invitations via `POST /tenants/:id/invitations`
- Shareable invitation links via `POST /tenants/:id/invite-links`

The affected handlers map this rejection to HTTP 403 Forbidden.

JWT-authenticated Owners can continue assigning the Owner role. Internal tenant bootstrap operations such as `EnsureOwner` are unaffected. API keys with `manage_members` can also continue managing non-Owner roles.

Regression tests cover all four affected paths and verify that rejected requests do not persist membership or invitation records.

No breaking API changes are introduced. This change only prevents an API-key operation that conflicts with the documented `manage_members` capability contract.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

The following checks were completed:

- Ran `gofmt` on all modified Go files.
- Ran `git diff --check` successfully.
- Ran the affected service and handler package tests in a Linux Podman container:

```text
podman run --rm --volume "D:\xinchen.ju\Code\WeKnora:/workspace" --workdir /workspace docker.io/library/golang:1.26-bookworm go test ./internal/application/service ./internal/handler
```

Results:

```text
ok  github.com/Tencent/WeKnora/internal/application/service
ok  github.com/Tencent/WeKnora/internal/handler
```

The complete repository-wide `make fmt && make lint && make test` suite was not run.

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A — no user-visible UI changes