### PR TITLE
fix(frontend): improve mobile responsive layout

### DIFF
--- a/frontend/src/components/Input-field.responsive.test.mjs
+++ b/frontend/src/components/Input-field.responsive.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const inputField = readFileSync(new URL('./Input-field.vue', import.meta.url), 'utf8')
+const createChat = readFileSync(new URL('../views/creatChat/creatChat.vue', import.meta.url), 'utf8')
+const chat = readFileSync(new URL('../views/chat/index.vue', import.meta.url), 'utf8')
+const platform = readFileSync(new URL('../views/platform/index.vue', import.meta.url), 'utf8')
+const uiStore = readFileSync(new URL('../stores/ui.ts', import.meta.url), 'utf8')
+
+test('platform and chat shells can shrink to a mobile viewport', () => {
+  assert.match(platform, /@media \(max-width: 768px\)[\s\S]*?\.main\s*\{[\s\S]*?min-width:\s*0/)
+  assert.match(chat, /@media \(max-width: 768px\)[\s\S]*?\.chat[\s\S]*?min-width:\s*0/)
+})
+
+test('new chat input follows its container instead of fixed viewport widths', () => {
+  assert.match(createChat, /\.dialogue-wrap\s*\{[\s\S]*?min-width:\s*0/)
+  assert.match(createChat, /\.dialogue-answers\s*\{[\s\S]*?min-width:\s*0/)
+  assert.doesNotMatch(createChat, /width:\s*(?:654|500|340|300)px\s*!important/)
+  assert.doesNotMatch(createChat, /translateX\(-(?:329|250)px\)/)
+})
+
+test('mobile input controls stay on one compact scrollable row', () => {
+  assert.match(inputField, /@media \(max-width: 768px\)[\s\S]*?\.answers-input\s*\{[\s\S]*?padding:\s*0 12px/)
+  assert.match(inputField, /\.control-left\s*\{[\s\S]*?overflow-x:\s*auto/)
+  assert.match(inputField, /\.agent-mode-text\s*\{[\s\S]*?text-overflow:\s*ellipsis/)
+})
+
+test('mobile model selector shrinks without covering the send button', () => {
+  assert.match(inputField, /class="model-selector-trigger" :title="selectedModelDisplayName"/)
+  assert.match(inputField, /\.model-display\s*\{[\s\S]*?flex:\s*1 1 auto;[\s\S]*?min-width:\s*0/)
+  assert.match(inputField, /\.model-selector-trigger\s*\{[\s\S]*?width:\s*100%;[\s\S]*?min-width:\s*0/)
+  assert.match(inputField, /\.model-selector-name\s*\{[\s\S]*?min-width:\s*0/)
+})
+
+test('mobile visits start with a collapsed sidebar even after a desktop preference', () => {
+  assert.match(uiStore, /localStorage\.getItem\(SIDEBAR_COLLAPSED_KEY\)/)
+  assert.match(
+    uiStore,
+    /if \(window\.matchMedia\('\(max-width: 768px\)'\)\.matches\)\s*\{\s*return true/,
+  )
+})

--- a/frontend/src/components/Input-field.vue
+++ b/frontend/src/components/Input-field.vue
@@ -2655,7 +2655,8 @@ defineExpose({
           <t-tooltip :content="isModelLockedByAgent ? $t('input.modelLockedByAgent') : ''"
             :disabled="!isModelLockedByAgent">
             <div class="model-display" :class="{ 'agent-controlled': isModelLockedByAgent }">
-              <div ref="modelButtonRef" class="model-selector-trigger" @click.stop="toggleModelSelector">
+              <div ref="modelButtonRef" class="model-selector-trigger" :title="selectedModelDisplayName"
+                @click.stop="toggleModelSelector">
                 <span class="model-selector-name">
                   {{ selectedModelDisplayName }}
                 </span>
@@ -2768,6 +2769,7 @@ const getImgSrc = (url: string) => {
   position: relative;
   width: 100%;
   max-width: 960px;
+  min-width: 0;
   background: var(--td-bg-color-container, #FFF);
   border-radius: 12px;
   border: 1px solid var(--td-component-stroke, #dcdcdc);
@@ -3419,6 +3421,72 @@ const getImgSrc = (url: string) => {
   img {
     width: 16px;
     height: 16px;
+  }
+}
+
+/* 移动端输入区域 */
+@media (max-width: 768px) {
+  .answers-input {
+    min-width: 0;
+    padding: 0 12px;
+    box-sizing: border-box;
+  }
+
+  :deep(.t-textarea__inner) {
+    min-height: 96px !important;
+    padding: 12px 12px 52px;
+  }
+
+  .control-bar {
+    left: 12px;
+    right: 12px;
+    flex-wrap: nowrap;
+    max-height: none;
+    gap: 6px;
+  }
+
+  .control-left {
+    flex-wrap: nowrap;
+    gap: 4px;
+    overflow-x: auto;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .control-right {
+    flex-shrink: 0;
+    gap: 4px;
+  }
+
+  .agent-mode-btn {
+    max-width: 124px;
+  }
+
+  .agent-mode-text {
+    min-width: 0;
+    max-width: 88px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .model-display {
+    flex: 1 1 auto;
+    min-width: 0;
+    margin-left: 0;
+  }
+
+  .model-selector-trigger {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    box-sizing: border-box;
+  }
+
+  .model-selector-name {
+    min-width: 0;
   }
 }
 

--- a/frontend/src/components/menu.vue
+++ b/frontend/src/components/menu.vue
@@ -1801,6 +1801,14 @@ const onDragHandleMouseDown = (e: MouseEvent) => {
     }
 }
 
+@media (max-width: 768px) {
+    .aside_box:not(.aside_box--collapsed) {
+        position: fixed;
+        inset: 0 auto 0 0;
+        z-index: 300;
+    }
+}
+
 .menu_item-box {
     display: flex;
     align-items: center;

--- a/frontend/src/stores/ui.ts
+++ b/frontend/src/stores/ui.ts
@@ -1,5 +1,18 @@
 import { defineStore } from 'pinia'
 
+const SIDEBAR_COLLAPSED_KEY = 'sidebar_collapsed'
+
+const getInitialSidebarCollapsed = () => {
+  if (window.matchMedia('(max-width: 768px)').matches) {
+    return true
+  }
+  const savedPreference = localStorage.getItem(SIDEBAR_COLLAPSED_KEY)
+  if (savedPreference !== null) {
+    return savedPreference === 'true'
+  }
+  return false
+}
+
 export const useUIStore = defineStore('ui', {
   state: () => ({
     showSettingsModal: false,
@@ -20,7 +33,7 @@ export const useUIStore = defineStore('ui', {
     manualEditorInitialContent: '',
     manualEditorInitialStatus: 'draft' as 'draft' | 'publish',
     manualEditorOnSuccess: null as null | ((payload: { kbId: string; knowledgeId: string; status: 'draft' | 'publish' }) => void),
-    sidebarCollapsed: localStorage.getItem('sidebar_collapsed') === 'true'
+    sidebarCollapsed: getInitialSidebarCollapsed()
   }),
 
   actions: {
@@ -122,17 +135,17 @@ export const useUIStore = defineStore('ui', {
 
     toggleSidebar() {
       this.sidebarCollapsed = !this.sidebarCollapsed
-      localStorage.setItem('sidebar_collapsed', String(this.sidebarCollapsed))
+      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(this.sidebarCollapsed))
     },
 
     collapseSidebar() {
       this.sidebarCollapsed = true
-      localStorage.setItem('sidebar_collapsed', 'true')
+      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, 'true')
     },
 
     expandSidebar() {
       this.sidebarCollapsed = false
-      localStorage.setItem('sidebar_collapsed', 'false')
+      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, 'false')
     }
   }
 })

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -1098,6 +1098,16 @@ onBeforeRouteUpdate((to, from, next) => {
     }
 }
 
+@media (max-width: 768px) {
+    .chat,
+    .chat.is-sidebar-collapsed {
+        width: 100%;
+        max-width: 100%;
+        min-width: 0;
+        padding: 0 0 12px 8px;
+    }
+}
+
 .chat_scroll_box {
     flex: 1;
     // Without min-height: 0, a flex-column child defaults to min-height: auto

--- a/frontend/src/views/creatChat/creatChat.vue
+++ b/frontend/src/views/creatChat/creatChat.vue
@@ -248,6 +248,9 @@ const handleKBEditorSuccess = (kbId: string) => {
     display: flex;
     justify-content: center;
     align-items: center;
+    min-width: 0;
+    padding: 24px;
+    box-sizing: border-box;
     // position: relative;
 }
 
@@ -257,6 +260,7 @@ const handleKBEditorSuccess = (kbId: string) => {
     align-items: center;
     width: 100%;
     max-width: 960px;
+    min-width: 0;
     gap: 24px;
 
     :deep(.answers-input) {
@@ -363,43 +367,17 @@ const handleKBEditorSuccess = (kbId: string) => {
     }
 }
 
-@media (max-width: 1250px) and (min-width: 1045px) {
-    .answers-input {
-        transform: translateX(-329px);
+@media (max-width: 768px) {
+    .dialogue-wrap {
+        padding: 16px 12px;
     }
 
-    :deep(.t-textarea__inner) {
-        width: 654px !important;
-    }
-}
-
-@media (max-width: 1045px) {
-    .answers-input {
-        transform: translateX(-250px);
+    .dialogue-answers {
+        gap: 16px;
     }
 
-    :deep(.t-textarea__inner) {
-        width: 500px !important;
-    }
-}
-
-@media (max-width: 750px) {
-    .answers-input {
-        transform: translateX(-250px);
-    }
-
-    :deep(.t-textarea__inner) {
-        width: 340px !important;
-    }
-}
-
-@media (max-width: 600px) {
-    .answers-input {
-        transform: translateX(-250px);
-    }
-
-    :deep(.t-textarea__inner) {
-        width: 300px !important;
+    .dialogue-title {
+        font-size: 22px;
     }
 }
 </style>

--- a/frontend/src/views/platform/index.vue
+++ b/frontend/src/views/platform/index.vue
@@ -263,6 +263,12 @@ onUnmounted(() => {
     background: var(--td-bg-color-container);
 }
 
+@media (max-width: 768px) {
+    .main {
+        min-width: 0;
+    }
+}
+
 /* 右侧路由区：占满剩余宽度与整列高度，并把 min-height:0 传给子页面以便内部 flex 滚动 */
 .platform-route-outlet {
     flex: 1;


### PR DESCRIPTION
## Description

优化移动端页面显示：

- 移动端默认折叠侧边栏，避免侧边栏挤压页面内容
- 移除页面和聊天区域的固定最小宽度
- 调整聊天输入框在小屏幕下的宽度和间距
- 修复模型名称过长时挤压发送按钮的问题
- 移除新建对话页面中针对不同宽度写死的输入框尺寸

## Related Issue

Fixes #917