### PR TITLE
fix: harden LLM rerank fallback for reasoning models

### DIFF
--- a/internal/agent/tools/knowledge_search.go
+++ b/internal/agent/tools/knowledge_search.go
@@ -707,9 +707,16 @@ func (t *KnowledgeSearchTool) rerankWithLLM(
 	// This prevents token overflow and improves processing efficiency
 	const batchSize = 15
 	const maxContentLength = 800 // Maximum characters per passage to avoid excessive tokens
+	const reasoningTokenReserve = 1024
 
 	// Process in batches
 	allScores := make([]float64, len(results))
+	useOriginalScores := func(start, end int) {
+		for i := start; i < end; i++ {
+			allScores[i] = results[i].Score
+		}
+	}
+	disableThinking := false
 
 	for batchStart := 0; batchStart < len(results); batchStart += batchSize {
 		batchEnd := batchStart + batchSize
@@ -793,23 +800,38 @@ Output only the scores, no explanations or additional text.`,
 			},
 		}
 
-		// Calculate appropriate max tokens based on batch size
-		// Each score line is ~15 tokens, add buffer for safety
-		maxTokens := len(batch)*20 + 100
+		// Each score line is ~15 tokens. Disable reasoning for this structured
+		// scoring task and keep a reserve for providers that ignore that option.
+		maxTokens := len(batch)*20 + 100 + reasoningTokenReserve
 
 		modelCtx := types.WithLLMCallMetadata(ctx, "knowledge_search_rerank", "")
 		response, err := t.chatModel.Chat(modelCtx, messages, &chat.ChatOptions{
 			Temperature: 0.1, // Low temperature for consistent scoring
 			MaxTokens:   maxTokens,
+			Thinking:    &disableThinking,
 		})
 		if err != nil {
 			logger.Warnf(ctx, "[Tool][KnowledgeSearch] LLM rerank batch %d-%d failed: %v, using original scores",
 				batchStart+1, batchEnd, err)
 			// Use original scores for this batch on error
-			for i := batchStart; i < batchEnd; i++ {
-				allScores[i] = results[i].Score
-			}
+			useOriginalScores(batchStart, batchEnd)
 			continue
+		}
+		if response == nil || strings.TrimSpace(response.Content) == "" ||
+			strings.EqualFold(response.FinishReason, "length") {
+			finishReason := ""
+			if response != nil {
+				finishReason = response.FinishReason
+			}
+			logger.Warnf(
+				ctx,
+				"[Tool][KnowledgeSearch] LLM rerank batch %d-%d returned incomplete output (finish_reason=%q), using original scores for remaining results",
+				batchStart+1,
+				batchEnd,
+				finishReason,
+			)
+			useOriginalScores(batchStart, len(results))
+			break
 		}
 
 		logger.Infof(ctx, "[Tool][KnowledgeSearch] LLM rerank batch %d-%d response: %s",
@@ -820,16 +842,13 @@ Output only the scores, no explanations or additional text.`,
 		if err != nil {
 			logger.Warnf(
 				ctx,
-				"[Tool][KnowledgeSearch] Failed to parse LLM scores for batch %d-%d: %v, using original scores",
+				"[Tool][KnowledgeSearch] Failed to parse LLM scores for batch %d-%d: %v, using original scores for remaining results",
 				batchStart+1,
 				batchEnd,
 				err,
 			)
-			// Use original scores for this batch on parsing error
-			for i := batchStart; i < batchEnd; i++ {
-				allScores[i] = results[i].Score
-			}
-			continue
+			useOriginalScores(batchStart, len(results))
+			break
 		}
 
 		// Store scores for this batch
@@ -919,18 +938,8 @@ func (t *KnowledgeSearchTool) parseScoresFromResponse(responseText string, expec
 		return nil, fmt.Errorf("no valid scores found in response")
 	}
 
-	// If we got fewer scores than expected, pad with last score or 0.5
-	for len(scores) < expectedCount {
-		if len(scores) > 0 {
-			scores = append(scores, scores[len(scores)-1])
-		} else {
-			scores = append(scores, 0.5)
-		}
-	}
-
-	// Truncate if we got more scores than expected
-	if len(scores) > expectedCount {
-		scores = scores[:expectedCount]
+	if len(scores) != expectedCount {
+		return nil, fmt.Errorf("expected %d scores, got %d", expectedCount, len(scores))
 	}
 
 	return scores, nil

--- a/internal/agent/tools/knowledge_search_rerank_test.go
+++ b/internal/agent/tools/knowledge_search_rerank_test.go
@@ -32,12 +32,36 @@ func (*rerankChatStub) ChatStream(
 	[]chat.Message,
 	*chat.ChatOptions,
 ) (<-chan types.StreamResponse, error) {
-	return nil, nil
+	stream := make(chan types.StreamResponse)
+	close(stream)
+	return stream, nil
 }
 
 func (*rerankChatStub) GetModelName() string { return "rerank-test" }
 
 func (*rerankChatStub) GetModelID() string { return "rerank-test" }
+
+func TestRerankChatStubStreamIsClosed(t *testing.T) {
+	t.Parallel()
+
+	stream, err := (&rerankChatStub{}).ChatStream(
+		context.Background(),
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ChatStream() error = %v", err)
+	}
+
+	select {
+	case _, ok := <-stream:
+		if ok {
+			t.Fatal("ChatStream() returned an open stream")
+		}
+	default:
+		t.Fatal("ChatStream() stream is not closed")
+	}
+}
 
 func TestFilterRerankRankResults_thresholdAndFallback(t *testing.T) {
 	t.Parallel()

--- a/internal/agent/tools/knowledge_search_rerank_test.go
+++ b/internal/agent/tools/knowledge_search_rerank_test.go
@@ -1,12 +1,43 @@
 package tools
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/models/chat"
 	"github.com/Tencent/WeKnora/internal/models/rerank"
 	"github.com/Tencent/WeKnora/internal/types"
 )
+
+type rerankChatStub struct {
+	response *types.ChatResponse
+	calls    int
+	options  []*chat.ChatOptions
+}
+
+func (s *rerankChatStub) Chat(
+	_ context.Context,
+	_ []chat.Message,
+	opts *chat.ChatOptions,
+) (*types.ChatResponse, error) {
+	s.calls++
+	copied := *opts
+	s.options = append(s.options, &copied)
+	return s.response, nil
+}
+
+func (*rerankChatStub) ChatStream(
+	context.Context,
+	[]chat.Message,
+	*chat.ChatOptions,
+) (<-chan types.StreamResponse, error) {
+	return nil, nil
+}
+
+func (*rerankChatStub) GetModelName() string { return "rerank-test" }
+
+func (*rerankChatStub) GetModelID() string { return "rerank-test" }
 
 func TestFilterRerankRankResults_thresholdAndFallback(t *testing.T) {
 	t.Parallel()
@@ -82,5 +113,81 @@ func TestRerankThreshold_default(t *testing.T) {
 	tool := &KnowledgeSearchTool{}
 	if got := tool.rerankThreshold(); got != 0.3 {
 		t.Fatalf("default threshold = %v, want 0.3", got)
+	}
+}
+
+func TestRerankWithLLMStopsAfterIncompleteOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		response *types.ChatResponse
+	}{
+		{
+			name: "reasoning budget exhausted",
+			response: &types.ChatResponse{
+				FinishReason: "length",
+			},
+		},
+		{
+			name: "score list is incomplete",
+			response: &types.ChatResponse{
+				Content:      "Passage 1: 0.90",
+				FinishReason: "stop",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			stub := &rerankChatStub{response: tt.response}
+			tool := &KnowledgeSearchTool{chatModel: stub}
+			results := make([]*searchResultWithMeta, 16)
+			for i := range results {
+				results[i] = &searchResultWithMeta{SearchResult: &types.SearchResult{
+					ID:      string(rune('a' + i)),
+					Content: "passage",
+					Score:   0.9,
+				}}
+			}
+
+			got, err := tool.rerankWithLLM(context.Background(), "query", results)
+			if err != nil {
+				t.Fatalf("rerankWithLLM returned error: %v", err)
+			}
+			if stub.calls != 1 {
+				t.Fatalf("chat calls = %d, want 1; invalid first batch should skip remaining batches", stub.calls)
+			}
+			if len(stub.options) != 1 {
+				t.Fatalf("captured options = %d, want 1", len(stub.options))
+			}
+			if stub.options[0].Thinking == nil || *stub.options[0].Thinking {
+				t.Fatalf("Thinking = %v, want false", stub.options[0].Thinking)
+			}
+			if stub.options[0].MaxTokens != 1424 {
+				t.Fatalf("MaxTokens = %d, want 1424", stub.options[0].MaxTokens)
+			}
+			if len(got) != len(results) {
+				t.Fatalf("reranked results = %d, want %d original-score fallbacks", len(got), len(results))
+			}
+		})
+	}
+}
+
+func TestParseScoresFromResponseRequiresExactCount(t *testing.T) {
+	t.Parallel()
+	tool := &KnowledgeSearchTool{}
+
+	scores, err := tool.parseScoresFromResponse("Passage 1: 0.90\nPassage 2: 0.40", 2)
+	if err != nil {
+		t.Fatalf("complete score list returned error: %v", err)
+	}
+	if len(scores) != 2 || scores[0] != 0.9 || scores[1] != 0.4 {
+		t.Fatalf("scores = %#v, want [0.9 0.4]", scores)
+	}
+
+	if _, err := tool.parseScoresFromResponse("Passage 1: 0.90", 2); err == nil {
+		t.Fatal("incomplete score list should return an error")
 	}
 }


### PR DESCRIPTION
## Description

Harden the knowledge search LLM reranker when a reasoning-capable model exhausts its output budget or returns a partial structured score list.

- disable model thinking for the deterministic scoring call and reserve output tokens for providers that ignore the option
- require the response to contain exactly one score per passage instead of padding or truncating partial output
- stop subsequent rerank batches after incomplete output and fall back to the original search scores for all remaining results
- add regression coverage for token exhaustion and incomplete score lists

This avoids spending additional LLM latency after the first unusable batch and preserves the original retrieval ranking instead of manufacturing missing scores.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [x] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Partially addresses #2703.

## Testing

- `go test ./internal/agent/tools -run 'TestRerankChatStubStreamIsClosed|TestRerankWithLLMStopsAfterIncompleteOutput|TestParseScoresFromResponseRequiresExactCount|TestRerankThreshold_default|TestFilterRerankRankResults|TestApplyModelRerankScores' -count=1`
- `go test -race ./internal/agent/tools -run 'TestRerankChatStubStreamIsClosed|TestRerankWithLLMStopsAfterIncompleteOutput|TestParseScoresFromResponseRequiresExactCount' -count=1`
- `go vet ./internal/agent/tools`
- `git diff --check upstream/main...HEAD`

The full `go test ./internal/agent/tools -count=1` command compiled but did not finish in the local environment after more than two minutes and was interrupted without test failure output. `golangci-lint` was not available locally.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (not applicable)
- [x] Breaking changes are clearly called out (none)

## Screenshots / Recordings

Not applicable; this is a backend-only change.