### PR TITLE
fix(knowledge): default custom metadata on create

### DIFF
--- a/internal/application/repository/knowledge_create_test.go
+++ b/internal/application/repository/knowledge_create_test.go
@@ -1,0 +1,40 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestCreateKnowledgeDefaultsCustomMetadataToEmptyObject(t *testing.T) {
+	dsn := "file:" + uuid.New().String() + "?mode=memory&cache=shared"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	require.NoError(t, db.AutoMigrate(&types.Knowledge{}))
+
+	repo := NewKnowledgeRepository(db)
+	knowledge := &types.Knowledge{
+		TenantID:        1,
+		KnowledgeBaseID: "kb-1",
+		Type:            "file",
+		Title:           "document.txt",
+		ParseStatus:     types.ParseStatusPending,
+		EnableStatus:    "disabled",
+	}
+
+	require.NoError(t, repo.CreateKnowledge(context.Background(), knowledge))
+	require.JSONEq(t, `{}`, string(knowledge.CustomMetadata))
+
+	persisted, err := repo.GetKnowledgeByID(context.Background(), knowledge.TenantID, knowledge.ID)
+	require.NoError(t, err)
+	require.JSONEq(t, `{}`, string(persisted.CustomMetadata))
+}

--- a/internal/types/knowledge.go
+++ b/internal/types/knowledge.go
@@ -158,7 +158,7 @@ type Knowledge struct {
 	Metadata JSON `json:"metadata"           gorm:"type:json"`
 	// CustomMetadata is user-authored descriptive metadata. It is deliberately
 	// separate from Metadata, which contains internal ingestion state and IDs.
-	CustomMetadata JSON `json:"custom_metadata" gorm:"type:json"`
+	CustomMetadata JSON `json:"custom_metadata" gorm:"type:json;not null"`
 	// Last FAQ import result (for FAQ type knowledge only)
 	LastFAQImportResult JSON `json:"last_faq_import_result" gorm:"type:json"`
 	// Creation time of the knowledge
@@ -220,10 +220,17 @@ func (k *Knowledge) GetMetadata() map[string]string {
 	return metadata
 }
 
-// BeforeCreate hook generates a UUID for new Knowledge entities before they are created.
+// BeforeCreate initializes required defaults for new Knowledge entities.
 func (k *Knowledge) BeforeCreate(tx *gorm.DB) (err error) {
 	if k.ID == "" {
 		k.ID = uuid.New().String()
+	}
+	// JSON.Value returns SQL NULL for an empty value. PostgreSQL's column
+	// default is not applied when GORM explicitly inserts that NULL, so keep the
+	// application-side representation aligned with the NOT NULL database
+	// invariant for every knowledge creation path.
+	if len(k.CustomMetadata) == 0 {
+		k.CustomMetadata = JSON(`{}`)
 	}
 	return nil
 }

--- a/migrations/mysql/00-init-db.sql
+++ b/migrations/mysql/00-init-db.sql
@@ -77,7 +77,7 @@ CREATE TABLE knowledges (
     file_hash VARCHAR(64),
     storage_size BIGINT NOT NULL DEFAULT 0,
     metadata JSON,
-    custom_metadata JSON,
+    custom_metadata JSON NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     deleted_at TIMESTAMP NULL DEFAULT NULL,


### PR DESCRIPTION
## Summary

- initialize empty knowledge custom metadata as `{}` in the shared GORM create hook
- declare the model and fresh MySQL schema column as non-null
- add a repository regression test that verifies both the in-memory and persisted values

## Root cause

`types.JSON.Value()` returns SQL `NULL` for an uninitialized value. GORM explicitly included that value in knowledge inserts, so PostgreSQL could not apply the column default and rejected the row because `custom_metadata` is `NOT NULL`.

## Impact

Knowledge creation paths that do not provide custom metadata, including file uploads, now persist an empty JSON object instead of failing with `SQLSTATE 23502`.

## Validation

- `go test ./internal/application/repository ./internal/types ./internal/application/service/...`
- `git diff --check github_public/main...HEAD`