### PR TITLE
test(ci): stabilize MCP session test and decouple frontend checks

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -6,24 +6,11 @@ on:
     paths:
       - "frontend/**"
       - "scripts/build_frontend_dist.sh"
-      # The frontend terminology regression test also scans these public docs.
-      - ".env.example"
-      - "README_CN.md"
-      - "client/**"
-      - "docker-compose.yml"
-      - "docs/**"
-      - "mcp-server/**"
       - ".github/workflows/frontend.yml"
   pull_request:
     paths:
       - "frontend/**"
       - "scripts/build_frontend_dist.sh"
-      - ".env.example"
-      - "README_CN.md"
-      - "client/**"
-      - "docker-compose.yml"
-      - "docs/**"
-      - "mcp-server/**"
       - ".github/workflows/frontend.yml"
   workflow_dispatch:
 

--- a/frontend/src/i18n/locales/workspaceTerminology.test.ts
+++ b/frontend/src/i18n/locales/workspaceTerminology.test.ts
@@ -1,8 +1,5 @@
 import assert from 'node:assert/strict'
-import { readdirSync, readFileSync } from 'node:fs'
-import { dirname, extname, resolve } from 'node:path'
 import test from 'node:test'
-import { fileURLToPath } from 'node:url'
 
 import enUS from './en-US.ts'
 import koKR from './ko-KR.ts'
@@ -41,26 +38,6 @@ const localeChecks = [
   { name: 'ru-RU', locale: ruRU, forbidden: /(?:тенант|арендатор)/i },
 ]
 
-const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..')
-const publicDocumentationRoots = [
-  '.env.example',
-  'README_CN.md',
-  'client',
-  'docker-compose.yml',
-  'docs',
-  'mcp-server',
-]
-const documentationExtensions = new Set(['.go', '.json', '.md', '.yaml', '.yml'])
-
-function collectDocumentationFiles(path: string): string[] {
-  const entries = readdirSync(path, { withFileTypes: true })
-  return entries.flatMap((entry) => {
-    const child = resolve(path, entry.name)
-    if (entry.isDirectory()) return collectDocumentationFiles(child)
-    return documentationExtensions.has(extname(entry.name)) ? [child] : []
-  })
-}
-
 test('user-facing locale values use workspace terminology', () => {
   for (const check of localeChecks) {
     const legacyValues = collectStrings(check.locale)
@@ -73,22 +50,4 @@ test('user-facing locale values use workspace terminology', () => {
       `${check.name} still contains user-facing tenant terminology`,
     )
   }
-})
-
-test('public documentation uses workspace terminology', () => {
-  const legacyLines = publicDocumentationRoots.flatMap((relativePath) => {
-    const absolutePath = resolve(repositoryRoot, relativePath)
-    const files = extname(absolutePath) ? [absolutePath] : collectDocumentationFiles(absolutePath)
-    return files.flatMap((file) =>
-      readFileSync(file, 'utf8')
-        .split('\n')
-        .flatMap((line, index) =>
-          line.includes('租户')
-            ? [`${file.slice(repositoryRoot.length + 1)}:${index + 1}=${line.trim()}`]
-            : [],
-        ),
-    )
-  })
-
-  assert.deepEqual(legacyLines, [], 'public documentation still contains legacy tenant terminology')
 })

--- a/mcp-server/test_mcp_transports.py
+++ b/mcp-server/test_mcp_transports.py
@@ -46,11 +46,11 @@ class TransportRegressionTest(unittest.TestCase):
 
         client = WeKnoraClient("http://localhost:8080/api/v1", "test-key")
         barrier = threading.Barrier(2)
-        sessions: dict[str, int] = {}
+        sessions: dict[str, object] = {}
 
         def worker(name: str) -> None:
             barrier.wait()
-            sessions[name] = id(client.session)
+            sessions[name] = client.session
 
         threads = [
             threading.Thread(target=worker, args=(name,))
@@ -62,7 +62,7 @@ class TransportRegressionTest(unittest.TestCase):
             thread.join()
 
         self.assertEqual(len(sessions), 2)
-        self.assertNotEqual(sessions["a"], sessions["b"])
+        self.assertIsNot(sessions["a"], sessions["b"])
 
 
 class StdioToolsListTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- retain strong references to per-thread `requests.Session` objects in the MCP transport regression test
- compare live Session objects directly instead of comparing reusable `id()` values
- keep frontend terminology coverage scoped to frontend locale values
- remove the repository-wide public documentation scan from the frontend test
- stop the Frontend workflow from listening to `.env.example`, README, client, Docker Compose, docs, and `mcp-server` changes

## Root cause

The MCP test stored only `id(client.session)`. Once a worker thread exited, its thread-local Session could be destroyed, allowing CPython to reuse the same memory address for the other thread's Session. This made the assertion flaky on Python 3.11 even though the Sessions were distinct.

Separately, a frontend locale test also scanned public documentation across the repository. That forced the full Node test, type-check, and build pipeline to run for unrelated changes such as Python-only MCP server updates.

## Impact

- thread-local isolation is verified without depending on object address lifetime or interpreter scheduling
- frontend CI is scoped to frontend-owned validation
- documentation and MCP-only changes no longer trigger the full Frontend pipeline solely for terminology scanning
- frontend locale wording remains protected against reintroducing user-facing tenant terminology

## Validation

- targeted MCP regression test on Python 3.10, 3.11, 3.12, and 3.13
- full `mcp-server` unittest suite on Python 3.11 (18 tests)
- frontend test suite (261 tests)
- frontend workflow YAML parsed successfully
- `git diff --check`