### PR TITLE
fix(agent): 配置agent后点击保存页面还在：调整为自动关闭，和知识库一样

### DIFF
--- a/frontend/src/views/agent/AgentEditorModal.test.mjs
+++ b/frontend/src/views/agent/AgentEditorModal.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const source = readFileSync(new URL('./AgentEditorModal.vue', import.meta.url), 'utf8')
+
+test('editing an agent closes the editor after a successful save', () => {
+  assert.match(
+    source,
+    /await updateAgent\(formData\.value\.id, formData\.value\);\s*MessagePlugin\.success\(t\('agent\.messages\.updated'\)\);\s*emit\('success'\);\s*handleClose\(\);/
+  )
+})
+
+test('the first successful create stays open for integration setup', () => {
+  const createBranch = source.match(
+    /if \(editorMode\.value === 'create'\) \{([\s\S]*?)^\s{4}\} else \{/m
+  )?.[1]
+
+  assert.ok(createBranch, 'expected to find the create branch')
+  assert.doesNotMatch(createBranch, /handleClose\(\)/)
+  assert.match(createBranch, /savedAgent\.value = created;/)
+})

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -4273,6 +4273,7 @@ const handleSave = async () => {
       await updateAgent(formData.value.id, formData.value);
       MessagePlugin.success(t('agent.messages.updated'));
       emit('success');
+      handleClose();
     }
   } catch (e: any) {
     MessagePlugin.error(e?.message || t('agent.messages.saveFailed'));


### PR DESCRIPTION
## Description

This PR fixes the agent editor remaining open after successfully saving changes to an existing agent.

### Root Cause

The edit branch of `handleSave()` updated the agent and emitted the `success` event, but it never emitted the visibility update needed to close the editor.

The create flow intentionally keeps the editor open after the first successful save so users can continue configuring IM and embed integrations. That behavior is preserved.

### Changes

- Close the agent editor after successfully updating an existing agent.
- Keep the editor open after the first successful agent creation.
- Keep the editor open when validation or the save request fails.
- Add regression tests covering both the edit and create behaviors.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

The targeted regression tests passed:

```text
node --test src/views/agent/AgentEditorModal.test.mjs

2 tests passed
0 tests failed
```

Covered scenarios:

- Editing an existing agent closes the editor after a successful save.
- The first successful agent creation keeps the editor open for integration setup.

Additional verification:

```text
git diff --check: passed
```

`npm run type-check` is currently blocked by pre-existing errors in unrelated code, including session sidebar options, locale files, system settings, and two existing `unknown` type errors in `AgentEditorModal.vue`. This change did not introduce new type errors.

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A — no layout or styling changes.