### PR TITLE
fix(knowledge): distinguish duplicate files by type

### DIFF
--- a/internal/application/repository/knowledge.go
+++ b/internal/application/repository/knowledge.go
@@ -248,7 +248,7 @@ func (r *knowledgeRepository) CheckKnowledgeExists(
 			var knowledge types.Knowledge
 			duplicateQuery := query.Where("type = ? AND file_hash = ?", "file", params.FileHash)
 			if params.FileType != "" {
-				duplicateQuery = duplicateQuery.Where("file_type = ?", params.FileType)
+				duplicateQuery = duplicateQuery.Where("LOWER(file_type) = ?", strings.ToLower(params.FileType))
 			}
 			err := duplicateQuery.First(&knowledge).Error
 			if err != nil {
@@ -260,13 +260,17 @@ func (r *knowledgeRepository) CheckKnowledgeExists(
 			return true, &knowledge, nil
 		}
 
-		// If no hash or hash doesn't match, use filename and size
+		// If no hash or hash doesn't match, use filename, size, and file type.
 		if params.FileName != "" && params.FileSize > 0 {
 			var knowledge types.Knowledge
-			err := query.Where(
-				"file_name = ? AND file_size = ?",
-				params.FileName, params.FileSize,
-			).First(&knowledge).Error
+			duplicateQuery := query.Where(
+				"type = ? AND file_name = ? AND file_size = ?",
+				"file", params.FileName, params.FileSize,
+			)
+			if params.FileType != "" {
+				duplicateQuery = duplicateQuery.Where("LOWER(file_type) = ?", strings.ToLower(params.FileType))
+			}
+			err := duplicateQuery.First(&knowledge).Error
 			if err != nil {
 				if errors.Is(err, gorm.ErrRecordNotFound) {
 					return false, nil, nil

--- a/internal/application/repository/knowledge.go
+++ b/internal/application/repository/knowledge.go
@@ -241,10 +241,16 @@ func (r *knowledgeRepository) CheckKnowledgeExists(
 
 	switch params.Type {
 	case "file":
-		// If file hash exists, prioritize exact match using hash
+		// File content is only a duplicate within the same file type. This keeps
+		// same-content documents with distinct formats (for example, .md and
+		// .txt) available as separate knowledge items.
 		if params.FileHash != "" {
 			var knowledge types.Knowledge
-			err := query.Where("file_hash = ?", params.FileHash).First(&knowledge).Error
+			duplicateQuery := query.Where("type = ? AND file_hash = ?", "file", params.FileHash)
+			if params.FileType != "" {
+				duplicateQuery = duplicateQuery.Where("file_type = ?", params.FileType)
+			}
+			err := duplicateQuery.First(&knowledge).Error
 			if err != nil {
 				if errors.Is(err, gorm.ErrRecordNotFound) {
 					return false, nil, nil

--- a/internal/application/repository/knowledge_duplicate_test.go
+++ b/internal/application/repository/knowledge_duplicate_test.go
@@ -1,0 +1,50 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckKnowledgeExists_FileHashIsScopedByFileType(t *testing.T) {
+	db := setupKnowledgeTestDB(t)
+	repo := NewKnowledgeRepository(db)
+	ctx := context.Background()
+	tenantID := uint64(1)
+	kbID := uuid.NewString()
+	const fileHash = "same-content-hash"
+
+	require.NoError(t, db.Exec(`
+		INSERT INTO knowledges (id, tenant_id, knowledge_base_id, type, title, file_name, file_type, file_hash, parse_status)
+		VALUES (?, ?, ?, 'file', 'document.md', 'document.md', 'md', ?, 'completed')
+	`, uuid.NewString(), tenantID, kbID, fileHash).Error)
+
+	t.Run("same content with another file type is allowed", func(t *testing.T) {
+		exists, knowledge, err := repo.CheckKnowledgeExists(ctx, tenantID, kbID, &types.KnowledgeCheckParams{
+			Type:     "file",
+			FileHash: fileHash,
+			FileType: "txt",
+		})
+
+		require.NoError(t, err)
+		assert.False(t, exists)
+		assert.Nil(t, knowledge)
+	})
+
+	t.Run("same content and file type remains a duplicate", func(t *testing.T) {
+		exists, knowledge, err := repo.CheckKnowledgeExists(ctx, tenantID, kbID, &types.KnowledgeCheckParams{
+			Type:     "file",
+			FileHash: fileHash,
+			FileType: "md",
+		})
+
+		require.NoError(t, err)
+		assert.True(t, exists)
+		require.NotNil(t, knowledge)
+		assert.Equal(t, "md", knowledge.FileType)
+	})
+}

--- a/internal/application/repository/knowledge_duplicate_test.go
+++ b/internal/application/repository/knowledge_duplicate_test.go
@@ -47,4 +47,17 @@ func TestCheckKnowledgeExists_FileHashIsScopedByFileType(t *testing.T) {
 		require.NotNil(t, knowledge)
 		assert.Equal(t, "md", knowledge.FileType)
 	})
+
+	t.Run("file type matching is case-insensitive", func(t *testing.T) {
+		exists, knowledge, err := repo.CheckKnowledgeExists(ctx, tenantID, kbID, &types.KnowledgeCheckParams{
+			Type:     "file",
+			FileHash: fileHash,
+			FileType: "MD",
+		})
+
+		require.NoError(t, err)
+		assert.True(t, exists)
+		require.NotNil(t, knowledge)
+		assert.Equal(t, "md", knowledge.FileType)
+	})
 }

--- a/internal/application/service/datasource_service.go
+++ b/internal/application/service/datasource_service.go
@@ -1253,8 +1253,8 @@ func (s *DataSourceService) ingestItem(ctx context.Context, ds *types.DataSource
 
 // dupIsSameNode reports whether a duplicate-content error means the parent still
 // exists in the KB *under this item's own external_id* — i.e. a content-dedup hit
-// against this same node, so reconciling its subtree is safe. Deduplication keys
-// on file_hash alone (CheckKnowledgeExists), so an updated node whose rebuilt body
+// against this same node, so reconciling its subtree is safe. File deduplication
+// keys on file_hash plus file_type (CheckKnowledgeExists), so an updated node whose rebuilt body
 // happens to hash-collide with a DIFFERENT knowledge item (another node, or a
 // manually-uploaded file with no external_id) would otherwise sweep this node's
 // children even though its own parent row was just deleted for the update and

--- a/internal/application/service/datasource_sweep_wiring_test.go
+++ b/internal/application/service/datasource_sweep_wiring_test.go
@@ -160,7 +160,7 @@ func TestIngestItem_ReplacesSubtreeSweepsOnDuplicateParent(t *testing.T) {
 
 // TestIngestItem_NoSweepWhenDuplicateIsDifferentNode guards the data-loss path:
 // when an updated node's rebuilt body content-hash-collides with a DIFFERENT
-// knowledge item (dedup keys on file_hash alone), the parent row under this
+// knowledge item (dedup keys on file_hash plus file_type), the parent row under this
 // node's external_id no longer exists (it was deleted for the update and never
 // recreated), so the subtree must NOT be swept — deleting the children would
 // destroy them with no parent to replace them.

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -82,6 +82,7 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 	exists, existingKnowledge, err := s.repo.CheckKnowledgeExists(ctx, tenantID, kbID, &types.KnowledgeCheckParams{
 		Type:     "file",
 		FileName: fileName,
+		FileType: getFileType(fileName),
 		FileSize: file.Size,
 		FileHash: hash,
 	})

--- a/internal/types/knowledge.go
+++ b/internal/types/knowledge.go
@@ -445,6 +445,7 @@ func (k *Knowledge) SetProcessOverrides(o *KnowledgeProcessOverrides) error {
 type KnowledgeCheckParams struct {
 	// File parameters
 	FileName string
+	FileType string
 	FileSize int64
 	FileHash string
 	// URL parameters

--- a/internal/types/knowledge.go
+++ b/internal/types/knowledge.go
@@ -445,6 +445,7 @@ func (k *Knowledge) SetProcessOverrides(o *KnowledgeProcessOverrides) error {
 type KnowledgeCheckParams struct {
 	// File parameters
 	FileName string
+	// FileType scopes file-hash deduplication; callers checking file uploads should set it.
 	FileType string
 	FileSize int64
 	FileHash string


### PR DESCRIPTION
## Description
Fixes duplicate-file detection for file uploads with identical content but different file types.

File deduplication now matches on `type`, `file_hash`, and `file_type`, allowing byte-identical files such as `.md` and `.txt` to coexist in the same knowledge base while continuing to reject duplicate uploads of the same file type.

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #2374 

## Testing
```powershell
go test ./internal/application/repository -run '^TestCheckKnowledgeExists_FileHashIsScopedByFileType$' -count=1 -v
```
Verified:
- Same hash with different file types (md and txt) is not treated as a duplicate.
- Same hash with the same file type remains a duplicate.
- git diff --check passes.

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
no user-visible UI changes.
