### PR TITLE
fix(test): use resolvable URLs in MCP service update test

### DIFF
--- a/internal/application/service/mcp_service_test.go
+++ b/internal/application/service/mcp_service_test.go
@@ -183,11 +183,13 @@ func TestUpdateMCPService_AppliesNonScalarUpdateWithoutName(t *testing.T) {
 	ctx := context.Background()
 	svc, repo := newTestService()
 	id := seedService(t, repo, "stored-api", "stored-token")
-	beforeURL := "https://before.example.com"
+	// Use resolvable example.com paths: subdomains like before.example.com fail
+	// SSRF DNS checks because they do not resolve to a public IP.
+	beforeURL := "https://example.com/before"
 	repo.store[id].Description = "before"
 	repo.store[id].URL = &beforeURL
 
-	afterURL := "https://after.example.com"
+	afterURL := "https://example.com/after"
 	update := &types.MCPService{
 		ID:       id,
 		TenantID: 1,


### PR DESCRIPTION
## Summary
- Fixes failing App CI test `TestUpdateMCPService_AppliesNonScalarUpdateWithoutName`.
- `UpdateMCPService` now runs outbound URL SSRF validation; `before.example.com` / `after.example.com` do not resolve via DNS and are rejected.
- Switches the test to `https://example.com/before` and `https://example.com/after`, which resolve to a public IP and pass SSRF checks.

## Test plan
- [x] `go test -run TestUpdateMCPService_AppliesNonScalarUpdateWithoutName ./internal/application/service/`
- [x] App workflow equivalent: `go vet` and `go test` on all packages except `docreader`