### PR TITLE
feat(reparse): add content-addressed cache layers for rebuild reuse (#1679)

### DIFF
--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -467,6 +467,14 @@ func (r *chunkRepository) DeleteChunksByKnowledgeID(ctx context.Context, tenantI
 	).Delete(&types.Chunk{}).Error
 }
 
+// PurgeSoftDeletedByKnowledgeID permanently removes chunks that were already
+// soft-deleted for the given knowledge ID. Live rows are intentionally excluded.
+func (r *chunkRepository) PurgeSoftDeletedByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) error {
+	return r.db.WithContext(ctx).Unscoped().
+		Where("tenant_id = ? AND knowledge_id = ? AND deleted_at IS NOT NULL", tenantID, knowledgeID).
+		Delete(&types.Chunk{}).Error
+}
+
 // ListImageInfoByKnowledgeIDs returns non-empty image_info values for the given knowledge IDs.
 // No chunk_type filter — collects from text, image_ocr, and image_caption chunks.
 func (r *chunkRepository) ListImageInfoByKnowledgeIDs(

--- a/internal/application/repository/chunk_sqlite_test.go
+++ b/internal/application/repository/chunk_sqlite_test.go
@@ -197,6 +197,59 @@ func TestCreateChunks_SQLite_SeqIDAfterSoftDelete(t *testing.T) {
 	assert.Equal(t, int64(5), saved[1].SeqID)
 }
 
+func TestPurgeSoftDeletedByKnowledgeID_SQLite_AllowsStableIDRecreate(t *testing.T) {
+	db := setupChunkTestDB(t)
+	repo := NewChunkRepository(db)
+	ctx := context.Background()
+
+	kbID := uuid.New().String()
+	knowledgeID := uuid.New().String()
+	liveKnowledgeID := uuid.New().String()
+	stableID := types.StableChunkID(1, knowledgeID, types.ChunkTypeText, types.ContentHash("stable content", ""), 0)
+
+	softDeleted := &types.Chunk{
+		ID:              stableID,
+		TenantID:        1,
+		KnowledgeBaseID: kbID,
+		KnowledgeID:     knowledgeID,
+		Content:         "stable content",
+		ContentHash:     types.ContentHash("stable content", ""),
+		ChunkType:       types.ChunkTypeText,
+		IsEnabled:       true,
+	}
+	liveSameKnowledge := makeChunk(kbID, knowledgeID, types.ChunkTypeText)
+	liveOtherKnowledge := makeChunk(kbID, liveKnowledgeID, types.ChunkTypeText)
+
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{softDeleted, liveSameKnowledge, liveOtherKnowledge}))
+	require.NoError(t, repo.DeleteChunk(ctx, 1, stableID))
+
+	require.NoError(t, repo.PurgeSoftDeletedByKnowledgeID(ctx, 1, knowledgeID))
+
+	var totalRows int64
+	require.NoError(t, db.Unscoped().Model(&types.Chunk{}).Count(&totalRows).Error)
+	assert.Equal(t, int64(2), totalRows, "only the already soft-deleted chunk should be purged")
+
+	var liveCount int64
+	require.NoError(t, db.Model(&types.Chunk{}).Where("knowledge_id IN ?", []string{knowledgeID, liveKnowledgeID}).Count(&liveCount).Error)
+	assert.Equal(t, int64(2), liveCount, "live chunks must not be purged")
+
+	recreated := &types.Chunk{
+		ID:              stableID,
+		TenantID:        1,
+		KnowledgeBaseID: kbID,
+		KnowledgeID:     knowledgeID,
+		Content:         "stable content",
+		ContentHash:     types.ContentHash("stable content", ""),
+		ChunkType:       types.ChunkTypeText,
+		IsEnabled:       true,
+	}
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{recreated}))
+
+	var active types.Chunk
+	require.NoError(t, db.First(&active, "id = ?", stableID).Error)
+	assert.Equal(t, "stable content", active.Content)
+}
+
 func TestUpdateChunk_SQLite_NoNOWError(t *testing.T) {
 	db := setupChunkTestDB(t)
 	ctx := context.Background()

--- a/internal/application/repository/content_cache.go
+++ b/internal/application/repository/content_cache.go
@@ -1,0 +1,52 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type contentCacheRepository struct {
+	db *gorm.DB
+}
+
+func NewContentCacheRepository(db *gorm.DB) interfaces.ContentCacheRepository {
+	return &contentCacheRepository{db: db}
+}
+
+func (r *contentCacheRepository) GetByKey(
+	ctx context.Context,
+	tenantID uint64,
+	cacheKind, cacheKey string,
+) (*types.ContentCacheEntry, error) {
+	var entry types.ContentCacheEntry
+	if err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND cache_kind = ? AND cache_key = ?", tenantID, cacheKind, cacheKey).
+		First(&entry).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &entry, nil
+}
+
+func (r *contentCacheRepository) Upsert(ctx context.Context, entry *types.ContentCacheEntry) error {
+	if entry == nil {
+		return nil
+	}
+	entry.UpdatedAt = time.Now()
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "tenant_id"},
+			{Name: "cache_kind"},
+			{Name: "cache_key"},
+		},
+		DoUpdates: clause.AssignmentColumns([]string{"payload", "updated_at"}),
+	}).Create(entry).Error
+}

--- a/internal/application/repository/content_cache_sqlite_test.go
+++ b/internal/application/repository/content_cache_sqlite_test.go
@@ -1,0 +1,87 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupContentCacheTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.ContentCacheEntry{}))
+	return db
+}
+
+func TestContentCacheRepository_SQLite_Miss(t *testing.T) {
+	repo := NewContentCacheRepository(setupContentCacheTestDB(t))
+
+	got, err := repo.GetByKey(context.Background(), 1, types.ContentCacheKindEmbedding, "missing")
+
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestContentCacheRepository_SQLite_UpsertGetAndOverwrite(t *testing.T) {
+	repo := NewContentCacheRepository(setupContentCacheTestDB(t))
+	ctx := context.Background()
+
+	entry := &types.ContentCacheEntry{
+		TenantID:  1,
+		CacheKind: types.ContentCacheKindEmbedding,
+		CacheKey:  "embedding:key",
+		Payload:   types.JSON(`{"value":1}`),
+	}
+	require.NoError(t, repo.Upsert(ctx, entry))
+
+	got, err := repo.GetByKey(ctx, 1, types.ContentCacheKindEmbedding, "embedding:key")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, `{"value":1}`, got.Payload.ToString())
+
+	require.NoError(t, repo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  1,
+		CacheKind: types.ContentCacheKindEmbedding,
+		CacheKey:  "embedding:key",
+		Payload:   types.JSON(`{"value":2}`),
+	}))
+
+	got, err = repo.GetByKey(ctx, 1, types.ContentCacheKindEmbedding, "embedding:key")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, `{"value":2}`, got.Payload.ToString())
+}
+
+func TestContentCacheRepository_SQLite_TenantIsolation(t *testing.T) {
+	repo := NewContentCacheRepository(setupContentCacheTestDB(t))
+	ctx := context.Background()
+
+	require.NoError(t, repo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  1,
+		CacheKind: types.ContentCacheKindEmbedding,
+		CacheKey:  "same",
+		Payload:   types.JSON(`[1]`),
+	}))
+	require.NoError(t, repo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  2,
+		CacheKind: types.ContentCacheKindEmbedding,
+		CacheKey:  "same",
+		Payload:   types.JSON(`[2]`),
+	}))
+
+	got1, err := repo.GetByKey(ctx, 1, types.ContentCacheKindEmbedding, "same")
+	require.NoError(t, err)
+	require.NotNil(t, got1)
+	assert.Equal(t, `[1]`, got1.Payload.ToString())
+
+	got2, err := repo.GetByKey(ctx, 2, types.ContentCacheKindEmbedding, "same")
+	require.NoError(t, err)
+	require.NotNil(t, got2)
+	assert.Equal(t, `[2]`, got2.Payload.ToString())
+}

--- a/internal/application/service/artifact_cache.go
+++ b/internal/application/service/artifact_cache.go
@@ -1,0 +1,211 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+func artifactModelID(model chat.Chat) string {
+	if model == nil {
+		return "unknown"
+	}
+	if id := strings.TrimSpace(model.GetModelID()); id != "" {
+		return id
+	}
+	if name := strings.TrimSpace(model.GetModelName()); name != "" {
+		return name
+	}
+	return "unknown"
+}
+
+func tenantIDFromContext(ctx context.Context) uint64 {
+	if ctx == nil {
+		return 0
+	}
+	switch tenantID := ctx.Value(types.TenantIDContextKey).(type) {
+	case uint64:
+		return tenantID
+	case int:
+		if tenantID > 0 {
+			return uint64(tenantID)
+		}
+	}
+	return 0
+}
+
+func artifactCacheKey(kind, subject string, parts ...string) string {
+	identity := strings.Join(parts, "\x00")
+	return fmt.Sprintf("%s:%s:%s", kind, shortArtifactSubject(subject), types.ContentHash(identity, ""))
+}
+
+func shortArtifactSubject(subject string) string {
+	subject = strings.TrimSpace(subject)
+	if subject == "" {
+		return "unknown"
+	}
+	if len(subject) <= 64 {
+		return subject
+	}
+	return types.ContentHash(subject, "")[:32]
+}
+
+func getContentCacheJSON(
+	ctx context.Context,
+	repo interfaces.ContentCacheRepository,
+	tenantID uint64,
+	cacheKind string,
+	cacheKey string,
+	out any,
+) bool {
+	if repo == nil {
+		return false
+	}
+	entry, err := repo.GetByKey(ctx, tenantID, cacheKind, cacheKey)
+	if err != nil {
+		logger.Warnf(ctx, "%s cache get failed: %v", cacheKind, err)
+		return false
+	}
+	if entry == nil {
+		return false
+	}
+	if err := json.Unmarshal(entry.Payload, out); err != nil {
+		logger.Warnf(ctx, "%s cache decode failed: %v", cacheKind, err)
+		return false
+	}
+	return true
+}
+
+func setContentCacheJSON(
+	ctx context.Context,
+	repo interfaces.ContentCacheRepository,
+	tenantID uint64,
+	cacheKind string,
+	cacheKey string,
+	payload any,
+) {
+	if repo == nil {
+		return
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		logger.Warnf(ctx, "%s cache encode failed: %v", cacheKind, err)
+		return
+	}
+	if err := repo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  tenantID,
+		CacheKind: cacheKind,
+		CacheKey:  cacheKey,
+		Payload:   types.JSON(data),
+	}); err != nil {
+		logger.Warnf(ctx, "%s cache upsert failed: %v", cacheKind, err)
+	}
+}
+
+func graphChunkCacheKey(
+	chunk *types.Chunk,
+	chatModel chat.Chat,
+	template *types.PromptTemplateStructured,
+	extractCfg types.ExtractConfig,
+) string {
+	subject := ""
+	contentHash := ""
+	if chunk != nil {
+		subject = chunk.ID
+		contentHash = chunk.ContentHash
+		if contentHash == "" {
+			contentHash = types.ContentHash(chunk.Content, chunk.ContextHeader)
+		}
+	}
+	templateJSON, _ := json.Marshal(template)
+	configJSON, _ := json.Marshal(extractCfg)
+	return artifactCacheKey(types.ContentCacheKindGraphChunk, subject,
+		contentHash,
+		artifactModelID(chatModel),
+		string(templateJSON),
+		string(configJSON),
+	)
+}
+
+func summaryCacheKey(
+	knowledgeID string,
+	content string,
+	summaryModel chat.Chat,
+	summaryPrompt string,
+	langName string,
+	maxInputChars int,
+	maxTokens int,
+) string {
+	return artifactCacheKey(types.ContentCacheKindSummary, knowledgeID,
+		types.ContentHash(content, ""),
+		artifactModelID(summaryModel),
+		types.ContentHash(summaryPrompt, ""),
+		strings.TrimSpace(langName),
+		fmt.Sprintf("%d", maxInputChars),
+		fmt.Sprintf("%d", maxTokens),
+	)
+}
+
+func questionCacheKey(
+	content string,
+	prevContent string,
+	nextContent string,
+	docName string,
+	questionModel chat.Chat,
+	renderedPrompt string,
+	customInstructions string,
+	langName string,
+	questionCount int,
+) string {
+	contentHash := types.ContentHash(content, "")
+	return artifactCacheKey(types.ContentCacheKindQuestion, contentHash,
+		contentHash,
+		types.ContentHash(prevContent, ""),
+		types.ContentHash(nextContent, ""),
+		types.ContentHash(docName, ""),
+		artifactModelID(questionModel),
+		types.ContentHash(renderedPrompt, ""),
+		types.ContentHash(customInstructions, ""),
+		strings.TrimSpace(langName),
+		fmt.Sprintf("%d", questionCount),
+	)
+}
+
+func cloneGraphDataForChunk(graph *types.GraphData, chunkID string) *types.GraphData {
+	if graph == nil {
+		return nil
+	}
+	cloned := &types.GraphData{Text: graph.Text}
+	if len(graph.Node) > 0 {
+		cloned.Node = make([]*types.GraphNode, 0, len(graph.Node))
+		for _, node := range graph.Node {
+			if node == nil {
+				cloned.Node = append(cloned.Node, nil)
+				continue
+			}
+			cloned.Node = append(cloned.Node, &types.GraphNode{
+				Name:       node.Name,
+				Chunks:     []string{chunkID},
+				Attributes: append([]string(nil), node.Attributes...),
+			})
+		}
+	}
+	if len(graph.Relation) > 0 {
+		cloned.Relation = make([]*types.GraphRelation, 0, len(graph.Relation))
+		for _, rel := range graph.Relation {
+			if rel == nil {
+				cloned.Relation = append(cloned.Relation, nil)
+				continue
+			}
+			copied := *rel
+			cloned.Relation = append(cloned.Relation, &copied)
+		}
+	}
+	return cloned
+}

--- a/internal/application/service/artifact_cache_test.go
+++ b/internal/application/service/artifact_cache_test.go
@@ -1,0 +1,177 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type artifactCacheChatModel struct {
+	modelID   string
+	modelName string
+	response  string
+	calls     int
+}
+
+func (m *artifactCacheChatModel) Chat(
+	_ context.Context,
+	_ []chat.Message,
+	_ *chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	m.calls++
+	return &types.ChatResponse{Content: m.response}, nil
+}
+
+func (m *artifactCacheChatModel) ChatStream(
+	context.Context,
+	[]chat.Message,
+	*chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	return nil, nil
+}
+
+func (m *artifactCacheChatModel) GetModelName() string { return m.modelName }
+func (m *artifactCacheChatModel) GetModelID() string   { return m.modelID }
+
+func TestArtifactCacheKeysInvalidateOnInputs(t *testing.T) {
+	model := &artifactCacheChatModel{modelID: "model-a", modelName: "name-a"}
+	otherModel := &artifactCacheChatModel{modelID: "model-b", modelName: "name-a"}
+	template := &types.PromptTemplateStructured{
+		Description: "extract {{graph}}",
+		Tags:        []string{"tag-a"},
+	}
+	extractCfg := types.ExtractConfig{
+		Enabled:            true,
+		CustomInstructions: "domain rules",
+		Tags:               []string{"tag-a"},
+	}
+	chunk := &types.Chunk{ID: "chunk-a", Content: "Graph content", ContentHash: types.ContentHash("Graph content", "")}
+
+	graphKey := graphChunkCacheKey(chunk, model, template, extractCfg)
+	assert.Less(t, len(graphKey), 255)
+	assert.Equal(t, graphKey, graphChunkCacheKey(chunk, model, template, extractCfg))
+	assert.NotEqual(t, graphKey, graphChunkCacheKey(
+		&types.Chunk{ID: "chunk-a", Content: "changed", ContentHash: types.ContentHash("changed", "")},
+		model, template, extractCfg,
+	))
+	assert.NotEqual(t, graphKey, graphChunkCacheKey(chunk, otherModel, template, extractCfg))
+	changedTemplate := *template
+	changedTemplate.Description = "changed"
+	assert.NotEqual(t, graphKey, graphChunkCacheKey(chunk, model, &changedTemplate, extractCfg))
+	changedCfg := extractCfg
+	changedCfg.CustomInstructions = "changed"
+	assert.NotEqual(t, graphKey, graphChunkCacheKey(chunk, model, template, changedCfg))
+
+	summaryKey := summaryCacheKey("knowledge-a", "content", model, "prompt", "English", 1000, 512)
+	assert.Less(t, len(summaryKey), 255)
+	assert.Equal(t, summaryKey, summaryCacheKey("knowledge-a", " content ", model, "prompt", "English", 1000, 512))
+	assert.NotEqual(t, summaryKey, summaryCacheKey("knowledge-a", "changed", model, "prompt", "English", 1000, 512))
+	assert.NotEqual(t, summaryKey, summaryCacheKey("knowledge-a", "content", otherModel, "prompt", "English", 1000, 512))
+	assert.NotEqual(t, summaryKey, summaryCacheKey("knowledge-a", "content", model, "changed", "English", 1000, 512))
+	assert.NotEqual(t, summaryKey, summaryCacheKey("knowledge-a", "content", model, "prompt", "Chinese", 1000, 512))
+	assert.NotEqual(t, summaryKey, summaryCacheKey("knowledge-a", "content", model, "prompt", "English", 2000, 512))
+	assert.NotEqual(t, summaryKey, summaryCacheKey("knowledge-a", "content", model, "prompt", "English", 1000, 1024))
+
+	questionKey := questionCacheKey("content", "prev", "next", "doc", model, "prompt", "custom", "English", 3)
+	assert.Less(t, len(questionKey), 255)
+	assert.Equal(t, questionKey, questionCacheKey(" content ", "prev", "next", "doc", model, "prompt", "custom", "English", 3))
+	assert.NotEqual(t, questionKey, questionCacheKey("changed", "prev", "next", "doc", model, "prompt", "custom", "English", 3))
+	assert.NotEqual(t, questionKey, questionCacheKey("content", "changed", "next", "doc", model, "prompt", "custom", "English", 3))
+	assert.NotEqual(t, questionKey, questionCacheKey("content", "prev", "changed", "doc", model, "prompt", "custom", "English", 3))
+	assert.NotEqual(t, questionKey, questionCacheKey("content", "prev", "next", "changed", model, "prompt", "custom", "English", 3))
+	assert.NotEqual(t, questionKey, questionCacheKey("content", "prev", "next", "doc", otherModel, "prompt", "custom", "English", 3))
+	assert.NotEqual(t, questionKey, questionCacheKey("content", "prev", "next", "doc", model, "changed", "custom", "English", 3))
+	assert.NotEqual(t, questionKey, questionCacheKey("content", "prev", "next", "doc", model, "prompt", "changed", "English", 3))
+	assert.NotEqual(t, questionKey, questionCacheKey("content", "prev", "next", "doc", model, "prompt", "custom", "Chinese", 3))
+	assert.NotEqual(t, questionKey, questionCacheKey("content", "prev", "next", "doc", model, "prompt", "custom", "English", 4))
+}
+
+func TestCloneGraphDataForChunkRebindsWithoutMutatingCachedGraph(t *testing.T) {
+	cached := &types.GraphData{
+		Text: "source",
+		Node: []*types.GraphNode{{
+			Name:       "Acme",
+			Chunks:     []string{"old-chunk"},
+			Attributes: []string{"company"},
+		}},
+		Relation: []*types.GraphRelation{{
+			Node1: "Acme",
+			Node2: "Search",
+			Type:  "builds",
+		}},
+	}
+
+	got := cloneGraphDataForChunk(cached, "current-chunk")
+
+	require.NotNil(t, got)
+	require.Len(t, got.Node, 1)
+	assert.Equal(t, []string{"current-chunk"}, got.Node[0].Chunks)
+	assert.Equal(t, []string{"old-chunk"}, cached.Node[0].Chunks)
+	got.Node[0].Attributes[0] = "mutated"
+	assert.Equal(t, "company", cached.Node[0].Attributes[0])
+	require.Len(t, got.Relation, 1)
+	got.Relation[0].Type = "changed"
+	assert.Equal(t, "builds", cached.Relation[0].Type)
+}
+
+func TestGenerateQuestionsWithContextUsesCache(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+	repo := newFakeContentCacheRepo()
+	svc := &knowledgeService{
+		config: &config.Config{Conversation: &config.ConversationConfig{
+			GenerateQuestionsPrompt: "Generate {{question_count}} questions for {{doc_name}} in {{language}}.\n{{context}}\n{{content}}",
+		}},
+		contentCacheRepo: repo,
+	}
+	model := &artifactCacheChatModel{
+		modelID:  "question-model",
+		response: "1. What is Acme?\n2. How does Acme use search?",
+	}
+
+	first, err := svc.generateQuestionsWithContext(ctx, model,
+		"Acme builds search tools.", "Before", "After", "Doc", 2, "Prefer concise questions.")
+	require.NoError(t, err)
+	assert.Len(t, first, 2)
+	assert.Equal(t, 1, model.calls)
+
+	second, err := svc.generateQuestionsWithContext(ctx, model,
+		"Acme builds search tools.", "Before", "After", "Doc", 2, "Prefer concise questions.")
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, model.calls)
+
+	_, err = svc.generateQuestionsWithContext(ctx, model,
+		"Acme builds search tools.", "Before", "After", "Doc", 3, "Prefer concise questions.")
+	require.NoError(t, err)
+	assert.Equal(t, 2, model.calls)
+}
+
+func TestGenerateQuestionsWithContextCacheErrorsFallback(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+	repo := newFakeContentCacheRepo()
+	repo.getErr = errors.New("cache read failed")
+	repo.upsertErr = errors.New("cache write failed")
+	svc := &knowledgeService{
+		config: &config.Config{Conversation: &config.ConversationConfig{
+			GenerateQuestionsPrompt: "Generate {{question_count}} questions.\n{{content}}",
+		}},
+		contentCacheRepo: repo,
+	}
+	model := &artifactCacheChatModel{
+		modelID:  "question-model",
+		response: "1. What is Acme?",
+	}
+
+	questions, err := svc.generateQuestionsWithContext(ctx, model,
+		"Acme builds search tools.", "", "", "Doc", 1, "")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"What is Acme?"}, questions)
+	assert.Equal(t, 1, model.calls)
+}

--- a/internal/application/service/embedding_cache.go
+++ b/internal/application/service/embedding_cache.go
@@ -1,0 +1,173 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type embeddingCacheWrapper struct {
+	inner    embedding.Embedder
+	repo     interfaces.ContentCacheRepository
+	tenantID uint64
+}
+
+func withEmbeddingCache(
+	inner embedding.Embedder,
+	repo interfaces.ContentCacheRepository,
+	tenantID uint64,
+) embedding.Embedder {
+	if inner == nil || repo == nil {
+		return inner
+	}
+	return &embeddingCacheWrapper{inner: inner, repo: repo, tenantID: tenantID}
+}
+
+func (w *embeddingCacheWrapper) Embed(ctx context.Context, text string) ([]float32, error) {
+	embeddings, err := w.BatchEmbed(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(embeddings) == 0 {
+		return nil, nil
+	}
+	return embeddings[0], nil
+}
+
+func (w *embeddingCacheWrapper) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	return w.batchEmbed(ctx, texts, func(missTexts []string) ([][]float32, error) {
+		return w.inner.BatchEmbed(ctx, missTexts)
+	})
+}
+
+func (w *embeddingCacheWrapper) BatchEmbedWithPool(
+	ctx context.Context,
+	_ embedding.Embedder,
+	texts []string,
+) ([][]float32, error) {
+	return w.batchEmbed(ctx, texts, func(missTexts []string) ([][]float32, error) {
+		return w.inner.BatchEmbedWithPool(ctx, w, missTexts)
+	})
+}
+
+func (w *embeddingCacheWrapper) batchEmbed(
+	ctx context.Context,
+	texts []string,
+	embedMisses func([]string) ([][]float32, error),
+) ([][]float32, error) {
+	if w == nil || w.inner == nil {
+		return nil, fmt.Errorf("embedding cache wrapper is not initialized")
+	}
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	if w.repo == nil {
+		return embedMisses(texts)
+	}
+
+	out := make([][]float32, len(texts))
+	type pending struct {
+		key     string
+		text    string
+		indexes []int
+	}
+	pendingByKey := make(map[string]*pending, len(texts))
+	pendingOrder := make([]*pending, 0, len(texts))
+
+	for i, text := range texts {
+		key := embeddingCacheKey(w.inner, text)
+		var cached []float32
+		hit, err := w.get(ctx, key, &cached)
+		if err != nil {
+			logger.Warnf(ctx, "embedding cache get failed: %v", err)
+		}
+		if hit {
+			out[i] = cached
+			continue
+		}
+		item := pendingByKey[key]
+		if item == nil {
+			item = &pending{key: key, text: text}
+			pendingByKey[key] = item
+			pendingOrder = append(pendingOrder, item)
+		}
+		item.indexes = append(item.indexes, i)
+	}
+
+	if len(pendingOrder) == 0 {
+		return out, nil
+	}
+
+	missTexts := make([]string, len(pendingOrder))
+	for i, item := range pendingOrder {
+		missTexts[i] = item.text
+	}
+	missVectors, err := embedMisses(missTexts)
+	if err != nil {
+		return nil, err
+	}
+	if len(missVectors) != len(missTexts) {
+		return nil, fmt.Errorf("embedding cache wrapper: got %d embeddings for %d inputs", len(missVectors), len(missTexts))
+	}
+
+	for i, item := range pendingOrder {
+		vector := missVectors[i]
+		for _, originalIndex := range item.indexes {
+			out[originalIndex] = vector
+		}
+		if err := w.set(ctx, item.key, vector); err != nil {
+			logger.Warnf(ctx, "embedding cache upsert failed: %v", err)
+		}
+	}
+	return out, nil
+}
+
+func (w *embeddingCacheWrapper) GetModelName() string {
+	return w.inner.GetModelName()
+}
+
+func (w *embeddingCacheWrapper) GetDimensions() int {
+	return w.inner.GetDimensions()
+}
+
+func (w *embeddingCacheWrapper) GetModelID() string {
+	return w.inner.GetModelID()
+}
+
+func (w *embeddingCacheWrapper) get(ctx context.Context, key string, out any) (bool, error) {
+	entry, err := w.repo.GetByKey(ctx, w.tenantID, types.ContentCacheKindEmbedding, key)
+	if err != nil || entry == nil {
+		return false, err
+	}
+	if err := json.Unmarshal(entry.Payload, out); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (w *embeddingCacheWrapper) set(ctx context.Context, key string, vector []float32) error {
+	payload, err := json.Marshal(vector)
+	if err != nil {
+		return err
+	}
+	return w.repo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  w.tenantID,
+		CacheKind: types.ContentCacheKindEmbedding,
+		CacheKey:  key,
+		Payload:   types.JSON(payload),
+	})
+}
+
+func embeddingCacheKey(embedder embedding.Embedder, text string) string {
+	modelID := strings.TrimSpace(embedder.GetModelID())
+	if modelID == "" {
+		modelID = strings.TrimSpace(embedder.GetModelName())
+	}
+	return fmt.Sprintf("embedding:%s:%s:%d", types.ContentHash(text, ""), modelID, embedder.GetDimensions())
+}

--- a/internal/application/service/embedding_cache_test.go
+++ b/internal/application/service/embedding_cache_test.go
@@ -1,0 +1,162 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeContentCacheRepo struct {
+	mu        sync.Mutex
+	entries   map[string]*types.ContentCacheEntry
+	getErr    error
+	upsertErr error
+}
+
+func newFakeContentCacheRepo() *fakeContentCacheRepo {
+	return &fakeContentCacheRepo{entries: make(map[string]*types.ContentCacheEntry)}
+}
+
+func (r *fakeContentCacheRepo) GetByKey(
+	_ context.Context,
+	tenantID uint64,
+	cacheKind, cacheKey string,
+) (*types.ContentCacheEntry, error) {
+	if r.getErr != nil {
+		return nil, r.getErr
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry := r.entries[cacheEntryKey(tenantID, cacheKind, cacheKey)]
+	if entry == nil {
+		return nil, nil
+	}
+	copied := *entry
+	return &copied, nil
+}
+
+func (r *fakeContentCacheRepo) Upsert(_ context.Context, entry *types.ContentCacheEntry) error {
+	if r.upsertErr != nil {
+		return r.upsertErr
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	copied := *entry
+	r.entries[cacheEntryKey(entry.TenantID, entry.CacheKind, entry.CacheKey)] = &copied
+	return nil
+}
+
+func cacheEntryKey(tenantID uint64, cacheKind, cacheKey string) string {
+	return fmt.Sprintf("%d\x00%s\x00%s", tenantID, cacheKind, cacheKey)
+}
+
+type fakeEmbeddingModel struct {
+	modelID    string
+	modelName  string
+	dimensions int
+	calls      [][]string
+}
+
+func (m *fakeEmbeddingModel) Embed(ctx context.Context, text string) ([]float32, error) {
+	got, err := m.BatchEmbed(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	return got[0], nil
+}
+
+func (m *fakeEmbeddingModel) BatchEmbed(_ context.Context, texts []string) ([][]float32, error) {
+	m.calls = append(m.calls, append([]string(nil), texts...))
+	out := make([][]float32, len(texts))
+	for i, text := range texts {
+		out[i] = []float32{float32(len(text)), float32(m.dimensions)}
+	}
+	return out, nil
+}
+
+func (m *fakeEmbeddingModel) BatchEmbedWithPool(
+	ctx context.Context,
+	_ embedding.Embedder,
+	texts []string,
+) ([][]float32, error) {
+	return m.BatchEmbed(ctx, texts)
+}
+
+func (m *fakeEmbeddingModel) GetModelName() string {
+	return m.modelName
+}
+
+func (m *fakeEmbeddingModel) GetDimensions() int {
+	return m.dimensions
+}
+
+func (m *fakeEmbeddingModel) GetModelID() string {
+	return m.modelID
+}
+
+func TestEmbeddingCacheBatchDeduplicatesAndHitsSecondPass(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeContentCacheRepo()
+	inner := &fakeEmbeddingModel{modelID: "model-a", dimensions: 2}
+	cached := withEmbeddingCache(inner, repo, 1)
+
+	first, err := cached.BatchEmbed(ctx, []string{"same", "same", "other"})
+	require.NoError(t, err)
+	require.Len(t, first, 3)
+	require.Len(t, inner.calls, 1)
+	assert.Equal(t, []string{"same", "other"}, inner.calls[0])
+	assert.Equal(t, first[0], first[1])
+
+	second, err := cached.BatchEmbed(ctx, []string{"same", "same", "other"})
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	require.Len(t, inner.calls, 1, "second identical batch should be fully cached")
+}
+
+func TestEmbeddingCacheMissesOnTextModelAndDimensions(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeContentCacheRepo()
+
+	modelA := &fakeEmbeddingModel{modelID: "model-a", dimensions: 2}
+	cachedA := withEmbeddingCache(modelA, repo, 1)
+	_, err := cachedA.BatchEmbed(ctx, []string{"text"})
+	require.NoError(t, err)
+	_, err = cachedA.BatchEmbed(ctx, []string{"text"})
+	require.NoError(t, err)
+	require.Len(t, modelA.calls, 1)
+
+	_, err = cachedA.BatchEmbed(ctx, []string{"changed"})
+	require.NoError(t, err)
+	require.Len(t, modelA.calls, 2)
+
+	modelB := &fakeEmbeddingModel{modelID: "model-b", dimensions: 2}
+	_, err = withEmbeddingCache(modelB, repo, 1).BatchEmbed(ctx, []string{"text"})
+	require.NoError(t, err)
+	require.Len(t, modelB.calls, 1)
+
+	modelDim := &fakeEmbeddingModel{modelID: "model-a", dimensions: 3}
+	_, err = withEmbeddingCache(modelDim, repo, 1).BatchEmbed(ctx, []string{"text"})
+	require.NoError(t, err)
+	require.Len(t, modelDim.calls, 1)
+}
+
+func TestEmbeddingCacheFallsBackOnCacheErrors(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeContentCacheRepo()
+	repo.getErr = errors.New("cache read failed")
+	repo.upsertErr = errors.New("cache write failed")
+	inner := &fakeEmbeddingModel{modelID: "model-a", dimensions: 2}
+
+	got, err := withEmbeddingCache(inner, repo, 1).BatchEmbed(ctx, []string{"text"})
+
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Len(t, inner.calls, 1)
+}

--- a/internal/application/service/extract.go
+++ b/internal/application/service/extract.go
@@ -164,6 +164,7 @@ type ChunkExtractService struct {
 	knowledgeRepo     interfaces.KnowledgeRepository
 	chunkRepo         interfaces.ChunkRepository
 	graphEngine       interfaces.RetrieveGraphRepository
+	contentCacheRepo  interfaces.ContentCacheRepository
 	// spanTracker records this graph-extract task's subspan under the
 	// parent attempt's postprocess stage so the trace viewer shows real
 	// per-chunk graph extraction time rather than the upstream's enqueue.
@@ -178,6 +179,7 @@ func NewChunkExtractService(
 	knowledgeRepo interfaces.KnowledgeRepository,
 	chunkRepo interfaces.ChunkRepository,
 	graphEngine interfaces.RetrieveGraphRepository,
+	contentCacheRepo interfaces.ContentCacheRepository,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
 	return &ChunkExtractService{
@@ -187,6 +189,7 @@ func NewChunkExtractService(
 		knowledgeRepo:     knowledgeRepo,
 		chunkRepo:         chunkRepo,
 		graphEngine:       graphEngine,
+		contentCacheRepo:  contentCacheRepo,
 		spanTracker:       spanTracker,
 	}
 }
@@ -329,11 +332,21 @@ func (s *ChunkExtractService) Handle(ctx context.Context, t *asynq.Task) error {
 			},
 		},
 	}
-	extractor := chatpipeline.NewExtractor(chatModel, template)
-	graph, err := extractor.Extract(ctx, chunk.Content)
-	if err != nil {
-		handleErr = err
-		return err
+	cacheKey := graphChunkCacheKey(chunk, chatModel, template, extractCfg)
+	var graph *types.GraphData
+	var cachedGraph types.GraphData
+	if getContentCacheJSON(ctx, s.contentCacheRepo, p.TenantID, types.ContentCacheKindGraphChunk, cacheKey, &cachedGraph) {
+		graph = cloneGraphDataForChunk(&cachedGraph, chunk.ID)
+		graphOut["cache_hit"] = true
+	} else {
+		extractor := chatpipeline.NewExtractor(chatModel, template)
+		graph, err = extractor.Extract(ctx, chunk.Content)
+		if err != nil {
+			handleErr = err
+			return err
+		}
+		setContentCacheJSON(ctx, s.contentCacheRepo, p.TenantID, types.ContentCacheKindGraphChunk, cacheKey, graph)
+		graphOut["cache_hit"] = false
 	}
 
 	chunk, err = s.chunkRepo.GetChunkByID(ctx, p.TenantID, p.ChunkID)
@@ -343,8 +356,13 @@ func (s *ChunkExtractService) Handle(ctx context.Context, t *asynq.Task) error {
 		return nil
 	}
 
+	if graph == nil {
+		graph = &types.GraphData{}
+	}
 	for _, node := range graph.Node {
-		node.Chunks = []string{chunk.ID}
+		if node != nil {
+			node.Chunks = []string{chunk.ID}
+		}
 	}
 	if err = s.graphEngine.AddGraph(ctx,
 		types.NameSpace{KnowledgeBase: chunk.KnowledgeBaseID, Knowledge: chunk.KnowledgeID},

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,7 +21,6 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
-	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
 	"github.com/redis/go-redis/v9"
 )
@@ -48,6 +49,8 @@ const (
 		"5. Output ONLY the extracted text content. Do NOT include any HTML tags, reasoning, or unrelated comments.\n" +
 		"6. If there is absolutely no recognizable text content in the image, reply ONLY with: No text content.\n" +
 		"</instructions>"
+	vlmCacheModeOCR     = "ocr"
+	vlmCacheModeCaption = "caption"
 )
 
 func buildVLMCaptionPrompt(ctx context.Context, cfg types.VLMConfig) string {
@@ -57,6 +60,31 @@ func buildVLMCaptionPrompt(ctx context.Context, cfg types.VLMConfig) string {
 	}
 	prompt := fmt.Sprintf("Provide a brief and concise description of the main content of the image in %s.", language)
 	return types.AppendCustomPromptInstructions(prompt, cfg.CustomInstructions, "image_description")
+}
+
+func resolvedVLMCacheModelID(cfg types.VLMConfig) string {
+	if id := strings.TrimSpace(cfg.ModelID); id != "" {
+		return id
+	}
+	return "legacy_inline"
+}
+
+func vlmCacheKey(imageBytes []byte, modelID, mode, prompt string) string {
+	return fmt.Sprintf("vlm:%s:%s:%s:%s",
+		sha256Hex(imageBytes),
+		strings.TrimSpace(modelID),
+		mode,
+		sha256StringHex(prompt),
+	)
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func sha256StringHex(s string) string {
+	return sha256Hex([]byte(s))
 }
 
 // ImageMultimodalService handles image:multimodal asynq tasks.
@@ -73,6 +101,8 @@ type ImageMultimodalService struct {
 	ollamaService  *ollama.OllamaService
 	taskEnqueuer   interfaces.TaskEnqueuer
 	redisClient    *redis.Client
+
+	contentCacheRepo interfaces.ContentCacheRepository
 	// fileSvc is the globally configured default FileService used as a fallback
 	// when the tenant-scoped storage config cannot produce a usable service
 	// (e.g. images were saved using the global MINIO_* env vars while the
@@ -101,26 +131,28 @@ func NewImageMultimodalService(
 	ollamaService *ollama.OllamaService,
 	taskEnqueuer interfaces.TaskEnqueuer,
 	redisClient *redis.Client,
+	contentCacheRepo interfaces.ContentCacheRepository,
 	fileSvc interfaces.FileService,
 	storageResolver interfaces.StorageBackendResolver,
 	resourceCatalog interfaces.ResourceCatalog,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
 	return &ImageMultimodalService{
-		chunkService:    chunkService,
-		modelService:    modelService,
-		kbService:       kbService,
-		knowledgeRepo:   knowledgeRepo,
-		tenantRepo:      tenantRepo,
-		retrieveEngine:  retrieveEngine,
-		ownership:       ownership,
-		ollamaService:   ollamaService,
-		taskEnqueuer:    taskEnqueuer,
-		redisClient:     redisClient,
-		fileSvc:         fileSvc,
-		storageResolver: storageResolver,
-		resourceCatalog: resourceCatalog,
-		spanTracker:     spanTracker,
+		chunkService:     chunkService,
+		modelService:     modelService,
+		kbService:        kbService,
+		knowledgeRepo:    knowledgeRepo,
+		tenantRepo:       tenantRepo,
+		retrieveEngine:   retrieveEngine,
+		ownership:        ownership,
+		ollamaService:    ollamaService,
+		taskEnqueuer:     taskEnqueuer,
+		redisClient:      redisClient,
+		contentCacheRepo: contentCacheRepo,
+		fileSvc:          fileSvc,
+		storageResolver:  storageResolver,
+		resourceCatalog:  resourceCatalog,
+		spanTracker:      spanTracker,
 	}
 }
 
@@ -131,6 +163,54 @@ func (s *ImageMultimodalService) tracker() SpanTracker {
 		return noopSpanTracker{}
 	}
 	return s.spanTracker
+}
+
+func (s *ImageMultimodalService) getOrComputeVLMResult(
+	ctx context.Context,
+	tenantID uint64,
+	cacheKind string,
+	mode string,
+	modelID string,
+	imageBytes []byte,
+	prompt string,
+	compute func() (string, error),
+) (string, bool, error) {
+	key := vlmCacheKey(imageBytes, modelID, mode, prompt)
+	if s.contentCacheRepo != nil {
+		entry, err := s.contentCacheRepo.GetByKey(ctx, tenantID, cacheKind, key)
+		if err != nil {
+			logger.Warnf(ctx, "[ImageMultimodal] VLM cache get failed kind=%s mode=%s: %v", cacheKind, mode, err)
+		} else if entry != nil {
+			var cached string
+			if err := json.Unmarshal(entry.Payload, &cached); err != nil {
+				logger.Warnf(ctx, "[ImageMultimodal] VLM cache decode failed kind=%s mode=%s: %v", cacheKind, mode, err)
+			} else {
+				return cached, true, nil
+			}
+		}
+	}
+
+	result, err := compute()
+	if err != nil {
+		return "", false, err
+	}
+	if s.contentCacheRepo == nil {
+		return result, false, nil
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		logger.Warnf(ctx, "[ImageMultimodal] VLM cache encode failed kind=%s mode=%s: %v", cacheKind, mode, err)
+		return result, false, nil
+	}
+	if err := s.contentCacheRepo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  tenantID,
+		CacheKind: cacheKind,
+		CacheKey:  key,
+		Payload:   types.JSON(payload),
+	}); err != nil {
+		logger.Warnf(ctx, "[ImageMultimodal] VLM cache upsert failed kind=%s mode=%s: %v", cacheKind, mode, err)
+	}
+	return result, false, nil
 }
 
 // Handle implements asynq handler for TypeImageMultimodal.
@@ -268,12 +348,27 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 		prompt = types.AppendCustomPromptInstructions(prompt, vlmCfg.CustomInstructions, "image_ocr")
 
-		ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt)
+		ocrText, cacheHit, ocrErr := s.getOrComputeVLMResult(
+			ctx,
+			payload.TenantID,
+			types.ContentCacheKindImageOCR,
+			vlmCacheModeOCR,
+			resolvedVLMCacheModelID(vlmCfg),
+			imgBytes,
+			prompt,
+			func() (string, error) {
+				text, err := vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt)
+				if err != nil {
+					return "", err
+				}
+				return sanitizeOCRText(text), nil
+			},
+		)
 		if ocrErr != nil {
 			logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
 			imgOut["ocr_error"] = ocrErr.Error()
 		} else {
-			ocrText = sanitizeOCRText(ocrText)
+			imgOut["ocr_cache_hit"] = cacheHit
 			if ocrText != "" {
 				imageInfo.OCRText = ocrText
 				imgOut["ocr_chars"] = len([]rune(ocrText))
@@ -286,14 +381,29 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 	}
 
-	caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, buildVLMCaptionPrompt(ctx, vlmCfg))
+	captionPrompt := buildVLMCaptionPrompt(ctx, vlmCfg)
+	caption, captionCacheHit, capErr := s.getOrComputeVLMResult(
+		ctx,
+		payload.TenantID,
+		types.ContentCacheKindImageCaption,
+		vlmCacheModeCaption,
+		resolvedVLMCacheModelID(vlmCfg),
+		imgBytes,
+		captionPrompt,
+		func() (string, error) {
+			return vlmModel.Predict(ctx, [][]byte{imgBytes}, captionPrompt)
+		},
+	)
 	if capErr != nil {
 		logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
 		imgOut["caption_error"] = capErr.Error()
-	} else if caption != "" {
-		imageInfo.Caption = caption
-		imgOut["caption_chars"] = len([]rune(caption))
-		imgOut["caption_preview"] = previewText(caption, 200)
+	} else {
+		imgOut["caption_cache_hit"] = captionCacheHit
+		if caption != "" {
+			imageInfo.Caption = caption
+			imgOut["caption_chars"] = len([]rune(caption))
+			imgOut["caption_preview"] = previewText(caption, 200)
+		}
 	}
 
 	// Build child chunks for OCR and caption results
@@ -302,7 +412,13 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 
 	if imageInfo.OCRText != "" {
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID: types.StableImageChildChunkID(
+				payload.TenantID,
+				payload.KnowledgeID,
+				payload.ChunkID,
+				types.ChunkTypeImageOCR,
+				imageInfo.OCRText,
+			),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
@@ -319,7 +435,13 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 
 	if imageInfo.Caption != "" {
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID: types.StableImageChildChunkID(
+				payload.TenantID,
+				payload.KnowledgeID,
+				payload.ChunkID,
+				types.ChunkTypeImageCaption,
+				imageInfo.Caption,
+			),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
@@ -342,6 +464,10 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 	}
 
 	// Persist chunks
+	if err := s.chunkService.GetRepository().PurgeSoftDeletedByKnowledgeID(ctx, payload.TenantID, payload.KnowledgeID); err != nil {
+		handleErr = fmt.Errorf("purge soft-deleted multimodal chunks: %w", err)
+		return handleErr
+	}
 	if err := s.chunkService.CreateChunks(ctx, newChunks); err != nil {
 		handleErr = fmt.Errorf("create multimodal chunks: %w", err)
 		return handleErr

--- a/internal/application/service/image_multimodal_cache_test.go
+++ b/internal/application/service/image_multimodal_cache_test.go
@@ -1,0 +1,151 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVLMCacheSecondPassSkipsCompute(t *testing.T) {
+	ctx := context.Background()
+	svc := &ImageMultimodalService{contentCacheRepo: newFakeContentCacheRepo()}
+	calls := 0
+	compute := func() (string, error) {
+		calls++
+		return "caption", nil
+	}
+
+	first, hit, err := svc.getOrComputeVLMResult(
+		ctx, 1, types.ContentCacheKindImageCaption, vlmCacheModeCaption, "vlm-a", []byte("image"), "prompt", compute,
+	)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, "caption", first)
+
+	second, hit, err := svc.getOrComputeVLMResult(
+		ctx, 1, types.ContentCacheKindImageCaption, vlmCacheModeCaption, "vlm-a", []byte("image"), "prompt", compute,
+	)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, "caption", second)
+	assert.Equal(t, 1, calls)
+}
+
+func TestVLMCacheOCRAndCaptionAreIndependent(t *testing.T) {
+	ctx := context.Background()
+	svc := &ImageMultimodalService{contentCacheRepo: newFakeContentCacheRepo()}
+	ocrCalls := 0
+	captionCalls := 0
+
+	_, _, err := svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-a", []byte("image"), "prompt", func() (string, error) {
+			ocrCalls++
+			return "ocr", nil
+		})
+	require.NoError(t, err)
+	_, _, err = svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageCaption, vlmCacheModeCaption,
+		"vlm-a", []byte("image"), "prompt", func() (string, error) {
+			captionCalls++
+			return "caption", nil
+		})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, ocrCalls)
+	assert.Equal(t, 1, captionCalls)
+}
+
+func TestVLMCacheInvalidatesOnImageModelAndPrompt(t *testing.T) {
+	ctx := context.Background()
+	svc := &ImageMultimodalService{contentCacheRepo: newFakeContentCacheRepo()}
+	calls := 0
+	compute := func() (string, error) {
+		calls++
+		return "ocr", nil
+	}
+
+	_, _, err := svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-a", []byte("image-a"), "prompt-a", compute)
+	require.NoError(t, err)
+	_, _, err = svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-a", []byte("image-b"), "prompt-a", compute)
+	require.NoError(t, err)
+	_, _, err = svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-b", []byte("image-a"), "prompt-a", compute)
+	require.NoError(t, err)
+	_, _, err = svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-a", []byte("image-a"), "prompt-b", compute)
+	require.NoError(t, err)
+
+	assert.Equal(t, 4, calls)
+}
+
+func TestVLMCacheDoesNotWriteErrors(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeContentCacheRepo()
+	svc := &ImageMultimodalService{contentCacheRepo: repo}
+	calls := 0
+
+	_, _, err := svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-a", []byte("image"), "prompt", func() (string, error) {
+			calls++
+			return "", errors.New("vlm failed")
+		})
+	require.Error(t, err)
+	assert.Empty(t, repo.entries)
+
+	got, hit, err := svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-a", []byte("image"), "prompt", func() (string, error) {
+			calls++
+			return "ocr", nil
+		})
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, "ocr", got)
+	assert.Equal(t, 2, calls)
+}
+
+func TestVLMCacheStoresEmptySuccess(t *testing.T) {
+	ctx := context.Background()
+	svc := &ImageMultimodalService{contentCacheRepo: newFakeContentCacheRepo()}
+	calls := 0
+	compute := func() (string, error) {
+		calls++
+		return "", nil
+	}
+
+	_, hit, err := svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageCaption, vlmCacheModeCaption,
+		"vlm-a", []byte("image"), "prompt", compute)
+	require.NoError(t, err)
+	assert.False(t, hit)
+
+	got, hit, err := svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageCaption, vlmCacheModeCaption,
+		"vlm-a", []byte("image"), "prompt", compute)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Empty(t, got)
+	assert.Equal(t, 1, calls)
+}
+
+func TestVLMCacheFallsBackOnCacheErrors(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeContentCacheRepo()
+	repo.getErr = errors.New("cache read failed")
+	repo.upsertErr = errors.New("cache write failed")
+	svc := &ImageMultimodalService{contentCacheRepo: repo}
+	calls := 0
+
+	got, hit, err := svc.getOrComputeVLMResult(ctx, 1, types.ContentCacheKindImageOCR, vlmCacheModeOCR,
+		"vlm-a", []byte("image"), "prompt", func() (string, error) {
+			calls++
+			return "ocr", nil
+		})
+
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Equal(t, "ocr", got)
+	assert.Equal(t, 1, calls)
+}

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -66,6 +66,8 @@ type knowledgeService struct {
 	imageResolver   *docparser.ImageResolver
 	taskPendingRepo interfaces.TaskPendingOpsRepository
 
+	contentCacheRepo interfaces.ContentCacheRepository
+
 	// In-memory fallbacks for Lite mode (no Redis)
 	memFAQProgress      sync.Map // taskID -> *types.FAQImportProgress
 	memFAQRunningImport sync.Map // kbID -> *runningFAQImportInfo
@@ -96,6 +98,7 @@ func NewKnowledgeService(
 	tenantService interfaces.TenantService,
 	chunkService interfaces.ChunkService,
 	chunkRepo interfaces.ChunkRepository,
+	contentCacheRepo interfaces.ContentCacheRepository,
 	tagRepo interfaces.KnowledgeTagRepository,
 	tagService interfaces.KnowledgeTagService,
 	fileSvc interfaces.FileService,
@@ -144,6 +147,8 @@ func NewKnowledgeService(
 		taskPendingRepo: taskPendingRepo,
 		spanTracker:     spanTracker,
 		audit:           audit,
+
+		contentCacheRepo: contentCacheRepo,
 	}, nil
 }
 

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -840,9 +840,17 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 	}
 
 	// Generate summary using AI model
+	langName := types.LanguageNameFromContext(ctx)
 	summaryPrompt := types.RenderPromptPlaceholders(s.config.Conversation.GenerateSummaryPrompt, types.PlaceholderValues{
-		"language": types.LanguageNameFromContext(ctx),
+		"language": langName,
 	})
+	cacheKey := summaryCacheKey(knowledge.ID, contentWithMetadata, summaryModel, summaryPrompt, langName, maxInputChars, maxTokens)
+	var cachedSummary string
+	if getContentCacheJSON(ctx, s.contentCacheRepo, knowledge.TenantID, types.ContentCacheKindSummary, cacheKey, &cachedSummary) {
+		logger.GetLogger(ctx).WithField("summary", cachedSummary).Infof("GetSummary cache hit")
+		return cachedSummary, nil
+	}
+
 	thinking := false
 	modelCtx := types.WithLLMCallMetadata(ctx, "document_summary", "")
 	summary, err := summaryModel.Chat(modelCtx, []chat.Message{
@@ -864,6 +872,7 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 		return "", err
 	}
 	logger.GetLogger(ctx).WithField("summary", summary.Content).Infof("GetSummary success")
+	setContentCacheJSON(ctx, s.contentCacheRepo, knowledge.TenantID, types.ContentCacheKindSummary, cacheKey, summary.Content)
 	return summary.Content, nil
 }
 
@@ -1536,7 +1545,7 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 		// Update chunk metadata with unique IDs for each question
 		generatedQuestions := make([]types.GeneratedQuestion, len(questions))
 		for j, question := range questions {
-			questionID := fmt.Sprintf("q%d", time.Now().UnixNano()+int64(j))
+			questionID := types.StableGeneratedQuestionID(chunk.ID, question)
 			generatedQuestions[j] = types.GeneratedQuestion{
 				ID:       questionID,
 				Question: question,
@@ -1865,7 +1874,7 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 		generatedQuestions := make([]types.GeneratedQuestion, len(questions))
 		for j, question := range questions {
 			generatedQuestions[j] = types.GeneratedQuestion{
-				ID:       fmt.Sprintf("q%d", time.Now().UnixNano()+int64(j)),
+				ID:       types.StableGeneratedQuestionID(chunk.ID, question),
 				Question: question,
 			}
 		}
@@ -1943,6 +1952,13 @@ func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
 	})
 	prompt = types.AppendCustomPromptInstructions(prompt, customInstructions, "question_generation")
 
+	cacheKey := questionCacheKey(
+		content, prevContent, nextContent, docName, chatModel, prompt, customInstructions, langName, questionCount)
+	var cachedQuestions []string
+	if getContentCacheJSON(ctx, s.contentCacheRepo, tenantIDFromContext(ctx), types.ContentCacheKindQuestion, cacheKey, &cachedQuestions) {
+		return cachedQuestions, nil
+	}
+
 	thinking := false
 	modelCtx := types.WithLLMCallMetadata(ctx, "question_generation", "")
 	response, err := chatModel.Chat(modelCtx, []chat.Message{
@@ -1977,6 +1993,7 @@ func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
 		}
 	}
 
+	setContentCacheJSON(ctx, s.contentCacheRepo, tenantIDFromContext(ctx), types.ContentCacheKindQuestion, cacheKey, questions)
 	return questions, nil
 }
 

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -383,17 +383,20 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	}
 
 	// === Parent-Child Chunking: create parent chunks first ===
+	chunkIDAllocator := types.NewChunkIDAllocator(knowledge.TenantID, knowledge.ID)
 	hasParentChild := len(options.ParentChunks) > 0
 	var parentDBChunks []*types.Chunk // indexed by ParsedParentChunk position
 	if hasParentChild {
 		parentDBChunks = make([]*types.Chunk, len(options.ParentChunks))
 		for i, pc := range options.ParentChunks {
+			chunkID, contentHash := chunkIDAllocator.Allocate(types.ChunkTypeParentText, pc.Content, "")
 			parentDBChunks[i] = &types.Chunk{
-				ID:              uuid.New().String(),
+				ID:              chunkID,
 				TenantID:        knowledge.TenantID,
 				KnowledgeID:     knowledge.ID,
 				KnowledgeBaseID: knowledge.KnowledgeBaseID,
 				Content:         pc.Content,
+				ContentHash:     contentHash,
 				ChunkIndex:      pc.Seq,
 				IsEnabled:       true,
 				CreatedAt:       time.Now(),
@@ -427,13 +430,15 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		}
 
 		// 创建主文本Chunk
+		chunkID, contentHash := chunkIDAllocator.Allocate(types.ChunkTypeText, chunkData.Content, chunkData.ContextHeader)
 		textChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              chunkID,
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
 			Content:         chunkData.Content,
 			ContextHeader:   chunkData.ContextHeader,
+			ContentHash:     contentHash,
 			ChunkIndex:      int(chunkData.Seq),
 			IsEnabled:       true,
 			CreatedAt:       time.Now(),
@@ -494,6 +499,15 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	s.beginStage(ctx, knowledge.ID, types.StageChunking, types.JSONMap{
 		"chunks_planned": len(insertChunks),
 	})
+	if err := s.chunkService.GetRepository().PurgeSoftDeletedByKnowledgeID(ctx, knowledge.TenantID, knowledge.ID); err != nil {
+		knowledge.ParseStatus = types.ParseStatusFailed
+		knowledge.ErrorMessage = err.Error()
+		knowledge.UpdatedAt = time.Now()
+		s.repo.UpdateKnowledge(ctx, knowledge)
+		s.failStage(ctx, knowledge.ID, types.StageChunking,
+			werrors.ErrCodeChunkingFailed, "purge soft-deleted chunks failed", err)
+		return
+	}
 	if err := s.chunkService.CreateChunks(ctx, insertChunks); err != nil {
 		knowledge.ParseStatus = types.ParseStatusFailed
 		knowledge.ErrorMessage = err.Error()

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -283,6 +283,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks get embedding model failed")
 			return
 		}
+		embeddingModel = withEmbeddingCache(embeddingModel, s.contentCacheRepo, knowledge.TenantID)
 	} else {
 		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping embedding model", kb.ID)
 	}

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -320,17 +320,18 @@ type WikiPendingOp struct {
 // both of which are correctness-critical short-lived flags rather
 // than data the system should survive without.
 type wikiIngestService struct {
-	wikiService    interfaces.WikiPageService
-	kbService      interfaces.KnowledgeBaseService
-	knowledgeSvc   interfaces.KnowledgeService
-	knowledgeRepo  interfaces.KnowledgeRepository
-	chunkRepo      interfaces.ChunkRepository
-	modelService   interfaces.ModelService
-	task           interfaces.TaskEnqueuer
-	logEntrySvc    interfaces.WikiLogEntryService
-	pendingRepo    interfaces.TaskPendingOpsRepository
-	deadLetterRepo interfaces.TaskDeadLetterRepository
-	redisClient    *redis.Client // nil in Lite mode (no Redis)
+	wikiService      interfaces.WikiPageService
+	kbService        interfaces.KnowledgeBaseService
+	knowledgeSvc     interfaces.KnowledgeService
+	knowledgeRepo    interfaces.KnowledgeRepository
+	chunkRepo        interfaces.ChunkRepository
+	modelService     interfaces.ModelService
+	task             interfaces.TaskEnqueuer
+	logEntrySvc      interfaces.WikiLogEntryService
+	pendingRepo      interfaces.TaskPendingOpsRepository
+	deadLetterRepo   interfaces.TaskDeadLetterRepository
+	contentCacheRepo interfaces.ContentCacheRepository
+	redisClient      *redis.Client // nil in Lite mode (no Redis)
 	// spanTracker lets per-document map work surface as a
 	// postprocess.wiki subspan in the knowledge trace tree. Async
 	// batch design means we look up the parent attempt by knowledge
@@ -370,22 +371,24 @@ func NewWikiIngestService(
 	logEntrySvc interfaces.WikiLogEntryService,
 	pendingRepo interfaces.TaskPendingOpsRepository,
 	deadLetterRepo interfaces.TaskDeadLetterRepository,
+	contentCacheRepo interfaces.ContentCacheRepository,
 	redisClient *redis.Client,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
 	svc := &wikiIngestService{
-		wikiService:    wikiService,
-		kbService:      kbService,
-		knowledgeSvc:   knowledgeSvc,
-		knowledgeRepo:  knowledgeRepo,
-		chunkRepo:      chunkRepo,
-		modelService:   modelService,
-		task:           task,
-		logEntrySvc:    logEntrySvc,
-		pendingRepo:    pendingRepo,
-		deadLetterRepo: deadLetterRepo,
-		redisClient:    redisClient,
-		spanTracker:    spanTracker,
+		wikiService:      wikiService,
+		kbService:        kbService,
+		knowledgeSvc:     knowledgeSvc,
+		knowledgeRepo:    knowledgeRepo,
+		chunkRepo:        chunkRepo,
+		modelService:     modelService,
+		task:             task,
+		logEntrySvc:      logEntrySvc,
+		pendingRepo:      pendingRepo,
+		deadLetterRepo:   deadLetterRepo,
+		contentCacheRepo: contentCacheRepo,
+		redisClient:      redisClient,
+		spanTracker:      spanTracker,
 	}
 	return svc
 }

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -1272,6 +1272,28 @@ func (s *wikiIngestService) mapOneDocument(
 	// surface during wiki page editing.
 	sourceRef := knowledgeID
 	oldPageSlugs := s.getExistingPageSlugsForKnowledge(ctx, payload.KnowledgeBaseID, knowledgeID)
+	cacheKey := wikiMapCacheKey(knowledgeID, content, chatModel, lang, batchCtx)
+	if cached, hit := s.getCachedWikiDocumentMap(ctx, payload.TenantID, cacheKey); hit {
+		result, updates := cached.buildResultAndUpdates(
+			ctx,
+			batchCtx,
+			knowledgeID,
+			docTitle,
+			sourceRef,
+			content,
+			oldPageSlugs,
+			wikiSpan,
+			true,
+			len(chunks),
+			lang,
+		)
+		logger.Infof(ctx,
+			"wiki ingest: wiki map cache hit knowledge %s title=%q candidates=%d chunks=%d updates=%d elapsed=%s",
+			knowledgeID, previewText(docTitle, 80), result.MapStats["candidate_slugs"], len(chunks), len(updates),
+			time.Since(docStartedAt).Round(time.Millisecond),
+		)
+		return result, updates, nil
+	}
 
 	// Pass 0: lightweight candidate slug extraction (skeleton only).
 	// On failure we fall back to the legacy single-shot extractor so the doc
@@ -1312,12 +1334,6 @@ func (s *wikiIngestService) mapOneDocument(
 	for slug := range slugItems {
 		summaryExtractedPages = append(summaryExtractedPages, slug)
 	}
-	// Wiki summary slug is derived from the knowledge ID rather than the
-	// docTitle (which is typically the upload filename). Filename-based slugs
-	// like "summary/mx5280-pdf" expose the filename in cross-link contexts
-	// that downstream LLM prompts read; a UUID-based slug is uglier but
-	// hallucination-safe.
-	summarySlug := fmt.Sprintf("summary/%s", slugify(knowledgeID))
 	var slugListing string
 	for _, slug := range summaryExtractedPages {
 		if item, ok := slugItems[slug]; ok {
@@ -1420,36 +1436,6 @@ func (s *wikiIngestService) mapOneDocument(
 		}
 	}
 
-	// extractedPages records every wiki page this document materialized
-	// (entities, concepts, plus the summary page appended below). The
-	// slug is used for link/retract bookkeeping; the title is captured
-	// for the log feed so the user sees "提供本学位在线验证报告查询…"
-	// rather than "entity/xue-xin-wang".
-	extractedPages := make([]types.WikiLogPageRef, 0, len(slugItems)+1)
-	for slug, item := range slugItems {
-		title := item.Name
-		if title == "" {
-			title = slug
-		}
-		extractedPages = append(extractedPages, types.WikiLogPageRef{Slug: slug, Title: title})
-	}
-
-	// Count total distinct chunks cited across all slugs for logging.
-	citedChunkSet := make(map[string]bool)
-	for _, ids := range citations {
-		for _, id := range ids {
-			citedChunkSet[id] = true
-		}
-	}
-
-	var updates []SlugUpdate
-	// docSummaryLine is the one-sentence headline used for terse log/audit
-	// previews and for <document_added> blocks in retract prompts.
-	// docSummary is the full summary body attached to each entity/concept
-	// update so the editor model gets rich framing in <source_context>.
-	var docSummaryLine string
-	var docSummary string
-
 	if summaryErr != nil {
 		// Summary is the headline artifact of an ingested document — a
 		// document with no summary page is half-ingested and leaves the
@@ -1467,170 +1453,46 @@ func (s *wikiIngestService) mapOneDocument(
 		s.tracker().FailSpan(ctx, wikiSpan, "SUMMARY_FAILED", summaryErr.Error(), summaryErr)
 		return nil, nil, fmt.Errorf("generate summary: %w", summaryErr)
 	}
-	sumLine, sumBody := splitSummaryLine(summaryContent)
-	if sumBody == "" {
-		sumBody = summaryContent
-	}
-	if sumLine == "" {
-		sumLine = docTitle
-	}
-	docSummaryLine = sumLine
-	docSummary = sumBody
-	if strings.TrimSpace(docSummary) == "" {
-		docSummary = sumLine
-	}
-	updates = append(updates, SlugUpdate{
-		Slug:        summarySlug,
-		Type:        types.WikiPageTypeSummary,
-		DocTitle:    docTitle,
-		KnowledgeID: knowledgeID,
-		SourceRef:   sourceRef,
-		Language:    lang,
-		SummaryLine: sumLine,
-		SummaryBody: sumBody,
-	})
-	extractedPages = append(extractedPages, types.WikiLogPageRef{Slug: summarySlug, Title: docTitle})
 
-	// Entities
-	for _, item := range extractedEntities {
-		if item.Slug != "" {
-			updates = append(updates, SlugUpdate{
-				Slug:         item.Slug,
-				Type:         types.WikiPageTypeEntity,
-				Item:         item,
-				DocTitle:     docTitle,
-				KnowledgeID:  knowledgeID,
-				SourceRef:    sourceRef,
-				Language:     lang,
-				SourceChunks: item.SourceChunks,
-				DocSummary:   docSummary,
-			})
+	citedChunkSet := make(map[string]bool)
+	for _, ids := range citations {
+		for _, id := range ids {
+			citedChunkSet[id] = true
 		}
 	}
-
-	// Concepts
-	for _, item := range extractedConcepts {
-		if item.Slug != "" {
-			updates = append(updates, SlugUpdate{
-				Slug:         item.Slug,
-				Type:         types.WikiPageTypeConcept,
-				Item:         item,
-				DocTitle:     docTitle,
-				KnowledgeID:  knowledgeID,
-				SourceRef:    sourceRef,
-				Language:     lang,
-				SourceChunks: item.SourceChunks,
-				DocSummary:   docSummary,
-			})
-		}
+	mapPayload := &wikiDocumentMapCachePayload{
+		KnowledgeID:        knowledgeID,
+		SummaryContent:     summaryContent,
+		Entities:           extractedEntities,
+		Concepts:           extractedConcepts,
+		Uncited:            uncited,
+		NewSlugCount:       len(newSlugs),
+		Pass0Failed:        pass0Failed,
+		ClassifyBatchCount: batchCount,
 	}
-
-	// Reconcile old page set against new extraction.
-	//
-	// Three cases:
-	//
-	//  (a) oldSlug ∉ new  → "retractStale": the doc no longer mentions this
-	//      page's subject, so strip its ref (and possibly delete the page
-	//      if this was the only source). Passes the NEW content as the
-	//      retract context — if the LLM finds matching facts it trims
-	//      them, otherwise the retract is a near no-op, which is fine.
-	//
-	//  (b) oldSlug ∈ new AND slug is an entity/concept page  → reparse
-	//      swap: emit BOTH a "retract" (carrying the doc's PRIOR summary
-	//      body as the old-version signal) AND the normal addition. The
-	//      reduce stage sees HasAdditions=1 + HasRetractions=1 and the
-	//      WikiPageModifyUserPrompt correctly tells the editor model to
-	//      remove the old K section and add the new K section in one
-	//      pass — giving us replace-not-append semantics that "append
-	//      new K on top of old K" would otherwise violate.
-	//
-	//  (c) oldSlug ∈ new AND slug is a summary page (summary/...) →
-	//      nothing to do here. reduceSlugUpdates' summary branch
-	//      unconditionally overwrites the whole page from the new
-	//      SummaryBody, so emitting an extra retract would just be
-	//      dead weight that the summary branch discards anyway.
-	//
-	// priorContribution is the doc's LAST summary body, fetched lazily
-	// at this point (rather than pre-loaded into the batch context).
-	// Empty on first-ever ingest — in that case oldPageSlugs is also
-	// empty, so we never consult it.
-	priorContribution := batchCtx.SummaryContentByKnowledgeID(ctx, knowledgeID)
-
-	newSlugSet := make(map[string]bool, len(extractedPages))
-	for _, ns := range extractedPages {
-		newSlugSet[ns.Slug] = true
-	}
-
-	var reparseOverlap, staleCount int
-	for oldSlug := range oldPageSlugs {
-		if newSlugSet[oldSlug] {
-			// Skip summary slugs — they're overwritten wholesale by the
-			// summary update, retract would be ignored downstream.
-			if strings.HasPrefix(oldSlug, "summary/") {
-				continue
-			}
-			reparseOverlap++
-			updates = append(updates, SlugUpdate{
-				Slug:              oldSlug,
-				Type:              "retract",
-				RetractDocContent: priorContribution,
-				DocTitle:          docTitle,
-				KnowledgeID:       knowledgeID,
-				Language:          lang,
-			})
-			continue
-		}
-		staleCount++
-		updates = append(updates, SlugUpdate{
-			Slug:              oldSlug,
-			Type:              "retractStale",
-			RetractDocContent: content,
-			DocTitle:          docTitle,
-			KnowledgeID:       knowledgeID,
-			Language:          lang,
-		})
-	}
+	result, updates := mapPayload.buildResultAndUpdates(
+		ctx,
+		batchCtx,
+		knowledgeID,
+		docTitle,
+		sourceRef,
+		content,
+		oldPageSlugs,
+		wikiSpan,
+		false,
+		len(chunks),
+		lang,
+	)
+	s.setCachedWikiDocumentMap(ctx, payload.TenantID, cacheKey, mapPayload)
 
 	logger.Infof(ctx,
 		"wiki ingest: mapped knowledge %s title=%q candidates=%d chunks=%d batches=%d cited_chunks=%d uncited_slugs=%d new_slugs=%d updates=%d reparse_slugs=%d stale_slugs=%d pass0_fallback=%v elapsed=%s",
 		knowledgeID, previewText(docTitle, 80),
 		len(slugItems), len(chunks), batchCount, len(citedChunkSet), uncited, len(newSlugs),
-		len(updates), reparseOverlap, staleCount, pass0Failed,
+		len(updates), result.MapStats["reparse_slugs"], result.MapStats["stale_slugs"], pass0Failed,
 		time.Since(docStartedAt).Round(time.Millisecond),
 	)
-
-	// Map-phase metrics get attached to the postprocess.wiki span's
-	// output, but we do NOT EndSpan here — the batch driver keeps the
-	// span open through reduce + index rebuild + cross-link injection
-	// + page publish, then closes it once this doc's pages have all
-	// been written. That way the span's duration reflects the full
-	// "wiki processing for this knowledge" time the user sees in the
-	// trace viewer, not just the LLM extraction slice.
-	mapStats := types.JSONMap{
-		"doc_title":        previewText(docTitle, 120),
-		"chunks":           len(chunks),
-		"candidate_slugs":  len(slugItems),
-		"cited_chunks":     len(citedChunkSet),
-		"uncited_slugs":    uncited,
-		"new_slugs":        len(newSlugs),
-		"updates":          len(updates),
-		"reparse_slugs":    reparseOverlap,
-		"stale_slugs":      staleCount,
-		"extracted_pages":  len(extractedPages),
-		"summary_chars":    utf8.RuneCountInString(docSummary),
-		"pass0_fallback":   pass0Failed,
-		"classify_batches": batchCount,
-		"summary_preview":  previewText(docSummaryLine, 160),
-	}
-
-	return &docIngestResult{
-		KnowledgeID: knowledgeID,
-		DocTitle:    docTitle,
-		Summary:     docSummaryLine,
-		Pages:       extractedPages,
-		MapStats:    mapStats,
-		WikiSpan:    wikiSpan,
-	}, updates, nil
+	return result, updates, nil
 }
 
 func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(

--- a/internal/application/service/wiki_ingest_map_cache.go
+++ b/internal/application/service/wiki_ingest_map_cache.go
@@ -1,0 +1,294 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/Tencent/WeKnora/internal/agent"
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+type wikiDocumentMapCachePayload struct {
+	KnowledgeID        string          `json:"knowledge_id"`
+	SummaryContent     string          `json:"summary_content"`
+	Entities           []extractedItem `json:"entities"`
+	Concepts           []extractedItem `json:"concepts"`
+	Uncited            int             `json:"uncited"`
+	NewSlugCount       int             `json:"new_slug_count"`
+	Pass0Failed        bool            `json:"pass0_failed"`
+	ClassifyBatchCount int             `json:"classify_batch_count"`
+}
+
+func wikiMapChatModelID(chatModel chat.Chat) string {
+	if chatModel == nil {
+		return "unknown"
+	}
+	if id := strings.TrimSpace(chatModel.GetModelID()); id != "" {
+		return id
+	}
+	if name := strings.TrimSpace(chatModel.GetModelName()); name != "" {
+		return name
+	}
+	return "unknown"
+}
+
+func wikiMapPromptBundleHash() string {
+	return types.ContentHash(strings.Join([]string{
+		agent.WikiCandidateSlugPrompt,
+		agent.WikiChunkCitationPrompt,
+		agent.WikiSummaryPrompt,
+		agent.WikiKnowledgeExtractPrompt,
+		agent.WikiDeduplicationPrompt,
+	}, "\x00"), "")
+}
+
+func wikiMapCacheKey(
+	knowledgeID string,
+	content string,
+	chatModel chat.Chat,
+	lang string,
+	batchCtx *WikiBatchContext,
+) string {
+	granularity := types.WikiExtractionStandard
+	contentInstructions := ""
+	extractionInstructions := ""
+	if batchCtx != nil {
+		granularity = batchCtx.ExtractionGranularity.Normalize()
+		contentInstructions = batchCtx.ContentInstructions
+		extractionInstructions = batchCtx.ExtractionInstructions
+	}
+	identity := strings.Join([]string{
+		knowledgeID,
+		types.ContentHash(content, ""),
+		wikiMapChatModelID(chatModel),
+		string(granularity),
+		strings.TrimSpace(lang),
+		types.ContentHash(contentInstructions, ""),
+		types.ContentHash(extractionInstructions, ""),
+		wikiMapPromptBundleHash(),
+	}, "\x00")
+	return fmt.Sprintf("wiki_map:%s:%s", knowledgeID, types.ContentHash(identity, ""))
+}
+
+func (s *wikiIngestService) getCachedWikiDocumentMap(
+	ctx context.Context,
+	tenantID uint64,
+	cacheKey string,
+) (*wikiDocumentMapCachePayload, bool) {
+	if s.contentCacheRepo == nil {
+		return nil, false
+	}
+	entry, err := s.contentCacheRepo.GetByKey(ctx, tenantID, types.ContentCacheKindWikiMap, cacheKey)
+	if err != nil {
+		logger.Warnf(ctx, "wiki ingest: wiki map cache get failed: %v", err)
+		return nil, false
+	}
+	if entry == nil {
+		return nil, false
+	}
+	var payload wikiDocumentMapCachePayload
+	if err := json.Unmarshal(entry.Payload, &payload); err != nil {
+		logger.Warnf(ctx, "wiki ingest: wiki map cache decode failed: %v", err)
+		return nil, false
+	}
+	return &payload, true
+}
+
+func (s *wikiIngestService) setCachedWikiDocumentMap(
+	ctx context.Context,
+	tenantID uint64,
+	cacheKey string,
+	payload *wikiDocumentMapCachePayload,
+) {
+	if s.contentCacheRepo == nil || payload == nil {
+		return
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		logger.Warnf(ctx, "wiki ingest: wiki map cache encode failed: %v", err)
+		return
+	}
+	if err := s.contentCacheRepo.Upsert(ctx, &types.ContentCacheEntry{
+		TenantID:  tenantID,
+		CacheKind: types.ContentCacheKindWikiMap,
+		CacheKey:  cacheKey,
+		Payload:   types.JSON(data),
+	}); err != nil {
+		logger.Warnf(ctx, "wiki ingest: wiki map cache upsert failed: %v", err)
+	}
+}
+
+func (p *wikiDocumentMapCachePayload) buildResultAndUpdates(
+	ctx context.Context,
+	batchCtx *WikiBatchContext,
+	knowledgeID string,
+	docTitle string,
+	sourceRef string,
+	content string,
+	oldPageSlugs map[string]bool,
+	wikiSpan *Span,
+	cacheHit bool,
+	chunkCount int,
+	lang string,
+) (*docIngestResult, []SlugUpdate) {
+	summarySlug := fmt.Sprintf("summary/%s", slugify(knowledgeID))
+	sumLine, sumBody := splitSummaryLine(p.SummaryContent)
+	if sumBody == "" {
+		sumBody = p.SummaryContent
+	}
+	if sumLine == "" {
+		sumLine = docTitle
+	}
+	docSummaryLine := sumLine
+	docSummary := sumBody
+	if strings.TrimSpace(docSummary) == "" {
+		docSummary = sumLine
+	}
+
+	slugItems := make(map[string]extractedItem, len(p.Entities)+len(p.Concepts))
+	for _, item := range p.Entities {
+		if item.Slug != "" && item.Name != "" {
+			slugItems[item.Slug] = item
+		}
+	}
+	for _, item := range p.Concepts {
+		if item.Slug != "" && item.Name != "" {
+			slugItems[item.Slug] = item
+		}
+	}
+
+	extractedPages := make([]types.WikiLogPageRef, 0, len(slugItems)+1)
+	for slug, item := range slugItems {
+		title := item.Name
+		if title == "" {
+			title = slug
+		}
+		extractedPages = append(extractedPages, types.WikiLogPageRef{Slug: slug, Title: title})
+	}
+
+	updates := []SlugUpdate{{
+		Slug:        summarySlug,
+		Type:        types.WikiPageTypeSummary,
+		DocTitle:    docTitle,
+		KnowledgeID: knowledgeID,
+		SourceRef:   sourceRef,
+		Language:    lang,
+		SummaryLine: sumLine,
+		SummaryBody: sumBody,
+	}}
+	extractedPages = append(extractedPages, types.WikiLogPageRef{Slug: summarySlug, Title: docTitle})
+
+	for _, item := range p.Entities {
+		if item.Slug == "" {
+			continue
+		}
+		updates = append(updates, SlugUpdate{
+			Slug:         item.Slug,
+			Type:         types.WikiPageTypeEntity,
+			Item:         item,
+			DocTitle:     docTitle,
+			KnowledgeID:  knowledgeID,
+			SourceRef:    sourceRef,
+			Language:     lang,
+			SourceChunks: item.SourceChunks,
+			DocSummary:   docSummary,
+		})
+	}
+	for _, item := range p.Concepts {
+		if item.Slug == "" {
+			continue
+		}
+		updates = append(updates, SlugUpdate{
+			Slug:         item.Slug,
+			Type:         types.WikiPageTypeConcept,
+			Item:         item,
+			DocTitle:     docTitle,
+			KnowledgeID:  knowledgeID,
+			SourceRef:    sourceRef,
+			Language:     lang,
+			SourceChunks: item.SourceChunks,
+			DocSummary:   docSummary,
+		})
+	}
+
+	priorContribution := ""
+	if batchCtx != nil && batchCtx.SummaryContentByKnowledgeID != nil {
+		priorContribution = batchCtx.SummaryContentByKnowledgeID(ctx, knowledgeID)
+	}
+	newSlugSet := make(map[string]bool, len(extractedPages))
+	for _, ns := range extractedPages {
+		newSlugSet[ns.Slug] = true
+	}
+
+	var reparseOverlap, staleCount int
+	for oldSlug := range oldPageSlugs {
+		if newSlugSet[oldSlug] {
+			if strings.HasPrefix(oldSlug, "summary/") {
+				continue
+			}
+			reparseOverlap++
+			updates = append(updates, SlugUpdate{
+				Slug:              oldSlug,
+				Type:              "retract",
+				RetractDocContent: priorContribution,
+				DocTitle:          docTitle,
+				KnowledgeID:       knowledgeID,
+				Language:          lang,
+			})
+			continue
+		}
+		staleCount++
+		updates = append(updates, SlugUpdate{
+			Slug:              oldSlug,
+			Type:              "retractStale",
+			RetractDocContent: content,
+			DocTitle:          docTitle,
+			KnowledgeID:       knowledgeID,
+			Language:          lang,
+		})
+	}
+
+	citedChunkSet := make(map[string]bool)
+	for _, item := range p.Entities {
+		for _, id := range item.SourceChunks {
+			citedChunkSet[id] = true
+		}
+	}
+	for _, item := range p.Concepts {
+		for _, id := range item.SourceChunks {
+			citedChunkSet[id] = true
+		}
+	}
+
+	mapStats := types.JSONMap{
+		"doc_title":        previewText(docTitle, 120),
+		"chunks":           chunkCount,
+		"candidate_slugs":  len(slugItems),
+		"cited_chunks":     len(citedChunkSet),
+		"uncited_slugs":    p.Uncited,
+		"new_slugs":        p.NewSlugCount,
+		"updates":          len(updates),
+		"reparse_slugs":    reparseOverlap,
+		"stale_slugs":      staleCount,
+		"extracted_pages":  len(extractedPages),
+		"summary_chars":    utf8.RuneCountInString(docSummary),
+		"pass0_fallback":   p.Pass0Failed,
+		"classify_batches": p.ClassifyBatchCount,
+		"summary_preview":  previewText(docSummaryLine, 160),
+		"cache_hit":        cacheHit,
+	}
+
+	return &docIngestResult{
+		KnowledgeID: knowledgeID,
+		DocTitle:    docTitle,
+		Summary:     docSummaryLine,
+		Pages:       extractedPages,
+		MapStats:    mapStats,
+		WikiSpan:    wikiSpan,
+	}, updates
+}

--- a/internal/application/service/wiki_ingest_map_cache_test.go
+++ b/internal/application/service/wiki_ingest_map_cache_test.go
@@ -1,0 +1,167 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type wikiMapCacheChatModel struct {
+	modelID   string
+	modelName string
+}
+
+func (m wikiMapCacheChatModel) Chat(
+	context.Context,
+	[]chat.Message,
+	*chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	return &types.ChatResponse{Content: ""}, nil
+}
+
+func (m wikiMapCacheChatModel) ChatStream(
+	context.Context,
+	[]chat.Message,
+	*chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	return nil, nil
+}
+
+func (m wikiMapCacheChatModel) GetModelName() string { return m.modelName }
+func (m wikiMapCacheChatModel) GetModelID() string   { return m.modelID }
+
+func TestWikiMapCacheKeyInvalidatesOnInputs(t *testing.T) {
+	baseCtx := &WikiBatchContext{
+		ExtractionGranularity:  types.WikiExtractionStandard,
+		ContentInstructions:    "content instructions",
+		ExtractionInstructions: "extract instructions",
+	}
+	model := wikiMapCacheChatModel{modelID: "model-a", modelName: "name-a"}
+	base := wikiMapCacheKey("knowledge-a", "document content", model, "English", baseCtx)
+
+	assert.Less(t, len(base), 255)
+	assert.Equal(t, base, wikiMapCacheKey("knowledge-a", " document content ", model, "English", baseCtx))
+	assert.NotEqual(t, base, wikiMapCacheKey("knowledge-a", "changed content", model, "English", baseCtx))
+	assert.NotEqual(t, base, wikiMapCacheKey("knowledge-a", "document content", model, "Chinese", baseCtx))
+	assert.NotEqual(t, base, wikiMapCacheKey("knowledge-a", "document content", model, "English", &WikiBatchContext{
+		ExtractionGranularity:  types.WikiExtractionFocused,
+		ContentInstructions:    "content instructions",
+		ExtractionInstructions: "extract instructions",
+	}))
+	assert.NotEqual(t, base, wikiMapCacheKey("knowledge-a", "document content", model, "English", &WikiBatchContext{
+		ExtractionGranularity:  types.WikiExtractionStandard,
+		ContentInstructions:    "changed content instructions",
+		ExtractionInstructions: "extract instructions",
+	}))
+	assert.NotEqual(t, base, wikiMapCacheKey("knowledge-a", "document content", model, "English", &WikiBatchContext{
+		ExtractionGranularity:  types.WikiExtractionStandard,
+		ContentInstructions:    "content instructions",
+		ExtractionInstructions: "changed extract instructions",
+	}))
+	assert.NotEqual(t, base, wikiMapCacheKey("knowledge-a", "document content",
+		wikiMapCacheChatModel{modelID: "model-b", modelName: "name-a"}, "English", baseCtx))
+	assert.NotEqual(t, base, wikiMapCacheKey("knowledge-a", "document content",
+		wikiMapCacheChatModel{modelName: "name-a"}, "English", baseCtx))
+}
+
+func TestWikiMapCachePayloadRoundTripAndRebuildUsesCurrentState(t *testing.T) {
+	payload := &wikiDocumentMapCachePayload{
+		KnowledgeID:    "knowledge-a",
+		SummaryContent: "SUMMARY: Acme overview\n\nAcme builds search tools.",
+		Entities: []extractedItem{{
+			Name:         "Acme",
+			Slug:         "entity/acme",
+			Description:  "A company.",
+			SourceChunks: []string{"chunk-1"},
+		}},
+		Concepts: []extractedItem{{
+			Name: "Search",
+			Slug: "concept/search",
+		}},
+		Uncited:            1,
+		NewSlugCount:       1,
+		ClassifyBatchCount: 2,
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var restored wikiDocumentMapCachePayload
+	require.NoError(t, json.Unmarshal(data, &restored))
+
+	batchCtx := &WikiBatchContext{
+		SummaryContentByKnowledgeID: func(context.Context, string) string {
+			return "previous summary contribution"
+		},
+	}
+	result, updates := restored.buildResultAndUpdates(
+		context.Background(),
+		batchCtx,
+		"knowledge-a",
+		"Current Title",
+		"knowledge-a",
+		"current document content",
+		map[string]bool{
+			"entity/acme":      true,
+			"summary/old":      true,
+			"concept/obsolete": true,
+		},
+		nil,
+		true,
+		3,
+		"English",
+	)
+
+	require.NotNil(t, result)
+	assert.Equal(t, "Current Title", result.DocTitle)
+	assert.Equal(t, "Acme overview", result.Summary)
+	assert.True(t, result.MapStats["cache_hit"].(bool))
+	assert.Equal(t, 3, result.MapStats["chunks"])
+	assert.Equal(t, 1, result.MapStats["reparse_slugs"])
+	assert.Equal(t, 2, result.MapStats["stale_slugs"])
+
+	var foundRetract, foundStale bool
+	for _, update := range updates {
+		if update.Type == "retract" && update.Slug == "entity/acme" {
+			foundRetract = true
+			assert.Equal(t, "previous summary contribution", update.RetractDocContent)
+		}
+		if update.Type == "retractStale" && update.Slug == "concept/obsolete" {
+			foundStale = true
+			assert.Equal(t, "current document content", update.RetractDocContent)
+		}
+	}
+	assert.True(t, foundRetract)
+	assert.True(t, foundStale)
+}
+
+func TestWikiMapCacheGetSetAndFallback(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeContentCacheRepo()
+	svc := &wikiIngestService{contentCacheRepo: repo}
+	cacheKey := "wiki_map:key"
+	payload := &wikiDocumentMapCachePayload{
+		KnowledgeID:    "knowledge-a",
+		SummaryContent: "SUMMARY: Cached\n\nBody",
+	}
+
+	svc.setCachedWikiDocumentMap(ctx, 1, cacheKey, payload)
+	got, hit := svc.getCachedWikiDocumentMap(ctx, 1, cacheKey)
+	require.True(t, hit)
+	require.NotNil(t, got)
+	assert.Equal(t, payload.SummaryContent, got.SummaryContent)
+
+	repo.getErr = errors.New("read failed")
+	got, hit = svc.getCachedWikiDocumentMap(ctx, 1, cacheKey)
+	assert.False(t, hit)
+	assert.Nil(t, got)
+
+	repo.getErr = nil
+	repo.upsertErr = errors.New("write failed")
+	svc.setCachedWikiDocumentMap(ctx, 1, "wiki_map:other", payload)
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -147,6 +147,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewKnowledgeRepository))
 	must(container.Provide(repository.NewKnowledgeSpanRepository))
 	must(container.Provide(repository.NewChunkRepository))
+	must(container.Provide(repository.NewContentCacheRepository))
 	must(container.Provide(repository.NewKnowledgeTagRepository))
 	must(container.Provide(repository.NewSessionRepository))
 	must(container.Provide(repository.NewMessageRepository))

--- a/internal/types/chunk_id.go
+++ b/internal/types/chunk_id.go
@@ -76,6 +76,17 @@ func StableImageChildChunkID(
 	return formatUUIDFromHash(sum)
 }
 
+// StableGeneratedQuestionID derives a deterministic ID for generated question metadata.
+func StableGeneratedQuestionID(chunkID string, question string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		stableChunkIDNamespace,
+		"generated_question",
+		chunkID,
+		ContentHash(question, ""),
+	}, "\x00")))
+	return formatUUIDFromHash(sum)
+}
+
 func formatUUIDFromHash(sum [32]byte) string {
 	id := sum[:16]
 	id[6] = (id[6] & 0x0f) | 0x80

--- a/internal/types/chunk_id.go
+++ b/internal/types/chunk_id.go
@@ -1,0 +1,92 @@
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+const stableChunkIDNamespace = "0ed67a0f-6d4d-4c9a-99ac-4c880ee62e96"
+
+// NormalizeForHash returns the canonical text used for document chunk hashing.
+// It mirrors embedding input semantics by including the context header when
+// present, while smoothing transport-only whitespace differences.
+func NormalizeForHash(content, contextHeader string) string {
+	content = normalizeHashText(content)
+	contextHeader = normalizeHashText(contextHeader)
+	if contextHeader == "" {
+		return content
+	}
+	if content == "" {
+		return contextHeader
+	}
+	return contextHeader + "\n\n" + content
+}
+
+func normalizeHashText(s string) string {
+	s = strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\r", "\n")
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+// ContentHash returns a 64-character SHA-256 hash for normalized chunk content.
+func ContentHash(content, contextHeader string) string {
+	normalized := NormalizeForHash(content, contextHeader)
+	if normalized == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(normalized))
+	return hex.EncodeToString(sum[:])
+}
+
+// StableChunkID derives a deterministic UUID-format chunk ID.
+func StableChunkID(tenantID uint64, knowledgeID string, chunkType ChunkType, contentHash string, occurrenceIndex int) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		stableChunkIDNamespace,
+		fmt.Sprintf("%d", tenantID),
+		knowledgeID,
+		string(chunkType),
+		contentHash,
+		fmt.Sprintf("%d", occurrenceIndex),
+	}, "\x00")))
+	return formatUUIDFromHash(sum)
+}
+
+func formatUUIDFromHash(sum [32]byte) string {
+	id := sum[:16]
+	id[6] = (id[6] & 0x0f) | 0x80
+	id[8] = (id[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", id[0:4], id[4:6], id[6:8], id[8:10], id[10:16])
+}
+
+// ChunkIDAllocator assigns stable IDs while disambiguating duplicate content
+// within one document by occurrence order.
+type ChunkIDAllocator struct {
+	tenantID    uint64
+	knowledgeID string
+	seen        map[string]int
+}
+
+func NewChunkIDAllocator(tenantID uint64, knowledgeID string) *ChunkIDAllocator {
+	return &ChunkIDAllocator{
+		tenantID:    tenantID,
+		knowledgeID: knowledgeID,
+		seen:        make(map[string]int),
+	}
+}
+
+// Allocate returns the stable chunk ID and content hash for a document chunk.
+func (a *ChunkIDAllocator) Allocate(chunkType ChunkType, content, contextHeader string) (string, string) {
+	if a == nil {
+		a = NewChunkIDAllocator(0, "")
+	}
+	contentHash := ContentHash(content, contextHeader)
+	key := string(chunkType) + "\x00" + contentHash
+	occurrenceIndex := a.seen[key]
+	a.seen[key] = occurrenceIndex + 1
+	return StableChunkID(a.tenantID, a.knowledgeID, chunkType, contentHash, occurrenceIndex), contentHash
+}

--- a/internal/types/chunk_id.go
+++ b/internal/types/chunk_id.go
@@ -56,6 +56,26 @@ func StableChunkID(tenantID uint64, knowledgeID string, chunkType ChunkType, con
 	return formatUUIDFromHash(sum)
 }
 
+// StableImageChildChunkID derives a deterministic ID for image OCR/caption child chunks.
+func StableImageChildChunkID(
+	tenantID uint64,
+	knowledgeID string,
+	parentChunkID string,
+	chunkType ChunkType,
+	canonicalText string,
+) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		stableChunkIDNamespace,
+		"image_child",
+		fmt.Sprintf("%d", tenantID),
+		knowledgeID,
+		parentChunkID,
+		string(chunkType),
+		ContentHash(canonicalText, ""),
+	}, "\x00")))
+	return formatUUIDFromHash(sum)
+}
+
 func formatUUIDFromHash(sum [32]byte) string {
 	id := sum[:16]
 	id[6] = (id[6] & 0x0f) | 0x80

--- a/internal/types/chunk_id_test.go
+++ b/internal/types/chunk_id_test.go
@@ -1,0 +1,87 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeForHash(t *testing.T) {
+	assert.Equal(t, "hello\nworld", NormalizeForHash("  hello  \r\nworld\t \n", ""))
+	assert.Equal(t, "Heading\n\nhello", NormalizeForHash(" hello ", " Heading \r\n"))
+	assert.Equal(t, "Heading", NormalizeForHash("", " Heading \t"))
+	assert.Equal(t, "", NormalizeForHash(" \r\n\t ", ""))
+}
+
+func TestContentHash(t *testing.T) {
+	hash1 := ContentHash(" hello \r\nworld\t", "")
+	hash2 := ContentHash("hello\nworld", "")
+
+	require.Len(t, hash1, 64)
+	assert.Equal(t, hash1, hash2)
+	assert.Empty(t, ContentHash(" \n\t ", ""))
+	assert.NotEqual(t, ContentHash("hello", ""), ContentHash("hello", "section"))
+}
+
+func TestStableChunkID(t *testing.T) {
+	hash := ContentHash("hello", "")
+	id1 := StableChunkID(1, "knowledge-a", ChunkTypeText, hash, 0)
+	id2 := StableChunkID(1, "knowledge-a", ChunkTypeText, hash, 0)
+
+	assert.Equal(t, id1, id2)
+	assert.Len(t, id1, 36)
+	_, err := uuid.Parse(id1)
+	require.NoError(t, err)
+}
+
+func TestChunkIDAllocator_ReparseReproducible(t *testing.T) {
+	allocate := func() []string {
+		allocator := NewChunkIDAllocator(1, "knowledge-a")
+		out := make([]string, 0, 3)
+		for _, content := range []string{"hello", "hello", "world"} {
+			id, _ := allocator.Allocate(ChunkTypeText, content, "")
+			out = append(out, id)
+		}
+		return out
+	}
+
+	assert.Equal(t, allocate(), allocate())
+}
+
+func TestChunkIDAllocator_NormalizedContentKeepsSameIDAcrossReparse(t *testing.T) {
+	allocator1 := NewChunkIDAllocator(1, "knowledge-a")
+	id1, hash1 := allocator1.Allocate(ChunkTypeText, " hello  \r\nworld\t ", " # Title \r\n")
+
+	allocator2 := NewChunkIDAllocator(1, "knowledge-a")
+	id2, hash2 := allocator2.Allocate(ChunkTypeText, "hello\nworld", "# Title")
+
+	assert.Equal(t, hash1, hash2)
+	assert.Equal(t, id1, id2)
+}
+
+func TestChunkIDAllocator_DuplicateContentUsesOccurrence(t *testing.T) {
+	allocator := NewChunkIDAllocator(1, "knowledge-a")
+
+	id1, hash1 := allocator.Allocate(ChunkTypeText, "same", "")
+	id2, hash2 := allocator.Allocate(ChunkTypeText, " same \n", "")
+
+	assert.Equal(t, hash1, hash2)
+	assert.NotEqual(t, id1, id2)
+	assert.Equal(t, StableChunkID(1, "knowledge-a", ChunkTypeText, hash1, 0), id1)
+	assert.Equal(t, StableChunkID(1, "knowledge-a", ChunkTypeText, hash1, 1), id2)
+}
+
+func TestChunkIDAllocator_IsolatedByKnowledgeAndType(t *testing.T) {
+	hash := ContentHash("same", "")
+
+	assert.NotEqual(t,
+		StableChunkID(1, "knowledge-a", ChunkTypeText, hash, 0),
+		StableChunkID(1, "knowledge-b", ChunkTypeText, hash, 0),
+	)
+	assert.NotEqual(t,
+		StableChunkID(1, "knowledge-a", ChunkTypeText, hash, 0),
+		StableChunkID(1, "knowledge-a", ChunkTypeParentText, hash, 0),
+	)
+}

--- a/internal/types/chunk_id_test.go
+++ b/internal/types/chunk_id_test.go
@@ -109,3 +109,20 @@ func TestStableImageChildChunkID_IsolatedByModeAndContent(t *testing.T) {
 		StableImageChildChunkID(1, "knowledge-a", "parent-b", ChunkTypeImageOCR, "same"),
 	)
 }
+
+func TestStableGeneratedQuestionID(t *testing.T) {
+	id1 := StableGeneratedQuestionID("chunk-a", " What is the answer? ")
+	id2 := StableGeneratedQuestionID("chunk-a", "What is the answer?")
+
+	assert.Equal(t, id1, id2)
+	assert.Len(t, id1, 36)
+	_, err := uuid.Parse(id1)
+	require.NoError(t, err)
+}
+
+func TestStableGeneratedQuestionID_IsolatedByChunkAndQuestion(t *testing.T) {
+	id := StableGeneratedQuestionID("chunk-a", "What is the answer?")
+
+	assert.NotEqual(t, id, StableGeneratedQuestionID("chunk-b", "What is the answer?"))
+	assert.NotEqual(t, id, StableGeneratedQuestionID("chunk-a", "What changed?"))
+}

--- a/internal/types/chunk_id_test.go
+++ b/internal/types/chunk_id_test.go
@@ -85,3 +85,27 @@ func TestChunkIDAllocator_IsolatedByKnowledgeAndType(t *testing.T) {
 		StableChunkID(1, "knowledge-a", ChunkTypeParentText, hash, 0),
 	)
 }
+
+func TestStableImageChildChunkID(t *testing.T) {
+	id1 := StableImageChildChunkID(1, "knowledge-a", "parent-a", ChunkTypeImageOCR, "text")
+	id2 := StableImageChildChunkID(1, "knowledge-a", "parent-a", ChunkTypeImageOCR, " text ")
+
+	assert.Equal(t, id1, id2)
+	assert.Len(t, id1, 36)
+	_, err := uuid.Parse(id1)
+	require.NoError(t, err)
+}
+
+func TestStableImageChildChunkID_IsolatedByModeAndContent(t *testing.T) {
+	id := StableImageChildChunkID(1, "knowledge-a", "parent-a", ChunkTypeImageOCR, "same")
+
+	assert.NotEqual(t, id,
+		StableImageChildChunkID(1, "knowledge-a", "parent-a", ChunkTypeImageCaption, "same"),
+	)
+	assert.NotEqual(t, id,
+		StableImageChildChunkID(1, "knowledge-a", "parent-a", ChunkTypeImageOCR, "changed"),
+	)
+	assert.NotEqual(t, id,
+		StableImageChildChunkID(1, "knowledge-a", "parent-b", ChunkTypeImageOCR, "same"),
+	)
+}

--- a/internal/types/content_cache.go
+++ b/internal/types/content_cache.go
@@ -11,6 +11,7 @@ const (
 	ContentCacheKindEmbedding    = "embedding"
 	ContentCacheKindImageOCR     = "image_ocr"
 	ContentCacheKindImageCaption = "image_caption"
+	ContentCacheKindWikiMap      = "wiki_map"
 )
 
 // ContentCacheEntry stores reusable deterministic processing artifacts.

--- a/internal/types/content_cache.go
+++ b/internal/types/content_cache.go
@@ -12,6 +12,9 @@ const (
 	ContentCacheKindImageOCR     = "image_ocr"
 	ContentCacheKindImageCaption = "image_caption"
 	ContentCacheKindWikiMap      = "wiki_map"
+	ContentCacheKindGraphChunk   = "graph_chunk"
+	ContentCacheKindSummary      = "summary"
+	ContentCacheKindQuestion     = "question"
 )
 
 // ContentCacheEntry stores reusable deterministic processing artifacts.

--- a/internal/types/content_cache.go
+++ b/internal/types/content_cache.go
@@ -8,7 +8,9 @@ import (
 )
 
 const (
-	ContentCacheKindEmbedding = "embedding"
+	ContentCacheKindEmbedding    = "embedding"
+	ContentCacheKindImageOCR     = "image_ocr"
+	ContentCacheKindImageCaption = "image_caption"
 )
 
 // ContentCacheEntry stores reusable deterministic processing artifacts.

--- a/internal/types/content_cache.go
+++ b/internal/types/content_cache.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const (
+	ContentCacheKindEmbedding = "embedding"
+)
+
+// ContentCacheEntry stores reusable deterministic processing artifacts.
+type ContentCacheEntry struct {
+	ID        string    `json:"id"         gorm:"type:varchar(36);primaryKey"`
+	TenantID  uint64    `json:"tenant_id"  gorm:"not null;uniqueIndex:idx_content_caches_key,priority:1"`
+	CacheKind string    `json:"cache_kind" gorm:"type:varchar(32);not null;uniqueIndex:idx_content_caches_key,priority:2"`
+	CacheKey  string    `json:"cache_key"  gorm:"type:varchar(255);not null;uniqueIndex:idx_content_caches_key,priority:3"`
+	Payload   JSON      `json:"payload"    gorm:"type:json;not null"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+func (ContentCacheEntry) TableName() string {
+	return "content_caches"
+}
+
+func (c *ContentCacheEntry) BeforeCreate(_ *gorm.DB) error {
+	if c.ID == "" {
+		c.ID = uuid.NewString()
+	}
+	return nil
+}

--- a/internal/types/interfaces/chunk.go
+++ b/internal/types/interfaces/chunk.go
@@ -64,6 +64,8 @@ type ChunkRepository interface {
 	DeleteChunks(ctx context.Context, tenantID uint64, ids []string) error
 	// DeleteChunksByKnowledgeID deletes chunks by knowledge id
 	DeleteChunksByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) error
+	// PurgeSoftDeletedByKnowledgeID permanently removes already soft-deleted chunks by knowledge id.
+	PurgeSoftDeletedByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) error
 	// DeleteByKnowledgeList deletes all chunks for a knowledge list
 	DeleteByKnowledgeList(ctx context.Context, tenantID uint64, knowledgeIDs []string) error
 	// ListImageInfoByKnowledgeIDs returns non-empty (knowledge_id, image_info) pairs for image cleanup.

--- a/internal/types/interfaces/content_cache.go
+++ b/internal/types/interfaces/content_cache.go
@@ -1,0 +1,13 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// ContentCacheRepository persists deterministic content-processing caches.
+type ContentCacheRepository interface {
+	GetByKey(ctx context.Context, tenantID uint64, cacheKind, cacheKey string) (*types.ContentCacheEntry, error)
+	Upsert(ctx context.Context, entry *types.ContentCacheEntry) error
+}

--- a/migrations/sqlite/000002_content_caches.down.sql
+++ b/migrations/sqlite/000002_content_caches.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS content_caches;

--- a/migrations/sqlite/000002_content_caches.up.sql
+++ b/migrations/sqlite/000002_content_caches.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS content_caches (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id INTEGER NOT NULL,
+    cache_kind VARCHAR(32) NOT NULL,
+    cache_key VARCHAR(255) NOT NULL,
+    payload TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_content_caches_key
+    ON content_caches (tenant_id, cache_kind, cache_key);

--- a/migrations/versioned/000074_content_caches.down.sql
+++ b/migrations/versioned/000074_content_caches.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS content_caches;

--- a/migrations/versioned/000074_content_caches.up.sql
+++ b/migrations/versioned/000074_content_caches.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS content_caches (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id INTEGER NOT NULL,
+    cache_kind VARCHAR(32) NOT NULL,
+    cache_key VARCHAR(255) NOT NULL,
+    payload JSONB NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_content_caches_key
+    ON content_caches (tenant_id, cache_kind, cache_key);


### PR DESCRIPTION
## Description
This PR implements #1679 by introducing a set of content‑addressed cache layers that eliminate redundant LLM / VLM / embedding calls during knowledge re‑parsing.

The work is organised into 5 logical commits that build on each other:

1. **Stable chunk IDs & ContentHash** – deterministic, content‑addressed identities for document‑derived chunks, keeping FAQ/manual/clone chunks on UUIDs.
2. **Embedding cache** – a DB‑backed cache for embedding vectors, reused when normalized text, model and dimensions are unchanged.
3. **VLM OCR / caption cache** – caches OCR and caption outputs from the vision model, freezes them as canonical text, and stabilises child chunk IDs to prevent output jitter.
4. **Wiki per‑document map cache** – caches the extract/summary/classify results of the Wiki pipeline while keeping the cross‑document `reduce` phase live.
5. **Graph, summary and question cache** – caches per‑chunk graph extraction, document summaries, and generated questions with stable question IDs.

All cache layers are **best‑effort**: on failure they fall back to the original processing path without affecting correctness. The cache infrastructure (a single `content_caches` table) is introduced in commit 2 and reused by all later layers.

## Type of Change
- [x] ✨ New feature
- [x] ⚡ Performance improvement
- [x] 🧪 Test

## Related Issue
Closes #1679

## Testing
Each commit includes focused unit tests covering:
- stable ID determinism and soft‑delete safety
- embedding cache hits, batch deduplication, model/dimension invalidation
- VLM cache hit/miss, error fallback, child chunk ID stability
- Wiki map cache key invalidation, payload round‑trip, live‑state rebuild
- Graph deep‑copy / chunk rebinding, summary & question cache hits, stable question IDs

### Local verification
- `gofmt` and `git diff --check` pass.
- File‑level tests (e.g. `go test ./internal/types -run ChunkID`) pass.
- Package‑level tests are currently blocked by a local CGO / `pg_query` dependency, unrelated to these changes. CI is expected to pass.

## Checklist
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] `make fmt && make lint && make test` pass locally (see note about CGO)
- [x] Breaking changes are clearly called out in the description above (none)

## Notes
- Previous smaller PRs (#2219, #2221, #2222) are superseded by this consolidated PR and can be closed.
- This PR deliberately does **not** change the existing reparse “delete‑all then recreate” semantics; it only avoids recomputation of identical results.