### PR TITLE
fix(knowledgebase): clean up wiki data when deleting a knowledge base

### DIFF
--- a/internal/application/repository/wiki_page.go
+++ b/internal/application/repository/wiki_page.go
@@ -1123,6 +1123,35 @@ func (r *wikiPageRepository) DeleteByID(ctx context.Context, id string) error {
 	return nil
 }
 
+// DeleteByKnowledgeBase removes every wiki row a knowledge base owns when the
+// KB itself is deleted. Pages, folders and issues carry gorm.DeletedAt, so
+// they follow the soft-delete semantics of the per-row Delete/DeleteFolder
+// methods above; revisions have no deleted_at column, so they are hard-deleted
+// exactly like DeleteRevisionsByPage. The sweep runs in one transaction so a
+// retried KB-delete task never observes a half-cleaned wiki. An empty kbID is
+// a no-op — it must never degrade into a table-wide delete.
+func (r *wikiPageRepository) DeleteByKnowledgeBase(ctx context.Context, kbID string) error {
+	if kbID == "" {
+		return nil
+	}
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("knowledge_base_id = ?", kbID).
+			Delete(&types.WikiPageRevision{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("knowledge_base_id = ?", kbID).
+			Delete(&types.WikiPage{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("knowledge_base_id = ?", kbID).
+			Delete(&types.WikiFolder{}).Error; err != nil {
+			return err
+		}
+		return tx.Where("knowledge_base_id = ?", kbID).
+			Delete(&types.WikiPageIssue{}).Error
+	})
+}
+
 // escapeLikePattern escapes LIKE / ILIKE metacharacters so the returned string
 // can be safely concatenated with % wildcards without unintended matches.
 // Order matters: escape the backslash first, then the wildcards.

--- a/internal/application/repository/wiki_page_test.go
+++ b/internal/application/repository/wiki_page_test.go
@@ -93,12 +93,32 @@ CREATE TABLE IF NOT EXISTS wiki_folders (
 );
 `
 
+// wikiPageIssuesTestDDL mirrors the production wiki_page_issues DDL
+// (migrations/versioned/000037_wiki_and_indexing.up.sql) for SQLite.
+const wikiPageIssuesTestDDL = `
+CREATE TABLE IF NOT EXISTS wiki_page_issues (
+    id                      VARCHAR(36) PRIMARY KEY,
+    tenant_id               INTEGER NOT NULL,
+    knowledge_base_id       VARCHAR(36) NOT NULL,
+    slug                    VARCHAR(255) NOT NULL,
+    issue_type              VARCHAR(50) NOT NULL,
+    description             TEXT NOT NULL,
+    suspected_knowledge_ids TEXT,
+    status                  VARCHAR(20) NOT NULL DEFAULT 'pending',
+    reported_by             VARCHAR(100) NOT NULL,
+    created_at              DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at              DATETIME DEFAULT CURRENT_TIMESTAMP,
+    deleted_at              DATETIME
+);
+`
+
 func setupWikiPagesTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.Exec(wikiPagesTestDDL).Error)
 	require.NoError(t, db.Exec(wikiFoldersTestDDL).Error)
+	require.NoError(t, db.Exec(wikiPageIssuesTestDDL).Error)
 	for _, stmt := range strings.Split(strings.TrimSpace(wikiPageRevisionsTestDDL), ";") {
 		if strings.TrimSpace(stmt) == "" {
 			continue
@@ -517,4 +537,88 @@ func TestDeleteRevisionsByPageOnlyTouchesThatPage(t *testing.T) {
 	// An empty id must not turn into a table-wide delete.
 	require.NoError(t, repo.DeleteRevisionsByPage(ctx, ""))
 	assert.Equal(t, int64(1), countWikiRevisions(t, db, bystander.ID))
+}
+
+// countSoftDeletedWikiRows counts rows of the given model that carry a
+// deleted_at timestamp, bypassing GORM's soft-delete filter.
+func countSoftDeletedWikiRows(t *testing.T, db *gorm.DB, model interface{}, kbID string) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, db.Unscoped().Model(model).
+		Where("knowledge_base_id = ? AND deleted_at IS NOT NULL", kbID).
+		Count(&n).Error)
+	return n
+}
+
+// TestDeleteByKnowledgeBaseRemovesAllWikiData covers the KB-delete cleanup
+// path: every wiki table owned by the victim KB must be cleaned — pages,
+// folders and issues soft-deleted (matching the per-row Delete methods),
+// revisions hard-deleted (they have no deleted_at column) — while a sibling
+// KB stays fully intact. An empty KB id must never widen into a table-wide
+// delete.
+func TestDeleteByKnowledgeBaseRemovesAllWikiData(t *testing.T) {
+	db := setupWikiPagesTestDB(t)
+	repo := NewWikiPageRepository(db)
+	ctx := context.Background()
+
+	seed := func(kbID, slug, folderID string) *types.WikiPage {
+		page := makeWikiPage(kbID, slug, types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+		require.NoError(t, repo.Create(ctx, page))
+		require.NoError(t, db.Create(makeWikiRevision(page, 1, types.WikiEditSourceUser)).Error)
+		require.NoError(t, repo.CreateFolder(ctx, &types.WikiFolder{
+			ID: folderID, TenantID: 1, KnowledgeBaseID: kbID,
+			Name: "folder", Path: "folder", Depth: 1,
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		}))
+		require.NoError(t, db.Create(&types.WikiPageIssue{
+			ID: uuid.New().String(), TenantID: 1, KnowledgeBaseID: kbID,
+			Slug: slug, IssueType: "broken_link", Description: "dangling link",
+			ReportedBy: "lint",
+		}).Error)
+		return page
+	}
+
+	victimPage := seed("kb-victim", "entity/victim", "f-victim")
+	bystanderPage := seed("kb-bystander", "entity/bystander", "f-bystander")
+
+	// A page that was already soft-deleted before the KB delete must stay
+	// soft-deleted and not trip the sweep.
+	gonePage := makeWikiPage("kb-victim", "entity/gone", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	require.NoError(t, repo.Create(ctx, gonePage))
+	require.NoError(t, repo.DeleteByID(ctx, gonePage.ID))
+
+	require.NoError(t, repo.DeleteByKnowledgeBase(ctx, "kb-victim"))
+
+	// Pages: hidden from live queries; both victim rows remain as
+	// soft-deleted rows (live + previously deleted).
+	_, err := repo.GetBySlug(ctx, "kb-victim", "entity/victim")
+	assert.ErrorIs(t, err, ErrWikiPageNotFound)
+	assert.Equal(t, int64(2), countSoftDeletedWikiRows(t, db, &types.WikiPage{}, "kb-victim"))
+
+	// Revisions: hard-deleted.
+	assert.Zero(t, countWikiRevisions(t, db, victimPage.ID))
+
+	// Folders and issues: soft-deleted, hidden from live queries.
+	_, err = repo.GetFolderByID(ctx, "kb-victim", "f-victim")
+	assert.ErrorIs(t, err, ErrWikiFolderNotFound)
+	assert.Equal(t, int64(1), countSoftDeletedWikiRows(t, db, &types.WikiFolder{}, "kb-victim"))
+	assert.Equal(t, int64(1), countSoftDeletedWikiRows(t, db, &types.WikiPageIssue{}, "kb-victim"))
+
+	// Bystander KB is fully intact.
+	_, err = repo.GetBySlug(ctx, "kb-bystander", "entity/bystander")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), countWikiRevisions(t, db, bystanderPage.ID))
+	_, err = repo.GetFolderByID(ctx, "kb-bystander", "f-bystander")
+	require.NoError(t, err)
+	assert.Zero(t, countSoftDeletedWikiRows(t, db, &types.WikiPage{}, "kb-bystander"))
+	assert.Zero(t, countSoftDeletedWikiRows(t, db, &types.WikiFolder{}, "kb-bystander"))
+	assert.Zero(t, countSoftDeletedWikiRows(t, db, &types.WikiPageIssue{}, "kb-bystander"))
+
+	// An empty id must not turn into a table-wide delete.
+	require.NoError(t, repo.DeleteByKnowledgeBase(ctx, ""))
+	_, err = repo.GetBySlug(ctx, "kb-bystander", "entity/bystander")
+	require.NoError(t, err)
+
+	// The sweep is idempotent so a retried KB-delete task succeeds.
+	require.NoError(t, repo.DeleteByKnowledgeBase(ctx, "kb-victim"))
 }

--- a/internal/application/service/knowledgebase.go
+++ b/internal/application/service/knowledgebase.go
@@ -34,6 +34,7 @@ type knowledgeBaseService struct {
 	chunkRepo       interfaces.ChunkRepository
 	shareRepo       interfaces.KBShareRepository
 	kbShareService  interfaces.KBShareService
+	wikiPageRepo    interfaces.WikiPageRepository
 	modelService    interfaces.ModelService
 	retrieveEngine  interfaces.RetrieveEngineRegistry
 	ownership       retriever.TenantStoreOwnership
@@ -56,6 +57,7 @@ func NewKnowledgeBaseService(repo interfaces.KnowledgeBaseRepository,
 	chunkRepo interfaces.ChunkRepository,
 	shareRepo interfaces.KBShareRepository,
 	kbShareService interfaces.KBShareService,
+	wikiPageRepo interfaces.WikiPageRepository,
 	modelService interfaces.ModelService,
 	retrieveEngine interfaces.RetrieveEngineRegistry,
 	ownership retriever.TenantStoreOwnership,
@@ -77,6 +79,7 @@ func NewKnowledgeBaseService(repo interfaces.KnowledgeBaseRepository,
 		chunkRepo:       chunkRepo,
 		shareRepo:       shareRepo,
 		kbShareService:  kbShareService,
+		wikiPageRepo:    wikiPageRepo,
 		modelService:    modelService,
 		retrieveEngine:  retrieveEngine,
 		ownership:       ownership,
@@ -953,6 +956,23 @@ func (s *knowledgeBaseService) ProcessKBDelete(ctx context.Context, t *asynq.Tas
 		// Delete all knowledge entries from database
 		logger.Infof(ctx, "Deleting knowledge entries from database")
 		if err := s.kgRepo.DeleteKnowledgeList(ctx, tenantID, knowledgeIDs); err != nil {
+			logger.ErrorWithFields(ctx, err, map[string]interface{}{
+				"knowledge_base_id": kbID,
+			})
+			return err
+		}
+	}
+
+	// Step 3: Delete the wiki rows this KB owned (pages, folders, issues and
+	// their revision history). This sits outside the knowledge-list block
+	// above: per-document deletes never touch wiki data, so a KB whose
+	// documents were removed one by one can still hold live wiki pages that
+	// would otherwise stay orphaned forever. Like the knowledge-row delete,
+	// these are pure DB rows, so a failure is returned for asynq to retry
+	// rather than swallowed — the deferred queue scrub still runs either way.
+	if s.wikiPageRepo != nil {
+		logger.Infof(ctx, "Deleting wiki data for knowledge base, ID: %s", kbID)
+		if err := s.wikiPageRepo.DeleteByKnowledgeBase(ctx, kbID); err != nil {
 			logger.ErrorWithFields(ctx, err, map[string]interface{}{
 				"knowledge_base_id": kbID,
 			})

--- a/internal/types/interfaces/wiki_page.go
+++ b/internal/types/interfaces/wiki_page.go
@@ -370,6 +370,12 @@ type WikiPageRepository interface {
 	// DeleteByID soft-deletes a wiki page by ID.
 	DeleteByID(ctx context.Context, id string) error
 
+	// DeleteByKnowledgeBase removes all wiki rows owned by a knowledge base —
+	// pages, folders and issues are soft-deleted (they carry gorm.DeletedAt),
+	// revision snapshots are hard-deleted (no deleted_at column) — in one
+	// transaction. Used by the async KB-delete cleanup; a no-op for "".
+	DeleteByKnowledgeBase(ctx context.Context, kbID string) error
+
 	// Search performs full-text search on wiki pages within a knowledge base.
 	Search(ctx context.Context, kbID string, query string, limit int) ([]*types.WikiPage, error)
 


### PR DESCRIPTION
## Description

Deleting a knowledge base runs the async `ProcessKBDelete` task, which removes embeddings, chunks, physical files, graph data and the knowledge rows — but never touches the wiki tables. After a KB with an active wiki is deleted, its `wiki_pages`, `wiki_folders`, `wiki_page_issues` and `wiki_page_revisions` rows stay orphaned forever, unreachable from any UI or API surface.

This PR adds `WikiPageRepository.DeleteByKnowledgeBase` and calls it from `ProcessKBDelete`:

- **Semantics follow each table’s existing conventions**: pages, folders and issues carry `gorm.DeletedAt` and are soft-deleted (matching the per-row `Delete`/`DeleteFolder` methods); revisions have no `deleted_at` column and are hard-deleted (matching `DeleteRevisionsByPage`).
- The sweep runs in **one transaction**, is **idempotent** (safe under asynq retries), and treats an empty KB ID as a no-op so it can never degrade into a table-wide delete.
- It sits **outside** the `len(knowledgeList) > 0` block: documents deleted one by one never touch wiki data, so a KB whose documents were already removed individually can still hold live wiki pages.
- Failures are **returned for asynq to retry** (matching the knowledge-row delete semantics for pure DB rows) instead of being swallowed as warnings; the deferred queue scrub still runs on every return path.

Note: `wiki_log_entries` is intentionally not covered — the table was removed by migration `000077_remove_wiki_log` and wiki activity now flows through the audit log.

## Type of Change
- [x] 🐛 Bug fix

## Related Issue

N/A

## Testing

- New `TestDeleteByKnowledgeBaseRemovesAllWikiData` covers: soft delete of pages/folders/issues, hard delete of revisions, already-soft-deleted rows not interfering, a sibling KB left untouched, empty KB ID not deleting the whole table, and idempotency across repeated calls.
- `go test ./internal/application/repository/ -count=1` — passes
- `go test ./internal/application/service/ -count=1` — 3 failures reproduce identically on a clean `main` checkout (Windows sqlite temp-file lock flake in unrelated tests); all other tests pass
- `gofmt -l` on changed files — clean; `git diff --check` — passes
- `golangci-lint run --new-from-rev=upstream/main ./internal/...` — 0 issues
- Full `go build ./...` is blocked by pre-existing Windows toolchain issues (duckdb prebuilt static lib incompatible with the local mingw gcc; reproduced on clean `main`), unrelated to this change

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (method-level comments document the soft/hard delete choice)
- [x] Breaking changes are clearly called out in the description above