### PR TITLE
修复：同步 knowledge-search 的 Swagger 路由与实际接口

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -10836,7 +10836,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/sessions/search": {
+        "/knowledge-search": {
             "post": {
                 "security": [
                     {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -10829,7 +10829,7 @@
                 }
             }
         },
-        "/sessions/search": {
+        "/knowledge-search": {
             "post": {
                 "security": [
                     {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -13112,7 +13112,7 @@ paths:
       summary: 继续流式响应
       tags:
       - 问答
-  /sessions/search:
+  /knowledge-search:
     post:
       consumes:
       - application/json

--- a/docs/swagger_contract_test.go
+++ b/docs/swagger_contract_test.go
@@ -1,0 +1,82 @@
+package docs_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	docs "github.com/Tencent/WeKnora/docs"
+	"gopkg.in/yaml.v3"
+)
+
+func TestKnowledgeSearchRouteContract(t *testing.T) {
+	tests := []struct {
+		name     string
+		loadSpec func(t *testing.T) []byte
+		parse    func([]byte, any) error
+	}{
+		{
+			name: "registered document",
+			loadSpec: func(t *testing.T) []byte {
+				t.Helper()
+				return []byte(docs.SwaggerInfo.ReadDoc())
+			},
+			parse: json.Unmarshal,
+		},
+		{
+			name: "swagger.json",
+			loadSpec: func(t *testing.T) []byte {
+				t.Helper()
+				return readSwaggerFile(t, "swagger.json")
+			},
+			parse: json.Unmarshal,
+		},
+		{
+			name: "swagger.yaml",
+			loadSpec: func(t *testing.T) []byte {
+				t.Helper()
+				return readSwaggerFile(t, "swagger.yaml")
+			},
+			parse: yaml.Unmarshal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertKnowledgeSearchRouteContract(t, tt.loadSpec(t), tt.parse)
+		})
+	}
+}
+
+func readSwaggerFile(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return data
+}
+
+func assertKnowledgeSearchRouteContract(t *testing.T, data []byte, parse func([]byte, any) error) {
+	t.Helper()
+	var spec struct {
+		Paths map[string]map[string]any `json:"paths" yaml:"paths"`
+	}
+	if err := parse(data, &spec); err != nil {
+		t.Fatalf("parse generated Swagger document: %v", err)
+	}
+
+	knowledgeSearch, ok := spec.Paths["/knowledge-search"]
+	if !ok {
+		t.Fatal("generated Swagger document does not expose /knowledge-search")
+	}
+	if _, ok := knowledgeSearch["post"]; !ok {
+		t.Fatal("generated Swagger document does not expose POST /knowledge-search")
+	}
+
+	if staleRoute, ok := spec.Paths["/sessions/search"]; ok {
+		if _, ok := staleRoute["post"]; ok {
+			t.Fatal("generated Swagger document still exposes stale POST /sessions/search")
+		}
+	}
+}

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -686,7 +686,7 @@ func (h *Handler) setupSSEStream(reqCtx *qaRequestContext, generateTitle bool) *
 // @Failure      400      {object}  errors.AppError         "请求参数错误"
 // @Security     Bearer
 // @Security     ApiKeyAuth
-// @Router       /sessions/search [post]
+// @Router       /knowledge-search [post]
 func (h *Handler) SearchKnowledge(c *gin.Context) {
 	ctx := logger.CloneContext(c.Request.Context())
 	logger.Info(ctx, "Start processing knowledge search request")


### PR DESCRIPTION
## 问题

`SearchKnowledge` 的实际接口为 `POST /api/v1/knowledge-search`，手写 API 文档也使用该路径，但 Swagger 注解仍声明为 `/sessions/search`。因此生成的 OpenAPI 规格会暴露一个不存在的旧接口，使用 Swagger UI 或根据规格生成客户端时可能得到 404。

## 改动

- 将 `SearchKnowledge` 的 `@Router` 注解改为 `/knowledge-search [post]`；
- 同步 `docs.go`、`swagger.json` 和 `swagger.yaml` 中的生成规格；
- 新增合同测试，结构化解析注册文档、JSON 规格和 YAML 规格，确认三者均包含 `POST /knowledge-search`，且不再包含陈旧的 `POST /sessions/search`。

本 PR 只修正文档合同，不修改运行时路由、请求/响应 Schema、权限或 API 行为。

## 测试

- `go test ./docs -count=1`
- `gofmt -d docs/swagger_contract_test.go`
- `git diff --check`
- 使用仓库依赖对应的 `swag v1.16.6` 重新生成并核对目标 operation；候选中的 `/knowledge-search.post` 与生成结果结构一致。

补充说明：在 Windows 环境运行 `go test ./internal/handler/session -count=1` 时，未修改的 `internal/utils` 会因 `pg_query.Parse/Deparse` 符号不可用而在编译阶段失败；同一失败已在未修改的 `main` 基线上复现，因此不是本 PR 引入的回归。

## 兼容性

运行时接口不变。此变更只让 Swagger/OpenAPI 与已经存在的实际路由保持一致。

## 相关条目

- #1797：同类 Swagger 路由漂移问题；
- #2561：已修复 `knowledge-chat` 和 `agent-chat` 的路由注解，本 PR 补齐遗漏的 `knowledge-search`。
