### PR TITLE
fix(im/wecom): scope connection close to its own generation

### DIFF
--- a/internal/im/wecom/longconn.go
+++ b/internal/im/wecom/longconn.go
@@ -217,12 +217,7 @@ func (c *LongConnClient) Start(ctx context.Context) error {
 // Stop gracefully closes the connection.
 func (c *LongConnClient) Stop() {
 	c.closed.Store(true)
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.conn != nil {
-		_ = c.conn.Close()
-		c.conn = nil
-	}
+	c.closeConn()
 }
 
 // SendReply sends a text reply through the WebSocket connection.
@@ -380,14 +375,20 @@ func (c *LongConnClient) connectAndRun(ctx context.Context) error {
 	c.mu.Unlock()
 
 	defer func() {
-		c.closeConn()
-		_ = conn.Close()
+		c.closeConnIf(conn)
 		// NOTE: streamBufs is intentionally NOT cleared on reconnect.
 		// Active streams survive reconnections — the WeCom replace-based
 		// protocol means the next UpdateStreamContent will resend the full
 		// accumulated content on the new connection. EndStream always
 		// cleans up the buffer, so there is no memory leak.
 	}()
+
+	// A Stop() that lands between the dial and the assignment above finds no
+	// connection to close, so re-check here to avoid running a receive loop
+	// that nobody will tear down until the read deadline expires.
+	if c.closed.Load() {
+		return fmt.Errorf("client stopped")
+	}
 
 	// Authenticate
 	if err := c.authenticate(ctx); err != nil {
@@ -399,7 +400,7 @@ func (c *LongConnClient) connectAndRun(ctx context.Context) error {
 	// Start heartbeat
 	heartbeatCtx, heartbeatCancel := context.WithCancel(ctx)
 	defer heartbeatCancel()
-	go c.heartbeatLoop(heartbeatCtx)
+	go c.heartbeatLoop(heartbeatCtx, conn)
 
 	// Message receive loop with read deadline.
 	// The deadline is reset on every successful read; if no message arrives
@@ -421,7 +422,7 @@ func (c *LongConnClient) connectAndRun(ctx context.Context) error {
 		switch frame.Cmd {
 		case cmdMsgCallback, cmdEventCallback:
 			// Detach from connection ctx so in-flight messages survive reconnects.
-			go c.handleCallback(context.WithoutCancel(ctx), frame)
+			go c.handleCallback(context.WithoutCancel(ctx), conn, frame)
 		default:
 			// pong or other control frames — ignore
 		}
@@ -472,7 +473,7 @@ func (c *LongConnClient) authenticate(ctx context.Context) error {
 	return nil
 }
 
-func (c *LongConnClient) heartbeatLoop(ctx context.Context) {
+func (c *LongConnClient) heartbeatLoop(ctx context.Context, conn *ws.Conn) {
 	ticker := time.NewTicker(defaultHeartbeatInterval)
 	defer ticker.Stop()
 
@@ -488,14 +489,14 @@ func (c *LongConnClient) heartbeatLoop(ctx context.Context) {
 			}
 			if err := c.writeJSON(frame); err != nil {
 				logger.Warnf(ctx, "[WeCom] Heartbeat failed: %v, closing connection to trigger reconnect", err)
-				c.closeConn()
+				c.closeConnIf(conn)
 				return
 			}
 		}
 	}
 }
 
-func (c *LongConnClient) handleCallback(ctx context.Context, frame wsFrame) {
+func (c *LongConnClient) handleCallback(ctx context.Context, conn *ws.Conn, frame wsFrame) {
 	// Log raw message body for debugging
 	logger.Debugf(ctx, "[WeCom] Raw callback body: %s", string(frame.Body))
 
@@ -514,7 +515,7 @@ func (c *LongConnClient) handleCallback(ctx context.Context, frame wsFrame) {
 		switch msg.Event.EventType {
 		case "disconnected_event":
 			logger.Warnf(ctx, "[WeCom] Server sent disconnected_event, closing connection to trigger reconnect")
-			c.closeConn()
+			c.closeConnIf(conn)
 		default:
 			logger.Infof(ctx, "[WeCom] Ignoring event type: %s", msg.Event.EventType)
 		}
@@ -701,14 +702,40 @@ func (c *LongConnClient) convertMixedMessage(msg *botMessage, chatID string, cha
 	return nil
 }
 
-// closeConn forcibly closes the underlying WebSocket, which unblocks any
-// pending ReadMessage call in the receive loop and triggers a reconnection.
+// closeConn forcibly closes the active WebSocket, which unblocks any pending
+// ReadMessage call in the receive loop and triggers a reconnection.
+//
+// c.mu is released before Close because closing a TLS connection writes a
+// close_notify alert and can block for seconds on a stalled peer. Holding c.mu
+// across that write stalls Stop(), and the IM service tears channels down while
+// holding its own channel-map lock, so the delay spreads to every other channel
+// operation in the process.
 func (c *LongConnClient) closeConn() {
 	c.mu.Lock()
 	conn := c.conn
 	c.conn = nil
 	c.mu.Unlock()
 	if conn != nil {
+		_ = conn.Close()
+	}
+}
+
+// closeConnIf closes conn only while it is still the active connection.
+// Callers bound to a single connection generation — the heartbeat loop and the
+// detached callback handlers — must use this instead of closeConn: their
+// goroutines can outlive the connection that spawned them, and an unconditional
+// close would tear down a healthy connection opened by a later reconnect.
+func (c *LongConnClient) closeConnIf(conn *ws.Conn) {
+	if conn == nil {
+		return
+	}
+	c.mu.Lock()
+	active := c.conn == conn
+	if active {
+		c.conn = nil
+	}
+	c.mu.Unlock()
+	if active {
 		_ = conn.Close()
 	}
 }

--- a/internal/im/wecom/longconn_close_test.go
+++ b/internal/im/wecom/longconn_close_test.go
@@ -1,0 +1,152 @@
+package wecom
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	ws "github.com/gorilla/websocket"
+)
+
+// newTestConn dials a throwaway WebSocket server and returns the client side.
+// The server drains frames until the client goes away.
+func newTestConn(t *testing.T) *ws.Conn {
+	t.Helper()
+
+	upgrader := ws.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverConn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = serverConn.Close() }()
+		for {
+			if _, _, err := serverConn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	conn, _, err := ws.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial test websocket: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+// connUsable reports whether conn still accepts writes.
+func connUsable(t *testing.T, conn *ws.Conn) bool {
+	t.Helper()
+	_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	return conn.WriteMessage(ws.TextMessage, []byte("probe")) == nil
+}
+
+func TestCloseConnClosesAndClearsActiveConnection(t *testing.T) {
+	conn := newTestConn(t)
+	c := &LongConnClient{conn: conn}
+
+	c.closeConn()
+
+	if c.conn != nil {
+		t.Error("closeConn left c.conn set")
+	}
+	if connUsable(t, conn) {
+		t.Error("closeConn did not close the connection")
+	}
+}
+
+func TestStopClosesActiveConnection(t *testing.T) {
+	conn := newTestConn(t)
+	c := &LongConnClient{conn: conn}
+
+	c.Stop()
+
+	if !c.closed.Load() {
+		t.Error("Stop did not mark the client closed")
+	}
+	if c.conn != nil {
+		t.Error("Stop left c.conn set")
+	}
+	if connUsable(t, conn) {
+		t.Error("Stop did not close the connection")
+	}
+}
+
+func TestCloseConnIfClosesActiveConnection(t *testing.T) {
+	conn := newTestConn(t)
+	c := &LongConnClient{conn: conn}
+
+	c.closeConnIf(conn)
+
+	if c.conn != nil {
+		t.Error("closeConnIf left c.conn set")
+	}
+	if connUsable(t, conn) {
+		t.Error("closeConnIf did not close the active connection")
+	}
+}
+
+// A heartbeat loop or detached callback handler from a previous connection
+// generation must not tear down the connection opened by a later reconnect.
+func TestCloseConnIfIgnoresSupersededConnection(t *testing.T) {
+	stale := newTestConn(t)
+	active := newTestConn(t)
+	c := &LongConnClient{conn: active}
+
+	c.closeConnIf(stale)
+
+	if c.conn != active {
+		t.Fatal("closeConnIf cleared the active connection on behalf of a stale caller")
+	}
+	if !connUsable(t, active) {
+		t.Fatal("closeConnIf closed the active connection on behalf of a stale caller")
+	}
+}
+
+func TestCloseConnIfIgnoresNilConnection(t *testing.T) {
+	conn := newTestConn(t)
+	c := &LongConnClient{conn: conn}
+
+	c.closeConnIf(nil)
+
+	if c.conn != conn {
+		t.Error("closeConnIf(nil) cleared the active connection")
+	}
+	if !connUsable(t, conn) {
+		t.Error("closeConnIf(nil) closed the active connection")
+	}
+}
+
+// Exercises the close and write paths together so the race detector can catch
+// any regression that reintroduces unsynchronized access to c.conn.
+func TestCloseConnRacesWithWriteJSON(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		conn := newTestConn(t)
+		c := &LongConnClient{conn: conn}
+
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			_ = c.writeJSON(wsFrame{Cmd: cmdPing})
+		}()
+		go func() {
+			defer wg.Done()
+			c.closeConnIf(conn)
+		}()
+		go func() {
+			defer wg.Done()
+			c.closeConn()
+		}()
+		wg.Wait()
+
+		if c.conn != nil {
+			t.Fatal("connection pointer still set after concurrent closes")
+		}
+	}
+}


### PR DESCRIPTION
## Description

Follow-up to #2551, which moved `conn.Close()` out of the `c.mu` critical section in `closeConn()`. This PR finishes that cleanup: it fixes the callers that can close the *wrong* connection, and applies the same lock discipline to `Stop()`, which #2551 left untouched.

### 1. A stale goroutine could close a freshly reconnected connection

`heartbeatLoop` and `handleCallback` both called `closeConn()`, which closes whatever connection is currently active — but neither is guaranteed to still belong to that connection:

- `heartbeatCancel()` only signals; if the heartbeat goroutine is already inside `writeJSON`, it keeps running and reports the failure afterwards.
- Callback handlers run on `context.WithoutCancel(ctx)`, deliberately detached so in-flight messages survive reconnects.

So a late-firing goroutine from generation N could tear down the connection that the reconnect loop had just opened for generation N+1. The client then silently dropped messages until the next read timeout (90s) forced another reconnect.

Both callers now receive their owning `conn` and close through a new `closeConnIf(conn)`, which only acts while that connection is still active. This mirrors the sibling drivers — `internal/im/yunzhijia` and `internal/im/qqbot` already scope their heartbeat loops to a single connection, and yunzhijia guards its writes with the same `c.conn != conn` check.

### 2. `Stop()` still held `c.mu` across `Close()`

`Stop()` is the caller where a blocking close actually hurts, and it is exactly the case the existing `writeTimeout` comment warns about: the IM service tears channels down while holding its own channel-map lock, so a TLS `close_notify` write to a stalled peer (bounded by Go's internal 5s deadline) stalls every other channel operation in the process. `Stop()` is now `closed.Store(true)` plus `closeConn()`, so there is one close path with one lock discipline.

For the record, this is also why the PR title says "scope the close" rather than "fix a deadlock": `tls.Conn.Close()` caps its `close_notify` write at 5 seconds and skips it entirely when a write is in flight, so the worst case was a bounded stall in teardown, not an indefinite hang.

### 3. Smaller cleanups

- The receive loop's deferred cleanup called `closeConn()` and then `conn.Close()` on the same connection. It now closes only through `closeConnIf(conn)`. `c.conn` only ever moves `conn -> nil` (by a caller that also closes it) or `nil -> newConn` (inside `connectAndRun`, serialised by `Start`), so the connection is still closed exactly once.
- `connectAndRun` re-checks `c.closed` after publishing the connection. A `Stop()` landing between the dial and the assignment previously found nothing to close and left a receive loop running until its read deadline expired.
- Documented on `closeConn` *why* the mutex is released before `Close`, so the next refactor does not quietly pull the I/O back under the lock.

## Type of Change

- [x] Bug fix
- [x] Test

## Testing

```bash
go test -race -count=1 ./internal/im/wecom/
go test -count=1 ./internal/im/...
go build ./...
go vet ./internal/im/wecom/
gofmt -l internal/im/wecom/longconn.go internal/im/wecom/longconn_close_test.go
git diff --check github_public/main...HEAD
```

All pass. `internal/im/wecom` had no coverage for the connection lifecycle, so `longconn_close_test.go` adds it: the tests dial real WebSocket connections against an `httptest` server and pin that `closeConn`/`Stop` close and clear the active connection, that `closeConnIf` closes only its own connection and leaves a superseded caller's request as a no-op, and that concurrent close/write paths stay clean under `-race`.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted with `gofmt`
- [x] Package tests pass with the race detector
- [x] Self-reviewed the code
- [x] Added regression coverage for the connection-generation guard
- [x] No breaking API change (all changed methods are unexported)