### PR TITLE
fix(frontend): distinguish main stages from postprocess tasks

### DIFF
--- a/frontend/src/components/knowledge-processing-timeline.vue
+++ b/frontend/src/components/knowledge-processing-timeline.vue
@@ -6,6 +6,7 @@ import { getKnowledgeSpans, reparseKnowledge, cancelKnowledgeParse, getKnowledge
 import {
   groupPostprocessGraphSpans,
   knowledgeSpansPayloadHasTrace,
+  summarizePostprocessTasks,
   type KnowledgeTraceNode,
 } from '@/utils/knowledgeTrace'
 import { resolveTimelineHeaderStatus } from '@/utils/knowledgeProcessingStatus'
@@ -1197,6 +1198,10 @@ const stagesStatDisplay = computed(() => {
   }
 })
 
+const postprocessTaskStats = computed(() =>
+  summarizePostprocessTasks(data.value?.trace),
+)
+
 const headMetaParts = computed(() => {
   if (!data.value) return []
   const parts: string[] = [t('knowledgeStages.title')]
@@ -1205,6 +1210,19 @@ const headMetaParts = computed(() => {
   }
   const st = stagesStatDisplay.value
   parts.push(`${st.label} ${st.value}`)
+  const postprocess = postprocessTaskStats.value
+  if (postprocess.total > 0) {
+    parts.push(t('knowledgeStages.head.postprocessTasks', {
+      running: postprocess.running,
+      failed: postprocess.failed,
+      completed: postprocess.completed,
+    }))
+  }
+  if (data.value.parse_status === 'completed' && postprocess.running > 0) {
+    parts.push(t('knowledgeStages.head.completedWithActiveTrace', {
+      n: postprocess.running,
+    }))
+  }
   if (attemptTabs.value.length === 0 && data.value.current_attempt) {
     parts.push(t('knowledgeStages.attempt', { n: data.value.current_attempt }))
   }

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -840,8 +840,10 @@ export default {
     head: {
       duration: 'Duration',
       stages: 'Stages',
-      stagesDone: 'Stages completed',
+      stagesDone: 'Main stages',
       stagesProgress: 'Current stage',
+      postprocessTasks: 'Postprocess: {running} running / {failed} failed / {completed} completed',
+      completedWithActiveTrace: 'Processing completed, but {n} trace task(s) remain active',
       stage: 'Stage',
       status: 'Status',
       attempt: 'Attempt',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -844,8 +844,10 @@ export default {
     head: {
       duration: "소요시간",
       stages: "단계",
-      stagesDone: "완료된 단계",
+      stagesDone: "주요 단계",
       stagesProgress: "현재 단계",
+      postprocessTasks: "후처리: 실행 중 {running} / 실패 {failed} / 완료 {completed}",
+      completedWithActiveTrace: "처리는 완료되었지만 {n}개의 Trace 작업이 아직 활성 상태입니다",
       stage: "단계",
       status: "상태",
       attempt: "시도",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -842,8 +842,10 @@ export default {
     head: {
       duration: "总耗时",
       stages: "阶段",
-      stagesDone: "已完成阶段",
+      stagesDone: "主流程阶段",
       stagesProgress: "当前阶段",
+      postprocessTasks: "后台任务：运行中 {running} / 失败 {failed} / 已完成 {completed}",
+      completedWithActiveTrace: "处理已完成，但仍有 {n} 个 Trace 任务处于活动状态",
       stage: "阶段",
       status: "状态",
       attempt: "尝试",

--- a/frontend/src/utils/knowledgeTrace.test.ts
+++ b/frontend/src/utils/knowledgeTrace.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { groupPostprocessGraphSpans, type KnowledgeTraceNode } from './knowledgeTrace.ts'
+import {
+  groupPostprocessGraphSpans,
+  summarizePostprocessTasks,
+  type KnowledgeTraceNode,
+} from './knowledgeTrace.ts'
 
 function graphChunk(index: number, overrides: Partial<KnowledgeTraceNode> = {}): KnowledgeTraceNode {
   return {
@@ -106,4 +110,50 @@ test('leaves postprocess unchanged when it has no graph chunks', () => {
   }
 
   assert.equal(groupPostprocessGraphSpans(stage), stage)
+})
+
+test('summarizes asynchronous postprocess leaf tasks', () => {
+  const trace: KnowledgeTraceNode = {
+    name: 'root',
+    kind: 'root',
+    status: 'done',
+    children: [
+      {
+        name: 'postprocess',
+        kind: 'stage',
+        status: 'done',
+        children: [
+          { name: 'postprocess.summary', kind: 'subspan', status: 'done' },
+          { name: 'postprocess.question', kind: 'subspan', status: 'running' },
+          {
+            name: 'postprocess.graph',
+            kind: 'group',
+            status: 'failed',
+            children: [
+              { name: 'postprocess.graph.chunk[0]', kind: 'subspan', status: 'failed' },
+              { name: 'postprocess.graph.chunk[1]', kind: 'subspan', status: 'pending' },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+
+  assert.deepEqual(summarizePostprocessTasks(trace), {
+    running: 2,
+    failed: 1,
+    completed: 1,
+    other: 0,
+    total: 4,
+  })
+})
+
+test('returns an empty postprocess summary when no trace is available', () => {
+  assert.deepEqual(summarizePostprocessTasks(undefined), {
+    running: 0,
+    failed: 0,
+    completed: 0,
+    other: 0,
+    total: 0,
+  })
 })

--- a/frontend/src/utils/knowledgeTrace.ts
+++ b/frontend/src/utils/knowledgeTrace.ts
@@ -23,6 +23,14 @@ export interface KnowledgeTraceNode {
   children?: KnowledgeTraceNode[]
 }
 
+export interface PostprocessTaskSummary {
+  running: number
+  failed: number
+  completed: number
+  other: number
+  total: number
+}
+
 const graphChunkName = /^postprocess\.graph\.chunk\[(\d+)\]$/
 
 function timestamp(value?: string | null): number | null {
@@ -104,4 +112,56 @@ export function groupPostprocessGraphSpans(
   }
 
   return { ...stage, children: groupedChildren }
+}
+
+/**
+ * Counts leaf postprocess spans so the UI can distinguish the five main
+ * pipeline stages from asynchronous enrichment work.
+ */
+export function summarizePostprocessTasks(
+  trace?: KnowledgeTraceNode,
+): PostprocessTaskSummary {
+  const summary: PostprocessTaskSummary = {
+    running: 0,
+    failed: 0,
+    completed: 0,
+    other: 0,
+    total: 0,
+  }
+  if (!trace) return summary
+
+  const postprocess = trace.name === 'postprocess'
+    ? trace
+    : (trace.children || []).find(child => child.name === 'postprocess')
+  if (!postprocess) return summary
+
+  const countLeaves = (node: KnowledgeTraceNode) => {
+    const children = node.children || []
+    if (children.length > 0) {
+      children.forEach(countLeaves)
+      return
+    }
+
+    summary.total++
+    switch (node.status) {
+      case 'running':
+      case 'pending':
+      case 'processing':
+      case 'finalizing':
+        summary.running++
+        break
+      case 'failed':
+        summary.failed++
+        break
+      case 'done':
+      case 'completed':
+        summary.completed++
+        break
+      default:
+        summary.other++
+    }
+  }
+
+  ;(postprocess.children || []).forEach(countLeaves)
+  return summary
 }


### PR DESCRIPTION
## Description

Clarify the document processing timeline so a `5/5` stage count is not presented as completion of all asynchronous work.

- Rename the completed-stage label to `Main stages` / `主流程阶段` / `주요 단계`.
- Summarize postprocess leaf tasks separately as running, failed, and completed.
- Show a diagnostic message when the knowledge status is completed but postprocess trace tasks remain active.
- Add unit coverage for nested postprocess task aggregation.

## Root cause

The header counted only the five top-level pipeline stages. Async summary, question, graph, and Wiki work can continue under postprocess after those stages reach `5/5`, so the old `Stages completed 5/5` wording implied a stronger terminal state than the data represented.

## Testing

- `tsx --test src/utils/knowledgeTrace.test.ts` — 7 tests passed
- `git diff --check`
- `vue-tsc --build` was attempted and remains blocked by existing errors on `main` in `sessionSidebarBuckets.ts`, `AgentEditorModal.vue`, and `SystemSettings.vue`; none are touched by this PR.

Fixes #2265