### PR TITLE
docs: 部署步骤增加 docker compose pull，防止复用缓存的旧镜像

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,8 @@
 
 # ========== A1. 镜像版本与构建 ==========
 # WeKnora 镜像版本标签：latest（稳定版）/ main（最新开发版）。
-# WEKNORA_VERSION=latest
+# 镜像版本标签，不指定时默认 latest。升级到指定版本（如 0.7.0）可避免本地缓存旧镜像导致版本不一致
+WEKNORA_VERSION=latest
 # Alpine apk 镜像源（构建 app 镜像用，留空用默认源；国内可设 mirrors.tencent.com 加速）。
 APK_MIRROR_ARG=mirrors.tencent.com
 # docreader 镜像构建时 apt 镜像源（留空用默认源）。

--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ See [`cli/README.md`](./cli/README.md) for install + 5-minute quickstart and
 git clone https://github.com/Tencent/WeKnora.git
 cd WeKnora
 cp .env.example .env   # Edit .env as needed, see comments in the file
-docker compose up -d   # Start core services
+docker compose pull     # Pull the latest images
+docker compose up -d    # Start core services
 ```
 
 Once started, visit **http://localhost** to get started.

--- a/README_CN.md
+++ b/README_CN.md
@@ -186,7 +186,8 @@
 git clone https://github.com/Tencent/WeKnora.git
 cd WeKnora
 cp .env.example .env   # 按需编辑 .env，详见文件内注释
-docker compose up -d   # 启动核心服务
+docker compose pull     # 拉取最新镜像
+docker compose up -d    # 启动核心服务
 ```
 
 启动成功后访问 **http://localhost** 即可使用。


### PR DESCRIPTION
用户下载新版本 release 后直接 `docker compose up -d`，
Docker 不会自动拉取新镜像，导致仍运行本地缓存的旧镜像，
UI 显示的版本与下载的 release 不一致。

改动：
- README / README\_CN 部署命令增加 `docker compose pull`
- .env.example 启用 WEKNORA\_VERSION 变量并加注释说明

Closes #2560