### PR TITLE
fix(chunks): 恢复未编辑分块的按位置合并

### DIFF
--- a/internal/application/service/chat_pipeline/merge_overlap.go
+++ b/internal/application/service/chat_pipeline/merge_overlap.go
@@ -9,10 +9,11 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 )
 
-// mergeSequentialChunks joins sequential current chunk bodies without using
-// parser StartAt/EndAt coordinates. Chunks MUST be pre-sorted by ChunkIndex.
-// Source coordinates remain useful for citations, but arbitrary user edits
-// make them unsafe for deciding whether current content can be discarded.
+// mergeSequentialChunks joins sequential current chunk bodies.
+// Trusted pairs use position-aware merging;
+// any pair involving edited, expanded, or stale content falls back to
+// text matching so current content is never discarded on parser coordinates.
+// Chunks MUST be pre-sorted by ChunkIndex.
 func (p *PluginMerge) mergeSequentialChunks(
 	ctx context.Context,
 	knowledgeID string,
@@ -31,29 +32,31 @@ func (p *PluginMerge) mergeSequentialChunks(
 		current := chunks[i]
 		last := &groups[len(groups)-1]
 		lastChunk := last.result
-		textContained := searchutil.ContainsChunkContent(lastChunk.Content, current.Content) ||
-			searchutil.ContainsChunkContent(current.Content, lastChunk.Content)
-		sequential := current.ChunkIndex == last.lastIndex+1
-		if !textContained && !sequential {
+
+		switch classifyMerge(lastChunk, last.lastIndex, current) {
+		case mergeSeparate:
 			groups = append(groups, mergedGroup{result: current, lastIndex: current.ChunkIndex})
 			continue
+		case mergeExtend:
+			lastChunk.Content = searchutil.AppendWithOverlap(
+				lastChunk.Content, current.Content, lastChunk.EndAt-current.StartAt,
+			)
+			lastChunk.EndAt = current.EndAt
+			recordMergedChild(ctx, knowledgeID, lastChunk, current, "image_merge")
+		case mergeSubsume:
+			recordMergedChild(ctx, knowledgeID, lastChunk, current, "image_merge_contained")
+		case mergeJoinDistinct:
+			lastChunk.Content = searchutil.JoinChunkContent(lastChunk.Content, current.Content, "\n\n")
+			recordMergedChild(ctx, knowledgeID, lastChunk, current, "image_merge_contained")
+		case mergeJoinText:
+			lastChunk.Content = searchutil.JoinChunkContent(lastChunk.Content, current.Content, "\n\n")
+			recordMergedChild(ctx, knowledgeID, lastChunk, current, "image_merge")
 		}
 
-		lastChunk.Content = searchutil.JoinChunkContent(lastChunk.Content, current.Content, "\n\n")
-		if !containsID(lastChunk.SubChunkID, current.ID) {
-			lastChunk.SubChunkID = append(lastChunk.SubChunkID, current.ID)
-		}
-		if err := mergeImageInfo(ctx, lastChunk, current); err != nil {
-			pipelineWarn(ctx, "Merge", "image_merge", map[string]interface{}{
-				"knowledge_id": knowledgeID,
-				"error":        err.Error(),
-			})
-		}
+		// Extend the merged group's span and keep the higher score.
 		if current.ChunkIndex > last.lastIndex {
 			last.lastIndex = current.ChunkIndex
 		}
-
-		// Keep the higher score
 		if current.Score > lastChunk.Score {
 			lastChunk.Score = current.Score
 		}
@@ -70,6 +73,81 @@ func (p *PluginMerge) mergeSequentialChunks(
 	})
 
 	return merged
+}
+
+// chunkTrusted reports whether a result's StartAt/EndAt can be trusted for
+// position-based merging: unedited, valid range, and splitter-consistent
+// length (runeLen(Content) == EndAt-StartAt).
+func chunkTrusted(chunk *types.SearchResult) bool {
+	return chunk.ContentRevision == 0 &&
+		chunk.EndAt > chunk.StartAt &&
+		runeLen(chunk.Content) == chunk.EndAt-chunk.StartAt
+}
+
+// mergeSituation labels how the current result relates to the group's leading
+// result in document order. The classifier decides it once; the merge loop
+// switches on it without nesting.
+type mergeSituation int
+
+const (
+	// mergeSeparate: current is not mergeable, it starts a new group
+	// (position gap, or untrusted pair that is neither text-contained nor
+	// index-sequential).
+	mergeSeparate mergeSituation = iota
+	// mergeExtend: trusted pair with partial overlap or adjacency; the
+	// non-overlapping suffix is appended with text-verified trimming.
+	mergeExtend
+	// mergeSubsume: trusted pair, range-contained and text-verified; current
+	// is recorded without touching the merged content.
+	mergeSubsume
+	// mergeJoinDistinct: trusted pair, range-contained but textually distinct;
+	// current is kept via a text join, breaking the length invariant so later
+	// pairs degrade to the text path.
+	mergeJoinDistinct
+	// mergeJoinText: untrusted pair that is text-contained or index-sequential;
+	// joined via pure text matching.
+	mergeJoinText
+)
+
+// classifyMerge labels the pair relationship so the merge loop can dispatch
+// with a flat switch. It needs the group's running lastIndex for the untrusted
+// sequentiality check.
+func classifyMerge(lastChunk *types.SearchResult, lastIndex int, current *types.SearchResult) mergeSituation {
+	if chunkTrusted(lastChunk) && chunkTrusted(current) && current.StartAt >= lastChunk.StartAt {
+		switch {
+		case current.StartAt > lastChunk.EndAt:
+			return mergeSeparate
+		case current.EndAt > lastChunk.EndAt:
+			return mergeExtend
+		case searchutil.ContainsChunkContent(lastChunk.Content, current.Content):
+			return mergeSubsume
+		default:
+			return mergeJoinDistinct
+		}
+	}
+
+	textContained := searchutil.ContainsChunkContent(lastChunk.Content, current.Content) ||
+		searchutil.ContainsChunkContent(current.Content, lastChunk.Content)
+	sequential := current.ChunkIndex == lastIndex+1
+	if !textContained && !sequential {
+		return mergeSeparate
+	}
+	return mergeJoinText
+}
+
+// recordMergedChild records a merged chunk on the group result: appends its ID
+// to SubChunkID (deduplicated) and merges its ImageInfo, warning on failure.
+// warnKey distinguishes merge contexts in pipeline diagnostics.
+func recordMergedChild(ctx context.Context, knowledgeID string, target, source *types.SearchResult, warnKey string) {
+	if !containsID(target.SubChunkID, source.ID) {
+		target.SubChunkID = append(target.SubChunkID, source.ID)
+	}
+	if err := mergeImageInfo(ctx, target, source); err != nil {
+		pipelineWarn(ctx, "Merge", warnKey, map[string]any{
+			"knowledge_id": knowledgeID,
+			"error":        err.Error(),
+		})
+	}
 }
 
 // mergeImageInfo merges ImageInfo from source into target, deduplicating by URL.

--- a/internal/application/service/chat_pipeline/merge_position_path_test.go
+++ b/internal/application/service/chat_pipeline/merge_position_path_test.go
@@ -1,0 +1,199 @@
+package chatpipeline
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rangeText returns deterministic text of exactly n runes so fixtures satisfy
+// the splitter invariant runeLen(Content) == EndAt-StartAt.
+func rangeText(seed rune, n int) string {
+	return strings.Repeat(string(seed), n)
+}
+
+// trustedResult builds a SearchResult whose coordinates are trustworthy
+// (unedited, valid range, splitter-consistent length).
+func trustedResult(id string, index, start, end int, content string) *types.SearchResult {
+	return &types.SearchResult{
+		ID: id, ChunkIndex: index, StartAt: start, EndAt: end, Content: content, Score: 1.0,
+	}
+}
+
+// mergeGrouped runs the merge stage as the pipeline does: group by knowledge
+// and chunk type, then merge sequential bodies. Observable behavior only.
+func mergeGrouped(chunks []*types.SearchResult) []*types.SearchResult {
+	return (&PluginMerge{}).groupAndMergeCurrentContent(context.Background(), chunks)
+}
+
+// All fixtures below share KnowledgeID "doc", ChunkType "text" and Score 1.0,
+// so results form a single group and the deterministic post-merge sort keeps
+// their relative order by ChunkIndex.
+func docChunks(chunks ...*types.SearchResult) []*types.SearchResult {
+	for _, c := range chunks {
+		c.KnowledgeID = "doc"
+		c.ChunkType = "text"
+	}
+	return chunks
+}
+
+func TestGroupAndMerge_TrustedOverlapTrimsAndExtendsRange(t *testing.T) {
+	// 20-rune real overlap between two trusted chunks: the merged body must
+	// contain the overlap exactly once and extend the result range.
+	first := trustedResult("c1", 1, 0, 100, rangeText('a', 80)+rangeText('b', 20))
+	second := trustedResult("c2", 2, 80, 200, rangeText('b', 20)+rangeText('c', 100))
+
+	results := mergeGrouped(docChunks(first, second))
+
+	require.Len(t, results, 1)
+	assert.Equal(t, rangeText('a', 80)+rangeText('b', 20)+rangeText('c', 100), results[0].Content)
+	assert.Equal(t, 200, results[0].EndAt, "merged range must extend to the second chunk")
+	assert.ElementsMatch(t, []string{"c2"}, results[0].SubChunkID)
+}
+
+func TestGroupAndMerge_TrustedAdjacentJoinsSeamlessly(t *testing.T) {
+	// Adjacent trusted chunks are contiguous in the original document: the
+	// merged body must be the exact concatenation, with no separator inserted.
+	first := trustedResult("c1", 1, 0, 100, rangeText('a', 100))
+	second := trustedResult("c2", 2, 100, 200, rangeText('b', 100))
+
+	results := mergeGrouped(docChunks(first, second))
+
+	require.Len(t, results, 1)
+	assert.Equal(t, rangeText('a', 100)+rangeText('b', 100), results[0].Content)
+	assert.Equal(t, 200, results[0].EndAt)
+}
+
+func TestGroupAndMerge_TrustedGapStartsNewGroup(t *testing.T) {
+	// A real position gap means content in between is missing: chunks must
+	// stay separate instead of being joined with a fabricated separator.
+	first := trustedResult("c1", 1, 0, 100, rangeText('a', 100))
+	second := trustedResult("c2", 2, 150, 250, rangeText('b', 100))
+
+	results := mergeGrouped(docChunks(first, second))
+
+	require.Len(t, results, 2, "position gap must not merge")
+}
+
+func TestGroupAndMerge_TrustedContainedSubsumes(t *testing.T) {
+	// Range-contained and text-verified: one result whose content is the
+	// outer body; the inner chunk is recorded, not duplicated.
+	outer := trustedResult("outer", 1, 0, 200, rangeText('a', 200))
+	inner := trustedResult("inner", 2, 50, 100, rangeText('a', 50))
+
+	results := mergeGrouped(docChunks(outer, inner))
+
+	require.Len(t, results, 1)
+	assert.Equal(t, rangeText('a', 200), results[0].Content)
+	assert.ElementsMatch(t, []string{"inner"}, results[0].SubChunkID)
+}
+
+func TestGroupAndMerge_TrustedContainedDistinctKeepsBoth(t *testing.T) {
+	// Range-contained but textually distinct: both bodies must survive; the
+	// inner one must never be dropped on coordinates alone.
+	outer := trustedResult("outer", 1, 0, 100, rangeText('a', 100))
+	inner := trustedResult("inner", 2, 50, 60, rangeText('b', 10))
+
+	results := mergeGrouped(docChunks(outer, inner))
+
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0].Content, rangeText('a', 100))
+	assert.Contains(t, results[0].Content, rangeText('b', 10))
+	assert.ElementsMatch(t, []string{"inner"}, results[0].SubChunkID)
+}
+
+func TestGroupAndMerge_EditedPairKeepsBoth(t *testing.T) {
+	first := trustedResult("c1", 1, 0, 100, rangeText('a', 100))
+	edited := &types.SearchResult{
+		ID: "c2", KnowledgeID: "doc", ChunkType: "text", ChunkIndex: 2, StartAt: 80, EndAt: 200,
+		Content: "rewritten body", ContentRevision: 1, Score: 1.0,
+	}
+
+	results := mergeGrouped(docChunks(first, edited))
+
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0].Content, "rewritten body")
+	assert.Contains(t, results[0].Content, rangeText('a', 100))
+}
+
+func TestGroupAndMerge_SameLengthRewriteKeepsBoth(t *testing.T) {
+	// An edit that happens to keep the splitter length invariant must still
+	// never cause the rewritten body to be swallowed on coordinates.
+	first := trustedResult("c1", 1, 0, 100, rangeText('a', 100))
+	edited := &types.SearchResult{
+		ID: "c2", KnowledgeID: "doc", ChunkType: "text", ChunkIndex: 2, StartAt: 80, EndAt: 200,
+		Content: rangeText('b', 120), ContentRevision: 1, Score: 1.0,
+	}
+
+	results := mergeGrouped(docChunks(first, edited))
+
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0].Content, rangeText('a', 100))
+	assert.Contains(t, results[0].Content, rangeText('b', 120))
+}
+
+func TestGroupAndMerge_InvariantBreakKeepsBoth(t *testing.T) {
+	// ContentRevision 0 but length inconsistent with the range (e.g. zero-width
+	// table headers, HTML entities): both bodies must survive.
+	first := trustedResult("c1", 1, 0, 100, rangeText('a', 100))
+	stale := &types.SearchResult{
+		ID: "c2", KnowledgeID: "doc", ChunkType: "text", ChunkIndex: 2, StartAt: 80, EndAt: 200,
+		Content: "short", Score: 1.0,
+	}
+
+	results := mergeGrouped(docChunks(first, stale))
+
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0].Content, "short")
+	assert.Contains(t, results[0].Content, rangeText('a', 100))
+}
+
+func TestGroupAndMerge_StartInversionKeepsBoth(t *testing.T) {
+	// A chunk whose StartAt precedes the group's but has a higher ChunkIndex
+	// contradicts document order: both bodies must survive.
+	first := trustedResult("c1", 1, 100, 200, rangeText('a', 100))
+	inverted := trustedResult("c2", 2, 50, 150, rangeText('b', 100))
+
+	results := mergeGrouped(docChunks(first, inverted))
+
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0].Content, rangeText('a', 100))
+	assert.Contains(t, results[0].Content, rangeText('b', 100))
+}
+
+func TestGroupAndMerge_EditedNonSequentialSeparates(t *testing.T) {
+	// Edited chunks that are neither text-contained nor index-sequential stay
+	// separate results.
+	first := &types.SearchResult{
+		ID: "c1", KnowledgeID: "doc", ChunkType: "text", ChunkIndex: 1, StartAt: 0, EndAt: 50,
+		Content: rangeText('a', 50), ContentRevision: 1, Score: 1.0,
+	}
+	third := &types.SearchResult{
+		ID: "c3", KnowledgeID: "doc", ChunkType: "text", ChunkIndex: 3, StartAt: 200, EndAt: 250,
+		Content: rangeText('b', 50), ContentRevision: 1, Score: 1.0,
+	}
+
+	results := mergeGrouped(docChunks(first, third))
+
+	require.Len(t, results, 2, "non-sequential edited chunks must not merge")
+}
+
+func TestGroupAndMerge_MidGroupDriftKeepsAllBodies(t *testing.T) {
+	// When an overlap cannot be trimmed the merged body no longer matches its
+	// range; subsequent pairs must still merge safely without losing content.
+	c1 := trustedResult("c1", 1, 0, 100, rangeText('a', 100))
+	c2 := trustedResult("c2", 2, 90, 200, rangeText('c', 110))
+	c3 := trustedResult("c3", 3, 200, 300, rangeText('e', 100))
+
+	results := mergeGrouped(docChunks(c1, c2, c3))
+
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0].Content, rangeText('a', 100))
+	assert.Contains(t, results[0].Content, rangeText('c', 110))
+	assert.Contains(t, results[0].Content, rangeText('e', 100))
+	assert.ElementsMatch(t, []string{"c2", "c3"}, results[0].SubChunkID)
+}

--- a/internal/application/service/chat_pipeline/search_entity.go
+++ b/internal/application/service/chat_pipeline/search_entity.go
@@ -211,6 +211,7 @@ func chunk2SearchResult(chunk *types.Chunk, knowledge *types.Knowledge) *types.S
 	return &types.SearchResult{
 		ID:                chunk.ID,
 		Content:           chunk.Content,
+		ContentRevision:   chunk.ContentRevision,
 		KnowledgeID:       chunk.KnowledgeID,
 		ChunkIndex:        chunk.ChunkIndex,
 		KnowledgeTitle:    knowledge.Title,

--- a/internal/application/service/knowledgebase_search_results.go
+++ b/internal/application/service/knowledgebase_search_results.go
@@ -309,6 +309,7 @@ func (s *knowledgeBaseService) buildSearchResult(chunk *types.Chunk,
 	return &types.SearchResult{
 		ID:                      chunk.ID,
 		Content:                 chunk.Content,
+		ContentRevision:         chunk.ContentRevision,
 		KnowledgeID:             chunk.KnowledgeID,
 		ChunkIndex:              chunk.ChunkIndex,
 		KnowledgeTitle:          knowledge.Title,

--- a/internal/types/search.go
+++ b/internal/types/search.go
@@ -207,6 +207,11 @@ type SearchResult struct {
 
 	// KnowledgeBaseID is the ID of the knowledge base this result belongs to
 	KnowledgeBaseID string `json:"knowledge_base_id,omitempty"`
+
+	// ContentRevision is the chunk edit revision at retrieval time.
+	// Internal only: used by the merge pipeline to decide whether source
+	// coordinates are still trustworthy.
+	ContentRevision int `json:"-"`
 }
 
 // SearchParams represents the search parameters


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

背景：为了支持“编辑分块”，上游把检索结果的合并逻辑从“按位置”改成了“按文本匹配”，本意是防编辑后位置失效，代价是没编辑过的文档也一起降级。因此会存在三种问题：

-   大 overlap 分块内容重复（稳定触发）：文本匹配的重叠识别窗口上限固定 400 个字符，当相邻分块的真实重叠超过 400 时，整段重叠原样重复进模型上下文
- 被裁剪内容留下的真实间隙被按 ChunkIndex 强行拼接，语义上不相邻的两段会被用伪造的 `\n\n` 连在一起
- 表格/日志等短周期文本偶发误判包含，丢失内容

改动：只对位置可信的分块恢复按位置合并，其余情况保持现有文本匹配。

- `types.SearchResult` 新增内部字段 `ContentRevision`
- 新增可信判定：分块没被编辑过 + 区间有效 + 内容长度与区间一致（`runeLen(Content) == EndAt-StartAt`），若满足则按位置合并
- 按位置合并的三种情况：
  - 两个块有间隙则不合并
  - 有重叠则裁剪重叠部分，先按位置估计重叠量，再用文本匹配裁剪
  - 一个块完全包含另一个，确认文本相同才合并

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [x] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->

新增 `merge_position_path_test.go`

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
