### PR TITLE
fix: localize builtin agent cards when config is persisted in DB

### DIFF
--- a/internal/application/service/custom_agent.go
+++ b/internal/application/service/custom_agent.go
@@ -144,8 +144,9 @@ func (s *customAgentService) GetAgentByID(ctx context.Context, id string) (*type
 		// Try to get from database first (for customized config)
 		agent, err := s.repo.GetAgentByID(ctx, id, tenantID)
 		if err == nil {
-			// Found in database, return with customized config
+			// Found in database, overlay locale-specific name/description/avatar
 			agent.EnsureDefaults()
+			types.ApplyBuiltinAgentLocalization(ctx, agent)
 			return agent, nil
 		}
 		// Not in database, return default built-in agent from registry (i18n-aware)
@@ -222,6 +223,7 @@ func (s *customAgentService) ListAgents(ctx context.Context) ([]*types.CustomAge
 			// Use customized config from database
 			for _, agent := range allAgents {
 				if agent.ID == builtinID {
+					types.ApplyBuiltinAgentLocalization(ctx, agent)
 					result = append(result, agent)
 					break
 				}

--- a/internal/types/builtin_agent_config.go
+++ b/internal/types/builtin_agent_config.go
@@ -125,6 +125,32 @@ func GetBuiltinAgentWithContext(ctx context.Context, id string, tenantID uint64)
 	return buildAgentFromEntry(id, tenantID, locale)
 }
 
+// ApplyBuiltinAgentLocalization overlays the locale-specific name, description,
+// and avatar from builtin_agents.yaml onto a persisted built-in agent.
+// Tenant-specific Config and other DB fields are left untouched.
+//
+// Built-in agents are seeded into the database with the locale that was active
+// at first run. ListAgents / GetAgentByID used to return those stored strings
+// verbatim, so switching the UI language left the cards in Chinese (or
+// whichever language was seeded). YAML already has per-locale copy; this
+// applies it on the read path.
+func ApplyBuiltinAgentLocalization(ctx context.Context, agent *CustomAgent) {
+	if agent == nil {
+		return
+	}
+	localized := GetBuiltinAgentWithContext(ctx, agent.ID, agent.TenantID)
+	if localized == nil {
+		return
+	}
+	if localized.Name != "" {
+		agent.Name = localized.Name
+	}
+	if localized.Description != "" {
+		agent.Description = localized.Description
+	}
+	agent.Avatar = localized.Avatar
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------

--- a/internal/types/builtin_agent_localization_test.go
+++ b/internal/types/builtin_agent_localization_test.go
@@ -1,0 +1,62 @@
+package types
+
+import (
+	"context"
+	"testing"
+)
+
+func TestApplyBuiltinAgentLocalizationOverlaysYAMLLocale(t *testing.T) {
+	builtinAgentEntriesMu.Lock()
+	prevEntries := builtinAgentEntries
+	builtinAgentEntries = map[string]*BuiltinAgentEntry{
+		BuiltinQuickAnswerID: {
+			ID:     BuiltinQuickAnswerID,
+			Avatar: "quick.png",
+			I18n: map[string]BuiltinAgentI18n{
+				"default": {Name: "快速问答", Description: "中文 RAG"},
+				"en-US":   {Name: "Quick Answer", Description: "Knowledge base RAG Q&A"},
+				"zh-CN":   {Name: "快速问答", Description: "中文 RAG"},
+			},
+		},
+	}
+	builtinAgentEntriesMu.Unlock()
+	t.Cleanup(func() {
+		builtinAgentEntriesMu.Lock()
+		builtinAgentEntries = prevEntries
+		builtinAgentEntriesMu.Unlock()
+	})
+
+	agent := &CustomAgent{
+		ID:          BuiltinQuickAnswerID,
+		Name:        "快速问答",
+		Description: "中文 RAG",
+		Avatar:      "",
+		IsBuiltin:   true,
+		TenantID:    1,
+	}
+	ctx := context.WithValue(context.Background(), LanguageContextKey, "en-US")
+	ApplyBuiltinAgentLocalization(ctx, agent)
+
+	if agent.Name != "Quick Answer" {
+		t.Fatalf("Name = %q, want Quick Answer", agent.Name)
+	}
+	if agent.Description != "Knowledge base RAG Q&A" {
+		t.Fatalf("Description = %q, want English copy", agent.Description)
+	}
+	if agent.Avatar != "quick.png" {
+		t.Fatalf("Avatar = %q, want quick.png", agent.Avatar)
+	}
+}
+
+func TestApplyBuiltinAgentLocalizationNilSafe(t *testing.T) {
+	ApplyBuiltinAgentLocalization(context.Background(), nil)
+}
+
+func TestApplyBuiltinAgentLocalizationLeavesUnknownAgents(t *testing.T) {
+	agent := &CustomAgent{ID: "custom-agent-1", Name: "Mine", Description: "keep me"}
+	ctx := context.WithValue(context.Background(), LanguageContextKey, "en-US")
+	ApplyBuiltinAgentLocalization(ctx, agent)
+	if agent.Name != "Mine" || agent.Description != "keep me" {
+		t.Fatalf("custom agent was rewritten: %+v", agent)
+	}
+}


### PR DESCRIPTION
## Summary
- Built-in agent YAML already has per-locale name/description, but `ListAgents` / `GetAgentByID` returned the DB-seeded Chinese strings whenever a tenant had customized config stored.
- Overlay locale-specific `name`, `description`, and `avatar` from YAML on the read path, while keeping tenant-specific `Config` from the database.
- Adds regression tests for `en-US` overlay and unknown custom agents.

Fixes https://github.com/Tencent/WeKnora/issues/2601

## Test plan
- [x] `go test ./internal/types/ -run TestApplyBuiltinAgentLocalization -count=1`
- [ ] Seed builtin agents, switch UI language to English, confirm cards show `Quick Answer` instead of `快速问答`

Made with [Cursor](https://cursor.com)