### PR TITLE
fix(embedding): validate WeKnoraCloud response indexes

### DIFF
--- a/internal/models/embedding/weknoracloud.go
+++ b/internal/models/embedding/weknoracloud.go
@@ -130,9 +130,24 @@ func (e *WeKnoraCloudEmbedder) BatchEmbed(ctx context.Context, texts []string) (
 	}
 
 	result := make([][]float32, len(texts))
+	seen := make([]bool, len(texts))
 	for _, item := range embedResp.Data {
-		if item.Index < len(result) {
-			result[item.Index] = item.Embedding
+		if item.Index < 0 || item.Index >= len(result) {
+			return nil, fmt.Errorf(
+				"weknoracloud embedder: response index %d out of range for %d inputs",
+				item.Index,
+				len(texts),
+			)
+		}
+		if seen[item.Index] {
+			return nil, fmt.Errorf("weknoracloud embedder: duplicate response index %d", item.Index)
+		}
+		result[item.Index] = item.Embedding
+		seen[item.Index] = true
+	}
+	for index, found := range seen {
+		if !found {
+			return nil, fmt.Errorf("weknoracloud embedder: missing embedding for input index %d", index)
 		}
 	}
 	return result, nil

--- a/internal/models/embedding/weknoracloud_test.go
+++ b/internal/models/embedding/weknoracloud_test.go
@@ -1,0 +1,100 @@
+package embedding
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func newWeKnoraCloudEmbedderTestServer(t *testing.T, response string) *WeKnoraCloudEmbedder {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != weKnoraCloudEmbedPath {
+			http.Error(w, fmt.Sprintf("request path = %q, want %q", r.URL.Path, weKnoraCloudEmbedPath), http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, response)
+	}))
+	t.Cleanup(server.Close)
+
+	return &WeKnoraCloudEmbedder{
+		modelName: "test-embedding",
+		modelID:   "test-model-id",
+		appID:     "test-app-id",
+		apiKey:    "test-api-key",
+		baseURL:   server.URL,
+		client:    server.Client(),
+	}
+}
+
+func TestWeKnoraCloudBatchEmbedPreservesInputOrder(t *testing.T) {
+	embedder := newWeKnoraCloudEmbedderTestServer(t, `{
+		"data": [
+			{"index": 1, "embedding": [0.3, 0.4]},
+			{"index": 0, "embedding": [0.1, 0.2]}
+		]
+	}`)
+
+	got, err := embedder.BatchEmbed(context.Background(), []string{"first", "second"})
+	if err != nil {
+		t.Fatalf("BatchEmbed returned error: %v", err)
+	}
+	want := [][]float32{{0.1, 0.2}, {0.3, 0.4}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("BatchEmbed result = %v, want %v", got, want)
+	}
+}
+
+func TestWeKnoraCloudBatchEmbedRejectsMalformedResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		response   string
+		texts      []string
+		wantErrMsg string
+	}{
+		{
+			name:       "negative index",
+			response:   `{"data": [{"index": -1, "embedding": [0.1, 0.2]}]}`,
+			texts:      []string{"first"},
+			wantErrMsg: "response index -1 out of range",
+		},
+		{
+			name:       "index above input range",
+			response:   `{"data": [{"index": 1, "embedding": [0.1, 0.2]}]}`,
+			texts:      []string{"first"},
+			wantErrMsg: "response index 1 out of range",
+		},
+		{
+			name:       "duplicate index",
+			response:   `{"data": [{"index": 0, "embedding": [0.1]}, {"index": 0, "embedding": [0.2]}]}`,
+			texts:      []string{"first"},
+			wantErrMsg: "duplicate response index 0",
+		},
+		{
+			name:       "missing result",
+			response:   `{"data": [{"index": 0, "embedding": [0.1, 0.2]}]}`,
+			texts:      []string{"first", "second"},
+			wantErrMsg: "missing embedding for input index 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			embedder := newWeKnoraCloudEmbedderTestServer(t, tt.response)
+
+			_, err := embedder.BatchEmbed(context.Background(), tt.texts)
+			if err == nil {
+				t.Fatalf("BatchEmbed returned nil error, want error containing %q", tt.wantErrMsg)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrMsg) {
+				t.Fatalf("BatchEmbed error = %q, want it to contain %q", err, tt.wantErrMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

`WeKnoraCloudEmbedder.BatchEmbed` trusted response indexes before assigning them to the output slice. A negative index could therefore panic, while out-of-range, duplicate, or missing indexes could produce an incomplete batch without a useful error.

This change keeps the existing out-of-order response support, but validates index range and uniqueness before assignment and verifies that every input index was returned. The scope is limited to response-index validation.

## Type of Change

- [x] Bug fix
- [x] Test

## Related Issue

N/A — found while reviewing this provider boundary.

## Testing

Red-before-fix reproduction on Go 1.26:

- a response missing input index 1 returned a nil error
- response index `-1` panicked at `weknoracloud.go:135`

Passing checks:

- `go test ./internal/models/embedding -run TestWeKnoraCloudBatchEmbed(PreservesInputOrder|RejectsMalformedResponse)$ -count=1`
- `SSRF_WHITELIST_EXTRA=example-resource.openai.azure.com go test ./internal/models/embedding -count=1`
- `go vet ./internal/models/embedding`
- `git diff --check upstream/main...HEAD`

Environment notes:

- The first package-wide run hit the existing Azure example-host SSRF check because this Docker DNS maps it to a private fake IP. Using `SSRF_WHITELIST` directly was overwritten/cached by existing package tests; the deployment-level `SSRF_WHITELIST_EXTRA` rerun above passed. This PR does not change that shared test infrastructure.
- `go build -o /tmp/weknora-server ./cmd/server` reached an existing CGO dependency, but the vanilla `golang:1.26` image lacks `sqlite3.h`; repository CI remains the build verification.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-package checks were run; environment-dependent results are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (N/A: internal response validation only)
- [x] No breaking change

## Screenshots / Recordings

N/A — backend-only change.