### PR TITLE
feat(wiki): cap hub-page write amplification during ingest

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -19768,8 +19768,16 @@ const docTemplate = `{
                     "description": "IngestReduceParallel sets the errgroup limit for the Reduce phase\n(per-slug page write) WITHIN one batch. 0 falls back to 10. Bound by the\nsame LLM concurrency / HTTP pool considerations as the Map phase, plus\nDB connection pool size. Same multiplier caveat as IngestMapParallel.",
                     "type": "integer"
                 },
+                "max_page_content_bytes": {
+                    "description": "MaxPageContentBytes caps how large a single wiki page's markdown body\nmay grow before ingest stops re-synthesizing it. 0 (default) disables\nthe cap — existing behaviour, pages grow unbounded.\n\nHighly-referenced \"hub\" entity/concept pages (e.g. a company cited by\nevery research report) otherwise accumulate hundreds of KB of content\nand get re-synthesized on every ingest that touches them. Each such\nrewrite re-tokenizes the whole body into the wiki_pages fulltext GIN\nindex (title + content), turning a single-row UPDATE into the dominant\ningest write-amplification cost. When a page is already at/over this\ncap and the current batch only ADDS information (no retractions),\ningest skips the LLM re-synthesis and persists only the bookkeeping\ncolumns (source/chunk refs) via the content-preserving UpdateMeta\npath — so the fulltext GIN is never touched. Retractions still\nregenerate the page (they shrink it). New information for a capped\nhub page remains fully retrievable from its own source documents; it\njust stops being woven into the oversized hub page.",
+                    "type": "integer"
+                },
                 "max_pages_per_ingest": {
                     "description": "MaxPagesPerIngest limits pages created/updated per ingest operation (0 = no limit)",
+                    "type": "integer"
+                },
+                "max_refs": {
+                    "description": "MaxRefs caps the length of a page's chunk_refs array (most-recent\nentries kept). 0 (default) disables the cap. Bounds per-row JSONB /\nTOAST write size on hub pages whose chunk citations grow into the\nthousands. The page body's inline [cNNN] citations are unaffected;\nthis only trims the provenance index used for evidence surfacing and\ndelete reconciliation.",
                     "type": "integer"
                 },
                 "synthesis_model_id": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -19761,8 +19761,16 @@
                     "description": "IngestReduceParallel sets the errgroup limit for the Reduce phase\n(per-slug page write) WITHIN one batch. 0 falls back to 10. Bound by the\nsame LLM concurrency / HTTP pool considerations as the Map phase, plus\nDB connection pool size. Same multiplier caveat as IngestMapParallel.",
                     "type": "integer"
                 },
+                "max_page_content_bytes": {
+                    "description": "MaxPageContentBytes caps how large a single wiki page's markdown body\nmay grow before ingest stops re-synthesizing it. 0 (default) disables\nthe cap — existing behaviour, pages grow unbounded.\n\nHighly-referenced \"hub\" entity/concept pages (e.g. a company cited by\nevery research report) otherwise accumulate hundreds of KB of content\nand get re-synthesized on every ingest that touches them. Each such\nrewrite re-tokenizes the whole body into the wiki_pages fulltext GIN\nindex (title + content), turning a single-row UPDATE into the dominant\ningest write-amplification cost. When a page is already at/over this\ncap and the current batch only ADDS information (no retractions),\ningest skips the LLM re-synthesis and persists only the bookkeeping\ncolumns (source/chunk refs) via the content-preserving UpdateMeta\npath — so the fulltext GIN is never touched. Retractions still\nregenerate the page (they shrink it). New information for a capped\nhub page remains fully retrievable from its own source documents; it\njust stops being woven into the oversized hub page.",
+                    "type": "integer"
+                },
                 "max_pages_per_ingest": {
                     "description": "MaxPagesPerIngest limits pages created/updated per ingest operation (0 = no limit)",
+                    "type": "integer"
+                },
+                "max_refs": {
+                    "description": "MaxRefs caps the length of a page's chunk_refs array (most-recent\nentries kept). 0 (default) disables the cap. Bounds per-row JSONB /\nTOAST write size on hub pages whose chunk citations grow into the\nthousands. The page body's inline [cNNN] citations are unaffected;\nthis only trims the provenance index used for evidence surfacing and\ndelete reconciliation.",
                     "type": "integer"
                 },
                 "synthesis_model_id": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3974,9 +3974,38 @@ definitions:
           same LLM concurrency / HTTP pool considerations as the Map phase, plus
           DB connection pool size. Same multiplier caveat as IngestMapParallel.
         type: integer
+      max_page_content_bytes:
+        description: |-
+          MaxPageContentBytes caps how large a single wiki page's markdown body
+          may grow before ingest stops re-synthesizing it. 0 (default) disables
+          the cap — existing behaviour, pages grow unbounded.
+
+          Highly-referenced "hub" entity/concept pages (e.g. a company cited by
+          every research report) otherwise accumulate hundreds of KB of content
+          and get re-synthesized on every ingest that touches them. Each such
+          rewrite re-tokenizes the whole body into the wiki_pages fulltext GIN
+          index (title + content), turning a single-row UPDATE into the dominant
+          ingest write-amplification cost. When a page is already at/over this
+          cap and the current batch only ADDS information (no retractions),
+          ingest skips the LLM re-synthesis and persists only the bookkeeping
+          columns (source/chunk refs) via the content-preserving UpdateMeta
+          path — so the fulltext GIN is never touched. Retractions still
+          regenerate the page (they shrink it). New information for a capped
+          hub page remains fully retrievable from its own source documents; it
+          just stops being woven into the oversized hub page.
+        type: integer
       max_pages_per_ingest:
         description: MaxPagesPerIngest limits pages created/updated per ingest operation
           (0 = no limit)
+        type: integer
+      max_refs:
+        description: |-
+          MaxRefs caps the length of a page's chunk_refs array (most-recent
+          entries kept). 0 (default) disables the cap. Bounds per-row JSONB /
+          TOAST write size on hub pages whose chunk citations grow into the
+          thousands. The page body's inline [cNNN] citations are unaffected;
+          this only trims the provenance index used for evidence surfacing and
+          delete reconciliation.
         type: integer
       synthesis_model_id:
         description: SynthesisModelID is the LLM model ID used for wiki page generation

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -1287,6 +1287,17 @@ type WikiBatchContext struct {
 	// pre-resolved ids and never races on folder creation. Read-only during
 	// reduce.
 	PlannedFolderID map[string]string
+
+	// MaxPageContentBytes mirrors KB.WikiConfig.MaxPageContentBytes, resolved
+	// once per batch. 0 = no cap (unbounded page growth). When > 0, reduce
+	// skips re-synthesizing a page whose existing content already meets or
+	// exceeds it on add-only updates (see WikiConfig.MaxPageContentBytes).
+	MaxPageContentBytes int
+
+	// MaxRefs mirrors KB.WikiConfig.MaxRefs, resolved once per batch. 0 = no
+	// cap. When > 0, reduce trims chunk_refs to the most-recent MaxRefs
+	// entries.
+	MaxRefs int
 }
 
 // SlugUpdate represents a single update operation for a specific slug

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -168,10 +168,14 @@ func (s *wikiIngestService) newWikiBatchContext(
 	granularity := types.WikiExtractionStandard
 	contentInstructions := ""
 	extractionInstructions := ""
+	maxPageContentBytes := 0
+	maxRefs := 0
 	if wikiConfig != nil {
 		granularity = wikiConfig.ExtractionGranularity.Normalize()
 		contentInstructions = wikiConfig.ContentInstructions
 		extractionInstructions = wikiConfig.ExtractionInstructions
+		maxPageContentBytes = wikiConfig.MaxPageContentBytes
+		maxRefs = wikiConfig.MaxRefs
 	}
 	return &WikiBatchContext{
 		SlugTitle: func(ctx context.Context, slug string) string {
@@ -186,6 +190,8 @@ func (s *wikiIngestService) newWikiBatchContext(
 		ExtractionGranularity:  granularity,
 		ContentInstructions:    contentInstructions,
 		ExtractionInstructions: extractionInstructions,
+		MaxPageContentBytes:    maxPageContentBytes,
+		MaxRefs:                maxRefs,
 	}
 }
 
@@ -1960,7 +1966,19 @@ func (s *wikiIngestService) reduceSlugUpdates(
 		}
 	}
 
-	if len(additions) > 0 || len(retracts) > 0 {
+	// Hub-page write-amplification guard: when a page is already at/over the
+	// configured content cap and this batch only ADDS information (no
+	// retractions), skip the LLM re-synthesis and the content rewrite. The
+	// page keeps its existing body, so UpdatePage detects "content unchanged"
+	// and routes to the content-preserving UpdateMeta path — the expensive
+	// fulltext-GIN reindex is never triggered. Only the bookkeeping refs
+	// below are refreshed. Retractions are never capped: they shrink the
+	// page and must regenerate it.
+	contentCapped := batchCtx != nil && batchCtx.MaxPageContentBytes > 0 && exists &&
+		len(retracts) == 0 && len(additions) > 0 &&
+		len(page.Content) >= batchCtx.MaxPageContentBytes
+
+	if (len(additions) > 0 || len(retracts) > 0) && !contentCapped {
 		titles := batchCtx.SlugTitleMany(ctx, []string(page.OutLinks))
 
 		// slugHandles escape high-entropy slugs behind short reference handles
@@ -2069,6 +2087,18 @@ func (s *wikiIngestService) reduceSlugUpdates(
 		}
 	}
 
+	if contentCapped {
+		// Bookkeeping-only update: the existing content is intentionally left
+		// untouched (so UpdatePage routes to UpdateMeta and the fulltext GIN
+		// is preserved), but the freshly-cited source/chunk refs below still
+		// need to land for retrieval grounding and delete reconciliation.
+		// Mark changed so the persist block runs.
+		logger.Infof(ctx,
+			"wiki ingest: page %s content %d bytes >= cap %d; skipping re-synthesis (bookkeeping-only, fulltext GIN preserved)",
+			slug, len(page.Content), batchCtx.MaxPageContentBytes)
+		changed = true
+	}
+
 	// Apply the batch taxonomy plan, but only to pages that aren't already
 	// filed — so brand-new pages get a coherent folder while previously-filed
 	// or user-moved pages keep their placement (manual edits are authoritative).
@@ -2086,6 +2116,9 @@ func (s *wikiIngestService) reduceSlugUpdates(
 		// the existing refs; addition rounds append the newly-cited chunks
 		// on top of what was already there, deduplicated.
 		page.ChunkRefs = mergeChunkRefs(page.ChunkRefs, additions)
+		if batchCtx != nil && batchCtx.MaxRefs > 0 {
+			page.ChunkRefs = capRecentStringArray(page.ChunkRefs, batchCtx.MaxRefs)
+		}
 		if exists {
 			_, err = s.wikiService.UpdatePage(ctx, page)
 		} else {
@@ -2126,4 +2159,19 @@ func mergeChunkRefs(current types.StringArray, additions []SlugUpdate) types.Str
 		}
 	}
 	return out
+}
+
+// capRecentStringArray bounds a string array to its most-recent `max` entries
+// (the tail), returning it unchanged when max <= 0 or already within bounds.
+// mergeChunkRefs appends newly-cited chunks after the existing ones, so
+// keeping the tail preserves the freshest evidence while trimming the
+// oldest. Used to stop hub-page chunk_refs from growing into the thousands
+// and bloating the per-row JSONB / TOAST write on every ingest.
+func capRecentStringArray(a types.StringArray, max int) types.StringArray {
+	if max <= 0 || len(a) <= max {
+		return a
+	}
+	trimmed := make(types.StringArray, max)
+	copy(trimmed, a[len(a)-max:])
+	return trimmed
 }

--- a/internal/application/service/wiki_ingest_caps_test.go
+++ b/internal/application/service/wiki_ingest_caps_test.go
@@ -1,0 +1,286 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/require"
+)
+
+// capWikiServiceStub records the pages handed to UpdatePage/CreatePage so
+// tests can assert what reduce persisted (and, crucially, whether the page
+// body was rewritten).
+type capWikiServiceStub struct {
+	interfaces.WikiPageService
+	existing     *types.WikiPage
+	updatedPages []*types.WikiPage
+	createdPages []*types.WikiPage
+}
+
+func (s *capWikiServiceStub) GetPageBySlug(
+	_ context.Context, kbID, slug string,
+) (*types.WikiPage, error) {
+	if s.existing != nil && s.existing.KnowledgeBaseID == kbID && s.existing.Slug == slug {
+		cp := *s.existing
+		return &cp, nil
+	}
+	return nil, nil
+}
+
+func (s *capWikiServiceStub) UpdatePage(_ context.Context, page *types.WikiPage) (*types.WikiPage, error) {
+	cp := *page
+	s.updatedPages = append(s.updatedPages, &cp)
+	return page, nil
+}
+
+func (s *capWikiServiceStub) CreatePage(_ context.Context, page *types.WikiPage) (*types.WikiPage, error) {
+	cp := *page
+	s.createdPages = append(s.createdPages, &cp)
+	return page, nil
+}
+
+// capKnowledgeServiceStub reports every knowledge id as alive so
+// filterLiveUpdates keeps the test's addition updates.
+type capKnowledgeServiceStub struct {
+	interfaces.KnowledgeService
+}
+
+func (s *capKnowledgeServiceStub) GetKnowledgeByIDOnly(
+	_ context.Context, id string,
+) (*types.Knowledge, error) {
+	return &types.Knowledge{ID: id, ParseStatus: types.ParseStatusCompleted}, nil
+}
+
+// capChunkRepoStub resolves the cited chunks fed to the reduce prompt.
+type capChunkRepoStub struct {
+	interfaces.ChunkRepository
+	contents map[string]string
+}
+
+func (s *capChunkRepoStub) ListChunksByID(
+	_ context.Context, _ uint64, ids []string,
+) ([]*types.Chunk, error) {
+	out := make([]*types.Chunk, 0, len(ids))
+	for _, id := range ids {
+		if content, ok := s.contents[id]; ok {
+			out = append(out, &types.Chunk{ID: id, Content: content})
+		}
+	}
+	return out, nil
+}
+
+// countingChatModel counts Chat invocations so tests can prove the
+// re-synthesis LLM call was skipped (or made).
+type countingChatModel struct {
+	calls    int
+	response string
+}
+
+func (m *countingChatModel) Chat(
+	_ context.Context, _ []chat.Message, _ *chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	m.calls++
+	return &types.ChatResponse{Content: m.response}, nil
+}
+
+func (m *countingChatModel) ChatStream(
+	context.Context, []chat.Message, *chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	return nil, nil
+}
+
+func (m *countingChatModel) GetModelName() string { return "counting" }
+func (m *countingChatModel) GetModelID() string   { return "counting" }
+
+func capTestBatchCtx(maxPageContentBytes, maxRefs int) *WikiBatchContext {
+	return &WikiBatchContext{
+		SlugTitleMany: func(context.Context, []string) map[string]string { return nil },
+		SummaryContentByKnowledgeID: func(context.Context, string) string {
+			return ""
+		},
+		PlannedFolderID:     map[string]string{},
+		MaxPageContentBytes: maxPageContentBytes,
+		MaxRefs:             maxRefs,
+	}
+}
+
+func capTestAddition(kid string, chunkIDs ...string) SlugUpdate {
+	return SlugUpdate{
+		Slug:         "hub-page",
+		Type:         types.WikiPageTypeEntity,
+		Item:         extractedItem{Name: "Hub Page", Description: "desc", Details: "details"},
+		DocTitle:     "New Report",
+		KnowledgeID:  kid,
+		SourceRef:    kid + "|New Report",
+		Language:     "zh-CN",
+		SourceChunks: chunkIDs,
+	}
+}
+
+func existingHubPage(content string, chunkRefs ...string) *types.WikiPage {
+	return &types.WikiPage{
+		ID:              "page-1",
+		TenantID:        1,
+		KnowledgeBaseID: "kb-1",
+		Slug:            "hub-page",
+		Title:           "Hub Page",
+		Content:         content,
+		PageType:        types.WikiPageTypeEntity,
+		Status:          types.WikiPageStatusPublished,
+		SourceRefs:      types.StringArray{"old-kid|Old Report"},
+		ChunkRefs:       chunkRefs,
+	}
+}
+
+func TestReduceSlugUpdatesContentCapSkipsResynthesis(t *testing.T) {
+	body := strings.Repeat("x", 4096)
+	wikiSvc := &capWikiServiceStub{existing: existingHubPage(body, "c1")}
+	model := &countingChatModel{response: "SUMMARY: should-not-be-used\nrewritten"}
+	svc := &wikiIngestService{
+		wikiService:  wikiSvc,
+		knowledgeSvc: &capKnowledgeServiceStub{},
+		chunkRepo:    &capChunkRepoStub{contents: map[string]string{"c2": "chunk two"}},
+	}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+
+	changed, affectedType, additionFailed, err := svc.reduceSlugUpdates(
+		ctx, model, "kb-1", "hub-page",
+		[]SlugUpdate{capTestAddition("new-kid", "c2")},
+		1, capTestBatchCtx(1024, 0), nil,
+	)
+	require.NoError(t, err)
+	require.True(t, changed, "bookkeeping-only persist must still run")
+	require.Equal(t, "ingest", affectedType)
+	require.False(t, additionFailed)
+	require.Zero(t, model.calls, "capped add-only update must skip the LLM re-synthesis")
+
+	require.Len(t, wikiSvc.updatedPages, 1)
+	require.Empty(t, wikiSvc.createdPages)
+	persisted := wikiSvc.updatedPages[0]
+	require.Equal(t, body, persisted.Content,
+		"capped page body must be preserved so UpdatePage routes to the UpdateMeta (no fulltext GIN) path")
+	require.Contains(t, []string(persisted.SourceRefs), "new-kid|New Report",
+		"fresh source refs must still land for delete reconciliation")
+	require.Equal(t, types.StringArray{"c1", "c2"}, persisted.ChunkRefs,
+		"freshly-cited chunk refs must still land for retrieval grounding")
+}
+
+func TestReduceSlugUpdatesContentCapBelowThresholdStillSynthesizes(t *testing.T) {
+	wikiSvc := &capWikiServiceStub{existing: existingHubPage(strings.Repeat("x", 512))}
+	model := &countingChatModel{response: "SUMMARY: refreshed\nregenerated body"}
+	svc := &wikiIngestService{
+		wikiService:  wikiSvc,
+		knowledgeSvc: &capKnowledgeServiceStub{},
+		chunkRepo:    &capChunkRepoStub{contents: map[string]string{"c2": "chunk two"}},
+	}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+
+	changed, _, _, err := svc.reduceSlugUpdates(
+		ctx, model, "kb-1", "hub-page",
+		[]SlugUpdate{capTestAddition("new-kid", "c2")},
+		1, capTestBatchCtx(1024, 0), nil,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, 1, model.calls, "page below the cap must still be re-synthesized")
+	require.Len(t, wikiSvc.updatedPages, 1)
+	require.Equal(t, "regenerated body", wikiSvc.updatedPages[0].Content)
+}
+
+func TestReduceSlugUpdatesContentCapNeverAppliesToRetract(t *testing.T) {
+	page := existingHubPage(strings.Repeat("x", 4096), "c1")
+	page.SourceRefs = types.StringArray{"dead-kid|Dead Report", "keep-kid|Keep Report"}
+	wikiSvc := &capWikiServiceStub{existing: page}
+	model := &countingChatModel{response: "SUMMARY: after-retract\nremaining body"}
+	svc := &wikiIngestService{
+		wikiService:  wikiSvc,
+		knowledgeSvc: &capKnowledgeServiceStub{},
+		chunkRepo:    &capChunkRepoStub{},
+	}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+
+	retract := SlugUpdate{
+		Slug:              "hub-page",
+		Type:              "retract",
+		DocTitle:          "Dead Report",
+		KnowledgeID:       "dead-kid",
+		Language:          "zh-CN",
+		RetractDocContent: "outdated content",
+	}
+	changed, affectedType, _, err := svc.reduceSlugUpdates(
+		ctx, model, "kb-1", "hub-page",
+		[]SlugUpdate{retract},
+		1, capTestBatchCtx(1024, 0), nil,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "retract", affectedType)
+	require.Equal(t, 1, model.calls, "retractions are never capped: the page must be regenerated")
+	require.Len(t, wikiSvc.updatedPages, 1)
+	require.Equal(t, "remaining body", wikiSvc.updatedPages[0].Content)
+	require.Equal(t, types.StringArray{"keep-kid|Keep Report"}, wikiSvc.updatedPages[0].SourceRefs)
+}
+
+func TestReduceSlugUpdatesMaxRefsTrimsChunkRefs(t *testing.T) {
+	wikiSvc := &capWikiServiceStub{
+		existing: existingHubPage(strings.Repeat("x", 4096), "c1", "c2"),
+	}
+	model := &countingChatModel{response: "SUMMARY: unused\nunused"}
+	svc := &wikiIngestService{
+		wikiService:  wikiSvc,
+		knowledgeSvc: &capKnowledgeServiceStub{},
+		chunkRepo:    &capChunkRepoStub{contents: map[string]string{"c3": "chunk three"}},
+	}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+
+	changed, _, _, err := svc.reduceSlugUpdates(
+		ctx, model, "kb-1", "hub-page",
+		[]SlugUpdate{capTestAddition("new-kid", "c3")},
+		1, capTestBatchCtx(1024, 2), nil,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Len(t, wikiSvc.updatedPages, 1)
+	require.Equal(t, types.StringArray{"c2", "c3"}, wikiSvc.updatedPages[0].ChunkRefs,
+		"chunk_refs must be trimmed to the most-recent MaxRefs entries")
+}
+
+func TestReduceSlugUpdatesZeroCapsPreserveHistoricalBehavior(t *testing.T) {
+	wikiSvc := &capWikiServiceStub{
+		existing: existingHubPage(strings.Repeat("x", 4096), "c1"),
+	}
+	model := &countingChatModel{response: "SUMMARY: refreshed\nregenerated body"}
+	svc := &wikiIngestService{
+		wikiService:  wikiSvc,
+		knowledgeSvc: &capKnowledgeServiceStub{},
+		chunkRepo:    &capChunkRepoStub{contents: map[string]string{"c2": "chunk two"}},
+	}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+
+	changed, _, _, err := svc.reduceSlugUpdates(
+		ctx, model, "kb-1", "hub-page",
+		[]SlugUpdate{capTestAddition("new-kid", "c2")},
+		1, capTestBatchCtx(0, 0), nil,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, 1, model.calls, "0 = disabled: oversized pages keep the historical re-synthesis path")
+	require.Len(t, wikiSvc.updatedPages, 1)
+	require.Equal(t, "regenerated body", wikiSvc.updatedPages[0].Content)
+	require.Equal(t, types.StringArray{"c1", "c2"}, wikiSvc.updatedPages[0].ChunkRefs,
+		"MaxRefs = 0 leaves chunk_refs unbounded")
+}
+
+func TestCapRecentStringArray(t *testing.T) {
+	require.Nil(t, capRecentStringArray(nil, 3))
+	require.Equal(t, types.StringArray{"a", "b"}, capRecentStringArray(types.StringArray{"a", "b"}, 3),
+		"within bounds stays unchanged")
+	require.Equal(t, types.StringArray{"a", "b"}, capRecentStringArray(types.StringArray{"a", "b"}, 0),
+		"max <= 0 disables the cap")
+	require.Equal(t, types.StringArray{"b", "c"}, capRecentStringArray(types.StringArray{"a", "b", "c"}, 2),
+		"over bounds keeps the most-recent tail")
+}

--- a/internal/types/wiki_page.go
+++ b/internal/types/wiki_page.go
@@ -549,6 +549,33 @@ type WikiConfig struct {
 	// this knob trades a single KB's peak throughput for cross-KB fairness.
 	// Set it >= the wiki pool size to effectively disable the cap.
 	IngestMaxInflight int `yaml:"ingest_max_inflight" json:"ingest_max_inflight,omitempty"`
+
+	// MaxPageContentBytes caps how large a single wiki page's markdown body
+	// may grow before ingest stops re-synthesizing it. 0 (default) disables
+	// the cap — existing behaviour, pages grow unbounded.
+	//
+	// Highly-referenced "hub" entity/concept pages (e.g. a company cited by
+	// every research report) otherwise accumulate hundreds of KB of content
+	// and get re-synthesized on every ingest that touches them. Each such
+	// rewrite re-tokenizes the whole body into the wiki_pages fulltext GIN
+	// index (title + content), turning a single-row UPDATE into the dominant
+	// ingest write-amplification cost. When a page is already at/over this
+	// cap and the current batch only ADDS information (no retractions),
+	// ingest skips the LLM re-synthesis and persists only the bookkeeping
+	// columns (source/chunk refs) via the content-preserving UpdateMeta
+	// path — so the fulltext GIN is never touched. Retractions still
+	// regenerate the page (they shrink it). New information for a capped
+	// hub page remains fully retrievable from its own source documents; it
+	// just stops being woven into the oversized hub page.
+	MaxPageContentBytes int `yaml:"max_page_content_bytes" json:"max_page_content_bytes,omitempty"`
+
+	// MaxRefs caps the length of a page's chunk_refs array (most-recent
+	// entries kept). 0 (default) disables the cap. Bounds per-row JSONB /
+	// TOAST write size on hub pages whose chunk citations grow into the
+	// thousands. The page body's inline [cNNN] citations are unaffected;
+	// this only trims the provenance index used for evidence surfacing and
+	// delete reconciliation.
+	MaxRefs int `yaml:"max_refs" json:"max_refs,omitempty"`
 }
 
 // IngestBatchSizeOrDefault returns IngestBatchSize when set (> 0),


### PR DESCRIPTION
## Description

During wiki ingest, every batch that cites a page triggers an LLM re-synthesis of that page plus a content rewrite. For hub pages cited by many documents, the cost grows with every new upload: each add-only batch rewrites the full page body and forces the `fulltext` GIN index (`to_tsvector` over `title || content`, see migration `000037`) to rebuild, even when the existing synthesis already covers the topic.

This PR adds two **opt-in** caps to `WikiConfig` (both default to `0` = disabled, preserving current behavior):

- **`max_page_content_bytes`** — when a page’s existing content already meets/exceeds the cap and the current batch is *add-only* (no retractions), the reduce phase skips the LLM re-synthesis and keeps the existing body. `UpdatePage` then detects “content unchanged” and routes to the metadata-only `UpdateMeta` path, so the fulltext GIN entry is never rebuilt. The batch’s bookkeeping (freshly-cited source/chunk refs) still lands for retrieval grounding and delete reconciliation. **Retractions are never capped** — they shrink the page and always regenerate it.
- **`max_refs`** — trims `chunk_refs` to the most recent N entries, stopping hub pages from accumulating thousands of refs and bloating the per-row JSON/TOAST write on every ingest.

Both values are resolved once per batch in `newWikiBatchContext` and exposed through the existing `wiki_config` JSON on the KB create/update APIs (swagger docs updated; the generated files were edited surgically for `WikiConfig` only, since a full `make docs` regeneration currently produces unrelated drift — happy to run it if maintainers prefer).

## Type of Change
- [x] ✨ New feature
- [x] ⚡ Performance improvement

## Related Issue

N/A

## Testing

New `wiki_ingest_caps_test.go` covers: cap reached → re-synthesis skipped and content preserved; below cap → synthesis still runs; retraction bypasses the cap; `max_refs` trims to the tail; `0` disables both guards; `capRecentStringArray` unit cases.

- `go test ./internal/application/service/ -run "TestReduceSlugUpdates|TestCapRecentStringArray" -count=1` — 6/6 pass
- `go test ./internal/types/ -count=1` — passes
- Full `go test ./internal/application/service/` — only 3 pre-existing Windows SQLite temp-file-lock flakes fail, reproduced identically on an unmodified `main` checkout
- `gofmt -l` — clean; `git diff --check` — passes
- `golangci-lint run --new-from-rev=upstream/main ./internal/...` — 0 issues

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (swagger; field comments document the semantics)
- [x] Breaking changes are clearly called out in the description above