### PR TITLE
fix(pipeline): 修复合并阶段输出顺序的不确定性

### DIFF
--- a/internal/application/service/chat_pipeline/merge.go
+++ b/internal/application/service/chat_pipeline/merge.go
@@ -201,6 +201,10 @@ func (p *PluginMerge) groupAndMergeOverlapping(ctx context.Context, results []*t
 		mergedChunks = append(mergedChunks, g...)
 	}
 
+	// Global sort restores relevance order after map-based grouping.
+	// n is typically < 100, O(n log n) is negligible here.
+	sortSearchResultsDeterministically(mergedChunks)
+
 	pipelineInfo(ctx, "Merge", "output", map[string]interface{}{
 		"merged_total": len(mergedChunks),
 	})

--- a/internal/application/service/chat_pipeline/merge_group_deterministic_test.go
+++ b/internal/application/service/chat_pipeline/merge_group_deterministic_test.go
@@ -1,0 +1,89 @@
+package chatpipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// groupAndMergeOverlapping groups results by KnowledgeID and ChunkType
+// using two levels of Go maps. Map iteration order is non-deterministic,
+// so the concatenated output can appear in arbitrary order. This test
+// verifies that the post-merge sort restores deterministic ordering
+// (score desc, then KnowledgeID, ChunkType).
+func TestGroupAndMergeOverlapping_DeterministicOrdering(t *testing.T) {
+	plugin := &PluginMerge{}
+
+	t.Run("sorts by score descending across groups", func(t *testing.T) {
+		// Same KnowledgeID, different ChunkTypes -> separate inner-map
+		// buckets whose iteration order is randomized.
+		chunks := []*types.SearchResult{
+			{ID: "low", KnowledgeID: "kb-001", ChunkType: "text", StartAt: 0, EndAt: 100, Score: 0.4},
+			{ID: "high", KnowledgeID: "kb-001", ChunkType: "summary", StartAt: 200, EndAt: 300, Score: 0.9},
+			{ID: "mid", KnowledgeID: "kb-001", ChunkType: "parent_text", StartAt: 400, EndAt: 500, Score: 0.6},
+		}
+		results := plugin.groupAndMergeOverlapping(context.Background(), chunks)
+
+		require.Len(t, results, 3)
+		assert.Equal(t, "high", results[0].ID, "highest score (0.9) must be first")
+		assert.Equal(t, "mid", results[1].ID, "middle score (0.6) must be second")
+		assert.Equal(t, "low", results[2].ID, "lowest score (0.4) must be last")
+	})
+
+	t.Run("uses KnowledgeID as first tie-breaker when scores equal", func(t *testing.T) {
+		// Different KnowledgeIDs -> separate outer-map buckets whose
+		// iteration order is randomized.
+		chunks := []*types.SearchResult{
+			{ID: "ab", KnowledgeID: "kb-ab", ChunkType: "text", StartAt: 0, EndAt: 50, Score: 0.8},
+			{ID: "aa", KnowledgeID: "kb-aa", ChunkType: "text", StartAt: 0, EndAt: 50, Score: 0.8},
+		}
+		results := plugin.groupAndMergeOverlapping(context.Background(), chunks)
+		require.Len(t, results, 2)
+		assert.Equal(t, "aa", results[0].ID, "same score, kb-aa < kb-ab")
+	})
+
+	t.Run("merged chunk uses max score and is sorted among other groups", func(t *testing.T) {
+		// Two overlapping text chunks merge into one (score = max(0.5,0.7) = 0.7),
+		// then the merged result competes with a higher-scored summary chunk
+		// across the inner-map boundary.
+		chunks := []*types.SearchResult{
+			{ID: "low-a", KnowledgeID: "kb-001", ChunkType: "text", StartAt: 0, EndAt: 50, Score: 0.5},
+			{ID: "low-b", KnowledgeID: "kb-001", ChunkType: "text", StartAt: 30, EndAt: 80, Score: 0.7},
+			{ID: "high", KnowledgeID: "kb-001", ChunkType: "summary", StartAt: 200, EndAt: 300, Score: 0.9},
+		}
+		results := plugin.groupAndMergeOverlapping(context.Background(), chunks)
+		require.Len(t, results, 2, "two text chunks merged into one, plus one summary")
+		assert.Equal(t, "high", results[0].ID, "summary (0.9) beats merged text (0.7)")
+	})
+
+	t.Run("uses ChunkType as tie-breaker when score and knowledge match", func(t *testing.T) {
+		// Same KnowledgeID, different ChunkTypes -> separate inner-map
+		// buckets whose iteration order is randomized.
+		chunks := []*types.SearchResult{
+			{ID: "txt", KnowledgeID: "kb-x", ChunkType: "text", StartAt: 0, EndAt: 50, Score: 0.8},
+			{ID: "sum", KnowledgeID: "kb-x", ChunkType: "summary", StartAt: 100, EndAt: 150, Score: 0.8},
+		}
+		results := plugin.groupAndMergeOverlapping(context.Background(), chunks)
+		require.Len(t, results, 2)
+		assert.Equal(t, "sum", results[0].ID, "same kb+score, 'summary' < 'text'")
+	})
+}
+
+// TestGroupAndMergeOverlapping_CrossKnowledgePreservesMergeLogic verifies
+// that chunks from different KnowledgeIDs do NOT accidentally merge across
+// knowledge boundaries even when they share StartAt/EndAt ranges.
+func TestGroupAndMergeOverlapping_CrossKnowledgePreservesMergeLogic(t *testing.T) {
+	plugin := &PluginMerge{}
+	chunks := []*types.SearchResult{
+		{ID: "a-1", KnowledgeID: "kb-a", ChunkType: "text", StartAt: 0, EndAt: 100, Score: 0.9},
+		{ID: "b-1", KnowledgeID: "kb-b", ChunkType: "text", StartAt: 0, EndAt: 100, Score: 0.5},
+	}
+	results := plugin.groupAndMergeOverlapping(context.Background(), chunks)
+
+	require.Len(t, results, 2, "chunks from different KBs must not merge")
+	assert.Equal(t, "a-1", results[0].ID, "higher score from kb-a first")
+	assert.Equal(t, "b-1", results[1].ID, "lower score from kb-b second")
+}


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

`groupAndMergeOverlapping` 使用两层 Go map 对检索结果按 KnowledgeID 和 ChunkType 进行分组。Go 的 map 迭代顺序有不确定性，因此不同合并单元的输出拼接后顺序随机。相同请求可能返回不同顺序的结果，影响检索稳定性。

修复方法：在拼接各合并单元的输出后，调用已有的 `sortSearchResultsDeterministically` 按分数降序重新排序，确保合并阶段输出顺序稳定。

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->

1. 新增 `TestGroupAndMergeOverlapping_DeterministicOrdering`，覆盖跨单元排序：分数降序、KnowledgeID 字典序、ChunkType 字典序
2. 修复前测试失败（map 迭代顺序随机，期望高分在前，实际低分在前）
3. 修复后全部通过
4. 新增 `TestGroupAndMergeOverlapping_CrossKnowledgePreservesMergeLogic` 确保跨知识库不合并
5. 已有测试无回归

## Checklist
- [x] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->