### PR TITLE
fix(frontend): restore audit and KB activity i18n after locale prune

### DIFF
--- a/frontend/src/i18n/auditActionLabel.ts
+++ b/frontend/src/i18n/auditActionLabel.ts
@@ -1,0 +1,22 @@
+import type { Composer } from 'vue-i18n'
+
+import type { FlatKeyBagPath } from './auditActionRegistry.ts'
+
+/**
+ * Resolve a dot-namespaced audit action to its localized label.
+ *
+ * Uses `tm(root)` + flat key lookup because action strings such as
+ * `rbac.member_added` must not be passed to `t()` — vue-i18n would split on
+ * every dot and expect a nested object tree.
+ */
+export function auditActionLabel(
+  i18n: Pick<Composer, 'tm'>,
+  root: FlatKeyBagPath,
+  action: string,
+): string {
+  const bag = i18n.tm(root) as unknown
+  if (bag !== null && typeof bag === 'object' && typeof (bag as Record<string, string>)[action] === 'string') {
+    return (bag as Record<string, string>)[action]
+  }
+  return action
+}

--- a/frontend/src/i18n/auditActionLocaleDefaults.ts
+++ b/frontend/src/i18n/auditActionLocaleDefaults.ts
@@ -1,0 +1,146 @@
+import {
+  AUDIT_ACTION_I18N_ROOTS,
+  KB_ACTIVITY_DETAIL_VALUES,
+  KB_ACTIVITY_I18N_ROOTS,
+  KB_ACTIVITY_OUTCOMES,
+  REGISTERED_AUDIT_ACTION_ENTRIES,
+} from './auditActionRegistry.ts'
+
+/**
+ * Canonical English labels for audit / KB-activity runtime keys.
+ * Used when locale files or git history lack a registered key during prune/regenerate.
+ */
+const TENANT_MEMBER_AUDIT_ACTION_LABELS_EN: Record<string, string> = {
+  'rbac.member_added': 'Member added',
+  'rbac.member_removed': 'Member removed',
+  'rbac.member_role_changed': 'Role changed',
+  'rbac.member_left': 'Member left',
+  'rbac.access_denied': 'Access denied',
+  'rbac.invitation_sent': 'Invitation sent',
+  'rbac.invitation_accepted': 'Invitation accepted',
+  'rbac.invitation_declined': 'Invitation declined',
+  'rbac.invitation_revoked': 'Invitation revoked',
+  'rbac.invitation_expired': 'Invitation expired',
+}
+
+const SYSTEM_GLOBAL_AUDIT_ACTION_LABELS_EN: Record<string, string> = {
+  'system.setting_changed': 'System setting changed',
+  'system.admin_promoted': 'System admin granted',
+  'system.api_key_created': 'Platform API key created',
+  'system.api_key_revoked': 'Platform API key revoked',
+  'system.admin_revoked': 'System admin revoked',
+  'system.user_password_reset': 'User password reset',
+  'system.queue_task_retried': 'Failed task run again',
+  'system.queue_task_deleted': 'Failed task record cleared',
+  'system.queue_task_run_now': 'Queue task run now',
+  'system.queue_task_cancelled': 'Queue task cancelled',
+  'system.queue_archived_purged': 'All failed tasks cleared',
+}
+
+const KB_ACTIVITY_ACTION_LABELS_EN: Record<string, string> = {
+  'kb.created': 'Knowledge base created',
+  'kb.updated': 'Knowledge base updated',
+  'kb.deleted': 'Knowledge base deleted',
+  'kb.duplicated': 'Knowledge base duplicated',
+  'kb.clone_started': 'Clone started',
+  'kb.clone_completed': 'Clone completed',
+  'kb.clone_failed': 'Clone failed',
+  'knowledge.created': 'Knowledge added',
+  'knowledge.updated': 'Knowledge updated',
+  'knowledge.deleted': 'Knowledge deleted',
+  'knowledge.batch_deleted': 'Knowledge batch deleted',
+  'knowledge.reparse_started': 'Reparse started',
+  'knowledge.parse_canceled': 'Parsing canceled',
+  'knowledge.move_started': 'Knowledge move started',
+  'knowledge.move_completed': 'Knowledge move completed',
+  'knowledge.move_failed': 'Knowledge move failed',
+  'tag.created': 'Tag created',
+  'tag.updated': 'Tag updated',
+  'tag.deleted': 'Tag deleted',
+  'datasource.created': 'Data source created',
+  'datasource.updated': 'Data source updated',
+  'datasource.deleted': 'Data source deleted',
+  'datasource.sync_started': 'Data source sync started',
+  'datasource.sync_completed': 'Data source sync completed',
+  'datasource.sync_failed': 'Data source sync failed',
+  'datasource.paused': 'Data source paused',
+  'datasource.resumed': 'Data source resumed',
+  'kb.share_added': 'Share added',
+  'kb.share_permission_changed': 'Share permission changed',
+  'kb.share_removed': 'Share removed',
+  'wiki.content_changed': 'Wiki content changed',
+  'faq.import_started': 'FAQ import started',
+  'faq.import_completed': 'FAQ import completed',
+  'faq.import_failed': 'FAQ import failed',
+}
+
+const KB_ACTIVITY_OUTCOME_LABELS_EN: Record<string, string> = {
+  accepted: 'Accepted',
+  success: 'Success',
+  failed: 'Failed',
+  partial: 'Partial',
+  canceled: 'Canceled',
+  denied: 'Denied',
+}
+
+const KB_ACTIVITY_DETAIL_VALUE_LABELS_EN: Record<string, string> = {
+  user: 'User initiated',
+  manual: 'Manual',
+  schedule: 'Scheduled',
+  system: 'System',
+  pending: 'Pending',
+  completed: 'Completed',
+  partial: 'Partially completed',
+  canceled: 'Canceled',
+  failed: 'Failed',
+  enqueue: 'Task submission',
+  reuse_vectors: 'Reuse vectors',
+  reparse: 'Reparse',
+  viewer: 'Read-only',
+  editor: 'Can edit',
+  admin: 'Manage',
+  append: 'Append',
+  replace: 'Replace',
+}
+
+function flattenBag(root: string, labels: Record<string, string>): Record<string, string> {
+  const flat: Record<string, string> = {}
+  for (const [key, value] of Object.entries(labels)) {
+    flat[`${root}.${key}`] = value
+  }
+  return flat
+}
+
+export const AUDIT_ACTION_LOCALE_DEFAULTS: Readonly<Record<string, string>> = {
+  ...flattenBag(AUDIT_ACTION_I18N_ROOTS.tenantMember, TENANT_MEMBER_AUDIT_ACTION_LABELS_EN),
+  ...flattenBag(AUDIT_ACTION_I18N_ROOTS.systemGlobal, SYSTEM_GLOBAL_AUDIT_ACTION_LABELS_EN),
+  ...flattenBag(AUDIT_ACTION_I18N_ROOTS.kbActivity, KB_ACTIVITY_ACTION_LABELS_EN),
+  ...flattenBag(KB_ACTIVITY_I18N_ROOTS.outcomes, KB_ACTIVITY_OUTCOME_LABELS_EN),
+  ...flattenBag(KB_ACTIVITY_I18N_ROOTS.detailValues, KB_ACTIVITY_DETAIL_VALUE_LABELS_EN),
+}
+
+export function getAuditActionLocaleDefault(path: string): string | undefined {
+  return AUDIT_ACTION_LOCALE_DEFAULTS[path]
+}
+
+/** Verify registry lists and baked-in English defaults stay aligned. */
+export function findAuditActionDefaultRegistryMismatches(): string[] {
+  const failures: string[] = []
+
+  for (const { root, actions } of REGISTERED_AUDIT_ACTION_ENTRIES) {
+    for (const action of actions) {
+      const path = `${root}.${action}`
+      if (!AUDIT_ACTION_LOCALE_DEFAULTS[path]) failures.push(`missing default for ${path}`)
+    }
+  }
+  for (const outcome of KB_ACTIVITY_OUTCOMES) {
+    const path = `${KB_ACTIVITY_I18N_ROOTS.outcomes}.${outcome}`
+    if (!AUDIT_ACTION_LOCALE_DEFAULTS[path]) failures.push(`missing default for ${path}`)
+  }
+  for (const value of KB_ACTIVITY_DETAIL_VALUES) {
+    const path = `${KB_ACTIVITY_I18N_ROOTS.detailValues}.${value}`
+    if (!AUDIT_ACTION_LOCALE_DEFAULTS[path]) failures.push(`missing default for ${path}`)
+  }
+
+  return failures
+}

--- a/frontend/src/i18n/auditActionRegistry.ts
+++ b/frontend/src/i18n/auditActionRegistry.ts
@@ -1,0 +1,137 @@
+/**
+ * Canonical audit / KB-activity action strings and their i18n message roots.
+ *
+ * Action values mirror `internal/types/audit_log.go` (dot-namespaced, e.g.
+ * `kb.created`, `rbac.member_added`). Locale bags under each root must expose
+ * those strings as **flat object keys** (not nested paths) because vue-i18n's
+ * `t('root.kb.created')` would traverse nested objects, while the runtime
+ * value from the API is the literal string `kb.created`.
+ *
+ * Keep this list in sync when adding new AuditAction constants in Go.
+ */
+export const AUDIT_ACTION_I18N_ROOTS = {
+  tenantMember: 'tenantMember.audit.action',
+  systemGlobal: 'system.globalSettings.audit.action',
+  kbActivity: 'knowledgeEditor.activity.actions',
+} as const
+
+/** Workspace membership / invitation audit events (tenantMember drawer). */
+export const TENANT_MEMBER_AUDIT_ACTIONS = [
+  'rbac.member_added',
+  'rbac.member_removed',
+  'rbac.member_role_changed',
+  'rbac.member_left',
+  'rbac.access_denied',
+  'rbac.invitation_sent',
+  'rbac.invitation_accepted',
+  'rbac.invitation_declined',
+  'rbac.invitation_revoked',
+  'rbac.invitation_expired',
+] as const
+
+/** Platform control-plane audit events (system settings → audit tab). */
+export const SYSTEM_GLOBAL_AUDIT_ACTIONS = [
+  'system.setting_changed',
+  'system.admin_promoted',
+  'system.api_key_created',
+  'system.api_key_revoked',
+  'system.admin_revoked',
+  'system.user_password_reset',
+  'system.queue_task_retried',
+  'system.queue_task_deleted',
+  'system.queue_task_run_now',
+  'system.queue_task_cancelled',
+  'system.queue_archived_purged',
+] as const
+
+/** Knowledge-base activity feed (KB settings → activity). */
+export const KB_ACTIVITY_ACTIONS = [
+  'kb.created',
+  'kb.updated',
+  'kb.deleted',
+  'kb.duplicated',
+  'kb.clone_started',
+  'kb.clone_completed',
+  'kb.clone_failed',
+  'knowledge.created',
+  'knowledge.updated',
+  'knowledge.deleted',
+  'knowledge.batch_deleted',
+  'knowledge.reparse_started',
+  'knowledge.parse_canceled',
+  'knowledge.move_started',
+  'knowledge.move_completed',
+  'knowledge.move_failed',
+  'tag.created',
+  'tag.updated',
+  'tag.deleted',
+  'datasource.created',
+  'datasource.updated',
+  'datasource.deleted',
+  'datasource.sync_started',
+  'datasource.sync_completed',
+  'datasource.sync_failed',
+  'datasource.paused',
+  'datasource.resumed',
+  'kb.share_added',
+  'kb.share_permission_changed',
+  'kb.share_removed',
+  'wiki.content_changed',
+  'faq.import_started',
+  'faq.import_completed',
+  'faq.import_failed',
+] as const
+
+/** KB activity outcome column / filter values (`AuditOutcome` subset used in activity UI). */
+export const KB_ACTIVITY_OUTCOMES = [
+  'accepted',
+  'success',
+  'failed',
+  'partial',
+  'canceled',
+  'denied',
+] as const
+
+/** Enum-like detail payload values shown in the activity task drawer. */
+export const KB_ACTIVITY_DETAIL_VALUES = [
+  'user',
+  'manual',
+  'schedule',
+  'system',
+  'pending',
+  'completed',
+  'partial',
+  'canceled',
+  'failed',
+  'enqueue',
+  'reuse_vectors',
+  'reparse',
+  'viewer',
+  'editor',
+  'admin',
+  'append',
+  'replace',
+] as const
+
+export const KB_ACTIVITY_I18N_ROOTS = {
+  outcomes: 'knowledgeEditor.activity.outcomes',
+  detailValues: 'knowledgeEditor.activity.detailValues',
+} as const
+
+/** Locale object paths whose children use flat keys containing dots. */
+export const FLAT_KEY_BAG_PATHS = [
+  AUDIT_ACTION_I18N_ROOTS.tenantMember,
+  AUDIT_ACTION_I18N_ROOTS.systemGlobal,
+  AUDIT_ACTION_I18N_ROOTS.kbActivity,
+] as const
+
+export type FlatKeyBagPath = (typeof FLAT_KEY_BAG_PATHS)[number]
+
+export const REGISTERED_AUDIT_ACTION_ENTRIES: ReadonlyArray<{
+  root: FlatKeyBagPath
+  actions: readonly string[]
+}> = [
+  { root: AUDIT_ACTION_I18N_ROOTS.tenantMember, actions: TENANT_MEMBER_AUDIT_ACTIONS },
+  { root: AUDIT_ACTION_I18N_ROOTS.systemGlobal, actions: SYSTEM_GLOBAL_AUDIT_ACTIONS },
+  { root: AUDIT_ACTION_I18N_ROOTS.kbActivity, actions: KB_ACTIVITY_ACTIONS },
+]

--- a/frontend/src/i18n/localeKeyAudit.test.ts
+++ b/frontend/src/i18n/localeKeyAudit.test.ts
@@ -1,15 +1,20 @@
 import assert from 'node:assert/strict'
 import { before, test } from 'node:test'
 
+import { findAuditActionDefaultRegistryMismatches } from './auditActionLocaleDefaults.ts'
+import { REGISTERED_AUDIT_ACTION_ENTRIES, KB_ACTIVITY_DETAIL_VALUES, KB_ACTIVITY_I18N_ROOTS, KB_ACTIVITY_OUTCOMES } from './auditActionRegistry.ts'
 import {
   CRITICAL_LOCALE_KEYS,
   LOCALE_BUNDLES,
+  alignLocaleBundleToReferenceKeys,
   collectI18nUsageFromSources,
   collectLocaleKeys,
   collectReferencedLocaleKeys,
   diffLocaleKeys,
   findAllLocaleMessageCompileErrors,
   findUsedKeysMissingInLocales,
+  getLocaleValueAtPath,
+  rebuildPrunedLocales,
   type LocaleName,
 } from './localeKeyAudit.ts'
 
@@ -62,6 +67,116 @@ const PARSER_ENGINE_NAMES = [
   'markitdown',
   'opendataloader',
 ] as const
+
+test('registered audit action labels exist as flat keys in every locale', () => {
+  const failures: string[] = []
+
+  for (const { root, actions } of REGISTERED_AUDIT_ACTION_ENTRIES) {
+    for (const action of actions) {
+      const dottedPath = `${root}.${action}`
+      for (const [localeName, bundle] of Object.entries(LOCALE_BUNDLES) as Array<[LocaleName, unknown]>) {
+        const bag = getLocaleValueAtPath(bundle, root)
+        const label =
+          bag !== null && typeof bag === 'object'
+            ? (bag as Record<string, string>)[action]
+            : undefined
+        if (typeof label !== 'string' || !label) {
+          failures.push(`${localeName}: missing flat ${dottedPath}`)
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(failures, [], failures.slice(0, 20).join('\n'))
+})
+
+test('locale alignment preserves flat audit action keys (regenerate safety)', () => {
+  const referenceKeys = collectLocaleKeys(LOCALE_BUNDLES[REFERENCE_LOCALE])
+  const aligned = alignLocaleBundleToReferenceKeys(referenceKeys, LOCALE_BUNDLES['zh-CN'], LOCALE_BUNDLES['en-US'])
+  const failures: string[] = []
+
+  for (const { root, actions } of REGISTERED_AUDIT_ACTION_ENTRIES) {
+    const bag = getLocaleValueAtPath(aligned, root)
+    if (bag == null || typeof bag !== 'object') {
+      failures.push(`zh-CN aligned: missing bag ${root}`)
+      continue
+    }
+    for (const action of actions) {
+      if (typeof (bag as Record<string, unknown>)[action] !== 'string') {
+        failures.push(`zh-CN aligned: missing flat ${root}.${action}`)
+      }
+      const nestedArea = action.split('.')[0]
+      if (
+        nestedArea &&
+        (bag as Record<string, unknown>)[nestedArea] != null &&
+        typeof (bag as Record<string, unknown>)[nestedArea] === 'object'
+      ) {
+        failures.push(`zh-CN aligned: nested corruption under ${root}.${nestedArea}`)
+      }
+    }
+  }
+
+  assert.deepEqual(failures, [], failures.join('\n'))
+})
+
+test('KB activity outcomes and detail values exist in every locale', () => {
+  const failures: string[] = []
+
+  for (const outcome of KB_ACTIVITY_OUTCOMES) {
+    const path = `${KB_ACTIVITY_I18N_ROOTS.outcomes}.${outcome}`
+    for (const [localeName, bundle] of Object.entries(LOCALE_BUNDLES) as Array<[LocaleName, unknown]>) {
+      const label = getLocaleValueAtPath(bundle, path)
+      if (typeof label !== 'string' || !label) failures.push(`${localeName}: missing ${path}`)
+    }
+  }
+
+  for (const value of KB_ACTIVITY_DETAIL_VALUES) {
+    const path = `${KB_ACTIVITY_I18N_ROOTS.detailValues}.${value}`
+    for (const [localeName, bundle] of Object.entries(LOCALE_BUNDLES) as Array<[LocaleName, unknown]>) {
+      const label = getLocaleValueAtPath(bundle, path)
+      if (typeof label !== 'string' || !label) failures.push(`${localeName}: missing ${path}`)
+    }
+  }
+
+  assert.deepEqual(failures, [], failures.slice(0, 20).join('\n'))
+})
+
+test('audit action locale defaults cover the registry', () => {
+  const failures = findAuditActionDefaultRegistryMismatches()
+  assert.deepEqual(failures, [], failures.join('\n'))
+})
+
+test('prune rebuild restores registered audit keys from baked-in English defaults', () => {
+  const usage = collectI18nUsageFromSources()
+  const emptyBundles = {
+    'en-US': {},
+    'zh-CN': {},
+    'ko-KR': {},
+    'ru-RU': {},
+  } as Record<LocaleName, Record<string, unknown>>
+  const rebuilt = rebuildPrunedLocales(emptyBundles, usage)
+  const en = rebuilt['en-US'] as Record<string, unknown>
+  const failures: string[] = []
+
+  for (const { root, actions } of REGISTERED_AUDIT_ACTION_ENTRIES) {
+    const bag = getLocaleValueAtPath(en, root)
+    for (const action of actions) {
+      if (
+        bag == null ||
+        typeof bag !== 'object' ||
+        typeof (bag as Record<string, string>)[action] !== 'string'
+      ) {
+        failures.push(`en-US rebuild: missing ${root}.${action}`)
+      }
+    }
+  }
+
+  assert.deepEqual(failures, [], failures.join('\n'))
+  assert.equal(
+    getLocaleValueAtPath(en, `${KB_ACTIVITY_I18N_ROOTS.outcomes}.success`),
+    'Success',
+  )
+})
 
 test('parser engine display keys exist in every locale', () => {
   const failures: string[] = []

--- a/frontend/src/i18n/localeKeyAudit.ts
+++ b/frontend/src/i18n/localeKeyAudit.ts
@@ -6,6 +6,14 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import { compile, type CompileError } from '@intlify/core-base'
 
+import {
+  FLAT_KEY_BAG_PATHS,
+  KB_ACTIVITY_DETAIL_VALUES,
+  KB_ACTIVITY_I18N_ROOTS,
+  KB_ACTIVITY_OUTCOMES,
+  REGISTERED_AUDIT_ACTION_ENTRIES,
+} from './auditActionRegistry.ts'
+import { AUDIT_ACTION_LOCALE_DEFAULTS, getAuditActionLocaleDefault } from './auditActionLocaleDefaults.ts'
 import { writeLocaleModule } from './localeSerialize.ts'
 
 import enUS from './locales/en-US.ts'
@@ -64,6 +72,8 @@ const EXTRA_PREFIXES = [
   'system.globalSettings.audit.action.',
   'system.globalSettings.audit.actorRole.',
   'knowledgeEditor.activity.detailFields.',
+  'knowledgeEditor.activity.detailValues.',
+  'knowledgeEditor.activity.outcomes.',
   'knowledgeEditor.activity.actions.',
   'knowledgeEditor.activity.targets.',
   'tenantMember.audit.action.',
@@ -553,7 +563,33 @@ export function getLocaleValueAtPath(root: unknown, path: string): unknown {
 
 export function setLocaleValueAtPath(root: LocaleTree, path: string, value: string): void {
   if (!path) return
+  if (setLocaleFlatBagValueIfApplicable(root, path, value)) return
   setLocaleValueAtPathParts(root, path.split('.'), value)
+}
+
+/** Write flat keys (e.g. `kb.created`) under audit action bags without nesting. */
+function setLocaleFlatBagValueIfApplicable(root: LocaleTree, path: string, value: string): boolean {
+  for (const bagPath of FLAT_KEY_BAG_PATHS) {
+    const prefix = `${bagPath}.`
+    if (!path.startsWith(prefix)) continue
+
+    const actionKey = path.slice(prefix.length)
+    if (!actionKey) return false
+
+    const bagParts = bagPath.split('.')
+    let node: Record<string, unknown> = root
+    for (const part of bagParts) {
+      let child = node[part]
+      if (child == null || typeof child !== 'object' || Array.isArray(child)) {
+        child = {}
+        node[part] = child
+      }
+      node = child as Record<string, unknown>
+    }
+    node[actionKey] = value
+    return true
+  }
+  return false
 }
 
 export function mergeLocaleKeysFromSource(
@@ -563,17 +599,32 @@ export function mergeLocaleKeysFromSource(
 ): void {
   for (const key of keys) {
     if (collectLocaleKeys(target).has(key)) continue
-    const value = getLocaleValueAtPath(source, key)
+    const value =
+      getLocaleValueAtPath(source, key) ??
+      getAuditActionLocaleDefault(key) ??
+      AUDIT_ACTION_LOCALE_DEFAULTS[key]
     if (typeof value === 'string') setLocaleValueAtPath(target, key, value)
   }
 }
 
 export function collectRequiredLocaleKeys(usage: I18nUsage, referenceBundle: unknown): Set<string> {
-  return new Set([
+  const required = new Set([
     ...collectReferencedLocaleKeys(referenceBundle, usage),
     ...usage.staticKeys,
     ...CRITICAL_LOCALE_KEYS,
   ])
+
+  for (const { root, actions } of REGISTERED_AUDIT_ACTION_ENTRIES) {
+    for (const action of actions) required.add(`${root}.${action}`)
+  }
+  for (const outcome of KB_ACTIVITY_OUTCOMES) {
+    required.add(`${KB_ACTIVITY_I18N_ROOTS.outcomes}.${outcome}`)
+  }
+  for (const value of KB_ACTIVITY_DETAIL_VALUES) {
+    required.add(`${KB_ACTIVITY_I18N_ROOTS.detailValues}.${value}`)
+  }
+
+  return required
 }
 
 export function alignLocaleBundleToReferenceKeys(
@@ -596,10 +647,10 @@ export function rebuildPrunedLocales(
   const requiredKeys = collectRequiredLocaleKeys(usage, fullBundles['en-US'])
   const enFull = structuredClone(fullBundles['en-US'])
   const enPruned = pruneLocaleTree(enFull, usage)
-  if (!enPruned || typeof enPruned !== 'object' || Array.isArray(enPruned)) {
-    throw new Error('prune removed entire en-US locale bundle')
-  }
-  const enTree = enPruned as LocaleTree
+  const enTree: LocaleTree =
+    enPruned && typeof enPruned === 'object' && !Array.isArray(enPruned)
+      ? (enPruned as LocaleTree)
+      : {}
   mergeLocaleKeysFromSource(enTree, fullBundles['en-US'], requiredKeys)
   const referenceKeys = collectLocaleKeys(enTree)
 
@@ -626,6 +677,18 @@ export function writePrunedLocaleFiles(
 }
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../..')
+
+export async function loadLocaleBundlesFromDisk(
+  localesDir = LOCALES_DIR,
+): Promise<Record<LocaleName, LocaleTree>> {
+  const bundles = {} as Record<LocaleName, LocaleTree>
+  for (const localeName of LOCALE_ORDER) {
+    const filePath = join(localesDir, `${localeName}.ts`)
+    const mod = await import(`${pathToFileURL(filePath).href}?disk=${Date.now()}`)
+    bundles[localeName] = structuredClone(mod.default) as LocaleTree
+  }
+  return bundles
+}
 
 export async function loadFullLocaleBundlesFromGit(
   ref = 'HEAD',
@@ -655,7 +718,7 @@ export async function regeneratePrunedLocaleFiles(localesDir = LOCALES_DIR): Pro
   after: number
 }> {
   const usage = collectI18nUsageFromSources()
-  const sourceBundles = await loadFullLocaleBundlesFromGit()
+  const sourceBundles = await loadLocaleBundlesFromDisk(localesDir)
   const before = collectLocaleKeys(sourceBundles['en-US']).size
   const rebuilt = rebuildPrunedLocales(sourceBundles, usage)
   writePrunedLocaleFiles(rebuilt, localesDir)

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1994,6 +1994,33 @@ export default {
         'faq.import_started': 'FAQ import started',
         'faq.import_completed': 'FAQ import completed',
         'faq.import_failed': 'FAQ import failed'
+      },
+      outcomes: {
+        accepted: 'Accepted',
+        success: 'Success',
+        failed: 'Failed',
+        partial: 'Partial',
+        canceled: 'Canceled',
+        denied: 'Denied'
+      },
+      detailValues: {
+        user: 'User initiated',
+        manual: 'Manual',
+        schedule: 'Scheduled',
+        system: 'System',
+        pending: 'Pending',
+        completed: 'Completed',
+        partial: 'Partially completed',
+        canceled: 'Canceled',
+        failed: 'Failed',
+        enqueue: 'Task submission',
+        reuse_vectors: 'Reuse vectors',
+        reparse: 'Reparse',
+        viewer: 'Read-only',
+        editor: 'Can edit',
+        admin: 'Manage',
+        append: 'Append',
+        replace: 'Replace'
       }
     },
     titleCreate: 'Create Knowledge Base',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -149,18 +149,16 @@ export default {
         denied: '거부'
       },
       action: {
-        rbac: {
-          member_added: '멤버 추가',
-          member_removed: '멤버 제거',
-          member_role_changed: '역할 변경',
-          member_left: '멤버 탈퇴',
-          access_denied: '접근 거부',
-          invitation_sent: '초대 전송',
-          invitation_accepted: '초대 수락',
-          invitation_declined: '초대 거절',
-          invitation_revoked: '초대 취소',
-          invitation_expired: '초대 만료'
-        }
+        'rbac.member_added': '멤버 추가',
+        'rbac.member_removed': '멤버 제거',
+        'rbac.member_role_changed': '역할 변경',
+        'rbac.member_left': '멤버 탈퇴',
+        'rbac.access_denied': '접근 거부',
+        'rbac.invitation_sent': '초대 전송',
+        'rbac.invitation_accepted': '초대 수락',
+        'rbac.invitation_declined': '초대 거절',
+        'rbac.invitation_revoked': '초대 취소',
+        'rbac.invitation_expired': '초대 만료'
       },
       columns: {
         time: '시간',
@@ -2546,19 +2544,17 @@ export default {
           denied: '거부'
         },
         action: {
-          system: {
-            setting_changed: '시스템 설정 변경',
-            admin_promoted: '시스템 관리자 부여',
-            api_key_created: '플랫폼 API 키 생성',
-            api_key_revoked: '플랫폼 API 키 폐기',
-            admin_revoked: '시스템 관리자 회수',
-            user_password_reset: '사용자 비밀번호 재설정',
-            queue_task_retried: '실패 작업 다시 실행',
-            queue_task_deleted: '실패 작업 기록 삭제',
-            queue_task_run_now: '큐 작업 즉시 실행',
-            queue_task_cancelled: '큐 작업 취소',
-            queue_archived_purged: '실패 작업 모두 지우기'
-          }
+          'system.setting_changed': '시스템 설정 변경',
+          'system.admin_promoted': '시스템 관리자 부여',
+          'system.api_key_created': '플랫폼 API 키 생성',
+          'system.api_key_revoked': '플랫폼 API 키 폐기',
+          'system.admin_revoked': '시스템 관리자 회수',
+          'system.user_password_reset': '사용자 비밀번호 재설정',
+          'system.queue_task_retried': '실패 작업 다시 실행',
+          'system.queue_task_deleted': '실패 작업 기록 삭제',
+          'system.queue_task_run_now': '큐 작업 즉시 실행',
+          'system.queue_task_cancelled': '큐 작업 취소',
+          'system.queue_archived_purged': '실패 작업 모두 지우기'
         },
         columns: {
           time: '시간',
@@ -3704,53 +3700,68 @@ export default {
       countItems: '{count}개 항목',
       titleWithCount: '{title} 외 {count}개',
       importSummary: '성공 {success} / 실패 {failed} / 건너뜀 {skipped}',
+      detailValues: {
+        user: '사용자 시작',
+        manual: '수동',
+        schedule: '예약',
+        system: '시스템',
+        pending: '대기 중',
+        completed: '완료',
+        partial: '일부 완료',
+        canceled: '취소됨',
+        failed: '실패',
+        enqueue: '작업 제출',
+        reuse_vectors: '벡터 재사용',
+        reparse: '재분석',
+        viewer: '읽기 전용',
+        editor: '편집 가능',
+        admin: '관리',
+        append: '추가',
+        replace: '덮어쓰기'
+      },
+      outcomes: {
+        accepted: '접수됨',
+        success: '성공',
+        failed: '실패',
+        partial: '일부 완료',
+        canceled: '취소됨',
+        denied: '거부됨'
+      },
       actions: {
-        kb: {
-          created: '지식 베이스 생성',
-          updated: '지식 베이스 업데이트',
-          deleted: '지식 베이스 삭제',
-          duplicated: '지식 베이스 복제',
-          clone_started: '복제 시작',
-          clone_completed: '복제 완료',
-          clone_failed: '복제 실패',
-          share_added: '공유 추가',
-          share_permission_changed: '공유 권한 변경',
-          share_removed: '공유 제거'
-        },
-        knowledge: {
-          created: '지식 추가',
-          updated: '지식 업데이트',
-          deleted: '지식 삭제',
-          batch_deleted: '지식 일괄 삭제',
-          reparse_started: '재분석 시작',
-          parse_canceled: '분석 취소',
-          move_started: '지식 이동 시작',
-          move_completed: '지식 이동 완료',
-          move_failed: '지식 이동 실패'
-        },
-        tag: {
-          created: '태그 생성',
-          updated: '태그 업데이트',
-          deleted: '태그 삭제'
-        },
-        datasource: {
-          created: '데이터 소스 생성',
-          updated: '데이터 소스 업데이트',
-          deleted: '데이터 소스 삭제',
-          sync_started: '데이터 소스 동기화 시작',
-          sync_completed: '데이터 소스 동기화 완료',
-          sync_failed: '데이터 소스 동기화 실패',
-          paused: '데이터 소스 일시 중지',
-          resumed: '데이터 소스 재개'
-        },
-        wiki: {
-          content_changed: 'Wiki 콘텐츠 업데이트'
-        },
-        faq: {
-          import_started: 'FAQ 가져오기 시작',
-          import_completed: 'FAQ 가져오기 완료',
-          import_failed: 'FAQ 가져오기 실패'
-        }
+        'kb.created': '지식 베이스 생성',
+        'kb.updated': '지식 베이스 업데이트',
+        'kb.deleted': '지식 베이스 삭제',
+        'kb.duplicated': '지식 베이스 복제',
+        'kb.clone_started': '복제 시작',
+        'kb.clone_completed': '복제 완료',
+        'kb.clone_failed': '복제 실패',
+        'knowledge.created': '지식 추가',
+        'knowledge.updated': '지식 업데이트',
+        'knowledge.deleted': '지식 삭제',
+        'knowledge.batch_deleted': '지식 일괄 삭제',
+        'knowledge.reparse_started': '재분석 시작',
+        'knowledge.parse_canceled': '분석 취소',
+        'knowledge.move_started': '지식 이동 시작',
+        'knowledge.move_completed': '지식 이동 완료',
+        'knowledge.move_failed': '지식 이동 실패',
+        'tag.created': '태그 생성',
+        'tag.updated': '태그 업데이트',
+        'tag.deleted': '태그 삭제',
+        'datasource.created': '데이터 소스 생성',
+        'datasource.updated': '데이터 소스 업데이트',
+        'datasource.deleted': '데이터 소스 삭제',
+        'datasource.sync_started': '데이터 소스 동기화 시작',
+        'datasource.sync_completed': '데이터 소스 동기화 완료',
+        'datasource.sync_failed': '데이터 소스 동기화 실패',
+        'datasource.paused': '데이터 소스 일시 중지',
+        'datasource.resumed': '데이터 소스 재개',
+        'kb.share_added': '공유 추가',
+        'kb.share_permission_changed': '공유 권한 변경',
+        'kb.share_removed': '공유 제거',
+        'wiki.content_changed': 'Wiki 콘텐츠 업데이트',
+        'faq.import_started': 'FAQ 가져오기 시작',
+        'faq.import_completed': 'FAQ 가져오기 완료',
+        'faq.import_failed': 'FAQ 가져오기 실패'
       },
       detailFields: {
         task_id: '작업 ID',

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -149,18 +149,16 @@ export default {
         denied: 'Отказ'
       },
       action: {
-        rbac: {
-          member_added: 'Добавлен участник',
-          member_removed: 'Удалён участник',
-          member_role_changed: 'Изменение роли',
-          member_left: 'Участник вышел',
-          access_denied: 'Доступ запрещён',
-          invitation_sent: 'Invitation sent',
-          invitation_accepted: 'Invitation accepted',
-          invitation_declined: 'Invitation declined',
-          invitation_revoked: 'Invitation revoked',
-          invitation_expired: 'Invitation expired'
-        }
+        'rbac.member_added': 'Добавлен участник',
+        'rbac.member_removed': 'Удалён участник',
+        'rbac.member_role_changed': 'Изменение роли',
+        'rbac.member_left': 'Участник вышел',
+        'rbac.access_denied': 'Доступ запрещён',
+        'rbac.invitation_sent': 'Приглашение отправлено',
+        'rbac.invitation_accepted': 'Приглашение принято',
+        'rbac.invitation_declined': 'Приглашение отклонено',
+        'rbac.invitation_revoked': 'Приглашение отозвано',
+        'rbac.invitation_expired': 'Приглашение истекло'
       },
       columns: {
         time: 'Время',
@@ -2546,19 +2544,17 @@ export default {
           denied: 'Отказано'
         },
         action: {
-          system: {
-            setting_changed: 'Изменена системная настройка',
-            admin_promoted: 'Выдан системный администратор',
-            api_key_created: 'Создан платформенный API-ключ',
-            api_key_revoked: 'Отозван платформенный API-ключ',
-            admin_revoked: 'Отозван системный администратор',
-            user_password_reset: 'Сброшен пароль пользователя',
-            queue_task_retried: 'Повторно запущена сбойная задача',
-            queue_task_deleted: 'Удалена запись о сбойной задаче',
-            queue_task_run_now: 'Задача очереди запущена сейчас',
-            queue_task_cancelled: 'Задача очереди отменена',
-            queue_archived_purged: 'Очищены все сбойные задачи'
-          }
+          'system.setting_changed': 'Изменена системная настройка',
+          'system.admin_promoted': 'Выдан системный администратор',
+          'system.api_key_created': 'Создан платформенный API-ключ',
+          'system.api_key_revoked': 'Отозван платформенный API-ключ',
+          'system.admin_revoked': 'Отозван системный администратор',
+          'system.user_password_reset': 'Сброшен пароль пользователя',
+          'system.queue_task_retried': 'Повторно запущена сбойная задача',
+          'system.queue_task_deleted': 'Удалена запись о сбойной задаче',
+          'system.queue_task_run_now': 'Задача очереди запущена сейчас',
+          'system.queue_task_cancelled': 'Задача очереди отменена',
+          'system.queue_archived_purged': 'Очищены все сбойные задачи'
         },
         columns: {
           time: 'Время',
@@ -3704,53 +3700,68 @@ export default {
       countItems: '{count} элем.',
       titleWithCount: '{title} и ещё {count}',
       importSummary: 'Успешно {success} / Ошибок {failed} / Пропущено {skipped}',
+      detailValues: {
+        user: 'Запущено пользоватем',
+        manual: 'Вручную',
+        schedule: 'По расписанию',
+        system: 'Система',
+        pending: 'Ожидает',
+        completed: 'Завершено',
+        partial: 'Частично завершено',
+        canceled: 'Отменено',
+        failed: 'Ошибка',
+        enqueue: 'Постановка в очередь',
+        reuse_vectors: 'Повторное использование векторов',
+        reparse: 'Повторный разбор',
+        viewer: 'Только чтение',
+        editor: 'Редактирование',
+        admin: 'Управление',
+        append: 'Добавление',
+        replace: 'Замена'
+      },
+      outcomes: {
+        accepted: 'Принято',
+        success: 'Успешно',
+        failed: 'Ошибка',
+        partial: 'Частично',
+        canceled: 'Отменено',
+        denied: 'Отклонено'
+      },
       actions: {
-        kb: {
-          created: 'База знаний создана',
-          updated: 'База знаний обновлена',
-          deleted: 'База знаний удалена',
-          duplicated: 'База знаний скопирована',
-          clone_started: 'Клонирование начато',
-          clone_completed: 'Клонирование завершено',
-          clone_failed: 'Ошибка клонирования',
-          share_added: 'Общий доступ добавлен',
-          share_permission_changed: 'Права доступа изменены',
-          share_removed: 'Общий доступ удалён'
-        },
-        knowledge: {
-          created: 'Знание добавлено',
-          updated: 'Знание обновлено',
-          deleted: 'Знание удалено',
-          batch_deleted: 'Знания удалены пакетом',
-          reparse_started: 'Повторный разбор начат',
-          parse_canceled: 'Разбор отменён',
-          move_started: 'Перемещение начато',
-          move_completed: 'Перемещение завершено',
-          move_failed: 'Ошибка перемещения'
-        },
-        tag: {
-          created: 'Тег создан',
-          updated: 'Тег обновлён',
-          deleted: 'Тег удалён'
-        },
-        datasource: {
-          created: 'Источник данных создан',
-          updated: 'Источник данных обновлён',
-          deleted: 'Источник данных удалён',
-          sync_started: 'Синхронизация начата',
-          sync_completed: 'Синхронизация завершена',
-          sync_failed: 'Ошибка синхронизации',
-          paused: 'Источник приостановлен',
-          resumed: 'Источник возобновлён'
-        },
-        wiki: {
-          content_changed: 'Содержимое Wiki обновлено'
-        },
-        faq: {
-          import_started: 'Импорт FAQ начат',
-          import_completed: 'Импорт FAQ завершён',
-          import_failed: 'Ошибка импорта FAQ'
-        }
+        'kb.created': 'База знаний создана',
+        'kb.updated': 'База знаний обновлена',
+        'kb.deleted': 'База знаний удалена',
+        'kb.duplicated': 'База знаний скопирована',
+        'kb.clone_started': 'Клонирование начато',
+        'kb.clone_completed': 'Клонирование завершено',
+        'kb.clone_failed': 'Ошибка клонирования',
+        'knowledge.created': 'Знание добавлено',
+        'knowledge.updated': 'Знание обновлено',
+        'knowledge.deleted': 'Знание удалено',
+        'knowledge.batch_deleted': 'Знания удалены пакетом',
+        'knowledge.reparse_started': 'Повторный разбор начат',
+        'knowledge.parse_canceled': 'Разбор отменён',
+        'knowledge.move_started': 'Перемещение начато',
+        'knowledge.move_completed': 'Перемещение завершено',
+        'knowledge.move_failed': 'Ошибка перемещения',
+        'tag.created': 'Тег создан',
+        'tag.updated': 'Тег обновлён',
+        'tag.deleted': 'Тег удалён',
+        'datasource.created': 'Источник данных создан',
+        'datasource.updated': 'Источник данных обновлён',
+        'datasource.deleted': 'Источник данных удалён',
+        'datasource.sync_started': 'Синхронизация начата',
+        'datasource.sync_completed': 'Синхронизация завершена',
+        'datasource.sync_failed': 'Ошибка синхронизации',
+        'datasource.paused': 'Источник приостановлен',
+        'datasource.resumed': 'Источник возобновлён',
+        'kb.share_added': 'Общий доступ добавлен',
+        'kb.share_permission_changed': 'Права доступа изменены',
+        'kb.share_removed': 'Общий доступ удалён',
+        'wiki.content_changed': 'Содержимое Wiki обновлено',
+        'faq.import_started': 'Импорт FAQ начат',
+        'faq.import_completed': 'Импорт FAQ завершён',
+        'faq.import_failed': 'Ошибка импорта FAQ'
       },
       detailFields: {
         task_id: 'ID задачи',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -149,18 +149,16 @@ export default {
         denied: '拒绝'
       },
       action: {
-        rbac: {
-          member_added: '新增成员',
-          member_removed: '移除成员',
-          member_role_changed: '角色变更',
-          member_left: '成员退出',
-          access_denied: '访问被拒',
-          invitation_sent: '发出邀请',
-          invitation_accepted: '接受邀请',
-          invitation_declined: '拒绝邀请',
-          invitation_revoked: '撤销邀请',
-          invitation_expired: '邀请过期'
-        }
+        'rbac.member_added': '新增成员',
+        'rbac.member_removed': '移除成员',
+        'rbac.member_role_changed': '角色变更',
+        'rbac.member_left': '成员退出',
+        'rbac.access_denied': '访问被拒',
+        'rbac.invitation_sent': '发出邀请',
+        'rbac.invitation_accepted': '接受邀请',
+        'rbac.invitation_declined': '拒绝邀请',
+        'rbac.invitation_revoked': '撤销邀请',
+        'rbac.invitation_expired': '邀请过期'
       },
       columns: {
         time: '时间',
@@ -2546,19 +2544,17 @@ export default {
           denied: '拒绝'
         },
         action: {
-          system: {
-            setting_changed: '系统设置变更',
-            admin_promoted: '授予系统管理员',
-            api_key_created: '创建平台 API Key',
-            api_key_revoked: '吊销平台 API Key',
-            admin_revoked: '回收系统管理员',
-            user_password_reset: '重置用户密码',
-            queue_task_retried: '重新执行失败任务',
-            queue_task_deleted: '清除失败任务记录',
-            queue_task_run_now: '立即执行队列任务',
-            queue_task_cancelled: '终止队列任务',
-            queue_archived_purged: '清除全部失败任务'
-          }
+          'system.setting_changed': '系统设置变更',
+          'system.admin_promoted': '授予系统管理员',
+          'system.api_key_created': '创建平台 API Key',
+          'system.api_key_revoked': '吊销平台 API Key',
+          'system.admin_revoked': '回收系统管理员',
+          'system.user_password_reset': '重置用户密码',
+          'system.queue_task_retried': '重新执行失败任务',
+          'system.queue_task_deleted': '清除失败任务记录',
+          'system.queue_task_run_now': '立即执行队列任务',
+          'system.queue_task_cancelled': '终止队列任务',
+          'system.queue_archived_purged': '清除全部失败任务'
         },
         columns: {
           time: '时间',
@@ -3704,53 +3700,68 @@ export default {
       countItems: '共 {count} 项',
       titleWithCount: '{title} 等 {count} 项',
       importSummary: '成功 {success} / 失败 {failed} / 跳过 {skipped}',
+      detailValues: {
+        user: '用户发起',
+        manual: '手动触发',
+        schedule: '定时调度',
+        system: '系统触发',
+        pending: '待处理',
+        completed: '已完成',
+        partial: '部分完成',
+        canceled: '已取消',
+        failed: '失败',
+        enqueue: '任务提交',
+        reuse_vectors: '复用向量',
+        reparse: '重新解析',
+        viewer: '只读',
+        editor: '可编辑',
+        admin: '管理',
+        append: '追加',
+        replace: '覆盖'
+      },
+      outcomes: {
+        accepted: '已受理',
+        success: '成功',
+        failed: '失败',
+        partial: '部分完成',
+        canceled: '已取消',
+        denied: '已拒绝'
+      },
       actions: {
-        kb: {
-          created: '创建知识库',
-          updated: '更新知识库',
-          deleted: '删除知识库',
-          duplicated: '复制知识库',
-          clone_started: '开始克隆',
-          clone_completed: '完成克隆',
-          clone_failed: '克隆失败',
-          share_added: '添加共享',
-          share_permission_changed: '修改共享权限',
-          share_removed: '移除共享'
-        },
-        knowledge: {
-          created: '添加知识',
-          updated: '更新知识',
-          deleted: '删除知识',
-          batch_deleted: '批量删除知识',
-          reparse_started: '开始重新解析',
-          parse_canceled: '取消解析',
-          move_started: '开始移动知识',
-          move_completed: '完成移动知识',
-          move_failed: '移动知识失败'
-        },
-        tag: {
-          created: '创建标签',
-          updated: '更新标签',
-          deleted: '删除标签'
-        },
-        datasource: {
-          created: '创建数据源',
-          updated: '更新数据源',
-          deleted: '删除数据源',
-          sync_started: '开始同步数据源',
-          sync_completed: '数据源同步完成',
-          sync_failed: '数据源同步失败',
-          paused: '暂停数据源',
-          resumed: '恢复数据源'
-        },
-        wiki: {
-          content_changed: '更新 Wiki 内容'
-        },
-        faq: {
-          import_started: '开始导入 FAQ',
-          import_completed: '完成导入 FAQ',
-          import_failed: '导入 FAQ 失败'
-        }
+        'kb.created': '创建知识库',
+        'kb.updated': '更新知识库',
+        'kb.deleted': '删除知识库',
+        'kb.duplicated': '复制知识库',
+        'kb.clone_started': '开始克隆',
+        'kb.clone_completed': '完成克隆',
+        'kb.clone_failed': '克隆失败',
+        'knowledge.created': '添加知识',
+        'knowledge.updated': '更新知识',
+        'knowledge.deleted': '删除知识',
+        'knowledge.batch_deleted': '批量删除知识',
+        'knowledge.reparse_started': '开始重新解析',
+        'knowledge.parse_canceled': '取消解析',
+        'knowledge.move_started': '开始移动知识',
+        'knowledge.move_completed': '完成移动知识',
+        'knowledge.move_failed': '移动知识失败',
+        'tag.created': '创建标签',
+        'tag.updated': '更新标签',
+        'tag.deleted': '删除标签',
+        'datasource.created': '创建数据源',
+        'datasource.updated': '更新数据源',
+        'datasource.deleted': '删除数据源',
+        'datasource.sync_started': '开始同步数据源',
+        'datasource.sync_completed': '数据源同步完成',
+        'datasource.sync_failed': '数据源同步失败',
+        'datasource.paused': '暂停数据源',
+        'datasource.resumed': '恢复数据源',
+        'kb.share_added': '添加共享',
+        'kb.share_permission_changed': '修改共享权限',
+        'kb.share_removed': '移除共享',
+        'wiki.content_changed': '更新 Wiki 内容',
+        'faq.import_started': '开始导入 FAQ',
+        'faq.import_completed': '完成导入 FAQ',
+        'faq.import_failed': '导入 FAQ 失败'
       },
       detailFields: {
         task_id: '任务 ID',

--- a/frontend/src/views/knowledge/settings/KnowledgeBaseActivitySettings.vue
+++ b/frontend/src/views/knowledge/settings/KnowledgeBaseActivitySettings.vue
@@ -261,6 +261,8 @@
 import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import SettingDrawer from '@/components/settings/SettingDrawer.vue'
+import { AUDIT_ACTION_I18N_ROOTS } from '@/i18n/auditActionRegistry'
+import { auditActionLabel } from '@/i18n/auditActionLabel'
 import { listKnowledgeBaseActivity, type KnowledgeBaseActivity } from '@/api/knowledge-base'
 import type { AuditOutcome } from '@/api/tenant/audit-log'
 import { useAuthStore } from '@/stores/auth'
@@ -401,11 +403,7 @@ function details(entry: KnowledgeBaseActivity): Record<string, unknown> {
 }
 
 function actionLabel(action: string): string {
-  const bag = tm('knowledgeEditor.activity.actions') as unknown
-  if (bag !== null && typeof bag === 'object' && typeof (bag as Record<string, string>)[action] === 'string') {
-    return (bag as Record<string, string>)[action]
-  }
-  return action
+  return auditActionLabel({ tm }, AUDIT_ACTION_I18N_ROOTS.kbActivity, action)
 }
 
 function outcomeLabel(value: AuditOutcome): string {

--- a/frontend/src/views/settings/TenantMembers.vue
+++ b/frontend/src/views/settings/TenantMembers.vue
@@ -515,6 +515,8 @@ import { computed, nextTick, onUnmounted, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { useAuthStore } from '@/stores/auth'
+import { AUDIT_ACTION_I18N_ROOTS } from '@/i18n/auditActionRegistry'
+import { auditActionLabel } from '@/i18n/auditActionLabel'
 import {
   listMembers,
   updateMemberRole,
@@ -1052,11 +1054,7 @@ function auditOutcomeTheme(o: AuditOutcome): 'success' | 'danger' | 'default' {
 // i18n 键名含点号（rbac.member_added）。用 t(path) 会按路径拆开解析，
 // 无法命中 tenantMember.audit.action['rbac.*'] — 必须用 tm + 字面量键。
 function formatAuditAction(action: AuditAction): string {
-  const bag = tm('tenantMember.audit.action') as unknown
-  if (bag !== null && typeof bag === 'object' && typeof (bag as Record<string, string>)[action] === 'string') {
-    return (bag as Record<string, string>)[action]
-  }
-  return action
+  return auditActionLabel({ tm }, AUDIT_ACTION_I18N_ROOTS.tenantMember, action)
 }
 
 // Resolve a user id to a display label: prefer current页的 members，

--- a/frontend/src/views/system/SystemAuditLog.vue
+++ b/frontend/src/views/system/SystemAuditLog.vue
@@ -180,6 +180,8 @@ import {
   type AuditOutcome,
 } from '@/api/system'
 import SettingDrawer from '@/components/settings/SettingDrawer.vue'
+import { AUDIT_ACTION_I18N_ROOTS } from '@/i18n/auditActionRegistry'
+import { auditActionLabel } from '@/i18n/auditActionLabel'
 import { useAuthStore } from '@/stores/auth'
 
 interface AuditDetailField {
@@ -274,11 +276,7 @@ function auditOutcomeTheme(o: AuditOutcome): 'success' | 'danger' | 'default' {
 }
 
 function formatAuditAction(action: AuditAction): string {
-  const bag = tm('system.globalSettings.audit.action') as unknown
-  if (bag !== null && typeof bag === 'object' && typeof (bag as Record<string, string>)[action] === 'string') {
-    return (bag as Record<string, string>)[action]
-  }
-  return action
+  return auditActionLabel({ tm }, AUDIT_ACTION_I18N_ROOTS.systemGlobal, action)
 }
 
 function auditActorLabel(userId: string): string {


### PR DESCRIPTION
## Summary

- Restore flat-key i18n labels for knowledge-base activity events, tenant audit logs, and platform audit logs that were dropped or nested incorrectly during locale pruning.
- Add `auditActionRegistry`, `auditActionLocaleDefaults`, and `auditActionLabel` so audit action strings stay aligned with backend `AuditAction` values and share one lookup path across the UI.
- Harden `regenerate-i18n-locales` to read the working-tree locale files (not git HEAD), preserve dot-containing flat keys during alignment, and backfill registered audit keys from baked-in English defaults when missing.

## Test plan

- [x] `cd frontend && npm run check-i18n`
- [x] `cd frontend && npm run regenerate-i18n-locales` then re-run `npm run check-i18n`
- [ ] Open KB settings → Activity and verify action/outcome labels render in zh-CN / en-US
- [ ] Open tenant Members → Audit log and verify event names are localized
- [ ] Open system settings → Audit log and verify platform event names are localized