### PR TITLE
fix(docparser): preserve filename extension in MinerU multipart uploads

### DIFF
--- a/internal/infrastructure/docparser/mineru_converter.go
+++ b/internal/infrastructure/docparser/mineru_converter.go
@@ -103,18 +103,18 @@ func (c *MinerUReader) Read(ctx context.Context, req *types.ReadRequest) (*types
 	}, nil
 }
 
-// mineruFileParseResponse mirrors the relevant fields from the MinerU API response.
-type mineruFileParseResponse struct {
-	Results struct {
-		Document struct {
-			MDContent string            `json:"md_content"`
-			Images    map[string]string `json:"images"` // path -> "data:image/png;base64,..." or raw base64
-		} `json:"document"`
-		Files struct {
-			MDContent string            `json:"md_content"`
-			Images    map[string]string `json:"images"` // path -> "data:image/png;base64,..." or raw base64
-		} `json:"files"`
-	} `json:"results"`
+type mineruFileEntry struct {
+	MDContent string            `json:"md_content"`
+	Images    map[string]string `json:"images"` // path -> "data:image/png;base64,..." or raw base64
+}
+
+func minerUCleanFileType(fileType string) string {
+	cleanType := strings.ToLower(strings.TrimSpace(fileType))
+	cleanType = strings.TrimPrefix(cleanType, ".")
+	if minerUFileTypePattern.MatchString(cleanType) {
+		return cleanType
+	}
+	return ""
 }
 
 func minerUUploadFileName(fileName, fileType string) string {
@@ -129,15 +129,62 @@ func minerUUploadFileName(fileName, fileType string) string {
 	}, cleanName)
 	cleanName = strings.TrimSpace(cleanName)
 	if cleanName != "" && cleanName != "." && cleanName != ".." && cleanName != "/" {
+		if filepath.Ext(cleanName) == "" {
+			if cleanType := minerUCleanFileType(fileType); cleanType != "" {
+				return cleanName + "." + cleanType
+			}
+		}
 		return cleanName
 	}
 
-	cleanType := strings.ToLower(strings.TrimSpace(fileType))
-	cleanType = strings.TrimPrefix(cleanType, ".")
-	if minerUFileTypePattern.MatchString(cleanType) {
+	if cleanType := minerUCleanFileType(fileType); cleanType != "" {
 		return "document." + cleanType
 	}
 	return "document"
+}
+
+// minerUResultStem mirrors MinerU's upload.stem: the basename without extension.
+func minerUResultStem(uploadFileName string) string {
+	stem := strings.TrimSuffix(path.Base(uploadFileName), filepath.Ext(uploadFileName))
+	if stem == "" || stem == "." {
+		return ""
+	}
+	return stem
+}
+
+func minerUResultLookupKeys(uploadFileName string) []string {
+	keys := make([]string, 0, 3)
+	if stem := minerUResultStem(uploadFileName); stem != "" {
+		keys = append(keys, stem)
+	}
+	return append(keys, "document", "files")
+}
+
+func parseMinerUFileParseResponse(respBody []byte, uploadFileName string) (string, map[string]string, string, error) {
+	var envelope struct {
+		Results map[string]mineruFileEntry `json:"results"`
+	}
+	if err := json.Unmarshal(respBody, &envelope); err != nil {
+		return "", nil, "", fmt.Errorf("decode response: %w", err)
+	}
+	if len(envelope.Results) == 0 {
+		return "", nil, "", nil
+	}
+
+	for _, key := range minerUResultLookupKeys(uploadFileName) {
+		if entry, ok := envelope.Results[key]; ok {
+			if entry.MDContent != "" || len(entry.Images) > 0 {
+				return entry.MDContent, entry.Images, key, nil
+			}
+		}
+	}
+
+	for key, entry := range envelope.Results {
+		if entry.MDContent != "" || len(entry.Images) > 0 {
+			return entry.MDContent, entry.Images, key, nil
+		}
+	}
+	return "", nil, "", nil
 }
 
 func (c *MinerUReader) callFileParse(
@@ -174,8 +221,10 @@ func (c *MinerUReader) callFileParse(
 		_ = writer.WriteField(k, v)
 	}
 
+	uploadFileName := minerUUploadFileName(fileName, fileType)
+
 	// File part
-	part, err := writer.CreateFormFile("files", minerUUploadFileName(fileName, fileType))
+	part, err := writer.CreateFormFile("files", uploadFileName)
 	if err != nil {
 		return "", nil, fmt.Errorf("create form file: %w", err)
 	}
@@ -224,25 +273,16 @@ func (c *MinerUReader) callFileParse(
 		c.logMinerUResponseStructure(rawMap, "")
 	}
 
-	var result mineruFileParseResponse
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return "", nil, fmt.Errorf("decode response: %w", err)
+	mdContent, imagesB64, resultKey, err := parseMinerUFileParseResponse(respBody, uploadFileName)
+	if err != nil {
+		return "", nil, err
+	}
+	if resultKey != "" {
+		logger.Infof(context.Background(), "[MinerU] Using response path: results.%s", resultKey)
+		return mdContent, imagesB64, nil
 	}
 
-	// MinerU response schema differs by version/deployment:
-	// - older/self-hosted variants: results.document.*
-	// - some variants:            results.files.*
-	// Prefer document when available, then fallback to files.
-	if result.Results.Document.MDContent != "" || len(result.Results.Document.Images) > 0 {
-		logger.Infof(context.Background(), "[MinerU] Using response path: results.document")
-		return result.Results.Document.MDContent, result.Results.Document.Images, nil
-	}
-	if result.Results.Files.MDContent != "" || len(result.Results.Files.Images) > 0 {
-		logger.Infof(context.Background(), "[MinerU] Using response path: results.files")
-		return result.Results.Files.MDContent, result.Results.Files.Images, nil
-	}
-
-	logger.Errorf(context.Background(), "[MinerU] Response has no markdown/images under results.document or results.files")
+	logger.Errorf(context.Background(), "[MinerU] Response has no markdown/images under results")
 	return "", nil, nil
 }
 

--- a/internal/infrastructure/docparser/mineru_converter.go
+++ b/internal/infrastructure/docparser/mineru_converter.go
@@ -11,6 +11,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -23,7 +24,10 @@ import (
 
 const mineruTimeout = 1000 * time.Second // large docs can take a while
 
-var b64DataURIPattern = regexp.MustCompile(`^data:image/(\w+);base64,(.+)$`)
+var (
+	b64DataURIPattern     = regexp.MustCompile(`^data:image/(\w+);base64,(.+)$`)
+	minerUFileTypePattern = regexp.MustCompile(`^[a-z0-9]+$`)
+)
 
 // MinerUReader calls a self-hosted MinerU API to read/convert documents.
 type MinerUReader struct {
@@ -76,7 +80,7 @@ func (c *MinerUReader) Read(ctx context.Context, req *types.ReadRequest) (*types
 
 	logger.Infof(context.Background(), "[MinerU] Parsing file=%s size=%d via %s", req.FileName, len(content), c.endpoint)
 
-	mdContent, imagesB64, err := c.callFileParse(ctx, content)
+	mdContent, imagesB64, err := c.callFileParse(ctx, content, req.FileName, req.FileType)
 	if err != nil {
 		return nil, fmt.Errorf("MinerU file_parse: %w", err)
 	}
@@ -113,7 +117,35 @@ type mineruFileParseResponse struct {
 	} `json:"results"`
 }
 
-func (c *MinerUReader) callFileParse(ctx context.Context, content []byte) (string, map[string]string, error) {
+func minerUUploadFileName(fileName, fileType string) string {
+	cleanName := strings.TrimSpace(fileName)
+	cleanName = strings.ReplaceAll(cleanName, `\`, "/")
+	cleanName = path.Base(cleanName)
+	cleanName = strings.Map(func(r rune) rune {
+		if r == '\r' || r == '\n' || r == 0 {
+			return -1
+		}
+		return r
+	}, cleanName)
+	cleanName = strings.TrimSpace(cleanName)
+	if cleanName != "" && cleanName != "." && cleanName != ".." && cleanName != "/" {
+		return cleanName
+	}
+
+	cleanType := strings.ToLower(strings.TrimSpace(fileType))
+	cleanType = strings.TrimPrefix(cleanType, ".")
+	if minerUFileTypePattern.MatchString(cleanType) {
+		return "document." + cleanType
+	}
+	return "document"
+}
+
+func (c *MinerUReader) callFileParse(
+	ctx context.Context,
+	content []byte,
+	fileName string,
+	fileType string,
+) (string, map[string]string, error) {
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 
@@ -143,7 +175,7 @@ func (c *MinerUReader) callFileParse(ctx context.Context, content []byte) (strin
 	}
 
 	// File part
-	part, err := writer.CreateFormFile("files", "document")
+	part, err := writer.CreateFormFile("files", minerUUploadFileName(fileName, fileType))
 	if err != nil {
 		return "", nil, fmt.Errorf("create form file: %w", err)
 	}

--- a/internal/infrastructure/docparser/mineru_converter_test.go
+++ b/internal/infrastructure/docparser/mineru_converter_test.go
@@ -3,6 +3,7 @@ package docparser
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -30,6 +31,100 @@ func TestNewMinerUReaderResolvesParseMethod(t *testing.T) {
 			reader := NewMinerUReader(tt.overrides)
 			if reader.parseMethod != tt.want {
 				t.Fatalf("parseMethod = %q, want %q", reader.parseMethod, tt.want)
+			}
+		})
+	}
+}
+
+func TestMinerUUploadFileName(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		fileType string
+		want     string
+	}{
+		{name: "original basename", fileName: "reports/Illustrator 研报.pdf", fileType: "pdf", want: "Illustrator 研报.pdf"},
+		{
+			name:     "strip multipart controls",
+			fileName: "reports/\r\nIllustrator\x00 export.pdf",
+			fileType: "pdf",
+			want:     "Illustrator export.pdf",
+		},
+		{name: "append extension from type", fileName: "report", fileType: "pdf", want: "report.pdf"},
+		{name: "fallback from bare type", fileType: "pdf", want: "document.pdf"},
+		{name: "fallback from dotted uppercase type", fileType: ".PDF", want: "document.pdf"},
+		{name: "fallback from path-only name", fileName: "/", fileType: "pdf", want: "document.pdf"},
+		{name: "legacy fallback without metadata", want: "document"},
+		{name: "reject unsafe fallback type", fileType: "../pdf", want: "document"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := minerUUploadFileName(tt.fileName, tt.fileType); got != tt.want {
+				t.Fatalf("minerUUploadFileName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseMinerUFileParseResponse(t *testing.T) {
+	tests := []struct {
+		name             string
+		uploadFileName   string
+		response         map[string]any
+		wantMarkdown     string
+		wantResultKey    string
+	}{
+		{
+			name:           "match upload stem",
+			uploadFileName: "Illustrator 研报.pdf",
+			response: map[string]any{
+				"results": map[string]any{
+					"Illustrator 研报": map[string]any{"md_content": "from-stem", "images": map[string]any{}},
+				},
+			},
+			wantMarkdown:  "from-stem",
+			wantResultKey: "Illustrator 研报",
+		},
+		{
+			name:           "legacy document key",
+			uploadFileName: "document",
+			response: map[string]any{
+				"results": map[string]any{
+					"document": map[string]any{"md_content": "legacy", "images": map[string]any{}},
+				},
+			},
+			wantMarkdown:  "legacy",
+			wantResultKey: "document",
+		},
+		{
+			name:           "files variant",
+			uploadFileName: "document.pdf",
+			response: map[string]any{
+				"results": map[string]any{
+					"files": map[string]any{"md_content": "from-files", "images": map[string]any{}},
+				},
+			},
+			wantMarkdown:  "from-files",
+			wantResultKey: "files",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			respBody, err := json.Marshal(tt.response)
+			if err != nil {
+				t.Fatalf("marshal response: %v", err)
+			}
+			gotMarkdown, _, gotKey, err := parseMinerUFileParseResponse(respBody, tt.uploadFileName)
+			if err != nil {
+				t.Fatalf("parseMinerUFileParseResponse() error: %v", err)
+			}
+			if gotMarkdown != tt.wantMarkdown {
+				t.Fatalf("markdown = %q, want %q", gotMarkdown, tt.wantMarkdown)
+			}
+			if gotKey != tt.wantResultKey {
+				t.Fatalf("result key = %q, want %q", gotKey, tt.wantResultKey)
 			}
 		})
 	}
@@ -73,6 +168,20 @@ func TestMinerUReaderPreservesMultipartFilename(t *testing.T) {
 			}
 
 			captured := make(chan capturedRequest, 1)
+			uploadName := minerUUploadFileName(tt.fileName, tt.fileType)
+			resultStem := minerUResultStem(uploadName)
+			responseBody, err := json.Marshal(map[string]any{
+				"results": map[string]any{
+					resultStem: map[string]any{
+						"md_content": "ok",
+						"images":     map[string]any{},
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("marshal response: %v", err)
+			}
+
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				got := capturedRequest{method: r.Method, path: r.URL.Path}
 				file, header, err := r.FormFile("files")
@@ -87,7 +196,7 @@ func TestMinerUReaderPreservesMultipartFilename(t *testing.T) {
 				}
 				captured <- got
 				w.Header().Set("Content-Type", "application/json")
-				_, _ = io.WriteString(w, `{"results":{"document":{"md_content":"ok","images":{}}}}`)
+				_, _ = w.Write(responseBody)
 			}))
 			defer server.Close()
 

--- a/internal/infrastructure/docparser/mineru_converter_test.go
+++ b/internal/infrastructure/docparser/mineru_converter_test.go
@@ -69,11 +69,11 @@ func TestMinerUUploadFileName(t *testing.T) {
 
 func TestParseMinerUFileParseResponse(t *testing.T) {
 	tests := []struct {
-		name             string
-		uploadFileName   string
-		response         map[string]any
-		wantMarkdown     string
-		wantResultKey    string
+		name           string
+		uploadFileName string
+		response       map[string]any
+		wantMarkdown   string
+		wantResultKey  string
 	}{
 		{
 			name:           "match upload stem",

--- a/internal/infrastructure/docparser/mineru_converter_test.go
+++ b/internal/infrastructure/docparser/mineru_converter_test.go
@@ -1,9 +1,16 @@
 package docparser
 
 import (
+	"context"
 	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/utils"
 )
 
 func TestNewMinerUReaderResolvesParseMethod(t *testing.T) {
@@ -23,6 +30,95 @@ func TestNewMinerUReaderResolvesParseMethod(t *testing.T) {
 			reader := NewMinerUReader(tt.overrides)
 			if reader.parseMethod != tt.want {
 				t.Fatalf("parseMethod = %q, want %q", reader.parseMethod, tt.want)
+			}
+		})
+	}
+}
+
+func TestMinerUReaderPreservesMultipartFilename(t *testing.T) {
+	utils.SetSSRFWhitelistFromRaw("127.0.0.1")
+	t.Cleanup(func() {
+		utils.SetSSRFWhitelistFromRaw("")
+	})
+
+	const fileContent = "%PDF-1.7 synthetic test content"
+	tests := []struct {
+		name     string
+		fileName string
+		fileType string
+		want     string
+	}{
+		{name: "original basename", fileName: "reports/Illustrator 研报.pdf", fileType: "pdf", want: "Illustrator 研报.pdf"},
+		{
+			name:     "strip multipart controls",
+			fileName: "reports/\r\nIllustrator\x00 export.pdf",
+			fileType: "pdf",
+			want:     "Illustrator export.pdf",
+		},
+		{name: "fallback from bare type", fileType: "pdf", want: "document.pdf"},
+		{name: "fallback from dotted uppercase type", fileType: ".PDF", want: "document.pdf"},
+		{name: "fallback from path-only name", fileName: "/", fileType: "pdf", want: "document.pdf"},
+		{name: "legacy fallback without metadata", want: "document"},
+		{name: "reject unsafe fallback type", fileType: "../pdf", want: "document"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			type capturedRequest struct {
+				method   string
+				path     string
+				fileName string
+				content  string
+				err      error
+			}
+
+			captured := make(chan capturedRequest, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got := capturedRequest{method: r.Method, path: r.URL.Path}
+				file, header, err := r.FormFile("files")
+				if err != nil {
+					got.err = err
+				} else {
+					got.fileName = header.Filename
+					content, readErr := io.ReadAll(file)
+					got.content = string(content)
+					got.err = readErr
+					_ = file.Close()
+				}
+				captured <- got
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"results":{"document":{"md_content":"ok","images":{}}}}`)
+			}))
+			defer server.Close()
+
+			reader := NewMinerUReader(map[string]string{"mineru_endpoint": server.URL})
+			result, err := reader.Read(context.Background(), &types.ReadRequest{
+				FileContent: []byte(fileContent),
+				FileName:    tt.fileName,
+				FileType:    tt.fileType,
+			})
+			if err != nil {
+				t.Fatalf("Read returned error: %v", err)
+			}
+			if result.MarkdownContent != "ok" {
+				t.Fatalf("MarkdownContent = %q, want %q", result.MarkdownContent, "ok")
+			}
+
+			request := <-captured
+			if request.err != nil {
+				t.Fatalf("capture multipart request: %v", request.err)
+			}
+			if request.method != http.MethodPost {
+				t.Errorf("method = %q, want %q", request.method, http.MethodPost)
+			}
+			if request.path != "/file_parse" {
+				t.Errorf("path = %q, want %q", request.path, "/file_parse")
+			}
+			if request.fileName != tt.want {
+				t.Errorf("multipart filename = %q, want %q", request.fileName, tt.want)
+			}
+			if request.content != fileContent {
+				t.Errorf("multipart content = %q, want %q", request.content, fileContent)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Preserve the original filename metadata when WeKnora uploads a document to a self-hosted MinerU endpoint.

The adapter already receives `ReadRequest.FileName` and `FileType`, but `callFileParse` previously sent every multipart file part as `filename=document`. That drops extensions such as `.pdf` and can contribute to downstream file-type misclassification.

This change:

- passes the existing filename and file type into `callFileParse`;
- uses a cleaned basename while preserving Unicode, spaces, and the original extension;
- removes CR, LF, and NUL characters from multipart filenames;
- falls back to `document.<type>` for a valid declared type, or the legacy `document` when both values are absent;
- adds an `httptest` regression test that captures the real multipart request, payload, path, and response flow.

No public API, configuration, database schema, or deployment behavior is changed beyond the multipart filename metadata.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2694

## Testing

Passing focused checks:

- `go test ./internal/infrastructure/docparser -run '^TestMinerUReaderPreservesMultipartFilename$' -count=1`
- `go test ./internal/infrastructure/docparser -count=1`
- `golangci-lint run --new-from-rev=origin/main ./internal/infrastructure/docparser/...` — `0 issues`
- `git diff --check origin/main...HEAD`

Full-repository checks were also attempted on Windows:

- `make lint` does not pass the current upstream baseline: it reports 166 existing full-repository findings and cannot type-check the unchanged SQLite retriever because `sqlite3.h` is unavailable. The focused diff-scoped lint above passes.
- `make test` runs many packages successfully, but the full suite cannot build the unchanged SQLite/DuckDB-dependent packages on this Windows toolchain because `sqlite3.h` is unavailable and the prebuilt DuckDB archive has MinGW linker incompatibilities. The changed docparser package passes independently.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed package pass
- [x] Diff-scoped lint for the changed package passes
- [x] Full-repository checks were run and unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added tests covering original names, path cleaning, control characters, declared-type fallback, legacy fallback, and unsafe inputs
- [ ] Updated related documentation — not applicable; no public interface or configuration changed
- [x] No breaking changes

## Screenshots / Recordings

Not applicable; this is a backend transport fix with no UI changes.