### PR TITLE
refactor(handler): extract shared searchResultFromMap

### DIFF
--- a/internal/handler/session/agent_stream_handler.go
+++ b/internal/handler/session/agent_stream_handler.go
@@ -390,28 +390,7 @@ func (h *AgentStreamHandler) handleReferences(ctx context.Context, evt event.Eve
 				h.knowledgeRefs = append(h.knowledgeRefs, sr)
 			} else if refMap, ok := ref.(map[string]interface{}); ok {
 				// Parse from map if needed
-				searchResult := &types.SearchResult{
-					ID:                   getString(refMap, "id"),
-					Content:              getString(refMap, "content"),
-					Score:                getFloat64(refMap, "score"),
-					KnowledgeID:          getString(refMap, "knowledge_id"),
-					KnowledgeTitle:       getString(refMap, "knowledge_title"),
-					ChunkIndex:           int(getFloat64(refMap, "chunk_index")),
-					KnowledgeDescription: getString(refMap, "knowledge_description"),
-					KnowledgeBaseID:      getString(refMap, "knowledge_base_id"),
-				}
-
-				if meta, ok := refMap["metadata"].(map[string]interface{}); ok {
-					metadata := make(map[string]string)
-					for k, v := range meta {
-						if strVal, ok := v.(string); ok {
-							metadata[k] = strVal
-						}
-					}
-					searchResult.Metadata = metadata
-				}
-
-				h.knowledgeRefs = append(h.knowledgeRefs, searchResult)
+				h.knowledgeRefs = append(h.knowledgeRefs, searchResultFromMap(refMap))
 			}
 		}
 	}

--- a/internal/handler/session/helpers.go
+++ b/internal/handler/session/helpers.go
@@ -221,25 +221,7 @@ func buildStreamResponse(evt interfaces.StreamEvent, requestID string) *types.St
 			searchResults := make([]*types.SearchResult, 0, len(refs))
 			for _, ref := range refs {
 				if refMap, ok := ref.(map[string]interface{}); ok {
-					sr := &types.SearchResult{
-						ID:                   getString(refMap, "id"),
-						Content:              getString(refMap, "content"),
-						KnowledgeID:          getString(refMap, "knowledge_id"),
-						ChunkIndex:           int(getFloat64(refMap, "chunk_index")),
-						KnowledgeTitle:       getString(refMap, "knowledge_title"),
-						StartAt:              int(getFloat64(refMap, "start_at")),
-						EndAt:                int(getFloat64(refMap, "end_at")),
-						Seq:                  int(getFloat64(refMap, "seq")),
-						Score:                getFloat64(refMap, "score"),
-						ChunkType:            getString(refMap, "chunk_type"),
-						ParentChunkID:        getString(refMap, "parent_chunk_id"),
-						ImageInfo:            getString(refMap, "image_info"),
-						KnowledgeFilename:    getString(refMap, "knowledge_filename"),
-						KnowledgeSource:      getString(refMap, "knowledge_source"),
-						KnowledgeDescription: getString(refMap, "knowledge_description"),
-						KnowledgeBaseID:      getString(refMap, "knowledge_base_id"),
-					}
-					searchResults = append(searchResults, sr)
+					searchResults = append(searchResults, searchResultFromMap(refMap))
 				}
 			}
 			response.KnowledgeReferences = types.References(searchResults)
@@ -448,6 +430,39 @@ func getFloat64(m map[string]interface{}, key string) float64 {
 		return float64(val)
 	}
 	return 0.0
+}
+
+// searchResultFromMap rebuilds a *types.SearchResult from a map that went
+// through JSON/Redis serialization, preserving all fields including metadata.
+func searchResultFromMap(refMap map[string]interface{}) *types.SearchResult {
+	sr := &types.SearchResult{
+		ID:                   getString(refMap, "id"),
+		Content:              getString(refMap, "content"),
+		KnowledgeID:          getString(refMap, "knowledge_id"),
+		ChunkIndex:           int(getFloat64(refMap, "chunk_index")),
+		KnowledgeTitle:       getString(refMap, "knowledge_title"),
+		StartAt:              int(getFloat64(refMap, "start_at")),
+		EndAt:                int(getFloat64(refMap, "end_at")),
+		Seq:                  int(getFloat64(refMap, "seq")),
+		Score:                getFloat64(refMap, "score"),
+		ChunkType:            getString(refMap, "chunk_type"),
+		ParentChunkID:        getString(refMap, "parent_chunk_id"),
+		ImageInfo:            getString(refMap, "image_info"),
+		KnowledgeFilename:    getString(refMap, "knowledge_filename"),
+		KnowledgeSource:      getString(refMap, "knowledge_source"),
+		KnowledgeDescription: getString(refMap, "knowledge_description"),
+		KnowledgeBaseID:      getString(refMap, "knowledge_base_id"),
+	}
+	if meta, ok := refMap["metadata"].(map[string]interface{}); ok {
+		metadata := make(map[string]string)
+		for k, v := range meta {
+			if strVal, ok := v.(string); ok {
+				metadata[k] = strVal
+			}
+		}
+		sr.Metadata = metadata
+	}
+	return sr
 }
 
 // createDefaultSummaryConfig and fillSummaryConfigDefaults used to build

--- a/internal/handler/session/helpers_test.go
+++ b/internal/handler/session/helpers_test.go
@@ -1,10 +1,12 @@
 package session
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTagScopesFromMentionedItems(t *testing.T) {
@@ -51,4 +53,55 @@ func TestValidateUnscopedTagIDs(t *testing.T) {
 	assert.NoError(t, validateUnscopedTagIDs([]string{"tag-9"}, []string{"kb-1"}))
 	assert.Error(t, validateUnscopedTagIDs([]string{"tag-9"}, []string{"kb-1", "kb-2"}))
 	assert.Error(t, validateUnscopedTagIDs([]string{"tag-9"}, nil))
+}
+
+// TestSearchResultFromMap_RoundTrip simulates the Redis round trip: a
+// *types.SearchResult is serialized to JSON, deserialized into a generic map,
+// and rebuilt via searchResultFromMap. All fields, including metadata, must
+// survive.
+func TestSearchResultFromMap_RoundTrip(t *testing.T) {
+	original := &types.SearchResult{
+		ID:                   "chunk-1",
+		Content:              "first part\nsecond part",
+		KnowledgeID:          "knowledge-1",
+		ChunkIndex:           3,
+		KnowledgeTitle:       "title",
+		StartAt:              10,
+		EndAt:                20,
+		Seq:                  2,
+		Score:                4.5,
+		ChunkType:            "text",
+		ParentChunkID:        "parent-1",
+		ImageInfo:            `[{"url":"cdn.example.com"}]`,
+		KnowledgeFilename:    "doc.txt",
+		KnowledgeSource:      "upload",
+		KnowledgeDescription: "desc",
+		KnowledgeBaseID:      "kb-1",
+		Metadata:             map[string]string{"page": "3"},
+	}
+
+	raw, err := json.Marshal(original)
+	require.NoError(t, err)
+	var refMap map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &refMap))
+
+	got := searchResultFromMap(refMap)
+
+	assert.Equal(t, original.ID, got.ID)
+	assert.Equal(t, original.Content, got.Content)
+	assert.Equal(t, original.KnowledgeID, got.KnowledgeID)
+	assert.Equal(t, original.ChunkIndex, got.ChunkIndex)
+	assert.Equal(t, original.KnowledgeTitle, got.KnowledgeTitle)
+	assert.Equal(t, original.StartAt, got.StartAt)
+	assert.Equal(t, original.EndAt, got.EndAt)
+	assert.Equal(t, original.Seq, got.Seq)
+	assert.Equal(t, original.Score, got.Score)
+	assert.Equal(t, original.ChunkType, got.ChunkType)
+	assert.Equal(t, original.ParentChunkID, got.ParentChunkID)
+	assert.Equal(t, original.ImageInfo, got.ImageInfo)
+	assert.Equal(t, original.KnowledgeFilename, got.KnowledgeFilename)
+	assert.Equal(t, original.KnowledgeSource, got.KnowledgeSource)
+	assert.Equal(t, original.KnowledgeDescription, got.KnowledgeDescription)
+	assert.Equal(t, original.KnowledgeBaseID, got.KnowledgeBaseID)
+	assert.Equal(t, original.Metadata, got.Metadata)
 }


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

`*types.SearchResult` 的反序列化重建（JSON/Redis 往返后从 `map[string]interface{}` 还原）存在两处内联实现，且行为不一致：

- `helpers.go` `buildStreamResponse`（SSE references 路径）：不解析 `metadata`，该字段往返后丢失
- `agent_stream_handler.go` `handleReferences`（agent 流式路径）：不还原 `start_at`/`end_at`/`seq`/`chunk_type` 等字段

提取共享函数 `searchResultFromMap`，实现两处字段并集 + metadata 解析。SSE 路径恢复 `metadata`，agent 路径恢复 `start_at`/`end_at`/`seq`/`chunk_type`

## Type of Change
<!-- Check applicable items -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [x] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->

新增 `TestSearchResultFromMap_RoundTrip` 模拟一次 Redis 往返，所有字段都不应丢失

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
