### PR TITLE
fix: exclude archived wiki pages from lint cursor

### DIFF
--- a/internal/application/repository/wiki_page.go
+++ b/internal/application/repository/wiki_page.go
@@ -950,7 +950,7 @@ func (r *wikiPageRepository) ListPagesCursor(
 		limit = 500
 	}
 	q := r.db.WithContext(ctx).
-		Where("knowledge_base_id = ?", kbID).
+		Where("knowledge_base_id = ? AND status <> ?", kbID, types.WikiPageStatusArchived).
 		Order("id ASC").
 		Limit(limit)
 	if cursor != "" {

--- a/internal/application/repository/wiki_page_test.go
+++ b/internal/application/repository/wiki_page_test.go
@@ -340,6 +340,45 @@ func TestListByTypeLight_EmptyType_ReturnsZero(t *testing.T) {
 	assert.Empty(t, entries)
 }
 
+func TestListPagesCursorExcludesArchivedPages(t *testing.T) {
+	db := setupWikiPagesTestDB(t)
+	repo := NewWikiPageRepository(db)
+	ctx := context.Background()
+
+	mk := func(id, slug, status string) *types.WikiPage {
+		page := makeWikiPage("kb-lint", slug, types.WikiPageTypeConcept, status)
+		page.ID = id
+		return page
+	}
+	pages := []*types.WikiPage{
+		mk("001", "concept/live-a", types.WikiPageStatusPublished),
+		mk("002", "concept/archived", types.WikiPageStatusArchived),
+		mk("003", "concept/live-b", types.WikiPageStatusDraft),
+		mk("004", "concept/other-kb", types.WikiPageStatusPublished),
+	}
+	pages[3].KnowledgeBaseID = "kb-other"
+	for _, p := range pages {
+		require.NoError(t, repo.Create(ctx, p))
+	}
+
+	first, next, err := repo.ListPagesCursor(ctx, "kb-lint", "", 1)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	assert.Equal(t, "concept/live-a", first[0].Slug)
+	assert.Equal(t, "001", next)
+
+	second, next, err := repo.ListPagesCursor(ctx, "kb-lint", next, 1)
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	assert.Equal(t, "concept/live-b", second[0].Slug)
+	assert.Equal(t, "003", next)
+
+	third, next, err := repo.ListPagesCursor(ctx, "kb-lint", next, 1)
+	require.NoError(t, err)
+	assert.Empty(t, third)
+	assert.Empty(t, next)
+}
+
 // TestListByTypeLight_ClampsLimit verifies the [1, 200] clamp. We don't
 // want a client passing limit=100000 and forcing the DB to return a
 // multi-MB response.


### PR DESCRIPTION
## Description
Fixes the wiki lint cursor scan so archived wiki pages are excluded before RunLint checks empty content, broken links, stale refs, and missing cross references. This prevents pages already archived by AutoFix from being re-flagged and counted again on subsequent lint/auto-fix cycles.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #2444

## Testing
- `git diff --check upstream/main...HEAD`
- `go test ./internal/application/repository -run "TestListPagesCursorExcludesArchivedPages|TestListByTypeLight" -count=1`
- `go test ./internal/application/service -run "WikiLint|WikiPage|PruneEmptyFolder|StripWikiInline" -count=1`

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
N/A - backend repository behavior only.