### PR TITLE
fix(ui): 统一剪贴板复制为公共方法，HTTP 环境回退 execCommand

### DIFF
--- a/frontend/src/components/AgentEmbedChannelPanel.vue
+++ b/frontend/src/components/AgentEmbedChannelPanel.vue
@@ -397,6 +397,7 @@
 import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { MessagePlugin } from 'tdesign-vue-next'
+import { copyWithToast } from '@/utils/clipboard'
 import { useAuthStore } from '@/stores/auth'
 import SettingDrawer from '@/components/settings/SettingDrawer.vue'
 import EmbedChannelPreview from '@/components/EmbedChannelPreview.vue'
@@ -749,8 +750,7 @@ const copyToken = async (ch: EmbedChannel) => {
     MessagePlugin.warning(t('embedPublish.tokenHint'))
     return
   }
-  await navigator.clipboard.writeText(token)
-  MessagePlugin.success(t('embedPublish.tokenCopied'))
+  await copyWithToast(token, 'embedPublish.tokenCopied')
 }
 
 const iframeSnippet = (ch: EmbedChannel) => {
@@ -1035,15 +1035,11 @@ async function openPreviewForChannel(
 }
 
 const copySecureServerExample = async () => {
-  if (!secureServerExample.value) return
-  await navigator.clipboard.writeText(secureServerExample.value)
-  MessagePlugin.success(t('embedPublish.copied'))
+  await copyWithToast(secureServerExample.value, 'embedPublish.copied')
 }
 
 const copyDrawerSnippet = async () => {
-  if (!drawerSnippet.value) return
-  await navigator.clipboard.writeText(drawerSnippet.value)
-  MessagePlugin.success(t('embedPublish.copied'))
+  await copyWithToast(drawerSnippet.value, 'embedPublish.copied')
 }
 
 const performRotate = async (id: string) => {

--- a/frontend/src/components/ChatHeader.vue
+++ b/frontend/src/components/ChatHeader.vue
@@ -117,6 +117,7 @@
 import { computed, nextTick, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { MessagePlugin } from 'tdesign-vue-next'
+import { copyToClipboard } from '@/utils/clipboard'
 import { getMessageList } from '@/api/chat'
 import {
   clearSession,
@@ -179,26 +180,8 @@ function onMenuAction(value: string): void {
 }
 
 async function copyText(text: string): Promise<void> {
-  if (navigator.clipboard?.writeText) {
-    try {
-      await navigator.clipboard.writeText(text)
-      return
-    } catch {
-      // Some browsers expose Clipboard API outside a permitted context.
-      // Fall through to the legacy copy path before reporting a failure.
-    }
-  }
-
-  const textarea = document.createElement('textarea')
-  textarea.value = text
-  textarea.setAttribute('readonly', '')
-  textarea.style.position = 'fixed'
-  textarea.style.opacity = '0'
-  document.body.appendChild(textarea)
-  textarea.select()
-  const copied = document.execCommand('copy')
-  textarea.remove()
-  if (!copied) throw new Error('clipboard unavailable')
+  const ok = await copyToClipboard(text)
+  if (!ok) throw new Error('clipboard unavailable')
 }
 
 function currentSessionLink(): string {

--- a/frontend/src/components/ChatRequestInfoButton.vue
+++ b/frontend/src/components/ChatRequestInfoButton.vue
@@ -48,12 +48,11 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { MessagePlugin } from 'tdesign-vue-next';
 import {
   buildChatRequestDebugPayload,
   type ChatRequestDebugInfo,
 } from '@/utils/chatRequestDebug';
-import { copyTextToClipboard } from '@/utils/chatMessageShared';
+import { copyWithToast } from '@/utils/clipboard';
 
 const props = defineProps<{
   session: Record<string, unknown>;
@@ -97,13 +96,8 @@ const rows = computed(() => {
 });
 
 const copyAll = async () => {
-  try {
-    await copyTextToClipboard(buildChatRequestDebugPayload(debugInfo.value));
-    MessagePlugin.success(t('common.copied'));
-    visible.value = false;
-  } catch {
-    MessagePlugin.error(t('common.copyFailed'));
-  }
+  const ok = await copyWithToast(buildChatRequestDebugPayload(debugInfo.value), 'common.copied');
+  if (ok) visible.value = false;
 };
 </script>
 

--- a/frontend/src/components/IMChannelPanel.vue
+++ b/frontend/src/components/IMChannelPanel.vue
@@ -579,6 +579,7 @@
 import { ref, onMounted, watch, onUnmounted, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { MessagePlugin } from 'tdesign-vue-next';
+import { copyWithToast } from '@/utils/clipboard';
 import {
   listIMChannels, createIMChannel, updateIMChannel, deleteIMChannel, toggleIMChannel,
   getWeChatQRCode, pollWeChatQRCodeStatus, listAllIMChannels, listAgents,
@@ -936,25 +937,7 @@ function getCallbackUrl(channel: IMChannel): string {
 }
 
 async function copyUrl(channel: IMChannel) {
-  const text = getCallbackUrl(channel);
-  try {
-    await navigator.clipboard.writeText(text);
-    MessagePlugin.success(t('common.copySuccess'));
-  } catch {
-    const el = document.createElement('textarea');
-    el.value = text;
-    el.style.cssText = 'position:fixed;top:-9999px;left:-9999px;opacity:0';
-    document.body.appendChild(el);
-    el.focus();
-    el.select();
-    const ok = document.execCommand('copy');
-    document.body.removeChild(el);
-    if (ok) {
-      MessagePlugin.success(t('common.copySuccess'));
-    } else {
-      MessagePlugin.error(t('common.copyFailed'));
-    }
-  }
+  await copyWithToast(getCallbackUrl(channel), 'common.copySuccess');
 }
 
 function openCreate() {

--- a/frontend/src/components/ModelDebugDrawer.vue
+++ b/frontend/src/components/ModelDebugDrawer.vue
@@ -195,6 +195,7 @@
 import { computed, ref, watch, onBeforeUnmount } from 'vue'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
+import { copyWithToast } from '@/utils/clipboard'
 import SettingDrawer from '@/components/settings/SettingDrawer.vue'
 import { debugModel, type ModelConfig, type ModelDebugResult } from '@/api/model'
 import { fileSizeVerification } from '@/utils'
@@ -448,12 +449,7 @@ const runDebug = async () => {
 
 const copyResult = async () => {
   if (!result.value) return
-  try {
-    await navigator.clipboard.writeText(JSON.stringify(result.value, null, 2))
-    MessagePlugin.success(t('common.copied'))
-  } catch {
-    MessagePlugin.error(t('common.copyFailed'))
-  }
+  await copyWithToast(JSON.stringify(result.value, null, 2), 'common.copied')
 }
 
 onBeforeUnmount(() => {

--- a/frontend/src/components/knowledge-processing-timeline.vue
+++ b/frontend/src/components/knowledge-processing-timeline.vue
@@ -2,6 +2,7 @@
 import { ref, reactive, onMounted, onBeforeUnmount, watch, computed, nextTick } from 'vue'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
+import { copyWithToast } from '@/utils/clipboard'
 import { getKnowledgeSpans, reparseKnowledge, cancelKnowledgeParse, getKnowledgeDetails } from '@/api/knowledge-base/index'
 import {
   groupPostprocessGraphSpans,
@@ -446,13 +447,8 @@ function localizedErrorSuggestion(code?: string): string {
 }
 
 async function copyValue(value: any) {
-  try {
-    const text = typeof value === 'string' ? value : JSON.stringify(value, null, 2)
-    await navigator.clipboard.writeText(text)
-    MessagePlugin.success(t('knowledgeStages.copied'))
-  } catch {
-    MessagePlugin.error(t('knowledgeStages.copyDetails'))
-  }
+  const text = typeof value === 'string' ? value : JSON.stringify(value, null, 2)
+  await copyWithToast(text, 'knowledgeStages.copied', 'knowledgeStages.copyDetails')
 }
 
 async function copySpan(node: SpanNode) {

--- a/frontend/src/utils/chatMessageShared.ts
+++ b/frontend/src/utils/chatMessageShared.ts
@@ -100,19 +100,3 @@ export const buildManualMarkdown = (_question: string, answer: string): string =
   const safeAnswer = answer?.trim() || i18n.global.t('chat.noAnswerContent');
   return `${safeAnswer}`;
 };
-
-export const copyTextToClipboard = async (content: string): Promise<void> => {
-  if (navigator.clipboard && navigator.clipboard.writeText) {
-    await navigator.clipboard.writeText(content);
-    return;
-  }
-
-  const textArea = document.createElement('textarea');
-  textArea.value = content;
-  textArea.style.position = 'fixed';
-  textArea.style.opacity = '0';
-  document.body.appendChild(textArea);
-  textArea.select();
-  document.execCommand('copy');
-  document.body.removeChild(textArea);
-};

--- a/frontend/src/utils/clipboard.ts
+++ b/frontend/src/utils/clipboard.ts
@@ -1,0 +1,67 @@
+import { MessagePlugin } from 'tdesign-vue-next'
+import i18n from '@/i18n'
+
+/**
+ * Copy text to the clipboard, falling back to a hidden textarea +
+ * document.execCommand('copy') when the async Clipboard API is unavailable
+ * (e.g. on non-secure HTTP origins) or rejects (e.g. permission denied).
+ *
+ * Returns true on success, false otherwise. This helper is UI-agnostic —
+ * callers own any feedback. Use copyWithToast for the common "copy + toast"
+ * case; call this directly when you need custom feedback (e.g. inline DOM
+ * state) or none at all.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (!text) return false
+
+  // Prefer the async Clipboard API where available (HTTPS / localhost).
+  if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // Fall through to the legacy path (e.g. permission denied).
+    }
+  }
+
+  // Legacy fallback that also works on non-secure (HTTP) origins.
+  try {
+    const textArea = document.createElement('textarea')
+    textArea.value = text
+    textArea.style.position = 'fixed'
+    textArea.style.top = '0'
+    textArea.style.left = '0'
+    textArea.style.opacity = '0'
+    document.body.appendChild(textArea)
+    textArea.focus()
+    textArea.select()
+    const ok = document.execCommand('copy')
+    document.body.removeChild(textArea)
+    return ok
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Copy text and surface the result via a toast. Returns the underlying
+ * copyToClipboard result so callers can run extra side effects on success
+ * (e.g. closing a dialog). Empty / null / undefined text is a silent no-op
+ * (no toast), so callers can pass optional values (e.g. obj.value?.id)
+ * without a separate guard. successKey is required; failureKey defaults to
+ * the common message.
+ */
+export async function copyWithToast(
+  text: string | null | undefined,
+  successKey: string,
+  failureKey: string = 'common.copyFailed',
+): Promise<boolean> {
+  if (!text) return false
+  const ok = await copyToClipboard(text)
+  if (ok) {
+    MessagePlugin.success(i18n.global.t(successKey))
+  } else {
+    MessagePlugin.error(i18n.global.t(failureKey))
+  }
+  return ok
+}

--- a/frontend/src/utils/markdownEnhancements.ts
+++ b/frontend/src/utils/markdownEnhancements.ts
@@ -1,6 +1,7 @@
 import i18n from '@/i18n';
 import hljs from 'highlight.js';
 import { openMermaidFullscreen } from '@/utils/mermaidViewer';
+import { copyToClipboard } from '@/utils/clipboard';
 
 const ENHANCE_FLAG = 'data-markdown-enhancements';
 const boundMarkdownRoots = new WeakSet<HTMLElement>();
@@ -134,26 +135,15 @@ async function handleCodeCopy(btn: HTMLButtonElement): Promise<void> {
   const copiedLabel = i18n.global.t('common.copied');
   const defaultLabel = i18n.global.t('embedPublish.copyCode');
 
-  try {
-    if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(code);
-    } else {
-      const textArea = document.createElement('textarea');
-      textArea.value = code;
-      textArea.style.position = 'fixed';
-      textArea.style.opacity = '0';
-      document.body.appendChild(textArea);
-      textArea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textArea);
-    }
+  const ok = await copyToClipboard(code);
+  if (ok) {
     btn.classList.add('is-copied');
     if (textEl) textEl.textContent = copiedLabel;
     window.setTimeout(() => {
       btn.classList.remove('is-copied');
       if (textEl) textEl.textContent = defaultLabel;
     }, 1600);
-  } catch {
+  } else {
     btn.classList.add('is-error');
     window.setTimeout(() => btn.classList.remove('is-error'), 1600);
   }

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -1689,6 +1689,7 @@ import {
 } from '@/config/contextualGuides';
 import { useI18n } from 'vue-i18n';
 import { selectInitialModelId } from '@/utils/modelDefaults';
+import { copyWithToast } from '@/utils/clipboard';
 import { MessagePlugin } from 'tdesign-vue-next';
 import {
   createAgent,
@@ -1778,27 +1779,7 @@ const saveButtonLabel = computed(() =>
 );
 
 const copyAgentId = async () => {
-  const id = editorAgent.value?.id;
-  if (!id) return;
-
-  try {
-    if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(id);
-    } else {
-      const textarea = document.createElement('textarea');
-      textarea.value = id;
-      textarea.setAttribute('readonly', '');
-      textarea.style.position = 'fixed';
-      textarea.style.opacity = '0';
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textarea);
-    }
-    MessagePlugin.success(t('common.copied'));
-  } catch {
-    MessagePlugin.error(t('common.copyFailed'));
-  }
+  await copyWithToast(editorAgent.value?.id, 'common.copied');
 };
 
 const currentSection = ref(props.initialSection || 'basic');

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -539,13 +539,13 @@ import { getQueryText, getWikiPageText } from '@/utils/agent-tool-display';
 import { parseWikiToolReferences } from '@/utils/wikiToolReferences';
 import {
   buildManualMarkdown,
-  copyTextToClipboard,
   formatManualTitle,
   replaceIncompleteMermaidWithPlaceholder,
   prepareStreamingMermaidMarkdown,
   extractFirstMermaidCode,
   injectCachedMermaidSvg,
 } from '@/utils/chatMessageShared';
+import { copyWithToast } from '@/utils/clipboard';
 import {
   configureMarkedForChatMarkdown,
   renderChatMarkdown,
@@ -2766,13 +2766,7 @@ const handleCopyAnswer = async (answerEvent: any) => {
     return;
   }
 
-  try {
-    await copyTextToClipboard(content);
-    MessagePlugin.success(t('agentStream.copy.success'));
-  } catch (err) {
-    console.error('Copy failed:', err);
-    MessagePlugin.error(t('agentStream.copy.failed'));
-  }
+  await copyWithToast(content, 'agentStream.copy.success', 'agentStream.copy.failed');
 };
 
 const handleAddToKnowledge = (answerEvent: any) => {

--- a/frontend/src/views/chat/components/botmsg.vue
+++ b/frontend/src/views/chat/components/botmsg.vue
@@ -112,9 +112,9 @@ import { MessagePlugin } from 'tdesign-vue-next';
 import { useUIStore } from '@/stores/ui';
 import {
     buildManualMarkdown,
-    copyTextToClipboard,
     formatManualTitle,
 } from '@/utils/chatMessageShared';
+import { copyWithToast } from '@/utils/clipboard';
 import {
     createChatMarkdownRenderer,
     renderChatMarkdown,
@@ -306,13 +306,7 @@ const handleCopyAnswer = async () => {
         return;
     }
 
-    try {
-        await copyTextToClipboard(content);
-        MessagePlugin.success(t('chat.copySuccess'));
-    } catch (err) {
-        console.error('复制失败:', err);
-        MessagePlugin.error(t('chat.copyFailed'));
-    }
+    await copyWithToast(content, 'chat.copySuccess', 'chat.copyFailed');
 };
 
 // 添加到知识库

--- a/frontend/src/views/chat/components/tool-results/ChunkDetail.vue
+++ b/frontend/src/views/chat/components/tool-results/ChunkDetail.vue
@@ -37,6 +37,7 @@
 <script setup lang="ts">
 import type { ChunkDetailData } from '@/types/tool-results';
 import { useI18n } from 'vue-i18n';
+import { copyToClipboard as copyTextToClipboard } from '@/utils/clipboard';
 
 const props = defineProps<{
   data: ChunkDetailData;
@@ -45,26 +46,8 @@ const props = defineProps<{
 const { t } = useI18n();
 
 const copyToClipboard = () => {
-  const text = props.data.content;
-  if (navigator.clipboard && navigator.clipboard.writeText) {
-    navigator.clipboard.writeText(text).catch(() => {
-      fallbackCopy(text);
-    });
-  } else {
-    fallbackCopy(text);
-  }
+  void copyTextToClipboard(props.data.content);
 };
-
-function fallbackCopy(text: string) {
-  const textArea = document.createElement('textarea');
-  textArea.value = text;
-  textArea.style.position = 'fixed';
-  textArea.style.opacity = '0';
-  document.body.appendChild(textArea);
-  textArea.select();
-  document.execCommand('copy');
-  document.body.removeChild(textArea);
-}
 </script>
 
 <style lang="less" scoped>

--- a/frontend/src/views/integrations/ApiIntegrationSettings.vue
+++ b/frontend/src/views/integrations/ApiIntegrationSettings.vue
@@ -674,6 +674,7 @@
 import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 import { DialogPlugin, MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
+import { copyWithToast } from '@/utils/clipboard'
 import { getCurrentUser } from '@/api/auth'
 import { listAgents, BUILTIN_SMART_REASONING_ID, type CustomAgent } from '@/api/agent'
 import SettingDrawer from '@/components/settings/SettingDrawer.vue'
@@ -1307,20 +1308,7 @@ async function saveIfNeeded(options: { showSuccess?: boolean } = {}) {
 }
 
 async function copy(text: string) {
-  if (!text) return
-  if (navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(text)
-  } else {
-    const textArea = document.createElement('textarea')
-    textArea.value = text
-    textArea.style.position = 'fixed'
-    textArea.style.opacity = '0'
-    document.body.appendChild(textArea)
-    textArea.select()
-    document.execCommand('copy')
-    document.body.removeChild(textArea)
-  }
-  MessagePlugin.success(t('integrations.api.copySuccess'))
+  await copyWithToast(text, 'integrations.api.copySuccess')
 }
 
 async function tryLoadWailsApiBaseURL() {

--- a/frontend/src/views/integrations/ChromeExtensionLanding.vue
+++ b/frontend/src/views/integrations/ChromeExtensionLanding.vue
@@ -89,8 +89,7 @@
 </template>
 
 <script setup lang="ts">
-import { MessagePlugin } from 'tdesign-vue-next'
-import { useI18n } from 'vue-i18n'
+import { copyWithToast } from '@/utils/clipboard'
 import { useRouter } from 'vue-router'
 import { CHROME_EXTENSION_URL } from '@/config/integrations'
 import { useApiBaseUrlDisplay } from '@/composables/useApiBaseUrlDisplay'
@@ -98,7 +97,6 @@ import { useUIStore } from '@/stores/ui'
 import IntegrationLandingLayout from './IntegrationLandingLayout.vue'
 import IntegrationExternalCta from './IntegrationExternalCta.vue'
 
-const { t } = useI18n()
 const router = useRouter()
 const uiStore = useUIStore()
 const { apiBaseUrlDisplay } = useApiBaseUrlDisplay()
@@ -124,13 +122,6 @@ const openApiSettings = () => {
 }
 
 const copyApiUrl = async () => {
-  const text = apiBaseUrlDisplay.value
-  if (!text) return
-  try {
-    await navigator.clipboard.writeText(text)
-    MessagePlugin.success(t('integrations.chrome.copySuccess'))
-  } catch {
-    MessagePlugin.success(t('integrations.chrome.copySuccess'))
-  }
+  await copyWithToast(apiBaseUrlDisplay.value, 'integrations.chrome.copySuccess')
 }
 </script>

--- a/frontend/src/views/integrations/ClawSkillLanding.vue
+++ b/frontend/src/views/integrations/ClawSkillLanding.vue
@@ -104,8 +104,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { MessagePlugin } from 'tdesign-vue-next'
-import { useI18n } from 'vue-i18n'
+import { copyWithToast } from '@/utils/clipboard'
 import { useRouter } from 'vue-router'
 import { CLAWHUB_SKILL_URL } from '@/config/integrations'
 import { useApiBaseUrlDisplay } from '@/composables/useApiBaseUrlDisplay'
@@ -113,7 +112,6 @@ import { useUIStore } from '@/stores/ui'
 import IntegrationLandingLayout from './IntegrationLandingLayout.vue'
 import IntegrationExternalCta from './IntegrationExternalCta.vue'
 
-const { t } = useI18n()
 const router = useRouter()
 const uiStore = useUIStore()
 const { apiBaseUrlDisplay } = useApiBaseUrlDisplay()
@@ -145,16 +143,6 @@ const openApiSettings = () => {
   uiStore.openSettings('integration-api')
 }
 
-const copyText = async (text: string, successKey: string) => {
-  if (!text) return
-  try {
-    await navigator.clipboard.writeText(text)
-    MessagePlugin.success(t(successKey))
-  } catch {
-    MessagePlugin.success(t(successKey))
-  }
-}
-
-const copyEnvExample = () => copyText(envExample.value, 'integrations.claw.copyEnvSuccess')
-const copyInstallCommand = () => copyText(installCommand, 'integrations.claw.copyCmdSuccess')
+const copyEnvExample = () => copyWithToast(envExample.value, 'integrations.claw.copyEnvSuccess')
+const copyInstallCommand = () => copyWithToast(installCommand, 'integrations.claw.copyCmdSuccess')
 </script>

--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
@@ -470,6 +470,7 @@ import { createKnowledgeBase, getKnowledgeBaseById, listKnowledgeFiles, updateKn
 import { updateKBConfig, type KBModelConfigRequest } from '@/api/initialization'
 import { useChatResourcesStore } from '@/stores/chatResources'
 import { selectInitialModelId } from '@/utils/modelDefaults'
+import { copyWithToast } from '@/utils/clipboard'
 import { useEditorResourcesStore } from '@/stores/editorResources'
 import { useUIStore } from '@/stores/ui'
 import { useAuthStore } from '@/stores/auth'
@@ -518,27 +519,7 @@ const saveButtonLabel = computed(() =>
 )
 
 const copyKbId = async () => {
-  const id = activeKbId.value
-  if (!id) return
-
-  try {
-    if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(id)
-    } else {
-      const textarea = document.createElement('textarea')
-      textarea.value = id
-      textarea.setAttribute('readonly', '')
-      textarea.style.position = 'fixed'
-      textarea.style.opacity = '0'
-      document.body.appendChild(textarea)
-      textarea.select()
-      document.execCommand('copy')
-      document.body.removeChild(textarea)
-    }
-    MessagePlugin.success(t('common.copied'))
-  } catch {
-    MessagePlugin.error(t('common.copyFailed'))
-  }
+  await copyWithToast(activeKbId.value, 'common.copied')
 }
 
 const currentSection = ref<string>('basic')

--- a/frontend/src/views/organization/OrganizationList.vue
+++ b/frontend/src/views/organization/OrganizationList.vue
@@ -482,6 +482,7 @@ import { useAuthStore } from '@/stores/auth'
 import type { Organization, OrganizationPreview, SearchableOrganizationItem } from '@/api/organization'
 import { previewOrganization, submitJoinRequest } from '@/api/organization'
 import { useI18n } from 'vue-i18n'
+import { copyWithToast } from '@/utils/clipboard'
 import OrganizationSettingsModal from './OrganizationSettingsModal.vue'
 import SpaceAvatar from '@/components/SpaceAvatar.vue'
 import ListSpaceSidebar from '@/components/ListSpaceSidebar.vue'
@@ -1040,35 +1041,8 @@ function viewOrganizationFromPreview() {
 }
 
 // 复制预览中的空间 ID
-function copyPreviewSpaceId() {
-  if (!invitePreviewData.value?.id) return
-  const text = invitePreviewData.value.id
-  try {
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(text).then(() => {
-        MessagePlugin.success(t('common.copied'))
-      }).catch(() => {
-        fallbackCopyText(text)
-        MessagePlugin.success(t('common.copied'))
-      })
-    } else {
-      fallbackCopyText(text)
-      MessagePlugin.success(t('common.copied'))
-    }
-  } catch {
-    MessagePlugin.error(t('common.copyFailed'))
-  }
-}
-
-function fallbackCopyText(text: string) {
-  const textArea = document.createElement('textarea')
-  textArea.value = text
-  textArea.style.position = 'fixed'
-  textArea.style.opacity = '0'
-  document.body.appendChild(textArea)
-  textArea.select()
-  document.execCommand('copy')
-  document.body.removeChild(textArea)
+async function copyPreviewSpaceId() {
+  await copyWithToast(invitePreviewData.value?.id, 'common.copied')
 }
 
 // 从搜索列表加入空间（通过空间 ID，无需邀请码）- 在预览确认后调用

--- a/frontend/src/views/organization/OrganizationSettingsModal.vue
+++ b/frontend/src/views/organization/OrganizationSettingsModal.vue
@@ -822,6 +822,7 @@ import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
+import { copyWithToast } from '@/utils/clipboard'
 import {
   getOrganization,
   listOrgShares,
@@ -1670,47 +1671,12 @@ const resetAddMemberDialog = () => {
   tenantSearchResults.value = []
 }
 
-const fallbackCopyText = (text: string) => {
-  const textArea = document.createElement('textarea')
-  textArea.value = text
-  textArea.style.position = 'fixed'
-  textArea.style.opacity = '0'
-  document.body.appendChild(textArea)
-  textArea.select()
-  document.execCommand('copy')
-  document.body.removeChild(textArea)
-}
-
 const copyInviteCode = async () => {
-  if (inviteCode.value) {
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        await navigator.clipboard.writeText(inviteCode.value)
-      } else {
-        fallbackCopyText(inviteCode.value)
-      }
-      MessagePlugin.success(t('common.copied'))
-    } catch {
-      fallbackCopyText(inviteCode.value)
-      MessagePlugin.success(t('common.copied'))
-    }
-  }
+  await copyWithToast(inviteCode.value, 'common.copied')
 }
 
 const copyInviteLink = async () => {
-  if (inviteLink.value) {
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        await navigator.clipboard.writeText(inviteLink.value)
-      } else {
-        fallbackCopyText(inviteLink.value)
-      }
-      MessagePlugin.success(t('common.copied'))
-    } catch {
-      fallbackCopyText(inviteLink.value)
-      MessagePlugin.success(t('common.copied'))
-    }
-  }
+  await copyWithToast(inviteLink.value, 'common.copied')
 }
 
 const refreshInviteCode = async () => {

--- a/frontend/src/views/settings/TenantMembers.vue
+++ b/frontend/src/views/settings/TenantMembers.vue
@@ -514,6 +514,7 @@
 import { computed, nextTick, onUnmounted, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { MessagePlugin } from 'tdesign-vue-next'
+import { copyWithToast } from '@/utils/clipboard'
 import { useAuthStore } from '@/stores/auth'
 import { AUDIT_ACTION_I18N_ROOTS } from '@/i18n/auditActionRegistry'
 import { auditActionLabel } from '@/i18n/auditActionLabel'
@@ -1265,13 +1266,7 @@ function absoluteInviteURL(raw: string): string {
 }
 
 async function copyText(text: string) {
-  if (!text) return
-  try {
-    await navigator.clipboard.writeText(text)
-    MessagePlugin.success(t('tenantInvitation.copied'))
-  } catch {
-    MessagePlugin.error(t('tenantInvitation.copyFailed'))
-  }
+  await copyWithToast(text, 'tenantInvitation.copied', 'tenantInvitation.copyFailed')
 }
 
 async function submitShareLink() {

--- a/frontend/src/views/system/PlatformAPIKeys.vue
+++ b/frontend/src/views/system/PlatformAPIKeys.vue
@@ -209,6 +209,7 @@
 import { onMounted, reactive, ref } from 'vue'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
+import { copyWithToast } from '@/utils/clipboard'
 import SettingDrawer from '@/components/settings/SettingDrawer.vue'
 import type { TenantAPIKey, TenantAPIKeyCapability } from '@/api/tenant'
 import { createPlatformAPIKey, deletePlatformAPIKey, listPlatformAPIKeys } from '@/api/system'
@@ -347,9 +348,8 @@ async function deleteKey(key: TenantAPIKey) {
 }
 
 async function copyToken() {
-  await navigator.clipboard.writeText(createdToken.value)
-  MessagePlugin.success(t('platformApiKeys.copySuccess'))
-  tokenVisible.value = false
+  const ok = await copyWithToast(createdToken.value, 'platformApiKeys.copySuccess')
+  if (ok) tokenVisible.value = false
 }
 
 onMounted(reload)


### PR DESCRIPTION
## 背景

在 HTTP（非安全上下文）环境下，`navigator.clipboard` 为 `undefined`，导致邀请链接、API Key、智能体 ID 等复制操作直接抛错，前端提示「复制失败，请手动选中文本」。

## 改动

1. **新增公共方法** `frontend/src/utils/clipboard.ts`：
   - `copyToClipboard(text)`：优先使用异步 Clipboard API（HTTPS / localhost），不可用或失败时回退到隐藏 `<textarea>` + `document.execCommand('copy')`，兼容 HTTP 环境；返回 `boolean` 表示是否成功，不绑定 UI。
   - `copyWithToast(text, successKey, failureKey?)`：在 `copyToClipboard` 基础上封装常用的「复制 + toast 反馈」，返回结果以便调用方做额外副作用（如关闭弹窗）；空值静默跳过。

2. **统一全项目复制逻辑**：将 17+ 处各自重复实现的 `navigator.clipboard` + textarea 兜底 + toast 代码，统一替换为 `copyToClipboard` / `copyWithToast`，净减少约 240 行。

3. **修复回归**：移除原先丢弃返回值、吞掉异常的 `copyTextToClipboard` 封装——它会使 HTTP 下复制失败被误报为成功（try/catch 的失败分支成为死代码）；改为直接调用带布尔返回值的底层方法。

## 验证

- `vue-tsc --build` 类型检查通过
- HTTP 环境下邀请链接等复制功能可正常回退到 execCommand