### PR TITLE
fix: preserve wiki folder path after creation

### DIFF
--- a/frontend/src/views/knowledge/wiki/WikiBrowser.vue
+++ b/frontend/src/views/knowledge/wiki/WikiBrowser.vue
@@ -772,6 +772,10 @@ import { hydrateProtectedFileImages, sanitizeMarkdownHTML } from '@/utils/securi
 import picturePreview from '@/components/picture-preview.vue'
 import WikiFolderActions from './WikiFolderActions.vue'
 import WikiRevisionDrawer from './WikiRevisionDrawer.vue'
+import {
+  expandedWikiDirectoryPaths,
+  expandWikiDirectoryPath,
+} from './wikiDirectoryState'
 import { getKnowledgeDetails } from '@/api/knowledge-base'
 import { createSessions } from '@/api/chat'
 import ChatView from '@/views/chat/index.vue'
@@ -2157,11 +2161,28 @@ async function loadCategoriesForType(type: string, opts: { reset?: boolean; pare
 // pages for one tab. Used after a structural mutation (move page, create /
 // rename / delete folder) so the tree reflects the new layout authoritatively
 // instead of guessing at the optimistic delta.
-async function reloadDirectoryForType(type: string) {
+async function reloadDirectoryForType(
+  type: string,
+  opts: { preserveDirectoryState?: boolean } = {},
+) {
   const refreshFlatList = sidebarViewMode.value === 'list' || ensureBucket(type).flatInitialized
-  clearDirectoryStateForType(type)
-  await loadPagesForType(type, { reset: true })
+  const expandedPaths = opts.preserveDirectoryState
+    ? expandedWikiDirectoryPaths(type, collapsedDirectories.value, touchedDirectories.value)
+    : []
+  if (!opts.preserveDirectoryState) clearDirectoryStateForType(type)
+  await loadPagesForType(type, {
+    reset: true,
+    preserveDirectoryState: opts.preserveDirectoryState,
+  })
   await loadCategoriesForType(type, { reset: true })
+  // Folder data is fetched one level at a time. Reload preserved paths in
+  // parent-first order so each child request can resolve its parent folder id.
+  for (const path of expandedPaths) {
+    await Promise.all([
+      loadPagesForType(type, { categoryPath: path }),
+      loadCategoriesForType(type, { parentPath: path }),
+    ])
+  }
   if (refreshFlatList) await loadFlatPagesForType(type, true)
 }
 
@@ -2301,16 +2322,28 @@ async function confirmPendingMove() {
 // the API call, surface a toast, and reload the affected tab so the tree
 // reflects the new layout authoritatively.
 async function createFolder(parentId: string, parentPath: string[], name: string) {
+  const type = activeTab.value
+  const scrollTop = pageListRef.value?.scrollTop
   try {
     await createWikiFolder(props.knowledgeBaseId, parentId, name)
     MessagePlugin.success(t('knowledgeEditor.wikiBrowser.createFolderSuccess'))
-    // Keep the parent expanded so the new child is visible.
+    // Keep the current path expanded so refreshing the authoritative tree does
+    // not collapse it and clamp the sidebar scroll position back to the root.
     if (parentPath.length > 0) {
-      collapsedDirectories.value = new Set(
-        [...collapsedDirectories.value].filter(k => k !== directoryPathKey(activeTab.value, parentPath)),
+      const state = expandWikiDirectoryPath(
+        type,
+        parentPath,
+        collapsedDirectories.value,
+        touchedDirectories.value,
       )
+      collapsedDirectories.value = state.collapsed
+      touchedDirectories.value = state.touched
     }
-    await reloadDirectoryForType(activeTab.value)
+    await reloadDirectoryForType(type, { preserveDirectoryState: true })
+    await nextTick()
+    if (activeTab.value === type && scrollTop !== undefined && pageListRef.value) {
+      pageListRef.value.scrollTop = scrollTop
+    }
   } catch (e: any) {
     console.error('Failed to create wiki folder:', e)
     MessagePlugin.error(e?.message || t('knowledgeEditor.wikiBrowser.createFolderFailed'))
@@ -2397,7 +2430,10 @@ async function deleteFolder(folderId: string) {
 // checks work without another round-trip. Guard against concurrent
 // invocations for the same type (e.g. scroll event fires rapidly while
 // a network request is still in flight).
-async function loadPagesForType(type: string, opts: { reset?: boolean; categoryPath?: string[] } = {}) {
+async function loadPagesForType(
+  type: string,
+  opts: { reset?: boolean; categoryPath?: string[]; preserveDirectoryState?: boolean } = {},
+) {
   const bucket = ensureBucket(type)
   const categoryPath = opts.categoryPath || []
   const scopedToCategory = categoryPath.length > 0
@@ -2446,7 +2482,7 @@ async function loadPagesForType(type: string, opts: { reset?: boolean; categoryP
         bucket.items = batch
         bucket.nextPage = 2
         bucket.directoryPages = {}
-        clearDirectoryStateForType(type)
+        if (!opts.preserveDirectoryState) clearDirectoryStateForType(type)
       } else {
         const seenItems = new Set(bucket.items.map(p => p.id))
         for (const p of batch) {

--- a/frontend/src/views/knowledge/wiki/wikiDirectoryState.test.ts
+++ b/frontend/src/views/knowledge/wiki/wikiDirectoryState.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import {
+  expandedWikiDirectoryPaths,
+  expandWikiDirectoryPath,
+} from './wikiDirectoryState.ts'
+
+test('keeps the current wiki directory path expanded without changing sibling state', () => {
+  const collapsed = new Set([
+    'knowledge:Guides',
+    'knowledge:Guides/Setup',
+    'knowledge:Reference',
+    'summary:Guides',
+  ])
+  const touched = new Set(['knowledge:Reference'])
+
+  const state = expandWikiDirectoryPath(
+    'knowledge',
+    ['Guides', 'Setup'],
+    collapsed,
+    touched,
+  )
+
+  assert.deepEqual([...state.collapsed].sort(), [
+    'knowledge:Reference',
+    'summary:Guides',
+  ])
+  assert.deepEqual([...state.touched].sort(), [
+    'knowledge:Guides',
+    'knowledge:Guides/Setup',
+    'knowledge:Reference',
+  ])
+  assert.equal(collapsed.has('knowledge:Guides'), true)
+  assert.equal(touched.has('knowledge:Guides'), false)
+})
+
+test('returns expanded wiki paths in parent-first order for a refreshed tree', () => {
+  const paths = expandedWikiDirectoryPaths(
+    'knowledge',
+    new Set(['knowledge:Reference']),
+    new Set([
+      'knowledge:Guides/Setup',
+      'summary:Guides',
+      'knowledge:Reference',
+      'knowledge:Guides',
+    ]),
+  )
+
+  assert.deepEqual(paths, [
+    ['Guides'],
+    ['Guides', 'Setup'],
+  ])
+})
+
+test('folder creation refreshes data while preserving the current directory state', () => {
+  const here = dirname(fileURLToPath(import.meta.url))
+  const source = readFileSync(join(here, 'WikiBrowser.vue'), 'utf8')
+  const createFolder = source.slice(
+    source.indexOf('async function createFolder'),
+    source.indexOf('// Inline rename:'),
+  )
+
+  assert.match(createFolder, /expandWikiDirectoryPath/)
+  assert.match(createFolder, /preserveDirectoryState:\s*true/)
+  assert.match(createFolder, /scrollTop/)
+})

--- a/frontend/src/views/knowledge/wiki/wikiDirectoryState.ts
+++ b/frontend/src/views/knowledge/wiki/wikiDirectoryState.ts
@@ -1,0 +1,45 @@
+export interface WikiDirectoryState {
+  collapsed: Set<string>
+  touched: Set<string>
+}
+
+function directoryPathKey(type: string, parts: string[]): string {
+  return `${type}:${parts.join('/')}`
+}
+
+/**
+ * Keep every directory in the current path expanded across a data refresh.
+ * Marking the path as touched prevents default initialization from collapsing
+ * it again when the refreshed folder and page batches arrive.
+ */
+export function expandWikiDirectoryPath(
+  type: string,
+  path: string[],
+  collapsed: ReadonlySet<string>,
+  touched: ReadonlySet<string>,
+): WikiDirectoryState {
+  const nextCollapsed = new Set(collapsed)
+  const nextTouched = new Set(touched)
+
+  for (let depth = 1; depth <= path.length; depth++) {
+    const key = directoryPathKey(type, path.slice(0, depth))
+    nextCollapsed.delete(key)
+    nextTouched.add(key)
+  }
+
+  return { collapsed: nextCollapsed, touched: nextTouched }
+}
+
+/** Return expanded, user-touched paths in parent-first order for reloading. */
+export function expandedWikiDirectoryPaths(
+  type: string,
+  collapsed: ReadonlySet<string>,
+  touched: ReadonlySet<string>,
+): string[][] {
+  const prefix = `${type}:`
+  return [...touched]
+    .filter(key => key.startsWith(prefix) && !collapsed.has(key))
+    .map(key => key.slice(prefix.length).split('/').filter(Boolean))
+    .filter(path => path.length > 0)
+    .sort((left, right) => left.length - right.length)
+}


### PR DESCRIPTION
## Description

修复 Wiki 前端新建目录后跳回根目录的问题。

### 问题现象

用户在 Wiki 的多级目录中创建子目录并确认后，目录树会重新初始化，导致当前路径被折叠，侧边栏不会停留在当前界面，会跳回根目录。

### 根因

创建目录成功后会重新加载目录树。原有刷新逻辑会清空目录的展开、折叠和用户访问状态。

虽然创建逻辑曾尝试保持父目录展开，但这个状态随后又被刷新逻辑清除。并且目录接口按层级返回直接子目录，刷新根目录后还需要逐层重新加载原来展开的深层路径。

### 修改内容

- 新建目录后保留当前目录及其祖先目录的展开状态。
- 保留侧边栏原有滚动位置，避免跳回顶部。
- 按父目录到子目录的顺序重新加载已展开路径的数据。
- 仅在创建目录时保留目录状态。
- 移动、重命名和删除目录仍使用原有刷新逻辑，避免保留已经失效的路径。
- 添加目录状态和创建目录行为的回归测试。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

在 Podman Linux、Node.js 24 环境中完成以下验证：

- Wiki 目录回归测试：3 个测试全部通过。
- `npm run type-check`：通过。
- 完整前端测试：263 个测试全部通过。
- `npm run build`：通过；构建时使用 `NODE_OPTIONS=--max-old-space-size=4096`。
- `git diff --check`：通过。

覆盖的主要场景：

1. 新建子目录后，当前目录及祖先目录保持展开。
2. 其他目录和其他 Wiki 类型的折叠状态不受影响。
3. 深层目录按照父级到子级顺序重新加载。
4. 创建目录刷新时使用保留目录状态的逻辑。

## Checklist

- [x] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A — behavior-only fix; no visual layout changes.