### PR TITLE
ci(mcp-server): publish on merge to main + manual, not only on tags

### DIFF
--- a/.github/workflows/mcp-server.yml
+++ b/.github/workflows/mcp-server.yml
@@ -4,7 +4,13 @@ name: Build & Publish (mcp-server)
 # Publishing uses PyPI Trusted Publishing (OIDC) — no API token required,
 # only the GitHub→PyPI OIDC trust configured on the repo.
 #
-# Release tags: mcp-server-v* (e.g. mcp-server-v1.0.1)
+# Release policy: publishing does NOT depend on tags. Bump the version in
+# mcp-server/pyproject.toml (and the synced version strings in setup.py,
+# __init__.py, weknora_mcp_server.py server_version, main.py --version),
+# merge to main, and the pipeline builds + publishes automatically.
+# A pre-publish check queries PyPI and skips upload if that version is
+# already published, so re-running on an unchanged version stays green.
+# Releases also still trigger on mcp-server-v* tags (back-compat).
 
 on:
   push:
@@ -54,7 +60,8 @@ jobs:
     name: Build sdist + wheel
     needs: test
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/mcp-server-v')
+    # Build on push to main, manual runs, and release tags — but never on PRs.
+    if: github.event_name != 'pull_request'
     defaults:
       run:
         working-directory: mcp-server
@@ -89,18 +96,51 @@ jobs:
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/mcp-server-v')
+    # Publish on push to main, manual runs, and release tags — but never on PRs.
+    if: github.event_name != 'pull_request'
     permissions:
       id-token: write
     environment:
       name: pypi
       url: https://pypi.org/project/weknora-mcp/
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Check if version is already published
+        id: check_pypi
+        working-directory: mcp-server
+        # Read the version from pyproject.toml and query PyPI. If that exact
+        # version already exists, skip publishing (so re-runs on an unchanged
+        # version stay green instead of failing with "File already exists").
+        run: |
+          set -e
+          version="$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
+          echo "packaged version: $version"
+          exists="$(python3 -c '
+          import json, sys, urllib.request
+          v = sys.argv[1]
+          try:
+              d = json.load(urllib.request.urlopen("https://pypi.org/pypi/weknora-mcp/json"))
+              print("true" if v in d.get("releases", {}) else "false")
+          except Exception:
+              # If PyPI is unreachable or the project is brand-new (404), treat as unpublished.
+              print("false")
+          ' "$version")"
+          echo "already on PyPI: $exists"
+          if [ "$exists" = "true" ]; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::weknora-mcp $version is already on PyPI; skipping publish. Bump the version to release."
+          else
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download artifacts
+        if: steps.check_pypi.outputs.should_publish == 'true'
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
+        if: steps.check_pypi.outputs.should_publish == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## 中文

### 问题
`mcp-server.yml` 的 `build`/`publish` 两个 job 被 `if: startsWith(github.ref, 'refs/tags/mcp-server-v')` 门控，而上游没有单独打 `mcp-server-v*` tag 的计划。结果是：mcp-server 代码合入 main 只会跑 test，**永远触发不了构建发布到 PyPI**，大家更新的代码发不出去。

### 修复
让发布**不再依赖 tag**，改为「合入 main 自动发布 + 手动触发」，并加版本查重避免重复上传失败。

1. **放开 `build`/`publish` 的 `if`**：`startsWith(github.ref, 'refs/tags/...')` → `github.event_name != 'pull_request'`
   - push 到 main：跑 test → build → publish
   - `workflow_dispatch`：同上（手动兜底）
   - PR：只跑 test，不 build/publish
   - `mcp-server-v*` tag：照旧发布（向后兼容，保留）

2. **新增「PyPI 版本查重」步骤**（publish job 第一步）：
   - 用 stdlib `tomllib` 读 `mcp-server/pyproject.toml` 的版本号
   - 查 `https://pypi.org/pypi/weknora-mcp/json` 看该版本是否已发布
   - 已发布 → `should_publish=false`，上传步骤跳过（带 `::notice` 提示），CI 保持绿色；未发布 → `should_publish=true`，正常上传
   - 这解决了「无 tag 模式下，版本号没变就重跑会撞 PyPI 的 `File already exists` 报错」的问题

### 发版约定（无 tag）
维护者发版只需：在 `mcp-server/pyproject.toml` 改大版本号（并同步 `setup.py`、`__init__.py`、`weknora_mcp_server.py` 的 `server_version`、`main.py` 的 `--version`）→ 合入 main → 流水线自动构建并发布到 PyPI。

### 触发矩阵（改后）
| 事件 | test | build | publish |
|---|---|---|---|
| PR | ✅ | ❌ | ❌ |
| push 到 main | ✅ | ✅ | ⚠️ 仅当版本号是 PyPI 上未发布的新版本 |
| workflow_dispatch | ✅ | ✅ | ⚠️ 同上 |
| mcp-server-v* tag | ✅ | ✅ | ⚠️ 同上（向后兼容） |

### 改动范围
仅 `.github/workflows/mcp-server.yml`（+43/−3）。`test` job、触发器、paths 过滤、OIDC/permissions、upload_paths 回归护栏、artifact 上传下载逻辑均不变。版本号本身不动（仍为 1.0.1）。

---

## English

### Problem
The `build`/`publish` jobs in `mcp-server.yml` are gated by `if: startsWith(github.ref, 'refs/tags/mcp-server-v')`, but upstream has no plan to cut `mcp-server-v*` tags. Result: merging mcp-server changes to main only runs `test` and **never triggers a build/publish to PyPI**, so new code can't ship.

### Fix
Stop depending on tags: publish on **merge to main (auto) + manual dispatch**, with a version-dedup check so re-uploads don't fail.

1. **Relax the `build`/`publish` `if`**: `startsWith(github.ref, 'refs/tags/...')` → `github.event_name != 'pull_request'`
   - push to main: test → build → publish
   - `workflow_dispatch`: same (manual fallback)
   - PR: test only, no build/publish
   - `mcp-server-v*` tag: still publishes (back-compat, kept)

2. **New "check if version already published" step** (first step of publish):
   - Reads the version from `mcp-server/pyproject.toml` via stdlib `tomllib`
   - Queries `https://pypi.org/pypi/weknora-mcp/json` to see if that version exists
   - Already published → `should_publish=false`, upload skipped (with a `::notice`), CI stays green; not published → `should_publish=true`, normal upload
   - This avoids the no-tag failure mode where re-running on an unchanged version hits PyPI's `File already exists` error

### Release policy (no tags)
To release, a maintainer bumps the version in `mcp-server/pyproject.toml` (plus the synced strings in `setup.py`, `__init__.py`, `weknora_mcp_server.py` `server_version`, `main.py` `--version`) → merges to main → the pipeline builds and publishes to PyPI automatically.

### Trigger matrix (after change)
| Event | test | build | publish |
|---|---|---|---|
| PR | ✅ | ❌ | ❌ |
| push to main | ✅ | ✅ | ⚠️ only if the version is unpublished on PyPI |
| workflow_dispatch | ✅ | ✅ | ⚠️ same |
| mcp-server-v* tag | ✅ | ✅ | ⚠️ same (back-compat) |

### Scope
Only `.github/workflows/mcp-server.yml` (+43/−3). The `test` job, triggers, paths filter, OIDC/permissions, the upload_paths regression guard, and artifact upload/download logic are unchanged. The version itself is untouched (still 1.0.1).
