### PR TITLE
feat(i18n): 前端默认语言支持经 DEFAULT_LOCALE 环境变量运行时配置

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,10 @@ TZ=Asia/Shanghai
 # 系统默认语言（BCP-47），用于 Prompt 中 {{language}} 占位符回退。
 # 优先级：Accept-Language 请求头 > 此变量 > 内置默认值 (en-US)。
 # WEKNORA_LANGUAGE=zh-CN
+# 前端界面默认语言（BCP-47）。可选：zh-CN | en-US | ru-RU | ko-KR。
+# 优先级：用户已选语言(localStorage) > 此变量 > 内置默认 zh-CN。
+# 仅影响首次访问/未手动切换语言的用户；改完重启 frontend 容器即生效，无需重建镜像。
+# DEFAULT_LOCALE=en-US
 # 启动时自动执行数据库迁移；设 false 禁用（默认启用）。
 AUTO_MIGRATE=true
 # 自动恢复脏数据迁移状态（默认 true）。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "${FRONTEND_PORT:-80}:80"
     environment:
       - MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
+      - DEFAULT_LOCALE=${DEFAULT_LOCALE:-}
       - APP_HOST=${APP_HOST:-app}
       # APP_BACKEND_PORT: the port NGINX proxies to (default 8080).
       # For local deployment this is the App container's listening port, independent of host-mapped APP_PORT.

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -3,7 +3,8 @@
 # 生成运行时配置文件，注入环境变量到前端
 cat > /usr/share/nginx/html/config.js << EOF
 window.__RUNTIME_CONFIG__ = {
-  MAX_FILE_SIZE_MB: ${MAX_FILE_SIZE_MB:-50}
+  MAX_FILE_SIZE_MB: ${MAX_FILE_SIZE_MB:-50},
+  DEFAULT_LOCALE: "${DEFAULT_LOCALE:-}"
 };
 EOF
 

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -11,8 +11,22 @@ const messages = {
   'ko-KR': koKR
 }
 
-// Получаем сохраненный язык из localStorage или используем китайский по умолчанию
-const savedLocale = localStorage.getItem('locale') || 'zh-CN'
+const SUPPORTED_LOCALES = Object.keys(messages)
+const BUILT_IN_DEFAULT = 'zh-CN'
+
+// Resolve the deployment default locale. Mirrors the MAX_FILE_SIZE_MB convention:
+// runtime config (.env -> docker-entrypoint -> window.__RUNTIME_CONFIG__) wins over
+// build-time env (VITE_DEFAULT_LOCALE), then the built-in default. Unknown values
+// (e.g. a typo in .env) fall back to the built-in default instead of a blank UI.
+function resolveDefaultLocale(): string {
+  const candidate = window.__RUNTIME_CONFIG__?.DEFAULT_LOCALE
+    || import.meta.env.VITE_DEFAULT_LOCALE
+    || BUILT_IN_DEFAULT
+  return SUPPORTED_LOCALES.includes(candidate) ? candidate : BUILT_IN_DEFAULT
+}
+
+// User's explicit past choice wins; otherwise use the deployment default.
+const savedLocale = localStorage.getItem('locale') || resolveDefaultLocale()
 
 const i18n = createI18n({
   legacy: false,

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -7,6 +7,7 @@ declare global {
   interface Window {
     __RUNTIME_CONFIG__?: {
       MAX_FILE_SIZE_MB?: number;
+      DEFAULT_LOCALE?: string;
     };
   }
 }


### PR DESCRIPTION
## 背景

当前前端界面默认语言硬编码为 `zh-CN`，无法通过部署配置调整。多语言部署（如默认英文/俄文）需改源码重新构建镜像，成本较高。

## 改动

新增 `DEFAULT_LOCALE` 环境变量，使前端界面默认语言可在运行时配置，**改完重启 frontend 容器即生效，无需重建镜像**。

涉及文件：
- `.env.example`：新增 `DEFAULT_LOCALE` 配置项与说明
- `docker-compose.yml`：透传 `DEFAULT_LOCALE` 到 frontend 容器
- `frontend/docker-entrypoint.sh`：将变量注入 `window.__RUNTIME_CONFIG__`（沿用 `MAX_FILE_SIZE_MB` 既有约定）
- `frontend/src/i18n/index.ts`：解析部署默认语言
- `frontend/src/utils/index.ts`：补充 `DEFAULT_LOCALE` 类型声明

## 语言解析优先级

```
用户已选语言(localStorage)  >  DEFAULT_LOCALE  >  内置默认 zh-CN
```

仅影响首次访问 / 未手动切换语言的用户；已知非法值（如 .env 拼写错误）回退到内置默认，避免空白界面。

## 配置示例

```bash
# .env
DEFAULT_LOCALE=en-US   # 可选：zh-CN | en-US | ru-RU | ko-KR
```