### PR TITLE
fix(knowledge): reconcile wiki state when moving documents across KBs

### DIFF
--- a/internal/application/service/knowledge_clone_move.go
+++ b/internal/application/service/knowledge_clone_move.go
@@ -1198,9 +1198,28 @@ func (s *knowledgeService) moveOneKnowledge(
 		return fmt.Errorf("failed to mark knowledge as processing: %w", err)
 	}
 
+	// From the source KB's point of view the document is leaving for good, so it
+	// needs the same wiki reconciliation a delete performs: wiki_pages carry
+	// source_refs back to this knowledge and are what the folder tree and the
+	// wiki graph are built from, and nothing below touches them. This must run
+	// while KnowledgeBaseID still points at the source and before any chunk is
+	// removed, since the cleanup matches pages by chunk_refs.
+	if sourceKB.IsWikiEnabled() {
+		s.cleanupWikiOnKnowledgeDelete(ctx, knowledge)
+	}
+
 	switch mode {
 	case "reuse_vectors":
-		return s.moveKnowledgeReuseVectors(ctx, knowledge, sourceKB, targetKB)
+		if err := s.moveKnowledgeReuseVectors(ctx, knowledge, sourceKB, targetKB); err != nil {
+			return err
+		}
+		// reparse re-ingests through KnowledgePostProcess once the new chunks
+		// land; reuse_vectors keeps the existing chunks and never re-enters that
+		// pipeline, so the target KB has to be told about the document here.
+		if targetKB.IsWikiEnabled() {
+			EnqueueWikiIngest(ctx, s.task, s.taskPendingRepo, tenantID, targetKB.ID, knowledge.ID)
+		}
+		return nil
 	case "reparse":
 		return s.moveKnowledgeReparse(ctx, knowledge, sourceKB, targetKB)
 	default:

--- a/internal/application/service/knowledge_move_wiki_test.go
+++ b/internal/application/service/knowledge_move_wiki_test.go
@@ -1,0 +1,174 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Moving a document out of a wiki-enabled KB must reconcile that KB's wiki
+// state the same way a delete does. wiki_pages hold source_refs back to the
+// knowledge and are what both the folder tree and the wiki graph are rendered
+// from, so skipping the cleanup leaves the source KB showing pages for a
+// document it no longer owns.
+
+type moveWikiKnowledgeRepo struct {
+	interfaces.KnowledgeRepository
+	knowledge *types.Knowledge
+}
+
+func (r *moveWikiKnowledgeRepo) GetKnowledgeByID(
+	_ context.Context, _ uint64, _ string,
+) (*types.Knowledge, error) {
+	clone := *r.knowledge
+	return &clone, nil
+}
+
+func (r *moveWikiKnowledgeRepo) UpdateKnowledge(_ context.Context, k *types.Knowledge) error {
+	clone := *k
+	r.knowledge = &clone
+	return nil
+}
+
+func (r *moveWikiKnowledgeRepo) DeleteKnowledgeTagRelations(_ context.Context, _ string) error {
+	return nil
+}
+
+type moveWikiPageRepo struct {
+	interfaces.WikiPageRepository
+	listedKBs []string
+}
+
+func (r *moveWikiPageRepo) ListBySourceRef(
+	_ context.Context, kbID, _ string,
+) ([]*types.WikiPage, error) {
+	r.listedKBs = append(r.listedKBs, kbID)
+	return nil, nil
+}
+
+type moveWikiPendingRepo struct {
+	interfaces.TaskPendingOpsRepository
+	ops []*types.TaskPendingOp
+}
+
+func (r *moveWikiPendingRepo) Enqueue(_ context.Context, op *types.TaskPendingOp) error {
+	r.ops = append(r.ops, op)
+	return nil
+}
+
+func (r *moveWikiPendingRepo) DeleteByDedupKey(_ context.Context, _, _, _, _, _ string) error {
+	return nil
+}
+
+type moveWikiChunkRepo struct {
+	interfaces.ChunkRepository
+	movedToKB string
+}
+
+func (r *moveWikiChunkRepo) ListChunksByKnowledgeID(
+	_ context.Context, _ uint64, _ string,
+) ([]*types.Chunk, error) {
+	return nil, nil
+}
+
+func (r *moveWikiChunkRepo) MoveChunksByKnowledgeID(
+	_ context.Context, _ uint64, _ string, targetKBID string,
+) error {
+	r.movedToKB = targetKBID
+	return nil
+}
+
+func wikiEnabledKB(id string) *types.KnowledgeBase {
+	return &types.KnowledgeBase{
+		ID:               id,
+		IndexingStrategy: types.IndexingStrategy{WikiEnabled: true},
+	}
+}
+
+// opsFor returns the pending ops enqueued against a given KB scope.
+func opsFor(ops []*types.TaskPendingOp, kbID string) []*types.TaskPendingOp {
+	var out []*types.TaskPendingOp
+	for _, op := range ops {
+		if op.ScopeID == kbID {
+			out = append(out, op)
+		}
+	}
+	return out
+}
+
+func newMoveWikiService(t *testing.T) (
+	*knowledgeService, *moveWikiPageRepo, *moveWikiPendingRepo, *moveWikiChunkRepo,
+) {
+	t.Helper()
+	wikiRepo := &moveWikiPageRepo{}
+	pendingRepo := &moveWikiPendingRepo{}
+	chunkRepo := &moveWikiChunkRepo{}
+	svc := &knowledgeService{
+		repo: &moveWikiKnowledgeRepo{knowledge: &types.Knowledge{
+			ID:              "kn-1",
+			TenantID:        1,
+			Title:           "Doc",
+			KnowledgeBaseID: "kb-src",
+			ParseStatus:     types.ParseStatusCompleted,
+		}},
+		wikiRepo:        wikiRepo,
+		taskPendingRepo: pendingRepo,
+		task:            &wikiGuardTaskQueue{},
+		chunkRepo:       chunkRepo,
+	}
+	return svc, wikiRepo, pendingRepo, chunkRepo
+}
+
+func moveWikiCtx() context.Context {
+	return context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+}
+
+func TestMoveOneKnowledgeRetractsWikiFromSourceKB(t *testing.T) {
+	// An unknown mode makes the move itself a no-op, which pins the cleanup as
+	// unconditional: it runs before the mode dispatch, while the knowledge still
+	// belongs to the source KB.
+	svc, wikiRepo, pendingRepo, _ := newMoveWikiService(t)
+
+	err := svc.moveOneKnowledge(moveWikiCtx(), "kn-1",
+		wikiEnabledKB("kb-src"), wikiEnabledKB("kb-dst"), "bogus")
+
+	require.Error(t, err)
+	assert.Equal(t, []string{"kb-src"}, wikiRepo.listedKBs)
+
+	srcOps := opsFor(pendingRepo.ops, "kb-src")
+	require.Len(t, srcOps, 1)
+	assert.Equal(t, WikiOpRetract, srcOps[0].Op)
+	assert.Equal(t, "kn-1", srcOps[0].DedupKey)
+}
+
+func TestMoveOneKnowledgeReuseVectorsIngestsIntoTargetKB(t *testing.T) {
+	// reuse_vectors keeps the existing chunks and never re-enters the parse
+	// pipeline, so nothing else would tell the target KB to build wiki pages.
+	svc, _, pendingRepo, chunkRepo := newMoveWikiService(t)
+
+	err := svc.moveOneKnowledge(moveWikiCtx(), "kn-1",
+		wikiEnabledKB("kb-src"), wikiEnabledKB("kb-dst"), "reuse_vectors")
+
+	require.NoError(t, err)
+	assert.Equal(t, "kb-dst", chunkRepo.movedToKB)
+
+	dstOps := opsFor(pendingRepo.ops, "kb-dst")
+	require.Len(t, dstOps, 1)
+	assert.Equal(t, WikiOpIngest, dstOps[0].Op)
+	assert.Equal(t, "kn-1", dstOps[0].DedupKey)
+}
+
+func TestMoveOneKnowledgeSkipsWikiWorkForNonWikiKBs(t *testing.T) {
+	svc, wikiRepo, pendingRepo, _ := newMoveWikiService(t)
+
+	err := svc.moveOneKnowledge(moveWikiCtx(), "kn-1",
+		&types.KnowledgeBase{ID: "kb-src"}, &types.KnowledgeBase{ID: "kb-dst"}, "reuse_vectors")
+
+	require.NoError(t, err)
+	assert.Empty(t, wikiRepo.listedKBs)
+	assert.Empty(t, pendingRepo.ops)
+}


### PR DESCRIPTION
## Summary
- Run the same wiki cleanup as document delete on the source KB when moving knowledge across knowledge bases, so stale `wiki_pages` source refs no longer keep moved documents visible in the folder tree and wiki graph.
- Enqueue wiki ingest on the target KB for `reuse_vectors` moves, since that path keeps existing chunks and does not re-enter the post-process pipeline that normally triggers wiki ingestion.
- Add regression tests covering source retract, target ingest, and non-wiki KB no-op behavior.

## Test plan
- [x] `go test ./internal/application/service/ -run TestMoveOneKnowledge -count=1`
- [x] `go test ./internal/application/service/ -count=1`
- [ ] Move a document from wiki KB A to wiki KB B with `reuse_vectors` and verify A's folder tree/wiki graph no longer show the document
- [ ] Verify B eventually ingests the moved document into its wiki tree
- [ ] Move with `reparse` and verify source wiki cleanup still happens without duplicate target ingest