### PR TITLE
style(wiki): polish revision drawer and sidebar to match session list UX

### DIFF
--- a/frontend/src/views/knowledge/wiki/WikiBrowser.vue
+++ b/frontend/src/views/knowledge/wiki/WikiBrowser.vue
@@ -403,10 +403,11 @@
 
               <!-- Page header -->
               <div class="wiki-reader-header">
-                <h2 class="wiki-reader-title" style="display: flex; align-items: center;">
-                  {{ selectedPage.title }}
+                <div class="wiki-reader-title-row">
+                  <h2 class="wiki-reader-title">
+                    <span class="wiki-reader-title-text">{{ selectedPage.title }}</span>
 
-                  <t-popup v-if="pageIssues.length > 0" v-model="showIssuesBox" placement="bottom-left" trigger="click"
+                    <t-popup v-if="pageIssues.length > 0" v-model="showIssuesBox" placement="bottom-left" trigger="click"
                     :overlayInnerStyle="{ padding: 0, boxShadow: 'var(--td-shadow-3)', borderRadius: '8px', width: '560px', maxWidth: '90vw' }">
                     <span class="wiki-issue-trigger"
                       :title="$t('knowledgeEditor.wikiBrowser.issueTitle', { count: pageIssues.length })">
@@ -468,7 +469,33 @@
                       </div>
                     </template>
                   </t-popup>
-                </h2>
+                  </h2>
+                  <div class="wiki-reader-header-actions">
+                    <t-tooltip :content="$t('knowledgeEditor.wikiBrowser.historyBtn')" placement="top">
+                      <button type="button" class="wiki-reader-action-btn"
+                        :aria-label="$t('knowledgeEditor.wikiBrowser.historyBtn')" @click="openRevisionDrawer">
+                        <t-icon name="history" />
+                      </button>
+                    </t-tooltip>
+                    <t-tooltip v-if="props.canEdit && !editingPage"
+                      :content="$t('knowledgeEditor.wikiBrowser.editBtn')" placement="top">
+                      <button type="button" class="wiki-reader-action-btn"
+                        :aria-label="$t('knowledgeEditor.wikiBrowser.editBtn')" @click="startEditPage">
+                        <t-icon name="edit" />
+                      </button>
+                    </t-tooltip>
+                    <t-popconfirm v-if="props.canEdit" theme="danger"
+                      :content="$t('knowledgeEditor.wikiBrowser.deletePageConfirm', { title: selectedPage.title })"
+                      @confirm="confirmDeletePage">
+                      <t-tooltip :content="$t('knowledgeEditor.wikiBrowser.deletePageBtn')" placement="top">
+                        <button type="button" class="wiki-reader-action-btn wiki-reader-action-btn--danger"
+                          :aria-label="$t('knowledgeEditor.wikiBrowser.deletePageBtn')">
+                          <t-icon name="delete" />
+                        </button>
+                      </t-tooltip>
+                    </t-popconfirm>
+                  </div>
+                </div>
                 <div v-if="selectedPage.aliases && selectedPage.aliases.length" class="wiki-reader-aliases">
                   <span class="wiki-alias-label">{{ $t('knowledgeEditor.wikiBrowser.aliases') }}:</span>
                   <t-tag v-for="alias in selectedPage.aliases" :key="alias" size="small" variant="light"
@@ -498,24 +525,6 @@
                     <template #prefixIcon><t-icon name="chart-bubble" /></template>
                     {{ $t('knowledgeEditor.wikiBrowser.viewInGraph') }}
                   </t-link>
-                  <span class="wiki-reader-actions">
-                    <t-link theme="default" hover="color" @click="openRevisionDrawer">
-                      <template #prefixIcon><t-icon name="history" /></template>
-                      {{ $t('knowledgeEditor.wikiBrowser.historyBtn') }}
-                    </t-link>
-                    <t-link v-if="props.canEdit && !editingPage" theme="primary" hover="color" @click="startEditPage">
-                      <template #prefixIcon><t-icon name="edit" /></template>
-                      {{ $t('knowledgeEditor.wikiBrowser.editBtn') }}
-                    </t-link>
-                    <t-popconfirm v-if="props.canEdit" theme="danger"
-                      :content="$t('knowledgeEditor.wikiBrowser.deletePageConfirm', { title: selectedPage.title })"
-                      @confirm="confirmDeletePage">
-                      <t-link theme="danger" hover="color">
-                        <template #prefixIcon><t-icon name="delete" /></template>
-                        {{ $t('knowledgeEditor.wikiBrowser.deletePageBtn') }}
-                      </t-link>
-                    </t-popconfirm>
-                  </span>
                 </div>
               </div>
 
@@ -546,16 +555,19 @@
                 <t-textarea v-model="editForm.content" class="wiki-page-editor-content"
                   :autosize="{ minRows: 16, maxRows: 40 }"
                   :placeholder="$t('knowledgeEditor.wikiBrowser.editContentPlaceholder')" />
-                <div v-if="editConflictVersion !== null" class="wiki-page-editor-conflict">
-                  <t-icon name="error-circle" />
-                  <span>{{ $t('knowledgeEditor.wikiBrowser.editConflictHint', { ver: editConflictVersion }) }}</span>
-                  <t-link theme="primary" hover="color" @click="reloadLatestIntoEditor">
-                    {{ $t('knowledgeEditor.wikiBrowser.editConflictReload') }}
-                  </t-link>
-                  <t-link theme="warning" hover="color" @click="overwriteSavePage">
-                    {{ $t('knowledgeEditor.wikiBrowser.editConflictOverwrite') }}
-                  </t-link>
-                </div>
+                <t-alert v-if="editConflictVersion !== null" theme="warning" class="wiki-page-editor-conflict"
+                  :message="t('knowledgeEditor.wikiBrowser.editConflictHint', { ver: editConflictVersion })">
+                  <template #operation>
+                    <span class="wiki-page-editor-conflict-actions">
+                      <t-link theme="primary" hover="color" @click="reloadLatestIntoEditor">
+                        {{ $t('knowledgeEditor.wikiBrowser.editConflictReload') }}
+                      </t-link>
+                      <t-link theme="warning" hover="color" @click="overwriteSavePage">
+                        {{ $t('knowledgeEditor.wikiBrowser.editConflictOverwrite') }}
+                      </t-link>
+                    </span>
+                  </template>
+                </t-alert>
                 <div class="wiki-page-editor-footer">
                   <t-button theme="primary" :loading="savingPage" @click="savePageEdit()">
                     {{ $t('common.save') }}
@@ -4854,6 +4866,10 @@ onUnmounted(() => {
   height: 100%;
   min-height: 0;
   background: var(--td-bg-color-container);
+  // Align list rows with the session sidebar grid (menu.vue).
+  --wiki-list-inset-x: 10px;
+  --wiki-list-row-radius: 6px;
+  --wiki-list-row-min-height: 30px;
 }
 
 // ── Left Sidebar ──
@@ -4868,10 +4884,12 @@ onUnmounted(() => {
 }
 
 .wiki-sidebar-header {
-  padding: 16px 16px 12px;
+  padding: 0 10px 8px 0;
+  margin-left: -8px;
+  padding-left: 8px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
 }
 
 .wiki-queue-status {
@@ -4914,7 +4932,9 @@ onUnmounted(() => {
 .wiki-page-list {
   flex: 1;
   overflow-y: auto;
-  padding: 0 12px 12px;
+  padding: 0 8px 12px 0;
+  margin-left: -8px;
+  padding-left: 8px;
 }
 
 .wiki-tree-list {
@@ -4925,7 +4945,7 @@ onUnmounted(() => {
 // left-aligned; only folder rows reserve trailing space for count / actions.
 .wiki-tree-panel {
   --wiki-tree-depth-indent: 14px;
-  padding: 0 8px;
+  padding: 0;
 }
 
 .wiki-tab-bar {
@@ -4964,7 +4984,8 @@ onUnmounted(() => {
   align-items: center;
   padding: 2px;
   border-radius: 6px;
-  background: var(--td-bg-color-secondarycontainer);
+  background: var(--td-bg-color-container);
+  border: 1px solid var(--td-component-stroke);
 }
 
 .wiki-view-toggle-btn {
@@ -5054,22 +5075,23 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 12px;
-  border-radius: 6px;
+  min-height: var(--wiki-list-row-min-height);
+  padding: 0 10px 0 var(--wiki-list-inset-x);
+  border-radius: var(--wiki-list-row-radius);
   cursor: pointer;
-  margin-bottom: 4px;
-  transition: all 0.15s;
+  margin-bottom: 0;
+  transition: background 0.15s ease, color 0.15s ease;
 
   &:hover {
     background: var(--td-bg-color-container-hover);
   }
 
   &.active {
-    background: var(--td-brand-color-light);
+    background: var(--td-bg-color-container-hover);
 
     .wiki-nav-text {
       color: var(--td-brand-color);
-      font-weight: 600;
+      font-weight: 400;
     }
 
     .wiki-nav-icon {
@@ -5084,7 +5106,8 @@ onUnmounted(() => {
 
   .wiki-nav-text {
     font-size: 14px;
-    font-weight: 500;
+    font-weight: 400;
+    line-height: 20px;
     color: var(--td-text-color-primary);
   }
 }
@@ -5092,7 +5115,7 @@ onUnmounted(() => {
 .wiki-sidebar-divider {
   height: 1px;
   background: var(--td-component-stroke);
-  margin: 8px 12px;
+  margin: 6px 0;
 }
 
 .wiki-tab {
@@ -5143,24 +5166,26 @@ onUnmounted(() => {
 }
 
 .wiki-page-item {
-  min-height: 64px;
+  min-height: var(--wiki-list-row-min-height);
   box-sizing: border-box;
   overflow: hidden;
-  padding: 10px 12px;
-  border-radius: 6px;
+  padding: 6px 10px 6px var(--wiki-list-inset-x);
+  border-radius: var(--wiki-list-row-radius);
   cursor: pointer;
-  margin-bottom: 2px;
-  // Without this, mousedown-drag on the title text starts a text selection
-  // instead of an HTML5 drag, so the page never picks up.
+  margin-bottom: 0;
   user-select: none;
-  transition: background 0.15s;
+  transition: background 0.15s ease, color 0.15s ease;
 
   &:hover {
     background: var(--td-bg-color-container-hover);
   }
 
   &.active {
-    background: var(--td-brand-color-light);
+    background: var(--td-bg-color-container-hover);
+
+    .wiki-page-item-title {
+      color: var(--td-brand-color);
+    }
   }
 }
 
@@ -5171,14 +5196,17 @@ onUnmounted(() => {
 
 .wiki-page-item--list {
   height: 98px;
-  padding: 10px 2px;
+  padding: 8px 10px 8px var(--wiki-list-inset-x);
 }
 
 .wiki-page-item--list .wiki-page-item-title {
   display: block;
-  font-size: 13px;
-  font-weight: 500;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
   margin-bottom: 4px;
+  color: var(--td-text-color-primary);
+  transition: color 0.15s ease;
 }
 
 .wiki-page-item-summary {
@@ -5207,14 +5235,14 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding-left: calc(var(--wiki-tree-depth, 0) * var(--wiki-tree-depth-indent, 14px));
-  border-radius: 6px;
+  padding: 0 10px 0 calc(var(--wiki-tree-depth, 0) * var(--wiki-tree-depth-indent, 14px) + var(--wiki-list-inset-x));
+  border-radius: var(--wiki-list-row-radius);
   cursor: pointer;
-  margin: 1px 0;
+  margin: 0;
   color: var(--td-text-color-secondary);
   background: transparent;
   user-select: none;
-  transition: background 0.15s, color 0.15s;
+  transition: background 0.15s ease, color 0.15s ease;
 
   &:hover {
     background: var(--td-bg-color-container-hover);
@@ -5338,14 +5366,12 @@ onUnmounted(() => {
 
 .wiki-directory-count {
   flex: 0 0 auto;
-  min-width: 22px;
-  text-align: center;
+  min-width: 16px;
+  text-align: right;
   font-size: 11px;
   line-height: 18px;
-  padding: 0 6px;
-  border-radius: 999px;
   color: var(--td-text-color-placeholder);
-  background: var(--td-bg-color-secondarycontainer);
+  font-variant-numeric: tabular-nums;
 }
 
 .wiki-directory-load-more {
@@ -5372,14 +5398,23 @@ onUnmounted(() => {
   gap: 6px;
   height: 34px;
   min-height: 34px;
-  padding: 0;
-  padding-left: calc(var(--wiki-tree-depth, 0) * var(--wiki-tree-depth-indent, 14px));
-  border-radius: 6px;
-  margin: 1px 0;
+  padding: 4px 10px 4px calc(var(--wiki-tree-depth, 0) * var(--wiki-tree-depth-indent, 14px) + var(--wiki-list-inset-x));
+  border-radius: var(--wiki-list-row-radius);
+  margin: 0;
+
+  &.active {
+    .wiki-page-file-icon {
+      color: var(--td-brand-color);
+    }
+  }
 }
 
 .wiki-page-item--tree .wiki-page-item-title {
-  font-weight: 500;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+  color: var(--td-text-color-primary);
+  transition: color 0.15s ease;
 }
 
 // ── Right Content ──
@@ -5394,7 +5429,7 @@ onUnmounted(() => {
 .wiki-reader {
   flex: 1;
   overflow-y: auto;
-  padding: 16px 24px;
+  padding: 0 24px 16px;
 }
 
 .wiki-reader-inner {
@@ -5402,11 +5437,11 @@ onUnmounted(() => {
 }
 
 .wiki-reader-header {
-  margin-bottom: 16px;
+  margin-bottom: 12px;
 }
 
 .wiki-nav-bar {
-  margin-bottom: 16px;
+  margin-bottom: 8px;
 }
 
 .wiki-nav-back {
@@ -5427,12 +5462,67 @@ onUnmounted(() => {
   }
 }
 
+.wiki-reader-title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
 .wiki-reader-title {
-  margin: 0 0 12px;
+  margin: 0;
   font-size: 26px;
   font-weight: 600;
   line-height: 1.3;
   color: var(--td-text-color-primary);
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wiki-reader-title-text {
+  min-width: 0;
+}
+
+.wiki-reader-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.wiki-reader-action-btn {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--td-text-color-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+
+  .t-icon {
+    font-size: 16px;
+  }
+
+  &:hover {
+    color: var(--td-brand-color);
+    background: var(--td-bg-color-container-hover);
+  }
+
+  &.wiki-reader-action-btn--danger:hover {
+    color: var(--td-error-color);
+    background: var(--td-error-color-1);
+  }
 }
 
 .wiki-reader-aliases {
@@ -5473,21 +5563,29 @@ onUnmounted(() => {
   font-size: 13px;
 }
 
-.wiki-reader-actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-  font-size: 13px;
-}
-
 .wiki-page-editor {
   display: flex;
   flex-direction: column;
   gap: 12px;
   margin-top: 8px;
+  padding: 16px;
+  background: var(--td-bg-color-container);
+  border: 1px solid var(--td-component-stroke);
+  border-radius: 8px;
 
   .wiki-page-editor-title :deep(.t-input__inner) {
+    font-size: 18px;
     font-weight: 600;
+    background: transparent;
+  }
+
+  .wiki-page-editor-title :deep(.t-input) {
+    background: transparent;
+  }
+
+  .wiki-page-editor-summary :deep(textarea) {
+    font-size: 13px;
+    line-height: 1.6;
   }
 
   .wiki-page-editor-content :deep(textarea) {
@@ -5498,20 +5596,19 @@ onUnmounted(() => {
 }
 
 .wiki-page-editor-conflict {
-  display: flex;
+  margin-bottom: 0;
+}
+
+.wiki-page-editor-conflict-actions {
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  border-radius: 6px;
-  background: var(--td-warning-color-1);
-  color: var(--td-warning-color-7);
-  font-size: 13px;
-  flex-wrap: wrap;
+  gap: 12px;
 }
 
 .wiki-page-editor-footer {
   display: flex;
   gap: 8px;
+  padding-top: 4px;
 }
 
 .wiki-create-page-form {
@@ -5870,10 +5967,14 @@ onUnmounted(() => {
 }
 
 .wiki-log-entry {
-  border: 1px solid var(--td-border-level-1-color);
-  border-radius: 8px;
-  padding: 10px 12px;
-  background: var(--td-bg-color-container);
+  border-radius: var(--wiki-list-row-radius);
+  padding: 10px 10px 10px var(--wiki-list-inset-x);
+  background: transparent;
+  transition: background 0.15s ease;
+
+  &:hover {
+    background: var(--td-bg-color-container-hover);
+  }
 }
 
 .wiki-log-entry-header {
@@ -5884,7 +5985,9 @@ onUnmounted(() => {
 }
 
 .wiki-log-entry-title {
-  font-weight: 500;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
   color: var(--td-text-color-primary);
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/views/knowledge/wiki/WikiBrowser.vue
+++ b/frontend/src/views/knowledge/wiki/WikiBrowser.vue
@@ -5953,7 +5953,7 @@ onUnmounted(() => {
 
   &:hover {
     color: var(--td-brand-color);
-    background: var(--td-brand-color-light);
+    background: var(--td-bg-color-container-hover);
   }
 }
 

--- a/frontend/src/views/knowledge/wiki/WikiBrowser.vue
+++ b/frontend/src/views/knowledge/wiki/WikiBrowser.vue
@@ -806,7 +806,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
+import { ref, computed, reactive, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useMenuStore } from '@/stores/menu'
 import { useSettingsStore } from '@/stores/settings'
@@ -818,6 +818,7 @@ import { hydrateProtectedFileImages, sanitizeMarkdownHTML } from '@/utils/securi
 import picturePreview from '@/components/picture-preview.vue'
 import WikiFolderActions from './WikiFolderActions.vue'
 import WikiRevisionDrawer from './WikiRevisionDrawer.vue'
+import { getKnowledgeDetails } from '@/api/knowledge-base'
 import { createSessions } from '@/api/chat'
 import ChatView from '@/views/chat/index.vue'
 import {
@@ -1265,18 +1266,55 @@ const hasContentPages = computed(() => {
   return false
 })
 
-// Parse source refs in "id|title" format
+// Pipeline ingest stores source_refs as bare knowledge IDs (see wiki_ingest_batch)
+// so filenames do not leak into LLM citation strings. Resolve titles for display.
+const sourceRefTitleCache = reactive<Record<string, string>>({})
+let sourceRefTitleRequestSeq = 0
+
+function parseSourceRefEntry(ref: string): { id: string; title: string } {
+  const pipeIdx = ref.indexOf('|')
+  if (pipeIdx > 0) {
+    return { id: ref.substring(0, pipeIdx), title: ref.substring(pipeIdx + 1) }
+  }
+  const cached = sourceRefTitleCache[ref]
+  if (cached) {
+    return { id: ref, title: cached }
+  }
+  return {
+    id: ref,
+    title: ref.length > 20 ? ref.substring(0, 8) + '...' : ref,
+  }
+}
+
 const parsedSourceRefs = computed(() => {
   if (!selectedPage.value?.source_refs?.length) return []
-  return selectedPage.value.source_refs.map(ref => {
-    const pipeIdx = ref.indexOf('|')
-    if (pipeIdx > 0) {
-      return { id: ref.substring(0, pipeIdx), title: ref.substring(pipeIdx + 1) }
-    }
-    // Fallback: show raw ref (backwards compat with old data)
-    return { id: ref, title: ref.length > 20 ? ref.substring(0, 8) + '...' : ref }
-  })
+  return selectedPage.value.source_refs.map(parseSourceRefEntry)
 })
+
+async function hydrateSourceRefTitles(refs: string[]) {
+  const ids = refs.filter((ref) => ref.indexOf('|') < 0 && !sourceRefTitleCache[ref])
+  if (!ids.length) return
+  const seq = ++sourceRefTitleRequestSeq
+  for (const id of ids) {
+    try {
+      const res = await getKnowledgeDetails(id)
+      if (seq !== sourceRefTitleRequestSeq) return
+      const data = (res as any)?.data ?? res
+      const title = data?.title || data?.file_name || data?.fileName
+      if (title) sourceRefTitleCache[id] = title
+    } catch {
+      // Keep truncated-ID fallback when the doc was deleted or is inaccessible.
+    }
+  }
+}
+
+watch(
+  () => selectedPage.value?.source_refs,
+  (refs) => {
+    if (refs?.length) hydrateSourceRefTitles(refs)
+  },
+  { immediate: true },
+)
 
 // Rendered content for graph drawer
 const graphDrawerContent = computed(() => {

--- a/frontend/src/views/knowledge/wiki/WikiBrowser.vue
+++ b/frontend/src/views/knowledge/wiki/WikiBrowser.vue
@@ -5945,13 +5945,14 @@ onUnmounted(() => {
   padding: 2px 10px;
   background: var(--td-bg-color-secondarycontainer);
   border-radius: 4px;
-  color: var(--td-brand-color);
+  color: var(--td-text-color-secondary);
   font-size: 12px;
   text-decoration: none;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: color 0.15s, background 0.15s;
 
   &:hover {
+    color: var(--td-brand-color);
     background: var(--td-brand-color-light);
   }
 }

--- a/frontend/src/views/knowledge/wiki/WikiRevisionDrawer.vue
+++ b/frontend/src/views/knowledge/wiki/WikiRevisionDrawer.vue
@@ -4,46 +4,42 @@
     @update:visible="(v: boolean) => emit('update:visible', v)">
     <div class="wiki-rev-layout">
       <!-- Version list -->
-      <div class="wiki-rev-list">
-        <!-- Current version pseudo-entry -->
-        <div v-if="currentPage" class="wiki-rev-item"
-          :class="{ 'wiki-rev-item--active': selectedVersion === currentPage.version }"
-          @click="selectCurrent">
-          <div class="wiki-rev-item-head">
-            <span class="wiki-rev-version">v{{ currentPage.version }}</span>
-            <t-tag size="small" theme="primary" variant="light">
-              {{ t('knowledgeEditor.wikiBrowser.revisionCurrent') }}
-            </t-tag>
-            <t-tag size="small" :theme="sourceTheme(currentPage.last_edit_source)" variant="light-outline">
-              {{ sourceLabel(currentPage.last_edit_source) }}
-            </t-tag>
+      <aside class="wiki-rev-list">
+        <div class="wiki-rev-list-items">
+          <div v-if="currentPage" class="wiki-rev-item"
+            :class="{ 'wiki-rev-item--active': selectedVersion === currentPage.version }"
+            @click="selectCurrent">
+            <div class="wiki-rev-item-primary">
+              <span class="wiki-rev-version">v{{ currentPage.version }}</span>
+              <span class="wiki-rev-current-label">{{ t('knowledgeEditor.wikiBrowser.revisionCurrent') }}</span>
+            </div>
+            <div class="wiki-rev-item-secondary">
+              <span>{{ sourceLabel(currentPage.last_edit_source) }}</span>
+              <span class="wiki-rev-time">{{ formatShortTime(currentPage.updated_at) }}</span>
+            </div>
           </div>
-          <div class="wiki-rev-item-meta">{{ formatTime(currentPage.updated_at) }}</div>
-        </div>
 
-        <div v-for="rev in revisions" :key="rev.id" class="wiki-rev-item"
-          :class="{ 'wiki-rev-item--active': selectedVersion === rev.version }" @click="selectRevision(rev)">
-          <div class="wiki-rev-item-head">
-            <span class="wiki-rev-version">v{{ rev.version }}</span>
-            <t-tag size="small" :theme="sourceTheme(rev.edit_source)" variant="light-outline">
-              {{ sourceLabel(rev.edit_source) }}
-            </t-tag>
+          <div v-for="rev in revisions" :key="rev.id" class="wiki-rev-item"
+            :class="{ 'wiki-rev-item--active': selectedVersion === rev.version }" @click="selectRevision(rev)">
+            <div class="wiki-rev-item-primary">
+              <span class="wiki-rev-version">v{{ rev.version }}</span>
+            </div>
+            <div class="wiki-rev-item-secondary">
+              <span>{{ sourceLabel(rev.edit_source) }}</span>
+              <span class="wiki-rev-time">{{ formatShortTime(rev.edited_at) }}</span>
+            </div>
           </div>
-          <div class="wiki-rev-item-meta">
-            {{ formatTime(rev.edited_at) }}
-            <span v-if="rev.editor_id" class="wiki-rev-editor">· {{ rev.editor_id }}</span>
-          </div>
-        </div>
 
-        <div v-if="revisions.length < total" class="wiki-rev-load-more">
-          <t-link theme="primary" hover="color" :disabled="loadingList" @click="loadMore">
-            {{ t('knowledgeEditor.wikiBrowser.logLoadMore') }}
-          </t-link>
+          <div v-if="revisions.length < total" class="wiki-rev-load-more">
+            <t-button size="small" variant="outline" theme="default" :loading="loadingList" block @click="loadMore">
+              {{ t('knowledgeEditor.wikiBrowser.logLoadMore') }}
+            </t-button>
+          </div>
         </div>
         <div v-if="!loadingList && revisions.length === 0" class="wiki-rev-empty">
           {{ t('knowledgeEditor.wikiBrowser.revisionEmpty') }}
         </div>
-      </div>
+      </aside>
 
       <!-- Detail pane -->
       <div class="wiki-rev-detail">
@@ -54,14 +50,22 @@
         <template v-else-if="selectedRevision">
           <div class="wiki-rev-detail-toolbar">
             <div class="wiki-rev-detail-title">
-              v{{ selectedRevision.version }} · {{ selectedRevision.title }}
+              <span class="wiki-rev-detail-version">v{{ selectedRevision.version }}</span>
+              <span class="wiki-rev-detail-name">{{ selectedRevision.title }}</span>
             </div>
             <div class="wiki-rev-detail-actions">
-              <t-radio-group v-model="detailMode" variant="default-filled" size="small">
-                <t-radio-button value="diff">{{ t('knowledgeEditor.wikiBrowser.revisionDiff') }}</t-radio-button>
-                <t-radio-button value="raw">{{ t('knowledgeEditor.wikiBrowser.revisionRaw') }}</t-radio-button>
-              </t-radio-group>
-              <t-popconfirm v-if="canEdit" :content="t('knowledgeEditor.wikiBrowser.revertConfirm', { ver: selectedRevision.version })"
+              <div class="wiki-rev-mode-toggle" role="group">
+                <button type="button" class="wiki-rev-mode-btn"
+                  :class="{ active: detailMode === 'diff' }" @click="detailMode = 'diff'">
+                  {{ t('knowledgeEditor.wikiBrowser.revisionDiff') }}
+                </button>
+                <button type="button" class="wiki-rev-mode-btn"
+                  :class="{ active: detailMode === 'raw' }" @click="detailMode = 'raw'">
+                  {{ t('knowledgeEditor.wikiBrowser.revisionRaw') }}
+                </button>
+              </div>
+              <t-popconfirm v-if="canEdit"
+                :content="t('knowledgeEditor.wikiBrowser.revertConfirm', { ver: selectedRevision.version })"
                 @confirm="doRevert">
                 <t-button size="small" theme="warning" variant="outline" :loading="reverting">
                   <template #icon><t-icon name="rollback" /></template>
@@ -71,7 +75,10 @@
             </div>
           </div>
 
-          <div v-if="loadingDetail" class="wiki-rev-detail-hint">{{ t('knowledgeEditor.wikiBrowser.logLoading') }}</div>
+          <div v-if="loadingDetail" class="wiki-rev-detail-loading">
+            <t-loading size="small" />
+            <span>{{ t('knowledgeEditor.wikiBrowser.logLoading') }}</span>
+          </div>
 
           <!-- Diff vs current -->
           <div v-else-if="detailMode === 'diff'" class="wiki-rev-diff">
@@ -255,96 +262,142 @@ function sourceLabel(source?: string): string {
   }
 }
 
-function sourceTheme(source?: string): 'primary' | 'success' | 'warning' | 'default' {
-  switch (source) {
-    case 'user':
-      return 'success'
-    case 'agent':
-      return 'primary'
-    case 'revert':
-      return 'warning'
-    default:
-      return 'default'
-  }
-}
-
-function formatTime(iso?: string): string {
+function formatShortTime(iso?: string): string {
   if (!iso) return ''
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) return iso
-  return d.toLocaleString()
+  const now = new Date()
+  if (d.toDateString() === now.toDateString()) {
+    return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+  }
+  return d.toLocaleString(undefined, {
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
 }
+
 </script>
 
 <style scoped>
 .wiki-rev-layout {
   display: flex;
-  gap: 16px;
-  height: 100%;
+  flex: 1;
   min-height: 0;
+  height: 100%;
+  align-items: stretch;
 }
 
 .wiki-rev-list {
   width: 220px;
   flex-shrink: 0;
-  overflow-y: auto;
+  min-height: 0;
+  overflow: hidden;
+  padding: 12px 0;
   border-right: 1px solid var(--td-component-stroke);
-  padding-right: 12px;
+  display: flex;
+  flex-direction: column;
+  background: var(--td-bg-color-container);
+}
+
+.wiki-rev-list-items {
+  flex: 0 0 auto;
+  overflow-y: auto;
+  min-height: 0;
+  padding: 0 8px 0 14px;
 }
 
 .wiki-rev-item {
-  padding: 8px 10px;
+  border: none;
   border-radius: 6px;
+  padding: 6px 10px 6px 14px;
   cursor: pointer;
-  margin-bottom: 4px;
+  transition: background 0.15s ease, color 0.15s ease;
 }
 
-.wiki-rev-item:hover {
+.wiki-rev-item:hover,
+.wiki-rev-item--active {
   background: var(--td-bg-color-container-hover);
 }
 
-.wiki-rev-item--active {
-  background: var(--td-brand-color-light);
+.wiki-rev-item--active .wiki-rev-version,
+.wiki-rev-item--active .wiki-rev-current-label {
+  color: var(--td-brand-color);
 }
 
-.wiki-rev-item-head {
+.wiki-rev-item-primary {
   display: flex;
   align-items: center;
-  gap: 6px;
-  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
 }
 
 .wiki-rev-version {
-  font-weight: 600;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
   font-family: var(--td-font-family-mono, monospace);
+  color: var(--td-text-color-primary);
+  transition: color 0.15s ease;
 }
 
-.wiki-rev-item-meta {
-  margin-top: 4px;
+.wiki-rev-current-label {
   font-size: 12px;
+  line-height: 16px;
   color: var(--td-text-color-placeholder);
-  word-break: break-all;
+  transition: color 0.15s ease;
 }
 
-.wiki-rev-load-more,
+.wiki-rev-item-secondary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 2px;
+  min-width: 0;
+  font-size: 11px;
+  line-height: 16px;
+  color: var(--td-text-color-placeholder);
+}
+
+.wiki-rev-time {
+  font-size: 11px;
+  color: var(--td-text-color-placeholder);
+  white-space: nowrap;
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.wiki-rev-load-more {
+  padding: 8px 0 4px;
+}
+
 .wiki-rev-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 14px;
   text-align: center;
-  padding: 12px 0;
-  font-size: 13px;
+  font-size: 12px;
+  line-height: 1.5;
   color: var(--td-text-color-placeholder);
 }
 
 .wiki-rev-detail {
   flex: 1;
   min-width: 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  padding: 16px 20px;
 }
 
 .wiki-rev-detail-toolbar {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
   margin-bottom: 12px;
@@ -352,7 +405,24 @@ function formatTime(iso?: string): string {
 }
 
 .wiki-rev-detail-title {
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.wiki-rev-detail-version {
   font-weight: 600;
+  font-family: var(--td-font-family-mono, monospace);
+  font-size: 13px;
+  color: var(--td-text-color-secondary);
+  flex-shrink: 0;
+}
+
+.wiki-rev-detail-name {
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--td-text-color-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -365,10 +435,59 @@ function formatTime(iso?: string): string {
   flex-shrink: 0;
 }
 
+.wiki-rev-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 6px;
+  background: var(--td-bg-color-container);
+  border: 1px solid var(--td-component-stroke);
+}
+
+.wiki-rev-mode-btn {
+  padding: 4px 10px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--td-text-color-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.wiki-rev-mode-btn:hover {
+  color: var(--td-text-color-primary);
+}
+
+.wiki-rev-mode-btn.active {
+  color: var(--td-brand-color);
+  background: var(--td-bg-color-container);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  font-weight: 500;
+}
+
 .wiki-rev-detail-hint {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: var(--td-text-color-placeholder);
-  padding: 40px 0;
+  padding: 24px;
   text-align: center;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.wiki-rev-detail-loading {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--td-text-color-placeholder);
+  font-size: 13px;
 }
 
 .wiki-rev-diff {
@@ -389,9 +508,10 @@ function formatTime(iso?: string): string {
   flex: 1;
   overflow: auto;
   margin: 0;
-  padding: 12px;
-  background: var(--td-bg-color-page);
-  border-radius: 6px;
+  padding: 12px 14px;
+  background: var(--td-bg-color-container);
+  border: 1px solid var(--td-component-stroke);
+  border-radius: 8px;
   font-size: 12px;
   line-height: 1.7;
   font-family: var(--td-font-family-mono, monospace);
@@ -404,13 +524,39 @@ function formatTime(iso?: string): string {
 }
 
 .wiki-rev-diff-line--add {
-  background: var(--td-success-color-1);
-  color: var(--td-success-color-7);
+  background: rgba(7, 192, 95, 0.08);
+  color: var(--td-text-color-primary);
 }
 
 .wiki-rev-diff-line--del {
-  background: var(--td-error-color-1);
-  color: var(--td-error-color-6);
-  text-decoration: line-through;
+  background: rgba(213, 73, 65, 0.06);
+  color: var(--td-text-color-secondary);
+}
+</style>
+
+<style lang="less">
+.wiki-revision-drawer {
+  .t-drawer__content-wrapper,
+  .t-drawer__content {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .t-drawer__header {
+    padding: 20px 24px;
+    border-bottom: 1px solid var(--td-component-stroke);
+    flex-shrink: 0;
+  }
+
+  .t-drawer__body {
+    flex: 1;
+    min-height: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    background: var(--td-bg-color-container);
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- Align Wiki sidebar list hover/active states with the session sidebar (light gray background + green text).
- Rework revision history drawer: session-style version list, full-height layout fix, lighter diff highlighting.
- Move page actions (history / edit / delete) to icon buttons in the title row; tighten top spacing so search and back navigation align with the content divider.
- Resolve source document titles at display time when `source_refs` only store knowledge IDs (pipeline ingest intentionally omits filenames).

The revision history API, migrations, and core editor flow landed in `80a5003` (already on `main`). This PR is the follow-up UI polish from manual review.

## Test plan
- [ ] Open a Wiki page: sidebar selection uses session-like hover/active styling (not heavy green blocks).
- [ ] Verify left search box and right back link align at the top of the split pane.
- [ ] Open version history: left list fills drawer height; empty state centered; diff/raw toggle works.
- [ ] Edit a page inline: editor card layout, conflict alert, save/cancel.
- [ ] Create page dialog still renders correctly.
- [ ] Bottom「来源文档」shows document titles (not truncated UUIDs) for pipeline-generated pages.