### PR TITLE
fix(wiki): stop housekeeping from force-failing documents with durable Wiki backlog

### DIFF
--- a/internal/application/service/knowledge_housekeeping.go
+++ b/internal/application/service/knowledge_housekeeping.go
@@ -42,8 +42,9 @@ type HousekeepingService struct {
 	// inspector lets the sweep distinguish a genuinely orphaned row from
 	// one whose enrichment subtasks are merely backlogged behind a busy
 	// queue (no span heartbeat yet because no worker has picked them up).
-	// nil-safe — a nil inspector disables the queue check and the sweep
-	// falls back to the span/updated_at heuristics alone.
+	// nil-safe — a nil inspector disables only the transient queue check.
+	// Durable Wiki ownership in task_pending_ops is always probed through db,
+	// so the sweep never falls back to the span/updated_at heuristics alone.
 	inspector interfaces.TaskInspector
 
 	mu      sync.Mutex
@@ -268,23 +269,67 @@ func (h *HousekeepingService) filterByLastSpanActivity(ctx context.Context, cand
 	return out
 }
 
-// filterOutQueued returns the subset of candidates that have NO task left
-// in the queue backend, plus a count of how many were dropped because a
-// task still references them. A dropped candidate is "backlogged, not
-// orphaned" — its enrichment subtasks are waiting for a worker, so the
-// missing span heartbeat is expected and recovering it would be a false
-// positive. When no inspector is wired (nil) the gate is a pass-through
-// so behaviour matches the pre-existing span-only sweep. On inspector
-// error we fail safe by KEEPING the candidate as stuck (recover it),
-// matching the span heartbeat query's fail-safe direction.
+// filterOutQueued returns the subset of candidates that have NO work left
+// in either the durable pending-op table or the queue backend, plus a count
+// of how many were dropped because work still references them. A dropped
+// candidate is "backlogged, not orphaned" — its enrichment subtasks are
+// waiting for a worker, so the missing span heartbeat is expected and
+// recovering it would be a false positive.
+//
+// The asynq inspector alone cannot answer this for Wiki. Wiki ingest work is
+// durable per document in task_pending_ops (dedup_key = knowledge ID), while
+// asynq only carries a per-KB wake-up trigger whose payload has no knowledge
+// ID — and TypeWikiIngest is deliberately absent from the inspector's
+// taskTypesForKnowledgeCancel set anyway. So HasQueuedTasksForKnowledge
+// structurally reports "nothing queued" for a document whose only outstanding
+// work is a queued Wiki ingest, and the sweep force-fails a perfectly healthy
+// row. Probe the durable table directly before consulting the inspector.
+//
+// When no inspector is wired (nil) the durable gate still applies; only the
+// transient queue check is skipped. On probe error we fail safe, but in
+// opposite directions by design: an inspector error KEEPS the candidate as
+// stuck (matching the span heartbeat query), whereas a durable-table error
+// DEFERS every candidate to the next sweep — we cannot tell backlog from
+// orphan without it, and wrongly failing a live document is not recoverable
+// by the user, while waiting one more interval is.
 func (h *HousekeepingService) filterOutQueued(
 	ctx context.Context, candidates []types.Knowledge,
 ) (kept []types.Knowledge, skipped int) {
-	if h.inspector == nil || len(candidates) == 0 {
+	if len(candidates) == 0 {
 		return candidates, 0
 	}
+
+	ids := make([]string, 0, len(candidates))
+	for _, k := range candidates {
+		ids = append(ids, k.ID)
+	}
+	var durableIDs []string
+	if err := h.db.WithContext(ctx).
+		Model(&types.TaskPendingOp{}).
+		Where("task_type = ? AND scope = ? AND op = ? AND dedup_key IN ?",
+			wikiTaskType, wikiTaskScope, WikiOpIngest, ids).
+		Distinct("dedup_key").
+		Pluck("dedup_key", &durableIDs).Error; err != nil {
+		logger.Warnf(ctx,
+			"[Housekeeping] durable queue probe failed: %v (deferring %d candidate(s))",
+			err, len(candidates))
+		return candidates[:0], len(candidates)
+	}
+	durable := make(map[string]struct{}, len(durableIDs))
+	for _, id := range durableIDs {
+		durable[id] = struct{}{}
+	}
+
 	out := candidates[:0]
 	for _, k := range candidates {
+		if _, ok := durable[k.ID]; ok {
+			skipped++
+			continue
+		}
+		if h.inspector == nil {
+			out = append(out, k)
+			continue
+		}
 		queued, err := h.inspector.HasQueuedTasksForKnowledge(ctx, k.ID)
 		if err != nil {
 			logger.Warnf(ctx,

--- a/internal/application/service/knowledge_housekeeping_test.go
+++ b/internal/application/service/knowledge_housekeeping_test.go
@@ -68,13 +68,43 @@ CREATE TABLE IF NOT EXISTS knowledge_processing_spans (
 );
 `
 
+const housekeepingPendingOpsDDL = `
+CREATE TABLE IF NOT EXISTS task_pending_ops (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id   INTEGER NOT NULL DEFAULT 0,
+    task_type   VARCHAR(64) NOT NULL,
+    scope       VARCHAR(32) NOT NULL,
+    scope_id    VARCHAR(64) NOT NULL,
+    op          VARCHAR(32) NOT NULL,
+    dedup_key   VARCHAR(128) NOT NULL DEFAULT '',
+    payload     TEXT NOT NULL DEFAULT '{}',
+    fail_count  INTEGER NOT NULL DEFAULT 0,
+    enqueued_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    claimed_at  DATETIME
+);
+`
+
 func setupHousekeepingDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.Exec(knowledgeTestDDL).Error)
 	require.NoError(t, db.Exec(housekeepingSpansDDL).Error)
+	require.NoError(t, db.Exec(housekeepingPendingOpsDDL).Error)
 	return db
+}
+
+// insertWikiPendingOp mirrors newWikiIngestPendingOp: the durable row is
+// scoped to the KB but deduplicated on the knowledge ID, which is exactly
+// why the per-knowledge asynq probe cannot see it.
+func insertWikiPendingOp(t *testing.T, db *gorm.DB, kbID, knowledgeID string) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`INSERT INTO task_pending_ops (task_type, scope, scope_id, op, dedup_key, payload)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		wikiTaskType, wikiTaskScope, kbID, WikiOpIngest, knowledgeID,
+		`{"op":"ingest","knowledge_id":"`+knowledgeID+`"}`,
+	).Error)
 }
 
 // insertKnowledge writes a knowledge row at the given updated_at. We
@@ -268,6 +298,53 @@ func TestHousekeeping_NoFalseKill_TasksStillQueued(t *testing.T) {
 	).Row().Scan(&status))
 	assert.Equal(t, types.ParseStatusFinalizing, status,
 		"finalizing row with tasks still queued must NOT be flipped to failed")
+}
+
+// A document whose only outstanding work is a queued Wiki ingest is
+// invisible to the asynq probe: the durable op lives in task_pending_ops
+// keyed by knowledge ID, while asynq holds only a per-KB trigger, and
+// TypeWikiIngest is not in taskTypesForKnowledgeCancel either. The
+// inspector below reports "nothing queued" — exactly what production does
+// — so without the durable gate the sweep force-fails a healthy row.
+func TestHousekeeping_NoFalseKill_DurableWikiIngestPending(t *testing.T) {
+	db := setupHousekeepingDB(t)
+	svc := newHousekeepingSvcWithInspector(db, fakeTaskInspector{})
+	stale := time.Now().Add(-3 * time.Hour)
+	insertKnowledge(t, db, "kid-durable-wiki", types.ParseStatusFinalizing, stale)
+	insertSpan(t, db, "kid-durable-wiki", 1, "wiki-1", types.SpanStatusRunning, stale)
+	insertWikiPendingOp(t, db, "kb-1", "kid-durable-wiki")
+
+	svc.runSweep(context.Background())
+
+	var status string
+	require.NoError(t, db.Raw(
+		`SELECT parse_status FROM knowledges WHERE id = ?`, "kid-durable-wiki",
+	).Row().Scan(&status))
+	assert.Equal(t, types.ParseStatusFinalizing, status,
+		"row with a durable wiki ingest op pending must NOT be flipped to failed")
+}
+
+// The durable gate must not become a blanket amnesty: a stale row with no
+// pending op and nothing in the queue is still genuinely orphaned, and the
+// sweep must keep recovering it. This is the regression guard for the gate
+// itself.
+func TestHousekeeping_StillRecoversWhenNoDurableOp(t *testing.T) {
+	db := setupHousekeepingDB(t)
+	svc := newHousekeepingSvcWithInspector(db, fakeTaskInspector{})
+	stale := time.Now().Add(-3 * time.Hour)
+	insertKnowledge(t, db, "kid-orphan", types.ParseStatusFinalizing, stale)
+	insertSpan(t, db, "kid-orphan", 1, "wiki-1", types.SpanStatusRunning, stale)
+	// A pending op for a DIFFERENT document must not shield this one.
+	insertWikiPendingOp(t, db, "kb-1", "kid-someone-else")
+
+	svc.runSweep(context.Background())
+
+	var status string
+	require.NoError(t, db.Raw(
+		`SELECT parse_status FROM knowledges WHERE id = ?`, "kid-orphan",
+	).Row().Scan(&status))
+	assert.Equal(t, types.ParseStatusFailed, status,
+		"row with no durable op and nothing queued must still be recovered")
 }
 
 // TestHousekeeping_QueueProbeError_FailsSafe confirms the fail-safe


### PR DESCRIPTION
## Description

The stuck-row sweep asks the asynq inspector whether a candidate still has work queued, and treats "nothing queued" as proof the row is orphaned. For Wiki that question cannot be answered by asynq at all:

- Wiki ingest work is durable **per document** in `task_pending_ops`, keyed by `dedup_key = knowledge ID` (`newWikiIngestPendingOp`, `wiki_ingest.go`).
- asynq only receives a **per-KB** wake-up trigger, whose payload carries `KnowledgeBaseID` and no knowledge ID (`enqueueWikiIngestTrigger`).
- `matchesKnowledge()` gates on `taskTypesForKnowledgeCancel` (`task_inspector.go:87`), which deliberately excludes `TypeWikiIngest` — the comment there says the set is "deliberately narrow".

So `HasQueuedTasksForKnowledge` **structurally** returns false for a document whose only outstanding work is a queued Wiki ingest. `filterOutQueued` then keeps it as a candidate and the sweep flips a perfectly healthy `finalizing` row to `failed` with `"task stuck in processing > Xh, recovered by housekeeping"`, zeroing `pending_subtasks_count`. The durable op later runs anyway.

That is how a document ends up `failed` while present in neither the dead-letter table nor any visible queue.

### Change

Probe `task_pending_ops` directly before consulting the inspector.

- A durable probe **error** defers every candidate to the next sweep rather than failing them. This is deliberately the opposite of the inspector's fail-safe direction: wrongly failing a live document is not user-recoverable, whereas waiting one more interval is. The inspector's own fail-safe behaviour is unchanged.
- A nil inspector no longer disables the whole gate, only the transient half.
- No schema change, no config, no new dependency.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Relates to #2688 — specifically its point 4, "部分文档的 Wiki span 明确显示失败，但既不在死信队列，也不在待处理队列中，似乎被静默丢弃了". This PR addresses that silent-drop mechanism only; the other asks in that issue (403 treated as non-transient, Wiki status not surfaced at document level, Wiki-only batch retry) are out of scope here.

## Testing

Go 1.26.0, `CGO_ENABLED=1`:

- `gofmt -l internal/application/service/knowledge_housekeeping.go internal/application/service/knowledge_housekeeping_test.go` — no output
- `go vet ./internal/application/service/` — clean
- `go test ./internal/application/service/ -run Housekeeping -count=1 -v` — all 10 cases pass (8 pre-existing + 2 new)

New coverage:

- `TestHousekeeping_NoFalseKill_DurableWikiIngestPending` reproduces the bug — it **fails on the unpatched sweep** (verified by reverting only the non-test file and re-running) and passes with the fix.
- `TestHousekeeping_StillRecoversWhenNoDurableOp` guards against the new gate becoming a blanket amnesty: a stale row with no pending op of its own — including the case where a pending op exists for a *different* document — must still be recovered.

The focused package was validated. Full-repository `make test` was not run; the change is confined to the housekeeping sweep and its unit tests.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages pass
- [x] Diff-scoped lint passes where applicable (`go vet` for the changed package)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (not applicable; no user-facing contract or configuration change)
- [x] Breaking changes are clearly called out (none)

## Screenshots / Recordings

Not applicable; backend-only fix.