### PR TITLE
fix: 在chunk overlap中保留更细的语义边界

### DIFF
--- a/internal/infrastructure/chunker/splitter.go
+++ b/internal/infrastructure/chunker/splitter.go
@@ -593,7 +593,7 @@ func buildChunk(units []splitUnit, seq int) Chunk {
 //
 //  1. paragraph break (\n\n / \r\n\r\n)
 //  2. line break (\n / \r\n)
-//  3. sentence end (。？！, ". ", and English ?/!)
+//  3. sentence end (。？！, ". ", "? ", "! ")
 //
 // Priority wins first; for boundaries with the same priority, the earliest
 // one in the window wins so the useful overlap is as large as possible. The
@@ -796,12 +796,10 @@ func findSemanticOverlapBoundaryEndingAtOrAfter(text string, minEnd int) (int, b
 		switch runes[i] {
 		case '。', '？', '！':
 			consider(i, i+1, 3)
-		case '.':
+		case '.', '?', '!':
 			if i+1 < len(runes) && runes[i+1] == ' ' {
 				consider(i, i+2, 3)
 			}
-		case '?', '!':
-			consider(i, i+1, 3)
 		}
 	}
 

--- a/internal/infrastructure/chunker/splitter.go
+++ b/internal/infrastructure/chunker/splitter.go
@@ -122,6 +122,7 @@ var protectedPatterns = []*regexp.Regexp{
 	regexp.MustCompile("(?m)[ ]*(?:\\|[^|\\n]*)+\\|[\\r\\n]+\\s*(?:\\|\\s*:?-{3,}:?\\s*)+\\|[\\r\\n]+"), // Table header+separator
 	regexp.MustCompile("(?m)[ ]*(?:\\|[^|\\n]*)+\\|[\\r\\n]+"),                                          // Table rows
 	regexp.MustCompile("(?s)```(?:\\w+)?[\\r\\n].*?```"),                                                // Fenced code blocks
+	regexp.MustCompile("`[^`\\r\\n]+`"),                                                                 // Markdown inline code
 }
 
 type span struct {
@@ -580,57 +581,234 @@ func buildChunk(units []splitUnit, seq int) Chunk {
 	}
 }
 
-// computeOverlap returns the units to keep for overlap and their total rune length.
+// computeOverlap returns the semantic suffix to keep for overlap and its total
+// rune length.
+//
+// The configured overlap is a hard upper bound, not a raw character slice.
+// Within that tail window we look for semantic boundaries using this priority:
+//
+//  1. paragraph break (\n\n / \r\n\r\n)
+//  2. line break (\n / \r\n)
+//  3. sentence end (。？！, ". ", and English ?/!)
+//
+// Priority wins first; for boundaries with the same priority, the earliest
+// one in the window wins so the useful overlap is as large as possible. The
+// next chunk starts immediately after the selected separator. If the window
+// has no valid semantic boundary, no overlap is retained. This keeps overlap
+// deterministic and bounded while allowing a boundary inside a large split
+// unit (the previous implementation could only retain whole units and often
+// collapsed to zero overlap for ordinary paragraphs).
 func computeOverlap(current []splitUnit, chunkOverlap, chunkSize, nextLen int) ([]splitUnit, int) {
 	if chunkOverlap <= 0 {
 		return nil, 0
 	}
 
-	// Walk backward from end, accumulating overlap
-	overlapLen := 0
-	startIdx := len(current)
-	for i := len(current) - 1; i >= 0; i-- {
-		uLen := runeLen(current[i].text)
-		if overlapLen+uLen > chunkOverlap {
-			break
-		}
-		// Check that overlap + next unit fits in chunk
-		if overlapLen+uLen+nextLen > chunkSize {
-			break
-		}
-		overlapLen += uLen
-		startIdx = i
+	// Overlap is part of the next chunk's total size. When the incoming unit
+	// is already close to the chunk budget, shrink the search window rather
+	// than creating an oversized chunk.
+	maxOverlap := chunkOverlap
+	if remaining := chunkSize - nextLen; remaining < maxOverlap {
+		maxOverlap = remaining
 	}
-
-	// Skip leading separator-only and header-marker units in the overlap
-	for startIdx < len(current) {
-		u := current[startIdx]
-		isHeaderMarker := u.start == u.end
-		trimmed := strings.TrimSpace(u.text)
-		if isHeaderMarker || trimmed == "" || isSeparatorOnly(u.text) {
-			overlapLen -= runeLen(u.text)
-			startIdx++
-		} else {
-			break
-		}
-	}
-
-	if startIdx >= len(current) {
+	if maxOverlap <= 0 {
 		return nil, 0
 	}
 
-	overlap := make([]splitUnit, len(current)-startIdx)
-	copy(overlap, current[startIdx:])
+	window := semanticOverlapWindow(current, maxOverlap)
+	if len(window) == 0 {
+		return nil, 0
+	}
+
+	windowText := unitsText(window)
+	boundaryEnd, ok := findSemanticOverlapBoundary(windowText)
+	if !ok {
+		return nil, 0
+	}
+
+	overlap := trimUnitsPrefix(window, boundaryEnd)
+	overlapLen := 0
+	for _, u := range overlap {
+		overlapLen += runeLen(u.text)
+	}
+	if overlapLen <= 0 || strings.TrimSpace(unitsText(overlap)) == "" {
+		return nil, 0
+	}
 	return overlap, overlapLen
 }
 
-func isSeparatorOnly(s string) bool {
-	for _, r := range s {
-		if r != '\n' && r != '\r' && r != ' ' && r != '\t' && r != '。' {
-			return false
+// semanticOverlapWindow returns at most maxLen source-backed runes from the
+// tail of current. It may slice inside the first retained splitUnit so a
+// semantic boundary inside a large paragraph remains discoverable. Synthetic
+// zero-width units (for example repeated table headers) form a hard barrier:
+// crossing them would break the Start/End-to-Content source invariant.
+func semanticOverlapWindow(current []splitUnit, maxLen int) []splitUnit {
+	if maxLen <= 0 || len(current) == 0 {
+		return nil
+	}
+
+	remaining := maxLen
+	reversed := make([]splitUnit, 0, len(current))
+	for i := len(current) - 1; i >= 0 && remaining > 0; i-- {
+		u := current[i]
+		uLen := runeLen(u.text)
+		if uLen == 0 {
+			continue
+		}
+		// Header markers contain generated text but occupy no source range.
+		// Do not include or cross them when deriving an overlap suffix.
+		if u.start == u.end || u.end-u.start != uLen {
+			break
+		}
+
+		if uLen <= remaining {
+			reversed = append(reversed, u)
+			remaining -= uLen
+			continue
+		}
+
+		runes := []rune(u.text)
+		start := uLen - remaining
+		reversed = append(reversed, splitUnit{
+			text:  string(runes[start:]),
+			start: u.start + start,
+			end:   u.end,
+		})
+		remaining = 0
+	}
+
+	if len(reversed) == 0 {
+		return nil
+	}
+	window := make([]splitUnit, len(reversed))
+	for i := range reversed {
+		window[len(reversed)-1-i] = reversed[i]
+	}
+	return window
+}
+
+type semanticOverlapBoundary struct {
+	start    int
+	end      int
+	priority int
+}
+
+// findSemanticOverlapBoundary returns the rune offset immediately after the
+// selected separator. Boundaries inside protected Markdown/code/math regions
+// are ignored, and a boundary is invalid when only whitespace follows it.
+func findSemanticOverlapBoundary(text string) (int, bool) {
+	runes := []rune(text)
+	if len(runes) == 0 {
+		return 0, false
+	}
+
+	protected := protectedSpansRune(text, protectedSpans(text))
+	insideProtected := func(pos int) bool {
+		for _, p := range protected {
+			if pos < p.start {
+				return false
+			}
+			if pos >= p.start && pos < p.end {
+				return true
+			}
+		}
+		return false
+	}
+	hasMeaningfulTail := func(end int) bool {
+		return end >= 0 && end < len(runes) && strings.TrimSpace(string(runes[end:])) != ""
+	}
+
+	var best semanticOverlapBoundary
+	found := false
+	consider := func(start, end, priority int) {
+		if start < 0 || end <= start || end > len(runes) || insideProtected(start) || !hasMeaningfulTail(end) {
+			return
+		}
+		candidate := semanticOverlapBoundary{start: start, end: end, priority: priority}
+		if !found || candidate.priority < best.priority ||
+			(candidate.priority == best.priority && candidate.start < best.start) {
+			best = candidate
+			found = true
 		}
 	}
-	return true
+
+	// Mark paragraph-break runes so their component newlines are not also
+	// emitted as lower-priority line-break candidates.
+	paragraphRune := make([]bool, len(runes))
+	for i := 0; i < len(runes); i++ {
+		switch {
+		case i+3 < len(runes) && runes[i] == '\r' && runes[i+1] == '\n' &&
+			runes[i+2] == '\r' && runes[i+3] == '\n':
+			consider(i, i+4, 1)
+			for j := i; j < i+4; j++ {
+				paragraphRune[j] = true
+			}
+			i += 3
+		case i+1 < len(runes) && runes[i] == '\n' && runes[i+1] == '\n':
+			consider(i, i+2, 1)
+			paragraphRune[i], paragraphRune[i+1] = true, true
+			i++
+		}
+	}
+
+	for i := 0; i < len(runes); i++ {
+		if paragraphRune[i] {
+			continue
+		}
+		if runes[i] == '\r' && i+1 < len(runes) && runes[i+1] == '\n' && !paragraphRune[i+1] {
+			consider(i, i+2, 2)
+			i++
+			continue
+		}
+		if runes[i] == '\n' {
+			consider(i, i+1, 2)
+		}
+	}
+
+	for i := 0; i < len(runes); i++ {
+		switch runes[i] {
+		case '。', '？', '！':
+			consider(i, i+1, 3)
+		case '.':
+			if i+1 < len(runes) && runes[i+1] == ' ' {
+				consider(i, i+2, 3)
+			}
+		case '?', '!':
+			consider(i, i+1, 3)
+		}
+	}
+
+	if !found {
+		return 0, false
+	}
+	return best.end, true
+}
+
+// trimUnitsPrefix removes prefixLen source runes while preserving the
+// remaining units' original positions. prefixLen is relative to unitsText.
+func trimUnitsPrefix(units []splitUnit, prefixLen int) []splitUnit {
+	if prefixLen <= 0 {
+		out := make([]splitUnit, len(units))
+		copy(out, units)
+		return out
+	}
+
+	remaining := prefixLen
+	out := make([]splitUnit, 0, len(units))
+	for _, u := range units {
+		uLen := runeLen(u.text)
+		if remaining >= uLen {
+			remaining -= uLen
+			continue
+		}
+		if remaining > 0 {
+			runes := []rune(u.text)
+			u.text = string(runes[remaining:])
+			u.start += remaining
+			remaining = 0
+		}
+		out = append(out, u)
+	}
+	return out
 }
 
 // ParentChildResult holds the two-level chunking output.

--- a/internal/infrastructure/chunker/splitter.go
+++ b/internal/infrastructure/chunker/splitter.go
@@ -585,7 +585,11 @@ func buildChunk(units []splitUnit, seq int) Chunk {
 // rune length.
 //
 // The configured overlap is a hard upper bound, not a raw character slice.
-// Within that tail window we look for semantic boundaries using this priority:
+// Boundary detection may inspect up to four additional runes immediately
+// before that tail window so a separator cut by the window boundary remains
+// visible. A candidate is eligible only when its last rune is at position -1
+// relative to the original window, or later, so retained content never exceeds
+// the overlap limit. Eligible boundaries use this priority:
 //
 //  1. paragraph break (\n\n / \r\n\r\n)
 //  2. line break (\n / \r\n)
@@ -598,6 +602,8 @@ func buildChunk(units []splitUnit, seq int) Chunk {
 // deterministic and bounded while allowing a boundary inside a large split
 // unit (the previous implementation could only retain whole units and often
 // collapsed to zero overlap for ordinary paragraphs).
+const semanticOverlapLookbehind = 4 // rune length of the longest separator: \r\n\r\n
+
 func computeOverlap(current []splitUnit, chunkOverlap, chunkSize, nextLen int) ([]splitUnit, int) {
 	if chunkOverlap <= 0 {
 		return nil, 0
@@ -614,13 +620,20 @@ func computeOverlap(current []splitUnit, chunkOverlap, chunkSize, nextLen int) (
 		return nil, 0
 	}
 
-	window := semanticOverlapWindow(current, maxOverlap)
+	window := semanticOverlapWindow(current, maxOverlap+semanticOverlapLookbehind)
 	if len(window) == 0 {
 		return nil, 0
 	}
 
 	windowText := unitsText(window)
-	boundaryEnd, ok := findSemanticOverlapBoundary(windowText)
+	// Coordinates before originalWindowStart are the lookbehind region. With
+	// end-exclusive offsets, requiring boundaryEnd >= originalWindowStart is
+	// equivalent to requiring the separator's final rune to be at -1 or later.
+	originalWindowStart := runeLen(windowText) - maxOverlap
+	if originalWindowStart < 0 {
+		originalWindowStart = 0
+	}
+	boundaryEnd, ok := findSemanticOverlapBoundaryEndingAtOrAfter(windowText, originalWindowStart)
 	if !ok {
 		return nil, 0
 	}
@@ -630,7 +643,7 @@ func computeOverlap(current []splitUnit, chunkOverlap, chunkSize, nextLen int) (
 	for _, u := range overlap {
 		overlapLen += runeLen(u.text)
 	}
-	if overlapLen <= 0 || strings.TrimSpace(unitsText(overlap)) == "" {
+	if overlapLen <= 0 || overlapLen > maxOverlap || strings.TrimSpace(unitsText(overlap)) == "" {
 		return nil, 0
 	}
 	return overlap, overlapLen
@@ -696,8 +709,22 @@ type semanticOverlapBoundary struct {
 // selected separator. Boundaries inside protected Markdown/code/math regions
 // are ignored, and a boundary is invalid when only whitespace follows it.
 func findSemanticOverlapBoundary(text string) (int, bool) {
+	return findSemanticOverlapBoundaryEndingAtOrAfter(text, 0)
+}
+
+// findSemanticOverlapBoundaryEndingAtOrAfter applies the normal priority and
+// earliest-position rules only to candidates whose end-exclusive rune offset
+// is at least minEnd. Filtering before comparison prevents an earlier but
+// ineligible lookbehind separator from hiding a later eligible boundary.
+func findSemanticOverlapBoundaryEndingAtOrAfter(text string, minEnd int) (int, bool) {
 	runes := []rune(text)
 	if len(runes) == 0 {
+		return 0, false
+	}
+	if minEnd < 0 {
+		minEnd = 0
+	}
+	if minEnd > len(runes) {
 		return 0, false
 	}
 
@@ -720,7 +747,8 @@ func findSemanticOverlapBoundary(text string) (int, bool) {
 	var best semanticOverlapBoundary
 	found := false
 	consider := func(start, end, priority int) {
-		if start < 0 || end <= start || end > len(runes) || insideProtected(start) || !hasMeaningfulTail(end) {
+		if start < 0 || end <= start || end < minEnd || end > len(runes) ||
+			insideProtected(start) || !hasMeaningfulTail(end) {
 			return
 		}
 		candidate := semanticOverlapBoundary{start: start, end: end, priority: priority}

--- a/internal/infrastructure/chunker/splitter_test.go
+++ b/internal/infrastructure/chunker/splitter_test.go
@@ -367,6 +367,40 @@ func TestFindSemanticOverlapBoundary_IgnoresProtectedContent(t *testing.T) {
 	}
 }
 
+func TestFindSemanticOverlapBoundary_FiltersEligibilityBeforePriorityAndPosition(t *testing.T) {
+	tests := []struct {
+		name   string
+		text   string
+		minEnd int
+		want   string
+	}{
+		{
+			name:   "earlier ineligible sentence does not hide eligible sentence",
+			text:   "a。bc。XYZ",
+			minEnd: 4,
+			want:   "XYZ",
+		},
+		{
+			name:   "ineligible paragraph does not outrank eligible sentence",
+			text:   "\n\nx?tail",
+			minEnd: 3,
+			want:   "tail",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			end, ok := findSemanticOverlapBoundaryEndingAtOrAfter(tt.text, tt.minEnd)
+			if !ok {
+				t.Fatal("expected eligible semantic overlap boundary")
+			}
+			if got := string([]rune(tt.text)[end:]); got != tt.want {
+				t.Fatalf("overlap tail = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestComputeOverlap_FindsBoundaryInsideLargeUnit(t *testing.T) {
 	text := "abcdefgh。尾巴内容"
 	unit := splitUnit{text: text, start: 100, end: 100 + len([]rune(text))}
@@ -403,6 +437,51 @@ func TestComputeOverlap_RespectsNextChunkCapacity(t *testing.T) {
 	}
 	if overlapLen+5 > 8 {
 		t.Fatalf("overlap plus next content exceeds chunk size: %d + %d > %d", overlapLen, 5, 8)
+	}
+}
+
+func TestComputeOverlap_LookbehindBoundaryEligibility(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{
+			name: "single rune separator ending at minus one is eligible",
+			text: "abcd。WXYZ",
+			want: "WXYZ",
+		},
+		{
+			name: "longest separator ending at minus one is eligible",
+			text: "\r\n\r\nWXYZ",
+			want: "WXYZ",
+		},
+		{
+			name: "separator ending before minus one is ineligible",
+			text: "a。bcWXYZ",
+			want: "",
+		},
+		{
+			name: "separator crossing original window start is eligible",
+			text: "abc. WXY",
+			want: "WXY",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unit := splitUnit{text: tt.text, start: 0, end: len([]rune(tt.text))}
+			overlap, overlapLen := computeOverlap([]splitUnit{unit}, 4, 20, 4)
+			if got := unitsText(overlap); got != tt.want {
+				t.Fatalf("overlap = %q, want %q", got, tt.want)
+			}
+			if overlapLen != len([]rune(tt.want)) {
+				t.Fatalf("overlapLen = %d, want %d", overlapLen, len([]rune(tt.want)))
+			}
+			if overlapLen > 4 {
+				t.Fatalf("overlap exceeds configured limit: %d > 4", overlapLen)
+			}
+		})
 	}
 }
 

--- a/internal/infrastructure/chunker/splitter_test.go
+++ b/internal/infrastructure/chunker/splitter_test.go
@@ -317,13 +317,13 @@ func TestFindSemanticOverlapBoundary_PriorityThenEarliest(t *testing.T) {
 			want: "Second sentence",
 		},
 		{
-			name: "english question mark needs no following space",
-			text: "Question?Answer",
+			name: "english question mark requires following space",
+			text: "Question? Answer",
 			want: "Answer",
 		},
 		{
-			name: "english exclamation mark needs no following space",
-			text: "Warning!Continue",
+			name: "english exclamation mark requires following space",
+			text: "Warning! Continue",
 			want: "Continue",
 		},
 	}
@@ -348,6 +348,7 @@ func TestFindSemanticOverlapBoundary_NoConfiguredSemanticSeparator(t *testing.T)
 		"只有，逗号；分号：冒号",
 		"version1.2 remains one unit",
 		"address 192.168.1.1 remains one unit",
+		"see https://ex.com?q=1&foo=bar",
 	} {
 		if end, ok := findSemanticOverlapBoundary(text); ok {
 			t.Errorf("findSemanticOverlapBoundary(%q) returned boundary at %d", text, end)
@@ -382,7 +383,7 @@ func TestFindSemanticOverlapBoundary_FiltersEligibilityBeforePriorityAndPosition
 		},
 		{
 			name:   "ineligible paragraph does not outrank eligible sentence",
-			text:   "\n\nx?tail",
+			text:   "\n\nx? tail",
 			minEnd: 3,
 			want:   "tail",
 		},
@@ -482,6 +483,31 @@ func TestComputeOverlap_LookbehindBoundaryEligibility(t *testing.T) {
 				t.Fatalf("overlap exceeds configured limit: %d > 4", overlapLen)
 			}
 		})
+	}
+}
+
+func TestSplitText_OverlapDoesNotBreakURLQuery(t *testing.T) {
+	line1 := strings.Repeat("a", 35)
+	text := line1 + "\n" + "https://ex.com?q=1 tail\n" + "more content here"
+	cfg := SplitterConfig{ChunkSize: 40, ChunkOverlap: 10, Separators: []string{"\n\n", "\n"}}
+
+	chunks := SplitText(text, cfg)
+	if len(chunks) < 3 {
+		t.Fatalf("expected at least 3 chunks, got %d: %#v", len(chunks), chunks)
+	}
+	if strings.HasPrefix(chunks[2].Content, "q=1") {
+		t.Fatalf("overlap broke at URL query string: chunk[2]=%q", chunks[2].Content)
+	}
+}
+
+func TestBuildUnitsWithProtection_InlineCodeNotSplit(t *testing.T) {
+	text := "intro `code.here` suffix"
+	units := buildUnitsWithProtection(text, protectedSpans(text), []string{"\n"}, 0)
+
+	for _, u := range units {
+		if strings.Contains(u.text, "code.here") && !strings.Contains(u.text, "`code.here`") {
+			t.Fatalf("inline code period split unit: %q", u.text)
+		}
 	}
 }
 

--- a/internal/infrastructure/chunker/splitter_test.go
+++ b/internal/infrastructure/chunker/splitter_test.go
@@ -270,6 +270,163 @@ func TestSplitText_OverlapChunks_NonNegativeStart(t *testing.T) {
 	}
 }
 
+func TestFindSemanticOverlapBoundary_PriorityThenEarliest(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{
+			name: "paragraph outranks earlier sentence and line",
+			text: "第一句。第二句\n普通换行后的内容\n\n最后一段",
+			want: "最后一段",
+		},
+		{
+			name: "earliest sentence wins within same priority",
+			text: "第一句。第二句。第三句",
+			want: "第二句。第三句",
+		},
+		{
+			name: "windows paragraph break",
+			text: "第一段。\r\n\r\n第二段",
+			want: "第二段",
+		},
+		{
+			name: "line outranks earlier sentence",
+			text: "第一句。第一行\n第二行",
+			want: "第二行",
+		},
+		{
+			name: "windows line break",
+			text: "第一句。第一行\r\n第二行",
+			want: "第二行",
+		},
+		{
+			name: "chinese question mark",
+			text: "第一句？第二句",
+			want: "第二句",
+		},
+		{
+			name: "chinese exclamation mark",
+			text: "第一句！第二句",
+			want: "第二句",
+		},
+		{
+			name: "english period requires following space",
+			text: "First sentence. Second sentence",
+			want: "Second sentence",
+		},
+		{
+			name: "english question mark needs no following space",
+			text: "Question?Answer",
+			want: "Answer",
+		},
+		{
+			name: "english exclamation mark needs no following space",
+			text: "Warning!Continue",
+			want: "Continue",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			end, ok := findSemanticOverlapBoundary(tt.text)
+			if !ok {
+				t.Fatal("expected semantic overlap boundary")
+			}
+			got := string([]rune(tt.text)[end:])
+			if got != tt.want {
+				t.Fatalf("overlap tail = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindSemanticOverlapBoundary_NoConfiguredSemanticSeparator(t *testing.T) {
+	for _, text := range []string{
+		"没有任何语义分隔符的连续文本",
+		"只有，逗号；分号：冒号",
+		"version1.2 remains one unit",
+		"address 192.168.1.1 remains one unit",
+	} {
+		if end, ok := findSemanticOverlapBoundary(text); ok {
+			t.Errorf("findSemanticOverlapBoundary(%q) returned boundary at %d", text, end)
+		}
+	}
+}
+
+func TestFindSemanticOverlapBoundary_IgnoresProtectedContent(t *testing.T) {
+	for _, text := range []string{
+		"代码是 `fmt.Println(\"hello. world\")` 后续内容",
+		"代码块 ```go\nfmt.Println(\"hello. world\")\n``` 后续内容",
+		"公式 $$x. y$$ 后续内容",
+	} {
+		if end, ok := findSemanticOverlapBoundary(text); ok {
+			t.Errorf("findSemanticOverlapBoundary(%q) returned protected boundary at %d", text, end)
+		}
+	}
+}
+
+func TestComputeOverlap_FindsBoundaryInsideLargeUnit(t *testing.T) {
+	text := "abcdefgh。尾巴内容"
+	unit := splitUnit{text: text, start: 100, end: 100 + len([]rune(text))}
+
+	overlap, overlapLen := computeOverlap([]splitUnit{unit}, 8, 32, 8)
+	if got := unitsText(overlap); got != "尾巴内容" {
+		t.Fatalf("overlap = %q, want %q", got, "尾巴内容")
+	}
+	if overlapLen != len([]rune("尾巴内容")) {
+		t.Fatalf("overlapLen = %d, want %d", overlapLen, len([]rune("尾巴内容")))
+	}
+	if len(overlap) != 1 || overlap[0].start != 109 || overlap[0].end != 113 {
+		t.Fatalf("overlap source span = %+v, want [109,113)", overlap)
+	}
+}
+
+func TestComputeOverlap_NoBoundaryMeansNoOverlap(t *testing.T) {
+	text := "abcdefgh尾巴内容"
+	unit := splitUnit{text: text, start: 0, end: len([]rune(text))}
+
+	overlap, overlapLen := computeOverlap([]splitUnit{unit}, 8, 32, 8)
+	if len(overlap) != 0 || overlapLen != 0 {
+		t.Fatalf("expected no overlap, got %q (%d)", unitsText(overlap), overlapLen)
+	}
+}
+
+func TestComputeOverlap_RespectsNextChunkCapacity(t *testing.T) {
+	text := "abcdefgh。尾巴"
+	unit := splitUnit{text: text, start: 0, end: len([]rune(text))}
+
+	overlap, overlapLen := computeOverlap([]splitUnit{unit}, 10, 8, 5)
+	if got := unitsText(overlap); got != "尾巴" {
+		t.Fatalf("overlap = %q, want %q", got, "尾巴")
+	}
+	if overlapLen+5 > 8 {
+		t.Fatalf("overlap plus next content exceeds chunk size: %d + %d > %d", overlapLen, 5, 8)
+	}
+}
+
+func TestSplitText_SemanticOverlapInsideParagraph(t *testing.T) {
+	first := strings.Repeat("甲", 15) + "。尾巴"
+	text := first + "\n\n" + "后续内容"
+	cfg := SplitterConfig{
+		ChunkSize:    20,
+		ChunkOverlap: 10,
+		Separators:   []string{"\n\n", "\n", "。"},
+	}
+
+	chunks := SplitText(text, cfg)
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d: %#v", len(chunks), chunks)
+	}
+	if !strings.HasPrefix(chunks[1].Content, "尾巴\n\n") {
+		t.Fatalf("second chunk should start at the sentence boundary inside the large unit, got %q", chunks[1].Content)
+	}
+	if got := chunks[1].End - chunks[1].Start; got != len([]rune(chunks[1].Content)) {
+		t.Fatalf("position invariant broken: span=%d content=%d", got, len([]rune(chunks[1].Content)))
+	}
+}
+
 func TestBuildUnitsWithProtection_RuneOffsets(t *testing.T) {
 	text := "你好世界"
 	units := buildUnitsWithProtection(text, nil, []string{"\n"}, 0)


### PR DESCRIPTION
## Description

本 PR 优化文本分块过程中的 overlap 生成逻辑，系统性降低 overlap 为 0 的可能性。

当前 chunk 切分流程会先递归拆分文本，生成不同大小的语义单元，再将这些语义单元合并为 chunk。原 overlap 算法只能从上一个 chunk 末尾开始保留完整的语义单元。如果末尾语义单元本身大于 overlap 上限，该单元就无法被保留，最终可能导致 overlap 变为 0。

本 PR 保持现有 overlap 大小算法和 chunkSize 限制不变，主要增加在允许的 overlap 范围内选择语义边界的方式（而非直接看上一个语义单元大小是不是超了）：

1. 在上一个 chunk 末尾、实际 overlap 上限覆盖的字符范围内寻找合法的语义分隔符。

2. 为避免 overlap 窗口起点刚好落在语义分隔符内部，额外向前检查最多 4 个字符。4 是当前最长语义分隔符 `\r\n\r\n` 的字符长度。额外字符只用于补全分隔符，不会扩大最终 overlap。

3. 只有最后一个字符位于原 overlap 窗口的 `-1` 位置或更靠后的分隔符才是合法候选。任何会导致最终 overlap 超过上限的候选都会被忽略。

4. 合法候选按照以下优先级选择：

   - 第一优先级：段落分隔符 `\n\n`、`\r\n\r\n`
   - 第二优先级：普通换行 `\n`、`\r\n`
   - 第三优先级：句末分隔符 `。`、`？`、`！`、`. `、`?`、`!`

5. 优先选择等级最高的语义分隔符；同一优先级存在多个候选时，选择最早出现的分隔符，以保留更多完整上下文。

6. 选中分隔符后，从分隔符之后开始生成 overlap，该位置同时作为下一个 chunk 的起点。分隔符本身不会出现在 overlap 开头。

7. Markdown 代码块、行内代码和数学公式等受保护区域中的分隔符不会参与边界选择。

8. 如果范围内不存在合法语义分隔符，则不生成 overlap，不会为了满足 overlap 大小而从文本中间强制截断。

通过允许在较大的语义单元末尾继续寻找语义边界，本次修改可以在严格遵守 overlap 和 chunk 大小上限的前提下，减少因语义单元过大而产生零 overlap 的情况，并降低 chunk 上下文在句子、实体或关系中间断裂的可能性。

本次修改不涉及公开 API、配置格式或数据库结构变更。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

已完成以下验证：

- 使用 `gofmt` 格式化修改的 Go 文件。
- `git diff --check` 通过。
- 使用 Go 1.26 Podman 容器运行：

  ```text
  go test ./internal/infrastructure/chunker
  ```

- 测试结果：

  ```text
  ok github.com/Tencent/WeKnora/internal/infrastructure/chunker
  ```

回归测试覆盖：

- 段落、普通换行和句子三级边界优先级。
- 同一优先级选择最早出现的分隔符。
- LF 和 Windows CRLF 换行。
- 中文句号、问号和感叹号。
- 英文句号加空格、问号和感叹号。
- 版本号和 IP 地址中的英文句号不会被误判。
- 在大语义单元内部寻找 overlap 边界。
- 没有合法语义分隔符时不生成 overlap。
- Markdown 代码块、行内代码和数学公式保护。
- 根据下一个 chunk 的剩余空间限制实际 overlap。
- 单字符分隔符恰好在原 overlap 窗口的 `-1` 位置结束。
- Windows 段落分隔符 `\r\n\r\n` 恰好在原 overlap 窗口前结束。
- 在 `-1` 位置之前结束的分隔符被判定为不合法。
- 跨越原 overlap 窗口起点的分隔符可以被完整识别。
- 不合法的高优先级或更早分隔符不会遮挡后面的合法候选。
- 最终 overlap 不超过配置上限。
- chunk 内容与原文位置保持一致。

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A — no user-visible UI changes