### PR TITLE
fix(chunk): sanitize context headers before persistence

### DIFF
--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -42,6 +42,7 @@ func NewChunkRepository(db *gorm.DB) interfaces.ChunkRepository {
 func (r *chunkRepository) CreateChunks(ctx context.Context, chunks []*types.Chunk) error {
 	for _, chunk := range chunks {
 		chunk.Content = common.CleanInvalidUTF8(chunk.Content)
+		chunk.ContextHeader = common.CleanInvalidUTF8(chunk.ContextHeader)
 		if chunk.SourceContent == "" {
 			chunk.SourceContent = chunk.Content
 		}

--- a/internal/application/repository/chunk_sqlite_test.go
+++ b/internal/application/repository/chunk_sqlite_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/google/uuid"
@@ -61,6 +62,25 @@ func TestCreateChunks_SQLite_SeqIDAutoAssigned(t *testing.T) {
 	for i, c := range saved {
 		assert.Equal(t, int64(i+1), c.SeqID, "chunk %d should have seq_id %d", i, i+1)
 	}
+}
+
+func TestCreateChunks_CleansContextHeaderBeforePersistence(t *testing.T) {
+	db := setupChunkTestDB(t)
+	repo := NewChunkRepository(db)
+	chunk := makeChunk(uuid.New().String(), uuid.New().String(), types.ChunkTypeText)
+	chunk.ContextHeader = "# \x00投资评级说明\xff"
+
+	require.NoError(t, repo.CreateChunks(context.Background(), []*types.Chunk{chunk}))
+
+	require.Equal(t, "# 投资评级说明", chunk.ContextHeader)
+	require.NotContains(t, chunk.ContextHeader, "\x00")
+	require.True(t, utf8.ValidString(chunk.ContextHeader))
+
+	var saved types.Chunk
+	require.NoError(t, db.First(&saved, "id = ?", chunk.ID).Error)
+	assert.Equal(t, "# 投资评级说明", saved.ContextHeader)
+	assert.NotContains(t, saved.ContextHeader, "\x00")
+	assert.True(t, utf8.ValidString(saved.ContextHeader))
 }
 
 func TestCreateChunks_SQLite_SeqIDContinuesFromExisting(t *testing.T) {


### PR DESCRIPTION
## Description

Sanitize `Chunk.ContextHeader` with the existing `common.CleanInvalidUTF8` helper at the `CreateChunks` persistence boundary.

Some parser-derived headings can contain embedded NUL bytes or invalid UTF-8. `CreateChunks` already sanitizes `Chunk.Content`, but the separately persisted `ContextHeader` field was not covered. PostgreSQL rejects those rows with `SQLSTATE 22021`.

This is a focused, backward-compatible change:
- no public API or schema changes;
- no new dependencies;
- no changes to existing `Content` cleanup;
- regression coverage verifies both the in-memory chunk and the SQLite-persisted value.

Reproduction details and the authorized sample PDF checksums are documented in #2700. Related historical report: #189. This is independent of the MinerU filename fix in #2695.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test
- [ ] Configuration / Build / CI

## Related Issue

Fixes #2700

Related: #189

## Testing

Passing focused checks:

```text
go test ./internal/application/repository -run '^TestCreateChunks_CleansContextHeaderBeforePersistence$' -count=1
go test ./internal/application/repository -count=1
golangci-lint run --new-from-rev=upstream/main ./internal/application/repository
git diff --check upstream/main...HEAD
```

The regression test was first run against the unmodified implementation and failed because the in-memory header remained `"# \x00投资评级说明\xff"`; it passes after the persistence-boundary cleanup.

Full-repository checks attempted:

- GitHub Actions `App` passes formatting, vet/test, and server build; `Go Lint` passes for the main module, CLI, and client.
- GitHub Actions `Go Lint` passes for the main module, CLI, and client. Locally, `golangci-lint run --new-from-rev=upstream/main ./...` reported `0 issues`, then exited non-zero during unrelated package typechecking because the Windows CGO environment lacks `sqlite3.h` for `sqlite-vec-go-bindings`.
- `make lint` and `make test` could not run because GNU Make is not installed in this Windows environment.
- Direct fallback `go test ./...` was attempted. The changed repository package passed, while the full suite exited non-zero on unrelated Windows/baseline failures, including the same missing `sqlite3.h`, DuckDB/MinGW linker incompatibilities, SQLite temporary-file locking, and existing tests in Feishu Wiki, deployment capabilities, and IM lifecycle packages.

## Checklist

- [x] `git diff --check upstream/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes in GitHub Actions; changed-package lint also passes locally with 0 issues (the documented local full-module typecheck is environment-blocked)
- [x] Full-repository checks were run, or unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Documentation update is not required for this internal persistence-boundary bug fix
- [x] No breaking changes

## Screenshots / Recordings

Not applicable; no user-visible UI changes.