### PR TITLE
fix(chat): 修复对话时间轴的三处失真（占位行样式、历史丢步骤、兜底计数）

### DIFF
--- a/frontend/src/composables/useChatMemoryRow.ts
+++ b/frontend/src/composables/useChatMemoryRow.ts
@@ -1,0 +1,50 @@
+import { computed, ref } from 'vue'
+import { MessagePlugin } from 'tdesign-vue-next'
+import { useI18n } from 'vue-i18n'
+import { deleteMemoryItem } from '@/api/memory'
+
+export type UsedMemory = { id: string; kind: string; content: string }
+
+/**
+ * State for the "memories used by this turn" timeline row.
+ *
+ * Both timelines (the quick-answer pipeline and the agent stream) show the same
+ * row, so the recall list, the expand state and the forget call live here rather
+ * than being written twice and drifting apart.
+ */
+export function useChatMemoryRow(getUsedMemories: () => UsedMemory[] | undefined) {
+  const { t } = useI18n()
+
+  const expanded = ref(false)
+  const forgettingId = ref('')
+  const forgottenIds = ref<string[]>([])
+
+  const memoryItems = computed(() => {
+    const used = getUsedMemories()
+    if (!Array.isArray(used)) return []
+    return used.filter((memory) => memory?.id && !forgottenIds.value.includes(memory.id))
+  })
+
+  const hasMemory = computed(() => memoryItems.value.length > 0)
+
+  const toggle = () => {
+    expanded.value = !expanded.value
+  }
+
+  // Forgetting from the answer is the shortest path from noticing a wrong memory
+  // to it being gone, which is where users actually notice one.
+  const forget = async (memory: { id: string }) => {
+    forgettingId.value = memory.id
+    try {
+      await deleteMemoryItem(memory.id)
+      forgottenIds.value = [...forgottenIds.value, memory.id]
+      MessagePlugin.success(t('chat.memoryForgotten'))
+    } catch (error: any) {
+      MessagePlugin.error(error?.message || t('chat.memoryForgetFailed'))
+    } finally {
+      forgettingId.value = ''
+    }
+  }
+
+  return { memoryItems, hasMemory, expanded, forgettingId, toggle, forget }
+}

--- a/frontend/src/i18n/embed.ts
+++ b/frontend/src/i18n/embed.ts
@@ -369,6 +369,7 @@ const messages = {
       },
       "search": {
         "noResults": "未找到匹配的内容",
+        "candidatesBelowThreshold": "命中 {count} 条候选，相关性不足，未用于回答",
         "foundResultsFromFiles": "找到 {count} 个结果，来自 {files} 个文件",
         "foundResults": "找到 {count} 个结果",
         "foundMixedResults": "找到 {count} 个结果（{docCount} 篇文档，{webCount} 条网页）",
@@ -865,6 +866,7 @@ const messages = {
       },
       "search": {
         "noResults": "No matching content found",
+        "candidatesBelowThreshold": "Matched {count} candidate(s), none relevant enough to use",
         "foundResultsFromFiles": "Found {count} result(s) from {files} file(s)",
         "foundResults": "Found {count} result(s)",
         "foundMixedResults": "Found {count} result(s) ({docCount} documents, {webCount} web results)",

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -5085,6 +5085,7 @@ export default {
     },
     search: {
       noResults: 'No matching content found',
+      candidatesBelowThreshold: 'Matched {count} candidate(s), none relevant enough to use',
       foundResultsFromFiles: 'Found {count} result(s) from {files} file(s)',
       foundResults: 'Found {count} result(s)',
       foundMixedResults: 'Found {count} result(s) ({docCount} documents, {webCount} web results)',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -1262,6 +1262,7 @@ export default {
     },
     search: {
       noResults: '일치하는 내용을 찾을 수 없습니다',
+      candidatesBelowThreshold: '후보 {count}개를 찾았지만 관련성이 부족해 답변에 사용하지 않았습니다',
       foundResultsFromFiles: '{files}개 파일에서 {count}개 결과 발견',
       foundResults: '{count}개 결과 발견',
       foundMixedResults: '{count}개 결과 발견 ({docCount}개 문서, {webCount}개 웹)',

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -1262,6 +1262,7 @@ export default {
     },
     search: {
       noResults: 'Совпадения не найдены',
+      candidatesBelowThreshold: 'Найдено кандидатов: {count}, ни один не подошёл по релевантности',
       foundResultsFromFiles: 'Найдено {count} результат(ов) из {files} файл(ов)',
       foundResults: 'Найдено {count} результат(ов)',
       foundMixedResults: 'Найдено {count} результат(ов) ({docCount} док., {webCount} веб)',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1264,6 +1264,7 @@ export default {
     },
     search: {
       noResults: '未找到匹配的内容',
+      candidatesBelowThreshold: '命中 {count} 条候选，相关性不足，未用于回答',
       foundResultsFromFiles: '找到 {count} 个结果，来自 {files} 个文件',
       foundResults: '找到 {count} 个结果',
       foundMixedResults: '找到 {count} 个结果（{docCount} 篇文档，{webCount} 条网页）',

--- a/frontend/src/utils/agent-tool-display.test.mjs
+++ b/frontend/src/utils/agent-tool-display.test.mjs
@@ -12,6 +12,9 @@ const t = (key, params) => {
   if (key === 'agentStream.search.foundResultsFromFiles') {
     return `found ${params?.count} from ${params?.files} files`
   }
+  if (key === 'agentStream.search.candidatesBelowThreshold') {
+    return `matched ${params?.count}, none relevant`
+  }
   if (key === 'agentStream.ragPipeline.searchingWithQuery') {
     return `searching ${params?.query}`
   }
@@ -56,6 +59,20 @@ test('getKnowledgeSearchSummaryHtml includes file count when present', () => {
     kb_counts: { a: 1, b: 2 },
   })
   assert.match(html, /found <strong>2<\/strong> from <strong>2<\/strong> files/)
+})
+
+// Candidates that all fell below the relevance threshold never reached the
+// answer, so the row must not read like a plain empty search: the difference
+// points at the threshold rather than at the knowledge base.
+test('getKnowledgeSearchSummaryHtml distinguishes filtered candidates from an empty search', () => {
+  assert.match(
+    getKnowledgeSearchSummaryHtml(t, { count: 0, candidate_count: 10 }),
+    /matched <strong>10<\/strong>, none relevant/,
+  )
+  assert.equal(
+    getKnowledgeSearchSummaryHtml(t, { count: 0, candidate_count: 0 }),
+    'agentStream.search.noResults',
+  )
 })
 
 test('getRagPipelineStepTitle uses query-aware search labels', () => {

--- a/frontend/src/utils/agent-tool-display.ts
+++ b/frontend/src/utils/agent-tool-display.ts
@@ -119,7 +119,19 @@ export function getKnowledgeSearchSummaryHtml(
 
   const results = toolData.results
   const count = (Array.isArray(results) ? results.length : 0) || Number(toolData.count) || 0
-  if (count === 0) return t('agentStream.search.noResults')
+  if (count === 0) {
+    // Retrieval found candidates but none cleared the relevance threshold, so the
+    // turn answered from the fallback with nothing retrieved in its context. Say
+    // that rather than "no matching content": the difference is what tells you to
+    // look at the threshold instead of the knowledge base.
+    const candidateCount = Number(toolData.candidate_count) || 0
+    if (candidateCount > 0) {
+      return t('agentStream.search.candidatesBelowThreshold', {
+        count: `<strong>${candidateCount}</strong>`,
+      })
+    }
+    return t('agentStream.search.noResults')
+  }
 
   const searchSource = getRetrievalSearchSource(null, toolData)
   const webCount = Number(toolData.web_count) || 0

--- a/frontend/src/views/chat/components/AgentStreamDisplay.style.test.mjs
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.style.test.mjs
@@ -92,6 +92,22 @@ test('only the collapsed root summary shows an expand chevron', () => {
   assert.doesNotMatch(source, /isEventExpanded\(event\.event_id\) \? 'chevron/)
 })
 
+// Recalled memory is one more thing the turn did before answering, so it rides
+// the same timeline as the steps instead of sitting in a card above them. It has
+// to travel into the collapsed tree with them, and appear exactly once.
+test('recalled memory rides the agent timeline as its leading row', () => {
+  const template = source.split('<script')[0]
+  assert.equal((template.match(/<ChatMemoryStep/g) || []).length, 2)
+  assert.match(template, /<div v-if="showIntermediateSteps" class="tree-children">\s*\n\s*<ChatMemoryStep/)
+  assert.match(template, /<ChatMemoryStep\s*\n\s*v-if="showMemoryRow"/)
+  assert.match(template, /<ChatMemoryStep[\s\S]*?:is-last="memoryIsLast"/)
+  assert.match(source, /!props\.ragMode && hasMemory\.value && !shouldShowCollapsedSteps\.value/)
+  assert.match(
+    source,
+    /const memoryIsLast = computed\([\s\S]*lastStreamingTimelineEventIndex\.value === -1/,
+  )
+})
+
 test('pending tool rows do not render an extra axis dot', () => {
   assert.doesNotMatch(source, /&\.action-pending\s*\{[\s\S]*&::after/)
 })

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -18,6 +18,14 @@
       </div>
       <!-- Tree children (intermediate steps) -->
       <div v-if="showIntermediateSteps" class="tree-children">
+        <ChatMemoryStep
+          v-if="hasMemory"
+          :memories="memoryItems"
+          :expanded="memoryExpanded"
+          :forgetting-id="memoryForgettingId"
+          @toggle="toggleMemory"
+          @forget="forgetMemory"
+        />
         <template v-for="(event, index) in visibleIntermediateEvents" :key="getEventKey(event, index)">
           <div v-if="event && event.type" class="tree-child"
             :class="{ 'tree-child-last': !isConversationDone && index === visibleIntermediateEvents.length - 1 }">
@@ -213,6 +221,19 @@
         'streaming-steps-constrained': !answerEverStarted && !isConversationDone,
         'is-streaming-timeline': showStreamingTimeline
       }">
+      <!-- Recalled memory leads the timeline: it is what the turn knew before it
+           started, so it belongs on the same line as the steps that follow it
+           rather than in a card of its own above them. -->
+      <ChatMemoryStep
+        v-if="showMemoryRow"
+        class="event-item"
+        :memories="memoryItems"
+        :expanded="memoryExpanded"
+        :is-last="memoryIsLast"
+        :forgetting-id="memoryForgettingId"
+        @toggle="toggleMemory"
+        @forget="forgetMemory"
+      />
       <template v-for="(event, index) in displayEvents" :key="getEventKey(event, index)">
         <div v-if="event && event.type" class="event-item" :class="{
           'event-answer': event.type === 'answer',
@@ -517,6 +538,8 @@ import ChatRequestInfoButton from '@/components/ChatRequestInfoButton.vue';
 import ChatCitationFloat from '@/components/ChatCitationFloat.vue';
 import picturePreview from '@/components/picture-preview.vue';
 import ChatArtifactsDrawer from './ChatArtifactsDrawer.vue';
+import ChatMemoryStep from './ChatMemoryStep.vue';
+import { useChatMemoryRow, type UsedMemory } from '@/composables/useChatMemoryRow';
 import { countGrepDocuments, groupGrepChunkResults } from '@/utils/grepResultsGroup';
 import { getKnowledgeChunksSummaryHtml } from '@/utils/knowledgeChunksDisplay';
 import { getAttachmentParsingSummaryHtml } from '@/utils/attachmentParsingDisplay';
@@ -843,6 +866,15 @@ const embedAuthProps = computed(() => ({
 const showRequestInfo = computed(
   () => !props.embeddedMode && !!(props.session?.request_id || props.session?.id),
 );
+
+const {
+  memoryItems,
+  hasMemory,
+  expanded: memoryExpanded,
+  forgettingId: memoryForgettingId,
+  toggle: toggleMemory,
+  forget: forgetMemory,
+} = useChatMemoryRow(() => props.session?.used_memories as UsedMemory[] | undefined);
 
 const resolveAssistantMessageId = (session?: SessionData) =>
   String(session?.assistant_message_id || session?.id || '').trim();
@@ -1664,6 +1696,19 @@ const shouldShowCollapsedSteps = computed(() => {
   const hasSteps = intermediateStepsCount.value > 0;
   return hasSteps && isConversationDone.value;
 });
+
+// Once the steps collapse, the memory row travels with them into the tree —
+// showing it here as well would leave two rows saying the same thing. In
+// quick-answer mode the pipeline component owns the timeline and its memory row.
+const showMemoryRow = computed(
+  () => !props.ragMode && hasMemory.value && !shouldShowCollapsedSteps.value,
+);
+
+// Memory leads the timeline, so it is only the last node while nothing has
+// followed it yet — and a lone node has no trunk line to draw below it.
+const memoryIsLast = computed(
+  () => lastStreamingTimelineEventIndex.value === -1 && !showAgentActivityIndicator.value,
+);
 
 // Check if event is a "deep thinking" type (either streaming thinking or thinking tool call)
 const isThinkingLikeEvent = (event: any): boolean => {

--- a/frontend/src/views/chat/components/RagPipelineProgress.style.test.mjs
+++ b/frontend/src/views/chat/components/RagPipelineProgress.style.test.mjs
@@ -49,6 +49,7 @@ test('rag pipeline opens references from search steps and the drawer composable'
 
 test('rag pipeline uses a native pending step and lets the thinking title shimmer while pending', () => {
   assert.match(source, /showPrePipelineWait/)
+  assert.match(source, /v-else-if="showPrePipelineWait"[\s\S]*class="tool-event"/)
   assert.match(source, /class="action-card action-pending"/)
   assert.match(source, /t\('chat\.preparingAnswer'\)/)
   assert.match(source, /showThinkingStep/)
@@ -128,7 +129,23 @@ test('memory-only hosts get the memory row and nothing else', () => {
   assert.match(source, /v-if="memoryOnly"\s*\n\s*variant="root"/)
   assert.match(source, /<div v-else-if="showPrePipelineWait"/)
   assert.match(source, /if \(props\.memoryOnly\) return hasMemory\.value/)
+})
 
+// The standalone row is for answers with no timeline at all. Agent turns keep
+// their memory row inside the agent timeline, so rendering it here too would
+// show the same recall twice, in two different visual languages.
+test('only timeline-less answers get the standalone memory row', () => {
   const botmsg = readFileSync(join(here, 'botmsg.vue'), 'utf8')
-  assert.match(botmsg, /<RagPipelineProgress v-if="session\.used_memories\?\.length"[\s\S]*?memory-only/)
+  assert.match(
+    botmsg,
+    /<RagPipelineProgress v-if="!session\.isAgentMode && session\.used_memories\?\.length"[\s\S]*?memory-only/,
+  )
+})
+
+// Both timelines show the same row from the same state; duplicating the recall
+// list, expand state and forget call is how the two drift apart.
+test('memory row state is shared by both timelines', () => {
+  assert.match(source, /useChatMemoryRow\(\(\) => props\.session\?\.used_memories\)/)
+  const agent = readFileSync(join(here, 'AgentStreamDisplay.vue'), 'utf8')
+  assert.match(agent, /useChatMemoryRow\(/)
 })

--- a/frontend/src/views/chat/components/RagPipelineProgress.vue
+++ b/frontend/src/views/chat/components/RagPipelineProgress.vue
@@ -22,11 +22,13 @@
       <div class="tree-child tree-child-last streaming-loading-node">
         <div class="tree-branch" />
         <div class="tree-child-content">
-          <div class="action-card action-pending">
-            <div class="action-header no-results">
-              <div class="action-title">
-                <t-icon class="action-title-icon" name="lightbulb" />
-                <span class="action-name">{{ t('chat.preparingAnswer') }}</span>
+          <div class="tool-event">
+            <div class="action-card action-pending">
+              <div class="action-header no-results">
+                <div class="action-title">
+                  <t-icon class="action-title-icon" name="lightbulb" />
+                  <span class="action-name">{{ t('chat.preparingAnswer') }}</span>
+                </div>
               </div>
             </div>
           </div>
@@ -247,10 +249,9 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
-import { MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
-import { deleteMemoryItem } from '@/api/memory'
 import ChatMemoryStep from './ChatMemoryStep.vue'
+import { useChatMemoryRow } from '@/composables/useChatMemoryRow'
 import { getAgentToolIconName } from '@/utils/agent-tool-icons'
 import {
   getKnowledgeSearchSummaryHtml,
@@ -295,36 +296,14 @@ const waitController = createRagWaitController((view) => {
 // Long-term memory is shown as a timeline row rather than as a card of its
 // own: it is one more thing the turn did before answering, and giving it a
 // separate visual language would make it read as unrelated to the pipeline.
-const memoryExpanded = ref(false)
-const forgettingId = ref('')
-const forgottenIds = ref<string[]>([])
-
-const memoryItems = computed(() => {
-  const used = props.session?.used_memories
-  if (!Array.isArray(used)) return []
-  return used.filter((memory) => memory?.id && !forgottenIds.value.includes(memory.id))
-})
-
-const hasMemory = computed(() => memoryItems.value.length > 0)
-
-const toggleMemory = () => {
-  memoryExpanded.value = !memoryExpanded.value
-}
-
-// Forgetting from the answer is the shortest path from noticing a wrong memory
-// to it being gone, which is where users actually notice one.
-const forgetMemory = async (memory: { id: string }) => {
-  forgettingId.value = memory.id
-  try {
-    await deleteMemoryItem(memory.id)
-    forgottenIds.value = [...forgottenIds.value, memory.id]
-    MessagePlugin.success(t('chat.memoryForgotten'))
-  } catch (error: any) {
-    MessagePlugin.error(error?.message || t('chat.memoryForgetFailed'))
-  } finally {
-    forgettingId.value = ''
-  }
-}
+const {
+  memoryItems,
+  hasMemory,
+  expanded: memoryExpanded,
+  forgettingId,
+  toggle: toggleMemory,
+  forget: forgetMemory,
+} = useChatMemoryRow(() => props.session?.used_memories)
 
 const thinkingContent = computed(() => {
   const stream = props.session?.agentEventStream

--- a/frontend/src/views/chat/components/botmsg.vue
+++ b/frontend/src/views/chat/components/botmsg.vue
@@ -21,13 +21,12 @@
                     @render-complete-change="emit('render-complete-change', $event)" />
             </div>
             <template v-else>
-                <!-- No pipeline here, but a turn that used long-term memory
-                     still has something to report. Only the memory row is
-                     wanted: agent mode already draws its own timeline, and
-                     letting this component re-derive one from the same event
-                     stream would show every step twice. -->
-                <RagPipelineProgress v-if="session.used_memories?.length" :session="session"
-                    :embedded-mode="embeddedMode" memory-only />
+                <!-- A plain answer has no timeline to put the memory row on, so
+                     it gets the standalone row. Agent turns render theirs inside
+                     the agent timeline instead, next to the steps it belongs
+                     with. -->
+                <RagPipelineProgress v-if="!session.isAgentMode && session.used_memories?.length"
+                    :session="session" :embedded-mode="embeddedMode" memory-only />
                 <docInfo v-if="session.knowledge_references?.length" :session="session"></docInfo>
                 <AgentStreamDisplay :session="session" :session-id="sessionId" :user-query="userQuery"
                     v-if="session.isAgentMode" :follow-up-loading="followUpLoading"

--- a/internal/application/service/agent_history.go
+++ b/internal/application/service/agent_history.go
@@ -194,11 +194,14 @@ func buildAssistantHistoryMessages(m *types.Message) []chat.Message {
 const legacyFinalAnswerToolName = "final_answer"
 
 // filterNonTerminalToolCalls drops legacy final_answer entries from historical
-// tool calls (see legacyFinalAnswerToolName). New turns never produce them.
+// tool calls (see legacyFinalAnswerToolName), plus the pipeline stages a
+// fast-answer turn records for its own timeline (see
+// types.PipelineToolCallIDPrefix): the model never issued those, so replaying
+// them would attribute calls to it that it cannot answer for.
 func filterNonTerminalToolCalls(calls []types.ToolCall) []types.ToolCall {
 	out := make([]types.ToolCall, 0, len(calls))
 	for _, tc := range calls {
-		if tc.Name == legacyFinalAnswerToolName {
+		if tc.Name == legacyFinalAnswerToolName || types.IsPipelineToolCallID(tc.ID) {
 			continue
 		}
 		out = append(out, tc)

--- a/internal/application/service/agent_history_test.go
+++ b/internal/application/service/agent_history_test.go
@@ -182,6 +182,37 @@ func TestBuildAssistantHistoryMessages_ToolCallsExpandIntoOpenAIShape(t *testing
 	assert.Empty(t, got[2].ToolCalls)
 }
 
+// A fast-answer turn persists its retrieval stages so the UI can redraw the
+// timeline after a reload. Those calls came from the pipeline, not the model, so
+// replaying them would hand the model tool calls it never made — and, in a
+// KnowledgeQA turn, tools it was never offered.
+func TestBuildAssistantHistoryMessages_SkipsPipelineTimelineToolCalls(t *testing.T) {
+	msg := &types.Message{
+		Role:    "assistant",
+		Content: "你好！很高兴见到你。",
+		AgentSteps: types.AgentSteps{
+			{
+				Iteration: 0,
+				ToolCalls: []types.ToolCall{
+					{
+						ID:     types.PipelineToolCallIDPrefix + "abc",
+						Name:   agenttools.ToolKnowledgeSearch,
+						Args:   map[string]interface{}{"query": "你好"},
+						Result: &types.ToolResult{Success: true, Output: "未检索到相关内容"},
+					},
+				},
+			},
+		},
+	}
+	got := buildAssistantHistoryMessages(msg)
+	if !assert.Len(t, got, 1) {
+		return
+	}
+	assert.Equal(t, "assistant", got[0].Role)
+	assert.Equal(t, "你好！很高兴见到你。", got[0].Content)
+	assert.Empty(t, got[0].ToolCalls)
+}
+
 // TestBuildAssistantHistoryMessages_ToolFailureSurfacesAsError ensures a
 // historical failed tool call is replayed as an "Error: …" tool message so the
 // model can see (and avoid retrying) the same failure path.

--- a/internal/application/service/chat_pipeline/progress.go
+++ b/internal/application/service/chat_pipeline/progress.go
@@ -183,6 +183,21 @@ func EndRetrievalProgress(
 	}
 
 	count, docCount, webCount := retrievalResultBreakdown(chatManage)
+
+	// ErrSearchNothing means retrieval short-circuited the pipeline into the
+	// fallback answer: nothing survived filtering, and the fallback prompt gets
+	// a knowledge-base listing rather than any retrieved chunk. So no chunk
+	// reached the model, and none can be cited either. Reporting the raw hits as
+	// the result count is what made the timeline promise results the answer never
+	// saw — and offer a row with no references to open. The raw hits stay
+	// available as candidates, which is the useful part when a threshold is what
+	// rejected them.
+	candidateCount := 0
+	if stageErr == ErrSearchNothing {
+		candidateCount = count
+		count, docCount, webCount = 0, 0, 0
+	}
+
 	searchSource := retrievalSearchSource(chatManage)
 	if count > 0 {
 		switch {
@@ -197,10 +212,13 @@ func EndRetrievalProgress(
 	success := stageErr == nil || stageErr == ErrSearchNothing
 	output := ""
 	if success {
-		if count == 0 {
-			output = "未检索到相关内容"
-		} else {
+		switch {
+		case count > 0:
 			output = fmt.Sprintf("检索到 %d 条相关内容", count)
+		case candidateCount > 0:
+			output = fmt.Sprintf("命中 %d 条候选，相关性不足，未用于回答", candidateCount)
+		default:
+			output = "未检索到相关内容"
 		}
 	}
 
@@ -220,10 +238,11 @@ func EndRetrievalProgress(
 			Success:    success,
 			Duration:   time.Since(start).Milliseconds(),
 			Data: map[string]interface{}{
-				"count":         count,
-				"doc_count":     docCount,
-				"web_count":     webCount,
-				"search_source": searchSource,
+				"count":           count,
+				"doc_count":       docCount,
+				"web_count":       webCount,
+				"search_source":   searchSource,
+				"candidate_count": candidateCount,
 			},
 		},
 	})

--- a/internal/application/service/chat_pipeline/progress_test.go
+++ b/internal/application/service/chat_pipeline/progress_test.go
@@ -121,6 +121,52 @@ func TestRetrievalProgressEmitsSingleToolCallAndResult(t *testing.T) {
 	assert.Equal(t, retrievalSourceKnowledge, resultData.Data["search_source"])
 }
 
+// A turn whose candidates all fell below the relevance threshold answers from
+// the fallback, which never sees a retrieved chunk. Reporting the raw hits as
+// the result count claimed context the answer did not have — and offered a row
+// with no references behind it.
+func TestRetrievalProgressReportsNoResultsWhenPipelineFellBack(t *testing.T) {
+	bus := &recordingEventBus{}
+	cm := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{SessionID: "sess-fallback"},
+		PipelineContext: types.PipelineContext{EventBus: bus},
+		PipelineState: types.PipelineState{
+			SearchResult: []*types.SearchResult{{ID: "r1"}, {ID: "r2"}, {ID: "r3"}},
+		},
+	}
+
+	progress := BeginRetrievalProgress(context.Background(), cm)
+	require.NotNil(t, progress)
+	EndRetrievalProgress(context.Background(), cm, progress, time.Now(), ErrSearchNothing)
+
+	resultData, ok := bus.events[1].Data.(event.AgentToolResultData)
+	require.True(t, ok)
+	assert.True(t, resultData.Success)
+	assert.Equal(t, 0, resultData.Data["count"])
+	assert.Equal(t, 0, resultData.Data["doc_count"])
+	assert.Equal(t, 0, resultData.Data["web_count"])
+	assert.Equal(t, 3, resultData.Data["candidate_count"])
+	assert.Equal(t, "命中 3 条候选，相关性不足，未用于回答", resultData.Output)
+}
+
+func TestRetrievalProgressReportsNothingFoundWhenThereWereNoCandidates(t *testing.T) {
+	bus := &recordingEventBus{}
+	cm := &types.ChatManage{
+		PipelineRequest: types.PipelineRequest{SessionID: "sess-empty"},
+		PipelineContext: types.PipelineContext{EventBus: bus},
+	}
+
+	progress := BeginRetrievalProgress(context.Background(), cm)
+	require.NotNil(t, progress)
+	EndRetrievalProgress(context.Background(), cm, progress, time.Now(), ErrSearchNothing)
+
+	resultData, ok := bus.events[1].Data.(event.AgentToolResultData)
+	require.True(t, ok)
+	assert.Equal(t, 0, resultData.Data["count"])
+	assert.Equal(t, 0, resultData.Data["candidate_count"])
+	assert.Equal(t, "未检索到相关内容", resultData.Output)
+}
+
 func TestRetrievalProgressWebOnlySearchSource(t *testing.T) {
 	bus := &recordingEventBus{}
 	cm := &types.ChatManage{

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -943,6 +943,11 @@ func (h *Handler) executeQA(reqCtx *qaRequestContext, mode qaMode, generateTitle
 	if mode == qaModeNormal {
 		var completionHandled bool
 
+		// Persist the pipeline's retrieval/attachment stages so a reloaded
+		// conversation redraws the timeline it showed while streaming, including
+		// turns that searched and cited nothing.
+		registerQuickAnswerTimelineRecorder(streamCtx.eventBus, streamCtx.assistantMessage)
+
 		// Persist reasoning_content into agent_steps so historical reload can
 		// reconstruct the thinking card (same shape as Agent-mode steps).
 		// Accumulate on assistantMessage directly so user-initiated stop also
@@ -1409,14 +1414,7 @@ func appendQuickAnswerReasoning(msg *types.Message, content string) {
 	if content == "" {
 		return
 	}
-	if len(msg.AgentSteps) == 0 {
-		msg.AgentSteps = types.AgentSteps{{
-			Iteration: 0,
-			Timestamp: time.Now(),
-			ToolCalls: make([]types.ToolCall, 0),
-		}}
-	}
-	msg.AgentSteps[0].ReasoningContent += content
+	ensureQuickAnswerStep(msg).ReasoningContent += content
 }
 
 // completeAssistantMessage marks an assistant message as complete, updates it,

--- a/internal/handler/session/quick_answer_timeline.go
+++ b/internal/handler/session/quick_answer_timeline.go
@@ -1,0 +1,130 @@
+package session
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/event"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// quickAnswerTimelineTools are the stages a fast-answer turn draws on its
+// timeline. A turn that retrieved nothing still reports the search it ran, so
+// the set is what decides whether the step survives a reload — not whether it
+// produced citations. Keep in sync with RAG_TIMELINE_TOOL_NAMES on the frontend.
+var quickAnswerTimelineTools = map[string]struct{}{
+	"query_understand":   {},
+	"knowledge_search":   {},
+	"attachment_parsing": {},
+	"image_analysis":     {},
+}
+
+// quickAnswerTimelineRecorder persists the fast-answer pipeline's timeline into
+// the assistant message's AgentSteps.
+//
+// Reconstructing the timeline from knowledge_references only works for turns
+// that cited something: a turn that searched and found nothing, or that only
+// parsed an attachment, came back from history with no steps at all and lost
+// the timeline it had while streaming.
+type quickAnswerTimelineRecorder struct {
+	mu        sync.Mutex
+	msg       *types.Message
+	pending   map[string]map[string]any
+	startedAt map[string]time.Time
+}
+
+// registerQuickAnswerTimelineRecorder subscribes to the pipeline's tool events
+// for the lifetime of one fast-answer turn. Agent mode is excluded on purpose:
+// its own steps are written by the agent stream handler, which overwrites
+// AgentSteps wholesale.
+func registerQuickAnswerTimelineRecorder(bus *event.EventBus, msg *types.Message) {
+	if bus == nil || msg == nil {
+		return
+	}
+	rec := &quickAnswerTimelineRecorder{
+		msg:       msg,
+		pending:   make(map[string]map[string]any),
+		startedAt: make(map[string]time.Time),
+	}
+	bus.On(event.EventAgentToolCall, rec.onToolCall)
+	bus.On(event.EventAgentToolResult, rec.onToolResult)
+}
+
+func (r *quickAnswerTimelineRecorder) onToolCall(_ context.Context, evt event.Event) error {
+	data, ok := evt.Data.(event.AgentToolCallData)
+	if !ok || !isQuickAnswerTimelineTool(data.ToolName) || data.ToolCallID == "" {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pending[data.ToolCallID] = data.Arguments
+	r.startedAt[data.ToolCallID] = time.Now()
+	return nil
+}
+
+// onToolResult is where the step is persisted. Waiting for the result keeps a
+// half-finished stage out of history: a stage still running when the turn is
+// stopped would come back from a reload looking like it had completed.
+func (r *quickAnswerTimelineRecorder) onToolResult(_ context.Context, evt event.Event) error {
+	data, ok := evt.Data.(event.AgentToolResultData)
+	if !ok || !isQuickAnswerTimelineTool(data.ToolName) || data.ToolCallID == "" {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	args := r.pending[data.ToolCallID]
+	delete(r.pending, data.ToolCallID)
+	started, hasStart := r.startedAt[data.ToolCallID]
+	delete(r.startedAt, data.ToolCallID)
+
+	duration := data.Duration
+	if duration == 0 && hasStart {
+		duration = time.Since(started).Milliseconds()
+	}
+
+	appendQuickAnswerToolCall(r.msg, types.ToolCall{
+		ID:   types.PipelineToolCallIDPrefix + data.ToolCallID,
+		Name: data.ToolName,
+		Args: args,
+		Result: &types.ToolResult{
+			Success: data.Success,
+			Output:  data.Output,
+			Error:   data.Error,
+			Data:    data.Data,
+		},
+		Duration: duration,
+	})
+	return nil
+}
+
+func isQuickAnswerTimelineTool(name string) bool {
+	_, ok := quickAnswerTimelineTools[name]
+	return ok
+}
+
+// ensureQuickAnswerStep returns the single step a fast-answer turn records
+// into. There is no ReAct loop here, so everything belongs to iteration 0.
+func ensureQuickAnswerStep(msg *types.Message) *types.AgentStep {
+	if len(msg.AgentSteps) == 0 {
+		msg.AgentSteps = types.AgentSteps{{
+			Iteration: 0,
+			Timestamp: time.Now(),
+			ToolCalls: make([]types.ToolCall, 0),
+		}}
+	}
+	return &msg.AgentSteps[0]
+}
+
+func appendQuickAnswerToolCall(msg *types.Message, call types.ToolCall) {
+	step := ensureQuickAnswerStep(msg)
+	for i := range step.ToolCalls {
+		if step.ToolCalls[i].ID == call.ID {
+			step.ToolCalls[i] = call
+			return
+		}
+	}
+	step.ToolCalls = append(step.ToolCalls, call)
+}

--- a/internal/handler/session/quick_answer_timeline_test.go
+++ b/internal/handler/session/quick_answer_timeline_test.go
@@ -1,0 +1,111 @@
+package session
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/event"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func emitTimelineStage(
+	t *testing.T,
+	bus *event.EventBus,
+	toolCallID, toolName string,
+	args map[string]any,
+	result event.AgentToolResultData,
+) {
+	t.Helper()
+	require.NoError(t, bus.Emit(context.Background(), event.Event{
+		Type: event.EventAgentToolCall,
+		Data: event.AgentToolCallData{ToolCallID: toolCallID, ToolName: toolName, Arguments: args},
+	}))
+	result.ToolCallID = toolCallID
+	result.ToolName = toolName
+	require.NoError(t, bus.Emit(context.Background(), event.Event{
+		Type: event.EventAgentToolResult,
+		Data: result,
+	}))
+}
+
+// A turn that searched and cited nothing is exactly the case history replay
+// could not reconstruct from knowledge_references, so it must be persisted.
+func TestQuickAnswerTimelineRecorderPersistsSearchWithoutResults(t *testing.T) {
+	bus := event.NewEventBus()
+	msg := &types.Message{}
+	registerQuickAnswerTimelineRecorder(bus, msg)
+
+	emitTimelineStage(t, bus, "call-1", "knowledge_search",
+		map[string]any{"query": "你好", "search_source": "knowledge"},
+		event.AgentToolResultData{
+			Output:   "未检索到相关内容",
+			Success:  true,
+			Duration: 12,
+			Data:     map[string]interface{}{"count": 0, "doc_count": 0, "web_count": 0},
+		})
+
+	require.Len(t, msg.AgentSteps, 1)
+	require.Len(t, msg.AgentSteps[0].ToolCalls, 1)
+	call := msg.AgentSteps[0].ToolCalls[0]
+	assert.Equal(t, "knowledge_search", call.Name)
+	assert.Equal(t, types.PipelineToolCallIDPrefix+"call-1", call.ID)
+	assert.Equal(t, "你好", call.Args["query"])
+	require.NotNil(t, call.Result)
+	assert.True(t, call.Result.Success)
+	assert.Equal(t, "未检索到相关内容", call.Result.Output)
+	assert.Equal(t, 0, call.Result.Data["count"])
+	assert.Equal(t, int64(12), call.Duration)
+}
+
+func TestQuickAnswerTimelineRecorderKeepsStageOrderAndIgnoresOtherTools(t *testing.T) {
+	bus := event.NewEventBus()
+	msg := &types.Message{}
+	registerQuickAnswerTimelineRecorder(bus, msg)
+
+	emitTimelineStage(t, bus, "call-1", "query_understand", nil,
+		event.AgentToolResultData{Output: "已完成问题理解", Success: true})
+	emitTimelineStage(t, bus, "call-2", "web_search", nil,
+		event.AgentToolResultData{Output: "ignored", Success: true})
+	emitTimelineStage(t, bus, "call-3", "knowledge_search", nil,
+		event.AgentToolResultData{Output: "检索到 3 条相关内容", Success: true})
+
+	require.Len(t, msg.AgentSteps, 1)
+	names := make([]string, 0, len(msg.AgentSteps[0].ToolCalls))
+	for _, call := range msg.AgentSteps[0].ToolCalls {
+		names = append(names, call.Name)
+	}
+	assert.Equal(t, []string{"query_understand", "knowledge_search"}, names)
+}
+
+// A stage that never reported a result belongs to an interrupted turn. Keeping
+// it out of history is what stops a reload from showing it as completed.
+func TestQuickAnswerTimelineRecorderSkipsStagesWithoutResult(t *testing.T) {
+	bus := event.NewEventBus()
+	msg := &types.Message{}
+	registerQuickAnswerTimelineRecorder(bus, msg)
+
+	require.NoError(t, bus.Emit(context.Background(), event.Event{
+		Type: event.EventAgentToolCall,
+		Data: event.AgentToolCallData{ToolCallID: "call-1", ToolName: "knowledge_search"},
+	}))
+
+	assert.Empty(t, msg.AgentSteps)
+}
+
+// Reasoning and timeline stages share one step, so neither may clobber the other.
+func TestQuickAnswerReasoningAndTimelineShareOneStep(t *testing.T) {
+	bus := event.NewEventBus()
+	msg := &types.Message{}
+	registerQuickAnswerTimelineRecorder(bus, msg)
+
+	appendQuickAnswerReasoning(msg, "思考中")
+	emitTimelineStage(t, bus, "call-1", "knowledge_search", nil,
+		event.AgentToolResultData{Output: "未检索到相关内容", Success: true})
+	appendQuickAnswerReasoning(msg, "继续")
+
+	require.Len(t, msg.AgentSteps, 1)
+	assert.Equal(t, "思考中继续", msg.AgentSteps[0].ReasoningContent)
+	require.Len(t, msg.AgentSteps[0].ToolCalls, 1)
+}

--- a/internal/types/agent.go
+++ b/internal/types/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"encoding/json"
+	"strings"
 	"time"
 )
 
@@ -204,6 +205,20 @@ type ToolCall struct {
 	Reflection       string                 `json:"reflection,omitempty"`        // Agent's reflection on this tool call result (if enabled)
 	Duration         int64                  `json:"duration"`                    // Execution time in milliseconds
 	ProviderMetadata ToolCallMetadata       `json:"provider_metadata,omitempty"` // Provider-specific tool-call state for replay
+}
+
+// PipelineToolCallIDPrefix marks a persisted tool call the model never made.
+// The fast-answer (KnowledgeQA) pipeline records its retrieval stages as tool
+// calls so a reloaded conversation can redraw the same timeline it showed while
+// streaming. History replay must skip them: asking the model to account for
+// calls it never issued, against tools it may not even have, breaks the
+// request protocol.
+const PipelineToolCallIDPrefix = "ragpipe-"
+
+// IsPipelineToolCallID reports whether a tool call was synthesized by the
+// fast-answer pipeline rather than requested by the model.
+func IsPipelineToolCallID(id string) bool {
+	return strings.HasPrefix(id, PipelineToolCallIDPrefix)
 }
 
 // AgentStep represents one iteration of the ReAct loop


### PR DESCRIPTION
## 背景

对话时间轴上有三处显示与实际不符，都会让人误判这一轮到底做了什么。

## 改动

### 1. 「正在准备回答」占位行文字被裁切

占位节点缺少 `.tool-event` 包装层，而图标绝对定位、行高等规则都写在该层下。shimmer 文案使用 `background-clip: text`，行高不足时顶部会被裁掉。补上包装，与同组件其他步骤结构一致。

### 2. 刷新后历史消息丢失时间轴

快速问答的检索步骤只存在于 SSE 事件流里，从不落库。刷新后前端只能靠 `knowledge_references` 反推，而 `synthesizeRagPipelineToolEvents` 在没有引用时返回空数组——于是「检索了但没命中知识库」的那一轮回到历史时，「理解问题 / 知识库检索 / 完成」全部消失。

改为在快速问答模式下订阅 pipeline 的工具事件，把 `query_understand` / `knowledge_search` / `attachment_parsing` / `image_analysis` 落到 `agent_steps`。只在收到 tool_result 时写入，避免被中断的步骤刷新后显示成已完成。

这些调用来自 pipeline 而非模型，ID 加 `ragpipe-` 前缀（`types.PipelineToolCallIDPrefix`），并在 Agent 历史回放 `buildAssistantHistoryMessages` 里过滤掉——否则会把模型没发起过、在 KnowledgeQA 轮次里甚至没被提供的工具调用塞进请求协议。

旧消息没有落库数据，仍走原来的引用反推逻辑，向后兼容。

### 3. 兜底回答把原始命中数报成检索结果数

检索阶段以 `ErrSearchNothing` 短路时会走兜底回答，而兜底 prompt 只拿到知识库的文档标题清单（`buildKBDocumentListing`），一条检索片段都没进模型上下文；引用事件只从 `MergeResult` 发出，此时也是空的。但进度条计数在 `MergeResult` / `RerankResult` 都为空时回退到原始 `SearchResult`，于是时间轴上写着「找到 10 个结果」——既不是模型看到的上下文数，也没有引用可以点开。

现在兜底路径下 `count` / `doc_count` / `web_count` 归零，原始命中数放进新的 `candidate_count`，前端显示「命中 N 条候选，相关性不足，未用于回答」，与完全没有候选的「未检索到相关内容」区分开：这个区别指向的是相关性阈值，而不是知识库。

### 4. 记忆行统一收进时间轴

Agent 模式的「本次使用了 N 条记忆」原先是悬在时间轴上方的独立卡片，现在作为时间轴首个节点渲染，折叠时随中间步骤一起收起。召回列表、展开状态与「忘记」调用抽成 `useChatMemoryRow`，两条时间轴（快速问答 pipeline 与 Agent 事件流）共用。没有时间轴的纯文本回答仍使用独立行。

## 测试

- [x] `go test ./internal/...`：新增 4 个时间轴持久化测试、2 个进度事件测试、1 个历史回放过滤测试
- [x] `go build ./cmd/server`、`go vet ./internal/...`、`golangci-lint`（pre-commit）
- [x] `scripts/verify_frontend_pr.sh`（`npm test` 148 项 + type-check + build）
- [x] `npm run check-i18n`：新 key `agentStream.search.candidatesBelowThreshold` 已补齐 zh-CN / en-US / ko-KR / ru-RU 与 embed 包