### PR TITLE
fix(chunker): cap oversized protected chunks safely

### DIFF
--- a/internal/infrastructure/chunker/heading_splitter.go
+++ b/internal/infrastructure/chunker/heading_splitter.go
@@ -106,9 +106,10 @@ func splitByHeadingsImpl(text string, cfg SplitterConfig, profile *DocProfile) [
 		subBreadcrumbs := sectionBreadcrumbs(sectionRunes, primaryLevel, sectionStart)
 		subChunks := SplitText(sectionContent, cfg)
 		for _, sub := range subChunks {
+			sectionBreadcrumb := breadcrumbAtOffset(subBreadcrumbs, sub.Start, breadcrumb)
 			out = append(out, Chunk{
 				Content:       sub.Content,
-				ContextHeader: breadcrumbAtOffset(subBreadcrumbs, sub.Start, breadcrumb),
+				ContextHeader: mergeBreadcrumbs(sectionBreadcrumb, sub.ContextHeader),
 				Seq:           seq,
 				Start:         b.runeStart + sub.Start,
 				End:           b.runeStart + sub.End,
@@ -153,6 +154,13 @@ func coalesceTinyChunks(in []Chunk, chunkSize int) []Chunk {
 		next := in[i]
 		nextLen := utf8.RuneCountInString(next.Content)
 		sharedHeader := commonHeadingPrefix(cur.ContextHeader, next.ContextHeader)
+		// Table headers and other non-heading context are semantic data, not a
+		// breadcrumb hierarchy. Never collapse them to a shared heading prefix
+		// when crossing into a chunk with different context.
+		if (hasNonHeadingContext(cur.ContextHeader) || hasNonHeadingContext(next.ContextHeader)) &&
+			cur.ContextHeader != next.ContextHeader {
+			sharedHeader = ""
+		}
 		// Adjacent + still-small + would not blow the size budget → merge.
 		if sharedHeader != "" && cur.End == next.Start && curLen < target && curLen+nextLen <= chunkSize {
 			cur.Content += next.Content
@@ -173,6 +181,16 @@ func coalesceTinyChunks(in []Chunk, chunkSize int) []Chunk {
 		out[i].Seq = i
 	}
 	return out
+}
+
+func hasNonHeadingContext(contextHeader string) bool {
+	for _, line := range strings.Split(contextHeader, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && !strings.HasPrefix(line, "#") {
+			return true
+		}
+	}
+	return false
 }
 
 // commonHeadingPrefix returns the longest line-aligned prefix shared by two

--- a/internal/infrastructure/chunker/heuristic_splitter.go
+++ b/internal/infrastructure/chunker/heuristic_splitter.go
@@ -258,10 +258,11 @@ func appendOversizeBlock(out []Chunk, runes []rune, start, end int, cfg Splitter
 	subs := SplitText(subText, cfg)
 	for _, s := range subs {
 		out = append(out, Chunk{
-			Content: s.Content,
-			Seq:     *seq,
-			Start:   start + s.Start,
-			End:     start + s.End,
+			Content:       s.Content,
+			ContextHeader: s.ContextHeader,
+			Seq:           *seq,
+			Start:         start + s.Start,
+			End:           start + s.End,
 		})
 		*seq++
 	}

--- a/internal/infrastructure/chunker/splitter.go
+++ b/internal/infrastructure/chunker/splitter.go
@@ -398,7 +398,10 @@ func mergeUnits(units []splitUnit, chunkSize, chunkOverlap int) []Chunk {
 		return nil
 	}
 
-	const absoluteMaxSize = 7500
+	// Keep oversized protected Markdown blocks under a conservative emergency
+	// ceiling to reduce the chance of exceeding common embedding input limits.
+	// Ordinary chunks still follow the knowledge base's smaller ChunkSize.
+	const absoluteMaxSize = 4096
 
 	ht := newHeaderTracker()
 
@@ -418,14 +421,31 @@ func mergeUnits(units []splitUnit, chunkSize, chunkOverlap int) []Chunk {
 				curLen = 0
 			}
 
-			// Update header state even for oversized units
+			// Update header state even for oversized units. Keep a long table row
+			// source-backed and carry its active table header separately so parent-
+			// child splitting can preserve offsets while still embedding the context.
 			ht.update(u.text)
+			headers := ht.getHeaders()
+			headersLen := runeLen(headers)
+			const contextSeparatorLen = 2 // "\n\n" inserted by EmbeddingContent
+			if headersLen+contextSeparatorLen > absoluteMaxSize/2 ||
+				headerAlreadyPresent(headers, "", u.text) ||
+				headerColumnMismatch(headers, u.text) {
+				headers = ""
+				headersLen = 0
+			}
+			bodyLimit := absoluteMaxSize - headersLen
+			if headers != "" {
+				bodyLimit -= contextSeparatorLen
+			}
 
-			// Split this oversized unit into smaller chunks
+			// Split this oversized unit into smaller chunks. Unlike the legacy
+			// emergency path, retain the configured overlap so lowering the ceiling
+			// does not reduce recall for content that previously stayed atomic.
 			runes := []rune(u.text)
 			offset := 0
 			for offset < len(runes) {
-				chunkEnd := offset + absoluteMaxSize
+				chunkEnd := offset + bodyLimit
 				if chunkEnd > len(runes) {
 					chunkEnd = len(runes)
 				} else {
@@ -439,12 +459,23 @@ func mergeUnits(units []splitUnit, chunkSize, chunkOverlap int) []Chunk {
 
 				chunkText := string(runes[offset:chunkEnd])
 				chunks = append(chunks, Chunk{
-					Content: chunkText,
-					Seq:     len(chunks),
-					Start:   u.start + offset,
-					End:     u.start + chunkEnd,
+					Content:       chunkText,
+					ContextHeader: headers,
+					Seq:           len(chunks),
+					Start:         u.start + offset,
+					End:           u.start + chunkEnd,
 				})
-				offset = chunkEnd
+				nextOffset := chunkEnd
+				if chunkEnd < len(runes) && chunkOverlap > 0 {
+					// Emergency overlap is capped at half the body budget. Without
+					// this guard, a configured overlap >= bodyLimit advances by one
+					// rune per chunk and can amplify one unit into thousands of chunks.
+					overlap := min(chunkOverlap, bodyLimit/2, chunkEnd-offset-1)
+					if overlap > 0 {
+						nextOffset -= overlap
+					}
+				}
+				offset = nextOffset
 			}
 			continue
 		}
@@ -883,6 +914,7 @@ func SplitTextParentChild(text string, parentCfg, childCfg SplitterConfig) Paren
 			sub.Seq = childSeq
 			sub.Start += parent.Start
 			sub.End += parent.Start
+			sub.ContextHeader = mergeBreadcrumbs(parent.ContextHeader, sub.ContextHeader)
 			children = append(children, ChildChunk{
 				Chunk:       sub,
 				ParentIndex: parentIndex,

--- a/internal/infrastructure/chunker/splitter_test.go
+++ b/internal/infrastructure/chunker/splitter_test.go
@@ -1336,3 +1336,172 @@ func TestSplitTextParentChild_WithTableHeaders(t *testing.T) {
 		}
 	}
 }
+
+func TestMergeUnitsCapsProtectedContentWithOverlapAndRestoration(t *testing.T) {
+	for _, size := range []int{4096, 4097, 7000} {
+		t.Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
+			text := strings.Repeat("数", size)
+			chunks := mergeUnits([]splitUnit{{text: text, start: 0, end: size}}, 512, 50)
+			for index, chunk := range chunks {
+				if chunkSize := len([]rune(chunk.Content)); chunkSize > 4096 {
+					t.Fatalf("chunk %d has %d runes, exceeds protected-content cap", index, chunkSize)
+				}
+			}
+			if size == 4096 && len(chunks) != 1 {
+				t.Fatalf("expected exact-limit content to stay in one chunk, got %d", len(chunks))
+			}
+			if size > 4096 {
+				if len(chunks) < 2 {
+					t.Fatalf("expected oversized content to split, got %d chunk", len(chunks))
+				}
+				if overlap := chunks[0].End - chunks[1].Start; overlap <= 0 || overlap > 50 {
+					t.Fatalf("expected overlap in (0, 50], got %d", overlap)
+				}
+			}
+			if restored := restoreTextFromChunks(chunks); restored != text {
+				t.Fatalf("restoration mismatch: got %d runes, want %d", len([]rune(restored)), size)
+			}
+		})
+	}
+}
+
+func TestMergeUnitsOversizedTableRowRetainsActiveHeader(t *testing.T) {
+	header := "| A | B |\n| --- | --- |\n"
+	row := "| " + strings.Repeat("数据", 2200) + " | value |\n"
+	headerLen := runeLen(header)
+	text := header + row
+	chunks := mergeUnits([]splitUnit{
+		{text: header, start: 0, end: headerLen},
+		{text: row, start: headerLen, end: runeLen(text)},
+	}, 512, 50)
+
+	if len(chunks) < 3 {
+		t.Fatalf("expected header plus multiple row chunks, got %d", len(chunks))
+	}
+	for index, chunk := range chunks[1:] {
+		if chunk.ContextHeader != header {
+			t.Fatalf("row chunk %d lost active table header", index)
+		}
+		if size := runeLen(chunk.EmbeddingContent()); size > 4096 {
+			t.Fatalf("row chunk %d has %d embedding runes, exceeds protected-content cap", index, size)
+		}
+		if got, want := chunk.Content, string([]rune(text)[chunk.Start:chunk.End]); got != want {
+			t.Fatalf("row chunk %d source span mismatch", index)
+		}
+	}
+	if restored := restoreTextFromChunks(chunks); restored != text {
+		t.Fatal("oversized table restoration mismatch")
+	}
+}
+
+func TestMergeUnitsCapsEmergencyOverlapAmplification(t *testing.T) {
+	text := strings.Repeat("数", 7000)
+	chunks := mergeUnits([]splitUnit{{text: text, start: 0, end: 7000}}, 10000, 5000)
+	if len(chunks) > 4 {
+		t.Fatalf("high overlap amplified one protected unit into %d chunks", len(chunks))
+	}
+	for index := 1; index < len(chunks); index++ {
+		overlap := chunks[index-1].End - chunks[index].Start
+		if overlap <= 0 || overlap > 2048 {
+			t.Fatalf("chunk pair %d overlap = %d, want in (0, 2048]", index, overlap)
+		}
+	}
+	if restored := restoreTextFromChunks(chunks); restored != text {
+		t.Fatal("high-overlap emergency split restoration mismatch")
+	}
+}
+
+func TestOversizedProtectedTableParentChildKeepsOffsetsAndHeader(t *testing.T) {
+	header := "| A | B |\n| --- | --- |\n"
+	row := "| " + strings.Repeat("数据", 2200) + " | value |\n"
+	text := header + row
+	headerLen := runeLen(header)
+	parentCfg := SplitterConfig{
+		ChunkSize: 10000, ChunkOverlap: 50, Separators: []string{"\n\n", "\n"}, Strategy: StrategyLegacy,
+	}
+	childCfg := SplitterConfig{
+		ChunkSize: 512, ChunkOverlap: 50, Separators: []string{"\n\n", "\n"}, Strategy: StrategyLegacy,
+	}
+
+	results := map[string]ParentChildResult{
+		"legacy":   SplitTextParentChild(text, parentCfg, childCfg),
+		"strategy": SplitParentChild(text, parentCfg, childCfg),
+	}
+	textRunes := []rune(text)
+	for name, result := range results {
+		t.Run(name, func(t *testing.T) {
+			foundRowChild := false
+			for index, child := range result.Children {
+				if child.Start < 0 || child.End > len(textRunes) || child.Start >= child.End {
+					t.Fatalf("child %d has invalid source span [%d, %d)", index, child.Start, child.End)
+				}
+				if got, want := child.Content, string(textRunes[child.Start:child.End]); got != want {
+					t.Fatalf("child %d source span mismatch", index)
+				}
+				if child.Start >= headerLen {
+					foundRowChild = true
+					if child.ContextHeader != header {
+						t.Fatalf("row child %d lost table header context", index)
+					}
+				}
+			}
+			if !foundRowChild {
+				t.Fatal("expected at least one child from the oversized table row")
+			}
+		})
+	}
+}
+
+func TestOversizedProtectedTableKeepsHeaderAcrossAdaptiveTiers(t *testing.T) {
+	header := "| A | B |\n| --- | --- |\n"
+	row := "| " + strings.Repeat("数据", 2200) + " | value |\n"
+	cfg := SplitterConfig{ChunkSize: 512, ChunkOverlap: 50, Separators: []string{"\n\n", "\n"}}
+
+	headingPrefix := "# Table Section\n\n" + header
+	headingText := headingPrefix + row + "plain tail\n\n# Next Section\n\nnext body"
+	heuristicText := "intro\f" + header + row
+	cases := map[string]struct {
+		text     string
+		rowStart int
+		rowEnd   int
+		chunks   []Chunk
+	}{
+		"heading": {
+			text:     headingText,
+			rowStart: runeLen(headingPrefix),
+			rowEnd:   runeLen(headingPrefix + row),
+			chunks:   splitByHeadingsImpl(headingText, cfg, nil),
+		},
+		"heuristic": {
+			text:     heuristicText,
+			rowStart: runeLen("intro\f" + header),
+			rowEnd:   runeLen(heuristicText),
+			chunks:   splitByHeuristicsImpl(heuristicText, cfg, nil),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			foundRowChunk := false
+			textRunes := []rune(tc.text)
+			for index, chunk := range tc.chunks {
+				if chunk.Start < 0 || chunk.End > len(textRunes) || chunk.Start >= chunk.End {
+					t.Fatalf("chunk %d has invalid span [%d, %d)", index, chunk.Start, chunk.End)
+				}
+				if chunk.End <= tc.rowStart || chunk.Start >= tc.rowEnd {
+					continue
+				}
+				foundRowChunk = true
+				if !strings.Contains(chunk.ContextHeader, header) {
+					t.Fatalf("row chunk %d lost table header context: %q", index, chunk.ContextHeader)
+				}
+				if got, want := chunk.Content, string(textRunes[chunk.Start:chunk.End]); got != want {
+					t.Fatalf("row chunk %d source span mismatch", index)
+				}
+			}
+			if !foundRowChunk {
+				t.Fatal("expected at least one oversized table row chunk")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- Lower the emergency ceiling for oversized protected units to 4096 runes.
- Preserve bounded overlap, source offsets, restoration, and active table context.
- Propagate table context through legacy, heading, heuristic, and parent-child strategies.
- Prevent high overlap or large headers from amplifying one protected unit into thousands of chunks.

## Why

Protected Markdown/code/table units could remain far larger than common embedding input budgets. A simple hard split would regress retrieval overlap and corrupt contextual headers or parent-child offsets, so those invariants are handled explicitly.

## Impact

Only the emergency path for oversized protected content changes. Ordinary chunks continue to use the configured chunk size. The 4096-rune ceiling is a conservative heuristic, not a strict tokenizer limit.

## Checks

- `go test -race ./internal/infrastructure/chunker`
- `go vet ./internal/infrastructure/chunker`
- `git diff --check origin/main...HEAD`
