### PR TITLE
fix(dev): use IPv4 loopback for local services

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -424,7 +424,7 @@ start_app() {
         return 1
     fi
     
-    # 本地 docker-compose.dev 模式：把容器服务名映射到 localhost
+    # 本地 docker-compose.dev 模式：把容器服务名映射到宿主机回环地址
     # 远程开发模式（DEV_REMOTE_HOST 或 .env.local 已设地址）则保留 .env/.env.local 中的值
     if [ -n "${DEV_REMOTE_HOST:-}" ]; then
         log_info "远程开发模式: 基础设施 → ${DEV_REMOTE_HOST}"
@@ -439,13 +439,13 @@ start_app() {
             export LANGFUSE_HOST="http://${DEV_REMOTE_HOST}:3000"
         fi
     else
-        export DB_HOST=localhost
-        export DOCREADER_ADDR=localhost:50051
-        export MINIO_ENDPOINT=localhost:9000
-        export REDIS_ADDR=localhost:6379
-        export MILVUS_ADDRESS=localhost:19530
-        export NEO4J_URI=bolt://localhost:7687
-        export QDRANT_HOST=localhost
+        export DB_HOST=127.0.0.1
+        export DOCREADER_ADDR=127.0.0.1:50051
+        export MINIO_ENDPOINT=127.0.0.1:9000
+        export REDIS_ADDR=127.0.0.1:6379
+        export MILVUS_ADDRESS=127.0.0.1:19530
+        export NEO4J_URI=bolt://127.0.0.1:7687
+        export QDRANT_HOST=127.0.0.1
     fi
     export DOCREADER_TRANSPORT="${DOCREADER_TRANSPORT:-grpc}"
 


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description

When running the backend locally with `scripts/dev.sh app`, `localhost` may resolve to the IPv6 loopback address `::1`. Local Docker services can be exposed only on IPv4, causing connections to PostgreSQL, Redis, DocReader, and other development dependencies to fail even though their containers are healthy.

This PR updates the local development overrides in `scripts/dev.sh` to use `127.0.0.1` explicitly for:

- PostgreSQL;
- Redis;
- DocReader;
- MinIO;
- Milvus;
- Neo4j;
- Qdrant.

Remote development behavior through `DEV_REMOTE_HOST` is unchanged.

Breaking changes: none.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [x] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

```bash
bash -n scripts/dev.sh
git diff --check origin/main...HEAD
```

The `scripts/dev.sh app` environment-loading path was also executed with the application launch intercepted. All local service variables were verified to resolve to IPv4 loopback addresses:

```text
DB_HOST=127.0.0.1
DOCREADER_ADDR=127.0.0.1:50051
MINIO_ENDPOINT=127.0.0.1:9000
REDIS_ADDR=127.0.0.1:6379
MILVUS_ADDRESS=127.0.0.1:19530
NEO4J_URI=bolt://127.0.0.1:7687
QDRANT_HOST=127.0.0.1
```

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed script pass
- [x] Diff-scoped lint is not applicable to this shell-only change
- [x] Full-repository checks are not required for this isolated development-script change
- [x] Self-reviewed the code
- [x] Existing behavior was verified through the script entry point
- [x] Documentation updates are not required
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

### Before: startup failure with `localhost`

The local backend fails to connect to development services when `localhost` resolves to the IPv6 loopback address `::1`, while the Docker services are exposed on IPv4.

<img width="1705" height="566" alt="image" src="https://github.com/user-attachments/assets/f06d01d9-4feb-4352-ae89-1d035edab122" />


### After: successful startup with `127.0.0.1`

After the local service overrides are changed to `127.0.0.1`, the backend connects to the development dependencies and starts successfully.

<img width="1630" height="771" alt="image" src="https://github.com/user-attachments/assets/7439b440-0b8e-42bc-bc85-566bbbeedec5" />
