### PR TITLE
fix(chat): keep attachment upload status reactive

### DIFF
--- a/frontend/src/components/AttachmentUpload.vue
+++ b/frontend/src/components/AttachmentUpload.vue
@@ -124,9 +124,13 @@ const addFiles = async (files: File[]) => {
     };
 
     attachments.value.push(attachment);
+    // Vue wraps objects inserted into a ref-backed array with a reactive proxy.
+    // Keep using that proxy in async upload/poll callbacks; mutating the raw
+    // object above does not trigger the attachment status UI to re-render.
+    const reactiveAttachment = attachments.value[attachments.value.length - 1];
     emit('update:files', [...attachments.value]);
     if (props.sessionId) {
-      void uploadAttachment(attachment);
+      void uploadAttachment(reactiveAttachment);
     }
   }
 };


### PR DESCRIPTION
## Description

Fix attachment uploads that remain visually stuck at `Uploading 0%` even after the upload and document parsing complete.

Vue stores objects inserted into a ref-backed array behind reactive proxies. The upload callback previously retained and mutated the raw object created before insertion, so changes to `progress`, `status`, and `error` did not trigger the component UI to re-render.

This change passes the array's reactive attachment object to the asynchronous upload and polling flow.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

No existing issue.

## Testing

- `npm test` — 290 tests passed
- `npm run type-check` — passed
- `npm run build` — passed
- Manually verified against a deployed internal environment:
  1. Upload a Markdown attachment in an existing web chat session.
  2. Confirm upload progress and parsing status update in the UI.
  3. Confirm the attachment reaches `ready` instead of remaining at `Uploading 0%`.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository frontend checks were run
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change — the repository does not currently provide a Vue component mount test environment; existing frontend tests and deployed manual verification cover this focused change
- [x] Updated related documentation — not applicable
- [x] Breaking changes are clearly called out — none

## Screenshots / Recordings

Not included because the reproduction environment is internal. The visible result is that the attachment status advances from upload progress to parsing and then ready.