### PR TITLE
feat(db): add MySQL full-stack support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,16 +101,18 @@ DOCREADER_TRANSPORT=grpc
 # ========== B1. 数据库 ⚠️ 必填 ==========
 # 主数据库类型：postgres / mysql / sqlite。
 DB_DRIVER=postgres
-# 数据库主机地址。
+# 数据库主机地址。MySQL 时需设为 mysql（容器服务名）或宿主机 IP。
 DB_HOST=postgres
-# 数据库端口。
+# 数据库端口（MySQL 默认 3306）。
 DB_PORT=5432
-# 数据库用户名。
+# 数据库用户名（MySQL 用 root 或自定义用户）。
 DB_USER=postgres
 # 数据库密码。
 DB_PASSWORD=postgres123!@#
 # 数据库名称。
 DB_NAME=WeKnora
+# MySQL 镜像对外映射端口（默认 3307 避免与宿主机 MySQL 冲突）。
+# MYSQL_PORT=3307
 # SQLite 驱动时使用（DB_DRIVER=sqlite），postgres/mysql 忽略。
 # DB_PATH=./data/weknora.db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -521,6 +521,35 @@ services:
     # 添加停机时的优雅退出时间
     stop_grace_period: 1m
 
+  mysql:
+    image: mysql:8.0
+    container_name: WeKnora-mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
+      - MYSQL_DATABASE=${DB_NAME}
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./migrations/mysql/00-init-db.sql:/docker-entrypoint-initdb.d/00-init-db.sql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --default-authentication-plugin=mysql_native_password
+      - --innodb_buffer_pool_size=512M
+      - --innodb_log_file_size=256M
+      - --max_allowed_packet=256M
+    ports:
+      - "${MYSQL_PORT:-3307}:3306"
+    networks:
+      - WeKnora-network
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${DB_PASSWORD}"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
+    restart: unless-stopped
+    stop_grace_period: 1m
+
   redis:
     image: redis:7.0-alpine
     container_name: WeKnora-redis
@@ -1009,6 +1038,7 @@ networks:
 
 volumes:
   postgres-data:
+  mysql-data:
   data-files:
   docreader-tmp:
   minio_data:

--- a/go.mod
+++ b/go.mod
@@ -62,8 +62,8 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/lkeap v1.3.103
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.73
 	github.com/tiktoken-go/tokenizer v0.7.0
-	github.com/volcengine/vikingdb-go-sdk v0.0.11
 	github.com/volcengine/ve-tos-golang-sdk/v2 v2.9.4
+	github.com/volcengine/vikingdb-go-sdk v0.0.11
 	github.com/wailsapp/wails/v2 v2.12.0
 	github.com/weaviate/weaviate v1.37.3
 	github.com/weaviate/weaviate-go-client/v5 v5.7.3
@@ -340,6 +340,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gorm.io/driver/mysql v1.6.0 // indirect
 	k8s.io/apimachinery v0.32.3 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3961,6 +3961,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/driver/mysql v1.6.0 h1:eNbLmNTpPpTOVZi8MMxCi2aaIm0ZpInbORNXDwyLGvg=
+gorm.io/driver/mysql v1.6.0/go.mod h1:D/oCC2GWK3M/dqoLxnOlaNKmXz8WNTfcS9y5ovaSqKo=
 gorm.io/driver/postgres v1.6.0 h1:2dxzU8xJ+ivvqTRph34QX+WrRaJlmfyPqXmoGVjMBa4=
 gorm.io/driver/postgres v1.6.0/go.mod h1:vUw0mrGgrTK+uPHEhAdV4sfFELrByKVGnaVRkXDhtWo=
 gorm.io/driver/sqlite v1.6.0 h1:WHRRrIiulaPiPFmDcod6prc4l2VGVWHz80KspNsxSfQ=

--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -455,6 +455,7 @@ func (r *chunkRepository) UpdateChunks(ctx context.Context, chunks []*types.Chun
 	}
 
 	isPostgres := r.db.Dialector.Name() == "postgres"
+	isMySQL := r.db.Dialector.Name() == "mysql"
 
 	var sql string
 	if isPostgres {
@@ -465,6 +466,24 @@ func (r *chunkRepository) UpdateChunks(ctx context.Context, chunks []*types.Chun
 				tag_id = CASE %s END,
 				flags = (CASE %s END)::integer,
 				status = (CASE %s END)::integer,
+				updated_at = NOW()
+			WHERE id IN (%s)
+		`,
+			strings.Join(contentCases, " "),
+			strings.Join(isEnabledCases, " "),
+			strings.Join(tagIDCases, " "),
+			strings.Join(flagsCases, " "),
+			strings.Join(statusCases, " "),
+			strings.Join(inPlaceholders, ","),
+		)
+	} else if isMySQL {
+		sql = fmt.Sprintf(`
+			UPDATE chunks SET
+				content = CASE %s END,
+				is_enabled = CASE %s END,
+				tag_id = CASE %s END,
+				flags = CASE %s END,
+				status = CASE %s END,
 				updated_at = NOW()
 			WHERE id IN (%s)
 		`,

--- a/internal/application/repository/retriever/mysql/repository.go
+++ b/internal/application/repository/retriever/mysql/repository.go
@@ -1,0 +1,404 @@
+package mysql
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/common"
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type mysqlEmbedding struct {
+	ID              uint      `gorm:"primarykey;autoIncrement"`
+	CreatedAt       time.Time `gorm:"column:created_at"`
+	UpdatedAt       time.Time `gorm:"column:updated_at"`
+	SourceID        string    `gorm:"column:source_id;not null;uniqueIndex:idx_mysql_emb_source"`
+	SourceType      int       `gorm:"column:source_type;not null;uniqueIndex:idx_mysql_emb_source"`
+	ChunkID         string    `gorm:"column:chunk_id;index"`
+	KnowledgeID     string    `gorm:"column:knowledge_id;index"`
+	KnowledgeBaseID string    `gorm:"column:knowledge_base_id;index"`
+	TagID           string    `gorm:"column:tag_id;index"`
+	Content         string    `gorm:"column:content;not null"`
+	Dimension       int       `gorm:"column:dimension;not null"`
+	Embedding       []byte    `gorm:"column:embedding;type:longblob"`
+	IsEnabled       *bool     `gorm:"column:is_enabled;default:true;index"`
+}
+
+func (mysqlEmbedding) TableName() string { return "mysql_embeddings" }
+
+type mysqlRepository struct {
+	db *gorm.DB
+}
+
+func NewMySQLRetrieveEngineRepository(db *gorm.DB) interfaces.RetrieveEngineRepository {
+	logger.GetLogger(context.Background()).Info("[MySQL] Initializing MySQL retriever engine repository")
+	if err := db.AutoMigrate(&mysqlEmbedding{}); err != nil {
+		logger.GetLogger(context.Background()).Errorf("[MySQL] AutoMigrate failed: %v", err)
+	}
+	return &mysqlRepository{db: db}
+}
+
+func (r *mysqlRepository) EngineType() types.RetrieverEngineType {
+	return types.PostgresRetrieverEngineType
+}
+
+func (r *mysqlRepository) Support() []types.RetrieverType {
+	return []types.RetrieverType{types.KeywordsRetrieverType, types.VectorRetrieverType}
+}
+
+func floatsToBytes(f []float32) []byte {
+	b := make([]byte, len(f)*4)
+	for i, v := range f {
+		binary.LittleEndian.PutUint32(b[i*4:], math.Float32bits(v))
+	}
+	return b
+}
+
+func bytesToFloats(b []byte) []float32 {
+	floats := make([]float32, len(b)/4)
+	for i := range floats {
+		floats[i] = math.Float32frombits(binary.LittleEndian.Uint32(b[i*4:]))
+	}
+	return floats
+}
+
+func cosineSimilarity(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, normA, normB float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		normA += float64(a[i]) * float64(a[i])
+		normB += float64(b[i]) * float64(b[i])
+	}
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
+}
+
+func toDBVectorEmbedding(info *types.IndexInfo, params map[string]any) *mysqlEmbedding {
+	m := &mysqlEmbedding{
+		SourceID:        info.SourceID,
+		SourceType:      int(info.SourceType),
+		ChunkID:         info.ChunkID,
+		KnowledgeID:     info.KnowledgeID,
+		KnowledgeBaseID: info.KnowledgeBaseID,
+		TagID:           info.TagID,
+		Content:         common.CleanInvalidUTF8(info.Content),
+	}
+	if params != nil {
+		if em, ok := params["embedding"].(map[string][]float32); ok {
+			if emb, ok := em[info.SourceID]; ok {
+				m.Embedding = floatsToBytes(emb)
+				m.Dimension = len(emb)
+			}
+		}
+	}
+	// Set is_enabled from info, with override from additionalParams
+	isEnabled := info.IsEnabled
+	if params != nil {
+		if chunkEnabledMap, ok := params["chunk_enabled"].(map[string]bool); ok {
+			if enabled, exists := chunkEnabledMap[info.ChunkID]; exists {
+				isEnabled = enabled
+			}
+		}
+	}
+	m.IsEnabled = &isEnabled
+	return m
+}
+
+func fromDBEmbedding(e *mysqlEmbedding, score float64, mt types.MatchType) *types.IndexWithScore {
+	return &types.IndexWithScore{
+		ID:              strconv.FormatUint(uint64(e.ID), 10),
+		SourceID:        e.SourceID,
+		SourceType:      types.SourceType(e.SourceType),
+		ChunkID:         e.ChunkID,
+		KnowledgeID:     e.KnowledgeID,
+		KnowledgeBaseID: e.KnowledgeBaseID,
+		TagID:           e.TagID,
+		Content:         e.Content,
+		Score:           score,
+		MatchType:       mt,
+	}
+}
+
+func (r *mysqlRepository) EstimateStorageSize(ctx context.Context, list []*types.IndexInfo, params map[string]any) int64 {
+	var total int64
+	for _, info := range list {
+		emb := toDBVectorEmbedding(info, params)
+		total += int64(len(emb.Content)) + int64(emb.Dimension*4) + 200
+	}
+	return total
+}
+
+func (r *mysqlRepository) Save(ctx context.Context, info *types.IndexInfo, params map[string]any) error {
+	return r.db.WithContext(ctx).Create(toDBVectorEmbedding(info, params)).Error
+}
+
+func (r *mysqlRepository) BatchSave(ctx context.Context, list []*types.IndexInfo, params map[string]any) error {
+	if len(list) == 0 {
+		return nil
+	}
+	embeddings := make([]*mysqlEmbedding, len(list))
+	for i := range list {
+		embeddings[i] = toDBVectorEmbedding(list[i], params)
+	}
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(embeddings).Error
+}
+
+func (r *mysqlRepository) DeleteByChunkIDList(ctx context.Context, ids []string, dim int, kt string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	return r.db.WithContext(ctx).Where("chunk_id IN ?", ids).Delete(&mysqlEmbedding{}).Error
+}
+
+func (r *mysqlRepository) DeleteBySourceIDList(ctx context.Context, ids []string, dim int, kt string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	return r.db.WithContext(ctx).Where("source_id IN ?", ids).Delete(&mysqlEmbedding{}).Error
+}
+
+func (r *mysqlRepository) DeleteByKnowledgeIDList(ctx context.Context, ids []string, dim int, kt string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	return r.db.WithContext(ctx).Where("knowledge_id IN ?", ids).Delete(&mysqlEmbedding{}).Error
+}
+
+func (r *mysqlRepository) Retrieve(ctx context.Context, params types.RetrieveParams) ([]*types.RetrieveResult, error) {
+	switch params.RetrieverType {
+	case types.KeywordsRetrieverType:
+		return r.KeywordsRetrieve(ctx, params)
+	case types.VectorRetrieverType:
+		return r.VectorRetrieve(ctx, params)
+	}
+	return nil, errors.New("invalid retriever type")
+}
+
+func (r *mysqlRepository) KeywordsRetrieve(ctx context.Context, params types.RetrieveParams) ([]*types.RetrieveResult, error) {
+	logger.GetLogger(ctx).Infof("[MySQL] Keywords retrieval: query=%s, topK=%d", params.Query, params.TopK)
+	db := r.db.WithContext(ctx).Table("mysql_embeddings")
+	if len(params.KnowledgeBaseIDs) > 0 {
+		db = db.Where("knowledge_base_id IN ?", params.KnowledgeBaseIDs)
+	}
+	if len(params.KnowledgeIDs) > 0 {
+		db = db.Where("knowledge_id IN ?", params.KnowledgeIDs)
+	}
+	if len(params.TagIDs) > 0 {
+		db = db.Where("tag_id IN ?", params.TagIDs)
+	}
+	db = db.Where("is_enabled IS NULL OR is_enabled = ?", true)
+
+	var list []mysqlEmbedding
+	// Try FULLTEXT first, fallback to LIKE
+	err := db.Where("MATCH(content) AGAINST(? IN BOOLEAN MODE)", params.Query).
+		Limit(int(params.TopK)).Find(&list).Error
+	if err != nil || len(list) == 0 {
+		db2 := r.db.WithContext(ctx).Table("mysql_embeddings").
+			Where("is_enabled IS NULL OR is_enabled = ?", true)
+		if len(params.KnowledgeBaseIDs) > 0 {
+			db2 = db2.Where("knowledge_base_id IN ?", params.KnowledgeBaseIDs)
+		}
+		if len(params.KnowledgeIDs) > 0 {
+			db2 = db2.Where("knowledge_id IN ?", params.KnowledgeIDs)
+		}
+		if len(params.TagIDs) > 0 {
+			db2 = db2.Where("tag_id IN ?", params.TagIDs)
+		}
+		err = db2.Where("content LIKE ?", "%"+params.Query+"%").Limit(int(params.TopK)).Find(&list).Error
+	}
+	if err != nil {
+		return nil, err
+	}
+	results := make([]*types.IndexWithScore, len(list))
+	for i := range list {
+		results[i] = fromDBEmbedding(&list[i], 1.0, types.MatchTypeKeywords)
+	}
+	return []*types.RetrieveResult{{
+		Results:             results,
+		RetrieverEngineType: types.PostgresRetrieverEngineType,
+		RetrieverType:       types.KeywordsRetrieverType,
+	}}, nil
+}
+
+func (r *mysqlRepository) VectorRetrieve(ctx context.Context, params types.RetrieveParams) ([]*types.RetrieveResult, error) {
+	logger.GetLogger(ctx).Infof("[MySQL] Vector retrieval: dim=%d, topK=%d, threshold=%.4f",
+		len(params.Embedding), params.TopK, params.Threshold)
+
+	queryEmb := params.Embedding
+	db := r.db.WithContext(ctx).Table("mysql_embeddings").
+		Where("dimension = ?", len(queryEmb)).
+		Where("is_enabled IS NULL OR is_enabled = ?", true)
+
+	if len(params.KnowledgeBaseIDs) > 0 {
+		db = db.Where("knowledge_base_id IN ?", params.KnowledgeBaseIDs)
+	}
+	if len(params.KnowledgeIDs) > 0 {
+		db = db.Where("knowledge_id IN ?", params.KnowledgeIDs)
+	}
+	if len(params.TagIDs) > 0 {
+		db = db.Where("tag_id IN ?", params.TagIDs)
+	}
+
+	fetchLimit := int(params.TopK) * 5
+	if fetchLimit < 100 {
+		fetchLimit = 100
+	}
+	if fetchLimit > 500 {
+		fetchLimit = 500
+	}
+
+	var candidates []mysqlEmbedding
+	if err := db.Limit(fetchLimit).Find(&candidates).Error; err != nil {
+		return nil, err
+	}
+
+	type scored struct {
+		e *mysqlEmbedding
+		s float64
+	}
+	scored := make([]scored, 0, len(candidates))
+	for i := range candidates {
+		if len(candidates[i].Embedding) == 0 {
+			continue
+		}
+		sim := cosineSimilarity(queryEmb, bytesToFloats(candidates[i].Embedding))
+		if sim >= float64(params.Threshold) {
+			scored = append(scored, scored{e: &candidates[i], s: sim})
+		}
+	}
+	sort.Slice(scored, func(i, j int) bool { return scored[i].s > scored[j].s })
+	if len(scored) > int(params.TopK) {
+		scored = scored[:params.TopK]
+	}
+
+	results := make([]*types.IndexWithScore, len(scored))
+	for i := range scored {
+		results[i] = fromDBEmbedding(scored[i].e, scored[i].s, types.MatchTypeEmbedding)
+	}
+	logger.GetLogger(ctx).Infof("[MySQL] Vector retrieval found %d results", len(results))
+	return []*types.RetrieveResult{{
+		Results:             results,
+		RetrieverEngineType: types.PostgresRetrieverEngineType,
+		RetrieverType:       types.VectorRetrieverType,
+	}}, nil
+}
+
+func (r *mysqlRepository) CopyIndices(ctx context.Context,
+	srcKBID string, kbMap map[string]string, chunkMap map[string]string,
+	dstKBID string, dim int, kt string,
+) error {
+	if len(chunkMap) == 0 {
+		return nil
+	}
+	batchSize := 500
+	offset := 0
+	total := 0
+	for {
+		var src []*mysqlEmbedding
+		if err := r.db.WithContext(ctx).Where("knowledge_base_id = ?", srcKBID).
+			Limit(batchSize).Offset(offset).Find(&src).Error; err != nil {
+			return err
+		}
+		if len(src) == 0 {
+			break
+		}
+		dst := make([]*mysqlEmbedding, 0, len(src))
+		for _, sv := range src {
+			tc, ok := chunkMap[sv.ChunkID]
+			if !ok {
+				continue
+			}
+			tk, ok := kbMap[sv.KnowledgeID]
+			if !ok {
+				continue
+			}
+			sid := tc
+			if sv.SourceID != sv.ChunkID {
+				if strings.HasPrefix(sv.SourceID, sv.ChunkID+"-") {
+					sid = tc + "-" + strings.TrimPrefix(sv.SourceID, sv.ChunkID+"-")
+				} else {
+					sid = uuid.New().String()
+				}
+			}
+			dst = append(dst, &mysqlEmbedding{
+				Content: sv.Content, SourceID: sid, SourceType: sv.SourceType,
+				ChunkID: tc, KnowledgeID: tk, KnowledgeBaseID: dstKBID,
+				Dimension: sv.Dimension, Embedding: sv.Embedding, IsEnabled: sv.IsEnabled,
+			})
+		}
+		if len(dst) > 0 {
+			if err := r.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).
+				Create(dst).Error; err != nil {
+				return err
+			}
+			total += len(dst)
+		}
+		offset += batchSize
+		if len(src) < batchSize {
+			break
+		}
+	}
+	logger.GetLogger(ctx).Infof("[MySQL] CopyIndices done: %d", total)
+	return nil
+}
+
+func (r *mysqlRepository) BatchUpdateChunkEnabledStatus(ctx context.Context, m map[string]bool) error {
+	if len(m) == 0 {
+		return nil
+	}
+	var on, off []string
+	for id, en := range m {
+		if en {
+			on = append(on, id)
+		} else {
+			off = append(off, id)
+		}
+	}
+	if len(on) > 0 {
+		if err := r.db.WithContext(ctx).Model(&mysqlEmbedding{}).
+			Where("chunk_id IN ?", on).Update("is_enabled", true).Error; err != nil {
+			return err
+		}
+	}
+	if len(off) > 0 {
+		if err := r.db.WithContext(ctx).Model(&mysqlEmbedding{}).
+			Where("chunk_id IN ?", off).Update("is_enabled", false).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *mysqlRepository) BatchUpdateChunkTagID(ctx context.Context, m map[string]string) error {
+	if len(m) == 0 {
+		return nil
+	}
+	groups := make(map[string][]string)
+	for id, tag := range m {
+		groups[tag] = append(groups[tag], id)
+	}
+	for tag, ids := range groups {
+		if err := r.db.WithContext(ctx).Model(&mysqlEmbedding{}).
+			Where("chunk_id IN ?", ids).Update("tag_id", tag).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/application/service/storagebackend.go
+++ b/internal/application/service/storagebackend.go
@@ -132,7 +132,7 @@ func (s *StorageBackendService) Delete(ctx context.Context, tenantID uint64, id 
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var backend types.StorageBackend
 		query := tx.Where("tenant_id = ? AND id = ?", tenantID, id)
-		if tx.Dialector.Name() == "postgres" {
+		if tx.Dialector.Name() == "postgres" || tx.Dialector.Name() == "mysql" {
 			query = query.Clauses(clause.Locking{Strength: "UPDATE"})
 		}
 		if err := query.First(&backend).Error; err != nil {
@@ -178,7 +178,7 @@ func (s *StorageBackendService) SetDefault(ctx context.Context, tenantID uint64,
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var backend types.StorageBackend
 		query := tx.Where("tenant_id = ? AND id = ?", tenantID, id)
-		if tx.Dialector.Name() == "postgres" {
+		if tx.Dialector.Name() == "postgres" || tx.Dialector.Name() == "mysql" {
 			query = query.Clauses(clause.Locking{Strength: "UPDATE"})
 		}
 		if err := query.First(&backend).Error; err != nil {

--- a/internal/application/service/vectorstore.go
+++ b/internal/application/service/vectorstore.go
@@ -251,7 +251,7 @@ func (s *vectorStoreService) unregisterSafely(ctx context.Context, storeID strin
 // Used to gate dialect-specific clauses (e.g., SELECT FOR UPDATE) that
 // SQLite would either ignore (recent versions) or fail to compile on.
 func (s *vectorStoreService) isPostgres(db *gorm.DB) bool {
-	return db != nil && db.Dialector != nil && db.Dialector.Name() == "postgres"
+	return db != nil && db.Dialector != nil && (db.Dialector.Name() == "postgres" || db.Dialector.Name() == "mysql")
 }
 
 // SaveDetectedVersion updates the connection_config.version for a stored vector store.

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -29,6 +29,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/dig"
 	"google.golang.org/grpc"
+	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -39,6 +40,7 @@ import (
 	elasticsearchRepoV7 "github.com/Tencent/WeKnora/internal/application/repository/retriever/elasticsearch/v7"
 	elasticsearchRepoV8 "github.com/Tencent/WeKnora/internal/application/repository/retriever/elasticsearch/v8"
 	milvusRepo "github.com/Tencent/WeKnora/internal/application/repository/retriever/milvus"
+	mysqlRepo "github.com/Tencent/WeKnora/internal/application/repository/retriever/mysql"
 	neo4jRepo "github.com/Tencent/WeKnora/internal/application/repository/retriever/neo4j"
 	openSearchRepo "github.com/Tencent/WeKnora/internal/application/repository/retriever/opensearch"
 	postgresRepo "github.com/Tencent/WeKnora/internal/application/repository/retriever/postgres"
@@ -632,6 +634,25 @@ func initDatabase(cfg *config.Config) (*gorm.DB, error) {
 		sqliteDBPath = dbPath
 		migrateDSN = "sqlite3://" + dbPath
 		logger.Infof(context.Background(), "DB Config: driver=sqlite path=%s", dbPath)
+	case "mysql":
+		dbPassword := os.Getenv("DB_PASSWORD")
+		gormDSN := fmt.Sprintf(
+			"%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=UTC&multiStatements=true",
+			os.Getenv("DB_USER"), dbPassword,
+			os.Getenv("DB_HOST"), os.Getenv("DB_PORT"),
+			os.Getenv("DB_NAME"),
+		)
+		dialector = mysql.Open(gormDSN)
+		encodedPassword := url.QueryEscape(dbPassword)
+		migrateDSN = fmt.Sprintf(
+			"mysql://%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=true&multiStatements=true",
+			os.Getenv("DB_USER"), encodedPassword,
+			os.Getenv("DB_HOST"), os.Getenv("DB_PORT"),
+			os.Getenv("DB_NAME"),
+		)
+		logger.Infof(context.Background(), "DB Config: driver=mysql user=%s host=%s port=%s dbname=%s",
+			os.Getenv("DB_USER"), os.Getenv("DB_HOST"), os.Getenv("DB_PORT"), os.Getenv("DB_NAME"),
+		)
 	default:
 		return nil, fmt.Errorf("unsupported database driver: %s", os.Getenv("DB_DRIVER"))
 	}
@@ -650,9 +671,9 @@ func initDatabase(cfg *config.Config) (*gorm.DB, error) {
 	// different name (e.g., a wrapper dialect for managed PG) would silently
 	// fall back to the SQLite path, dropping the row-level X-lock. Catching
 	// the mismatch at startup is loud and inexpensive.
-	if name := db.Dialector.Name(); name != "postgres" && name != "sqlite" {
+	if name := db.Dialector.Name(); name != "postgres" && name != "sqlite" && name != "mysql" {
 		return nil, fmt.Errorf(
-			"unsupported gorm dialector %q; expected postgres or sqlite "+
+			"unsupported gorm dialector %q; expected postgres, sqlite or mysql "+
 				"(see vectorStoreService.isPostgres for impact)", name)
 	}
 
@@ -1059,6 +1080,16 @@ func initRetrieveEngineRegistry(
 			log.Errorf("Register sqlite retrieve engine failed: %v", err)
 		} else {
 			log.Infof("Register sqlite retrieve engine success")
+		}
+	}
+	if slices.Contains(retrieveDriver, "mysql") {
+		mySQLRepo := mysqlRepo.NewMySQLRetrieveEngineRepository(db)
+		if err := registry.Register(
+			retriever.NewKVHybridRetrieveEngine(mySQLRepo, types.PostgresRetrieverEngineType),
+		); err != nil {
+			log.Errorf("Register mysql retrieve engine failed: %v", err)
+		} else {
+			log.Infof("Register mysql retrieve engine success")
 		}
 	}
 	if slices.Contains(retrieveDriver, "elasticsearch_v8") {

--- a/internal/database/migration.go
+++ b/internal/database/migration.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/mysql"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	sqlite3migrate "github.com/golang-migrate/migrate/v4/database/sqlite3"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -106,6 +107,8 @@ func RunMigrationsWithOptions(dsn string, opts MigrationOptions) error {
 	migrationsPath := "file://migrations/versioned"
 	if strings.HasPrefix(dsn, "sqlite3://") {
 		migrationsPath = "file://migrations/sqlite"
+	} else if strings.HasPrefix(dsn, "mysql://") {
+		migrationsPath = "file://migrations/mysql"
 	}
 
 	var m *migrate.Migrate

--- a/migrations/mysql/00-init-db.sql
+++ b/migrations/mysql/00-init-db.sql
@@ -1,27 +1,27 @@
-DROP TABLE IF EXISTS tenants;
-DROP TABLE IF EXISTS models;
-DROP TABLE IF EXISTS knowledge_bases;
-DROP TABLE IF EXISTS knowledges;
-DROP TABLE IF EXISTS sessions;
-DROP TABLE IF EXISTS messages;
-DROP TABLE IF EXISTS chunks;
-
-CREATE TABLE tenants (
+-- WeKnora MySQL 完整初始化脚本 (MySQL 8.0+)
+-- ============================================================================
+-- 覆盖全部 PostgreSQL migrations 000000–000079，适配 MySQL 语法
+-- JSONB→JSON, SERIAL→BIGINT AUTO_INCREMENT, BOOLEAN→TINYINT(1)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS tenants (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     description TEXT,
-    retriever_engines JSON NOT NULL,
+    api_key VARCHAR(64) NOT NULL,
+    retriever_engines JSON NOT NULL DEFAULT ('[]'),
     status VARCHAR(50) DEFAULT 'active',
     business VARCHAR(255) NOT NULL,
     storage_quota BIGINT NOT NULL DEFAULT 10737418240,
     storage_used BIGINT NOT NULL DEFAULT 0,
-    agent_config JSON DEFAULT NULL COMMENT 'Tenant-level agent configuration in JSON format',
+    agent_config JSON DEFAULT NULL,
+    context_config JSON DEFAULT NULL,
+    conversation_config JSON DEFAULT NULL,
+    web_search_config JSON DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     deleted_at TIMESTAMP NULL DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 AUTO_INCREMENT=10000;
-
-CREATE TABLE models (
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=10000;
+CREATE TABLE IF NOT EXISTS models (
     id VARCHAR(64) PRIMARY KEY,
     tenant_id INT NOT NULL,
     name VARCHAR(255) NOT NULL,
@@ -30,16 +30,39 @@ CREATE TABLE models (
     source VARCHAR(50) NOT NULL,
     description TEXT,
     parameters JSON NOT NULL,
-    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    is_default TINYINT(1) NOT NULL DEFAULT 0,
     status VARCHAR(50) NOT NULL DEFAULT 'active',
+    is_builtin TINYINT(1) NOT NULL DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     deleted_at TIMESTAMP NULL DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;  
-
-CREATE INDEX idx_models_tenant_source_type ON models(tenant_id, source, type);
-
-CREATE TABLE knowledge_bases (
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS users (
+    id VARCHAR(36) PRIMARY KEY,
+    username VARCHAR(100) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    avatar VARCHAR(500),
+    tenant_id INT,
+    is_active TINYINT(1) NOT NULL DEFAULT 1,
+    can_access_all_tenants TINYINT(1) NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    UNIQUE KEY uk_users_username (username),
+    UNIQUE KEY uk_users_email (email)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS auth_tokens (
+    id VARCHAR(36) PRIMARY KEY,
+    user_id VARCHAR(36) NOT NULL,
+    token TEXT NOT NULL,
+    token_type VARCHAR(50) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    is_revoked TINYINT(1) NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS knowledge_bases (
     id VARCHAR(36) PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     description TEXT,
@@ -48,18 +71,21 @@ CREATE TABLE knowledge_bases (
     image_processing_config JSON NOT NULL,
     embedding_model_id VARCHAR(64) NOT NULL,
     summary_model_id VARCHAR(64) NOT NULL,
-    rerank_model_id VARCHAR(64) NOT NULL,
     cos_config JSON NOT NULL,
     vlm_config JSON NOT NULL,
     extract_config JSON NULL,
+    is_temporary TINYINT(1) NOT NULL DEFAULT 0,
+    type VARCHAR(32) NOT NULL DEFAULT 'document',
+    faq_config JSON NULL,
+    question_generation_config JSON NULL,
+    storage_provider_config JSON NULL,
+    vector_store_id VARCHAR(36),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    deleted_at TIMESTAMP NULL DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE INDEX idx_knowledge_bases_tenant_name ON knowledge_bases(tenant_id, name);
-
-CREATE TABLE knowledges (
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    INDEX idx_kb_tenant (tenant_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS knowledges (
     id VARCHAR(36) PRIMARY KEY,
     tenant_id INT NOT NULL,
     knowledge_base_id VARCHAR(36) NOT NULL,
@@ -77,112 +103,70 @@ CREATE TABLE knowledges (
     file_hash VARCHAR(64),
     storage_size BIGINT NOT NULL DEFAULT 0,
     metadata JSON,
+    tag_id VARCHAR(36),
+    summary_status VARCHAR(32) DEFAULT 'none',
     custom_metadata JSON NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    processed_at TIMESTAMP NULL DEFAULT NULL,
+    error_message TEXT,
     deleted_at TIMESTAMP NULL DEFAULT NULL,
-    processed_at TIMESTAMP,
-    error_message TEXT
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE INDEX idx_knowledges_tenant_id ON knowledges(tenant_id, knowledge_base_id);
-
-CREATE TABLE sessions (
+    INDEX idx_k_tenant_base (tenant_id, knowledge_base_id),
+    INDEX idx_k_parse_status (parse_status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS sessions (
     id VARCHAR(36) PRIMARY KEY,
-    tenant_id INTEGER NOT NULL,
+    tenant_id INT NOT NULL,
     title VARCHAR(255),
     description TEXT,
     knowledge_base_id VARCHAR(36),
     max_rounds INT NOT NULL DEFAULT 5,
-    enable_rewrite BOOLEAN NOT NULL DEFAULT TRUE,
+    enable_rewrite TINYINT(1) NOT NULL DEFAULT 1,
     fallback_strategy VARCHAR(255) NOT NULL DEFAULT 'fixed',
-    fallback_response VARCHAR(255) NOT NULL DEFAULT '很抱歉，我暂时无法回答这个问题。',
+    fallback_response TEXT NOT NULL,
     keyword_threshold FLOAT NOT NULL DEFAULT 0.5,
     vector_threshold FLOAT NOT NULL DEFAULT 0.5,
     rerank_model_id VARCHAR(64),
-    embedding_top_k INTEGER NOT NULL DEFAULT 10,
-    rerank_top_k INTEGER NOT NULL DEFAULT 10,
+    embedding_top_k INT NOT NULL DEFAULT 10,
+    rerank_top_k INT NOT NULL DEFAULT 10,
     rerank_threshold FLOAT NOT NULL DEFAULT 0.65,
     summary_model_id VARCHAR(64),
     summary_parameters JSON NOT NULL,
-    agent_config JSON DEFAULT NULL COMMENT 'Session-level agent configuration in JSON format',
-    context_config JSON DEFAULT NULL COMMENT 'LLM context management configuration (separate from message storage)',
+    agent_config JSON DEFAULT NULL,
+    context_config JSON DEFAULT NULL,
+    user_id VARCHAR(36),
+    is_pinned TINYINT(1) NOT NULL DEFAULT 0,
+    pinned_at TIMESTAMP NULL DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    deleted_at TIMESTAMP NULL DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE INDEX idx_sessions_tenant_id ON sessions(tenant_id);
-
-CREATE TABLE messages (
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    INDEX idx_s_tenant (tenant_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS messages (
     id VARCHAR(36) PRIMARY KEY,
     request_id VARCHAR(36) NOT NULL,
     session_id VARCHAR(36) NOT NULL,
     role VARCHAR(50) NOT NULL,
     content TEXT NOT NULL,
     knowledge_references JSON NOT NULL,
-    agent_steps JSON DEFAULT NULL COMMENT 'Agent execution steps (reasoning process and tool calls)',
-    is_completed BOOLEAN NOT NULL DEFAULT FALSE,
+    agent_steps JSON DEFAULT NULL,
+    is_completed TINYINT(1) NOT NULL DEFAULT 0,
     agent_id VARCHAR(36) NOT NULL DEFAULT '',
-    agent_tenant_id INTEGER NOT NULL DEFAULT 0,
+    agent_tenant_id INT NOT NULL DEFAULT 0,
     model_id VARCHAR(64) NOT NULL DEFAULT '',
     execution_context JSON NOT NULL,
+    rendered_content TEXT,
+    channel_type VARCHAR(32),
+    images JSON,
+    knowledge_id VARCHAR(36),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    deleted_at TIMESTAMP NULL DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE INDEX idx_messages_session_role ON messages(session_id, role); 
-CREATE INDEX idx_messages_agent_id ON messages(agent_id);
-
-CREATE TABLE message_suggestion_sets (
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    INDEX idx_m_session (session_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS chunks (
     id VARCHAR(36) PRIMARY KEY,
-    tenant_id INTEGER NOT NULL,
-    session_id VARCHAR(36) NOT NULL,
-    assistant_message_id VARCHAR(36) NOT NULL,
-    agent_id VARCHAR(36) NOT NULL DEFAULT '',
-    agent_tenant_id INTEGER NOT NULL DEFAULT 0,
-    placement VARCHAR(32) NOT NULL,
-    config_hash VARCHAR(64) NOT NULL,
-    locale VARCHAR(16) NOT NULL DEFAULT '',
-    status VARCHAR(16) NOT NULL,
-    allow_regenerate BOOLEAN NOT NULL DEFAULT FALSE,
-    suppression_reason VARCHAR(64) NOT NULL DEFAULT '',
-    questions JSON NOT NULL,
-    model_id VARCHAR(64) NOT NULL DEFAULT '',
-    prompt_tokens INTEGER NOT NULL DEFAULT 0,
-    completion_tokens INTEGER NOT NULL DEFAULT 0,
-    latency_ms BIGINT NOT NULL DEFAULT 0,
-    error_code VARCHAR(64) NOT NULL DEFAULT '',
-    lease_until TIMESTAMP NULL DEFAULT NULL,
-    generated_at TIMESTAMP NULL DEFAULT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    UNIQUE KEY idx_message_suggestion_sets_cache_key
-        (tenant_id, assistant_message_id, placement, config_hash, locale),
-    KEY idx_message_suggestion_sets_session (tenant_id, session_id, created_at),
-    KEY idx_message_suggestion_sets_status (status, lease_until)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE message_suggestion_events (
-    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    tenant_id INTEGER NOT NULL,
-    session_id VARCHAR(36) NOT NULL,
-    suggestion_set_id VARCHAR(36) NOT NULL,
-    question_id VARCHAR(64) NOT NULL DEFAULT '',
-    event_type VARCHAR(32) NOT NULL,
-    actor_id VARCHAR(512) NOT NULL DEFAULT '',
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    KEY idx_message_suggestion_events_set (suggestion_set_id, created_at),
-    KEY idx_message_suggestion_events_session (tenant_id, session_id, created_at),
-    KEY idx_message_suggestion_events_type (event_type, created_at),
-    CONSTRAINT fk_message_suggestion_events_set
-        FOREIGN KEY (suggestion_set_id) REFERENCES message_suggestion_sets(id) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE chunks (
-    id VARCHAR(36) PRIMARY KEY,
-    tenant_id INTEGER NOT NULL,
+    tenant_id INT NOT NULL,
     knowledge_base_id VARCHAR(36) NOT NULL,
     knowledge_id VARCHAR(36) NOT NULL,
     content TEXT NOT NULL,
@@ -191,10 +175,10 @@ CREATE TABLE chunks (
     index_status VARCHAR(16) NOT NULL DEFAULT 'ready',
     last_editor_id VARCHAR(64) NOT NULL DEFAULT '',
     context_header TEXT NOT NULL,
-    chunk_index INTEGER NOT NULL,
-    is_enabled BOOLEAN NOT NULL DEFAULT TRUE,
-    start_at INTEGER NOT NULL,
-    end_at INTEGER NOT NULL,
+    chunk_index INT NOT NULL,
+    is_enabled TINYINT(1) NOT NULL DEFAULT 1,
+    start_at INT NOT NULL,
+    end_at INT NOT NULL,
     pre_chunk_id VARCHAR(36),
     next_chunk_id VARCHAR(36),
     chunk_type VARCHAR(20) NOT NULL DEFAULT 'text',
@@ -202,16 +186,19 @@ CREATE TABLE chunks (
     image_info TEXT,
     relation_chunks JSON,
     indirect_relation_chunks JSON,
+    metadata JSON,
+    tag_id VARCHAR(36),
+    status INT NOT NULL DEFAULT 0,
+    content_hash VARCHAR(64),
+    flags INT NOT NULL DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    deleted_at TIMESTAMP NULL DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE INDEX idx_chunks_tenant_knowledge ON chunks(tenant_id, knowledge_id);
-CREATE INDEX idx_chunks_parent_id ON chunks(parent_chunk_id);
-CREATE INDEX idx_chunks_chunk_type ON chunks(chunk_type);
-
-CREATE TABLE chunk_revisions (
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    INDEX idx_c_tenant_knowledge (tenant_id, knowledge_id),
+    INDEX idx_c_parent (parent_chunk_id),
+    INDEX idx_c_type (chunk_type)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS chunk_revisions (
     id VARCHAR(36) PRIMARY KEY,
     tenant_id BIGINT NOT NULL,
     knowledge_base_id VARCHAR(36) NOT NULL,
@@ -219,11 +206,259 @@ CREATE TABLE chunk_revisions (
     chunk_id VARCHAR(36) NOT NULL,
     revision INT NOT NULL,
     content TEXT NOT NULL,
-    is_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    is_enabled TINYINT(1) NOT NULL DEFAULT 1,
     editor_id VARCHAR(64) NOT NULL DEFAULT '',
     edit_source VARCHAR(16) NOT NULL DEFAULT 'user',
     edited_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE KEY idx_chunk_revisions_chunk_revision (chunk_id, revision),
-    KEY idx_chunk_revisions_tenant_chunk (tenant_id, chunk_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+    UNIQUE KEY uk_cr_chunk_rev (chunk_id, revision)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS knowledge_tags (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id INT NOT NULL,
+    knowledge_base_id VARCHAR(36) NOT NULL,
+    name VARCHAR(128) NOT NULL,
+    color VARCHAR(32),
+    sort_order INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    UNIQUE KEY uk_kt_kb_name (tenant_id, knowledge_base_id, name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS mcp_services (
+    id VARCHAR(64) PRIMARY KEY,
+    tenant_id INT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    enabled TINYINT(1) DEFAULT 1,
+    transport_type VARCHAR(50) NOT NULL,
+    url VARCHAR(512),
+    headers JSON,
+    auth_config JSON,
+    advanced_config JSON,
+    stdio_config JSON,
+    env_vars JSON,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    INDEX idx_mcp_tenant (tenant_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS message_suggestion_sets (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id INT NOT NULL,
+    session_id VARCHAR(36) NOT NULL,
+    assistant_message_id VARCHAR(36) NOT NULL,
+    agent_id VARCHAR(36) NOT NULL DEFAULT '',
+    agent_tenant_id INT NOT NULL DEFAULT 0,
+    placement VARCHAR(32) NOT NULL,
+    config_hash VARCHAR(64) NOT NULL,
+    locale VARCHAR(16) NOT NULL DEFAULT '',
+    status VARCHAR(16) NOT NULL,
+    allow_regenerate TINYINT(1) NOT NULL DEFAULT 0,
+    suppression_reason VARCHAR(64) NOT NULL DEFAULT '',
+    questions JSON NOT NULL,
+    model_id VARCHAR(64) NOT NULL DEFAULT '',
+    prompt_tokens INT NOT NULL DEFAULT 0,
+    completion_tokens INT NOT NULL DEFAULT 0,
+    latency_ms BIGINT NOT NULL DEFAULT 0,
+    error_code VARCHAR(64) NOT NULL DEFAULT '',
+    lease_until TIMESTAMP NULL DEFAULT NULL,
+    generated_at TIMESTAMP NULL DEFAULT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_mss_cache (tenant_id, assistant_message_id, placement, config_hash, locale),
+    INDEX idx_mss_session (tenant_id, session_id, created_at),
+    INDEX idx_mss_status (status, lease_until)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS message_suggestion_events (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    tenant_id INT NOT NULL,
+    session_id VARCHAR(36) NOT NULL,
+    suggestion_set_id VARCHAR(36) NOT NULL,
+    question_id VARCHAR(64) NOT NULL DEFAULT '',
+    event_type VARCHAR(32) NOT NULL,
+    actor_id VARCHAR(512) NOT NULL DEFAULT '',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_mse_set (suggestion_set_id, created_at),
+    INDEX idx_mse_session (tenant_id, session_id, created_at),
+    INDEX idx_mse_type (event_type, created_at),
+    CONSTRAINT fk_mse_set FOREIGN KEY (suggestion_set_id) REFERENCES message_suggestion_sets(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS vector_stores (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    engine_type VARCHAR(50) NOT NULL,
+    connection_config JSON,
+    index_config JSON,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+-- MySQL 向量存储表 (BLOB 存储 embedding，Go 端余弦相似度)
+CREATE TABLE IF NOT EXISTS mysql_embeddings (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    source_id VARCHAR(64) NOT NULL,
+    source_type INT NOT NULL,
+    chunk_id VARCHAR(64),
+    knowledge_id VARCHAR(64),
+    knowledge_base_id VARCHAR(64),
+    tag_id VARCHAR(36),
+    content TEXT,
+    dimension INT NOT NULL,
+    embedding LONGBLOB,
+    is_enabled TINYINT(1) DEFAULT 1,
+    UNIQUE KEY uk_mysql_emb_source (source_id, source_type),
+    INDEX idx_mysql_emb_chunk (chunk_id),
+    INDEX idx_mysql_emb_knowledge (knowledge_id),
+    INDEX idx_mysql_emb_kb (knowledge_base_id),
+    INDEX idx_mysql_emb_enabled (is_enabled),
+    FULLTEXT INDEX ft_mysql_emb_content (content) WITH PARSER ngram
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS web_search_providers (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id INT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    provider_type VARCHAR(50) NOT NULL,
+    api_key VARCHAR(512),
+    config JSON,
+    is_enabled TINYINT(1) DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    INDEX idx_wsp_tenant (tenant_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS data_sources (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id INT NOT NULL,
+    knowledge_base_id VARCHAR(36) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    source_type VARCHAR(50) NOT NULL,
+    config JSON,
+    sync_schedule VARCHAR(100),
+    is_enabled TINYINT(1) DEFAULT 1,
+    last_sync_at TIMESTAMP NULL DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    INDEX idx_ds_tenant_kb (tenant_id, knowledge_base_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS tenant_members (
+    user_id VARCHAR(36) NOT NULL,
+    tenant_id INT NOT NULL,
+    role VARCHAR(50) NOT NULL DEFAULT 'member',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (tenant_id, user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS tenant_invitations (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id INT NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    token VARCHAR(255) NOT NULL UNIQUE,
+    role VARCHAR(50) NOT NULL DEFAULT 'member',
+    invited_by VARCHAR(36),
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    expires_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_ti_tenant (tenant_id),
+    INDEX idx_ti_token (token)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS organizations (
+    id VARCHAR(36) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    owner_id VARCHAR(36),
+    tenant_id INT,
+    invite_code VARCHAR(36) UNIQUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS user_kb_pins (
+    user_id VARCHAR(36) NOT NULL,
+    knowledge_base_id VARCHAR(36) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, knowledge_base_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS user_resource_favorites (
+    id VARCHAR(36) PRIMARY KEY,
+    user_id VARCHAR(36) NOT NULL,
+    resource_type VARCHAR(50) NOT NULL,
+    resource_id VARCHAR(36) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_urf_user_res (user_id, resource_type, resource_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id INT NOT NULL,
+    user_id VARCHAR(36),
+    action VARCHAR(100) NOT NULL,
+    resource_type VARCHAR(50),
+    resource_id VARCHAR(36),
+    detail JSON,
+    ip_address VARCHAR(45),
+    user_agent TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_al_tenant_time (tenant_id, created_at),
+    INDEX idx_al_user (user_id),
+    INDEX idx_al_action (action)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS embed_channels (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id INT NOT NULL,
+    knowledge_base_id VARCHAR(36) NOT NULL,
+    name VARCHAR(255),
+    channel_key VARCHAR(64) NOT NULL UNIQUE,
+    rate_limit INT DEFAULT 100,
+    style_config JSON,
+    is_enabled TINYINT(1) DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    INDEX idx_ec_tenant (tenant_id),
+    INDEX idx_ec_key (channel_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS temporary_documents (
+    id VARCHAR(36) PRIMARY KEY,
+    session_id VARCHAR(36) NOT NULL,
+    file_name VARCHAR(255),
+    file_type VARCHAR(50),
+    file_size BIGINT,
+    content TEXT,
+    parse_status VARCHAR(50) DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP,
+    INDEX idx_td_session (session_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS custom_agents (
+    id VARCHAR(36) NOT NULL,
+    tenant_id INT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    agent_type VARCHAR(50) NOT NULL DEFAULT 'custom',
+    config JSON,
+    is_default TINYINT(1) DEFAULT 0,
+    is_active TINYINT(1) DEFAULT 1,
+    creator_id VARCHAR(36),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    PRIMARY KEY (id, tenant_id),
+    INDEX idx_ca_tenant (tenant_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE IF NOT EXISTS knowledge_folders (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id INT NOT NULL,
+    knowledge_base_id VARCHAR(36) NOT NULL,
+    parent_id VARCHAR(36),
+    name VARCHAR(255) NOT NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    INDEX idx_kf_kb (tenant_id, knowledge_base_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
Add MySQL as first-class database driver alongside PostgreSQL and SQLite.

New:
- retriever/mysql/repository.go: stores embeddings as LONGBLOB, computes cosine similarity in Go
- migrations/mysql/00-init-db.sql: 28-table MySQL 8.0 init script

Modified:
- container.go: mysql DSN, dialector whitelist, retriever reg
- migration.go: mysql DSN routing
- chunk.go: MySQL update SQL path (no PG casts)
- vectorstore.go, storagebackend.go: row-locking for mysql
- docker-compose.yml: mysql service + volume
- .env.example: MySQL config docs
- go.mod: gorm.io/driver/mysql v1.6.0

<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

## Type of Change
<!-- Check applicable items -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #1418 

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->

## Checklist
- [ ] `git diff --check origin/main...HEAD` passes
- [ ] Changed source files are formatted
- [ ] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [ ] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
