### PR TITLE
fix(chunk-merge): stop dropping content when contiguous chunks repeat text

### DIFF
--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -527,11 +527,17 @@ const viewMode = ref<'chunks' | 'merged' | 'preview'>('merged');
  *  2. HTML 实体编码（&#34; 等）导致的 content 长度与原文区间不一致——比对的是
  *     文本本身，不受长度偏差影响。
  *
+ * positionOverlap <= 0 时两段位置上严格相邻或不相交，无可去重重叠；此时进入
+ * 文本匹配会因 headSlack 下限 320 在 next 开头窗口内误命中 acc 后缀的真实
+ * 内容重复（如同一句话在文档多次出现），把 next 开头整段误判为补写表头删掉，
+ * 造成不可逆的内容丢失。直接拼接，补写表头重复交给调用方后处理。
+ *
  * @param positionOverlap 由 start/end 估算的重叠量，仅用于界定搜索窗口大小。
  */
 const appendChunkContent = (acc: string, next: string, positionOverlap: number): string => {
   if (!acc) return next;
   if (!next) return acc;
+  if (positionOverlap <= 0) return acc + next;
 
   const MIN_OVERLAP = 12;          // 过短的后缀容易误匹配（如分隔行），忽略
   const span = Math.max(positionOverlap, 0);

--- a/internal/searchutil/chunkmerge.go
+++ b/internal/searchutil/chunkmerge.go
@@ -98,6 +98,12 @@ const (
 // positionOverlap 是由 StartAt/EndAt 估算的重叠量（lastEnd - curStart），仅用于
 // 界定搜索窗口大小；真正的重叠按文本匹配，能兼容补写表头与 HTML 实体长度偏差。
 // 若找不到文本重叠，则原样拼接（不裁剪），宁可保留也不破坏内容。
+//
+// positionOverlap <= 0 时两段位置上严格相邻或不相交，没有可去重的重叠；
+// 此时进入文本匹配会因 headSlack 下限 320 在 next 开头窗口内误命中
+// acc 后缀的真实内容重复（如同一句话在文档多次出现），把 next 开头
+// 整段误判为补写表头删掉，造成不可逆的内容丢失。直接拼接，补写表头
+// 重复交给调用方后处理。
 func AppendWithOverlap(acc, next string, positionOverlap int) string {
 	if acc == "" {
 		return next
@@ -105,14 +111,14 @@ func AppendWithOverlap(acc, next string, positionOverlap int) string {
 	if next == "" {
 		return acc
 	}
+	if positionOverlap <= 0 {
+		return acc + next
+	}
 
 	accRunes := []rune(acc)
 	nextRunes := []rune(next)
 
 	span := positionOverlap
-	if span < 0 {
-		span = 0
-	}
 
 	maxK := minInt(len(accRunes), len(nextRunes))
 	if cap := maxInt(span*3, defaultSearchSpan); maxK > cap {

--- a/internal/searchutil/chunkmerge_test.go
+++ b/internal/searchutil/chunkmerge_test.go
@@ -159,3 +159,23 @@ func TestMergeTextChunks_GapSeparator(t *testing.T) {
 		t.Fatalf("gap separator mismatch:\n got=%q\nwant=%q", got, want)
 	}
 }
+
+// TestAppendWithOverlap_ContiguousRealContentRepeat is a regression test:
+// two chunks are strictly contiguous (positionOverlap==0), but a boilerplate
+// sentence at the tail of acc reappears inside the head window of next as
+// real content (the same sentence is written multiple times in the document).
+// The old algorithm would enter text matching and, due to the headSlack
+// floor of 320, mistake the head of next for a prepended table header and
+// delete it, causing irreversible content loss. After the fix it should
+// concatenate directly without trimming.
+func TestAppendWithOverlap_ContiguousRealContentRepeat(t *testing.T) {
+	repeat := "The system shall maintain a complete audit trail of all transactions."
+	acc := "3.2 Logging Requirements\n\n" + repeat
+	next := "\n\n5.1 Security Controls\n\n* Role-based access\n* Encryption at rest\n\n5.2 Compliance\n\n" + repeat + " This satisfies SOC 2."
+	got := AppendWithOverlap(acc, next, 0)
+	want := acc + next
+	if got != want {
+		t.Fatalf("contiguous real-content repeat must not trim:\n got.len=%d\nwant.len=%d\n got.tail=%q\nwant.tail=%q",
+			len(got), len(want), got[len(acc)-50:], want[len(acc)-50:])
+	}
+}


### PR DESCRIPTION

## Description
<!-- Briefly describe the purpose and changes of this PR -->
### chunk 合并 bug：相邻 chunk 内容重复时被误删
**现象**

  文档上传后，"全文展示"和 wiki 检索缺失部分内容；RAG 检索在相邻 chunk 同时命中时返回内容被截断。

 **根因**

  AppendWithOverlap 函数的作用是拼接两个相邻 chunk 时，去除 chunker 切表时补写的零宽表头重叠。做法是在 next 开头窗口里搜索 acc 的后缀，找到就只接重叠之后的部分。

  但函数有个 headSlack 下限（320 字符），即使两块位置上严格相邻（positionOverlap == 0，明确没有可去重的重叠），也会进文本匹配循环。

  触发场景：文档里同一句话被多次写入（财报的产品介绍、合规文档的审计条款、招投标的模板话术）。当 acc 末尾的这句话在 next 开头 320 字符窗口内作为真实内容再次出现，算法分不清这是"chunker 补写表头"还是"文档真实重复"，把 next 开头到匹配位置之间的整段当表头删掉——几百字符一次蒸发，不可逆。

**修复**

  positionOverlap <= 0 时直接拼接 acc + next，跳过文本匹配。chunker 的补写表头只发生在重叠区域内（positionOverlap > 0），那个分支仍走原逻辑，所以补写表头去重能力没丢。

  加了回归测试：合规文档里 "audit trail of all transactions" 这句话在 Logging 章节和 Compliance 章节各出现一次，旧算法会删掉 152 字符（含整个 "5.1 Security Controls" 段），修复后完整保留。

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix


## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
