### PR TITLE
feat(tenant): allow owners to edit storage quota within disk capacity

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -13966,6 +13966,47 @@ const docTemplate = `{
                 }
             }
         },
+        "/tenants/{id}/storage-stats": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "返回当前已用空间、卷剩余空间与可设置的最大配额，供 Owner 编辑配额时约束取值范围",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "空间管理"
+                ],
+                "summary": "获取空间存储配额统计",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "空间ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "存储统计",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "请求参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Tencent_WeKnora_internal_errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
         "/user/favorites": {
             "get": {
                 "description": "Lists this user's starred resources in the current workspace for a given type",
@@ -15276,6 +15317,7 @@ const docTemplate = `{
                 "rbac.invitation_declined",
                 "rbac.invitation_revoked",
                 "rbac.invitation_expired",
+                "tenant.storage_quota_updated",
                 "vector_store.created",
                 "vector_store.updated",
                 "vector_store.deleted",
@@ -15339,6 +15381,7 @@ const docTemplate = `{
                 "AuditActionInvitationDeclined",
                 "AuditActionInvitationRevoked",
                 "AuditActionInvitationExpired",
+                "AuditActionTenantStorageQuotaUpdated",
                 "AuditActionVectorStoreCreated",
                 "AuditActionVectorStoreUpdated",
                 "AuditActionVectorStoreDeleted",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -13959,6 +13959,47 @@
                 }
             }
         },
+        "/tenants/{id}/storage-stats": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "返回当前已用空间、卷剩余空间与可设置的最大配额，供 Owner 编辑配额时约束取值范围",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "空间管理"
+                ],
+                "summary": "获取空间存储配额统计",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "空间ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "存储统计",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "请求参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Tencent_WeKnora_internal_errors.AppError"
+                        }
+                    }
+                }
+            }
+        },
         "/user/favorites": {
             "get": {
                 "description": "Lists this user's starred resources in the current workspace for a given type",
@@ -15269,6 +15310,7 @@
                 "rbac.invitation_declined",
                 "rbac.invitation_revoked",
                 "rbac.invitation_expired",
+                "tenant.storage_quota_updated",
                 "vector_store.created",
                 "vector_store.updated",
                 "vector_store.deleted",
@@ -15332,6 +15374,7 @@
                 "AuditActionInvitationDeclined",
                 "AuditActionInvitationRevoked",
                 "AuditActionInvitationExpired",
+                "AuditActionTenantStorageQuotaUpdated",
                 "AuditActionVectorStoreCreated",
                 "AuditActionVectorStoreUpdated",
                 "AuditActionVectorStoreDeleted",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -284,6 +284,7 @@ definitions:
     - rbac.invitation_declined
     - rbac.invitation_revoked
     - rbac.invitation_expired
+    - tenant.storage_quota_updated
     - vector_store.created
     - vector_store.updated
     - vector_store.deleted
@@ -347,6 +348,7 @@ definitions:
     - AuditActionInvitationDeclined
     - AuditActionInvitationRevoked
     - AuditActionInvitationExpired
+    - AuditActionTenantStorageQuotaUpdated
     - AuditActionVectorStoreCreated
     - AuditActionVectorStoreUpdated
     - AuditActionVectorStoreDeleted
@@ -14613,6 +14615,32 @@ paths:
       summary: 修改空间成员角色
       tags:
       - 空间成员
+  /tenants/{id}/storage-stats:
+    get:
+      description: 返回当前已用空间、卷剩余空间与可设置的最大配额，供 Owner 编辑配额时约束取值范围
+      parameters:
+      - description: 空间ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: 存储统计
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: 请求参数错误
+          schema:
+            $ref: '#/definitions/github_com_Tencent_WeKnora_internal_errors.AppError'
+      security:
+      - Bearer: []
+      summary: 获取空间存储配额统计
+      tags:
+      - 空间管理
   /tenants/all:
     get:
       consumes:

--- a/frontend/src/api/tenant/index.ts
+++ b/frontend/src/api/tenant/index.ts
@@ -242,15 +242,26 @@ export async function deleteTenantAPIKey(
   }
 }
 
+// 磁盘/配额实时数据（GET /tenants/:id/storage-stats，Viewer 权限即可读）。
+// 磁盘探测失败时 disk_free_bytes 缺省且 disk_unavailable=true，前端据此降级提示。
+export interface TenantStorageStats {
+  disk_free_bytes?: number
+  quota_max_bytes: number
+  storage_used_bytes: number
+  disk_unavailable?: boolean
+}
+
 /**
- * 更新空间信息（目前暴露名称、描述两个字段的编辑入口）。
+ * 更新空间信息（目前暴露名称、描述、存储配额三个字段的编辑入口）。
  * 后端 `PUT /tenants/:id` 用指针字段区分"未传"和"显式空串"，未传的列不会
- * 被改动；这里也按需选择性传 `name` / `description`，互不影响。
+ * 被改动；这里也按需选择性传 `name` / `description` / `storage_quota`，互不影响。
+ * `storage_quota` 单位是字节（int64），服务端会做配额校验
+ * （>0、>= 当前已用、<= 磁盘可用 + 已用），前端仅做预校验兜底。
  * 权限：owner（与 router.go 中的 g.Owner() 守卫保持一致）。
  */
 export async function updateTenant(
   tenantId: number,
-  payload: { name?: string; description?: string },
+  payload: { name?: string; description?: string; storage_quota?: number },
 ): Promise<{ success: boolean; data?: TenantInfo; message?: string }> {
   try {
     const response = await put(`/api/v1/tenants/${tenantId}`, payload)
@@ -259,6 +270,24 @@ export async function updateTenant(
     return {
       success: false,
       message: error.message || t('error.tenant.updateFailed'),
+    }
+  }
+}
+
+/**
+ * 获取空间存储实时数据（磁盘剩余、配额上限、当前已用）。
+ * 权限：Viewer 即可。用于配额编辑态的上限提示。
+ */
+export async function getTenantStorageStats(
+  tenantId: string | number,
+): Promise<{ success: boolean; data?: TenantStorageStats; message?: string }> {
+  try {
+    const response = await get(`/api/v1/tenants/${tenantId}/storage-stats`)
+    return response as unknown as { success: boolean; data?: TenantStorageStats; message?: string }
+  } catch (error: any) {
+    return {
+      success: false,
+      message: error.message || t('error.tenant.getStorageStatsFailed'),
     }
   }
 }

--- a/frontend/src/i18n/auditActionLocaleDefaults.ts
+++ b/frontend/src/i18n/auditActionLocaleDefaults.ts
@@ -25,6 +25,7 @@ const TENANT_MEMBER_AUDIT_ACTION_LABELS_EN: Record<string, string> = {
 
 const SYSTEM_GLOBAL_AUDIT_ACTION_LABELS_EN: Record<string, string> = {
   'system.setting_changed': 'System setting changed',
+  'tenant.storage_quota_updated': 'Workspace storage quota updated',
   'system.admin_promoted': 'System admin granted',
   'system.api_key_created': 'Platform API key created',
   'system.api_key_revoked': 'Platform API key revoked',

--- a/frontend/src/i18n/auditActionRegistry.ts
+++ b/frontend/src/i18n/auditActionRegistry.ts
@@ -32,6 +32,7 @@ export const TENANT_MEMBER_AUDIT_ACTIONS = [
 /** Platform control-plane audit events (system settings → audit tab). */
 export const SYSTEM_GLOBAL_AUDIT_ACTIONS = [
   'system.setting_changed',
+  'tenant.storage_quota_updated',
   'system.admin_promoted',
   'system.api_key_created',
   'system.api_key_revoked',

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2821,7 +2821,14 @@ export default {
       usedLabel: 'Used Storage',
       usedDescription: 'Storage space that has been used',
       usageLabel: 'Storage Usage',
-      usageDescription: 'Percentage of storage capacity used'
+      usageDescription: 'Percentage of storage capacity used',
+      editQuota: 'Edit quota',
+      editQuotaPlaceholder: 'Enter quota (GB)',
+      quotaMaxHint: 'Max ≈ {max} (disk free + current usage)',
+      quotaBelowUsedError: 'Quota cannot be below current usage {used}',
+      quotaExceedsDiskError: 'Quota exceeds available disk capacity',
+      quotaUpdateSuccess: 'Storage quota updated',
+      quotaUpdateFailed: 'Failed to update quota'
     },
     leaveDangerZone: {
       title: 'Leave this workspace',
@@ -3352,6 +3359,7 @@ export default {
         },
         action: {
           'system.setting_changed': 'System setting changed',
+          'tenant.storage_quota_updated': 'Workspace storage quota updated',
           'system.admin_promoted': 'System admin granted',
           'system.api_key_created': 'Platform API key created',
           'system.api_key_revoked': 'Platform API key revoked',
@@ -3370,6 +3378,7 @@ export default {
         target: {
           bulkQuota: 'Bulk sync: default storage quota',
           bulkQuotaDiff: 'Applied to {count} workspaces ({gb} GB)',
+          quotaDiff: '{old} → {new}',
           promoteIdempotent: 'Target was already a system admin (idempotent)',
           revokeNoop: 'Target was not a system admin (idempotent)',
           requiredRole: 'Required role: {role}',
@@ -3442,7 +3451,8 @@ export default {
       updateApiPrincipalConfigFailed: 'Failed to update API principal config',
       createApiPrincipalTestTokenFailed: 'Failed to create API test token',
       updateFailed: 'Failed to update workspace information',
-      deleteFailed: 'Failed to delete workspace'
+      deleteFailed: 'Failed to delete workspace',
+      getStorageStatsFailed: 'Failed to fetch storage stats'
     },
     initialization: {
       checkFailed: 'Check failed',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -2463,7 +2463,8 @@ export default {
       updateApiPrincipalConfigFailed: 'API principal config 업데이트 실패',
       createApiPrincipalTestTokenFailed: 'API 테스트 토큰 생성 실패',
       updateFailed: '워크스페이스 정보 업데이트 실패',
-      deleteFailed: 'Failed to delete workspace'
+      deleteFailed: 'Failed to delete workspace',
+      getStorageStatsFailed: '스토리지 통계를 가져오지 못했습니다'
     },
     model: {
       createFailed: '모델 생성 실패',
@@ -2575,6 +2576,7 @@ export default {
         target: {
           bulkQuota: '일괄 동기화: 기본 저장 할당량',
           bulkQuotaDiff: '{count}개 워크스페이스에 적용됨 ({gb} GB)',
+          quotaDiff: '{old} → {new}',
           promoteIdempotent: '이미 시스템 관리자임 (멱등)',
           revokeNoop: '원래 시스템 관리자가 아니었음 (멱등)',
           requiredRole: '필요 역할: {role}',
@@ -2586,6 +2588,7 @@ export default {
         },
         action: {
           'system.setting_changed': '시스템 설정 변경',
+          'tenant.storage_quota_updated': '워크스페이스 스토리지 할당량 변경됨',
           'system.admin_promoted': '시스템 관리자 부여',
           'system.api_key_created': '플랫폼 API 키 생성',
           'system.api_key_revoked': '플랫폼 API 키 폐기',
@@ -3091,7 +3094,14 @@ export default {
       usedLabel: '사용된 저장소',
       usedDescription: '이미 사용된 저장 스페이스',
       usageLabel: '저장소 사용률',
-      usageDescription: '저장 스페이스의 사용 백분율'
+      usageDescription: '저장 스페이스의 사용 백분율',
+      editQuota: '할당량 편집',
+      editQuotaPlaceholder: '할당량 입력 (GB)',
+      quotaMaxHint: '최대 약 {max} (디스크 여유 + 사용량)',
+      quotaBelowUsedError: '할당량은 현재 사용량 {used}보다 낮을 수 없습니다',
+      quotaExceedsDiskError: '할당량이 디스크 가용 용량을 초과합니다',
+      quotaUpdateSuccess: '스토리지 할당량이 업데이트되었습니다',
+      quotaUpdateFailed: '할당량 업데이트 실패'
     },
     details: {
       idLabel: '워크스페이스 ID',

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -2463,7 +2463,8 @@ export default {
       updateApiPrincipalConfigFailed: 'Не удалось обновить конфигурацию API principal',
       createApiPrincipalTestTokenFailed: 'Не удалось создать тестовый API Token',
       updateFailed: 'Не удалось обновить информацию о пространстве',
-      deleteFailed: 'Failed to delete workspace'
+      deleteFailed: 'Failed to delete workspace',
+      getStorageStatsFailed: 'Не удалось получить данные о хранилище'
     },
     model: {
       createFailed: 'Не удалось создать модель',
@@ -2575,6 +2576,7 @@ export default {
         target: {
           bulkQuota: 'Массовая синхронизация: квота хранилища по умолчанию',
           bulkQuotaDiff: 'Применено к {count} пространствам ({gb} ГБ)',
+          quotaDiff: '{old} → {new}',
           promoteIdempotent: 'Уже системный администратор (идемпотентно)',
           revokeNoop: 'И так не был системным администратором (идемпотентно)',
           requiredRole: 'Требуемая роль: {role}',
@@ -2586,6 +2588,7 @@ export default {
         },
         action: {
           'system.setting_changed': 'Изменена системная настройка',
+          'tenant.storage_quota_updated': 'Квота хранилища рабочей области изменена',
           'system.admin_promoted': 'Выдан системный администратор',
           'system.api_key_created': 'Создан платформенный API-ключ',
           'system.api_key_revoked': 'Отозван платформенный API-ключ',
@@ -3091,7 +3094,14 @@ export default {
       usedLabel: 'Использовано хранения',
       usedDescription: 'Объём уже использованного пространства',
       usageLabel: 'Использование хранения',
-      usageDescription: 'Процент использованного пространства'
+      usageDescription: 'Процент использованного пространства',
+      editQuota: 'Изменить квоту',
+      editQuotaPlaceholder: 'Введите квоту (ГБ)',
+      quotaMaxHint: 'Максимум ≈ {max} (свободно на диске + использовано)',
+      quotaBelowUsedError: 'Квота не может быть ниже текущего использования {used}',
+      quotaExceedsDiskError: 'Квота превышает доступную ёмкость диска',
+      quotaUpdateSuccess: 'Квота хранилища обновлена',
+      quotaUpdateFailed: 'Не удалось обновить квоту'
     },
     details: {
       idLabel: 'ID пространства',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2463,7 +2463,8 @@ export default {
       updateApiPrincipalConfigFailed: '更新 API 用户身份配置失败',
       createApiPrincipalTestTokenFailed: '生成 API 测试 Token 失败',
       updateFailed: '更新空间信息失败',
-      deleteFailed: '删除空间失败'
+      deleteFailed: '删除空间失败',
+      getStorageStatsFailed: '获取存储用量数据失败'
     },
     model: {
       createFailed: '创建模型失败',
@@ -2575,6 +2576,7 @@ export default {
         target: {
           bulkQuota: '批量同步：默认存储配额',
           bulkQuotaDiff: '应用到 {count} 个空间（{gb} GB）',
+          quotaDiff: '{old} → {new}',
           promoteIdempotent: '目标已是系统管理员（幂等）',
           revokeNoop: '目标本就不是系统管理员（幂等）',
           requiredRole: '需要角色：{role}',
@@ -2586,6 +2588,7 @@ export default {
         },
         action: {
           'system.setting_changed': '系统设置变更',
+          'tenant.storage_quota_updated': '空间存储配额变更',
           'system.admin_promoted': '授予系统管理员',
           'system.api_key_created': '创建平台 API Key',
           'system.api_key_revoked': '吊销平台 API Key',
@@ -3091,7 +3094,14 @@ export default {
       usedLabel: '已使用存储',
       usedDescription: '已经使用的存储空间',
       usageLabel: '存储使用率',
-      usageDescription: '存储空间的使用百分比'
+      usageDescription: '存储空间的使用百分比',
+      editQuota: '编辑配额',
+      editQuotaPlaceholder: '输入配额（GB）',
+      quotaMaxHint: '上限约 {max}（本机磁盘可用空间 + 已用量）',
+      quotaBelowUsedError: '配额不能低于当前已用量 {used}',
+      quotaExceedsDiskError: '配额超过本机磁盘可用容量',
+      quotaUpdateSuccess: '存储配额已更新',
+      quotaUpdateFailed: '配额更新失败'
     },
     details: {
       idLabel: '空间 ID',

--- a/frontend/src/views/settings/TenantInfo.vue
+++ b/frontend/src/views/settings/TenantInfo.vue
@@ -661,8 +661,11 @@ const onEditQuotaKeydown = (_value: any, ctx: { e: KeyboardEvent }) => {
 
 const saveTenantQuota = async () => {
   if (!tenantInfo.value?.id) return
-  const gb = Number(editQuotaGB.value)
-  if (!editQuotaGB.value.trim() || !Number.isFinite(gb) || gb <= 0) {
+  // t-input type="number" 会把 v-model 转成 number，这里统一归一成字符串再校验，
+  // 否则对 number 调 .trim() 会直接抛 TypeError（在 try 之外，表现为点击没反应）。
+  const raw = String(editQuotaGB.value ?? '').trim()
+  const gb = Number(raw)
+  if (!raw || !Number.isFinite(gb) || gb <= 0) {
     MessagePlugin.warning(t('tenant.storage.quotaUpdateFailed'))
     return
   }

--- a/frontend/src/views/settings/TenantInfo.vue
+++ b/frontend/src/views/settings/TenantInfo.vue
@@ -152,7 +152,35 @@
             <p class="desc">{{ $t('tenant.storage.quotaDescription') }}</p>
           </div>
           <div class="setting-control">
-            <span class="info-value">{{ formatBytes(tenantInfo.storage_quota) }}</span>
+            <!-- 只读态：显示配额 + 编辑按钮（owner 才看得见编辑入口）。
+               与名称/描述同款"原地编辑"模式。 -->
+            <template v-if="!editingQuota">
+              <span class="info-value">{{ formatBytes(tenantInfo.storage_quota) }}</span>
+              <t-button v-if="canEditTenant" theme="default" variant="text" shape="square" size="small"
+                class="edit-btn" :title="$t('tenant.storage.editQuota')"
+                :aria-label="$t('tenant.storage.editQuota')" @click="startEditQuota">
+                <template #icon>
+                  <t-icon name="edit" />
+                </template>
+              </t-button>
+            </template>
+            <!-- 编辑态：GB 数值输入（允许 1 位小数）+ 保存/取消。回车保存，Esc 取消。 -->
+            <div v-else class="inline-edit inline-edit-quota">
+              <div class="inline-edit-quota-field">
+                <t-input v-model="editQuotaGB" type="number"
+                  :placeholder="$t('tenant.storage.editQuotaPlaceholder')" :disabled="savingQuota" autofocus
+                  class="inline-edit-input" @enter="saveTenantQuota" @keydown="onEditQuotaKeydown" />
+                <!-- 上限提示：磁盘探测失败（disk_unavailable）或 stats 拉取失败时降级不显示。 -->
+                <p v-if="quotaMaxHintText" class="quota-max-hint">{{ quotaMaxHintText }}</p>
+              </div>
+              <t-button theme="primary" size="small" :loading="savingQuota" @click="saveTenantQuota">
+                {{ $t('tenant.details.editNameConfirm') }}
+              </t-button>
+              <t-button theme="default" variant="outline" size="small" :disabled="savingQuota"
+                @click="cancelEditQuota">
+                {{ $t('tenant.details.editNameCancel') }}
+              </t-button>
+            </div>
           </div>
         </div>
 
@@ -242,7 +270,12 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { DialogPlugin, MessagePlugin } from 'tdesign-vue-next'
 import { getCurrentUser, type TenantInfo } from '@/api/auth'
-import { deleteTenant as deleteTenantApi, updateTenant as updateTenantApi } from '@/api/tenant'
+import {
+  deleteTenant as deleteTenantApi,
+  getTenantStorageStats,
+  updateTenant as updateTenantApi,
+  type TenantStorageStats,
+} from '@/api/tenant'
 import {
   leaveTenant,
   fetchAllTenantMembers,
@@ -578,6 +611,105 @@ const saveTenantName = async () => {
   }
 }
 
+// 原地编辑存储配额：与名称对称的 editing / editValue / saving 三态。
+// 输入单位是 GB（允许 1 位小数），提交时换算成字节；服务端做最终校验，
+// 前端按 storage-stats 做预校验（即时 toast，不发请求）。
+const editingQuota = ref(false)
+const editQuotaGB = ref('')
+const savingQuota = ref(false)
+const storageStats = ref<TenantStorageStats | null>(null)
+
+// 上限提示：磁盘探测失败（disk_unavailable）或 stats 拉取失败时降级不显示。
+const quotaMaxHintText = computed(() => {
+  const stats = storageStats.value
+  if (!stats || stats.disk_unavailable || !stats.quota_max_bytes) return ''
+  return t('tenant.storage.quotaMaxHint', { max: formatBytes(stats.quota_max_bytes) })
+})
+
+const startEditQuota = () => {
+  const quota = tenantInfo.value?.storage_quota
+  if (quota === undefined) return
+  editQuotaGB.value = (quota / 1024 ** 3).toFixed(1)
+  editingQuota.value = true
+  // 进入编辑态时拉一次实时数据用于上限提示；失败只记 console，不阻断编辑。
+  storageStats.value = null
+  void loadStorageStats()
+}
+
+const loadStorageStats = async () => {
+  if (!tenantInfo.value?.id) return
+  const resp = await getTenantStorageStats(Number(tenantInfo.value.id))
+  if (resp.success && resp.data) {
+    storageStats.value = resp.data
+  } else {
+    console.warn('[TenantInfo] failed to load storage stats:', resp.message)
+  }
+}
+
+const cancelEditQuota = () => {
+  if (savingQuota.value) return
+  editingQuota.value = false
+  editQuotaGB.value = ''
+}
+
+// t-input 自身不冒泡 esc，这里手动处理（与 enter 的体验对称）。
+const onEditQuotaKeydown = (_value: any, ctx: { e: KeyboardEvent }) => {
+  if (ctx?.e?.key === 'Escape') {
+    cancelEditQuota()
+  }
+}
+
+const saveTenantQuota = async () => {
+  if (!tenantInfo.value?.id) return
+  const gb = Number(editQuotaGB.value)
+  if (!editQuotaGB.value.trim() || !Number.isFinite(gb) || gb <= 0) {
+    MessagePlugin.warning(t('tenant.storage.quotaUpdateFailed'))
+    return
+  }
+  const bytes = Math.round(gb * 1024 ** 3)
+  // 预校验下限：已用量优先取实时 stats，拉不到就退回 tenantInfo 里的快照值。
+  const storageUsed = storageStats.value?.storage_used_bytes ?? tenantInfo.value.storage_used ?? 0
+  if (bytes < storageUsed) {
+    MessagePlugin.error(t('tenant.storage.quotaBelowUsedError', { used: formatBytes(storageUsed) }))
+    return
+  }
+  const stats = storageStats.value
+  if (stats && !stats.disk_unavailable && stats.quota_max_bytes && bytes > stats.quota_max_bytes) {
+    MessagePlugin.error(t('tenant.storage.quotaExceedsDiskError'))
+    return
+  }
+  if (bytes === tenantInfo.value.storage_quota) {
+    editingQuota.value = false
+    return
+  }
+
+  try {
+    savingQuota.value = true
+    const resp = await updateTenantApi(Number(tenantInfo.value.id), { storage_quota: bytes })
+    if (resp.success) {
+      // 本地立即回显，避免等 /auth/me 往返；storage_quota 只影响本页展示，
+      // 无需同步 authStore。只取响应里的配额字段合并：本页 tenantInfo 的类型
+      // 来自 /auth/me（id 为 string），与租户接口的 TenantInfo（id 为 number）
+      // 不同构，不能整体铺开。
+      if (tenantInfo.value) {
+        tenantInfo.value = {
+          ...tenantInfo.value,
+          storage_quota: resp.data?.storage_quota ?? bytes,
+          storage_used: resp.data?.storage_used ?? tenantInfo.value.storage_used,
+        }
+      }
+      MessagePlugin.success(t('tenant.storage.quotaUpdateSuccess'))
+      editingQuota.value = false
+    } else {
+      MessagePlugin.error(resp.message || t('tenant.storage.quotaUpdateFailed'))
+    }
+  } catch (err: any) {
+    MessagePlugin.error(err?.message || t('tenant.storage.quotaUpdateFailed'))
+  } finally {
+    savingQuota.value = false
+  }
+}
+
 // Methods
 const loadInfo = async () => {
   try {
@@ -818,6 +950,31 @@ onMounted(() => {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
+}
+
+/* 配额行的原地编辑：上限提示放在输入框下方成一列，按钮与输入框顶部对齐。 */
+.inline-edit-quota {
+  align-items: flex-start;
+}
+
+.inline-edit-quota-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-width: 220px;
+  flex: 1;
+
+  .inline-edit-input {
+    max-width: none;
+  }
+}
+
+.quota-max-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--td-text-color-secondary);
+  line-height: 1.4;
+  text-align: right;
 }
 
 /* 只读态的描述：多行可换行；空描述用占位色提示用户可点编辑写入。 */

--- a/frontend/src/views/system/SystemAuditLog.vue
+++ b/frontend/src/views/system/SystemAuditLog.vue
@@ -358,6 +358,19 @@ function auditTargetDiff(row: AuditLog): string {
     }
     return formatSettingDiff(details)
   }
+  if (row.action === 'tenant.storage_quota_updated') {
+    // Details: { old_quota_bytes, new_quota_bytes, disk_free_bytes? }。
+    // 字节值人类可读化成 GB（保留 1 位小数），与配额编辑页的输入单位一致。
+    const oldBytes = typeof details.old_quota_bytes === 'number' ? details.old_quota_bytes : null
+    const newBytes = typeof details.new_quota_bytes === 'number' ? details.new_quota_bytes : null
+    if (oldBytes !== null && newBytes !== null) {
+      return t('system.globalSettings.audit.target.quotaDiff', {
+        old: `${(oldBytes / 1024 ** 3).toFixed(1)} GB`,
+        new: `${(newBytes / 1024 ** 3).toFixed(1)} GB`,
+      })
+    }
+    return ''
+  }
   if (row.action === 'system.admin_promoted' && typeof details.idempotent === 'boolean') {
     if (details.idempotent === true) {
       return t('system.globalSettings.audit.target.promoteIdempotent')

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/redis/go-redis/v9 v9.14.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sashabaranov/go-openai v1.41.2
+	github.com/shirou/gopsutil/v3 v3.23.12
 	github.com/sirupsen/logrus v1.9.4
 	github.com/slack-go/slack v0.23.1
 	github.com/spf13/viper v1.21.0
@@ -268,7 +269,6 @@ require (
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/samber/lo v1.49.1 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
-	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect

--- a/internal/application/service/tenant.go
+++ b/internal/application/service/tenant.go
@@ -3,12 +3,14 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	werrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/Tencent/WeKnora/internal/utils"
 )
 
 // ListTenantsParams defines parameters for listing tenants with filtering and pagination
@@ -230,6 +232,105 @@ func (s *tenantService) BulkSetStorageQuota(ctx context.Context, quotaBytes int6
 	}
 	logger.Infof(ctx, "Bulk set storage_quota=%d on %d tenants", quotaBytes, affected)
 	return affected, nil
+}
+
+// localStorageFreeBytesFn probes free space on the volume hosting the
+// local storage root. A package-level variable so tests can stub the
+// statfs call without a real filesystem layout.
+var localStorageFreeBytesFn = utils.LocalStorageFreeBytes
+
+// UpdateStorageQuota validates and persists an Owner-initiated quota
+// change for a single tenant. Validation order matters: the usage floor
+// is checked before the disk ceiling so the caller gets the most
+// actionable error first.
+//
+// Rules:
+//   - quotaBytes must be > 0 (knowledge_create.go treats <= 0 as
+//     "unlimited", which a self-service editor must never produce);
+//   - quotaBytes must be >= current StorageUsed — a quota below usage
+//     would wedge every future write;
+//   - quotaBytes must fit the volume: disk free + StorageUsed (bytes
+//     already occupied need no extra disk).
+//
+// When the disk probe fails the check is fail-closed for increases only:
+// raising the quota is rejected because we cannot prove it fits, while
+// lowering or restating the current quota stays allowed (it cannot make
+// the disk situation worse).
+func (s *tenantService) UpdateStorageQuota(ctx context.Context, tenantID uint64, quotaBytes int64) (*types.Tenant, error) {
+	if tenantID == 0 {
+		return nil, errors.New("tenant ID cannot be 0")
+	}
+	if quotaBytes <= 0 {
+		return nil, fmt.Errorf("storage quota must be positive, got %d", quotaBytes)
+	}
+
+	tenant, err := s.repo.GetTenantByID(ctx, tenantID)
+	if err != nil {
+		logger.ErrorWithFields(ctx, err, map[string]interface{}{
+			"tenant_id": tenantID,
+		})
+		return nil, err
+	}
+
+	if quotaBytes < tenant.StorageUsed {
+		return nil, fmt.Errorf("storage quota cannot be below current usage (%d bytes used)", tenant.StorageUsed)
+	}
+
+	free, err := localStorageFreeBytesFn()
+	if err != nil {
+		if quotaBytes > tenant.StorageQuota {
+			logger.ErrorWithFields(ctx, err, map[string]interface{}{
+				"tenant_id":   tenantID,
+				"quota_bytes": quotaBytes,
+			})
+			return nil, fmt.Errorf("cannot verify free disk space, refusing to raise storage quota: %w", err)
+		}
+		logger.Warnf(ctx, "Free disk space probe failed, allowing quota decrease without ceiling check: %v", err)
+	} else if quotaBytes > free+tenant.StorageUsed {
+		return nil, fmt.Errorf(
+			"storage quota exceeds available disk capacity (%d bytes free + %d bytes used)",
+			free, tenant.StorageUsed,
+		)
+	}
+
+	tenant.StorageQuota = quotaBytes
+	tenant.UpdatedAt = time.Now()
+	// GORM `Updates(struct)` skips zero values, which is safe here because
+	// the >0 rule above guarantees the new quota is never a zero value.
+	if err := s.repo.UpdateTenant(ctx, tenant); err != nil {
+		logger.ErrorWithFields(ctx, err, map[string]interface{}{
+			"tenant_id":   tenantID,
+			"quota_bytes": quotaBytes,
+		})
+		return nil, err
+	}
+
+	logger.Infof(ctx, "Tenant %d storage quota updated to %d bytes", tenantID, quotaBytes)
+	return tenant, nil
+}
+
+// GetTenantStorageStats reports current usage plus the quota ceiling the
+// local volume can honour. The probe failure is not an error here: the
+// UI still needs usage to render, so the stats degrade to
+// DiskUnavailable with QuotaMaxBytes = StorageUsed (matching the
+// fail-closed decrease-only rule in UpdateStorageQuota).
+func (s *tenantService) GetTenantStorageStats(ctx context.Context, tenantID uint64) (*types.TenantStorageStats, error) {
+	tenant, err := s.GetTenantByID(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	stats := &types.TenantStorageStats{StorageUsedBytes: tenant.StorageUsed}
+	free, err := localStorageFreeBytesFn()
+	if err != nil {
+		logger.Warnf(ctx, "Free disk space probe failed for tenant %d storage stats: %v", tenantID, err)
+		stats.DiskUnavailable = true
+		stats.QuotaMaxBytes = tenant.StorageUsed
+		return stats, nil
+	}
+	stats.DiskFreeBytes = free
+	stats.QuotaMaxBytes = free + tenant.StorageUsed
+	return stats, nil
 }
 
 // SearchTenants searches tenants with pagination and filters

--- a/internal/application/service/tenant_storage_quota_test.go
+++ b/internal/application/service/tenant_storage_quota_test.go
@@ -1,0 +1,155 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+// quotaTestTenantRepo is an in-memory TenantRepository for the
+// UpdateStorageQuota tests. Only the two methods the service path
+// touches are implemented; everything else panics via the embedded nil
+// interface, which surfaces test bugs instead of silently passing.
+type quotaTestTenantRepo struct {
+	interfaces.TenantRepository
+	tenant      *types.Tenant
+	updateCalls int
+}
+
+func (r *quotaTestTenantRepo) GetTenantByID(_ context.Context, id uint64) (*types.Tenant, error) {
+	if r.tenant != nil && r.tenant.ID == id {
+		// Copy so the service's in-place mutation only becomes visible
+		// through UpdateTenant, mirroring real DB semantics.
+		cp := *r.tenant
+		return &cp, nil
+	}
+	return nil, errors.New("tenant not found")
+}
+
+func (r *quotaTestTenantRepo) UpdateTenant(_ context.Context, tenant *types.Tenant) error {
+	r.updateCalls++
+	cp := *tenant
+	r.tenant = &cp
+	return nil
+}
+
+// stubLocalStorageFree swaps the disk probe for the duration of a test.
+func stubLocalStorageFree(t *testing.T, free int64, err error) {
+	t.Helper()
+	orig := localStorageFreeBytesFn
+	localStorageFreeBytesFn = func() (int64, error) { return free, err }
+	t.Cleanup(func() { localStorageFreeBytesFn = orig })
+}
+
+func TestUpdateStorageQuota(t *testing.T) {
+	const (
+		tenantID    = uint64(1)
+		currentQuot = int64(1000)
+		storageUsed = int64(400)
+		diskFree    = int64(600)
+	)
+	probeErr := errors.New("statfs failed")
+
+	tests := []struct {
+		name string
+		// quota the Owner asks for
+		quota int64
+		// disk probe stub; probeErr simulates an unreadable volume
+		free     int64
+		probeErr error
+		// wantErr asserts the change is rejected and nothing is persisted
+		wantErr bool
+	}{
+		{name: "zero quota rejected", quota: 0, free: diskFree, wantErr: true},
+		{name: "negative quota rejected", quota: -5, free: diskFree, wantErr: true},
+		{name: "quota below current usage rejected", quota: storageUsed - 1, free: diskFree, wantErr: true},
+		{name: "quota above disk headroom rejected", quota: diskFree + storageUsed + 1, free: diskFree, wantErr: true},
+		{name: "quota exactly at disk headroom allowed", quota: diskFree + storageUsed, free: diskFree},
+		{name: "lowering quota to current usage allowed", quota: storageUsed, free: diskFree},
+		{name: "raising rejected when disk probe fails", quota: currentQuot + 1, probeErr: probeErr, wantErr: true},
+		{name: "lowering allowed when disk probe fails", quota: currentQuot - 200, probeErr: probeErr},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubLocalStorageFree(t, tt.free, tt.probeErr)
+			repo := &quotaTestTenantRepo{tenant: &types.Tenant{
+				ID:           tenantID,
+				Name:         "workspace",
+				StorageQuota: currentQuot,
+				StorageUsed:  storageUsed,
+			}}
+			svc := NewTenantService(repo, nil)
+
+			updated, err := svc.UpdateStorageQuota(context.Background(), tenantID, tt.quota)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("UpdateStorageQuota(%d) succeeded, want error", tt.quota)
+				}
+				if repo.updateCalls != 0 {
+					t.Fatalf("UpdateTenant persisted %d times on a rejected change", repo.updateCalls)
+				}
+				if repo.tenant.StorageQuota != currentQuot {
+					t.Fatalf("quota mutated to %d despite rejection", repo.tenant.StorageQuota)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("UpdateStorageQuota(%d) failed: %v", tt.quota, err)
+			}
+			if updated.StorageQuota != tt.quota {
+				t.Fatalf("returned quota=%d, want %d", updated.StorageQuota, tt.quota)
+			}
+			if repo.tenant.StorageQuota != tt.quota {
+				t.Fatalf("persisted quota=%d, want %d", repo.tenant.StorageQuota, tt.quota)
+			}
+		})
+	}
+}
+
+func TestGetTenantStorageStats(t *testing.T) {
+	repo := &quotaTestTenantRepo{tenant: &types.Tenant{
+		ID:           1,
+		Name:         "workspace",
+		StorageQuota: 1000,
+		StorageUsed:  400,
+	}}
+	svc := NewTenantService(repo, nil)
+
+	t.Run("probe success reports headroom", func(t *testing.T) {
+		stubLocalStorageFree(t, 600, nil)
+		stats, err := svc.GetTenantStorageStats(context.Background(), 1)
+		if err != nil {
+			t.Fatalf("GetTenantStorageStats failed: %v", err)
+		}
+		if stats.DiskUnavailable {
+			t.Fatal("DiskUnavailable=true on a successful probe")
+		}
+		if stats.DiskFreeBytes != 600 {
+			t.Fatalf("DiskFreeBytes=%d, want 600", stats.DiskFreeBytes)
+		}
+		if stats.QuotaMaxBytes != 1000 {
+			t.Fatalf("QuotaMaxBytes=%d, want 1000 (600 free + 400 used)", stats.QuotaMaxBytes)
+		}
+		if stats.StorageUsedBytes != 400 {
+			t.Fatalf("StorageUsedBytes=%d, want 400", stats.StorageUsedBytes)
+		}
+	})
+
+	t.Run("probe failure degrades to usage-only ceiling", func(t *testing.T) {
+		stubLocalStorageFree(t, 0, errors.New("statfs failed"))
+		stats, err := svc.GetTenantStorageStats(context.Background(), 1)
+		if err != nil {
+			t.Fatalf("GetTenantStorageStats failed: %v", err)
+		}
+		if !stats.DiskUnavailable {
+			t.Fatal("DiskUnavailable=false on a failed probe")
+		}
+		if stats.QuotaMaxBytes != 400 {
+			t.Fatalf("QuotaMaxBytes=%d, want 400 (usage only)", stats.QuotaMaxBytes)
+		}
+	})
+}

--- a/internal/handler/embed_flow_test.go
+++ b/internal/handler/embed_flow_test.go
@@ -110,6 +110,12 @@ func (f *flowTenantSvc) ListAllTenants(context.Context) ([]*types.Tenant, error)
 func (f *flowTenantSvc) BulkSetStorageQuota(context.Context, int64) (int64, error) {
 	return 0, nil
 }
+func (f *flowTenantSvc) UpdateStorageQuota(context.Context, uint64, int64) (*types.Tenant, error) {
+	return nil, nil
+}
+func (f *flowTenantSvc) GetTenantStorageStats(context.Context, uint64) (*types.TenantStorageStats, error) {
+	return nil, nil
+}
 func (f *flowTenantSvc) SearchTenants(context.Context, string, uint64, int, int) ([]*types.Tenant, int64, error) {
 	return nil, 0, nil
 }

--- a/internal/handler/tenant.go
+++ b/internal/handler/tenant.go
@@ -36,6 +36,11 @@ type TenantHandler struct {
 	// in-code default, so a SystemAdmin's UI override applies on the
 	// very next CreateTenant call.
 	systemSettingSvc interfaces.SystemSettingService
+	// auditSvc records Owner-initiated storage-quota changes. Optional —
+	// when nil the audit write is skipped so unit tests that wire a
+	// partial handler still compile. In production the dig graph always
+	// provides one.
+	auditSvc interfaces.AuditLogService
 }
 
 // NewTenantHandler creates a new tenant handler instance with the provided service
@@ -63,6 +68,7 @@ func NewTenantHandler(
 	kbService interfaces.KnowledgeBaseService,
 	config *config.Config,
 	systemSettingSvc interfaces.SystemSettingService,
+	auditSvc interfaces.AuditLogService,
 ) *TenantHandler {
 	return &TenantHandler{
 		service:          service,
@@ -72,6 +78,7 @@ func NewTenantHandler(
 		kbService:        kbService,
 		config:           config,
 		systemSettingSvc: systemSettingSvc,
+		auditSvc:         auditSvc,
 	}
 }
 
@@ -92,16 +99,24 @@ type createTenantRequest struct {
 
 // updateTenantRequest is the JSON body for PUT /tenants/:id. Only the
 // fields an Owner is permitted to mutate via the public API are bound;
-// everything else (storage_quota, status, business, api_key, agent /
-// retrieval / storage configs, ...) is intentionally NOT writable here
-// — those go through dedicated endpoints (PUT /tenants/kv/:key, ...)
-// that have their own validation.
+// everything else (status, business, api_key, agent / retrieval /
+// storage configs, ...) is intentionally NOT writable here — those go
+// through dedicated endpoints (PUT /tenants/kv/:key, ...) that have
+// their own validation.
+//
+// storage_quota is the one privileged column allowed here: self-service
+// quota editing is a deliberate Owner feature, and it does NOT trust the
+// bound value blindly — TenantService.UpdateStorageQuota re-validates
+// the quota semantics (> 0, >= current usage, <= disk free + usage)
+// before persisting, so a crafted body cannot grant more headroom than
+// the volume actually has.
 //
 // Pointers so we can distinguish "not sent" from "explicit empty
 // string"; when nil we leave the existing column untouched.
 type updateTenantRequest struct {
-	Name        *string `json:"name"        binding:"omitempty,min=1,max=128"`
-	Description *string `json:"description" binding:"omitempty,max=512"`
+	Name         *string `json:"name"          binding:"omitempty,min=1,max=128"`
+	Description  *string `json:"description"   binding:"omitempty,max=512"`
+	StorageQuota *int64  `json:"storage_quota" binding:"omitempty,gt=0"`
 }
 
 type apiPrincipalConfigRequest struct {
@@ -581,13 +596,16 @@ func (h *TenantHandler) UpdateTenant(c *gin.Context) {
 		return
 	}
 
-	// Strict whitelist: only Name / Description are mutable through the
-	// public PUT. Storage quota, status, business, configs, api_key and
-	// every other privileged column live behind dedicated endpoints
+	// Strict whitelist: only Name / Description / StorageQuota are
+	// mutable through the public PUT. Status, business, configs, api_key
+	// and every other privileged column live behind dedicated endpoints
 	// (PUT /tenants/kv/:key, ...). Without this, an
 	// Owner — including any user who just self-served a tenant — could
-	// flip status / bump storage_quota by simply crafting an extended
-	// JSON body. Pointers distinguish "field omitted" from "explicit
+	// flip status by simply crafting an extended JSON body. StorageQuota
+	// is the exception by design (Owner self-service), but it is routed
+	// through TenantService.UpdateStorageQuota which re-validates the
+	// value against usage and real disk headroom instead of trusting the
+	// bound body. Pointers distinguish "field omitted" from "explicit
 	// empty string" so we can leave untouched columns alone.
 	var req updateTenantRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -622,6 +640,33 @@ func (h *TenantHandler) UpdateTenant(c *gin.Context) {
 		existing.Description = strings.TrimSpace(*req.Description)
 	}
 
+	// quotaAudit carries an Owner-initiated quota change from the
+	// StorageQuota branch down to the post-UpdateTenant success path, so
+	// the audit row is only written once the whole update has persisted
+	// (and only when the quota actually changed — restating the current
+	// value is a no-op the audit log should not record).
+	var quotaAudit *struct{ old, new int64 }
+
+	if req.StorageQuota != nil {
+		oldQuota := existing.StorageQuota
+		updated, err := h.service.UpdateStorageQuota(ctx, id, *req.StorageQuota)
+		if err != nil {
+			logger.ErrorWithFields(ctx, err, map[string]interface{}{
+				"tenant_id":     id,
+				"storage_quota": *req.StorageQuota,
+			})
+			c.Error(errors.NewValidationError("Invalid storage quota").WithDetails(err.Error()))
+			return
+		}
+		// Reflect the persisted value so the response below reports the
+		// new quota even though the Name/Description path re-saves the
+		// same struct afterwards.
+		existing.StorageQuota = updated.StorageQuota
+		if oldQuota != updated.StorageQuota {
+			quotaAudit = &struct{ old, new int64 }{old: oldQuota, new: updated.StorageQuota}
+		}
+	}
+
 	logger.Infof(ctx, "Updating tenant, ID: %d, Name: %s", id, secutils.SanitizeForLog(existing.Name))
 
 	updatedTenant, err := h.service.UpdateTenant(ctx, existing)
@@ -642,10 +687,86 @@ func (h *TenantHandler) UpdateTenant(c *gin.Context) {
 		updatedTenant.ID,
 		secutils.SanitizeForLog(updatedTenant.Name),
 	)
+	// Audit only after the full update persisted: emitting it inside the
+	// StorageQuota branch would record a "success" row even if the
+	// subsequent UpdateTenant save failed.
+	if quotaAudit != nil {
+		h.emitStorageQuotaAudit(ctx, id, quotaAudit.old, quotaAudit.new)
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"data":    dto.NewTenantResponse(ctx, updatedTenant),
 	})
+}
+
+// GetTenantStorageStats godoc
+// @Summary      获取空间存储配额统计
+// @Description  返回当前已用空间、卷剩余空间与可设置的最大配额，供 Owner 编辑配额时约束取值范围
+// @Tags         空间管理
+// @Produce      json
+// @Param        id  path      int  true  "空间ID"
+// @Success      200  {object}  map[string]interface{}  "存储统计"
+// @Failure      400  {object}  errors.AppError         "请求参数错误"
+// @Security     Bearer
+// @Router       /tenants/{id}/storage-stats [get]
+func (h *TenantHandler) GetTenantStorageStats(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		logger.Errorf(ctx, "Invalid workspace ID: %s", secutils.SanitizeForLog(c.Param("id")))
+		c.Error(errors.NewBadRequestError("Invalid workspace ID"))
+		return
+	}
+
+	stats, err := h.service.GetTenantStorageStats(ctx, id)
+	if err != nil {
+		if appErr, ok := errors.IsAppError(err); ok {
+			c.Error(appErr)
+		} else {
+			logger.ErrorWithFields(ctx, err, nil)
+			c.Error(errors.NewInternalServerError("Failed to load storage stats").WithDetails(err.Error()))
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    stats,
+	})
+}
+
+// emitStorageQuotaAudit writes one audit row for an Owner-initiated
+// storage-quota change. Best-effort: a nil audit service or a write
+// failure only logs a warning and never blocks the main flow (mirrors
+// emitAdminAudit in system.go). disk_free_bytes is probed via
+// GetTenantStorageStats and simply omitted when the disk is unreadable —
+// the old/new quota pair is the load-bearing part of the record.
+func (h *TenantHandler) emitStorageQuotaAudit(ctx context.Context, tenantID uint64, oldQuota, newQuota int64) {
+	if h.auditSvc == nil {
+		return
+	}
+	actorID, _ := types.UserIDFromContext(ctx)
+	detailMap := map[string]any{
+		"old_quota_bytes": oldQuota,
+		"new_quota_bytes": newQuota,
+	}
+	if stats, err := h.service.GetTenantStorageStats(ctx, tenantID); err == nil && !stats.DiskUnavailable {
+		detailMap["disk_free_bytes"] = stats.DiskFreeBytes
+	}
+	details, _ := json.Marshal(detailMap)
+	if err := h.auditSvc.Log(ctx, &types.AuditLog{
+		TenantID:    tenantID,
+		ActorUserID: actorID,
+		ActorRole:   string(types.TenantRoleFromContext(ctx)),
+		Action:      types.AuditActionTenantStorageQuotaUpdated,
+		TargetType:  "tenant_storage_quota",
+		TargetID:    strconv.FormatUint(tenantID, 10),
+		Outcome:     types.AuditOutcomeSuccess,
+		Details:     types.JSON(details),
+	}); err != nil {
+		logger.Warnf(ctx, "Failed to write storage quota audit log for tenant %d: %v", tenantID, err)
+	}
 }
 
 func (h *TenantHandler) ListAPIKeys(c *gin.Context) {

--- a/internal/handler/tenant_secret_disclosure_test.go
+++ b/internal/handler/tenant_secret_disclosure_test.go
@@ -46,6 +46,12 @@ func (s *stubTenantService) SearchTenants(context.Context, string, uint64, int, 
 func (s *stubTenantService) BulkSetStorageQuota(context.Context, int64) (int64, error) {
 	return 0, nil
 }
+func (s *stubTenantService) UpdateStorageQuota(context.Context, uint64, int64) (*types.Tenant, error) {
+	return nil, nil
+}
+func (s *stubTenantService) GetTenantStorageStats(context.Context, uint64) (*types.TenantStorageStats, error) {
+	return nil, nil
+}
 func (s *stubTenantService) GetTenantByIDForUser(context.Context, uint64, string) (*types.Tenant, error) {
 	return s.tenant, nil
 }

--- a/internal/handler/tenant_storage_quota_test.go
+++ b/internal/handler/tenant_storage_quota_test.go
@@ -1,0 +1,186 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+// quotaTenantService is a TenantService stub for the storage-quota
+// handler tests. Only the methods UpdateTenant / GetTenantStorageStats
+// exercise are implemented; the embedded nil interface panics on
+// anything unexpected.
+type quotaTenantService struct {
+	interfaces.TenantService
+	tenant           *types.Tenant
+	updateQuotaCalls int
+	updateQuotaErr   error
+}
+
+func (s *quotaTenantService) GetTenantByID(_ context.Context, id uint64) (*types.Tenant, error) {
+	cp := *s.tenant
+	cp.ID = id
+	return &cp, nil
+}
+
+func (s *quotaTenantService) UpdateTenant(_ context.Context, tenant *types.Tenant) (*types.Tenant, error) {
+	return tenant, nil
+}
+
+func (s *quotaTenantService) UpdateStorageQuota(
+	_ context.Context, tenantID uint64, quotaBytes int64,
+) (*types.Tenant, error) {
+	s.updateQuotaCalls++
+	if s.updateQuotaErr != nil {
+		return nil, s.updateQuotaErr
+	}
+	cp := *s.tenant
+	cp.ID = tenantID
+	cp.StorageQuota = quotaBytes
+	return &cp, nil
+}
+
+func (s *quotaTenantService) GetTenantStorageStats(
+	_ context.Context, tenantID uint64,
+) (*types.TenantStorageStats, error) {
+	return &types.TenantStorageStats{
+		DiskFreeBytes:    600,
+		QuotaMaxBytes:    1000,
+		StorageUsedBytes: 400,
+	}, nil
+}
+
+// quotaAuditService captures audit rows so tests can assert the
+// Owner-initiated quota change was recorded.
+type quotaAuditService struct {
+	interfaces.AuditLogService
+	entries []*types.AuditLog
+}
+
+func (s *quotaAuditService) Log(_ context.Context, entry *types.AuditLog) error {
+	s.entries = append(s.entries, entry)
+	return nil
+}
+
+func setupQuotaUpdateRouter(svc *quotaTenantService, audit *quotaAuditService) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	h := &TenantHandler{service: svc, auditSvc: audit}
+	r := gin.New()
+	// tenantPolicyErrorCapture serialises the full AppError (including
+	// details) so the validation-detail assertions below can see the
+	// service's reason string.
+	r.Use(tenantPolicyErrorCapture())
+	r.PUT("/tenants/:id", h.UpdateTenant)
+	return r
+}
+
+func putTenantBody(t *testing.T, r *gin.Engine, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/tenants/1", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestUpdateTenantWithoutStorageQuotaLeavesQuotaUntouched(t *testing.T) {
+	svc := &quotaTenantService{tenant: &types.Tenant{ID: 1, Name: "ws", StorageQuota: 1000, StorageUsed: 400}}
+	audit := &quotaAuditService{}
+	r := setupQuotaUpdateRouter(svc, audit)
+
+	w := putTenantBody(t, r, `{"name":"renamed"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if svc.updateQuotaCalls != 0 {
+		t.Fatalf("UpdateStorageQuota called %d times for a body without storage_quota", svc.updateQuotaCalls)
+	}
+	if !strings.Contains(w.Body.String(), `"storage_quota":1000`) {
+		t.Fatalf("quota changed in response: %s", w.Body.String())
+	}
+	if len(audit.entries) != 0 {
+		t.Fatalf("unexpected audit entries without a quota change: %d", len(audit.entries))
+	}
+}
+
+func TestUpdateTenantRejectsQuotaWhenServiceValidationFails(t *testing.T) {
+	svc := &quotaTenantService{
+		tenant:         &types.Tenant{ID: 1, Name: "ws", StorageQuota: 1000, StorageUsed: 400},
+		updateQuotaErr: errors.New("storage quota exceeds available disk capacity"),
+	}
+	audit := &quotaAuditService{}
+	r := setupQuotaUpdateRouter(svc, audit)
+
+	w := putTenantBody(t, r, `{"storage_quota":50}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "storage quota exceeds available disk capacity") {
+		t.Fatalf("validation detail missing from response: %s", w.Body.String())
+	}
+	if len(audit.entries) != 0 {
+		t.Fatalf("audit entries written for a rejected change: %d", len(audit.entries))
+	}
+}
+
+func TestUpdateTenantAppliesStorageQuotaAndAudits(t *testing.T) {
+	svc := &quotaTenantService{tenant: &types.Tenant{ID: 1, Name: "ws", StorageQuota: 1000, StorageUsed: 400}}
+	audit := &quotaAuditService{}
+	r := setupQuotaUpdateRouter(svc, audit)
+
+	w := putTenantBody(t, r, `{"storage_quota":900}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if svc.updateQuotaCalls != 1 {
+		t.Fatalf("UpdateStorageQuota called %d times, want 1", svc.updateQuotaCalls)
+	}
+	if !strings.Contains(w.Body.String(), `"storage_quota":900`) {
+		t.Fatalf("response does not report the new quota: %s", w.Body.String())
+	}
+	if len(audit.entries) != 1 {
+		t.Fatalf("audit entries=%d, want 1", len(audit.entries))
+	}
+	entry := audit.entries[0]
+	if entry.Action != types.AuditActionTenantStorageQuotaUpdated {
+		t.Fatalf("audit action=%q, want %q", entry.Action, types.AuditActionTenantStorageQuotaUpdated)
+	}
+	if entry.TenantID != 1 || entry.TargetID != "1" || entry.TargetType != "tenant_storage_quota" {
+		t.Fatalf("audit target mismatch: %+v", entry)
+	}
+	details := string(entry.Details)
+	for _, want := range []string{`"old_quota_bytes":1000`, `"new_quota_bytes":900`, `"disk_free_bytes":600`} {
+		if !strings.Contains(details, want) {
+			t.Fatalf("audit details missing %s: %s", want, details)
+		}
+	}
+}
+
+func TestGetTenantStorageStats(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &quotaTenantService{tenant: &types.Tenant{ID: 1, Name: "ws", StorageQuota: 1000, StorageUsed: 400}}
+	h := &TenantHandler{service: svc}
+	r := gin.New()
+	r.Use(errorCapture())
+	r.GET("/tenants/:id/storage-stats", h.GetTenantStorageStats)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/tenants/1/storage-stats", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	for _, want := range []string{`"disk_free_bytes":600`, `"quota_max_bytes":1000`, `"storage_used_bytes":400`} {
+		if !strings.Contains(w.Body.String(), want) {
+			t.Fatalf("stats response missing %s: %s", want, w.Body.String())
+		}
+	}
+}

--- a/internal/middleware/embed_auth_test.go
+++ b/internal/middleware/embed_auth_test.go
@@ -169,6 +169,18 @@ func (f *fakeTenantService) BulkSetStorageQuota(ctx context.Context, quotaBytes 
 	return 0, nil
 }
 
+func (f *fakeTenantService) UpdateStorageQuota(
+	ctx context.Context, tenantID uint64, quotaBytes int64,
+) (*types.Tenant, error) {
+	return nil, nil
+}
+
+func (f *fakeTenantService) GetTenantStorageStats(
+	ctx context.Context, tenantID uint64,
+) (*types.TenantStorageStats, error) {
+	return nil, nil
+}
+
 func (f *fakeTenantService) SearchTenants(
 	ctx context.Context, keyword string, tenantID uint64, page, pageSize int,
 ) ([]*types.Tenant, int64, error) {

--- a/internal/router/router_presigned_test.go
+++ b/internal/router/router_presigned_test.go
@@ -57,6 +57,12 @@ func (s *stubTenantService) ListAllTenants(context.Context) ([]*types.Tenant, er
 func (s *stubTenantService) BulkSetStorageQuota(context.Context, int64) (int64, error) {
 	panic("unexpected")
 }
+func (s *stubTenantService) UpdateStorageQuota(context.Context, uint64, int64) (*types.Tenant, error) {
+	panic("unexpected")
+}
+func (s *stubTenantService) GetTenantStorageStats(context.Context, uint64) (*types.TenantStorageStats, error) {
+	panic("unexpected")
+}
 
 func (s *stubTenantService) SearchTenants(context.Context, string, uint64, int, int) ([]*types.Tenant, int64, error) {
 	panic("unexpected")

--- a/internal/router/routes_auth_tenant.go
+++ b/internal/router/routes_auth_tenant.go
@@ -16,6 +16,7 @@ import (
 //   - GET   /:id          Viewer+ (read tenant settings)
 //   - PUT   /:id          Owner+ (mutate tenant config)
 //   - DELETE /:id         Owner+ (also normally a CanAccessAllTenants op)
+//   - GET   /:id/storage-stats   Viewer+ (disk headroom for the quota editor)
 //   - GET/POST/DELETE /:id/api-keys   Owner+ (scoped API key management)
 //   - GET    /:id/members            Viewer+ (any member can see who else is in)
 //   - POST   /:id/members            Owner+ (only Owner can add new members)
@@ -94,6 +95,12 @@ func RegisterTenantRoutes(
 				apiKeyPlatform(types.APIKeyCapabilitySystemTenantsManage), g.Owner(), handler.UpdateTenant)
 			g.apiKeyRoute(tenantByID, http.MethodDelete, "",
 				apiKeyPlatform(types.APIKeyCapabilitySystemTenantsManage), g.Owner(), handler.DeleteTenant)
+			// Volume headroom for the Owner quota editor. Viewer+ is
+			// enough: free disk space is not sensitive, and
+			// PathTenantMatch already scopes the read to the active
+			// tenant. JWT-only like the other lifecycle routes — the
+			// quota editor is a UI flow, not an API-key integration.
+			tenantByID.GET("/storage-stats", g.Viewer(), handler.GetTenantStorageStats)
 			tenantByID.GET("/api-keys", g.Owner(), handler.ListAPIKeys)
 			tenantByID.POST("/api-keys", g.Owner(), handler.CreateAPIKey)
 			tenantByID.DELETE("/api-keys/:key_id", g.Owner(), handler.DeleteAPIKey)

--- a/internal/types/audit_log.go
+++ b/internal/types/audit_log.go
@@ -51,6 +51,14 @@ const (
 	// an overdue pending row to expired. Actor is empty (system).
 	AuditActionInvitationExpired AuditAction = "rbac.invitation_expired"
 
+	// AuditActionTenantStorageQuotaUpdated fires when a tenant Owner
+	// changes their own workspace's storage_quota through
+	// PUT /tenants/:id. Tenant-scoped (tenant_id = the workspace), unlike
+	// the SystemAdmin bulk apply which reuses
+	// AuditActionSystemSettingChanged with tenant_id=0. Details payload
+	// carries {old_quota_bytes, new_quota_bytes, disk_free_bytes}.
+	AuditActionTenantStorageQuotaUpdated AuditAction = "tenant.storage_quota_updated"
+
 	// VectorStore lifecycle actions. Emitted by VectorStoreService.
 	// Cover both env-store-derived (__env_*) and DB store create /
 	// update / delete paths. Details payload identifies the store_id

--- a/internal/types/interfaces/tenant.go
+++ b/internal/types/interfaces/tenant.go
@@ -32,6 +32,19 @@ type TenantService interface {
 	// forbids storage_quota edits for Owners). quotaBytes must be > 0;
 	// callers are responsible for resolving GB→bytes.
 	BulkSetStorageQuota(ctx context.Context, quotaBytes int64) (int64, error)
+	// UpdateStorageQuota persists an Owner-initiated quota change for a
+	// single tenant after validating it against current usage and the
+	// free space on the local storage volume. Unlike BulkSetStorageQuota
+	// this is the self-service path and therefore enforces:
+	// quotaBytes > 0, quotaBytes >= storage used, and
+	// quotaBytes <= disk free + storage used. When the disk probe fails
+	// the check is fail-closed for increases (raising is rejected) but
+	// lowering or restating the quota stays allowed.
+	UpdateStorageQuota(ctx context.Context, tenantID uint64, quotaBytes int64) (*types.Tenant, error)
+	// GetTenantStorageStats reports the tenant's storage usage together
+	// with the quota ceiling the local volume can currently honour, so
+	// the UI can bound the Owner's quota editor.
+	GetTenantStorageStats(ctx context.Context, tenantID uint64) (*types.TenantStorageStats, error)
 	// SearchTenants searches tenants with pagination and filters
 	SearchTenants(ctx context.Context, keyword string, tenantID uint64, page, pageSize int) ([]*types.Tenant, int64, error)
 	// GetTenantByIDForUser gets a tenant by ID with permission check

--- a/internal/types/tenant.go
+++ b/internal/types/tenant.go
@@ -126,6 +126,26 @@ type Tenant struct {
 	DeletedAt gorm.DeletedAt `yaml:"deleted_at"          json:"deleted_at"          gorm:"index"`
 }
 
+// TenantStorageStats reports how much headroom an Owner has when raising
+// their storage quota. QuotaMaxBytes is the largest quota the volume can
+// honour right now: disk-free plus what the tenant already occupies
+// (raising the quota into already-used space needs no extra disk). When
+// the disk probe fails, DiskUnavailable is true, DiskFreeBytes is omitted
+// and QuotaMaxBytes degrades to the current usage — the UI should then
+// only offer lowering the quota, mirroring the fail-closed rule in
+// TenantService.UpdateStorageQuota.
+type TenantStorageStats struct {
+	// Free bytes on the volume hosting the local storage root; omitted
+	// when the probe failed.
+	DiskFreeBytes int64 `json:"disk_free_bytes,omitempty"`
+	// Maximum quota the tenant may set (disk free + storage used).
+	QuotaMaxBytes int64 `json:"quota_max_bytes"`
+	// Bytes the tenant currently occupies.
+	StorageUsedBytes int64 `json:"storage_used_bytes"`
+	// True when the disk free-space probe failed.
+	DiskUnavailable bool `json:"disk_unavailable"`
+}
+
 // RetrieverEngines represents the retriever engines for a tenant
 type RetrieverEngines struct {
 	Engines []RetrieverEngineParams `yaml:"engines" json:"engines" gorm:"type:json"`

--- a/internal/utils/disk.go
+++ b/internal/utils/disk.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/shirou/gopsutil/v3/disk"
+)
+
+// LocalStorageBaseDir resolves LOCAL_STORAGE_BASE_DIR with the container
+// default (mirrors router/files.go localStorageBaseDir). The desktop app
+// sets this env at startup (cmd/desktop/main.go) to point at the app
+// support directory, so reading the env here stays correct there too.
+func LocalStorageBaseDir() string {
+	baseDir := strings.TrimSpace(os.Getenv("LOCAL_STORAGE_BASE_DIR"))
+	if baseDir == "" {
+		baseDir = "/data/files"
+	}
+	return baseDir
+}
+
+// DiskFreeBytes returns the free bytes on the volume hosting path.
+//
+// The path itself may not exist yet (e.g. LOCAL_STORAGE_BASE_DIR on a
+// fresh install), so we walk up to the nearest existing ancestor before
+// calling statfs. We deliberately do NOT MkdirAll here: a probe function
+// must not mutate the filesystem it is measuring.
+func DiskFreeBytes(path string) (uint64, error) {
+	probe := strings.TrimSpace(path)
+	if probe == "" {
+		probe = "."
+	}
+	probe = filepath.Clean(probe)
+	for {
+		if info, err := os.Stat(probe); err == nil && info.IsDir() {
+			break
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe {
+			// Reached the filesystem root without finding an existing
+			// directory; stat the root itself and let disk.Usage report
+			// any real error.
+			break
+		}
+		probe = parent
+	}
+	usage, err := disk.Usage(probe)
+	if err != nil {
+		return 0, err
+	}
+	return usage.Free, nil
+}
+
+// LocalStorageFreeBytes returns the free bytes on the volume that hosts
+// the local storage root. Inside a container this observes the mounted
+// volume, which is exactly the capacity an operator means by "local
+// available capacity".
+func LocalStorageFreeBytes() (int64, error) {
+	free, err := DiskFreeBytes(LocalStorageBaseDir())
+	if err != nil {
+		return 0, err
+	}
+	return int64(free), nil
+}

--- a/internal/utils/disk_test.go
+++ b/internal/utils/disk_test.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDiskFreeBytesExistingDir(t *testing.T) {
+	free, err := DiskFreeBytes(t.TempDir())
+	if err != nil {
+		t.Fatalf("DiskFreeBytes on temp dir: %v", err)
+	}
+	if free == 0 {
+		t.Fatal("expected non-zero free bytes on temp dir volume")
+	}
+}
+
+func TestDiskFreeBytesWalksUpToExistingAncestor(t *testing.T) {
+	base := t.TempDir()
+	deep := filepath.Join(base, "does", "not", "exist", "yet")
+	free, err := DiskFreeBytes(deep)
+	if err != nil {
+		t.Fatalf("DiskFreeBytes should walk up to an existing ancestor: %v", err)
+	}
+	if free == 0 {
+		t.Fatal("expected non-zero free bytes after walk-up")
+	}
+}
+
+func TestDiskFreeBytesEmptyPath(t *testing.T) {
+	// Empty path probes the working directory's volume; must not error.
+	if _, err := DiskFreeBytes("   "); err != nil {
+		t.Fatalf("DiskFreeBytes with blank path: %v", err)
+	}
+}
+
+func TestLocalStorageFreeBytes(t *testing.T) {
+	t.Setenv("LOCAL_STORAGE_BASE_DIR", t.TempDir())
+	free, err := LocalStorageFreeBytes()
+	if err != nil {
+		t.Fatalf("LocalStorageFreeBytes: %v", err)
+	}
+	if free <= 0 {
+		t.Fatal("expected positive free bytes")
+	}
+}
+
+func TestLocalStorageBaseDirDefault(t *testing.T) {
+	t.Setenv("LOCAL_STORAGE_BASE_DIR", "")
+	if got := LocalStorageBaseDir(); got != "/data/files" {
+		t.Fatalf("expected container default /data/files, got %q", got)
+	}
+}


### PR DESCRIPTION
## Description

Tenant (workspace) owners currently cannot adjust their storage quota themselves: `PUT /tenants/:id` whitelists only name/description, and the only lever is the deployment-wide default (`WEKNORA_TENANT_DEFAULT_STORAGE_QUOTA_GB`). This PR adds owner self-service quota editing, capped by the actual capacity of the volume hosting `LOCAL_STORAGE_BASE_DIR`.

**Backend**
- New `internal/utils/disk.go`: cross-platform free-space probe via `gopsutil/v3` (promoted from indirect to direct dependency). Walks up to the nearest existing ancestor directory; read-only, never creates directories.
- New `TenantService.UpdateStorageQuota`: rejects `quota <= 0` (non-positive means "unlimited" in the existing model and must not be written through this channel), rejects values below current `StorageUsed`, and rejects values above `diskFree + StorageUsed`. If the disk probe fails, increasing the quota is refused (fail-closed) while lowering/keeping it is allowed.
- `updateTenantRequest` gains an optional `storage_quota *int64` (`binding:"omitempty,gt=0"`), so existing clients are unaffected.
- New endpoint `GET /api/v1/tenants/:id/storage-stats` (Viewer+) returning `{storage_used_bytes, disk_free_bytes, quota_max_bytes, disk_unavailable}` so the UI can show a live upper bound. Probe failure degrades to `disk_unavailable: true`.
- Audit log: new action `tenant.storage_quota_updated` with `{old_quota_bytes, new_quota_bytes}` details, emitted only when the value actually changes (best-effort, never blocks the update).

**Frontend**
- Tenant Info settings page: the quota row becomes an inline editor (same pattern as the existing name row), gated by the existing owner check. Input is in GB (decimals allowed), converted to bytes client-side.
- Live upper-bound hint (`quota_max_bytes ≈ disk free + used`) shown in edit mode; client-side pre-validation for immediate feedback (server remains the authority).
- i18n for zh-CN / en-US / ru-RU / ko-KR, including the new audit action label and a `{old} → {new}` GB diff renderer on the audit log page.

**Notes / boundaries**
- No DB migration: `storage_quota` / `storage_used` columns already exist.
- The admin bulk channel (`apply-default-storage-quota`) is intentionally unaffected.
- With non-local storage backends (COS/MinIO), "disk free + used" is an approximation of "local available capacity"; the UI hint wording says "约/approximately".
- Includes a small follow-up fix: TDesign `t-input type="number"` converts the v-model value to a number, so the first validation called `.trim()` on a number and the save click died silently; input is now normalized to a string first.

## Type of Change
- [x] 🐛 Bug fix
- [x] ✨ New feature

## Related Issue

Closes #1476 — the issue asks for (1) a default-quota env var, already available as `WEKNORA_TENANT_DEFAULT_STORAGE_QUOTA_GB`, and (2) a UI for owners to adjust the quota, which this PR adds. The S3/OSS suggestion in the issue is documented as approximation semantics above rather than disabled.

## Testing

- `go test ./internal/utils/ ./internal/application/service/ ./internal/handler/ ./internal/middleware/ ./internal/router/` — **all pass** (Go 1.26). New coverage: 5 disk-probe cases; 8 table-driven `UpdateStorageQuota` cases (zero/negative, below-used, above-disk-cap, at-cap boundary, lowering, probe-failure fail-closed both directions) plus 2 storage-stats degradation cases; 4 handler cases (nil field untouched, validation 400 with details, success + audit fields, GET stats endpoint).
- `golangci-lint run --new-from-rev=origin/main ./...` — **no new issues** in changed files. (Full-run note: linting in a container without `sqlite3.h` reports one pre-existing `typecheck` failure for `asg017/sqlite-vec-go-bindings/cgo`; unrelated environment limitation.)
- `go vet ./...` reports pre-existing baseline failures in `internal/models/vlm` and `internal/models/asr` on `origin/main`; unrelated to this change.
- `git diff --check origin/main...HEAD` — passes.
- Swagger regenerated via `make docs` (`swag init -g ./cmd/server/main.go -o ./docs --parseDependency --parseInternal`); diff contains only the new endpoint and audit-action enum.
- End-to-end on a deployed instance (docker compose, Postgres): edited quota 300 GB → 301 GB → 320 GB in the UI, all persisted (`PUT /api/v1/tenants/10000` 200) and re-rendered; over-limit and below-used inputs show the corresponding error toasts without issuing a request; audit entry `tenant.storage_quota_updated` recorded. Non-owner accounts do not see the edit button.

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above (none)

## Screenshots / Recordings

Quota row with owner edit entry (view mode):

![quota view mode](https://raw.githubusercontent.com/oscarlius/WeKnora/pr-assets/assets/pr-quota/quota-view-mode.png)

Edit mode with live upper-bound hint (≈ disk free + used):

![quota edit mode](https://raw.githubusercontent.com/oscarlius/WeKnora/pr-assets/assets/pr-quota/quota-edit-mode.png)

After saving 320 GB (persisted and re-rendered):

![quota saved](https://raw.githubusercontent.com/oscarlius/WeKnora/pr-assets/assets/pr-quota/quota-save-success.png)
