### PR TITLE
fix(mcp): preserve omitted service update fields

### DIFF
--- a/internal/application/service/mcp_service.go
+++ b/internal/application/service/mcp_service.go
@@ -116,7 +116,11 @@ func (s *mcpServiceService) ListMCPServicesByIDs(
 }
 
 // UpdateMCPService updates an MCP service
-func (s *mcpServiceService) UpdateMCPService(ctx context.Context, service *types.MCPService) error {
+func (s *mcpServiceService) UpdateMCPService(
+	ctx context.Context,
+	service *types.MCPService,
+	updateFields map[string]bool,
+) error {
 	// Check if service exists
 	existing, err := s.mcpServiceRepo.GetByID(ctx, service.TenantID, service.ID)
 	if err != nil {
@@ -211,40 +215,34 @@ func (s *mcpServiceService) UpdateMCPService(ctx context.Context, service *types
 		}
 	}
 
-	// Merge updates: only update fields that are provided (non-zero or explicitly set)
-	// This ensures that false values for enabled field are properly updated
-	// Handler ensures that service.Enabled is only set if "enabled" key exists in the request
-	// So we can safely update enabled field if service.Name is empty (indicating partial update)
-	// or if we're updating other fields (indicating full update)
-	// For enabled field, we'll update it if this is a partial update (only enabled) or if it's explicitly set
-	if service.Name == "" {
-		// Partial update - only update enabled field.
-		existing.Enabled = service.Enabled
-	} else {
-		// Full update - update all fields including enabled
+	// Scalar zero values cannot distinguish omission from an explicit update,
+	// so use the handler's field-presence map for name, description, and enabled.
+	if updateFields["name"] {
 		existing.Name = service.Name
-		if service.Description != existing.Description {
-			existing.Description = service.Description
-		}
+	}
+	if updateFields["description"] {
+		existing.Description = service.Description
+	}
+	if updateFields["enabled"] {
 		existing.Enabled = service.Enabled
-		if service.TransportType != "" {
-			existing.TransportType = service.TransportType
-		}
-		if service.URL != nil {
-			existing.URL = service.URL
-		}
-		if service.StdioConfig != nil {
-			existing.StdioConfig = service.StdioConfig
-		}
-		if service.EnvVars != nil {
-			existing.EnvVars = service.EnvVars
-		}
-		if service.Headers != nil {
-			existing.Headers = service.Headers
-		}
-		if service.AdvancedConfig != nil {
-			existing.AdvancedConfig = service.AdvancedConfig
-		}
+	}
+	if service.TransportType != "" {
+		existing.TransportType = service.TransportType
+	}
+	if service.URL != nil {
+		existing.URL = service.URL
+	}
+	if service.StdioConfig != nil {
+		existing.StdioConfig = service.StdioConfig
+	}
+	if service.EnvVars != nil {
+		existing.EnvVars = service.EnvVars
+	}
+	if service.Headers != nil {
+		existing.Headers = service.Headers
+	}
+	if service.AdvancedConfig != nil {
+		existing.AdvancedConfig = service.AdvancedConfig
 	}
 
 	// Update timestamp

--- a/internal/application/service/mcp_service_test.go
+++ b/internal/application/service/mcp_service_test.go
@@ -117,6 +117,92 @@ func newTestService() (*mcpServiceService, *fakeMCPRepo) {
 	return svc, repo
 }
 
+func TestUpdateMCPService_RespectsScalarFieldPresence(t *testing.T) {
+	tests := []struct {
+		name            string
+		update          *types.MCPService
+		updateFields    map[string]bool
+		wantName        string
+		wantDescription string
+		wantEnabled     bool
+	}{
+		{
+			name:            "description only",
+			update:          &types.MCPService{Description: "after"},
+			updateFields:    map[string]bool{"description": true},
+			wantName:        "test",
+			wantDescription: "after",
+			wantEnabled:     true,
+		},
+		{
+			name:            "name only",
+			update:          &types.MCPService{Name: "renamed"},
+			updateFields:    map[string]bool{"name": true},
+			wantName:        "renamed",
+			wantDescription: "before",
+			wantEnabled:     true,
+		},
+		{
+			name:            "explicit empty description",
+			update:          &types.MCPService{Description: ""},
+			updateFields:    map[string]bool{"description": true},
+			wantName:        "test",
+			wantDescription: "",
+			wantEnabled:     true,
+		},
+		{
+			name:            "explicit disable",
+			update:          &types.MCPService{Enabled: false},
+			updateFields:    map[string]bool{"enabled": true},
+			wantName:        "test",
+			wantDescription: "before",
+			wantEnabled:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			svc, repo := newTestService()
+			id := seedService(t, repo, "stored-api", "stored-token")
+			repo.store[id].Description = "before"
+
+			tt.update.ID = id
+			tt.update.TenantID = 1
+			require.NoError(t, svc.UpdateMCPService(ctx, tt.update, tt.updateFields))
+
+			got := repo.store[id]
+			assert.Equal(t, tt.wantName, got.Name)
+			assert.Equal(t, tt.wantDescription, got.Description)
+			assert.Equal(t, tt.wantEnabled, got.Enabled)
+		})
+	}
+}
+
+func TestUpdateMCPService_AppliesNonScalarUpdateWithoutName(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestService()
+	id := seedService(t, repo, "stored-api", "stored-token")
+	beforeURL := "https://before.example.com"
+	repo.store[id].Description = "before"
+	repo.store[id].URL = &beforeURL
+
+	afterURL := "https://after.example.com"
+	update := &types.MCPService{
+		ID:       id,
+		TenantID: 1,
+		URL:      &afterURL,
+	}
+	require.NoError(t, svc.UpdateMCPService(ctx, update, nil))
+
+	got := repo.store[id]
+	require.NotNil(t, got.URL)
+	assert.Equal(t, afterURL, *got.URL)
+	assert.Equal(t, "test", got.Name)
+	assert.Equal(t, "before", got.Description)
+	assert.True(t, got.Enabled)
+}
+
 // ---- UpdateMCPService: must not touch APIKey/Token even when caller sends them ----
 
 // The handler now strips api_key/token from the main PUT body, but defense
@@ -140,7 +226,10 @@ func TestUpdateMCPService_DoesNotTouchSecretsEvenIfPassed(t *testing.T) {
 			Token:  "should-not-overwrite-either",
 		},
 	}
-	require.NoError(t, svc.UpdateMCPService(ctx, upd))
+	require.NoError(t, svc.UpdateMCPService(ctx, upd, map[string]bool{
+		"name":    true,
+		"enabled": true,
+	}))
 
 	got := repo.store[id]
 	assert.Equal(t, "stored-api", got.AuthConfig.APIKey,
@@ -165,7 +254,7 @@ func TestUpdateMCPService_CustomHeadersPreserveOnNil(t *testing.T) {
 		// AuthConfig present but CustomHeaders nil → preserve.
 		AuthConfig: &types.MCPAuthConfig{},
 	}
-	require.NoError(t, svc.UpdateMCPService(ctx, upd))
+	require.NoError(t, svc.UpdateMCPService(ctx, upd, nil))
 
 	got := repo.store[id]
 	assert.Equal(t, "acme", got.AuthConfig.CustomHeaders["X-Tenant"],
@@ -188,7 +277,7 @@ func TestUpdateMCPService_CustomHeadersReplaceOnNonNil(t *testing.T) {
 			CustomHeaders: map[string]string{"X-Replaced": "yes"},
 		},
 	}
-	require.NoError(t, svc.UpdateMCPService(ctx, upd))
+	require.NoError(t, svc.UpdateMCPService(ctx, upd, nil))
 
 	got := repo.store[id]
 	assert.Equal(t, map[string]string{"X-Replaced": "yes"}, got.AuthConfig.CustomHeaders,

--- a/internal/handler/mcp_service.go
+++ b/internal/handler/mcp_service.go
@@ -334,7 +334,7 @@ func (h *MCPServiceHandler) UpdateMCPService(c *gin.Context) {
 		}
 	}
 
-	if err := h.mcpServiceService.UpdateMCPService(ctx, &service); err != nil {
+	if err := h.mcpServiceService.UpdateMCPService(ctx, &service, updateFields); err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{"service_id": secutils.SanitizeForLog(serviceID)})
 		c.Error(errors.NewInternalServerError("Failed to update MCP service: " + err.Error()))
 		return

--- a/internal/types/interfaces/mcp_service.go
+++ b/internal/types/interfaces/mcp_service.go
@@ -44,8 +44,15 @@ type MCPServiceService interface {
 	// ListMCPServicesByIDs retrieves multiple MCP services by IDs
 	ListMCPServicesByIDs(ctx context.Context, tenantID uint64, ids []string) ([]*types.MCPService, error)
 
-	// UpdateMCPService updates an MCP service
-	UpdateMCPService(ctx context.Context, service *types.MCPService) error
+	// UpdateMCPService updates an MCP service. updateFields records presence for
+	// scalar fields whose zero values cannot represent omission. Supported keys
+	// are "name", "description", and "enabled"; a nil map means none of those
+	// scalar fields were provided.
+	UpdateMCPService(
+		ctx context.Context,
+		service *types.MCPService,
+		updateFields map[string]bool,
+	) error
 
 	// DeleteMCPService deletes an MCP service
 	DeleteMCPService(ctx context.Context, tenantID uint64, id string) error


### PR DESCRIPTION
## Description

`PUT /api/v1/mcp-services/{id}` already tracks which fields are present in the request, but that information was not passed to the service layer. The service instead used `service.Name == ""` to guess whether an update was partial, which caused description-only updates to be ignored and name-only updates to clear the description and disable the service.

This change passes the field-presence map through `UpdateMCPService` and only assigns `name`, `description`, and `enabled` when they are present. Explicit zero values, such as an empty description or `enabled: false`, still work.

Non-scalar fields keep their existing non-empty/non-nil merge rules, but are no longer gated on `name`, so configuration-only partial updates are applied as expected.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🧪 Test

## Related Issue

Fixes #2611

## Testing

```bash
go test ./internal/application/service -run "^TestUpdateMCPService_" -count=1
go test ./internal/application/service -count=1
go test ./internal/handler -run "^$" -count=1
go vet ./internal/application/service ./internal/handler ./internal/types/interfaces
```

Regression coverage includes description-only and name-only updates, explicit zero values, and a URL-only update without a name field.

## Checklist

- [x] Changed Go files are formatted
- [x] Targeted tests pass
- [x] `git diff --check origin/main...HEAD` passes
- [x] Added regression coverage
- [x] No breaking API changes
