### PR TITLE
Feat/content addressed chunk

### DIFF
--- a/internal/application/repository/content_cache.go
+++ b/internal/application/repository/content_cache.go
@@ -1,0 +1,89 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// contentCacheRepository implements the ContentCacheRepository interface.
+type contentCacheRepository struct {
+	db *gorm.DB
+}
+
+// NewContentCacheRepository creates a new content cache repository.
+func NewContentCacheRepository(db *gorm.DB) interfaces.ContentCacheRepository {
+	return &contentCacheRepository{db: db}
+}
+
+// Get retrieves a cached payload by key.
+func (r *contentCacheRepository) Get(ctx context.Context, cacheKey string) ([]byte, bool, error) {
+	var row types.ContentCache
+	err := r.db.WithContext(ctx).
+		Where("cache_key = ?", cacheKey).
+		First(&row).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return []byte(row.Payload), true, nil
+}
+
+// Set upserts a payload for a key. Upsert (rather than insert) keeps the
+// operation race-safe: two workers computing the same key concurrently end
+// with one row holding an equivalent payload.
+func (r *contentCacheRepository) Set(ctx context.Context, cacheKey, kind string, payload []byte) error {
+	if len(payload) > types.ContentCachePayloadMaxBytes {
+		return nil
+	}
+	now := time.Now()
+	row := types.ContentCache{
+		CacheKey:  cacheKey,
+		Kind:      kind,
+		Payload:   string(payload),
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "cache_key"}},
+		DoUpdates: clause.AssignmentColumns([]string{"kind", "payload", "updated_at"}),
+	}).Create(&row).Error
+}
+
+// Delete removes a single cache row.
+func (r *contentCacheRepository) Delete(ctx context.Context, cacheKey string) error {
+	return r.db.WithContext(ctx).
+		Where("cache_key = ?", cacheKey).
+		Delete(&types.ContentCache{}).Error
+}
+
+// PruneBefore deletes rows updated before the given time, in bounded batches.
+func (r *contentCacheRepository) PruneBefore(ctx context.Context, before time.Time, limit int) (int, error) {
+	if limit <= 0 {
+		limit = 1000
+	}
+	var keys []string
+	if err := r.db.WithContext(ctx).
+		Model(&types.ContentCache{}).
+		Where("updated_at < ?", before).
+		Limit(limit).
+		Pluck("cache_key", &keys).Error; err != nil {
+		return 0, err
+	}
+	if len(keys) == 0 {
+		return 0, nil
+	}
+	if err := r.db.WithContext(ctx).
+		Where("cache_key IN ?", keys).
+		Delete(&types.ContentCache{}).Error; err != nil {
+		return 0, err
+	}
+	return len(keys), nil
+}

--- a/internal/application/repository/content_cache_test.go
+++ b/internal/application/repository/content_cache_test.go
@@ -1,0 +1,97 @@
+package repository
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupContentCacheTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.ContentCache{}))
+	return db
+}
+
+func TestContentCache_SetGetAndUpsert(t *testing.T) {
+	db := setupContentCacheTestDB(t)
+	repo := NewContentCacheRepository(db)
+	ctx := context.Background()
+
+	// Missing key -> found=false, no error.
+	_, found, err := repo.Get(ctx, "missing")
+	require.NoError(t, err)
+	assert.False(t, found)
+
+	require.NoError(t, repo.Set(ctx, "k1", types.ContentCacheKindEmbedding, []byte(`[1,2,3]`)))
+
+	payload, found, err := repo.Get(ctx, "k1")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, `[1,2,3]`, string(payload))
+
+	// Upsert replaces the payload in place.
+	require.NoError(t, repo.Set(ctx, "k1", types.ContentCacheKindEmbedding, []byte(`[4,5]`)))
+	payload, found, _ = repo.Get(ctx, "k1")
+	require.True(t, found)
+	assert.Equal(t, `[4,5]`, string(payload))
+
+	// Kind is persisted (used for observability / future sweep tooling).
+	var row types.ContentCache
+	require.NoError(t, db.Where("cache_key = ?", "k1").First(&row).Error)
+	assert.Equal(t, types.ContentCacheKindEmbedding, row.Kind)
+}
+
+func TestContentCache_SetSkipsOversizedPayload(t *testing.T) {
+	db := setupContentCacheTestDB(t)
+	repo := NewContentCacheRepository(db)
+	ctx := context.Background()
+
+	big := strings.Repeat("x", types.ContentCachePayloadMaxBytes+1)
+	require.NoError(t, repo.Set(ctx, "big", types.ContentCacheKindVLM, []byte(big)))
+	_, found, err := repo.Get(ctx, "big")
+	require.NoError(t, err)
+	assert.False(t, found, "oversized payloads must not be persisted")
+}
+
+func TestContentCache_PruneBefore(t *testing.T) {
+	db := setupContentCacheTestDB(t)
+	repo := NewContentCacheRepository(db)
+	ctx := context.Background()
+
+	require.NoError(t, repo.Set(ctx, "old", types.ContentCacheKindVLM, []byte(`a`)))
+	require.NoError(t, repo.Set(ctx, "new", types.ContentCacheKindVLM, []byte(`b`)))
+	// Age only the "old" row.
+	require.NoError(t, db.Model(&types.ContentCache{}).
+		Where("cache_key = ?", "old").
+		Update("updated_at", time.Now().Add(-48*time.Hour)).Error)
+
+	n, err := repo.PruneBefore(ctx, time.Now().Add(-24*time.Hour), 10)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	_, found, _ := repo.Get(ctx, "old")
+	assert.False(t, found)
+	_, found, _ = repo.Get(ctx, "new")
+	assert.True(t, found)
+}
+
+func TestContentCache_Delete(t *testing.T) {
+	db := setupContentCacheTestDB(t)
+	repo := NewContentCacheRepository(db)
+	ctx := context.Background()
+
+	require.NoError(t, repo.Set(ctx, "k", types.ContentCacheKindQuestion, []byte(`["q"]`)))
+	require.NoError(t, repo.Delete(ctx, "k"))
+	_, found, err := repo.Get(ctx, "k")
+	require.NoError(t, err)
+	assert.False(t, found)
+}

--- a/internal/application/service/cache_util.go
+++ b/internal/application/service/cache_util.go
@@ -1,0 +1,174 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+// contentCache is the shared JSON wrapper around the content-addressed cache
+// store. It is nil-safe: a service constructed without a cache repo (test
+// harness / minimal wiring) behaves as a permanent cache miss, so caching is
+// strictly additive and never changes behavior when the store is absent.
+type contentCache struct {
+	repo interfaces.ContentCacheRepository
+}
+
+// get loads the cached payload for key into out. Returns true on a hit.
+// Corrupt payloads are treated as misses (they will be recomputed and
+// overwritten on the next Set).
+func (c *contentCache) get(ctx context.Context, key string, out any) (bool, error) {
+	if c == nil || c.repo == nil {
+		return false, nil
+	}
+	payload, found, err := c.repo.Get(ctx, key)
+	if err != nil {
+		logger.Warnf(ctx, "content cache get failed for %q: %v", key, err)
+		return false, nil
+	}
+	if !found {
+		return false, nil
+	}
+	if err := json.Unmarshal(payload, out); err != nil {
+		logger.Warnf(ctx, "content cache payload corrupt for %q: %v (will recompute)", key, err)
+		return false, nil
+	}
+	return true, nil
+}
+
+// set stores the JSON encoding of in under key. Best-effort: failures are
+// logged and never propagated, so a broken cache cannot fail the pipeline.
+func (c *contentCache) set(ctx context.Context, key, kind string, in any) {
+	if c == nil || c.repo == nil {
+		return
+	}
+	payload, err := json.Marshal(in)
+	if err != nil {
+		logger.Warnf(ctx, "content cache marshal failed for %q: %v", key, err)
+		return
+	}
+	if err := c.repo.Set(ctx, key, kind, payload); err != nil {
+		logger.Warnf(ctx, "content cache set failed for %q: %v", key, err)
+	}
+}
+
+// cachingEmbedder wraps an embedding.Embedder with a content-addressed cache.
+// Embedding is a pure function of (normalized text, model, dimensions), so two
+// ingestion runs over the same text with the same model produce the same
+// vector. The wrapper sits OUTSIDE the concurrency/debug/langfuse decorators
+// (mirroring how the retrieve engine consumes an Embedder), and forwards
+// BatchEmbedWithPool through so the pooler's per-sub-batch callbacks land on
+// the caching BatchEmbed.
+type cachingEmbedder struct {
+	inner embedding.Embedder
+	cache *contentCache
+}
+
+// embeddingCacheKey derives the cache key for a normalized embedding input.
+// The model id and dimensions are part of the key so switching the embedding
+// model invalidates exactly the vector layer (VLM/Wiki map caches survive).
+func embeddingCacheKey(modelID string, dims int, text string) string {
+	return types.ContentCacheKey(types.ContentCacheKindEmbedding,
+		modelID, itoa(dims), text)
+}
+
+func (w *cachingEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	key := embeddingCacheKey(w.inner.GetModelID(), w.inner.GetDimensions(), text)
+	var cached []float32
+	if hit, _ := w.cache.get(ctx, key, &cached); hit && len(cached) > 0 {
+		return cached, nil
+	}
+	vec, err := w.inner.Embed(ctx, text)
+	if err != nil {
+		return nil, err
+	}
+	w.cache.set(ctx, key, types.ContentCacheKindEmbedding, vec)
+	return vec, nil
+}
+
+func (w *cachingEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	results := make([][]float32, len(texts))
+	missing := make([]int, 0, len(texts))
+	modelID := w.inner.GetModelID()
+	dims := w.inner.GetDimensions()
+	for i, text := range texts {
+		var cached []float32
+		if hit, _ := w.cache.get(ctx, embeddingCacheKey(modelID, dims, text), &cached); hit && len(cached) > 0 {
+			results[i] = cached
+			continue
+		}
+		missing = append(missing, i)
+	}
+	if len(missing) == 0 {
+		return results, nil
+	}
+	missTexts := make([]string, len(missing))
+	for k, idx := range missing {
+		missTexts[k] = texts[idx]
+	}
+	computed, err := w.inner.BatchEmbed(ctx, missTexts)
+	if err != nil {
+		return nil, err
+	}
+	for k, idx := range missing {
+		results[idx] = computed[k]
+		w.cache.set(ctx, embeddingCacheKey(modelID, dims, texts[idx]), types.ContentCacheKindEmbedding, computed[k])
+	}
+	return results, nil
+}
+
+func (w *cachingEmbedder) BatchEmbedWithPool(ctx context.Context, model embedding.Embedder, texts []string) ([][]float32, error) {
+	return w.inner.BatchEmbedWithPool(ctx, w, texts)
+}
+
+func (w *cachingEmbedder) GetModelName() string { return w.inner.GetModelName() }
+func (w *cachingEmbedder) GetDimensions() int   { return w.inner.GetDimensions() }
+func (w *cachingEmbedder) GetModelID() string   { return w.inner.GetModelID() }
+
+// withEmbeddingCache wraps an embedder with the content-addressed cache when a
+// cache store is available. nil inputs (no embedding model configured) pass
+// through unchanged.
+func (c *contentCache) wrapEmbedder(e embedding.Embedder) embedding.Embedder {
+	if e == nil || c == nil || c.repo == nil {
+		return e
+	}
+	return &cachingEmbedder{inner: e, cache: c}
+}
+
+// itoa is a small int formatter for cache key parts (avoids importing strconv
+// in every call site of the key builders).
+func itoa(v int) string {
+	if v == 0 {
+		return "0"
+	}
+	neg := v < 0
+	if neg {
+		v = -v
+	}
+	var b [20]byte
+	i := len(b)
+	for v > 0 {
+		i--
+		b[i] = byte('0' + v%10)
+		v /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}
+
+// promptFingerprint hashes prompt text so edits to built-in or configured
+// prompts automatically invalidate every cache layer that consumed them.
+func promptFingerprint(parts ...string) string {
+	return strings.Join(parts, "\x00")
+}

--- a/internal/application/service/cache_util_test.go
+++ b/internal/application/service/cache_util_test.go
@@ -1,0 +1,200 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// memCacheRepo is an in-memory ContentCacheRepository for service-level tests.
+type memCacheRepo struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newMemCacheRepo() *memCacheRepo { return &memCacheRepo{m: map[string][]byte{}} }
+
+func (r *memCacheRepo) Get(_ context.Context, key string) ([]byte, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	v, ok := r.m[key]
+	return v, ok, nil
+}
+
+func (r *memCacheRepo) Set(_ context.Context, key, _ string, payload []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.m[key] = payload
+	return nil
+}
+
+func (r *memCacheRepo) Delete(_ context.Context, key string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.m, key)
+	return nil
+}
+
+func (r *memCacheRepo) PruneBefore(_ context.Context, _ time.Time, _ int) (int, error) { return 0, nil }
+
+// fakeEmbedder counts provider calls so tests can assert cache hits.
+type fakeEmbedder struct {
+	modelID   string
+	dims      int
+	callCount int
+}
+
+func (f *fakeEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
+	f.callCount++
+	return []float32{float32(len(text))}, nil
+}
+
+func (f *fakeEmbedder) BatchEmbed(_ context.Context, texts []string) ([][]float32, error) {
+	f.callCount += len(texts)
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		out[i] = []float32{float32(len(t))}
+	}
+	return out, nil
+}
+
+func (f *fakeEmbedder) BatchEmbedWithPool(_ context.Context, model embedding.Embedder, texts []string) ([][]float32, error) {
+	return model.BatchEmbed(context.Background(), texts)
+}
+
+func (f *fakeEmbedder) GetModelName() string { return "fake-model" }
+func (f *fakeEmbedder) GetDimensions() int   { return f.dims }
+func (f *fakeEmbedder) GetModelID() string   { return f.modelID }
+
+func TestCachingEmbedder_EmbedHitsCache(t *testing.T) {
+	cache := &contentCache{repo: newMemCacheRepo()}
+	inner := &fakeEmbedder{modelID: "emb-a", dims: 3}
+	wrapped := cache.wrapEmbedder(inner)
+	require.NotNil(t, wrapped)
+
+	ctx := context.Background()
+	v1, err := wrapped.Embed(ctx, "hello world")
+	require.NoError(t, err)
+	v2, err := wrapped.Embed(ctx, "hello world")
+	require.NoError(t, err)
+	assert.Equal(t, v1, v2)
+	assert.Equal(t, 1, inner.callCount, "second Embed must be served from cache")
+
+	// A different text is a miss.
+	_, err = wrapped.Embed(ctx, "different text")
+	require.NoError(t, err)
+	assert.Equal(t, 2, inner.callCount)
+}
+
+func TestCachingEmbedder_ModelInKey(t *testing.T) {
+	cache := &contentCache{repo: newMemCacheRepo()}
+	innerA := &fakeEmbedder{modelID: "emb-a", dims: 3}
+	innerB := &fakeEmbedder{modelID: "emb-b", dims: 3}
+	wrappedA := cache.wrapEmbedder(innerA)
+	wrappedB := cache.wrapEmbedder(innerB)
+
+	ctx := context.Background()
+	_, _ = wrappedA.Embed(ctx, "same text")
+	_, _ = wrappedB.Embed(ctx, "same text")
+	assert.Equal(t, 1, innerA.callCount)
+	assert.Equal(t, 1, innerB.callCount, "different model must not share embedding cache")
+}
+
+func TestCachingEmbedder_BatchEmbedPartialHit(t *testing.T) {
+	cache := &contentCache{repo: newMemCacheRepo()}
+	inner := &fakeEmbedder{modelID: "emb-a", dims: 3}
+	wrapped := cache.wrapEmbedder(inner)
+
+	ctx := context.Background()
+	first, err := wrapped.BatchEmbed(ctx, []string{"alpha", "beta"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, inner.callCount)
+
+	// Second batch overlaps "beta" only; "gamma" is new.
+	second, err := wrapped.BatchEmbed(ctx, []string{"beta", "gamma"})
+	require.NoError(t, err)
+	assert.Equal(t, 3, inner.callCount, "only the unseen text should hit the provider")
+	assert.Equal(t, first[1], second[0])
+}
+
+func TestCachingEmbedder_NilCacheIsPassthrough(t *testing.T) {
+	inner := &fakeEmbedder{modelID: "emb-a", dims: 3}
+	var cache *contentCache
+	wrapped := cache.wrapEmbedder(inner)
+	require.NotNil(t, wrapped, "nil cache must still return a working embedder")
+
+	ctx := context.Background()
+	_, err := wrapped.Embed(ctx, "text")
+	require.NoError(t, err)
+	_, err = wrapped.Embed(ctx, "text")
+	require.NoError(t, err)
+	assert.Equal(t, 2, inner.callCount, "without a cache store every call reaches the provider")
+}
+
+func TestContentCache_GetSetJSONAndNilSafety(t *testing.T) {
+	cache := &contentCache{repo: newMemCacheRepo()}
+	ctx := context.Background()
+
+	type payload struct {
+		A string `json:"a"`
+	}
+	key := types.ContentCacheKey(types.ContentCacheKindSummary, "model", "content")
+	cache.set(ctx, key, types.ContentCacheKindSummary, payload{A: "summary"})
+
+	var out payload
+	hit, err := cache.get(ctx, key, &out)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, "summary", out.A)
+
+	// Missing key -> miss.
+	hit, err = cache.get(ctx, types.ContentCacheKey(types.ContentCacheKindSummary, "other"), &out)
+	require.NoError(t, err)
+	assert.False(t, hit)
+
+	// Nil cache behaves as a permanent miss without panicking.
+	var nilCache *contentCache
+	hit, err = nilCache.get(ctx, key, &out)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	nilCache.set(ctx, key, types.ContentCacheKindSummary, payload{A: "x"})
+}
+
+// TestWikiMapCacheKey_Deterministic verifies the wiki per-document map cache
+// key is a pure function of its inputs: identical inputs produce the same key,
+// slug ordering is irrelevant, and any input change (model, content, language,
+// granularity, instructions) moves the key so only that layer invalidates.
+func TestWikiMapCacheKey_Deterministic(t *testing.T) {
+	batchCtx := &WikiBatchContext{
+		ExtractionGranularity:  types.WikiExtractionStandard,
+		ContentInstructions:    "content-instr",
+		ExtractionInstructions: "extract-instr",
+	}
+	slugs := map[string]bool{"entity/alpha": true, "concept/beta": true}
+	key1 := wikiMapCacheKey("model-a", "doc-content", "zh", slugs, batchCtx)
+	key2 := wikiMapCacheKey("model-a", "doc-content", "zh", slugs, batchCtx)
+	require.Equal(t, key1, key2)
+
+	// Slug ordering must not change the key (sorted before hashing).
+	require.Equal(t, key1, wikiMapCacheKey("model-a", "doc-content", "zh",
+		map[string]bool{"concept/beta": true, "entity/alpha": true}, batchCtx))
+
+	// Each input change moves the key.
+	require.NotEqual(t, key1, wikiMapCacheKey("model-b", "doc-content", "zh", slugs, batchCtx))
+	require.NotEqual(t, key1, wikiMapCacheKey("model-a", "doc-content-v2", "zh", slugs, batchCtx))
+	require.NotEqual(t, key1, wikiMapCacheKey("model-a", "doc-content", "en", slugs, batchCtx))
+
+	alt := *batchCtx
+	alt.ExtractionGranularity = types.WikiExtractionExhaustive
+	require.NotEqual(t, key1, wikiMapCacheKey("model-a", "doc-content", "zh", slugs, &alt))
+
+	alt2 := *batchCtx
+	alt2.ContentInstructions = "content-instr-v2"
+	require.NotEqual(t, key1, wikiMapCacheKey("model-a", "doc-content", "zh", slugs, &alt2))
+}

--- a/internal/application/service/extract.go
+++ b/internal/application/service/extract.go
@@ -164,6 +164,9 @@ type ChunkExtractService struct {
 	knowledgeRepo     interfaces.KnowledgeRepository
 	chunkRepo         interfaces.ChunkRepository
 	graphEngine       interfaces.RetrieveGraphRepository
+	// cache is the content-addressed store for per-chunk graph extractions.
+	// nil-safe: a missing store behaves as a permanent miss.
+	cache *contentCache
 	// spanTracker records this graph-extract task's subspan under the
 	// parent attempt's postprocess stage so the trace viewer shows real
 	// per-chunk graph extraction time rather than the upstream's enqueue.
@@ -178,6 +181,7 @@ func NewChunkExtractService(
 	knowledgeRepo interfaces.KnowledgeRepository,
 	chunkRepo interfaces.ChunkRepository,
 	graphEngine interfaces.RetrieveGraphRepository,
+	cacheRepo interfaces.ContentCacheRepository,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
 	return &ChunkExtractService{
@@ -187,6 +191,7 @@ func NewChunkExtractService(
 		knowledgeRepo:     knowledgeRepo,
 		chunkRepo:         chunkRepo,
 		graphEngine:       graphEngine,
+		cache:             &contentCache{repo: cacheRepo},
 		spanTracker:       spanTracker,
 	}
 }
@@ -330,10 +335,27 @@ func (s *ChunkExtractService) Handle(ctx context.Context, t *asynq.Task) error {
 		},
 	}
 	extractor := chatpipeline.NewExtractor(chatModel, template)
-	graph, err := extractor.Extract(ctx, chunk.Content)
-	if err != nil {
-		handleErr = err
-		return err
+
+	// Per-chunk graph cache: extraction is a pure function of (chunk content,
+	// model, template). The key embeds the effective template (custom
+	// instructions, tags, examples) plus the model id, so a reparse of an
+	// unchanged chunk reuses the extracted nodes/relations instead of burning
+	// another Chat call; a config or model change invalidates this layer only.
+	templateJSON, _ := json.Marshal(template)
+	graphKey := types.ContentCacheKey(types.ContentCacheKindGraph,
+		p.ModelID, promptFingerprint(string(templateJSON), chunk.Content))
+	var graph *types.GraphData
+	if hit, _ := s.cache.get(ctx, graphKey, &graph); hit {
+		graphOut["graph_cache"] = "hit"
+		logger.Infof(ctx, "graph extract: cache hit for chunk %s", p.ChunkID)
+	} else {
+		graphOut["graph_cache"] = "miss"
+		graph, err = extractor.Extract(ctx, chunk.Content)
+		if err != nil {
+			handleErr = err
+			return err
+		}
+		s.cache.set(ctx, graphKey, types.ContentCacheKindGraph, graph)
 	}
 
 	chunk, err = s.chunkRepo.GetChunkByID(ctx, p.TenantID, p.ChunkID)

--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,7 +21,6 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
-	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
 	"github.com/redis/go-redis/v9"
 )
@@ -59,6 +60,16 @@ func buildVLMCaptionPrompt(ctx context.Context, cfg types.VLMConfig) string {
 	return types.AppendCustomPromptInstructions(prompt, cfg.CustomInstructions, "image_description")
 }
 
+// vlmResult is the frozen OCR/Caption output for one image, keyed by
+// hash(image bytes) + vlm model id + effective prompt text. Freezing VLM
+// output at this layer isolates model nondeterminism: downstream chunk IDs,
+// embeddings, wiki maps and graph extractions are all derived from this
+// canonical text, so they remain cache-stable across reparses.
+type vlmResult struct {
+	OCRText string `json:"ocr_text"`
+	Caption string `json:"caption"`
+}
+
 // ImageMultimodalService handles image:multimodal asynq tasks.
 // It reads images from storage (via FileService for provider:// URLs),
 // performs OCR and VLM caption, and creates child chunks.
@@ -88,6 +99,11 @@ type ImageMultimodalService struct {
 	// spanTracker records this image's subspan under the parent attempt's
 	// multimodal stage. nil-safe — falls back to no-op via tracker().
 	spanTracker SpanTracker
+
+	// cache is the content-addressed VLM result cache (OCR/Caption frozen by
+	// image bytes + model + prompt fingerprint). nil-safe: a missing store
+	// behaves as a permanent miss.
+	cache *contentCache
 }
 
 func NewImageMultimodalService(
@@ -104,6 +120,7 @@ func NewImageMultimodalService(
 	fileSvc interfaces.FileService,
 	storageResolver interfaces.StorageBackendResolver,
 	resourceCatalog interfaces.ResourceCatalog,
+	cacheRepo interfaces.ContentCacheRepository,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
 	return &ImageMultimodalService{
@@ -121,6 +138,7 @@ func NewImageMultimodalService(
 		storageResolver: storageResolver,
 		resourceCatalog: resourceCatalog,
 		spanTracker:     spanTracker,
+		cache:           &contentCache{repo: cacheRepo},
 	}
 }
 
@@ -257,52 +275,100 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		OriginalURL: payload.ImageURL,
 	}
 
+	// VLM cache: OCR/Caption is a pure function of (image bytes, model,
+	// prompts). Successful results are frozen under a content-addressed key
+	// (image hash + model id + effective prompt text), so a reparse or
+	// crash-retry of an unchanged image never re-runs the VLM, and VLM output
+	// nondeterminism is isolated at the source: downstream content hashes
+	// (chunk IDs, wiki maps, embeddings) stay stable across reruns.
+	ocrPrompt := ""
 	if payload.EnableOCR {
-		prompt := vlmOCRPrompt
+		ocrPrompt = vlmOCRPrompt
 		if payload.ImageSourceType == "scanned_pdf" {
-			prompt = vlmOCRScannedPDFPrompt
-			logger.Infof(ctx, "[ImageMultimodal] Using scanned PDF prompt for OCR: %s", payload.ImageURL)
+			ocrPrompt = vlmOCRScannedPDFPrompt
 			imgOut["ocr_prompt"] = "scanned_pdf"
 		} else {
 			imgOut["ocr_prompt"] = "default"
 		}
-		prompt = types.AppendCustomPromptInstructions(prompt, vlmCfg.CustomInstructions, "image_ocr")
+		ocrPrompt = types.AppendCustomPromptInstructions(ocrPrompt, vlmCfg.CustomInstructions, "image_ocr")
+	}
+	captionPrompt := buildVLMCaptionPrompt(ctx, vlmCfg)
 
-		ocrText, ocrErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, prompt)
-		if ocrErr != nil {
-			logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
-			imgOut["ocr_error"] = ocrErr.Error()
+	imgHash := sha256.Sum256(imgBytes)
+	vlmModelID := strings.TrimSpace(vlmCfg.ModelID)
+	if vlmModelID == "" {
+		vlmModelID = "legacy_inline"
+	}
+	vlmKey := types.ContentCacheKey(types.ContentCacheKindVLM,
+		hex.EncodeToString(imgHash[:]), vlmModelID, ocrPrompt, captionPrompt)
+	var cachedVLM vlmResult
+	if hit, _ := s.cache.get(ctx, vlmKey, &cachedVLM); hit {
+		// Cache hit: freeze the canonical OCR/Caption text. No VLM call.
+		imageInfo.OCRText = cachedVLM.OCRText
+		imageInfo.Caption = cachedVLM.Caption
+		imgOut["vlm_cache"] = "hit"
+		if imageInfo.OCRText != "" {
+			imgOut["ocr_chars"] = len([]rune(imageInfo.OCRText))
+			imgOut["ocr_preview"] = previewText(imageInfo.OCRText, 200)
 		} else {
-			ocrText = sanitizeOCRText(ocrText)
-			if ocrText != "" {
-				imageInfo.OCRText = ocrText
-				imgOut["ocr_chars"] = len([]rune(ocrText))
-				imgOut["ocr_preview"] = previewText(ocrText, 200)
+			imgOut["ocr_chars"] = 0
+		}
+		if imageInfo.Caption != "" {
+			imgOut["caption_chars"] = len([]rune(imageInfo.Caption))
+			imgOut["caption_preview"] = previewText(imageInfo.Caption, 200)
+		}
+	} else {
+		imgOut["vlm_cache"] = "miss"
+		var ocrErr, capErr error
+		if payload.EnableOCR {
+			var ocrText string
+			ocrText, ocrErr = vlmModel.Predict(ctx, [][]byte{imgBytes}, ocrPrompt)
+			if ocrErr != nil {
+				logger.Warnf(ctx, "[ImageMultimodal] OCR failed for %s: %v", payload.ImageURL, ocrErr)
+				imgOut["ocr_error"] = ocrErr.Error()
 			} else {
-				logger.Warnf(ctx, "[ImageMultimodal] OCR returned empty/invalid content for %s, discarded", payload.ImageURL)
-				imgOut["ocr_chars"] = 0
-				imgOut["ocr_skipped"] = "empty_or_invalid"
+				ocrText = sanitizeOCRText(ocrText)
+				if ocrText != "" {
+					imageInfo.OCRText = ocrText
+					imgOut["ocr_chars"] = len([]rune(ocrText))
+					imgOut["ocr_preview"] = previewText(ocrText, 200)
+				} else {
+					logger.Warnf(ctx, "[ImageMultimodal] OCR returned empty/invalid content for %s, discarded", payload.ImageURL)
+					imgOut["ocr_chars"] = 0
+					imgOut["ocr_skipped"] = "empty_or_invalid"
+				}
 			}
 		}
-	}
 
-	caption, capErr := vlmModel.Predict(ctx, [][]byte{imgBytes}, buildVLMCaptionPrompt(ctx, vlmCfg))
-	if capErr != nil {
-		logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
-		imgOut["caption_error"] = capErr.Error()
-	} else if caption != "" {
-		imageInfo.Caption = caption
-		imgOut["caption_chars"] = len([]rune(caption))
-		imgOut["caption_preview"] = previewText(caption, 200)
-	}
+		var caption string
+		caption, capErr = vlmModel.Predict(ctx, [][]byte{imgBytes}, captionPrompt)
+		if capErr != nil {
+			logger.Warnf(ctx, "[ImageMultimodal] Caption failed for %s: %v", payload.ImageURL, capErr)
+			imgOut["caption_error"] = capErr.Error()
+		} else if caption != "" {
+			imageInfo.Caption = caption
+			imgOut["caption_chars"] = len([]rune(caption))
+			imgOut["caption_preview"] = previewText(caption, 200)
+		}
 
+		// Freeze the result only when every VLM call succeeded. Any error is
+		// treated as transient and left uncached so a retry (asynq redelivery
+		// / crash recovery) re-runs the failed call instead of permanently
+		// freezing an empty OCR/Caption.
+		if ocrErr == nil && capErr == nil {
+			s.cache.set(ctx, vlmKey, types.ContentCacheKindVLM, vlmResult{
+				OCRText: imageInfo.OCRText,
+				Caption: imageInfo.Caption,
+			})
+		}
+	}
 	// Build child chunks for OCR and caption results
 	imageInfoJSON, _ := json.Marshal([]types.ImageInfo{imageInfo})
 	var newChunks []*types.Chunk
 
 	if imageInfo.OCRText != "" {
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              types.StableChunkID(payload.KnowledgeID, string(types.ChunkTypeImageOCR), payload.ChunkID, imageInfo.OCRText),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
@@ -319,7 +385,7 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 
 	if imageInfo.Caption != "" {
 		newChunks = append(newChunks, &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              types.StableChunkID(payload.KnowledgeID, string(types.ChunkTypeImageCaption), payload.ChunkID, imageInfo.Caption),
 			TenantID:        payload.TenantID,
 			KnowledgeID:     payload.KnowledgeID,
 			KnowledgeBaseID: payload.KnowledgeBaseID,
@@ -341,18 +407,39 @@ func (s *ImageMultimodalService) Handle(ctx context.Context, task *asynq.Task) e
 		return nil
 	}
 
-	// Persist chunks
-	if err := s.chunkService.CreateChunks(ctx, newChunks); err != nil {
+	// Persist chunks. With content-addressed chunk IDs a retried delivery may
+	// already have written the same children (asynq redelivery after a crash);
+	// skip existing rows instead of failing on duplicate primary keys.
+	var toCreate []*types.Chunk
+	reusedChunks := 0
+	chunkRepo := s.chunkService.GetRepository()
+	for _, c := range newChunks {
+		if chunkRepo != nil {
+			if existing, gerr := chunkRepo.GetChunkByID(ctx, payload.TenantID, c.ID); gerr == nil && existing != nil {
+				reusedChunks++
+				logger.Infof(ctx, "[ImageMultimodal] Reused existing %s chunk %s for image %s",
+					c.ChunkType, c.ID, payload.ImageURL)
+				continue
+			}
+		}
+		toCreate = append(toCreate, c)
+	}
+	imgOut["reused_chunks"] = reusedChunks
+	if len(toCreate) == 0 {
+		imgOut["skipped"] = "chunks_already_exist"
+		return nil
+	}
+	if err := s.chunkService.CreateChunks(ctx, toCreate); err != nil {
 		handleErr = fmt.Errorf("create multimodal chunks: %w", err)
 		return handleErr
 	}
-	for _, c := range newChunks {
+	for _, c := range toCreate {
 		logger.Infof(ctx, "[ImageMultimodal] Created %s chunk %s for image %s, len=%d",
 			c.ChunkType, c.ID, payload.ImageURL, len(c.Content))
 	}
 
 	// Index chunks so they can be retrieved
-	s.indexChunks(ctx, payload, newChunks)
+	s.indexChunks(ctx, payload, toCreate)
 	imgOut["indexed"] = true
 
 	// Enqueue question generation for the caption/OCR content if KB has it enabled.

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -80,6 +80,10 @@ type knowledgeService struct {
 	// which has a no-op fallback. See knowledge_span_tracker.go.
 	spanTracker SpanTracker
 	audit       interfaces.AuditLogService
+	// contentCache is the content-addressed cache for deterministic pipeline
+	// products (VLM OCR/Caption, embeddings, summaries, questions, wiki maps,
+	// graph extractions). nil-safe: absent in test harnesses / minimal wiring.
+	contentCache *contentCache
 }
 
 const (
@@ -117,6 +121,7 @@ func NewKnowledgeService(
 	taskPendingRepo interfaces.TaskPendingOpsRepository,
 	spanTracker SpanTracker,
 	audit interfaces.AuditLogService,
+	contentCacheRepo interfaces.ContentCacheRepository,
 ) (interfaces.KnowledgeService, error) {
 	return &knowledgeService{
 		config:          config,
@@ -146,6 +151,7 @@ func NewKnowledgeService(
 		taskPendingRepo: taskPendingRepo,
 		spanTracker:     spanTracker,
 		audit:           audit,
+		contentCache:    &contentCache{repo: contentCacheRepo},
 	}, nil
 }
 

--- a/internal/application/service/knowledge_housekeeping.go
+++ b/internal/application/service/knowledge_housekeeping.go
@@ -209,6 +209,22 @@ func (h *HousekeepingService) runSweep(ctx context.Context) {
 	} else if resSummary.RowsAffected > 0 {
 		logger.Infof(ctx, "[Housekeeping] recovered %d stuck summary rows", resSummary.RowsAffected)
 	}
+
+	// Sweep C: prune the content-addressed pipeline cache. Cache keys embed
+	// content hashes and config/model/prompt versions, so entries naturally
+	// become unreachable after any content or config change; this sweep only
+	// bounds table growth. 30 days is far longer than any realistic reparse
+	// window, so it never evicts a still-reachable entry.
+	cacheCutoff := time.Now().Add(-30 * 24 * time.Hour)
+	resCache := h.db.WithContext(ctx).
+		Where("updated_at < ?", cacheCutoff).
+		Limit(5000).
+		Delete(&types.ContentCache{})
+	if resCache.Error != nil {
+		logger.Warnf(ctx, "[Housekeeping] content cache sweep failed: %v", resCache.Error)
+	} else if resCache.RowsAffected > 0 {
+		logger.Infof(ctx, "[Housekeeping] pruned %d stale content cache rows", resCache.RowsAffected)
+	}
 }
 
 // filterByLastSpanActivity returns the subset of candidates whose most

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -283,6 +284,10 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks get embedding model failed")
 			return
 		}
+		// Content-addressed embedding cache: embeddings are a pure function of
+		// (normalized text, model, dimensions), so unchanged chunks across a
+		// reparse reuse the cached vectors instead of re-calling the provider.
+		embeddingModel = s.contentCache.wrapEmbedder(embeddingModel)
 	} else {
 		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping embedding model", kb.ID)
 	}
@@ -389,7 +394,10 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		parentDBChunks = make([]*types.Chunk, len(options.ParentChunks))
 		for i, pc := range options.ParentChunks {
 			parentDBChunks[i] = &types.Chunk{
-				ID:              uuid.New().String(),
+				// Content-addressed ID: the same parsed content yields the same
+				// chunk ID across reparses, keeping vector / wiki / graph
+				// references alive when nothing changed.
+				ID:              types.StableChunkID(knowledge.ID, string(types.ChunkTypeParentText), strconv.Itoa(pc.Seq), pc.Content),
 				TenantID:        knowledge.TenantID,
 				KnowledgeID:     knowledge.ID,
 				KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -428,7 +436,8 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 
 		// 创建主文本Chunk
 		textChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			// Content-addressed ID (see StableChunkID above).
+			ID:              types.StableChunkID(knowledge.ID, string(types.ChunkTypeText), strconv.Itoa(int(chunkData.Seq)), chunkData.Content),
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -872,6 +881,19 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 	summaryPrompt := types.RenderPromptPlaceholders(s.config.Conversation.GenerateSummaryPrompt, types.PlaceholderValues{
 		"language": types.LanguageNameFromContext(ctx),
 	})
+
+	// Summary cache: the document summary is a pure function of (content,
+	// model, prompt, language, max tokens). A reparse of unchanged content
+	// reuses the cached summary instead of re-running the Chat call.
+	summaryKey := types.ContentCacheKey(types.ContentCacheKindSummary,
+		summaryModel.GetModelID(),
+		promptFingerprint(summaryPrompt, contentWithMetadata, itoa(maxTokens)))
+	var cachedSummary string
+	if hit, _ := s.contentCache.get(ctx, summaryKey, &cachedSummary); hit {
+		logger.GetLogger(ctx).WithField("summary", cachedSummary).Infof("GetSummary cache hit for knowledge %s", knowledge.ID)
+		return cachedSummary, nil
+	}
+
 	thinking := false
 	modelCtx := types.WithLLMCallMetadata(ctx, "document_summary", "")
 	summary, err := summaryModel.Chat(modelCtx, []chat.Message{
@@ -892,6 +914,7 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 		logger.GetLogger(ctx).WithField("error", err).Errorf("GetSummary failed")
 		return "", err
 	}
+	s.contentCache.set(ctx, summaryKey, types.ContentCacheKindSummary, summary.Content)
 	logger.GetLogger(ctx).WithField("summary", summary.Content).Infof("GetSummary success")
 	return summary.Content, nil
 }
@@ -1201,7 +1224,9 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 		// and surfacing them in retrieved RAG context can re-introduce the
 		// hallucination vector this branch is meant to close.
 		summaryChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			// Content-addressed slot ID: stable across reparses of the same
+			// document (the summary content itself is cached separately).
+			ID:              types.StableChunkID(knowledge.ID, string(types.ChunkTypeSummary), strconv.Itoa(maxChunkIndex+1), ""),
 			TenantID:        knowledge.TenantID,
 			KnowledgeID:     knowledge.ID,
 			KnowledgeBaseID: knowledge.KnowledgeBaseID,
@@ -1246,6 +1271,7 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 			summaryErr = err
 			return fmt.Errorf("failed to get embedding model: %w", err)
 		}
+		embeddingModel = s.contentCache.wrapEmbedder(embeddingModel)
 
 		indexInfo := []*types.IndexInfo{{
 			Content:         summaryChunk.Content,
@@ -1516,6 +1542,7 @@ func (s *knowledgeService) processQuestionGenerationForKnowledge(ctx context.Con
 		logger.Errorf(ctx, "Failed to get embedding model: %v", err)
 		return fmt.Errorf("failed to get embedding model: %w", err)
 	}
+	embeddingModel = s.contentCache.wrapEmbedder(embeddingModel)
 
 	tenantInfo, err := s.tenantRepo.GetTenantByID(ctx, payload.TenantID)
 	if err != nil {
@@ -1826,6 +1853,7 @@ func (s *knowledgeService) processQuestionGenerationForChunks(ctx context.Contex
 		logger.Errorf(ctx, "Failed to get embedding model: %v", err)
 		return fmt.Errorf("failed to get embedding model: %w", err)
 	}
+	embeddingModel = s.contentCache.wrapEmbedder(embeddingModel)
 
 	tenantInfo, err := s.tenantRepo.GetTenantByID(ctx, payload.TenantID)
 	if err != nil {
@@ -2026,6 +2054,18 @@ func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
 	})
 	prompt = types.AppendCustomPromptInstructions(prompt, customInstructions, "question_generation")
 
+	// Question cache: per-chunk question generation is a pure function of
+	// (chunk content + surrounding context, model, prompt, question count).
+	// The final rendered prompt already embeds every input, so it is hashed
+	// directly into the key; a reparse of unchanged chunks reuses the cached
+	// questions instead of re-running the Chat call per chunk.
+	questionKey := types.ContentCacheKey(types.ContentCacheKindQuestion,
+		chatModel.GetModelID(), promptFingerprint(prompt, langName, itoa(questionCount)))
+	var cachedQuestions []string
+	if hit, _ := s.contentCache.get(ctx, questionKey, &cachedQuestions); hit {
+		return cachedQuestions, nil
+	}
+
 	thinking := false
 	modelCtx := types.WithLLMCallMetadata(ctx, "question_generation", "")
 	response, err := chatModel.Chat(modelCtx, []chat.Message{
@@ -2058,6 +2098,9 @@ func (s *knowledgeService) generateQuestionsWithContext(ctx context.Context,
 				break
 			}
 		}
+	}
+	if len(questions) > 0 {
+		s.contentCache.set(ctx, questionKey, types.ContentCacheKindQuestion, questions)
 	}
 
 	return questions, nil
@@ -2233,7 +2276,8 @@ func (s *knowledgeService) RegenerateKnowledgeSummary(
 		}
 		if !found {
 			summaryChunk := &types.Chunk{
-				ID: uuid.NewString(), TenantID: tenantID, KnowledgeID: knowledge.ID,
+				ID:       types.StableChunkID(knowledge.ID, string(types.ChunkTypeSummary), strconv.Itoa(maxIndex+1), ""),
+				TenantID: tenantID, KnowledgeID: knowledge.ID,
 				KnowledgeBaseID: knowledge.KnowledgeBaseID, Content: "# Summary\n" + summary,
 				ChunkIndex: maxIndex + 1, IsEnabled: true, ChunkType: types.ChunkTypeSummary,
 				ParentChunkID: textChunks[0].ID, CreatedAt: time.Now(), UpdatedAt: time.Now(),
@@ -2672,6 +2716,7 @@ func (s *knowledgeService) updateChunkVector(ctx context.Context, kbID string, c
 	if err != nil {
 		return err
 	}
+	embeddingModel = s.contentCache.wrapEmbedder(embeddingModel)
 
 	// Initialize composite retrieve engine from tenant configuration
 	indexInfo := make([]*types.IndexInfo, 0, len(chunks))
@@ -2826,7 +2871,9 @@ func (s *knowledgeService) UpdateImageInfo(
 	// Create a new caption chunk if it doesn't exist and we have caption data
 	if !hasCaptionChunk && image.Caption != "" {
 		captionChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			// Content-addressed ID so a re-upload of the same image content
+			// reuses the same child chunk (and its downstream references).
+			ID:              types.StableChunkID(chunk.KnowledgeID, string(types.ChunkTypeImageCaption), chunk.ID, image.Caption),
 			TenantID:        tenantID,
 			KnowledgeID:     chunk.KnowledgeID,
 			KnowledgeBaseID: chunk.KnowledgeBaseID,
@@ -2842,7 +2889,7 @@ func (s *knowledgeService) UpdateImageInfo(
 	// Create a new OCR chunk if it doesn't exist and we have OCR data
 	if !hasOCRChunk && image.OCRText != "" {
 		ocrChunk := &types.Chunk{
-			ID:              uuid.New().String(),
+			ID:              types.StableChunkID(chunk.KnowledgeID, string(types.ChunkTypeImageOCR), chunk.ID, image.OCRText),
 			TenantID:        tenantID,
 			KnowledgeID:     chunk.KnowledgeID,
 			KnowledgeBaseID: chunk.KnowledgeBaseID,

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -331,6 +331,9 @@ type wikiIngestService struct {
 	pendingRepo    interfaces.TaskPendingOpsRepository
 	deadLetterRepo interfaces.TaskDeadLetterRepository
 	redisClient    *redis.Client // nil in Lite mode (no Redis)
+	// cache is the content-addressed store for per-document wiki maps
+	// (candidate slugs / summary / chunk-citation classification). nil-safe.
+	cache *contentCache
 	// spanTracker lets per-document map work surface as a
 	// postprocess.wiki subspan in the knowledge trace tree. Async
 	// batch design means we look up the parent attempt by knowledge
@@ -371,6 +374,7 @@ func NewWikiIngestService(
 	pendingRepo interfaces.TaskPendingOpsRepository,
 	deadLetterRepo interfaces.TaskDeadLetterRepository,
 	redisClient *redis.Client,
+	cacheRepo interfaces.ContentCacheRepository,
 	spanTracker SpanTracker,
 ) interfaces.TaskHandler {
 	svc := &wikiIngestService{
@@ -385,6 +389,7 @@ func NewWikiIngestService(
 		pendingRepo:    pendingRepo,
 		deadLetterRepo: deadLetterRepo,
 		redisClient:    redisClient,
+		cache:          &contentCache{repo: cacheRepo},
 		spanTracker:    spanTracker,
 	}
 	return svc

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -1148,6 +1148,49 @@ func (s *wikiIngestService) ProcessWikiFinalize(ctx context.Context, t *asynq.Ta
 	return nil
 }
 
+// wikiMapCachePayload is the frozen per-document wiki map: everything the
+// map phase computes from LLM calls (candidate slugs, dedup output, summary,
+// chunk citations) with no cross-document state. The reduce/merge phase is
+// deliberately NOT cached — it depends on the live state of other pages.
+type wikiMapCachePayload struct {
+	Pass0Failed       bool                     `json:"pass0_failed"`
+	ExtractedEntities []extractedItem          `json:"extracted_entities"`
+	ExtractedConcepts []extractedItem          `json:"extracted_concepts"`
+	SlugItems         map[string]extractedItem `json:"slug_items"`
+	SummaryContent    string                   `json:"summary_content"`
+	Citations         map[string][]string      `json:"citations"`
+	NewSlugs          []newSlugFromCitation    `json:"new_slugs"`
+	BatchCount        int                      `json:"batch_count"`
+}
+
+// wikiMapCacheKey derives the content-addressed key for a document's wiki map.
+// Every LLM-facing input is embedded in the key: the frozen document content,
+// language, the document's current page set (which shapes slug continuity),
+// extraction granularity / custom instructions, the chat model id and the
+// prompt templates. Changing any of them invalidates exactly this layer; a
+// reparse of an unchanged document therefore hits and skips extract/dedup/
+// summary/classify.
+func wikiMapCacheKey(modelID, content, lang string, oldPageSlugs map[string]bool, batchCtx *WikiBatchContext) string {
+	slugs := make([]string, 0, len(oldPageSlugs))
+	for slug := range oldPageSlugs {
+		slugs = append(slugs, slug)
+	}
+	sort.Strings(slugs)
+	granularity := batchCtx.ExtractionGranularity.Normalize()
+	return types.ContentCacheKey(types.ContentCacheKindWikiMap,
+		content, lang, strings.Join(slugs, "\n"),
+		string(granularity),
+		batchCtx.ContentInstructions,
+		batchCtx.ExtractionInstructions,
+		modelID,
+		promptFingerprint(
+			agent.WikiCandidateSlugPrompt,
+			agent.WikiDeduplicationPrompt,
+			agent.WikiSummaryPrompt,
+			agent.WikiChunkCitationPrompt,
+		),
+	)
+}
 func (s *wikiIngestService) mapOneDocument(
 	ctx context.Context,
 	chatModel chat.Chat,
@@ -1233,39 +1276,58 @@ func (s *wikiIngestService) mapOneDocument(
 	sourceRef := knowledgeID
 	oldPageSlugs := s.getExistingPageSlugsForKnowledge(ctx, payload.KnowledgeBaseID, knowledgeID)
 
-	// Pass 0: lightweight candidate slug extraction (skeleton only).
-	// On failure we fall back to the legacy single-shot extractor so the doc
-	// still gets ingested, just without chunk-level citations.
 	var (
 		extractedEntities []extractedItem
 		extractedConcepts []extractedItem
 		slugItems         map[string]extractedItem
 		pass0Failed       bool
 	)
-	logger.Infof(ctx, "wiki ingest: pass 0 — extracting candidate slugs for %s", knowledgeID)
-	extractSpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.extract", types.SpanKindSubSpan, types.JSONMap{
-		"content_chars": utf8.RuneCountInString(content),
-		"old_pages":     len(oldPageSlugs),
-	})
-	extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
-	if err != nil {
-		logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) — falling back to legacy extractor", knowledgeID, err)
-		pass0Failed = true
-		extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
-		if err != nil {
-			logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
-			s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
-			s.tracker().FailSpan(ctx, wikiSpan, "EXTRACT_FAILED", err.Error(), err)
-			return nil, nil, err
-		}
+
+	// Map cache: the wiki per-document map (candidate slugs + dedup + summary
+	// + chunk citations) is a pure function of the frozen document content and
+	// the extraction configuration. On a hit we skip every per-doc LLM call
+	// and go straight to the (deliberately uncached) reduce/merge phase.
+	wikiMapKey := wikiMapCacheKey(chatModel.GetModelID(), content, lang, oldPageSlugs, batchCtx)
+	var cachedMap wikiMapCachePayload
+	mapCacheHit := false
+	if hit, _ := s.cache.get(ctx, wikiMapKey, &cachedMap); hit {
+		mapCacheHit = true
+		extractedEntities = cachedMap.ExtractedEntities
+		extractedConcepts = cachedMap.ExtractedConcepts
+		slugItems = cachedMap.SlugItems
+		pass0Failed = cachedMap.Pass0Failed
+		logger.Infof(ctx, "wiki ingest: map cache hit for %s (skipping extract/dedup/summary/classify)", knowledgeID)
 	}
-	s.tracker().EndSpan(ctx, extractSpan, types.JSONMap{
-		"entities":         len(extractedEntities),
-		"concepts":         len(extractedConcepts),
-		"pass0_fallback":   pass0Failed,
-		"entities_preview": previewExtractedItems(extractedEntities, 8),
-		"concepts_preview": previewExtractedItems(extractedConcepts, 8),
-	})
+
+	if !mapCacheHit {
+		// Pass 0: lightweight candidate slug extraction (skeleton only).
+		// On failure we fall back to the legacy single-shot extractor so the doc
+		// still gets ingested, just without chunk-level citations.
+		logger.Infof(ctx, "wiki ingest: pass 0 extracting candidate slugs for %s", knowledgeID)
+		extractSpan := s.tracker().BeginSubSpan(ctx, wikiSpan, "postprocess.wiki.extract", types.SpanKindSubSpan, types.JSONMap{
+			"content_chars": utf8.RuneCountInString(content),
+			"old_pages":     len(oldPageSlugs),
+		})
+		extractedEntities, extractedConcepts, slugItems, err = s.extractCandidateSlugs(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
+		if err != nil {
+			logger.Warnf(ctx, "wiki ingest: pass 0 failed for %s (%v) falling back to legacy extractor", knowledgeID, err)
+			pass0Failed = true
+			extractedEntities, extractedConcepts, slugItems, err = s.extractEntitiesAndConceptsNoUpsert(ctx, chatModel, payload.KnowledgeBaseID, content, lang, oldPageSlugs, batchCtx)
+			if err != nil {
+				logger.Warnf(ctx, "wiki ingest: legacy fallback also failed for %s: %v", knowledgeID, err)
+				s.tracker().FailSpan(ctx, extractSpan, "EXTRACT_FAILED", err.Error(), err)
+				s.tracker().FailSpan(ctx, wikiSpan, "EXTRACT_FAILED", err.Error(), err)
+				return nil, nil, err
+			}
+		}
+		s.tracker().EndSpan(ctx, extractSpan, types.JSONMap{
+			"entities":         len(extractedEntities),
+			"concepts":         len(extractedConcepts),
+			"pass0_fallback":   pass0Failed,
+			"entities_preview": previewExtractedItems(extractedEntities, 8),
+			"concepts_preview": previewExtractedItems(extractedConcepts, 8),
+		})
+	}
 
 	// Build slug listing for Summary's wiki-link input.
 	var summaryExtractedPages []string
@@ -1302,6 +1364,16 @@ func (s *wikiIngestService) mapOneDocument(
 		batchCount     int
 	)
 
+	// On a map cache hit the parallel goroutines below skip every LLM call;
+	// restore the frozen summary/citation halves so the reduce phase and the
+	// summary page reuse the exact cached text instead of empty values.
+	if mapCacheHit {
+		summaryContent = cachedMap.SummaryContent
+		citations = cachedMap.Citations
+		newSlugs = cachedMap.NewSlugs
+		batchCount = cachedMap.BatchCount
+	}
+
 	// Both calls run in parallel goroutines under the same wikiSpan
 	// parent — their subspans will visually overlap in the trace view,
 	// which correctly reflects their wall-clock concurrency.
@@ -1321,6 +1393,17 @@ func (s *wikiIngestService) mapOneDocument(
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
+		if mapCacheHit {
+			// Summary is part of the frozen per-doc map; reuse it verbatim.
+			sumLine, sumBody := splitSummaryLine(summaryContent)
+			s.tracker().EndSpan(ctx, summarySpan, types.JSONMap{
+				"cache_hit":    true,
+				"chars":        utf8.RuneCountInString(summaryContent),
+				"summary_line": previewText(sumLine, 160),
+				"body_preview": previewText(sumBody, 320),
+			})
+			return
+		}
 		summaryContent, summaryErr = s.generateWithTemplate(ctx, chatModel, agent.WikiSummaryPrompt, map[string]string{
 			"Content":            content,
 			"Language":           lang,
@@ -1344,6 +1427,16 @@ func (s *wikiIngestService) mapOneDocument(
 		// Skip citation pass when Pass 0 has fallen back to the legacy path —
 		// the legacy output already contains paraphrased Details, so chunk
 		// citations would be redundant and we'd spend LLM calls for nothing.
+		if mapCacheHit {
+			// Chunk citations are part of the frozen per-doc map; reuse them.
+			s.tracker().EndSpan(ctx, classifySpan, types.JSONMap{
+				"cache_hit":   true,
+				"cited_slugs": len(citations),
+				"new_slugs":   len(newSlugs),
+				"batches":     batchCount,
+			})
+			return
+		}
 		if pass0Failed {
 			citations = map[string][]string{}
 			return
@@ -1359,6 +1452,21 @@ func (s *wikiIngestService) mapOneDocument(
 		})
 	}()
 	wg.Wait()
+
+	// Freeze the map result. Only stored after a full LLM pass so a
+	// partially-failed run (summary error) never poisons the cache.
+	if !mapCacheHit {
+		s.cache.set(ctx, wikiMapKey, types.ContentCacheKindWikiMap, wikiMapCachePayload{
+			Pass0Failed:       pass0Failed,
+			ExtractedEntities: extractedEntities,
+			ExtractedConcepts: extractedConcepts,
+			SlugItems:         slugItems,
+			SummaryContent:    summaryContent,
+			Citations:         citations,
+			NewSlugs:          newSlugs,
+			BatchCount:        batchCount,
+		})
+	}
 
 	// Merge citations back into the item structs (non-failing; items without
 	// citations simply keep their Description+Details fallback).
@@ -1565,8 +1673,13 @@ func (s *wikiIngestService) mapOneDocument(
 	// been written. That way the span's duration reflects the full
 	// "wiki processing for this knowledge" time the user sees in the
 	// trace viewer, not just the LLM extraction slice.
+	mapCacheLabel := "miss"
+	if mapCacheHit {
+		mapCacheLabel = "hit"
+	}
 	mapStats := types.JSONMap{
 		"doc_title":        previewText(docTitle, 120),
+		"map_cache":        mapCacheLabel,
 		"chunks":           len(chunks),
 		"candidate_slugs":  len(slugItems),
 		"cited_chunks":     len(citedChunkSet),

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -147,6 +147,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewKnowledgeRepository))
 	must(container.Provide(repository.NewKnowledgeSpanRepository))
 	must(container.Provide(repository.NewChunkRepository))
+	must(container.Provide(repository.NewContentCacheRepository))
 	must(container.Provide(repository.NewKnowledgeTagRepository))
 	must(container.Provide(repository.NewSessionRepository))
 	must(container.Provide(repository.NewMessageRepository))

--- a/internal/types/content_cache.go
+++ b/internal/types/content_cache.go
@@ -1,0 +1,71 @@
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"time"
+)
+
+// Content cache kind identifiers. Every cache key embeds the kind so the
+// same content never collides across layers, and every key embeds the
+// model id / prompt version / config that produced the payload so a model or
+// config change invalidates exactly the affected layer (see ContentCacheKey).
+const (
+	ContentCacheKindVLM       = "vlm"
+	ContentCacheKindEmbedding = "embedding"
+	ContentCacheKindWikiMap   = "wiki_map"
+	ContentCacheKindSummary   = "summary"
+	ContentCacheKindQuestion  = "question"
+	ContentCacheKindGraph     = "graph_extract"
+)
+
+// ContentCache is a content-addressed cache row for deterministic pipeline
+// products (VLM OCR/Caption, embeddings, wiki per-document maps, per-chunk
+// graph extractions, summaries, questions). Keys are derived from the inputs
+// of the cached computation so an unchanged input always resolves to the same
+// key, while any input change (content, model, prompt, config) produces a
+// miss and a fresh computation.
+type ContentCache struct {
+	CacheKey  string    `json:"cache_key" gorm:"column:cache_key;type:varchar(128);primaryKey"`
+	Kind      string    `json:"kind"      gorm:"column:kind;type:varchar(32);index"`
+	Payload   string    `json:"payload"   gorm:"column:payload;type:text"`
+	CreatedAt time.Time `json:"created_at" gorm:"column:created_at"`
+	UpdatedAt time.Time `json:"updated_at" gorm:"column:updated_at"`
+}
+
+// TableName returns the content_cache table name.
+func (ContentCache) TableName() string { return "content_cache" }
+
+// StableChunkID derives a deterministic chunk ID from content-identifying
+// parts (knowledge id, chunk type, sequence, normalized content). Two parses
+// of the same content produce the same chunk ID, so vectors, wiki chunk
+// references and graph edges survive a reparse. The returned value is 32 hex
+// characters and fits the chunks.id VARCHAR(36) column.
+func StableChunkID(parts ...string) string {
+	h := sha256.New()
+	for _, p := range parts {
+		h.Write([]byte(p))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))[:32]
+}
+
+// ContentCacheKey builds a content-addressed cache key for the given kind.
+// Every contributing input (content hash, model id, prompt version, config
+// fingerprint) is hashed into the key, so a change to any of them moves the
+// key: the cache layer affected by that input invalidates precisely, while
+// layers whose inputs did not change keep hitting.
+func ContentCacheKey(kind string, parts ...string) string {
+	h := sha256.New()
+	h.Write([]byte(kind))
+	for _, p := range parts {
+		h.Write([]byte{0})
+		h.Write([]byte(p))
+	}
+	return kind + ":" + hex.EncodeToString(h.Sum(nil))
+}
+
+// ContentCachePayload is the maximum payload size we are willing to persist.
+// Payloads beyond this are skipped (best-effort caching) so a single oversized
+// document cannot blow up the table.
+const ContentCachePayloadMaxBytes = 512 * 1024

--- a/internal/types/content_cache_test.go
+++ b/internal/types/content_cache_test.go
@@ -1,0 +1,46 @@
+package types
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStableChunkID_DeterministicAndSensitive(t *testing.T) {
+	id := StableChunkID("knowledge-1", "text", "3", "hello world")
+	require.Len(t, id, 32)
+
+	// Same inputs -> same ID (the reparse-reuse property).
+	assert.Equal(t, id, StableChunkID("knowledge-1", "text", "3", "hello world"))
+
+	// Any input change -> different ID (content edits invalidate references).
+	assert.NotEqual(t, id, StableChunkID("knowledge-1", "text", "3", "hello world!"))
+	assert.NotEqual(t, id, StableChunkID("knowledge-1", "text", "4", "hello world"))
+	assert.NotEqual(t, id, StableChunkID("knowledge-2", "text", "3", "hello world"))
+	assert.NotEqual(t, id, StableChunkID("knowledge-1", "parent_text", "3", "hello world"))
+}
+
+func TestStableChunkID_DistinguishesIdenticalChunkBodies(t *testing.T) {
+	// Two chunks in the same document with identical content must not collide:
+	// the sequence number is part of the key.
+	a := StableChunkID("k", "text", "1", "same")
+	b := StableChunkID("k", "text", "2", "same")
+	assert.NotEqual(t, a, b)
+}
+
+func TestContentCacheKey_DeterministicAndSensitive(t *testing.T) {
+	k1 := ContentCacheKey(ContentCacheKindEmbedding, "model-a", "text")
+	k2 := ContentCacheKey(ContentCacheKindEmbedding, "model-a", "text")
+	assert.Equal(t, k1, k2)
+	assert.True(t, strings.HasPrefix(k1, ContentCacheKindEmbedding+":"))
+
+	// Model / content / kind changes each move the key (layered invalidation).
+	assert.NotEqual(t, k1, ContentCacheKey(ContentCacheKindEmbedding, "model-b", "text"))
+	assert.NotEqual(t, k1, ContentCacheKey(ContentCacheKindEmbedding, "model-a", "text2"))
+	assert.NotEqual(t, k1, ContentCacheKey(ContentCacheKindVLM, "model-a", "text"))
+
+	// Must fit the cache_key VARCHAR(128) primary key.
+	require.LessOrEqual(t, len(k1), 128)
+}

--- a/internal/types/interfaces/content_cache.go
+++ b/internal/types/interfaces/content_cache.go
@@ -1,0 +1,27 @@
+package interfaces
+
+import (
+	"context"
+	"time"
+)
+
+// ContentCacheRepository is a content-addressed cache store for deterministic
+// pipeline products. Keys are derived from the computation inputs (content
+// hash + model id + prompt/config version), so hits are only possible when
+// the exact same input was computed before. Implementations must be safe for
+// concurrent readers/writers (best-effort: a Set racing another Set for the
+// same key may keep either value, since the payload is a pure function of the
+// key).
+type ContentCacheRepository interface {
+	// Get returns the cached payload for cacheKey. found is false when the
+	// key has no row.
+	Get(ctx context.Context, cacheKey string) (payload []byte, found bool, err error)
+	// Set upserts the payload for cacheKey.
+	Set(ctx context.Context, cacheKey, kind string, payload []byte) error
+	// Delete removes a single cache row.
+	Delete(ctx context.Context, cacheKey string) error
+	// PruneBefore deletes rows whose updated_at is older than before and
+	// returns the number of rows removed. limit bounds the batch so a single
+	// sweep cannot lock the table for minutes.
+	PruneBefore(ctx context.Context, before time.Time, limit int) (int, error)
+}

--- a/migrations/mysql/00-init-db.sql
+++ b/migrations/mysql/00-init-db.sql
@@ -227,3 +227,16 @@ CREATE TABLE chunk_revisions (
     UNIQUE KEY idx_chunk_revisions_chunk_revision (chunk_id, revision),
     KEY idx_chunk_revisions_tenant_chunk (tenant_id, chunk_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-- Content-addressed cache for deterministic pipeline products (VLM OCR/Caption,
+-- embeddings, wiki per-document maps, per-chunk graph extractions, summaries,
+-- questions). Keys embed content hash + model id + prompt/config version so an
+-- unchanged input always hits and a changed input (or model) misses.
+CREATE TABLE content_cache (
+    cache_key VARCHAR(128) PRIMARY KEY,
+    kind VARCHAR(32) NOT NULL DEFAULT '',
+    payload LONGTEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_content_cache_kind (kind),
+    KEY idx_content_cache_updated_at (updated_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/migrations/sqlite/000002_content_cache.down.sql
+++ b/migrations/sqlite/000002_content_cache.down.sql
@@ -1,0 +1,2 @@
+﻿-- Roll back migration 000002.
+DROP TABLE IF EXISTS content_cache;

--- a/migrations/sqlite/000002_content_cache.up.sql
+++ b/migrations/sqlite/000002_content_cache.up.sql
@@ -1,0 +1,10 @@
+﻿-- Migration 000002: content-addressed cache table (SQLite).
+CREATE TABLE IF NOT EXISTS content_cache (
+    cache_key VARCHAR(128) PRIMARY KEY,
+    kind VARCHAR(32) NOT NULL DEFAULT '',
+    payload TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_content_cache_kind ON content_cache (kind);
+CREATE INDEX IF NOT EXISTS idx_content_cache_updated_at ON content_cache (updated_at);

--- a/migrations/versioned/000079_content_cache.down.sql
+++ b/migrations/versioned/000079_content_cache.down.sql
@@ -1,0 +1,2 @@
+﻿-- Roll back migration 000079.
+DROP TABLE IF EXISTS content_cache;

--- a/migrations/versioned/000079_content_cache.up.sql
+++ b/migrations/versioned/000079_content_cache.up.sql
@@ -1,0 +1,13 @@
+﻿-- Migration 000079: content-addressed cache for deterministic pipeline products.
+-- Stores VLM OCR/Caption, embeddings, wiki per-document maps, per-chunk graph
+-- extractions, summaries and questions keyed by hash(content + model + prompt
+-- version + config), so a reparse of unchanged content reuses prior results.
+CREATE TABLE IF NOT EXISTS content_cache (
+    cache_key VARCHAR(128) PRIMARY KEY,
+    kind VARCHAR(32) NOT NULL DEFAULT '',
+    payload TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_content_cache_kind ON content_cache (kind);
+CREATE INDEX IF NOT EXISTS idx_content_cache_updated_at ON content_cache (updated_at);


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description

Knowledge rebuilds (ReparseKnowledge, edit / re-upload, crash recovery) previously followed a
"delete everything, recompute from scratch" strategy: all chunks and vectors were dropped, then the
full pipeline (parse → chunk → embed → VLM OCR/Caption → summary → question → Wiki map → Wiki
reduce → GraphRAG extract) reran unconditionally. Because chunk IDs were regenerated with
`uuid.New()` on every parse and no content-addressed cache existed, none of the expensive products
could be reused — the cost of a rebuild was identical to first-time ingestion and scaled linearly
with rebuild frequency. In Wiki mode on mid-to-large knowledge bases this made token cost
unacceptable (O(full recompute × rebuild count), independent of model price).

This PR introduces a content-addressed cache layer with stable chunk IDs so unchanged content
reuses prior results:

- **Stable chunk IDs**: chunk IDs are now derived via `StableChunkID(doc_id + chunk_type + seq +
  normalized content)` instead of `uuid.New()`. Identical content parses to identical IDs, so
  vectors, Wiki `SourceChunks`/`ChunkRefs` and graph edges survive rebuilds. Applied to parent
  text, text, summary and OCR/Caption child chunks.
- **VLM OCR/Caption freeze**: results are cached under `hash(image bytes) + vlm model + prompt
  fingerprints`. On a hit the canonical OCR/Caption text is frozen and the VLM is never re-run
  unless the image bytes change. This isolates VLM nondeterminism at the source so downstream
  content hashes stay stable. Failed VLM calls are **not** cached, so crash retries re-run only the
  failed call. Existing child chunks with stable IDs are skipped instead of failing on duplicates.
- **Embedding cache**: deterministic `(normalized text, model, dimensions)` key with batch-level
  partial hits and cross-document dedup, wired into chunk indexing, summary, question generation
  and chunk vector updates.
- **Summary / Question caches**: keyed on content + model + prompt fingerprint, with hit short-circuits.
- **Wiki per-document map cache**: keyed on model + frozen content + language + granularity +
  custom instructions + prompt versions + old page slugs. On a hit, `extract / dedup / summary /
  classify` are skipped entirely and processing goes straight to the (deliberately uncached,
  cross-document) reduce/merge phase.
- **GraphRAG per-chunk cache**: keyed on chunk content + model + effective template; hits skip the
  per-chunk Chat call.
- **Layered invalidation**: every key embeds model ID / config / prompt version, so changing e.g.
  only the embedding model recomputes exactly the vector layer while VLM and Wiki map caches stay
  valid.
- **Housekeeping**: bounded prune of `content_cache` rows older than 30 days.

New table `content_cache` (key ≤ 128 chars, payload ≤ 512 KB) via migrations for PostgreSQL
(`000079_content_cache`), SQLite (`000002_content_cache`) and MySQL init script.

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #1679 

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->
Scoped checks for the changed packages all pass:

```powershell
go build ./internal/types ./internal/application/repository ./internal/application/service
go vet ./internal/types ./internal/application/repository ./internal/application/service
go test ./internal/types ./internal/application/repository ./internal/application/service `
  -run 'TestStableChunkID|TestContentCache|TestCaching|TestWikiMapCacheKey' -count=1
```
Coverage added: `StableChunkID` / `ContentCacheKey` determinism and layered invalidation
(`internal/types/content_cache_test.go`); GORM cache repository Set/Get/upsert/oversize skip /
prune / delete (`internal/application/repository/content_cache_test.go`); caching embedder hit /
model isolation / partial batch hit / nil-safe passthrough and wiki map key determinism
(`internal/application/service/cache_util_test.go`).

Full-repository checks: `go build ./...` and full `go test ./...` cannot complete in the current
Windows environment due to pre-existing, unrelated cgo setup issues — `sqlite-vec-go-bindings`
cannot find `sqlite3.h` (mingw include paths) and `duckdb` fails to link pthread. The packages
touched by this PR compile, vet and test cleanly.

Suggested end-to-end verification after deploy: ingest a document (baseline), then rebuild the same
document and confirm the log/trace markers `vlm_cache=hit`, `map_cache=hit`, `graph_cache=hit`,
`GetSummary cache hit` and reused child chunks, with LLM/VLM calls approaching zero apart from Wiki
reduce.
## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above


