### PR TITLE
perf(agent): make knowledge_search MMR selection incremental

### DIFF
--- a/internal/agent/tools/knowledge_search.go
+++ b/internal/agent/tools/knowledge_search.go
@@ -1540,23 +1540,20 @@ func (t *KnowledgeSearchTool) applyMMR(
 		tokenSets[i] = t.tokenizeSimple(t.getEnrichedPassage(ctx, r.SearchResult))
 	}
 
-	// MMR selection loop
+	// MMR selection loop, incremental form: maxRedundancy[i] caches candidate i's
+	// maximum jaccard against everything selected so far, so each round only needs
+	// one comparison per remaining candidate instead of one per (candidate, selected)
+	// pair. Selection output is identical to the naive form, including tie-breaking,
+	// because the candidate iteration order is unchanged.
+	selectedTokenSets := make([]map[string]struct{}, 0, k)
+	maxRedundancy := make([]float64, len(candidates))
 	for len(selected) < k && len(candidates) > 0 {
 		bestIdx := 0
 		bestScore := -1.0
 
 		for i, r := range candidates {
-			relevance := r.Score
-			redundancy := 0.0
-
-			// Calculate maximum redundancy with already selected results
-			for _, s := range selected {
-				selectedTokens := t.tokenizeSimple(t.getEnrichedPassage(ctx, s.SearchResult))
-				redundancy = math.Max(redundancy, t.jaccard(tokenSets[i], selectedTokens))
-			}
-
 			// MMR score: balance relevance and diversity
-			mmr := lambda*relevance - (1.0-lambda)*redundancy
+			mmr := lambda*r.Score - (1.0-lambda)*maxRedundancy[i]
 			if mmr > bestScore {
 				bestScore = mmr
 				bestIdx = i
@@ -1565,20 +1562,27 @@ func (t *KnowledgeSearchTool) applyMMR(
 
 		// Add best candidate to selected and remove from candidates
 		selected = append(selected, candidates[bestIdx])
+		chosenTokens := tokenSets[bestIdx]
+		selectedTokenSets = append(selectedTokenSets, chosenTokens)
 		candidates = append(candidates[:bestIdx], candidates[bestIdx+1:]...)
-		// Remove corresponding token set
+		// Remove corresponding token set and cached redundancy
 		tokenSets = append(tokenSets[:bestIdx], tokenSets[bestIdx+1:]...)
+		maxRedundancy = append(maxRedundancy[:bestIdx], maxRedundancy[bestIdx+1:]...)
+
+		// Fold the freshly selected result into every remaining candidate's cache
+		for i := range candidates {
+			maxRedundancy[i] = math.Max(maxRedundancy[i], t.jaccard(tokenSets[i], chosenTokens))
+		}
 	}
 
-	// Compute average redundancy among selected results
+	// Compute average redundancy among selected results, reusing the cached token
+	// sets instead of re-tokenizing every pair
 	avgRed := 0.0
-	if len(selected) > 1 {
+	if len(selectedTokenSets) > 1 {
 		pairs := 0
-		for i := 0; i < len(selected); i++ {
-			for j := i + 1; j < len(selected); j++ {
-				si := t.tokenizeSimple(t.getEnrichedPassage(ctx, selected[i].SearchResult))
-				sj := t.tokenizeSimple(t.getEnrichedPassage(ctx, selected[j].SearchResult))
-				avgRed += t.jaccard(si, sj)
+		for i := 0; i < len(selectedTokenSets); i++ {
+			for j := i + 1; j < len(selectedTokenSets); j++ {
+				avgRed += t.jaccard(selectedTokenSets[i], selectedTokenSets[j])
 				pairs++
 			}
 		}

--- a/internal/agent/tools/knowledge_search_mmr_test.go
+++ b/internal/agent/tools/knowledge_search_mmr_test.go
@@ -1,0 +1,165 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// applyMMRNaive is the pre-optimization form of applyMMR: it recomputes the
+// redundancy of every candidate against every already-selected result on each
+// round, re-tokenizing the selected passages every time. It is kept here purely
+// as the reference oracle for the incremental implementation.
+func (t *KnowledgeSearchTool) applyMMRNaive(
+	ctx context.Context,
+	results []*searchResultWithMeta,
+	k int,
+	lambda float64,
+) []*searchResultWithMeta {
+	if k <= 0 || len(results) == 0 {
+		return nil
+	}
+
+	selected := make([]*searchResultWithMeta, 0, k)
+	candidates := make([]*searchResultWithMeta, len(results))
+	copy(candidates, results)
+
+	tokenSets := make([]map[string]struct{}, len(candidates))
+	for i, r := range candidates {
+		tokenSets[i] = t.tokenizeSimple(t.getEnrichedPassage(ctx, r.SearchResult))
+	}
+
+	for len(selected) < k && len(candidates) > 0 {
+		bestIdx := 0
+		bestScore := -1.0
+
+		for i, r := range candidates {
+			relevance := r.Score
+			redundancy := 0.0
+			for _, s := range selected {
+				selectedTokens := t.tokenizeSimple(t.getEnrichedPassage(ctx, s.SearchResult))
+				redundancy = math.Max(redundancy, t.jaccard(tokenSets[i], selectedTokens))
+			}
+			mmr := lambda*relevance - (1.0-lambda)*redundancy
+			if mmr > bestScore {
+				bestScore = mmr
+				bestIdx = i
+			}
+		}
+
+		selected = append(selected, candidates[bestIdx])
+		candidates = append(candidates[:bestIdx], candidates[bestIdx+1:]...)
+		tokenSets = append(tokenSets[:bestIdx], tokenSets[bestIdx+1:]...)
+	}
+
+	return selected
+}
+
+// mmrTestCorpus builds a deterministic candidate set whose passages share
+// vocabulary in overlapping bands, so redundancy actually drives selection
+// instead of the score alone.
+func mmrTestCorpus(n int) []*searchResultWithMeta {
+	vocab := []string{
+		"insurance", "policy", "claim", "premium", "deductible", "liability",
+		"coverage", "endorsement", "underwriting", "reinsurance", "subrogation",
+		"indemnity", "exclusion", "rider", "annuity",
+	}
+
+	results := make([]*searchResultWithMeta, 0, n)
+	// Simple LCG so the corpus is identical on every run and every platform.
+	state := uint64(42)
+	next := func(mod int) int {
+		state = state*6364136223846793005 + 1442695040888963407
+		return int((state >> 33) % uint64(mod))
+	}
+
+	for i := 0; i < n; i++ {
+		words := make([]byte, 0, 128)
+		for j := 0; j < 12; j++ {
+			words = append(words, vocab[next(len(vocab))]...)
+			words = append(words, ' ')
+		}
+		content := fmt.Sprintf("chunk %d %s", i, string(words))
+		results = append(results, &searchResultWithMeta{
+			SearchResult: &types.SearchResult{
+				ID:          fmt.Sprintf("chunk-%03d", i),
+				Content:     content,
+				KnowledgeID: fmt.Sprintf("doc-%d", i%7),
+				// Scores intentionally collide across candidates so the
+				// tie-breaking path is exercised too.
+				Score: float64(next(20)) / 20.0,
+			},
+			QueryType:       "vector",
+			KnowledgeBaseID: "kb-1",
+		})
+	}
+	return results
+}
+
+func TestApplyMMR_matchesNaiveSelection(t *testing.T) {
+	t.Parallel()
+
+	tool := &KnowledgeSearchTool{}
+	ctx := context.Background()
+	results := mmrTestCorpus(40)
+
+	for _, tc := range []struct {
+		k      int
+		lambda float64
+	}{
+		{k: 1, lambda: 0.7},
+		{k: 5, lambda: 0.7},
+		{k: 12, lambda: 0.3},
+		{k: 40, lambda: 0.9},
+		{k: 60, lambda: 0.5}, // k larger than the candidate count
+	} {
+		tc := tc
+		t.Run(fmt.Sprintf("k=%d/lambda=%.1f", tc.k, tc.lambda), func(t *testing.T) {
+			want := tool.applyMMRNaive(ctx, results, tc.k, tc.lambda)
+			got := tool.applyMMR(ctx, results, tc.k, tc.lambda)
+
+			if len(got) != len(want) {
+				t.Fatalf("selected %d results, naive selected %d", len(got), len(want))
+			}
+			for i := range want {
+				if got[i].ID != want[i].ID {
+					t.Fatalf("rank %d: got %s, naive got %s", i, got[i].ID, want[i].ID)
+				}
+			}
+		})
+	}
+}
+
+func TestApplyMMR_emptyAndNonPositiveK(t *testing.T) {
+	t.Parallel()
+
+	tool := &KnowledgeSearchTool{}
+	ctx := context.Background()
+
+	if got := tool.applyMMR(ctx, mmrTestCorpus(3), 0, 0.7); got != nil {
+		t.Fatalf("expected nil for k=0, got %d results", len(got))
+	}
+	if got := tool.applyMMR(ctx, nil, 5, 0.7); got != nil {
+		t.Fatalf("expected nil for empty candidates, got %d results", len(got))
+	}
+}
+
+func BenchmarkApplyMMR(b *testing.B) {
+	tool := &KnowledgeSearchTool{}
+	ctx := context.Background()
+	results := mmrTestCorpus(250)
+
+	b.Run("incremental", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			tool.applyMMR(ctx, results, 250, 0.7)
+		}
+	})
+	b.Run("naive", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			tool.applyMMRNaive(ctx, results, 250, 0.7)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

`applyMMR` in `internal/agent/tools/knowledge_search.go` recomputes each candidate's redundancy against **every already-selected result on every round**, re-tokenizing the selected passages each time:

```go
for i, r := range candidates {
    for _, s := range selected {
        selectedTokens := t.tokenizeSimple(t.getEnrichedPassage(ctx, s.SearchResult))
        redundancy = math.Max(redundancy, t.jaccard(tokenSets[i], selectedTokens))
    }
}
```

With `C` candidates and `k` selections that is `O(k^2)` calls to `getEnrichedPassage` + `tokenizeSimple` over full chunk bodies. `k` is `len(filteredResults)` at the call site, so this is quadratic in the number of results that survive dedup/rerank. The diagnostic average-redundancy loop right after re-tokenizes another `O(k^2)` times.

This is pure CPU burned inside every `knowledge_search` call, and no log line attributes it — on our deployment ~250 candidates commonly reach the MMR stage and the stage cost was tens of seconds, invisible next to the (correctly logged) retrieval and rerank stages.

## Change

Standard incremental MMR: cache each candidate's running max jaccard against the selected set, and fold in only the newly selected result once per round. The average-redundancy diagnostic reuses the token sets that were already computed. Tokenization now happens exactly once per candidate.

Selection output is **unchanged**, including tie-breaking, because the candidate iteration order and the comparison are the same.

## Verification

- New `TestApplyMMR_matchesNaiveSelection` keeps a copy of the previous implementation as an oracle and asserts identical selection over a deterministic corpus (deliberately colliding scores so the tie-breaking path is exercised) for k = 1, 5, 12, 40 and k > len(candidates).
- `BenchmarkApplyMMR`, 250 candidates, k = 250, short synthetic passages (real chunks are far longer, so the real-world gap is wider):

  ```
  BenchmarkApplyMMR/incremental-16    18,215,374 ns/op
  BenchmarkApplyMMR/naive-16       4,984,845,812 ns/op
  ```

- `gofmt`, `go vet ./internal/agent/tools/` and `go test ./internal/agent/tools/` all clean (go 1.26).