### PR TITLE
fix(models): align model debug upload limit with global MAX_FILE_SIZE

### DIFF
--- a/frontend/src/components/ModelDebugDrawer.vue
+++ b/frontend/src/components/ModelDebugDrawer.vue
@@ -197,6 +197,7 @@ import { MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
 import SettingDrawer from '@/components/settings/SettingDrawer.vue'
 import { debugModel, type ModelConfig, type ModelDebugResult } from '@/api/model'
+import { fileSizeVerification } from '@/utils'
 import { modelSupportsThinking } from '@/utils/thinkingControl'
 
 const props = defineProps<{
@@ -389,7 +390,14 @@ const selectModelType = (type: DebugModelType) => {
 
 const onNativeFileChange = (event: Event) => {
   const target = event.target as HTMLInputElement
-  file.value = target.files?.[0] || null
+  const selectedFile = target.files?.[0] || null
+  if (selectedFile && fileSizeVerification(selectedFile)) {
+    target.value = ''
+    file.value = null
+    resetResult()
+    return
+  }
+  file.value = selectedFile
   resetResult()
 }
 

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -15,7 +15,7 @@ declare global {
 export const MAX_FILE_SIZE_MB = window.__RUNTIME_CONFIG__?.MAX_FILE_SIZE_MB
   || Number(import.meta.env.VITE_MAX_FILE_SIZE_MB) 
   || 50;
-const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
+export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
 
 export function generateRandomString(length: number) {
   let result = "";
@@ -42,6 +42,15 @@ export function formatStringDate(date: any) {
 }
 const DEFAULT_VALID_TYPES = new Set(["pdf", "txt", "md", "docx", "doc", "pptx", "ppt", "epub", "mhtml", "jpg", "jpeg", "png", "csv", "xlsx", "xls", "mp3", "wav", "m4a", "flac", "ogg"]);
 
+/** Returns true when the file exceeds the deploy-time upload limit. */
+export function fileSizeVerification(file: Pick<File, 'size'>, silent = false) {
+  if (file.size <= MAX_FILE_SIZE_BYTES) return false;
+  if (!silent) {
+    MessagePlugin.error(i18n.global.t('error.fileSizeExceeded', { size: MAX_FILE_SIZE_MB }));
+  }
+  return true;
+}
+
 /**
  * Returns true when the file should be **rejected**.
  * @param validTypes - override the default extension whitelist with a dynamic set (e.g. from engine registry).
@@ -61,11 +70,5 @@ export function kbFileTypeVerification(file: any, silent = false, validTypes?: S
     }
     return true;
   }
-  if (file.size > MAX_FILE_SIZE_BYTES) {
-    if (!silent) {
-      MessagePlugin.error(i18n.global.t('error.fileSizeExceeded', { size: MAX_FILE_SIZE_MB }));
-    }
-    return true;
-  }
-  return false;
+  return fileSizeVerification(file, silent);
 }

--- a/internal/handler/model.go
+++ b/internal/handler/model.go
@@ -205,10 +205,7 @@ func (h *ModelHandler) ListModels(c *gin.Context) {
 	})
 }
 
-const (
-	modelDebugMaxInputBytes = 64 * 1024
-	modelDebugMaxFileBytes  = 20 * 1024 * 1024
-)
+const modelDebugMaxInputBytes = 64 * 1024
 
 // ModelDebugOptions contains the cross-provider parameters exposed by the
 // model debugger. Pointer fields preserve explicit zero/false values.
@@ -397,17 +394,19 @@ func (h *ModelHandler) DebugModel(c *gin.Context) {
 		defer file.Close()
 		fileName = header.Filename
 		fileSize = header.Size
-		if fileSize > modelDebugMaxFileBytes {
-			c.Error(errors.NewBadRequestError("file cannot exceed 20 MB"))
+		maxFileBytes := secutils.GetMaxFileSize()
+		maxFileSizeMB := secutils.GetMaxFileSizeMB()
+		if fileSize > maxFileBytes {
+			c.Error(errors.NewBadRequestError(fmt.Sprintf("file cannot exceed %d MB", maxFileSizeMB)))
 			return
 		}
-		fileBytes, err = io.ReadAll(io.LimitReader(file, modelDebugMaxFileBytes+1))
+		fileBytes, err = io.ReadAll(io.LimitReader(file, maxFileBytes+1))
 		if err != nil {
 			c.Error(errors.NewBadRequestError("failed to read uploaded file"))
 			return
 		}
-		if len(fileBytes) > modelDebugMaxFileBytes {
-			c.Error(errors.NewBadRequestError("file cannot exceed 20 MB"))
+		if int64(len(fileBytes)) > maxFileBytes {
+			c.Error(errors.NewBadRequestError(fmt.Sprintf("file cannot exceed %d MB", maxFileSizeMB)))
 			return
 		}
 		fileSize = int64(len(fileBytes))


### PR DESCRIPTION
## Summary
- Replace the hardcoded 20 MB cap in the model debugger backend with the deploy-time `MAX_FILE_SIZE` configuration via `secutils.GetMaxFileSize()`.
- Extract a shared `fileSizeVerification()` helper on the frontend and use it in `ModelDebugDrawer` to reject oversized files before upload.

## Test plan
- [ ] Upload a file smaller than `MAX_FILE_SIZE_MB` in the model debugger and confirm it succeeds.
- [ ] Upload a file larger than the configured limit and confirm the frontend shows the file size error without sending the request.
- [ ] Upload an oversized file via API and confirm the backend returns a limit error that reflects the configured MB value.