### PR TITLE
feat(frontend): improve responsive layouts for mobile devices

### DIFF
--- a/frontend/embed.html
+++ b/frontend/embed.html
@@ -3,7 +3,7 @@
 <head>
     <title>WeKnora Embed</title>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="renderer" content="webkit">
     <link rel="shortcut icon" type="image/png" href="./public/favicon.ico"/>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
 <head>
     <title>WeKnora</title>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="renderer" content="webkit">
     <meta name="mobile-web-app-capable" content="yes">

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -12,6 +12,7 @@ import { consumePendingTenantSwitchToast } from '@/utils/tenantSwitch'
 import { useRoleLabel } from '@/composables/useRoleLabel'
 import { notifyLoginSuccess } from '@/utils/loginNotify'
 import { renderWorkspaceNotifyContent } from '@/utils/workspaceNotifyContent'
+import { useResponsiveViewport } from '@/composables/useResponsiveViewport'
 
 // TDesign locale configs
 import enUSConfig from 'tdesign-vue-next/esm/locale/en_US'
@@ -24,6 +25,9 @@ const { formatRole, roleIcon } = useRoleLabel()
 const router = useRouter()
 const authStore = useAuthStore()
 const settingsStore = useSettingsStore()
+
+// Keep one application-wide viewport observer alive across auth/platform routes.
+useResponsiveViewport()
 
 const tdLocaleMap: Record<string, object> = {
   'en-US': enUSConfig,
@@ -268,6 +272,10 @@ onUnmounted(() => {
 </template>
 <style>
 html {
+  /* The application root must remain renderable in every viewport mode.
+     A malformed scoped :global(...) descendant selector once compiled into
+     html.app-coarse-pointer { display: none }, hiding the routed DOM on phones. */
+  display: block !important;
   /* 提示 UA 使用对应配色绘制滚动条等，减少主题切换时的额外重绘 */
   color-scheme: light dark;
 }
@@ -292,5 +300,76 @@ html,
   isolation: isolate;
   transform: translateZ(0);
   backface-visibility: hidden;
+}
+
+
+/* Compact safety net for teleported TDesign surfaces. Desktop widths remain
+   useful defaults, but dialogs and drawers must never escape a phone viewport. */
+@media screen and (max-width: 899px),
+  screen and (max-height: 520px) and (pointer: coarse) {
+  html.app-compact-viewport {
+    --app-font-family: "TencentSans", "PingFang SC", "Microsoft YaHei", sans-serif;
+  }
+
+  html.app-compact-viewport .t-dialog__ctx .t-dialog__position {
+    padding: max(12px, env(safe-area-inset-top)) max(12px, env(safe-area-inset-right)) max(12px, env(safe-area-inset-bottom)) max(12px, env(safe-area-inset-left));
+    align-items: center;
+  }
+
+  html.app-compact-viewport .t-dialog__ctx .t-dialog__position.t-dialog--top {
+    padding-top: max(12px, env(safe-area-inset-top)) !important;
+    align-items: center;
+  }
+
+  html.app-compact-viewport .t-dialog__ctx .t-dialog:not(.t-dialog--fullscreen) {
+    width: min(100%, 560px) !important;
+    max-width: 100% !important;
+    max-height: calc(var(--app-viewport-height, 100dvh) - max(24px, env(safe-area-inset-top)) - max(24px, env(safe-area-inset-bottom)));
+    margin: 0;
+    overflow: hidden;
+  }
+
+  html.app-compact-viewport .t-dialog__ctx .t-dialog__body {
+    max-height: calc(var(--app-viewport-height, 100dvh) - 180px);
+    overflow-y: auto;
+    overflow-x: hidden;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  html.app-compact-viewport .t-drawer .t-drawer__content-wrapper--right,
+  html.app-compact-viewport .t-drawer .t-drawer__content-wrapper--left {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+
+  html.app-compact-viewport .t-drawer .t-drawer__content-wrapper,
+  html.app-compact-viewport .t-drawer .t-drawer__content {
+    max-height: var(--app-viewport-height, 100dvh);
+  }
+
+  html.app-compact-viewport .t-drawer .t-drawer__header {
+    min-height: 52px;
+    padding-top: max(8px, env(safe-area-inset-top));
+    padding-right: max(52px, env(safe-area-inset-right));
+    padding-left: max(12px, env(safe-area-inset-left));
+    flex-shrink: 0;
+  }
+
+  html.app-compact-viewport .t-drawer .t-drawer__close-btn {
+    top: max(8px, env(safe-area-inset-top));
+    right: max(6px, env(safe-area-inset-right));
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+  }
+
+  html.app-compact-viewport .t-drawer .t-drawer__body {
+    min-width: 0;
+    min-height: 0;
+    overflow-x: hidden;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
 }
 </style>

--- a/frontend/src/assets/responsive.less
+++ b/frontend/src/assets/responsive.less
@@ -1,0 +1,31 @@
+// Shared responsive contract for the web UI. Keep these values in sync with
+// composables/useResponsiveViewport.ts. Components should use the semantic
+// mixins instead of introducing one-off breakpoint numbers.
+@phone-max: 767px;
+@compact-max: 899px;
+@tablet-max: 1199px;
+
+.phone(@rules) {
+  @media screen and (max-width: @phone-max) { @rules(); }
+}
+
+.compact(@rules) {
+  @media screen and (max-width: @compact-max),
+    screen and (max-height: 520px) and (pointer: coarse) { @rules(); }
+}
+
+.tablet(@rules) {
+  @media screen and (min-width: 768px) and (max-width: @tablet-max) { @rules(); }
+}
+
+.phone-landscape(@rules) {
+  @media screen and (max-height: 520px) and (pointer: coarse) and (orientation: landscape) { @rules(); }
+}
+
+.touch(@rules) {
+  @media (hover: none) and (pointer: coarse) { @rules(); }
+}
+
+.reduced-motion(@rules) {
+  @media (prefers-reduced-motion: reduce) { @rules(); }
+}

--- a/frontend/src/components/AgentSelector.vue
+++ b/frontend/src/components/AgentSelector.vue
@@ -180,7 +180,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, nextTick } from 'vue';
+import { ref, computed, watch, nextTick, onUnmounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import { Icon as TIcon, Tooltip as TTooltip } from 'tdesign-vue-next';
@@ -190,6 +190,9 @@ import { useOrganizationStore } from '@/stores/organization';
 import { useSettingsStore } from '@/stores/settings';
 import type { SharedAgentInfo } from '@/api/organization';
 import { getRootZoom, rectToCssPx, cssViewportSize } from '@/utils/zoom';
+import { PHONE_MAX_WIDTH } from '@/composables/useResponsiveViewport';
+import { computeAnchoredPopoverLayout } from '@/utils/popoverPosition';
+import { observeViewportChanges } from '@/utils/viewportChangeObserver';
 import { type ModelConfig } from '@/api/model';
 import {
   getAgentNotReadyReasonKeys,
@@ -541,65 +544,55 @@ const updateDropdownPosition = () => {
 
   const zoom = getRootZoom();
   const rect = rectToCssPx(props.anchorEl.getBoundingClientRect(), zoom);
-  const { width: vw, height: vh } = cssViewportSize(zoom);
+  const viewport = cssViewportSize(zoom);
+  const layout = computeAnchoredPopoverLayout(rect, viewport, {
+    preferredWidth: viewport.width <= PHONE_MAX_WIDTH ? 360 : 220,
+    preferredHeight: viewport.width <= PHONE_MAX_WIDTH ? 380 : 280,
+    minSpaceBelow: 100,
+    maxHeightRatio: 0.62,
+    offsetY: 6,
+  });
 
-  const dropdownWidth = 220;
-  const offsetY = 6;
+  dropdownStyle.value = {
+    ...layout.style,
+    zIndex: '10001',
+  };
+};
 
-  let left = Math.floor(rect.left);
-  const minLeft = 16;
-  const maxLeft = Math.max(16, vw - dropdownWidth - 16);
-  left = Math.max(minLeft, Math.min(maxLeft, left));
+let stopViewportObserver: (() => void) | null = null;
 
-  const preferredDropdownHeight = 280;
-  const minDropdownHeight = 100;
-  const topMargin = 20;
-  const spaceBelow = vh - rect.bottom;
-  const spaceAbove = rect.top;
+const stopViewportListeners = () => {
+  stopViewportObserver?.();
+  stopViewportObserver = null;
+};
 
-  let actualHeight: number;
-
-  if (spaceBelow >= minDropdownHeight + offsetY) {
-    actualHeight = Math.min(preferredDropdownHeight, spaceBelow - offsetY - 16);
-    dropdownStyle.value = {
-      position: 'fixed',
-      width: `${dropdownWidth}px`,
-      left: `${left}px`,
-      top: `${Math.floor(rect.bottom + offsetY)}px`,
-      maxHeight: `${actualHeight}px`,
-      zIndex: '10001',
-    };
-  } else {
-    const availableHeight = spaceAbove - offsetY - topMargin;
-    actualHeight = availableHeight >= preferredDropdownHeight
-      ? preferredDropdownHeight
-      : Math.max(minDropdownHeight, availableHeight);
-
-    dropdownStyle.value = {
-      position: 'fixed',
-      width: `${dropdownWidth}px`,
-      left: `${left}px`,
-      bottom: `${vh - rect.top + offsetY}px`,
-      maxHeight: `${actualHeight}px`,
-      zIndex: '10001',
-    };
-  }
+const startViewportListeners = () => {
+  stopViewportListeners();
+  stopViewportObserver = observeViewportChanges(() => {
+    if (!props.visible) return;
+    updateDropdownPosition();
+    hideDetailPanel();
+  });
 };
 
 watch(() => props.visible, (newVal) => {
   if (newVal) {
+    startViewportListeners();
     nextTick(() => updateDropdownPosition());
     chatResources.ensureWebSearchProviders();
   } else {
+    stopViewportListeners();
     hideDetailPanel();
   }
-});
+}, { immediate: true });
 
 watch(activeDetail, (detail) => {
   if (detail) {
     scheduleDetailPanelPosition();
   }
 });
+
+onUnmounted(stopViewportListeners);
 </script>
 
 <style scoped lang="less">
@@ -615,7 +608,8 @@ watch(activeDetail, (detail) => {
   inset: 0;
   z-index: 10000;
   background: transparent;
-  touch-action: none;
+  touch-action: manipulation;
+  overscroll-behavior: contain;
 }
 
 .agent-selector-dropdown {
@@ -684,6 +678,7 @@ watch(activeDetail, (detail) => {
   overflow-y: auto;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
   padding: 6px 4px 8px;
 }
 
@@ -1128,5 +1123,15 @@ watch(activeDetail, (detail) => {
   width: 14px;
   height: 14px;
   flex-shrink: 0;
+}
+
+/* Keep the complete descendant selector inside :global(). Scoped SFC CSS
+   drops descendants that are placed outside the global wrapper. */
+:global(html.app-coarse-pointer .agent-detail-panel) {
+  display: none;
+}
+
+:global(html.app-compact-viewport .agent-selector-dropdown) {
+  border-radius: 12px;
 }
 </style>

--- a/frontend/src/components/AttachmentUpload.vue
+++ b/frontend/src/components/AttachmentUpload.vue
@@ -66,7 +66,7 @@ onMounted(async () => {
       .flatMap(engine => engine.FileTypes || [])
       .filter(type => type && type.toLowerCase() !== 'url')
       .map(type => `.${type.replace(/^\./, '').toLowerCase()}`);
-    supportedTypes.value = [...new Set([...supportedTypes.value, ...discovered])];
+    if (!disposed) supportedTypes.value = [...new Set([...supportedTypes.value, ...discovered])];
   } catch {
     // The static baseline remains available when engine discovery is offline.
   }
@@ -141,6 +141,7 @@ const uploadAttachment = async (attachment: AttachmentFile) => {
       props.agentId,
       'auto',
       (progress) => {
+        if (disposed || !attachments.value.some(item => item.id === attachment.id)) return;
         attachment.progress = progress;
         emitFiles();
       },
@@ -157,6 +158,7 @@ const uploadAttachment = async (attachment: AttachmentFile) => {
       scheduleStatusPoll(attachment);
     }
   } catch (error: any) {
+    if (disposed || !attachments.value.some(item => item.id === attachment.id)) return;
     attachment.status = 'failed';
     attachment.error = error?.message || t('chat.attachmentUploadFailed');
     emitFiles();
@@ -169,14 +171,16 @@ const scheduleStatusPoll = (attachment: AttachmentFile) => {
 };
 
 const pollStatus = async (attachment: AttachmentFile) => {
-  if (!props.sessionId || !attachment.documentId || !attachments.value.some(item => item.id === attachment.id)) return;
+  if (disposed || !props.sessionId || !attachment.documentId || !attachments.value.some(item => item.id === attachment.id)) return;
   try {
     const response = await getTemporaryAttachment(props.sessionId, attachment.documentId);
+    if (disposed || !attachments.value.some(item => item.id === attachment.id)) return;
     attachment.status = response.data.status;
     attachment.error = response.data.error_message;
     emitFiles();
     if (attachment.status !== 'ready' && attachment.status !== 'failed') scheduleStatusPoll(attachment);
   } catch (error: any) {
+    if (disposed || !attachments.value.some(item => item.id === attachment.id)) return;
     attachment.status = 'failed';
     attachment.error = error?.message || t('chat.attachmentParseFailed');
     emitFiles();
@@ -299,6 +303,7 @@ defineExpose({
 </template>
 
 <style scoped lang="less">
+@import '@/assets/responsive.less';
 .attachment-upload {
   width: 100%;
 }
@@ -402,4 +407,29 @@ defineExpose({
 @keyframes attachment-spin {
   to { transform: rotate(360deg); }
 }
+
+.compact({
+  .attachment-preview-bar {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    touch-action: pan-x;
+    scrollbar-width: none;
+  }
+
+  .attachment-preview-bar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .attachment-preview-item {
+    flex: 0 0 min(240px, calc(var(--app-viewport-width, 100vw) - 48px));
+    min-width: 0;
+    max-width: calc(var(--app-viewport-width, 100vw) - 48px);
+  }
+
+  .attachment-preview-remove {
+    width: 24px !important;
+    height: 24px !important;
+  }
+});
 </style>

--- a/frontend/src/components/ChatAttachmentPreviewDrawer.vue
+++ b/frontend/src/components/ChatAttachmentPreviewDrawer.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import DocumentPreview from '@/components/document-preview.vue'
 import { useChatAttachmentPreviewDrawer } from '@/composables/useChatAttachmentPreviewDrawer'
+import { useResponsiveViewport } from '@/composables/useResponsiveViewport'
+import { setBodyScrollLock, releaseBodyScrollLock } from '@/utils/bodyScrollLock'
 
 const drawer = useChatAttachmentPreviewDrawer()
+const { layoutWidth, isCompact } = useResponsiveViewport()
 
 const MAIN_DRAWER_WIDTH_KEY = 'weknora-chat-attachment-drawer-width'
 const MAIN_DRAWER_DEFAULT_WIDTH = 654
 const MAIN_DRAWER_MIN_WIDTH = 480
+const ATTACHMENT_DRAWER_SCROLL_LOCK = 'chat-attachment-preview'
 
 const mainDrawerWidth = ref(MAIN_DRAWER_DEFAULT_WIDTH)
 const mainDrawerResizing = ref(false)
@@ -17,9 +21,10 @@ let mainResizeStartWidth = 0
 
 const visible = computed(() => drawer?.visible.value ?? false)
 const target = computed(() => drawer?.target.value ?? null)
+const drawerSize = computed(() => isCompact.value ? '100%' : `${mainDrawerWidth.value}px`)
 
 function mainDrawerMaxWidth() {
-  return Math.min(1600, Math.max(MAIN_DRAWER_MIN_WIDTH, Math.floor(window.innerWidth * 0.95)))
+  return Math.min(1600, Math.max(MAIN_DRAWER_MIN_WIDTH, Math.floor(layoutWidth.value * 0.95)))
 }
 
 function clampMainDrawerWidth(width: number) {
@@ -39,6 +44,7 @@ function loadMainDrawerWidth() {
 }
 
 function onMainDrawerResizeStart(e: MouseEvent) {
+  if (isCompact.value) return
   mainDrawerResizing.value = true
   mainResizeStartX = e.clientX
   mainResizeStartWidth = mainDrawerWidth.value
@@ -82,6 +88,11 @@ function close() {
   drawer?.close()
 }
 
+watch([visible, isCompact], ([open, compact]) => {
+  setBodyScrollLock(ATTACHMENT_DRAWER_SCROLL_LOCK, open && compact)
+  if ((!open || compact) && mainDrawerResizing.value) cleanupMainDrawerResize()
+}, { immediate: true })
+
 onMounted(() => {
   loadMainDrawerWidth()
   window.addEventListener('resize', onWindowResize)
@@ -90,6 +101,7 @@ onMounted(() => {
 onUnmounted(() => {
   window.removeEventListener('resize', onWindowResize)
   cleanupMainDrawerResize()
+  releaseBodyScrollLock(ATTACHMENT_DRAWER_SCROLL_LOCK)
 })
 </script>
 
@@ -101,7 +113,7 @@ onUnmounted(() => {
       aria-hidden="true"
     />
     <div
-      v-if="visible"
+      v-if="visible && !isCompact"
       class="chat-attachment-drawer-resize-handle"
       :class="{ 'chat-attachment-drawer-resize-handle--active': mainDrawerResizing }"
       :style="{ right: `${mainDrawerWidth}px` }"
@@ -116,11 +128,14 @@ onUnmounted(() => {
   <t-drawer
     :visible="visible"
     :z-index="2000"
-    :size="`${mainDrawerWidth}px`"
+    :size="drawerSize"
     attach="body"
     :close-btn="true"
     :footer="false"
-    :class="['chat-attachment-preview-drawer', { 'chat-attachment-preview-drawer--resizing': mainDrawerResizing }]"
+    :class="['chat-attachment-preview-drawer', {
+      'chat-attachment-preview-drawer--resizing': mainDrawerResizing,
+      'chat-attachment-preview-drawer--compact': isCompact,
+    }]"
     @close="close"
   >
     <template #header>
@@ -148,6 +163,7 @@ onUnmounted(() => {
 </template>
 
 <style scoped lang="less">
+@import '@/assets/responsive.less';
 :deep(.t-drawer__header) {
   font-weight: normal;
 }
@@ -233,6 +249,7 @@ onUnmounted(() => {
 </style>
 
 <style lang="less">
+@import '@/assets/responsive.less';
 .t-drawer.chat-attachment-preview-drawer {
   .t-drawer__content-wrapper,
   .t-drawer__content {
@@ -252,6 +269,24 @@ onUnmounted(() => {
     display: flex;
     flex-direction: column;
     overflow: hidden;
+  }
+}
+
+.t-drawer.chat-attachment-preview-drawer--compact {
+  .t-drawer__content-wrapper,
+  .t-drawer__content {
+    width: 100% !important;
+    max-width: 100%;
+    height: var(--app-viewport-height, 100dvh);
+  }
+
+  .t-drawer__header {
+    min-height: 52px;
+    padding: max(8px, env(safe-area-inset-top)) max(12px, env(safe-area-inset-right)) 8px max(12px, env(safe-area-inset-left));
+  }
+
+  .t-drawer__body {
+    padding: 8px max(8px, env(safe-area-inset-right)) max(12px, env(safe-area-inset-bottom)) max(8px, env(safe-area-inset-left));
   }
 }
 

--- a/frontend/src/components/ChatHeader.vue
+++ b/frontend/src/components/ChatHeader.vue
@@ -366,6 +366,7 @@ function handleMenuClick(data: { value: string }): void {
 </script>
 
 <style scoped lang="less">
+@import '@/assets/responsive.less';
 .chat-header {
   position: absolute;
   top: 10px;
@@ -516,9 +517,53 @@ function handleMenuClick(data: { value: string }): void {
     transform: rotate(360deg);
   }
 }
+
+.compact({
+  .chat-header {
+    position: relative;
+    top: auto;
+    left: auto;
+    align-self: stretch;
+    flex: 0 0 auto;
+    width: 100%;
+    max-width: none;
+    min-height: 48px;
+    padding: 6px max(8px, env(safe-area-inset-right)) 6px max(10px, env(safe-area-inset-left));
+    border-radius: 0;
+    border-bottom: 1px solid var(--td-component-stroke);
+    background: var(--td-bg-color-container);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+
+    &.is-editing {
+      max-width: none;
+      padding: 6px max(8px, env(safe-area-inset-right)) 6px max(8px, env(safe-area-inset-left));
+    }
+  }
+
+  .chat-header__title {
+    flex: 1 1 auto;
+    overflow: hidden;
+  }
+
+  .chat-header__edit {
+    width: auto;
+  }
+
+  .chat-header__edit-input {
+    height: 36px;
+    font-size: 16px;
+  }
+
+  .chat-header__menu-btn {
+    width: 36px;
+    height: 36px;
+  }
+});
 </style>
 
 <style lang="less">
+@import '@/assets/responsive.less';
 .chat-header-menu-popup {
   z-index: 99 !important;
 
@@ -665,5 +710,23 @@ function handleMenuClick(data: { value: string }): void {
   box-shadow:
     0 0 0 0.5px rgba(255, 255, 255, 0.05),
     0 2px 6px rgba(0, 0, 0, 0.2) !important;
+}
+
+html.app-compact-viewport .chat-header-menu-popup .t-popup__content {
+  max-width: calc(var(--app-viewport-width, 100vw) - 16px) !important;
+}
+
+html.app-compact-viewport .chat-header-menu-popup.is-confirm .t-popup__content {
+  width: min(320px, calc(var(--app-viewport-width, 100vw) - 16px)) !important;
+  min-width: 0 !important;
+}
+
+html.app-compact-viewport .chat-header-confirm {
+  width: auto;
+  max-width: 100%;
+}
+
+html.app-coarse-pointer .chat-header-menu__item {
+  min-height: 44px;
 }
 </style>

--- a/frontend/src/components/ChatReferencesDrawer.vue
+++ b/frontend/src/components/ChatReferencesDrawer.vue
@@ -135,10 +135,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, reactive, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { useChatReferencesDrawer } from '@/composables/useChatReferencesDrawer'
+import { useResponsiveViewport } from '@/composables/useResponsiveViewport'
+import { setBodyScrollLock, releaseBodyScrollLock } from '@/utils/bodyScrollLock'
 import {
   buildReferenceSections,
   formatReferenceSnippet,
@@ -154,6 +156,7 @@ const props = defineProps<{
 const { t } = useI18n()
 const router = useRouter()
 const drawer = useChatReferencesDrawer()
+const { layoutWidth, isCompact } = useResponsiveViewport()
 
 const listElement = ref<HTMLElement | null>(null)
 const itemElements = new Map<string, HTMLElement>()
@@ -167,8 +170,8 @@ const highlight = computed(() => drawer?.highlight.value ?? null)
 
 const useOverlay = computed(() => {
   if (props.embeddedMode) return true
-  if (typeof window === 'undefined') return false
-  return window.innerWidth < (props.overlayBreakpoint ?? 960)
+  const width = layoutWidth.value
+  return width > 0 ? width < (props.overlayBreakpoint ?? 960) : isCompact.value
 })
 
 const sections = computed(() => buildReferenceSections(references.value))
@@ -317,6 +320,21 @@ watch(highlight, () => {
   void scrollToHighlight()
 })
 
+const REFERENCES_SCROLL_LOCK = 'chat-references-overlay'
+const handleEscape = (event: KeyboardEvent) => {
+  if (event.key === 'Escape' && visible.value && useOverlay.value) close()
+}
+
+watch(() => visible.value && useOverlay.value, (locked) => {
+  setBodyScrollLock(REFERENCES_SCROLL_LOCK, locked)
+}, { immediate: true })
+
+onMounted(() => window.addEventListener('keydown', handleEscape))
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleEscape)
+  releaseBodyScrollLock(REFERENCES_SCROLL_LOCK)
+})
+
 watch(visible, (open) => {
   if (!open) {
     panelEntered.value = false
@@ -327,6 +345,7 @@ watch(visible, (open) => {
 </script>
 
 <style scoped lang="less">
+@import '@/assets/responsive.less';
 .chat-references-panel__backdrop {
   position: fixed;
   inset: 0;
@@ -601,4 +620,30 @@ watch(visible, (open) => {
 .references-backdrop-leave-to {
   opacity: 0;
 }
+
+.compact({
+  .chat-references-panel {
+    width: 100%;
+    max-width: none;
+    border-left: 0;
+    box-shadow: none;
+  }
+
+  .chat-references-panel__header {
+    min-height: 52px;
+    padding: max(8px, env(safe-area-inset-top)) max(12px, env(safe-area-inset-right)) 8px max(12px, env(safe-area-inset-left));
+  }
+
+  .chat-references-panel__body {
+    padding: 4px max(10px, env(safe-area-inset-right)) max(20px, env(safe-area-inset-bottom)) max(10px, env(safe-area-inset-left));
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-y;
+  }
+
+  .chat-references-panel__close {
+    width: 40px;
+    height: 40px;
+  }
+});
 </style>

--- a/frontend/src/components/ContextualGuide.vue
+++ b/frontend/src/components/ContextualGuide.vue
@@ -13,6 +13,7 @@ import {
   type ContextualGuideTourConfig,
   type ContextualGuideTourId,
 } from '@/config/contextualGuides'
+import { useResponsiveViewport } from '@/composables/useResponsiveViewport'
 
 const props = defineProps<{
   tour: ContextualGuideTourId
@@ -22,6 +23,23 @@ const props = defineProps<{
 
 const config: ContextualGuideTourConfig = CONTEXTUAL_GUIDE_TOURS[props.tour]
 const active = ref(false)
+const { isCompact } = useResponsiveViewport()
+const COMPACT_EXIT_DEBOUNCE_MS = 300
+let compactExiting = false
+let compactExitTimer: number | null = null
+
+const clearCompactExitTimer = () => {
+  if (compactExitTimer !== null) {
+    window.clearTimeout(compactExitTimer)
+    compactExitTimer = null
+  }
+}
+
+const canOpen = () => {
+  if (!props.when) return false
+  if (isCompact.value) return false
+  return !compactExiting
+}
 
 let openTimer: ReturnType<typeof setTimeout> | null = null
 let waitGlobalTimer: ReturnType<typeof setTimeout> | null = null
@@ -35,23 +53,24 @@ const clearTimers = () => {
     clearTimeout(waitGlobalTimer)
     waitGlobalTimer = null
   }
+  clearCompactExitTimer()
 }
 
 const tryOpen = () => {
   if (active.value) return
-  if (!props.when) return
+  if (!canOpen()) return
   if (isContextualGuideDone(props.tour)) return
   if (!isGlobalUserGuideDone()) return
 
   openTimer = setTimeout(() => {
-    if (!props.when || isContextualGuideDone(props.tour) || active.value) return
+    if (!canOpen() || isContextualGuideDone(props.tour) || active.value) return
     active.value = true
   }, config.openDelayMs)
 }
 
 const scheduleOpen = () => {
   clearTimers()
-  if (!props.when || isContextualGuideDone(props.tour)) return
+  if (!canOpen() || isContextualGuideDone(props.tour)) return
 
   if (isGlobalUserGuideDone()) {
     tryOpen()
@@ -60,7 +79,7 @@ const scheduleOpen = () => {
 
   // 等待全局新手引导结束后再展示情境引导，避免两层遮罩叠加
   const poll = () => {
-    if (!props.when || isContextualGuideDone(props.tour)) {
+    if (!canOpen() || isContextualGuideDone(props.tour)) {
       clearTimers()
       return
     }
@@ -82,14 +101,27 @@ const onFinish = () => {
 }
 
 watch(
-  () => props.when,
-  (val) => {
-    if (val) {
-      scheduleOpen()
-    } else {
+  [() => props.when, isCompact],
+  ([when, compact]) => {
+    if (compact) {
       clearTimers()
       active.value = false
+      compactExiting = false
+      clearCompactExitTimer()
+      return
     }
+    if (!when) {
+      clearTimers()
+      active.value = false
+      return
+    }
+    clearCompactExitTimer()
+    compactExiting = true
+    compactExitTimer = window.setTimeout(() => {
+      compactExitTimer = null
+      compactExiting = false
+      if (!isCompact.value && props.when) scheduleOpen()
+    }, COMPACT_EXIT_DEBOUNCE_MS)
   },
   { immediate: true },
 )

--- a/frontend/src/components/GlobalCommandPalette.vue
+++ b/frontend/src/components/GlobalCommandPalette.vue
@@ -647,6 +647,7 @@ onUnmounted(() => {
 </script>
 
 <style lang="less" scoped>
+@import '@/assets/responsive.less';
 .cmdk {
   display: flex;
   flex-direction: column;
@@ -838,6 +839,40 @@ onUnmounted(() => {
   color: var(--td-text-color-secondary);
   border-radius: 3px;
 }
+
+
+.compact({
+  .cmdk {
+    min-height: 0;
+    height: min(68vh, calc(var(--app-viewport-height, 100dvh) - 24px));
+    max-height: calc(var(--app-viewport-height, 100dvh) - 24px);
+  }
+
+  .cmdk__input-row {
+    gap: 4px;
+    padding: 10px;
+  }
+
+  .cmdk__scope-chip {
+    max-width: 110px;
+  }
+
+  .cmdk__icon-btn {
+    width: 40px;
+    min-width: 40px;
+    height: 40px;
+    border-radius: 10px;
+  }
+
+  .cmdk__results {
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .cmdk__footer {
+    display: none;
+  }
+});
 </style>
 
 <style lang="less">
@@ -856,6 +891,20 @@ onUnmounted(() => {
 .cmdk-retrieval-drawer {
   .section-header {
     font-weight: 600;
+  }
+}
+
+
+@media screen and (max-width: 899px),
+  screen and (max-height: 520px) and (pointer: coarse) {
+  .cmdk-dialog .t-dialog {
+    width: calc(100vw - 16px) !important;
+    max-width: calc(100vw - 16px) !important;
+    border-radius: 14px;
+  }
+
+  .cmdk-dialog .t-dialog__body {
+    max-height: none !important;
   }
 }
 </style>

--- a/frontend/src/components/Input-field.vue
+++ b/frontend/src/components/Input-field.vue
@@ -16,6 +16,14 @@ import MentionSelector from './MentionSelector.vue';
 import AgentSelector from './AgentSelector.vue';
 import { getCaretCoordinates } from '@/utils/caret';
 import { getRootZoom, rectToCssPx, cssViewportSize } from '@/utils/zoom';
+import { PHONE_MAX_WIDTH, useResponsiveViewport } from '@/composables/useResponsiveViewport';
+import {
+  DEFAULT_POPOVER_EDGE_GAP,
+  clampPopoverLeft,
+  clampPopoverWidth,
+  computeAnchoredPopoverLayout,
+} from '@/utils/popoverPosition';
+import { observeViewportChanges } from '@/utils/viewportChangeObserver';
 import { type ModelConfig } from '@/api/model';
 import { type CustomAgent, BUILTIN_QUICK_ANSWER_ID, BUILTIN_SMART_REASONING_ID } from '@/api/agent';
 import { useChatResourcesStore } from '@/stores/chatResources';
@@ -51,6 +59,7 @@ const orgStore = useOrganizationStore();
 const menuStore = useMenuStore();
 const chatResources = useChatResourcesStore();
 const editorResources = useEditorResourcesStore();
+const { isCompact } = useResponsiveViewport();
 const {
   agents,
   disabledOwnAgentIds,
@@ -146,7 +155,6 @@ const triggerImageUpload = () => {
 const atButtonRef = ref<HTMLElement>();
 const showAgentModeSelector = ref(false);
 const agentModeButtonRef = ref<HTMLElement>();
-const agentModeDropdownStyle = ref<Record<string, string>>({});
 
 const selectedAgentId = computed({
   get: () => settingsStore.selectedAgentId || BUILTIN_QUICK_ANSWER_ID,
@@ -221,8 +229,7 @@ const agentKBSelectionMode = computed(() => {
 // 共享智能体下的知识库列表（来自 listKnowledgeBases(agent_id)），用于已选知识库展示与 org 角标
 const sharedAgentKbList = ref<Array<{ id: string; name: string; type?: string; knowledge_count?: number; chunk_count?: number }>>([]);
 
-// 当智能体改变时，模型、可@知识库列表均跟随新智能体配置；网络搜索由用户主动开启
-// 知识库：用新智能体配置的列表替换当前选中，使已选与可@列表一致（含共享智能体）
+// Keep knowledge-base selection aligned when the active agent changes.
 watch([selectedAgentId, agentKnowledgeBases, agentKBSelectionMode], ([newAgentId, newAgentKbs, newKbMode], [oldAgentId]) => {
   if (settingsStore._isApplyingSessionState) return;
   if (newAgentId !== oldAgentId && oldAgentId !== undefined) {
@@ -275,8 +282,7 @@ const isWebSearchDisabledByAgent = computed(() => {
 });
 
 // 知识库选择是否被智能体锁定
-// 1. 如果智能体配置了 kb_selection_mode = 'none' → 完全禁用知识库
-// 其他情况用户都可以在允许的范围内通过 @ 选择知识库
+// kb_selection_mode='none' disables knowledge-base mentions; other modes allow selection within the agent scope.
 const isKnowledgeBaseLockedByAgent = computed(() => {
   if (!hasAgentConfig.value) return false;
   // 只有禁用了知识库才锁定
@@ -378,8 +384,7 @@ watch([selectedAgentId, agentMCPSelectionMode, agentSkillsSelectionMode], ([newA
   }
 });
 
-// 从 KB 对象里抽能力位，优先用 backend 显式的 capabilities 字段；否则回退到 indexing_strategy，
-// 最后拿 kb.type === 'faq' 兜底。shared / owned / agent-scope 三路的 KB 响应结构一致。
+// Normalize KB capabilities from explicit metadata, indexing strategy, or the FAQ type fallback.
 const kbToScopeCaps = (kb: any): Partial<ScopeCapabilities> => {
   if (kb?.capabilities) {
     return {
@@ -400,8 +405,7 @@ const kbToScopeCaps = (kb: any): Partial<ScopeCapabilities> => {
   };
 };
 
-// 当前智能体的 agent_mode（quick-answer / smart-reasoning），用于把
-// "RAG-only 模式不能 @ wiki-only 知识库"这种隐式约束带进 KB 过滤。
+// Apply agent-mode capability constraints so incompatible knowledge bases are not offered.
 const agentMode = computed(() => {
   if (!hasAgentConfig.value) return '';
   return currentAgentConfig.value?.agent_mode || '';
@@ -463,8 +467,7 @@ const isComposing = ref(false);
 const isMentionTriggeredByButton = ref(false);
 const mentionHasMore = ref(false);
 const mentionGroupCounts = ref<Partial<Record<MentionItemType, number>>>({});
-// 当前 @ 会话可见的 KB ID 集合（含工具兼容性过滤），分页加载文件时复用，
-// 避免 append 请求把不兼容 KB 的文件漏进来。`null` 表示"不受限制"（非智能体场景）
+// Reuse the compatible KB id set for paginated file loading; null means unrestricted.
 const mentionAllowedKbIds = ref<Set<string> | null>(null);
 const mentionLoading = ref(false);
 const mentionOffset = ref(0);
@@ -580,8 +583,7 @@ const selectedMCPItems = computed<MentionItem[]>(() => {
     });
 });
 
-// 合并所有选中项（用于输入框内显示）
-// 现在智能体配置的知识库也在 store 中，统一从 selectedKbs 获取
+// Build the input chips from selected resources kept in the settings store.
 const allSelectedItems = computed(() => {
   // 获取智能体预配置的知识库 IDs（用于标记和排序）
   const agentKbIds = agentKnowledgeBases.value;
@@ -594,7 +596,7 @@ const allSelectedItems = computed(() => {
     isAgentConfigured: agentKbIds.includes(kb.id)
   }));
 
-  // 用户选择的文件（根据 fileIdToKbId + 共享列表/共享智能体补全 org_name，用于角标）
+  // Enrich selected files with their knowledge-base and shared-space metadata.
   const sharedKbOrgMap: Record<string, string> = {};
   (orgStore.sharedKnowledgeBases || []).forEach((s: any) => {
     if (s.knowledge_base?.id != null && s.org_name) {
@@ -832,10 +834,8 @@ const loadAgents = async (force = false) => {
   }
 };
 
-// 默认选中的 builtin（builtin-quick-answer）也可能被当前空间管理员停用。
-// 列表加载完后做一次纠偏：若当前选中的是本空间停用的 agent（仅限「我的/builtin」，
-// 共享智能体由源空间决定，本地停用列表不适用），按 智能推理 → 快速问答 →
-// 第一个可用 的顺序兜底切换。全部都被停用时保持原选择不动（极端场景，UI 仍会
+// Reconcile a disabled default builtin agent after the agent list has loaded.
+// Shared agents follow their source tenant; otherwise fall back to the first enabled local agent.
 // 在 enabledAgents 过滤后显示空，由用户在智能体页恢复任意一个）。
 const ensureSelectedAgentNotDisabled = () => {
   if (settingsStore.selectedAgentSourceTenantId) return
@@ -856,8 +856,7 @@ const ensureSelectedAgentNotDisabled = () => {
   if (!fallback) return
 
   settingsStore.selectAgent(fallback.id)
-  // selectAgent 内部仅对两个 builtin 常量自动切 isAgentEnabled；自定义 agent 兜底时
-  // 需要按其 agent_mode 显式同步一次，保证模式徽标与对话行为一致。
+  // Keep the mode badge and chat behavior in sync for custom agents as well as builtins.
   if (fallback.id !== BUILTIN_QUICK_ANSWER_ID && fallback.id !== BUILTIN_SMART_REASONING_ID) {
     settingsStore.toggleAgent(fallback.config?.agent_mode === 'smart-reasoning')
   }
@@ -946,10 +945,8 @@ const ensureModelSelection = () => {
   }
 };
 
-// 智能体身份或其数据到位时，把对话模型同步到智能体配置的 model_id。
-// 修复场景：导航离开再返回时，initChatModelSelection 会用 localStorage 的 lastPick
-// 覆盖共享智能体绑定的源空间 model_id，UI 显示「未配置」——此时需要拉回 agent 模型。
-// 但若用户在本页手动改过模型（lastPick 与 agent 默认不同且当前选中即为 lastPick），
+// Resync the configured agent model after route restoration overrides it with the last local choice.
+// Preserve a deliberate user model choice while repairing stale route-restored state.
 // 则保留用户选择，避免 creatChat → chat 跳转后把模型 B 冲回智能体默认 A。
 watch(
   [selectedAgentId, () => settingsStore.selectedAgentSourceTenantId, agentModelId],
@@ -1038,111 +1035,22 @@ const modelDisplayName = (model: ModelConfig) => {
 
 const updateModelDropdownPosition = () => {
   const anchor = modelButtonRef.value;
-  if (!anchor) {
-    modelDropdownStyle.value = {
-      position: 'fixed',
-      top: '50%',
-      left: '50%',
-      transform: 'translate(-50%, -50%)',
-    };
-    return;
-  }
+  if (!anchor) return;
 
-  // Normalize coordinates to CSS pixels so they are interpreted the same way
-  // the browser will render them under the root `zoom` (see utils/zoom.ts).
   const zoom = getRootZoom();
   const rect = rectToCssPx(anchor.getBoundingClientRect(), zoom);
-  console.log('[Model Dropdown] Button rect:', {
-    top: rect.top,
-    bottom: rect.bottom,
-    left: rect.left,
-    right: rect.right,
-    width: rect.width,
-    height: rect.height
+  const viewport = cssViewportSize(zoom);
+  const layout = computeAnchoredPopoverLayout(rect, viewport, {
+    preferredWidth: viewport.width <= PHONE_MAX_WIDTH
+      ? viewport.width - DEFAULT_POPOVER_EDGE_GAP * 2
+      : 280,
+    preferredHeight: viewport.width <= PHONE_MAX_WIDTH ? 360 : 280,
+    minSpaceBelow: 200,
+    maxHeightRatio: 0.58,
+    offsetY: 8,
   });
 
-  const dropdownWidth = 280;
-  const offsetY = 8;
-  const { width: vw, height: vh } = cssViewportSize(zoom);
-
-  // 左对齐到触发元素的左边缘
-  // 使用 Math.floor 而不是 Math.round，避免像素对齐问题
-  let left = Math.floor(rect.left);
-
-  // 边界处理：不超出视口左右（留 16px margin）
-  const minLeft = 16;
-  const maxLeft = Math.max(16, vw - dropdownWidth - 16);
-  left = Math.max(minLeft, Math.min(maxLeft, left));
-
-  // 垂直定位：紧贴按钮，使用合理的高度避免空白
-  const preferredDropdownHeight = 280; // 优选高度（紧凑且够用）
-  const maxDropdownHeight = 360; // 最大高度
-  const minDropdownHeight = 200; // 最小高度
-  const topMargin = 20; // 顶部留白
-  const spaceBelow = vh - rect.bottom; // 下方剩余空间
-  const spaceAbove = rect.top; // 上方剩余空间
-
-  console.log('[Model Dropdown] Space check:', {
-    spaceBelow,
-    spaceAbove,
-    windowHeight: vh
-  });
-
-  let actualHeight: number;
-  let shouldOpenBelow: boolean;
-
-  // 优先考虑下方空间
-  if (spaceBelow >= minDropdownHeight + offsetY) {
-    // 下方有足够空间，向下弹出
-    actualHeight = Math.min(preferredDropdownHeight, spaceBelow - offsetY - 16);
-    shouldOpenBelow = true;
-    console.log('[Model Dropdown] Position: below button', { actualHeight });
-  } else {
-    // 向上弹出，优先使用 preferredHeight，必要时才扩展到 maxHeight
-    const availableHeight = spaceAbove - offsetY - topMargin;
-    if (availableHeight >= preferredDropdownHeight) {
-      // 有足够空间显示优选高度
-      actualHeight = preferredDropdownHeight;
-    } else {
-      // 空间不够，使用可用空间（但不小于最小高度）
-      actualHeight = Math.max(minDropdownHeight, availableHeight);
-    }
-    shouldOpenBelow = false;
-    console.log('[Model Dropdown] Position: above button', { actualHeight });
-  }
-
-  // 根据弹出方向使用不同的定位方式
-  if (shouldOpenBelow) {
-    // 向下弹出：使用 top 定位，左对齐
-    const top = Math.floor(rect.bottom + offsetY);
-    console.log('[Model Dropdown] Opening below, top:', top);
-    modelDropdownStyle.value = {
-      position: 'fixed !important',
-      width: `${dropdownWidth}px`,
-      left: `${left}px`,
-      top: `${top}px`,
-      maxHeight: `${actualHeight}px`,
-      transform: 'none !important',
-      margin: '0 !important',
-      padding: '0 !important'
-    };
-  } else {
-    // 向上弹出：使用 bottom 定位，左对齐
-    const bottom = vh - rect.top + offsetY;
-    console.log('[Model Dropdown] Opening above, bottom:', bottom);
-    modelDropdownStyle.value = {
-      position: 'fixed !important',
-      width: `${dropdownWidth}px`,
-      left: `${left}px`,
-      bottom: `${bottom}px`,
-      maxHeight: `${actualHeight}px`,
-      transform: 'none !important',
-      margin: '0 !important',
-      padding: '0 !important'
-    };
-  }
-
-  console.log('[Model Dropdown] Applied style:', modelDropdownStyle.value);
+  modelDropdownStyle.value = layout.style;
 };
 
 // Mention Logic
@@ -1165,7 +1073,7 @@ const loadMentionItems = async (q: string, resetIndex = true, append = false) =>
     const agentId = selectedAgentId.value;
     if (sourceTenantId && agentId) {
       // 共享智能体：按 agent_id 拉取该智能体配置的知识库范围（后端从共享关系解析空间）
-      try {
+    try {
         const list = await chatResources.ensureAgentKnowledgeBases(agentId);
         const orgLabel = sharedAgentOrgName.value || '';
         // 保留 capabilities / indexing_strategy，后面过滤时要用
@@ -1219,8 +1127,7 @@ const loadMentionItems = async (q: string, resetIndex = true, append = false) =>
     if (hasAgentConfig.value) {
       const kbMode = agentKBSelectionMode.value;
       // 共享智能体路径：`availableKbs` 已经来自 `listKnowledgeBases({agent_id})`,
-      // 后端按 kb_selection_mode + allowed_tools 做过权威过滤；前端不再重复一遍。
-      // 本人智能体路径：走 own KBs + user-shared KBs 合并，后端拿不到 agent 上下文，
+      // Shared-agent responses are backend-filtered; local agents still need client-side compatibility filtering.
       // 所以 'selected' 要收敛到配置集合，'all' 要按工具派生的能力过滤。
       const isSharedAgent = !!(sourceTenantId && agentId);
       if (kbMode === 'none') {
@@ -1335,8 +1242,7 @@ const loadMentionItems = async (q: string, resetIndex = true, append = false) =>
   const toolsAllowFiles = !hasAgentConfig.value || toolsConsumeFiles(agentAllowedTools.value);
   const shouldLoadFiles = kbModeAllowsFiles && toolsAllowFiles;
 
-  // 空关键词时显式请求最近文件；有关键词时返回匹配文件。
-  // `recent=true` 只用于浏览态，避免其他搜索调用漏传关键词时静默退化为最近列表。
+  // Use recent-file browsing only for an empty query; non-empty queries remain explicit searches.
   const fileSearchKeyword = q.trim();
   if (shouldLoadFiles) {
     mentionLoading.value = true;
@@ -1360,11 +1266,8 @@ const loadMentionItems = async (q: string, resetIndex = true, append = false) =>
         let files = res.data;
         const rawTotal = typeof res.total === 'number' ? res.total : undefined;
         const apiPageSize = res.data.length;
-        // 按当前 @ 会话的兼容 KB 集合过滤：
-        //   - 非智能体场景：`mentionAllowedKbIds` 为 null，跳过；
-        //   - 智能体场景（含 shared agent）：'selected' 会把 ID 收敛到用户勾的 KB，
-        //     'all' 会收敛到"兼容"的 KB，'none' 根本走不到这里（shouldLoadFiles=false）。
-        //   这样分页 append 也能用同一份集合，不再只兜住 'selected' + 非共享的分支。
+        // Apply the current mention-session KB scope before appending files.
+        // Agent modes narrow files to selected or compatible KBs; none skips file loading entirely.
         if (mentionAllowedKbIds.value) {
           const allowed = mentionAllowedKbIds.value;
           files = files.filter((f: any) => {
@@ -1514,40 +1417,27 @@ const onInput = (val: string | InputEvent) => {
       // Normalize coordinates to CSS pixels (root <html> may carry `zoom`).
       const zoom = getRootZoom();
       const rect = rectToCssPx(textarea.getBoundingClientRect(), zoom);
-      const { width: vw, height: vh } = cssViewportSize(zoom);
+      const { width: viewportWidth, height: viewportHeight } = cssViewportSize(zoom);
       const scrollTop = textarea.scrollTop;
-      const menuHeight = 320; // 预估最大高度
+      const menuWidth = clampPopoverWidth(viewportWidth <= PHONE_MAX_WIDTH ? 340 : 220, viewportWidth);
+      const left = clampPopoverLeft(rect.left + coords.left, menuWidth, viewportWidth);
 
-      let left = rect.left + coords.left;
-      // Prevent menu from going off-screen horizontally
-      if (left + 300 > vw) {
-        left = vw - 300 - 10;
-      }
-
-      // 光标相对于视口的实际 top 位置（CSS 像素）
+      // VisualViewport height shrinks with the Android keyboard, so caret popovers must use it.
       const cursorAbsoluteTop = rect.top + coords.top - scrollTop;
-      const lineHeight = coords.height; // 光标高度
+      const lineHeight = coords.height;
+      const availableBelow = Math.max(0, viewportHeight - cursorAbsoluteTop - lineHeight - DEFAULT_POPOVER_EDGE_GAP);
+      const availableAbove = Math.max(0, cursorAbsoluteTop - DEFAULT_POPOVER_EDGE_GAP);
+      const openAbove = availableBelow < 160 && availableAbove > availableBelow;
+      const maxHeight = Math.min(320, openAbove ? availableAbove : availableBelow);
 
-      // Check vertical space below cursor
-      const spaceBelow = vh - (cursorAbsoluteTop + lineHeight);
-
-      if (spaceBelow < menuHeight && cursorAbsoluteTop > menuHeight) {
-        // Show above cursor (using bottom positioning)
-        const bottom = vh - cursorAbsoluteTop;
-        mentionStyle.value = {
-          left: `${left}px`,
-          bottom: `${bottom}px`,
-          top: 'auto'
-        };
-      } else {
-        // Show below cursor (using top positioning)
-        const top = cursorAbsoluteTop + lineHeight;
-        mentionStyle.value = {
-          left: `${left}px`,
-          top: `${top}px`,
-          bottom: 'auto'
-        };
-      }
+      mentionStyle.value = {
+        width: `${menuWidth}px`,
+        maxHeight: `${maxHeight}px`,
+        left: `${left}px`,
+        ...(openAbove
+          ? { bottom: `${Math.floor(viewportHeight - cursorAbsoluteTop)}px`, top: 'auto' }
+          : { top: `${Math.floor(cursorAbsoluteTop + lineHeight)}px`, bottom: 'auto' }),
+      };
 
       loadMentionItems("");
     }
@@ -1561,15 +1451,23 @@ const onCompositionStart = () => {
 const onCompositionEnd = (e: CompositionEvent) => {
   isComposing.value = false;
   // 手动触发 onInput 逻辑
-  // 注意：在 compositionend 时，v-model 可能还没更新，或者已经更新但我们需要用最新值
-  // TDesign textarea 可能需要 nextTick
+  // Wait for v-model and the TDesign textarea to settle after IME composition.
   nextTick(() => {
     onInput(query.value);
   });
 };
 
+const releaseChatInputFocus = () => {
+  const textarea = getTextareaEl();
+  if (textarea && document.activeElement === textarea) textarea.blur();
+
+  const activeElement = document.activeElement;
+  if (activeElement instanceof HTMLElement && activeElement.closest('.answers-input')) {
+    activeElement.blur();
+  }
+};
+
 const triggerMention = () => {
-  // 如果当前没有任何可提及资源，不允许打开选择器
   if (isMentionDisabled.value) {
     const msgKey = isKnowledgeBaseDisabledByAgent.value ? 'input.kbDisabledByAgent' : 'input.kbLockedByAgent';
     MessagePlugin.warning(t(msgKey));
@@ -1579,13 +1477,33 @@ const triggerMention = () => {
   const textarea = getTextareaEl();
   if (!textarea) return;
 
-  // 关闭其他选择器
   showAgentModeSelector.value = false;
   showModelSelector.value = false;
 
+  // Desktop mention search intentionally uses the chat textarea as its filter.
+  // On compact touch screens that behavior opens the software keyboard and
+  // mixes filter text into the actual question, so use the independent KB
+  // picker and keep the chat textarea unfocused.
+  if (isCompact.value) {
+    showMention.value = false;
+    isMentionTriggeredByButton.value = false;
+    mentionQuery.value = "";
+
+    const nextVisible = !showKbSelector.value;
+    if (nextVisible) releaseChatInputFocus();
+    showKbSelector.value = nextVisible;
+
+    if (nextVisible) {
+      nextTick(() => {
+        if (showKbSelector.value) releaseChatInputFocus();
+      });
+    }
+    return;
+  }
+
+  showKbSelector.value = false;
   textarea.focus();
 
-  // 直接显示菜单，不插入 @
   showMention.value = true;
   isMentionTriggeredByButton.value = true;
   mentionQuery.value = "";
@@ -1594,29 +1512,22 @@ const triggerMention = () => {
   // Normalize coordinates to CSS pixels (root <html> may carry `zoom`).
   const zoom = getRootZoom();
   const rect = rectToCssPx(textarea.getBoundingClientRect(), zoom);
-  const { height: vh } = cssViewportSize(zoom);
-  const menuHeight = 320;
+  const { width: viewportWidth, height: viewportHeight } = cssViewportSize(zoom);
+  const menuWidth = clampPopoverWidth(viewportWidth <= PHONE_MAX_WIDTH ? 340 : 220, viewportWidth);
+  const left = clampPopoverLeft(rect.left, menuWidth, viewportWidth);
+  const availableAbove = Math.max(0, rect.top - DEFAULT_POPOVER_EDGE_GAP);
+  const availableBelow = Math.max(0, viewportHeight - rect.bottom - DEFAULT_POPOVER_EDGE_GAP);
+  const openAbove = availableAbove > availableBelow;
+  const maxHeight = Math.min(320, openAbove ? availableAbove : availableBelow);
 
-  // 判断输入框上方空间
-  const spaceAbove = rect.top;
-  const spaceBelow = vh - rect.bottom;
-
-  // 优先显示在上方，除非上方空间不足且下方空间充足
-  if (spaceAbove > menuHeight || spaceAbove > spaceBelow) {
-    // Show above textarea
-    mentionStyle.value = {
-      left: `${rect.left}px`,
-      bottom: `${vh - rect.top + 8}px`, // 8px padding
-      top: 'auto'
-    };
-  } else {
-    // Show below textarea
-    mentionStyle.value = {
-      left: `${rect.left}px`,
-      top: `${rect.bottom + 8}px`,
-      bottom: 'auto'
-    };
-  }
+  mentionStyle.value = {
+    width: `${menuWidth}px`,
+    maxHeight: `${maxHeight}px`,
+    left: `${left}px`,
+    ...(openAbove
+      ? { bottom: `${Math.floor(viewportHeight - rect.top + 8)}px`, top: 'auto' }
+      : { top: `${Math.floor(rect.bottom + 8)}px`, bottom: 'auto' }),
+  };
 
   loadMentionItems("");
 };
@@ -1685,34 +1596,24 @@ const removeFile = (id: string) => {
 };
 
 const toggleModelSelector = () => {
-  // 如果智能体锁定了模型，不允许打开选择器
   if (isModelLockedByAgent.value) {
     MessagePlugin.warning(t('input.modelLockedByAgent'));
     return;
   }
 
-  // 互斥：关闭其他
+  // Keep floating selectors mutually exclusive.
   showMention.value = false;
   showAgentModeSelector.value = false;
 
   showModelSelector.value = !showModelSelector.value;
   if (showModelSelector.value) {
-    if (!availableModels.value.length) {
-      loadChatModels();
-    }
-    // 多次更新位置确保准确
+    if (!availableModels.value.length) loadChatModels();
     nextTick(() => {
       updateModelDropdownPosition();
-      requestAnimationFrame(() => {
-        updateModelDropdownPosition();
-        setTimeout(() => {
-          updateModelDropdownPosition();
-        }, 50);
-      });
+      requestAnimationFrame(updateModelDropdownPosition);
     });
   }
 };
-
 const closeModelSelector = () => {
   showModelSelector.value = false;
 };
@@ -1731,12 +1632,30 @@ const closeMentionSelector = (e: MouseEvent) => {
   showMention.value = false;
 };
 
-// 窗口事件处理器
-let resizeHandler: (() => void) | null = null;
-let scrollHandler: (() => void) | null = null;
+const closeFloatingSelectorsOnEscape = (event: KeyboardEvent) => {
+  if (event.key !== 'Escape') return;
+  showMention.value = false;
+  showAgentModeSelector.value = false;
+  showModelSelector.value = false;
+};
 
+// 窗口事件处理器
+let stopViewportObserver: (() => void) | null = null;
+
+const handleViewportChange = () => {
+  if (showModelSelector.value) updateModelDropdownPosition();
+  // Caret-relative mention geometry becomes stale after any viewport movement.
+  if (showMention.value) showMention.value = false;
+};
 onMounted(() => {
-  // Embed 渠道由宿主注入 agent/KB，勿拉取需 JWT 的平台资源
+  window.addEventListener(CHAT_FILE_DROP_EVENT, handleChatFileDrop as EventListener);
+  document.addEventListener('click', closeAgentModeSelector);
+  document.addEventListener('click', closeModelSelector);
+  document.addEventListener('click', closeMentionSelector);
+  document.addEventListener('keydown', closeFloatingSelectorsOnEscape);
+  stopViewportObserver = observeViewportChanges(handleViewportChange);
+
+  // Embed channels receive agent/KB state from the host and must not call JWT platform APIs.
   if (props.embeddedMode) return;
 
   // 并行拉取；若 platform 已预取且缓存未过期则直接复用
@@ -1748,7 +1667,6 @@ onMounted(() => {
     loadAgents(),
     loadMCPServices(),
   ]);
-  window.addEventListener(CHAT_FILE_DROP_EVENT, handleChatFileDrop as EventListener);
 
   // 从持久化恢复 fileId -> kbId，刷新后共享知识库文件可带 kb_id 拉取（仅保留当前仍选中的文件）
   const persisted = settingsStore.settings.selectedFileKbMap;
@@ -1776,31 +1694,7 @@ onMounted(() => {
     });
   }
 
-  // 监听点击外部关闭下拉菜单
-  document.addEventListener('click', closeAgentModeSelector);
-  document.addEventListener('click', closeModelSelector);
-  document.addEventListener('click', closeMentionSelector);
 
-  // 监听窗口大小变化和滚动，重新计算位置
-  resizeHandler = () => {
-    if (showModelSelector.value) {
-      updateModelDropdownPosition();
-    }
-    if (showAgentModeSelector.value) {
-      updateAgentModeDropdownPosition();
-    }
-  };
-  scrollHandler = () => {
-    if (showModelSelector.value) {
-      updateModelDropdownPosition();
-    }
-    if (showAgentModeSelector.value) {
-      updateAgentModeDropdownPosition();
-    }
-  };
-
-  window.addEventListener('resize', resizeHandler, { passive: true });
-  window.addEventListener('scroll', scrollHandler, { passive: true, capture: true });
 });
 
 onUnmounted(() => {
@@ -1808,12 +1702,9 @@ onUnmounted(() => {
   document.removeEventListener('click', closeAgentModeSelector);
   document.removeEventListener('click', closeModelSelector);
   document.removeEventListener('click', closeMentionSelector);
-  if (resizeHandler) {
-    window.removeEventListener('resize', resizeHandler);
-  }
-  if (scrollHandler) {
-    window.removeEventListener('scroll', scrollHandler, { capture: true });
-  }
+  document.removeEventListener('keydown', closeFloatingSelectorsOnEscape);
+  stopViewportObserver?.();
+  stopViewportObserver = null;
 });
 
 // 监听路由变化
@@ -1949,110 +1840,14 @@ const createSession = async (val: string) => {
   clearvalue();
 }
 
-const updateAgentModeDropdownPosition = () => {
-  const anchor = agentModeButtonRef.value;
-
-  if (!anchor) {
-    agentModeDropdownStyle.value = {
-      position: 'fixed',
-      top: '50%',
-      left: '50%',
-      transform: 'translate(-50%, -50%)'
-    };
-    return;
-  }
-
-  // Normalize coordinates to CSS pixels (root <html> may carry `zoom`).
-  const zoom = getRootZoom();
-  const rect = rectToCssPx(anchor.getBoundingClientRect(), zoom);
-  const dropdownWidth = 200;
-  const offsetY = 8;
-  const { width: vw, height: vh } = cssViewportSize(zoom);
-
-  // 水平位置：左对齐
-  let left = Math.floor(rect.left);
-  const minLeft = 16;
-  const maxLeft = Math.max(16, vw - dropdownWidth - 16);
-  left = Math.max(minLeft, Math.min(maxLeft, left));
-
-  // 垂直位置：紧贴按钮，使用合理的高度避免空白
-  const preferredDropdownHeight = 140; // Agent 模式选择器内容较少，用更小的优选高度
-  const maxDropdownHeight = 150;
-  const minDropdownHeight = 100;
-  const topMargin = 20;
-  const spaceBelow = vh - rect.bottom;
-  const spaceAbove = rect.top;
-
-  console.log('[Agent Dropdown] Space check:', {
-    spaceBelow,
-    spaceAbove,
-    windowHeight: vh
-  });
-
-  let actualHeight: number;
-
-  // 优先考虑下方空间
-  if (spaceBelow >= minDropdownHeight + offsetY) {
-    // 下方有足够空间，向下弹出
-    actualHeight = Math.min(preferredDropdownHeight, spaceBelow - offsetY - 16);
-    const top = Math.floor(rect.bottom + offsetY);
-
-    agentModeDropdownStyle.value = {
-      position: 'fixed !important',
-      width: `${dropdownWidth}px`,
-      left: `${left}px`,
-      top: `${top}px`,
-      maxHeight: `${actualHeight}px`,
-      transform: 'none !important',
-      margin: '0 !important',
-      padding: '0 !important',
-    };
-    console.log('[Agent Dropdown] Position: below button', { actualHeight });
-  } else {
-    // 向上弹出，使用 bottom 定位确保紧贴按钮
-    const availableHeight = spaceAbove - offsetY - topMargin;
-    if (availableHeight >= preferredDropdownHeight) {
-      actualHeight = preferredDropdownHeight;
-    } else {
-      actualHeight = Math.max(minDropdownHeight, availableHeight);
-    }
-
-    const bottom = vh - rect.top + offsetY;
-
-    agentModeDropdownStyle.value = {
-      position: 'fixed !important',
-      width: `${dropdownWidth}px`,
-      left: `${left}px`,
-      bottom: `${bottom}px`, // 使用 bottom 定位，确保紧贴按钮
-      maxHeight: `${actualHeight}px`,
-      transform: 'none !important',
-      margin: '0 !important',
-      padding: '0 !important',
-    };
-    console.log('[Agent Dropdown] Position: above button', { actualHeight, bottom });
-  }
-};
-
 const toggleAgentModeSelector = () => {
   // 互斥
   showMention.value = false;
   showModelSelector.value = false;
 
   showAgentModeSelector.value = !showAgentModeSelector.value;
-  if (showAgentModeSelector.value) {
-    if (!chatResources.isFresh('agents')) {
-      void loadAgents(true);
-    }
-    // 多次更新位置确保准确
-    nextTick(() => {
-      updateAgentModeDropdownPosition();
-      requestAnimationFrame(() => {
-        updateAgentModeDropdownPosition();
-        setTimeout(() => {
-          updateAgentModeDropdownPosition();
-        }, 50);
-      });
-    });
+  if (showAgentModeSelector.value && !chatResources.isFresh('agents')) {
+    void loadAgents(true);
   }
 }
 
@@ -2124,8 +1919,7 @@ const handleSelectAgent = async (agent: CustomAgent, sourceTenantId?: string) =>
   settingsStore.selectAgent(agent.id, sourceTenantId);
   settingsStore.toggleAgent(!!isAgentType);
 
-  // 同步模型（选中的对话模型随智能体切换，含共享智能体）。
-  // 网络搜索已由 selectAgent 重置为关闭，智能体配置只控制该开关是否可用。
+  // Follow the selected agent model while leaving web-search enablement under explicit user control.
   const agentModel = agent.config?.model_id;
   if (agentModel && agentModel.trim() !== '') {
     selectedModelId.value = agentModel;
@@ -2413,10 +2207,6 @@ const toggleWebSearch = () => {
   MessagePlugin.success(newValue ? t('input.messages.webSearchEnabled') : t('input.messages.webSearchDisabled'));
 };
 
-const toggleKbSelector = () => {
-  showKbSelector.value = !showKbSelector.value;
-}
-
 const removeKb = (kbId: string) => {
   settingsStore.removeKnowledgeBase(kbId);
 }
@@ -2628,21 +2418,6 @@ defineExpose({
             </div>
           </t-tooltip>
 
-          <!-- 模型显示 -->
-          <t-tooltip :content="isModelLockedByAgent ? $t('input.modelLockedByAgent') : ''"
-            :disabled="!isModelLockedByAgent">
-            <div class="model-display" :class="{ 'agent-controlled': isModelLockedByAgent }">
-              <div ref="modelButtonRef" class="model-selector-trigger" @click.stop="toggleModelSelector">
-                <span class="model-selector-name">
-                  {{ selectedModelDisplayName }}
-                </span>
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" class="model-dropdown-arrow"
-                  :class="{ 'rotate': showModelSelector }">
-                  <path d="M2.5 4.5L6 8L9.5 4.5H2.5Z" />
-                </svg>
-              </div>
-            </div>
-          </t-tooltip>
         </div>
 
         <Teleport to="body">
@@ -2678,20 +2453,36 @@ defineExpose({
 
         <!-- 右侧控制按钮组 -->
         <div class="control-right">
-          <!-- 停止按钮（仅在回复中时显示） -->
-          <t-tooltip v-if="isReplying" :content="$t('input.stopGeneration')" placement="top">
-            <div @click="handleStop" class="control-btn stop-btn">
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                <rect x="5" y="5" width="6" height="6" rx="1" />
-              </svg>
+          <!-- Keep model and send/stop controls pinned while auxiliary tools scroll. -->
+          <t-tooltip v-if="!embeddedMode" :content="isModelLockedByAgent ? $t('input.modelLockedByAgent') : ''"
+            :disabled="!isModelLockedByAgent">
+            <div class="model-display" :class="{ 'agent-controlled': isModelLockedByAgent }">
+              <button ref="modelButtonRef" type="button" class="model-selector-trigger"
+                :disabled="isModelLockedByAgent" aria-haspopup="listbox" :aria-expanded="showModelSelector"
+                @click.stop="toggleModelSelector">
+                <span class="model-selector-name">{{ selectedModelDisplayName }}</span>
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" class="model-dropdown-arrow"
+                  :class="{ 'rotate': showModelSelector }" aria-hidden="true">
+                  <path d="M2.5 4.5L6 8L9.5 4.5H2.5Z" />
+                </svg>
+              </button>
             </div>
           </t-tooltip>
 
+          <!-- 停止按钮（仅在回复中时显示） -->
+          <t-tooltip v-if="isReplying" :content="$t('input.stopGeneration')" placement="top">
+            <button type="button" @click="handleStop" class="control-btn stop-btn" :aria-label="$t('input.stopGeneration')">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <rect x="5" y="5" width="6" height="6" rx="1" />
+              </svg>
+            </button>
+          </t-tooltip>
+
           <!-- 发送按钮 -->
-          <div v-if="!isReplying" @click="createSession(query)" class="control-btn send-btn" data-guide="chat-send"
-            :class="{ 'disabled': !query.length }">
-            <img src="../assets/img/sending-aircraft.svg" :alt="$t('input.send')" />
-          </div>
+          <button v-if="!isReplying" type="button" @click="createSession(query)" class="control-btn send-btn"
+            data-guide="chat-send" :disabled="!query.trim()" :aria-label="$t('input.send')">
+            <img src="../assets/img/sending-aircraft.svg" alt="" aria-hidden="true" />
+          </button>
         </div>
       </div>
     </div>
@@ -2715,6 +2506,7 @@ const getImgSrc = (url: string) => {
 }
 </script>
 <style scoped lang="less">
+@import '@/assets/responsive.less';
 @import './css/chat-resource-chips.less';
 
 .answers-input {
@@ -2724,6 +2516,8 @@ const getImgSrc = (url: string) => {
   left: 50%;
   transform: translateX(-50%);
   width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   display: flex;
   justify-content: center;
 
@@ -2745,6 +2539,8 @@ const getImgSrc = (url: string) => {
   position: relative;
   width: 100%;
   max-width: 960px;
+  min-width: 0;
+  box-sizing: border-box;
   background: var(--td-bg-color-container, #FFF);
   border-radius: 12px;
   border: 1px solid var(--td-component-stroke, #dcdcdc);
@@ -2994,12 +2790,20 @@ const getImgSrc = (url: string) => {
   transition: background 0.12s, color 0.12s;
   user-select: none;
   flex-shrink: 0;
+  border: 0;
+  font: inherit;
+
+  &:focus-visible {
+    outline: 2px solid var(--td-brand-color);
+    outline-offset: 2px;
+  }
 
   &:hover {
     background: var(--td-bg-color-secondarycontainer-hover, #e6e6e6);
   }
 
-  &.disabled {
+  &.disabled,
+  &:disabled {
     opacity: 0.5;
     cursor: not-allowed;
 
@@ -3403,7 +3207,7 @@ const getImgSrc = (url: string) => {
 .model-display {
   display: flex;
   align-items: center;
-  margin-left: auto;
+  margin-left: 0;
   flex-shrink: 0;
 
   &.agent-controlled {
@@ -3425,12 +3229,15 @@ const getImgSrc = (url: string) => {
   border: .5px solid var(--td-component-border, #e7e7e7);
   transition: background 0.12s, border-color 0.12s;
   cursor: pointer;
+  background: transparent;
+  font: inherit;
 
   &:hover {
     background: var(--td-bg-color-secondarycontainer-hover, #e6e6e6);
   }
 
-  &.disabled {
+  &.disabled,
+  &:disabled {
     opacity: 0.5;
     cursor: not-allowed;
 
@@ -3471,7 +3278,8 @@ const getImgSrc = (url: string) => {
   inset: 0;
   z-index: 9999;
   background: transparent;
-  touch-action: none;
+  touch-action: manipulation;
+  overscroll-behavior: contain;
 }
 
 .model-selector-dropdown {
@@ -3522,6 +3330,7 @@ const getImgSrc = (url: string) => {
   overflow-y: auto;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
   padding: 6px 8px;
 }
 
@@ -3745,4 +3554,156 @@ const getImgSrc = (url: string) => {
     text-decoration: underline;
   }
 }
+
+.compact({
+  .answers-input {
+    padding-left: max(8px, env(safe-area-inset-left));
+    padding-right: max(8px, env(safe-area-inset-right));
+  }
+
+  :deep(.t-textarea__inner) {
+    min-height: 104px !important;
+    max-height: min(180px, calc(var(--app-viewport-height, 100dvh) * 0.36)) !important;
+    padding: 12px 10px 58px !important;
+    font-size: 16px !important;
+  }
+
+  .rich-input-container:not(:has(.selected-tags-inline)) :deep(.t-textarea__inner) {
+    padding-top: 12px !important;
+  }
+
+  .selected-tags-inline {
+    max-height: 74px;
+    padding: 6px 10px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .mention-chip__name {
+    max-width: 88px;
+  }
+
+  .image-preview-bar {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    touch-action: pan-x;
+    scrollbar-width: none;
+  }
+
+  .image-preview-bar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .control-bar {
+    right: 8px;
+    bottom: 6px;
+    left: 8px;
+    gap: 4px;
+    max-height: none;
+    flex-wrap: nowrap;
+    padding-top: 6px;
+  }
+
+  .control-left {
+    gap: 4px;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    touch-action: pan-x;
+    scrollbar-width: none;
+    scroll-snap-type: x proximity;
+  }
+
+  .control-left > * {
+    scroll-snap-align: start;
+  }
+
+  .control-left::-webkit-scrollbar {
+    display: none;
+  }
+
+  .agent-mode-btn {
+    max-width: 116px;
+    min-height: 36px;
+    padding-inline: 8px;
+  }
+
+  .agent-mode-text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .websearch-btn,
+  .image-upload-btn,
+  .attachment-upload-btn,
+  .kb-btn {
+    width: 36px;
+    min-width: 36px;
+    height: 36px;
+  }
+
+  .model-selector-trigger {
+    min-width: 76px;
+    max-width: 108px;
+    height: 36px;
+  }
+
+  .control-right {
+    flex-shrink: 0;
+    gap: 4px;
+    padding-left: 4px;
+    background: var(--td-bg-color-container);
+  }
+
+  .send-btn,
+  .stop-btn {
+    width: 36px;
+    height: 36px;
+  }
+
+  .model-selector-dropdown {
+    max-width: calc(var(--app-viewport-width, 100vw) - 16px);
+  }
+});
+
+.phone({
+  .mention-chip__name {
+    max-width: 72px;
+  }
+});
+
+@media screen and (max-width: 360px) {
+  .model-selector-trigger {
+    min-width: 64px;
+    max-width: 76px;
+    padding-inline: 6px;
+  }
+
+  .agent-mode-btn {
+    max-width: 96px;
+  }
+}
+
+.phone-landscape({
+  :deep(.t-textarea__inner) {
+    min-height: 84px !important;
+    max-height: min(120px, calc(var(--app-viewport-height, 100dvh) * 0.42)) !important;
+    padding-bottom: 52px !important;
+  }
+
+  .control-bar {
+    bottom: 4px;
+  }
+});
+
+:global(html.app-keyboard-open .answers-input) {
+  padding-bottom: 0;
+}
+
+:global(html.app-keyboard-open .answers-input .t-textarea__inner) {
+  max-height: min(132px, calc(var(--app-viewport-height, 100dvh) * 0.42)) !important;
+}
+
 </style>

--- a/frontend/src/components/KnowledgeBaseSelector.vue
+++ b/frontend/src/components/KnowledgeBaseSelector.vue
@@ -68,6 +68,13 @@ import { useSettingsStore } from '@/stores/settings'
 import { listKnowledgeBases } from '@/api/knowledge-base'
 import { useI18n } from 'vue-i18n'
 import { getRootZoom, rectToCssPx, cssViewportSize } from '@/utils/zoom'
+import { PHONE_MAX_WIDTH, useResponsiveViewport } from '@/composables/useResponsiveViewport'
+import {
+  DEFAULT_POPOVER_EDGE_GAP,
+  clampPopoverWidth,
+  computeAnchoredPopoverLayout,
+} from '@/utils/popoverPosition'
+import { observeViewportChanges } from '@/utils/viewportChangeObserver'
 
 interface KnowledgeBase {
   id: string
@@ -91,6 +98,7 @@ const props = defineProps<{
 const emit = defineEmits(['close', 'update:visible'])
 
 const settingsStore = useSettingsStore()
+const { isCompact } = useResponsiveViewport()
 
 // 本地状态
 const searchQuery = ref('')
@@ -137,6 +145,9 @@ const isSelected = (id: string) => selectedKbIds.value.includes(id)
 
 const toggleKb = (id: string) => {
   isSelected(id) ? settingsStore.removeKnowledgeBase(id) : settingsStore.addKnowledgeBase(id)
+  // Keep the optional picker search separate from the chat input. Once a
+  // mobile user taps a result, hide the keyboard so it cannot cover the list.
+  if (isCompact.value) searchInput.value?.blur()
 }
 
 const toggleSelection = () => {
@@ -158,6 +169,7 @@ const selectAll = () => settingsStore.selectKnowledgeBases(filteredKnowledgeBase
 const clearAll = () => settingsStore.clearKnowledgeBases()
 
 const close = () => {
+  searchInput.value?.blur()
   emit('update:visible', false)
   emit('close')
 }
@@ -171,46 +183,43 @@ const loadKnowledgeBases = async () => {
   }
 }
 
-// 计算下拉位置：水平居中对齐到按钮中点，处理视口边界
+// 计算下拉位置：按当前可视视口约束，避免被 Android 键盘或屏幕边缘遮挡
 const updateDropdownPosition = () => {
   const anchor = resolveAnchorEl()
-  
-  // Cache root zoom for this update. Both fallback and rect-anchored paths
-  // need to convert visual measurements to CSS pixels (see utils/zoom.ts).
   const zoom = getRootZoom()
-  const { width: vwFallback, height: vhFallback } = cssViewportSize(zoom)
+  const { width: viewportWidth, height: viewportHeight } = cssViewportSize(zoom)
+  const edgeGap = DEFAULT_POPOVER_EDGE_GAP
+  const preferredWidth = viewportWidth <= PHONE_MAX_WIDTH ? viewportWidth - edgeGap * 2 : dropdownWidth
+  const width = clampPopoverWidth(preferredWidth, viewportWidth, edgeGap)
 
-  // fallback 函数
   const applyFallback = () => {
-    const topFallback = Math.max(80, vhFallback / 2 - 160);
     dropdownStyle.value = {
       position: 'fixed',
-      width: `${dropdownWidth}px`,
-      left: `${Math.round((vwFallback - dropdownWidth) / 2)}px`,
-      top: `${Math.round(topFallback)}px`,
+      width: `${width}px`,
+      left: `${Math.max(edgeGap, Math.round((viewportWidth - width) / 2))}px`,
+      top: `${Math.max(edgeGap, Math.round((viewportHeight - 280) / 2))}px`,
+      maxHeight: `${Math.max(0, viewportHeight - edgeGap * 2)}px`,
       transform: 'none',
       margin: '0',
       padding: '0',
-    };
-  };
-  
+    }
+  }
+
   if (!anchor) {
     applyFallback()
     return
   }
 
-  // 获取 anchor 的 bounding rect（相对于视口）
   let rawRect: { top: number; left: number; right: number; bottom: number; width: number; height: number } | null = null
   try {
     if (typeof anchor.getBoundingClientRect === 'function') {
-      const r = anchor.getBoundingClientRect()
-      rawRect = { top: r.top, left: r.left, right: r.right, bottom: r.bottom, width: r.width, height: r.height }
+      const rect = anchor.getBoundingClientRect()
+      rawRect = { top: rect.top, left: rect.left, right: rect.right, bottom: rect.bottom, width: rect.width, height: rect.height }
     } else if (anchor.width !== undefined && anchor.left !== undefined) {
-      // Already a DOMRect-like
       rawRect = anchor as DOMRect
     }
-  } catch (e) {
-    console.error('[KnowledgeBaseSelector] Error getting bounding rect:', e)
+  } catch (error) {
+    console.error('[KnowledgeBaseSelector] Error getting bounding rect:', error)
   }
 
   if (!rawRect || rawRect.width === 0 || rawRect.height === 0) {
@@ -218,132 +227,60 @@ const updateDropdownPosition = () => {
     return
   }
 
-  // Convert to CSS pixels so subsequent comparisons against the dropdown's
-  // own width/height stay in one coordinate system.
   const rect = rectToCssPx(rawRect, zoom)
-  console.log('[KB Selector] Button rect (css px):', rect)
-  const vw = vwFallback
-  const vh = vhFallback
-  
-  // 左对齐到触发元素的左边缘
-  // 使用 Math.floor 而不是 Math.round，避免像素对齐问题
-  let left = Math.floor(rect.left)
-  
-  // 边界处理：不超出视口左右（留 16px margin）
-  const minLeft = 16
-  const maxLeft = Math.max(16, vw - dropdownWidth - 16)
-  left = Math.max(minLeft, Math.min(maxLeft, left))
-
-  // 垂直定位：紧贴按钮，使用合理的高度避免空白
-  const preferredDropdownHeight = 280 // 优选高度（紧凑且够用）
-  const maxDropdownHeight = 360 // 最大高度
-  const minDropdownHeight = 200 // 最小高度
-  const topMargin = 20 // 顶部留白
-  const spaceBelow = vh - rect.bottom // 下方剩余空间
-  const spaceAbove = rect.top // 上方剩余空间
-  
-  console.log('[KB Selector] Space check:', {
-    spaceBelow,
-    spaceAbove,
-    windowHeight: vh
+  const layout = computeAnchoredPopoverLayout(rect, {
+    width: viewportWidth,
+    height: viewportHeight,
+  }, {
+    preferredWidth,
+    preferredHeight: viewportWidth <= PHONE_MAX_WIDTH ? 380 : 280,
+    minSpaceBelow: 160,
+    maxHeightRatio: 0.62,
+    edgeGap,
+    offsetY,
   })
-  
-  let actualHeight: number
-  let shouldOpenBelow: boolean
-  
-  // 优先考虑下方空间
-  if (spaceBelow >= minDropdownHeight + offsetY) {
-    // 下方有足够空间，向下弹出
-    actualHeight = Math.min(preferredDropdownHeight, spaceBelow - offsetY - 16)
-    shouldOpenBelow = true
-    console.log('[KB Selector] Position: below button', { actualHeight })
-  } else {
-    // 向上弹出，优先使用 preferredHeight，必要时才扩展到 maxHeight
-    const availableHeight = spaceAbove - offsetY - topMargin
-    if (availableHeight >= preferredDropdownHeight) {
-      // 有足够空间显示优选高度
-      actualHeight = preferredDropdownHeight
-    } else {
-      // 空间不够，使用可用空间（但不小于最小高度）
-      actualHeight = Math.max(minDropdownHeight, availableHeight)
-    }
-    shouldOpenBelow = false
-    console.log('[KB Selector] Position: above button', { actualHeight })
-  }
-  
-  // 根据弹出方向使用不同的定位方式
-  if (shouldOpenBelow) {
-    // 向下弹出：使用 top 定位
-    const top = Math.floor(rect.bottom + offsetY)
-    console.log('[KB Selector] Opening below, top:', top)
-    dropdownStyle.value = {
-      position: 'fixed',
-      width: `${dropdownWidth}px`,
-      left: `${left}px`,
-      top: `${top}px`,
-      maxHeight: `${actualHeight}px`,
-      transform: 'none',
-      margin: '0',
-      padding: '0'
-    }
-  } else {
-    // 向上弹出：使用 bottom 定位
-    const bottom = vh - rect.top + offsetY
-    console.log('[KB Selector] Opening above, bottom:', bottom)
-    dropdownStyle.value = {
-      position: 'fixed',
-      width: `${dropdownWidth}px`,
-      left: `${left}px`,
-      bottom: `${bottom}px`,
-      maxHeight: `${actualHeight}px`,
-      transform: 'none',
-      margin: '0',
-      padding: '0'
-    }
+
+  dropdownStyle.value = {
+    ...layout.style,
+    transform: 'none',
+    margin: '0',
+    padding: '0',
   }
 }
+watch(() => props.visible, async (visible, _previous, onCleanup) => {
+  let cancelled = false
+  let settleFrame: number | null = null
+  let stopViewportObserver: (() => void) | null = null
 
-// 事件监听器引用，用于清理
-let resizeHandler: (() => void) | null = null
-let scrollHandler: (() => void) | null = null
+  onCleanup(() => {
+    cancelled = true
+    stopViewportObserver?.()
+    if (settleFrame !== null) cancelAnimationFrame(settleFrame)
+  })
 
-// 当 visible 变化时处理
-watch(() => props.visible, async (v) => {
-  if (v) {
-    await loadKnowledgeBases();
-    // 等 DOM 渲染完再计算位置
-    await nextTick();
-    // 多次更新位置确保准确
-    requestAnimationFrame(() => {
-      updateDropdownPosition();
-      requestAnimationFrame(() => {
-        updateDropdownPosition();
-        setTimeout(() => {
-          updateDropdownPosition();
-        }, 50);
-      });
-    });
-    // 确保 focus
-    nextTick(() => searchInput.value?.focus());
-    // 监听 resize/scroll 做微调（使用 passive 提高性能）
-    resizeHandler = () => updateDropdownPosition();
-    scrollHandler = () => updateDropdownPosition();
-    window.addEventListener('resize', resizeHandler, { passive: true });
-    window.addEventListener('scroll', scrollHandler, { passive: true, capture: true });
-  } else {
-    searchQuery.value = '';
-    highlightedIndex.value = 0;
-    // 清理事件监听器
-    if (resizeHandler) {
-      window.removeEventListener('resize', resizeHandler);
-      resizeHandler = null;
-    }
-    if (scrollHandler) {
-      window.removeEventListener('scroll', scrollHandler, { capture: true });
-      scrollHandler = null;
-    }
+  if (!visible) {
+    searchQuery.value = ''
+    highlightedIndex.value = 0
+    return
   }
-});
+
+  await loadKnowledgeBases()
+  if (cancelled || !props.visible) return
+
+  await nextTick()
+  if (cancelled || !props.visible) return
+
+  updateDropdownPosition()
+  settleFrame = requestAnimationFrame(() => {
+    settleFrame = null
+    if (!cancelled && props.visible) updateDropdownPosition()
+  })
+  stopViewportObserver = observeViewportChanges(() => {
+    if (!cancelled && props.visible) updateDropdownPosition()
+  })
+  // Do not summon the software keyboard merely by opening the picker.
+  if (!isCompact.value) searchInput.value?.focus({ preventScroll: true })
+}, { immediate: true })
 </script>
 
 <style scoped lang="less">
@@ -360,8 +297,9 @@ watch(() => props.visible, async (v) => {
   inset: 0;
   z-index: 9999;
   background: transparent;
-  /* 不阻止点击穿透，但防止触摸滚动 */
-  touch-action: none;
+  /* 遮罩自身不滚动，但允许下拉列表进行纵向触摸滚动 */
+  touch-action: manipulation;
+  overscroll-behavior: contain;
 }
 
 /* 下拉面板使用 fixed 定位，相对于视口 */
@@ -410,6 +348,7 @@ watch(() => props.visible, async (v) => {
   /* 确保滚动限制在此容器内 */
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
 }
 
 .kb-item {

--- a/frontend/src/components/MentionSelector.vue
+++ b/frontend/src/components/MentionSelector.vue
@@ -818,6 +818,19 @@ const scrollToItem = (index: number) => {
   justify-content: center;
   padding: 8px 12px;
 }
+
+@media screen and (max-width: 767px) {
+  .mention-menu {
+    max-width: calc(var(--app-viewport-width, 100vw) - 16px);
+    border-radius: 12px;
+  }
+
+  .mention-group-entry,
+  .mention-back-row,
+  .mention-item {
+    min-height: 40px;
+  }
+}
 </style>
 
 <style>
@@ -960,5 +973,11 @@ const scrollToItem = (index: number) => {
 .mention-detail-content .detail-value.clickable:hover {
   color: var(--td-brand-color, #07c05f);
   text-decoration-color: var(--td-brand-color, #07c05f);
+}
+
+html.app-compact-viewport .mention-detail-popup-wrap.t-popup__content {
+  min-width: 0;
+  width: min(320px, calc(var(--app-viewport-width, 100vw) - 16px));
+  max-width: calc(var(--app-viewport-width, 100vw) - 16px);
 }
 </style>

--- a/frontend/src/components/NewUserGuide.vue
+++ b/frontend/src/components/NewUserGuide.vue
@@ -1,17 +1,20 @@
 <template>
   <SpotlightGuide v-model:active="active" :steps="steps" step-i18n-prefix="newUserGuide.steps"
-    labels-prefix="newUserGuide" @finish="onFinish" @step-change="onStepChange" />
+    labels-prefix="newUserGuide" @finish="onFinish" @dismiss="onFinish" @step-change="onStepChange" />
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import SpotlightGuide from '@/components/SpotlightGuide.vue'
 import { GLOBAL_USER_GUIDE_KEY, OPEN_NEW_USER_GUIDE_EVENT } from '@/config/contextualGuides'
 import { useUIStore } from '@/stores/ui'
 import type { SpotlightGuideStep } from '@/types/spotlightGuide'
+import { useResponsiveViewport } from '@/composables/useResponsiveViewport'
 
 const uiStore = useUIStore()
+const { isCompact } = useResponsiveViewport()
 let settingsOpenedByGuide = false
+let autoOpenTimer: number | null = null
 
 const steps = computed<SpotlightGuideStep[]>(() => [
   { key: 'welcome' },
@@ -72,8 +75,25 @@ const onStepChange = ({ toKey }: { toKey: string }) => {
   }
 }
 
+const clearAutoOpenTimer = () => {
+  if (autoOpenTimer) {
+    clearTimeout(autoOpenTimer)
+    autoOpenTimer = null
+  }
+}
+
 const open = () => {
+  if (isCompact.value) return
   active.value = true
+}
+
+const scheduleAutoOpen = () => {
+  clearAutoOpenTimer()
+  if (isCompact.value || localStorage.getItem(GLOBAL_USER_GUIDE_KEY) === '1') return
+  autoOpenTimer = window.setTimeout(() => {
+    autoOpenTimer = null
+    if (!isCompact.value && localStorage.getItem(GLOBAL_USER_GUIDE_KEY) !== '1') open()
+  }, 700)
 }
 
 const handleOpenEvent = () => {
@@ -83,17 +103,22 @@ const handleOpenEvent = () => {
 
 onMounted(() => {
   window.addEventListener(OPEN_NEW_USER_GUIDE_EVENT, handleOpenEvent)
-  if (localStorage.getItem(GLOBAL_USER_GUIDE_KEY) !== '1') {
-    window.setTimeout(() => {
-      if (localStorage.getItem(GLOBAL_USER_GUIDE_KEY) !== '1') {
-        open()
-      }
-    }, 700)
+  scheduleAutoOpen()
+})
+
+watch(isCompact, (compact) => {
+  if (compact) {
+    clearAutoOpenTimer()
+    active.value = false
+    closeGuideSettings()
+  } else {
+    scheduleAutoOpen()
   }
 })
 
 onBeforeUnmount(() => {
   window.removeEventListener(OPEN_NEW_USER_GUIDE_EVENT, handleOpenEvent)
+  clearAutoOpenTimer()
   closeGuideSettings()
 })
 </script>

--- a/frontend/src/components/SpotlightGuide.vue
+++ b/frontend/src/components/SpotlightGuide.vue
@@ -14,7 +14,7 @@
         <div v-if="hole" class="guide__ring" :style="ringStyle" aria-hidden="true" />
 
         <div ref="cardRef" class="guide__card" :class="{ 'guide__card--center': !hole }" :style="cardStyle">
-          <button type="button" class="guide__close" :aria-label="t(`${labelsPrefix}.skip`)" @click="dismiss">
+          <button type="button" class="guide__close" :aria-label="safeT(`${labelsPrefix}.skip`)" @click="dismiss">
             <t-icon name="close" size="18px" />
           </button>
 
@@ -23,23 +23,23 @@
               :class="{ 'is-active': i === index, 'is-done': i < index }" />
           </div>
 
-          <p class="guide__step-label">{{ t(`${labelsPrefix}.stepOf`, { current: index + 1, total: steps.length }) }}
+          <p class="guide__step-label">{{ safeT(`${labelsPrefix}.stepOf`, { current: index + 1, total: steps.length }) }}
           </p>
           <h3 class="guide__title">{{ stepTitle }}</h3>
           <p class="guide__desc">{{ stepDesc }}</p>
-          <p v-if="step.interact" class="guide__interact-hint">{{ t(`${labelsPrefix}.interactHint`) }}</p>
+          <p v-if="step.interact" class="guide__interact-hint">{{ safeT(`${labelsPrefix}.interactHint`) }}</p>
 
           <div class="guide__actions">
-            <button type="button" class="guide__skip" @click="dismiss">{{ t(`${labelsPrefix}.skip`) }}</button>
+            <button type="button" class="guide__skip" @click="dismiss">{{ safeT(`${labelsPrefix}.skip`) }}</button>
             <div v-if="!step.interact" class="guide__actions-main">
               <t-button v-if="index > 0" size="small" variant="outline" @click="prev">
-                {{ t(`${labelsPrefix}.prev`) }}
+                {{ safeT(`${labelsPrefix}.prev`) }}
               </t-button>
               <t-button v-if="!isLast" size="small" theme="primary" @click="next">
-                {{ t(`${labelsPrefix}.next`) }}
+                {{ safeT(`${labelsPrefix}.next`) }}
               </t-button>
               <t-button v-else size="small" theme="primary" @click="finish">
-                {{ t(`${labelsPrefix}.done`) }}
+                {{ safeT(`${labelsPrefix}.done`) }}
               </t-button>
             </div>
           </div>
@@ -53,6 +53,9 @@
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { SpotlightGuideStep } from '@/types/spotlightGuide'
+import { getRootZoom, rectToCssPx, cssViewportSize } from '@/utils/zoom'
+import { observeViewportChanges } from '@/utils/viewportChangeObserver'
+import { setBodyScrollLock, releaseBodyScrollLock } from '@/utils/bodyScrollLock'
 
 const CARD_WIDTH = 340
 const GAP = 16
@@ -60,6 +63,7 @@ const EDGE = 16
 const PAD = 8
 const holeRadius = 8
 const BACKDROP_COLOR = 'rgba(15, 18, 22, 0.58)'
+const EMPTY_GUIDE_STEP: SpotlightGuideStep = { key: 'unavailable' }
 
 const props = withDefaults(
   defineProps<{
@@ -86,27 +90,43 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const reportedI18nFailures = new Set<string>()
 
+const safeT = (key: string, params?: Record<string, string | number>) => {
+  try {
+    return params ? t(key, params) : t(key)
+  } catch (error) {
+    if (!reportedI18nFailures.has(key)) {
+      reportedI18nFailures.add(key)
+      console.error(`[WeKnora] Failed to render guide translation: ${key}`, error)
+    }
+    // 情境引导属于辅助功能。翻译异常时保留可诊断信息，但不能拖垮核心页面。
+    return key
+  }
+}
+
+const initialViewport = cssViewportSize()
 const index = ref(0)
-const vw = ref(window.innerWidth)
-const vh = ref(window.innerHeight)
-const targetRect = ref<DOMRect | null>(null)
+const vw = ref(initialViewport.width)
+const vh = ref(initialViewport.height)
+const targetRect = ref<ReturnType<typeof rectToCssPx> | null>(null)
 const targetEl = ref<HTMLElement | null>(null)
 const cardSize = ref({ width: CARD_WIDTH, height: 220 })
 
 type HoleRect = { x: number; y: number; width: number; height: number }
 
-const measureNeighborGap = (el: HTMLElement, r: DOMRect) => {
+const measureNeighborGap = (el: HTMLElement, r: ReturnType<typeof rectToCssPx>) => {
+  const zoom = getRootZoom()
   let above = PAD
   const prev = el.previousElementSibling
   if (prev) {
-    above = Math.max(0, r.top - prev.getBoundingClientRect().bottom)
+    above = Math.max(0, r.top - rectToCssPx(prev.getBoundingClientRect(), zoom).bottom)
   }
 
   let below = PAD
   const next = el.nextElementSibling
   if (next) {
-    below = Math.max(0, next.getBoundingClientRect().top - r.bottom)
+    below = Math.max(0, rectToCssPx(next.getBoundingClientRect(), zoom).top - r.bottom)
   } else {
     const mb = parseFloat(getComputedStyle(el).marginBottom) || 0
     below = Math.max(0, PAD - mb)
@@ -115,7 +135,7 @@ const measureNeighborGap = (el: HTMLElement, r: DOMRect) => {
   return { above, below }
 }
 
-const computeHighlightHole = (el: HTMLElement, r: DOMRect): HoleRect => {
+const computeHighlightHole = (el: HTMLElement, r: ReturnType<typeof rectToCssPx>): HoleRect => {
   const { above, below } = measureNeighborGap(el, r)
   const inset = Math.min(PAD, above, below)
 
@@ -147,12 +167,12 @@ const computeHighlightHole = (el: HTMLElement, r: DOMRect): HoleRect => {
 const rootRef = ref<HTMLElement | null>(null)
 const cardRef = ref<HTMLElement | null>(null)
 
-let retryTimer: ReturnType<typeof setTimeout> | null = null
+let retryTimer: number | null = null
 
-const step = computed(() => props.steps[index.value] ?? props.steps[0])
-const isLast = computed(() => index.value === props.steps.length - 1)
-const stepTitle = computed(() => t(`${props.stepI18nPrefix}.${step.value.key}.title`))
-const stepDesc = computed(() => t(`${props.stepI18nPrefix}.${step.value.key}.desc`))
+const step = computed(() => props.steps[index.value] ?? props.steps[0] ?? EMPTY_GUIDE_STEP)
+const isLast = computed(() => props.steps.length === 0 || index.value === props.steps.length - 1)
+const stepTitle = computed(() => safeT(`${props.stepI18nPrefix}.${step.value.key}.title`))
+const stepDesc = computed(() => safeT(`${props.stepI18nPrefix}.${step.value.key}.desc`))
 
 const hole = computed(() => {
   const el = targetEl.value
@@ -208,7 +228,7 @@ const overlaps = (
 ) => !(a.right <= b.left || a.left >= b.right || a.bottom <= b.top || a.top >= b.bottom)
 
 const cardStyle = computed(() => {
-  const w = Math.min(CARD_WIDTH, vw.value - EDGE * 2)
+  const w = Math.max(0, Math.min(CARD_WIDTH, vw.value - EDGE * 2))
   const h = cardSize.value.height
   const h0 = hole.value
 
@@ -263,6 +283,7 @@ const queryTarget = (selector?: string): HTMLElement | null => {
 
 const measureCard = async () => {
   await nextTick()
+  if (!props.active) return
   if (cardRef.value) {
     cardSize.value = {
       width: cardRef.value.offsetWidth,
@@ -272,8 +293,12 @@ const measureCard = async () => {
 }
 
 const locate = async (retry = 0) => {
-  vw.value = window.innerWidth
-  vh.value = window.innerHeight
+  if (!props.active) return
+
+  const zoom = getRootZoom()
+  const viewport = cssViewportSize(zoom)
+  vw.value = viewport.width
+  vh.value = viewport.height
 
   const cur = step.value
   if (!cur.target) {
@@ -287,7 +312,11 @@ const locate = async (retry = 0) => {
   if (!el) {
     if (retry < 12) {
       if (retryTimer) clearTimeout(retryTimer)
-      retryTimer = setTimeout(() => locate(retry + 1), 120)
+      retryTimer = window.setTimeout(() => {
+        retryTimer = null
+        if (!props.active) return
+        void locate(retry + 1)
+      }, 120)
       return
     }
     if (cur.optional) {
@@ -302,12 +331,12 @@ const locate = async (retry = 0) => {
 
   el.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' })
   targetEl.value = el
-  targetRect.value = el.getBoundingClientRect()
+  targetRect.value = rectToCssPx(el.getBoundingClientRect(), zoom)
   await measureCard()
 }
 
 const goTo = async (i: number) => {
-  if (i < 0 || i >= props.steps.length) return
+  if (!props.active || i < 0 || i >= props.steps.length) return
   if (retryTimer) {
     clearTimeout(retryTimer)
     retryTimer = null
@@ -316,13 +345,16 @@ const goTo = async (i: number) => {
   index.value = i
   emit('step-change', { fromKey, toKey: step.value.key, index: i })
   await step.value.before?.()
+  if (!props.active) return
   const delay = step.value.before ? props.beforeDelayMs : 0
   if (delay > 0) {
     await new Promise((r) => setTimeout(r, delay))
+    if (!props.active) return
   }
   await locate()
+  if (!props.active) return
   await nextTick()
-  rootRef.value?.focus()
+  if (props.active) rootRef.value?.focus()
 }
 
 const next = () => goTo(index.value + 1)
@@ -345,7 +377,7 @@ const finish = () => {
 
 const dismiss = () => {
   emit('dismiss')
-  finish()
+  close()
 }
 
 const onViewportChange = () => {
@@ -354,6 +386,10 @@ const onViewportChange = () => {
 }
 
 const open = async () => {
+  if (props.steps.length === 0) {
+    emit('update:active', false)
+    return
+  }
   index.value = 0
   emit('update:active', true)
   await nextTick()
@@ -372,27 +408,35 @@ watch(
       }
     }
   },
+  { immediate: true },
 )
 
-onBeforeUnmount(() => {
-  window.removeEventListener('resize', onViewportChange)
-  window.removeEventListener('scroll', onViewportChange, true)
-  if (retryTimer) clearTimeout(retryTimer)
-})
+const GUIDE_SCROLL_LOCK = `spotlight-guide:${props.stepI18nPrefix}`
+let stopViewportObserver: (() => void) | null = null
+
+const stopViewportListeners = () => {
+  stopViewportObserver?.()
+  stopViewportObserver = null
+}
 
 watch(
   () => props.active,
   (val) => {
-    if (val) {
-      window.addEventListener('resize', onViewportChange)
-      window.addEventListener('scroll', onViewportChange, true)
-    } else {
-      window.removeEventListener('resize', onViewportChange)
-      window.removeEventListener('scroll', onViewportChange, true)
-    }
+    setBodyScrollLock(GUIDE_SCROLL_LOCK, val)
+    stopViewportListeners()
+    if (val) stopViewportObserver = observeViewportChanges(onViewportChange)
   },
   { immediate: true },
 )
+
+onBeforeUnmount(() => {
+  stopViewportListeners()
+  releaseBodyScrollLock(GUIDE_SCROLL_LOCK)
+  if (retryTimer) {
+    clearTimeout(retryTimer)
+    retryTimer = null
+  }
+})
 
 defineExpose({ open, close })
 </script>
@@ -464,7 +508,7 @@ defineExpose({ open, close })
   border: 1px solid var(--td-component-stroke);
   box-shadow: 0 20px 48px rgba(0, 0, 0, 0.18);
   color: var(--td-text-color-primary);
-  max-height: calc(100vh - 32px);
+  max-height: calc(var(--app-viewport-height, 100dvh) - 32px);
   overflow-y: auto;
   transition:
     top 0.28s cubic-bezier(0.4, 0, 0.2, 1),

--- a/frontend/src/components/css/suggested-questions.less
+++ b/frontend/src/components/css/suggested-questions.less
@@ -1,3 +1,4 @@
+@import (reference) '@/assets/responsive.less';
 @suggested-ease: cubic-bezier(0.16, 1, 0.3, 1);
 
 // Shared hover for starter / follow-up suggestion chips.
@@ -202,3 +203,18 @@
     color: var(--td-brand-color);
 }
 
+.compact({
+    .suggested-questions-container {
+        padding: 10px 8px;
+    }
+
+    .suggested-questions-grid {
+        gap: 8px;
+    }
+
+    .suggested-question-card {
+        width: 100%;
+        justify-content: space-between;
+        padding: 8px 10px;
+    }
+});

--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -22,9 +22,13 @@ import { useI18n } from 'vue-i18n';
 import { useAuthStore } from '@/stores/auth';
 import DocumentPreview from '@/components/document-preview.vue';
 import KnowledgeProcessingTimeline from '@/components/knowledge-processing-timeline.vue';
+import { useResponsiveViewport } from '@/composables/useResponsiveViewport';
+import { setBodyScrollLock, releaseBodyScrollLock } from '@/utils/bodyScrollLock';
 
 const { t } = useI18n();
 const authStore = useAuthStore();
+const { layoutWidth, isCompact } = useResponsiveViewport();
+const DOC_DRAWER_SCROLL_LOCK = 'knowledge-document-detail';
 
 // canDeleteGeneratedQuestion 对应后端 DELETE /chunks/by-id/:id/questions
 // 的 OwnedChunkKBOrAdminFromChunkID 守卫——KB 创建者或空间 Admin+
@@ -320,7 +324,8 @@ let traceResizeStartX = 0;
 let traceResizeStartWidth = 0;
 
 function traceDrawerMaxWidth() {
-  return Math.min(1400, Math.max(TRACE_DRAWER_MIN_WIDTH, Math.floor(window.innerWidth * 0.92)));
+  const availableWidth = layoutWidth.value || window.innerWidth;
+  return Math.min(1400, Math.max(TRACE_DRAWER_MIN_WIDTH, Math.floor(availableWidth * 0.92)));
 }
 
 function clampTraceDrawerWidth(width: number) {
@@ -340,6 +345,7 @@ function loadTraceDrawerWidth() {
 }
 
 function onTraceDrawerResizeStart(e: MouseEvent) {
+  if (isCompact.value) return;
   timelineDrawerResizing.value = true;
   traceResizeStartX = e.clientX;
   traceResizeStartWidth = timelineDrawerWidth.value;
@@ -387,12 +393,15 @@ const MAIN_DRAWER_MIN_WIDTH = 480;
 
 const mainDrawerWidth = ref(MAIN_DRAWER_DEFAULT_WIDTH);
 const mainDrawerResizing = ref(false);
+const mainDrawerSize = computed(() => isCompact.value ? '100%' : `${mainDrawerWidth.value}px`);
+const timelineDrawerSize = computed(() => isCompact.value ? '100%' : `${timelineDrawerWidth.value}px`);
 
 let mainResizeStartX = 0;
 let mainResizeStartWidth = 0;
 
 function mainDrawerMaxWidth() {
-  return Math.min(1600, Math.max(MAIN_DRAWER_MIN_WIDTH, Math.floor(window.innerWidth * 0.95)));
+  const availableWidth = layoutWidth.value || window.innerWidth;
+  return Math.min(1600, Math.max(MAIN_DRAWER_MIN_WIDTH, Math.floor(availableWidth * 0.95)));
 }
 
 function clampMainDrawerWidth(width: number) {
@@ -412,6 +421,7 @@ function loadMainDrawerWidth() {
 }
 
 function onMainDrawerResizeStart(e: MouseEvent) {
+  if (isCompact.value) return;
   mainDrawerResizing.value = true;
   mainResizeStartX = e.clientX;
   mainResizeStartWidth = mainDrawerWidth.value;
@@ -619,9 +629,16 @@ watch(() => props.visible, (visible) => {
       maybeLoadMoreChunks();
     });
   } else {
+    timelineDrawerVisible.value = false;
     unbindDrawerScroll();
   }
 });
+
+watch([() => props.visible, isCompact], ([visible, compact]) => {
+  setBodyScrollLock(DOC_DRAWER_SCROLL_LOCK, visible && compact);
+  if ((!visible || compact) && mainDrawerResizing.value) cleanupMainDrawerResize();
+  if ((!visible || compact) && timelineDrawerResizing.value) cleanupTraceDrawerResize();
+}, { immediate: true });
 watch(() => props.details?.id, () => {
   page = 1;
   loadingChunks = false;
@@ -652,6 +669,7 @@ onUnmounted(() => {
   cleanupTraceDrawerResize();
   cleanupMainDrawerResize();
   unbindDrawerScroll();
+  releaseBodyScrollLock(DOC_DRAWER_SCROLL_LOCK);
   if (audioBlobUrl.value) {
     URL.revokeObjectURL(audioBlobUrl.value);
   }
@@ -1599,13 +1617,13 @@ const handleDetailsScroll = () => {
 <template>
   <div class="doc_content" ref="mdContentWrap">
     <teleport to="body">
-      <div v-if="visible" class="doc-drawer-resize-handle" :style="{ right: `${mainDrawerWidth}px` }" role="separator"
+      <div v-if="visible && !isCompact" class="doc-drawer-resize-handle" :style="{ right: `${mainDrawerWidth}px` }" role="separator"
         aria-orientation="vertical" @mousedown.prevent="onMainDrawerResizeStart">
         <div class="doc-drawer-resize-line" />
       </div>
     </teleport>
-    <t-drawer :visible="visible" :zIndex="2000" :size="`${mainDrawerWidth}px`" attach="body" :closeBtn="true"
-      :footer="false" :class="['doc-main-drawer', { 'doc-main-drawer--resizing': mainDrawerResizing }]"
+    <t-drawer :visible="visible" :zIndex="2000" :size="mainDrawerSize" attach="body" :closeBtn="true"
+      :footer="false" :class="['doc-main-drawer', { 'doc-main-drawer--resizing': mainDrawerResizing, 'doc-main-drawer--compact': isCompact }]"
       @close="handleClose">
       <template #header>
         <div class="doc-drawer-header">
@@ -1644,16 +1662,16 @@ const handleDetailsScroll = () => {
 
       <!-- 二级抽屉：完整 Langfuse-style waterfall -->
       <teleport to="body">
-        <div v-if="timelineDrawerVisible" class="trace-drawer-resize-handle"
+        <div v-if="timelineDrawerVisible && !isCompact" class="trace-drawer-resize-handle"
           :style="{ right: `${timelineDrawerWidth}px` }" role="separator" aria-orientation="vertical"
           :aria-label="$t('knowledgeStages.resizeDrawer')" :title="$t('knowledgeStages.resizeDrawer')"
           @mousedown.prevent="onTraceDrawerResizeStart">
           <div class="trace-drawer-resize-line" />
         </div>
       </teleport>
-      <t-drawer :visible="timelineDrawerVisible" :zIndex="2100" :size="`${timelineDrawerWidth}px`" attach="body"
+      <t-drawer :visible="timelineDrawerVisible" :zIndex="2100" :size="timelineDrawerSize" attach="body"
         :closeBtn="false" :footer="false" :header="false" :showOverlay="true" :closeOnOverlayClick="true"
-        placement="right" :class="['kp-secondary-drawer', { 'kp-secondary-drawer--resizing': timelineDrawerResizing }]"
+        placement="right" :class="['kp-secondary-drawer', { 'kp-secondary-drawer--resizing': timelineDrawerResizing, 'kp-secondary-drawer--compact': isCompact }]"
         @close="closeTimeline">
         <div class="kp-drawer-shell" :class="{ 'kp-drawer-shell--resizing': timelineDrawerResizing }">
           <KnowledgeProcessingTimeline v-if="details.id && timelineDrawerVisible" :knowledge-id="details.id"
@@ -2130,6 +2148,7 @@ const handleDetailsScroll = () => {
 </template>
 <style scoped lang="less">
 @import "./css/markdown.less";
+@import '@/assets/responsive.less';
 
 .section-title-actions,
 .metadata-actions,
@@ -3174,6 +3193,166 @@ const handleDetailsScroll = () => {
   color: var(--td-text-color-primary);
 }
 
+
+.doc-markdown-root,
+.md-content,
+.chunk-list,
+.chunk-item,
+.parent-context-content,
+.question-item {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  overflow-wrap: anywhere;
+}
+
+.md-content {
+  :deep(img),
+  :deep(video),
+  :deep(canvas),
+  :deep(svg) {
+    max-width: 100%;
+    height: auto;
+  }
+
+  :deep(table) {
+    display: block;
+    width: max-content;
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  :deep(pre),
+  :deep(.code-block-wrapper) {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+}
+
+.compact({
+  .doc-drawer-header {
+    gap: 8px;
+    padding-right: 44px;
+  }
+
+  .doc-drawer-header-icon {
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    font-size: 15px;
+  }
+
+  .doc-drawer-header-title {
+    font-size: 15px;
+  }
+
+  .header-actions {
+    gap: 0;
+  }
+
+  .header-action-btn {
+    width: 40px;
+    min-width: 40px;
+    height: 40px;
+    border-radius: 10px;
+  }
+
+  .doc-drawer-body {
+    gap: 0;
+  }
+
+  .doc-drawer-body .setting-drawer__section {
+    padding: 14px 0;
+    gap: 12px;
+  }
+
+  .doc-detail-row {
+    gap: 8px;
+  }
+
+  .doc-detail-label {
+    flex-basis: 64px;
+  }
+
+  .doc-content-section {
+    min-width: 0;
+  }
+
+  .doc-content-section-head {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 10px;
+    margin: 0 -12px;
+    padding: 10px 12px 8px;
+    background: var(--td-bg-color-container);
+    border-bottom: 1px solid var(--td-component-stroke);
+  }
+
+  .doc-content-section-head-left {
+    width: 100%;
+  }
+
+  .view-mode-buttons {
+    width: 100%;
+    min-width: 0;
+    padding: 3px;
+    gap: 3px;
+    box-sizing: border-box;
+    border-radius: 11px;
+    background: var(--td-bg-color-secondarycontainer);
+
+    .view-mode-btn {
+      flex: 1 1 0;
+      min-width: 0;
+      height: 38px;
+      border: 0;
+      border-radius: 8px;
+    }
+  }
+
+  .audio-player-section {
+    padding: 10px 12px;
+  }
+
+  .chunk-list {
+    gap: 10px;
+  }
+
+  .chunk-item {
+    padding: 12px;
+    border-radius: 10px;
+  }
+
+  .chunk-header {
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .chunk-header-right {
+    min-width: 0;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 6px;
+  }
+
+  .questions-list {
+    padding-left: 0;
+  }
+
+  .question-item {
+    padding: 8px;
+  }
+
+  .delete-question-btn {
+    opacity: 1 !important;
+  }
+});
+
 // 保留旧样式作为兼容（已被chunk-item替代）
 .content {
   word-break: break-word;
@@ -3204,6 +3383,67 @@ const handleDetailsScroll = () => {
 
 /* 主抽屉宽度可调：拖拽手柄通过 teleport 挂到 body，不受 scoped 影响，
    故样式写在非 scoped 块里。手柄贴在抽屉面板左缘（right = 抽屉宽度）。 */
+
+.t-drawer.doc-main-drawer--compact {
+  .t-drawer__content-wrapper,
+  .t-drawer__content {
+    width: 100% !important;
+    max-width: 100%;
+    height: var(--app-viewport-height, 100dvh);
+    max-height: var(--app-viewport-height, 100dvh);
+  }
+
+  .t-drawer__content {
+    border-radius: 0;
+  }
+
+  .t-drawer__header {
+    min-height: 52px;
+    padding: max(8px, env(safe-area-inset-top)) max(10px, env(safe-area-inset-right)) 8px max(12px, env(safe-area-inset-left));
+    flex-shrink: 0;
+  }
+
+  .t-drawer__close-btn {
+    top: max(8px, env(safe-area-inset-top));
+    right: max(6px, env(safe-area-inset-right));
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+  }
+
+  .t-drawer__body {
+    min-width: 0;
+    min-height: 0;
+    padding: 0 max(12px, env(safe-area-inset-right)) max(20px, env(safe-area-inset-bottom)) max(12px, env(safe-area-inset-left));
+    overflow-y: auto;
+    overflow-x: hidden;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    scroll-padding-top: 92px;
+  }
+}
+
+.t-drawer.kp-secondary-drawer--compact {
+  .t-drawer__content-wrapper,
+  .t-drawer__content {
+    width: 100% !important;
+    max-width: 100%;
+    height: var(--app-viewport-height, 100dvh);
+    max-height: var(--app-viewport-height, 100dvh);
+  }
+
+  .t-drawer__content {
+    border-radius: 0;
+  }
+
+  .t-drawer__body {
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+    overscroll-behavior: contain;
+  }
+}
+
 .doc-drawer-resize-handle {
   position: fixed;
   top: 0;

--- a/frontend/src/components/menu.vue
+++ b/frontend/src/components/menu.vue
@@ -1,7 +1,13 @@
 <template>
-    <div class="aside_box" :class="{ 'aside_box--collapsed': uiStore.sidebarCollapsed }">
+    <div id="platform-sidebar" class="aside_box" :class="{
+        'aside_box--collapsed': sidebarCollapsed,
+        'aside_box--mobile-open': uiStore.compactViewport && uiStore.mobileSidebarOpen,
+        'aside_box--compact-viewport': uiStore.compactViewport,
+    }" :role="uiStore.compactViewport && uiStore.mobileSidebarOpen ? 'dialog' : 'navigation'"
+        :aria-modal="uiStore.compactViewport && uiStore.mobileSidebarOpen ? true : undefined"
+        :aria-label="uiStore.compactViewport && uiStore.mobileSidebarOpen ? t('menu.collapseSidebar') : undefined">
         <!-- 展开时：Logo + 搜索/折叠按钮同行 -->
-        <div class="logo_row" v-if="!uiStore.sidebarCollapsed">
+        <div class="logo_row" v-if="!sidebarCollapsed">
             <div class="logo_box" @click="router.push('/platform/knowledge-bases')" style="cursor: pointer;">
                 <img class="logo" src="@/assets/img/weknora.png" alt="">
                 <sup v-if="isLiteEdition" class="lite-badge">Lite</sup>
@@ -19,19 +25,22 @@
                         <img class="header-icon-img" :src="getImgSrc('search.svg')" alt="">
                     </div>
                 </t-tooltip>
-                <div class="sidebar-toggle" @click="uiStore.toggleSidebar" :title="t('menu.collapseSidebar')">
+                <button type="button" class="sidebar-toggle" data-sidebar-toggle data-sidebar-close @click="uiStore.toggleSidebar"
+                    :title="t('menu.collapseSidebar')" :aria-label="t('menu.collapseSidebar')"
+                    aria-controls="platform-sidebar" :aria-expanded="!sidebarCollapsed">
                     <svg viewBox="0 0 20 20" width="18" height="18" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <rect x="1.5" y="1.5" width="17" height="17" rx="3" stroke="currentColor" stroke-width="1.2" />
                         <line x1="7.5" y1="1.5" x2="7.5" y2="18.5" stroke="currentColor" stroke-width="1.2" />
                         <line x1="4" y1="7.5" x2="4" y2="12.5" stroke="currentColor" stroke-width="1.2"
                             stroke-linecap="round" />
                     </svg>
-                </div>
+                </button>
             </div>
         </div>
         <!-- 折叠时：展开按钮 -->
         <t-tooltip v-else :content="t('menu.expandSidebar')" placement="right">
-            <div class="menu_item sidebar-toggle-item" @click="uiStore.toggleSidebar">
+            <button type="button" class="menu_item sidebar-toggle-item" data-sidebar-toggle data-sidebar-open @click="uiStore.toggleSidebar"
+                :aria-label="t('menu.expandSidebar')" aria-controls="platform-sidebar" :aria-expanded="!sidebarCollapsed">
                 <div class="menu_item-box">
                     <div class="menu_icon">
                         <svg class="icon" viewBox="0 0 20 20" width="20" height="20" fill="none"
@@ -46,20 +55,20 @@
                         </svg>
                     </div>
                 </div>
-            </div>
+            </button>
         </t-tooltip>
 
         <!-- 空间选择器：仅在用户可切换空间时显示 -->
-        <TenantSelector v-if="canAccessAllTenants && !uiStore.sidebarCollapsed" />
+        <TenantSelector v-if="canAccessAllTenants && !sidebarCollapsed" />
 
         <!-- 折叠时右侧拖拽展开手柄 -->
-        <div v-if="uiStore.sidebarCollapsed" class="sidebar-drag-handle" @mousedown="onDragHandleMouseDown" />
+        <div v-if="sidebarCollapsed && !uiStore.compactViewport" class="sidebar-drag-handle" @mousedown="onDragHandleMouseDown" />
 
         <!-- 上半部分：新对话吸顶 + 知识库/智能体/共享空间/历史会话随滚动一起滚走 -->
         <div class="menu_top" ref="scrollContainer" @scroll="handleScroll">
             <!-- 全局搜索入口：点击打开命令面板（⌘K）。展开态移至顶部 logo_row 的图标按钮；
                  折叠态在此处保留为图标项 + 深色 tooltip。 -->
-            <div class="menu_box menu_box--cmdk" v-if="uiStore.sidebarCollapsed">
+            <div class="menu_box menu_box--cmdk" v-if="sidebarCollapsed">
                 <t-tooltip placement="right">
                     <template #content>
                         <span class="cmdk-tip">
@@ -76,9 +85,9 @@
                     </div>
                 </t-tooltip>
             </div>
-            <div class="menu_box" :class="{ 'menu_box--sticky': item.children && !uiStore.sidebarCollapsed }"
+            <div class="menu_box" :class="{ 'menu_box--sticky': item.children && !sidebarCollapsed }"
                 v-for="(item, index) in topMenuItems" :key="index">
-                <t-tooltip :content="item.title" placement="right" :disabled="!uiStore.sidebarCollapsed">
+                <t-tooltip :content="item.title" placement="right" :disabled="!sidebarCollapsed">
                     <div @click="handleMenuClick(item.path)" @mouseenter="mouseenteMenu(item.path)"
                         @mouseleave="mouseleaveMenu(item.path)" :data-guide="`nav-${item.path}`"
                         :class="['menu_item', item.childrenPath && item.childrenPath == currentpath ? 'menu_item_c_active' : isMenuItemActive(item.path) ? 'menu_item_active' : '']">
@@ -88,7 +97,7 @@
                                     :src="getImgSrc(item.icon == 'zhishiku' ? knowledgeIcon : item.icon == 'agent' ? agentIcon : item.icon == 'organization' ? organizationIcon : item.icon == 'logout' ? logoutIcon : item.icon == 'setting' ? settingIcon : prefixIcon)"
                                     alt="">
                             </div>
-                            <template v-if="!uiStore.sidebarCollapsed">
+                            <template v-if="!sidebarCollapsed">
                                 <span class="menu_title" :title="item.title">{{ item.title }}</span>
                                 <span v-if="item.path === 'organizations' && orgStore.totalPendingJoinRequestCount > 0"
                                     class="menu-pending-badge"
@@ -101,7 +110,7 @@
             </div>
 
             <!-- 历史会话：按来源筛选后统一按日期分组展示 -->
-            <div class="submenu" v-if="!uiStore.sidebarCollapsed">
+            <div class="submenu" v-if="!sidebarCollapsed">
                 <!-- Stable, always-mounted source filter: reserving its row here
                      (instead of embedding it in the first date group, which
                      appears/disappears while a bucket loads) prevents the
@@ -170,7 +179,7 @@
         </div>
 
         <!-- 批量管理底部操作条：固定在侧栏底部、用户头像上方 -->
-        <div v-if="batchMode && !uiStore.sidebarCollapsed" class="batch-inline-footer">
+        <div v-if="batchMode && !sidebarCollapsed" class="batch-inline-footer">
             <div class="batch-footer-left">
                 <t-checkbox :checked="isAllBatchSelected" :indeterminate="isBatchIndeterminate"
                     @change="toggleBatchSelectAll">
@@ -288,6 +297,7 @@ const usemenuStore = useMenuStore();
 const authStore = useAuthStore();
 const orgStore = useOrganizationStore();
 const uiStore = useUIStore();
+const sidebarCollapsed = computed(() => uiStore.effectiveSidebarCollapsed);
 const commandPaletteStore = useCommandPaletteStore();
 
 // Platform-aware label for the ⌘K hint. navigator.platform is deprecated but
@@ -1081,6 +1091,7 @@ const handleMenuClick = async (path: string) => {
     } else {
         gotopage(path)
     }
+    if (uiStore.compactViewport) uiStore.closeMobileSidebar()
 }
 
 // 处理退出登录确认
@@ -1126,6 +1137,7 @@ const gotopage = async (path: string) => {
         }
     }
     getIcon(path)
+    if (uiStore.compactViewport) uiStore.closeMobileSidebar()
 }
 
 const getImgSrc = (url: string) => {
@@ -1160,6 +1172,7 @@ const onDragHandleMouseDown = (e: MouseEvent) => {
 
 </script>
 <style lang="less" scoped>
+@import '@/assets/responsive.less';
 .aside_box {
     // 侧栏水平栅格：图标列与文案列统一对齐（Logo / 菜单 / 会话分组 / 会话行）
     --sidebar-inset-x: 14px;
@@ -1242,6 +1255,15 @@ const onDragHandleMouseDown = (e: MouseEvent) => {
         border-radius: 4px;
         transition: background-color 0.2s ease;
         box-sizing: border-box;
+        padding: 0;
+        border: 0;
+        background: transparent;
+        font: inherit;
+
+        &:focus-visible {
+            outline: 2px solid var(--td-brand-color);
+            outline-offset: 2px;
+        }
 
         &:hover {
             background: var(--td-bg-color-container-hover);
@@ -1885,6 +1907,79 @@ const onDragHandleMouseDown = (e: MouseEvent) => {
 .menu_box {
     position: relative;
 }
+
+.sidebar-toggle-item {
+    width: 100%;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: inherit;
+    appearance: none;
+}
+
+.aside_box--compact-viewport.aside_box--collapsed {
+    min-width: 44px;
+    width: 44px;
+    padding: 6px 2px;
+    overflow: hidden;
+
+    /* On phones the closed sidebar is only an opener. Rendering the whole
+       desktop navigation inside a 44px rail made labels wrap vertically and
+       consumed valuable reading width. */
+    .menu_top,
+    .menu_bottom {
+        display: none;
+    }
+
+    .sidebar-toggle-item {
+        width: 40px;
+        min-width: 40px;
+        min-height: 40px;
+        height: 40px;
+        margin: 0;
+        padding: 0;
+        border-radius: 10px;
+    }
+
+    .sidebar-toggle-item .menu_item-box {
+        width: 40px;
+        height: 40px;
+        justify-content: center;
+    }
+}
+
+.aside_box--mobile-open {
+    position: fixed;
+    inset: var(--app-viewport-offset-top, 0) auto auto 0;
+    z-index: 920;
+    width: min(320px, 88vw);
+    min-width: min(320px, 88vw);
+    height: var(--app-viewport-height, 100dvh);
+    padding-top: max(8px, env(safe-area-inset-top));
+    padding-bottom: max(6px, env(safe-area-inset-bottom));
+    overflow: hidden;
+    border-right: 1px solid var(--td-component-stroke);
+    box-shadow: 8px 0 28px rgba(0, 0, 0, 0.2);
+    transition: none;
+
+    .menu_item {
+        min-height: 44px;
+        height: auto;
+        padding-block: 10px;
+    }
+
+    .sidebar-toggle {
+        width: 40px;
+        height: 40px;
+    }
+}
+
+.reduced-motion({
+    .aside_box {
+        transition: none;
+    }
+});
 </style>
 <style lang="less">
 // Dark mode: invert dark logo to light

--- a/frontend/src/components/settings/SettingDrawer.vue
+++ b/frontend/src/components/settings/SettingDrawer.vue
@@ -1,6 +1,6 @@
 <template>
   <teleport to="body">
-    <div v-if="drawerVisible && resizable" class="setting-drawer-resize-handle"
+    <div v-if="drawerVisible && resizable && !isCompact" class="setting-drawer-resize-handle"
       :class="{ 'setting-drawer-resize-handle--active': drawerResizing }"
       :style="{ right: `${drawerWidthPx}px`, '--setting-drawer-travel': `${drawerWidthPx}px` }"
       role="separator" aria-orientation="vertical" @mousedown.prevent="onResizeStart">
@@ -57,8 +57,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, useAttrs, onMounted, onUnmounted } from 'vue'
+import { ref, computed, useAttrs, onMounted, onUnmounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useResponsiveViewport } from '@/composables/useResponsiveViewport'
+import { setBodyScrollLock, releaseBodyScrollLock } from '@/utils/bodyScrollLock'
 
 interface Props {
   visible: boolean
@@ -117,6 +119,8 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const attrs = useAttrs()
+const { isCompact } = useResponsiveViewport()
+const SETTING_DRAWER_SCROLL_LOCK = 'shared-setting-drawer'
 
 const drawerPassthroughAttrs = computed(() => {
   const { class: _class, ...rest } = attrs
@@ -162,7 +166,7 @@ const loadStoredWidth = (): number | null => {
 const userWidthPx = ref<number | null>(loadStoredWidth())
 
 const effectiveWidth = computed(() =>
-  userWidthPx.value != null ? `${userWidthPx.value}px` : props.width
+  isCompact.value ? '100%' : (userWidthPx.value != null ? `${userWidthPx.value}px` : props.width)
 )
 
 const drawerWidthPx = computed(() =>
@@ -186,13 +190,17 @@ const drawerResizing = ref(false)
 const drawerClass = computed(() => [
   'setting-drawer',
   attrs.class,
-  { 'setting-drawer--resizing': drawerResizing.value },
+  {
+    'setting-drawer--resizing': drawerResizing.value,
+    'setting-drawer--compact': isCompact.value,
+  },
 ])
 
 let resizeStartX = 0
 let resizeStartWidth = 0
 
 function onResizeStart(e: MouseEvent) {
+  if (isCompact.value) return
   drawerResizing.value = true
   resizeStartX = e.clientX
   resizeStartWidth = drawerWidthPx.value
@@ -230,6 +238,11 @@ function onWindowResize() {
   }
 }
 
+watch([drawerVisible, isCompact], ([visible, compact]) => {
+  setBodyScrollLock(SETTING_DRAWER_SCROLL_LOCK, visible && compact)
+  if ((!visible || compact) && drawerResizing.value) cleanupResize()
+}, { immediate: true })
+
 onMounted(() => {
   window.addEventListener('resize', onWindowResize, { passive: true })
 })
@@ -237,6 +250,7 @@ onMounted(() => {
 onUnmounted(() => {
   window.removeEventListener('resize', onWindowResize)
   cleanupResize()
+  releaseBodyScrollLock(SETTING_DRAWER_SCROLL_LOCK)
 })
 
 const handleConfirm = () => emit('confirm')
@@ -247,6 +261,7 @@ const handleCancel = () => {
 </script>
 
 <style lang="less" scoped>
+@import '@/assets/responsive.less';
 /* ---------- Header ---------- */
 .setting-drawer__header {
   display: flex;
@@ -401,6 +416,48 @@ const handleCancel = () => {
   gap: 12px;
   flex-shrink: 0;
 }
+
+
+.compact({
+  .setting-drawer__header {
+    gap: 8px;
+    padding-right: 34px;
+  }
+
+  .setting-drawer__header-icon {
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+  }
+
+  .setting-drawer__title {
+    font-size: 15px;
+  }
+
+  .setting-drawer__subtitle {
+    display: none;
+  }
+
+  .setting-drawer__footer {
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .setting-drawer__footer-left:empty {
+    display: none;
+  }
+
+  .setting-drawer__footer-right {
+    width: 100%;
+    gap: 8px;
+
+    :deep(.t-button) {
+      flex: 1 1 0;
+      min-width: 0;
+      height: 40px;
+    }
+  }
+});
 </style>
 
 <!--
@@ -424,6 +481,36 @@ const handleCancel = () => {
     padding: 10px 18px;
     border-top: 1px solid var(--td-component-stroke);
     box-shadow: 0 -2px 8px rgba(15, 23, 42, 0.04);
+  }
+}
+
+
+.setting-drawer.setting-drawer--compact {
+  .t-drawer__content-wrapper,
+  .t-drawer__content {
+    width: 100% !important;
+    max-width: 100%;
+    height: var(--app-viewport-height, 100dvh);
+    max-height: var(--app-viewport-height, 100dvh);
+  }
+
+  .t-drawer__content {
+    border-radius: 0;
+  }
+
+  .t-drawer__header {
+    min-height: 52px;
+    padding: max(8px, env(safe-area-inset-top)) max(10px, env(safe-area-inset-right)) 8px max(12px, env(safe-area-inset-left));
+  }
+
+  .t-drawer__body {
+    padding: 12px max(12px, env(safe-area-inset-right)) max(20px, env(safe-area-inset-bottom)) max(12px, env(safe-area-inset-left));
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  .t-drawer__footer {
+    padding: 8px max(12px, env(safe-area-inset-right)) max(8px, env(safe-area-inset-bottom)) max(12px, env(safe-area-inset-left));
   }
 }
 

--- a/frontend/src/composables/responsiveViewportMetrics.test.ts
+++ b/frontend/src/composables/responsiveViewportMetrics.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { resolveResponsiveViewportGeometry } from './responsiveViewportMetrics'
+
+test('normal mobile viewport follows VisualViewport and detects keyboard inset', () => {
+  const normal = resolveResponsiveViewportGeometry({
+    innerWidth: 390,
+    innerHeight: 844,
+    visualWidth: 390,
+    visualHeight: 844,
+    visualScale: 1,
+  })
+
+  assert.deepEqual(normal, {
+    layoutWidth: 390,
+    layoutHeight: 844,
+    visualWidth: 390,
+    visualHeight: 844,
+    visualOffsetTop: 0,
+    visualScale: 1,
+    keyboardInset: 0,
+    isPinchZoomed: false,
+  })
+
+  const keyboard = resolveResponsiveViewportGeometry({
+    innerWidth: 390,
+    innerHeight: 844,
+    visualWidth: 390,
+    visualHeight: 500,
+    visualOffsetTop: 0,
+    visualScale: 1,
+  })
+
+  assert.equal(keyboard.visualHeight, 500)
+  assert.equal(keyboard.keyboardInset, 344)
+  assert.equal(keyboard.isPinchZoomed, false)
+})
+
+test('pinch zoom does not shrink the application layout or imitate a keyboard', () => {
+  const zoomed = resolveResponsiveViewportGeometry({
+    innerWidth: 390,
+    innerHeight: 844,
+    visualWidth: 195,
+    visualHeight: 422,
+    visualOffsetTop: 80,
+    visualScale: 2,
+  })
+
+  assert.equal(zoomed.isPinchZoomed, true)
+  assert.equal(zoomed.visualScale, 2)
+  assert.equal(zoomed.visualWidth, 390)
+  assert.equal(zoomed.visualHeight, 844)
+  assert.equal(zoomed.visualOffsetTop, 0)
+  assert.equal(zoomed.keyboardInset, 0)
+})
+
+test('small VisualViewport scale noise does not trigger pinch mode', () => {
+  const noisy = resolveResponsiveViewportGeometry({
+    innerWidth: 390,
+    innerHeight: 844,
+    visualWidth: 388,
+    visualHeight: 840,
+    visualScale: 1.01,
+  })
+
+  assert.equal(noisy.isPinchZoomed, false)
+  assert.equal(noisy.visualWidth, 388)
+  assert.equal(noisy.visualHeight, 840)
+})
+
+test('CSS root zoom and browser pinch zoom remain separate coordinate systems', () => {
+  const rootZoomOnly = resolveResponsiveViewportGeometry({
+    innerWidth: 500,
+    innerHeight: 1000,
+    rootZoom: 1.25,
+    visualWidth: 500,
+    visualHeight: 750,
+    visualScale: 1,
+  })
+
+  assert.equal(rootZoomOnly.layoutWidth, 400)
+  assert.equal(rootZoomOnly.layoutHeight, 800)
+  assert.equal(rootZoomOnly.visualHeight, 600)
+  assert.equal(rootZoomOnly.keyboardInset, 200)
+  assert.equal(rootZoomOnly.isPinchZoomed, false)
+
+  const combinedZoom = resolveResponsiveViewportGeometry({
+    innerWidth: 500,
+    innerHeight: 1000,
+    rootZoom: 1.25,
+    visualWidth: 250,
+    visualHeight: 500,
+    visualOffsetTop: 50,
+    visualScale: 2,
+  })
+
+  assert.equal(combinedZoom.layoutWidth, 400)
+  assert.equal(combinedZoom.layoutHeight, 800)
+  assert.equal(combinedZoom.visualWidth, 400)
+  assert.equal(combinedZoom.visualHeight, 800)
+  assert.equal(combinedZoom.visualOffsetTop, 0)
+  assert.equal(combinedZoom.keyboardInset, 0)
+  assert.equal(combinedZoom.isPinchZoomed, true)
+})

--- a/frontend/src/composables/responsiveViewportMetrics.ts
+++ b/frontend/src/composables/responsiveViewportMetrics.ts
@@ -1,0 +1,85 @@
+export const PINCH_ZOOM_EPSILON = 0.02
+
+export interface ResponsiveViewportGeometryInput {
+  innerWidth: number
+  innerHeight: number
+  rootZoom?: number
+  visualWidth?: number
+  visualHeight?: number
+  visualOffsetTop?: number
+  visualScale?: number
+}
+
+export interface ResponsiveViewportGeometry {
+  layoutWidth: number
+  layoutHeight: number
+  visualWidth: number
+  visualHeight: number
+  visualOffsetTop: number
+  visualScale: number
+  keyboardInset: number
+  isPinchZoomed: boolean
+}
+
+const positiveOr = (value: number | undefined, fallback: number): number =>
+  typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback
+
+const nonNegativeOr = (value: number | undefined, fallback: number): number =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : fallback
+
+/**
+ * Resolve the two viewport coordinate systems used by the application.
+ *
+ * `window.innerWidth/innerHeight` describe the layout viewport. A mobile
+ * pinch gesture only changes `VisualViewport`, so feeding its shrunken size
+ * into full-screen layout CSS makes pages collapse or appear blank. The
+ * visual viewport is still useful while the software keyboard is open, but
+ * only at the normal browser scale.
+ */
+export function resolveResponsiveViewportGeometry({
+  innerWidth,
+  innerHeight,
+  rootZoom = 1,
+  visualWidth,
+  visualHeight,
+  visualOffsetTop = 0,
+  visualScale = 1,
+}: ResponsiveViewportGeometryInput): ResponsiveViewportGeometry {
+  const zoom = positiveOr(rootZoom, 1)
+  const safeInnerWidth = nonNegativeOr(innerWidth, 0)
+  const safeInnerHeight = nonNegativeOr(innerHeight, 0)
+  const layoutWidth = safeInnerWidth / zoom
+  const layoutHeight = safeInnerHeight / zoom
+  const rawVisualWidth = positiveOr(visualWidth, safeInnerWidth) / zoom
+  const rawVisualHeight = positiveOr(visualHeight, safeInnerHeight) / zoom
+  const rawVisualOffsetTop = nonNegativeOr(visualOffsetTop, 0) / zoom
+  const scale = positiveOr(visualScale, 1)
+  const isPinchZoomed = Math.abs(scale - 1) > PINCH_ZOOM_EPSILON
+
+  // During pinch zoom, VisualViewport represents only the magnified slice
+  // currently visible on screen. Keep the app's layout contract stable and
+  // let the browser perform the visual magnification/panning itself.
+  if (isPinchZoomed) {
+    return {
+      layoutWidth,
+      layoutHeight,
+      visualWidth: layoutWidth,
+      visualHeight: layoutHeight,
+      visualOffsetTop: 0,
+      visualScale: scale,
+      keyboardInset: 0,
+      isPinchZoomed: true,
+    }
+  }
+
+  return {
+    layoutWidth,
+    layoutHeight,
+    visualWidth: rawVisualWidth,
+    visualHeight: rawVisualHeight,
+    visualOffsetTop: rawVisualOffsetTop,
+    visualScale: scale,
+    keyboardInset: Math.max(0, layoutHeight - rawVisualHeight - rawVisualOffsetTop),
+    isPinchZoomed: false,
+  }
+}

--- a/frontend/src/composables/useResponsiveViewport.ts
+++ b/frontend/src/composables/useResponsiveViewport.ts
@@ -1,0 +1,218 @@
+import { onMounted, onUnmounted, readonly, ref } from 'vue'
+import { getRootZoom } from '@/utils/zoom'
+import { resolveResponsiveViewportGeometry } from './responsiveViewportMetrics'
+
+export const PHONE_MAX_WIDTH = 767
+export const COMPACT_MAX_WIDTH = 899
+export const TABLET_MAX_WIDTH = 1199
+export const COMPACT_LAYOUT_QUERY =
+  `(max-width: ${COMPACT_MAX_WIDTH}px), (max-height: 520px) and (pointer: coarse)`
+
+type ViewportKind = 'phone' | 'tablet' | 'desktop'
+type Orientation = 'portrait' | 'landscape'
+
+const layoutWidth = ref(0)
+const layoutHeight = ref(0)
+const visualWidth = ref(0)
+const visualHeight = ref(0)
+const visualOffsetTop = ref(0)
+const visualScale = ref(1)
+const keyboardInset = ref(0)
+const isPinchZoomed = ref(false)
+const isKeyboardOpen = ref(false)
+const isCoarsePointer = ref(false)
+const orientation = ref<Orientation>('portrait')
+const viewportKind = ref<ViewportKind>('desktop')
+const isPhone = ref(false)
+const isTablet = ref(false)
+const isDesktop = ref(true)
+const isCompact = ref(false)
+
+let consumers = 0
+let listening = false
+let animationFrame: number | null = null
+let coarsePointerQuery: MediaQueryList | null = null
+const focusMeasureTimers = new Set<number>()
+
+export function matchesCompactLayout(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia(COMPACT_LAYOUT_QUERY).matches
+}
+
+const applyRootMetrics = () => {
+  if (typeof document === 'undefined') return
+  const root = document.documentElement
+  root.style.setProperty('--app-layout-width', `${layoutWidth.value}px`)
+  root.style.setProperty('--app-layout-height', `${layoutHeight.value}px`)
+  root.style.setProperty('--app-viewport-width', `${visualWidth.value}px`)
+  root.style.setProperty('--app-viewport-height', `${visualHeight.value}px`)
+  root.style.setProperty('--app-viewport-offset-top', `${visualOffsetTop.value}px`)
+  root.style.setProperty('--app-visual-scale', String(visualScale.value))
+  root.style.setProperty('--app-keyboard-inset', `${keyboardInset.value}px`)
+  root.dataset.viewport = viewportKind.value
+  root.dataset.orientation = orientation.value
+  root.classList.toggle('app-compact-viewport', isCompact.value)
+  root.classList.toggle('app-pinch-zoomed', isPinchZoomed.value)
+  root.classList.toggle('app-keyboard-open', isKeyboardOpen.value)
+  root.classList.toggle('app-coarse-pointer', isCoarsePointer.value)
+}
+
+export function measureResponsiveViewport() {
+  if (typeof window === 'undefined') return
+  const viewport = window.visualViewport
+  const metrics = resolveResponsiveViewportGeometry({
+    innerWidth: window.innerWidth,
+    innerHeight: window.innerHeight,
+    rootZoom: getRootZoom(),
+    visualWidth: viewport?.width,
+    visualHeight: viewport?.height,
+    visualOffsetTop: viewport?.offsetTop,
+    visualScale: viewport?.scale,
+  })
+  const {
+    layoutWidth: nextLayoutWidth,
+    layoutHeight: nextLayoutHeight,
+    visualWidth: nextVisualWidth,
+    visualHeight: nextVisualHeight,
+    visualOffsetTop: nextOffsetTop,
+    visualScale: nextVisualScale,
+    keyboardInset: nextKeyboardInset,
+    isPinchZoomed: nextIsPinchZoomed,
+  } = metrics
+  const coarse = coarsePointerQuery?.matches
+    ?? window.matchMedia?.('(pointer: coarse)').matches
+    ?? false
+  const landscape = nextLayoutWidth > nextLayoutHeight
+  const compact = nextLayoutWidth <= COMPACT_MAX_WIDTH || (coarse && landscape && nextLayoutHeight <= 520)
+  const phone = nextLayoutWidth <= PHONE_MAX_WIDTH || (coarse && landscape && nextLayoutHeight <= 520)
+
+  layoutWidth.value = nextLayoutWidth
+  layoutHeight.value = nextLayoutHeight
+  visualWidth.value = nextVisualWidth
+  visualHeight.value = nextVisualHeight
+  visualOffsetTop.value = nextOffsetTop
+  visualScale.value = nextVisualScale
+  keyboardInset.value = nextKeyboardInset
+  isPinchZoomed.value = nextIsPinchZoomed
+  isCoarsePointer.value = coarse
+  orientation.value = landscape ? 'landscape' : 'portrait'
+  isCompact.value = compact
+  isPhone.value = phone
+  isTablet.value = !phone && nextLayoutWidth <= TABLET_MAX_WIDTH
+  isDesktop.value = nextLayoutWidth > TABLET_MAX_WIDTH
+  viewportKind.value = phone ? 'phone' : isTablet.value ? 'tablet' : 'desktop'
+  isKeyboardOpen.value = !nextIsPinchZoomed
+    && coarse
+    && nextKeyboardInset > 100
+    && nextVisualHeight < nextLayoutHeight * 0.86
+
+  applyRootMetrics()
+}
+
+const scheduleMeasure = () => {
+  if (!listening || animationFrame !== null || typeof window === 'undefined') return
+  animationFrame = window.requestAnimationFrame(() => {
+    animationFrame = null
+    measureResponsiveViewport()
+  })
+}
+
+const addMediaListener = (query: MediaQueryList, listener: () => void) => {
+  if (typeof query.addEventListener === 'function') query.addEventListener('change', listener)
+  else query.addListener?.(listener)
+}
+
+const removeMediaListener = (query: MediaQueryList, listener: () => void) => {
+  if (typeof query.removeEventListener === 'function') query.removeEventListener('change', listener)
+  else query.removeListener?.(listener)
+}
+
+const scheduleDelayedMeasure = (delay: number) => {
+  const timer = window.setTimeout(() => {
+    focusMeasureTimers.delete(timer)
+    scheduleMeasure()
+  }, delay)
+  focusMeasureTimers.add(timer)
+}
+
+const handleFocusChange = () => {
+  scheduleMeasure()
+  scheduleDelayedMeasure(80)
+  scheduleDelayedMeasure(240)
+}
+
+const startListening = () => {
+  if (listening || typeof window === 'undefined') return
+  listening = true
+  coarsePointerQuery = window.matchMedia?.('(pointer: coarse)') ?? null
+  window.addEventListener('resize', scheduleMeasure, { passive: true })
+  window.addEventListener('orientationchange', scheduleMeasure, { passive: true })
+  window.addEventListener('pageshow', scheduleMeasure, { passive: true })
+  window.visualViewport?.addEventListener('resize', scheduleMeasure, { passive: true })
+  window.visualViewport?.addEventListener('scroll', scheduleMeasure, { passive: true })
+  document.addEventListener('focusin', handleFocusChange, true)
+  document.addEventListener('focusout', handleFocusChange, true)
+  if (coarsePointerQuery) addMediaListener(coarsePointerQuery, scheduleMeasure)
+  measureResponsiveViewport()
+}
+
+const stopListening = () => {
+  if (!listening || typeof window === 'undefined') return
+  listening = false
+  window.removeEventListener('resize', scheduleMeasure)
+  window.removeEventListener('orientationchange', scheduleMeasure)
+  window.removeEventListener('pageshow', scheduleMeasure)
+  window.visualViewport?.removeEventListener('resize', scheduleMeasure)
+  window.visualViewport?.removeEventListener('scroll', scheduleMeasure)
+  document.removeEventListener('focusin', handleFocusChange, true)
+  document.removeEventListener('focusout', handleFocusChange, true)
+  if (coarsePointerQuery) removeMediaListener(coarsePointerQuery, scheduleMeasure)
+  coarsePointerQuery = null
+  if (animationFrame !== null) {
+    window.cancelAnimationFrame(animationFrame)
+    animationFrame = null
+  }
+  focusMeasureTimers.forEach(timer => window.clearTimeout(timer))
+  focusMeasureTimers.clear()
+}
+
+export function retainResponsiveViewport() {
+  consumers += 1
+  if (consumers === 1) startListening()
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    consumers = Math.max(0, consumers - 1)
+    if (consumers === 0) stopListening()
+  }
+}
+
+if (typeof window !== 'undefined') measureResponsiveViewport()
+
+export function useResponsiveViewport() {
+  let release: (() => void) | null = null
+  onMounted(() => { release = retainResponsiveViewport() })
+  onUnmounted(() => { release?.(); release = null })
+
+  return {
+    layoutWidth: readonly(layoutWidth),
+    layoutHeight: readonly(layoutHeight),
+    visualWidth: readonly(visualWidth),
+    visualHeight: readonly(visualHeight),
+    visualOffsetTop: readonly(visualOffsetTop),
+    visualScale: readonly(visualScale),
+    isPinchZoomed: readonly(isPinchZoomed),
+    keyboardInset: readonly(keyboardInset),
+    isKeyboardOpen: readonly(isKeyboardOpen),
+    isCoarsePointer: readonly(isCoarsePointer),
+    orientation: readonly(orientation),
+    viewportKind: readonly(viewportKind),
+    isPhone: readonly(isPhone),
+    isTablet: readonly(isTablet),
+    isDesktop: readonly(isDesktop),
+    isCompact: readonly(isCompact),
+    refresh: measureResponsiveViewport,
+  } as const
+}

--- a/frontend/src/stores/ui.ts
+++ b/frontend/src/stores/ui.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { matchesCompactLayout } from '@/composables/useResponsiveViewport'
 
 export const useUIStore = defineStore('ui', {
   state: () => ({
@@ -20,8 +21,16 @@ export const useUIStore = defineStore('ui', {
     manualEditorInitialContent: '',
     manualEditorInitialStatus: 'draft' as 'draft' | 'publish',
     manualEditorOnSuccess: null as null | ((payload: { kbId: string; knowledgeId: string; status: 'draft' | 'publish' }) => void),
-    sidebarCollapsed: localStorage.getItem('sidebar_collapsed') === 'true'
+    sidebarCollapsed: localStorage.getItem('sidebar_collapsed') === 'true',
+    compactViewport: matchesCompactLayout(),
+    mobileSidebarOpen: false
   }),
+
+  getters: {
+    effectiveSidebarCollapsed: (state) => state.compactViewport
+      ? !state.mobileSidebarOpen
+      : state.sidebarCollapsed
+  },
 
   actions: {
     openSettings(section?: string, subSection?: string) {
@@ -121,18 +130,40 @@ export const useUIStore = defineStore('ui', {
     },
 
     toggleSidebar() {
+      if (this.compactViewport) {
+        this.mobileSidebarOpen = !this.mobileSidebarOpen
+        return
+      }
       this.sidebarCollapsed = !this.sidebarCollapsed
       localStorage.setItem('sidebar_collapsed', String(this.sidebarCollapsed))
     },
 
     collapseSidebar() {
+      if (this.compactViewport) {
+        this.mobileSidebarOpen = false
+        return
+      }
       this.sidebarCollapsed = true
       localStorage.setItem('sidebar_collapsed', 'true')
     },
 
     expandSidebar() {
+      if (this.compactViewport) {
+        this.mobileSidebarOpen = true
+        return
+      }
       this.sidebarCollapsed = false
       localStorage.setItem('sidebar_collapsed', 'false')
+    },
+
+    setCompactViewport(compact: boolean) {
+      if (this.compactViewport === compact) return
+      this.compactViewport = compact
+      this.mobileSidebarOpen = false
+    },
+
+    closeMobileSidebar() {
+      this.mobileSidebarOpen = false
     }
   }
 })

--- a/frontend/src/utils/bodyScrollLock.ts
+++ b/frontend/src/utils/bodyScrollLock.ts
@@ -1,0 +1,31 @@
+const lockTokens = new Set<string>()
+let previousOverflow = ''
+let previousOverscrollBehavior = ''
+
+const applyLockState = () => {
+  if (typeof document === 'undefined') return
+  const body = document.body
+  const locked = lockTokens.size > 0
+  if (locked && !body.classList.contains('app-scroll-locked')) {
+    previousOverflow = body.style.overflow
+    previousOverscrollBehavior = body.style.overscrollBehavior
+    body.style.overflow = 'hidden'
+    body.style.overscrollBehavior = 'none'
+    body.classList.add('app-scroll-locked')
+  } else if (!locked && body.classList.contains('app-scroll-locked')) {
+    body.style.overflow = previousOverflow
+    body.style.overscrollBehavior = previousOverscrollBehavior
+    body.classList.remove('app-scroll-locked')
+  }
+}
+
+export function setBodyScrollLock(token: string, locked: boolean) {
+  if (locked) lockTokens.add(token)
+  else lockTokens.delete(token)
+  applyLockState()
+}
+
+export function releaseBodyScrollLock(token: string) {
+  lockTokens.delete(token)
+  applyLockState()
+}

--- a/frontend/src/utils/focusTrap.ts
+++ b/frontend/src/utils/focusTrap.ts
@@ -1,0 +1,56 @@
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) => {
+      if (element.hidden || element.getClientRects().length === 0) return false
+      if (element.getAttribute('aria-disabled') === 'true') return false
+      if (element.closest('[inert], [aria-hidden="true"]')) return false
+      const style = window.getComputedStyle(element)
+      return style.display !== 'none' && style.visibility !== 'hidden' && style.visibility !== 'collapse'
+    })
+}
+
+export function focusFirstElement(container: HTMLElement, preferredSelector?: string) {
+  const focusable = getFocusableElements(container)
+  const preferred = preferredSelector
+    ? container.querySelector<HTMLElement>(preferredSelector)
+    : null
+  const target = preferred && focusable.includes(preferred)
+    ? preferred
+    : focusable[0] ?? container
+  if (!container.hasAttribute('tabindex')) container.setAttribute('tabindex', '-1')
+  target.focus({ preventScroll: true })
+}
+
+export function trapTabKey(event: KeyboardEvent, container: HTMLElement): boolean {
+  if (event.key !== 'Tab') return false
+  const focusable = getFocusableElements(container)
+  if (!focusable.length) {
+    event.preventDefault()
+    container.focus({ preventScroll: true })
+    return true
+  }
+
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  const active = document.activeElement
+  if (event.shiftKey && (active === first || !container.contains(active))) {
+    event.preventDefault()
+    last.focus({ preventScroll: true })
+    return true
+  }
+  if (!event.shiftKey && (active === last || !container.contains(active))) {
+    event.preventDefault()
+    first.focus({ preventScroll: true })
+    return true
+  }
+  return false
+}

--- a/frontend/src/utils/popoverPosition.test.ts
+++ b/frontend/src/utils/popoverPosition.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  clampPopoverLeft,
+  clampPopoverWidth,
+  computeAnchoredPopoverLayout,
+} from './popoverPosition'
+
+const anchor = {
+  top: 100,
+  right: 220,
+  bottom: 130,
+  left: 100,
+  width: 120,
+  height: 30,
+}
+
+test('popover width and horizontal position stay inside viewport edges', () => {
+  assert.equal(clampPopoverWidth(360, 320), 304)
+  assert.equal(clampPopoverLeft(300, 220, 320), 92)
+  assert.equal(clampPopoverLeft(-20, 220, 320), 8)
+})
+
+test('tiny and invalid viewports produce finite non-negative geometry', () => {
+  assert.equal(clampPopoverWidth(100, 10), 0)
+  assert.equal(clampPopoverLeft(Number.NaN, 100, 10), 5)
+
+  const layout = computeAnchoredPopoverLayout(anchor, {
+    width: Number.NaN,
+    height: -1,
+  }, {
+    preferredWidth: Number.POSITIVE_INFINITY,
+    preferredHeight: Number.NaN,
+  })
+
+  assert.equal(layout.width, 0)
+  assert.equal(layout.maxHeight, 0)
+  assert.ok(Object.values(layout.style).every(value => !value.includes('NaN')))
+})
+
+test('popover opens below when there is sufficient visible space', () => {
+  const layout = computeAnchoredPopoverLayout(anchor, { width: 400, height: 800 }, {
+    preferredWidth: 220,
+    preferredHeight: 280,
+    minSpaceBelow: 160,
+    maxHeightRatio: 0.62,
+    offsetY: 8,
+  })
+
+  assert.equal(layout.openBelow, true)
+  assert.equal(layout.left, 100)
+  assert.equal(layout.maxHeight, 280)
+  assert.equal(layout.style.top, '138px')
+  assert.equal(layout.style.bottom, 'auto')
+})
+
+test('popover opens above near the bottom and supports end alignment', () => {
+  const bottomAnchor = { ...anchor, top: 700, bottom: 730, left: 250, right: 370 }
+  const layout = computeAnchoredPopoverLayout(bottomAnchor, { width: 400, height: 800 }, {
+    preferredWidth: 220,
+    preferredHeight: 280,
+    align: 'end',
+    minSpaceBelow: 160,
+    offsetY: 8,
+  })
+
+  assert.equal(layout.openBelow, false)
+  assert.equal(layout.left, 150)
+  assert.equal(layout.maxHeight, 280)
+  assert.equal(layout.style.top, 'auto')
+  assert.equal(layout.style.bottom, '108px')
+})

--- a/frontend/src/utils/popoverPosition.ts
+++ b/frontend/src/utils/popoverPosition.ts
@@ -1,0 +1,105 @@
+export const DEFAULT_POPOVER_EDGE_GAP = 8
+
+const finiteNonNegative = (value: number): number =>
+  Number.isFinite(value) ? Math.max(0, value) : 0
+
+const effectiveEdgeGap = (viewportSize: number, edgeGap: number): number =>
+  Math.min(finiteNonNegative(edgeGap), finiteNonNegative(viewportSize) / 2)
+
+export interface ViewportSize {
+  width: number
+  height: number
+}
+
+export interface AnchorRect {
+  top: number
+  right: number
+  bottom: number
+  left: number
+  width: number
+  height: number
+}
+
+export interface AnchoredPopoverOptions {
+  preferredWidth: number
+  preferredHeight: number
+  minSpaceBelow?: number
+  maxHeightRatio?: number
+  edgeGap?: number
+  offsetY?: number
+  align?: 'start' | 'end'
+}
+
+export interface AnchoredPopoverLayout {
+  style: Record<string, string>
+  width: number
+  maxHeight: number
+  left: number
+  openBelow: boolean
+}
+
+export function clampPopoverWidth(
+  preferredWidth: number,
+  viewportWidth: number,
+  edgeGap = DEFAULT_POPOVER_EDGE_GAP,
+): number {
+  const safeViewportWidth = finiteNonNegative(viewportWidth)
+  const safeEdgeGap = effectiveEdgeGap(safeViewportWidth, edgeGap)
+  return Math.min(finiteNonNegative(preferredWidth), safeViewportWidth - safeEdgeGap * 2)
+}
+
+export function clampPopoverLeft(
+  preferredLeft: number,
+  popoverWidth: number,
+  viewportWidth: number,
+  edgeGap = DEFAULT_POPOVER_EDGE_GAP,
+): number {
+  const safeViewportWidth = finiteNonNegative(viewportWidth)
+  const safePopoverWidth = Math.min(finiteNonNegative(popoverWidth), safeViewportWidth)
+  const safeEdgeGap = effectiveEdgeGap(safeViewportWidth, edgeGap)
+  const minLeft = safeEdgeGap
+  const maxLeft = Math.max(minLeft, safeViewportWidth - safePopoverWidth - safeEdgeGap)
+  const candidate = Number.isFinite(preferredLeft) ? Math.floor(preferredLeft) : minLeft
+  return Math.max(minLeft, Math.min(maxLeft, candidate))
+}
+
+export function computeAnchoredPopoverLayout(
+  anchor: AnchorRect,
+  viewport: ViewportSize,
+  options: AnchoredPopoverOptions,
+): AnchoredPopoverLayout {
+  const viewportWidth = finiteNonNegative(viewport.width)
+  const viewportHeight = finiteNonNegative(viewport.height)
+  const requestedEdgeGap = options.edgeGap ?? DEFAULT_POPOVER_EDGE_GAP
+  const horizontalEdgeGap = effectiveEdgeGap(viewportWidth, requestedEdgeGap)
+  const verticalEdgeGap = effectiveEdgeGap(viewportHeight, requestedEdgeGap)
+  const offsetY = finiteNonNegative(options.offsetY ?? 8)
+  const width = clampPopoverWidth(options.preferredWidth, viewportWidth, horizontalEdgeGap)
+  const preferredLeft = options.align === 'end' ? anchor.right - width : anchor.left
+  const left = clampPopoverLeft(preferredLeft, width, viewportWidth, horizontalEdgeGap)
+  const anchorTop = Number.isFinite(anchor.top) ? anchor.top : 0
+  const anchorBottom = Number.isFinite(anchor.bottom) ? anchor.bottom : anchorTop
+  const availableBelow = Math.max(0, viewportHeight - anchorBottom - offsetY - verticalEdgeGap)
+  const availableAbove = Math.max(0, anchorTop - offsetY - verticalEdgeGap)
+  const openBelow = availableBelow >= (options.minSpaceBelow ?? 160) || availableBelow > availableAbove
+  const availableHeight = openBelow ? availableBelow : availableAbove
+  const ratio = finiteNonNegative(options.maxHeightRatio ?? 1)
+  const ratioLimit = viewportHeight * ratio
+  const maxHeight = Math.min(finiteNonNegative(options.preferredHeight), ratioLimit, availableHeight)
+
+  return {
+    width,
+    maxHeight,
+    left,
+    openBelow,
+    style: {
+      position: 'fixed',
+      width: `${width}px`,
+      left: `${left}px`,
+      maxHeight: `${maxHeight}px`,
+      ...(openBelow
+        ? { top: `${Math.floor(anchorBottom + offsetY)}px`, bottom: 'auto' }
+        : { top: 'auto', bottom: `${Math.floor(viewportHeight - anchorTop + offsetY)}px` }),
+    },
+  }
+}

--- a/frontend/src/utils/viewportChangeObserver.ts
+++ b/frontend/src/utils/viewportChangeObserver.ts
@@ -1,0 +1,47 @@
+export interface ViewportChangeObserverOptions {
+  captureScroll?: boolean
+  immediate?: boolean
+}
+
+/**
+ * Observe layout and VisualViewport changes through one animation-frame-throttled callback.
+ * The returned cleanup function is idempotent and cancels any queued callback.
+ */
+export function observeViewportChanges(
+  callback: () => void,
+  options: ViewportChangeObserverOptions = {},
+): () => void {
+  if (typeof window === 'undefined') return () => undefined
+
+  const captureScroll = options.captureScroll ?? true
+  let active = true
+  let frame: number | null = null
+
+  const schedule = () => {
+    if (!active || frame !== null) return
+    frame = window.requestAnimationFrame(() => {
+      frame = null
+      if (active) callback()
+    })
+  }
+
+  window.addEventListener('resize', schedule, { passive: true })
+  window.addEventListener('scroll', schedule, { passive: true, capture: captureScroll })
+  window.visualViewport?.addEventListener('resize', schedule, { passive: true })
+  window.visualViewport?.addEventListener('scroll', schedule, { passive: true })
+
+  if (options.immediate) schedule()
+
+  return () => {
+    if (!active) return
+    active = false
+    window.removeEventListener('resize', schedule)
+    window.removeEventListener('scroll', schedule, { capture: captureScroll })
+    window.visualViewport?.removeEventListener('resize', schedule)
+    window.visualViewport?.removeEventListener('scroll', schedule)
+    if (frame !== null) {
+      window.cancelAnimationFrame(frame)
+      frame = null
+    }
+  }
+}

--- a/frontend/src/utils/zoom.ts
+++ b/frontend/src/utils/zoom.ts
@@ -62,14 +62,15 @@ export function rectToCssPx(
 }
 
 /**
- * Viewport size in CSS pixels (i.e., the coordinate system used by CSS
- * lengths under the root zoom). `window.innerWidth/innerHeight` are visual
- * pixels, so divide by zoom.
+ * Visible viewport size in CSS pixels (i.e., the coordinate system used by CSS
+ * lengths under the root zoom). Prefer VisualViewport so Android's on-screen
+ * keyboard and browser chrome are excluded from the available popup area.
  */
 export function cssViewportSize(zoom: number = getRootZoom()): { width: number; height: number } {
   if (typeof window === 'undefined') return { width: 0, height: 0 }
+  const viewport = window.visualViewport
   return {
-    width: window.innerWidth / zoom,
-    height: window.innerHeight / zoom,
+    width: (viewport?.width ?? window.innerWidth) / zoom,
+    height: (viewport?.height ?? window.innerHeight) / zoom,
   }
 }

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -1639,6 +1639,8 @@ import {
   markContextualGuideDone,
 } from '@/config/contextualGuides';
 import { useI18n } from 'vue-i18n';
+import { useResponsiveViewport } from '@/composables/useResponsiveViewport';
+import { setBodyScrollLock, releaseBodyScrollLock } from '@/utils/bodyScrollLock';
 import { MessagePlugin } from 'tdesign-vue-next';
 import {
   createAgent,
@@ -1690,6 +1692,8 @@ const chatResources = useChatResourcesStore();
 const editorResources = useEditorResourcesStore();
 
 const { t, locale: i18nLocale } = useI18n();
+const { isCompact } = useResponsiveViewport();
+const AGENT_EDITOR_SCROLL_LOCK = 'agent-editor';
 
 const props = defineProps<{
   visible: boolean;
@@ -1817,6 +1821,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener(AGENT_EDITOR_FOCUS_SECTION_EVENT, onAgentEditorFocusSection)
+  releaseBodyScrollLock(AGENT_EDITOR_SCROLL_LOCK)
 })
 
 const saving = ref(false);
@@ -2893,6 +2898,10 @@ const needsRerankModel = computed(() => {
 });
 
 // 监听可见性变化，重置表单
+watch([() => props.visible, isCompact], ([visible, compact]) => {
+  setBodyScrollLock(AGENT_EDITOR_SCROLL_LOCK, visible && compact);
+}, { immediate: true });
+
 watch(() => props.visible, async (val) => {
   if (val) {
     savedAgent.value = null;
@@ -4283,6 +4292,7 @@ const handleSave = async () => {
 </script>
 
 <style scoped lang="less">
+@import '@/assets/responsive.less';
 // 复用创建知识库的样式
 .settings-overlay {
   position: fixed;
@@ -5900,6 +5910,196 @@ const handleSave = async () => {
   background: rgba(0, 180, 42, 0.1);
 }
 
+
+
+.compact({
+  .settings-overlay {
+    align-items: stretch;
+    justify-content: stretch;
+    padding: 0;
+    background: var(--td-bg-color-container);
+    backdrop-filter: none;
+  }
+
+  .settings-modal {
+    width: 100%;
+    max-width: none;
+    height: var(--app-viewport-height, 100dvh);
+    max-height: var(--app-viewport-height, 100dvh);
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .close-btn {
+    top: max(8px, env(safe-area-inset-top));
+    right: max(8px, env(safe-area-inset-right));
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+  }
+
+  .settings-container {
+    min-height: 0;
+    flex-direction: column;
+  }
+
+  .settings-sidebar {
+    width: 100%;
+    max-width: none;
+    flex: 0 0 auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--td-component-stroke);
+    overflow: hidden;
+  }
+
+  .sidebar-header {
+    min-height: 52px;
+    padding: max(12px, env(safe-area-inset-top)) 56px 8px max(14px, env(safe-area-inset-left));
+    box-sizing: border-box;
+  }
+
+  .sidebar-title {
+    overflow: hidden;
+    font-size: 16px;
+    line-height: 32px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .settings-nav {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 0;
+    padding: 6px max(10px, env(safe-area-inset-right)) 8px max(10px, env(safe-area-inset-left));
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .nav-group-title {
+    display: none;
+  }
+
+  .nav-item {
+    min-height: 40px;
+    margin: 0;
+    padding: 8px 12px;
+    flex: 0 0 auto;
+    white-space: nowrap;
+    box-sizing: border-box;
+    background: var(--td-bg-color-container);
+    border: 1px solid var(--td-component-stroke);
+    border-radius: 10px;
+
+    &.active {
+      border-color: color-mix(in srgb, var(--td-brand-color) 35%, transparent);
+    }
+  }
+
+  .settings-content {
+    min-width: 0;
+    min-height: 0;
+    width: 100%;
+  }
+
+  .content-wrapper,
+  .content-wrapper--prompts {
+    padding: 18px max(14px, env(safe-area-inset-right)) 24px max(14px, env(safe-area-inset-left));
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .content-wrapper--prompts {
+    padding-bottom: 16px;
+  }
+
+  .section-header {
+    margin-bottom: 14px;
+
+    h2 {
+      font-size: 18px;
+      line-height: 1.35;
+    }
+  }
+
+  .setting-row {
+    gap: 14px;
+  }
+
+  .setting-info {
+    flex-basis: 46%;
+    max-width: 46%;
+  }
+
+  .setting-control {
+    flex-basis: 54%;
+    max-width: 54%;
+  }
+
+  .settings-footer {
+    padding: 8px max(12px, env(safe-area-inset-right)) max(8px, env(safe-area-inset-bottom)) max(12px, env(safe-area-inset-left));
+    gap: 8px;
+
+    :deep(.t-button) {
+      flex: 1 1 0;
+      min-width: 0;
+      height: 40px;
+    }
+  }
+
+  .modal-enter-from .settings-modal,
+  .modal-leave-to .settings-modal {
+    transform: translateY(12px);
+  }
+});
+
+.phone({
+  .setting-row {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .setting-info,
+  .setting-control {
+    width: 100%;
+    max-width: none;
+    flex-basis: auto;
+  }
+
+  .setting-control {
+    align-items: stretch;
+
+    :deep(.t-input),
+    :deep(.t-select),
+    :deep(.t-select-input),
+    :deep(.t-input-number),
+    :deep(.t-textarea) {
+      width: 100% !important;
+      max-width: 100%;
+    }
+  }
+
+  .prompts-outline {
+    gap: 6px;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    &__pill {
+      flex: 0 0 auto;
+    }
+  }
+});
 </style>
 
 <!-- Non-scoped styles: TDesign teleports the popup outside this component, so

--- a/frontend/src/views/agent/AgentList.vue
+++ b/frontend/src/views/agent/AgentList.vue
@@ -1583,6 +1583,7 @@ defineExpose({
 </script>
 
 <style scoped lang="less">
+@import '@/assets/responsive.less';
 .agent-list-container {
   margin: 0;
   height: 100%;
@@ -2449,10 +2450,6 @@ defineExpose({
   }
 }
 
-:deep(.t-dialog__position.t-dialog--top) {
-  padding-top: 40vh !important;
-}
-
 .circle-wrap {
   .dialog-header {
     display: flex;
@@ -2514,6 +2511,55 @@ defineExpose({
     }
   }
 }
+
+
+.compact({
+  .agent-list-content {
+    padding: 12px 0 0 12px;
+  }
+
+  .header {
+    gap: 10px;
+    margin-bottom: 12px;
+    padding-right: 12px;
+
+    h2 {
+      font-size: 20px;
+      line-height: 28px;
+    }
+  }
+
+  .header-subtitle {
+    font-size: 13px;
+    line-height: 18px;
+  }
+
+  .header-action-btn {
+    width: 40px !important;
+    min-width: 40px !important;
+    height: 40px !important;
+    border-radius: 10px !important;
+  }
+
+  .agent-list-main {
+    padding-right: 12px;
+    padding-bottom: max(16px, env(safe-area-inset-bottom));
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .agent-card-wrap {
+    gap: 10px;
+  }
+
+  .agent-card {
+    min-width: 0;
+  }
+
+  .empty-state {
+    padding: 36px 16px;
+  }
+});
 </style>
 
 <style lang="less">

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -1697,17 +1697,28 @@ onMounted(async () => {
 }
 
 @media (max-width: 480px) {
+  .login-layout {
+    min-height: var(--app-viewport-height, 100dvh);
+    overflow-x: hidden;
+  }
+
   .animated-bg {
     display: none;
   }
 
   .showcase-section {
-    padding: 32px 20px;
+    min-height: auto;
+    align-items: stretch;
+    padding: calc(78px + env(safe-area-inset-top)) 20px 28px;
+  }
+
+  .showcase-content {
+    margin-bottom: 0;
   }
 
   .header-logo {
-    top: 18px;
-    left: 20px;
+    top: calc(14px + env(safe-area-inset-top));
+    left: max(16px, env(safe-area-inset-left));
 
     .logo-image {
       width: 70px;
@@ -1724,17 +1735,30 @@ onMounted(async () => {
   }
 
   .form-section {
-    padding: 20px;
+    padding: 20px max(16px, env(safe-area-inset-right))
+      calc(20px + env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-left));
   }
 
   .header-links {
-    top: 14px;
-    right: 14px;
+    top: calc(10px + env(safe-area-inset-top));
+    right: max(12px, env(safe-area-inset-right));
     gap: 6px;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
 
-    .header-link {
-      padding: 7px 10px;
+    > .header-link {
+      width: 40px;
+      height: 40px;
+      padding: 0;
+      justify-content: center;
+
+      .link-text {
+        display: none;
+      }
+    }
+
+    .language-switch .header-link {
+      min-height: 40px;
+      padding: 0 10px;
       font-size: 11px;
     }
   }
@@ -1745,6 +1769,54 @@ onMounted(async () => {
 
   .form-header {
     margin-bottom: 24px;
+  }
+}
+
+@media (max-width: 900px) and (max-height: 520px) {
+  .login-layout {
+    min-height: var(--app-viewport-height, 100dvh);
+    flex-direction: column;
+    overflow-x: hidden;
+  }
+
+  .showcase-section {
+    display: none;
+  }
+
+  .header-logo {
+    top: calc(12px + env(safe-area-inset-top));
+    left: max(16px, env(safe-area-inset-left));
+
+    .logo-image {
+      width: 76px;
+    }
+  }
+
+  .header-links {
+    top: calc(8px + env(safe-area-inset-top));
+    right: max(12px, env(safe-area-inset-right));
+    gap: 6px;
+
+    .header-link {
+      min-height: 40px;
+      padding: 0 10px;
+      font-size: 11px;
+    }
+  }
+
+  .form-section {
+    flex: 0 0 auto;
+    min-height: var(--app-viewport-height, 100dvh);
+    align-items: flex-start;
+    padding: calc(64px + env(safe-area-inset-top))
+      max(16px, env(safe-area-inset-right))
+      calc(16px + env(safe-area-inset-bottom))
+      max(16px, env(safe-area-inset-left));
+  }
+
+  .form-panel {
+    max-width: 520px;
+    margin-bottom: 0;
   }
 }
 

--- a/frontend/src/views/chat/components/botmsg.vue
+++ b/frontend/src/views/chat/components/botmsg.vue
@@ -327,6 +327,7 @@ onBeforeUnmount(() => {
 });
 </script>
 <style lang="less" scoped>
+@import '@/assets/responsive.less';
 @import '../../../components/css/chat-markdown.less';
 @import '../../../components/css/chat-message-shared.less';
 @import '../../../components/css/chat-citations.less';
@@ -443,4 +444,29 @@ onBeforeUnmount(() => {
     background: conic-gradient(from 90deg at 50% 50%, #fff 0deg, #676767 360deg) !important;
 
 }
+
+.compact({
+  .bot_msg {
+    width: 100%;
+    max-width: 100%;
+    font-size: 15px;
+  }
+
+  .content-wrapper {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .ai-markdown-img {
+    max-width: 100%;
+    max-height: min(320px, calc(var(--app-viewport-height, 100dvh) * 0.48));
+    margin-inline: 0;
+  }
+
+  .img_loading {
+    width: min(230px, 76vw);
+    height: min(230px, 76vw);
+    margin-left: 0;
+  }
+});
 </style>

--- a/frontend/src/views/chat/components/usermsg.vue
+++ b/frontend/src/views/chat/components/usermsg.vue
@@ -184,6 +184,7 @@ const closePreImg = () => {
 };
 </script>
 <style scoped lang="less">
+@import '@/assets/responsive.less';
 @import '../../../components/css/chat-resource-chips.less';
 
 .user_msg_container {
@@ -354,5 +355,35 @@ html[theme-mode="dark"] {
         background: var(--td-bg-color-secondarycontainer);
         color: var(--td-text-color-primary);
     }
+}
+
+.compact({
+  .user_msg {
+    max-width: min(90%, 820px);
+    font-size: 15px;
+    line-height: 1.55;
+    padding: 8px 10px;
+  }
+
+  .user_attachments {
+    width: 100%;
+  }
+
+  .user_attachment_card {
+    width: min(280px, 92%);
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .user_image_thumb {
+    width: clamp(84px, 28vw, 112px);
+    height: clamp(84px, 28vw, 112px);
+  }
+});
+
+@media screen and (max-width: 360px) {
+  .user_msg {
+    max-width: 94%;
+  }
 }
 </style>

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="chat" :class="{
         'is-embedded': embeddedMode,
-        'is-sidebar-collapsed': uiStore.sidebarCollapsed,
+        'is-sidebar-collapsed': uiStore.effectiveSidebarCollapsed,
         'has-references-panel': referencesDrawerVisible,
     }">
         <ChatHeader v-if="!embeddedMode" :session="currentSession" :has-references-panel="referencesDrawerVisible" />
@@ -1016,6 +1016,7 @@ onBeforeRouteUpdate((to, from, next) => {
 })
 </script>
 <style lang="less" scoped>
+@import '@/assets/responsive.less';
 .chat {
     font-size: 20px;
     // 右侧不留 padding，滚动条贴到内容区最右缘
@@ -1031,11 +1032,12 @@ onBeforeRouteUpdate((to, from, next) => {
     display: flex;
     flex-direction: column;
     align-items: center;
-    max-width: calc(100vw - 260px);
-    min-width: 400px;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
 
     &.is-sidebar-collapsed {
-        max-width: calc(100vw - 60px);
+        max-width: 100%;
     }
 
     &.is-embedded {
@@ -1110,7 +1112,7 @@ onBeforeRouteUpdate((to, from, next) => {
 }
 
 // 深色模式下 theme.css 对 * 做了 webkit 滚动条着色，这里恢复为系统默认
-:global(:root[theme-mode="dark"]) .chat_scroll_box {
+:global(:root[theme-mode="dark"] .chat_scroll_box) {
     &::-webkit-scrollbar-thumb {
         background-color: initial !important;
     }
@@ -1204,6 +1206,7 @@ onBeforeRouteUpdate((to, from, next) => {
     margin: 0 auto;
     width: 100%;
     max-width: 960px;
+    min-width: 0;
     box-sizing: border-box;
     position: relative;
 
@@ -1223,9 +1226,11 @@ onBeforeRouteUpdate((to, from, next) => {
     flex-direction: column;
     gap: 16px;
     max-width: 960px;
+    min-width: 0;
     flex: 1;
     margin: 0 auto;
     width: 100%;
+    box-sizing: border-box;
 
     /*
       给每条消息加 layout/style containment：
@@ -1298,4 +1303,66 @@ onBeforeRouteUpdate((to, from, next) => {
 .sq-fade-leave-to {
     opacity: 0;
 }
+
+.compact({
+    .chat:not(.is-embedded) {
+        padding: 0 0 max(8px, env(safe-area-inset-bottom));
+        overflow: hidden;
+    }
+
+    .chat:not(.is-embedded) .chat_scroll_box {
+        padding: 8px max(8px, env(safe-area-inset-right)) 0 max(8px, env(safe-area-inset-left));
+        scroll-padding-top: 8px;
+        scroll-padding-bottom: 16px;
+        overscroll-behavior-y: contain;
+        -webkit-overflow-scrolling: touch;
+        touch-action: pan-y;
+    }
+
+    .msg_list,
+    .msg-skeleton-list {
+        gap: 12px;
+        max-width: 100%;
+    }
+
+    .input-container:not(.is-embedded) {
+        min-height: 104px;
+        max-width: 100%;
+    }
+
+    .scroll-to-bottom-btn {
+        bottom: calc(112px + env(safe-area-inset-bottom));
+        width: 40px;
+        height: 40px;
+    }
+});
+
+.phone({
+    .chat:not(.is-embedded) .chat_scroll_box {
+        padding-inline: max(6px, env(safe-area-inset-left));
+    }
+});
+
+.phone-landscape({
+    .chat:not(.is-embedded) {
+        padding-bottom: 4px;
+    }
+
+    .chat:not(.is-embedded) .chat_scroll_box {
+        padding-top: 4px;
+    }
+
+    .input-container:not(.is-embedded) {
+        min-height: 92px;
+    }
+});
+
+:global(html.app-keyboard-open .chat:not(.is-embedded)) {
+    padding-bottom: 2px;
+}
+
+:global(html.app-keyboard-open .scroll-to-bottom-btn) {
+    bottom: 104px;
+}
+
 </style>

--- a/frontend/src/views/creatChat/creatChat.vue
+++ b/frontend/src/views/creatChat/creatChat.vue
@@ -55,7 +55,7 @@
         @update:visible="(val) => val ? null : uiStore.closeKBEditor()" @success="handleKBEditorSuccess" />
 </template>
 <script setup lang="ts">
-import { ref, watch, onMounted, nextTick, computed } from 'vue';
+import { ref, watch, onMounted, onUnmounted, nextTick, computed } from 'vue';
 import ContextualGuide from '@/components/ContextualGuide.vue';
 import InputField from '@/components/Input-field.vue';
 import { createSessions } from "@/api/chat/index";
@@ -179,6 +179,14 @@ watch(
 
 onMounted(() => { fetchSuggestedQuestions(); });
 
+onUnmounted(() => {
+    suggestedQuestionsFetchId += 1;
+    if (debounceTimer) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+    }
+});
+
 const inputFieldRef = ref();
 
 const handleSuggestedQuestionClick = (question: string) => {
@@ -243,12 +251,19 @@ const handleKBEditorSuccess = (kbId: string) => {
 
 </script>
 <style lang="less" scoped>
+@import '@/assets/responsive.less';
 .dialogue-wrap {
     flex: 1;
     display: flex;
     justify-content: center;
     align-items: center;
-    // position: relative;
+    min-width: 0;
+    min-height: 0;
+    padding: 32px clamp(16px, 4vw, 48px);
+    box-sizing: border-box;
+    overflow-y: auto;
+    overscroll-behavior-y: contain;
+    -webkit-overflow-scrolling: touch;
 }
 
 .dialogue-answers {
@@ -257,11 +272,14 @@ const handleKBEditorSuccess = (kbId: string) => {
     align-items: center;
     width: 100%;
     max-width: 960px;
+    min-width: 0;
     gap: 24px;
+    box-sizing: border-box;
 
     :deep(.answers-input) {
         position: static;
-        transform: translateX(0);
+        width: 100%;
+        transform: none;
     }
 }
 
@@ -308,6 +326,8 @@ const handleKBEditorSuccess = (kbId: string) => {
     max-width: 960px;
     margin: 0;
     padding: 0 16px;
+    width: 100%;
+    box-sizing: border-box;
     transition: height 0.35s @suggested-ease;
 }
 
@@ -363,44 +383,67 @@ const handleKBEditorSuccess = (kbId: string) => {
     }
 }
 
-@media (max-width: 1250px) and (min-width: 1045px) {
-    .answers-input {
-        transform: translateX(-329px);
+.compact({
+    .dialogue-wrap {
+        justify-content: flex-start;
+        padding: 20px 8px max(16px, env(safe-area-inset-bottom));
     }
 
-    :deep(.t-textarea__inner) {
-        width: 654px !important;
+    .dialogue-answers {
+        gap: 16px;
     }
+
+    .dialogue-title {
+        font-size: 22px;
+        line-height: 1.3;
+        text-align: center;
+    }
+
+    .suggested-questions-container {
+        padding: 0;
+    }
+});
+
+.phone({
+    .dialogue-wrap {
+        padding-inline: 6px;
+    }
+
+    .dialogue-title {
+        font-size: 20px;
+    }
+});
+
+.phone-landscape({
+    .dialogue-wrap {
+        padding-block: 8px;
+    }
+
+    .dialogue-title,
+    .suggested-questions-container {
+        display: none;
+    }
+
+    .dialogue-answers {
+        gap: 8px;
+        justify-content: center;
+        min-height: 100%;
+    }
+});
+
+:global(html.app-keyboard-open .dialogue-wrap) {
+    padding-top: 6px;
+    padding-bottom: max(4px, env(safe-area-inset-bottom));
 }
 
-@media (max-width: 1045px) {
-    .answers-input {
-        transform: translateX(-250px);
-    }
-
-    :deep(.t-textarea__inner) {
-        width: 500px !important;
-    }
+:global(html.app-keyboard-open .dialogue-title),
+:global(html.app-keyboard-open .suggested-questions-container) {
+    display: none;
 }
 
-@media (max-width: 750px) {
-    .answers-input {
-        transform: translateX(-250px);
-    }
-
-    :deep(.t-textarea__inner) {
-        width: 340px !important;
-    }
-}
-
-@media (max-width: 600px) {
-    .answers-input {
-        transform: translateX(-250px);
-    }
-
-    :deep(.t-textarea__inner) {
-        width: 300px !important;
-    }
+:global(html.app-keyboard-open .dialogue-answers) {
+    justify-content: flex-end;
+    gap: 6px;
 }
 </style>
 <style lang="less">

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -3354,45 +3354,6 @@ async function createNewSession(value: string): Promise<void> {
   margin: 0 16px 0 4px;
 }
 
-@media (max-width: 1250px) and (min-width: 1045px) {
-  .answers-input {
-    transform: translateX(-329px);
-  }
-
-  :deep(.t-textarea__inner) {
-    width: 654px !important;
-  }
-}
-
-@media (max-width: 1045px) {
-  .answers-input {
-    transform: translateX(-250px);
-  }
-
-  :deep(.t-textarea__inner) {
-    width: 500px !important;
-  }
-}
-
-@media (max-width: 750px) {
-  .answers-input {
-    transform: translateX(-182px);
-  }
-
-  :deep(.t-textarea__inner) {
-    width: 340px !important;
-  }
-}
-
-@media (max-width: 600px) {
-  .answers-input {
-    transform: translateX(-164px);
-  }
-
-  :deep(.t-textarea__inner) {
-    width: 300px !important;
-  }
-}
 
 @keyframes contentFadeIn {
   from {

--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
@@ -474,12 +474,16 @@ import KBShareSettings from './settings/KBShareSettings.vue'
 import DataSourceSettings from './settings/DataSourceSettings.vue'
 import KnowledgeBaseActivitySettings from './settings/KnowledgeBaseActivitySettings.vue'
 import { useI18n } from 'vue-i18n'
+import { useResponsiveViewport } from '@/composables/useResponsiveViewport'
+import { setBodyScrollLock, releaseBodyScrollLock } from '@/utils/bodyScrollLock'
 
 const uiStore = useUIStore()
 const authStore = useAuthStore()
 const chatResources = useChatResourcesStore()
 const editorResources = useEditorResourcesStore()
 const { t } = useI18n()
+const { isCompact } = useResponsiveViewport()
+const KB_EDITOR_SCROLL_LOCK = 'knowledge-base-editor'
 
 // Props
 const props = defineProps<{
@@ -534,6 +538,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener(KB_EDITOR_FOCUS_SECTION_EVENT, onKbEditorFocusSection)
+  releaseBodyScrollLock(KB_EDITOR_SCROLL_LOCK)
 })
 const saving = ref(false)
 const loading = ref(false)
@@ -1508,6 +1513,10 @@ const handleClose = () => {
 }
 
 // 监听弹窗打开/关闭
+watch([() => props.visible, isCompact], ([visible, compact]) => {
+  setBodyScrollLock(KB_EDITOR_SCROLL_LOCK, visible && compact)
+}, { immediate: true })
+
 watch(() => props.visible, async (newVal) => {
   if (newVal) {
     // 打开弹窗时，先重置状态
@@ -1552,6 +1561,7 @@ watch(
 </script>
 
 <style scoped lang="less">
+@import '@/assets/responsive.less';
 // 复用创建知识库的样式
 .settings-overlay {
   position: fixed;
@@ -2028,4 +2038,136 @@ watch(
     font-weight: 500;
   }
 }
+
+
+.compact({
+  .settings-overlay {
+    align-items: stretch;
+    justify-content: stretch;
+    padding: 0;
+    background: var(--td-bg-color-container);
+    backdrop-filter: none;
+  }
+
+  .settings-modal {
+    width: 100%;
+    max-width: none;
+    height: var(--app-viewport-height, 100dvh);
+    max-height: var(--app-viewport-height, 100dvh);
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .close-btn {
+    top: max(8px, env(safe-area-inset-top));
+    right: max(8px, env(safe-area-inset-right));
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+  }
+
+  .settings-container {
+    min-height: 0;
+    flex-direction: column;
+  }
+
+  .settings-sidebar {
+    width: 100%;
+    max-width: none;
+    flex: 0 0 auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--td-component-stroke);
+    overflow: hidden;
+  }
+
+  .sidebar-header {
+    min-height: 52px;
+    padding: max(12px, env(safe-area-inset-top)) 56px 8px max(14px, env(safe-area-inset-left));
+    box-sizing: border-box;
+  }
+
+  .sidebar-title {
+    overflow: hidden;
+    font-size: 16px;
+    line-height: 32px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .settings-nav {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 0;
+    padding: 6px max(10px, env(safe-area-inset-right)) 8px max(10px, env(safe-area-inset-left));
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .nav-group-title {
+    display: none;
+  }
+
+  .nav-item {
+    min-height: 40px;
+    margin: 0;
+    padding: 8px 12px;
+    flex: 0 0 auto;
+    white-space: nowrap;
+    box-sizing: border-box;
+    background: var(--td-bg-color-container);
+    border: 1px solid var(--td-component-stroke);
+    border-radius: 10px;
+
+    &.active {
+      border-color: color-mix(in srgb, var(--td-brand-color) 35%, transparent);
+    }
+  }
+
+  .settings-content {
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .content-wrapper {
+    padding: 18px max(14px, env(safe-area-inset-right)) 24px max(14px, env(safe-area-inset-left));
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .section {
+    margin-bottom: 20px;
+  }
+
+  .section-content .section-title,
+  .kb-multimodal-settings .section-header h2 {
+    font-size: 18px;
+  }
+
+  .indexing-checks {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-footer {
+    padding: 8px max(12px, env(safe-area-inset-right)) max(8px, env(safe-area-inset-bottom)) max(12px, env(safe-area-inset-left));
+    gap: 8px;
+
+    :deep(.t-button) {
+      flex: 1 1 0;
+      min-width: 0;
+      height: 40px;
+    }
+  }
+
+  .modal-enter-from .settings-modal,
+  .modal-leave-to .settings-modal {
+    transform: translateY(12px);
+  }
+});
 </style>

--- a/frontend/src/views/knowledge/KnowledgeBaseList.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseList.vue
@@ -1787,6 +1787,7 @@ const handleUploadFinishedEvent = (event: Event) => {
 </script>
 
 <style scoped lang="less">
+@import '@/assets/responsive.less';
 .kb-list-container {
   margin: 0;
   height: 100%;
@@ -2857,10 +2858,6 @@ const handleUploadFinishedEvent = (event: Event) => {
   }
 }
 
-:deep(.t-dialog__position.t-dialog--top) {
-  padding-top: 40vh !important;
-}
-
 .circle-wrap {
   .dialog-header {
     display: flex;
@@ -2922,6 +2919,55 @@ const handleUploadFinishedEvent = (event: Event) => {
     }
   }
 }
+
+
+.compact({
+  .kb-list-content {
+    padding: 12px 0 0 12px;
+  }
+
+  .header {
+    gap: 10px;
+    margin-bottom: 12px;
+    padding-right: 12px;
+
+    h2 {
+      font-size: 20px;
+      line-height: 28px;
+    }
+  }
+
+  .header-subtitle {
+    font-size: 13px;
+    line-height: 18px;
+  }
+
+  .header-action-btn {
+    width: 40px !important;
+    min-width: 40px !important;
+    height: 40px !important;
+    border-radius: 10px !important;
+  }
+
+  .kb-list-main {
+    padding-right: 12px;
+    padding-bottom: max(16px, env(safe-area-inset-bottom));
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .kb-card-wrap {
+    gap: 10px;
+  }
+
+  .kb-card {
+    min-width: 0;
+  }
+
+  .empty-state {
+    padding: 36px 16px;
+  }
+});
 </style>
 
 <style lang="less">

--- a/frontend/src/views/mobileChatLayout.test.mjs
+++ b/frontend/src/views/mobileChatLayout.test.mjs
@@ -1,0 +1,295 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const read = (relativePath) => readFileSync(new URL(relativePath, import.meta.url), 'utf8')
+
+const platform = read('./platform/index.vue')
+const chat = read('./chat/index.vue')
+const createChat = read('./creatChat/creatChat.vue')
+const app = read('../App.vue')
+const inputField = read('../components/Input-field.vue')
+const menu = read('../components/menu.vue')
+const header = read('../components/ChatHeader.vue')
+const login = read('./auth/Login.vue')
+const agentSelector = read('../components/AgentSelector.vue')
+const knowledgeBaseSelector = read('../components/KnowledgeBaseSelector.vue')
+const referencesDrawer = read('../components/ChatReferencesDrawer.vue')
+const attachmentDrawer = read('../components/ChatAttachmentPreviewDrawer.vue')
+const settingsPage = read('./settings/Settings.vue')
+const settingDrawer = read('../components/settings/SettingDrawer.vue')
+const commandPalette = read('../components/GlobalCommandPalette.vue')
+const knowledgeBaseList = read('./knowledge/KnowledgeBaseList.vue')
+const knowledgeBaseDetail = read('./knowledge/KnowledgeBase.vue')
+const knowledgeBaseEditor = read('./knowledge/KnowledgeBaseEditorModal.vue')
+const agentList = read('./agent/AgentList.vue')
+const agentEditor = read('./agent/AgentEditorModal.vue')
+const organizationList = read('./organization/OrganizationList.vue')
+const organizationEditor = read('./organization/OrganizationEditorModal.vue')
+const documentDrawer = read('../components/doc-content.vue')
+const contextualGuide = read('../components/ContextualGuide.vue')
+const spotlightGuide = read('../components/SpotlightGuide.vue')
+const newUserGuide = read('../components/NewUserGuide.vue')
+const attachmentUpload = read('../components/AttachmentUpload.vue')
+const focusTrap = read('../utils/focusTrap.ts')
+const uiStore = read('../stores/ui.ts')
+const responsiveViewport = read('../composables/useResponsiveViewport.ts')
+const responsiveViewportMetrics = read('../composables/responsiveViewportMetrics.ts')
+const responsiveLess = read('../assets/responsive.less')
+const popoverPosition = read('../utils/popoverPosition.ts')
+const viewportObserver = read('../utils/viewportChangeObserver.ts')
+const indexHtml = read('../../index.html')
+const embedHtml = read('../../embed.html')
+
+const sources = [
+  platform,
+  chat,
+  createChat,
+  app,
+  inputField,
+  menu,
+  header,
+  login,
+  agentSelector,
+  knowledgeBaseSelector,
+  referencesDrawer,
+  attachmentDrawer,
+  settingsPage,
+  settingDrawer,
+  commandPalette,
+  knowledgeBaseList,
+  knowledgeBaseDetail,
+  knowledgeBaseEditor,
+  agentList,
+  agentEditor,
+  organizationList,
+  organizationEditor,
+  documentDrawer,
+  contextualGuide,
+  spotlightGuide,
+  newUserGuide,
+  attachmentUpload,
+  focusTrap,
+  uiStore,
+  responsiveViewport,
+  responsiveViewportMetrics,
+  responsiveLess,
+  popoverPosition,
+  viewportObserver,
+]
+
+test('responsive breakpoint contract stays synchronized between TypeScript and Less', () => {
+  const tsBreakpoints = Object.fromEntries(
+    [...responsiveViewport.matchAll(/export const (PHONE|COMPACT|TABLET)_MAX_WIDTH = (\d+)/g)]
+      .map(([, name, value]) => [name.toLowerCase(), Number(value)]),
+  )
+  const lessBreakpoints = Object.fromEntries(
+    [...responsiveLess.matchAll(/@(phone|compact|tablet)-max:\s*(\d+)px/g)]
+      .map(([, name, value]) => [name, Number(value)]),
+  )
+
+  assert.deepEqual(tsBreakpoints, lessBreakpoints)
+  assert.match(responsiveLess, /\.phone-landscape\(@rules\)/)
+  assert.match(responsiveLess, /prefers-reduced-motion/)
+})
+
+test('responsive viewport observer is singleton, synchronous, and lifecycle-safe', () => {
+  assert.match(app, /useResponsiveViewport\(\)/)
+  assert.match(responsiveViewport, /let consumers = 0/)
+  assert.match(responsiveViewport, /if \(consumers === 1\) startListening\(\)/)
+  assert.match(responsiveViewport, /if \(consumers === 0\) stopListening\(\)/)
+  assert.match(responsiveViewport, /if \(typeof window !== 'undefined'\) measureResponsiveViewport\(\)/)
+  assert.match(responsiveViewport, /window\.visualViewport\?\.addEventListener\('resize'/)
+  assert.match(responsiveViewport, /focusMeasureTimers\.forEach/)
+  assert.match(responsiveViewport, /--app-keyboard-inset/)
+})
+
+test('pinch zoom keeps the application viewport stable without faking keyboard state', () => {
+  assert.match(responsiveViewport, /visualScale: viewport\?\.scale/)
+  assert.match(responsiveViewport, /app-pinch-zoomed/)
+  assert.match(responsiveViewport, /isKeyboardOpen\.value = !nextIsPinchZoomed/)
+  assert.match(responsiveViewportMetrics, /Math\.abs\(scale - 1\) > PINCH_ZOOM_EPSILON/)
+  assert.match(responsiveViewportMetrics, /if \(isPinchZoomed\)[\s\S]*?visualWidth: layoutWidth[\s\S]*?visualHeight: layoutHeight/)
+  assert.match(responsiveViewportMetrics, /visualOffsetTop: 0[\s\S]*?keyboardInset: 0/)
+})
+test('compact sidebar preserves desktop preference and behaves as a temporary dialog', () => {
+  assert.match(uiStore, /compactViewport:\s*matchesCompactLayout\(\)/)
+  assert.match(uiStore, /effectiveSidebarCollapsed:[\s\S]*?mobileSidebarOpen[\s\S]*?sidebarCollapsed/)
+  assert.match(platform, /class="mobile-sidebar-backdrop"/)
+  assert.match(platform, /:inert="uiStore\.compactViewport && uiStore\.mobileSidebarOpen"/)
+  assert.match(platform, /trapTabKey/)
+  assert.match(platform, /setBodyScrollLock/)
+  assert.match(platform, /watch\(\(\) => route\.fullPath[\s\S]*?closeMobileSidebar/)
+  assert.match(menu, /:role="uiStore\.compactViewport && uiStore\.mobileSidebarOpen \? 'dialog' : 'navigation'"/)
+  assert.match(menu, /data-sidebar-close/)
+  assert.match(menu, /aria-controls="platform-sidebar"/)
+  assert.match(menu, /\.aside_box--compact-viewport\.aside_box--collapsed[\s\S]*?width: 44px/)
+})
+
+test('mobile chat surfaces use semantic responsive mixins and avoid legacy fixed hacks', () => {
+  for (const source of [chat, createChat, inputField, header]) {
+    assert.match(source, /@import ['"]@\/assets\/responsive\.less['"]/)
+    assert.match(source, /\.compact\(\{/)
+  }
+  assert.match(chat, /\.phone-landscape\(\{/)
+  assert.match(createChat, /\.phone-landscape\(\{/)
+  assert.match(inputField, /\.phone-landscape\(\{/)
+  assert.doesNotMatch(platform, /min-width:\s*600px/)
+  assert.doesNotMatch(chat, /min-width:\s*400px/)
+  assert.doesNotMatch(createChat, /translateX\(-(?:329|250|182|164)px\)/)
+  assert.doesNotMatch(createChat, /width:\s*(?:654|500|340|300)px\s*!important/)
+})
+
+test('phone login header reserves space and respects safe areas', () => {
+  assert.match(login, /min-height:\s*var\(--app-viewport-height, 100dvh\)/)
+  assert.match(login, /padding:\s*calc\(78px \+ env\(safe-area-inset-top\)\)/)
+  assert.match(login, /overflow-x:\s*hidden/)
+  assert.match(login, /> \.header-link[\s\S]*?width:\s*40px[\s\S]*?height:\s*40px/)
+  assert.match(login, /@media \(max-width: 900px\) and \(max-height: 520px\)[\s\S]*?\.showcase-section\s*\{[\s\S]*?display:\s*none/)
+})
+
+test('critical input controls stay pinned and popovers share hardened viewport logic', () => {
+  assert.match(inputField, /<div class="control-right">[\s\S]*?class="model-display"[\s\S]*?class="control-btn send-btn"/)
+  assert.match(inputField, /\.control-left\s*\{[\s\S]*?overflow-x:\s*auto/)
+  assert.match(inputField, /computeAnchoredPopoverLayout/)
+  assert.match(agentSelector, /computeAnchoredPopoverLayout/)
+  assert.match(knowledgeBaseSelector, /computeAnchoredPopoverLayout/)
+  assert.match(inputField, /observeViewportChanges/)
+  assert.match(agentSelector, /observeViewportChanges/)
+  assert.match(knowledgeBaseSelector, /observeViewportChanges/)
+  assert.match(viewportObserver, /requestAnimationFrame/)
+  assert.match(viewportObserver, /cancelAnimationFrame/)
+  assert.match(popoverPosition, /finiteNonNegative/)
+})
+
+test('compact knowledge picker never borrows the chat textarea for filtering', () => {
+  assert.match(inputField, /const \{ isCompact \} = useResponsiveViewport\(\)/)
+  assert.match(inputField, /const releaseChatInputFocus = \(\) => \{[\s\S]*?textarea\.blur\(\)/)
+  assert.match(inputField, /if \(isCompact\.value\) \{[\s\S]*?showMention\.value = false[\s\S]*?showKbSelector\.value = nextVisible/)
+  assert.match(inputField, /if \(nextVisible\) releaseChatInputFocus\(\)/)
+  assert.match(knowledgeBaseSelector, /if \(!isCompact\.value\) searchInput\.value\?\.focus/)
+  assert.match(knowledgeBaseSelector, /if \(isCompact\.value\) searchInput\.value\?\.blur\(\)/)
+  assert.match(knowledgeBaseSelector, /const close = \(\) => \{[\s\S]*?searchInput\.value\?\.blur\(\)/)
+})
+test('drawers lock background scrolling and become compact full-screen surfaces', () => {
+  for (const drawer of [referencesDrawer, attachmentDrawer]) {
+    assert.match(drawer, /setBodyScrollLock/)
+    assert.match(drawer, /releaseBodyScrollLock/)
+  }
+  assert.match(referencesDrawer, /const width = layoutWidth\.value/)
+  assert.doesNotMatch(referencesDrawer, /return window\.innerWidth < /)
+  assert.match(referencesDrawer, /\.compact\(\{/)
+  assert.match(attachmentDrawer, /setBodyScrollLock\(ATTACHMENT_DRAWER_SCROLL_LOCK, open && compact\)/)
+  assert.match(attachmentDrawer, /v-if="visible && !isCompact"/)
+  assert.match(attachmentDrawer, /app-viewport-height|100dvh/)
+})
+
+
+test('mobile document detail is a full-screen, single-scroll reading surface', () => {
+  assert.match(documentDrawer, /const mainDrawerSize = computed\(\(\) => isCompact\.value \? '100%' :/)
+  assert.match(documentDrawer, /const timelineDrawerSize = computed\(\(\) => isCompact\.value \? '100%' :/)
+  assert.match(documentDrawer, /v-if="visible && !isCompact"/)
+  assert.match(documentDrawer, /v-if="timelineDrawerVisible && !isCompact"/)
+  assert.match(documentDrawer, /'doc-main-drawer--compact': isCompact/)
+  assert.match(documentDrawer, /'kp-secondary-drawer--compact': isCompact/)
+  assert.match(documentDrawer, /setBodyScrollLock\(DOC_DRAWER_SCROLL_LOCK, visible && compact\)/)
+  assert.match(documentDrawer, /\.t-drawer\.doc-main-drawer--compact[\s\S]*?width: 100% !important[\s\S]*?app-viewport-height[\s\S]*?overflow-x: hidden/)
+  assert.match(documentDrawer, /\.doc-content-section-head[\s\S]*?position: sticky/)
+  assert.match(documentDrawer, /\.view-mode-buttons[\s\S]*?width: 100%/)
+  assert.match(documentDrawer, /:deep\(img\)[\s\S]*?max-width: 100%/)
+  assert.match(documentDrawer, /:deep\(table\)[\s\S]*?overflow-x: auto/)
+})
+
+
+test('remaining primary routes use compact mobile surfaces instead of desktop geometry', () => {
+  assert.match(app, /Compact safety net for teleported TDesign surfaces/)
+  assert.match(app, /html\.app-compact-viewport \.t-dialog__ctx[\s\S]*?width: min\(100%, 560px\) !important/)
+  assert.match(app, /html\.app-compact-viewport \.t-drawer[\s\S]*?width: 100% !important/)
+
+  assert.match(settingsPage, /mobile-settings-header/)
+  assert.match(settingsPage, /settings-sidebar--mobile-open/)
+  assert.match(settingsPage, /setBodyScrollLock\(SETTINGS_SCROLL_LOCK, open && compact\)/)
+  assert.match(settingsPage, /height: var\(--app-viewport-height, 100dvh\)/)
+  assert.match(settingsPage, /width: min\(84vw, 320px\)/)
+
+  assert.match(settingDrawer, /isCompact\.value \? '100%'/)
+  assert.match(settingDrawer, /drawerVisible && resizable && !isCompact/)
+  assert.match(settingDrawer, /setting-drawer--compact/)
+  assert.match(settingDrawer, /setBodyScrollLock\(SETTING_DRAWER_SCROLL_LOCK, visible && compact\)/)
+
+  assert.match(commandPalette, /@import ['"]@\/assets\/responsive\.less['"]/)
+  assert.match(commandPalette, /calc\(var\(--app-viewport-height, 100dvh\) - 24px\)/)
+
+  for (const listPage of [knowledgeBaseList, agentList, organizationList]) {
+    assert.match(listPage, /@import ['"]@\/assets\/responsive\.less['"]/)
+    assert.match(listPage, /\.compact\(\{/)
+    assert.doesNotMatch(listPage, /padding-top:\s*40vh\s*!important/)
+  }
+
+  assert.doesNotMatch(knowledgeBaseDetail, /translateX\(-(?:329|250|182|164)px\)/)
+  assert.doesNotMatch(knowledgeBaseDetail, /width:\s*(?:654|500|340|300)px\s*!important/)
+
+  for (const editor of [knowledgeBaseEditor, organizationEditor, agentEditor]) {
+    assert.match(editor, /@import ['"]@\/assets\/responsive\.less['"]/)
+    assert.match(editor, /setBodyScrollLock/)
+    assert.match(editor, /height: var\(--app-viewport-height, 100dvh\)/)
+    assert.match(editor, /flex-direction: column/)
+    assert.match(editor, /overflow-x: auto/)
+  }
+
+  assert.match(menu, /\.menu_top,[\s\S]*?\.menu_bottom[\s\S]*?display: none/)
+  assert.match(menu, /\.sidebar-toggle-item[\s\S]*?width: 40px/)
+  assert.match(app, /--app-font-family: "TencentSans"/)
+  assert.match(agentEditor, /AGENT_EDITOR_SCROLL_LOCK/)
+  assert.match(agentEditor, /\.phone\(\{[\s\S]*?\.setting-row[\s\S]*?flex-direction: column/)
+})
+
+test('optional guides cannot crash or destabilize compact route rendering', () => {
+  assert.match(contextualGuide, /const \{ isCompact \} = useResponsiveViewport\(\)/)
+  assert.match(contextualGuide, /const canOpen = \(\) => \{[\s\S]*?!props\.when[\s\S]*?isCompact\.value[\s\S]*?!compactExiting[\s\S]*?\}/)
+  assert.match(contextualGuide, /\[\(\) => props\.when, isCompact\]/)
+  assert.match(newUserGuide, /if \(isCompact\.value\) return/)
+  assert.match(newUserGuide, /clearAutoOpenTimer/)
+  assert.match(spotlightGuide, /const safeT =/)
+  assert.match(spotlightGuide, /Failed to render guide translation/)
+  assert.match(spotlightGuide, /return key/)
+  assert.match(spotlightGuide, /rectToCssPx\(el\.getBoundingClientRect\(\), zoom\)/)
+  assert.match(spotlightGuide, /observeViewportChanges\(onViewportChange\)/)
+  assert.match(spotlightGuide, /setBodyScrollLock\(GUIDE_SCROLL_LOCK, val\)/)
+  assert.match(spotlightGuide, /const dismiss = \(\) => \{[\s\S]*?emit\('dismiss'\)[\s\S]*?close\(\)/)
+  assert.doesNotMatch(spotlightGuide, /const dismiss = \(\) => \{[\s\S]*?finish\(\)/)
+})
+
+test('mobile lifecycle cleanup prevents stale async and focus state', () => {
+  assert.match(createChat, /onUnmounted\(\(\) => \{[\s\S]*?suggestedQuestionsFetchId \+= 1[\s\S]*?clearTimeout\(debounceTimer\)/)
+  assert.match(attachmentUpload, /if \(disposed \|\| !attachments\.value\.some/)
+  assert.match(focusTrap, /element\.closest\('\[inert\], \[aria-hidden=/)
+  assert.match(focusTrap, /style\.visibility !== 'hidden'/)
+  assert.match(platform, /watch\(\(\) => uiStore\.compactViewport && uiStore\.mobileSidebarOpen,[\s\S]*?\{ immediate: true \}\)/)
+})
+
+test('standalone and embedded pages declare safe-area and keyboard-aware viewport behavior', () => {
+  for (const html of [indexHtml, embedHtml]) {
+    assert.match(html, /viewport-fit=cover/)
+    assert.match(html, /interactive-widget=resizes-content/)
+  }
+})
+
+test('scoped global selectors keep the full descendant selector inside :global()', () => {
+  const scopedSources = [agentSelector, inputField, chat, createChat]
+  for (const source of scopedSources) {
+    // Vue SFC's scoped CSS compiler drops descendants written after :global(...).
+    // That previously compiled :global(html.app-coarse-pointer) .panel into
+    // html.app-coarse-pointer { ... } and hid the entire application on phones.
+    assert.doesNotMatch(source, /:global\([^)]*\)\s+(?:[.#:]|[a-z])/i)
+  }
+
+  assert.match(app, /html\s*\{[\s\S]*?display:\s*block\s*!important/)
+  assert.match(agentSelector, /:global\(html\.app-coarse-pointer \.agent-detail-panel\)/)
+  assert.match(agentSelector, /:global\(html\.app-compact-viewport \.agent-selector-dropdown\)/)
+  assert.match(inputField, /:global\(html\.app-keyboard-open \.answers-input\)/)
+  assert.match(createChat, /:global\(html\.app-keyboard-open \.dialogue-title\)/)
+})
+test('mobile adaptation sources contain no replacement characters from encoding damage', () => {
+  for (const source of sources) assert.doesNotMatch(source, /\uFFFD/)
+})

--- a/frontend/src/views/organization/OrganizationEditorModal.vue
+++ b/frontend/src/views/organization/OrganizationEditorModal.vue
@@ -248,15 +248,19 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onUnmounted } from 'vue'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { useOrganizationStore } from '@/stores/organization'
 import { useI18n } from 'vue-i18n'
 import type { OrganizationPreview } from '@/api/organization'
 import SpaceAvatar from '@/components/SpaceAvatar.vue'
+import { useResponsiveViewport } from '@/composables/useResponsiveViewport'
+import { setBodyScrollLock, releaseBodyScrollLock } from '@/utils/bodyScrollLock'
 
 const { t } = useI18n()
 const orgStore = useOrganizationStore()
+const { isCompact } = useResponsiveViewport()
+const ORG_EDITOR_SCROLL_LOCK = 'organization-editor'
 
 // Props
 const props = defineProps<{
@@ -401,6 +405,14 @@ const confirmJoin = async () => {
 }
 
 // 监听
+watch([() => props.visible, isCompact], ([visible, compact]) => {
+  setBodyScrollLock(ORG_EDITOR_SCROLL_LOCK, visible && compact)
+}, { immediate: true })
+
+onUnmounted(() => {
+  releaseBodyScrollLock(ORG_EDITOR_SCROLL_LOCK)
+})
+
 watch(() => props.visible, (newVal) => {
   if (newVal) {
     resetForm()
@@ -413,6 +425,7 @@ watch(() => props.mode, () => {
 </script>
 
 <style scoped lang="less">
+@import '@/assets/responsive.less';
 .settings-overlay {
   position: fixed;
   top: 0;
@@ -911,4 +924,122 @@ watch(() => props.mode, () => {
     color: var(--td-brand-color);
   }
 }
+
+
+.compact({
+  .settings-overlay {
+    align-items: stretch;
+    justify-content: stretch;
+    padding: 0;
+    background: var(--td-bg-color-container);
+    backdrop-filter: none;
+  }
+
+  .settings-modal,
+  .settings-modal.join-mode {
+    width: 100%;
+    max-width: none;
+    height: var(--app-viewport-height, 100dvh);
+    max-height: var(--app-viewport-height, 100dvh);
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .close-btn {
+    top: max(8px, env(safe-area-inset-top));
+    right: max(8px, env(safe-area-inset-right));
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+  }
+
+  .settings-container {
+    min-height: 0;
+    flex-direction: column;
+  }
+
+  .settings-sidebar {
+    width: 100%;
+    max-width: none;
+    flex: 0 0 auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--td-component-stroke);
+  }
+
+  .sidebar-header {
+    min-height: 52px;
+    padding: max(12px, env(safe-area-inset-top)) 56px 8px max(14px, env(safe-area-inset-left));
+    box-sizing: border-box;
+  }
+
+  .sidebar-title {
+    overflow: hidden;
+    font-size: 16px;
+    line-height: 32px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .settings-nav {
+    display: flex;
+    gap: 6px;
+    padding: 6px max(10px, env(safe-area-inset-right)) 8px max(10px, env(safe-area-inset-left));
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .nav-item {
+    min-height: 40px;
+    margin: 0;
+    padding: 8px 12px;
+    flex: 0 0 auto;
+    white-space: nowrap;
+    box-sizing: border-box;
+    background: var(--td-bg-color-container);
+    border: 1px solid var(--td-component-stroke);
+    border-radius: 10px;
+  }
+
+  .settings-content {
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .content-wrapper {
+    padding: 18px max(14px, env(safe-area-inset-right)) 24px max(14px, env(safe-area-inset-left));
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .section,
+  .form-item {
+    margin-bottom: 20px;
+  }
+
+  .permissions-info {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-footer {
+    padding: 8px max(12px, env(safe-area-inset-right)) max(8px, env(safe-area-inset-bottom)) max(12px, env(safe-area-inset-left));
+    gap: 8px;
+
+    :deep(.t-button) {
+      flex: 1 1 0;
+      min-width: 0;
+      height: 40px;
+    }
+  }
+
+  .modal-enter-from .settings-modal,
+  .modal-leave-to .settings-modal {
+    transform: translateY(12px);
+  }
+});
 </style>

--- a/frontend/src/views/organization/OrganizationList.vue
+++ b/frontend/src/views/organization/OrganizationList.vue
@@ -1144,6 +1144,7 @@ onUnmounted(() => {
 </script>
 
 <style scoped lang="less">
+@import '@/assets/responsive.less';
 .org-list-container {
   margin: 0 16px 0 0;
   height: 100%;
@@ -1885,10 +1886,6 @@ onUnmounted(() => {
   }
 }
 
-:deep(.t-dialog__position.t-dialog--top) {
-  padding-top: 40vh !important;
-}
-
 .circle-wrap {
   .dialog-header {
     display: flex;
@@ -1950,6 +1947,100 @@ onUnmounted(() => {
     }
   }
 }
+
+
+.compact({
+  .org-list-content {
+    padding: 12px 0 0 12px;
+  }
+
+  .header {
+    align-items: flex-start;
+    gap: 10px;
+    margin-bottom: 12px;
+    padding-right: 12px;
+    flex-wrap: wrap;
+
+    h2 {
+      font-size: 20px;
+      line-height: 28px;
+    }
+  }
+
+  .header-subtitle {
+    font-size: 13px;
+    line-height: 18px;
+  }
+
+  .header-actions {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+
+    :deep(.t-button) {
+      width: 100%;
+      min-width: 0;
+      height: 40px;
+    }
+  }
+
+  .header-action-btn {
+    width: 40px !important;
+    min-width: 40px !important;
+    height: 40px !important;
+    border-radius: 10px !important;
+  }
+
+  .org-list-main {
+    padding-right: 12px;
+    padding-bottom: max(16px, env(safe-area-inset-bottom));
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .org-tabs {
+    gap: 22px;
+    margin-bottom: 16px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    .tab-item {
+      min-height: 44px;
+      padding: 12px 0;
+      white-space: nowrap;
+      box-sizing: border-box;
+    }
+  }
+
+  .org-card-wrap {
+    gap: 10px;
+  }
+
+  .org-card {
+    min-width: 0;
+  }
+
+  .empty-state {
+    padding: 36px 16px;
+
+    .empty-state-actions {
+      width: 100%;
+      flex-direction: column;
+
+      :deep(.t-button) {
+        width: 100%;
+        height: 40px;
+      }
+    }
+  }
+});
 </style>
 
 <style lang="less">

--- a/frontend/src/views/platform/index.vue
+++ b/frontend/src/views/platform/index.vue
@@ -1,7 +1,15 @@
 <template>
-    <div class="main" ref="dropzone">
+    <div class="main" ref="dropzone" :class="{
+        'is-compact-viewport': isCompact,
+        'is-keyboard-open': isKeyboardOpen,
+    }">
         <Menu></Menu>
-        <div v-if="isRouterAlive" class="platform-route-outlet">
+        <button v-if="uiStore.compactViewport && uiStore.mobileSidebarOpen" type="button"
+            class="mobile-sidebar-backdrop" :aria-label="t('menu.collapseSidebar')"
+            @click="closeMobileSidebar(true)" />
+        <div v-if="isRouterAlive" class="platform-route-outlet"
+            :inert="uiStore.compactViewport && uiStore.mobileSidebarOpen"
+            :aria-hidden="uiStore.compactViewport && uiStore.mobileSidebarOpen ? 'true' : undefined">
             <RouterView />
         </div>
         <div class="upload-mask" v-show="ismask">
@@ -29,13 +37,19 @@ import GlobalInvitationBell from '@/components/GlobalInvitationBell.vue'
 import NewUserGuide from '@/components/NewUserGuide.vue'
 import { useCommandPaletteStore } from '@/stores/commandPalette'
 import { useChatResourcesStore } from '@/stores/chatResources'
+import { useUIStore } from '@/stores/ui'
 import { getKnowledgeBaseById } from '@/api/knowledge-base/index'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
+import { useResponsiveViewport } from '@/composables/useResponsiveViewport'
+import { setBodyScrollLock, releaseBodyScrollLock } from '@/utils/bodyScrollLock'
+import { focusFirstElement, trapTabKey } from '@/utils/focusTrap'
 
 const route = useRoute();
 const router = useRouter();
 const commandPaletteStore = useCommandPaletteStore();
+const uiStore = useUIStore();
+const { isCompact, isKeyboardOpen } = useResponsiveViewport();
 let ismask = ref(false)
 const { t } = useI18n();
 
@@ -199,12 +213,39 @@ const handleGlobalDrop = async (event: DragEvent) => {
     }));
 }
 
-// 组件挂载时添加全局事件监听器
+// 移动端侧栏交互由共享 viewport / scroll-lock / focus-trap 基础设施驱动。
+const MOBILE_SIDEBAR_LOCK = 'platform-mobile-sidebar'
+const getSidebarElement = () => document.getElementById('platform-sidebar')
+
+const focusSidebarToggle = () => {
+    nextTick(() => {
+        document.querySelector<HTMLElement>('[data-sidebar-open]')?.focus({ preventScroll: true });
+    });
+};
+
+const closeMobileSidebar = (restoreFocus = false) => {
+    if (!uiStore.mobileSidebarOpen) return;
+    uiStore.closeMobileSidebar();
+    if (restoreFocus) focusSidebarToggle();
+};
+
+const handleMobileSidebarKeyDown = (event: KeyboardEvent) => {
+    if (!uiStore.compactViewport || !uiStore.mobileSidebarOpen) return;
+    if (event.key === 'Escape') {
+        event.preventDefault();
+        closeMobileSidebar(true);
+        return;
+    }
+    const sidebar = getSidebarElement();
+    if (sidebar) trapTabKey(event, sidebar);
+};
+
 onMounted(() => {
     document.addEventListener('dragenter', handleGlobalDragEnter, true);
     document.addEventListener('dragover', handleGlobalDragOver, true);
     document.addEventListener('dragleave', handleGlobalDragLeave, true);
     document.addEventListener('drop', handleGlobalDrop, true);
+    window.addEventListener('keydown', handleMobileSidebarKeyDown);
     if (isWailsDesktop) {
         window.addEventListener('keydown', handleGlobalKeyDown);
         // @ts-ignore
@@ -223,6 +264,24 @@ onMounted(() => {
 watch(() => route.query.cmdk, () => {
     maybeOpenCmdkFromRoute()
 })
+
+watch(isCompact, (compact) => {
+    uiStore.setCompactViewport(compact);
+}, { immediate: true })
+
+watch(() => route.fullPath, () => {
+    if (uiStore.compactViewport) closeMobileSidebar();
+})
+
+watch(() => uiStore.compactViewport && uiStore.mobileSidebarOpen, (open) => {
+    setBodyScrollLock(MOBILE_SIDEBAR_LOCK, open);
+    if (open) {
+        nextTick(() => {
+            const sidebar = getSidebarElement();
+            if (sidebar) focusFirstElement(sidebar, '[data-sidebar-close]');
+        });
+    }
+}, { immediate: true })
 
 function maybeOpenCmdkFromRoute() {
     if (!('cmdk' in route.query)) return
@@ -248,6 +307,8 @@ onUnmounted(() => {
             window.runtime.EventsOff('app:reload')
         }
     }
+    window.removeEventListener('keydown', handleMobileSidebarKeyDown);
+    releaseBodyScrollLock(MOBILE_SIDEBAR_LOCK);
     dragCounter = 0;
 });
 </script>
@@ -257,8 +318,9 @@ onUnmounted(() => {
     align-items: stretch;
     width: 100%;
     height: 100%;
-    min-width: 600px;
+    min-width: 0;
     min-height: 0;
+    overflow: hidden;
     /* 统一整页背景，让左侧菜单与右侧内容区视觉连贯 */
     background: var(--td-bg-color-container);
 }
@@ -271,6 +333,20 @@ onUnmounted(() => {
     display: flex;
     flex-direction: column;
     overflow: hidden;
+}
+
+.mobile-sidebar-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 910;
+    padding: 0;
+    border: 0;
+    background: rgba(0, 0, 0, 0.28);
+    touch-action: none;
+}
+
+.main.is-compact-viewport {
+    height: var(--app-viewport-height, 100dvh);
 }
 
 .upload-mask {

--- a/frontend/src/views/settings/Settings.vue
+++ b/frontend/src/views/settings/Settings.vue
@@ -3,6 +3,19 @@
     <Transition name="modal">
       <div v-if="visible" class="settings-overlay">
         <div class="settings-modal">
+          <div class="mobile-settings-header">
+            <button type="button" class="mobile-settings-nav-btn" :aria-expanded="mobileNavOpen"
+              :aria-label="$t('general.settings')" @click="mobileNavOpen = !mobileNavOpen">
+              <t-icon name="menu-fold" size="20px" />
+            </button>
+            <div class="mobile-settings-heading">
+              <span class="mobile-settings-kicker">{{ $t('general.settings') }}</span>
+              <span class="mobile-settings-current">{{ currentNavLabel }}</span>
+            </div>
+            <button type="button" class="mobile-settings-close" @click="handleClose" :aria-label="$t('general.close')">
+              <t-icon name="close" size="20px" />
+            </button>
+          </div>
           <!-- 关闭按钮 -->
           <button class="close-btn" @click="handleClose" :aria-label="$t('general.close')">
             <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
@@ -11,8 +24,10 @@
           </button>
 
           <div class="settings-container">
+            <button v-if="mobileNavOpen" type="button" class="mobile-settings-backdrop"
+              :aria-label="$t('general.close')" @click="mobileNavOpen = false" />
             <!-- 左侧导航 -->
-            <div class="settings-sidebar">
+            <div class="settings-sidebar" :class="{ 'settings-sidebar--mobile-open': mobileNavOpen }">
               <div class="sidebar-header">
                 <h2 class="sidebar-title">{{ $t('general.settings') }}</h2>
               </div>
@@ -193,6 +208,8 @@ import { useRoute, useRouter } from 'vue-router'
 import { useUIStore } from '@/stores/ui'
 import { useAuthStore } from '@/stores/auth'
 import { useI18n } from 'vue-i18n'
+import { useResponsiveViewport } from '@/composables/useResponsiveViewport'
+import { setBodyScrollLock, releaseBodyScrollLock } from '@/utils/bodyScrollLock'
 import SystemInfo from './SystemInfo.vue'
 import TenantInfo from './TenantInfo.vue'
 import UserProfile from './UserProfile.vue'
@@ -228,6 +245,9 @@ const router = useRouter()
 const uiStore = useUIStore()
 const authStore = useAuthStore()
 const { t } = useI18n()
+const { isCompact } = useResponsiveViewport()
+const SETTINGS_SCROLL_LOCK = 'settings-surface'
+const mobileNavOpen = ref(false)
 
 const currentSection = ref<string>('general')
 const currentSubSection = ref<string>('')
@@ -407,6 +427,12 @@ const navGroups = computed<NavGroup[]>(() => {
   ].filter((group) => group.items.length > 0)
 })
 
+const currentNavLabel = computed(() => {
+  const item = navItems.value.find((entry) => entry.key === currentSection.value)
+  const child = item?.children?.find((entry) => entry.key === currentSubSection.value)
+  return child?.label || item?.label || t('general.settings')
+})
+
 // 导航项点击处理
 const handleNavClick = (item: any) => {
   if (item.children && item.children.length > 0) {
@@ -441,6 +467,7 @@ const handleNavClick = (item: any) => {
       query: { ...query, section: item.key },
     })
   }
+  if (isCompact.value) mobileNavOpen.value = false
 }
 
 // 子菜单点击处理
@@ -455,12 +482,18 @@ const handleSubMenuClick = (parentKey: string, childKey: string) => {
       element.scrollIntoView({ behavior: 'smooth', block: 'start' })
     }
   }, 100)
+  if (isCompact.value) mobileNavOpen.value = false
 }
 
 // 控制弹窗显示
 const visible = computed(() => {
   return route.path === '/platform/settings' || uiStore.showSettingsModal
 })
+
+watch([visible, isCompact], ([open, compact]) => {
+  setBodyScrollLock(SETTINGS_SCROLL_LOCK, open && compact)
+  if (!open || !compact) mobileNavOpen.value = false
+}, { immediate: true })
 
 // 关闭弹窗
 const handleClose = () => {
@@ -553,10 +586,12 @@ onMounted(() => {
 onUnmounted(() => {
   window.removeEventListener('keydown', handleEscape)
   window.removeEventListener('settings-nav', handleSettingsNav as EventListener)
+  releaseBodyScrollLock(SETTINGS_SCROLL_LOCK)
 })
 </script>
 
 <style lang="less" scoped>
+@import '@/assets/responsive.less';
 /* 遮罩层 */
 .settings-overlay {
   position: fixed;
@@ -898,4 +933,160 @@ onUnmounted(() => {
     line-height: 1.6;
   }
 }
+
+
+.mobile-settings-header,
+.mobile-settings-backdrop {
+  display: none;
+}
+
+.compact({
+  .settings-overlay {
+    align-items: stretch;
+    justify-content: stretch;
+    padding: 0;
+    background: var(--td-bg-color-container);
+    backdrop-filter: none;
+  }
+
+  .settings-modal {
+    width: 100%;
+    max-width: none;
+    height: var(--app-viewport-height, 100dvh);
+    max-height: var(--app-viewport-height, 100dvh);
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .close-btn {
+    display: none;
+  }
+
+  .mobile-settings-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 52px;
+    padding: max(8px, env(safe-area-inset-top)) max(8px, env(safe-area-inset-right)) 8px max(8px, env(safe-area-inset-left));
+    box-sizing: border-box;
+    border-bottom: 1px solid var(--td-component-stroke);
+    background: var(--td-bg-color-container);
+    flex-shrink: 0;
+    z-index: 30;
+  }
+
+  .mobile-settings-nav-btn,
+  .mobile-settings-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    min-width: 40px;
+    height: 40px;
+    padding: 0;
+    border: 0;
+    border-radius: 10px;
+    background: transparent;
+    color: var(--td-text-color-primary);
+  }
+
+  .mobile-settings-heading {
+    min-width: 0;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .mobile-settings-kicker {
+    color: var(--td-text-color-placeholder);
+    font-size: 11px;
+    line-height: 1.2;
+  }
+
+  .mobile-settings-current {
+    overflow: hidden;
+    color: var(--td-text-color-primary);
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 1.35;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .settings-container {
+    position: relative;
+    min-height: 0;
+  }
+
+  .mobile-settings-backdrop {
+    position: absolute;
+    inset: 0;
+    z-index: 19;
+    display: block;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border: 0;
+    background: rgba(0, 0, 0, 0.42);
+  }
+
+  .settings-sidebar {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 20;
+    width: min(84vw, 320px);
+    max-width: 100%;
+    border-right: 1px solid var(--td-component-stroke);
+    box-shadow: 12px 0 30px rgba(0, 0, 0, 0.14);
+    transform: translateX(-104%);
+    transition: transform 180ms ease;
+
+    &.settings-sidebar--mobile-open {
+      transform: translateX(0);
+    }
+  }
+
+  .sidebar-header {
+    padding: 14px 14px 10px;
+  }
+
+  .settings-nav {
+    padding-bottom: max(16px, env(safe-area-inset-bottom));
+  }
+
+  .nav-item,
+  .submenu-item {
+    min-height: 44px;
+    box-sizing: border-box;
+  }
+
+  .settings-content {
+    min-width: 0;
+    width: 100%;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .content-wrapper,
+  .content-wrapper--wide,
+  .content-wrapper--full {
+    width: 100%;
+    max-width: none;
+    padding: 18px max(14px, env(safe-area-inset-right)) max(28px, env(safe-area-inset-bottom)) max(14px, env(safe-area-inset-left));
+    box-sizing: border-box;
+  }
+
+  .role-denied {
+    min-height: 180px;
+    padding: 40px 16px;
+  }
+
+  .modal-enter-from .settings-modal,
+  .modal-leave-to .settings-modal {
+    transform: translateY(12px);
+  }
+});
 </style>


### PR DESCRIPTION
## Description

本 PR 为 WeKnora 完善移动端和窄屏设备适配，使用户能够直接在 Android/手机浏览器中完成登录、知识库浏览、文档查看、对话、智能体编辑和系统设置等主要操作，同时保持桌面端现有布局与侧栏偏好不变。

整体方案为：

> **统一响应式视口契约 + 临时移动侧栏 + 全屏抽屉/编辑器 + 聊天触摸交互优化 + 安全区域与软键盘适配**

主要改动：

- 新增统一响应式断点和 `useResponsiveViewport`，集中管理 phone、compact、tablet、横竖屏和粗指针状态。
- 区分布局视口、`VisualViewport`、CSS 根缩放与浏览器双指缩放，避免手机放大/缩小时全屏容器被错误压缩、内容裁切或白屏。
- 使用 `viewport-fit=cover`、动态视口高度和 safe-area inset，适配刘海屏、浏览器工具栏及 Android 软键盘。
- 移动端侧栏改为临时抽屉交互，不覆盖用户保存的桌面端折叠偏好；补充背景滚动锁、焦点约束、遮罩关闭和路由切换关闭。
- 优化手机端聊天页、欢迎页、消息列表、建议问题、顶部栏和底部输入区域，移除桌面固定宽度与位移补丁，避免横向溢出。
- 手机点击知识库选择时使用独立选择面板，不再借用聊天输入框过滤，避免软键盘和知识库选择互相抢占焦点。
- 统一智能体、知识库和 Mention 弹层的边界定位，在窄屏、软键盘、滚动和视口变化时重新计算位置。
- 对用户消息、机器人消息、Markdown 图片、表格、代码块和引用内容增加窄屏换行与横向溢出保护。
- 文档详情、引用、附件预览和设置抽屉在移动端使用全屏单滚动容器，并隐藏桌面端拖拽尺寸手柄。
- 知识库、智能体、组织列表调整手机边距、卡片、Tab、操作按钮和删除确认框。
- 知识库、智能体、组织编辑器在移动端改为全屏布局，桌面左右导航在窄屏下转换为顶部横向导航，表单切换为单栏。
- 设置中心、全局命令面板和 TDesign teleported dialog/drawer 增加移动端宽高及触摸尺寸兜底。
- 修正 scoped `:global()` 后代选择器的错误写法，避免样式编译后意外隐藏根页面。
- 限制引导浮层在紧凑视口中的自动打开，并补充异步清理，避免路由切换后残留遮罩或焦点状态。
- 增加响应式布局、弹层定位和双指缩放视口计算回归测试。

移动端行为：

| 场景 | 预期行为 |
|---|---|
| 首次打开手机页面 | 主内容完整显示，侧栏保持收起 |
| 展开移动侧栏 | 侧栏以临时抽屉显示，可通过遮罩、按钮或路由切换关闭 |
| 打开聊天输入框 | 输入区域固定在可用视口底部，并避让 Android 软键盘 |
| 选择知识库 | 打开独立知识库选择面板，不自动唤起聊天输入键盘 |
| 打开智能体或 Mention 选择器 | 弹层保持在可视区域内，滚动或键盘变化时重新定位 |
| 查看文档、引用或附件 | 使用移动端全屏抽屉和单一滚动区域 |
| 编辑知识库、智能体或组织 | 使用全屏编辑界面，导航可横向滚动，表单单栏显示 |
| 双指放大页面 | 浏览器负责视觉放大和平移，应用布局尺寸不被错误缩小 |
| 双指缩小恢复 | 页面恢复正常布局，不出现内容消失或白屏 |
| 桌面端重新打开 | 保留原桌面布局和用户保存的侧栏折叠状态 |


## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #917

## Testing

已验证：

- 手机端登录、知识库列表和知识库详情页面布局。
- 手机端聊天输入、知识库选择、智能体选择和 Mention 弹层交互。
- 对话消息、Markdown、引用和附件内容的窄屏换行与滚动。
- 文档详情、设置中心及各类抽屉的全屏移动布局。
- 知识库、智能体和组织的列表与编辑页面。
- 侧栏展开/关闭、背景滚动锁、焦点约束和路由切换清理。
- Android 软键盘、safe area、横竖屏和动态浏览器工具栏变化。
- 双指缩放到 2 倍时，`VisualViewport` 从 `390 × 844` 缩至 `195 × 422`，应用布局变量仍稳定为 `390 × 844`。
- 桌面端原有侧栏偏好和主要布局不受移动端状态影响。

执行的测试：

```bash
cd frontend
npx vue-tsc --noEmit --pretty false
npx tsx --test \
  src/composables/responsiveViewportMetrics.test.ts \
  src/utils/popoverPosition.test.ts \
  src/views/mobileChatLayout.test.mjs
npm run build

git diff upstream/main...HEAD --check
```

结果：

- TypeScript / Vue 类型检查通过。
- 响应式、弹层和视口计算测试 `24/24` 通过。
- Vite 生产构建通过。
- PR 差异检查通过。

Reproduction/verification steps:

1. 启动 WeKnora 前后端，并使用手机浏览器访问前端地址。
2. 完成登录，进入知识库列表，确认页面没有桌面最小宽度导致的横向裁切。
3. 展开和关闭左侧菜单，确认遮罩、滚动锁和路由跳转行为正常。
4. 进入知识库详情并打开具体文档，确认文档抽屉全屏显示且内容可以正常滚动。
5. 进入聊天页，点击知识库选择按钮，确认不会自动聚焦聊天输入框或弹出冲突键盘。
6. 选择知识库和智能体后发送消息，确认输入区域避让软键盘，消息和引用不会横向溢出。
7. 打开引用、附件预览、设置中心、知识库编辑器和智能体编辑器，确认窄屏布局完整可操作。
8. 在上述页面执行双指放大、拖动和缩小，确认内容不会消失或白屏。
9. 横竖屏切换后重复主要操作，确认侧栏、弹层和全屏页面重新计算尺寸。
10. 在桌面浏览器重新打开页面，确认桌面侧栏偏好和原有布局保持正常。

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] No breaking changes are introduced

## Screenshots / Recordings
### PC

<video src="https://github.com/user-attachments/assets/e5e49075-fa06-4eee-b5b3-33d27d7fa9b3" controls></video>

### OPPO Reno14 Pro

<video src="https://github.com/user-attachments/assets/d869f1b3-fc92-4c80-bf24-4f35d9a8a989" controls></video>

<video src="https://github.com/user-attachments/assets/fe784bda-dbd7-4496-8b18-8f64beb750c5" controls></video>


<!-- Mobile screenshots and recordings can be added on GitHub. -->