### PR TITLE
feat: paginate document chunks

### DIFF
--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -496,13 +496,10 @@ const preprocessMathDelimiters = (rawText: string): string => {
     .replace(/\\\(([\s\S]*?)\\\)/g, '$$$1$$');
 };
 const renderer = new marked.Renderer();
-let page = 1;
-let loadingChunks = false;
-let pendingRequestedPage: number | null = null;
-let pendingChunksBeforeLoad = 0;
 const CHUNK_PAGE_SIZE = 25;
-/** Scroll container for the main doc drawer (not the first .t-drawer__body on the page). */
-let docScrollEl: HTMLElement | null = null;
+const chunkPage = ref(1);
+let loadedChunkPage = 1;
+let pendingChunkPage: number | null = null;
 let mdContentWrap = ref()
 // Drawer uses attach="body", so markdown nodes live outside mdContentWrap in the DOM.
 const docMarkdownRoot = ref<HTMLElement | null>(null)
@@ -589,62 +586,26 @@ const mergeChunks = (chunks: any[]): string => {
   return merged;
 };
 
-const findDocDrawerScrollEl = (): HTMLElement | null =>
-  document.querySelector('.doc-main-drawer .t-drawer__body') as HTMLElement | null;
-
-const unbindDrawerScroll = () => {
-  if (docScrollEl) {
-    docScrollEl.removeEventListener('scroll', handleDetailsScroll);
-    docScrollEl = null;
-  }
-};
-
-const bindDrawerScroll = () => {
-  unbindDrawerScroll();
-  docScrollEl = findDocDrawerScrollEl();
-  if (docScrollEl) {
-    docScrollEl.addEventListener('scroll', handleDetailsScroll, { passive: true });
-  }
-};
-
 onMounted(() => {
   loadTraceDrawerWidth();
   loadMainDrawerWidth();
   window.addEventListener('resize', onTraceDrawerWindowResize, { passive: true });
 });
 
-watch(() => props.visible, (visible) => {
-  if (visible) {
-    nextTick(() => {
-      bindDrawerScroll();
-      maybeLoadMoreChunks();
-    });
-  } else {
-    unbindDrawerScroll();
-  }
-});
 watch(() => props.details?.id, () => {
-  page = 1;
-  loadingChunks = false;
-  pendingRequestedPage = null;
-  pendingChunksBeforeLoad = 0;
+  chunkPage.value = 1;
+  loadedChunkPage = 1;
+  pendingChunkPage = null;
 });
 watch(() => props.details?.chunkLoading, (val) => {
-  if (val === false) {
-    if (pendingRequestedPage !== null) {
-      const currentLength = props.details?.md?.length || 0;
-      const hasError = Boolean(props.details?.chunkLoadError);
-      if (hasError && currentLength <= pendingChunksBeforeLoad) {
-        page = Math.max(1, pendingRequestedPage - 1);
-        MessagePlugin.warning(props.details?.chunkLoadError);
-      }
+  if (val === false && pendingChunkPage !== null) {
+    if (props.details?.chunkLoadError) {
+      chunkPage.value = loadedChunkPage;
+      MessagePlugin.warning(props.details.chunkLoadError);
+    } else {
+      loadedChunkPage = pendingChunkPage;
     }
-    pendingRequestedPage = null;
-    pendingChunksBeforeLoad = 0;
-    loadingChunks = false;
-    if (props.visible) {
-      nextTick(() => maybeLoadMoreChunks());
-    }
+    pendingChunkPage = null;
   }
 });
 onUnmounted(() => {
@@ -652,7 +613,6 @@ onUnmounted(() => {
   window.removeEventListener('resize', onTraceDrawerWindowResize);
   cleanupTraceDrawerResize();
   cleanupMainDrawerResize();
-  unbindDrawerScroll();
   if (audioBlobUrl.value) {
     URL.revokeObjectURL(audioBlobUrl.value);
   }
@@ -837,9 +797,6 @@ watch(() => props.details.md, () => {
 watch(() => viewMode.value, (mode) => {
   if ((mode === 'chunks' || mode === 'merged') && props.visible) {
     runMarkdownPostRenderPipeline();
-    if (mode === 'chunks') {
-      nextTick(() => maybeLoadMoreChunks());
-    }
   }
 }, { flush: 'post' });
 
@@ -944,7 +901,7 @@ const processMarkdown = (markdownText) => {
 };
 const handleClose = () => {
   emit("closeDoc", false);
-  const scrollEl = docScrollEl || findDocDrawerScrollEl();
+  const scrollEl = document.querySelector('.doc-main-drawer .t-drawer__body') as HTMLElement | null;
   if (scrollEl) scrollEl.scrollTop = 0;
   viewMode.value = 'merged';
 };
@@ -1134,10 +1091,8 @@ const notifyChunkMutationOutcome = (item: any, result: any, successMessage?: str
 };
 
 const reloadChunksFromStart = () => {
-  page = 1;
-  loadingChunks = true;
-  pendingRequestedPage = 1;
-  pendingChunksBeforeLoad = 0;
+  chunkPage.value = 1;
+  pendingChunkPage = 1;
   editingChunkId.value = '';
   chunkDraft.value = '';
   emit('getDoc', 1);
@@ -1564,43 +1519,12 @@ const downloadFile = () => {
       MessagePlugin.error(t('file.downloadFailed'));
     });
 };
-const requestNextChunkPage = () => {
-  if (loadingChunks || props.details?.chunkLoading) return;
-  const total = props.details?.total ?? 0;
-  const loaded = props.details?.md?.length ?? 0;
-  if (loaded >= total || total === 0) return;
-  const pageNum = Math.ceil(total / CHUNK_PAGE_SIZE);
-  if (page + 1 > pageNum) return;
-  page++;
-  loadingChunks = true;
-  pendingRequestedPage = page;
-  pendingChunksBeforeLoad = loaded;
-  emit('getDoc', page);
+const handleChunkPageChange = (pageInfo: { current: number }) => {
+  if (props.details?.chunkLoading || pageInfo.current === loadedChunkPage) return;
+  pendingChunkPage = pageInfo.current;
+  emit('getDoc', pageInfo.current);
 };
 
-/** When the list is shorter than the drawer, scroll never fires — prefetch until scrollable or done. */
-const maybeLoadMoreChunks = () => {
-  if (!props.visible || loadingChunks || props.details?.chunkLoading) return;
-  const el = docScrollEl || findDocDrawerScrollEl();
-  if (!el) return;
-  const loaded = props.details?.md?.length ?? 0;
-  const total = props.details?.total ?? 0;
-  if (loaded >= total) return;
-  const { scrollHeight, clientHeight } = el;
-  if (scrollHeight <= clientHeight + 8) {
-    requestNextChunkPage();
-  }
-};
-
-const handleDetailsScroll = () => {
-  if (loadingChunks || props.details?.chunkLoading) return;
-  const el = docScrollEl || findDocDrawerScrollEl();
-  if (!el) return;
-  const { scrollTop, scrollHeight, clientHeight } = el;
-  if (scrollTop + clientHeight >= scrollHeight - 8) {
-    requestNextChunkPage();
-  }
-};
 </script>
 <template>
   <div class="doc_content" ref="mdContentWrap">
@@ -1874,7 +1798,7 @@ const handleDetailsScroll = () => {
                 v-for="(chunk, index) in processedChunks" :key="chunk.original.id || index">
                 <div class="chunk-header">
                   <div class="chunk-heading">
-                    <span class="chunk-index">{{ $t('knowledgeBase.segment') }} {{ index + 1 }}</span>
+                    <span class="chunk-index">{{ $t('knowledgeBase.segment') }} {{ (chunkPage - 1) * CHUNK_PAGE_SIZE + index + 1 }}</span>
                     <span class="chunk-meta">{{ chunk.meta }}</span>
                   </div>
                   <div class="chunk-header-right">
@@ -2124,6 +2048,13 @@ const handleDetailsScroll = () => {
           </div>
 
           <!-- 文档预览视图 -->
+          <div v-if="(viewMode === 'merged' || viewMode === 'chunks') && details.total > CHUNK_PAGE_SIZE"
+            class="chunk-pagination">
+            <t-pagination v-model="chunkPage" :total="details.total" :page-size="CHUNK_PAGE_SIZE" size="small"
+              show-jumper show-page-number :show-page-size="false" :disabled="details.chunkLoading"
+              @change="handleChunkPageChange" />
+          </div>
+
           <div v-else-if="viewMode === 'preview'">
             <DocumentPreview :knowledgeId="details.id" :fileType="details.file_type" :fileName="details.title"
               :active="viewMode === 'preview'" />
@@ -2149,6 +2080,14 @@ const handleDetailsScroll = () => {
 .metadata-empty { color: var(--td-text-color-placeholder); }
 .metadata-actions, .chunk-editor-actions { margin-top: 8px; justify-content: flex-end; }
 .chunk-disabled { opacity: .5; }
+
+.chunk-pagination {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--td-component-stroke);
+}
 
 .icon-action-btn {
   width: 28px;

--- a/frontend/src/hooks/useKnowledgeBase.ts
+++ b/frontend/src/hooks/useKnowledgeBase.ts
@@ -40,6 +40,8 @@ export default function (knowledgeBaseId?: string) {
     tags: [] as Array<{ id: string; name: string; color?: string }>,
   });
   let knowledgeListGeneration = 0;
+  let chunkRequestGeneration = 0;
+  let activeKnowledgeId = '';
   const getKnowled = (
     query: {
       page: number;
@@ -180,6 +182,8 @@ export default function (knowledgeBaseId?: string) {
       });
   };
   const getCardDetails = (item: any) => {
+    activeKnowledgeId = item.id;
+    chunkRequestGeneration++;
     Object.assign(details, {
       title: "",
       time: "",
@@ -223,21 +227,20 @@ export default function (knowledgeBaseId?: string) {
   };
   
   const getfDetails = (id: string, page: number) => {
+    const requestGeneration = ++chunkRequestGeneration;
     details.chunkLoading = true;
     details.chunkLoadError = "";
     getKnowledgeDetailsCon(id, page)
       .then((result: any) => {
+        if (requestGeneration !== chunkRequestGeneration || activeKnowledgeId !== id) return;
         if (result.success && result.data) {
           const { data, total: totalResult } = result;
-          if (page === 1) {
-            details.md = data;
-          } else {
-            details.md.push(...data);
-          }
+          details.md = data;
           details.total = totalResult;
         }
       })
       .catch((err: any) => {
+        if (requestGeneration !== chunkRequestGeneration) return;
         details.chunkLoadError = err?.message || t('knowledgeBase.chunkLoadFailed');
         console.error("[ChunkLoad] failed", {
           knowledgeId: id,
@@ -246,7 +249,9 @@ export default function (knowledgeBaseId?: string) {
         });
       })
       .finally(() => {
-        details.chunkLoading = false;
+        if (requestGeneration === chunkRequestGeneration) {
+          details.chunkLoading = false;
+        }
       });
   };
   return {


### PR DESCRIPTION
## Description

文档详情中的“全文”和“查看分块”原先采用无限滚动方式加载片段。随着滚动，后续分页数据会持续追加到前端；对于包含多个片段的文档，最终仍会加载并渲染全部内容，导致页面严重卡顿、长时间无法操作。

本 PR 将文档片段展示改为服务端分页：

- “全文”和“查看分块”视图共用分页器。
- 每页展示 25 个片段。
- 切换页码时调用现有分页接口，仅保留当前页数据，不再累加历史页面数据。
- 分块序号按照文档中的全局位置连续显示。
- 切页后保持当前滚动位置不变。
- 分页请求失败时恢复原页码并显示错误提示。
- 增加请求竞态保护，防止快速切页或切换文档时旧请求覆盖当前文档数据。
- 移除滚动到底部自动加载后续片段的逻辑。

后端已有分页接口，本次无需修改后端：

```http
GET /api/v1/chunks/{documentId}?page={page}&page_size=25
```

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [x] Performance improvement
- [ ] Test
- [ ] Configuration / Build / CI

## Related Issue

#2390 

## Testing

已完成以下验证：

1. 执行前端生产构建：

   ```bash
   cd frontend
   npm run build
   ```

   构建成功。

2. 执行差异格式检查：

   ```bash
   git diff --check
   ```

   检查通过。

3. 验证分页行为：

   - 文档详情首次打开时仅加载第一页的 25 个片段。
   - 点击页码后仅展示目标页数据。
   - 切换页码不会将新片段追加到上一页数据中。
   - 分块序号可以跨页连续显示。
   - 点击页码后抽屉滚动位置保持不变。
   - 快速切页或切换文档时，过期请求不会覆盖当前数据。

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings


https://github.com/user-attachments/assets/1daab2c0-478f-4f4a-900e-7d67c3c141e0


