### PR TITLE
fix(migrations): renumber knowledge metadata index migration to 000076

### DIFF
--- a/migrations/versioned/000075_knowledge_metadata_external_id_index.down.sql
+++ b/migrations/versioned/000075_knowledge_metadata_external_id_index.down.sql
@@ -1,3 +1,0 @@
-DO $$ BEGIN RAISE NOTICE '[Migration 000075] Dropping knowledge metadata external_id prefix index...'; END $$;
-
-DROP INDEX IF EXISTS idx_knowledges_kb_metadata_external_id;

--- a/migrations/versioned/000076_knowledge_metadata_external_id_index.down.sql
+++ b/migrations/versioned/000076_knowledge_metadata_external_id_index.down.sql
@@ -1,0 +1,3 @@
+DO $$ BEGIN RAISE NOTICE '[Migration 000076] Dropping knowledge metadata external_id prefix index...'; END $$;
+
+DROP INDEX IF EXISTS idx_knowledges_kb_metadata_external_id;

--- a/migrations/versioned/000076_knowledge_metadata_external_id_index.up.sql
+++ b/migrations/versioned/000076_knowledge_metadata_external_id_index.up.sql
@@ -1,4 +1,4 @@
-DO $$ BEGIN RAISE NOTICE '[Migration 000075] Adding knowledge metadata external_id prefix index...'; END $$;
+DO $$ BEGIN RAISE NOTICE '[Migration 000076] Adding knowledge metadata external_id prefix index...'; END $$;
 
 -- Speeds up the datasource subtree sweep (repository FindByMetadataKeyPrefix),
 -- which runs on every re-sync of a multi-item source node:


### PR DESCRIPTION
## Summary
- Renumber `knowledge_metadata_external_id_index` migration from `000075` to `000076` to resolve a duplicate migration version conflict with `000075_wiki_page_revisions`.
- Update migration notice messages to match the new version number.

## Test plan
- [ ] Run migrations on a fresh database and confirm both `000075_wiki_page_revisions` and `000076_knowledge_metadata_external_id_index` apply in order without version conflicts.
- [ ] Verify `idx_knowledges_kb_metadata_external_id` is created successfully after migration `000076`.