### PR TITLE
docs: clarify scope-aware contributor validation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,9 +20,19 @@ Fixes #
 
 ## Testing
 <!-- Describe how these changes were tested. Include reproduction or verification steps. -->
+<!--
+For a focused change, run checks scoped to the files/packages you changed.
+See the Contributing section in README.md for examples. If a full-repository
+check is blocked by unrelated baseline or environment failures, record the
+exact command and failure here.
+-->
 
 ## Checklist
-- [ ] `make fmt && make lint && make test` pass locally
+- [ ] `git diff --check origin/main...HEAD` passes
+- [ ] Changed source files are formatted
+- [ ] Targeted tests for the changed packages/components pass
+- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
+- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
 - [ ] Self-reviewed the code
 - [ ] Added/updated tests covering the change
 - [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)

--- a/README.md
+++ b/README.md
@@ -296,6 +296,29 @@ Welcome to submit [Issues](https://github.com/Tencent/WeKnora/issues) or Pull Re
 
 **Standards:** Format code with `gofmt`, follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:` / `fix:` / `docs:` / `test:` / `refactor:`)
 
+### Validation
+
+For a focused PR, validate the changed scope first:
+
+```bash
+git fetch origin main
+git diff --check origin/main...HEAD
+golangci-lint run --new-from-rev=origin/main ./...
+go test ./path/to/changed/package -count=1
+```
+
+Run `gofmt` on changed Go files before committing. For frontend changes, run the relevant tests from `frontend/` and use `npm run type-check` when the change affects TypeScript or Vue components.
+
+The full maintainer gate remains:
+
+```bash
+make fmt
+make lint
+make test
+```
+
+`make fmt` formats the entire Go repository, so run it only with a clean worktree and review the resulting diff. Some full-suite tests require local infrastructure or service configuration. If a full check fails for an unrelated baseline or environment reason, include the exact command and failure in the PR while still providing passing targeted tests for your change.
+
 ## 🔒 Security Notice
 
 **Important:** Starting from v0.1.3, WeKnora includes login authentication functionality to enhance system security. For production deployments, we strongly recommend:

--- a/README_CN.md
+++ b/README_CN.md
@@ -279,6 +279,29 @@ make dev-frontend
 
 **规范：** 使用 `gofmt` 格式化代码，遵循 [Conventional Commits](https://www.conventionalcommits.org/) 提交（`feat:` / `fix:` / `docs:` / `test:` / `refactor:`）
 
+### 验证方式
+
+对于范围集中的 PR，优先验证本次改动涉及的文件和包：
+
+```bash
+git fetch origin main
+git diff --check origin/main...HEAD
+golangci-lint run --new-from-rev=origin/main ./...
+go test ./path/to/changed/package -count=1
+```
+
+提交前请对改动过的 Go 文件运行 `gofmt`。对于前端改动，请在 `frontend/` 目录运行相关测试；如果改动涉及 TypeScript 或 Vue 组件，还应运行 `npm run type-check`。
+
+维护者使用的全仓验证命令仍然是：
+
+```bash
+make fmt
+make lint
+make test
+```
+
+`make fmt` 会格式化整个 Go 仓库，因此请仅在工作区干净时运行，并检查产生的 diff。部分全量测试依赖本地基础设施或服务配置。如果全仓检查因无关的基线问题或环境依赖失败，请在 PR 中写明具体命令和错误，同时提供本次改动范围内通过的定向测试。
+
 ## 🔒 安全声明
 
 **重要提示：** 从 v0.1.3 版本开始，WeKnora 提供了登录鉴权功能，以增强系统安全性。在生产环境部署时，我们强烈建议：


### PR DESCRIPTION
## Description

Align contributor guidance and the pull request checklist with checks that external contributors can run honestly for focused changes.

- Document diff validation, diff-scoped Go lint, targeted package tests, formatting, and frontend checks in both English and Chinese READMEs.
- Retain the full maintainer gate while documenting its whole-repository and environment-sensitive behavior.
- Replace the single all-or-nothing PR-template checkbox with scope-aware validation items.
- Ask contributors to record exact unrelated baseline or environment failures instead of silently claiming the full suite passed.

## Impact

Small PRs can provide a reproducible, reviewable validation record without being blocked by unrelated full-repository failures, while maintainers still retain visibility into whether the full gate was attempted.

## Testing

- `git diff --check`
- Reviewed English and Chinese command examples against the current Makefile targets and PR template.

Fixes #2261