### PR TITLE
feat(chat): Wire rerank model resolution into KnowledgeQA

### DIFF
--- a/docs/api/chat.md
+++ b/docs/api/chat.md
@@ -32,12 +32,25 @@
 | `knowledge_ids` | string[] | 否 | 知识文件 ID 列表，指定具体文件进行检索 |
 | `agent_id` | string | 否 | 自定义 Agent ID，指定使用的智能体 |
 | `summary_model_id` | string | 否 | 覆盖默认的摘要模型 ID |
-| `rerank_model_id` | string | 否 | 检索重排序使用的 Rerank 模型。接受模型 ID 或当前 Tenant 可访问 Rerank 模型中的唯一名称；传入但无法解析时返回 400/403。不传时按 Agent 配置 > Tenant RetrievalConfig > 自动探测第一个可用 Rerank 模型 的顺序解析。与 `summary_model_id` 不同：无效的 `rerank_model_id` 硬失败而非回退 |
+| `rerank_model_id` | string | 否 | 检索重排序使用的 Rerank 模型（模型 ID 或唯一名称） |
 | `mentioned_items` | object[] | 否 | @提及的知识库和文件列表 |
 | `disable_title` | bool | 否 | 是否禁用自动标题生成（默认 false） |
 | `images` | object[] | 否 | 附带的图片（base64 格式），需要 Agent 启用图片上传 |
 | `channel` | string | 否 | 来源渠道标识：`web`、`api`、`im`、`browser_extension` |
 | `suggestion_attribution` | object | 否 | 用户从推荐问题发起本轮时传入 `{suggestion_set_id, question_id}`；服务端会校验归属 |
+
+**模型解析规则**：
+
+`summary_model_id` 与 `rerank_model_id` 均为可选覆盖，解析顺序如下：
+
+| 字段 | 解析顺序 | 无效值处理 |
+|------|---------|-----------|
+| `summary_model_id` | 请求值 > Agent 的 `model_id` > 知识库配置 > 自动探测可用的 KnowledgeQA 模型 | 忽略并回退 |
+| `rerank_model_id` | 请求值 > Agent 配置 > Tenant 检索配置 > 自动探测第一个可用的 Rerank 模型 | 返回 400/403，不回退 |
+
+- 有 Agent 时其 `model_id` 必须有值且有效，否则请求失败。
+- `rerank_model_id` 仅当请求实际触发检索时解析；纯聊天请求不解析。
+- Agent 模式下 `rerank_model_id` 请求值不生效，Rerank 模型取 Agent 配置。
 
 **请求**:
 
@@ -83,7 +96,7 @@ Agent 模式支持更智能的问答，包括工具调用、网络搜索、多�
 | `agent_id` | string | 否 | 自定义 Agent ID，指定使用的智能体（支持共享 Agent） |
 | `web_search_enabled` | bool | 否 | 是否启用网络搜索（默认 false） |
 | `summary_model_id` | string | 否 | 覆盖默认的摘要模型 ID |
-| `rerank_model_id` | string | 否 | 检索重排序使用的 Rerank 模型。接受模型 ID 或当前 Tenant 可访问 Rerank 模型中的唯一名称；传入但无法解析时返回 400/403。不传时按 Agent 配置 > Tenant RetrievalConfig > 自动探测第一个可用 Rerank 模型 的顺序解析。与 `summary_model_id` 不同：无效的 `rerank_model_id` 硬失败而非回退。Agent 模式下该字段不生效 |
+| `rerank_model_id` | string | 否 | 同上；Agent 模式下该字段不生效 |
 | `mentioned_items` | object[] | 否 | @提及的知识库和文件列表 |
 | `disable_title` | bool | 否 | 是否禁用自动标题生成（默认 false） |
 | `images` | object[] | 否 | 附带的图片（base64 格式），需要 Agent 启用图片上传 |

--- a/docs/api/chat.md
+++ b/docs/api/chat.md
@@ -32,6 +32,7 @@
 | `knowledge_ids` | string[] | 否 | 知识文件 ID 列表，指定具体文件进行检索 |
 | `agent_id` | string | 否 | 自定义 Agent ID，指定使用的智能体 |
 | `summary_model_id` | string | 否 | 覆盖默认的摘要模型 ID |
+| `rerank_model_id` | string | 否 | 检索重排序使用的 Rerank 模型。接受模型 ID 或当前 Tenant 可访问 Rerank 模型中的唯一名称；传入但无法解析时返回 400/403。不传时按 Agent 配置 > Tenant RetrievalConfig > 自动探测第一个可用 Rerank 模型 的顺序解析。与 `summary_model_id` 不同：无效的 `rerank_model_id` 硬失败而非回退 |
 | `mentioned_items` | object[] | 否 | @提及的知识库和文件列表 |
 | `disable_title` | bool | 否 | 是否禁用自动标题生成（默认 false） |
 | `images` | object[] | 否 | 附带的图片（base64 格式），需要 Agent 启用图片上传 |
@@ -82,6 +83,7 @@ Agent 模式支持更智能的问答，包括工具调用、网络搜索、多�
 | `agent_id` | string | 否 | 自定义 Agent ID，指定使用的智能体（支持共享 Agent） |
 | `web_search_enabled` | bool | 否 | 是否启用网络搜索（默认 false） |
 | `summary_model_id` | string | 否 | 覆盖默认的摘要模型 ID |
+| `rerank_model_id` | string | 否 | 检索重排序使用的 Rerank 模型。接受模型 ID 或当前 Tenant 可访问 Rerank 模型中的唯一名称；传入但无法解析时返回 400/403。不传时按 Agent 配置 > Tenant RetrievalConfig > 自动探测第一个可用 Rerank 模型 的顺序解析。与 `summary_model_id` 不同：无效的 `rerank_model_id` 硬失败而非回退 |
 | `mentioned_items` | object[] | 否 | @提及的知识库和文件列表 |
 | `disable_title` | bool | 否 | 是否禁用自动标题生成（默认 false） |
 | `images` | object[] | 否 | 附带的图片（base64 格式），需要 Agent 启用图片上传 |

--- a/docs/api/chat.md
+++ b/docs/api/chat.md
@@ -83,7 +83,7 @@ Agent 模式支持更智能的问答，包括工具调用、网络搜索、多�
 | `agent_id` | string | 否 | 自定义 Agent ID，指定使用的智能体（支持共享 Agent） |
 | `web_search_enabled` | bool | 否 | 是否启用网络搜索（默认 false） |
 | `summary_model_id` | string | 否 | 覆盖默认的摘要模型 ID |
-| `rerank_model_id` | string | 否 | 检索重排序使用的 Rerank 模型。接受模型 ID 或当前 Tenant 可访问 Rerank 模型中的唯一名称；传入但无法解析时返回 400/403。不传时按 Agent 配置 > Tenant RetrievalConfig > 自动探测第一个可用 Rerank 模型 的顺序解析。与 `summary_model_id` 不同：无效的 `rerank_model_id` 硬失败而非回退 |
+| `rerank_model_id` | string | 否 | 检索重排序使用的 Rerank 模型。接受模型 ID 或当前 Tenant 可访问 Rerank 模型中的唯一名称；传入但无法解析时返回 400/403。不传时按 Agent 配置 > Tenant RetrievalConfig > 自动探测第一个可用 Rerank 模型 的顺序解析。与 `summary_model_id` 不同：无效的 `rerank_model_id` 硬失败而非回退。Agent 模式下该字段不生效 |
 | `mentioned_items` | object[] | 否 | @提及的知识库和文件列表 |
 | `disable_title` | bool | 否 | 是否禁用自动标题生成（默认 false） |
 | `images` | object[] | 否 | 附带的图片（base64 格式），需要 Agent 启用图片上传 |

--- a/internal/application/service/session.go
+++ b/internal/application/service/session.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/models/chat"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	secutils "github.com/Tencent/WeKnora/internal/utils"
 	"github.com/google/uuid"
 
 	chatpipeline "github.com/Tencent/WeKnora/internal/application/service/chat_pipeline"
@@ -827,10 +828,12 @@ func (s *sessionService) ResolveRerankModel(ctx context.Context, requested strin
 		}
 	}
 	if len(matches) > 1 {
+		logger.Warnf(ctx, "Request provided ambiguous rerank model %s", secutils.SanitizeForLog(requested))
 		return "", apperrors.NewBadRequestError("rerank_model_id matches multiple models")
 	}
 	if len(matches) == 1 {
 		return matches[0].ID, nil
 	}
+	logger.Warnf(ctx, "Request provided invalid rerank model %s", secutils.SanitizeForLog(requested))
 	return "", apperrors.NewForbiddenError("rerank model not found or not accessible")
 }

--- a/internal/application/service/session.go
+++ b/internal/application/service/session.go
@@ -794,3 +794,10 @@ func (s *sessionService) GenerateTitleAsync(
 		}
 	}()
 }
+
+// ResolveRerankModel resolves a requested rerank model ID or name to a model ID.
+// Empty requested returns empty; resolution is left to the caller's chain.
+// TODO: implement full resolution. See session_rerank_resolution_test.go.
+func (s *sessionService) ResolveRerankModel(ctx context.Context, requested string) (string, error) {
+	return "", nil
+}

--- a/internal/application/service/session.go
+++ b/internal/application/service/session.go
@@ -798,6 +798,7 @@ func (s *sessionService) GenerateTitleAsync(
 // ResolveRerankModel resolves a requested rerank model ID or name to a model ID.
 // An empty requested string returns empty, leaving fallback to resolveRerankModelID.
 func (s *sessionService) ResolveRerankModel(ctx context.Context, requested string) (string, error) {
+	requested = strings.TrimSpace(requested)
 	if requested == "" {
 		return "", nil
 	}

--- a/internal/application/service/session.go
+++ b/internal/application/service/session.go
@@ -796,7 +796,7 @@ func (s *sessionService) GenerateTitleAsync(
 }
 
 // ResolveRerankModel resolves a requested rerank model ID or name to a model ID.
-// Empty requested returns empty; resolution is left to the caller's chain.
+// An empty requested string returns empty, leaving fallback to resolveRerankModelID.
 func (s *sessionService) ResolveRerankModel(ctx context.Context, requested string) (string, error) {
 	if requested == "" {
 		return "", nil

--- a/internal/application/service/session.go
+++ b/internal/application/service/session.go
@@ -797,7 +797,39 @@ func (s *sessionService) GenerateTitleAsync(
 
 // ResolveRerankModel resolves a requested rerank model ID or name to a model ID.
 // Empty requested returns empty; resolution is left to the caller's chain.
-// TODO: implement full resolution. See session_rerank_resolution_test.go.
 func (s *sessionService) ResolveRerankModel(ctx context.Context, requested string) (string, error) {
-	return "", nil
+	if requested == "" {
+		return "", nil
+	}
+	if s.modelService == nil {
+		return "", apperrors.NewInternalServerError("model service not available")
+	}
+	models, err := s.modelService.ListModels(ctx)
+	if err != nil {
+		return "", err
+	}
+	rerank := make([]*types.Model, 0)
+	for _, model := range models {
+		if model != nil && model.Type == types.ModelTypeRerank && model.Status == types.ModelStatusActive {
+			rerank = append(rerank, model)
+		}
+	}
+	for _, model := range rerank {
+		if model.ID == requested {
+			return model.ID, nil
+		}
+	}
+	matches := make([]*types.Model, 0)
+	for _, model := range rerank {
+		if model.Name == requested {
+			matches = append(matches, model)
+		}
+	}
+	if len(matches) > 1 {
+		return "", apperrors.NewBadRequestError("rerank_model_id matches multiple models")
+	}
+	if len(matches) == 1 {
+		return matches[0].ID, nil
+	}
+	return "", apperrors.NewForbiddenError("rerank model not found or not accessible")
 }

--- a/internal/application/service/session_knowledge_qa.go
+++ b/internal/application/service/session_knowledge_qa.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/models/chat"
 	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
+	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
 
 // KnowledgeQA performs knowledge base question answering with LLM summarization
@@ -870,10 +871,10 @@ func (s *sessionService) SearchKnowledge(ctx context.Context,
 		},
 	}
 
-	// Resolve the rerank model: request override (hard-failing) then tenant
-	// RetrievalConfig, then auto-detect the first active rerank model.
+	// Resolve the rerank model
 	chatManage.RerankModelID, err = s.resolveRerankModelID(ctx, rerankModelID, "", rc)
 	if err != nil {
+		logger.Errorf(ctx, "Failed to resolve rerank model ID '%s': %v", secutils.SanitizeForLog(rerankModelID), err)
 		return nil, err
 	}
 

--- a/internal/application/service/session_knowledge_qa.go
+++ b/internal/application/service/session_knowledge_qa.go
@@ -86,6 +86,12 @@ func (s *sessionService) KnowledgeQA(
 	// Resolve retrieval tenant scope using shared helper
 	retrievalTenantID := s.resolveRetrievalTenantID(ctx, req)
 
+	// Load tenant-level retrieval config (nil is safe; used for rerank model fallback)
+	var rc *types.RetrievalConfig
+	if tenant, err2 := s.tenantService.GetTenantByID(ctx, retrievalTenantID); err2 == nil {
+		rc = tenant.RetrievalConfig
+	}
+
 	// Build unified search targets (computed once, used throughout pipeline)
 	searchTargets, err := s.buildSearchTargets(ctx, retrievalTenantID, knowledgeBaseIDs, knowledgeIDs, req.TagScopes)
 	if err != nil {
@@ -147,6 +153,17 @@ func (s *sessionService) KnowledgeQA(
 			MessageID:     req.AssistantMessageID,
 			UserMessageID: req.UserMessageID,
 		},
+	}
+
+	// Resolve the rerank model: request override (hard-failing 400/403) then
+	// agent config, then tenant RetrievalConfig, then auto-detect.
+	var agentRerankModelID string
+	if req.CustomAgent != nil {
+		agentRerankModelID = req.CustomAgent.Config.RerankModelID
+	}
+	chatManage.RerankModelID, err = s.resolveRerankModelID(ctx, req.RerankModelID, agentRerankModelID, rc)
+	if err != nil {
+		return err
 	}
 
 	// Apply custom agent overrides (system prompt, temperature, retrieval params,
@@ -798,7 +815,7 @@ func (s *sessionService) KnowledgeQAByEvent(ctx context.Context,
 // knowledgeBaseIDs: list of knowledge base IDs to search (supports multi-KB)
 // knowledgeIDs: list of specific knowledge (file) IDs to search
 func (s *sessionService) SearchKnowledge(ctx context.Context,
-	knowledgeBaseIDs []string, knowledgeIDs []string, tagScopes []types.TagScope, query string,
+	knowledgeBaseIDs []string, knowledgeIDs []string, tagScopes []types.TagScope, query string, rerankModelID string,
 ) ([]*types.SearchResult, error) {
 	logger.Info(ctx, "Start knowledge base search without LLM summary")
 	logger.Infof(ctx, "Knowledge base search parameters, knowledge base IDs: %v, knowledge IDs: %v, tag scopes: %d, query: %s",
@@ -850,26 +867,11 @@ func (s *sessionService) SearchKnowledge(ctx context.Context,
 		},
 	}
 
-	// Get default models
-	models, err := s.modelService.ListModels(ctx)
+	// Resolve the rerank model: request override (hard-failing) then tenant
+	// RetrievalConfig, then auto-detect the first active rerank model.
+	chatManage.RerankModelID, err = s.resolveRerankModelID(ctx, rerankModelID, "", rc)
 	if err != nil {
-		logger.Errorf(ctx, "Failed to get models: %v", err)
 		return nil, err
-	}
-
-	// Use rerank model from RetrievalConfig if set, otherwise auto-select the first available
-	if rc != nil && rc.RerankModelID != "" {
-		chatManage.RerankModelID = rc.RerankModelID
-	} else {
-		for _, model := range models {
-			if model == nil {
-				continue
-			}
-			if model.Type == types.ModelTypeRerank {
-				chatManage.RerankModelID = model.ID
-				break
-			}
-		}
 	}
 
 	// Use specific event list, only including retrieval-related events, not LLM summarization

--- a/internal/application/service/session_knowledge_qa.go
+++ b/internal/application/service/session_knowledge_qa.go
@@ -155,21 +155,6 @@ func (s *sessionService) KnowledgeQA(
 		},
 	}
 
-	// Resolve the rerank model: request override (hard-failing 400/403) then
-	// agent config, then tenant RetrievalConfig, then auto-detect.
-	var agentRerankModelID string
-	if req.CustomAgent != nil {
-		agentRerankModelID = req.CustomAgent.Config.RerankModelID
-	}
-	chatManage.RerankModelID, err = s.resolveRerankModelID(ctx, req.RerankModelID, agentRerankModelID, rc)
-	if err != nil {
-		return err
-	}
-
-	// Apply custom agent overrides (system prompt, temperature, retrieval params,
-	// rewrite, fallback, FAQ strategy, history turns)
-	s.applyAgentOverridesToChatManage(ctx, req.CustomAgent, chatManage)
-
 	// Determine pipeline based on the effective knowledge retrieval scope and
 	// web search setting. Tag-only mentions leave the raw KB/knowledge ID slices
 	// empty but produce SearchTargets, so the unified targets must participate in
@@ -177,6 +162,24 @@ func (s *sessionService) KnowledgeQA(
 	hasKB := types.HasKnowledgeRetrievalScope(searchTargets, knowledgeBaseIDs, knowledgeIDs)
 	needsRAG := hasKB || req.WebSearchEnabled
 	hasHistory := chatManage.MaxRounds > 0
+
+	// Resolve the rerank model: request override (hard-failing 400/403) then
+	// agent config, then tenant RetrievalConfig, then auto-detect.
+	// Only when retrieval actually runs.
+	var agentRerankModelID string
+	if req.CustomAgent != nil {
+		agentRerankModelID = req.CustomAgent.Config.RerankModelID
+	}
+	if needsRAG {
+		chatManage.RerankModelID, err = s.resolveRerankModelID(ctx, req.RerankModelID, agentRerankModelID, rc)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Apply custom agent overrides (system prompt, temperature, retrieval params,
+	// rewrite, fallback, FAQ strategy, history turns)
+	s.applyAgentOverridesToChatManage(ctx, req.CustomAgent, chatManage)
 
 	var pipeline []types.EventType
 	if !needsRAG {

--- a/internal/application/service/session_qa_helpers.go
+++ b/internal/application/service/session_qa_helpers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
+	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
 
 // ---------------------------------------------------------------------------
@@ -343,6 +344,7 @@ func (s *sessionService) resolveRerankModelID(
 		if err != nil {
 			return "", err
 		}
+		logger.Infof(ctx, "Using request's rerank model override: %s", secutils.SanitizeForLog(resolved))
 		return resolved, nil
 	}
 	if agentRerankModelID != "" {
@@ -350,9 +352,11 @@ func (s *sessionService) resolveRerankModelID(
 		if err != nil {
 			return "", err
 		}
+		logger.Infof(ctx, "Using custom agent's rerank model: %s", secutils.SanitizeForLog(resolved))
 		return resolved, nil
 	}
 	if rc != nil && rc.RerankModelID != "" {
+		logger.Infof(ctx, "Using tenant retrieval config rerank model: %s", rc.RerankModelID)
 		return rc.RerankModelID, nil
 	}
 	if s.modelService == nil {
@@ -361,9 +365,12 @@ func (s *sessionService) resolveRerankModelID(
 	if models, err := s.modelService.ListModels(ctx); err == nil {
 		for _, model := range models {
 			if model != nil && model.Type == types.ModelTypeRerank && model.Status == types.ModelStatusActive {
+				logger.Infof(ctx, "Auto-detected first active rerank model: %s", model.ID)
 				return model.ID, nil
 			}
 		}
+	} else {
+		logger.Warnf(ctx, "Failed to list rerank models for auto-detect, skipping rerank: %v", err)
 	}
 	return "", nil
 }

--- a/internal/application/service/session_qa_helpers.go
+++ b/internal/application/service/session_qa_helpers.go
@@ -210,9 +210,6 @@ func (s *sessionService) applyAgentOverridesToChatManage(
 		cm.RerankTopK = customAgent.Config.RerankTopK
 	}
 	cm.RerankThreshold = customAgent.Config.RerankThreshold
-	if customAgent.Config.RerankModelID != "" {
-		cm.RerankModelID = customAgent.Config.RerankModelID
-	}
 
 	// Override rewrite settings
 	cm.EnableRewrite = customAgent.Config.EnableRewrite
@@ -335,12 +332,38 @@ func (s *sessionService) restrictMentionsToAgentScope(
 // resolveRerankModelID resolves the effective rerank model ID for a request.
 // Precedence mirrors resolveChatModelID: requested override, then agent
 // config, then tenant RetrievalConfig, then auto-detect.
-// TODO: implement full resolution. See session_rerank_resolution_test.go.
 func (s *sessionService) resolveRerankModelID(
 	ctx context.Context,
 	requested string,
 	agentRerankModelID string,
 	rc *types.RetrievalConfig,
 ) (string, error) {
+	if requested != "" {
+		resolved, err := s.ResolveRerankModel(ctx, requested)
+		if err != nil {
+			return "", err
+		}
+		return resolved, nil
+	}
+	if agentRerankModelID != "" {
+		resolved, err := s.ResolveRerankModel(ctx, agentRerankModelID)
+		if err != nil {
+			return "", err
+		}
+		return resolved, nil
+	}
+	if rc != nil && rc.RerankModelID != "" {
+		return rc.RerankModelID, nil
+	}
+	if s.modelService == nil {
+		return "", nil
+	}
+	if models, err := s.modelService.ListModels(ctx); err == nil {
+		for _, model := range models {
+			if model != nil && model.Type == types.ModelTypeRerank && model.Status == types.ModelStatusActive {
+				return model.ID, nil
+			}
+		}
+	}
 	return "", nil
 }

--- a/internal/application/service/session_qa_helpers.go
+++ b/internal/application/service/session_qa_helpers.go
@@ -331,3 +331,16 @@ func (s *sessionService) restrictMentionsToAgentScope(
 
 	return filteredKBs, filteredKnowledge
 }
+
+// resolveRerankModelID resolves the effective rerank model ID for a request.
+// Precedence mirrors resolveChatModelID: requested override, then agent
+// config, then tenant RetrievalConfig, then auto-detect.
+// TODO: implement full resolution. See session_rerank_resolution_test.go.
+func (s *sessionService) resolveRerankModelID(
+	ctx context.Context,
+	requested string,
+	agentRerankModelID string,
+	rc *types.RetrievalConfig,
+) (string, error) {
+	return "", nil
+}

--- a/internal/application/service/session_rerank_resolution_test.go
+++ b/internal/application/service/session_rerank_resolution_test.go
@@ -159,7 +159,8 @@ func TestResolveRerankModel_ModelServiceNil_InternalError(t *testing.T) {
 func TestResolveRerankModelID_RequestBeatsAgentAndTenant(t *testing.T) {
 	svc := newRerankResolutionService(&rerankResolutionModelService{models: activeRerankModels()})
 
-	got, err := svc.resolveRerankModelID(context.Background(), "rerank-1", "rerank-2", &types.RetrievalConfig{RerankModelID: "rerank-3"})
+	got, err := svc.resolveRerankModelID(context.Background(),
+		"rerank-1", "rerank-2", &types.RetrievalConfig{RerankModelID: "rerank-3"})
 	require.NoError(t, err)
 	assert.Equal(t, "rerank-1", got)
 }
@@ -169,7 +170,8 @@ func TestResolveRerankModelID_RequestBeatsAgentAndTenant(t *testing.T) {
 func TestResolveRerankModelID_AgentBeatsTenant(t *testing.T) {
 	svc := newRerankResolutionService(&rerankResolutionModelService{models: activeRerankModels()})
 
-	got, err := svc.resolveRerankModelID(context.Background(), "", "rerank-2", &types.RetrievalConfig{RerankModelID: "rerank-3"})
+	got, err := svc.resolveRerankModelID(context.Background(),
+		"", "rerank-2", &types.RetrievalConfig{RerankModelID: "rerank-3"})
 	require.NoError(t, err)
 	assert.Equal(t, "rerank-2", got)
 }
@@ -216,7 +218,8 @@ func TestResolveRerankModelID_RequestInvalid_HardFailsNoFallback(t *testing.T) {
 	ms := &rerankResolutionModelService{models: activeRerankModels()}
 	svc := newRerankResolutionService(ms)
 
-	_, err := svc.resolveRerankModelID(context.Background(), "no-such-model", "", &types.RetrievalConfig{RerankModelID: "rerank-3"})
+	_, err := svc.resolveRerankModelID(context.Background(),
+		"no-such-model", "", &types.RetrievalConfig{RerankModelID: "rerank-3"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found or not accessible")
 }
@@ -228,7 +231,8 @@ func TestResolveRerankModelID_RequestInvalid_HardFailsNoFallback(t *testing.T) {
 func TestResolveRerankModelID_AgentInvalid_HardFails(t *testing.T) {
 	svc := newRerankResolutionService(&rerankResolutionModelService{models: activeRerankModels()})
 
-	_, err := svc.resolveRerankModelID(context.Background(), "", "agent-stale-model", &types.RetrievalConfig{RerankModelID: "rerank-3"})
+	_, err := svc.resolveRerankModelID(context.Background(),
+		"", "agent-stale-model", &types.RetrievalConfig{RerankModelID: "rerank-3"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found or not accessible")
 }
@@ -241,7 +245,8 @@ func TestResolveRerankModelID_TenantConfigNotValidated(t *testing.T) {
 	ms := &rerankResolutionModelService{models: activeRerankModels()}
 	svc := newRerankResolutionService(ms)
 
-	got, err := svc.resolveRerankModelID(context.Background(), "", "", &types.RetrievalConfig{RerankModelID: "stale-or-invalid-id"})
+	got, err := svc.resolveRerankModelID(context.Background(),
+		"", "", &types.RetrievalConfig{RerankModelID: "stale-or-invalid-id"})
 	require.NoError(t, err)
 	assert.Equal(t, "stale-or-invalid-id", got)
 	assert.Equal(t, 0, ms.listCalls, "tenant config path must not consult the model list")

--- a/internal/application/service/session_rerank_resolution_test.go
+++ b/internal/application/service/session_rerank_resolution_test.go
@@ -1,0 +1,279 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+// rerankResolutionModelService is a minimal model-service stub exposing only
+// ListModels. ResolveRerankModel and the auto-detect fallback both read the
+// model list from here.
+type rerankResolutionModelService struct {
+	interfaces.ModelService
+	models    []*types.Model
+	listErr   error
+	listCalls int
+}
+
+func (s *rerankResolutionModelService) ListModels(context.Context) ([]*types.Model, error) {
+	s.listCalls++
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.models, nil
+}
+
+func newRerankResolutionService(ms *rerankResolutionModelService) *sessionService {
+	return &sessionService{modelService: ms}
+}
+
+// rerankModel returns a ready-made rerank model; status overrides to inactive.
+func rerankModel(id, name string, active bool) *types.Model {
+	status := types.ModelStatusActive
+	if !active {
+		status = types.ModelStatusDownloading
+	}
+	return &types.Model{ID: id, Name: name, Type: types.ModelTypeRerank, Status: status}
+}
+
+func activeRerankModels() []*types.Model {
+	return []*types.Model{
+		rerankModel("rerank-1", "rerank-a", true),
+		rerankModel("rerank-2", "rerank-b", true),
+	}
+}
+
+// --- ResolveRerankModel (low-level helper) ---
+
+// An empty requested string means "no override": returns empty with no
+// error, leaving resolution to the chain (tenant config -> auto-detect).
+func TestResolveRerankModel_EmptyRequest_ReturnsEmpty(t *testing.T) {
+	svc := newRerankResolutionService(&rerankResolutionModelService{models: activeRerankModels()})
+
+	got, err := svc.ResolveRerankModel(context.Background(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "", got)
+}
+
+// UUID exact match wins, regardless of name collisions.
+func TestResolveRerankModel_IDMatch(t *testing.T) {
+	svc := newRerankResolutionService(&rerankResolutionModelService{models: activeRerankModels()})
+
+	got, err := svc.ResolveRerankModel(context.Background(), "rerank-1")
+	require.NoError(t, err)
+	assert.Equal(t, "rerank-1", got)
+}
+
+// When no ID matches, a name matching exactly one active rerank model
+// resolves to that model's ID (convenience for callers that only know the
+// configured model name).
+func TestResolveRerankModel_NameUniqueMatch(t *testing.T) {
+	svc := newRerankResolutionService(&rerankResolutionModelService{models: activeRerankModels()})
+
+	got, err := svc.ResolveRerankModel(context.Background(), "rerank-b")
+	require.NoError(t, err)
+	assert.Equal(t, "rerank-2", got)
+}
+
+// A name shared by more than one active rerank model is ambiguous and
+// fails with 400: silently picking one would be non-deterministic.
+func TestResolveRerankModel_NameAmbiguous_400(t *testing.T) {
+	svc := newRerankResolutionService(&rerankResolutionModelService{models: []*types.Model{
+		rerankModel("rerank-1", "shared", true),
+		rerankModel("rerank-2", "shared", true),
+	}})
+
+	_, err := svc.ResolveRerankModel(context.Background(), "shared")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "matches multiple models")
+}
+
+// An unknown ID or name fails with 403: hard fail, no silent fallback to
+// the tenant default.
+func TestResolveRerankModel_NotFound_403(t *testing.T) {
+	svc := newRerankResolutionService(&rerankResolutionModelService{models: activeRerankModels()})
+
+	_, err := svc.ResolveRerankModel(context.Background(), "no-such-model")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found or not accessible")
+}
+
+// Non-active models are invisible to resolution: unreachable by ID or
+// name, and never auto-selected.
+func TestResolveRerankModel_InactiveExcluded(t *testing.T) {
+	svc := newRerankResolutionService(&rerankResolutionModelService{models: []*types.Model{
+		rerankModel("rerank-inactive", "inactive-name", false),
+	}})
+
+	_, err := svc.ResolveRerankModel(context.Background(), "rerank-inactive")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found or not accessible")
+
+	_, err = svc.ResolveRerankModel(context.Background(), "inactive-name")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found or not accessible")
+}
+
+// A model-list failure propagates; the tenant-configured model path must
+// not depend on ListModels succeeding.
+func TestResolveRerankModel_ListError_Propagates(t *testing.T) {
+	ms := &rerankResolutionModelService{listErr: assert.AnError}
+	svc := newRerankResolutionService(ms)
+
+	_, err := svc.ResolveRerankModel(context.Background(), "rerank-1")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+// With a non-empty requested value and no model service, resolution fails
+// with an internal error rather than silently returning empty.
+func TestResolveRerankModel_ModelServiceNil_InternalError(t *testing.T) {
+	svc := &sessionService{}
+
+	_, err := svc.ResolveRerankModel(context.Background(), "rerank-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "model service not available")
+}
+
+// --- resolveRerankModelID (full resolution chain) ---
+//
+// Mirrors resolveChatModelID precedence:
+// request override > agent config > tenant RetrievalConfig > auto-detect.
+// Request and agent values are validated hard (400/403); the tenant value
+// is used verbatim (matching the retrieve API path); auto-detect picks the
+// first active rerank model.
+//
+// Structural rule: applyAgentOverridesToChatManage must NOT overwrite
+// RerankModelID; the agent step lives in this chain (see
+// TestApplyAgentOverrides_RerankModelIDUntouched).
+
+// The request override wins over agent config, tenant config and
+// auto-detect: identical precedence to summary_model_id in
+// resolveChatModelID.
+func TestResolveRerankModelID_RequestBeatsAgentAndTenant(t *testing.T) {
+	svc := newRerankResolutionService(&rerankResolutionModelService{models: activeRerankModels()})
+
+	got, err := svc.resolveRerankModelID(context.Background(), "rerank-1", "rerank-2", &types.RetrievalConfig{RerankModelID: "rerank-3"})
+	require.NoError(t, err)
+	assert.Equal(t, "rerank-1", got)
+}
+
+// With no request override, the agent config beats tenant config and
+// auto-detect (agent is the more specific per-session configuration).
+func TestResolveRerankModelID_AgentBeatsTenant(t *testing.T) {
+	svc := newRerankResolutionService(&rerankResolutionModelService{models: activeRerankModels()})
+
+	got, err := svc.resolveRerankModelID(context.Background(), "", "rerank-2", &types.RetrievalConfig{RerankModelID: "rerank-3"})
+	require.NoError(t, err)
+	assert.Equal(t, "rerank-2", got)
+}
+
+// With no request or agent override, the tenant RetrievalConfig wins and
+// auto-detect is never reached (no model list call).
+func TestResolveRerankModelID_TenantBeatsAutoDetect(t *testing.T) {
+	ms := &rerankResolutionModelService{models: activeRerankModels()}
+	svc := newRerankResolutionService(ms)
+
+	got, err := svc.resolveRerankModelID(context.Background(), "", "", &types.RetrievalConfig{RerankModelID: "rerank-3"})
+	require.NoError(t, err)
+	assert.Equal(t, "rerank-3", got)
+	assert.Equal(t, 0, ms.listCalls, "auto-detect must not run when a tenant model is configured")
+}
+
+// With no override at all, the first active rerank model is auto-selected,
+// keeping the rerank stage functional for tenants without a configured model.
+func TestResolveRerankModelID_AutoDetectLast(t *testing.T) {
+	svc := newRerankResolutionService(&rerankResolutionModelService{models: activeRerankModels()})
+
+	got, err := svc.resolveRerankModelID(context.Background(), "", "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "rerank-1", got)
+}
+
+// Auto-detect skips non-active models: the first active rerank model wins
+// even if inactive models sort earlier in the list.
+func TestResolveRerankModelID_AutoDetectSkipsInactive(t *testing.T) {
+	svc := newRerankResolutionService(&rerankResolutionModelService{models: []*types.Model{
+		rerankModel("rerank-inactive", "inactive-name", false),
+		rerankModel("rerank-1", "rerank-a", true),
+	}})
+
+	got, err := svc.resolveRerankModelID(context.Background(), "", "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "rerank-1", got)
+}
+
+// An invalid request-level rerank_model_id hard-fails
+// (403) and does NOT fall back to the tenant config: an explicit but wrong
+// request must be surfaced, not silently ignored (unlike summary_model_id).
+func TestResolveRerankModelID_RequestInvalid_HardFailsNoFallback(t *testing.T) {
+	ms := &rerankResolutionModelService{models: activeRerankModels()}
+	svc := newRerankResolutionService(ms)
+
+	_, err := svc.resolveRerankModelID(context.Background(), "no-such-model", "", &types.RetrievalConfig{RerankModelID: "rerank-3"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found or not accessible")
+}
+
+// An invalid agent-configured rerank model hard-fails, mirroring
+// the agent model validation in resolveChatModelID:
+// a misconfigured agent is a config bug to be fixed, not papered over
+// by the tenant default.
+func TestResolveRerankModelID_AgentInvalid_HardFails(t *testing.T) {
+	svc := newRerankResolutionService(&rerankResolutionModelService{models: activeRerankModels()})
+
+	_, err := svc.resolveRerankModelID(context.Background(), "", "agent-stale-model", &types.RetrievalConfig{RerankModelID: "rerank-3"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found or not accessible")
+}
+
+// The tenant RetrievalConfig value is used verbatim without
+// existence/active validation (matching the retrieve API path). A stale
+// value fails later at the rerank stage (GetRerankModel ->
+// ErrGetRerankModel), not here.
+func TestResolveRerankModelID_TenantConfigNotValidated(t *testing.T) {
+	ms := &rerankResolutionModelService{models: activeRerankModels()}
+	svc := newRerankResolutionService(ms)
+
+	got, err := svc.resolveRerankModelID(context.Background(), "", "", &types.RetrievalConfig{RerankModelID: "stale-or-invalid-id"})
+	require.NoError(t, err)
+	assert.Equal(t, "stale-or-invalid-id", got)
+	assert.Equal(t, 0, ms.listCalls, "tenant config path must not consult the model list")
+}
+
+// When auto-detect is reached and ListModels fails, the error is swallowed
+// and resolution returns empty (matching the retrieve API auto-detect
+// behavior). The rerank stage then skips (empty_model_id) instead of
+// failing the whole request.
+func TestResolveRerankModelID_AutoDetectListError_Swallowed(t *testing.T) {
+	ms := &rerankResolutionModelService{listErr: assert.AnError}
+	svc := newRerankResolutionService(ms)
+
+	got, err := svc.resolveRerankModelID(context.Background(), "", "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "", got)
+}
+
+// --- applyAgentOverridesToChatManage regression ---
+
+// applyAgentOverridesToChatManage must NOT touch RerankModelID: resolution
+// is owned by resolveRerankModelID so the request > agent > tenant >
+// auto-detect precedence holds (agent in the blanket pass would win over an
+// explicit request override, contradicting the summary_model_id semantics).
+func TestApplyAgentOverrides_RerankModelIDUntouched(t *testing.T) {
+	svc := &sessionService{}
+	cm := &types.ChatManage{}
+	cm.RerankModelID = "resolved-by-chain"
+	agent := &types.CustomAgent{Config: types.CustomAgentConfig{RerankModelID: "agent-model"}}
+
+	svc.applyAgentOverridesToChatManage(context.Background(), agent, cm)
+
+	assert.Equal(t, "resolved-by-chain", cm.RerankModelID,
+		"applyAgentOverridesToChatManage must not override RerankModelID (resolution is owned by resolveRerankModelID)")
+}

--- a/internal/application/service/session_rerank_resolution_test.go
+++ b/internal/application/service/session_rerank_resolution_test.go
@@ -33,7 +33,8 @@ func newRerankResolutionService(ms *rerankResolutionModelService) *sessionServic
 	return &sessionService{modelService: ms}
 }
 
-// rerankModel returns a ready-made rerank model; status overrides to inactive.
+// rerankModel returns a rerank model with the given ID/name; a false
+// active flag sets a non-active status.
 func rerankModel(id, name string, active bool) *types.Model {
 	status := types.ModelStatusActive
 	if !active {
@@ -52,7 +53,7 @@ func activeRerankModels() []*types.Model {
 // --- ResolveRerankModel (low-level helper) ---
 
 // An empty requested string means "no override": returns empty with no
-// error, leaving resolution to the chain (tenant config -> auto-detect).
+// error, leaving fallback to resolveRerankModelID.
 func TestResolveRerankModel_EmptyRequest_ReturnsEmpty(t *testing.T) {
 	svc := newRerankResolutionService(&rerankResolutionModelService{models: activeRerankModels()})
 
@@ -104,8 +105,7 @@ func TestResolveRerankModel_NotFound_403(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found or not accessible")
 }
 
-// Non-active models are invisible to resolution: unreachable by ID or
-// name, and never auto-selected.
+// Non-active models are invisible to resolution: unreachable by ID or name.
 func TestResolveRerankModel_InactiveExcluded(t *testing.T) {
 	svc := newRerankResolutionService(&rerankResolutionModelService{models: []*types.Model{
 		rerankModel("rerank-inactive", "inactive-name", false),
@@ -120,8 +120,8 @@ func TestResolveRerankModel_InactiveExcluded(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found or not accessible")
 }
 
-// A model-list failure propagates; the tenant-configured model path must
-// not depend on ListModels succeeding.
+// A model-list failure propagates to the caller; when the tenant config
+// supplies the model, ListModels must not be consulted.
 func TestResolveRerankModel_ListError_Propagates(t *testing.T) {
 	ms := &rerankResolutionModelService{listErr: assert.AnError}
 	svc := newRerankResolutionService(ms)
@@ -145,8 +145,8 @@ func TestResolveRerankModel_ModelServiceNil_InternalError(t *testing.T) {
 //
 // Mirrors resolveChatModelID precedence:
 // request override > agent config > tenant RetrievalConfig > auto-detect.
-// Request and agent values are validated hard (400/403); the tenant value
-// is used verbatim (matching the retrieve API path); auto-detect picks the
+// Request and agent values fail hard (400/403); the tenant value is used
+// without validation (same as SearchKnowledge); auto-detect picks the
 // first active rerank model.
 //
 // Structural rule: applyAgentOverridesToChatManage must NOT overwrite
@@ -237,10 +237,9 @@ func TestResolveRerankModelID_AgentInvalid_HardFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found or not accessible")
 }
 
-// The tenant RetrievalConfig value is used verbatim without
-// existence/active validation (matching the retrieve API path). A stale
-// value fails later at the rerank stage (GetRerankModel ->
-// ErrGetRerankModel), not here.
+// The tenant RetrievalConfig value is used without existence/active
+// validation (same as SearchKnowledge). A stale value fails later at the
+// rerank stage (GetRerankModel -> ErrGetRerankModel), not here.
 func TestResolveRerankModelID_TenantConfigNotValidated(t *testing.T) {
 	ms := &rerankResolutionModelService{models: activeRerankModels()}
 	svc := newRerankResolutionService(ms)
@@ -252,10 +251,10 @@ func TestResolveRerankModelID_TenantConfigNotValidated(t *testing.T) {
 	assert.Equal(t, 0, ms.listCalls, "tenant config path must not consult the model list")
 }
 
-// When auto-detect is reached and ListModels fails, the error is swallowed
-// and resolution returns empty (matching the retrieve API auto-detect
-// behavior). The rerank stage then skips (empty_model_id) instead of
-// failing the whole request.
+// When auto-detect is reached and ListModels fails, the error is ignored
+// and resolution returns empty (same as SearchKnowledge's auto-detect).
+// The rerank stage then skips (empty_model_id) instead of failing the
+// whole request.
 func TestResolveRerankModelID_AutoDetectListError_Swallowed(t *testing.T) {
 	ms := &rerankResolutionModelService{listErr: assert.AnError}
 	svc := newRerankResolutionService(ms)
@@ -269,8 +268,9 @@ func TestResolveRerankModelID_AutoDetectListError_Swallowed(t *testing.T) {
 
 // applyAgentOverridesToChatManage must NOT touch RerankModelID: resolution
 // is owned by resolveRerankModelID so the request > agent > tenant >
-// auto-detect precedence holds (agent in the blanket pass would win over an
-// explicit request override, contradicting the summary_model_id semantics).
+// auto-detect precedence holds. If the agent value were still applied
+// last, it would win over an explicit request override, contradicting the
+// summary_model_id semantics.
 func TestApplyAgentOverrides_RerankModelIDUntouched(t *testing.T) {
 	svc := &sessionService{}
 	cm := &types.ChatManage{}

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -722,7 +722,14 @@ func (h *Handler) SearchKnowledge(c *gin.Context) {
 		request.KnowledgeIDs, tagScopes, request.Query, request.RerankModelID)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
-		c.Error(errors.NewInternalServerError(err.Error()))
+		// Preserve typed errors (e.g. 400/403 for an invalid rerank_model_id)
+		// so the documented error-code contract holds; only unknown errors
+		// are flattened to 500.
+		if appErr, ok := errors.IsAppError(err); ok {
+			_ = c.Error(appErr)
+		} else {
+			_ = c.Error(errors.NewInternalServerError(err.Error()))
+		}
 		return
 	}
 

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -41,6 +41,7 @@ type qaRequestContext struct {
 	mcpServiceIDs         []string
 	skillNames            []string
 	summaryModelID        string
+	rerankModelID         string
 	webSearchEnabled      bool
 	mentionedItems        types.MentionedItems
 	effectiveTenantID     uint64                   // when using shared agent, tenant ID for model/KB/MCP resolution; 0 = use context tenant
@@ -72,6 +73,7 @@ func (rc *qaRequestContext) buildQARequest() *types.QARequest {
 		Query:               rc.query,
 		AssistantMessageID:  rc.assistantMessage.ID,
 		SummaryModelID:      rc.summaryModelID,
+		RerankModelID:       rc.rerankModelID,
 		CustomAgent:         rc.customAgent,
 		SharedAgentReadOnly: rc.sharedAgentReadOnly,
 		KnowledgeBaseIDs:    rc.knowledgeBaseIDs,
@@ -361,6 +363,7 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 		mcpServiceIDs:         secutils.SanitizeForLogArray(mcpServiceIDs),
 		skillNames:            secutils.SanitizeForLogArray(skillNames),
 		summaryModelID:        secutils.SanitizeForLog(request.SummaryModelID),
+		rerankModelID:         request.RerankModelID,
 		webSearchEnabled:      request.WebSearchEnabled,
 		mentionedItems:        convertMentionedItems(request.MentionedItems),
 		effectiveTenantID:     effectiveTenantID,
@@ -715,7 +718,7 @@ func (h *Handler) SearchKnowledge(c *gin.Context) {
 	)
 
 	// Directly call knowledge retrieval service without LLM summarization
-	searchResults, err := h.sessionService.SearchKnowledge(ctx, knowledgeBaseIDs, request.KnowledgeIDs, tagScopes, request.Query)
+	searchResults, err := h.sessionService.SearchKnowledge(ctx, knowledgeBaseIDs, request.KnowledgeIDs, tagScopes, request.Query, request.RerankModelID)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(errors.NewInternalServerError(err.Error()))

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -718,7 +718,8 @@ func (h *Handler) SearchKnowledge(c *gin.Context) {
 	)
 
 	// Directly call knowledge retrieval service without LLM summarization
-	searchResults, err := h.sessionService.SearchKnowledge(ctx, knowledgeBaseIDs, request.KnowledgeIDs, tagScopes, request.Query, request.RerankModelID)
+	searchResults, err := h.sessionService.SearchKnowledge(ctx, knowledgeBaseIDs,
+		request.KnowledgeIDs, tagScopes, request.Query, request.RerankModelID)
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, nil)
 		c.Error(errors.NewInternalServerError(err.Error()))

--- a/internal/handler/session/search_knowledge_resource_urls_test.go
+++ b/internal/handler/session/search_knowledge_resource_urls_test.go
@@ -22,7 +22,7 @@ type stubSearchSessionService struct {
 }
 
 func (s *stubSearchSessionService) SearchKnowledge(
-	_ context.Context, _ []string, _ []string, _ []types.TagScope, _ string,
+	_ context.Context, _ []string, _ []string, _ []types.TagScope, _ string, _ string,
 ) ([]*types.SearchResult, error) {
 	return []*types.SearchResult{{
 		Content:   "chunk ![c](" + testResourceHandle + ")",

--- a/internal/handler/session/search_knowledge_test.go
+++ b/internal/handler/session/search_knowledge_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	apperrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/middleware"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
@@ -19,11 +21,15 @@ import (
 
 type stubSearchSessionService struct {
 	interfaces.SessionService
+	err error
 }
 
 func (s *stubSearchSessionService) SearchKnowledge(
 	_ context.Context, _ []string, _ []string, _ []types.TagScope, _ string, _ string,
 ) ([]*types.SearchResult, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
 	return []*types.SearchResult{{
 		Content:   "chunk ![c](" + testResourceHandle + ")",
 		ImageInfo: `[{"url":"` + testResourceHandle + `"}]`,
@@ -97,4 +103,45 @@ func TestSearchKnowledge_DefaultKeepsHandles(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp.Data, 1)
 	assert.Contains(t, resp.Data[0].Content, testResourceHandle)
+}
+
+func setupSearchKnowledgeRouter(err error) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.ErrorHandler())
+	h := &Handler{
+		sessionService: &stubSearchSessionService{err: err},
+		fileService:    &stubResourceFileService{},
+	}
+	r.POST("/knowledge-search", h.SearchKnowledge)
+
+	body := bytes.NewBufferString(`{"query":"diagram","knowledge_base_ids":["kb-1"]}`)
+	req := httptest.NewRequest(http.MethodPost, "/knowledge-search", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestSearchKnowledge_TypedForbiddenErrorPreserved(t *testing.T) {
+	w := setupSearchKnowledgeRouter(
+		apperrors.NewForbiddenError("rerank model not found or not accessible"))
+
+	require.Equal(t, http.StatusForbidden, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "rerank model not found or not accessible")
+}
+
+func TestSearchKnowledge_TypedBadRequestErrorPreserved(t *testing.T) {
+	w := setupSearchKnowledgeRouter(
+		apperrors.NewBadRequestError("rerank_model_id matches multiple models"))
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "rerank_model_id matches multiple models")
+}
+
+func TestSearchKnowledge_GenericErrorFlattenedTo500(t *testing.T) {
+	w := setupSearchKnowledgeRouter(errors.New("db down"))
+
+	require.Equal(t, http.StatusInternalServerError, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), `"code":1007`)
 }

--- a/internal/handler/session/types.go
+++ b/internal/handler/session/types.go
@@ -50,6 +50,7 @@ type CreateKnowledgeQARequest struct {
 	AgentSourceTenantID   uint64                       `json:"agent_source_tenant_id,omitempty"`      // Optional disambiguator; backend still verifies the share relation
 	WebSearchEnabled      bool                         `json:"web_search_enabled"`                    // Whether web search is enabled for this request
 	SummaryModelID        string                       `json:"summary_model_id"`                      // Optional summary model ID for this request (overrides session default)
+	RerankModelID         string                       `json:"rerank_model_id,omitempty"`             // Optional rerank model ID or unique name for this request
 	MCPServiceIDs         []string                     `json:"mcp_service_ids"`                       // Per-request MCP services selected via @mention
 	SkillNames            []string                     `json:"skill_names"`                           // Per-request Skills selected via @mention
 	TagIDs                []string                     `json:"tag_ids"`                               // @mentioned tag IDs (display/debug; scoped via MentionedItems)
@@ -77,6 +78,7 @@ type SearchKnowledgeRequest struct {
 	KnowledgeIDs     []string               `json:"knowledge_ids"`                         // IDs of specific knowledge (files) to search
 	TagIDs           []string               `json:"tag_ids"`                               // Tag IDs for filtering within a single KB
 	MentionedItems   []MentionedItemRequest `json:"mentioned_items"`                       // Optional scoped tag mentions
+	RerankModelID    string                 `json:"rerank_model_id,omitempty"`             // Optional rerank model ID or unique name for this request
 }
 
 // StopSessionRequest represents the stop session request

--- a/internal/handler/session/types.go
+++ b/internal/handler/session/types.go
@@ -50,7 +50,7 @@ type CreateKnowledgeQARequest struct {
 	AgentSourceTenantID   uint64                       `json:"agent_source_tenant_id,omitempty"`      // Optional disambiguator; backend still verifies the share relation
 	WebSearchEnabled      bool                         `json:"web_search_enabled"`                    // Whether web search is enabled for this request
 	SummaryModelID        string                       `json:"summary_model_id"`                      // Optional summary model ID for this request (overrides session default)
-	RerankModelID         string                       `json:"rerank_model_id,omitempty"`             // Optional rerank model ID or unique name for this request
+	RerankModelID         string                       `json:"rerank_model_id,omitempty"`             // rerank override
 	MCPServiceIDs         []string                     `json:"mcp_service_ids"`                       // Per-request MCP services selected via @mention
 	SkillNames            []string                     `json:"skill_names"`                           // Per-request Skills selected via @mention
 	TagIDs                []string                     `json:"tag_ids"`                               // @mentioned tag IDs (display/debug; scoped via MentionedItems)
@@ -78,7 +78,7 @@ type SearchKnowledgeRequest struct {
 	KnowledgeIDs     []string               `json:"knowledge_ids"`                         // IDs of specific knowledge (files) to search
 	TagIDs           []string               `json:"tag_ids"`                               // Tag IDs for filtering within a single KB
 	MentionedItems   []MentionedItemRequest `json:"mentioned_items"`                       // Optional scoped tag mentions
-	RerankModelID    string                 `json:"rerank_model_id,omitempty"`             // Optional rerank model ID or unique name for this request
+	RerankModelID    string                 `json:"rerank_model_id,omitempty"`             // rerank override
 }
 
 // StopSessionRequest represents the stop session request

--- a/internal/handler/session/types.go
+++ b/internal/handler/session/types.go
@@ -50,7 +50,7 @@ type CreateKnowledgeQARequest struct {
 	AgentSourceTenantID   uint64                       `json:"agent_source_tenant_id,omitempty"`      // Optional disambiguator; backend still verifies the share relation
 	WebSearchEnabled      bool                         `json:"web_search_enabled"`                    // Whether web search is enabled for this request
 	SummaryModelID        string                       `json:"summary_model_id"`                      // Optional summary model ID for this request (overrides session default)
-	RerankModelID         string                       `json:"rerank_model_id,omitempty"`             // rerank override
+	RerankModelID         string                       `json:"rerank_model_id,omitempty"`             // per-request rerank
 	MCPServiceIDs         []string                     `json:"mcp_service_ids"`                       // Per-request MCP services selected via @mention
 	SkillNames            []string                     `json:"skill_names"`                           // Per-request Skills selected via @mention
 	TagIDs                []string                     `json:"tag_ids"`                               // @mentioned tag IDs (display/debug; scoped via MentionedItems)
@@ -78,7 +78,7 @@ type SearchKnowledgeRequest struct {
 	KnowledgeIDs     []string               `json:"knowledge_ids"`                         // IDs of specific knowledge (files) to search
 	TagIDs           []string               `json:"tag_ids"`                               // Tag IDs for filtering within a single KB
 	MentionedItems   []MentionedItemRequest `json:"mentioned_items"`                       // Optional scoped tag mentions
-	RerankModelID    string                 `json:"rerank_model_id,omitempty"`             // rerank override
+	RerankModelID    string                 `json:"rerank_model_id,omitempty"`             // per-request rerank
 }
 
 // StopSessionRequest represents the stop session request

--- a/internal/im/cmd_search.go
+++ b/internal/im/cmd_search.go
@@ -84,9 +84,7 @@ func (c *SearchCommand) Execute(ctx context.Context, cmdCtx *CommandContext, arg
 		}
 	}
 
-	// Resolve the rerank model from the agent config, mirroring the QA
-	// pipeline (empty when no agent; the chain falls back to tenant config /
-	// auto-detect).
+	// Resolve the rerank model from the agent config.
 	var rerankModelID string
 	if cmdCtx.CustomAgent != nil {
 		rerankModelID = cmdCtx.CustomAgent.Config.RerankModelID

--- a/internal/im/cmd_search.go
+++ b/internal/im/cmd_search.go
@@ -84,7 +84,15 @@ func (c *SearchCommand) Execute(ctx context.Context, cmdCtx *CommandContext, arg
 		}
 	}
 
-	results, err := c.sessionService.SearchKnowledge(ctx, kbIDs, nil, nil, query)
+	// Resolve the rerank model from the agent config, mirroring the QA
+	// pipeline (empty when no agent; the chain falls back to tenant config /
+	// auto-detect).
+	var rerankModelID string
+	if cmdCtx.CustomAgent != nil {
+		rerankModelID = cmdCtx.CustomAgent.Config.RerankModelID
+	}
+
+	results, err := c.sessionService.SearchKnowledge(ctx, kbIDs, nil, nil, query, rerankModelID)
 	if err != nil {
 		return nil, fmt.Errorf("search knowledge: %w", err)
 	}

--- a/internal/types/interfaces/session.go
+++ b/internal/types/interfaces/session.go
@@ -63,7 +63,7 @@ type SessionService interface {
 	// SearchKnowledge performs knowledge-based search, without summarization
 	// knowledgeBaseIDs: list of knowledge base IDs to search (supports multi-KB)
 	// knowledgeIDs: list of specific knowledge (file) IDs to search
-	SearchKnowledge(ctx context.Context, knowledgeBaseIDs []string, knowledgeIDs []string, tagScopes []types.TagScope, query string) ([]*types.SearchResult, error)
+	SearchKnowledge(ctx context.Context, knowledgeBaseIDs []string, knowledgeIDs []string, tagScopes []types.TagScope, query string, rerankModelID string) ([]*types.SearchResult, error)
 	// AgentQA performs agent-based question answering with conversation history and streaming support.
 	AgentQA(ctx context.Context, req *types.QARequest, eventBus *event.EventBus) error
 }

--- a/internal/types/qa_request.go
+++ b/internal/types/qa_request.go
@@ -8,6 +8,7 @@ type QARequest struct {
 	Query               string             // User query text
 	AssistantMessageID  string             // Pre-created assistant message ID
 	SummaryModelID      string             // Optional model override; empty = use agent/KB default
+	RerankModelID       string             // Optional rerank model ID or unique name; empty = tenant config / auto-detect
 	CustomAgent         *CustomAgent       // Optional custom agent for config override
 	SharedAgentReadOnly bool               // True only when access came from an agent share; source-workspace writes are forbidden
 	KnowledgeBaseIDs    []string           // Knowledge base IDs to search (from request + @mentions)

--- a/internal/types/qa_request.go
+++ b/internal/types/qa_request.go
@@ -8,7 +8,7 @@ type QARequest struct {
 	Query               string             // User query text
 	AssistantMessageID  string             // Pre-created assistant message ID
 	SummaryModelID      string             // Optional model override; empty = use agent/KB default
-	RerankModelID       string             // Optional rerank model ID or unique name; empty = tenant config / auto-detect
+	RerankModelID       string             // Optional rerank model ID or unique name; empty = agent config / tenant config / auto-detect
 	CustomAgent         *CustomAgent       // Optional custom agent for config override
 	SharedAgentReadOnly bool               // True only when access came from an agent share; source-workspace writes are forbidden
 	KnowledgeBaseIDs    []string           // Knowledge base IDs to search (from request + @mentions)


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

聊天管线（`KnowledgeQA`）此前从不解析 rerank 模型：只有 CustomAgent 显式配置才会生效，否则 `CHUNK_RERANK` 阶段被静默跳过（`empty_model_id`），context 组成退化为原始 RRF 分数排序，知识图谱结果（固定 score=1.0）无条件占据前列。`SearchKnowledge` 可以从 tenant `RetrievalConfig` 解析 rerank 模型，但聊天不能。

改动：

- `CreateKnowledgeQARequest`、`SearchKnowledgeRequest` 与 `QARequest` 新增可选的 `rerank_model_id`。
- 新增 `ResolveRerankModel`：在 active rerank 模型中按 ID 精确匹配 -> 唯一名称匹配解析，名称多义返回 400，未找到返回 403，空输入返回空串交由调用方回退。
- 新增 `resolveRerankModelID`，优先级类似 `resolveChatModelID`：request 覆盖 > Agent 配置 > tenant `RetrievalConfig` > 自动探测。
  - request/agent 值如果指定，ID 或唯一名称匹配失败时直接返回错误（名称多义 400、未找到 403），不会回退到 tenant 配置或自动探测
  - tenant 值直接采用、不做校验
  - 自动探测失败时忽略模型列表错误，rerank 阶段跳过而非整个请求失败
- `applyAgentOverridesToChatManage` 不再覆盖 `RerankModelID`：显式 request 覆盖优先于 Agent 配置（与 `summary_model_id` 一致）。
- `KnowledgeQA` 通过共享解析链 `resolveRerankModelID` 解析 rerank 模型。`SearchKnowledge` 移除内联的 tenant/自动探测代码，改用同一链。handler 与 IM `/search` 命令透传请求的 `rerank_model_id`。
- 文档：`docs/api/chat.md` 补充字段与解析顺序说明。

## Type of Change
<!-- Check applicable items -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->

新增测试：ID/唯一名称匹配、仅 active 可见、优先级顺序、tenant 值直接采用、自动探测忽略模型列表错误，`applyAgentOverridesToChatManage` 不覆盖 RerankModelID 等。

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
