### PR TITLE
fix: resolve request-local source handles

### DIFF
--- a/internal/agent/act.go
+++ b/internal/agent/act.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -305,6 +306,11 @@ func (e *AgentEngine) runToolCall(
 	ctx context.Context, tc types.LLMToolCall, i int,
 	iteration, round int, sessionID, assistantMessageID string,
 ) types.ToolCall {
+	// Think normally decodes request-local references before tool execution.
+	// Do it again at the dispatch boundary so a provider-specific streaming
+	// path cannot let dN/bN/cN/wN aliases leak into a database-facing tool.
+	e.decodeToolCallReferences(&tc)
+
 	tc.ID = agenttools.NormalizeToolCallID(tc.ID, tc.Function.Name, i)
 	total := "?" // unknown in isolation; callers log the batch size
 	toolTag := fmt.Sprintf("[Agent][Round-%d][Tool %s (%d/%s)]",
@@ -331,6 +337,36 @@ func (e *AgentEngine) runToolCall(
 		}
 		logger.Warnf(ctx, "%s Repaired malformed JSON arguments", toolTag)
 		tc.Function.Arguments = repaired
+		e.decodeToolCallReferences(&tc)
+		if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+			logger.Errorf(ctx, "%s Failed to parse repaired arguments after decoding references: %v", toolTag, err)
+			return types.ToolCall{
+				ID:               tc.ID,
+				Name:             tc.Function.Name,
+				Args:             map[string]any{"_raw": argsStr},
+				ProviderMetadata: tc.ProviderMetadata,
+				Result: &types.ToolResult{
+					Success: false,
+					Error: fmt.Sprintf(
+						"Failed to parse tool arguments: %v", err,
+					) + "\n\n[Analyze the error above and try a different approach.]",
+				},
+			}
+		}
+	}
+	if aliases := e.sourceRefs.UnresolvedToolAliases(tc.Function.Arguments); len(aliases) > 0 {
+		errMsg := unresolvedSourceHandleError(aliases)
+		logger.Warnf(ctx, "%s Rejected %s", toolTag, errMsg)
+		return types.ToolCall{
+			ID:               tc.ID,
+			Name:             tc.Function.Name,
+			Args:             args,
+			ProviderMetadata: tc.ProviderMetadata,
+			Result: &types.ToolResult{
+				Success: false,
+				Error:   errMsg,
+			},
+		}
 	}
 
 	logger.Debugf(ctx, "%s Args: %s", toolTag, tc.Function.Arguments)
@@ -473,4 +509,34 @@ func (e *AgentEngine) runToolCall(
 	}
 
 	return toolCall
+}
+
+func (e *AgentEngine) decodeToolCallReferences(tc *types.LLMToolCall) {
+	if tc == nil {
+		return
+	}
+	decodedCalls := []types.LLMToolCall{*tc}
+	if e.resourceRefs != nil {
+		e.resourceRefs.DecodeToolCalls(decodedCalls)
+	}
+	if e.sourceRefs != nil {
+		e.sourceRefs.DecodeToolCalls(decodedCalls)
+	}
+	*tc = decodedCalls[0]
+}
+
+func unresolvedSourceHandleError(aliases []string) string {
+	quoted := make([]string, 0, len(aliases))
+	for _, alias := range aliases {
+		quoted = append(quoted, fmt.Sprintf("%q", alias))
+	}
+	label := "unknown or incompatible source handle"
+	if len(quoted) > 1 {
+		label += "s"
+	}
+	return fmt.Sprintf(
+		"%s %s: source handles are request-local. Use only a cN/dN/bN/wN value that appeared in the current runtime context or a tool result; do not guess a handle or reuse one from a previous turn.",
+		label,
+		strings.Join(quoted, ", "),
+	)
 }

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -2,10 +2,12 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
 
+	agenttools "github.com/Tencent/WeKnora/internal/agent/tools"
 	"github.com/Tencent/WeKnora/internal/event"
 	"github.com/Tencent/WeKnora/internal/llmreference"
 	"github.com/Tencent/WeKnora/internal/models/chat"
@@ -93,6 +95,44 @@ func (m *mockChat) Chat(_ context.Context, _ []chat.Message, _ *chat.ChatOptions
 func (m *mockChat) GetModelName() string { return "mock-model" }
 func (m *mockChat) GetModelID() string   { return "mock-id" }
 
+type sourceHandleProbeTool struct {
+	agenttools.BaseTool
+	mu    sync.Mutex
+	calls []json.RawMessage
+}
+
+func newSourceHandleProbeTool(name string) *sourceHandleProbeTool {
+	return &sourceHandleProbeTool{
+		BaseTool: agenttools.NewBaseTool(
+			name,
+			"Captures tool arguments for source-handle tests.",
+			json.RawMessage(`{"type":"object"}`),
+		),
+	}
+}
+
+func (t *sourceHandleProbeTool) Execute(_ context.Context, args json.RawMessage) (*types.ToolResult, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.calls = append(t.calls, append(json.RawMessage(nil), args...))
+	return &types.ToolResult{Success: true, Output: "probe executed"}, nil
+}
+
+func (t *sourceHandleProbeTool) callCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.calls)
+}
+
+func (t *sourceHandleProbeTool) lastCall() json.RawMessage {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.calls) == 0 {
+		return nil
+	}
+	return append(json.RawMessage(nil), t.calls[len(t.calls)-1]...)
+}
+
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
@@ -114,7 +154,9 @@ func withCitationsEnabled(enabled bool) testEngineOption {
 func TestBuildSystemPromptUsesInternalCitationSetting(t *testing.T) {
 	model := &mockChat{}
 	enabledEngine := newTestEngine(t, model)
-	require.Contains(t, enabledEngine.buildSystemPrompt(context.Background()), "Source citations are enabled")
+	enabledPrompt := enabledEngine.buildSystemPrompt(context.Background())
+	require.Contains(t, enabledPrompt, "Source citations are enabled")
+	require.Contains(t, enabledPrompt, "Use only a cN/dN/bN/wN handle that appeared verbatim")
 
 	disabledEngine := newTestEngine(t, model, withCitationsEnabled(false))
 	prompt := disabledEngine.buildSystemPrompt(context.Background())
@@ -154,6 +196,154 @@ func emptyMessages() []chat.Message {
 
 func emptyTools() []chat.Tool {
 	return nil
+}
+
+func TestExecuteLoopRejectsUnknownSourceHandleBeforeToolExecution(t *testing.T) {
+	for _, alias := range []string{"d0", "d4"} {
+		t.Run(alias, func(t *testing.T) {
+			probe := newSourceHandleProbeTool(agenttools.ToolListKnowledgeChunks)
+			toolRegistry := agenttools.NewToolRegistry()
+			toolRegistry.RegisterTool(probe)
+
+			model := &mockChat{responses: []mockResponse{
+				{chunks: []types.StreamResponse{{
+					ResponseType: types.ResponseTypeToolCall,
+					ToolCalls: []types.LLMToolCall{{
+						ID:   "call-unknown-source",
+						Type: "function",
+						Function: types.FunctionCall{
+							Name:      probe.Name(),
+							Arguments: `{"knowledge_id":"` + alias + `"}`,
+						},
+					}},
+					Done:         true,
+					FinishReason: "tool_calls",
+				}}},
+				{chunks: []types.StreamResponse{{
+					ResponseType: types.ResponseTypeAnswer,
+					Content:      "I will search again using a listed source.",
+					Done:         true,
+					FinishReason: "stop",
+				}}},
+			}}
+			engine := newTestEngine(t, model)
+			engine.toolRegistry = toolRegistry
+
+			state := &types.AgentState{}
+			_, err := engine.executeLoop(
+				context.Background(),
+				state,
+				"read the requested document",
+				emptyMessages(),
+				engine.buildToolsForLLM(),
+				"sess-1",
+				"msg-1",
+			)
+			require.NoError(t, err)
+			require.NotEmpty(t, state.RoundSteps)
+			require.Len(t, state.RoundSteps[0].ToolCalls, 1)
+
+			result := state.RoundSteps[0].ToolCalls[0].Result
+			require.NotNil(t, result)
+			assert.False(t, result.Success)
+			assert.Contains(t, result.Error, `unknown or incompatible source handle "`+alias+`"`)
+			assert.Zero(t, probe.callCount(), "an unknown request-local alias must not reach the underlying tool")
+		})
+	}
+}
+
+func TestRunToolCallResolvesDocumentHandlesAtExecutionBoundary(t *testing.T) {
+	tests := []struct {
+		name      string
+		toolName  string
+		arguments string
+		expected  string
+	}{
+		{
+			name:      "list knowledge chunks",
+			toolName:  agenttools.ToolListKnowledgeChunks,
+			arguments: `{"knowledge_id":"d1"}`,
+			expected:  `{"knowledge_id":"knowledge-uuid-1"}`,
+		},
+		{
+			name:      "get document info",
+			toolName:  agenttools.ToolGetDocumentInfo,
+			arguments: `{"knowledge_ids":["d1"]}`,
+			expected:  `{"knowledge_ids":["knowledge-uuid-1"]}`,
+		},
+		{
+			name:      "direct UUID remains unchanged",
+			toolName:  agenttools.ToolListKnowledgeChunks,
+			arguments: `{"knowledge_id":"knowledge-uuid-1"}`,
+			expected:  `{"knowledge_id":"knowledge-uuid-1"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			probe := newSourceHandleProbeTool(tt.toolName)
+			toolRegistry := agenttools.NewToolRegistry()
+			toolRegistry.RegisterTool(probe)
+
+			engine := newTestEngine(t, &mockChat{})
+			engine.toolRegistry = toolRegistry
+			engine.sourceRefs.RegisterDocument("knowledge-uuid-1")
+
+			toolCall := engine.runToolCall(
+				context.Background(),
+				types.LLMToolCall{
+					ID:   "call-known-source",
+					Type: "function",
+					Function: types.FunctionCall{
+						Name:      probe.Name(),
+						Arguments: tt.arguments,
+					},
+				},
+				0,
+				0,
+				1,
+				"sess-1",
+				"msg-1",
+			)
+
+			require.NotNil(t, toolCall.Result)
+			assert.True(t, toolCall.Result.Success)
+			assert.Equal(t, 1, probe.callCount())
+			require.JSONEq(t, tt.expected, string(probe.lastCall()))
+		})
+	}
+}
+
+func TestRunToolCallResolvesSourceHandleAfterJSONRepair(t *testing.T) {
+	probe := newSourceHandleProbeTool(agenttools.ToolListKnowledgeChunks)
+	toolRegistry := agenttools.NewToolRegistry()
+	toolRegistry.RegisterTool(probe)
+
+	engine := newTestEngine(t, &mockChat{})
+	engine.toolRegistry = toolRegistry
+	engine.sourceRefs.RegisterDocument("knowledge-uuid-1")
+
+	toolCall := engine.runToolCall(
+		context.Background(),
+		types.LLMToolCall{
+			ID:   "call-repaired-source",
+			Type: "function",
+			Function: types.FunctionCall{
+				Name:      probe.Name(),
+				Arguments: `{"knowledge_id":"d1",}`,
+			},
+		},
+		0,
+		0,
+		1,
+		"sess-1",
+		"msg-1",
+	)
+
+	require.NotNil(t, toolCall.Result)
+	assert.True(t, toolCall.Result.Success)
+	assert.Equal(t, 1, probe.callCount())
+	require.JSONEq(t, `{"knowledge_id":"knowledge-uuid-1"}`, string(probe.lastCall()))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/llmreference/registry.go
+++ b/internal/llmreference/registry.go
@@ -23,6 +23,7 @@ const sourceAliasProtocolPrompt = `
 ## Source handling protocol (system-owned)
 Retrieved content uses request-local source handles: cN identifies a knowledge chunk, wN a web page, dN a document, and bN a knowledge base.
 - Use dN and bN only as tool arguments when a tool requests a document or knowledge base.
+- Use only a cN/dN/bN/wN handle that appeared verbatim in the current runtime context or a tool result. Never guess a handle or reuse one from a previous turn.
 - Never reveal raw chunk IDs, knowledge IDs, knowledge-base IDs, or private source handles in user-visible output. This does not change separate instructions to preserve retrieved Markdown image URLs.`
 
 const citationEnabledProtocolPrompt = `
@@ -258,6 +259,54 @@ func (r *Registry) DecodeToolCalls(toolCalls []types.LLMToolCall) {
 	}
 }
 
+// UnresolvedToolAliases returns the request-local source handles in ID-bearing
+// tool arguments that cannot be resolved for that argument's expected source
+// kind. Callers can reject these before invoking an underlying tool, which
+// keeps a model-hallucinated or wrong-kind handle from degrading into a
+// misleading database "not found" error.
+func (r *Registry) UnresolvedToolAliases(raw string) []string {
+	if r == nil || strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var value interface{}
+	if err := json.Unmarshal([]byte(raw), &value); err != nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	unresolved := make([]string, 0)
+	r.collectUnresolvedToolAliases("", value, seen, &unresolved)
+	sort.Strings(unresolved)
+	return unresolved
+}
+
+func (r *Registry) collectUnresolvedToolAliases(key string, value interface{}, seen map[string]struct{}, unresolved *[]string) {
+	switch typed := value.(type) {
+	case string:
+		kind, ok := sourceAliasKindForKey(key)
+		if !ok {
+			return
+		}
+		alias := strings.ToLower(strings.TrimSpace(typed))
+		if !shortSourceAliasRE.MatchString(alias) || r.realForAliasOfKind(alias, kind) != "" {
+			return
+		}
+		if _, duplicate := seen[alias]; duplicate {
+			return
+		}
+		seen[alias] = struct{}{}
+		*unresolved = append(*unresolved, alias)
+	case []interface{}:
+		for _, item := range typed {
+			r.collectUnresolvedToolAliases(key, item, seen, unresolved)
+		}
+	case map[string]interface{}:
+		for childKey, item := range typed {
+			r.collectUnresolvedToolAliases(childKey, item, seen, unresolved)
+		}
+	}
+}
+
 // EncodeMessages compacts known real identifiers in assistant tool-call replay.
 func (r *Registry) EncodeMessages(messages []chat.Message) []chat.Message {
 	if r == nil || len(messages) == 0 {
@@ -300,7 +349,42 @@ func (r *Registry) EncodeMessages(messages []chat.Message) []chat.Message {
 	return out
 }
 
-var shortSourceAliasRE = regexp.MustCompile(`(?i)^[cdbw][1-9][0-9]*$`)
+var shortSourceAliasRE = regexp.MustCompile(`(?i)^[cdbw][0-9]+$`)
+
+type sourceAliasKind byte
+
+const (
+	sourceAliasChunk         sourceAliasKind = 'c'
+	sourceAliasDocument      sourceAliasKind = 'd'
+	sourceAliasKnowledgeBase sourceAliasKind = 'b'
+	sourceAliasWeb           sourceAliasKind = 'w'
+)
+
+// sourceAliasKindByKey is shared by registration, decoding, and validation so
+// an alias can only be used for the kind of identifier its JSON field expects.
+var sourceAliasKindByKey = map[string]sourceAliasKind{
+	"chunk_id": sourceAliasChunk, "faq_id": sourceAliasChunk,
+	"chunk_ids": sourceAliasChunk, "faq_ids": sourceAliasChunk,
+	"knowledge_id": sourceAliasDocument, "knowledge_ids": sourceAliasDocument,
+	"suspected_knowledge_ids": sourceAliasDocument, "source_refs": sourceAliasDocument,
+	"knowledge_base": sourceAliasKnowledgeBase, "knowledge_base_id": sourceAliasKnowledgeBase,
+	"knowledge_base_ids": sourceAliasKnowledgeBase, "kb_id": sourceAliasKnowledgeBase,
+	"kb_ids": sourceAliasKnowledgeBase,
+	"url":    sourceAliasWeb, "urls": sourceAliasWeb,
+}
+
+func sourceAliasKindForKey(key string) (sourceAliasKind, bool) {
+	kind, ok := sourceAliasKindByKey[strings.ToLower(key)]
+	return kind, ok
+}
+
+func sourceAliasKindForAlias(alias string) (sourceAliasKind, bool) {
+	alias = strings.ToLower(strings.TrimSpace(alias))
+	if !shortSourceAliasRE.MatchString(alias) {
+		return 0, false
+	}
+	return sourceAliasKind(alias[0]), true
+}
 
 func (r *Registry) registerToolArguments(raw string) {
 	if r == nil || strings.TrimSpace(raw) == "" {
@@ -320,14 +404,18 @@ func (r *Registry) registerToolArgumentValue(key string, value interface{}) {
 		if value == "" || shortSourceAliasRE.MatchString(value) {
 			return
 		}
-		switch strings.ToLower(key) {
-		case "chunk_id", "faq_id", "chunk_ids", "faq_ids":
+		kind, ok := sourceAliasKindForKey(key)
+		if !ok {
+			return
+		}
+		switch kind {
+		case sourceAliasChunk:
 			r.RegisterChunk(ChunkReference{ChunkID: value})
-		case "knowledge_id", "knowledge_ids", "suspected_knowledge_ids", "source_refs":
+		case sourceAliasDocument:
 			r.RegisterDocument(value)
-		case "knowledge_base", "knowledge_base_id", "knowledge_base_ids", "kb_id", "kb_ids":
+		case sourceAliasKnowledgeBase:
 			r.RegisterKnowledgeBase(value)
-		case "url", "urls":
+		case sourceAliasWeb:
 			if parsed, err := url.Parse(value); err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") {
 				r.RegisterWeb(value, "")
 			}
@@ -428,17 +516,6 @@ func (r *Registry) decodeJSON(raw string, encode bool) string {
 	return string(encoded)
 }
 
-// decodableKeys mirrors the ID-bearing keys recognized by
-// registerToolArgumentValue. Alias -> real substitution on decode is restricted
-// to these keys so that free-text values (e.g. a grep/search query that happens
-// to equal "d1") are never rewritten into internal identifiers.
-var decodableKeys = map[string]struct{}{
-	"chunk_id": {}, "faq_id": {}, "chunk_ids": {}, "faq_ids": {},
-	"knowledge_id": {}, "knowledge_ids": {}, "suspected_knowledge_ids": {}, "source_refs": {},
-	"knowledge_base": {}, "knowledge_base_id": {}, "knowledge_base_ids": {}, "kb_id": {}, "kb_ids": {},
-	"url": {}, "urls": {},
-}
-
 func (r *Registry) walkJSON(key string, value interface{}, encode bool) interface{} {
 	switch typed := value.(type) {
 	case string:
@@ -450,15 +527,14 @@ func (r *Registry) walkJSON(key string, value interface{}, encode bool) interfac
 			}
 			return typed
 		}
-		// Decode only ID-bearing keys, and only when the value is alias-shaped,
-		// so ordinary strings that coincidentally equal an alias are preserved.
-		if _, ok := decodableKeys[strings.ToLower(key)]; !ok {
+		// Decode only ID-bearing keys, and only when the value is an alias of
+		// the kind that key expects, so ordinary strings and wrong-kind aliases
+		// are preserved for the dispatch boundary to diagnose.
+		kind, ok := sourceAliasKindForKey(key)
+		if !ok {
 			return typed
 		}
-		if !shortSourceAliasRE.MatchString(strings.TrimSpace(typed)) {
-			return typed
-		}
-		if real := r.realForAlias(typed); real != "" {
+		if real := r.realForAliasOfKind(typed, kind); real != "" {
 			return real
 		}
 		return typed
@@ -492,20 +568,27 @@ func (r *Registry) aliasForRealValue(real string) string {
 	return ""
 }
 
-func (r *Registry) realForAlias(alias string) string {
+func (r *Registry) realForAliasOfKind(alias string, expected sourceAliasKind) string {
+	alias = strings.ToLower(strings.TrimSpace(alias))
+	kind, ok := sourceAliasKindForAlias(alias)
+	if !ok || kind != expected {
+		return ""
+	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if ref := r.chunkByAlias[alias]; ref != nil {
-		return ref.ChunkID
-	}
-	if real := r.aliasToDoc[alias]; real != "" {
-		return real
-	}
-	if real := r.aliasToKB[alias]; real != "" {
-		return real
-	}
-	if ref := r.webByAlias[alias]; ref != nil {
-		return ref.URL
+	switch expected {
+	case sourceAliasChunk:
+		if ref := r.chunkByAlias[alias]; ref != nil {
+			return ref.ChunkID
+		}
+	case sourceAliasDocument:
+		return r.aliasToDoc[alias]
+	case sourceAliasKnowledgeBase:
+		return r.aliasToKB[alias]
+	case sourceAliasWeb:
+		if ref := r.webByAlias[alias]; ref != nil {
+			return ref.URL
+		}
 	}
 	return ""
 }

--- a/internal/llmreference/registry_test.go
+++ b/internal/llmreference/registry_test.go
@@ -87,6 +87,43 @@ func TestDecodeToolCallsOnlyRewritesAliasBearingKeys(t *testing.T) {
 	)
 }
 
+func TestRegistryReportsOnlyUnresolvedAliasValuedToolArguments(t *testing.T) {
+	registry := NewRegistry()
+	registry.RegisterDocument("knowledge-uuid-1")
+
+	unresolved := registry.UnresolvedToolAliases(`{
+  "knowledge_id": " D1 ",
+  "knowledge_ids": ["d0"],
+  "knowledge_base_ids": ["b9"],
+  "nested": {"chunk_id": "c8", "content": "see c8"},
+  "query": "d4"
+}`)
+
+	require.Equal(t, []string{"b9", "c8", "d0"}, unresolved)
+}
+
+func TestRegistryRejectsWrongKindAliasesWithoutChangingDirectIDs(t *testing.T) {
+	registry := NewRegistry()
+	registry.RegisterDocument("knowledge-uuid-1")
+	registry.RegisterKnowledgeBase("knowledge-base-uuid-1")
+
+	directID := []types.LLMToolCall{{
+		Function: types.FunctionCall{Arguments: `{"knowledge_id":"knowledge-uuid-1","knowledge_base_id":"b1"}`},
+	}}
+	registry.DecodeToolCalls(directID)
+	require.JSONEq(t,
+		`{"knowledge_id":"knowledge-uuid-1","knowledge_base_id":"knowledge-base-uuid-1"}`,
+		directID[0].Function.Arguments,
+	)
+
+	wrongKind := []types.LLMToolCall{{
+		Function: types.FunctionCall{Arguments: `{"knowledge_id":"b1"}`},
+	}}
+	registry.DecodeToolCalls(wrongKind)
+	require.JSONEq(t, `{"knowledge_id":"b1"}`, wrongKind[0].Function.Arguments)
+	require.Equal(t, []string{"b1"}, registry.UnresolvedToolAliases(wrongKind[0].Function.Arguments))
+}
+
 func TestStreamExpanderHoldsSplitReferenceAndDropsUnknown(t *testing.T) {
 	registry := NewRegistry()
 	registry.RegisterChunk(ChunkReference{ChunkID: "chunk-1", DocumentTitle: "Doc"})


### PR DESCRIPTION
## Summary
- Resolve request-local source handles again at the final tool-dispatch boundary.
- Reject unknown or type-incompatible handles before a tool reaches a database lookup.
- Resolve handles again after malformed tool-call JSON is repaired, with regression coverage.

## Testing
- `go test ./internal/agent ./internal/llmreference -count=1`
- `go vet ./internal/agent ./internal/llmreference`