### PR TITLE
fix(vlm): support GPT-5 completion tokens

### DIFF
--- a/internal/models/vlm/remote_api.go
+++ b/internal/models/vlm/remote_api.go
@@ -143,6 +143,11 @@ func (v *RemoteAPIVLM) Predict(ctx context.Context, imgBytesList [][]byte, promp
 		MaxTokens:   defaultMaxToks,
 		Temperature: v.temperature,
 	}
+	if provider.IsOpenAIReasoningOrGPT5Model(v.modelName) {
+		req.MaxCompletionTokens = req.MaxTokens
+		req.MaxTokens = 0
+		req.Temperature = 0
+	}
 
 	totalImageSize := 0
 	for _, img := range imgBytesList {

--- a/internal/models/vlm/remote_api_test.go
+++ b/internal/models/vlm/remote_api_test.go
@@ -1,0 +1,57 @@
+package vlm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+func TestRemoteAPIVLMPredictUsesCompletionTokensForReasoningModels(t *testing.T) {
+	var gotRequest openai.ChatCompletionRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotRequest); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":0,
+			"model":"gpt-5-mini",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"described"},"finish_reason":"stop"}]
+		}`))
+	}))
+	defer server.Close()
+
+	config := openai.DefaultConfig("test-key")
+	config.BaseURL = server.URL
+	model := &RemoteAPIVLM{
+		modelName:   "gpt-5-mini",
+		client:      openai.NewClientWithConfig(config),
+		baseURL:     server.URL,
+		temperature: defaultTemp,
+	}
+
+	result, err := model.Predict(context.Background(), [][]byte{{0x89, 'P', 'N', 'G'}}, "describe")
+	if err != nil {
+		t.Fatalf("Predict() error = %v", err)
+	}
+	if result != "described" {
+		t.Fatalf("Predict() = %q, want described", result)
+	}
+	if gotRequest.MaxTokens != 0 {
+		t.Errorf("MaxTokens = %d, want 0", gotRequest.MaxTokens)
+	}
+	if gotRequest.MaxCompletionTokens != defaultMaxToks {
+		t.Errorf("MaxCompletionTokens = %d, want %d", gotRequest.MaxCompletionTokens, defaultMaxToks)
+	}
+	if gotRequest.Temperature != 0 {
+		t.Errorf("Temperature = %v, want 0", gotRequest.Temperature)
+	}
+}


### PR DESCRIPTION
## Description

Fixes #2537.

`RemoteAPIVLM` always sent `max_tokens` and a non-default `temperature`. The
go-openai client rejects those fields locally for GPT-5 and o-series models,
so image OCR and caption requests failed before reaching the configured
provider and produced no image chunks.

Reuse the existing reasoning-model detector to send
`max_completion_tokens` and omit the unsupported temperature for those models.
Other VLM models keep their existing request shape. A previous implementation
attempt in #2229 was closed unmerged; this patch keeps the correction local to
the VLM request path.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2537

## Testing

Failing before the production change, passing after:

```bash
go test ./internal/models/vlm -run TestRemoteAPIVLMPredictUsesCompletionTokensForReasoningModels -count=1
```

The unchanged base failed with:

```text
OpenAI VLM request: this model is not supported MaxTokens, please use MaxCompletionTokens
```

Passing checks:

```bash
go test ./internal/models/vlm ./internal/models/provider -count=1
go test ./internal/models/... -count=1
go vet -v ./...
git diff --check
```

`go test ./... -count=1` was also run. Every package except
`internal/datasource/connector/feishu/wiki` passed. Its unrelated
`TestFetchAll_LogsSummaryWithSkipBreakdown` assertion received repeated `json`
log lines instead of the expected `stream summary` text; neither changed file
is in that package or logging path.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (repository-wide `go vet -v ./...` passes)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (not required; no public configuration or API changed)
- [x] Breaking changes are clearly called out in the description above (not applicable)

## Screenshots / Recordings

Not applicable; this is a request-shaping fix with a focused HTTP regression test.
