### PR TITLE
fix(rerank): preserve code and math passages

### DIFF
--- a/internal/application/service/chat_pipeline/rerank.go
+++ b/internal/application/service/chat_pipeline/rerank.go
@@ -559,10 +559,10 @@ var (
 	reMarkdownLink = regexp.MustCompile(`\[([^\]]+)\]\([^()\s]*(?:\([^)]*\)[^()\s]*)*\)`)
 	// reRawURL matches standalone http(s) URLs.
 	reRawURL = regexp.MustCompile(`https?://[^\s)\]>]+`)
-	// reCodeBlock matches fenced code blocks (```...```).
-	reCodeBlock = regexp.MustCompile("(?s)```(?:\\w*)\n?.*?```")
-	// reLatexBlock matches block-level LaTeX ($$...$$).
-	reLatexBlock = regexp.MustCompile(`(?s)\$\$.*?\$\$`)
+	// reCodeBlock captures the semantic body of fenced code blocks.
+	reCodeBlock = regexp.MustCompile("(?s)```[^\\r\\n]*\\r?\\n(.*?)\\r?\\n?```")
+	// reLatexBlock captures the semantic body of block-level LaTeX ($$...$$).
+	reLatexBlock = regexp.MustCompile(`(?s)\$\$(.*?)\$\$`)
 	// reTableSep matches table separator rows like |---|---|.
 	// Uses [ \t] instead of \s to avoid consuming newlines across rows.
 	reTableSep = regexp.MustCompile(`(?m)^[ \t]*\|[ \t:|-]+\|[ \t]*$`)
@@ -589,13 +589,13 @@ var (
 
 // cleanPassageForRerank strips markdown/structural noise from text to produce
 // a clean semantic passage for the rerank model. The cleaning is designed to
-// preserve all meaningful natural-language content while removing formatting
+// preserve all meaningful semantic content while removing formatting
 // that would confuse text-similarity scoring.
 func cleanPassageForRerank(text string) string {
-	// 1. Remove code blocks (before other patterns to avoid partial matches)
-	text = reCodeBlock.ReplaceAllString(text, "")
-	// 2. Remove LaTeX block math
-	text = reLatexBlock.ReplaceAllString(text, "")
+	// 1. Unwrap code blocks so code-only candidates remain rerankable.
+	text = reCodeBlock.ReplaceAllString(text, "$1")
+	// 2. Unwrap LaTeX blocks so formula-only candidates remain rerankable.
+	text = reLatexBlock.ReplaceAllString(text, "$1")
 	// 3. Remove HTML tags
 	text = reHTMLTag.ReplaceAllString(text, "")
 	// 3.5. Unwrap nested [![alt](img_url)](link_url) → ![alt](img_url)

--- a/internal/application/service/chat_pipeline/rerank_clean_test.go
+++ b/internal/application/service/chat_pipeline/rerank_clean_test.go
@@ -29,6 +29,37 @@ func TestGetEnrichedPassageKeepsQuestionsFromEarlierRevision(t *testing.T) {
 	}
 }
 
+func TestGetEnrichedPassageKeepsCodeAndMathCandidates(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "code only",
+			content: "```go\nfunc answer() int { return 42 }\n```",
+			want:    "func answer() int { return 42 }",
+		},
+		{
+			name:    "math only",
+			content: "$$\nE = mc^2\n$$",
+			want:    "E = mc^2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			passage := getEnrichedPassage(context.Background(), &types.SearchResult{Content: tt.content})
+			if strings.TrimSpace(passage) == "" {
+				t.Fatal("semantic-only candidate was removed from the rerank passage")
+			}
+			if !strings.Contains(passage, tt.want) {
+				t.Fatalf("rerank passage %q does not preserve %q", passage, tt.want)
+			}
+		})
+	}
+}
+
 func TestCleanPassageForRerank(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -56,14 +87,14 @@ func TestCleanPassageForRerank(t *testing.T) {
 			expect: "访问  获取更多信息",
 		},
 		{
-			name:   "remove code blocks",
+			name:   "unwrap code blocks",
 			input:  "示例代码：\n```python\nprint('hello')\n```\n以上是示例",
-			expect: "示例代码：\n\n以上是示例",
+			expect: "示例代码：\nprint('hello')\n以上是示例",
 		},
 		{
-			name:   "remove LaTeX blocks",
+			name:   "unwrap LaTeX blocks",
 			input:  "公式如下 $$E=mc^2$$ 其中E是能量",
-			expect: "公式如下  其中E是能量",
+			expect: "公式如下 E=mc^2 其中E是能量",
 		},
 		{
 			name:   "remove table separator rows and convert data rows",
@@ -114,7 +145,7 @@ func TestCleanPassageForRerank(t *testing.T) {
 - 功能二
 
 ` + "```json\n{\"key\": \"value\"}\n```",
-			expect: "产品介绍\n\n这是一个 重要的 产品。详见 产品页面。\n\n用户评价：非常好用\n\n功能一\n功能二",
+			expect: "产品介绍\n\n这是一个 重要的 产品。详见 产品页面。\n\n用户评价：非常好用\n\n功能一\n功能二\n\n{\"key\": \"value\"}",
 		},
 		{
 			name:   "convert table data rows to plain text",


### PR DESCRIPTION
## Description / 描述

### English

Rerank passage cleaning removed entire fenced-code and block-LaTeX sections. Code-only or formula-only retrieval candidates therefore became empty and were skipped before reaching the rerank model.

This change removes only the Markdown delimiters while preserving the code or formula body as semantic rerank input.

### 中文

Rerank 文本清洗此前会删除完整的 fenced code 和块级 LaTeX 内容。仅包含代码或公式的召回候选因此会变成空字符串，并在调用 rerank 模型前被跳过。

本次修改只移除 Markdown 定界符，保留代码和公式正文作为 rerank 的语义输入。

## Type of Change / 变更类型

- [x] Bug fix / Bug 修复
- [x] Test / 测试

## Reproduction / 复现说明

Before this fix / 修复前：

1. Retrieve a chunk whose content is only fenced code, for example:

````text
```go
func answer() int { return 42 }
```
````

2. Or retrieve a chunk containing only block math: `$$ E = mc^2 $$`.
3. `cleanPassageForRerank` replaces the complete match with an empty string.
4. `getEnrichedPassage` returns empty, so the candidate is excluded by the `empty_passage_skip` branch.

中文复现：召回仅包含 fenced code 或 `$$...$$` 公式的 chunk；清洗函数删除完整匹配后返回空字符串，候选随后命中 `empty_passage_skip`，无法进入 rerank 模型。

Automated reproduction / 自动化复现：

```bash
go test ./internal/application/service/chat_pipeline -run TestGetEnrichedPassageKeepsCodeAndMathCandidates -count=1 -v
```

Before the implementation, both `code_only` and `math_only` failed with `semantic-only candidate was removed from the rerank passage`.

实现前，`code_only` 与 `math_only` 两个子用例都会以 `semantic-only candidate was removed from the rerank passage` 失败。

## Root Cause / 根因

The code-block and LaTeX regular expressions matched the entire block, and `ReplaceAllString(..., "")` deleted both formatting and semantic content.

代码块与 LaTeX 正则匹配了整个内容块，`ReplaceAllString(..., "")` 同时删除了格式标记和真正的语义内容。

## Fix / 修复

- Capture the inner body of fenced-code and `$$...$$` blocks.
- Replace each match with capture group `$1`, stripping only the delimiters.
- Keep all other Markdown cleanup behavior unchanged.
- Add regression coverage for code-only, math-only, mixed-code, and mixed-math passages.

- 捕获 fenced code 与 `$$...$$` 内部正文。
- 使用捕获组 `$1` 替换完整匹配，只移除定界符。
- 保持其他 Markdown 清洗行为不变。
- 增加代码-only、公式-only、混合代码及混合公式的回归覆盖。

## Testing / 测试

- [x] `go test ./internal/application/service/chat_pipeline -count=1`
- [x] `go vet ./internal/application/service/chat_pipeline`
- [x] `git diff --check main...HEAD`
- [x] Changed Go files formatted with `gofmt` / 已使用 `gofmt` 格式化
- [x] Self-reviewed the focused two-file diff / 已自审仅涉及两个文件的差异

## Documentation / 文档

No user-facing API or configuration changed, so repository documentation is not affected.

未修改用户可见 API 或配置，因此无需更新仓库文档。