### PR TITLE
feat: add content-addressed caches for knowledge reparsing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,17 @@ GIN_MODE=release
 # EMBEDDING_BASE_URL=
 # EMBEDDING_API_KEY=
 # EMBEDDING_PROVIDER=openai
+# Embedding 内容寻址缓存：标准版写入 Redis，Lite 版使用有界进程内缓存。
+# 相同租户、模型配置和文本再次向量化时可直接复用，减少重解析成本。
+# WEKNORA_EMBEDDING_CACHE_ENABLED=true
+# WEKNORA_EMBEDDING_CACHE_TTL=720h
+# WEKNORA_EMBEDDING_CACHE_MAX_ENTRIES=10000
+# 内容寻址推理缓存：复用相同图片的 OCR/Caption、GraphRAG 提取和 Wiki Map 结果。
+# 缓存键包含租户、模型配置、Prompt 与输入内容；错误结果不会写入缓存。
+# WEKNORA_INFERENCE_CACHE_ENABLED=true
+# Covers deterministic OCR/Caption, GraphRAG, Wiki map, document-summary, and question-generation inference.
+# WEKNORA_INFERENCE_CACHE_TTL=720h
+# WEKNORA_INFERENCE_CACHE_MAX_ENTRIES=10000
 #
 # RERANK_MODEL_NAME=
 # RERANK_BASE_URL=

--- a/internal/application/repository/task_queue.go
+++ b/internal/application/repository/task_queue.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -119,6 +120,7 @@ func (r *taskPendingOpsRepository) ClaimBatch(
 		limit = 1000
 	}
 	now := time.Now()
+	claimToken := uuid.NewString()
 	var claimed []*types.TaskPendingOp
 	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// 1. Pick up to `limit` distinct dedup_keys to claim, oldest first.
@@ -193,7 +195,10 @@ FOR UPDATE SKIP LOCKED`
 		}
 		if err := tx.Model(&types.TaskPendingOp{}).
 			Where("id IN ?", ids).
-			Update("claimed_at", now).Error; err != nil {
+			Updates(map[string]interface{}{
+				"claimed_at":  now,
+				"claim_token": claimToken,
+			}).Error; err != nil {
 			return err
 		}
 		return tx.Where("id IN ?", ids).Order("id ASC").Find(&claimed).Error
@@ -202,6 +207,60 @@ FOR UPDATE SKIP LOCKED`
 		return nil, err
 	}
 	return claimed, nil
+}
+
+// RenewClaims refreshes a live claim lease without allowing a stale owner to
+// take back rows that have already been reclaimed under another token.
+func (r *taskPendingOpsRepository) RenewClaims(ctx context.Context, ids []int64, claimToken string) (int64, error) {
+	if len(ids) == 0 || claimToken == "" {
+		return 0, nil
+	}
+	result := r.db.WithContext(ctx).
+		Model(&types.TaskPendingOp{}).
+		Where("id IN ? AND claim_token = ?", ids, claimToken).
+		Update("claimed_at", time.Now())
+	return result.RowsAffected, result.Error
+}
+
+// ReleaseClaims returns only rows owned by claimToken to the unclaimed pool.
+func (r *taskPendingOpsRepository) ReleaseClaims(ctx context.Context, ids []int64, claimToken string) error {
+	if len(ids) == 0 || claimToken == "" {
+		return nil
+	}
+	return r.db.WithContext(ctx).
+		Model(&types.TaskPendingOp{}).
+		Where("id IN ? AND claim_token = ?", ids, claimToken).
+		Updates(map[string]interface{}{
+			"claimed_at":  nil,
+			"claim_token": "",
+		}).Error
+}
+
+// DeleteClaims consumes only rows still owned by claimToken.
+func (r *taskPendingOpsRepository) DeleteClaims(ctx context.Context, ids []int64, claimToken string) error {
+	if len(ids) == 0 || claimToken == "" {
+		return nil
+	}
+	return r.db.WithContext(ctx).
+		Where("id IN ? AND claim_token = ?", ids, claimToken).
+		Delete(&types.TaskPendingOp{}).Error
+}
+
+// IncrClaimFailCount increments retry state only while the caller still owns
+// the row. A zero result means the row disappeared or the lease was lost.
+func (r *taskPendingOpsRepository) IncrClaimFailCount(ctx context.Context, id int64, claimToken string) (int, error) {
+	if id == 0 || claimToken == "" {
+		return 0, nil
+	}
+	var newCount int
+	err := r.db.WithContext(ctx).Raw(
+		`UPDATE task_pending_ops SET fail_count = fail_count + 1 WHERE id = ? AND claim_token = ? RETURNING fail_count`,
+		id, claimToken,
+	).Scan(&newCount).Error
+	if err != nil {
+		return 0, err
+	}
+	return newCount, nil
 }
 
 // ReleaseByIDs clears claimed_at for the given rows, returning them to the
@@ -214,7 +273,10 @@ func (r *taskPendingOpsRepository) ReleaseByIDs(ctx context.Context, ids []int64
 	return r.db.WithContext(ctx).
 		Model(&types.TaskPendingOp{}).
 		Where("id IN ?", ids).
-		Update("claimed_at", nil).Error
+		Updates(map[string]interface{}{
+			"claimed_at":  nil,
+			"claim_token": "",
+		}).Error
 }
 
 // DeleteByIDs removes the given rows in one statement. Empty input is a

--- a/internal/application/repository/task_queue_test.go
+++ b/internal/application/repository/task_queue_test.go
@@ -31,7 +31,8 @@ CREATE TABLE IF NOT EXISTS task_pending_ops (
     payload     TEXT NOT NULL DEFAULT '{}',
     fail_count  INTEGER NOT NULL DEFAULT 0,
     enqueued_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    claimed_at  DATETIME
+    claimed_at  DATETIME,
+    claim_token VARCHAR(64) NOT NULL DEFAULT ''
 );
 `
 
@@ -294,6 +295,8 @@ func TestTaskPendingOps_ClaimBatch_MarksAndReturnsDisjoint(t *testing.T) {
 	assert.Equal(t, "k1", first[0].DedupKey)
 	assert.Equal(t, "k2", first[1].DedupKey)
 	assert.NotNil(t, first[0].ClaimedAt, "claimed_at should be stamped")
+	require.NotEmpty(t, first[0].ClaimToken, "claim_token should identify the lease owner")
+	assert.Equal(t, first[0].ClaimToken, first[1].ClaimToken, "one batch must share one owner token")
 
 	// Second claim skips the two already-claimed rows and returns the last.
 	second, err := repo.ClaimBatch(ctx, "wiki:ingest", "knowledge_base", "kb", 10, stale)
@@ -435,6 +438,78 @@ func TestTaskPendingOps_ClaimBatch_ReclaimsStale(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 1, "stale claim must be recoverable")
 	assert.Equal(t, "k1", got[0].DedupKey)
+}
+
+// TestTaskPendingOps_ClaimLeaseOwnership verifies that a reclaimed row gets a
+// new owner token and that the former owner can no longer renew, release,
+// mutate, or delete it. This is the fencing guarantee that makes short claim
+// leases safe when a crashed worker resumes after another worker took over.
+func TestTaskPendingOps_ClaimLeaseOwnership(t *testing.T) {
+	db := setupTaskQueueTestDB(t)
+	repo := NewTaskPendingOpsRepository(db)
+	ctx := context.Background()
+
+	op := makePendingOp("wiki:ingest", "knowledge_base", "kb", "ingest", "k1", nil)
+	require.NoError(t, repo.Enqueue(ctx, op))
+
+	first, err := repo.ClaimBatch(ctx, "wiki:ingest", "knowledge_base", "kb", 1, time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	oldToken := first[0].ClaimToken
+	require.NotEmpty(t, oldToken)
+
+	n, err := repo.RenewClaims(ctx, []int64{op.ID}, oldToken)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+
+	n, err = repo.RenewClaims(ctx, []int64{op.ID}, "wrong-token")
+	require.NoError(t, err)
+	assert.Zero(t, n)
+
+	// Force the current lease stale and reclaim it under a new token.
+	second, err := repo.ClaimBatch(ctx, "wiki:ingest", "knowledge_base", "kb", 1, time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	newToken := second[0].ClaimToken
+	require.NotEmpty(t, newToken)
+	assert.NotEqual(t, oldToken, newToken)
+
+	// Every mutation from the stale owner is fenced out.
+	n, err = repo.RenewClaims(ctx, []int64{op.ID}, oldToken)
+	require.NoError(t, err)
+	assert.Zero(t, n)
+
+	count, err := repo.IncrClaimFailCount(ctx, op.ID, oldToken)
+	require.NoError(t, err)
+	assert.Zero(t, count)
+	require.NoError(t, repo.ReleaseClaims(ctx, []int64{op.ID}, oldToken))
+	require.NoError(t, repo.DeleteClaims(ctx, []int64{op.ID}, oldToken))
+
+	var owned types.TaskPendingOp
+	require.NoError(t, db.First(&owned, op.ID).Error)
+	assert.Equal(t, newToken, owned.ClaimToken)
+	assert.NotNil(t, owned.ClaimedAt)
+	assert.Zero(t, owned.FailCount)
+
+	// The current owner can mutate and release the row.
+	count, err = repo.IncrClaimFailCount(ctx, op.ID, newToken)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	require.NoError(t, repo.ReleaseClaims(ctx, []int64{op.ID}, newToken))
+	owned = types.TaskPendingOp{}
+	require.NoError(t, db.First(&owned, op.ID).Error)
+	assert.Empty(t, owned.ClaimToken)
+	assert.Nil(t, owned.ClaimedAt)
+
+	// A subsequent owner can claim and consume it.
+	third, err := repo.ClaimBatch(ctx, "wiki:ingest", "knowledge_base", "kb", 1, time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Len(t, third, 1)
+	require.NotEmpty(t, third[0].ClaimToken)
+	require.NoError(t, repo.DeleteClaims(ctx, []int64{op.ID}, third[0].ClaimToken))
+	var remaining int64
+	require.NoError(t, db.Model(&types.TaskPendingOp{}).Where("id = ?", op.ID).Count(&remaining).Error)
+	assert.Zero(t, remaining)
 }
 
 // TestTaskPendingOps_ReleaseByIDs_ReturnsToPool verifies a released row

--- a/internal/application/repository/wiki_page.go
+++ b/internal/application/repository/wiki_page.go
@@ -861,7 +861,7 @@ func (r *wikiPageRepository) FindSimilarPages(
 	var rows []types.WikiPageLite
 	if err := r.db.WithContext(ctx).
 		Model(&types.WikiPage{}).
-		Select("slug, title, page_type, status, aliases, out_links, similarity(lower(title), ?) AS sim", q).
+		Select("slug, title, page_type, status, aliases, out_links, source_refs, similarity(lower(title), ?) AS sim", q).
 		Where("knowledge_base_id = ? AND page_type IN ? AND status <> ? AND lower(title) % ?",
 			kbID, pageTypes, types.WikiPageStatusArchived, q).
 		Order("sim DESC").

--- a/internal/application/service/extract.go
+++ b/internal/application/service/extract.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -17,6 +18,8 @@ import (
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/models/chat"
 	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/models/inferencecache"
+	"github.com/Tencent/WeKnora/internal/searchutil"
 	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
@@ -161,6 +164,7 @@ func NewDataTableSummaryTask(
 type ChunkExtractService struct {
 	template          *types.PromptTemplateStructured
 	modelService      interfaces.ModelService
+	inferenceCache    inferencecache.Cache
 	knowledgeBaseRepo interfaces.KnowledgeBaseRepository
 	knowledgeRepo     interfaces.KnowledgeRepository
 	chunkRepo         interfaces.ChunkRepository
@@ -175,6 +179,7 @@ type ChunkExtractService struct {
 func NewChunkExtractService(
 	config *config.Config,
 	modelService interfaces.ModelService,
+	inferenceCache inferencecache.Cache,
 	knowledgeBaseRepo interfaces.KnowledgeBaseRepository,
 	knowledgeRepo interfaces.KnowledgeRepository,
 	chunkRepo interfaces.ChunkRepository,
@@ -184,6 +189,7 @@ func NewChunkExtractService(
 	return &ChunkExtractService{
 		template:          config.ExtractManager.ExtractGraph,
 		modelService:      modelService,
+		inferenceCache:    inferenceCache,
 		knowledgeBaseRepo: knowledgeBaseRepo,
 		knowledgeRepo:     knowledgeRepo,
 		chunkRepo:         chunkRepo,
@@ -330,8 +336,30 @@ func (s *ChunkExtractService) Handle(ctx context.Context, t *asynq.Task) error {
 			},
 		},
 	}
-	extractor := chatpipeline.NewExtractor(chatModel, template)
-	graph, err := extractor.Extract(ctx, chunk.Content)
+	templateJSON, _ := json.Marshal(template)
+	modelInput := searchutil.CanonicalizeImageURLsForModel(chunk.Content)
+	graphKey := inferencecache.Key(
+		"graphrag.extract", p.TenantID, chat.FingerprintOf(chatModel),
+		[]byte(types.LanguageNameFromContext(ctx)), templateJSON, []byte(modelInput),
+	)
+	graph, cacheStats, err := inferencecache.ResolveJSON(ctx, s.inferenceCache, graphKey,
+		func(loadCtx context.Context) (*types.GraphData, error) {
+			extractor := chatpipeline.NewExtractor(chatModel, template)
+			result, extractErr := extractor.Extract(loadCtx, modelInput)
+			if extractErr == nil && result == nil {
+				return nil, errors.New("graph extractor returned nil result")
+			}
+			return result, extractErr
+		})
+	if cacheStats.ReadError != nil {
+		logger.Warnf(ctx, "[InferenceCache] GraphRAG read failed, using provider: %v", cacheStats.ReadError)
+	}
+	if cacheStats.WriteError != nil {
+		logger.Warnf(ctx, "[InferenceCache] GraphRAG write failed: %v", cacheStats.WriteError)
+	}
+	graphOut["cache_hit"] = cacheStats.Hit || cacheStats.Coalesced
+	logger.Infof(ctx, "[InferenceCache] stage=graphrag.extract hit=%v coalesced=%v",
+		cacheStats.Hit, cacheStats.Coalesced)
 	if err != nil {
 		handleErr = err
 		return err

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -14,6 +14,7 @@ import (
 	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
 	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/models/inferencecache"
 	"github.com/Tencent/WeKnora/internal/models/utils/ollama"
 	"github.com/Tencent/WeKnora/internal/models/vlm"
 	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
@@ -74,6 +75,7 @@ type ImageMultimodalService struct {
 	ollamaService  *ollama.OllamaService
 	taskEnqueuer   interfaces.TaskEnqueuer
 	redisClient    *redis.Client
+	inferenceCache inferencecache.Cache
 	// fileSvc is the globally configured default FileService used as a fallback
 	// when the tenant-scoped storage config cannot produce a usable service
 	// (e.g. images were saved using the global MINIO_* env vars while the
@@ -97,6 +99,7 @@ func NewImageMultimodalService(
 	ollamaService *ollama.OllamaService,
 	taskEnqueuer interfaces.TaskEnqueuer,
 	redisClient *redis.Client,
+	inferenceCache inferencecache.Cache,
 	fileSvc interfaces.FileService,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
@@ -111,6 +114,7 @@ func NewImageMultimodalService(
 		ollamaService:  ollamaService,
 		taskEnqueuer:   taskEnqueuer,
 		redisClient:    redisClient,
+		inferenceCache: inferenceCache,
 		fileSvc:        fileSvc,
 		spanTracker:    spanTracker,
 	}
@@ -260,7 +264,8 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 		prompt = types.AppendCustomPromptInstructions(prompt, vlmCfg.CustomInstructions, "image_ocr")
 
-		ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt)
+		ocrText, ocrHit, ocrErr := s.predictVLM(ctx, payload.TenantID, "ocr", vlmModel, [][]byte{imgBytes}, prompt)
+		imgOut["ocr_cache_hit"] = ocrHit
 		if ocrErr != nil {
 			logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
 			imgOut["ocr_error"] = ocrErr.Error()
@@ -278,7 +283,9 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		}
 	}
 
-	caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, buildVLMCaptionPrompt(ctx, vlmCfg))
+	captionPrompt := buildVLMCaptionPrompt(ctx, vlmCfg)
+	caption, captionHit, capErr := s.predictVLM(ctx, payload.TenantID, "caption", vlmModel, [][]byte{imgBytes}, captionPrompt)
+	imgOut["caption_cache_hit"] = captionHit
 	if capErr != nil {
 		logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
 		imgOut["caption_error"] = capErr.Error()
@@ -355,6 +362,41 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 	// all images are processed before triggering summary/question generation.
 	// Deferred finalize handles the parent knowledge counter.
 	return nil
+}
+
+// predictVLM reuses successful OCR/caption output for the exact image bytes,
+// prompt, tenant and VLM configuration. Provider errors are never cached and
+// cache failures fail open through inferencecache.Cache.
+func (s *ImageMultimodalService) predictVLM(
+	ctx context.Context,
+	tenantID uint64,
+	operation string,
+	model vlm.VLM,
+	images [][]byte,
+	prompt string,
+) (string, bool, error) {
+	if s.inferenceCache == nil {
+		value, err := model.Predict(ctx, images, prompt)
+		return value, false, err
+	}
+	parts := make([][]byte, 0, len(images)+1)
+	parts = append(parts, []byte(prompt))
+	parts = append(parts, images...)
+	key := inferencecache.Key("vlm."+operation, tenantID, vlm.FingerprintOf(model), parts...)
+	raw, stats, err := s.inferenceCache.Resolve(ctx, key, func(loadCtx context.Context) ([]byte, error) {
+		value, predictErr := model.Predict(loadCtx, images, prompt)
+		return []byte(value), predictErr
+	})
+	if stats.ReadError != nil {
+		logger.Warnf(ctx, "[InferenceCache] VLM %s read failed, using provider: %v", operation, stats.ReadError)
+	}
+	if stats.WriteError != nil {
+		logger.Warnf(ctx, "[InferenceCache] VLM %s write failed: %v", operation, stats.WriteError)
+	}
+	if err == nil {
+		logger.Infof(ctx, "[InferenceCache] stage=vlm.%s hit=%v coalesced=%v", operation, stats.Hit, stats.Coalesced)
+	}
+	return string(raw), stats.Hit || stats.Coalesced, err
 }
 
 // shouldDropOrphanedMultimodal reports whether the task should exit without

--- a/internal/application/service/image_multimodal_cache_test.go
+++ b/internal/application/service/image_multimodal_cache_test.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/inferencecache"
+	"github.com/stretchr/testify/require"
+)
+
+type countingVLM struct {
+	calls atomic.Int32
+}
+
+func (v *countingVLM) Predict(_ context.Context, _ [][]byte, prompt string) (string, error) {
+	v.calls.Add(1)
+	return "result:" + prompt, nil
+}
+
+func (*countingVLM) GetModelName() string { return "fake-vlm" }
+func (*countingVLM) GetModelID() string   { return "fake-vlm-id" }
+
+func TestImageMultimodalPredictVLMReusesExactRequest(t *testing.T) {
+	service := &ImageMultimodalService{inferenceCache: inferencecache.New(nil)}
+	model := &countingVLM{}
+	ctx := context.Background()
+	image := [][]byte{[]byte("same-image")}
+
+	first, hit, err := service.predictVLM(ctx, 7, "ocr", model, image, "same-prompt")
+	require.NoError(t, err)
+	require.False(t, hit)
+	second, hit, err := service.predictVLM(ctx, 7, "ocr", model, image, "same-prompt")
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Equal(t, first, second)
+	require.Equal(t, int32(1), model.calls.Load())
+
+	_, hit, err = service.predictVLM(ctx, 7, "ocr", model, image, "changed-prompt")
+	require.NoError(t, err)
+	require.False(t, hit)
+	require.Equal(t, int32(2), model.calls.Load())
+}

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -15,6 +15,7 @@ import (
 	werrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/infrastructure/docparser"
 	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/models/inferencecache"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"github.com/redis/go-redis/v9"
@@ -60,6 +61,7 @@ type knowledgeService struct {
 	taskInspector   interfaces.TaskInspector
 	graphEngine     interfaces.RetrieveGraphRepository
 	redisClient     *redis.Client
+	inferenceCache  inferencecache.Cache
 	kbShareService  interfaces.KBShareService
 	imageResolver   *docparser.ImageResolver
 	taskPendingRepo interfaces.TaskPendingOpsRepository
@@ -103,6 +105,7 @@ func NewKnowledgeService(
 	retrieveEngine interfaces.RetrieveEngineRegistry,
 	ownership retriever.TenantStoreOwnership,
 	redisClient *redis.Client,
+	inferenceCache inferencecache.Cache,
 	kbShareService interfaces.KBShareService,
 	imageResolver *docparser.ImageResolver,
 	wikiRepo interfaces.WikiPageRepository,
@@ -129,6 +132,7 @@ func NewKnowledgeService(
 		retrieveEngine:  retrieveEngine,
 		ownership:       ownership,
 		redisClient:     redisClient,
+		inferenceCache:  inferenceCache,
 		kbShareService:  kbShareService,
 		imageResolver:   imageResolver,
 		wikiRepo:        wikiRepo,

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/models/chat"
 	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/models/inferencecache"
 	"github.com/Tencent/WeKnora/internal/searchutil"
 	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
@@ -740,10 +741,10 @@ func checkSufficientSummaryContent(ctx context.Context, knowledgeID, content str
 // getSummary generates a summary for knowledge content using an AI model
 func (s *knowledgeService) getSummary(ctx context.Context,
 	summaryModel chat.Chat, knowledge *types.Knowledge, chunks []*types.Chunk,
-) (string, error) {
+) (string, inferencecache.Stats, error) {
 	// Get knowledge info from the first chunk
 	if len(chunks) == 0 {
-		return "", fmt.Errorf("no chunks provided for summary generation")
+		return "", inferencecache.Stats{}, fmt.Errorf("no chunks provided for summary generation")
 	}
 
 	// Determine max input chars from config
@@ -799,6 +800,11 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 		}
 	}
 
+	// Export filenames and signed URLs are transport metadata and may change on
+	// every parse. Canonicalize them before sampling so URL length/entropy cannot
+	// shift the sampled text or invalidate an otherwise identical summary.
+	chunkContents = searchutil.CanonicalizeImageURLsForModel(chunkContents)
+
 	// Apply length limit: sample long content to fit within maxInputChars
 	chunkContents = sampleLongContent(chunkContents, maxInputChars)
 
@@ -812,7 +818,7 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 	// hallucinate a scanner manual instead of admitting the document had no
 	// extractable text.
 	if err := checkSufficientSummaryContent(ctx, knowledge.ID, chunkContents); err != nil {
-		return "", err
+		return "", inferencecache.Stats{}, err
 	}
 
 	// Pass the raw chunk text to the LLM with no filename / file-type framing.
@@ -824,31 +830,63 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 		maxTokens = s.config.Conversation.Summary.MaxCompletionTokens
 	}
 
-	// Generate summary using AI model
+	// Generate or reuse the summary. The key includes the fully rendered prompt,
+	// final provider input, model fingerprint and all request-affecting options.
 	summaryPrompt := types.RenderPromptPlaceholders(s.config.Conversation.GenerateSummaryPrompt, types.PlaceholderValues{
 		"language": types.LanguageNameFromContext(ctx),
 	})
 	thinking := false
-	summary, err := summaryModel.Chat(ctx, []chat.Message{
-		{
-			Role:    "system",
-			Content: summaryPrompt,
-		},
-		{
-			Role:    "user",
-			Content: contentWithMetadata,
-		},
-	}, &chat.ChatOptions{
-		Temperature: 0.3,
-		MaxTokens:   maxTokens,
-		Thinking:    &thinking,
-	})
+	const summaryTemperature = 0.3
+	cacheInput := documentSummaryCacheInput{
+		Language:            types.LanguageNameFromContext(ctx),
+		Prompt:              summaryPrompt,
+		Content:             contentWithMetadata,
+		MaxInputChars:       maxInputChars,
+		MaxCompletionTokens: maxTokens,
+		Temperature:         summaryTemperature,
+		Thinking:            thinking,
+	}
+	cacheKey := documentSummaryCacheKey(ctx, summaryModel, cacheInput)
+	summary, cacheStats, err := resolveDocumentSummaryValue(ctx, s.inferenceCache, cacheKey,
+		func(loadCtx context.Context) (string, error) {
+			response, chatErr := summaryModel.Chat(loadCtx, []chat.Message{
+				{
+					Role:    "system",
+					Content: summaryPrompt,
+				},
+				{
+					Role:    "user",
+					Content: contentWithMetadata,
+				},
+			}, &chat.ChatOptions{
+				Temperature: summaryTemperature,
+				MaxTokens:   maxTokens,
+				Thinking:    &thinking,
+			})
+			if chatErr != nil {
+				return "", chatErr
+			}
+			if response == nil {
+				return "", errors.New("summary model returned nil response")
+			}
+			return response.Content, nil
+		})
+	if cacheStats.ReadError != nil {
+		logger.Warnf(ctx, "[InferenceCache] document summary read failed, using provider: %v", cacheStats.ReadError)
+	}
+	if cacheStats.WriteError != nil {
+		logger.Warnf(ctx, "[InferenceCache] document summary write failed: %v", cacheStats.WriteError)
+	}
+	if err == nil {
+		logger.Infof(ctx, "[InferenceCache] stage=document.summary key=%s hit=%v coalesced=%v",
+			inferenceCacheKeyID(cacheKey), cacheStats.Hit, cacheStats.Coalesced)
+	}
 	if err != nil {
 		logger.GetLogger(ctx).WithField("error", err).Errorf("GetSummary failed")
-		return "", err
+		return "", cacheStats, err
 	}
-	logger.GetLogger(ctx).WithField("summary", summary.Content).Infof("GetSummary success")
-	return summary.Content, nil
+	logger.GetLogger(ctx).WithField("summary", summary).Infof("GetSummary success")
+	return summary, cacheStats, nil
 }
 
 // sampleLongContent returns content that fits within maxChars.
@@ -1050,7 +1088,9 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 	}
 
 	// Generate summary
-	summary, err := s.getSummary(ctx, chatModel, knowledge, textChunks)
+	summary, summaryCacheStats, err := s.getSummary(ctx, chatModel, knowledge, textChunks)
+	summaryOut["cache_hit"] = summaryCacheStats.Hit || summaryCacheStats.Coalesced
+	summaryOut["cache_coalesced"] = summaryCacheStats.Coalesced
 	if err != nil {
 		logger.Errorf(ctx, "Failed to generate summary for knowledge %s: %v", payload.KnowledgeID, err)
 		// Surface the underlying LLM/IO error on the span so the trace UI
@@ -1927,24 +1967,67 @@ func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
 		"language":       langName,
 	})
 	prompt = types.AppendCustomPromptInstructions(prompt, customInstructions, "question_generation")
+	// Export paths and signed image URLs are transport metadata. Removing them
+	// before both the provider call and cache lookup makes the question input
+	// stable across an otherwise identical reparse while preserving OCR,
+	// captions, alt text and surrounding prose.
+	prompt = searchutil.CanonicalizeImageURLsForModel(prompt)
 
 	thinking := false
-	response, err := chatModel.Chat(ctx, []chat.Message{
-		{
-			Role:    "user",
-			Content: prompt,
-		},
-	}, &chat.ChatOptions{
-		Temperature: 0.7,
-		MaxTokens:   512,
-		Thinking:    &thinking,
+	const (
+		questionTemperature = 0.7
+		questionMaxTokens   = 512
+	)
+	cacheKey := documentQuestionCacheKey(ctx, chatModel, documentQuestionCacheInput{
+		Prompt:        prompt,
+		QuestionCount: questionCount,
+		Temperature:   questionTemperature,
+		MaxTokens:     questionMaxTokens,
+		Thinking:      thinking,
 	})
+	questions, cacheStats, err := resolveDocumentQuestionsValue(ctx, s.inferenceCache, cacheKey,
+		func(loadCtx context.Context) ([]string, error) {
+			response, chatErr := chatModel.Chat(loadCtx, []chat.Message{
+				{
+					Role:    "user",
+					Content: prompt,
+				},
+			}, &chat.ChatOptions{
+				Temperature: questionTemperature,
+				MaxTokens:   questionMaxTokens,
+				Thinking:    &thinking,
+			})
+			if chatErr != nil {
+				return nil, chatErr
+			}
+			if response == nil {
+				return nil, errors.New("question model returned nil response")
+			}
+			return parseGeneratedQuestions(response.Content, questionCount), nil
+		})
+	if cacheStats.ReadError != nil {
+		logger.Warnf(ctx, "[InferenceCache] document questions read failed, using provider: %v", cacheStats.ReadError)
+	}
+	if cacheStats.WriteError != nil {
+		logger.Warnf(ctx, "[InferenceCache] document questions write failed: %v", cacheStats.WriteError)
+	}
+	if err == nil {
+		logger.Infof(ctx, "[InferenceCache] stage=document.questions key=%s hit=%v coalesced=%v",
+			inferenceCacheKeyID(cacheKey), cacheStats.Hit, cacheStats.Coalesced)
+	}
 	if err != nil {
+		if errors.Is(err, errEmptyDocumentQuestions) {
+			// Preserve the existing behavior: an empty model response is a
+			// successful no-op for this chunk, but is deliberately not cached.
+			return nil, nil
+		}
 		return nil, fmt.Errorf("failed to generate questions: %w", err)
 	}
+	return questions, nil
+}
 
-	// Parse response
-	lines := strings.Split(response.Content, "\n")
+func parseGeneratedQuestions(content string, questionCount int) []string {
+	lines := strings.Split(content, "\n")
 	questions := make([]string, 0, questionCount)
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
@@ -1960,8 +2043,7 @@ func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
 			}
 		}
 	}
-
-	return questions, nil
+	return questions
 }
 
 // ReparseKnowledge deletes existing document content and re-parses the knowledge asynchronously.

--- a/internal/application/service/knowledge_question_cache.go
+++ b/internal/application/service/knowledge_question_cache.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/models/inferencecache"
+	"github.com/Tencent/WeKnora/internal/searchutil"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+const documentQuestionCacheVersion = "v1"
+
+var errEmptyDocumentQuestions = errors.New("question model returned no valid questions")
+
+// documentQuestionCacheInput contains the exact provider request after prompt
+// rendering plus every request option that can affect the generated questions.
+// The rendered prompt already contains the chunk, its neighbors, document
+// title, language, requested count and custom instructions.
+type documentQuestionCacheInput struct {
+	Version       string  `json:"version"`
+	Prompt        string  `json:"prompt"`
+	QuestionCount int     `json:"question_count"`
+	Temperature   float64 `json:"temperature"`
+	MaxTokens     int     `json:"max_tokens"`
+	Thinking      bool    `json:"thinking"`
+}
+
+func documentQuestionCacheKey(
+	ctx context.Context,
+	questionModel chat.Chat,
+	input documentQuestionCacheInput,
+) string {
+	tenantID, _ := types.TenantIDFromContext(ctx)
+	input.Version = documentQuestionCacheVersion
+	input.Prompt = searchutil.CanonicalizeImageURLsForModel(input.Prompt)
+	encoded, _ := json.Marshal(input)
+	return inferencecache.Key(
+		"document.questions",
+		tenantID,
+		chat.FingerprintOf(questionModel),
+		[]byte(documentQuestionCacheVersion),
+		encoded,
+	)
+}
+
+func normalizeDocumentQuestions(questions []string) ([]string, error) {
+	normalized := make([]string, 0, len(questions))
+	for _, question := range questions {
+		question = strings.TrimSpace(question)
+		if question != "" {
+			normalized = append(normalized, question)
+		}
+	}
+	if len(normalized) == 0 {
+		return nil, errEmptyDocumentQuestions
+	}
+	return normalized, nil
+}
+
+// resolveDocumentQuestionsValue caches only validated, non-empty question
+// lists. Provider/parse errors and empty results are never retained. A valid
+// JSON but semantically empty legacy/corrupt entry is evicted and recomputed.
+func resolveDocumentQuestionsValue(
+	ctx context.Context,
+	cache inferencecache.Cache,
+	key string,
+	loader func(context.Context) ([]string, error),
+) ([]string, inferencecache.Stats, error) {
+	validatedLoader := func(loadCtx context.Context) ([]string, error) {
+		questions, err := loader(loadCtx)
+		if err != nil {
+			return nil, err
+		}
+		return normalizeDocumentQuestions(questions)
+	}
+
+	if cache == nil {
+		questions, err := validatedLoader(ctx)
+		return questions, inferencecache.Stats{}, err
+	}
+
+	questions, stats, err := inferencecache.ResolveJSON(ctx, cache, key, validatedLoader)
+	if err != nil {
+		return nil, stats, err
+	}
+	questions, validationErr := normalizeDocumentQuestions(questions)
+	if validationErr == nil {
+		return questions, stats, nil
+	}
+
+	_ = cache.Invalidate(ctx, key)
+	questions, retryStats, err := inferencecache.ResolveJSON(ctx, cache, key, validatedLoader)
+	stats.Hit = false
+	stats.Coalesced = retryStats.Coalesced
+	stats.WriteError = retryStats.WriteError
+	if stats.ReadError == nil {
+		stats.ReadError = validationErr
+	}
+	if err != nil {
+		return nil, stats, err
+	}
+	questions, err = normalizeDocumentQuestions(questions)
+	return questions, stats, err
+}

--- a/internal/application/service/knowledge_question_cache_test.go
+++ b/internal/application/service/knowledge_question_cache_test.go
@@ -1,0 +1,202 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/models/inferencecache"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+type questionCacheTestChat struct {
+	id   string
+	name string
+}
+
+func (*questionCacheTestChat) Chat(context.Context, []chat.Message, *chat.ChatOptions) (*types.ChatResponse, error) {
+	return nil, nil
+}
+
+func (*questionCacheTestChat) ChatStream(context.Context, []chat.Message, *chat.ChatOptions) (<-chan types.StreamResponse, error) {
+	return nil, nil
+}
+
+func (m *questionCacheTestChat) GetModelName() string { return m.name }
+func (m *questionCacheTestChat) GetModelID() string   { return m.id }
+
+func TestDocumentQuestionCacheKeyLayeredInvalidation(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(10000))
+	model := &questionCacheTestChat{id: "model-a", name: "chat-a"}
+	base := documentQuestionCacheInput{
+		Prompt:        "Generate 3 questions for ![diagram](local://exports/random-a.png)",
+		QuestionCount: 3,
+		Temperature:   0.7,
+		MaxTokens:     512,
+		Thinking:      false,
+	}
+	baseKey := documentQuestionCacheKey(ctx, model, base)
+
+	sameContentNewURL := base
+	sameContentNewURL.Prompt = "Generate 3 questions for ![diagram](local://exports/random-b.png)"
+	if got := documentQuestionCacheKey(ctx, model, sameContentNewURL); got != baseKey {
+		t.Fatalf("random image URL changed question cache key: %q != %q", got, baseKey)
+	}
+
+	tests := []struct {
+		name  string
+		ctx   context.Context
+		model chat.Chat
+		input documentQuestionCacheInput
+	}{
+		{
+			name:  "tenant",
+			ctx:   context.WithValue(context.Background(), types.TenantIDContextKey, uint64(10001)),
+			model: model,
+			input: base,
+		},
+		{
+			name:  "model",
+			ctx:   ctx,
+			model: &questionCacheTestChat{id: "model-b", name: "chat-b"},
+			input: base,
+		},
+	}
+
+	changed := base
+	changed.Prompt = "Generate questions using a revised prompt"
+	tests = append(tests, struct {
+		name  string
+		ctx   context.Context
+		model chat.Chat
+		input documentQuestionCacheInput
+	}{"prompt", ctx, model, changed})
+	changed = base
+	changed.QuestionCount++
+	tests = append(tests, struct {
+		name  string
+		ctx   context.Context
+		model chat.Chat
+		input documentQuestionCacheInput
+	}{"question count", ctx, model, changed})
+	changed = base
+	changed.Temperature = 0.8
+	tests = append(tests, struct {
+		name  string
+		ctx   context.Context
+		model chat.Chat
+		input documentQuestionCacheInput
+	}{"temperature", ctx, model, changed})
+	changed = base
+	changed.MaxTokens++
+	tests = append(tests, struct {
+		name  string
+		ctx   context.Context
+		model chat.Chat
+		input documentQuestionCacheInput
+	}{"max tokens", ctx, model, changed})
+	changed = base
+	changed.Thinking = true
+	tests = append(tests, struct {
+		name  string
+		ctx   context.Context
+		model chat.Chat
+		input documentQuestionCacheInput
+	}{"thinking", ctx, model, changed})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := documentQuestionCacheKey(tt.ctx, tt.model, tt.input); got == baseKey {
+				t.Fatalf("%s change did not invalidate question cache key", tt.name)
+			}
+		})
+	}
+}
+
+func TestResolveDocumentQuestionsValueCachesOnlySuccessfulNonEmptyResults(t *testing.T) {
+	t.Setenv("WEKNORA_INFERENCE_CACHE_ENABLED", "true")
+	cache := inferencecache.New(nil)
+	ctx := context.Background()
+
+	successCalls := 0
+	loader := func(context.Context) ([]string, error) {
+		successCalls++
+		return []string{"  First question?  ", "Second question?"}, nil
+	}
+	first, firstStats, err := resolveDocumentQuestionsValue(ctx, cache, "questions-success", loader)
+	if err != nil {
+		t.Fatalf("first resolve failed: %v", err)
+	}
+	if firstStats.Hit || len(first) != 2 || first[0] != "First question?" {
+		t.Fatalf("unexpected first resolve: value=%v stats=%+v", first, firstStats)
+	}
+	second, secondStats, err := resolveDocumentQuestionsValue(ctx, cache, "questions-success", loader)
+	if err != nil {
+		t.Fatalf("second resolve failed: %v", err)
+	}
+	if !secondStats.Hit || len(second) != 2 || successCalls != 1 {
+		t.Fatalf("questions were not reused: value=%v stats=%+v calls=%d", second, secondStats, successCalls)
+	}
+
+	providerErr := errors.New("provider unavailable")
+	errorCalls := 0
+	errorLoader := func(context.Context) ([]string, error) {
+		errorCalls++
+		return nil, providerErr
+	}
+	for i := 0; i < 2; i++ {
+		if _, _, err := resolveDocumentQuestionsValue(ctx, cache, "questions-error", errorLoader); !errors.Is(err, providerErr) {
+			t.Fatalf("attempt %d: expected provider error, got %v", i+1, err)
+		}
+	}
+	if errorCalls != 2 {
+		t.Fatalf("provider errors were cached: calls=%d", errorCalls)
+	}
+
+	emptyCalls := 0
+	emptyLoader := func(context.Context) ([]string, error) {
+		emptyCalls++
+		return []string{"", "   "}, nil
+	}
+	for i := 0; i < 2; i++ {
+		if _, _, err := resolveDocumentQuestionsValue(ctx, cache, "questions-empty", emptyLoader); !errors.Is(err, errEmptyDocumentQuestions) {
+			t.Fatalf("attempt %d: expected empty-question error, got %v", i+1, err)
+		}
+	}
+	if emptyCalls != 2 {
+		t.Fatalf("empty question lists were cached: calls=%d", emptyCalls)
+	}
+}
+
+func TestResolveDocumentQuestionsValueRepairsSemanticallyEmptyEntry(t *testing.T) {
+	t.Setenv("WEKNORA_INFERENCE_CACHE_ENABLED", "true")
+	cache := inferencecache.New(nil)
+	ctx := context.Background()
+	const key = "questions-corrupt-empty"
+
+	if _, _, err := cache.Resolve(ctx, key, func(context.Context) ([]byte, error) {
+		return []byte("[]"), nil
+	}); err != nil {
+		t.Fatalf("seed empty cache entry: %v", err)
+	}
+
+	loaderCalls := 0
+	questions, stats, err := resolveDocumentQuestionsValue(ctx, cache, key, func(context.Context) ([]string, error) {
+		loaderCalls++
+		return []string{"Recovered question?"}, nil
+	})
+	if err != nil {
+		t.Fatalf("repair resolve failed: %v", err)
+	}
+	if stats.Hit || loaderCalls != 1 || len(questions) != 1 || questions[0] != "Recovered question?" {
+		t.Fatalf("unexpected repaired result: value=%v stats=%+v calls=%d", questions, stats, loaderCalls)
+	}
+}
+
+func TestParseGeneratedQuestions(t *testing.T) {
+	got := parseGeneratedQuestions("1. What is WeKnora?\n2) How does caching work?\n- Why use RAG?\n", 2)
+	if len(got) != 2 || got[0] != "What is WeKnora?" || got[1] != "How does caching work?" {
+		t.Fatalf("parsed questions = %v", got)
+	}
+}

--- a/internal/application/service/knowledge_summary_cache.go
+++ b/internal/application/service/knowledge_summary_cache.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/models/inferencecache"
+	"github.com/Tencent/WeKnora/internal/searchutil"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+const documentSummaryCacheVersion = "v1"
+
+var errEmptyDocumentSummary = errors.New("summary model returned empty content")
+
+// documentSummaryCacheInput contains every non-model input that can change a
+// generated document summary. Content is the final, image-enriched and sampled
+// text sent to the provider, so parser, chunking, OCR/caption and sampling
+// changes invalidate this layer only when they affect the actual request.
+type documentSummaryCacheInput struct {
+	Version             string  `json:"version"`
+	Language            string  `json:"language"`
+	Prompt              string  `json:"prompt"`
+	Content             string  `json:"content"`
+	MaxInputChars       int     `json:"max_input_chars"`
+	MaxCompletionTokens int     `json:"max_completion_tokens"`
+	Temperature         float64 `json:"temperature"`
+	Thinking            bool    `json:"thinking"`
+}
+
+func documentSummaryCacheKey(
+	ctx context.Context,
+	summaryModel chat.Chat,
+	input documentSummaryCacheInput,
+) string {
+	tenantID, _ := types.TenantIDFromContext(ctx)
+	input.Version = documentSummaryCacheVersion
+	input.Content = searchutil.CanonicalizeImageURLsForModel(input.Content)
+	encoded, _ := json.Marshal(input)
+	return inferencecache.Key(
+		"document.summary",
+		tenantID,
+		chat.FingerprintOf(summaryModel),
+		[]byte(documentSummaryCacheVersion),
+		encoded,
+	)
+}
+
+// resolveDocumentSummaryValue caches only validated, non-empty provider
+// results. Errors and fallback summaries are deliberately excluded. An empty
+// or corrupt cached entry is evicted and recomputed once.
+func resolveDocumentSummaryValue(
+	ctx context.Context,
+	cache inferencecache.Cache,
+	key string,
+	loader func(context.Context) (string, error),
+) (string, inferencecache.Stats, error) {
+	validatedLoader := func(loadCtx context.Context) ([]byte, error) {
+		value, err := loader(loadCtx)
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(value) == "" {
+			return nil, errEmptyDocumentSummary
+		}
+		return []byte(value), nil
+	}
+
+	if cache == nil {
+		raw, err := validatedLoader(ctx)
+		return string(raw), inferencecache.Stats{}, err
+	}
+
+	raw, stats, err := cache.Resolve(ctx, key, validatedLoader)
+	if err != nil {
+		return "", stats, err
+	}
+	if strings.TrimSpace(string(raw)) != "" {
+		return string(raw), stats, nil
+	}
+
+	// Validated loaders never write an empty value, so this can only be a
+	// corrupt or legacy cache entry.
+	_ = cache.Invalidate(ctx, key)
+	raw, retryStats, err := cache.Resolve(ctx, key, validatedLoader)
+	stats.Hit = false
+	stats.Coalesced = retryStats.Coalesced
+	stats.WriteError = retryStats.WriteError
+	if stats.ReadError == nil {
+		stats.ReadError = errEmptyDocumentSummary
+	}
+	if err != nil {
+		return "", stats, err
+	}
+	return string(raw), stats, nil
+}

--- a/internal/application/service/knowledge_summary_cache_test.go
+++ b/internal/application/service/knowledge_summary_cache_test.go
@@ -1,0 +1,197 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/models/inferencecache"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+type summaryCacheTestChat struct {
+	id   string
+	name string
+}
+
+func (*summaryCacheTestChat) Chat(context.Context, []chat.Message, *chat.ChatOptions) (*types.ChatResponse, error) {
+	return nil, nil
+}
+
+func (*summaryCacheTestChat) ChatStream(context.Context, []chat.Message, *chat.ChatOptions) (<-chan types.StreamResponse, error) {
+	return nil, nil
+}
+
+func (m *summaryCacheTestChat) GetModelName() string { return m.name }
+func (m *summaryCacheTestChat) GetModelID() string   { return m.id }
+
+func TestDocumentSummaryCacheKeyLayeredInvalidation(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(10000))
+	model := &summaryCacheTestChat{id: "model-a", name: "chat-a"}
+	base := documentSummaryCacheInput{
+		Language:            "English",
+		Prompt:              "Summarize in English",
+		Content:             "stable frozen document content",
+		MaxInputChars:       24 * 1024,
+		MaxCompletionTokens: 2048,
+		Temperature:         0.3,
+		Thinking:            false,
+	}
+	baseKey := documentSummaryCacheKey(ctx, model, base)
+	if got := documentSummaryCacheKey(ctx, model, base); got != baseKey {
+		t.Fatalf("identical inputs produced different keys: %q != %q", got, baseKey)
+	}
+
+	tests := []struct {
+		name  string
+		ctx   context.Context
+		model chat.Chat
+		input documentSummaryCacheInput
+	}{
+		{
+			name:  "tenant",
+			ctx:   context.WithValue(context.Background(), types.TenantIDContextKey, uint64(10001)),
+			model: model,
+			input: base,
+		},
+		{
+			name:  "model",
+			ctx:   ctx,
+			model: &summaryCacheTestChat{id: "model-b", name: "chat-b"},
+			input: base,
+		},
+	}
+
+	changed := base
+	changed.Content = "changed document content"
+	tests = append(tests, struct {
+		name  string
+		ctx   context.Context
+		model chat.Chat
+		input documentSummaryCacheInput
+	}{"content", ctx, model, changed})
+	changed = base
+	changed.Prompt = "A revised summary prompt"
+	tests = append(tests, struct {
+		name  string
+		ctx   context.Context
+		model chat.Chat
+		input documentSummaryCacheInput
+	}{"prompt", ctx, model, changed})
+	changed = base
+	changed.Language = "Chinese"
+	tests = append(tests, struct {
+		name  string
+		ctx   context.Context
+		model chat.Chat
+		input documentSummaryCacheInput
+	}{"language", ctx, model, changed})
+	changed = base
+	changed.MaxInputChars++
+	tests = append(tests, struct {
+		name  string
+		ctx   context.Context
+		model chat.Chat
+		input documentSummaryCacheInput
+	}{"max input", ctx, model, changed})
+	changed = base
+	changed.MaxCompletionTokens++
+	tests = append(tests, struct {
+		name  string
+		ctx   context.Context
+		model chat.Chat
+		input documentSummaryCacheInput
+	}{"max completion", ctx, model, changed})
+	changed = base
+	changed.Temperature = 0.4
+	tests = append(tests, struct {
+		name  string
+		ctx   context.Context
+		model chat.Chat
+		input documentSummaryCacheInput
+	}{"temperature", ctx, model, changed})
+	changed = base
+	changed.Thinking = true
+	tests = append(tests, struct {
+		name  string
+		ctx   context.Context
+		model chat.Chat
+		input documentSummaryCacheInput
+	}{"thinking", ctx, model, changed})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := documentSummaryCacheKey(tt.ctx, tt.model, tt.input); got == baseKey {
+				t.Fatalf("%s change did not invalidate summary cache key", tt.name)
+			}
+		})
+	}
+
+	firstImage := base
+	firstImage.Content = "diagram ![architecture](local://exports/random-a.png)\n<image_caption>system layout</image_caption>"
+	secondImage := firstImage
+	secondImage.Content = "diagram ![architecture](local://exports/random-b.png)\n<image_caption>system layout</image_caption>"
+	if firstKey, secondKey := documentSummaryCacheKey(ctx, model, firstImage), documentSummaryCacheKey(ctx, model, secondImage); firstKey != secondKey {
+		t.Fatalf("random image URL changed summary cache key: %q != %q", firstKey, secondKey)
+	}
+	secondImage.Content = "diagram ![architecture](local://exports/random-b.png)\n<image_caption>changed layout</image_caption>"
+	if documentSummaryCacheKey(ctx, model, firstImage) == documentSummaryCacheKey(ctx, model, secondImage) {
+		t.Fatal("semantic image caption change did not invalidate summary cache key")
+	}
+}
+
+func TestResolveDocumentSummaryValueCachesOnlySuccessfulNonEmptyResults(t *testing.T) {
+	t.Setenv("WEKNORA_INFERENCE_CACHE_ENABLED", "true")
+	cache := inferencecache.New(nil)
+	ctx := context.Background()
+
+	successCalls := 0
+	loader := func(context.Context) (string, error) {
+		successCalls++
+		return "cached summary", nil
+	}
+	first, firstStats, err := resolveDocumentSummaryValue(ctx, cache, "summary-success", loader)
+	if err != nil {
+		t.Fatalf("first resolve failed: %v", err)
+	}
+	if first != "cached summary" || firstStats.Hit {
+		t.Fatalf("unexpected first resolve: value=%q hit=%v", first, firstStats.Hit)
+	}
+	second, secondStats, err := resolveDocumentSummaryValue(ctx, cache, "summary-success", loader)
+	if err != nil {
+		t.Fatalf("second resolve failed: %v", err)
+	}
+	if second != first || !secondStats.Hit || successCalls != 1 {
+		t.Fatalf("summary was not reused: value=%q hit=%v calls=%d", second, secondStats.Hit, successCalls)
+	}
+
+	providerErr := errors.New("provider unavailable")
+	errorCalls := 0
+	errorLoader := func(context.Context) (string, error) {
+		errorCalls++
+		return "", providerErr
+	}
+	for i := 0; i < 2; i++ {
+		if _, _, err := resolveDocumentSummaryValue(ctx, cache, "summary-error", errorLoader); !errors.Is(err, providerErr) {
+			t.Fatalf("attempt %d: expected provider error, got %v", i+1, err)
+		}
+	}
+	if errorCalls != 2 {
+		t.Fatalf("provider errors were cached: calls=%d", errorCalls)
+	}
+
+	emptyCalls := 0
+	emptyLoader := func(context.Context) (string, error) {
+		emptyCalls++
+		return "   ", nil
+	}
+	for i := 0; i < 2; i++ {
+		if _, _, err := resolveDocumentSummaryValue(ctx, cache, "summary-empty", emptyLoader); !errors.Is(err, errEmptyDocumentSummary) {
+			t.Fatalf("attempt %d: expected empty-summary error, got %v", i+1, err)
+		}
+	}
+	if emptyCalls != 2 {
+		t.Fatalf("empty summaries were cached: calls=%d", emptyCalls)
+	}
+}

--- a/internal/application/service/model.go
+++ b/internal/application/service/model.go
@@ -29,6 +29,7 @@ type modelService struct {
 	agentRepo     interfaces.CustomAgentRepository
 	ollamaService *ollama.OllamaService
 	pooler        embedding.EmbedderPooler
+	vectorCache   embedding.VectorCache
 	tenantService interfaces.TenantService
 }
 
@@ -38,6 +39,7 @@ func NewModelService(repo interfaces.ModelRepository,
 	agentRepo interfaces.CustomAgentRepository,
 	ollamaService *ollama.OllamaService,
 	pooler embedding.EmbedderPooler,
+	vectorCache embedding.VectorCache,
 	tenantService interfaces.TenantService,
 ) interfaces.ModelService {
 	return &modelService{
@@ -46,6 +48,7 @@ func NewModelService(repo interfaces.ModelRepository,
 		agentRepo:     agentRepo,
 		ollamaService: ollamaService,
 		pooler:        pooler,
+		vectorCache:   vectorCache,
 		tenantService: tenantService,
 	}
 }
@@ -423,7 +426,8 @@ func (s *modelService) GetEmbeddingModel(ctx context.Context, modelId string) (e
 
 	appID, appSecret := s.resolveWeKnoraCloudCredentials(ctx, &model.Parameters)
 
-	embedder, err := embedding.NewEmbedder(embedding.ConfigFromModel(model, appID, appSecret), s.pooler, s.ollamaService)
+	embedConfig := embedding.ConfigFromModel(model, appID, appSecret)
+	embedder, err := embedding.NewEmbedder(embedConfig, s.pooler, s.ollamaService)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"model_id":   model.ID,
@@ -432,8 +436,11 @@ func (s *modelService) GetEmbeddingModel(ctx context.Context, modelId string) (e
 		return nil, err
 	}
 
+	tenantID := types.MustTenantIDFromContext(ctx)
 	logger.Info(ctx, "Embedding model initialized successfully")
-	return embedder, nil
+	return embedding.NewCachedEmbedder(
+		embedder, s.vectorCache, tenantID, embedding.ModelFingerprint(embedConfig),
+	), nil
 }
 
 // GetEmbeddingModelForTenant retrieves and initializes an embedding model for a specific tenant
@@ -470,7 +477,8 @@ func (s *modelService) GetEmbeddingModelForTenant(ctx context.Context, modelId s
 
 	appID, appSecret := s.resolveWeKnoraCloudCredentials(ctx, &model.Parameters)
 
-	embedder, err := embedding.NewEmbedder(embedding.ConfigFromModel(model, appID, appSecret), s.pooler, s.ollamaService)
+	embedConfig := embedding.ConfigFromModel(model, appID, appSecret)
+	embedder, err := embedding.NewEmbedder(embedConfig, s.pooler, s.ollamaService)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"model_id":   model.ID,
@@ -481,7 +489,9 @@ func (s *modelService) GetEmbeddingModelForTenant(ctx context.Context, modelId s
 	}
 
 	logger.Info(ctx, "Cross-tenant embedding model initialized successfully")
-	return embedder, nil
+	return embedding.NewCachedEmbedder(
+		embedder, s.vectorCache, tenantID, embedding.ModelFingerprint(embedConfig),
+	), nil
 }
 
 // GetRerankModel retrieves and initializes a reranking model instance

--- a/internal/application/service/model_builtin_management_test.go
+++ b/internal/application/service/model_builtin_management_test.go
@@ -27,7 +27,7 @@ func TestUpdateBuiltinModel_RequiresSystemAdmin(t *testing.T) {
 			updated = true
 			return nil
 		},
-	}, nil, nil, nil, nil, nil)
+	}, nil, nil, nil, nil, nil, nil)
 
 	err := svc.UpdateModel(builtinModelContext(false), &types.Model{ID: stored.ID})
 	require.Error(t, err)
@@ -50,7 +50,7 @@ func TestUpdateBuiltinModel_SystemAdminCreatesRuntimeOverride(t *testing.T) {
 			saved = &copy
 			return nil
 		},
-	}, nil, nil, nil, nil, nil)
+	}, nil, nil, nil, nil, nil, nil)
 
 	input := &types.Model{ID: stored.ID, Name: "edited"}
 	require.NoError(t, svc.UpdateModel(builtinModelContext(true), input))
@@ -65,7 +65,7 @@ func TestUpdateBuiltinModelCredentials_SystemAdminOnly(t *testing.T) {
 
 	t.Run("tenant admin denied", func(t *testing.T) {
 		stored := &types.Model{ID: "builtin-chat", TenantID: 10000, IsBuiltin: true}
-		svc := NewModelService(&stubModelRepoForDelete{model: stored}, nil, nil, nil, nil, nil)
+		svc := NewModelService(&stubModelRepoForDelete{model: stored}, nil, nil, nil, nil, nil, nil)
 		_, err := svc.UpdateModelCredentials(builtinModelContext(false), stored.ID, &newKey, nil)
 		require.Error(t, err)
 		appErr, ok := apperrors.IsAppError(err)
@@ -86,7 +86,7 @@ func TestUpdateBuiltinModelCredentials_SystemAdminOnly(t *testing.T) {
 				saved = &copy
 				return nil
 			},
-		}, nil, nil, nil, nil, nil)
+		}, nil, nil, nil, nil, nil, nil)
 
 		updated, err := svc.UpdateModelCredentials(
 			builtinModelContext(true), stored.ID, &newKey, nil,

--- a/internal/application/service/model_delete_test.go
+++ b/internal/application/service/model_delete_test.go
@@ -112,7 +112,7 @@ func TestDeleteModel_RejectsWhenReferenced(t *testing.T) {
 		&stubModelRepoForDelete{model: &types.Model{ID: modelID, TenantID: 1}},
 		&stubKBRepoForModelDelete{count: 1},
 		&stubAgentRepoForModelDelete{count: 0},
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 
 	err := svc.DeleteModel(ctx, modelID)
@@ -131,7 +131,7 @@ func TestDeleteModel_RejectsWhenUsedByAgent(t *testing.T) {
 		&stubModelRepoForDelete{model: &types.Model{ID: modelID, TenantID: 1}},
 		&stubKBRepoForModelDelete{count: 0},
 		&stubAgentRepoForModelDelete{count: 2},
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 
 	err := svc.DeleteModel(ctx, modelID)
@@ -157,7 +157,7 @@ func TestDeleteModel_SucceedsWhenUnreferenced(t *testing.T) {
 		},
 		&stubKBRepoForModelDelete{},
 		&stubAgentRepoForModelDelete{},
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 
 	require.NoError(t, svc.DeleteModel(ctx, modelID))

--- a/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
+++ b/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
@@ -2,15 +2,14 @@ package retriever
 
 import (
 	"context"
-	"regexp"
 	"slices"
-	"strings"
 	"time"
 	"unicode/utf8"
 
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/models/embedding"
 	"github.com/Tencent/WeKnora/internal/models/utils"
+	"github.com/Tencent/WeKnora/internal/searchutil"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"golang.org/x/sync/errgroup"
@@ -29,13 +28,6 @@ const (
 	embedRetryAttempts  = 5
 	embedRetryBaseDelay = 200 * time.Millisecond
 )
-
-var embeddingImagePayloadPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`(?is)<img\b[^>]*\bsrc=["']\s*data:image/[a-z0-9.+-]+;base64,[^"']+["'][^>]*>`),
-	regexp.MustCompile(`(?is)!\[[^\]]*\]\(\s*data:image/[a-z0-9.+-]+;base64,[^)]+\)`),
-	regexp.MustCompile(`(?i)data:image/[a-z0-9.+-]+;base64,[a-z0-9+/=]{200,}`),
-	regexp.MustCompile(`(?i)data:[a-z0-9.+/-]+;base64,[a-z0-9+/=]{200,}`),
-}
 
 // KeywordsVectorHybridRetrieveEngineService implements a hybrid retrieval engine
 // that supports both keyword-based and vector-based retrieval
@@ -157,14 +149,7 @@ func batchEmbedWithBackoff(ctx context.Context, embedder embedding.Embedder, con
 // truncation point is char-based, not token-based, so it sits well above any
 // realistic token limit. We log a warning whenever truncation kicks in.
 func sanitizeForEmbedding(ctx context.Context, content string) string {
-	sanitized := content
-	// Scrubbing only matters when an inline base64 payload is present; skip the
-	// regex passes otherwise so the common (no-image) path stays cheap.
-	if strings.Contains(content, "base64,") {
-		for _, pattern := range embeddingImagePayloadPatterns {
-			sanitized = pattern.ReplaceAllString(sanitized, "[image]")
-		}
-	}
+	sanitized := searchutil.CanonicalizeImageURLsForModel(content)
 
 	if utf8.RuneCountInString(sanitized) <= safetyMaxChars {
 		return sanitized

--- a/internal/application/service/retriever/keywords_vector_hybrid_indexer_test.go
+++ b/internal/application/service/retriever/keywords_vector_hybrid_indexer_test.go
@@ -107,6 +107,47 @@ func TestBatchIndexTruncatesOversizedEmbeddingInput(t *testing.T) {
 	}
 }
 
+func TestSanitizeForEmbeddingCanonicalizesImageURLs(t *testing.T) {
+	ctx := context.Background()
+	first := "text ![Figure 2: Architecture](local://10000/exports/random-a_111.jpg) end"
+	second := "text ![Figure 2: Architecture](https://minio.example/random-b.jpg?signature=222) end"
+	if gotFirst, gotSecond := sanitizeForEmbedding(ctx, first), sanitizeForEmbedding(ctx, second); gotFirst != gotSecond {
+		t.Fatalf("same image caption produced different model inputs: %q != %q", gotFirst, gotSecond)
+	}
+
+	differentCaption := "text ![Figure 3: Results](local://10000/exports/random-a_111.jpg) end"
+	if sanitizeForEmbedding(ctx, first) == sanitizeForEmbedding(ctx, differentCaption) {
+		t.Fatal("different image captions must remain distinguishable")
+	}
+
+	ordinaryLink := "read [the paper](https://example.com/paper.pdf)"
+	if got := sanitizeForEmbedding(ctx, ordinaryLink); got != ordinaryLink {
+		t.Fatalf("ordinary link changed: %q", got)
+	}
+}
+
+func TestBatchIndexCanonicalizesHTMLImageSource(t *testing.T) {
+	ctx := context.Background()
+	embedder := &capturingEmbedder{}
+	service := &KeywordsVectorHybridRetrieveEngineService{indexRepository: &saveOnlyRepository{}}
+	content := `<img alt="plot" src="provider://exports/random.png" width="200">`
+
+	err := service.BatchIndex(ctx, embedder, []*types.IndexInfo{{
+		Content:  content,
+		SourceID: "source-1",
+	}}, []types.RetrieverType{types.VectorRetrieverType})
+	if err != nil {
+		t.Fatalf("BatchIndex returned error: %v", err)
+	}
+	if len(embedder.batchTexts) != 1 {
+		t.Fatalf("expected one embedding input, got %d", len(embedder.batchTexts))
+	}
+	want := `<img alt="plot" src="[image]" width="200">`
+	if embedder.batchTexts[0] != want {
+		t.Fatalf("embedding input = %q, want %q", embedder.batchTexts[0], want)
+	}
+}
+
 func assertImagePayloadRemoved(t *testing.T, content string, payload string) {
 	t.Helper()
 	if strings.Contains(content, "data:image/png;base64") || strings.Contains(content, payload) {

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -16,6 +17,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/agent"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/models/inferencecache"
 	"github.com/Tencent/WeKnora/internal/searchutil"
 	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
@@ -46,13 +48,12 @@ const (
 	// reduce locks (withSlugLock). Lite mode still serializes per KB via the
 	// in-process liteLocks map.
 	//
-	// wikiClaimStaleAfter is how long a claimed-but-undrained ingest row
-	// waits before another worker may re-claim it. It MUST exceed the asynq
-	// task Timeout for wiki:ingest (60m) so a still-running batch's rows are
-	// never stolen mid-flight — only genuinely crashed/abandoned claims are
-	// recovered. This preserves the pre-claim crash behaviour where a dead
-	// batch's undeleted rows were simply re-peeked by the next trigger.
-	wikiClaimStaleAfter = 90 * time.Minute
+	// claimed_at is a renewable lease rather than a one-shot timestamp. Live
+	// workers refresh it frequently; a kill -9 stops renewal and makes the
+	// abandoned rows reclaimable after this short safety window.
+	wikiClaimStaleAfter    = 2 * time.Minute
+	wikiClaimRenewInterval = 30 * time.Second
+	wikiClaimRenewTimeout  = 5 * time.Second
 
 	// wikiSlugLockPrefix guards read-modify-write on a single shared wiki
 	// page (entity/concept/summary/index) so two concurrent batches for the
@@ -306,6 +307,7 @@ type wikiIngestService struct {
 	knowledgeRepo  interfaces.KnowledgeRepository
 	chunkRepo      interfaces.ChunkRepository
 	modelService   interfaces.ModelService
+	inferenceCache inferencecache.Cache
 	task           interfaces.TaskEnqueuer
 	logEntrySvc    interfaces.WikiLogEntryService
 	pendingRepo    interfaces.TaskPendingOpsRepository
@@ -335,6 +337,7 @@ func NewWikiIngestService(
 	knowledgeRepo interfaces.KnowledgeRepository,
 	chunkRepo interfaces.ChunkRepository,
 	modelService interfaces.ModelService,
+	inferenceCache inferencecache.Cache,
 	task interfaces.TaskEnqueuer,
 	logEntrySvc interfaces.WikiLogEntryService,
 	pendingRepo interfaces.TaskPendingOpsRepository,
@@ -349,6 +352,7 @@ func NewWikiIngestService(
 		knowledgeRepo:  knowledgeRepo,
 		chunkRepo:      chunkRepo,
 		modelService:   modelService,
+		inferenceCache: inferenceCache,
 		task:           task,
 		logEntrySvc:    logEntrySvc,
 		pendingRepo:    pendingRepo,
@@ -652,10 +656,11 @@ func (s *wikiIngestService) peekPendingList(ctx context.Context, kbID string, li
 // double-processing. Stale claims (older than wikiClaimStaleAfter, i.e. from
 // a crashed worker) are recovered. Dedup / peekedIDs semantics match
 // peekPendingList; the returned peekedIDs are the claimed rows that the
-// caller must DeleteByIDs on success or ReleaseByIDs to retry.
-func (s *wikiIngestService) claimPendingList(ctx context.Context, kbID string, limit int) (ops []WikiPendingOp, peekedIDs []int64, err error) {
+// caller must settle with the returned claimToken (DeleteClaims on success or
+// ReleaseClaims to retry).
+func (s *wikiIngestService) claimPendingList(ctx context.Context, kbID string, limit int) (ops []WikiPendingOp, peekedIDs []int64, claimToken string, err error) {
 	if s.pendingRepo == nil {
-		return nil, nil, nil
+		return nil, nil, "", nil
 	}
 	if limit <= 0 {
 		limit = wikiMaxDocsPerBatch
@@ -666,10 +671,64 @@ func (s *wikiIngestService) claimPendingList(ctx context.Context, kbID string, l
 		// A claim failure is transient (DB blip). Propagate it so the batch
 		// returns an error and asynq retries, instead of acking the trigger
 		// as a false "no pending ops" success and stranding the queue.
-		return nil, nil, err
+		return nil, nil, "", err
+	}
+	if len(rows) > 0 {
+		claimToken = rows[0].ClaimToken
 	}
 	ops, peekedIDs = s.decodePendingRows(ctx, rows)
-	return ops, peekedIDs, nil
+	return ops, peekedIDs, claimToken, nil
+}
+
+// keepClaimsAlive turns claimed_at into a short renewable lease. Ownership is
+// scoped by claimToken: once another worker reclaims the rows, this worker can
+// neither renew nor settle them. Losing ownership cancels the processing
+// context so an old worker cannot keep mutating Wiki pages beside its
+// replacement.
+func (s *wikiIngestService) keepClaimsAlive(
+	parent context.Context,
+	kbID string,
+	ids []int64,
+	claimToken string,
+) (context.Context, func()) {
+	leaseCtx, cancelLease := context.WithCancel(parent)
+	heartbeatCtx, stopHeartbeat := context.WithCancel(context.Background())
+	lastRenewed := time.Now()
+
+	go func() {
+		ticker := time.NewTicker(wikiClaimRenewInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				return
+			case <-ticker.C:
+				renewCtx, cancel := context.WithTimeout(context.Background(), wikiClaimRenewTimeout)
+				n, renewErr := s.pendingRepo.RenewClaims(renewCtx, ids, claimToken)
+				cancel()
+				if renewErr != nil {
+					logger.Warnf(parent, "wiki ingest: claim lease renewal failed for KB %s: %v", kbID, renewErr)
+					if time.Since(lastRenewed) >= wikiClaimStaleAfter-wikiClaimRenewInterval {
+						logger.Warnf(parent, "wiki ingest: claim lease for KB %s could not be renewed safely; cancelling batch", kbID)
+						cancelLease()
+						return
+					}
+					continue
+				}
+				if n != int64(len(ids)) {
+					logger.Warnf(parent, "wiki ingest: claim lease lost for KB %s (owned=%d expected=%d); cancelling stale batch", kbID, n, len(ids))
+					cancelLease()
+					return
+				}
+				lastRenewed = time.Now()
+			}
+		}
+	}()
+
+	return leaseCtx, func() {
+		stopHeartbeat()
+		cancelLease()
+	}
 }
 
 // withSlugLock serializes read-modify-write on one shared wiki page across
@@ -811,7 +870,7 @@ func (s *wikiIngestService) scheduleCappedRetry(ctx context.Context, payload Wik
 	}
 }
 
-// scheduleStaleClaimRecheck arms a single, far-future safety-net trigger for a
+// scheduleStaleClaimRecheck arms a single delayed safety-net trigger for a
 // KB that still has pending rows but yielded nothing to claim (every eligible
 // row is held by a FRESH claim). Normally a running batch drains those rows and
 // chains its own fast follow-up on completion; this net exists only for the
@@ -843,7 +902,11 @@ func (s *wikiIngestService) scheduleStaleClaimRecheck(ctx context.Context, paylo
 		asynq.MaxRetry(wikiIngestMaxRetry),
 		asynq.Timeout(60*time.Minute),
 		asynq.ProcessIn(wikiClaimStaleAfter+wikiFollowUpDelay),
-		asynq.TaskID("wiki-ingest-recheck-"+payload.KnowledgeBaseID),
+		// Include the lease duration in the identity. Deployments upgrading
+		// from the former 90-minute stale window may still have its delayed
+		// recheck in Redis; a duration-scoped ID lets the new short-window
+		// safety net coexist instead of being rejected as a duplicate.
+		asynq.TaskID(fmt.Sprintf("wiki-ingest-recheck-%ds-%s", int(wikiClaimStaleAfter.Seconds()), payload.KnowledgeBaseID)),
 	)
 	if _, err := s.task.Enqueue(t); err != nil {
 		if errors.Is(err, asynq.ErrTaskIDConflict) || errors.Is(err, asynq.ErrDuplicateTask) {
@@ -920,8 +983,14 @@ func (s *wikiIngestService) decodePendingRows(ctx context.Context, rows []*types
 // trimPendingList deletes consumed rows from task_pending_ops. Empty
 // input is a no-op so callers can invoke unconditionally at the end
 // of a batch.
-func (s *wikiIngestService) trimPendingList(ctx context.Context, ids []int64) {
+func (s *wikiIngestService) trimPendingList(ctx context.Context, ids []int64, claimTokens ...string) {
 	if s.pendingRepo == nil || len(ids) == 0 {
+		return
+	}
+	if len(claimTokens) > 0 && claimTokens[0] != "" {
+		if err := s.pendingRepo.DeleteClaims(ctx, ids, claimTokens[0]); err != nil {
+			logger.Warnf(ctx, "wiki ingest: failed to trim %d owned pending rows: %v", len(ids), err)
+		}
 		return
 	}
 	if err := s.pendingRepo.DeleteByIDs(ctx, ids); err != nil {
@@ -963,7 +1032,7 @@ func (s *wikiIngestService) finalizeWikiSubtask(ctx context.Context, knowledgeID
 //     Both writes are best-effort — a DB failure here is logged and
 //     swallowed so a single transient blip doesn't recursively spawn
 //     more failures.
-func (s *wikiIngestService) requeueFailedOps(ctx context.Context, payload WikiIngestPayload, ops []WikiPendingOp) {
+func (s *wikiIngestService) requeueFailedOps(ctx context.Context, payload WikiIngestPayload, ops []WikiPendingOp, claimTokens ...string) {
 	if s.pendingRepo == nil || len(ops) == 0 {
 		return
 	}
@@ -973,12 +1042,30 @@ func (s *wikiIngestService) requeueFailedOps(ctx context.Context, payload WikiIn
 			// retry against.
 			continue
 		}
-		count, err := s.pendingRepo.IncrFailCount(ctx, op.dbID)
+		claimToken := ""
+		if len(claimTokens) > 0 {
+			claimToken = claimTokens[0]
+		}
+		var count int
+		var err error
+		if claimToken != "" {
+			count, err = s.pendingRepo.IncrClaimFailCount(ctx, op.dbID, claimToken)
+		} else {
+			count, err = s.pendingRepo.IncrFailCount(ctx, op.dbID)
+		}
 		if err != nil {
 			logger.Warnf(ctx, "wiki ingest: failed to increment fail count for %s (id=%d): %v", op.KnowledgeID, op.dbID, err)
 			// Without a fresh count we can't tell whether to drop. Be
 			// conservative: leave the row in place; the next PeekBatch
 			// will see it again and we'll try once more.
+			continue
+		}
+		if claimToken != "" && count == 0 {
+			// The row was reclaimed or consumed after this worker lost its
+			// lease. Ownership-scoped settlement must stop here: logging it as
+			// a retry would be misleading, and the current owner is now solely
+			// responsible for the row.
+			logger.Warnf(ctx, "wiki ingest: claim ownership lost while settling failed op %s (id=%d); skipping stale settlement", op.KnowledgeID, op.dbID)
 			continue
 		}
 		if count <= wikiMaxFailRetries {
@@ -987,7 +1074,12 @@ func (s *wikiIngestService) requeueFailedOps(ctx context.Context, payload WikiIn
 			// wikiClaimStaleAfter. No-op in Lite mode (row was peeked, never
 			// claimed). ReleaseByIDs preserves fail_count, so the retry
 			// budget still counts down.
-			if err := s.pendingRepo.ReleaseByIDs(ctx, []int64{op.dbID}); err != nil {
+			if claimToken != "" {
+				err = s.pendingRepo.ReleaseClaims(ctx, []int64{op.dbID}, claimToken)
+			} else {
+				err = s.pendingRepo.ReleaseByIDs(ctx, []int64{op.dbID})
+			}
+			if err != nil {
 				logger.Warnf(ctx, "wiki ingest: failed to release claim for retry id=%d: %v", op.dbID, err)
 			}
 			logger.Infof(ctx, "wiki ingest: re-queued failed op %s (%s) for retry (attempt %d/%d)", op.KnowledgeID, op.DocTitle, count, wikiMaxFailRetries)
@@ -1018,7 +1110,12 @@ func (s *wikiIngestService) requeueFailedOps(ctx context.Context, payload WikiIn
 				logger.Warnf(ctx, "wiki ingest: failed to archive op %s to dead letters: %v", op.KnowledgeID, dlErr)
 			}
 		}
-		if err := s.pendingRepo.DeleteByIDs(ctx, []int64{op.dbID}); err != nil {
+		if claimToken != "" {
+			err = s.pendingRepo.DeleteClaims(ctx, []int64{op.dbID}, claimToken)
+		} else {
+			err = s.pendingRepo.DeleteByIDs(ctx, []int64{op.dbID})
+		}
+		if err != nil {
 			logger.Warnf(ctx, "wiki ingest: failed to drop dead-lettered row id=%d: %v", op.dbID, err)
 		}
 	}
@@ -2068,69 +2165,44 @@ func xmlEscape(s string) string {
 func (s *wikiIngestService) deduplicateExtractedBatch(
 	ctx context.Context,
 	chatModel chat.Chat,
-	kbID string,
+	kbID, knowledgeID string,
 	entities, concepts []extractedItem,
-) ([]extractedItem, []extractedItem) {
+) ([]extractedItem, []extractedItem, string, error) {
 	if len(entities) == 0 && len(concepts) == 0 {
-		return entities, concepts
+		return entities, concepts, wikiDedupCandidateState(nil, knowledgeID), nil
 	}
 	if s.wikiService == nil {
-		return entities, concepts
+		return entities, concepts, wikiDedupCandidateState(nil, knowledgeID), nil
 	}
 
-	// Build the candidate set: for each new item, ask the repo for
-	// the top-K trigram-similar pages and union the results. Dedup by
-	// slug as we go so the prompt only carries each candidate once.
-	candidatePages := make(map[string]*types.WikiPageLite)
-	probe := func(item extractedItem) {
-		queries := make([]string, 0, 1+len(item.Aliases))
-		if item.Name != "" {
-			queries = append(queries, item.Name)
-		}
-		for _, alias := range item.Aliases {
-			if alias != "" {
-				queries = append(queries, alias)
-			}
-		}
-		for _, q := range queries {
-			pages, err := s.wikiService.FindSimilarPages(ctx, kbID, q,
-				[]string{types.WikiPageTypeEntity, types.WikiPageTypeConcept},
-				dedupCandidateTopK)
-			if err != nil {
-				logger.Warnf(ctx, "wiki ingest: dedup FindSimilarPages(%q) failed: %v", q, err)
-				continue
-			}
-			for _, p := range pages {
-				if p == nil || p.Slug == "" {
-					continue
-				}
-				if _, ok := candidatePages[p.Slug]; !ok {
-					candidatePages[p.Slug] = p
-				}
-			}
-		}
+	// Build the candidate set from the exact lightweight page projection used
+	// by the dedup prompt. The same helper validates cached map artifacts.
+	candidatePages, candidateErr := s.findDedupCandidatePages(ctx, kbID, entities, concepts)
+	if candidateErr != nil {
+		return entities, concepts, "", candidateErr
 	}
-	for _, e := range entities {
-		probe(e)
-	}
-	for _, c := range concepts {
-		probe(c)
-	}
+	dedupState := wikiDedupCandidateState(candidatePages, knowledgeID)
 	if len(candidatePages) == 0 {
 		// No similar existing pages — nothing to merge against. The
 		// items pass through unchanged.
 		logger.Infof(ctx, "wiki ingest: no similar existing pages found for %d new items", len(entities)+len(concepts))
-		return entities, concepts
+		return entities, concepts, dedupState, nil
 	}
 	logger.Infof(ctx, "wiki ingest: %d similar existing pages selected for %d new items",
 		len(candidatePages), len(entities)+len(concepts))
 
 	var existingBuf strings.Builder
-	for _, p := range candidatePages {
+	candidateSlugs := make([]string, 0, len(candidatePages))
+	for slug := range candidatePages {
+		candidateSlugs = append(candidateSlugs, slug)
+	}
+	sort.Strings(candidateSlugs)
+	for _, slug := range candidateSlugs {
+		p := candidatePages[slug]
 		writeDedupItemXML(&existingBuf, p.Slug, p.Title, p.PageType, []string(p.Aliases))
 	}
 	if existingBuf.Len() == 0 {
-		return entities, concepts
+		return entities, concepts, dedupState, nil
 	}
 
 	var newBuf strings.Builder
@@ -2147,7 +2219,7 @@ func (s *wikiIngestService) deduplicateExtractedBatch(
 	})
 	if err != nil {
 		logger.Warnf(ctx, "wiki ingest: deduplication LLM call failed: %v", err)
-		return entities, concepts
+		return entities, concepts, dedupState, nil
 	}
 
 	dedupeJSON = cleanLLMJSON(dedupeJSON)
@@ -2157,11 +2229,11 @@ func (s *wikiIngestService) deduplicateExtractedBatch(
 	}
 	if err := json.Unmarshal([]byte(dedupeJSON), &dedupeResult); err != nil {
 		logger.Warnf(ctx, "wiki ingest: failed to parse dedup JSON: %v\nRaw: %s", err, dedupeJSON)
-		return entities, concepts
+		return entities, concepts, dedupState, nil
 	}
 
 	if len(dedupeResult.Merges) == 0 {
-		return entities, concepts
+		return entities, concepts, dedupState, nil
 	}
 
 	// Build the existing-slug set from the candidate map: anything not
@@ -2212,7 +2284,71 @@ func (s *wikiIngestService) deduplicateExtractedBatch(
 		}
 	}
 
-	return entities, concepts
+	return entities, concepts, dedupState, nil
+}
+
+// findDedupCandidatePages returns exactly the live Wiki page projection seen
+// by the deduplication prompt. Querying only candidates similar to this
+// document keeps cache validation proportional to the extracted items instead
+// of scanning every page in a large knowledge base.
+func (s *wikiIngestService) findDedupCandidatePages(
+	ctx context.Context,
+	kbID string,
+	entities, concepts []extractedItem,
+) (map[string]*types.WikiPageLite, error) {
+	candidatePages := make(map[string]*types.WikiPageLite)
+	if s.wikiService == nil {
+		return candidatePages, nil
+	}
+	seenQueries := make(map[string]struct{})
+	probe := func(item extractedItem) error {
+		queries := make([]string, 0, 1+len(item.Aliases))
+		if item.Name != "" {
+			queries = append(queries, item.Name)
+		}
+		for _, alias := range item.Aliases {
+			if alias != "" {
+				queries = append(queries, alias)
+			}
+		}
+		for _, query := range queries {
+			query = strings.TrimSpace(query)
+			if query == "" {
+				continue
+			}
+			queryKey := strings.ToLower(query)
+			if _, seen := seenQueries[queryKey]; seen {
+				continue
+			}
+			seenQueries[queryKey] = struct{}{}
+			pages, err := s.wikiService.FindSimilarPages(ctx, kbID, query,
+				[]string{types.WikiPageTypeEntity, types.WikiPageTypeConcept},
+				dedupCandidateTopK)
+			if err != nil {
+				return fmt.Errorf("dedup FindSimilarPages(%q): %w", query, err)
+			}
+			for _, page := range pages {
+				if page == nil || page.Slug == "" {
+					continue
+				}
+				if _, exists := candidatePages[page.Slug]; !exists {
+					candidatePages[page.Slug] = page
+				}
+			}
+		}
+		return nil
+	}
+	for _, entity := range entities {
+		if err := probe(entity); err != nil {
+			return nil, err
+		}
+	}
+	for _, concept := range concepts {
+		if err := probe(concept); err != nil {
+			return nil, err
+		}
+	}
+	return candidatePages, nil
 }
 
 // generateWithTemplate executes a prompt template and calls the LLM with
@@ -2233,12 +2369,28 @@ func (s *wikiIngestService) deduplicateExtractedBatch(
 // summary page permanently. Retries plus failedOps requeuing (see
 // mapOneDocument) turn those events into at-most-a-few-minute hiccups.
 func (s *wikiIngestService) generateWithTemplate(ctx context.Context, chatModel chat.Chat, promptTpl string, data map[string]string) (string, error) {
+	maskedData, urlMap := maskTemplateDataImageURLs(data)
+	response, err := s.generateWithTemplateMasked(ctx, chatModel, promptTpl, maskedData)
+	if err != nil {
+		return "", err
+	}
+	return unmaskImageURLs(response, urlMap), nil
+}
+
+// generateWithTemplateMasked renders and executes a prompt whose image URLs
+// have already been replaced by deterministic wkimg tokens. It deliberately
+// returns the still-masked model response so cache entries never retain a URL
+// from an earlier parse. Callers restore the current parse's URLs afterwards.
+func (s *wikiIngestService) generateWithTemplateMasked(
+	ctx context.Context,
+	chatModel chat.Chat,
+	promptTpl string,
+	maskedData map[string]string,
+) (string, error) {
 	tmpl, err := template.New("wiki").Parse(promptTpl)
 	if err != nil {
 		return "", fmt.Errorf("parse template: %w", err)
 	}
-
-	maskedData, urlMap := maskTemplateDataImageURLs(data)
 
 	var buf strings.Builder
 	if err := tmpl.Execute(&buf, maskedData); err != nil {
@@ -2246,7 +2398,7 @@ func (s *wikiIngestService) generateWithTemplate(ctx context.Context, chatModel 
 	}
 
 	prompt := buf.String()
-	prompt = types.AppendCustomPromptInstructions(prompt, data["CustomInstructions"], data["InstructionScope"])
+	prompt = types.AppendCustomPromptInstructions(prompt, maskedData["CustomInstructions"], maskedData["InstructionScope"])
 	thinking := false
 
 	var lastErr error
@@ -2258,7 +2410,7 @@ func (s *wikiIngestService) generateWithTemplate(ctx context.Context, chatModel 
 			Thinking:    &thinking,
 		})
 		if err == nil {
-			return unmaskImageURLs(response.Content, urlMap), nil
+			return response.Content, nil
 		}
 		lastErr = err
 
@@ -2282,6 +2434,149 @@ func (s *wikiIngestService) generateWithTemplate(ctx context.Context, chatModel 
 		}
 	}
 	return "", fmt.Errorf("LLM call failed after %d attempts: %w", wikiLLMMaxAttempts, lastErr)
+}
+
+// wikiCacheKey binds a validated map-stage result to the exact prompt
+// template, rendered inputs, tenant and chat-model configuration. Including
+// the template text automatically invalidates entries when prompts evolve.
+func wikiCacheKey(ctx context.Context, namespace string, chatModel chat.Chat, promptTpl string, data map[string]string) string {
+	tenantID, _ := types.TenantIDFromContext(ctx)
+	maskedData, _ := maskTemplateDataImageURLs(data)
+	encoded, _ := json.Marshal(maskedData)
+	return inferencecache.Key("wiki.map."+namespace, tenantID, chat.FingerprintOf(chatModel),
+		[]byte(promptTpl), encoded)
+}
+
+func inferenceCacheKeyID(key string) string {
+	if idx := strings.LastIndexByte(key, ':'); idx >= 0 && idx+1 < len(key) {
+		key = key[idx+1:]
+	}
+	if len(key) > 12 {
+		return key[:12]
+	}
+	return key
+}
+
+func resolveWikiCachedJSON[T any](
+	ctx context.Context,
+	cache inferencecache.Cache,
+	namespace string,
+	chatModel chat.Chat,
+	promptTpl string,
+	data map[string]string,
+	loader func(context.Context, map[string]string) (T, error),
+) (T, error) {
+	maskedData, urlMap := maskTemplateDataImageURLs(data)
+	key := wikiCacheKey(ctx, namespace, chatModel, promptTpl, maskedData)
+	value, stats, err := inferencecache.ResolveJSON(ctx, cache, key, func(loadCtx context.Context) (T, error) {
+		return loader(loadCtx, maskedData)
+	})
+	if stats.ReadError != nil {
+		logger.Warnf(ctx, "[InferenceCache] Wiki %s read failed, using provider: %v", namespace, stats.ReadError)
+	}
+	if stats.WriteError != nil {
+		logger.Warnf(ctx, "[InferenceCache] Wiki %s write failed: %v", namespace, stats.WriteError)
+	}
+	if err == nil {
+		logger.Infof(ctx, "[InferenceCache] stage=wiki.map.%s key=%s hit=%v coalesced=%v",
+			namespace, inferenceCacheKeyID(key), stats.Hit, stats.Coalesced)
+	}
+	if err != nil {
+		return value, err
+	}
+	return rebindWikiImageURLs(value, urlMap)
+}
+
+func (s *wikiIngestService) generateWithTemplateCached(
+	ctx context.Context,
+	namespace string,
+	chatModel chat.Chat,
+	promptTpl string,
+	data map[string]string,
+) (string, error) {
+	maskedData, urlMap := maskTemplateDataImageURLs(data)
+	key := wikiCacheKey(ctx, namespace, chatModel, promptTpl, maskedData)
+	if s.inferenceCache == nil {
+		return s.generateWithTemplate(ctx, chatModel, promptTpl, data)
+	}
+	raw, stats, err := s.inferenceCache.Resolve(ctx, key, func(loadCtx context.Context) ([]byte, error) {
+		value, loadErr := s.generateWithTemplateMasked(loadCtx, chatModel, promptTpl, maskedData)
+		return []byte(value), loadErr
+	})
+	if stats.ReadError != nil {
+		logger.Warnf(ctx, "[InferenceCache] Wiki %s read failed, using provider: %v", namespace, stats.ReadError)
+	}
+	if stats.WriteError != nil {
+		logger.Warnf(ctx, "[InferenceCache] Wiki %s write failed: %v", namespace, stats.WriteError)
+	}
+	if err == nil {
+		logger.Infof(ctx, "[InferenceCache] stage=wiki.map.%s key=%s hit=%v coalesced=%v",
+			namespace, inferenceCacheKeyID(key), stats.Hit, stats.Coalesced)
+	}
+	if err != nil {
+		return "", err
+	}
+	return unmaskImageURLs(string(raw), urlMap), nil
+}
+
+func rebindWikiImageURLs[T any](value T, urlMap map[string]string) (T, error) {
+	var rebound T
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return rebound, fmt.Errorf("marshal cached wiki result: %w", err)
+	}
+	raw, err = rebindWikiJSONImageURLs(raw, urlMap)
+	if err != nil {
+		return rebound, err
+	}
+	if err := json.Unmarshal(raw, &rebound); err != nil {
+		return rebound, fmt.Errorf("unmarshal rebound wiki result: %w", err)
+	}
+	return rebound, nil
+}
+
+func rebindWikiJSONImageURLs(raw []byte, urlMap map[string]string) ([]byte, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return raw, nil
+	}
+
+	switch trimmed[0] {
+	case '"':
+		var value string
+		if err := json.Unmarshal(trimmed, &value); err != nil {
+			return nil, fmt.Errorf("decode cached wiki string: %w", err)
+		}
+		return json.Marshal(unmaskImageURLs(value, urlMap))
+	case '[':
+		var values []json.RawMessage
+		if err := json.Unmarshal(trimmed, &values); err != nil {
+			return nil, fmt.Errorf("decode cached wiki array: %w", err)
+		}
+		for i := range values {
+			rebound, err := rebindWikiJSONImageURLs(values[i], urlMap)
+			if err != nil {
+				return nil, err
+			}
+			values[i] = rebound
+		}
+		return json.Marshal(values)
+	case '{':
+		var values map[string]json.RawMessage
+		if err := json.Unmarshal(trimmed, &values); err != nil {
+			return nil, fmt.Errorf("decode cached wiki object: %w", err)
+		}
+		for key, value := range values {
+			rebound, err := rebindWikiJSONImageURLs(value, urlMap)
+			if err != nil {
+				return nil, err
+			}
+			values[key] = rebound
+		}
+		return json.Marshal(values)
+	default:
+		return raw, nil
+	}
 }
 
 // isTransientLLMError reports whether an error from the chat provider

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -339,9 +340,12 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 	// batches); Lite mode peeks under its in-process lock.
 	var pendingOps []WikiPendingOp
 	var peekedIDs []int64
+	var claimToken string
+	var stopClaimHeartbeat func()
+	claimParentCtx := ctx
 	var loadErr error
 	if s.redisClient != nil {
-		pendingOps, peekedIDs, loadErr = s.claimPendingList(ctx, payload.KnowledgeBaseID, batchSize)
+		pendingOps, peekedIDs, claimToken, loadErr = s.claimPendingList(ctx, payload.KnowledgeBaseID, batchSize)
 	} else {
 		pendingOps, peekedIDs, loadErr = s.peekPendingList(ctx, payload.KnowledgeBaseID, batchSize)
 	}
@@ -371,11 +375,19 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 
 	logger.Infof(ctx, "wiki ingest: batch processing %d ops for KB %s", len(pendingOps), payload.KnowledgeBaseID)
 
+	// Keep the short DB claim lease alive for however long Map/Reduce takes.
+	// A killed process stops this heartbeat and becomes reclaimable within
+	// wikiClaimStaleAfter instead of waiting for the full task timeout.
+	if s.redisClient != nil && len(peekedIDs) > 0 && claimToken != "" {
+		ctx, stopClaimHeartbeat = s.keepClaimsAlive(ctx, payload.KnowledgeBaseID, peekedIDs, claimToken)
+		defer stopClaimHeartbeat()
+	}
+
 	// Crash/abort safety net (standard/claim mode only). If this batch exits
 	// abnormally — panic, ctx timeout, or an early error return — BEFORE it
 	// settles its claimed rows (trim + requeueFailedOps), release the claims
 	// so the next trigger can re-claim within seconds instead of waiting out
-	// wikiClaimStaleAfter (~90m). On the normal path claimsSettled flips true
+	// the short renewable lease. On the normal path claimsSettled flips true
 	// once the rows reach their terminal state, making this a no-op. Uses a
 	// background context because ctx may already be cancelled on the timeout
 	// path. Lite mode peeks without claiming, so there is nothing to release.
@@ -385,7 +397,7 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 			if claimsSettled {
 				return
 			}
-			if err := s.pendingRepo.ReleaseByIDs(context.Background(), peekedIDs); err != nil {
+			if err := s.pendingRepo.ReleaseClaims(context.Background(), peekedIDs, claimToken); err != nil {
 				logger.Warnf(ctx, "wiki ingest: failed to release %d claims on abnormal exit for KB %s: %v", len(peekedIDs), payload.KnowledgeBaseID, err)
 				return
 			}
@@ -875,14 +887,22 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 		}
 		trimIDs = append(trimIDs, id)
 	}
-	s.trimPendingList(ctx, trimIDs)
+	// Model and reduce work is complete. Stop renewing before settlement so
+	// the heartbeat cannot mistake rows deleted below for a lost lease. Use
+	// the pre-lease context for the short DB settlement because stopping the
+	// heartbeat also cancels the derived processing context.
+	if stopClaimHeartbeat != nil {
+		stopClaimHeartbeat()
+		ctx = claimParentCtx
+	}
+	s.trimPendingList(ctx, trimIDs, claimToken)
 
 	// Process failed ops: increment fail_count and dead-letter once
 	// the cap is hit. Must come AFTER trim so successful siblings are
 	// already gone from the queue — otherwise a follow-up batch could
 	// re-pick them up.
 	if len(failedOps) > 0 {
-		s.requeueFailedOps(ctx, payload, failedOps)
+		s.requeueFailedOps(ctx, payload, failedOps, claimToken)
 	}
 	// All claimed rows have now reached a terminal state (deleted on success,
 	// released for retry, or dead-lettered), so disarm the abnormal-exit
@@ -1162,142 +1182,30 @@ func (s *wikiIngestService) mapOneDocument(
 	sourceRef := knowledgeID
 	oldPageSlugs := s.getExistingPageSlugsForKnowledge(ctx, payload.KnowledgeBaseID, knowledgeID)
 
-	// Pass 0: lightweight candidate slug extraction (skeleton only).
-	// On failure we fall back to the legacy single-shot extractor so the doc
-	// still gets ingested, just without chunk-level citations.
-	var (
-		extractedEntities []extractedItem
-		extractedConcepts []extractedItem
-		slugItems         map[string]extractedItem
-		pass0Failed       bool
+	artifact, mapCacheHit, err := s.resolveWikiDocMapArtifact(
+		ctx, chatModel, payload.KnowledgeBaseID, knowledgeID, content, lang,
+		chunks, oldPageSlugs, batchCtx, wikiSpan,
 	)
-	logger.Infof(ctx, "wiki ingest: pass 0 — extracting candidate slugs for %s", knowledgeID)
-	extractSpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.extract", types.SpanKindSubSpan, types.JSONMap{
-		"content_chars": utf8.RuneCountInString(content),
-		"old_pages":     len(oldPageSlugs),
-	})
-	extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
 	if err != nil {
-		logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) — falling back to legacy extractor", knowledgeID, err)
-		pass0Failed = true
-		extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
-		if err != nil {
-			logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
-			s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
-			s.tracker().FailSpan(ctx, wikiSpan, "EXTRACT_FAILED", err.Error(), err)
-			return nil, nil, err
-		}
+		logger.Errorf(ctx, "wiki ingest: document map failed for %s: %v", knowledgeID, err)
+		s.tracker().FailSpan(ctx, wikiSpan, "MAP_FAILED", err.Error(), err)
+		return nil, nil, err
 	}
-	s.tracker().EndSpan(ctx, extractSpan, types.JSONMap{
-		"entities":         len(extractedEntities),
-		"concepts":         len(extractedConcepts),
-		"pass0_fallback":   pass0Failed,
-		"entities_preview": previewExtractedItems(extractedEntities, 8),
-		"concepts_preview": previewExtractedItems(extractedConcepts, 8),
-	})
+	extractedEntities := artifact.Entities
+	extractedConcepts := artifact.Concepts
+	summaryContent := artifact.Summary
+	pass0Failed := artifact.Pass0Fallback
+	batchCount := artifact.BatchCount
+	uncited := artifact.UncitedCount
+	newSlugCount := artifact.NewSlugCount
 
-	// Build slug listing for Summary's wiki-link input.
-	var summaryExtractedPages []string
-	for slug := range slugItems {
-		summaryExtractedPages = append(summaryExtractedPages, slug)
-	}
-	// Wiki summary slug is derived from the knowledge ID rather than the
-	// docTitle (which is typically the upload filename). Filename-based slugs
-	// like "summary/mx5280-pdf" expose the filename in cross-link contexts
-	// that downstream LLM prompts read; a UUID-based slug is uglier but
-	// hallucination-safe.
+	// The summary page slug is source-owned and therefore stays outside the
+	// cached artifact; it is deterministic for the current knowledge row.
 	summarySlug := fmt.Sprintf("summary/%s", slugify(knowledgeID))
-	var slugListing string
-	for _, slug := range summaryExtractedPages {
-		if item, ok := slugItems[slug]; ok {
-			aliases := ""
-			if len(item.Aliases) > 0 {
-				aliases = fmt.Sprintf(" (Aliases: %s)", strings.Join(item.Aliases, ", "))
-			}
-			slugListing += fmt.Sprintf("- [[%s]] = %s%s\n", slug, item.Name, aliases)
-		} else {
-			slugListing += fmt.Sprintf("- [[%s]]\n", slug)
-		}
-	}
 
-	// Summary and chunk classification are independent given Pass 0 output —
-	// run them in parallel. Summary handles wiki-link injection; classification
-	// attaches concrete chunk IDs to each candidate slug.
-	var (
-		summaryContent string
-		summaryErr     error
-		citations      map[string][]string
-		newSlugs       []newSlugFromCitation
-		batchCount     int
-	)
-
-	// Both calls run in parallel goroutines under the same wikiSpan
-	// parent — their subspans will visually overlap in the trace view,
-	// which correctly reflects their wall-clock concurrency.
-	summarySpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.summary", types.SpanKindSubSpan, types.JSONMap{
-		"content_chars":   utf8.RuneCountInString(content),
-		"extracted_slugs": len(summaryExtractedPages),
-	})
-	var classifySpan *Span
-	if !pass0Failed {
-		classifySpan = s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.classify", types.SpanKindSubSpan, types.JSONMap{
-			"chunks":     len(chunks),
-			"candidates": len(extractedEntities) + len(extractedConcepts),
-		})
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		summaryContent, summaryErr = s.generateWithTemplate(ctx, chatModel, agent.WikiSummaryPrompt, map[string]string{
-			"Content":            content,
-			"Language":           lang,
-			"ExtractedSlugs":     slugListing,
-			"CustomInstructions": batchCtx.ContentInstructions,
-			"InstructionScope":   "wiki_content",
-		})
-		if summaryErr != nil {
-			s.tracker().FailSpan(ctx, summarySpan, "SUMMARY_FAILED", summaryErr.Error(), summaryErr)
-		} else {
-			sumLine, sumBody := splitSummaryLine(summaryContent)
-			s.tracker().EndSpan(ctx, summarySpan, types.JSONMap{
-				"chars":        utf8.RuneCountInString(summaryContent),
-				"summary_line": previewText(sumLine, 160),
-				"body_preview": previewText(sumBody, 320),
-			})
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		// Skip citation pass when Pass 0 has fallen back to the legacy path —
-		// the legacy output already contains paraphrased Details, so chunk
-		// citations would be redundant and we'd spend LLM calls for nothing.
-		if pass0Failed {
-			citations = map[string][]string{}
-			return
-		}
-		candidatesXML := renderCandidateSlugsXML(extractedEntities, extractedConcepts)
-		citations, newSlugs, batchCount = s.classifyChunkCitations(ctx, chatModel, candidatesXML, chunks, lang, batchCtx)
-		s.tracker().EndSpan(ctx, classifySpan, types.JSONMap{
-			"cited_slugs":      len(citations),
-			"new_slugs":        len(newSlugs),
-			"batches":          batchCount,
-			"top_cited":        topCitedSlugs(citations, 8),
-			"new_slugs_sample": previewNewSlugs(newSlugs, 8),
-		})
-	}()
-	wg.Wait()
-
-	// Merge citations back into the item structs (non-failing; items without
-	// citations simply keep their Description+Details fallback).
-	var uncited int
-	extractedEntities, extractedConcepts, uncited = mergeCitationsIntoItems(extractedEntities, extractedConcepts, citations, newSlugs)
-
-	// Rebuild slugItems so stale entries (for slugs that did not survive the
-	// merge) and brand-new slugs discovered by the citation pass are both
-	// reflected in summaryExtractedPages tracking.
-	slugItems = make(map[string]extractedItem, len(extractedEntities)+len(extractedConcepts))
+	// Rebuild the lookup from the canonical artifact. This includes slugs
+	// discovered by citation classification as well as initial candidates.
+	slugItems := make(map[string]extractedItem, len(extractedEntities)+len(extractedConcepts))
 	for _, item := range extractedEntities {
 		if item.Slug != "" && item.Name != "" {
 			slugItems[item.Slug] = item
@@ -1323,10 +1231,11 @@ func (s *wikiIngestService) mapOneDocument(
 		extractedPages = append(extractedPages, types.WikiLogPageRef{Slug: slug, Title: title})
 	}
 
-	// Count total distinct chunks cited across all slugs for logging.
+	// Count total distinct chunks cited across all slugs for logging. The
+	// artifact already carries merged source-chunk references.
 	citedChunkSet := make(map[string]bool)
-	for _, ids := range citations {
-		for _, id := range ids {
+	for _, item := range append(append([]extractedItem(nil), extractedEntities...), extractedConcepts...) {
+		for _, id := range item.SourceChunks {
 			citedChunkSet[id] = true
 		}
 	}
@@ -1338,24 +1247,6 @@ func (s *wikiIngestService) mapOneDocument(
 	// update so the editor model gets rich framing in <source_context>.
 	var docSummaryLine string
 	var docSummary string
-
-	if summaryErr != nil {
-		// Summary is the headline artifact of an ingested document — a
-		// document with no summary page is half-ingested and leaves the
-		// entity/concept updates hanging without a root to link back to
-		// from the index. Historically we just logged and moved on,
-		// which meant a single transient 504 permanently dropped the
-		// summary page for that document.
-		//
-		// Returning an error here sends the op to failedOps (see the
-		// map-phase loop in ProcessWikiIngest), which requeueFailedOps
-		// appends back onto the pending list so the next batch retries.
-		// The internal retries in generateWithTemplate already exhaust
-		// the LLM's own transient-error budget before we give up here.
-		logger.Errorf(ctx, "wiki ingest: generate summary failed for %s, will requeue: %v", knowledgeID, summaryErr)
-		s.tracker().FailSpan(ctx, wikiSpan, "SUMMARY_FAILED", summaryErr.Error(), summaryErr)
-		return nil, nil, fmt.Errorf("generate summary: %w", summaryErr)
-	}
 	sumLine, sumBody := splitSummaryLine(summaryContent)
 	if sumBody == "" {
 		sumBody = summaryContent
@@ -1483,7 +1374,7 @@ func (s *wikiIngestService) mapOneDocument(
 	logger.Infof(ctx,
 		"wiki ingest: mapped knowledge %s title=%q candidates=%d chunks=%d batches=%d cited_chunks=%d uncited_slugs=%d new_slugs=%d updates=%d reparse_slugs=%d stale_slugs=%d pass0_fallback=%v elapsed=%s",
 		knowledgeID, previewText(docTitle, 80),
-		len(slugItems), len(chunks), batchCount, len(citedChunkSet), uncited, len(newSlugs),
+		len(slugItems), len(chunks), batchCount, len(citedChunkSet), uncited, newSlugCount,
 		len(updates), reparseOverlap, staleCount, pass0Failed,
 		time.Since(docStartedAt).Round(time.Millisecond),
 	)
@@ -1501,7 +1392,7 @@ func (s *wikiIngestService) mapOneDocument(
 		"candidate_slugs":  len(slugItems),
 		"cited_chunks":     len(citedChunkSet),
 		"uncited_slugs":    uncited,
-		"new_slugs":        len(newSlugs),
+		"new_slugs":        newSlugCount,
 		"updates":          len(updates),
 		"reparse_slugs":    reparseOverlap,
 		"stale_slugs":      staleCount,
@@ -1509,6 +1400,7 @@ func (s *wikiIngestService) mapOneDocument(
 		"summary_chars":    utf8.RuneCountInString(docSummary),
 		"pass0_fallback":   pass0Failed,
 		"classify_batches": batchCount,
+		"map_cache_hit":    mapCacheHit,
 		"summary_preview":  previewText(docSummaryLine, 160),
 	}
 
@@ -1525,11 +1417,11 @@ func (s *wikiIngestService) mapOneDocument(
 func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 	ctx context.Context,
 	chatModel chat.Chat,
-	kbID string,
+	kbID, knowledgeID string,
 	content, lang string,
 	oldPageSlugs map[string]bool,
 	batchCtx *WikiBatchContext,
-) ([]extractedItem, []extractedItem, map[string]extractedItem, error) {
+) ([]extractedItem, []extractedItem, map[string]extractedItem, string, error) {
 	// Only entity/* and concept/* slugs are relevant for LLM slug-continuity —
 	// summary slugs are code-generated from the knowledge ID and never appear
 	// in the extraction output, so including them just wastes tokens and risks
@@ -1537,10 +1429,15 @@ func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 	var prevSlugsText string
 	if len(oldPageSlugs) > 0 {
 		var sb strings.Builder
+		slugs := make([]string, 0, len(oldPageSlugs))
 		for slug := range oldPageSlugs {
 			if !strings.HasPrefix(slug, "entity/") && !strings.HasPrefix(slug, "concept/") {
 				continue
 			}
+			slugs = append(slugs, slug)
+		}
+		sort.Strings(slugs)
+		for _, slug := range slugs {
 			fmt.Fprintf(&sb, "- %s\n", slug)
 		}
 		prevSlugsText = sb.String()
@@ -1549,23 +1446,29 @@ func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 		prevSlugsText = "(none — this is a new document)"
 	}
 
-	extractionJSON, err := s.generateWithTemplate(ctx, chatModel, agent.WikiKnowledgeExtractPrompt, map[string]string{
+	requestData := map[string]string{
 		"Content":            content,
 		"Language":           lang,
 		"PreviousSlugs":      prevSlugsText,
 		"CustomInstructions": batchCtx.ExtractionInstructions,
 		"InstructionScope":   "wiki_extraction",
-	})
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("combined extraction failed: %w", err)
 	}
-
-	extractionJSON = cleanLLMJSON(extractionJSON)
-
-	var result combinedExtraction
-	if err := json.Unmarshal([]byte(extractionJSON), &result); err != nil {
-		logger.Warnf(ctx, "wiki ingest: failed to parse combined extraction JSON: %v\nRaw: %s", err, extractionJSON)
-		return nil, nil, nil, fmt.Errorf("parse combined extraction JSON: %w", err)
+	result, err := resolveWikiCachedJSON(ctx, s.inferenceCache, "legacy_extraction", chatModel,
+		agent.WikiKnowledgeExtractPrompt, requestData, func(loadCtx context.Context, maskedData map[string]string) (combinedExtraction, error) {
+			extractionJSON, generateErr := s.generateWithTemplateMasked(loadCtx, chatModel, agent.WikiKnowledgeExtractPrompt, maskedData)
+			if generateErr != nil {
+				return combinedExtraction{}, generateErr
+			}
+			extractionJSON = cleanLLMJSON(extractionJSON)
+			var parsed combinedExtraction
+			if parseErr := json.Unmarshal([]byte(extractionJSON), &parsed); parseErr != nil {
+				logger.Warnf(loadCtx, "wiki ingest: failed to parse combined extraction JSON: %v\nRaw: %s", parseErr, extractionJSON)
+				return combinedExtraction{}, fmt.Errorf("parse combined extraction JSON: %w", parseErr)
+			}
+			return parsed, nil
+		})
+	if err != nil {
+		return nil, nil, nil, "", fmt.Errorf("combined extraction failed: %w", err)
 	}
 
 	// Dedup pre-filter is dispatched against the wiki page repo via
@@ -1573,9 +1476,13 @@ func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 	// lands the dedup pre-filter degrades to "no dedup" which is the
 	// safe default — the LLM merge call simply doesn't get a candidate
 	// list and the items pass through unchanged.
-	result.Entities, result.Concepts = s.deduplicateExtractedBatch(
-		ctx, chatModel, kbID, result.Entities, result.Concepts,
+	var dedupState string
+	result.Entities, result.Concepts, dedupState, err = s.deduplicateExtractedBatch(
+		ctx, chatModel, kbID, knowledgeID, result.Entities, result.Concepts,
 	)
+	if err != nil {
+		return nil, nil, nil, "", fmt.Errorf("resolve dedup candidates: %w", err)
+	}
 
 	slugItems := make(map[string]extractedItem)
 	for _, item := range result.Entities {
@@ -1589,7 +1496,7 @@ func (s *wikiIngestService) extractEntitiesAndConceptsNoUpsert(
 		}
 	}
 
-	return result.Entities, result.Concepts, slugItems, nil
+	return result.Entities, result.Concepts, slugItems, dedupState, nil
 }
 
 // reduceSlugUpdates returns:

--- a/internal/application/service/wiki_ingest_cite.go
+++ b/internal/application/service/wiki_ingest_cite.go
@@ -71,18 +71,23 @@ type citationPipelineOutcome struct {
 func (s *wikiIngestService) extractCandidateSlugs(
 	ctx context.Context,
 	chatModel chat.Chat,
-	kbID string,
+	kbID, knowledgeID string,
 	content, lang string,
 	oldPageSlugs map[string]bool,
 	batchCtx *WikiBatchContext,
-) ([]extractedItem, []extractedItem, map[string]extractedItem, error) {
+) ([]extractedItem, []extractedItem, map[string]extractedItem, string, error) {
 	var prevSlugsText string
 	if len(oldPageSlugs) > 0 {
 		var sb strings.Builder
+		slugs := make([]string, 0, len(oldPageSlugs))
 		for slug := range oldPageSlugs {
 			if !strings.HasPrefix(slug, "entity/") && !strings.HasPrefix(slug, "concept/") {
 				continue
 			}
+			slugs = append(slugs, slug)
+		}
+		sort.Strings(slugs)
+		for _, slug := range slugs {
 			fmt.Fprintf(&sb, "- %s\n", slug)
 		}
 		prevSlugsText = sb.String()
@@ -92,7 +97,7 @@ func (s *wikiIngestService) extractCandidateSlugs(
 	}
 
 	granularity := batchCtx.ExtractionGranularity.Normalize()
-	raw, err := s.generateWithTemplate(ctx, chatModel, agent.WikiCandidateSlugPrompt, map[string]string{
+	requestData := map[string]string{
 		"Content":             content,
 		"Language":            lang,
 		"PreviousSlugs":       prevSlugsText,
@@ -100,22 +105,32 @@ func (s *wikiIngestService) extractCandidateSlugs(
 		"GranularityGuidance": agent.WikiGranularityGuidance(string(granularity)),
 		"CustomInstructions":  batchCtx.ExtractionInstructions,
 		"InstructionScope":    "wiki_extraction",
-	})
+	}
+	result, err := resolveWikiCachedJSON(ctx, s.inferenceCache, "candidate_slugs", chatModel,
+		agent.WikiCandidateSlugPrompt, requestData, func(loadCtx context.Context, maskedData map[string]string) (combinedExtraction, error) {
+			raw, generateErr := s.generateWithTemplateMasked(loadCtx, chatModel, agent.WikiCandidateSlugPrompt, maskedData)
+			if generateErr != nil {
+				return combinedExtraction{}, generateErr
+			}
+			raw = cleanLLMJSON(raw)
+			var parsed combinedExtraction
+			if parseErr := json.Unmarshal([]byte(raw), &parsed); parseErr != nil {
+				logger.Warnf(loadCtx, "wiki ingest: failed to parse candidate slug JSON: %v\nRaw: %s", parseErr, raw)
+				return combinedExtraction{}, fmt.Errorf("parse candidate slug JSON: %w", parseErr)
+			}
+			return parsed, nil
+		})
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("candidate slug extraction failed: %w", err)
+		return nil, nil, nil, "", fmt.Errorf("candidate slug extraction failed: %w", err)
 	}
 
-	raw = cleanLLMJSON(raw)
-
-	var result combinedExtraction
-	if err := json.Unmarshal([]byte(raw), &result); err != nil {
-		logger.Warnf(ctx, "wiki ingest: failed to parse candidate slug JSON: %v\nRaw: %s", err, raw)
-		return nil, nil, nil, fmt.Errorf("parse candidate slug JSON: %w", err)
-	}
-
-	result.Entities, result.Concepts = s.deduplicateExtractedBatch(
-		ctx, chatModel, kbID, result.Entities, result.Concepts,
+	var dedupState string
+	result.Entities, result.Concepts, dedupState, err = s.deduplicateExtractedBatch(
+		ctx, chatModel, kbID, knowledgeID, result.Entities, result.Concepts,
 	)
+	if err != nil {
+		return nil, nil, nil, "", fmt.Errorf("resolve dedup candidates: %w", err)
+	}
 
 	slugItems := make(map[string]extractedItem, len(result.Entities)+len(result.Concepts))
 	for _, item := range result.Entities {
@@ -129,7 +144,7 @@ func (s *wikiIngestService) extractCandidateSlugs(
 		}
 	}
 
-	return result.Entities, result.Concepts, slugItems, nil
+	return result.Entities, result.Concepts, slugItems, dedupState, nil
 }
 
 // chunkBatch groups chunks that will be sent in a single WikiChunkCitationPrompt call.
@@ -302,21 +317,27 @@ func (s *wikiIngestService) classifyChunkCitations(
 		batchIdx := bi
 		eg.Go(func() error {
 			chunksXML := renderChunksXML(batch)
-			raw, err := s.generateWithTemplate(ectx, chatModel, agent.WikiChunkCitationPrompt, map[string]string{
+			requestData := map[string]string{
 				"CandidateSlugs": candidatesXML,
 				"ChunksXML":      chunksXML,
 				"Language":       lang,
-			})
+			}
+			parsed, err := resolveWikiCachedJSON(ectx, s.inferenceCache, "citations", chatModel,
+				agent.WikiChunkCitationPrompt, requestData, func(loadCtx context.Context, maskedData map[string]string) (citationBatchResult, error) {
+					raw, generateErr := s.generateWithTemplateMasked(loadCtx, chatModel, agent.WikiChunkCitationPrompt, maskedData)
+					if generateErr != nil {
+						return citationBatchResult{}, generateErr
+					}
+					raw = cleanLLMJSON(raw)
+					var result citationBatchResult
+					if parseErr := json.Unmarshal([]byte(raw), &result); parseErr != nil {
+						return citationBatchResult{}, fmt.Errorf("parse citation JSON: %w", parseErr)
+					}
+					return result, nil
+				})
 			if err != nil {
 				logger.Warnf(ectx, "wiki ingest: citation batch %d failed: %v", batchIdx, err)
 				return nil // don't abort peer batches
-			}
-			raw = cleanLLMJSON(raw)
-
-			var parsed citationBatchResult
-			if jerr := json.Unmarshal([]byte(raw), &parsed); jerr != nil {
-				logger.Warnf(ectx, "wiki ingest: citation batch %d parse failed: %v\nRaw: %s", batchIdx, jerr, raw)
-				return nil
 			}
 
 			// Translate aliases → real chunk UUIDs; drop unknown aliases.

--- a/internal/application/service/wiki_ingest_test.go
+++ b/internal/application/service/wiki_ingest_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/models/inferencecache"
 	"github.com/Tencent/WeKnora/internal/types"
 )
 
@@ -329,9 +330,86 @@ func TestGenerateWithTemplateMasksImageURLsBeforeLLM(t *testing.T) {
 	}
 }
 
+func TestGenerateWithTemplateCachedRebindsCurrentImageURL(t *testing.T) {
+	t.Setenv("WEKNORA_INFERENCE_CACHE_ENABLED", "true")
+	const firstURL = "local://10000/exports/first-random.jpg"
+	const secondURL = "local://10000/exports/second-random.jpg"
+	model := &templateCaptureChatModel{
+		response: `summary ![caption](wkimg:0001)`,
+	}
+	service := &wikiIngestService{inferenceCache: inferencecache.New(nil)}
+	template := `Content={{.Content}}`
+
+	first, err := service.generateWithTemplateCached(context.Background(), "summary", model, template,
+		map[string]string{"Content": "![alt](" + firstURL + ")"})
+	if err != nil {
+		t.Fatalf("first generateWithTemplateCached() error = %v", err)
+	}
+	second, err := service.generateWithTemplateCached(context.Background(), "summary", model, template,
+		map[string]string{"Content": "![alt](" + secondURL + ")"})
+	if err != nil {
+		t.Fatalf("second generateWithTemplateCached() error = %v", err)
+	}
+
+	if model.calls != 1 {
+		t.Fatalf("model calls = %d, want 1 cache miss followed by one hit", model.calls)
+	}
+	if !strings.Contains(first, firstURL) {
+		t.Fatalf("first result does not contain first URL: %q", first)
+	}
+	if !strings.Contains(second, secondURL) || strings.Contains(second, firstURL) {
+		t.Fatalf("cache hit did not bind current URL: %q", second)
+	}
+}
+
+func TestResolveWikiCachedJSONRebindsCurrentImageURL(t *testing.T) {
+	t.Setenv("WEKNORA_INFERENCE_CACHE_ENABLED", "true")
+	type result struct {
+		Details string `json:"details"`
+	}
+
+	const firstURL = "minio://bucket/exports/first-random.jpg"
+	const secondURL = "minio://bucket/exports/second-random.jpg"
+	cache := inferencecache.New(nil)
+	model := &templateCaptureChatModel{}
+	loaderCalls := 0
+	loader := func(_ context.Context, maskedData map[string]string) (result, error) {
+		loaderCalls++
+		if strings.Contains(maskedData["Content"], "exports/") || !strings.Contains(maskedData["Content"], "wkimg:0001") {
+			t.Fatalf("loader received unmasked data: %q", maskedData["Content"])
+		}
+		return result{Details: `keep ![current](wkimg:0001), drop ![unknown](wkimg:9999)`}, nil
+	}
+
+	first, err := resolveWikiCachedJSON(context.Background(), cache, "candidate_slugs", model, "{{.Content}}",
+		map[string]string{"Content": "![alt](" + firstURL + ")"}, loader)
+	if err != nil {
+		t.Fatalf("first resolveWikiCachedJSON() error = %v", err)
+	}
+	second, err := resolveWikiCachedJSON(context.Background(), cache, "candidate_slugs", model, "{{.Content}}",
+		map[string]string{"Content": "![alt](" + secondURL + ")"}, loader)
+	if err != nil {
+		t.Fatalf("second resolveWikiCachedJSON() error = %v", err)
+	}
+
+	if loaderCalls != 1 {
+		t.Fatalf("loader calls = %d, want 1", loaderCalls)
+	}
+	if !strings.Contains(first.Details, firstURL) {
+		t.Fatalf("first typed result does not contain first URL: %q", first.Details)
+	}
+	if !strings.Contains(second.Details, secondURL) || strings.Contains(second.Details, firstURL) {
+		t.Fatalf("typed cache hit did not bind current URL: %q", second.Details)
+	}
+	if strings.Contains(second.Details, "wkimg:9999") || strings.Contains(second.Details, "![unknown]") {
+		t.Fatalf("unknown placeholder was not dropped: %q", second.Details)
+	}
+}
+
 type templateCaptureChatModel struct {
 	prompt   string
 	response string
+	calls    int
 }
 
 func (m *templateCaptureChatModel) Chat(
@@ -339,6 +417,7 @@ func (m *templateCaptureChatModel) Chat(
 	messages []chat.Message,
 	_ *chat.ChatOptions,
 ) (*types.ChatResponse, error) {
+	m.calls++
 	if len(messages) > 0 {
 		m.prompt = messages[0].Content
 	}

--- a/internal/application/service/wiki_map_artifact.go
+++ b/internal/application/service/wiki_map_artifact.go
@@ -1,0 +1,545 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"unicode/utf8"
+
+	"github.com/Tencent/WeKnora/internal/agent"
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/models/inferencecache"
+	"github.com/Tencent/WeKnora/internal/searchutil"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+const (
+	wikiDocMapArtifactVersion = "v2"
+	wikiStableChunkRefVersion = "v1"
+	wikiDedupStateVersion     = "v1"
+)
+
+// wikiDocMapArtifact is the source-owned output of the expensive Wiki map
+// phase. It deliberately stops before reduce: page state, other contributors,
+// retracts and cross-document conflicts remain live inputs to reduce.
+//
+// SourceChunks contain stable logical refs while this value is cached. They
+// are rebound to the current parse's physical chunk UUIDs before mapOneDocument
+// builds SlugUpdates.
+type wikiDocMapArtifact struct {
+	Entities      []extractedItem `json:"entities"`
+	Concepts      []extractedItem `json:"concepts"`
+	Summary       string          `json:"summary"`
+	Pass0Fallback bool            `json:"pass0_fallback"`
+	BatchCount    int             `json:"batch_count"`
+	UncitedCount  int             `json:"uncited_count"`
+	NewSlugCount  int             `json:"new_slug_count"`
+	DedupState    string          `json:"dedup_state"`
+}
+
+type wikiFrozenChunk struct {
+	Ref           string          `json:"ref"`
+	ChunkIndex    int             `json:"chunk_index"`
+	StartAt       int             `json:"start_at"`
+	EndAt         int             `json:"end_at"`
+	ChunkType     types.ChunkType `json:"chunk_type"`
+	Content       string          `json:"content"`
+	ContextHeader string          `json:"context_header,omitempty"`
+}
+
+// wikiDedupCandidateState fingerprints the exact external page projection
+// consumed by the dedup prompt. Pages whose source_refs all belong to the
+// current document are excluded: creating or refreshing those pages is this
+// document's own reduce-side effect and must not invalidate its map cache on
+// the next unchanged reparse.
+func wikiDedupCandidateState(pages map[string]*types.WikiPageLite, knowledgeID string) string {
+	type dependency struct {
+		Slug     string   `json:"slug"`
+		Title    string   `json:"title"`
+		PageType string   `json:"page_type"`
+		Aliases  []string `json:"aliases,omitempty"`
+	}
+	dependencies := make([]dependency, 0, len(pages))
+	for _, page := range pages {
+		if page == nil || page.Slug == "" || wikiPageOnlyReferencesKnowledge(page, knowledgeID) {
+			continue
+		}
+		aliases := append([]string(nil), page.Aliases...)
+		sort.Strings(aliases)
+		dependencies = append(dependencies, dependency{
+			Slug:     page.Slug,
+			Title:    page.Title,
+			PageType: page.PageType,
+			Aliases:  aliases,
+		})
+	}
+	sort.Slice(dependencies, func(i, j int) bool {
+		return dependencies[i].Slug < dependencies[j].Slug
+	})
+	encoded, _ := json.Marshal(struct {
+		Version string       `json:"version"`
+		Pages   []dependency `json:"pages"`
+	}{Version: wikiDedupStateVersion, Pages: dependencies})
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:])
+}
+
+func wikiPageOnlyReferencesKnowledge(page *types.WikiPageLite, knowledgeID string) bool {
+	if page == nil || knowledgeID == "" || len(page.SourceRefs) == 0 {
+		return false
+	}
+	for _, sourceRef := range page.SourceRefs {
+		sourceID := sourceRef
+		if separator := strings.IndexByte(sourceID, '|'); separator >= 0 {
+			sourceID = sourceID[:separator]
+		}
+		if sourceID != knowledgeID {
+			return false
+		}
+	}
+	return true
+}
+
+// wikiStableChunkRef gives cache artifacts a deterministic logical reference
+// without changing the chunks table's UUID primary key. Including position
+// disambiguates repeated boilerplate chunks while normalized content keeps the
+// ref stable across random export-image URLs.
+func wikiStableChunkRef(chunk *types.Chunk) string {
+	if chunk == nil {
+		return ""
+	}
+	payload := struct {
+		Version       string          `json:"version"`
+		ChunkIndex    int             `json:"chunk_index"`
+		StartAt       int             `json:"start_at"`
+		EndAt         int             `json:"end_at"`
+		ChunkType     types.ChunkType `json:"chunk_type"`
+		Content       string          `json:"content"`
+		ContextHeader string          `json:"context_header,omitempty"`
+	}{
+		Version:       wikiStableChunkRefVersion,
+		ChunkIndex:    chunk.ChunkIndex,
+		StartAt:       chunk.StartAt,
+		EndAt:         chunk.EndAt,
+		ChunkType:     chunk.ChunkType,
+		Content:       searchutil.CanonicalizeImageURLsForModel(chunk.Content),
+		ContextHeader: searchutil.CanonicalizeImageURLsForModel(chunk.ContextHeader),
+	}
+	encoded, _ := json.Marshal(payload)
+	sum := sha256.Sum256(encoded)
+	return "wkchunk:" + wikiStableChunkRefVersion + ":" + hex.EncodeToString(sum[:])
+}
+
+func freezeWikiChunks(chunks []*types.Chunk) ([]wikiFrozenChunk, map[string]string, map[string]string) {
+	frozen := make([]wikiFrozenChunk, 0, len(chunks))
+	idToRef := make(map[string]string, len(chunks))
+	refToID := make(map[string]string, len(chunks))
+	for _, chunk := range chunks {
+		if chunk == nil || chunk.ID == "" {
+			continue
+		}
+		ref := wikiStableChunkRef(chunk)
+		idToRef[chunk.ID] = ref
+		refToID[ref] = chunk.ID
+		frozen = append(frozen, wikiFrozenChunk{
+			Ref:           ref,
+			ChunkIndex:    chunk.ChunkIndex,
+			StartAt:       chunk.StartAt,
+			EndAt:         chunk.EndAt,
+			ChunkType:     chunk.ChunkType,
+			Content:       searchutil.CanonicalizeImageURLsForModel(chunk.Content),
+			ContextHeader: searchutil.CanonicalizeImageURLsForModel(chunk.ContextHeader),
+		})
+	}
+	sort.Slice(frozen, func(i, j int) bool {
+		if frozen[i].ChunkIndex != frozen[j].ChunkIndex {
+			return frozen[i].ChunkIndex < frozen[j].ChunkIndex
+		}
+		if frozen[i].StartAt != frozen[j].StartAt {
+			return frozen[i].StartAt < frozen[j].StartAt
+		}
+		return frozen[i].Ref < frozen[j].Ref
+	})
+	return frozen, idToRef, refToID
+}
+
+func wikiDocMapArtifactKey(
+	ctx context.Context,
+	chatModel chat.Chat,
+	kbID string,
+	content, lang string,
+	chunks []*types.Chunk,
+	batchCtx *WikiBatchContext,
+) string {
+	tenantID, _ := types.TenantIDFromContext(ctx)
+	maskedContent, _ := maskImageURLs(content)
+	frozenChunks, _, _ := freezeWikiChunks(chunks)
+	granularity := types.WikiExtractionStandard
+	var contentInstructions, extractionInstructions string
+	if batchCtx != nil {
+		granularity = batchCtx.ExtractionGranularity.Normalize()
+		contentInstructions = batchCtx.ContentInstructions
+		extractionInstructions = batchCtx.ExtractionInstructions
+	}
+	input := struct {
+		Version                string                          `json:"version"`
+		KnowledgeBaseID        string                          `json:"knowledge_base_id"`
+		Language               string                          `json:"language"`
+		Granularity            types.WikiExtractionGranularity `json:"granularity"`
+		ContentInstructions    string                          `json:"content_instructions"`
+		ExtractionInstructions string                          `json:"extraction_instructions"`
+		Content                string                          `json:"content"`
+		Chunks                 []wikiFrozenChunk               `json:"chunks"`
+	}{
+		Version:                wikiDocMapArtifactVersion,
+		KnowledgeBaseID:        kbID,
+		Language:               lang,
+		Granularity:            granularity,
+		ContentInstructions:    contentInstructions,
+		ExtractionInstructions: extractionInstructions,
+		Content:                maskedContent,
+		Chunks:                 frozenChunks,
+	}
+	encoded, _ := json.Marshal(input)
+	return inferencecache.Key(
+		"wiki.doc.map", tenantID, chat.FingerprintOf(chatModel),
+		[]byte(wikiDocMapArtifactVersion),
+		[]byte(agent.WikiCandidateSlugPrompt),
+		[]byte(agent.WikiKnowledgeExtractPrompt),
+		[]byte(agent.WikiDeduplicationPrompt),
+		[]byte(agent.WikiSummaryPrompt),
+		[]byte(agent.WikiChunkCitationPrompt),
+		encoded,
+	)
+}
+
+func transformArtifactChunkRefs(items []extractedItem, refs map[string]string) error {
+	for i := range items {
+		for j, sourceChunk := range items[i].SourceChunks {
+			mapped, ok := refs[sourceChunk]
+			if !ok {
+				return fmt.Errorf("wiki map artifact references unknown chunk %q", sourceChunk)
+			}
+			items[i].SourceChunks[j] = mapped
+		}
+	}
+	return nil
+}
+
+func transformArtifactImageURLs(artifact *wikiDocMapArtifact, transform func(string) string) {
+	if artifact == nil || transform == nil {
+		return
+	}
+	artifact.Summary = transform(artifact.Summary)
+	transformItems := func(items []extractedItem) {
+		for i := range items {
+			items[i].Name = transform(items[i].Name)
+			items[i].Slug = transform(items[i].Slug)
+			items[i].Description = transform(items[i].Description)
+			items[i].Details = transform(items[i].Details)
+			for j := range items[i].Aliases {
+				items[i].Aliases[j] = transform(items[i].Aliases[j])
+			}
+		}
+	}
+	transformItems(artifact.Entities)
+	transformItems(artifact.Concepts)
+}
+
+func freezeWikiDocMapArtifact(artifact *wikiDocMapArtifact, content string, idToRef map[string]string) error {
+	if err := transformArtifactChunkRefs(artifact.Entities, idToRef); err != nil {
+		return err
+	}
+	if err := transformArtifactChunkRefs(artifact.Concepts, idToRef); err != nil {
+		return err
+	}
+	_, tokenToURL := maskImageURLs(content)
+	urlToToken := make(map[string]string, len(tokenToURL))
+	for token, url := range tokenToURL {
+		urlToToken[url] = token
+	}
+	transformArtifactImageURLs(artifact, func(value string) string {
+		return maskImageURLsWithState(value, urlToToken, tokenToURL)
+	})
+	return nil
+}
+
+func thawWikiDocMapArtifact(artifact *wikiDocMapArtifact, content string, refToID map[string]string) error {
+	if err := transformArtifactChunkRefs(artifact.Entities, refToID); err != nil {
+		return err
+	}
+	if err := transformArtifactChunkRefs(artifact.Concepts, refToID); err != nil {
+		return err
+	}
+	_, tokenToURL := maskImageURLs(content)
+	transformArtifactImageURLs(artifact, func(value string) string {
+		return unmaskImageURLs(value, tokenToURL)
+	})
+	return nil
+}
+
+func (s *wikiIngestService) resolveWikiDocMapArtifact(
+	ctx context.Context,
+	chatModel chat.Chat,
+	kbID, knowledgeID, content, lang string,
+	chunks []*types.Chunk,
+	oldPageSlugs map[string]bool,
+	batchCtx *WikiBatchContext,
+	wikiSpan *Span,
+) (wikiDocMapArtifact, bool, error) {
+	key := wikiDocMapArtifactKey(ctx, chatModel, kbID, content, lang, chunks, batchCtx)
+	_, idToRef, refToID := freezeWikiChunks(chunks)
+	loader := func(loadCtx context.Context) (wikiDocMapArtifact, error) {
+		return s.computeWikiDocMapArtifact(
+			loadCtx, chatModel, kbID, knowledgeID, content, lang,
+			chunks, oldPageSlugs, batchCtx, wikiSpan,
+		)
+	}
+	artifact, stats, err := resolveWikiDocMapArtifactValue(
+		ctx, s.inferenceCache, key, content, idToRef, refToID, loader,
+	)
+	if stats.ReadError != nil {
+		logger.Warnf(ctx, "[InferenceCache] Wiki doc map read failed, using provider: %v", stats.ReadError)
+	}
+	if stats.WriteError != nil {
+		logger.Warnf(ctx, "[InferenceCache] Wiki doc map write failed: %v", stats.WriteError)
+	}
+	if err != nil {
+		return wikiDocMapArtifact{}, false, err
+	}
+	if stats.Hit {
+		candidatePages, candidateErr := s.findDedupCandidatePages(ctx, kbID, artifact.Entities, artifact.Concepts)
+		if candidateErr != nil {
+			return wikiDocMapArtifact{}, false, fmt.Errorf("validate wiki dedup state: %w", candidateErr)
+		}
+		currentDedupState := wikiDedupCandidateState(candidatePages, knowledgeID)
+		if currentDedupState != artifact.DedupState {
+			logger.Infof(ctx, "[InferenceCache] stage=wiki.doc.map key=%s invalidated=dedup_state old=%s new=%s",
+				inferenceCacheKeyID(key), shortFingerprint(artifact.DedupState), shortFingerprint(currentDedupState))
+			var invalidateErr error
+			if s.inferenceCache != nil {
+				invalidateErr = s.inferenceCache.Invalidate(ctx, key)
+			}
+			if s.inferenceCache == nil || invalidateErr != nil {
+				// Cache invalidation failures must not make stale Wiki mappings
+				// authoritative. Recompute directly and continue without caching.
+				if invalidateErr != nil {
+					logger.Warnf(ctx, "[InferenceCache] Wiki doc map invalidation failed, recomputing without cache: %v", invalidateErr)
+				}
+				artifact, err = loader(ctx)
+				if err != nil {
+					return wikiDocMapArtifact{}, false, err
+				}
+				return artifact, false, nil
+			}
+			artifact, stats, err = resolveWikiDocMapArtifactValue(
+				ctx, s.inferenceCache, key, content, idToRef, refToID, loader,
+			)
+			if err != nil {
+				return wikiDocMapArtifact{}, false, err
+			}
+			// A concurrent writer may have restored the stale entry after our
+			// invalidation. Validate the reloaded artifact against its own
+			// candidate set; extraction itself may legitimately have changed.
+			reloadedPages, reloadStateErr := s.findDedupCandidatePages(ctx, kbID, artifact.Entities, artifact.Concepts)
+			if reloadStateErr != nil {
+				return wikiDocMapArtifact{}, false, fmt.Errorf("validate refreshed wiki dedup state: %w", reloadStateErr)
+			}
+			if artifact.DedupState != wikiDedupCandidateState(reloadedPages, knowledgeID) {
+				artifact, err = loader(ctx)
+				if err != nil {
+					return wikiDocMapArtifact{}, false, err
+				}
+				return artifact, false, nil
+			}
+		}
+	}
+	logger.Infof(ctx, "[InferenceCache] stage=wiki.doc.map key=%s hit=%v coalesced=%v",
+		inferenceCacheKeyID(key), stats.Hit, stats.Coalesced)
+	return artifact, stats.Hit || stats.Coalesced, nil
+}
+
+func shortFingerprint(value string) string {
+	if len(value) > 12 {
+		return value[:12]
+	}
+	return value
+}
+
+func resolveWikiDocMapArtifactValue(
+	ctx context.Context,
+	cache inferencecache.Cache,
+	key, content string,
+	idToRef, refToID map[string]string,
+	loader func(context.Context) (wikiDocMapArtifact, error),
+) (wikiDocMapArtifact, inferencecache.Stats, error) {
+	artifact, stats, err := inferencecache.ResolveJSON(ctx, cache, key,
+		func(loadCtx context.Context) (wikiDocMapArtifact, error) {
+			computed, loadErr := loader(loadCtx)
+			if loadErr != nil {
+				return wikiDocMapArtifact{}, loadErr
+			}
+			if freezeErr := freezeWikiDocMapArtifact(&computed, content, idToRef); freezeErr != nil {
+				return wikiDocMapArtifact{}, freezeErr
+			}
+			return computed, nil
+		})
+	if err != nil {
+		return wikiDocMapArtifact{}, stats, err
+	}
+	if err := thawWikiDocMapArtifact(&artifact, content, refToID); err != nil {
+		if cache != nil {
+			_ = cache.Invalidate(ctx, key)
+		}
+		return wikiDocMapArtifact{}, stats, fmt.Errorf("rebind wiki doc map artifact: %w", err)
+	}
+	return artifact, stats, nil
+}
+
+func (s *wikiIngestService) computeWikiDocMapArtifact(
+	ctx context.Context,
+	chatModel chat.Chat,
+	kbID, knowledgeID, content, lang string,
+	chunks []*types.Chunk,
+	oldPageSlugs map[string]bool,
+	batchCtx *WikiBatchContext,
+	wikiSpan *Span,
+) (wikiDocMapArtifact, error) {
+	if batchCtx == nil {
+		batchCtx = &WikiBatchContext{}
+	}
+	var (
+		extractedEntities []extractedItem
+		extractedConcepts []extractedItem
+		slugItems         map[string]extractedItem
+		dedupState        string
+		pass0Failed       bool
+	)
+	logger.Infof(ctx, "wiki ingest: pass 0 - extracting candidate slugs for %s", knowledgeID)
+	extractSpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.extract", types.SpanKindSubSpan, types.JSONMap{
+		"content_chars": utf8.RuneCountInString(content),
+		"old_pages":     len(oldPageSlugs),
+	})
+	extractedEntities, extractedConcepts, slugItems, dedupState, err := s.extractCandidateSlugs(
+		ctx, chatModel, kbID, knowledgeID, content, lang, oldPageSlugs, batchCtx,
+	)
+	if err != nil {
+		logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) - falling back to legacy extractor", knowledgeID, err)
+		pass0Failed = true
+		extractedEntities, extractedConcepts, slugItems, dedupState, err = s.extractEntitiesAndConceptsNoUpsert(
+			ctx, chatModel, kbID, knowledgeID, content, lang, oldPageSlugs, batchCtx,
+		)
+		if err != nil {
+			s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
+			return wikiDocMapArtifact{}, err
+		}
+	}
+	s.tracker().EndSpan(ctx, extractSpan, types.JSONMap{
+		"entities":         len(extractedEntities),
+		"concepts":         len(extractedConcepts),
+		"pass0_fallback":   pass0Failed,
+		"entities_preview": previewExtractedItems(extractedEntities, 8),
+		"concepts_preview": previewExtractedItems(extractedConcepts, 8),
+	})
+
+	var summaryExtractedPages []string
+	for slug := range slugItems {
+		summaryExtractedPages = append(summaryExtractedPages, slug)
+	}
+	sort.Strings(summaryExtractedPages)
+	var slugListing strings.Builder
+	for _, slug := range summaryExtractedPages {
+		if item, ok := slugItems[slug]; ok {
+			aliases := ""
+			if len(item.Aliases) > 0 {
+				aliases = fmt.Sprintf(" (Aliases: %s)", strings.Join(item.Aliases, ", "))
+			}
+			fmt.Fprintf(&slugListing, "- [[%s]] = %s%s\n", slug, item.Name, aliases)
+		} else {
+			fmt.Fprintf(&slugListing, "- [[%s]]\n", slug)
+		}
+	}
+
+	var (
+		summaryContent string
+		summaryErr     error
+		citations      map[string][]string
+		newSlugs       []newSlugFromCitation
+		batchCount     int
+	)
+	summarySpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.summary", types.SpanKindSubSpan, types.JSONMap{
+		"content_chars":   utf8.RuneCountInString(content),
+		"extracted_slugs": len(summaryExtractedPages),
+	})
+	var classifySpan *Span
+	if !pass0Failed {
+		classifySpan = s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.classify", types.SpanKindSubSpan, types.JSONMap{
+			"chunks":     len(chunks),
+			"candidates": len(extractedEntities) + len(extractedConcepts),
+		})
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		summaryContent, summaryErr = s.generateWithTemplateCached(ctx, "summary", chatModel, agent.WikiSummaryPrompt, map[string]string{
+			"Content":            content,
+			"Language":           lang,
+			"ExtractedSlugs":     slugListing.String(),
+			"CustomInstructions": batchCtx.ContentInstructions,
+			"InstructionScope":   "wiki_content",
+		})
+		if summaryErr != nil {
+			s.tracker().FailSpan(ctx, summarySpan, "SUMMARY_FAILED", summaryErr.Error(), summaryErr)
+		} else {
+			sumLine, sumBody := splitSummaryLine(summaryContent)
+			s.tracker().EndSpan(ctx, summarySpan, types.JSONMap{
+				"chars":        utf8.RuneCountInString(summaryContent),
+				"summary_line": previewText(sumLine, 160),
+				"body_preview": previewText(sumBody, 320),
+			})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if pass0Failed {
+			citations = map[string][]string{}
+			return
+		}
+		candidatesXML := renderCandidateSlugsXML(extractedEntities, extractedConcepts)
+		citations, newSlugs, batchCount = s.classifyChunkCitations(ctx, chatModel, candidatesXML, chunks, lang, batchCtx)
+		s.tracker().EndSpan(ctx, classifySpan, types.JSONMap{
+			"cited_slugs":      len(citations),
+			"new_slugs":        len(newSlugs),
+			"batches":          batchCount,
+			"top_cited":        topCitedSlugs(citations, 8),
+			"new_slugs_sample": previewNewSlugs(newSlugs, 8),
+		})
+	}()
+	wg.Wait()
+	if summaryErr != nil {
+		return wikiDocMapArtifact{}, fmt.Errorf("generate summary: %w", summaryErr)
+	}
+
+	var uncitedCount int
+	extractedEntities, extractedConcepts, uncitedCount = mergeCitationsIntoItems(
+		extractedEntities, extractedConcepts, citations, newSlugs,
+	)
+	return wikiDocMapArtifact{
+		Entities:      extractedEntities,
+		Concepts:      extractedConcepts,
+		Summary:       summaryContent,
+		Pass0Fallback: pass0Failed,
+		BatchCount:    batchCount,
+		UncitedCount:  uncitedCount,
+		NewSlugCount:  len(newSlugs),
+		DedupState:    dedupState,
+	}, nil
+}

--- a/internal/application/service/wiki_map_artifact_test.go
+++ b/internal/application/service/wiki_map_artifact_test.go
@@ -1,0 +1,223 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/models/inferencecache"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+type wikiArtifactTestChat struct {
+	id   string
+	name string
+}
+
+func (*wikiArtifactTestChat) Chat(context.Context, []chat.Message, *chat.ChatOptions) (*types.ChatResponse, error) {
+	return nil, nil
+}
+
+func (*wikiArtifactTestChat) ChatStream(context.Context, []chat.Message, *chat.ChatOptions) (<-chan types.StreamResponse, error) {
+	return nil, nil
+}
+
+func (m *wikiArtifactTestChat) GetModelName() string { return m.name }
+func (m *wikiArtifactTestChat) GetModelID() string   { return m.id }
+
+func wikiArtifactChunk(id, content string) *types.Chunk {
+	return &types.Chunk{
+		ID:            id,
+		Content:       content,
+		ChunkIndex:    3,
+		StartAt:       120,
+		EndAt:         240,
+		ChunkType:     types.ChunkTypeText,
+		ContextHeader: "# Results",
+	}
+}
+
+func TestWikiStableChunkRefSurvivesReparseUUIDAndImageURL(t *testing.T) {
+	first := wikiArtifactChunk("old-uuid", "evidence ![chart](local://exports/random-a.png)")
+	second := wikiArtifactChunk("new-uuid", "evidence ![chart](local://exports/random-b.png)")
+
+	if got, want := wikiStableChunkRef(first), wikiStableChunkRef(second); got != want {
+		t.Fatalf("stable refs differ across physical UUID/URL changes: %q != %q", got, want)
+	}
+
+	changed := wikiArtifactChunk("third-uuid", "different evidence ![chart](local://exports/random-b.png)")
+	if wikiStableChunkRef(first) == wikiStableChunkRef(changed) {
+		t.Fatal("content change did not invalidate stable chunk ref")
+	}
+}
+
+func TestWikiDocMapArtifactKeyLayeredInvalidation(t *testing.T) {
+	ctx := context.Background()
+	firstModel := &wikiArtifactTestChat{id: "model-a", name: "chat-a"}
+	secondModel := &wikiArtifactTestChat{id: "model-b", name: "chat-b"}
+	firstChunk := wikiArtifactChunk("old-uuid", "evidence ![chart](local://exports/random-a.png)")
+	secondChunk := wikiArtifactChunk("new-uuid", "evidence ![chart](local://exports/random-b.png)")
+	firstContent := "paper ![chart](local://exports/random-a.png)"
+	secondContent := "paper ![chart](local://exports/random-b.png)"
+	standard := &WikiBatchContext{ExtractionGranularity: types.WikiExtractionStandard}
+
+	base := wikiDocMapArtifactKey(ctx, firstModel, "kb-1", firstContent, "English", []*types.Chunk{firstChunk}, standard)
+	reparse := wikiDocMapArtifactKey(ctx, firstModel, "kb-1", secondContent, "English", []*types.Chunk{secondChunk}, standard)
+	if base != reparse {
+		t.Fatalf("random physical IDs changed artifact key: %q != %q", base, reparse)
+	}
+
+	changedModel := wikiDocMapArtifactKey(ctx, secondModel, "kb-1", secondContent, "English", []*types.Chunk{secondChunk}, standard)
+	if base == changedModel {
+		t.Fatal("chat model change did not invalidate artifact key")
+	}
+
+	exhaustive := &WikiBatchContext{ExtractionGranularity: types.WikiExtractionExhaustive}
+	changedGranularity := wikiDocMapArtifactKey(ctx, firstModel, "kb-1", secondContent, "English", []*types.Chunk{secondChunk}, exhaustive)
+	if base == changedGranularity {
+		t.Fatal("extraction granularity change did not invalidate artifact key")
+	}
+
+	changedContent := wikiDocMapArtifactKey(ctx, firstModel, "kb-1", "revised paper", "English", []*types.Chunk{wikiArtifactChunk("new", "revised evidence")}, standard)
+	if base == changedContent {
+		t.Fatal("document content change did not invalidate artifact key")
+	}
+}
+
+func TestWikiDedupCandidateStateIgnoresSelfOnlyPages(t *testing.T) {
+	const knowledgeID = "knowledge-1"
+	baseline := wikiDedupCandidateState(nil, knowledgeID)
+	selfOnly := map[string]*types.WikiPageLite{
+		"entity/cache": {
+			Slug:       "entity/cache",
+			Title:      "Cache",
+			PageType:   types.WikiPageTypeEntity,
+			Status:     types.WikiPageStatusPublished,
+			Aliases:    types.StringArray{"Caching"},
+			SourceRefs: types.StringArray{knowledgeID + "|Current document"},
+		},
+	}
+	if got := wikiDedupCandidateState(selfOnly, knowledgeID); got != baseline {
+		t.Fatalf("self-only reduce output invalidated map state: %q != %q", got, baseline)
+	}
+
+	external := map[string]*types.WikiPageLite{
+		"entity/cache": {
+			Slug:       "entity/cache",
+			Title:      "Cache",
+			PageType:   types.WikiPageTypeEntity,
+			Status:     types.WikiPageStatusPublished,
+			Aliases:    types.StringArray{"Caching"},
+			SourceRefs: types.StringArray{"knowledge-2|Other document"},
+		},
+	}
+	externalState := wikiDedupCandidateState(external, knowledgeID)
+	if externalState == baseline {
+		t.Fatal("external dedup candidate did not invalidate map state")
+	}
+	external["entity/cache"].SourceRefs = types.StringArray{
+		knowledgeID + "|Current document",
+		"knowledge-2|Other document",
+	}
+	if got := wikiDedupCandidateState(external, knowledgeID); got != externalState {
+		t.Fatalf("adding the current document to an external page changed its dedup state: %q != %q", got, externalState)
+	}
+
+	external["entity/cache"].Aliases = types.StringArray{"Memoization"}
+	if changed := wikiDedupCandidateState(external, knowledgeID); changed == externalState {
+		t.Fatal("external candidate alias change did not invalidate map state")
+	}
+}
+
+func TestWikiDedupCandidateStateIsOrderIndependent(t *testing.T) {
+	first := map[string]*types.WikiPageLite{
+		"concept/rag": {
+			Slug:       "concept/rag",
+			Title:      "RAG",
+			PageType:   types.WikiPageTypeConcept,
+			Status:     types.WikiPageStatusPublished,
+			Aliases:    types.StringArray{"Retrieval Augmented Generation", "Retrieval-Augmented Generation"},
+			SourceRefs: types.StringArray{"knowledge-2"},
+		},
+		"entity/weknora": {
+			Slug:       "entity/weknora",
+			Title:      "WeKnora",
+			PageType:   types.WikiPageTypeEntity,
+			Status:     types.WikiPageStatusPublished,
+			SourceRefs: types.StringArray{"knowledge-3"},
+		},
+	}
+	second := map[string]*types.WikiPageLite{
+		"entity/weknora": first["entity/weknora"],
+		"concept/rag": {
+			Slug:       "concept/rag",
+			Title:      "RAG",
+			PageType:   types.WikiPageTypeConcept,
+			Status:     types.WikiPageStatusPublished,
+			Aliases:    types.StringArray{"Retrieval-Augmented Generation", "Retrieval Augmented Generation"},
+			SourceRefs: types.StringArray{"knowledge-2"},
+		},
+	}
+	if got, want := wikiDedupCandidateState(first, "knowledge-1"), wikiDedupCandidateState(second, "knowledge-1"); got != want {
+		t.Fatalf("map or alias order changed dedup state: %q != %q", got, want)
+	}
+}
+
+func TestResolveWikiDocMapArtifactValueHitsAndRebinds(t *testing.T) {
+	t.Setenv("WEKNORA_INFERENCE_CACHE_ENABLED", "true")
+	ctx := context.Background()
+	cache := inferencecache.New(nil)
+	const key = "wiki-doc-map-test-key"
+	const firstURL = "local://exports/random-first.png"
+	const secondURL = "local://exports/random-second.png"
+
+	firstChunk := wikiArtifactChunk("old-uuid", "evidence ![chart]("+firstURL+")")
+	_, firstIDToRef, firstRefToID := freezeWikiChunks([]*types.Chunk{firstChunk})
+	loaderCalls := 0
+	loader := func(context.Context) (wikiDocMapArtifact, error) {
+		loaderCalls++
+		return wikiDocMapArtifact{
+			Entities: []extractedItem{{
+				Name:         "Chart",
+				Slug:         "entity/chart",
+				Details:      "See ![chart](" + firstURL + ")",
+				SourceChunks: []string{firstChunk.ID},
+			}},
+			Summary: "Summary ![chart](" + firstURL + ")",
+		}, nil
+	}
+
+	first, firstStats, err := resolveWikiDocMapArtifactValue(
+		ctx, cache, key, "paper ![chart]("+firstURL+")",
+		firstIDToRef, firstRefToID, loader,
+	)
+	if err != nil {
+		t.Fatalf("first resolve error = %v", err)
+	}
+	if firstStats.Hit || loaderCalls != 1 {
+		t.Fatalf("first resolve stats=%+v loaderCalls=%d, want miss and one load", firstStats, loaderCalls)
+	}
+	if first.Entities[0].SourceChunks[0] != "old-uuid" || !strings.Contains(first.Summary, firstURL) {
+		t.Fatalf("first result not rebound: %+v", first)
+	}
+
+	secondChunk := wikiArtifactChunk("new-uuid", "evidence ![chart]("+secondURL+")")
+	_, secondIDToRef, secondRefToID := freezeWikiChunks([]*types.Chunk{secondChunk})
+	second, secondStats, err := resolveWikiDocMapArtifactValue(
+		ctx, cache, key, "paper ![chart]("+secondURL+")",
+		secondIDToRef, secondRefToID, loader,
+	)
+	if err != nil {
+		t.Fatalf("second resolve error = %v", err)
+	}
+	if !secondStats.Hit || loaderCalls != 1 {
+		t.Fatalf("second resolve stats=%+v loaderCalls=%d, want hit without reload", secondStats, loaderCalls)
+	}
+	if got := second.Entities[0].SourceChunks[0]; got != "new-uuid" {
+		t.Fatalf("cached stable ref rebound to %q, want new-uuid", got)
+	}
+	if !strings.Contains(second.Summary, secondURL) || strings.Contains(second.Summary, firstURL) {
+		t.Fatalf("cached image URL was not rebound to current parse: %q", second.Summary)
+	}
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -78,6 +78,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/mcp"
 	"github.com/Tencent/WeKnora/internal/models/chat"
 	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/models/inferencecache"
 	"github.com/Tencent/WeKnora/internal/models/limiter"
 	"github.com/Tencent/WeKnora/internal/models/utils/ollama"
 	"github.com/Tencent/WeKnora/internal/router"
@@ -197,6 +198,8 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(service.NewChunkService))
 	must(container.Provide(service.NewKnowledgeTagService))
 	must(container.Provide(embedding.NewBatchEmbedder))
+	must(container.Provide(embedding.NewVectorCache))
+	must(container.Provide(inferencecache.New))
 	must(container.Provide(service.NewModelService))
 	must(container.Provide(service.NewDatasetService))
 	must(container.Provide(service.NewEvaluationService))

--- a/internal/container/reset_pending_tasks_test.go
+++ b/internal/container/reset_pending_tasks_test.go
@@ -74,7 +74,8 @@ CREATE TABLE IF NOT EXISTS task_pending_ops (
     payload     TEXT NOT NULL DEFAULT '{}',
     fail_count  INTEGER NOT NULL DEFAULT 0,
     enqueued_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    claimed_at  DATETIME
+    claimed_at  DATETIME,
+    claim_token VARCHAR(64) NOT NULL DEFAULT ''
 );
 `
 

--- a/internal/models/chat/chat.go
+++ b/internal/models/chat/chat.go
@@ -154,7 +154,11 @@ func NewChat(config *ChatConfig, ollamaService *ollama.OllamaService) (Chat, err
 	c, err = wrapChatLangfuse(c, err)
 	// Outermost: hold the per-model concurrency slot only around the real
 	// provider round-trip, so the wait is excluded from debug/langfuse timing.
-	return wrapChatConcurrency(c, config.MaxConcurrency, err)
+	c, err = wrapChatConcurrency(c, config.MaxConcurrency, err)
+	if err == nil && c != nil {
+		c = &fingerprintedChat{chatDelegate: c, fingerprint: ModelFingerprint(config)}
+	}
+	return c, err
 }
 
 // NewRemoteChat 根据 provider 创建远程聊天实例。

--- a/internal/models/chat/fingerprint.go
+++ b/internal/models/chat/fingerprint.go
@@ -1,0 +1,55 @@
+package chat
+
+import "github.com/Tencent/WeKnora/internal/models/inferencecache"
+
+// chatDelegate avoids naming the embedded field "Chat", which would shadow
+// the Chat(...) method and prevent method promotion from satisfying Chat.
+type chatDelegate = Chat
+
+type fingerprintedChat struct {
+	chatDelegate
+	fingerprint string
+}
+
+func (c *fingerprintedChat) CacheFingerprint() string { return c.fingerprint }
+
+// ModelFingerprint includes every non-secret setting that can change a chat
+// completion. Credential rotation and concurrency tuning do not invalidate
+// deterministic enrichment results.
+func ModelFingerprint(config *ChatConfig) string {
+	if config == nil {
+		return inferencecache.Fingerprint(nil)
+	}
+	return inferencecache.Fingerprint(struct {
+		Source        string            `json:"source"`
+		BaseURL       string            `json:"base_url"`
+		ModelName     string            `json:"model_name"`
+		ModelID       string            `json:"model_id"`
+		Provider      string            `json:"provider"`
+		AppID         string            `json:"app_id,omitempty"`
+		ExtraConfig   map[string]string `json:"extra_config,omitempty"`
+		CustomHeaders map[string]string `json:"custom_headers,omitempty"`
+	}{
+		Source:        string(config.Source),
+		BaseURL:       config.BaseURL,
+		ModelName:     config.ModelName,
+		ModelID:       config.ModelID,
+		Provider:      config.Provider,
+		AppID:         config.AppID,
+		ExtraConfig:   config.ExtraConfig,
+		CustomHeaders: config.CustomHeaders,
+	})
+}
+
+func FingerprintOf(model Chat) string {
+	if identified, ok := model.(interface{ CacheFingerprint() string }); ok {
+		return identified.CacheFingerprint()
+	}
+	if model == nil {
+		return inferencecache.Fingerprint(nil)
+	}
+	return inferencecache.Fingerprint(struct {
+		ModelID   string `json:"model_id"`
+		ModelName string `json:"model_name"`
+	}{ModelID: model.GetModelID(), ModelName: model.GetModelName()})
+}

--- a/internal/models/chat/fingerprint_test.go
+++ b/internal/models/chat/fingerprint_test.go
@@ -1,0 +1,29 @@
+package chat
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelFingerprintExcludesChatCredentialsAndConcurrency(t *testing.T) {
+	base := &ChatConfig{
+		Source:         types.ModelSourceRemote,
+		BaseURL:        "https://example.com/v1",
+		ModelName:      "chat-model",
+		ModelID:        "model-id",
+		Provider:       "generic",
+		APIKey:         "secret-a",
+		AppSecret:      "app-secret-a",
+		MaxConcurrency: 4,
+	}
+	changed := *base
+	changed.APIKey = "secret-b"
+	changed.AppSecret = "app-secret-b"
+	changed.MaxConcurrency = 100
+	require.Equal(t, ModelFingerprint(base), ModelFingerprint(&changed))
+
+	changed.ModelName = "different-model"
+	require.NotEqual(t, ModelFingerprint(base), ModelFingerprint(&changed))
+}

--- a/internal/models/embedding/cache.go
+++ b/internal/models/embedding/cache.go
@@ -1,0 +1,121 @@
+package embedding
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/models/embedding/vectorcache"
+	"github.com/redis/go-redis/v9"
+)
+
+const embeddingCacheKeyVersion = "v1"
+
+type VectorCache = vectorcache.Cache
+
+func NewVectorCache(redisClient *redis.Client) VectorCache {
+	return vectorcache.New(redisClient)
+}
+
+// ModelFingerprint scopes cache entries to every non-secret setting that can
+// change embedding output. Rotating an API key therefore preserves cache hits,
+// while changing provider/model/base URL/dimension or provider-specific config
+// invalidates only the affected model namespace.
+func ModelFingerprint(config Config) string {
+	payload := struct {
+		Source                    string            `json:"source"`
+		BaseURL                   string            `json:"base_url"`
+		ModelName                 string            `json:"model_name"`
+		ModelID                   string            `json:"model_id"`
+		Provider                  string            `json:"provider"`
+		AppID                     string            `json:"app_id,omitempty"`
+		Dimensions                int               `json:"dimensions"`
+		TruncatePromptTokens      int               `json:"truncate_prompt_tokens"`
+		SupportsDimensionOverride bool              `json:"supports_dimension_override"`
+		ExtraConfig               map[string]string `json:"extra_config,omitempty"`
+		CustomHeaders             map[string]string `json:"custom_headers,omitempty"`
+	}{
+		Source:                    string(config.Source),
+		BaseURL:                   config.BaseURL,
+		ModelName:                 config.ModelName,
+		ModelID:                   config.ModelID,
+		Provider:                  config.Provider,
+		AppID:                     config.AppID,
+		Dimensions:                config.Dimensions,
+		TruncatePromptTokens:      config.TruncatePromptTokens,
+		SupportsDimensionOverride: config.SupportsDimensionOverride,
+		ExtraConfig:               config.ExtraConfig,
+		CustomHeaders:             config.CustomHeaders,
+	}
+	encoded, _ := json.Marshal(payload)
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:])
+}
+
+// cachedEmbedder wraps a provider embedder with content-addressed reuse.
+type cachedEmbedder struct {
+	inner      Embedder
+	cache      VectorCache
+	keyPrefix  string
+	dimensions int
+}
+
+func NewCachedEmbedder(inner Embedder, cache VectorCache, tenantID uint64, modelFingerprint string) Embedder {
+	if inner == nil || cache == nil {
+		return inner
+	}
+	return &cachedEmbedder{
+		inner:      inner,
+		cache:      cache,
+		keyPrefix:  fmt.Sprintf("weknora:embedding:%s:%d:%s", embeddingCacheKeyVersion, tenantID, modelFingerprint),
+		dimensions: inner.GetDimensions(),
+	}
+}
+
+func (e *cachedEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	results, _, err := e.resolve(ctx, []string{text}, e.inner.BatchEmbed)
+	if err != nil {
+		return nil, err
+	}
+	return results[0], nil
+}
+
+func (e *cachedEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	results, _, err := e.resolve(ctx, texts, e.inner.BatchEmbed)
+	return results, err
+}
+
+func (e *cachedEmbedder) BatchEmbedWithPool(ctx context.Context, _ Embedder, texts []string) ([][]float32, error) {
+	results, _, err := e.resolve(ctx, texts, func(ctx context.Context, misses []string) ([][]float32, error) {
+		return e.inner.BatchEmbedWithPool(ctx, e.inner, misses)
+	})
+	return results, err
+}
+
+func (e *cachedEmbedder) resolve(
+	ctx context.Context, texts []string, embed vectorcache.EmbedFunc,
+) ([][]float32, vectorcache.Stats, error) {
+	startedAt := time.Now()
+	results, stats, err := vectorcache.Resolve(ctx, e.cache, e.keyPrefix, e.dimensions, texts, embed)
+	if stats.ReadError != nil {
+		logger.Warnf(ctx, "[EmbeddingCache] read failed, continuing with provider misses: %v", stats.ReadError)
+	}
+	if stats.WriteError != nil {
+		logger.Warnf(ctx, "[EmbeddingCache] write failed: %v", stats.WriteError)
+	}
+	if err == nil {
+		logger.Infof(ctx, "[EmbeddingCache] model=%s inputs=%d unique=%d hits=%d misses=%d provider_inputs=%d coalesced=%d miss_samples=%v elapsed=%s",
+			e.GetModelID(), stats.Inputs, stats.Unique, stats.Hits, stats.Misses,
+			stats.ProviderInputs, stats.Coalesced, stats.MissSamples,
+			time.Since(startedAt).Round(time.Millisecond))
+	}
+	return results, stats, err
+}
+
+func (e *cachedEmbedder) GetModelName() string { return e.inner.GetModelName() }
+func (e *cachedEmbedder) GetDimensions() int   { return e.inner.GetDimensions() }
+func (e *cachedEmbedder) GetModelID() string   { return e.inner.GetModelID() }

--- a/internal/models/embedding/cache_test.go
+++ b/internal/models/embedding/cache_test.go
@@ -1,0 +1,64 @@
+package embedding
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelFingerprintIsStableAndExcludesSecrets(t *testing.T) {
+	base := Config{
+		Source:                    types.ModelSourceRemote,
+		BaseURL:                   "https://example.com/v1",
+		ModelName:                 "embed-v1",
+		ModelID:                   "model-id",
+		Provider:                  "generic",
+		Dimensions:                1024,
+		TruncatePromptTokens:      512,
+		SupportsDimensionOverride: true,
+		APIKey:                    "secret-a",
+		AppSecret:                 "app-secret-a",
+		MaxConcurrency:            4,
+		ExtraConfig:               map[string]string{"b": "2", "a": "1"},
+	}
+	rotated := base
+	rotated.APIKey = "secret-b"
+	rotated.AppSecret = "app-secret-b"
+	rotated.MaxConcurrency = 99
+	rotated.ExtraConfig = map[string]string{"a": "1", "b": "2"}
+
+	require.Equal(t, ModelFingerprint(base), ModelFingerprint(rotated),
+		"credential rotation, concurrency tuning and map iteration order must preserve cache hits")
+}
+
+func TestModelFingerprintChangesWithEmbeddingOutputConfiguration(t *testing.T) {
+	base := Config{
+		Source:               types.ModelSourceRemote,
+		BaseURL:              "https://example.com/v1",
+		ModelName:            "embed-v1",
+		ModelID:              "model-id",
+		Provider:             "generic",
+		Dimensions:           1024,
+		TruncatePromptTokens: 512,
+	}
+	baseFingerprint := ModelFingerprint(base)
+
+	cases := map[string]func(*Config){
+		"base URL":      func(c *Config) { c.BaseURL = "https://other.example/v1" },
+		"model name":    func(c *Config) { c.ModelName = "embed-v2" },
+		"model ID":      func(c *Config) { c.ModelID = "other-id" },
+		"provider":      func(c *Config) { c.Provider = "openai" },
+		"dimensions":    func(c *Config) { c.Dimensions = 1536 },
+		"truncation":    func(c *Config) { c.TruncatePromptTokens = 256 },
+		"extra config":  func(c *Config) { c.ExtraConfig = map[string]string{"mode": "new"} },
+		"custom header": func(c *Config) { c.CustomHeaders = map[string]string{"X-Model-Route": "blue"} },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			changed := base
+			mutate(&changed)
+			require.NotEqual(t, baseFingerprint, ModelFingerprint(changed))
+		})
+	}
+}

--- a/internal/models/embedding/vectorcache/cache.go
+++ b/internal/models/embedding/vectorcache/cache.go
@@ -1,0 +1,385 @@
+package vectorcache
+
+import (
+	"container/list"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	defaultTTL        = 30 * 24 * time.Hour
+	defaultMaxEntries = 10000
+)
+
+// Cache stores content-addressed embedding vectors. Keys already include
+// tenant and model configuration scope and must be treated as opaque.
+type Cache interface {
+	GetMany(ctx context.Context, keys []string) (map[string][]float32, error)
+	SetMany(ctx context.Context, values map[string][]float32) error
+}
+
+// EmbedFunc computes vectors for cache misses only.
+type EmbedFunc func(context.Context, []string) ([][]float32, error)
+
+// Stats describes one Resolve call.
+type Stats struct {
+	Inputs         int
+	Unique         int
+	Hits           int
+	Misses         int
+	ProviderInputs int
+	Coalesced      int
+	ReadError      error
+	WriteError     error
+	MissSamples    []MissSample
+}
+
+// MissSample identifies a cache miss without exposing source text.
+type MissSample struct {
+	Index int
+	Hash  string
+	Runes int
+}
+
+type memoryEntry struct {
+	vector    []float32
+	expiresAt time.Time
+	element   *list.Element
+}
+
+// hybridCache uses Redis when available and always keeps a bounded in-process
+// cache as a fast path and Lite-mode fallback.
+type hybridCache struct {
+	redis      *redis.Client
+	ttl        time.Duration
+	maxEntries int
+
+	mu     sync.Mutex
+	values map[string]*memoryEntry
+	order  *list.List
+	now    func() time.Time
+}
+
+type flightEntry struct {
+	done   chan struct{}
+	vector []float32
+	err    error
+}
+
+var vectorFlights = struct {
+	sync.Mutex
+	entries map[string]*flightEntry
+}{entries: make(map[string]*flightEntry)}
+
+type disabledCache struct{}
+
+func (disabledCache) GetMany(_ context.Context, _ []string) (map[string][]float32, error) {
+	return map[string][]float32{}, nil
+}
+
+func (disabledCache) SetMany(_ context.Context, _ map[string][]float32) error { return nil }
+
+// New constructs a shared cache. WEKNORA_EMBEDDING_CACHE_TTL accepts a Go
+// duration (for example "720h" or "0" to disable Redis expiry).
+// WEKNORA_EMBEDDING_CACHE_MAX_ENTRIES controls the bounded in-process cache.
+func New(redisClient *redis.Client) Cache {
+	if raw := strings.TrimSpace(strings.ToLower(os.Getenv("WEKNORA_EMBEDDING_CACHE_ENABLED"))); raw == "false" || raw == "0" || raw == "off" {
+		return disabledCache{}
+	}
+	ttl := defaultTTL
+	if raw := os.Getenv("WEKNORA_EMBEDDING_CACHE_TTL"); raw != "" {
+		if parsed, err := time.ParseDuration(raw); err == nil && parsed >= 0 {
+			ttl = parsed
+		}
+	}
+	maxEntries := defaultMaxEntries
+	if raw := os.Getenv("WEKNORA_EMBEDDING_CACHE_MAX_ENTRIES"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			maxEntries = parsed
+		}
+	}
+	return &hybridCache{
+		redis:      redisClient,
+		ttl:        ttl,
+		maxEntries: maxEntries,
+		values:     make(map[string]*memoryEntry),
+		order:      list.New(),
+		now:        time.Now,
+	}
+}
+
+func (c *hybridCache) GetMany(ctx context.Context, keys []string) (map[string][]float32, error) {
+	result := make(map[string][]float32, len(keys))
+	missing := make([]string, 0, len(keys))
+
+	c.mu.Lock()
+	for _, key := range keys {
+		if entry, ok := c.values[key]; ok {
+			if !entry.expiresAt.IsZero() && !c.now().Before(entry.expiresAt) {
+				c.removeMemoryEntry(entry)
+				missing = append(missing, key)
+				continue
+			}
+			c.order.MoveToBack(entry.element)
+			result[key] = clone(entry.vector)
+		} else {
+			missing = append(missing, key)
+		}
+	}
+	c.mu.Unlock()
+
+	if c.redis == nil || len(missing) == 0 {
+		return result, nil
+	}
+
+	rawValues, err := c.redis.MGet(ctx, missing...).Result()
+	if err != nil {
+		return result, err
+	}
+	redisHits := make(map[string][]float32)
+	for i, raw := range rawValues {
+		if raw == nil {
+			continue
+		}
+		var encoded string
+		switch value := raw.(type) {
+		case string:
+			encoded = value
+		case []byte:
+			encoded = string(value)
+		default:
+			continue
+		}
+		var vector []float32
+		if err := json.Unmarshal([]byte(encoded), &vector); err != nil || len(vector) == 0 {
+			continue
+		}
+		key := missing[i]
+		redisHits[key] = vector
+		result[key] = clone(vector)
+	}
+	c.storeMemory(redisHits)
+	return result, nil
+}
+
+func (c *hybridCache) SetMany(ctx context.Context, values map[string][]float32) error {
+	if len(values) == 0 {
+		return nil
+	}
+	c.storeMemory(values)
+	if c.redis == nil {
+		return nil
+	}
+
+	pipe := c.redis.Pipeline()
+	for key, vector := range values {
+		encoded, err := json.Marshal(vector)
+		if err != nil {
+			return err
+		}
+		pipe.Set(ctx, key, encoded, c.ttl)
+	}
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+func (c *hybridCache) storeMemory(values map[string][]float32) {
+	if len(values) == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key, value := range values {
+		if len(value) == 0 {
+			continue
+		}
+		expiresAt := time.Time{}
+		if c.ttl > 0 {
+			expiresAt = c.now().Add(c.ttl)
+		}
+		if entry, exists := c.values[key]; exists {
+			entry.vector = clone(value)
+			entry.expiresAt = expiresAt
+			c.order.MoveToBack(entry.element)
+			continue
+		}
+		element := c.order.PushBack(key)
+		c.values[key] = &memoryEntry{vector: clone(value), expiresAt: expiresAt, element: element}
+	}
+	for len(c.values) > c.maxEntries && c.order.Len() > 0 {
+		oldest := c.order.Front()
+		if entry := c.values[oldest.Value.(string)]; entry != nil {
+			c.removeMemoryEntry(entry)
+		} else {
+			c.order.Remove(oldest)
+		}
+	}
+}
+
+func (c *hybridCache) removeMemoryEntry(entry *memoryEntry) {
+	if entry == nil || entry.element == nil {
+		return
+	}
+	key, _ := entry.element.Value.(string)
+	delete(c.values, key)
+	c.order.Remove(entry.element)
+}
+
+// Resolve returns vectors in the original input order, reusing cached values
+// and embedding each unique miss once. Cache read/write failures fail open;
+// provider failures and malformed provider output are returned.
+func Resolve(
+	ctx context.Context,
+	cache Cache,
+	keyPrefix string,
+	dimensions int,
+	texts []string,
+	embed EmbedFunc,
+) ([][]float32, Stats, error) {
+	stats := Stats{Inputs: len(texts)}
+	if len(texts) == 0 {
+		return [][]float32{}, stats, nil
+	}
+
+	keys := make([]string, len(texts))
+	uniqueKeys := make([]string, 0, len(texts))
+	textByKey := make(map[string]string, len(texts))
+	firstIndexByKey := make(map[string]int, len(texts))
+	for i, text := range texts {
+		hash := sha256.Sum256([]byte(text))
+		key := keyPrefix + ":" + hex.EncodeToString(hash[:])
+		keys[i] = key
+		if _, exists := textByKey[key]; !exists {
+			textByKey[key] = text
+			firstIndexByKey[key] = i
+			uniqueKeys = append(uniqueKeys, key)
+		}
+	}
+	stats.Unique = len(uniqueKeys)
+
+	cached, cacheErr := cache.GetMany(ctx, uniqueKeys)
+	stats.ReadError = cacheErr
+	if cached == nil {
+		cached = make(map[string][]float32, len(uniqueKeys))
+	}
+
+	missKeys := make([]string, 0, len(uniqueKeys))
+	missTexts := make([]string, 0, len(uniqueKeys))
+	for _, key := range uniqueKeys {
+		vector, ok := cached[key]
+		if ok && (dimensions <= 0 || len(vector) == dimensions) {
+			continue
+		}
+		delete(cached, key)
+		missKeys = append(missKeys, key)
+		missTexts = append(missTexts, textByKey[key])
+		if len(stats.MissSamples) < 8 {
+			contentHash := sha256.Sum256([]byte(textByKey[key]))
+			stats.MissSamples = append(stats.MissSamples, MissSample{
+				Index: firstIndexByKey[key],
+				Hash:  hex.EncodeToString(contentHash[:4]),
+				Runes: utf8.RuneCountInString(textByKey[key]),
+			})
+		}
+	}
+	stats.Misses = len(missKeys)
+	stats.Hits = stats.Unique - stats.Misses
+
+	if len(missTexts) > 0 {
+		ownedKeys := make([]string, 0, len(missKeys))
+		ownedTexts := make([]string, 0, len(missKeys))
+		entries := make([]*flightEntry, len(missKeys))
+
+		vectorFlights.Lock()
+		for i, key := range missKeys {
+			if existing := vectorFlights.entries[key]; existing != nil {
+				entries[i] = existing
+				stats.Coalesced++
+				continue
+			}
+			entry := &flightEntry{done: make(chan struct{})}
+			vectorFlights.entries[key] = entry
+			entries[i] = entry
+			ownedKeys = append(ownedKeys, key)
+			ownedTexts = append(ownedTexts, textByKey[key])
+		}
+		vectorFlights.Unlock()
+
+		if len(ownedTexts) > 0 {
+			stats.ProviderInputs = len(ownedTexts)
+			vectors, providerErr := embed(ctx, ownedTexts)
+			if providerErr == nil && len(vectors) != len(ownedTexts) {
+				providerErr = fmt.Errorf("embedding provider returned %d vectors for %d texts", len(vectors), len(ownedTexts))
+			}
+			if providerErr == nil {
+				for i := range vectors {
+					if dimensions > 0 && len(vectors[i]) != dimensions {
+						providerErr = fmt.Errorf("embedding provider returned dimension %d, expected %d", len(vectors[i]), dimensions)
+						break
+					}
+				}
+			}
+
+			fresh := make(map[string][]float32, len(ownedKeys))
+			if providerErr == nil {
+				for i, key := range ownedKeys {
+					fresh[key] = vectors[i]
+				}
+				stats.WriteError = cache.SetMany(ctx, fresh)
+			}
+
+			vectorFlights.Lock()
+			for i, key := range ownedKeys {
+				entry := vectorFlights.entries[key]
+				if providerErr == nil {
+					entry.vector = clone(vectors[i])
+				} else {
+					entry.err = providerErr
+				}
+				delete(vectorFlights.entries, key)
+				close(entry.done)
+			}
+			vectorFlights.Unlock()
+		}
+
+		for i, entry := range entries {
+			select {
+			case <-ctx.Done():
+				return nil, stats, ctx.Err()
+			case <-entry.done:
+				if entry.err != nil {
+					return nil, stats, entry.err
+				}
+				cached[missKeys[i]] = clone(entry.vector)
+			}
+		}
+	}
+
+	results := make([][]float32, len(texts))
+	for i, key := range keys {
+		vector, ok := cached[key]
+		if !ok {
+			if cacheErr != nil {
+				return nil, stats, fmt.Errorf("embedding cache read failed and result %d is missing: %w", i, cacheErr)
+			}
+			return nil, stats, fmt.Errorf("embedding cache assembly missing result for input %d", i)
+		}
+		results[i] = clone(vector)
+	}
+	return results, stats, nil
+}
+
+func clone(vector []float32) []float32 {
+	return append([]float32(nil), vector...)
+}

--- a/internal/models/embedding/vectorcache/cache_test.go
+++ b/internal/models/embedding/vectorcache/cache_test.go
@@ -1,0 +1,219 @@
+package vectorcache
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+type failingCache struct{}
+
+func (failingCache) GetMany(_ context.Context, _ []string) (map[string][]float32, error) {
+	return nil, errors.New("redis unavailable")
+}
+
+func (failingCache) SetMany(_ context.Context, _ map[string][]float32) error {
+	return errors.New("redis unavailable")
+}
+
+func TestResolveReusesHitsAndEmbedsUniqueMisses(t *testing.T) {
+	cache := New(nil)
+	var batches [][]string
+	embed := func(_ context.Context, texts []string) ([][]float32, error) {
+		batches = append(batches, append([]string(nil), texts...))
+		results := make([][]float32, len(texts))
+		for i, text := range texts {
+			results[i] = []float32{float32(len(text)), float32(len(text) * 10)}
+		}
+		return results, nil
+	}
+
+	first, stats, err := Resolve(
+		context.Background(), cache, "tenant:7:model:a", 2,
+		[]string{"alpha", "beta", "alpha"}, embed,
+	)
+	require.NoError(t, err)
+	require.Equal(t, Stats{
+		Inputs: 3, Unique: 2, Hits: 0, Misses: 2, ProviderInputs: 2,
+		MissSamples: []MissSample{{Index: 0, Hash: "8ed3f6ad", Runes: 5}, {Index: 1, Hash: "f44e64e7", Runes: 4}},
+	}, stats)
+	require.Equal(t, [][]float32{{5, 50}, {4, 40}, {5, 50}}, first)
+	require.Equal(t, [][]string{{"alpha", "beta"}}, batches,
+		"duplicate content should be embedded once")
+
+	second, stats, err := Resolve(
+		context.Background(), cache, "tenant:7:model:a", 2,
+		[]string{"alpha", "gamma"}, embed,
+	)
+	require.NoError(t, err)
+	require.Equal(t, Stats{
+		Inputs: 2, Unique: 2, Hits: 1, Misses: 1, ProviderInputs: 1,
+		MissSamples: []MissSample{{Index: 1, Hash: "be9d587d", Runes: 5}},
+	}, stats)
+	require.Equal(t, [][]float32{{5, 50}, {5, 50}}, second)
+	require.Equal(t, [][]string{{"alpha", "beta"}, {"gamma"}}, batches,
+		"only the new content should reach the provider")
+}
+
+func TestResolveScopesEntriesByPrefix(t *testing.T) {
+	cache := New(nil)
+	calls := 0
+	embed := func(_ context.Context, texts []string) ([][]float32, error) {
+		calls++
+		return [][]float32{{float32(len(texts[0])), 1}}, nil
+	}
+
+	_, _, err := Resolve(context.Background(), cache, "tenant:1:model:a", 2, []string{"private"}, embed)
+	require.NoError(t, err)
+	_, _, err = Resolve(context.Background(), cache, "tenant:2:model:a", 2, []string{"private"}, embed)
+	require.NoError(t, err)
+	require.Equal(t, 2, calls, "different tenant prefixes must not share vectors")
+}
+
+func TestCachePersistsThroughRedisAcrossInstances(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	ctx := context.Background()
+	first := New(client)
+	require.NoError(t, first.SetMany(ctx, map[string][]float32{"key": []float32{1, 2, 3}}))
+
+	second := New(client)
+	values, err := second.GetMany(ctx, []string{"key", "missing"})
+	require.NoError(t, err)
+	require.Equal(t, []float32{1, 2, 3}, values["key"])
+	_, found := values["missing"]
+	require.False(t, found)
+}
+
+func TestResolveRecomputesWrongDimensionCacheEntry(t *testing.T) {
+	cache := New(nil)
+	require.NoError(t, cache.SetMany(context.Background(), map[string][]float32{
+		"prefix:2d711642b726b04401627ca9fbac32f5c8530fb1903cc4db02258717921a4881": []float32{1},
+	}))
+
+	calls := 0
+	results, stats, err := Resolve(
+		context.Background(), cache, "prefix", 2, []string{"x"},
+		func(_ context.Context, _ []string) ([][]float32, error) {
+			calls++
+			return [][]float32{{2, 3}}, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+	require.Equal(t, 1, stats.Misses)
+	require.Equal(t, [][]float32{{2, 3}}, results)
+}
+
+func TestDisabledCacheAlwaysMisses(t *testing.T) {
+	t.Setenv("WEKNORA_EMBEDDING_CACHE_ENABLED", "false")
+	cache := New(nil)
+	require.NoError(t, cache.SetMany(context.Background(), map[string][]float32{
+		"key": []float32{1, 2},
+	}))
+	values, err := cache.GetMany(context.Background(), []string{"key"})
+	require.NoError(t, err)
+	require.Empty(t, values)
+}
+
+func TestResolveFailsOpenWhenCacheBackendIsUnavailable(t *testing.T) {
+	results, stats, err := Resolve(
+		context.Background(), failingCache{}, "prefix", 2, []string{"alpha"},
+		func(_ context.Context, _ []string) ([][]float32, error) {
+			return [][]float32{{1, 2}}, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, [][]float32{{1, 2}}, results)
+	require.Error(t, stats.ReadError)
+	require.Error(t, stats.WriteError)
+}
+
+func TestResolveCoalescesConcurrentMisses(t *testing.T) {
+	cache := New(nil)
+	var providerCalls atomic.Int32
+	providerStarted := make(chan struct{})
+	releaseProvider := make(chan struct{})
+	embed := func(_ context.Context, texts []string) ([][]float32, error) {
+		if providerCalls.Add(1) == 1 {
+			close(providerStarted)
+		}
+		<-releaseProvider
+		return [][]float32{{float32(len(texts[0])), 1}}, nil
+	}
+
+	const workers = 12
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			result, _, err := Resolve(context.Background(), cache, "concurrent", 2, []string{"same"}, embed)
+			if err == nil && len(result) != 1 {
+				err = errors.New("unexpected result length")
+			}
+			errs <- err
+		}()
+	}
+	close(start)
+	<-providerStarted
+	// Keep the owner in flight long enough for peer goroutines to join the
+	// per-key flight. This is bounded and does not affect production code.
+	time.Sleep(25 * time.Millisecond)
+	close(releaseProvider)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int32(1), providerCalls.Load())
+}
+
+func TestMemoryCacheHonorsTTL(t *testing.T) {
+	cache := New(nil).(*hybridCache)
+	now := time.Unix(1000, 0)
+	cache.now = func() time.Time { return now }
+	cache.ttl = time.Hour
+
+	require.NoError(t, cache.SetMany(context.Background(), map[string][]float32{"key": {1, 2}}))
+	values, err := cache.GetMany(context.Background(), []string{"key"})
+	require.NoError(t, err)
+	require.Equal(t, []float32{1, 2}, values["key"])
+
+	now = now.Add(time.Hour)
+	values, err = cache.GetMany(context.Background(), []string{"key"})
+	require.NoError(t, err)
+	require.Empty(t, values)
+}
+
+func TestMemoryCacheEvictsLeastRecentlyUsed(t *testing.T) {
+	cache := New(nil).(*hybridCache)
+	cache.maxEntries = 2
+	ctx := context.Background()
+	require.NoError(t, cache.SetMany(ctx, map[string][]float32{
+		"first":  {1},
+		"second": {2},
+	}))
+	// Touch first so second becomes the least-recently-used entry.
+	_, err := cache.GetMany(ctx, []string{"first"})
+	require.NoError(t, err)
+	require.NoError(t, cache.SetMany(ctx, map[string][]float32{"third": {3}}))
+
+	values, err := cache.GetMany(ctx, []string{"first", "second", "third"})
+	require.NoError(t, err)
+	require.Contains(t, values, "first")
+	require.NotContains(t, values, "second")
+	require.Contains(t, values, "third")
+}

--- a/internal/models/inferencecache/cache.go
+++ b/internal/models/inferencecache/cache.go
@@ -1,0 +1,301 @@
+package inferencecache
+
+import (
+	"container/list"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	cacheKeyVersion   = "v1"
+	defaultTTL        = 30 * 24 * time.Hour
+	defaultMaxEntries = 10000
+)
+
+// Loader performs one expensive inference call. Successful empty responses
+// are cacheable; errors are never cached.
+type Loader func(context.Context) ([]byte, error)
+
+// Stats describes one cache resolution without exposing cached content.
+type Stats struct {
+	Hit        bool
+	Coalesced  bool
+	ReadError  error
+	WriteError error
+}
+
+// Cache stores validated model outputs by opaque content-addressed keys.
+type Cache interface {
+	Resolve(ctx context.Context, key string, loader Loader) ([]byte, Stats, error)
+	Invalidate(ctx context.Context, key string) error
+}
+
+type memoryEntry struct {
+	value     []byte
+	expiresAt time.Time
+	element   *list.Element
+}
+
+type hybridCache struct {
+	redis      *redis.Client
+	ttl        time.Duration
+	maxEntries int
+	now        func() time.Time
+
+	mu     sync.Mutex
+	values map[string]*memoryEntry
+	order  *list.List
+	group  singleflight.Group
+}
+
+type disabledCache struct{}
+
+type flightResult struct {
+	value      []byte
+	hit        bool
+	readError  error
+	writeError error
+}
+
+// New builds the shared inference cache used by deterministic enrichment
+// stages (VLM OCR/caption, GraphRAG extraction, and Wiki map calls).
+func New(redisClient *redis.Client) Cache {
+	if raw := strings.TrimSpace(strings.ToLower(os.Getenv("WEKNORA_INFERENCE_CACHE_ENABLED"))); raw == "false" || raw == "0" || raw == "off" {
+		return disabledCache{}
+	}
+	ttl := defaultTTL
+	if raw := os.Getenv("WEKNORA_INFERENCE_CACHE_TTL"); raw != "" {
+		if parsed, err := time.ParseDuration(raw); err == nil && parsed >= 0 {
+			ttl = parsed
+		}
+	}
+	maxEntries := defaultMaxEntries
+	if raw := os.Getenv("WEKNORA_INFERENCE_CACHE_MAX_ENTRIES"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			maxEntries = parsed
+		}
+	}
+	return &hybridCache{
+		redis:      redisClient,
+		ttl:        ttl,
+		maxEntries: maxEntries,
+		now:        time.Now,
+		values:     make(map[string]*memoryEntry),
+		order:      list.New(),
+	}
+}
+
+func (disabledCache) Resolve(ctx context.Context, _ string, loader Loader) ([]byte, Stats, error) {
+	value, err := loader(ctx)
+	return clone(value), Stats{}, err
+}
+
+func (disabledCache) Invalidate(context.Context, string) error { return nil }
+
+func (c *hybridCache) Resolve(ctx context.Context, key string, loader Loader) ([]byte, Stats, error) {
+	if value, ok, err := c.get(ctx, key); ok {
+		return value, Stats{Hit: true}, nil
+	} else if err != nil {
+		// Fail open. The error is carried into the singleflight result so the
+		// caller can log it while still receiving the provider output.
+	}
+
+	resultCh := c.group.DoChan(key, func() (any, error) {
+		result := flightResult{}
+		if value, ok, err := c.get(ctx, key); ok {
+			result.value = value
+			result.hit = true
+			return result, nil
+		} else if err != nil {
+			result.readError = err
+		}
+
+		value, err := loader(ctx)
+		if err != nil {
+			return nil, err
+		}
+		result.value = clone(value)
+		result.writeError = c.set(ctx, key, value)
+		return result, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		return nil, Stats{}, ctx.Err()
+	case shared := <-resultCh:
+		if shared.Err != nil {
+			return nil, Stats{Coalesced: shared.Shared}, shared.Err
+		}
+		result := shared.Val.(flightResult)
+		return clone(result.value), Stats{
+			Hit:        result.hit,
+			Coalesced:  shared.Shared,
+			ReadError:  result.readError,
+			WriteError: result.writeError,
+		}, nil
+	}
+}
+
+func (c *hybridCache) Invalidate(ctx context.Context, key string) error {
+	c.mu.Lock()
+	if entry := c.values[key]; entry != nil {
+		c.removeEntry(entry)
+	}
+	c.mu.Unlock()
+	if c.redis == nil {
+		return nil
+	}
+	return c.redis.Del(ctx, key).Err()
+}
+
+func (c *hybridCache) get(ctx context.Context, key string) ([]byte, bool, error) {
+	c.mu.Lock()
+	if entry := c.values[key]; entry != nil {
+		if !entry.expiresAt.IsZero() && !c.now().Before(entry.expiresAt) {
+			c.removeEntry(entry)
+		} else {
+			c.order.MoveToBack(entry.element)
+			value := clone(entry.value)
+			c.mu.Unlock()
+			return value, true, nil
+		}
+	}
+	c.mu.Unlock()
+
+	if c.redis == nil {
+		return nil, false, nil
+	}
+	value, err := c.redis.Get(ctx, key).Bytes()
+	if err == redis.Nil {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	c.storeMemory(key, value)
+	return clone(value), true, nil
+}
+
+func (c *hybridCache) set(ctx context.Context, key string, value []byte) error {
+	c.storeMemory(key, value)
+	if c.redis == nil {
+		return nil
+	}
+	return c.redis.Set(ctx, key, value, c.ttl).Err()
+}
+
+func (c *hybridCache) storeMemory(key string, value []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	expiresAt := time.Time{}
+	if c.ttl > 0 {
+		expiresAt = c.now().Add(c.ttl)
+	}
+	if entry := c.values[key]; entry != nil {
+		entry.value = clone(value)
+		entry.expiresAt = expiresAt
+		c.order.MoveToBack(entry.element)
+	} else {
+		element := c.order.PushBack(key)
+		c.values[key] = &memoryEntry{value: clone(value), expiresAt: expiresAt, element: element}
+	}
+	for len(c.values) > c.maxEntries {
+		oldest := c.order.Front()
+		if oldest == nil {
+			break
+		}
+		c.removeEntry(c.values[oldest.Value.(string)])
+	}
+}
+
+func (c *hybridCache) removeEntry(entry *memoryEntry) {
+	if entry == nil || entry.element == nil {
+		return
+	}
+	key, _ := entry.element.Value.(string)
+	delete(c.values, key)
+	c.order.Remove(entry.element)
+}
+
+// Key scopes an inference result to a stage, tenant, model configuration and
+// an unambiguous sequence of request parts. Parts are length-prefixed before
+// hashing so ["ab", "c"] cannot collide with ["a", "bc"].
+func Key(namespace string, tenantID uint64, modelFingerprint string, parts ...[]byte) string {
+	hash := sha256.New()
+	var length [8]byte
+	for _, part := range parts {
+		binary.BigEndian.PutUint64(length[:], uint64(len(part)))
+		_, _ = hash.Write(length[:])
+		_, _ = hash.Write(part)
+	}
+	namespace = strings.NewReplacer(":", "_", " ", "_").Replace(strings.TrimSpace(namespace))
+	return fmt.Sprintf("weknora:inference:%s:%s:%d:%s:%s",
+		cacheKeyVersion, namespace, tenantID, modelFingerprint, hex.EncodeToString(hash.Sum(nil)))
+}
+
+// Fingerprint hashes deterministic, non-secret model configuration.
+func Fingerprint(value any) string {
+	encoded, _ := json.Marshal(value)
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:])
+}
+
+// ResolveJSON caches only values that the loader has already validated and
+// marshalled successfully. Corrupt entries are evicted and recomputed once.
+func ResolveJSON[T any](ctx context.Context, cache Cache, key string, loader func(context.Context) (T, error)) (T, Stats, error) {
+	var zero T
+	if cache == nil {
+		value, err := loader(ctx)
+		return value, Stats{}, err
+	}
+	raw, stats, err := cache.Resolve(ctx, key, func(loadCtx context.Context) ([]byte, error) {
+		value, loadErr := loader(loadCtx)
+		if loadErr != nil {
+			return nil, loadErr
+		}
+		return json.Marshal(value)
+	})
+	if err != nil {
+		return zero, stats, err
+	}
+	var value T
+	if decodeErr := json.Unmarshal(raw, &value); decodeErr != nil {
+		// A truncated/corrupt cache entry must not pin the enrichment stage in
+		// a permanent failure loop. Remove it and recompute once.
+		_ = cache.Invalidate(ctx, key)
+		raw, retryStats, retryErr := cache.Resolve(ctx, key, func(loadCtx context.Context) ([]byte, error) {
+			loaded, loadErr := loader(loadCtx)
+			if loadErr != nil {
+				return nil, loadErr
+			}
+			return json.Marshal(loaded)
+		})
+		stats.WriteError = retryStats.WriteError
+		stats.ReadError = fmt.Errorf("decode inference cache entry: %w", decodeErr)
+		stats.Hit = false
+		stats.Coalesced = retryStats.Coalesced
+		if retryErr != nil {
+			return zero, stats, retryErr
+		}
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return zero, stats, fmt.Errorf("decode refreshed inference cache entry: %w", err)
+		}
+	}
+	return value, stats, nil
+}
+
+func clone(value []byte) []byte {
+	return append([]byte(nil), value...)
+}

--- a/internal/models/inferencecache/cache_test.go
+++ b/internal/models/inferencecache/cache_test.go
@@ -1,0 +1,177 @@
+package inferencecache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveReusesSuccessfulOutput(t *testing.T) {
+	cache := New(nil)
+	var calls int
+	loader := func(context.Context) ([]byte, error) {
+		calls++
+		return []byte("validated output"), nil
+	}
+
+	first, stats, err := cache.Resolve(context.Background(), "key", loader)
+	require.NoError(t, err)
+	require.False(t, stats.Hit)
+	require.Equal(t, []byte("validated output"), first)
+
+	second, stats, err := cache.Resolve(context.Background(), "key", loader)
+	require.NoError(t, err)
+	require.True(t, stats.Hit)
+	require.Equal(t, first, second)
+	require.Equal(t, 1, calls)
+}
+
+func TestResolveCoalescesConcurrentLoaders(t *testing.T) {
+	cache := New(nil)
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	loader := func(context.Context) ([]byte, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return []byte("one result"), nil
+	}
+
+	const workers = 10
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			value, _, err := cache.Resolve(context.Background(), "shared", loader)
+			if err == nil && string(value) != "one result" {
+				err = fmt.Errorf("unexpected result %q", value)
+			}
+			errs <- err
+		}()
+	}
+	close(start)
+	<-started
+	time.Sleep(25 * time.Millisecond)
+	close(release)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int32(1), calls.Load())
+}
+
+func TestCachePersistsInRedisAndExpires(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	t.Setenv("WEKNORA_INFERENCE_CACHE_TTL", "1h")
+
+	first := New(client)
+	_, _, err := first.Resolve(context.Background(), "persistent", func(context.Context) ([]byte, error) {
+		return []byte("cached"), nil
+	})
+	require.NoError(t, err)
+
+	second := New(client)
+	value, stats, err := second.Resolve(context.Background(), "persistent", func(context.Context) ([]byte, error) {
+		return []byte("unexpected"), nil
+	})
+	require.NoError(t, err)
+	require.True(t, stats.Hit)
+	require.Equal(t, []byte("cached"), value)
+
+	server.FastForward(time.Hour)
+	third := New(client)
+	value, stats, err = third.Resolve(context.Background(), "persistent", func(context.Context) ([]byte, error) {
+		return []byte("fresh"), nil
+	})
+	require.NoError(t, err)
+	require.False(t, stats.Hit)
+	require.Equal(t, []byte("fresh"), value)
+}
+
+func TestMemoryCacheHonorsTTLAndLRUCapacity(t *testing.T) {
+	cache := New(nil).(*hybridCache)
+	now := time.Unix(1000, 0)
+	cache.now = func() time.Time { return now }
+	cache.ttl = time.Hour
+	cache.maxEntries = 2
+	ctx := context.Background()
+
+	load := func(value string) Loader {
+		return func(context.Context) ([]byte, error) { return []byte(value), nil }
+	}
+	_, _, _ = cache.Resolve(ctx, "first", load("1"))
+	_, _, _ = cache.Resolve(ctx, "second", load("2"))
+	_, _, _ = cache.Resolve(ctx, "first", load("unexpected")) // touch first
+	_, _, _ = cache.Resolve(ctx, "third", load("3"))
+
+	_, stats, _ := cache.Resolve(ctx, "second", load("2-new"))
+	require.False(t, stats.Hit, "least-recently-used entry should be evicted")
+
+	now = now.Add(time.Hour)
+	_, stats, _ = cache.Resolve(ctx, "first", load("1-new"))
+	require.False(t, stats.Hit, "expired in-memory entry should be recomputed")
+}
+
+func TestKeySeparatesPartsAndTenants(t *testing.T) {
+	fingerprint := Fingerprint(map[string]string{"model": "a"})
+	require.NotEqual(t,
+		Key("wiki", 1, fingerprint, []byte("ab"), []byte("c")),
+		Key("wiki", 1, fingerprint, []byte("a"), []byte("bc")),
+	)
+	require.NotEqual(t,
+		Key("wiki", 1, fingerprint, []byte("same")),
+		Key("wiki", 2, fingerprint, []byte("same")),
+	)
+}
+
+func TestLoaderErrorsAreNotCached(t *testing.T) {
+	cache := New(nil)
+	calls := 0
+	loader := func(context.Context) ([]byte, error) {
+		calls++
+		if calls == 1 {
+			return nil, errors.New("temporary provider failure")
+		}
+		return []byte("recovered"), nil
+	}
+	_, _, err := cache.Resolve(context.Background(), "retry", loader)
+	require.Error(t, err)
+	value, _, err := cache.Resolve(context.Background(), "retry", loader)
+	require.NoError(t, err)
+	require.Equal(t, []byte("recovered"), value)
+	require.Equal(t, 2, calls)
+}
+
+func TestResolveJSONRepairsCorruptEntry(t *testing.T) {
+	cache := New(nil).(*hybridCache)
+	require.NoError(t, cache.set(context.Background(), "json", []byte("not-json")))
+	type payload struct {
+		Value string `json:"value"`
+	}
+	calls := 0
+	value, stats, err := ResolveJSON(context.Background(), cache, "json", func(context.Context) (payload, error) {
+		calls++
+		return payload{Value: "fresh"}, nil
+	})
+	require.NoError(t, err)
+	require.Error(t, stats.ReadError)
+	require.Equal(t, payload{Value: "fresh"}, value)
+	require.Equal(t, 1, calls)
+}

--- a/internal/models/vlm/fingerprint.go
+++ b/internal/models/vlm/fingerprint.go
@@ -1,0 +1,52 @@
+package vlm
+
+import "github.com/Tencent/WeKnora/internal/models/inferencecache"
+
+type fingerprintedVLM struct {
+	VLM
+	fingerprint string
+}
+
+func (v *fingerprintedVLM) CacheFingerprint() string { return v.fingerprint }
+
+// ModelFingerprint scopes cached image analysis to all non-secret settings
+// that can alter a VLM response.
+func ModelFingerprint(config *Config) string {
+	if config == nil {
+		return inferencecache.Fingerprint(nil)
+	}
+	return inferencecache.Fingerprint(struct {
+		Source        string            `json:"source"`
+		BaseURL       string            `json:"base_url"`
+		ModelName     string            `json:"model_name"`
+		ModelID       string            `json:"model_id"`
+		InterfaceType string            `json:"interface_type"`
+		Provider      string            `json:"provider"`
+		AppID         string            `json:"app_id,omitempty"`
+		Extra         map[string]any    `json:"extra,omitempty"`
+		CustomHeaders map[string]string `json:"custom_headers,omitempty"`
+	}{
+		Source:        string(config.Source),
+		BaseURL:       config.BaseURL,
+		ModelName:     config.ModelName,
+		ModelID:       config.ModelID,
+		InterfaceType: config.InterfaceType,
+		Provider:      config.Provider,
+		AppID:         config.AppID,
+		Extra:         config.Extra,
+		CustomHeaders: config.CustomHeaders,
+	})
+}
+
+func FingerprintOf(model VLM) string {
+	if identified, ok := model.(interface{ CacheFingerprint() string }); ok {
+		return identified.CacheFingerprint()
+	}
+	if model == nil {
+		return inferencecache.Fingerprint(nil)
+	}
+	return inferencecache.Fingerprint(struct {
+		ModelID   string `json:"model_id"`
+		ModelName string `json:"model_name"`
+	}{ModelID: model.GetModelID(), ModelName: model.GetModelName()})
+}

--- a/internal/models/vlm/fingerprint_test.go
+++ b/internal/models/vlm/fingerprint_test.go
@@ -1,0 +1,29 @@
+package vlm
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelFingerprintExcludesVLMCredentialsAndConcurrency(t *testing.T) {
+	base := &Config{
+		Source:         types.ModelSourceRemote,
+		BaseURL:        "https://example.com/v1",
+		ModelName:      "vision-model",
+		ModelID:        "model-id",
+		Provider:       "generic",
+		APIKey:         "secret-a",
+		AppSecret:      "app-secret-a",
+		MaxConcurrency: 4,
+	}
+	changed := *base
+	changed.APIKey = "secret-b"
+	changed.AppSecret = "app-secret-b"
+	changed.MaxConcurrency = 100
+	require.Equal(t, ModelFingerprint(base), ModelFingerprint(&changed))
+
+	changed.ModelName = "different-model"
+	require.NotEqual(t, ModelFingerprint(base), ModelFingerprint(&changed))
+}

--- a/internal/models/vlm/vlm.go
+++ b/internal/models/vlm/vlm.go
@@ -94,7 +94,11 @@ func NewVLM(config *Config, ollamaService *ollama.OllamaService) (VLM, error) {
 	v, err = wrapVLMLangfuse(v, nil)
 	// Outermost: hold the per-model concurrency slot only around the real
 	// provider round-trip, so the wait is excluded from debug/langfuse timing.
-	return wrapVLMConcurrency(v, config.MaxConcurrency, err)
+	v, err = wrapVLMConcurrency(v, config.MaxConcurrency, err)
+	if err == nil && v != nil {
+		v = &fingerprintedVLM{VLM: v, fingerprint: ModelFingerprint(config)}
+	}
+	return v, err
 }
 
 func newVLM(config *Config, ollamaService *ollama.OllamaService) (VLM, error) {

--- a/internal/searchutil/imageurl.go
+++ b/internal/searchutil/imageurl.go
@@ -1,0 +1,49 @@
+package searchutil
+
+import (
+	"regexp"
+	"strings"
+)
+
+const modelImagePlaceholder = "[image]"
+
+var (
+	markdownAngleImageURLRE = regexp.MustCompile(`(?s)(!\[[^\]]*\]\(\s*)<[^>\r\n]*>([^)]*\))`)
+	markdownImageURLRE      = regexp.MustCompile(`(?s)(!\[[^\]]*\]\(\s*)[^\s)]+([^)]*\))`)
+	htmlImageSrcDoubleRE    = regexp.MustCompile(`(?is)(<img\b[^>]*\bsrc\s*=\s*")[^"]*(")`)
+	htmlImageSrcSingleRE    = regexp.MustCompile(`(?is)(<img\b[^>]*\bsrc\s*=\s*')[^']*(')`)
+	imageURLDoubleRE        = regexp.MustCompile(`(?is)(<image\b[^>]*\burl\s*=\s*")[^"]*(")`)
+	imageURLSingleRE        = regexp.MustCompile(`(?is)(<image\b[^>]*\burl\s*=\s*')[^']*(')`)
+	rawImageDataURIRe       = regexp.MustCompile(`(?i)data:image/[a-z0-9.+-]+;base64,[a-z0-9+/=]{200,}`)
+	rawDataURIRe            = regexp.MustCompile(`(?i)data:[a-z0-9.+/-]+;base64,[a-z0-9+/=]{200,}`)
+)
+
+// CanonicalizeImageURLsForModel removes storage-location entropy from model
+// inputs while retaining Markdown alt text, titles, HTML attributes, OCR and
+// captions. Export URLs are transport metadata: embedding or extracting them
+// adds no semantics and makes an identical reparse produce a different cache
+// key whenever the storage layer generates a new UUID or signed URL.
+func CanonicalizeImageURLsForModel(content string) string {
+	if content == "" {
+		return content
+	}
+
+	canonical := content
+	if strings.Contains(canonical, "![") {
+		canonical = markdownAngleImageURLRE.ReplaceAllString(canonical, `${1}`+modelImagePlaceholder+`${2}`)
+		canonical = markdownImageURLRE.ReplaceAllString(canonical, `${1}`+modelImagePlaceholder+`${2}`)
+	}
+	if strings.Contains(strings.ToLower(canonical), "<img") {
+		canonical = htmlImageSrcDoubleRE.ReplaceAllString(canonical, `${1}`+modelImagePlaceholder+`${2}`)
+		canonical = htmlImageSrcSingleRE.ReplaceAllString(canonical, `${1}`+modelImagePlaceholder+`${2}`)
+	}
+	if strings.Contains(strings.ToLower(canonical), "<image") {
+		canonical = imageURLDoubleRE.ReplaceAllString(canonical, `${1}`+modelImagePlaceholder+`${2}`)
+		canonical = imageURLSingleRE.ReplaceAllString(canonical, `${1}`+modelImagePlaceholder+`${2}`)
+	}
+	if strings.Contains(canonical, "base64,") {
+		canonical = rawImageDataURIRe.ReplaceAllString(canonical, modelImagePlaceholder)
+		canonical = rawDataURIRe.ReplaceAllString(canonical, modelImagePlaceholder)
+	}
+	return canonical
+}

--- a/internal/searchutil/imageurl_test.go
+++ b/internal/searchutil/imageurl_test.go
@@ -1,0 +1,63 @@
+package searchutil
+
+import "testing"
+
+func TestCanonicalizeImageURLsForModel(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "markdown local export keeps alt text",
+			in:   `before ![Figure 2: Architecture](local://10000/exports/random-a.jpg) after`,
+			want: `before ![Figure 2: Architecture]([image]) after`,
+		},
+		{
+			name: "markdown signed URL keeps title",
+			in:   `![plot](https://objects.example/uuid.png?X-Signature=one "training curve")`,
+			want: `![plot]([image] "training curve")`,
+		},
+		{
+			name: "markdown angle destination",
+			in:   `![scan](<minio://bucket/path with spaces/page.png>)`,
+			want: `![scan]([image])`,
+		},
+		{
+			name: "html image keeps semantic attributes",
+			in:   `<img alt="confusion matrix" src="provider://exports/random.png" width="200">`,
+			want: `<img alt="confusion matrix" src="[image]" width="200">`,
+		},
+		{
+			name: "enriched image keeps caption body",
+			in:   `<image url='local://exports/random.jpg'><image_caption>two people</image_caption></image>`,
+			want: `<image url='[image]'><image_caption>two people</image_caption></image>`,
+		},
+		{
+			name: "ordinary link remains intact",
+			in:   `[paper](https://example.com/paper.pdf)`,
+			want: `[paper](https://example.com/paper.pdf)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanonicalizeImageURLsForModel(tt.in); got != tt.want {
+				t.Fatalf("CanonicalizeImageURLsForModel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalizeImageURLsForModelIsStableAcrossExportURLs(t *testing.T) {
+	first := `![Figure 3](local://10000/exports/uuid-a_111.jpg)`
+	second := `![Figure 3](https://minio.example/signed/uuid-b.jpg?signature=222)`
+	if gotFirst, gotSecond := CanonicalizeImageURLsForModel(first), CanonicalizeImageURLsForModel(second); gotFirst != gotSecond {
+		t.Fatalf("canonical inputs differ: %q != %q", gotFirst, gotSecond)
+	}
+
+	differentCaption := `![Figure 4](local://10000/exports/uuid-a_111.jpg)`
+	if CanonicalizeImageURLsForModel(first) == CanonicalizeImageURLsForModel(differentCaption) {
+		t.Fatal("different alt text must remain distinguishable")
+	}
+}

--- a/internal/types/interfaces/task_queue.go
+++ b/internal/types/interfaces/task_queue.go
@@ -46,10 +46,23 @@ type TaskPendingOpsRepository interface {
 	// locked with FOR UPDATE SKIP LOCKED so concurrent claimers take
 	// disjoint key sets without blocking or double-claiming.
 	//
-	// Claimed rows are NOT removed: the consumer must DeleteByIDs on
-	// success, or ReleaseByIDs to hand a still-retryable row back to the
-	// pool (otherwise it stays claimed until staleBefore elapses).
+	// Claimed rows are NOT removed: the consumer must use the returned
+	// ClaimToken with DeleteClaims on success, or ReleaseClaims to hand a
+	// still-retryable row back to the pool. Token-scoped mutation fences out
+	// a former worker after a stale claim is reclaimed by a new owner.
 	ClaimBatch(ctx context.Context, taskType, scope, scopeID string, limit int, staleBefore time.Time) ([]*types.TaskPendingOp, error)
+
+	// RenewClaims advances claimed_at only for rows still owned by
+	// claimToken. The affected-row count lets the consumer detect a lost
+	// lease and cancel its work before it can race a replacement worker.
+	RenewClaims(ctx context.Context, ids []int64, claimToken string) (int64, error)
+
+	// ReleaseClaims and DeleteClaims are ownership-scoped counterparts of
+	// ReleaseByIDs and DeleteByIDs. A stale worker cannot settle rows after a
+	// replacement worker has reclaimed them under a different token.
+	ReleaseClaims(ctx context.Context, ids []int64, claimToken string) error
+	DeleteClaims(ctx context.Context, ids []int64, claimToken string) error
+	IncrClaimFailCount(ctx context.Context, id int64, claimToken string) (int, error)
 
 	// ReleaseByIDs clears claimed_at (back to NULL) for the given rows so
 	// a claimed-but-not-consumed row becomes immediately eligible for the

--- a/internal/types/task_pending_op.go
+++ b/internal/types/task_pending_op.go
@@ -49,12 +49,13 @@ type TaskPendingOp struct {
 	// but useful for ops queries like "rows older than 1h that never
 	// drained".
 	EnqueuedAt time.Time `json:"enqueued_at"`
-	// Optional claim timestamp for future locking workflows. Not used
-	// in the current revision: consumers rely on external mutual
-	// exclusion (e.g. wiki:active:<kbID> Redis SetNX). Reserved column
-	// so future no-lock parallel workers can flip it inside a row-level
-	// lock without another migration.
+	// Claim timestamp. Long-running consumers renew it as a lease; a value
+	// older than their stale threshold is eligible for crash recovery.
 	ClaimedAt *time.Time `json:"claimed_at,omitempty"`
+	// ClaimToken identifies the current lease owner. It prevents a worker
+	// that resumes after losing its lease from renewing, releasing, or
+	// deleting rows already reclaimed by another worker.
+	ClaimToken string `json:"claim_token,omitempty" gorm:"type:varchar(64);default:''"`
 }
 
 // TableName binds TaskPendingOp to the `task_pending_ops` table.

--- a/internal/types/wiki_page.go
+++ b/internal/types/wiki_page.go
@@ -619,12 +619,15 @@ type WikiIndexResponse struct {
 // Aliases is included because dedup and cross-link injection both treat
 // the alias surface forms as first-class match targets; OutLinks is
 // included so dead-link cleanup can determine which pages reference a
-// given dead slug without a second query.
+// given dead slug without a second query. SourceRefs is selected only by
+// dedup-state queries so map caching can distinguish this document's own
+// reduce output from pages contributed by other documents.
 type WikiPageLite struct {
-	Slug     string      `json:"slug"`
-	Title    string      `json:"title"`
-	PageType string      `json:"page_type"`
-	Status   string      `json:"status"`
-	Aliases  StringArray `json:"aliases,omitempty"`
-	OutLinks StringArray `json:"out_links,omitempty"`
+	Slug       string      `json:"slug"`
+	Title      string      `json:"title"`
+	PageType   string      `json:"page_type"`
+	Status     string      `json:"status"`
+	Aliases    StringArray `json:"aliases,omitempty"`
+	OutLinks   StringArray `json:"out_links,omitempty"`
+	SourceRefs StringArray `json:"source_refs,omitempty"`
 }

--- a/migrations/versioned/000068_task_pending_claim_leases.down.sql
+++ b/migrations/versioned/000068_task_pending_claim_leases.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE task_pending_ops
+    DROP COLUMN IF EXISTS claim_token;

--- a/migrations/versioned/000068_task_pending_claim_leases.up.sql
+++ b/migrations/versioned/000068_task_pending_claim_leases.up.sql
@@ -1,0 +1,8 @@
+-- Migration: 000068_task_pending_claim_leases
+-- Description: Add ownership tokens for renewable pending-op claim leases.
+
+ALTER TABLE task_pending_ops
+    ADD COLUMN IF NOT EXISTS claim_token VARCHAR(64) NOT NULL DEFAULT '';
+
+COMMENT ON COLUMN task_pending_ops.claim_token IS
+    'Current renewable claim lease owner. Ownership-scoped renew/release/delete prevents stale workers from settling rows reclaimed after a crash.';


### PR DESCRIPTION
## Description

本 PR 优化知识重新解析链路，为确定性的模型推理结果增加内容寻址缓存。

此前知识重解析会删除现有 Chunk 和索引，并重新调用 Embedding、VLM、Chat 等模型。即使文档内容没有变化，也会重复执行 OCR、Caption、摘要、问题生成、Wiki map 和 GraphRAG 抽取，导致重解析成本接近首次摄取。

本 PR 将重解析从“所有模型结果重新计算”优化为“按内容和配置补算缓存未命中的部分”。

### 主要实现

#### 1. Embedding 内容寻址缓存

- 缓存键包含租户、Embedding 模型指纹、维度和文本内容 Hash。
- 支持批内相同文本去重。
- 支持批量请求部分命中，只向模型提交未命中的文本。
- 支持并发请求合并，避免相同文本同时重复调用模型。
- 覆盖正文、摘要、问题、FAQ 和图谱相关向量化调用。

#### 2. VLM OCR/Caption 缓存

- 按图片原始字节、VLM 模型指纹、操作类型和完整 Prompt 建立缓存。
- OCR 与 Caption 使用独立命名空间。
- 相同图片在重解析时直接复用已有结果。
- 模型错误和无效结果不会写入缓存。
- 将随机导出 URL 从模型输入中正典化，隔离存储路径变化带来的非确定性。

#### 3. 文档摘要和问题生成缓存

- 文档摘要根据最终正文、语言、Prompt、模型及推理参数缓存。
- 问题生成根据当前 Chunk、相邻上下文、文档标题、语言、问题数量、自定义指令及模型参数缓存。
- 命中后将结果重新绑定到本次生成的 Chunk。
- 问题和摘要的 Embedding 继续通过统一向量缓存复用。
- 空结果、模型错误和损坏缓存不会被保留。

#### 4. GraphRAG per-chunk 缓存

- 按规范化 Chunk 内容、Graph 抽取模板、语言和 Chat 模型指纹缓存。
- 重解析时复用已有节点和关系抽取结果。
- 使用当前 Chunk 重新完成图谱持久化，不依赖旧任务的物理 UUID。

#### 5. Wiki per-document map 缓存

- 将 candidate extraction、deduplication、summary 和 chunk classification 的结果缓存为文档级 map artifact。
- 缓存键包含冻结后的文档内容、抽取粒度、自定义指令、Chat 模型和全部相关 Prompt。
- 使用稳定逻辑 Chunk ref 保存 `SourceChunks`。
- 缓存命中后，将稳定引用重新绑定到本次解析生成的 Chunk UUID。
- 随机图片 URL 使用占位符冻结，并在读取缓存后恢复为当前解析的 URL。
- 缓存产物记录实际参与去重的外部 Wiki 候选状态；其他文档新增或修改相似页面时精确失效，仅由当前文档产生的页面不会使自身重解析缓存失效。
- Wiki reduce/finalize 继续使用知识库实时页面状态执行，保证跨文档合并结果正确。

#### 6. 分层失效策略

所有缓存键只包含会影响输出的输入：

- 更换 Embedding 模型只失效向量缓存。
- 更换 VLM 模型或 OCR/Caption Prompt 只失效对应 VLM 层。
- 更换 Chat 模型或 Prompt 只失效依赖该模型的摘要、问题、GraphRAG 或 Wiki map。
- 修改 Chunk 内容只重算受影响的 Chunk。
- 修改 Chunk size 时，OCR/Caption 仍可根据图片字节复用。
- API Key 轮换和并发数调整不会使确定性结果失效。

#### 7. Wiki 崩溃恢复

- 为待处理 Wiki 操作增加短租约、owner token 和心跳续租。
- 使用 claim token fencing，防止租约过期后的旧 Worker 修改已被新 Worker 接管的任务。
- Worker 被 `kill -9` 终止后，任务可在租约过期后自动重新领取，不再被固定保护时间长期阻塞。
- 租约丢失时取消旧批次上下文，正常结算前停止心跳，避免新旧 Worker 并发提交。
- 新增数据库迁移 `000068_task_pending_claim_leases`，并兼容存量待处理任务的恢复。

#### 8. 缓存可靠性与可观测性

- Redis 作为跨进程持久缓存。
- 有界进程内缓存作为快速路径。
- 缓存读取或写入异常时 fail-open，不阻塞正常解析。
- 使用 singleflight 合并并发相同请求。
- 支持 TTL、最大内存条目和开关配置。
- 错误结果不缓存。
- JSON 损坏或语义无效的缓存会自动清除并重新计算。
- 日志输出各阶段 hit、miss、provider_inputs 和 coalesced 信息。

## Type of Change

- [X] New feature
- [X] Performance improvement
- [X] Test
- [X] Configuration / Build / CI

## Related Issue

Closes #1679

## Testing

### 自动化测试覆盖

新增测试覆盖：

- Embedding 完整命中、部分命中、批内去重和并发合并。
- Embedding 模型和维度精确失效。
- Redis 跨缓存实例复用及 TTL。
- Chat、Embedding、VLM 模型指纹。
- VLM OCR/Caption 相同请求复用。
- 文档摘要和问题生成缓存。
- 错误、空结果和损坏缓存处理。
- 随机图片 URL 正典化。
- Wiki map artifact 缓存和 Chunk UUID 重新绑定。
- Wiki map 模型、内容和抽取配置分层失效。
- Wiki 去重候选外部状态变化失效，同时忽略当前文档自身 reduce 产物。
- Wiki 待处理任务的租约领取、续租、owner fencing 和崩溃恢复。

### PDF 重解析验证

相同 PDF 第四次重解析结果：

- Embedding：33/33 cache-hit。
- VLM OCR/Caption：6/6 cache-hit。
- GraphRAG：28/28 cache-hit。
- Document summary：cache-hit。
- Wiki document map：cache-hit。
- 除 Wiki reduce/finalize 外：0 次 LLM/VLM provider call。

### 问题生成验证

使用 3 个 Markdown 文档开启问题生成，完成首次解析后进行相同内容重解析：

- Embedding：13/13 cache-hit。
- Question generation：5/5 cache-hit。
- Document summary：3/3 cache-hit。
- GraphRAG：5/5 cache-hit。
- Wiki document map：3/3 cache-hit。
- 所有可复用阶段产生 0 次模型调用。
- 三个文档的有效处理耗时合计从约 287.5 秒降低到 205.2 秒，降低约 28.6%。
- 未发现 ERROR、FATAL 或 WARNING。

### 崩溃续跑验证

在 Wiki map 命中后自动向后端发送 `SIGKILL`，随后重新启动服务：

- 重启后识别到仍在租约保护期内的任务，并在约 98 秒后自动重新领取。
- 恢复任务在约 22.7 秒内成功完成，知识状态最终为 `completed`。
- 已完成的 Embedding、VLM、摘要、问题生成、GraphRAG 和 Wiki map 均未重新调用模型。
- 仅重新执行不可缓存的 Wiki reduce/finalize。
- 崩溃前和恢复日志均未发现 ERROR、FATAL 或 WARNING。

### 分层失效验证

保持文档、模型及其他配置不变，仅将问题生成数量从 1 修改为 2：

- 正文 Embedding：3/3 cache-hit。
- VLM OCR/Caption：全部 cache-hit。
- Document summary：cache-hit。
- GraphRAG：3/3 cache-hit。
- Question generation：3/3 精确失效，并生成 6 个新问题。
- 新问题 Embedding：6/6 重新计算，属于问题产物变化后的必要下游补算。
- Wiki map 缓存键未受问题数量变化影响；测试期间因外部 Wiki 去重页面状态变化而按 `dedup_state` 正确失效。
- 文档最终状态为 `completed`，未发现 ERROR、FATAL 或 WARNING。

### Test commands

```bash
go test -count=1 \
  ./internal/models/embedding/... \
  ./internal/models/inferencecache \
  ./internal/models/chat \
  ./internal/models/vlm \
  ./internal/searchutil \
  ./internal/application/repository \
  ./internal/application/service \
  ./internal/container

git diff --check
```

## Checklist

- [X] Relevant Go test packages pass locally
- [X] `git diff --check` passes
- [X] Self-reviewed the code
- [X] Added/updated tests covering the change
- [X] Updated related configuration documentation
- [X] No breaking API changes; the database migration includes a rollback

## Screenshots / Recordings

Not applicable. This PR changes backend caching and knowledge processing behavior without user-visible UI changes.