### PR TITLE
fix(frontend): keep knowledge view controls visible

### DIFF
--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -3050,7 +3050,10 @@ async function createNewSession(value: string): Promise<void> {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  min-width: 0;
   position: relative;
+  container-type: inline-size;
+  container-name: doc-card-area;
   /* 作为批量工具栏悬浮的定位上下文 */
 }
 
@@ -3171,17 +3174,22 @@ async function createNewSession(value: string): Promise<void> {
     align-items: center;
     gap: 8px;
     flex-shrink: 0;
+    position: relative;
+    z-index: 1;
   }
 
-  @media (min-width: 1280px) {
+  // The folder tree changes the available document width without changing the
+  // viewport width. Switch to a single row only when this content area itself
+  // is wide enough for TDesign's fixed-width filter controls.
+  @container doc-card-area (min-width: 1240px) {
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
     gap: 12px;
 
     &__filters {
-      flex: 0 1 auto;
-      overflow-x: visible;
+      flex: 1 1 auto;
+      overflow-x: auto;
     }
   }
 


### PR DESCRIPTION

## Description

修复知识库详情页中文档视图切换按钮在可用空间不足时消失或被日期范围选择器遮挡的问题。

此前工具栏根据浏览器视口宽度切换布局。当文件目录展开后，文档内容区域虽然变窄，但工具栏仍可能保持单行布局，导致 TDesign `TDateRangePicker` 挤压或覆盖卡片/列表视图切换按钮。

本次修改：

- 使用 CSS Container Query，根据文档内容区域的实际宽度切换工具栏布局。
- 内容区域不足时自动回退为两行布局。
- 为文档区域增加 `min-width: 0`，避免 Flex 子项撑破容器。
- 保持筛选区域可横向滚动，避免 TDesign 固定宽度控件挤压操作区。
- 防止视图切换及新增文档操作区收缩或被其他控件覆盖。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✅ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI


## Testing

已执行以下检查：

```bash
cd frontend
npm run type-check
npm run build
```

```bash
git diff --check origin/main...HEAD
```

验证场景：

1. 打开知识库详情页的文档列表。
2. 展开左侧文件目录，缩小文档内容区域。
3. 确认工具栏自动切换为两行布局。
4. 确认卡片视图和列表视图按钮始终可见且可点击。
5. 确认日期范围选择器不会覆盖视图切换按钮。
6. 缩小浏览器窗口，确认筛选区域可横向滚动且操作区保持可见。

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (not applicable to this CSS/Vue-only change)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

未新增自动化测试：本次修改仅涉及响应式 CSS 布局，并已通过前端类型检查与生产构建验证。

未更新文档：该修复不改变用户操作流程、接口或配置。

## Screenshots / Recordings

问题复现：


https://github.com/user-attachments/assets/e0a03e65-eba3-42fb-9e7c-88e7ca50ba2b

问题修复后：



https://github.com/user-attachments/assets/4e46e27e-1b20-4c65-9fd3-9374a95ff066



