### PR TITLE
fix(docreader): avoid chart serialization during xlsx preprocessing

### DIFF
--- a/docreader/parser/xlsx_merge.py
+++ b/docreader/parser/xlsx_merge.py
@@ -36,6 +36,20 @@ def fill_merged_cells_xlsx(content: bytes) -> bytes:
     if not changed:
         return content
 
+    # Charts are not part of the cell text extracted by DocReader. Remove
+    # dedicated chart sheets through the public workbook API, then clear
+    # embedded worksheet charts (openpyxl has no public removal API for them)
+    # before saving this temporary workbook.
+    active_sheet = wb.active
+    for chart_sheet in list(wb.chartsheets):
+        wb.remove(chart_sheet)
+    if active_sheet in wb.worksheets:
+        wb.active = active_sheet
+    elif wb.worksheets:
+        wb.active = wb.worksheets[0]
+    for ws in wb.worksheets:
+        ws._charts.clear()
+
     out = BytesIO()
     wb.save(out)
     logger.info("Filled merged cells in XLSX before parse")

--- a/docreader/tests/test_excel_parser.py
+++ b/docreader/tests/test_excel_parser.py
@@ -5,9 +5,11 @@ import subprocess
 import tempfile
 import unittest
 import zipfile
+from unittest.mock import patch
 
 import openpyxl
 import pandas as pd
+from openpyxl.chart import BarChart, Reference
 
 from docreader.parser.excel_convert import detect_excel_format, engine_for_format
 from docreader.parser.excel_parser import ExcelParser
@@ -136,6 +138,28 @@ class XlsxRepairTest(unittest.TestCase):
 
 
 class XlsxMergeFillTest(unittest.TestCase):
+    @staticmethod
+    def _workbook_with_merged_cells_and_chart() -> bytes:
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws["A1"] = "title"
+        ws.merge_cells("A1:B1")
+        ws.append(["category", "value"])
+        ws.append(["one", 1])
+        ws.append(["two", 2])
+
+        chart = BarChart()
+        chart.add_data(
+            Reference(ws, min_col=2, min_row=2, max_row=4),
+            titles_from_data=True,
+        )
+        chart.set_categories(Reference(ws, min_col=1, min_row=3, max_row=4))
+        ws.add_chart(chart, "D2")
+
+        bio = io.BytesIO()
+        wb.save(bio)
+        return bio.getvalue()
+
     def test_fill_merged_cells_propagates_master_value(self):
         wb = openpyxl.Workbook()
         ws = wb.active
@@ -154,6 +178,89 @@ class XlsxMergeFillTest(unittest.TestCase):
         self.assertEqual(out_ws["B1"].value, "title")
         self.assertEqual(out_ws["A3"].value, "left")
         self.assertEqual(out_ws["B3"].value, "only-b")
+
+    def test_fill_merged_cells_does_not_serialize_charts(self):
+        content = self._workbook_with_merged_cells_and_chart()
+
+        with patch(
+            "openpyxl.chart._chart.ChartBase._write",
+            side_effect=AttributeError("'Typed' object has no attribute 'to_tree'"),
+        ):
+            filled = fill_merged_cells_xlsx(content)
+
+        out_wb = openpyxl.load_workbook(io.BytesIO(filled), data_only=True)
+        out_ws = out_wb.active
+        self.assertEqual(out_ws["B1"].value, "title")
+        self.assertEqual(out_ws["A3"].value, "one")
+        self.assertEqual(out_ws["B4"].value, 2)
+        self.assertEqual(out_ws._charts, [])
+
+    def test_excel_parser_reads_merged_workbook_with_chart(self):
+        document = ExcelParser().parse_into_text(
+            self._workbook_with_merged_cells_and_chart()
+        )
+
+        self.assertIn("A: title,B: title", document.content)
+        self.assertIn("A: one,B: 1", document.content)
+        self.assertIn("A: two,B: 2", document.content)
+
+    def test_chart_workbook_without_merges_passes_through_unchanged(self):
+        content = self._workbook_with_merged_cells_and_chart()
+        wb = openpyxl.load_workbook(io.BytesIO(content))
+        wb.active.unmerge_cells("A1:B1")
+        bio = io.BytesIO()
+        wb.save(bio)
+        content = bio.getvalue()
+
+        self.assertEqual(fill_merged_cells_xlsx(content), content)
+
+    def test_fill_does_not_serialize_dedicated_chart_sheets(self):
+        content = self._workbook_with_merged_cells_and_chart()
+        wb = openpyxl.load_workbook(io.BytesIO(content))
+        ws = wb.active
+        chart = BarChart()
+        chart.add_data(
+            Reference(ws, min_col=2, min_row=2, max_row=4),
+            titles_from_data=True,
+        )
+        chart.set_categories(Reference(ws, min_col=1, min_row=3, max_row=4))
+        chart_sheet = wb.create_chartsheet("Summary")
+        chart_sheet.add_chart(chart)
+        wb.active = chart_sheet
+        bio = io.BytesIO()
+        wb.save(bio)
+
+        with patch(
+            "openpyxl.chart._chart.ChartBase._write",
+            side_effect=AttributeError("'Typed' object has no attribute 'to_tree'"),
+        ):
+            filled = fill_merged_cells_xlsx(bio.getvalue())
+
+        out_wb = openpyxl.load_workbook(io.BytesIO(filled), data_only=True)
+        self.assertEqual(out_wb.active._charts, [])
+        self.assertEqual(out_wb.active.title, "Sheet")
+        self.assertEqual(out_wb.chartsheets, [])
+
+    def test_fill_keeps_active_worksheet_after_removing_earlier_chart_sheet(self):
+        content = self._workbook_with_merged_cells_and_chart()
+        wb = openpyxl.load_workbook(io.BytesIO(content))
+        data_sheet = wb.active
+        chart = BarChart()
+        chart.add_data(
+            Reference(data_sheet, min_col=2, min_row=2, max_row=4),
+            titles_from_data=True,
+        )
+        chart_sheet = wb.create_chartsheet("Summary", 0)
+        chart_sheet.add_chart(chart)
+        wb.active = data_sheet
+        bio = io.BytesIO()
+        wb.save(bio)
+
+        filled = fill_merged_cells_xlsx(bio.getvalue())
+
+        out_wb = openpyxl.load_workbook(io.BytesIO(filled), data_only=True)
+        self.assertEqual(out_wb.active.title, "Sheet")
+        self.assertEqual(out_wb.chartsheets, [])
 
     def test_parse_en_mergecell_workbook(self):
         path = os.path.join(


### PR DESCRIPTION
## Description

Fix XLSX parsing failures when merged-cell preprocessing rewrites workbooks containing chart structures that openpyxl can read but cannot serialize again.

`fill_merged_cells_xlsx` only creates a temporary workbook for pandas-based cell-text extraction. Charts and dedicated chart sheets do not contribute any cell text, but previously they were still serialized by `wb.save()`, which can fail with errors such as:

```text
AttributeError: 'Typed' object has no attribute 'to_tree'
```

This change removes chart-only content from the temporary workbook before saving:

- remove dedicated chart sheets through the workbook API;
- clear charts embedded in worksheets;
- preserve the active worksheet after chart-sheet removal;
- leave chart workbooks without merged cells byte-for-byte unchanged because they do not need preprocessing.

The original uploaded XLSX bytes are not modified or persisted; only the in-memory copy used for text extraction is simplified.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2648

## Testing

Added regression coverage for:

- a merged-cell workbook with an embedded chart;
- the reported chart serialization failure via deterministic fault injection;
- dedicated chart sheets, including when one is active;
- preserving the active worksheet when an earlier chart sheet is removed;
- byte-for-byte pass-through when a chart workbook has no merged cells;
- full `ExcelParser` cell-text extraction after preprocessing.

Passed:

```text
uv sync --project docreader --locked --no-dev --python 3.12
uv run --project docreader --python 3.12 python -m compileall -q docreader
uv run --project docreader --python 3.12 python -m unittest discover -s docreader/tests -p 'test_*.py' -v
# 143 tests total: 131 passed, 12 skipped

uvx ruff check docreader/parser/xlsx_merge.py docreader/tests/test_excel_parser.py
# passed

go test ./docreader/client ./docreader/proto
# passed

git diff --check origin/main...HEAD
# passed
```

The skipped Python tests require optional repository fixtures or local tools that are not present in this checkout.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or environment-dependent skips are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Related documentation reviewed; no API, configuration, or user workflow documentation changes are required
- [x] No breaking changes

## Screenshots / Recordings

N/A. This is a backend XLSX preprocessing fix covered by parser regression tests.