### PR TITLE
fix(agent): 恢复共享智能体使用默认模型

### DIFF
--- a/frontend/src/components/Input-field.agent-switch.test.mjs
+++ b/frontend/src/components/Input-field.agent-switch.test.mjs
@@ -24,3 +24,18 @@ test('selecting an agent leaves web search off until the user enables it', () =>
   assert.doesNotMatch(handleSelectAgent, /agentWebSearch/)
   assert.doesNotMatch(handleSelectAgent, /settingsStore\.toggleWebSearch/)
 })
+
+test('shared agents keep a selectable path back to their source model', () => {
+  assert.match(
+    inputField,
+    /const sharedAgentDefaultModelId = computed\(\(\) => \{[\s\S]*?settingsStore\.selectedAgentSourceTenantId[\s\S]*?availableModels\.value\.some\(model => model\.id === modelId\)/
+  )
+  assert.match(
+    inputField,
+    /const restoreSharedAgentDefaultModel = \(\) => \{[\s\S]*?selectedModelId\.value = modelId;[\s\S]*?showModelSelector\.value = false;/
+  )
+  assert.match(
+    inputField,
+    /v-if="sharedAgentDefaultModelId"[\s\S]*?@click="restoreSharedAgentDefaultModel"[\s\S]*?\$t\('input\.sharedAgentModelLabel'\)/
+  )
+})

--- a/frontend/src/components/Input-field.vue
+++ b/frontend/src/components/Input-field.vue
@@ -1021,6 +1021,29 @@ const selectedModel = computed(() => {
   return availableModels.value.find(model => model.id === selectedModelId.value);
 });
 
+// A shared agent can reference a model owned by its source workspace. That
+// model is intentionally absent from the current workspace's model list, so
+// expose a synthetic option that lets the user return to the agent default
+// after temporarily selecting one of their own models.
+const sharedAgentDefaultModelId = computed(() => {
+  const modelId = agentModelId.value?.trim() || '';
+  if (!settingsStore.selectedAgentSourceTenantId || !modelId) return '';
+  return availableModels.value.some(model => model.id === modelId) ? '' : modelId;
+});
+
+const restoreSharedAgentDefaultModel = () => {
+  const modelId = sharedAgentDefaultModelId.value;
+  if (!modelId) return;
+
+  selectedModelId.value = modelId;
+  showModelSelector.value = false;
+  settingsStore.updateConversationModels({
+    summaryModelId: modelId,
+    selectedChatModelId: modelId,
+    rerankModelId: '',
+  });
+};
+
 // 模型展示名：本空间列表中有则用名称；若为共享智能体且其 model_id 不在本空间列表中则显示“共享智能体配置的模型”
 const selectedModelDisplayName = computed(() => {
   if (selectedModel.value) return modelDisplayName(selectedModel.value);
@@ -2656,6 +2679,18 @@ defineExpose({
                 </button>
               </div>
               <div class="model-selector-content">
+                <div v-if="sharedAgentDefaultModelId" class="model-option"
+                  :class="{ selected: sharedAgentDefaultModelId === selectedModelId }"
+                  @click="restoreSharedAgentDefaultModel">
+                  <div class="model-option-left">
+                    <div class="model-option-icon">
+                      <t-icon name="chat" size="14px" />
+                    </div>
+                    <div class="model-option-name-wrap">
+                      <span class="model-option-name">{{ $t('input.sharedAgentModelLabel') }}</span>
+                    </div>
+                  </div>
+                </div>
                 <div v-for="model in availableModels" :key="model.id" class="model-option"
                   :class="{ selected: model.id === selectedModelId }" @click="handleModelChange(model.id || '')">
                   <div class="model-option-left">


### PR DESCRIPTION
## Description

本 PR 修复使用共享智能体时无法切回智能体原配置模型的问题。

用户首次选择共享智能体时，会默认使用该智能体配置的模型。但用户临时切换到自己空间中的模型后，模型下拉列表中不再显示共享智能体原本配置的模型，导致无法恢复使用智能体配置的模型。

### 问题原因

共享智能体配置的模型可能属于来源空间，因此不会出现在当前空间的 `availableModels` 模型列表中。

此前，输入框在使用来源模型时，可以通过“共享智能体配置的模型”显示当前状态；但模型下拉列表只渲染当前空间 `availableModels` 中的模型。

因此，用户切换到自己的模型后，共享智能体的来源模型就失去了可点击的入口，无法再切换回去。

### 修改内容

- 在模型下拉列表中增加“共享智能体配置的模型”选项。
- 仅在以下条件同时满足时显示该选项：
  - 当前使用的是其他空间共享的智能体；
  - 该智能体配置了对话模型；
  - 该模型不在当前空间的模型列表中。
- 点击该选项后，恢复使用共享智能体原本配置的模型。
- 恢复模型时同步更新当前会话的模型状态，并关闭模型下拉列表。
- 复用现有的多语言“共享智能体配置的模型”文案。
- 如果来源模型已经存在于当前空间的模型列表中，则不额外显示，避免产生重复选项。
- 补充回归测试，防止该问题再次出现。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

已运行共享智能体模型切换相关回归测试：

```text
node --preserve-symlinks-main --test src/components/Input-field.agent-switch.test.mjs

2 tests passed
0 tests failed
```

覆盖以下场景：

- 选择智能体后，网络搜索仍保持关闭，直到用户主动开启。
- 当共享智能体的来源模型不属于当前空间时，模型下拉列表仍提供切回该模型的入口。

其他检查：

```text
git diff --check: passed
```

完整 TypeScript 类型检查仍被仓库中已有的 10 个无关错误阻断，涉及：

- 会话侧栏选项；
- 多语言文件；
- `AgentEditorModal.vue` 中已有的类型问题；
- `SystemSettings.vue` 中缺少 `nextTick` 的问题。

本 PR 修改的文件没有产生新的类型错误。

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above
