### PR TITLE
fix: remove SYSTEM_AES_KEY env override to prevent empty key in container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -281,7 +281,7 @@ services:
       # 需重新填写）。生产环境必须显式设置且妥善保管，丢失则所有加密数据不可恢复。
       # （TENANT_AES_KEY / CRYPTO_MASTER_KEY / CRYPTO_SALT 已废弃：v0.4.0 起加密统一
       #   改用 SYSTEM_AES_KEY，Go 主应用不再读取这三个变量。）
-      - SYSTEM_AES_KEY=${SYSTEM_AES_KEY:-}
+      # SYSTEM_AES_KEY 由 env_file (.env) 提供，不在此处覆盖以避免空值覆盖。
       - SSRF_WHITELIST=${SSRF_WHITELIST:-}
       # 保留原始 URL 的图片域名白名单（逗号分隔，不替换为 provider://）
       - IMAGE_HOST_KEEP_URL=${IMAGE_HOST_KEEP_URL:-}

--- a/internal/utils/crypto.go
+++ b/internal/utils/crypto.go
@@ -25,9 +25,9 @@ func GetAESKey() []byte {
 }
 
 // EncryptAESGCM encrypts plaintext with AES-256-GCM.
-// Returns the original string if empty, already encrypted, or key is nil.
+// Returns the original string if empty, already encrypted, or key is empty.
 func EncryptAESGCM(plaintext string, key []byte) (string, error) {
-	if plaintext == "" || key == nil {
+	if plaintext == "" || len(key) == 0 {
 		return plaintext, nil
 	}
 	if strings.HasPrefix(plaintext, EncPrefix) {
@@ -63,7 +63,7 @@ var ErrEncryptedDataMissingKey = errors.New("encrypted data found but SYSTEM_AES
 // DecryptAESGCM decrypts an AES-256-GCM encrypted string.
 // If the string lacks the enc:v1: prefix, it's treated as legacy plaintext and returned as-is.
 func DecryptAESGCM(encrypted string, key []byte) (string, error) {
-	if encrypted == "" || key == nil {
+	if encrypted == "" || len(key) == 0 {
 		return encrypted, nil
 	}
 	if !strings.HasPrefix(encrypted, EncPrefix) {


### PR DESCRIPTION
## 问题

`docker-compose.yml` 中 `environment` 段的 `SYSTEM_AES_KEY=${SYSTEM_AES_KEY:-}` 在 Docker Compose 解析阶段，如果 shell 中没有 export 该变量，会解析为空字符串。而 `environment` 优先级高于 `env_file`，导致 `.env` 中正确配置的 32 字节密钥被空值覆盖。

这使得容器内的 `SYSTEM_AES_KEY` 实际为空（非 32 字节），`GetAESKey()` 返回 `nil`，加密/解密操作静默跳过，认证相关功能可能因此失败。

## 修改

1. **docker-compose.yml**: 移除 `SYSTEM_AES_KEY` 的 `environment` 覆盖行，该变量由 `env_file: .env` 提供即可
2. **internal/utils/crypto.go**: `EncryptAESGCM` / `DecryptAESGCM` 中将 `key == nil` 改为 `len(key) == 0`，同时防御 `nil` 和空 `[]byte{}` 切片

## 声明

- 本 PR 修复了 `environment` 覆盖 `env_file` 导致密钥为空的问题，这是明确的 bug
- 如果用户部署后仍有密钥相关报错，需进一步排查 `.env` 配置是否正确（`SYSTEM_AES_KEY` 是否为 32 字节）、以及 `docker-compose.yml` 中 `env_file` 路径是否有效

Closes #2554