### PR TITLE
fix(chunking): normalize line endings before splitting

### DIFF
--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -1208,6 +1208,10 @@ func (s *knowledgeService) triggerManualProcessing(ctx context.Context,
 		}
 	}
 
+	// Keep manually entered CRLF text aligned with the LF values sent by the
+	// chunking preview endpoint.
+	clean = chunker.NormalizeLineEndings(clean)
+
 	processOverrides, _ := knowledge.ProcessOverrides()
 	eff := ResolveProcessConfig(kb, processOverrides)
 

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -3350,7 +3350,10 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 		logger.Infof(ctx, "Resolved %d total images for knowledge %s", len(storedImages), knowledge.ID)
 	}
 
-	// Step 3: Split into chunks using Go chunker
+	// Step 3: Split into chunks using Go chunker. Browser textareas normalize
+	// pasted content to LF, so normalize uploaded source text before calculating
+	// chunk boundaries as well.
+	convertResult.MarkdownContent = chunker.NormalizeLineEndings(convertResult.MarkdownContent)
 	chunkCfg := buildSplitterConfigFromChunking(eff.ChunkingConfig)
 
 	processOpts := ProcessChunksOptions{

--- a/internal/handler/chunker_debug.go
+++ b/internal/handler/chunker_debug.go
@@ -146,6 +146,7 @@ func PreviewChunking(c *gin.Context) {
 		})
 		return
 	}
+	text := chunker.NormalizeLineEndings(req.Text)
 
 	cfg := chunker.NormalizeSplitterConfig(chunker.SplitterConfig{
 		ChunkSize:    req.ChunkingConfig.ChunkSize,
@@ -173,14 +174,14 @@ func PreviewChunking(c *gin.Context) {
 				req.ChunkingConfig.ParentChunkSize,
 				req.ChunkingConfig.ChildChunkSize,
 			)
-			result, parentDiag := chunker.SplitParentChildWithDiagnostics(req.Text, parentCfg, childCfg)
+			result, parentDiag := chunker.SplitParentChildWithDiagnostics(text, parentCfg, childCfg)
 			chunks = make([]chunker.Chunk, len(result.Children))
 			for i, child := range result.Children {
 				chunks[i] = child.Chunk
 			}
 			diag = parentDiag
 		} else {
-			chunks, diag = chunker.SplitWithDiagnostics(req.Text, cfg)
+			chunks, diag = chunker.SplitWithDiagnostics(text, cfg)
 		}
 		resCh <- splitResult{chunks: chunks, diag: diag}
 	}()
@@ -203,7 +204,7 @@ func PreviewChunking(c *gin.Context) {
 	// can still show document stats. Avoids the previous double-pass.
 	profile := diag.Profile
 	if profile == nil {
-		profile = chunker.ProfileDocument(req.Text)
+		profile = chunker.ProfileDocument(text)
 	}
 
 	logger.Debugf(ctx, "chunker preview: tier=%s chunks=%d", diag.SelectedTier, len(chunks))

--- a/internal/handler/chunker_debug_test.go
+++ b/internal/handler/chunker_debug_test.go
@@ -298,3 +298,45 @@ func TestPreviewChunking_ParentChildDefaultSizes(t *testing.T) {
 		t.Fatalf("chunk count: got %d want %d", len(got), len(want.Children))
 	}
 }
+
+func TestPreviewChunking_LineEndingsMatchUpload(t *testing.T) {
+	uploaded := strings.Repeat("## Record\r\n"+strings.Repeat("A sufficiently long entry body. ", 10)+"\r\n\r\n", 12)
+	pasted := strings.ReplaceAll(uploaded, "\r\n", "\n") // HTML textarea normalization
+	payload := PreviewChunkingPayload{
+		ChunkSize:    500,
+		ChunkOverlap: 20,
+		Separators:   []string{"\n\n", "\n", "。", "！", "？", ";", "；"},
+		Strategy:     chunker.StrategyHeading,
+	}
+	actual := chunker.Split(chunker.NormalizeLineEndings(uploaded), chunker.NormalizeSplitterConfig(chunker.SplitterConfig{
+		ChunkSize:    payload.ChunkSize,
+		ChunkOverlap: payload.ChunkOverlap,
+		Separators:   payload.Separators,
+		Strategy:     payload.Strategy,
+	}))
+	for name, text := range map[string]string{
+		"uploaded CRLF": uploaded,
+		"pasted LF":     pasted,
+	} {
+		t.Run(name, func(t *testing.T) {
+			w, parsed := postPreview(t, PreviewChunkingRequest{Text: text, ChunkingConfig: payload})
+			if w.Code != http.StatusOK {
+				t.Fatalf("status %d body=%s", w.Code, w.Body.String())
+			}
+			data := parsed["data"].(map[string]any)
+			preview := data["chunks"].([]any)
+			if len(preview) != len(actual) {
+				t.Fatalf("chunk count: got %d want %d", len(preview), len(actual))
+			}
+			for i, chunk := range actual {
+				previewChunk := preview[i].(map[string]any)
+				if previewChunk["content"] != chunk.Content {
+					t.Errorf("chunk %d content differs", i)
+				}
+				if int(previewChunk["start"].(float64)) != chunk.Start || int(previewChunk["end"].(float64)) != chunk.End {
+					t.Errorf("chunk %d span: got %v-%v want %d-%d", i, previewChunk["start"], previewChunk["end"], chunk.Start, chunk.End)
+				}
+			}
+		})
+	}
+}

--- a/internal/infrastructure/chunker/strategy.go
+++ b/internal/infrastructure/chunker/strategy.go
@@ -200,6 +200,18 @@ func NormalizeSplitterConfig(cfg SplitterConfig) SplitterConfig {
 	return cfg
 }
 
+// NormalizeLineEndings canonicalizes text before chunking. Browser textareas
+// normalize pasted CRLF text to LF, while uploaded files preserve their
+// original line endings; without this, the same document produces different
+// character counts and chunk boundaries.
+func NormalizeLineEndings(text string) string {
+	if !strings.Contains(text, "\r") {
+		return text
+	}
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	return strings.ReplaceAll(text, "\r", "\n")
+}
+
 // DeriveParentChildConfigs produces the exact parent and child splitter
 // configurations used by knowledge ingestion. Keeping this here lets preview
 // and ingestion remain in lockstep as the parent-child defaults evolve.

--- a/internal/infrastructure/chunker/strategy_test.go
+++ b/internal/infrastructure/chunker/strategy_test.go
@@ -237,6 +237,13 @@ func TestNormalizeSplitterConfig_MatchesIngestionDefaults(t *testing.T) {
 	}
 }
 
+func TestNormalizeLineEndings(t *testing.T) {
+	input := "first\r\nsecond\rthird\nfourth"
+	if got, want := NormalizeLineEndings(input), "first\nsecond\nthird\nfourth"; got != want {
+		t.Errorf("NormalizeLineEndings() = %q, want %q", got, want)
+	}
+}
+
 func TestDeriveParentChildConfigs_DefaultSizes(t *testing.T) {
 	base := SplitterConfig{
 		ChunkSize:    1000,


### PR DESCRIPTION

Fixes #2535

## Description

### 中文

修复关闭父子分块、按标题切分时，在线测试分块预览与上传文档实际分块结果不一致的问题。

浏览器文本框会将粘贴内容的 CRLF 换行符规范为 LF，而上传文档保留原始 CRLF。额外的 `\r` 会参与字符长度和边界计算，导致相同内容在预览与正式解析中产生不同分块。

本次统一在在线预览、上传文档处理和手工录入处理前，将 CRLF/CR 规范为 LF，并新增 CRLF 场景的回归测试。

使用 Issue 附件 `test.md` 验证：关闭父子分块、按标题切分、块大小 500、重叠 20 时，预览与实际解析均生成 44 个分块。

### English

Fixes inconsistent chunking results between the online preview and uploaded document ingestion when parent-child chunking is disabled and heading-based splitting is used.

Browser textareas normalize pasted CRLF text to LF, while uploaded files preserve CRLF. The additional `\r` characters affected character counts and chunk boundaries, resulting in different chunks for the same content.

This change normalizes CRLF/CR line endings to LF before previewing, processing uploaded documents, and processing manually entered content. Regression tests cover CRLF input.

Verified with the issue fixture `test.md`: with parent-child chunking disabled, heading splitting, chunk size 500, and overlap 20, both preview and ingestion produce 44 chunks.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2535

## Testing

- `go test ./internal/infrastructure/chunker ./internal/handler -count=1`
- `go test ./internal/application/service -run TestBuildParentChildConfigs_PropagatesStrategy -count=1`
- Used the downloaded issue fixture to verify that normalized upload content and LF preview content both produce 44 chunks.
- `git diff --check upstream/main...HEAD`

## Checklist

- [x] `git diff --check upstream/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint was not run
- [ ] Full-repository checks were not run; full service tests are affected by existing Windows SQLite temporary-file lock failures in unrelated data-source deletion tests
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Documentation update is not required for this internal behavior fix
- [x] No breaking changes

## Screenshots / Recordings

Not applicable. This is a backend-only fix.