### PR TITLE
fix(nginx): 修复SSE配置导致普通API请求连接重置问题

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -120,7 +120,6 @@ server {
         # SSE 相关配置
         proxy_http_version 1.1;                    # 使用 HTTP/1.1
         proxy_set_header Connection "";            # 禁用 Connection: close，保持连接打开
-        chunked_transfer_encoding off;             # 关闭分块传输编码
         proxy_buffering off;                       # 关闭缓冲
         proxy_cache off;                           # 关闭缓存
         proxy_read_timeout 3600s;                  # 增加读取超时时间


### PR DESCRIPTION
## Description

登录时输入正确密码，后端返回200但前端报错"网络连接错误"（`net::ERR_CONNECTION_RESET 200 (OK)`）。

**根本原因：**

Nginx配置中同时设置了 `proxy_buffering off` 和 `chunked_transfer_encoding off`：
- `proxy_buffering off` 使nginx以流式方式转发响应（边收边发）
- `chunked_transfer_encoding off` 强制关闭了HTTP/1.1的chunked分块编码

两者组合导致HTTP响应**既没有Content-Length头，也没有chunked分块标记**，浏览器无法判断响应何时结束，最终触发连接重置。

SSE流式聊天之所以不受影响，是因为SSE本身就是长连接，浏览器通过EventSource API持续监听，不依赖Content-Length或chunked标记判断结束。

**修复方案：**

移除 `chunked_transfer_encoding off;` 一行，恢复HTTP/1.1默认的chunked编码行为。流式传输和普通请求均能正常工作。

**修改文件：**
- `frontend/nginx.conf` - 删除 `chunked_transfer_encoding off;`

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [x] 🔧 Configuration / Build / CI

## Related Issue

Fixes #

## Testing

**复现步骤：**
1. 使用生产模式部署（docker compose，走Nginx代理）
2. 访问登录页面，输入正确的用户名和密码
3. 观察到登录请求返回200，但前端提示"网络连接错误"
4. 浏览器控制台显示 `net::ERR_CONNECTION_RESET 200 (OK)`

**修复验证：**
1. 移除 `chunked_transfer_encoding off;` 后重启前端容器
2. 再次登录，正常返回，不再报错
3. 验证SSE流式聊天功能正常

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings