### PR TITLE
fix: 修复 Wiki 生成语言不稳定问题

### DIFF
--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -450,7 +450,7 @@ func EnqueueWikiIngest(
 	tenantID uint64,
 	kbID, knowledgeID string,
 ) {
-	lang, _ := types.LanguageFromContext(ctx)
+	lang := wikiContentLanguage()
 
 	// Persist the pending op. A re-ingest of the same knowledge id while
 	// a previous op is still queued simply appends another row; the
@@ -1010,6 +1010,11 @@ func (s *wikiIngestService) decodePendingRows(ctx context.Context, rows []*types
 				KnowledgeID: r.DedupKey,
 			}
 		}
+		// Wiki is persistent knowledge-base content, so its generation
+		// language must not depend on the browser locale captured when the
+		// task was created. Normalizing at the worker boundary also repairs
+		// legacy pending/dead-letter payloads with a missing or stale language.
+		op.Language = wikiContentLanguage()
 		op.dbID = r.ID
 		all = append(all, op)
 	}
@@ -1041,6 +1046,13 @@ func (s *wikiIngestService) decodePendingRows(ctx context.Context, rows []*types
 		ops = append(ops, reversedUnique[i])
 	}
 	return ops, peekedIDs
+}
+
+// wikiContentLanguage returns the configured language for persistent Wiki
+// content. WEKNORA_LANGUAGE is the single source of truth; DefaultLanguage
+// falls back to zh-CN when it is unset.
+func wikiContentLanguage() string {
+	return types.DefaultLanguage()
 }
 
 // trimPendingList deletes consumed rows from task_pending_ops. Empty

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -249,12 +249,11 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 		exitStatus = "invalid_payload"
 		return fmt.Errorf("wiki ingest: unmarshal payload: %w", err)
 	}
+	payload.Language = wikiContentLanguage()
 
 	// Inject context
 	ctx = context.WithValue(ctx, types.TenantIDContextKey, payload.TenantID)
-	if payload.Language != "" {
-		ctx = context.WithValue(ctx, types.LanguageContextKey, payload.Language)
-	}
+	ctx = context.WithValue(ctx, types.LanguageContextKey, payload.Language)
 
 	// Concurrency model (Phase 3):
 	//
@@ -953,10 +952,9 @@ func (s *wikiIngestService) ProcessWikiFinalize(ctx context.Context, t *asynq.Ta
 	if err := json.Unmarshal(t.Payload(), &payload); err != nil {
 		return fmt.Errorf("wiki finalize: unmarshal payload: %w", err)
 	}
+	payload.Language = wikiContentLanguage()
 	ctx = context.WithValue(ctx, types.TenantIDContextKey, payload.TenantID)
-	if payload.Language != "" {
-		ctx = context.WithValue(ctx, types.LanguageContextKey, payload.Language)
-	}
+	ctx = context.WithValue(ctx, types.LanguageContextKey, payload.Language)
 	if s.pendingRepo == nil {
 		return nil
 	}
@@ -1196,7 +1194,7 @@ func (s *wikiIngestService) mapOneDocument(
 ) (*docIngestResult, []SlugUpdate, error) {
 	docStartedAt := time.Now()
 	knowledgeID := op.KnowledgeID
-	lang := types.LanguageLocaleName(op.Language)
+	lang := types.LanguageLocaleName(wikiContentLanguage())
 
 	// Open a postprocess.wiki subspan under the parent attempt's
 	// postprocess stage so the actual per-doc work (LLM extraction +

--- a/internal/application/service/wiki_ingest_test.go
+++ b/internal/application/service/wiki_ingest_test.go
@@ -79,6 +79,52 @@ func TestAppendUnique(t *testing.T) {
 	}
 }
 
+func TestWikiContentLanguage(t *testing.T) {
+	t.Run("defaults to simplified Chinese", func(t *testing.T) {
+		t.Setenv("WEKNORA_LANGUAGE", "")
+		if got := wikiContentLanguage(); got != "zh-CN" {
+			t.Fatalf("wikiContentLanguage() = %q, want zh-CN", got)
+		}
+	})
+
+	t.Run("uses configured system content language", func(t *testing.T) {
+		t.Setenv("WEKNORA_LANGUAGE", "ja-JP")
+		if got := wikiContentLanguage(); got != "ja-JP" {
+			t.Fatalf("wikiContentLanguage() = %q, want ja-JP", got)
+		}
+	})
+}
+
+func TestDecodePendingRowsNormalizesWikiLanguage(t *testing.T) {
+	t.Setenv("WEKNORA_LANGUAGE", "zh-CN")
+	svc := &wikiIngestService{}
+
+	rows := []*types.TaskPendingOp{
+		{
+			ID:       1,
+			Op:       WikiOpIngest,
+			DedupKey: "missing-language",
+			Payload:  []byte(`{"op":"ingest","knowledge_id":"missing-language"}`),
+		},
+		{
+			ID:       2,
+			Op:       WikiOpIngest,
+			DedupKey: "browser-english",
+			Payload:  []byte(`{"op":"ingest","knowledge_id":"browser-english","language":"en-US"}`),
+		},
+	}
+
+	ops, ids := svc.decodePendingRows(context.Background(), rows)
+	if len(ops) != 2 || len(ids) != 2 {
+		t.Fatalf("decodePendingRows() returned %d ops and %d ids, want 2 and 2", len(ops), len(ids))
+	}
+	for _, op := range ops {
+		if op.Language != "zh-CN" {
+			t.Errorf("op %q language = %q, want zh-CN", op.KnowledgeID, op.Language)
+		}
+	}
+}
+
 func TestReconstructContent(t *testing.T) {
 	chunks := []*types.Chunk{
 		{ChunkIndex: 2, ChunkType: types.ChunkTypeText, Content: "Third paragraph."},


### PR DESCRIPTION
## Description

修复 Wiki 内容生成语言受浏览器界面语言和历史任务空语言影响的问题。

此前 Wiki 入队任务直接读取请求上下文中的语言：浏览器使用英文界面时会写入 `en-US`，后台任务缺少语言上下文时又可能写入空字符串，最终导致提示词出现空语言或生成英文 Wiki 内容。

本次采用最小后端改动：

- Wiki 内容语言统一读取 `WEKNORA_LANGUAGE`，未配置时使用系统默认值 `zh-CN`。
- 入队时不再使用浏览器 locale 作为持久化 Wiki 的生成语言。
- Wiki ingest 与 finalize Worker 在消费入口重新写入系统内容语言。
- 解码历史 pending/dead-letter 恢复任务时规范化语言，兼容空语言和旧的 `en-US` payload。
- 增加默认语言、系统语言和历史任务语言规范化的回归测试。

该修改不包含数据库迁移和前端变更，也不会直接修改已有 Wiki 页面；已有英文内容仍需按 `zh-CN` 定向重建。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

暂无关联 Issue。

## Testing

已使用 Go 1.26 容器执行：

```bash
go test ./internal/application/service ./internal/types -count=1
```

结果：

```text
ok  github.com/Tencent/WeKnora/internal/application/service
ok  github.com/Tencent/WeKnora/internal/types
```

覆盖场景：

- 未配置 `WEKNORA_LANGUAGE` 时回退到 `zh-CN`。
- 配置系统内容语言时使用配置值。
- 历史任务 payload 缺少 `language` 时自动补齐。
- 历史任务携带浏览器 `en-US` 时统一使用系统内容语言。

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (本次无需更新文档)
- [x] Breaking changes are clearly called out in the description above (无破坏性变更)

## Screenshots / Recordings

纯后端修复，无界面变化。