### PR TITLE
fix(rerank): normalize NVIDIA logit scores

### DIFF
--- a/internal/models/rerank/nvidia_reranker.go
+++ b/internal/models/rerank/nvidia_reranker.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -41,8 +42,8 @@ type NvidiaRerankRequest struct {
 }
 
 type NvidiaRankResult struct {
-	Index          int     `json:"index"`
-	RelevanceScore float64 `json:"logit"`
+	Index int     `json:"index"`
+	Logit float64 `json:"logit"`
 }
 
 // NvidiaRerankResponse represents the response from a Jina reranking request
@@ -129,10 +130,19 @@ func (r *NvidiaReranker) Rerank(ctx context.Context, query string, documents []s
 		ret[i] = RankResult{
 			Index:          result.Index,
 			Document:       DocumentInfo{Text: documents[result.Index]},
-			RelevanceScore: result.RelevanceScore,
+			RelevanceScore: normalizeNvidiaLogit(result.Logit),
 		}
 	}
 	return ret, nil
+}
+
+// normalizeNvidiaLogit converts NVIDIA's raw reranker logit into a probability.
+func normalizeNvidiaLogit(logit float64) float64 {
+	if logit >= 0 {
+		return 1 / (1 + math.Exp(-logit))
+	}
+	expLogit := math.Exp(logit)
+	return expLogit / (1 + expLogit)
 }
 
 // GetModelName returns the name of the reranking model

--- a/internal/models/rerank/nvidia_reranker_test.go
+++ b/internal/models/rerank/nvidia_reranker_test.go
@@ -1,0 +1,49 @@
+package rerank
+
+import (
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNvidiaRerankerNormalizesLogitsToProbabilities(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"model": "nvidia-rerank-model",
+			"rankings": [
+				{"index": 0, "logit": 23.0},
+				{"index": 1, "logit": 0.0},
+				{"index": 2, "logit": -23.0}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	reranker := &NvidiaReranker{
+		modelName: "nvidia-rerank-model",
+		apiKey:    "nvapi-test",
+		baseURL:   server.URL,
+		client:    server.Client(),
+	}
+
+	results, err := reranker.Rerank(t.Context(), "query", []string{"high", "neutral", "low"})
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+
+	logits := []float64{23, 0, -23}
+	for i, logit := range logits {
+		want := 1 / (1 + math.Exp(-logit))
+		assert.InDelta(t, want, results[i].RelevanceScore, 1e-12)
+		assert.Greater(t, results[i].RelevanceScore, 0.0)
+		assert.Less(t, results[i].RelevanceScore, 1.0)
+	}
+
+	assert.Greater(t, results[0].RelevanceScore, results[1].RelevanceScore)
+	assert.Greater(t, results[1].RelevanceScore, results[2].RelevanceScore)
+}


### PR DESCRIPTION
## 中文

### 修复内容
- 将 NVIDIA reranker 响应中的原始 `logit` 映射为 `[0, 1]` 概率型 `RelevanceScore`。
- 使用数值稳定的 sigmoid 实现，避免极大正负 logit 的指数溢出。
- 新增真实 HTTP 适配器路径的回归测试，覆盖正、零、负 logit，校验范围和相对排序。

### 复现说明
1. 配置 NVIDIA rerank provider，并使接口返回多个高 `logit`，例如 `23.0`、`5.0`、`2.0`。
2. 修复前，适配器将这些原始值直接写入 `RelevanceScore`。聊天链把它们按概率型分数合成并截断到 `1`，多个候选会出现相同的最终相关性，MMR 丢失模型的排序信息。
3. 修复后，适配器在边界处执行 sigmoid 映射。`23.0`、`0.0`、`-23.0` 分别转换为接近 `1`、`0.5`、`0` 的值，仍保留严格的相对顺序。
NVIDIA 响应里的字段明确叫 logit，但代码直接映射到 RelevanceScore：[nvidia_reranker.go (line 42)]
随后不做转换地复制给公共结果：[nvidia_reranker.go (line 126)
聊天 pipeline 再把它代入：
composite := 0.6*modelScore + 0.3*baseScore + 0.1*sourceWeight
然后强制限制到 [0,1]：[rerank.go (line 439)。
假设原始召回分数 baseScore=0.5、普通知识库来源权重为 1：
logit = 23  → 0.6×23 + 0.3×0.5 + 0.1 = 14.05 → 截断为 1
logit = 5   → 0.6×5  + 0.3×0.5 + 0.1 =  3.25 → 截断为 1
logit = 2   → 0.6×2  + 0.3×0.5 + 0.1 =  1.45 → 截断为 1
logit = -23 →                              -13.55 → 截断为 0
原来 23 > 5 > 2，进入 MMR 后却全是 1。

### 验证
- [x] `go test ./internal/models/rerank ./internal/application/service/chat_pipeline -count=1`
- [x] `go vet ./internal/models/rerank`

未修改仓库文档。

## English

### Fix
- Map the raw NVIDIA reranker `logit` response field to a probability-like `[0, 1]` `RelevanceScore`.
- Use a numerically stable sigmoid implementation to avoid exponential overflow for extreme logits.
- Add an adapter-level regression test through a real HTTP path, covering positive, zero, and negative logits, score range, and order preservation.

### Reproduction
1. Configure the NVIDIA rerank provider and return several high `logit` values, for example `23.0`, `5.0`, and `2.0`.
2. Before this change, the adapter copied those raw values into `RelevanceScore`. The chat pipeline then combined them as probability-like scores and capped them at `1`, giving multiple candidates the same final relevance and causing MMR to lose the model ranking signal.
3. With this change, the adapter applies sigmoid at the provider boundary. `23.0`, `0.0`, and `-23.0` become values near `1`, `0.5`, and `0`, respectively, while preserving strict relative order.

### Verification
- [x] `go test ./internal/models/rerank ./internal/application/service/chat_pipeline -count=1`
- [x] `go vet ./internal/models/rerank`

No repository documentation was changed.

## Checklist
- [x] `git diff --check upstream/main...HEAD`
- [x] Changed Go files are formatted
- [x] Targeted tests for affected packages pass
- [x] Self-reviewed the change
- [x] Added regression coverage
