### PR TITLE
feat(reparse): reuse content-addressed processing artifacts

### DIFF
--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -44,6 +44,24 @@ func (r *chunkRepository) CreateChunks(ctx context.Context, chunks []*types.Chun
 
 	db := r.db.WithContext(ctx)
 
+	// Whole-document replacement soft-deletes the previous rows before
+	// inserting content-addressed chunks with the same IDs. Purge only those
+	// matching tombstones so stable IDs can be reused without changing the
+	// soft-delete semantics of the public delete operations.
+	ids := make([]string, 0, len(chunks))
+	for _, chunk := range chunks {
+		if chunk != nil && chunk.ID != "" {
+			ids = append(ids, chunk.ID)
+		}
+	}
+	if len(ids) > 0 {
+		if err := db.Unscoped().
+			Where("id IN ? AND deleted_at IS NOT NULL", ids).
+			Delete(&types.Chunk{}).Error; err != nil {
+			return fmt.Errorf("failed to purge replaced chunk tombstones: %w", err)
+		}
+	}
+
 	// SQLite doesn't support autoIncrement on non-PK columns,
 	// so we must pre-assign SeqIDs manually (safe: single connection).
 	// PostgreSQL / MySQL use DB sequences — skip to avoid duplicate key

--- a/internal/application/repository/chunk_sqlite_test.go
+++ b/internal/application/repository/chunk_sqlite_test.go
@@ -95,6 +95,30 @@ func TestCreateChunks_SQLite_SeqIDContinuesFromExisting(t *testing.T) {
 	}
 }
 
+func TestDeleteChunksByKnowledgeIDAllowsStableIDReuse(t *testing.T) {
+	db := setupChunkTestDB(t)
+	repo := NewChunkRepository(db)
+	ctx := context.Background()
+
+	chunk := makeChunk(uuid.NewString(), uuid.NewString(), types.ChunkTypeText)
+	stableID := chunk.ID
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{chunk}))
+	require.NoError(t, repo.DeleteChunksByKnowledgeID(ctx, chunk.TenantID, chunk.KnowledgeID))
+
+	replacement := makeChunk(chunk.KnowledgeBaseID, chunk.KnowledgeID, types.ChunkTypeText)
+	replacement.ID = stableID
+	replacement.Content = "replacement"
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{replacement}))
+
+	got, err := repo.GetChunkByID(ctx, chunk.TenantID, stableID)
+	require.NoError(t, err)
+	require.Equal(t, "replacement", got.Content)
+
+	var count int64
+	require.NoError(t, db.Unscoped().Model(&types.Chunk{}).Where("id = ?", stableID).Count(&count).Error)
+	require.EqualValues(t, 1, count)
+}
+
 func TestCreateChunks_SQLite_SeqIDUniqueAcrossKBs(t *testing.T) {
 	db := setupChunkTestDB(t)
 	repo := NewChunkRepository(db)

--- a/internal/application/repository/processing_cache.go
+++ b/internal/application/repository/processing_cache.go
@@ -1,0 +1,77 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type processingCacheRepository struct {
+	db *gorm.DB
+}
+
+func NewProcessingCacheRepository(db *gorm.DB) interfaces.ProcessingCacheRepository {
+	return &processingCacheRepository{db: db}
+}
+
+func (r *processingCacheRepository) Get(
+	ctx context.Context,
+	tenantID uint64,
+	cacheType, cacheKey string,
+) ([]byte, bool, error) {
+	var entry types.ProcessingCacheEntry
+	err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND cache_type = ? AND cache_key = ?", tenantID, cacheType, cacheKey).
+		First(&entry).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	now := time.Now()
+	_ = r.db.WithContext(ctx).Model(&types.ProcessingCacheEntry{}).
+		Where("tenant_id = ? AND cache_type = ? AND cache_key = ?", tenantID, cacheType, cacheKey).
+		Updates(map[string]any{
+			"hit_count":   gorm.Expr("hit_count + 1"),
+			"last_hit_at": now,
+		}).Error
+
+	return append([]byte(nil), entry.Payload...), true, nil
+}
+
+func (r *processingCacheRepository) Put(
+	ctx context.Context,
+	tenantID uint64,
+	cacheType, cacheKey string,
+	payload []byte,
+) error {
+	now := time.Now()
+	entry := &types.ProcessingCacheEntry{
+		TenantID:  tenantID,
+		CacheType: cacheType,
+		CacheKey:  cacheKey,
+		Payload:   append([]byte(nil), payload...),
+		SizeBytes: int64(len(payload)),
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "tenant_id"},
+			{Name: "cache_type"},
+			{Name: "cache_key"},
+		},
+		DoUpdates: clause.Assignments(map[string]any{
+			"payload":    entry.Payload,
+			"size_bytes": entry.SizeBytes,
+			"updated_at": now,
+		}),
+	}).Create(entry).Error
+}

--- a/internal/application/repository/processing_cache_test.go
+++ b/internal/application/repository/processing_cache_test.go
@@ -1,0 +1,50 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestProcessingCacheRepositoryTenantIsolationAndUpsert(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:processing-cache?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.ProcessingCacheEntry{}))
+
+	repo := NewProcessingCacheRepository(db)
+	ctx := context.Background()
+
+	require.NoError(t, repo.Put(ctx, 1, "embedding", "key", []byte("tenant-1")))
+	require.NoError(t, repo.Put(ctx, 2, "embedding", "key", []byte("tenant-2")))
+
+	got, found, err := repo.Get(ctx, 1, "embedding", "key")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, []byte("tenant-1"), got)
+
+	got, found, err = repo.Get(ctx, 2, "embedding", "key")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, []byte("tenant-2"), got)
+
+	require.NoError(t, repo.Put(ctx, 1, "embedding", "key", []byte("updated")))
+	got, found, err = repo.Get(ctx, 1, "embedding", "key")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, []byte("updated"), got)
+
+	_, found, err = repo.Get(ctx, 1, "embedding", "missing")
+	require.NoError(t, err)
+	require.False(t, found)
+
+	var entry types.ProcessingCacheEntry
+	require.NoError(t, db.Where(
+		"tenant_id = ? AND cache_type = ? AND cache_key = ?", 1, "embedding", "key",
+	).First(&entry).Error)
+	require.EqualValues(t, 2, entry.HitCount)
+	require.NotNil(t, entry.LastHitAt)
+}

--- a/internal/application/service/extract.go
+++ b/internal/application/service/extract.go
@@ -164,6 +164,7 @@ type ChunkExtractService struct {
 	knowledgeRepo     interfaces.KnowledgeRepository
 	chunkRepo         interfaces.ChunkRepository
 	graphEngine       interfaces.RetrieveGraphRepository
+	cacheRepo         interfaces.ProcessingCacheRepository
 	// spanTracker records this graph-extract task's subspan under the
 	// parent attempt's postprocess stage so the trace viewer shows real
 	// per-chunk graph extraction time rather than the upstream's enqueue.
@@ -178,6 +179,7 @@ func NewChunkExtractService(
 	knowledgeRepo interfaces.KnowledgeRepository,
 	chunkRepo interfaces.ChunkRepository,
 	graphEngine interfaces.RetrieveGraphRepository,
+	cacheRepo interfaces.ProcessingCacheRepository,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
 	return &ChunkExtractService{
@@ -187,6 +189,7 @@ func NewChunkExtractService(
 		knowledgeRepo:     knowledgeRepo,
 		chunkRepo:         chunkRepo,
 		graphEngine:       graphEngine,
+		cacheRepo:         cacheRepo,
 		spanTracker:       spanTracker,
 	}
 }
@@ -316,6 +319,7 @@ func (s *ChunkExtractService) Handle(ctx context.Context, t *asynq.Task) error {
 		handleErr = err
 		return err
 	}
+	chatModel = newCachedChat(chatModel, s.cacheRepo, p.TenantID, cacheTypeGraph)
 
 	template := &types.PromptTemplateStructured{
 		Description: types.AppendCustomPromptInstructions(
@@ -406,6 +410,7 @@ type DataTableSummaryService struct {
 	ownership            retriever.TenantStoreOwnership
 	sqlDB                *sql.DB
 	storageResolver      interfaces.StorageBackendResolver
+	cacheRepo            interfaces.ProcessingCacheRepository
 }
 
 // NewDataTableSummaryService creates a new DataTableSummaryService
@@ -420,6 +425,7 @@ func NewDataTableSummaryService(
 	ownership retriever.TenantStoreOwnership,
 	sqlDB *sql.DB,
 	storageResolver interfaces.StorageBackendResolver,
+	cacheRepo interfaces.ProcessingCacheRepository,
 ) interfaces.TaskHandler {
 	return &DataTableSummaryService{
 		modelService:         modelService,
@@ -432,6 +438,7 @@ func NewDataTableSummaryService(
 		ownership:            ownership,
 		sqlDB:                sqlDB,
 		storageResolver:      storageResolver,
+		cacheRepo:            cacheRepo,
 	}
 }
 
@@ -513,6 +520,7 @@ func (s *DataTableSummaryService) prepareResources(ctx context.Context, payload 
 		logger.Errorf(ctx, "failed to get chat model: %v", err)
 		return nil, err
 	}
+	chatModel = newCachedChat(chatModel, s.cacheRepo, payload.TenantID, cacheTypeTable)
 
 	// 获取嵌入模型（用于向量化）
 	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, payload.EmbeddingModel)
@@ -520,6 +528,7 @@ func (s *DataTableSummaryService) prepareResources(ctx context.Context, payload 
 		logger.Errorf(ctx, "failed to get embedding model: %v", err)
 		return nil, err
 	}
+	embeddingModel = newCachedEmbedder(embeddingModel, s.cacheRepo, payload.TenantID)
 
 	// Load the KB to discover its VectorStoreID binding so the factory can
 	// route to the bound store (or fall back to tenant engines if unbound).

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -19,7 +19,6 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
-	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
 	"github.com/redis/go-redis/v9"
 )
@@ -73,6 +72,7 @@ type ImageMultimodalService struct {
 	ollamaService  *ollama.OllamaService
 	taskEnqueuer   interfaces.TaskEnqueuer
 	redisClient    *redis.Client
+	cacheRepo      interfaces.ProcessingCacheRepository
 	// fileSvc is the globally configured default FileService used as a fallback
 	// when the tenant-scoped storage config cannot produce a usable service
 	// (e.g. images were saved using the global MINIO_* env vars while the
@@ -101,6 +101,7 @@ func NewImageMultimodalService(
 	ollamaService *ollama.OllamaService,
 	taskEnqueuer interfaces.TaskEnqueuer,
 	redisClient *redis.Client,
+	cacheRepo interfaces.ProcessingCacheRepository,
 	fileSvc interfaces.FileService,
 	storageResolver interfaces.StorageBackendResolver,
 	resourceCatalog interfaces.ResourceCatalog,
@@ -117,6 +118,7 @@ func NewImageMultimodalService(
 		ollamaService:   ollamaService,
 		taskEnqueuer:    taskEnqueuer,
 		redisClient:     redisClient,
+		cacheRepo:       cacheRepo,
 		fileSvc:         fileSvc,
 		storageResolver: storageResolver,
 		resourceCatalog: resourceCatalog,
@@ -251,6 +253,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		return nil
 	}
 	imgOut["image_bytes"] = len(imgBytes)
+	vlmModel = newCachedVLM(vlmModel, s.cacheRepo, payload.TenantID)
 
 	imageInfo := types.ImageInfo{
 		URL:         payload.ImageURL,
@@ -302,7 +305,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 
 	if imageInfo.OCRText != "" {
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              stableChunkID(payload.KnowledgeID, types.ChunkTypeImageOCR, payload.ImageIndex, imageInfo.OCRText),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
@@ -319,7 +322,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 
 	if imageInfo.Caption != "" {
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              stableChunkID(payload.KnowledgeID, types.ChunkTypeImageCaption, payload.ImageIndex, imageInfo.Caption),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
@@ -458,6 +461,7 @@ func (s *ImageMultimodalService) indexChunks(ctx context.Context, payload types.
 		logger.Warnf(ctx, "[ImageMultimodal] Failed to get embedding model for indexing: %v", err)
 		return
 	}
+	embeddingModel = newCachedEmbedder(embeddingModel, s.cacheRepo, payload.TenantID)
 
 	tenantInfo, err := s.tenantRepo.GetTenantByID(ctx, payload.TenantID)
 	if err != nil {

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -65,6 +65,7 @@ type knowledgeService struct {
 	kbShareService  interfaces.KBShareService
 	imageResolver   *docparser.ImageResolver
 	taskPendingRepo interfaces.TaskPendingOpsRepository
+	cacheRepo       interfaces.ProcessingCacheRepository
 
 	// In-memory fallbacks for Lite mode (no Redis)
 	memFAQProgress      sync.Map // taskID -> *types.FAQImportProgress
@@ -113,6 +114,7 @@ func NewKnowledgeService(
 	wikiRepo interfaces.WikiPageRepository,
 	wikiService interfaces.WikiPageService,
 	taskPendingRepo interfaces.TaskPendingOpsRepository,
+	cacheRepo interfaces.ProcessingCacheRepository,
 	spanTracker SpanTracker,
 	audit interfaces.AuditLogService,
 ) (interfaces.KnowledgeService, error) {
@@ -142,6 +144,7 @@ func NewKnowledgeService(
 		wikiRepo:        wikiRepo,
 		wikiService:     wikiService,
 		taskPendingRepo: taskPendingRepo,
+		cacheRepo:       cacheRepo,
 		spanTracker:     spanTracker,
 		audit:           audit,
 	}, nil

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -864,7 +864,7 @@ func (s *knowledgeService) CreateKnowledgeFromManual(ctx context.Context,
 
 	if status == types.ManualKnowledgeStatusPublish {
 		logger.Infof(ctx, "Manual knowledge created, enqueuing async processing task, ID: %s", knowledge.ID)
-		taskID, err := s.enqueueManualProcessing(ctx, knowledge, cleanContent, false)
+		taskID, err := s.enqueueManualProcessing(ctx, knowledge, cleanContent, false, 0)
 		if err != nil {
 			logger.Errorf(ctx, "Failed to enqueue manual processing task for new knowledge: %v", err)
 			// Non-fatal: mark as failed so user can retry
@@ -1131,7 +1131,7 @@ func (s *knowledgeService) UpdateManualKnowledge(ctx context.Context,
 	}
 
 	logger.Infof(ctx, "Manual knowledge updated, enqueuing async processing task, ID: %s", existing.ID)
-	taskID, err := s.enqueueManualProcessing(ctx, existing, cleanContent, true)
+	taskID, err := s.enqueueManualProcessing(ctx, existing, cleanContent, true, 0)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to enqueue manual processing task: %v", err)
 		// Non-fatal: mark as failed so user can retry
@@ -1155,7 +1155,7 @@ func (s *knowledgeService) UpdateManualKnowledge(ctx context.Context,
 
 // enqueueManualProcessing enqueues a manual:process Asynq task for async cleanup + re-indexing.
 func (s *knowledgeService) enqueueManualProcessing(ctx context.Context,
-	knowledge *types.Knowledge, content string, needCleanup bool,
+	knowledge *types.Knowledge, content string, needCleanup bool, attempt int,
 ) (string, error) {
 	requestID, _ := types.RequestIDFromContext(ctx)
 	payload := types.ManualProcessPayload{
@@ -1165,6 +1165,7 @@ func (s *knowledgeService) enqueueManualProcessing(ctx context.Context,
 		KnowledgeBaseID: knowledge.KnowledgeBaseID,
 		Content:         content,
 		NeedCleanup:     needCleanup,
+		Attempt:         attempt,
 	}
 	langfuse.InjectTracing(ctx, &payload)
 	payloadBytes, err := json.Marshal(payload)

--- a/internal/application/service/knowledge_faq.go
+++ b/internal/application/service/knowledge_faq.go
@@ -173,6 +173,7 @@ func (s *knowledgeService) CreateFAQEntry(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("failed to get embedding model: %w", err)
 	}
+	embeddingModel = newCachedEmbedder(embeddingModel, s.cacheRepo, tenantID)
 
 	// 创建chunk
 	isEnabled := true
@@ -411,6 +412,7 @@ func (s *knowledgeService) UpdateFAQEntry(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	embeddingModel = newCachedEmbedder(embeddingModel, s.cacheRepo, tenantID)
 
 	// 增量索引优化：只对变化的内容进行索引操作
 	if questionIndexMode == types.FAQQuestionIndexModeSeparate && len(oldSimilarQuestions) > 0 {
@@ -583,6 +585,7 @@ func (s *knowledgeService) AddSimilarQuestions(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	embeddingModel = newCachedEmbedder(embeddingModel, s.cacheRepo, tenantID)
 
 	questionIndexMode := types.FAQQuestionIndexModeCombined
 	if kb.FAQConfig != nil && kb.FAQConfig.QuestionIndexMode != "" {

--- a/internal/application/service/knowledge_faq_import.go
+++ b/internal/application/service/knowledge_faq_import.go
@@ -1382,6 +1382,7 @@ func (s *knowledgeService) executeFAQImport(ctx context.Context, taskID string, 
 	if err != nil {
 		return fmt.Errorf("failed to get embedding model: %w", err)
 	}
+	embeddingModel = newCachedEmbedder(embeddingModel, s.cacheRepo, tenantID)
 	faqKnowledge, err := s.ensureFAQKnowledge(ctx, tenantID, kb)
 	if err != nil {
 		return err

--- a/internal/application/service/knowledge_manual_attempt_test.go
+++ b/internal/application/service/knowledge_manual_attempt_test.go
@@ -1,0 +1,123 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/require"
+)
+
+type manualAttemptTaskEnqueuer struct {
+	task *asynq.Task
+}
+
+func (e *manualAttemptTaskEnqueuer) Enqueue(
+	task *asynq.Task,
+	_ ...asynq.Option,
+) (*asynq.TaskInfo, error) {
+	e.task = task
+	return &asynq.TaskInfo{ID: "manual-task"}, nil
+}
+
+func TestEnqueueManualProcessingCarriesReparseAttempt(t *testing.T) {
+	enqueuer := &manualAttemptTaskEnqueuer{}
+	svc := &knowledgeService{task: enqueuer}
+	knowledge := &types.Knowledge{
+		ID:              "knowledge-1",
+		TenantID:        42,
+		KnowledgeBaseID: "kb-1",
+	}
+
+	taskID, err := svc.enqueueManualProcessing(
+		context.Background(),
+		knowledge,
+		"# unchanged content",
+		true,
+		7,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "manual-task", taskID)
+	require.NotNil(t, enqueuer.task)
+	require.Equal(t, types.TypeManualProcess, enqueuer.task.Type())
+
+	var payload types.ManualProcessPayload
+	require.NoError(t, json.Unmarshal(enqueuer.task.Payload(), &payload))
+	require.Equal(t, 7, payload.Attempt)
+	require.True(t, payload.NeedCleanup)
+	require.Equal(t, knowledge.ID, payload.KnowledgeID)
+}
+
+type manualAttemptKnowledgeRepo struct {
+	interfaces.KnowledgeRepository
+	updated *types.Knowledge
+}
+
+func (r *manualAttemptKnowledgeRepo) UpdateKnowledge(
+	_ context.Context,
+	knowledge *types.Knowledge,
+) error {
+	r.updated = knowledge
+	return nil
+}
+
+type manualAttemptSpanTracker struct {
+	noopSpanTracker
+	knowledgeID  string
+	attempt      int
+	status       string
+	errorCode    string
+	errorMessage string
+}
+
+func (t *manualAttemptSpanTracker) FinalizeAttempt(
+	_ context.Context,
+	knowledgeID string,
+	attempt int,
+	status string,
+	_ types.JSONMap,
+	errorCode string,
+	errorMessage string,
+) {
+	t.knowledgeID = knowledgeID
+	t.attempt = attempt
+	t.status = status
+	t.errorCode = errorCode
+	t.errorMessage = errorMessage
+}
+
+func TestFailManualProcessingAttemptClosesTrace(t *testing.T) {
+	repo := &manualAttemptKnowledgeRepo{}
+	tracker := &manualAttemptSpanTracker{}
+	svc := &knowledgeService{
+		repo:        repo,
+		spanTracker: tracker,
+	}
+	knowledge := &types.Knowledge{ID: "knowledge-1"}
+
+	svc.failManualProcessingAttempt(
+		context.Background(),
+		knowledge,
+		6,
+		"manual_cleanup_failed",
+		"failed to cleanup old resources",
+		errors.New("neo4j unavailable"),
+	)
+
+	require.Same(t, knowledge, repo.updated)
+	require.Equal(t, types.ParseStatusFailed, knowledge.ParseStatus)
+	require.Equal(
+		t,
+		"failed to cleanup old resources: neo4j unavailable",
+		knowledge.ErrorMessage,
+	)
+	require.Equal(t, knowledge.ID, tracker.knowledgeID)
+	require.Equal(t, 6, tracker.attempt)
+	require.Equal(t, types.SpanStatusFailed, tracker.status)
+	require.Equal(t, "manual_cleanup_failed", tracker.errorCode)
+	require.Equal(t, knowledge.ErrorMessage, tracker.errorMessage)
+}

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -283,6 +285,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks get embedding model failed")
 			return
 		}
+		embeddingModel = newCachedEmbedder(embeddingModel, s.cacheRepo, knowledge.TenantID)
 	} else {
 		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping embedding model", kb.ID)
 	}
@@ -389,7 +392,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		parentDBChunks = make([]*types.Chunk, len(options.ParentChunks))
 		for i, pc := range options.ParentChunks {
 			parentDBChunks[i] = &types.Chunk{
-				ID:              uuid.New().String(),
+				ID:              stableChunkID(knowledge.ID, types.ChunkTypeParentText, pc.Seq, pc.Content),
 				TenantID:        knowledge.TenantID,
 				KnowledgeID:     knowledge.ID,
 				KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -428,7 +431,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 
 		// 创建主文本Chunk
 		textChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              stableChunkID(knowledge.ID, types.ChunkTypeText, int(chunkData.Seq), chunkData.Content),
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -1047,6 +1050,7 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 		summaryErr = err
 		return fmt.Errorf("failed to get chat model: %w", err)
 	}
+	chatModel = newCachedChat(chatModel, s.cacheRepo, payload.TenantID, cacheTypeSummary)
 
 	// Generate summary
 	summary, err := s.getSummary(ctx, chatModel, knowledge, textChunks)
@@ -1122,7 +1126,7 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 		// and surfacing them in retrieved RAG context can re-introduce the
 		// hallucination vector this branch is meant to close.
 		summaryChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              stableChunkID(knowledge.ID, types.ChunkTypeSummary, maxChunkIndex+1, summary),
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -1167,6 +1171,7 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 			summaryErr = err
 			return fmt.Errorf("failed to get embedding model: %w", err)
 		}
+		embeddingModel = newCachedEmbedder(embeddingModel, s.cacheRepo, payload.TenantID)
 
 		indexInfo := []*types.IndexInfo{{
 			Content:         summaryChunk.Content,
@@ -1428,6 +1433,7 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 		logger.Errorf(ctx, "Failed to get chat model: %v", err)
 		return fmt.Errorf("failed to get chat model: %w", err)
 	}
+	chatModel = newCachedChat(chatModel, s.cacheRepo, payload.TenantID, cacheTypeQuestion)
 	resolvedModelID = kb.SummaryModelID
 
 	// Initialize embedding model and retrieval engine
@@ -1437,6 +1443,7 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 		logger.Errorf(ctx, "Failed to get embedding model: %v", err)
 		return fmt.Errorf("failed to get embedding model: %w", err)
 	}
+	embeddingModel = newCachedEmbedder(embeddingModel, s.cacheRepo, payload.TenantID)
 
 	tenantInfo, err := s.tenantRepo.GetTenantByID(ctx, payload.TenantID)
 	if err != nil {
@@ -1730,6 +1737,7 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 		logger.Errorf(ctx, "Failed to get chat model: %v", err)
 		return fmt.Errorf("failed to get chat model: %w", err)
 	}
+	chatModel = newCachedChat(chatModel, s.cacheRepo, payload.TenantID, cacheTypeQuestion)
 	resolvedModelID = kb.SummaryModelID
 
 	embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
@@ -1738,6 +1746,7 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 		logger.Errorf(ctx, "Failed to get embedding model: %v", err)
 		return fmt.Errorf("failed to get embedding model: %w", err)
 	}
+	embeddingModel = newCachedEmbedder(embeddingModel, s.cacheRepo, payload.TenantID)
 
 	tenantInfo, err := s.tenantRepo.GetTenantByID(ctx, payload.TenantID)
 	if err != nil {
@@ -2388,6 +2397,7 @@ func (s *knowledgeService) updateChunkVector(ctx context.Context, kbID string, c
 	if err != nil {
 		return err
 	}
+	embeddingModel = newCachedEmbedder(embeddingModel, s.cacheRepo, types.MustTenantIDFromContext(ctx))
 
 	// Initialize composite retrieve engine from tenant configuration
 	indexInfo := make([]*types.IndexInfo, 0, len(chunks))
@@ -3198,7 +3208,40 @@ func (s *knowledgeService) convert(
 		req.FileType = fileType
 	}
 
-	result, err := s.callDocReaderWithTimeout(ctx, reader, req)
+	var (
+		result   *types.ReadResult
+		parseKey string
+		cacheHit bool
+		err      error
+	)
+	if !isURL && len(req.FileContent) > 0 {
+		fileDigest := sha256.Sum256(req.FileContent)
+		parseKey, _ = contentCacheKey(struct {
+			Version         string
+			FileHash        string
+			FileName        string
+			FileType        string
+			ParserEngine    string
+			ParserOverrides map[string]string
+		}{
+			Version:         "v1",
+			FileHash:        hex.EncodeToString(fileDigest[:]),
+			FileName:        req.FileName,
+			FileType:        req.FileType,
+			ParserEngine:    req.ParserEngine,
+			ParserOverrides: req.ParserEngineOverrides,
+		})
+		var cached types.ReadResult
+		if cacheGetJSON(ctx, s.cacheRepo, knowledge.TenantID, cacheTypeParse, parseKey, &cached) {
+			result = &cached
+			cacheHit = true
+			logger.Infof(ctx, "processing cache hit (type=%s key=%s)", cacheTypeParse, parseKey[:12])
+		}
+	}
+
+	if result == nil {
+		result, err = s.callDocReaderWithTimeout(ctx, reader, req)
+	}
 	if err != nil {
 		// Distinguish DocReader timeout (a knowable user-facing
 		// failure) from generic read errors so the UI can suggest
@@ -3222,10 +3265,14 @@ func (s *knowledgeService) convert(
 			werrors.ErrCodeDocReaderParseFailed, result.Error, nil)
 		return nil, nil
 	}
+	if !cacheHit && parseKey != "" {
+		cachePutJSON(ctx, s.cacheRepo, knowledge.TenantID, cacheTypeParse, parseKey, result)
+	}
 	docOutput := types.JSONMap{
 		"text_length":  len(result.MarkdownContent),
 		"images_found": len(result.ImageRefs),
 		"is_audio":     result.IsAudio,
+		"cache_hit":    cacheHit,
 	}
 	if pages := result.Metadata["pages"]; pages != "" {
 		docOutput["pages"] = pages

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -2074,7 +2074,7 @@ func (s *knowledgeService) ReparseKnowledge(
 			return nil, err
 		}
 
-		if _, err := s.enqueueManualProcessing(ctx, existing, meta.Content, true); err != nil {
+		if _, err := s.enqueueManualProcessing(ctx, existing, meta.Content, true, reparseAttempt); err != nil {
 			logger.Errorf(ctx, "Failed to enqueue manual reparse task: %v", err)
 			existing.ParseStatus = "failed"
 			existing.ErrorMessage = "Failed to enqueue processing task"
@@ -2670,15 +2670,16 @@ func (s *knowledgeService) ProcessManualUpdate(ctx context.Context, t *asynq.Tas
 		return nil
 	}
 
-	// Allocate a fresh span-tracking attempt for this manual (re)index.
-	// Without it attemptFromCtx stays 0, so processChunks drops all stage
-	// spans and KnowledgePostProcess falls back to LatestAttempt — piling
-	// this run's summary/wiki subspans onto the previous attempt's trace.
-	attempt := 0
-	if root, n, err := s.tracker().OpenAttempt(ctx, knowledge.ID, payload.LangfuseTraceID); err == nil && root != nil {
-		attempt = n
-	} else if err != nil {
-		logger.Warnf(ctx, "ProcessManualUpdate: OpenAttempt failed for %s: %v", knowledge.ID, err)
+	// ReparseKnowledge allocates the attempt before enqueueing so the UI can
+	// show pending stages immediately. Initial create/update tasks carry 0 and
+	// allocate here for backward compatibility.
+	attempt := payload.Attempt
+	if attempt <= 0 {
+		if root, n, err := s.tracker().OpenAttempt(ctx, knowledge.ID, payload.LangfuseTraceID); err == nil && root != nil {
+			attempt = n
+		} else if err != nil {
+			logger.Warnf(ctx, "ProcessManualUpdate: OpenAttempt failed for %s: %v", knowledge.ID, err)
+		}
 	}
 	ctx = withAttempt(ctx, attempt)
 
@@ -2688,10 +2689,14 @@ func (s *knowledgeService) ProcessManualUpdate(ctx context.Context, t *asynq.Tas
 			logger.ErrorWithFields(ctx, err, map[string]interface{}{
 				"knowledge_id": payload.KnowledgeID,
 			})
-			knowledge.ParseStatus = "failed"
-			knowledge.ErrorMessage = fmt.Sprintf("failed to cleanup old resources: %v", err)
-			knowledge.UpdatedAt = time.Now()
-			s.repo.UpdateKnowledge(ctx, knowledge)
+			s.failManualProcessingAttempt(
+				ctx,
+				knowledge,
+				attempt,
+				"manual_cleanup_failed",
+				"failed to cleanup old resources",
+				err,
+			)
 			return nil
 		}
 	}
@@ -2699,6 +2704,31 @@ func (s *knowledgeService) ProcessManualUpdate(ctx context.Context, t *asynq.Tas
 	// Run manual processing (image resolution + chunking + embedding) synchronously within the worker
 	s.triggerManualProcessing(ctx, kb, knowledge, payload.Content, true)
 	return nil
+}
+
+func (s *knowledgeService) failManualProcessingAttempt(
+	ctx context.Context,
+	knowledge *types.Knowledge,
+	attempt int,
+	errorCode string,
+	message string,
+	err error,
+) {
+	knowledge.ParseStatus = types.ParseStatusFailed
+	knowledge.ErrorMessage = fmt.Sprintf("%s: %v", message, err)
+	knowledge.UpdatedAt = time.Now()
+	if updateErr := s.repo.UpdateKnowledge(ctx, knowledge); updateErr != nil {
+		logger.Warnf(ctx, "failed to persist manual processing failure: %v", updateErr)
+	}
+	s.tracker().FinalizeAttempt(
+		ctx,
+		knowledge.ID,
+		attempt,
+		types.SpanStatusFailed,
+		nil,
+		errorCode,
+		knowledge.ErrorMessage,
+	)
 }
 
 // ProcessDocument handles Asynq document processing tasks

--- a/internal/application/service/processing_cache.go
+++ b/internal/application/service/processing_cache.go
@@ -1,0 +1,372 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/models/vlm"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/google/uuid"
+)
+
+const (
+	cacheTypeParse     = "parse"
+	cacheTypeEmbedding = "embedding"
+	cacheTypeVLM       = "vlm"
+	cacheTypeSummary   = "chat_summary"
+	cacheTypeQuestion  = "chat_question"
+	cacheTypeTable     = "chat_table"
+	cacheTypeWikiMap   = "wiki_map"
+	cacheTypeWikiChat  = "chat_wiki_map"
+	cacheTypeGraph     = "chat_graph"
+)
+
+var (
+	cacheMarkdownImagePattern = regexp.MustCompile(`!\[([^\]]*)\]\(([^)]+)\)`)
+	cacheImageURLPattern      = regexp.MustCompile(`(?i)<image\s+url="[^"]*">`)
+	cacheImageOriginalPattern = regexp.MustCompile(`(?is)<image_original>.*?</image_original>`)
+)
+
+func contentCacheKey(value any) (string, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// normalizeCacheText removes storage-generated image identities while keeping
+// all semantic text, including OCR and captions. Object URLs are deliberately
+// excluded because image bytes are keyed independently at the VLM layer.
+func normalizeCacheText(text string) string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	text = cacheMarkdownImagePattern.ReplaceAllString(text, "![$1]([image])")
+	text = cacheImageURLPattern.ReplaceAllString(text, `<image url="[image]">`)
+	text = cacheImageOriginalPattern.ReplaceAllString(text, "<image_original>[image]</image_original>")
+	return strings.TrimSpace(text)
+}
+
+func stableChunkID(knowledgeID string, chunkType types.ChunkType, sequence int, content string) string {
+	name := strings.Join([]string{
+		knowledgeID,
+		chunkType,
+		strconv.Itoa(sequence),
+		normalizeCacheText(content),
+	}, "\x00")
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(name)).String()
+}
+
+func cacheGetJSON(
+	ctx context.Context,
+	repo interfaces.ProcessingCacheRepository,
+	tenantID uint64,
+	cacheType, key string,
+	target any,
+) bool {
+	if repo == nil || tenantID == 0 || key == "" {
+		return false
+	}
+	payload, found, err := repo.Get(ctx, tenantID, cacheType, key)
+	if err != nil {
+		logger.Warnf(ctx, "processing cache get failed (type=%s): %v", cacheType, err)
+		return false
+	}
+	if !found {
+		return false
+	}
+	if err := json.Unmarshal(payload, target); err != nil {
+		logger.Warnf(ctx, "processing cache decode failed (type=%s): %v", cacheType, err)
+		return false
+	}
+	return true
+}
+
+func cachePutJSON(
+	ctx context.Context,
+	repo interfaces.ProcessingCacheRepository,
+	tenantID uint64,
+	cacheType, key string,
+	value any,
+) {
+	if repo == nil || tenantID == 0 || key == "" {
+		return
+	}
+	payload, err := json.Marshal(value)
+	if err != nil {
+		logger.Warnf(ctx, "processing cache encode failed (type=%s): %v", cacheType, err)
+		return
+	}
+	if err := repo.Put(ctx, tenantID, cacheType, key, payload); err != nil {
+		logger.Warnf(ctx, "processing cache put failed (type=%s): %v", cacheType, err)
+	}
+}
+
+type cachedChat struct {
+	inner     chat.Chat
+	repo      interfaces.ProcessingCacheRepository
+	tenantID  uint64
+	cacheType string
+}
+
+func newCachedChat(
+	inner chat.Chat,
+	repo interfaces.ProcessingCacheRepository,
+	tenantID uint64,
+	cacheType string,
+) chat.Chat {
+	if inner == nil || repo == nil || tenantID == 0 {
+		return inner
+	}
+	return &cachedChat{inner: inner, repo: repo, tenantID: tenantID, cacheType: cacheType}
+}
+
+func (c *cachedChat) GetModelName() string { return c.inner.GetModelName() }
+func (c *cachedChat) GetModelID() string   { return c.inner.GetModelID() }
+
+func (c *cachedChat) Chat(
+	ctx context.Context,
+	messages []chat.Message,
+	opts *chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	canonicalMessages := make([]chat.Message, len(messages))
+	copy(canonicalMessages, messages)
+	for i := range canonicalMessages {
+		canonicalMessages[i].Content = normalizeCacheText(canonicalMessages[i].Content)
+	}
+	key, err := contentCacheKey(struct {
+		ModelID   string
+		ModelName string
+		Messages  []chat.Message
+		Options   *chat.ChatOptions
+	}{
+		ModelID:   c.inner.GetModelID(),
+		ModelName: c.inner.GetModelName(),
+		Messages:  canonicalMessages,
+		Options:   opts,
+	})
+	if err == nil {
+		var cached types.ChatResponse
+		if cacheGetJSON(ctx, c.repo, c.tenantID, c.cacheType, key, &cached) {
+			cached.Usage = types.TokenUsage{}
+			logger.Infof(ctx, "processing cache hit (type=%s key=%s)", c.cacheType, key[:12])
+			return &cached, nil
+		}
+	}
+
+	response, callErr := c.inner.Chat(ctx, messages, opts)
+	if callErr == nil && response != nil && err == nil {
+		cachePutJSON(ctx, c.repo, c.tenantID, c.cacheType, key, response)
+	}
+	return response, callErr
+}
+
+func (c *cachedChat) ChatStream(
+	ctx context.Context,
+	messages []chat.Message,
+	opts *chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	return c.inner.ChatStream(ctx, messages, opts)
+}
+
+type cachedVLM struct {
+	inner    vlm.VLM
+	repo     interfaces.ProcessingCacheRepository
+	tenantID uint64
+}
+
+func newCachedVLM(
+	inner vlm.VLM,
+	repo interfaces.ProcessingCacheRepository,
+	tenantID uint64,
+) vlm.VLM {
+	if inner == nil || repo == nil || tenantID == 0 {
+		return inner
+	}
+	return &cachedVLM{inner: inner, repo: repo, tenantID: tenantID}
+}
+
+func (c *cachedVLM) GetModelName() string { return c.inner.GetModelName() }
+func (c *cachedVLM) GetModelID() string   { return c.inner.GetModelID() }
+
+func (c *cachedVLM) Predict(ctx context.Context, images [][]byte, prompt string) (string, error) {
+	imageHashes := make([]string, len(images))
+	for i, image := range images {
+		sum := sha256.Sum256(image)
+		imageHashes[i] = hex.EncodeToString(sum[:])
+	}
+	key, err := contentCacheKey(struct {
+		ModelID    string
+		ModelName  string
+		ImageHash  []string
+		PromptText string
+	}{
+		ModelID:    c.inner.GetModelID(),
+		ModelName:  c.inner.GetModelName(),
+		ImageHash:  imageHashes,
+		PromptText: prompt,
+	})
+	if err == nil {
+		var cached string
+		if cacheGetJSON(ctx, c.repo, c.tenantID, cacheTypeVLM, key, &cached) {
+			logger.Infof(ctx, "processing cache hit (type=%s key=%s)", cacheTypeVLM, key[:12])
+			return cached, nil
+		}
+	}
+
+	result, callErr := c.inner.Predict(ctx, images, prompt)
+	if callErr == nil && err == nil {
+		cachePutJSON(ctx, c.repo, c.tenantID, cacheTypeVLM, key, result)
+	}
+	return result, callErr
+}
+
+type cachedEmbedder struct {
+	inner    embedding.Embedder
+	repo     interfaces.ProcessingCacheRepository
+	tenantID uint64
+}
+
+func newCachedEmbedder(
+	inner embedding.Embedder,
+	repo interfaces.ProcessingCacheRepository,
+	tenantID uint64,
+) embedding.Embedder {
+	if inner == nil || repo == nil || tenantID == 0 {
+		return inner
+	}
+	return &cachedEmbedder{inner: inner, repo: repo, tenantID: tenantID}
+}
+
+func (c *cachedEmbedder) GetModelName() string { return c.inner.GetModelName() }
+func (c *cachedEmbedder) GetModelID() string   { return c.inner.GetModelID() }
+func (c *cachedEmbedder) GetDimensions() int   { return c.inner.GetDimensions() }
+
+func (c *cachedEmbedder) embeddingKey(text string) (string, error) {
+	return contentCacheKey(struct {
+		ModelID    string
+		ModelName  string
+		Dimensions int
+		Text       string
+	}{
+		ModelID:    c.inner.GetModelID(),
+		ModelName:  c.inner.GetModelName(),
+		Dimensions: c.inner.GetDimensions(),
+		Text:       normalizeCacheText(text),
+	})
+}
+
+func (c *cachedEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	results, err := c.embedBatch(ctx, []string{text}, func(missing []string) ([][]float32, error) {
+		vector, embedErr := c.inner.Embed(ctx, missing[0])
+		return [][]float32{vector}, embedErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return results[0], nil
+}
+
+func (c *cachedEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	return c.embedBatch(ctx, texts, func(missing []string) ([][]float32, error) {
+		return c.inner.BatchEmbed(ctx, missing)
+	})
+}
+
+func (c *cachedEmbedder) BatchEmbedWithPool(
+	ctx context.Context,
+	_ embedding.Embedder,
+	texts []string,
+) ([][]float32, error) {
+	return c.embedBatch(ctx, texts, func(missing []string) ([][]float32, error) {
+		return c.inner.BatchEmbedWithPool(ctx, c.inner, missing)
+	})
+}
+
+func (c *cachedEmbedder) embedBatch(
+	ctx context.Context,
+	texts []string,
+	fetch func([]string) ([][]float32, error),
+) ([][]float32, error) {
+	results := make([][]float32, len(texts))
+	keys := make([]string, len(texts))
+	missingTexts := make([]string, 0, len(texts))
+	missingIndexes := make(map[string][]int)
+
+	for i, text := range texts {
+		key, err := c.embeddingKey(text)
+		if err != nil {
+			key = "uncacheable:" + strconv.Itoa(i)
+			keys[i] = key
+			missingTexts = append(missingTexts, text)
+			missingIndexes[key] = []int{i}
+			continue
+		}
+		keys[i] = key
+		var vector []float32
+		if cacheGetJSON(ctx, c.repo, c.tenantID, cacheTypeEmbedding, key, &vector) {
+			results[i] = vector
+			continue
+		}
+		if _, exists := missingIndexes[key]; !exists {
+			missingTexts = append(missingTexts, text)
+		}
+		missingIndexes[key] = append(missingIndexes[key], i)
+	}
+
+	if len(missingTexts) == 0 {
+		logger.Infof(ctx, "processing cache hit (type=%s count=%d)", cacheTypeEmbedding, len(texts))
+		return results, nil
+	}
+
+	fetched, err := fetch(missingTexts)
+	if err != nil {
+		return nil, err
+	}
+	if len(fetched) != len(missingTexts) {
+		return nil, &cacheResultCountError{expected: len(missingTexts), actual: len(fetched)}
+	}
+
+	fetchedIndex := 0
+	seen := make(map[string]bool)
+	for i := range texts {
+		key := keys[i]
+		if results[i] != nil || seen[key] {
+			continue
+		}
+		seen[key] = true
+		vector := fetched[fetchedIndex]
+		fetchedIndex++
+		for _, index := range missingIndexes[key] {
+			results[index] = append([]float32(nil), vector...)
+		}
+		if key != "" {
+			cachePutJSON(ctx, c.repo, c.tenantID, cacheTypeEmbedding, key, vector)
+		}
+	}
+	return results, nil
+}
+
+type cacheResultCountError struct {
+	expected int
+	actual   int
+}
+
+func (e *cacheResultCountError) Error() string {
+	return fmt.Sprintf(
+		"embedding provider returned %d results for %d inputs",
+		e.actual,
+		e.expected,
+	)
+}

--- a/internal/application/service/processing_cache_test.go
+++ b/internal/application/service/processing_cache_test.go
@@ -1,0 +1,233 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+type memoryProcessingCache struct {
+	mu      sync.Mutex
+	entries map[string][]byte
+}
+
+func (c *memoryProcessingCache) cacheKey(tenantID uint64, cacheType, key string) string {
+	return fmt.Sprintf("%d:%s:%s", tenantID, cacheType, key)
+}
+
+func (c *memoryProcessingCache) Get(
+	_ context.Context, tenantID uint64, cacheType, key string,
+) ([]byte, bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	payload, ok := c.entries[c.cacheKey(tenantID, cacheType, key)]
+	return append([]byte(nil), payload...), ok, nil
+}
+
+func (c *memoryProcessingCache) Put(
+	_ context.Context, tenantID uint64, cacheType, key string, payload []byte,
+) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.entries == nil {
+		c.entries = make(map[string][]byte)
+	}
+	c.entries[c.cacheKey(tenantID, cacheType, key)] = append([]byte(nil), payload...)
+	return nil
+}
+
+type countingEmbedder struct {
+	batchCalls int
+	batches    [][]string
+}
+
+func (e *countingEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
+	return []float32{float32(len(text))}, nil
+}
+
+func (e *countingEmbedder) BatchEmbed(_ context.Context, texts []string) ([][]float32, error) {
+	e.batchCalls++
+	e.batches = append(e.batches, append([]string(nil), texts...))
+	out := make([][]float32, len(texts))
+	for i, text := range texts {
+		out[i] = []float32{float32(len(text))}
+	}
+	return out, nil
+}
+
+func (e *countingEmbedder) BatchEmbedWithPool(
+	ctx context.Context, _ embedding.Embedder, texts []string,
+) ([][]float32, error) {
+	return e.BatchEmbed(ctx, texts)
+}
+
+func (e *countingEmbedder) GetModelName() string { return "embedding-model" }
+func (e *countingEmbedder) GetDimensions() int   { return 1 }
+func (e *countingEmbedder) GetModelID() string   { return "embedding-id" }
+
+func TestCachedEmbedderBatchPartialHitsAndDeduplicates(t *testing.T) {
+	cache := &memoryProcessingCache{}
+	inner := &countingEmbedder{}
+	cached := newCachedEmbedder(inner, cache, 7)
+
+	got, err := cached.BatchEmbed(context.Background(), []string{"alpha", "beta", "alpha"})
+	require.NoError(t, err)
+	require.Equal(t, [][]float32{{5}, {4}, {5}}, got)
+	require.Equal(t, 1, inner.batchCalls)
+	require.Equal(t, []string{"alpha", "beta"}, inner.batches[0])
+
+	got, err = cached.BatchEmbed(context.Background(), []string{"beta", "alpha"})
+	require.NoError(t, err)
+	require.Equal(t, [][]float32{{4}, {5}}, got)
+	require.Equal(t, 1, inner.batchCalls)
+}
+
+type failingProcessingCache struct{}
+
+func (failingProcessingCache) Get(
+	context.Context, uint64, string, string,
+) ([]byte, bool, error) {
+	return nil, false, errors.New("cache unavailable")
+}
+
+func (failingProcessingCache) Put(
+	context.Context, uint64, string, string, []byte,
+) error {
+	return errors.New("cache unavailable")
+}
+
+func TestCachedEmbedderFailsOpenWhenCacheIsUnavailable(t *testing.T) {
+	inner := &countingEmbedder{}
+	cached := newCachedEmbedder(inner, failingProcessingCache{}, 7)
+
+	got, err := cached.BatchEmbed(context.Background(), []string{"alpha", "beta"})
+	require.NoError(t, err)
+	require.Equal(t, [][]float32{{5}, {4}}, got)
+	require.Equal(t, 1, inner.batchCalls)
+}
+
+type countingChat struct {
+	calls int
+}
+
+func (c *countingChat) Chat(
+	_ context.Context, messages []chat.Message, _ *chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	c.calls++
+	return &types.ChatResponse{Content: fmt.Sprintf("response-%d:%s", c.calls, messages[0].Content)}, nil
+}
+
+func (c *countingChat) ChatStream(
+	context.Context, []chat.Message, *chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	return nil, nil
+}
+
+func (c *countingChat) GetModelName() string { return "chat-model" }
+func (c *countingChat) GetModelID() string   { return "chat-id" }
+
+func TestCachedChatIgnoresVolatileImageURLButKeepsSemanticText(t *testing.T) {
+	cache := &memoryProcessingCache{}
+	inner := &countingChat{}
+	cached := newCachedChat(inner, cache, 9, cacheTypeWikiChat)
+	ctx := context.Background()
+
+	first, err := cached.Chat(ctx, []chat.Message{{
+		Role:    "user",
+		Content: `![page](resource://first)<image_ocr>same text</image_ocr>`,
+	}}, &chat.ChatOptions{Temperature: 0.1})
+	require.NoError(t, err)
+
+	second, err := cached.Chat(ctx, []chat.Message{{
+		Role:    "user",
+		Content: `![page](resource://second)<image_ocr>same text</image_ocr>`,
+	}}, &chat.ChatOptions{Temperature: 0.1})
+	require.NoError(t, err)
+	require.Equal(t, first.Content, second.Content)
+	require.Equal(t, 1, inner.calls)
+
+	_, err = cached.Chat(ctx, []chat.Message{{
+		Role:    "user",
+		Content: `![page](resource://second)<image_ocr>changed text</image_ocr>`,
+	}}, &chat.ChatOptions{Temperature: 0.1})
+	require.NoError(t, err)
+	require.Equal(t, 2, inner.calls)
+}
+
+type countingVLM struct {
+	calls int
+}
+
+func (v *countingVLM) Predict(_ context.Context, _ [][]byte, prompt string) (string, error) {
+	v.calls++
+	return fmt.Sprintf("%s-%d", prompt, v.calls), nil
+}
+
+func (v *countingVLM) GetModelName() string { return "vlm-model" }
+func (v *countingVLM) GetModelID() string   { return "vlm-id" }
+
+func TestCachedVLMKeysImageBytesAndPrompt(t *testing.T) {
+	cache := &memoryProcessingCache{}
+	inner := &countingVLM{}
+	cached := newCachedVLM(inner, cache, 11)
+	ctx := context.Background()
+
+	first, err := cached.Predict(ctx, [][]byte{[]byte("image-a")}, "ocr-v1")
+	require.NoError(t, err)
+	second, err := cached.Predict(ctx, [][]byte{[]byte("image-a")}, "ocr-v1")
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+	require.Equal(t, 1, inner.calls)
+
+	_, err = cached.Predict(ctx, [][]byte{[]byte("image-a")}, "ocr-v2")
+	require.NoError(t, err)
+	_, err = cached.Predict(ctx, [][]byte{[]byte("image-b")}, "ocr-v1")
+	require.NoError(t, err)
+	require.Equal(t, 3, inner.calls)
+}
+
+func TestCachedVLMFailsOpenOnCorruptPayload(t *testing.T) {
+	cache := &memoryProcessingCache{entries: make(map[string][]byte)}
+	inner := &countingVLM{}
+	cached := newCachedVLM(inner, cache, 11)
+	ctx := context.Background()
+
+	image := [][]byte{[]byte("image-a")}
+	imageHash := sha256.Sum256(image[0])
+	key, err := contentCacheKey(struct {
+		ModelID    string
+		ModelName  string
+		ImageHash  []string
+		PromptText string
+	}{
+		ModelID:    inner.GetModelID(),
+		ModelName:  inner.GetModelName(),
+		ImageHash:  []string{hex.EncodeToString(imageHash[:])},
+		PromptText: "ocr-v1",
+	})
+	require.NoError(t, err)
+	cache.entries[cache.cacheKey(11, cacheTypeVLM, key)] = []byte("{not-json")
+
+	got, err := cached.Predict(ctx, image, "ocr-v1")
+	require.NoError(t, err)
+	require.Equal(t, "ocr-v1-1", got)
+	require.Equal(t, 1, inner.calls)
+}
+
+func TestStableChunkIDNormalizesImageStorageURL(t *testing.T) {
+	first := stableChunkID("knowledge", types.ChunkTypeText, 3, "before ![page](resource://first) after")
+	second := stableChunkID("knowledge", types.ChunkTypeText, 3, "before ![page](resource://second) after")
+	require.Equal(t, first, second)
+
+	changed := stableChunkID("knowledge", types.ChunkTypeText, 3, "different text")
+	require.NotEqual(t, first, changed)
+}

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -330,6 +330,7 @@ type wikiIngestService struct {
 	pendingRepo    interfaces.TaskPendingOpsRepository
 	deadLetterRepo interfaces.TaskDeadLetterRepository
 	redisClient    *redis.Client // nil in Lite mode (no Redis)
+	cacheRepo      interfaces.ProcessingCacheRepository
 	// spanTracker lets per-document map work surface as a
 	// postprocess.wiki subspan in the knowledge trace tree. Async
 	// batch design means we look up the parent attempt by knowledge
@@ -359,6 +360,7 @@ func NewWikiIngestService(
 	pendingRepo interfaces.TaskPendingOpsRepository,
 	deadLetterRepo interfaces.TaskDeadLetterRepository,
 	redisClient *redis.Client,
+	cacheRepo interfaces.ProcessingCacheRepository,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
 	svc := &wikiIngestService{
@@ -373,6 +375,7 @@ func NewWikiIngestService(
 		pendingRepo:    pendingRepo,
 		deadLetterRepo: deadLetterRepo,
 		redisClient:    redisClient,
+		cacheRepo:      cacheRepo,
 		spanTracker:    spanTracker,
 	}
 	return svc

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -415,6 +416,7 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 	}
 
 	batchCtx := s.newWikiBatchContext(payload.KnowledgeBaseID, wikiConfig)
+	mapChatModel := newCachedChat(chatModel, s.cacheRepo, payload.TenantID, cacheTypeWikiChat)
 
 	// 1. MAP PHASE (Parallel extraction and generation of updates)
 	var mapMu sync.Mutex
@@ -514,7 +516,7 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 			mapMu.Unlock()
 
 			logger.Infof(mapCtx, "wiki ingest: processing document '%s' (%s)", op.DocTitle, op.KnowledgeID)
-			result, updates, err := s.mapOneDocument(mapCtx, chatModel, payload, op, batchCtx)
+			result, updates, err := s.mapOneDocument(mapCtx, mapChatModel, payload, op, batchCtx)
 			if err != nil {
 				mapMu.Lock()
 				ingestFailed++
@@ -1187,6 +1189,75 @@ func (s *wikiIngestService) ProcessWikiFinalize(ctx context.Context, t *asynq.Ta
 	return nil
 }
 
+type wikiMapCacheArtifact struct {
+	Entities       []extractedItem       `json:"entities"`
+	Concepts       []extractedItem       `json:"concepts"`
+	SummaryContent string                `json:"summary_content"`
+	Citations      map[string][]string   `json:"citations"`
+	NewSlugs       []newSlugFromCitation `json:"new_slugs"`
+	BatchCount     int                   `json:"batch_count"`
+	Pass0Failed    bool                  `json:"pass0_failed"`
+}
+
+type wikiMapChunkFingerprint struct {
+	ID         string `json:"id"`
+	ChunkIndex int    `json:"chunk_index"`
+	Content    string `json:"content"`
+}
+
+func buildWikiMapCacheKey(
+	knowledgeID string,
+	chatModel chat.Chat,
+	lang, content string,
+	chunks []*types.Chunk,
+	batchCtx *WikiBatchContext,
+) string {
+	chunkFingerprints := make([]wikiMapChunkFingerprint, 0, len(chunks))
+	for _, chunk := range chunks {
+		if chunk == nil {
+			continue
+		}
+		chunkFingerprints = append(chunkFingerprints, wikiMapChunkFingerprint{
+			ID:         chunk.ID,
+			ChunkIndex: chunk.ChunkIndex,
+			Content:    normalizeCacheText(chunk.Content),
+		})
+	}
+	key, _ := contentCacheKey(struct {
+		Version                string
+		KnowledgeID            string
+		ModelID                string
+		ModelName              string
+		Language               string
+		Content                string
+		Chunks                 []wikiMapChunkFingerprint
+		ExtractionGranularity  types.WikiExtractionGranularity
+		ContentInstructions    string
+		ExtractionInstructions string
+		Prompts                []string
+	}{
+		Version:                "v1",
+		KnowledgeID:            knowledgeID,
+		ModelID:                chatModel.GetModelID(),
+		ModelName:              chatModel.GetModelName(),
+		Language:               lang,
+		Content:                normalizeCacheText(content),
+		Chunks:                 chunkFingerprints,
+		ExtractionGranularity:  batchCtx.ExtractionGranularity,
+		ContentInstructions:    batchCtx.ContentInstructions,
+		ExtractionInstructions: batchCtx.ExtractionInstructions,
+		Prompts: []string{
+			agent.WikiCandidateSlugPrompt,
+			agent.WikiGranularityGuidance(string(batchCtx.ExtractionGranularity)),
+			agent.WikiKnowledgeExtractPrompt,
+			agent.WikiSummaryPrompt,
+			agent.WikiChunkCitationPrompt,
+			agent.WikiDeduplicationPrompt,
+		},
+	})
+	return key
+}
+
 func (s *wikiIngestService) mapOneDocument(
 	ctx context.Context,
 	chatModel chat.Chat,
@@ -1272,45 +1343,89 @@ func (s *wikiIngestService) mapOneDocument(
 	sourceRef := knowledgeID
 	oldPageSlugs := s.getExistingPageSlugsForKnowledge(ctx, payload.KnowledgeBaseID, knowledgeID)
 
-	// Pass 0: lightweight candidate slug extraction (skeleton only).
-	// On failure we fall back to the legacy single-shot extractor so the doc
-	// still gets ingested, just without chunk-level citations.
 	var (
 		extractedEntities []extractedItem
 		extractedConcepts []extractedItem
 		slugItems         map[string]extractedItem
 		pass0Failed       bool
+		summaryContent    string
+		summaryErr        error
+		citations         map[string][]string
+		newSlugs          []newSlugFromCitation
+		batchCount        int
 	)
-	logger.Infof(ctx, "wiki ingest: pass 0 — extracting candidate slugs for %s", knowledgeID)
-	extractSpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.extract", types.SpanKindSubSpan, types.JSONMap{
-		"content_chars": utf8.RuneCountInString(content),
-		"old_pages":     len(oldPageSlugs),
-	})
-	extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
-	if err != nil {
-		logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) — falling back to legacy extractor", knowledgeID, err)
-		pass0Failed = true
-		extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
+
+	mapCacheKey := buildWikiMapCacheKey(knowledgeID, chatModel, lang, content, chunks, batchCtx)
+	// Existing wiki pages are intentionally absent from this key. The cached
+	// artifact is the document-pure map output; retractions and replacements
+	// are rebuilt below from the current page state before reduce.
+	var cachedMap wikiMapCacheArtifact
+	mapCacheHit := cacheGetJSON(
+		ctx, s.cacheRepo, payload.TenantID, cacheTypeWikiMap, mapCacheKey, &cachedMap,
+	)
+	if mapCacheHit {
+		extractedEntities = cachedMap.Entities
+		extractedConcepts = cachedMap.Concepts
+		summaryContent = cachedMap.SummaryContent
+		citations = cachedMap.Citations
+		newSlugs = cachedMap.NewSlugs
+		batchCount = cachedMap.BatchCount
+		pass0Failed = cachedMap.Pass0Failed
+		logger.Infof(ctx, "wiki ingest: map cache hit for %s (key=%s)", knowledgeID, mapCacheKey[:12])
+	} else {
+		// Pass 0: lightweight candidate slug extraction (skeleton only).
+		// On failure we fall back to the legacy single-shot extractor so the
+		// document still gets ingested, just without chunk-level citations.
+		logger.Infof(ctx, "wiki ingest: pass 0 — extracting candidate slugs for %s", knowledgeID)
+		extractSpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.extract", types.SpanKindSubSpan, types.JSONMap{
+			"content_chars": utf8.RuneCountInString(content),
+			"old_pages":     len(oldPageSlugs),
+		})
+		extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(
+			ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx,
+		)
 		if err != nil {
-			logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
-			s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
-			s.tracker().FailSpan(ctx, wikiSpan, "EXTRACT_FAILED", err.Error(), err)
-			return nil, nil, err
+			logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) — falling back to legacy extractor", knowledgeID, err)
+			pass0Failed = true
+			extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(
+				ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx,
+			)
+			if err != nil {
+				logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
+				s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
+				s.tracker().FailSpan(ctx, wikiSpan, "EXTRACT_FAILED", err.Error(), err)
+				return nil, nil, err
+			}
+		}
+		s.tracker().EndSpan(ctx, extractSpan, types.JSONMap{
+			"entities":         len(extractedEntities),
+			"concepts":         len(extractedConcepts),
+			"pass0_fallback":   pass0Failed,
+			"entities_preview": previewExtractedItems(extractedEntities, 8),
+			"concepts_preview": previewExtractedItems(extractedConcepts, 8),
+		})
+	}
+
+	if slugItems == nil {
+		slugItems = make(map[string]extractedItem, len(extractedEntities)+len(extractedConcepts))
+		for _, item := range extractedEntities {
+			if item.Slug != "" && item.Name != "" {
+				slugItems[item.Slug] = item
+			}
+		}
+		for _, item := range extractedConcepts {
+			if item.Slug != "" && item.Name != "" {
+				slugItems[item.Slug] = item
+			}
 		}
 	}
-	s.tracker().EndSpan(ctx, extractSpan, types.JSONMap{
-		"entities":         len(extractedEntities),
-		"concepts":         len(extractedConcepts),
-		"pass0_fallback":   pass0Failed,
-		"entities_preview": previewExtractedItems(extractedEntities, 8),
-		"concepts_preview": previewExtractedItems(extractedConcepts, 8),
-	})
 
 	// Build slug listing for Summary's wiki-link input.
 	var summaryExtractedPages []string
 	for slug := range slugItems {
 		summaryExtractedPages = append(summaryExtractedPages, slug)
 	}
+	sort.Strings(summaryExtractedPages)
 	// Wiki summary slug is derived from the knowledge ID rather than the
 	// docTitle (which is typically the upload filename). Filename-based slugs
 	// like "summary/mx5280-pdf" expose the filename in cross-link contexts
@@ -1330,74 +1445,76 @@ func (s *wikiIngestService) mapOneDocument(
 		}
 	}
 
-	// Summary and chunk classification are independent given Pass 0 output —
-	// run them in parallel. Summary handles wiki-link injection; classification
-	// attaches concrete chunk IDs to each candidate slug.
-	var (
-		summaryContent string
-		summaryErr     error
-		citations      map[string][]string
-		newSlugs       []newSlugFromCitation
-		batchCount     int
-	)
-
-	// Both calls run in parallel goroutines under the same wikiSpan
-	// parent — their subspans will visually overlap in the trace view,
-	// which correctly reflects their wall-clock concurrency.
-	summarySpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.summary", types.SpanKindSubSpan, types.JSONMap{
-		"content_chars":   utf8.RuneCountInString(content),
-		"extracted_slugs": len(summaryExtractedPages),
-	})
-	var classifySpan *Span
-	if !pass0Failed {
-		classifySpan = s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.classify", types.SpanKindSubSpan, types.JSONMap{
-			"chunks":     len(chunks),
-			"candidates": len(extractedEntities) + len(extractedConcepts),
+	if !mapCacheHit {
+		// Summary and chunk classification are independent given Pass 0 output.
+		// Run them in parallel; summary handles wiki-link injection while
+		// classification attaches concrete chunk IDs to candidate slugs.
+		summarySpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.summary", types.SpanKindSubSpan, types.JSONMap{
+			"content_chars":   utf8.RuneCountInString(content),
+			"extracted_slugs": len(summaryExtractedPages),
 		})
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		summaryContent, summaryErr = s.generateWithTemplate(ctx, chatModel, agent.WikiSummaryPrompt, map[string]string{
-			"Content":            content,
-			"Language":           lang,
-			"ExtractedSlugs":     slugListing,
-			"CustomInstructions": batchCtx.ContentInstructions,
-			"InstructionScope":   "wiki_content",
-		})
-		if summaryErr != nil {
-			s.tracker().FailSpan(ctx, summarySpan, "SUMMARY_FAILED", summaryErr.Error(), summaryErr)
-		} else {
-			sumLine, sumBody := splitSummaryLine(summaryContent)
-			s.tracker().EndSpan(ctx, summarySpan, types.JSONMap{
-				"chars":        utf8.RuneCountInString(summaryContent),
-				"summary_line": previewText(sumLine, 160),
-				"body_preview": previewText(sumBody, 320),
+		var classifySpan *Span
+		if !pass0Failed {
+			classifySpan = s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.classify", types.SpanKindSubSpan, types.JSONMap{
+				"chunks":     len(chunks),
+				"candidates": len(extractedEntities) + len(extractedConcepts),
 			})
 		}
-	}()
-	go func() {
-		defer wg.Done()
-		// Skip citation pass when Pass 0 has fallen back to the legacy path —
-		// the legacy output already contains paraphrased Details, so chunk
-		// citations would be redundant and we'd spend LLM calls for nothing.
-		if pass0Failed {
-			citations = map[string][]string{}
-			return
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			summaryContent, summaryErr = s.generateWithTemplate(ctx, chatModel, agent.WikiSummaryPrompt, map[string]string{
+				"Content":            content,
+				"Language":           lang,
+				"ExtractedSlugs":     slugListing,
+				"CustomInstructions": batchCtx.ContentInstructions,
+				"InstructionScope":   "wiki_content",
+			})
+			if summaryErr != nil {
+				s.tracker().FailSpan(ctx, summarySpan, "SUMMARY_FAILED", summaryErr.Error(), summaryErr)
+			} else {
+				sumLine, sumBody := splitSummaryLine(summaryContent)
+				s.tracker().EndSpan(ctx, summarySpan, types.JSONMap{
+					"chars":        utf8.RuneCountInString(summaryContent),
+					"summary_line": previewText(sumLine, 160),
+					"body_preview": previewText(sumBody, 320),
+				})
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if pass0Failed {
+				citations = map[string][]string{}
+				return
+			}
+			candidatesXML := renderCandidateSlugsXML(extractedEntities, extractedConcepts)
+			citations, newSlugs, batchCount = s.classifyChunkCitations(
+				ctx, chatModel, candidatesXML, chunks, lang, batchCtx,
+			)
+			s.tracker().EndSpan(ctx, classifySpan, types.JSONMap{
+				"cited_slugs":      len(citations),
+				"new_slugs":        len(newSlugs),
+				"batches":          batchCount,
+				"top_cited":        topCitedSlugs(citations, 8),
+				"new_slugs_sample": previewNewSlugs(newSlugs, 8),
+			})
+		}()
+		wg.Wait()
+
+		if summaryErr == nil {
+			cachePutJSON(ctx, s.cacheRepo, payload.TenantID, cacheTypeWikiMap, mapCacheKey, wikiMapCacheArtifact{
+				Entities:       extractedEntities,
+				Concepts:       extractedConcepts,
+				SummaryContent: summaryContent,
+				Citations:      citations,
+				NewSlugs:       newSlugs,
+				BatchCount:     batchCount,
+				Pass0Failed:    pass0Failed,
+			})
 		}
-		candidatesXML := renderCandidateSlugsXML(extractedEntities, extractedConcepts)
-		citations, newSlugs, batchCount = s.classifyChunkCitations(ctx, chatModel, candidatesXML, chunks, lang, batchCtx)
-		s.tracker().EndSpan(ctx, classifySpan, types.JSONMap{
-			"cited_slugs":      len(citations),
-			"new_slugs":        len(newSlugs),
-			"batches":          batchCount,
-			"top_cited":        topCitedSlugs(citations, 8),
-			"new_slugs_sample": previewNewSlugs(newSlugs, 8),
-		})
-	}()
-	wg.Wait()
+	}
 
 	// Merge citations back into the item structs (non-failing; items without
 	// citations simply keep their Description+Details fallback).
@@ -1620,6 +1737,7 @@ func (s *wikiIngestService) mapOneDocument(
 		"pass0_fallback":   pass0Failed,
 		"classify_batches": batchCount,
 		"summary_preview":  previewText(docSummaryLine, 160),
+		"cache_hit":        mapCacheHit,
 	}
 
 	return &docIngestResult{
@@ -1646,11 +1764,15 @@ func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 	// confusing the model.
 	var prevSlugsText string
 	if len(oldPageSlugs) > 0 {
-		var sb strings.Builder
+		slugs := make([]string, 0, len(oldPageSlugs))
 		for slug := range oldPageSlugs {
-			if !strings.HasPrefix(slug, "entity/") && !strings.HasPrefix(slug, "concept/") {
-				continue
+			if strings.HasPrefix(slug, "entity/") || strings.HasPrefix(slug, "concept/") {
+				slugs = append(slugs, slug)
 			}
+		}
+		sort.Strings(slugs)
+		var sb strings.Builder
+		for _, slug := range slugs {
 			fmt.Fprintf(&sb, "- %s\n", slug)
 		}
 		prevSlugsText = sb.String()

--- a/internal/application/service/wiki_ingest_cache_test.go
+++ b/internal/application/service/wiki_ingest_cache_test.go
@@ -1,0 +1,120 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/require"
+)
+
+type wikiCacheKnowledgeService struct {
+	interfaces.KnowledgeService
+	knowledge *types.Knowledge
+}
+
+func (s *wikiCacheKnowledgeService) GetKnowledgeByIDOnly(
+	context.Context, string,
+) (*types.Knowledge, error) {
+	return s.knowledge, nil
+}
+
+type wikiCacheChunkRepository struct {
+	interfaces.ChunkRepository
+	chunks []*types.Chunk
+}
+
+func (r *wikiCacheChunkRepository) ListChunksByKnowledgeID(
+	context.Context, uint64, string,
+) ([]*types.Chunk, error) {
+	return r.chunks, nil
+}
+
+func (r *wikiCacheChunkRepository) ListChunksByParentIDs(
+	context.Context, uint64, []string,
+) ([]*types.Chunk, error) {
+	return nil, nil
+}
+
+type wikiCachePageService struct {
+	interfaces.WikiPageService
+	slugs []string
+}
+
+func (s *wikiCachePageService) ListSlugsBySourceRef(
+	context.Context, string, string,
+) ([]string, error) {
+	return s.slugs, nil
+}
+
+func TestWikiMapArtifactCacheSkipsMapLLMAndStillBuildsRetractions(t *testing.T) {
+	const (
+		tenantID    = uint64(12)
+		knowledgeID = "knowledge-1"
+		kbID        = "kb-1"
+	)
+	chunk := &types.Chunk{
+		ID:              "chunk-1",
+		TenantID:        tenantID,
+		KnowledgeID:     knowledgeID,
+		KnowledgeBaseID: kbID,
+		ChunkIndex:      0,
+		ChunkType:       types.ChunkTypeText,
+		Content:         "Acme builds a retrieval platform. This text is long enough for wiki extraction.",
+	}
+	knowledge := &types.Knowledge{
+		ID:          knowledgeID,
+		TenantID:    tenantID,
+		Title:       "Acme document",
+		ParseStatus: types.ParseStatusCompleted,
+	}
+	cache := &memoryProcessingCache{}
+	model := &countingChat{}
+	batchCtx := &WikiBatchContext{
+		ExtractionGranularity: types.WikiExtractionStandard,
+		SummaryContentByKnowledgeID: func(context.Context, string) string {
+			return "previous contribution"
+		},
+	}
+	lang := types.LanguageLocaleName("en")
+	key := buildWikiMapCacheKey(knowledgeID, model, lang, chunk.Content, []*types.Chunk{chunk}, batchCtx)
+	cachePutJSON(context.Background(), cache, tenantID, cacheTypeWikiMap, key, wikiMapCacheArtifact{
+		Entities: []extractedItem{{
+			Name:        "Acme",
+			Slug:        "entity/acme",
+			Description: "A retrieval platform company",
+		}},
+		SummaryContent: "SUMMARY: Acme overview\nAcme builds a retrieval platform.",
+		Citations: map[string][]string{
+			"entity/acme": {"chunk-1"},
+		},
+		BatchCount: 1,
+	})
+
+	svc := &wikiIngestService{
+		knowledgeSvc: &wikiCacheKnowledgeService{knowledge: knowledge},
+		chunkRepo:    &wikiCacheChunkRepository{chunks: []*types.Chunk{chunk}},
+		wikiService:  &wikiCachePageService{slugs: []string{"entity/acme", "summary/knowledge-1"}},
+		cacheRepo:    cache,
+	}
+	result, updates, err := svc.mapOneDocument(
+		context.Background(),
+		model,
+		WikiIngestPayload{TenantID: tenantID, KnowledgeBaseID: kbID},
+		WikiPendingOp{Op: WikiOpIngest, KnowledgeID: knowledgeID, Language: "en"},
+		batchCtx,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Zero(t, model.calls)
+	require.Equal(t, true, result.MapStats["cache_hit"])
+
+	updateTypes := make(map[string]int)
+	for _, update := range updates {
+		updateTypes[update.Type]++
+	}
+	require.Equal(t, 1, updateTypes[types.WikiPageTypeSummary])
+	require.Equal(t, 1, updateTypes[types.WikiPageTypeEntity])
+	require.Equal(t, 1, updateTypes["retract"])
+}

--- a/internal/application/service/wiki_ingest_cite.go
+++ b/internal/application/service/wiki_ingest_cite.go
@@ -78,11 +78,15 @@ func (s *wikiIngestService) extractCandidateSlugs(
 ) ([]extractedItem, []extractedItem, map[string]extractedItem, error) {
 	var prevSlugsText string
 	if len(oldPageSlugs) > 0 {
-		var sb strings.Builder
+		slugs := make([]string, 0, len(oldPageSlugs))
 		for slug := range oldPageSlugs {
-			if !strings.HasPrefix(slug, "entity/") && !strings.HasPrefix(slug, "concept/") {
-				continue
+			if strings.HasPrefix(slug, "entity/") || strings.HasPrefix(slug, "concept/") {
+				slugs = append(slugs, slug)
 			}
+		}
+		sort.Strings(slugs)
+		var sb strings.Builder
+		for _, slug := range slugs {
 			fmt.Fprintf(&sb, "- %s\n", slug)
 		}
 		prevSlugsText = sb.String()

--- a/internal/application/service/wiki_ingest_taxonomy.go
+++ b/internal/application/service/wiki_ingest_taxonomy.go
@@ -182,6 +182,7 @@ func (s *wikiIngestService) selectRelevantFolders(
 		logger.Warnf(ctx, "wiki ingest: taxonomy plan embed model unavailable, feeding all folders: %v", err)
 		return capFolders(pool, wikiTaxonomyPromptMaxPaths)
 	}
+	embedder = newCachedEmbedder(embedder, s.cacheRepo, kb.TenantID)
 
 	folderTexts := make([]string, len(deeper))
 	for i, p := range deeper {

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -147,6 +147,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewKnowledgeRepository))
 	must(container.Provide(repository.NewKnowledgeSpanRepository))
 	must(container.Provide(repository.NewChunkRepository))
+	must(container.Provide(repository.NewProcessingCacheRepository))
 	must(container.Provide(repository.NewKnowledgeTagRepository))
 	must(container.Provide(repository.NewSessionRepository))
 	must(container.Provide(repository.NewMessageRepository))

--- a/internal/database/migration_processing_cache_test.go
+++ b/internal/database/migration_processing_cache_test.go
@@ -1,0 +1,48 @@
+package database
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLiteMigrationsCreateProcessingCache(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(repoRoot))
+	t.Cleanup(func() {
+		_ = os.Chdir(originalDir)
+	})
+
+	dbPath := filepath.Join(t.TempDir(), "migration.db")
+	require.NoError(t, RunMigrationsWithOptions(
+		"sqlite3://"+dbPath,
+		MigrationOptions{SQLiteDBPath: dbPath},
+	))
+
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	var tableName string
+	require.NoError(t, db.QueryRow(
+		"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'processing_cache_entries'",
+	).Scan(&tableName))
+	require.Equal(t, "processing_cache_entries", tableName)
+
+	version, dirty, available := CachedMigrationVersion()
+	require.True(t, available)
+	require.False(t, dirty)
+	require.EqualValues(t, 75, version)
+}

--- a/internal/types/interfaces/processing_cache.go
+++ b/internal/types/interfaces/processing_cache.go
@@ -1,0 +1,10 @@
+package interfaces
+
+import "context"
+
+// ProcessingCacheRepository persists content-addressed ingestion artifacts.
+// Implementations must isolate entries by tenant.
+type ProcessingCacheRepository interface {
+	Get(ctx context.Context, tenantID uint64, cacheType, cacheKey string) ([]byte, bool, error)
+	Put(ctx context.Context, tenantID uint64, cacheType, cacheKey string, payload []byte) error
+}

--- a/internal/types/processing_cache.go
+++ b/internal/types/processing_cache.go
@@ -1,0 +1,22 @@
+package types
+
+import "time"
+
+// ProcessingCacheEntry stores a content-addressed ingestion artifact.
+// Cache keys are scoped by tenant and artifact type to prevent cross-tenant
+// reuse of document-derived data.
+type ProcessingCacheEntry struct {
+	TenantID  uint64     `json:"tenant_id" gorm:"primaryKey;autoIncrement:false"`
+	CacheType string     `json:"cache_type" gorm:"type:varchar(32);primaryKey"`
+	CacheKey  string     `json:"cache_key" gorm:"type:varchar(64);primaryKey"`
+	Payload   []byte     `json:"payload" gorm:"type:bytea;not null"`
+	SizeBytes int64      `json:"size_bytes" gorm:"not null;default:0"`
+	HitCount  int64      `json:"hit_count" gorm:"not null;default:0"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+	LastHitAt *time.Time `json:"last_hit_at,omitempty" gorm:"index"`
+}
+
+func (ProcessingCacheEntry) TableName() string {
+	return "processing_cache_entries"
+}

--- a/internal/types/task.go
+++ b/internal/types/task.go
@@ -459,6 +459,10 @@ type ManualProcessPayload struct {
 	KnowledgeBaseID string `json:"knowledge_base_id"`
 	Content         string `json:"content"`      // cleaned markdown content
 	NeedCleanup     bool   `json:"need_cleanup"` // true for update, false for create
+	// Attempt joins a user-initiated reparse to the root span allocated by
+	// ReparseKnowledge. Initial create/update tasks leave it unset and let
+	// the worker allocate a fresh attempt.
+	Attempt int `json:"attempt,omitempty"`
 }
 
 // ImageMultimodalPayload represents the image multimodal processing task payload.

--- a/migrations/sqlite/000075_processing_cache.down.sql
+++ b/migrations/sqlite/000075_processing_cache.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS processing_cache_entries;

--- a/migrations/sqlite/000075_processing_cache.up.sql
+++ b/migrations/sqlite/000075_processing_cache.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS processing_cache_entries (
+    tenant_id INTEGER NOT NULL,
+    cache_type VARCHAR(32) NOT NULL,
+    cache_key VARCHAR(64) NOT NULL,
+    payload BLOB NOT NULL,
+    size_bytes INTEGER NOT NULL DEFAULT 0,
+    hit_count INTEGER NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_hit_at DATETIME,
+    PRIMARY KEY (tenant_id, cache_type, cache_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_processing_cache_last_hit
+    ON processing_cache_entries(last_hit_at);

--- a/migrations/versioned/000075_processing_cache.down.sql
+++ b/migrations/versioned/000075_processing_cache.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS processing_cache_entries;

--- a/migrations/versioned/000075_processing_cache.up.sql
+++ b/migrations/versioned/000075_processing_cache.up.sql
@@ -1,0 +1,19 @@
+DO $$ BEGIN RAISE NOTICE '[Migration 000075] Creating processing cache...'; END $$;
+
+CREATE TABLE IF NOT EXISTS processing_cache_entries (
+    tenant_id BIGINT NOT NULL,
+    cache_type VARCHAR(32) NOT NULL,
+    cache_key VARCHAR(64) NOT NULL,
+    payload BYTEA NOT NULL,
+    size_bytes BIGINT NOT NULL DEFAULT 0,
+    hit_count BIGINT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_hit_at TIMESTAMP WITH TIME ZONE,
+    PRIMARY KEY (tenant_id, cache_type, cache_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_processing_cache_last_hit
+    ON processing_cache_entries(last_hit_at);
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000075] Processing cache ready'; END $$;


### PR DESCRIPTION
## Description

Fixes #1679

Adds a tenant-scoped, database-backed content-addressed cache so unchanged knowledge reparses and crash retries reuse expensive ingestion artifacts instead of calling models again. Cache failures are best-effort misses and never block ingestion.

## Changes

- Generate deterministic UUIDv5 IDs for parser-derived text, parent, image OCR/caption, and summary chunks; purge only matching soft-deleted tombstones before stable-ID reinsertion.
- Add `processing_cache_entries` with PostgreSQL and SQLite migrations, composite tenant/type/key isolation, hit metadata, and upsert support.
- Cache parsed document results by file bytes + parser engine/config.
- Cache OCR/caption by image bytes + VLM identity + rendered prompt, freezing successful output as canonical text.
- Cache embeddings by normalized text + model ID/name + dimensions, including partial batch hits and duplicate-text coalescing.
- Cache summary, question, GraphRAG per-chunk, FAQ, and table enrichment Chat/Embedding calls using their effective prompts and configuration.
- Cache durable Wiki per-document map output (extract/dedup/summary/classify and chunk citations), then rebuild retractions from current page state before running reduce.
- Keep Wiki reduce/finalization live because they depend on cross-document state.
- Normalize volatile image storage URLs in downstream cache keys so re-uploaded identical image bytes do not invalidate semantic artifacts.
- Sort Wiki slug inputs to remove map-order cache jitter.

## Invalidation behavior

Cache keys include the exact dependency layer: model identity, dimensions, prompts/options, parser overrides, extraction granularity, language, custom instructions, content, and stable chunk fingerprints. Changing one layer only invalidates dependent artifacts; for example, changing the embedding model preserves parser/VLM/Wiki artifacts, while changing chunking preserves parser/VLM results.

## Verification

- `go test ./internal/application/repository ./internal/application/service ./internal/database ./internal/container`
- `go test -race ./internal/application/service ./internal/application/repository -run 'Test(Cached|StableChunk|WikiMapArtifact|ProcessingCacheRepository|DeleteChunksByKnowledgeID)'`
- `go vet ./...`
- `go build ./cmd/server`
- SQLite migration round trip test reaches version 75 with `dirty=false`.
- PostgreSQL 17 migration `000075` up/down executed successfully in a real container.

Repository-wide `go test ./...` was also run. Modified packages pass; unrelated existing environment-dependent failures require DocReader on `:50051`, permit localhost in SSRF tests, and allow sandbox access to `~/.duckdb`.

## Checklist

- [x] Self-reviewed the code
- [x] Added tests for cache hit/miss, tenant isolation, fail-open behavior, stable IDs, Wiki map reuse, and migration behavior
- [x] Verified PostgreSQL and SQLite migrations
- [x] Kept cache operations fail-open
- [x] Kept Wiki reduce intentionally uncached
