### PR TITLE
fix(i18n): harden DEFAULT_LOCALE runtime config after #2658

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,8 @@ TZ=Asia/Shanghai
 # 优先级：用户已选语言(localStorage) > 此变量 > 内置默认 zh-CN。
 # 仅影响首次访问/未手动切换语言的用户；改完重启 frontend 容器即生效，无需重建镜像。
 # DEFAULT_LOCALE=en-US
+# 构建前端镜像时的默认语言回退（仅在不使用 Docker 运行时 config.js 时生效）。
+# VITE_DEFAULT_LOCALE=en-US
 # 启动时自动执行数据库迁移；设 false 禁用（默认启用）。
 AUTO_MIGRATE=true
 # 自动恢复脏数据迁移状态（默认 true）。

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,10 +1,16 @@
 #!/bin/sh
 
+# Only emit whitelisted locale tags to avoid config.js injection from env values.
+RUNTIME_DEFAULT_LOCALE=""
+case "${DEFAULT_LOCALE:-}" in
+  zh-CN|en-US|ru-RU|ko-KR) RUNTIME_DEFAULT_LOCALE="${DEFAULT_LOCALE}" ;;
+esac
+
 # 生成运行时配置文件，注入环境变量到前端
 cat > /usr/share/nginx/html/config.js << EOF
 window.__RUNTIME_CONFIG__ = {
   MAX_FILE_SIZE_MB: ${MAX_FILE_SIZE_MB:-50},
-  DEFAULT_LOCALE: "${DEFAULT_LOCALE:-}"
+  DEFAULT_LOCALE: "${RUNTIME_DEFAULT_LOCALE}"
 };
 EOF
 

--- a/frontend/public/config.js
+++ b/frontend/public/config.js
@@ -3,4 +3,6 @@ window.__RUNTIME_CONFIG__ = {
   MAX_FILE_SIZE_MB: 50,
   // Optional: serve embed on a dedicated origin, e.g. 'https://embed.example.com'
   EMBED_BASE_URL: '',
+  // Optional: default UI locale for first-time visitors (zh-CN | en-US | ru-RU | ko-KR)
+  DEFAULT_LOCALE: '',
 };

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -3,6 +3,7 @@ import zhCN from './locales/zh-CN.ts'
 import ruRU from './locales/ru-RU.ts'
 import enUS from './locales/en-US.ts'
 import koKR from './locales/ko-KR.ts'
+import { BUILT_IN_DEFAULT, resolveDefaultLocale } from './resolveDefaultLocale.ts'
 
 const messages = {
   'zh-CN': zhCN,
@@ -11,27 +12,16 @@ const messages = {
   'ko-KR': koKR
 }
 
-const SUPPORTED_LOCALES = Object.keys(messages)
-const BUILT_IN_DEFAULT = 'zh-CN'
-
-// Resolve the deployment default locale. Mirrors the MAX_FILE_SIZE_MB convention:
-// runtime config (.env -> docker-entrypoint -> window.__RUNTIME_CONFIG__) wins over
-// build-time env (VITE_DEFAULT_LOCALE), then the built-in default. Unknown values
-// (e.g. a typo in .env) fall back to the built-in default instead of a blank UI.
-function resolveDefaultLocale(): string {
-  const candidate = window.__RUNTIME_CONFIG__?.DEFAULT_LOCALE
-    || import.meta.env.VITE_DEFAULT_LOCALE
-    || BUILT_IN_DEFAULT
-  return SUPPORTED_LOCALES.includes(candidate) ? candidate : BUILT_IN_DEFAULT
-}
-
 // User's explicit past choice wins; otherwise use the deployment default.
-const savedLocale = localStorage.getItem('locale') || resolveDefaultLocale()
+const savedLocale = localStorage.getItem('locale') || resolveDefaultLocale(
+  window.__RUNTIME_CONFIG__?.DEFAULT_LOCALE,
+  import.meta.env.VITE_DEFAULT_LOCALE,
+)
 
 const i18n = createI18n({
   legacy: false,
   locale: savedLocale,
-  fallbackLocale: 'zh-CN',
+  fallbackLocale: BUILT_IN_DEFAULT,
   globalInjection: true,
   // Some translations intentionally embed `<strong>` markup (e.g. agent step summaries).
   // We render them via v-html with our own sanitization, so silence vue-i18n's HTML warning

--- a/frontend/src/i18n/resolveDefaultLocale.test.ts
+++ b/frontend/src/i18n/resolveDefaultLocale.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { BUILT_IN_DEFAULT, resolveDefaultLocale } from './resolveDefaultLocale.ts'
+
+test('resolveDefaultLocale prefers runtime over build-time default', () => {
+  assert.equal(resolveDefaultLocale('en-US', 'ru-RU'), 'en-US')
+})
+
+test('resolveDefaultLocale falls back to build-time then built-in default', () => {
+  assert.equal(resolveDefaultLocale('', 'ko-KR'), 'ko-KR')
+  assert.equal(resolveDefaultLocale(undefined, undefined), BUILT_IN_DEFAULT)
+})
+
+test('resolveDefaultLocale trims whitespace around supported tags', () => {
+  assert.equal(resolveDefaultLocale(' en-US '), 'en-US')
+})
+
+test('resolveDefaultLocale rejects unknown values', () => {
+  assert.equal(resolveDefaultLocale('fr-FR'), BUILT_IN_DEFAULT)
+  assert.equal(resolveDefaultLocale('en-US"};alert(1);//'), BUILT_IN_DEFAULT)
+  assert.equal(resolveDefaultLocale('   '), BUILT_IN_DEFAULT)
+})

--- a/frontend/src/i18n/resolveDefaultLocale.ts
+++ b/frontend/src/i18n/resolveDefaultLocale.ts
@@ -1,0 +1,18 @@
+export const SUPPORTED_LOCALES = ['zh-CN', 'en-US', 'ru-RU', 'ko-KR'] as const
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number]
+
+export const BUILT_IN_DEFAULT: SupportedLocale = 'zh-CN'
+
+function isSupportedLocale(value: string): value is SupportedLocale {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(value)
+}
+
+/** Resolve deployment default locale before any user preference is applied. */
+export function resolveDefaultLocale(
+  runtimeLocale?: string | null,
+  buildTimeLocale?: string | null,
+): SupportedLocale {
+  const raw = runtimeLocale || buildTimeLocale || BUILT_IN_DEFAULT
+  const candidate = typeof raw === 'string' ? raw.trim() : BUILT_IN_DEFAULT
+  return isSupportedLocale(candidate) ? candidate : BUILT_IN_DEFAULT
+}

--- a/website-docs/05-clients/01-frontend.md
+++ b/website-docs/05-clients/01-frontend.md
@@ -299,8 +299,8 @@ RAG 流水线的可视化进度（`views/chat/components/RagPipelineProgress.vue
 
 `frontend/docker-entrypoint.sh`（运行时配置注入）：
 
-1. 生成 `/usr/share/nginx/html/config.js`，把 `MAX_FILE_SIZE_MB`（默认 50）写入 `window.__RUNTIME_CONFIG__` 供前端运行时读取；
-2. 用 `envsubst` 渲染 nginx 模板，可配置环境变量：`MAX_FILE_SIZE_MB`、`APP_HOST`（默认 `app`）、`APP_PORT`（默认 `8080`）、`APP_SCHEME`（默认 `http`，远程 HTTPS 后端可设 `https`）；
+1. 生成 `/usr/share/nginx/html/config.js`，把 `MAX_FILE_SIZE_MB`（默认 50）与 `DEFAULT_LOCALE`（可选，默认空）写入 `window.__RUNTIME_CONFIG__` 供前端运行时读取；entrypoint 仅允许 `zh-CN|en-US|ru-RU|ko-KR`，非法值会被丢弃；
+2. 用 `envsubst` 渲染 nginx 模板，可配置环境变量：`MAX_FILE_SIZE_MB`、`DEFAULT_LOCALE`、`APP_HOST`（默认 `app`）、`APP_PORT`（默认 `8080`）、`APP_SCHEME`（默认 `http`，远程 HTTPS 后端可设 `https`）；
 3. 前台启动 nginx。
 
 `frontend/nginx.conf` 关键行为：


### PR DESCRIPTION
## Summary

Follow-up hardening for #2658 (`DEFAULT_LOCALE` runtime config):

- Whitelist `zh-CN|en-US|ru-RU|ko-KR` in `docker-entrypoint.sh` before writing `config.js`, preventing JS injection via malicious env values
- Extract `resolveDefaultLocale()` with trim + validation; add unit tests for edge cases (whitespace, invalid tags, injection-like strings)
- Sync `frontend/public/config.js`, `.env.example` (`VITE_DEFAULT_LOCALE`), and frontend client docs

## Test plan

- [x] `npm run test -- src/i18n/resolveDefaultLocale.test.ts`
- [ ] Set `DEFAULT_LOCALE=en-US` in `.env`, restart frontend container → first-time visitors see English
- [ ] Set `DEFAULT_LOCALE=en-US"};alert(1);//` → entrypoint drops value, UI falls back to `zh-CN`
- [ ] Set `DEFAULT_LOCALE= en-US ` → UI uses English (trimmed on client)