### PR TITLE
feat(wiki): fall back through synthesis model chain on LLM failures

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -19772,6 +19772,17 @@ const docTemplate = `{
                     "description": "MaxPagesPerIngest limits pages created/updated per ingest operation (0 = no limit)",
                     "type": "integer"
                 },
+                "synthesis_fallback_model_id": {
+                    "description": "SynthesisFallbackModelID is the first fallback LLM model ID kept for compatibility\nwith older clients that only support a single fallback field.",
+                    "type": "string"
+                },
+                "synthesis_fallback_model_ids": {
+                    "description": "SynthesisFallbackModelIDs are tried in order after the effective synthesis model.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "synthesis_model_id": {
                     "description": "SynthesisModelID is the LLM model ID used for wiki page generation and updates",
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -19765,6 +19765,17 @@
                     "description": "MaxPagesPerIngest limits pages created/updated per ingest operation (0 = no limit)",
                     "type": "integer"
                 },
+                "synthesis_fallback_model_id": {
+                    "description": "SynthesisFallbackModelID is the first fallback LLM model ID kept for compatibility\nwith older clients that only support a single fallback field.",
+                    "type": "string"
+                },
+                "synthesis_fallback_model_ids": {
+                    "description": "SynthesisFallbackModelIDs are tried in order after the effective synthesis model.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "synthesis_model_id": {
                     "description": "SynthesisModelID is the LLM model ID used for wiki page generation and updates",
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3978,6 +3978,17 @@ definitions:
         description: MaxPagesPerIngest limits pages created/updated per ingest operation
           (0 = no limit)
         type: integer
+      synthesis_fallback_model_id:
+        description: SynthesisFallbackModelID is the first fallback LLM model ID
+          kept for compatibility with older clients that only support a single
+          fallback field.
+        type: string
+      synthesis_fallback_model_ids:
+        description: SynthesisFallbackModelIDs are tried in order after the effective
+          synthesis model.
+        items:
+          type: string
+        type: array
       synthesis_model_id:
         description: SynthesisModelID is the LLM model ID used for wiki page generation
           and updates

--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -1272,6 +1272,14 @@ type WikiBatchContext struct {
 	// three valid values.
 	ExtractionGranularity types.WikiExtractionGranularity
 
+	// SynthesisModelChainIDs records the ordered model chain used by this
+	// batch so per-document trace spans show which fallback set was active.
+	SynthesisModelChainIDs []string
+
+	// SynthesisModelResolveErrors records model IDs that were configured but
+	// could not be instantiated at batch start.
+	SynthesisModelResolveErrors []string
+
 	// ContentInstructions and ExtractionInstructions are KB-scoped business
 	// guidance. Stable citation, merge, taxonomy and JSON rules remain in the
 	// system templates and cannot be replaced by these fields.
@@ -2414,17 +2422,169 @@ func (s *wikiIngestService) deduplicateExtractedBatch(
 	return entities, concepts
 }
 
+// wikiSynthesisModelCandidate is one resolved entry of the Wiki synthesis
+// model chain: an instantiated chat model plus the configured model ID it was
+// built from (kept separately because chat implementations may report an
+// empty or provider-level ID).
+type wikiSynthesisModelCandidate struct {
+	model   chat.Chat
+	modelID string
+}
+
+// wikiSynthesisModelChain wraps the ordered Wiki synthesis models (primary +
+// configured fallbacks) behind the chat.Chat interface so every existing
+// call site keeps a single-model shape. Resolution order is fixed at batch
+// start; generateWithTemplate walks the candidates in order and advances to
+// the next one whenever a model call fails (rate limit, timeout, 5xx, or
+// model-specific hard errors), only surfacing an error once the whole chain
+// is exhausted.
+type wikiSynthesisModelChain struct {
+	candidates        []wikiSynthesisModelCandidate
+	requestedModelIDs []string
+	resolveErrors     []string
+}
+
+func (c *wikiSynthesisModelChain) Chat(ctx context.Context, messages []chat.Message, opts *chat.ChatOptions) (*types.ChatResponse, error) {
+	if c == nil || len(c.candidates) == 0 {
+		return nil, fmt.Errorf("wiki synthesis model chain is empty")
+	}
+	return c.candidates[0].model.Chat(ctx, messages, opts)
+}
+
+func (c *wikiSynthesisModelChain) ChatStream(ctx context.Context, messages []chat.Message, opts *chat.ChatOptions) (<-chan types.StreamResponse, error) {
+	if c == nil || len(c.candidates) == 0 {
+		return nil, fmt.Errorf("wiki synthesis model chain is empty")
+	}
+	return c.candidates[0].model.ChatStream(ctx, messages, opts)
+}
+
+func (c *wikiSynthesisModelChain) GetModelName() string {
+	if c == nil || len(c.candidates) == 0 || c.candidates[0].model == nil {
+		return ""
+	}
+	return c.candidates[0].model.GetModelName()
+}
+
+func (c *wikiSynthesisModelChain) GetModelID() string {
+	if c == nil || len(c.candidates) == 0 {
+		return ""
+	}
+	if c.candidates[0].modelID != "" {
+		return c.candidates[0].modelID
+	}
+	if c.candidates[0].model == nil {
+		return ""
+	}
+	return c.candidates[0].model.GetModelID()
+}
+
+// modelChainTraceIDs returns the configured chain in requested order,
+// including models that failed to resolve, for trace/span attribution.
+func (c *wikiSynthesisModelChain) modelChainTraceIDs() []string {
+	if c == nil {
+		return nil
+	}
+	if len(c.requestedModelIDs) > 0 {
+		return append([]string(nil), c.requestedModelIDs...)
+	}
+	ids := make([]string, 0, len(c.candidates))
+	for _, candidate := range c.candidates {
+		if candidate.modelID != "" {
+			ids = append(ids, candidate.modelID)
+		}
+	}
+	return ids
+}
+
+// resolveErrorTrace returns one "modelID: error" entry per configured model
+// that could not be instantiated at batch start.
+func (c *wikiSynthesisModelChain) resolveErrorTrace() []string {
+	if c == nil || len(c.resolveErrors) == 0 {
+		return nil
+	}
+	return append([]string(nil), c.resolveErrors...)
+}
+
+// singleWikiSynthesisModelChain adapts a plain chat.Chat (e.g. a model built
+// outside the batch chain resolution) into the chain shape so
+// generateWithTemplate only has one code path.
+func singleWikiSynthesisModelChain(model chat.Chat) *wikiSynthesisModelChain {
+	if model == nil {
+		return &wikiSynthesisModelChain{}
+	}
+	modelID := strings.TrimSpace(model.GetModelID())
+	return &wikiSynthesisModelChain{
+		candidates: []wikiSynthesisModelCandidate{{
+			model:   model,
+			modelID: modelID,
+		}},
+		requestedModelIDs: []string{modelID},
+	}
+}
+
+// resolveWikiSynthesisModelChain builds the ordered synthesis model chain for
+// a Wiki KB. The primary is WikiConfig.SynthesisModelID (falling back to the
+// KB summary model, matching the legacy single-model behavior), followed by
+// the configured fallbacks. Models that fail to instantiate are skipped and
+// recorded in resolveErrors; an error is returned only when nothing usable
+// remains.
+func (s *wikiIngestService) resolveWikiSynthesisModelChain(ctx context.Context, kb *types.KnowledgeBase) (*wikiSynthesisModelChain, error) {
+	if kb == nil {
+		return nil, fmt.Errorf("knowledge base is nil")
+	}
+
+	var chainIDs []string
+	if kb.WikiConfig != nil {
+		chainIDs = kb.WikiConfig.SynthesisModelChainIDs(kb.SummaryModelID)
+	} else {
+		chainIDs = (types.WikiConfig{}).SynthesisModelChainIDs(kb.SummaryModelID)
+	}
+	if len(chainIDs) == 0 {
+		return nil, fmt.Errorf("no synthesis model configured for KB %s", kb.ID)
+	}
+
+	chain := &wikiSynthesisModelChain{
+		requestedModelIDs: append([]string(nil), chainIDs...),
+		candidates:        make([]wikiSynthesisModelCandidate, 0, len(chainIDs)),
+	}
+	for _, modelID := range chainIDs {
+		chatModel, err := s.modelService.GetChatModel(ctx, modelID)
+		if err != nil {
+			chain.resolveErrors = append(chain.resolveErrors, fmt.Sprintf("%s: %v", modelID, err))
+			logger.Warnf(ctx, "wiki ingest: get synthesis model %s failed, trying next configured model: %v", modelID, err)
+			continue
+		}
+		chain.candidates = append(chain.candidates, wikiSynthesisModelCandidate{
+			model:   chatModel,
+			modelID: modelID,
+		})
+	}
+	if len(chain.candidates) == 0 {
+		if len(chain.resolveErrors) > 0 {
+			return nil, fmt.Errorf("get wiki synthesis models failed: %s", strings.Join(chain.resolveErrors, "; "))
+		}
+		return nil, fmt.Errorf("no usable synthesis model configured for KB %s", kb.ID)
+	}
+	return chain, nil
+}
+
 // generateWithTemplate executes a prompt template and calls the LLM with
 // bounded exponential-backoff retries for transient infrastructure errors.
 //
-// Retry policy:
+// Retry policy (per model):
 //   - Up to wikiLLMMaxAttempts total attempts (initial + retries).
 //   - Only retry errors classified as transient by isTransientLLMError:
 //     HTTP 408/429/5xx, context deadline exceeded (when the parent ctx is
 //     still alive), or generic "timeout"/"connection reset" wording.
-//     4xx (except 408/429) is a caller-side fault and fails fast.
 //   - Backoff is exponential base 2s: 2s, 4s, 8s — roughly wikiLLMBackoffBase
 //   - 2^(attempt-1). Honors ctx cancellation so the task can abort.
+//
+// Fallback policy: when chatModel is a *wikiSynthesisModelChain (the normal
+// batch path), a model that exhausts its attempts — or fails fast on a
+// non-transient, model-specific error such as 4xx — advances to the next
+// configured fallback model, which gets its own full attempt budget. An
+// error is surfaced only once every model in the chain has failed. Context
+// cancellation always aborts immediately instead of falling through.
 //
 // This exists because wiki ingest makes several independent LLM calls per
 // document (extraction, summary, dedup, citations, intro) and a single
@@ -2499,36 +2659,80 @@ func (s *wikiIngestService) generateWithTemplate(ctx context.Context, chatModel 
 		}
 		defer releaseWarmup()
 
+		modelChain, ok := chatModel.(*wikiSynthesisModelChain)
+		if !ok {
+			modelChain = singleWikiSynthesisModelChain(chatModel)
+		}
+		if modelChain == nil || len(modelChain.candidates) == 0 {
+			return "", fmt.Errorf("wiki synthesis model chain is empty")
+		}
+
 		var lastErr error
-		for attempt := 1; attempt <= wikiLLMMaxAttempts; attempt++ {
-			response, callErr := chatModel.Chat(ctx, messages, opts)
-			if callErr == nil && response != nil {
-				return response.Content, nil
+		var primaryErr error
+		for modelIdx, candidate := range modelChain.candidates {
+			if candidate.model == nil {
+				continue
 			}
-			if callErr == nil {
-				callErr = errors.New("LLM returned nil response")
+			modelID := candidate.modelID
+			if modelID == "" {
+				modelID = candidate.model.GetModelID()
 			}
-			lastErr = callErr
+			var modelErr error
+			for attempt := 1; attempt <= wikiLLMMaxAttempts; attempt++ {
+				response, callErr := candidate.model.Chat(ctx, messages, opts)
+				if callErr == nil && response != nil {
+					if modelIdx > 0 {
+						logger.Infof(ctx, "wiki ingest: LLM call succeeded with fallback model %s", modelID)
+					}
+					return response.Content, nil
+				}
+				if callErr == nil {
+					callErr = errors.New("LLM returned nil response")
+				}
+				modelErr = callErr
+				lastErr = callErr
+				if modelIdx == 0 && primaryErr == nil {
+					primaryErr = callErr
+				}
 
-			if !isTransientLLMError(ctx, callErr) {
-				return "", fmt.Errorf("LLM call failed: %w", callErr)
-			}
-			if attempt == wikiLLMMaxAttempts {
-				break
-			}
+				// Abort immediately on context cancellation. Other
+				// non-transient model-call failures still advance to the
+				// next configured model below.
+				if ctx.Err() != nil {
+					return "", fmt.Errorf("LLM call failed: %w", callErr)
+				}
+				if !isTransientLLMError(ctx, callErr) {
+					break
+				}
+				if attempt == wikiLLMMaxAttempts {
+					break
+				}
 
-			backoff := wikiLLMBackoffBase << (attempt - 1)
-			logger.Warnf(ctx, "wiki ingest: LLM call failed (attempt %d/%d), retrying in %s: %v",
-				attempt, wikiLLMMaxAttempts, backoff, callErr)
-			timer := time.NewTimer(backoff)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return "", fmt.Errorf("LLM call aborted during backoff: %w", ctx.Err())
-			case <-timer.C:
+				backoff := wikiLLMBackoffBase << (attempt - 1)
+				logger.Warnf(ctx, "wiki ingest: LLM call failed on model %s (attempt %d/%d), retrying in %s: %v",
+					modelID, attempt, wikiLLMMaxAttempts, backoff, callErr)
+				timer := time.NewTimer(backoff)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return "", fmt.Errorf("LLM call aborted during backoff: %w", ctx.Err())
+				case <-timer.C:
+				}
+			}
+			if modelIdx < len(modelChain.candidates)-1 {
+				nextID := modelChain.candidates[modelIdx+1].modelID
+				if nextID == "" && modelChain.candidates[modelIdx+1].model != nil {
+					nextID = modelChain.candidates[modelIdx+1].model.GetModelID()
+				}
+				logger.Warnf(ctx, "wiki ingest: LLM model %s failed after retries, trying fallback model %s: %v",
+					modelID, nextID, modelErr)
 			}
 		}
-		return "", fmt.Errorf("LLM call failed after %d attempts: %w", wikiLLMMaxAttempts, lastErr)
+		if primaryErr != nil && lastErr != nil && primaryErr.Error() != lastErr.Error() {
+			return "", fmt.Errorf("LLM call failed across %d models (primary: %v; last: %w)",
+				len(modelChain.candidates), primaryErr, lastErr)
+		}
+		return "", fmt.Errorf("LLM call failed across %d models: %w", len(modelChain.candidates), lastErr)
 	}
 
 	// Missing tenant context is unexpected for production Wiki work. Fail safe

--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -295,21 +295,14 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 		return fmt.Errorf("wiki ingest: KB %s is not wiki type", kb.ID)
 	}
 
-	var synthesisModelID string
-	if kb.WikiConfig != nil {
-		synthesisModelID = kb.WikiConfig.SynthesisModelID
-	}
-	if synthesisModelID == "" {
-		synthesisModelID = kb.SummaryModelID
-	}
-	if synthesisModelID == "" {
-		exitStatus = "missing_synthesis_model"
-		return fmt.Errorf("wiki ingest: no synthesis model configured for KB %s", kb.ID)
-	}
-	chatModel, err := s.modelService.GetChatModel(ctx, synthesisModelID)
+	chatModel, err := s.resolveWikiSynthesisModelChain(ctx, kb)
 	if err != nil {
-		exitStatus = "get_chat_model_failed"
-		return fmt.Errorf("wiki ingest: get chat model: %w", err)
+		exitStatus = "get_synthesis_model_chain_failed"
+		return fmt.Errorf("wiki ingest: get synthesis model chain: %w", err)
+	}
+	if len(chatModel.resolveErrors) > 0 {
+		logger.Warnf(ctx, "wiki ingest: synthesis model chain resolved with skipped models: %s",
+			strings.Join(chatModel.resolveErrors, "; "))
 	}
 
 	// Resolve per-KB tunables once. WikiConfig.IngestBatchSize /
@@ -413,6 +406,8 @@ func (s *wikiIngestService) ProcessWikiIngest(ctx context.Context, t *asynq.Task
 	}
 
 	batchCtx := s.newWikiBatchContext(payload.KnowledgeBaseID, wikiConfig)
+	batchCtx.SynthesisModelChainIDs = chatModel.modelChainTraceIDs()
+	batchCtx.SynthesisModelResolveErrors = chatModel.resolveErrorTrace()
 
 	// 1. MAP PHASE (Parallel extraction and generation of updates)
 	var mapMu sync.Mutex
@@ -1043,27 +1038,18 @@ func (s *wikiIngestService) ProcessWikiFinalize(ctx context.Context, t *asynq.Ta
 		return nil
 	}
 
-	synthesisModelID := ""
-	if kb.WikiConfig != nil {
-		synthesisModelID = kb.WikiConfig.SynthesisModelID
-	}
-	if synthesisModelID == "" {
-		synthesisModelID = kb.SummaryModelID
-	}
-	if synthesisModelID == "" {
-		// No model to rebuild the index with; still run the pure-text passes,
-		// then drain. Missing model is a config gap, not a transient error.
-		logger.Warnf(ctx, "wiki finalize: no synthesis model for KB %s, skipping index rebuild", payload.KnowledgeBaseID)
-	}
-
 	batchCtx := s.newWikiBatchContext(payload.KnowledgeBaseID, kb.WikiConfig)
 	lang := types.LanguageNameFromContext(ctx)
 
 	indexRebuilt := false
-	if changeDesc.Len() > 0 && synthesisModelID != "" {
-		chatModel, mErr := s.modelService.GetChatModel(ctx, synthesisModelID)
+	if changeDesc.Len() > 0 {
+		chatModel, mErr := s.resolveWikiSynthesisModelChain(ctx, kb)
 		if mErr != nil {
-			logger.Warnf(ctx, "wiki finalize: get chat model failed: %v", mErr)
+			// No usable model to rebuild the index with; still run the
+			// pure-text passes, then drain. A missing model is a config gap,
+			// not a transient error.
+			logger.Warnf(ctx, "wiki finalize: no synthesis model for KB %s, skipping index rebuild: %v",
+				payload.KnowledgeBaseID, mErr)
 		} else if err := s.rebuildIndexPage(ctx, chatModel, payload, changeDesc.String(), lang,
 			batchCtx.ContentInstructions); err != nil {
 			logger.Warnf(ctx, "wiki finalize: rebuild index failed: %v", err)
@@ -1165,8 +1151,10 @@ func (s *wikiIngestService) mapOneDocument(
 	// nil when the parent attempt is gone (no panic on missing
 	// lookups — span tracker is best-effort).
 	wikiSpan := s.beginWikiSubspan(ctx, knowledgeID, types.JSONMap{
-		"language":          lang,
-		"knowledge_base_id": payload.KnowledgeBaseID,
+		"language":                       lang,
+		"knowledge_base_id":              payload.KnowledgeBaseID,
+		"synthesis_model_chain_ids":      batchCtx.SynthesisModelChainIDs,
+		"synthesis_model_resolve_errors": batchCtx.SynthesisModelResolveErrors,
 	})
 
 	// Guard against the ingest/delete race: if the user deleted the doc while

--- a/internal/application/service/wiki_ingest_test.go
+++ b/internal/application/service/wiki_ingest_test.go
@@ -341,6 +341,9 @@ type templateCaptureChatModel struct {
 	options  chat.ChatOptions
 	purpose  string
 	prefix   string
+	err      error
+	modelID  string
+	calls    int
 }
 
 func (m *templateCaptureChatModel) Chat(
@@ -348,6 +351,7 @@ func (m *templateCaptureChatModel) Chat(
 	messages []chat.Message,
 	opts *chat.ChatOptions,
 ) (*types.ChatResponse, error) {
+	m.calls++
 	if len(messages) > 0 {
 		m.prompt = messages[0].Content
 	}
@@ -356,6 +360,9 @@ func (m *templateCaptureChatModel) Chat(
 		m.options = *opts
 	}
 	m.purpose, m.prefix = types.LLMCallMetadataFromContext(ctx)
+	if m.err != nil {
+		return nil, m.err
+	}
 	return &types.ChatResponse{Content: m.response}, nil
 }
 
@@ -368,7 +375,157 @@ func (m *templateCaptureChatModel) ChatStream(
 }
 
 func (m *templateCaptureChatModel) GetModelName() string { return "capture" }
-func (m *templateCaptureChatModel) GetModelID() string   { return "capture" }
+func (m *templateCaptureChatModel) GetModelID() string {
+	if m.modelID != "" {
+		return m.modelID
+	}
+	return "capture"
+}
+
+func TestGenerateWithTemplateFallsBackToNextSynthesisModel(t *testing.T) {
+	primary := &templateCaptureChatModel{
+		modelID: "primary",
+		err:     errors.New("API request failed with status 403: model unavailable for tenant"),
+	}
+	fallback := &templateCaptureChatModel{
+		modelID:  "fallback",
+		response: "fallback result",
+	}
+	service := &wikiIngestService{}
+
+	got, err := service.generateWithTemplate(
+		context.Background(),
+		&wikiSynthesisModelChain{
+			requestedModelIDs: []string{"primary", "fallback"},
+			candidates: []wikiSynthesisModelCandidate{
+				{model: primary, modelID: "primary"},
+				{model: fallback, modelID: "fallback"},
+			},
+		},
+		`Content={{.Content}}`,
+		map[string]string{"Content": "hello"},
+	)
+	if err != nil {
+		t.Fatalf("generateWithTemplate() error = %v", err)
+	}
+	if got != "fallback result" {
+		t.Fatalf("got %q, want fallback result", got)
+	}
+	if primary.calls != 1 {
+		t.Fatalf("primary calls = %d, want 1 (non-transient errors fail fast)", primary.calls)
+	}
+	if fallback.calls != 1 {
+		t.Fatalf("fallback calls = %d, want 1", fallback.calls)
+	}
+}
+
+func TestGenerateWithTemplatePrimarySuccessDoesNotFallBack(t *testing.T) {
+	primary := &templateCaptureChatModel{
+		modelID:  "primary",
+		response: "primary result",
+	}
+	fallback := &templateCaptureChatModel{
+		modelID:  "fallback",
+		response: "fallback result",
+	}
+	service := &wikiIngestService{}
+
+	got, err := service.generateWithTemplate(
+		context.Background(),
+		&wikiSynthesisModelChain{
+			requestedModelIDs: []string{"primary", "fallback"},
+			candidates: []wikiSynthesisModelCandidate{
+				{model: primary, modelID: "primary"},
+				{model: fallback, modelID: "fallback"},
+			},
+		},
+		`Content={{.Content}}`,
+		map[string]string{"Content": "hello"},
+	)
+	if err != nil {
+		t.Fatalf("generateWithTemplate() error = %v", err)
+	}
+	if got != "primary result" {
+		t.Fatalf("got %q, want primary result", got)
+	}
+	if fallback.calls != 0 {
+		t.Fatalf("fallback calls = %d, want 0", fallback.calls)
+	}
+}
+
+func TestGenerateWithTemplateAllSynthesisModelsFailAggregatesError(t *testing.T) {
+	primary := &templateCaptureChatModel{
+		modelID: "primary",
+		err:     errors.New("API request failed with status 403: primary denied"),
+	}
+	fallback := &templateCaptureChatModel{
+		modelID: "fallback",
+		err:     errors.New("API request failed with status 400: fallback invalid"),
+	}
+	service := &wikiIngestService{}
+
+	_, err := service.generateWithTemplate(
+		context.Background(),
+		&wikiSynthesisModelChain{
+			requestedModelIDs: []string{"primary", "fallback"},
+			candidates: []wikiSynthesisModelCandidate{
+				{model: primary, modelID: "primary"},
+				{model: fallback, modelID: "fallback"},
+			},
+		},
+		`Content={{.Content}}`,
+		map[string]string{"Content": "hello"},
+	)
+	if err == nil {
+		t.Fatal("generateWithTemplate() error = nil, want aggregated failure")
+	}
+	if !strings.Contains(err.Error(), "across 2 models") {
+		t.Fatalf("error should mention chain size, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "primary denied") || !strings.Contains(err.Error(), "fallback invalid") {
+		t.Fatalf("error should aggregate primary and last model errors, got: %v", err)
+	}
+	if primary.calls != 1 || fallback.calls != 1 {
+		t.Fatalf("calls = (%d, %d), want (1, 1)", primary.calls, fallback.calls)
+	}
+}
+
+func TestGenerateWithTemplateEmptySynthesisModelChainFails(t *testing.T) {
+	service := &wikiIngestService{}
+	_, err := service.generateWithTemplate(
+		context.Background(),
+		&wikiSynthesisModelChain{},
+		`Content={{.Content}}`,
+		map[string]string{"Content": "hello"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "wiki synthesis model chain is empty") {
+		t.Fatalf("generateWithTemplate() error = %v, want empty chain error", err)
+	}
+}
+
+func TestGenerateWithTemplateSingleModelStillFailsFast(t *testing.T) {
+	model := &templateCaptureChatModel{
+		modelID: "single",
+		err:     errors.New("API request failed with status 400: invalid request"),
+	}
+	service := &wikiIngestService{}
+
+	_, err := service.generateWithTemplate(
+		context.Background(),
+		model,
+		`Content={{.Content}}`,
+		map[string]string{"Content": "hello"},
+	)
+	if err == nil {
+		t.Fatal("generateWithTemplate() error = nil, want failure")
+	}
+	if !strings.Contains(err.Error(), "invalid request") {
+		t.Fatalf("error should wrap the model error, got: %v", err)
+	}
+	if model.calls != 1 {
+		t.Fatalf("single model calls = %d, want 1 (no fallback configured)", model.calls)
+	}
+}
 
 func TestGenerateWikiPageModifyUsesCacheableMessageLayout(t *testing.T) {
 	model := &templateCaptureChatModel{response: "SUMMARY: page\n# Alpha"}

--- a/internal/types/knowledgebase.go
+++ b/internal/types/knowledgebase.go
@@ -627,6 +627,9 @@ func (kb *KnowledgeBase) EnsureDefaults() {
 	if kb.Type != KnowledgeBaseTypeFAQ {
 		kb.FAQConfig = nil
 	}
+	if kb.WikiConfig != nil {
+		kb.WikiConfig.NormalizeSynthesisModelChain()
+	}
 	// Set defaults for FAQ
 	if kb.Type == KnowledgeBaseTypeFAQ {
 		if kb.FAQConfig == nil {

--- a/internal/types/wiki_page.go
+++ b/internal/types/wiki_page.go
@@ -500,6 +500,11 @@ func (g WikiExtractionGranularity) Normalize() WikiExtractionGranularity {
 type WikiConfig struct {
 	// SynthesisModelID is the LLM model ID used for wiki page generation and updates
 	SynthesisModelID string `yaml:"synthesis_model_id" json:"synthesis_model_id"`
+	// SynthesisFallbackModelID is the first fallback LLM model ID kept for compatibility
+	// with older clients that only support a single fallback field.
+	SynthesisFallbackModelID string `yaml:"synthesis_fallback_model_id" json:"synthesis_fallback_model_id,omitempty"`
+	// SynthesisFallbackModelIDs are tried in order after the effective synthesis model.
+	SynthesisFallbackModelIDs []string `yaml:"synthesis_fallback_model_ids" json:"synthesis_fallback_model_ids,omitempty"`
 	// MaxPagesPerIngest limits pages created/updated per ingest operation (0 = no limit)
 	MaxPagesPerIngest int `yaml:"max_pages_per_ingest" json:"max_pages_per_ingest"`
 	// ExtractionGranularity controls how many candidate slugs Pass 0 extracts
@@ -551,6 +556,83 @@ type WikiConfig struct {
 	IngestMaxInflight int `yaml:"ingest_max_inflight" json:"ingest_max_inflight,omitempty"`
 }
 
+// MaxWikiSynthesisModelChainLength caps the ordered Wiki synthesis model
+// chain (primary + fallbacks). Keeps a misconfigured KB from turning one
+// failed synthesis call into an unbounded fan-out of provider attempts.
+const MaxWikiSynthesisModelChainLength = 5
+
+// NormalizeSynthesisModelChain trims and de-duplicates configured Wiki
+// synthesis fallback models while keeping the legacy single fallback field in
+// sync with the first configured fallback. Unlike VLM config, an empty primary
+// synthesis model is valid: the runtime then uses the KB summary model as the
+// primary and still honors these fallbacks.
+func (c *WikiConfig) NormalizeSynthesisModelChain() {
+	if c == nil {
+		return
+	}
+	c.SynthesisModelID = strings.TrimSpace(c.SynthesisModelID)
+	c.SynthesisFallbackModelID = strings.TrimSpace(c.SynthesisFallbackModelID)
+
+	source := c.SynthesisFallbackModelIDs
+	if len(source) == 0 && c.SynthesisFallbackModelID != "" {
+		source = []string{c.SynthesisFallbackModelID}
+	}
+
+	seen := make(map[string]bool)
+	if c.SynthesisModelID != "" {
+		seen[c.SynthesisModelID] = true
+	}
+	fallbacks := make([]string, 0, MaxWikiSynthesisModelChainLength-1)
+	for _, raw := range source {
+		id := strings.TrimSpace(raw)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		fallbacks = append(fallbacks, id)
+		if len(fallbacks) >= MaxWikiSynthesisModelChainLength-1 {
+			break
+		}
+	}
+	c.SynthesisFallbackModelIDs = fallbacks
+	if len(fallbacks) > 0 {
+		c.SynthesisFallbackModelID = fallbacks[0]
+	} else {
+		c.SynthesisFallbackModelID = ""
+	}
+}
+
+// SynthesisModelChainIDs returns the ordered Wiki synthesis model chain. The
+// primary model is WikiConfig.SynthesisModelID when set, otherwise the KB
+// summary model; configured fallbacks follow in order.
+func (c WikiConfig) SynthesisModelChainIDs(summaryModelID string) []string {
+	c.NormalizeSynthesisModelChain()
+
+	primary := strings.TrimSpace(c.SynthesisModelID)
+	if primary == "" {
+		primary = strings.TrimSpace(summaryModelID)
+	}
+
+	ids := make([]string, 0, MaxWikiSynthesisModelChainLength)
+	seen := make(map[string]bool)
+	if primary != "" {
+		ids = append(ids, primary)
+		seen[primary] = true
+	}
+	for _, raw := range c.SynthesisFallbackModelIDs {
+		id := strings.TrimSpace(raw)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+		if len(ids) >= MaxWikiSynthesisModelChainLength {
+			break
+		}
+	}
+	return ids
+}
+
 // IngestBatchSizeOrDefault returns IngestBatchSize when set (> 0),
 // otherwise the hard-coded fallback. Centralized so callers don't have
 // to repeat the 0-check.
@@ -590,6 +672,7 @@ func (c *WikiConfig) IngestMaxInflightOrDefault(fallback int) int {
 
 // Value implements the driver.Valuer interface
 func (c WikiConfig) Value() (driver.Value, error) {
+	c.NormalizeSynthesisModelChain()
 	return json.Marshal(c)
 }
 
@@ -602,7 +685,11 @@ func (c *WikiConfig) Scan(value interface{}) error {
 	if !ok {
 		return nil
 	}
-	return json.Unmarshal(b, c)
+	if err := json.Unmarshal(b, c); err != nil {
+		return err
+	}
+	c.NormalizeSynthesisModelChain()
+	return nil
 }
 
 // WikiPageListRequest represents a request to list wiki pages with filtering

--- a/internal/types/wiki_page_test.go
+++ b/internal/types/wiki_page_test.go
@@ -65,6 +65,117 @@ func TestWikiConfigScanNil(t *testing.T) {
 	}
 }
 
+func TestWikiConfig_SynthesisModelChainIDsLegacyFallback(t *testing.T) {
+	cfg := WikiConfig{
+		SynthesisModelID:         "wiki-primary",
+		SynthesisFallbackModelID: "wiki-fallback",
+	}
+	got := cfg.SynthesisModelChainIDs("summary-model")
+	want := []string{"wiki-primary", "wiki-fallback"}
+	if len(got) != len(want) {
+		t.Fatalf("chain length = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("chain[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	cfg.NormalizeSynthesisModelChain()
+	if cfg.SynthesisFallbackModelID != "wiki-fallback" {
+		t.Fatalf("synthesis_fallback_model_id = %q, want wiki-fallback", cfg.SynthesisFallbackModelID)
+	}
+}
+
+func TestWikiConfig_SynthesisModelChainIDsSummaryPrimary(t *testing.T) {
+	cfg := WikiConfig{
+		SynthesisFallbackModelIDs: []string{"fallback-1", "summary-model", "fallback-2"},
+	}
+	got := cfg.SynthesisModelChainIDs("summary-model")
+	want := []string{"summary-model", "fallback-1", "fallback-2"}
+	if len(got) != len(want) {
+		t.Fatalf("chain length = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("chain[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestWikiConfig_SynthesisModelChainIDsFallbackOnly(t *testing.T) {
+	cfg := WikiConfig{
+		SynthesisFallbackModelIDs: []string{"fallback-1", "fallback-2"},
+	}
+	got := cfg.SynthesisModelChainIDs("")
+	want := []string{"fallback-1", "fallback-2"}
+	if len(got) != len(want) {
+		t.Fatalf("chain length = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("chain[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestWikiConfig_NormalizeSynthesisModelChainDedupesAndCaps(t *testing.T) {
+	cfg := WikiConfig{
+		SynthesisModelID: " primary ",
+		SynthesisFallbackModelIDs: []string{
+			" fallback-1 ",
+			"primary",
+			"",
+			"fallback-2",
+			"fallback-1",
+			"fallback-3",
+			"fallback-4",
+			"fallback-5",
+		},
+	}
+	cfg.NormalizeSynthesisModelChain()
+	want := []string{"primary", "fallback-1", "fallback-2", "fallback-3", "fallback-4"}
+	got := cfg.SynthesisModelChainIDs("summary-model")
+	if len(got) != len(want) {
+		t.Fatalf("chain length = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("chain[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if cfg.SynthesisFallbackModelID != "fallback-1" {
+		t.Fatalf("synthesis_fallback_model_id = %q, want fallback-1", cfg.SynthesisFallbackModelID)
+	}
+}
+
+func TestWikiConfig_ValueScanNormalizesSynthesisModelChain(t *testing.T) {
+	cfg := WikiConfig{
+		SynthesisModelID:          " primary ",
+		SynthesisFallbackModelIDs: []string{"primary", " fallback-1 ", "fallback-1", "fallback-2"},
+	}
+	val, err := cfg.Value()
+	if err != nil {
+		t.Fatalf("WikiConfig.Value() error: %v", err)
+	}
+	var restored WikiConfig
+	if err := restored.Scan(val); err != nil {
+		t.Fatalf("WikiConfig.Scan() error: %v", err)
+	}
+	want := []string{"primary", "fallback-1", "fallback-2"}
+	got := restored.SynthesisModelChainIDs("summary-model")
+	if len(got) != len(want) {
+		t.Fatalf("chain length = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("chain[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if restored.SynthesisFallbackModelID != "fallback-1" {
+		t.Fatalf("synthesis_fallback_model_id = %q, want fallback-1", restored.SynthesisFallbackModelID)
+	}
+}
+
 func TestStringArrayValueScan(t *testing.T) {
 	arr := StringArray{"a", "b", "c"}
 


### PR DESCRIPTION
## Description

Wiki page synthesis binds a single `synthesis_model_id`. When that model is rate-limited or decommissioned, every wiki batch for the knowledge base fails — the whole wiki stalls even though other working chat models are configured.

This PR adds an **ordered fallback chain** for wiki synthesis:

- `WikiConfig` gains `synthesis_fallback_model_ids` (ordered list, chain capped at 5 via `MaxWikiSynthesisModelChainLength`) plus a single-value `synthesis_fallback_model_id` kept in sync with the first entry for compatibility with simpler clients. Normalization (trim/de-dupe/cap) runs on `Value`/`Scan` and `EnsureDefaults`. When the chain is empty, behavior is **identical to today** (primary model, falling back to the KB summary model when unset).
- `wikiSynthesisModelChain` implements `chat.Chat`, so every existing call site keeps its single-model shape. Resolution happens once per batch: candidates that fail to instantiate are skipped and recorded; only when *no* candidate resolves does the batch fail.
- During generation, each candidate keeps the full existing transient-retry budget (`wikiLLMMaxAttempts`); once a candidate is exhausted — including on model-level hard errors like 4xx — execution advances to the next candidate. Context cancellation stops immediately. When every candidate fails, the aggregated error reports the chain size plus the first and last errors.
- Observability: the resolved chain and per-model resolve errors are recorded on `WikiBatchContext` and surfaced in each document’s wiki span output (`synthesis_model_chain_ids` / `synthesis_model_resolve_errors`). The debounced finalize-time index rebuild resolves the same chain (best-effort semantics preserved: a resolve failure only warns and skips).
- Frontend is intentionally out of scope: the chain is configurable today through the KB create/update API’s `wiki_config` JSON; a chain selector UI can follow the VLM chain selector proposed in #2487.

Known follow-up (not in scope): `repository/model_usage.go`’s “model still referenced” check only inspects `wiki_config->>synthesis_model_id`, so deleting a model used *only* as a synthesis fallback is not blocked (it degrades to a resolve error at runtime).

## Type of Change
- [x] ✨ New feature

## Related Issue

N/A

## Testing

New tests cover: primary succeeds without fallback, fallback after a failed candidate (non-transient error, fail-fast), aggregated error when all candidates fail (chain size + both endpoint errors), empty-chain error, single-model compatibility (no fallback without a chain), types-level chain parsing/normalization, and `Value`/`Scan` round-trip normalization.

- `go test ./internal/types/ -count=1` — passes
- `go test ./internal/application/service/ -run "Wiki|GenerateWithTemplate" -count=1` — passes; full service package shows only the 3 pre-existing Windows SQLite temp-file-lock flakes, reproduced identically on clean `main`
- `gofmt -l` — clean on changed files; `git diff --check` — passes
- `golangci-lint run --new-from-rev=upstream/main ./internal/...` — 0 issues
- Swagger files updated surgically for the two new `WikiConfig` properties (a full `make docs` regeneration currently produces unrelated drift)

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (swagger; field comments)
- [x] Breaking changes are clearly called out in the description above