### PR TITLE
fix(rerank): batch LKEAP requests within API limits

### DIFF
--- a/internal/models/rerank/lkeap_reranker.go
+++ b/internal/models/rerank/lkeap_reranker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
@@ -12,6 +13,10 @@ import (
 )
 
 const (
+	// LKEAPMaxDocumentsPerRequest is the maximum number of documents accepted by RunRerank.
+	LKEAPMaxDocumentsPerRequest = 60
+	// LKEAPMaxRequestCharacters is the maximum combined length of Query and Docs accepted by RunRerank.
+	LKEAPMaxRequestCharacters = 2000
 	// LKEAPRerankEndpoint 腾讯云知识引擎原子能力 Rerank API 域名
 	LKEAPRerankEndpoint = "lkeap.tencentcloudapi.com"
 	// LKEAPDefaultRegion RunRerank 支持的地域，默认广州
@@ -72,10 +77,62 @@ func (r *LKEAPReranker) Rerank(ctx context.Context, query string, documents []st
 	if len(documents) == 0 {
 		return []RankResult{}, nil
 	}
-	if len(documents) > 60 {
-		return nil, fmt.Errorf("LKEAP rerank supports at most 60 documents, got %d", len(documents))
+
+	batches, err := lkeapRerankBatches(query, documents)
+	if err != nil {
+		return nil, err
 	}
 
+	results := make([]RankResult, 0, len(documents))
+	for _, batch := range batches {
+		batchResults, err := r.rerankBatch(ctx, query, batch.documents)
+		if err != nil {
+			return nil, err
+		}
+		for i := range batchResults {
+			batchResults[i].Index += batch.start
+		}
+		results = append(results, batchResults...)
+	}
+	return results, nil
+}
+
+type lkeapRerankBatch struct {
+	start     int
+	documents []string
+}
+
+func lkeapRerankBatches(query string, documents []string) ([]lkeapRerankBatch, error) {
+	queryLength := utf8.RuneCountInString(query)
+	if queryLength >= LKEAPMaxRequestCharacters {
+		return nil, fmt.Errorf("LKEAP rerank query is %d characters; Query and Docs together support at most %d characters", queryLength, LKEAPMaxRequestCharacters)
+	}
+
+	batches := make([]lkeapRerankBatch, 0, (len(documents)+LKEAPMaxDocumentsPerRequest-1)/LKEAPMaxDocumentsPerRequest)
+	batchStart := 0
+	batchLength := queryLength
+	batchDocuments := make([]string, 0, LKEAPMaxDocumentsPerRequest)
+	for index, document := range documents {
+		documentLength := utf8.RuneCountInString(document)
+		if queryLength+documentLength > LKEAPMaxRequestCharacters {
+			return nil, fmt.Errorf("LKEAP rerank document at index %d is %d characters; Query and each document together support at most %d characters", index, documentLength, LKEAPMaxRequestCharacters)
+		}
+		if len(batchDocuments) == LKEAPMaxDocumentsPerRequest || batchLength+documentLength > LKEAPMaxRequestCharacters {
+			batches = append(batches, lkeapRerankBatch{start: batchStart, documents: batchDocuments})
+			batchStart = index
+			batchLength = queryLength
+			batchDocuments = make([]string, 0, LKEAPMaxDocumentsPerRequest)
+		}
+		batchDocuments = append(batchDocuments, document)
+		batchLength += documentLength
+	}
+	if len(batchDocuments) > 0 {
+		batches = append(batches, lkeapRerankBatch{start: batchStart, documents: batchDocuments})
+	}
+	return batches, nil
+}
+
+func (r *LKEAPReranker) rerankBatch(ctx context.Context, query string, documents []string) ([]RankResult, error) {
 	req := lkeap.NewRunRerankRequest()
 	req.Query = common.StringPtr(query)
 	req.Docs = common.StringPtrs(documents)

--- a/internal/models/rerank/lkeap_reranker_test.go
+++ b/internal/models/rerank/lkeap_reranker_test.go
@@ -1,10 +1,19 @@
 package rerank
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"
+	lkeap "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/lkeap/v20240522"
 )
 
 func TestNewLKEAPReranker_requiresCredentials(t *testing.T) {
@@ -50,18 +59,120 @@ func TestLKEAPReranker_Rerank_emptyDocuments(t *testing.T) {
 	assert.Empty(t, results)
 }
 
-func TestLKEAPReranker_Rerank_tooManyDocuments(t *testing.T) {
-	r, err := NewLKEAPReranker(&RerankerConfig{
-		APIKey:    "AKIDtest",
-		AppSecret: "sk-test",
-	})
+func TestLKEAPReranker_Rerank_batchesMoreThan60Documents(t *testing.T) {
+	var batches [][]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var request struct {
+			Docs []string `json:"Docs"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		batches = append(batches, request.Docs)
+
+		scores := make([]float64, len(request.Docs))
+		for i, doc := range request.Docs {
+			index, err := lkeapTestDocumentIndex(doc)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			scores[i] = float64(index)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Response": map[string]any{
+				"ScoreList": scores,
+				"RequestId": "test-request",
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := newTestLKEAPReranker(t, server.URL)
+	documents := make([]string, 61)
+	for i := range documents {
+		documents[i] = strconv.Itoa(i) + ":document"
+	}
+
+	results, err := r.Rerank(t.Context(), "query", documents)
+	require.NoError(t, err)
+	require.Len(t, results, len(documents))
+	require.Len(t, batches, 2)
+	assert.Len(t, batches[0], 60)
+	assert.Len(t, batches[1], 1)
+	for i, result := range results {
+		assert.Equal(t, i, result.Index)
+		assert.Equal(t, documents[i], result.Document.Text)
+		assert.Equal(t, float64(i), result.RelevanceScore)
+	}
+}
+
+func TestLKEAPReranker_Rerank_batchesWithinCharacterLimit(t *testing.T) {
+	var batches [][]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var request struct {
+			Docs []string `json:"Docs"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		batches = append(batches, request.Docs)
+
+		scores := make([]float64, len(request.Docs))
+		for i, doc := range request.Docs {
+			index, err := lkeapTestDocumentIndex(doc)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			scores[i] = float64(index)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Response": map[string]any{
+				"ScoreList": scores,
+				"RequestId": "test-request",
+			},
+		})
+	}))
+	defer server.Close()
+
+	r := newTestLKEAPReranker(t, server.URL)
+	documents := []string{
+		"0:" + strings.Repeat("a", 1000),
+		"1:" + strings.Repeat("b", 1000),
+		"2:" + strings.Repeat("c", 1000),
+	}
+
+	results, err := r.Rerank(t.Context(), "query", documents)
+	require.NoError(t, err)
+	require.Len(t, results, len(documents))
+	require.Len(t, batches, 3)
+	for i, batch := range batches {
+		assert.Len(t, batch, 1)
+		assert.Equal(t, documents[i], batch[0])
+	}
+}
+
+func newTestLKEAPReranker(t *testing.T, serverURL string) *LKEAPReranker {
+	t.Helper()
+	endpoint, err := url.Parse(serverURL)
 	require.NoError(t, err)
 
-	docs := make([]string, 61)
-	for i := range docs {
-		docs[i] = "doc"
+	clientProfile := profile.NewClientProfile()
+	clientProfile.HttpProfile.Endpoint = endpoint.Host
+	clientProfile.HttpProfile.Scheme = "HTTP"
+	client, err := lkeap.NewClient(common.NewCredential("AKIDtest", "sk-test"), LKEAPDefaultRegion, clientProfile)
+	require.NoError(t, err)
+
+	return &LKEAPReranker{
+		modelName: LKEAPDefaultRerankModel,
+		client:    client,
 	}
-	_, err = r.Rerank(t.Context(), "query", docs)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "60")
+}
+
+func lkeapTestDocumentIndex(document string) (int, error) {
+	value, _, _ := strings.Cut(document, ":")
+	return strconv.Atoi(value)
 }


### PR DESCRIPTION
## Description / 描述

English:
Fix LKEAP reranking when retrieval returns more than 60 candidates. The LKEAP `RunRerank` API has hard per-request limits of 60 documents and 2,000 combined characters for `Query + Docs`; increasing the local limit to 100 alone would still cause API failures.

中文：
修复 LKEAP 在召回候选超过 60 条时无法重排的问题。LKEAP `RunRerank` API 对单次请求有硬限制：最多 60 条文档，且 `Query + Docs` 总长度最多 2,000 字符；仅将本地限制改为 100 仍会导致 API 调用失败。

## Changes / 变更

- Batch LKEAP rerank requests by both document count and character budget.
- Preserve original global document indices when merging batch results.
- Return clear errors when a query or an individual document cannot fit within the API character limit.
- Add regression coverage for:
  - 61 candidates split into `60 + 1` requests.
  - Candidate sets below 60 that exceed the 2,000-character request limit.

- 同时按文档数量和字符预算拆分 LKEAP 重排请求。
- 合并批次结果时保留原始全局文档索引。
- 当 query 或单篇文档本身无法满足 API 字符限制时返回明确错误。
- 增加 61 条候选和字符超限场景的回归测试。

## Reproduction / 复现

Before:
1. Configure an LKEAP rerank model.
2. Set `embedding_top_k` to any value from 61 to 100.
3. Run chat retrieval or message search with more than 60 candidates.
4. The provider returns `LKEAP rerank supports at most 60 documents`, and callers fall back to the original retrieval order.

After:
1. The same 61-100 candidates are split into valid LKEAP requests.
2. Rerank scores and original candidate indices are merged correctly.
3. Chat retrieval and message search can use reranked results instead of falling back solely because of the request-size limit.

修复前：
1. 配置 LKEAP rerank 模型。
2. 将 `embedding_top_k` 设置为 61 至 100。
3. 聊天检索或消息搜索产生超过 60 条候选。
4. Provider 返回 `LKEAP rerank supports at most 60 documents`，调用链退化为原始召回顺序。

修复后：
1. 61-100 条候选会被拆分为符合 LKEAP 限制的请求。
2. 各批次的重排分数和原始候选索引会正确合并。
3. 聊天检索和消息搜索不再因请求大小限制而退化为未重排结果。

## Testing / 验证

```bash
go test ./internal/models/rerank ./internal/application/service/chat_pipeline -count=1
go vet ./internal/models/rerank
git diff --check upstream/main...HEAD
