### PR TITLE
fix: replace all exact wiki text matches

### DIFF
--- a/internal/agent/tools/wiki_replace_text.go
+++ b/internal/agent/tools/wiki_replace_text.go
@@ -30,7 +30,7 @@ func NewWikiReplaceTextTool(
 	return &wikiReplaceTextTool{
 		BaseTool: NewBaseTool(
 			ToolWikiReplaceText,
-			"Replace specific exact text in a Wiki page. Ideal for minor corrections.",
+			"Replace all occurrences of specific exact text in a Wiki page. Ideal for consistent minor corrections.",
 			json.RawMessage(`{
 				"type": "object",
 				"properties": {
@@ -103,11 +103,12 @@ func (t *wikiReplaceTextTool) Execute(ctx context.Context, args json.RawMessage)
 		return &types.ToolResult{Success: false, Error: fmt.Sprintf("Failed to fetch page %s: %v", params.Slug, err)}, nil
 	}
 
-	if !strings.Contains(existingPage.Content, params.OldText) {
+	replacementCount := strings.Count(existingPage.Content, params.OldText)
+	if replacementCount == 0 {
 		return &types.ToolResult{Success: false, Error: "old_text not found in the current page content. Ensure you copy it exactly as it appears."}, nil
 	}
 
-	existingPage.Content = strings.Replace(existingPage.Content, params.OldText, params.NewText, 1)
+	existingPage.Content = strings.ReplaceAll(existingPage.Content, params.OldText, params.NewText)
 
 	if params.SourceRefs != nil {
 		if t.scopeEnforced {
@@ -129,17 +130,18 @@ func (t *wikiReplaceTextTool) Execute(ctx context.Context, args json.RawMessage)
 	oldPreview := truncateRunes(params.OldText, 80)
 	newPreview := truncateRunes(params.NewText, 80)
 
-	output := fmt.Sprintf("Successfully replaced text on page [[%s]].\n- Old: %s\n- New: %s", params.Slug, oldPreview, newPreview)
+	output := fmt.Sprintf("Successfully replaced %d occurrence(s) on page [[%s]].\n- Old: %s\n- New: %s", replacementCount, params.Slug, oldPreview, newPreview)
 
 	return &types.ToolResult{
 		Success: true,
 		Output:  output,
 		Data: map[string]interface{}{
-			"display_type": "wiki_replace_text",
-			"slug":         params.Slug,
-			"title":        existingPage.Title,
-			"old_text":     oldPreview,
-			"new_text":     newPreview,
+			"display_type":      "wiki_replace_text",
+			"slug":              params.Slug,
+			"title":             existingPage.Title,
+			"old_text":          oldPreview,
+			"new_text":          newPreview,
+			"replacement_count": replacementCount,
 		},
 	}, nil
 }

--- a/internal/agent/tools/wiki_replace_text_test.go
+++ b/internal/agent/tools/wiki_replace_text_test.go
@@ -1,0 +1,146 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type replaceTextWikiService struct {
+	interfaces.WikiPageService
+	page        *types.WikiPage
+	updateCalls int
+}
+
+func (s *replaceTextWikiService) GetPageBySlug(_ context.Context, _, _ string) (*types.WikiPage, error) {
+	pageCopy := *s.page
+	return &pageCopy, nil
+}
+
+func (s *replaceTextWikiService) UpdatePage(_ context.Context, page *types.WikiPage) (*types.WikiPage, error) {
+	s.updateCalls++
+	pageCopy := *page
+	s.page = &pageCopy
+	return &pageCopy, nil
+}
+
+func executeReplaceText(t *testing.T, content, oldText, newText string) (*replaceTextWikiService, *types.ToolResult) {
+	t.Helper()
+	service := &replaceTextWikiService{page: &types.WikiPage{
+		KnowledgeBaseID: "kb-1",
+		Slug:            "concept/repeated",
+		Title:           "Repeated",
+		Content:         content,
+	}}
+	tool := NewWikiReplaceTextTool(service, []string{"kb-1"}, nil, NewWikiRouteResolver())
+	args, err := json.Marshal(map[string]string{
+		"slug":     "concept/repeated",
+		"old_text": oldText,
+		"new_text": newText,
+	})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Execute returned nil result")
+	}
+	return service, result
+}
+
+func TestWikiReplaceTextReplacesAllExactMatches(t *testing.T) {
+	service, result := executeReplaceText(
+		t,
+		"alpha target beta target gamma target",
+		"target",
+		"replacement",
+	)
+
+	if !result.Success {
+		t.Fatalf("replace failed: %+v", result)
+	}
+	const want = "alpha replacement beta replacement gamma replacement"
+	if service.page.Content != want {
+		t.Fatalf("content = %q, want %q", service.page.Content, want)
+	}
+	if service.updateCalls != 1 {
+		t.Fatalf("UpdatePage calls = %d, want 1", service.updateCalls)
+	}
+	if got := result.Data["replacement_count"]; got != 3 {
+		t.Fatalf("replacement_count = %#v, want 3", got)
+	}
+}
+
+func TestWikiReplaceTextExactMatchCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		oldText   string
+		newText   string
+		want      string
+		wantCount int
+	}{
+		{
+			name: "single match remains compatible", content: "before target after",
+			oldText: "target", newText: "replacement", want: "before replacement after", wantCount: 1,
+		},
+		{
+			name: "new text containing old text is not replaced recursively", content: "a a",
+			oldText: "a", newText: "aa", want: "aa aa", wantCount: 2,
+		},
+		{
+			name: "empty new text deletes every match", content: "keep-X-keep-X",
+			oldText: "X", newText: "", want: "keep--keep-", wantCount: 2,
+		},
+		{
+			name: "unicode exact matches", content: "旧文本与旧文本",
+			oldText: "旧文本", newText: "新文本", want: "新文本与新文本", wantCount: 2,
+		},
+		{
+			name: "markdown links remain plain exact text", content: "See [[concept/old]] and [[concept/old]].",
+			oldText: "[[concept/old]]", newText: "[[concept/new]]", want: "See [[concept/new]] and [[concept/new]].", wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, result := executeReplaceText(t, tt.content, tt.oldText, tt.newText)
+			if !result.Success {
+				t.Fatalf("replace failed: %+v", result)
+			}
+			if service.page.Content != tt.want {
+				t.Fatalf("content = %q, want %q", service.page.Content, tt.want)
+			}
+			if result.Data["replacement_count"] != tt.wantCount {
+				t.Fatalf("replacement_count = %#v, want %d", result.Data["replacement_count"], tt.wantCount)
+			}
+			if service.updateCalls != 1 {
+				t.Fatalf("UpdatePage calls = %d, want 1", service.updateCalls)
+			}
+		})
+	}
+}
+
+func TestWikiReplaceTextNotFoundDoesNotPersist(t *testing.T) {
+	service, result := executeReplaceText(t, "keep this content", "missing", "replacement")
+
+	if result.Success {
+		t.Fatalf("expected failure, got %+v", result)
+	}
+	if !strings.Contains(result.Error, "old_text not found") {
+		t.Fatalf("error = %q, want old_text not found", result.Error)
+	}
+	if service.page.Content != "keep this content" {
+		t.Fatalf("stored content changed to %q", service.page.Content)
+	}
+	if service.updateCalls != 0 {
+		t.Fatalf("UpdatePage calls = %d, want 0", service.updateCalls)
+	}
+}


### PR DESCRIPTION
## Description

### Affected Component

Agent wiki fixer / `wiki_replace_text` tool

### Bug

This PR fixes [Issue #2445](https://github.com/Tencent/WeKnora/issues/2445).

`wiki_replace_text` used `strings.Replace(content, oldText, newText, 1)`, so when the same incorrect text appeared multiple times on one Wiki page, only the first occurrence was changed. The fixer could then mark the issue as resolved while duplicate incorrect text remained.

### Change

- Count all non-overlapping exact matches with `strings.Count`.
- Replace all matches with `strings.ReplaceAll`.
- Return `replacement_count` in the tool result.
- Preserve existing exact-match, `source_refs`, not-found, and persistence behavior.
- Add tool-level regression tests for repeated, single, missing, deletion, Unicode, Markdown, and non-recursive replacement cases.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🧪 Test
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2445

## Testing

Validated in Linux Docker with Go 1.26:

- `go test ./internal/agent/tools -count=1`
- `go test ./internal/agent/tools -run '^TestWikiReplaceText' -count=1 -v`
- `go test ./internal/agent/tools -run '^(TestWiki|TestResolveUniqueWikiPage)' -count=1`
- `go test -race ./internal/agent/tools -run '^TestWikiReplaceText' -count=1`
- `git diff --check upstream/main...HEAD`

The native Windows toolchain cannot link the prebuilt DuckDB static library (`__emutls_v...`), so the complete package validation was run in Linux Docker.

## Checklist

- [x] Changed source files are formatted
- [x] Targeted tests for the changed package pass
- [x] Full package checks pass in Linux Docker
- [x] Self-reviewed the code
- [x] Added tests covering the change
- [ ] Diff-scoped golangci-lint was not run
- [ ] Documentation update is not required for this backend behavior change