### PR TITLE
fix(docreader): restore optional XLSX header context

### DIFF
--- a/docreader/parser/excel_parser.py
+++ b/docreader/parser/excel_parser.py
@@ -142,24 +142,15 @@ def _read_sheet_dataframe(
     """Read a worksheet into a DataFrame with stable column labels."""
     from openpyxl.utils import get_column_letter
 
-    # XLSX keeps row 1 as data by default. Users can explicitly restore the
-    # historical behavior where row 1 supplies semantic labels for every row.
-    if excel_file.engine == "openpyxl":
-        df = excel_file.parse(sheet_name=sheet_name, header=None)
-        if xlsx_first_row_as_header and len(df.index) >= 2:
-            df.columns = _stable_header_labels(df.iloc[0].tolist())
-            return df.iloc[1:].copy()
+    # Keep row 1 as data by default for both XLSX and legacy XLS. Users can
+    # explicitly restore the historical behavior where row 1 supplies semantic
+    # labels for every row.
+    df = excel_file.parse(sheet_name=sheet_name, header=None)
+    if xlsx_first_row_as_header and len(df.index) >= 2:
+        df.columns = _stable_header_labels(df.iloc[0].tolist())
+        return df.iloc[1:].copy()
 
-        df.columns = [get_column_letter(idx + 1) for idx in range(len(df.columns))]
-        return df
-
-    df = excel_file.parse(sheet_name=sheet_name, header=0)
-    if df.empty:
-        df = excel_file.parse(sheet_name=sheet_name, header=None)
-        df.columns = [get_column_letter(idx + 1) for idx in range(len(df.columns))]
-    elif any(str(col).startswith("Unnamed:") for col in df.columns):
-        df = excel_file.parse(sheet_name=sheet_name, header=None)
-        df.columns = [get_column_letter(idx + 1) for idx in range(len(df.columns))]
+    df.columns = [get_column_letter(idx + 1) for idx in range(len(df.columns))]
     return df
 
 

--- a/docreader/parser/excel_parser.py
+++ b/docreader/parser/excel_parser.py
@@ -8,7 +8,7 @@ sheets and handles various Excel formats using pandas.
 import logging
 import re
 from io import BytesIO
-from typing import List
+from typing import Any, List
 
 import pandas as pd
 
@@ -64,6 +64,16 @@ class ExcelParser(BaseParser):
         Name: John,Age: 30,City: NYC
         Name: Jane,Age: 25,City: LA
     """
+
+    def __init__(
+        self,
+        file_name: str = "",
+        file_type: str | None = None,
+        xlsx_first_row_as_header: Any = False,
+        **kwargs: Any,
+    ):
+        super().__init__(file_name=file_name, file_type=file_type, **kwargs)
+        self.xlsx_first_row_as_header = _parse_bool(xlsx_first_row_as_header)
     
     def parse_into_text(self, content: bytes) -> Document:
         """Parse Excel file bytes into a Document object.
@@ -89,7 +99,11 @@ class ExcelParser(BaseParser):
         
         # Process each sheet in the Excel file
         for excel_sheet_name in excel_file.sheet_names:
-            df = _read_sheet_dataframe(excel_file, excel_sheet_name)
+            df = _read_sheet_dataframe(
+                excel_file,
+                excel_sheet_name,
+                xlsx_first_row_as_header=self.xlsx_first_row_as_header,
+            )
             # Remove rows where all values are NaN (completely empty rows)
             df.dropna(how="all", inplace=True)
 
@@ -120,13 +134,22 @@ class ExcelParser(BaseParser):
         return Document(content="".join(text), chunks=chunks)
 
 
-def _read_sheet_dataframe(excel_file: pd.ExcelFile, sheet_name: str) -> pd.DataFrame:
+def _read_sheet_dataframe(
+    excel_file: pd.ExcelFile,
+    sheet_name: str,
+    xlsx_first_row_as_header: bool = False,
+) -> pd.DataFrame:
     """Read a worksheet into a DataFrame with stable column labels."""
     from openpyxl.utils import get_column_letter
 
-    # XLSX is preprocessed (merge fill); use A/B/C column letters and keep row 1 as data.
+    # XLSX keeps row 1 as data by default. Users can explicitly restore the
+    # historical behavior where row 1 supplies semantic labels for every row.
     if excel_file.engine == "openpyxl":
         df = excel_file.parse(sheet_name=sheet_name, header=None)
+        if xlsx_first_row_as_header and len(df.index) >= 2:
+            df.columns = _stable_header_labels(df.iloc[0].tolist())
+            return df.iloc[1:].copy()
+
         df.columns = [get_column_letter(idx + 1) for idx in range(len(df.columns))]
         return df
 
@@ -138,6 +161,31 @@ def _read_sheet_dataframe(excel_file: pd.ExcelFile, sheet_name: str) -> pd.DataF
         df = excel_file.parse(sheet_name=sheet_name, header=None)
         df.columns = [get_column_letter(idx + 1) for idx in range(len(df.columns))]
     return df
+
+
+def _stable_header_labels(values: List[object]) -> List[str]:
+    """Build non-empty, unique labels from an explicitly selected header row."""
+    from openpyxl.utils import get_column_letter
+
+    labels: List[str] = []
+    counts: dict[str, int] = {}
+    for index, value in enumerate(values, start=1):
+        label = ""
+        if pd.notna(value) and not _is_image_function(value):
+            label = str(value).strip()
+        if not label:
+            label = get_column_letter(index)
+
+        count = counts.get(label, 0) + 1
+        counts[label] = count
+        labels.append(label if count == 1 else f"{label}_{count}")
+    return labels
+
+
+def _parse_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _prepare_xlsx_bytes(data: bytes) -> bytes:

--- a/docreader/tests/test_excel_parser.py
+++ b/docreader/tests/test_excel_parser.py
@@ -360,6 +360,24 @@ class ExcelParserTest(unittest.TestCase):
             ["Name: Alice,Name_2: Alias,C: Shenzhen"],
         )
 
+    def test_xlsx_explicit_false_override_keeps_first_row_as_data(self):
+        content = self._workbook_bytes(
+            [
+                ["Name", "Age"],
+                ["Alice", 30],
+            ]
+        )
+
+        document = ExcelParser(
+            file_name="people.xlsx",
+            file_type="xlsx",
+            xlsx_first_row_as_header="false",
+        ).parse_into_text(content)
+
+        chunks = [chunk.content.strip() for chunk in document.chunks]
+        self.assertEqual(chunks[0], "A: Name,B: Age")
+        self.assertEqual(chunks[1], "A: Alice,B: 30")
+
     def test_parse_phantom_shared_strings_workbook(self):
         document = ExcelParser().parse_into_text(_xlsx_with_phantom_shared_strings())
         self.assertIn("hello", document.content)

--- a/docreader/tests/test_excel_parser.py
+++ b/docreader/tests/test_excel_parser.py
@@ -275,6 +275,91 @@ class ExcelImageFilterTest(unittest.TestCase):
 
 
 class ExcelParserTest(unittest.TestCase):
+    @staticmethod
+    def _workbook_bytes(rows):
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        for row in rows:
+            ws.append(row)
+        bio = io.BytesIO()
+        wb.save(bio)
+        return bio.getvalue()
+
+    def test_xlsx_first_row_header_mode_repeats_column_context(self):
+        content = self._workbook_bytes(
+            [
+                ["Name", "Age", "City"],
+                ["Alice", 30, "Shenzhen"],
+                ["Bob", 28, "Shanghai"],
+            ]
+        )
+
+        document = ExcelParser(
+            file_name="people.xlsx",
+            file_type="xlsx",
+            xlsx_first_row_as_header="true",
+        ).parse_into_text(content)
+
+        chunks = [chunk.content.strip() for chunk in document.chunks]
+        self.assertEqual(
+            chunks,
+            [
+                "Name: Alice,Age: 30,City: Shenzhen",
+                "Name: Bob,Age: 28,City: Shanghai",
+            ],
+        )
+        self.assertNotIn("A: Name", document.content)
+
+    def test_xlsx_keeps_first_row_as_data_by_default(self):
+        content = self._workbook_bytes(
+            [
+                ["Name", "City"],
+                ["Alice", "Shenzhen"],
+            ]
+        )
+
+        document = ExcelParser(file_name="people.xlsx", file_type="xlsx").parse_into_text(
+            content
+        )
+
+        chunks = [chunk.content.strip() for chunk in document.chunks]
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual(chunks[0], "A: Name,B: City")
+        self.assertEqual(chunks[1], "A: Alice,B: Shenzhen")
+
+    def test_single_row_xlsx_is_not_consumed_in_header_mode(self):
+        content = self._workbook_bytes([["Name", "Age", "City"]])
+
+        document = ExcelParser(
+            file_name="single.xlsx",
+            file_type="xlsx",
+            xlsx_first_row_as_header=True,
+        ).parse_into_text(content)
+
+        self.assertEqual(
+            [chunk.content.strip() for chunk in document.chunks],
+            ["A: Name,B: Age,C: City"],
+        )
+
+    def test_header_mode_generates_stable_labels_for_duplicate_and_empty_cells(self):
+        content = self._workbook_bytes(
+            [
+                ["Name", "Name", None],
+                ["Alice", "Alias", "Shenzhen"],
+            ]
+        )
+
+        document = ExcelParser(
+            file_name="people.xlsx",
+            file_type="xlsx",
+            xlsx_first_row_as_header="yes",
+        ).parse_into_text(content)
+
+        self.assertEqual(
+            [chunk.content.strip() for chunk in document.chunks],
+            ["Name: Alice,Name_2: Alias,C: Shenzhen"],
+        )
+
     def test_parse_phantom_shared_strings_workbook(self):
         document = ExcelParser().parse_into_text(_xlsx_with_phantom_shared_strings())
         self.assertIn("hello", document.content)

--- a/frontend/src/api/initialization/index.ts
+++ b/frontend/src/api/initialization/index.ts
@@ -121,7 +121,11 @@ export interface KBModelConfigRequest {
         chunkSize: number
         chunkOverlap: number
         separators: string[]
-        parserEngineRules?: { file_types: string[]; engine: string }[]
+        parserEngineRules?: {
+            file_types: string[]
+            engine: string
+            xlsx_first_row_as_header?: boolean
+        }[]
         enableParentChild?: boolean
         parentChunkSize?: number
         childChunkSize?: number

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -5586,6 +5586,7 @@ export default {
       fileTypeWord: 'Word Documents',
       fileTypePpt: 'Presentations',
       fileTypeExcel: 'Excel Spreadsheets',
+      xlsxFirstRowAsHeader: 'Use the first row as column context for every row',
       fileTypeEbook: 'E-books',
       fileTypeWebArchive: 'Web Archives',
       fileTypeCsv: 'CSV Files',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -5609,6 +5609,7 @@ export default {
       fileTypeWord: 'Word 문서',
       fileTypePpt: '프레젠테이션',
       fileTypeExcel: 'Excel 스프레드시트',
+      xlsxFirstRowAsHeader: '첫 행을 각 행의 열 컨텍스트로 사용',
       fileTypeEbook: '전자책',
       fileTypeWebArchive: '웹 아카이브',
       fileTypeCsv: 'CSV 파일',

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -5051,6 +5051,7 @@ export default {
       fileTypeWord: 'Документы Word',
       fileTypePpt: 'Презентации',
       fileTypeExcel: 'Таблицы Excel',
+      xlsxFirstRowAsHeader: 'Использовать первую строку как контекст столбцов',
       fileTypeEbook: 'Электронные книги',
       fileTypeWebArchive: 'Веб-архивы',
       fileTypeCsv: 'Файлы CSV',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -5639,6 +5639,7 @@ export default {
       fileTypeWord: "Word 文档",
       fileTypePpt: "演示文稿",
       fileTypeExcel: "Excel 表格",
+      xlsxFirstRowAsHeader: "将首行作为列标题，并保留在每行上下文中",
       fileTypeEbook: "电子书",
       fileTypeWebArchive: "网页归档",
       fileTypeCsv: "CSV 文件",

--- a/frontend/src/types/knowledgeProcess.ts
+++ b/frontend/src/types/knowledgeProcess.ts
@@ -3,6 +3,7 @@
 export interface ParserEngineRule {
   file_types: string[]
   engine: string
+  xlsx_first_row_as_header?: boolean
 }
 
 export interface ChunkingConfigOverride {

--- a/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
+++ b/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
@@ -279,7 +279,11 @@ interface ChunkingUIConfig {
   chunkSize: number
   chunkOverlap: number
   separators: string[]
-  parserEngineRules?: Array<{ file_types: string[]; engine: string }>
+  parserEngineRules?: Array<{
+    file_types: string[]
+    engine: string
+    xlsx_first_row_as_header?: boolean
+  }>
   enableParentChild: boolean
   parentChunkSize: number
   childChunkSize: number
@@ -884,7 +888,11 @@ const removeFile = (index: number) => {
   localFiles.value = localFiles.value.filter((_, i) => i !== index)
 }
 
-const handleParserEngineRulesUpdate = (rules: Array<{ file_types: string[]; engine: string }>) => {
+const handleParserEngineRulesUpdate = (rules: Array<{
+  file_types: string[]
+  engine: string
+  xlsx_first_row_as_header?: boolean
+}>) => {
   uiState.value.chunkingConfig.parserEngineRules = rules
 }
 

--- a/frontend/src/views/knowledge/settings/KBChunkingSettings.vue
+++ b/frontend/src/views/knowledge/settings/KBChunkingSettings.vue
@@ -220,6 +220,7 @@ import KBChunkingDebug from './KBChunkingDebug.vue'
 interface ParserEngineRule {
   file_types: string[]
   engine: string
+  xlsx_first_row_as_header?: boolean
 }
 
 // Slider ranges defined in this file (min/max props on t-slider) mirror

--- a/frontend/src/views/knowledge/settings/KBParserSettings.vue
+++ b/frontend/src/views/knowledge/settings/KBParserSettings.vue
@@ -46,6 +46,14 @@
               :label="opt.selectLabel"
             />
           </t-select>
+          <t-checkbox
+            v-if="group.extensions.includes('xlsx') && getEngineForGroup(group.extensions) === 'builtin'"
+            class="xlsx-header-option"
+            :checked="getXLSXFirstRowAsHeader(group.extensions)"
+            @change="(checked: boolean) => handleXLSXFirstRowAsHeaderChange(group.extensions, checked)"
+          >
+            {{ $t('kbSettings.parser.xlsxFirstRowAsHeader') }}
+          </t-checkbox>
           <div v-if="!hasAvailableEngine(group.extensions)" class="no-engine-warning">
             <a class="go-settings" @click.prevent="goToParserSettings">{{ $t('kbSettings.parser.goConfig') }}</a>
           </div>
@@ -75,6 +83,7 @@ function getEngineDisplayName(engineName: string): string {
 export interface ParserEngineRule {
   file_types: string[]
   engine: string
+  xlsx_first_row_as_header?: boolean
 }
 
 interface EngineOption {
@@ -217,14 +226,41 @@ function getEngineForGroup(extensions: string[]): string {
 }
 
 function handleEngineChange(extensions: string[], engine: string) {
+  const currentRule = getRuleForGroup(extensions)
   const otherRules = localEngineRules.value.filter(
     r => !r.file_types.some(ft => extensions.includes(ft))
   )
   if (engine) {
-    otherRules.push({ file_types: [...extensions], engine })
+    otherRules.push({
+      file_types: [...extensions],
+      engine,
+      ...(currentRule?.xlsx_first_row_as_header !== undefined
+        ? { xlsx_first_row_as_header: currentRule.xlsx_first_row_as_header }
+        : {}),
+    })
   }
   localEngineRules.value = otherRules
   emit('update:parserEngineRules', buildCompleteRules())
+}
+
+function getRuleForGroup(extensions: string[]): ParserEngineRule | undefined {
+  return localEngineRules.value.find(
+    rule => rule.file_types.some(fileType => extensions.includes(fileType))
+  )
+}
+
+function getXLSXFirstRowAsHeader(extensions: string[]): boolean {
+  return getRuleForGroup(extensions)?.xlsx_first_row_as_header === true
+}
+
+function handleXLSXFirstRowAsHeaderChange(extensions: string[], checked: boolean) {
+  const rules = buildCompleteRules()
+  const rule = rules.find(item => item.file_types.some(fileType => extensions.includes(fileType)))
+  if (!rule) return
+
+  rule.xlsx_first_row_as_header = checked
+  localEngineRules.value = rules
+  emit('update:parserEngineRules', rules)
 }
 
 function buildCompleteRules(): ParserEngineRule[] {
@@ -232,7 +268,14 @@ function buildCompleteRules(): ParserEngineRule[] {
   for (const group of fileTypeGroups.value) {
     const engine = getEngineForGroup(group.extensions)
     if (engine) {
-      rules.push({ file_types: [...group.extensions], engine })
+      const currentRule = getRuleForGroup(group.extensions)
+      rules.push({
+        file_types: [...group.extensions],
+        engine,
+        ...(currentRule?.xlsx_first_row_as_header !== undefined
+          ? { xlsx_first_row_as_header: currentRule.xlsx_first_row_as_header }
+          : {}),
+      })
     }
   }
   return rules
@@ -388,6 +431,11 @@ watch(() => props.parserEngineRules, (v) => {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+}
+
+.xlsx-header-option {
+  margin-top: 10px;
+  text-align: right;
 }
 
 .no-engine-warning {

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -3138,6 +3138,7 @@ func (s *knowledgeService) convert(
 		uploadOverrides = processOverrides.ParserEngineOverrides
 	}
 	mergedOverrides := MergeParserEngineOverrides(tenantOverrides, uploadOverrides)
+	applyParserRuleOverrides(mergedOverrides, eff.ChunkingConfig, fileType)
 
 	if isURL {
 		if err := secutils.ValidateURLForSSRF(payload.URL); err != nil {

--- a/internal/application/service/knowledge_process_config.go
+++ b/internal/application/service/knowledge_process_config.go
@@ -17,14 +17,23 @@ func applyParserRuleOverrides(
 	config types.ChunkingConfig,
 	fileType string,
 ) {
-	if fileType != "xlsx" {
+	fileType = normalizeParserFileType(fileType)
+	if fileType != "xlsx" && fileType != "xls" {
 		return
 	}
 	rule := config.ResolveParserEngineRule(fileType)
 	if rule == nil || rule.XLSXFirstRowAsHeader == nil {
 		return
 	}
+	engine := strings.TrimSpace(rule.Engine)
+	if engine != "" && engine != "builtin" {
+		return
+	}
 	overrides[xlsxFirstRowAsHeaderOverride] = strconv.FormatBool(*rule.XLSXFirstRowAsHeader)
+}
+
+func normalizeParserFileType(fileType string) string {
+	return strings.TrimPrefix(strings.ToLower(strings.TrimSpace(fileType)), ".")
 }
 
 // ResolveProcessConfig merges KB defaults with per-upload overrides for the parse pipeline.

--- a/internal/application/service/knowledge_process_config.go
+++ b/internal/application/service/knowledge_process_config.go
@@ -3,11 +3,29 @@ package service
 import (
 	"context"
 	"os"
+	"strconv"
 	"strings"
 
 	werrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/types"
 )
+
+const xlsxFirstRowAsHeaderOverride = "xlsx_first_row_as_header"
+
+func applyParserRuleOverrides(
+	overrides map[string]string,
+	config types.ChunkingConfig,
+	fileType string,
+) {
+	if fileType != "xlsx" {
+		return
+	}
+	rule := config.ResolveParserEngineRule(fileType)
+	if rule == nil || rule.XLSXFirstRowAsHeader == nil {
+		return
+	}
+	overrides[xlsxFirstRowAsHeaderOverride] = strconv.FormatBool(*rule.XLSXFirstRowAsHeader)
+}
 
 // ResolveProcessConfig merges KB defaults with per-upload overrides for the parse pipeline.
 func ResolveProcessConfig(kb *types.KnowledgeBase, overrides *types.KnowledgeProcessOverrides) types.EffectiveProcessConfig {

--- a/internal/application/service/knowledge_process_config_test.go
+++ b/internal/application/service/knowledge_process_config_test.go
@@ -179,6 +179,60 @@ func TestApplyParserRuleOverrides_XLSXFirstRowAsHeader(t *testing.T) {
 	}
 }
 
+func TestApplyParserRuleOverrides_XLSFileType(t *testing.T) {
+	t.Parallel()
+
+	enabled := true
+	config := types.ChunkingConfig{
+		ParserEngineRules: []types.ParserEngineRule{{
+			FileTypes:            []string{"xlsx", "xls"},
+			Engine:               "builtin",
+			XLSXFirstRowAsHeader: &enabled,
+		}},
+	}
+	overrides := map[string]string{}
+
+	applyParserRuleOverrides(overrides, config, "xls")
+
+	require.Equal(t, "true", overrides[xlsxFirstRowAsHeaderOverride])
+}
+
+func TestApplyParserRuleOverrides_NormalizesFileTypeCase(t *testing.T) {
+	t.Parallel()
+
+	enabled := true
+	config := types.ChunkingConfig{
+		ParserEngineRules: []types.ParserEngineRule{{
+			FileTypes:            []string{"xlsx"},
+			Engine:               "builtin",
+			XLSXFirstRowAsHeader: &enabled,
+		}},
+	}
+	overrides := map[string]string{}
+
+	applyParserRuleOverrides(overrides, config, ".XLSX")
+
+	require.Equal(t, "true", overrides[xlsxFirstRowAsHeaderOverride])
+}
+
+func TestApplyParserRuleOverrides_SkipsNonBuiltinEngine(t *testing.T) {
+	t.Parallel()
+
+	enabled := true
+	config := types.ChunkingConfig{
+		ParserEngineRules: []types.ParserEngineRule{{
+			FileTypes:            []string{"xlsx"},
+			Engine:               "markitdown",
+			XLSXFirstRowAsHeader: &enabled,
+		}},
+	}
+	overrides := map[string]string{}
+
+	applyParserRuleOverrides(overrides, config, "xlsx")
+
+	require.NotContains(t, overrides, xlsxFirstRowAsHeaderOverride)
+}
+
 func TestResolveProcessConfig_ParserEngineRulesReplaced(t *testing.T) {
 	t.Parallel()
 

--- a/internal/application/service/knowledge_process_config_test.go
+++ b/internal/application/service/knowledge_process_config_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -129,6 +130,7 @@ func TestBuildSplitterConfigFromChunking_UsesEffectiveChunkingConfig(t *testing.
 func TestEffectiveChunkingConfig_ResolveParserEngineFromOverrides(t *testing.T) {
 	t.Parallel()
 
+	xlsxFirstRowAsHeader := true
 	kb := &types.KnowledgeBase{
 		ChunkingConfig: types.ChunkingConfig{
 			ParserEngineRules: []types.ParserEngineRule{
@@ -139,10 +141,42 @@ func TestEffectiveChunkingConfig_ResolveParserEngineFromOverrides(t *testing.T) 
 	overrides := &types.KnowledgeProcessOverrides{
 		ParserEngineRules: []types.ParserEngineRule{
 			{FileTypes: []string{"pdf"}, Engine: "mineru"},
+			{
+				FileTypes:            []string{"xlsx", "xls"},
+				Engine:               "builtin",
+				XLSXFirstRowAsHeader: &xlsxFirstRowAsHeader,
+			},
 		},
 	}
 	eff := ResolveProcessConfig(kb, overrides)
 	require.Equal(t, "mineru", eff.ChunkingConfig.ResolveParserEngine("pdf"))
+	xlsxRule := eff.ChunkingConfig.ResolveParserEngineRule("xlsx")
+	require.NotNil(t, xlsxRule)
+	require.Equal(t, "builtin", xlsxRule.Engine)
+	require.Equal(t, &xlsxFirstRowAsHeader, xlsxRule.XLSXFirstRowAsHeader)
+}
+
+func TestApplyParserRuleOverrides_XLSXFirstRowAsHeader(t *testing.T) {
+	t.Parallel()
+
+	for _, enabled := range []bool{true, false} {
+		enabled := enabled
+		t.Run(strconv.FormatBool(enabled), func(t *testing.T) {
+			config := types.ChunkingConfig{
+				ParserEngineRules: []types.ParserEngineRule{{
+					FileTypes:            []string{"xlsx", "xls"},
+					Engine:               "builtin",
+					XLSXFirstRowAsHeader: &enabled,
+				}},
+			}
+			overrides := map[string]string{"tenant_option": "preserved"}
+
+			applyParserRuleOverrides(overrides, config, "xlsx")
+
+			require.Equal(t, strconv.FormatBool(enabled), overrides[xlsxFirstRowAsHeaderOverride])
+			require.Equal(t, "preserved", overrides["tenant_option"])
+		})
+	}
 }
 
 func TestResolveProcessConfig_ParserEngineRulesReplaced(t *testing.T) {

--- a/internal/types/knowledgebase.go
+++ b/internal/types/knowledgebase.go
@@ -165,6 +165,9 @@ type KnowledgeBaseConfig struct {
 type ParserEngineRule struct {
 	FileTypes []string `yaml:"file_types" json:"file_types"`
 	Engine    string   `yaml:"engine"     json:"engine"`
+	// XLSXFirstRowAsHeader restores row-1 column context for flat XLSX tables.
+	// nil preserves the parser default; an explicit false disables the mode.
+	XLSXFirstRowAsHeader *bool `yaml:"xlsx_first_row_as_header,omitempty" json:"xlsx_first_row_as_header,omitempty"`
 }
 
 // ChunkingConfig represents the document splitting configuration
@@ -209,14 +212,22 @@ type ChunkingConfig struct {
 // based on the configured rules. Returns empty string (builtin) when
 // no rule matches.
 func (c ChunkingConfig) ResolveParserEngine(fileType string) string {
-	for _, rule := range c.ParserEngineRules {
-		for _, ft := range rule.FileTypes {
+	if rule := c.ResolveParserEngineRule(fileType); rule != nil {
+		return rule.Engine
+	}
+	return ""
+}
+
+// ResolveParserEngineRule returns the parser rule for a file type.
+func (c ChunkingConfig) ResolveParserEngineRule(fileType string) *ParserEngineRule {
+	for i := range c.ParserEngineRules {
+		for _, ft := range c.ParserEngineRules[i].FileTypes {
 			if ft == fileType {
-				return rule.Engine
+				return &c.ParserEngineRules[i]
 			}
 		}
 	}
-	return ""
+	return nil
 }
 
 // StorageProviderConfig stores the KB-level storage provider selection.

--- a/internal/types/knowledgebase.go
+++ b/internal/types/knowledgebase.go
@@ -220,14 +220,22 @@ func (c ChunkingConfig) ResolveParserEngine(fileType string) string {
 
 // ResolveParserEngineRule returns the parser rule for a file type.
 func (c ChunkingConfig) ResolveParserEngineRule(fileType string) *ParserEngineRule {
+	fileType = normalizeParserFileType(fileType)
+	if fileType == "" {
+		return nil
+	}
 	for i := range c.ParserEngineRules {
 		for _, ft := range c.ParserEngineRules[i].FileTypes {
-			if ft == fileType {
+			if normalizeParserFileType(ft) == fileType {
 				return &c.ParserEngineRules[i]
 			}
 		}
 	}
 	return nil
+}
+
+func normalizeParserFileType(fileType string) string {
+	return strings.TrimPrefix(strings.ToLower(strings.TrimSpace(fileType)), ".")
 }
 
 // StorageProviderConfig stores the KB-level storage provider selection.


### PR DESCRIPTION
## Summary

- add an opt-in built-in XLSX parser setting that uses row 1 as column context for every data row
- keep the current lossless behavior by default, including safe handling for single-row and malformed headers
- reuse the existing parser-rule and override pipeline without database or protocol changes

The v0.7.1 built-in XLSX path treats row 1 as ordinary A/B/C data, leaving later rows without semantic column context.

## Validation

- Excel parser unit suite: 17 tests run, 3 environment-dependent skips
- `go test ./internal/application/service -run 'TestEffectiveChunkingConfig_ResolveParserEngineFromOverrides|TestApplyParserRuleOverrides_XLSXFirstRowAsHeader' -count=1`
- `npm run build-only`
- `git diff --check`

Closes #2310
