### PR TITLE
fix: unify organization settings modal scrolling

### DIFF
--- a/frontend/src/views/organization/OrganizationSettingsModal.test.mjs
+++ b/frontend/src/views/organization/OrganizationSettingsModal.test.mjs
@@ -14,3 +14,22 @@ test('reviewing join requests goes through the store and refreshes modal data', 
   const refreshCalls = source.match(/await refreshOrganizationAfterReview\(\)/g) ?? []
   assert.equal(refreshCalls.length, 2)
 })
+
+test('organization settings use one outer content scroller and reset it on navigation', () => {
+  assert.match(source, /ref="contentWrapperRef" class="content-wrapper"/)
+  assert.match(source, /class="data-table-shell members-table-shell"/)
+  assert.match(source, /contentWrapperRef\.value\?\.scrollTo\(\{ top: 0, behavior: 'auto' \}\)/)
+  assert.match(source, /watch\(\(\) => props\.visible,[\s\S]*?void scrollContentToTop\(\)/)
+  assert.match(source, /\}, \{ immediate: true \}\)\s*\n\s*watch\(\(\) => props\.orgId/)
+  assert.match(source, /watch\(\(\) => props\.orgId,[\s\S]*?void scrollContentToTop\(\)/)
+  assert.match(source, /watch\(currentSection,[\s\S]*?void scrollContentToTop\(\)/)
+  assert.match(source, /\.members-table-shell\s*\{[\s\S]*?overflow: visible;[\s\S]*?\.t-table__content/)
+})
+
+test('organization settings lock and restore background scrolling', () => {
+  assert.match(source, /document\.body\.style\.overflow = 'hidden'/)
+  assert.match(source, /document\.body\.style\.overflow = previousBodyOverflow/)
+  assert.match(source, /onBeforeUnmount\(\(\) => \{\s*unlockBackgroundScroll\(\)/)
+  assert.match(source, /\.settings-overlay\s*\{[\s\S]*?overscroll-behavior: none;/)
+  assert.match(source, /\.content-wrapper\s*\{[\s\S]*?overscroll-behavior: contain;/)
+})

--- a/frontend/src/views/organization/OrganizationSettingsModal.vue
+++ b/frontend/src/views/organization/OrganizationSettingsModal.vue
@@ -38,7 +38,7 @@
 
             <!-- 右侧内容区域 -->
             <div class="settings-content">
-              <div class="content-wrapper">
+              <div ref="contentWrapperRef" class="content-wrapper">
                 <!-- 组织管理员但空间角色不足，给出只读提示 -->
                 <div v-if="showTenantRoleHint" class="tenant-role-hint">
                   <t-icon name="info-circle" size="16px" />
@@ -456,7 +456,7 @@
                         ? $t('organization.members.emptySearch', { q: memberSearchQuery })
                         : $t('organization.noMembers')" />
                     </div>
-                    <div v-else class="data-table-shell">
+                    <div v-else class="data-table-shell members-table-shell">
                       <t-table row-key="id" :data="filteredMembers" :columns="memberColumns" size="medium" hover
                         stripe :loading="membersLoading">
                         <template #member="{ row }">
@@ -818,7 +818,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
@@ -863,6 +863,7 @@ const emit = defineEmits<{
 
 // State
 const currentSection = ref('basic')
+const contentWrapperRef = ref<HTMLElement | null>(null)
 const orgInfo = computed(() => orgStore.currentOrganization)
 const members = computed(() => orgStore.currentMembers)
 const sharedKnowledgeBases = ref<KnowledgeBaseShare[]>([])
@@ -1855,9 +1856,32 @@ const getPermissionTheme = (permission: string) => {
   }
 }
 
+const scrollContentToTop = async () => {
+  await nextTick()
+  contentWrapperRef.value?.scrollTo({ top: 0, behavior: 'auto' })
+}
+
+let previousBodyOverflow = ''
+let bodyScrollLocked = false
+
+const lockBackgroundScroll = () => {
+  if (bodyScrollLocked) return
+  previousBodyOverflow = document.body.style.overflow
+  document.body.style.overflow = 'hidden'
+  bodyScrollLocked = true
+}
+
+const unlockBackgroundScroll = () => {
+  if (!bodyScrollLocked) return
+  document.body.style.overflow = previousBodyOverflow
+  bodyScrollLocked = false
+}
+
 // Watch
 watch(() => props.visible, (newVal) => {
   if (newVal) {
+    lockBackgroundScroll()
+    void scrollContentToTop()
     currentSection.value = 'basic'
     memberSearchQuery.value = ''
     joinRequestSearchQuery.value = ''
@@ -1880,13 +1904,26 @@ watch(() => props.visible, (newVal) => {
       fetchMembers()
       fetchSharedKBs()
     }
+  } else {
+    unlockBackgroundScroll()
+  }
+}, { immediate: true })
+
+watch(() => props.orgId, () => {
+  if (props.visible) {
+    void scrollContentToTop()
   }
 })
 
 watch(currentSection, (section) => {
+  void scrollContentToTop()
   if (section === 'joinRequests' && props.orgId) {
     fetchJoinRequests()
   }
+})
+
+onBeforeUnmount(() => {
+  unlockBackgroundScroll()
 })
 
 watch(addMemberPopupVisible, (visible) => {
@@ -1914,6 +1951,7 @@ watch(addMemberPopupVisible, (visible) => {
   justify-content: center;
   z-index: 2000;
   backdrop-filter: blur(4px);
+  overscroll-behavior: none;
 }
 
 .settings-modal {
@@ -2082,6 +2120,7 @@ watch(addMemberPopupVisible, (visible) => {
   padding: 28px 40px 48px;
   box-sizing: border-box;
   scroll-padding-bottom: 24px;
+  overscroll-behavior: contain;
 }
 
 .tenant-role-hint {
@@ -2829,6 +2868,16 @@ watch(addMemberPopupVisible, (visible) => {
 
   :deep(.member-role-select.t-select) {
     width: 100%;
+  }
+}
+
+.members-table-shell {
+  overflow: visible;
+  max-height: none;
+
+  :deep(.t-table__content) {
+    overflow: visible !important;
+    max-height: none !important;
   }
 }
 


### PR DESCRIPTION
## Description

修复共享空间设置弹窗中的嵌套滚动和滚动位置残留问题。

### 问题表现

成员较多时，成员名单和空间设置内容区域存在不同的滚动区域。切换到“成员管理”等栏目后，可能沿用上一个栏目的滚动位置，导致部分成员没有出现在当前可见区域，容易误以为成员缺失。

滚动到弹窗边界后，滚轮事件还可能继续影响弹窗后面的页面。

### 根因

- 成员名单存在独立的滚动区域，和空间设置外层滚动区域相互嵌套。
- 打开空间设置以及切换栏目时，没有重置外层内容区域的滚动位置。
- 弹窗打开期间没有完整阻止背景页面滚动和滚动链穿透。

### 修改内容

- 取消成员名单自身的滚动区域，统一使用空间设置外层滚动条。
- 打开空间设置时自动将内容区域滚动到顶部。
- 切换“基本信息”“成员管理”等栏目时自动回到顶部。
- 弹窗打开期间锁定背景页面滚动。
- 阻止滚动从弹窗内容区域继续穿透到背景页面。
- 弹窗关闭或组件卸载时恢复页面原来的滚动状态。
- 增加滚动区域、自动回顶和背景滚动锁定的回归测试。

### 用户影响

成员数量较多时，用户可以沿同一条外层滚动条查看完整成员名单。切换设置栏目后会从顶部开始展示内容，滚动也不会影响弹窗后面的页面。

### Breaking Changes

无。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

在 Podman Linux Node.js 环境中执行：

- `node --test src/views/organization/OrganizationSettingsModal.test.mjs`
  - 3 个测试全部通过。
- `vue-tsc --build --pretty false`
  - 类型检查通过。
- `git diff --check`
  - 通过。

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (N/A — no documentation changes required)
- [x] Breaking changes are clearly called out in the description above

