### PR TITLE
fix(suggestion): avoid echoing the current query

### DIFF
--- a/internal/application/service/message_suggestion.go
+++ b/internal/application/service/message_suggestion.go
@@ -355,6 +355,11 @@ func (s *messageSuggestionService) generateWithModel(
 		return nil, types.TokenUsage{}, err
 	}
 	items, err := parseGeneratedSuggestions(response.Content, config.Categories, count)
+	if err == nil {
+		// The system prompt already asks the model not to repeat prior user
+		// questions, but that is guidance the model does not always honour.
+		items = filterSuggestionItemsAgainstQuery(items, generationContext.CurrentQuery)
+	}
 	return items, response.Usage, err
 }
 
@@ -441,7 +446,18 @@ func (s *messageSuggestionService) generateFromKnowledge(
 	items := make(types.SuggestionItems, 0, len(candidates))
 	for _, candidate := range candidates {
 		text := strings.TrimSpace(candidate.Question)
-		if text == "" {
+		// The knowledge path never reaches the model, so the "do not repeat
+		// prior user questions" system-prompt rule cannot apply here. Worse,
+		// rankKnowledgeSuggestions ranks candidates against a context that
+		// starts with CurrentQuery and IsContentContained adds +1, so a
+		// candidate identical to the question just asked is actively promoted
+		// to the top of the knowledge pool.
+		// Typical trigger: the user asks "介绍一下X" while X has an
+		// entity/summary wiki page, which wikiSuggestionFromPage turns into
+		// the very same "介绍一下X".
+		// Skip via continue rather than filtering afterwards so that later
+		// candidates can backfill and the configured count is preserved.
+		if text == "" || suggestionMatchesQuery(text, generationContext.CurrentQuery) {
 			continue
 		}
 		item := types.SuggestionItem{
@@ -886,6 +902,36 @@ func mergeHybridSuggestionItems(model, knowledge types.SuggestionItems, limit in
 	appendFrom(model, -1)
 	appendFrom(knowledge, -1)
 	return result
+}
+
+// filterSuggestionItemsAgainstQuery drops suggestions that are, after
+// normalization, exactly the question the user just asked.
+// Only exact matches are removed, deliberately: a similarity threshold would
+// also kill legitimate follow-ups about the same entity, which is precisely
+// what the feature exists for.
+func filterSuggestionItemsAgainstQuery(
+	items types.SuggestionItems,
+	currentQuery string,
+) types.SuggestionItems {
+	if normalizeSuggestionText(currentQuery) == "" {
+		return items
+	}
+	filtered := make(types.SuggestionItems, 0, len(items))
+	for _, item := range items {
+		if suggestionMatchesQuery(item.Text, currentQuery) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
+// suggestionMatchesQuery reports whether a candidate is the current question.
+// It reuses normalizeSuggestionText so punctuation, whitespace and case
+// variants ("Tell me about Foo?" vs "tell me about foo") are caught too.
+func suggestionMatchesQuery(value, currentQuery string) bool {
+	queryKey := normalizeSuggestionText(currentQuery)
+	return queryKey != "" && normalizeSuggestionText(value) == queryKey
 }
 
 func normalizeSuggestionText(value string) string {

--- a/internal/application/service/message_suggestion_test.go
+++ b/internal/application/service/message_suggestion_test.go
@@ -33,6 +33,78 @@ func TestParseGeneratedSuggestionsFiltersAndDeduplicates(t *testing.T) {
 	}
 }
 
+func TestFilterSuggestionItemsAgainstQueryDropsNormalizedEchoes(t *testing.T) {
+	const currentQuery = "介绍一下江苏省劳动争议仲裁委员会"
+	items := types.SuggestionItems{
+		{ID: "model-echo", Text: "介绍一下 江苏省劳动争议仲裁委员会？", Source: "model"},
+		{ID: "wiki-echo", Text: "介绍一下江苏省劳动争议仲裁委员会。", Source: "wiki"},
+		{ID: "keep", Text: "该委员会目前是否已经更名？", Source: "model"},
+	}
+	got := filterSuggestionItemsAgainstQuery(items, currentQuery)
+	if len(got) != 1 || got[0].ID != "keep" {
+		t.Fatalf("filterSuggestionItemsAgainstQuery() = %#v", got)
+	}
+}
+
+func TestFilterSuggestionItemsAgainstQueryKeepsAllWhenQueryEmpty(t *testing.T) {
+	items := types.SuggestionItems{
+		{ID: "1", Text: "A?", Source: "model"},
+		{ID: "2", Text: "B?", Source: "wiki"},
+	}
+	for _, query := range []string{"", "   ", "？？"} {
+		got := filterSuggestionItemsAgainstQuery(items, query)
+		if len(got) != 2 {
+			t.Fatalf("query %q: len = %d, want 2", query, len(got))
+		}
+	}
+}
+
+func TestSuggestionMatchesQueryIgnoresPunctuationAndCase(t *testing.T) {
+	cases := []struct {
+		value, query string
+		want         bool
+	}{
+		{"Tell me about Foo?", "tell me about foo", true},
+		{"介绍一下X", "介绍一下X？", true},
+		{"介绍一下 X", "介绍一下X", true},
+		{"什么是X？", "介绍一下X", false},
+		{"介绍一下XY", "介绍一下X", false},
+		{"介绍一下X", "", false},
+	}
+	for _, c := range cases {
+		if got := suggestionMatchesQuery(c.value, c.query); got != c.want {
+			t.Fatalf("suggestionMatchesQuery(%q, %q) = %v, want %v", c.value, c.query, got, c.want)
+		}
+	}
+}
+
+// Removing the echo must not collapse the hybrid layout: the knowledge slot
+// should be filled by the next knowledge candidate, not stolen by the model.
+func TestMergeHybridKeepsLayoutAfterEchoRemoved(t *testing.T) {
+	const currentQuery = "介绍一下江苏省劳动争议仲裁委员会"
+	model := types.SuggestionItems{
+		{ID: "m1", Text: "该机构是否已更名？", Source: "model"},
+		{ID: "m2", Text: "苏高法审委〔2011〕14号规定了什么？", Source: "model"},
+	}
+	knowledge := filterSuggestionItemsAgainstQuery(types.SuggestionItems{
+		{ID: "k-echo", Text: currentQuery, Source: "wiki"},
+		{ID: "k2", Text: "什么是劳动争议受理范围？", Source: "wiki"},
+	}, currentQuery)
+
+	got := mergeHybridSuggestionItems(model, knowledge, 3)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3: %#v", len(got), got)
+	}
+	if got[0].ID != "m1" || got[1].ID != "m2" || got[2].ID != "k2" {
+		t.Fatalf("mergeHybridSuggestionItems() = %#v", got)
+	}
+	for _, item := range got {
+		if item.Text == currentQuery {
+			t.Fatalf("follow-up still echoes the current question: %#v", got)
+		}
+	}
+}
+
 func TestMergeSuggestionItemsPreservesPriorityAndLimit(t *testing.T) {
 	primary := types.SuggestionItems{{ID: "1", Text: "A?", Source: "model"}}
 	fallback := types.SuggestionItems{

--- a/internal/application/service/message_suggestion_test.go
+++ b/internal/application/service/message_suggestion_test.go
@@ -34,11 +34,11 @@ func TestParseGeneratedSuggestionsFiltersAndDeduplicates(t *testing.T) {
 }
 
 func TestFilterSuggestionItemsAgainstQueryDropsNormalizedEchoes(t *testing.T) {
-	const currentQuery = "介绍一下江苏省劳动争议仲裁委员会"
+	const currentQuery = "介绍一下手冲咖啡"
 	items := types.SuggestionItems{
-		{ID: "model-echo", Text: "介绍一下 江苏省劳动争议仲裁委员会？", Source: "model"},
-		{ID: "wiki-echo", Text: "介绍一下江苏省劳动争议仲裁委员会。", Source: "wiki"},
-		{ID: "keep", Text: "该委员会目前是否已经更名？", Source: "model"},
+		{ID: "model-echo", Text: "介绍一下 手冲咖啡？", Source: "model"},
+		{ID: "wiki-echo", Text: "介绍一下手冲咖啡。", Source: "wiki"},
+		{ID: "keep", Text: "手冲咖啡适合用什么水温？", Source: "model"},
 	}
 	got := filterSuggestionItemsAgainstQuery(items, currentQuery)
 	if len(got) != 1 || got[0].ID != "keep" {
@@ -81,14 +81,14 @@ func TestSuggestionMatchesQueryIgnoresPunctuationAndCase(t *testing.T) {
 // Removing the echo must not collapse the hybrid layout: the knowledge slot
 // should be filled by the next knowledge candidate, not stolen by the model.
 func TestMergeHybridKeepsLayoutAfterEchoRemoved(t *testing.T) {
-	const currentQuery = "介绍一下江苏省劳动争议仲裁委员会"
+	const currentQuery = "介绍一下手冲咖啡"
 	model := types.SuggestionItems{
-		{ID: "m1", Text: "该机构是否已更名？", Source: "model"},
-		{ID: "m2", Text: "苏高法审委〔2011〕14号规定了什么？", Source: "model"},
+		{ID: "m1", Text: "手冲咖啡适合用什么水温？", Source: "model"},
+		{ID: "m2", Text: "如何选择咖啡豆？", Source: "model"},
 	}
 	knowledge := filterSuggestionItemsAgainstQuery(types.SuggestionItems{
 		{ID: "k-echo", Text: currentQuery, Source: "wiki"},
-		{ID: "k2", Text: "什么是劳动争议受理范围？", Source: "wiki"},
+		{ID: "k2", Text: "咖啡豆应该如何保存？", Source: "wiki"},
 	}, currentQuery)
 
 	got := mergeHybridSuggestionItems(model, knowledge, 3)


### PR DESCRIPTION
## Description

Prevent follow-up suggestions from repeating the user's current question after normalization.

The knowledge path can mechanically turn an entity or summary Wiki page titled `X` into `介绍一下X`. When that is also the current query, relevance ranking promotes the echo because its context starts with `CurrentQuery`, and the hybrid merge reserves a knowledge slot for it. The model path can also ignore the prompt-level instruction not to repeat prior questions.

This change:

- filters normalized exact matches against `CurrentQuery` on both model and knowledge paths;
- filters knowledge candidates inside the selection loop so later candidates can backfill the configured count;
- deliberately avoids fuzzy similarity thresholds so valid deeper questions about the same entity remain available;
- adds coverage for punctuation, whitespace, case, empty-query behavior, and hybrid slot preservation.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2519

## Testing

- `gofmt -l internal/application/service/message_suggestion.go internal/application/service/message_suggestion_test.go` — no output
- `go test ./internal/application/service/ -run 'Suggestion|FollowUp|MergeHybrid' -count=1` — passed with Go 1.26
- `go vet ./internal/application/service/` — passed with Go 1.26
- `git diff --check upstream/main...HEAD` — passed

The focused backend package was validated. Full-repository `make test` was not run because this change is isolated to follow-up suggestion generation and its unit tests.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (validated with `go vet` for the changed package)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (not applicable; no user-facing contract or configuration change)
- [x] Breaking changes are clearly called out (none)

## Screenshots / Recordings

Not applicable; this is a backend-only fix.
