### PR TITLE
fix(i18n): remove duplicate 'members' key in organization locale objects

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -5082,7 +5082,7 @@ export default {
     description: 'Shared Space Description',
     descriptionPlaceholder: 'Enter shared space description (optional)',
     noDescription: 'No description',
-    members: 'members',
+
     memberCount: 'Member count',
     owner: 'Creator',
     inviteCode: 'Invite Code',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -5085,7 +5085,7 @@ export default {
     description: "공유 공간 설명",
     descriptionPlaceholder: "공유 공간 설명을 입력하세요(선택사항).",
     noDescription: "아직 설명이 없습니다",
-    members: "회원",
+
     memberCount: "회원 수",
     owner: "소유자",
     inviteCode: "초대코드",

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -5725,7 +5725,7 @@ export default {
     description: 'Описание общего пространства',
     descriptionPlaceholder: 'Введите описание общего пространства (необязательно)',
     noDescription: 'No description',
-    members: 'members',
+
     memberCount: 'Member count',
     owner: 'Creator',
     inviteCode: 'Invite Code',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -5188,7 +5188,7 @@ export default {
       invalidTitle: "无效邀请",
       invalidCode: "邀请码无效或已过期",
       previewFailed: "预览失败，请稍后重试",
-      members: "成员",
+
       knowledgeBases: "知识库",
       agents: "智能体",
       alreadyMember: "您已经是该共享空间的成员",


### PR DESCRIPTION
## Description

Fixes esbuild warnings about duplicate `members` keys in the `organization` 
i18n object. The string-form key (`members: 'members'` / `members: "成员"` / 
`members: "회원"`) conflicted with the nested object form used by 
`OrganizationSettingsModal`. The string form was dead code — no frontend 
component ever references `organization.members` as a terminal key; all 
usages go through `organization.members.*` sub-keys.

- Removed the unused string entries from `en-US.ts`, `zh-CN.ts`, `ko-KR.ts`, 
  and `ru-RU.ts`
- Verified zero references to the string form across the entire frontend

version: v0.7.1

## Type of Change
- [x] 🐛 Bug fix

## Testing
- `grep` verified no remaining `organization.members` terminal references in 
  the frontend codebase
- `grep` confirmed all `organization.members.*` nested usages still resolve 
  correctly in `OrganizationSettingsModal.vue`
- Vite dev server recompiles without the duplicate-key warnings

## Checklist
- [x] Self-reviewed the code
- [ ] `make fmt && make lint && make test` pass locally
- [ ] Added/updated tests covering the change (N/A — dead code removal)
- [ ] Updated related documentation (N/A)
- [ ] Breaking changes (N/A)

## Screenshots / Recordings

<img width="960" height="861" alt="problem" src="https://github.com/user-attachments/assets/88828630-bdd9-4df4-b54f-16c2d5bbdc2e" />

