### PR TITLE
fix(build): Enable Docker BuildKit in build_images.sh

### DIFF
--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -12,6 +12,9 @@ NC='\033[0m' # 无颜色
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
 
+# 启用 BuildKit
+export DOCKER_BUILDKIT=1
+
 # 版本信息
 VERSION="1.0.0"
 SCRIPT_NAME=$(basename "$0")


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->
fix(build): Enable Docker BuildKit in build_images.sh
## Description
<!-- Briefly describe the purpose and changes of this PR -->
解决以下问题：在 build_images.sh 文件中启用 Docker BuildKit 构建工具。

如果本地没安装buildx, 将在后端make build-images-app 构建过程中报错
```
RUN --mount=type=cache,target=/go/pkg/mod go mod download
the --mount option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled
```
在build_images.sh 提前声明开启buildx, 这样构建初始就可以提前报错
```
ERROR: BuildKit is enabled but the buildx component is missing or broken.
       Install the buildx component to build images with BuildKit:
       https://docs.docker.com/go/buildx/
```

## Type of Change
<!-- Check applicable items -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [x] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->

## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [ ] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
