### PR TITLE
feat(agent): let custom agents opt into parallel tool execution

### DIFF
--- a/internal/application/service/agent_parallel_tool_calls_config_test.go
+++ b/internal/application/service/agent_parallel_tool_calls_config_test.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// The engine already knows how to run a round's tool calls concurrently
+// (AgentEngine.executeToolCallsParallel, gated on AgentConfig.ParallelToolCalls),
+// but nothing ever set that flag: buildAgentConfig copies CustomAgentConfig into
+// the runtime AgentConfig field by field and this one was absent, so the gate
+// read the zero value and the parallel branch was unreachable for every custom
+// agent. Failure was silent — tools just kept running one at a time.
+func TestAgentConfigCarriesTheParallelToolCallsPreference(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{
+		{name: "opted in", want: true},
+		{name: "opted out", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &sessionService{
+				cfg:                   &config.Config{},
+				webSearchProviderRepo: &sharedAgentWebSearchRepo{},
+			}
+			req := &types.QARequest{
+				Session: &types.Session{ID: "session-1", TenantID: 1},
+				CustomAgent: &types.CustomAgent{
+					TenantID: 1,
+					Config: types.CustomAgentConfig{
+						MaxIterations:     5,
+						ParallelToolCalls: tc.want,
+					},
+				},
+			}
+
+			agentConfig, err := svc.buildAgentConfig(t.Context(), req, &types.Tenant{ID: 1}, 1)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, agentConfig.ParallelToolCalls)
+		})
+	}
+}
+
+// Agents saved before this option existed must keep running their tools
+// sequentially: tools are not required to be side-effect free, so silently
+// turning on concurrency for them would be a behavior change, not a fix.
+func TestAgentConfigDefaultsParallelToolCallsOff(t *testing.T) {
+	svc := &sessionService{
+		cfg:                   &config.Config{},
+		webSearchProviderRepo: &sharedAgentWebSearchRepo{},
+	}
+	req := &types.QARequest{
+		Session: &types.Session{ID: "session-1", TenantID: 1},
+		CustomAgent: &types.CustomAgent{
+			TenantID: 1,
+			Config:   types.CustomAgentConfig{MaxIterations: 5},
+		},
+	}
+
+	agentConfig, err := svc.buildAgentConfig(t.Context(), req, &types.Tenant{ID: 1}, 1)
+	require.NoError(t, err)
+	require.False(t, agentConfig.ParallelToolCalls)
+}

--- a/internal/application/service/session_agent_qa.go
+++ b/internal/application/service/session_agent_qa.go
@@ -256,6 +256,7 @@ func (s *sessionService) buildAgentConfig(
 	customAgent := req.CustomAgent
 	agentConfig := &types.AgentConfig{
 		MaxIterations:               customAgent.Config.MaxIterations,
+		ParallelToolCalls:           customAgent.Config.ParallelToolCalls,
 		Temperature:                 customAgent.Config.Temperature,
 		WebSearchEnabled:            customAgent.Config.WebSearchEnabled && req.WebSearchEnabled,
 		WebSearchMaxResults:         customAgent.Config.WebSearchMaxResults,

--- a/internal/types/custom_agent.go
+++ b/internal/types/custom_agent.go
@@ -132,6 +132,10 @@ type CustomAgentConfig struct {
 	// ===== Agent Mode Settings =====
 	// Maximum iterations for ReAct loop (only for agent type)
 	MaxIterations int `yaml:"max_iterations" json:"max_iterations"`
+	// Whether independent tool calls in one round run concurrently (default: false).
+	// Opt-in because tools are not required to be side-effect free; agents that
+	// depend on tools observing each other's writes must leave this off.
+	ParallelToolCalls bool `yaml:"parallel_tool_calls" json:"parallel_tool_calls,omitempty"`
 	// Timeout for a single LLM call in seconds (0 = use global default)
 	LLMCallTimeout int `yaml:"llm_call_timeout" json:"llm_call_timeout,omitempty"`
 	// Allowed tools (only for agent type)


### PR DESCRIPTION
## Description

`AgentEngine.executeToolCalls` already branches to `executeToolCallsParallel` when `AgentConfig.ParallelToolCalls` is set (`internal/agent/act.go:230`), and that branch is fully implemented — errgroup, results collected in original order, siblings not cancelled on individual failure.

But nothing ever sets the flag. `buildAgentConfig` copies `CustomAgentConfig` into the runtime `AgentConfig` field by field, and this field was missing from the bridge, so the gate always read the zero value:

```
$ grep -rn "ParallelToolCalls:\|\.ParallelToolCalls =" --include=*.go internal/ | grep -v _test | grep -v chat/
internal/agent/think.go:176:  ParallelToolCalls: &parallelToolCalls,
```

That single hit is `chat.Options.ParallelToolCalls` (a `*bool` on the outbound LLM request) — a different struct. `types.AgentConfig.ParallelToolCalls` has no assignment anywhere, which makes `executeToolCallsParallel` unreachable for every custom agent.

This PR adds `ParallelToolCalls` to `CustomAgentConfig` and maps it in `buildAgentConfig`, so the existing engine capability becomes reachable.

**Defaults to false.** Tools are not required to be side-effect free, and agents that depend on tools observing each other's writes must keep running them sequentially. Turning concurrency on for already-saved agents would be a behaviour change rather than a fix, so opting in is explicit.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

None — found while reading the agent execution path.

## Testing

Go 1.26.0, `CGO_ENABLED=1`:

- `gofmt -l internal/types/custom_agent.go internal/application/service/session_agent_qa.go internal/application/service/agent_parallel_tool_calls_config_test.go` — no output
- `go vet ./internal/types/ ./internal/application/service/` — clean
- `go test ./internal/application/service/ -run ParallelToolCalls -count=1 -v` — 3 cases pass

New coverage mirrors the existing `agent_memory_config_test.go`, which guards the same class of defect (a field silently absent from `buildAgentConfig`'s field-by-field copy):

- `TestAgentConfigCarriesTheParallelToolCallsPreference` — opted in / opted out both propagate.
- `TestAgentConfigDefaultsParallelToolCallsOff` — an agent that never set the field stays sequential.

The focused packages were validated. Full-repository `make test` was not run; the change is two field additions plus their unit tests.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages pass
- [x] Diff-scoped lint passes where applicable (`go vet` for the changed packages)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (not applicable; the field is self-documenting in the config struct and defaults to existing behavior)
- [x] Breaking changes are clearly called out (none — default preserves sequential execution)

## Screenshots / Recordings

Not applicable; backend-only change. No frontend toggle is included — the field is settable through the existing agent config API. Happy to add a UI control in the agent editor if maintainers would like it in the same PR.