### PR TITLE
fix(knowledge): bubble embedding model resolution failure for retry

### DIFF
--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -1180,10 +1180,10 @@ func sanitizeManualDownloadFilename(title string) string {
 
 func (s *knowledgeService) triggerManualProcessing(ctx context.Context,
 	kb *types.KnowledgeBase, knowledge *types.Knowledge, content string, doSync bool,
-) {
+) error {
 	clean := strings.TrimSpace(content)
 	if clean == "" {
-		return
+		return nil
 	}
 
 	// Resolve embedded data:base64 images and remote http(s) images → storage, replace URLs.
@@ -1265,10 +1265,21 @@ func (s *knowledgeService) triggerManualProcessing(ctx context.Context,
 	}
 
 	if doSync {
-		s.processChunks(ctx, kb, knowledge, parsed, opts)
-		return
+		return s.processChunks(ctx, kb, knowledge, parsed, opts)
 	}
 
 	newCtx := logger.CloneContext(ctx)
-	go s.processChunks(newCtx, kb, knowledge, parsed, opts)
+	go func() {
+		if err := s.processChunks(newCtx, kb, knowledge, parsed, opts); err != nil {
+			logger.GetLogger(newCtx).WithField("error", err).
+				Errorf("triggerManualProcessing process chunks failed")
+			// No error channel out of the goroutine: mark the row failed so
+			// the UI shows the failure instead of a permanent spinner.
+			knowledge.ParseStatus = types.ParseStatusFailed
+			knowledge.ErrorMessage = err.Error()
+			knowledge.UpdatedAt = time.Now()
+			s.repo.UpdateKnowledge(ctx, knowledge)
+		}
+	}()
+	return nil
 }

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -1274,7 +1274,8 @@ func (s *knowledgeService) triggerManualProcessing(ctx context.Context,
 			logger.GetLogger(newCtx).WithField("error", err).
 				Errorf("triggerManualProcessing process chunks failed")
 			// No error channel out of the goroutine: fail the row in place.
-			s.markKnowledgeFailed(ctx, knowledge, err.Error())
+			// Use the detached context: a cancelled request would otherwise skip the failure write.
+			s.markKnowledgeFailed(newCtx, knowledge, err.Error())
 		}
 	}()
 	return nil

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -1273,12 +1273,8 @@ func (s *knowledgeService) triggerManualProcessing(ctx context.Context,
 		if err := s.processChunks(newCtx, kb, knowledge, parsed, opts); err != nil {
 			logger.GetLogger(newCtx).WithField("error", err).
 				Errorf("triggerManualProcessing process chunks failed")
-			// No error channel out of the goroutine: mark the row failed so
-			// the UI shows the failure instead of a permanent spinner.
-			knowledge.ParseStatus = types.ParseStatusFailed
-			knowledge.ErrorMessage = err.Error()
-			knowledge.UpdatedAt = time.Now()
-			s.repo.UpdateKnowledge(ctx, knowledge)
+			// No error channel out of the goroutine: fail the row in place.
+			s.markKnowledgeFailed(ctx, knowledge, err.Error())
 		}
 	}()
 	return nil

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -3741,9 +3741,14 @@ func (s *knowledgeService) resolveDocReader(ctx context.Context, engine, fileTyp
 	}
 }
 
-// markKnowledgeFailed persists a terminal failed state for the knowledge
-// row: parse_status=failed plus a visible error message.
+// markKnowledgeFailed persists a terminal failed state: parse_status=failed
+// plus a visible error message. Skips when the row was cancelled or is being
+// deleted so a failure cannot overwrite a newer user action.
 func (s *knowledgeService) markKnowledgeFailed(ctx context.Context, knowledge *types.Knowledge, errMsg string) {
+	if aborted, status := s.isKnowledgeAborted(ctx, knowledge.TenantID, knowledge.ID); aborted {
+		logger.Warnf(ctx, "markKnowledgeFailed skipped for %s: row is %s", knowledge.ID, status)
+		return
+	}
 	knowledge.ParseStatus = types.ParseStatusFailed
 	knowledge.ErrorMessage = errMsg
 	knowledge.UpdatedAt = time.Now()

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -149,12 +149,8 @@ func (s *knowledgeService) processDocumentFromPassage(ctx context.Context,
 		}
 	}
 	if err := s.processChunks(ctx, kb, knowledge, chunks, opts); err != nil {
-		// Sync (request-path) processing has no asynq retry loop, so surface
-		// the failure on the row immediately instead of leaving it stuck.
-		knowledge.ParseStatus = types.ParseStatusFailed
-		knowledge.ErrorMessage = err.Error()
-		knowledge.UpdatedAt = time.Now()
-		s.repo.UpdateKnowledge(ctx, knowledge)
+		// No asynq retry loop in the sync path: fail the row immediately.
+		s.markKnowledgeFailed(ctx, knowledge, err.Error())
 	}
 }
 
@@ -3107,10 +3103,7 @@ func (s *knowledgeService) ProcessManualUpdate(ctx context.Context, t *asynq.Tas
 	kb, err := s.kbService.GetKnowledgeBaseByID(ctx, payload.KnowledgeBaseID)
 	if err != nil {
 		logger.Errorf(ctx, "ProcessManualUpdate: failed to get knowledge base: %v", err)
-		knowledge.ParseStatus = "failed"
-		knowledge.ErrorMessage = fmt.Sprintf("failed to get knowledge base: %v", err)
-		knowledge.UpdatedAt = time.Now()
-		s.repo.UpdateKnowledge(ctx, knowledge)
+		s.markKnowledgeFailed(ctx, knowledge, fmt.Sprintf("failed to get knowledge base: %v", err))
 		return nil
 	}
 
@@ -3145,25 +3138,14 @@ func (s *knowledgeService) ProcessManualUpdate(ctx context.Context, t *asynq.Tas
 			logger.ErrorWithFields(ctx, err, map[string]interface{}{
 				"knowledge_id": payload.KnowledgeID,
 			})
-			knowledge.ParseStatus = "failed"
-			knowledge.ErrorMessage = fmt.Sprintf("failed to cleanup old resources: %v", err)
-			knowledge.UpdatedAt = time.Now()
-			s.repo.UpdateKnowledge(ctx, knowledge)
+			s.markKnowledgeFailed(ctx, knowledge, fmt.Sprintf("failed to cleanup old resources: %v", err))
 			return nil
 		}
 	}
 
 	// Run manual processing (image resolution + chunking + embedding) synchronously within the worker
 	if err := s.triggerManualProcessing(ctx, kb, knowledge, payload.Content, true); err != nil {
-		// Same contract as ProcessDocument: asynq retries transient failures;
-		// only the final attempt marks the row failed.
-		if isFinalAsynqAttempt(ctx) {
-			knowledge.ParseStatus = types.ParseStatusFailed
-			knowledge.ErrorMessage = err.Error()
-			knowledge.UpdatedAt = time.Now()
-			s.repo.UpdateKnowledge(ctx, knowledge)
-		}
-		return err
+		return s.failKnowledgeRetryable(ctx, knowledge, isFinalAsynqAttempt(ctx), err)
 	}
 	return nil
 }
@@ -3248,10 +3230,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 	kb, err := s.kbService.GetKnowledgeBaseByID(ctx, payload.KnowledgeBaseID)
 	if err != nil {
 		logger.Errorf(ctx, "failed to get knowledge base: %v", err)
-		knowledge.ParseStatus = "failed"
-		knowledge.ErrorMessage = fmt.Sprintf("failed to get knowledge base: %v", err)
-		knowledge.UpdatedAt = time.Now()
-		s.repo.UpdateKnowledge(ctx, knowledge)
+		s.markKnowledgeFailed(ctx, knowledge, fmt.Sprintf("failed to get knowledge base: %v", err))
 		return nil
 	}
 
@@ -3290,10 +3269,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 	if payload.FilePath != "" && !payload.EnableMultimodel && IsImageType(payload.FileType) {
 		logger.GetLogger(ctx).WithField("knowledge_id", knowledge.ID).
 			WithField("error", ErrImageNotParse).Errorf("processDocument image without enable multimodel")
-		knowledge.ParseStatus = "failed"
-		knowledge.ErrorMessage = ErrImageNotParse.Error()
-		knowledge.UpdatedAt = time.Now()
-		s.repo.UpdateKnowledge(ctx, knowledge)
+		s.markKnowledgeFailed(ctx, knowledge, ErrImageNotParse.Error())
 		return nil
 	}
 
@@ -3301,10 +3277,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 	if payload.FilePath != "" && IsAudioType(payload.FileType) && !eff.ASRConfig.IsASREnabled() {
 		logger.GetLogger(ctx).WithField("knowledge_id", knowledge.ID).
 			Errorf("processDocument audio without ASR model configured")
-		knowledge.ParseStatus = "failed"
-		knowledge.ErrorMessage = "上传音频文件需要设置ASR语音识别模型"
-		knowledge.UpdatedAt = time.Now()
-		s.repo.UpdateKnowledge(ctx, knowledge)
+		s.markKnowledgeFailed(ctx, knowledge, "上传音频文件需要设置ASR语音识别模型")
 		return nil
 	}
 
@@ -3312,10 +3285,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 	if payload.FilePath != "" && IsVideoType(payload.FileType) {
 		logger.GetLogger(ctx).WithField("knowledge_id", knowledge.ID).
 			Errorf("processDocument video not supported")
-		knowledge.ParseStatus = "failed"
-		knowledge.ErrorMessage = "暂不支持视频文件"
-		knowledge.UpdatedAt = time.Now()
-		s.repo.UpdateKnowledge(ctx, knowledge)
+		s.markKnowledgeFailed(ctx, knowledge, "暂不支持视频文件")
 		return nil
 	}
 
@@ -3327,10 +3297,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 		// file_url import: SSRF re-check (防 DNS 重绑定), download, persist, then delegate to convert()
 		if err := secutils.ValidateURLForSSRF(payload.FileURL); err != nil {
 			logger.Errorf(ctx, "File URL rejected for SSRF protection in ProcessDocument: %s, err: %v", payload.FileURL, err)
-			knowledge.ParseStatus = "failed"
-			knowledge.ErrorMessage = "File URL is not allowed for security reasons"
-			knowledge.UpdatedAt = time.Now()
-			s.repo.UpdateKnowledge(ctx, knowledge)
+			s.markKnowledgeFailed(ctx, knowledge, "File URL is not allowed for security reasons")
 			return nil
 		}
 
@@ -3339,21 +3306,12 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 		contentBytes, err := downloadFileFromURL(ctx, payload.FileURL, &resolvedFileName, &resolvedFileType)
 		if err != nil {
 			logger.Errorf(ctx, "Failed to download file from URL: %s, error: %v", payload.FileURL, err)
-			if isLastRetry {
-				knowledge.ParseStatus = "failed"
-				knowledge.ErrorMessage = err.Error()
-				knowledge.UpdatedAt = time.Now()
-				s.repo.UpdateKnowledge(ctx, knowledge)
-			}
-			return fmt.Errorf("failed to download file from URL: %w", err)
+			return s.failKnowledgeRetryable(ctx, knowledge, isLastRetry, fmt.Errorf("failed to download file from URL: %w", err))
 		}
 
 		if resolvedFileType != "" && !isSupportedImportExtension(resolvedFileType) {
 			logger.Errorf(ctx, "Unsupported file type resolved from file URL: %s", resolvedFileType)
-			knowledge.ParseStatus = "failed"
-			knowledge.ErrorMessage = fmt.Sprintf("unsupported file type: %s", resolvedFileType)
-			knowledge.UpdatedAt = time.Now()
-			s.repo.UpdateKnowledge(ctx, knowledge)
+			s.markKnowledgeFailed(ctx, knowledge, fmt.Sprintf("unsupported file type: %s", resolvedFileType))
 			return nil
 		}
 
@@ -3368,13 +3326,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 		fileSvc := s.resolveFileService(ctx, kb)
 		filePath, err := fileSvc.SaveBytes(ctx, contentBytes, payload.TenantID, resolvedFileName, true)
 		if err != nil {
-			if isLastRetry {
-				knowledge.ParseStatus = "failed"
-				knowledge.ErrorMessage = err.Error()
-				knowledge.UpdatedAt = time.Now()
-				s.repo.UpdateKnowledge(ctx, knowledge)
-			}
-			return fmt.Errorf("failed to save downloaded file: %w", err)
+			return s.failKnowledgeRetryable(ctx, knowledge, isLastRetry, fmt.Errorf("failed to save downloaded file: %w", err))
 		}
 
 		payload.FilePath = filePath
@@ -3430,16 +3382,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 			QuestionCount:            payload.QuestionCount,
 		}
 		if err := s.processChunks(ctx, kb, knowledge, passageChunks, passageOpts); err != nil {
-			// Retryable: asynq retries transient failures; only the final
-			// attempt marks the row failed. Returning nil here would report
-			// task success and strand the document in "processing" forever.
-			if isLastRetry {
-				knowledge.ParseStatus = types.ParseStatusFailed
-				knowledge.ErrorMessage = err.Error()
-				knowledge.UpdatedAt = time.Now()
-				s.repo.UpdateKnowledge(ctx, knowledge)
-			}
-			return err
+			return s.failKnowledgeRetryable(ctx, knowledge, isLastRetry, err)
 		}
 		return nil
 	} else {
@@ -3457,10 +3400,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 	if convertResult != nil && convertResult.IsAudio && len(convertResult.AudioData) > 0 {
 		if !eff.ASRConfig.IsASREnabled() {
 			logger.Error(ctx, "Audio file detected but ASR is not configured")
-			knowledge.ParseStatus = "failed"
-			knowledge.ErrorMessage = "ASR model is not configured for audio transcription"
-			knowledge.UpdatedAt = time.Now()
-			s.repo.UpdateKnowledge(ctx, knowledge)
+			s.markKnowledgeFailed(ctx, knowledge, "ASR model is not configured for audio transcription")
 			return nil
 		}
 
@@ -3470,23 +3410,14 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 		asrModel, err := s.modelService.GetASRModel(ctx, eff.ASRConfig.ModelID)
 		if err != nil {
 			logger.Errorf(ctx, "[ASR] Failed to get ASR model: %v", err)
-			knowledge.ParseStatus = "failed"
-			knowledge.ErrorMessage = fmt.Sprintf("failed to get ASR model: %v", err)
-			knowledge.UpdatedAt = time.Now()
-			s.repo.UpdateKnowledge(ctx, knowledge)
+			s.markKnowledgeFailed(ctx, knowledge, fmt.Sprintf("failed to get ASR model: %v", err))
 			return nil
 		}
 
 		transcriptionResult, err := asrModel.Transcribe(ctx, convertResult.AudioData, knowledge.FileName)
 		if err != nil {
 			logger.Errorf(ctx, "[ASR] Transcription failed: %v", err)
-			if isLastRetry {
-				knowledge.ParseStatus = "failed"
-				knowledge.ErrorMessage = fmt.Sprintf("audio transcription failed: %v", err)
-				knowledge.UpdatedAt = time.Now()
-				s.repo.UpdateKnowledge(ctx, knowledge)
-			}
-			return fmt.Errorf("audio transcription failed: %w", err)
+			return s.failKnowledgeRetryable(ctx, knowledge, isLastRetry, fmt.Errorf("audio transcription failed: %w", err))
 		}
 
 		var transcribedText string
@@ -3591,16 +3522,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 
 	// Step 4: Process chunks (vectorize + index + enqueue async tasks)
 	if err := s.processChunks(ctx, kb, knowledge, chunks, processOpts); err != nil {
-		// Retryable: asynq retries transient failures; only the final
-		// attempt marks the row failed. Returning nil here would report
-		// task success and strand the document in "processing" forever.
-		if isLastRetry {
-			knowledge.ParseStatus = types.ParseStatusFailed
-			knowledge.ErrorMessage = err.Error()
-			knowledge.UpdatedAt = time.Now()
-			s.repo.UpdateKnowledge(ctx, knowledge)
-		}
-		return err
+		return s.failKnowledgeRetryable(ctx, knowledge, isLastRetry, err)
 	}
 
 	return nil
@@ -3642,10 +3564,7 @@ func (s *knowledgeService) convert(
 	if isURL {
 		if err := secutils.ValidateURLForSSRF(payload.URL); err != nil {
 			logger.Errorf(ctx, "URL rejected for SSRF protection: %s, err: %v", payload.URL, err)
-			knowledge.ParseStatus = "failed"
-			knowledge.ErrorMessage = "URL is not allowed for security reasons"
-			knowledge.UpdatedAt = time.Now()
-			s.repo.UpdateKnowledge(ctx, knowledge)
+			s.markKnowledgeFailed(ctx, knowledge, "URL is not allowed for security reasons")
 			s.failStage(ctx, knowledge.ID, types.StageDocReader,
 				werrors.ErrCodeDocReaderParseFailed, "URL rejected for security reasons", err)
 			return nil, nil
@@ -3664,12 +3583,10 @@ func (s *knowledgeService) convert(
 	if reader == nil {
 		logger.Errorf(ctx, "[convert] no doc reader for kb=%s knowledge=%s fileType=%s engine=%q isURL=%v",
 			kb.ID, knowledge.ID, fileType, parserEngine, isURL)
-		knowledge.ParseStatus = "failed"
-		knowledge.ErrorMessage = "Document parsing service is not configured. Please use text/paragraph import or set DOCREADER_ADDR."
-		knowledge.UpdatedAt = time.Now()
-		s.repo.UpdateKnowledge(ctx, knowledge)
+		msg := "Document parsing service is not configured. Please use text/paragraph import or set DOCREADER_ADDR."
+		s.markKnowledgeFailed(ctx, knowledge, msg)
 		s.failStage(ctx, knowledge.ID, types.StageDocReader,
-			werrors.ErrCodeDocReaderUnavailable, knowledge.ErrorMessage, nil)
+			werrors.ErrCodeDocReaderUnavailable, msg, nil)
 		return nil, nil
 	}
 
@@ -3716,10 +3633,7 @@ func (s *knowledgeService) convert(
 	if result.Error != "" {
 		logger.Errorf(ctx, "[convert] parser returned error kb=%s knowledge=%s file=%q type=%s engine=%q: %s",
 			kb.ID, knowledge.ID, req.FileName, fileType, parserEngine, result.Error)
-		knowledge.ParseStatus = "failed"
-		knowledge.ErrorMessage = result.Error
-		knowledge.UpdatedAt = time.Now()
-		s.repo.UpdateKnowledge(ctx, knowledge)
+		s.markKnowledgeFailed(ctx, knowledge, result.Error)
 		s.failStage(ctx, knowledge.ID, types.StageDocReader,
 			werrors.ErrCodeDocReaderParseFailed, result.Error, nil)
 		return nil, nil
@@ -3827,6 +3741,28 @@ func (s *knowledgeService) resolveDocReader(ctx context.Context, engine, fileTyp
 	}
 }
 
+// markKnowledgeFailed persists a terminal failed state for the knowledge
+// row: parse_status=failed plus a visible error message.
+func (s *knowledgeService) markKnowledgeFailed(ctx context.Context, knowledge *types.Knowledge, errMsg string) {
+	knowledge.ParseStatus = types.ParseStatusFailed
+	knowledge.ErrorMessage = errMsg
+	knowledge.UpdatedAt = time.Now()
+	if err := s.repo.UpdateKnowledge(ctx, knowledge); err != nil {
+		logger.Warnf(ctx, "markKnowledgeFailed update failed for %s: %v", knowledge.ID, err)
+	}
+}
+
+// failKnowledgeRetryable marks the row failed on the final attempt and
+// returns err so the caller can hand it to asynq for retry.
+func (s *knowledgeService) failKnowledgeRetryable(
+	ctx context.Context, knowledge *types.Knowledge, isLastRetry bool, err error,
+) error {
+	if isLastRetry {
+		s.markKnowledgeFailed(ctx, knowledge, err.Error())
+	}
+	return err
+}
+
 // failKnowledge marks knowledge as failed (only on last retry) and returns an error.
 func (s *knowledgeService) failKnowledge(
 	ctx context.Context,
@@ -3836,13 +3772,7 @@ func (s *knowledgeService) failKnowledge(
 	args ...interface{},
 ) (*types.ReadResult, error) {
 	errMsg := fmt.Sprintf(format, args...)
-	if isLastRetry {
-		knowledge.ParseStatus = "failed"
-		knowledge.ErrorMessage = errMsg
-		knowledge.UpdatedAt = time.Now()
-		s.repo.UpdateKnowledge(ctx, knowledge)
-	}
-	return nil, fmt.Errorf(format, args...)
+	return nil, s.failKnowledgeRetryable(ctx, knowledge, isLastRetry, errors.New(errMsg))
 }
 
 // enqueueImageMultimodalTasks enqueues asynq tasks for multimodal image processing.

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -148,7 +148,14 @@ func (s *knowledgeService) processDocumentFromPassage(ctx context.Context,
 			opts.QuestionCount = 3
 		}
 	}
-	s.processChunks(ctx, kb, knowledge, chunks, opts)
+	if err := s.processChunks(ctx, kb, knowledge, chunks, opts); err != nil {
+		// Sync (request-path) processing has no asynq retry loop, so surface
+		// the failure on the row immediately instead of leaving it stuck.
+		knowledge.ParseStatus = types.ParseStatusFailed
+		knowledge.ErrorMessage = err.Error()
+		knowledge.UpdatedAt = time.Now()
+		s.repo.UpdateKnowledge(ctx, knowledge)
+	}
 }
 
 // ProcessChunksOptions contains options for processing chunks
@@ -244,7 +251,7 @@ func buildParentChildConfigs(cc types.ChunkingConfig, base chunker.SplitterConfi
 func (s *knowledgeService) processChunks(ctx context.Context,
 	kb *types.KnowledgeBase, knowledge *types.Knowledge, chunks []types.ParsedChunk,
 	opts ...ProcessChunksOptions,
-) {
+) error {
 	// Get options
 	var options ProcessChunksOptions
 	if len(opts) > 0 {
@@ -256,7 +263,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	// up yet so the branch is purely "stop early".
 	if aborted, status := s.isKnowledgeAborted(ctx, knowledge.TenantID, knowledge.ID); aborted {
 		logger.Infof(ctx, "Knowledge aborted (%s), skipping chunk processing: %s", status, knowledge.ID)
-		return
+		return nil
 	}
 
 	// Get embedding model for vectorization — only needed when vector/keyword indexing is enabled
@@ -266,7 +273,12 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		embeddingModel, err = s.modelService.GetEmbeddingModel(ctx, kb.EmbeddingModelID)
 		if err != nil {
 			logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks get embedding model failed")
-			return
+			// Nothing is persisted yet.
+			// Bubble the error so asynq retries and only the final attempt marks the row failed.
+			s.beginStage(ctx, knowledge.ID, types.StageEmbedding, types.JSONMap{"model_id": kb.EmbeddingModelID})
+			s.failStage(ctx, knowledge.ID, types.StageEmbedding,
+				werrors.ErrCodeEmbeddingProviderFail, "resolve embedding model failed", err)
+			return fmt.Errorf("resolve embedding model failed: %w", err)
 		}
 	} else {
 		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping embedding model", kb.ID)
@@ -470,7 +482,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	// Nothing has been persisted yet, so both branches just bail.
 	if aborted, status := s.isKnowledgeAborted(ctx, knowledge.TenantID, knowledge.ID); aborted {
 		logger.Infof(ctx, "Knowledge aborted (%s), skipping chunk write: %s", status, knowledge.ID)
-		return
+		return nil
 	}
 
 	// Save chunks to database — ALWAYS, regardless of indexing strategy.
@@ -486,7 +498,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		s.repo.UpdateKnowledge(ctx, knowledge)
 		s.failStage(ctx, knowledge.ID, types.StageChunking,
 			werrors.ErrCodeChunkingFailed, "create chunks failed", err)
-		return
+		return nil
 	}
 	totalChunkChars := 0
 	for _, c := range insertChunks {
@@ -541,7 +553,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 				knowledge.ErrorMessage = err.Error()
 				knowledge.UpdatedAt = time.Now()
 				s.repo.UpdateKnowledge(ctx, knowledge)
-				return
+				return nil
 			}
 			// Check if there's enough storage quota available
 			if tenantInfo.StorageUsed+totalStorageSize > tenantInfo.StorageQuota {
@@ -549,7 +561,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 				knowledge.ErrorMessage = "存储空间不足"
 				knowledge.UpdatedAt = time.Now()
 				s.repo.UpdateKnowledge(ctx, knowledge)
-				return
+				return nil
 			}
 		}
 
@@ -563,7 +575,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 					logger.Warnf(ctx, "Failed to cleanup chunks after deletion detected: %v", err)
 				}
 			}
-			return
+			return nil
 		}
 
 		err = retrieveEngine.BatchIndex(ctx, embeddingModel, indexInfoList)
@@ -592,7 +604,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 			}
 			s.failStage(ctx, knowledge.ID, types.StageEmbedding,
 				code, "batch index failed", err)
-			return
+			return nil
 		}
 		logger.GetLogger(ctx).Infof("processChunks batch index successfully, with %d index", len(indexInfoList))
 		s.endStage(ctx, knowledge.ID, types.StageEmbedding, types.JSONMap{
@@ -614,7 +626,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 					logger.Warnf(ctx, "Failed to cleanup index after deletion detected: %v", err)
 				}
 			}
-			return
+			return nil
 		}
 	} else {
 		logger.Infof(ctx, "Vector/keyword indexing disabled for KB %s, skipping BatchIndex", kb.ID)
@@ -680,6 +692,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		logger.GetLogger(ctx).WithField("error", err).Errorf("processChunks update tenant storage used failed")
 	}
 	logger.GetLogger(ctx).Infof("processChunks successfully")
+	return nil
 }
 
 // defaultMaxInputChars is the default maximum characters used as input for summary generation.
@@ -3141,7 +3154,17 @@ func (s *knowledgeService) ProcessManualUpdate(ctx context.Context, t *asynq.Tas
 	}
 
 	// Run manual processing (image resolution + chunking + embedding) synchronously within the worker
-	s.triggerManualProcessing(ctx, kb, knowledge, payload.Content, true)
+	if err := s.triggerManualProcessing(ctx, kb, knowledge, payload.Content, true); err != nil {
+		// Same contract as ProcessDocument: asynq retries transient failures;
+		// only the final attempt marks the row failed.
+		if isFinalAsynqAttempt(ctx) {
+			knowledge.ParseStatus = types.ParseStatusFailed
+			knowledge.ErrorMessage = err.Error()
+			knowledge.UpdatedAt = time.Now()
+			s.repo.UpdateKnowledge(ctx, knowledge)
+		}
+		return err
+	}
 	return nil
 }
 
@@ -3163,7 +3186,7 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 	// 获取任务重试信息，用于判断是否是最后一次重试
 	retryCount, _ := asynq.GetRetryCount(ctx)
 	maxRetry, _ := asynq.GetMaxRetry(ctx)
-	isLastRetry := retryCount >= maxRetry
+	isLastRetry := isFinalAsynqAttempt(ctx)
 
 	tenantInfo, err := s.tenantRepo.GetTenantByID(ctx, payload.TenantID)
 	if err != nil {
@@ -3406,7 +3429,18 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 			EnableQuestionGeneration: payload.EnableQuestionGeneration,
 			QuestionCount:            payload.QuestionCount,
 		}
-		s.processChunks(ctx, kb, knowledge, passageChunks, passageOpts)
+		if err := s.processChunks(ctx, kb, knowledge, passageChunks, passageOpts); err != nil {
+			// Retryable: asynq retries transient failures; only the final
+			// attempt marks the row failed. Returning nil here would report
+			// task success and strand the document in "processing" forever.
+			if isLastRetry {
+				knowledge.ParseStatus = types.ParseStatusFailed
+				knowledge.ErrorMessage = err.Error()
+				knowledge.UpdatedAt = time.Now()
+				s.repo.UpdateKnowledge(ctx, knowledge)
+			}
+			return err
+		}
 		return nil
 	} else {
 		// File import
@@ -3556,7 +3590,18 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 	}
 
 	// Step 4: Process chunks (vectorize + index + enqueue async tasks)
-	s.processChunks(ctx, kb, knowledge, chunks, processOpts)
+	if err := s.processChunks(ctx, kb, knowledge, chunks, processOpts); err != nil {
+		// Retryable: asynq retries transient failures; only the final
+		// attempt marks the row failed. Returning nil here would report
+		// task success and strand the document in "processing" forever.
+		if isLastRetry {
+			knowledge.ParseStatus = types.ParseStatusFailed
+			knowledge.ErrorMessage = err.Error()
+			knowledge.UpdatedAt = time.Now()
+			s.repo.UpdateKnowledge(ctx, knowledge)
+		}
+		return err
+	}
 
 	return nil
 }

--- a/internal/application/service/knowledge_process_embedding_model_test.go
+++ b/internal/application/service/knowledge_process_embedding_model_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/Tencent/WeKnora/internal/models/embedding"
 	"github.com/Tencent/WeKnora/internal/types"
@@ -74,7 +75,9 @@ func (r embeddingModelFailureTenantRepo) GetTenantByID(
 	return r.tenant, nil
 }
 
-func newEmbeddingModelFailureService() (*knowledgeService, *embeddingModelFailureRepo) {
+func newEmbeddingModelFailureService() (
+	*knowledgeService, *embeddingModelFailureRepo, *types.KnowledgeBase, *types.Knowledge,
+) {
 	knowledge := &types.Knowledge{
 		ID:              "knowledge-1",
 		TenantID:        7,
@@ -84,18 +87,19 @@ func newEmbeddingModelFailureService() (*knowledgeService, *embeddingModelFailur
 		EnableStatus:    "disabled",
 	}
 	repo := &embeddingModelFailureRepo{knowledge: knowledge}
+	kb := &types.KnowledgeBase{
+		ID:               "kb-1",
+		TenantID:         7,
+		EmbeddingModelID: "embed-1",
+		IndexingStrategy: types.DefaultIndexingStrategy(),
+	}
 	svc := &knowledgeService{
-		repo: repo,
-		kbService: embeddingModelFailureKBService{kb: &types.KnowledgeBase{
-			ID:               "kb-1",
-			TenantID:         7,
-			EmbeddingModelID: "embed-1",
-			IndexingStrategy: types.DefaultIndexingStrategy(),
-		}},
+		repo:         repo,
+		kbService:    embeddingModelFailureKBService{kb: kb},
 		tenantRepo:   embeddingModelFailureTenantRepo{tenant: &types.Tenant{ID: 7}},
 		modelService: embeddingModelFailureModelService{},
 	}
-	return svc, repo
+	return svc, repo, kb, knowledge
 }
 
 func embeddingModelFailureTask(t *testing.T) *asynq.Task {
@@ -116,7 +120,7 @@ func embeddingModelFailureTask(t *testing.T) *asynq.Task {
 // returned nil (task "succeeded"), leaving the knowledge row stuck in
 // "processing" forever with no error message and no retry.
 func TestProcessDocumentEmbeddingModelFailureReturnsErrorForRetry(t *testing.T) {
-	svc, repo := newEmbeddingModelFailureService()
+	svc, repo, _, _ := newEmbeddingModelFailureService()
 
 	err := svc.ProcessDocument(context.Background(), embeddingModelFailureTask(t))
 
@@ -131,7 +135,7 @@ func TestProcessDocumentEmbeddingModelFailureReturnsErrorForRetry(t *testing.T) 
 // marked failed with a visible error message instead of staying stuck in
 // "processing".
 func TestProcessDocumentEmbeddingModelFailureMarksFailedOnLastRetry(t *testing.T) {
-	svc, repo := newEmbeddingModelFailureService()
+	svc, repo, _, _ := newEmbeddingModelFailureService()
 	ctx := types.WithTaskRetryMetadata(context.Background(), 3, 3)
 
 	err := svc.ProcessDocument(ctx, embeddingModelFailureTask(t))
@@ -140,4 +144,85 @@ func TestProcessDocumentEmbeddingModelFailureMarksFailedOnLastRetry(t *testing.T
 	require.Equal(t, types.ParseStatusFailed, repo.knowledge.ParseStatus)
 	require.Contains(t, repo.knowledge.ErrorMessage, "resolve embedding model failed")
 	require.GreaterOrEqual(t, repo.updateCalls, 2, "processing and failed states must both be persisted")
+}
+
+// TestMarkKnowledgeFailedSkipsWhenAborted pins the guard on
+// markKnowledgeFailed: a failure landing after the user cancelled the row
+// must not overwrite the newer "cancelled" status.
+func TestMarkKnowledgeFailedSkipsWhenAborted(t *testing.T) {
+	svc, repo, _, _ := newEmbeddingModelFailureService()
+	repo.knowledge.ParseStatus = types.ParseStatusCancelled
+
+	svc.markKnowledgeFailed(context.Background(), repo.knowledge, "boom")
+
+	require.Equal(t, types.ParseStatusCancelled, repo.knowledge.ParseStatus)
+	require.Empty(t, repo.knowledge.ErrorMessage)
+	require.Zero(t, repo.updateCalls)
+}
+
+// TestProcessDocumentFromPassageEmbeddingModelFailureMarksFailed pins the
+// sync (request-path) contract: there is no asynq retry loop, so the row
+// must be marked failed immediately instead of staying stuck in
+// "processing".
+func TestProcessDocumentFromPassageEmbeddingModelFailureMarksFailed(t *testing.T) {
+	svc, repo, kb, knowledge := newEmbeddingModelFailureService()
+
+	svc.processDocumentFromPassage(context.Background(), kb, knowledge, []string{"hello world"})
+
+	require.Equal(t, types.ParseStatusFailed, repo.knowledge.ParseStatus)
+	require.Contains(t, repo.knowledge.ErrorMessage, "resolve embedding model failed")
+}
+
+// TestTriggerManualProcessingEmbeddingModelFailureMarksFailed pins the async
+// goroutine path (used by moveKnowledgeReparse): there is no error channel,
+// so the goroutine must mark the row failed itself.
+func TestTriggerManualProcessingEmbeddingModelFailureMarksFailed(t *testing.T) {
+	svc, repo, kb, knowledge := newEmbeddingModelFailureService()
+
+	err := svc.triggerManualProcessing(context.Background(), kb, knowledge, "# content", false)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return repo.knowledge.ParseStatus == types.ParseStatusFailed
+	}, 2*time.Second, 5*time.Millisecond)
+	require.Contains(t, repo.knowledge.ErrorMessage, "resolve embedding model failed")
+}
+
+func manualUpdateFailureTask(t *testing.T) *asynq.Task {
+	t.Helper()
+	payloadBytes, err := json.Marshal(types.ManualProcessPayload{
+		TenantID:        7,
+		KnowledgeID:     "knowledge-1",
+		KnowledgeBaseID: "kb-1",
+		Content:         "# content",
+	})
+	require.NoError(t, err)
+	return asynq.NewTask(types.TypeManualProcess, payloadBytes)
+}
+
+// TestProcessManualUpdateEmbeddingModelFailureReturnsErrorForRetry pins the
+// manual-reprocess contract: the error is returned so asynq retries, and the
+// non-final attempt leaves the row in "processing".
+func TestProcessManualUpdateEmbeddingModelFailureReturnsErrorForRetry(t *testing.T) {
+	svc, repo, _, _ := newEmbeddingModelFailureService()
+
+	err := svc.ProcessManualUpdate(context.Background(), manualUpdateFailureTask(t))
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "resolve embedding model failed")
+	require.Equal(t, types.ParseStatusProcessing, repo.knowledge.ParseStatus,
+		"non-final attempt must stay processing so asynq can retry")
+}
+
+// TestProcessManualUpdateEmbeddingModelFailureMarksFailedOnLastRetry pins the
+// terminal behavior for manual reprocessing.
+func TestProcessManualUpdateEmbeddingModelFailureMarksFailedOnLastRetry(t *testing.T) {
+	svc, repo, _, _ := newEmbeddingModelFailureService()
+	ctx := types.WithTaskRetryMetadata(context.Background(), 3, 3)
+
+	err := svc.ProcessManualUpdate(ctx, manualUpdateFailureTask(t))
+
+	require.Error(t, err)
+	require.Equal(t, types.ParseStatusFailed, repo.knowledge.ParseStatus)
+	require.Contains(t, repo.knowledge.ErrorMessage, "resolve embedding model failed")
 }

--- a/internal/application/service/knowledge_process_embedding_model_test.go
+++ b/internal/application/service/knowledge_process_embedding_model_test.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/require"
+)
+
+// embeddingModelFailureRepo is a KnowledgeRepository fake that keeps the
+// persisted row in sync so pipeline re-reads (isKnowledgeAborted) observe
+// the same status a real repository would.
+type embeddingModelFailureRepo struct {
+	interfaces.KnowledgeRepository
+	knowledge   *types.Knowledge
+	updateCalls int
+}
+
+func (r *embeddingModelFailureRepo) GetKnowledgeByID(
+	context.Context, uint64, string,
+) (*types.Knowledge, error) {
+	return r.knowledge, nil
+}
+
+func (r *embeddingModelFailureRepo) UpdateKnowledge(_ context.Context, k *types.Knowledge) error {
+	r.updateCalls++
+	r.knowledge = k
+	return nil
+}
+
+func (r *embeddingModelFailureRepo) UpdateKnowledgeColumn(
+	context.Context, string, string, interface{},
+) error {
+	return nil
+}
+
+// embeddingModelFailureModelService makes GetEmbeddingModel fail the way a
+// missing or misconfigured embedding provider does.
+type embeddingModelFailureModelService struct {
+	interfaces.ModelService
+}
+
+func (embeddingModelFailureModelService) GetEmbeddingModel(
+	context.Context, string,
+) (embedding.Embedder, error) {
+	return nil, errors.New("embedding model not found")
+}
+
+type embeddingModelFailureKBService struct {
+	interfaces.KnowledgeBaseService
+	kb *types.KnowledgeBase
+}
+
+func (s embeddingModelFailureKBService) GetKnowledgeBaseByID(
+	context.Context, string,
+) (*types.KnowledgeBase, error) {
+	return s.kb, nil
+}
+
+type embeddingModelFailureTenantRepo struct {
+	interfaces.TenantRepository
+	tenant *types.Tenant
+}
+
+func (r embeddingModelFailureTenantRepo) GetTenantByID(
+	context.Context, uint64,
+) (*types.Tenant, error) {
+	return r.tenant, nil
+}
+
+func newEmbeddingModelFailureService() (*knowledgeService, *embeddingModelFailureRepo) {
+	knowledge := &types.Knowledge{
+		ID:              "knowledge-1",
+		TenantID:        7,
+		KnowledgeBaseID: "kb-1",
+		Type:            "passage",
+		ParseStatus:     types.ParseStatusPending,
+		EnableStatus:    "disabled",
+	}
+	repo := &embeddingModelFailureRepo{knowledge: knowledge}
+	svc := &knowledgeService{
+		repo: repo,
+		kbService: embeddingModelFailureKBService{kb: &types.KnowledgeBase{
+			ID:               "kb-1",
+			TenantID:         7,
+			EmbeddingModelID: "embed-1",
+			IndexingStrategy: types.DefaultIndexingStrategy(),
+		}},
+		tenantRepo:   embeddingModelFailureTenantRepo{tenant: &types.Tenant{ID: 7}},
+		modelService: embeddingModelFailureModelService{},
+	}
+	return svc, repo
+}
+
+func embeddingModelFailureTask(t *testing.T) *asynq.Task {
+	t.Helper()
+	payloadBytes, err := json.Marshal(types.DocumentProcessPayload{
+		TenantID:        7,
+		KnowledgeID:     "knowledge-1",
+		KnowledgeBaseID: "kb-1",
+		Passages:        []string{"hello world"},
+	})
+	require.NoError(t, err)
+	return asynq.NewTask(types.TypeDocumentProcess, payloadBytes)
+}
+
+// TestProcessDocumentEmbeddingModelFailureReturnsErrorForRetry pins the
+// contract that a failed GetEmbeddingModel bubbles an error out of
+// ProcessDocument so asynq retries. Before the fix ProcessDocument
+// returned nil (task "succeeded"), leaving the knowledge row stuck in
+// "processing" forever with no error message and no retry.
+func TestProcessDocumentEmbeddingModelFailureReturnsErrorForRetry(t *testing.T) {
+	svc, repo := newEmbeddingModelFailureService()
+
+	err := svc.ProcessDocument(context.Background(), embeddingModelFailureTask(t))
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "resolve embedding model failed")
+	require.Equal(t, types.ParseStatusProcessing, repo.knowledge.ParseStatus,
+		"non-final attempt must stay processing so asynq can retry")
+}
+
+// TestProcessDocumentEmbeddingModelFailureMarksFailedOnLastRetry pins the
+// terminal behavior: once the retry budget is exhausted the row must be
+// marked failed with a visible error message instead of staying stuck in
+// "processing".
+func TestProcessDocumentEmbeddingModelFailureMarksFailedOnLastRetry(t *testing.T) {
+	svc, repo := newEmbeddingModelFailureService()
+	ctx := types.WithTaskRetryMetadata(context.Background(), 3, 3)
+
+	err := svc.ProcessDocument(ctx, embeddingModelFailureTask(t))
+
+	require.Error(t, err)
+	require.Equal(t, types.ParseStatusFailed, repo.knowledge.ParseStatus)
+	require.Contains(t, repo.knowledge.ErrorMessage, "resolve embedding model failed")
+	require.GreaterOrEqual(t, repo.updateCalls, 2, "processing and failed states must both be persisted")
+}

--- a/internal/application/service/knowledge_process_embedding_model_test.go
+++ b/internal/application/service/knowledge_process_embedding_model_test.go
@@ -24,8 +24,11 @@ type embeddingModelFailureRepo struct {
 }
 
 func (r *embeddingModelFailureRepo) GetKnowledgeByID(
-	context.Context, uint64, string,
+	ctx context.Context, _ uint64, _ string,
 ) (*types.Knowledge, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	return r.knowledge, nil
 }
 
@@ -180,6 +183,25 @@ func TestTriggerManualProcessingEmbeddingModelFailureMarksFailed(t *testing.T) {
 	svc, repo, kb, knowledge := newEmbeddingModelFailureService()
 
 	err := svc.triggerManualProcessing(context.Background(), kb, knowledge, "# content", false)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return repo.knowledge.ParseStatus == types.ParseStatusFailed
+	}, 2*time.Second, 5*time.Millisecond)
+	require.Contains(t, repo.knowledge.ErrorMessage, "resolve embedding model failed")
+}
+
+// TestTriggerManualProcessingEmbeddingModelFailureSurvivesCancelledParent
+// pins that the detached goroutine persists its failure write with the
+// detached context. With the parent request context cancelled,
+// isKnowledgeAborted would see a cancelled repo read (treated as deleting)
+// and skip the terminal write, stranding the row in "processing".
+func TestTriggerManualProcessingEmbeddingModelFailureSurvivesCancelledParent(t *testing.T) {
+	svc, repo, kb, knowledge := newEmbeddingModelFailureService()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := svc.triggerManualProcessing(ctx, kb, knowledge, "# content", false)
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

`processChunks` 在获取 embedding 模型失败时直接静默返回，`ProcessDocument` 因此将任务视为成功，knowledge 停留在 `processing` 状态

修复将错误向上传递：
- asynq 会对瞬时性故障自动重试，在最后一次重试时把 knowledge 标记为失败
- 没有重试机制的同步路径（`processDocumentFromPassage`、`triggerManualProcessing` 的 goroutine），在出错时立即标记失败

提取 `markKnowledgeFailed` / `failKnowledgeRetryable` 两个公共 helper，统一散落的失败标记逻辑

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [x] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->

- asynq 文档处理（文件导入 和 段落导入）：embedding 模型解析失败时向上返回错误，触发 asynq 自动重试，非最终重试时 knowledge 保持 `processing`
- asynq 文档处理：重试次数耗尽时 knowledge 被标记为 `failed` 并写入错误信息，不再卡在 `processing`
- 手动重新解析 asynq 任务：失败返回错误触发重试，非最终重试时 knowledge 保持 `processing`
- 手动重新解析：重试耗尽后标记 `failed` 并写入错误信息
- 同步路径（无重试机制），失败时标记 `failed` 并写入错误信息
- 异步 goroutine 路径，失败时在 goroutine 内标记 `failed` 并写入错误信息
- knowledge 已被用户取消或正在删除时，跳过失败写入（状态与错误信息不覆盖）

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
