### PR TITLE
fix(sqlite): filter vector candidates before top-k

### DIFF
--- a/internal/application/repository/retriever/sqlite/repository.go
+++ b/internal/application/repository/retriever/sqlite/repository.go
@@ -434,7 +434,7 @@ func (r *sqliteRepository) vectorRetrieve(ctx context.Context, params types.Retr
 	for i, v := range rows {
 		// cosine distance = 1 - cosine_similarity
 		score := 1 - v.Distance
-		if score < params.Threshold {
+		if params.Threshold > 0 && score < params.Threshold {
 			continue
 		}
 

--- a/internal/application/repository/retriever/sqlite/repository.go
+++ b/internal/application/repository/retriever/sqlite/repository.go
@@ -269,27 +269,17 @@ func (r *sqliteRepository) Retrieve(ctx context.Context, params types.RetrievePa
 	if params.RetrieverType == types.KeywordsRetrieverType || params.RetrieverType == "" {
 		res, err := r.keywordsRetrieve(ctx, params)
 		if err != nil {
-			results = append(results, &types.RetrieveResult{
-				RetrieverEngineType: types.SQLiteRetrieverEngineType,
-				RetrieverType:       types.KeywordsRetrieverType,
-				Error:               err,
-			})
-		} else {
-			results = append(results, res...)
+			return nil, err
 		}
+		results = append(results, res...)
 	}
 
 	if params.RetrieverType == types.VectorRetrieverType || params.RetrieverType == "" {
 		res, err := r.vectorRetrieve(ctx, params)
 		if err != nil {
-			results = append(results, &types.RetrieveResult{
-				RetrieverEngineType: types.SQLiteRetrieverEngineType,
-				RetrieverType:       types.VectorRetrieverType,
-				Error:               err,
-			})
-		} else {
-			results = append(results, res...)
+			return nil, err
 		}
+		results = append(results, res...)
 	}
 
 	return results, nil
@@ -316,7 +306,7 @@ func (r *sqliteRepository) keywordsRetrieve(ctx context.Context, params types.Re
 
 	args := []interface{}{ftsQuery}
 
-	for _, wp := range buildFilterWhere(params) {
+	for _, wp := range buildFilterWhere(params, "e") {
 		sql += " AND " + wp.clause
 		args = append(args, wp.args...)
 	}
@@ -398,7 +388,10 @@ func (r *sqliteRepository) vectorRetrieve(ctx context.Context, params types.Retr
 		JOIN lite_embeddings e ON e.id = v.rowid
 		WHERE v.embedding MATCH ?
 		AND k = ?
-		AND (e.is_enabled IS NULL OR e.is_enabled = 1)
+		AND v.rowid IN (
+			SELECT filtered.id
+			FROM lite_embeddings filtered
+			WHERE (filtered.is_enabled IS NULL OR filtered.is_enabled = 1)
 	`, tbl)
 
 	args := []interface{}{
@@ -407,13 +400,13 @@ func (r *sqliteRepository) vectorRetrieve(ctx context.Context, params types.Retr
 	}
 
 	// 追加过滤条件
-	for _, wp := range buildFilterWhere(params) {
+	for _, wp := range buildFilterWhere(params, "filtered") {
 		vecSQL += " AND " + wp.clause
 		args = append(args, wp.args...)
 	}
 
 	// ⚠️ 这里仍然建议加 ORDER BY，虽然 vec0 已经按距离返回
-	vecSQL += " ORDER BY v.distance ASC"
+	vecSQL += ") ORDER BY v.distance ASC"
 
 	type row struct {
 		Rowid           uint
@@ -441,6 +434,9 @@ func (r *sqliteRepository) vectorRetrieve(ctx context.Context, params types.Retr
 	for i, v := range rows {
 		// cosine distance = 1 - cosine_similarity
 		score := 1 - v.Distance
+		if score < params.Threshold {
+			continue
+		}
 
 		logger.GetLogger(ctx).Infof("[SQLite] vectorRetrieve: #%d chunk_id=%s, distance=%.4f, score=%.4f, content_preview=%.60s",
 			i+1, v.ChunkID, v.Distance, score, v.Content)
@@ -550,23 +546,23 @@ type whereClause struct {
 	args   []interface{}
 }
 
-func buildFilterWhere(params types.RetrieveParams) []whereClause {
+func buildFilterWhere(params types.RetrieveParams, tableAlias string) []whereClause {
 	var parts []whereClause
 	if len(params.KnowledgeBaseIDs) > 0 {
 		parts = append(parts, whereClause{
-			clause: "e.knowledge_base_id IN (" + placeholders(len(params.KnowledgeBaseIDs)) + ")",
+			clause: tableAlias + ".knowledge_base_id IN (" + placeholders(len(params.KnowledgeBaseIDs)) + ")",
 			args:   toInterfaceSlice(params.KnowledgeBaseIDs),
 		})
 	}
 	if len(params.KnowledgeIDs) > 0 {
 		parts = append(parts, whereClause{
-			clause: "e.knowledge_id IN (" + placeholders(len(params.KnowledgeIDs)) + ")",
+			clause: tableAlias + ".knowledge_id IN (" + placeholders(len(params.KnowledgeIDs)) + ")",
 			args:   toInterfaceSlice(params.KnowledgeIDs),
 		})
 	}
 	if len(params.TagIDs) > 0 {
 		parts = append(parts, whereClause{
-			clause: "e.tag_id IN (" + placeholders(len(params.TagIDs)) + ")",
+			clause: tableAlias + ".tag_id IN (" + placeholders(len(params.TagIDs)) + ")",
 			args:   toInterfaceSlice(params.TagIDs),
 		})
 	}

--- a/internal/application/repository/retriever/sqlite/repository_test.go
+++ b/internal/application/repository/retriever/sqlite/repository_test.go
@@ -1,0 +1,167 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	sqlite_vec "github.com/asg017/sqlite-vec-go-bindings/cgo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gormsqlite "gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var registerSQLiteVec sync.Once
+
+func newSQLiteRetrieverTestRepository(t *testing.T) *sqliteRepository {
+	t.Helper()
+	registerSQLiteVec.Do(sqlite_vec.Auto)
+
+	dbName := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	db, err := gorm.Open(gormsqlite.Open(fmt.Sprintf("file:%s?mode=memory&cache=shared", dbName)), &gorm.Config{})
+	require.NoError(t, err)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, sqlDB.Close())
+	})
+
+	repository, ok := NewSQLiteRetrieveEngineRepository(db).(*sqliteRepository)
+	require.True(t, ok)
+	return repository
+}
+
+func saveSQLiteTestVector(t *testing.T, repository *sqliteRepository, info *types.IndexInfo, embedding []float32) {
+	t.Helper()
+	require.NoError(t, repository.Save(context.Background(), info, map[string]any{
+		"embedding": map[string][]float32{info.SourceID: embedding},
+	}))
+}
+
+func sqliteTestIndex(chunkID, knowledgeBaseID, knowledgeID, tagID string, enabled bool) *types.IndexInfo {
+	return &types.IndexInfo{
+		Content:         chunkID,
+		SourceID:        "source-" + chunkID,
+		SourceType:      types.ChunkSourceType,
+		ChunkID:         chunkID,
+		KnowledgeID:     knowledgeID,
+		KnowledgeBaseID: knowledgeBaseID,
+		TagID:           tagID,
+		IsEnabled:       enabled,
+	}
+}
+
+func TestVectorRetrieveFiltersBeforeTopK(t *testing.T) {
+	testCases := []struct {
+		name      string
+		blocker   *types.IndexInfo
+		configure func(*types.RetrieveParams)
+	}{
+		{
+			name:    "knowledge base",
+			blocker: sqliteTestIndex("blocker", "kb-other", "knowledge-target", "tag-target", true),
+			configure: func(params *types.RetrieveParams) {
+				params.KnowledgeBaseIDs = []string{"kb-target"}
+			},
+		},
+		{
+			name:    "knowledge",
+			blocker: sqliteTestIndex("blocker", "kb-target", "knowledge-other", "tag-target", true),
+			configure: func(params *types.RetrieveParams) {
+				params.KnowledgeIDs = []string{"knowledge-target"}
+			},
+		},
+		{
+			name:    "tag",
+			blocker: sqliteTestIndex("blocker", "kb-target", "knowledge-target", "tag-other", true),
+			configure: func(params *types.RetrieveParams) {
+				params.TagIDs = []string{"tag-target"}
+			},
+		},
+		{
+			name:      "enabled status",
+			blocker:   sqliteTestIndex("blocker", "kb-target", "knowledge-target", "tag-target", false),
+			configure: func(_ *types.RetrieveParams) {},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			repository := newSQLiteRetrieverTestRepository(t)
+			saveSQLiteTestVector(t, repository, testCase.blocker, []float32{1, 0})
+			saveSQLiteTestVector(t, repository,
+				sqliteTestIndex("target", "kb-target", "knowledge-target", "tag-target", true),
+				[]float32{0.8, 0.6},
+			)
+
+			params := types.RetrieveParams{
+				Embedding:     []float32{1, 0},
+				TopK:          1,
+				RetrieverType: types.VectorRetrieverType,
+			}
+			testCase.configure(&params)
+
+			results, err := repository.vectorRetrieve(context.Background(), params)
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			require.Len(t, results[0].Results, 1)
+			assert.Equal(t, "target", results[0].Results[0].ChunkID)
+		})
+	}
+}
+
+func TestVectorRetrieveAppliesSimilarityThreshold(t *testing.T) {
+	repository := newSQLiteRetrieverTestRepository(t)
+	saveSQLiteTestVector(t, repository,
+		sqliteTestIndex("below-threshold", "kb-target", "knowledge-target", "tag-target", true),
+		[]float32{0.5, 0.8660254},
+	)
+
+	results, err := repository.vectorRetrieve(context.Background(), types.RetrieveParams{
+		Embedding:        []float32{1, 0},
+		KnowledgeBaseIDs: []string{"kb-target"},
+		TopK:             1,
+		Threshold:        0.75,
+		RetrieverType:    types.VectorRetrieverType,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].Results)
+}
+
+func TestRetrieveReturnsVectorQueryError(t *testing.T) {
+	repository := newSQLiteRetrieverTestRepository(t)
+	saveSQLiteTestVector(t, repository,
+		sqliteTestIndex("chunk", "kb-target", "knowledge-target", "tag-target", true),
+		[]float32{1, 0},
+	)
+	require.NoError(t, repository.db.Exec("DROP TABLE "+vecTableName(2)).Error)
+
+	results, err := repository.Retrieve(context.Background(), types.RetrieveParams{
+		Embedding:     []float32{1, 0},
+		TopK:          1,
+		RetrieverType: types.VectorRetrieverType,
+	})
+	require.Error(t, err)
+	assert.Nil(t, results)
+	assert.Contains(t, err.Error(), "sqlite-vec query failed")
+}
+
+func TestRetrieveReturnsKeywordQueryError(t *testing.T) {
+	repository := newSQLiteRetrieverTestRepository(t)
+	require.NoError(t, repository.db.Exec("DROP TABLE IF EXISTS lite_embeddings_fts").Error)
+
+	results, err := repository.Retrieve(context.Background(), types.RetrieveParams{
+		Query:         "missing fts table",
+		TopK:          1,
+		RetrieverType: types.KeywordsRetrieverType,
+	})
+	require.Error(t, err)
+	assert.Nil(t, results)
+	assert.Contains(t, err.Error(), "FTS5 query failed")
+}

--- a/internal/application/repository/retriever/sqlite/repository_test.go
+++ b/internal/application/repository/retriever/sqlite/repository_test.go
@@ -115,6 +115,27 @@ func TestVectorRetrieveFiltersBeforeTopK(t *testing.T) {
 	}
 }
 
+func TestVectorRetrieveZeroThresholdDoesNotFilter(t *testing.T) {
+	repository := newSQLiteRetrieverTestRepository(t)
+	saveSQLiteTestVector(t, repository,
+		sqliteTestIndex("anti-correlated", "kb-target", "knowledge-target", "tag-target", true),
+		[]float32{-1, 0},
+	)
+
+	results, err := repository.vectorRetrieve(context.Background(), types.RetrieveParams{
+		Embedding:        []float32{1, 0},
+		KnowledgeBaseIDs: []string{"kb-target"},
+		TopK:             1,
+		Threshold:        0,
+		RetrieverType:    types.VectorRetrieverType,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Len(t, results[0].Results, 1)
+	assert.Equal(t, "anti-correlated", results[0].Results[0].ChunkID)
+	assert.Less(t, results[0].Results[0].Score, 0.0)
+}
+
 func TestVectorRetrieveAppliesSimilarityThreshold(t *testing.T) {
 	repository := newSQLiteRetrieverTestRepository(t)
 	saveSQLiteTestVector(t, repository,


### PR DESCRIPTION
## 中文说明

### 问题

SQLite 向量召回原先在 sqlite-vec 完成 TopK 后，才通过 JOIN/WHERE 过滤启用状态、知识库、知识和标签。高相似度但不属于当前查询范围的记录会占满 TopK，导致合法候选被漏召回，甚至返回空结果。

此外还有两个相关问题：

- `Threshold` 未应用于向量召回结果；
- FTS5/sqlite-vec 查询错误被包装进召回结果，调用方可能把执行失败误判为“没有命中”。

### 复现步骤

1. 在同一个 SQLite 向量表中写入两条二维向量：
   - `blocker`：向量 `[1, 0]`，`knowledge_base_id = "kb-other"`，启用；
   - `target`：向量 `[0.8, 0.6]`，`knowledge_base_id = "kb-target"`，启用。
2. 使用向量 `[1, 0]` 发起召回，设置 `KnowledgeBaseIDs = ["kb-target"]`、`TopK = 1`，召回类型为 vector。
3. 旧实现的实际结果：sqlite-vec 先把相似度更高的 `blocker` 选入 TopK，后置知识库过滤再将其移除，最终错误地返回空结果。
4. 预期结果 / 修复后结果：候选集在 TopK 前按知识库过滤，返回合法的 `target`。
5. 将 `blocker` 分别改为禁用、其他 knowledge 或其他 tag，可复现相同的漏召回问题。

### 修复

- 使用 sqlite-vec 支持的 `rowid IN (SELECT ...)` 在 KNN/TopK 阶段约束候选集；
- 对向量结果应用 `score >= Threshold`；
- 将关键词和向量查询错误作为顶层错误返回；
- 为知识库、知识、标签、启用状态的过滤顺序，以及阈值和错误透传增加回归测试。

### 验证

- `go test -count=1 ./internal/application/repository/retriever/sqlite`
- `go test -count=1 -tags sqlite_fts5 ./internal/application/repository/retriever/sqlite`
- `go test -count=1 ./internal/application/service/retriever ./internal/application/service`
- `go vet -tags sqlite_fts5 ./internal/application/repository/retriever/sqlite ./internal/application/service/retriever ./internal/application/service`
- `git diff --check upstream/main...HEAD`

## English

### Problem

SQLite vector retrieval previously applied enabled-status, knowledge-base, knowledge, and tag filters through JOIN/WHERE clauses only after sqlite-vec had already selected the TopK rows. Highly similar rows outside the requested scope could consume the TopK slots, causing valid candidates to be missed or producing an empty result.

Two related issues were also present:

- `Threshold` was not applied to vector retrieval results;
- FTS5/sqlite-vec query failures were embedded in retrieval results, so callers could misinterpret execution failures as “no matches.”

### Reproduction steps

1. Insert two 2D vectors into the same SQLite vector table:
   - `blocker`: embedding `[1, 0]`, `knowledge_base_id = "kb-other"`, enabled;
   - `target`: embedding `[0.8, 0.6]`, `knowledge_base_id = "kb-target"`, enabled.
2. Run vector retrieval with query embedding `[1, 0]`, `KnowledgeBaseIDs = ["kb-target"]`, `TopK = 1`, and retriever type `vector`.
3. Actual result before this fix: sqlite-vec selects the more similar `blocker` into TopK first; the later knowledge-base filter removes it, incorrectly leaving an empty result.
4. Expected result / result after this fix: the candidate set is filtered by knowledge base before TopK, so the valid `target` is returned.
5. The same false-empty result can be reproduced by making `blocker` disabled or assigning it to a different knowledge or tag.

### Fix

- Constrain the sqlite-vec KNN/TopK candidate set with the supported `rowid IN (SELECT ...)` pattern;
- Apply `score >= Threshold` to vector results;
- Return keyword and vector query failures as top-level errors;
- Add regression coverage for knowledge-base, knowledge, tag, and enabled-status filtering order, plus threshold handling and error propagation.

### Verification

- `go test -count=1 ./internal/application/repository/retriever/sqlite`
- `go test -count=1 -tags sqlite_fts5 ./internal/application/repository/retriever/sqlite`
- `go test -count=1 ./internal/application/service/retriever ./internal/application/service`
- `go vet -tags sqlite_fts5 ./internal/application/repository/retriever/sqlite ./internal/application/service/retriever ./internal/application/service`
- `git diff --check upstream/main...HEAD`
