### PR TITLE
fix: support zero chunk overlap

### DIFF
--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
@@ -870,7 +870,7 @@ const loadKBData = async (kbIdOverride?: string) => {
         chunkSize: kb.chunking_config?.chunk_size || 512,
         // Fallback only used when the loaded KB has no chunk_overlap stored.
         // Aligned with chunker.DefaultChunkOverlap on the backend.
-        chunkOverlap: kb.chunking_config?.chunk_overlap || 80,
+        chunkOverlap: kb.chunking_config?.chunk_overlap ?? 80,
         separators: kb.chunking_config?.separators || ['\n\n', '\n', '。', '！', '？', ';', '；'],
         parserEngineRules: kb.chunking_config?.parser_engine_rules || undefined,
         enableParentChild: kb.chunking_config?.enable_parent_child || false,

--- a/frontend/src/views/knowledge/components/UploadConfirmDialog.test.ts
+++ b/frontend/src/views/knowledge/components/UploadConfirmDialog.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 import { readFileSync } from 'node:fs'
 
 const dialog = readFileSync(new URL('./UploadConfirmDialog.vue', import.meta.url), 'utf8')
+const editor = readFileSync(new URL('../KnowledgeBaseEditorModal.vue', import.meta.url), 'utf8')
 const host = readFileSync(new URL('../../../components/UploadConfirmHost.vue', import.meta.url), 'utf8')
 const knowledgeBase = readFileSync(new URL('../KnowledgeBase.vue', import.meta.url), 'utf8')
 const platform = readFileSync(new URL('../../platform/index.vue', import.meta.url), 'utf8')
@@ -77,4 +78,11 @@ test('uses section navigation with inline chunking controls and advanced options
   assert.match(dialog, /statusFull/)
   assert.match(dialog, /data-section="multimodal"/)
   assert.doesNotMatch(dialog, /<KBChunkingSettings/)
+})
+
+test('preserves an explicit zero chunk overlap when loading saved settings', () => {
+  assert.match(dialog, /chunkOverlap: kb\.chunking_config\?\.chunk_overlap \?\? 80/)
+  assert.match(editor, /chunkOverlap: kb\.chunking_config\?\.chunk_overlap \?\? 80/)
+  assert.doesNotMatch(dialog, /chunk_overlap \|\| 80/)
+  assert.doesNotMatch(editor, /chunk_overlap \|\| 80/)
 })

--- a/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
+++ b/frontend/src/views/knowledge/components/UploadConfirmDialog.vue
@@ -1094,7 +1094,7 @@ function initFromKbInfo(kb: any) {
   uiState.value = {
     chunkingConfig: {
       chunkSize: kb.chunking_config?.chunk_size || 512,
-      chunkOverlap: kb.chunking_config?.chunk_overlap || 80,
+      chunkOverlap: kb.chunking_config?.chunk_overlap ?? 80,
       separators: kb.chunking_config?.separators || ['\n\n', '\n', '。', '！', '？', ';', '；'],
       parserEngineRules: kb.chunking_config?.parser_engine_rules || undefined,
       enableParentChild: kb.chunking_config?.enable_parent_child ?? false,

--- a/internal/application/service/knowledge_create_test.go
+++ b/internal/application/service/knowledge_create_test.go
@@ -281,7 +281,7 @@ func TestCreateKnowledgeFromFile_PersistsProcessOverrides(t *testing.T) {
 
 	chunkSize := 512
 	overrides := &types.KnowledgeProcessOverrides{
-		ChunkingConfig: &types.ChunkingConfig{ChunkSize: chunkSize},
+		ChunkingConfig: &types.ChunkingConfigOverride{ChunkSize: chunkSize},
 	}
 
 	knowledge, err := svc.CreateKnowledgeFromFile(

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -212,9 +212,8 @@ func markKnowledgeProcessing(knowledge *types.Knowledge, now time.Time) {
 }
 
 // buildSplitterConfig creates a SplitterConfig with fallbacks from a KnowledgeBase.
-// Defaults mirror chunker.DefaultChunkSize / DefaultChunkOverlap so behavior is
-// identical whether callers come through this path or invoke the chunker
-// directly with a zero-value config.
+// ChunkOverlap deliberately has no zero-value fallback: zero is a valid setting
+// that disables overlap.
 func buildSplitterConfig(kb *types.KnowledgeBase) chunker.SplitterConfig {
 	return buildSplitterConfigFromChunking(kb.ChunkingConfig)
 }
@@ -231,8 +230,8 @@ func buildSplitterConfigFromChunking(cc types.ChunkingConfig) chunker.SplitterCo
 	if chunkCfg.ChunkSize <= 0 {
 		chunkCfg.ChunkSize = chunker.DefaultChunkSize
 	}
-	if chunkCfg.ChunkOverlap <= 0 {
-		chunkCfg.ChunkOverlap = chunker.DefaultChunkOverlap
+	if chunkCfg.ChunkOverlap < 0 {
+		chunkCfg.ChunkOverlap = 0
 	}
 	if len(chunkCfg.Separators) == 0 {
 		chunkCfg.Separators = []string{"\n\n", "\n", "。"}
@@ -261,9 +260,13 @@ func buildParentChildConfigs(cc types.ChunkingConfig, base chunker.SplitterConfi
 		Separators:   base.Separators,
 		Strategy:     base.Strategy,
 	}
+	childOverlap := childSize / 5 // ~20% overlap for child chunks
+	if base.ChunkOverlap == 0 {
+		childOverlap = 0
+	}
 	child = chunker.SplitterConfig{
 		ChunkSize:    childSize,
-		ChunkOverlap: childSize / 5, // ~20% overlap for child chunks
+		ChunkOverlap: childOverlap,
 		Separators:   base.Separators,
 		Strategy:     base.Strategy,
 	}

--- a/internal/application/service/knowledge_process_config.go
+++ b/internal/application/service/knowledge_process_config.go
@@ -246,7 +246,7 @@ func derefExtractConfig(cfg *types.ExtractConfig) types.ExtractConfig {
 	return *cfg
 }
 
-func mergeChunkingConfig(base types.ChunkingConfig, override *types.ChunkingConfig) types.ChunkingConfig {
+func mergeChunkingConfig(base types.ChunkingConfig, override *types.ChunkingConfigOverride) types.ChunkingConfig {
 	if override == nil {
 		return base
 	}
@@ -254,8 +254,8 @@ func mergeChunkingConfig(base types.ChunkingConfig, override *types.ChunkingConf
 	if override.ChunkSize != 0 {
 		result.ChunkSize = override.ChunkSize
 	}
-	if override.ChunkOverlap != 0 {
-		result.ChunkOverlap = override.ChunkOverlap
+	if override.ChunkOverlap != nil {
+		result.ChunkOverlap = *override.ChunkOverlap
 	}
 	if len(override.Separators) > 0 {
 		result.Separators = override.Separators

--- a/internal/application/service/knowledge_process_config_test.go
+++ b/internal/application/service/knowledge_process_config_test.go
@@ -16,6 +16,10 @@ func processConfigBoolPtr(v bool) *bool {
 	return &v
 }
 
+func processConfigIntPtr(v int) *int {
+	return &v
+}
+
 func testKBWithGraphEnabled(enabled bool) *types.KnowledgeBase {
 	return &types.KnowledgeBase{
 		IndexingStrategy: types.IndexingStrategy{GraphEnabled: enabled},
@@ -30,11 +34,27 @@ func TestResolveProcessConfig_OverridesChunkSize(t *testing.T) {
 		ChunkingConfig: types.ChunkingConfig{ChunkSize: 512, ChunkOverlap: 50},
 	}
 	overrides := &types.KnowledgeProcessOverrides{
-		ChunkingConfig: &types.ChunkingConfig{ChunkSize: 2048},
+		ChunkingConfig: &types.ChunkingConfigOverride{ChunkSize: 2048},
 	}
 	eff := ResolveProcessConfig(kb, overrides)
 	require.Equal(t, 2048, eff.ChunkingConfig.ChunkSize)
 	require.Equal(t, 50, eff.ChunkingConfig.ChunkOverlap)
+}
+
+func TestResolveProcessConfig_ExplicitZeroChunkOverlap(t *testing.T) {
+	t.Parallel()
+
+	kb := &types.KnowledgeBase{
+		ChunkingConfig: types.ChunkingConfig{ChunkSize: 512, ChunkOverlap: 80},
+	}
+	overrides := &types.KnowledgeProcessOverrides{
+		ChunkingConfig: &types.ChunkingConfigOverride{
+			ChunkOverlap: processConfigIntPtr(0),
+		},
+	}
+
+	eff := ResolveProcessConfig(kb, overrides)
+	require.Zero(t, eff.ChunkingConfig.ChunkOverlap)
 }
 
 func TestResolveProcessConfig_OverrideTogglesParentChild(t *testing.T) {
@@ -45,7 +65,7 @@ func TestResolveProcessConfig_OverrideTogglesParentChild(t *testing.T) {
 		ChunkingConfig: types.ChunkingConfig{ChunkSize: 512, EnableParentChild: true},
 	}
 	effOff := ResolveProcessConfig(kbOn, &types.KnowledgeProcessOverrides{
-		ChunkingConfig: &types.ChunkingConfig{ChunkSize: 512, EnableParentChild: false},
+		ChunkingConfig: &types.ChunkingConfigOverride{ChunkSize: 512, EnableParentChild: false},
 	})
 	require.False(t, effOff.ChunkingConfig.EnableParentChild)
 
@@ -54,7 +74,7 @@ func TestResolveProcessConfig_OverrideTogglesParentChild(t *testing.T) {
 		ChunkingConfig: types.ChunkingConfig{ChunkSize: 512, EnableParentChild: false},
 	}
 	effOn := ResolveProcessConfig(kbOff, &types.KnowledgeProcessOverrides{
-		ChunkingConfig: &types.ChunkingConfig{ChunkSize: 512, EnableParentChild: true},
+		ChunkingConfig: &types.ChunkingConfigOverride{ChunkSize: 512, EnableParentChild: true},
 	})
 	require.True(t, effOn.ChunkingConfig.EnableParentChild)
 }
@@ -117,7 +137,9 @@ func TestBuildSplitterConfigFromChunking_UsesEffectiveChunkingConfig(t *testing.
 		ChunkingConfig: types.ChunkingConfig{ChunkSize: 512, ChunkOverlap: 50, Strategy: "token"},
 	}
 	overrides := &types.KnowledgeProcessOverrides{
-		ChunkingConfig: &types.ChunkingConfig{ChunkSize: 1500, ChunkOverlap: 120, Strategy: "character"},
+		ChunkingConfig: &types.ChunkingConfigOverride{
+			ChunkSize: 1500, ChunkOverlap: processConfigIntPtr(120), Strategy: "character",
+		},
 	}
 	eff := ResolveProcessConfig(kb, overrides)
 	cfg := buildSplitterConfigFromChunking(eff.ChunkingConfig)
@@ -125,6 +147,18 @@ func TestBuildSplitterConfigFromChunking_UsesEffectiveChunkingConfig(t *testing.
 	require.Equal(t, 1500, cfg.ChunkSize)
 	require.Equal(t, 120, cfg.ChunkOverlap)
 	require.Equal(t, "character", cfg.Strategy)
+}
+
+func TestBuildSplitterConfigFromChunking_PreservesZeroOverlap(t *testing.T) {
+	t.Parallel()
+
+	cfg := buildSplitterConfigFromChunking(types.ChunkingConfig{
+		ChunkSize:    512,
+		ChunkOverlap: 0,
+		Separators:   []string{"\n"},
+	})
+
+	require.Zero(t, cfg.ChunkOverlap)
 }
 
 func TestEffectiveChunkingConfig_ResolveParserEngineFromOverrides(t *testing.T) {
@@ -303,7 +337,7 @@ func TestResolveProcessConfig_PreservesKnowledgeBasePromptInstructions(t *testin
 		ExtractConfig: &types.ExtractConfig{Enabled: true, CustomInstructions: "contract entities"},
 	}
 	overrides := &types.KnowledgeProcessOverrides{
-		ChunkingConfig:           &types.ChunkingConfig{ChunkSize: 256},
+		ChunkingConfig:           &types.ChunkingConfigOverride{ChunkSize: 256},
 		VLMConfig:                &types.VLMConfig{Enabled: true, ModelID: "vlm-2"},
 		QuestionGenerationConfig: &types.QuestionGenerationConfig{Enabled: true, QuestionCount: 5},
 		ExtractConfig:            &types.ExtractConfig{Enabled: true},
@@ -524,4 +558,20 @@ func TestBuildParentChildConfigs_PropagatesStrategy(t *testing.T) {
 	require.Equal(t, 512/5, child.ChunkOverlap)
 	require.Equal(t, base.Separators, parent.Separators)
 	require.Equal(t, base.Separators, child.Separators)
+}
+
+func TestBuildParentChildConfigs_ZeroOverlapDisablesBothLevels(t *testing.T) {
+	t.Parallel()
+
+	base := chunker.SplitterConfig{
+		ChunkSize:    1000,
+		ChunkOverlap: 0,
+		Separators:   []string{"\n\n", "\n"},
+	}
+	cc := types.ChunkingConfig{ParentChunkSize: 4096, ChildChunkSize: 512}
+
+	parent, child := buildParentChildConfigs(cc, base)
+
+	require.Zero(t, parent.ChunkOverlap)
+	require.Zero(t, child.ChunkOverlap)
 }

--- a/internal/infrastructure/chunker/splitter.go
+++ b/internal/infrastructure/chunker/splitter.go
@@ -90,16 +90,8 @@ type SplitterConfig struct {
 // strictly atomic data (FAQ, JSON records), 150–200 for long narratives
 // where reasoning crosses chunks.
 //
-// MIGRATION NOTE: Prior versions had three different overlap defaults
-// (Go DefaultConfig: 64, knowledge.go buildSplitterConfig: 50, Python
-// docreader: 100). All consolidated to 80 here.
-//
-// Existing knowledge bases that stored ChunkOverlap=0 in the DB pick
-// this 80 up on next re-index; their previously-indexed embeddings will
-// not match new ones bit-for-bit. Recall stays similar but search
-// ranking can shift slightly. To freeze the old behavior on a per-KB
-// basis, explicitly set ChunkingConfig.ChunkOverlap to 64 before
-// re-indexing.
+// Callers wanting these recommended defaults should use DefaultConfig. A
+// literal ChunkOverlap=0 is preserved because it explicitly disables overlap.
 const (
 	DefaultChunkSize    = 512
 	DefaultChunkOverlap = 80

--- a/internal/infrastructure/chunker/strategy.go
+++ b/internal/infrastructure/chunker/strategy.go
@@ -238,9 +238,9 @@ func runTier(tier StrategyTier, text string, cfg SplitterConfig, profile *DocPro
 	return SplitText(text, cfg)
 }
 
-// ensureDefaults fills in zero-value config fields with sane defaults.
-// Mirrors buildSplitterConfig in internal/application/service/knowledge.go
-// so direct callers of this package get the same numbers.
+// ensureDefaults fills in unset config fields with sane defaults. ChunkOverlap
+// is excluded because zero is a valid setting that disables overlap; callers
+// wanting the recommended overlap should start from DefaultConfig.
 //
 // When cfg.TokenLimit is set, ChunkSize is clamped to the character budget
 // that fits within that token limit (with a 10% safety factor). This makes
@@ -249,8 +249,8 @@ func ensureDefaults(cfg SplitterConfig) SplitterConfig {
 	if cfg.ChunkSize <= 0 {
 		cfg.ChunkSize = DefaultChunkSize
 	}
-	if cfg.ChunkOverlap <= 0 {
-		cfg.ChunkOverlap = DefaultChunkOverlap
+	if cfg.ChunkOverlap < 0 {
+		cfg.ChunkOverlap = 0
 	}
 	if len(cfg.Separators) == 0 {
 		cfg.Separators = []string{"\n\n", "\n", "。"}

--- a/internal/infrastructure/chunker/strategy_test.go
+++ b/internal/infrastructure/chunker/strategy_test.go
@@ -211,16 +211,34 @@ func TestSplitParentChild_LegacyStrategy(t *testing.T) {
 	}
 }
 
-func TestEnsureDefaults(t *testing.T) {
+func TestEnsureDefaults_PreservesZeroOverlap(t *testing.T) {
 	cfg := ensureDefaults(SplitterConfig{})
 	if cfg.ChunkSize != DefaultChunkSize {
 		t.Errorf("expected default ChunkSize %d, got %d", DefaultChunkSize, cfg.ChunkSize)
 	}
-	if cfg.ChunkOverlap != DefaultChunkOverlap {
-		t.Errorf("expected default ChunkOverlap %d, got %d", DefaultChunkOverlap, cfg.ChunkOverlap)
+	if cfg.ChunkOverlap != 0 {
+		t.Errorf("expected explicit zero ChunkOverlap to be preserved, got %d", cfg.ChunkOverlap)
 	}
 	if len(cfg.Separators) == 0 {
 		t.Error("expected default separators")
+	}
+}
+
+func TestSplit_PreservesZeroOverlap(t *testing.T) {
+	text := strings.Repeat("abcdefghij\n", 20)
+	chunks := Split(text, SplitterConfig{
+		ChunkSize:    30,
+		ChunkOverlap: 0,
+		Separators:   []string{"\n"},
+		Strategy:     StrategyLegacy,
+	})
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+	for i := 1; i < len(chunks); i++ {
+		if chunks[i].Start < chunks[i-1].End {
+			t.Fatalf("chunks overlap at %d: previous end=%d, current start=%d", i, chunks[i-1].End, chunks[i].Start)
+		}
 	}
 }
 

--- a/internal/types/knowledge_process.go
+++ b/internal/types/knowledge_process.go
@@ -3,7 +3,7 @@ package types
 // KnowledgeProcessOverrides stores per-upload parse config overrides in knowledge metadata.
 type KnowledgeProcessOverrides struct {
 	ParserEngineRules        []ParserEngineRule        `json:"parser_engine_rules,omitempty"`
-	ChunkingConfig           *ChunkingConfig           `json:"chunking_config,omitempty"`
+	ChunkingConfig           *ChunkingConfigOverride   `json:"chunking_config,omitempty"`
 	EnableMultimodel         *bool                     `json:"enable_multimodel,omitempty"`
 	VLMConfig                *VLMConfig                `json:"vlm_config,omitempty"`
 	ASRConfig                *ASRConfig                `json:"asr_config,omitempty"`
@@ -14,6 +14,23 @@ type KnowledgeProcessOverrides struct {
 	// (e.g. pdf_force_scanned=true). Merged with workspace-level overrides in the
 	// parse pipeline; per-upload values take priority on conflict.
 	ParserEngineOverrides map[string]string `json:"parser_engine_overrides,omitempty"`
+}
+
+// ChunkingConfigOverride contains optional per-upload chunking settings.
+// ChunkOverlap is a pointer so an omitted value can inherit the knowledge-base
+// setting while an explicit zero can disable overlap.
+type ChunkingConfigOverride struct {
+	ChunkSize                 int                `json:"chunk_size,omitempty"`
+	ChunkOverlap              *int               `json:"chunk_overlap,omitempty"`
+	Separators                []string           `json:"separators,omitempty"`
+	ParserEngineRules         []ParserEngineRule `json:"parser_engine_rules,omitempty"`
+	EnableParentChild         bool               `json:"enable_parent_child,omitempty"`
+	ParentChunkSize           int                `json:"parent_chunk_size,omitempty"`
+	ChildChunkSize            int                `json:"child_chunk_size,omitempty"`
+	Strategy                  string             `json:"strategy,omitempty"`
+	TokenLimit                int                `json:"token_limit,omitempty"`
+	Languages                 []string           `json:"languages,omitempty"`
+	TableMetadataInstructions string             `json:"table_metadata_instructions,omitempty"`
 }
 
 // EffectiveProcessConfig is the merged view used by the parse pipeline.

--- a/internal/types/knowledge_process_test.go
+++ b/internal/types/knowledge_process_test.go
@@ -14,7 +14,7 @@ func TestKnowledgeProcessOverridesRoundtrip(t *testing.T) {
 	k := &Knowledge{}
 	overrides := &KnowledgeProcessOverrides{
 		EnableMultimodel:      boolPtr(true),
-		ChunkingConfig:        &ChunkingConfig{ChunkSize: 1024},
+		ChunkingConfig:        &ChunkingConfigOverride{ChunkSize: 1024},
 		ParserEngineOverrides: map[string]string{"pdf_force_scanned": "true"},
 	}
 	require.NoError(t, k.SetProcessOverrides(overrides))
@@ -23,7 +23,24 @@ func TestKnowledgeProcessOverridesRoundtrip(t *testing.T) {
 	require.NotNil(t, got)
 	require.True(t, *got.EnableMultimodel)
 	require.Equal(t, 1024, got.ChunkingConfig.ChunkSize)
+	require.Nil(t, got.ChunkingConfig.ChunkOverlap)
 	require.Equal(t, "true", got.ParserEngineOverrides["pdf_force_scanned"])
+}
+
+func TestKnowledgeProcessOverridesRoundtripPreservesZeroChunkOverlap(t *testing.T) {
+	k := &Knowledge{}
+	zero := 0
+	overrides := &KnowledgeProcessOverrides{
+		ChunkingConfig: &ChunkingConfigOverride{ChunkOverlap: &zero},
+	}
+
+	require.NoError(t, k.SetProcessOverrides(overrides))
+	got, err := k.ProcessOverrides()
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.ChunkingConfig)
+	require.NotNil(t, got.ChunkingConfig.ChunkOverlap)
+	require.Zero(t, *got.ChunkingConfig.ChunkOverlap)
 }
 
 func TestSetProcessOverridesPreservesOtherMetadata(t *testing.T) {


### PR DESCRIPTION
## Description

修复分块重叠值 `chunk_overlap=0` 无法真正生效的问题。

根因是前端和后端多处将合法的 `0` 当成未配置值，并回退到默认值 `80`：

- 前端重新加载知识库和上传配置时使用 `|| 80`。
- 实际分块前将 `chunk_overlap <= 0` 替换为默认值。
- 单次上传覆盖配置无法区分“未传递”和“明确设置为 0”。
- 父子分块中的子块始终使用固定重叠值。

本次修改：

- 使用空值判断保留前端配置中的显式 `0`。
- 让后端分块器保留零重叠配置。
- 使用可选字段区分未提供的上传覆盖值和显式 `0`。
- 设置为 `0` 时同时关闭父块和子块重叠。
- 增加配置持久化、覆盖合并、实际分块和前端回显测试。

默认重叠值仍然是 `80`，只有明确配置为 `0` 时才禁用重叠。

Breaking changes: none.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2534

## Testing

在 Podman Linux 环境中执行：

- `go test ./internal/infrastructure/chunker ./internal/types ./internal/application/service -count=1` — passed
- `go test ./internal/handler -run '^TestPreviewChunking' -count=1` — passed
- `npm test -- src/views/knowledge/components/UploadConfirmDialog.test.ts` — 8/8 passed
- `npm run type-check` — passed
- `git diff --check` — passed


## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation — N/A; existing chunking documentation already states that `0` is supported
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A — no user-visible UI changes