### PR TITLE
fix(frontend): correct optimistic organization state after review and detail loads

### DIFF
--- a/frontend/src/stores/organization.ts
+++ b/frontend/src/stores/organization.ts
@@ -44,7 +44,12 @@ import {
   requestRoleUpgrade as requestRoleUpgradeApi
 } from '@/api/organization'
 import { createVersionedRequestCoordinator } from './versionedRequest'
-import { applyOrganizationResourceDelta, upsertById } from './organizationState'
+import {
+  applyOrganizationResourceDelta,
+  upsertById,
+  mergeById,
+  reviewMemberCountDelta
+} from './organizationState'
 
 export const useOrganizationStore = defineStore('organization', () => {
   // State
@@ -146,6 +151,19 @@ export const useOrganizationStore = defineStore('organization', () => {
     if (currentOrganization.value?.id === organization.id) {
       currentOrganization.value = organization
     }
+  }
+
+  /**
+   * Merge a detail payload (which may omit list-only aggregate fields) onto the
+   * existing card instead of replacing it, so badges like share_count survive.
+   */
+  function mergeOrganizationDetail(organization: Organization) {
+    organizationsRequest.invalidate()
+    organizationsLoadedAt = 0
+    const next = mergeById(organizations.value, organization)
+    organizations.value = next
+    currentOrganization.value =
+      next.find(org => org.id === organization.id) ?? organization
   }
 
   function adjustOrganizationResourceCount(
@@ -685,13 +703,16 @@ export const useOrganizationStore = defineStore('organization', () => {
   async function reviewOrganizationJoinRequest(
     organizationId: string,
     requestId: string,
-    request: ReviewJoinRequestRequest
+    request: ReviewJoinRequestRequest,
+    options?: { requestType?: 'join' | 'upgrade' }
   ): Promise<ApiResponse<void>> {
     const response = await reviewJoinRequestApi(organizationId, requestId, request)
     if (response.success) {
       const organization = organizations.value.find(org => org.id === organizationId)
       patchOrganization(organizationId, {
-        member_count: (organization?.member_count ?? 0) + (request.approved ? 1 : 0),
+        member_count:
+          (organization?.member_count ?? 0) +
+          reviewMemberCountDelta(request.approved, options?.requestType),
         pending_join_request_count: Math.max(
           0,
           (organization?.pending_join_request_count ?? 0) - 1
@@ -719,7 +740,7 @@ export const useOrganizationStore = defineStore('organization', () => {
    */
   function setCurrentOrganization(org: Organization | null) {
     if (org) {
-      upsertOrganization(org)
+      mergeOrganizationDetail(org)
       void fetchOrganizations({ force: true })
     } else {
       currentOrganization.value = null

--- a/frontend/src/stores/organizationState.test.ts
+++ b/frontend/src/stores/organizationState.test.ts
@@ -2,7 +2,9 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
   applyOrganizationResourceDelta,
-  upsertById
+  upsertById,
+  mergeById,
+  reviewMemberCountDelta
 } from './organizationState.ts'
 
 test('upsert adds a newly joined organization to the front', () => {
@@ -53,4 +55,37 @@ test('resource counts never become negative when a share is removed', () => {
 
   assert.equal(result.organizations[0].agent_share_count, 0)
   assert.equal(result.resourceCounts?.agents.by_organization['space-1'], 0)
+})
+
+test('merge keeps list-only aggregate fields when a detail payload omits them', () => {
+  const result = mergeById(
+    [{ id: 'space-1', name: 'Old name', share_count: 5, agent_share_count: 2 }],
+    { id: 'space-1', name: 'New name' }
+  )
+
+  assert.deepEqual(result, [
+    { id: 'space-1', name: 'New name', share_count: 5, agent_share_count: 2 }
+  ])
+})
+
+test('merge inserts a brand-new organization at the front', () => {
+  const result = mergeById(
+    [{ id: 'existing', name: 'Existing' }],
+    { id: 'new', name: 'New' }
+  )
+
+  assert.deepEqual(result.map(organization => organization.id), ['new', 'existing'])
+})
+
+test('approving a new join request adds one member', () => {
+  assert.equal(reviewMemberCountDelta(true, 'join'), 1)
+})
+
+test('approving a role upgrade does not change member_count', () => {
+  assert.equal(reviewMemberCountDelta(true, 'upgrade'), 0)
+})
+
+test('rejecting any request does not change member_count', () => {
+  assert.equal(reviewMemberCountDelta(false, 'join'), 0)
+  assert.equal(reviewMemberCountDelta(false, 'upgrade'), 0)
 })

--- a/frontend/src/stores/organizationState.ts
+++ b/frontend/src/stores/organizationState.ts
@@ -5,6 +5,33 @@ export function upsertById<T extends { id: string }>(items: T[], item: T): T[] {
     : [item, ...items]
 }
 
+/**
+ * Merge a (possibly partial) organization payload onto the existing card.
+ *
+ * Detail endpoints (e.g. GET /organizations/:id) may omit list-only aggregate
+ * fields such as share_count / agent_share_count / pending_join_request_count.
+ * A plain replace would blank those badges until the background refresh lands,
+ * so when a card already exists we shallow-merge instead of overwriting it.
+ */
+export function mergeById<T extends { id: string }>(items: T[], item: T): T[] {
+  const existing = items.find(entry => entry.id === item.id)
+  const merged = existing ? { ...existing, ...item } : item
+  return upsertById(items, merged)
+}
+
+/**
+ * How much a join-request review changes the organization's member_count.
+ *
+ * Only brand-new "join" approvals add a member. Approving an "upgrade" request
+ * (an existing member asking for a higher role) must not change member_count.
+ */
+export function reviewMemberCountDelta(
+  approved: boolean,
+  requestType: 'join' | 'upgrade' | undefined
+): number {
+  return approved && requestType !== 'upgrade' ? 1 : 0
+}
+
 interface OrganizationResourceCounts {
   knowledge_bases: { by_organization: Record<string, number> }
   agents: { by_organization: Record<string, number> }

--- a/frontend/src/views/organization/OrganizationSettingsModal.vue
+++ b/frontend/src/views/organization/OrganizationSettingsModal.vue
@@ -1447,7 +1447,8 @@ const handleApproveRequest = async (req: JoinRequestResponse, assignRole: 'viewe
     const res = await orgStore.reviewOrganizationJoinRequest(
       props.orgId,
       req.id,
-      { approved: true, role: assignRole }
+      { approved: true, role: assignRole },
+      { requestType: req.request_type }
     )
     if (res.success) {
       MessagePlugin.success(t('organization.settings.approveSuccess'))
@@ -1472,7 +1473,8 @@ const handleRejectRequest = async (req: JoinRequestResponse) => {
     const res = await orgStore.reviewOrganizationJoinRequest(
       props.orgId,
       req.id,
-      { approved: false }
+      { approved: false },
+      { requestType: req.request_type }
     )
     if (res.success) {
       MessagePlugin.success(t('organization.settings.rejectSuccess'))
@@ -1871,6 +1873,11 @@ watch(() => props.visible, (newVal) => {
       inviteCode.value = ''
       inviteCodeExpiresAt.value = null
     } else if (props.orgId) {
+      // 清空上一个组织的详情上下文，避免在 fetchOrgDetail 返回前短暂显示旧组织信息
+      if (orgStore.currentOrganization?.id !== props.orgId) {
+        orgStore.clearCurrentOrganizationContext()
+        sharedKnowledgeBases.value = []
+      }
       fetchOrgDetail()
       fetchMembers()
       fetchSharedKBs()


### PR DESCRIPTION
## Description

Follow-up to #2268. That PR centralized organization state in the store and added optimistic updates + a versioned request coordinator. This PR fixes three residual issues in the optimistic-update paths found during review.

### Root cause & changes

1. **Approving a role-upgrade request wrongly bumped `member_count`.**
   The join-requests table contains both `join` and `upgrade` requests, and both are approved through the same handler. `reviewOrganizationJoinRequest` incremented `member_count` for any approval, so approving an *upgrade* (an existing member requesting a higher role) over-counted members until the background refresh corrected it.
   - `reviewOrganizationJoinRequest` now takes the `request_type` and only counts genuine `join` approvals (via the new pure helper `reviewMemberCountDelta`).

2. **Loading org detail could transiently blank list-only badges.**
   `setCurrentOrganization` used `upsertOrganization`, replacing the whole card with the `GET /organizations/:id` payload. Detail responses may omit list-only aggregate fields (`share_count`, `agent_share_count`, `pending_join_request_count`), which blanked those badges until the forced refresh landed.
   - `setCurrentOrganization` now shallow-merges the detail payload onto the existing card (`mergeById`), preserving aggregate fields the detail endpoint doesn't return.

3. **Stale organization shown when reopening the settings modal for a different org.**
   In edit mode the modal did not clear the shared `currentOrganization` before `fetchOrgDetail()` resolved, so the header/avatar briefly showed the previously opened org.
   - `OrganizationSettingsModal` now clears the context when reopening for a different org id.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🧪 Test

## Related Issue / PR

Follow-up to #2268.

## Testing

- New pure-helper unit tests for `mergeById` and `reviewMemberCountDelta` in `organizationState.test.ts`.
- Targeted org regression suites pass:

```text
npx tsx --test src/stores/organizationState.test.ts src/stores/versionedRequest.test.ts \
  src/views/organization/OrganizationStateSync.test.mjs \
  src/views/organization/OrganizationSettingsModal.test.mjs
# tests 18 / pass 18 / fail 0
```

- `vue-tsc` reports no type errors in the changed files (pre-existing errors elsewhere are unaffected).

## Checklist

- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (N/A)