### PR TITLE
fix(docparser): default PPT/PPTX to MarkItDown

### DIFF
--- a/internal/types/knowledgebase.go
+++ b/internal/types/knowledgebase.go
@@ -179,7 +179,7 @@ type ChunkingConfig struct {
 	// Separators
 	Separators []string `yaml:"separators"    json:"separators"`
 	// ParserEngineRules configures which parser engine to use for each file type.
-	// When empty, the builtin engine is used for all types.
+	// When no rule matches, presentations use MarkItDown and other types use the builtin engine.
 	ParserEngineRules []ParserEngineRule `yaml:"parser_engine_rules,omitempty" json:"parser_engine_rules,omitempty"`
 	// EnableParentChild enables two-level parent-child chunking strategy.
 	// When enabled, large parent chunks provide context while small child chunks
@@ -208,12 +208,18 @@ type ChunkingConfig struct {
 	TableMetadataInstructions string `yaml:"table_metadata_instructions,omitempty" json:"table_metadata_instructions,omitempty"`
 }
 
-// ResolveParserEngine returns the engine name for the given file type
-// based on the configured rules. Returns empty string (builtin) when
-// no rule matches.
+// ResolveParserEngine returns the engine name for the given file type based on
+// the configured rules. Presentations default to MarkItDown when no explicit
+// rule matches; other file types return an empty string (builtin).
 func (c ChunkingConfig) ResolveParserEngine(fileType string) string {
 	if rule := c.ResolveParserEngineRule(fileType); rule != nil {
 		return rule.Engine
+	}
+	// The bundled DocReader handles presentations through its MarkItDown
+	// engine; the builtin engine intentionally covers other Office formats.
+	switch normalizeParserFileType(fileType) {
+	case "ppt", "pptx":
+		return "markitdown"
 	}
 	return ""
 }

--- a/internal/types/knowledgebase_test.go
+++ b/internal/types/knowledgebase_test.go
@@ -315,3 +315,30 @@ func TestEffectiveStorageProvider_CrossBackendDetection(t *testing.T) {
 			dstSame.EffectiveStorageProvider(tenantDefault), sp)
 	}
 }
+
+func TestResolveParserEngineDefaultsPresentationsToMarkItDown(t *testing.T) {
+	config := ChunkingConfig{}
+	for _, fileType := range []string{"ppt", "pptx", "PPTX", ".pptx"} {
+		if got := config.ResolveParserEngine(fileType); got != "markitdown" {
+			t.Fatalf("ResolveParserEngine(%q) = %q, want markitdown", fileType, got)
+		}
+	}
+	if got := config.ResolveParserEngine("pdf"); got != "" {
+		t.Fatalf("ResolveParserEngine(pdf) = %q, want builtin default", got)
+	}
+
+	overridden := ChunkingConfig{ParserEngineRules: []ParserEngineRule{{
+		FileTypes: []string{".PPTX"},
+		Engine:    "mineru",
+	}}}
+	if got := overridden.ResolveParserEngine("pptx"); got != "mineru" {
+		t.Fatalf("explicit presentation parser rule = %q, want mineru", got)
+	}
+	builtin := ChunkingConfig{ParserEngineRules: []ParserEngineRule{{
+		FileTypes: []string{"ppt", "pptx"},
+		Engine:    "builtin",
+	}}}
+	if got := builtin.ResolveParserEngine(".PPT"); got != "builtin" {
+		t.Fatalf("explicit builtin presentation parser rule = %q, want builtin", got)
+	}
+}


### PR DESCRIPTION
## What changed

- Default PPT and PPTX files to the MarkItDown parser when no explicit parser rule matches.
- Preserve explicit `builtin`, `mineru`, and other parser overrides.
- Keep PDF and other file types on their existing builtin default.

## Why

Presentations need a parser with reliable PPT/PPTX support. Previously an empty parser rule selected the generic builtin path instead of the already registered MarkItDown presentation parser.

## Impact

Only the no-matching-rule fallback for PPT/PPTX changes. Existing parser configuration remains authoritative.

## Checks

- Focused tests in `./internal/types` and `./internal/application/service`
- `go vet ./internal/types`
- `git diff --check origin/main...HEAD`
