### PR TITLE
fix: count skipped stages in parsing progress

### DIFF
--- a/frontend/src/components/knowledge-processing-timeline.test.ts
+++ b/frontend/src/components/knowledge-processing-timeline.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const source = readFileSync(join(here, 'knowledge-processing-timeline.vue'), 'utf8')
+
+test('counts skipped stages when determining the current stage', () => {
+  const currentStageIndex = source.slice(
+    source.indexOf('const currentStageIndex'),
+    source.indexOf('function formatDuration'),
+  )
+
+  assert.match(currentStageIndex, /status === 'done' \|\| s\.status === 'skipped'/)
+  assert.match(currentStageIndex, /Math\.min\(traversed \+ 1, stages\.value\.length\)/)
+})
+
+test('counts skipped stages in the completed stage total', () => {
+  const stagesStatDisplay = source.slice(
+    source.indexOf('const stagesStatDisplay'),
+    source.indexOf('const postprocessTaskStats'),
+  )
+
+  assert.match(stagesStatDisplay, /status === 'done' \|\| s\.status === 'skipped'/)
+  assert.match(stagesStatDisplay, /value: `\$\{completedCount\}\/\$\{total\}`/)
+})

--- a/frontend/src/components/knowledge-processing-timeline.vue
+++ b/frontend/src/components/knowledge-processing-timeline.vue
@@ -167,8 +167,10 @@ const currentStageLabel = computed(() => {
 const currentStageIndex = computed(() => {
   const idx = stages.value.findIndex((s) => s.status === 'running' || s.status === 'failed')
   if (idx >= 0) return idx + 1
-  const done = stages.value.filter((s) => s.status === 'done').length
-  return Math.min(done + 1, stages.value.length)
+  const traversed = stages.value.filter(
+    (s) => s.status === 'done' || s.status === 'skipped',
+  ).length
+  return Math.min(traversed + 1, stages.value.length)
 })
 
 function formatDuration(ms?: number): string {
@@ -1182,7 +1184,9 @@ const showLastError = computed(() =>
 
 const stagesStatDisplay = computed(() => {
   const total = stages.value.length
-  const doneCount = stages.value.filter((s) => s.status === 'done').length
+  const completedCount = stages.value.filter(
+    (s) => s.status === 'done' || s.status === 'skipped',
+  ).length
   const inProgress = stages.value.some(
     (s) => s.status === 'running' || s.status === 'failed' || s.status === 'pending',
   )
@@ -1194,7 +1198,7 @@ const stagesStatDisplay = computed(() => {
   }
   return {
     label: t('knowledgeStages.head.stagesDone'),
-    value: `${doneCount}/${total}`,
+    value: `${completedCount}/${total}`,
   }
 })
 


### PR DESCRIPTION
## Description

修复文件解析主流程阶段数字未计入 `skipped` 状态的问题。

### 问题

解析进度使用“当前阶段”口径，但原来的后备计算只统计 `done + 1`。

当中间阶段因为不适用而变成 `skipped` 时，当前阶段数字会少算；流程结束后的阶段总数也只统计 `done`，可能无法正确显示为 `5/5`。

### 根因

进行过程中和流程结束后的两处统计都遗漏了 `skipped` 状态。

### 修改内容

- 进行过程中改为使用 `done + skipped + 1` 计算当前阶段。
- 当前阶段数字继续限制为不超过阶段总数。
- 流程结束后改为使用 `done + skipped` 计算已处理阶段总数。
- 保留 `running` 和 `failed` 阶段的优先定位逻辑。
- 保留“当前阶段”文案，不修改界面布局或样式。
- 增加回归测试，覆盖进行中和流程结束后的两处统计规则。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

已完成：

- `git diff --check`
- 静态检查进行过程中使用 `done + skipped + 1`
- 静态检查流程结束后使用 `done + skipped`
- 增加对应回归测试
- 前端单元测试
- 前端类型检查

## Checklist

- [x] `make fmt && make lint && make test` pass locally
- [ ] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above
