### PR TITLE
fix(docker): copy anydoc-go go.mod before go mod download

### DIFF
--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -24,8 +24,10 @@ RUN if [ -n "$APK_MIRROR_ARG" ]; then \
 # Install migrate tool
 RUN go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
 
-# Copy go mod and sum files
+# Copy go mod files. go.mod replace-points anydoc at ./third_party/anydoc-go,
+# so that module's go.mod must exist before `go mod download`.
 COPY go.mod go.sum ./
+COPY third_party/anydoc-go/go.mod third_party/anydoc-go/go.mod
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
 COPY cmd/download cmd/download
 RUN go run cmd/download/duckdb/duckdb.go


### PR DESCRIPTION
## Summary
- `#2702` 把 `github.com/firecrawl/anydoc/go` replace 到 `./third_party/anydoc-go` 后，`Dockerfile.app` 仍只拷贝 `go.mod`/`go.sum` 就执行 `go mod download`，镜像里还没有 vendored 模块的 `go.mod`，构建失败。
- 在 `go mod download` 前拷贝 `third_party/anydoc-go/go.mod`（不拷整个目录，避免 rust 源码变动打掉依赖下载层缓存）。

## Test plan
- [ ] `docker build -f docker/Dockerfile.app .` 能过 `go mod download` 这一层
- [ ] 本地用仅含 `go.mod`、`go.sum`、`third_party/anydoc-go/go.mod` 的目录跑 `go mod download` 成功