### PR TITLE
feat: record model usage events and add aggregated usage dashboard

### DIFF
--- a/frontend/src/api/model/index.ts
+++ b/frontend/src/api/model/index.ts
@@ -145,6 +145,114 @@ export function deleteModel(id: string): Promise<void> {
   });
 }
 
+// ----------------------------------------------------------------------------
+// Model usage metering (see internal/handler/model_usage.go). Metadata only:
+// tokens, latency and outcome per model call — never prompts or outputs.
+export type ModelUsageRange = '15m' | '1h' | '24h' | '7d'
+export type ModelUsageType = 'all' | 'KnowledgeQA' | 'Embedding' | 'Rerank' | 'VLLM' | 'ASR'
+
+export interface ModelUsageSummary {
+  window_start: string
+  window_end: string
+  refresh_seconds: number
+  total_calls: number
+  total_tokens: number
+  prompt_tokens: number
+  completion_tokens: number
+  cached_tokens: number
+  error_count: number
+  success_rate: number
+}
+
+export interface ModelUsageModelStats {
+  model_id: string
+  model_name: string
+  display_name: string
+  model_type: Exclude<ModelUsageType, 'all'>
+  model_source: string
+  provider: string
+  calls: number
+  prompt_tokens: number
+  completion_tokens: number
+  cached_tokens: number
+  total_tokens: number
+  input_items: number
+  duration_ms: number
+  error_count: number
+  success_rate: number
+  avg_tokens_per_call: number
+  last_used_at?: string | null
+}
+
+export interface ModelUsageTimelinePoint {
+  bucket_start: string
+  model_id: string
+  model_name: string
+  model_type: Exclude<ModelUsageType, 'all'>
+  calls: number
+  prompt_tokens: number
+  completion_tokens: number
+  cached_tokens: number
+  total_tokens: number
+  error_count: number
+}
+
+export interface ModelUsageEvent {
+  id: number
+  tenant_id: number
+  user_id: string
+  request_id: string
+  model_id: string
+  model_name: string
+  model_type: Exclude<ModelUsageType, 'all'>
+  model_source: string
+  provider: string
+  request_kind: string
+  usage_source: string
+  prompt_tokens: number
+  completion_tokens: number
+  cached_tokens: number
+  total_tokens: number
+  input_items: number
+  duration_ms: number
+  success: boolean
+  error_type: string
+  created_at: string
+}
+
+export interface ModelUsageReport {
+  summary: ModelUsageSummary
+  models: ModelUsageModelStats[]
+  timeline: ModelUsageTimelinePoint[]
+  recent_events: ModelUsageEvent[]
+}
+
+export function getModelUsage(params: {
+  range?: ModelUsageRange
+  model_type?: ModelUsageType
+  model_id?: string
+} = {}): Promise<ModelUsageReport> {
+  const search = new URLSearchParams()
+  if (params.range) search.set('range', params.range)
+  if (params.model_type) search.set('model_type', params.model_type)
+  if (params.model_id) search.set('model_id', params.model_id)
+  const query = search.toString()
+  return new Promise((resolve, reject) => {
+    get(`/api/v1/models/usage${query ? `?${query}` : ''}`)
+      .then((response: any) => {
+        if (response.success && response.data) {
+          resolve(response.data)
+        } else {
+          reject(new Error(response.message || 'Failed to load model usage'))
+        }
+      })
+      .catch((error: any) => {
+        console.error('Failed to load model usage:', error)
+        reject(error)
+      })
+  })
+}
+
 export interface ModelDebugOptions {
   system_prompt?: string
   temperature?: number

--- a/frontend/src/assets/img/model-usage-green.svg
+++ b/frontend/src/assets/img/model-usage-green.svg
@@ -1,0 +1,7 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3.5 16.5h13" stroke="#07C160" stroke-width="1.5" stroke-linecap="round"/>
+  <rect x="4.2" y="9.5" width="2.6" height="5.2" rx="0.8" stroke="#07C160" stroke-width="1.4"/>
+  <rect x="8.7" y="5.3" width="2.6" height="9.4" rx="0.8" stroke="#07C160" stroke-width="1.4"/>
+  <rect x="13.2" y="7.4" width="2.6" height="7.3" rx="0.8" stroke="#07C160" stroke-width="1.4"/>
+  <path d="M4.5 5.7 7.3 3l2.6 2.2 4.8-3.1" stroke="#07C160" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/assets/img/model-usage.svg
+++ b/frontend/src/assets/img/model-usage.svg
@@ -1,0 +1,7 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3.5 16.5h13" stroke="#5F6673" stroke-width="1.5" stroke-linecap="round"/>
+  <rect x="4.2" y="9.5" width="2.6" height="5.2" rx="0.8" stroke="#5F6673" stroke-width="1.4"/>
+  <rect x="8.7" y="5.3" width="2.6" height="9.4" rx="0.8" stroke="#5F6673" stroke-width="1.4"/>
+  <rect x="13.2" y="7.4" width="2.6" height="7.3" rx="0.8" stroke="#5F6673" stroke-width="1.4"/>
+  <path d="M4.5 5.7 7.3 3l2.6 2.2 4.8-3.1" stroke="#5F6673" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/menu.vue
+++ b/frontend/src/components/menu.vue
@@ -85,7 +85,7 @@
                         <div class="menu_item-box">
                             <div class="menu_icon">
                                 <img class="icon"
-                                    :src="getImgSrc(item.icon == 'zhishiku' ? knowledgeIcon : item.icon == 'agent' ? agentIcon : item.icon == 'organization' ? organizationIcon : item.icon == 'logout' ? logoutIcon : item.icon == 'setting' ? settingIcon : prefixIcon)"
+                                    :src="getImgSrc(item.icon == 'zhishiku' ? knowledgeIcon : item.icon == 'agent' ? agentIcon : item.icon == 'modelUsage' ? modelUsageIcon : item.icon == 'organization' ? organizationIcon : item.icon == 'logout' ? logoutIcon : item.icon == 'setting' ? settingIcon : prefixIcon)"
                                     alt="">
                             </div>
                             <template v-if="!uiStore.sidebarCollapsed">
@@ -403,6 +403,8 @@ const isMenuItemActive = (itemPath: string): boolean => {
                 currentRoute === 'knowledgeBaseSettings';
         case 'agents':
             return currentRoute === 'agentList';
+        case 'model-usage':
+            return currentRoute === 'modelUsage';
         case 'organizations':
             return currentRoute === 'organizationList';
         case 'creatChat':
@@ -425,6 +427,7 @@ const getIconActiveState = (itemPath: string) => {
             currentRoute === 'knowledgeBaseSettings'
         ),
         isCreatChatActive: itemPath === 'creatChat' && (currentRoute === 'kbCreatChat' || currentRoute === 'globalCreatChat'),
+        isModelUsageActive: itemPath === 'model-usage' && currentRoute === 'modelUsage',
         isSettingsActive: itemPath === 'settings' && currentRoute === 'settings',
         isChatActive: itemPath === 'chat' && currentRoute === 'chat'
     };
@@ -433,13 +436,13 @@ const getIconActiveState = (itemPath: string) => {
 // 分离上下两部分菜单（使用 visibleMenuArr 以便 lite 模式过滤 logout）
 const topMenuItems = computed<MenuItem[]>(() => {
     return (visibleMenuArr.value as unknown as MenuItem[]).filter((item: MenuItem) =>
-        item.path === 'knowledge-bases' || item.path === 'agents' || item.path === 'organizations' || item.path === 'creatChat'
+        item.path === 'knowledge-bases' || item.path === 'agents' || item.path === 'model-usage' || item.path === 'organizations' || item.path === 'creatChat'
     );
 });
 
 const bottomMenuItems = computed<MenuItem[]>(() => {
     return (visibleMenuArr.value as unknown as MenuItem[]).filter((item: MenuItem) => {
-        if (item.path === 'knowledge-bases' || item.path === 'agents' || item.path === 'organizations' || item.path === 'creatChat') {
+        if (item.path === 'knowledge-bases' || item.path === 'agents' || item.path === 'model-usage' || item.path === 'organizations' || item.path === 'creatChat') {
             return false;
         }
         return true;
@@ -1031,6 +1034,7 @@ let prefixIcon = ref('prefixIcon.svg');
 let logoutIcon = ref('logout.svg');
 let settingIcon = ref('setting.svg');
 let agentIcon = ref('agent.svg');
+let modelUsageIcon = ref('model-usage.svg');
 let organizationIcon = ref('organization.svg');
 let pathPrefix = ref(route.name)
 const getIcon = (path: string) => {
@@ -1039,6 +1043,7 @@ const getIcon = (path: string) => {
     const creatChatActiveState = getIconActiveState('creatChat');
     const settingsActiveState = getIconActiveState('settings');
     const agentsActiveState = route.name === 'agentList';
+    const modelUsageActiveState = getIconActiveState('model-usage');
     const organizationsActiveState = route.name === 'organizationList';
 
     // 知识库图标：只在知识库页面显示绿色
@@ -1046,6 +1051,9 @@ const getIcon = (path: string) => {
 
     // 智能体图标：只在智能体页面显示绿色
     agentIcon.value = agentsActiveState ? 'agent-green.svg' : 'agent.svg';
+
+    // 用量看板图标：只在用量页面显示绿色
+    modelUsageIcon.value = modelUsageActiveState.isModelUsageActive ? 'model-usage-green.svg' : 'model-usage.svg';
 
     // 组织图标：只在组织页面显示绿色
     organizationIcon.value = organizationsActiveState ? 'organization-green.svg' : 'organization.svg';
@@ -1071,6 +1079,8 @@ const handleMenuClick = async (path: string) => {
         }
     } else if (path === 'agents') {
         router.push('/platform/agents')
+    } else if (path === 'model-usage') {
+        router.push('/platform/model-usage')
     } else if (path === 'organizations') {
         // 组织菜单项：跳转到组织列表
         router.push('/platform/organizations')

--- a/frontend/src/config/settingsAccess.ts
+++ b/frontend/src/config/settingsAccess.ts
@@ -12,6 +12,7 @@ export const SETTINGS_SECTION_MIN_ROLE: Record<string, SettingsRoleKey> = {
   ollama: 'admin',
   weknoracloud: 'admin',
   models: 'viewer',
+  modelUsage: 'viewer',
   websearch: 'admin',
   chathistory: 'admin',
   vectorstore: 'admin',

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2,6 +2,7 @@ export default {
   menu: {
     knowledgeBase: 'Knowledge Base',
     agents: 'Agents',
+    modelUsage: 'Model Usage',
     organizations: 'Shared Spaces',
     newChat: 'New Chat',
     settings: 'System Settings',
@@ -992,6 +993,7 @@ export default {
   },
   settings: {
     modelManagement: 'Model Management',
+    modelUsage: 'Model Usage',
     webSearchConfig: 'Web Search',
     autoCheckUpdate: 'Auto Download Updates',
     autoCheckUpdateDesc: 'When enabled, automatically check and download the latest version in the background.',
@@ -3883,6 +3885,71 @@ export default {
         segmentCount: 'Segment count'
       }
     }
+  },
+  modelUsage: {
+    title: 'Model Usage',
+    description: 'Watch calls, token usage, errors, and recent activity for every model in this workspace.',
+    loadFailed: 'Failed to load model usage',
+    empty: 'No model calls in this time range',
+    autoRefresh: 'Auto refresh',
+    autoRefreshOn: 'Auto refresh every 5 seconds',
+    autoRefreshOff: 'Auto refresh paused',
+    ranges: {
+      '15m': '15 min',
+      '1h': '1 hour',
+      '24h': '24 hours',
+      '7d': '7 days',
+    },
+    types: {
+      KnowledgeQA: 'Chat',
+      Embedding: 'Embedding',
+      Rerank: 'ReRank',
+      VLLM: 'Vision',
+      ASR: 'Speech',
+    },
+    usageSource: {
+      provider: 'Provider',
+      estimated: 'Estimated',
+      missing: 'Missing',
+      not_applicable: 'N/A',
+    },
+    metrics: {
+      totalTokens: 'Total Tokens',
+      cached: 'Cached {count}',
+      calls: 'Calls',
+      errors: 'Errors {count}',
+      promptCompletion: 'Input / Output',
+      promptCompletionHint: 'Prompt / Completion tokens',
+      successRate: 'Success Rate',
+    },
+    timeline: {
+      title: 'Usage Timeline',
+      subtitle: 'Aggregated by the selected time range',
+    },
+    table: {
+      title: 'Model Ranking',
+      subtitle: 'Sorted by token usage',
+    },
+    recent: {
+      title: 'Recent Calls',
+      subtitle: 'Metadata only',
+      success: 'Success',
+      failed: 'Failed',
+    },
+    columns: {
+      model: 'Model',
+      type: 'Type',
+      provider: 'Source',
+      calls: 'Calls',
+      totalTokens: 'Total Tokens',
+      breakdown: 'Token Breakdown',
+      promptShort: 'In',
+      completionShort: 'Out',
+      cachedShort: 'Cached',
+      errors: 'Errors',
+      successRate: 'Success',
+      lastUsed: 'Last Used',
+    },
   },
   ollamaSettings: {
     title: 'Ollama Settings',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -1795,6 +1795,71 @@ export default {
       urlInvalid: '유효한 URL을 입력해주세요'
     }
   },
+  modelUsage: {
+    title: '모델 사용량',
+    description: '이 워크스페이스의 모든 모델 호출 횟수, 토큰 사용량, 오류 및 최근 활동을 확인합니다.',
+    loadFailed: '모델 사용량을 불러오지 못했습니다',
+    empty: '선택한 시간 범위에 모델 호출 기록이 없습니다',
+    autoRefresh: '자동 새로고침',
+    autoRefreshOn: '5초마다 자동 새로고침',
+    autoRefreshOff: '자동 새로고침 일시 중지됨',
+    ranges: {
+      '15m': '15분',
+      '1h': '1시간',
+      '24h': '24시간',
+      '7d': '7일',
+    },
+    types: {
+      KnowledgeQA: '대화',
+      Embedding: 'Embedding',
+      Rerank: 'ReRank',
+      VLLM: '비전',
+      ASR: '음성',
+    },
+    usageSource: {
+      provider: '공급자',
+      estimated: '추정',
+      missing: '미반환',
+      not_applicable: '해당 없음',
+    },
+    metrics: {
+      totalTokens: '총 토큰',
+      cached: '캐시 적중 {count}',
+      calls: '호출 횟수',
+      errors: '오류 {count}',
+      promptCompletion: '입력 / 출력',
+      promptCompletionHint: 'Prompt / Completion 토큰',
+      successRate: '성공률',
+    },
+    timeline: {
+      title: '사용량 타임라인',
+      subtitle: '선택한 시간 범위로 집계',
+    },
+    table: {
+      title: '모델 순위',
+      subtitle: '토큰 사용량 순 정렬',
+    },
+    recent: {
+      title: '최근 호출',
+      subtitle: '메타데이터만 표시',
+      success: '성공',
+      failed: '실패',
+    },
+    columns: {
+      model: '모델',
+      type: '유형',
+      provider: '소스',
+      calls: '호출',
+      totalTokens: '총 토큰',
+      breakdown: '토큰 구성',
+      promptShort: '입력',
+      completionShort: '출력',
+      cachedShort: '캐시',
+      errors: '오류',
+      successRate: '성공률',
+      lastUsed: '마지막 사용',
+    },
+  },
   ollamaSettings: {
     title: 'Ollama 설정',
     description: '로컬 Ollama 서비스를 관리하고 모델을 보고 다운로드합니다',
@@ -4492,6 +4557,7 @@ export default {
   },
   settings: {
     modelManagement: '모델 관리',
+    modelUsage: '모델 사용량',
     webSearchConfig: '웹 검색',
     autoCheckUpdate: '업데이트 자동 다운로드',
     autoCheckUpdateDesc: '활성화하면 시작 시 최신 버전을 자동으로 확인하고 백그라운드에서 다운로드합니다.',
@@ -5697,6 +5763,7 @@ export default {
   menu: {
     knowledgeBase: '지식베이스',
     agents: '에이전트',
+    modelUsage: '모델 사용량',
     organizations: '공유 공간',
     newChat: '새 대화',
     settings: '시스템 설정',

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -1795,6 +1795,71 @@ export default {
       urlInvalid: 'Введите корректный URL'
     }
   },
+  modelUsage: {
+    title: 'Использование моделей',
+    description: 'Отслеживайте вызовы, использование токенов, ошибки и последнюю активность каждой модели в этом пространстве.',
+    loadFailed: 'Не удалось загрузить использование моделей',
+    empty: 'Нет вызовов моделей в выбранном диапазоне времени',
+    autoRefresh: 'Автообновление',
+    autoRefreshOn: 'Автообновление каждые 5 секунд',
+    autoRefreshOff: 'Автообновление приостановлено',
+    ranges: {
+      '15m': '15 мин',
+      '1h': '1 час',
+      '24h': '24 часа',
+      '7d': '7 дней',
+    },
+    types: {
+      KnowledgeQA: 'Чат',
+      Embedding: 'Embedding',
+      Rerank: 'ReRank',
+      VLLM: 'Зрение',
+      ASR: 'Речь',
+    },
+    usageSource: {
+      provider: 'Провайдер',
+      estimated: 'Оценка',
+      missing: 'Нет данных',
+      not_applicable: 'Н/Д',
+    },
+    metrics: {
+      totalTokens: 'Всего токенов',
+      cached: 'Из кэша {count}',
+      calls: 'Вызовы',
+      errors: 'Ошибки {count}',
+      promptCompletion: 'Ввод / Вывод',
+      promptCompletionHint: 'Токены Prompt / Completion',
+      successRate: 'Успешность',
+    },
+    timeline: {
+      title: 'Шкала использования',
+      subtitle: 'Агрегация по выбранному диапазону времени',
+    },
+    table: {
+      title: 'Рейтинг моделей',
+      subtitle: 'Сортировка по использованию токенов',
+    },
+    recent: {
+      title: 'Последние вызовы',
+      subtitle: 'Только метаданные',
+      success: 'Успех',
+      failed: 'Ошибка',
+    },
+    columns: {
+      model: 'Модель',
+      type: 'Тип',
+      provider: 'Источник',
+      calls: 'Вызовы',
+      totalTokens: 'Всего токенов',
+      breakdown: 'Структура токенов',
+      promptShort: 'Ввод',
+      completionShort: 'Вывод',
+      cachedShort: 'Кэш',
+      errors: 'Ошибки',
+      successRate: 'Успешность',
+      lastUsed: 'Последний вызов',
+    },
+  },
   ollamaSettings: {
     title: 'Настройки Ollama',
     description: 'Управление локальным сервисом Ollama и моделями',
@@ -4492,6 +4557,7 @@ export default {
   },
   settings: {
     modelManagement: 'Управление моделями',
+    modelUsage: 'Использование моделей',
     webSearchConfig: 'Сетевой поиск',
     autoCheckUpdate: 'Автоматическая загрузка обновлений',
     autoCheckUpdateDesc: 'При включении автоматически проверять и скачивать последнюю версию в фоновом режиме при запуске.',
@@ -5697,6 +5763,7 @@ export default {
   menu: {
     knowledgeBase: 'База знаний',
     agents: 'Агенты',
+    modelUsage: 'Использование моделей',
     organizations: 'Общие пространства',
     newChat: 'Новый диалог',
     settings: 'Настройки системы',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1795,6 +1795,71 @@ export default {
       urlInvalid: '请输入有效的 URL'
     }
   },
+  modelUsage: {
+    title: '模型统计',
+    description: '实时查看当前空间各类模型的调用次数、Token 消耗、错误和最近调用情况。',
+    loadFailed: '加载模型消耗失败',
+    empty: '当前时间范围内暂无模型调用记录',
+    autoRefresh: '自动刷新',
+    autoRefreshOn: '5 秒自动刷新',
+    autoRefreshOff: '已暂停自动刷新',
+    ranges: {
+      '15m': '15 分钟',
+      '1h': '1 小时',
+      '24h': '24 小时',
+      '7d': '7 天',
+    },
+    types: {
+      KnowledgeQA: '对话',
+      Embedding: 'Embedding',
+      Rerank: 'ReRank',
+      VLLM: '视觉',
+      ASR: '语音',
+    },
+    usageSource: {
+      provider: '供应商',
+      estimated: '估算',
+      missing: '未返回',
+      not_applicable: '不适用',
+    },
+    metrics: {
+      totalTokens: '总 Token',
+      cached: '缓存命中 {count}',
+      calls: '调用次数',
+      errors: '错误 {count}',
+      promptCompletion: '输入 / 输出',
+      promptCompletionHint: 'Prompt / Completion Token',
+      successRate: '成功率',
+    },
+    timeline: {
+      title: '消耗时间轴',
+      subtitle: '按当前时间范围聚合',
+    },
+    table: {
+      title: '模型排行',
+      subtitle: '按 Token 消耗排序',
+    },
+    recent: {
+      title: '最近调用',
+      subtitle: '仅展示调用元数据',
+      success: '成功',
+      failed: '失败',
+    },
+    columns: {
+      model: '模型',
+      type: '类型',
+      provider: '来源',
+      calls: '调用',
+      totalTokens: '总 Token',
+      breakdown: 'Token 结构',
+      promptShort: '输入',
+      completionShort: '输出',
+      cachedShort: '缓存',
+      errors: '错误',
+      successRate: '成功率',
+      lastUsed: '最近调用',
+    },
+  },
   ollamaSettings: {
     title: 'Ollama 配置',
     description: '管理本地 Ollama 服务，查看和下载模型',
@@ -4492,6 +4557,7 @@ export default {
   },
   settings: {
     modelManagement: '模型管理',
+    modelUsage: '模型统计',
     webSearchConfig: '网络搜索',
     autoCheckUpdate: '自动下载更新',
     autoCheckUpdateDesc: '开启后自动检查并在后台下载最新版本安装包。',
@@ -5697,6 +5763,7 @@ export default {
   menu: {
     knowledgeBase: '知识库',
     agents: '智能体',
+    modelUsage: '模型统计',
     organizations: '共享空间',
     newChat: '新对话',
     settings: '系统设置',

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -106,6 +106,12 @@ const router = createRouter({
           meta: { requiresInit: true, requiresAuth: true }
         },
         {
+          path: "model-usage",
+          name: "modelUsage",
+          component: () => import("../views/model-usage/ModelUsageView.vue"),
+          meta: { requiresInit: true, requiresAuth: true }
+        },
+        {
           path: "knowledge-bases",
           name: "knowledgeBaseList",
           component: () => import("../views/knowledge/KnowledgeBaseList.vue"),
@@ -293,6 +299,12 @@ let liteDeepLinkRestoreDone = false
 // 路由守卫：检查认证状态和系统初始化状态
 router.beforeEach(async (to, from, next) => {
   const authStore = useAuthStore()
+
+  // 模型用量已从设置页迁出为独立看板页，深链重定向。
+  if (to.path === '/platform/settings' && to.query.section === 'modelUsage') {
+    next('/platform/model-usage')
+    return
+  }
 
   // OIDC 回跳登录结果依赖 App.vue 在挂载后消费 URL hash。
   // 如果这里先按“未登录”拦截到 /login，会导致回调结果没有机会落盘。

--- a/frontend/src/stores/menu.ts
+++ b/frontend/src/stores/menu.ts
@@ -28,6 +28,7 @@ export const useMenuStore = defineStore('menuStore', () => {
     },
     { title: '', titleKey: 'menu.knowledgeBase', icon: 'zhishiku', path: 'knowledge-bases' },
     { title: '', titleKey: 'menu.agents', icon: 'agent', path: 'agents' },
+    { title: '', titleKey: 'menu.modelUsage', icon: 'modelUsage', path: 'model-usage' },
     { title: '', titleKey: 'menu.organizations', icon: 'organization', path: 'organizations' },
     { title: '', titleKey: 'menu.settings', icon: 'setting', path: 'settings' },
     { title: '', titleKey: 'menu.logout', icon: 'logout', path: 'logout' }

--- a/frontend/src/views/model-usage/ModelUsageView.vue
+++ b/frontend/src/views/model-usage/ModelUsageView.vue
@@ -1,0 +1,27 @@
+<template>
+  <main class="model-usage-page">
+    <ModelUsageSettings />
+  </main>
+</template>
+
+<script setup lang="ts">
+import ModelUsageSettings from '@/views/settings/ModelUsageSettings.vue'
+</script>
+
+<style scoped lang="less">
+.model-usage-page {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow-y: auto;
+  box-sizing: border-box;
+  padding: 32px 36px 40px;
+  background: var(--td-bg-color-page, #f5f7fa);
+}
+
+@media (max-width: 768px) {
+  .model-usage-page {
+    padding: 20px 16px 28px;
+  }
+}
+</style>

--- a/frontend/src/views/settings/ModelUsageSettings.vue
+++ b/frontend/src/views/settings/ModelUsageSettings.vue
@@ -1,0 +1,924 @@
+<template>
+  <div class="model-usage-settings">
+    <div class="section-header">
+      <div>
+        <h2>{{ t('modelUsage.title') }}</h2>
+        <p class="section-description">{{ t('modelUsage.description') }}</p>
+      </div>
+      <div class="header-actions">
+        <span class="refresh-state">
+          <span class="refresh-dot" :class="{ 'refresh-dot--on': autoRefresh }" />
+          {{ autoRefresh ? t('modelUsage.autoRefreshOn') : t('modelUsage.autoRefreshOff') }}
+        </span>
+        <t-button variant="outline" size="small" :loading="refreshing" @click="loadUsage(false)">
+          <template #icon><t-icon name="refresh" /></template>
+          {{ t('common.refresh') }}
+        </t-button>
+      </div>
+    </div>
+
+    <div class="usage-toolbar">
+      <t-radio-group v-model="range" variant="default-filled" size="small">
+        <t-radio-button v-for="item in rangeOptions" :key="item.value" :value="item.value">
+          {{ item.label }}
+        </t-radio-button>
+      </t-radio-group>
+
+      <t-select v-model="modelType" size="small" class="type-filter" :options="typeOptions" />
+
+      <div class="auto-refresh-control">
+        <span>{{ t('modelUsage.autoRefresh') }}</span>
+        <t-switch v-model="autoRefresh" size="small" />
+      </div>
+    </div>
+
+    <t-alert v-if="error" theme="error" :message="error" class="usage-alert">
+      <template #operation>
+        <t-button size="small" variant="text" @click="loadUsage(true)">
+          {{ t('common.retry') }}
+        </t-button>
+      </template>
+    </t-alert>
+
+    <t-loading :loading="loading" size="small" class="usage-loading">
+      <div class="metric-grid">
+        <div class="metric-card">
+          <span class="metric-label">{{ t('modelUsage.metrics.totalTokens') }}</span>
+          <strong>{{ formatNumber(summary.total_tokens) }}</strong>
+          <span>{{ t('modelUsage.metrics.cached', { count: formatNumber(summary.cached_tokens) }) }}</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-label">{{ t('modelUsage.metrics.calls') }}</span>
+          <strong>{{ formatNumber(summary.total_calls) }}</strong>
+          <span>{{ t('modelUsage.metrics.errors', { count: formatNumber(summary.error_count) }) }}</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-label">{{ t('modelUsage.metrics.promptCompletion') }}</span>
+          <strong>{{ formatNumber(summary.prompt_tokens) }} / {{ formatNumber(summary.completion_tokens) }}</strong>
+          <span>{{ t('modelUsage.metrics.promptCompletionHint') }}</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-label">{{ t('modelUsage.metrics.successRate') }}</span>
+          <strong>{{ formatPercent(summary.success_rate) }}</strong>
+          <span>{{ windowLabel }}</span>
+        </div>
+      </div>
+
+      <div v-if="!loading && !report.models.length" class="empty-state">
+        <t-empty :description="t('modelUsage.empty')" />
+      </div>
+
+      <template v-else>
+        <section class="usage-panel chart-panel">
+          <div class="panel-header">
+            <h3>{{ t('modelUsage.timeline.title') }}</h3>
+            <span>{{ t('modelUsage.timeline.subtitle') }}</span>
+          </div>
+          <div v-if="chartBuckets.length" class="usage-chart">
+            <div class="chart-plot">
+              <div v-for="bucket in chartBuckets" :key="bucket.bucket_start" class="chart-column">
+                <span class="chart-value">{{ formatCompactNumber(bucket.total_tokens) }}</span>
+                <div
+                  class="chart-bar"
+                  :style="{ height: `${barHeight(bucket.total_tokens)}%` }"
+                  :title="bucketTooltip(bucket)"
+                >
+                  <div
+                    v-for="segment in bucket.segments"
+                    :key="segment.model_key"
+                    class="chart-segment"
+                    :style="{ height: `${segment.percent}%`, backgroundColor: segment.color }"
+                    :title="segmentTooltip(bucket, segment)"
+                  />
+                </div>
+                <span class="chart-time">{{ formatBucketLabel(bucket.bucket_start) }}</span>
+              </div>
+            </div>
+            <div class="chart-legend">
+              <div v-for="item in modelLegend" :key="item.model_key" class="legend-item">
+                <span class="legend-swatch" :style="{ backgroundColor: item.color }" />
+                <span class="legend-name">{{ item.model_name }}</span>
+                <span class="legend-value">{{ formatNumber(item.total_tokens) }}</span>
+              </div>
+            </div>
+          </div>
+          <div v-else class="chart-empty">
+            <t-empty :description="t('modelUsage.empty')" />
+          </div>
+        </section>
+
+        <section class="usage-panel">
+          <div class="panel-header">
+            <h3>{{ t('modelUsage.table.title') }}</h3>
+            <span>{{ t('modelUsage.table.subtitle') }}</span>
+          </div>
+          <t-table
+            row-key="row_key"
+            :data="modelRows"
+            :columns="columns"
+            size="medium"
+            hover
+            stripe
+          >
+            <template #model="{ row }">
+              <div class="model-cell">
+                <span class="model-cell__name">{{ row.display_name || row.model_name || '-' }}</span>
+                <span v-if="row.display_name && row.model_name" class="model-cell__id">{{ row.model_name }}</span>
+              </div>
+            </template>
+            <template #model_type="{ row }">
+              <t-tag size="small" variant="light-outline">{{ modelTypeLabel(row.model_type) }}</t-tag>
+            </template>
+            <template #provider="{ row }">
+              <span class="provider-cell">{{ providerLabel(row) }}</span>
+            </template>
+            <template #total_tokens="{ row }">
+              <span class="numeric strong">{{ formatNumber(row.total_tokens) }}</span>
+            </template>
+            <template #token_breakdown="{ row }">
+              <div class="token-breakdown">
+                <span>{{ t('modelUsage.columns.promptShort') }} {{ formatNumber(row.prompt_tokens) }}</span>
+                <span>{{ t('modelUsage.columns.completionShort') }} {{ formatNumber(row.completion_tokens) }}</span>
+                <span>{{ t('modelUsage.columns.cachedShort') }} {{ formatNumber(row.cached_tokens) }}</span>
+              </div>
+            </template>
+            <template #success_rate="{ row }">
+              <span :class="['rate-cell', { 'rate-cell--warn': row.error_count > 0 }]">
+                {{ formatPercent(row.success_rate) }}
+              </span>
+            </template>
+            <template #last_used_at="{ row }">
+              <span>{{ formatDate(row.last_used_at) }}</span>
+            </template>
+          </t-table>
+        </section>
+
+        <section class="usage-panel recent-panel">
+          <div class="panel-header">
+            <h3>{{ t('modelUsage.recent.title') }}</h3>
+            <span>{{ t('modelUsage.recent.subtitle') }}</span>
+          </div>
+          <div class="recent-list">
+            <div v-for="event in report.recent_events" :key="event.id" class="recent-row">
+              <div class="recent-main">
+                <span class="recent-model">{{ event.model_name || '-' }}</span>
+                <t-tag size="small" :theme="event.success ? 'success' : 'danger'" variant="light">
+                  {{ event.success ? t('modelUsage.recent.success') : t('modelUsage.recent.failed') }}
+                </t-tag>
+                <t-tag size="small" variant="light-outline">{{ event.request_kind }}</t-tag>
+                <t-tag size="small" variant="light-outline">{{ usageSourceLabel(event.usage_source) }}</t-tag>
+              </div>
+              <div class="recent-meta">
+                <span>{{ formatNumber(event.total_tokens) }} tokens</span>
+                <span>{{ formatDuration(event.duration_ms) }}</span>
+                <span>{{ formatDate(event.created_at) }}</span>
+              </div>
+            </div>
+          </div>
+        </section>
+      </template>
+    </t-loading>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import {
+  getModelUsage,
+  type ModelUsageModelStats,
+  type ModelUsageRange,
+  type ModelUsageReport,
+  type ModelUsageType,
+} from '@/api/model'
+
+type ModelUsageRow = ModelUsageModelStats & { row_key: string }
+type ChartSegment = {
+  model_key: string
+  model_name: string
+  total_tokens: number
+  calls: number
+  error_count: number
+  percent: number
+  color: string
+}
+type ChartBucket = {
+  bucket_start: string
+  total_tokens: number
+  calls: number
+  error_count: number
+  segments: ChartSegment[]
+}
+type ChartLegendItem = {
+  model_key: string
+  model_name: string
+  total_tokens: number
+  color: string
+}
+
+const { t, locale } = useI18n()
+
+const range = ref<ModelUsageRange>('24h')
+const modelType = ref<ModelUsageType>('all')
+const autoRefresh = ref(true)
+const loading = ref(true)
+const refreshing = ref(false)
+const error = ref('')
+const report = ref<ModelUsageReport>(emptyReport())
+let timer: ReturnType<typeof setInterval> | undefined
+let requestSeq = 0
+
+const rangeOptions = computed(() => [
+  { value: '15m', label: t('modelUsage.ranges.15m') },
+  { value: '1h', label: t('modelUsage.ranges.1h') },
+  { value: '24h', label: t('modelUsage.ranges.24h') },
+  { value: '7d', label: t('modelUsage.ranges.7d') },
+])
+
+const typeOptions = computed(() => [
+  { value: 'all', label: t('common.all') },
+  { value: 'KnowledgeQA', label: t('modelUsage.types.KnowledgeQA') },
+  { value: 'Embedding', label: t('modelUsage.types.Embedding') },
+  { value: 'Rerank', label: t('modelUsage.types.Rerank') },
+  { value: 'VLLM', label: t('modelUsage.types.VLLM') },
+  { value: 'ASR', label: t('modelUsage.types.ASR') },
+])
+
+const columns = computed(() => [
+  { colKey: 'model', title: t('modelUsage.columns.model'), minWidth: 220, ellipsis: true },
+  { colKey: 'model_type', title: t('modelUsage.columns.type'), width: 104 },
+  { colKey: 'provider', title: t('modelUsage.columns.provider'), width: 132, ellipsis: true },
+  { colKey: 'calls', title: t('modelUsage.columns.calls'), width: 96, align: 'right' },
+  { colKey: 'total_tokens', title: t('modelUsage.columns.totalTokens'), width: 132, align: 'right' },
+  { colKey: 'token_breakdown', title: t('modelUsage.columns.breakdown'), minWidth: 210 },
+  { colKey: 'error_count', title: t('modelUsage.columns.errors'), width: 88, align: 'right' },
+  { colKey: 'success_rate', title: t('modelUsage.columns.successRate'), width: 112, align: 'right' },
+  { colKey: 'last_used_at', title: t('modelUsage.columns.lastUsed'), width: 168 },
+])
+
+const summary = computed(() => report.value.summary)
+const modelRows = computed<ModelUsageRow[]>(() =>
+  report.value.models.map((row, index) => ({
+    ...row,
+    row_key: `${row.model_id || row.model_name || 'model'}-${index}`,
+  })),
+)
+
+const chartPalette = [
+  '#2f7cf6',
+  '#00a870',
+  '#f5a623',
+  '#e34d59',
+  '#7c3aed',
+  '#14b8a6',
+  '#f97316',
+  '#64748b',
+  '#d946ef',
+  '#0ea5e9',
+  '#84cc16',
+  '#ef4444',
+]
+const minChartBucketCalls = 100
+
+const modelNameMap = computed(() => {
+  const names = new Map<string, string>()
+  for (const row of report.value.models) {
+    names.set(modelUsageKey(row.model_id, row.model_name, row.model_type), row.display_name || row.model_name || '-')
+  }
+  return names
+})
+
+const modelColorMap = computed(() => {
+  const colors = new Map<string, string>()
+  const keys = new Set<string>()
+  for (const row of report.value.models) {
+    keys.add(modelUsageKey(row.model_id, row.model_name, row.model_type))
+  }
+  for (const point of report.value.timeline) {
+    keys.add(modelUsageKey(point.model_id, point.model_name, point.model_type))
+  }
+  Array.from(keys).forEach((key, index) => {
+    colors.set(key, chartPalette[index % chartPalette.length])
+  })
+  return colors
+})
+
+const chartBuckets = computed<ChartBucket[]>(() => {
+  const buckets = new Map<
+    string,
+    {
+      bucket_start: string
+      total_tokens: number
+      calls: number
+      error_count: number
+      models: Map<string, Omit<ChartSegment, 'percent' | 'color'>>
+    }
+  >()
+  for (const point of report.value.timeline) {
+    const existing = buckets.get(point.bucket_start) || {
+      bucket_start: point.bucket_start,
+      total_tokens: 0,
+      calls: 0,
+      error_count: 0,
+      models: new Map<string, Omit<ChartSegment, 'percent' | 'color'>>(),
+    }
+    existing.total_tokens += point.total_tokens
+    existing.calls += point.calls
+    existing.error_count += point.error_count
+    const key = modelUsageKey(point.model_id, point.model_name, point.model_type)
+    const model = existing.models.get(key) || {
+      model_key: key,
+      model_name: modelNameMap.value.get(key) || point.model_name || '-',
+      total_tokens: 0,
+      calls: 0,
+      error_count: 0,
+    }
+    model.total_tokens += point.total_tokens
+    model.calls += point.calls
+    model.error_count += point.error_count
+    existing.models.set(key, model)
+    buckets.set(point.bucket_start, existing)
+  }
+  return Array.from(buckets.values())
+    .sort((a, b) => new Date(a.bucket_start).getTime() - new Date(b.bucket_start).getTime())
+    .filter((bucket) => bucket.calls >= minChartBucketCalls)
+    .slice(-24)
+    .map((bucket) => ({
+      bucket_start: bucket.bucket_start,
+      total_tokens: bucket.total_tokens,
+      calls: bucket.calls,
+      error_count: bucket.error_count,
+      segments: Array.from(bucket.models.values())
+        .sort((a, b) => b.total_tokens - a.total_tokens)
+        .map((segment) => ({
+          ...segment,
+          percent: bucket.total_tokens > 0 ? (segment.total_tokens / bucket.total_tokens) * 100 : 0,
+          color: modelColorMap.value.get(segment.model_key) || chartPalette[0],
+        })),
+    }))
+})
+
+const modelLegend = computed<ChartLegendItem[]>(() => {
+  const totals = new Map<string, ChartLegendItem>()
+  for (const bucket of chartBuckets.value) {
+    for (const segment of bucket.segments) {
+      const existing = totals.get(segment.model_key) || {
+        model_key: segment.model_key,
+        model_name: segment.model_name,
+        total_tokens: 0,
+        color: segment.color,
+      }
+      existing.total_tokens += segment.total_tokens
+      totals.set(segment.model_key, existing)
+    }
+  }
+  return Array.from(totals.values()).sort((a, b) => b.total_tokens - a.total_tokens)
+})
+
+const maxChartTokens = computed(() => Math.max(1, ...chartBuckets.value.map((row) => row.total_tokens)))
+const windowLabel = computed(() => `${formatDate(summary.value.window_start)} - ${formatDate(summary.value.window_end)}`)
+
+function emptyReport(): ModelUsageReport {
+  const now = new Date().toISOString()
+  return {
+    summary: {
+      window_start: now,
+      window_end: now,
+      refresh_seconds: 5,
+      total_calls: 0,
+      total_tokens: 0,
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      cached_tokens: 0,
+      error_count: 0,
+      success_rate: 1,
+    },
+    models: [],
+    timeline: [],
+    recent_events: [],
+  }
+}
+
+async function loadUsage(showLoading = true) {
+  const seq = ++requestSeq
+  if (showLoading) loading.value = true
+  refreshing.value = !showLoading
+  error.value = ''
+  try {
+    const data = await getModelUsage({
+      range: range.value,
+      model_type: modelType.value,
+    })
+    if (seq === requestSeq) {
+      report.value = data
+    }
+  } catch (err: any) {
+    if (seq === requestSeq) {
+      error.value = err?.message || t('modelUsage.loadFailed')
+    }
+  } finally {
+    if (seq === requestSeq) {
+      loading.value = false
+      refreshing.value = false
+    }
+  }
+}
+
+function resetTimer() {
+  if (timer) {
+    clearInterval(timer)
+    timer = undefined
+  }
+  if (autoRefresh.value) {
+    timer = setInterval(() => loadUsage(false), 5000)
+  }
+}
+
+function formatNumber(value?: number | null) {
+  return new Intl.NumberFormat(locale.value || 'zh-CN').format(value || 0)
+}
+
+function formatCompactNumber(value?: number | null) {
+  return new Intl.NumberFormat(locale.value || 'zh-CN', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(value || 0)
+}
+
+function formatPercent(value?: number | null) {
+  return `${(((value ?? 0) || 0) * 100).toFixed(1)}%`
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '-'
+  return new Intl.DateTimeFormat(locale.value || 'zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}
+
+function formatTime(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '-'
+  return new Intl.DateTimeFormat(locale.value || 'zh-CN', {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}
+
+function formatBucketLabel(value: string) {
+  if (range.value === '7d') return formatDate(value)
+  return formatTime(value)
+}
+
+function formatDuration(ms?: number | null) {
+  const value = ms || 0
+  if (value < 1000) return `${value}ms`
+  return `${(value / 1000).toFixed(1)}s`
+}
+
+function barHeight(totalTokens: number) {
+  if (totalTokens <= 0) return 0
+  return Math.max(6, Math.round((totalTokens / maxChartTokens.value) * 100))
+}
+
+function modelUsageKey(modelID?: string, modelName?: string, type?: string) {
+  return [modelID || modelName || 'unknown', type || 'unknown'].join(':')
+}
+
+function bucketTooltip(bucket: ChartBucket) {
+  const lines = [
+    `${formatDate(bucket.bucket_start)} · ${formatNumber(bucket.total_tokens)} tokens · ${formatNumber(bucket.calls)} calls`,
+    ...bucket.segments.map(
+      (segment) =>
+        `${segment.model_name}: ${formatNumber(segment.total_tokens)} tokens, ${formatNumber(segment.calls)} calls`,
+    ),
+  ]
+  return lines.join('\n')
+}
+
+function segmentTooltip(bucket: ChartBucket, segment: ChartSegment) {
+  const share = bucket.total_tokens > 0 ? segment.total_tokens / bucket.total_tokens : 0
+  return `${segment.model_name}\n${formatNumber(segment.total_tokens)} tokens · ${formatNumber(segment.calls)} calls · ${formatPercent(share)}`
+}
+
+function modelTypeLabel(type: string) {
+  const key = `modelUsage.types.${type}`
+  return t(key)
+}
+
+function providerLabel(row: ModelUsageModelStats) {
+  if (row.provider) return row.provider
+  return row.model_source || '-'
+}
+
+function usageSourceLabel(source: string) {
+  const key = `modelUsage.usageSource.${source || 'missing'}`
+  return t(key)
+}
+
+watch([range, modelType], () => {
+  loadUsage(true)
+})
+
+watch(autoRefresh, resetTimer)
+
+onMounted(() => {
+  loadUsage(true)
+  resetTimer()
+})
+
+onUnmounted(() => {
+  if (timer) clearInterval(timer)
+})
+</script>
+
+<style scoped lang="less">
+.model-usage-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--td-text-color-primary);
+}
+
+.section-description {
+  margin: 8px 0 0;
+  color: var(--td-text-color-secondary);
+  line-height: 1.6;
+}
+
+.header-actions,
+.usage-toolbar,
+.auto-refresh-control {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.header-actions {
+  flex-shrink: 0;
+}
+
+.refresh-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--td-text-color-secondary);
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.refresh-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--td-gray-color-5);
+}
+
+.refresh-dot--on {
+  background: var(--td-success-color);
+}
+
+.usage-toolbar {
+  flex-wrap: wrap;
+  padding: 12px;
+  border: 1px solid var(--td-border-level-1-color);
+  border-radius: 8px;
+  background: var(--td-bg-color-container);
+}
+
+.type-filter {
+  width: 168px;
+}
+
+.auto-refresh-control {
+  margin-left: auto;
+  color: var(--td-text-color-secondary);
+  font-size: 13px;
+}
+
+.usage-alert {
+  margin-bottom: -4px;
+}
+
+.usage-loading {
+  min-height: 240px;
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.metric-card {
+  min-height: 104px;
+  padding: 16px;
+  border: 1px solid var(--td-border-level-1-color);
+  border-radius: 8px;
+  background: var(--td-bg-color-container);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.metric-card strong {
+  display: block;
+  margin: 8px 0 6px;
+  font-size: 24px;
+  line-height: 1.2;
+  color: var(--td-text-color-primary);
+}
+
+.metric-card span {
+  color: var(--td-text-color-secondary);
+  font-size: 13px;
+}
+
+.metric-label {
+  color: var(--td-text-color-placeholder) !important;
+}
+
+.usage-panel {
+  margin-top: 14px;
+  padding: 16px;
+  border: 1px solid var(--td-border-level-1-color);
+  border-radius: 8px;
+  background: var(--td-bg-color-container);
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+  margin-bottom: 14px;
+}
+
+.panel-header h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--td-text-color-primary);
+}
+
+.panel-header span {
+  color: var(--td-text-color-secondary);
+  font-size: 13px;
+}
+
+.chart-panel {
+  overflow: hidden;
+}
+
+.usage-chart {
+  display: grid;
+  gap: 14px;
+}
+
+.chart-plot {
+  min-height: 260px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(34px, 1fr));
+  align-items: end;
+  gap: 10px;
+  padding: 12px 4px 4px;
+  border-bottom: 1px solid var(--td-border-level-1-color);
+  overflow-x: auto;
+}
+
+.chart-column {
+  min-width: 34px;
+  height: 232px;
+  display: grid;
+  grid-template-rows: 22px 1fr 32px;
+  align-items: end;
+  justify-items: center;
+  gap: 6px;
+}
+
+.chart-value {
+  max-width: 58px;
+  overflow: hidden;
+  color: var(--td-text-color-placeholder);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chart-bar {
+  width: 100%;
+  max-width: 34px;
+  min-height: 8px;
+  display: flex;
+  flex-direction: column-reverse;
+  overflow: hidden;
+  border-radius: 6px 6px 2px 2px;
+  background: var(--td-bg-color-component);
+  box-shadow: inset 0 0 0 1px var(--td-border-level-1-color);
+}
+
+.chart-segment {
+  width: 100%;
+  min-height: 2px;
+  transition: opacity 0.15s ease;
+}
+
+.chart-segment:hover {
+  opacity: 0.78;
+}
+
+.chart-time {
+  color: var(--td-text-color-secondary);
+  font-size: 11px;
+  line-height: 1.2;
+  text-align: center;
+  white-space: normal;
+  word-break: keep-all;
+}
+
+.chart-legend {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px 14px;
+}
+
+.legend-item {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  color: var(--td-text-color-secondary);
+  font-size: 12px;
+}
+
+.legend-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+}
+
+.legend-name {
+  overflow: hidden;
+  color: var(--td-text-color-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.legend-value {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.chart-empty {
+  padding: 24px 0;
+}
+
+.model-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.model-cell__name {
+  color: var(--td-text-color-primary);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.model-cell__id {
+  color: var(--td-text-color-placeholder);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.provider-cell,
+.numeric,
+.rate-cell {
+  font-variant-numeric: tabular-nums;
+}
+
+.strong {
+  font-weight: 600;
+  color: var(--td-text-color-primary);
+}
+
+.token-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  color: var(--td-text-color-secondary);
+  font-size: 12px;
+}
+
+.rate-cell--warn {
+  color: var(--td-warning-color);
+}
+
+.recent-list {
+  display: grid;
+  gap: 10px;
+}
+
+.recent-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--td-border-level-1-color);
+}
+
+.recent-row:last-child {
+  border-bottom: 0;
+}
+
+.recent-main,
+.recent-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.recent-model {
+  color: var(--td-text-color-primary);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.recent-meta {
+  flex-shrink: 0;
+  color: var(--td-text-color-secondary);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.empty-state {
+  padding: 48px 0;
+}
+
+@media (max-width: 960px) {
+  .section-header,
+  .recent-row {
+    flex-direction: column;
+  }
+
+  .header-actions,
+  .auto-refresh-control {
+    margin-left: 0;
+  }
+
+  .metric-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .recent-meta {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 640px) {
+  .metric-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .chart-plot {
+    grid-template-columns: repeat(24, minmax(28px, 1fr));
+    gap: 8px;
+  }
+
+  .chart-column {
+    min-width: 28px;
+  }
+
+  .chart-legend {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/views/settings/Settings.vue
+++ b/frontend/src/views/settings/Settings.vue
@@ -70,7 +70,7 @@
             <!-- 右侧内容区域 -->
             <div class="settings-content">
               <div class="content-wrapper" :class="{
-                'content-wrapper--wide': currentSection === 'members',
+                'content-wrapper--wide': currentSection === 'members' || currentSection === 'modelUsage',
                 'content-wrapper--full': SYSTEM_ADMIN_SECTIONS.has(currentSection) || isIntegrationSection(currentSection),
               }">
                 <!-- 角色不允许访问当前 section（deep-link 进来 / 跨空间切换后角色降级）—— 优先于具体 section 渲染。
@@ -102,6 +102,11 @@
                   <!-- 模型配置 -->
                   <div v-if="currentSection === 'models'" class="section">
                     <ModelSettings />
+                  </div>
+
+                  <!-- 模型用量看板（独立页面 /platform/model-usage 的深链兜底） -->
+                  <div v-if="currentSection === 'modelUsage'" class="section">
+                    <ModelUsageSettings />
                   </div>
 
                   <!-- 网络搜索配置 -->
@@ -198,6 +203,7 @@ import TenantInfo from './TenantInfo.vue'
 import UserProfile from './UserProfile.vue'
 import GeneralSettings from './GeneralSettings.vue'
 import ModelSettings from './ModelSettings.vue'
+import ModelUsageSettings from './ModelUsageSettings.vue'
 import OllamaSettings from './OllamaSettings.vue'
 import McpSettings from './McpSettings.vue'
 import WebSearchSettings from './WebSearchSettings.vue'
@@ -324,6 +330,7 @@ const navItems = computed(() => {
     { key: 'ollama', icon: 'server', label: 'Ollama' },
     { key: 'weknoracloud', icon: '', label: 'WeKnora Cloud' },
     { key: 'models', icon: 'control-platform', label: t('settings.modelManagement') },
+    { key: 'modelUsage', icon: 'chart-bar', label: t('settings.modelUsage') },
     { key: 'websearch', icon: 'search', label: t('settings.webSearchConfig') },
     { key: 'chathistory', icon: 'chat', label: t('chatHistorySettings.title') },
     { key: 'vectorstore', icon: 'data-base', label: t('settings.vectorStoreEngine') },
@@ -370,7 +377,7 @@ const navGroups = computed<NavGroup[]>(() => {
     {
       key: 'models_runtime',
       label: t('settings.navGroups.modelsRuntime'),
-      items: pickItems(['models', 'ollama', 'weknoracloud']),
+      items: pickItems(['models', 'modelUsage', 'ollama', 'weknoracloud']),
     },
     {
       key: 'integrations',

--- a/internal/application/repository/model_usage_events.go
+++ b/internal/application/repository/model_usage_events.go
@@ -1,0 +1,288 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"gorm.io/gorm"
+)
+
+// modelUsageRepository implements interfaces.ModelUsageRepository on top of
+// the model_usage_events table (see migrations 000079).
+type modelUsageRepository struct {
+	db *gorm.DB
+}
+
+const (
+	defaultModelUsageTimelineBucket = 2 * time.Hour
+	// minModelUsageTimelineBucketCalls hides timeline buckets with too little
+	// traffic: a bucket with a handful of calls renders as noise next to
+	// high-traffic buckets on the stacked-bar chart.
+	minModelUsageTimelineBucketCalls = int64(100)
+)
+
+// NewModelUsageRepository creates a repository for model usage metering events.
+func NewModelUsageRepository(db *gorm.DB) interfaces.ModelUsageRepository {
+	return &modelUsageRepository{db: db}
+}
+
+func (r *modelUsageRepository) Create(ctx context.Context, event *types.ModelUsageEvent) error {
+	return r.db.WithContext(ctx).Create(event).Error
+}
+
+func (r *modelUsageRepository) Report(
+	ctx context.Context,
+	tenantID uint64,
+	query types.ModelUsageQuery,
+) (*types.ModelUsageReport, error) {
+	models, err := r.modelStats(ctx, tenantID, query)
+	if err != nil {
+		return nil, err
+	}
+	timeline, err := r.timeline(ctx, tenantID, query)
+	if err != nil {
+		return nil, err
+	}
+	recent, err := r.recentEvents(ctx, tenantID, query)
+	if err != nil {
+		return nil, err
+	}
+	if models == nil {
+		models = []types.ModelUsageModelStats{}
+	}
+	if timeline == nil {
+		timeline = []types.ModelUsageTimelinePoint{}
+	}
+	if recent == nil {
+		recent = []types.ModelUsageEvent{}
+	}
+
+	report := &types.ModelUsageReport{
+		Summary: types.ModelUsageSummary{
+			WindowStart:    query.Start,
+			WindowEnd:      query.End,
+			RefreshSeconds: 5,
+		},
+		Models:       models,
+		Timeline:     timeline,
+		RecentEvents: recent,
+	}
+	for i := range report.Models {
+		row := &report.Models[i]
+		row.SuccessRate = successRate(row.Calls, row.ErrorCount)
+		if row.Calls > 0 {
+			row.AvgTokensPerCall = float64(row.TotalTokens) / float64(row.Calls)
+		}
+		report.Summary.TotalCalls += row.Calls
+		report.Summary.TotalTokens += row.TotalTokens
+		report.Summary.PromptTokens += row.PromptTokens
+		report.Summary.CompletionTokens += row.CompletionTokens
+		report.Summary.CachedTokens += row.CachedTokens
+		report.Summary.ErrorCount += row.ErrorCount
+	}
+	report.Summary.SuccessRate = successRate(report.Summary.TotalCalls, report.Summary.ErrorCount)
+	return report, nil
+}
+
+func (r *modelUsageRepository) filteredEvents(
+	ctx context.Context,
+	tenantID uint64,
+	query types.ModelUsageQuery,
+) *gorm.DB {
+	tx := r.db.WithContext(ctx).
+		Table("model_usage_events AS e").
+		Where("e.tenant_id = ? AND e.created_at >= ? AND e.created_at < ?", tenantID, query.Start, query.End)
+	if query.ModelType != "" {
+		tx = tx.Where("e.model_type = ?", query.ModelType)
+	}
+	if query.ModelID != "" {
+		tx = tx.Where("e.model_id = ?", query.ModelID)
+	}
+	return tx
+}
+
+func (r *modelUsageRepository) modelStats(
+	ctx context.Context,
+	tenantID uint64,
+	query types.ModelUsageQuery,
+) ([]types.ModelUsageModelStats, error) {
+	// MAX() loses the column's temporal type under sqlite (the driver returns
+	// a string that cannot scan into *time.Time), so aggregate as epoch
+	// seconds and convert in Go on both dialects.
+	lastUsedExpr := "CAST(FLOOR(EXTRACT(EPOCH FROM MAX(e.created_at))) AS BIGINT)"
+	if r.db.Name() == "sqlite" {
+		lastUsedExpr = "CAST(strftime('%s', MAX(e.created_at)) AS INTEGER)"
+	}
+
+	type modelStatsRow struct {
+		ModelID          string
+		ModelName        string
+		DisplayName      string
+		ModelType        types.ModelType
+		ModelSource      types.ModelSource
+		Provider         string
+		Calls            int64
+		PromptTokens     int64
+		CompletionTokens int64
+		CachedTokens     int64
+		TotalTokens      int64
+		InputItems       int64
+		DurationMs       int64
+		ErrorCount       int64
+		LastUsedEpoch    int64
+	}
+	var rows []modelStatsRow
+	err := r.filteredEvents(ctx, tenantID, query).
+		Select(fmt.Sprintf(`
+			e.model_id AS model_id,
+			e.model_name AS model_name,
+			COALESCE(m.display_name, '') AS display_name,
+			e.model_type AS model_type,
+			e.model_source AS model_source,
+			e.provider AS provider,
+			COUNT(*) AS calls,
+			COALESCE(SUM(e.prompt_tokens), 0) AS prompt_tokens,
+			COALESCE(SUM(e.completion_tokens), 0) AS completion_tokens,
+			COALESCE(SUM(e.cached_tokens), 0) AS cached_tokens,
+			COALESCE(SUM(e.total_tokens), 0) AS total_tokens,
+			COALESCE(SUM(e.input_items), 0) AS input_items,
+			COALESCE(SUM(e.duration_ms), 0) AS duration_ms,
+			COALESCE(SUM(CASE WHEN e.success THEN 0 ELSE 1 END), 0) AS error_count,
+			%s AS last_used_epoch`, lastUsedExpr)).
+		Joins(`LEFT JOIN models m ON m.id = e.model_id
+			AND (m.tenant_id = e.tenant_id OR m.is_builtin = true)
+			AND m.deleted_at IS NULL`).
+		Group("e.model_id, e.model_name, m.display_name, e.model_type, e.model_source, e.provider").
+		Order("total_tokens DESC, calls DESC, model_name ASC").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	stats := make([]types.ModelUsageModelStats, 0, len(rows))
+	for _, row := range rows {
+		lastUsedAt := time.Unix(row.LastUsedEpoch, 0).UTC()
+		stats = append(stats, types.ModelUsageModelStats{
+			ModelID:          row.ModelID,
+			ModelName:        row.ModelName,
+			DisplayName:      row.DisplayName,
+			ModelType:        row.ModelType,
+			ModelSource:      row.ModelSource,
+			Provider:         row.Provider,
+			Calls:            row.Calls,
+			PromptTokens:     row.PromptTokens,
+			CompletionTokens: row.CompletionTokens,
+			CachedTokens:     row.CachedTokens,
+			TotalTokens:      row.TotalTokens,
+			InputItems:       row.InputItems,
+			DurationMs:       row.DurationMs,
+			ErrorCount:       row.ErrorCount,
+			LastUsedAt:       &lastUsedAt,
+		})
+	}
+	return stats, nil
+}
+
+func (r *modelUsageRepository) timeline(
+	ctx context.Context,
+	tenantID uint64,
+	query types.ModelUsageQuery,
+) ([]types.ModelUsageTimelinePoint, error) {
+	bucketSeconds := int64(query.BucketSize.Seconds())
+	if bucketSeconds <= 0 {
+		bucketSeconds = int64(defaultModelUsageTimelineBucket.Seconds())
+	}
+	bucketExpr := "CAST(FLOOR(EXTRACT(EPOCH FROM e.created_at) / ?) * ? AS BIGINT)"
+	if r.db.Name() == "sqlite" {
+		bucketExpr = "(CAST(strftime('%s', e.created_at) AS INTEGER) / ?) * ?"
+	}
+
+	type row struct {
+		BucketEpoch      int64
+		ModelID          string
+		ModelName        string
+		ModelType        types.ModelType
+		Calls            int64
+		PromptTokens     int64
+		CompletionTokens int64
+		CachedTokens     int64
+		TotalTokens      int64
+		ErrorCount       int64
+	}
+	var rows []row
+	err := r.filteredEvents(ctx, tenantID, query).
+		Select(fmt.Sprintf(`
+			%s AS bucket_epoch,
+			e.model_id AS model_id,
+			e.model_name AS model_name,
+			e.model_type AS model_type,
+			COUNT(*) AS calls,
+			COALESCE(SUM(e.prompt_tokens), 0) AS prompt_tokens,
+			COALESCE(SUM(e.completion_tokens), 0) AS completion_tokens,
+			COALESCE(SUM(e.cached_tokens), 0) AS cached_tokens,
+			COALESCE(SUM(e.total_tokens), 0) AS total_tokens,
+			COALESCE(SUM(CASE WHEN e.success THEN 0 ELSE 1 END), 0) AS error_count`, bucketExpr), bucketSeconds, bucketSeconds).
+		Group("1, e.model_id, e.model_name, e.model_type").
+		Order("bucket_epoch ASC, total_tokens DESC").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	bucketCalls := make(map[int64]int64, len(rows))
+	for _, item := range rows {
+		bucketCalls[item.BucketEpoch] += item.Calls
+	}
+
+	points := make([]types.ModelUsageTimelinePoint, 0, len(rows))
+	for _, r := range rows {
+		if bucketCalls[r.BucketEpoch] < minModelUsageTimelineBucketCalls {
+			continue
+		}
+		points = append(points, types.ModelUsageTimelinePoint{
+			BucketStart:      time.Unix(r.BucketEpoch, 0).UTC(),
+			ModelID:          r.ModelID,
+			ModelName:        r.ModelName,
+			ModelType:        r.ModelType,
+			Calls:            r.Calls,
+			PromptTokens:     r.PromptTokens,
+			CompletionTokens: r.CompletionTokens,
+			CachedTokens:     r.CachedTokens,
+			TotalTokens:      r.TotalTokens,
+			ErrorCount:       r.ErrorCount,
+		})
+	}
+	return points, nil
+}
+
+func (r *modelUsageRepository) recentEvents(
+	ctx context.Context,
+	tenantID uint64,
+	query types.ModelUsageQuery,
+) ([]types.ModelUsageEvent, error) {
+	limit := query.RecentLimit
+	if limit <= 0 || limit > 100 {
+		limit = 30
+	}
+	var events []types.ModelUsageEvent
+	err := r.filteredEvents(ctx, tenantID, query).
+		Select("e.*").
+		Order("e.created_at DESC, e.id DESC").
+		Limit(limit).
+		Find(&events).Error
+	return events, err
+}
+
+func successRate(calls, errors int64) float64 {
+	if calls <= 0 {
+		return 1
+	}
+	successes := calls - errors
+	if successes < 0 {
+		successes = 0
+	}
+	return float64(successes) / float64(calls)
+}

--- a/internal/application/repository/model_usage_events_test.go
+++ b/internal/application/repository/model_usage_events_test.go
@@ -1,0 +1,148 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newModelUsageTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.ModelUsageEvent{}))
+	require.NoError(t, db.Exec(`
+		CREATE TABLE models (
+			id TEXT PRIMARY KEY,
+			tenant_id INTEGER NOT NULL DEFAULT 0,
+			display_name TEXT NOT NULL DEFAULT '',
+			is_builtin INTEGER NOT NULL DEFAULT 0,
+			deleted_at DATETIME NULL
+		)
+	`).Error)
+	return db
+}
+
+func createModelUsageEvents(t *testing.T, db *gorm.DB, count int, event types.ModelUsageEvent) {
+	t.Helper()
+	events := make([]types.ModelUsageEvent, 0, count)
+	for i := 0; i < count; i++ {
+		events = append(events, event)
+	}
+	require.NoError(t, db.Create(&events).Error)
+}
+
+func TestModelUsageReportReturnsEmptySlices(t *testing.T) {
+	db := newModelUsageTestDB(t)
+	repo := NewModelUsageRepository(db)
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+
+	report, err := repo.Report(context.Background(), 1, types.ModelUsageQuery{
+		Start:      now.Add(-time.Hour),
+		End:        now,
+		BucketSize: time.Minute,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, report)
+	assert.NotNil(t, report.Models)
+	assert.NotNil(t, report.Timeline)
+	assert.NotNil(t, report.RecentEvents)
+	assert.Empty(t, report.Models)
+	assert.Empty(t, report.Timeline)
+	assert.Empty(t, report.RecentEvents)
+}
+
+func TestModelUsageReportFiltersTenantAndAggregates(t *testing.T) {
+	db := newModelUsageTestDB(t)
+	repo := NewModelUsageRepository(db)
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+
+	createModelUsageEvents(t, db, 100, types.ModelUsageEvent{
+		TenantID:         1,
+		ModelID:          "model-chat",
+		ModelName:        "gpt-test",
+		ModelType:        types.ModelTypeKnowledgeQA,
+		ModelSource:      types.ModelSourceRemote,
+		Provider:         "openai",
+		RequestKind:      "chat.completion",
+		UsageSource:      types.ModelUsageSourceProvider,
+		PromptTokens:     10,
+		CompletionTokens: 5,
+		TotalTokens:      15,
+		InputItems:       1,
+		Success:          true,
+		CreatedAt:        now.Add(-time.Minute),
+	})
+	require.NoError(t, db.Create(&types.ModelUsageEvent{
+		TenantID:    2,
+		ModelID:     "other-tenant-model",
+		ModelName:   "other",
+		ModelType:   types.ModelTypeKnowledgeQA,
+		TotalTokens: 999,
+		Success:     true,
+		CreatedAt:   now.Add(-time.Minute),
+	}).Error)
+
+	report, err := repo.Report(context.Background(), 1, types.ModelUsageQuery{
+		Start:      now.Add(-time.Hour),
+		End:        now,
+		BucketSize: time.Hour,
+	})
+	require.NoError(t, err)
+	require.Len(t, report.Models, 1)
+	assert.Equal(t, int64(100), report.Summary.TotalCalls)
+	assert.Equal(t, int64(1500), report.Summary.TotalTokens)
+	assert.Equal(t, "model-chat", report.Models[0].ModelID)
+	assert.Equal(t, int64(1500), report.Models[0].TotalTokens)
+	assert.Equal(t, float64(1), report.Models[0].SuccessRate)
+	require.Len(t, report.Timeline, 1)
+	assert.Equal(t, int64(100), report.Timeline[0].Calls)
+	assert.Equal(t, int64(1500), report.Timeline[0].TotalTokens)
+	assert.Len(t, report.RecentEvents, 30)
+}
+
+func TestModelUsageTimelineSkipsBucketsBelowCallThreshold(t *testing.T) {
+	db := newModelUsageTestDB(t)
+	repo := NewModelUsageRepository(db)
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+
+	baseEvent := types.ModelUsageEvent{
+		TenantID:         1,
+		ModelID:          "model-chat",
+		ModelName:        "gpt-test",
+		ModelType:        types.ModelTypeKnowledgeQA,
+		ModelSource:      types.ModelSourceRemote,
+		Provider:         "openai",
+		RequestKind:      "chat.completion",
+		UsageSource:      types.ModelUsageSourceProvider,
+		PromptTokens:     10,
+		CompletionTokens: 5,
+		TotalTokens:      15,
+		InputItems:       1,
+		Success:          true,
+	}
+
+	smallBucketEvent := baseEvent
+	smallBucketEvent.CreatedAt = now.Add(-90 * time.Minute)
+	createModelUsageEvents(t, db, 99, smallBucketEvent)
+
+	visibleBucketEvent := baseEvent
+	visibleBucketEvent.CreatedAt = now.Add(-10 * time.Minute)
+	createModelUsageEvents(t, db, 100, visibleBucketEvent)
+
+	report, err := repo.Report(context.Background(), 1, types.ModelUsageQuery{
+		Start:      now.Add(-2 * time.Hour),
+		End:        now,
+		BucketSize: time.Hour,
+	})
+	require.NoError(t, err)
+	require.Len(t, report.Timeline, 1)
+	assert.Equal(t, int64(100), report.Timeline[0].Calls)
+	assert.Equal(t, now.Add(-time.Hour).Truncate(time.Hour), report.Timeline[0].BucketStart)
+}

--- a/internal/application/service/model_usage.go
+++ b/internal/application/service/model_usage.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+// modelUsageService resolves the reporting window for the usage dashboard and
+// delegates aggregation to the repository.
+type modelUsageService struct {
+	repo interfaces.ModelUsageRepository
+}
+
+// modelUsageTimelineBucket is fixed regardless of range: the stacked-bar
+// chart always renders 2-hour buckets (the repository additionally hides
+// buckets with too little traffic).
+const modelUsageTimelineBucket = 2 * time.Hour
+
+// NewModelUsageService creates the model usage report service.
+func NewModelUsageService(repo interfaces.ModelUsageRepository) interfaces.ModelUsageService {
+	return &modelUsageService{repo: repo}
+}
+
+func (s *modelUsageService) GetUsageReport(
+	ctx context.Context,
+	query types.ModelUsageQuery,
+) (*types.ModelUsageReport, error) {
+	tenantID, ok := types.TenantIDFromContext(ctx)
+	if !ok || tenantID == 0 {
+		return nil, fmt.Errorf("tenant ID not found in context")
+	}
+
+	now := time.Now().UTC()
+	query.End = now
+	query.Start, query.BucketSize = usageWindow(query.Range, now)
+	query.RecentLimit = 30
+
+	if query.ModelType == types.ModelType("all") {
+		query.ModelType = ""
+	}
+	return s.repo.Report(ctx, tenantID, query)
+}
+
+func usageWindow(value string, now time.Time) (time.Time, time.Duration) {
+	switch value {
+	case "15m":
+		return now.Add(-15 * time.Minute), modelUsageTimelineBucket
+	case "1h":
+		return now.Add(-time.Hour), modelUsageTimelineBucket
+	case "7d":
+		return now.Add(-7 * 24 * time.Hour), modelUsageTimelineBucket
+	default:
+		return now.Add(-24 * time.Hour), modelUsageTimelineBucket
+	}
+}

--- a/internal/application/service/model_usage_test.go
+++ b/internal/application/service/model_usage_test.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUsageWindowUsesTwoHourBuckets(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name      string
+		value     string
+		wantStart time.Time
+	}{
+		{name: "15 minutes", value: "15m", wantStart: now.Add(-15 * time.Minute)},
+		{name: "1 hour", value: "1h", wantStart: now.Add(-time.Hour)},
+		{name: "24 hours default", value: "24h", wantStart: now.Add(-24 * time.Hour)},
+		{name: "7 days", value: "7d", wantStart: now.Add(-7 * 24 * time.Hour)},
+		{name: "unknown defaults to 24 hours", value: "unknown", wantStart: now.Add(-24 * time.Hour)},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			start, bucket := usageWindow(tt.value, now)
+
+			assert.Equal(t, tt.wantStart, start)
+			assert.Equal(t, 2*time.Hour, bucket)
+		})
+	}
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -79,6 +79,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/models/embedding"
 	"github.com/Tencent/WeKnora/internal/models/limiter"
 	"github.com/Tencent/WeKnora/internal/models/utils/ollama"
+	"github.com/Tencent/WeKnora/internal/modelusage"
 	"github.com/Tencent/WeKnora/internal/router"
 	"github.com/Tencent/WeKnora/internal/storageallowlist"
 	"github.com/Tencent/WeKnora/internal/stream"
@@ -172,6 +173,11 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewWikiPageRepository))
 	must(container.Provide(repository.NewTaskPendingOpsRepository))
 	must(container.Provide(repository.NewTaskDeadLetterRepository))
+	must(container.Provide(repository.NewModelUsageRepository))
+	must(container.Provide(func(repo interfaces.ModelUsageRepository) *modelusage.AsyncRecorder {
+		return modelusage.NewAsyncRecorder(repo)
+	}))
+	must(container.Invoke(registerModelUsageRecorder))
 
 	// MCP manager for managing MCP client connections
 	logger.Debugf(ctx, "[Container] Registering MCP manager...")
@@ -196,6 +202,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(service.NewKnowledgeTagService))
 	must(container.Provide(embedding.NewBatchEmbedder))
 	must(container.Provide(service.NewModelService))
+	must(container.Provide(service.NewModelUsageService))
 	must(container.Provide(service.NewDatasetService))
 	must(container.Provide(service.NewEvaluationService))
 	must(container.Provide(service.NewUserService))
@@ -349,6 +356,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(handler.NewMessageHandler))
 	must(container.Provide(handler.NewMessageSuggestionHandler))
 	must(container.Provide(handler.NewModelHandler))
+	must(container.Provide(handler.NewModelUsageHandler))
 	must(container.Provide(handler.NewEvaluationHandler))
 	must(container.Provide(handler.NewInitializationHandler))
 	must(container.Provide(handler.NewAuthHandler))
@@ -1417,6 +1425,21 @@ func registerLangfuseCleanup(mgr *langfuse.Manager, cleaner interfaces.ResourceC
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		return mgr.Shutdown(ctx)
+	})
+}
+
+// registerModelUsageRecorder installs the async usage recorder process-wide so
+// model wrappers can report events, and drains the queue on shutdown.
+func registerModelUsageRecorder(rec *modelusage.AsyncRecorder, cleaner interfaces.ResourceCleaner) {
+	if rec == nil {
+		return
+	}
+	modelusage.SetRecorder(rec)
+	cleaner.RegisterWithName("ModelUsageRecorder", func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		modelusage.SetRecorder(nil)
+		return rec.Shutdown(ctx)
 	})
 }
 

--- a/internal/handler/model_usage.go
+++ b/internal/handler/model_usage.go
@@ -1,0 +1,81 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/gin-gonic/gin"
+)
+
+// ModelUsageHandler serves the model usage dashboard report.
+type ModelUsageHandler struct {
+	service interfaces.ModelUsageService
+}
+
+// NewModelUsageHandler creates a ModelUsageHandler.
+func NewModelUsageHandler(service interfaces.ModelUsageService) *ModelUsageHandler {
+	return &ModelUsageHandler{service: service}
+}
+
+// GetUsage GET /api/v1/models/usage?range=24h&model_type=all&model_id=
+func (h *ModelUsageHandler) GetUsage(c *gin.Context) {
+	ctx := c.Request.Context()
+	rangeValue := c.DefaultQuery("range", "24h")
+	if !validUsageRange(rangeValue) {
+		_ = c.Error(errors.NewBadRequestError("invalid range"))
+		return
+	}
+
+	modelType := types.ModelType(c.DefaultQuery("model_type", "all"))
+	if !validUsageModelType(modelType) {
+		_ = c.Error(errors.NewBadRequestError("invalid model_type"))
+		return
+	}
+
+	query := types.ModelUsageQuery{
+		Range:     rangeValue,
+		ModelType: modelType,
+		ModelID:   strings.TrimSpace(c.Query("model_id")),
+	}
+	report, err := h.service.GetUsageReport(ctx, query)
+	if err != nil {
+		logger.ErrorWithFields(ctx, err, map[string]interface{}{
+			"range":      rangeValue,
+			"model_type": modelType,
+		})
+		_ = c.Error(errors.NewInternalServerError(err.Error()))
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    report,
+	})
+}
+
+func validUsageRange(value string) bool {
+	switch value {
+	case "15m", "1h", "24h", "7d":
+		return true
+	default:
+		return false
+	}
+}
+
+func validUsageModelType(value types.ModelType) bool {
+	switch value {
+	case "all",
+		types.ModelTypeKnowledgeQA,
+		types.ModelTypeEmbedding,
+		types.ModelTypeRerank,
+		types.ModelTypeVLLM,
+		types.ModelTypeASR:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/models/asr/asr.go
+++ b/internal/models/asr/asr.go
@@ -35,6 +35,7 @@ type Config struct {
 	ModelName string
 	APIKey    string
 	ModelID   string
+	Provider  string
 	Language  string // optional: specify language for transcription
 	// CustomHeaders 允许在调用远程 API 时附加自定义 HTTP 请求头（类似 OpenAI Python SDK 的 extra_headers）。
 	CustomHeaders map[string]string
@@ -53,6 +54,7 @@ func ConfigFromModel(m *types.Model) *Config {
 		BaseURL:       m.Parameters.BaseURL,
 		ModelName:     m.Name,
 		Source:        m.Source,
+		Provider:      m.Parameters.Provider,
 		CustomHeaders: m.Parameters.CustomHeaders,
 	}
 }
@@ -60,6 +62,8 @@ func ConfigFromModel(m *types.Model) *Config {
 // NewASR creates an ASR instance based on the provided configuration.
 // All ASR vendors use the OpenAI-compatible /v1/audio/transcriptions API.
 func NewASR(config *Config) (ASR, error) {
+	var a ASR
 	a, err := NewOpenAIASR(config)
+	a, err = wrapASRUsage(a, err, config)
 	return wrapASRLangfuse(a, err)
 }

--- a/internal/models/asr/usage_wrapper.go
+++ b/internal/models/asr/usage_wrapper.go
@@ -1,0 +1,54 @@
+package asr
+
+import (
+	"context"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/modelusage"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// usageASR records every Transcribe call as a model usage event. ASR billing
+// is not token-based, so token counters stay zero and usage_source is
+// not_applicable.
+type usageASR struct {
+	inner    ASR
+	source   types.ModelSource
+	provider string
+}
+
+func (u *usageASR) GetModelName() string { return u.inner.GetModelName() }
+func (u *usageASR) GetModelID() string   { return u.inner.GetModelID() }
+
+func (u *usageASR) Transcribe(ctx context.Context, audioBytes []byte, fileName string) (*TranscriptionResult, error) {
+	start := time.Now()
+	result, err := u.inner.Transcribe(ctx, audioBytes, fileName)
+	modelusage.Record(ctx, types.ModelUsageEvent{
+		ModelID:     u.inner.GetModelID(),
+		ModelName:   u.inner.GetModelName(),
+		ModelType:   types.ModelTypeASR,
+		ModelSource: u.source,
+		Provider:    u.provider,
+		RequestKind: "asr.transcribe",
+		UsageSource: types.ModelUsageSourceNotApplicable,
+		InputItems:  1,
+		DurationMs:  time.Since(start).Milliseconds(),
+		Success:     err == nil,
+		ErrorType:   modelusage.ErrorType(err),
+	})
+	return result, err
+}
+
+// wrapASRUsage applies the usage-recording decorator.
+func wrapASRUsage(a ASR, err error, config *Config) (ASR, error) {
+	if err != nil || a == nil {
+		return a, err
+	}
+	source := types.ModelSource("")
+	provider := ""
+	if config != nil {
+		source = config.Source
+		provider = config.Provider
+	}
+	return &usageASR{inner: a, source: source, provider: provider}, nil
+}

--- a/internal/models/chat/chat.go
+++ b/internal/models/chat/chat.go
@@ -151,6 +151,7 @@ func NewChat(config *ChatConfig, ollamaService *ollama.OllamaService) (Chat, err
 		return nil, fmt.Errorf("unsupported chat model source: %s", config.Source)
 	}
 	c, err = wrapChatDebug(c, err)
+	c, err = wrapChatUsage(c, err, config)
 	c, err = wrapChatLangfuse(c, err)
 	// Outermost: hold the per-model concurrency slot only around the real
 	// provider round-trip, so the wait is excluded from debug/langfuse timing.

--- a/internal/models/chat/usage_wrapper.go
+++ b/internal/models/chat/usage_wrapper.go
@@ -1,0 +1,125 @@
+package chat
+
+import (
+	"context"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/modelusage"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// usageChat records every chat call (tokens, latency, outcome) as a model
+// usage event for the usage dashboard.
+type usageChat struct {
+	inner    Chat
+	source   types.ModelSource
+	provider string
+}
+
+func (u *usageChat) GetModelName() string { return u.inner.GetModelName() }
+func (u *usageChat) GetModelID() string   { return u.inner.GetModelID() }
+
+func (u *usageChat) Chat(ctx context.Context, messages []Message, opts *ChatOptions) (*types.ChatResponse, error) {
+	start := time.Now()
+	resp, err := u.inner.Chat(ctx, messages, opts)
+	var usage *types.TokenUsage
+	if resp != nil {
+		usage = &resp.Usage
+	}
+	u.record(ctx, "chat.completion", usage, len(messages), time.Since(start), err == nil, modelusage.ErrorType(err))
+	return resp, err
+}
+
+func (u *usageChat) ChatStream(
+	ctx context.Context, messages []Message, opts *ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	start := time.Now()
+	ch, err := u.inner.ChatStream(ctx, messages, opts)
+	if err != nil {
+		u.record(ctx, "chat.completion.stream", nil, len(messages), time.Since(start), false, modelusage.ErrorType(err))
+		return ch, err
+	}
+	if ch == nil {
+		u.record(ctx, "chat.completion.stream", nil, len(messages), time.Since(start), true, "")
+		return nil, nil
+	}
+
+	wrapped := make(chan types.StreamResponse)
+	go func() {
+		defer close(wrapped)
+		var usage *types.TokenUsage
+		success := true
+		errorType := ""
+		for resp := range ch {
+			if resp.Usage != nil {
+				usage = resp.Usage
+			}
+			if resp.ResponseType == types.ResponseTypeError {
+				success = false
+				if errorType == "" {
+					errorType = "stream_error"
+				}
+			}
+			wrapped <- resp
+		}
+		u.record(ctx, "chat.completion.stream", usage, len(messages), time.Since(start), success, errorType)
+	}()
+	return wrapped, nil
+}
+
+func (u *usageChat) record(
+	ctx context.Context,
+	kind string,
+	usage *types.TokenUsage,
+	inputItems int,
+	duration time.Duration,
+	success bool,
+	errorType string,
+) {
+	event := types.ModelUsageEvent{
+		ModelID:     u.inner.GetModelID(),
+		ModelName:   u.inner.GetModelName(),
+		ModelType:   types.ModelTypeKnowledgeQA,
+		ModelSource: u.source,
+		Provider:    u.provider,
+		RequestKind: kind,
+		UsageSource: usageSource(usage),
+		InputItems:  inputItems,
+		DurationMs:  duration.Milliseconds(),
+		Success:     success,
+		ErrorType:   errorType,
+	}
+	if usage != nil {
+		event.PromptTokens = int64(usage.PromptTokens)
+		event.CompletionTokens = int64(usage.CompletionTokens)
+		event.CachedTokens = int64(usage.CachedTokens)
+		event.TotalTokens = int64(usage.TotalTokens)
+	}
+	modelusage.Record(ctx, event)
+}
+
+func usageSource(usage *types.TokenUsage) string {
+	if usage == nil {
+		return types.ModelUsageSourceMissing
+	}
+	if usage.PromptTokens == 0 && usage.CompletionTokens == 0 && usage.TotalTokens == 0 {
+		return types.ModelUsageSourceMissing
+	}
+	return types.ModelUsageSourceProvider
+}
+
+// wrapChatUsage applies the usage-recording decorator. Sits above the real
+// provider call (below langfuse/debug) so its latency reflects the true
+// upstream round-trip.
+func wrapChatUsage(c Chat, err error, config *ChatConfig) (Chat, error) {
+	if err != nil || c == nil {
+		return c, err
+	}
+	source := types.ModelSource("")
+	provider := ""
+	if config != nil {
+		source = config.Source
+		provider = config.Provider
+	}
+	return &usageChat{inner: c, source: source, provider: provider}, nil
+}

--- a/internal/models/embedding/embedder.go
+++ b/internal/models/embedding/embedder.go
@@ -101,6 +101,7 @@ func NewEmbedder(config Config, pooler EmbedderPooler, ollamaService *ollama.Oll
 	if logger.LLMDebugEnabled() {
 		e = &debugEmbedder{inner: e}
 	}
+	e = wrapEmbedderUsage(e, config)
 	if langfuse.GetManager().Enabled() {
 		e = &langfuseEmbedder{inner: e}
 	}

--- a/internal/models/embedding/usage_wrapper.go
+++ b/internal/models/embedding/usage_wrapper.go
@@ -1,0 +1,79 @@
+package embedding
+
+import (
+	"context"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/modelusage"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// usageEmbedder records every embed call as a model usage event. Embedders
+// don't return token usage, so input tokens are estimated (~runes/4, same
+// approximation as the langfuse wrapper) and flagged as estimated.
+type usageEmbedder struct {
+	inner    Embedder
+	source   types.ModelSource
+	provider string
+}
+
+func (u *usageEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	start := time.Now()
+	result, err := u.inner.Embed(ctx, text)
+	u.record(ctx, "embedding.embed", []string{text}, 1, time.Since(start), err == nil, modelusage.ErrorType(err))
+	return result, err
+}
+
+func (u *usageEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	start := time.Now()
+	result, err := u.inner.BatchEmbed(ctx, texts)
+	u.record(ctx, "embedding.batch_embed", texts, len(texts), time.Since(start), err == nil, modelusage.ErrorType(err))
+	return result, err
+}
+
+func (u *usageEmbedder) BatchEmbedWithPool(ctx context.Context, _ Embedder, texts []string) ([][]float32, error) {
+	return u.inner.BatchEmbedWithPool(ctx, u, texts)
+}
+
+func (u *usageEmbedder) GetModelName() string { return u.inner.GetModelName() }
+func (u *usageEmbedder) GetDimensions() int   { return u.inner.GetDimensions() }
+func (u *usageEmbedder) GetModelID() string   { return u.inner.GetModelID() }
+
+func (u *usageEmbedder) record(
+	ctx context.Context,
+	kind string,
+	texts []string,
+	inputItems int,
+	duration time.Duration,
+	success bool,
+	errorType string,
+) {
+	event := types.ModelUsageEvent{
+		ModelID:     u.inner.GetModelID(),
+		ModelName:   u.inner.GetModelName(),
+		ModelType:   types.ModelTypeEmbedding,
+		ModelSource: u.source,
+		Provider:    u.provider,
+		RequestKind: kind,
+		UsageSource: types.ModelUsageSourceEstimated,
+		InputItems:  inputItems,
+		DurationMs:  duration.Milliseconds(),
+		Success:     success,
+		ErrorType:   errorType,
+	}
+	if usage := approxEmbeddingUsage(texts); usage != nil {
+		event.PromptTokens = int64(usage.Input)
+		event.TotalTokens = int64(usage.Total)
+	} else {
+		event.UsageSource = types.ModelUsageSourceMissing
+	}
+	modelusage.Record(ctx, event)
+}
+
+// wrapEmbedderUsage applies the usage-recording decorator.
+func wrapEmbedderUsage(e Embedder, config Config) Embedder {
+	if e == nil {
+		return e
+	}
+	return &usageEmbedder{inner: e, source: config.Source, provider: config.Provider}
+}

--- a/internal/models/rerank/reranker.go
+++ b/internal/models/rerank/reranker.go
@@ -122,6 +122,7 @@ func NewReranker(config *RerankerConfig) (Reranker, error) {
 	if logger.LLMDebugEnabled() {
 		r = &debugReranker{inner: r}
 	}
+	r = wrapRerankerUsage(r, config)
 	return wrapRerankerLangfuse(r, nil)
 }
 

--- a/internal/models/rerank/usage_wrapper.go
+++ b/internal/models/rerank/usage_wrapper.go
@@ -1,0 +1,61 @@
+package rerank
+
+import (
+	"context"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/modelusage"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// usageReranker records every Rerank call as a model usage event. Rerankers
+// don't return token usage, so input tokens are estimated (same approximation
+// as the langfuse wrapper) and flagged as estimated.
+type usageReranker struct {
+	inner    Reranker
+	source   types.ModelSource
+	provider string
+}
+
+func (u *usageReranker) GetModelName() string { return u.inner.GetModelName() }
+func (u *usageReranker) GetModelID() string   { return u.inner.GetModelID() }
+
+func (u *usageReranker) Rerank(ctx context.Context, query string, documents []string) ([]RankResult, error) {
+	start := time.Now()
+	results, err := u.inner.Rerank(ctx, query, documents)
+	event := types.ModelUsageEvent{
+		ModelID:     u.inner.GetModelID(),
+		ModelName:   u.inner.GetModelName(),
+		ModelType:   types.ModelTypeRerank,
+		ModelSource: u.source,
+		Provider:    u.provider,
+		RequestKind: "rerank",
+		UsageSource: types.ModelUsageSourceEstimated,
+		InputItems:  len(documents),
+		DurationMs:  time.Since(start).Milliseconds(),
+		Success:     err == nil,
+		ErrorType:   modelusage.ErrorType(err),
+	}
+	if usage := approxRerankUsage(query, documents); usage != nil {
+		event.PromptTokens = int64(usage.Input)
+		event.TotalTokens = int64(usage.Total)
+	} else {
+		event.UsageSource = types.ModelUsageSourceMissing
+	}
+	modelusage.Record(ctx, event)
+	return results, err
+}
+
+// wrapRerankerUsage applies the usage-recording decorator.
+func wrapRerankerUsage(r Reranker, config *RerankerConfig) Reranker {
+	if r == nil {
+		return r
+	}
+	source := types.ModelSource("")
+	provider := ""
+	if config != nil {
+		source = config.Source
+		provider = config.Provider
+	}
+	return &usageReranker{inner: r, source: source, provider: provider}
+}

--- a/internal/models/vlm/usage_wrapper.go
+++ b/internal/models/vlm/usage_wrapper.go
@@ -1,0 +1,59 @@
+package vlm
+
+import (
+	"context"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/modelusage"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// usageVLM records every Predict call as a model usage event. VLMs don't
+// return token usage, so tokens are estimated (~runes/4, same approximation
+// as the langfuse wrapper) and flagged as estimated.
+type usageVLM struct {
+	inner    VLM
+	source   types.ModelSource
+	provider string
+}
+
+func (u *usageVLM) GetModelName() string { return u.inner.GetModelName() }
+func (u *usageVLM) GetModelID() string   { return u.inner.GetModelID() }
+
+func (u *usageVLM) Predict(ctx context.Context, imgBytes [][]byte, prompt string) (string, error) {
+	start := time.Now()
+	result, err := u.inner.Predict(ctx, imgBytes, prompt)
+	promptTokens := int64(len([]rune(prompt))/4 + 1)
+	completionTokens := int64(len([]rune(result)) / 4)
+	modelusage.Record(ctx, types.ModelUsageEvent{
+		ModelID:          u.inner.GetModelID(),
+		ModelName:        u.inner.GetModelName(),
+		ModelType:        types.ModelTypeVLLM,
+		ModelSource:      u.source,
+		Provider:         u.provider,
+		RequestKind:      "vlm.predict",
+		UsageSource:      types.ModelUsageSourceEstimated,
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		TotalTokens:      promptTokens + completionTokens,
+		InputItems:       len(imgBytes),
+		DurationMs:       time.Since(start).Milliseconds(),
+		Success:          err == nil,
+		ErrorType:        modelusage.ErrorType(err),
+	})
+	return result, err
+}
+
+// wrapVLMUsage applies the usage-recording decorator.
+func wrapVLMUsage(v VLM, config *Config) VLM {
+	if v == nil {
+		return v
+	}
+	source := types.ModelSource("")
+	provider := ""
+	if config != nil {
+		source = config.Source
+		provider = config.Provider
+	}
+	return &usageVLM{inner: v, source: source, provider: provider}
+}

--- a/internal/models/vlm/vlm.go
+++ b/internal/models/vlm/vlm.go
@@ -91,6 +91,7 @@ func NewVLM(config *Config, ollamaService *ollama.OllamaService) (VLM, error) {
 	if logger.LLMDebugEnabled() {
 		v = &debugVLM{inner: v}
 	}
+	v = wrapVLMUsage(v, config)
 	v, err = wrapVLMLangfuse(v, nil)
 	// Outermost: hold the per-model concurrency slot only around the real
 	// provider round-trip, so the wait is excluded from debug/langfuse timing.

--- a/internal/modelusage/recorder.go
+++ b/internal/modelusage/recorder.go
@@ -1,0 +1,164 @@
+// Package modelusage provides process-wide recording of model invocation
+// events (tokens, latency, outcome) for the model usage dashboard.
+//
+// Model wrappers call Record, which is a no-op until the container installs
+// an AsyncRecorder via SetRecorder. Events carry only metadata — never
+// prompts, documents, image/audio bytes, or model outputs.
+package modelusage
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// Recorder accepts a single model usage event.
+type Recorder interface {
+	Record(ctx context.Context, event types.ModelUsageEvent)
+}
+
+type noopRecorder struct{}
+
+func (noopRecorder) Record(context.Context, types.ModelUsageEvent) {}
+
+var (
+	currentMu sync.RWMutex
+	current   Recorder = noopRecorder{}
+)
+
+// SetRecorder installs the process-wide recorder; nil restores the no-op.
+func SetRecorder(rec Recorder) {
+	currentMu.Lock()
+	defer currentMu.Unlock()
+	if rec == nil {
+		current = noopRecorder{}
+		return
+	}
+	current = rec
+}
+
+// Record forwards an event to the installed recorder.
+func Record(ctx context.Context, event types.ModelUsageEvent) {
+	currentMu.RLock()
+	rec := current
+	currentMu.RUnlock()
+	rec.Record(ctx, event)
+}
+
+// EventStore is the persistence sink used by AsyncRecorder.
+type EventStore interface {
+	Create(ctx context.Context, event *types.ModelUsageEvent) error
+}
+
+// AsyncRecorder buffers events on a bounded channel and persists them from a
+// single background goroutine, so model calls never block on the database.
+// When the queue is full the event is dropped (metering must never break the
+// call path).
+type AsyncRecorder struct {
+	repo EventStore
+	ch   chan types.ModelUsageEvent
+	done chan struct{}
+	wg   sync.WaitGroup
+	once sync.Once
+}
+
+// NewAsyncRecorder creates and starts an AsyncRecorder.
+func NewAsyncRecorder(repo EventStore) *AsyncRecorder {
+	rec := &AsyncRecorder{
+		repo: repo,
+		ch:   make(chan types.ModelUsageEvent, 2048),
+		done: make(chan struct{}),
+	}
+	rec.wg.Add(1)
+	go rec.run()
+	return rec
+}
+
+// Record enqueues the event after stamping tenant/user/request identity from
+// ctx. Events without a tenant (e.g. background jobs without session context)
+// are skipped.
+func (r *AsyncRecorder) Record(ctx context.Context, event types.ModelUsageEvent) {
+	if r == nil || r.repo == nil {
+		return
+	}
+	tenantID, ok := types.SessionTenantIDFromContext(ctx)
+	if !ok || tenantID == 0 {
+		return
+	}
+	event.TenantID = tenantID
+	if userID, ok := types.UserIDFromContext(ctx); ok {
+		event.UserID = userID
+	}
+	if requestID, ok := types.RequestIDFromContext(ctx); ok {
+		event.RequestID = requestID
+	}
+	if event.CreatedAt.IsZero() {
+		event.CreatedAt = time.Now().UTC()
+	}
+	if event.TotalTokens == 0 {
+		event.TotalTokens = event.PromptTokens + event.CompletionTokens
+	}
+	if event.UsageSource == "" {
+		event.UsageSource = types.ModelUsageSourceMissing
+	}
+
+	select {
+	case r.ch <- event:
+	default:
+		logger.Warnf(ctx, "model usage recorder queue full; dropping event model_id=%s kind=%s",
+			event.ModelID, event.RequestKind)
+	}
+}
+
+// Shutdown drains the queue and stops the worker, honoring ctx deadline.
+func (r *AsyncRecorder) Shutdown(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	r.once.Do(func() {
+		close(r.ch)
+		go func() {
+			r.wg.Wait()
+			close(r.done)
+		}()
+	})
+	select {
+	case <-r.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *AsyncRecorder) run() {
+	defer r.wg.Done()
+	for event := range r.ch {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		if err := r.repo.Create(ctx, &event); err != nil {
+			logger.Warnf(ctx, "failed to persist model usage event: %v", err)
+		}
+		cancel()
+	}
+}
+
+// ErrorType returns a short, stable label for err (concrete type name without
+// pointer marker), capped to fit the error_type column.
+func ErrorType(err error) string {
+	if err == nil {
+		return ""
+	}
+	name := reflect.TypeOf(err).String()
+	name = strings.TrimPrefix(name, "*")
+	if name == "" {
+		name = "error"
+	}
+	if len(name) > 128 {
+		return name[:128]
+	}
+	return name
+}

--- a/internal/modelusage/recorder_test.go
+++ b/internal/modelusage/recorder_test.go
@@ -1,0 +1,86 @@
+package modelusage
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+type fakeUsageStore struct {
+	mu     sync.Mutex
+	events []types.ModelUsageEvent
+}
+
+func (s *fakeUsageStore) Create(_ context.Context, event *types.ModelUsageEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, *event)
+	return nil
+}
+
+func TestAsyncRecorderRecordFillsContextFields(t *testing.T) {
+	store := &fakeUsageStore{}
+	rec := NewAsyncRecorder(store)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, types.TenantIDContextKey, uint64(7))
+	ctx = context.WithValue(ctx, types.UserIDContextKey, "user-1")
+	ctx = context.WithValue(ctx, types.RequestIDContextKey, "req-1")
+
+	rec.Record(ctx, types.ModelUsageEvent{
+		ModelID:          "model-1",
+		ModelName:        "gpt-test",
+		ModelType:        types.ModelTypeKnowledgeQA,
+		ModelSource:      types.ModelSourceRemote,
+		RequestKind:      "chat.completion",
+		PromptTokens:     10,
+		CompletionTokens: 5,
+		Success:          true,
+	})
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := rec.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("shutdown recorder: %v", err)
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(store.events))
+	}
+	got := store.events[0]
+	if got.TenantID != 7 || got.UserID != "user-1" || got.RequestID != "req-1" {
+		t.Fatalf("context fields not copied: %+v", got)
+	}
+	if got.TotalTokens != 15 {
+		t.Fatalf("expected total tokens to be derived, got %d", got.TotalTokens)
+	}
+	if got.UsageSource != types.ModelUsageSourceMissing {
+		t.Fatalf("expected missing usage source default, got %q", got.UsageSource)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Fatal("expected CreatedAt to be set")
+	}
+}
+
+func TestAsyncRecorderDropsEventsWithoutTenant(t *testing.T) {
+	store := &fakeUsageStore{}
+	rec := NewAsyncRecorder(store)
+	rec.Record(context.Background(), types.ModelUsageEvent{ModelID: "model-1"})
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := rec.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("shutdown recorder: %v", err)
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.events) != 0 {
+		t.Fatalf("expected no events, got %d", len(store.events))
+	}
+}

--- a/internal/router/model_usage_routes_test.go
+++ b/internal/router/model_usage_routes_test.go
@@ -1,0 +1,71 @@
+package router
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/handler"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeModelUsageService struct {
+	called bool
+	query  types.ModelUsageQuery
+}
+
+func (f *fakeModelUsageService) GetUsageReport(
+	_ context.Context,
+	query types.ModelUsageQuery,
+) (*types.ModelUsageReport, error) {
+	f.called = true
+	f.query = query
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	return &types.ModelUsageReport{
+		Summary: types.ModelUsageSummary{
+			WindowStart:    now.Add(-24 * time.Hour),
+			WindowEnd:      now,
+			RefreshSeconds: 5,
+			SuccessRate:    1,
+		},
+		Models:       []types.ModelUsageModelStats{},
+		Timeline:     []types.ModelUsageTimelinePoint{},
+		RecentEvents: []types.ModelUsageEvent{},
+	}, nil
+}
+
+func TestRegisterModelRoutesUsagePrecedesModelID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	usageSvc := &fakeModelUsageService{}
+	rbacOff := false
+	guards := &rbacGuards{cfg: &config.Config{Tenant: &config.TenantConfig{EnableRBAC: &rbacOff}}}
+
+	RegisterModelRoutes(
+		r.Group("/api/v1"),
+		&handler.ModelHandler{},
+		handler.NewModelUsageHandler(usageSvc),
+		&handler.ModelCredentialsHandler{},
+		guards,
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/models/usage?range=1h&model_type=Embedding", nil)
+	ctx := req.Context()
+	ctx = context.WithValue(ctx, types.TenantIDContextKey, uint64(1))
+	ctx = context.WithValue(ctx, types.TenantRoleContextKey, types.TenantRoleViewer)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, usageSvc.called)
+	assert.Equal(t, "1h", usageSvc.query.Range)
+	assert.Equal(t, types.ModelTypeEmbedding, usageSvc.query.ModelType)
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -55,6 +55,7 @@ type RouterParams struct {
 	MessageHandler               *handler.MessageHandler
 	MessageSuggestionHandler     *handler.MessageSuggestionHandler
 	ModelHandler                 *handler.ModelHandler
+	ModelUsageHandler            *handler.ModelUsageHandler
 	ModelCredentialsHandler      *handler.ModelCredentialsHandler
 	EvaluationHandler            *handler.EvaluationHandler
 	AuthHandler                  *handler.AuthHandler
@@ -247,7 +248,7 @@ func NewRouter(params RouterParams) *gin.Engine {
 		RegisterSessionRoutes(v1, params.SessionHandler, params.MessageSuggestionHandler, rbacGuards)
 		RegisterChatRoutes(v1, params.SessionHandler, rbacGuards)
 		RegisterMessageRoutes(v1, params.MessageHandler, rbacGuards)
-		RegisterModelRoutes(v1, params.ModelHandler, params.ModelCredentialsHandler, rbacGuards)
+		RegisterModelRoutes(v1, params.ModelHandler, params.ModelUsageHandler, params.ModelCredentialsHandler, rbacGuards)
 		RegisterEvaluationRoutes(v1, params.EvaluationHandler, rbacGuards)
 		RegisterInitializationRoutes(v1, params.InitializationHandler, rbacGuards)
 		RegisterSystemRoutes(v1, params.SystemHandler, rbacGuards)

--- a/internal/router/router_api_key_capabilities_test.go
+++ b/internal/router/router_api_key_capabilities_test.go
@@ -335,7 +335,8 @@ func TestTenantInfrastructureRoutesDeclareSpecificCapabilities(t *testing.T) {
 	v1 := gin.New().Group("/api/v1")
 
 	RegisterTenantRoutes(v1, &handler.TenantHandler{}, nil, nil, nil, g)
-	RegisterModelRoutes(v1, &handler.ModelHandler{}, &handler.ModelCredentialsHandler{}, g)
+	RegisterModelRoutes(v1, &handler.ModelHandler{}, handler.NewModelUsageHandler(nil),
+		&handler.ModelCredentialsHandler{}, g)
 	RegisterEvaluationRoutes(v1, &handler.EvaluationHandler{}, g)
 	RegisterSystemRoutes(v1, &handler.SystemHandler{}, g)
 	RegisterMCPServiceRoutes(v1, &handler.MCPServiceHandler{}, &handler.MCPCredentialsHandler{}, &handler.MCPOAuthHandler{}, g)

--- a/internal/router/routes_infra.go
+++ b/internal/router/routes_infra.go
@@ -14,6 +14,7 @@ import (
 func RegisterModelRoutes(
 	r *gin.RouterGroup,
 	handler *handler.ModelHandler,
+	usageHandler *handler.ModelUsageHandler,
 	credHandler *handler.ModelCredentialsHandler,
 	g *rbacGuards,
 ) {
@@ -22,6 +23,9 @@ func RegisterModelRoutes(
 	{
 		// 获取模型厂商列表 — Viewer+
 		models.GET("/providers", g.Viewer(), handler.ListModelProviders)
+		// 获取模型用量统计 — Viewer+。必须注册在 /:id 之前，否则 Gin 会把
+		// "usage" 当成模型 id。
+		models.GET("/usage", g.Viewer(), usageHandler.GetUsage)
 		// 创建模型 — Admin+
 		models.POST("", g.Admin(), handler.CreateModel)
 		// 获取模型列表 — Viewer+

--- a/internal/types/interfaces/model_usage.go
+++ b/internal/types/interfaces/model_usage.go
@@ -1,0 +1,20 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// ModelUsageRepository persists model usage events and builds aggregated
+// reports for the usage dashboard.
+type ModelUsageRepository interface {
+	Create(ctx context.Context, event *types.ModelUsageEvent) error
+	Report(ctx context.Context, tenantID uint64, query types.ModelUsageQuery) (*types.ModelUsageReport, error)
+}
+
+// ModelUsageService resolves the reporting window and returns the tenant's
+// usage report.
+type ModelUsageService interface {
+	GetUsageReport(ctx context.Context, query types.ModelUsageQuery) (*types.ModelUsageReport, error)
+}

--- a/internal/types/model_usage.go
+++ b/internal/types/model_usage.go
@@ -1,0 +1,112 @@
+package types
+
+import "time"
+
+// Usage provenance for a model call: token counters either came from the
+// provider response, were estimated locally (~runes/4), or are unavailable
+// for this model kind (e.g. ASR).
+const (
+	ModelUsageSourceProvider      = "provider"
+	ModelUsageSourceEstimated     = "estimated"
+	ModelUsageSourceMissing       = "missing"
+	ModelUsageSourceNotApplicable = "not_applicable"
+)
+
+// ModelUsageEvent is one recorded model invocation. It deliberately stores
+// only metadata (model, tokens, latency, outcome) — never prompts, documents,
+// image/audio bytes, or model outputs.
+type ModelUsageEvent struct {
+	ID               uint64      `json:"id" gorm:"primaryKey"`
+	TenantID         uint64      `json:"tenant_id"`
+	UserID           string      `json:"user_id"`
+	RequestID        string      `json:"request_id"`
+	ModelID          string      `json:"model_id"`
+	ModelName        string      `json:"model_name"`
+	ModelType        ModelType   `json:"model_type"`
+	ModelSource      ModelSource `json:"model_source"`
+	Provider         string      `json:"provider"`
+	RequestKind      string      `json:"request_kind"`
+	UsageSource      string      `json:"usage_source"`
+	PromptTokens     int64       `json:"prompt_tokens"`
+	CompletionTokens int64       `json:"completion_tokens"`
+	CachedTokens     int64       `json:"cached_tokens"`
+	TotalTokens      int64       `json:"total_tokens"`
+	InputItems       int         `json:"input_items"`
+	DurationMs       int64       `json:"duration_ms"`
+	Success          bool        `json:"success"`
+	ErrorType        string      `json:"error_type"`
+	CreatedAt        time.Time   `json:"created_at"`
+}
+
+// TableName maps the event to its storage table.
+func (ModelUsageEvent) TableName() string {
+	return "model_usage_events"
+}
+
+// ModelUsageQuery selects the reporting window and optional filters.
+type ModelUsageQuery struct {
+	Range       string
+	ModelType   ModelType
+	ModelID     string
+	Start       time.Time
+	End         time.Time
+	BucketSize  time.Duration
+	RecentLimit int
+}
+
+// ModelUsageSummary aggregates totals over the reporting window.
+type ModelUsageSummary struct {
+	WindowStart      time.Time `json:"window_start"`
+	WindowEnd        time.Time `json:"window_end"`
+	RefreshSeconds   int       `json:"refresh_seconds"`
+	TotalCalls       int64     `json:"total_calls"`
+	TotalTokens      int64     `json:"total_tokens"`
+	PromptTokens     int64     `json:"prompt_tokens"`
+	CompletionTokens int64     `json:"completion_tokens"`
+	CachedTokens     int64     `json:"cached_tokens"`
+	ErrorCount       int64     `json:"error_count"`
+	SuccessRate      float64   `json:"success_rate"`
+}
+
+// ModelUsageModelStats aggregates usage per model over the window.
+type ModelUsageModelStats struct {
+	ModelID          string      `json:"model_id"`
+	ModelName        string      `json:"model_name"`
+	DisplayName      string      `json:"display_name"`
+	ModelType        ModelType   `json:"model_type"`
+	ModelSource      ModelSource `json:"model_source"`
+	Provider         string      `json:"provider"`
+	Calls            int64       `json:"calls"`
+	PromptTokens     int64       `json:"prompt_tokens"`
+	CompletionTokens int64       `json:"completion_tokens"`
+	CachedTokens     int64       `json:"cached_tokens"`
+	TotalTokens      int64       `json:"total_tokens"`
+	InputItems       int64       `json:"input_items"`
+	DurationMs       int64       `json:"duration_ms"`
+	ErrorCount       int64       `json:"error_count"`
+	SuccessRate      float64     `json:"success_rate"`
+	AvgTokensPerCall float64     `json:"avg_tokens_per_call"`
+	LastUsedAt       *time.Time  `json:"last_used_at"`
+}
+
+// ModelUsageTimelinePoint aggregates usage for one (bucket, model) pair.
+type ModelUsageTimelinePoint struct {
+	BucketStart      time.Time `json:"bucket_start"`
+	ModelID          string    `json:"model_id"`
+	ModelName        string    `json:"model_name"`
+	ModelType        ModelType `json:"model_type"`
+	Calls            int64     `json:"calls"`
+	PromptTokens     int64     `json:"prompt_tokens"`
+	CompletionTokens int64     `json:"completion_tokens"`
+	CachedTokens     int64     `json:"cached_tokens"`
+	TotalTokens      int64     `json:"total_tokens"`
+	ErrorCount       int64     `json:"error_count"`
+}
+
+// ModelUsageReport is the dashboard payload.
+type ModelUsageReport struct {
+	Summary      ModelUsageSummary         `json:"summary"`
+	Models       []ModelUsageModelStats    `json:"models"`
+	Timeline     []ModelUsageTimelinePoint `json:"timeline"`
+	RecentEvents []ModelUsageEvent         `json:"recent_events"`
+}

--- a/migrations/sqlite/000002_model_usage_events.down.sql
+++ b/migrations/sqlite/000002_model_usage_events.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_model_usage_events_tenant_type_time;
+DROP INDEX IF EXISTS idx_model_usage_events_tenant_model_time;
+DROP INDEX IF EXISTS idx_model_usage_events_tenant_time;
+DROP TABLE IF EXISTS model_usage_events;

--- a/migrations/sqlite/000002_model_usage_events.up.sql
+++ b/migrations/sqlite/000002_model_usage_events.up.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS model_usage_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id INTEGER NOT NULL,
+    user_id VARCHAR(64) NOT NULL DEFAULT '',
+    request_id VARCHAR(64) NOT NULL DEFAULT '',
+    model_id VARCHAR(64) NOT NULL DEFAULT '',
+    model_name VARCHAR(255) NOT NULL DEFAULT '',
+    model_type VARCHAR(32) NOT NULL DEFAULT '',
+    model_source VARCHAR(32) NOT NULL DEFAULT '',
+    provider VARCHAR(64) NOT NULL DEFAULT '',
+    request_kind VARCHAR(64) NOT NULL DEFAULT '',
+    usage_source VARCHAR(32) NOT NULL DEFAULT '',
+    prompt_tokens INTEGER NOT NULL DEFAULT 0,
+    completion_tokens INTEGER NOT NULL DEFAULT 0,
+    cached_tokens INTEGER NOT NULL DEFAULT 0,
+    total_tokens INTEGER NOT NULL DEFAULT 0,
+    input_items INTEGER NOT NULL DEFAULT 0,
+    duration_ms INTEGER NOT NULL DEFAULT 0,
+    success INTEGER NOT NULL DEFAULT 1,
+    error_type VARCHAR(128) NOT NULL DEFAULT '',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_model_usage_events_tenant_time
+    ON model_usage_events (tenant_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_model_usage_events_tenant_model_time
+    ON model_usage_events (tenant_id, model_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_model_usage_events_tenant_type_time
+    ON model_usage_events (tenant_id, model_type, created_at DESC);

--- a/migrations/versioned/000079_model_usage_events.down.sql
+++ b/migrations/versioned/000079_model_usage_events.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_model_usage_events_tenant_type_time;
+DROP INDEX IF EXISTS idx_model_usage_events_tenant_model_time;
+DROP INDEX IF EXISTS idx_model_usage_events_tenant_time;
+DROP TABLE IF EXISTS model_usage_events;

--- a/migrations/versioned/000079_model_usage_events.up.sql
+++ b/migrations/versioned/000079_model_usage_events.up.sql
@@ -1,0 +1,39 @@
+-- Migration: 000079_model_usage_events
+-- Stores per-model usage metering events for the model usage dashboard.
+-- The table deliberately does not store prompts, retrieved documents, image
+-- bytes, audio bytes, or model outputs.
+DO $$ BEGIN RAISE NOTICE '[Migration 000079] Creating table: model_usage_events'; END $$;
+
+CREATE TABLE IF NOT EXISTS model_usage_events (
+    id                BIGSERIAL PRIMARY KEY,
+    tenant_id         BIGINT NOT NULL,
+    user_id           VARCHAR(64) NOT NULL DEFAULT '',
+    request_id        VARCHAR(64) NOT NULL DEFAULT '',
+    model_id          VARCHAR(64) NOT NULL DEFAULT '',
+    model_name        VARCHAR(255) NOT NULL DEFAULT '',
+    model_type        VARCHAR(32) NOT NULL DEFAULT '',
+    model_source      VARCHAR(32) NOT NULL DEFAULT '',
+    provider          VARCHAR(64) NOT NULL DEFAULT '',
+    request_kind      VARCHAR(64) NOT NULL DEFAULT '',
+    usage_source      VARCHAR(32) NOT NULL DEFAULT '',
+    prompt_tokens     BIGINT NOT NULL DEFAULT 0,
+    completion_tokens BIGINT NOT NULL DEFAULT 0,
+    cached_tokens     BIGINT NOT NULL DEFAULT 0,
+    total_tokens      BIGINT NOT NULL DEFAULT 0,
+    input_items       INTEGER NOT NULL DEFAULT 0,
+    duration_ms       BIGINT NOT NULL DEFAULT 0,
+    success           BOOLEAN NOT NULL DEFAULT TRUE,
+    error_type        VARCHAR(128) NOT NULL DEFAULT '',
+    created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_model_usage_events_tenant_time
+    ON model_usage_events (tenant_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_model_usage_events_tenant_model_time
+    ON model_usage_events (tenant_id, model_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_model_usage_events_tenant_type_time
+    ON model_usage_events (tenant_id, model_type, created_at DESC);
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000079] model_usage_events table ready'; END $$;


### PR DESCRIPTION
## Description

Operators currently have no built-in visibility into how much each model is actually being used (requests, tokens, latency, failures) across chat, embedding, rerank, VLM and ASR pipelines — Langfuse helps per-trace, but there is no aggregate, per-model metering view inside WeKnora itself.

This PR adds **model usage metering**:

- **Event recording** — lightweight decorator wrappers around chat (incl. streaming), embedding (Embed/BatchEmbed), rerank, VLM and ASR record one usage event per call into a new `model_usage_events` table (migration `000079` + sqlite `000002`). Events carry metadata only — model, token counts, duration, success/error type, request kind. **No prompts, retrieved documents, media bytes, or model outputs are stored.** Token counts come from the provider response where available (chat) and fall back to the existing local estimators (`approxEmbeddingUsage` / `approxRerankUsage`, runes/4) elsewhere; ASR records `not_applicable`.
- **Async recorder** — events go through a bounded in-process queue with an async flush worker (`internal/modelusage`), so metering never sits on the request hot path; the queue drains on shutdown via the existing `ResourceCleaner` lifecycle.
- **Aggregated report API** — per-model, per-type time-window aggregation (hour/day buckets) with dialect-correct epoch-second `last_used_at` (works on both Postgres and SQLite).
- **Dashboard** — new settings view with a stacked bar chart of usage per model over time, i18n for en-US / zh-CN / ko-KR / ru-RU, menu + router wiring, and viewer-level settings access per the existing role matrix.

Naming note: the existing `internal/application/repository/model_usage.go` (which scopes KBs/agents *referencing* a model) is untouched; the new code uses "usage events" file/table naming to keep the two concepts distinct.

## Type of Change
- [x] ✨ New feature

## Related Issue

N/A

## Testing

- New tests: `internal/modelusage/recorder_test.go`, `internal/application/repository/model_usage_events_test.go`, `internal/application/service/model_usage_test.go`, `internal/router/model_usage_routes_test.go`
- `go test ./internal/modelusage/ ./internal/types/ ./internal/router/ ./internal/application/repository/ ./internal/models/... ./internal/handler/ -count=1` — all pass
- `go build ./internal/...` — passes (full `go build ./...` blocked by a pre-existing Windows toolchain issue: duckdb prebuilt static lib vs local mingw gcc, reproduced on clean `main`)
- `gofmt -l` on changed files — clean; `git diff --check` — passes
- `golangci-lint run --new-from-rev=upstream/main ./internal/...` — 0 issues
- Frontend `npm ci` + `npm run type-check` (vue-tsc) — passes

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (type/method comments; migration header documents the no-content-storage guarantee)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

Adds a settings dashboard view (`ModelUsageView`). Prepared in a headless environment; happy to attach screenshots on request, or check out the branch and open *Settings → Model Usage*.