### PR TITLE
fix(knowledge): clear stale error_message on the remaining reprocess paths

### DIFF
--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -184,14 +184,29 @@ func finalizeIndexedKnowledgeState(
 		knowledge.SummaryStatus = types.SummaryStatusNone
 	} else {
 		// No text chunks and no pending multimodal work: there is nothing for
-		// post-process to enrich, so complete immediately.
+		// post-process to enrich, so complete immediately. This is the only
+		// route to 'completed' that bypasses FinalizeSubtask, so it has to
+		// clear error_message itself — otherwise a successfully indexed row
+		// keeps reporting a failure from an earlier attempt.
 		knowledge.ParseStatus = types.ParseStatusCompleted
 		knowledge.SummaryStatus = types.SummaryStatusNone
+		knowledge.ErrorMessage = ""
 	}
 
 	knowledge.EnableStatus = "enabled"
 	knowledge.StorageSize = totalStorageSize
 	knowledge.ProcessedAt = &now
+	knowledge.UpdatedAt = now
+}
+
+// markKnowledgeProcessing makes the top-level knowledge state describe the
+// attempt that is starting now. Clearing error_message is part of that: the
+// column is only meaningful for the attempt that produced it, so a row
+// re-entering processing must not keep surfacing the previous attempt's
+// failure while it is visibly running again.
+func markKnowledgeProcessing(knowledge *types.Knowledge, now time.Time) {
+	knowledge.ParseStatus = types.ParseStatusProcessing
+	knowledge.ErrorMessage = ""
 	knowledge.UpdatedAt = now
 }
 
@@ -2976,8 +2991,7 @@ func (s *knowledgeService) ProcessManualUpdate(ctx context.Context, t *asynq.Tas
 		return nil
 	}
 	// Update status to processing
-	knowledge.ParseStatus = "processing"
-	knowledge.UpdatedAt = time.Now()
+	markKnowledgeProcessing(knowledge, time.Now())
 	if err := s.repo.UpdateKnowledge(ctx, knowledge); err != nil {
 		logger.Errorf(ctx, "ProcessManualUpdate: failed to update status to processing: %v", err)
 		return nil
@@ -3112,9 +3126,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 		logger.Infof(ctx, "Knowledge aborted (%s) before marking processing: %s", status, knowledge.ID)
 		return nil
 	}
-	knowledge.ParseStatus = "processing"
-	knowledge.ErrorMessage = ""
-	knowledge.UpdatedAt = time.Now()
+	markKnowledgeProcessing(knowledge, time.Now())
 	if err := s.repo.UpdateKnowledge(ctx, knowledge); err != nil {
 		logger.Errorf(ctx, "failed to update knowledge status to processing: %v", err)
 		return nil

--- a/internal/application/service/knowledge_process_status_test.go
+++ b/internal/application/service/knowledge_process_status_test.go
@@ -16,18 +16,23 @@ func TestFinalizeIndexedKnowledgeState(t *testing.T) {
 		textChunkCount       int
 		wantParseStatus      string
 		wantSummaryStatus    string
+		wantErrorMessage     string
 	}{
 		{
 			name:              "text document stays processing so post-process can fan out enrichment",
 			textChunkCount:    2,
 			wantParseStatus:   types.ParseStatusProcessing,
 			wantSummaryStatus: types.SummaryStatusNone,
+			// Still processing: FinalizeSubtask clears the column when this
+			// row is eventually promoted to completed.
+			wantErrorMessage: "previous attempt failed",
 		},
 		{
 			name:              "empty indexed document is completed without summary work",
 			textChunkCount:    0,
 			wantParseStatus:   types.ParseStatusCompleted,
 			wantSummaryStatus: types.SummaryStatusNone,
+			wantErrorMessage:  "",
 		},
 		{
 			name:                 "document waits while multimodal image work is pending",
@@ -35,6 +40,7 @@ func TestFinalizeIndexedKnowledgeState(t *testing.T) {
 			textChunkCount:       2,
 			wantParseStatus:      types.ParseStatusProcessing,
 			wantSummaryStatus:    types.SummaryStatusNone,
+			wantErrorMessage:     "previous attempt failed",
 		},
 	}
 
@@ -43,9 +49,14 @@ func TestFinalizeIndexedKnowledgeState(t *testing.T) {
 			knowledge := &types.Knowledge{
 				ParseStatus:   types.ParseStatusProcessing,
 				SummaryStatus: types.SummaryStatusCompleted,
+				ErrorMessage:  "previous attempt failed",
 			}
 
 			finalizeIndexedKnowledgeState(knowledge, 4096, tt.textChunkCount, tt.hasPendingMultimodal, now)
+
+			if knowledge.ErrorMessage != tt.wantErrorMessage {
+				t.Fatalf("ErrorMessage = %q, want %q", knowledge.ErrorMessage, tt.wantErrorMessage)
+			}
 
 			if knowledge.ParseStatus != tt.wantParseStatus {
 				t.Fatalf("ParseStatus = %q, want %q", knowledge.ParseStatus, tt.wantParseStatus)
@@ -66,5 +77,30 @@ func TestFinalizeIndexedKnowledgeState(t *testing.T) {
 				t.Fatalf("UpdatedAt = %v, want %v", knowledge.UpdatedAt, now)
 			}
 		})
+	}
+}
+
+// TestMarkKnowledgeProcessingClearsPreviousAttemptError covers the transition
+// every worker performs before it starts a new attempt. A row that failed
+// earlier still carries that attempt's error_message, and leaving it in place
+// makes the UI report a failure on a document it is simultaneously showing as
+// processing.
+func TestMarkKnowledgeProcessingClearsPreviousAttemptError(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	knowledge := &types.Knowledge{
+		ParseStatus:  types.ParseStatusFailed,
+		ErrorMessage: "Task interrupted due to application restart",
+	}
+
+	markKnowledgeProcessing(knowledge, now)
+
+	if knowledge.ParseStatus != types.ParseStatusProcessing {
+		t.Fatalf("ParseStatus = %q, want %q", knowledge.ParseStatus, types.ParseStatusProcessing)
+	}
+	if knowledge.ErrorMessage != "" {
+		t.Fatalf("ErrorMessage = %q, want empty", knowledge.ErrorMessage)
+	}
+	if !knowledge.UpdatedAt.Equal(now) {
+		t.Fatalf("UpdatedAt = %v, want %v", knowledge.UpdatedAt, now)
 	}
 }


### PR DESCRIPTION

Follow-up to the error_message clearing added for SetFinalizing, FinalizeSubtask and ProcessDocument. Two routes still persisted a previous attempt's failure message:

- ProcessManualUpdate flips a row back to 'processing' without clearing error_message. A manual knowledge item that failed earlier (for example when the knowledge base lookup failed, or after an Asynq retry) re-enters processing still carrying that message, so the UI shows a failure on a document it also shows as running.

- finalizeIndexedKnowledgeState is the only route to 'completed' that bypasses FinalizeSubtask. When a document has no text chunks and no pending multimodal work it is completed in place, so the promotion that would otherwise clear the column never runs and a successfully indexed row keeps reporting the earlier failure.

The 'processing' transition is extracted into markKnowledgeProcessing so ProcessDocument and ProcessManualUpdate share one definition of what starting a new attempt means, and a future worker cannot reintroduce the same omission. The helper also replaces the "processing" string literal with types.ParseStatusProcessing.

Tests: markKnowledgeProcessing gets direct coverage, and the finalizeIndexedKnowledgeState table now seeds a stale error_message and asserts it survives the processing branches (FinalizeSubtask clears it later) and is cleared on the completed branch.
