### PR TITLE
fix(embedding): pace sub-batches and avoid whole-document 429 retries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -327,8 +327,13 @@ RETRIEVE_DRIVER=postgres
 OLLAMA_OPTIONAL=true
 # Ollama 服务基准 URL（连接本地/远程 Ollama）。
 OLLAMA_BASE_URL=http://host.docker.internal:11434
-# 批量 embedding 大小（留空走代码默认）。
+# 批量 embedding 大小（留空走代码默认 5）。
 # BATCH_EMBED_SIZE=
+# 子批次请求最小间隔（毫秒）。配合 WEKNORA_MODEL_MAX_CONCURRENCY 限制 RPM/TPM；
+# 0 或不设 = 不额外限速（仍保留并发上限与 429 退避）。大文档遇 429 时可设 50–200。
+# EMBED_REQUEST_INTERVAL_MS=
+# 子批次失败后的最大重试次数（只重试失败批次，不重放整篇文档；默认 3）。
+# EMBED_BATCH_MAX_RETRIES=
 # VLM 单次 HTTP 请求超时（秒，默认 180；慢端点超时报 context deadline 时调大）。
 # VLM_HTTP_TIMEOUT_SECONDS=180
 # LLM 流原始转储（排查上下文问题；1 启用，默认目录 ~/.weknora/investigate/llm-stream）。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -249,8 +249,10 @@ services:
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
       # Ollama 不可用时仅告警不阻断（true 时生效）
       - OLLAMA_OPTIONAL=${OLLAMA_OPTIONAL:-true}
-      # 批量 embedding 大小
+      # 批量 embedding 大小 / 子批次速率 pacing / 失败子批次重试（见 .env.example）
       - BATCH_EMBED_SIZE=${BATCH_EMBED_SIZE:-}
+      - EMBED_REQUEST_INTERVAL_MS=${EMBED_REQUEST_INTERVAL_MS:-}
+      - EMBED_BATCH_MAX_RETRIES=${EMBED_BATCH_MAX_RETRIES:-}
       # VLM 单次 HTTP 请求超时（秒，默认 180）
       - VLM_HTTP_TIMEOUT_SECONDS=${VLM_HTTP_TIMEOUT_SECONDS:-}
       # LLM 流原始转储（排查上下文问题；1 启用，默认目录 ~/.weknora/investigate/llm-stream）

--- a/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
+++ b/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
@@ -2,6 +2,7 @@ package retriever
 
 import (
 	"context"
+	"errors"
 	"regexp"
 	"slices"
 	"strings"
@@ -23,11 +24,16 @@ import (
 // kicks in for genuinely pathological inputs.
 const safetyMaxChars = 20000
 
-// embedRetryAttempts and embedRetryBaseDelay control the exponential backoff
-// applied to BatchEmbedWithPool calls.
+// embedRetryAttempts and embedRetryBaseDelay control the outer exponential
+// backoff applied to BatchEmbedWithPool calls. Sub-batch failures (including
+// 429) are already retried inside BatchEmbedWithPool; this outer loop is a
+// last-resort safety net for whole-call failures and deliberately uses a
+// longer base delay so rate-limited providers are not immediately re-slammed.
 const (
-	embedRetryAttempts  = 5
-	embedRetryBaseDelay = 200 * time.Millisecond
+	embedRetryAttempts     = 5
+	embedRetryBaseDelay    = 500 * time.Millisecond
+	embedRetryMaxDelay     = 16 * time.Second
+	embedRetryRateLimitMin = 2 * time.Second
 )
 
 var embeddingImagePayloadPatterns = []*regexp.Regexp{
@@ -126,8 +132,11 @@ func (v *KeywordsVectorHybridRetrieveEngineService) BatchIndex(ctx context.Conte
 }
 
 // batchEmbedWithBackoff calls BatchEmbedWithPool with exponential backoff on
-// transient failures (200 / 400 / 800 / 1600 / 3200 ms). It returns the last
-// embedding result on success or the last error if every attempt failed.
+// transient failures. BatchEmbedWithPool itself already preserves successful
+// sub-batches and retries only the failed ones; this outer loop covers the
+// rare case where the whole call still fails (e.g. every sub-batch 429'd).
+// Rate-limit errors force a longer floor delay so we do not re-amplify RPM
+// pressure within a few hundred milliseconds.
 func batchEmbedWithBackoff(ctx context.Context, embedder embedding.Embedder, contentList []string) ([][]float32, error) {
 	delay := embedRetryBaseDelay
 	var (
@@ -140,13 +149,30 @@ func batchEmbedWithBackoff(ctx context.Context, embedder embedding.Embedder, con
 			return embeddings, nil
 		}
 		logger.Errorf(ctx, "BatchEmbedWithPool attempt %d/%d failed: %v", attempt+1, embedRetryAttempts, err)
-		if attempt+1 < embedRetryAttempts {
-			select {
-			case <-time.After(delay):
-			case <-ctx.Done():
-				return nil, ctx.Err()
+		if attempt+1 >= embedRetryAttempts {
+			break
+		}
+		wait := delay
+		if embedding.IsRateLimitError(err) {
+			if wait < embedRetryRateLimitMin {
+				wait = embedRetryRateLimitMin
 			}
-			delay *= 2
+			var rl *embedding.RateLimitError
+			if errors.As(err, &rl) && rl.RetryAfter > wait {
+				wait = rl.RetryAfter
+			}
+		}
+		if wait > embedRetryMaxDelay {
+			wait = embedRetryMaxDelay
+		}
+		select {
+		case <-time.After(wait):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		delay *= 2
+		if delay > embedRetryMaxDelay {
+			delay = embedRetryMaxDelay
 		}
 	}
 	return embeddings, err

--- a/internal/models/embedding/batch.go
+++ b/internal/models/embedding/batch.go
@@ -2,13 +2,28 @@ package embedding
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"sync"
+	"time"
 
+	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/models/utils"
 	"github.com/panjf2000/ants/v2"
+)
+
+// Defaults for the batch pool. Overridable via env without rebuilding:
+//
+//	BATCH_EMBED_SIZE            – texts per provider call (default 5)
+//	EMBED_REQUEST_INTERVAL_MS   – min spacing between sub-batch starts (default 0)
+//	EMBED_BATCH_MAX_RETRIES     – retries for failed sub-batches only (default 3)
+const (
+	defaultBatchEmbedSize      = 5
+	defaultBatchMaxRetries     = 3
+	defaultBatchRetryBaseDelay = 500 * time.Millisecond
+	defaultBatchRetryMaxDelay  = 15 * time.Second
 )
 
 type batchEmbedder struct {
@@ -24,81 +39,238 @@ type textEmbedding struct {
 	results []float32
 }
 
+// batchJob is one sub-batch of texts submitted to the provider together.
+type batchJob struct {
+	items []*textEmbedding
+	err   error
+}
+
+// BatchEmbedWithPool splits texts into sub-batches, embeds them through the
+// worker pool, and — critically — only retries the sub-batches that failed.
+// Successful results are preserved so a transient 429 on one sub-batch does
+// not force the entire document to be re-embedded (see #2533).
+//
+// Optional rate pacing: when EMBED_REQUEST_INTERVAL_MS > 0, each sub-batch
+// start is spaced by at least that many milliseconds. This complements the
+// concurrency governor (which only caps in-flight calls) by bounding request
+// rate against provider RPM/TPM limits.
 func (e *batchEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string) ([][]float32, error) {
-	// Create goroutine pool for concurrent processing of document chunks
-	var wg sync.WaitGroup
-	var mu sync.Mutex  // For synchronizing access to error
-	var firstErr error // Record the first error that occurs
-	batchSizeStr := os.Getenv("BATCH_EMBED_SIZE")
-	if batchSizeStr == "" {
-		batchSizeStr = "5"
+	if len(texts) == 0 {
+		return [][]float32{}, nil
 	}
-	batchSize, err := strconv.Atoi(batchSizeStr)
+
+	batchSize, err := envInt("BATCH_EMBED_SIZE", defaultBatchEmbedSize)
 	if err != nil {
 		return nil, err
 	}
+	if batchSize < 1 {
+		batchSize = defaultBatchEmbedSize
+	}
+	maxRetries, err := envInt("EMBED_BATCH_MAX_RETRIES", defaultBatchMaxRetries)
+	if err != nil {
+		return nil, err
+	}
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	requestInterval := envDurationMS("EMBED_REQUEST_INTERVAL_MS", 0)
+
 	textEmbeddings := utils.MapSlice(texts, func(text string) *textEmbedding {
 		return &textEmbedding{text: text}
 	})
-
-	// Function to process each document chunk
-	processChunk := func(texts []*textEmbedding) func() {
-		return func() {
-			defer wg.Done()
-			// If an error has already occurred, don't continue processing
-			if firstErr != nil {
-				return
-			}
-			// Embed text
-			embedding, err := model.BatchEmbed(ctx, utils.MapSlice(texts, func(text *textEmbedding) string {
-				return text.text
-			}))
-			if err != nil {
-				mu.Lock()
-				if firstErr == nil {
-					firstErr = err
-				}
-				mu.Unlock()
-				return
-			}
-			if len(embedding) != len(texts) {
-				mu.Lock()
-				if firstErr == nil {
-					firstErr = fmt.Errorf("embedding model returned %d embeddings for %d inputs", len(embedding), len(texts))
-				}
-				mu.Unlock()
-				return
-			}
-			mu.Lock()
-			for i, text := range texts {
-				if text == nil {
-					continue
-				}
-				text.results = embedding[i]
-			}
-			mu.Unlock()
-		}
+	jobs := make([]*batchJob, 0)
+	for _, chunk := range utils.ChunkSlice(textEmbeddings, batchSize) {
+		jobs = append(jobs, &batchJob{items: chunk})
 	}
 
-	// Submit all tasks to the goroutine pool
-	for _, texts := range utils.ChunkSlice(textEmbeddings, batchSize) {
-		wg.Add(1)
-		err := e.pool.Submit(processChunk(texts))
-		if err != nil {
+	// Pace + run a wave of jobs. First wave runs everything; subsequent waves
+	// only include jobs that still lack results.
+	pending := jobs
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if len(pending) == 0 {
+			break
+		}
+		if attempt > 0 {
+			// Honour the longest Retry-After among the failed jobs when the
+			// provider told us how long to wait; otherwise exponential backoff.
+			wait := backoffForFailedJobs(pending, attempt)
+			logger.GetLogger(ctx).Warnf(
+				"BatchEmbedWithPool retrying %d/%d failed sub-batches (attempt %d/%d), waiting %v",
+				len(pending), len(jobs), attempt, maxRetries, wait,
+			)
+			if err := waitCtx(ctx, wait); err != nil {
+				return nil, err
+			}
+		}
+		if err := e.runJobs(ctx, model, pending, requestInterval); err != nil {
 			return nil, err
 		}
+		pending = filterFailedJobs(pending)
 	}
 
-	// Wait for all tasks to complete
-	wg.Wait()
-
-	// Check if any errors occurred
-	if firstErr != nil {
-		return nil, firstErr
+	if len(pending) > 0 {
+		// Surface the first remaining error so callers can log / classify it.
+		return nil, pending[0].err
 	}
 
 	results := utils.MapSlice(textEmbeddings, func(text *textEmbedding) []float32 {
 		return text.results
 	})
+	// Defensive: every text should now have a non-nil vector. A nil result
+	// would only happen if a job reported success without writing — treat as
+	// hard failure so we never index zero-vectors silently.
+	for i, vec := range results {
+		if vec == nil {
+			return nil, fmt.Errorf("embedding missing for text index %d after retries", i)
+		}
+	}
 	return results, nil
+}
+
+// runJobs submits the given jobs to the ants pool (optionally paced) and
+// waits for completion. It does not short-circuit remaining work on the
+// first error: every job gets a chance so successes can be retained.
+func (e *batchEmbedder) runJobs(
+	ctx context.Context,
+	model Embedder,
+	jobs []*batchJob,
+	requestInterval time.Duration,
+) error {
+	var (
+		wg       sync.WaitGroup
+		paceMu   sync.Mutex
+		nextSlot = time.Now()
+	)
+
+	process := func(job *batchJob) func() {
+		return func() {
+			defer wg.Done()
+			if err := ctx.Err(); err != nil {
+				job.err = err
+				return
+			}
+
+			// Rate pacing: reserve the next start slot under the mutex so
+			// concurrent workers queue on distinct slots instead of all
+			// sleeping until the same deadline (thundering herd). The
+			// actual provider call runs outside the lock.
+			if requestInterval > 0 {
+				paceMu.Lock()
+				now := time.Now()
+				var sleep time.Duration
+				if now.Before(nextSlot) {
+					sleep = nextSlot.Sub(now)
+					nextSlot = nextSlot.Add(requestInterval)
+				} else {
+					nextSlot = now.Add(requestInterval)
+				}
+				paceMu.Unlock()
+				if err := waitCtx(ctx, sleep); err != nil {
+					job.err = err
+					return
+				}
+			}
+
+			inputs := utils.MapSlice(job.items, func(t *textEmbedding) string { return t.text })
+			embedding, err := model.BatchEmbed(ctx, inputs)
+			if err != nil {
+				job.err = err
+				return
+			}
+			if len(embedding) != len(job.items) {
+				job.err = fmt.Errorf("embedding model returned %d embeddings for %d inputs",
+					len(embedding), len(job.items))
+				return
+			}
+			for i, text := range job.items {
+				if text == nil {
+					continue
+				}
+				text.results = embedding[i]
+			}
+			job.err = nil
+		}
+	}
+
+	for _, job := range jobs {
+		// Skip jobs that already have results (defensive — filterFailedJobs
+		// should have removed them, but keep the invariant local).
+		if jobHasResults(job) {
+			continue
+		}
+		wg.Add(1)
+		if err := e.pool.Submit(process(job)); err != nil {
+			wg.Done()
+			return err
+		}
+	}
+	wg.Wait()
+	return ctx.Err()
+}
+
+func jobHasResults(job *batchJob) bool {
+	if job == nil || len(job.items) == 0 {
+		return true
+	}
+	for _, item := range job.items {
+		if item == nil || item.results == nil {
+			return false
+		}
+	}
+	return true
+}
+
+func filterFailedJobs(jobs []*batchJob) []*batchJob {
+	var failed []*batchJob
+	for _, job := range jobs {
+		if !jobHasResults(job) {
+			failed = append(failed, job)
+		}
+	}
+	return failed
+}
+
+// backoffForFailedJobs picks a wait duration for the next retry wave.
+// Prefer the largest Retry-After advertised by a RateLimitError; otherwise
+// fall back to jittered exponential backoff based on the attempt number.
+func backoffForFailedJobs(jobs []*batchJob, attempt int) time.Duration {
+	var maxRetryAfter time.Duration
+	for _, job := range jobs {
+		var rl *RateLimitError
+		if errors.As(job.err, &rl) && rl.RetryAfter > maxRetryAfter {
+			maxRetryAfter = rl.RetryAfter
+		}
+	}
+	if maxRetryAfter > 0 {
+		return maxRetryAfter
+	}
+	// attempt is 1-based for the first retry wave.
+	return jitteredBackoff(defaultBatchRetryBaseDelay, attempt-1, defaultBatchRetryMaxDelay)
+}
+
+// envInt reads an integer env var or returns the default. Empty string → default.
+// Non-numeric values return an error so misconfiguration is visible at startup.
+func envInt(name string, def int) (int, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return def, nil
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", name, err)
+	}
+	return v, nil
+}
+
+// envDurationMS reads a millisecond env var into a time.Duration.
+func envDurationMS(name string, def time.Duration) time.Duration {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v < 0 {
+		return def
+	}
+	return time.Duration(v) * time.Millisecond
 }

--- a/internal/models/embedding/batch_test.go
+++ b/internal/models/embedding/batch_test.go
@@ -1,0 +1,128 @@
+package embedding
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/panjf2000/ants/v2"
+)
+
+// stubModel is a minimal Embedder that records BatchEmbed calls and can
+// fail a configurable prefix of each wave so we exercise partial retry.
+type stubModel struct {
+	// failFirstN fails the first N BatchEmbed calls (global counter).
+	failFirstN int32
+	calls      atomic.Int32
+	// textsSeen accumulates every text successfully embedded.
+	successTexts []string
+}
+
+func (m *stubModel) Embed(context.Context, string) ([]float32, error) {
+	return []float32{1}, nil
+}
+
+func (m *stubModel) BatchEmbed(_ context.Context, texts []string) ([][]float32, error) {
+	n := m.calls.Add(1)
+	if int(n) <= int(m.failFirstN) {
+		return nil, &RateLimitError{
+			StatusCode: 429,
+			RetryAfter: 10 * time.Millisecond,
+			Body:       "rate limited",
+		}
+	}
+	out := make([][]float32, len(texts))
+	for i, text := range texts {
+		out[i] = []float32{float32(len(text))}
+		m.successTexts = append(m.successTexts, text)
+	}
+	return out, nil
+}
+
+func (m *stubModel) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string) ([][]float32, error) {
+	return nil, fmt.Errorf("not used")
+}
+func (m *stubModel) GetModelName() string { return "stub" }
+func (m *stubModel) GetDimensions() int   { return 1 }
+func (m *stubModel) GetModelID() string   { return "stub-id" }
+
+func TestBatchEmbedWithPoolRetriesOnlyFailedSubBatches(t *testing.T) {
+	t.Setenv("BATCH_EMBED_SIZE", "2")
+	t.Setenv("EMBED_BATCH_MAX_RETRIES", "3")
+	t.Setenv("EMBED_REQUEST_INTERVAL_MS", "0")
+
+	pool, err := ants.NewPool(4)
+	if err != nil {
+		t.Fatalf("ants.NewPool: %v", err)
+	}
+	defer pool.Release()
+
+	// 6 texts → 3 sub-batches of size 2. Fail the first 2 BatchEmbed
+	// calls (first wave of 3 jobs: 2 fail, 1 succeeds). Second wave
+	// retries only the 2 failures and should succeed without re-calling
+	// the already-successful sub-batch.
+	model := &stubModel{failFirstN: 2}
+	pooler := NewBatchEmbedder(pool)
+
+	texts := []string{"a", "bb", "ccc", "dddd", "eeeee", "ffffff"}
+	got, err := pooler.BatchEmbedWithPool(context.Background(), model, texts)
+	if err != nil {
+		t.Fatalf("BatchEmbedWithPool: %v", err)
+	}
+	if len(got) != len(texts) {
+		t.Fatalf("len(results)=%d, want %d", len(got), len(texts))
+	}
+	for i, text := range texts {
+		if got[i] == nil || got[i][0] != float32(len(text)) {
+			t.Fatalf("result[%d]=%v, want vector with len(text)=%d", i, got[i], len(text))
+		}
+	}
+
+	// 3 calls in wave 1 + 2 retries = 5. Must NOT be 3+3=6 (whole re-run).
+	if calls := model.calls.Load(); calls != 5 {
+		t.Fatalf("BatchEmbed calls = %d, want 5 (3 first wave + 2 retries only)", calls)
+	}
+}
+
+func TestBatchEmbedWithPoolHonoursRequestInterval(t *testing.T) {
+	t.Setenv("BATCH_EMBED_SIZE", "1")
+	t.Setenv("EMBED_BATCH_MAX_RETRIES", "0")
+	t.Setenv("EMBED_REQUEST_INTERVAL_MS", "30")
+
+	pool, err := ants.NewPool(4)
+	if err != nil {
+		t.Fatalf("ants.NewPool: %v", err)
+	}
+	defer pool.Release()
+
+	model := &stubModel{}
+	pooler := NewBatchEmbedder(pool)
+
+	start := time.Now()
+	// 4 single-text batches with 30ms spacing → at least ~90ms total.
+	if _, err := pooler.BatchEmbedWithPool(context.Background(), model, []string{"a", "b", "c", "d"}); err != nil {
+		t.Fatalf("BatchEmbedWithPool: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < 80*time.Millisecond {
+		t.Fatalf("elapsed %v, want >= 80ms with EMBED_REQUEST_INTERVAL_MS=30", elapsed)
+	}
+}
+
+func TestBatchEmbedWithPoolEmptyInput(t *testing.T) {
+	pool, err := ants.NewPool(1)
+	if err != nil {
+		t.Fatalf("ants.NewPool: %v", err)
+	}
+	defer pool.Release()
+	pooler := NewBatchEmbedder(pool)
+	got, err := pooler.BatchEmbedWithPool(context.Background(), &stubModel{}, nil)
+	if err != nil {
+		t.Fatalf("empty input err = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %v, want empty slice", got)
+	}
+}

--- a/internal/models/embedding/openai.go
+++ b/internal/models/embedding/openai.go
@@ -111,19 +111,25 @@ func (e *OpenAIEmbedder) doRequestWithRetry(ctx context.Context, jsonData []byte
 	var err error
 	url := e.baseURL + "/embeddings"
 
+	// pendingWait is set by the 429/5xx branch so the next loop iteration
+	// does not stack an extra exponential backoff on top of Retry-After.
+	var pendingWait time.Duration
+
 	for i := 0; i <= e.maxRetries; i++ {
-		if i > 0 {
-			backoffTime := time.Duration(1<<uint(i-1)) * time.Second
-			if backoffTime > 10*time.Second {
-				backoffTime = 10 * time.Second
+		if pendingWait > 0 {
+			logger.GetLogger(ctx).
+				Infof("OpenAIEmbedder retrying request (%d/%d), waiting %v", i, e.maxRetries, pendingWait)
+			if werr := waitCtx(ctx, pendingWait); werr != nil {
+				return nil, werr
 			}
+			pendingWait = 0
+		} else if i > 0 {
+			// Transport-error backoff (connection failures).
+			backoffTime := jitteredBackoff(time.Second, i-1, 10*time.Second)
 			logger.GetLogger(ctx).
 				Infof("OpenAIEmbedder retrying request (%d/%d), waiting %v", i, e.maxRetries, backoffTime)
-
-			select {
-			case <-time.After(backoffTime):
-			case <-ctx.Done():
-				return nil, ctx.Err()
+			if werr := waitCtx(ctx, backoffTime); werr != nil {
+				return nil, werr
 			}
 		}
 
@@ -150,14 +156,58 @@ func (e *OpenAIEmbedder) doRequestWithRetry(ctx context.Context, jsonData []byte
 		secutils.ApplyCustomHeaders(req, e.customHeaders)
 
 		resp, err = e.httpClient.Do(req)
-		if err == nil {
-			return resp, nil
+		if err != nil {
+			logger.GetLogger(ctx).Errorf("OpenAIEmbedder request failed (attempt %d/%d): %v", i+1, e.maxRetries+1, err)
+			continue
 		}
 
-		logger.GetLogger(ctx).Errorf("OpenAIEmbedder request failed (attempt %d/%d): %v", i+1, e.maxRetries+1, err)
+		// Transport succeeded. Retry 429 / 5xx inside this loop so a single
+		// sub-batch does not immediately bubble up and force a whole-document
+		// re-embed. Non-retriable statuses are returned as-is for BatchEmbed
+		// to translate into a hard error.
+		if shouldRetryHTTPStatus(resp.StatusCode) {
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			fallback := jitteredBackoff(time.Second, i, 10*time.Second)
+			if resp.StatusCode == http.StatusTooManyRequests {
+				rlErr := rateLimitErrorFromResponse(resp.StatusCode, resp.Header.Get("Retry-After"), body, fallback)
+				err = rlErr
+				if i == e.maxRetries {
+					return nil, rlErr
+				}
+				pendingWait = rlErr.RetryAfter
+				logger.GetLogger(ctx).Warnf(
+					"OpenAIEmbedder rate limited (attempt %d/%d), will wait %v: %s",
+					i+1, e.maxRetries+1, pendingWait, rlErr.Body,
+				)
+				continue
+			}
+			// 5xx
+			err = fmt.Errorf("EmbedBatch API temporary error: Http Status %s, Response: %s",
+				resp.Status, truncateForLog(body, 500))
+			if i == e.maxRetries {
+				return nil, err
+			}
+			pendingWait = fallback
+			logger.GetLogger(ctx).Warnf(
+				"OpenAIEmbedder server error (attempt %d/%d), will wait %v: %v",
+				i+1, e.maxRetries+1, pendingWait, err,
+			)
+			continue
+		}
+
+		return resp, nil
 	}
 
 	return nil, err
+}
+
+func truncateForLog(body []byte, max int) string {
+	s := string(body)
+	if len(s) > max {
+		return s[:max] + "... (truncated)"
+	}
+	return s
 }
 
 func (e *OpenAIEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
@@ -225,11 +275,18 @@ func (e *OpenAIEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]fl
 
 	if resp.StatusCode != http.StatusOK {
 		// Log detailed error response from OpenAI API
-		bodyStr := string(body)
-		if len(bodyStr) > 1000 {
-			bodyStr = bodyStr[:1000] + "... (truncated)"
-		}
+		bodyStr := truncateForLog(body, 1000)
 		logger.GetLogger(ctx).Errorf("OpenAIEmbedder EmbedBatch API error: Http Status %s, Response Body: %s", resp.Status, bodyStr)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			// doRequestWithRetry should already have exhausted 429 retries;
+			// surface a typed error so the batch pool can pace remaining work.
+			return nil, rateLimitErrorFromResponse(
+				resp.StatusCode,
+				resp.Header.Get("Retry-After"),
+				body,
+				time.Second,
+			)
+		}
 		return nil, fmt.Errorf("EmbedBatch API error: Http Status %s, Response: %s", resp.Status, bodyStr)
 	}
 

--- a/internal/models/embedding/openai_test.go
+++ b/internal/models/embedding/openai_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 )
 
@@ -41,6 +42,61 @@ func TestOpenAIEmbedderBatchEmbedOmitsDimensionsForFixedSizeModels(t *testing.T)
 
 	if _, ok := requestBody["dimensions"]; ok {
 		t.Fatalf("expected request body to omit dimensions for fixed-size model, got %v", requestBody)
+	}
+}
+
+func TestOpenAIEmbedderRetries429WithRetryAfter(t *testing.T) {
+	t.Setenv("SSRF_WHITELIST", "127.0.0.1")
+
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := hits.Add(1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"embedding":[0.1,0.2],"index":0}]}`))
+	}))
+	defer server.Close()
+
+	embedder, err := NewOpenAIEmbedder("test-key", server.URL, "text-embedding-3-small", 511, 0, "m1", nil)
+	if err != nil {
+		t.Fatalf("NewOpenAIEmbedder: %v", err)
+	}
+	got, err := embedder.BatchEmbed(context.Background(), []string{"hello"})
+	if err != nil {
+		t.Fatalf("BatchEmbed: %v", err)
+	}
+	if len(got) != 1 || len(got[0]) != 2 {
+		t.Fatalf("unexpected embeddings: %#v", got)
+	}
+	if hits.Load() < 2 {
+		t.Fatalf("hits = %d, want >= 2 (429 then success)", hits.Load())
+	}
+}
+
+func TestOpenAIEmbedderExhausts429Retries(t *testing.T) {
+	t.Setenv("SSRF_WHITELIST", "127.0.0.1")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"still limited"}`))
+	}))
+	defer server.Close()
+
+	embedder, err := NewOpenAIEmbedder("test-key", server.URL, "text-embedding-3-small", 511, 0, "m1", nil)
+	if err != nil {
+		t.Fatalf("NewOpenAIEmbedder: %v", err)
+	}
+	// Force a single attempt so the test stays fast.
+	embedder.maxRetries = 0
+	_, err = embedder.BatchEmbed(context.Background(), []string{"hello"})
+	if !IsRateLimitError(err) {
+		t.Fatalf("err = %v, want RateLimitError", err)
 	}
 }
 

--- a/internal/models/embedding/retry.go
+++ b/internal/models/embedding/retry.go
@@ -1,0 +1,128 @@
+package embedding
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RateLimitError is returned when an embedding provider rejects a request
+// with HTTP 429 (or an equivalent rate-limit signal). Callers can inspect
+// RetryAfter to back off without replaying already-successful work.
+type RateLimitError struct {
+	StatusCode int
+	RetryAfter time.Duration
+	Body       string
+}
+
+func (e *RateLimitError) Error() string {
+	if e == nil {
+		return "embedding rate limited"
+	}
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("embedding rate limited: status=%d retry_after=%s body=%s",
+			e.StatusCode, e.RetryAfter, e.Body)
+	}
+	return fmt.Sprintf("embedding rate limited: status=%d body=%s", e.StatusCode, e.Body)
+}
+
+// IsRateLimitError reports whether err (or any wrapped cause) is a rate-limit
+// failure that should be paced rather than treated as a permanent error.
+func IsRateLimitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var rl *RateLimitError
+	if errors.As(err, &rl) {
+		return true
+	}
+	// Fallback for providers that still surface 429 as a plain fmt.Errorf.
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "429") ||
+		strings.Contains(msg, "rate limit") ||
+		strings.Contains(msg, "ratelimit") ||
+		strings.Contains(msg, "too many requests") ||
+		strings.Contains(msg, "accountratelimitexceeded")
+}
+
+// shouldRetryHTTPStatus reports whether a provider HTTP status is worth
+// retrying inside doRequestWithRetry (429 + 5xx).
+func shouldRetryHTTPStatus(code int) bool {
+	return code == http.StatusTooManyRequests || (code >= 500 && code < 600)
+}
+
+// parseRetryAfter interprets a Retry-After header (integer seconds) into a
+// wait duration. Empty / unparseable values fall back to fallback. Zero or
+// negative values are coerced to 100ms so we still yield the scheduler.
+func parseRetryAfter(header string, fallback time.Duration) time.Duration {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return fallback
+	}
+	if secs, err := strconv.Atoi(header); err == nil {
+		if secs <= 0 {
+			return 100 * time.Millisecond
+		}
+		return time.Duration(secs) * time.Second
+	}
+	// Some providers emit Go-style durations ("1.5s"); accept those too.
+	if d, err := time.ParseDuration(header); err == nil {
+		if d <= 0 {
+			return 100 * time.Millisecond
+		}
+		return d
+	}
+	return fallback
+}
+
+// jitteredBackoff returns base * 2^attempt capped at max, with ±20% jitter
+// so concurrent document workers do not thundering-herd the provider.
+func jitteredBackoff(base time.Duration, attempt int, max time.Duration) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+	d := base << uint(attempt)
+	if d > max || d <= 0 {
+		d = max
+	}
+	// ±20% jitter
+	j := time.Duration(float64(d) * (0.8 + 0.4*rand.Float64()))
+	if j < 100*time.Millisecond {
+		return 100 * time.Millisecond
+	}
+	return j
+}
+
+// waitCtx pauses for d or until ctx is cancelled.
+func waitCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// rateLimitErrorFromResponse builds a RateLimitError from a 429 response
+// body + Retry-After header. Body is truncated for log safety.
+func rateLimitErrorFromResponse(statusCode int, retryAfterHeader string, body []byte, fallback time.Duration) *RateLimitError {
+	bodyStr := string(body)
+	if len(bodyStr) > 500 {
+		bodyStr = bodyStr[:500] + "... (truncated)"
+	}
+	return &RateLimitError{
+		StatusCode: statusCode,
+		RetryAfter: parseRetryAfter(retryAfterHeader, fallback),
+		Body:       bodyStr,
+	}
+}

--- a/internal/models/embedding/retry_test.go
+++ b/internal/models/embedding/retry_test.go
@@ -1,0 +1,58 @@
+package embedding
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestParseRetryAfter(t *testing.T) {
+	cases := []struct {
+		header   string
+		fallback time.Duration
+		want     time.Duration
+	}{
+		{"", time.Second, time.Second},
+		{"2", time.Second, 2 * time.Second},
+		{"0", time.Second, 100 * time.Millisecond},
+		{"-1", time.Second, 100 * time.Millisecond},
+		{"1.5s", time.Second, 1500 * time.Millisecond},
+		{"nope", 3 * time.Second, 3 * time.Second},
+	}
+	for _, c := range cases {
+		if got := parseRetryAfter(c.header, c.fallback); got != c.want {
+			t.Fatalf("parseRetryAfter(%q) = %v, want %v", c.header, got, c.want)
+		}
+	}
+}
+
+func TestIsRateLimitError(t *testing.T) {
+	if !IsRateLimitError(&RateLimitError{StatusCode: 429}) {
+		t.Fatal("typed RateLimitError should match")
+	}
+	if !IsRateLimitError(fmt.Errorf("wrap: %w", &RateLimitError{StatusCode: 429})) {
+		t.Fatal("wrapped RateLimitError should match")
+	}
+	if !IsRateLimitError(errors.New("EmbedBatch API error: Http Status 429 Too Many Requests")) {
+		t.Fatal("plain 429 string should match")
+	}
+	if !IsRateLimitError(errors.New("AccountRateLimitExceeded")) {
+		t.Fatal("AccountRateLimitExceeded should match")
+	}
+	if IsRateLimitError(errors.New("invalid api key")) {
+		t.Fatal("unrelated error must not match")
+	}
+	if IsRateLimitError(nil) {
+		t.Fatal("nil must not match")
+	}
+}
+
+func TestShouldRetryHTTPStatus(t *testing.T) {
+	if !shouldRetryHTTPStatus(429) || !shouldRetryHTTPStatus(503) {
+		t.Fatal("429/5xx should be retriable")
+	}
+	if shouldRetryHTTPStatus(400) || shouldRetryHTTPStatus(401) || shouldRetryHTTPStatus(200) {
+		t.Fatal("4xx (non-429) and 200 must not be retriable")
+	}
+}


### PR DESCRIPTION
## Description
Large document ingestion could exceed provider RPM/TPM even when concurrency was set conservatively. Two compounding problems made this worse:

1. `BatchEmbedWithPool` failed fast and discarded successful sub-batches; the outer `batchEmbedWithBackoff` then re-embedded the **entire** document on every 429.
2. The OpenAI-compatible client treated HTTP 429 as a final response (no `Retry-After` handling), so recoverable rate limits became document-level failures within ~12 seconds.

This PR:

- **OpenAI embedder**: retry 429 / 5xx inside `doRequestWithRetry`, honour `Retry-After`, surface typed `RateLimitError`
- **Batch pool**: keep successful sub-batch vectors; retry only failed sub-batches with backoff / Retry-After
- **Optional pacing**: `EMBED_REQUEST_INTERVAL_MS` spaces sub-batch starts (complements concurrency limits)
- **Outer backoff**: longer floor delay when the error is rate-limit related
- **Config**: document + wire `EMBED_REQUEST_INTERVAL_MS` / `EMBED_BATCH_MAX_RETRIES` in `.env.example` and `docker-compose.yml`

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [x] ⚡ Performance improvement
- [x] 🧪 Test
- [x] 🔧 Configuration / Build / CI

## Related Issue
Fixes #2533

## Testing
```bash
gofmt -w internal/models/embedding/*.go \
  internal/application/service/retriever/keywords_vector_hybrid_indexer.go
go test ./internal/models/embedding/ ./internal/application/service/retriever/ -count=1
```
Result: both packages `ok`.

Covered cases:
- partial sub-batch failure → only failed batches retried (5 calls for 3 batches, not 6)
- `EMBED_REQUEST_INTERVAL_MS` pacing
- OpenAI 429 + `Retry-After` then success
- exhausted 429 → typed `RateLimitError`
- `parseRetryAfter` / `IsRateLimitError`

## Config (optional)
```bash
# space sub-batch starts (ms); try 50–200 if provider RPM is tight
EMBED_REQUEST_INTERVAL_MS=100
# max retries for failed sub-batches only (default 3)
EMBED_BATCH_MAX_RETRIES=3
```

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (`.env.example`)
- [ ] Breaking changes are clearly called out in the description above