### PR TITLE
fix: PPT/PPTX 文件解析引擎的可选状态

### DIFF
--- a/frontend/src/stores/editorResources.ts
+++ b/frontend/src/stores/editorResources.ts
@@ -62,6 +62,9 @@ export const useEditorResourcesStore = defineStore('editorResources', () => {
   const placeholders = ref<PlaceholdersResponse | null>(null)
   const tenantRetrievalConfig = ref<Record<string, unknown> | null>(null)
   const parserEngines = ref<ParserEngineInfo[]>([])
+  const parserEnginesLoading = ref(false)
+  const parserEnginesLoaded = ref(false)
+  const parserEnginesLoadFailed = ref(false)
   const systemInfo = ref<SystemInfo | null>(null)
 
   const loadedAt = ref<Partial<Record<EditorResourceKey, number>>>({})
@@ -158,9 +161,25 @@ export const useEditorResourcesStore = defineStore('editorResources', () => {
 
   async function ensureParserEngines(force = false): Promise<void> {
     return runOnce('parserEngines', force, async () => {
-      const resp = await getParserEngines()
-      parserEngines.value = resp?.data && Array.isArray(resp.data) ? resp.data : []
-      loadedAt.value.parserEngines = Date.now()
+      parserEnginesLoading.value = true
+      parserEnginesLoadFailed.value = false
+      try {
+        const resp = await getParserEngines()
+        parserEngines.value = resp?.data && Array.isArray(resp.data) ? resp.data : []
+        parserEnginesLoaded.value = true
+        loadedAt.value.parserEngines = Date.now()
+      } catch (error) {
+        // Engine availability is live state. Keeping a previous successful
+        // response after a failed refresh can route uploads to a service that
+        // has already gone offline.
+        parserEngines.value = []
+        parserEnginesLoaded.value = false
+        parserEnginesLoadFailed.value = true
+        delete loadedAt.value.parserEngines
+        throw error
+      } finally {
+        parserEnginesLoading.value = false
+      }
     })
   }
 
@@ -198,6 +217,9 @@ export const useEditorResourcesStore = defineStore('editorResources', () => {
       placeholders.value = null
       tenantRetrievalConfig.value = null
       parserEngines.value = []
+      parserEnginesLoading.value = false
+      parserEnginesLoaded.value = false
+      parserEnginesLoadFailed.value = false
       systemInfo.value = null
       inflight.clear()
       return
@@ -220,6 +242,9 @@ export const useEditorResourcesStore = defineStore('editorResources', () => {
     placeholders,
     tenantRetrievalConfig,
     parserEngines,
+    parserEnginesLoading,
+    parserEnginesLoaded,
+    parserEnginesLoadFailed,
     systemInfo,
     ensureStorageEngine,
     resolveUsableStorageProvider,

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,5 +1,6 @@
 import { MessagePlugin } from "tdesign-vue-next";
 import i18n from '@/i18n';
+import { isKnowledgeFileTypeAllowed } from './knowledgeFileTypes';
 
 // 声明全局运行时配置类型
 declare global {
@@ -40,8 +41,6 @@ export function formatStringDate(date: any) {
     year + "-" + month + "-" + day + " " + hour + ":" + minute + ":" + second
   );
 }
-const DEFAULT_VALID_TYPES = new Set(["pdf", "txt", "md", "docx", "doc", "pptx", "ppt", "epub", "mhtml", "jpg", "jpeg", "png", "csv", "xlsx", "xls", "mp3", "wav", "m4a", "flac", "ogg"]);
-
 /** Returns true when the file exceeds the deploy-time upload limit. */
 export function fileSizeVerification(file: Pick<File, 'size'>, silent = false) {
   if (file.size <= MAX_FILE_SIZE_BYTES) return false;
@@ -56,15 +55,7 @@ export function fileSizeVerification(file: Pick<File, 'size'>, silent = false) {
  * @param validTypes - override the default extension whitelist with a dynamic set (e.g. from engine registry).
  */
 export function kbFileTypeVerification(file: any, silent = false, validTypes?: Set<string> | string[]) {
-  const provided = validTypes
-    ? (validTypes instanceof Set ? validTypes : new Set(validTypes))
-    : undefined;
-  // An empty whitelist means the engine registry hasn't loaded yet; fall back to
-  // the default set rather than rejecting every file.
-  const allowed = provided && provided.size > 0 ? provided : DEFAULT_VALID_TYPES;
-
-  const type = file.name.substring(file.name.lastIndexOf(".") + 1).toLowerCase();
-  if (!allowed.has(type)) {
+  if (!isKnowledgeFileTypeAllowed(file.name, validTypes)) {
     if (!silent) {
       MessagePlugin.error(i18n.global.t('error.unsupportedFileType'));
     }

--- a/frontend/src/utils/knowledgeFileTypes.test.ts
+++ b/frontend/src/utils/knowledgeFileTypes.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { isKnowledgeFileTypeAllowed } from './knowledgeFileTypes'
+
+test('rejects PPTX when the loaded dynamic whitelist is explicitly empty', () => {
+  assert.equal(isKnowledgeFileTypeAllowed('slides.pptx', []), false)
+  assert.equal(isKnowledgeFileTypeAllowed('slides.pptx', new Set()), false)
+})
+
+test('uses the static whitelist only when no dynamic whitelist is supplied', () => {
+  assert.equal(isKnowledgeFileTypeAllowed('slides.pptx'), true)
+})

--- a/frontend/src/utils/knowledgeFileTypes.ts
+++ b/frontend/src/utils/knowledgeFileTypes.ts
@@ -1,0 +1,18 @@
+export const DEFAULT_KB_VALID_TYPES = new Set([
+  'pdf', 'txt', 'md', 'docx', 'doc', 'pptx', 'ppt', 'epub', 'mhtml',
+  'jpg', 'jpeg', 'png', 'csv', 'xlsx', 'xls',
+  'mp3', 'wav', 'm4a', 'flac', 'ogg',
+])
+
+export function isKnowledgeFileTypeAllowed(
+  fileName: string,
+  validTypes?: Set<string> | string[],
+): boolean {
+  const allowed = validTypes === undefined
+    ? DEFAULT_KB_VALID_TYPES
+    : validTypes instanceof Set
+      ? validTypes
+      : new Set(validTypes)
+  const fileType = fileName.substring(fileName.lastIndexOf('.') + 1).toLowerCase()
+  return allowed.has(fileType)
+}

--- a/frontend/src/utils/parserEngines.test.ts
+++ b/frontend/src/utils/parserEngines.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { ParserEngineInfo } from '@/api/system'
+import {
+  completeParserEngineRules,
+  getSupportedParserFileTypes,
+  getUnroutableParserFileTypes,
+  resolveParserEngineForFileType,
+} from './parserEngines'
+
+const engines: ParserEngineInfo[] = [
+  {
+    Name: 'builtin',
+    Description: 'Built in',
+    FileTypes: ['pdf', 'docx'],
+    Available: true,
+  },
+  {
+    Name: 'markitdown',
+    Description: 'MarkItDown',
+    FileTypes: ['ppt', 'pptx', 'pdf'],
+    Available: true,
+  },
+  {
+    Name: 'mineru',
+    Description: 'MinerU',
+    FileTypes: ['ppt', 'pptx', 'pdf'],
+    Available: false,
+  },
+]
+
+test('does not report PPT/PPTX support before engines are loaded', () => {
+  assert.deepEqual([...getSupportedParserFileTypes([])], [])
+})
+
+test('reports PPT/PPTX support when an available engine can route them', () => {
+  const supported = getSupportedParserFileTypes(engines)
+  assert.equal(supported.has('ppt'), true)
+  assert.equal(supported.has('pptx'), true)
+})
+
+test('generates an explicit PPT/PPTX route for the upload batch', () => {
+  const rules = completeParserEngineRules(['ppt', 'pptx'], engines)
+  assert.deepEqual(rules, [{
+    file_types: ['ppt', 'pptx'],
+    engine: 'markitdown',
+  }])
+})
+
+test('keeps an unavailable explicit engine authoritative', () => {
+  const rules = [{ file_types: ['pptx'], engine: 'mineru' }]
+  assert.equal(resolveParserEngineForFileType('pptx', engines, rules), undefined)
+  assert.deepEqual(getUnroutableParserFileTypes(['pptx'], engines, rules), ['pptx'])
+  assert.deepEqual(completeParserEngineRules(['pptx'], engines, rules), rules)
+})
+
+test('requires the explicitly selected engine to support the extension', () => {
+  const rules = [{ file_types: ['pptx'], engine: 'builtin' }]
+  assert.equal(resolveParserEngineForFileType('pptx', engines, rules), undefined)
+})

--- a/frontend/src/utils/parserEngines.ts
+++ b/frontend/src/utils/parserEngines.ts
@@ -1,0 +1,119 @@
+import type { ParserEngineInfo } from '@/api/system'
+
+export interface ParserEngineRule {
+  file_types: string[]
+  engine: string
+}
+
+function normalizeFileType(fileType: string): string {
+  return fileType.trim().toLowerCase().replace(/^\./, '')
+}
+
+function supportsFileType(engine: ParserEngineInfo, fileType: string): boolean {
+  const normalized = normalizeFileType(fileType)
+  return (engine.FileTypes || []).some(candidate => normalizeFileType(candidate) === normalized)
+}
+
+function findExplicitEngine(fileType: string, rules: ParserEngineRule[]): string {
+  const normalized = normalizeFileType(fileType)
+  for (const rule of rules) {
+    if (rule.file_types.some(candidate => normalizeFileType(candidate) === normalized)) {
+      return rule.engine.trim()
+    }
+  }
+  return ''
+}
+
+/**
+ * Resolves the parser route the UI can actually submit for a file type.
+ * An explicit rule is authoritative: an unavailable or incompatible selected
+ * engine must not silently fall back to another engine.
+ */
+export function resolveParserEngineForFileType(
+  fileType: string,
+  engines: ParserEngineInfo[],
+  rules: ParserEngineRule[] = [],
+): ParserEngineInfo | undefined {
+  const normalized = normalizeFileType(fileType)
+  if (!normalized) return undefined
+
+  const explicitEngine = findExplicitEngine(normalized, rules)
+  if (explicitEngine) {
+    return engines.find(engine =>
+      engine.Name === explicitEngine &&
+      engine.Available !== false &&
+      supportsFileType(engine, normalized),
+    )
+  }
+
+  return engines.find(engine =>
+    engine.Available !== false && supportsFileType(engine, normalized),
+  )
+}
+
+export function getSupportedParserFileTypes(
+  engines: ParserEngineInfo[],
+  rules: ParserEngineRule[] = [],
+): Set<string> {
+  const allTypes = new Set<string>()
+  for (const engine of engines) {
+    for (const fileType of engine.FileTypes || []) {
+      const normalized = normalizeFileType(fileType)
+      if (normalized) allTypes.add(normalized)
+    }
+  }
+
+  return new Set(
+    [...allTypes].filter(fileType =>
+      resolveParserEngineForFileType(fileType, engines, rules) !== undefined,
+    ),
+  )
+}
+
+export function getUnroutableParserFileTypes(
+  fileTypes: string[],
+  engines: ParserEngineInfo[],
+  rules: ParserEngineRule[] = [],
+): string[] {
+  const unique = new Set(fileTypes.map(normalizeFileType).filter(Boolean))
+  return [...unique].filter(fileType =>
+    resolveParserEngineForFileType(fileType, engines, rules) === undefined,
+  )
+}
+
+/**
+ * Adds explicit rules for currently unconfigured file types. Existing rules
+ * are preserved, including invalid explicit selections, so configuration
+ * mistakes remain visible instead of being silently replaced.
+ */
+export function completeParserEngineRules(
+  fileTypes: string[],
+  engines: ParserEngineInfo[],
+  rules: ParserEngineRule[] = [],
+): ParserEngineRule[] {
+  const completed = rules.map(rule => ({
+    file_types: [...rule.file_types],
+    engine: rule.engine,
+  }))
+  const configured = new Set(
+    completed.flatMap(rule => rule.file_types.map(normalizeFileType).filter(Boolean)),
+  )
+  const uniqueTypes = new Set(fileTypes.map(normalizeFileType).filter(Boolean))
+
+  for (const fileType of uniqueTypes) {
+    if (configured.has(fileType)) continue
+
+    const engine = resolveParserEngineForFileType(fileType, engines)
+    if (!engine) continue
+
+    const sameEngineRule = completed.find(rule => rule.engine === engine.Name)
+    if (sameEngineRule) {
+      sameEngineRule.file_types.push(fileType)
+    } else {
+      completed.push({ file_types: [fileType], engine: engine.Name })
+    }
+    configured.add(fileType)
+  }
+
+  return completed
+}

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -57,6 +57,7 @@ import { listMoveTargets, moveKnowledge, getKnowledgeMoveProgress } from '@/api/
 import { useI18n } from 'vue-i18n';
 import { useMarqueeSelect } from '@/hooks/useMarqueeSelect';
 import type { ParserEngineInfo } from '@/api/system';
+import { getSupportedParserFileTypes } from '@/utils/parserEngines';
 const route = useRoute();
 const { t } = useI18n();
 const kbId = computed(() => (route.params as any).kbId as string || '');
@@ -164,39 +165,20 @@ const missingStorageEngine = computed(() => {
 const parserEngines = computed<ParserEngineInfo[]>(() => editorResources.parserEngines);
 
 const supportedFileTypes = computed<Set<string>>(() => {
-  const engines = parserEngines.value
-  if (!engines.length) return new Set<string>()
-
   const rules: { file_types: string[]; engine: string }[] =
     kbInfo.value?.chunking_config?.parser_engine_rules || []
-
-  const ruleMap = new Map<string, string>()
-  for (const r of rules) {
-    for (const ft of r.file_types) ruleMap.set(ft, r.engine)
-  }
-
-  const available = new Set<string>()
-  const availableEngineNames = new Set(
-    engines.filter(e => e.Available !== false).map(e => e.Name)
-  )
-
-  for (const engine of engines) {
-    for (const ft of engine.FileTypes || []) {
-      if (available.has(ft)) continue
-
-      const explicitEngine = ruleMap.get(ft)
-      if (explicitEngine) {
-        if (availableEngineNames.has(explicitEngine)) available.add(ft)
-      } else {
-        if (engine.Available !== false) available.add(ft)
-      }
-    }
-  }
-  return available
+  return getSupportedParserFileTypes(parserEngines.value, rules)
 })
 
 const acceptFileTypes = computed(() =>
   [...supportedFileTypes.value].map(t => '.' + t).join(',')
+)
+
+const parserFileUploadDisabled = computed(() =>
+  editorResources.parserEnginesLoading ||
+  !editorResources.parserEnginesLoaded ||
+  editorResources.parserEnginesLoadFailed ||
+  supportedFileTypes.value.size === 0
 )
 
 const unsupportedFileTypes = computed<string[]>(() => {
@@ -1042,7 +1024,9 @@ const handleOpenKnowledgeEvent = (e: Event) => {
 
 onMounted(() => {
   loadKnowledgeList();
-  editorResources.ensureParserEngines();
+  editorResources.ensureParserEngines().catch(() => {
+    // The store records the failed state and disables file selection.
+  });
 
   window.addEventListener('knowledgeFileUploaded', handleFileUploaded as EventListener);
   window.addEventListener('openURLImportDialog', handleOpenURLImportDialog as EventListener);
@@ -2223,6 +2207,7 @@ async function createNewSession(value: string): Promise<void> {
                   <div v-if="canEdit" class="doc-filter-actions">
                     <KbUploadSourceDropdown ref="uploadSourceRef" :accept-file-types="acceptFileTypes"
                       :supported-file-types="[...supportedFileTypes]" include-manual trigger-icon="file-add"
+                      :file-upload-disabled="parserFileUploadDisabled"
                       trigger-class="content-bar-icon-btn" data-guide="kb-detail-add-doc"
                       :tooltip="t('knowledgeBase.addDocument')" placement="bottom-right" @files="handleUploadSourceFiles"
                       @url="handleUploadSourceUrl" @manual="handleManualCreate" />

--- a/frontend/src/views/knowledge/components/KbUploadSourceDropdown.vue
+++ b/frontend/src/views/knowledge/components/KbUploadSourceDropdown.vue
@@ -69,6 +69,7 @@ import { filterUploadFiles } from '../utils/uploadSources'
 const props = withDefaults(defineProps<{
   acceptFileTypes?: string
   supportedFileTypes?: string[]
+  fileUploadDisabled?: boolean
   includeManual?: boolean
   triggerIcon?: string
   triggerClass?: string
@@ -78,6 +79,7 @@ const props = withDefaults(defineProps<{
 }>(), {
   acceptFileTypes: '',
   supportedFileTypes: () => [],
+  fileUploadDisabled: false,
   includeManual: false,
   triggerIcon: 'file-add',
   triggerClass: '',
@@ -106,11 +108,13 @@ const dropdownOptions = computed(() => {
     {
       content: t('upload.uploadDocument'),
       value: 'upload',
+      disabled: props.fileUploadDisabled,
       prefixIcon: () => h(TIcon, { name: 'upload', size: '16px' }),
     },
     {
       content: t('upload.uploadFolder'),
       value: 'uploadFolder',
+      disabled: props.fileUploadDisabled,
       prefixIcon: () => h(TIcon, { name: 'folder-add', size: '16px' }),
     },
     {
@@ -130,6 +134,9 @@ const dropdownOptions = computed(() => {
 })
 
 const handleActionSelect = (data: { value: string }) => {
+  if (props.fileUploadDisabled && (data.value === 'upload' || data.value === 'uploadFolder')) {
+    return
+  }
   switch (data.value) {
     case 'upload':
       fileInputRef.value?.click()

--- a/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
+++ b/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
@@ -16,8 +16,9 @@
                 <div v-if="mode === 'file'" class="files-panel-actions">
                   <span class="files-count">{{ batchItemCount }}</span>
                   <KbUploadSourceDropdown
-                    :accept-file-types="acceptFileTypes"
-                    :supported-file-types="supportedFileTypes"
+                    :accept-file-types="currentAcceptFileTypes"
+                    :supported-file-types="[...currentSupportedFileTypes]"
+                    :file-upload-disabled="parserFileUploadDisabled"
                     :tooltip="t('uploadConfirm.continueAdd')"
                     placement="bottom-left"
                     @files="appendFiles"
@@ -260,8 +261,15 @@ import KBChunkingSettings from '../settings/KBChunkingSettings.vue'
 import KBAdvancedSettings from '../settings/KBAdvancedSettings.vue'
 import GraphSettings from '../settings/GraphSettings.vue'
 import { useChatResourcesStore } from '@/stores/chatResources'
+import { useEditorResourcesStore } from '@/stores/editorResources'
 import { useUIStore } from '@/stores/ui'
 import { formatFileSize, getFileIcon } from '@/utils/files'
+import {
+  completeParserEngineRules,
+  getSupportedParserFileTypes,
+  getUnroutableParserFileTypes,
+  resolveParserEngineForFileType,
+} from '@/utils/parserEngines'
 import { getUploadFileKey } from '../utils/uploadSources'
 import KbUploadSourceDropdown from './KbUploadSourceDropdown.vue'
 import type { KnowledgeProcessOverrides } from '@/types/knowledgeProcess'
@@ -335,6 +343,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const chatResources = useChatResourcesStore()
+const editorResources = useEditorResourcesStore()
 const uiStore = useUIStore()
 
 const allModels = ref<any[]>([])
@@ -451,23 +460,51 @@ const batchFileExts = computed(() => {
   return [...set]
 })
 
+const currentParserRules = computed(() =>
+  uiState.value.chunkingConfig.parserEngineRules || [],
+)
+
+const currentSupportedFileTypes = computed(() =>
+  getSupportedParserFileTypes(editorResources.parserEngines, currentParserRules.value),
+)
+
+const currentAcceptFileTypes = computed(() =>
+  [...currentSupportedFileTypes.value].map(fileType => `.${fileType}`).join(','),
+)
+
+const parserRoutesUnavailable = computed(() =>
+  getUnroutableParserFileTypes(
+    batchFileExts.value,
+    editorResources.parserEngines,
+    currentParserRules.value,
+  ),
+)
+
+const parserStateUnavailable = computed(() =>
+  editorResources.parserEnginesLoading ||
+  !editorResources.parserEnginesLoaded ||
+  editorResources.parserEnginesLoadFailed,
+)
+
+const parserFileUploadDisabled = computed(() =>
+  parserStateUnavailable.value || currentSupportedFileTypes.value.size === 0,
+)
+
 const hasPdf = computed(() => {
   return batchFileExts.value.includes('pdf')
 })
 
 function resolveEngineForExt(ext: string): string {
-  const rules = uiState.value.chunkingConfig.parserEngineRules
-  let engineKey = 'builtin'
-  let name = t('uploadConfirm.summaryParserBuiltin')
-  if (rules?.length) {
-    for (const rule of rules) {
-      if (rule.file_types.includes(ext)) {
-        engineKey = rule.engine
-        name = getEngineDisplayName(rule.engine)
-        break
-      }
-    }
+  const engine = resolveParserEngineForFileType(
+    ext,
+    editorResources.parserEngines,
+    currentParserRules.value,
+  )
+  if (!engine) {
+    return t('kbSettings.parser.noEngineAvailable')
   }
+  const engineKey = engine.Name
+  const name = getEngineDisplayName(engine.Name)
   if (ext === 'pdf' && uiState.value.pdfForceScanned && engineKey === 'builtin') {
     return `${name} · ${t('uploadConfirm.summaryParserForceScanned')}`
   }
@@ -588,6 +625,10 @@ const showAsrModelError = computed(() => {
 
 const issueSectionKeys = computed(() => {
   const keys = new Set<string>()
+  if (batchFileExts.value.length > 0 &&
+      (parserStateUnavailable.value || parserRoutesUnavailable.value.length > 0)) {
+    keys.add('parser')
+  }
   if (hasImages.value) {
     if (!uiState.value.multimodalConfig.enabled || !uiState.value.multimodalConfig.vllmModelId) {
       keys.add('multimodal')
@@ -608,6 +649,10 @@ const issueSectionKeys = computed(() => {
 const canConfirm = computed(() => {
   if (props.mode === 'file' && batchItemCount.value === 0) return false
   if (props.mode === 'manual' && !props.manualPreview?.content?.trim()) return false
+  if (batchFileExts.value.length > 0 &&
+      (parserStateUnavailable.value || parserRoutesUnavailable.value.length > 0)) {
+    return false
+  }
   if (hasImages.value) {
     if (!uiState.value.multimodalConfig.enabled || !uiState.value.multimodalConfig.vllmModelId) {
       return false
@@ -829,10 +874,28 @@ async function loadModels() {
   }
 }
 
+let parserRefreshSequence = 0
+const parserRulesReady = ref(false)
+
+function ensureBatchParserRules() {
+  if (!parserRulesReady.value || parserStateUnavailable.value) return
+
+  const completed = completeParserEngineRules(
+    batchFileExts.value,
+    editorResources.parserEngines,
+    currentParserRules.value,
+  )
+  if (JSON.stringify(completed) !== JSON.stringify(currentParserRules.value)) {
+    uiState.value.chunkingConfig.parserEngineRules = completed
+  }
+}
+
 watch(
   () => props.visible,
   (visible) => {
     if (!visible) return
+    const refreshSequence = ++parserRefreshSequence
+    parserRulesReady.value = false
     localFiles.value = props.mode === 'file' ? [...(props.files || [])] : []
     localUrls.value = props.mode === 'file' ? [...(props.urls || [])] : []
     initFromKbInfo(props.kbInfo)
@@ -841,6 +904,33 @@ watch(
     }
     activeSection.value = 'overview'
     loadModels()
+    editorResources.ensureParserEngines(true)
+      .then(() => {
+        if (!props.visible || refreshSequence !== parserRefreshSequence) return
+        parserRulesReady.value = true
+        ensureBatchParserRules()
+      })
+      .catch(() => {
+        // The store clears stale engine data and exposes the failed state.
+      })
+  },
+)
+
+watch(
+  () => batchFileExts.value.join('|'),
+  () => ensureBatchParserRules(),
+)
+
+watch(
+  () => [
+    editorResources.parserEnginesLoading,
+    editorResources.parserEnginesLoaded,
+    editorResources.parserEnginesLoadFailed,
+  ],
+  () => {
+    if (!props.visible || parserStateUnavailable.value) return
+    parserRulesReady.value = true
+    ensureBatchParserRules()
   },
 )
 
@@ -917,6 +1007,13 @@ const handleNodeExtractUpdate = (config: UploadUIState['nodeExtractConfig']) => 
 }
 
 const validateBeforeConfirm = (): boolean => {
+  if (batchFileExts.value.length > 0 &&
+      (parserStateUnavailable.value || parserRoutesUnavailable.value.length > 0)) {
+    MessagePlugin.warning(t('knowledgeBase.allFilesSkippedNoEngine'))
+    activeSection.value = 'parser'
+    return false
+  }
+
   if (hasImages.value) {
     if (!uiState.value.multimodalConfig.enabled || !uiState.value.multimodalConfig.vllmModelId) {
       MessagePlugin.warning(t('uploadConfirm.vlmModelRequired'))

--- a/frontend/src/views/knowledge/utils/uploadSources.ts
+++ b/frontend/src/views/knowledge/utils/uploadSources.ts
@@ -31,15 +31,11 @@ export function filterUploadFiles(
   options: FilterUploadFilesOptions = {},
 ): FilterUploadFilesResult {
   const list = Array.from(files)
-  const dynamicTypesRaw = options.supportedFileTypes
+  const dynamicTypes = options.supportedFileTypes !== undefined
     ? options.supportedFileTypes instanceof Set
       ? options.supportedFileTypes
       : new Set(options.supportedFileTypes)
     : undefined
-  // An empty set means the parser-engine list hasn't loaded yet (race with the
-  // async fetch on mount). Treat it as "unknown" and fall back to the default
-  // whitelist instead of rejecting every file as unsupported.
-  const dynamicTypes = dynamicTypesRaw && dynamicTypesRaw.size > 0 ? dynamicTypesRaw : undefined
 
   const validFiles: File[] = []
   let skippedCount = 0

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -185,6 +185,15 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 		}
 	}
 
+	if err := s.validateParserEngineRoutes(
+		ctx,
+		kb,
+		processOverrides,
+		[]string{getFileType(safeFilename)},
+	); err != nil {
+		return nil, err
+	}
+
 	// Prepare knowledge record
 	logger.Info(ctx, "Preparing knowledge record")
 	knowledge := &types.Knowledge{

--- a/internal/application/service/knowledge_create_test.go
+++ b/internal/application/service/knowledge_create_test.go
@@ -269,6 +269,44 @@ func TestCreateKnowledgeFromFile_PersistsProcessOverrides(t *testing.T) {
 	require.Equal(t, "test", metadataMap["source"])
 }
 
+func TestCreateKnowledgeFromFileRejectsPowerPointBeforeSavingWithoutExplicitRoute(t *testing.T) {
+	t.Parallel()
+
+	repo := &createKnowledgeFileRepoStub{}
+	fileSvc := &createKnowledgeFileServiceStub{}
+	reader := &parserRouteDocumentReaderStub{
+		connected: true,
+		engines: []types.ParserEngineInfo{{
+			Name:      "markitdown",
+			FileTypes: []string{"ppt", "pptx"},
+			Available: true,
+		}},
+	}
+	svc := &knowledgeService{
+		repo:           repo,
+		kbService:      &createKnowledgeFileKBServiceStub{kb: &types.KnowledgeBase{ID: "kb-1"}},
+		fileSvc:        fileSvc,
+		documentReader: reader,
+	}
+
+	knowledge, err := svc.CreateKnowledgeFromFile(
+		newCreateKnowledgeFileContext(),
+		"kb-1",
+		newMultipartFileHeader(t, "slides.pptx", "presentation"),
+		nil,
+		nil,
+		"",
+		nil,
+		"",
+		nil,
+	)
+
+	require.Error(t, err)
+	require.Nil(t, knowledge)
+	require.Zero(t, fileSvc.saveCalls)
+	require.Zero(t, repo.createCalls)
+}
+
 func newCreateKnowledgeFileContext() context.Context {
 	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
 	ctx = context.WithValue(ctx, types.TenantInfoContextKey, &types.Tenant{})

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -1981,19 +1981,6 @@ func (s *knowledgeService) ReparseKnowledge(
 		return nil, err
 	}
 
-	// Allocate a fresh span tree attempt up front. Doing this BEFORE
-	// the cleanup + enqueue means: (a) the UI immediately sees a new
-	// attempt with all five stages back to "pending" instead of the
-	// previous run's "failed" badge lingering; (b) the worker's
-	// fallback path won't double-allocate when payload.Attempt is
-	// already set on the queued task.
-	reparseAttempt := 0
-	if root, n, err := s.tracker().OpenAttempt(ctx, existing.ID, ""); err == nil && root != nil {
-		reparseAttempt = n
-	} else if err != nil {
-		logger.Warnf(ctx, "[Reparse] OpenAttempt failed for %s: %v (will fall back in worker)", existing.ID, err)
-	}
-
 	// Get knowledge base configuration
 	kb, err := s.kbService.GetKnowledgeBaseByID(ctx, existing.KnowledgeBaseID)
 	if err != nil {
@@ -2001,14 +1988,37 @@ func (s *knowledgeService) ReparseKnowledge(
 		return nil, err
 	}
 
+	effectiveProcessOverrides := processOverrides
+	if effectiveProcessOverrides == nil {
+		effectiveProcessOverrides, _ = existing.ProcessOverrides()
+	}
+	parserRouteFileTypes := reparseFileTypes(existing)
+	if existing.Type == "url" || existing.Type == "file_url" {
+		parserRouteFileTypes = nil
+	}
+
 	// When the caller supplies new overrides (e.g. via the reparse confirm
-	// dialog), validate them against this knowledge's file type, then persist
-	// to metadata so both this call's enqueue and the worker re-read the same
-	// config. nil keeps whatever was stored at upload time.
+	// dialog), validate them against this knowledge's file type. The parser
+	// route is also validated when reusing stored overrides, before any new
+	// attempt or destructive cleanup is created.
 	if processOverrides != nil {
 		if err := ValidateProcessOverrides(ctx, kb, processOverrides, reparseFileTypes(existing)); err != nil {
 			return nil, err
 		}
+	}
+	if err := s.validateParserEngineRoutes(
+		ctx,
+		kb,
+		effectiveProcessOverrides,
+		parserRouteFileTypes,
+	); err != nil {
+		return nil, err
+	}
+
+	// Persist caller-supplied overrides only after their complete route has
+	// passed validation so the existing working configuration remains intact
+	// on rejection.
+	if processOverrides != nil {
 		if err := existing.SetProcessOverrides(processOverrides); err != nil {
 			logger.Errorf(ctx, "Failed to set process overrides on reparse: %v", err)
 			return nil, err
@@ -2019,8 +2029,17 @@ func (s *knowledgeService) ReparseKnowledge(
 		}
 	}
 
-	processOverrides, _ = existing.ProcessOverrides()
+	processOverrides = effectiveProcessOverrides
 	reparseEff := ResolveProcessConfig(kb, processOverrides)
+
+	// Allocate the new attempt only after validation and metadata persistence.
+	// This avoids a permanently pending attempt when the route is invalid.
+	reparseAttempt := 0
+	if root, n, err := s.tracker().OpenAttempt(ctx, existing.ID, ""); err == nil && root != nil {
+		reparseAttempt = n
+	} else if err != nil {
+		logger.Warnf(ctx, "[Reparse] OpenAttempt failed for %s: %v (will fall back in worker)", existing.ID, err)
+	}
 
 	// Keep wiki's pending queue consistent across both manual and non-manual
 	// paths. The destructive work (swapping old wiki contributions for new)

--- a/internal/application/service/knowledge_process_config.go
+++ b/internal/application/service/knowledge_process_config.go
@@ -2,10 +2,12 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
 	werrors "github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/infrastructure/docparser"
 	"github.com/Tencent/WeKnora/internal/types"
 )
 
@@ -105,6 +107,132 @@ func ValidateProcessOverrides(
 
 	if err := types.ValidateEffectiveProcessPromptInstructions(eff); err != nil {
 		return werrors.NewBadRequestError(err.Error())
+	}
+
+	return nil
+}
+
+// validateParserEngineRoutes verifies the exact parser route the worker will
+// use for each file type. It runs before files are persisted or existing
+// parsed content is removed, so an invalid/offline route fails synchronously.
+func (s *knowledgeService) validateParserEngineRoutes(
+	ctx context.Context,
+	kb *types.KnowledgeBase,
+	overrides *types.KnowledgeProcessOverrides,
+	fileTypes []string,
+) error {
+	if kb == nil || len(fileTypes) == 0 {
+		return nil
+	}
+
+	eff := ResolveProcessConfig(kb, overrides)
+	tenantOverrides := s.getParserEngineOverridesFromContext(ctx)
+	var uploadOverrides map[string]string
+	if overrides != nil {
+		uploadOverrides = overrides.ParserEngineOverrides
+	}
+	engineOverrides := MergeParserEngineOverrides(tenantOverrides, uploadOverrides)
+
+	if tenant, ok := types.TenantInfoFromContext(ctx); ok {
+		if credentials := tenant.Credentials.GetWeKnoraCloud(); credentials != nil {
+			engineOverrides["weknoracloud_app_id"] = credentials.AppID
+		}
+	} else if s.tenantService != nil {
+		if credentials := s.tenantService.GetWeKnoraCloudCredentials(ctx); credentials != nil {
+			engineOverrides["weknoracloud_app_id"] = credentials.AppID
+		}
+	}
+
+	docreaderConnected := s.documentReader != nil && s.documentReader.IsConnected()
+	var remoteEngines []types.ParserEngineInfo
+	remoteEnginesFetched := false
+	engineCache := make(map[string]types.ParserEngineInfo)
+
+	for _, rawFileType := range fileTypes {
+		fileType := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(rawFileType)), ".")
+		// Generic web pages and manual knowledge do not use the file-extension
+		// parser route validated here.
+		if fileType == "" || fileType == "html" || fileType == "url" || fileType == types.KnowledgeTypeManual {
+			continue
+		}
+
+		engineName := eff.ChunkingConfig.ResolveParserEngine(fileType)
+		if engineName == "" {
+			if docparser.IsSimpleFormat(fileType) {
+				engineName = docparser.SimpleEngineName
+			} else {
+				engineName = "builtin"
+			}
+		}
+
+		engine, cached := engineCache[engineName]
+		found := cached
+		if !cached {
+			engine, found = docparser.GetEngineInfo(
+				engineName,
+				docreaderConnected,
+				engineOverrides,
+				nil,
+			)
+			if !found && docreaderConnected {
+				if !remoteEnginesFetched {
+					var err error
+					remoteEngines, err = s.documentReader.ListEngines(ctx, engineOverrides)
+					if err != nil {
+						return werrors.NewBadRequestError(fmt.Sprintf(
+							"无法检查解析引擎 %s 的状态: %v",
+							engineName,
+							err,
+						))
+					}
+					remoteEnginesFetched = true
+				}
+				engine, found = docparser.GetEngineInfo(
+					engineName,
+					docreaderConnected,
+					engineOverrides,
+					remoteEngines,
+				)
+			}
+			if found {
+				engineCache[engineName] = engine
+			}
+		}
+
+		if !found {
+			return werrors.NewBadRequestError(fmt.Sprintf(
+				"解析引擎 %s 不存在，无法处理 .%s 文件",
+				engineName,
+				fileType,
+			))
+		}
+		if !engine.Available {
+			reason := strings.TrimSpace(engine.UnavailableReason)
+			if reason != "" {
+				reason = ": " + reason
+			}
+			return werrors.NewBadRequestError(fmt.Sprintf(
+				"解析引擎 %s 当前不可用，无法处理 .%s 文件%s",
+				engineName,
+				fileType,
+				reason,
+			))
+		}
+
+		supported := false
+		for _, candidate := range engine.FileTypes {
+			if strings.TrimPrefix(strings.ToLower(strings.TrimSpace(candidate)), ".") == fileType {
+				supported = true
+				break
+			}
+		}
+		if !supported {
+			return werrors.NewBadRequestError(fmt.Sprintf(
+				"解析引擎 %s 不支持 .%s 文件",
+				engineName,
+				fileType,
+			))
+		}
 	}
 
 	return nil

--- a/internal/application/service/knowledge_process_config_test.go
+++ b/internal/application/service/knowledge_process_config_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -10,6 +11,36 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/stretchr/testify/require"
 )
+
+type parserRouteDocumentReaderStub struct {
+	connected bool
+	engines   []types.ParserEngineInfo
+	listErr   error
+	listCalls int
+}
+
+func (s *parserRouteDocumentReaderStub) Read(
+	ctx context.Context,
+	req *types.ReadRequest,
+) (*types.ReadResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *parserRouteDocumentReaderStub) Reconnect(addr string) error {
+	return nil
+}
+
+func (s *parserRouteDocumentReaderStub) IsConnected() bool {
+	return s.connected
+}
+
+func (s *parserRouteDocumentReaderStub) ListEngines(
+	ctx context.Context,
+	overrides map[string]string,
+) ([]types.ParserEngineInfo, error) {
+	s.listCalls++
+	return s.engines, s.listErr
+}
 
 func processConfigBoolPtr(v bool) *bool {
 	return &v
@@ -322,6 +353,111 @@ func TestValidateProcessOverrides_COSIncompleteForImage(t *testing.T) {
 
 	err := ValidateProcessOverrides(ctx, kb, &types.KnowledgeProcessOverrides{}, []string{"png"})
 	require.Error(t, err)
+}
+
+func TestValidateParserEngineRoutes_DefaultBuiltinRejectsPowerPoint(t *testing.T) {
+	t.Parallel()
+
+	reader := &parserRouteDocumentReaderStub{
+		connected: true,
+		engines: []types.ParserEngineInfo{{
+			Name:      "markitdown",
+			FileTypes: []string{"ppt", "pptx"},
+			Available: true,
+		}},
+	}
+	svc := &knowledgeService{documentReader: reader}
+
+	err := svc.validateParserEngineRoutes(
+		context.Background(),
+		&types.KnowledgeBase{},
+		nil,
+		[]string{"pptx"},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "builtin")
+	require.Contains(t, err.Error(), ".pptx")
+	require.Zero(t, reader.listCalls, "the actual default route is builtin, not any capable engine")
+}
+
+func TestValidateParserEngineRoutes_ExplicitRemoteEnginePasses(t *testing.T) {
+	t.Parallel()
+
+	reader := &parserRouteDocumentReaderStub{
+		connected: true,
+		engines: []types.ParserEngineInfo{{
+			Name:      "markitdown",
+			FileTypes: []string{"ppt", "pptx"},
+			Available: true,
+		}},
+	}
+	svc := &knowledgeService{documentReader: reader}
+	kb := &types.KnowledgeBase{ChunkingConfig: types.ChunkingConfig{
+		ParserEngineRules: []types.ParserEngineRule{{
+			FileTypes: []string{".PPTX"},
+			Engine:    "markitdown",
+		}},
+	}}
+
+	err := svc.validateParserEngineRoutes(
+		context.Background(),
+		kb,
+		nil,
+		[]string{"pptx"},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, reader.listCalls)
+}
+
+func TestValidateParserEngineRoutes_ExplicitUnavailableEngineDoesNotFallback(t *testing.T) {
+	t.Parallel()
+
+	reader := &parserRouteDocumentReaderStub{
+		connected: true,
+		engines: []types.ParserEngineInfo{
+			{
+				Name:              "markitdown",
+				FileTypes:         []string{"pptx"},
+				Available:         false,
+				UnavailableReason: "service offline",
+			},
+			{
+				Name:      "another-parser",
+				FileTypes: []string{"pptx"},
+				Available: true,
+			},
+		},
+	}
+	svc := &knowledgeService{documentReader: reader}
+	kb := &types.KnowledgeBase{ChunkingConfig: types.ChunkingConfig{
+		ParserEngineRules: []types.ParserEngineRule{{
+			FileTypes: []string{"pptx"},
+			Engine:    "markitdown",
+		}},
+	}}
+
+	err := svc.validateParserEngineRoutes(
+		context.Background(),
+		kb,
+		nil,
+		[]string{"pptx"},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "markitdown")
+	require.Contains(t, err.Error(), "service offline")
+}
+
+func TestValidateParserEngineRoutes_SimpleFormatNeedsNoDocReader(t *testing.T) {
+	t.Parallel()
+
+	svc := &knowledgeService{}
+	err := svc.validateParserEngineRoutes(
+		context.Background(),
+		&types.KnowledgeBase{},
+		nil,
+		[]string{"txt"},
+	)
+	require.NoError(t, err)
 }
 
 func TestMergeParserEngineOverrides(t *testing.T) {

--- a/internal/infrastructure/docparser/engine_registry.go
+++ b/internal/infrastructure/docparser/engine_registry.go
@@ -231,3 +231,55 @@ func ListAllEngines(docreaderConnected bool, overrides map[string]string, remote
 
 	return result
 }
+
+// GetEngineInfo returns the current capability and availability of one parser
+// engine. Unlike ListAllEngines, it only runs the selected local engine's
+// availability check, avoiding unrelated network probes during an upload.
+func GetEngineInfo(
+	name string,
+	docreaderConnected bool,
+	overrides map[string]string,
+	remoteEngines []types.ParserEngineInfo,
+) (types.ParserEngineInfo, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return types.ParserEngineInfo{}, false
+	}
+
+	for _, engine := range localEngines {
+		if engine.Name() != name {
+			continue
+		}
+
+		fileTypes := engine.FileTypes(docreaderConnected)
+		description := engine.Description()
+		for _, remote := range remoteEngines {
+			if remote.Name != name {
+				continue
+			}
+			if len(remote.FileTypes) > 0 {
+				fileTypes = remote.FileTypes
+			}
+			if remote.Description != "" {
+				description = remote.Description
+			}
+			break
+		}
+
+		available, reason := engine.CheckAvailable(docreaderConnected, overrides)
+		return types.ParserEngineInfo{
+			Name:              name,
+			Description:       description,
+			FileTypes:         fileTypes,
+			Available:         available,
+			UnavailableReason: reason,
+		}, true
+	}
+
+	for _, remote := range remoteEngines {
+		if remote.Name == name {
+			return remote, true
+		}
+	}
+	return types.ParserEngineInfo{}, false
+}

--- a/internal/infrastructure/docparser/engine_registry_test.go
+++ b/internal/infrastructure/docparser/engine_registry_test.go
@@ -1,0 +1,31 @@
+package docparser
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetEngineInfoBuiltinDoesNotSupportPowerPoint(t *testing.T) {
+	t.Parallel()
+
+	engine, found := GetEngineInfo("builtin", true, nil, nil)
+	require.True(t, found)
+	require.True(t, engine.Available)
+	require.NotContains(t, engine.FileTypes, "ppt")
+	require.NotContains(t, engine.FileTypes, "pptx")
+}
+
+func TestGetEngineInfoFindsRemoteOnlyEngine(t *testing.T) {
+	t.Parallel()
+
+	remote := []types.ParserEngineInfo{{
+		Name:      "markitdown",
+		FileTypes: []string{"ppt", "pptx"},
+		Available: true,
+	}}
+	engine, found := GetEngineInfo("markitdown", true, nil, remote)
+	require.True(t, found)
+	require.Equal(t, remote[0], engine)
+}

--- a/internal/types/knowledgebase.go
+++ b/internal/types/knowledgebase.go
@@ -209,10 +209,12 @@ type ChunkingConfig struct {
 // based on the configured rules. Returns empty string (builtin) when
 // no rule matches.
 func (c ChunkingConfig) ResolveParserEngine(fileType string) string {
+	fileType = strings.TrimPrefix(strings.ToLower(strings.TrimSpace(fileType)), ".")
 	for _, rule := range c.ParserEngineRules {
 		for _, ft := range rule.FileTypes {
-			if ft == fileType {
-				return rule.Engine
+			candidate := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(ft)), ".")
+			if candidate == fileType {
+				return strings.TrimSpace(rule.Engine)
 			}
 		}
 	}


### PR DESCRIPTION
## Description

修复上传 PPT/PPTX 文件时，解析引擎的可选状态配置在加载前后不一致的问题。

### 问题表现

进入知识库页面后立即选择文件时，PPT/PPTX 有时可以被选择；等待解析引擎配置加载完成后，再次选择相同文件时却可能不再受支持。

此外，原有逻辑主要根据通用文件类型白名单判断文件是否可上传，没有完整验证文件所选择的解析引擎及其解析路径是否真正支持该文件类型。

### 根因

- 前端在解析引擎配置尚未加载时，会回退到静态文件类型列表。
- 服务端返回明确的空文件类型列表时，前端也可能错误地回退到静态列表。
- 上传确认阶段没有统一验证文件扩展名与最终解析引擎路径是否匹配。
- 后端在保存文件或清理重新解析数据前，没有验证最终选择的解析路径。

### 修改内容

- 增加解析引擎配置的加载状态，配置未准备完成时暂时禁用文件和文件夹选择入口。
- 区分“配置尚未加载”和“服务端明确返回空列表”，避免错误回退到静态白名单。
- 增加统一的解析路径匹配逻辑，根据文件扩展名和解析规则确定实际可用的解析引擎。
- 上传确认时自动补全解析规则，并在增加文件后重新校验。
- 当文件不存在可用解析路径时，在前端阻止提交。
- 后端在保存上传文件前验证最终解析引擎。
- 后端在重新解析并清理原有数据前完成验证，避免无效请求破坏已有数据。
- 增加前端和后端回归测试。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

已执行以下验证：

- 前端针对性测试通过：`7/7`。
- 前端生产构建通过。
- 全量前端测试：`247/249` 通过；另外 2 项为已有的、与本次修改无关的 workspace/tenant 术语断言失败。
- 前端类型检查受到项目中 10 个已有且与本次修改无关的类型错误影响，未能整体通过。
- Go 相关包测试受本地环境限制未能运行：当前环境为 `CGO_ENABLED=0`，没有 GCC，已有 `pg_query` 依赖无法完成编译。
- `git diff --check` 通过；仅出现 Windows 下的 LF/CRLF 换行符提醒。

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above
