### PR TITLE
fix(knowledge): clean bound vector stores in batch delete

### DIFF
--- a/internal/application/service/knowledge_delete.go
+++ b/internal/application/service/knowledge_delete.go
@@ -441,6 +441,52 @@ func removeChunkRefs(refs types.StringArray, removed map[string]bool) types.Stri
 	return result
 }
 
+type knowledgeVectorDeleteGroup struct {
+	VectorStoreID    string
+	EmbeddingModelID string
+	Type             string
+	KnowledgeIDs     []string
+}
+
+func buildKnowledgeVectorDeleteGroups(
+	knowledges []*types.Knowledge,
+	knowledgeBases map[string]*types.KnowledgeBase,
+) []knowledgeVectorDeleteGroup {
+	type groupKey struct {
+		VectorStoreID    string
+		EmbeddingModelID string
+		Type             string
+	}
+
+	grouped := make(map[groupKey][]string)
+	for _, knowledge := range knowledges {
+		if knowledge == nil {
+			continue
+		}
+		var vectorStoreID string
+		if kb := knowledgeBases[knowledge.KnowledgeBaseID]; kb != nil && kb.VectorStoreID != nil {
+			vectorStoreID = strings.TrimSpace(*kb.VectorStoreID)
+		}
+		key := groupKey{
+			VectorStoreID:    vectorStoreID,
+			EmbeddingModelID: knowledge.EmbeddingModelID,
+			Type:             knowledge.Type,
+		}
+		grouped[key] = append(grouped[key], knowledge.ID)
+	}
+
+	groups := make([]knowledgeVectorDeleteGroup, 0, len(grouped))
+	for key, knowledgeIDs := range grouped {
+		groups = append(groups, knowledgeVectorDeleteGroup{
+			VectorStoreID:    key.VectorStoreID,
+			EmbeddingModelID: key.EmbeddingModelID,
+			Type:             key.Type,
+			KnowledgeIDs:     knowledgeIDs,
+		})
+	}
+	return groups
+}
+
 // DeleteKnowledgeList deletes a knowledge entry and all related resources
 func (s *knowledgeService) DeleteKnowledgeList(ctx context.Context, ids []string) error {
 	if len(ids) == 0 {
@@ -479,11 +525,13 @@ func (s *knowledgeService) DeleteKnowledgeList(ctx context.Context, ids []string
 		s.dequeueKnowledgeTasks(ctx, kid)
 	}
 
-	// Pre-resolve file services per KB so goroutines don't need DB access
+	// Pre-resolve KB metadata and file services so goroutines don't need DB access.
+	knowledgeBases := make(map[string]*types.KnowledgeBase)
 	kbFileServices := make(map[string]interfaces.FileService)
 	for _, knowledge := range knowledgeList {
 		if _, ok := kbFileServices[knowledge.KnowledgeBaseID]; !ok {
 			kb, _ := s.kbService.GetKnowledgeBaseByID(ctx, knowledge.KnowledgeBaseID)
+			knowledgeBases[knowledge.KnowledgeBaseID] = kb
 			kbFileServices[knowledge.KnowledgeBaseID] = s.resolveFileService(ctx, kb)
 		}
 	}
@@ -511,41 +559,32 @@ func (s *knowledgeService) DeleteKnowledgeList(ctx context.Context, ids []string
 	// 2. Delete knowledge embeddings from vector store
 	wg.Go(func() error {
 		tenantID := types.MustTenantIDFromContext(ctx)
-		// Batch cleanup spans multiple KBs that may be bound to different
-		// VectorStores; routing this batch through tenant effective engines
-		// keeps the legacy behavior intact.
-		// TODO: fan out the batch per-store using each KB's own
-		// VectorStoreID so cleanup hits the right backend for bound KBs.
-		retrieveEngine, err := retriever.CreateRetrieveEngineForKB(
-			ctx, s.retrieveEngine, s.ownership, tenantID, nil)
-		if err != nil {
-			logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge delete knowledge embedding failed")
-			return err
-		}
-		// Group by EmbeddingModelID and Type
-		type groupKey struct {
-			EmbeddingModelID string
-			Type             string
-		}
-		group := map[groupKey][]string{}
-		for _, knowledge := range knowledgeList {
-			key := groupKey{EmbeddingModelID: knowledge.EmbeddingModelID, Type: knowledge.Type}
-			group[key] = append(group[key], knowledge.ID)
-		}
-		for key, knowledgeIDs := range group {
+		for _, group := range buildKnowledgeVectorDeleteGroups(knowledgeList, knowledgeBases) {
 			// Wiki-only knowledge never had embeddings written to the vector store,
 			// and its EmbeddingModelID is intentionally empty. Skip the whole group
 			// to avoid the spurious "model ID cannot be empty" failure.
-			if strings.TrimSpace(key.EmbeddingModelID) == "" {
-				logger.Infof(ctx, "Skipping vector store cleanup for %d knowledge entries without embedding model", len(knowledgeIDs))
+			if strings.TrimSpace(group.EmbeddingModelID) == "" {
+				logger.Infof(ctx, "Skipping vector store cleanup for %d knowledge entries without embedding model", len(group.KnowledgeIDs))
 				continue
 			}
-			embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, key.EmbeddingModelID)
+
+			var vectorStoreID *string
+			if group.VectorStoreID != "" {
+				storeID := group.VectorStoreID
+				vectorStoreID = &storeID
+			}
+			retrieveEngine, err := retriever.CreateRetrieveEngineForKB(
+				ctx, s.retrieveEngine, s.ownership, tenantID, vectorStoreID)
+			if err != nil {
+				logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge delete knowledge embedding failed")
+				return err
+			}
+			embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, group.EmbeddingModelID)
 			if err != nil {
 				logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge get embedding model failed")
 				return err
 			}
-			if err := retrieveEngine.DeleteByKnowledgeIDList(ctx, knowledgeIDs, embeddingModel.GetDimensions(), key.Type); err != nil {
+			if err := retrieveEngine.DeleteByKnowledgeIDList(ctx, group.KnowledgeIDs, embeddingModel.GetDimensions(), group.Type); err != nil {
 				logger.GetLogger(ctx).
 					WithField("error", err).
 					Errorf("DeleteKnowledge delete knowledge embedding failed")

--- a/internal/application/service/knowledge_delete_test.go
+++ b/internal/application/service/knowledge_delete_test.go
@@ -23,3 +23,29 @@ func TestRemoveChunkRefsNoRemovedSet(t *testing.T) {
 
 	require.Equal(t, refs, got)
 }
+
+func TestBuildKnowledgeVectorDeleteGroupsSeparatesBoundStores(t *testing.T) {
+	storeA := "store-a"
+	storeB := "store-b"
+	kbs := map[string]*types.KnowledgeBase{
+		"kb-default": {ID: "kb-default"},
+		"kb-a":       {ID: "kb-a", VectorStoreID: &storeA},
+		"kb-b":       {ID: "kb-b", VectorStoreID: &storeB},
+	}
+	knowledges := []*types.Knowledge{
+		{ID: "default-1", KnowledgeBaseID: "kb-default", EmbeddingModelID: "model-1", Type: "file"},
+		{ID: "store-a-1", KnowledgeBaseID: "kb-a", EmbeddingModelID: "model-1", Type: "file"},
+		{ID: "store-a-2", KnowledgeBaseID: "kb-a", EmbeddingModelID: "model-1", Type: "file"},
+		{ID: "store-b-1", KnowledgeBaseID: "kb-b", EmbeddingModelID: "model-1", Type: "file"},
+	}
+
+	groups := buildKnowledgeVectorDeleteGroups(knowledges, kbs)
+
+	actual := make(map[string][]string, len(groups))
+	for _, group := range groups {
+		actual[group.VectorStoreID] = group.KnowledgeIDs
+	}
+	require.Equal(t, []string{"default-1"}, actual[""])
+	require.Equal(t, []string{"store-a-1", "store-a-2"}, actual["store-a"])
+	require.Equal(t, []string{"store-b-1"}, actual["store-b"])
+}


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI


## Checklist
- [x] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->


## 中文说明

###修复BUG：批量删除不会清理知识库绑定的自定义向量库
[knowledge_delete.go (line 517)](/D:/WeKnora/internal/application/service/knowledge_delete.go:517) 固定使用默认向量库，而单条删除会传入 kb.VectorStoreID。批量删除或清空绑定自定义 VectorStore 的知识库后，原向量会残留，可能继续被检索。
修复应按知识库的 VectorStoreID 创建对应检索引擎并清理。

### 修复内容

- 批量删除知识时，按照向量库 ID、Embedding 模型和知识类型进行分组。
- 使用知识库绑定的 `VectorStoreID` 创建对应的检索引擎。
- 保持默认向量库及仅启用 Wiki 的知识库原有行为。
- 增加覆盖默认向量库和多个自定义向量库的回归测试。

### 复现步骤

1. 注册一个自定义向量库。
2. 创建知识库，并将其绑定到该自定义向量库。
3. 上传并解析文档，确认向量已写入自定义向量库。
4. 对该知识库执行批量删除或清空操作。
5. 修复前：数据库记录和分块已删除，但自定义向量库中的向量仍然存在。这是因为 `DeleteKnowledgeList` 固定向 `CreateRetrieveEngineForKB` 传入 `nil`，导致清理操作始终使用默认向量库。
6. 修复后：批量删除会按照 `VectorStoreID` 拆分任务，并通过对应的检索引擎清理每个向量库中的数据。

### 验证结果

- 回归测试覆盖默认向量库及多个自定义向量库。
- `internal/application/service` 包测试通过。
- `internal/handler` 编译检查通过。
- `git diff --check` 通过。
