### PR TITLE
fix(chat): prevent duplicate terminal answer events

### DIFF
--- a/internal/application/service/chat_pipeline/chat_completion_stream.go
+++ b/internal/application/service/chat_pipeline/chat_completion_stream.go
@@ -112,6 +112,7 @@ func (p *PluginChatCompletionStream) OnEvent(ctx context.Context,
 		thinkingID := fmt.Sprintf("%s-thinking", uuid.New().String()[:8])
 		answerID := fmt.Sprintf("%s-answer", uuid.New().String()[:8])
 		thinkingOpen := false
+		answerCompleted := false
 
 		closeThinking := func() {
 			if !thinkingOpen {
@@ -216,9 +217,17 @@ func (p *PluginChatCompletionStream) OnEvent(ctx context.Context,
 				}
 
 				if response.ResponseType == types.ResponseTypeAnswer {
+					// Providers can emit a completion once for finish_reason and again
+					// for their EOF sentinel. A final answer is a terminal event for a
+					// single stream, so forwarding a later duplicate would put an answer
+					// after the session's complete event.
+					if answerCompleted {
+						continue
+					}
 					response.Content = answerDecoder.Feed(response.Content)
 					if response.Done {
 						response.Content += answerDecoder.Flush()
+						answerCompleted = true
 					}
 					closeThinking()
 					eventBus.Emit(ctx, types.Event{

--- a/internal/application/service/chat_pipeline/chat_completion_stream_test.go
+++ b/internal/application/service/chat_pipeline/chat_completion_stream_test.go
@@ -48,7 +48,8 @@ func (b *syncEventBus) finalAnswerContents() []string {
 // closes it, so the stream plugin blocks on the channel until ctx is cancelled
 // — deterministically exercising the ctx.Done() branch.
 type openStreamChat struct {
-	chunks []types.StreamResponse
+	chunks      []types.StreamResponse
+	closeStream bool
 }
 
 func (m *openStreamChat) Chat(context.Context, []chat.Message, *chat.ChatOptions) (*types.ChatResponse, error) {
@@ -62,7 +63,10 @@ func (m *openStreamChat) ChatStream(
 	for _, c := range m.chunks {
 		ch <- c
 	}
-	return ch, nil // intentionally left open
+	if m.closeStream {
+		close(ch)
+	}
+	return ch, nil
 }
 
 func (m *openStreamChat) GetModelName() string { return "mock" }
@@ -115,4 +119,37 @@ func TestStreamDropsIncompleteHandleOnCancel(t *testing.T) {
 	require.Eventually(t, func() bool { return len(bus.finalAnswerContents()) >= 1 }, 2*time.Second, 5*time.Millisecond)
 	time.Sleep(20 * time.Millisecond)
 	require.Equal(t, []string{"hello "}, bus.finalAnswerContents())
+}
+
+func TestStreamIgnoresDuplicateTerminalAnswer(t *testing.T) {
+	bus := &syncEventBus{}
+	model := &openStreamChat{closeStream: true, chunks: []types.StreamResponse{
+		{ResponseType: types.ResponseTypeAnswer, Content: "hello"},
+		{ResponseType: types.ResponseTypeAnswer, Done: true},
+		// Some providers repeat the same terminal response when their EOF
+		// sentinel is received after finish_reason.
+		{ResponseType: types.ResponseTypeAnswer, Done: true},
+	}}
+
+	chatManage := &types.ChatManage{}
+	chatManage.SessionID = "sess-duplicate-done"
+	chatManage.EventBus = bus
+	plugin := &PluginChatCompletionStream{modelService: &stubModelService{model: model}}
+	require.Nil(t, plugin.OnEvent(context.Background(), types.CHAT_COMPLETION_STREAM, chatManage, func() *PluginError { return nil }))
+
+	require.Eventually(t, func() bool {
+		bus.mu.Lock()
+		defer bus.mu.Unlock()
+		return len(bus.events) == 2
+	}, 2*time.Second, 5*time.Millisecond)
+
+	bus.mu.Lock()
+	defer bus.mu.Unlock()
+	var answerEvents []event.AgentFinalAnswerData
+	for _, evt := range bus.events {
+		if evt.Type == types.EventType(event.EventAgentFinalAnswer) {
+			answerEvents = append(answerEvents, evt.Data.(event.AgentFinalAnswerData))
+		}
+	}
+	require.Equal(t, []event.AgentFinalAnswerData{{Content: "hello"}, {Done: true}}, answerEvents)
 }


### PR DESCRIPTION
## Description
Fix duplicate terminal answer events in the non-Agent / Quick Answer streaming path.

Some providers may emit the same logical completion twice (for example, once for `finish_reason` and again for an EOF sentinel). Previously, each `Done=true` response was forwarded as an `EventAgentFinalAnswer`, which could result in an empty answer event being emitted after the session `complete` event.

This change treats the first terminal answer as final and ignores subsequent answer responses for the same stream. A regression test covers the duplicate `Done` scenario.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #2339 

## Testing
Ran:

```bash
go test ./internal/application/service/chat_pipeline -count=1 -v
```
Added TestStreamIgnoresDuplicateTerminalAnswer, which simulates:
answer content="hello" done=false
answer content=""      done=true
answer content=""      done=true
Verified that only one terminal answer event is emitted and no subsequent answer event is produced.

## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
no UI changes.
