### PR TITLE
fix(sqlite): serialize chunk seq id allocation

### DIFF
--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -52,14 +52,19 @@ func (r *chunkRepository) CreateChunks(ctx context.Context, chunks []*types.Chun
 
 	db := r.db.WithContext(ctx)
 
-	// SQLite doesn't support autoIncrement on non-PK columns,
-	// so we must pre-assign SeqIDs manually (safe: single connection).
-	// PostgreSQL / MySQL use DB sequences — skip to avoid duplicate key
-	// races under concurrent inserts.
+	// SQLite doesn't support autoIncrement on non-PK columns, so SeqIDs are
+	// assigned before insertion. MaxOpenConns(1) serializes individual SQL
+	// statements, but without a transaction another goroutine can run
+	// SELECT MAX(seq_id) between this call's SELECT and INSERT. The transaction
+	// pins the single SQLite connection across allocation and insertion.
+	// PostgreSQL / MySQL use DB sequences and do not need this path.
 	if db.Dialector.Name() == "sqlite" {
-		if err := types.AssignChunkSeqIDs(db, chunks); err != nil {
-			return fmt.Errorf("failed to assign chunk seq_ids: %w", err)
-		}
+		return db.Transaction(func(tx *gorm.DB) error {
+			if err := types.AssignChunkSeqIDs(tx, chunks); err != nil {
+				return fmt.Errorf("failed to assign chunk seq_ids: %w", err)
+			}
+			return tx.Select("*").CreateInBatches(chunks, 100).Error
+		})
 	}
 
 	// Select("*") ensures zero-value fields (IsEnabled=false, Flags=0) are

--- a/internal/application/repository/chunk_sqlite_concurrency_test.go
+++ b/internal/application/repository/chunk_sqlite_concurrency_test.go
@@ -1,0 +1,67 @@
+package repository
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateChunks_SQLiteConcurrentCallsAssignUniqueSeqIDs(t *testing.T) {
+	db := setupChunkTestDB(t)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	// Match the runtime pool configuration. A single connection serializes SQL
+	// statements, but the transaction is what makes allocation and insertion one
+	// indivisible operation for concurrent callers.
+	sqlDB.SetMaxOpenConns(1)
+
+	previousMaxProcs := runtime.GOMAXPROCS(8)
+	t.Cleanup(func() {
+		runtime.GOMAXPROCS(previousMaxProcs)
+	})
+
+	repo := NewChunkRepository(db)
+	ctx := context.Background()
+
+	const workers = 64
+	start := make(chan struct{})
+	results := make(chan error, workers)
+	chunks := make([]*types.Chunk, workers)
+
+	for i := 0; i < workers; i++ {
+		chunks[i] = makeChunk(
+			uuid.NewString(),
+			uuid.NewString(),
+			"text",
+		)
+		go func(chunk *types.Chunk) {
+			<-start
+			results <- repo.CreateChunks(
+				ctx,
+				[]*types.Chunk{chunk},
+			)
+		}(chunks[i])
+	}
+
+	close(start)
+
+	for i := 0; i < workers; i++ {
+		require.NoError(t, <-results)
+	}
+
+	seqIDs := make(map[int64]struct{}, workers)
+	for _, chunk := range chunks {
+		saved, err := repo.GetChunkByID(ctx, chunk.TenantID, chunk.ID)
+		require.NoError(t, err)
+		require.NotZero(t, saved.SeqID)
+		require.NotContains(t, seqIDs, saved.SeqID)
+		seqIDs[saved.SeqID] = struct{}{}
+	}
+	require.Len(t, seqIDs, workers)
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -711,9 +711,15 @@ func initDatabase(cfg *config.Config) (*gorm.DB, error) {
 
 	// Configure connection pool parameters
 	if os.Getenv("DB_DRIVER") == "sqlite" {
-		// SQLite only supports one concurrent writer even in WAL mode.
-		// Limiting to a single open connection serialises all DB access and
-		// prevents "database is locked" errors from concurrent goroutines.
+		// SQLite permits only one writer at a time. SQLite deployments
+		// intentionally use a single pooled connection to reduce SQLITE_BUSY
+		// contention between in-process goroutines.
+		//
+		// This serializes individual SQL statements, not multi-statement
+		// operations: read-modify-write sequences must still run in one
+		// transaction. The limit is scoped to this *sql.DB and does not
+		// coordinate other processes or database handles. Do not increase it
+		// without auditing SQLite transaction and ID-allocation paths.
 		sqlDB.SetMaxOpenConns(1)
 	} else {
 		sqlDB.SetMaxIdleConns(10)

--- a/internal/types/chunk.go
+++ b/internal/types/chunk.go
@@ -211,7 +211,8 @@ func (c *Chunk) EmbeddingContent() string {
 }
 
 // AssignChunkSeqIDs assigns sequential SeqIDs to a batch of chunks that have SeqID == 0.
-// Must be called before CreateInBatches for SQLite compatibility.
+// SQLite callers must run this and the subsequent insert in one transaction so
+// concurrent allocations cannot observe the same MAX(seq_id).
 func AssignChunkSeqIDs(tx *gorm.DB, chunks []*Chunk) error {
 	needAssign := false
 	for _, c := range chunks {


### PR DESCRIPTION
## Description

SQLite manually assigns `chunks.seq_id` by reading `MAX(seq_id)` before inserting a batch. Although SQLite deployments already use `SetMaxOpenConns(1)`, that setting only serializes individual SQL statements; concurrent goroutines could still interleave between the allocation query and the insert and select the same range.

This PR:

- runs SQLite SeqID allocation and `CreateInBatches` in the same transaction;
- keeps the existing single-connection SQLite runtime configuration and documents its actual guarantee;
- adds a 64-goroutine regression test matching `SetMaxOpenConns(1)`;
- leaves the PostgreSQL/MySQL path and all database schemas unchanged.

The fix is intentionally scoped to the current SQLite runtime contract: one pooled connection serializes in-process access, while the transaction makes the read-modify-write sequence atomic for concurrent callers. Coordinating multiple processes or independent database handles would require a separate database-backed sequence allocator.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Closes #2473

## Testing

Before the fix, the new regression test failed under `SetMaxOpenConns(1)` with:

```text
UNIQUE constraint failed: chunks.seq_id
```

After the fix:

```bash
env -u LOG_FORMAT go test ./internal/application/repository \
  -run '^TestCreateChunks_SQLiteConcurrentCallsAssignUniqueSeqIDs$' -count=100

env -u LOG_FORMAT go test -race ./internal/application/repository \
  -run '^TestCreateChunks_SQLiteConcurrentCallsAssignUniqueSeqIDs$' -count=1

env -u LOG_FORMAT go test ./...
go vet ./...
git diff --check 5780affdfc76342ddd0f5cf95b548a1a4d0b2a5a...HEAD
```

All commands passed. `golangci-lint` was not available in the local environment, so the diff-scoped lint checkbox remains unchecked.

Real UI verification used the normal multi-file upload entry against a source-built SQLite service:

- uploaded 50 distinct Markdown documents through the browser;
- all 50 document and summary Chunk writes succeeded;
- 5,400 Chunk rows produced 5,400 distinct SeqIDs in the continuous range `4923-10322`;
- no document failed and the fixed-service log contained zero occurrences of `UNIQUE constraint failed: chunks.seq_id`.

Independent Standards and Spec review passes reported no findings.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

Not applicable; this is a backend-only concurrency fix with no UI changes.
