### PR TITLE
fix(frontend): improve responsive chat input layout

### DIFF
--- a/frontend/src/components/Input-field.vue
+++ b/frontend/src/components/Input-field.vue
@@ -2747,6 +2747,9 @@ const getImgSrc = (url: string) => {
   left: 50%;
   transform: translateX(-50%);
   width: 100%;
+  min-width: 0;
+  padding: 0 16px;
+  box-sizing: border-box;
   display: flex;
   justify-content: center;
 
@@ -2756,6 +2759,7 @@ const getImgSrc = (url: string) => {
     left: auto;
     transform: none;
     z-index: auto;
+    padding: 0;
 
     .rich-input-container {
       max-width: 100%;
@@ -2768,6 +2772,8 @@ const getImgSrc = (url: string) => {
   position: relative;
   width: 100%;
   max-width: 960px;
+  min-width: 0;
+  box-sizing: border-box;
   background: var(--td-bg-color-container, #FFF);
   border-radius: 12px;
   border: 1px solid var(--td-component-stroke, #dcdcdc);
@@ -3443,6 +3449,7 @@ const getImgSrc = (url: string) => {
   gap: 6px;
   padding: 2px 8px;
   min-width: 100px;
+  max-width: 180px;
   height: 22px;
   border-radius: 6px;
   border: .5px solid var(--td-component-border, #e7e7e7);
@@ -3464,6 +3471,7 @@ const getImgSrc = (url: string) => {
 }
 
 .model-selector-name {
+  min-width: 0;
   flex: 1;
   font-size: 12px;
   font-weight: 500;
@@ -3766,6 +3774,116 @@ const getImgSrc = (url: string) => {
   &:hover {
     color: var(--td-brand-color-active);
     text-decoration: underline;
+  }
+}
+
+@media (max-width: 768px) {
+  .answers-input {
+    bottom: 16px;
+    padding: 0 12px;
+  }
+
+  .rich-input-container {
+    border-radius: 10px;
+  }
+
+  .selected-tags-inline {
+    gap: 4px;
+    padding: 6px 10px;
+    border-radius: 9px 9px 0 0;
+  }
+
+  .mention-chip {
+    max-width: 100%;
+  }
+
+  .mention-chip__name {
+    max-width: 72px;
+  }
+
+  :deep(.t-textarea__inner) {
+    min-height: 104px !important;
+    max-height: 160px !important;
+    padding: 10px 12px 50px;
+    border-radius: 0 0 10px 10px;
+  }
+
+  .rich-input-container:not(:has(.selected-tags-inline)) :deep(.t-textarea__inner) {
+    padding-top: 12px;
+    border-radius: 10px;
+  }
+
+  .control-bar {
+    right: 12px;
+    bottom: 10px;
+    left: 12px;
+    gap: 6px;
+    max-height: none;
+    flex-wrap: nowrap;
+  }
+
+  .control-left {
+    gap: 4px;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .agent-mode-btn {
+    max-width: 112px;
+    padding: 0 8px;
+  }
+
+  .agent-mode-text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .model-display {
+    min-width: 0;
+    margin-left: 0;
+    flex-shrink: 1;
+  }
+
+  .model-selector-trigger {
+    min-width: 72px;
+    max-width: 108px;
+    padding: 2px 6px;
+  }
+
+  .control-right {
+    gap: 6px;
+    flex-shrink: 0;
+  }
+
+  .image-preview-item {
+    width: 48px;
+    height: 48px;
+  }
+}
+
+@media (max-width: 380px) {
+  .answers-input {
+    padding: 0 8px;
+  }
+
+  .agent-mode-btn {
+    max-width: 96px;
+  }
+
+  .model-selector-trigger {
+    max-width: 88px;
+  }
+
+  .mention-chip__name {
+    max-width: 56px;
   }
 }
 </style>

--- a/frontend/src/components/css/suggested-questions.less
+++ b/frontend/src/components/css/suggested-questions.less
@@ -20,7 +20,9 @@
     max-width: 860px;
     margin: 0 auto;
     width: 100%;
+    min-width: 0;
     min-height: 0;
+    box-sizing: border-box;
 
     &.has-questions {
         min-height: 64px;
@@ -200,5 +202,39 @@
     letter-spacing: 0.04em;
     text-transform: uppercase;
     color: var(--td-brand-color);
+}
+
+@media (max-width: 600px) {
+    .suggested-questions-container {
+        padding: 8px 12px;
+    }
+
+    .suggested-questions-title-row {
+        margin-bottom: 8px;
+    }
+
+    .suggested-questions-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr);
+        gap: 8px;
+    }
+
+    .suggested-question-card,
+    .suggested-question-card.sq-card-skeleton {
+        width: 100%;
+    }
+
+    .suggested-question-card {
+        justify-content: space-between;
+        padding: 8px 12px;
+    }
+
+    .suggested-question-text {
+        display: -webkit-box;
+        white-space: normal;
+        overflow-wrap: anywhere;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+    }
 }
 

--- a/frontend/src/components/responsive-chat-layout.test.mjs
+++ b/frontend/src/components/responsive-chat-layout.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const sourceRoot = resolve(here, '..')
+const readSource = (...segments) => readFileSync(join(sourceRoot, ...segments), 'utf8')
+
+const inputField = readSource('components', 'Input-field.vue')
+const suggestedQuestions = readSource('components', 'css', 'suggested-questions.less')
+const chatView = readSource('views', 'chat', 'index.vue')
+const createChatView = readSource('views', 'creatChat', 'creatChat.vue')
+const knowledgeBaseView = readSource('views', 'knowledge', 'KnowledgeBase.vue')
+const platformView = readSource('views', 'platform', 'index.vue')
+const uiStore = readSource('stores', 'ui.ts')
+
+test('chat input is container-sized on desktop, tablet, and phone viewports', () => {
+  assert.match(
+    inputField,
+    /\.answers-input\s*\{[^}]*width:\s*100%;[^}]*min-width:\s*0;[^}]*box-sizing:\s*border-box;/,
+  )
+  assert.match(
+    inputField,
+    /\.rich-input-container\s*\{[^}]*width:\s*100%;[^}]*max-width:\s*960px;[^}]*min-width:\s*0;[^}]*box-sizing:\s*border-box;/,
+  )
+  assert.match(
+    inputField,
+    /@media \(max-width: 768px\)[\s\S]*?\.control-left\s*\{[^}]*overflow-x:\s*auto;/,
+  )
+})
+
+test('chat entry points no longer impose fixed widths or translations on InputField', () => {
+  for (const source of [createChatView, knowledgeBaseView]) {
+    assert.doesNotMatch(source, /\.answers-input\s*\{[^}]*translateX\(-\d+px\)/)
+    assert.doesNotMatch(source, /:deep\(\.t-textarea__inner\)\s*\{[^}]*width:\s*\d+px\s*!important/)
+  }
+})
+
+test('page shells can shrink below their former desktop minimum widths', () => {
+  assert.match(platformView, /\.main\s*\{[^}]*min-width:\s*0;/)
+  assert.doesNotMatch(platformView, /\.main\s*\{[^}]*min-width:\s*600px;/)
+  assert.match(chatView, /\.chat\s*\{[^}]*min-width:\s*0;/)
+  assert.doesNotMatch(chatView, /\.chat\s*\{[^}]*min-width:\s*400px;/)
+})
+
+test('suggested questions fit a narrow viewport without horizontal overflow', () => {
+  assert.match(
+    suggestedQuestions,
+    /\.suggested-questions-container\s*\{[^}]*width:\s*100%;[^}]*min-width:\s*0;[^}]*box-sizing:\s*border-box;/,
+  )
+  assert.match(
+    suggestedQuestions,
+    /@media \(max-width: 600px\)[\s\S]*?grid-template-columns:\s*minmax\(0,\s*1fr\);/,
+  )
+})
+
+test('first-time tablet and phone visits start with the sidebar collapsed', () => {
+  assert.match(uiStore, /localStorage\.getItem\('sidebar_collapsed'\)/)
+  assert.match(uiStore, /window\.matchMedia\('\(max-width: 768px\)'\)\.matches/)
+  assert.match(uiStore, /sidebarCollapsed:\s*getInitialSidebarCollapsed\(\)/)
+})

--- a/frontend/src/stores/ui.ts
+++ b/frontend/src/stores/ui.ts
@@ -1,5 +1,16 @@
 import { defineStore } from 'pinia'
 
+const getInitialSidebarCollapsed = () => {
+  const storedPreference = localStorage.getItem('sidebar_collapsed')
+  if (storedPreference !== null) {
+    return storedPreference === 'true'
+  }
+
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(max-width: 768px)').matches
+}
+
 export const useUIStore = defineStore('ui', {
   state: () => ({
     showSettingsModal: false,
@@ -20,7 +31,7 @@ export const useUIStore = defineStore('ui', {
     manualEditorInitialContent: '',
     manualEditorInitialStatus: 'draft' as 'draft' | 'publish',
     manualEditorOnSuccess: null as null | ((payload: { kbId: string; knowledgeId: string; status: 'draft' | 'publish' }) => void),
-    sidebarCollapsed: localStorage.getItem('sidebar_collapsed') === 'true'
+    sidebarCollapsed: getInitialSidebarCollapsed()
   }),
 
   actions: {

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -1038,7 +1038,7 @@ onBeforeRouteUpdate((to, from, next) => {
     flex-direction: column;
     align-items: center;
     max-width: calc(100vw - 260px);
-    min-width: 400px;
+    min-width: 0;
 
     &.is-sidebar-collapsed {
         max-width: calc(100vw - 60px);
@@ -1303,5 +1303,20 @@ onBeforeRouteUpdate((to, from, next) => {
 .sq-fade-enter-from,
 .sq-fade-leave-to {
     opacity: 0;
+}
+
+@media (max-width: 768px) {
+    .chat {
+        width: 100%;
+        max-width: 100%;
+        padding: 0 12px 12px;
+    }
+
+    .chat_scroll_box,
+    .msg_list,
+    .input-container {
+        min-width: 0;
+        max-width: 100%;
+    }
 }
 </style>

--- a/frontend/src/views/creatChat/creatChat.vue
+++ b/frontend/src/views/creatChat/creatChat.vue
@@ -245,6 +245,7 @@ const handleKBEditorSuccess = (kbId: string) => {
 <style lang="less" scoped>
 .dialogue-wrap {
     flex: 1;
+    min-width: 0;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -257,6 +258,7 @@ const handleKBEditorSuccess = (kbId: string) => {
     align-items: center;
     width: 100%;
     max-width: 960px;
+    min-width: 0;
     gap: 24px;
 
     :deep(.answers-input) {
@@ -363,43 +365,22 @@ const handleKBEditorSuccess = (kbId: string) => {
     }
 }
 
-@media (max-width: 1250px) and (min-width: 1045px) {
-    .answers-input {
-        transform: translateX(-329px);
-    }
-
-    :deep(.t-textarea__inner) {
-        width: 654px !important;
-    }
-}
-
-@media (max-width: 1045px) {
-    .answers-input {
-        transform: translateX(-250px);
-    }
-
-    :deep(.t-textarea__inner) {
-        width: 500px !important;
-    }
-}
-
-@media (max-width: 750px) {
-    .answers-input {
-        transform: translateX(-250px);
-    }
-
-    :deep(.t-textarea__inner) {
-        width: 340px !important;
-    }
-}
-
 @media (max-width: 600px) {
-    .answers-input {
-        transform: translateX(-250px);
+    .dialogue-wrap {
+        align-items: flex-start;
+        padding: clamp(24px, 8vh, 64px) 12px 16px;
+        box-sizing: border-box;
+        overflow-y: auto;
     }
 
-    :deep(.t-textarea__inner) {
-        width: 300px !important;
+    .dialogue-answers {
+        gap: 16px;
+    }
+
+    .dialogue-title {
+        font-size: 22px;
+        line-height: 30px;
+        text-align: center;
     }
 }
 </style>

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -3416,46 +3416,6 @@ async function createNewSession(value: string): Promise<void> {
   margin: 0 16px 0 4px;
 }
 
-@media (max-width: 1250px) and (min-width: 1045px) {
-  .answers-input {
-    transform: translateX(-329px);
-  }
-
-  :deep(.t-textarea__inner) {
-    width: 654px !important;
-  }
-}
-
-@media (max-width: 1045px) {
-  .answers-input {
-    transform: translateX(-250px);
-  }
-
-  :deep(.t-textarea__inner) {
-    width: 500px !important;
-  }
-}
-
-@media (max-width: 750px) {
-  .answers-input {
-    transform: translateX(-182px);
-  }
-
-  :deep(.t-textarea__inner) {
-    width: 340px !important;
-  }
-}
-
-@media (max-width: 600px) {
-  .answers-input {
-    transform: translateX(-164px);
-  }
-
-  :deep(.t-textarea__inner) {
-    width: 300px !important;
-  }
-}
-
 @keyframes contentFadeIn {
   from {
     opacity: 0;

--- a/frontend/src/views/platform/index.vue
+++ b/frontend/src/views/platform/index.vue
@@ -257,7 +257,7 @@ onUnmounted(() => {
     align-items: stretch;
     width: 100%;
     height: 100%;
-    min-width: 600px;
+    min-width: 0;
     min-height: 0;
     /* 统一整页背景，让左侧菜单与右侧内容区视觉连贯 */
     background: var(--td-bg-color-container);


### PR DESCRIPTION
## Description

Fixes the responsive layout issue reported in #917.

The chat input previously relied on fixed minimum widths, fixed textarea widths, and horizontal translation offsets. These styles caused the input controls and suggested questions to overflow or appear oversized on Android and tablet viewports.

This PR:

- Makes the chat input shrink to the available viewport width while retaining the 960px desktop maximum width.
- Removes obsolete fixed-width and horizontal translation workarounds.
- Makes chat, platform, knowledge-base, and create-chat containers shrink correctly.
- Uses a compact, horizontally scrollable control bar on narrow screens.
- Displays suggested questions in a single-column layout on mobile.
- Collapses the sidebar by default for first-time tablet and mobile visitors.
- Adds responsive layout regression tests.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #917

## Testing

- [x] `node --test src/components/responsive-chat-layout.test.mjs` — 5/5 passed
- [x] `npm test` — 287/287 passed
- [x] `npm run type-check` passed
- [x] `npm run build` passed
- [x] `git diff --check upstream/main...HEAD` passed
- [x] Manually verified at 360×800, 390×844, 768×1024, and 1440×900
- [x] Confirmed there is no horizontal page overflow on mobile

## Checklist

- [x] `git diff --check upstream/main...HEAD` passes
- [x] Changed source files follow the existing formatting
- [x] Targeted tests for the changed components pass
- [x] Diff-scoped lint is not applicable because the frontend package has no lint script
- [x] Full frontend tests, type checking, and production build were run
- [x] Self-reviewed the code
- [x] Added tests covering the change
- [x] Documentation updates are not required
- [x] No breaking changes

## Screenshots / Recordings

### Android — 360×800

<img width="548" height="907" alt="image" src="https://github.com/user-attachments/assets/d2924167-7e56-4ed4-a2f6-55348dc6b811" />


### Tablet — 768×1024

<img width="845" height="1142" alt="image" src="https://github.com/user-attachments/assets/49bf2fba-699e-4dab-83b8-05a9e4cdd541" />

### Desktop — 1440×900

<img width="1336" height="903" alt="image" src="https://github.com/user-attachments/assets/85de1c69-dae9-4375-b99c-2bfec2b4cdb6" />