### PR TITLE
fix(wiki): exclude archived pages from stats queries

### DIFF
--- a/internal/application/repository/wiki_page.go
+++ b/internal/application/repository/wiki_page.go
@@ -1055,11 +1055,11 @@ func (r *wikiPageRepository) FindSimilarPages(
 	return out, nil
 }
 
-// ListAll retrieves all wiki pages in a knowledge base
+// ListAll retrieves all non-archived wiki pages in a knowledge base.
 func (r *wikiPageRepository) ListAll(ctx context.Context, kbID string) ([]*types.WikiPage, error) {
 	var pages []*types.WikiPage
 	if err := r.db.WithContext(ctx).
-		Where("knowledge_base_id = ?", kbID).
+		Where("knowledge_base_id = ? AND status <> ?", kbID, types.WikiPageStatusArchived).
 		Order("page_type ASC, title ASC").
 		Find(&pages).Error; err != nil {
 		return nil, err
@@ -1193,7 +1193,7 @@ func (r *wikiPageRepository) CountByType(ctx context.Context, kbID string) (map[
 	if err := r.db.WithContext(ctx).
 		Model(&types.WikiPage{}).
 		Select("page_type, count(*) as count").
-		Where("knowledge_base_id = ?", kbID).
+		Where("knowledge_base_id = ? AND status <> ?", kbID, types.WikiPageStatusArchived).
 		Group("page_type").
 		Scan(&results).Error; err != nil {
 		return nil, err
@@ -1211,7 +1211,7 @@ func (r *wikiPageRepository) CountOrphans(ctx context.Context, kbID string) (int
 	var count int64
 	if err := r.db.WithContext(ctx).
 		Model(&types.WikiPage{}).
-		Where("knowledge_base_id = ?", kbID).
+		Where("knowledge_base_id = ? AND status <> ?", kbID, types.WikiPageStatusArchived).
 		Where(r.wikiEmptyInLinksPredicate()).
 		// Exclude the index page because it is naturally a root page.
 		Where("page_type <> ?", types.WikiPageTypeIndex).

--- a/internal/application/repository/wiki_page_test.go
+++ b/internal/application/repository/wiki_page_test.go
@@ -429,6 +429,43 @@ func TestCountOrphans_SQLiteCountsEmptyInLinks(t *testing.T) {
 	assert.Equal(t, int64(1), got)
 }
 
+func TestWikiStatsQueriesExcludeArchivedPages(t *testing.T) {
+	db := setupWikiPagesTestDB(t)
+	repo := NewWikiPageRepository(db)
+	ctx := context.Background()
+
+	live := makeWikiPage("kb-stats", "entity/live", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+	live.InLinks = types.StringArray{"index"}
+	live.OutLinks = types.StringArray{"concept/live-target"}
+	archived := makeWikiPage("kb-stats", "entity/archived", types.WikiPageTypeEntity, types.WikiPageStatusArchived)
+	archived.InLinks = types.StringArray{}
+	archived.OutLinks = types.StringArray{"concept/archived-target"}
+	indexPage := makeWikiPage("kb-stats", "index", types.WikiPageTypeIndex, types.WikiPageStatusPublished)
+	indexPage.InLinks = types.StringArray{}
+	otherKB := makeWikiPage("kb-other", "entity/other", types.WikiPageTypeEntity, types.WikiPageStatusPublished)
+
+	for _, p := range []*types.WikiPage{live, archived, indexPage, otherKB} {
+		require.NoError(t, repo.Create(ctx, p))
+	}
+
+	counts, err := repo.CountByType(ctx, "kb-stats")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), counts[types.WikiPageTypeEntity])
+	assert.Equal(t, int64(1), counts[types.WikiPageTypeIndex])
+
+	orphans, err := repo.CountOrphans(ctx, "kb-stats")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), orphans)
+
+	pages, err := repo.ListAll(ctx, "kb-stats")
+	require.NoError(t, err)
+	assert.Len(t, pages, 2)
+	for _, page := range pages {
+		assert.NotEqual(t, types.WikiPageStatusArchived, page.Status)
+		assert.Equal(t, "kb-stats", page.KnowledgeBaseID)
+	}
+}
+
 // makeWikiRevision builds a snapshot row for the given page state.
 func makeWikiRevision(page *types.WikiPage, version int, editSource string) *types.WikiPageRevision {
 	return &types.WikiPageRevision{

--- a/internal/application/service/wiki_page.go
+++ b/internal/application/service/wiki_page.go
@@ -906,7 +906,7 @@ func (s *wikiPageService) RebuildLinks(ctx context.Context, kbID string) error {
 	return nil
 }
 
-// ListAllPages retrieves all wiki pages without pagination.
+// ListAllPages retrieves all non-archived wiki pages without pagination.
 func (s *wikiPageService) ListAllPages(ctx context.Context, kbID string) ([]*types.WikiPage, error) {
 	return s.repo.ListAll(ctx, kbID)
 }

--- a/internal/types/interfaces/wiki_page.go
+++ b/internal/types/interfaces/wiki_page.go
@@ -97,7 +97,7 @@ type WikiPageService interface {
 	// RebuildIndexPage regenerates the index page.
 	RebuildIndexPage(ctx context.Context, kbID string) error
 
-	// ListAllPages retrieves all wiki pages in a knowledge base without pagination.
+	// ListAllPages retrieves all non-archived wiki pages in a knowledge base without pagination.
 	// Used for index rebuild, graph generation, cross-link injection, etc.
 	ListAllPages(ctx context.Context, kbID string) ([]*types.WikiPage, error)
 
@@ -354,7 +354,7 @@ type WikiPageRepository interface {
 	// Used to recompute cached paths when a folder subtree is moved/renamed.
 	ListPagesByFolderIDs(ctx context.Context, kbID string, folderIDs []string) ([]*types.WikiPage, error)
 
-	// ListAll retrieves all wiki pages in a knowledge base (for link rebuilding, graph generation).
+	// ListAll retrieves all non-archived wiki pages in a knowledge base (for link rebuilding, graph generation).
 	ListAll(ctx context.Context, kbID string) ([]*types.WikiPage, error)
 
 	// ListRecentForSuggestions returns recent user-visible wiki pages under the given


### PR DESCRIPTION
## Description

Exclude archived wiki pages from the repository queries used by wiki statistics. This keeps total/page-type counts, orphan counts, and link-count inputs aligned with the active wiki views that already hide archived pages.

The `ListAll` contract is also clarified as returning non-archived pages because its callers drive user-visible graph, link rebuild, cross-link, and stats flows.

## Type of Change

- [x] Bug fix
- [x] Test

## Related Issue

Fixes #2504

## Testing

```bash
go test ./internal/application/repository -run 'TestWikiStatsQueriesExcludeArchivedPages|TestCountOrphans_SQLiteCountsEmptyInLinks|TestListPagesCursorExcludesArchivedPages|TestListByTypeLight_ProjectsNarrowColumnsAndExcludesArchived' -count=1
go test ./internal/application/repository ./internal/application/service -count=1
git diff --check
```

All commands pass using the repository's Go 1.26 toolchain in Docker.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted with `gofmt`
- [x] Targeted repository and service tests pass
- [x] Self-reviewed the code
- [x] Added regression coverage for all three affected query paths
- [x] Updated the internal interface comments to match the non-archived contract
- [x] No breaking API change