### PR TITLE
Docs/cli wire vocab sweep

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -47,7 +47,7 @@ jobs:
         run: go test -race -coverprofile=coverage.out ./...
       - name: go vet
         run: go vet ./...
-      - name: Check skill wire vocabulary
+      - name: Check agent-facing doc wire vocabulary
         if: runner.os == 'Linux'
         run: scripts/check-skill-wire-vocab.sh
       - name: Check for committed credentials in docs

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -412,9 +412,6 @@ Agents parse the first colon to extract the typed code. The exit code class (see
 | `local.upload_file_not_found` | 1 | no | verify the path is correct and readable |
 | `local.user_aborted` | 1 | no (user said no) | no action taken; pass `-y/--yes` to skip the confirmation prompt |
 | `internal.error` | 1 | no | catch-all for an untyped error that reached the top (a bug or unmapped dependency error); a recurring one is a classification gap worth reporting |
-| `mcp.readonly_mode` | 1 | no | MCP tool surface is read-only; mutations not exposed in this mode |
-| `mcp.schema_unknown_command` | 1 | no | (no canonical hint) |
-| `mcp.tool_not_allowed` | 1 | no | MCP tool not in the curated allowlist |
 
 <!-- ERROR_REFERENCE_END -->
 
@@ -460,7 +457,7 @@ auto-retry this exit code — every exit 10 is a user-in-the-loop decision.
 
 ## Stream recovery
 
-The `weknora session continue-stream <session-id> --message <msg-id>` command resumes an SSE event stream for an existing assistant message. Use cases: network-blip recovery, long-running agent invocation polling, completed-stream inspection.
+The `weknora session resume <session-id> --message <msg-id>` command resumes an SSE event stream for an existing assistant message. Use cases: network-blip recovery, long-running agent invocation polling, completed-stream inspection.
 
 ### Server semantics: replay-from-0, not cursor-resume
 
@@ -479,7 +476,7 @@ The server **replays all stored events from the start** of the assistant message
 | `STREAM_MANAGER_TYPE=redis` | **1 hour** (server-side; not configurable from the CLI) |
 | `STREAM_MANAGER_TYPE=memory` (default) | **Process lifetime** (server restart = data loss; no explicit cleanup logic) |
 
-After TTL, `weknora session continue-stream` returns the typed error `local.sse_stream_aborted`, which maps to exit code 1 per the Error code reference.
+After TTL, `weknora session resume` returns the typed error `local.sse_stream_aborted`, which maps to exit code 1 per the Error code reference.
 
 ## Dry-run contract
 
@@ -552,7 +549,7 @@ The curated 10 tools (`cli/internal/mcp/tools.go`):
 | `search_chunks` | hybrid (vector + keyword) retrieval |
 | `chat` | stream a RAG answer; auto-creates a session if absent |
 | `agent_list` | list custom agents |
-| `agent_invoke` | run a query through a custom agent |
+| `session_ask` | run a query through a custom agent |
 
 Adding a tool is a deliberate API expansion — the AI-agent-callable surface is the reason this CLI ships an MCP server, not its CLI command list, so the registration list in `registerTools` is maintained by hand.
 

--- a/cli/internal/cmdutil/errors_doc_test.go
+++ b/cli/internal/cmdutil/errors_doc_test.go
@@ -7,13 +7,10 @@ import (
 	"testing"
 )
 
-// TestAllCodes_DocumentedInAGENTS verifies every typed code returned by
-// AllCodes() surfaces in cli/AGENTS.md "Error code reference" section
-// (delimited by ERROR_REFERENCE_START/END markers).
-//
-// Prevents drift: a contributor adding a new ErrorCode without updating
-// the doc fails this test, forcing the doc to stay current.
-func TestAllCodes_DocumentedInAGENTS(t *testing.T) {
+// loadErrorReferenceSection returns the body of the cli/AGENTS.md "Error code
+// reference" section, delimited by the ERROR_REFERENCE_START/END markers.
+func loadErrorReferenceSection(t *testing.T) string {
+	t.Helper()
 	// From cli/internal/cmdutil/, go up two levels to find cli/AGENTS.md.
 	docPath, err := filepath.Abs("../../AGENTS.md")
 	if err != nil {
@@ -32,7 +29,42 @@ func TestAllCodes_DocumentedInAGENTS(t *testing.T) {
 	if startIdx == -1 || endIdx == -1 || endIdx <= startIdx {
 		t.Fatalf("error-reference markers missing or malformed in %s:\n  start=%d end=%d", docPath, startIdx, endIdx)
 	}
-	refSection := doc[startIdx:endIdx]
+	return doc[startIdx:endIdx]
+}
+
+// documentedCodes extracts the codes listed in the first column of the error
+// reference table. Only the first column is read: hint cells also carry
+// backticked flags, paths, and commands that are not error codes.
+func documentedCodes(refSection string) []string {
+	var codes []string
+	for _, line := range strings.Split(refSection, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "|") {
+			continue
+		}
+		cells := strings.Split(strings.Trim(line, "|"), "|")
+		if len(cells) == 0 {
+			continue
+		}
+		// Skips the header ("Code") and separator ("---") rows, which carry no
+		// backticks in the first column.
+		first := strings.TrimSpace(cells[0])
+		if len(first) < 3 || !strings.HasPrefix(first, "`") || !strings.HasSuffix(first, "`") {
+			continue
+		}
+		codes = append(codes, strings.Trim(first, "`"))
+	}
+	return codes
+}
+
+// TestAllCodes_DocumentedInAGENTS verifies every typed code returned by
+// AllCodes() surfaces in cli/AGENTS.md "Error code reference" section
+// (delimited by ERROR_REFERENCE_START/END markers).
+//
+// Prevents drift: a contributor adding a new ErrorCode without updating
+// the doc fails this test, forcing the doc to stay current.
+func TestAllCodes_DocumentedInAGENTS(t *testing.T) {
+	refSection := loadErrorReferenceSection(t)
 
 	missing := []string{}
 	for _, c := range AllCodes() {
@@ -44,5 +76,39 @@ func TestAllCodes_DocumentedInAGENTS(t *testing.T) {
 	if len(missing) > 0 {
 		t.Errorf("the following error codes are registered in AllCodes() but not listed in cli/AGENTS.md \"Error code reference\" section between the ERROR_REFERENCE markers:\n  - %s\n\nAdd a row for each missing code to keep agent-facing docs in sync.",
 			strings.Join(missing, "\n  - "))
+	}
+}
+
+// TestDocumentedCodes_RegisteredInAllCodes is the reverse of
+// TestAllCodes_DocumentedInAGENTS: every code the doc advertises must still be
+// a code the CLI can emit.
+//
+// Without this direction a removed code lingers in the doc forever, and agents
+// branch on codes that will never arrive — the failure mode that left three
+// `mcp.*` codes documented for two minor versions after they were deleted.
+func TestDocumentedCodes_RegisteredInAllCodes(t *testing.T) {
+	refSection := loadErrorReferenceSection(t)
+
+	registered := make(map[string]bool, len(AllCodes()))
+	for _, c := range AllCodes() {
+		registered[string(c)] = true
+	}
+
+	documented := documentedCodes(refSection)
+	// Guards against the parser silently matching nothing, which would make this
+	// check pass vacuously if the table format ever changes.
+	if len(documented) == 0 {
+		t.Fatal("parsed zero error codes out of the reference table; the table format or the parser changed")
+	}
+
+	stale := []string{}
+	for _, c := range documented {
+		if !registered[c] {
+			stale = append(stale, c)
+		}
+	}
+	if len(stale) > 0 {
+		t.Errorf("the following error codes are documented in cli/AGENTS.md \"Error code reference\" but are not registered in AllCodes():\n  - %s\n\nDrop the row if the code was removed, or register the code if the row is correct.",
+			strings.Join(stale, "\n  - "))
 	}
 }

--- a/cli/internal/cmdutil/errors_doc_test.go
+++ b/cli/internal/cmdutil/errors_doc_test.go
@@ -108,7 +108,9 @@ func TestDocumentedCodes_RegisteredInAllCodes(t *testing.T) {
 		}
 	}
 	if len(stale) > 0 {
-		t.Errorf("the following error codes are documented in cli/AGENTS.md \"Error code reference\" but are not registered in AllCodes():\n  - %s\n\nDrop the row if the code was removed, or register the code if the row is correct.",
+		t.Errorf("the following error codes are documented in cli/AGENTS.md "+
+			"\"Error code reference\" but are not registered in AllCodes():\n  - %s\n\n"+
+			"Drop the row if the code was removed, or register the code if the row is correct.",
 			strings.Join(stale, "\n  - "))
 	}
 }

--- a/cli/internal/cmdutil/exit.go
+++ b/cli/internal/cmdutil/exit.go
@@ -35,7 +35,7 @@ func GetProfile() string { return globalProfile }
 // ExitCode maps an error to the documented CLI exit code.
 //   - 0  success
 //   - 1  generic / unknown typed error - fallback bucket: resource.already_exists,
-//     resource.locked, local.*, mcp.*, operation.failed, server.session_create_failed
+//     resource.locked, local.*, operation.failed, server.session_create_failed
 //     (workflow-level, see special case below), and any code outside the named
 //     buckets below
 //   - 2  cobra-parse problem (unrecognised flag, arg-count violation) —

--- a/cli/scripts/check-skill-wire-vocab.sh
+++ b/cli/scripts/check-skill-wire-vocab.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# check-skill-wire-vocab.sh — fail if cli/skills/ still references wire
-# vocabulary that the CLI has renamed or removed. Wire-shape changes must
-# sweep skills in the same PR.
+# check-skill-wire-vocab.sh — fail if the agent-facing docs still reference wire
+# vocabulary that the CLI has renamed or removed. Wire-shape changes must sweep
+# every agent-facing doc in the same PR.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -18,13 +18,33 @@ BANNED=(
   "agent create --kb:agent create --attach-kb (renamed in v0.9)"
   "kb init:kb config set (renamed — kb init removed)"
   "continue-stream:session resume (renamed)"
+  "retry_command:retry_argv (error envelope field renamed in v0.10)"
 )
+
+# Every doc an agent or integrator reads as current truth. AGENTS.md and
+# README.md are in scope because they are the authoritative wire contract that
+# skills are condensed from — a rename that lands in skills/ but not here leaves
+# the source of truth wrong.
+#
+# CHANGELOG.md is deliberately NOT scanned: recording a rename requires naming
+# the legacy term, so scanning it would guarantee a false positive.
+SCAN_TARGETS=(skills/ AGENTS.md README.md)
+
+# The v0.10 retry_command miss happened because the scan silently covered less
+# than the docs that needed covering. Fail loudly if a target disappears rather
+# than quietly shrinking coverage again.
+for target in "${SCAN_TARGETS[@]}"; do
+  if [ ! -e "$target" ]; then
+    echo "scan target '$target' does not exist — update SCAN_TARGETS" >&2
+    exit 2
+  fi
+done
 
 fail=0
 for entry in "${BANNED[@]}"; do
   term="${entry%%:*}"
   why="${entry#*:}"
-  if hits=$(grep -rn --include='*.md' -F "$term" skills/ 2>/dev/null); then
+  if hits=$(grep -rn --include='*.md' -F "$term" "${SCAN_TARGETS[@]}" 2>/dev/null); then
     echo "BANNED wire vocab '$term' found (use: $why):"
     echo "$hits"
     fail=1

--- a/cli/scripts/check-skill-wire-vocab.sh
+++ b/cli/scripts/check-skill-wire-vocab.sh
@@ -21,14 +21,14 @@ BANNED=(
   "retry_command:retry_argv (error envelope field renamed in v0.10)"
 )
 
-# Every doc an agent or integrator reads as current truth. AGENTS.md and
-# README.md are in scope because they are the authoritative wire contract that
+# Current-truth sources only. AGENTS.md is the authoritative wire contract that
 # skills are condensed from — a rename that lands in skills/ but not here leaves
 # the source of truth wrong.
 #
-# CHANGELOG.md is deliberately NOT scanned: recording a rename requires naming
-# the legacy term, so scanning it would guarantee a false positive.
-SCAN_TARGETS=(skills/ AGENTS.md README.md)
+# CHANGELOG.md and README.md are deliberately NOT scanned. Both will name
+# legacy terms when recording a rename or writing upgrade notes for agents
+# moving between CLI versions; scanning them would guarantee a false positive.
+SCAN_TARGETS=(skills/ AGENTS.md)
 
 # The v0.10 retry_command miss happened because the scan silently covered less
 # than the docs that needed covering. Fail loudly if a target disappears rather


### PR DESCRIPTION
## Description
`cli/AGENTS.md` 是 CLI 给 AI agent 看的对外契约（JSON 、错误码、MCP 工具名、命令形状）。v0.9 / v0.10 改名之后，这份文档有些遗漏，导致一些过期的契约会让agent以为「当前有效」：
- MCP 工具 `agent_invoke` → 实际是 `session_ask`
- 命令 `weknora session continue-stream` → 实际是 `weknora session resume`
- 三条 `mcp.*` 错误码（`readonly_mode` / `schema_unknown_command` / `tool_not_allowed`）→ `AllCodes()` 里已经没有了
Agent 如果按这份文档做分支判断，会走到永远不会出现的字段和命令上。

#2731 把 `retry_command` → `retry_argv` 修掉了，但上面这些漏网了。

漏网的原因不是词条没进黑名单，而是扫错了地方、检查只做了一半：
1. `check-skill-wire-vocab.sh` 的 `BANNED` 列表里其实早就有 `agent_invoke`、`continue-stream`、三个 `mcp.*`，但它只扫 `skills/`。真正的权威文档 `AGENTS.md`  完全不在范围内，所以 #2731 那种「skills 改对了、源头还错」不会被拦住。这次把扫描范围扩到 `skills/`、`AGENTS.md`，并断言这些路径必须存在，避免覆盖范围再次有遗漏。`CHANGELOG.md` 和 README.md 考虑到里面肯定可能存在就的接口和文档，暂不用扫。

2. `errors_doc_test.go` 原来只检查「代码里有的码，文档里必须有」，所以删掉的码可以在文档里一直存在。这次补了反向扫：文档里写的码必须还在 `AllCodes()` 里。
顺手清掉 `cli/internal/cmdutil/exit.go` 注释里 exit-1  对 `mcp.*` 的同一处幽灵引用。

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [x] 🔧 Configuration / Build / CI

## Related Issue
无独立 issue。这是 #2731 合入后的跟进。

## Testing
只动了 `cli/`。下面命令都在 `cli/` 下跑。
```bash
git diff --check origin/main...HEAD
gofmt -l internal/cmdutil/errors_doc_test.go internal/cmdutil/exit.go
bash -n scripts/check-skill-wire-vocab.sh
bash scripts/check-skill-wire-vocab.sh
bash scripts/check-secret-tokens.sh
go build ./...
go vet ./...
go test -count=1 -run 'DocumentedInAGENTS|RegisteredInAllCodes' -v ./internal/cmdutil/
go test -race -count=1 ./...
```
闸门有效性用负向用例验过（注入后已还原，不在提交里）：
- 往错误码表塞两条 `mcp.*` → `TestDocumentedCodes_RegisteredInAllCodes` 失败
- 往 `AGENTS.md` 塞 `retry_command` → vocab 脚本 exit 1
- 把扫描目标改成不存在的文件 → vocab 脚本 exit 2
- 旧范围（只扫 `skills/`）对 `AGENTS.md` 里同一处 `retry_command` 零命中，证实当初漏过 #2731 的缺口

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
无 UI 改动。