### PR TITLE
fix(frontend): refine user profile change-password popup UX

### DIFF
--- a/frontend/src/views/settings/UserProfile.vue
+++ b/frontend/src/views/settings/UserProfile.vue
@@ -66,8 +66,8 @@
         </div>
       </div>
 
-      <!-- 修改密码 -->
-      <div class="setting-row password-row">
+      <!-- 修改密码：与其它 setting-row 同款只读行 + 编辑入口，表单进原地 popup -->
+      <div class="setting-row">
         <div class="setting-info">
           <label>{{ $t('userProfile.changePassword.label') }}</label>
           <p class="desc">
@@ -76,67 +76,93 @@
               : $t('userProfile.changePassword.description') }}
           </p>
         </div>
-        <div class="setting-control password-control">
-          <t-alert
-            v-if="oidcOnlyLogin"
-            theme="info"
-            :message="$t('userProfile.changePassword.oidcOnlyNotice')"
-            class="oidc-only-notice"
-          />
-          <t-form
-            v-else
-            ref="passwordFormRef"
-            :data="passwordForm"
-            :rules="passwordRules"
-            label-align="top"
-            class="password-form"
-            @submit.prevent
-          >
-            <t-form-item :label="$t('userProfile.changePassword.currentLabel')" name="oldPassword">
-              <t-input
-                v-model="passwordForm.oldPassword"
-                type="password"
-                autocomplete="current-password"
-                :disabled="passwordSubmitting"
-                :placeholder="$t('userProfile.changePassword.currentPlaceholder')"
-              >
-                <template #prefix-icon><t-icon name="lock-on" /></template>
-              </t-input>
-            </t-form-item>
-            <t-form-item :label="$t('userProfile.changePassword.newLabel')" name="newPassword">
-              <t-input
-                v-model="passwordForm.newPassword"
-                type="password"
-                autocomplete="new-password"
-                :disabled="passwordSubmitting"
-                :placeholder="$t('userProfile.changePassword.newPlaceholder')"
-              >
-                <template #prefix-icon><t-icon name="lock-on" /></template>
-              </t-input>
-            </t-form-item>
-            <t-form-item :label="$t('userProfile.changePassword.confirmLabel')" name="confirmPassword">
-              <t-input
-                v-model="passwordForm.confirmPassword"
-                type="password"
-                autocomplete="new-password"
-                :disabled="passwordSubmitting"
-                :placeholder="$t('userProfile.changePassword.confirmPlaceholder')"
-                @enter="submitPasswordChange"
-              >
-                <template #prefix-icon><t-icon name="lock-on" /></template>
-              </t-input>
-            </t-form-item>
-            <div class="password-actions">
+        <div class="setting-control">
+          <template v-if="oidcOnlyLogin">
+            <span class="info-value info-value--muted">—</span>
+          </template>
+          <template v-else>
+            <span class="info-value password-mask" aria-hidden="true">••••••••</span>
+            <t-popup
+              v-model="passwordPopupVisible"
+              trigger="click"
+              placement="bottom-end"
+              destroy-on-close
+              overlay-class-name="user-profile-password-popup-overlay"
+            >
               <t-button
-                theme="primary"
-                :loading="passwordSubmitting"
-                :disabled="passwordSubmitting"
-                @click="submitPasswordChange"
+                theme="default"
+                variant="text"
+                shape="square"
+                size="small"
+                class="edit-btn"
+                :title="$t('userProfile.changePassword.label')"
+                :aria-label="$t('userProfile.changePassword.label')"
               >
-                {{ $t('userProfile.changePassword.submit') }}
+                <template #icon>
+                  <t-icon name="edit" />
+                </template>
               </t-button>
-            </div>
-          </t-form>
+              <template #content>
+                <div class="password-popup-inner" @click.stop>
+                  <div class="password-popup-title">{{ $t('userProfile.changePassword.label') }}</div>
+                  <p class="password-popup-hint">{{ $t('userProfile.changePassword.description') }}</p>
+                  <t-form
+                    ref="passwordFormRef"
+                    :data="passwordForm"
+                    :rules="passwordRules"
+                    label-align="top"
+                    class="password-popup-form"
+                    @submit.prevent
+                  >
+                    <t-form-item :label="$t('userProfile.changePassword.currentLabel')" name="oldPassword">
+                      <t-input
+                        v-model="passwordForm.oldPassword"
+                        type="password"
+                        autocomplete="current-password"
+                        :disabled="passwordSubmitting"
+                        :placeholder="$t('userProfile.changePassword.currentPlaceholder')"
+                      />
+                    </t-form-item>
+                    <t-form-item :label="$t('userProfile.changePassword.newLabel')" name="newPassword">
+                      <t-input
+                        v-model="passwordForm.newPassword"
+                        type="password"
+                        autocomplete="new-password"
+                        :disabled="passwordSubmitting"
+                        :placeholder="$t('userProfile.changePassword.newPlaceholder')"
+                      />
+                    </t-form-item>
+                    <t-form-item :label="$t('userProfile.changePassword.confirmLabel')" name="confirmPassword">
+                      <t-input
+                        v-model="passwordForm.confirmPassword"
+                        type="password"
+                        autocomplete="new-password"
+                        :disabled="passwordSubmitting"
+                        :placeholder="$t('userProfile.changePassword.confirmPlaceholder')"
+                        @enter="submitPasswordChange"
+                      />
+                    </t-form-item>
+                  </t-form>
+                  <div class="password-popup-footer">
+                    <t-button
+                      variant="outline"
+                      :disabled="passwordSubmitting"
+                      @click="closePasswordPopup"
+                    >
+                      {{ $t('common.cancel') }}
+                    </t-button>
+                    <t-button
+                      theme="primary"
+                      :loading="passwordSubmitting"
+                      @click="submitPasswordChange"
+                    >
+                      {{ $t('userProfile.changePassword.submit') }}
+                    </t-button>
+                  </div>
+                </div>
+              </template>
+            </t-popup>
+          </template>
         </div>
       </div>
     </div>
@@ -144,7 +170,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed, onMounted } from 'vue'
+import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { MessagePlugin } from 'tdesign-vue-next'
 import type { FormInstanceFunctions, FormRule } from 'tdesign-vue-next'
@@ -165,6 +191,7 @@ const userInfo = ref<UserInfo | null>(null)
 const loading = ref(true)
 const error = ref('')
 
+const passwordPopupVisible = ref(false)
 const passwordFormRef = ref<FormInstanceFunctions | null>(null)
 const passwordSubmitting = ref(false)
 const passwordForm = reactive({
@@ -176,6 +203,12 @@ const passwordForm = reactive({
 const oidcOnlyLogin = computed(
   () => userInfo.value?.preferences?.oidc_only_login === true,
 )
+
+watch(passwordPopupVisible, (open) => {
+  if (open) {
+    resetPasswordForm()
+  }
+})
 
 const passwordRules = computed<Record<string, FormRule[]>>(() => ({
   oldPassword: [
@@ -245,6 +278,12 @@ const resetPasswordForm = () => {
   passwordFormRef.value?.clearValidate?.()
 }
 
+const closePasswordPopup = () => {
+  if (passwordSubmitting.value) return
+  passwordPopupVisible.value = false
+  resetPasswordForm()
+}
+
 const submitPasswordChange = async () => {
   if (passwordSubmitting.value) return
   const result = await passwordFormRef.value?.validate?.()
@@ -261,6 +300,7 @@ const submitPasswordChange = async () => {
       return
     }
 
+    passwordPopupVisible.value = false
     MessagePlugin.success(t('userProfile.changePassword.success'))
     resetPasswordForm()
 
@@ -364,7 +404,8 @@ onMounted(loadInfo)
   min-width: 280px;
   display: flex;
   justify-content: flex-end;
-  align-items: flex-start;
+  align-items: center;
+  gap: 8px;
 
   .info-value {
     font-size: 14px;
@@ -372,34 +413,85 @@ onMounted(loadInfo)
     text-align: right;
     word-break: break-word;
   }
-}
 
-.password-row {
-  align-items: flex-start;
-}
+  .info-value--muted {
+    color: var(--td-text-color-placeholder);
+  }
 
-.password-control {
-  min-width: 320px;
-  max-width: 360px;
-  flex-direction: column;
-  align-items: stretch;
-}
-
-.oidc-only-notice {
-  width: 100%;
-}
-
-.password-form {
-  width: 100%;
-
-  :deep(.t-form__item) {
-    margin-bottom: 16px;
+  .edit-btn {
+    flex-shrink: 0;
   }
 }
 
-.password-actions {
+.password-mask {
+  letter-spacing: 0.12em;
+  color: var(--td-text-color-secondary);
+}
+
+.password-popup-inner {
+  max-width: 100%;
+}
+
+.password-popup-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--td-text-color-primary);
+  margin: 0 0 8px;
+  line-height: 1.35;
+}
+
+.password-popup-hint {
+  margin: 0 0 12px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--td-text-color-secondary);
+}
+
+.password-popup-form {
+  :deep(.t-form__item) {
+    margin-bottom: 14px;
+
+    &:last-child {
+      margin-bottom: 4px;
+    }
+  }
+}
+
+.password-popup-footer {
   display: flex;
   justify-content: flex-end;
-  margin-top: 4px;
+  gap: 8px;
+  margin-top: 16px;
+}
+</style>
+
+<style lang="less">
+/* t-popup 挂到 body，需全局样式；z-index 需高于设置全屏遮罩（2000）。 */
+.user-profile-password-popup-overlay {
+  z-index: 3050 !important;
+
+  .t-popup__content {
+    padding: 14px 16px !important;
+    min-width: 300px;
+    max-width: min(392px, calc(100vw - 24px));
+    border-radius: 12px !important;
+    background: var(--td-bg-color-container) !important;
+    border: 0.5px solid var(--td-component-stroke) !important;
+    box-shadow:
+      0 0 0 0.5px rgba(0, 0, 0, 0.03),
+      0 2px 4px rgba(0, 0, 0, 0.04),
+      0 8px 24px rgba(0, 0, 0, 0.1) !important;
+    backdrop-filter: blur(20px) saturate(180%) !important;
+    -webkit-backdrop-filter: blur(20px) saturate(180%) !important;
+  }
+}
+
+:root[theme-mode='dark'] .user-profile-password-popup-overlay .t-popup__content {
+  background: rgba(36, 36, 36, 0.92) !important;
+  border-color: rgba(255, 255, 255, 0.08) !important;
+  box-shadow:
+    0 0 0 0.5px rgba(255, 255, 255, 0.05),
+    0 2px 4px rgba(0, 0, 0, 0.12),
+    0 8px 32px rgba(0, 0, 0, 0.28) !important;
 }
 </style>


### PR DESCRIPTION
## Summary
- Replace the inline three-field password form on the user profile settings row with a masked read-only state and edit icon, consistent with other settings rows.
- Open the change-password form in an anchored inline `t-popup` (same pattern as member invite popups in settings), instead of exposing all fields directly in the row or using a modal dialog.
- Simplify OIDC-only accounts to a muted placeholder on the right while keeping guidance in the row description.

## Test plan
- [ ] Open Settings → User Profile on a local-password account; confirm the row shows `••••••••` and an edit icon.
- [ ] Click the edit icon; confirm the popup opens beside the control with current/new/confirm password fields.
- [ ] Submit with invalid input and confirm validation errors stay in the popup without closing it.
- [ ] Submit with the wrong current password and confirm the error toast appears and the popup stays open.
- [ ] Submit with a valid new password and confirm success toast, session logout, and redirect to login.
- [ ] On an OIDC-only account, confirm no edit icon appears and the row shows `—`.
- [ ] Verify popup styling in light and dark themes inside the settings overlay.