### PR TITLE
fix: make document and knowledge-base deletion durable / 修复文档与知识库的可靠删除

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -590,7 +590,7 @@ export default {
     clearSelection: 'Deselect all',
     batchDelete: 'Delete selected',
     confirmBatchDeleteDocument: 'Delete {count} selected documents? This action cannot be undone.',
-    batchDeleteSuccess: 'Deleted {count} documents',
+    batchDeleteSuccess: 'Deletion task submitted for {count} documents',
     batchDeleteFailed: 'Batch delete failed',
     batchTag: 'Batch Tag',
     batchTagDialogHeading: 'Batch Tag',
@@ -648,7 +648,7 @@ export default {
     allUploadSuccess: 'All files uploaded successfully ({count} files)',
     partialUploadSuccess: 'Partial upload success (success: {success}, failed: {fail})',
     allUploadFailed: 'All files failed to upload ({count} files)',
-    deleteSuccess: 'Knowledge deleted successfully!',
+    deleteSuccess: 'Deletion task submitted',
     chunkLoadFailed: 'Failed to load chunks'
   },
   uploadConfirm: {
@@ -1786,7 +1786,7 @@ export default {
       sharedReadonly: 'Shared with me · View only'
     },
     messages: {
-      deleted: 'Knowledge base deleted',
+      deleted: 'Knowledge base deletion task submitted',
       deleteFailed: 'Failed to delete knowledge base',
       duplicateSuccess: 'Knowledge base duplicate created (content not included)',
       duplicateFailed: 'Failed to create knowledge base duplicate'

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -4132,7 +4132,7 @@ export default {
       goToKb: '지식베이스를 입력하세요'
     },
     messages: {
-      deleted: '삭제됨',
+      deleted: '지식베이스 삭제 작업이 제출되었습니다',
       deleteFailed: '삭제 실패',
       duplicateSuccess: '지식베이스 복제본이 생성되었습니다(콘텐츠 제외)',
       duplicateFailed: '지식베이스 복제본 생성 실패'
@@ -5500,7 +5500,7 @@ export default {
     clearSelection: '선택 해제',
     batchDelete: '선택 삭제',
     confirmBatchDeleteDocument: '선택한 {count}개 문서를 삭제하시겠습니까? 삭제 후 복구할 수 없습니다.',
-    batchDeleteSuccess: '{count}개 문서가 삭제되었습니다',
+    batchDeleteSuccess: '{count}개 문서의 삭제 작업이 제출되었습니다',
     batchDeleteFailed: '일괄 삭제 실패',
     batchTag: '일괄 태그',
     batchTagDialogHeading: '일괄 태그 지정',
@@ -5558,7 +5558,7 @@ export default {
     allUploadSuccess: '모든 파일 업로드 성공 ({count}개)',
     partialUploadSuccess: '일부 파일 업로드 성공 (성공: {success}, 실패: {fail})',
     allUploadFailed: '모든 파일 업로드 실패 ({count}개)',
-    deleteSuccess: '지식이 성공적으로 삭제되었습니다!',
+    deleteSuccess: '삭제 작업이 제출되었습니다',
     chunkLoadFailed: '청크 로드 실패',
     infoCard: {
       tooltip: '지식베이스 정보 보기',

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -4132,7 +4132,7 @@ export default {
       goToKb: 'Go to Knowledge Base'
     },
     messages: {
-      deleted: 'База знаний удалена',
+      deleted: 'Задача удаления базы знаний отправлена',
       deleteFailed: 'Не удалось удалить базу знаний',
       duplicateSuccess: 'Дубликат базы знаний создан (без содержимого)',
       duplicateFailed: 'Не удалось создать дубликат базы знаний'
@@ -5500,7 +5500,7 @@ export default {
     clearSelection: 'Снять выделение',
     batchDelete: 'Удалить выбранные',
     confirmBatchDeleteDocument: 'Удалить {count} выбранных документов? Это действие нельзя отменить.',
-    batchDeleteSuccess: 'Удалено документов: {count}',
+    batchDeleteSuccess: 'Отправлена задача удаления документов: {count}',
     batchDeleteFailed: 'Ошибка пакетного удаления',
     batchTag: 'Пакетная метка',
     batchTagDialogHeading: 'Пакетное назначение меток',
@@ -5558,7 +5558,7 @@ export default {
     allUploadSuccess: 'Все файлы загружены ({count})',
     partialUploadSuccess: 'Частичная загрузка (успешно: {success}, ошибки: {fail})',
     allUploadFailed: 'Все файлы не удалось загрузить ({count})',
-    deleteSuccess: 'Знание удалено!',
+    deleteSuccess: 'Задача удаления отправлена',
     chunkLoadFailed: 'Не удалось загрузить фрагменты',
     infoCard: {
       tooltip: 'Просмотр информации о базе знаний',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -4132,7 +4132,7 @@ export default {
       goToKb: '进入知识库'
     },
     messages: {
-      deleted: '已删除',
+      deleted: '知识库删除任务已提交',
       deleteFailed: '删除失败',
       duplicateSuccess: '知识库副本已创建（不包含知识内容）',
       duplicateFailed: '创建知识库副本失败'
@@ -5500,7 +5500,7 @@ export default {
     clearSelection: '取消选择',
     batchDelete: '批量删除',
     confirmBatchDeleteDocument: '确认删除选中的 {count} 个文档？删除后将无法恢复。',
-    batchDeleteSuccess: '成功删除 {count} 个文档',
+    batchDeleteSuccess: '已提交 {count} 个文档的删除任务',
     batchDeleteFailed: '批量删除失败',
     batchTag: '批量打标签',
     batchTagDialogHeading: '批量打标签',
@@ -5558,7 +5558,7 @@ export default {
     allUploadSuccess: '所有文件上传成功（{count}个）',
     partialUploadSuccess: '部分文件上传成功（成功：{success}，失败：{fail}）',
     allUploadFailed: '所有文件上传失败（{count}个）',
-    deleteSuccess: '知识删除成功！',
+    deleteSuccess: '删除任务已提交',
     chunkLoadFailed: '分块加载失败',
     infoCard: {
       tooltip: '查看知识库信息',

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -2080,7 +2080,7 @@ const confirmBatchDelete = async () => {
   try {
     const res: any = await batchDeleteKnowledge(kbId.value, ids);
     if (res?.success) {
-      MessagePlugin.success(t('knowledgeBase.batchDeleteSuccess', { count: ids.length }));
+      MessagePlugin.info(t('knowledgeBase.batchDeleteSuccess', { count: ids.length }));
       clearSelection();
       batchMode.value = false;
       resetPage();

--- a/frontend/src/views/knowledge/KnowledgeBaseList.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseList.vue
@@ -1537,7 +1537,7 @@ const confirmDelete = () => {
 
   deleteKnowledgeBase(deletingKb.value.id).then((res: any) => {
     if (res.success) {
-      MessagePlugin.success(t('knowledgeList.messages.deleted'))
+      MessagePlugin.info(t('knowledgeList.messages.deleted'))
       deleteVisible.value = false
       deletingKb.value = null
       fetchList(true)

--- a/internal/application/repository/knowledge.go
+++ b/internal/application/repository/knowledge.go
@@ -97,6 +97,21 @@ func (r *knowledgeRepository) ListKnowledgeByKnowledgeBaseID(
 	return knowledges, nil
 }
 
+// ListKnowledgeByKnowledgeBaseIDUnscoped includes soft-deleted rows so a
+// replayed knowledge-base deletion can clean vector, graph, Wiki, and file
+// data left by older failed delete attempts.
+func (r *knowledgeRepository) ListKnowledgeByKnowledgeBaseIDUnscoped(
+	ctx context.Context, tenantID uint64, kbID string,
+) ([]*types.Knowledge, error) {
+	var knowledges []*types.Knowledge
+	if err := r.db.WithContext(ctx).Unscoped().
+		Where("tenant_id = ? AND knowledge_base_id = ?", tenantID, kbID).
+		Order("created_at DESC").Find(&knowledges).Error; err != nil {
+		return nil, err
+	}
+	return knowledges, nil
+}
+
 // applyKnowledgeListFilter applies the optional filter dimensions of
 // KnowledgeListFilter to a GORM query. Tenant / knowledge base scoping must be
 // applied by the caller before invoking this helper.

--- a/internal/application/repository/knowledge_unscoped_delete_test.go
+++ b/internal/application/repository/knowledge_unscoped_delete_test.go
@@ -1,0 +1,35 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestListKnowledgeByKnowledgeBaseIDUnscopedIncludesSoftDeletedRows(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE knowledges (
+		id TEXT PRIMARY KEY,
+		tenant_id INTEGER NOT NULL,
+		knowledge_base_id TEXT NOT NULL,
+		created_at DATETIME,
+		deleted_at DATETIME
+	)`).Error)
+	require.NoError(t, db.Exec(
+		"INSERT INTO knowledges (id, tenant_id, knowledge_base_id, created_at, deleted_at) VALUES (?, ?, ?, ?, ?)",
+		"knowledge-deleted", 1, "kb-1", time.Now(), time.Now(),
+	).Error)
+
+	repo := &knowledgeRepository{db: db}
+	items, err := repo.ListKnowledgeByKnowledgeBaseIDUnscoped(context.Background(), 1, "kb-1")
+
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.Equal(t, "knowledge-deleted", items[0].ID)
+	require.True(t, items[0].DeletedAt.Valid)
+}

--- a/internal/application/repository/knowledgebase.go
+++ b/internal/application/repository/knowledgebase.go
@@ -177,6 +177,44 @@ func (r *knowledgeBaseRepository) DeleteKnowledgeBase(ctx context.Context, id st
 	return r.db.WithContext(ctx).Where("id = ?", id).Delete(&types.KnowledgeBase{}).Error
 }
 
+// DeleteKnowledgeBaseWithPendingOp commits the logical deletion and its
+// durable cleanup intent in one database transaction. The worker trigger may
+// be lost or ambiguously acknowledged by Redis; the pending row remains the
+// source of truth and is re-dispatched until cleanup succeeds.
+func (r *knowledgeBaseRepository) DeleteKnowledgeBaseWithPendingOp(
+	ctx context.Context,
+	id string,
+	tenantID uint64,
+	op *types.TaskPendingOp,
+) error {
+	if id == "" || tenantID == 0 {
+		return errors.New("knowledge base delete outbox: id and tenant_id are required")
+	}
+	if err := preparePendingOp(op); err != nil {
+		return err
+	}
+	if op.TenantID != tenantID || op.TaskType != types.TypeKBDelete ||
+		op.Scope != types.TaskScopeKnowledgeBaseDelete || op.ScopeID != id ||
+		op.DedupKey != id || op.Op != types.TaskOpKnowledgeBaseDelete {
+		return errors.New("knowledge base delete outbox: pending operation scope mismatch")
+	}
+
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(op).Error; err != nil {
+			return err
+		}
+		result := tx.Where("id = ? AND tenant_id = ?", id, tenantID).
+			Delete(&types.KnowledgeBase{})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 1 {
+			return ErrKnowledgeBaseNotFound
+		}
+		return nil
+	})
+}
+
 // CountByVectorStoreID counts active knowledge bases that are bound to the
 // given vector store within a tenant scope.
 //

--- a/internal/application/repository/knowledgebase_sqlite_test.go
+++ b/internal/application/repository/knowledgebase_sqlite_test.go
@@ -1,15 +1,141 @@
 package repository
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+func TestDeleteKnowledgeBaseWithPendingOpCommitsAtomically(t *testing.T) {
+	db := setupKBTestDB(t)
+	require.NoError(t, db.Exec(taskPendingOpsTestDDL).Error)
+	kb := makeKB(nil)
+	require.NoError(t, db.Create(kb).Error)
+
+	repo := NewKnowledgeBaseRepository(db)
+	outbox, ok := repo.(interfaces.KnowledgeBaseDeleteOutbox)
+	require.True(t, ok)
+	payload, err := json.Marshal(types.KBDeletePayload{
+		TenantID:        kb.TenantID,
+		KnowledgeBaseID: kb.ID,
+	})
+	require.NoError(t, err)
+	op := &types.TaskPendingOp{
+		TenantID: kb.TenantID,
+		TaskType: types.TypeKBDelete,
+		Scope:    types.TaskScopeKnowledgeBaseDelete,
+		ScopeID:  kb.ID,
+		Op:       types.TaskOpKnowledgeBaseDelete,
+		DedupKey: kb.ID,
+		Payload:  payload,
+	}
+
+	require.NoError(t, outbox.DeleteKnowledgeBaseWithPendingOp(
+		context.Background(), kb.ID, kb.TenantID, op,
+	))
+
+	var activeCount int64
+	require.NoError(t, db.Model(&types.KnowledgeBase{}).
+		Where("id = ?", kb.ID).Count(&activeCount).Error)
+	assert.Zero(t, activeCount)
+	var deleted types.KnowledgeBase
+	require.NoError(t, db.Unscoped().First(&deleted, "id = ?", kb.ID).Error)
+	assert.True(t, deleted.DeletedAt.Valid)
+	var persisted types.TaskPendingOp
+	require.NoError(t, db.First(&persisted, "scope_id = ?", kb.ID).Error)
+	assert.Equal(t, types.TaskScopeKnowledgeBaseDelete, persisted.Scope)
+	assert.JSONEq(t, string(payload), string(persisted.Payload))
+}
+
+func TestDeleteKnowledgeBaseWithPendingOpRollsBackWhenDeleteFails(t *testing.T) {
+	db := setupKBTestDB(t)
+	require.NoError(t, db.Exec(taskPendingOpsTestDDL).Error)
+	kbID := uuid.New().String()
+
+	repo := NewKnowledgeBaseRepository(db)
+	outbox := repo.(interfaces.KnowledgeBaseDeleteOutbox)
+	err := outbox.DeleteKnowledgeBaseWithPendingOp(context.Background(), kbID, 1,
+		&types.TaskPendingOp{
+			TenantID: 1,
+			TaskType: types.TypeKBDelete,
+			Scope:    types.TaskScopeKnowledgeBaseDelete,
+			ScopeID:  kbID,
+			Op:       types.TaskOpKnowledgeBaseDelete,
+			DedupKey: kbID,
+			Payload:  []byte(`{}`),
+		})
+	require.ErrorIs(t, err, ErrKnowledgeBaseNotFound)
+
+	var pendingCount int64
+	require.NoError(t, db.Model(&types.TaskPendingOp{}).Count(&pendingCount).Error)
+	assert.Zero(t, pendingCount, "the pending operation must roll back with the failed soft-delete")
+}
+
+func TestDeleteKnowledgeBaseWithPendingOpRejectsMismatchedScopeWithoutDeleting(t *testing.T) {
+	db := setupKBTestDB(t)
+	require.NoError(t, db.Exec(taskPendingOpsTestDDL).Error)
+	kb := makeKB(nil)
+	require.NoError(t, db.Create(kb).Error)
+
+	repo := NewKnowledgeBaseRepository(db)
+	outbox := repo.(interfaces.KnowledgeBaseDeleteOutbox)
+	err := outbox.DeleteKnowledgeBaseWithPendingOp(context.Background(), kb.ID, kb.TenantID,
+		&types.TaskPendingOp{
+			TenantID: kb.TenantID,
+			TaskType: types.TypeKBDelete,
+			Scope:    types.TaskScopeKnowledgeBaseDelete,
+			ScopeID:  "another-kb",
+			Op:       types.TaskOpKnowledgeBaseDelete,
+			DedupKey: kb.ID,
+			Payload:  []byte(`{}`),
+		})
+	require.Error(t, err)
+
+	var activeCount int64
+	require.NoError(t, db.Model(&types.KnowledgeBase{}).
+		Where("id = ?", kb.ID).Count(&activeCount).Error)
+	assert.EqualValues(t, 1, activeCount)
+	var pendingCount int64
+	require.NoError(t, db.Model(&types.TaskPendingOp{}).Count(&pendingCount).Error)
+	assert.Zero(t, pendingCount)
+}
+
+func TestDeleteKnowledgeBaseWithPendingOpRejectsMismatchedOperation(t *testing.T) {
+	db := setupKBTestDB(t)
+	require.NoError(t, db.Exec(taskPendingOpsTestDDL).Error)
+	kb := makeKB(nil)
+	require.NoError(t, db.Create(kb).Error)
+
+	repo := NewKnowledgeBaseRepository(db)
+	outbox := repo.(interfaces.KnowledgeBaseDeleteOutbox)
+	err := outbox.DeleteKnowledgeBaseWithPendingOp(context.Background(), kb.ID, kb.TenantID,
+		&types.TaskPendingOp{
+			TenantID: kb.TenantID,
+			TaskType: types.TypeKBDelete,
+			Scope:    types.TaskScopeKnowledgeBaseDelete,
+			ScopeID:  kb.ID,
+			Op:       "not-delete",
+			DedupKey: kb.ID,
+			Payload:  []byte(`{}`),
+		})
+	require.Error(t, err)
+
+	var activeCount int64
+	require.NoError(t, db.Model(&types.KnowledgeBase{}).
+		Where("id = ?", kb.ID).Count(&activeCount).Error)
+	assert.EqualValues(t, 1, activeCount)
+	var pendingCount int64
+	require.NoError(t, db.Model(&types.TaskPendingOp{}).Count(&pendingCount).Error)
+	assert.Zero(t, pendingCount)
+}
 
 // knowledgeBasesTestDDL mirrors the `knowledge_bases` section of
 // migrations/sqlite/000000_init.up.sql. We inline the DDL here instead of

--- a/internal/application/repository/retriever/doris/repository.go
+++ b/internal/application/repository/retriever/doris/repository.go
@@ -245,6 +245,24 @@ func (r *dorisRepository) DeleteByKnowledgeIDList(ctx context.Context,
 	return r.deleteByField(ctx, fieldKnowledgeID, knowledgeIDList, dimension)
 }
 
+func (r *dorisRepository) DeleteByKnowledgeIDListAllDimensions(
+	ctx context.Context, knowledgeIDList []string, _ string,
+) error {
+	if len(knowledgeIDList) == 0 {
+		return nil
+	}
+	tables, err := r.listEmbeddingTables(ctx)
+	if err != nil {
+		return fmt.Errorf("list embedding tables for knowledge deletion: %w", err)
+	}
+	for _, table := range tables {
+		if err := r.deleteByFieldFromTable(ctx, table, fieldKnowledgeID, knowledgeIDList); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // DeleteBySourceIDList 用 source_id 列删除。
 func (r *dorisRepository) DeleteBySourceIDList(ctx context.Context,
 	sourceIDList []string, dimension int, _ string,
@@ -257,12 +275,18 @@ func (r *dorisRepository) DeleteBySourceIDList(ctx context.Context,
 func (r *dorisRepository) deleteByField(ctx context.Context,
 	field string, ids []string, dimension int,
 ) error {
-	log := logger.GetLogger(ctx)
 	if len(ids) == 0 {
 		return nil
 	}
 
 	table := r.getTableName(dimension)
+	return r.deleteByFieldFromTable(ctx, table, field, ids)
+}
+
+func (r *dorisRepository) deleteByFieldFromTable(
+	ctx context.Context, table, field string, ids []string,
+) error {
+	log := logger.GetLogger(ctx)
 	placeholders := make([]string, len(ids))
 	args := make([]any, len(ids))
 	for i, v := range ids {

--- a/internal/application/repository/retriever/doris/repository_test.go
+++ b/internal/application/repository/retriever/doris/repository_test.go
@@ -321,6 +321,28 @@ func TestDeleteByKnowledgeIDList_NoOpOnEmpty(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestDeleteByKnowledgeIDListAllDimensionsDeletesEveryMatchingTable(t *testing.T) {
+	repo, mock, _, cleanup := newTestRepo(t)
+	defer cleanup()
+
+	mock.ExpectQuery(`SELECT TABLE_NAME FROM information_schema.tables`).
+		WithArgs("weknora", "weknora_embeddings\\_%").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).
+			AddRow("weknora_embeddings_2048").
+			AddRow("weknora_embeddings_4096"))
+	mock.ExpectExec("DELETE FROM `weknora_embeddings_2048` WHERE knowledge_id IN \\(\\?\\)").
+		WithArgs("knowledge-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM `weknora_embeddings_4096` WHERE knowledge_id IN \\(\\?\\)").
+		WithArgs("knowledge-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	require.NoError(t, repo.DeleteByKnowledgeIDListAllDimensions(
+		context.Background(), []string{"knowledge-1"}, "file",
+	))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestVectorRetrieve_SQLShape(t *testing.T) {
 	repo, mock, _, cleanup := newTestRepo(t)
 	defer cleanup()

--- a/internal/application/repository/retriever/milvus/repository.go
+++ b/internal/application/repository/retriever/milvus/repository.go
@@ -363,6 +363,35 @@ func (m *milvusRepository) DeleteByKnowledgeIDList(ctx context.Context,
 
 	collectionName := m.getCollectionName(dimension)
 	log.Infof("[Milvus] Deleting indices by knowledge IDs from %s, count: %d", collectionName, len(knowledgeIDList))
+	return m.deleteKnowledgeIDsFromCollection(ctx, collectionName, knowledgeIDList)
+}
+
+func (m *milvusRepository) DeleteByKnowledgeIDListAllDimensions(
+	ctx context.Context, knowledgeIDList []string, _ string,
+) error {
+	if len(knowledgeIDList) == 0 {
+		return nil
+	}
+	collections, err := m.client.ListCollections(ctx, client.NewListCollectionOption())
+	if err != nil {
+		return fmt.Errorf("failed to list collections for knowledge deletion: %w", err)
+	}
+	prefix := m.collectionBaseName + "_"
+	for _, collectionName := range collections {
+		if !strings.HasPrefix(collectionName, prefix) {
+			continue
+		}
+		if err := m.deleteKnowledgeIDsFromCollection(ctx, collectionName, knowledgeIDList); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *milvusRepository) deleteKnowledgeIDsFromCollection(
+	ctx context.Context, collectionName string, knowledgeIDList []string,
+) error {
+	log := logger.GetLogger(ctx)
 
 	deleteOpt := client.NewDeleteOption(collectionName)
 	deleteOpt.WithStringIDs(fieldKnowledgeID, knowledgeIDList)
@@ -372,7 +401,7 @@ func (m *milvusRepository) DeleteByKnowledgeIDList(ctx context.Context,
 		return fmt.Errorf("failed to delete by knowledge IDs: %w", err)
 	}
 
-	log.Infof("[Milvus] Successfully deleted documents by knowledge IDs")
+	log.Infof("[Milvus] Successfully deleted documents by knowledge IDs from %s", collectionName)
 	return nil
 }
 

--- a/internal/application/repository/retriever/opensearch/crud.go
+++ b/internal/application/repository/retriever/opensearch/crud.go
@@ -349,6 +349,23 @@ func (r *Repository) DeleteByKnowledgeIDList(
 	return r.deleteByList(ctx, knowledgeIDs, dim, "knowledge_id")
 }
 
+func (r *Repository) DeleteByKnowledgeIDListAllDimensions(
+	ctx context.Context, knowledgeIDs []string, _ string,
+) error {
+	if len(knowledgeIDs) == 0 {
+		return nil
+	}
+	for from := 0; from < len(knowledgeIDs); from += 1000 {
+		to := min(from+1000, len(knowledgeIDs))
+		if err := r.deleteByTermsAcrossIndices(
+			ctx, r.baseIndex+"_*", "knowledge_id", knowledgeIDs[from:to],
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // deleteByList factors the common cap / empty / ensureReady / dispatch
 // logic out of the three DeleteBy* methods. dim==0 routes to the
 // dim-less keywords index.
@@ -380,6 +397,18 @@ func (r *Repository) deleteByList(
 func (r *Repository) deleteByTerms(
 	ctx context.Context, index, field string, values []string,
 ) error {
+	return r.deleteByTermsRequest(ctx, index, field, values, false)
+}
+
+func (r *Repository) deleteByTermsAcrossIndices(
+	ctx context.Context, index, field string, values []string,
+) error {
+	return r.deleteByTermsRequest(ctx, index, field, values, true)
+}
+
+func (r *Repository) deleteByTermsRequest(
+	ctx context.Context, index, field string, values []string, allowMissingIndices bool,
+) error {
 	body, err := json.Marshal(map[string]any{
 		"query": map[string]any{
 			"terms": map[string]any{field: values},
@@ -389,10 +418,15 @@ func (r *Repository) deleteByTerms(
 		return fmt.Errorf("opensearch: marshal delete body: %w", err)
 	}
 	refresh := true
+	params := osapi.DocumentDeleteByQueryParams{Refresh: &refresh}
+	if allowMissingIndices {
+		params.AllowNoIndices = &allowMissingIndices
+		params.IgnoreUnavailable = &allowMissingIndices
+	}
 	req := osapi.DocumentDeleteByQueryReq{
 		Indices: []string{index},
 		Body:    bytes.NewReader(body),
-		Params:  osapi.DocumentDeleteByQueryParams{Refresh: &refresh},
+		Params:  params,
 	}
 	resp, err := r.client.Document.DeleteByQuery(ctx, req)
 	if err != nil {

--- a/internal/application/repository/retriever/opensearch/repository_test.go
+++ b/internal/application/repository/retriever/opensearch/repository_test.go
@@ -65,6 +65,55 @@ func newTestRepo(t *testing.T, handler http.HandlerFunc) (*Repository, *httptest
 	return repo, ts
 }
 
+func TestDeleteByKnowledgeIDListAllDimensionsUsesIndexWildcard(t *testing.T) {
+	var requestPath string
+	var requestQuery string
+	repo, server := newTestRepo(t, func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		requestQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"deleted": 1}`))
+	})
+	defer server.Close()
+
+	err := repo.DeleteByKnowledgeIDListAllDimensions(
+		context.Background(), []string{"knowledge-1"}, "file",
+	)
+	if err != nil {
+		t.Fatalf("DeleteByKnowledgeIDListAllDimensions returned error: %v", err)
+	}
+	if !strings.Contains(requestPath, "/weknora_test_*/_delete_by_query") {
+		t.Fatalf("request path = %q, want cross-dimension wildcard", requestPath)
+	}
+	if !strings.Contains(requestQuery, "allow_no_indices=true") ||
+		!strings.Contains(requestQuery, "ignore_unavailable=true") {
+		t.Fatalf("request query = %q, want idempotent missing-index flags", requestQuery)
+	}
+}
+
+func TestDeleteByKnowledgeIDListAllDimensionsBatchesLargeLists(t *testing.T) {
+	var requestCount int
+	repo, server := newTestRepo(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"deleted": 1}`))
+	})
+	defer server.Close()
+
+	knowledgeIDs := make([]string, 2001)
+	for i := range knowledgeIDs {
+		knowledgeIDs[i] = fmt.Sprintf("knowledge-%d", i)
+	}
+	if err := repo.DeleteByKnowledgeIDListAllDimensions(
+		context.Background(), knowledgeIDs, "file",
+	); err != nil {
+		t.Fatalf("DeleteByKnowledgeIDListAllDimensions returned error: %v", err)
+	}
+	if requestCount != 3 {
+		t.Fatalf("delete-by-query requests = %d, want 3", requestCount)
+	}
+}
+
 // ============================================================================
 // Interface satisfaction (compile-time check — duplicates the var _ assertion
 // in repository.go but documents the intent explicitly in tests).

--- a/internal/application/repository/retriever/qdrant/repository.go
+++ b/internal/application/repository/retriever/qdrant/repository.go
@@ -311,6 +311,35 @@ func (q *qdrantRepository) DeleteByKnowledgeIDList(ctx context.Context,
 
 	collectionName := q.getCollectionName(dimension)
 	log.Infof("[Qdrant] Deleting indices by knowledge IDs from %s, count: %d", collectionName, len(knowledgeIDList))
+	return q.deleteKnowledgeIDsFromCollection(ctx, collectionName, knowledgeIDList)
+}
+
+func (q *qdrantRepository) DeleteByKnowledgeIDListAllDimensions(
+	ctx context.Context, knowledgeIDList []string, _ string,
+) error {
+	if len(knowledgeIDList) == 0 {
+		return nil
+	}
+	collections, err := q.client.ListCollections(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list collections for knowledge deletion: %w", err)
+	}
+	prefix := q.collectionBaseName + "_"
+	for _, collectionName := range collections {
+		if !strings.HasPrefix(collectionName, prefix) {
+			continue
+		}
+		if err := q.deleteKnowledgeIDsFromCollection(ctx, collectionName, knowledgeIDList); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (q *qdrantRepository) deleteKnowledgeIDsFromCollection(
+	ctx context.Context, collectionName string, knowledgeIDList []string,
+) error {
+	log := logger.GetLogger(ctx)
 
 	_, err := q.client.Delete(ctx, &qdrant.DeletePoints{
 		CollectionName: collectionName,
@@ -325,7 +354,7 @@ func (q *qdrantRepository) DeleteByKnowledgeIDList(ctx context.Context,
 		return fmt.Errorf("failed to delete by knowledge IDs: %w", err)
 	}
 
-	log.Infof("[Qdrant] Successfully deleted documents by knowledge IDs")
+	log.Infof("[Qdrant] Successfully deleted documents by knowledge IDs from %s", collectionName)
 	return nil
 }
 

--- a/internal/application/repository/retriever/tencentvectordb/repository.go
+++ b/internal/application/repository/retriever/tencentvectordb/repository.go
@@ -143,6 +143,28 @@ func (r *repository) DeleteByKnowledgeIDList(ctx context.Context, knowledgeIDLis
 	return r.deleteByFilter(ctx, dimension, tcvectordb.In(fieldKnowledgeID, knowledgeIDList))
 }
 
+func (r *repository) DeleteByKnowledgeIDListAllDimensions(
+	ctx context.Context, knowledgeIDList []string, _ string,
+) error {
+	if len(knowledgeIDList) == 0 {
+		return nil
+	}
+	collections, err := r.client.Database(r.databaseName).ListCollection(ctx)
+	if err != nil {
+		return fmt.Errorf("tencent vectordb list collections for knowledge deletion: %w", err)
+	}
+	cond := tcvectordb.In(fieldKnowledgeID, knowledgeIDList)
+	for _, collection := range collections.Collections {
+		if !r.matchesCollection(collection.CollectionName) {
+			continue
+		}
+		if err := r.deleteCollectionByFilter(ctx, collection.CollectionName, cond); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (r *repository) CopyIndices(
 	ctx context.Context,
 	sourceKnowledgeBaseID string,
@@ -458,6 +480,10 @@ func (r *repository) deleteByFilter(ctx context.Context, dimension int, cond str
 		return nil
 	}
 	collectionName := r.collectionName(dimension)
+	return r.deleteCollectionByFilter(ctx, collectionName, cond)
+}
+
+func (r *repository) deleteCollectionByFilter(ctx context.Context, collectionName, cond string) error {
 	_, err := r.client.Database(r.databaseName).Collection(collectionName).Delete(ctx, tcvectordb.DeleteDocumentParams{
 		Filter: tcvectordb.NewFilter(cond),
 	})

--- a/internal/application/repository/retriever/weaviate/repository.go
+++ b/internal/application/repository/retriever/weaviate/repository.go
@@ -326,6 +326,35 @@ func (w *weaviateRepository) DeleteByKnowledgeIDList(ctx context.Context,
 
 	collectionName := w.getCollectionName(dimension)
 	log.Infof("[Weaviate] Deleting indices by knowledge IDs from %s, count: %d", collectionName, len(knowledgeIDList))
+	return w.deleteKnowledgeIDsFromCollection(ctx, collectionName, knowledgeIDList)
+}
+
+func (w *weaviateRepository) DeleteByKnowledgeIDListAllDimensions(
+	ctx context.Context, knowledgeIDList []string, _ string,
+) error {
+	if len(knowledgeIDList) == 0 {
+		return nil
+	}
+	collections, err := w.ListCollections(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list collections for knowledge deletion: %w", err)
+	}
+	prefix := w.collectionBaseName + "_"
+	for _, collectionName := range collections {
+		if !strings.HasPrefix(collectionName, prefix) {
+			continue
+		}
+		if err := w.deleteKnowledgeIDsFromCollection(ctx, collectionName, knowledgeIDList); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *weaviateRepository) deleteKnowledgeIDsFromCollection(
+	ctx context.Context, collectionName string, knowledgeIDList []string,
+) error {
+	log := logger.GetLogger(ctx)
 
 	//define filter
 	filter := w.client.Batch().ObjectsBatchDeleter().
@@ -341,7 +370,7 @@ func (w *weaviateRepository) DeleteByKnowledgeIDList(ctx context.Context,
 		log.Errorf("[Weaviate] Failed to delete by knowledge IDs: %v", err)
 		return fmt.Errorf("failed to delete by knowledge IDs: %w", err)
 	}
-	log.Infof("[Weaviate] Successfully deleted documents by knowledge IDs")
+	log.Infof("[Weaviate] Successfully deleted documents by knowledge IDs from %s", collectionName)
 	return nil
 }
 

--- a/internal/application/repository/wiki_page.go
+++ b/internal/application/repository/wiki_page.go
@@ -1123,6 +1123,29 @@ func (r *wikiPageRepository) DeleteByID(ctx context.Context, id string) error {
 	return nil
 }
 
+// DeleteByKnowledgeBaseID permanently removes the complete Wiki scope for a
+// deleted knowledge base. The operation is transactional and idempotent so an
+// asynchronous KB delete can safely retry after a partial infrastructure
+// failure without leaving revisions, folders, or issues behind.
+func (r *wikiPageRepository) DeleteByKnowledgeBaseID(ctx context.Context, kbID string) error {
+	if kbID == "" {
+		return nil
+	}
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for _, model := range []interface{}{
+			&types.WikiPageRevision{},
+			&types.WikiPageIssue{},
+			&types.WikiPage{},
+			&types.WikiFolder{},
+		} {
+			if err := tx.Unscoped().Where("knowledge_base_id = ?", kbID).Delete(model).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
 // escapeLikePattern escapes LIKE / ILIKE metacharacters so the returned string
 // can be safely concatenated with % wildcards without unintended matches.
 // Order matters: escape the backslash first, then the wildcards.

--- a/internal/application/repository/wiki_page.go
+++ b/internal/application/repository/wiki_page.go
@@ -1127,8 +1127,10 @@ func (r *wikiPageRepository) DeleteByID(ctx context.Context, id string) error {
 // deleted knowledge base. The operation is transactional and idempotent so an
 // asynchronous KB delete can safely retry after a partial infrastructure
 // failure without leaving revisions, folders, or issues behind.
-func (r *wikiPageRepository) DeleteByKnowledgeBaseID(ctx context.Context, kbID string) error {
-	if kbID == "" {
+func (r *wikiPageRepository) DeleteByKnowledgeBaseID(
+	ctx context.Context, tenantID uint64, kbID string,
+) error {
+	if tenantID == 0 || kbID == "" {
 		return nil
 	}
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -1138,7 +1140,9 @@ func (r *wikiPageRepository) DeleteByKnowledgeBaseID(ctx context.Context, kbID s
 			&types.WikiPage{},
 			&types.WikiFolder{},
 		} {
-			if err := tx.Unscoped().Where("knowledge_base_id = ?", kbID).Delete(model).Error; err != nil {
+			if err := tx.Unscoped().
+				Where("tenant_id = ? AND knowledge_base_id = ?", tenantID, kbID).
+				Delete(model).Error; err != nil {
 				return err
 			}
 		}

--- a/internal/application/repository/wiki_page_test.go
+++ b/internal/application/repository/wiki_page_test.go
@@ -108,6 +108,48 @@ func setupWikiPagesTestDB(t *testing.T) *gorm.DB {
 	return db
 }
 
+func TestDeleteByKnowledgeBaseIDRemovesCompleteWikiScope(t *testing.T) {
+	db := setupWikiPagesTestDB(t)
+	require.NoError(t, db.AutoMigrate(&types.WikiPageIssue{}))
+	repo := NewWikiPageRepository(db)
+	ctx := context.Background()
+	page := makeWikiPage("kb-delete", "concept/delete", types.WikiPageTypeConcept, types.WikiPageStatusPublished)
+	require.NoError(t, repo.Create(ctx, page))
+	require.NoError(t, db.Create(&types.WikiPageRevision{
+		ID:              uuid.New().String(),
+		TenantID:        1,
+		KnowledgeBaseID: "kb-delete",
+		PageID:          page.ID,
+		Slug:            page.Slug,
+		Version:         1,
+	}).Error)
+	require.NoError(t, db.Create(&types.WikiFolder{
+		ID:              uuid.New().String(),
+		TenantID:        1,
+		KnowledgeBaseID: "kb-delete",
+		Name:            "folder",
+	}).Error)
+	require.NoError(t, db.Create(&types.WikiPageIssue{
+		ID:              uuid.New().String(),
+		TenantID:        1,
+		KnowledgeBaseID: "kb-delete",
+		Slug:            page.Slug,
+	}).Error)
+
+	require.NoError(t, repo.DeleteByKnowledgeBaseID(ctx, "kb-delete"))
+
+	for _, model := range []interface{}{
+		&types.WikiPage{},
+		&types.WikiPageRevision{},
+		&types.WikiFolder{},
+		&types.WikiPageIssue{},
+	} {
+		var count int64
+		require.NoError(t, db.Unscoped().Model(model).Where("knowledge_base_id = ?", "kb-delete").Count(&count).Error)
+		require.Zero(t, count)
+	}
+}
+
 // makeWikiPage builds a minimal WikiPage suitable for insert. Title is
 // derived from the slug so ORDER BY title ASC yields a predictable
 // test ordering without callers having to spell out both fields.

--- a/internal/application/repository/wiki_page_test.go
+++ b/internal/application/repository/wiki_page_test.go
@@ -136,7 +136,32 @@ func TestDeleteByKnowledgeBaseIDRemovesCompleteWikiScope(t *testing.T) {
 		Slug:            page.Slug,
 	}).Error)
 
-	require.NoError(t, repo.DeleteByKnowledgeBaseID(ctx, "kb-delete"))
+	otherTenantPage := makeWikiPage("kb-delete", "concept/preserve", types.WikiPageTypeConcept, types.WikiPageStatusPublished)
+	otherTenantPage.ID = uuid.New().String()
+	otherTenantPage.TenantID = 2
+	require.NoError(t, repo.Create(ctx, otherTenantPage))
+	require.NoError(t, db.Create(&types.WikiPageRevision{
+		ID:              uuid.New().String(),
+		TenantID:        2,
+		KnowledgeBaseID: "kb-delete",
+		PageID:          otherTenantPage.ID,
+		Slug:            otherTenantPage.Slug,
+		Version:         1,
+	}).Error)
+	require.NoError(t, db.Create(&types.WikiFolder{
+		ID:              uuid.New().String(),
+		TenantID:        2,
+		KnowledgeBaseID: "kb-delete",
+		Name:            "preserve-folder",
+	}).Error)
+	require.NoError(t, db.Create(&types.WikiPageIssue{
+		ID:              uuid.New().String(),
+		TenantID:        2,
+		KnowledgeBaseID: "kb-delete",
+		Slug:            otherTenantPage.Slug,
+	}).Error)
+
+	require.NoError(t, repo.DeleteByKnowledgeBaseID(ctx, 1, "kb-delete"))
 
 	for _, model := range []interface{}{
 		&types.WikiPage{},
@@ -145,8 +170,15 @@ func TestDeleteByKnowledgeBaseIDRemovesCompleteWikiScope(t *testing.T) {
 		&types.WikiPageIssue{},
 	} {
 		var count int64
-		require.NoError(t, db.Unscoped().Model(model).Where("knowledge_base_id = ?", "kb-delete").Count(&count).Error)
+		require.NoError(t, db.Unscoped().Model(model).
+			Where("tenant_id = ? AND knowledge_base_id = ?", 1, "kb-delete").
+			Count(&count).Error)
 		require.Zero(t, count)
+		var preserved int64
+		require.NoError(t, db.Unscoped().Model(model).
+			Where("tenant_id = ? AND knowledge_base_id = ?", 2, "kb-delete").
+			Count(&preserved).Error)
+		require.EqualValues(t, 1, preserved)
 	}
 }
 

--- a/internal/application/service/knowledge_delete.go
+++ b/internal/application/service/knowledge_delete.go
@@ -103,14 +103,13 @@ func (s *knowledgeService) DeleteKnowledge(ctx context.Context, id string) error
 	imageURLs := collectImageURLs(ctx, imageInfoStrs)
 
 	wg := errgroup.Group{}
-	// Delete knowledge embeddings from vector store.
-	// Skip entirely when the knowledge has no embedding model (e.g. Wiki-only KB):
-	// nothing was ever written to the vector store, so there is nothing to delete,
-	// and GetEmbeddingModel would fail with "model ID cannot be empty".
+	// Delete knowledge embeddings from every dimension-backed collection.
+	// The stored model may have been removed or its configured dimensions may
+	// have changed since indexing, so deletion must rely only on knowledge ID.
+	// An empty model ID still identifies a Wiki-only document that never wrote
+	// vectors and may not have any retrieve engine configured.
 	if strings.TrimSpace(knowledge.EmbeddingModelID) != "" {
 		wg.Go(func() error {
-			// kb was already loaded above for resolveFileService — reuse its
-			// VectorStoreID for engine routing.
 			var boundStoreID *string
 			if kb != nil {
 				boundStoreID = kb.VectorStoreID
@@ -126,19 +125,14 @@ func (s *knowledgeService) DeleteKnowledge(ctx context.Context, id string) error
 				logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge delete knowledge embedding failed")
 				return err
 			}
-			embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, knowledge.EmbeddingModelID)
-			if err != nil {
-				logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge delete knowledge embedding failed")
-				return err
-			}
-			if err := retrieveEngine.DeleteByKnowledgeIDList(ctx, []string{knowledge.ID}, embeddingModel.GetDimensions(), knowledge.Type); err != nil {
+			if err := retrieveEngine.DeleteByKnowledgeIDListAllDimensions(
+				ctx, []string{knowledge.ID}, knowledge.Type,
+			); err != nil {
 				logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge delete knowledge embedding failed")
 				return err
 			}
 			return nil
 		})
-	} else {
-		logger.Infof(ctx, "Knowledge %s has no embedding model, skipping vector store cleanup", knowledge.ID)
 	}
 
 	// Clean wiki pages before deleting chunks so cleanup can still identify
@@ -560,14 +554,9 @@ func (s *knowledgeService) DeleteKnowledgeList(ctx context.Context, ids []string
 	wg.Go(func() error {
 		tenantID := types.MustTenantIDFromContext(ctx)
 		for _, group := range buildKnowledgeVectorDeleteGroups(knowledgeList, knowledgeBases) {
-			// Wiki-only knowledge never had embeddings written to the vector store,
-			// and its EmbeddingModelID is intentionally empty. Skip the whole group
-			// to avoid the spurious "model ID cannot be empty" failure.
 			if strings.TrimSpace(group.EmbeddingModelID) == "" {
-				logger.Infof(ctx, "Skipping vector store cleanup for %d knowledge entries without embedding model", len(group.KnowledgeIDs))
 				continue
 			}
-
 			var vectorStoreID *string
 			if group.VectorStoreID != "" {
 				storeID := group.VectorStoreID
@@ -579,12 +568,7 @@ func (s *knowledgeService) DeleteKnowledgeList(ctx context.Context, ids []string
 				logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge delete knowledge embedding failed")
 				return err
 			}
-			embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, group.EmbeddingModelID)
-			if err != nil {
-				logger.GetLogger(ctx).WithField("error", err).Errorf("DeleteKnowledge get embedding model failed")
-				return err
-			}
-			if err := retrieveEngine.DeleteByKnowledgeIDList(ctx, group.KnowledgeIDs, embeddingModel.GetDimensions(), group.Type); err != nil {
+			if err := retrieveEngine.DeleteByKnowledgeIDListAllDimensions(ctx, group.KnowledgeIDs, group.Type); err != nil {
 				logger.GetLogger(ctx).
 					WithField("error", err).
 					Errorf("DeleteKnowledge delete knowledge embedding failed")

--- a/internal/application/service/knowledgebase.go
+++ b/internal/application/service/knowledgebase.go
@@ -27,6 +27,26 @@ var ErrInvalidTenantID = errors.New("invalid tenant ID")
 
 const kbTaskCleanupTimeout = 5 * time.Second
 
+// KBDeleteTaskID identifies the single trigger allowed to execute a durable
+// delete intent at a time.
+func KBDeleteTaskID(kbID string) string {
+	return "kb-delete-" + kbID
+}
+
+// EnqueueKBDeleteTask builds the deterministic trigger for one durable KB
+// delete intent. Passing options to Enqueue (rather than embedding them only
+// in asynq.Task) lets the Lite executor honor the same retry and dedup rules.
+func EnqueueKBDeleteTask(
+	enqueuer interfaces.TaskEnqueuer, payload []byte, kbID string,
+) (*asynq.TaskInfo, error) {
+	return enqueuer.Enqueue(asynq.NewTask(types.TypeKBDelete, payload),
+		asynq.Queue(types.QueueMaintenance),
+		asynq.MaxRetry(3),
+		asynq.Timeout(2*time.Hour),
+		asynq.TaskID(KBDeleteTaskID(kbID)),
+	)
+}
+
 // knowledgeBaseService implements the knowledge base service interface
 type knowledgeBaseService struct {
 	repo            interfaces.KnowledgeBaseRepository
@@ -696,8 +716,8 @@ func (s *knowledgeBaseService) applyUserKBPins(
 }
 
 // DeleteKnowledgeBase deletes a knowledge base by its ID
-// This method marks the knowledge base as deleted and enqueues an async task
-// to handle the heavy cleanup operations (embeddings, chunks, files, graph data)
+// This method atomically marks the knowledge base as deleted and records a
+// durable cleanup intent, then enqueues an async trigger for the heavy work.
 func (s *knowledgeBaseService) DeleteKnowledgeBase(ctx context.Context, id string) error {
 	if id == "" {
 		logger.Error(ctx, "Knowledge base ID is empty")
@@ -725,55 +745,14 @@ func (s *knowledgeBaseService) DeleteKnowledgeBase(ctx context.Context, id strin
 		vectorStoreIDSnapshot = kb.VectorStoreID
 	}
 
-	// Step 1: Delete the knowledge base record first (mark as deleted)
-	logger.Infof(ctx, "Deleting knowledge base from database")
-	err = s.repo.DeleteKnowledgeBase(ctx, id)
+	// Snapshot data-source IDs before soft deletion. The worker uses this list
+	// to cancel sync work even if the API-side best-effort cleanup wins the race
+	// and hides the data-source rows before the worker starts.
+	dataSourceIDs, err := s.listDataSourceIDsForKnowledgeBase(ctx, id)
 	if err != nil {
-		logger.ErrorWithFields(ctx, err, map[string]interface{}{
-			"knowledge_base_id": id,
-		})
-		return err
-	}
-	deletedName := ""
-	if kb != nil {
-		deletedName = kb.Name
-	}
-	recordKBActivity(ctx, s.audit, tenantID, id, types.AuditActionKBDeleted,
-		"knowledge_base", id, types.AuditOutcomeSuccess, map[string]any{"name": deletedName})
-
-	// Stop both ephemeral queue work and durable wiki operations that target
-	// the now-deleted KB. ProcessKBDelete repeats this with document IDs and
-	// performs one final scrub after heavy cleanup to close enqueue races.
-	//
-	// Run detached with a bounded timeout so a disconnecting API client cannot
-	// truncate this best-effort scrub mid-scan, matching ProcessKBDelete's
-	// cleanup semantics. The KB row is already soft-deleted, so the async
-	// delete task remains the durable backstop even if this pass is cut short.
-	kbCleanupCtx, cancelKBCleanup := context.WithTimeout(
-		context.WithoutCancel(ctx), kbTaskCleanupTimeout,
-	)
-	s.cleanupTasksForKnowledgeBase(kbCleanupCtx, id, nil, nil)
-	cancelKBCleanup()
-
-	// Step 1b: Remove all organization shares for this KB so org settings no longer show them
-	if s.shareRepo != nil {
-		if delErr := s.shareRepo.DeleteByKnowledgeBaseID(ctx, id); delErr != nil {
-			logger.Warnf(ctx, "Failed to delete KB shares for knowledge base %s: %v", id, delErr)
-		}
+		return fmt.Errorf("list data sources for KB %s: %w", id, err)
 	}
 
-	// Step 1c: Stop and soft-delete all data sources bound to this KB so cron
-	// schedules and in-flight sync logs do not keep running against a deleted KB.
-	dataSourceIDs := s.deleteDataSourcesForKnowledgeBase(ctx, id)
-	if len(dataSourceIDs) > 0 {
-		dsCancelCtx, cancelDSCancel := context.WithTimeout(
-			context.WithoutCancel(ctx), kbTaskCleanupTimeout,
-		)
-		s.cancelTasksForKnowledgeBase(dsCancelCtx, id, nil, dataSourceIDs)
-		cancelDSCancel()
-	}
-
-	// Step 2: Enqueue async task for heavy cleanup operations
 	payload := types.KBDeletePayload{
 		TenantID:         tenantID,
 		KnowledgeBaseID:  id,
@@ -785,21 +764,77 @@ func (s *knowledgeBaseService) DeleteKnowledgeBase(ctx context.Context, id strin
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		logger.Warnf(ctx, "Failed to marshal KB delete payload: %v", err)
-		// Don't fail the request, the KB record is already deleted
-		return nil
+		return fmt.Errorf("marshal KB delete payload: %w", err)
 	}
 
-	task := asynq.NewTask(types.TypeKBDelete, payloadBytes,
-		asynq.Queue(types.QueueMaintenance), asynq.MaxRetry(3), asynq.Timeout(2*time.Hour))
-	info, err := s.asynqClient.Enqueue(task)
+	outbox, ok := s.repo.(interfaces.KnowledgeBaseDeleteOutbox)
+	if !ok {
+		return errors.New("knowledge base repository does not support durable deletion")
+	}
+	pendingOp := &types.TaskPendingOp{
+		TenantID: tenantID,
+		TaskType: types.TypeKBDelete,
+		Scope:    types.TaskScopeKnowledgeBaseDelete,
+		ScopeID:  id,
+		Op:       types.TaskOpKnowledgeBaseDelete,
+		DedupKey: id,
+		Payload:  json.RawMessage(payloadBytes),
+	}
+	logger.Infof(ctx, "Persisting knowledge base deletion intent")
+	if err := outbox.DeleteKnowledgeBaseWithPendingOp(ctx, id, tenantID, pendingOp); err != nil {
+		logger.ErrorWithFields(ctx, err, map[string]interface{}{"knowledge_base_id": id})
+		return err
+	}
+
+	deletedName := ""
+	if kb != nil {
+		deletedName = kb.Name
+	}
+	recordKBActivity(ctx, s.audit, tenantID, id, types.AuditActionKBDeleted,
+		"knowledge_base", id, types.AuditOutcomeSuccess, map[string]any{"name": deletedName})
+
+	// The durable intent is authoritative. A Redis timeout can be ambiguous
+	// (the task may already exist), so enqueue errors must never restore the KB.
+	// Startup/periodic recovery will re-dispatch the same deterministic task ID.
+	info, err := EnqueueKBDeleteTask(s.asynqClient, payloadBytes, id)
 	if err != nil {
-		logger.Warnf(ctx, "Failed to enqueue KB delete task: %v", err)
-		// Don't fail the request, the KB record is already deleted
-		return nil
+		if errors.Is(err, asynq.ErrTaskIDConflict) || errors.Is(err, asynq.ErrDuplicateTask) {
+			logger.Infof(ctx, "KB delete task already exists, knowledge base ID: %s", id)
+		} else {
+			logger.Warnf(ctx, "Failed to enqueue KB delete trigger; durable recovery will retry: %v", err)
+		}
+	} else if info != nil {
+		logger.Infof(ctx, "KB delete task enqueued: %s, knowledge base ID: %s", info.ID, id)
+	} else {
+		logger.Warnf(ctx, "KB delete enqueue returned no task info; durable recovery will verify KB %s", id)
 	}
 
-	logger.Infof(ctx, "KB delete task enqueued: %s, knowledge base ID: %s", info.ID, id)
+	// Stop obsolete work promptly. The worker repeats every operation below,
+	// so a process exit anywhere in this best-effort fast path cannot leak it.
+	kbCleanupCtx, cancelKBCleanup := context.WithTimeout(
+		context.WithoutCancel(ctx), kbTaskCleanupTimeout,
+	)
+	s.cleanupTasksForKnowledgeBase(kbCleanupCtx, id, nil, dataSourceIDs)
+	cancelKBCleanup()
+
+	if s.shareRepo != nil {
+		if delErr := s.shareRepo.DeleteByKnowledgeBaseID(ctx, id); delErr != nil {
+			logger.Warnf(ctx, "Failed to delete KB shares for knowledge base %s: %v", id, delErr)
+		}
+	}
+	cleanedDataSourceIDs, dsErr := s.deleteDataSourcesForKnowledgeBase(ctx, id, dataSourceIDs...)
+	if dsErr != nil {
+		logger.Warnf(ctx, "Failed to fully clean data sources for deleted KB %s: %v", id, dsErr)
+	}
+	dataSourceIDs = mergeStringIDs(dataSourceIDs, cleanedDataSourceIDs)
+	if len(dataSourceIDs) > 0 {
+		dsCancelCtx, cancelDSCancel := context.WithTimeout(
+			context.WithoutCancel(ctx), kbTaskCleanupTimeout,
+		)
+		s.cancelTasksForKnowledgeBase(dsCancelCtx, id, nil, dataSourceIDs)
+		cancelDSCancel()
+	}
+
 	logger.Infof(ctx, "Knowledge base deleted successfully, ID: %s", id)
 	return nil
 }
@@ -829,13 +864,29 @@ func (s *knowledgeBaseService) ProcessKBDelete(ctx context.Context, t *asynq.Tas
 	}()
 
 	logger.Infof(ctx, "Processing KB delete task for knowledge base: %s", kbID)
+	if tenantID == 0 || kbID == "" {
+		return errors.New("invalid KB delete payload: tenant_id and knowledge_base_id are required")
+	}
+
+	// Lifecycle metadata is part of the durable worker, not only the HTTP fast
+	// path. This closes the crash window after the outbox commit but before the
+	// request goroutine removes shares, schedules, and pending sync logs.
+	if s.shareRepo != nil {
+		if err := s.shareRepo.DeleteByKnowledgeBaseID(ctx, kbID); err != nil {
+			return fmt.Errorf("delete shares for KB %s: %w", kbID, err)
+		}
+	}
+	cleanedDataSourceIDs, err := s.deleteDataSourcesForKnowledgeBase(
+		ctx, kbID, payload.DataSourceIDs...,
+	)
+	payload.DataSourceIDs = mergeStringIDs(payload.DataSourceIDs, cleanedDataSourceIDs)
+	if err != nil {
+		return fmt.Errorf("delete data sources for KB %s: %w", kbID, err)
+	}
 
 	// Step 1: Get all knowledge entries in this knowledge base
 	logger.Infof(ctx, "Fetching all knowledge entries in knowledge base, ID: %s", kbID)
-	var (
-		knowledgeList []*types.Knowledge
-		err           error
-	)
+	var knowledgeList []*types.Knowledge
 	if lister, ok := s.kgRepo.(interfaces.UnscopedKnowledgeLister); ok {
 		knowledgeList, err = lister.ListKnowledgeByKnowledgeBaseIDUnscoped(ctx, tenantID, kbID)
 	} else {
@@ -868,45 +919,35 @@ func (s *knowledgeBaseService) ProcessKBDelete(ctx context.Context, t *asynq.Tas
 	if len(knowledgeList) > 0 {
 		logger.Infof(ctx, "Deleting all knowledge entries and their resources")
 
-		// Delete embeddings from vector store.
-		// Resolve the engine via the factory, using the VectorStoreID captured
-		// at enqueue time (may be nil → falls back to payload.EffectiveEngines).
-		// If the payload references a store no longer owned/registered
-		// (e.g. tampered queue entry or a store that was deleted while the
-		// task sat in the queue), the factory returns a sentinel and we
-		// SkipRetry to avoid burning retries on an unrecoverable situation.
-		logger.Infof(ctx, "Deleting embeddings from vector store")
-		retrieveEngine, err := retriever.CreateRetrieveEngineFromPayload(
-			ctx,
-			s.retrieveEngine,
-			s.ownership,
-			payload.TenantID,
-			payload.EffectiveEngines,
-			payload.VectorStoreID,
-		)
-		if errors.Is(err, retriever.ErrVectorStoreForbidden) ||
-			errors.Is(err, retriever.ErrVectorStoreNotFound) {
-			logger.Errorf(ctx, "KB delete task aborted: %v (tenant=%d, kb=%s)", err, payload.TenantID, payload.KnowledgeBaseID)
-			return asynq.SkipRetry
-		}
-		if err != nil {
-			// Transient failures — store temporarily unavailable, request
-			// cancellation during resolution, or other retryable errors —
-			// must not fall through and report success while embeddings remain.
-			logger.Errorf(ctx, "KB delete task deferred: %v (tenant=%d, kb=%s)", err, payload.TenantID, payload.KnowledgeBaseID)
-			return err
-		} else {
-			// Deletion is keyed by knowledge ID and must not depend on the
-			// currently configured model or dimension. Historical data may live
-			// in a collection created by an older embedding model.
-			embeddingGroups := make(map[string][]string)
-			for _, knowledge := range knowledgeList {
-				if strings.TrimSpace(knowledge.EmbeddingModelID) == "" {
-					continue
-				}
-				embeddingGroups[knowledge.Type] = append(embeddingGroups[knowledge.Type], knowledge.ID)
+		// Deletion is keyed by knowledge ID and must not depend on the
+		// currently configured model or dimension. Historical data may live in
+		// a collection created by an older embedding model. Knowledge with no
+		// embedding model never wrote vectors, so it does not require an engine.
+		embeddingGroups := make(map[string][]string)
+		for _, knowledge := range knowledgeList {
+			if strings.TrimSpace(knowledge.EmbeddingModelID) == "" {
+				continue
 			}
-
+			embeddingGroups[knowledge.Type] = append(embeddingGroups[knowledge.Type], knowledge.ID)
+		}
+		if len(embeddingGroups) > 0 {
+			// Resolve the engine via the factory, using the VectorStoreID captured
+			// at enqueue time (may be nil → falls back to payload engines).
+			// Ownership/registration failures remain retryable because the store
+			// registry may be repaired while the durable intent remains pending.
+			logger.Infof(ctx, "Deleting embeddings from vector store")
+			retrieveEngine, err := retriever.CreateRetrieveEngineFromPayload(
+				ctx,
+				s.retrieveEngine,
+				s.ownership,
+				payload.TenantID,
+				payload.EffectiveEngines,
+				payload.VectorStoreID,
+			)
+			if err != nil {
+				logger.Errorf(ctx, "KB delete task deferred: %v (tenant=%d, kb=%s)", err, payload.TenantID, payload.KnowledgeBaseID)
+				return err
+			}
 			for knowledgeType, knowledgeGroup := range embeddingGroups {
 				if err := retrieveEngine.DeleteByKnowledgeIDListAllDimensions(ctx, knowledgeGroup, knowledgeType); err != nil {
 					return fmt.Errorf("delete embeddings for KB %s: %w", kbID, err)
@@ -951,7 +992,7 @@ func (s *knowledgeBaseService) ProcessKBDelete(ctx context.Context, t *asynq.Tas
 
 	if s.wikiRepo != nil {
 		logger.Infof(ctx, "Deleting Wiki data for knowledge base")
-		if err := s.wikiRepo.DeleteByKnowledgeBaseID(ctx, kbID); err != nil {
+		if err := s.wikiRepo.DeleteByKnowledgeBaseID(ctx, tenantID, kbID); err != nil {
 			return fmt.Errorf("delete Wiki data for KB %s: %w", kbID, err)
 		}
 	}
@@ -990,6 +1031,19 @@ func (s *knowledgeBaseService) ProcessKBDelete(ctx context.Context, t *asynq.Tas
 			if err := s.tenantRepo.AdjustStorageUsed(ctx, tenantID, storageAdjust); err != nil {
 				logger.Warnf(ctx, "Failed to adjust tenant storage: %v", err)
 			}
+		}
+	}
+
+	if s.taskPendingRepo != nil {
+		if err := s.taskPendingRepo.DeleteByDedupKey(
+			ctx,
+			types.TypeKBDelete,
+			types.TaskScopeKnowledgeBaseDelete,
+			kbID,
+			kbID,
+			types.TaskOpKnowledgeBaseDelete,
+		); err != nil {
+			return fmt.Errorf("complete durable delete intent for KB %s: %w", kbID, err)
 		}
 	}
 
@@ -1042,40 +1096,78 @@ func (s *knowledgeBaseService) deletePendingTasksForKnowledgeBase(ctx context.Co
 	return cleaner.DeleteByScope(ctx, types.TaskScopeKnowledgeBase, kbID)
 }
 
-// deleteDataSourcesForKnowledgeBase mirrors DataSourceService.DeleteDataSource for
-// every data source attached to the KB. Errors on individual sources are logged
-// but do not fail KB deletion — the KB record is already soft-deleted.
-func (s *knowledgeBaseService) deleteDataSourcesForKnowledgeBase(ctx context.Context, kbID string) []string {
-	if s.dsRepo == nil {
-		return nil
+func mergeStringIDs(groups ...[]string) []string {
+	seen := make(map[string]struct{})
+	var merged []string
+	for _, group := range groups {
+		for _, id := range group {
+			if id == "" {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			merged = append(merged, id)
+		}
 	}
+	return merged
+}
 
+func (s *knowledgeBaseService) listDataSourceIDsForKnowledgeBase(
+	ctx context.Context, kbID string,
+) ([]string, error) {
+	if s.dsRepo == nil {
+		return nil, nil
+	}
 	dataSources, err := s.dsRepo.FindByKnowledgeBase(ctx, kbID)
 	if err != nil {
-		logger.Warnf(ctx, "Failed to list data sources for deleted KB %s: %v", kbID, err)
-		return nil
+		return nil, err
 	}
 	dataSourceIDs := make([]string, 0, len(dataSources))
 	for _, ds := range dataSources {
-		if ds == nil || ds.ID == "" {
-			continue
+		if ds != nil && ds.ID != "" {
+			dataSourceIDs = append(dataSourceIDs, ds.ID)
 		}
-		dataSourceIDs = append(dataSourceIDs, ds.ID)
-		if err := s.dsRepo.Delete(ctx, ds.ID); err != nil {
-			logger.Warnf(ctx, "Failed to delete data source %s for KB %s: %v", ds.ID, kbID, err)
-			continue
+	}
+	return mergeStringIDs(dataSourceIDs), nil
+}
+
+// deleteDataSourcesForKnowledgeBase mirrors DataSourceService.DeleteDataSource
+// and is idempotent across task retries. knownIDs preserves access to sources
+// already soft-deleted by the API-side fast path so sync logs can still be
+// cancelled by the durable worker.
+func (s *knowledgeBaseService) deleteDataSourcesForKnowledgeBase(
+	ctx context.Context, kbID string, knownIDs ...string,
+) ([]string, error) {
+	if s.dsRepo == nil {
+		return mergeStringIDs(knownIDs), nil
+	}
+
+	listedIDs, listErr := s.listDataSourceIDsForKnowledgeBase(ctx, kbID)
+	dataSourceIDs := mergeStringIDs(knownIDs, listedIDs)
+	var cleanupErr error
+	if listErr != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("list data sources: %w", listErr))
+	}
+	for _, dataSourceID := range dataSourceIDs {
+		if err := s.dsRepo.Delete(ctx, dataSourceID); err != nil {
+			cleanupErr = errors.Join(cleanupErr,
+				fmt.Errorf("delete data source %s: %w", dataSourceID, err))
+		} else {
+			logger.Infof(ctx, "Data source deleted with knowledge base: ds=%s kb=%s", dataSourceID, kbID)
 		}
 		if s.dsScheduler != nil {
-			s.dsScheduler.Remove(ds.ID)
+			s.dsScheduler.Remove(dataSourceID)
 		}
 		if s.syncLogRepo != nil {
-			if err := s.syncLogRepo.CancelPendingByDataSource(ctx, ds.ID); err != nil {
-				logger.Warnf(ctx, "Failed to cancel pending sync logs for ds=%s (kb=%s): %v", ds.ID, kbID, err)
+			if err := s.syncLogRepo.CancelPendingByDataSource(ctx, dataSourceID); err != nil {
+				cleanupErr = errors.Join(cleanupErr,
+					fmt.Errorf("cancel pending sync logs for data source %s: %w", dataSourceID, err))
 			}
 		}
-		logger.Infof(ctx, "Data source deleted with knowledge base: ds=%s kb=%s", ds.ID, kbID)
 	}
-	return dataSourceIDs
+	return dataSourceIDs, cleanupErr
 }
 
 // SetEmbeddingModel sets the embedding model for a knowledge base

--- a/internal/application/service/knowledgebase.go
+++ b/internal/application/service/knowledgebase.go
@@ -44,6 +44,7 @@ type knowledgeBaseService struct {
 	asynqClient     interfaces.TaskEnqueuer
 	taskInspector   interfaces.TaskInspector
 	taskPendingRepo interfaces.TaskPendingOpsRepository
+	wikiRepo        interfaces.WikiPageRepository
 	dsRepo          interfaces.DataSourceRepository
 	syncLogRepo     interfaces.SyncLogRepository
 	dsScheduler     *datasource.Scheduler
@@ -66,6 +67,7 @@ func NewKnowledgeBaseService(repo interfaces.KnowledgeBaseRepository,
 	asynqClient interfaces.TaskEnqueuer,
 	taskInspector interfaces.TaskInspector,
 	taskPendingRepo interfaces.TaskPendingOpsRepository,
+	wikiRepo interfaces.WikiPageRepository,
 	dsRepo interfaces.DataSourceRepository,
 	syncLogRepo interfaces.SyncLogRepository,
 	dsScheduler *datasource.Scheduler,
@@ -87,6 +89,7 @@ func NewKnowledgeBaseService(repo interfaces.KnowledgeBaseRepository,
 		asynqClient:     asynqClient,
 		taskInspector:   taskInspector,
 		taskPendingRepo: taskPendingRepo,
+		wikiRepo:        wikiRepo,
 		dsRepo:          dsRepo,
 		syncLogRepo:     syncLogRepo,
 		dsScheduler:     dsScheduler,
@@ -829,7 +832,15 @@ func (s *knowledgeBaseService) ProcessKBDelete(ctx context.Context, t *asynq.Tas
 
 	// Step 1: Get all knowledge entries in this knowledge base
 	logger.Infof(ctx, "Fetching all knowledge entries in knowledge base, ID: %s", kbID)
-	knowledgeList, err := s.kgRepo.ListKnowledgeByKnowledgeBaseID(ctx, tenantID, kbID)
+	var (
+		knowledgeList []*types.Knowledge
+		err           error
+	)
+	if lister, ok := s.kgRepo.(interfaces.UnscopedKnowledgeLister); ok {
+		knowledgeList, err = lister.ListKnowledgeByKnowledgeBaseIDUnscoped(ctx, tenantID, kbID)
+	} else {
+		knowledgeList, err = s.kgRepo.ListKnowledgeByKnowledgeBaseID(ctx, tenantID, kbID)
+	}
 	if err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"knowledge_base_id": kbID,
@@ -845,7 +856,13 @@ func (s *knowledgeBaseService) ProcessKBDelete(ctx context.Context, t *asynq.Tas
 	// Repeat the best-effort queue scrub with document IDs. Some batch tasks
 	// only carry knowledge_id(s), and active work from the first pass may have
 	// enqueued another downstream task before cancellation reached it.
-	s.cleanupTasksForKnowledgeBase(ctx, kbID, knowledgeIDs, payload.DataSourceIDs)
+	if err := s.deletePendingTasksForKnowledgeBase(ctx, kbID); err != nil {
+		logger.Errorf(ctx, "Failed to clear durable tasks for deleted KB %s: %v", kbID, err)
+		return err
+	}
+	s.cancelTasksForKnowledgeBase(ctx, kbID, knowledgeIDs, payload.DataSourceIDs)
+
+	var imageURLs []string
 
 	// Step 2: Delete all knowledge entries and their resources
 	if len(knowledgeList) > 0 {
@@ -879,25 +896,20 @@ func (s *knowledgeBaseService) ProcessKBDelete(ctx context.Context, t *asynq.Tas
 			logger.Errorf(ctx, "KB delete task deferred: %v (tenant=%d, kb=%s)", err, payload.TenantID, payload.KnowledgeBaseID)
 			return err
 		} else {
-			// Group knowledge by embedding model and type
-			type groupKey struct {
-				EmbeddingModelID string
-				Type             string
-			}
-			embeddingGroups := make(map[groupKey][]string)
+			// Deletion is keyed by knowledge ID and must not depend on the
+			// currently configured model or dimension. Historical data may live
+			// in a collection created by an older embedding model.
+			embeddingGroups := make(map[string][]string)
 			for _, knowledge := range knowledgeList {
-				key := groupKey{EmbeddingModelID: knowledge.EmbeddingModelID, Type: knowledge.Type}
-				embeddingGroups[key] = append(embeddingGroups[key], knowledge.ID)
-			}
-
-			for key, knowledgeGroup := range embeddingGroups {
-				embeddingModel, err := s.modelService.GetEmbeddingModel(ctx, key.EmbeddingModelID)
-				if err != nil {
-					logger.Warnf(ctx, "Failed to get embedding model %s: %v", key.EmbeddingModelID, err)
+				if strings.TrimSpace(knowledge.EmbeddingModelID) == "" {
 					continue
 				}
-				if err := retrieveEngine.DeleteByKnowledgeIDList(ctx, knowledgeGroup, embeddingModel.GetDimensions(), key.Type); err != nil {
-					logger.Warnf(ctx, "Failed to delete embeddings for model %s: %v", key.EmbeddingModelID, err)
+				embeddingGroups[knowledge.Type] = append(embeddingGroups[knowledge.Type], knowledge.ID)
+			}
+
+			for knowledgeType, knowledgeGroup := range embeddingGroups {
+				if err := retrieveEngine.DeleteByKnowledgeIDListAllDimensions(ctx, knowledgeGroup, knowledgeType); err != nil {
+					return fmt.Errorf("delete embeddings for KB %s: %w", kbID, err)
 				}
 			}
 		}
@@ -911,31 +923,13 @@ func (s *knowledgeBaseService) ProcessKBDelete(ctx context.Context, t *asynq.Tas
 		for _, ci := range chunkImageInfos {
 			imageInfoStrs = append(imageInfoStrs, ci.ImageInfo)
 		}
-		imageURLs := collectImageURLs(ctx, imageInfoStrs)
+		imageURLs = collectImageURLs(ctx, imageInfoStrs)
 
 		// Delete all chunks
 		logger.Infof(ctx, "Deleting all chunks in knowledge base")
 		for _, knowledgeID := range knowledgeIDs {
 			if err := s.chunkRepo.DeleteChunksByKnowledgeID(ctx, tenantID, knowledgeID); err != nil {
-				logger.Warnf(ctx, "Failed to delete chunks for knowledge %s: %v", knowledgeID, err)
-			}
-		}
-
-		// Delete physical files, extracted images, and adjust storage
-		logger.Infof(ctx, "Deleting physical files and extracted images")
-		storageAdjust := int64(0)
-		for _, knowledge := range knowledgeList {
-			if knowledge.FilePath != "" {
-				if err := s.fileSvc.DeleteFile(ctx, knowledge.FilePath); err != nil {
-					logger.Warnf(ctx, "Failed to delete file %s: %v", knowledge.FilePath, err)
-				}
-			}
-			storageAdjust -= knowledge.StorageSize
-		}
-		deleteExtractedImages(ctx, s.fileSvc, imageURLs)
-		if storageAdjust != 0 {
-			if err := s.tenantRepo.AdjustStorageUsed(ctx, tenantID, storageAdjust); err != nil {
-				logger.Warnf(ctx, "Failed to adjust tenant storage: %v", err)
+				return fmt.Errorf("delete chunks for knowledge %s: %w", knowledgeID, err)
 			}
 		}
 
@@ -950,10 +944,19 @@ func (s *knowledgeBaseService) ProcessKBDelete(ctx context.Context, t *asynq.Tas
 		}
 		if s.graphEngine != nil && len(namespaces) > 0 {
 			if err := s.graphEngine.DelGraph(ctx, namespaces); err != nil {
-				logger.Warnf(ctx, "Failed to delete knowledge graph: %v", err)
+				return fmt.Errorf("delete knowledge graph for KB %s: %w", kbID, err)
 			}
 		}
+	}
 
+	if s.wikiRepo != nil {
+		logger.Infof(ctx, "Deleting Wiki data for knowledge base")
+		if err := s.wikiRepo.DeleteByKnowledgeBaseID(ctx, kbID); err != nil {
+			return fmt.Errorf("delete Wiki data for KB %s: %w", kbID, err)
+		}
+	}
+
+	if len(knowledgeList) > 0 {
 		// Delete all knowledge entries from database
 		logger.Infof(ctx, "Deleting knowledge entries from database")
 		if err := s.kgRepo.DeleteKnowledgeList(ctx, tenantID, knowledgeIDs); err != nil {
@@ -961,6 +964,32 @@ func (s *knowledgeBaseService) ProcessKBDelete(ctx context.Context, t *asynq.Tas
 				"knowledge_base_id": kbID,
 			})
 			return err
+		}
+
+		// Physical files are removed only after every retryable index, chunk,
+		// graph, Wiki, and database cleanup has succeeded. Failures below may
+		// leak storage but cannot make the remaining metadata impossible to
+		// retry. Only rows that were active at task start adjust quota; unscoped
+		// historical rows may already have been accounted for by an older task.
+		logger.Infof(ctx, "Deleting physical files and extracted images")
+		storageAdjust := int64(0)
+		for _, knowledge := range knowledgeList {
+			if knowledge.FilePath != "" && s.fileSvc != nil {
+				if err := s.fileSvc.DeleteFile(ctx, knowledge.FilePath); err != nil {
+					logger.Warnf(ctx, "Failed to delete file %s: %v", knowledge.FilePath, err)
+				}
+			}
+			if !knowledge.DeletedAt.Valid {
+				storageAdjust -= knowledge.StorageSize
+			}
+		}
+		if s.fileSvc != nil {
+			deleteExtractedImages(ctx, s.fileSvc, imageURLs)
+		}
+		if storageAdjust != 0 && s.tenantRepo != nil {
+			if err := s.tenantRepo.AdjustStorageUsed(ctx, tenantID, storageAdjust); err != nil {
+				logger.Warnf(ctx, "Failed to adjust tenant storage: %v", err)
+			}
 		}
 	}
 
@@ -999,16 +1028,18 @@ func (s *knowledgeBaseService) cleanupTasksForKnowledgeBase(
 	if kbID == "" {
 		return
 	}
-	cleaner, ok := s.taskPendingRepo.(interfaces.TaskPendingOpsScopeCleaner)
-	if ok {
-		// Clear durable work before scanning Redis. A large or degraded queue
-		// must not consume the caller's entire deadline and starve the database
-		// fence that prevents startup recovery from reviving this KB.
-		if err := cleaner.DeleteByScope(ctx, types.TaskScopeKnowledgeBase, kbID); err != nil {
-			logger.Warnf(ctx, "Failed to clear durable tasks for deleted KB %s: %v", kbID, err)
-		}
+	if err := s.deletePendingTasksForKnowledgeBase(ctx, kbID); err != nil {
+		logger.Warnf(ctx, "Failed to clear durable tasks for deleted KB %s: %v", kbID, err)
 	}
 	s.cancelTasksForKnowledgeBase(ctx, kbID, knowledgeIDs, dataSourceIDs)
+}
+
+func (s *knowledgeBaseService) deletePendingTasksForKnowledgeBase(ctx context.Context, kbID string) error {
+	cleaner, ok := s.taskPendingRepo.(interfaces.TaskPendingOpsScopeCleaner)
+	if !ok || kbID == "" {
+		return nil
+	}
+	return cleaner.DeleteByScope(ctx, types.TaskScopeKnowledgeBase, kbID)
 }
 
 // deleteDataSourcesForKnowledgeBase mirrors DataSourceService.DeleteDataSource for

--- a/internal/application/service/knowledgebase_delete_datasource_test.go
+++ b/internal/application/service/knowledgebase_delete_datasource_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sync"
 	"testing"
@@ -107,13 +108,25 @@ var _ interfaces.SyncLogRepository = (*kbDeleteSyncLogRepo)(nil)
 
 type kbDeleteKBRepo struct {
 	fakeKBRepo
-	deletedID string
+	deletedID   string
+	pendingOps  []*types.TaskPendingOp
+	outboxError error
 }
 
 func (r *kbDeleteKBRepo) DeleteKnowledgeBase(_ context.Context, id string) error {
 	r.deletedID = id
 	delete(r.rows, id)
 	return nil
+}
+
+func (r *kbDeleteKBRepo) DeleteKnowledgeBaseWithPendingOp(
+	ctx context.Context, id string, _ uint64, op *types.TaskPendingOp,
+) error {
+	if r.outboxError != nil {
+		return r.outboxError
+	}
+	r.pendingOps = append(r.pendingOps, op)
+	return r.DeleteKnowledgeBase(ctx, id)
 }
 
 type kbDeleteTaskEnqueuer struct{}
@@ -141,7 +154,8 @@ func TestDeleteDataSourcesForKnowledgeBase(t *testing.T) {
 		dsScheduler: scheduler,
 	}
 
-	svc.deleteDataSourcesForKnowledgeBase(ctxWithTenant(1), kbID)
+	_, err := svc.deleteDataSourcesForKnowledgeBase(ctxWithTenant(1), kbID)
+	require.NoError(t, err)
 
 	assert.ElementsMatch(t, []string{"ds-1", "ds-2"}, dsRepo.deleteIDs)
 	assert.ElementsMatch(t, []string{"ds-1", "ds-2"}, syncLogRepo.canceled)
@@ -191,7 +205,8 @@ func TestDeleteDataSourcesForKnowledgeBaseContinuesOnDeleteError(t *testing.T) {
 		syncLogRepo: &kbDeleteSyncLogRepo{},
 	}
 
-	svc.deleteDataSourcesForKnowledgeBase(context.Background(), kbID)
+	_, err := svc.deleteDataSourcesForKnowledgeBase(context.Background(), kbID)
+	require.ErrorIs(t, err, dsRepo.deleteErr)
 	assert.Empty(t, dsRepo.deleteIDs)
 }
 
@@ -215,6 +230,63 @@ func TestDeleteKnowledgeBaseContinuesWhenDataSourceCleanupFails(t *testing.T) {
 	err := svc.DeleteKnowledgeBase(ctxWithTenantStorage(1, "local"), kbID)
 	require.NoError(t, err)
 	assert.Equal(t, kbID, kbRepo.deletedID)
+}
+
+func TestDeleteKnowledgeBaseKeepsDurableIntentWhenTriggerEnqueueFails(t *testing.T) {
+	const kbID = "kb-durable-delete"
+	kbRepo := &kbDeleteKBRepo{fakeKBRepo: *newFakeKBRepo()}
+	kbRepo.rows[kbID] = &types.KnowledgeBase{ID: kbID, TenantID: 1, Name: "test"}
+	enqueueErr := errors.New("redis timeout")
+	enqueuer := &recordingKBDeleteEnqueuer{err: enqueueErr}
+	svc := &knowledgeBaseService{repo: kbRepo, asynqClient: enqueuer}
+
+	err := svc.DeleteKnowledgeBase(ctxWithTenantStorage(1, "local"), kbID)
+
+	require.NoError(t, err, "the durable DB intent accepted the deletion")
+	assert.Equal(t, kbID, kbRepo.deletedID)
+	require.Len(t, kbRepo.pendingOps, 1)
+	assert.Equal(t, types.TypeKBDelete, kbRepo.pendingOps[0].TaskType)
+	assert.Equal(t, types.TaskScopeKnowledgeBaseDelete, kbRepo.pendingOps[0].Scope)
+	assert.Equal(t, kbID, kbRepo.pendingOps[0].DedupKey)
+	assert.Equal(t, 1, enqueuer.calls)
+}
+
+func TestDeleteKnowledgeBaseDoesNotEnqueueWhenDurableIntentFails(t *testing.T) {
+	const kbID = "kb-outbox-failure"
+	outboxErr := errors.New("database unavailable")
+	kbRepo := &kbDeleteKBRepo{fakeKBRepo: *newFakeKBRepo(), outboxError: outboxErr}
+	kbRepo.rows[kbID] = &types.KnowledgeBase{ID: kbID, TenantID: 1, Name: "test"}
+	enqueuer := &recordingKBDeleteEnqueuer{}
+	svc := &knowledgeBaseService{repo: kbRepo, asynqClient: enqueuer}
+
+	err := svc.DeleteKnowledgeBase(ctxWithTenantStorage(1, "local"), kbID)
+
+	require.ErrorIs(t, err, outboxErr)
+	assert.Empty(t, kbRepo.deletedID)
+	assert.Zero(t, enqueuer.calls)
+}
+
+func TestProcessKBDeleteRepeatsDataSourceCleanupFromPayload(t *testing.T) {
+	const kbID = "kb-worker-datasource"
+	dsRepo := newKBDeleteDSRepo(kbID)
+	syncLogRepo := &kbDeleteSyncLogRepo{}
+	svc := &knowledgeBaseService{
+		kgRepo:      emptyKBKnowledgeRepo{},
+		dsRepo:      dsRepo,
+		syncLogRepo: syncLogRepo,
+	}
+	payload, err := json.Marshal(types.KBDeletePayload{
+		TenantID:        1,
+		KnowledgeBaseID: kbID,
+		DataSourceIDs:   []string{"ds-already-hidden"},
+	})
+	require.NoError(t, err)
+
+	err = svc.ProcessKBDelete(context.Background(), asynq.NewTask(types.TypeKBDelete, payload))
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ds-already-hidden"}, dsRepo.deleteIDs)
+	assert.Equal(t, []string{"ds-already-hidden"}, syncLogRepo.canceled)
 }
 
 // deleteErrDSRepo injects a delete failure for testing best-effort cleanup.

--- a/internal/application/service/knowledgebase_task_cancel_test.go
+++ b/internal/application/service/knowledgebase_task_cancel_test.go
@@ -80,6 +80,17 @@ type recordingKBPendingRepo struct {
 	deleteErr error
 }
 
+type recordingKBWikiRepo struct {
+	interfaces.WikiPageRepository
+	kbIDs []string
+	err   error
+}
+
+func (r *recordingKBWikiRepo) DeleteByKnowledgeBaseID(_ context.Context, kbID string) error {
+	r.kbIDs = append(r.kbIDs, kbID)
+	return r.err
+}
+
 func (r *recordingKBPendingRepo) DeleteByScope(_ context.Context, scope, scopeID string) error {
 	if scope == types.TaskScopeKnowledgeBase {
 		r.scopeIDs = append(r.scopeIDs, scopeID)
@@ -195,6 +206,52 @@ func TestProcessKBDeleteRepeatsQueueCleanup(t *testing.T) {
 	assert.Equal(t, []string{"kb-race", "kb-race"}, pendingRepo.scopeIDs)
 }
 
+func TestProcessKBDeleteRetriesWhenDurableCleanupFails(t *testing.T) {
+	pendingErr := errors.New("database unavailable")
+	pendingRepo := &recordingKBPendingRepo{deleteErr: pendingErr}
+	svc := &knowledgeBaseService{
+		kgRepo:          emptyKBKnowledgeRepo{},
+		taskPendingRepo: pendingRepo,
+	}
+	payload, err := json.Marshal(types.KBDeletePayload{TenantID: 1, KnowledgeBaseID: "kb-pending"})
+	require.NoError(t, err)
+
+	err = svc.ProcessKBDelete(context.Background(), asynq.NewTask(types.TypeKBDelete, payload))
+
+	require.ErrorIs(t, err, pendingErr)
+	assert.Equal(t, []string{"kb-pending", "kb-pending"}, pendingRepo.scopeIDs)
+}
+
+func TestProcessKBDeleteCleansWikiDataWithoutKnowledgeRows(t *testing.T) {
+	wikiRepo := &recordingKBWikiRepo{}
+	svc := &knowledgeBaseService{
+		kgRepo:   emptyKBKnowledgeRepo{},
+		wikiRepo: wikiRepo,
+	}
+	payload, err := json.Marshal(types.KBDeletePayload{TenantID: 1, KnowledgeBaseID: "kb-wiki"})
+	require.NoError(t, err)
+
+	err = svc.ProcessKBDelete(context.Background(), asynq.NewTask(types.TypeKBDelete, payload))
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"kb-wiki"}, wikiRepo.kbIDs)
+}
+
+func TestProcessKBDeleteRetriesWhenWikiCleanupFails(t *testing.T) {
+	wikiErr := errors.New("wiki database unavailable")
+	wikiRepo := &recordingKBWikiRepo{err: wikiErr}
+	svc := &knowledgeBaseService{
+		kgRepo:   emptyKBKnowledgeRepo{},
+		wikiRepo: wikiRepo,
+	}
+	payload, err := json.Marshal(types.KBDeletePayload{TenantID: 1, KnowledgeBaseID: "kb-wiki"})
+	require.NoError(t, err)
+
+	err = svc.ProcessKBDelete(context.Background(), asynq.NewTask(types.TypeKBDelete, payload))
+
+	require.ErrorIs(t, err, wikiErr)
+}
+
 type populatedKBKnowledgeRepo struct {
 	interfaces.KnowledgeRepository
 	items []*types.Knowledge
@@ -253,6 +310,37 @@ func (kbCleanupEmbedder) BatchEmbedWithPool(
 	return nil, nil
 }
 
+type failingKBDeleteEngine struct {
+	interfaces.RetrieveEngineService
+	err         error
+	deleteCalls int
+}
+
+func (e *failingKBDeleteEngine) EngineType() types.RetrieverEngineType {
+	return types.QdrantRetrieverEngineType
+}
+
+func (e *failingKBDeleteEngine) Support() []types.RetrieverType {
+	return []types.RetrieverType{types.VectorRetrieverType}
+}
+
+func (e *failingKBDeleteEngine) DeleteByKnowledgeIDList(
+	context.Context, []string, int, string,
+) error {
+	e.deleteCalls++
+	return e.err
+}
+
+type trackingKBChunkRepo struct {
+	kbCleanupChunkRepo
+	deleteCalls int
+}
+
+func (r *trackingKBChunkRepo) DeleteChunksByKnowledgeID(context.Context, uint64, string) error {
+	r.deleteCalls++
+	return nil
+}
+
 func TestProcessKBDeleteCollectsKnowledgeIDsForEveryScrub(t *testing.T) {
 	inspector := &recordingKBTaskInspector{}
 	svc := &knowledgeBaseService{
@@ -274,6 +362,39 @@ func TestProcessKBDeleteCollectsKnowledgeIDsForEveryScrub(t *testing.T) {
 	for _, call := range inspector.calls {
 		assert.Equal(t, []string{"knowledge-1", "knowledge-2"}, call.knowledgeIDs)
 	}
+}
+
+func TestProcessKBDeleteVectorFailureKeepsKnowledgeRows(t *testing.T) {
+	vectorErr := errors.New("qdrant unavailable")
+	engine := &failingKBDeleteEngine{err: vectorErr}
+	registry := retriever.NewRetrieveEngineRegistry(nil, nil)
+	require.NoError(t, registry.Register(engine))
+	repo := &kbDeleteTrackingKnowledgeRepo{populatedKBKnowledgeRepo: populatedKBKnowledgeRepo{items: []*types.Knowledge{
+		{ID: "knowledge-1", KnowledgeBaseID: "kb-1", EmbeddingModelID: "model-1", Type: "file"},
+	}}}
+	chunkRepo := &trackingKBChunkRepo{}
+	svc := &knowledgeBaseService{
+		kgRepo:         repo,
+		chunkRepo:      chunkRepo,
+		modelService:   kbCleanupModelService{},
+		retrieveEngine: registry,
+	}
+	payload, err := json.Marshal(types.KBDeletePayload{
+		TenantID:        1,
+		KnowledgeBaseID: "kb-1",
+		EffectiveEngines: []types.RetrieverEngineParams{{
+			RetrieverEngineType: types.QdrantRetrieverEngineType,
+			RetrieverType:       types.VectorRetrieverType,
+		}},
+	})
+	require.NoError(t, err)
+
+	err = svc.ProcessKBDelete(context.Background(), asynq.NewTask(types.TypeKBDelete, payload))
+
+	require.ErrorIs(t, err, vectorErr)
+	assert.Equal(t, 1, engine.deleteCalls)
+	assert.Equal(t, 0, chunkRepo.deleteCalls)
+	assert.Equal(t, 0, repo.deleteCalls, "knowledge rows must remain available for retry")
 }
 
 // kbDeleteDeferredRegistry reports a retryable engine-resolution failure from

--- a/internal/application/service/knowledgebase_task_cancel_test.go
+++ b/internal/application/service/knowledgebase_task_cancel_test.go
@@ -72,21 +72,28 @@ var (
 type recordingKBDeleteEnqueuer struct {
 	calls int
 	task  *asynq.Task
+	err   error
 }
 
 type recordingKBPendingRepo struct {
 	interfaces.TaskPendingOpsRepository
-	scopeIDs  []string
-	deleteErr error
+	scopeIDs    []string
+	completedKB []string
+	deleteErr   error
+	completeErr error
 }
 
 type recordingKBWikiRepo struct {
 	interfaces.WikiPageRepository
-	kbIDs []string
-	err   error
+	tenantIDs []uint64
+	kbIDs     []string
+	err       error
 }
 
-func (r *recordingKBWikiRepo) DeleteByKnowledgeBaseID(_ context.Context, kbID string) error {
+func (r *recordingKBWikiRepo) DeleteByKnowledgeBaseID(
+	_ context.Context, tenantID uint64, kbID string,
+) error {
+	r.tenantIDs = append(r.tenantIDs, tenantID)
 	r.kbIDs = append(r.kbIDs, kbID)
 	return r.err
 }
@@ -98,12 +105,25 @@ func (r *recordingKBPendingRepo) DeleteByScope(_ context.Context, scope, scopeID
 	return r.deleteErr
 }
 
+func (r *recordingKBPendingRepo) DeleteByDedupKey(
+	_ context.Context, taskType, scope, scopeID, dedupKey, op string,
+) error {
+	if taskType == types.TypeKBDelete && scope == types.TaskScopeKnowledgeBaseDelete &&
+		scopeID == dedupKey && op == types.TaskOpKnowledgeBaseDelete {
+		r.completedKB = append(r.completedKB, scopeID)
+	}
+	return r.completeErr
+}
+
 func (r *recordingKBDeleteEnqueuer) Enqueue(
 	task *asynq.Task,
 	_ ...asynq.Option,
 ) (*asynq.TaskInfo, error) {
 	r.calls++
 	r.task = task
+	if r.err != nil {
+		return nil, r.err
+	}
 	return &asynq.TaskInfo{ID: "kb-delete-task"}, nil
 }
 
@@ -125,8 +145,9 @@ func TestDeleteKnowledgeBaseForwardsDataSourceTaskScope(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, inspector.calls, 2)
-	assert.Empty(t, inspector.calls[0].dataSourceIDs)
-	assert.Equal(t, []string{"datasource-1"}, inspector.calls[1].dataSourceIDs)
+	for _, call := range inspector.calls {
+		assert.Equal(t, []string{"datasource-1"}, call.dataSourceIDs)
+	}
 	require.NotNil(t, enqueuer.task)
 	var payload types.KBDeletePayload
 	require.NoError(t, json.Unmarshal(enqueuer.task.Payload(), &payload))
@@ -204,6 +225,7 @@ func TestProcessKBDeleteRepeatsQueueCleanup(t *testing.T) {
 		assert.Empty(t, call.knowledgeIDs)
 	}
 	assert.Equal(t, []string{"kb-race", "kb-race"}, pendingRepo.scopeIDs)
+	assert.Equal(t, []string{"kb-race"}, pendingRepo.completedKB)
 }
 
 func TestProcessKBDeleteRetriesWhenDurableCleanupFails(t *testing.T) {
@@ -234,6 +256,7 @@ func TestProcessKBDeleteCleansWikiDataWithoutKnowledgeRows(t *testing.T) {
 	err = svc.ProcessKBDelete(context.Background(), asynq.NewTask(types.TypeKBDelete, payload))
 
 	require.NoError(t, err)
+	assert.Equal(t, []uint64{1}, wikiRepo.tenantIDs)
 	assert.Equal(t, []string{"kb-wiki"}, wikiRepo.kbIDs)
 }
 
@@ -467,6 +490,29 @@ func TestProcessKBDeleteEngineResolutionFailureRetries(t *testing.T) {
 	assert.Equal(t, 0, repo.deleteCalls, "knowledge rows must not be deleted when engine resolution is deferred")
 }
 
+func TestProcessKBDeleteWithoutVectorsSkipsEngineResolution(t *testing.T) {
+	repo := &kbDeleteTrackingKnowledgeRepo{populatedKBKnowledgeRepo: populatedKBKnowledgeRepo{items: []*types.Knowledge{
+		{ID: "wiki-only", KnowledgeBaseID: "kb-1", EmbeddingModelID: "", Type: "wiki"},
+	}}}
+	chunkRepo := &trackingKBChunkRepo{}
+	svc := &knowledgeBaseService{
+		kgRepo:         repo,
+		chunkRepo:      chunkRepo,
+		retrieveEngine: kbDeleteDeferredRegistry{err: errors.New("must not resolve vector engine")},
+	}
+	payload, err := json.Marshal(types.KBDeletePayload{
+		TenantID:        1,
+		KnowledgeBaseID: "kb-1",
+	})
+	require.NoError(t, err)
+
+	err = svc.ProcessKBDelete(context.Background(), asynq.NewTask(types.TypeKBDelete, payload))
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, chunkRepo.deleteCalls)
+	assert.Equal(t, 1, repo.deleteCalls)
+}
+
 func TestProcessKBDeleteUnavailableStoreRetries(t *testing.T) {
 	const storeID = "00000000-0000-0000-0000-0000000000ee"
 	storeIDPtr := storeID
@@ -491,6 +537,33 @@ func TestProcessKBDeleteUnavailableStoreRetries(t *testing.T) {
 
 	require.ErrorIs(t, err, retriever.ErrVectorStoreUnavailable)
 	assert.Equal(t, 0, repo.deleteCalls, "knowledge rows must not be deleted when engine resolution is deferred")
+}
+
+func TestProcessKBDeleteStoreOwnershipFailureRetries(t *testing.T) {
+	const storeID = "00000000-0000-0000-0000-0000000000ff"
+	storeIDPtr := storeID
+	repo := &kbDeleteTrackingKnowledgeRepo{populatedKBKnowledgeRepo: populatedKBKnowledgeRepo{items: []*types.Knowledge{
+		{ID: "knowledge-1", KnowledgeBaseID: "kb-1", EmbeddingModelID: "model-1"},
+	}}}
+	svc := &knowledgeBaseService{
+		kgRepo:         repo,
+		chunkRepo:      kbCleanupChunkRepo{},
+		modelService:   kbCleanupModelService{},
+		retrieveEngine: kbDeleteDeferredRegistry{err: retriever.ErrVectorStoreNotFound},
+		ownership:      &kbDeleteOwnership{owned: map[string]uint64{}},
+	}
+	payload, err := json.Marshal(types.KBDeletePayload{
+		TenantID:        1,
+		KnowledgeBaseID: "kb-1",
+		VectorStoreID:   &storeIDPtr,
+	})
+	require.NoError(t, err)
+
+	err = svc.ProcessKBDelete(context.Background(), asynq.NewTask(types.TypeKBDelete, payload))
+
+	require.ErrorIs(t, err, retriever.ErrVectorStoreForbidden)
+	require.NotErrorIs(t, err, asynq.SkipRetry)
+	assert.Equal(t, 0, repo.deleteCalls)
 }
 
 func TestCancelTasksForKnowledgeBaseForwardsKnowledgeIDs(t *testing.T) {

--- a/internal/application/service/retriever/composite.go
+++ b/internal/application/service/retriever/composite.go
@@ -298,6 +298,21 @@ func (c *CompositeRetrieveEngine) DeleteByKnowledgeIDList(ctx context.Context,
 	})
 }
 
+// DeleteByKnowledgeIDListAllDimensions deletes knowledge data without relying
+// on the currently configured embedding dimension. Dimension-partitioned
+// repositories discover and clean every owned collection; single-index
+// repositories ignore the zero-dimension fallback as they always have.
+func (c *CompositeRetrieveEngine) DeleteByKnowledgeIDListAllDimensions(
+	ctx context.Context, knowledgeIDList []string, knowledgeType string,
+) error {
+	return c.concurrentExecWithError(ctx, func(ctx context.Context, engineInfo *engineInfo) error {
+		if deleter, ok := engineInfo.retrieveEngine.(interfaces.CrossDimensionKnowledgeDeleter); ok {
+			return deleter.DeleteByKnowledgeIDListAllDimensions(ctx, knowledgeIDList, knowledgeType)
+		}
+		return engineInfo.retrieveEngine.DeleteByKnowledgeIDList(ctx, knowledgeIDList, 0, knowledgeType)
+	})
+}
+
 // EstimateStorageSize estimates the storage size required for the provided index information
 func (c *CompositeRetrieveEngine) EstimateStorageSize(ctx context.Context,
 	embedder embedding.Embedder, indexInfoList []*types.IndexInfo,

--- a/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
+++ b/internal/application/service/retriever/keywords_vector_hybrid_indexer.go
@@ -286,7 +286,22 @@ func (v *KeywordsVectorHybridRetrieveEngineService) DeleteBySourceIDList(ctx con
 func (v *KeywordsVectorHybridRetrieveEngineService) DeleteByKnowledgeIDList(ctx context.Context,
 	knowledgeIDList []string, dimension int, knowledgeType string,
 ) error {
+	if deleter, ok := v.indexRepository.(interfaces.CrossDimensionKnowledgeDeleter); ok {
+		return deleter.DeleteByKnowledgeIDListAllDimensions(ctx, knowledgeIDList, knowledgeType)
+	}
 	return v.indexRepository.DeleteByKnowledgeIDList(ctx, knowledgeIDList, dimension, knowledgeType)
+}
+
+// DeleteByKnowledgeIDListAllDimensions exposes the repository capability to a
+// composite engine. Repositories backed by a single physical index already
+// ignore dimension, so the zero-dimension fallback preserves their behavior.
+func (v *KeywordsVectorHybridRetrieveEngineService) DeleteByKnowledgeIDListAllDimensions(
+	ctx context.Context, knowledgeIDList []string, knowledgeType string,
+) error {
+	if deleter, ok := v.indexRepository.(interfaces.CrossDimensionKnowledgeDeleter); ok {
+		return deleter.DeleteByKnowledgeIDListAllDimensions(ctx, knowledgeIDList, knowledgeType)
+	}
+	return v.indexRepository.DeleteByKnowledgeIDList(ctx, knowledgeIDList, 0, knowledgeType)
 }
 
 // Support returns the retriever types supported by this engine

--- a/internal/application/service/retriever/keywords_vector_hybrid_indexer_test.go
+++ b/internal/application/service/retriever/keywords_vector_hybrid_indexer_test.go
@@ -50,6 +50,30 @@ func (r *saveOnlyRepository) BatchSave(
 	return nil
 }
 
+type crossDimensionDeleteRepository struct {
+	interfaces.RetrieveEngineRepository
+	allDimensionCalls int
+	configuredCalls   int
+	knowledgeIDs      []string
+	knowledgeType     string
+}
+
+func (r *crossDimensionDeleteRepository) DeleteByKnowledgeIDList(
+	context.Context, []string, int, string,
+) error {
+	r.configuredCalls++
+	return nil
+}
+
+func (r *crossDimensionDeleteRepository) DeleteByKnowledgeIDListAllDimensions(
+	_ context.Context, knowledgeIDs []string, knowledgeType string,
+) error {
+	r.allDimensionCalls++
+	r.knowledgeIDs = append([]string(nil), knowledgeIDs...)
+	r.knowledgeType = knowledgeType
+	return nil
+}
+
 func TestIndexRemovesInlineImagePayloadBeforeEmbedding(t *testing.T) {
 	ctx := context.Background()
 	embedder := &capturingEmbedder{}
@@ -104,6 +128,25 @@ func TestBatchIndexTruncatesOversizedEmbeddingInput(t *testing.T) {
 	}
 	if got := len([]rune(embedder.batchTexts[0])); got > safetyMaxChars {
 		t.Fatalf("embedding input length = %d, want <= %d", got, safetyMaxChars)
+	}
+}
+
+func TestDeleteByKnowledgeIDListUsesCrossDimensionRepositoryCapability(t *testing.T) {
+	repo := &crossDimensionDeleteRepository{}
+	service := &KeywordsVectorHybridRetrieveEngineService{indexRepository: repo}
+
+	err := service.DeleteByKnowledgeIDList(
+		context.Background(), []string{"knowledge-1"}, 2048, "file",
+	)
+	if err != nil {
+		t.Fatalf("DeleteByKnowledgeIDList returned error: %v", err)
+	}
+	if repo.allDimensionCalls != 1 || repo.configuredCalls != 0 {
+		t.Fatalf("all-dimension calls = %d, configured-dimension calls = %d, want 1 and 0",
+			repo.allDimensionCalls, repo.configuredCalls)
+	}
+	if len(repo.knowledgeIDs) != 1 || repo.knowledgeIDs[0] != "knowledge-1" || repo.knowledgeType != "file" {
+		t.Fatalf("unexpected delete payload: ids=%v type=%q", repo.knowledgeIDs, repo.knowledgeType)
 	}
 }
 

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -284,6 +284,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 		// Asynq inspector for cancel-by-knowledge-id (best-effort
 		// dequeue of pending/scheduled/retry tasks + active-task cancel).
 		must(container.Provide(router.NewAsynqInspector))
+		must(container.Provide(router.NewAsynqTaskRecoveryController))
 		must(container.Provide(router.NewAsynqTaskInspector))
 		// Install the distributed per-model chat concurrency governor. Only
 		// available with Redis (the shared semaphore backend); Lite mode is
@@ -292,6 +293,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	} else {
 		syncExec := router.NewSyncTaskExecutor()
 		must(container.Provide(func() interfaces.TaskEnqueuer { return syncExec }))
+		must(container.Provide(func() interfaces.TaskRecoveryController { return syncExec }))
 		must(container.Provide(func() *router.SyncTaskExecutor { return syncExec }))
 		// Lite mode: no Redis means no asynq inspector. SyncTaskExecutor
 		// dispatches inline goroutines that the checkpoint-based abort
@@ -403,6 +405,9 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	// persistence succeeded immediately before trigger enqueue failed). Re-arm
 	// them only after the matching handlers are ready.
 	must(container.Invoke(recoverPendingWikiTasks))
+	// KB deletion uses the same durable-trigger pattern so a lost Redis
+	// acknowledgement or process restart cannot strand physical cleanup.
+	must(container.Invoke(startKBDeleteRecovery))
 
 	logger.Infof(ctx, "[Container] Container initialization completed successfully")
 	return container

--- a/internal/container/recover_pending_kb_delete_tasks.go
+++ b/internal/container/recover_pending_kb_delete_tasks.go
@@ -1,0 +1,145 @@
+package container
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/application/service"
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/hibiken/asynq"
+	"gorm.io/gorm"
+)
+
+const kbDeleteRecoveryInterval = time.Minute
+
+type pendingKBDeleteIntent struct {
+	ID       int64  `gorm:"column:id"`
+	TenantID uint64 `gorm:"column:tenant_id"`
+	ScopeID  string `gorm:"column:scope_id"`
+	Payload  []byte `gorm:"column:payload"`
+}
+
+// recoverPendingKBDeleteTasks re-arms triggers for durable KB deletion
+// intents. The intent is committed with the soft-delete, so a lost Redis
+// enqueue or a process crash cannot strand the KB without a cleanup path.
+// A deterministic task ID makes this safe to run from multiple replicas.
+func recoverPendingKBDeleteTasks(
+	db *gorm.DB,
+	task interfaces.TaskEnqueuer,
+	recovery interfaces.TaskRecoveryController,
+) {
+	if db == nil || task == nil || recovery == nil {
+		return
+	}
+	ctx := context.Background()
+	var intents []pendingKBDeleteIntent
+	if err := db.WithContext(ctx).
+		Model(&types.TaskPendingOp{}).
+		Select("id, tenant_id, scope_id, payload").
+		Where("task_type = ? AND scope = ? AND op = ?",
+			types.TypeKBDelete, types.TaskScopeKnowledgeBaseDelete, types.TaskOpKnowledgeBaseDelete).
+		Order("id ASC").
+		Find(&intents).Error; err != nil {
+		logger.Warnf(ctx, "[KBDeleteRecovery] failed to list durable intents: %v", err)
+		return
+	}
+
+	seen := make(map[string]struct{}, len(intents))
+	for _, intent := range intents {
+		if intent.ScopeID == "" {
+			continue
+		}
+		if _, ok := seen[intent.ScopeID]; ok {
+			continue
+		}
+		seen[intent.ScopeID] = struct{}{}
+
+		var payload types.KBDeletePayload
+		if err := json.Unmarshal(intent.Payload, &payload); err != nil ||
+			payload.TenantID == 0 || payload.TenantID != intent.TenantID ||
+			payload.KnowledgeBaseID != intent.ScopeID {
+			logger.Warnf(ctx, "[KBDeleteRecovery] invalid durable intent id=%d kb=%s", intent.ID, intent.ScopeID)
+			continue
+		}
+		if _, err := service.EnqueueKBDeleteTask(task, intent.Payload, intent.ScopeID); err != nil {
+			if errors.Is(err, asynq.ErrTaskIDConflict) || errors.Is(err, asynq.ErrDuplicateTask) {
+				recoverArchivedKBDeleteTask(ctx, task, recovery, intent)
+				continue
+			}
+			logger.Warnf(ctx, "[KBDeleteRecovery] enqueue trigger for KB %s failed: %v", intent.ScopeID, err)
+			continue
+		}
+		logger.Infof(ctx, "[KBDeleteRecovery] re-armed cleanup trigger for KB %s", intent.ScopeID)
+	}
+}
+
+// recoverArchivedKBDeleteTask replaces an exhausted trigger while keeping the
+// durable outbox row intact. Pending, active, scheduled, and retrying tasks are
+// left alone; their existing execution already owns the delete intent.
+func recoverArchivedKBDeleteTask(
+	ctx context.Context,
+	task interfaces.TaskEnqueuer,
+	recovery interfaces.TaskRecoveryController,
+	intent pendingKBDeleteIntent,
+) {
+	taskID := service.KBDeleteTaskID(intent.ScopeID)
+	info, err := recovery.GetTaskInfo(types.QueueMaintenance, taskID)
+	if err != nil {
+		if !errors.Is(err, asynq.ErrTaskNotFound) {
+			logger.Warnf(ctx, "[KBDeleteRecovery] inspect trigger for KB %s failed: %v", intent.ScopeID, err)
+		}
+		return
+	}
+	if info.State != asynq.TaskStateArchived {
+		return
+	}
+	if err := recovery.DeleteTask(types.QueueMaintenance, taskID); err != nil &&
+		!errors.Is(err, asynq.ErrTaskNotFound) {
+		logger.Warnf(ctx, "[KBDeleteRecovery] remove archived trigger for KB %s failed: %v", intent.ScopeID, err)
+		return
+	}
+	if _, err := service.EnqueueKBDeleteTask(task, intent.Payload, intent.ScopeID); err != nil {
+		if errors.Is(err, asynq.ErrTaskIDConflict) || errors.Is(err, asynq.ErrDuplicateTask) {
+			return
+		}
+		logger.Warnf(ctx, "[KBDeleteRecovery] replace archived trigger for KB %s failed: %v", intent.ScopeID, err)
+		return
+	}
+	logger.Infof(ctx, "[KBDeleteRecovery] replaced exhausted cleanup trigger for KB %s", intent.ScopeID)
+}
+
+// startKBDeleteRecovery performs startup recovery and a lightweight periodic
+// pass in every deployment. Redis uses the inspector to replace archived
+// tasks; Lite mode deduplicates active task IDs in SyncTaskExecutor.
+func startKBDeleteRecovery(
+	db *gorm.DB,
+	task interfaces.TaskEnqueuer,
+	recovery interfaces.TaskRecoveryController,
+	cleaner interfaces.ResourceCleaner,
+) {
+	recoverPendingKBDeleteTasks(db, task, recovery)
+	if db == nil || task == nil || recovery == nil || cleaner == nil {
+		return
+	}
+	stop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(kbDeleteRecoveryInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				recoverPendingKBDeleteTasks(db, task, recovery)
+			case <-stop:
+				return
+			}
+		}
+	}()
+	cleaner.RegisterWithName("KBDeleteRecovery", func() error {
+		close(stop)
+		return nil
+	})
+}

--- a/internal/container/recover_pending_kb_delete_tasks_test.go
+++ b/internal/container/recover_pending_kb_delete_tasks_test.go
@@ -1,0 +1,160 @@
+package container
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/application/service"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const kbDeleteRecoveryTestDDL = `
+CREATE TABLE task_pending_ops (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id INTEGER NOT NULL,
+    task_type VARCHAR(64) NOT NULL,
+    scope VARCHAR(32) NOT NULL,
+    scope_id VARCHAR(64) NOT NULL,
+    op VARCHAR(32) NOT NULL,
+    dedup_key VARCHAR(128) NOT NULL DEFAULT '',
+    payload TEXT NOT NULL DEFAULT '{}',
+    fail_count INTEGER NOT NULL DEFAULT 0,
+    enqueued_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    claimed_at DATETIME
+);`
+
+type kbDeleteRecoveryEnqueuer struct {
+	tasks     []*asynq.Task
+	err       error
+	conflicts int
+}
+
+func (e *kbDeleteRecoveryEnqueuer) Enqueue(
+	task *asynq.Task, _ ...asynq.Option,
+) (*asynq.TaskInfo, error) {
+	e.tasks = append(e.tasks, task)
+	if e.conflicts > 0 {
+		e.conflicts--
+		return nil, asynq.ErrTaskIDConflict
+	}
+	if e.err != nil {
+		return nil, e.err
+	}
+	return &asynq.TaskInfo{ID: "recovered-kb-delete"}, nil
+}
+
+type kbDeleteRecoveryController struct {
+	info       *asynq.TaskInfo
+	deleteIDs  []string
+	inspectErr error
+	deleteErr  error
+}
+
+func (c *kbDeleteRecoveryController) GetTaskInfo(_, _ string) (*asynq.TaskInfo, error) {
+	if c.inspectErr != nil {
+		return nil, c.inspectErr
+	}
+	if c.info == nil {
+		return nil, asynq.ErrTaskNotFound
+	}
+	copy := *c.info
+	return &copy, nil
+}
+
+func (c *kbDeleteRecoveryController) DeleteTask(_, id string) error {
+	c.deleteIDs = append(c.deleteIDs, id)
+	if c.deleteErr != nil {
+		return c.deleteErr
+	}
+	c.info = nil
+	return nil
+}
+
+func setupKBDeleteRecoveryDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(kbDeleteRecoveryTestDDL).Error)
+	return db
+}
+
+func TestRecoverPendingKBDeleteTasksRearmsDurableIntent(t *testing.T) {
+	db := setupKBDeleteRecoveryDB(t)
+	payload, err := json.Marshal(types.KBDeletePayload{
+		TenantID:        7,
+		KnowledgeBaseID: "kb-pending-delete",
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&types.TaskPendingOp{
+		TenantID: 7,
+		TaskType: types.TypeKBDelete,
+		Scope:    types.TaskScopeKnowledgeBaseDelete,
+		ScopeID:  "kb-pending-delete",
+		Op:       types.TaskOpKnowledgeBaseDelete,
+		DedupKey: "kb-pending-delete",
+		Payload:  payload,
+	}).Error)
+	enqueuer := &kbDeleteRecoveryEnqueuer{}
+
+	recoverPendingKBDeleteTasks(db, enqueuer, &kbDeleteRecoveryController{})
+
+	require.Len(t, enqueuer.tasks, 1)
+	assert.Equal(t, types.TypeKBDelete, enqueuer.tasks[0].Type())
+	assert.JSONEq(t, string(payload), string(enqueuer.tasks[0].Payload()))
+	var pendingCount int64
+	require.NoError(t, db.Model(&types.TaskPendingOp{}).Count(&pendingCount).Error)
+	assert.EqualValues(t, 1, pendingCount, "the worker consumes the intent only after cleanup succeeds")
+}
+
+func TestRecoverPendingKBDeleteTasksRejectsMismatchedPayload(t *testing.T) {
+	db := setupKBDeleteRecoveryDB(t)
+	require.NoError(t, db.Create(&types.TaskPendingOp{
+		TenantID: 7,
+		TaskType: types.TypeKBDelete,
+		Scope:    types.TaskScopeKnowledgeBaseDelete,
+		ScopeID:  "kb-delete",
+		Op:       types.TaskOpKnowledgeBaseDelete,
+		DedupKey: "kb-delete",
+		Payload:  []byte(`{"tenant_id":8,"knowledge_base_id":"kb-delete"}`),
+	}).Error)
+	enqueuer := &kbDeleteRecoveryEnqueuer{err: errors.New("must not be called")}
+
+	recoverPendingKBDeleteTasks(db, enqueuer, &kbDeleteRecoveryController{})
+
+	assert.Empty(t, enqueuer.tasks)
+}
+
+func TestRecoverPendingKBDeleteTasksReplacesArchivedTrigger(t *testing.T) {
+	db := setupKBDeleteRecoveryDB(t)
+	payload, err := json.Marshal(types.KBDeletePayload{
+		TenantID:        7,
+		KnowledgeBaseID: "kb-archived-delete",
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&types.TaskPendingOp{
+		TenantID: 7,
+		TaskType: types.TypeKBDelete,
+		Scope:    types.TaskScopeKnowledgeBaseDelete,
+		ScopeID:  "kb-archived-delete",
+		Op:       types.TaskOpKnowledgeBaseDelete,
+		DedupKey: "kb-archived-delete",
+		Payload:  payload,
+	}).Error)
+	enqueuer := &kbDeleteRecoveryEnqueuer{conflicts: 1}
+	controller := &kbDeleteRecoveryController{info: &asynq.TaskInfo{
+		ID:    service.KBDeleteTaskID("kb-archived-delete"),
+		Queue: types.QueueMaintenance,
+		State: asynq.TaskStateArchived,
+	}}
+
+	recoverPendingKBDeleteTasks(db, enqueuer, controller)
+
+	require.Len(t, enqueuer.tasks, 2, "the second enqueue replaces the archived trigger")
+	assert.Equal(t, []string{service.KBDeleteTaskID("kb-archived-delete")}, controller.deleteIDs)
+}

--- a/internal/router/sync_task.go
+++ b/internal/router/sync_task.go
@@ -17,13 +17,15 @@ import (
 // SyncTaskExecutor executes tasks synchronously (in a goroutine) without Redis.
 // Used in Lite mode as a drop-in replacement for *asynq.Client.
 type SyncTaskExecutor struct {
-	mu       sync.RWMutex
-	handlers map[string]func(context.Context, *asynq.Task) error
+	mu        sync.RWMutex
+	handlers  map[string]func(context.Context, *asynq.Task) error
+	activeIDs map[string]*asynq.TaskInfo
 }
 
 func NewSyncTaskExecutor() *SyncTaskExecutor {
 	return &SyncTaskExecutor{
-		handlers: make(map[string]func(context.Context, *asynq.Task) error),
+		handlers:  make(map[string]func(context.Context, *asynq.Task) error),
+		activeIDs: make(map[string]*asynq.TaskInfo),
 	}
 }
 
@@ -38,17 +40,11 @@ func (e *SyncTaskExecutor) RegisterHandler(pattern string, handler func(context.
 // Instead of queuing to Redis, it dispatches the task to a goroutine.
 // Supports ProcessIn (delay) and MaxRetry options for parity with asynq.
 func (e *SyncTaskExecutor) Enqueue(task *asynq.Task, opts ...asynq.Option) (*asynq.TaskInfo, error) {
-	e.mu.RLock()
-	handler, ok := e.handlers[task.Type()]
-	e.mu.RUnlock()
-
-	if !ok {
-		return nil, fmt.Errorf("sync task executor: no handler registered for type %q", task.Type())
-	}
-
 	var delay time.Duration
 	maxRetry := 25 // asynq default
 	maxRetrySet := false
+	taskID := ""
+	queueName := "sync"
 	for _, opt := range opts {
 		switch opt.Type() {
 		case asynq.ProcessInOpt:
@@ -60,6 +56,14 @@ func (e *SyncTaskExecutor) Enqueue(task *asynq.Task, opts ...asynq.Option) (*asy
 				maxRetry = n
 				maxRetrySet = true
 			}
+		case asynq.TaskIDOpt:
+			if id, ok := opt.Value().(string); ok {
+				taskID = id
+			}
+		case asynq.QueueOpt:
+			if queue, ok := opt.Value().(string); ok && queue != "" {
+				queueName = queue
+			}
 		}
 	}
 	// Callers that explicitly pass MaxRetry(0) want no retries.
@@ -68,14 +72,35 @@ func (e *SyncTaskExecutor) Enqueue(task *asynq.Task, opts ...asynq.Option) (*asy
 		maxRetry = 0
 	}
 
-	taskID := uuid.New().String()
+	if taskID == "" {
+		taskID = uuid.New().String()
+	}
 	info := &asynq.TaskInfo{
 		ID:    taskID,
-		Queue: "sync",
+		Queue: queueName,
 		Type:  task.Type(),
+		State: asynq.TaskStateActive,
 	}
 
+	e.mu.Lock()
+	handler, ok := e.handlers[task.Type()]
+	if !ok {
+		e.mu.Unlock()
+		return nil, fmt.Errorf("sync task executor: no handler registered for type %q", task.Type())
+	}
+	if _, exists := e.activeIDs[taskID]; exists {
+		e.mu.Unlock()
+		return nil, asynq.ErrTaskIDConflict
+	}
+	e.activeIDs[taskID] = info
+	e.mu.Unlock()
+
 	go func() {
+		defer func() {
+			e.mu.Lock()
+			delete(e.activeIDs, taskID)
+			e.mu.Unlock()
+		}()
 		if delay > 0 {
 			time.Sleep(delay)
 		}
@@ -113,6 +138,28 @@ func (e *SyncTaskExecutor) Enqueue(task *asynq.Task, opts ...asynq.Option) (*asy
 	}()
 
 	return info, nil
+}
+
+// GetTaskInfo exposes active deterministic task IDs to durable recovery.
+func (e *SyncTaskExecutor) GetTaskInfo(queue, id string) (*asynq.TaskInfo, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	info, ok := e.activeIDs[id]
+	if !ok || info.Queue != queue {
+		return nil, asynq.ErrTaskNotFound
+	}
+	copy := *info
+	return &copy, nil
+}
+
+// DeleteTask mirrors the inspector contract. Lite tasks cannot be forcefully
+// removed while their handler is running; completed tasks are removed from
+// activeIDs automatically and can be enqueued again by outbox recovery.
+func (e *SyncTaskExecutor) DeleteTask(queue, id string) error {
+	if _, err := e.GetTaskInfo(queue, id); err != nil {
+		return err
+	}
+	return fmt.Errorf("sync task executor: task %q is active", id)
 }
 
 type SyncTaskParams struct {

--- a/internal/router/sync_task_retry_test.go
+++ b/internal/router/sync_task_retry_test.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -34,5 +35,57 @@ func TestSyncTaskExecutorInjectsRetryMetadata(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for sync task")
+	}
+}
+
+func TestSyncTaskExecutorDeduplicatesActiveTaskID(t *testing.T) {
+	executor := NewSyncTaskExecutor()
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	executor.RegisterHandler("test:dedup", func(context.Context, *asynq.Task) error {
+		started <- struct{}{}
+		<-release
+		return nil
+	})
+
+	task := asynq.NewTask("test:dedup", nil)
+	opts := []asynq.Option{
+		asynq.Queue(types.QueueMaintenance),
+		asynq.TaskID("durable-delete-1"),
+		asynq.MaxRetry(0),
+	}
+	info, err := executor.Enqueue(task, opts...)
+	if err != nil {
+		t.Fatalf("first enqueue: %v", err)
+	}
+	if info.ID != "durable-delete-1" || info.Queue != types.QueueMaintenance {
+		t.Fatalf("task info = %#v", info)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first task")
+	}
+	if _, err := executor.Enqueue(task, opts...); !errors.Is(err, asynq.ErrTaskIDConflict) {
+		t.Fatalf("second enqueue error = %v, want task ID conflict", err)
+	}
+	active, err := executor.GetTaskInfo(types.QueueMaintenance, "durable-delete-1")
+	if err != nil || active.State != asynq.TaskStateActive {
+		t.Fatalf("active task info = %#v, err=%v", active, err)
+	}
+
+	close(release)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := executor.Enqueue(task, opts...); err == nil {
+			break
+		} else if !errors.Is(err, asynq.ErrTaskIDConflict) {
+			t.Fatalf("re-enqueue after completion: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("task ID was not released after completion")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/internal/router/task_inspector.go
+++ b/internal/router/task_inspector.go
@@ -21,6 +21,14 @@ func NewAsynqInspector(redisClient *redis.Client) *asynq.Inspector {
 	return asynq.NewInspectorFromRedisClient(redisClient)
 }
 
+// NewAsynqTaskRecoveryController exposes the concrete inspector through the
+// narrow interface used by durable outbox recovery.
+func NewAsynqTaskRecoveryController(
+	inspector *asynq.Inspector,
+) interfaces.TaskRecoveryController {
+	return inspector
+}
+
 // asynqTaskInspector implements interfaces.TaskInspector backed by an
 // *asynq.Inspector. Scans the queues we actually use and matches tasks
 // whose payload carries the given

--- a/internal/types/interfaces/knowledge.go
+++ b/internal/types/interfaces/knowledge.go
@@ -227,6 +227,15 @@ type KnowledgeService interface {
 }
 
 // KnowledgeRepository defines the interface for knowledge repositories.
+// UnscopedKnowledgeLister exposes soft-deleted knowledge rows for destructive
+// knowledge-base cleanup. It is optional so existing repository fakes and
+// alternate implementations keep their current contract.
+type UnscopedKnowledgeLister interface {
+	ListKnowledgeByKnowledgeBaseIDUnscoped(
+		ctx context.Context, tenantID uint64, kbID string,
+	) ([]*types.Knowledge, error)
+}
+
 type KnowledgeRepository interface {
 	CreateKnowledge(ctx context.Context, knowledge *types.Knowledge) error
 	GetKnowledgeByID(ctx context.Context, tenantID uint64, id string) (*types.Knowledge, error)

--- a/internal/types/interfaces/knowledgebase.go
+++ b/internal/types/interfaces/knowledgebase.go
@@ -242,3 +242,16 @@ type KnowledgeBaseRepository interface {
 		ctx context.Context, tenantID uint64, userID string,
 	) (map[string]time.Time, error)
 }
+
+// KnowledgeBaseDeleteOutbox atomically soft-deletes a knowledge base and
+// persists the durable operation that will drive its physical cleanup. It is
+// optional so alternate read-only repository implementations do not need to
+// support destructive workflows.
+type KnowledgeBaseDeleteOutbox interface {
+	DeleteKnowledgeBaseWithPendingOp(
+		ctx context.Context,
+		id string,
+		tenantID uint64,
+		op *types.TaskPendingOp,
+	) error
+}

--- a/internal/types/interfaces/retriever.go
+++ b/internal/types/interfaces/retriever.go
@@ -64,6 +64,14 @@ type RetrieveEngineRepository interface {
 	RetrieveEngine
 }
 
+// CrossDimensionKnowledgeDeleter removes knowledge data from every
+// dimension-partitioned collection owned by a retrieve repository. Repositories
+// whose physical storage is not partitioned by dimension do not need to
+// implement it; callers fall back to DeleteByKnowledgeIDList.
+type CrossDimensionKnowledgeDeleter interface {
+	DeleteByKnowledgeIDListAllDimensions(ctx context.Context, knowledgeIDList []string, knowledgeType string) error
+}
+
 // RetrieveEngineRegistry defines the retrieve engine registry interface
 type RetrieveEngineRegistry interface {
 	// Register registers the retrieve engine service

--- a/internal/types/interfaces/task_enqueuer.go
+++ b/internal/types/interfaces/task_enqueuer.go
@@ -7,3 +7,11 @@ import "github.com/hibiken/asynq"
 type TaskEnqueuer interface {
 	Enqueue(task *asynq.Task, opts ...asynq.Option) (*asynq.TaskInfo, error)
 }
+
+// TaskRecoveryController exposes the minimum task-state operations required
+// by durable outbox recovery. Redis mode is backed by *asynq.Inspector; Lite
+// mode reports its in-process active task IDs through SyncTaskExecutor.
+type TaskRecoveryController interface {
+	GetTaskInfo(queue, id string) (*asynq.TaskInfo, error)
+	DeleteTask(queue, id string) error
+}

--- a/internal/types/interfaces/wiki_page.go
+++ b/internal/types/interfaces/wiki_page.go
@@ -370,6 +370,10 @@ type WikiPageRepository interface {
 	// DeleteByID soft-deletes a wiki page by ID.
 	DeleteByID(ctx context.Context, id string) error
 
+	// DeleteByKnowledgeBaseID hard-deletes all Wiki pages, revisions, folders,
+	// and issues owned by a deleted knowledge base.
+	DeleteByKnowledgeBaseID(ctx context.Context, kbID string) error
+
 	// Search performs full-text search on wiki pages within a knowledge base.
 	Search(ctx context.Context, kbID string, query string, limit int) ([]*types.WikiPage, error)
 

--- a/internal/types/interfaces/wiki_page.go
+++ b/internal/types/interfaces/wiki_page.go
@@ -372,7 +372,7 @@ type WikiPageRepository interface {
 
 	// DeleteByKnowledgeBaseID hard-deletes all Wiki pages, revisions, folders,
 	// and issues owned by a deleted knowledge base.
-	DeleteByKnowledgeBaseID(ctx context.Context, kbID string) error
+	DeleteByKnowledgeBaseID(ctx context.Context, tenantID uint64, kbID string) error
 
 	// Search performs full-text search on wiki pages within a knowledge base.
 	Search(ctx context.Context, kbID string, query string, limit int) ([]*types.WikiPage, error)

--- a/internal/types/task_dead_letter.go
+++ b/internal/types/task_dead_letter.go
@@ -64,7 +64,10 @@ func (TaskDeadLetter) TableName() string {
 // have to guess at variations.
 const (
 	TaskScopeKnowledgeBase = "knowledge_base"
-	TaskScopeKnowledge     = "knowledge"
-	TaskScopeTenant        = "tenant"
-	TaskScopeUnknown       = "unknown"
+	// TaskScopeKnowledgeBaseDelete isolates durable KB deletion intents from
+	// normal KB-scoped work, which is purged as part of deletion cleanup.
+	TaskScopeKnowledgeBaseDelete = "knowledge_base_delete"
+	TaskScopeKnowledge           = "knowledge"
+	TaskScopeTenant              = "tenant"
+	TaskScopeUnknown             = "unknown"
 )

--- a/internal/types/task_pending_op.go
+++ b/internal/types/task_pending_op.go
@@ -57,6 +57,8 @@ type TaskPendingOp struct {
 	ClaimedAt *time.Time `json:"claimed_at,omitempty"`
 }
 
+const TaskOpKnowledgeBaseDelete = "delete"
+
 // TableName binds TaskPendingOp to the `task_pending_ops` table.
 func (TaskPendingOp) TableName() string {
 	return "task_pending_ops"


### PR DESCRIPTION
## 中文

### 问题

文档和知识库删除原先依赖当前 embedding 模型及其维度。模型被删除、维度配置变化，或历史向量位于其他维度集合时，清理会失败，脏数据任务还可能让已删除文档重新出现。

Fixes #2337

### 修复

- 文档删除、批量删除和知识库删除按 knowledge_id 跨所有已配置向量维度清理，不再查询当前 embedding 模型。
- Qdrant、Weaviate、Milvus、Tencent VectorDB、Doris 和 OpenSearch 均支持跨维度删除；无 embedding 模型的 Wiki-only 文档不会触发向量引擎解析。
- 知识库软删除与持久化删除意图在同一数据库事务中提交。事务提交前失败会整体回滚；提交后 Redis 入队或物理清理失败不会恢复知识库，而是保留删除意图，由启动恢复和周期扫描持续重试。
- 删除任务使用确定性任务 ID，Redis 归档任务可替换，Lite 模式也会去重活动任务，避免重复 worker。
- 清理读取已软删除文档并补偿历史残留，失败的向量、分块、图谱、Wiki、数据源和持久化任务清理由异步重试负责。
- 永久清理知识库关联的 Wiki 页面、修订、目录和问题记录，所有删除均按 tenant_id + knowledge_base_id 精确限定，避免误删其他租户同 ID 知识库的数据。
- 前端提示改为删除任务已提交，避免异步清理尚未完成时误报删除成功。

### 验证

通过：

- npm run check-i18n
- npm run type-check
- npm run build
- Go compile gates: ./internal/application/service, ./internal/application/repository, ./internal/router, the standalone KB recovery test, ./internal/application/service/retriever, and all six vector backends
- git diff --check upstream/main...HEAD
- Changed Go files pass gofmt -d

Windows 下 Go 运行时测试被仓库现有的 gojieba CGO 初始化访问冲突阻塞：

github.com/yanyiwu/gojieba._Cfunc_NewJieba: Exception 0xc0000005

显式设置有效 JIEBA_DICT_DIR 后仍复现；CGO_ENABLED=0 又触发仓库现有的 pg_query.Parse / pg_query.Deparse 限制。这些环境问题不是本次修改引入的。

## English

### Problem

Document and knowledge-base deletion depended on the currently configured embedding model and dimension. If the model was removed, its dimension changed, or historical vectors lived in another dimension-specific collection, cleanup could fail and dirty-data recovery could make deleted documents reappear.

Fixes #2337

### Changes

- Delete documents, batch selections, and entire knowledge bases by knowledge_id across every configured vector dimension, without looking up the current embedding model.
- Add cross-dimension deletion for Qdrant, Weaviate, Milvus, Tencent VectorDB, Doris, and OpenSearch; Wiki-only documents without an embedding model skip vector-engine resolution.
- Commit the knowledge-base soft delete and durable cleanup intent in one database transaction. Failures before commit roll back together; after commit, Redis enqueue or cleanup failures do not restore the knowledge base and instead leave the intent for startup and periodic retry.
- Use deterministic task IDs, replace archived Redis triggers, and deduplicate active Lite-mode tasks so only one cleanup worker owns an intent at a time.
- Read soft-deleted document rows to compensate historical leftovers. Vector, chunk, graph, Wiki, data-source, and durable-task cleanup failures remain retryable.
- Permanently delete Wiki pages, revisions, folders, and issues with an exact tenant_id plus knowledge_base_id scope, preventing deletion of another tenant's data.
- Report deletion task submitted in the UI instead of claiming asynchronous cleanup has already completed.

### Verification

Passed:

- npm run check-i18n
- npm run type-check
- npm run build
- Go compile gates for ./internal/application/service, ./internal/application/repository, ./internal/router, the standalone KB recovery test, ./internal/application/service/retriever, and all six vector backends
- git diff --check upstream/main...HEAD
- Changed Go files pass gofmt -d

Go runtime tests are blocked on Windows by the repository's existing gojieba CGO initialization access violation:

github.com/yanyiwu/gojieba._Cfunc_NewJieba: Exception 0xc0000005

The crash reproduces with a valid JIEBA_DICT_DIR; CGO_ENABLED=0 instead reaches the repository's existing pg_query.Parse / pg_query.Deparse limitation. Neither environment issue is introduced by this change.

## Type of Change

- [x] Bug fix
- [x] Test
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] git diff --check upstream/main...HEAD passes
- [x] Changed source files are formatted
- [x] Frontend i18n, type, and build checks pass
- [x] Changed Go packages pass compile gates
- [x] Added transaction, retry, deduplication, and tenant-isolation regression tests
- [x] Environment-dependent test failures are documented above
- [ ] Runtime Go tests pass on Windows