### PR TITLE
feat(frontend): select all documents across pages

### DIFF
--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -35,6 +35,7 @@ import {
   batchReparseKnowledge,
   getKnowledgeSpans,
   getKnowledgeDetails,
+  listKnowledgeFiles,
   listKnowledgeFolders,
   moveKnowledgeToFolder,
   renameKnowledgeFolder,
@@ -1999,15 +2000,57 @@ const onCardGridCheckboxChange = (id: string, checked: boolean, ctx?: { e?: Even
   toggleSelectRow(id, checked, !!me?.shiftKey);
 };
 
-const toggleSelectAll = (checked: boolean) => {
-  if (checked) {
-    for (const item of cardList.value || []) selectedIds.value.add(item.id);
-  } else {
-    for (const item of cardList.value || []) selectedIds.value.delete(item.id);
+// Select all across pages: the list is loaded incrementally via infinite
+// scroll, so cardList only holds the loaded window. When the header checkbox
+// is checked, fetch every document id matching the current filters from the
+// backend page by page; otherwise only the loaded slice would be selected.
+// The backend caps page_size at 1000.
+const SELECT_ALL_PAGE_SIZE = 1000;
+const selectAllAcrossPages = ref(false);
+const selectAllLoading = ref(false);
+let selectAllGeneration = 0;
+
+const toggleSelectAll = async (checked: boolean) => {
+  if (!checked) {
+    clearSelection();
+    return;
+  }
+  for (const item of cardList.value || []) selectedIds.value.add(item.id);
+  selectAllAcrossPages.value = true;
+  if (cardList.value.length >= total.value) return;
+  const currentKbId = kbId.value;
+  if (!currentKbId) return;
+  const generation = ++selectAllGeneration;
+  selectAllLoading.value = true;
+  try {
+    let pageNum = 1;
+    while (true) {
+      const res: any = await listKnowledgeFiles(currentKbId, {
+        page: pageNum,
+        page_size: SELECT_ALL_PAGE_SIZE,
+        ...filterParams.value,
+      });
+      // The user cancelled select-all or switched filters/kb while fetching:
+      // discard this result.
+      if (generation !== selectAllGeneration || !isCurrentKb(currentKbId)) return;
+      const items = res?.data || [];
+      const totalAll = res?.total || 0;
+      for (const it of items) {
+        if (it?.id) selectedIds.value.add(it.id);
+      }
+      if (items.length === 0 || pageNum * SELECT_ALL_PAGE_SIZE >= totalAll) break;
+      pageNum++;
+    }
+  } catch {
+    // Keep the partially selected ids if the fetch fails midway.
+  } finally {
+    if (generation === selectAllGeneration) selectAllLoading.value = false;
   }
 };
 
 const clearSelection = () => {
+  selectAllGeneration++;
+  selectAllAcrossPages.value = false;
   selectedIds.value.clear();
   lastSelectedIndex = -1;
 };
@@ -2197,6 +2240,9 @@ watch(cardList, () => {
     moreIndex.value = -1;
   }
   if (selectedIds.value.size === 0) return;
+  // With select-all across pages, selectedIds intentionally contains ids
+  // outside the loaded window; don't prune them against the visible list.
+  if (selectAllAcrossPages.value) return;
   const visible = new Set(items.map((i: KnowledgeCard) => i.id));
   for (const id of selectedIds.value) {
     if (!visible.has(id)) selectedIds.value.delete(id);
@@ -2629,7 +2675,8 @@ async function createNewSession(value: string): Promise<void> {
               </div>
               <div class="doc-batch-bar-anchor" v-show="batchMode || selectedIds.size > 0">
                 <DocumentBatchBar :count="selectedIds.size" :delete-loading="batchDeleting"
-                  :reparse-loading="batchReparsing" :tag-loading="batchTagging" :visible="batchMode || selectedIds.size > 0"
+                  :reparse-loading="batchReparsing" :tag-loading="batchTagging" :select-all-loading="selectAllLoading"
+                  :visible="batchMode || selectedIds.size > 0"
                   :show-move-to-folder="canEdit" :folder-options="folderOptions"
                   @cancel="handleBatchCancel" @delete="confirmBatchDelete" @reparse="confirmBatchReparse"
                   @batch-tag="handleBatchTag"

--- a/frontend/src/views/knowledge/components/DocumentBatchBar.vue
+++ b/frontend/src/views/knowledge/components/DocumentBatchBar.vue
@@ -8,6 +8,9 @@ defineProps<{
   deleteLoading?: boolean;
   reparseLoading?: boolean;
   tagLoading?: boolean;
+  // Select-all across pages is still fetching every matched id: disable the
+  // action buttons so operations don't run on an incomplete selection.
+  selectAllLoading?: boolean;
   // When true the bar stays visible even with 0 selections, so users can exit
   // batch mode from here without selecting anything first.
   visible?: boolean;
@@ -35,6 +38,7 @@ const folderPickerVisible = ref(false);
       :aria-label="t('knowledgeBase.selectedCount', { count })">
       <div class="batch-bar-inner">
         <div class="batch-bar-left">
+          <t-loading v-if="selectAllLoading" size="12px" class="batch-bar-loading" />
           <span class="batch-bar-count">{{ t('knowledgeBase.selectedCount', { count }) }}</span>
           <t-button variant="text" theme="default" size="small" class="batch-bar-clear" @click="emit('cancel')">
             {{ t('knowledgeBase.clearSelection') }}
@@ -45,14 +49,14 @@ const folderPickerVisible = ref(false);
             :confirm-btn="{ content: t('knowledgeBase.confirmBatchReparse'), theme: 'warning' }"
             :cancel-btn="{ content: t('common.cancel') }" placement="top" @confirm="emit('reparse')">
             <t-button theme="default" variant="outline" size="small"
-              :disabled="count === 0 || deleteLoading || reparseLoading || tagLoading" :loading="reparseLoading" @click.stop>
+              :disabled="count === 0 || deleteLoading || reparseLoading || tagLoading || selectAllLoading" :loading="reparseLoading" @click.stop>
               <template #icon><t-icon name="refresh" size="14px" /></template>
               {{ t('knowledgeBase.rebuildDocument') }}
             </t-button>
           </t-popconfirm>
 
           <t-button theme="default" variant="outline" size="small"
-            :disabled="count === 0 || deleteLoading || reparseLoading || tagLoading" :loading="tagLoading"
+            :disabled="count === 0 || deleteLoading || reparseLoading || tagLoading || selectAllLoading" :loading="tagLoading"
             @click="emit('batchTag')">
             <template #icon><t-icon name="discount" size="14px" /></template>
             {{ t('knowledgeBase.batchTag') }}
@@ -61,7 +65,7 @@ const folderPickerVisible = ref(false);
           <t-popup v-if="showMoveToFolder" v-model:visible="folderPickerVisible" trigger="click"
             placement="top" overlay-class-name="card-more" destroy-on-close>
             <t-button theme="default" variant="outline" size="small"
-              :disabled="count === 0 || deleteLoading || reparseLoading || tagLoading">
+              :disabled="count === 0 || deleteLoading || reparseLoading || tagLoading || selectAllLoading">
               <template #icon><t-icon name="folder" size="14px" /></template>
               {{ t('knowledgeBase.moveToFolder.action') }}
             </t-button>
@@ -77,7 +81,7 @@ const folderPickerVisible = ref(false);
             :confirm-btn="{ content: t('knowledgeBase.confirmDelete'), theme: 'danger' }"
             :cancel-btn="{ content: t('common.cancel') }" placement="top" @confirm="emit('delete')">
             <t-button theme="danger" variant="outline" size="small"
-              :disabled="count === 0 || deleteLoading || reparseLoading || tagLoading" :loading="deleteLoading" @click.stop>
+              :disabled="count === 0 || deleteLoading || reparseLoading || tagLoading || selectAllLoading" :loading="deleteLoading" @click.stop>
               <template #icon><t-icon name="delete" size="14px" /></template>
               {{ t('knowledgeBase.batchDelete') }}
             </t-button>
@@ -124,6 +128,12 @@ const folderPickerVisible = ref(false);
   font-weight: 500;
   color: var(--td-text-color-secondary);
   white-space: nowrap;
+}
+
+.batch-bar-loading {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
 }
 
 .batch-bar-clear {


### PR DESCRIPTION
## 问题

文档列表采用无限滚动加载，`cardList` 只保存已加载的窗口。
表头"全选"只能选中已加载的部分，想要选中靠后的文档，
用户必须一直向下滚动直到所有页面加载完成，操作繁琐且容易遗漏。

## 改动

- 勾选全选时，按当前筛选条件从后端逐页拉取全部命中的文档 id
  （page_size 取后端上限 1000），与列表筛选条件保持一致。
- 拉取期间批量操作栏显示 loading 指示，并禁用删除/重建/标签/
  移动等操作按钮，避免对尚未拉全的选择集执行操作。
- 通过 generation 计数处理竞态：拉取过程中用户取消全选、
  切换筛选条件或知识库时，丢弃本次拉取结果。
- 跨页全选激活期间，列表刷新不再按可见项裁剪选择集
  （选择集本来就包含未加载窗口内的 id）。

## 关联

本功能让选中超过 200 个文档变得容易，依赖配套的批量提交修复：
https://github.com/Tencent/WeKnora/pull/2588（按 200 分批提交，避免后端 400）。
建议两个 PR 一并合入。

## 测试

- 知识库文档超过一屏时勾选全选：自动拉取全部文档 id，
  批量操作栏计数随拉取增长直至总数。
- 拉取过程中取消全选/切换筛选：选择集被正确清空，无残留。
