### PR TITLE
fix(chunking): sync preview swagger and normalize splitter config

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -21472,17 +21472,26 @@ const docTemplate = `{
         "internal_handler.PreviewChunkingPayload": {
             "type": "object",
             "properties": {
+                "child_chunk_size": {
+                    "type": "integer"
+                },
                 "chunk_overlap": {
                     "type": "integer"
                 },
                 "chunk_size": {
                     "type": "integer"
                 },
+                "enable_parent_child": {
+                    "type": "boolean"
+                },
                 "languages": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "parent_chunk_size": {
+                    "type": "integer"
                 },
                 "separators": {
                     "type": "array",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -21465,17 +21465,26 @@
         "internal_handler.PreviewChunkingPayload": {
             "type": "object",
             "properties": {
+                "child_chunk_size": {
+                    "type": "integer"
+                },
                 "chunk_overlap": {
                     "type": "integer"
                 },
                 "chunk_size": {
                     "type": "integer"
                 },
+                "enable_parent_child": {
+                    "type": "boolean"
+                },
                 "languages": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "parent_chunk_size": {
+                    "type": "integer"
                 },
                 "separators": {
                     "type": "array",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5045,14 +5045,20 @@ definitions:
     type: object
   internal_handler.PreviewChunkingPayload:
     properties:
+      child_chunk_size:
+        type: integer
       chunk_overlap:
         type: integer
       chunk_size:
         type: integer
+      enable_parent_child:
+        type: boolean
       languages:
         items:
           type: string
         type: array
+      parent_chunk_size:
+        type: integer
       separators:
         items:
           type: string

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -220,24 +220,14 @@ func buildSplitterConfig(kb *types.KnowledgeBase) chunker.SplitterConfig {
 }
 
 func buildSplitterConfigFromChunking(cc types.ChunkingConfig) chunker.SplitterConfig {
-	chunkCfg := chunker.SplitterConfig{
+	return chunker.NormalizeSplitterConfig(chunker.SplitterConfig{
 		ChunkSize:    cc.ChunkSize,
 		ChunkOverlap: cc.ChunkOverlap,
 		Separators:   cc.Separators,
 		Strategy:     cc.Strategy,
 		TokenLimit:   cc.TokenLimit,
 		Languages:    cc.Languages,
-	}
-	if chunkCfg.ChunkSize <= 0 {
-		chunkCfg.ChunkSize = chunker.DefaultChunkSize
-	}
-	if chunkCfg.ChunkOverlap <= 0 {
-		chunkCfg.ChunkOverlap = chunker.DefaultChunkOverlap
-	}
-	if len(chunkCfg.Separators) == 0 {
-		chunkCfg.Separators = []string{"\n\n", "\n", "。"}
-	}
-	return chunkCfg
+	})
 }
 
 // buildParentChildConfigs derives parent and child SplitterConfig from ChunkingConfig.

--- a/internal/handler/chunker_debug.go
+++ b/internal/handler/chunker_debug.go
@@ -147,14 +147,14 @@ func PreviewChunking(c *gin.Context) {
 		return
 	}
 
-	cfg := chunker.SplitterConfig{
+	cfg := chunker.NormalizeSplitterConfig(chunker.SplitterConfig{
 		ChunkSize:    req.ChunkingConfig.ChunkSize,
 		ChunkOverlap: req.ChunkingConfig.ChunkOverlap,
 		Separators:   req.ChunkingConfig.Separators,
 		Strategy:     req.ChunkingConfig.Strategy,
 		TokenLimit:   req.ChunkingConfig.TokenLimit,
 		Languages:    req.ChunkingConfig.Languages,
-	}
+	})
 
 	// Run the splitter on a goroutine so we can honor the request timeout.
 	// The splitter is CPU-bound and doesn't accept a context — wrapping

--- a/internal/handler/chunker_debug_test.go
+++ b/internal/handler/chunker_debug_test.go
@@ -214,12 +214,12 @@ func TestPreviewChunking_ParentChildMatchesIngestion(t *testing.T) {
 		t.Fatalf("status %d body=%s", w.Code, w.Body.String())
 	}
 
-	base := chunker.SplitterConfig{
+	base := chunker.NormalizeSplitterConfig(chunker.SplitterConfig{
 		ChunkSize:    payload.ChunkSize,
 		ChunkOverlap: payload.ChunkOverlap,
 		Separators:   payload.Separators,
 		Strategy:     payload.Strategy,
-	}
+	})
 	parentCfg, childCfg := chunker.DeriveParentChildConfigs(base, payload.ParentChunkSize, payload.ChildChunkSize)
 	want := chunker.SplitParentChild(text, parentCfg, childCfg)
 
@@ -236,5 +236,65 @@ func TestPreviewChunking_ParentChildMatchesIngestion(t *testing.T) {
 		if int(previewChunk["start"].(float64)) != child.Start || int(previewChunk["end"].(float64)) != child.End {
 			t.Errorf("chunk %d span: got %v-%v want %d-%d", i, previewChunk["start"], previewChunk["end"], child.Start, child.End)
 		}
+		gotHeader, _ := previewChunk["context_header"].(string)
+		if gotHeader != child.ContextHeader {
+			t.Errorf("chunk %d context_header: got %q want %q", i, gotHeader, child.ContextHeader)
+		}
+	}
+}
+
+func TestPreviewChunking_SingleLevelUnchanged(t *testing.T) {
+	text := strings.Repeat("Paragraph one.\n\nParagraph two.\n\n", 20)
+	payload := PreviewChunkingPayload{
+		ChunkSize:    200,
+		ChunkOverlap: 20,
+		Separators:   []string{"\n\n", "\n"},
+		Strategy:     chunker.StrategyLegacy,
+	}
+	w, parsed := postPreview(t, PreviewChunkingRequest{Text: text, ChunkingConfig: payload})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", w.Code, w.Body.String())
+	}
+
+	want, _ := chunker.SplitWithDiagnostics(text, chunker.NormalizeSplitterConfig(chunker.SplitterConfig{
+		ChunkSize:    payload.ChunkSize,
+		ChunkOverlap: payload.ChunkOverlap,
+		Separators:   payload.Separators,
+		Strategy:     payload.Strategy,
+	}))
+	data := parsed["data"].(map[string]any)
+	got := data["chunks"].([]any)
+	if len(got) != len(want) {
+		t.Fatalf("chunk count: got %d want %d", len(got), len(want))
+	}
+}
+
+func TestPreviewChunking_ParentChildDefaultSizes(t *testing.T) {
+	text := strings.Repeat("## Record\n"+strings.Repeat("A sufficiently long entry body. ", 10)+"\n\n", 12)
+	payload := PreviewChunkingPayload{
+		ChunkSize:         300,
+		ChunkOverlap:      30,
+		Separators:        []string{"\n\n", "\n"},
+		EnableParentChild: true,
+		Strategy:          chunker.StrategyHeading,
+	}
+	w, parsed := postPreview(t, PreviewChunkingRequest{Text: text, ChunkingConfig: payload})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", w.Code, w.Body.String())
+	}
+
+	base := chunker.NormalizeSplitterConfig(chunker.SplitterConfig{
+		ChunkSize:    payload.ChunkSize,
+		ChunkOverlap: payload.ChunkOverlap,
+		Separators:   payload.Separators,
+		Strategy:     payload.Strategy,
+	})
+	parentCfg, childCfg := chunker.DeriveParentChildConfigs(base, 0, 0)
+	want := chunker.SplitParentChild(text, parentCfg, childCfg)
+
+	data := parsed["data"].(map[string]any)
+	got := data["chunks"].([]any)
+	if len(got) != len(want.Children) {
+		t.Fatalf("chunk count: got %d want %d", len(got), len(want.Children))
 	}
 }

--- a/internal/infrastructure/chunker/strategy.go
+++ b/internal/infrastructure/chunker/strategy.go
@@ -185,6 +185,21 @@ func splitParentChild(text string, parentCfg, childCfg SplitterConfig, withDiagn
 	return ParentChildResult{Parents: newParents, Children: children}, diag
 }
 
+// NormalizeSplitterConfig applies the same base splitter defaults used by
+// knowledge ingestion before parent-child derivation or single-pass splitting.
+func NormalizeSplitterConfig(cfg SplitterConfig) SplitterConfig {
+	if cfg.ChunkSize <= 0 {
+		cfg.ChunkSize = DefaultChunkSize
+	}
+	if cfg.ChunkOverlap <= 0 {
+		cfg.ChunkOverlap = DefaultChunkOverlap
+	}
+	if len(cfg.Separators) == 0 {
+		cfg.Separators = []string{"\n\n", "\n", "。"}
+	}
+	return cfg
+}
+
 // DeriveParentChildConfigs produces the exact parent and child splitter
 // configurations used by knowledge ingestion. Keeping this here lets preview
 // and ingestion remain in lockstep as the parent-child defaults evolve.

--- a/internal/infrastructure/chunker/strategy_test.go
+++ b/internal/infrastructure/chunker/strategy_test.go
@@ -224,6 +224,38 @@ func TestEnsureDefaults(t *testing.T) {
 	}
 }
 
+func TestNormalizeSplitterConfig_MatchesIngestionDefaults(t *testing.T) {
+	cfg := NormalizeSplitterConfig(SplitterConfig{})
+	if cfg.ChunkSize != DefaultChunkSize {
+		t.Errorf("chunk size: got %d want %d", cfg.ChunkSize, DefaultChunkSize)
+	}
+	if cfg.ChunkOverlap != DefaultChunkOverlap {
+		t.Errorf("chunk overlap: got %d want %d", cfg.ChunkOverlap, DefaultChunkOverlap)
+	}
+	if len(cfg.Separators) != 3 {
+		t.Fatalf("separators: got %v", cfg.Separators)
+	}
+}
+
+func TestDeriveParentChildConfigs_DefaultSizes(t *testing.T) {
+	base := SplitterConfig{
+		ChunkSize:    1000,
+		ChunkOverlap: 100,
+		Separators:   []string{"\n\n", "\n"},
+		Strategy:     StrategyHeading,
+	}
+	parent, child := DeriveParentChildConfigs(base, 0, 0)
+	if parent.ChunkSize != 4096 || child.ChunkSize != 384 {
+		t.Fatalf("default sizes: parent=%d child=%d", parent.ChunkSize, child.ChunkSize)
+	}
+	if parent.Strategy != StrategyHeading || child.Strategy != StrategyHeading {
+		t.Fatalf("strategy not propagated: parent=%q child=%q", parent.Strategy, child.Strategy)
+	}
+	if child.ChunkOverlap != 384/5 {
+		t.Fatalf("child overlap: got %d want %d", child.ChunkOverlap, 384/5)
+	}
+}
+
 func TestValidateChunks_Empty(t *testing.T) {
 	if v := ValidateChunks(nil, 1000, 500); v.OK {
 		t.Error("nil chunks should be invalid")


### PR DESCRIPTION
## Summary
- 将 ingestion 的 base 分块默认值收敛到 `chunker.NormalizeSplitterConfig`，预览接口与正式上传共用同一套归一化逻辑
- 运行 `make docs`，同步 Swagger 中父子分块预览字段（`enable_parent_child`、`parent_chunk_size`、`child_chunk_size`）
- 补充单层预览、默认 parent/child size、context_header 等回归测试

Follow-up to #2539.

## Test plan
- [x] `go test ./internal/infrastructure/chunker ./internal/handler ./internal/application/service -run 'TestNormalizeSplitterConfig|TestDeriveParentChildConfigs|TestPreviewChunking|TestBuildParentChildConfigs' -count=1`