### PR TITLE
fix(frontend): dismiss stale card popover on folder navigation

### DIFF
--- a/frontend/src/views/knowledge/components/DocumentCardView.vue
+++ b/frontend/src/views/knowledge/components/DocumentCardView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, nextTick } from 'vue';
+import { ref, computed, nextTick, onBeforeUnmount, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { formatFileSize } from '@/utils/files';
 import { useTagChipsOverflow } from '@/composables/useTagChipsOverflow';
@@ -182,6 +182,15 @@ const cardHoverShowDelay = 300;
 let cardHoverTimer: ReturnType<typeof setTimeout> | null = null;
 let cardPopoverElement: HTMLElement | null = null;
 
+const dismissCardPopover = () => {
+  if (cardHoverTimer) {
+    clearTimeout(cardHoverTimer);
+    cardHoverTimer = null;
+  }
+  hoveredCardItem.value = null;
+  cardPopoverElement = null;
+};
+
 const calculatePopoverPositionFromCard = (cardElement: HTMLElement): { x: number; y: number } => {
   const cardRect = cardElement.getBoundingClientRect();
   const viewportWidth = window.innerWidth;
@@ -246,10 +255,15 @@ const onCardMouseEnter = (ev: MouseEvent, item: KnowledgeCard) => {
   const cardElement = (ev.currentTarget as HTMLElement);
   cardHoverTimer = setTimeout(() => {
     cardHoverTimer = null;
+    // Folder navigation can replace the card list before this delayed callback
+    // runs. A detached card has a zero rect, which used to place the teleported
+    // popover at the top-left corner of the viewport.
+    if (!cardElement.isConnected || !props.items.some(candidate => candidate.id === item.id)) return;
     hoveredCardItem.value = item;
     const pos = calculatePopoverPositionFromCard(cardElement);
     cardPopoverPos.value = pos;
     nextTick(() => {
+      if (!cardElement.isConnected || hoveredCardItem.value?.id !== item.id) return;
       cardPopoverElement = document.querySelector('.knowledge-card-hover-popover') as HTMLElement;
       if (cardPopoverElement) {
         const refinedPos = calculatePopoverPositionFromCard(cardElement);
@@ -260,12 +274,17 @@ const onCardMouseEnter = (ev: MouseEvent, item: KnowledgeCard) => {
 };
 
 const onCardMouseLeave = () => {
-  if (cardHoverTimer) {
-    clearTimeout(cardHoverTimer);
-    cardHoverTimer = null;
-  }
-  hoveredCardItem.value = null;
-  cardPopoverElement = null;
+  dismissCardPopover();
+};
+
+// Browsing to another folder swaps the item collection without necessarily
+// dispatching mouseleave on a card that Vue removes.
+watch(() => props.items, dismissCardPopover);
+onBeforeUnmount(dismissCardPopover);
+
+const onOpenFolder = (path: string) => {
+  dismissCardPopover();
+  emit('open-folder', path);
 };
 
 const onFolderPicked = (item: KnowledgeCard, path: string) => {
@@ -301,8 +320,8 @@ const handleAction = (action: 'edit' | 'view-trace' | 'reparse' | 'cancel-parse'
         :title="folder.path"
         role="button"
         tabindex="0"
-        @click="emit('open-folder', folder.path)"
-        @keydown.enter="emit('open-folder', folder.path)"
+        @click="onOpenFolder(folder.path)"
+        @keydown.enter="onOpenFolder(folder.path)"
       >
         <div class="folder-card__body">
           <t-icon name="folder" class="folder-card__icon" />

--- a/frontend/src/views/knowledge/components/KbFolderTree.test.ts
+++ b/frontend/src/views/knowledge/components/KbFolderTree.test.ts
@@ -45,3 +45,10 @@ test('the folder picker wins over the normal action menu', () => {
     assert.ok(pickerIdx < normalIdx)
   }
 })
+
+test('folder navigation cancels stale card hover popovers', () => {
+  assert.match(cardView, /if \(!cardElement\.isConnected/)
+  assert.match(cardView, /watch\(\(\) => props\.items, dismissCardPopover\)/)
+  assert.match(cardView, /const onOpenFolder = \(path: string\)[\s\S]*?dismissCardPopover\(\)[\s\S]*?emit\('open-folder', path\)/)
+  assert.match(cardView, /@click="onOpenFolder\(folder\.path\)"/)
+})


### PR DESCRIPTION

## Description

修复知识库文档卡片悬浮浮层在切换文件夹后偶发出现在页面左上角的问题。

问题原因是文件夹切换会替换文档列表，但卡片的延迟悬浮回调可能继续引用已经脱离 DOM 的元素。该元素的坐标信息为零，导致 `CARD_POPOVER` 被定位到视口左上角。

问题复现：


https://github.com/user-attachments/assets/6a2742cc-687b-42d7-ba72-10640c79a749



本次修改：

- 切换文件夹时取消待执行的悬浮计时器并关闭 Popover。
- 文档列表更新或组件卸载时清理悬浮状态。
- Popover 定位前检查对应卡片是否仍在 DOM 和当前文档列表中。
- 在 `nextTick` 二次定位前再次校验卡片和悬浮状态。
- 添加文件夹导航场景的回归测试。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

已执行以下检查：

```bash
cd frontend
npm test -- --test-name-pattern "folder navigation|folder picker|rename sentinel"
npm run type-check
```

测试结果：

- 前端测试通过：63 passed，0 failed。
- Vue/TypeScript 类型检查通过。
- `git diff --check origin/main...HEAD` 通过。

回归测试覆盖：

1. 将鼠标悬停在知识文档卡片上。
2. 在悬浮延迟回调执行前切换文件夹。
3. 确认已脱离 DOM 的卡片不会触发 Popover。
4. 确认文件夹切换会主动清理已有或待显示的 Popover。

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Breaking changes are clearly called out in the description above (no breaking changes)

