### PR TITLE
fix(query-understand): LLM 输出不可解析时应回退到原始查询输入

### DIFF
--- a/internal/application/service/chat_pipeline/query_understand.go
+++ b/internal/application/service/chat_pipeline/query_understand.go
@@ -334,11 +334,7 @@ func (p *PluginQueryUnderstand) parseOutput(chatManage *types.ChatManage, raw st
 		return
 	}
 
-	// If JSON parsing failed entirely, treat the raw text as the rewritten query
-	// and default to IntentKBSearch for safety.
-	if content != "" {
-		chatManage.RewriteQuery = content
-	}
+	// On parse failure, keep the original query and intent.
 }
 
 func parseStructuredQueryOutput(raw string) (queryUnderstandOutput, bool) {

--- a/internal/application/service/chat_pipeline/query_understand_test.go
+++ b/internal/application/service/chat_pipeline/query_understand_test.go
@@ -85,3 +85,67 @@ func TestApplyIntentPromptOverride_GlobalOnly(t *testing.T) {
 		t.Errorf("override: got %q, want %q", cm.SystemPromptOverride, "hi there")
 	}
 }
+
+// TestParseOutput_UnparsableFallsBackToOriginalQuery pins the degradation
+// contract for query understanding: when the LLM returns output that cannot be
+// parsed as the structured {"rewrite_query","intent",...} JSON, RewriteQuery
+// must remain the original user query (which OnEvent sets before calling
+// parseOutput) instead of leaking the raw model text into the downstream
+// retrieval query.
+func TestParseOutput_UnparsableFallsBackToOriginalQuery(t *testing.T) {
+	p := &PluginQueryUnderstand{}
+	cm := &types.ChatManage{
+		PipelineState: types.PipelineState{
+			RewriteQuery: "original user query",
+			Intent:       types.IntentKBSearch,
+		},
+	}
+
+	p.parseOutput(cm, "The answer is: check the admin console")
+
+	if cm.RewriteQuery != "original user query" {
+		t.Fatalf("RewriteQuery = %q, want original user query", cm.RewriteQuery)
+	}
+	if cm.Intent != types.IntentKBSearch {
+		t.Errorf("Intent = %q, want kb_search", cm.Intent)
+	}
+}
+
+// TestParseOutput_UnparsableBlankDoesNotRewrite verifies that empty LLM output
+// also leaves the original query untouched.
+func TestParseOutput_UnparsableBlankDoesNotRewrite(t *testing.T) {
+	p := &PluginQueryUnderstand{}
+	cm := &types.ChatManage{
+		PipelineState: types.PipelineState{
+			RewriteQuery: "original user query",
+			Intent:       types.IntentKBSearch,
+		},
+	}
+
+	p.parseOutput(cm, "   \n\t  ")
+
+	if cm.RewriteQuery != "original user query" {
+		t.Fatalf("RewriteQuery = %q, want original user query", cm.RewriteQuery)
+	}
+}
+
+// TestParseOutput_ValidJSONStillAppliesRewrite guards the happy path: a
+// well-formed structured output still overrides RewriteQuery and Intent.
+func TestParseOutput_ValidJSONStillAppliesRewrite(t *testing.T) {
+	p := &PluginQueryUnderstand{}
+	cm := &types.ChatManage{
+		PipelineState: types.PipelineState{
+			RewriteQuery: "original user query",
+			Intent:       types.IntentKBSearch,
+		},
+	}
+
+	p.parseOutput(cm, `{"rewrite_query":"rewritten query","intent":"summarize"}`)
+
+	if cm.RewriteQuery != "rewritten query" {
+		t.Fatalf("RewriteQuery = %q, want rewritten query", cm.RewriteQuery)
+	}
+	if cm.Intent != types.IntentSummarize {
+		t.Errorf("Intent = %q, want summarize", cm.Intent)
+	}
+}


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

查询理解阶段（`PluginQueryUnderstand`）调用 LLM 将用户查询改写为检索友好的形式，期望返回结构化的 JSON：

```json
{"rewrite_query": "改写后的查询", "intent": "kb_search"}
```

当 LLM 输出无法解析为上述结构时，`parseOutput` 的失败路径会把**整段未解析的模型回复原文**写入 `chatManage.RewriteQuery`。

`RewriteQuery` 是后续检索管线（Chunk Search、Rerank、Query Expansion）的检索输入。`OnEvent` 在调用 `parseOutput` 之前已把 `RewriteQuery` 设为原始用户查询，本意是”无法改写时退回原话检索”，但失败路径把整段未解析的模型回复原文覆盖进去，这会导致检索偏离。

改动：删除 `parseOutput` 失败路径中对 `RewriteQuery` 的覆盖。解析失败时 `RewriteQuery` 保持原始用户查询。这样后续管线按照原始用户查询降级。

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->

`internal/application/service/chat_pipeline/query_understand_test.go`

- `TestParseOutput_UnparsableFallsBackToOriginalQuery`：非 JSON 输出时 `RewriteQuery` 保持原始用户查询（修复前失败）。
- `TestParseOutput_UnparsableBlankDoesNotRewrite`：空输出不覆盖原查询。
- `TestParseOutput_ValidJSONStillAppliesRewrite`：合法 JSON 输出仍正常改写。

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
