### PR TITLE
fix(im/wecom): resolve longconn deadlock between closeConn and heartbeatLoop

### DIFF
--- a/internal/im/wecom/longconn.go
+++ b/internal/im/wecom/longconn.go
@@ -380,9 +380,7 @@ func (c *LongConnClient) connectAndRun(ctx context.Context) error {
 	c.mu.Unlock()
 
 	defer func() {
-		c.mu.Lock()
-		c.conn = nil
-		c.mu.Unlock()
+		c.closeConn()
 		_ = conn.Close()
 		// NOTE: streamBufs is intentionally NOT cleared on reconnect.
 		// Active streams survive reconnections — the WeCom replace-based
@@ -707,9 +705,11 @@ func (c *LongConnClient) convertMixedMessage(msg *botMessage, chatID string, cha
 // pending ReadMessage call in the receive loop and triggers a reconnection.
 func (c *LongConnClient) closeConn() {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.conn != nil {
-		_ = c.conn.Close()
+	conn := c.conn
+	c.conn = nil
+	c.mu.Unlock()
+	if conn != nil {
+		_ = conn.Close()
 	}
 }
 


### PR DESCRIPTION
### Summary
This PR fixes a critical mutex deadlock in `internal/im/wecom/longconn.go` that causes the WeCom WebSocket longconnection worker to permanently freeze after network drops or heartbeat timeouts.

### Root Cause Analysis
1. When a network connection drops or times out, `ReadMessage()` in the receive loop exits and triggers its deferred cleanup logic, which attempts to acquire `c.mu.Lock()`.
2. Concurrently, `heartbeatLoop` detects a ping failure and calls `closeConn()`, which previously held `c.mu.Lock()` while calling `_ = c.conn.Close()`.
3. If `conn.Close()` blocks on OS-level socket I/O (e.g. stalled TCP connection), `heartbeatLoop` holds `c.mu` indefinitely.
4. As a result, `ReadMessage()`'s defer cleanup blocks waiting for `c.mu.Lock()`, preventing `connectAndRun()` from returning to the outer `Start()` loop.
5. The infinite reconnection loop remains permanently stuck, leading to a silent freeze where no incoming messages are processed.

### Key Changes
- Refactored `closeConn()` to safely extract `c.conn` under `c.mu` lock and release `c.mu` immediately before calling `conn.Close()`.
- Refactored `connectAndRun()`'s defer cleanup to call `c.closeConn()` safely without re-entering `c.mu.Lock()`.
- Eliminates lock contention between the receive loop defer and heartbeat loop, ensuring automatic reconnects trigger instantly on connection loss.