### PR TITLE
fix(storage): allow image uploads to use file service fallback

### DIFF
--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"mime/multipart"
 	"net/url"
-	"os"
 	"path"
 	"slices"
 	"strings"
@@ -135,44 +134,11 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 			return nil, err
 		}
 	} else {
-		// 检查多模态配置完整性 - 只在图片文件时校验
+		// 图片入库必须由 VLM 解析。存储服务不在这里做 provider-specific
+		// 配置检查：resolveFileService 会在空配置或 legacy 配置不完整时
+		// 按统一语义回退到全局 fileSvc。
 		if IsImageType(getFileType(safeFilename)) {
-			provider := kb.GetStorageProvider()
-			tenant, _ := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
-			if provider == "" && tenant != nil && tenant.StorageEngineConfig != nil {
-				provider = strings.ToLower(strings.TrimSpace(tenant.StorageEngineConfig.DefaultProvider))
-			}
-
-			concreteBackend := kb.StorageBackendID != nil && strings.TrimSpace(*kb.StorageBackendID) != ""
-			switch {
-			case concreteBackend:
-				// Registration already validated and tested the concrete instance.
-			case provider == "cos":
-				if tenant == nil || tenant.StorageEngineConfig == nil || tenant.StorageEngineConfig.COS == nil ||
-					tenant.StorageEngineConfig.COS.SecretID == "" || tenant.StorageEngineConfig.COS.SecretKey == "" ||
-					tenant.StorageEngineConfig.COS.Region == "" || tenant.StorageEngineConfig.COS.BucketName == "" {
-					logger.Error(ctx, "COS configuration incomplete for image multimodal processing")
-					return nil, werrors.NewBadRequestError("上传图片文件需要完整的对象存储配置信息, 请前往知识库存储设置或系统设置页面进行补全")
-				}
-			case provider == "minio":
-				ok := false
-				if tenant != nil && tenant.StorageEngineConfig != nil && tenant.StorageEngineConfig.MinIO != nil {
-					m := tenant.StorageEngineConfig.MinIO
-					if m.Mode == "remote" {
-						ok = m.Endpoint != "" && m.AccessKeyID != "" && m.SecretAccessKey != "" && m.BucketName != ""
-					} else {
-						ok = os.Getenv("MINIO_ENDPOINT") != "" && os.Getenv("MINIO_ACCESS_KEY_ID") != "" &&
-							os.Getenv("MINIO_SECRET_ACCESS_KEY") != "" &&
-							(m.BucketName != "" || os.Getenv("MINIO_BUCKET_NAME") != "")
-					}
-				}
-				if !ok {
-					logger.Error(ctx, "MinIO configuration incomplete for image multimodal processing")
-					return nil, werrors.NewBadRequestError("上传图片文件需要完整的对象存储配置信息, 请前往知识库存储设置或系统设置页面进行补全")
-				}
-			}
-
-			if !kb.VLMConfig.Enabled || kb.VLMConfig.ModelID == "" {
+			if !eff.VLMConfig.IsEnabled() {
 				logger.Error(ctx, "VLM model is not configured")
 				return nil, werrors.NewBadRequestError("上传图片文件需要设置VLM模型")
 			}

--- a/internal/application/service/knowledge_create_test.go
+++ b/internal/application/service/knowledge_create_test.go
@@ -192,6 +192,49 @@ func TestCreateKnowledgeFromFilePersistsStoredFilePathOnCreate(t *testing.T) {
 	require.Equal(t, 1, task.calls)
 }
 
+func TestCreateKnowledgeFromImageFallsBackWhenLegacyStorageConfigIsIncomplete(t *testing.T) {
+	t.Parallel()
+
+	repo := &createKnowledgeFileRepoStub{}
+	fileSvc := &createKnowledgeFileServiceStub{}
+	task := &createKnowledgeTaskEnqueuerStub{}
+	kb := &types.KnowledgeBase{
+		ID:        "kb-1",
+		VLMConfig: types.VLMConfig{Enabled: true, ModelID: "vlm-1"},
+	}
+	kb.SetStorageProvider("cos")
+	svc := &knowledgeService{
+		repo:      repo,
+		kbService: &createKnowledgeFileKBServiceStub{kb: kb},
+		fileSvc:   fileSvc,
+		task:      task,
+	}
+	ctx := context.WithValue(newCreateKnowledgeFileContext(), types.TenantInfoContextKey, &types.Tenant{
+		StorageEngineConfig: &types.StorageEngineConfig{
+			DefaultProvider: "cos",
+			COS:             &types.COSEngineConfig{SecretID: "incomplete"},
+		},
+	})
+
+	knowledge, err := svc.CreateKnowledgeFromFile(
+		ctx,
+		"kb-1",
+		newMultipartFileHeader(t, "image.png", "image bytes"),
+		nil,
+		nil,
+		"",
+		nil,
+		"",
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, knowledge)
+	require.Equal(t, 1, fileSvc.saveCalls)
+	require.Equal(t, 1, repo.createCalls)
+	require.Equal(t, 1, task.calls)
+}
+
 func TestCreateKnowledgeFromFileDeletesStoredFileWhenCreateFails(t *testing.T) {
 	t.Parallel()
 

--- a/internal/application/service/knowledge_process_config.go
+++ b/internal/application/service/knowledge_process_config.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"os"
 	"strconv"
 	"strings"
 
@@ -118,9 +117,6 @@ func ValidateProcessOverrides(
 	eff := ResolveProcessConfig(kb, overrides)
 
 	if hasImage {
-		if err := validateImageMultimodalConfig(ctx, kb); err != nil {
-			return err
-		}
 		if !eff.VLMConfig.IsEnabled() {
 			return werrors.NewBadRequestError("上传图片文件需要设置VLM模型")
 		}
@@ -259,45 +255,6 @@ func mergeExtractConfig(base types.ExtractConfig, override *types.ExtractConfig)
 		result.CustomInstructions = override.CustomInstructions
 	}
 	return result
-}
-
-func validateImageMultimodalConfig(ctx context.Context, kb *types.KnowledgeBase) error {
-	// Concrete backends are validated and connectivity-tested when registered.
-	// The checks below only apply to unmigrated provider-only bindings.
-	if kb != nil && kb.StorageBackendID != nil && strings.TrimSpace(*kb.StorageBackendID) != "" {
-		return nil
-	}
-	provider := kb.GetStorageProvider()
-	tenant, _ := ctx.Value(types.TenantInfoContextKey).(*types.Tenant)
-	if provider == "" && tenant != nil && tenant.StorageEngineConfig != nil {
-		provider = strings.ToLower(strings.TrimSpace(tenant.StorageEngineConfig.DefaultProvider))
-	}
-
-	switch provider {
-	case "cos":
-		if tenant == nil || tenant.StorageEngineConfig == nil || tenant.StorageEngineConfig.COS == nil ||
-			tenant.StorageEngineConfig.COS.SecretID == "" || tenant.StorageEngineConfig.COS.SecretKey == "" ||
-			tenant.StorageEngineConfig.COS.Region == "" || tenant.StorageEngineConfig.COS.BucketName == "" {
-			return werrors.NewBadRequestError("上传图片文件需要完整的对象存储配置信息, 请前往知识库存储设置或系统设置页面进行补全")
-		}
-	case "minio":
-		ok := false
-		if tenant != nil && tenant.StorageEngineConfig != nil && tenant.StorageEngineConfig.MinIO != nil {
-			m := tenant.StorageEngineConfig.MinIO
-			if m.Mode == "remote" {
-				ok = m.Endpoint != "" && m.AccessKeyID != "" && m.SecretAccessKey != "" && m.BucketName != ""
-			} else {
-				ok = os.Getenv("MINIO_ENDPOINT") != "" && os.Getenv("MINIO_ACCESS_KEY_ID") != "" &&
-					os.Getenv("MINIO_SECRET_ACCESS_KEY") != "" &&
-					(m.BucketName != "" || os.Getenv("MINIO_BUCKET_NAME") != "")
-			}
-		}
-		if !ok {
-			return werrors.NewBadRequestError("上传图片文件需要完整的对象存储配置信息, 请前往知识库存储设置或系统设置页面进行补全")
-		}
-	}
-
-	return nil
 }
 
 // MergeParserEngineOverrides merges upload overrides on top of tenant overrides safely.

--- a/internal/application/service/knowledge_process_config_test.go
+++ b/internal/application/service/knowledge_process_config_test.go
@@ -395,7 +395,7 @@ func TestValidateProcessOverrides_NonMediaFileTypes(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestValidateProcessOverrides_COSIncompleteForImage(t *testing.T) {
+func TestValidateProcessOverrides_ImageAllowsStorageFallback(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.WithValue(context.Background(), types.TenantInfoContextKey, &types.Tenant{
@@ -409,7 +409,7 @@ func TestValidateProcessOverrides_COSIncompleteForImage(t *testing.T) {
 	kb.SetStorageProvider("cos")
 
 	err := ValidateProcessOverrides(ctx, kb, &types.KnowledgeProcessOverrides{}, []string{"png"})
-	require.Error(t, err)
+	require.NoError(t, err)
 }
 
 func TestMergeParserEngineOverrides(t *testing.T) {


### PR DESCRIPTION
## What changed

- Remove image-only COS and MinIO completeness checks from file upload validation.
- Preserve VLM validation for image ingestion using the effective VLM configuration.
- Allow both default uploads and uploads with process overrides to follow the existing global file service fallback.
- Add regression coverage for incomplete legacy storage configuration.

## Why

Image uploads were rejected before storage resolution when a legacy COS or MinIO provider was selected but its configuration was incomplete. This bypassed the existing `resolveFileService` behavior, which intentionally falls back to the globally configured file service when tenant-level storage cannot be constructed.

The provider-specific checks were also duplicated between the normal upload path and process override validation.

## Impact

Image ingestion now uses the same storage fallback semantics as other file types. Images still require a valid VLM configuration.

## Validation

- `go test ./internal/application/service ./internal/application/service/file -count=1`
