### PR TITLE
fix(vlm): GPT-5/o 系列模型使用 max_completion_tokens

### DIFF
--- a/internal/models/chat/provider.go
+++ b/internal/models/chat/provider.go
@@ -220,7 +220,7 @@ func (azureReasoningProvider) Matches(model string) bool {
 	return provider.IsOpenAIReasoningOrGPT5Model(model)
 }
 func (azureReasoningProvider) ShapeRequest(req *openai.ChatCompletionRequest, _ *ChatOptions, _ bool) {
-	shapeOpenAIReasoning(req)
+	provider.ShapeOpenAIReasoning(req)
 }
 
 // --- OpenAI reasoning / GPT-5: no sampling params, must use max_completion_tokens ---
@@ -232,7 +232,7 @@ func (openAIReasoningProvider) Matches(model string) bool {
 	return provider.IsOpenAIReasoningOrGPT5Model(model)
 }
 func (openAIReasoningProvider) ShapeRequest(req *openai.ChatCompletionRequest, _ *ChatOptions, _ bool) {
-	shapeOpenAIReasoning(req)
+	provider.ShapeOpenAIReasoning(req)
 }
 
 // --- Moonshot: v1 models accept only temperature=1 ---
@@ -250,19 +250,6 @@ func (moonshotProvider) ShapeRequest(req *openai.ChatCompletionRequest, _ *ChatO
 	req.TopP = 0
 	req.FrequencyPenalty = 0
 	req.PresencePenalty = 0
-}
-
-// shapeOpenAIReasoning strips sampling params (unsupported by o-series / GPT-5)
-// and migrates max_tokens to max_completion_tokens. See issue #1283.
-func shapeOpenAIReasoning(req *openai.ChatCompletionRequest) {
-	req.Temperature = 0
-	req.TopP = 0
-	req.FrequencyPenalty = 0
-	req.PresencePenalty = 0
-	if req.MaxCompletionTokens == 0 && req.MaxTokens > 0 {
-		req.MaxCompletionTokens = req.MaxTokens
-	}
-	req.MaxTokens = 0
 }
 
 // providerRegistry is ordered: more specific adapters (those with a real

--- a/internal/models/provider/openai.go
+++ b/internal/models/provider/openai.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Tencent/WeKnora/internal/types"
+	openai "github.com/sashabaranov/go-openai"
 )
 
 const (
@@ -83,4 +84,24 @@ func IsOpenAIReasoningOrGPT5Model(modelName string) bool {
 		}
 	}
 	return false
+}
+
+// ShapeOpenAIReasoning strips sampling params unsupported by OpenAI's
+// o-series / GPT-5 reasoning models and migrates max_tokens to
+// max_completion_tokens. Intended for OpenAI and Azure OpenAI providers; pair
+// with IsOpenAIReasoningOrGPT5Model. See issue #1283.
+//
+// The go-openai fields carry the `omitempty` JSON tag, so zeroing
+// Temperature / TopP / MaxTokens omits them from the request body instead of
+// sending explicit zeros - which is what makes these models accept the request
+// (they fall back to their defaults, e.g. temperature=1).
+func ShapeOpenAIReasoning(req *openai.ChatCompletionRequest) {
+	req.Temperature = 0
+	req.TopP = 0
+	req.FrequencyPenalty = 0
+	req.PresencePenalty = 0
+	if req.MaxCompletionTokens == 0 && req.MaxTokens > 0 {
+		req.MaxCompletionTokens = req.MaxTokens
+	}
+	req.MaxTokens = 0
 }

--- a/internal/models/provider/openai_test.go
+++ b/internal/models/provider/openai_test.go
@@ -1,6 +1,10 @@
 package provider
 
-import "testing"
+import (
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+)
 
 // TestIsOpenAIReasoningOrGPT5Model 验证 GPT-5 / o-series 模型识别逻辑。
 // 见 issue #1283：这些模型必须使用 max_completion_tokens 替代 max_tokens。
@@ -42,5 +46,44 @@ func TestIsOpenAIReasoningOrGPT5Model(t *testing.T) {
 				t.Errorf("IsOpenAIReasoningOrGPT5Model(%q) = %v, want %v", tc.input, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestShapeOpenAIReasoning verifies max_tokens -> max_completion_tokens
+// migration and that sampling params are zeroed (which the `omitempty` JSON
+// tags turn into omitted fields - the actual goal for o-series / GPT-5).
+func TestShapeOpenAIReasoning(t *testing.T) {
+	req := &openai.ChatCompletionRequest{
+		Model:            "gpt-5",
+		MaxTokens:        5000,
+		Temperature:      0.1,
+		TopP:             0.2,
+		FrequencyPenalty: 0.3,
+		PresencePenalty:  0.4,
+	}
+	ShapeOpenAIReasoning(req)
+
+	if req.MaxTokens != 0 {
+		t.Errorf("MaxTokens = %d, want 0 (must be dropped)", req.MaxTokens)
+	}
+	if req.MaxCompletionTokens != 5000 {
+		t.Errorf("MaxCompletionTokens = %d, want 5000 (migrated from MaxTokens)", req.MaxCompletionTokens)
+	}
+	if req.Temperature != 0 || req.TopP != 0 || req.FrequencyPenalty != 0 || req.PresencePenalty != 0 {
+		t.Errorf("sampling params not zeroed: temp=%v topP=%v freq=%v pres=%v",
+			req.Temperature, req.TopP, req.FrequencyPenalty, req.PresencePenalty)
+	}
+
+	// An already-set MaxCompletionTokens must not be overwritten by MaxTokens.
+	req2 := &openai.ChatCompletionRequest{
+		MaxTokens:           100,
+		MaxCompletionTokens: 200,
+	}
+	ShapeOpenAIReasoning(req2)
+	if req2.MaxCompletionTokens != 200 {
+		t.Errorf("MaxCompletionTokens = %d, want 200 (existing value must win)", req2.MaxCompletionTokens)
+	}
+	if req2.MaxTokens != 0 {
+		t.Errorf("MaxTokens = %d, want 0", req2.MaxTokens)
 	}
 }

--- a/internal/models/vlm/remote_api.go
+++ b/internal/models/vlm/remote_api.go
@@ -144,6 +144,10 @@ func (v *RemoteAPIVLM) Predict(ctx context.Context, imgBytesList [][]byte, promp
 		Temperature: v.temperature,
 	}
 
+	if shouldShapeReasoning(v.modelName) {
+		provider.ShapeOpenAIReasoning(&req)
+	}
+
 	totalImageSize := 0
 	for _, img := range imgBytesList {
 		totalImageSize += len(img)
@@ -162,6 +166,21 @@ func (v *RemoteAPIVLM) Predict(ctx context.Context, imgBytesList [][]byte, promp
 	content := resp.Choices[0].Message.Content
 	logger.Infof(ctx, "[VLM] OpenAI response received, len=%d", len(content))
 	return content, nil
+}
+
+// shouldShapeReasoning reports whether an OpenAI-compatible VLM request must be
+// reshaped for GPT-5 / o-series reasoning models.
+//
+// The go-openai SDK enforces this client-side via ReasoningValidator (see
+// reasoning_validator.go): for any model whose name starts with o1/o3/o4/gpt-5
+// it rejects requests carrying MaxTokens (>0) or non-default sampling params
+// BEFORE the request is sent, regardless of provider or endpoint. So the
+// max_tokens -> max_completion_tokens migration (and zeroing the sampling
+// params) is required purely by model name - including the generic / legacy
+// inline-config path (NewVLMFromLegacyConfig) where no provider is set and
+// DetectProvider falls back to "generic".
+func shouldShapeReasoning(modelName string) bool {
+	return provider.IsOpenAIReasoningOrGPT5Model(modelName)
 }
 
 func (v *RemoteAPIVLM) GetModelName() string { return v.modelName }

--- a/internal/models/vlm/remote_api_test.go
+++ b/internal/models/vlm/remote_api_test.go
@@ -1,0 +1,40 @@
+package vlm
+
+import (
+	"testing"
+)
+
+// TestShouldShapeReasoning verifies VLM requests are reshaped for GPT-5 /
+// o-series models purely by model name. The go-openai SDK rejects such
+// requests client-side (ReasoningValidator) regardless of provider, so the
+// decision must NOT depend on provider - including the generic / legacy
+// inline-config path where no provider is set. The function taking only the
+// model name (no provider argument) is itself the regression guard against
+// re-introducing provider gating.
+func TestShouldShapeReasoning(t *testing.T) {
+	cases := []struct {
+		name      string
+		modelName string
+		want      bool
+	}{
+		{"gpt-5", "gpt-5", true},
+		{"gpt-5-mini", "gpt-5-mini", true},
+		{"gpt-5.2", "gpt-5.2", true},
+		{"GPT-5 mixed case", "GPT-5.4-Mini", true},
+		{"o1", "o1", true},
+		{"o3-mini", "o3-mini", true},
+		{"o4-mini", "o4-mini", true},
+
+		{"gpt-4o", "gpt-4o", false},
+		{"gpt-4-turbo", "gpt-4-turbo", false},
+		{"qwen-vl", "qwen-vl", false},
+		{"empty model", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldShapeReasoning(tc.modelName); got != tc.want {
+				t.Errorf("shouldShapeReasoning(%q) = %v, want %v", tc.modelName, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 背景
Fixes #2228

在 k8s 部署中，将 VLM 配置为 GPT-5 / o 系列模型后，图片识别报错：

```
OpenAI VLM request: this model is not supported MaxTokens, please use MaxCompletionTokens
```

该错误来自 go-openai SDK 的客户端 `ReasoningValidator`：对 `o1 / o3 / o4 / gpt-5` 前缀的模型，携带 `MaxTokens > 0` 的请求在发出前即被拒绝（详见 #2228）。聊天路径已有 `shapeOpenAIReasoning` 处理，VLM 路径未接入。

## 改动
1. **下沉 shaping 到共享 provider 包**：将 `shapeOpenAIReasoning` 从 `internal/models/chat` 移至 `internal/models/provider/openai.go` 并导出为 `ShapeOpenAIReasoning`，与已有的 `IsOpenAIReasoningOrGPT5Model` 配对；聊天路径 2 个调用点改用 `provider.ShapeOpenAIReasoning`。
2. **VLM 接入整形**：`RemoteAPIVLM.Predict` 在发送请求前，若模型为推理模型（`shouldShapeReasoning`），调用 `provider.ShapeOpenAIReasoning`，将 `max_tokens` 迁移为 `max_completion_tokens`，并清零 `temperature` / `top_p` 等采样参数。

### 为什么只按模型名判定、不按 provider
go-openai 的 `ReasoningValidator` 纯按模型名在客户端拒绝，与 provider / endpoint 无关；且旧版内联 VLM 配置（`NewVLMFromLegacyConfig`）不带 provider，`DetectProvider` 对自定义 BaseURL 回退为 `generic`。若按 provider 判定（仅 OpenAI / Azure 才整形），会漏掉这条生产路径。故整形只由模型名决定。

### 为什么清零采样参数是安全的
go-openai 字段带 `omitempty`，清零 `temperature` / `top_p` / `max_tokens` 等于在请求体中省略这些字段，模型回退默认值（如 temperature=1），满足推理模型限制；`max_tokens` 则迁移为 `max_completion_tokens`。

## 测试
- `TestShapeOpenAIReasoning`（provider 包）：迁移 + 清零 + 已设值不被覆盖。
- `TestShouldShapeReasoning`（vlm 包）：模型名表驱动；函数仅接收模型名这一设计本身即防止 provider 判定回潮。
- 既有 `TestIsOpenAIReasoningOrGPT5Model` 保持通过。

```
go test ./internal/models/vlm/ ./internal/models/provider/
ok  	github.com/Tencent/WeKnora/internal/models/vlm	0.429s
ok  	github.com/Tencent/WeKnora/internal/models/provider	0.435s
```

## 改动文件
- `internal/models/provider/openai.go`：新增导出 `ShapeOpenAIReasoning`
- `internal/models/chat/provider.go`：2 个调用点改用 `provider.ShapeOpenAIReasoning`，删除本地未导出函数
- `internal/models/vlm/remote_api.go`：`Predict` 接入整形 + `shouldShapeReasoning` helper
- `internal/models/provider/openai_test.go`：`TestShapeOpenAIReasoning`
- `internal/models/vlm/remote_api_test.go`（新增）：`TestShouldShapeReasoning`
