### PR TITLE
fix(knowledge): clear stale error_message on reprocessing and finalize

### DIFF
--- a/internal/application/repository/knowledge.go
+++ b/internal/application/repository/knowledge.go
@@ -437,7 +437,10 @@ func (r *knowledgeRepository) UpdateActiveDeletingKnowledgeColumns(
 // FinalizeSubtask atomically decrements pending_subtasks_count and, when
 // the counter reaches zero while parse_status is still 'finalizing',
 // flips the row to 'completed' in the same statement so concurrent
-// subtask completions can't race the promotion.
+// subtask completions can't race the promotion. Both this promotion and
+// SetFinalizing clear error_message: a row that re-enters processing or
+// finishes successfully must not keep displaying a failure from a
+// previous attempt.
 //
 // Returns (newCount, promoted, error). promoted is true iff this caller
 // was the one whose UPDATE flipped 'finalizing'→'completed'.
@@ -481,9 +484,10 @@ func (r *knowledgeRepository) FinalizeSubtask(
 		Where("id = ? AND parse_status = ? AND pending_subtasks_count = 0",
 			id, types.ParseStatusFinalizing).
 		Updates(map[string]interface{}{
-			"parse_status": types.ParseStatusCompleted,
-			"processed_at": now,
-			"updated_at":   now,
+			"parse_status":  types.ParseStatusCompleted,
+			"error_message": "",
+			"processed_at":  now,
+			"updated_at":    now,
 		})
 	if promoteRes.Error != nil {
 		return 0, false, promoteRes.Error
@@ -526,6 +530,7 @@ func (r *knowledgeRepository) SetFinalizing(
 		Updates(map[string]interface{}{
 			"parse_status":           types.ParseStatusFinalizing,
 			"pending_subtasks_count": expectedSubtasks,
+			"error_message":          "",
 			"updated_at":             now,
 		})
 	if res.Error != nil {

--- a/internal/application/repository/knowledge_finalize_test.go
+++ b/internal/application/repository/knowledge_finalize_test.go
@@ -91,6 +91,13 @@ func reloadKnowledgeRow(t *testing.T, db *gorm.DB, id string) (status string, co
 	return status, count
 }
 
+func reloadKnowledgeErrorMessage(t *testing.T, db *gorm.DB, id string) string {
+	t.Helper()
+	var msg string
+	require.NoError(t, db.Raw(`SELECT COALESCE(error_message, '') FROM knowledges WHERE id = ?`, id).Scan(&msg).Error)
+	return msg
+}
+
 func insertKnowledgeWithStatus(t *testing.T, db *gorm.DB, status string, deleted bool) string {
 	t.Helper()
 	id := uuid.New().String()
@@ -204,6 +211,41 @@ func TestFinalizeSubtask_DecrementClampedAtZero(t *testing.T) {
 	status, count := reloadKnowledgeRow(t, db, id)
 	assert.Equal(t, types.ParseStatusCompleted, status)
 	assert.Equal(t, 0, count, "pending_subtasks_count must be clamped at zero")
+}
+
+// TestSetFinalizingAndFinalizeSubtask_ClearStaleErrorMessage is the
+// regression test for stale error_message: a row that failed once keeps
+// error_message set, and both entering finalizing (a new attempt) and
+// promoting to completed (a successful finish) must clear it so the UI
+// no longer shows an outdated failure.
+func TestSetFinalizingAndFinalizeSubtask_ClearStaleErrorMessage(t *testing.T) {
+	db := setupKnowledgeTestDB(t)
+	repo := NewKnowledgeRepository(db).(*knowledgeRepository)
+	ctx := context.Background()
+
+	id := insertProcessingKnowledge(t, db)
+	require.NoError(t, db.Exec(
+		`UPDATE knowledges SET error_message = ? WHERE id = ?`,
+		"Task interrupted due to application restart",
+		id,
+	).Error)
+
+	transitioned, err := repo.SetFinalizing(ctx, id, 1)
+	require.NoError(t, err)
+	require.True(t, transitioned)
+	assert.Empty(t, reloadKnowledgeErrorMessage(t, db, id),
+		"SetFinalizing must clear error_message from the previous attempt")
+
+	require.NoError(t, db.Exec(
+		`UPDATE knowledges SET error_message = ? WHERE id = ?`,
+		"stale finalizing failure",
+		id,
+	).Error)
+	_, promoted, err := repo.FinalizeSubtask(ctx, id)
+	require.NoError(t, err)
+	require.True(t, promoted)
+	assert.Empty(t, reloadKnowledgeErrorMessage(t, db, id),
+		"promotion to completed must clear error_message")
 }
 
 // TestUpdateKnowledge_DoesNotClobberPendingCounter is the regression test

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -3113,6 +3113,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 		return nil
 	}
 	knowledge.ParseStatus = "processing"
+	knowledge.ErrorMessage = ""
 	knowledge.UpdatedAt = time.Now()
 	if err := s.repo.UpdateKnowledge(ctx, knowledge); err != nil {
 		logger.Errorf(ctx, "failed to update knowledge status to processing: %v", err)


### PR DESCRIPTION
## Description

Once a knowledge item fails, `error_message` stays set on the row. When the item is later reprocessed or driven through the finalizing pipeline, nothing clears that column, so the UI keeps displaying an outdated failure message on items that are processing again or have already completed successfully.

This PR clears `error_message` at exactly the transitions where a stale failure becomes misleading:

- `SetFinalizing` — clears it in the same atomic `UPDATE` that flips `parse_status` to `finalizing`
- `FinalizeSubtask` — clears it in the same atomic `UPDATE` that promotes `finalizing` → `completed` (so a successfully promoted row can’t surface an error from a previous attempt)
- `ProcessDocument` — clears `knowledge.ErrorMessage` when the row flips back to `processing` for a new attempt

Both repository transitions clear the column inside the same conditional `UPDATE` that guards on the current status, so the atomicity/race properties of the existing code are unchanged.

## Type of Change
- [x] 🐛 Bug fix

## Related Issue

N/A

## Testing

- New SQLite-backed regression test `TestSetFinalizingAndFinalizeSubtask_ClearStaleErrorMessage`: seeds a stale `error_message`, asserts `SetFinalizing` clears it, re-seeds, and asserts the `FinalizeSubtask` promotion clears it again.
- `go test ./internal/application/repository/ -count=1` — passes
- `gofmt -l` on changed files — clean; `git diff --check` — passes
- `golangci-lint run --new-from-rev=upstream/main ./internal/...` — 0 issues

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (method comment documents the clearing semantics)
- [x] Breaking changes are clearly called out in the description above