### PR TITLE
fix: support string args for skill script execution

### DIFF
--- a/internal/agent/tools/skill_execute.go
+++ b/internal/agent/tools/skill_execute.go
@@ -47,6 +47,46 @@ type ExecuteSkillScriptInput struct {
 	Input      string   `json:"input,omitempty" jsonschema:"Optional input data to pass to the script via stdin. Use this when you have data in memory (e.g. JSON string) that the script should process. This is equivalent to piping data: echo 'data' | python script.py"`
 }
 
+// UnmarshalJSON accepts args as either the documented string array or a single
+// command-line string. Some model providers emit a string for a single tool
+// argument; accepting it here keeps that malformed-but-unambiguous call from
+// failing before the script can run.
+func (i *ExecuteSkillScriptInput) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		SkillName  string          `json:"skill_name"`
+		ScriptPath string          `json:"script_path"`
+		Args       json.RawMessage `json:"args"`
+		Input      string          `json:"input"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	i.SkillName = raw.SkillName
+	i.ScriptPath = raw.ScriptPath
+	i.Input = raw.Input
+	i.Args = nil
+
+	if len(raw.Args) == 0 || string(raw.Args) == "null" {
+		return nil
+	}
+
+	if err := json.Unmarshal(raw.Args, &i.Args); err == nil {
+		return nil
+	}
+
+	var argsString string
+	if err := json.Unmarshal(raw.Args, &argsString); err != nil {
+		return fmt.Errorf("args must be a string or an array of strings: %w", err)
+	}
+
+	// A string is interpreted as a conventional space-separated command line.
+	// The tool schema continues to advertise []string, so well-formed calls are
+	// unaffected; this is only a compatibility fallback for model output.
+	i.Args = strings.Fields(argsString)
+	return nil
+}
+
 // ExecuteSkillScriptTool allows the agent to execute skill scripts in a sandbox
 type ExecuteSkillScriptTool struct {
 	BaseTool


### PR DESCRIPTION
## Description 

Fixes argument parsing for skill script execution. Previously, ExecuteSkillScriptInput.args was defined as []string, so execution failed when a tool caller provided args as a command-line string:

```text
json: cannot unmarshal string into Go struct field ExecuteSkillScriptInput.args of type []string
```
This change supports both string arrays and space-separated command-line strings, while rejecting unsupported argument types.

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #1792

## Testing
Verified in a Linux Docker container with:

```bash
go test ./internal/agent/tools -run TestExecuteSkillScriptInput -v
```

Result:
```text
=== RUN   TestExecuteSkillScriptInputUnmarshalArgs
=== RUN   TestExecuteSkillScriptInputUnmarshalArgs/array
=== RUN   TestExecuteSkillScriptInputUnmarshalArgs/single_command_line_string
=== RUN   TestExecuteSkillScriptInputUnmarshalArgs/omitted
--- PASS: TestExecuteSkillScriptInputUnmarshalArgs (0.00s)
    --- PASS: TestExecuteSkillScriptInputUnmarshalArgs/array (0.00s)
    --- PASS: TestExecuteSkillScriptInputUnmarshalArgs/single_command_line_string (0.00s)
    --- PASS: TestExecuteSkillScriptInputUnmarshalArgs/omitted (0.00s)
=== RUN   TestExecuteSkillScriptInputRejectsInvalidArgs
--- PASS: TestExecuteSkillScriptInputRejectsInvalidArgs (0.00s)
PASS
ok      github.com/Tencent/WeKnora/internal/agent/tools 0.506s
```


## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings 
Not applicable. This change does not include user-visible UI changes.
