### PR TITLE
fix(knowledge): support local HTML file uploads

### DIFF
--- a/docreader/parser/__init__.py
+++ b/docreader/parser/__init__.py
@@ -16,6 +16,7 @@ meaningful chunks for further processing and indexing.
 from .doc_parser import DocParser
 from .docx2_parser import Docx2Parser
 from .excel_parser import ExcelParser
+from .html_parser import HTMLParser
 from .image_parser import ImageParser
 from .markdown_parser import MarkdownParser
 from .parser import Parser
@@ -33,6 +34,7 @@ __all__ = [
     "WebParser",
     "Parser",
     "ExcelParser",
+    "HTMLParser",
     "ParserEngineRegistry",
     "registry",
 ]

--- a/docreader/parser/html_parser.py
+++ b/docreader/parser/html_parser.py
@@ -1,0 +1,37 @@
+"""Static HTML file parser."""
+
+from bs4 import BeautifulSoup
+
+from docreader.models.document import Document
+from docreader.parser.base_parser import BaseParser
+from docreader.parser.chain_parser import PipelineParser
+from docreader.parser.markdown_parser import MarkdownParser
+from docreader.parser.mhtml_parser import MHTMLParser
+
+
+class HTMLToMarkdownParser(BaseParser):
+    """Convert uploaded HTML bytes to Markdown without browser or network access."""
+
+    def parse_into_text(self, content: bytes) -> Document:
+        if not content.strip():
+            return Document()
+
+        # Inspect the original bytes so BOMs and HTML charset declarations are
+        # honored before the shared Markdown conversion runs.
+        html = BeautifulSoup(content, "lxml").decode()
+        markdown = MHTMLParser(
+            file_name=self.file_name,
+            file_type=self.file_type,
+            extract_images=False,
+        ).html_to_markdown(
+            html,
+            strip_internal_links=False,
+            fallback_to_raw_html=False,
+        )
+        return Document(content=markdown or "")
+
+
+class HTMLParser(PipelineParser):
+    """Extract static HTML content and normalize the resulting Markdown."""
+
+    _parser_cls = (HTMLToMarkdownParser, MarkdownParser)

--- a/docreader/parser/mhtml_parser.py
+++ b/docreader/parser/mhtml_parser.py
@@ -83,7 +83,7 @@ class MHTMLParser(BaseParser):
         html_content = main_html["content"]
 
         try:
-            markdown_text = self._html_to_markdown(
+            markdown_text = self.html_to_markdown(
                 html_content,
                 image_aliases=image_aliases,
                 base_location=main_html.get("location", ""),
@@ -118,11 +118,15 @@ class MHTMLParser(BaseParser):
             return non_ad[0]
 
         largest = max(html_parts, key=lambda part: part["size"])
-        logger.warning("Only ad content found, using largest: %d bytes", largest["size"])
+        logger.warning(
+            "Only ad content found, using largest: %d bytes", largest["size"]
+        )
         return largest
 
     @staticmethod
-    def _add_image_aliases(image_aliases: Dict[str, str], part, image_path: str) -> None:
+    def _add_image_aliases(
+        image_aliases: Dict[str, str], part, image_path: str
+    ) -> None:
         """Register the refs an MHTML document may use for an image part."""
         for raw in (
             part.get("Content-Location", ""),
@@ -192,19 +196,30 @@ class MHTMLParser(BaseParser):
             return ""
         return filename
 
-    def _html_to_markdown(
+    def html_to_markdown(
         self,
         html_content: str,
         image_aliases: Dict[str, str] | None = None,
         base_location: str = "",
+        *,
+        strip_internal_links: bool = True,
+        fallback_to_raw_html: bool = True,
     ) -> str:
+        """Convert HTML to Markdown with explicit link and fallback policies."""
+
+        def raw_html_fallback() -> str:
+            if not fallback_to_raw_html:
+                return ""
+            return f"```html\n{html_content[:50000]}\n```"
+
         try:
             from markdownify import markdownify as md
 
             soup = BeautifulSoup(html_content, "lxml")
             for tag in soup(["script", "style", "noscript", "iframe"]):
                 tag.decompose()
-            self._strip_internal_links(soup)
+            if strip_internal_links:
+                self._strip_internal_links(soup)
             if image_aliases:
                 self._rewrite_image_sources(soup, image_aliases, base_location)
             text_fallback = soup.get_text(separator="\n", strip=True)
@@ -214,14 +229,23 @@ class MHTMLParser(BaseParser):
                 logger.warning("Markdown empty, falling back to text extraction")
                 return text_fallback
             if not result:
-                return f"```html\n{html_content[:50000]}\n```"
+                return raw_html_fallback()
             return result
         except ImportError:
             logger.warning("markdownify not available, returning raw HTML")
-            return f"```html\n{html_content}\n```"
+            return raw_html_fallback()
         except Exception as e:
             logger.error("HTML to Markdown conversion failed: %s", e)
-            return f"```html\n{html_content}\n```"
+            return raw_html_fallback()
+
+    def _html_to_markdown(
+        self,
+        html_content: str,
+        image_aliases: Dict[str, str] | None = None,
+        base_location: str = "",
+    ) -> str:
+        """Backward-compatible wrapper for existing internal callers and tests."""
+        return self.html_to_markdown(html_content, image_aliases, base_location)
 
     @staticmethod
     def _normalize_markdown(markdown_text: str) -> str:

--- a/docreader/parser/registry.py
+++ b/docreader/parser/registry.py
@@ -1,11 +1,12 @@
 import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Callable, Dict, List, Optional, Tuple, Type
 
 from docreader.parser.base_parser import BaseParser
 from docreader.parser.doc_parser import DocParser
 from docreader.parser.docx2_parser import Docx2Parser
 from docreader.parser.epub_parser import EPUBParser
 from docreader.parser.excel_parser import ExcelParser
+from docreader.parser.html_parser import HTMLParser
 from docreader.parser.image_parser import ImageParser
 from docreader.parser.markdown_parser import MarkdownParser
 from docreader.parser.markitdown_parser import MarkitdownParser
@@ -134,6 +135,8 @@ def _build_default_registry() -> ParserEngineRegistry:
             "xlsx": ExcelParser,
             "xls": ExcelParser,
             "epub": EPUBParser,
+            "html": HTMLParser,
+            "htm": HTMLParser,
             "mhtml": MHTMLParser,
             **_image_types,
         },
@@ -161,7 +164,9 @@ def _build_default_registry() -> ParserEngineRegistry:
         "opendataloader",
         {"pdf": OpenDataLoaderParser},
         description="OpenDataLoader PDF（版面分析，需 Java 11+）",
-        check_available=lambda overrides: opendataloader_available(overrides, quick=True),
+        check_available=lambda overrides: opendataloader_available(
+            overrides, quick=True
+        ),
         unavailable_hint="请安装 opendataloader-pdf 与 Java 11+",
     )
 

--- a/docreader/tests/test_html_parser.py
+++ b/docreader/tests/test_html_parser.py
@@ -1,0 +1,71 @@
+import unittest
+from pathlib import Path
+
+from docreader.parser.html_parser import HTMLParser
+from docreader.parser.registry import BUILTIN_ENGINE, registry
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class HTMLParserTest(unittest.TestCase):
+    def test_parse_static_html_fixture_into_markdown(self):
+        content = (REPO_ROOT / "docreader" / "testdata" / "test.html").read_bytes()
+
+        document = HTMLParser(file_name="test.html", file_type="html").parse(content)
+
+        self.assertIn("# 测试 HTML 文档", document.content)
+        self.assertIn("[测试链接](https://example.com)", document.content)
+        self.assertIn("| 表头1 | 表头2 |", document.content)
+        self.assertIn("内容4", document.content)
+
+    def test_parse_empty_html_returns_empty_document(self):
+        document = HTMLParser(file_name="empty.htm", file_type="htm").parse(b"")
+
+        self.assertEqual("", document.content)
+
+    def test_parse_honors_declared_windows_1252_charset(self):
+        html = (
+            '<meta charset="windows-1252">'
+            "<h1>R\u00e9sum\u00e9 \u201cquoted\u201d \u20ac</h1>"
+        ).encode("windows-1252")
+
+        document = HTMLParser(file_name="legacy.html", file_type="html").parse(html)
+
+        self.assertIn("# R\u00e9sum\u00e9 \u201cquoted\u201d \u20ac", document.content)
+
+    def test_parse_honors_utf16_bom(self):
+        html = "<html><body><h1>UTF-16 title</h1></body></html>".encode("utf-16")
+
+        document = HTMLParser(file_name="utf16.html", file_type="html").parse(html)
+
+        self.assertIn("# UTF-16 title", document.content)
+        self.assertNotIn("\x00", document.content)
+
+    def test_parse_script_only_html_returns_empty_document(self):
+        html = (
+            b"<html><body><script>alert('x')</script><style>p{}</style></body></html>"
+        )
+
+        document = HTMLParser(file_name="script.html", file_type="html").parse(html)
+
+        self.assertEqual("", document.content)
+
+    def test_parse_preserves_relative_and_fragment_links(self):
+        html = b'<a href="./guide.html">Guide</a><a href="#section">Section</a>'
+
+        document = HTMLParser(file_name="links.html", file_type="html").parse(html)
+
+        self.assertIn("[Guide](./guide.html)", document.content)
+        self.assertIn("[Section](#section)", document.content)
+
+    def test_registry_routes_html_extensions_to_html_parser(self):
+        self.assertIs(registry.get_parser_class("", "html"), HTMLParser)
+        self.assertIs(registry.get_parser_class("", "htm"), HTMLParser)
+
+        builtin_types = registry._engines[BUILTIN_ENGINE]
+        self.assertIn("html", builtin_types)
+        self.assertIn("htm", builtin_types)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/utils/fileTypeVerification.test.ts
+++ b/frontend/src/utils/fileTypeVerification.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { shouldRejectKnowledgeFileType } from './fileTypeVerification.ts'
+
+test('shouldRejectKnowledgeFileType accepts HTML in the fallback whitelist', () => {
+  assert.equal(shouldRejectKnowledgeFileType('page.html'), false)
+  assert.equal(shouldRejectKnowledgeFileType('legacy.HTM'), false)
+  assert.equal(shouldRejectKnowledgeFileType('payload.exe'), true)
+})
+
+test('shouldRejectKnowledgeFileType preserves dynamic whitelist behavior', () => {
+  assert.equal(shouldRejectKnowledgeFileType('custom.xyz', ['xyz']), false)
+  assert.equal(shouldRejectKnowledgeFileType('page.html', ['pdf']), true)
+  assert.equal(shouldRejectKnowledgeFileType('page.html', []), false)
+})

--- a/frontend/src/utils/fileTypeVerification.ts
+++ b/frontend/src/utils/fileTypeVerification.ts
@@ -1,0 +1,39 @@
+const DEFAULT_VALID_TYPES = new Set([
+  "pdf",
+  "txt",
+  "md",
+  "docx",
+  "doc",
+  "pptx",
+  "ppt",
+  "epub",
+  "html",
+  "htm",
+  "mhtml",
+  "jpg",
+  "jpeg",
+  "png",
+  "csv",
+  "xlsx",
+  "xls",
+  "mp3",
+  "wav",
+  "m4a",
+  "flac",
+  "ogg",
+]);
+
+export function shouldRejectKnowledgeFileType(
+  filename: string,
+  validTypes?: Set<string> | string[],
+) {
+  const provided = validTypes
+    ? validTypes instanceof Set
+      ? validTypes
+      : new Set(validTypes)
+    : undefined;
+  const allowed = provided && provided.size > 0 ? provided : DEFAULT_VALID_TYPES;
+  const type = filename.substring(filename.lastIndexOf(".") + 1).toLowerCase();
+
+  return !allowed.has(type);
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,5 +1,6 @@
 import { MessagePlugin } from "tdesign-vue-next";
 import i18n from '@/i18n';
+import { shouldRejectKnowledgeFileType } from "./fileTypeVerification";
 
 // 声明全局运行时配置类型
 declare global {
@@ -40,8 +41,6 @@ export function formatStringDate(date: any) {
     year + "-" + month + "-" + day + " " + hour + ":" + minute + ":" + second
   );
 }
-const DEFAULT_VALID_TYPES = new Set(["pdf", "txt", "md", "docx", "doc", "pptx", "ppt", "epub", "mhtml", "jpg", "jpeg", "png", "csv", "xlsx", "xls", "mp3", "wav", "m4a", "flac", "ogg"]);
-
 /** Returns true when the file exceeds the deploy-time upload limit. */
 export function fileSizeVerification(file: Pick<File, 'size'>, silent = false) {
   if (file.size <= MAX_FILE_SIZE_BYTES) return false;
@@ -56,15 +55,7 @@ export function fileSizeVerification(file: Pick<File, 'size'>, silent = false) {
  * @param validTypes - override the default extension whitelist with a dynamic set (e.g. from engine registry).
  */
 export function kbFileTypeVerification(file: any, silent = false, validTypes?: Set<string> | string[]) {
-  const provided = validTypes
-    ? (validTypes instanceof Set ? validTypes : new Set(validTypes))
-    : undefined;
-  // An empty whitelist means the engine registry hasn't loaded yet; fall back to
-  // the default set rather than rejecting every file.
-  const allowed = provided && provided.size > 0 ? provided : DEFAULT_VALID_TYPES;
-
-  const type = file.name.substring(file.name.lastIndexOf(".") + 1).toLowerCase();
-  if (!allowed.has(type)) {
+  if (shouldRejectKnowledgeFileType(file.name, validTypes)) {
     if (!silent) {
       MessagePlugin.error(i18n.global.t('error.unsupportedFileType'));
     }

--- a/internal/application/service/knowledge_util.go
+++ b/internal/application/service/knowledge_util.go
@@ -22,7 +22,7 @@ import (
 // isValidFileType checks if a file type is supported
 func isValidFileType(filename string) bool {
 	switch strings.ToLower(getFileType(filename)) {
-	case "pdf", "txt", "docx", "doc", "epub", "mhtml", "md", "markdown", "png", "jpg", "jpeg", "gif", "csv", "xlsx", "xls", "pptx", "ppt", "json",
+	case "pdf", "txt", "docx", "doc", "epub", "html", "htm", "mhtml", "md", "markdown", "png", "jpg", "jpeg", "gif", "csv", "xlsx", "xls", "pptx", "ppt", "json",
 		"mp3", "wav", "m4a", "flac", "ogg":
 		return true
 	default:

--- a/internal/application/service/knowledge_util_filetype_test.go
+++ b/internal/application/service/knowledge_util_filetype_test.go
@@ -1,0 +1,24 @@
+package service
+
+import "testing"
+
+func TestIsValidFileTypeHTML(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     bool
+	}{
+		{name: "html", filename: "index.html", want: true},
+		{name: "uppercase html", filename: "INDEX.HTML", want: true},
+		{name: "htm", filename: "legacy.htm", want: true},
+		{name: "unsupported", filename: "payload.exe", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidFileType(tt.filename); got != tt.want {
+				t.Fatalf("isValidFileType(%q) = %v, want %v", tt.filename, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/docparser/engine_registry.go
+++ b/internal/infrastructure/docparser/engine_registry.go
@@ -45,7 +45,7 @@ func (e *builtinEngine) Description() string {
 	return "DocReader built-in parser engine"
 }
 func (e *builtinEngine) FileTypes(_ bool) []string {
-	return []string{"docx", "doc", "pdf", "md", "markdown", "xlsx", "xls", "epub", "mhtml", "jpg", "jpeg", "png", "gif", "bmp", "tiff", "webp", "mp3", "wav", "m4a", "flac", "ogg"}
+	return []string{"docx", "doc", "pdf", "md", "markdown", "xlsx", "xls", "epub", "html", "htm", "mhtml", "jpg", "jpeg", "png", "gif", "bmp", "tiff", "webp", "mp3", "wav", "m4a", "flac", "ogg"}
 }
 func (e *builtinEngine) CheckAvailable(docreaderConnected bool, _ map[string]string) (bool, string) {
 	if docreaderConnected {

--- a/internal/infrastructure/docparser/engine_registry_test.go
+++ b/internal/infrastructure/docparser/engine_registry_test.go
@@ -1,0 +1,28 @@
+package docparser
+
+import "testing"
+
+func TestListAllEnginesBuiltinIncludesHTML(t *testing.T) {
+	engines := ListAllEngines(true, nil, nil)
+	for _, engine := range engines {
+		if engine.Name != "builtin" {
+			continue
+		}
+		if !engine.Available {
+			t.Fatalf("builtin engine is unavailable: %s", engine.UnavailableReason)
+		}
+
+		fileTypes := make(map[string]bool, len(engine.FileTypes))
+		for _, fileType := range engine.FileTypes {
+			fileTypes[fileType] = true
+		}
+		for _, want := range []string{"html", "htm"} {
+			if !fileTypes[want] {
+				t.Errorf("builtin engine file types do not include %q: %v", want, engine.FileTypes)
+			}
+		}
+		return
+	}
+
+	t.Fatal("builtin engine not found")
+}


### PR DESCRIPTION
## English

### Summary

- Add end-to-end support for uploading local `.html` and `.htm` files to knowledge bases.
- Register both extensions consistently in the frontend fallback validator, Go upload validator and parser-engine metadata, and Python DocReader.
- Parse static HTML into Markdown with charset-aware decoding while preserving headings, links, lists, tables, and image references.
- Do not execute JavaScript or fetch remote resources during HTML parsing.

### Root Cause

The local upload path advertised HTML support but did not register `html`/`htm` consistently across validation and parser registries, and DocReader had no local HTML parser. This caused uploads to be rejected or fail with `Unsupported file type: html`.

### Behavior

- Accepts `.html` and `.htm` case-insensitively.
- Honors HTML charset declarations and UTF-16 BOMs.
- Preserves external, relative, and fragment links.
- Removes script/style/iframe content and returns an empty document when no visible content remains.
- Keeps existing MHTML behavior backward-compatible.

### Test Plan

- [x] Python HTML/MHTML/Web/routing tests: 32 passed
- [x] Go service and DocReader registry packages passed
- [x] Frontend file-type tests: 2 passed
- [x] Frontend production build: 6,312 modules transformed successfully
- [x] Ruff lint and format checks passed
- [x] `git diff --check upstream/main` passed
- [x] Independent pre-landing review: no Critical or Important findings

Known baseline limitations: the full frontend suite has 2 existing workspace/tenant terminology failures and type-check has 7 existing errors, both reproduced on clean `main`. The full DocReader suite has 5 environment errors because the repository does not include required DOCX/PPT/PPTX binary fixtures.

### Related Issue

Fixes #2373

---

## 中文

### 摘要

- 打通知识库本地 `.html` 和 `.htm` 文件的完整上传链路。
- 在前端兜底校验、Go 上传校验与解析引擎元数据、Python DocReader 中统一注册两个扩展名。
- 使用可识别字符编码的静态 HTML 转 Markdown 解析，保留标题、链接、列表、表格和图片引用等结构。
- HTML 解析期间不执行 JavaScript，也不抓取远程资源。

### 根因

本地文件上传链路虽然声明支持 HTML，但 `html`/`htm` 没有在各层校验与解析器注册表中保持一致，同时 DocReader 缺少本地 HTML 解析器，因此文件会在上传时被拒绝，或在解析阶段报错 `Unsupported file type: html`。

### 修复后行为

- 大小写不敏感地接受 `.html` 和 `.htm`。
- 正确识别 HTML charset 声明及 UTF-16 BOM。
- 保留外部链接、相对链接和页面片段链接。
- 移除 script/style/iframe 内容；没有可见内容时返回空文档。
- 保持现有 MHTML 行为向后兼容。

### 测试计划

- [x] Python HTML/MHTML/Web/路由测试：32 项通过
- [x] Go 服务与 DocReader 引擎注册包测试通过
- [x] 前端文件类型测试：2 项通过
- [x] 前端生产构建成功：转换 6,312 个模块
- [x] Ruff lint 与格式检查通过
- [x] `git diff --check upstream/main` 通过
- [x] 独立合入前审查：无 Critical 或 Important 问题

### 关联 Issue

Fixes #2373
