### PR TITLE
fix: sanitize NUL bytes in chunk context header

### DIFF
--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -42,6 +42,7 @@ func NewChunkRepository(db *gorm.DB) interfaces.ChunkRepository {
 func (r *chunkRepository) CreateChunks(ctx context.Context, chunks []*types.Chunk) error {
 	for _, chunk := range chunks {
 		chunk.Content = common.CleanInvalidUTF8(chunk.Content)
+		chunk.ContextHeader = common.CleanInvalidUTF8(chunk.ContextHeader)
 		if chunk.SourceContent == "" {
 			chunk.SourceContent = chunk.Content
 		}

--- a/internal/application/repository/chunk_sqlite_test.go
+++ b/internal/application/repository/chunk_sqlite_test.go
@@ -197,6 +197,26 @@ func TestCreateChunks_SQLite_SeqIDAfterSoftDelete(t *testing.T) {
 	assert.Equal(t, int64(5), saved[1].SeqID)
 }
 
+func TestCreateChunks_SQLite_SanitizesContextHeaderNULBytes(t *testing.T) {
+	db := setupChunkTestDB(t)
+	repo := NewChunkRepository(db)
+	ctx := context.Background()
+
+	kbID := uuid.New().String()
+	knowledgeID := uuid.New().String()
+
+	chunk := makeChunk(kbID, knowledgeID, "text")
+	chunk.Content = "content\x00 with NUL"
+	chunk.ContextHeader = "# Header\x00 with NUL"
+
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{chunk}))
+
+	var saved types.Chunk
+	require.NoError(t, db.Where("id = ?", chunk.ID).First(&saved).Error)
+	assert.Equal(t, "content with NUL", saved.Content)
+	assert.Equal(t, "# Header with NUL", saved.ContextHeader)
+}
+
 func TestUpdateChunk_SQLite_NoNOWError(t *testing.T) {
 	db := setupChunkTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Description

`CreateChunks` sanitizes `Chunk.Content` with `common.CleanInvalidUTF8` but leaves `Chunk.ContextHeader` untouched. PDFs whose text layer contains embedded NUL bytes (`0x00`) can propagate them into the context header, and PostgreSQL then rejects the batch insert with `invalid byte sequence for encoding "UTF8": 0x00` (SQLSTATE 22021).

This change applies the same sanitization to `ContextHeader`.

## Type of Change
- [x] 🐛 Bug fix

## Related Issue
Fixes #2700

## Testing

Added `TestCreateChunks_SQLite_SanitizesContextHeaderNULBytes`, which inserts a chunk whose `Content` and `ContextHeader` contain NUL bytes and asserts the persisted values are sanitized.

- `go build ./internal/application/repository/` passes
- `gofmt -l` reports no changes
- `go vet ./internal/application/repository/` passes
- `git diff --check` passes

Note: running the test suite locally on Windows (`go test ./internal/application/repository/`) crashes with a heap corruption (`0xc0000374`) in the sqlite CGo driver before tests complete. This reproduces on unmodified code (e.g. `TestCreateChunks_SQLite_SeqIDAutoAssigned`), so it is an environment issue rather than related to this change.

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Added/updated tests covering the change
- [x] Self-reviewed the code
