### PR TITLE
fix: 修复共享空间下拉列表无法滚动

### DIFF
--- a/frontend/src/components/share-to-space-panel.overlay.less
+++ b/frontend/src/components/share-to-space-panel.overlay.less
@@ -94,16 +94,7 @@
     border: 1px solid var(--td-component-stroke) !important;
     background: var(--td-bg-color-container) !important;
     box-shadow: 0 4px 16px rgba(15, 23, 42, 0.1) !important;
-    overflow: hidden;
-  }
-
-  .t-select__dropdown {
-    padding: 0 !important;
-    margin: 0 !important;
-    border: none !important;
-    box-shadow: none !important;
-    background: transparent !important;
-    max-height: min(280px, 40vh);
+    max-height: min(400px, 60vh);
     overflow-x: hidden;
     overflow-y: auto;
   }


### PR DESCRIPTION
## 修改

- 修复共享空间下拉列表滚动失效问题
- 增大下拉列表最大高度，空间较多时可完整选择

## 验证

- `npm run build`

Fixes #2643