### PR TITLE
fix(chunking): preserve parent-child text child embeddings

### DIFF
--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -442,14 +442,15 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 		return insertChunks[i].ChunkIndex < insertChunks[j].ChunkIndex
 	})
 
-	// 仅为文本类型的Chunk设置前后关系（child chunks only, parents already linked above）
+	// Collect retrievable text chunks only. ParentChunkID only controls parent expansion after retrieval.
+	// When ParentChunkID is empty, retrieval keeps the standalone child content without loading a parent.
 	textChunks := make([]*types.Chunk, 0, len(chunks))
 	for _, chunk := range insertChunks {
-		if chunk.ChunkType == types.ChunkTypeText && chunk.ParentChunkID != "" {
-			// This is a child chunk in parent-child mode
+		if chunk.ChunkType == types.ChunkTypeText && hasParentChild {
+			// A child whose redundant parent was elided still needs its own embedding.
 			textChunks = append(textChunks, chunk)
 		} else if chunk.ChunkType == types.ChunkTypeText && !hasParentChild {
-			// Normal flat chunk (no parent-child mode)
+			// Flat chunking indexes the text chunk directly.
 			textChunks = append(textChunks, chunk)
 		}
 	}

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -446,11 +446,7 @@ func (s *knowledgeService) processChunks(ctx context.Context,
 	// When ParentChunkID is empty, retrieval keeps the standalone child content without loading a parent.
 	textChunks := make([]*types.Chunk, 0, len(chunks))
 	for _, chunk := range insertChunks {
-		if chunk.ChunkType == types.ChunkTypeText && hasParentChild {
-			// A child whose redundant parent was elided still needs its own embedding.
-			textChunks = append(textChunks, chunk)
-		} else if chunk.ChunkType == types.ChunkTypeText && !hasParentChild {
-			// Flat chunking indexes the text chunk directly.
+		if chunk.ChunkType == types.ChunkTypeText {
 			textChunks = append(textChunks, chunk)
 		}
 	}

--- a/internal/application/service/knowledge_process_parent_child_test.go
+++ b/internal/application/service/knowledge_process_parent_child_test.go
@@ -1,0 +1,200 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/require"
+)
+
+type parentChildKnowledgeRepo struct {
+	interfaces.KnowledgeRepository
+	knowledge *types.Knowledge
+}
+
+func (r *parentChildKnowledgeRepo) GetKnowledgeByID(
+	context.Context, uint64, string,
+) (*types.Knowledge, error) {
+	return r.knowledge, nil
+}
+
+func (r *parentChildKnowledgeRepo) UpdateKnowledge(
+	context.Context, *types.Knowledge,
+) error {
+	return nil
+}
+
+type parentChildChunkService struct {
+	interfaces.ChunkService
+	created []*types.Chunk
+}
+
+func (s *parentChildChunkService) DeleteChunksByKnowledgeID(context.Context, string) error {
+	return nil
+}
+
+func (s *parentChildChunkService) CreateChunks(_ context.Context, chunks []*types.Chunk) error {
+	s.created = append([]*types.Chunk(nil), chunks...)
+	return nil
+}
+
+type parentChildModelService struct {
+	interfaces.ModelService
+	embedder embedding.Embedder
+}
+
+func (s parentChildModelService) GetEmbeddingModel(context.Context, string) (embedding.Embedder, error) {
+	return s.embedder, nil
+}
+
+type parentChildEmbedder struct{}
+
+func (parentChildEmbedder) Embed(context.Context, string) ([]float32, error) {
+	return []float32{1}, nil
+}
+
+func (parentChildEmbedder) BatchEmbed(context.Context, []string) ([][]float32, error) {
+	return [][]float32{{1}}, nil
+}
+
+func (parentChildEmbedder) BatchEmbedWithPool(
+	context.Context, embedding.Embedder, []string,
+) ([][]float32, error) {
+	return [][]float32{{1}}, nil
+}
+
+func (parentChildEmbedder) GetModelName() string { return "parent-child-test" }
+func (parentChildEmbedder) GetDimensions() int   { return 1 }
+func (parentChildEmbedder) GetModelID() string   { return "parent-child-test" }
+
+type parentChildRetrieveEngine struct {
+	interfaces.RetrieveEngineService
+	indexed []*types.IndexInfo
+}
+
+func (e *parentChildRetrieveEngine) EngineType() types.RetrieverEngineType {
+	return types.PostgresRetrieverEngineType
+}
+
+func (e *parentChildRetrieveEngine) Support() []types.RetrieverType {
+	return []types.RetrieverType{types.VectorRetrieverType}
+}
+
+func (e *parentChildRetrieveEngine) DeleteByKnowledgeIDList(
+	context.Context, []string, int, string,
+) error {
+	return nil
+}
+
+func (e *parentChildRetrieveEngine) EstimateStorageSize(
+	context.Context, embedding.Embedder, []*types.IndexInfo, []types.RetrieverType,
+) int64 {
+	return 0
+}
+
+func (e *parentChildRetrieveEngine) BatchIndex(
+	_ context.Context,
+	_ embedding.Embedder,
+	infos []*types.IndexInfo,
+	_ []types.RetrieverType,
+) error {
+	e.indexed = append([]*types.IndexInfo(nil), infos...)
+	return nil
+}
+
+type parentChildRetrieveRegistry struct {
+	interfaces.RetrieveEngineRegistry
+	engine interfaces.RetrieveEngineService
+}
+
+func (r parentChildRetrieveRegistry) GetRetrieveEngineService(
+	types.RetrieverEngineType,
+) (interfaces.RetrieveEngineService, error) {
+	return r.engine, nil
+}
+
+type parentChildGraphRepo struct {
+	interfaces.RetrieveGraphRepository
+}
+
+func (parentChildGraphRepo) DelGraph(context.Context, []types.NameSpace) error {
+	return nil
+}
+
+type parentChildTenantRepo struct {
+	interfaces.TenantRepository
+}
+
+func (parentChildTenantRepo) AdjustStorageUsed(context.Context, uint64, int64) error {
+	return nil
+}
+
+type parentChildTaskEnqueuer struct{}
+
+func (parentChildTaskEnqueuer) Enqueue(*asynq.Task, ...asynq.Option) (*asynq.TaskInfo, error) {
+	return nil, nil
+}
+
+func TestProcessChunksIndexesEveryTextChild(t *testing.T) {
+	knowledge := &types.Knowledge{
+		ID:              "knowledge-1",
+		TenantID:        1,
+		KnowledgeBaseID: "kb-1",
+		ParseStatus:     types.ParseStatusProcessing,
+	}
+	chunkService := &parentChildChunkService{}
+	retrieveEngine := &parentChildRetrieveEngine{}
+	tenant := &types.Tenant{
+		ID: 1,
+		RetrieverEngines: types.RetrieverEngines{Engines: []types.RetrieverEngineParams{
+			{
+				RetrieverType:       types.VectorRetrieverType,
+				RetrieverEngineType: types.PostgresRetrieverEngineType,
+			},
+		}},
+	}
+	ctx := context.WithValue(context.Background(), types.TenantInfoContextKey, tenant)
+	svc := &knowledgeService{
+		repo:           &parentChildKnowledgeRepo{knowledge: knowledge},
+		chunkService:   chunkService,
+		modelService:   parentChildModelService{embedder: parentChildEmbedder{}},
+		retrieveEngine: parentChildRetrieveRegistry{engine: retrieveEngine},
+		graphEngine:    parentChildGraphRepo{},
+		tenantRepo:     parentChildTenantRepo{},
+		task:           parentChildTaskEnqueuer{},
+	}
+	kb := &types.KnowledgeBase{
+		ID:               "kb-1",
+		TenantID:         1,
+		EmbeddingModelID: "embedding-1",
+		IndexingStrategy: types.IndexingStrategy{VectorEnabled: true},
+	}
+	chunks := []types.ParsedChunk{
+		{Content: "linked child", Seq: 0, Start: 0, End: 12, ParentIndex: 0},
+		{Content: "standalone child", Seq: 1, Start: 12, End: 28, ParentIndex: -1},
+	}
+
+	svc.processChunks(ctx, kb, knowledge, chunks, ProcessChunksOptions{
+		ParentChunks: []types.ParsedParentChunk{
+			{Content: "parent context", Seq: 0, Start: 0, End: 28},
+		},
+	})
+
+	var textChunkIDs []string
+	for _, chunk := range chunkService.created {
+		if chunk.ChunkType == types.ChunkTypeText {
+			textChunkIDs = append(textChunkIDs, chunk.ID)
+		}
+	}
+	require.Len(t, textChunkIDs, 2)
+
+	indexedSourceIDs := make([]string, 0, len(retrieveEngine.indexed))
+	for _, info := range retrieveEngine.indexed {
+		indexedSourceIDs = append(indexedSourceIDs, info.SourceID)
+	}
+	require.ElementsMatch(t, textChunkIDs, indexedSourceIDs)
+}

--- a/internal/infrastructure/chunker/strategy.go
+++ b/internal/infrastructure/chunker/strategy.go
@@ -215,6 +215,8 @@ func NormalizeLineEndings(text string) string {
 // DeriveParentChildConfigs produces the exact parent and child splitter
 // configurations used by knowledge ingestion. Keeping this here lets preview
 // and ingestion remain in lockstep as the parent-child defaults evolve.
+// Languages are copied to both levels so parent and child splitters use the same boundary rules.
+// TokenLimit is copied only to children because parents keep the configured context window.
 func DeriveParentChildConfigs(base SplitterConfig, parentSize, childSize int) (parent, child SplitterConfig) {
 	if parentSize <= 0 {
 		parentSize = 4096
@@ -227,12 +229,15 @@ func DeriveParentChildConfigs(base SplitterConfig, parentSize, childSize int) (p
 		ChunkOverlap: base.ChunkOverlap,
 		Separators:   base.Separators,
 		Strategy:     base.Strategy,
+		Languages:    base.Languages,
 	}
 	child = SplitterConfig{
 		ChunkSize:    childSize,
 		ChunkOverlap: childSize / 5,
 		Separators:   base.Separators,
 		Strategy:     base.Strategy,
+		TokenLimit:   base.TokenLimit,
+		Languages:    base.Languages,
 	}
 	return
 }

--- a/internal/infrastructure/chunker/strategy_test.go
+++ b/internal/infrastructure/chunker/strategy_test.go
@@ -263,6 +263,51 @@ func TestDeriveParentChildConfigs_DefaultSizes(t *testing.T) {
 	}
 }
 
+func TestDeriveParentChildConfigs_AppliesEmbeddingTokenLimitOnlyToChildren(t *testing.T) {
+	const (
+		parentSize = 4096
+		childSize  = 1024
+		tokenLimit = 200
+	)
+	base := SplitterConfig{
+		ChunkSize:    DefaultChunkSize,
+		ChunkOverlap: DefaultChunkOverlap,
+		Separators:   []string{"。"},
+		Strategy:     StrategyLegacy,
+		TokenLimit:   tokenLimit,
+		Languages:    []string{LangChinese},
+	}
+
+	parent, child := DeriveParentChildConfigs(base, parentSize, childSize)
+	if parent.TokenLimit != 0 {
+		t.Fatalf("parent token limit: got %d want 0", parent.TokenLimit)
+	}
+	if len(parent.Languages) != 1 || parent.Languages[0] != LangChinese {
+		t.Fatalf("parent languages: got %v want [%s]", parent.Languages, LangChinese)
+	}
+	if child.TokenLimit != tokenLimit {
+		t.Fatalf("child token limit: got %d want %d", child.TokenLimit, tokenLimit)
+	}
+	if len(child.Languages) != 1 || child.Languages[0] != LangChinese {
+		t.Fatalf("child languages: got %v want [%s]", child.Languages, LangChinese)
+	}
+
+	text := strings.Repeat("这是用于验证中文分块预算的句子。", 100)
+	result := SplitParentChild(text, parent, child)
+	if len(result.Parents) != 1 {
+		t.Fatalf("parents: got %d want 1", len(result.Parents))
+	}
+	if got := len([]rune(result.Parents[0].Content)); got != len([]rune(text)) {
+		t.Fatalf("parent length: got %d want %d", got, len([]rune(text)))
+	}
+	budget := CharsForTokenLimit(tokenLimit, LangChinese)
+	for i, c := range result.Children {
+		if got := len([]rune(c.Content)); got > budget {
+			t.Fatalf("child[%d] length: got %d want <= %d", i, got, budget)
+		}
+	}
+}
+
 func TestValidateChunks_Empty(t *testing.T) {
 	if v := ValidateChunks(nil, 1000, 500); v.OK {
 		t.Error("nil chunks should be invalid")


### PR DESCRIPTION
## Description

本 PR 修复父子分块模式下 text child 可能漏 Embedding / 向量索引的问题。

父子分块的核心设计是：child 作为更细粒度的检索单元参与 Embedding 和向量召回；parent 不直接参与向量索引，只在 child 命中后提供更大的上下文窗口。也就是说，是否需要索引应该由 chunk 类型决定，而不是由 child 是否存在 `ParentChunkID` 决定。

当前实现里有两个问题：

1. 当 splitter 省略与 child 内容完全相同的冗余 parent 时，child 会保持 `ParentIndex=-1` 且没有 `ParentChunkID`。这类 child 仍然是合法的 `ChunkTypeText`，但旧逻辑会因为 `ParentChunkID` 为空而跳过索引。
2. parent-child splitter config 派生时没有继承 `TokenLimit` / `Languages`，导致 child splitter 没有按 Embedding 模型预算和语言边界规则工作。

本 PR 做了以下修复：

- 修正 parent-child 模式下的索引候选选择，确保所有 `ChunkTypeText` child 都会进入 Embedding / 向量索引。
- 补齐 parent-child splitter config 传播：`Languages` 传给 parent 和 child，`TokenLimit` 只传给 child。
- 增加回归测试，覆盖 standalone child 漏索引和 parent-child config 传播问题。

本次修改不改变检索阶段的 parent 展开逻辑，也不涉及数据库 schema 变更。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2678

## Testing

已在旧实现上验证新增回归测试会失败：

- `TestDeriveParentChildConfigs_AppliesEmbeddingTokenLimitOnlyToChildren` 失败，旧实现没有把 `Languages` 传给 parent / child，也没有把 `TokenLimit` 传给 child。
- `TestProcessChunksIndexesEveryTextChild` 失败，旧实现只索引了有 `ParentChunkID` 的 child，漏掉了 `ParentIndex=-1` 的 standalone child。

修复后已完成以下验证：

- `go test ./internal/infrastructure/chunker -run 'TestDeriveParentChildConfigs_(DefaultSizes|AppliesEmbeddingTokenLimitOnlyToChildren)$' -count=1`
- `go test ./internal/application/service -run TestProcessChunksIndexesEveryTextChild -count=1`
- `go test ./internal/infrastructure/chunker -count=1`
- `go test ./internal/application/service -count=1`
- `go test ./internal/router -count=1`
- `go vet ./internal/infrastructure/chunker ./internal/application/service`
- `go test ./... -count=1`
- 前端 `npm run type-check`
- `golangci-lint run --new-from-rev=origin/main ./...`
- `git diff --check origin/main...HEAD`

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A — backend chunking and indexing behavior only.