### PR TITLE
feat(datasource): add DingTalk connector

### DIFF
--- a/frontend/src/components/empty-knowledge.vue
+++ b/frontend/src/components/empty-knowledge.vue
@@ -1,13 +1,35 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+
+withDefaults(defineProps<{
+    showActions?: boolean
+    showDingtalkImport?: boolean
+}>(), {
+    showActions: false,
+    showDingtalkImport: false,
+})
+
+const emit = defineEmits<{
+    uploadLocal: []
+    importDingtalk: []
+}>()
+
 const { t } = useI18n()
 </script>
 <template>
     <div class="empty">
         <img class="empty-img" src="@/assets/img/upload.svg" alt="">
-        <span class="empty-txt">{{ $t('knowledgeBase.emptyKnowledgeDragDrop') }}</span>
-        <span class="empty-type-txt">{{ $t('knowledgeBase.pdfDocFormat') }}</span>
-        <span class="empty-type-txt">{{ $t('knowledgeBase.textMarkdownFormat') }}</span>
+        <span class="empty-txt">{{ t('knowledgeBase.emptyKnowledgeDragDrop') }}</span>
+        <span class="empty-type-txt">{{ t('knowledgeBase.pdfDocFormat') }}</span>
+        <span class="empty-type-txt">{{ t('knowledgeBase.textMarkdownFormat') }}</span>
+        <div v-if="showActions" class="empty-actions">
+            <t-button theme="primary" @click="emit('uploadLocal')">
+                {{ t('knowledgeBase.uploadLocalFile') }}
+            </t-button>
+            <t-button v-if="showDingtalkImport" variant="outline" @click="emit('importDingtalk')">
+                {{ t('knowledgeBase.importFromDingtalk') }}
+            </t-button>
+        </div>
     </div>
 </template>
 <style scoped lang="less">
@@ -40,5 +62,13 @@ const { t } = useI18n()
 .empty-img {
     width: 162px;
     height: 162px;
+}
+
+.empty-actions {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    margin-top: 20px;
 }
 </style>

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -406,7 +406,13 @@ export default {
     videosFilteredNoVLM: 'Skipped {count} video file(s) (video upload is not supported)',
     unsupportedTypesHint: 'Some document types ({types}) have no available parser engine and cannot be processed',
     goToParserSettings: 'Configure',
+    uploadLocalFile: 'Upload local file',
     importURL: 'Import from URL',
+    importFromDingtalk: 'Import from DingTalk',
+    connectDingtalk: 'Connect DingTalk',
+    dingtalkSyncStarted: 'DingTalk content is being synchronized',
+    dingtalkSyncCompleted: 'DingTalk content synchronized',
+    dingtalkSyncTimeout: 'Synchronization is still running in the background',
     addDocument: 'Add Document',
     importURLTitle: 'Import from URL',
     urlRequired: 'Please enter a URL',
@@ -867,15 +873,6 @@ export default {
     editor: {
       createTitle: 'Create Agent',
       editTitle: 'Edit Agent',
-      buttons: {
-        create: 'Create Agent',
-        saveAndClose: 'Save and Close',
-      },
-      postCreateHint: {
-        title: 'Created successfully',
-        footer: 'Keep adjusting settings, configure sharing and publishing, then click "Save and Close".',
-        integrationDesc: 'Go to Integrations to configure IM, web embed, and other publishing channels',
-      },
       basicInfo: 'Basic Info',
       basicInfoDesc: 'Configure agent name, description, and run mode',
       promptsConfig: 'Prompts',
@@ -2003,33 +2000,6 @@ export default {
         'faq.import_started': 'FAQ import started',
         'faq.import_completed': 'FAQ import completed',
         'faq.import_failed': 'FAQ import failed'
-      },
-      outcomes: {
-        accepted: 'Accepted',
-        success: 'Success',
-        failed: 'Failed',
-        partial: 'Partial',
-        canceled: 'Canceled',
-        denied: 'Denied'
-      },
-      detailValues: {
-        user: 'User initiated',
-        manual: 'Manual',
-        schedule: 'Scheduled',
-        system: 'System',
-        pending: 'Pending',
-        completed: 'Completed',
-        partial: 'Partially completed',
-        canceled: 'Canceled',
-        failed: 'Failed',
-        enqueue: 'Task submission',
-        reuse_vectors: 'Reuse vectors',
-        reparse: 'Reparse',
-        viewer: 'Read-only',
-        editor: 'Can edit',
-        admin: 'Manage',
-        append: 'Append',
-        replace: 'Replace'
       }
     },
     titleCreate: 'Create Knowledge Base',
@@ -2265,13 +2235,7 @@ export default {
     },
     buttons: {
       create: 'Create Knowledge Base',
-      save: 'Save Configuration',
-      saveAndClose: 'Save and Close',
-    },
-    postCreateHint: {
-      title: 'Created successfully',
-      footer: 'Keep adjusting settings, configure sharing and data sources, then click "Save and Close".',
-      followUpDesc: 'Configure data sources on the left, or use Share Management to publish to spaces',
+      save: 'Save Configuration'
     },
     share: {
       description: 'Share the knowledge base with spaces so members can access and use it',
@@ -5128,14 +5092,16 @@ export default {
       lark: 'Lark',
       notion: 'Notion',
       yuque: 'Yuque',
-      rss: 'RSS / Atom Feed'
+      rss: 'RSS / Atom Feed',
+      dingtalk: 'DingTalk'
     },
     connectorDesc: {
       feishu: 'Sync documents, spreadsheets and files from Feishu Wiki',
       lark: 'Sync documents, spreadsheets and files from Lark Wiki (Feishu international)',
       notion: 'Sync pages and databases from Notion',
       yuque: 'Sync documents from Yuque knowledge bases',
-      rss: 'Sync articles from RSS / Atom feeds'
+      rss: 'Sync articles from RSS / Atom feeds',
+      dingtalk: 'Sync DingTalk drive files and online documents'
     },
     field: {
       appId: 'App ID',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -149,16 +149,18 @@ export default {
         denied: '拒绝'
       },
       action: {
-        'rbac.member_added': '新增成员',
-        'rbac.member_removed': '移除成员',
-        'rbac.member_role_changed': '角色变更',
-        'rbac.member_left': '成员退出',
-        'rbac.access_denied': '访问被拒',
-        'rbac.invitation_sent': '发出邀请',
-        'rbac.invitation_accepted': '接受邀请',
-        'rbac.invitation_declined': '拒绝邀请',
-        'rbac.invitation_revoked': '撤销邀请',
-        'rbac.invitation_expired': '邀请过期'
+        rbac: {
+          member_added: '新增成员',
+          member_removed: '移除成员',
+          member_role_changed: '角色变更',
+          member_left: '成员退出',
+          access_denied: '访问被拒',
+          invitation_sent: '发出邀请',
+          invitation_accepted: '接受邀请',
+          invitation_declined: '拒绝邀请',
+          invitation_revoked: '撤销邀请',
+          invitation_expired: '邀请过期'
+        }
       },
       columns: {
         time: '时间',
@@ -644,14 +646,16 @@ export default {
       lark: '同步 Lark 知识库中的文档、表格、文件（飞书国际版）',
       notion: '同步 Notion 中的页面和数据库',
       yuque: '同步语雀知识库中的文档',
-      rss: '同步 RSS / Atom 订阅源中的文章'
+      rss: '同步 RSS / Atom 订阅源中的文章',
+      dingtalk: '同步钉钉网盘文件和在线文档'
     },
     connector: {
       feishu: '飞书',
       lark: 'Lark（飞书国际版）',
       notion: 'Notion',
       yuque: '语雀',
-      rss: 'RSS / Atom 订阅'
+      rss: 'RSS / Atom 订阅',
+      dingtalk: '钉钉'
     },
     logDetail: {
       startTime: '开始时间',
@@ -2544,17 +2548,19 @@ export default {
           denied: '拒绝'
         },
         action: {
-          'system.setting_changed': '系统设置变更',
-          'system.admin_promoted': '授予系统管理员',
-          'system.api_key_created': '创建平台 API Key',
-          'system.api_key_revoked': '吊销平台 API Key',
-          'system.admin_revoked': '回收系统管理员',
-          'system.user_password_reset': '重置用户密码',
-          'system.queue_task_retried': '重新执行失败任务',
-          'system.queue_task_deleted': '清除失败任务记录',
-          'system.queue_task_run_now': '立即执行队列任务',
-          'system.queue_task_cancelled': '终止队列任务',
-          'system.queue_archived_purged': '清除全部失败任务'
+          system: {
+            setting_changed: '系统设置变更',
+            admin_promoted: '授予系统管理员',
+            api_key_created: '创建平台 API Key',
+            api_key_revoked: '吊销平台 API Key',
+            admin_revoked: '回收系统管理员',
+            user_password_reset: '重置用户密码',
+            queue_task_retried: '重新执行失败任务',
+            queue_task_deleted: '清除失败任务记录',
+            queue_task_run_now: '立即执行队列任务',
+            queue_task_cancelled: '终止队列任务',
+            queue_archived_purged: '清除全部失败任务'
+          }
         },
         columns: {
           time: '时间',
@@ -3451,13 +3457,7 @@ export default {
     },
     buttons: {
       create: '创建知识库',
-      save: '保存配置',
-      saveAndClose: '保存并关闭',
-    },
-    postCreateHint: {
-      title: '创建成功',
-      footer: '可继续调整配置，设置共享与数据源，完成后点击「保存并关闭」。',
-      followUpDesc: '可在左侧配置数据源，或在「共享管理」中发布到空间',
+      save: '保存配置'
     },
     wikiBrowser: {
       editBtn: '编辑',
@@ -3706,68 +3706,53 @@ export default {
       countItems: '共 {count} 项',
       titleWithCount: '{title} 等 {count} 项',
       importSummary: '成功 {success} / 失败 {failed} / 跳过 {skipped}',
-      detailValues: {
-        user: '用户发起',
-        manual: '手动触发',
-        schedule: '定时调度',
-        system: '系统触发',
-        pending: '待处理',
-        completed: '已完成',
-        partial: '部分完成',
-        canceled: '已取消',
-        failed: '失败',
-        enqueue: '任务提交',
-        reuse_vectors: '复用向量',
-        reparse: '重新解析',
-        viewer: '只读',
-        editor: '可编辑',
-        admin: '管理',
-        append: '追加',
-        replace: '覆盖'
-      },
-      outcomes: {
-        accepted: '已受理',
-        success: '成功',
-        failed: '失败',
-        partial: '部分完成',
-        canceled: '已取消',
-        denied: '已拒绝'
-      },
       actions: {
-        'kb.created': '创建知识库',
-        'kb.updated': '更新知识库',
-        'kb.deleted': '删除知识库',
-        'kb.duplicated': '复制知识库',
-        'kb.clone_started': '开始克隆',
-        'kb.clone_completed': '完成克隆',
-        'kb.clone_failed': '克隆失败',
-        'knowledge.created': '添加知识',
-        'knowledge.updated': '更新知识',
-        'knowledge.deleted': '删除知识',
-        'knowledge.batch_deleted': '批量删除知识',
-        'knowledge.reparse_started': '开始重新解析',
-        'knowledge.parse_canceled': '取消解析',
-        'knowledge.move_started': '开始移动知识',
-        'knowledge.move_completed': '完成移动知识',
-        'knowledge.move_failed': '移动知识失败',
-        'tag.created': '创建标签',
-        'tag.updated': '更新标签',
-        'tag.deleted': '删除标签',
-        'datasource.created': '创建数据源',
-        'datasource.updated': '更新数据源',
-        'datasource.deleted': '删除数据源',
-        'datasource.sync_started': '开始同步数据源',
-        'datasource.sync_completed': '数据源同步完成',
-        'datasource.sync_failed': '数据源同步失败',
-        'datasource.paused': '暂停数据源',
-        'datasource.resumed': '恢复数据源',
-        'kb.share_added': '添加共享',
-        'kb.share_permission_changed': '修改共享权限',
-        'kb.share_removed': '移除共享',
-        'wiki.content_changed': '更新 Wiki 内容',
-        'faq.import_started': '开始导入 FAQ',
-        'faq.import_completed': '完成导入 FAQ',
-        'faq.import_failed': '导入 FAQ 失败'
+        kb: {
+          created: '创建知识库',
+          updated: '更新知识库',
+          deleted: '删除知识库',
+          duplicated: '复制知识库',
+          clone_started: '开始克隆',
+          clone_completed: '完成克隆',
+          clone_failed: '克隆失败',
+          share_added: '添加共享',
+          share_permission_changed: '修改共享权限',
+          share_removed: '移除共享'
+        },
+        knowledge: {
+          created: '添加知识',
+          updated: '更新知识',
+          deleted: '删除知识',
+          batch_deleted: '批量删除知识',
+          reparse_started: '开始重新解析',
+          parse_canceled: '取消解析',
+          move_started: '开始移动知识',
+          move_completed: '完成移动知识',
+          move_failed: '移动知识失败'
+        },
+        tag: {
+          created: '创建标签',
+          updated: '更新标签',
+          deleted: '删除标签'
+        },
+        datasource: {
+          created: '创建数据源',
+          updated: '更新数据源',
+          deleted: '删除数据源',
+          sync_started: '开始同步数据源',
+          sync_completed: '数据源同步完成',
+          sync_failed: '数据源同步失败',
+          paused: '暂停数据源',
+          resumed: '恢复数据源'
+        },
+        wiki: {
+          content_changed: '更新 Wiki 内容'
+        },
+        faq: {
+          import_started: '开始导入 FAQ',
+          import_completed: '完成导入 FAQ',
+          import_failed: '导入 FAQ 失败'
+        }
       },
       detailFields: {
         task_id: '任务 ID',
@@ -4777,15 +4762,6 @@ export default {
     editor: {
       createTitle: '创建智能体',
       editTitle: '编辑智能体',
-      buttons: {
-        create: '创建智能体',
-        saveAndClose: '保存并关闭',
-      },
-      postCreateHint: {
-        title: '创建成功',
-        footer: '可继续调整配置，设置共享与发布渠道，完成后点击「保存并关闭」。',
-        integrationDesc: '前往集成中心配置 IM、网页嵌入等发布渠道',
-      },
       basicInfo: '基本信息',
       basicInfoDesc: '配置智能体的名称、描述与运行模式',
       promptsConfig: '提示词',
@@ -5152,7 +5128,13 @@ export default {
     videosFilteredNoVLM: '已跳过 {count} 个视频文件（暂不支持视频上传）',
     unsupportedTypesHint: '部分文档类型（{types}）暂无可用解析引擎，上传后将无法解析',
     goToParserSettings: '前往配置',
+    uploadLocalFile: '上传本地文件',
     importURL: '导入网页',
+    importFromDingtalk: '从钉钉导入',
+    connectDingtalk: '连接钉钉',
+    dingtalkSyncStarted: '钉钉内容正在同步',
+    dingtalkSyncCompleted: '钉钉内容同步完成',
+    dingtalkSyncTimeout: '同步仍在后台进行，可稍后刷新查看',
     addDocument: '添加文档',
     importURLTitle: '导入网页',
     urlRequired: '请输入URL',

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -42,6 +42,7 @@ import DocumentListView from './components/DocumentListView.vue';
 import DocumentCardView from './components/DocumentCardView.vue';
 import DocumentBatchBar from './components/DocumentBatchBar.vue';
 import KbUploadSourceDropdown from './components/KbUploadSourceDropdown.vue';
+import DataSourceEditorDialog from './settings/DataSourceEditorDialog.vue';
 import TagEditDialog from './components/TagEditDialog.vue';
 import BatchTagDialog from './components/BatchTagDialog.vue';
 import KbTagManageDrawer from './components/KbTagManageDrawer.vue';
@@ -282,6 +283,10 @@ const canManage = computed(() => {
   if (authStore.hasRole('admin')) return true;
   return orgStore.canManageKB(kbId.value, false);
 });
+
+const canManageDataSource = computed(() =>
+  authStore.hasRole('admin')
+);
 
 // The activity feed exposes owner-side actor and configuration summaries.
 // It lives in KB settings (KnowledgeBaseEditorModal) for Owner/Admin in the home tenant.
@@ -1090,6 +1095,7 @@ onUnmounted(() => {
   window.removeEventListener('weknora:knowledge-file-drop', handleKnowledgeFileDrop as EventListener);
   window.removeEventListener('weknora:open-knowledge', handleOpenKnowledgeEvent as EventListener);
   stopMovePoll();
+  stopDingtalkImportPolling();
   if (timeout !== null) {
     clearTimeout(timeout);
     timeout = null;
@@ -1627,6 +1633,61 @@ const handleManualCreate = () => {
     onSuccess: manualEditorSuccess,
   });
 };
+
+const dingtalkImportVisible = ref(false);
+let dingtalkImportPollTimer: ReturnType<typeof setInterval> | null = null;
+let dingtalkImportPollCount = 0;
+let dingtalkImportBaselineTotal = 0;
+
+function stopDingtalkImportPolling() {
+  if (dingtalkImportPollTimer) {
+    clearInterval(dingtalkImportPollTimer);
+    dingtalkImportPollTimer = null;
+  }
+}
+
+function openLocalUploadFromEmpty() {
+  if (!ensureDocumentKbReady()) return;
+  (uploadSourceRef.value as any)?.openFileDialog?.();
+}
+
+function openDingtalkImport() {
+  if (!kbId.value) return;
+  dingtalkImportVisible.value = true;
+}
+
+async function pollDingtalkImportOnce() {
+  if (!kbId.value) return;
+  dingtalkImportPollCount += 1;
+  resetPage();
+  await loadKnowledgeFiles(kbId.value);
+  if (total.value > dingtalkImportBaselineTotal) {
+    stopDingtalkImportPolling();
+    MessagePlugin.success(t('knowledgeBase.dingtalkSyncCompleted'));
+    return;
+  }
+  if (dingtalkImportPollCount >= 20) {
+    stopDingtalkImportPolling();
+    MessagePlugin.info(t('knowledgeBase.dingtalkSyncTimeout'));
+  }
+}
+
+async function handleDingtalkImportSaved() {
+  dingtalkImportVisible.value = false;
+  MessagePlugin.info(t('knowledgeBase.dingtalkSyncStarted'));
+  dingtalkImportBaselineTotal = total.value || 0;
+  dingtalkImportPollCount = 0;
+  stopDingtalkImportPolling();
+  resetPage();
+  await loadKnowledgeFiles(kbId.value);
+  if (total.value > dingtalkImportBaselineTotal) {
+    MessagePlugin.success(t('knowledgeBase.dingtalkSyncCompleted'));
+    return;
+  }
+  dingtalkImportPollTimer = setInterval(() => {
+    void pollDingtalkImportOnce();
+  }, 3000);
+}
 
 const handleOpenKBSettings = () => {
   if (!kbId.value) {
@@ -2310,7 +2371,8 @@ async function createNewSession(value: string): Promise<void> {
                       :supported-file-types="[...supportedFileTypes]" include-manual trigger-icon="file-add"
                       trigger-class="content-bar-icon-btn" data-guide="kb-detail-add-doc"
                       :tooltip="t('knowledgeBase.addDocument')" placement="bottom-right" @files="handleUploadSourceFiles"
-                      @url="handleUploadSourceUrl" @manual="handleManualCreate" />
+                      :include-dingtalk="canManageDataSource"
+                      @url="handleUploadSourceUrl" @manual="handleManualCreate" @dingtalk="openDingtalkImport" />
                   </div>
                 </div>
               </div>
@@ -2384,7 +2446,12 @@ async function createNewSession(value: string): Promise<void> {
                 </template>
                 <template v-else-if="!docListLoading">
                   <div class="doc-empty-state">
-                    <EmptyKnowledge />
+                    <EmptyKnowledge
+                      :show-actions="canEdit"
+                      :show-dingtalk-import="canManageDataSource"
+                      @upload-local="openLocalUploadFromEmpty"
+                      @import-dingtalk="openDingtalkImport"
+                    />
                   </div>
                 </template>
               </div>
@@ -2416,6 +2483,14 @@ async function createNewSession(value: string): Promise<void> {
   <KnowledgeBaseEditorModal :visible="uiStore.showKBEditorModal" :mode="uiStore.kbEditorMode"
     :kb-id="uiStore.currentKBId || undefined" :initial-type="uiStore.kbEditorType"
     @update:visible="(val) => val ? null : uiStore.closeKBEditor()" @success="handleKBEditorSuccess" />
+
+  <DataSourceEditorDialog
+    v-model:visible="dingtalkImportVisible"
+    :kb-id="kbId"
+    :data-source="null"
+    initial-type="dingtalk"
+    @saved="handleDingtalkImportSaved"
+  />
 
   <ContextualGuide tour="kbDetail" :when="showKbDetailContextualGuide" />
 

--- a/frontend/src/views/knowledge/components/KbUploadSourceDropdown.vue
+++ b/frontend/src/views/knowledge/components/KbUploadSourceDropdown.vue
@@ -65,11 +65,13 @@ import { ref, computed, h } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { MessagePlugin, Icon as TIcon } from 'tdesign-vue-next'
 import { filterUploadFiles } from '../utils/uploadSources'
+import dingtalkIcon from '@/assets/img/im/dingtalk.svg'
 
 const props = withDefaults(defineProps<{
   acceptFileTypes?: string
   supportedFileTypes?: string[]
   includeManual?: boolean
+  includeDingtalk?: boolean
   triggerIcon?: string
   triggerClass?: string
   dataGuide?: string
@@ -79,6 +81,7 @@ const props = withDefaults(defineProps<{
   acceptFileTypes: '',
   supportedFileTypes: () => [],
   includeManual: false,
+  includeDingtalk: false,
   triggerIcon: 'file-add',
   triggerClass: '',
   dataGuide: '',
@@ -90,6 +93,7 @@ const emit = defineEmits<{
   files: [files: File[]]
   url: [url: string]
   manual: []
+  dingtalk: []
 }>()
 
 const { t } = useI18n()
@@ -126,6 +130,13 @@ const dropdownOptions = computed(() => {
       prefixIcon: () => h(TIcon, { name: 'edit', size: '16px' }),
     })
   }
+  if (props.includeDingtalk) {
+    options.push({
+      content: t('knowledgeBase.importFromDingtalk'),
+      value: 'importDingtalk',
+      prefixIcon: () => h('img', { src: dingtalkIcon, class: 'dropdown-dingtalk-icon', alt: '' }),
+    })
+  }
   return options
 })
 
@@ -143,6 +154,9 @@ const handleActionSelect = (data: { value: string }) => {
       break
     case 'manualCreate':
       emit('manual')
+      break
+    case 'importDingtalk':
+      emit('dingtalk')
       break
     default:
       break
@@ -213,7 +227,11 @@ const openUrlDialog = () => {
   urlDialogVisible.value = true
 }
 
-defineExpose({ openUrlDialog })
+const openFileDialog = () => {
+  fileInputRef.value?.click()
+}
+
+defineExpose({ openUrlDialog, openFileDialog })
 </script>
 
 <style lang="less" scoped>
@@ -247,5 +265,11 @@ defineExpose({ openUrlDialog })
     line-height: 1.5;
     color: var(--td-text-color-placeholder);
   }
+}
+
+:deep(.dropdown-dingtalk-icon) {
+  width: 16px;
+  height: 16px;
+  object-fit: contain;
 }
 </style>

--- a/frontend/src/views/knowledge/settings/DataSourceEditorDialog.vue
+++ b/frontend/src/views/knowledge/settings/DataSourceEditorDialog.vue
@@ -23,6 +23,7 @@ import { getDatasourceIconUrl } from './datasourceIcons'
 const props = defineProps<{
   kbId: string
   dataSource: DataSource | null
+  initialType?: string
 }>()
 
 const visible = defineModel<boolean>('visible', { default: false })
@@ -30,6 +31,7 @@ const emit = defineEmits<{ saved: [] }>()
 const { t } = useI18n()
 
 const isEdit = computed(() => !!props.dataSource)
+const isInitialTypeCreate = computed(() => !isEdit.value && !!props.initialType)
 const step = ref(0)
 const submitting = ref(false)
 
@@ -323,6 +325,7 @@ const tempDsId = ref('')
 
 // Schedule presets
 const schedulePresets = computed(() => [
+  { label: t('datasource.schedule15min'), value: '0 */15 * * * *' },
   { label: t('datasource.schedule30min'), value: '0 */30 * * * *' },
   { label: t('datasource.schedule1h'), value: '0 0 * * * *' },
   { label: t('datasource.schedule6h'), value: '0 0 */6 * * *' },
@@ -425,6 +428,25 @@ const connectorDefs = computed<ConnectorDef[]>(() => [
       { key: 'auth_headers', labelKey: 'datasource.field.authHeaders', placeholder: '', optional: true, hintKey: 'datasource.field.authHeadersHint', fieldType: 'custom_headers' },
     ],
   },
+  {
+    type: 'dingtalk',
+    available: true,
+    docUrl: 'https://open-dev.dingtalk.com/',
+    permissionDocUrl: 'https://open.dingtalk.com/document/orgapp-server/authorization-overview',
+    permissionPageUrl: 'https://open-dev.dingtalk.com/',
+    requiredPermissions: [
+      'qyapi_base',
+      'Drive.Space.Read',
+      'Storage.File.Read',
+      'Drive.DownloadInfo.Read',
+      'Document.WorkspaceDocument.Read',
+    ],
+    fields: [
+      { key: 'client_id', labelKey: 'datasource.field.clientId', placeholder: 'dingxxxx' },
+      { key: 'app_secret', labelKey: 'datasource.field.appSecret', placeholder: '', secret: true },
+      { key: 'union_id', labelKey: 'datasource.field.unionId', placeholder: '50qorRtuCvi...' },
+    ],
+  },
 ])
 
 
@@ -495,6 +517,12 @@ watch(visible, async (v) => {
       conflict_strategy: 'overwrite',
       sync_deletions: true,
     }
+    const def = connectorDefs.value.find(
+      item => item.type === props.initialType && item.available,
+    )
+    if (def) {
+      selectType(def)
+    }
   }
 })
 
@@ -536,6 +564,9 @@ function selectType(def: ConnectorDef) {
   form.value.type = def.type
   form.value.name = t(`datasource.connector.${def.type}`)
   form.value.config.credentials = {}
+  if (def.type === 'dingtalk') {
+    form.value.sync_schedule = '0 */15 * * * *'
+  }
   rssAuthHeaders.value = []
   step.value = 1
 }
@@ -944,7 +975,9 @@ const stepTitles = computed(() => [
 ])
 
 const drawerTitle = computed(() =>
-  isEdit.value ? t('datasource.editTitle') : t('datasource.createTitle'),
+  !isEdit.value && props.initialType === 'dingtalk'
+    ? t('knowledgeBase.connectDingtalk')
+    : (isEdit.value ? t('datasource.editTitle') : t('datasource.createTitle')),
 )
 
 const drawerDescription = computed(() => stepTitles.value[step.value] ?? '')
@@ -981,7 +1014,7 @@ const drawerConfirmText = computed(() => {
     </template>
 
     <template v-if="step === 1" #footer-left>
-      <t-button v-if="!isEdit" variant="outline" @click="step = 0">
+      <t-button v-if="!isEdit && !isInitialTypeCreate" variant="outline" @click="step = 0">
         {{ t('datasource.back') }}
       </t-button>
       <t-button variant="outline" :loading="testing" @click="testConnection">

--- a/frontend/src/views/knowledge/settings/datasourceIcons.ts
+++ b/frontend/src/views/knowledge/settings/datasourceIcons.ts
@@ -3,6 +3,7 @@ import larkIcon from '@/assets/img/datasource-lark.svg'
 import notionIcon from '@/assets/img/datasource-notion.ico'
 import yuqueIcon from '@/assets/img/datasource-yuque.ico'
 import rssIcon from '@/assets/img/datasource-rss.svg'
+import dingtalkIcon from '@/assets/img/im/dingtalk.svg'
 
 export const datasourceIconMap: Record<string, string> = {
   feishu: feishuIcon,
@@ -10,6 +11,7 @@ export const datasourceIconMap: Record<string, string> = {
   notion: notionIcon,
   yuque: yuqueIcon,
   rss: rssIcon,
+  dingtalk: dingtalkIcon,
 }
 
 export function getDatasourceIconUrl(type: string): string | undefined {

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -54,6 +54,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/database"
 	"github.com/Tencent/WeKnora/internal/datasource"
+	dingtalkConnector "github.com/Tencent/WeKnora/internal/datasource/connector/dingtalk"
 	feishuConnector "github.com/Tencent/WeKnora/internal/datasource/connector/feishu"
 	notionConnector "github.com/Tencent/WeKnora/internal/datasource/connector/notion"
 	rssConnector "github.com/Tencent/WeKnora/internal/datasource/connector/rss"
@@ -1593,6 +1594,9 @@ func initConnectorRegistry() (*datasource.ConnectorRegistry, error) {
 	}
 	if err := registry.Register(rssConnector.NewConnector()); err != nil {
 		errs = errors.Join(errs, fmt.Errorf("register rss connector: %w", err))
+	}
+	if err := registry.Register(dingtalkConnector.NewConnector()); err != nil {
+		errs = errors.Join(errs, fmt.Errorf("register dingtalk connector: %w", err))
 	}
 
 	// Future connectors will be registered here:

--- a/internal/datasource/connector/dingtalk/client.go
+++ b/internal/datasource/connector/dingtalk/client.go
@@ -1,0 +1,529 @@
+package dingtalk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/datasource"
+)
+
+const userAgent = "WeKnora-DingTalk-Connector/1.0"
+
+type client struct {
+	baseURL    string
+	clientID   string
+	appSecret  string
+	unionID    string
+	httpClient *http.Client
+}
+
+func newClient(cfg *Config) *client {
+	return &client{
+		baseURL:    cfg.BaseURL,
+		clientID:   cfg.ClientID,
+		appSecret:  cfg.AppSecret,
+		unionID:    cfg.UnionID,
+		httpClient: datasource.NewConnectorHTTPClient(90 * time.Second),
+	}
+}
+
+func (c *client) accessToken(ctx context.Context) (string, error) {
+	var resp map[string]interface{}
+	if err := c.doJSON(ctx, http.MethodPost, "/v1.0/oauth2/accessToken", "", map[string]string{
+		"appKey":    c.clientID,
+		"appSecret": c.appSecret,
+	}, &resp); err != nil {
+		return "", err
+	}
+	token := firstString(resp, "access_token", "accessToken")
+	if token == "" {
+		return "", fmt.Errorf("dingtalk access_token missing")
+	}
+	return token, nil
+}
+
+func (c *client) listSpaces(ctx context.Context, token string) ([]space, error) {
+	var out []space
+	next := ""
+	for {
+		q := url.Values{}
+		q.Set("unionId", c.unionID)
+		q.Set("spaceType", "org")
+		q.Set("maxResults", "50")
+		if next != "" {
+			q.Set("nextToken", next)
+		}
+		var resp map[string]interface{}
+		if err := c.doJSON(ctx, http.MethodGet, "/v1.0/drive/spaces?"+q.Encode(), token, nil, &resp); err != nil {
+			return nil, err
+		}
+		for _, raw := range firstArray(resp, "spaces", "items", "data", "result") {
+			item := unwrap(raw)
+			id := firstString(item, "spaceId", "id")
+			if id == "" {
+				continue
+			}
+			name := firstString(item, "spaceName", "name", "title")
+			if name == "" {
+				name = id
+			}
+			out = append(out, space{ID: id, Name: name})
+		}
+		next = firstString(resp, "nextToken")
+		if next == "" {
+			next = firstString(asMap(resp["result"]), "nextToken")
+		}
+		if next == "" {
+			break
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no DingTalk drive spaces found for unionId %s", c.unionID)
+	}
+	return out, nil
+}
+
+func (c *client) listAllEntries(ctx context.Context, token, spaceID string, limit int) ([]driveEntry, error) {
+	entries, err := c.listAllStorageEntries(ctx, token, spaceID, limit)
+	if err == nil {
+		return entries, nil
+	}
+	legacy, legacyErr := c.listAllDriveEntries(ctx, token, spaceID, limit)
+	if legacyErr != nil {
+		return nil, fmt.Errorf("storage API failed: %v; drive API failed: %w", err, legacyErr)
+	}
+	return legacy, nil
+}
+
+func (c *client) listAllStorageEntries(ctx context.Context, token, spaceID string, limit int) ([]driveEntry, error) {
+	var out []driveEntry
+	next := ""
+	for {
+		option := map[string]interface{}{
+			"maxResults":    50,
+			"order":         "DESC",
+			"withThumbnail": false,
+		}
+		if next != "" {
+			option["nextToken"] = next
+		}
+		path := "/v1.0/storage/spaces/" + url.PathEscape(spaceID) +
+			"/dentries/listAll?unionId=" + url.QueryEscape(c.unionID)
+		var resp map[string]interface{}
+		if err := c.doJSON(ctx, http.MethodPost, path, token, map[string]interface{}{"option": option}, &resp); err != nil {
+			return nil, err
+		}
+		for _, raw := range firstArray(resp, "dentries", "items", "data", "result") {
+			entry := parseDriveEntry(raw)
+			if entry.ID == "" {
+				continue
+			}
+			out = append(out, entry)
+			if len(out) >= limit {
+				return nil, fmt.Errorf("DingTalk directory contains more than %d entries", limit)
+			}
+		}
+		next = firstString(resp, "nextToken")
+		if next == "" {
+			next = firstString(asMap(resp["result"]), "nextToken")
+		}
+		if next == "" {
+			next = firstString(asMap(resp["data"]), "nextToken")
+		}
+		if next == "" {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (c *client) listAllDriveEntries(ctx context.Context, token, spaceID string, limit int) ([]driveEntry, error) {
+	var out []driveEntry
+	queue := []string{"0"}
+	seen := map[string]bool{}
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+		if seen[parent] {
+			continue
+		}
+		seen[parent] = true
+		next := ""
+		for {
+			q := url.Values{}
+			q.Set("parentId", parent)
+			q.Set("maxResults", "100")
+			q.Set("unionId", c.unionID)
+			if next != "" {
+				q.Set("nextToken", next)
+			}
+			path := "/v1.0/drive/spaces/" + url.PathEscape(spaceID) + "/files?" + q.Encode()
+			var resp map[string]interface{}
+			if err := c.doJSON(ctx, http.MethodGet, path, token, nil, &resp); err != nil {
+				return nil, err
+			}
+			for _, raw := range firstArray(resp, "files", "items", "data", "result") {
+				entry := parseDriveEntry(raw)
+				if entry.ID == "" {
+					continue
+				}
+				out = append(out, entry)
+				if entry.isFolder() {
+					queue = append(queue, entry.ID)
+				}
+				if len(out) >= limit {
+					return nil, fmt.Errorf("DingTalk directory contains more than %d entries", limit)
+				}
+			}
+			next = firstString(resp, "nextToken")
+			if next == "" {
+				next = firstString(asMap(resp["result"]), "nextToken")
+			}
+			if next == "" {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (c *client) downloadInfo(ctx context.Context, token, spaceID, fileID string) (string, map[string]string, error) {
+	path := "/v1.0/storage/spaces/" + url.PathEscape(spaceID) + "/dentries/" +
+		url.PathEscape(fileID) + "/downloadInfos/query?unionId=" + url.QueryEscape(c.unionID)
+	var resp map[string]interface{}
+	err := c.doJSON(ctx, http.MethodPost, path, token,
+		map[string]interface{}{"option": map[string]interface{}{"preferIntranet": false}}, &resp)
+	if err != nil {
+		legacyPath := "/v1.0/drive/spaces/" + url.PathEscape(spaceID) + "/files/" +
+			url.PathEscape(fileID) + "/downloadInfos?unionId=" + url.QueryEscape(c.unionID)
+		if legacyErr := c.doJSON(ctx, http.MethodGet, legacyPath, token, nil, &resp); legacyErr != nil {
+			return "", nil, fmt.Errorf("storage downloadInfo failed: %v; drive downloadInfo failed: %w", err, legacyErr)
+		}
+	}
+	node := asMap(resp["downloadInfo"])
+	if len(node) == 0 {
+		node = asMap(resp["result"])
+	}
+	if len(node) == 0 {
+		node = resp
+	}
+	downloadURL := firstString(node, "resourceUrl", "downloadUrl", "url", "downloadURL")
+	if downloadURL == "" {
+		downloadURL = firstArrayURL(node, "resourceUrls", "internalResourceUrls", "urls")
+	}
+	if downloadURL == "" {
+		downloadURL = firstStringRecursive(resp, "resourceUrl", "downloadUrl", "url", "downloadURL")
+	}
+	if downloadURL == "" {
+		return "", nil, fmt.Errorf("DingTalk download URL missing")
+	}
+	headers := map[string]string{}
+	for k, v := range asMap(node["headers"]) {
+		if s, ok := v.(string); ok {
+			headers[k] = s
+		}
+	}
+	return downloadURL, headers, nil
+}
+
+func (c *client) download(ctx context.Context, rawURL string, headers map[string]string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("download HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFileBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxFileBytes {
+		return nil, fmt.Errorf("file exceeds 50MB")
+	}
+	return body, nil
+}
+
+func (c *client) readDocument(ctx context.Context, token, documentID string) ([]byte, error) {
+	path := "/v1.0/doc/suites/documents/" + url.PathEscape(documentID) +
+		"/blocks?operatorId=" + url.QueryEscape(c.unionID)
+	var resp map[string]interface{}
+	if err := c.doJSON(ctx, http.MethodGet, path, token, nil, &resp); err != nil {
+		return nil, err
+	}
+	var texts []string
+	collectText(resp, &texts)
+	content := strings.TrimSpace(strings.Join(texts, "\n"))
+	if content == "" {
+		return nil, fmt.Errorf("DingTalk document has no readable text blocks")
+	}
+	return []byte(content), nil
+}
+
+func (c *client) doJSON(ctx context.Context, method, path, token string, payload interface{}, out interface{}) error {
+	var payloadBytes []byte
+	if payload != nil {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		payloadBytes = b
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		var body io.Reader
+		if payloadBytes != nil {
+			body = bytes.NewReader(payloadBytes)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", userAgent)
+		if token != "" {
+			req.Header.Set("x-acs-dingtalk-access-token", token)
+		}
+		if payloadBytes != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			if sleepErr := sleepCtx(ctx, time.Duration(attempt+1)*800*time.Millisecond); sleepErr != nil {
+				return sleepErr
+			}
+			continue
+		}
+		data, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return readErr
+		}
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("DingTalk API temporary failure HTTP %d: %s", resp.StatusCode, truncate(string(data), 300))
+			if attempt < 2 {
+				if sleepErr := sleepCtx(ctx, time.Duration(attempt+1)*800*time.Millisecond); sleepErr != nil {
+					return sleepErr
+				}
+				continue
+			}
+		}
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return fmt.Errorf("%w: DingTalk permission denied HTTP %d: %s", datasource.ErrInvalidCredentials, resp.StatusCode, truncate(string(data), 500))
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("DingTalk API HTTP %d: %s", resp.StatusCode, truncate(string(data), 500))
+		}
+		if out != nil && len(data) > 0 {
+			if err := json.Unmarshal(data, out); err != nil {
+				return fmt.Errorf("decode DingTalk response: %w", err)
+			}
+		}
+		return nil
+	}
+	return lastErr
+}
+
+func parseDriveEntry(raw interface{}) driveEntry {
+	node := unwrap(raw)
+	modified := firstTime(node, "modifyTime", "modifiedTime", "updatedAt", "modifiedAt")
+	return driveEntry{
+		ID:         firstString(node, "dentryId", "fileId", "nodeId", "id"),
+		ParentID:   firstString(node, "parentId", "parentDentryId", "parentNodeId"),
+		Name:       firstString(node, "name", "fileName", "title"),
+		Path:       firstString(node, "filePath", "path", "displayPath"),
+		Type:       firstString(node, "fileType", "dentryType", "type", "entryType"),
+		MediaType:  firstString(node, "mediaType", "mimeType", "contentType", "fileExtension", "extension", "category"),
+		Size:       firstInt64(node, "size", "fileSize", "sizeBytes"),
+		ModifiedAt: modified,
+		Version:    firstString(node, "version", "revision", "versionId"),
+		URL:        firstString(node, "url", "webUrl", "shareUrl"),
+		DocKey:     firstString(node, "docKey", "documentId", "nodeId", "uuid"),
+	}
+}
+
+func unwrap(raw interface{}) map[string]interface{} {
+	node := asMap(raw)
+	if child := asMap(node["dentry"]); len(child) > 0 {
+		return child
+	}
+	if child := asMap(node["item"]); len(child) > 0 {
+		return child
+	}
+	return node
+}
+
+func asMap(raw interface{}) map[string]interface{} {
+	if m, ok := raw.(map[string]interface{}); ok {
+		return m
+	}
+	return map[string]interface{}{}
+}
+
+func firstString(m map[string]interface{}, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := m[k]; ok {
+			switch t := v.(type) {
+			case string:
+				if strings.TrimSpace(t) != "" {
+					return strings.TrimSpace(t)
+				}
+			case float64:
+				return strconv.FormatInt(int64(t), 10)
+			case json.Number:
+				return t.String()
+			}
+		}
+	}
+	return ""
+}
+
+func firstArray(m map[string]interface{}, keys ...string) []interface{} {
+	for _, key := range keys {
+		if arr, ok := m[key].([]interface{}); ok {
+			return arr
+		}
+		for _, child := range []string{"result", "data"} {
+			if arr, ok := asMap(m[child])[key].([]interface{}); ok {
+				return arr
+			}
+		}
+	}
+	return nil
+}
+
+func firstArrayURL(m map[string]interface{}, keys ...string) string {
+	for _, key := range keys {
+		arr, ok := m[key].([]interface{})
+		if !ok || len(arr) == 0 {
+			continue
+		}
+		if s, ok := arr[0].(string); ok {
+			return s
+		}
+		if s := firstString(asMap(arr[0]), "url", "resourceUrl", "downloadUrl"); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func firstStringRecursive(raw interface{}, keys ...string) string {
+	if m, ok := raw.(map[string]interface{}); ok {
+		if s := firstString(m, keys...); s != "" {
+			return s
+		}
+		for _, v := range m {
+			if s := firstStringRecursive(v, keys...); s != "" {
+				return s
+			}
+		}
+	}
+	if arr, ok := raw.([]interface{}); ok {
+		for _, v := range arr {
+			if s := firstStringRecursive(v, keys...); s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+func firstInt64(m map[string]interface{}, keys ...string) int64 {
+	for _, k := range keys {
+		switch v := m[k].(type) {
+		case float64:
+			return int64(v)
+		case int64:
+			return v
+		case json.Number:
+			n, _ := v.Int64()
+			return n
+		case string:
+			n, _ := strconv.ParseInt(v, 10, 64)
+			return n
+		}
+	}
+	return 0
+}
+
+func firstTime(m map[string]interface{}, keys ...string) time.Time {
+	for _, k := range keys {
+		switch v := m[k].(type) {
+		case float64:
+			raw := int64(v)
+			if raw > 9999999999 {
+				return time.UnixMilli(raw)
+			}
+			return time.Unix(raw, 0)
+		case string:
+			if t, err := time.Parse(time.RFC3339, v); err == nil {
+				return t
+			}
+			if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+				if n > 9999999999 {
+					return time.UnixMilli(n)
+				}
+				return time.Unix(n, 0)
+			}
+		}
+	}
+	return time.Time{}
+}
+
+func collectText(raw interface{}, out *[]string) {
+	switch node := raw.(type) {
+	case map[string]interface{}:
+		for k, v := range node {
+			if k == "text" {
+				if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+					*out = append(*out, strings.TrimSpace(s))
+					continue
+				}
+			}
+			collectText(v, out)
+		}
+	case []interface{}:
+		for _, v := range node {
+			collectText(v, out)
+		}
+	}
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/internal/datasource/connector/dingtalk/connector.go
+++ b/internal/datasource/connector/dingtalk/connector.go
@@ -1,0 +1,471 @@
+package dingtalk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/datasource"
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+var _ datasource.Connector = (*Connector)(nil)
+
+type Connector struct{}
+
+func NewConnector() *Connector { return &Connector{} }
+
+func (c *Connector) Type() string { return types.ConnectorTypeDingTalk }
+
+func (c *Connector) Validate(ctx context.Context, config *types.DataSourceConfig) error {
+	cfg, err := parseConfig(config)
+	if err != nil {
+		return err
+	}
+	cli := newClient(cfg)
+	token, err := cli.accessToken(ctx)
+	if err != nil {
+		return fmt.Errorf("dingtalk access token failed: %w", err)
+	}
+	if _, err := cli.listSpaces(ctx, token); err != nil {
+		return fmt.Errorf("dingtalk list spaces failed: %w", err)
+	}
+	return nil
+}
+
+func (c *Connector) ListResources(ctx context.Context, config *types.DataSourceConfig, parentID string) ([]types.Resource, error) {
+	cfg, err := parseConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	cli := newClient(cfg)
+	token, err := cli.accessToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if parentID == "" {
+		spaces, err := cli.listSpaces(ctx, token)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]types.Resource, 0, len(spaces))
+		for _, sp := range spaces {
+			out = append(out, types.Resource{
+				ExternalID:  resourceID(resourceKindSpace, sp.ID, ""),
+				Name:        sp.Name,
+				Type:        "space",
+				Description: sp.ID,
+				URL:         "https://alidocs.dingtalk.com/i/drive/" + sp.ID + "/0",
+				HasChildren: true,
+				Metadata:    map[string]interface{}{"space_id": sp.ID},
+			})
+		}
+		return out, nil
+	}
+
+	kind, spaceID, fileID := parseResourceID(parentID)
+	if kind == "" || spaceID == "" {
+		return nil, fmt.Errorf("%w: invalid DingTalk resource id %q", datasource.ErrResourceNotFound, parentID)
+	}
+	entries, err := cli.listAllEntries(ctx, token, spaceID, maxDriveEntries)
+	if err != nil {
+		return nil, err
+	}
+	parentFileID := "0"
+	if kind == resourceKindFile {
+		parentFileID = fileID
+	}
+	out := make([]types.Resource, 0)
+	for _, entry := range entries {
+		if entry.ParentID != parentFileID {
+			continue
+		}
+		out = append(out, entryToResource(spaceID, parentID, entry))
+	}
+	return out, nil
+}
+
+func (c *Connector) ResolveResourceAncestors(ctx context.Context, config *types.DataSourceConfig, resourceIDs []string) ([]string, error) {
+	cfg, err := parseConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	cli := newClient(cfg)
+	token, err := cli.accessToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+	needed := map[string]bool{}
+	for _, id := range resourceIDs {
+		kind, spaceID, fileID := parseResourceID(id)
+		if kind == resourceKindSpace {
+			continue
+		}
+		if kind != resourceKindFile || spaceID == "" || fileID == "" {
+			continue
+		}
+		needed[resourceID(resourceKindSpace, spaceID, "")] = true
+		entries, err := cli.listAllEntries(ctx, token, spaceID, maxDriveEntries)
+		if err != nil {
+			return nil, err
+		}
+		byID := make(map[string]driveEntry, len(entries))
+		for _, entry := range entries {
+			byID[entry.ID] = entry
+		}
+		for cur := byID[fileID].ParentID; cur != "" && cur != "0"; cur = byID[cur].ParentID {
+			needed[resourceID(resourceKindFile, spaceID, cur)] = true
+		}
+	}
+	out := make([]string, 0, len(needed))
+	for id := range needed {
+		out = append(out, id)
+	}
+	slices.Sort(out)
+	return out, nil
+}
+
+func (c *Connector) FetchAll(ctx context.Context, config *types.DataSourceConfig, resourceIDs []string) ([]types.FetchedItem, error) {
+	items, _, err := c.walk(ctx, config, resourceIDs, nil, false)
+	return items, err
+}
+
+func (c *Connector) FetchIncremental(ctx context.Context, config *types.DataSourceConfig, cursor *types.SyncCursor) ([]types.FetchedItem, *types.SyncCursor, error) {
+	var prev *dingtalkCursor
+	if cursor != nil && cursor.ConnectorCursor != nil {
+		b, err := json.Marshal(cursor.ConnectorCursor)
+		if err == nil {
+			var parsed dingtalkCursor
+			if json.Unmarshal(b, &parsed) == nil {
+				prev = &parsed
+			}
+		}
+	}
+	items, next, err := c.walk(ctx, config, config.ResourceIDs, prev, true)
+	if next == nil {
+		return items, nil, err
+	}
+	cursorMap := make(map[string]interface{})
+	if b, marshalErr := json.Marshal(next); marshalErr == nil {
+		_ = json.Unmarshal(b, &cursorMap)
+	}
+	return items, &types.SyncCursor{
+		LastSyncTime:    next.LastSyncTime,
+		ConnectorCursor: cursorMap,
+	}, err
+}
+
+func (c *Connector) walk(
+	ctx context.Context,
+	config *types.DataSourceConfig,
+	resourceIDs []string,
+	prev *dingtalkCursor,
+	incremental bool,
+) ([]types.FetchedItem, *dingtalkCursor, error) {
+	cfg, err := parseConfig(config)
+	if err != nil {
+		return nil, nil, err
+	}
+	cli := newClient(cfg)
+	token, err := cli.accessToken(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(resourceIDs) == 0 {
+		spaces, err := cli.listSpaces(ctx, token)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, sp := range spaces {
+			resourceIDs = append(resourceIDs, resourceID(resourceKindSpace, sp.ID, ""))
+		}
+	}
+
+	next := &dingtalkCursor{LastSyncTime: time.Now().UTC(), FileSignals: map[string]string{}}
+	var out []types.FetchedItem
+	var details []string
+	seen := map[string]bool{}
+
+	for _, rid := range resourceIDs {
+		items, signals, err := c.fetchResource(ctx, cli, token, rid, prev, incremental, config.MultimodalEnabled)
+		for k, v := range signals {
+			next.FileSignals[k] = v
+			seen[k] = true
+		}
+		out = append(out, items...)
+		if err != nil {
+			details = append(details, err.Error())
+		}
+	}
+
+	if incremental && prev != nil && len(prev.FileSignals) > 0 {
+		for id := range prev.FileSignals {
+			if !seen[id] {
+				out = append(out, types.FetchedItem{
+					ExternalID: id,
+					IsDeleted:  true,
+					Metadata:   map[string]string{"channel": types.ChannelDingtalk},
+				})
+			}
+		}
+	}
+
+	if len(details) > 0 {
+		if len(out) == 0 {
+			return nil, next, fmt.Errorf("all DingTalk resources failed: %s", strings.Join(details, "; "))
+		}
+		return out, next, &datasource.PartialFetchError{Details: details}
+	}
+	return out, next, nil
+}
+
+func (c *Connector) fetchResource(
+	ctx context.Context,
+	cli *client,
+	token, rid string,
+	prev *dingtalkCursor,
+	incremental bool,
+	multimodalEnabled bool,
+) ([]types.FetchedItem, map[string]string, error) {
+	kind, spaceID, fileID := parseResourceID(rid)
+	if kind == "" || spaceID == "" {
+		return nil, nil, fmt.Errorf("invalid DingTalk resource id %q", rid)
+	}
+	entries, err := cli.listAllEntries(ctx, token, spaceID, maxDriveEntries)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list entries for %s: %w", rid, err)
+	}
+	selected := selectedEntries(entries, kind, fileID)
+	signals := make(map[string]string, len(selected))
+	var out []types.FetchedItem
+	for _, entry := range selected {
+		externalID := resourceID(resourceKindFile, spaceID, entry.ID)
+		signal := entry.signal()
+		signals[externalID] = signal
+		if incremental && prev != nil && prev.FileSignals[externalID] == signal {
+			continue
+		}
+		item, err := c.fetchEntry(ctx, cli, token, spaceID, rid, entry, multimodalEnabled)
+		if err != nil {
+			out = append(out, types.FetchedItem{
+				ExternalID:       externalID,
+				Title:            entry.Name,
+				SourceResourceID: rid,
+				Metadata: map[string]string{
+					"channel":  types.ChannelDingtalk,
+					"error":    err.Error(),
+					"space_id": spaceID,
+					"file_id":  entry.ID,
+				},
+			})
+			continue
+		}
+		out = append(out, *item)
+	}
+	return out, signals, nil
+}
+
+func (c *Connector) fetchEntry(
+	ctx context.Context,
+	cli *client,
+	token, spaceID, sourceResourceID string,
+	entry driveEntry,
+	multimodalEnabled bool,
+) (*types.FetchedItem, error) {
+	if entry.Size > maxFileBytes {
+		return nil, fmt.Errorf("file exceeds 50MB")
+	}
+	meta := map[string]string{
+		"channel":       types.ChannelDingtalk,
+		"space_id":      spaceID,
+		"file_id":       entry.ID,
+		"file_path":     entry.displayPath(),
+		"modified_time": entry.ModifiedAt.Format(time.RFC3339),
+	}
+	externalID := resourceID(resourceKindFile, spaceID, entry.ID)
+	title := entry.Name
+	if strings.TrimSpace(title) == "" {
+		title = entry.ID
+	}
+
+	if entry.isOnlineDocument() {
+		docID := entry.DocKey
+		if docID == "" {
+			docID = entry.ID
+		}
+		content, err := cli.readDocument(ctx, token, docID)
+		if err == nil {
+			return &types.FetchedItem{
+				ExternalID:       externalID,
+				Title:            title,
+				Content:          content,
+				ContentType:      "text/markdown",
+				FileName:         sanitizeFileName(title) + ".md",
+				URL:              entry.sourceURL(spaceID),
+				UpdatedAt:        entry.ModifiedAt,
+				SourceResourceID: sourceResourceID,
+				Metadata:         meta,
+			}, nil
+		}
+		logger.Warnf(ctx, "[DingTalk] blocks read failed for %s (%s), falling back to download: %v", title, docID, err)
+	}
+
+	if !supportedFile(entry.Name, entry.MediaType) {
+		return nil, fmt.Errorf("unsupported file type")
+	}
+	if !multimodalEnabled && isImageExt(filepath.Ext(entry.Name)) {
+		// Match Feishu's behaviour: image OCR requires a multimodal KB.
+		return nil, fmt.Errorf("image OCR requires multimodal knowledge base")
+	}
+	downloadURL, headers, err := cli.downloadInfo(ctx, token, spaceID, entry.ID)
+	if err != nil {
+		return nil, err
+	}
+	data, err := cli.download(ctx, downloadURL, headers)
+	if err != nil {
+		// Download URLs can expire. Re-query once, mirroring the standalone project.
+		downloadURL, headers, retryErr := cli.downloadInfo(ctx, token, spaceID, entry.ID)
+		if retryErr != nil {
+			return nil, err
+		}
+		data, err = cli.download(ctx, downloadURL, headers)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &types.FetchedItem{
+		ExternalID:       externalID,
+		Title:            title,
+		Content:          data,
+		ContentType:      contentType(entry.Name, entry.MediaType, data),
+		FileName:         fileName(title, entry.Name),
+		URL:              entry.sourceURL(spaceID),
+		UpdatedAt:        entry.ModifiedAt,
+		SourceResourceID: sourceResourceID,
+		Metadata:         meta,
+	}, nil
+}
+
+func selectedEntries(entries []driveEntry, kind, fileID string) []driveEntry {
+	if kind == resourceKindFile && fileID != "" {
+		root, ok := findEntry(entries, fileID)
+		if ok && !root.isFolder() {
+			return []driveEntry{root}
+		}
+	}
+	parent := "0"
+	if kind == resourceKindFile {
+		parent = fileID
+	}
+	acceptedParents := map[string]bool{parent: true}
+	var out []driveEntry
+	changed := true
+	for changed {
+		changed = false
+		for _, entry := range entries {
+			if !acceptedParents[entry.ParentID] || containsEntry(out, entry.ID) {
+				continue
+			}
+			if entry.isFolder() {
+				if !acceptedParents[entry.ID] {
+					acceptedParents[entry.ID] = true
+					changed = true
+				}
+				continue
+			}
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+func entryToResource(spaceID, parentResourceID string, entry driveEntry) types.Resource {
+	typ := "file"
+	if entry.isFolder() {
+		typ = "folder"
+	}
+	return types.Resource{
+		ExternalID:  resourceID(resourceKindFile, spaceID, entry.ID),
+		Name:        firstNonEmpty(entry.Name, entry.ID),
+		Type:        typ,
+		Description: entry.displayPath(),
+		URL:         entry.sourceURL(spaceID),
+		ParentID:    parentResourceID,
+		HasChildren: entry.isFolder(),
+		ModifiedAt:  entry.ModifiedAt,
+		Metadata: map[string]interface{}{
+			"space_id":   spaceID,
+			"file_id":    entry.ID,
+			"parent_id":  entry.ParentID,
+			"media_type": entry.MediaType,
+			"size":       entry.Size,
+		},
+	}
+}
+
+func findEntry(entries []driveEntry, id string) (driveEntry, bool) {
+	for _, entry := range entries {
+		if entry.ID == id {
+			return entry, true
+		}
+	}
+	return driveEntry{}, false
+}
+
+func containsEntry(entries []driveEntry, id string) bool {
+	for _, entry := range entries {
+		if entry.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func contentType(name, mediaType string, data []byte) string {
+	if strings.TrimSpace(mediaType) != "" && strings.Contains(mediaType, "/") {
+		return mediaType
+	}
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".md", ".markdown":
+		return "text/markdown"
+	case ".txt":
+		return "text/plain"
+	case ".pdf":
+		return "application/pdf"
+	case ".doc":
+		return "application/msword"
+	case ".docx":
+		return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+	case ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp":
+		return http.DetectContentType(data)
+	default:
+		return "application/octet-stream"
+	}
+}
+
+func fileName(title, original string) string {
+	ext := filepath.Ext(original)
+	if ext == "" {
+		ext = ".txt"
+	}
+	name := sanitizeFileName(title)
+	if strings.HasSuffix(strings.ToLower(name), strings.ToLower(ext)) {
+		return name
+	}
+	return name + ext
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}

--- a/internal/datasource/connector/dingtalk/connector_test.go
+++ b/internal/datasource/connector/dingtalk/connector_test.go
@@ -1,0 +1,85 @@
+package dingtalk
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseResourceID(t *testing.T) {
+	kind, spaceID, fileID := parseResourceID(resourceID(resourceKindSpace, "space-1", ""))
+	if kind != resourceKindSpace || spaceID != "space-1" || fileID != "" {
+		t.Fatalf("unexpected space id parse: kind=%q spaceID=%q fileID=%q", kind, spaceID, fileID)
+	}
+
+	kind, spaceID, fileID = parseResourceID(resourceID(resourceKindFile, "space-1", "file-1"))
+	if kind != resourceKindFile || spaceID != "space-1" || fileID != "file-1" {
+		t.Fatalf("unexpected file id parse: kind=%q spaceID=%q fileID=%q", kind, spaceID, fileID)
+	}
+
+	kind, spaceID, fileID = parseResourceID("bad-id")
+	if kind != "" || spaceID != "" || fileID != "" {
+		t.Fatalf("invalid id should parse empty values, got kind=%q spaceID=%q fileID=%q", kind, spaceID, fileID)
+	}
+}
+
+func TestSelectedEntries(t *testing.T) {
+	entries := []driveEntry{
+		{ID: "folder-a", ParentID: "0", Name: "A", Type: "folder"},
+		{ID: "doc-root", ParentID: "0", Name: "root.md"},
+		{ID: "doc-a", ParentID: "folder-a", Name: "a.md"},
+		{ID: "folder-b", ParentID: "folder-a", Name: "B", Type: "folder"},
+		{ID: "doc-b", ParentID: "folder-b", Name: "b.md"},
+	}
+
+	all := selectedEntries(entries, resourceKindSpace, "")
+	if ids(all) != "doc-root,doc-a,doc-b" {
+		t.Fatalf("space selection mismatch: %s", ids(all))
+	}
+
+	folder := selectedEntries(entries, resourceKindFile, "folder-a")
+	if ids(folder) != "doc-a,doc-b" {
+		t.Fatalf("folder selection mismatch: %s", ids(folder))
+	}
+
+	file := selectedEntries(entries, resourceKindFile, "doc-a")
+	if ids(file) != "doc-a" {
+		t.Fatalf("file selection mismatch: %s", ids(file))
+	}
+}
+
+func TestParseDriveEntry(t *testing.T) {
+	raw := map[string]interface{}{
+		"dentryId":       "file-1",
+		"parentDentryId": "folder-1",
+		"name":           "计划.md",
+		"dentryType":     "file",
+		"mediaType":      "text/markdown",
+		"size":           float64(123),
+		"modifiedTime":   "2026-07-29T10:20:30Z",
+		"version":        "v1",
+		"webUrl":         "https://alidocs.dingtalk.com/i/drive/space/file",
+		"documentId":     "doc-key",
+	}
+
+	entry := parseDriveEntry(raw)
+	if entry.ID != "file-1" || entry.ParentID != "folder-1" || entry.Name != "计划.md" {
+		t.Fatalf("unexpected entry identity: %+v", entry)
+	}
+	if entry.Size != 123 || entry.Version != "v1" || entry.DocKey != "doc-key" {
+		t.Fatalf("unexpected entry details: %+v", entry)
+	}
+	if entry.ModifiedAt.IsZero() || !entry.ModifiedAt.Equal(time.Date(2026, 7, 29, 10, 20, 30, 0, time.UTC)) {
+		t.Fatalf("unexpected modified time: %s", entry.ModifiedAt)
+	}
+}
+
+func ids(entries []driveEntry) string {
+	out := ""
+	for i, entry := range entries {
+		if i > 0 {
+			out += ","
+		}
+		out += entry.ID
+	}
+	return out
+}

--- a/internal/datasource/connector/dingtalk/types.go
+++ b/internal/datasource/connector/dingtalk/types.go
@@ -1,0 +1,202 @@
+// Package dingtalk implements the DingTalk data source connector for WeKnora.
+package dingtalk
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/Tencent/WeKnora/internal/datasource"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+const (
+	defaultBaseURL = "https://api.dingtalk.com"
+
+	resourceKindSpace = "space"
+	resourceKindFile  = "file"
+	resourceSeparator = ":"
+
+	maxDriveEntries = 10000
+	maxFileBytes    = 50 * 1024 * 1024
+)
+
+// Config holds DingTalk connector credentials.
+type Config struct {
+	ClientID  string `json:"client_id"`
+	AppSecret string `json:"app_secret"`
+	UnionID   string `json:"union_id"`
+	BaseURL   string `json:"base_url,omitempty"`
+}
+
+func parseConfig(config *types.DataSourceConfig) (*Config, error) {
+	if config == nil {
+		return nil, fmt.Errorf("%w: config is nil", datasource.ErrInvalidConfig)
+	}
+	credBytes, err := json.Marshal(config.Credentials)
+	if err != nil {
+		return nil, fmt.Errorf("marshal credentials: %w", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(credBytes, &cfg); err != nil {
+		return nil, fmt.Errorf("parse dingtalk credentials: %w", err)
+	}
+	cfg.ClientID = strings.TrimSpace(cfg.ClientID)
+	cfg.AppSecret = strings.TrimSpace(cfg.AppSecret)
+	cfg.UnionID = strings.TrimSpace(cfg.UnionID)
+	if cfg.ClientID == "" || cfg.AppSecret == "" || cfg.UnionID == "" {
+		return nil, fmt.Errorf("%w: client_id, app_secret and union_id are required", datasource.ErrInvalidCredentials)
+	}
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = defaultBaseURL
+	}
+	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
+	if err := datasource.ValidateConnectorBaseURL(cfg.BaseURL); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+type space struct {
+	ID   string
+	Name string
+}
+
+type driveEntry struct {
+	ID         string
+	ParentID   string
+	Name       string
+	Path       string
+	Type       string
+	MediaType  string
+	Size       int64
+	ModifiedAt time.Time
+	Version    string
+	URL        string
+	DocKey     string
+}
+
+func (e driveEntry) isFolder() bool {
+	value := strings.ToLower(e.Type + " " + e.MediaType)
+	return strings.Contains(value, "folder") || strings.Contains(value, "directory")
+}
+
+func (e driveEntry) sourceURL(spaceID string) string {
+	if strings.TrimSpace(e.URL) != "" {
+		return e.URL
+	}
+	return "https://alidocs.dingtalk.com/i/drive/" + spaceID + "/" + e.ID
+}
+
+func (e driveEntry) displayPath() string {
+	if strings.TrimSpace(e.Path) != "" {
+		return e.Path
+	}
+	return e.Name
+}
+
+func (e driveEntry) signal() string {
+	parts := []string{
+		e.ID,
+		e.Version,
+		fmt.Sprintf("%d", e.Size),
+	}
+	if !e.ModifiedAt.IsZero() {
+		parts = append(parts, e.ModifiedAt.UTC().Format(time.RFC3339Nano))
+	}
+	return strings.Join(parts, "|")
+}
+
+func (e driveEntry) isOnlineDocument() bool {
+	name := strings.ToLower(e.Name)
+	ext := strings.ToLower(filepath.Ext(name))
+	if ext == ".pdf" || ext == ".doc" || ext == ".docx" || ext == ".txt" ||
+		ext == ".md" || ext == ".markdown" || isImageExt(ext) {
+		return false
+	}
+	media := strings.ToLower(e.MediaType)
+	typ := strings.ToLower(e.Type)
+	if strings.HasPrefix(media, "image/") || strings.Contains(media, "pdf") ||
+		strings.Contains(media, "wordprocessingml") || strings.HasPrefix(media, "text/") {
+		return false
+	}
+	return media == "alidoc" || media == "adoc" || strings.Contains(media, "dingtalk") ||
+		strings.Contains(typ, "doc") || strings.Contains(typ, "sheet") ||
+		strings.Contains(typ, "wiki") || strings.Contains(typ, "online")
+}
+
+func supportedFile(name, mediaType string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	media := strings.ToLower(mediaType)
+	switch ext {
+	case ".pdf", ".doc", ".docx", ".txt", ".md", ".markdown", ".csv",
+		".xls", ".xlsx", ".ppt", ".pptx":
+		return true
+	}
+	return isImageExt(ext) || strings.HasPrefix(media, "text/") ||
+		strings.Contains(media, "pdf") || strings.Contains(media, "wordprocessingml") ||
+		strings.HasPrefix(media, "image/")
+}
+
+func isImageExt(ext string) bool {
+	switch strings.ToLower(ext) {
+	case ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tif", ".tiff", ".webp":
+		return true
+	default:
+		return false
+	}
+}
+
+func resourceID(kind, spaceID, fileID string) string {
+	if kind == resourceKindSpace {
+		return resourceKindSpace + resourceSeparator + spaceID
+	}
+	return resourceKindFile + resourceSeparator + spaceID + resourceSeparator + fileID
+}
+
+func parseResourceID(id string) (kind, spaceID, fileID string) {
+	parts := strings.SplitN(id, resourceSeparator, 3)
+	if len(parts) == 2 && parts[0] == resourceKindSpace {
+		return resourceKindSpace, parts[1], ""
+	}
+	if len(parts) == 3 && parts[0] == resourceKindFile {
+		return resourceKindFile, parts[1], parts[2]
+	}
+	return "", "", ""
+}
+
+type dingtalkCursor struct {
+	LastSyncTime time.Time         `json:"last_sync_time"`
+	FileSignals  map[string]string `json:"file_signals,omitempty"`
+}
+
+func sanitizeFileName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "untitled"
+	}
+	replacer := strings.NewReplacer(
+		"/", "_", "\\", "_", ":", "_", "*", "_",
+		"?", "_", "\"", "_", "<", "_", ">", "_", "|", "_",
+		"\n", " ", "\r", " ", "\t", " ",
+	)
+	result := strings.TrimSpace(replacer.Replace(name))
+	if result == "" {
+		return "untitled"
+	}
+	const maxBytes = 200
+	if len(result) > maxBytes {
+		result = result[:maxBytes]
+		for len(result) > 0 {
+			r, size := utf8.DecodeLastRuneInString(result)
+			if r != utf8.RuneError || size != 1 {
+				break
+			}
+			result = result[:len(result)-1]
+		}
+	}
+	return result
+}


### PR DESCRIPTION
## Summary
- add a native DingTalk datasource connector for Client ID / AppSecret / unionId credentials
- list accessible DingTalk drive spaces and files, then sync selected spaces/folders/files into WeKnora
- support incremental scan signals, download retry, online document block reads, file metadata, and DingTalk UI/i18n entries

## Validation
- `CGO_ENABLED=1 go test ./internal/datasource/connector/dingtalk`
- `CGO_ENABLED=1 go test ./internal/datasource`

## Notes
- `npm run type-check` currently fails on pre-existing unrelated files: `sessionSidebarBuckets.ts`, `AgentEditorModal.vue`, and `SystemSettings.vue`.
- `go test ./internal/container` reaches unrelated Windows DuckDB/static-link issues after dependency setup; DingTalk connector and datasource package tests pass.
- Closes #1707 