### PR TITLE
fix(chunks): 流水线重写后的检索结果不用位置匹配

### DIFF
--- a/internal/application/service/chat_pipeline/merge.go
+++ b/internal/application/service/chat_pipeline/merge.go
@@ -338,6 +338,7 @@ func (p *PluginMerge) resolveParentChunks(
 			assignScopedImageInfo(r, scopedImageInfo, r.ID)
 			parentContent := searchutil.PruneMarkdownImagesByImageInfo(parent.Content, r.ImageInfo)
 			r.Content = searchutil.JoinChunkContent(parentContent, r.Content, "\n\n")
+			r.ContentRewritten = true
 			if !containsID(r.SubChunkID, r.ID) {
 				r.SubChunkID = append(r.SubChunkID, r.ID)
 			}
@@ -357,6 +358,7 @@ func (p *PluginMerge) resolveParentChunks(
 			}
 			r.Content = textParent.Content
 			r.ChunkIndex = textParent.ChunkIndex
+			r.ContentRewritten = true
 			assignScopedImageInfo(r, scopedImageInfo, textParent.ID)
 			if r.ImageInfo == "" && hitImageInfo != "" {
 				r.ImageInfo = searchutil.FilterImageInfoByContentURLs(textParent.Content, hitImageInfo)
@@ -364,6 +366,7 @@ func (p *PluginMerge) resolveParentChunks(
 			textContent := searchutil.PruneMarkdownImagesByImageInfo(textParent.Content, r.ImageInfo)
 			parentContent := searchutil.PruneMarkdownImagesByImageInfo(contentSource.Content, r.ImageInfo)
 			r.Content = searchutil.JoinChunkContent(parentContent, textContent, "\n\n")
+			r.ContentRewritten = true
 			pipelineInfo(ctx, "Merge", "image_parent_resolve", map[string]interface{}{
 				"child_id":   r.ID,
 				"child_type": r.ChunkType,

--- a/internal/application/service/chat_pipeline/merge_expand.go
+++ b/internal/application/service/chat_pipeline/merge_expand.go
@@ -215,6 +215,7 @@ func (p *PluginMerge) expandShortContextWithNeighbors(
 
 		beforeLen := runeLen(res.Content)
 		res.Content = merged
+		res.ContentRewritten = true
 
 		for _, id := range prevIDs {
 			if id != "" && !containsID(res.SubChunkID, id) {

--- a/internal/application/service/chat_pipeline/merge_overlap.go
+++ b/internal/application/service/chat_pipeline/merge_overlap.go
@@ -89,10 +89,11 @@ func appendTrustedContent(acc, next string, positionOverlap int) string {
 }
 
 // chunkTrusted reports whether a result's StartAt/EndAt can be trusted for
-// position-based merging: unedited, valid range, and splitter-consistent
-// length (runeLen(Content) == EndAt-StartAt).
+// position-based merging: unedited, not pipeline-rewritten, valid range, and
+// splitter-consistent length (runeLen(Content) == EndAt-StartAt).
 func chunkTrusted(chunk *types.SearchResult) bool {
 	return chunk.ContentRevision == 0 &&
+		!chunk.ContentRewritten &&
 		chunk.EndAt > chunk.StartAt &&
 		runeLen(chunk.Content) == chunk.EndAt-chunk.StartAt
 }

--- a/internal/application/service/chat_pipeline/merge_position_path_test.go
+++ b/internal/application/service/chat_pipeline/merge_position_path_test.go
@@ -125,6 +125,23 @@ func TestGroupAndMerge_TrustedGapStartsNewGroup(t *testing.T) {
 	require.Len(t, results, 2, "position gap must not merge")
 }
 
+func TestGroupAndMerge_RewrittenResultDoesNotTrustCoordinates(t *testing.T) {
+	// A result whose content was replaced by the pipeline (parent or neighbor
+	// expansion) must never enter the position path, even when the replacement
+	// happens to satisfy the length invariant and share boundary text: its
+	// stale coordinates must not extend the merged group's range.
+	first := trustedResult("c1", 1, 0, 100, rangeText('a', 100))
+	rewritten := trustedResult("c2", 2, 80, 200, rangeText('a', 20)+rangeText('b', 100))
+	rewritten.ContentRewritten = true
+
+	results := mergeGrouped(docChunks(first, rewritten))
+
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0].Content, rangeText('a', 100))
+	assert.Contains(t, results[0].Content, rangeText('b', 100))
+	assert.Equal(t, 100, results[0].EndAt, "rewritten result must not extend the range via stale coordinates")
+}
+
 func TestGroupAndMerge_TrustedContainedSubsumes(t *testing.T) {
 	// Range-contained and text-verified: one result whose content is the
 	// outer body; the inner chunk is recorded, not duplicated.

--- a/internal/types/search.go
+++ b/internal/types/search.go
@@ -218,6 +218,12 @@ type SearchResult struct {
 	// serialized; the length invariant in chunkTrusted is the remaining guard
 	// there. Keep the gorm column explicit so direct row scans populate it.
 	ContentRevision int `gorm:"column:content_revision" json:"-"`
+
+	// ContentRewritten reports that the merge pipeline replaced Content
+	// (parent or neighbor expansion) after retrieval, so StartAt/EndAt no
+	// longer describe the body. Internal only: used by the merge pipeline,
+	// never serialized.
+	ContentRewritten bool `json:"-"`
 }
 
 // SearchParams represents the search parameters


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

parent/邻居展开会替换检索结果的 `Content` 但不更新 `StartAt/EndAt`，而 `chunkTrusted`
此前仅靠长度恒等式意外拦截。

新增内部字段 `ContentRewritten`，`chunkTrusted` 检查该字段，凡是展开过的结果一律显式标记、不再信任位置。

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->

新增 `TestGroupAndMerge_RewrittenResultDoesNotTrustCoordinates`

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
