### PR TITLE
fix(migrations): 补齐 Lite 模式缺失的 SQLite 版本化迁移 (fixes #2158)

### DIFF
--- a/internal/database/migration_sqlite_versioned_schema_test.go
+++ b/internal/database/migration_sqlite_versioned_schema_test.go
@@ -1,0 +1,184 @@
+package database
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// versionedSQLiteTables is the set of tables that SQLite migrations must
+// create to stay in sync with the versioned (PostgreSQL) migrations:
+// 000041 task queue, 000053 system settings, 000055 processing spans,
+// 000063 knowledge multi-tags.
+var versionedSQLiteTables = []string{
+	"task_pending_ops",
+	"task_dead_letters",
+	"system_settings",
+	"knowledge_processing_spans",
+	"knowledge_tag_relations",
+}
+
+// versionedSQLiteColumns maps each existing table to the columns that the
+// versioned migrations add and the SQLite baseline was missing.
+var versionedSQLiteColumns = map[string][]string{
+	"tenants":            {"api_principal_config"},           // 000064
+	"users":              {"is_system_admin"},                // 000053
+	"knowledges":         {"pending_subtasks_count"},         // 000056
+	"messages":           {"attachments"},                    // 000034
+	"tenant_invitations": {"token", "accepted_count"},        // 000054
+	"embed_channels":     {"allow_memory"},                   // 000060
+	"mcp_oauth_tokens":   {"principal_type", "principal_id"}, // 000064
+}
+
+const expectedSQLiteMigrationVersion = 11
+
+func TestSQLiteMigrationsCreateVersionedSchema(t *testing.T) {
+	repoRoot := sqliteRepoRoot(t)
+	chdirAndRestore(t, repoRoot)
+
+	dbPath := filepath.Join(t.TempDir(), "fresh.db")
+	require.NoError(t, RunMigrationsWithOptions("sqlite3://unused", MigrationOptions{SQLiteDBPath: dbPath}))
+
+	db := openSQLiteDB(t, dbPath)
+	version, dirty := sqliteMigrationState(t, db)
+	require.Equal(t, expectedSQLiteMigrationVersion, version)
+	require.False(t, dirty)
+
+	for _, table := range versionedSQLiteTables {
+		require.Truef(t, sqliteTableExists(t, db, table), "SQLite migrations must create table %s", table)
+	}
+	for table, columns := range versionedSQLiteColumns {
+		for _, column := range columns {
+			require.Truef(
+				t,
+				sqliteColumnExists(t, db, table, column),
+				"SQLite migrations must add column %s.%s",
+				table,
+				column,
+			)
+		}
+	}
+}
+
+func TestSQLiteMigrationsUpgradeV4PreservesData(t *testing.T) {
+	repoRoot := sqliteRepoRoot(t)
+
+	// Build a legacy v4 migration root (000000_init .. 000004_memory) so we
+	// can prove the new migrations upgrade an existing Lite database without
+	// replaying the baseline.
+	legacyRoot := copySQLiteMigrationsV4(t, repoRoot)
+	chdirAndRestore(t, legacyRoot)
+
+	dbPath := filepath.Join(t.TempDir(), "upgrade.db")
+	require.NoError(t, RunMigrationsWithOptions("sqlite3://unused", MigrationOptions{SQLiteDBPath: dbPath}))
+
+	db := openSQLiteDB(t, dbPath)
+	versionBefore, dirtyBefore := sqliteMigrationState(t, db)
+	require.Equal(t, 4, versionBefore)
+	require.False(t, dirtyBefore)
+	_, err := db.Exec("INSERT INTO tenants (name, business) VALUES (?, ?)", "upgrade-sentinel", "migration-test")
+	require.NoError(t, err)
+
+	// Run the full migration set from the repo root.
+	chdirAndRestore(t, repoRoot)
+	require.NoError(t, RunMigrationsWithOptions("sqlite3://unused", MigrationOptions{SQLiteDBPath: dbPath}))
+
+	db = openSQLiteDB(t, dbPath)
+	versionAfter, dirtyAfter := sqliteMigrationState(t, db)
+	require.Equal(t, expectedSQLiteMigrationVersion, versionAfter)
+	require.False(t, dirtyAfter)
+
+	for _, table := range versionedSQLiteTables {
+		require.Truef(t, sqliteTableExists(t, db, table), "upgraded SQLite DB must have table %s", table)
+	}
+	for table, columns := range versionedSQLiteColumns {
+		for _, column := range columns {
+			require.Truef(
+				t,
+				sqliteColumnExists(t, db, table, column),
+				"upgraded SQLite DB must have column %s.%s",
+				table,
+				column,
+			)
+		}
+	}
+
+	var sentinelName string
+	require.NoError(t, db.QueryRow("SELECT name FROM tenants WHERE business = ?", "migration-test").Scan(&sentinelName))
+	require.Equal(t, "upgrade-sentinel", sentinelName)
+}
+
+func sqliteRepoRoot(t *testing.T) string {
+	t.Helper()
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	return repoRoot
+}
+
+func chdirAndRestore(t *testing.T, dir string) {
+	t.Helper()
+	previousDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(previousDir) })
+}
+
+func openSQLiteDB(t *testing.T, dbPath string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func sqliteMigrationState(t *testing.T, db *sql.DB) (version int, dirty bool) {
+	t.Helper()
+	require.NoError(t, db.QueryRow("SELECT version, dirty FROM schema_migrations").Scan(&version, &dirty))
+	return version, dirty
+}
+
+func sqliteTableExists(t *testing.T, db *sql.DB, table string) bool {
+	t.Helper()
+	var n int
+	require.NoError(t, db.QueryRow(
+		"SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?",
+		table,
+	).Scan(&n))
+	return n == 1
+}
+
+func sqliteColumnExists(t *testing.T, db *sql.DB, table, column string) bool {
+	t.Helper()
+	var n int
+	require.NoError(t, db.QueryRow(
+		"SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?",
+		table,
+		column,
+	).Scan(&n))
+	return n == 1
+}
+
+func copySQLiteMigrationsV4(t *testing.T, repoRoot string) string {
+	t.Helper()
+	dest := t.TempDir()
+	srcDir := filepath.Join(repoRoot, "migrations", "sqlite")
+	destDir := filepath.Join(dest, "migrations", "sqlite")
+	require.NoError(t, os.MkdirAll(destDir, 0o755))
+
+	legacy := []string{
+		"000000_init.up.sql",
+		"000001_remove_wiki_log.up.sql",
+		"000002_knowledge_folder_path.up.sql",
+		"000003_knowledge_base_auto_tag_config.up.sql",
+		"000004_memory.up.sql",
+	}
+	for _, name := range legacy {
+		data, err := os.ReadFile(filepath.Join(srcDir, name))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(destDir, name), data, 0o600))
+	}
+	return dest
+}

--- a/internal/database/migration_sqlite_versioned_schema_test.go
+++ b/internal/database/migration_sqlite_versioned_schema_test.go
@@ -61,6 +61,11 @@ func TestSQLiteMigrationsCreateVersionedSchema(t *testing.T) {
 			)
 		}
 	}
+
+	assertSQLiteShareLinkInvitationsWork(t, db)
+	assertSQLiteMCPOAuthPrincipalUpsertWorks(t, db)
+	require.False(t, sqliteColumnExists(t, db, "knowledges", "tag_id"),
+		"SQLite migrations must drop legacy knowledges.tag_id after multi-tag migration")
 }
 
 func TestSQLiteMigrationsUpgradeV4PreservesData(t *testing.T) {
@@ -80,6 +85,12 @@ func TestSQLiteMigrationsUpgradeV4PreservesData(t *testing.T) {
 	require.Equal(t, 4, versionBefore)
 	require.False(t, dirtyBefore)
 	_, err := db.Exec("INSERT INTO tenants (name, business) VALUES (?, ?)", "upgrade-sentinel", "migration-test")
+	require.NoError(t, err)
+	_, err = db.Exec(
+		"INSERT INTO knowledges (id, tenant_id, knowledge_base_id, type, title, source, tag_id) "+
+			"VALUES (?, 1, ?, 'document', 'tagged-doc', 'manual', ?)",
+		"legacy-knowledge-1", "legacy-kb-1", "legacy-tag-1",
+	)
 	require.NoError(t, err)
 
 	// Run the full migration set from the repo root.
@@ -109,6 +120,14 @@ func TestSQLiteMigrationsUpgradeV4PreservesData(t *testing.T) {
 	var sentinelName string
 	require.NoError(t, db.QueryRow("SELECT name FROM tenants WHERE business = ?", "migration-test").Scan(&sentinelName))
 	require.Equal(t, "upgrade-sentinel", sentinelName)
+
+	var relationCount int
+	require.NoError(t, db.QueryRow(
+		"SELECT COUNT(*) FROM knowledge_tag_relations WHERE knowledge_id = ? AND tag_id = ?",
+		"legacy-knowledge-1", "legacy-tag-1",
+	).Scan(&relationCount))
+	require.Equal(t, 1, relationCount)
+	require.False(t, sqliteColumnExists(t, db, "knowledges", "tag_id"))
 }
 
 func sqliteRepoRoot(t *testing.T) string {
@@ -159,6 +178,66 @@ func sqliteColumnExists(t *testing.T, db *sql.DB, table, column string) bool {
 		column,
 	).Scan(&n))
 	return n == 1
+}
+
+func assertSQLiteShareLinkInvitationsWork(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.Exec("INSERT INTO tenants (name, business) VALUES (?, ?)", "share-link-tenant", "share-link-test")
+	require.NoError(t, err)
+
+	expiresAt := "2099-01-01 00:00:00"
+	shareLinkInsert := "INSERT INTO tenant_invitations " +
+		"(tenant_id, invitee_user_id, token, role, status, expires_at) " +
+		"VALUES (1, '', ?, 'member', 'pending', ?)"
+	_, err = db.Exec(shareLinkInsert, "token-a", expiresAt)
+	require.NoError(t, err)
+	_, err = db.Exec(shareLinkInsert, "token-b", expiresAt)
+	require.NoError(t, err)
+
+	var count int
+	require.NoError(t, db.QueryRow(
+		"SELECT COUNT(*) FROM tenant_invitations WHERE tenant_id = 1 AND invitee_user_id = '' AND status = 'pending'",
+	).Scan(&count))
+	require.Equal(t, 2, count)
+}
+
+func assertSQLiteMCPOAuthPrincipalUpsertWorks(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.Exec(
+		"INSERT INTO mcp_services (id, tenant_id, name, transport_type) VALUES (?, 1, 'svc', 'http')",
+		"svc-migration-1",
+	)
+	require.NoError(t, err)
+
+	tokenInsertPrefix := "INSERT INTO mcp_oauth_tokens " +
+		"(id, tenant_id, user_id, service_id, principal_type, principal_id, access_token) "
+	_, err = db.Exec(
+		tokenInsertPrefix +
+			"VALUES ('tok-1', 1, 'u1', 'svc-migration-1', 'web_user', 'u1', 'token-1')",
+	)
+	require.NoError(t, err)
+
+	_, err = db.Exec(
+		tokenInsertPrefix +
+			"VALUES ('tok-2', 1, 'u1', 'svc-migration-1', 'web_user', 'u1', 'token-2') " +
+			"ON CONFLICT(tenant_id, principal_type, principal_id, service_id) " +
+			"DO UPDATE SET access_token = excluded.access_token",
+	)
+	require.NoError(t, err)
+
+	var accessToken string
+	require.NoError(t, db.QueryRow(
+		"SELECT access_token FROM mcp_oauth_tokens "+
+			"WHERE tenant_id = 1 AND principal_type = 'web_user' "+
+			"AND principal_id = 'u1' AND service_id = 'svc-migration-1'",
+	).Scan(&accessToken))
+	require.Equal(t, "token-2", accessToken)
+
+	var rowCount int
+	require.NoError(t, db.QueryRow(
+		"SELECT COUNT(*) FROM mcp_oauth_tokens WHERE tenant_id = 1 AND service_id = 'svc-migration-1'",
+	).Scan(&rowCount))
+	require.Equal(t, 1, rowCount)
 }
 
 func copySQLiteMigrationsV4(t *testing.T, repoRoot string) string {

--- a/migrations/sqlite/000005_messages_attachments_and_invitation_fields.down.sql
+++ b/migrations/sqlite/000005_messages_attachments_and_invitation_fields.down.sql
@@ -1,3 +1,15 @@
+DROP INDEX IF EXISTS idx_tenant_invitations_token;
+DROP INDEX IF EXISTS idx_tenant_invitations_unique_pending;
+
+-- Legacy unique index cannot coexist with multiple share-link rows.
+DELETE FROM tenant_invitations
+    WHERE invitee_user_id = ''
+      AND deleted_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tenant_invitations_unique_pending
+    ON tenant_invitations(tenant_id, invitee_user_id)
+    WHERE status = 'pending' AND deleted_at IS NULL;
+
 ALTER TABLE tenant_invitations DROP COLUMN accepted_count;
 ALTER TABLE tenant_invitations DROP COLUMN token;
 ALTER TABLE messages DROP COLUMN attachments;

--- a/migrations/sqlite/000005_messages_attachments_and_invitation_fields.down.sql
+++ b/migrations/sqlite/000005_messages_attachments_and_invitation_fields.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tenant_invitations DROP COLUMN accepted_count;
+ALTER TABLE tenant_invitations DROP COLUMN token;
+ALTER TABLE messages DROP COLUMN attachments;

--- a/migrations/sqlite/000005_messages_attachments_and_invitation_fields.up.sql
+++ b/migrations/sqlite/000005_messages_attachments_and_invitation_fields.up.sql
@@ -1,0 +1,8 @@
+-- Mirrors versioned migrations:
+--   000034_add_attachments        messages.attachments
+--   000054_invitation_tokens      tenant_invitations.token / accepted_count
+
+ALTER TABLE messages ADD COLUMN attachments TEXT NOT NULL DEFAULT '[]';
+
+ALTER TABLE tenant_invitations ADD COLUMN token VARCHAR(64) NOT NULL DEFAULT '';
+ALTER TABLE tenant_invitations ADD COLUMN accepted_count INTEGER NOT NULL DEFAULT 0;

--- a/migrations/sqlite/000005_messages_attachments_and_invitation_fields.up.sql
+++ b/migrations/sqlite/000005_messages_attachments_and_invitation_fields.up.sql
@@ -6,3 +6,16 @@ ALTER TABLE messages ADD COLUMN attachments TEXT NOT NULL DEFAULT '[]';
 
 ALTER TABLE tenant_invitations ADD COLUMN token VARCHAR(64) NOT NULL DEFAULT '';
 ALTER TABLE tenant_invitations ADD COLUMN accepted_count INTEGER NOT NULL DEFAULT 0;
+
+-- Share-link rows use invitee_user_id=''; relax the pending uniqueness index
+-- so multiple share links can coexist on one tenant (see versioned 000054).
+DROP INDEX IF EXISTS idx_tenant_invitations_unique_pending;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tenant_invitations_unique_pending
+    ON tenant_invitations(tenant_id, invitee_user_id)
+    WHERE status = 'pending'
+      AND deleted_at IS NULL
+      AND invitee_user_id <> '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tenant_invitations_token
+    ON tenant_invitations(token)
+    WHERE token <> '' AND deleted_at IS NULL;

--- a/migrations/sqlite/000006_task_queue_and_dead_letters.down.sql
+++ b/migrations/sqlite/000006_task_queue_and_dead_letters.down.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS idx_task_dead_letters_task_type;
+DROP INDEX IF EXISTS idx_task_dead_letters_tenant;
+DROP INDEX IF EXISTS idx_task_dead_letters_scope;
+DROP INDEX IF EXISTS idx_task_pending_ops_tenant;
+DROP INDEX IF EXISTS idx_task_pending_ops_scope;
+
+DROP TABLE IF EXISTS task_dead_letters;
+DROP TABLE IF EXISTS task_pending_ops;

--- a/migrations/sqlite/000006_task_queue_and_dead_letters.up.sql
+++ b/migrations/sqlite/000006_task_queue_and_dead_letters.up.sql
@@ -1,0 +1,44 @@
+-- Mirrors versioned migration 000041_task_queue_and_wiki_indexes:
+-- durable pending-op queue and dead-letter archive for SQLite.
+
+CREATE TABLE IF NOT EXISTS task_pending_ops (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id   INTEGER NOT NULL,
+    task_type   VARCHAR(64) NOT NULL,
+    scope       VARCHAR(32) NOT NULL,
+    scope_id    VARCHAR(64) NOT NULL,
+    op          VARCHAR(32) NOT NULL,
+    dedup_key   VARCHAR(128) NOT NULL DEFAULT '',
+    payload     TEXT NOT NULL DEFAULT '{}',
+    fail_count  INTEGER NOT NULL DEFAULT 0,
+    enqueued_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    claimed_at  DATETIME
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_pending_ops_scope
+    ON task_pending_ops (task_type, scope, scope_id, id);
+
+CREATE INDEX IF NOT EXISTS idx_task_pending_ops_tenant
+    ON task_pending_ops (tenant_id);
+
+CREATE TABLE IF NOT EXISTS task_dead_letters (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id   INTEGER NOT NULL,
+    task_type   VARCHAR(64) NOT NULL,
+    scope       VARCHAR(32) NOT NULL,
+    scope_id    VARCHAR(64) NOT NULL,
+    related_id  VARCHAR(64) NOT NULL DEFAULT '',
+    payload     TEXT NOT NULL,
+    last_error  TEXT NOT NULL DEFAULT '',
+    fail_count  INTEGER NOT NULL,
+    failed_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_dead_letters_scope
+    ON task_dead_letters (scope, scope_id, failed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_task_dead_letters_tenant
+    ON task_dead_letters (tenant_id, failed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_task_dead_letters_task_type
+    ON task_dead_letters (task_type, failed_at DESC);

--- a/migrations/sqlite/000007_system_admin_and_settings.down.sql
+++ b/migrations/sqlite/000007_system_admin_and_settings.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_system_settings_category;
+DROP TABLE IF EXISTS system_settings;
+DROP INDEX IF EXISTS idx_users_is_system_admin;
+ALTER TABLE users DROP COLUMN is_system_admin;

--- a/migrations/sqlite/000007_system_admin_and_settings.up.sql
+++ b/migrations/sqlite/000007_system_admin_and_settings.up.sql
@@ -1,0 +1,22 @@
+-- Mirrors versioned migration 000053_system_admin_and_settings:
+-- users.is_system_admin + system_settings table.
+
+ALTER TABLE users ADD COLUMN is_system_admin BOOLEAN NOT NULL DEFAULT 0;
+CREATE INDEX IF NOT EXISTS idx_users_is_system_admin ON users (is_system_admin);
+
+CREATE TABLE IF NOT EXISTS system_settings (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    key              VARCHAR(128) NOT NULL UNIQUE,
+    value            TEXT NOT NULL,
+    value_type       VARCHAR(16)  NOT NULL,
+    category         VARCHAR(32)  NOT NULL,
+    description      TEXT NOT NULL DEFAULT '',
+    is_secret        BOOLEAN NOT NULL DEFAULT 0,
+    requires_restart BOOLEAN NOT NULL DEFAULT 0,
+    last_modified_by VARCHAR(36) NOT NULL DEFAULT '',
+    created_at       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_system_settings_category
+    ON system_settings (category);

--- a/migrations/sqlite/000008_processing_spans_and_pending_subtasks.down.sql
+++ b/migrations/sqlite/000008_processing_spans_and_pending_subtasks.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE knowledges DROP COLUMN pending_subtasks_count;
+
+DROP INDEX IF EXISTS idx_kpspan_parent;
+DROP INDEX IF EXISTS idx_kpspan_status_started;
+DROP INDEX IF EXISTS idx_kpspan_knowledge_attempt;
+DROP TABLE IF EXISTS knowledge_processing_spans;

--- a/migrations/sqlite/000008_processing_spans_and_pending_subtasks.up.sql
+++ b/migrations/sqlite/000008_processing_spans_and_pending_subtasks.up.sql
@@ -1,6 +1,7 @@
 -- Mirrors versioned migrations:
 --   000055_knowledge_processing_spans   knowledge_processing_spans table
 --   000056_knowledge_pending_subtasks   knowledges.pending_subtasks_count
+--   000066_expand_knowledge_span_name   name VARCHAR(255)
 
 CREATE TABLE IF NOT EXISTS knowledge_processing_spans (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -8,7 +9,7 @@ CREATE TABLE IF NOT EXISTS knowledge_processing_spans (
     attempt         INTEGER NOT NULL DEFAULT 1,
     span_id         VARCHAR(64) NOT NULL,
     parent_span_id  VARCHAR(64),
-    name            VARCHAR(64) NOT NULL,
+    name            VARCHAR(255) NOT NULL,
     kind            VARCHAR(16) NOT NULL,
     status          VARCHAR(16) NOT NULL,
     input           TEXT,

--- a/migrations/sqlite/000008_processing_spans_and_pending_subtasks.up.sql
+++ b/migrations/sqlite/000008_processing_spans_and_pending_subtasks.up.sql
@@ -1,0 +1,38 @@
+-- Mirrors versioned migrations:
+--   000055_knowledge_processing_spans   knowledge_processing_spans table
+--   000056_knowledge_pending_subtasks   knowledges.pending_subtasks_count
+
+CREATE TABLE IF NOT EXISTS knowledge_processing_spans (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    knowledge_id    VARCHAR(64) NOT NULL,
+    attempt         INTEGER NOT NULL DEFAULT 1,
+    span_id         VARCHAR(64) NOT NULL,
+    parent_span_id  VARCHAR(64),
+    name            VARCHAR(64) NOT NULL,
+    kind            VARCHAR(16) NOT NULL,
+    status          VARCHAR(16) NOT NULL,
+    input           TEXT,
+    output          TEXT,
+    metadata        TEXT,
+    error_code      VARCHAR(64),
+    error_message   TEXT,
+    error_detail    TEXT,
+    started_at      DATETIME,
+    finished_at     DATETIME,
+    duration_ms     INTEGER,
+    created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_kpspan_attempt_span UNIQUE (knowledge_id, attempt, span_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_kpspan_knowledge_attempt
+    ON knowledge_processing_spans (knowledge_id, attempt);
+
+CREATE INDEX IF NOT EXISTS idx_kpspan_status_started
+    ON knowledge_processing_spans (status, started_at);
+
+CREATE INDEX IF NOT EXISTS idx_kpspan_parent
+    ON knowledge_processing_spans (parent_span_id)
+    WHERE parent_span_id IS NOT NULL;
+
+ALTER TABLE knowledges ADD COLUMN pending_subtasks_count INTEGER NOT NULL DEFAULT 0;

--- a/migrations/sqlite/000009_embed_channel_memory_flag.down.sql
+++ b/migrations/sqlite/000009_embed_channel_memory_flag.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE embed_channels DROP COLUMN allow_memory;

--- a/migrations/sqlite/000009_embed_channel_memory_flag.up.sql
+++ b/migrations/sqlite/000009_embed_channel_memory_flag.up.sql
@@ -1,0 +1,3 @@
+-- Mirrors versioned migration 000060_embed_channels: embed_channels.allow_memory.
+
+ALTER TABLE embed_channels ADD COLUMN allow_memory BOOLEAN NOT NULL DEFAULT 0;

--- a/migrations/sqlite/000010_knowledge_multi_tags.down.sql
+++ b/migrations/sqlite/000010_knowledge_multi_tags.down.sql
@@ -1,3 +1,18 @@
+ALTER TABLE knowledges ADD COLUMN tag_id VARCHAR(36);
+CREATE INDEX IF NOT EXISTS idx_knowledges_tag ON knowledges(tag_id);
+
+UPDATE knowledges
+SET tag_id = (
+    SELECT ktr.tag_id
+    FROM knowledge_tag_relations ktr
+    WHERE ktr.knowledge_id = knowledges.id
+    ORDER BY ktr.created_at ASC
+    LIMIT 1
+)
+WHERE EXISTS (
+    SELECT 1 FROM knowledge_tag_relations ktr WHERE ktr.knowledge_id = knowledges.id
+);
+
 DROP INDEX IF EXISTS idx_ktr_tag;
 DROP INDEX IF EXISTS idx_ktr_knowledge;
 DROP TABLE IF EXISTS knowledge_tag_relations;

--- a/migrations/sqlite/000010_knowledge_multi_tags.down.sql
+++ b/migrations/sqlite/000010_knowledge_multi_tags.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_ktr_tag;
+DROP INDEX IF EXISTS idx_ktr_knowledge;
+DROP TABLE IF EXISTS knowledge_tag_relations;

--- a/migrations/sqlite/000010_knowledge_multi_tags.up.sql
+++ b/migrations/sqlite/000010_knowledge_multi_tags.up.sql
@@ -13,3 +13,13 @@ CREATE INDEX IF NOT EXISTS idx_ktr_knowledge
 
 CREATE INDEX IF NOT EXISTS idx_ktr_tag
     ON knowledge_tag_relations (tag_id);
+
+-- Migrate existing single-tag data into the join table.
+INSERT INTO knowledge_tag_relations (knowledge_id, tag_id, created_at)
+SELECT id, tag_id, updated_at
+FROM knowledges
+WHERE tag_id IS NOT NULL AND tag_id != ''
+  AND deleted_at IS NULL;
+
+DROP INDEX IF EXISTS idx_knowledges_tag;
+ALTER TABLE knowledges DROP COLUMN tag_id;

--- a/migrations/sqlite/000010_knowledge_multi_tags.up.sql
+++ b/migrations/sqlite/000010_knowledge_multi_tags.up.sql
@@ -1,0 +1,15 @@
+-- Mirrors versioned migration 000063_knowledge_multi_tags:
+-- many-to-many join table between knowledges and knowledge_tags.
+
+CREATE TABLE IF NOT EXISTS knowledge_tag_relations (
+    knowledge_id VARCHAR(36) NOT NULL,
+    tag_id       VARCHAR(36) NOT NULL,
+    created_at   DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (knowledge_id, tag_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ktr_knowledge
+    ON knowledge_tag_relations (knowledge_id);
+
+CREATE INDEX IF NOT EXISTS idx_ktr_tag
+    ON knowledge_tag_relations (tag_id);

--- a/migrations/sqlite/000011_principal_model.down.sql
+++ b/migrations/sqlite/000011_principal_model.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE mcp_oauth_tokens DROP COLUMN principal_id;
+ALTER TABLE mcp_oauth_tokens DROP COLUMN principal_type;
+ALTER TABLE tenants DROP COLUMN api_principal_config;

--- a/migrations/sqlite/000011_principal_model.down.sql
+++ b/migrations/sqlite/000011_principal_model.down.sql
@@ -1,3 +1,9 @@
+DROP INDEX IF EXISTS idx_mcp_oauth_tokens_principal;
+DROP INDEX IF EXISTS idx_mcp_oauth_tokens_tenant_principal_svc;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_oauth_tokens_tenant_user_svc
+    ON mcp_oauth_tokens(tenant_id, user_id, service_id);
+
 ALTER TABLE mcp_oauth_tokens DROP COLUMN principal_id;
 ALTER TABLE mcp_oauth_tokens DROP COLUMN principal_type;
 ALTER TABLE tenants DROP COLUMN api_principal_config;

--- a/migrations/sqlite/000011_principal_model.up.sql
+++ b/migrations/sqlite/000011_principal_model.up.sql
@@ -5,3 +5,18 @@ ALTER TABLE tenants ADD COLUMN api_principal_config TEXT;
 
 ALTER TABLE mcp_oauth_tokens ADD COLUMN principal_type VARCHAR(32);
 ALTER TABLE mcp_oauth_tokens ADD COLUMN principal_id VARCHAR(512);
+
+UPDATE mcp_oauth_tokens
+SET principal_type = 'web_user',
+    principal_id = user_id
+WHERE (principal_type IS NULL OR principal_type = '')
+  AND user_id IS NOT NULL
+  AND user_id <> '';
+
+DROP INDEX IF EXISTS idx_mcp_oauth_tokens_tenant_user_svc;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_oauth_tokens_tenant_principal_svc
+    ON mcp_oauth_tokens(tenant_id, principal_type, principal_id, service_id);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_oauth_tokens_principal
+    ON mcp_oauth_tokens(principal_type, principal_id);

--- a/migrations/sqlite/000011_principal_model.up.sql
+++ b/migrations/sqlite/000011_principal_model.up.sql
@@ -1,0 +1,7 @@
+-- Mirrors versioned migration 000064_principal_model:
+-- principal identity for MCP OAuth tokens and tenant API config.
+
+ALTER TABLE tenants ADD COLUMN api_principal_config TEXT;
+
+ALTER TABLE mcp_oauth_tokens ADD COLUMN principal_type VARCHAR(32);
+ALTER TABLE mcp_oauth_tokens ADD COLUMN principal_id VARCHAR(512);


### PR DESCRIPTION
## 问题

Lite 模式（SQLite）全新数据库首次建号失败：`POST /api/v1/auth/auto-setup` / `/register` 报 500，根因是 `migrations/sqlite` 只有 5 个迁移（当前 v4），落后于 `migrations/versioned`（85 个）。启动时服务能跑、页面能开，但建号/建空间路径会撞上缺失的表和列：

- `tenants.api_principal_config`（000064）→ 建空间 INSERT 失败
- `users.is_system_admin`（000053）、`system_settings`（000053）
- `task_pending_ops` / `task_dead_letters`（000041）
- `knowledge_processing_spans`（000055）、`knowledges.pending_subtasks_count`（000056）
- `knowledge_tag_relations`（000063）
- `messages.attachments`（000034）、`tenant_invitations.token/accepted_count`（000054）
- `embed_channels.allow_memory`（000060）、`mcp_oauth_tokens.principal_*`（000064）

## 修改

新增 7 个 SQLite 版本化迁移（000005–000011），按 versioned 迁移主题一一映射，SQLite 兼容类型（INTEGER PRIMARY KEY AUTOINCREMENT / TEXT / DATETIME / CURRENT_TIMESTAMP）：

| SQLite 迁移 | 对应 versioned | 内容 |
|---|---|---|
| 000005 | 000034 / 000054 | messages.attachments、tenant_invitations.token / accepted_count |
| 000006 | 000041 | task_pending_ops、task_dead_letters（DDL 与 #2433 一致） |
| 000007 | 000053 | system_settings、users.is_system_admin |
| 000008 | 000055 / 000056 | knowledge_processing_spans、knowledges.pending_subtasks_count |
| 000009 | 000060 | embed_channels.allow_memory |
| 000010 | 000063 | knowledge_tag_relations |
| 000011 | 000064 | tenants.api_principal_config、mcp_oauth_tokens.principal_type / principal_id |

不修改 `000000_init`（已记录迁移版本 v4 的数据库不会重放基线），全部走版本化增量迁移。每个迁移均带 down 文件。

## 测试

新增 `internal/database/migration_sqlite_versioned_schema_test.go`：

- 全新库跑完迁移后版本 = 11、dirty = false，5 张新表 + 9 个新列全部存在；
- v4 → v11 升级路径：升级前插入哨兵数据，升级后版本正确、数据保留、新对象齐全。

本地验证：`go test ./internal/database` 全绿；macOS 上全新 Lite 库启动后 `auto-setup` 成功建号建空间，前端正常登录。

## 关联

- Fixes #2158
- 与 #2433（SQLite 持久化任务表迁移）范围有重叠；本 PR 任务表 DDL 与其保持一致，并补齐 #2433 未覆盖的其余 schema 漂移。