### PR TITLE
fix(chatpipeline): normalize graph triple schema aliases

### DIFF
--- a/internal/application/service/chat_pipeline/extract_entity.go
+++ b/internal/application/service/chat_pipeline/extract_entity.go
@@ -417,6 +417,117 @@ func (f *Formater) parseOutput(ctx context.Context, text string) ([]map[string]i
 	return itemsList, nil
 }
 
+// normalizeGroup maps common LLM output aliases to the canonical Formater
+// keys so graph extraction is robust to variations of the same triple schema
+// (e.g. RDF-style subject/predicate/object, or head_entity/tail_entity/relation)
+// instead of the canonical entity1/entity2/relation. It is a pure key-
+// normalization pass: the canonical keys themselves are in the alias lists,
+// so existing output passes through unchanged.
+func (f *Formater) normalizeGroup(group map[string]interface{}) map[string]interface{} {
+	source, hasSource := graphValueByAlias(group, f.relationSource, "subject", "head_entity", "head", "source", "from")
+	target, hasTarget := graphValueByAlias(group, f.relationTarget, "object", "tail_entity", "tail", "target", "to")
+	if hasSource && hasTarget {
+		out := map[string]interface{}{
+			f.relationSource: graphName(source),
+			f.relationTarget: graphName(target),
+		}
+		relation, ok := graphValueByAlias(
+			group,
+			f.relationPrefix,
+			"predicate",
+			"relation_type",
+			"relationship_type",
+			"type",
+			"rel",
+			"edge",
+		)
+		if ok {
+			out[f.relationPrefix] = graphName(relation)
+		}
+		return out
+	}
+
+	entity, hasEntity := graphValueByAlias(group, f.nodePrefix, "node", "subject", "object", "name", "title", "id")
+	if hasEntity {
+		out := map[string]interface{}{
+			f.nodePrefix: graphName(entity),
+		}
+		attributes, ok := graphValueByAlias(
+			group,
+			f.nodePrefix+f.attributeSuffix,
+			"attributes",
+			"node_attributes",
+			"attrs",
+			"properties",
+			"props",
+		)
+		if ok {
+			out[f.nodePrefix+f.attributeSuffix] = graphAttributes(attributes)
+		}
+		return out
+	}
+
+	return group
+}
+
+func graphValueByAlias(group map[string]interface{}, aliases ...string) (interface{}, bool) {
+	for _, alias := range aliases {
+		for key, value := range group {
+			if value != nil && strings.EqualFold(key, alias) {
+				return value, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func graphName(value interface{}) string {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		if nested, ok := graphValueByAlias(typed, "text", "name", "title", "id", "label", "entity"); ok {
+			return graphName(nested)
+		}
+	case map[string]string:
+		for _, alias := range []string{"text", "name", "title", "id", "label", "entity"} {
+			for key, nested := range typed {
+				if strings.EqualFold(key, alias) {
+					return strings.TrimSpace(nested)
+				}
+			}
+		}
+	}
+	return strings.TrimSpace(fmt.Sprintf("%v", value))
+}
+
+func graphAttributes(value interface{}) []interface{} {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case []interface{}:
+		return typed
+	case []string:
+		out := make([]interface{}, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, item)
+		}
+		return out
+	case map[string]interface{}:
+		out := make([]interface{}, 0, len(typed))
+		for key, item := range typed {
+			out = append(out, fmt.Sprintf("%s: %v", key, item))
+		}
+		return out
+	case map[string]string:
+		out := make([]interface{}, 0, len(typed))
+		for key, item := range typed {
+			out = append(out, fmt.Sprintf("%s: %s", key, item))
+		}
+		return out
+	default:
+		return []interface{}{fmt.Sprintf("%v", value)}
+	}
+}
+
 func (f *Formater) ParseGraph(ctx context.Context, text string) (*types.GraphData, error) {
 	matchData, err := f.parseOutput(ctx, text)
 	if err != nil {
@@ -433,6 +544,7 @@ func (f *Formater) ParseGraph(ctx context.Context, text string) (*types.GraphDat
 	var relations []*types.GraphRelation
 
 	for _, group := range matchData {
+		group = f.normalizeGroup(group)
 		switch {
 		case group[f.nodePrefix] != nil:
 			attributes := make([]string, 0)

--- a/internal/application/service/chat_pipeline/extract_entity_test.go
+++ b/internal/application/service/chat_pipeline/extract_entity_test.go
@@ -259,3 +259,112 @@ func TestIsLikelyLanguageTag(t *testing.T) {
 		})
 	}
 }
+
+// TestFormater_ParseGraph_AliasNormalization verifies that common LLM output
+// variations of the same triple schema are normalized to the canonical
+// entity/entity1/entity2/relation keys and extracted, instead of being dropped
+// as "Unsupported graph group". This fixes the upstream graph-extraction
+// contract mismatch where the parser only accepted canonical keys.
+func TestFormater_ParseGraph_AliasNormalization(t *testing.T) {
+	cases := []struct {
+		name         string
+		input        string
+		wantNodes    int
+		wantRels     int
+		wantRelation [3]string
+	}{
+		{
+			name:         "RDF triple subject/predicate/object",
+			input:        `[{"subject": "Alice", "predicate": "knows", "object": "Bob"}]`,
+			wantNodes:    2,
+			wantRels:     1,
+			wantRelation: [3]string{"Alice", "Bob", "knows"},
+		},
+		{
+			name: "head/tail entity with relationship_type",
+			input: `[{"head_entity":"Patients",` +
+				`"tail_entity":"Antimicrobial De-escalation Therapy",` +
+				`"relationship_type":"Patient_Treatment",` +
+				`"related_attributes":"Based on negative result"}]`,
+			wantNodes:    2,
+			wantRels:     1,
+			wantRelation: [3]string{"Patients", "Antimicrobial De-escalation Therapy", "Patient_Treatment"},
+		},
+		{
+			name:         "source/target/relation_type",
+			input:        `[{"source": "Alice", "target": "Bob", "relation_type": "knows"}]`,
+			wantNodes:    2,
+			wantRels:     1,
+			wantRelation: [3]string{"Alice", "Bob", "knows"},
+		},
+		{
+			name: "nested head/tail objects use text",
+			input: `[{"head":{"id":"E1","text":"blood culture","type":"Test"},` +
+				`"relation":"Comparison",` +
+				`"tail":{"id":"E2","text":"ddPCR","type":"Test"}}]`,
+			wantNodes:    2,
+			wantRels:     1,
+			wantRelation: [3]string{"blood culture", "ddPCR", "Comparison"},
+		},
+		{
+			name:         "canonical keys still work",
+			input:        `[{"entity": "Alice"}, {"entity1": "Alice", "entity2": "Bob", "relation": "knows"}]`,
+			wantNodes:    2,
+			wantRels:     1,
+			wantRelation: [3]string{"Alice", "Bob", "knows"},
+		},
+		{
+			name:      "standalone subject node",
+			input:     `[{"subject": "Alice"}]`,
+			wantNodes: 1,
+			wantRels:  0,
+		},
+		{
+			name:      "node with attrs alias",
+			input:     `[{"node": "Alice", "attrs": ["person"]}]`,
+			wantNodes: 1,
+			wantRels:  0,
+		},
+		{
+			name:      "genuinely unrecognized keys still dropped",
+			input:     `[{"foo": "bar"}]`,
+			wantNodes: 0,
+			wantRels:  0,
+		},
+	}
+
+	ctx := context.Background()
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			f := NewFormater()
+			graph, err := f.ParseGraph(ctx, tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if graph == nil {
+				t.Fatalf("expected non-nil graph")
+			}
+			if got := len(graph.Node); got != tc.wantNodes {
+				t.Errorf("nodes: got %d, want %d (graph=%+v)", got, tc.wantNodes, graph)
+			}
+			if got := len(graph.Relation); got != tc.wantRels {
+				t.Errorf("relations: got %d, want %d (graph=%+v)", got, tc.wantRels, graph)
+			}
+			if tc.wantRels == 0 {
+				return
+			}
+			if len(graph.Relation) != 1 {
+				t.Fatalf("expected one relation, got %d", len(graph.Relation))
+			}
+			relation := graph.Relation[0]
+			if relation.Node1 != tc.wantRelation[0] ||
+				relation.Node2 != tc.wantRelation[1] ||
+				relation.Type != tc.wantRelation[2] {
+				t.Fatalf("relation = %s --[%s]--> %s, want %s --[%s]--> %s",
+					relation.Node1, relation.Type, relation.Node2,
+					tc.wantRelation[0], tc.wantRelation[2], tc.wantRelation[1])
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixes graph extraction silently dropping valid JSON triples when the LLM returns common schema aliases instead of WeKnora's canonical graph keys.

The current parser only accepts canonical keys such as:

- `entity`
- `entity1`
- `entity2`
- `relation`

In practice, LLMs often return equivalent triple schemas such as:

- `subject` / `predicate` / `object`
- `head_entity` / `tail_entity` / `relationship_type`
- `source` / `target` / `relation_type`
- nested `head` / `tail` objects with `text`, `name`, or `id`

Before this change, those outputs were valid graph triples semantically, but were dropped as unsupported graph groups.

This PR adds a small normalization pass before graph parsing. It maps common aliases to the existing canonical internal keys and leaves already-canonical output unchanged.

No API, storage schema, Swagger annotation, frontend behavior, or user-facing configuration is changed.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🧪 Test

## Related Issue

Fixes #2256

## Testing

Targeted parser tests:

```bash
go test ./internal/application/service/chat_pipeline -run "TestFormater_ParseGraph|TestIsLikelyLanguageTag" -count=1
```

Result:

```text
ok  github.com/Tencent/WeKnora/internal/application/service/chat_pipeline
```

Diff-only lint for this change:

```bash
golangci-lint run --new-from-rev=origin/main ./...
```

Result:

```text
0 issues.
```

Formatting/diff checks:

```bash
git diff --check origin/main...HEAD
gofmt -l internal/application/service/chat_pipeline/extract_entity.go internal/application/service/chat_pipeline/extract_entity_test.go
```

Result: no output.

The full template command was also attempted:

```bash
make fmt && make lint && make test
```

It currently does not pass on this checkout because `make lint` reports existing full-repo baseline issues unrelated to this PR. In the clean validation worktree, `make fmt` rewrote 59 existing files and `golangci-lint run` reported 248 existing issues across unrelated packages, so the chained command stopped at `make lint` before reaching `make test`.

A separate full-repo `make test` attempt also fails on unrelated baseline/environment-sensitive tests:

- `github.com/Tencent/WeKnora/docreader/client`: expects a local docreader gRPC service at `127.0.0.1:50051`.
- `github.com/Tencent/WeKnora/internal/datasource/connector/notion`: loopback test endpoint is rejected by SSRF validation.
- `github.com/Tencent/WeKnora/internal/infrastructure/docparser`: loopback image test endpoint is rejected by SSRF validation.

Production E2E validation was also run on three real ddPCR paper PDFs with graph extraction enabled. All completed successfully:

```text
202504 ddPCR paper: completed, graph 48/48, failed 0, Neo4j 450 nodes / 548 relations
202505 ddPCR paper: completed, graph 46/46, failed 0, Neo4j 314 nodes / 367 relations
202509 ddPCR paper: completed, graph 56/56, failed 0, Neo4j 526 nodes / 497 relations
```

Application logs during the E2E window:

```text
Unsupported graph group: 0
failed to parse graph: 0
failed to add graph: 0
panic/ERROR/FATAL: 0
```

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

Not applicable. This is a backend parser fix with tests.
