### PR TITLE
fix(chunks): 受信任分块按精确位置裁剪重叠

### DIFF
--- a/internal/application/service/chat_pipeline/merge_overlap.go
+++ b/internal/application/service/chat_pipeline/merge_overlap.go
@@ -38,9 +38,7 @@ func (p *PluginMerge) mergeSequentialChunks(
 			groups = append(groups, mergedGroup{result: current, lastIndex: current.ChunkIndex})
 			continue
 		case mergeExtend:
-			lastChunk.Content = searchutil.AppendWithOverlap(
-				lastChunk.Content, current.Content, lastChunk.EndAt-current.StartAt,
-			)
+			lastChunk.Content = appendTrustedContent(lastChunk.Content, current.Content, lastChunk.EndAt-current.StartAt)
 			lastChunk.EndAt = current.EndAt
 			recordMergedChild(ctx, knowledgeID, lastChunk, current, "image_merge")
 		case mergeSubsume:
@@ -73,6 +71,21 @@ func (p *PluginMerge) mergeSequentialChunks(
 	})
 
 	return merged
+}
+
+// appendTrustedContent joins a trusted pair using the overlap the coordinates
+// already give us, and only falls back to text search when the overlap does not
+// match character for character (HTML entities or synthetic table headers can
+// keep the length invariant while changing the body).
+//
+// The fallback matters both ways: searching for the longest suffix match would
+// otherwise mistake a repeated table row or log line for the overlap and drop
+// real content, which is exactly what the position path is meant to avoid.
+func appendTrustedContent(acc, next string, positionOverlap int) string {
+	if merged, ok := searchutil.AppendWithExactOverlap(acc, next, positionOverlap); ok {
+		return merged
+	}
+	return searchutil.AppendWithOverlap(acc, next, positionOverlap)
 }
 
 // chunkTrusted reports whether a result's StartAt/EndAt can be trusted for

--- a/internal/application/service/chat_pipeline/merge_position_path_test.go
+++ b/internal/application/service/chat_pipeline/merge_position_path_test.go
@@ -55,6 +55,52 @@ func TestGroupAndMerge_TrustedOverlapTrimsAndExtendsRange(t *testing.T) {
 	assert.ElementsMatch(t, []string{"c2"}, results[0].SubChunkID)
 }
 
+func TestGroupAndMerge_TrustedOverlapBeyondTextSearchWindow(t *testing.T) {
+	// A real overlap wider than the text matcher's 400-rune window: the position
+	// path knows the exact amount, so the overlap must not survive twice.
+	overlap := rangeText('o', 500)
+	first := trustedResult("c1", 1, 0, 1000, rangeText('a', 500)+overlap)
+	second := trustedResult("c2", 2, 500, 1500, overlap+rangeText('b', 500))
+
+	results := mergeGrouped(docChunks(first, second))
+
+	require.Len(t, results, 1)
+	assert.Equal(t, rangeText('a', 500)+overlap+rangeText('b', 500), results[0].Content)
+	assert.Equal(t, 1500, results[0].EndAt)
+}
+
+func TestGroupAndMerge_TrustedAdjacentRepeatedTextKeepsEveryRow(t *testing.T) {
+	// Adjacent trusted chunks (positional overlap 0) made of one repeating row:
+	// searching for the longest suffix match would mistake the repetition for an
+	// overlap and drop rows, so the exact-overlap path must concatenate verbatim.
+	row := "| cell | cell |\n"
+	firstBody := rangeText('x', 100) + strings.Repeat(row, 2)
+	secondBody := strings.Repeat(row, 3) + rangeText('y', 60)
+	first := trustedResult("c1", 1, 0, runeLen(firstBody), firstBody)
+	second := trustedResult("c2", 2, runeLen(firstBody), runeLen(firstBody)+runeLen(secondBody), secondBody)
+
+	results := mergeGrouped(docChunks(first, second))
+
+	require.Len(t, results, 1)
+	assert.Equal(t, firstBody+secondBody, results[0].Content)
+	assert.Equal(t, 5, strings.Count(results[0].Content, row), "no repeated row may be dropped")
+}
+
+func TestGroupAndMerge_TrustedOverlapTextMismatchFallsBackToTextMatch(t *testing.T) {
+	// Length invariant holds but the bodies disagree inside the overlap window
+	// (HTML entities, synthetic headers): the exact path must refuse and the text
+	// fallback must keep both bodies rather than trim on coordinates.
+	first := trustedResult("c1", 1, 0, 100, rangeText('a', 80)+rangeText('b', 20))
+	second := trustedResult("c2", 2, 80, 200, rangeText('c', 20)+rangeText('d', 100))
+
+	results := mergeGrouped(docChunks(first, second))
+
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0].Content, rangeText('b', 20))
+	assert.Contains(t, results[0].Content, rangeText('c', 20))
+	assert.Contains(t, results[0].Content, rangeText('d', 100))
+}
+
 func TestGroupAndMerge_TrustedAdjacentJoinsSeamlessly(t *testing.T) {
 	// Adjacent trusted chunks are contiguous in the original document: the
 	// merged body must be the exact concatenation, with no separator inserted.

--- a/internal/searchutil/chunkmerge.go
+++ b/internal/searchutil/chunkmerge.go
@@ -130,6 +130,40 @@ func AppendWithOverlap(acc, next string, positionOverlap int) string {
 	return acc + next
 }
 
+// AppendWithExactOverlap 在调用方已确认位置坐标可信时，按坐标给出的精确重叠量
+// 拼接 acc 与 next：校验 acc 的末 overlap 个字符与 next 的前 overlap 个字符逐字
+// 符相等，相等则精确裁剪，overlap 为 0 时直接拼接。
+//
+// 与 AppendWithOverlap 的区别在于「不猜」：后者为兼容补写表头、HTML 实体等长度
+// 偏差，会在窗口内搜索最长后缀匹配，重复周期性文本（表格、日志）可能被误判成重
+// 叠而裁掉真实内容。坐标可信时重叠量是已知的，不需要搜索。
+//
+// 校验不通过返回 ok=false，由调用方决定是否回退到 AppendWithOverlap。
+func AppendWithExactOverlap(acc, next string, overlap int) (string, bool) {
+	if acc == "" {
+		return next, true
+	}
+	if next == "" {
+		return acc, true
+	}
+	if overlap < 0 {
+		return "", false
+	}
+	if overlap == 0 {
+		return acc + next, true
+	}
+
+	accRunes := []rune(acc)
+	nextRunes := []rune(next)
+	if overlap > len(accRunes) || overlap > len(nextRunes) {
+		return "", false
+	}
+	if !runeSlicesEqual(accRunes[len(accRunes)-overlap:], nextRunes[:overlap]) {
+		return "", false
+	}
+	return acc + string(nextRunes[overlap:]), true
+}
+
 // MergeTextChunks 按 StartAt（并列时按 ChunkIndex）排序后，用 AppendWithOverlap
 // 把多个 chunk 的内容重建为完整文本。gapSep 用于位置不相邻（有间隙）的两段之间
 // 的分隔符（如 "\n"），传空串则直接拼接。

--- a/internal/searchutil/chunkmerge_test.go
+++ b/internal/searchutil/chunkmerge_test.go
@@ -58,6 +58,50 @@ func TestAppendWithOverlap_NoOverlap(t *testing.T) {
 	}
 }
 
+func TestAppendWithExactOverlap_TrimsKnownOverlap(t *testing.T) {
+	overlap := "shared boundary text"
+	got, ok := AppendWithExactOverlap("before "+overlap, overlap+" after", len([]rune(overlap)))
+	if !ok {
+		t.Fatal("exact overlap should be accepted")
+	}
+	want := "before " + overlap + " after"
+	if got != want {
+		t.Fatalf("exact overlap mismatch:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+func TestAppendWithExactOverlap_ZeroOverlapConcatenatesRepeatedText(t *testing.T) {
+	// 首尾相接的两段都由同一周期性文本组成（表格行 / 日志行）。重叠量为 0 时
+	// 必须原样拼接，不能去搜索后缀匹配，否则会吃掉 next 开头的重复行。
+	row := "| cell | cell |\n"
+	acc := "前言\n" + row + row
+	next := row + row + row + "结尾\n"
+	got, ok := AppendWithExactOverlap(acc, next, 0)
+	if !ok {
+		t.Fatal("zero overlap should be accepted")
+	}
+	if got != acc+next {
+		t.Fatalf("zero overlap must concatenate verbatim:\n got=%q\nwant=%q", got, acc+next)
+	}
+}
+
+func TestAppendWithExactOverlap_RejectsMismatchedOverlap(t *testing.T) {
+	// 长度不变式成立但文本已经不同（HTML 实体、补写表头等），必须拒绝，
+	// 由调用方回退到按文本匹配。
+	if _, ok := AppendWithExactOverlap("abcdefghijkl", "XYZdefghijkl", 6); ok {
+		t.Fatal("mismatched overlap should be rejected")
+	}
+}
+
+func TestAppendWithExactOverlap_RejectsOverlapLongerThanBodies(t *testing.T) {
+	if _, ok := AppendWithExactOverlap("short", "shorter", 99); ok {
+		t.Fatal("overlap exceeding body length should be rejected")
+	}
+	if _, ok := AppendWithExactOverlap("short", "shorter", -1); ok {
+		t.Fatal("negative overlap should be rejected")
+	}
+}
+
 func TestJoinChunkContentUsesCurrentTextInsteadOfSourceOffsets(t *testing.T) {
 	first := "first edited body with no original overlap"
 	second := "second independently edited body"

--- a/internal/types/search.go
+++ b/internal/types/search.go
@@ -211,7 +211,13 @@ type SearchResult struct {
 	// ContentRevision is the chunk edit revision at retrieval time.
 	// Internal only: used by the merge pipeline to decide whether source
 	// coordinates are still trustworthy.
-	ContentRevision int `json:"-"`
+	//
+	// Zero means "never edited", so any construction path that forgets to carry
+	// it over fails open to the position path. Results rebuilt from JSON (stored
+	// message references) always land on zero because the field is not
+	// serialized; the length invariant in chunkTrusted is the remaining guard
+	// there. Keep the gorm column explicit so direct row scans populate it.
+	ContentRevision int `gorm:"column:content_revision" json:"-"`
 }
 
 // SearchParams represents the search parameters


### PR DESCRIPTION
## Description

#2555 恢复了「位置可信时按位置合并」，但受信任路径的裁剪仍然走 `searchutil.AppendWithOverlap` —— 它会在窗口内搜索**最长**后缀匹配。坐标既然已被判定可信，重叠量就是已知的，不需要搜索，而搜索本身会带来两个问题：

- **相邻分块丢内容（`chunk_overlap=0` 时每一对相邻分块都会走到）**：`positionOverlap` 为 0 时 `AppendWithOverlap` 依然以 12 字符的最短针、320 字符的窗口去搜后缀。周期性文本（表格行、日志行）会被误判成重叠而裁掉真实内容。实测：前段结尾两遍 `| cell | cell |\n`、后段开头三遍，期望 5 行，实际只剩 3 行。
- **过度裁剪**：搜索上限是 `max(span*3, 400)` 且从最长匹配开始，重复文本下可能裁掉多于真实重叠的部分。

改动：受信任分块用坐标给出的精确重叠量校验并裁剪，只在重叠区文本逐字符不相等时才回退到文本匹配。

- `searchutil` 新增 `AppendWithExactOverlap(acc, next string, overlap int) (string, bool)`：校验 `acc` 末 `overlap` 个字符与 `next` 前 `overlap` 个字符相等则精确裁剪；`overlap == 0` 直接拼接；校验失败返回 `ok=false`。
- `mergeExtend` 经 `appendTrustedContent` 先试精确裁剪，失败回退 `AppendWithOverlap`，保留对补写表头、HTML 实体等「长度巧合相等但文本不同」的兜底。
- `types.SearchResult.ContentRevision` 补上显式 `gorm:"column:content_revision"`：该字段为 0 表示「未编辑」，也就是任何漏传的路径都会 fail-open 到位置路径。直接扫行的查询靠显式列名保证赋值；从 JSON 还原的历史引用（字段为 `json:"-"`）必然为 0，注释里写明此时只剩 `chunkTrusted` 的长度不变式兜底。

### 一处行为说明（未改代码）

受信任分块遇到真实位置间隙时会拆成两条结果（#2555 的既有行为，语义上正确）。`filter_top_k` 在 merge 之后按 `RerankTopK` 截断，因此一对原本合成一条的结果现在占两个名额，可能挤掉其他文档的召回结果。若线上 top-K 余量紧张需要留意。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test

## Related Issue

Follow-up to #2555

## Testing

`internal/searchutil/chunkmerge_test.go` 新增 4 个 `AppendWithExactOverlap` 单测（精确裁剪、零重叠原样拼接、文本不匹配拒绝、越界/负数拒绝）。

`merge_position_path_test.go` 新增 3 个管线级用例：

- `TestGroupAndMerge_TrustedOverlapBeyondTextSearchWindow`：500 字符重叠只保留一份，钉住 #2555 的核心收益（原有用例只有 20 字符重叠，旧逻辑下也能通过，钉不住回归）。
- `TestGroupAndMerge_TrustedAdjacentRepeatedTextKeepsEveryRow`：本 PR 修复的丢内容场景，在 `main` 上失败（5 行只剩 3 行），本分支通过。
- `TestGroupAndMerge_TrustedOverlapTextMismatchFallsBackToTextMatch`：长度不变式成立但重叠区文本不同，两段内容都必须保留。

`go test ./internal/searchutil/... ./internal/application/service/chat_pipeline/...` 全绿；`go build ./...` 通过。

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (`golangci-lint run --new-from-rev=github_public/main` on the changed packages: 0 issues)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above