### PR TITLE
fix(frontend): 适配移动端聊天界面

### DIFF
--- a/frontend/src/components/Input-field.vue
+++ b/frontend/src/components/Input-field.vue
@@ -2723,7 +2723,9 @@ const getImgSrc = (url: string) => {
   bottom: 60px;
   left: 50%;
   transform: translateX(-50%);
-  width: 100%;
+  width: min(960px, 100%);
+  min-width: 0;
+  box-sizing: border-box;
   display: flex;
   justify-content: center;
 
@@ -2744,7 +2746,9 @@ const getImgSrc = (url: string) => {
 .rich-input-container {
   position: relative;
   width: 100%;
+  min-width: 0;
   max-width: 960px;
+  box-sizing: border-box;
   background: var(--td-bg-color-container, #FFF);
   border-radius: 12px;
   border: 1px solid var(--td-component-stroke, #dcdcdc);
@@ -3743,6 +3747,112 @@ const getImgSrc = (url: string) => {
   &:hover {
     color: var(--td-brand-color-active);
     text-decoration: underline;
+  }
+}
+
+/* 平板与手机共享父容器的可用宽度，不再依赖固定像素宽度或水平位移。 */
+@media screen and (max-width: 1199px) {
+  .answers-input {
+    width: 100%;
+    padding-inline: 16px;
+  }
+
+  .answers-input.is-embedded {
+    padding-inline: 0;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .answers-input {
+    bottom: max(12px, env(safe-area-inset-bottom));
+    padding-inline: 12px;
+  }
+
+  .answers-input.is-embedded {
+    padding-inline: 0;
+  }
+
+  .rich-input-container {
+    max-width: none;
+    border-radius: 10px;
+  }
+
+  :deep(.t-textarea__inner) {
+    min-height: 96px !important;
+    max-height: min(160px, 32dvh) !important;
+    padding: 10px 12px 50px;
+    border-radius: 0 0 10px 10px;
+  }
+
+  .rich-input-container:not(:has(.selected-tags-inline)) :deep(.t-textarea__inner) {
+    padding-top: 12px;
+    border-radius: 10px;
+  }
+
+  .selected-tags-inline {
+    max-height: 72px;
+    padding: 6px 10px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .control-bar {
+    bottom: 8px;
+    left: 10px;
+    right: 10px;
+    gap: 4px;
+    flex-wrap: nowrap;
+    max-height: 36px;
+    padding-top: 4px;
+  }
+
+  .control-left {
+    min-width: 0;
+    gap: 4px;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .control-right {
+    gap: 4px;
+    flex-shrink: 0;
+  }
+
+  .control-btn {
+    padding-inline: 6px;
+  }
+
+  .agent-mode-btn {
+    max-width: 112px;
+    padding-inline: 6px;
+  }
+
+  .agent-mode-text {
+    max-width: 76px;
+    margin-inline: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .model-display {
+    margin-left: 0;
+  }
+
+  .model-selector-trigger {
+    min-width: 72px;
+    max-width: 104px;
+    padding-inline: 6px;
+  }
+
+  .image-preview-item {
+    width: 48px;
+    height: 48px;
   }
 }
 </style>

--- a/frontend/src/components/css/suggested-questions.less
+++ b/frontend/src/components/css/suggested-questions.less
@@ -202,3 +202,27 @@
     color: var(--td-brand-color);
 }
 
+@media screen and (max-width: 767px) {
+    .suggested-questions-container {
+        padding: 8px 0;
+    }
+
+    .suggested-questions-title-row {
+        margin-bottom: 8px;
+    }
+
+    .suggested-questions-grid {
+        gap: 8px;
+    }
+
+    .suggested-question-card,
+    .suggested-question-card.sq-card-skeleton {
+        width: 100%;
+        padding: 8px 12px;
+    }
+
+    .suggested-question-text {
+        white-space: normal;
+        overflow-wrap: anywhere;
+    }
+}

--- a/frontend/src/components/menu.vue
+++ b/frontend/src/components/menu.vue
@@ -1885,6 +1885,83 @@ const onDragHandleMouseDown = (e: MouseEvent) => {
 .menu_box {
     position: relative;
 }
+
+/*
+ * 手机端保留可用的图标导航栏，同时释放聊天内容宽度。这里沿用桌面端的
+ * collapsed 布局尺寸，但不改写用户保存在 localStorage 中的桌面侧栏偏好。
+ */
+@media screen and (max-width: 767px) {
+    .aside_box {
+        min-width: 60px;
+        width: 60px;
+        padding: max(8px, env(safe-area-inset-top)) 3px max(6px, env(safe-area-inset-bottom));
+        overflow: visible;
+
+        :deep(.tenant-selector),
+        .submenu,
+        .batch-inline-footer,
+        .menu_title,
+        .menu-pending-badge {
+            display: none;
+        }
+
+        .logo_row {
+            justify-content: center;
+            height: 44px;
+            padding: 0;
+
+            .logo_box,
+            .sidebar-toggle {
+                display: none;
+            }
+
+            .logo_actions {
+                gap: 0;
+            }
+        }
+
+        .menu_item {
+            justify-content: center;
+            padding: 9px 0;
+
+            .menu_item-box {
+                justify-content: center;
+                width: auto;
+            }
+        }
+
+        .menu_icon {
+            margin-right: 0;
+        }
+
+        .menu_top {
+            margin-right: 0;
+            padding-right: 0;
+        }
+
+        .menu_bottom {
+            align-items: center;
+        }
+
+        :deep(.user-menu .user-button) {
+            justify-content: center;
+            gap: 0;
+            padding: 6px 3px;
+        }
+
+        :deep(.user-menu .user-info),
+        :deep(.user-menu .dropdown-icon) {
+            display: none;
+        }
+
+        :deep(.user-menu .user-dropdown) {
+            left: calc(100% + 8px);
+            right: auto;
+            bottom: 0;
+            min-width: min(260px, calc(100vw - 76px));
+        }
+    }
+}
 </style>
 <style lang="less">
 // Dark mode: invert dark logo to light

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -1031,8 +1031,9 @@ onBeforeRouteUpdate((to, from, next) => {
     display: flex;
     flex-direction: column;
     align-items: center;
+    width: 100%;
     max-width: calc(100vw - 260px);
-    min-width: 400px;
+    min-width: 0;
 
     &.is-sidebar-collapsed {
         max-width: calc(100vw - 60px);
@@ -1264,6 +1265,43 @@ onBeforeRouteUpdate((to, from, next) => {
         border-top-color: var(--td-text-color-secondary);
         border-radius: 50%;
         animation: chatGlobalWaitSpin 0.8s linear infinite;
+    }
+}
+
+@media screen and (min-width: 768px) and (max-width: 1199px) {
+    .chat {
+        padding-left: 16px;
+    }
+
+    .input-container,
+    .msg_list {
+        max-width: min(960px, 100%);
+    }
+}
+
+@media screen and (max-width: 767px) {
+    .chat:not(.is-embedded) {
+        max-width: calc(100vw - 60px);
+        padding: 0 12px max(12px, env(safe-area-inset-bottom));
+        overflow-x: hidden;
+    }
+
+    .chat_scroll_box {
+        padding-top: 4px;
+    }
+
+    .input-container {
+        min-height: 99px;
+    }
+
+    .msg_list {
+        gap: 12px;
+    }
+
+    .scroll-to-bottom-btn {
+        bottom: 112px;
+        width: 32px;
+        height: 32px;
     }
 }
 

--- a/frontend/src/views/creatChat/creatChat.vue
+++ b/frontend/src/views/creatChat/creatChat.vue
@@ -248,7 +248,13 @@ const handleKBEditorSuccess = (kbId: string) => {
     display: flex;
     justify-content: center;
     align-items: center;
-    // position: relative;
+    width: 100%;
+    min-width: 0;
+    min-height: 0;
+    padding: 32px clamp(16px, 4vw, 48px);
+    box-sizing: border-box;
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 .dialogue-answers {
@@ -256,6 +262,7 @@ const handleKBEditorSuccess = (kbId: string) => {
     flex-flow: column;
     align-items: center;
     width: 100%;
+    min-width: 0;
     max-width: 960px;
     gap: 24px;
 
@@ -272,7 +279,10 @@ const handleKBEditorSuccess = (kbId: string) => {
     font-size: 28px;
     font-weight: 600;
     align-items: center;
+    max-width: 100%;
     margin-bottom: 0;
+    line-height: 1.35;
+    text-align: center;
 
     .icon {
         display: flex;
@@ -305,6 +315,8 @@ const handleKBEditorSuccess = (kbId: string) => {
 }
 
 .suggested-questions-container {
+    box-sizing: border-box;
+    width: 100%;
     max-width: 960px;
     margin: 0;
     padding: 0 16px;
@@ -363,43 +375,33 @@ const handleKBEditorSuccess = (kbId: string) => {
     }
 }
 
-@media (max-width: 1250px) and (min-width: 1045px) {
-    .answers-input {
-        transform: translateX(-329px);
+@media screen and (min-width: 768px) and (max-width: 1199px) {
+    .dialogue-wrap {
+        padding-inline: 24px;
     }
 
-    :deep(.t-textarea__inner) {
-        width: 654px !important;
-    }
-}
-
-@media (max-width: 1045px) {
-    .answers-input {
-        transform: translateX(-250px);
-    }
-
-    :deep(.t-textarea__inner) {
-        width: 500px !important;
+    .dialogue-title {
+        font-size: 24px;
     }
 }
 
-@media (max-width: 750px) {
-    .answers-input {
-        transform: translateX(-250px);
+@media screen and (max-width: 767px) {
+    .dialogue-wrap {
+        align-items: flex-start;
+        padding: clamp(24px, 10dvh, 72px) 12px max(20px, env(safe-area-inset-bottom));
     }
 
-    :deep(.t-textarea__inner) {
-        width: 340px !important;
-    }
-}
-
-@media (max-width: 600px) {
-    .answers-input {
-        transform: translateX(-250px);
+    .dialogue-answers {
+        gap: 16px;
+        margin-block: auto;
     }
 
-    :deep(.t-textarea__inner) {
-        width: 300px !important;
+    .dialogue-title {
+        font-size: 22px;
+    }
+
+    .suggested-questions-container {
+        padding-inline: 0;
     }
 }
 </style>

--- a/frontend/src/views/mobileChatLayout.test.mjs
+++ b/frontend/src/views/mobileChatLayout.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const read = (relativePath) =>
+  readFileSync(new URL(relativePath, import.meta.url), 'utf8')
+
+test('mobile viewport can shrink below the former desktop minimums', () => {
+  const platform = read('./platform/index.vue')
+  const chat = read('./chat/index.vue')
+
+  assert.match(platform, /\.main\s*\{[\s\S]*?min-width:\s*0;/)
+  assert.doesNotMatch(platform, /\.main\s*\{[\s\S]*?min-width:\s*600px;/)
+  assert.match(chat, /\.chat\s*\{[\s\S]*?min-width:\s*0;/)
+  assert.doesNotMatch(chat, /\.chat\s*\{[\s\S]*?min-width:\s*400px;/)
+})
+
+test('input and create-chat layouts use responsive widths instead of fixed phone widths', () => {
+  const input = read('../components/Input-field.vue')
+  const createChat = read('./creatChat/creatChat.vue')
+  const chat = read('./chat/index.vue')
+
+  assert.match(input, /width:\s*min\(960px,\s*100%\)/)
+  assert.match(input, /@media screen and \(max-width:\s*767px\)/)
+  assert.match(input, /\.control-left\s*\{[\s\S]*?overflow-x:\s*auto;/)
+  assert.match(createChat, /@media screen and \(max-width:\s*767px\)/)
+  assert.doesNotMatch(createChat, /width:\s*(?:300|340|500|654)px\s*!important/)
+  assert.doesNotMatch(createChat, /translateX\(-(?:164|182|250|329)px\)/)
+  assert.match(chat, /\.chat:not\(\.is-embedded\)\s*\{[\s\S]*?max-width:\s*calc\(100vw - 60px\)/)
+})
+
+test('phone navigation preserves usable Android space', () => {
+  const menu = read('../components/menu.vue')
+
+  assert.match(menu, /@media screen and \(max-width:\s*767px\)/)
+  assert.match(menu, /\.aside_box\s*\{[\s\S]*?min-width:\s*60px;[\s\S]*?width:\s*60px;/)
+  assert.match(menu, /\.logo_row\s*\{[\s\S]*?justify-content:\s*center;/)
+  assert.doesNotMatch(menu, /\.logo_row,\s*:deep\(\.tenant-selector\)/)
+})

--- a/frontend/src/views/platform/index.vue
+++ b/frontend/src/views/platform/index.vue
@@ -257,8 +257,9 @@ onUnmounted(() => {
     align-items: stretch;
     width: 100%;
     height: 100%;
-    min-width: 600px;
+    min-width: 0;
     min-height: 0;
+    overflow: hidden;
     /* 统一整页背景，让左侧菜单与右侧内容区视觉连贯 */
     background: var(--td-bg-color-container);
 }


### PR DESCRIPTION
## 关联 Issue

Closes #917

## 修改内容

- 移除聊天页面的桌面最小宽度限制，适配平板和安卓窄屏
- 调整输入框、控制栏和推荐问题在手机端的尺寸与布局
- 手机端侧栏收窄为图标导航，并保留搜索入口
- 移除新建对话页的固定宽度和水平位移，避免内容溢出
- 保持嵌入式聊天原有宽度行为
- 增加移动端布局回归测试

## 验证

- `npm test -- src/views/mobileChatLayout.test.mjs`
- `npm run build-only`