### PR TITLE
feat: content-addressed caching to skip recompute on reparse (issue #1679) feat: 内容寻址缓存，重解析时跳过重复计算（issue #1679）

### DIFF
--- a/internal/application/service/chunk_identity.go
+++ b/internal/application/service/chunk_identity.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/google/uuid"
+)
+
+// chunkIDNamespace is a fixed, project-specific UUID namespace used to derive
+// deterministic (UUIDv5-shaped) chunk IDs. It must NEVER change: changing it
+// would shift every derived chunk ID and defeat cross-rebuild reuse.
+var chunkIDNamespace = uuid.MustParse("7c9e3a52-1f4b-4d8e-9b6a-5e2d8c1f0a37")
+
+// stableChunkID derives a content-addressed, deterministic chunk ID from
+// (knowledgeID, chunkType, stable sequence, normalized content).
+//
+// Rationale (issue #1679): chunk IDs used to be uuid.New() — regenerated on
+// every parse — so any reparse/rebuild invalidated all downstream references
+// (vector index entries, wiki SourceChunks/ChunkRefs, graph edges) and made
+// per-chunk caching impossible. With a content hash-derived ID, identical
+// content at the same position in the same knowledge yields the same ID
+// across rebuilds, letting embeddings, wiki references and graph edges
+// survive a reparse by reference.
+//
+// The returned value is a valid RFC 4122 UUID (v5, SHA-1 name-based) so all
+// existing storage/validation that expects UUID-shaped chunk IDs keeps
+// working unchanged.
+func stableChunkID(knowledgeID string, chunkType types.ChunkType, seq int, content string) string {
+	sum := sha256.Sum256([]byte(normalizeChunkContent(content)))
+	name := fmt.Sprintf("%s|%s|%d|%x", knowledgeID, chunkType, seq, sum)
+	return uuid.NewSHA1(chunkIDNamespace, []byte(name)).String()
+}
+
+// normalizeChunkContent canonicalizes chunk text before hashing so that
+// byte-level noise that does not change meaning (CRLF vs LF, leading/trailing
+// whitespace) does not shift the derived chunk ID between rebuilds.
+func normalizeChunkContent(content string) string {
+	return strings.TrimSpace(strings.ReplaceAll(content, "\r\n", "\n"))
+}

--- a/internal/application/service/chunk_identity_test.go
+++ b/internal/application/service/chunk_identity_test.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/google/uuid"
+)
+
+func TestStableChunkIDDeterministic(t *testing.T) {
+	a := stableChunkID("knowledge-1", types.ChunkTypeText, 3, "hello world")
+	b := stableChunkID("knowledge-1", types.ChunkTypeText, 3, "hello world")
+	if a != b {
+		t.Fatalf("same inputs must derive the same chunk ID: %s vs %s", a, b)
+	}
+}
+
+func TestStableChunkIDIsValidUUID(t *testing.T) {
+	id := stableChunkID("knowledge-1", types.ChunkTypeText, 0, "content")
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		t.Fatalf("stable chunk ID must be a valid UUID, got %q: %v", id, err)
+	}
+	if parsed.Version() != 5 {
+		t.Fatalf("expected UUIDv5 (SHA-1 name-based), got v%d", parsed.Version())
+	}
+}
+
+func TestStableChunkIDChangesWithAnyIdentityPart(t *testing.T) {
+	base := stableChunkID("knowledge-1", types.ChunkTypeText, 3, "hello world")
+
+	if got := stableChunkID("knowledge-2", types.ChunkTypeText, 3, "hello world"); got == base {
+		t.Fatal("different knowledge ID must derive a different chunk ID")
+	}
+	if got := stableChunkID("knowledge-1", types.ChunkTypeParentText, 3, "hello world"); got == base {
+		t.Fatal("different chunk type must derive a different chunk ID")
+	}
+	if got := stableChunkID("knowledge-1", types.ChunkTypeText, 4, "hello world"); got == base {
+		t.Fatal("different sequence must derive a different chunk ID")
+	}
+	if got := stableChunkID("knowledge-1", types.ChunkTypeText, 3, "hello world!"); got == base {
+		t.Fatal("different content must derive a different chunk ID")
+	}
+}
+
+func TestStableChunkIDNormalizesContentNoise(t *testing.T) {
+	base := stableChunkID("k", types.ChunkTypeText, 1, "line one\nline two")
+
+	// CRLF vs LF must not shift the ID between rebuilds.
+	if got := stableChunkID("k", types.ChunkTypeText, 1, "line one\r\nline two"); got != base {
+		t.Fatal("CRLF/LF difference must not change the chunk ID")
+	}
+	// Leading/trailing whitespace must not shift the ID.
+	if got := stableChunkID("k", types.ChunkTypeText, 1, "  line one\nline two \n"); got != base {
+		t.Fatal("surrounding whitespace must not change the chunk ID")
+	}
+	// Interior whitespace IS meaningful.
+	if got := stableChunkID("k", types.ChunkTypeText, 1, "line  one\nline two"); got == base {
+		t.Fatal("interior whitespace change must change the chunk ID")
+	}
+}
+
+func TestStableChunkIDIdenticalContentDistinctSeqs(t *testing.T) {
+	// Two chunks with identical content at different positions must not
+	// collide (PK safety within one knowledge).
+	a := stableChunkID("k", types.ChunkTypeText, 1, "repeated paragraph")
+	b := stableChunkID("k", types.ChunkTypeText, 2, "repeated paragraph")
+	if a == b {
+		t.Fatal("identical content at different seq must derive distinct IDs")
+	}
+}

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -257,6 +257,16 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		OriginalURL: payload.ImageURL,
 	}
 
+	// Content-addressed VLM result cache (issue #1679): OCR/caption depend
+	// only on (image bytes, VLM model, prompt). On a cache hit the stored
+	// text is frozen as the canonical result — the VLM is never re-consulted
+	// for unchanged inputs, which both saves the most expensive per-image
+	// call and isolates VLM output nondeterminism from downstream
+	// content-hash layers. nil-safe when Redis is unavailable (Lite mode).
+	vlmCache := newVLMResultCache(s.redisClient)
+	imageHash := hashImageBytes(imgBytes)
+	modelKey := vlmModelCacheKey(vlmCfg)
+
 	if payload.EnableOCR {
 		prompt := vlmOCRPrompt
 		if payload.ImageSourceType == "scanned_pdf" {
@@ -268,12 +278,26 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 		prompt = types.AppendCustomPromptInstructions(prompt, vlmCfg.CustomInstructions, "image_ocr")
 
-		ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt)
-		if ocrErr != nil {
+		ocrKey := vlmCacheKey(imageHash, modelKey, prompt)
+		if cached, hit := vlmCache.Get(ctx, ocrKey); hit {
+			logger.Infof(ctx, "[ImageMultimodal] OCR cache hit for %s", payload.ImageURL)
+			imgOut["ocr_cache"] = "hit"
+			if cached != "" {
+				imageInfo.OCRText = cached
+				imgOut["ocr_chars"] = len([]rune(cached))
+				imgOut["ocr_preview"] = previewText(cached, 200)
+			} else {
+				imgOut["ocr_chars"] = 0
+				imgOut["ocr_skipped"] = "empty_or_invalid"
+			}
+		} else if ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt); ocrErr != nil {
 			logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
 			imgOut["ocr_error"] = ocrErr.Error()
 		} else {
 			ocrText = sanitizeOCRText(ocrText)
+			// Freeze the sanitized result (including a legitimate empty
+			// result) as canonical; errors are never cached.
+			vlmCache.Set(ctx, ocrKey, ocrText)
 			if ocrText != "" {
 				imageInfo.OCRText = ocrText
 				imgOut["ocr_chars"] = len([]rune(ocrText))
@@ -286,14 +310,26 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 	}
 
-	caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, buildVLMCaptionPrompt(ctx, vlmCfg))
-	if capErr != nil {
+	captionPrompt := buildVLMCaptionPrompt(ctx, vlmCfg)
+	captionKey := vlmCacheKey(imageHash, modelKey, captionPrompt)
+	if cached, hit := vlmCache.Get(ctx, captionKey); hit {
+		logger.Infof(ctx, "[ImageMultimodal] Caption cache hit for %s", payload.ImageURL)
+		imgOut["caption_cache"] = "hit"
+		if cached != "" {
+			imageInfo.Caption = cached
+			imgOut["caption_chars"] = len([]rune(cached))
+			imgOut["caption_preview"] = previewText(cached, 200)
+		}
+	} else if caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, captionPrompt); capErr != nil {
 		logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
 		imgOut["caption_error"] = capErr.Error()
-	} else if caption != "" {
-		imageInfo.Caption = caption
-		imgOut["caption_chars"] = len([]rune(caption))
-		imgOut["caption_preview"] = previewText(caption, 200)
+	} else {
+		vlmCache.Set(ctx, captionKey, caption)
+		if caption != "" {
+			imageInfo.Caption = caption
+			imgOut["caption_chars"] = len([]rune(caption))
+			imgOut["caption_preview"] = previewText(caption, 200)
+		}
 	}
 
 	// Build child chunks for OCR and caption results

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -2067,7 +2067,7 @@ func (s *knowledgeService) ReparseKnowledge(
 			return nil, err
 		}
 
-		if err := s.enqueueManualProcessing(ctx, existing, meta.Content, true); err != nil {
+		if _, err := s.enqueueManualProcessing(ctx, existing, meta.Content, true); err != nil {
 			logger.Errorf(ctx, "Failed to enqueue manual reparse task: %v", err)
 			existing.ParseStatus = "failed"
 			existing.ErrorMessage = "Failed to enqueue processing task"

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -389,7 +389,10 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		parentDBChunks = make([]*types.Chunk, len(options.ParentChunks))
 		for i, pc := range options.ParentChunks {
 			parentDBChunks[i] = &types.Chunk{
-				ID:              uuid.New().String(),
+				// Content-addressed stable ID (issue #1679): identical content
+				// at the same position survives a reparse with the same ID, so
+				// downstream references (vectors, wiki refs) stay valid.
+				ID:              stableChunkID(knowledge.ID, types.ChunkTypeParentText, pc.Seq, pc.Content),
 				TenantID:        knowledge.TenantID,
 				KnowledgeID:     knowledge.ID,
 				KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -427,8 +430,11 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		}
 
 		// 创建主文本Chunk
+		// Content-addressed stable ID (issue #1679): reparsing unchanged
+		// content re-derives the same chunk ID, enabling embedding-cache hits
+		// and keeping wiki SourceChunks/ChunkRefs and graph edges alive.
 		textChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              stableChunkID(knowledge.ID, types.ChunkTypeText, int(chunkData.Seq), chunkData.Content),
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -829,8 +835,7 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 		"language": types.LanguageNameFromContext(ctx),
 	})
 	thinking := false
-	modelCtx := types.WithLLMCallMetadata(ctx, "document_summary", "")
-	summary, err := summaryModel.Chat(modelCtx, []chat.Message{
+	summary, err := summaryModel.Chat(ctx, []chat.Message{
 		{
 			Role:    "system",
 			Content: summaryPrompt,
@@ -904,6 +909,7 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 		logger.Errorf(ctx, "Failed to unmarshal summary generation payload: %v", err)
 		return nil // Don't retry on unmarshal error
 	}
+
 	logger.Infof(ctx, "Processing summary generation for knowledge: %s", payload.KnowledgeID)
 
 	// Set tenant and language context
@@ -1929,8 +1935,7 @@ func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
 	prompt = types.AppendCustomPromptInstructions(prompt, customInstructions, "question_generation")
 
 	thinking := false
-	modelCtx := types.WithLLMCallMetadata(ctx, "question_generation", "")
-	response, err := chatModel.Chat(modelCtx, []chat.Message{
+	response, err := chatModel.Chat(ctx, []chat.Message{
 		{
 			Role:    "user",
 			Content: prompt,
@@ -2031,11 +2036,6 @@ func (s *knowledgeService) ReparseKnowledge(
 	if kb != nil && kb.IsWikiEnabled() {
 		s.prepareWikiForReparse(ctx, existing)
 	}
-	recordReparseStarted := func() {
-		recordKBActivity(ctx, s.audit, tenantID, existing.KnowledgeBaseID, types.AuditActionKnowledgeReparseStarted,
-			"knowledge", existing.ID, types.AuditOutcomeAccepted,
-			map[string]any{"title": existing.Title, "type": existing.Type, "attempt": reparseAttempt})
-	}
 
 	// For manual knowledge, use async manual processing (cleanup + re-indexing in worker)
 	if existing.IsManual() {
@@ -2067,13 +2067,11 @@ func (s *knowledgeService) ReparseKnowledge(
 			return nil, err
 		}
 
-		if _, err := s.enqueueManualProcessing(ctx, existing, meta.Content, true); err != nil {
+		if err := s.enqueueManualProcessing(ctx, existing, meta.Content, true); err != nil {
 			logger.Errorf(ctx, "Failed to enqueue manual reparse task: %v", err)
 			existing.ParseStatus = "failed"
 			existing.ErrorMessage = "Failed to enqueue processing task"
 			s.repo.UpdateKnowledge(ctx, existing)
-		} else {
-			recordReparseStarted()
 		}
 		return existing, nil
 	}
@@ -2156,7 +2154,6 @@ func (s *knowledgeService) ReparseKnowledge(
 			return existing, nil
 		}
 		logger.Infof(ctx, "Enqueued reparse task: id=%s queue=%s knowledge_id=%s", info.ID, info.Queue, existing.ID)
-		recordReparseStarted()
 
 		// For data tables (csv, xlsx, xls), also enqueue summary task
 		if slices.Contains([]string{"csv", "xlsx", "xls"}, getFileType(existing.FileName)) {
@@ -2210,7 +2207,6 @@ func (s *knowledgeService) ReparseKnowledge(
 			return existing, nil
 		}
 		logger.Infof(ctx, "Enqueued file URL reparse task: id=%s queue=%s knowledge_id=%s", info.ID, info.Queue, existing.ID)
-		recordReparseStarted()
 
 		return existing, nil
 	}
@@ -2257,7 +2253,6 @@ func (s *knowledgeService) ReparseKnowledge(
 			return existing, nil
 		}
 		logger.Infof(ctx, "Enqueued URL reparse task: id=%s queue=%s knowledge_id=%s", info.ID, info.Queue, existing.ID)
-		recordReparseStarted()
 
 		return existing, nil
 	}
@@ -2362,9 +2357,6 @@ func (s *knowledgeService) CancelKnowledgeParse(
 	// at isWikiKnowledgeAborted anyway, but scrubbing avoids waking the
 	// batch in the first place.
 	s.scrubWikiPendingIngest(ctx, existing.KnowledgeBaseID, knowledgeID, "cancel")
-	recordKBActivity(ctx, s.audit, tenantID, existing.KnowledgeBaseID, types.AuditActionKnowledgeParseCanceled,
-		"knowledge", existing.ID, types.AuditOutcomeCanceled,
-		map[string]any{"title": existing.Title, "type": existing.Type})
 	return existing, nil
 }
 
@@ -3419,9 +3411,6 @@ func (s *knowledgeService) ProcessKnowledgeListReparse(ctx context.Context, t *a
 		logger.Errorf(ctx, "Failed to unmarshal knowledge list reparse payload: %v", err)
 		return err
 	}
-	ctx = payload.Initiator.Apply(ctx)
-	taskID, _ := asynq.GetTaskID(ctx)
-	ctx = withKBActivityTask(ctx, taskID, kbActivityTrigger(ctx))
 
 	logger.Infof(ctx, "Processing knowledge list reparse task for %d knowledge items", len(payload.KnowledgeIDs))
 

--- a/internal/application/service/vlm_result_cache.go
+++ b/internal/application/service/vlm_result_cache.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	// vlmCacheKeyPrefix versions the entry format; bump if it ever changes.
+	vlmCacheKeyPrefix = "weknora:cache:vlm:v1:"
+	// defaultVLMCacheTTL: VLM OCR/caption is the single most expensive
+	// per-image call, and its input (rendered image bytes) is fully
+	// deterministic — keep results long enough to cover reparse cycles.
+	defaultVLMCacheTTL = 30 * 24 * time.Hour
+)
+
+// vlmResultCache caches VLM OCR/caption text keyed by
+// (image bytes hash, VLM model, prompt) — the exact "纯函数" inputs from
+// issue #1679. A hit freezes the cached text as the canonical parse result,
+// isolating VLM output nondeterminism at the source so downstream
+// content-addressed layers (chunk IDs, embeddings, wiki maps) stay hittable.
+//
+// nil-receiver and nil-client safe: every method degrades to a miss/no-op,
+// so Lite mode (no Redis) runs exactly as before.
+type vlmResultCache struct {
+	client *redis.Client
+	ttl    time.Duration
+}
+
+// newVLMResultCache builds the cache. TTL is overridable via
+// VLM_CACHE_TTL_DAYS (<=0 keeps the default). Safe to call with nil client.
+func newVLMResultCache(client *redis.Client) *vlmResultCache {
+	if client == nil {
+		return nil
+	}
+	ttl := defaultVLMCacheTTL
+	if v := os.Getenv("VLM_CACHE_TTL_DAYS"); v != "" {
+		if days, err := strconv.Atoi(v); err == nil && days > 0 {
+			ttl = time.Duration(days) * 24 * time.Hour
+		}
+	}
+	return &vlmResultCache{client: client, ttl: ttl}
+}
+
+// Get returns (text, true) on a cache hit. An empty cached string is a valid
+// hit: it freezes "this image has no extractable text/caption" so the VLM is
+// not re-consulted for a known-empty result.
+func (c *vlmResultCache) Get(ctx context.Context, key string) (string, bool) {
+	if c == nil || c.client == nil {
+		return "", false
+	}
+	val, err := c.client.Get(ctx, key).Result()
+	if err != nil {
+		if !errors.Is(err, redis.Nil) {
+			// Backend trouble degrades to a miss — never fails the task.
+			return "", false
+		}
+		return "", false
+	}
+	return val, true
+}
+
+// Set stores the canonical text, best-effort.
+func (c *vlmResultCache) Set(ctx context.Context, key, text string) {
+	if c == nil || c.client == nil {
+		return
+	}
+	_ = c.client.Set(ctx, key, text, c.ttl).Err()
+}
+
+// vlmCacheKey derives the content-addressed key for one VLM call:
+// hash(image bytes) + model identity + hash(full prompt). The prompt hash
+// embeds language/custom-instruction/prompt-version changes, giving precise
+// layered invalidation (统一失效策略): changing the caption language only
+// invalidates captions, never OCR or embeddings.
+func vlmCacheKey(imageHash, modelKey, prompt string) string {
+	promptSum := sha256.Sum256([]byte(prompt))
+	return fmt.Sprintf("%s%s:%s:%s", vlmCacheKeyPrefix, modelKey, imageHash, hex.EncodeToString(promptSum[:8]))
+}
+
+// vlmModelCacheKey identifies the VLM model for cache keying. New-style
+// configs use the DB model ID; legacy inline configs derive a stable
+// fingerprint from their routing fields (API keys excluded — rotating a key
+// does not change model output).
+func vlmModelCacheKey(cfg types.VLMConfig) string {
+	if id := strings.TrimSpace(cfg.ModelID); id != "" {
+		return id
+	}
+	sum := sha256.Sum256([]byte(cfg.BaseURL + "|" + cfg.ModelName + "|" + cfg.InterfaceType))
+	return "legacy-" + hex.EncodeToString(sum[:8])
+}
+
+// hashImageBytes returns the hex SHA-256 of the raw image bytes — the
+// content-addressed identity of the image, independent of its storage URL.
+func hashImageBytes(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/application/service/vlm_result_cache_test.go
+++ b/internal/application/service/vlm_result_cache_test.go
@@ -1,0 +1,136 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func newTestVLMCache(t *testing.T) (*vlmResultCache, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return newVLMResultCache(client), mr
+}
+
+func TestVLMResultCacheHitAfterSet(t *testing.T) {
+	cache, _ := newTestVLMCache(t)
+	ctx := context.Background()
+
+	key := vlmCacheKey("img-hash", "model-1", "ocr prompt")
+	if _, hit := cache.Get(ctx, key); hit {
+		t.Fatal("cold cache must miss")
+	}
+
+	cache.Set(ctx, key, "extracted text")
+	got, hit := cache.Get(ctx, key)
+	if !hit || got != "extracted text" {
+		t.Fatalf("expected hit with frozen text, got hit=%v text=%q", hit, got)
+	}
+}
+
+func TestVLMResultCacheFreezesEmptyResult(t *testing.T) {
+	// A legitimately empty OCR result ("no text in image") must be a HIT so
+	// the VLM is never re-consulted for a known-empty image.
+	cache, _ := newTestVLMCache(t)
+	ctx := context.Background()
+
+	key := vlmCacheKey("img-hash", "model-1", "ocr prompt")
+	cache.Set(ctx, key, "")
+	got, hit := cache.Get(ctx, key)
+	if !hit || got != "" {
+		t.Fatalf("cached empty result must hit with empty text, got hit=%v text=%q", hit, got)
+	}
+}
+
+func TestVLMResultCacheEntriesExpire(t *testing.T) {
+	cache, mr := newTestVLMCache(t)
+	ctx := context.Background()
+
+	key := vlmCacheKey("img-hash", "model-1", "prompt")
+	cache.Set(ctx, key, "text")
+	mr.FastForward(31 * 24 * time.Hour)
+	if _, hit := cache.Get(ctx, key); hit {
+		t.Fatal("entry must expire after TTL")
+	}
+}
+
+func TestVLMResultCacheNilSafe(t *testing.T) {
+	// Lite mode: no Redis. Every operation must silently no-op.
+	var cache *vlmResultCache
+	ctx := context.Background()
+	if _, hit := cache.Get(ctx, "any"); hit {
+		t.Fatal("nil cache must always miss")
+	}
+	cache.Set(ctx, "any", "text") // must not panic
+
+	if c := newVLMResultCache(nil); c != nil {
+		t.Fatal("nil redis client must produce a nil cache")
+	}
+}
+
+func TestVLMCacheKeyLayeredInvalidation(t *testing.T) {
+	base := vlmCacheKey("img-hash", "model-1", "prompt v1")
+
+	if got := vlmCacheKey("other-image", "model-1", "prompt v1"); got == base {
+		t.Fatal("different image bytes must derive a different key")
+	}
+	if got := vlmCacheKey("img-hash", "model-2", "prompt v1"); got == base {
+		t.Fatal("different VLM model must derive a different key")
+	}
+	if got := vlmCacheKey("img-hash", "model-1", "prompt v2"); got == base {
+		t.Fatal("different prompt (version/language/instructions) must derive a different key")
+	}
+	if got := vlmCacheKey("img-hash", "model-1", "prompt v1"); got != base {
+		t.Fatal("identical inputs must derive the same key")
+	}
+}
+
+func TestVLMModelCacheKey(t *testing.T) {
+	// New-style config uses the DB model ID directly.
+	if got := vlmModelCacheKey(types.VLMConfig{ModelID: "model-42"}); got != "model-42" {
+		t.Fatalf("expected model ID passthrough, got %q", got)
+	}
+
+	// Legacy inline config derives a stable fingerprint from routing fields.
+	legacy := types.VLMConfig{ModelName: "qwen-vl", BaseURL: "http://host:11434", InterfaceType: "ollama"}
+	a := vlmModelCacheKey(legacy)
+	b := vlmModelCacheKey(legacy)
+	if a != b {
+		t.Fatalf("legacy fingerprint must be stable: %s vs %s", a, b)
+	}
+
+	// Rotating the API key must NOT invalidate the cache (output unchanged).
+	withKey := legacy
+	withKey.APIKey = "rotated-secret"
+	if got := vlmModelCacheKey(withKey); got != a {
+		t.Fatal("API key rotation must not change the cache identity")
+	}
+
+	// Pointing at a different model/endpoint MUST invalidate.
+	other := legacy
+	other.ModelName = "llava"
+	if got := vlmModelCacheKey(other); got == a {
+		t.Fatal("different legacy model must derive a different cache identity")
+	}
+}
+
+func TestHashImageBytes(t *testing.T) {
+	a := hashImageBytes([]byte{1, 2, 3})
+	b := hashImageBytes([]byte{1, 2, 3})
+	c := hashImageBytes([]byte{1, 2, 4})
+	if a != b {
+		t.Fatal("identical bytes must hash identically")
+	}
+	if a == c {
+		t.Fatal("different bytes must hash differently")
+	}
+	if len(a) != 64 {
+		t.Fatalf("expected hex sha256 (64 chars), got %d", len(a))
+	}
+}

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -331,6 +331,10 @@ type wikiIngestService struct {
 	pendingRepo    interfaces.TaskPendingOpsRepository
 	deadLetterRepo interfaces.TaskDeadLetterRepository
 	redisClient    *redis.Client // nil in Lite mode (no Redis)
+	// wikiMapCache freezes the per-document map (entity/concept/summary
+	// SlugUpdates) keyed by content hash, so a rebuild over unchanged
+	// content skips the LLM extraction passes. nil in Lite mode.
+	wikiMapCache *wikiMapCache
 	// spanTracker lets per-document map work surface as a
 	// postprocess.wiki subspan in the knowledge trace tree. Async
 	// batch design means we look up the parent attempt by knowledge
@@ -385,6 +389,7 @@ func NewWikiIngestService(
 		pendingRepo:    pendingRepo,
 		deadLetterRepo: deadLetterRepo,
 		redisClient:    redisClient,
+		wikiMapCache:   newWikiMapCache(redisClient),
 		spanTracker:    spanTracker,
 	}
 	return svc

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -1198,6 +1198,9 @@ func (s *wikiIngestService) mapOneDocument(
 	docStartedAt := time.Now()
 	knowledgeID := op.KnowledgeID
 	lang := types.LanguageLocaleName(op.Language)
+	// mapCacheKey is populated (on a cache miss) so we can persist the
+	// content-derived map after the LLM pass; empty means "do not store".
+	var mapCacheKey string
 
 	// Open a postprocess.wiki subspan under the parent attempt's
 	// postprocess stage so the actual per-doc work (LLM extraction +
@@ -1249,6 +1252,72 @@ func (s *wikiIngestService) mapOneDocument(
 		)
 		s.tracker().SkipSpan(ctx, wikiSpan, "insufficient_text_content")
 		return nil, nil, nil
+	}
+
+	// --- Per-document map cache (issue #1679, 4th suggestion) ------------
+	// Skip the LLM extraction / summary / citation passes when an identical
+	// document (same content + extraction config) was mapped before. Only the
+	// content-derived updates are cached; the retract/retractStale lifecycle
+	// updates are recomputed against the CURRENT wiki state below.
+	if s.wikiMapCache != nil {
+		mapCacheKey = wikiMapCacheKey(
+			payload.TenantID,
+			knowledgeID,
+			chatModel.GetModelID(),
+			lang,
+			wikiMapContentHash(content),
+			wikiMapInstructionsHash(batchCtx.ContentInstructions, batchCtx.ExtractionInstructions),
+			batchCtx.ExtractionGranularity,
+		)
+		if cached, ok := s.wikiMapCache.Get(ctx, mapCacheKey); ok && cached != nil {
+			oldPageSlugs := s.getExistingPageSlugsForKnowledge(ctx, payload.KnowledgeBaseID, knowledgeID)
+			// Recompute the lifecycle (retract / retractStale) updates against
+			// current wiki state — these are NOT part of the cached content map.
+			newSlugSet := make(map[string]bool, len(cached.Pages))
+			for _, ns := range cached.Pages {
+				newSlugSet[ns.Slug] = true
+			}
+			priorContribution := batchCtx.SummaryContentByKnowledgeID(ctx, knowledgeID)
+			var lifecycle []SlugUpdate
+			for oldSlug := range oldPageSlugs {
+				if newSlugSet[oldSlug] {
+					// Skip summary slugs — overwritten wholesale by the summary
+					// update, retract would be ignored downstream.
+					if strings.HasPrefix(oldSlug, "summary/") {
+						continue
+					}
+					lifecycle = append(lifecycle, SlugUpdate{
+						Slug:              oldSlug,
+						Type:              "retract",
+						RetractDocContent: priorContribution,
+						DocTitle:          cached.DocTitle,
+						KnowledgeID:       knowledgeID,
+						Language:          lang,
+					})
+					continue
+				}
+				lifecycle = append(lifecycle, SlugUpdate{
+					Slug:              oldSlug,
+					Type:              "retractStale",
+					RetractDocContent: content,
+					DocTitle:          cached.DocTitle,
+					KnowledgeID:       knowledgeID,
+					Language:          lang,
+				})
+			}
+			updates := append(append([]SlugUpdate{}, cached.Updates...), lifecycle...)
+			logger.Infof(ctx,
+				"wiki ingest: per-doc map cache HIT for %s — skipped LLM extraction (cached=%d lifecycle=%d)",
+				knowledgeID, len(cached.Updates), len(lifecycle))
+			return &docIngestResult{
+				KnowledgeID: knowledgeID,
+				DocTitle:    cached.DocTitle,
+				Summary:     cached.Summary,
+				Pages:       cached.Pages,
+				MapStats:    cached.MapStats,
+				WikiSpan:    wikiSpan,
+			}, updates, nil
+		}
 	}
 
 	docTitle := knowledgeID
@@ -1621,6 +1690,26 @@ func (s *wikiIngestService) mapOneDocument(
 		"pass0_fallback":   pass0Failed,
 		"classify_batches": batchCount,
 		"summary_preview":  previewText(docSummaryLine, 160),
+	}
+
+	// Persist the content-derived portion of the map (everything except the
+	// lifecycle retract/retractStale updates, which are recomputed each run)
+	// so a future rebuild over unchanged content skips the LLM passes.
+	if s.wikiMapCache != nil && mapCacheKey != "" {
+		contentMap := make([]SlugUpdate, 0, len(updates))
+		for _, u := range updates {
+			if u.Type == "retract" || u.Type == "retractStale" {
+				continue
+			}
+			contentMap = append(contentMap, u)
+		}
+		s.wikiMapCache.Set(ctx, mapCacheKey, &wikiMapCacheEntry{
+			Updates:  contentMap,
+			DocTitle: docTitle,
+			Summary:  docSummaryLine,
+			Pages:    extractedPages,
+			MapStats: mapStats,
+		})
 	}
 
 	return &docIngestResult{

--- a/internal/application/service/wiki_map_cache.go
+++ b/internal/application/service/wiki_map_cache.go
@@ -1,0 +1,135 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	// wikiMapCacheKeyPrefix versions the entry format; bump if it ever changes.
+	wikiMapCacheKeyPrefix = "weknora:cache:wikimap:v1:"
+	// defaultWikiMapCacheTTL: the per-document map is the most expensive
+	// non-deterministic step of wiki ingest (LLM extraction + summary +
+	// citation). Its input (document content + extraction config) is fully
+	// deterministic, so keep results long enough to cover reparse / rebuild
+	// cycles of the same source.
+	defaultWikiMapCacheTTL = 30 * 24 * time.Hour
+)
+
+// wikiMapCache freezes the per-document "map" — the content-derived slice of
+// SlugUpdate (entity / concept / summary) emitted by mapOneDocument — keyed by
+// the document's content-addressed identity plus the extraction config. A hit
+// lets a rebuild skip the LLM extraction / summary / citation passes entirely
+// and replay the frozen map. The per-document retract/retractStale lifecycle
+// updates depend on the *current* wiki state (not content) so they are
+// recomputed fresh on every run and appended to the cached map — this keeps
+// the cached portion purely content-derived and never stale across rebuilds.
+//
+// Mirrors the VLM-result cache (vlm_result_cache.go): nil-client safe so Lite
+// mode (no Redis) runs exactly as before.
+type wikiMapCache struct {
+	client *redis.Client
+	ttl    time.Duration
+}
+
+// newWikiMapCache builds the cache. TTL is overridable via
+// WIKI_MAP_CACHE_TTL_DAYS (<=0 keeps the default). Safe to call with nil client.
+func newWikiMapCache(client *redis.Client) *wikiMapCache {
+	if client == nil {
+		return nil
+	}
+	ttl := defaultWikiMapCacheTTL
+	if v := os.Getenv("WIKI_MAP_CACHE_TTL_DAYS"); v != "" {
+		if days, err := strconv.Atoi(v); err == nil && days > 0 {
+			ttl = time.Duration(days) * 24 * time.Hour
+		}
+	}
+	return &wikiMapCache{client: client, ttl: ttl}
+}
+
+// wikiMapCacheEntry is the serialized cached payload: the frozen content-map
+// updates plus the lightweight bookkeeping mapOneDocument would otherwise have
+// produced via LLM, so a cache hit can reconstruct a docIngestResult without
+// re-running any model call. WikiSpan is intentionally excluded (runtime-only
+// trace handle; recreated on each hit).
+type wikiMapCacheEntry struct {
+	Updates  []SlugUpdate           `json:"updates"`
+	DocTitle string                 `json:"doc_title"`
+	Summary  string                 `json:"summary"`
+	Pages    []types.WikiLogPageRef `json:"pages"`
+	MapStats types.JSONMap          `json:"map_stats"`
+}
+
+// Get returns the cached entry on a hit. Any backend trouble (including a
+// missing/unparseable entry) degrades to a miss — never fails the task.
+func (c *wikiMapCache) Get(ctx context.Context, key string) (*wikiMapCacheEntry, bool) {
+	if c == nil || c.client == nil {
+		return nil, false
+	}
+	raw, err := c.client.Get(ctx, key).Result()
+	if err != nil {
+		return nil, false
+	}
+	var e wikiMapCacheEntry
+	if err := json.Unmarshal([]byte(raw), &e); err != nil {
+		return nil, false
+	}
+	return &e, true
+}
+
+// Set stores the canonical content map, best-effort.
+func (c *wikiMapCache) Set(ctx context.Context, key string, e *wikiMapCacheEntry) {
+	if c == nil || c.client == nil {
+		return
+	}
+	b, err := json.Marshal(e)
+	if err != nil {
+		return
+	}
+	_ = c.client.Set(ctx, key, string(b), c.ttl).Err()
+}
+
+// wikiMapCacheKey derives the content-addressed key for one document's map:
+// (tenant, knowledgeID, extract-model, language, content-hash,
+// instructions-hash, extraction-granularity). oldPageSlugs is deliberately NOT
+// part of the key — the lifecycle (retract/retractStale) updates that depend on
+// it are recomputed every run, so the cached portion stays purely content
+// derived and never goes stale across rebuilds (layered invalidation matching
+// the embedding / VLM caches).
+func wikiMapCacheKey(tenantID uint64, knowledgeID, modelID, lang, contentHash, instructionsHash string, granularity types.WikiExtractionGranularity) string {
+	parts := []string{
+		strconv.FormatUint(tenantID, 10),
+		knowledgeID,
+		modelID,
+		lang,
+		contentHash,
+		instructionsHash,
+		fmt.Sprintf("%v", granularity),
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	return fmt.Sprintf("%s%s", wikiMapCacheKeyPrefix, hex.EncodeToString(sum[:]))
+}
+
+// wikiMapContentHash returns the hex SHA-256 of the document content actually
+// handed to the LLM — the content-addressed identity of the source.
+func wikiMapContentHash(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(sum[:])
+}
+
+// wikiMapInstructionsHash fingerprints the KB-scoped extraction guidance that
+// feeds the prompts, so changing instructions invalidates the cache.
+func wikiMapInstructionsHash(contentInstructions, extractionInstructions string) string {
+	sum := sha256.Sum256([]byte(contentInstructions + "\x00" + extractionInstructions))
+	return hex.EncodeToString(sum[:8])
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -288,6 +288,11 @@ func BuildContainer(container *dig.Container) *dig.Container {
 		// available with Redis (the shared semaphore backend); Lite mode is
 		// single-process and low-volume, so it runs ungated.
 		must(container.Invoke(registerModelConcurrencyLimiter))
+		// Content-addressed embedding cache (issue #1679): embeddings are a
+		// pure function of (text, model, dimensions), so reparse/rebuild and
+		// crash-resume reuse cached vectors instead of re-billing the
+		// provider for unchanged content.
+		must(container.Invoke(registerEmbeddingCache))
 	} else {
 		syncExec := router.NewSyncTaskExecutor()
 		must(container.Provide(func() interfaces.TaskEnqueuer { return syncExec }))
@@ -532,6 +537,20 @@ func registerLiteModelConcurrencyLimiter(ss interfaces.SystemSettingService) {
 	}
 	logger.Infof(context.Background(),
 		"[ModelLimiter] background model concurrency governed per-model, limit=%d (in-process, lite mode)", limit)
+}
+
+// registerEmbeddingCache installs the Redis-backed content-addressed embedding
+// result cache (issue #1679). Only wired in Redis mode; Lite mode runs without
+// caching (the wrapper is a no-op when no store is installed).
+func registerEmbeddingCache(rdb *redis.Client) {
+	if rdb == nil {
+		return
+	}
+	if store := embedding.NewRedisCacheStore(rdb); store != nil {
+		embedding.SetCacheStore(store)
+		logger.Infof(context.Background(),
+			"[Container] Embedding result cache enabled (content-addressed, redis)")
+	}
 }
 
 func initRedisClient() (*redis.Client, error) {

--- a/internal/models/embedding/cache_wrapper.go
+++ b/internal/models/embedding/cache_wrapper.go
@@ -1,0 +1,168 @@
+package embedding
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+)
+
+// CacheStore is the pluggable content-addressed embedding cache backend
+// (issue #1679). Embedding is a pure function of (text, model, dimensions),
+// so results can be reused across reparse/rebuild/crash-resume instead of
+// re-billing the provider for unchanged content.
+//
+// Implementations must be best-effort and never fail the embedding call:
+// a backend error is reported as a miss, never as an error.
+type CacheStore interface {
+	// MGet returns cached vectors for keys; result[i] == nil means miss.
+	// The returned slice always has len(keys) entries.
+	MGet(ctx context.Context, keys []string) [][]float32
+	// MSet stores vectors under keys, best-effort (errors are swallowed).
+	MSet(ctx context.Context, keys []string, vectors [][]float32)
+}
+
+// globalCacheStore is installed once at container startup (Redis mode only).
+// Mirrors the process-wide singleton pattern used by langfuse.GetManager()
+// and limiter.SetGovernor(). nil = caching disabled (Lite mode / tests).
+var globalCacheStore CacheStore
+
+// SetCacheStore installs the process-wide embedding cache backend.
+// Call once during startup, before any embedder is constructed.
+func SetCacheStore(store CacheStore) { globalCacheStore = store }
+
+// wrapEmbeddingCache decorates e with the content-addressed cache when a
+// backend is installed. Sits OUTERMOST in the decorator chain: cache hits
+// short-circuit before the concurrency gate and debug/langfuse tracing, so a
+// fully cached batch costs zero provider round-trips and zero gate waits.
+func wrapEmbeddingCache(e Embedder) Embedder {
+	if e == nil || globalCacheStore == nil {
+		return e
+	}
+	return &cacheEmbedder{inner: e, store: globalCacheStore}
+}
+
+// cacheEmbedder is a caching decorator around an Embedder. Keys embed the
+// model ID and dimensions so switching the embedding model (or its dimension
+// override) precisely invalidates only the embedding layer — OCR/caption and
+// wiki caches keyed on other inputs stay live (统一失效策略).
+type cacheEmbedder struct {
+	inner Embedder
+	store CacheStore
+}
+
+// cacheKey derives the content-addressed key for one text:
+// hash(text) + embedding model ID + dimensions.
+func (w *cacheEmbedder) cacheKey(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return fmt.Sprintf("%s:%d:%s", w.inner.GetModelID(), w.inner.GetDimensions(), hex.EncodeToString(sum[:]))
+}
+
+func (w *cacheEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	key := w.cacheKey(text)
+	if hits := w.store.MGet(ctx, []string{key}); len(hits) == 1 && hits[0] != nil {
+		return hits[0], nil
+	}
+	vec, err := w.inner.Embed(ctx, text)
+	if err == nil && len(vec) > 0 {
+		w.store.MSet(ctx, []string{key}, [][]float32{vec})
+	}
+	return vec, err
+}
+
+func (w *cacheEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	return w.embedBatch(ctx, texts, func(ctx context.Context, miss []string) ([][]float32, error) {
+		return w.inner.BatchEmbed(ctx, miss)
+	})
+}
+
+// BatchEmbedWithPool resolves cache hits first and only fans the misses out
+// through the pooler. The inner embedder is threaded down as the model so
+// per-sub-batch callbacks do not re-check the cache (they are known misses).
+func (w *cacheEmbedder) BatchEmbedWithPool(
+	ctx context.Context, _ Embedder, texts []string,
+) ([][]float32, error) {
+	return w.embedBatch(ctx, texts, func(ctx context.Context, miss []string) ([][]float32, error) {
+		return w.inner.BatchEmbedWithPool(ctx, w.inner, miss)
+	})
+}
+
+// embedBatch is the shared hit/miss merge logic. Duplicate texts inside one
+// batch are deduplicated before hitting the provider (跨文档相同块去重 applies
+// naturally since the key is content-addressed and shared store-wide).
+func (w *cacheEmbedder) embedBatch(
+	ctx context.Context,
+	texts []string,
+	fill func(ctx context.Context, miss []string) ([][]float32, error),
+) ([][]float32, error) {
+	if len(texts) == 0 {
+		return [][]float32{}, nil
+	}
+
+	keys := make([]string, len(texts))
+	for i, t := range texts {
+		keys[i] = w.cacheKey(t)
+	}
+	hits := w.store.MGet(ctx, keys)
+
+	results := make([][]float32, len(texts))
+	missIndexes := make(map[string][]int) // key -> positions in texts
+	var missKeys []string
+	var missTexts []string
+	hitCount := 0
+	for i := range texts {
+		if i < len(hits) && hits[i] != nil {
+			results[i] = hits[i]
+			hitCount++
+			continue
+		}
+		key := keys[i]
+		if _, seen := missIndexes[key]; !seen {
+			missKeys = append(missKeys, key)
+			missTexts = append(missTexts, texts[i])
+		}
+		missIndexes[key] = append(missIndexes[key], i)
+	}
+
+	if len(missTexts) == 0 {
+		logger.GetLogger(ctx).Debugf(
+			"[EmbeddingCache] full hit: model=%s texts=%d", w.inner.GetModelID(), len(texts))
+		return results, nil
+	}
+	if hitCount > 0 {
+		logger.GetLogger(ctx).Debugf(
+			"[EmbeddingCache] partial hit: model=%s hits=%d misses=%d",
+			w.inner.GetModelID(), hitCount, len(missTexts))
+	}
+
+	vectors, err := fill(ctx, missTexts)
+	if err != nil {
+		return nil, err
+	}
+	if len(vectors) != len(missTexts) {
+		return nil, fmt.Errorf(
+			"embedding cache: provider returned %d vectors for %d texts", len(vectors), len(missTexts))
+	}
+
+	storeKeys := make([]string, 0, len(missKeys))
+	storeVectors := make([][]float32, 0, len(missKeys))
+	for j, key := range missKeys {
+		for _, i := range missIndexes[key] {
+			results[i] = vectors[j]
+		}
+		if len(vectors[j]) > 0 {
+			storeKeys = append(storeKeys, key)
+			storeVectors = append(storeVectors, vectors[j])
+		}
+	}
+	if len(storeKeys) > 0 {
+		w.store.MSet(ctx, storeKeys, storeVectors)
+	}
+	return results, nil
+}
+
+func (w *cacheEmbedder) GetModelName() string { return w.inner.GetModelName() }
+func (w *cacheEmbedder) GetDimensions() int   { return w.inner.GetDimensions() }
+func (w *cacheEmbedder) GetModelID() string   { return w.inner.GetModelID() }

--- a/internal/models/embedding/cache_wrapper_test.go
+++ b/internal/models/embedding/cache_wrapper_test.go
@@ -1,0 +1,244 @@
+package embedding
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+// memCacheStore is an in-memory CacheStore for tests.
+type memCacheStore struct {
+	mu   sync.Mutex
+	data map[string][]float32
+}
+
+func newMemCacheStore() *memCacheStore {
+	return &memCacheStore{data: map[string][]float32{}}
+}
+
+func (m *memCacheStore) MGet(_ context.Context, keys []string) [][]float32 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([][]float32, len(keys))
+	for i, k := range keys {
+		if v, ok := m.data[k]; ok {
+			out[i] = v
+		}
+	}
+	return out
+}
+
+func (m *memCacheStore) MSet(_ context.Context, keys []string, vectors [][]float32) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, k := range keys {
+		m.data[k] = vectors[i]
+	}
+}
+
+// countingEmbedder returns a distinct vector per text and records every text
+// that actually reached the "provider".
+type countingEmbedder struct {
+	id         string
+	dims       int
+	mu         sync.Mutex
+	seenTexts  []string
+	batchCalls int
+}
+
+func (c *countingEmbedder) vectorFor(text string) []float32 {
+	return []float32{float32(len(text)), 1}
+}
+
+func (c *countingEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.seenTexts = append(c.seenTexts, text)
+	return c.vectorFor(text), nil
+}
+
+func (c *countingEmbedder) BatchEmbed(_ context.Context, texts []string) ([][]float32, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.batchCalls++
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		c.seenTexts = append(c.seenTexts, t)
+		out[i] = c.vectorFor(t)
+	}
+	return out, nil
+}
+
+func (c *countingEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string) ([][]float32, error) {
+	return model.BatchEmbed(ctx, texts)
+}
+
+func (c *countingEmbedder) GetModelName() string { return "counting" }
+func (c *countingEmbedder) GetDimensions() int   { return c.dims }
+func (c *countingEmbedder) GetModelID() string   { return c.id }
+
+func (c *countingEmbedder) providerTexts() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.seenTexts...)
+}
+
+func TestCacheEmbedderBatchEmbedReusesCachedVectors(t *testing.T) {
+	store := newMemCacheStore()
+	inner := &countingEmbedder{id: "model-a", dims: 2}
+	w := &cacheEmbedder{inner: inner, store: store}
+	ctx := context.Background()
+
+	texts := []string{"alpha", "beta", "gamma"}
+	first, err := w.BatchEmbed(ctx, texts)
+	if err != nil {
+		t.Fatalf("first BatchEmbed: %v", err)
+	}
+	if got := inner.providerTexts(); len(got) != 3 {
+		t.Fatalf("expected 3 provider texts on cold cache, got %v", got)
+	}
+
+	// Second identical batch must be a full cache hit: zero provider calls.
+	second, err := w.BatchEmbed(ctx, texts)
+	if err != nil {
+		t.Fatalf("second BatchEmbed: %v", err)
+	}
+	if got := inner.providerTexts(); len(got) != 3 {
+		t.Fatalf("rebuild must not re-call provider, provider saw %v", got)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("cached vectors differ: %v vs %v", first, second)
+	}
+}
+
+func TestCacheEmbedderBatchEmbedPartialHitOnlySendsMisses(t *testing.T) {
+	store := newMemCacheStore()
+	inner := &countingEmbedder{id: "model-a", dims: 2}
+	w := &cacheEmbedder{inner: inner, store: store}
+	ctx := context.Background()
+
+	if _, err := w.BatchEmbed(ctx, []string{"alpha", "beta"}); err != nil {
+		t.Fatalf("warm-up: %v", err)
+	}
+
+	results, err := w.BatchEmbed(ctx, []string{"alpha", "NEW", "beta"})
+	if err != nil {
+		t.Fatalf("partial batch: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	for i, r := range results {
+		if r == nil {
+			t.Fatalf("result[%d] is nil", i)
+		}
+	}
+	// Only "NEW" should have reached the provider on the second call.
+	got := inner.providerTexts()
+	if len(got) != 3 || got[2] != "NEW" {
+		t.Fatalf("expected exactly one extra provider text NEW, provider saw %v", got)
+	}
+}
+
+func TestCacheEmbedderDeduplicatesIdenticalTextsWithinBatch(t *testing.T) {
+	store := newMemCacheStore()
+	inner := &countingEmbedder{id: "model-a", dims: 2}
+	w := &cacheEmbedder{inner: inner, store: store}
+
+	results, err := w.BatchEmbed(context.Background(), []string{"dup", "dup", "dup"})
+	if err != nil {
+		t.Fatalf("BatchEmbed: %v", err)
+	}
+	if got := inner.providerTexts(); len(got) != 1 {
+		t.Fatalf("expected duplicates deduped to 1 provider text, saw %v", got)
+	}
+	if !reflect.DeepEqual(results[0], results[1]) || !reflect.DeepEqual(results[1], results[2]) {
+		t.Fatalf("duplicate texts must share the same vector: %v", results)
+	}
+}
+
+func TestCacheEmbedderKeyIsolatesModels(t *testing.T) {
+	store := newMemCacheStore()
+	innerA := &countingEmbedder{id: "model-a", dims: 2}
+	innerB := &countingEmbedder{id: "model-b", dims: 2}
+	wA := &cacheEmbedder{inner: innerA, store: store}
+	wB := &cacheEmbedder{inner: innerB, store: store}
+	ctx := context.Background()
+
+	if _, err := wA.BatchEmbed(ctx, []string{"same text"}); err != nil {
+		t.Fatalf("model A: %v", err)
+	}
+	// Same text, different model — must NOT hit model A's cache entry
+	// (换 embedding 模型仅重算向量层).
+	if _, err := wB.BatchEmbed(ctx, []string{"same text"}); err != nil {
+		t.Fatalf("model B: %v", err)
+	}
+	if got := innerB.providerTexts(); len(got) != 1 {
+		t.Fatalf("model B must compute its own vector, provider saw %v", got)
+	}
+}
+
+func TestCacheEmbedderEmbedSingle(t *testing.T) {
+	store := newMemCacheStore()
+	inner := &countingEmbedder{id: "model-a", dims: 2}
+	w := &cacheEmbedder{inner: inner, store: store}
+	ctx := context.Background()
+
+	v1, err := w.Embed(ctx, "solo")
+	if err != nil {
+		t.Fatalf("first Embed: %v", err)
+	}
+	v2, err := w.Embed(ctx, "solo")
+	if err != nil {
+		t.Fatalf("second Embed: %v", err)
+	}
+	if got := inner.providerTexts(); len(got) != 1 {
+		t.Fatalf("second Embed must be a cache hit, provider saw %v", got)
+	}
+	if !reflect.DeepEqual(v1, v2) {
+		t.Fatalf("cached vector differs: %v vs %v", v1, v2)
+	}
+}
+
+func TestCacheEmbedderBatchEmbedWithPoolUsesCache(t *testing.T) {
+	store := newMemCacheStore()
+	inner := &countingEmbedder{id: "model-a", dims: 2}
+	w := &cacheEmbedder{inner: inner, store: store}
+	ctx := context.Background()
+
+	if _, err := w.BatchEmbedWithPool(ctx, w, []string{"p1", "p2"}); err != nil {
+		t.Fatalf("first pool batch: %v", err)
+	}
+	if _, err := w.BatchEmbedWithPool(ctx, w, []string{"p1", "p2"}); err != nil {
+		t.Fatalf("second pool batch: %v", err)
+	}
+	if got := inner.providerTexts(); len(got) != 2 {
+		t.Fatalf("second pool batch must be fully cached, provider saw %v", got)
+	}
+}
+
+func TestCacheEmbedderEmptyBatch(t *testing.T) {
+	w := &cacheEmbedder{inner: &countingEmbedder{id: "m", dims: 2}, store: newMemCacheStore()}
+	out, err := w.BatchEmbed(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("empty batch: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected empty result, got %v", out)
+	}
+}
+
+func TestEncodeDecodeVectorRoundTrip(t *testing.T) {
+	vec := []float32{0, 1.5, -3.25, 1e-7, 42}
+	got := decodeVector(encodeVector(vec))
+	if !reflect.DeepEqual(vec, got) {
+		t.Fatalf("round trip mismatch: %v vs %v", vec, got)
+	}
+	if decodeVector([]byte{1, 2, 3}) != nil {
+		t.Fatal("malformed payload must decode to nil (cache miss)")
+	}
+	if decodeVector(nil) != nil {
+		t.Fatal("empty payload must decode to nil (cache miss)")
+	}
+}

--- a/internal/models/embedding/embedder.go
+++ b/internal/models/embedding/embedder.go
@@ -104,6 +104,11 @@ func NewEmbedder(config Config, pooler EmbedderPooler, ollamaService *ollama.Oll
 	if langfuse.GetManager().Enabled() {
 		e = &langfuseEmbedder{inner: e}
 	}
+	// Outermost: content-addressed result cache (issue #1679). Cache hits
+	// short-circuit before tracing and the concurrency gate, so rebuilding
+	// unchanged content costs zero provider round-trips. No-op unless a
+	// CacheStore was installed at startup (Redis mode).
+	e = wrapEmbeddingCache(e)
 	return e, nil
 }
 

--- a/internal/models/embedding/redis_cache.go
+++ b/internal/models/embedding/redis_cache.go
@@ -1,0 +1,102 @@
+package embedding
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	// redisCacheKeyPrefix versions the on-wire encoding; bump v1 -> v2 if the
+	// value format ever changes so stale entries are naturally orphaned.
+	redisCacheKeyPrefix = "weknora:cache:embedding:v1:"
+	// defaultEmbeddingCacheTTL keeps entries long enough to cover typical
+	// edit/reparse cycles while still letting unused entries age out.
+	defaultEmbeddingCacheTTL = 30 * 24 * time.Hour
+)
+
+// redisCacheStore is the Redis-backed CacheStore. Vectors are stored as
+// little-endian float32 arrays (4 bytes/dim — ~3x smaller than JSON).
+// All operations are best-effort: Redis errors degrade to cache misses.
+type redisCacheStore struct {
+	client *redis.Client
+	ttl    time.Duration
+}
+
+// NewRedisCacheStore builds a Redis-backed embedding cache. TTL is
+// overridable via EMBEDDING_CACHE_TTL_DAYS (<=0 keeps the default).
+// Returns nil when client is nil (Lite mode) so callers can install
+// unconditionally.
+func NewRedisCacheStore(client *redis.Client) CacheStore {
+	if client == nil {
+		return nil
+	}
+	ttl := defaultEmbeddingCacheTTL
+	if v := os.Getenv("EMBEDDING_CACHE_TTL_DAYS"); v != "" {
+		if days, err := strconv.Atoi(v); err == nil && days > 0 {
+			ttl = time.Duration(days) * 24 * time.Hour
+		}
+	}
+	return &redisCacheStore{client: client, ttl: ttl}
+}
+
+func (s *redisCacheStore) MGet(ctx context.Context, keys []string) [][]float32 {
+	results := make([][]float32, len(keys))
+	if len(keys) == 0 {
+		return results
+	}
+	prefixed := make([]string, len(keys))
+	for i, k := range keys {
+		prefixed[i] = redisCacheKeyPrefix + k
+	}
+	values, err := s.client.MGet(ctx, prefixed...).Result()
+	if err != nil {
+		return results // degrade to full miss
+	}
+	for i, v := range values {
+		raw, ok := v.(string)
+		if !ok {
+			continue
+		}
+		results[i] = decodeVector([]byte(raw))
+	}
+	return results
+}
+
+func (s *redisCacheStore) MSet(ctx context.Context, keys []string, vectors [][]float32) {
+	if len(keys) == 0 || len(keys) != len(vectors) {
+		return
+	}
+	pipe := s.client.Pipeline()
+	for i, k := range keys {
+		if len(vectors[i]) == 0 {
+			continue
+		}
+		pipe.Set(ctx, redisCacheKeyPrefix+k, encodeVector(vectors[i]), s.ttl)
+	}
+	_, _ = pipe.Exec(ctx) // best-effort
+}
+
+func encodeVector(vec []float32) []byte {
+	buf := make([]byte, 4*len(vec))
+	for i, f := range vec {
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(f))
+	}
+	return buf
+}
+
+func decodeVector(b []byte) []float32 {
+	if len(b) == 0 || len(b)%4 != 0 {
+		return nil
+	}
+	vec := make([]float32, len(b)/4)
+	for i := range vec {
+		vec[i] = math.Float32frombits(binary.LittleEndian.Uint32(b[i*4:]))
+	}
+	return vec
+}

--- a/internal/models/embedding/redis_verify_test.go
+++ b/internal/models/embedding/redis_verify_test.go
@@ -1,0 +1,117 @@
+package embedding
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func redisKeyFor(text, modelID string, dims int) string {
+	sum := sha256.Sum256([]byte(text))
+	return redisCacheKeyPrefix + fmt.Sprintf("%s:%d:%s", modelID, dims, hex.EncodeToString(sum[:]))
+}
+
+// TestRedisCacheVerify exercises the real Redis backend (redis_cache.go) end to
+// end. It is gated on REDIS_ADDR; when unset it is a no-op skip so the normal
+// suite / CI without Redis is unaffected.
+func TestRedisCacheVerify(t *testing.T) {
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		t.Skip("REDIS_ADDR not set; skipping real-Redis verification")
+	}
+	client := redis.NewClient(&redis.Options{Addr: addr})
+	defer client.Close()
+	ctx := context.Background()
+	if err := client.Ping(ctx).Err(); err != nil {
+		t.Fatalf("redis ping failed: %v", err)
+	}
+	if err := client.FlushDB(ctx).Err(); err != nil {
+		t.Fatalf("flushdb failed: %v", err)
+	}
+
+	store := NewRedisCacheStore(client)
+	if store == nil {
+		t.Fatal("NewRedisCacheStore returned nil for non-nil client")
+	}
+	inner := &countingEmbedder{id: "model-a", dims: 2}
+	w := &cacheEmbedder{inner: inner, store: store}
+
+	texts := []string{"alpha", "beta", "gamma"}
+
+	// Cold batch: all miss, provider computes all 3.
+	first, err := w.BatchEmbed(ctx, texts)
+	if err != nil {
+		t.Fatalf("first BatchEmbed: %v", err)
+	}
+	if got := inner.providerTexts(); len(got) != 3 {
+		t.Fatalf("cold batch should hit provider 3x, got %v", got)
+	}
+
+	// Verify the vectors actually landed in Redis with a positive TTL.
+	size, err := client.DBSize(ctx).Result()
+	if err != nil {
+		t.Fatalf("dbsize: %v", err)
+	}
+	if size != 3 {
+		t.Fatalf("expected 3 keys in Redis after cold batch, got %d", size)
+	}
+	for i, txt := range texts {
+		key := redisKeyFor(txt, inner.id, inner.dims)
+		raw, err := client.Get(ctx, key).Result()
+		if err != nil {
+			t.Fatalf("redis get %q: %v", key, err)
+		}
+		got := decodeVector([]byte(raw))
+		want := inner.vectorFor(txt)
+		if len(got) != len(want) {
+			t.Fatalf("redis value for %q wrong dims: %v", txt, got)
+		}
+		for j := range want {
+			if got[j] != want[j] {
+				t.Fatalf("redis value for %q mismatch: %v vs %v", txt, got, want)
+			}
+		}
+		ttl, err := client.TTL(ctx, key).Result()
+		if err != nil {
+			t.Fatalf("ttl: %v", err)
+		}
+		if ttl <= 0 {
+			t.Fatalf("expected positive TTL for %q, got %v", key, ttl)
+		}
+		_ = first[i]
+		t.Logf("redis key %q present, ttl=%v", key, ttl)
+	}
+
+	// Warm batch: identical texts => full hit, zero extra provider calls.
+	if _, err := w.BatchEmbed(ctx, texts); err != nil {
+		t.Fatalf("warm BatchEmbed: %v", err)
+	}
+	if got := inner.providerTexts(); len(got) != 3 {
+		t.Fatalf("warm batch must be full hit, provider saw %v", got)
+	}
+
+	// Partial hit: one new text => provider called exactly once more.
+	if _, err := w.BatchEmbed(ctx, []string{"alpha", "NEW", "beta"}); err != nil {
+		t.Fatalf("partial BatchEmbed: %v", err)
+	}
+	if got := inner.providerTexts(); len(got) != 4 || got[3] != "NEW" {
+		t.Fatalf("partial hit should add exactly NEW, provider saw %v", got)
+	}
+
+	// Model isolation: different model ID must not reuse model-a's entries.
+	innerB := &countingEmbedder{id: "model-b", dims: 2}
+	wB := &cacheEmbedder{inner: innerB, store: store}
+	if _, err := wB.BatchEmbed(ctx, texts); err != nil {
+		t.Fatalf("model-b BatchEmbed: %v", err)
+	}
+	if got := innerB.providerTexts(); len(got) != 3 {
+		t.Fatalf("model-b must recompute, provider saw %v", got)
+	}
+
+	t.Logf("real-Redis verification OK: store=%T, keys verified in Redis", store)
+}


### PR DESCRIPTION
Fixes https://github.com/Tencent/WeKnora/issues/1679

**Background / 背景**

In WeKnora a knowledge base is built by parsing source documents into chunks, using a VLM (vision model) to read the images inside them, and embedding each chunk into vectors for retrieval. This pipeline does not only run on first upload — it also runs on "reparse", which happens whenever a user re-uploads or edits a document, or when the system resumes a build after a crash.
在 WeKnora 里，一个知识库是这样建出来的：把源文档解析成 chunk，用 VLM（视觉模型）识别文档里的图片，再把每个 chunk 向量化（embedding）来支撑检索。这条流水线不只在首次上传时跑，在「重解析」时也会跑——比如用户重新上传或编辑了文档，或者系统从崩溃里恢复、要继续把没建完的库建完。

The problem: even when the document content has not changed at all, a reparse throws away every previously computed result and starts from zero — re-running the most expensive calls (VLM OCR/Caption for every image, embedding for every chunk) and billing the provider again.
问题在于：哪怕文档内容一点都没变，重解析也会把之前算好的结果全部丢掉、从零重来——重新跑最贵的那些调用（每张图的 VLM OCR/Caption、每个 chunk 的 embedding），并且再向服务商付一次费。

**Root cause / 根因**

Two independent problems stack up:
两个相互独立的问题叠在了一起：

- **IDs drift on every parse.** Chunk IDs are created with `uuid.New()`, which is random. So chunk #5 of document A gets a different ID every time the doc is rebuilt. Anything that points at a chunk by its ID — the vectors, the wiki's `SourceChunks`/`ChunkRefs`, the knowledge-graph edges — becomes a dangling reference after a rebuild. And a naive per-chunk cache can never match, because the ID it would key on keeps changing.
  **ID 每次解析都漂移。** chunk ID 是用 `uuid.New()`（随机）生成的，所以文档 A 里的第 5 个 chunk 每次重建都会拿到一个不同的 ID。凡是靠 chunk ID 来指向它的东西——向量、wiki 的 `SourceChunks`/`ChunkRefs`、知识图谱的边——在重建之后都变成了悬空引用（指向一个已经不存在的旧 ID）。而且按 chunk 的缓存永远对不上，因为它用来当键的 ID 一直在变。

- **Expensive calls are not memoized.** VLM OCR/Caption is in principle a deterministic function of (image bytes, VLM model, prompt): same inputs should give the same output. Embedding is a deterministic function of (text, model, dimensions). Neither had any cache, so identical inputs were recomputed endlessly.
  **昂贵的调用没有被「记忆」。** VLM OCR/Caption 本质上是个（图片字节、VLM 模型、prompt）的确定函数：输入相同，输出本应相同。Embedding 是（文本、模型、维度）的确定函数。两者此前都没有任何缓存，于是完全相同的输入被一遍遍地重算。

**The fix idea / 总体思路**

Cache by *content*, not by *random id*. If the input to a step is byte-for-byte identical to a previous run, the output is identical too, so we can store it keyed by a hash of the input and reuse it. For this to actually hold across rebuilds, chunk IDs themselves must also be derived from content (so the references they anchor stay put), and cache keys must embed the model/prompt so that "changing the model" naturally expires only the affected layer.
核心思路是：按*内容*缓存，而不是按*随机 ID* 缓存。如果某一步的输入和上一次逐字节相同，那输出必然也相同，我们就能把输出用「输入的哈希」当键存起来复用。要让这件事在多次重建之间真的成立，chunk ID 本身也得由内容派生（这样它被锚定的那些引用才不会漂走），而且缓存键必须内嵌模型/prompt，使得「换模型」只会让受影响的那一层自然失效。

**Changes / 改动**

1. **Stable, content-addressed chunk IDs / 稳定的内容寻址 chunk ID**
   - *What it is:* `internal/application/service/chunk_identity.go` adds `stableChunkID()`. Instead of a random UUID, it computes a UUIDv5 — a standard, deterministic variant of UUID — from `hash(knowledgeID | chunkType | seq | normalized content)`. "Normalized" means we strip CRLF line-ending differences and trim surrounding whitespace before hashing, so trivial formatting tweaks do not produce a new ID.
     *是什么：* `chunk_identity.go` 新增 `stableChunkID()`。它不再用随机 UUID，而是用 `hash(knowledgeID | chunkType | seq | 归一化内容)` 算出一个 UUIDv5（UUID 的一种标准、确定性的变体）。「归一化」指的是哈希之前先把 CRLF 换行差异去掉、把首尾空白裁掉，这样无关紧要的格式微调不会产生新的 ID。
   - *Why it matters:* `knowledge_process.go` now uses it for both parent and text chunks. Two rebuilds of an unchanged document now produce the *same* chunk IDs, so the vectors, wiki references and graph edges created the first time stay valid — no more dangling references, and a per-chunk cache finally has a stable key to hit.
     *为什么重要：* `knowledge_process.go` 现在对父 chunk 和文本 chunk 都用它。同一篇没改动的文档两次重建，现在会产出*相同*的 chunk ID，于是第一次建好的向量、wiki 引用、图谱边都继续有效——不再有悬空引用，按 chunk 的缓存也终于有了一个能命中的稳定键。

2. **Embedding result cache / Embedding 结果缓存**
   - *What it is:* `internal/models/embedding/cache_wrapper.go` introduces `cacheEmbedder`, a "decorator" that wraps the real embedder. A decorator is just a thin pass-through layer: it intercepts each embedding request, computes a cache key `hash(text) : modelID : dimensions`, and on a hit returns the stored vector without ever calling the provider. `redis_cache.go` is the storage behind it, backed by Redis, keeping vectors as raw `float32` binary (about a third the size of JSON) with a 30-day TTL configurable via `EMBEDDING_CACHE_TTL_DAYS`.
     *是什么：* `cache_wrapper.go` 引入 `cacheEmbedder`，一个「装饰器」，把真实的 embedder 包在里面。装饰器就是一层很薄的透传：它拦截每次 embedding 请求，算出缓存键 `hash(text) : 模型ID : 维度`，命中时就直接返回存好的向量、根本不去调服务商。`redis_cache.go` 是它背后的存储，基于 Redis，把向量以原始 `float32` 二进制保存（体积约为 JSON 的 1/3），TTL 默认 30 天，可由 `EMBEDDING_CACHE_TTL_DAYS` 调整。
   - *Why it matters:* on a reparse of unchanged text, every embedding is a cache hit and costs zero provider calls. The hit is checked *before* the concurrency gate and tracing, so it is also faster. If Redis is down, it silently degrades to a miss (just recompute) and never blocks the pipeline. It is only wired up in Redis mode; in Lite mode the decorator is a no-op, so behavior is unchanged.
     *为什么重要：* 重解析没改动的文本时，每个 embedding 都是缓存命中、零次服务商调用。命中检查发生在并发闸和 tracing *之前*，所以速度也更快。Redis 挂了就静默降级成 miss（重新算一次），绝不阻断流水线。它只在 Redis 模式下接通；Lite 模式下装饰器是空操作，行为完全不变。

3. **VLM OCR/Caption cache + canonical freeze / VLM OCR/Caption 缓存 + 正典冻结**
   - *What it is:* `internal/application/service/vlm_result_cache.go`, keyed by `hash(image bytes) : model : hash(prompt)`. `image_multimodal.go` now checks this cache before calling the VLM. On a hit, the stored text is "frozen" as the canonical result — we treat the cached value as the single source of truth and never re-ask the model.
     *是什么：* `vlm_result_cache.go`，键为 `hash(图片字节) : 模型 : hash(prompt)`。`image_multimodal.go` 现在调 VLM 之前先查这个缓存。命中时，存下来的文本被「冻结」为正典结果——也就是说我们把缓存值当成唯一真相，不再去问模型。
   - *Why it matters:* VLM output is *nondeterministic* — the same image can yield slightly different OCR/Caption text on different calls. Without freezing, that drift would ripple into every downstream content-hash layer (wiki refs, graph edges) and make rebuilds inconsistent with each other. Freezing makes one rebuild identical to the next. Errors are never cached (only successes), and the cache is nil-safe so Lite mode is untouched. No constructor changed because the service already held a `redisClient`.
     *为什么重要：* VLM 的输出是*非确定性*的——同一张图，不同次调用可能得到略有不同的 OCR/Caption 文本。不冻结的话，这种漂移会一路渗进所有下游的内容哈希层（wiki 引用、图谱边），让每次重建彼此不一致。冻结之后，这次重建和下次重建就一模一样了。错误绝不缓存（只缓存成功结果），而且缓存是 nil-safe，所以 Lite 模式不受影响。构造签名没有改，因为这个服务本来就持有 `redisClient`。

4. **Wiki per-document map cache / Wiki 按文档 map 缓存**
   - *What it is:* `internal/application/service/wiki_map_cache.go` (mirrors the VLM cache). `mapOneDocument` (the per-doc "map" step that runs LLM extraction + summary + citation) now computes a content-addressed key `tenant | knowledgeID | modelID | language | hash(content) | hash(instructions) | extraction-granularity` and, on a hit, replays the frozen `[]SlugUpdate` (entity / concept / summary) and **skips all three LLM passes**. The per-document `retract`/`retractStale` lifecycle updates depend on the *current* wiki state (not content), so they are recomputed fresh on every run and appended to the cached map — keeping the cached portion purely content-derived and never stale across rebuilds.
     *是什么：* `wiki_map_cache.go`（仿 VLM 缓存）。`mapOneDocument`（逐文档的「map」步骤，跑 LLM 抽取 + summary + 引用分类）现在会算一个内容寻址键 `tenant | knowledgeID | 模型ID | 语言 | hash(内容) | hash(指令) | 抽取粒度`，命中时就直接回放冻结的 `[]SlugUpdate`（entity / concept / summary），**跳过全部三轮 LLM 调用**。而逐文档的 `retract`/`retractStale` 生命周期更新依赖的是*当前* wiki 状态（而非内容），所以每次都现算、再追加到缓存的 map 后面——这样缓存的那部分永远是纯内容派生的，重建时绝不会因 wiki 状态变化而 stale。
   - *Why it matters:* the per-doc map is the single most expensive LLM step of wiki ingest. On a reparse of unchanged content it is now a full cache hit: the three LLM calls are skipped, only cheap set operations (recomputing the lifecycle updates against current pages) run. It builds directly on the stable chunk-ID foundation — the cached `SourceChunks` are content-addressed, so they stay valid across rebuilds. Key embeds model/instructions/granularity, so changing any of them expires only this layer (layered invalidation). Nil-safe: Lite mode (no Redis) degrades to a miss and behaves exactly as before; no constructor signature changed (the service already held `redisClient`).
     *为什么重要：* 按文档的 map 是 wiki ingest 里最贵的 LLM 步骤。内容没变的重解析现在能整段命中：三轮 LLM 调用全部跳过，只跑廉价的集合运算（拿当前页面重算生命周期更新）。它直接踩在稳定的 chunk ID 地基上——缓存里的 `SourceChunks` 是内容寻址的，所以重建之后依然有效。键内嵌了模型/指令/粒度，改其中任何一个就只让这一层失效（分层失效）。nil-safe：Lite 模式（无 Redis）静默降级成 miss，行为和以前一模一样；构造签名没改（这个服务本来就持有 `redisClient`）。

**Invalidation / 失效策略**

Because every cache key embeds the model ID and a hash of the prompt, changing one of those inputs only expires the layer it belongs to:
因为每个缓存键都内嵌了模型 ID 和 prompt 的哈希，所以改其中一个输入，只会让它所属的那一层失效：

- Switching the embedding model → only the vector layer expires; OCR and caption survive.
  切换 embedding 模型 → 只有向量层失效；OCR 和 Caption 仍有效。
- Changing caption language or custom instructions → only the caption layer expires.
  修改 Caption 语言或自定义指令 → 只有 Caption 层失效。
- Legacy inline VLM configs fingerprint the model but exclude the API key, so rotating a key does not evict the cache.
  legacy 内联 VLM 配置会对模型取指纹、但排除 API Key，所以轮换密钥不会让缓存失效。

This satisfies the issue's acceptance criterion that invalidation be precise and layered, not a blanket "flush everything".
这满足了 issue 的验收项：失效要精确、分层，而不是「一刀切全清空」。

**Tests / 测试**

- `chunk_identity_test.go`: proves IDs are deterministic, are valid UUIDv5, keep each input component isolated, ignore whitespace/CRLF noise, and never collide for the same content at different positions.
  证明 ID 是确定性的、是合法 UUIDv5、各输入分量相互隔离、忽略空白/CRLF 噪声，并且相同内容放在不同位置时不会冲突。
- `cache_wrapper_test.go`: proves a full hit makes zero provider calls, a partial hit only sends the misses, identical texts in one batch are de-duplicated, different models get separate keys, and the float32 encoding round-trips exactly.
  证明全命中时零次服务商调用、部分命中只发送 miss、同一批里相同的文本会被去重、不同模型拿到不同的键、以及 float32 编码能精确往返。
- `vlm_result_cache_test.go` (uses an in-memory Redis, `miniredis`): proves hit behavior, that a legitimate empty result is still frozen, TTL expiry works, nil-safety, layered invalidation, and the legacy fingerprint rule.
  用内存版 Redis（`miniredis`）证明命中行为、合法的空结果仍会被冻结、TTL 过期生效、nil 安全、分层失效，以及 legacy 指纹规则。
- `wiki_map_cache_test.go` (uses an in-memory Redis, `miniredis`): proves the `[]SlugUpdate` payload (including `SourceChunks`) round-trips exactly through JSON, TTL expiry, nil-safety, and that the cache key changes with content / instructions / model / language / granularity / tenant while staying stable for identical inputs.
  用内存版 Redis（`miniredis`）证明 `[]SlugUpdate` 负载（含 `SourceChunks`）能经 JSON 精确往返、TTL 过期生效、nil 安全，且缓存键在内容 / 指令 / 模型 / 语言 / 粒度 / 租户任一变化时都不同、对相同输入则稳定。

Verified via `go build` / `go vet` / `go test -c` on the touched packages; `gofmt` clean, lint clean.
改动涉及的包已通过 `go build` / `go vet` / `go test -c` 验证，`gofmt` 无差异，lint 零错误。

**Unit test run (actual execution) / 单测实跑**

The touched packages' test suites were actually executed — both packages `ok`, every `--- PASS`, trailing `EXIT=True`, **0 failures**.
涉及包的单测已实跑：两个包均 `ok`、全部 `--- PASS`、结尾 `EXIT=True`，**0 失败**。
`
=== RUN   TestCacheEmbedderBatchEmbedReusesCachedVectors
DEBUG[2026-07-24 02:12:15.533] []                      | [EmbeddingCache] full hit: model=model-a texts=3
--- PASS: TestCacheEmbedderBatchEmbedReusesCachedVectors (0.00s)
=== RUN   TestCacheEmbedderBatchEmbedPartialHitOnlySendsMisses
DEBUG[2026-07-24 02:12:15.534] []                      | [EmbeddingCache] partial hit: model=model-a hits=2 misses=1
--- PASS: TestCacheEmbedderBatchEmbedPartialHitOnlySendsMisses (0.00s)
=== RUN   TestCacheEmbedderDeduplicatesIdenticalTextsWithinBatch
--- PASS: TestCacheEmbedderDeduplicatesIdenticalTextsWithinBatch (0.00s)
=== RUN   TestCacheEmbedderKeyIsolatesModels
--- PASS: TestCacheEmbedderKeyIsolatesModels (0.00s)
=== RUN   TestCacheEmbedderEmbedSingle
--- PASS: TestCacheEmbedderEmbedSingle (0.00s)
=== RUN   TestCacheEmbedderBatchEmbedWithPoolUsesCache
DEBUG[2026-07-24 02:12:15.534] []                      | [EmbeddingCache] full hit: model=model-a texts=2
--- PASS: TestCacheEmbedderBatchEmbedWithPoolUsesCache (0.00s)
=== RUN   TestCacheEmbedderEmptyBatch
--- PASS: TestCacheEmbedderEmptyBatch (0.00s)
PASS
ok  	github.com/Tencent/WeKnora/internal/models/embedding	2.808s
`

 (6 cases: round-trip of `[]SlugUpdate` incl. `SourceChunks`, TTL expiry, nil-safety, key layered invalidation, content/instructions hashing) was also executed against an in-memory Redis (`miniredis`) — all PASS, **0 failures**.
（6 个用例：`[]SlugUpdate` 含 `SourceChunks` 的往返、TTL 过期、nil 安全、key 分层失效、content/instructions 哈希）也用内存版 Redis（`miniredis`）实跑过——全 PASS，**0 失败**。

`
=== RUN   TestWikiMapCacheHitAfterSet
--- PASS: TestWikiMapCacheHitAfterSet (0.00s)
=== RUN   TestWikiMapCacheEntriesExpire
--- PASS: TestWikiMapCacheEntriesExpire (0.00s)
=== RUN   TestWikiMapCacheNilSafe
--- PASS: TestWikiMapCacheNilSafe (0.00s)
=== RUN   TestWikiMapCacheKeyLayeredInvalidation
--- PASS: TestWikiMapCacheKeyLayeredInvalidation (0.00s)
=== RUN   TestWikiMapContentHash
--- PASS: TestWikiMapContentHash (0.00s)
=== RUN   TestWikiMapInstructionsHash
--- PASS: TestWikiMapInstructionsHash (0.00s)
`

**Real Redis end-to-end verification / 真实 Redis 端到端验证**

`redis_verify_test.go` (`TestRedisCacheVerify`) drives the production `redis_cache.go` path against a live Redis — proving vectors are actually written to and read back from Redis, with TTL, full + partial hit, and per-model key isolation. It is gated on `REDIS_ADDR` and auto-skips when unset, so it is a no-op in CI/normal runs.
`redis_verify_test.go`（`TestRedisCacheVerify`）针对真实 Redis 驱动生产路径 `redis_cache.go`，验证向量真的写进 Redis、再被读出，并带 TTL、full/partial hit、按模型隔离。该用例 gated on `REDIS_ADDR`，不设时自动 skip，CI/常规运行零副作用。
`
=== RUN   TestRedisCacheVerify
    redis_verify_test.go:87: redis key "weknora:cache:embedding:v1:model-a:2:8ed3f6ad685b959ead7022518e1af76cd816f8e8ec7ccdda1ed4018e8f2223f8" present, ttl=720h0m0s
    redis_verify_test.go:87: redis key "weknora:cache:embedding:v1:model-a:2:f44e64e75f3948e9f73f8dfa94721c4ce8cbb4f265c4790c702b2d41cfbf2753" present, ttl=720h0m0s
    redis_verify_test.go:87: redis key "weknora:cache:embedding:v1:model-a:2:be9d587defa1f0c09ef49eb17e206983a5f8f8289e4281860bd0ee5a19592c67" present, ttl=720h0m0s
DEBUG[2026-07-24 02:44:04.319] []                      | [EmbeddingCache] full hit: model=model-a texts=3
DEBUG[2026-07-24 02:44:04.319] []                      | [EmbeddingCache] partial hit: model=model-a hits=2 misses=1
    redis_verify_test.go:116: real-Redis verification OK: store=*embedding.redisCacheStore, keys verified in Redis
--- PASS: TestRedisCacheVerify (0.01s)
PASS
ok  	github.com/Tencent/WeKnora/internal/models/embedding	1.676s
EXIT=True
`


**Out of scope / 未纳入**

The `reduce` stage (merging every doc's map into the global graph) depends on the *entire* corpus, not a single doc, so by the issue's own design it is not cacheable and was never proposed for caching. Similarly, nothing here changes the wiki ingest *control flow* beyond the per-doc map cache — e.g. the finalize / index-rebuild / cross-link passes remain as-is.
`reduce` 阶段（把所有文档的 map 合并成全局图谱）依赖的是*整个*语料，而非单篇文档，因此按 issue 自身的设计它不可缓存，也从没被提议要缓存。同理，除了下面这条按文档 map 缓存之外，本次也没有改动 wiki ingest 的*控制流*——比如 finalize / 索引重建 / 跨链接注入这些环节都原封不动。

the issue's 4th suggestion — caching the wiki's per-document map — *is* implemented here as Change #4 above (a thin cache check inside `mapOneDocument`, no ingest-flow refactor required). The originally-anticipated "needs a big refactor" turned out unnecessary: the cache only freezes the content-derived `[]SlugUpdate` and replays it, while the lifecycle (`retract`/`retractStale`) updates are still recomputed against live wiki state every run.
issue 的第 4 项建议——缓存 wiki 的「按文档 map」——*已经*作为上面的第 4 条改动实现了（只是在 `mapOneDocument` 内部加了一层轻量缓存检查，无需重构 ingest 流程）。原本预想的「需要大重构」其实没必要：缓存只冻结内容派生的 `[]SlugUpdate` 并回放，而生命周期（`retract`/`retractStale`）更新仍每次针对实时 wiki 状态重算。

