### PR TITLE
fix(mcp): 修复非 UUID Agent ID 无法解析的问题

### DIFF
--- a/mcp-server/tests/test_agent_id_resolution.py
+++ b/mcp-server/tests/test_agent_id_resolution.py
@@ -1,0 +1,34 @@
+from weknora_mcp_server import WeKnoraClient
+
+
+def test_resolve_agent_id_accepts_non_uuid_agent_id(monkeypatch):
+    client = WeKnoraClient("http://example.test/api/v1", "")
+    agents = {
+        "data": [
+            {
+                "id": "builtin-wiki-researcher",
+                "name": "维基问答",
+            }
+        ]
+    }
+    monkeypatch.setattr(client, "_request", lambda *args, **kwargs: agents)
+
+    assert (
+        client.resolve_agent_id("builtin-wiki-researcher")
+        == "builtin-wiki-researcher"
+    )
+
+
+def test_resolve_agent_id_accepts_agent_name_case_insensitively(monkeypatch):
+    client = WeKnoraClient("http://example.test/api/v1", "")
+    agents = {
+        "data": [
+            {
+                "id": "builtin-wiki-researcher",
+                "name": "Wiki Questioner",
+            }
+        ]
+    }
+    monkeypatch.setattr(client, "_request", lambda *args, **kwargs: agents)
+
+    assert client.resolve_agent_id("wiki questioner") == "builtin-wiki-researcher"

--- a/mcp-server/weknora_mcp_server.py
+++ b/mcp-server/weknora_mcp_server.py
@@ -213,11 +213,12 @@ class WeKnoraClient:
     )
 
     def resolve_agent_id(self, agent_id_or_name: str) -> str:
-        """Resolve an agent name to its UUID if needed.
+        """Resolve an agent ID or name to its canonical ID.
 
         If *agent_id_or_name* is already a UUID it is returned unchanged.
-        Otherwise all agents are listed and the first one whose
-        ``name`` matches (case-insensitive) is returned.
+        Otherwise all agents are listed and the first one whose ``id``
+        matches exactly or whose ``name`` matches case-insensitively is
+        returned.
         Raises ValueError when no match is found.
         """
         if self._UUID_RE.match(agent_id_or_name):
@@ -228,7 +229,11 @@ class WeKnoraClient:
             agents = agents.get("list", agents.get("items", []))
         needle = agent_id_or_name.lower()
         for agent in (agents or []):
-            if isinstance(agent, dict) and agent.get("name", "").lower() == needle:
+            if not isinstance(agent, dict):
+                continue
+            if agent.get("id") == agent_id_or_name:
+                return agent["id"]
+            if agent.get("name", "").lower() == needle:
                 return agent["id"]
         raise ValueError(
             f"Agent {agent_id_or_name!r} not found. "


### PR DESCRIPTION
## 问题描述

使用MCP来调用工具`list_agents` 会返回内置 Agent 的 ID（例如 `builtin-wiki-researcher`），但该非 UUID ID 传给 `agent_chat` 或 `get_agent` 时会被解析失败并报“Agent not found”。

根因是 `resolve_agent_id` 对非 UUID 入参仅按 Agent 的 `name`（忽略大小写）匹配，未按 `id` 匹配。

## 变更类型
- [x]  🐛 Bug fix

## 修复内容

- 对非 UUID 入参优先精确匹配 Agent 的 `id`。
- 未匹配时保留原有按 `name` 忽略大小写匹配的行为。
- 更新函数说明，使其准确描述支持 ID 与名称两种输入。

## 测试

- 新增 `builtin-wiki-researcher` 可按非 UUID ID 解析的回归测试。
- 覆盖原有按名称、忽略大小写解析的兼容行为。
- 执行 `pytest`，结果：`2 passed`。

## 检查清单

- [x] `git diff --check origin/main...HEAD` 通过
- [x] 已新增覆盖本次修复的单元测试
- [x] 已完成自查