### PR TITLE
feat: add Metaso web search provider

### DIFF
--- a/frontend/src/api/web-search-provider.ts
+++ b/frontend/src/api/web-search-provider.ts
@@ -5,7 +5,7 @@ export interface WebSearchProviderEntity {
   id?: string
   tenant_id?: number
   name: string
-  provider: 'bing' | 'google' | 'duckduckgo' | 'tavily' | 'ollama' | 'baidu' | 'searxng' | 'keenable' | 'zhipu'
+  provider: 'bing' | 'google' | 'duckduckgo' | 'tavily' | 'ollama' | 'baidu' | 'searxng' | 'keenable' | 'zhipu' | 'metaso'
   description?: string
   parameters: {
     // api_key is never returned by the server in this shape; it lives behind

--- a/internal/application/service/web_search_provider.go
+++ b/internal/application/service/web_search_provider.go
@@ -137,6 +137,7 @@ func isValidProviderType(provider types.WebSearchProviderType) bool {
 		types.WebSearchProviderTypeBaidu,
 		types.WebSearchProviderTypeSearxng,
 		types.WebSearchProviderTypeKeenable,
+		types.WebSearchProviderTypeMetaso,
 		types.WebSearchProviderTypeZhipu:
 		return true
 	default:
@@ -172,6 +173,10 @@ func validateProviderParameters(provider types.WebSearchProviderType, params typ
 		}
 	case types.WebSearchProviderTypeZhipu:
 		if err := infra_web_search.ValidateZhipuParameters(params); err != nil {
+			return err
+		}
+	case types.WebSearchProviderTypeMetaso:
+		if err := infra_web_search.ValidateMetasoParameters(params); err != nil {
 			return err
 		}
 	case types.WebSearchProviderTypeDuckDuckGo:

--- a/internal/application/service/web_search_provider_test.go
+++ b/internal/application/service/web_search_provider_test.go
@@ -30,3 +30,21 @@ func TestIsValidProviderTypeIncludesZhipu(t *testing.T) {
 		t.Fatal("Zhipu provider type is not accepted")
 	}
 }
+
+func TestValidateProviderParametersMetaso(t *testing.T) {
+	valid := types.WebSearchProviderParameters{
+		APIKey:      "mk-test",
+		ExtraConfig: map[string]string{"scope": "webpage"},
+	}
+	if err := validateProviderParameters(types.WebSearchProviderTypeMetaso, valid); err != nil {
+		t.Fatalf("valid Metaso parameters rejected: %v", err)
+	}
+	invalid := valid
+	invalid.ExtraConfig = map[string]string{"scope": "unsupported"}
+	if err := validateProviderParameters(types.WebSearchProviderTypeMetaso, invalid); err == nil {
+		t.Fatal("invalid Metaso scope was accepted")
+	}
+	if !isValidProviderType(types.WebSearchProviderTypeMetaso) {
+		t.Fatal("Metaso provider type is not accepted")
+	}
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -1564,6 +1564,7 @@ func registerWebSearchProviders(registry *infra_web_search.Registry) {
 	registry.Register("searxng", infra_web_search.NewSearxngProvider)
 	registry.Register("keenable", infra_web_search.NewKeenableProvider)
 	registry.Register("zhipu", infra_web_search.NewZhipuProvider)
+	registry.Register("metaso", infra_web_search.NewMetasoProvider)
 }
 
 // registerIMService registers adapter factories, loads enabled channels, and

--- a/internal/infrastructure/web_search/metaso.go
+++ b/internal/infrastructure/web_search/metaso.go
@@ -1,0 +1,207 @@
+package web_search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+const (
+	defaultMetasoSearchURL = "https://metaso.cn/api/v1/search"
+	defaultMetasoTimeout   = 30 * time.Second
+	defaultMetasoResults   = 10
+	maxMetasoResults       = 50
+	maxMetasoResponseBytes = 4 << 20
+	defaultMetasoScope     = "webpage"
+)
+
+var validMetasoScopes = map[string]struct{}{
+	"webpage": {}, "document": {}, "scholar": {},
+	"podcast": {}, "video": {}, "image": {},
+}
+
+// MetasoProvider implements web search using the official Metaso AI Search API.
+type MetasoProvider struct {
+	client  *http.Client
+	baseURL string
+	apiKey  string
+	scope   string
+}
+
+func NewMetasoProvider(params types.WebSearchProviderParameters) (interfaces.WebSearchProvider, error) {
+	if err := ValidateMetasoParameters(params); err != nil {
+		return nil, err
+	}
+	client, err := NewSearchHTTPClient(defaultMetasoTimeout, params.ProxyURL)
+	if err != nil {
+		return nil, err
+	}
+	return &MetasoProvider{
+		client: client, baseURL: defaultMetasoSearchURL,
+		apiKey: strings.TrimSpace(params.APIKey), scope: metasoScope(params.ExtraConfig),
+	}, nil
+}
+
+func ValidateMetasoParameters(params types.WebSearchProviderParameters) error {
+	if strings.TrimSpace(params.APIKey) == "" {
+		return fmt.Errorf("API key is required for Metaso provider")
+	}
+	scope := metasoScope(params.ExtraConfig)
+	if _, ok := validMetasoScopes[scope]; !ok {
+		return fmt.Errorf("invalid Metaso search scope: %s", scope)
+	}
+	return nil
+}
+
+func metasoScope(extraConfig map[string]string) string {
+	if scope := strings.TrimSpace(extraConfig["scope"]); scope != "" {
+		return scope
+	}
+	return defaultMetasoScope
+}
+
+func (p *MetasoProvider) Name() string { return "metaso" }
+
+func (p *MetasoProvider) Search(ctx context.Context, query string, maxResults int, includeDate bool) ([]*types.WebSearchResult, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, fmt.Errorf("query is empty")
+	}
+	if maxResults <= 0 {
+		maxResults = defaultMetasoResults
+	}
+	if maxResults > maxMetasoResults {
+		maxResults = maxMetasoResults
+	}
+
+	body, err := json.Marshal(metasoSearchRequest{
+		Query: query, Scope: p.scope, Size: maxResults,
+		IncludeSummary: true, IncludeRawContent: false, ConciseSnippet: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Metaso request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Metaso request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	logger.Infof(ctx, "[WebSearch][Metaso] query=%q maxResults=%d scope=%s", query, maxResults, p.scope)
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute Metaso request: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := readMetasoResponseBody(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, metasoHTTPError(resp.StatusCode, respBody)
+	}
+
+	var response metasoSearchResponse
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal Metaso response: %w", err)
+	}
+	results := make([]*types.WebSearchResult, 0, len(response.Webpages))
+	for _, item := range response.Webpages {
+		if strings.TrimSpace(item.Title) == "" && strings.TrimSpace(item.Link) == "" {
+			continue
+		}
+		snippet := strings.TrimSpace(item.Summary)
+		if snippet == "" {
+			snippet = strings.TrimSpace(item.Snippet)
+		}
+		result := &types.WebSearchResult{Title: item.Title, URL: item.Link, Snippet: snippet, Content: item.RawContent, Source: "metaso"}
+		if includeDate {
+			if publishedAt, ok := parseMetasoDate(item.Date); ok {
+				result.PublishedAt = &publishedAt
+			}
+		}
+		results = append(results, result)
+		if len(results) >= maxResults {
+			break
+		}
+	}
+	logger.Infof(ctx, "[WebSearch][Metaso] returned %d results", len(results))
+	return results, nil
+}
+
+func readMetasoResponseBody(reader io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(reader, maxMetasoResponseBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Metaso response: %w", err)
+	}
+	if len(body) > maxMetasoResponseBytes {
+		return nil, fmt.Errorf("Metaso response exceeds %d bytes", maxMetasoResponseBytes)
+	}
+	return body, nil
+}
+
+func metasoHTTPError(statusCode int, body []byte) error {
+	var apiError struct {
+		Message string `json:"message"`
+		Error   string `json:"error"`
+	}
+	if json.Unmarshal(body, &apiError) == nil {
+		detail := strings.TrimSpace(apiError.Message)
+		if detail == "" {
+			detail = strings.TrimSpace(apiError.Error)
+		}
+		if detail != "" {
+			return fmt.Errorf("Metaso API returned status %d: %s", statusCode, detail)
+		}
+	}
+	detail := strings.TrimSpace(string(body))
+	if len(detail) > 4096 {
+		detail = detail[:4096]
+	}
+	if detail == "" {
+		return fmt.Errorf("Metaso API returned status %d", statusCode)
+	}
+	return fmt.Errorf("Metaso API returned status %d: %s", statusCode, detail)
+}
+
+func parseMetasoDate(value string) (time.Time, bool) {
+	for _, layout := range []string{time.RFC3339Nano, "2006-01-02 15:04:05", "2006-01-02"} {
+		if parsed, err := time.Parse(layout, strings.TrimSpace(value)); err == nil {
+			return parsed, true
+		}
+	}
+	return time.Time{}, false
+}
+
+type metasoSearchRequest struct {
+	Query             string `json:"q"`
+	Scope             string `json:"scope"`
+	Size              int    `json:"size"`
+	IncludeSummary    bool   `json:"includeSummary"`
+	IncludeRawContent bool   `json:"includeRawContent"`
+	ConciseSnippet    bool   `json:"conciseSnippet"`
+}
+
+type metasoSearchResponse struct {
+	Webpages []metasoWebpage `json:"webpages"`
+}
+
+type metasoWebpage struct {
+	Title      string `json:"title"`
+	Link       string `json:"link"`
+	Snippet    string `json:"snippet"`
+	Summary    string `json:"summary"`
+	RawContent string `json:"rawContent"`
+	Date       string `json:"date"`
+}

--- a/internal/infrastructure/web_search/metaso_test.go
+++ b/internal/infrastructure/web_search/metaso_test.go
@@ -1,0 +1,87 @@
+package web_search
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestMetasoProviderSearch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer mk-test" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		var request metasoSearchRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		if request.Query != "WeKnora" || request.Scope != "scholar" || request.Size != 2 {
+			t.Fatalf("unexpected request: %+v", request)
+		}
+		if !request.IncludeSummary || request.IncludeRawContent || !request.ConciseSnippet {
+			t.Fatalf("unexpected content options: %+v", request)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"webpages":[
+			{"title":"First","link":"https://example.com/1","summary":"Summary","snippet":"Snippet","date":"2026-08-09"},
+			{"title":"Second","link":"https://example.com/2","snippet":"Fallback snippet","date":"invalid"},
+			{"title":"Third","link":"https://example.com/3","snippet":"must be capped"}
+		]}`))
+	}))
+	defer server.Close()
+
+	metaso := &MetasoProvider{client: server.Client(), baseURL: server.URL, apiKey: "mk-test", scope: "scholar"}
+	results, err := metaso.Search(context.Background(), " WeKnora ", 2, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].Snippet != "Summary" || results[1].Snippet != "Fallback snippet" {
+		t.Fatalf("unexpected snippets: %q, %q", results[0].Snippet, results[1].Snippet)
+	}
+	if results[0].Source != "metaso" || results[0].PublishedAt == nil {
+		t.Fatalf("unexpected first result: %+v", results[0])
+	}
+	if want := time.Date(2026, 8, 9, 0, 0, 0, 0, time.UTC); !results[0].PublishedAt.Equal(want) {
+		t.Fatalf("date = %v, want %v", results[0].PublishedAt, want)
+	}
+	if results[1].PublishedAt != nil {
+		t.Fatalf("invalid date should be ignored: %v", results[1].PublishedAt)
+	}
+}
+
+func TestValidateMetasoParameters(t *testing.T) {
+	if err := ValidateMetasoParameters(types.WebSearchProviderParameters{}); err == nil {
+		t.Fatal("expected missing API key error")
+	}
+	if err := ValidateMetasoParameters(types.WebSearchProviderParameters{APIKey: "mk-test", ExtraConfig: map[string]string{"scope": "unknown"}}); err == nil {
+		t.Fatal("expected invalid scope error")
+	}
+	if err := ValidateMetasoParameters(types.WebSearchProviderParameters{APIKey: "mk-test"}); err != nil {
+		t.Fatalf("default parameters: %v", err)
+	}
+}
+
+func TestMetasoProviderHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"invalid API key"}`))
+	}))
+	defer server.Close()
+	metaso := &MetasoProvider{client: server.Client(), baseURL: server.URL, apiKey: "bad", scope: defaultMetasoScope}
+	_, err := metaso.Search(context.Background(), "test", 1, false)
+	if err == nil || !strings.Contains(err.Error(), "invalid API key") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/internal/types/web_search_provider.go
+++ b/internal/types/web_search_provider.go
@@ -24,6 +24,7 @@ const (
 	WebSearchProviderTypeSearxng    WebSearchProviderType = "searxng"
 	WebSearchProviderTypeKeenable   WebSearchProviderType = "keenable"
 	WebSearchProviderTypeZhipu      WebSearchProviderType = "zhipu"
+	WebSearchProviderTypeMetaso     WebSearchProviderType = "metaso"
 )
 
 // WebSearchProviderEntity represents a configured web search provider instance for a workspace.
@@ -234,6 +235,32 @@ func GetWebSearchProviderTypes() []WebSearchProviderTypeInfo {
 			SupportsProxy:          true,
 			Description:            "Keenable web search built for AI agents (keyless by default; an optional API key lifts the rate limit)",
 			DocsURL:                "https://keenable.ai/",
+		},
+		{
+			ID:             "metaso",
+			Name:           "Metaso AI Search",
+			RequiresAPIKey: true,
+			SupportsProxy:  true,
+			Description:    "Metaso AI Search API (requires API key)",
+			DocsURL:        "https://metaso.cn/search-api/playground",
+			ConfigFields: []WebSearchProviderConfigField{
+				{
+					Key:         "scope",
+					Label:       "Search scope",
+					Type:        "select",
+					Required:    true,
+					Default:     "webpage",
+					Description: "Select the content source searched by Metaso.",
+					Options: []WebSearchProviderConfigFieldOption{
+						{Label: "Web pages", Value: "webpage"},
+						{Label: "Documents", Value: "document"},
+						{Label: "Scholar", Value: "scholar"},
+						{Label: "Podcasts", Value: "podcast"},
+						{Label: "Videos", Value: "video"},
+						{Label: "Images", Value: "image"},
+					},
+				},
+			},
 		},
 		{
 			ID:             "zhipu",

--- a/internal/types/web_search_provider_test.go
+++ b/internal/types/web_search_provider_test.go
@@ -30,3 +30,23 @@ func TestGetWebSearchProviderTypesIncludesZhipuConfig(t *testing.T) {
 		t.Fatalf("unexpected content size config metadata: %+v", zhipu.ConfigFields[1])
 	}
 }
+
+func TestGetWebSearchProviderTypesIncludesMetaso(t *testing.T) {
+	var metaso *WebSearchProviderTypeInfo
+	providerTypes := GetWebSearchProviderTypes()
+	for i := range providerTypes {
+		if providerTypes[i].ID == string(WebSearchProviderTypeMetaso) {
+			metaso = &providerTypes[i]
+			break
+		}
+	}
+	if metaso == nil {
+		t.Fatal("Metaso provider type not found")
+	}
+	if !metaso.RequiresAPIKey || !metaso.SupportsProxy || len(metaso.ConfigFields) != 1 {
+		t.Fatalf("unexpected Metaso metadata: %+v", metaso)
+	}
+	if field := metaso.ConfigFields[0]; field.Key != "scope" || field.Default != "webpage" || len(field.Options) != 6 {
+		t.Fatalf("unexpected Metaso scope metadata: %+v", field)
+	}
+}


### PR DESCRIPTION

## Description

新增秘塔 AI 搜索（Metaso AI Search）作为网络搜索 Provider。

主要改动：

- 在网络搜索设置中新增 `Metaso AI Search` 选项
- 支持配置 API Key 和 HTTP/HTTPS 代理
- 支持以下搜索范围：
  - 网页
  - 文库
  - 学术
  - 播客
  - 视频
  - 图片
- 接入秘塔官方 `POST https://metaso.cn/api/v1/search` 接口
- 将秘塔返回的 `webpages` 转换为统一的 `WebSearchResult`
- 支持摘要、发布日期、结果数量限制及 API 错误处理
- 注册 Metaso Provider，并更新前端 TypeScript Provider 类型
- 补充 Provider 元数据、参数校验、请求响应和错误处理测试


## Type of Change

- [ ] 🐛 Bug fix
- [x] ✅ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixed #2562

## Testing

Targeted tests passed:

```bash
go test -vet=off ./internal/infrastructure/web_search ./internal/types ./internal/application/service \
  -run 'Metaso|WebSearchProvider|ValidateProvider' -count=1
```

Result:

```text
ok  github.com/Tencent/WeKnora/internal/infrastructure/web_search
ok  github.com/Tencent/WeKnora/internal/types
ok  github.com/Tencent/WeKnora/internal/application/service
```

Diff validation passed:

```bash
git diff --check origin/main...HEAD
```

A broader `go test` run for `internal/application/service` was attempted. Existing Windows-specific SQLite temporary-file cleanup tests failed because database files remained locked by another process. These failures are unrelated to the Metaso provider changes.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings


https://github.com/user-attachments/assets/2124df93-981c-4d22-b946-f5dfc586368d


