### PR TITLE
fix: enforce cross-tenant access flag for tenant switching

### DIFF
--- a/internal/application/service/user.go
+++ b/internal/application/service/user.go
@@ -717,9 +717,10 @@ func (s *userService) GenerateTokens(
 //     this repairs partial invitation/admin-assignment flows.
 //  2. Otherwise validate the preference: the tenant must still exist and
 //     the user must still have an active membership (or be a cross-tenant
-//     superuser). Validation failure logs a warning, best-effort clears
-//     the stale preference (so we don't waste a DB round-trip on every
-//     subsequent login), and falls back to home.
+//     superuser while EnableCrossTenantAccess is enabled). Validation failure
+//     logs a warning, best-effort clears the stale preference (so we don't
+//     waste a DB round-trip on every subsequent login), and falls back to
+//     home.
 //
 // This is intentionally a private method on userService so it can reach
 // memberService / tenantService / userRepo. Errors from the validation
@@ -746,9 +747,11 @@ func (s *userService) resolveLoginTenantID(ctx context.Context, user *types.User
 		}
 	}
 
-	// Membership (or cross-tenant superuser) must still be valid. Mirrors
-	// the gate in SwitchTenant so the two entry points stay consistent.
-	if !user.CanAccessAllTenants {
+	// Membership (or an enabled cross-tenant superuser bypass) must still
+	// be valid. Mirrors the gate in SwitchTenant so login / refresh cannot
+	// restore a foreign-tenant preference after the cluster-wide switch has
+	// been turned off.
+	if !s.canBypassTenantMembership(user, preferred) {
 		if s.memberService == nil {
 			logger.Warnf(ctx,
 				"resolveLoginTenantID: member service unavailable; falling back to home for user %s",
@@ -767,6 +770,21 @@ func (s *userService) resolveLoginTenantID(ctx context.Context, user *types.User
 	}
 
 	return preferred
+}
+
+// canBypassTenantMembership reports whether user may enter targetTenantID
+// without an active tenant_members row. The per-user database flag is
+// deliberately dormant unless the cluster-wide switch is enabled. Keeping
+// this decision in one service helper prevents SwitchTenant and login/refresh
+// preference restoration from drifting apart again.
+func (s *userService) canBypassTenantMembership(user *types.User, targetTenantID uint64) bool {
+	if user == nil || targetTenantID == 0 || targetTenantID == user.TenantID {
+		return false
+	}
+	return s.config != nil &&
+		s.config.Tenant != nil &&
+		s.config.Tenant.EnableCrossTenantAccess &&
+		user.CanAccessAllTenants
 }
 
 // homeOrFirstMembershipTenant returns the user's home tenant, or — for a
@@ -914,8 +932,9 @@ func (s *userService) generateTokensForTenant(
 // can no longer roll forward into the source tenant.
 //
 // Returns ErrMembershipNotFound when the user is not a member of the
-// target tenant. Cross-tenant superuser access (CanAccessAllTenants)
-// is allowed without a membership row, mirroring the auth middleware's
+// target tenant. Cross-tenant superuser access is allowed without a
+// membership row only when both CanAccessAllTenants and the cluster-wide
+// EnableCrossTenantAccess switch are enabled, mirroring the auth middleware's
 // resolveTenantRole behaviour.
 func (s *userService) SwitchTenant(
 	ctx context.Context,
@@ -930,9 +949,9 @@ func (s *userService) SwitchTenant(
 		return nil, errors.New("target workspace ID is required")
 	}
 
-	// Verify membership unless the caller is a cross-tenant superuser
-	// switching outside their home tenant.
-	if !user.CanAccessAllTenants || targetTenantID == user.TenantID {
+	// Verify membership unless the caller is an explicitly enabled
+	// cross-tenant superuser switching outside their home tenant.
+	if !s.canBypassTenantMembership(user, targetTenantID) {
 		if s.memberService == nil {
 			return nil, errors.New("workspace membership service unavailable")
 		}

--- a/internal/application/service/user_switch_tenant_test.go
+++ b/internal/application/service/user_switch_tenant_test.go
@@ -1,0 +1,220 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type switchTenantMemberService struct {
+	interfaces.TenantMemberService
+	member   *types.TenantMember
+	getCalls int
+}
+
+func (s *switchTenantMemberService) GetMembership(
+	_ context.Context,
+	userID string,
+	tenantID uint64,
+) (*types.TenantMember, error) {
+	s.getCalls++
+	if s.member == nil ||
+		s.member.UserID != userID ||
+		s.member.TenantID != tenantID {
+		return nil, nil
+	}
+	copy := *s.member
+	return &copy, nil
+}
+
+func (s *switchTenantMemberService) ListByUser(
+	_ context.Context,
+	userID string,
+) ([]*types.TenantMember, error) {
+	if s.member == nil || s.member.UserID != userID {
+		return []*types.TenantMember{}, nil
+	}
+	copy := *s.member
+	return []*types.TenantMember{&copy}, nil
+}
+
+type switchTenantService struct {
+	interfaces.TenantService
+}
+
+func (s *switchTenantService) GetTenantByID(
+	_ context.Context,
+	tenantID uint64,
+) (*types.Tenant, error) {
+	return &types.Tenant{ID: tenantID, Name: "target"}, nil
+}
+
+type switchTenantTokenRepo struct {
+	interfaces.AuthTokenRepository
+	createCalls int
+}
+
+func (r *switchTenantTokenRepo) CreateToken(_ context.Context, _ *types.AuthToken) error {
+	r.createCalls++
+	return nil
+}
+
+type switchTenantUserRepo struct {
+	interfaces.UserRepository
+	updateCalls int
+}
+
+func (r *switchTenantUserRepo) UpdateUser(_ context.Context, _ *types.User) error {
+	r.updateCalls++
+	return nil
+}
+
+func switchTenantConfig(enabled bool) *config.Config {
+	return &config.Config{Tenant: &config.TenantConfig{
+		EnableCrossTenantAccess: enabled,
+	}}
+}
+
+func newSwitchTenantService(
+	enabled bool,
+	member *types.TenantMember,
+) (*userService, *switchTenantMemberService, *switchTenantTokenRepo) {
+	memberSvc := &switchTenantMemberService{member: member}
+	tokenRepo := &switchTenantTokenRepo{}
+	return &userService{
+		tokenRepo:     tokenRepo,
+		tenantService: &switchTenantService{},
+		memberService: memberSvc,
+		config:        switchTenantConfig(enabled),
+	}, memberSvc, tokenRepo
+}
+
+func TestSwitchTenant_CrossTenantSuperuserBlockedWhenGlobalFlagDisabled(t *testing.T) {
+	svc, memberSvc, tokenRepo := newSwitchTenantService(false, nil)
+	user := &types.User{ID: "super", TenantID: 1, CanAccessAllTenants: true}
+
+	_, err := svc.SwitchTenant(context.Background(), user, 2, "")
+	if !errors.Is(err, ErrMembershipNotFound) {
+		t.Fatalf("SwitchTenant() error = %v, want ErrMembershipNotFound", err)
+	}
+	if memberSvc.getCalls != 1 {
+		t.Fatalf("disabled bypass must check active membership, got %d lookups", memberSvc.getCalls)
+	}
+	if tokenRepo.createCalls != 0 {
+		t.Fatalf("disabled bypass must not issue tokens, got %d writes", tokenRepo.createCalls)
+	}
+}
+
+func TestSwitchTenant_CrossTenantSuperuserAllowedWhenGlobalFlagEnabled(t *testing.T) {
+	svc, memberSvc, tokenRepo := newSwitchTenantService(true, nil)
+	user := &types.User{ID: "super", TenantID: 1, CanAccessAllTenants: true}
+
+	resp, err := svc.SwitchTenant(context.Background(), user, 2, "")
+	if err != nil {
+		t.Fatalf("SwitchTenant() error = %v", err)
+	}
+	if resp == nil || resp.ActiveTenant == nil || resp.ActiveTenant.ID != 2 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if memberSvc.getCalls != 0 {
+		t.Fatalf("enabled superuser bypass should not require membership, got %d lookups", memberSvc.getCalls)
+	}
+	if tokenRepo.createCalls != 2 {
+		t.Fatalf("token pair should be persisted, got %d token writes", tokenRepo.createCalls)
+	}
+}
+
+func TestSwitchTenant_ActiveMemberAllowedWhenGlobalFlagDisabled(t *testing.T) {
+	member := &types.TenantMember{
+		UserID:   "super",
+		TenantID: 2,
+		Role:     types.TenantRoleAdmin,
+		Status:   types.TenantMemberStatusActive,
+	}
+	svc, memberSvc, tokenRepo := newSwitchTenantService(false, member)
+	user := &types.User{ID: "super", TenantID: 1, CanAccessAllTenants: true}
+
+	resp, err := svc.SwitchTenant(context.Background(), user, 2, "")
+	if err != nil {
+		t.Fatalf("SwitchTenant() error = %v", err)
+	}
+	if resp == nil || resp.ActiveTenant == nil || resp.ActiveTenant.ID != 2 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if memberSvc.getCalls != 1 {
+		t.Fatalf("member path should perform one membership lookup, got %d", memberSvc.getCalls)
+	}
+	if tokenRepo.createCalls != 2 {
+		t.Fatalf("token pair should be persisted, got %d token writes", tokenRepo.createCalls)
+	}
+}
+
+func TestResolveLoginTenantID_CrossTenantPreferenceRespectsGlobalFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		enabled       bool
+		wantTenantID  uint64
+		wantCleared   bool
+		wantGetCalls  int
+		wantUserWrite int
+	}{
+		{
+			name:          "disabled",
+			enabled:       false,
+			wantTenantID:  1,
+			wantCleared:   true,
+			wantGetCalls:  1,
+			wantUserWrite: 1,
+		},
+		{
+			name:          "enabled",
+			enabled:       true,
+			wantTenantID:  2,
+			wantCleared:   false,
+			wantGetCalls:  0,
+			wantUserWrite: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			preferred := uint64(2)
+			user := &types.User{
+				ID:                  "super",
+				TenantID:            1,
+				CanAccessAllTenants: true,
+				Preferences: types.UserPreferences{
+					LastActiveTenantID: &preferred,
+				},
+			}
+			memberSvc := &switchTenantMemberService{}
+			userRepo := &switchTenantUserRepo{}
+			svc := &userService{
+				userRepo:      userRepo,
+				tenantService: &switchTenantService{},
+				memberService: memberSvc,
+				config:        switchTenantConfig(tc.enabled),
+			}
+
+			got := svc.resolveLoginTenantID(context.Background(), user)
+			if got != tc.wantTenantID {
+				t.Fatalf("resolveLoginTenantID() = %d, want %d", got, tc.wantTenantID)
+			}
+			if (user.Preferences.LastActiveTenantID == nil) != tc.wantCleared {
+				t.Fatalf(
+					"preference cleared = %t, want %t",
+					user.Preferences.LastActiveTenantID == nil,
+					tc.wantCleared,
+				)
+			}
+			if memberSvc.getCalls != tc.wantGetCalls {
+				t.Fatalf("membership lookups = %d, want %d", memberSvc.getCalls, tc.wantGetCalls)
+			}
+			if userRepo.updateCalls != tc.wantUserWrite {
+				t.Fatalf("user updates = %d, want %d", userRepo.updateCalls, tc.wantUserWrite)
+			}
+		})
+	}
+}

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -688,12 +688,13 @@ func principalTenantIDFromClaims(claims jwt.MapClaims) uint64 {
 //
 // Order of resolution:
 //  1. Active TenantMember row → return that role.
-//  2. Cross-tenant superuser switch (X-Tenant-ID with CanAccessAllTenants=true)
-//     → grant Admin in the target tenant. Org admins are intentionally not
-//     promoted to Owner; tenant deletion / API-key rotation should always
-//     stay with a real Owner inside the target tenant. Cross-tenant access
-//     is also never allowed to trigger the orphan-tenant auto-promotion
-//     below — a superuser only visits, never claims ownership.
+//  2. Cross-tenant superuser switch (X-Tenant-ID or a JWT tenant claim with
+//     CanAccessAllTenants=true AND EnableCrossTenantAccess=true) → grant Admin
+//     in the target tenant. Org admins are intentionally not promoted to
+//     Owner; tenant deletion / API-key rotation should always stay with a real
+//     Owner inside the target tenant. Cross-tenant access is also never
+//     allowed to trigger the orphan-tenant auto-promotion below — a superuser
+//     only visits, never claims ownership.
 //  3. No membership but the tenant currently has zero active members AND
 //     the caller is authenticating into their own home tenant (i.e.
 //     targetTenantID == user.TenantID and this is not a cross-tenant
@@ -744,14 +745,27 @@ func resolveTenantRole(
 			user.ID, targetTenantID, statusInfo)
 	}
 
-	// 2. 跨空间超管直通：CanAccessAllTenants 用户切到别的空间时不强制要求 membership。
-	//    注意：这里只授予临时 Admin 角色，不写入 tenant_members，避免"看一眼别人空间"
-	//    意外升级为持久化所有权。
-	if crossTenantSwitch && user.CanAccessAllTenants {
-		logger.Infof(ctx,
-			"[auth] resolveTenantRole step2 (cross-tenant superuser) -> Admin: user=%s tenant=%d",
-			user.ID, targetTenantID)
-		return types.TenantRoleAdmin, true
+	// 2. 跨空间请求始终 fail-closed：只有总开关和用户标志同时开启，才允许在没有
+	//    membership 时获得临时 Admin。不能落入下面 EnableRBAC=false 的 fail-open，
+	//    因为跨空间总开关是独立且更高优先级的安全边界。
+	if crossTenantSwitch {
+		if cfg != nil &&
+			cfg.Tenant != nil &&
+			cfg.Tenant.EnableCrossTenantAccess &&
+			user.CanAccessAllTenants {
+			logger.Infof(ctx,
+				"[auth] resolveTenantRole step2 (cross-tenant superuser) -> Admin: user=%s tenant=%d",
+				user.ID, targetTenantID)
+			return types.TenantRoleAdmin, true
+		}
+		logger.Warnf(ctx,
+			"[auth] resolveTenantRole step2 blocked cross-tenant request: user=%s tenant=%d enabled=%t privileged=%t",
+			user.ID,
+			targetTenantID,
+			cfg != nil && cfg.Tenant != nil && cfg.Tenant.EnableCrossTenantAccess,
+			user.CanAccessAllTenants,
+		)
+		return "", false
 	}
 
 	// 3. 孤儿空间自愈：仅当用户登录的是自己的 home tenant、且该空间尚无任何活跃成员时

--- a/internal/middleware/auth_role_test.go
+++ b/internal/middleware/auth_role_test.go
@@ -145,6 +145,13 @@ func cfgWithRBAC(enabled bool) *config.Config {
 	return &config.Config{Tenant: &config.TenantConfig{EnableRBAC: &enabled}}
 }
 
+func cfgWithRBACAndCrossTenant(rbacEnabled, crossTenantEnabled bool) *config.Config {
+	return &config.Config{Tenant: &config.TenantConfig{
+		EnableRBAC:              &rbacEnabled,
+		EnableCrossTenantAccess: crossTenantEnabled,
+	}}
+}
+
 func TestResolveTenantRole_ActiveMembershipWins(t *testing.T) {
 	svc := newFakeMemberService()
 	svc.seedActive("u1", 10, types.TenantRoleContributor)
@@ -164,7 +171,10 @@ func TestResolveTenantRole_CrossTenantSuperuserGetsAdmin_NoAutoPromote(t *testin
 	svc := newFakeMemberService()
 	user := &types.User{ID: "super", TenantID: 1, CanAccessAllTenants: true}
 
-	got, ok := resolveTenantRole(context.Background(), svc, user, 99, true, cfgWithRBAC(true))
+	got, ok := resolveTenantRole(
+		context.Background(), svc, user, 99, true,
+		cfgWithRBACAndCrossTenant(true, true),
+	)
 	if !ok || got != types.TenantRoleAdmin {
 		t.Fatalf("got (%v, %v), want (admin, true)", got, ok)
 	}
@@ -179,12 +189,55 @@ func TestResolveTenantRole_AutoPromoteRequiresHomeTenant(t *testing.T) {
 	svc := newFakeMemberService() // 空 — 任何空间都是孤儿
 	user := &types.User{ID: "u1", TenantID: 1, CanAccessAllTenants: true}
 
-	got, ok := resolveTenantRole(context.Background(), svc, user, 42, true, cfgWithRBAC(true))
+	got, ok := resolveTenantRole(
+		context.Background(), svc, user, 42, true,
+		cfgWithRBACAndCrossTenant(true, true),
+	)
 	if !ok || got != types.TenantRoleAdmin {
 		t.Fatalf("cross-tenant superuser should still get visitor Admin, got (%v, %v)", got, ok)
 	}
 	if len(svc.addCalls) != 0 {
 		t.Fatalf("auto-promote must skip cross-tenant target, got %+v", svc.addCalls)
+	}
+}
+
+func TestResolveTenantRole_CrossTenantSuperuserBlockedWhenGlobalFlagDisabled(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		rbacEnabled bool
+	}{
+		{name: "rbac-enabled", rbacEnabled: true},
+		{name: "rbac-disabled", rbacEnabled: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newFakeMemberService()
+			user := &types.User{ID: "super", TenantID: 1, CanAccessAllTenants: true}
+
+			got, ok := resolveTenantRole(
+				context.Background(), svc, user, 99, true,
+				cfgWithRBACAndCrossTenant(tc.rbacEnabled, false),
+			)
+			if ok || got != "" {
+				t.Fatalf(
+					"disabled global flag must reject foreign JWT even when RBAC fail-open is configured, got (%v, %v)",
+					got, ok,
+				)
+			}
+		})
+	}
+}
+
+func TestResolveTenantRole_CrossTenantActiveMemberAllowedWhenGlobalFlagDisabled(t *testing.T) {
+	svc := newFakeMemberService()
+	svc.seedActive("super", 99, types.TenantRoleContributor)
+	user := &types.User{ID: "super", TenantID: 1, CanAccessAllTenants: true}
+
+	got, ok := resolveTenantRole(
+		context.Background(), svc, user, 99, true,
+		cfgWithRBACAndCrossTenant(true, false),
+	)
+	if !ok || got != types.TenantRoleContributor {
+		t.Fatalf("active membership should remain usable with global flag disabled, got (%v, %v)", got, ok)
 	}
 }
 

--- a/internal/types/interfaces/user.go
+++ b/internal/types/interfaces/user.go
@@ -53,8 +53,9 @@ type UserService interface {
 	BuildLoginMemberships(ctx context.Context, user *types.User, activeTenant *types.Tenant) []types.Membership
 	// SwitchTenant issues a new token pair scoped to targetTenantID and
 	// returns the corresponding LoginResponse. The caller's previous
-	// refresh token (passed in for revocation) is invalidated. Membership
-	// is verified via the TenantMember service before tokens are issued.
+	// refresh token (passed in for revocation) is invalidated. Active
+	// membership is required unless both CanAccessAllTenants and the
+	// cluster-wide EnableCrossTenantAccess switch are enabled.
 	SwitchTenant(ctx context.Context, user *types.User, targetTenantID uint64, currentRefreshToken string) (*types.LoginResponse, error)
 	// ValidateToken validates an access token. It returns the user
 	// referenced by the token plus the active tenant ID encoded in the

--- a/internal/types/user.go
+++ b/internal/types/user.go
@@ -27,9 +27,9 @@ type UserPreferences struct {
 	// refresh token) lands them back in that workspace instead of always
 	// bouncing to their home workspace. Login / RefreshToken validate that
 	// the workspace still exists and the user still has an active membership
-	// (or CanAccessAllTenants) before honouring this preference; an
-	// invalid pointer is best-effort cleared and the user falls back to
-	// home.
+	// (or CanAccessAllTenants while EnableCrossTenantAccess is enabled)
+	// before honouring this preference; an invalid pointer is best-effort
+	// cleared and the user falls back to home.
 	//
 	// nil  = no preference (use user.TenantID, i.e. home)
 	// *0   = "clear preference" sentinel for the partial-update endpoint


### PR DESCRIPTION
## Description

The cluster-wide `EnableCrossTenantAccess` switch was not enforced consistently across all tenant-token paths.

The `X-Tenant-ID` authentication path already required both:

- `EnableCrossTenantAccess=true`
- `User.CanAccessAllTenants=true`

However, `UserService.SwitchTenant` only checked `CanAccessAllTenants`. A user retaining that database flag could therefore call `POST /auth/switch-tenant` and obtain a token scoped to another tenant even after cross-tenant access had been disabled globally.

The same inconsistency also affected two related token paths:

- Login or token refresh could restore a foreign `LastActiveTenantID` preference based only on `CanAccessAllTenants`.
- A previously issued JWT containing a foreign tenant claim could still receive the temporary Admin role without checking the global switch.

This change makes the global switch authoritative across these paths.

### Changes

- Added a shared service-layer check requiring both `CanAccessAllTenants` and `EnableCrossTenantAccess` before bypassing an active tenant membership.
- Updated `SwitchTenant` to require an active membership when the cross-tenant bypass is disabled.
- Updated login, OIDC login, and token refresh tenant restoration to use the same rule.
- Invalid foreign-tenant preferences are cleared and fall back to the user’s home tenant when the global switch is disabled.
- Updated JWT tenant-role resolution so foreign-tenant tokens fail closed when cross-tenant access is disabled.
- Prevented `EnableRBAC=false` from overriding the cluster-wide cross-tenant switch.
- Preserved normal multi-tenant membership behavior: users with an active membership in the target tenant can still switch to it when the global cross-tenant switch is disabled.
- Updated service/interface comments to document the combined global-switch and user-flag requirement.

No breaking API changes are introduced. The change prevents access that conflicts with the existing cluster-wide configuration contract.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

The following checks were completed:

- Ran `gofmt` on all modified Go files.
- Ran `git diff --check` successfully.
- Ran the affected service and authentication middleware tests in a Linux Podman container:

```text
podman run --rm --volume "D:\xinchen.ju\Code\WeKnora:/workspace" --workdir /workspace docker.io/library/golang:1.26-bookworm go test ./internal/application/service ./internal/middleware
```

Results:

```text
ok  github.com/Tencent/WeKnora/internal/application/service
ok  github.com/Tencent/WeKnora/internal/middleware
```

The regression tests cover:

- A cross-tenant superuser without membership is rejected when the global switch is disabled.
- The same superuser bypass remains available when the global switch is enabled.
- A user with an active membership can still switch tenants when the global switch is disabled.
- A saved foreign-tenant preference respects the global switch.
- A foreign-tenant JWT is rejected when the global switch is disabled.
- The JWT path remains fail-closed even when tenant RBAC is configured in fail-open mode.

The complete repository-wide `make fmt && make lint && make test` suite was not run.

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A — no user-visible UI changes