### PR TITLE
fix: Remove SanitizeForDisplay from chunk handler responses

### DIFF
--- a/internal/handler/chunk.go
+++ b/internal/handler/chunk.go
@@ -75,11 +75,6 @@ func (h *ChunkHandler) GetChunkByIDOnly(c *gin.Context) {
 		return
 	}
 
-	// 对 chunk 内容进行安全清理
-	if chunk.Content != "" {
-		chunk.Content = secutils.SanitizeForDisplay(chunk.Content)
-	}
-
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"data":    chunk,
@@ -144,13 +139,6 @@ func (h *ChunkHandler) ListKnowledgeChunks(c *gin.Context) {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(errors.NewInternalServerError(err.Error()))
 		return
-	}
-
-	// 对 chunk 内容进行安全清理
-	for _, chunk := range result.Data.([]*types.Chunk) {
-		if chunk.Content != "" {
-			chunk.Content = secutils.SanitizeForDisplay(chunk.Content)
-		}
 	}
 
 	c.JSON(http.StatusOK, gin.H{

--- a/internal/handler/embed_channel.go
+++ b/internal/handler/embed_channel.go
@@ -366,9 +366,6 @@ func (h *EmbedChannelHandler) GetEmbedChunk(c *gin.Context) {
 		}
 		return
 	}
-	if chunk.Content != "" {
-		chunk.Content = secutils.SanitizeForDisplay(chunk.Content)
-	}
 	c.JSON(http.StatusOK, gin.H{"success": true, "data": chunk})
 }
 


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

`CleanMarkdown` regex patterns (`script`, `onclick=`, `javascript:`, etc.) unconditionally delete matching substrings from chunk content, even when they appear in code blocks or inline code.

JSON APIs should return raw stored data; XSS protection is the frontend markdown renderer's responsibility.

`SanitizeForDisplay` and `CleanMarkdown` are retained in `security.go`.

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #2322

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->

Run the full test suite. No regression (no existing tests covering markdown sanitize).

Frontend have already sanitized the API content.

## Checklist
- [x] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
