### PR TITLE
fix(config): 补齐 WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS 的 env 读取

### DIFF
--- a/internal/config/auth_legacy_env_test.go
+++ b/internal/config/auth_legacy_env_test.go
@@ -102,3 +102,55 @@ func TestApplyAuthAndTenantDefaults_DefaultTenantMode(t *testing.T) {
 		}
 	})
 }
+
+// TestApplyAuthAndTenantDefaults_CrossTenantAccess is a regression test for the
+// env-binding gap: viper.AutomaticEnv has no SetEnvPrefix, so
+// WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS is never bound to the nested struct
+// automatically. applyAuthAndTenantDefaults must read it explicitly (like RBAC);
+// without that, only config.yaml's enable_cross_tenant_access would take effect
+// and the documented env override would be silently ignored.
+func TestApplyAuthAndTenantDefaults_CrossTenantAccess(t *testing.T) {
+	t.Run("environment true enables cross-tenant access", func(t *testing.T) {
+		t.Setenv("WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS", "true")
+		cfg := &Config{Tenant: &TenantConfig{EnableCrossTenantAccess: false}}
+
+		applyAuthAndTenantDefaults(cfg)
+
+		if !cfg.Tenant.EnableCrossTenantAccess {
+			t.Fatal("WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS=true should enable cross-tenant access")
+		}
+	})
+
+	t.Run("environment false overrides yaml true", func(t *testing.T) {
+		t.Setenv("WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS", "false")
+		cfg := &Config{Tenant: &TenantConfig{EnableCrossTenantAccess: true}}
+
+		applyAuthAndTenantDefaults(cfg)
+
+		if cfg.Tenant.EnableCrossTenantAccess {
+			t.Fatal("WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS=false should disable cross-tenant access")
+		}
+	})
+
+	t.Run("case-insensitive TRUE also enables", func(t *testing.T) {
+		t.Setenv("WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS", "TRUE")
+		cfg := &Config{Tenant: &TenantConfig{EnableCrossTenantAccess: false}}
+
+		applyAuthAndTenantDefaults(cfg)
+
+		if !cfg.Tenant.EnableCrossTenantAccess {
+			t.Fatal("WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS=TRUE should enable cross-tenant access (case-insensitive)")
+		}
+	})
+
+	t.Run("unset leaves yaml value untouched", func(t *testing.T) {
+		t.Setenv("WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS", "")
+		cfg := &Config{Tenant: &TenantConfig{EnableCrossTenantAccess: true}}
+
+		applyAuthAndTenantDefaults(cfg)
+
+		if !cfg.Tenant.EnableCrossTenantAccess {
+			t.Fatal("empty env should leave the YAML-provided cross-tenant access value untouched")
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -808,6 +808,9 @@ func applyAgentEnvOverrides(cfg *Config) {
 //   - WEKNORA_AUTH_DEFAULT_TENANT_MODE ("create_personal"/"tenantless")
 //   - WEKNORA_TENANT_SELF_SERVICE_CREATION_ENABLED (boolean)
 //   - WEKNORA_TENANT_ENABLE_RBAC      ("true"/"false", case-insensitive)
+//   - WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS ("true"/"false", case-insensitive).
+//     Read explicitly because viper.AutomaticEnv has no SetEnvPrefix, so the
+//     WEKNORA_-prefixed var is not bound to the nested struct automatically.
 //   - WEKNORA_TENANT_MAX_OWNED_PER_USER (integer; <0 disables the cap,
 //     0 falls back to the handler default, >0 enforces that exact cap).
 //     Unparseable / empty values are ignored so a stale shell variable
@@ -857,6 +860,16 @@ func applyAuthAndTenantDefaults(cfg *Config) {
 		// via config.yaml `enable_rbac: false` or the env override.
 		on := true
 		cfg.Tenant.EnableRBAC = &on
+	}
+
+	// WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS mirrors the RBAC switch above.
+	// It must be read explicitly: viper.AutomaticEnv has no SetEnvPrefix, so the
+	// WEKNORA_-prefixed env var is never bound to the nested struct field —
+	// without this block, only config.yaml's enable_cross_tenant_access takes
+	// effect and the documented env override is silently ignored. The default
+	// stays whatever config.yaml provides (false unless set there).
+	if value := strings.TrimSpace(os.Getenv("WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS")); value != "" {
+		cfg.Tenant.EnableCrossTenantAccess = strings.EqualFold(value, "true")
 	}
 
 	if value := strings.TrimSpace(os.Getenv("WEKNORA_TENANT_SELF_SERVICE_CREATION_ENABLED")); value != "" {


### PR DESCRIPTION
## 问题

设置环境变量 `WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS=true` 后，跨租户访问并不生效。启动日志可见明显的自相矛盾：

```
[config] tenant RBAC enforcement: enable_rbac=true cross_tenant_access=false (env: WEKNORA_TENANT_ENABLE_RBAC="" WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS="true")
```

env 明明是 `"true"`，解析结果却是 `false`。这导致 `userInfo.CanAccessAllTenants = user.CanAccessAllTenants && EnableCrossTenantAccess` 恒为 false，跨租户超管看不到跨空间视角。

## 根因

配置加载使用 viper（`internal/config/config.go`）：

```go
viper.AutomaticEnv()
viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
// 没有 viper.SetEnvPrefix("WEKNORA")
```

`AutomaticEnv` 把 key `tenant.enable_cross_tenant_access` 映射成 env 名 `TENANT_ENABLE_CROSS_TENANT_ACCESS`（无 `WEKNORA_` 前缀），与实际变量 `WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS` 对不上，自动绑定失效。

其他租户开关（`ENABLE_RBAC` / `SELF_SERVICE_CREATION_ENABLED` / `MAX_OWNED_PER_USER`）能从 env 生效，是因为它们在 `applyAuthAndTenantDefaults` 里被 `os.Getenv` **手动读取**。唯独 `ENABLE_CROSS_TENANT_ACCESS` 两条路都没接上，`cfg.Tenant.EnableCrossTenantAccess` 始终是 config.yaml 的值（默认 false）。`.env.example`、注释、启动日志都引用了这个变量，让人以为改 env 即可——属代码遗漏。

## 修复

在 `applyAuthAndTenantDefaults` 中补齐手动读取，与 RBAC 采用完全一致的模式：

```go
if value := strings.TrimSpace(os.Getenv("WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS")); value != "" {
    cfg.Tenant.EnableCrossTenantAccess = strings.EqualFold(value, "true")
}
```

未设置时保持 config.yaml 的值不变；同时更新函数文档注释，将该变量列入 env override 清单。

## 测试

新增回归测试 `TestApplyAuthAndTenantDefaults_CrossTenantAccess`，覆盖 env=true / false / 大小写 / 未设置 四种情况，全部通过；既有 config 测试不受影响。