### PR TITLE
fix(wiki): deterministically collapse repeated blocks before persisting a page

### DIFF
--- a/internal/application/service/wiki_ingest_batch.go
+++ b/internal/application/service/wiki_ingest_batch.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -2060,11 +2061,21 @@ func (s *wikiIngestService) reduceSlugUpdates(
 			// parsed/stored, so out_links reflect real pages again.
 			updatedContent = slugHandles.decodeContent(updatedContent)
 			updatedSummary, updatedBody := splitSummaryLine(updatedContent)
-			if updatedBody != "" {
-				page.Content = updatedBody
-			} else {
-				page.Content = updatedContent
+			contentToStore := updatedBody
+			if contentToStore == "" {
+				contentToStore = updatedContent
 			}
+			// WikiPageModifyPrompt already tells the model not to restate what
+			// the page says, but instruction-following is the weakest link
+			// exactly where it matters most: on a hub page that many documents
+			// touch, the same paragraph comes back across successive batches and
+			// each round persists another copy. Collapse identical prose blocks
+			// deterministically instead of relying on the prompt to hold.
+			contentToStore, deduped := dedupeRepeatedBlocks(contentToStore)
+			if deduped > 0 {
+				logger.Infof(ctx, "wiki ingest: deduped %d repeated block(s) for slug %s", deduped, slug)
+			}
+			page.Content = contentToStore
 			if updatedSummary != "" {
 				page.Summary = updatedSummary
 			}
@@ -2143,4 +2154,93 @@ func mergeChunkRefs(current types.StringArray, additions []SlugUpdate) types.Str
 		}
 	}
 	return out
+}
+
+// wikiBlankLinePattern splits page content on blank lines, capturing the exact
+// separator so an unmodified document can be rebuilt byte-for-byte.
+var wikiBlankLinePattern = regexp.MustCompile(`(?:\r?\n)[\t ]*(?:\r?\n)+`)
+
+// minDedupeBlockRunes is the length below which a repeated block is left alone.
+// Short repeats are usually legitimate structure — a bare "---", a repeated
+// table header, a one-line list item that genuinely appears under two sections.
+// Collapsing those would corrupt the page, and they cost almost nothing to
+// keep. The duplication that actually hurts is repeated prose paragraphs.
+const minDedupeBlockRunes = 48
+
+// dedupeRepeatedBlocks removes repeated long prose blocks, leaving short blocks
+// and Markdown headings alone. Comparison is on whitespace-normalized text, so
+// a paragraph that came back with different wrapping still counts as a repeat.
+//
+// When nothing is removed the input is returned byte-for-byte — same newline
+// style, same spacing — so this is a no-op for the overwhelming majority of
+// pages and cannot churn content on its own.
+//
+// Returns the resulting content and how many blocks were dropped.
+func dedupeRepeatedBlocks(content string) (string, int) {
+	separatorIndexes := wikiBlankLinePattern.FindAllStringIndex(content, -1)
+	if len(separatorIndexes) == 0 {
+		return content, 0
+	}
+
+	blocks := make([]string, 0, len(separatorIndexes)+1)
+	separators := make([]string, 0, len(separatorIndexes))
+	start := 0
+	for _, loc := range separatorIndexes {
+		blocks = append(blocks, content[start:loc[0]])
+		separators = append(separators, content[loc[0]:loc[1]])
+		start = loc[1]
+	}
+	blocks = append(blocks, content[start:])
+
+	seen := make(map[string]struct{}, len(blocks))
+	keep := make([]bool, len(blocks))
+	removed := 0
+	for i, block := range blocks {
+		keep[i] = true
+		normalized := strings.Join(strings.Fields(block), " ")
+		if normalized == "" ||
+			utf8.RuneCountInString(normalized) < minDedupeBlockRunes ||
+			isMarkdownHeadingBlock(block) {
+			continue
+		}
+		if _, duplicate := seen[normalized]; duplicate {
+			keep[i] = false
+			removed++
+			continue
+		}
+		seen[normalized] = struct{}{}
+	}
+	if removed == 0 {
+		return content, 0
+	}
+
+	var out strings.Builder
+	wroteBlock := false
+	for i, block := range blocks {
+		if !keep[i] {
+			continue
+		}
+		if wroteBlock {
+			out.WriteString(separators[i-1])
+		}
+		out.WriteString(block)
+		wroteBlock = true
+	}
+	return out.String(), removed
+}
+
+// isMarkdownHeadingBlock reports whether a block is a single ATX heading line.
+// Headings legitimately repeat across a page ("## Sources" under several
+// sections) and dropping one would orphan everything beneath it.
+func isMarkdownHeadingBlock(block string) bool {
+	trimmed := strings.TrimSpace(strings.ReplaceAll(block, "\r\n", "\n"))
+	if trimmed == "" || strings.ContainsRune(trimmed, '\n') {
+		return false
+	}
+	hashes := 0
+	for hashes < len(trimmed) && trimmed[hashes] == '#' {
+		hashes++
+	}
+	return hashes >= 1 && hashes <= 6 && hashes < len(trimmed) &&
+		(trimmed[hashes] == ' ' || trimmed[hashes] == '\t')
 }

--- a/internal/application/service/wiki_ingest_dedupe_test.go
+++ b/internal/application/service/wiki_ingest_dedupe_test.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A hub page touched by many documents accumulates the same paragraph across
+// successive modify rounds. Headings and short blocks legitimately repeat and
+// must survive; only long prose duplicates collapse.
+func TestDedupeRepeatedBlocksCollapsesRepeatedProse(t *testing.T) {
+	longBlock := strings.Repeat("这是需要确定性去重的完整长段落。", 5)
+	input := strings.Join([]string{
+		"# 重复标题",
+		longBlock,
+		"无",
+		"# 重复标题",
+		longBlock,
+		"无",
+		longBlock,
+	}, "\n\n")
+
+	got, removed := dedupeRepeatedBlocks(input)
+
+	require.Equal(t, 2, removed)
+	require.Equal(t, 1, strings.Count(got, longBlock),
+		"repeated prose block must be collapsed to a single copy")
+	require.Equal(t, 2, strings.Count(got, "# 重复标题"),
+		"heading blocks must not be deduped")
+	require.Equal(t, 2, strings.Count(got, "\n\n无"),
+		"blocks below the length threshold must not be deduped")
+}
+
+// Matching is on whitespace-normalized text: the model frequently re-emits the
+// same paragraph with different wrapping or indentation, and that is still a
+// duplicate.
+func TestDedupeRepeatedBlocksIgnoresWhitespaceDifferences(t *testing.T) {
+	longBlock := strings.Repeat("Deterministic dedupe keeps one copy of this sentence. ", 3)
+	rewrapped := "  " + strings.Join(strings.Fields(longBlock), "   ") + "  "
+	input := strings.Join([]string{longBlock, rewrapped}, "\n\n")
+
+	got, removed := dedupeRepeatedBlocks(input)
+
+	require.Equal(t, 1, removed)
+	require.NotContains(t, got, rewrapped)
+}
+
+// The overwhelming majority of pages have no duplicates. On those the function
+// must not touch a single byte — no newline-style normalization, no trailing
+// whitespace stripping — so it can never churn content on its own.
+func TestDedupeRepeatedBlocksNoopIsByteExact(t *testing.T) {
+	input := "# 标题\r\n\r\n第一段没有重复。  \r\n\r\n- 无\r\n\r\n结尾\r\n"
+
+	got, removed := dedupeRepeatedBlocks(input)
+
+	require.Zero(t, removed)
+	require.Equal(t, []byte(input), []byte(got))
+}
+
+// Content with no blank-line separator is a single block and cannot contain a
+// repeat by this definition.
+func TestDedupeRepeatedBlocksSingleBlockIsUntouched(t *testing.T) {
+	input := strings.Repeat("one long unbroken paragraph. ", 10)
+
+	got, removed := dedupeRepeatedBlocks(input)
+
+	require.Zero(t, removed)
+	require.Equal(t, input, got)
+}
+
+// Repeats shorter than the threshold are usually real structure (a rule, a
+// repeated table header, a short list item under two sections). Dropping them
+// would corrupt the page.
+func TestDedupeRepeatedBlocksKeepsShortRepeats(t *testing.T) {
+	input := strings.Join([]string{"---", "Alpha section.", "---", "Beta section.", "---"}, "\n\n")
+
+	got, removed := dedupeRepeatedBlocks(input)
+
+	require.Zero(t, removed)
+	require.Equal(t, input, got)
+}
+
+func TestIsMarkdownHeadingBlock(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		block string
+		want  bool
+	}{
+		{name: "h1", block: "# Title", want: true},
+		{name: "h6", block: "###### Title", want: true},
+		{name: "tab after hashes", block: "#\tTitle", want: true},
+		{name: "surrounding whitespace", block: "  ## Title  ", want: true},
+		{name: "seven hashes is not a heading", block: "####### Title", want: false},
+		{name: "no space after hashes", block: "#Title", want: false},
+		{name: "hashes only", block: "###", want: false},
+		{name: "multiline is not a bare heading", block: "# Title\nbody", want: false},
+		{name: "plain prose", block: "Not a heading", want: false},
+		{name: "empty", block: "   ", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isMarkdownHeadingBlock(tc.block))
+		})
+	}
+}


### PR DESCRIPTION
## Description

`WikiPageModifyPrompt` instructs the model not to restate what a page already says. That guarantee is only as strong as the model's instruction following — and it is weakest exactly where the cost is highest.

On a hub page that many documents touch, the same paragraph comes back across successive modify rounds, and every round persists another copy. The page grows monotonically with duplicated prose, and because the duplication is *stored*, no later round removes it.

This adds a deterministic guard: after `reduceSlugUpdates` gets the model's output and splits the summary line, but before the page is written, identical prose blocks are collapsed.

### Deliberately conservative

- **Only blocks of ≥ 48 runes are considered.** Short repeats are usually real structure — a `---` rule, a repeated table header, a one-line list item that genuinely belongs under two sections. Collapsing those would corrupt the page and they cost almost nothing to keep.
- **Markdown heading blocks are exempt.** Headings legitimately repeat (`## Sources` under several sections) and dropping one would orphan everything beneath it.
- **Comparison is on whitespace-normalized text**, so the same paragraph re-emitted with different wrapping or indentation still counts as a repeat.
- **When nothing is removed the content is returned byte-for-byte** — same newline style, same trailing spaces. On a page with no duplicates this is provably a no-op and cannot churn content on its own.

No schema change, no config, no new dependency, no change to the ingest architecture.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Relates to #2232. That issue argues the Wiki self-healing design is sound but that its reliability is staked on LLM instruction following, and lists four failure points. This PR narrows one of them — the duplicate-content path — by replacing a prompt-level constraint with a structural one, which is the direction #2232 proposes. It does **not** address the other three (slug reuse hints, synthesis grounding, replace semantics), nor does it implement the unimplemented `LintIssueDuplicateSlug` detector.

## Testing

Go 1.26.0, `CGO_ENABLED=1`:

- `gofmt -l internal/application/service/wiki_ingest_batch.go internal/application/service/wiki_ingest_dedupe_test.go` — no output
- `go vet ./internal/application/service/` — clean
- `go test ./internal/application/service/ -run Wiki -count=1` — the full existing Wiki suite passes, confirming the new call site does not disturb the modify path
- `go test ./internal/application/service/ -run "Dedupe|MarkdownHeading" -count=1 -v` — 6 new cases (incl. 10 sub-cases) pass

New coverage:

- repeated prose collapses while headings and short blocks survive
- whitespace-normalized matching (same paragraph, different wrapping)
- **no-op is byte-exact**, verified by `[]byte` comparison on CRLF input with trailing spaces
- content with no blank-line separator is untouched
- short repeats below the threshold are preserved
- `isMarkdownHeadingBlock` table test: h1..h6, tab separator, surrounding whitespace, seven hashes, no space after hashes, hashes-only, multiline, plain prose, empty

The focused package was validated. Full-repository `make test` was not run; the change is one call site plus two pure functions.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages pass
- [x] Diff-scoped lint passes where applicable (`go vet` for the changed package)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (not applicable; no user-facing contract or configuration change)
- [x] Breaking changes are clearly called out (none)

## Screenshots / Recordings

Not applicable; backend-only fix.