### PR TITLE
fix(embedding): prevent ants worker panic and mutex deadlock on empty/mismatched results

### DIFF
--- a/internal/models/embedding/batch.go
+++ b/internal/models/embedding/batch.go
@@ -2,6 +2,7 @@ package embedding
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 	"sync"
@@ -56,6 +57,14 @@ func (e *batchEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, 
 				mu.Lock()
 				if firstErr == nil {
 					firstErr = err
+				}
+				mu.Unlock()
+				return
+			}
+			if len(embedding) != len(texts) {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("embedding model returned %d embeddings for %d inputs", len(embedding), len(texts))
 				}
 				mu.Unlock()
 				return


### PR DESCRIPTION
### Description
When the embedding provider returns an empty slice of vectors (e.g., length 0) due to API mismatch or empty input, `BatchEmbed` returns a slice of length 0. 
Accessing `embedding[i]` directly in `BatchEmbedWithPool` results in an index out of bounds panic: `runtime error: index out of range [0] with length 0`.

Because the panic occurs inside a `mu.Lock()` block in the `ants` pool worker goroutine, the mutex is never unlocked. This leaves the semaphore locked permanently, leading to a deadlock of the entire document processing queue (e.g., `wg.Wait()` hangs forever).

### Changes
- Added validation for `len(embedding) != len(texts)` in `BatchEmbedWithPool` of `internal/models/embedding/batch.go`.
- If the length is mismatched or empty, it sets the first error, safely releases the lock (`mu.Unlock()`), and returns instead of panicking.