### PR TITLE
fix(files): fall back when message image proxy is unavailable

### DIFF
--- a/frontend/src/utils/protectedFileAccess.test.ts
+++ b/frontend/src/utils/protectedFileAccess.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  buildProtectedFileFallbackRequest,
   buildProtectedFileRequest,
   isProtectedFileProxyPath,
   isProviderFileURL,
@@ -52,6 +53,23 @@ test('message access routes through the session-message-scoped proxy', () => {
   assert.equal(
     request?.url,
     `/api/v1/sessions/session%201/messages/message%2F1/files?file_path=${encodeURIComponent(RESOURCE)}`,
+  )
+})
+
+test('message access falls back to the tenant proxy when the server lacks the message route', () => {
+  const request = buildProtectedFileFallbackRequest(RESOURCE, {
+    mode: 'message',
+    sessionId: 'session 1',
+    messageId: 'message/1',
+  })
+
+  assert.equal(request?.url, `/files?file_path=${encodeURIComponent(RESOURCE)}`)
+})
+
+test('an embed context has no tenant-proxy fallback', () => {
+  assert.equal(
+    buildProtectedFileFallbackRequest(RESOURCE, { mode: 'embed', channelId: 'ch-1', token: 'tok-1' }),
+    null,
   )
 })
 

--- a/frontend/src/utils/protectedFileAccess.ts
+++ b/frontend/src/utils/protectedFileAccess.ts
@@ -134,6 +134,17 @@ function tenantRequestHeaders(): Record<string, string> {
  * 为一个存储路径构造代理请求。返回 null 表示当前上下文无法发起该请求
  * （非存储路径，或嵌入上下文尚未拿到 token），调用方应跳过并稍后重试。
  */
+export function buildProtectedFileFallbackRequest(
+  sourceURL: string,
+  access: ProtectedFileAccessContext,
+): ProtectedFileRequest | null {
+  // 訊息範圍代理晚於部分自架後端才加入；若該端點回傳 404，改以既有的
+  // 已驗證 /files 路徑重試。不可降級嵌入訪客，因其沒有租戶憑證。
+  if (access.mode !== 'message' || !isProviderFileURL(sourceURL.trim())) return null;
+  const query = new URLSearchParams({ file_path: sourceURL.trim() }).toString();
+  return { url: `/files?${query}`, headers: tenantRequestHeaders() };
+}
+
 export function buildProtectedFileRequest(
   sourceURL: string,
   access: ProtectedFileAccessContext,

--- a/frontend/src/utils/security.ts
+++ b/frontend/src/utils/security.ts
@@ -11,6 +11,7 @@ import {
   markdownDomPurifySecurityHooks,
 } from './markdownDomPurify.ts';
 import {
+  buildProtectedFileFallbackRequest,
   buildProtectedFileRequest,
   isProtectedFileProxyPath,
   isProviderFileURL,
@@ -537,7 +538,26 @@ export async function hydrateProtectedFileImages(
             credentials: 'include',
           });
           if (!resp.ok) {
+            // 新版前端可使用訊息範圍圖片代理；較舊的自架後端沒有該端點，
+            // 但仍可透過已驗證的租戶 /files 代理讀取同一資源，因此僅在 404
+            // 時進行相容性重試。
             if (resp.status === 404) {
+              const fallback = buildProtectedFileFallbackRequest(sourceURL, resolvedAccess);
+              if (fallback) {
+                const fallbackResp = await fetch(fallback.url, {
+                  method: 'GET',
+                  headers: fallback.headers,
+                  credentials: 'include',
+                });
+                if (fallbackResp.ok) {
+                  const blob = await fallbackResp.blob();
+                  const blobURL = URL.createObjectURL(blob);
+                  protectedFileBlobCache.set(requestURL, blobURL);
+                  protectedFileBlobCache.set(fallback.url, blobURL);
+                  protectedFileFailureCache.delete(requestURL);
+                  return { status: 'loaded', blobURL };
+                }
+              }
               protectedFileFailureCache.set(requestURL, Date.now());
               return { status: 'missing' };
             }


### PR DESCRIPTION
## Summary

Fixes protected `resource://` image rendering when a newer frontend is served by a self-hosted backend that does not yet expose the message-scoped file endpoint.

## Problem

The frontend first requests:

```text
/api/v1/sessions/:session_id/messages/:message_id/files?file_path=resource://...
```

On older compatible backends this endpoint returns `404`, and the existing hydration logic treats that as a missing file and removes the image, even when the existing authenticated `/files` endpoint can serve it.

## Change

- On a `404` from the message-scoped proxy only, retry the existing authenticated tenant endpoint:
  ```text
  /files?file_path=resource://...
  ```
- Do not apply this fallback to embed visitors, which must remain scoped to their Embed token.
- Cache the successfully hydrated Blob URL under both request keys.

## Tests

- `npx tsx --test src/utils/protectedFileAccess.test.ts src/utils/security.test.ts`
- `npm run build`
- Verified against a self-hosted v0.7.2 backend: historical RAG images render again after the message route returns `404` and `/files` succeeds.
