### PR TITLE
fix(mcp-server): correct SSE message route to prevent initialization …

### DIFF
--- a/mcp-server/weknora_mcp_server.py
+++ b/mcp-server/weknora_mcp_server.py
@@ -1357,8 +1357,8 @@ async def run_sse(host: str, port: int):
 
     starlette_app = Starlette(
         routes=[
+            Mount("/sse/messages/", app=sse.handle_post_message),  # 更具体的路由必须在 /sse 前面
             Mount("/sse", app=handle_sse),
-            Mount("/messages/", app=sse.handle_post_message),
         ]
     )
     starlette_app = MCPAuthMiddleware(starlette_app, auth_token)


### PR DESCRIPTION
…timeout

The SSE transport's POST handler was mounted at /messages/, but the SseServerTransport SDK prepends the Starlette root_path ("/sse") to the endpoint parameter, instructing clients to POST to /sse/messages/. This path mismatch caused MCP initialization requests to never reach the handler, resulting in a 60s+ timeout on connect.

Fix: move the Mount to /sse/messages/ and place it before the /sse catch-all route, since Starlette's Mount uses prefix matching and /sse would otherwise intercept /sse/messages/ requests.

<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

## Type of Change
<!-- Check applicable items -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->

## Checklist
- [ ] `make fmt && make lint && make test` pass locally
- [ ] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
