### PR TITLE
fix(wiki): set MaxTokens for generateWithTemplate LLM calls

### DIFF
--- a/internal/application/service/wiki_ingest.go
+++ b/internal/application/service/wiki_ingest.go
@@ -148,6 +148,17 @@ const (
 	// materially prolonging task runtime when the remote is genuinely down.
 	wikiLLMMaxAttempts = 3
 
+	// wikiLLMMaxTokens is the completion-token budget for every LLM call
+	// routed through generateWithTemplate. Combined wiki extraction emits a
+	// single large JSON document (entities + concepts + details). When
+	// MaxTokens is left at 0, OpenAI-compatible clients omit max_tokens and
+	// providers such as DeepSeek apply a default of 8192 — long extracts are
+	// truncated mid-JSON with finish_reason=length, and parse fails with
+	// "unexpected end of JSON input" (EXTRACT_FAILED). Raising the budget to
+	// 32768 matches verified complete outputs for large Chinese policy docs;
+	// shorter replies still stop early via finish_reason=stop. See #2604.
+	wikiLLMMaxTokens = 32768
+
 	// wikiLLMBackoffBase is the base delay for the exponential backoff
 	// between retry attempts. The nth retry waits base << (n-1) — so with
 	// a 2s base we wait 2s, 4s, 8s between attempts.
@@ -2467,7 +2478,7 @@ func (s *wikiIngestService) generateWithTemplate(ctx context.Context, chatModel 
 		)
 	}
 	thinking := false
-	opts := &chat.ChatOptions{Temperature: 0.3, Thinking: &thinking}
+	opts := &chat.ChatOptions{Temperature: 0.3, Thinking: &thinking, MaxTokens: wikiLLMMaxTokens}
 	prefixFingerprint := chat.PromptPrefixFingerprint(messages, opts)
 	warmupKey := ""
 	if promptTpl == agent.WikiPageModifyUserPrompt {

--- a/internal/application/service/wiki_ingest_test.go
+++ b/internal/application/service/wiki_ingest_test.go
@@ -611,3 +611,26 @@ func (r *wikiPendingRepoForCleanupTest) DeleteByDedupKey(
 ) error {
 	return nil
 }
+
+// TestGenerateWithTemplateSetsMaxTokens is a regression for #2604: without an
+// explicit MaxTokens, DeepSeek-class providers default to 8192 completion
+// tokens and truncate combined wiki extraction JSON mid-field.
+func TestGenerateWithTemplateSetsMaxTokens(t *testing.T) {
+	model := &templateCaptureChatModel{response: `{"entities":[],"concepts":[]}`}
+	service := &wikiIngestService{}
+	_, err := service.generateWithTemplate(
+		context.Background(),
+		model,
+		`Content={{.Content}}`,
+		map[string]string{"Content": "hello"},
+	)
+	if err != nil {
+		t.Fatalf("generateWithTemplate() error = %v", err)
+	}
+	if model.options.MaxTokens != wikiLLMMaxTokens {
+		t.Fatalf("MaxTokens = %d, want %d", model.options.MaxTokens, wikiLLMMaxTokens)
+	}
+	if model.options.Thinking == nil || *model.options.Thinking {
+		t.Fatalf("Thinking should be non-nil false, got %#v", model.options.Thinking)
+	}
+}


### PR DESCRIPTION
## Description
Wiki combined extraction (`postprocess.wiki.extract`) builds one large JSON of entities + concepts + details. `generateWithTemplate` previously built `ChatOptions` without `MaxTokens`. On OpenAI-compatible providers this omits `max_tokens`, and DeepSeek defaults completion to **8192**, truncating mid-field (`finish_reason=length`). The truncated payload then fails with:

```text
parse combined extraction JSON: unexpected end of JSON input
EXTRACT_FAILED
```

Graph extraction still succeeded because it issues many small per-chunk calls.

This PR sets `MaxTokens: 32768` for every LLM call through `generateWithTemplate` (same budget verified to complete large Chinese policy-doc extracts in #2604). Shorter replies still stop early via `finish_reason=stop`.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #2604

## Testing
```bash
gofmt -w internal/application/service/wiki_ingest.go internal/application/service/wiki_ingest_test.go
go test ./internal/application/service/ -count=1 -run 'TestGenerateWithTemplate'
```
Result: `ok`.

Covered cases:
- `generateWithTemplate` passes `MaxTokens == wikiLLMMaxTokens` (32768)
- Thinking remains explicitly disabled

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above