### PR TITLE
fix(data-analysis): 修复 Excel 表格摘要丢失样本数据

### DIFF
--- a/internal/application/service/extract.go
+++ b/internal/application/service/extract.go
@@ -649,7 +649,7 @@ func (s *DataTableSummaryService) processTableData(ctx context.Context, resource
 
 	// 构建共用的schema和样本数据描述
 	schemaDesc := tableSchema.Description()
-	sampleDesc := s.buildSampleDataDescription(sampleResult, 10)
+	sampleDesc := s.buildSampleDataDescription(ctx, sampleResult, 10)
 
 	// 使用AI生成表格摘要和列描述
 	customInstructions := ""
@@ -860,12 +860,36 @@ func (s *DataTableSummaryService) generateColumnDescriptions(ctx context.Context
 }
 
 // buildSampleDataDescription builds a formatted sample data description
-func (s *DataTableSummaryService) buildSampleDataDescription(sampleData *types.ToolResult, maxRows int) string {
+func (s *DataTableSummaryService) buildSampleDataDescription(ctx context.Context, sampleData *types.ToolResult, maxRows int) string {
 	var builder strings.Builder
 	builder.WriteString(fmt.Sprintf("Sample data (first %d rows):\n", maxRows))
 
-	rows, ok := sampleData.Data["rows"].([]map[string]interface{})
-	if !ok {
+	if sampleData == nil || sampleData.Data == nil {
+		return builder.String()
+	}
+
+	rawRows, exists := sampleData.Data["rows"]
+	if !exists || rawRows == nil {
+		return builder.String()
+	}
+
+	// DataAnalysisTool returns []map[string]string. A decoded ToolResult can
+	// instead contain []map[string]interface{}, so normalize both shapes before
+	// serializing the sample rows.
+	var rows []interface{}
+	switch typedRows := rawRows.(type) {
+	case []map[string]string:
+		rows = make([]interface{}, len(typedRows))
+		for i, row := range typedRows {
+			rows[i] = row
+		}
+	case []map[string]interface{}:
+		rows = make([]interface{}, len(typedRows))
+		for i, row := range typedRows {
+			rows[i] = row
+		}
+	default:
+		logger.Warnf(ctx, "[TableSummary] Unsupported sample rows type: %T", rawRows)
 		return builder.String()
 	}
 

--- a/internal/application/service/extract_data_table_summary_test.go
+++ b/internal/application/service/extract_data_table_summary_test.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestBuildSampleDataDescriptionIncludesDataAnalysisRows(t *testing.T) {
+	service := &DataTableSummaryService{}
+	result := &types.ToolResult{Data: map[string]interface{}{
+		"rows": []map[string]string{
+			{"date": "20250101", "status": "approved"},
+			{"date": "20250102", "status": "pending"},
+		},
+	}}
+
+	got := service.buildSampleDataDescription(context.Background(), result, 10)
+	for _, want := range []string{
+		`"date":"20250101"`,
+		`"status":"approved"`,
+		`"date":"20250102"`,
+		`"status":"pending"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("sample description missing %s:\n%s", want, got)
+		}
+	}
+}
+
+func TestBuildSampleDataDescriptionSupportsDecodedRows(t *testing.T) {
+	service := &DataTableSummaryService{}
+	result := &types.ToolResult{Data: map[string]interface{}{
+		"rows": []map[string]interface{}{
+			{"date": "20250101", "count": float64(3)},
+		},
+	}}
+
+	got := service.buildSampleDataDescription(context.Background(), result, 10)
+	for _, want := range []string{`"date":"20250101"`, `"count":3`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("sample description missing %s:\n%s", want, got)
+		}
+	}
+}
+
+func TestBuildSampleDataDescriptionLimitsRows(t *testing.T) {
+	service := &DataTableSummaryService{}
+	result := &types.ToolResult{Data: map[string]interface{}{
+		"rows": []map[string]string{
+			{"id": "first"},
+			{"id": "second"},
+		},
+	}}
+
+	got := service.buildSampleDataDescription(context.Background(), result, 1)
+	if !strings.Contains(got, `"id":"first"`) {
+		t.Fatalf("first row missing:\n%s", got)
+	}
+	if strings.Contains(got, `"id":"second"`) {
+		t.Fatalf("sample limit was ignored:\n%s", got)
+	}
+}


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description

修复 CSV / Excel 表格摘要生成时丢失样本行的问题。

`DataAnalysisTool` 实际返回的查询结果类型为 `[]map[string]string`，但 `buildSampleDataDescription` 之前仅处理 `[]map[string]interface{}`。类型断言失败后会静默返回空样本，导致表格摘要模型只能看到 Schema，无法识别实际的列值、状态或日期范围。

本次修改：

- 支持工具实际返回的 `[]map[string]string` 样本行。
- 保留对 JSON 解码后 `[]map[string]interface{}` 行数据的兼容。
- 增加样本行序列化、兼容类型和采样上限的回归测试。

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

无

## Testing

单测

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

无
