### PR TITLE
fix: retry document summaries before fallback

### DIFF
--- a/internal/application/service/image_multimodal.go
+++ b/internal/application/service/image_multimodal.go
@@ -401,7 +401,7 @@ func (s *ImageMultimodalService) shouldDropOrphanedMultimodal(
 }
 
 // isFinalAsynqAttempt reports whether the current task context belongs to the
-// last retry attempt before asynq archives the task as a dead-letter. We use
+// last retry attempt before Asynq (or the Lite executor) archives the task. We use
 // this to flip multimodal finalize semantics: during normal retries we skip
 // counter decrement (the retry might still succeed), but on the final attempt
 // we count the image regardless of outcome so a permanently-failing image
@@ -412,14 +412,14 @@ func (s *ImageMultimodalService) shouldDropOrphanedMultimodal(
 // "not final" keeps test ergonomics — tests should drive finalize explicitly.
 func isFinalAsynqAttempt(ctx context.Context) bool {
 	retried, ok := asynq.GetRetryCount(ctx)
-	if !ok {
-		return false
+	if ok {
+		maxRetry, maxRetryOK := asynq.GetMaxRetry(ctx)
+		if maxRetryOK {
+			return retried >= maxRetry
+		}
 	}
-	maxRetry, ok := asynq.GetMaxRetry(ctx)
-	if !ok {
-		return false
-	}
-	return retried >= maxRetry
+	retried, maxRetry, ok := types.TaskRetryMetadataFromContext(ctx)
+	return ok && retried >= maxRetry
 }
 
 // indexChunks indexes the newly created multimodal chunks into the retrieval engine

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -712,7 +712,70 @@ const imageDominatedTextThreshold = 200
 // (typical for scanned PDFs where VLM OCR yielded nothing). Callers should
 // mark the knowledge's summary as failed instead of falling back to the first
 // chunk's raw content (which would just be a bare image reference).
-var errInsufficientSummaryContent = errors.New("insufficient text content for summary generation")
+var (
+	errInsufficientSummaryContent = errors.New("insufficient text content for summary generation")
+	errEmptySummaryOutput         = errors.New("summary model returned empty output")
+)
+
+const summaryFallbackMaxRunes = 500
+
+// validateSummaryOutput rejects successful model responses that contain no
+// user-visible text. Treating whitespace-only output as an error lets Asynq
+// retry the summary task instead of persisting description="" as completed.
+func validateSummaryOutput(response *types.ChatResponse) (string, error) {
+	if response == nil {
+		return "", errEmptySummaryOutput
+	}
+	content := strings.TrimSpace(response.Content)
+	if content == "" {
+		return "", errEmptySummaryOutput
+	}
+	return content, nil
+}
+
+// firstTextChunkSummaryFallback preserves the existing deterministic fallback:
+// use the first already-ordered text chunk and cap it by runes so Chinese and
+// emoji are never cut in the middle of a UTF-8 sequence.
+func firstTextChunkSummaryFallback(textChunks []*types.Chunk) string {
+	if len(textChunks) == 0 || textChunks[0] == nil {
+		return ""
+	}
+	fallback := strings.TrimSpace(textChunks[0].Content)
+	runes := []rune(fallback)
+	if len(runes) > summaryFallbackMaxRunes {
+		fallback = string(runes[:summaryFallbackMaxRunes])
+	}
+	return fallback
+}
+
+// applyRetryableSummaryFailureState keeps an existing description visible
+// while another attempt is queued, then publishes the deterministic fallback
+// and marks only the summary subtask failed after the retry budget is exhausted.
+func applyRetryableSummaryFailureState(
+	knowledge *types.Knowledge, textChunks []*types.Chunk, willRetry bool,
+) string {
+	knowledge.UpdatedAt = time.Now()
+	if willRetry {
+		knowledge.SummaryStatus = types.SummaryStatusPending
+		return ""
+	}
+	fallback := firstTextChunkSummaryFallback(textChunks)
+	knowledge.Description = fallback
+	knowledge.SummaryStatus = types.SummaryStatusFailed
+	return fallback
+}
+
+// summaryTaskWillRetry reports whether the current Asynq delivery has another
+// configured attempt remaining. Calls outside an Asynq worker are terminal.
+func summaryTaskWillRetry(ctx context.Context) bool {
+	retried, retryOK := asynq.GetRetryCount(ctx)
+	maxRetry, maxRetryOK := asynq.GetMaxRetry(ctx)
+	if retryOK && maxRetryOK {
+		return retried < maxRetry
+	}
+	retried, maxRetry, ok := types.TaskRetryMetadataFromContext(ctx)
+	return ok && retried < maxRetry
+}
 
 // checkSufficientSummaryContent returns errInsufficientSummaryContent if the
 // given content does not carry enough real text (after stripping image markup)
@@ -891,8 +954,13 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 		logger.GetLogger(ctx).WithField("error", err).Errorf("GetSummary failed")
 		return "", err
 	}
-	logger.GetLogger(ctx).WithField("summary", summary.Content).Infof("GetSummary success")
-	return summary.Content, nil
+	content, err := validateSummaryOutput(summary)
+	if err != nil {
+		logger.GetLogger(ctx).WithField("error", err).Warnf("GetSummary returned no usable content")
+		return "", err
+	}
+	logger.GetLogger(ctx).WithField("summary", content).Infof("GetSummary success")
+	return content, nil
 }
 
 // sampleLongContent returns content that fits within maxChars.
@@ -975,7 +1043,10 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 				return nil
 			}
 			logger.Warnf(ctx, "Summary refresh failed for knowledge %s: %v", payload.KnowledgeID, err)
-			_ = s.repo.UpdateKnowledgeColumn(ctx, payload.KnowledgeID, "summary_status", types.SummaryStatusFailed)
+			if errors.Is(err, errInsufficientSummaryContent) {
+				return nil
+			}
+			return err
 		}
 		return nil
 	}
@@ -1087,8 +1158,8 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 
 	if len(textChunks) == 0 {
 		logger.Infof(ctx, "No text chunks found for knowledge: %s", payload.KnowledgeID)
-		// Mark as completed since there's nothing to summarize
-		knowledge.SummaryStatus = types.SummaryStatusCompleted
+		knowledge.Description = ""
+		knowledge.SummaryStatus = types.SummaryStatusFailed
 		knowledge.UpdatedAt = time.Now()
 		s.repo.UpdateKnowledge(ctx, knowledge)
 		summaryOut["skipped"] = "no_text_chunks"
@@ -1100,17 +1171,64 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 		return textChunks[i].ChunkIndex < textChunks[j].ChunkIndex
 	})
 
-	// Initialize chat model for summary
+	summaryMetadataVersion := string(knowledge.CustomMetadata)
+	handleRetryableSummaryFailure := func(generationErr error) error {
+		summaryErr = generationErr
+		summaryOut["error"] = previewText(generationErr.Error(), 500)
+		summaryOut["error_type"] = fmt.Sprintf("%T", generationErr)
+
+		if summaryTaskWillRetry(ctx) {
+			applyRetryableSummaryFailureState(knowledge, textChunks, true)
+			if updateErr := s.repo.UpdateKnowledge(ctx, knowledge); updateErr != nil {
+				logger.Warnf(ctx, "Failed to mark summary pending for retry: %v", updateErr)
+			}
+			summaryOut["retrying"] = true
+			return fmt.Errorf("summary generation attempt failed: %w", generationErr)
+		}
+
+		// Before publishing the terminal fallback, make sure its source still
+		// matches the chunks and metadata captured for this attempt.
+		stale, staleErr := summarySourceChanged(
+			ctx, s.repo, s.chunkRepo, payload.TenantID, payload.KnowledgeID,
+			summaryMetadataVersion, textChunks,
+		)
+		if staleErr != nil {
+			logger.Errorf(ctx, "Failed to verify summary fallback freshness for knowledge %s: %v",
+				payload.KnowledgeID, staleErr)
+			markSummaryFailed()
+			summaryErr = staleErr
+			return fmt.Errorf("verify summary fallback freshness: %w", staleErr)
+		}
+		if stale {
+			logger.Infof(ctx, "Discarding stale summary fallback for knowledge %s", payload.KnowledgeID)
+			summaryOut["skipped"] = "content_revision_changed"
+			return nil
+		}
+
+		fallback := applyRetryableSummaryFailureState(knowledge, textChunks, false)
+		if updateErr := s.repo.UpdateKnowledge(ctx, knowledge); updateErr != nil {
+			logger.Errorf(ctx, "Failed to save terminal summary fallback: %v", updateErr)
+			summaryErr = updateErr
+			return fmt.Errorf("save terminal summary fallback: %w", updateErr)
+		}
+		if fallback == "" {
+			summaryOut["fallback"] = "empty"
+		} else {
+			summaryOut["fallback"] = "first_chunk"
+		}
+		summaryOut["fallback_chars"] = len([]rune(fallback))
+		return fmt.Errorf("summary generation exhausted retries: %w", generationErr)
+	}
+
+	// Initialize chat model for summary. Model resolution failures use the same
+	// retry budget and terminal first-chunk fallback as LLM request failures.
 	chatModel, err := s.modelService.GetChatModel(ctx, kb.SummaryModelID)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to get chat model: %v", err)
-		markSummaryFailed()
-		summaryErr = err
-		return fmt.Errorf("failed to get chat model: %w", err)
+		return handleRetryableSummaryFailure(fmt.Errorf("get chat model: %w", err))
 	}
 
 	// Generate summary
-	summaryMetadataVersion := string(knowledge.CustomMetadata)
 	summary, err := s.getSummary(ctx, chatModel, knowledge, textChunks)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to generate summary for knowledge %s: %v", payload.KnowledgeID, err)
@@ -1138,17 +1256,7 @@ func (s *knowledgeService) ProcessSummaryGeneration(ctx context.Context, t *asyn
 			summaryErr = err
 			return nil
 		}
-		// For other errors (LLM API issues etc.), fall back to the first chunk.
-		if len(textChunks) > 0 {
-			summary = textChunks[0].Content
-			if len(summary) > 500 {
-				runes := []rune(summary)
-				if len(runes) > 500 {
-					summary = string(runes[:500])
-				}
-			}
-			summaryOut["fallback"] = "first_chunk"
-		}
+		return handleRetryableSummaryFailure(err)
 	}
 	// Do not publish an answer derived from a superseded chunk or metadata
 	// version. A user can explicitly refresh again from the latest revision.
@@ -2177,22 +2285,66 @@ func (s *knowledgeService) RegenerateKnowledgeSummary(
 		}
 	}
 	if len(textChunks) == 0 {
-		return nil, fmt.Errorf("no enabled text chunks to summarize")
+		knowledge.Description = ""
+		knowledge.SummaryStatus = types.SummaryStatusFailed
+		knowledge.UpdatedAt = time.Now()
+		if updateErr := s.repo.UpdateKnowledge(ctx, knowledge); updateErr != nil {
+			return knowledge, updateErr
+		}
+		return knowledge, errInsufficientSummaryContent
 	}
-	chatModel, err := s.modelService.GetChatModel(ctx, kb.SummaryModelID)
-	if err != nil {
-		return nil, err
-	}
+	sort.Slice(textChunks, func(i, j int) bool {
+		return textChunks[i].ChunkIndex < textChunks[j].ChunkIndex
+	})
 	metadataVersion := string(knowledge.CustomMetadata)
 	knowledge.SummaryStatus = types.SummaryStatusProcessing
 	if err := s.repo.UpdateKnowledge(ctx, knowledge); err != nil {
 		return nil, err
 	}
+	handleGenerationFailure := func(generationErr error) (*types.Knowledge, error) {
+		if errors.Is(generationErr, errInsufficientSummaryContent) {
+			knowledge.Description = ""
+			knowledge.SummaryStatus = types.SummaryStatusFailed
+			knowledge.UpdatedAt = time.Now()
+			if updateErr := s.repo.UpdateKnowledge(ctx, knowledge); updateErr != nil {
+				return knowledge, updateErr
+			}
+			return knowledge, generationErr
+		}
+		if summaryTaskWillRetry(ctx) {
+			applyRetryableSummaryFailureState(knowledge, textChunks, true)
+			if updateErr := s.repo.UpdateKnowledge(ctx, knowledge); updateErr != nil {
+				logger.Warnf(ctx, "Failed to mark summary refresh pending for retry: %v", updateErr)
+			}
+			return knowledge, generationErr
+		}
+
+		stale, staleErr := summarySourceChanged(
+			ctx, s.repo, s.chunkRepo, tenantID, knowledgeID, metadataVersion, textChunks,
+		)
+		if staleErr != nil {
+			knowledge.SummaryStatus = types.SummaryStatusFailed
+			_ = s.repo.UpdateKnowledge(ctx, knowledge)
+			return knowledge, fmt.Errorf("verify summary fallback freshness: %w", staleErr)
+		}
+		if stale {
+			return knowledge, ErrSummaryRefreshStale
+		}
+
+		applyRetryableSummaryFailureState(knowledge, textChunks, false)
+		if updateErr := s.repo.UpdateKnowledge(ctx, knowledge); updateErr != nil {
+			return knowledge, updateErr
+		}
+		return knowledge, generationErr
+	}
+
+	chatModel, err := s.modelService.GetChatModel(ctx, kb.SummaryModelID)
+	if err != nil {
+		return handleGenerationFailure(fmt.Errorf("get chat model: %w", err))
+	}
 	summary, err := s.getSummary(ctx, chatModel, knowledge, textChunks)
 	if err != nil {
-		knowledge.SummaryStatus = types.SummaryStatusFailed
-		_ = s.repo.UpdateKnowledge(ctx, knowledge)
-		return nil, err
+		return handleGenerationFailure(err)
 	}
 	stale, err := summarySourceChanged(
 		ctx, s.repo, s.chunkRepo, tenantID, knowledgeID, metadataVersion, textChunks,

--- a/internal/application/service/knowledge_summary_test.go
+++ b/internal/application/service/knowledge_summary_test.go
@@ -3,7 +3,10 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
 )
 
 // TestCheckSufficientSummaryContent verifies the gate that prevents getSummary
@@ -41,8 +44,8 @@ func TestCheckSufficientSummaryContent(t *testing.T) {
 			wantError: true,
 		},
 		{
-			name: "scanned PDF with empty <image> wrapper rejected",
-			content: `<image url="x"><image_original>![a](x)</image_original></image>`,
+			name:      "scanned PDF with empty <image> wrapper rejected",
+			content:   `<image url="x"><image_original>![a](x)</image_original></image>`,
 			wantError: true,
 		},
 		{
@@ -101,5 +104,138 @@ func TestCheckSufficientSummaryContent_ThresholdOverride(t *testing.T) {
 	err := checkSufficientSummaryContent(ctx, "kid", content)
 	if !errors.Is(err, errInsufficientSummaryContent) {
 		t.Fatalf("tightened threshold: expected errInsufficientSummaryContent, got %v", err)
+	}
+}
+
+func TestValidateSummaryOutput(t *testing.T) {
+	tests := []struct {
+		name      string
+		response  *types.ChatResponse
+		want      string
+		wantError bool
+	}{
+		{name: "nil response rejected", response: nil, wantError: true},
+		{name: "empty response rejected", response: &types.ChatResponse{}, wantError: true},
+		{
+			name:      "whitespace response rejected",
+			response:  &types.ChatResponse{Content: " \n\t "},
+			wantError: true,
+		},
+		{
+			name:     "valid response is trimmed",
+			response: &types.ChatResponse{Content: "  useful summary \n"},
+			want:     "useful summary",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateSummaryOutput(tt.response)
+			if tt.wantError {
+				if !errors.Is(err, errEmptySummaryOutput) {
+					t.Fatalf("expected errEmptySummaryOutput, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("summary = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFirstTextChunkSummaryFallback(t *testing.T) {
+	t.Run("uses only the first chunk", func(t *testing.T) {
+		got := firstTextChunkSummaryFallback([]*types.Chunk{
+			{Content: "  first chunk  "},
+			{Content: "second chunk"},
+		})
+		if got != "first chunk" {
+			t.Fatalf("fallback = %q, want first chunk", got)
+		}
+	})
+
+	t.Run("does not skip an empty first chunk", func(t *testing.T) {
+		got := firstTextChunkSummaryFallback([]*types.Chunk{
+			{Content: " \n\t "},
+			{Content: "second chunk"},
+		})
+		if got != "" {
+			t.Fatalf("fallback = %q, want empty", got)
+		}
+	})
+
+	t.Run("caps unicode content by runes", func(t *testing.T) {
+		got := firstTextChunkSummaryFallback([]*types.Chunk{{
+			Content: strings.Repeat("摘", summaryFallbackMaxRunes+25),
+		}})
+		if len([]rune(got)) != summaryFallbackMaxRunes {
+			t.Fatalf("fallback rune count = %d, want %d", len([]rune(got)), summaryFallbackMaxRunes)
+		}
+	})
+
+	t.Run("empty input stays empty", func(t *testing.T) {
+		if got := firstTextChunkSummaryFallback(nil); got != "" {
+			t.Fatalf("fallback = %q, want empty", got)
+		}
+	})
+}
+
+func TestApplyRetryableSummaryFailureState(t *testing.T) {
+	chunks := []*types.Chunk{{Content: "first body chunk"}}
+
+	t.Run("retry keeps existing description", func(t *testing.T) {
+		knowledge := &types.Knowledge{
+			Description:   "previous summary",
+			SummaryStatus: types.SummaryStatusProcessing,
+		}
+		fallback := applyRetryableSummaryFailureState(knowledge, chunks, true)
+		if fallback != "" {
+			t.Fatalf("retry fallback = %q, want empty", fallback)
+		}
+		if knowledge.Description != "previous summary" {
+			t.Fatalf("retry changed description to %q", knowledge.Description)
+		}
+		if knowledge.SummaryStatus != types.SummaryStatusPending {
+			t.Fatalf("retry status = %q, want pending", knowledge.SummaryStatus)
+		}
+	})
+
+	t.Run("terminal failure publishes fallback and fails summary", func(t *testing.T) {
+		knowledge := &types.Knowledge{
+			Description:   "previous summary",
+			SummaryStatus: types.SummaryStatusProcessing,
+		}
+		fallback := applyRetryableSummaryFailureState(knowledge, chunks, false)
+		if fallback != "first body chunk" {
+			t.Fatalf("terminal fallback = %q", fallback)
+		}
+		if knowledge.Description != fallback {
+			t.Fatalf("description = %q, want %q", knowledge.Description, fallback)
+		}
+		if knowledge.SummaryStatus != types.SummaryStatusFailed {
+			t.Fatalf("terminal status = %q, want failed", knowledge.SummaryStatus)
+		}
+	})
+}
+
+func TestSummaryRetryStateSupportsLiteExecutorContext(t *testing.T) {
+	retryCtx := types.WithTaskRetryMetadata(context.Background(), 1, 3)
+	if !summaryTaskWillRetry(retryCtx) {
+		t.Fatal("attempt 1 of maxRetry 3 should have another retry")
+	}
+	if isFinalAsynqAttempt(retryCtx) {
+		t.Fatal("attempt 1 of maxRetry 3 should not be final")
+	}
+
+	finalCtx := types.WithTaskRetryMetadata(context.Background(), 3, 3)
+	if summaryTaskWillRetry(finalCtx) {
+		t.Fatal("attempt 3 of maxRetry 3 should not retry")
+	}
+	if !isFinalAsynqAttempt(finalCtx) {
+		t.Fatal("attempt 3 of maxRetry 3 should be final")
 	}
 }

--- a/internal/router/sync_task.go
+++ b/internal/router/sync_task.go
@@ -99,7 +99,8 @@ func (e *SyncTaskExecutor) Enqueue(task *asynq.Task, opts ...asynq.Option) (*asy
 				time.Sleep(backoff)
 			}
 
-			lastErr = handler(ctx, task)
+			attemptCtx := types.WithTaskRetryMetadata(ctx, attempt, maxRetry)
+			lastErr = handler(attemptCtx, task)
 			if lastErr == nil {
 				logger.Infof(ctx, "[SyncTask] Task completed type=%s id=%s elapsed=%v",
 					task.Type(), taskID, time.Since(start))

--- a/internal/router/sync_task_retry_test.go
+++ b/internal/router/sync_task_retry_test.go
@@ -1,0 +1,38 @@
+package router
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/hibiken/asynq"
+)
+
+func TestSyncTaskExecutorInjectsRetryMetadata(t *testing.T) {
+	executor := NewSyncTaskExecutor()
+	observed := make(chan [2]int, 1)
+	executor.RegisterHandler("test:retry-metadata", func(ctx context.Context, _ *asynq.Task) error {
+		retried, maxRetry, ok := types.TaskRetryMetadataFromContext(ctx)
+		if !ok {
+			observed <- [2]int{-1, -1}
+			return nil
+		}
+		observed <- [2]int{retried, maxRetry}
+		return nil
+	})
+
+	task := asynq.NewTask("test:retry-metadata", nil)
+	if _, err := executor.Enqueue(task, asynq.MaxRetry(3)); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	select {
+	case got := <-observed:
+		if got != [2]int{0, 3} {
+			t.Fatalf("retry metadata = %v, want [0 3]", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for sync task")
+	}
+}

--- a/internal/types/context_helpers.go
+++ b/internal/types/context_helpers.go
@@ -197,6 +197,34 @@ func IsBackgroundTask(ctx context.Context) bool {
 	return v
 }
 
+type taskRetryMetadata struct {
+	retried  int
+	maxRetry int
+}
+
+// WithTaskRetryMetadata records retry counters for task executors that do not
+// provide Asynq's native worker context, notably the Lite synchronous executor.
+func WithTaskRetryMetadata(ctx context.Context, retried, maxRetry int) context.Context {
+	return context.WithValue(ctx, taskRetryMetadataContextKey{}, taskRetryMetadata{
+		retried: retried, maxRetry: maxRetry,
+	})
+}
+
+// TaskRetryMetadataFromContext returns retry counters supplied by a non-Asynq
+// task executor. The boolean is false for ordinary request contexts.
+func TaskRetryMetadataFromContext(ctx context.Context) (retried, maxRetry int, ok bool) {
+	if ctx == nil {
+		return 0, 0, false
+	}
+	metadata, ok := ctx.Value(taskRetryMetadataContextKey{}).(taskRetryMetadata)
+	if !ok {
+		return 0, 0, false
+	}
+	return metadata.retried, metadata.maxRetry, true
+}
+
+type taskRetryMetadataContextKey struct{}
+
 // WithLLMCallMetadata annotates a provider call for cache observability. The
 // fingerprint must be a hash, never raw prompt content.
 func WithLLMCallMetadata(ctx context.Context, purpose, prefixFingerprint string) context.Context {

--- a/internal/types/context_helpers_test.go
+++ b/internal/types/context_helpers_test.go
@@ -153,6 +153,21 @@ func TestLLMCallMetadataContext(t *testing.T) {
 	}
 }
 
+func TestTaskRetryMetadataContext(t *testing.T) {
+	if _, _, ok := TaskRetryMetadataFromContext(nil); ok {
+		t.Fatal("nil context should not contain task retry metadata")
+	}
+	if _, _, ok := TaskRetryMetadataFromContext(context.Background()); ok {
+		t.Fatal("background context should not contain task retry metadata")
+	}
+
+	ctx := WithTaskRetryMetadata(context.Background(), 2, 3)
+	retried, maxRetry, ok := TaskRetryMetadataFromContext(ctx)
+	if !ok || retried != 2 || maxRetry != 3 {
+		t.Fatalf("retry metadata = (%d, %d, %v), want (2, 3, true)", retried, maxRetry, ok)
+	}
+}
+
 // BenchmarkLanguageLocaleName benchmarks the language name lookup
 func BenchmarkLanguageLocaleName(b *testing.B) {
 	testCases := []string{"zh", "en", "zh-CN", "ko", "unknown"}


### PR DESCRIPTION
## Description

文档摘要模型返回空内容或调用失败时，摘要任务未按配置重试。本PR补全相应检测机制。

### 问题与根因

原摘要生成流程简述：

判断正文是否有有效文本-LLM调用，判断是否成功-前端根据description进行显示。

- 正文有有效文本，LLM 调用成功但返回空字符串或纯空白时：后端仍会把 summary_status 设置为 completed，因为目前没有校验摘要是否为空。
- 只有创建摘要 Chunk 时才检查 strings.TrimSpace(summary) != ""；为空就不创建 Chunk，但状态已经是 completed。
- 手动“重新生成摘要”也有同样问题，会无条件设置为 completed。
- 原有处理逻辑会在模型第一次调用失败后立即使用第一个正文 Chunk 作为兜底，并返回成功，导致 Asynq 的 `MaxRetry(3)` 无法生效。
- Lite 模式虽然实现了任务重试循环，但没有把当前重试次数传入任务 Context，因此摘要任务无法判断是否已经到达最后一次尝试。

### 修改目标

预期修改为以下流程：

- 一、有效正文检查
摘要生成前继续使用现有检查。

- 二、调用摘要模型
以下两种情况都视为本次任务失败：
模型调用返回错误；
模型调用成功，但返回空字符串、空格或换行。

- 三、有限重试
摘要任务继续使用现有配置：
asynq.MaxRetry(3)
修改当前“模型一报错就立刻使用第一个 Chunk”的行为，改为只有所有重试耗尽后才使用兜底。

- 四、重试期间的状态
重试期间不提前写入 failed，改为：
任务等待执行：pending
正在调用模型：processing
本次失败，等待重试：pending
下一次执行：processing
前端在 pending 或 processing 时继续显示“正在生成摘要”，不会过早显示“暂无文档摘要”。

- 五、四次全部失败后的兜底
当首次执行加三次重试全部失败后，继续使用原来的兜底机制，用第一个正文 Chunk，保存前检查兜底是否为空。
若有内容：
保存兜底，summary_status 仍然使用 failed，因为模型摘要实际生成失败，展示的只是正文兜底，不是真正的模型摘要。前端会正常显示 description，所以用户仍能看到兜底内容。
第一个正文 Chunk 也为空：
保存description = ""且summary_status = failed，这样接上前端显示：暂无文档摘要。

- 六、手动重新生成摘要
用户点击“重新生成摘要”时也执行相同流程：
检查有效正文
→ 最多调用模型4次
→ 成功则保存模型摘要
→ 全部失败则使用第一个正文Chunk
→ 第一个Chunk也为空则清空description
当前手动刷新分支会吞掉错误并返回成功，因此也必须调整为向 Asynq 返回错误，否则 MaxRetry(3) 不会生效。

### 修改内容

- 检查摘要模型响应，拒绝以下空结果：
  - `nil` 响应；
  - 空字符串；
  - 仅包含空格、换行或制表符的响应。
- 模型调用失败或返回空摘要时，将错误返回给任务执行器。
- 使用现有 `MaxRetry(3)`：
  - 首次执行加 3 次重试；
  - 总计最多尝试 4 次。
- 非最后一次失败时：
  - 将 `summary_status` 恢复为 `pending`；
  - 保留已有的 `description`；
  - 等待下一次重试。
- 所有尝试失败后：
  - 使用排序后的第一个正文 Chunk 作为展示兜底；
  - 最多保留 500 个 Unicode 字符；
  - 将 `summary_status` 标记为 `failed`。
- 如果第一个正文 Chunk 也为空，则将 `description` 保存为空。
- 有效正文不足时直接标记摘要失败，不进行无意义重试。
- 手动异步重新生成摘要时使用相同的重试和兜底逻辑。
- 为 Lite 任务执行器补充重试次数 Context，使其与 Redis Asynq 模式保持一致，并确保最终失败后能够正确释放后处理任务计数。
- 摘要失败只影响 `summary_status`，不会将整个文档的 `parse_status` 标记为失败，也不会取消问题生成、图谱或 Wiki 等其他后处理任务。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Checklist

- [x] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

