### PR TITLE
fix(wiki): prevent finalizing stalls on enqueue failure

### DIFF
--- a/internal/application/repository/task_queue.go
+++ b/internal/application/repository/task_queue.go
@@ -93,6 +93,70 @@ func (r *taskPendingOpsRepository) EnqueueIfKnowledgeBaseActive(
 	return accepted, err
 }
 
+// SeedKnowledgeFinalizingWithPendingOp commits the finalizing counter and the
+// durable operation that owns one slot in the same transaction. This closes
+// the crash window where a knowledge row could enter finalizing before its
+// Wiki operation existed.
+func (r *taskPendingOpsRepository) SeedKnowledgeFinalizingWithPendingOp(
+	ctx context.Context,
+	knowledgeID string,
+	expectedSubtasks int,
+	op *types.TaskPendingOp,
+) (bool, error) {
+	if knowledgeID == "" {
+		return false, errors.New("task pending ops: knowledge_id is required")
+	}
+	if expectedSubtasks <= 0 {
+		return false, errors.New("task pending ops: expected_subtasks must be positive")
+	}
+	if err := preparePendingOp(op); err != nil {
+		return false, err
+	}
+	if op.Scope != types.TaskScopeKnowledgeBase {
+		return false, errors.New("task pending ops: finalizing seed requires knowledge_base scope")
+	}
+
+	promoted := false
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		query := tx.Model(&types.KnowledgeBase{}).
+			Select("id").
+			Where("id = ? AND tenant_id = ?", op.ScopeID, op.TenantID)
+		if tx.Dialector.Name() == "postgres" {
+			query = query.Clauses(clause.Locking{Strength: "SHARE"})
+		}
+		var kb types.KnowledgeBase
+		if err := query.Take(&kb).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil
+			}
+			return err
+		}
+
+		res := tx.Model(&types.Knowledge{}).
+			Where(
+				"id = ? AND tenant_id = ? AND knowledge_base_id = ? AND parse_status = ?",
+				knowledgeID, op.TenantID, op.ScopeID, types.ParseStatusProcessing,
+			).
+			Updates(map[string]interface{}{
+				"parse_status":           types.ParseStatusFinalizing,
+				"pending_subtasks_count": expectedSubtasks,
+				"updated_at":             time.Now(),
+			})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return nil
+		}
+		if err := tx.Create(op).Error; err != nil {
+			return err
+		}
+		promoted = true
+		return nil
+	})
+	return promoted, err
+}
+
 // PeekBatch returns up to `limit` rows for the (task_type, scope, scope_id)
 // tuple ordered by id ASC. Rows are not removed; callers must
 // DeleteByIDs once they have been consumed (or IncrFailCount and leave

--- a/internal/application/repository/task_queue_test.go
+++ b/internal/application/repository/task_queue_test.go
@@ -51,6 +51,26 @@ CREATE TABLE IF NOT EXISTS task_dead_letters (
 );
 `
 
+const taskQueueKnowledgeBaseTestDDL = `
+CREATE TABLE IF NOT EXISTS knowledge_bases (
+    id         VARCHAR(64) PRIMARY KEY,
+    tenant_id  INTEGER NOT NULL,
+    deleted_at DATETIME
+);
+`
+
+const taskQueueKnowledgeTestDDL = `
+CREATE TABLE IF NOT EXISTS knowledges (
+    id                     VARCHAR(64) PRIMARY KEY,
+    tenant_id              INTEGER NOT NULL,
+    knowledge_base_id      VARCHAR(64) NOT NULL,
+    parse_status           VARCHAR(32) NOT NULL,
+    pending_subtasks_count INTEGER NOT NULL DEFAULT 0,
+    updated_at             DATETIME,
+    deleted_at             DATETIME
+);
+`
+
 func setupTaskQueueTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
@@ -70,6 +90,100 @@ func makePendingOp(taskType, scope, scopeID, op, dedup string, payload []byte) *
 		DedupKey: dedup,
 		Payload:  payload,
 	}
+}
+
+func setupFinalizingPendingOpTest(t *testing.T) (*gorm.DB, interfaces.TaskPendingOpsFinalizingSeeder) {
+	t.Helper()
+	db := setupTaskQueueTestDB(t)
+	repo := NewTaskPendingOpsRepository(db)
+	seeder, ok := repo.(interfaces.TaskPendingOpsFinalizingSeeder)
+	require.True(t, ok, "task pending repository must support atomic finalizing handoff")
+	require.NoError(t, db.Exec(taskQueueKnowledgeBaseTestDDL).Error)
+	require.NoError(t, db.Exec(taskQueueKnowledgeTestDDL).Error)
+	require.NoError(t, db.Exec(
+		`INSERT INTO knowledge_bases (id, tenant_id) VALUES ('kb-1', 1)`,
+	).Error)
+	require.NoError(t, db.Exec(
+		`INSERT INTO knowledges (id, tenant_id, knowledge_base_id, parse_status) VALUES ('knowledge-1', 1, 'kb-1', ?)`,
+		types.ParseStatusProcessing,
+	).Error)
+	return db, seeder
+}
+
+func TestTaskPendingOps_SeedKnowledgeFinalizingWithPendingOpCommitsTogether(t *testing.T) {
+	db, seeder := setupFinalizingPendingOpTest(t)
+	op := makePendingOp(types.TypeWikiIngest, types.TaskScopeKnowledgeBase, "kb-1", "ingest", "knowledge-1", []byte(`{}`))
+
+	promoted, err := seeder.SeedKnowledgeFinalizingWithPendingOp(
+		context.Background(), "knowledge-1", 3, op,
+	)
+
+	require.NoError(t, err)
+	require.True(t, promoted)
+	var knowledge types.Knowledge
+	require.NoError(t, db.Select("parse_status", "pending_subtasks_count").First(&knowledge, "id = ?", "knowledge-1").Error)
+	assert.Equal(t, types.ParseStatusFinalizing, knowledge.ParseStatus)
+	assert.Equal(t, 3, knowledge.PendingSubtasksCount)
+	var count int64
+	require.NoError(t, db.Model(&types.TaskPendingOp{}).Where("dedup_key = ?", "knowledge-1").Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestTaskPendingOps_SeedKnowledgeFinalizingRollsBackWhenPendingOpInsertFails(t *testing.T) {
+	db, seeder := setupFinalizingPendingOpTest(t)
+	require.NoError(t, db.Exec(`DROP TABLE task_pending_ops`).Error)
+	op := makePendingOp(types.TypeWikiIngest, types.TaskScopeKnowledgeBase, "kb-1", "ingest", "knowledge-1", []byte(`{}`))
+
+	promoted, err := seeder.SeedKnowledgeFinalizingWithPendingOp(
+		context.Background(), "knowledge-1", 3, op,
+	)
+
+	require.Error(t, err)
+	assert.False(t, promoted)
+	var knowledge types.Knowledge
+	require.NoError(t, db.Select("parse_status", "pending_subtasks_count").First(&knowledge, "id = ?", "knowledge-1").Error)
+	assert.Equal(t, types.ParseStatusProcessing, knowledge.ParseStatus)
+	assert.Zero(t, knowledge.PendingSubtasksCount)
+}
+
+func TestTaskPendingOps_SeedKnowledgeFinalizingSkipsNonProcessingKnowledge(t *testing.T) {
+	db, seeder := setupFinalizingPendingOpTest(t)
+	require.NoError(t, db.Model(&types.Knowledge{}).
+		Where("id = ?", "knowledge-1").
+		Update("parse_status", types.ParseStatusCancelled).Error)
+	op := makePendingOp(types.TypeWikiIngest, types.TaskScopeKnowledgeBase, "kb-1", "ingest", "knowledge-1", []byte(`{}`))
+
+	promoted, err := seeder.SeedKnowledgeFinalizingWithPendingOp(
+		context.Background(), "knowledge-1", 3, op,
+	)
+
+	require.NoError(t, err)
+	assert.False(t, promoted)
+	var count int64
+	require.NoError(t, db.Model(&types.TaskPendingOp{}).Count(&count).Error)
+	assert.Zero(t, count)
+}
+
+func TestTaskPendingOps_SeedKnowledgeFinalizingSkipsDeletedKnowledgeBase(t *testing.T) {
+	db, seeder := setupFinalizingPendingOpTest(t)
+	require.NoError(t, db.Exec(
+		`UPDATE knowledge_bases SET deleted_at = ? WHERE id = ?`, time.Now(), "kb-1",
+	).Error)
+	op := makePendingOp(types.TypeWikiIngest, types.TaskScopeKnowledgeBase, "kb-1", "ingest", "knowledge-1", []byte(`{}`))
+
+	promoted, err := seeder.SeedKnowledgeFinalizingWithPendingOp(
+		context.Background(), "knowledge-1", 3, op,
+	)
+
+	require.NoError(t, err)
+	assert.False(t, promoted)
+	var knowledge types.Knowledge
+	require.NoError(t, db.Select("parse_status", "pending_subtasks_count").First(&knowledge, "id = ?", "knowledge-1").Error)
+	assert.Equal(t, types.ParseStatusProcessing, knowledge.ParseStatus)
+	assert.Zero(t, knowledge.PendingSubtasksCount)
+	var count int64
+	require.NoError(t, db.Model(&types.TaskPendingOp{}).Count(&count).Error)
+	assert.Zero(t, count)
 }
 
 // ---------------- TaskPendingOpsRepository ----------------

--- a/internal/application/service/knowledge_post_process.go
+++ b/internal/application/service/knowledge_post_process.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -216,13 +217,27 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 	}
 	expectedSubtasks += graphChunkCount
 
-	// enteredFinalizing is set only when SetFinalizing actually seeded the
-	// counter (the promoted branch below). It gates the reconciliation that
-	// releases planned-but-not-enqueued slots so the row can leave
-	// "finalizing" — see the note where enqueue actuals are tallied.
+	// enteredFinalizing is set only when the processing-to-finalizing handoff
+	// actually seeded the counter. For Wiki-enabled knowledge, that handoff
+	// also persists the pending Wiki op in the same transaction.
 	enteredFinalizing := false
+	wikiSlotOwned := false
 
 	switch {
+	case knowledge.ParseStatus == types.ParseStatusFinalizing && kb.IndexingStrategy.WikiEnabled:
+		// A previous delivery may have persisted the Wiki op but failed to
+		// enqueue its KB-scoped trigger. Retry only the trigger: appending a
+		// second pending op would duplicate durable work and its finalizer.
+		if err := enqueueWikiIngestTrigger(ctx, s.taskEnqueuer, payload.TenantID, payload.KnowledgeBaseID); err != nil {
+			s.tracker().FailSpan(ctx, postSpan, "WIKI_TRIGGER_ENQUEUE_FAILED", err.Error(), err)
+			return fmt.Errorf("retry wiki ingest trigger: %w", err)
+		}
+		logger.Infof(ctx, "[KnowledgePostProcess] Re-enqueued wiki ingest trigger for %s", payload.KnowledgeID)
+		retryOutput := types.JSONMap{"retried_wiki_trigger": true}
+		s.tracker().EndSpan(ctx, postSpan, retryOutput)
+		s.tracker().FinalizeAttempt(ctx, payload.KnowledgeID, attempt,
+			types.SpanStatusDone, retryOutput, "", "")
+		return nil
 	case knowledge.ParseStatus != types.ParseStatusProcessing:
 		// The row was already in some other state (deleting / cancelled /
 		// failed / completed) when we arrived. Don't touch parse_status
@@ -258,12 +273,34 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 				payload.KnowledgeID)
 		}
 	default:
-		// Flip processing → finalizing in one statement so a parallel
+		// Flip processing to finalizing before fan-out so a parallel
 		// cancel/delete cannot race us into completed.
-		promoted, err := s.knowledgeRepo.SetFinalizing(ctx, payload.KnowledgeID, expectedSubtasks)
+		var promoted bool
+		var err error
+		if willSpawnWiki {
+			seeder, ok := s.pendingRepo.(interfaces.TaskPendingOpsFinalizingSeeder)
+			if !ok {
+				return errors.New("wiki post-process requires atomic finalizing handoff")
+			}
+			pendingOp, buildErr := newWikiIngestPendingOp(
+				ctx, payload.TenantID, payload.KnowledgeBaseID, payload.KnowledgeID,
+			)
+			if buildErr != nil {
+				return buildErr
+			}
+			promoted, err = seeder.SeedKnowledgeFinalizingWithPendingOp(
+				ctx, payload.KnowledgeID, expectedSubtasks, pendingOp,
+			)
+			wikiSlotOwned = promoted
+		} else {
+			promoted, err = s.knowledgeRepo.SetFinalizing(ctx, payload.KnowledgeID, expectedSubtasks)
+		}
 		if err != nil {
 			logger.Warnf(ctx, "[KnowledgePostProcess] SetFinalizing failed for %s: %v",
 				payload.KnowledgeID, err)
+			if willSpawnWiki {
+				return fmt.Errorf("seed finalizing with wiki pending op: %w", err)
+			}
 		}
 		if promoted {
 			enteredFinalizing = true
@@ -341,25 +378,21 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 		}
 	}
 
-	// 6. Spawn Wiki Ingest Task if wiki indexing is enabled in IndexingStrategy.
-	//    Wiki is NOT reconciled here: it's a debounced KB-scoped batch whose
-	//    worker calls FinalizeSubtask once when the per-knowledge op reaches a
-	//    terminal state, so its single counted slot drains on its own path.
-	//
-	//    KNOWN GAP (TODO): EnqueueWikiIngest is fire-and-forget — it logs and
-	//    swallows both pending-op insert failures and trigger-task enqueue
-	//    failures. If BOTH fail (e.g. Postgres down + Redis down) no wiki
-	//    worker will ever run for this knowledge, so its seeded slot strands
-	//    the row in "finalizing". This is the only un-reconciled hole in the
-	//    counter; folding wiki into the shortfall release above will require
-	//    EnqueueWikiIngest to return (enqueued bool, err error) so we can
-	//    distinguish "no worker will ever run" from "worker will run later
-	//    and drain on its own".
-	enqueuedWiki := false
+	// 6. Schedule the Wiki trigger. The durable per-knowledge op already owns
+	//    its finalizing slot because it was committed atomically with the state
+	//    transition above. A trigger failure is returned so the post-process
+	//    task retries only the trigger without double-accounting.
+	var wikiEnqueueErr error
 	if willSpawnWiki {
-		EnqueueWikiIngest(ctx, s.taskEnqueuer, s.pendingRepo, payload.TenantID, payload.KnowledgeBaseID, payload.KnowledgeID)
-		logger.Infof(ctx, "[KnowledgePostProcess] Enqueued wiki ingest task for %s", payload.KnowledgeID)
-		enqueuedWiki = true
+		wikiEnqueueErr = enqueueWikiIngestTrigger(
+			ctx, s.taskEnqueuer, payload.TenantID, payload.KnowledgeBaseID,
+		)
+		if wikiEnqueueErr != nil {
+			logger.Warnf(ctx, "[KnowledgePostProcess] Failed to enqueue wiki ingest for %s: %v",
+				payload.KnowledgeID, wikiEnqueueErr)
+		} else if wikiSlotOwned {
+			logger.Infof(ctx, "[KnowledgePostProcess] Enqueued wiki ingest task for %s", payload.KnowledgeID)
+		}
 	}
 
 	// Reconcile the seeded counter against what was actually enqueued.
@@ -368,8 +401,8 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 	// off, a transient enqueue/marshal failure, a nil enqueuer) has no owner
 	// and would otherwise strand the row in "finalizing". Release exactly the
 	// shortfall — each release is a clamped decrement that promotes the row to
-	// "completed" if it brings the counter to zero. Wiki is excluded (see
-	// above). Safe against fast workers: shortfall slots have no draining
+	// "completed" if it brings the counter to zero. Safe against fast workers:
+	// shortfall slots have no draining
 	// task, so total drains == seeded count regardless of ordering.
 	//
 	// Detached ctx: the same reasoning that motivates finalizeSubtaskDetached
@@ -385,8 +418,14 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 		if willSpawnSummary {
 			plannedOwned++
 		}
+		if willSpawnWiki {
+			plannedOwned++
+		}
 		actualOwned := enqueuedQuestionCount + enqueuedGraphCount
 		if enqueuedSummary {
+			actualOwned++
+		}
+		if wikiSlotOwned {
 			actualOwned++
 		}
 		if shortfall := plannedOwned - actualOwned; shortfall > 0 {
@@ -412,11 +451,15 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 		"enqueued_summary":        enqueuedSummary,
 		"enqueued_question":       enqueuedQuestionCount > 0,
 		"enqueued_question_count": enqueuedQuestionCount,
-		"enqueued_wiki":           enqueuedWiki,
+		"enqueued_wiki":           wikiSlotOwned && wikiEnqueueErr == nil,
+		"wiki_slot_owned":         wikiSlotOwned,
 		"enqueued_graph":          enqueuedGraphCount > 0,
 		"enqueued_graph_count":    enqueuedGraphCount,
 	}
 	s.tracker().EndSpan(ctx, postSpan, postOutput)
+	if wikiSlotOwned && wikiEnqueueErr != nil {
+		return fmt.Errorf("enqueue wiki ingest trigger: %w", wikiEnqueueErr)
+	}
 	// Close the root span — the parse pipeline is done. Async
 	// downstream stages (summary/question/wiki/graph) record their
 	// own spans independently; their finishing extends the trace's

--- a/internal/application/service/knowledge_post_process_wiki_enqueue_test.go
+++ b/internal/application/service/knowledge_post_process_wiki_enqueue_test.go
@@ -1,0 +1,221 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type wikiEnqueueFailureKnowledgeRepo struct {
+	interfaces.KnowledgeRepository
+	knowledge        *types.Knowledge
+	expectedSubtasks int
+}
+
+func (r *wikiEnqueueFailureKnowledgeRepo) GetKnowledgeByIDOnly(
+	context.Context,
+	string,
+) (*types.Knowledge, error) {
+	return r.knowledge, nil
+}
+
+func (r *wikiEnqueueFailureKnowledgeRepo) SetFinalizing(
+	_ context.Context,
+	_ string,
+	expectedSubtasks int,
+) (bool, error) {
+	r.expectedSubtasks = expectedSubtasks
+	r.knowledge.ParseStatus = types.ParseStatusFinalizing
+	return true, nil
+}
+
+func (r *wikiEnqueueFailureKnowledgeRepo) UpdateKnowledgeColumn(
+	context.Context,
+	string,
+	string,
+	interface{},
+) error {
+	return nil
+}
+
+type wikiEnqueueFailureKBService struct {
+	interfaces.KnowledgeBaseService
+	kb *types.KnowledgeBase
+}
+
+func (s *wikiEnqueueFailureKBService) GetKnowledgeBaseByIDOnly(
+	context.Context,
+	string,
+) (*types.KnowledgeBase, error) {
+	return s.kb, nil
+}
+
+type wikiEnqueueFailureChunkService struct {
+	interfaces.ChunkService
+	chunks []*types.Chunk
+}
+
+func (s *wikiEnqueueFailureChunkService) ListChunksByKnowledgeID(
+	context.Context,
+	string,
+) ([]*types.Chunk, error) {
+	return s.chunks, nil
+}
+
+type wikiEnqueueFailureTaskQueue struct {
+	interfaces.TaskEnqueuer
+	taskTypes []string
+	wikiErr   error
+}
+
+func (q *wikiEnqueueFailureTaskQueue) Enqueue(
+	task *asynq.Task,
+	_ ...asynq.Option,
+) (*asynq.TaskInfo, error) {
+	q.taskTypes = append(q.taskTypes, task.Type())
+	if task.Type() == types.TypeWikiIngest {
+		return nil, q.wikiErr
+	}
+	return &asynq.TaskInfo{ID: "queued", Type: task.Type()}, nil
+}
+
+type wikiEnqueueFailurePendingRepo struct {
+	interfaces.TaskPendingOpsRepository
+	seedErr       error
+	seedCalls     int
+	seededOp      *types.TaskPendingOp
+	knowledgeRepo *wikiEnqueueFailureKnowledgeRepo
+}
+
+func (r *wikiEnqueueFailurePendingRepo) SeedKnowledgeFinalizingWithPendingOp(
+	_ context.Context,
+	_ string,
+	expectedSubtasks int,
+	op *types.TaskPendingOp,
+) (bool, error) {
+	r.seedCalls++
+	if r.seedErr != nil {
+		return false, r.seedErr
+	}
+	r.seededOp = op
+	r.knowledgeRepo.expectedSubtasks = expectedSubtasks
+	r.knowledgeRepo.knowledge.ParseStatus = types.ParseStatusFinalizing
+	return true, nil
+}
+
+func newWikiEnqueueTestService(
+	knowledgeID string,
+	pendingRepo *wikiEnqueueFailurePendingRepo,
+	queue *wikiEnqueueFailureTaskQueue,
+) (*KnowledgePostProcessService, *wikiEnqueueFailureKnowledgeRepo) {
+	repo := &wikiEnqueueFailureKnowledgeRepo{
+		knowledge: &types.Knowledge{
+			ID:          knowledgeID,
+			ParseStatus: types.ParseStatusProcessing,
+		},
+	}
+	pendingRepo.knowledgeRepo = repo
+	return &KnowledgePostProcessService{
+		knowledgeRepo: repo,
+		kbService: &wikiEnqueueFailureKBService{kb: &types.KnowledgeBase{
+			ID: "kb-wiki",
+			IndexingStrategy: types.IndexingStrategy{
+				WikiEnabled: true,
+			},
+		}},
+		chunkService: &wikiEnqueueFailureChunkService{chunks: []*types.Chunk{
+			{ID: "chunk-1", ChunkType: types.ChunkTypeText},
+		}},
+		taskEnqueuer: queue,
+		pendingRepo:  pendingRepo,
+	}, repo
+}
+
+func newWikiEnqueuePostProcessTask(t *testing.T, knowledgeID string) *asynq.Task {
+	t.Helper()
+	payload, err := json.Marshal(types.KnowledgePostProcessPayload{
+		TenantID:        7,
+		KnowledgeID:     knowledgeID,
+		KnowledgeBaseID: "kb-wiki",
+	})
+	require.NoError(t, err)
+	return asynq.NewTask(types.TypeKnowledgePostProcess, payload)
+}
+
+func TestKnowledgePostProcessAtomicallySeedsWikiSlot(t *testing.T) {
+	const knowledgeID = "knowledge-wiki-enqueue-failure"
+	tests := []struct {
+		name       string
+		pendingErr error
+		wantTasks  []string
+		wantStatus string
+		wantErr    bool
+	}{
+		{
+			name:       "pending op persistence fails",
+			pendingErr: errors.New("postgres unavailable"),
+			wantStatus: types.ParseStatusProcessing,
+			wantErr:    true,
+		},
+		{
+			name:       "pending op and trigger succeed",
+			wantTasks:  []string{types.TypeSummaryGeneration, types.TypeWikiIngest},
+			wantStatus: types.ParseStatusFinalizing,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pendingRepo := &wikiEnqueueFailurePendingRepo{seedErr: test.pendingErr}
+			queue := &wikiEnqueueFailureTaskQueue{}
+			service, repo := newWikiEnqueueTestService(knowledgeID, pendingRepo, queue)
+
+			err := service.Handle(context.Background(), newWikiEnqueuePostProcessTask(t, knowledgeID))
+
+			if test.wantErr {
+				require.ErrorIs(t, err, test.pendingErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, 2, repo.expectedSubtasks, "summary and wiki each seed one slot")
+				require.NotNil(t, pendingRepo.seededOp)
+				assert.Equal(t, knowledgeID, pendingRepo.seededOp.DedupKey)
+			}
+			assert.Equal(t, test.wantStatus, repo.knowledge.ParseStatus)
+			assert.Equal(t, test.wantTasks, queue.taskTypes)
+			assert.Equal(t, 1, pendingRepo.seedCalls)
+		})
+	}
+}
+
+func TestKnowledgePostProcessRetriesWikiTriggerWithoutDoubleAccounting(t *testing.T) {
+	const knowledgeID = "knowledge-wiki-trigger-retry"
+	wikiErr := errors.New("redis unavailable")
+	pendingRepo := &wikiEnqueueFailurePendingRepo{}
+	queue := &wikiEnqueueFailureTaskQueue{wikiErr: wikiErr}
+	service, repo := newWikiEnqueueTestService(knowledgeID, pendingRepo, queue)
+	task := newWikiEnqueuePostProcessTask(t, knowledgeID)
+
+	err := service.Handle(context.Background(), task)
+
+	require.ErrorIs(t, err, wikiErr)
+	assert.Equal(t, 2, repo.expectedSubtasks, "summary and wiki each seed one slot")
+	assert.Equal(t, 1, pendingRepo.seedCalls)
+	assert.Equal(t, []string{types.TypeSummaryGeneration, types.TypeWikiIngest}, queue.taskTypes)
+
+	queue.wikiErr = nil
+	err = service.Handle(context.Background(), task)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, pendingRepo.seedCalls, "retry must not append another pending op")
+	assert.Equal(t,
+		[]string{types.TypeSummaryGeneration, types.TypeWikiIngest, types.TypeWikiIngest},
+		queue.taskTypes,
+	)
+}

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -424,7 +424,10 @@ func (s *wikiIngestService) beginWikiSubspan(ctx context.Context, knowledgeID st
 	return s.tracker().BeginSubSpan(ctx, parent, "postprocess.wiki", types.SpanKindSubSpan, input)
 }
 
-// EnqueueWikiIngest queues a document for wiki ingestion.
+// EnqueueWikiIngest queues a document for wiki ingestion. The returned bool
+// reports whether the durable pending op was persisted. A trigger enqueue
+// error may therefore be returned together with true; callers can retry only
+// the KB-scoped trigger without appending a duplicate operation.
 //
 // Architecture: each upload inserts one row into task_pending_ops
 // (task_type="wiki:ingest", scope="knowledge_base", scope_id=kbID,
@@ -461,14 +464,39 @@ func EnqueueWikiIngest(
 	pendingRepo interfaces.TaskPendingOpsRepository,
 	tenantID uint64,
 	kbID, knowledgeID string,
-) {
-	lang, _ := types.LanguageFromContext(ctx)
+) (bool, error) {
+	pendingOp, err := newWikiIngestPendingOp(ctx, tenantID, kbID, knowledgeID)
 
 	// Persist the pending op. A re-ingest of the same knowledge id while
 	// a previous op is still queued simply appends another row; the
 	// peekPendingList consumer collapses by dedup_key (== knowledge_id),
 	// keeping the LATEST op for each knowledge — matching the legacy
 	// "RPush + reverse-dedupe" semantics.
+	if err != nil {
+		logger.Warnf(ctx, "wiki ingest: failed to marshal pending op for %s: %v", knowledgeID, err)
+		return false, err
+	}
+	accepted, err := enqueueWikiPendingOp(ctx, pendingRepo, pendingOp)
+	if err != nil {
+		logger.Warnf(ctx, "wiki ingest: failed to enqueue pending op for %s: %v", knowledgeID, err)
+		return false, fmt.Errorf("enqueue wiki ingest pending op: %w", err)
+	}
+	if !accepted {
+		logger.Infof(ctx, "wiki ingest: skip enqueue for deleted KB %s", kbID)
+		return false, nil
+	}
+	if err := enqueueWikiIngestTrigger(ctx, task, tenantID, kbID); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+func newWikiIngestPendingOp(
+	ctx context.Context,
+	tenantID uint64,
+	kbID, knowledgeID string,
+) (*types.TaskPendingOp, error) {
+	lang, _ := types.LanguageFromContext(ctx)
 	op := WikiPendingOp{
 		Op:          WikiOpIngest,
 		KnowledgeID: knowledgeID,
@@ -476,10 +504,9 @@ func EnqueueWikiIngest(
 	}
 	payloadBytes, err := json.Marshal(op)
 	if err != nil {
-		logger.Warnf(ctx, "wiki ingest: failed to marshal pending op for %s: %v", knowledgeID, err)
-		return
+		return nil, fmt.Errorf("marshal wiki ingest pending op: %w", err)
 	}
-	accepted, err := enqueueWikiPendingOp(ctx, pendingRepo, &types.TaskPendingOp{
+	return &types.TaskPendingOp{
 		TenantID: tenantID,
 		TaskType: wikiTaskType,
 		Scope:    wikiTaskScope,
@@ -487,23 +514,30 @@ func EnqueueWikiIngest(
 		Op:       WikiOpIngest,
 		DedupKey: knowledgeID,
 		Payload:  payloadBytes,
-	})
-	if err != nil {
-		logger.Warnf(ctx, "wiki ingest: failed to enqueue pending op for %s: %v", knowledgeID, err)
-		return
-	}
-	if !accepted {
-		logger.Infof(ctx, "wiki ingest: skip enqueue for deleted KB %s", kbID)
-		return
-	}
+	}, nil
+}
 
+func enqueueWikiIngestTrigger(
+	ctx context.Context,
+	task interfaces.TaskEnqueuer,
+	tenantID uint64,
+	kbID string,
+) error {
+	lang, _ := types.LanguageFromContext(ctx)
 	trigger := WikiIngestPayload{
 		TenantID:        tenantID,
 		KnowledgeBaseID: kbID,
 		Language:        lang,
 	}
 	langfuse.InjectTracing(ctx, &trigger)
-	triggerBytes, _ := json.Marshal(trigger)
+	triggerBytes, err := json.Marshal(trigger)
+	if err != nil {
+		logger.Warnf(ctx, "wiki ingest: failed to marshal trigger task: %v", err)
+		return fmt.Errorf("marshal wiki ingest trigger: %w", err)
+	}
+	if task == nil {
+		return errors.New("enqueue wiki ingest trigger: task enqueuer is nil")
+	}
 
 	t := asynq.NewTask(types.TypeWikiIngest, triggerBytes,
 		asynq.Queue(types.QueueWiki),
@@ -513,7 +547,9 @@ func EnqueueWikiIngest(
 	)
 	if _, err := task.Enqueue(t); err != nil {
 		logger.Warnf(ctx, "wiki ingest: failed to enqueue trigger task: %v", err)
+		return fmt.Errorf("enqueue wiki ingest trigger: %w", err)
 	}
+	return nil
 }
 
 // EnqueueWikiRetract queues a wiki retraction op (a delete cleanup).

--- a/internal/types/interfaces/task_queue.go
+++ b/internal/types/interfaces/task_queue.go
@@ -100,6 +100,18 @@ type TaskPendingOpsKnowledgeBaseGuard interface {
 	EnqueueIfKnowledgeBaseActive(ctx context.Context, op *types.TaskPendingOp) (accepted bool, err error)
 }
 
+// TaskPendingOpsFinalizingSeeder atomically hands a processing knowledge row
+// to the asynchronous finalizing pipeline while persisting the durable
+// pending operation that owns one of its subtask slots.
+type TaskPendingOpsFinalizingSeeder interface {
+	SeedKnowledgeFinalizingWithPendingOp(
+		ctx context.Context,
+		knowledgeID string,
+		expectedSubtasks int,
+		op *types.TaskPendingOp,
+	) (promoted bool, err error)
+}
+
 // TaskDeadLetterRepository persists rows for the generic task dead-letter
 // archive (`task_dead_letters`). Two writers exist: the asynq
 // dead-letter middleware (one row per archived asynq task), and the


### PR DESCRIPTION
## Description

Fixes Wiki-enabled knowledge records remaining in `finalizing` when the durable pending operation or Redis trigger cannot be enqueued during post-processing.

### What changed

- Atomically transition knowledge from `processing` to `finalizing`, seed `pending_subtasks_count`, and insert the Wiki pending operation in one database transaction.
- Roll back the state transition when the pending-op insert fails, leaving the knowledge in `processing` so the post-process task can retry safely.
- If only the Redis trigger enqueue fails, keep the durable operation and retry only the KB-scoped trigger without duplicating pending operations, summary tasks, or subtask accounting.
- Preserve the existing knowledge-base deletion guard and add repository/service regression coverage.

## Reproduction (English)

1. Enable Wiki indexing for a knowledge base.
2. Upload a document that contains text chunks.
3. During knowledge post-processing, simulate either:
   - a database failure while inserting the Wiki row into `task_pending_ops`; or
   - a Redis/asynq failure while enqueueing the Wiki trigger.
4. Before this fix, the knowledge could already enter `finalizing` with a Wiki subtask slot, while no worker owned a durable operation capable of releasing that slot. The knowledge could remain stuck for a long time.
5. After this fix, the state transition and pending-op insert commit atomically. A database failure leaves the knowledge in `processing`; a trigger failure retries only the trigger and does not double-account work.

## 修复BUG  Wiki 入队失败会让知识长时间卡在 finalizing （中文）
[knowledge_post_process.go (line 359)](/D:/WeKnora/internal/application/service/knowledge_post_process.go:359) 无条件认为 Wiki 已成功入队，但 [wiki_ingest.go (line 490)](/D:/WeKnora/internal/application/service/wiki_ingest.go:490) 遇到数据库或 Redis 错误只记录日志、不返回失败。对应子任务永远不会完成，约 70 分钟后才由 housekeeping 标记失败。
修复应让入队函数返回错误，并立即释放任务槽位或触发可控重试。


## 复现步骤

1. 为知识库启用 Wiki 索引。
2. 上传一个包含文本分块的文档。
3. 在知识后处理阶段模拟以下任一故障：
   - 向 `task_pending_ops` 写入 Wiki pending-op 时数据库失败；或
   - 向 Redis/asynq 投递 Wiki 触发任务时失败。
4. 修复前，knowledge 可能已经进入 `finalizing` 并占用一个 Wiki 子任务计数，但没有持久任务可由 worker 执行并释放该计数，因此会长时间卡住。
5. 修复后，状态转换与 pending-op 在同一事务中提交；数据库失败时 knowledge 保持 `processing`，触发任务失败时仅重试 trigger，不会重复 pending-op、摘要任务或子任务计数。

## Type of Change

- [x] 🐛 Bug fix
- [x] 🧪 Test

## Testing

- `go test -p=1 ./internal/application/repository -count=1`
- `go test -p=1 ./internal/application/service -count=1`
- `git diff --check`

Additional compile-only checks for `./internal/router` and `./internal/container` were attempted twice. The local dependency build exceeded the 3-minute and 5-minute timeouts without emitting a compiler error.

## Checklist

- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] No user-visible UI change
- [x] No breaking change