### PR TITLE
fix(mcp-server): pin MCP Python SDK to v1.x

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,11 @@
 格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)，
 并且本项目遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [Unreleased]
+
+### 修复
+- 将 `mcp` 依赖上限锁定为 `<2`，避免 `pip install` / `uv sync` 自动安装 MCP Python SDK 2.x 导致 `@app.list_tools()` 启动失败（`AttributeError: 'Server' object has no attribute 'list_tools'`）
+
 ## [1.0.1] - 2026-07-28
 
 ### 修复

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -30,8 +30,10 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.28,<2",
     "requests>=2.31.0",
+    "starlette>=0.27.0",
+    "uvicorn>=0.24.0",
 ]
 
 [project.optional-dependencies]

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -1,4 +1,4 @@
-mcp>=1.0.0
+mcp>=1.28,<2
 requests>=2.31.0
 starlette>=0.27.0
 uvicorn>=0.24.0

--- a/mcp-server/setup.py
+++ b/mcp-server/setup.py
@@ -23,7 +23,12 @@ def read_requirements():
                 line.strip() for line in f if line.strip() and not line.startswith("#")
             ]
     except FileNotFoundError:
-        return ["mcp>=1.0.0", "requests>=2.31.0"]
+        return [
+            "mcp>=1.28,<2",
+            "requests>=2.31.0",
+            "starlette>=0.27.0",
+            "uvicorn>=0.24.0",
+        ]
 
 
 setup(


### PR DESCRIPTION
## Summary
- Pin `mcp` to `>=1.28,<2` in `requirements.txt`, `pyproject.toml`, and `setup.py` fallback deps.
- Align `pyproject.toml` with HTTP transport runtime deps (`starlette`, `uvicorn`).
- Document the fix in `mcp-server/CHANGELOG.md`.

## Why
WeKnora MCP Server still uses MCP Python SDK v1 low-level `Server` decorators such as `@app.list_tools()`. MCP SDK 2.0 removed those APIs, so fresh `pip install` / `uv sync` installs can fail at startup with:

```
AttributeError: 'Server' object has no attribute 'list_tools'
```

The lower bound `1.28` keeps Streamable HTTP transport (`StreamableHTTPSessionManager`) available.

## Test plan
- [x] `uv pip install 'mcp>=1.28,<2'` resolves to a 1.x release
- [x] `import weknora_mcp_server` succeeds on MCP SDK 1.x
- [x] `python main.py --transport http` starts and serves `/mcp`