### PR TITLE
fix(summary): preserve rows across table chunks 

### DIFF
--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -793,10 +793,9 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 	// any chunk has been manually edited; after that ChunkIndex is safer.
 	sortedChunks := sortChunksForSummary(chunks)
 
-	// Concatenate original chunk contents by StartAt offset to reconstruct the
-	// document, then enrich with image info in a second pass. Enrichment must
-	// happen AFTER concatenation because StartAt is based on original document
-	// offsets — enriched (longer) content would break the positioning.
+	// Reconstruct the document before enriching it with image info. Enrichment
+	// must happen AFTER reconstruction because StartAt is based on original
+	// document offsets; enriched (longer) content would break the positioning.
 	chunkContents := ""
 	hasEditedChunk := false
 	for _, chunk := range sortedChunks {
@@ -817,14 +816,9 @@ func (s *knowledgeService) getSummary(ctx context.Context,
 		}
 		chunkContents = strings.Join(parts, "\n\n")
 	} else {
-		for _, chunk := range sortedChunks {
-			runes := []rune(chunkContents)
-			if chunk.StartAt <= len(runes) {
-				chunkContents = string(runes[:chunk.StartAt]) + chunk.Content
-			} else {
-				chunkContents += chunk.Content
-			}
-		}
+		// Synthetic table headers are not represented in StartAt/EndAt. Match
+		// real text overlap instead of slicing by source offsets.
+		chunkContents = searchutil.MergeTextChunks(sortedChunks, "")
 	}
 
 	// Collect image_info from image_ocr/image_caption children and enrich

--- a/internal/application/service/knowledge_summary_reconstruction_test.go
+++ b/internal/application/service/knowledge_summary_reconstruction_test.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type summaryContentCaptureChat struct {
+	messages []chat.Message
+}
+
+func (m *summaryContentCaptureChat) Chat(
+	_ context.Context,
+	messages []chat.Message,
+	_ *chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	m.messages = append([]chat.Message(nil), messages...)
+	return &types.ChatResponse{Content: "summary"}, nil
+}
+
+func (m *summaryContentCaptureChat) ChatStream(
+	context.Context,
+	[]chat.Message,
+	*chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	return nil, nil
+}
+
+func (m *summaryContentCaptureChat) GetModelName() string { return "summary-capture" }
+func (m *summaryContentCaptureChat) GetModelID() string   { return "summary-capture" }
+
+type summaryImageInfoChunkRepo struct {
+	interfaces.ChunkRepository
+}
+
+func (summaryImageInfoChunkRepo) ListChunksByParentIDs(
+	context.Context, uint64, []string,
+) ([]*types.Chunk, error) {
+	return nil, nil
+}
+
+func TestGetSummaryReconstructsTableChunksWithSyntheticHeaders(t *testing.T) {
+	header := "| Country | Capital |\n| --- | --- |\n"
+	rowOne := "| Alpha Republic | North City |\n"
+	rowTwo := "| Beta Federation | East Harbor |\n"
+	rowThree := "| Gamma State | South Port |\n"
+	want := header + rowOne + rowTwo + rowThree
+
+	firstContent := header + rowOne + rowTwo
+	service := &knowledgeService{
+		config: &config.Config{Conversation: &config.ConversationConfig{
+			GenerateSummaryPrompt: "Summarize the document.",
+		}},
+		chunkRepo: summaryImageInfoChunkRepo{},
+	}
+	model := &summaryContentCaptureChat{}
+
+	_, err := service.getSummary(context.Background(), model, &types.Knowledge{ID: "knowledge-1"}, []*types.Chunk{
+		{
+			ID: "first", Content: firstContent, ChunkIndex: 0,
+			StartAt: 0, EndAt: len([]rune(firstContent)),
+		},
+		{
+			// The repeated header is synthetic: StartAt points at row two in the source.
+			ID: "second", Content: header + rowTwo + rowThree, ChunkIndex: 1,
+			StartAt: len([]rune(header + rowOne)), EndAt: len([]rune(want)),
+		},
+	})
+	if err != nil {
+		t.Fatalf("getSummary() error = %v", err)
+	}
+	if len(model.messages) != 2 {
+		t.Fatalf("summary model received %d messages, want 2", len(model.messages))
+	}
+	if got := model.messages[1].Content; got != want {
+		t.Fatalf("summary content mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}


### PR DESCRIPTION
## 中文

### 问题

表格跨 chunk 切分时，后续 chunk 会补写 Markdown 表头。该表头是合成内容，不占用原文位置，因此 `Content` 长度大于 `EndAt - StartAt`。

摘要重建此前按 `StartAt` 截断已拼接文本，导致补写表头重复，并可能丢失表格行。

### 复现步骤

1. 准备一个足够长、会跨多个 chunk 的 Markdown 表格。
2. 生成知识摘要。
3. 观察摘要输入内容：后续 chunk 的表头重复，边界附近的表格行缺失。

### 修复

未编辑 chunk 改用 `searchutil.MergeTextChunks`，按真实文本重叠去重，不再假设源位置覆盖合成表头。已编辑 chunk 的现有拼接逻辑保持不变。

### 测试

- `go test ./internal/application/service -run '^TestGetSummaryReconstructsTableChunksWithSyntheticHeaders$' -count=1`
- `go test ./internal/infrastructure/chunker -count=1`
- `go test ./internal/searchutil -count=1`

完整 service 包测试在 Windows 上仍受既有 SQLite 临时文件句柄清理问题影响，与本次改动无关。

## English

### Problem

When a Markdown table spans multiple chunks, the chunker prepends a synthetic table header to subsequent chunks. This header does not consume source positions, so `len(Content)` is larger than `EndAt - StartAt`.

Summary reconstruction previously sliced the accumulated text by `StartAt`, which duplicated synthetic headers and could drop table rows.

### Reproduction

1. Prepare a Markdown table large enough to span multiple chunks.
2. Generate the knowledge summary.
3. Inspect the summary input: repeated headers appear and rows near chunk boundaries are missing.

### Fix

Use `searchutil.MergeTextChunks` for unedited chunks so overlaps are removed by matching actual text instead of relying on source offsets. The existing edited-chunk path remains unchanged.

### Tests

- `go test ./internal/application/service -run '^TestGetSummaryReconstructsTableChunksWithSyntheticHeaders$' -count=1`
- `go test ./internal/infrastructure/chunker -count=1`
- `go test ./internal/searchutil -count=1`

The full service package remains affected by a pre-existing Windows SQLite temporary-file cleanup issue unrelated to this change.