### PR TITLE
fix(auth): do not sanitize registration password before hashing

### DIFF
--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -164,7 +164,12 @@ func (h *AuthHandler) Register(c *gin.Context) {
 	}
 	req.Username = secutils.SanitizeForLog(req.Username)
 	req.Email = secutils.SanitizeForLog(req.Email)
-	req.Password = secutils.SanitizeForLog(req.Password)
+	// Password is intentionally NOT sanitized: SanitizeForLog replaces
+	// \n, \r, \t and strips other control characters so a string is safe
+	// to write into a log line. Applying it to a real password would
+	// silently rewrite the credential before hashing, so registration
+	// would succeed but login with the original password would fail.
+	// Passwords must never be logged, so they don't need that defence.
 
 	// Validate required fields
 	if req.Username == "" || req.Email == "" || req.Password == "" {

--- a/internal/handler/auth_register_invite_only_test.go
+++ b/internal/handler/auth_register_invite_only_test.go
@@ -167,3 +167,37 @@ func TestRegister_NilAuthConfigDoesNotPanic(t *testing.T) {
 		t.Fatalf("nil Auth config must fall back to allow, got %d body=%s", w.Code, w.Body.String())
 	}
 }
+
+// TestRegister_PreservesPasswordBytes is the regression for #2521.
+// SanitizeForLog is for log output only; applying it to credentials
+// rewrites tabs/newlines/control chars before hashing, so a password
+// that registers successfully cannot be used at login.
+func TestRegister_PreservesPasswordBytes(t *testing.T) {
+	// Password contains a tab and a newline — both are rewritten by
+	// SanitizeForLog (tab → space, newline → space). The handler must
+	// pass the exact original string to UserService.Register.
+	const originalPassword = "abc\t123!\nX"
+
+	var gotPassword string
+	us := &stubRegisterUserService{
+		register: func(_ context.Context, req *types.RegisterRequest) (*types.User, error) {
+			gotPassword = req.Password
+			return &types.User{ID: "u1", Email: "alice@example.com"}, nil
+		},
+	}
+	h := NewAuthHandler(&config.Config{
+		Auth: &config.AuthConfig{RegistrationMode: config.AuthRegistrationModeSelfServe},
+	}, us, nil, nil, nil)
+
+	body := validRegisterBody()
+	body["password"] = originalPassword
+	w := doRegister(t, newRegisterTestRouter(h), body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("registration with control chars in password must succeed, got %d body=%s",
+			w.Code, w.Body.String())
+	}
+	if gotPassword != originalPassword {
+		t.Fatalf("password mutated before UserService.Register:\n  got  %q\n  want %q",
+			gotPassword, originalPassword)
+	}
+}


### PR DESCRIPTION
## Description
Public registration was calling `SanitizeForLog` on `req.Password` before `UserService.Register`. That helper is meant for log output and rewrites tabs, newlines, and other control characters, so a password that registered successfully could not be used at login.

This matches the invite registration path (`RegisterByInvite`), which already leaves passwords untouched and documents why.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #2521

## Testing
```bash
gofmt -w internal/handler/auth.go internal/handler/auth_register_invite_only_test.go
go test ./internal/handler/ -count=1 -run 'TestRegister_'
```
Result: `ok github.com/Tencent/WeKnora/internal/handler`

Added `TestRegister_PreservesPasswordBytes` to assert that a password containing tab/newline is passed to `UserService.Register` unchanged.

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above