### PR TITLE
fix(chat): segment Chinese query expansions with jieba

### DIFF
--- a/internal/application/service/chat_pipeline/query_expansion.go
+++ b/internal/application/service/chat_pipeline/query_expansion.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/Tencent/WeKnora/internal/types"
 )
@@ -194,7 +195,7 @@ func extractKeywords(text string) []string {
 	keywords := make([]string, 0, len(words))
 	for _, w := range words {
 		lower := strings.ToLower(w)
-		if _, isStop := stopwords[lower]; !isStop && len(w) > 1 {
+		if _, isStop := stopwords[lower]; !isStop && utf8.RuneCountInString(w) > 1 {
 			keywords = append(keywords, w)
 		}
 	}
@@ -235,28 +236,46 @@ func removeQuestionWords(text string) string {
 func tokenize(text string) []string {
 	var tokens []string
 	var current strings.Builder
+	currentIsHan := false
+
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+
+		if currentIsHan {
+			// Use the existing search-mode dictionary for continuous Chinese text.
+			for _, word := range types.Jieba.CutForSearch(current.String(), true) {
+				word = strings.TrimSpace(word)
+				if word != "" {
+					tokens = append(tokens, word)
+				}
+			}
+		} else {
+			tokens = append(tokens, current.String())
+		}
+
+		current.Reset()
+		currentIsHan = false
+	}
 
 	for _, r := range text {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+		if unicode.Is(unicode.Han, r) {
+			if current.Len() > 0 && !currentIsHan {
+				flush()
+			}
+			currentIsHan = true
 			current.WriteRune(r)
-		} else if unicode.Is(unicode.Han, r) {
-			// Flush current token
-			if current.Len() > 0 {
-				tokens = append(tokens, current.String())
-				current.Reset()
+		} else if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			if current.Len() > 0 && currentIsHan {
+				flush()
 			}
-			// Chinese character as single token
-			tokens = append(tokens, string(r))
+			currentIsHan = false
+			current.WriteRune(r)
 		} else {
-			// Delimiter
-			if current.Len() > 0 {
-				tokens = append(tokens, current.String())
-				current.Reset()
-			}
+			flush()
 		}
 	}
-	if current.Len() > 0 {
-		tokens = append(tokens, current.String())
-	}
+	flush()
 	return tokens
 }

--- a/internal/application/service/chat_pipeline/query_expansion_test.go
+++ b/internal/application/service/chat_pipeline/query_expansion_test.go
@@ -1,0 +1,65 @@
+package chatpipeline
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractKeywordsSegmentsChineseQuery(t *testing.T) {
+	keywords := extractKeywords("如何配置向量数据库")
+
+	assert.NotContains(t, keywords, "如何配置向量数据库")
+	assert.Contains(t, keywords, "配置")
+	assert.Contains(t, keywords, "向量")
+	assert.Contains(t, keywords, "数据库")
+}
+
+func TestTokenizePreservesMixedLanguageBoundaries(t *testing.T) {
+	tokens := tokenize("RAG如何配置PostgreSQL")
+
+	assert.Contains(t, tokens, "RAG")
+	assert.Contains(t, tokens, "配置")
+	assert.Contains(t, tokens, "PostgreSQL")
+	assert.NotContains(t, tokens, "RAG如何配置")
+}
+
+func TestExtractKeywordsDropsSingleRuneChineseTokens(t *testing.T) {
+	keywords := extractKeywords("他来到了网易杭研大厦")
+
+	assert.Contains(t, keywords, "网易")
+	assert.Contains(t, keywords, "大厦")
+	for _, keyword := range keywords {
+		assert.Greater(t, utf8.RuneCountInString(keyword), 1, "unexpected single-rune keyword %q", keyword)
+	}
+}
+
+func TestExpandQueriesBuildsChineseKeywordVariant(t *testing.T) {
+	expansions := (&PluginSearch{}).expandQueries(context.Background(), &types.ChatManage{
+		PipelineState: types.PipelineState{RewriteQuery: "如何配置向量数据库"},
+	})
+
+	var foundKeywordVariant bool
+	for _, expansion := range expansions {
+		fields := strings.Fields(expansion)
+		if containsToken(fields, "配置") && containsToken(fields, "向量") && containsToken(fields, "数据库") {
+			foundKeywordVariant = true
+			break
+		}
+	}
+
+	assert.True(t, foundKeywordVariant, "expected a Chinese keyword expansion with segmented terms, got %v", expansions)
+}
+
+func containsToken(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## 中文说明

### 问题

`tokenize` 先判断 `unicode.IsLetter`，再判断 `unicode.Han`。由于汉字同时属于 Unicode Letter，Han 分支永远不可达，连续中文查询会被当成一个完整 token，导致停用词过滤和关键词扩展无法生成有意义的中文检索词。

### 复现步骤

1. 将 query expansion 的输入设为 `如何配置向量数据库`。
2. 调用本地 query expansion，或直接调用 `extractKeywords`/`tokenize`。
3. 修复前，`tokenize` 返回 `["如何配置向量数据库"]`；pipeline 只能得到去掉疑问词后的 `配置向量数据库`，无法产生按词切分的关键词扩展。
4. 使用无空格混合查询 `RAG如何配置PostgreSQL` 时，修复前也会把中英文粘成同一个 token。
5. 预期结果：中文部分至少产生 `配置`、`向量`、`数据库` 等词，混合查询保留独立的 `RAG` 和 `PostgreSQL` token。

### 修复

- 在普通 Letter/Digit 判断前识别 Han 字符；
- 仅对连续 Han 片段使用仓库现有的 `types.Jieba.CutForSearch`；
- 保留英文和数字原有的 token 边界行为；
- 使用 rune 数而不是 UTF-8 字节数过滤单汉字噪声；
- 增加中文关键词扩展、单汉字过滤和双向中英文边界回归测试。

### 验证

- `go test -count=1 ./internal/application/service/chat_pipeline`
- `go test -count=1 ./internal/application/service/chat_pipeline -run 'Test(ExtractKeywordsSegmentsChineseQuery|TokenizePreservesMixedLanguageBoundaries|ExtractKeywordsDropsSingleRuneChineseTokens|ExpandQueriesBuildsChineseKeywordVariant)$'`
- `go vet ./internal/application/service/chat_pipeline ./internal/application/service`
- `git diff --check`

已运行 `go test -count=1 ./internal/application/service`。上游最新主线在 Windows 上有 3 个与本 PR 无关的 SQLite 临时文件锁失败：`TestDataSourceServiceDeleteSQLiteCleansUpAfterSoftDelete`、`TestDataSourceServiceDeleteKeepsCleanupStateWhenSoftDeleteFails`、`TestDeleteKnowledgeBaseCleansUpSQLiteDataSources`，失败原因均为测试清理时 `weknora.db` 仍被占用。

## English

### Problem

`tokenize` checked `unicode.IsLetter` before `unicode.Han`. Han characters are Unicode letters, so the Han branch was unreachable. A continuous Chinese query became one large token, preventing stop-word removal and keyword expansion from producing useful Chinese retrieval terms.

### Reproduction steps

1. Set the query-expansion input to `如何配置向量数据库`.
2. Run local query expansion, or call `extractKeywords`/`tokenize` directly.
3. Before this fix, `tokenize` returns `["如何配置向量数据库"]`; the pipeline can only produce the question-word-stripped string `配置向量数据库`, not a word-segmented keyword variant.
4. With the unspaced mixed query `RAG如何配置PostgreSQL`, the old implementation also merges the Chinese and Latin text into one token.
5. Expected result: the Chinese span yields terms such as `配置`, `向量`, and `数据库`, while `RAG` and `PostgreSQL` remain separate tokens.

### Fix

- Detect Han characters before the general Letter/Digit branch;
- Send only continuous Han spans through the existing `types.Jieba.CutForSearch` tokenizer;
- Preserve the existing English and numeric token-boundary behavior;
- Filter single-character noise by rune count instead of UTF-8 byte length;
- Add regression coverage for Chinese keyword expansion, single-rune filtering, and both mixed-language boundaries.

### Verification

- `go test -count=1 ./internal/application/service/chat_pipeline`
- `go test -count=1 ./internal/application/service/chat_pipeline -run 'Test(ExtractKeywordsSegmentsChineseQuery|TokenizePreservesMixedLanguageBoundaries|ExtractKeywordsDropsSingleRuneChineseTokens|ExpandQueriesBuildsChineseKeywordVariant)$'`
- `go vet ./internal/application/service/chat_pipeline ./internal/application/service`
- `git diff --check`

`go test -count=1 ./internal/application/service` was also attempted. The latest upstream main has three unrelated Windows SQLite temp-file lock failures: `TestDataSourceServiceDeleteSQLiteCleansUpAfterSoftDelete`, `TestDataSourceServiceDeleteKeepsCleanupStateWhenSoftDeleteFails`, and `TestDeleteKnowledgeBaseCleansUpSQLiteDataSources`. Each fails during cleanup because `weknora.db` is still in use.
