### PR TITLE
fix(embed): keep host context out of retrieval queries

### DIFF
--- a/docs/api/chat.md
+++ b/docs/api/chat.md
@@ -20,6 +20,7 @@
 | 参数 | 类型 | 必填 | 说明 |
 |------|------|------|------|
 | `query` | string | 是 | 查询文本 |
+| `prompt_context` | string | 否 | 仅在 LLM Prompt 阶段注入，不参与直接 Query Rewrite 或检索 |
 | `knowledge_base_ids` | string[] | 否 | 知识库 ID 列表 |
 | `knowledge_ids` | string[] | 否 | 知识文件 ID 列表，指定具体文件进行检索 |
 | `agent_id` | string | 否 | 自定义 Agent ID，指定使用的智能体 |
@@ -68,6 +69,7 @@ Agent 模式支持更智能的问答，包括工具调用、网络搜索、多�
 | 参数 | 类型 | 必填 | 说明 |
 |------|------|------|------|
 | `query` | string | 是 | 查询文本 |
+| `prompt_context` | string | 否 | 对 Agent 模型可见；不直接作为检索 Query，但 Agent 可能据此生成工具搜索参数 |
 | `knowledge_base_ids` | string[] | 否 | 知识库 ID 列表，可动态指定本次查询使用的知识库 |
 | `knowledge_ids` | string[] | 否 | 知识文件 ID 列表，可动态指定本次查询使用的具体文件 |
 | `agent_enabled` | bool | 否 | 是否启用 Agent 模式（默认 false，优先使用 Agent 配置） |

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -22133,6 +22133,10 @@ const docTemplate = `{
                         "$ref": "#/definitions/internal_handler_session.MentionedItemRequest"
                     }
                 },
+                "prompt_context": {
+                    "description": "Optional LLM-only context; excluded from direct query rewrite and retrieval inputs",
+                    "type": "string"
+                },
                 "query": {
                     "description": "Query text for knowledge base search",
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -22126,6 +22126,10 @@
                         "$ref": "#/definitions/internal_handler_session.MentionedItemRequest"
                     }
                 },
+                "prompt_context": {
+                    "description": "Optional LLM-only context; excluded from direct query rewrite and retrieval inputs",
+                    "type": "string"
+                },
                 "query": {
                     "description": "Query text for knowledge base search",
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5642,6 +5642,9 @@ definitions:
         items:
           $ref: '#/definitions/internal_handler_session.MentionedItemRequest'
         type: array
+      prompt_context:
+        description: Optional LLM-only context; excluded from direct query rewrite and retrieval inputs
+        type: string
       query:
         description: Query text for knowledge base search
         type: string

--- a/frontend/src/api/chat/streame.ts
+++ b/frontend/src/api/chat/streame.ts
@@ -36,7 +36,7 @@ export function useStream() {
   let renderTimer: number | null = null
 
   // 启动流式请求
-  const startStream = async (params: { session_id: any; query: any; knowledge_base_ids?: string[]; knowledge_ids?: string[]; tag_ids?: string[]; agent_enabled?: boolean; agent_id?: string; agent_source_tenant_id?: string | number; web_search_enabled?: boolean; summary_model_id?: string; mcp_service_ids?: string[]; skill_names?: string[]; mentioned_items?: Array<{id: string; name: string; type: string; kb_type?: string; kb_id?: string; kb_name?: string; service_id?: string; skill_name?: string}>; images?: Array<{data: string}>; attachment_uploads?: Array<{data: string; file_name: string; file_size: number}>; attachment_ids?: string[]; suggestion_attribution?: { suggestion_set_id: string; question_id: string }; method: string; url: string; embed_token?: string; embed_session_sig?: string; embed_visitor_id?: string }) => {
+  const startStream = async (params: { session_id: any; query: any; prompt_context?: string; knowledge_base_ids?: string[]; knowledge_ids?: string[]; tag_ids?: string[]; agent_enabled?: boolean; agent_id?: string; agent_source_tenant_id?: string | number; web_search_enabled?: boolean; summary_model_id?: string; mcp_service_ids?: string[]; skill_names?: string[]; mentioned_items?: Array<{id: string; name: string; type: string; kb_type?: string; kb_id?: string; kb_name?: string; service_id?: string; skill_name?: string}>; images?: Array<{data: string}>; attachment_uploads?: Array<{data: string; file_name: string; file_size: number}>; attachment_ids?: string[]; suggestion_attribution?: { suggestion_set_id: string; question_id: string }; method: string; url: string; embed_token?: string; embed_session_sig?: string; embed_visitor_id?: string }) => {
     const myGeneration = ++streamGeneration
     // 重置状态
     output.value = '';
@@ -87,6 +87,9 @@ export function useStream() {
         query: params.query,
         agent_enabled: params.agent_enabled !== undefined ? params.agent_enabled : true
       };
+      if (params.prompt_context) {
+        postBody.prompt_context = params.prompt_context;
+      }
       // Always include knowledge_base_ids for agent-chat (already validated above)
       if (params.knowledge_base_ids !== undefined && params.knowledge_base_ids.length > 0) {
         postBody.knowledge_base_ids = params.knowledge_base_ids;
@@ -140,11 +143,15 @@ export function useStream() {
       }
       postBody.channel = embedToken ? "embed" : "web";
 
+      const debugBody = sanitizeStreamRequestBody(postBody);
+      if (Object.hasOwn(debugBody, 'prompt_context')) {
+        debugBody.prompt_context = '[redacted]';
+      }
       lastStreamRequest.value = {
         requestId: requestID,
         url,
         method: params.method,
-        body: params.method === 'POST' ? sanitizeStreamRequestBody(postBody) : null,
+        body: params.method === 'POST' ? debugBody : null,
         sentAt: Date.now(),
       };
       

--- a/frontend/src/composables/useEmbedChatSession.ts
+++ b/frontend/src/composables/useEmbedChatSession.ts
@@ -16,7 +16,7 @@ import {
   stopEmbedSession,
 } from '@/api/embed'
 import { embedToast } from '@/utils/embedToast'
-import { buildQueryWithHostContext } from '@/utils/embedContext'
+import { buildEmbedChatPayload } from '@/utils/embedContext'
 import { fileToDataURI } from '@/utils/embedFile'
 import { useI18n } from 'vue-i18n'
 import { useChatStreamHandler } from '@/composables/useChatStreamHandler'
@@ -249,7 +249,7 @@ export function useEmbedChatSession(options: {
   ) => {
     stopStream()
     prepareForNewOutgoingMessage()
-    const outboundQuery = buildQueryWithHostContext(value, options.hostContext?.value)
+    const outboundPayload = buildEmbedChatPayload(value, options.hostContext?.value)
     const visitorWebSearchEnabled = opts.webSearchEnabled ?? false
     const imageFiles = (options.allowFileUpload ? opts.imageFiles : undefined) || []
     const attachmentFiles = (options.allowFileUpload ? opts.attachmentFiles : undefined) || []
@@ -280,20 +280,20 @@ export function useEmbedChatSession(options: {
     }
 
     messagesList.push({
-      content: value,
+      content: outboundPayload.query,
       role: 'user',
       mentioned_items: [],
       images: displayImages,
       attachments: displayAttachments,
       channel: 'embed',
     })
-    postEmbedMessageSent(options.channelId, options.sessionId.value, value)
+    postEmbedMessageSent(options.channelId, options.sessionId.value, outboundPayload.query)
     relayEmbedWebhookEvent(
       options.channelId,
       options.token,
       options.sessionId.value,
       options.sessionSig.value,
-      { type: 'message_sent', query: value },
+      { type: 'message_sent', query: outboundPayload.query },
     )
     userHasScrolledUp.value = false
     scrollToBottom(true)
@@ -317,7 +317,8 @@ export function useEmbedChatSession(options: {
       mentioned_items: [],
       images: imageAttachments.length > 0 ? imageAttachments : undefined,
       attachment_uploads: attachmentUploads.length > 0 ? attachmentUploads : undefined,
-      query: outboundQuery,
+      query: outboundPayload.query,
+      prompt_context: outboundPayload.prompt_context,
       suggestion_attribution: suggestionAttribution || undefined,
       method: 'POST',
       url: endpoint,

--- a/frontend/src/utils/embedContext.test.ts
+++ b/frontend/src/utils/embedContext.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildEmbedChatPayload } from './embedContext.ts'
+
+test('buildEmbedChatPayload keeps host context out of the retrieval query', () => {
+  const query = 'How do I reset my password?'
+  const payload = buildEmbedChatPayload(query, {
+    page: 'checkout',
+    error: 'ERR_500',
+  })
+
+  assert.equal(payload.query, query)
+  assert.ok(payload.prompt_context)
+  assert.doesNotMatch(payload.query, /checkout|ERR_500|Host context/)
+})
+
+test('buildEmbedChatPayload serializes JSON, newlines, and special characters', () => {
+  const hostContext = {
+    details: {
+      message: 'line one\nline two',
+      symbols: '<>&"\'\\',
+      values: [1, true, null],
+    },
+  }
+
+  const payload = buildEmbedChatPayload('original question', hostContext)
+
+  assert.equal(payload.query, 'original question')
+  assert.ok(payload.prompt_context?.startsWith('[Host context]\n'))
+  assert.deepEqual(
+    JSON.parse(payload.prompt_context!.slice('[Host context]\n'.length)),
+    hostContext,
+  )
+})
+
+test('buildEmbedChatPayload is backward compatible without usable host context', () => {
+  assert.deepEqual(buildEmbedChatPayload('hello'), { query: 'hello' })
+  assert.deepEqual(buildEmbedChatPayload('hello', {}), { query: 'hello' })
+  assert.deepEqual(
+    buildEmbedChatPayload('hello', { empty: '', nil: null, missing: undefined }),
+    { query: 'hello' },
+  )
+})

--- a/frontend/src/utils/embedContext.ts
+++ b/frontend/src/utils/embedContext.ts
@@ -1,12 +1,20 @@
-/** Prefix host-injected context onto the user query for embed chat. */
-export function buildQueryWithHostContext(
+export interface EmbedChatPayload {
+  query: string
+  prompt_context?: string
+}
+
+/** Build an embed chat payload without mixing host context into the retrieval query. */
+export function buildEmbedChatPayload(
   query: string,
   hostContext?: Record<string, unknown>,
-): string {
-  if (!hostContext || !Object.keys(hostContext).length) return query
-  const lines = Object.entries(hostContext)
+): EmbedChatPayload {
+  if (!hostContext || !Object.keys(hostContext).length) return { query }
+  const entries = Object.entries(hostContext)
     .filter(([, v]) => v !== undefined && v !== null && v !== '')
-    .map(([k, v]) => `${k}: ${typeof v === 'string' ? v : JSON.stringify(v)}`)
-  if (!lines.length) return query
-  return `[Host context]\n${lines.join('\n')}\n\n${query}`
+  if (!entries.length) return { query }
+
+  return {
+    query,
+    prompt_context: `[Host context]\n${JSON.stringify(Object.fromEntries(entries), null, 2)}`,
+  }
 }

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -30,6 +30,7 @@ type qaRequestContext struct {
 	requestID             string
 	receivedAt            time.Time // Wall-clock time the handler started processing the request
 	query                 string
+	promptContext         string // LLM-only context; never merged into the retrieval query or persisted Message.Content
 	session               *types.Session
 	customAgent           *types.CustomAgent
 	assistantMessage      *types.Message
@@ -65,6 +66,7 @@ func (rc *qaRequestContext) buildQARequest() *types.QARequest {
 	return &types.QARequest{
 		Session:             rc.session,
 		Query:               rc.query,
+		QuotedContext:       rc.promptContext,
 		AssistantMessageID:  rc.assistantMessage.ID,
 		SummaryModelID:      rc.summaryModelID,
 		CustomAgent:         rc.customAgent,
@@ -124,7 +126,9 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 	}
 
 	// Log request details
-	if requestJSON, err := json.Marshal(request); err == nil {
+	requestForLog := request
+	requestForLog.PromptContext = ""
+	if requestJSON, err := json.Marshal(requestForLog); err == nil {
 		logger.Infof(ctx, "[%s] Request: session_id=%s, request=%s",
 			logPrefix, sessionID, secutils.SanitizeForLog(secutils.CompactImageDataURLForLog(string(requestJSON))))
 	}
@@ -322,14 +326,15 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 
 	// Build request context
 	reqCtx := &qaRequestContext{
-		ctx:         ctx,
-		c:           c,
-		sessionID:   sessionID,
-		requestID:   requestID,
-		receivedAt:  receivedAt,
-		query:       request.Query,
-		session:     session,
-		customAgent: customAgent,
+		ctx:           ctx,
+		c:             c,
+		sessionID:     sessionID,
+		requestID:     requestID,
+		receivedAt:    receivedAt,
+		query:         request.Query,
+		promptContext: request.PromptContext,
+		session:       session,
+		customAgent:   customAgent,
 		assistantMessage: &types.Message{
 			SessionID:        sessionID,
 			Role:             "assistant",

--- a/internal/handler/session/qa_prompt_context_test.go
+++ b/internal/handler/session/qa_prompt_context_test.go
@@ -1,0 +1,86 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	chatpipeline "github.com/Tencent/WeKnora/internal/application/service/chat_pipeline"
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateKnowledgeQARequestParsesPromptContext(t *testing.T) {
+	const promptContext = "[Host context]\n{\"error\":\"ERR_500\",\"details\":\"line one\nline two <>&\\\"\"}"
+	raw, err := json.Marshal(map[string]string{
+		"query":          "reset password",
+		"prompt_context": promptContext,
+	})
+	require.NoError(t, err)
+
+	var request CreateKnowledgeQARequest
+	require.NoError(t, json.Unmarshal(raw, &request))
+	assert.Equal(t, promptContext, request.PromptContext)
+}
+
+func TestBuildQARequestKeepsPromptContextSeparateFromQuery(t *testing.T) {
+	const (
+		query         = "How do I reset my password?"
+		promptContext = "[Host context]\n{\"page\":\"checkout\",\"error\":\"ERR_500\"}"
+	)
+	rc := &qaRequestContext{
+		query:            query,
+		promptContext:    promptContext,
+		assistantMessage: &types.Message{ID: "assistant-1"},
+	}
+
+	request := rc.buildQARequest()
+	assert.Equal(t, query, request.Query)
+	assert.Equal(t, promptContext, request.QuotedContext)
+	assert.NotContains(t, request.Query, "checkout")
+	assert.NotContains(t, request.Query, "ERR_500")
+}
+
+func TestQuotedContextRemainsPromptOnlyForKnowledgeQA(t *testing.T) {
+	const (
+		query         = "How do I reset my password?"
+		promptContext = "[Host context]\n{\"page\":\"checkout\",\"error\":\"ERR_500\"}"
+	)
+
+	queryManager := chatpipeline.NewEventManager()
+	chatpipeline.NewPluginQueryUnderstand(queryManager, nil, nil, &config.Config{})
+	chatManage := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{
+			Query:         query,
+			EnableRewrite: false,
+		},
+		PipelineState: types.PipelineState{QuotedContext: promptContext},
+	}
+
+	require.Nil(t, queryManager.Trigger(context.Background(), types.QUERY_UNDERSTAND, chatManage))
+	assert.Equal(t, query, chatManage.RewriteQuery)
+	assert.NotContains(t, chatManage.RewriteQuery, "checkout")
+	assert.NotContains(t, chatManage.RewriteQuery, "ERR_500")
+
+	promptManager := chatpipeline.NewEventManager()
+	chatpipeline.NewPluginIntoChatMessage(promptManager, nil)
+	chatManage.SummaryConfig.ContextTemplate = "Question: {{query}}\nSources: {{contexts}}"
+	require.Nil(t, promptManager.Trigger(context.Background(), types.INTO_CHAT_MESSAGE, chatManage))
+	assert.Contains(t, chatManage.UserContent, query)
+	assert.Contains(t, chatManage.UserContent, promptContext)
+	assert.True(t, strings.HasSuffix(chatManage.UserContent, promptContext))
+}
+
+func TestBuildQARequestWithoutPromptContextIsUnchanged(t *testing.T) {
+	rc := &qaRequestContext{
+		query:            "hello",
+		assistantMessage: &types.Message{ID: "assistant-1"},
+	}
+
+	request := rc.buildQARequest()
+	assert.Equal(t, "hello", request.Query)
+	assert.Empty(t, request.QuotedContext)
+}

--- a/internal/handler/session/types.go
+++ b/internal/handler/session/types.go
@@ -60,6 +60,8 @@ type CreateKnowledgeQARequest struct {
 	AttachmentIDs         []string                     `json:"attachment_ids,omitempty"`              // Pre-uploaded session-scoped document IDs
 	Channel               string                       `json:"channel"`                               // Source channel: "web", "api", "im", etc.
 	SuggestionAttribution *types.SuggestionAttribution `json:"suggestion_attribution,omitempty"`
+	// PromptContext is optional LLM-only context excluded from direct query rewrite and retrieval inputs.
+	PromptContext string `json:"prompt_context,omitempty"`
 }
 
 // AttachmentUpload represents a file attachment upload from the client

--- a/internal/types/qa_request.go
+++ b/internal/types/qa_request.go
@@ -19,6 +19,6 @@ type QARequest struct {
 	ImageDescription    string             // VLM-generated image description (fallback for non-vision models)
 	UserMessageID       string             // Created user message ID
 	WebSearchEnabled    bool               // Whether web search is enabled for this request
-	QuotedContext       string             // Quoted message content from IM quote-reply (appended at LLM prompt stage, not used for retrieval)
+	QuotedContext       string             // Prompt-only IM quote or API context
 	Attachments         MessageAttachments // File attachments (processed and ready for prompt injection)
 }


### PR DESCRIPTION
## Description

The Embed client previously prefixed host-provided context to the user's
`query`. The combined value then entered query rewriting, embedding generation,
BM25/vector retrieval, and request-side observability.

This change separates the two semantic channels:

- `query`: the user's original question and direct retrieval input
- `prompt_context`: optional context injected when the LLM prompt is built

The new field is mapped to the existing prompt-only
`QARequest.QuotedContext` path. UI messages, persisted user message content,
and `message_sent` webhooks continue to use the original query. The committed
Chat API documentation and Swagger schema now expose the optional field.

### Agent-mode boundary

For Knowledge QA, `prompt_context` is excluded from direct query rewriting and
retrieval.

For Agent QA, the context remains visible to the agent model. The model may
therefore use it when generating tool search arguments. This PR does not claim
complete isolation from agent-generated searches and does not change existing
IM quote-reply behavior.

### Privacy

Prompt context is redacted from request debug logs and is not added to the
`message_sent` webhook. The rendered LLM input may still contain it as part of
the execution snapshot, while the canonical persisted user message remains the
original query.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Related to #2185

## Testing

Passed:

- `go test ./internal/handler/session -run 'PromptContext|QuotedContext' -count=1`
- `go test ./internal/handler/session -count=1`
- `go test ./internal/application/service/chat_pipeline -count=1`
- `go test ./internal/application/service -run 'KnowledgeQA|AgentQA|QuotedContext|Fallback' -count=1`
- `go test ./internal/handler -run 'Embed|PatchEmbed' -count=1`
- `go test ./internal/im -run 'FormatQuotedContext|BuildIMQARequest_QuotedContext' -count=1`
- `go test -race ./internal/handler/session -run 'PromptContext|QuotedContext' -count=1`
- `go vet ./internal/handler/session ./internal/application/service/chat_pipeline`
- `go test -run '^$' ./...` (all repository Go packages compiled with Go 1.26.0)
- `pnpm run test` from an isolated frontend verification copy: 293/293 tests passed
- `pnpm run type-check` from the same copy
- `gofmt` on all changed Go files
- `git diff upstream/main...HEAD --check`
- Swagger JSON parse validation

Not run:

- `golangci-lint run --new-from-rev=upstream/main ./...`: `golangci-lint` is not installed in the execution environment.
- `go test ./...`: repository-wide runtime tests may require local infrastructure or service configuration. Targeted tests and the repository-wide compile-only check passed without calling a real LLM, embedding API, or database service.

No unrelated baseline failures were observed in the final passing checks.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (tool unavailable; documented above)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above (none)

## Screenshots / Recordings

Not applicable. This changes request semantics without a visible UI change.
