### PR TITLE
fix: serve embed entry for Lite routes

### DIFF
--- a/internal/router/router_static_test.go
+++ b/internal/router/router_static_test.go
@@ -11,6 +11,68 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFrontendStaticServesEmbedEntryForEmbedRoute(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	webDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(webDir, "index.html"), []byte("main spa"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(webDir, "embed.html"), []byte("embed spa"), 0o600))
+	t.Setenv("WEKNORA_WEB_DIR", webDir)
+
+	r := gin.New()
+	serveFrontendStatic(r)
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		t.Run(method, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(method, "/embed/channel-123?locale=zh-CN", nil)
+			r.ServeHTTP(recorder, request)
+
+			require.Equal(t, http.StatusOK, recorder.Code)
+			require.Equal(t, "no-cache, must-revalidate", recorder.Header().Get("Cache-Control"))
+			if method == http.MethodGet {
+				require.Equal(t, "embed spa", recorder.Body.String())
+			} else {
+				require.Empty(t, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestFrontendStaticKeepsMainSPAFallbackForNonEmbedRoute(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	webDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(webDir, "index.html"), []byte("main spa"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(webDir, "embed.html"), []byte("embed spa"), 0o600))
+	t.Setenv("WEKNORA_WEB_DIR", webDir)
+
+	r := gin.New()
+	serveFrontendStatic(r)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/settings/profile", nil)
+	r.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, "main spa", recorder.Body.String())
+}
+
+func TestFrontendStaticReturnsNotFoundWhenEmbedEntryIsMissing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	webDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(webDir, "index.html"), []byte("main spa"), 0o600))
+	t.Setenv("WEKNORA_WEB_DIR", webDir)
+
+	r := gin.New()
+	serveFrontendStatic(r)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/embed/channel-123", nil)
+	r.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusNotFound, recorder.Code)
+	require.NotContains(t, recorder.Body.String(), "main spa")
+}
+
 func TestFrontendStaticDoesNotInterceptResourceGrant(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	webDir := t.TempDir()

--- a/internal/router/static.go
+++ b/internal/router/static.go
@@ -25,6 +25,12 @@ func serveFrontendStatic(r *gin.Engine) {
 	if _, err := os.Stat(indexPath); err != nil {
 		return
 	}
+	embedIndexPath := filepath.Join(absDir, "embed.html")
+	embedIndexInfo, embedIndexErr := os.Stat(embedIndexPath)
+	hasEmbedIndex := embedIndexErr == nil && !embedIndexInfo.IsDir()
+	if !hasEmbedIndex {
+		logger.Warnf(context.Background(), "[Router] Embed entry %s is unavailable; /embed/* requests will return 404", embedIndexPath)
+	}
 
 	logger.Infof(context.Background(), "[Router] Serving frontend static files from %s", absDir)
 
@@ -46,6 +52,17 @@ func serveFrontendStatic(r *gin.Engine) {
 		if info, err := os.Stat(fullPath); err == nil && !info.IsDir() {
 			setFrontendCacheHeaders(c.Writer, path)
 			fileServer.ServeHTTP(c.Writer, c.Request)
+			c.Abort()
+			return
+		}
+		if strings.HasPrefix(path, "/embed/") {
+			if !hasEmbedIndex {
+				c.Status(http.StatusNotFound)
+				c.Abort()
+				return
+			}
+			setFrontendCacheHeaders(c.Writer, "/embed.html")
+			c.File(embedIndexPath)
 			c.Abort()
 			return
 		}


### PR DESCRIPTION
## Description

修复 Lite 部署中 Embed 页面静态路由回退错误的问题。

管理页生成的 Embed 地址使用 `/embed/{channelId}`。标准部署的 Nginx 会将该路径正确回退到独立的 `embed.html`，但 Lite 的 Go 静态文件服务此前会统一回退到主站 `index.html`，导致 Embed 地址加载管理后台入口，而不是 Embed 应用。

本次修改：

- Lite 模式下将不存在的 `/embed/*` 路径回退到 `embed.html`。
- 保持普通前端路由继续回退到 `index.html`。
- 保持已有静态文件的直接访问逻辑不变。
- 当构建产物缺少 `embed.html` 时返回 404，并记录警告，避免错误地返回管理后台页面。
- 补充 GET、HEAD、普通 SPA 回退及缺少 Embed 入口等回归测试。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

已完成以下验证：

- `git diff --check` 通过。
- 在 Podman Linux 环境的 `golang:1.26-bookworm` 镜像中运行聚焦测试：
  - `go test internal/router/static.go internal/router/router_static_test.go -count=1`
  - 测试通过。
- 尝试运行完整的 `go test ./internal/router -count=1 -p=1`，但下载 `github.com/pierrec/lz4/v4` 和 `github.com/go-ego/gse` 间接依赖时网络连接被重置，因此完整包测试未能完成；失败发生在依赖下载阶段，不是编译或测试断言失败。

## Checklist

- [ ] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A — no user-visible UI changes