### PR TITLE
fix(knowledge): clear stale errors when reparse starts

### DIFF
--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -2045,18 +2045,7 @@ func (s *knowledgeService) ReparseKnowledge(
 			return nil, werrors.NewBadRequestError("无法获取手工知识内容")
 		}
 
-		existing.ParseStatus = "pending"
-		existing.EnableStatus = "disabled"
-		existing.Description = ""
-		existing.ProcessedAt = nil
-		existing.EmbeddingModelID = kb.EmbeddingModelID
-		// Reset the enrichment counter so a leftover value from a
-		// previous attempt (e.g. cancelled before all subtasks decremented)
-		// cannot block the new finalizing transition later. This must be
-		// an explicit column write: UpdateKnowledge (full-row Save) omits
-		// pending_subtasks_count, so the struct assignment alone would not
-		// persist.
-		existing.PendingSubtasksCount = 0
+		resetKnowledgeForReparse(existing, kb)
 
 		if err := s.repo.UpdateKnowledge(ctx, existing); err != nil {
 			logger.Errorf(ctx, "Failed to update knowledge status before reparse: %v", err)
@@ -2088,17 +2077,7 @@ func (s *knowledgeService) ReparseKnowledge(
 	}
 
 	// Step 2: Update knowledge status and metadata
-	existing.ParseStatus = "pending"
-	existing.EnableStatus = "disabled"
-	existing.Description = ""
-	existing.ProcessedAt = nil
-	existing.EmbeddingModelID = kb.EmbeddingModelID
-	// Reset the enrichment counter so a leftover value from a previous
-	// attempt cannot block the new finalizing transition later. This must
-	// be an explicit column write: UpdateKnowledge (full-row Save) omits
-	// pending_subtasks_count, so the struct assignment alone would not
-	// persist.
-	existing.PendingSubtasksCount = 0
+	resetKnowledgeForReparse(existing, kb)
 
 	if err := s.repo.UpdateKnowledge(ctx, existing); err != nil {
 		logger.Errorf(ctx, "Failed to update knowledge status before reparse: %v", err)
@@ -2264,6 +2243,21 @@ func (s *knowledgeService) ReparseKnowledge(
 
 	logger.Warnf(ctx, "Knowledge %s has no parseable content (no file, URL, or manual content)", knowledgeID)
 	return existing, nil
+}
+
+// resetKnowledgeForReparse makes the top-level knowledge state describe the
+// new processing attempt rather than retaining terminal state from the
+// previous one.
+func resetKnowledgeForReparse(knowledge *types.Knowledge, kb *types.KnowledgeBase) {
+	knowledge.ParseStatus = types.ParseStatusPending
+	knowledge.EnableStatus = "disabled"
+	knowledge.Description = ""
+	knowledge.ProcessedAt = nil
+	knowledge.ErrorMessage = ""
+	knowledge.EmbeddingModelID = kb.EmbeddingModelID
+	// UpdateKnowledge deliberately omits pending_subtasks_count, so callers
+	// must still persist this reset through an explicit column update.
+	knowledge.PendingSubtasksCount = 0
 }
 
 // CancelKnowledgeParse marks an in-progress parse as cancelled by the user.

--- a/internal/application/service/knowledge_reparse_test.go
+++ b/internal/application/service/knowledge_reparse_test.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResetKnowledgeForReparseClearsPreviousAttemptState(t *testing.T) {
+	processedAt := time.Now()
+	knowledge := &types.Knowledge{
+		ParseStatus:          types.ParseStatusFailed,
+		EnableStatus:         "enabled",
+		Description:          "previous description",
+		ProcessedAt:          &processedAt,
+		ErrorMessage:         "embedding request failed: context deadline exceeded",
+		EmbeddingModelID:     "old-model",
+		PendingSubtasksCount: 3,
+	}
+	kb := &types.KnowledgeBase{EmbeddingModelID: "new-model"}
+
+	resetKnowledgeForReparse(knowledge, kb)
+
+	require.Equal(t, types.ParseStatusPending, knowledge.ParseStatus)
+	require.Equal(t, "disabled", knowledge.EnableStatus)
+	require.Empty(t, knowledge.Description)
+	require.Nil(t, knowledge.ProcessedAt)
+	require.Empty(t, knowledge.ErrorMessage)
+	require.Equal(t, "new-model", knowledge.EmbeddingModelID)
+	require.Zero(t, knowledge.PendingSubtasksCount)
+}


### PR DESCRIPTION
## Description

Clear attempt-specific terminal state whenever a new knowledge reparse begins.

The manual and non-manual paths now share one reset helper, which resets `parse_status`, `enable_status`, `description`, `processed_at`, `error_message`, the embedding model, and the in-memory enrichment counter for the new attempt.

## Root cause

`ReparseKnowledge` reset the processing status and completion timestamp but left `ErrorMessage` untouched. Because the full-row repository save persists that field, an error from the previous failed attempt remained visible while the new attempt was pending, processing, or already searchable.

## Impact

API and UI consumers no longer see a previous attempt's failure as the current document error after reparse starts.

## Testing

- `go test ./internal/application/service -run TestResetKnowledgeForReparseClearsPreviousAttemptState -count=1`
- `git diff --check`

Fixes #2296