### PR TITLE
feat(mcp-server): add create_knowledge_from_text tool

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### 新增
+- 新增 `create_knowledge_from_text` 工具：通过手动 Markdown 文本创建知识条目，调用既有 `/knowledge-bases/{id}/knowledge/manual` 接口，补齐 #323 中"文本"部分。默认 `status="publish"`，创建后即进入解析/索引流程、可被检索；可传 `status="draft"` 仅保存不索引。
+- README 工具清单补列既有的 `create_knowledge_from_file`。
+
 ## [1.1.1] - 2026-07-30
 
 ### 变更

--- a/mcp-server/EXAMPLES.md
+++ b/mcp-server/EXAMPLES.md
@@ -122,6 +122,19 @@ echo "WEKNORA_API_KEY=your_api_key_here" >> .env
 }
 ```
 
+#### 从文本创建知识
+```json
+{
+  "tool": "create_knowledge_from_text",
+  "arguments": {
+    "kb_id": "my-knowledge-base",
+    "title": "注意力机制摘要",
+    "content": "# 注意力机制\n\n注意力机制允许模型在处理序列时动态分配权重...",
+    "status": "publish"
+  }
+}
+```
+
 #### 列出知识
 ```json
 {

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -120,7 +120,9 @@ python test_module.py
 - `hybrid_search` - 混合搜索
 
 ### 知识管理
+- `create_knowledge_from_file` - 从本地文件创建知识
 - `create_knowledge_from_url` - 从 URL 创建知识
+- `create_knowledge_from_text` - 从文本创建知识
 - `list_knowledge` - 列出知识
 - `get_knowledge` - 获取知识详情
 - `delete_knowledge` - 删除知识

--- a/mcp-server/test_create_knowledge_from_text.py
+++ b/mcp-server/test_create_knowledge_from_text.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Tests for the create_knowledge_from_text MCP tool and client method.
+
+unittest discover 会收集本文件中的 TestCase；也可直接运行:
+python test_create_knowledge_from_text.py
+"""
+
+import unittest
+from unittest import mock
+
+import weknora_mcp_server as srv
+
+
+class CreateKnowledgeFromTextTest(unittest.TestCase):
+    def test_client_method_exists_and_callable(self):
+        client = srv.WeKnoraClient("http://localhost:8080/api/v1", "k")
+        self.assertTrue(callable(getattr(client, "create_knowledge_from_text", None)))
+
+    def test_posts_to_manual_endpoint_with_expected_body(self):
+        client = srv.WeKnoraClient("http://localhost:8080/api/v1", "k")
+        with mock.patch.object(client, "_request", return_value={"ok": True}) as req:
+            client.create_knowledge_from_text("kb-1", "T", "C", tag_ids=["t1"])
+        args, kwargs = req.call_args
+        self.assertEqual(args[0], "POST")
+        self.assertEqual(args[1], "/knowledge-bases/kb-1/knowledge/manual")
+        body = kwargs["json"]
+        self.assertEqual(body["title"], "T")
+        self.assertEqual(body["content"], "C")
+        self.assertEqual(body["tag_ids"], ["t1"])
+        # status defaults to "publish" so the entry is indexed/searchable.
+        self.assertEqual(body["status"], "publish")
+
+    def test_status_can_be_overridden_to_draft(self):
+        client = srv.WeKnoraClient("http://localhost:8080/api/v1", "k")
+        with mock.patch.object(client, "_request", return_value={"ok": True}) as req:
+            client.create_knowledge_from_text("kb-1", "T", "C", status="draft")
+        self.assertEqual(req.call_args.kwargs["json"]["status"], "draft")
+
+    def test_omits_tag_ids_when_none(self):
+        client = srv.WeKnoraClient("http://localhost:8080/api/v1", "k")
+        with mock.patch.object(client, "_request", return_value={"ok": True}) as req:
+            client.create_knowledge_from_text("kb-1", "T", "C")
+        body = req.call_args.kwargs["json"]
+        self.assertNotIn("tag_ids", body)
+        self.assertEqual(body["status"], "publish")
+
+    def test_tool_function_resolves_kb_id_and_forwards_status(self):
+        with mock.patch.object(
+            srv.client, "resolve_kb_id", return_value="uuid-1"
+        ) as rid, mock.patch.object(
+            srv.client, "create_knowledge_from_text", return_value={"ok": True}
+        ) as method:
+            srv.create_knowledge_from_text("my-kb", "T", "C", status="draft")
+        rid.assert_called_once_with("my-kb")
+        method.assert_called_once_with("uuid-1", "T", "C", tag_ids=None, status="draft")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp-server/test_mcp_transports.py
+++ b/mcp-server/test_mcp_transports.py
@@ -66,7 +66,7 @@ class TransportRegressionTest(unittest.TestCase):
 
 
 class StdioToolsListTest(unittest.TestCase):
-    def test_tools_list_returns_29_tools(self):
+    def test_tools_list_returns_30_tools(self):
         async def _run() -> int:
             from mcp import ClientSession, StdioServerParameters
             from mcp.client.stdio import stdio_client
@@ -86,7 +86,7 @@ class StdioToolsListTest(unittest.TestCase):
                     return len(tools.tools)
 
         count = asyncio.run(_run())
-        self.assertEqual(count, 29)
+        self.assertEqual(count, 30)
 
 
 class HttpStatelessSmokeTest(unittest.TestCase):

--- a/mcp-server/weknora_mcp_server.py
+++ b/mcp-server/weknora_mcp_server.py
@@ -335,6 +335,31 @@ class WeKnoraClient:
             "POST", f"/knowledge-bases/{kb_id}/knowledge/url", json=data
         )
 
+    def create_knowledge_from_text(
+        self,
+        kb_id: str,
+        title: str,
+        content: str,
+        tag_ids: list[str] | None = None,
+        status: str = "publish",
+    ) -> Dict:
+        """Create a knowledge entry from raw Markdown text (manual knowledge).
+
+        ``status`` defaults to ``"publish"`` so the entry is chunked, embedded
+        and made searchable immediately, which suits API/MCP callers that have
+        no UI to publish drafts. Pass ``"draft"`` to save without indexing.
+        """
+        data = {
+            "title": title,
+            "content": content,
+            "status": status,
+        }
+        if tag_ids:
+            data["tag_ids"] = tag_ids
+        return self._request(
+            "POST", f"/knowledge-bases/{kb_id}/knowledge/manual", json=data
+        )
+
     def list_knowledge(self, kb_id: str, page: int = 1, page_size: int = 20) -> Dict:
         """List knowledge in a knowledge base"""
         params = {"page": page, "page_size": page_size}
@@ -712,6 +737,27 @@ def create_knowledge_from_url(
 ) -> dict:
     """Create knowledge from a web URL."""
     return client.create_knowledge_from_url(kb_id, url, enable_multimodel)
+
+
+@mcp.tool()
+def create_knowledge_from_text(
+    kb_id: str,
+    title: str,
+    content: str,
+    tag_ids: list[str] | None = None,
+    status: str = "publish",
+) -> dict:
+    """Create a knowledge entry from raw Markdown text.
+
+    Use this when you have the document content directly (e.g. an abstract or
+    pasted text) instead of a file path or URL. ``kb_id`` may be a UUID or a
+    knowledge-base name (resolved automatically). ``title`` and ``content``
+    are required. ``status`` defaults to ``"publish"`` so the entry is indexed
+    and searchable immediately; pass ``"draft"`` to save without indexing.
+    """
+    return client.create_knowledge_from_text(
+        client.resolve_kb_id(kb_id), title, content, tag_ids=tag_ids, status=status
+    )
 
 
 @mcp.tool()


### PR DESCRIPTION
## Description

Adds a `create_knowledge_from_text` MCP tool that creates a knowledge entry from raw Markdown text by calling the existing backend endpoint `POST /knowledge-bases/{id}/knowledge/manual` (`handler.CreateManualKnowledge`). This completes the "text" half of #323, which asks for MCP tools to add knowledge from "local file **or text**" — the file half (`create_knowledge_from_file`) already exists; this adds the missing text half.

No Go/backend changes: the `/manual` endpoint already powers the web UI's "paste text" knowledge-creation flow and uses the same `OwnedKBOrAdmin` + `KBAccessWrite` middleware as `/file` and `/url`.

The tool defaults to `status="publish"` so the created entry is enqueued for chunking/embedding and becomes searchable (vs. `status="draft"`, which saves without indexing) — matching the API/MCP use case where there is no UI to publish a draft. `kb_id` may be a UUID or a knowledge-base name (resolved automatically, like `create_session` / `hybrid_search`). Note: the sibling `create_knowledge_from_file` / `create_knowledge_from_url` tools currently require a UUID; aligning them to also resolve names could be a follow-up.

This PR also documents the pre-existing `create_knowledge_from_file` tool, which was missing from the README tool list.

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #323

## Testing

From `mcp-server/` (CI runs the suite via `python -m unittest discover -s . -p "test_*.py" -v`):

- `python -m unittest discover -s . -p "test_*.py" -v` → 23 tests pass, including the 5 new `test_create_knowledge_from_text` tests and the updated `test_tools_list_returns_30_tools` (tool count 29 → 30 for the newly registered tool).
- `python -m black --check test_create_knowledge_from_text.py` → clean.
- `python -m ruff check weknora_mcp_server.py test_create_knowledge_from_text.py test_mcp_transports.py` → all checks passed.

The new tests verify (without a live WeKnora stack, by monkeypatching the HTTP layer):
- The client method POSTs to `/knowledge-bases/{kb_id}/knowledge/manual` with the expected body `{title, content, status, tag_ids?}`.
- `status` defaults to `"publish"` and can be overridden to `"draft"`.
- `tag_ids` is omitted when not provided.
- The `@mcp.tool()` function resolves `kb_id` via `resolve_kb_id` and forwards `status`.

The request shape was verified against `internal/types/knowledge.go` (`ManualKnowledgePayload`), the route `internal/router/routes_knowledge.go:75`, and that `status="publish"` triggers indexing in `internal/application/service/knowledge_create.go` (`CreateManualKnowledge`).

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`; N/A here — no Go changes, `ruff check` passes on the changed Python files)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.) — updated README.md, EXAMPLES.md, CHANGELOG.md
- [ ] Breaking changes are clearly called out in the description above (N/A — purely additive)

## Screenshots / Recordings
N/A — no user-visible UI changes (MCP tool addition only).
