### PR TITLE
fix(im): persist session mode configuration

### DIFF
--- a/internal/handler/im.go
+++ b/internal/handler/im.go
@@ -65,6 +65,7 @@ func (h *IMHandler) CreateIMChannel(c *gin.Context) {
 		Name            string     `json:"name"`
 		Mode            string     `json:"mode"`
 		OutputMode      string     `json:"output_mode"`
+		SessionMode     string     `json:"session_mode"`
 		KnowledgeBaseID string     `json:"knowledge_base_id"`
 		Credentials     types.JSON `json:"credentials"`
 		Enabled         *bool      `json:"enabled"`
@@ -86,6 +87,7 @@ func (h *IMHandler) CreateIMChannel(c *gin.Context) {
 		Name:            req.Name,
 		Mode:            req.Mode,
 		OutputMode:      req.OutputMode,
+		SessionMode:     req.SessionMode,
 		KnowledgeBaseID: req.KnowledgeBaseID,
 		Credentials:     req.Credentials,
 		Enabled:         true,
@@ -207,6 +209,7 @@ func (h *IMHandler) UpdateIMChannel(c *gin.Context) {
 		Name            *string    `json:"name"`
 		Mode            *string    `json:"mode"`
 		OutputMode      *string    `json:"output_mode"`
+		SessionMode     *string    `json:"session_mode"`
 		KnowledgeBaseID *string    `json:"knowledge_base_id"`
 		Credentials     types.JSON `json:"credentials"`
 		Enabled         *bool      `json:"enabled"`
@@ -225,6 +228,9 @@ func (h *IMHandler) UpdateIMChannel(c *gin.Context) {
 	}
 	if req.OutputMode != nil {
 		channel.OutputMode = *req.OutputMode
+	}
+	if req.SessionMode != nil {
+		channel.SessionMode = *req.SessionMode
 	}
 	if req.KnowledgeBaseID != nil {
 		channel.KnowledgeBaseID = *req.KnowledgeBaseID


### PR DESCRIPTION
## Summary

Persist the existing `session_mode` field when IM channels are created or updated through the API.

## Root cause

The IM channel model and session resolver already support `user` and `thread` modes, but the create and update request structs discarded the submitted `session_mode` value. UI/API configuration therefore remained at the default `user` mode.

## Impact

Thread-capable IM adapters can now use the existing shared session-mode configuration through the normal channel settings API.

## Validation

- `go test ./internal/handler -run '^$'`
- Full `go test ./internal/handler` is currently blocked by pre-existing `TestPutTenantParserConfigAdminPreservesRedactedSecrets` (expected 200, got 400), unrelated to this change.
