### PR TITLE
feat(yunzhijia): support thread sessions

### DIFF
--- a/frontend/src/components/IMChannelPanel.vue
+++ b/frontend/src/components/IMChannelPanel.vue
@@ -775,7 +775,7 @@ function resolvedChannelName(): string {
 }
 
 function platformSupportsThread(platform: string): boolean {
-  return ['slack', 'mattermost', 'feishu', 'lark', 'telegram'].includes(platform);
+  return ['slack', 'mattermost', 'feishu', 'lark', 'telegram', 'yunzhijia'].includes(platform);
 }
 
 watch(

--- a/internal/im/yunzhijia/adapter.go
+++ b/internal/im/yunzhijia/adapter.go
@@ -162,6 +162,12 @@ func toIncomingMessage(ctx context.Context, msg *callbackMessage) *im.IncomingMe
 	if err != nil {
 		logger.Warnf(ctx, "[Yunzhijia] Failed to parse msgParam: msgId=%s err=%v", msg.MsgID, err)
 	}
+	if param != nil {
+		// Keep topic diagnostics to identifiers only: they are sufficient to
+		// validate reply-root stability without recording user message content.
+		logger.Infof(ctx, "[Yunzhijia] Thread callback: msg_id=%s reply_msg_id=%s reply_root_msg_id=%s",
+			msg.MsgID, param.ReplyMsgID, param.ReplyRootMsgID)
+	}
 	image, hasImage := param.firstImage()
 
 	content := strings.TrimSpace(msg.Content)
@@ -202,6 +208,7 @@ func toIncomingMessage(ctx context.Context, msg *callbackMessage) *im.IncomingMe
 		ChatType:    chatType,
 		Content:     content,
 		MessageID:   msg.MsgID,
+		ThreadID:    threadIDForMessage(msg.MsgID, param),
 		Extra: map[string]string{
 			"robot_id":      msg.RobotID,
 			"robot_name":    msg.RobotName,
@@ -219,6 +226,16 @@ func toIncomingMessage(ctx context.Context, msg *callbackMessage) *im.IncomingMe
 		incoming.Extra["yunzhijia_image_height"] = fmt.Sprintf("%d", image.Height)
 	}
 	return incoming
+}
+
+// threadIDForMessage returns the message-thread identifier received from
+// Yunzhijia. A top-level message starts a new thread with its own msgId;
+// replies carry replyRootMsgId (normally the bot message at the thread root).
+func threadIDForMessage(messageID string, param *messageParam) string {
+	if param != nil && param.ReplyRootMsgID != "" {
+		return param.ReplyRootMsgID
+	}
+	return messageID
 }
 
 func firstNonEmpty(values ...string) string {
@@ -298,12 +315,18 @@ func (a *Adapter) SendReply(ctx context.Context, incoming *im.IncomingMessage, r
 	}
 	if reply.Extra != nil {
 		if formatType, ok := reply.Extra["yunzhijia_format_type"]; ok {
-			if formatType == "" {
-				payload.Param = nil
-			} else {
-				payload.Param = &sendMessageParam{FormatType: formatType}
-			}
+			payload.Param.FormatType = formatType
 		}
+	}
+	if incoming.MessageID != "" {
+		payload.ParamType = 3
+		payload.Param.ReplyMsgID = incoming.MessageID
+		payload.Param.IsReference = true
+		payload.Param.ReplySummary = incoming.Content
+		payload.Param.ReplyPersonName = incoming.UserName
+	} else if payload.Param.FormatType == "" {
+		// Keep the prior opt-out behaviour for non-reference replies.
+		payload.Param = nil
 	}
 
 	// When groupType == 3, don't set notifyParams (per reference implementation).

--- a/internal/im/yunzhijia/adapter_test.go
+++ b/internal/im/yunzhijia/adapter_test.go
@@ -112,6 +112,45 @@ func TestToIncomingMessageParsesMsgParamImage(t *testing.T) {
 	}
 }
 
+func TestToIncomingMessageUsesYunzhijiaReplyRootAsThreadID(t *testing.T) {
+	msg := &callbackMessage{
+		Type:           2,
+		RobotID:        "BOT-1",
+		RobotName:      "Websocket",
+		GroupID:        "group-1",
+		OperatorOpenid: "user-b",
+		Time:           123,
+		MsgID:          "message-b",
+		Content:        "@Websocket follow up",
+		MsgParam:       `{"replyMsgId":"BOT-answer-1","replyRootMsgId":"BOT-answer-1","replyPersonId":"BOT-1"}`,
+	}
+
+	got := toIncomingMessage(t.Context(), msg)
+	if got == nil {
+		t.Fatal("toIncomingMessage() returned nil")
+	}
+	if got.ThreadID != "BOT-answer-1" {
+		t.Fatalf("ThreadID = %q, want BOT-answer-1", got.ThreadID)
+	}
+}
+
+func TestThreadIDForTopLevelMessage(t *testing.T) {
+	if got := threadIDForMessage("message-a", &messageParam{}); got != "message-a" {
+		t.Fatalf("threadIDForMessage() = %q, want message-a", got)
+	}
+}
+
+func TestToIncomingMessageAcceptsStringNotifyType(t *testing.T) {
+	msg := &callbackMessage{
+		Type: 2, RobotID: "BOT-1", RobotName: "Websocket", OperatorOpenid: "user",
+		Time: 123, MsgID: "message", Content: "reply text",
+		MsgParam: `{"notifyTo":["BOT-1"],"notifyType":"1","replyMsgId":"BOT-answer"}`,
+	}
+	if got := toIncomingMessage(t.Context(), msg); got == nil {
+		t.Fatal("toIncomingMessage() = nil; string notifyType must not prevent bot mention detection")
+	}
+}
+
 func TestToIncomingMessageAcceptsMsgParamMention(t *testing.T) {
 	msg := &callbackMessage{
 		Type:           2,
@@ -182,6 +221,30 @@ func TestSendReplyAcceptsAny2xxAndBuildsPayload(t *testing.T) {
 	}
 	if payload.Param == nil || payload.Param.FormatType != markdownFormatType {
 		t.Fatalf("expected markdown format param by default, got %#v", payload.Param)
+	}
+}
+
+func TestSendReplyReferencesIncomingMessage(t *testing.T) {
+	adapter := NewAdapter("https://www.yunzhijia.com/send", "", "", "", 10, "yunzhijia.com")
+	var payload sendMessagePayload
+	adapter.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"data":{"msgId":"BOT-answer-1"}}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	incoming := &im.IncomingMessage{MessageID: "message-a", Content: "question", UserName: "Alice"}
+	reply := &im.ReplyMessage{Content: "answer"}
+	if err := adapter.SendReply(context.Background(), incoming, reply); err != nil {
+		t.Fatalf("SendReply() error = %v", err)
+	}
+	if payload.ParamType != 3 || payload.Param == nil || payload.Param.ReplyMsgID != "message-a" || !payload.Param.IsReference {
+		t.Fatalf("reference payload = %#v", payload)
 	}
 }
 

--- a/internal/im/yunzhijia/types.go
+++ b/internal/im/yunzhijia/types.go
@@ -27,9 +27,14 @@ type callbackMessage struct {
 }
 
 type messageParam struct {
-	Desc       []messageParamDesc `json:"desc"`
-	NotifyTo   []string           `json:"notifyTo"`
-	NotifyType int                `json:"notifyType"`
+	Desc     []messageParamDesc `json:"desc"`
+	NotifyTo []string           `json:"notifyTo"`
+	// Yunzhijia sends this as either a number or a string depending on the
+	// message client. We do not use its value, but it must be tolerant so a
+	// reply's notifyTo list remains available for mention detection.
+	NotifyType     json.RawMessage `json:"notifyType"`
+	ReplyMsgID     string          `json:"replyMsgId"`
+	ReplyRootMsgID string          `json:"replyRootMsgId"`
 }
 
 type messageParamDesc struct {
@@ -46,6 +51,7 @@ type sendMessagePayload struct {
 	MsgType      int               `json:"msgtype"`
 	Content      string            `json:"content"`
 	NotifyParams []notifyParam     `json:"notifyParams,omitempty"`
+	ParamType    int               `json:"paramType,omitempty"`
 	Param        *sendMessageParam `json:"param,omitempty"`
 }
 
@@ -58,7 +64,11 @@ type notifyParam struct {
 // sendMessageParam carries extra rendering options for a Yunzhijia reply,
 // such as requesting Markdown rendering of Content via formatType.
 type sendMessageParam struct {
-	FormatType string `json:"formatType,omitempty"`
+	FormatType      string `json:"formatType,omitempty"`
+	ReplyMsgID      string `json:"replyMsgId,omitempty"`
+	IsReference     bool   `json:"isReference,omitempty"`
+	ReplySummary    string `json:"replySummary,omitempty"`
+	ReplyPersonName string `json:"replyPersonName,omitempty"`
 }
 
 type appAccessTokenResponse struct {


### PR DESCRIPTION
## Summary

Add Yunzhijia support for the existing thread-session model.

## Changes

- Map `replyRootMsgId` to the shared `IncomingMessage.ThreadID` field, falling back to the top-level message ID.
- Send bot answers as Yunzhijia reference replies so participants can continue a topic.
- Accept both string and numeric `notifyType` callback payloads.
- Enable the existing thread-mode option for Yunzhijia in the channel settings UI.

Yunzhijia bot answers are reference replies in both user and thread session modes. `session_mode` controls only WeKnora session grouping.

## Dependency

This PR depends on #2629, which persists the existing `session_mode` field through the IM channel create/update API.

## Manual validation

Verified with a real Yunzhijia group:

1. Sent a top-level message mentioning the bot.
2. Confirmed the bot responded with a reference reply.
3. Replied to successive bot responses multiple times.
4. Confirmed callbacks retained the same `replyRootMsgId` as the original top-level message ID.
5. Confirmed all follow-up messages resolved to one WeKnora session.
6. Confirmed a new top-level message created a separate session.

Observed relationship: `top-level msgId=A → bot reply B → follow-up C`; subsequent callbacks had `replyMsgId=B` (or the reply being addressed) while `replyRootMsgId` remained `A`.

## Validation

- `go test ./internal/im/yunzhijia ./internal/im`
