### PR TITLE
fix(docker): install Chromium runtime for web_fetch

### DIFF
--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -73,7 +73,8 @@ RUN if [ -n "$APK_MIRROR_ARG" ]; then \
         python3 python3-pip python3-dev libffi-dev libssl-dev \
         nodejs npm \
         gosu \
-        ffmpeg && \
+        ffmpeg \
+        chromium chromium-sandbox && \
     python3 -m pip install --break-system-packages --upgrade pip setuptools wheel && \
     mkdir -p /home/appuser/.local/bin && \
     curl -LsSf https://astral.sh/uv/install.sh | CARGO_HOME=/home/appuser/.cargo UV_INSTALL_DIR=/home/appuser/.local/bin sh && \


### PR DESCRIPTION
## Description

This PR installs the Chromium runtime in the app Docker image so the `web_fetch` tool can launch chromedp in Docker Compose deployments.

`web_fetch` depends on a Chrome/Chromium executable for browser-rendered page fetching, but the current app image does not include one. As a result, agent web browsing can fail with:

```shell
chromedp run failed: exec: "google-chrome": executable file not found in $PATH
```

The change adds `chromium` and `chromium-sandbox` to the existing runtime apt install list in `docker/Dockerfile.app`.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [x] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2297

## Testing

Checked the Dockerfile diff and staged patch:

```bash
git diff --check
```

Validated the same runtime dependency fix in a Docker Compose deployment on a Linux self-hosted server after rebuilding the app image:

```bash
docker compose build app
docker compose up -d app
docker compose exec -T app command -v chromium
docker compose exec -T app chromium --version
curl -fsS http://127.0.0.1:8080/health
```

Observed:

```text
/usr/bin/chromium
Chromium 150.0.7871.181 built on Debian GNU/Linux 12 (bookworm)
health=200
```

A production-like agent E2E with `web_search` followed by `web_fetch` was also validated after rebuilding the app image. The browser executable was present in the final container and the app remained healthy after restart.

Note: I did not run the full `make fmt && make lint && make test` suite for this one-line Docker runtime dependency change.

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A. This is a Docker runtime dependency fix with no UI change.