### PR TITLE
fix(tenant): clear stale home tenant after member removal

### DIFF
--- a/internal/application/service/tenant_member.go
+++ b/internal/application/service/tenant_member.go
@@ -75,8 +75,10 @@ const (
 
 // tenantMemberService implements interfaces.TenantMemberService.
 type tenantMemberService struct {
-	repo  interfaces.TenantMemberRepository
-	audit interfaces.AuditLogService // optional; nil ⇒ no audit, business ops still succeed
+	repo      interfaces.TenantMemberRepository
+	audit     interfaces.AuditLogService     // optional; nil ⇒ no audit, business ops still succeed
+	userRepo  interfaces.UserRepository      // optional; used to clear stale home-tenant pointers
+	tokenRepo interfaces.AuthTokenRepository // optional; used to revoke sessions after removal
 }
 
 // NewTenantMemberService constructs the service. Wired up via the DI
@@ -86,11 +88,25 @@ type tenantMemberService struct {
 // constructs tenant_member before audit_log won't crash and tests
 // don't need to stub the dependency unless they care about audit
 // behaviour.
+//
+// userRepo / tokenRepo are also optional and only used by RemoveMember
+// cleanup: after a membership is soft-deleted we best-effort clear a
+// dangling users.tenant_id / LastActiveTenantID and revoke outstanding
+// sessions so the removed user cannot keep a JWT scoped to a workspace
+// they no longer belong to. Passing nil keeps unit tests that only
+// exercise membership invariants free of extra stubs.
 func NewTenantMemberService(
 	repo interfaces.TenantMemberRepository,
 	audit interfaces.AuditLogService,
+	userRepo interfaces.UserRepository,
+	tokenRepo interfaces.AuthTokenRepository,
 ) interfaces.TenantMemberService {
-	return &tenantMemberService{repo: repo, audit: audit}
+	return &tenantMemberService{
+		repo:      repo,
+		audit:     audit,
+		userRepo:  userRepo,
+		tokenRepo: tokenRepo,
+	}
 }
 
 // emitAudit is the per-mutation audit hook. Best-effort: a nil audit
@@ -372,6 +388,15 @@ func (s *tenantMemberService) emitRoleChangeAudit(
 // DELETE /tenants/:id/members/:user_id). Both go through this same
 // service method but the recorded action differs so an audit reader
 // can tell the two apart.
+//
+// After a successful soft-delete, best-effort cleanup clears any
+// dangling users.tenant_id / LastActiveTenantID that still points at
+// the removed workspace and revokes outstanding auth tokens. Without
+// this, a tenantless→invited→removed user keeps a stale home pointer
+// and the login path synthesises the removed workspace back into the
+// space switcher (see issue #2586). Cleanup failures are logged but
+// never fail the removal itself: the membership row is already gone
+// and the login-path membership checks act as a second line of defence.
 func (s *tenantMemberService) RemoveMember(ctx context.Context, userID string, tenantID uint64) error {
 	current, err := s.repo.Get(ctx, userID, tenantID)
 	if err != nil {
@@ -389,13 +414,57 @@ func (s *tenantMemberService) RemoveMember(ctx context.Context, userID string, t
 			return err
 		}
 		s.emitRemovalAudit(ctx, tenantID, userID)
+		s.cleanupRemovedMemberState(ctx, userID, tenantID)
 		return nil
 	}
 	if err := s.repo.SoftDelete(ctx, userID, tenantID); err != nil {
 		return err
 	}
 	s.emitRemovalAudit(ctx, tenantID, userID)
+	s.cleanupRemovedMemberState(ctx, userID, tenantID)
 	return nil
+}
+
+// cleanupRemovedMemberState drops stale home/preference pointers that
+// reference the removed tenant and revokes the user's sessions so any
+// JWT still scoped to that tenant cannot keep serving 403-only UI.
+// All steps are best-effort and nil-safe for partial DI graphs in tests.
+func (s *tenantMemberService) cleanupRemovedMemberState(ctx context.Context, userID string, tenantID uint64) {
+	if s.userRepo != nil {
+		user, err := s.userRepo.GetUserByID(ctx, userID)
+		if err != nil {
+			logger.Warnf(ctx,
+				"RemoveMember cleanup: failed to load user %s after removing tenant %d: %v",
+				userID, tenantID, err)
+		} else if user != nil {
+			changed := false
+			if user.TenantID == tenantID {
+				user.TenantID = 0
+				changed = true
+			}
+			if user.Preferences.LastActiveTenantID != nil && *user.Preferences.LastActiveTenantID == tenantID {
+				user.Preferences.LastActiveTenantID = nil
+				changed = true
+			}
+			if changed {
+				user.UpdatedAt = time.Now()
+				if err := s.userRepo.UpdateUser(ctx, user); err != nil {
+					logger.Warnf(ctx,
+						"RemoveMember cleanup: failed to clear stale tenant pointers for user %s tenant %d: %v",
+						userID, tenantID, err)
+				}
+			}
+		}
+	}
+
+	if s.tokenRepo == nil {
+		return
+	}
+	if err := s.tokenRepo.RevokeTokensByUserID(ctx, userID); err != nil {
+		logger.Warnf(ctx,
+			"RemoveMember cleanup: failed to revoke tokens for user %s after removing tenant %d: %v",
+			userID, tenantID, err)
+	}
 }
 
 // emitRemovalAudit picks AuditActionMemberLeft when the caller is

--- a/internal/application/service/tenant_member_test.go
+++ b/internal/application/service/tenant_member_test.go
@@ -253,11 +253,148 @@ var _ interfaces.TenantMemberRepository = (*fakeTenantMemberRepo)(nil)
 
 func newServiceWithRepo() (interfaces.TenantMemberService, *fakeTenantMemberRepo) {
 	r := newFakeRepo()
-	// Audit dependency is intentionally nil — these tests pre-date PR 6
-	// and exercise membership invariants only. The service's audit
-	// hooks are nil-safe (see emitAudit), so passing nil keeps existing
-	// coverage intact without forcing a stub.
-	return NewTenantMemberService(r, nil), r
+	// Audit / user / token dependencies are intentionally nil — these
+	// tests pre-date PR 6 and exercise membership invariants only. The
+	// service's audit and RemoveMember-cleanup hooks are nil-safe, so
+	// passing nil keeps existing coverage intact without forcing stubs.
+	return NewTenantMemberService(r, nil, nil, nil), r
+}
+
+// cleanupUserRepo is a minimal UserRepository used to assert that
+// RemoveMember clears dangling home-tenant pointers (#2586).
+type cleanupUserRepo struct {
+	users map[string]*types.User
+}
+
+func (r *cleanupUserRepo) CreateUser(context.Context, *types.User) error { return nil }
+func (r *cleanupUserRepo) GetUserByID(_ context.Context, id string) (*types.User, error) {
+	u, ok := r.users[id]
+	if !ok {
+		return nil, errors.New("user not found")
+	}
+	cp := *u
+	return &cp, nil
+}
+func (r *cleanupUserRepo) GetUsersByIDs(context.Context, []string) (map[string]*types.User, error) {
+	return nil, nil
+}
+func (r *cleanupUserRepo) GetUserByEmail(context.Context, string) (*types.User, error) {
+	return nil, nil
+}
+func (r *cleanupUserRepo) GetUserByUsername(context.Context, string) (*types.User, error) {
+	return nil, nil
+}
+func (r *cleanupUserRepo) GetUserByTenantID(context.Context, uint64) (*types.User, error) {
+	return nil, nil
+}
+func (r *cleanupUserRepo) UpdateUser(_ context.Context, user *types.User) error {
+	cp := *user
+	r.users[user.ID] = &cp
+	return nil
+}
+func (r *cleanupUserRepo) DeleteUser(context.Context, string) error { return nil }
+func (r *cleanupUserRepo) ListUsers(context.Context, int, int) ([]*types.User, error) {
+	return nil, nil
+}
+func (r *cleanupUserRepo) ListSystemAdmins(context.Context, int, int) ([]*types.User, int64, error) {
+	return nil, 0, nil
+}
+func (r *cleanupUserRepo) RevokeSystemAdmin(context.Context, string, string) (*types.User, error) {
+	return nil, nil
+}
+func (r *cleanupUserRepo) SearchUsers(context.Context, string, int) ([]*types.User, error) {
+	return nil, nil
+}
+
+type cleanupTokenRepo struct {
+	revoked []string
+}
+
+func (r *cleanupTokenRepo) CreateToken(context.Context, *types.AuthToken) error { return nil }
+func (r *cleanupTokenRepo) GetTokenByValue(context.Context, string) (*types.AuthToken, error) {
+	return nil, errors.New("not found")
+}
+func (r *cleanupTokenRepo) GetTokensByUserID(context.Context, string) ([]*types.AuthToken, error) {
+	return nil, nil
+}
+func (r *cleanupTokenRepo) UpdateToken(context.Context, *types.AuthToken) error { return nil }
+func (r *cleanupTokenRepo) DeleteToken(context.Context, string) error           { return nil }
+func (r *cleanupTokenRepo) DeleteExpiredTokens(context.Context) error           { return nil }
+func (r *cleanupTokenRepo) RevokeTokensByUserID(_ context.Context, userID string) error {
+	r.revoked = append(r.revoked, userID)
+	return nil
+}
+
+func TestTenantMemberService_RemoveMember_ClearsStaleHomeAndRevokesTokens(t *testing.T) {
+	memberRepo := newFakeRepo()
+	prefTenant := uint64(7)
+	userRepo := &cleanupUserRepo{users: map[string]*types.User{
+		"contrib": {
+			ID:       "contrib",
+			TenantID: 7,
+			Preferences: types.UserPreferences{
+				LastActiveTenantID: &prefTenant,
+			},
+		},
+	}}
+	tokenRepo := &cleanupTokenRepo{}
+	svc := NewTenantMemberService(memberRepo, nil, userRepo, tokenRepo)
+	ctx := context.Background()
+
+	if _, err := svc.EnsureOwner(ctx, "owner", 7); err != nil {
+		t.Fatalf("seed owner: %v", err)
+	}
+	if _, err := svc.AddMember(ctx, "contrib", 7, types.TenantRoleContributor, nil); err != nil {
+		t.Fatalf("seed contributor: %v", err)
+	}
+	if err := svc.RemoveMember(ctx, "contrib", 7); err != nil {
+		t.Fatalf("RemoveMember: %v", err)
+	}
+
+	got := userRepo.users["contrib"]
+	if got == nil {
+		t.Fatal("user missing after cleanup")
+	}
+	if got.TenantID != 0 {
+		t.Fatalf("TenantID = %d, want 0 after home membership removal", got.TenantID)
+	}
+	if got.Preferences.LastActiveTenantID != nil {
+		t.Fatalf("LastActiveTenantID = %v, want nil", got.Preferences.LastActiveTenantID)
+	}
+	if len(tokenRepo.revoked) != 1 || tokenRepo.revoked[0] != "contrib" {
+		t.Fatalf("revoked users = %v, want [contrib]", tokenRepo.revoked)
+	}
+}
+
+func TestTenantMemberService_RemoveMember_RevokesTokensEvenWhenHomeUnchanged(t *testing.T) {
+	// User's home is tenant 1; they are removed from tenant 7. Home
+	// pointer stays, but sessions must still be revoked so a JWT scoped
+	// to tenant 7 cannot keep serving a 403-only UI.
+	memberRepo := newFakeRepo()
+	userRepo := &cleanupUserRepo{users: map[string]*types.User{
+		"contrib": {ID: "contrib", TenantID: 1},
+	}}
+	tokenRepo := &cleanupTokenRepo{}
+	svc := NewTenantMemberService(memberRepo, nil, userRepo, tokenRepo)
+	ctx := context.Background()
+
+	if _, err := svc.EnsureOwner(ctx, "owner", 7); err != nil {
+		t.Fatalf("seed owner: %v", err)
+	}
+	if _, err := svc.AddMember(ctx, "contrib", 7, types.TenantRoleContributor, nil); err != nil {
+		t.Fatalf("seed contributor: %v", err)
+	}
+	if err := svc.RemoveMember(ctx, "contrib", 7); err != nil {
+		t.Fatalf("RemoveMember: %v", err)
+	}
+
+	got := userRepo.users["contrib"]
+	if got.TenantID != 1 {
+		t.Fatalf("TenantID = %d, want home 1 left untouched", got.TenantID)
+	}
+	if len(tokenRepo.revoked) != 1 || tokenRepo.revoked[0] != "contrib" {
+		t.Fatalf("revoked users = %v, want [contrib]", tokenRepo.revoked)
+	}
 }
 
 func TestTenantMemberService_AddMember_RejectsInvalidRole(t *testing.T) {

--- a/internal/application/service/user.go
+++ b/internal/application/service/user.go
@@ -312,16 +312,21 @@ func (s *userService) buildMembershipsForUser(
 	if user == nil {
 		return []types.Membership{}
 	}
+	// Only synthesise a membership from User.TenantID when the membership
+	// service is entirely unavailable (partial DI graphs / legacy tests).
+	// Once ListByUser is reachable, an empty or fully-filtered result is
+	// authoritative: inventing a row from a stale users.tenant_id is what
+	// kept removed workspaces visible in the space switcher (#2586).
 	if s.memberService == nil {
 		return synthFallbackMembership(user, activeTenant)
 	}
 	rows, err := s.memberService.ListByUser(ctx, user.ID)
 	if err != nil {
 		logger.Warnf(ctx, "Failed to list memberships for user %s: %v", user.ID, err)
-		return synthFallbackMembership(user, activeTenant)
+		return []types.Membership{}
 	}
 	if len(rows) == 0 {
-		return synthFallbackMembership(user, activeTenant)
+		return []types.Membership{}
 	}
 	// 收集需要批量查询名称的 tenant id（跳过 activeTenant 因为它已经在手）。
 	needsLookup := make([]uint64, 0, len(rows))
@@ -366,17 +371,18 @@ func (s *userService) buildMembershipsForUser(
 			Role:       m.Role,
 		})
 	}
-	if len(out) == 0 {
-		return synthFallbackMembership(user, activeTenant)
-	}
 	return out
 }
 
 // synthFallbackMembership returns a single-row membership list inferred
-// from User.TenantID. Used when the membership table has not been
-// populated yet (e.g. during the rollout window where the migration has
-// run but the auth middleware's auto-promotion hasn't fired) so the
-// response shape stays consistent.
+// from User.TenantID. Used only when the membership service itself is
+// unavailable (partial DI graphs in tests, or a rollout window where the
+// service has not been wired yet) so the response shape stays consistent.
+//
+// Callers that successfully queried tenant_members must NOT use this
+// helper: an empty membership list is authoritative and synthesising
+// from users.tenant_id would re-surface workspaces the user was removed
+// from (#2586).
 //
 // The fallback role is intentionally TenantRoleViewer (least privilege):
 // the login response only feeds UI rendering, and the backend re-derives
@@ -776,6 +782,14 @@ func (s *userService) resolveLoginTenantID(ctx context.Context, user *types.User
 // token when a usable tenant is available (repairs partial
 // invitation/admin-assignment flows). resolveFirstMembershipTenant
 // best-effort persists the resolved tenant as the new home.
+//
+// When users.tenant_id is non-zero we still verify an active membership
+// still exists (mirroring resolveLoginTenantID's check on
+// LastActiveTenantID). A dangling home pointer is common after
+// RemoveMember: the membership row is soft-deleted but users.tenant_id
+// was historically left untouched, which made the removed workspace
+// reappear via synthFallbackMembership (#2586). Superusers that can
+// access every tenant skip the membership gate.
 func (s *userService) homeOrFirstMembershipTenant(ctx context.Context, user *types.User) uint64 {
 	if user == nil {
 		return 0
@@ -783,7 +797,42 @@ func (s *userService) homeOrFirstMembershipTenant(ctx context.Context, user *typ
 	if user.TenantID == 0 {
 		return s.resolveFirstMembershipTenant(ctx, user)
 	}
-	return user.TenantID
+	if user.CanAccessAllTenants || s.memberService == nil {
+		return user.TenantID
+	}
+	member, err := s.memberService.GetMembership(ctx, user.ID, user.TenantID)
+	if err == nil && member != nil && member.Status == types.TenantMemberStatusActive {
+		return user.TenantID
+	}
+	logger.Warnf(ctx,
+		"homeOrFirstMembershipTenant: user %s home tenant %d has no active membership, "+
+			"clearing stale home and re-resolving (err=%v)",
+		user.ID, user.TenantID, err)
+	s.clearStaleHomeTenant(ctx, user)
+	return s.resolveFirstMembershipTenant(ctx, user)
+}
+
+// clearStaleHomeTenant best-effort zeroes users.tenant_id (and a
+// LastActiveTenantID that pointed at the same workspace) after the home
+// membership is observed to be gone. Failures are logged but never
+// fail login: the in-memory user is already corrected for this request.
+func (s *userService) clearStaleHomeTenant(ctx context.Context, user *types.User) {
+	if user == nil {
+		return
+	}
+	staleHome := user.TenantID
+	user.TenantID = 0
+	if user.Preferences.LastActiveTenantID != nil && *user.Preferences.LastActiveTenantID == staleHome {
+		user.Preferences.LastActiveTenantID = nil
+	}
+	if s.userRepo == nil {
+		return
+	}
+	if err := s.userRepo.UpdateUser(ctx, user); err != nil {
+		logger.Warnf(ctx,
+			"clearStaleHomeTenant: failed to persist cleared home for user %s (was tenant %d): %v",
+			user.ID, staleHome, err)
+	}
 }
 
 // resolveFirstMembershipTenant makes a tenantless identity usable when an

--- a/internal/application/service/user_provisioning_test.go
+++ b/internal/application/service/user_provisioning_test.go
@@ -94,3 +94,119 @@ func TestResolveLoginTenantIDRepairsTenantlessUserWithMembership(t *testing.T) {
 		t.Fatalf("repair was not persisted: repo=%d user=%d", repo.updatedTenant, user.TenantID)
 	}
 }
+
+// membershipLookupService lets tests control GetMembership independently
+// of ListByUser so we can simulate "home tenant pointer is stale after
+// RemoveMember" without also inventing residual membership rows.
+type membershipLookupService struct {
+	interfaces.TenantMemberService
+	members  []*types.TenantMember
+	byTenant map[uint64]*types.TenantMember
+	listErr  error
+	getErr   error
+}
+
+func (s *membershipLookupService) ListByUser(context.Context, string) ([]*types.TenantMember, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.members, nil
+}
+
+func (s *membershipLookupService) GetMembership(_ context.Context, _ string, tenantID uint64) (*types.TenantMember, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	if s.byTenant != nil {
+		return s.byTenant[tenantID], nil
+	}
+	for _, m := range s.members {
+		if m != nil && m.TenantID == tenantID {
+			return m, nil
+		}
+	}
+	return nil, nil
+}
+
+func TestHomeOrFirstMembershipTenantClearsStaleHome(t *testing.T) {
+	repo := &provisioningUserRepo{}
+	tenantSvc := &provisioningTenantService{}
+	// Home still points at tenant 7, but the membership is gone. Another
+	// active membership on tenant 42 must become the new home.
+	memberSvc := &membershipLookupService{
+		members: []*types.TenantMember{
+			{TenantID: 42, Status: types.TenantMemberStatusActive},
+		},
+		byTenant: map[uint64]*types.TenantMember{},
+	}
+	svc := &userService{userRepo: repo, tenantService: tenantSvc, memberService: memberSvc}
+	stalePref := uint64(7)
+	user := &types.User{
+		ID:       "alice",
+		TenantID: 7,
+		Preferences: types.UserPreferences{
+			LastActiveTenantID: &stalePref,
+		},
+	}
+
+	if got := svc.homeOrFirstMembershipTenant(context.Background(), user); got != 42 {
+		t.Fatalf("resolved tenant = %d, want 42", got)
+	}
+	if user.TenantID != 42 {
+		t.Fatalf("in-memory TenantID = %d, want 42 after repair", user.TenantID)
+	}
+	if user.Preferences.LastActiveTenantID != nil {
+		t.Fatalf("LastActiveTenantID = %v, want nil after stale home clear", user.Preferences.LastActiveTenantID)
+	}
+	if repo.updatedTenant != 42 {
+		t.Fatalf("persisted tenant = %d, want 42", repo.updatedTenant)
+	}
+}
+
+func TestHomeOrFirstMembershipTenantKeepsValidHome(t *testing.T) {
+	memberSvc := &membershipLookupService{
+		byTenant: map[uint64]*types.TenantMember{
+			7: {TenantID: 7, Status: types.TenantMemberStatusActive},
+		},
+	}
+	svc := &userService{memberService: memberSvc}
+	user := &types.User{ID: "alice", TenantID: 7}
+
+	if got := svc.homeOrFirstMembershipTenant(context.Background(), user); got != 7 {
+		t.Fatalf("resolved tenant = %d, want 7", got)
+	}
+	if user.TenantID != 7 {
+		t.Fatalf("TenantID mutated to %d, want 7", user.TenantID)
+	}
+}
+
+func TestBuildLoginMembershipsDoesNotSynthFromStaleHome(t *testing.T) {
+	// Reproduces #2586: membership table is authoritative and empty after
+	// RemoveMember, but users.tenant_id still points at the removed space.
+	// The space switcher must NOT receive a synthesised membership row.
+	memberSvc := &membershipLookupService{members: nil}
+	svc := &userService{memberService: memberSvc}
+	user := &types.User{ID: "alice", TenantID: 7}
+	active := &types.Tenant{ID: 7, Name: "Removed Space"}
+
+	got := svc.BuildLoginMemberships(context.Background(), user, active)
+	if got == nil {
+		t.Fatal("memberships must be non-nil (empty array contract)")
+	}
+	if len(got) != 0 {
+		t.Fatalf("memberships = %#v, want empty (no synth from stale TenantID)", got)
+	}
+}
+
+func TestBuildLoginMembershipsSynthsWhenMemberServiceMissing(t *testing.T) {
+	// Partial DI graphs (tests / legacy wiring) still get the single-row
+	// fallback so login responses keep a stable shape.
+	svc := &userService{}
+	user := &types.User{ID: "alice", TenantID: 7}
+	active := &types.Tenant{ID: 7, Name: "Home"}
+
+	got := svc.BuildLoginMemberships(context.Background(), user, active)
+	if len(got) != 1 || got[0].TenantID != 7 || got[0].TenantName != "Home" {
+		t.Fatalf("fallback memberships = %#v", got)
+	}
+}


### PR DESCRIPTION
## Description
When a member is removed from a workspace, `RemoveMember` soft-deletes the `tenant_members` row but historically left `users.tenant_id` / `LastActiveTenantID` pointing at the removed workspace. On the next login, `homeOrFirstMembershipTenant` trusted the dangling home pointer and `buildMembershipsForUser` synthesised a Viewer membership from it, so the removed workspace stayed in the space switcher while every API call returned 403.

This change applies both fixes from #2586:

1. **RemoveMember cleanup** — after a successful soft-delete, best-effort clear `users.tenant_id` / `LastActiveTenantID` when they still reference the removed tenant, and revoke outstanding auth tokens so sessions scoped to that workspace cannot keep serving a broken UI.
2. **Login-path defence** — `homeOrFirstMembershipTenant` now verifies the home tenant still has an active membership (same idea as `resolveLoginTenantID` for preferences). When the membership service is available, an empty `ListByUser` result is treated as authoritative and no longer falls back to synthesising a membership from `users.tenant_id`.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #2586

## Testing
```bash
gofmt -w internal/application/service/tenant_member.go \
  internal/application/service/tenant_member_test.go \
  internal/application/service/user.go \
  internal/application/service/user_provisioning_test.go
go test ./internal/application/service/ -count=1 \
  -run 'TestTenantMemberService_RemoveMember|TestHomeOrFirst|TestBuildLoginMemberships|TestResolveLoginTenantID|TestUserServiceRegisterTenantless'
go build -o /dev/null ./internal/application/service/ ./internal/container/
```
Result: `ok github.com/Tencent/WeKnora/internal/application/service` and container package builds.

New coverage:
- `TestTenantMemberService_RemoveMember_ClearsStaleHomeAndRevokesTokens`
- `TestTenantMemberService_RemoveMember_RevokesTokensEvenWhenHomeUnchanged`
- `TestHomeOrFirstMembershipTenantClearsStaleHome`
- `TestHomeOrFirstMembershipTenantKeepsValidHome`
- `TestBuildLoginMembershipsDoesNotSynthFromStaleHome`
- `TestBuildLoginMembershipsSynthsWhenMemberServiceMissing`

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above