### PR TITLE
fix(organization): pass avatar when creating shared space

### DIFF
--- a/frontend/src/stores/organization.ts
+++ b/frontend/src/stores/organization.ts
@@ -191,11 +191,11 @@ export const useOrganizationStore = defineStore('organization', () => {
   /**
    * Create a new organization
    */
-  async function create(name: string, description?: string) {
+  async function create(name: string, description?: string, avatar?: string) {
     loading.value = true
     error.value = null
     try {
-      const response = await createOrganization({ name, description })
+      const response = await createOrganization({ name, description, avatar })
       if (response.success && response.data) {
         upsertOrganization(response.data)
         // 创建成功后重置缓存时间戳，确保后续 fetchOrganizations() 不会被 TTL 缓存跳过，

--- a/frontend/src/views/organization/OrganizationSettingsModal.vue
+++ b/frontend/src/views/organization/OrganizationSettingsModal.vue
@@ -1502,7 +1502,8 @@ const handleSave = async () => {
       // 创建模式
       const result = await orgStore.create(
         formData.value.name.trim(),
-        formData.value.description.trim()
+        formData.value.description.trim(),
+        formData.value.avatar || undefined
       )
       if (result) {
         MessagePlugin.success(t('organization.createSuccess'))


### PR DESCRIPTION
## Description

修复在 `/platform/organizations` 界面创建共享空间时，设置头像后创建成功却未显示头像的问题。

**根因：** 创建模式下，`OrganizationSettingsModal` 和 `orgStore.create()` 只传递了 `name` 和 `description`，漏掉了 `avatar` 字段。而编辑模式正确传递了 `avatar`，所以修改头像能成功。

**修复：**
- `stores/organization.ts` — `create()` 函数增加 `avatar` 参数，并传递给 `createOrganization()` API
- `views/organization/OrganizationSettingsModal.vue` — 创建时把 `formData.value.avatar` 传给 `orgStore.create()`

## Type of Change

- [x] 🐛 Bug fix


## Testing

1. 进入 `/platform/organizations` 页面
2. 创建新的共享空间，选择头像 emoji
3. 确认创建成功后头像正确显示
4. 编辑已有共享空间，修改头像，确认修改仍然正常

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation
