### PR TITLE
fix(chat): preserve retrieval results during embedding failures

### DIFF
--- a/internal/application/service/chat_pipeline/search.go
+++ b/internal/application/service/chat_pipeline/search.go
@@ -323,6 +323,23 @@ func logSearchScoreSample(ctx context.Context, action string, results []*types.S
 	}
 }
 
+// targetReportsEmbedFailure reports whether an embedding failure for a KB should
+// be recorded as a retrieval error. Wiki/graph-only KBs have no vector or keyword
+// index to degrade into; HybridSearch returns empty without error. When KB metadata
+// is unavailable, callers still attempt keyword-degraded search.
+func targetReportsEmbedFailure(kb *types.KnowledgeBase) bool {
+	if kb == nil {
+		return false
+	}
+	if kb.Type == types.KnowledgeBaseTypeFAQ {
+		return true
+	}
+	if kb.IsKeywordEnabled() {
+		return false
+	}
+	return kb.IsVectorEnabled()
+}
+
 // searchByTargets performs KB searches using pre-computed SearchTargets.
 // Targets sharing the same underlying embedding model (identified by model
 // name + endpoint, not just model ID) are grouped so the query embedding is
@@ -403,7 +420,7 @@ func (p *PluginSearch) searchByTargets(
 					searchableTargets = make([]*types.SearchTarget, 0, len(targets))
 					for _, target := range targets {
 						kb := kbMap[target.KnowledgeBaseID]
-						if kb != nil && kb.Type != types.KnowledgeBaseTypeFAQ && kb.IsKeywordEnabled() {
+						if !targetReportsEmbedFailure(kb) {
 							searchableTargets = append(searchableTargets, target)
 							continue
 						}

--- a/internal/application/service/chat_pipeline/search.go
+++ b/internal/application/service/chat_pipeline/search.go
@@ -93,12 +93,14 @@ func (p *PluginSearch) OnEvent(ctx context.Context,
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	allResults := make([]*types.SearchResult, 0)
+	var kbSearchErr error
 
 	wg.Add(2)
 	// Goroutine 1: Knowledge base search using SearchTargets
 	go func() {
 		defer wg.Done()
-		kbResults := p.searchByTargets(ctx, chatManage)
+		kbResults, err := p.searchByTargets(ctx, chatManage)
+		kbSearchErr = err
 		if len(kbResults) > 0 {
 			mu.Lock()
 			allResults = append(allResults, kbResults...)
@@ -118,6 +120,18 @@ func (p *PluginSearch) OnEvent(ctx context.Context,
 	}()
 
 	wg.Wait()
+	if kbSearchErr != nil && len(allResults) == 0 {
+		pipelineError(ctx, "Search", "kb_search_failed", map[string]interface{}{
+			"error": kbSearchErr.Error(),
+		})
+		return ErrSearch.WithError(kbSearchErr)
+	}
+	if kbSearchErr != nil {
+		pipelineWarn(ctx, "Search", "kb_search_partial_failure", map[string]interface{}{
+			"error":        kbSearchErr.Error(),
+			"result_count": len(allResults),
+		})
+	}
 
 	chatManage.SearchResult = allResults
 
@@ -317,9 +331,9 @@ func logSearchScoreSample(ctx context.Context, action string, results []*types.S
 func (p *PluginSearch) searchByTargets(
 	ctx context.Context,
 	chatManage *types.ChatManage,
-) []*types.SearchResult {
+) ([]*types.SearchResult, error) {
 	if len(chatManage.SearchTargets) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	queryText := strings.TrimSpace(chatManage.RewriteQuery)
@@ -364,22 +378,45 @@ func (p *PluginSearch) searchByTargets(
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var results []*types.SearchResult
+	var firstErr error
+	var errOnce sync.Once
+	recordError := func(err error) {
+		if err != nil {
+			errOnce.Do(func() { firstErr = err })
+		}
+	}
 
 	for modelKey, targets := range groups {
 		wg.Add(1)
 		go func(modelKey string, targets []*types.SearchTarget) {
 			defer wg.Done()
 
-			// Compute embedding once for this model group.
+			// Compute embedding once for this model group. When that fails, retain
+			// only targets that have a real keyword index; vector-only targets must
+			// propagate the embedding failure instead of looking like empty recall.
 			var queryEmbedding []float32
+			disableVector := false
+			searchableTargets := targets
 			if modelKey != "" {
 				emb, err := p.knowledgeBaseService.GetQueryEmbedding(ctx, targets[0].KnowledgeBaseID, queryText)
 				if err != nil {
-					pipelineWarn(ctx, "Search", "group_embed_error", map[string]interface{}{
-						"model_key": modelKey,
-						"kb_id":     targets[0].KnowledgeBaseID,
-						"error":     err.Error(),
+					searchableTargets = make([]*types.SearchTarget, 0, len(targets))
+					for _, target := range targets {
+						kb := kbMap[target.KnowledgeBaseID]
+						if kb != nil && kb.Type != types.KnowledgeBaseTypeFAQ && kb.IsKeywordEnabled() {
+							searchableTargets = append(searchableTargets, target)
+							continue
+						}
+						recordError(fmt.Errorf("knowledge base %s has no keyword fallback: %w", target.KnowledgeBaseID, err))
+					}
+					pipelineWarn(ctx, "Search", "group_embed_degrade_keyword", map[string]interface{}{
+						"model_key":        modelKey,
+						"kb_id":            targets[0].KnowledgeBaseID,
+						"error":            err.Error(),
+						"fallback_targets": len(searchableTargets),
+						"failed_targets":   len(targets) - len(searchableTargets),
 					})
+					disableVector = true
 				} else {
 					queryEmbedding = emb
 				}
@@ -389,7 +426,7 @@ func (p *PluginSearch) searchByTargets(
 			// from specific-knowledge targets (need per-target direct loading).
 			var fullKBIDs []string
 			var knowledgeTargets []*types.SearchTarget
-			for _, t := range targets {
+			for _, t := range searchableTargets {
 				if t.Type == types.SearchTargetTypeKnowledgeBase && len(t.TagIDs) == 0 {
 					fullKBIDs = append(fullKBIDs, t.KnowledgeBaseID)
 				} else {
@@ -420,6 +457,7 @@ func (p *PluginSearch) searchByTargets(
 						KeywordThreshold:      chatManage.KeywordThreshold,
 						MatchCount:            chatManage.EmbeddingTopK,
 						SkipContextEnrichment: true,
+						DisableVectorMatch:    disableVector,
 					}
 					res, err := p.knowledgeBaseService.HybridSearch(ctx, fullKBIDs[0], params)
 					if err != nil {
@@ -427,6 +465,7 @@ func (p *PluginSearch) searchByTargets(
 							"kb_ids": fullKBIDs,
 							"error":  err.Error(),
 						})
+						recordError(err)
 						return
 					}
 					pipelineInfo(ctx, "Search", "combined_kb_result", map[string]interface{}{
@@ -444,7 +483,9 @@ func (p *PluginSearch) searchByTargets(
 				innerWg.Add(1)
 				go func(t *types.SearchTarget) {
 					defer innerWg.Done()
-					p.searchSingleTarget(ctx, chatManage, t, queryText, queryEmbedding, &mu, &results)
+					recordError(p.searchSingleTarget(
+						ctx, chatManage, t, queryText, queryEmbedding, disableVector, &mu, &results,
+					))
 				}(target)
 			}
 
@@ -457,7 +498,7 @@ func (p *PluginSearch) searchByTargets(
 	pipelineInfo(ctx, "Search", "kb_result_summary", map[string]interface{}{
 		"total_hits": len(results),
 	})
-	return results
+	return results, firstErr
 }
 
 // searchSingleTarget performs hybrid retrieval inside one constrained target.
@@ -467,11 +508,12 @@ func (p *PluginSearch) searchSingleTarget(
 	t *types.SearchTarget,
 	queryText string,
 	queryEmbedding []float32,
+	disableVector bool,
 	mu *sync.Mutex,
 	results *[]*types.SearchResult,
-) {
+) error {
 	if t.Type == types.SearchTargetTypeKnowledge && len(t.KnowledgeIDs) == 0 {
-		return
+		return nil
 	}
 
 	vectorThreshold, keywordThreshold := t.RecallThresholds(
@@ -494,6 +536,7 @@ func (p *PluginSearch) searchSingleTarget(
 		TagIDs:                t.TagIDs,
 		ScopeTagIDs:           t.ScopeTagIDs,
 		SkipContextEnrichment: true,
+		DisableVectorMatch:    disableVector,
 	}
 	if t.Type == types.SearchTargetTypeKnowledge {
 		params.KnowledgeIDs = t.KnowledgeIDs
@@ -506,7 +549,7 @@ func (p *PluginSearch) searchSingleTarget(
 			"query":       params.QueryText,
 			"error":       err.Error(),
 		})
-		return
+		return err
 	}
 	pipelineInfo(ctx, "Search", "kb_result", map[string]interface{}{
 		"kb_id":       t.KnowledgeBaseID,
@@ -516,6 +559,7 @@ func (p *PluginSearch) searchSingleTarget(
 	mu.Lock()
 	*results = append(*results, res...)
 	mu.Unlock()
+	return nil
 }
 
 // searchWebIfEnabled executes web search when enabled and returns converted results

--- a/internal/application/service/chat_pipeline/search_error_test.go
+++ b/internal/application/service/chat_pipeline/search_error_test.go
@@ -257,6 +257,122 @@ func (s *partialSearchKnowledgeBaseService) HybridSearch(
 	return []*types.SearchResult{{ID: "chunk-good", Content: "可用结果", KnowledgeID: "knowledge-good"}}, nil
 }
 
+type stubWebSearchService struct {
+	interfaces.WebSearchService
+	results []*types.WebSearchResult
+}
+
+func (s *stubWebSearchService) Search(
+	_ context.Context, _ string, _ *types.WebSearchConfig, _ string,
+) ([]*types.WebSearchResult, error) {
+	return s.results, nil
+}
+
+func TestSearchKeepsWebResultsWhenKnowledgeBaseFails(t *testing.T) {
+	rootCause := errors.New("kb store unavailable")
+	plugin := &PluginSearch{
+		knowledgeBaseService: &failingSearchKnowledgeBaseService{err: rootCause},
+		webSearchService: &stubWebSearchService{
+			results: []*types.WebSearchResult{{
+				URL:     "https://example.com/doc",
+				Title:   "Web hit",
+				Content: "web content",
+			}},
+		},
+		tenantService: &struct{ interfaces.TenantService }{},
+	}
+	chatManage := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{
+			SearchTargets: types.SearchTargets{{
+				Type:            types.SearchTargetTypeKnowledgeBase,
+				KnowledgeBaseID: "kb-1",
+			}},
+			EmbeddingTopK:       10,
+			WebSearchEnabled:    true,
+			WebSearchProviderID: "provider-1",
+		},
+		PipelineState: types.PipelineState{RewriteQuery: "并发检索"},
+	}
+	nextCalled := false
+
+	err := plugin.OnEvent(context.Background(), types.CHUNK_SEARCH, chatManage, func() *PluginError {
+		nextCalled = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected web results to keep pipeline alive, got %#v", err)
+	}
+	if !nextCalled {
+		t.Fatal("expected pipeline to continue with web results")
+	}
+	if len(chatManage.SearchResult) != 1 || chatManage.SearchResult[0].ID != "https://example.com/doc" {
+		t.Fatalf("expected web search result, got %#v", chatManage.SearchResult)
+	}
+}
+
+type wikiOnlySearchKnowledgeBaseService struct {
+	interfaces.KnowledgeBaseService
+	embedErr     error
+	hybridCalled bool
+}
+
+func (s *wikiOnlySearchKnowledgeBaseService) GetKnowledgeBasesByIDsOnly(
+	context.Context, []string,
+) ([]*types.KnowledgeBase, error) {
+	return []*types.KnowledgeBase{{
+		ID:               "wiki-1",
+		Type:             types.KnowledgeBaseTypeDocument,
+		EmbeddingModelID: "embedding-1",
+		IndexingStrategy: types.IndexingStrategy{WikiEnabled: true},
+	}}, nil
+}
+
+func (s *wikiOnlySearchKnowledgeBaseService) ResolveEmbeddingModelKeys(
+	context.Context, []*types.KnowledgeBase,
+) map[string]string {
+	return map[string]string{"wiki-1": "doubao|https://ark.cn-beijing.volces.com/api/v3"}
+}
+
+func (s *wikiOnlySearchKnowledgeBaseService) GetQueryEmbedding(
+	context.Context, string, string,
+) ([]float32, error) {
+	return nil, s.embedErr
+}
+
+func (s *wikiOnlySearchKnowledgeBaseService) HybridSearch(
+	context.Context, string, types.SearchParams,
+) ([]*types.SearchResult, error) {
+	s.hybridCalled = true
+	return nil, nil
+}
+
+func TestSearchEmbeddingFailureOnWikiOnlyTargetReportsNoResults(t *testing.T) {
+	svc := &wikiOnlySearchKnowledgeBaseService{
+		embedErr: errors.New("embedding endpoint unavailable"),
+	}
+	plugin := &PluginSearch{knowledgeBaseService: svc}
+	chatManage := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{
+			SearchTargets: types.SearchTargets{{
+				Type:            types.SearchTargetTypeKnowledgeBase,
+				KnowledgeBaseID: "wiki-1",
+			}},
+			EmbeddingTopK: 10,
+		},
+		PipelineState: types.PipelineState{RewriteQuery: "wiki only"},
+	}
+
+	err := plugin.OnEvent(context.Background(), types.CHUNK_SEARCH, chatManage, func() *PluginError {
+		return nil
+	})
+	if err != ErrSearchNothing {
+		t.Fatalf("expected search_nothing for wiki-only KB, got %#v", err)
+	}
+	if !svc.hybridCalled {
+		t.Fatal("wiki-only target should still delegate empty recall to HybridSearch")
+	}
+}
+
 func TestSearchKeepsSuccessfulResultsWhenAnotherTargetFails(t *testing.T) {
 	rootCause := errors.New("one store unavailable")
 	plugin := &PluginSearch{knowledgeBaseService: &partialSearchKnowledgeBaseService{rootCause: rootCause}}

--- a/internal/application/service/chat_pipeline/search_error_test.go
+++ b/internal/application/service/chat_pipeline/search_error_test.go
@@ -1,0 +1,288 @@
+package chatpipeline
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type failingSearchKnowledgeBaseService struct {
+	interfaces.KnowledgeBaseService
+	err error
+}
+
+func (s *failingSearchKnowledgeBaseService) GetKnowledgeBasesByIDsOnly(
+	context.Context, []string,
+) ([]*types.KnowledgeBase, error) {
+	return []*types.KnowledgeBase{{
+		ID:               "kb-1",
+		Type:             types.KnowledgeBaseTypeDocument,
+		EmbeddingModelID: "embedding-1",
+		IndexingStrategy: types.DefaultIndexingStrategy(),
+	}}, nil
+}
+
+func (s *failingSearchKnowledgeBaseService) ResolveEmbeddingModelKeys(
+	context.Context, []*types.KnowledgeBase,
+) map[string]string {
+	return map[string]string{"kb-1": "doubao|https://ark.cn-beijing.volces.com/api/v3"}
+}
+
+func (s *failingSearchKnowledgeBaseService) GetQueryEmbedding(
+	context.Context, string, string,
+) ([]float32, error) {
+	return nil, s.err
+}
+
+func (s *failingSearchKnowledgeBaseService) HybridSearch(
+	context.Context, string, types.SearchParams,
+) ([]*types.SearchResult, error) {
+	return nil, s.err
+}
+
+// embedding 失败会先降级为关键词检索；本用例中关键词检索也失败，
+// 此时必须仍报 search_failed 并保留根因，而不是伪装成"无结果"。
+func TestSearchEmbeddingFailureIsNotReportedAsNoResults(t *testing.T) {
+	rootCause := errors.New("embedding endpoint unavailable")
+	plugin := &PluginSearch{
+		knowledgeBaseService: &failingSearchKnowledgeBaseService{err: rootCause},
+	}
+	chatManage := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{
+			SearchTargets: types.SearchTargets{{
+				Type:            types.SearchTargetTypeKnowledgeBase,
+				KnowledgeBaseID: "kb-1",
+			}},
+			EmbeddingTopK: 10,
+		},
+		PipelineState: types.PipelineState{RewriteQuery: "精简邮件效果"},
+	}
+
+	err := plugin.OnEvent(context.Background(), types.CHUNK_SEARCH, chatManage, func() *PluginError {
+		return nil
+	})
+	if err == nil || err.ErrorType != ErrSearch.ErrorType {
+		t.Fatalf("expected search_failed, got %#v", err)
+	}
+	if !errors.Is(err.Err, rootCause) {
+		t.Fatalf("expected root cause to be preserved, got %v", err.Err)
+	}
+}
+
+type degradingSearchKnowledgeBaseService struct {
+	interfaces.KnowledgeBaseService
+	embedErr     error
+	gotParams    *types.SearchParams
+	searchResult []*types.SearchResult
+}
+
+func (s *degradingSearchKnowledgeBaseService) GetKnowledgeBasesByIDsOnly(
+	context.Context, []string,
+) ([]*types.KnowledgeBase, error) {
+	return []*types.KnowledgeBase{{
+		ID:               "kb-1",
+		Type:             types.KnowledgeBaseTypeDocument,
+		EmbeddingModelID: "embedding-1",
+		IndexingStrategy: types.DefaultIndexingStrategy(),
+	}}, nil
+}
+
+func (s *degradingSearchKnowledgeBaseService) ResolveEmbeddingModelKeys(
+	context.Context, []*types.KnowledgeBase,
+) map[string]string {
+	return map[string]string{"kb-1": "doubao|https://ark.cn-beijing.volces.com/api/v3"}
+}
+
+func (s *degradingSearchKnowledgeBaseService) GetQueryEmbedding(
+	context.Context, string, string,
+) ([]float32, error) {
+	return nil, s.embedErr
+}
+
+func (s *degradingSearchKnowledgeBaseService) HybridSearch(
+	_ context.Context, _ string, params types.SearchParams,
+) ([]*types.SearchResult, error) {
+	s.gotParams = &params
+	return s.searchResult, nil
+}
+
+// embedding API 限流/长尾时检索必须降级为纯关键词模式返回结果，
+// 而不是让整次 knowledge-search 以 500 失败（评测中三次复现的故障）。
+func TestSearchEmbeddingFailureDegradesToKeywordSearch(t *testing.T) {
+	svc := &degradingSearchKnowledgeBaseService{
+		embedErr: errors.New("embedding rate limited"),
+		searchResult: []*types.SearchResult{
+			{ID: "chunk-1", Content: "关键词命中的内容", KnowledgeID: "k-1"},
+		},
+	}
+	plugin := &PluginSearch{knowledgeBaseService: svc}
+	chatManage := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{
+			SearchTargets: types.SearchTargets{{
+				Type:            types.SearchTargetTypeKnowledgeBase,
+				KnowledgeBaseID: "kb-1",
+			}},
+			EmbeddingTopK: 10,
+		},
+		PipelineState: types.PipelineState{RewriteQuery: "树状筛选器 新建入口"},
+	}
+
+	err := plugin.OnEvent(context.Background(), types.CHUNK_SEARCH, chatManage, func() *PluginError {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected degraded keyword search to succeed, got %#v", err)
+	}
+	if len(chatManage.SearchResult) != 1 || chatManage.SearchResult[0].ID != "chunk-1" {
+		t.Fatalf("expected keyword results to be returned, got %#v", chatManage.SearchResult)
+	}
+	if svc.gotParams == nil || !svc.gotParams.DisableVectorMatch {
+		t.Fatalf("expected DisableVectorMatch=true after embedding failure, got %#v", svc.gotParams)
+	}
+	if len(svc.gotParams.QueryEmbedding) != 0 {
+		t.Fatalf("expected empty query embedding in degraded mode")
+	}
+}
+
+type vectorOnlySearchKnowledgeBaseService struct {
+	interfaces.KnowledgeBaseService
+	embedErr     error
+	hybridCalled bool
+}
+
+func (s *vectorOnlySearchKnowledgeBaseService) GetKnowledgeBasesByIDsOnly(
+	context.Context, []string,
+) ([]*types.KnowledgeBase, error) {
+	return []*types.KnowledgeBase{{
+		ID:               "faq-1",
+		Type:             types.KnowledgeBaseTypeFAQ,
+		EmbeddingModelID: "embedding-1",
+		IndexingStrategy: types.IndexingStrategy{VectorEnabled: true},
+	}}, nil
+}
+
+func (s *vectorOnlySearchKnowledgeBaseService) ResolveEmbeddingModelKeys(
+	context.Context, []*types.KnowledgeBase,
+) map[string]string {
+	return map[string]string{"faq-1": "doubao|https://ark.cn-beijing.volces.com/api/v3"}
+}
+
+func (s *vectorOnlySearchKnowledgeBaseService) GetQueryEmbedding(
+	context.Context, string, string,
+) ([]float32, error) {
+	return nil, s.embedErr
+}
+
+func (s *vectorOnlySearchKnowledgeBaseService) HybridSearch(
+	context.Context, string, types.SearchParams,
+) ([]*types.SearchResult, error) {
+	s.hybridCalled = true
+	return nil, nil
+}
+
+func TestSearchEmbeddingFailureOnVectorOnlyTargetPreservesRootCause(t *testing.T) {
+	rootCause := errors.New("embedding endpoint unavailable")
+	svc := &vectorOnlySearchKnowledgeBaseService{embedErr: rootCause}
+	plugin := &PluginSearch{knowledgeBaseService: svc}
+	chatManage := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{
+			SearchTargets: types.SearchTargets{{
+				Type:            types.SearchTargetTypeKnowledgeBase,
+				KnowledgeBaseID: "faq-1",
+			}},
+			EmbeddingTopK: 10,
+		},
+		PipelineState: types.PipelineState{RewriteQuery: "退款规则"},
+	}
+
+	err := plugin.OnEvent(context.Background(), types.CHUNK_SEARCH, chatManage, func() *PluginError {
+		return nil
+	})
+	if err == nil || err.ErrorType != ErrSearch.ErrorType {
+		t.Fatalf("expected search_failed, got %#v", err)
+	}
+	if !errors.Is(err.Err, rootCause) {
+		t.Fatalf("expected root cause to be preserved, got %v", err.Err)
+	}
+	if svc.hybridCalled {
+		t.Fatal("vector-only target must not run a disabled-vector search")
+	}
+}
+
+type partialSearchKnowledgeBaseService struct {
+	interfaces.KnowledgeBaseService
+	rootCause error
+}
+
+func (s *partialSearchKnowledgeBaseService) GetKnowledgeBasesByIDsOnly(
+	_ context.Context, ids []string,
+) ([]*types.KnowledgeBase, error) {
+	result := make([]*types.KnowledgeBase, 0, len(ids))
+	for _, id := range ids {
+		result = append(result, &types.KnowledgeBase{
+			ID:               id,
+			Type:             types.KnowledgeBaseTypeDocument,
+			EmbeddingModelID: "embedding-" + id,
+			IndexingStrategy: types.DefaultIndexingStrategy(),
+		})
+	}
+	return result, nil
+}
+
+func (s *partialSearchKnowledgeBaseService) ResolveEmbeddingModelKeys(
+	_ context.Context, kbs []*types.KnowledgeBase,
+) map[string]string {
+	result := make(map[string]string, len(kbs))
+	for _, kb := range kbs {
+		result[kb.ID] = "model-" + kb.ID
+	}
+	return result
+}
+
+func (s *partialSearchKnowledgeBaseService) GetQueryEmbedding(
+	context.Context, string, string,
+) ([]float32, error) {
+	return []float32{1}, nil
+}
+
+func (s *partialSearchKnowledgeBaseService) HybridSearch(
+	_ context.Context, id string, _ types.SearchParams,
+) ([]*types.SearchResult, error) {
+	if id == "kb-bad" {
+		return nil, s.rootCause
+	}
+	return []*types.SearchResult{{ID: "chunk-good", Content: "可用结果", KnowledgeID: "knowledge-good"}}, nil
+}
+
+func TestSearchKeepsSuccessfulResultsWhenAnotherTargetFails(t *testing.T) {
+	rootCause := errors.New("one store unavailable")
+	plugin := &PluginSearch{knowledgeBaseService: &partialSearchKnowledgeBaseService{rootCause: rootCause}}
+	chatManage := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{
+			SearchTargets: types.SearchTargets{
+				{Type: types.SearchTargetTypeKnowledgeBase, KnowledgeBaseID: "kb-good"},
+				{Type: types.SearchTargetTypeKnowledgeBase, KnowledgeBaseID: "kb-bad"},
+			},
+			EmbeddingTopK: 10,
+		},
+		PipelineState: types.PipelineState{RewriteQuery: "部分成功"},
+	}
+	nextCalled := false
+
+	err := plugin.OnEvent(context.Background(), types.CHUNK_SEARCH, chatManage, func() *PluginError {
+		nextCalled = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected partial success to continue, got %#v", err)
+	}
+	if !nextCalled {
+		t.Fatal("expected pipeline to continue with successful results")
+	}
+	if len(chatManage.SearchResult) != 1 || chatManage.SearchResult[0].ID != "chunk-good" {
+		t.Fatalf("expected successful target result, got %#v", chatManage.SearchResult)
+	}
+}


### PR DESCRIPTION
## What changed

- Propagate knowledge-base search errors instead of reporting them as empty recall.
- Fall back to keyword retrieval when query embedding fails and the target has a keyword index.
- Preserve successful KB or web results when another independent search branch fails.
- Keep the original embedding error for FAQ/vector-only targets that cannot degrade to keyword search.

## Why

Embedding provider throttling or latency could either abort retrieval unnecessarily or be hidden as `search_nothing`. Independent partial successes were also discarded when one KB branch failed.

## Impact

The change is limited to the chat retrieval pipeline. Existing target grouping, thresholds, and KB/web concurrency are preserved.

## Checks

- `go test -race ./internal/application/service/chat_pipeline`
- `go vet ./internal/application/service/chat_pipeline`
- `git diff --check origin/main...HEAD`
