### PR TITLE
fix(session): bound the auto-generated session title to fit the column

### DIFF
--- a/internal/application/service/session.go
+++ b/internal/application/service/session.go
@@ -704,6 +704,26 @@ func (s *sessionService) destroyBoundSandbox(ctx context.Context, sessionID stri
 	}
 }
 
+// maxSessionTitleRunes bounds the auto-generated session title. sessions.title
+// is VARCHAR(255) in every shipped migration, so an over-long model response
+// would be rejected by the database; 100 runes stays well clear of that limit
+// while still being a reasonable title length in the UI.
+const maxSessionTitleRunes = 100
+
+// sanitizeGeneratedTitle turns a raw title completion into something safe to
+// persist: the reasoning prefix some models emit is dropped, surrounding
+// whitespace is trimmed, and the result is truncated by rune (not byte) so a
+// multi-byte character is never cut in half. It reports whether truncation
+// happened so the caller can log it.
+func sanitizeGeneratedTitle(raw string) (string, bool) {
+	title := strings.TrimSpace(strings.TrimPrefix(raw, "<think>\n\n</think>"))
+	runes := []rune(title)
+	if len(runes) <= maxSessionTitleRunes {
+		return title, false
+	}
+	return strings.TrimSpace(string(runes[:maxSessionTitleRunes])), true
+}
+
 // GenerateTitle generates a title for the current conversation content
 // modelID: optional model ID to use for title generation (if empty, uses first available KnowledgeQA model)
 func (s *sessionService) GenerateTitle(ctx context.Context,
@@ -801,7 +821,14 @@ func (s *sessionService) GenerateTitle(ctx context.Context,
 	}
 
 	// Process and store the generated title
-	session.Title = strings.TrimPrefix(response.Content, "<think>\n\n</think>")
+	title, truncated := sanitizeGeneratedTitle(response.Content)
+	if truncated {
+		logger.Warnf(ctx,
+			"Generated session title exceeded %d runes and was truncated, session=%s, model=%s",
+			maxSessionTitleRunes, session.ID, modelID,
+		)
+	}
+	session.Title = title
 
 	// Update session with new title
 	_, err = s.sessionRepo.Update(ctx, session, session.UserID)

--- a/internal/application/service/session_title_test.go
+++ b/internal/application/service/session_title_test.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeGeneratedTitle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		raw           string
+		want          string
+		wantTruncated bool
+	}{
+		{
+			name: "plain title is kept as is",
+			raw:  "保单理赔流程咨询",
+			want: "保单理赔流程咨询",
+		},
+		{
+			name: "thinking prefix and surrounding whitespace are dropped",
+			raw:  "<think>\n\n</think>  Claim filing steps \n",
+			want: "Claim filing steps",
+		},
+		{
+			name:          "over-long ascii title is truncated",
+			raw:           strings.Repeat("a", 300),
+			want:          strings.Repeat("a", maxSessionTitleRunes),
+			wantTruncated: true,
+		},
+		{
+			name:          "over-long cjk title is truncated by rune, not byte",
+			raw:           strings.Repeat("保", 300),
+			want:          strings.Repeat("保", maxSessionTitleRunes),
+			wantTruncated: true,
+		},
+		{
+			name: "title exactly at the limit is not truncated",
+			raw:  strings.Repeat("保", maxSessionTitleRunes),
+			want: strings.Repeat("保", maxSessionTitleRunes),
+		},
+		{
+			name: "empty completion stays empty",
+			raw:  "   ",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, truncated := sanitizeGeneratedTitle(tt.raw)
+			if got != tt.want {
+				t.Fatalf("title = %q, want %q", got, tt.want)
+			}
+			if truncated != tt.wantTruncated {
+				t.Fatalf("truncated = %v, want %v", truncated, tt.wantTruncated)
+			}
+			if len([]rune(got)) > maxSessionTitleRunes {
+				t.Fatalf("title still exceeds %d runes: %d", maxSessionTitleRunes, len([]rune(got)))
+			}
+		})
+	}
+}
+
+// The database column is VARCHAR(255) in every shipped migration; guard the
+// constant so nobody raises it past what the column can hold.
+func TestMaxSessionTitleRunesFitsColumn(t *testing.T) {
+	t.Parallel()
+	// Worst case for UTF-8 is 4 bytes per rune, but the column counts characters
+	// in PostgreSQL and bytes in some engines, so keep a conservative bound.
+	if maxSessionTitleRunes > 255 {
+		t.Fatalf("maxSessionTitleRunes=%d exceeds the sessions.title column limit", maxSessionTitleRunes)
+	}
+}


### PR DESCRIPTION
## Problem

`GenerateTitle` writes the model completion straight into `sessions.title`:

```go
session.Title = strings.TrimPrefix(response.Content, "<think>\n\n</think>")
```

`sessions.title` is `VARCHAR(255)` in every shipped migration (`migrations/paradedb/00-init-db.sql`, `migrations/mysql/00-init-db.sql`, `migrations/sqlite/000000_init.up.sql`). When the model ignores the "short title" instruction and returns the title plus an explanation, the following `sessionRepo.Update` fails with `value too long for type character varying(255) (SQLSTATE 22001)` and the session silently ends up with no title.

The failure mode is easy to miss: the error only reaches the log, the answer itself is unaffected, and the user just sees an untitled conversation. We hit this in production after picking up the conversation-title feature.

## Change

Extract a small pure helper, `sanitizeGeneratedTitle`, that:

- drops the reasoning prefix and surrounding whitespace (previous behavior, plus the trim);
- truncates to 100 runes — well clear of the column limit and still a reasonable title length in the UI;
- truncates **by rune, not byte**, so a multi-byte character is never cut in half;
- reports whether it truncated, so the caller can log a warning and the prompt can be revisited.

## Verification

- New `TestSanitizeGeneratedTitle` covers: plain title untouched, reasoning prefix and whitespace trimmed, over-long ASCII truncated, over-long CJK truncated by rune (not byte), exactly-at-limit not truncated, empty completion stays empty.
- `TestMaxSessionTitleRunesFitsColumn` guards the constant against being raised past what the column can hold.
- `gofmt`, `go vet ./internal/application/service/` and `go test ./internal/application/service/` all clean (go 1.26).