### PR TITLE
fix: remove Starters.Count cap on suggested-questions limit parameter

### DIFF
--- a/internal/application/service/custom_agent.go
+++ b/internal/application/service/custom_agent.go
@@ -529,9 +529,6 @@ func (s *customAgentService) getSuggestedQuestions(
 		if suggestionConfig == nil || !suggestionConfig.Starters.Enabled {
 			return []types.SuggestedQuestion{}, nil
 		}
-		if limit > suggestionConfig.Starters.Count {
-			limit = suggestionConfig.Starters.Count
-		}
 		starterMode = suggestionConfig.Starters.Mode
 		// Add curated agent prompts first (highest priority).
 		if suggestionConfig.Starters.Mode == types.SuggestionModeCurated ||


### PR DESCRIPTION
## Description

修复 `GET /api/v1/agents/{id}/suggested-questions` 接口的 `limit` 参数不生效的问题。

**根因：** `getSuggestedQuestions()` 中，用户传入的 `limit` 会被 `suggestionConfig.Starters.Count`（默认 6）静默截断。传入 `limit=10` 等大于配置值的参数时，始终最多返回 6 条。

**修复：** 移除 3 行截断逻辑，使 `limit` 参数按文档描述生效。

**前端影响：** 无。前端所有调用方均写死 `limit=6`，与默认 `Starters.Count` 一致。

## Type of Change

- [x] 🐛 Bug fix

## Related Issue

Fixes #2238

## Testing

- [x] `go build ./internal/application/service/` 编译通过
- [x] 确认下游逻辑（round-robin、`finalizeStarterSuggestions`、`truncateQuestions`）均直接使用传入的 `limit`，不受影响

## Checklist

- [x] 已自查代码
- [x] 无破坏性变更
