### PR TITLE
fix(knowledge): populate both knowledge base counts

### DIFF
--- a/internal/application/service/knowledgebase.go
+++ b/internal/application/service/knowledgebase.go
@@ -361,24 +361,7 @@ func (s *knowledgeBaseService) ListKnowledgeBases(ctx context.Context) ([]*types
 	for _, kb := range kbs {
 		kb.EnsureDefaults()
 
-		// Get knowledge count
-		switch kb.Type {
-		case types.KnowledgeBaseTypeDocument:
-			knowledgeCount, err := s.kgRepo.CountKnowledgeByKnowledgeBaseID(ctx, tenantID, kb.ID)
-			if err != nil {
-				logger.Warnf(ctx, "Failed to get knowledge count for knowledge base %s: %v", kb.ID, err)
-			} else {
-				kb.KnowledgeCount = knowledgeCount
-			}
-		case types.KnowledgeBaseTypeFAQ:
-			// Get chunk count
-			chunkCount, err := s.chunkRepo.CountChunksByKnowledgeBaseID(ctx, tenantID, kb.ID)
-			if err != nil {
-				logger.Warnf(ctx, "Failed to get chunk count for knowledge base %s: %v", kb.ID, err)
-			} else {
-				kb.ChunkCount = chunkCount
-			}
-		}
+		s.fillKnowledgeBaseResourceCounts(ctx, tenantID, kb)
 
 		// Check if there is a processing import task
 		processingCount, err := s.kgRepo.CountKnowledgeByStatus(
@@ -416,16 +399,7 @@ func (s *knowledgeBaseService) ListKnowledgeBasesByTenantID(ctx context.Context,
 	}
 	for _, kb := range kbs {
 		kb.EnsureDefaults()
-		switch kb.Type {
-		case types.KnowledgeBaseTypeDocument:
-			if cnt, err := s.kgRepo.CountKnowledgeByKnowledgeBaseID(ctx, tenantID, kb.ID); err == nil {
-				kb.KnowledgeCount = cnt
-			}
-		case types.KnowledgeBaseTypeFAQ:
-			if cnt, err := s.chunkRepo.CountChunksByKnowledgeBaseID(ctx, tenantID, kb.ID); err == nil {
-				kb.ChunkCount = cnt
-			}
-		}
+		s.fillKnowledgeBaseResourceCounts(ctx, tenantID, kb)
 		if processingCount, err := s.kgRepo.CountKnowledgeByStatus(ctx, tenantID, kb.ID, []string{"pending", "processing"}); err == nil {
 			kb.IsProcessing = processingCount > 0
 			kb.ProcessingCount = processingCount
@@ -450,21 +424,35 @@ func (s *knowledgeBaseService) FillKnowledgeBaseCounts(ctx context.Context, kb *
 	}
 	tenantID := kb.TenantID
 	kb.EnsureDefaults()
-	switch kb.Type {
-	case types.KnowledgeBaseTypeDocument:
-		if cnt, err := s.kgRepo.CountKnowledgeByKnowledgeBaseID(ctx, tenantID, kb.ID); err == nil {
-			kb.KnowledgeCount = cnt
-		}
-	case types.KnowledgeBaseTypeFAQ:
-		if cnt, err := s.chunkRepo.CountChunksByKnowledgeBaseID(ctx, tenantID, kb.ID); err == nil {
-			kb.ChunkCount = cnt
-		}
-	}
+	s.fillKnowledgeBaseResourceCounts(ctx, tenantID, kb)
 	if processingCount, err := s.kgRepo.CountKnowledgeByStatus(ctx, tenantID, kb.ID, []string{"pending", "processing"}); err == nil {
 		kb.IsProcessing = processingCount > 0
 		kb.ProcessingCount = processingCount
 	}
 	return nil
+}
+
+// fillKnowledgeBaseResourceCounts populates both independent resource counts
+// for every knowledge base type. A failure in one query must not prevent the
+// other statistic from being returned.
+func (s *knowledgeBaseService) fillKnowledgeBaseResourceCounts(
+	ctx context.Context,
+	tenantID uint64,
+	kb *types.KnowledgeBase,
+) {
+	knowledgeCount, err := s.kgRepo.CountKnowledgeByKnowledgeBaseID(ctx, tenantID, kb.ID)
+	if err != nil {
+		logger.Warnf(ctx, "Failed to get knowledge count for knowledge base %s: %v", kb.ID, err)
+	} else {
+		kb.KnowledgeCount = knowledgeCount
+	}
+
+	chunkCount, err := s.chunkRepo.CountChunksByKnowledgeBaseID(ctx, tenantID, kb.ID)
+	if err != nil {
+		logger.Warnf(ctx, "Failed to get chunk count for knowledge base %s: %v", kb.ID, err)
+	} else {
+		kb.ChunkCount = chunkCount
+	}
 }
 
 // UpdateKnowledgeBase updates a knowledge base's mutable properties.

--- a/internal/application/service/knowledgebase_counts_test.go
+++ b/internal/application/service/knowledgebase_counts_test.go
@@ -1,0 +1,141 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type knowledgeBaseCountRepo struct {
+	interfaces.KnowledgeBaseRepository
+	rows []*types.KnowledgeBase
+}
+
+func (r *knowledgeBaseCountRepo) ListKnowledgeBasesByTenantID(
+	_ context.Context,
+	tenantID uint64,
+) ([]*types.KnowledgeBase, error) {
+	rows := make([]*types.KnowledgeBase, 0, len(r.rows))
+	for _, kb := range r.rows {
+		if kb.TenantID == tenantID {
+			copyKB := *kb
+			rows = append(rows, &copyKB)
+		}
+	}
+	return rows, nil
+}
+
+type knowledgeCountRepo struct {
+	interfaces.KnowledgeRepository
+	count int64
+	err   error
+	calls int
+}
+
+func (r *knowledgeCountRepo) CountKnowledgeByKnowledgeBaseID(
+	context.Context,
+	uint64,
+	string,
+) (int64, error) {
+	r.calls++
+	return r.count, r.err
+}
+
+func (*knowledgeCountRepo) CountKnowledgeByStatus(
+	context.Context,
+	uint64,
+	string,
+	[]string,
+) (int64, error) {
+	return 0, nil
+}
+
+type chunkCountRepo struct {
+	interfaces.ChunkRepository
+	count int64
+	err   error
+	calls int
+}
+
+func (r *chunkCountRepo) CountChunksByKnowledgeBaseID(
+	context.Context,
+	uint64,
+	string,
+) (int64, error) {
+	r.calls++
+	return r.count, r.err
+}
+
+func TestListKnowledgeBasesPopulatesBothCountsForEveryType(t *testing.T) {
+	rows := []*types.KnowledgeBase{
+		{ID: "document-kb", TenantID: 7, Type: types.KnowledgeBaseTypeDocument},
+		{ID: "faq-kb", TenantID: 7, Type: types.KnowledgeBaseTypeFAQ},
+	}
+	knowledgeRepo := &knowledgeCountRepo{count: 4}
+	chunkRepo := &chunkCountRepo{count: 149}
+	service := &knowledgeBaseService{
+		repo:      &knowledgeBaseCountRepo{rows: rows},
+		kgRepo:    knowledgeRepo,
+		chunkRepo: chunkRepo,
+	}
+
+	knowledgeBases, err := service.ListKnowledgeBases(ctxWithTenant(7))
+
+	require.NoError(t, err)
+	require.Len(t, knowledgeBases, 2)
+	for _, kb := range knowledgeBases {
+		assert.Equal(t, int64(4), kb.KnowledgeCount, "knowledge_count for %s", kb.Type)
+		assert.Equal(t, int64(149), kb.ChunkCount, "chunk_count for %s", kb.Type)
+	}
+	assert.Equal(t, 2, knowledgeRepo.calls)
+	assert.Equal(t, 2, chunkRepo.calls)
+}
+
+func TestListKnowledgeBasesByTenantIDPopulatesBothCountsForEveryType(t *testing.T) {
+	rows := []*types.KnowledgeBase{
+		{ID: "document-kb", TenantID: 7, Type: types.KnowledgeBaseTypeDocument},
+		{ID: "faq-kb", TenantID: 7, Type: types.KnowledgeBaseTypeFAQ},
+	}
+	knowledgeRepo := &knowledgeCountRepo{count: 4}
+	chunkRepo := &chunkCountRepo{count: 149}
+	service := &knowledgeBaseService{
+		repo:      &knowledgeBaseCountRepo{rows: rows},
+		kgRepo:    knowledgeRepo,
+		chunkRepo: chunkRepo,
+	}
+
+	knowledgeBases, err := service.ListKnowledgeBasesByTenantID(context.Background(), 7)
+
+	require.NoError(t, err)
+	require.Len(t, knowledgeBases, 2)
+	for _, kb := range knowledgeBases {
+		assert.Equal(t, int64(4), kb.KnowledgeCount, "knowledge_count for %s", kb.Type)
+		assert.Equal(t, int64(149), kb.ChunkCount, "chunk_count for %s", kb.Type)
+	}
+	assert.Equal(t, 2, knowledgeRepo.calls)
+	assert.Equal(t, 2, chunkRepo.calls)
+}
+
+func TestFillKnowledgeBaseCountsContinuesAfterKnowledgeCountFailure(t *testing.T) {
+	knowledgeRepo := &knowledgeCountRepo{err: errors.New("knowledge count failed")}
+	chunkRepo := &chunkCountRepo{count: 149}
+	service := &knowledgeBaseService{kgRepo: knowledgeRepo, chunkRepo: chunkRepo}
+	kb := &types.KnowledgeBase{
+		ID:       "document-kb",
+		TenantID: 7,
+		Type:     types.KnowledgeBaseTypeDocument,
+	}
+
+	err := service.FillKnowledgeBaseCounts(context.Background(), kb)
+
+	require.NoError(t, err)
+	assert.Zero(t, kb.KnowledgeCount)
+	assert.Equal(t, int64(149), kb.ChunkCount)
+	assert.Equal(t, 1, knowledgeRepo.calls)
+	assert.Equal(t, 1, chunkRepo.calls)
+}


### PR DESCRIPTION
## Description

Populate both `knowledge_count` and `chunk_count` for every knowledge base type.

Previously, document knowledge bases only queried `knowledge_count`, while FAQ
knowledge bases only queried `chunk_count`. As a result, a document knowledge
base with existing chunks could be returned with `chunk_count: 0`.

This change:

- adds a shared best-effort count enrichment helper;
- uses it for current-workspace lists, explicit-workspace lists, and single-KB details;
- keeps the two count queries independent so one failure does not suppress the other result;
- adds regression coverage for document and FAQ knowledge bases.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor
- [ ] Performance improvement
- [x] Test
- [ ] Configuration / Build / CI

## Related Issue

Fixes #2628

## Testing

Passed:

```text
go test ./internal/application/service -run 'Test(ListKnowledgeBasesPopulatesBothCountsForEveryType|ListKnowledgeBasesByTenantIDPopulatesBothCountsForEveryType|FillKnowledgeBaseCountsContinuesAfterKnowledgeCountFailure)$' -count=1
go test -race ./internal/application/service -run 'Test(ListKnowledgeBasesPopulatesBothCountsForEveryType|ListKnowledgeBasesByTenantIDPopulatesBothCountsForEveryType|FillKnowledgeBaseCountsContinuesAfterKnowledgeCountFailure)$' -count=1
go vet ./internal/application/service
git diff --check origin/main...HEAD
```

Broader checks:

- `go test ./internal/application/service -count=1` reaches unrelated Windows-only SQLite cleanup failures because three tests leave `weknora.db` open during `t.TempDir` cleanup. The same three failures were reproduced in a clean `origin/main` worktree.
- `go test ./... -count=1` was run. In addition to the same baseline SQLite cleanup failures, this Windows environment maps public test hosts to the restricted `198.18.0.0/15` range (triggering SSRF tests) and lacks the Unix shell behavior expected by `internal/sandbox` tests.
- `golangci-lint` is not installed in the local environment; `go vet` for the changed package passes.
- A live Docker API test was not run because Docker is unavailable in the local environment.

## Potential Impact

There are no schema, route, authorization, or response-field changes. Each
knowledge base now performs the previously omitted count query, adding one
count query per knowledge base to list/detail enrichment.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (local `golangci-lint` unavailable; `go vet` passes)
- [x] Full-repository checks were run, with unrelated/environment-dependent failures documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (not required; no API contract changes)
- [x] No breaking changes

## Screenshots / Recordings

Not applicable; API response statistics only.
