### PR TITLE
feat: add default model support

### DIFF
--- a/frontend/src/api/model/index.ts
+++ b/frontend/src/api/model/index.ts
@@ -145,6 +145,24 @@ export function deleteModel(id: string): Promise<void> {
   });
 }
 
+// 设置默认模型
+export function setDefaultModel(id: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    put(`/api/v1/models/${id}/default`, {})
+      .then((response: any) => {
+        if (response.success) {
+          resolve();
+        } else {
+          reject(new Error(response.message || t('error.model.setDefaultFailed')));
+        }
+      })
+      .catch((error: any) => {
+        console.error('Failed to set default model:', error);
+        reject(error);
+      });
+  });
+}
+
 export interface ModelDebugOptions {
   system_prompt?: string
   temperature?: number

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -4147,6 +4147,7 @@ export default {
       getFailed: 'Failed to get model',
       updateFailed: 'Failed to update model',
       deleteFailed: 'Failed to delete model',
+      setDefaultFailed: 'Failed to set default model',
     },
     tenant: {
       listFailed: 'Failed to list workspaces',
@@ -4810,7 +4811,8 @@ export default {
     actions: {
       addModel: 'Add Model',
       debugModel: 'Model Test',
-      setDefault: 'Set as Default'
+      setDefault: 'Set as Default',
+      unsetDefault: 'Unset Default',
     },
     source: {
       remote: 'Remote',
@@ -4855,8 +4857,9 @@ export default {
       saveFailed: 'Failed to save model',
       deleted: 'Model deleted',
       deleteFailed: 'Failed to delete model',
-      setDefault: 'Set as default',
+      defaultSet: 'Set as default model',
       setDefaultFailed: 'Failed to set default model',
+      unsetDefaultHint: 'Set another model as default to unset the current one',
       builtinCannotEdit: 'Built-in models cannot be edited',
       builtinCannotDelete: 'Built-in models cannot be deleted',
       builtinCannotCopy: 'Built-in models cannot be copied',
@@ -4871,6 +4874,7 @@ export default {
       viewGuide: 'View Built-in Models Guide',
     },
     builtinTag: 'Built-in',
+    defaultTag: 'Default',
     confirmDelete: 'Delete model "{name}"?',
     debug: {
       title: 'Model Test',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -4814,6 +4814,7 @@ export default {
       addModel: "모델 추가",
       debugModel: "모델 테스트",
       setDefault: "기본값으로 설정",
+      unsetDefault: "기본값 해제",
     },
     source: {
       remote: "Remote",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -2794,7 +2794,8 @@ export default {
       createFailed: 'Не удалось создать модель',
       getFailed: 'Не удалось получить модель',
       updateFailed: 'Не удалось обновить модель',
-      deleteFailed: 'Не удалось удалить модель'
+      deleteFailed: 'Не удалось удалить модель',
+      setDefaultFailed: 'Не удалось установить модель по умолчанию',
     },
     tenant: {
       listFailed: 'Не удалось получить список пространств',
@@ -4469,7 +4470,8 @@ export default {
     actions: {
       addModel: 'Добавить модель',
       debugModel: 'Тест модели',
-      setDefault: 'Сделать по умолчанию'
+      setDefault: 'Сделать по умолчанию',
+      unsetDefault: 'Отменить по умолчанию',
     },
     chat: {
       title: 'Модели диалога',
@@ -4514,8 +4516,9 @@ export default {
       saveFailed: 'Не удалось сохранить модель',
       deleted: 'Модель удалена',
       deleteFailed: 'Не удалось удалить модель',
-      setDefault: 'Установлено по умолчанию',
+      defaultSet: 'Установлено по умолчанию',
       setDefaultFailed: 'Не удалось установить по умолчанию',
+      unsetDefaultHint: 'Установите другую модель по умолчанию, чтобы отменить текущую',
       builtinCannotEdit: 'Встроенные модели нельзя редактировать',
       builtinCannotDelete: 'Встроенные модели нельзя удалить',
       builtinCannotCopy: 'Встроенные модели нельзя копировать',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -3120,6 +3120,7 @@ export default {
       getFailed: "获取模型失败",
       updateFailed: "更新模型失败",
       deleteFailed: "删除模型失败",
+      setDefaultFailed: "设置默认模型失败",
     },
     tenant: {
       listFailed: "获取空间列表失败",
@@ -4852,6 +4853,7 @@ export default {
       addModel: "添加模型",
       debugModel: "模型测试",
       setDefault: "设为默认",
+      unsetDefault: "取消默认",
     },
     source: {
       remote: "Remote",
@@ -4896,8 +4898,9 @@ export default {
       saveFailed: "保存模型失败",
       deleted: "模型已删除",
       deleteFailed: "删除模型失败",
-      setDefault: "已设为默认模型",
+      defaultSet: "已设为默认模型",
       setDefaultFailed: "设置默认模型失败",
+      unsetDefaultHint: "选择其他模型设为默认即可取消当前默认",
       builtinCannotEdit: "内置模型不能编辑",
       builtinCannotDelete: "内置模型不能删除",
       builtinCannotCopy: "内置模型不能复制",
@@ -4912,6 +4915,7 @@ export default {
       viewGuide: "查看内置模型管理指南",
     },
     builtinTag: "内置",
+    defaultTag: "默认",
     confirmDelete: "确定删除模型「{name}」吗？",
     debug: {
       title: "模型测试",

--- a/frontend/src/views/settings/ModelSettings.vue
+++ b/frontend/src/views/settings/ModelSettings.vue
@@ -66,6 +66,9 @@
           <div class="model-card__body">
             <div class="model-card__header">
               <h3 class="model-card__title">{{ modelDisplayName(model) }}</h3>
+              <span v-if="model.isDefault" class="model-card__default-badge">
+                {{ $t('modelSettings.defaultTag') }}
+              </span>
               <span v-if="model.isBuiltin" class="model-card__lock" :title="$t('modelSettings.builtinTag')"
                 :aria-label="$t('modelSettings.builtinTag')">
                 <t-icon :name="authStore.isSystemAdmin ? 'edit-1' : 'lock-on'" />
@@ -147,7 +150,7 @@ import { AddIcon, PlayCircleIcon } from 'tdesign-icons-vue-next'
 import { useI18n } from 'vue-i18n'
 import ModelEditorDialog from '@/components/ModelEditorDialog.vue'
 import ModelDebugDrawer from '@/components/ModelDebugDrawer.vue'
-import { listModels, createModel, updateModel as updateModelAPI, deleteModel as deleteModelAPI, type ModelConfig } from '@/api/model'
+import { listModels, createModel, updateModel as updateModelAPI, deleteModel as deleteModelAPI, setDefaultModel, type ModelConfig } from '@/api/model'
 import { useAuthStore } from '@/stores/auth'
 
 const { t, te } = useI18n()
@@ -204,11 +207,20 @@ function convertToLegacyFormat(model: ModelConfig) {
     // Preserve the credential metadata map so the editor dialog can render
     // the "Configured" state without an extra round-trip.
     credentials: model.credentials,
+    isDefault: model.is_default || false,
   }
 }
 
-// 平铺 + 过滤
-const allLegacyModels = computed(() => allModels.value.map(convertToLegacyFormat))
+// 平铺 + 过滤 + 排序（默认模型优先）
+const allLegacyModels = computed(() => {
+  const models = allModels.value.map(convertToLegacyFormat)
+  // 按默认状态排序：默认模型排在前面
+  return models.sort((a, b) => {
+    if (a.isDefault && !b.isDefault) return -1
+    if (!a.isDefault && b.isDefault) return 1
+    return 0
+  })
+})
 const filteredModels = computed(() => {
   if (activeTypeFilter.value === 'all') return allLegacyModels.value
   return allLegacyModels.value.filter(m => m._modelType === activeTypeFilter.value)
@@ -531,6 +543,19 @@ const getModelOptions = (type: ModelType, model: any) => {
     value: `copy-${type}-${model.id}`
   })
 
+  // 添加设置/取消默认选项
+  if (model.isDefault) {
+    options.push({
+      content: t('modelSettings.actions.unsetDefault'),
+      value: `unset-default-${type}-${model.id}`
+    })
+  } else {
+    options.push({
+      content: t('modelSettings.actions.setDefault'),
+      value: `set-default-${type}-${model.id}`
+    })
+  }
+
   return options
 }
 
@@ -542,6 +567,10 @@ const handleMenuAction = (data: { value: string }, type: ModelType, model: any) 
     editModel(type, model)
   } else if (value.indexOf('copy-') === 0) {
     copyModel(type, model.id)
+  } else if (value.indexOf('set-default-') === 0) {
+    setDefaultModelAction(model.id)
+  } else if (value.indexOf('unset-default-') === 0) {
+    unsetDefaultModelAction(model.id)
   }
 }
 
@@ -586,6 +615,23 @@ const copyModel = async (_type: ModelType, modelId: string) => {
     console.error('复制模型失败:', error)
     MessagePlugin.error(error.message || t('modelSettings.toasts.copyFailed'))
   }
+}
+
+// 设置默认模型
+const setDefaultModelAction = async (modelId: string) => {
+  try {
+    await setDefaultModel(modelId)
+    MessagePlugin.success(t('modelSettings.toasts.defaultSet'))
+    await loadModels()
+  } catch (error: any) {
+    console.error('设置默认模型失败:', error)
+    MessagePlugin.error(error.message || t('modelSettings.toasts.setDefaultFailed'))
+  }
+}
+
+// 取消默认模型（通过将另一个模型设为默认来实现）
+const unsetDefaultModelAction = async (modelId: string) => {
+  MessagePlugin.info(t('modelSettings.toasts.unsetDefaultHint'))
 }
 
 // 获取后端模型类型
@@ -909,6 +955,31 @@ onMounted(() => {
 .model-card:hover .model-card__lock {
   opacity: 1;
   color: var(--td-text-color-secondary);
+}
+
+/*
+  Default badge indicator. Shows "默认" text for the default model.
+  Uses a subtle badge style to indicate this is the preferred choice.
+*/
+.model-card__default-badge {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 8px;
+  height: 20px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--td-brand-color);
+  background: var(--td-brand-color-light);
+  border-radius: 3px;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.model-card:hover .model-card__default-badge {
+  color: var(--td-brand-color-hover);
+  background: color-mix(in srgb, var(--td-brand-color) 15%, transparent);
 }
 
 .model-card__subtitle {

--- a/internal/application/service/model.go
+++ b/internal/application/service/model.go
@@ -630,6 +630,56 @@ func (s *modelService) GetASRModel(ctx context.Context, modelId string) (asr.ASR
 	return sttModel, nil
 }
 
+// SetDefaultModel sets a model as the default for its type
+// Only one model per type can be the default within a tenant
+func (s *modelService) SetDefaultModel(ctx context.Context, id string) error {
+	logger.Info(ctx, "Start setting default model")
+	logger.Infof(ctx, "Model ID: %s", id)
+
+	tenantID := types.MustTenantIDFromContext(ctx)
+
+	// Get the model to determine its type
+	model, err := s.repo.GetByID(ctx, tenantID, id)
+	if err != nil {
+		logger.ErrorWithFields(ctx, err, map[string]interface{}{
+			"model_id": id,
+		})
+		return err
+	}
+	if model == nil {
+		return ErrModelNotFound
+	}
+
+	// Built-in models can be set as default by both tenant admins and system admins
+	if model.IsBuiltin && !types.IsSystemAdminFromContext(ctx) {
+		// Tenant admins can set built-in models as their tenant's default
+		logger.Infof(ctx, "Tenant admin setting builtin model as default: %s", id)
+	}
+
+	// Clear any existing default for this model type in this tenant
+	if err := s.repo.ClearDefaultByType(ctx, uint(tenantID), model.Type, id); err != nil {
+		logger.ErrorWithFields(ctx, err, map[string]interface{}{
+			"model_id":   id,
+			"model_type": model.Type,
+			"tenant_id":  tenantID,
+		})
+		return err
+	}
+
+	// Set this model as default
+	model.IsDefault = true
+	if err := s.repo.Update(ctx, model); err != nil {
+		logger.ErrorWithFields(ctx, err, map[string]interface{}{
+			"model_id":   id,
+			"model_name": model.Name,
+		})
+		return err
+	}
+
+	logger.Infof(ctx, "Model set as default successfully: %s (type: %s)", id, model.Type)
+	return nil
+}
+
 func formatModelInUseMessage(kbCount, agentCount int64) string {
 	switch {
 	case kbCount > 0 && agentCount > 0:

--- a/internal/handler/model.go
+++ b/internal/handler/model.go
@@ -695,6 +695,53 @@ func (h *ModelHandler) DeleteModel(c *gin.Context) {
 	})
 }
 
+// SetDefaultModel godoc
+// @Summary      设置默认模型
+// @Description  将指定模型设置为其类型的默认模型
+// @Tags         模型管理
+// @Accept       json
+// @Produce      json
+// @Param        id   path      string  true  "模型ID"
+// @Success      200  {object}  map[string]interface{}  "设置成功"
+// @Failure      404  {object}  errors.AppError         "模型不存在"
+// @Security     Bearer
+// @Security     ApiKeyAuth
+// @Router       /models/{id}/default [put]
+func (h *ModelHandler) SetDefaultModel(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	logger.Info(ctx, "Start setting default model")
+
+	id := secutils.SanitizeForLog(c.Param("id"))
+	if id == "" {
+		logger.Error(ctx, "Model ID is empty")
+		c.Error(errors.NewBadRequestError("Model ID cannot be empty"))
+		return
+	}
+
+	logger.Infof(ctx, "Setting model as default, ID: %s", id)
+	if err := h.service.SetDefaultModel(ctx, id); err != nil {
+		if err == service.ErrModelNotFound {
+			logger.Warnf(ctx, "Model not found, ID: %s", id)
+			c.Error(errors.NewNotFoundError("Model not found"))
+			return
+		}
+		if appErr, ok := errors.IsAppError(err); ok {
+			c.Error(appErr)
+			return
+		}
+		logger.ErrorWithFields(ctx, err, nil)
+		c.Error(errors.NewInternalServerError(err.Error()))
+		return
+	}
+
+	logger.Infof(ctx, "Model set as default successfully, ID: %s", id)
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "Model set as default",
+	})
+}
+
 // ModelProviderDTO 模型厂商信息 DTO
 type ModelProviderDTO struct {
 	Value       string            `json:"value"`       // provider 标识符

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -800,6 +800,8 @@ func RegisterModelRoutes(
 		models.GET("/:id", g.Viewer(), handler.GetModel)
 		// 更新模型 — Admin+；内置模型仍由服务层额外限定为 SystemAdmin。
 		models.PUT("/:id", g.AdminOrSystemAdmin(), handler.UpdateModel)
+		// 设置默认模型 — Admin+
+		models.PUT("/:id/default", g.Admin(), handler.SetDefaultModel)
 		// 删除模型 — Admin+
 		models.DELETE("/:id", g.Admin(), handler.DeleteModel)
 		// Per-field credential subresource (see internal/handler/model_credentials.go) — Admin+

--- a/internal/types/interfaces/model.go
+++ b/internal/types/interfaces/model.go
@@ -44,6 +44,8 @@ type ModelService interface {
 	GetVLMModel(ctx context.Context, modelId string) (vlm.VLM, error)
 	// GetASRModel gets an automatic speech recognition model
 	GetASRModel(ctx context.Context, modelId string) (asr.ASR, error)
+	// SetDefaultModel sets a model as the default for its type
+	SetDefaultModel(ctx context.Context, id string) error
 }
 
 // ModelRepository defines the model repository interface


### PR DESCRIPTION
## Description

支持用户在模型配置页面将某个模型设置为**默认模型**。同种类型（对话 / Embedding / ReRank / 视觉 / 语音）的模型只能设置一个为默认。

设置默认后的效果：

- 模型卡片显示"默认"文字标签
- 默认模型自动排在列表最前面
- 创建知识库时自动选中默认的 Embedding、Chat 模型
- 创建智能体时自动选中默认的 Chat 模型

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2231

## Testing

- [x] Go 编译通过，无报错
- [x] 前端 `npm run build` 构建成功
- [x] 手动验证：设置默认模型 → 同类型其他默认自动清除 → 列表排序正确 → 创建知识库/智能体自动选中默认模型

## Checklist

- [x] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [x] Updated related documentation (Swagger annotations 已补充)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

### 模型列表页面

- 默认模型卡片标题旁显示 **"默认"** 文字标签（蓝色背景）
- 默认模型自动排在列表最前面

### 操作入口

- 非默认模型 → 下拉菜单显示"设为默认"
- 已默认模型 → 下拉菜单显示"取消默认"（点击提示设置其他模型替代）

### 自动应用

- 创建知识库时 Embedding / Chat 模型选择器自动选中默认模型
- 创建智能体时 Chat 模型选择器自动选中默认模型


https://github.com/user-attachments/assets/54c1ecde-b05b-49a4-9b77-ca2a95b4ec7f




