### PR TITLE
fix: stop deleted images and stale summaries from being retrieved

### DIFF
--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -2340,26 +2340,51 @@ func (s *knowledgeService) RegenerateKnowledgeSummary(
 		return nil, err
 	}
 	if kb.NeedsEmbeddingModel() {
-		found := false
 		maxIndex := 0
-		summaryChunks := make([]*types.Chunk, 0, 1)
-		for _, chunk := range allChunks {
+		textChunkIDs := make([]string, 0, len(textChunks))
+		for _, chunk := range textChunks {
 			if chunk.ChunkIndex > maxIndex {
 				maxIndex = chunk.ChunkIndex
 			}
-			if chunk.ChunkType == types.ChunkTypeSummary {
-				chunk.Content = "# Summary\n" + summary
-				chunk.SourceContent = chunk.Content
-				chunk.IsEnabled = true
-				chunk.UpdatedAt = time.Now()
-				if err := s.chunkRepo.UpdateChunk(ctx, chunk); err != nil {
-					return nil, err
-				}
-				summaryChunks = append(summaryChunks, chunk)
-				found = true
+			textChunkIDs = append(textChunkIDs, chunk.ID)
+		}
+
+		// The summary chunk is stored as a child of the first text chunk.
+		// ListChunksByKnowledgeID only returns text chunks, so scanning
+		// allChunks for it can never find the summary and every refresh used to
+		// create a duplicate. Resolve it through its parent instead, keep one,
+		// and disable any leftovers from earlier refreshes so their vectors are
+		// dropped by updateChunkVector rather than kept retrievable.
+		summaryChunks := make([]*types.Chunk, 0, 1)
+		children, err := s.chunkRepo.ListChunksByParentIDs(ctx, tenantID, textChunkIDs)
+		if err != nil {
+			return nil, err
+		}
+		var existingSummary *types.Chunk
+		var staleSummaries []*types.Chunk
+		for _, child := range children {
+			if child.ChunkType != types.ChunkTypeSummary {
+				continue
+			}
+			if existingSummary == nil {
+				existingSummary = child
+			} else {
+				staleSummaries = append(staleSummaries, child)
 			}
 		}
-		if !found {
+
+		if existingSummary != nil {
+			existingSummary.Content = "# Summary\n" + summary
+			existingSummary.SourceContent = existingSummary.Content
+			existingSummary.ParentChunkID = textChunks[0].ID
+			existingSummary.ChunkIndex = maxIndex + 1
+			existingSummary.IsEnabled = true
+			existingSummary.UpdatedAt = time.Now()
+			if err := s.chunkRepo.UpdateChunk(ctx, existingSummary); err != nil {
+				return nil, err
+			}
+			summaryChunks = append(summaryChunks, existingSummary)
+		} else {
 			summaryChunk := &types.Chunk{
 				ID: uuid.NewString(), TenantID: tenantID, KnowledgeID: knowledge.ID,
 				KnowledgeBaseID: knowledge.KnowledgeBaseID, Content: "# Summary\n" + summary,
@@ -2371,6 +2396,19 @@ func (s *knowledgeService) RegenerateKnowledgeSummary(
 			}
 			summaryChunks = append(summaryChunks, summaryChunk)
 		}
+
+		// Disable duplicate summary chunks left behind by previous refreshes.
+		for _, stale := range staleSummaries {
+			if stale.IsEnabled {
+				stale.IsEnabled = false
+				stale.UpdatedAt = time.Now()
+				if err := s.chunkRepo.UpdateChunk(ctx, stale); err != nil {
+					return nil, err
+				}
+			}
+			summaryChunks = append(summaryChunks, stale)
+		}
+
 		if err := s.updateChunkVector(ctx, knowledge.KnowledgeBaseID, summaryChunks); err != nil {
 			return nil, err
 		}
@@ -2973,6 +3011,7 @@ func (s *knowledgeService) UpdateImageInfo(
 			ChunkType:       types.ChunkTypeImageCaption,
 			ParentChunkID:   chunk.ID,
 			ImageInfo:       imageInfo,
+			IsEnabled:       true,
 		}
 		addChunk = append(addChunk, captionChunk)
 		logger.Infof(ctx, "Created new caption chunk ID: %s for image URL: %s", captionChunk.ID, image.OriginalURL)
@@ -2989,6 +3028,7 @@ func (s *knowledgeService) UpdateImageInfo(
 			ChunkType:       types.ChunkTypeImageOCR,
 			ParentChunkID:   chunk.ID,
 			ImageInfo:       imageInfo,
+			IsEnabled:       true,
 		}
 		addChunk = append(addChunk, ocrChunk)
 		logger.Infof(ctx, "Created new OCR chunk ID: %s for image URL: %s", ocrChunk.ID, image.OriginalURL)

--- a/internal/searchutil/imageinfo.go
+++ b/internal/searchutil/imageinfo.go
@@ -68,6 +68,9 @@ func CollectImageInfoByChunkIDs(
 	aggMap := make(map[string]*imageAgg)
 
 	addInfo := func(targetID string, child *types.Chunk) {
+		if !child.IsEnabled {
+			return
+		}
 		if child.ImageInfo == "" {
 			return
 		}

--- a/internal/searchutil/imageinfo_collect_test.go
+++ b/internal/searchutil/imageinfo_collect_test.go
@@ -1,0 +1,74 @@
+package searchutil
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+// stubChunkRepo embeds the ChunkRepository interface so only the method under
+// test needs a concrete implementation. CollectImageInfoByChunkIDs only calls
+// ListChunksByParentIDs.
+type stubChunkRepo struct {
+	interfaces.ChunkRepository
+	children map[string][]*types.Chunk
+}
+
+func (s stubChunkRepo) ListChunksByParentIDs(
+	_ context.Context, _ uint64, parentIDs []string,
+) ([]*types.Chunk, error) {
+	var out []*types.Chunk
+	for _, id := range parentIDs {
+		out = append(out, s.children[id]...)
+	}
+	return out, nil
+}
+
+func collectImageInfoJSON(t *testing.T, url string) string {
+	t.Helper()
+	raw, err := json.Marshal([]types.ImageInfo{{URL: url, OCRText: "ocr", Caption: "caption"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+func TestCollectImageInfoByChunkIDs_ExcludesDisabledImages(t *testing.T) {
+	repo := stubChunkRepo{children: map[string][]*types.Chunk{
+		"text-1": {
+			{
+				ID:            "ocr-enabled",
+				ChunkType:     types.ChunkTypeImageOCR,
+				ParentChunkID: "text-1",
+				ImageInfo:     collectImageInfoJSON(t, "enabled.jpg"),
+				IsEnabled:     true,
+			},
+			{
+				ID:            "ocr-disabled",
+				ChunkType:     types.ChunkTypeImageOCR,
+				ParentChunkID: "text-1",
+				ImageInfo:     collectImageInfoJSON(t, "disabled.jpg"),
+				IsEnabled:     false,
+			},
+		},
+	}}
+
+	got := CollectImageInfoByChunkIDs(context.Background(), repo, 1, []string{"text-1"})
+	if len(got) != 1 {
+		t.Fatalf("expected one chunk with merged image info, got %d", len(got))
+	}
+	raw, ok := got["text-1"]
+	if !ok || raw == "" {
+		t.Fatal("expected image info for text-1")
+	}
+	var infos []types.ImageInfo
+	if err := json.Unmarshal([]byte(raw), &infos); err != nil {
+		t.Fatal(err)
+	}
+	if len(infos) != 1 || infos[0].URL != "enabled.jpg" {
+		t.Fatalf("disabled image leaked into merged info: %+v", infos)
+	}
+}


### PR DESCRIPTION
## Description

Three defects combine into "deleted images are still retrieved" and "summary
chunks duplicate on every edit":

1. **Disabled image children are merged back into their parent.**
   `CollectImageInfoByChunkIDs` merges child `image_info` without checking
   `IsEnabled`, so `image_ocr`/`image_caption` children that
   `syncEditedChunkImages` sets to `is_enabled=false` on deletion are still
   reattached and later rendered into the LLM context. Skip disabled children.

2. **Recreated image children are born disabled.**
   `UpdateImageInfo` creates `image_ocr`/`image_caption` children without
   setting `IsEnabled`; `CreateChunks` inserts with `Select("*")`, which
   bypasses gorm's `default:true` and writes the zero value `false`. Set
   `IsEnabled: true` explicitly.

3. **Summary refresh appends instead of replacing.**
   The refresh reuses `ListChunksByKnowledgeID` (which hardcodes
   `chunk_type='text'`) to find the existing summary chunk, which can never
   match, so every refresh appends a new summary. Resolve the summary through
   `ListChunksByParentIDs`, reuse the first one, and disable stale leftovers so
   `updateChunkVector` drops their vectors.

## Type of Change

- [x] 🐛 Bug fix

## Related Issue

Fixes #2734

## Testing

Added `TestCollectImageInfoByChunkIDs_ExcludesDisabledImages`, which verifies a
disabled image child is excluded from the merged result via an in-memory stub.

- `go build ./internal/searchutil/ ./internal/application/service/` passes
- `go vet` passes
- `gofmt -l` reports no changes
- `git diff --check` passes

Note: `go test ./internal/searchutil/` crashes locally on Windows with
`0xc0000374` during CGo init (`pganalyze/pg_query_go`); the unmodified existing
test `TestSliceContentByDocumentRange` reproduces the same crash, so this is an
environment issue rather than caused by this change.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Added/updated tests covering the change
- [x] Self-reviewed the code
