### PR TITLE
fix(frontend): isolate markdown preview renderers

### DIFF
--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -892,8 +892,10 @@ const processMarkdown = (markdownText) => {
   const safeMarkdown = safeMarkdownToHTML(mathSafeText);
 
   // 使用标记渲染
-  marked.use({ renderer });
-  let html = marked.parse(safeMarkdown) as string;
+  // Do not register this renderer globally. DocumentPreview uses the same
+  // `marked` module; registering here made its later Markdown preview reuse
+  // this image validator after the user had opened the chunk view.
+  let html = marked.parse(safeMarkdown, { renderer }) as string;
 
   // 还原被转义的 <br>
   html = html.replace(/&lt;br\s*\/?&gt;/gi, '<br>');

--- a/frontend/src/components/document-preview.vue
+++ b/frontend/src/components/document-preview.vue
@@ -239,10 +239,11 @@ async function renderMarkdown(blob: Blob) {
     }
     return `<pre><code class="hljs">${highlighted}</code></pre>`;
   };
-  marked.use({ renderer });
   const mathSafeText = preprocessMathDelimiters(text);
   const safeText = safeMarkdownToHTML(mathSafeText);
-  const rawHtml = marked.parse(safeText) as string;
+  // Keep this renderer local. `marked.use` mutates a shared singleton and
+  // would otherwise inherit renderers installed by the chunk-content view.
+  const rawHtml = marked.parse(safeText, { renderer }) as string;
   markdownHtml.value = sanitizeHTML(rawHtml);
 }
 


### PR DESCRIPTION
## Summary

- isolate the chunk-detail Markdown renderer instead of registering it on the shared `marked` singleton
- keep the file-preview renderer local as well

## Root cause

Opening **View chunks** called `marked.use({ renderer })` from `doc-content.vue`. `marked` is a module-level singleton, so the renderer's image URL validator remained active when the user returned to the raw Markdown file preview. Inline `data:image/...` image URLs were then rendered as "Invalid image link" despite the preview working after a page refresh.

Passing the renderer through `marked.parse(..., { renderer })` keeps each rendering path isolated and makes the sequence `Preview -> View chunks -> Preview` stable.

## Validation

- confirmed Tencent/WeKnora `main` still had both global renderer registrations
- ran `git diff --check`

