### PR TITLE
fix(vlm): support GPT-5 completion token parameter

### DIFF
--- a/internal/models/chat/provider.go
+++ b/internal/models/chat/provider.go
@@ -259,14 +259,7 @@ func (moonshotProvider) ShapeRequest(req *openai.ChatCompletionRequest, _ *ChatO
 // shapeOpenAIReasoning strips sampling params (unsupported by o-series / GPT-5)
 // and migrates max_tokens to max_completion_tokens. See issue #1283.
 func shapeOpenAIReasoning(req *openai.ChatCompletionRequest) {
-	req.Temperature = 0
-	req.TopP = 0
-	req.FrequencyPenalty = 0
-	req.PresencePenalty = 0
-	if req.MaxCompletionTokens == 0 && req.MaxTokens > 0 {
-		req.MaxCompletionTokens = req.MaxTokens
-	}
-	req.MaxTokens = 0
+	provider.ShapeOpenAIReasoningRequest(req)
 }
 
 // providerRegistry is ordered: more specific adapters (those with a real

--- a/internal/models/provider/openai.go
+++ b/internal/models/provider/openai.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Tencent/WeKnora/internal/types"
+	openai "github.com/sashabaranov/go-openai"
 )
 
 const (
@@ -83,4 +84,17 @@ func IsOpenAIReasoningOrGPT5Model(modelName string) bool {
 		}
 	}
 	return false
+}
+
+// ShapeOpenAIReasoningRequest removes sampling parameters unsupported by
+// o-series / GPT-5 models and migrates max_tokens to max_completion_tokens.
+func ShapeOpenAIReasoningRequest(req *openai.ChatCompletionRequest) {
+	req.Temperature = 0
+	req.TopP = 0
+	req.FrequencyPenalty = 0
+	req.PresencePenalty = 0
+	if req.MaxCompletionTokens == 0 && req.MaxTokens > 0 {
+		req.MaxCompletionTokens = req.MaxTokens
+	}
+	req.MaxTokens = 0
 }

--- a/internal/models/provider/openai_test.go
+++ b/internal/models/provider/openai_test.go
@@ -1,6 +1,10 @@
 package provider
 
-import "testing"
+import (
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+)
 
 // TestIsOpenAIReasoningOrGPT5Model 验证 GPT-5 / o-series 模型识别逻辑。
 // 见 issue #1283：这些模型必须使用 max_completion_tokens 替代 max_tokens。
@@ -42,5 +46,33 @@ func TestIsOpenAIReasoningOrGPT5Model(t *testing.T) {
 				t.Errorf("IsOpenAIReasoningOrGPT5Model(%q) = %v, want %v", tc.input, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestShapeOpenAIReasoningRequest(t *testing.T) {
+	req := openai.ChatCompletionRequest{
+		MaxTokens:        128,
+		Temperature:      0.7,
+		TopP:             0.9,
+		FrequencyPenalty: 0.1,
+		PresencePenalty:  0.2,
+	}
+
+	ShapeOpenAIReasoningRequest(&req)
+
+	if req.MaxTokens != 0 {
+		t.Fatalf("MaxTokens = %d, want 0", req.MaxTokens)
+	}
+	if req.MaxCompletionTokens != 128 {
+		t.Fatalf("MaxCompletionTokens = %d, want 128", req.MaxCompletionTokens)
+	}
+	if req.Temperature != 0 || req.TopP != 0 || req.FrequencyPenalty != 0 || req.PresencePenalty != 0 {
+		t.Fatalf("unsupported sampling parameters were not cleared: %+v", req)
+	}
+
+	req = openai.ChatCompletionRequest{MaxTokens: 128, MaxCompletionTokens: 2048}
+	ShapeOpenAIReasoningRequest(&req)
+	if req.MaxCompletionTokens != 2048 {
+		t.Fatalf("existing MaxCompletionTokens was overwritten: got %d want 2048", req.MaxCompletionTokens)
 	}
 }

--- a/internal/models/vlm/remote_api.go
+++ b/internal/models/vlm/remote_api.go
@@ -143,6 +143,9 @@ func (v *RemoteAPIVLM) Predict(ctx context.Context, imgBytesList [][]byte, promp
 		MaxTokens:   defaultMaxToks,
 		Temperature: v.temperature,
 	}
+	if provider.IsOpenAIReasoningOrGPT5Model(v.modelName) {
+		provider.ShapeOpenAIReasoningRequest(&req)
+	}
 
 	totalImageSize := 0
 	for _, img := range imgBytesList {

--- a/internal/models/vlm/remote_api_test.go
+++ b/internal/models/vlm/remote_api_test.go
@@ -1,0 +1,76 @@
+package vlm
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	secutils "github.com/Tencent/WeKnora/internal/utils"
+)
+
+func TestRemoteAPIVLMPredictShapesReasoningModelRequest(t *testing.T) {
+	requestBody := captureVLMRequest(t, "gpt-5-mini")
+
+	if _, ok := requestBody["max_tokens"]; ok {
+		t.Fatalf("reasoning-model request contains unsupported max_tokens: %v", requestBody)
+	}
+	if got := requestBody["max_completion_tokens"]; got != float64(defaultMaxToks) {
+		t.Fatalf("max_completion_tokens = %v, want %d", got, defaultMaxToks)
+	}
+	if _, ok := requestBody["temperature"]; ok {
+		t.Fatalf("reasoning-model request contains unsupported temperature: %v", requestBody)
+	}
+}
+
+func TestRemoteAPIVLMPredictPreservesStandardModelRequest(t *testing.T) {
+	requestBody := captureVLMRequest(t, "gpt-4o")
+
+	if got := requestBody["max_tokens"]; got != float64(defaultMaxToks) {
+		t.Fatalf("max_tokens = %v, want %d", got, defaultMaxToks)
+	}
+	if _, ok := requestBody["max_completion_tokens"]; ok {
+		t.Fatalf("standard-model request contains max_completion_tokens: %v", requestBody)
+	}
+	if got, ok := requestBody["temperature"].(float64); !ok || math.Abs(got-float64(defaultTemp)) > 1e-6 {
+		t.Fatalf("temperature = %v, want %v", got, defaultTemp)
+	}
+}
+
+func captureVLMRequest(t *testing.T, modelName string) map[string]any {
+	t.Helper()
+	t.Setenv("SSRF_WHITELIST", "127.0.0.1")
+	secutils.ResetSSRFWhitelistForTest()
+	t.Cleanup(secutils.ResetSSRFWhitelistForTest)
+
+	requestBody := map[string]any{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"caption"}}]}`))
+	}))
+	defer server.Close()
+
+	client, err := NewRemoteAPIVLM(&Config{
+		ModelName: modelName,
+		ModelID:   modelName,
+		APIKey:    "test-key",
+		BaseURL:   server.URL,
+		Provider:  "openai",
+	})
+	if err != nil {
+		t.Fatalf("NewRemoteAPIVLM: %v", err)
+	}
+	if _, err := client.Predict(context.Background(), nil, "describe the image"); err != nil {
+		t.Fatalf("Predict: %v", err)
+	}
+
+	return requestBody
+}


### PR DESCRIPTION
## Description

The remote VLM path always sends `max_tokens`, which the OpenAI client rejects for GPT-5 and o-series models before image OCR or caption generation can run. The chat path already shapes these requests, but VLM requests did not share that behavior.

This change:

- moves the existing OpenAI reasoning-model request shaping into the shared provider package;
- reuses it from the chat adapter to preserve current chat behavior;
- applies it to remote VLM requests for GPT-5 and o-series model names;
- verifies the serialized VLM request body for both reasoning and standard models.

For reasoning models, `max_tokens` is migrated to `max_completion_tokens` and unsupported sampling parameters are omitted. Existing `max_completion_tokens` values remain authoritative. Standard models such as `gpt-4o` keep their current request shape.

A previous implementation attempt in #2229 was closed by its author without merge. This branch is rebuilt from current `main` and independently validated against the current provider and SSRF-safe transport code.

## Type of Change

- [x] Bug fix
- [x] Test

## Related Issue

Fixes #2537

## Testing

Passed in the official Go 1.26 container:

```text
go test ./internal/models/provider ./internal/models/chat ./internal/models/vlm -count=1
ok  github.com/Tencent/WeKnora/internal/models/provider
ok  github.com/Tencent/WeKnora/internal/models/chat
ok  github.com/Tencent/WeKnora/internal/models/vlm

go vet ./internal/models/provider ./internal/models/chat ./internal/models/vlm
```

`go test ./internal/models/... -count=1` was also attempted. Every package except `internal/models/embedding` passed. Its three existing Azure tests resolve `example-resource.openai.azure.com` to Docker-private `172.29.0.47` in this environment and are rejected by the SSRF guard before their mocked transport is installed. No embedding files are changed by this PR.

## Checklist

- [x] `git diff --check upstream/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped static analysis passes (`go vet` on changed packages)
- [x] Full-repository checks were run, or unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Documentation is not required; this restores the existing VLM contract
- [x] No breaking changes

## Screenshots / Recordings

Not applicable; backend request-shaping fix only.