### PR TITLE
docs: fix 登陆 typo to 登录

### DIFF
--- a/docs/KnowledgeGraph.md
+++ b/docs/KnowledgeGraph.md
@@ -23,6 +23,6 @@ docker-compose --profile neo4j up -d
 
 ## 查看图谱
 
-登陆 `http://localhost:7474`，执行 `match (n) return (n)` 即可查看生成的知识图谱。
+登录 `http://localhost:7474`，执行 `match (n) return (n)` 即可查看生成的知识图谱。
 
 在对话时，系统会自动查询知识图谱，并获取相关知识。

--- a/docs/wiki/核心功能/知识图谱.md
+++ b/docs/wiki/核心功能/知识图谱.md
@@ -32,7 +32,7 @@ docker-compose --profile neo4j up -d
 
 ## 查看图谱
 
-登陆 `http://localhost:7474`，执行 `match (n) return (n)` 即可查看生成的知识图谱。
+登录 `http://localhost:7474`，执行 `match (n) return (n)` 即可查看生成的知识图谱。
 
 在对话时，系统会自动查询知识图谱，并获取相关知识。
 

--- a/frontend/src/utils/tenantSwitch.ts
+++ b/frontend/src/utils/tenantSwitch.ts
@@ -12,7 +12,7 @@ const SAFE_FALLBACK_PATH = '/platform/knowledge-bases'
 
 /**
  * Return the URL to navigate to after a tenant switch. 目前始终返回 KB 列表
- * 作为登陆页，保留函数签名是为了未来需要按路由做特殊处理时留个口子。
+ * 作为登录页，保留函数签名是为了未来需要按路由做特殊处理时留个口子。
  */
 export function tenantSwitchTargetPath(_currentPath: string): string {
   return SAFE_FALLBACK_PATH


### PR DESCRIPTION
## Description
Replace the incorrect simplified-Chinese spelling **登陆** with the standard term **登录** in documentation and a frontend comment.

No product or password-policy behavior is changed.

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
N/A (typo cleanup)

## Files
- `docs/KnowledgeGraph.md`
- `docs/wiki/核心功能/知识图谱.md`
- `frontend/src/utils/tenantSwitch.ts` (comment only)

## Checklist
- [x] Self-reviewed the change
- [x] No runtime / policy logic modified