### PR TITLE
fix: allow clearing optional model selections

### DIFF
--- a/frontend/src/components/modelSelectorClearability.test.ts
+++ b/frontend/src/components/modelSelectorClearability.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readFileSync } from 'node:fs'
+
+const selector = readFileSync(new URL('./ModelSelector.vue', import.meta.url), 'utf8')
+const agentEditor = readFileSync(new URL('../views/agent/AgentEditorModal.vue', import.meta.url), 'utf8')
+const kbModelConfig = readFileSync(new URL('../views/knowledge/settings/KBModelConfig.vue', import.meta.url), 'utf8')
+const kbEditor = readFileSync(new URL('../views/knowledge/KnowledgeBaseEditorModal.vue', import.meta.url), 'utf8')
+const uploadConfirm = readFileSync(new URL('../views/knowledge/components/UploadConfirmDialog.vue', import.meta.url), 'utf8')
+
+function modelSelectorTag(source: string, selectedModelBinding: string): string {
+  const tag = source
+    .match(/<ModelSelector\b[\s\S]*?\/>/g)
+    ?.find((candidate) => candidate.includes(selectedModelBinding))
+  assert.ok(tag, `找不到模型选择器：${selectedModelBinding}`)
+  return tag
+}
+
+function assertClearable(tag: string): void {
+  assert.match(tag, /(?:\s|:)clearable(?:\s|=|\/>)/)
+}
+
+function assertNotClearable(tag: string): void {
+  assert.doesNotMatch(tag, /(?:\s|:)clearable(?:\s|=|\/>)/)
+}
+
+test('ModelSelector 清空时向父组件回传空字符串，默认仍不可清空', () => {
+  assert.match(selector, /:clearable="clearable"/)
+  assert.match(selector, /clearable:\s*false/)
+  assert.match(selector, /emit\('update:selectedModelId', value \|\| ''\)/)
+})
+
+test('智能体中允许继承或关闭的可选模型可以恢复为空', () => {
+  const rerank = modelSelectorTag(agentEditor, 'formData.config.rerank_model_id')
+  assert.match(rerank, /:clearable="!needsRerankModel"/)
+  assertClearable(modelSelectorTag(agentEditor, 'formData.config.query_understand_model_id'))
+  assertClearable(modelSelectorTag(agentEditor, 'formData.config.asr_model_id'))
+  assertClearable(modelSelectorTag(agentEditor, 'formData.config.question_suggestions.follow_ups.model_id'))
+})
+
+test('知识库仅在模型确实可选时允许恢复为空', () => {
+  const embedding = modelSelectorTag(kbModelConfig, 'config.embeddingModelId')
+  assert.match(embedding, /:clearable="ragEnabled === false && wikiEnabled"/)
+  assertClearable(modelSelectorTag(kbModelConfig, 'config.wikiSynthesisModelId'))
+})
+
+test('必填模型继续保持不可清空', () => {
+  assertNotClearable(modelSelectorTag(agentEditor, 'formData.config.model_id'))
+  assertNotClearable(modelSelectorTag(agentEditor, 'formData.config.vlm_model_id'))
+  assertNotClearable(modelSelectorTag(kbModelConfig, 'config.llmModelId'))
+  assertNotClearable(modelSelectorTag(kbEditor, 'formData.multimodalConfig.vllmModelId'))
+  assertNotClearable(modelSelectorTag(kbEditor, 'formData.asrConfig.modelId'))
+  assertNotClearable(modelSelectorTag(uploadConfirm, 'uiState.multimodalConfig.vllmModelId'))
+  assertNotClearable(modelSelectorTag(uploadConfirm, 'uiState.asrConfig.modelId'))
+})

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -654,6 +654,7 @@
                       <div class="setting-control">
                         <ModelSelector model-type="Rerank" :selected-model-id="formData.config.rerank_model_id"
                           :all-models="allModels"
+                          :clearable="!needsRerankModel"
                           @update:selected-model-id="(val: string) => formData.config.rerank_model_id = val"
                           @add-model="handleAddModel('rerank')"
                           :placeholder="$t('agent.editor.rerankModelPlaceholder')" />
@@ -671,6 +672,7 @@
                       <div class="setting-control">
                         <ModelSelector model-type="KnowledgeQA"
                           :selected-model-id="formData.config.query_understand_model_id" :all-models="allModels"
+                          clearable
                           @update:selected-model-id="(val: string) => formData.config.query_understand_model_id = val"
                           @add-model="handleAddModel('llm')"
                           :placeholder="$t('agent.editor.queryUnderstandModelPlaceholder')" />
@@ -809,6 +811,7 @@
                       <div class="setting-control">
                         <ModelSelector model-type="ASR" :selected-model-id="formData.config.asr_model_id"
                           :all-models="allModels"
+                          clearable
                           @update:selected-model-id="(val: string) => formData.config.asr_model_id = val"
                           @add-model="handleAddModel('asr')"
                           :placeholder="$t('agentEditor.audioUpload.asrModelPlaceholder')" />
@@ -1011,6 +1014,7 @@
                           <ModelSelector model-type="KnowledgeQA"
                             :selected-model-id="formData.config.question_suggestions.follow_ups.model_id"
                             :all-models="allModels"
+                            clearable
                             @update:selected-model-id="(val: string) => formData.config.question_suggestions.follow_ups.model_id = val"
                             @add-model="handleAddModel('summary')" />
                         </div>

--- a/frontend/src/views/knowledge/settings/KBModelConfig.vue
+++ b/frontend/src/views/knowledge/settings/KBModelConfig.vue
@@ -52,6 +52,7 @@
             :selected-model-id="config.embeddingModelId"
             :all-models="allModels"
             :disabled="ragEnabled && hasFiles"
+            :clearable="ragEnabled === false && wikiEnabled"
             @update:selected-model-id="handleEmbeddingChange"
             @add-model="handleAddModel('embedding')"
             :placeholder="$t('knowledgeEditor.models.embeddingPlaceholder')"
@@ -70,6 +71,7 @@
             model-type="KnowledgeQA"
             :selected-model-id="config.wikiSynthesisModelId"
             :all-models="allModels"
+            clearable
             @update:selected-model-id="handleWikiModelChange"
             @add-model="handleAddModel('knowledgeqa')"
             :placeholder="$t('knowledgeEditor.wiki.synthesisModelPlaceholder')"


### PR DESCRIPTION
## Description

共用的 `ModelSelector` 组件已经支持 `clearable`，但知识库和智能体页面中的可选模型字段没有启用该能力。用户一旦选择模型，就只能切换到其他模型，无法恢复为空。

本 PR：

- 允许清空智能体中的查询理解模型、ASR 模型和追问建议模型。
- 仅在重排模型不是必填项时允许清空。
- 允许清空知识库的 Wiki 内容生成模型。
- 仅在启用 Wiki 且未启用 RAG 时允许清空 Embedding 模型。
- 必填模型继续保持不可清空，避免提交无效配置。
- 增加回归测试，覆盖可清空和不可清空的模型字段。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

已在 Podman Linux 环境中完成以下验证：

- `npx tsx --test src/components/modelSelectorClearability.test.ts`
  - 4 个测试全部通过。
- `npm run type-check`
  - TypeScript 类型检查通过。
- `git diff --check`
  - 通过，没有空白字符错误。

## Checklist

- [ ] `make fmt && make lint && make test` pass locally
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

