### PR TITLE
fix(rerank):  prevent invalid-index panics and terminate error SSE

### DIFF
--- a/frontend/src/utils/referenceSources.test.mjs
+++ b/frontend/src/utils/referenceSources.test.mjs
@@ -4,9 +4,73 @@ import {
   buildReferenceSections,
   buildReferenceList,
   getDomainFromUrl,
+  mergeReferenceSources,
   normalizeReferenceUrl,
   resolveReferenceHighlightKey,
 } from './referenceSources.ts'
+
+test('mergeReferenceSources combines message and tool references', () => {
+  const merged = mergeReferenceSources(
+    [
+      {
+        id: 'chunk-a',
+        knowledge_id: 'doc-1',
+        knowledge_title: 'Policy',
+        content: 'first retrieval',
+      },
+    ],
+    [
+      {
+        id: 'chunk-b',
+        knowledge_id: 'doc-1',
+        knowledge_title: 'Policy',
+        content: 'second retrieval',
+      },
+    ],
+  )
+
+  assert.deepEqual(merged.map((item) => item.id), ['chunk-a', 'chunk-b'])
+})
+
+test('mergeReferenceSources deduplicates chunk ids and normalized web urls', () => {
+  const merged = mergeReferenceSources(
+    [
+      { id: 'chunk-a', knowledge_id: 'doc-1' },
+      {
+        id: 'https://example.com/article#section',
+        chunk_type: 'web_search',
+        metadata: { url: 'https://example.com/article#section' },
+      },
+    ],
+    [
+      { id: 'chunk-a', knowledge_id: 'doc-1', content: 'duplicate chunk' },
+      { id: 'chunk-b', knowledge_id: 'doc-1', content: 'new chunk' },
+      {
+        id: 'https://example.com/article/',
+        chunk_type: 'web_search',
+        metadata: { url: 'https://example.com/article/' },
+      },
+    ],
+  )
+
+  assert.deepEqual(merged.map((item) => item.id), [
+    'chunk-a',
+    'https://example.com/article#section',
+    'chunk-b',
+  ])
+})
+
+test('mergeReferenceSources accepts raw chunk_id fields', () => {
+  const merged = mergeReferenceSources(
+    [{ chunk_id: 'chunk-a', knowledge_id: 'doc-1' }],
+    [
+      { chunk_id: 'chunk-a', knowledge_id: 'doc-1' },
+      { chunk_id: 'chunk-b', knowledge_id: 'doc-1' },
+    ],
+  )
+
+  assert.deepEqual(merged.map((item) => item.chunk_id), ['chunk-a', 'chunk-b'])
+})
 
 test('buildReferenceList separates web and document references', () => {
   const items = buildReferenceList([

--- a/frontend/src/utils/referenceSources.ts
+++ b/frontend/src/utils/referenceSources.ts
@@ -2,6 +2,7 @@ export type ReferenceItemKind = 'web' | 'document' | 'tool'
 
 export type KnowledgeReferenceLike = {
   id?: string
+  chunk_id?: string
   chunk_ids?: string[]
   knowledge_id?: string
   knowledge_title?: string
@@ -57,6 +58,50 @@ export function getWebSearchUrl(item: KnowledgeReferenceLike): string {
     return item.id
   }
   return ''
+}
+
+/**
+ * Merge references collected at message level with references replayed from
+ * Agent tool calls. Message references are kept first so their richer
+ * persisted metadata wins when the same source appears in both streams.
+ */
+export function mergeReferenceSources(
+  ...sources: Array<KnowledgeReferenceLike[] | null | undefined>
+): KnowledgeReferenceLike[] {
+  const merged: KnowledgeReferenceLike[] = []
+  const seenChunkIds = new Set<string>()
+  const seenUrls = new Set<string>()
+
+  for (const source of sources) {
+    if (!Array.isArray(source)) continue
+
+    for (const item of source) {
+      if (!item || typeof item !== 'object') continue
+
+      const url = getWebSearchUrl(item)
+      if (url) {
+        const key = normalizeReferenceUrl(url)
+        if (key && seenUrls.has(key)) continue
+        if (key) seenUrls.add(key)
+        merged.push(item)
+        continue
+      }
+
+      const chunkIds = Array.from(new Set([
+        ...(item.chunk_id ? [item.chunk_id] : []),
+        ...(Array.isArray(item.chunk_ids) ? item.chunk_ids : []),
+        ...(item.id ? [item.id] : []),
+      ].map((value) => String(value).trim()).filter(Boolean)))
+
+      if (chunkIds.length && chunkIds.every((chunkId) => seenChunkIds.has(chunkId))) {
+        continue
+      }
+      for (const chunkId of chunkIds) seenChunkIds.add(chunkId)
+      merged.push(item)
+    }
+  }
+
+  return merged
 }
 
 export function getDomainFromUrl(url: string): string {
@@ -159,7 +204,7 @@ function buildWebItem(item: KnowledgeReferenceLike, index: number): ReferenceLis
 }
 
 function buildDocumentItem(item: KnowledgeReferenceLike, index: number): ReferenceListItem {
-  const chunkId = item.id || `${item.knowledge_id || 'doc'}-${item.chunk_index ?? index}`
+  const chunkId = item.chunk_id || item.id || `${item.knowledge_id || 'doc'}-${item.chunk_index ?? index}`
   const title = item.knowledge_title || item.knowledge_filename || item.knowledge_id || 'Document'
   const documentKey =
     item.knowledge_id ||
@@ -209,7 +254,11 @@ function mergeDocumentReferences(refs: KnowledgeReferenceLike[]): KnowledgeRefer
   refs.forEach((item, index) => {
     const key = getDocumentGroupKey(item, index)
     const content = String(item.content || '').trim()
-    const chunkIds = Array.from(new Set([...(item.chunk_ids || []), ...(item.id ? [item.id] : [])]))
+    const chunkIds = Array.from(new Set([
+      ...(item.chunk_id ? [item.chunk_id] : []),
+      ...(item.chunk_ids || []),
+      ...(item.id ? [item.id] : []),
+    ]))
     const existing = groups.get(key)
 
     if (!existing) {

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -497,7 +497,11 @@ import { getKnowledgeChunksSummaryHtml } from '@/utils/knowledgeChunksDisplay';
 import { getAttachmentParsingSummaryHtml } from '@/utils/attachmentParsingDisplay';
 import { useChatCitationPopover } from '@/composables/useChatCitationPopover';
 import { useChatReferencesDrawer } from '@/composables/useChatReferencesDrawer';
-import type { KnowledgeReferenceLike, ReferenceHighlightTarget } from '@/utils/referenceSources';
+import {
+  mergeReferenceSources,
+  type KnowledgeReferenceLike,
+  type ReferenceHighlightTarget,
+} from '@/utils/referenceSources';
 import { resolveCitationChunkId } from '@/utils/citationMarkdown';
 import { getWikiPage, type WikiPage } from '@/api/wiki';
 import { MessagePlugin } from 'tdesign-vue-next';
@@ -833,7 +837,7 @@ const {
   cancelClose: cancelCitationClose,
   scheduleClose: scheduleCitationClose,
 } = useChatCitationPopover(rootElement, {
-  getKnowledgeReferences: () => props.session?.knowledge_references,
+  getKnowledgeReferences: () => getReferencesForDrawer(),
   embedChannelId: () => (props.embeddedMode ? props.embedChannelId : undefined),
   embedToken: () => (props.embeddedMode ? props.embedToken : undefined),
   sessionId: () => props.sessionId,
@@ -847,16 +851,10 @@ const getReferencesForDrawer = (
   const messageReferences = refsOverride?.length
     ? refsOverride
     : props.session?.knowledge_references;
-  if (messageReferences?.length) return messageReferences;
-
-  // Agent answers can already contain citation tags before the aggregated
-  // knowledge_references event is emitted (and some restored conversations do
-  // not have that aggregate at all). The completed retrieval tool events still
-  // carry the same source data, so use them to keep citation clicks in the
-  // references drawer instead of falling through to KB-page navigation.
-  return (props.session?.agentEventStream || []).flatMap((event) =>
+  const toolReferences = (props.session?.agentEventStream || []).flatMap((event) =>
     getToolReferenceItems(event),
   );
+  return mergeReferenceSources(messageReferences, toolReferences);
 };
 
 const openReferencesDrawer = (

--- a/frontend/src/views/chat/components/chatLinksNewTab.test.mjs
+++ b/frontend/src/views/chat/components/chatLinksNewTab.test.mjs
@@ -41,11 +41,15 @@ test('agent citations recover drawer references from retrieval tool events', () 
   )
   assert.match(
     agentStream,
+    /return mergeReferenceSources\(messageReferences, toolReferences\)/,
+  )
+  assert.match(
+    agentStream,
     /chunk_ids: group\.chunks\.map\(\(chunk\) => chunk\.chunk_id\)\.filter\(Boolean\)/,
   )
   assert.equal(
     agentStream.match(/knowledgeReferences: getReferencesForDrawer\(\)|getReferencesForDrawer\(\),/g)?.length,
-    3,
+    4,
   )
   assert.match(
     referenceDrawer,

--- a/internal/application/service/chat_pipeline/rerank.go
+++ b/internal/application/service/chat_pipeline/rerank.go
@@ -192,7 +192,7 @@ func (p *PluginRerank) OnEvent(ctx context.Context,
 
 	// Process reranked results
 	for _, rr := range rerankResp {
-		if rr.Index >= len(candidatesToRerank) {
+		if !validRerankIndex(rr.Index, len(candidatesToRerank)) {
 			continue
 		}
 		sr := candidatesToRerank[rr.Index]
@@ -281,7 +281,7 @@ func buildRerankSpanOutput(
 			"index":       rr.Index,
 			"model_score": rr.RelevanceScore,
 		}
-		if rr.Index >= 0 && rr.Index < len(candidates) {
+		if validRerankIndex(rr.Index, len(candidates)) {
 			row["chunk_id"] = candidates[rr.Index].ID
 			row["knowledge_id"] = candidates[rr.Index].KnowledgeID
 			row["knowledge_title"] = candidates[rr.Index].KnowledgeTitle
@@ -357,7 +357,7 @@ func (p *PluginRerank) rerank(ctx context.Context,
 	})
 	logged := min(5, len(rerankResp))
 	for i := range logged {
-		if rerankResp[i].Index < len(candidates) {
+		if validRerankIndex(rerankResp[i].Index, len(candidates)) {
 			pipelineInfo(ctx, "Rerank", "top_score", map[string]interface{}{
 				"rank":        i + 1,
 				"score":       rerankResp[i].RelevanceScore,
@@ -379,7 +379,7 @@ func (p *PluginRerank) rerank(ctx context.Context,
 	// Filter results based on threshold
 	rankFilter := []rerank.RankResult{}
 	for _, result := range rerankResp {
-		if result.Index >= len(candidates) {
+		if !validRerankIndex(result.Index, len(candidates)) {
 			continue
 		}
 		if result.RelevanceScore >= chatManage.RerankThreshold {
@@ -392,12 +392,19 @@ func (p *PluginRerank) rerank(ctx context.Context,
 	// when the best score is too low — forcing irrelevant results is worse than
 	// returning nothing and letting the caller handle the empty-result case.
 	fallbackMinScore := rerankFallbackMinScore(chatManage.SearchTargets)
-	if len(rankFilter) == 0 && len(rerankResp) > 0 && rerankResp[0].RelevanceScore >= fallbackMinScore {
-		rankFilter = rerankResp[:1]
+	var fallbackResult *rerank.RankResult
+	for i := range rerankResp {
+		if validRerankIndex(rerankResp[i].Index, len(candidates)) {
+			fallbackResult = &rerankResp[i]
+			break
+		}
+	}
+	if len(rankFilter) == 0 && fallbackResult != nil && fallbackResult.RelevanceScore >= fallbackMinScore {
+		rankFilter = []rerank.RankResult{*fallbackResult}
 		pipelineInfo(ctx, "Rerank", "fallback_top1", map[string]interface{}{
 			"reason":    "all_below_threshold",
 			"threshold": chatManage.RerankThreshold,
-			"top_score": rerankResp[0].RelevanceScore,
+			"top_score": fallbackResult.RelevanceScore,
 		})
 	} else if len(rankFilter) == 0 {
 		pipelineInfo(ctx, "Rerank", "fallback_skip", map[string]interface{}{
@@ -408,6 +415,10 @@ func (p *PluginRerank) rerank(ctx context.Context,
 	}
 
 	return rankFilter, nil
+}
+
+func validRerankIndex(index, candidateCount int) bool {
+	return index >= 0 && index < candidateCount
 }
 
 func rerankFallbackMinScore(searchTargets types.SearchTargets) float64 {

--- a/internal/application/service/chat_pipeline/rerank_index_test.go
+++ b/internal/application/service/chat_pipeline/rerank_index_test.go
@@ -1,0 +1,64 @@
+package chatpipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/rerank"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+type fixedReranker struct {
+	results []rerank.RankResult
+}
+
+func (f fixedReranker) Rerank(context.Context, string, []string) ([]rerank.RankResult, error) {
+	return f.results, nil
+}
+
+func (f fixedReranker) GetModelName() string { return "fixed" }
+
+func (f fixedReranker) GetModelID() string { return "fixed" }
+
+func TestPluginRerankRerankSkipsNegativeIndexes(t *testing.T) {
+	plugin := &PluginRerank{}
+	chatManage := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{RerankThreshold: 0.1},
+	}
+	candidates := []*types.SearchResult{{ID: "valid", Content: "candidate"}}
+	model := fixedReranker{results: []rerank.RankResult{
+		{Index: -1, RelevanceScore: 0.99},
+		{Index: 0, RelevanceScore: 0.8},
+	}}
+
+	got, err := plugin.rerank(context.Background(), chatManage, model, "query", []string{"candidate"}, candidates)
+	if err != nil {
+		t.Fatalf("rerank returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("rerank returned %d results, want 1", len(got))
+	}
+	if got[0].Index != 0 {
+		t.Fatalf("rerank returned index %d, want 0", got[0].Index)
+	}
+}
+
+func TestPluginRerankRerankDoesNotFallbackToInvalidIndex(t *testing.T) {
+	plugin := &PluginRerank{}
+	chatManage := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{RerankThreshold: 0.95},
+	}
+	candidates := []*types.SearchResult{{ID: "valid", Content: "candidate"}}
+	model := fixedReranker{results: []rerank.RankResult{
+		{Index: -1, RelevanceScore: 0.99},
+		{Index: 0, RelevanceScore: 0.1},
+	}}
+
+	got, err := plugin.rerank(context.Background(), chatManage, model, "query", []string{"candidate"}, candidates)
+	if err != nil {
+		t.Fatalf("rerank returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("rerank returned %d results, want 0", len(got))
+	}
+}

--- a/internal/application/service/message.go
+++ b/internal/application/service/message.go
@@ -663,7 +663,7 @@ func (s *messageService) rerankResults(ctx context.Context, rc *types.RetrievalC
 
 	var reranked []*types.SearchResult
 	for _, rr := range rankResults {
-		if rr.Index >= len(results) {
+		if rr.Index < 0 || rr.Index >= len(results) {
 			continue
 		}
 		if rr.RelevanceScore < threshold {

--- a/internal/application/service/message_rerank_test.go
+++ b/internal/application/service/message_rerank_test.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/rerank"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type fixedMessageRerankModelService struct {
+	interfaces.ModelService
+	reranker rerank.Reranker
+}
+
+func (s fixedMessageRerankModelService) GetRerankModel(context.Context, string) (rerank.Reranker, error) {
+	return s.reranker, nil
+}
+
+type fixedMessageReranker struct {
+	results []rerank.RankResult
+}
+
+func (f fixedMessageReranker) Rerank(context.Context, string, []string) ([]rerank.RankResult, error) {
+	return f.results, nil
+}
+
+func (f fixedMessageReranker) GetModelName() string { return "fixed" }
+
+func (f fixedMessageReranker) GetModelID() string { return "fixed" }
+
+func TestMessageServiceRerankResultsSkipsNegativeIndexes(t *testing.T) {
+	service := &messageService{
+		modelService: fixedMessageRerankModelService{reranker: fixedMessageReranker{
+			results: []rerank.RankResult{
+				{Index: -1, RelevanceScore: 0.99},
+				{Index: 0, RelevanceScore: 0.8},
+			},
+		}},
+	}
+	config := &types.RetrievalConfig{
+		RerankModelID:   "model-1",
+		RerankThreshold: 0.1,
+		RerankTopK:      2,
+	}
+
+	got := service.rerankResults(context.Background(), config, "query", []*types.SearchResult{{ID: "valid", Content: "candidate"}})
+	if len(got) != 1 {
+		t.Fatalf("rerank returned %d results, want 1", len(got))
+	}
+	if got[0].ID != "valid" {
+		t.Fatalf("rerank returned result ID %q, want %q", got[0].ID, "valid")
+	}
+}

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -569,6 +569,26 @@ type sseStreamContext struct {
 	assistantMessage *types.Message
 }
 
+func emitQAErrorEvent(ctx context.Context, eventBus *event.EventBus, sessionID, stage string, serviceErr error) {
+	if serviceErr == nil {
+		return
+	}
+	if err := eventBus.Emit(ctx, event.Event{
+		Type:      event.EventError,
+		SessionID: sessionID,
+		Data: event.ErrorData{
+			Error:     serviceErr.Error(),
+			Stage:     stage,
+			SessionID: sessionID,
+		},
+	}); err != nil {
+		logger.ErrorWithFields(ctx, err, map[string]interface{}{
+			"session_id": sessionID,
+			"stage":      stage,
+		})
+	}
+}
+
 // setupSSEStream sets up the SSE streaming context
 func (h *Handler) setupSSEStream(reqCtx *qaRequestContext, generateTitle bool) *sseStreamContext {
 	// Set SSE headers
@@ -938,9 +958,11 @@ func (h *Handler) executeQA(reqCtx *qaRequestContext, mode qaMode, generateTitle
 				if mode == qaModeAgent {
 					stageName = "Agent QA"
 				}
+				panicErr := fmt.Errorf("%s service panicked: %v", stageName, r)
 				logger.ErrorWithFields(streamCtx.asyncCtx,
-					errors.NewInternalServerError(fmt.Sprintf("%s service panicked: %v\n%s", stageName, r, string(buf))),
+					errors.NewInternalServerError(fmt.Sprintf("%s\n%s", panicErr.Error(), string(buf))),
 					map[string]interface{}{"session_id": sessionID})
+				emitQAErrorEvent(streamCtx.asyncCtx, streamCtx.eventBus, sessionID, stageName, panicErr)
 			}
 			// Agent mode: complete the assistant message in defer (normal mode does it via event handler)
 			if mode == qaModeAgent {
@@ -987,15 +1009,7 @@ func (h *Handler) executeQA(reqCtx *qaRequestContext, mode qaMode, generateTitle
 				logger.Infof(streamCtx.asyncCtx, "QA cancelled by user stop for session: %s", sessionID)
 			} else {
 				logger.ErrorWithFields(streamCtx.asyncCtx, serviceErr, nil)
-				streamCtx.eventBus.Emit(streamCtx.asyncCtx, event.Event{
-					Type:      event.EventError,
-					SessionID: sessionID,
-					Data: event.ErrorData{
-						Error:     serviceErr.Error(),
-						Stage:     stageName,
-						SessionID: sessionID,
-					},
-				})
+				emitQAErrorEvent(streamCtx.asyncCtx, streamCtx.eventBus, sessionID, stageName, serviceErr)
 			}
 		}
 	}()

--- a/internal/handler/session/qa_error_test.go
+++ b/internal/handler/session/qa_error_test.go
@@ -1,0 +1,70 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/event"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type recordingQAStreamManager struct {
+	interfaces.StreamManager
+	events []interfaces.StreamEvent
+}
+
+func (m *recordingQAStreamManager) AppendEvent(
+	_ context.Context, _ string, _ string, streamEvent interfaces.StreamEvent,
+) error {
+	m.events = append(m.events, streamEvent)
+	return nil
+}
+
+func TestEmitQAErrorEvent(t *testing.T) {
+	bus := event.NewEventBus()
+	streamManager := &recordingQAStreamManager{}
+	streamHandler := NewAgentStreamHandler(
+		context.Background(), "session-1", "message-1", "request-1", time.Now(),
+		&types.Message{ID: "message-1"}, streamManager, bus,
+	)
+	streamHandler.Subscribe()
+	received := make(chan event.ErrorData, 1)
+	bus.On(event.EventError, func(_ context.Context, evt event.Event) error {
+		data, ok := evt.Data.(event.ErrorData)
+		if !ok {
+			t.Fatalf("event data type = %T, want event.ErrorData", evt.Data)
+		}
+		received <- data
+		return nil
+	})
+
+	emitQAErrorEvent(context.Background(), bus, "session-1", "Agent QA", errors.New("service panicked"))
+
+	select {
+	case data := <-received:
+		if data.Error != "service panicked" {
+			t.Fatalf("error = %q, want %q", data.Error, "service panicked")
+		}
+		if data.Stage != "Agent QA" {
+			t.Fatalf("stage = %q, want %q", data.Stage, "Agent QA")
+		}
+		if data.SessionID != "session-1" {
+			t.Fatalf("session ID = %q, want %q", data.SessionID, "session-1")
+		}
+	default:
+		t.Fatal("expected EventError to be emitted")
+	}
+	if len(streamManager.events) != 1 {
+		t.Fatalf("stream event count = %d, want 1", len(streamManager.events))
+	}
+	streamEvent := streamManager.events[0]
+	if streamEvent.Type != types.ResponseTypeError {
+		t.Fatalf("stream event type = %q, want %q", streamEvent.Type, types.ResponseTypeError)
+	}
+	if !streamEvent.Done {
+		t.Fatal("error stream event must terminate the SSE response")
+	}
+}

--- a/internal/handler/session/resource_urls_test.go
+++ b/internal/handler/session/resource_urls_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -238,6 +239,30 @@ func TestHandleAgentEventsForSSE_FlushesHeldContentOnStop(t *testing.T) {
 		indexOf(body, `"response_type":"stop"`),
 		"held content must precede the stop notification",
 	)
+}
+
+func TestHandleAgentEventsForSSE_StopsOnTerminalError(t *testing.T) {
+	h := &Handler{streamManager: &stubStreamManager{events: []interfaces.StreamEvent{
+		{ID: "err-1", Type: types.ResponseTypeError, Content: "upstream failed", Done: true},
+	}}}
+	c, _ := newTestGinContext(t, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.Request = c.Request.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		h.handleAgentEventsForSSE(ctx, c, "sess1", "msg1", "req-1", nil, false, publicStreamRewriter())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		cancel()
+		<-done
+		t.Fatal("terminal error did not stop SSE streaming")
+	}
 }
 
 func TestHoldbackKeyRoundTrip(t *testing.T) {

--- a/internal/handler/session/stream.go
+++ b/internal/handler/session/stream.go
@@ -139,9 +139,14 @@ func (h *Handler) ContinueStream(c *gin.Context) {
 
 	// Check if stream is already completed
 	streamCompleted := false
+	streamErrored := false
 	for _, evt := range events {
 		if evt.Type == "complete" {
 			streamCompleted = true
+			break
+		}
+		if evt.Type == types.ResponseTypeError && evt.Done {
+			streamErrored = true
 			break
 		}
 	}
@@ -152,7 +157,11 @@ func (h *Handler) ContinueStream(c *gin.Context) {
 		emitStreamEvent(ctx, c, evt, message.RequestID, resourceRewriter)
 	}
 
-	// If stream is already completed, send final event and return
+	// If stream is already terminal, return after replaying the terminal event.
+	if streamErrored {
+		logger.Infof(ctx, "Stream already ended with terminal error, session ID: %s, message ID: %s", sessionID, messageID)
+		return
+	}
 	if streamCompleted {
 		logger.Infof(ctx, "Stream already completed, session ID: %s, message ID: %s", sessionID, messageID)
 		sendCompletionEvent(c, message.RequestID)
@@ -181,10 +190,14 @@ func (h *Handler) ContinueStream(c *gin.Context) {
 
 			// Send new events
 			streamCompletedNow := false
+			streamErroredNow := false
 			for _, evt := range newEvents {
 				// Check for completion event
 				if evt.Type == "complete" {
 					streamCompletedNow = true
+				}
+				if evt.Type == types.ResponseTypeError && evt.Done {
+					streamErroredNow = true
 				}
 
 				emitStreamEvent(ctx, c, evt, message.RequestID, resourceRewriter)
@@ -192,6 +205,12 @@ func (h *Handler) ContinueStream(c *gin.Context) {
 
 			// Update offset
 			currentOffset = newOffset
+
+			// A terminal error already carries Done=true and is the final event.
+			if streamErroredNow {
+				logger.Infof(ctx, "Stream ended with terminal error, session ID: %s, message ID: %s", sessionID, messageID)
+				return
+			}
 
 			// If stream completed, send final event and exit
 			if streamCompletedNow {
@@ -364,6 +383,7 @@ func (h *Handler) handleAgentEventsForSSE(
 
 			// Send any new events
 			streamCompleted := false
+			streamErrored := false
 			titleReceived := false
 			for _, evt := range events {
 				// Check for stop event
@@ -404,6 +424,9 @@ func (h *Handler) handleAgentEventsForSSE(
 				if evt.Type == "complete" {
 					streamCompleted = true
 				}
+				if evt.Type == types.ResponseTypeError && evt.Done {
+					streamErrored = true
+				}
 
 				// Check for title event
 				if evt.Type == types.ResponseTypeSessionTitle {
@@ -424,6 +447,14 @@ func (h *Handler) handleAgentEventsForSSE(
 
 			// Update offset
 			lastOffset = newOffset
+
+			// A terminal error is the final stream event. The error payload
+			// already carries Done=true, so close the SSE loop without adding a
+			// misleading completion event.
+			if streamErrored {
+				log.Infof("Stream ended with terminal error for session=%s, message=%s", sessionID, assistantMessageID)
+				return
+			}
 
 			// Check if stream is completed - wait for title event only if needed and not already received
 			if streamCompleted {

--- a/internal/models/rerank/nvidia_reranker.go
+++ b/internal/models/rerank/nvidia_reranker.go
@@ -125,13 +125,16 @@ func (r *NvidiaReranker) Rerank(ctx context.Context, query string, documents []s
 	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, fmt.Errorf("unmarshal response: %w", err)
 	}
-	ret := make([]RankResult, len(response.Results))
-	for i, result := range response.Results {
-		ret[i] = RankResult{
+	ret := make([]RankResult, 0, len(response.Results))
+	for _, result := range response.Results {
+		if result.Index < 0 || result.Index >= len(documents) {
+			continue
+		}
+		ret = append(ret, RankResult{
 			Index:          result.Index,
 			Document:       DocumentInfo{Text: documents[result.Index]},
 			RelevanceScore: normalizeNvidiaLogit(result.Logit),
-		}
+		})
 	}
 	return ret, nil
 }

--- a/internal/models/rerank/nvidia_reranker_test.go
+++ b/internal/models/rerank/nvidia_reranker_test.go
@@ -47,3 +47,30 @@ func TestNvidiaRerankerNormalizesLogitsToProbabilities(t *testing.T) {
 	assert.Greater(t, results[0].RelevanceScore, results[1].RelevanceScore)
 	assert.Greater(t, results[1].RelevanceScore, results[2].RelevanceScore)
 }
+
+func TestNvidiaRerankerSkipsInvalidIndexes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"model": "nvidia-rerank-model",
+			"rankings": [
+				{"index": -1, "logit": 23.0},
+				{"index": 0, "logit": 0.0},
+				{"index": 1, "logit": -23.0}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	reranker := &NvidiaReranker{
+		modelName: "nvidia-rerank-model",
+		apiKey:    "nvapi-test",
+		baseURL:   server.URL,
+		client:    server.Client(),
+	}
+
+	results, err := reranker.Rerank(t.Context(), "query", []string{"only document"})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, 0, results[0].Index)
+}

--- a/internal/models/rerank/reranker_test.go
+++ b/internal/models/rerank/reranker_test.go
@@ -78,6 +78,14 @@ func TestRankResultUnmarshalJSON(t *testing.T) {
 			expectedScore: 0.0,
 			expectError:   false,
 		},
+		{
+			name:          "negative index is preserved for pipeline validation",
+			input:         `{"index": -1, "document": "invalid provider result", "relevance_score": 0.99}`,
+			expectedText:  "invalid provider result",
+			expectedIndex: -1,
+			expectedScore: 0.99,
+			expectError:   false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION


## 中文

### 问题
上游 rerank 可返回负数 `index`。部分消费路径仅校验上界，访问候选切片时会触发 panic。QA goroutine 的 recover 之前只记录日志，未发送终态 SSE 事件，客户端会一直处于生成状态。

### 修复
- 在 rerank 消费路径统一过滤 `0 <= index && index < len(candidates)`。
- NVIDIA reranker 跳过无效上游 index，避免 provider 内部切片 panic。
- QA panic recover 发送 `error` SSE，且 `Done: true`。
- 首次 SSE 和续流在收到终态 error 后结束轮询并关闭响应。

### 复现步骤
1. 配置或 mock 一个 rerank 上游，使其返回 `{"index": -1, "relevance_score": 0.99}`。
2. 发起知识问答、消息检索或 Agent 检索请求。
3. 修复前：候选结果访问 `[-1]` 时 panic。
4. 使 KnowledgeQA 或 AgentQA 在 SSE 初始化后 panic。
5. 修复前：服务端仅记录 panic，客户端没有终态事件并持续转圈。
6. 修复后：无效 rerank 结果被忽略；panic 会产生 `response_type: "error"` 且 `done: true`，SSE 随后结束。

### 验证
- [x] `go test ./internal/models/rerank -count=1`
- [x] `go test ./internal/application/service/chat_pipeline -count=1`
- [x] `go test ./internal/handler/session -count=1`
- [x] `go test ./internal/application/service -run 'TestMessageServiceRerankResultsSkipsNegativeIndexes' -count=1`

## English

### Problem
An upstream reranker can return a negative `index`. Several consumers previously checked only the upper bound, so indexing candidates could panic. The QA goroutine recovery path only logged the panic and emitted no terminal SSE event, leaving clients in a loading state.

### Fix
- Consistently filter rerank results with `0 <= index && index < len(candidates)`.
- Skip invalid upstream indexes in the NVIDIA reranker to prevent provider-side slice panics.
- Emit a terminal `error` SSE event with `Done: true` from the QA panic recovery path.
- Stop both initial and resumed SSE polling after a terminal error.

### Reproduction Steps
1. Configure or mock a rerank upstream response containing `{"index": -1, "relevance_score": 0.99}`.
2. Run a knowledge QA, message search, or Agent retrieval request.
3. Before this fix, accessing candidate `[-1]` panics.
4. Trigger a KnowledgeQA or AgentQA panic after SSE initialization.
5. Before this fix, the server only logs the panic and the client keeps loading.
6. After this fix, invalid rerank entries are ignored; a panic emits `response_type: "error"` with `done: true`, then the SSE stream ends.
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
