### PR TITLE
fix(docker): 默认在 app 镜像中链接 anydoc 解析引擎

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,8 @@
 WEKNORA_VERSION=latest
 # Alpine apk 镜像源（构建 app 镜像用，留空用默认源；国内可设 mirrors.tencent.com 加速）。
 APK_MIRROR_ARG=mirrors.tencent.com
+# 构建 app 镜像时是否链接 anydoc 进程内解析引擎（默认 1）。设 0 可跳过 Rust 工具链、缩短构建时间，引擎在设置页显示为不可用。
+# WITH_ANYDOC=1
 # docreader 镜像构建时 apt 镜像源（留空用默认源）。
 # APT_MIRROR=
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -186,7 +186,7 @@ jobs:
             platform: linux/arm64
             runs: ubuntu-24.04-arm
     runs-on: ${{ matrix.runs }}
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -234,6 +234,7 @@ jobs:
             ${{ format('COMMIT_ID_ARG={0}', steps.version.outputs.commit_id) }}
             ${{ format('BUILD_TIME_ARG={0}', steps.version.outputs.build_time) }}
             ${{ format('GO_VERSION_ARG={0}', steps.version.outputs.go_version) }}
+            WITH_ANYDOC=1
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/weknora-app
           cache-from: type=gha,scope=build-app-${{ env.PLATFORM_PAIR }}

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ docker-build-app:
 		--build-arg COMMIT_ID_ARG="$$COMMIT_ID" \
 		--build-arg BUILD_TIME_ARG="$$BUILD_TIME" \
 		--build-arg GO_VERSION_ARG="$$GO_VERSION" \
+		--build-arg WITH_ANYDOC=$${WITH_ANYDOC:-1} \
 		-f docker/Dockerfile.app -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
 
 # Build docreader Docker image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       dockerfile: docker/Dockerfile.app
       args:
         - APK_MIRROR_ARG=${APK_MIRROR_ARG:-}
+        - WITH_ANYDOC=${WITH_ANYDOC:-1}
     container_name: WeKnora-app
     ports:
       - "${APP_PORT:-8080}:8080"

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -19,7 +19,7 @@ RUN if [ -n "$APK_MIRROR_ARG" ]; then \
         sed -i "s@deb.debian.org@${APK_MIRROR_ARG}@g" /etc/apt/sources.list.d/debian.sources; \
     fi && \
     apt-get update && \
-    apt-get install -y git build-essential libsqlite3-dev
+    apt-get install -y git build-essential libsqlite3-dev curl
 
 # Install migrate tool
 RUN go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
@@ -45,15 +45,16 @@ ENV COMMIT_ID=${COMMIT_ID_ARG}
 ENV BUILD_TIME=${BUILD_TIME_ARG}
 ENV GO_VERSION=${GO_VERSION_ARG}
 
-# Optional: link the anydoc parser engine, which converts office documents in
-# the Go process instead of the Python docreader. It is off by default because
-# it needs a Rust toolchain (a few minutes and ~1 GB of build-stage layers) for
-# an engine most deployments do not select.
-#   docker build --build-arg WITH_ANYDOC=1 ...
-ARG WITH_ANYDOC=0
+# Link the anydoc parser engine (office docs converted in-process, no
+# Python docreader). Default on so Hub / compose images ship a working
+# engine; pass WITH_ANYDOC=0 to skip the Rust toolchain (~few minutes and
+# ~1 GB of build-stage layers).
+ARG WITH_ANYDOC=1
 ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo
 ENV PATH=/usr/local/cargo/bin:$PATH
-RUN if [ "$WITH_ANYDOC" = "1" ]; then \
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    if [ "$WITH_ANYDOC" = "1" ]; then \
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
             | sh -s -- -y --profile minimal --default-toolchain stable && \
         ./scripts/build-anydoc-lib.sh; \

--- a/internal/infrastructure/docparser/anydoc/backend_stub.go
+++ b/internal/infrastructure/docparser/anydoc/backend_stub.go
@@ -8,7 +8,8 @@ package anydoc
 // registry simply reports the engine as unavailable.
 
 const unavailableReason = "anydoc engine not built into this binary " +
-	"(rebuild with `make build-anydoc` / `-tags anydoc`)"
+	"(rebuild with `make build-anydoc` / `-tags anydoc`; " +
+	"Docker images need `--build-arg WITH_ANYDOC=1`)"
 
 func backendAvailable() bool { return false }
 

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -142,6 +142,7 @@ build_app_image() {
         --build-arg COMMIT_ID_ARG="$COMMIT_ID" \
         --build-arg BUILD_TIME_ARG="$BUILD_TIME" \
         --build-arg GO_VERSION_ARG="$GO_VERSION" \
+        --build-arg WITH_ANYDOC=${WITH_ANYDOC:-1} \
         -f docker/Dockerfile.app \
         -t wechatopenai/weknora-app:latest \
         .

--- a/website-docs/01-getting-started/02-installation.md
+++ b/website-docs/01-getting-started/02-installation.md
@@ -127,7 +127,7 @@ make dev-logs / dev-status / dev-stop / dev-restart
 
 | Dockerfile | 产物镜像 | 要点 |
 | --- | --- | --- |
-| `docker/Dockerfile.app` | `wechatopenai/weknora-app` | 两阶段：`golang:1.26-bookworm` 编译（`make build-prod`，注入版本信息，预下载 DuckDB 扩展 `cmd/download/duckdb`）→ `debian:12.12-slim` 运行层（含 `migrate` 迁移工具、python3/node/uvx（供 stdio MCP 与 Skills 使用）、ffmpeg（ASR）、gosu 降权）。入口 `scripts/docker-entrypoint.sh`：修复挂载目录属主、把 `_builtin` 内置 Skills 合并回 `skills/preloaded`，再以 appuser 运行 `./WeKnora`。`EXPOSE 8080` |
+| `docker/Dockerfile.app` | `wechatopenai/weknora-app` | 两阶段：`golang:1.26-bookworm` 编译（`make build-prod`，默认 `WITH_ANYDOC=1` 链接进程内 office 解析引擎，注入版本信息，预下载 DuckDB 扩展 `cmd/download/duckdb`）→ `debian:12.12-slim` 运行层（含 `migrate` 迁移工具、python3/node/uvx（供 stdio MCP 与 Skills 使用）、ffmpeg（ASR）、gosu 降权）。入口 `scripts/docker-entrypoint.sh`：修复挂载目录属主、把 `_builtin` 内置 Skills 合并回 `skills/preloaded`，再以 appuser 运行 `./WeKnora`。`EXPOSE 8080` |
 | `docker/Dockerfile.docreader` | `wechatopenai/weknora-docreader` | Python 3.10 + uv 依赖锁定；生成 protobuf；运行层安装 LibreOffice、OpenJDK 17、antiword、Playwright（webkit）与 `grpc_health_probe`。轻量版不含 PaddleOCR。`EXPOSE 50051`。支持 `APT_MIRROR` 构建参数 |
 | `docker/Dockerfile.odl-hybrid` | `weknora-odl-hybrid:local` | 安装 `opendataloader-pdf[hybrid]`（Docling），监听 5002，默认 `--no-ocr`；仅本地构建不发布 |
 | `docker/Dockerfile.sandbox` | `wechatopenai/weknora-sandbox` | Python 3.11-slim + Node 20 + jq，非 root 用户 `sandbox`(UID 1000)，供 Agent Skills 脚本在一次性容器中执行 |

--- a/website-docs/03-features/03-document-parsing.md
+++ b/website-docs/03-features/03-document-parsing.md
@@ -408,7 +408,7 @@ Python 依赖（`pyproject.toml` + `uv.lock` 锁定）：`grpcio`、`pypdfium2`�
 
 ### 8.1 启用方式
 
-解析库是 Rust 静态库，需要 Rust 工具链构建，因此默认不链接：未启用时该引擎在「解析引擎」列表里显示为不可用，并给出提示，其它引擎不受影响。
+解析库是 Rust 静态库，需要 Rust 工具链构建。官方 Docker 镜像（`wechatopenai/weknora-app`）和 `docker compose build` **默认链接** anydoc，设置页可直接选用。本地 `go build` 默认不链接：未加 `-tags anydoc` 时该引擎在「解析引擎」列表里显示为不可用，其它引擎不受影响。
 
 ```bash
 make build-anydoc                  # 构建静态库 + 带 anydoc 标签的二进制
@@ -416,10 +416,11 @@ make build-anydoc                  # 构建静态库 + 带 anydoc 标签的二�
 scripts/build-anydoc-lib.sh && go build -tags anydoc ./cmd/server
 ```
 
-Docker 镜像：
+Docker 镜像默认 `WITH_ANYDOC=1`。若要跳过 Rust 工具链、缩短构建：
 
 ```bash
-docker build -f docker/Dockerfile.app --build-arg WITH_ANYDOC=1 -t weknora-app:anydoc .
+docker build -f docker/Dockerfile.app --build-arg WITH_ANYDOC=0 -t weknora-app .
+# 或在 .env 里设 WITH_ANYDOC=0 再 docker compose build
 ```
 
 启用后在知识库的解析设置里把对应文件类型指向 `anydoc` 引擎即可。


### PR DESCRIPTION
## Summary
- `#2702` 把 anydoc 做成可选编译（`-tags anydoc`），但 `Dockerfile.app` 的 `WITH_ANYDOC` 默认是 0，Hub CI / compose / Makefile 都没传这个参数，打包出来的 `wechatopenai/weknora-app` 是 stub，设置页显示 “anydoc engine not built into this binary”。
- 将 `WITH_ANYDOC` 默认改为 1，使官方镜像和 `docker compose build` 带上进程内 office 解析引擎；`--build-arg WITH_ANYDOC=0` 仍可跳过 Rust 工具链。
- builder 补装 `curl`（rustup 需要），CI app 构建超时从 45 提到 60 分钟。

## Test plan
- [ ] `docker compose build app` 能完成 rustup + `build-anydoc-lib.sh` + `make build-prod GO_BUILD_TAGS=anydoc`
- [ ] 新镜像启动后，设置 → 解析引擎里 anydoc 显示为可用
- [ ] `WITH_ANYDOC=0 docker compose build app` 仍能构建，anydoc 显示不可用
- [ ] 合入后等 Hub 重新推送 `wechatopenai/weknora-app`，再 `docker compose pull` 验证官方镜像