### PR TITLE
Fix/hybrid search match count normalization

### DIFF
--- a/internal/application/service/knowledgebase_search.go
+++ b/internal/application/service/knowledgebase_search.go
@@ -12,6 +12,19 @@ import (
 	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
 
+const (
+	// defaultMatchCount is the retrieval depth used when a caller supplies no
+	// usable MatchCount. It doubles as the over-retrieval floor, so the
+	// fallback and the pool it draws from cannot drift apart.
+	defaultMatchCount = 50
+
+	// maxRetrievalPoolSize bounds every retrieval depth derived from
+	// MatchCount: the over-retrieval pool below and the doubling TopK of the
+	// FAQ iterative path. Without it a caller-supplied MatchCount scales the
+	// vector-store query depth without limit.
+	maxRetrievalPoolSize = 500
+)
+
 // GetQueryEmbedding computes the query embedding using the embedding model
 // associated with the given knowledge base. Callers can pre-compute and reuse
 // the result across multiple KBs that share the same embedding model to avoid
@@ -88,6 +101,10 @@ func (s *knowledgeBaseService) HybridSearch(ctx context.Context,
 	id string,
 	params types.SearchParams,
 ) ([]*types.SearchResult, error) {
+	// Normalize once, before anything reads MatchCount. params is a value
+	// copy, so this stays local to the call.
+	params.MatchCount = normalizedMatchCount(params.MatchCount)
+
 	// Determine the set of KB IDs to search.
 	searchKBIDs := params.KnowledgeBaseIDs
 	if len(searchKBIDs) == 0 {
@@ -147,10 +164,11 @@ func (s *knowledgeBaseService) HybridSearch(ctx context.Context,
 	}
 
 	// Over-retrieval (existing rule, preserved): 5x per-KB matchCount,
-	// floor of 50, capped at 500 across the whole search.
-	matchCount := max(params.MatchCount*5, 50) * len(searchKBIDs)
-	if matchCount > 500 {
-		matchCount = 500
+	// floored at defaultMatchCount, capped at maxRetrievalPoolSize across the
+	// whole search.
+	matchCount := max(params.MatchCount*5, defaultMatchCount) * len(searchKBIDs)
+	if matchCount > maxRetrievalPoolSize {
+		matchCount = maxRetrievalPoolSize
 	}
 
 	// Compute the query embedding once before fan-out and propagate via
@@ -248,15 +266,35 @@ func (s *knowledgeBaseService) HybridSearch(ctx context.Context,
 		return nil, err
 	}
 
-	// Limit to MatchCount; 0 means "no explicit limit" — use over-retrieval floor (50).
-	effectiveMatchCount := params.MatchCount
-	if effectiveMatchCount <= 0 {
-		effectiveMatchCount = 50
+	// Truncate to the primary-match cap. MatchCount is guaranteed positive by
+	// the normalization at the top of this function; the slice bound below
+	// depends on that.
+	if len(deduplicatedChunks) > params.MatchCount {
+		deduplicatedChunks = deduplicatedChunks[:params.MatchCount]
 	}
-	if len(deduplicatedChunks) > effectiveMatchCount {
-		deduplicatedChunks = deduplicatedChunks[:effectiveMatchCount]
-	}
+
 	return s.processSearchResults(ctx, deduplicatedChunks, params.SkipContextEnrichment)
+}
+
+// normalizedMatchCount resolves the effective primary-match cap for a search.
+//
+// MatchCount arrives as Go's zero value whenever a caller omits it — JSON
+// cannot tell an absent match_count from an explicit 0 — and three consumers
+// inside HybridSearch read it: the over-retrieval floor, the FAQ
+// iterative-retrieval trigger, and the final truncation. They must agree, so
+// the value is resolved here rather than at each use site. A raw 0 truncates
+// the deduplicated chunk list to [:0] and empties an otherwise successful
+// search; a negative value panics on that same slice bound.
+//
+// The fallback matches RetrievalConfig.GetEffectiveEmbeddingTopK: internal
+// callers (chat pipeline, agent tools) feed these results into reranking,
+// which trims to RerankTopK afterwards, so a wide candidate pool is the right
+// failure mode for them.
+func normalizedMatchCount(requested int) int {
+	if requested <= 0 {
+		return defaultMatchCount
+	}
+	return requested
 }
 
 // pickPrimary returns the KB whose ID matches id, or nil if id is not in

--- a/internal/application/service/knowledgebase_search.go
+++ b/internal/application/service/knowledgebase_search.go
@@ -12,18 +12,11 @@ import (
 	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
 
-const (
-	// defaultMatchCount is the retrieval depth used when a caller supplies no
-	// usable MatchCount. It doubles as the over-retrieval floor, so the
-	// fallback and the pool it draws from cannot drift apart.
-	defaultMatchCount = 50
-
-	// maxRetrievalPoolSize bounds every retrieval depth derived from
-	// MatchCount: the over-retrieval pool below and the doubling TopK of the
-	// FAQ iterative path. Without it a caller-supplied MatchCount scales the
-	// vector-store query depth without limit.
-	maxRetrievalPoolSize = 500
-)
+// maxRetrievalPoolSize bounds every retrieval depth derived from MatchCount:
+// the over-retrieval pool below and the doubling TopK of the FAQ iterative
+// path. Without it a caller-supplied MatchCount scales the vector-store query
+// depth without limit.
+const maxRetrievalPoolSize = 500
 
 // GetQueryEmbedding computes the query embedding using the embedding model
 // associated with the given knowledge base. Callers can pre-compute and reuse
@@ -164,9 +157,9 @@ func (s *knowledgeBaseService) HybridSearch(ctx context.Context,
 	}
 
 	// Over-retrieval (existing rule, preserved): 5x per-KB matchCount,
-	// floored at defaultMatchCount, capped at maxRetrievalPoolSize across the
-	// whole search.
-	matchCount := max(params.MatchCount*5, defaultMatchCount) * len(searchKBIDs)
+	// floored at DefaultRetrievalTopK, capped at maxRetrievalPoolSize across
+	// the whole search.
+	matchCount := max(params.MatchCount*5, types.DefaultRetrievalTopK) * len(searchKBIDs)
 	if matchCount > maxRetrievalPoolSize {
 		matchCount = maxRetrievalPoolSize
 	}
@@ -286,13 +279,13 @@ func (s *knowledgeBaseService) HybridSearch(ctx context.Context,
 // the deduplicated chunk list to [:0] and empties an otherwise successful
 // search; a negative value panics on that same slice bound.
 //
-// The fallback matches RetrievalConfig.GetEffectiveEmbeddingTopK: internal
-// callers (chat pipeline, agent tools) feed these results into reranking,
-// which trims to RerankTopK afterwards, so a wide candidate pool is the right
-// failure mode for them.
+// The fallback is shared with RetrievalConfig.GetEffectiveEmbeddingTopK:
+// internal callers (chat pipeline, agent tools) feed these results into
+// reranking, which trims to RerankTopK afterwards, so a wide candidate pool is
+// the right failure mode for them.
 func normalizedMatchCount(requested int) int {
 	if requested <= 0 {
-		return defaultMatchCount
+		return types.DefaultRetrievalTopK
 	}
 	return requested
 }

--- a/internal/application/service/knowledgebase_search_faq.go
+++ b/internal/application/service/knowledgebase_search_faq.go
@@ -77,8 +77,11 @@ func (s *knowledgeBaseService) iterativeRetrieveWithDeduplication(ctx context.Co
 ) ([]*types.IndexWithScore, error) {
 	maxIterations := 5
 	// Start with a larger TopK since we're called when first retrieval wasn't enough
-	// The first retrieval already used matchCount*3, so start from there
-	currentTopK := matchCount * 3
+	// The first retrieval already used matchCount*3, so start from there.
+	// matchCount is caller-supplied, so both the seed and the per-iteration
+	// doubling are bounded by maxRetrievalPoolSize — otherwise a single request
+	// could drive the vector-store query depth arbitrarily deep.
+	currentTopK := min(matchCount*3, maxRetrievalPoolSize)
 	uniqueChunks := make(map[string]*types.IndexWithScore)
 	// Cache chunk data to avoid repeated DB queries across iterations
 	chunkDataCache := make(map[string]*types.Chunk)
@@ -198,8 +201,13 @@ func (s *knowledgeBaseService) iterativeRetrieveWithDeduplication(ctx context.Co
 			break
 		}
 
-		// Increase TopK for next iteration
-		currentTopK *= 2
+		// Increase TopK for next iteration. Once the cap is reached, another
+		// round would re-issue an identical query, so stop instead.
+		if currentTopK >= maxRetrievalPoolSize {
+			logger.Infof(ctx, "Retrieval depth cap %d reached, stopping iteration", maxRetrievalPoolSize)
+			break
+		}
+		currentTopK = min(currentTopK*2, maxRetrievalPoolSize)
 	}
 
 	// Convert map to slice and sort by score

--- a/internal/application/service/knowledgebase_search_matchcount_test.go
+++ b/internal/application/service/knowledgebase_search_matchcount_test.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// TestNormalizedMatchCount pins the contract that a non-positive MatchCount
+// resolves to the service-wide retrieval depth. The regression this guards is
+// severe and silent: a caller that omitted match_count reached the truncation
+// step with 0, which sliced the deduplicated chunk list to [:0] and turned a
+// successful retrieval into an empty response. A negative value panicked on
+// the same slice bound.
+//
+// The fallback shares defaultMatchCount with the over-retrieval floor on
+// purpose: with no explicit MatchCount the `*5` amplification in HybridSearch
+// collapses, so that floor alone decides the per-retriever depth and a larger
+// truncation bound could never yield more results.
+func TestNormalizedMatchCount(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		requested int
+		want      int
+	}{
+		{name: "omitted arrives as zero", requested: 0, want: defaultMatchCount},
+		{name: "negative cannot index a slice", requested: -1, want: defaultMatchCount},
+		{name: "explicit value is honored", requested: 3, want: 3},
+		{name: "large explicit value is not clamped here", requested: 10000, want: 10000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, normalizedMatchCount(tt.requested))
+		})
+	}
+}
+
+// TestIterativeRetrieve_CapsSeedTopK guards the FAQ iterative path against an
+// unbounded caller-supplied MatchCount. The seed is MatchCount*3 and doubles
+// each round, so without the cap a single request could ask a vector store for
+// hundreds of thousands of rows.
+func TestIterativeRetrieve_CapsSeedTopK(t *testing.T) {
+	t.Parallel()
+	// canned is nil, so the first iteration retrieves nothing and the loop
+	// breaks — leaving group.TopK at exactly the seed value under test.
+	empty := &fakeRetrieveEngineService{
+		engineType: types.PostgresRetrieverEngineType,
+		support:    []types.RetrieverType{types.VectorRetrieverType},
+	}
+	groups := []*storeGroup{
+		{
+			Engine:     buildBoundComposite(t, empty),
+			BaseParams: vectorParams("q"),
+			TopK:       50,
+			KBIDs:      []string{"kb-1"},
+		},
+	}
+	s := &knowledgeBaseService{}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+
+	results, err := s.iterativeRetrieveWithDeduplication(ctx, groups, 100000, "q")
+	require.NoError(t, err)
+	assert.Empty(t, results)
+	assert.Equal(t, maxRetrievalPoolSize, groups[0].TopK,
+		"seed TopK must be capped at the retrieval pool bound")
+}

--- a/internal/application/service/knowledgebase_search_matchcount_test.go
+++ b/internal/application/service/knowledgebase_search_matchcount_test.go
@@ -17,7 +17,7 @@ import (
 // successful retrieval into an empty response. A negative value panicked on
 // the same slice bound.
 //
-// The fallback shares defaultMatchCount with the over-retrieval floor on
+// The fallback shares DefaultRetrievalTopK with the over-retrieval floor on
 // purpose: with no explicit MatchCount the `*5` amplification in HybridSearch
 // collapses, so that floor alone decides the per-retriever depth and a larger
 // truncation bound could never yield more results.
@@ -28,8 +28,8 @@ func TestNormalizedMatchCount(t *testing.T) {
 		requested int
 		want      int
 	}{
-		{name: "omitted arrives as zero", requested: 0, want: defaultMatchCount},
-		{name: "negative cannot index a slice", requested: -1, want: defaultMatchCount},
+		{name: "omitted arrives as zero", requested: 0, want: types.DefaultRetrievalTopK},
+		{name: "negative cannot index a slice", requested: -1, want: types.DefaultRetrievalTopK},
 		{name: "explicit value is honored", requested: 3, want: 3},
 		{name: "large explicit value is not clamped here", requested: 10000, want: 10000},
 	}

--- a/internal/types/retrieval_config.go
+++ b/internal/types/retrieval_config.go
@@ -37,10 +37,16 @@ type RetrievalConfig struct {
 	RRFKeywordWeight float64 `json:"rrf_keyword_weight,omitempty"`
 }
 
+// DefaultRetrievalTopK is the retrieval depth used when a caller supplies no
+// usable TopK / MatchCount. HybridSearch also floors its over-retrieval pool
+// at this value, so the fallback and the pool it draws from stay in step by
+// construction rather than by two independently maintained literals.
+const DefaultRetrievalTopK = 50
+
 // GetEffectiveEmbeddingTopK returns EmbeddingTopK with a fallback default.
 func (c *RetrievalConfig) GetEffectiveEmbeddingTopK() int {
 	if c == nil || c.EmbeddingTopK <= 0 {
-		return 50
+		return DefaultRetrievalTopK
 	}
 	return c.EmbeddingTopK
 }

--- a/website-docs/02-architecture/04-rag-pipeline.md
+++ b/website-docs/02-architecture/04-rag-pipeline.md
@@ -476,7 +476,7 @@ sequenceDiagram
 `internal/application/service/knowledgebase_search.go` 是所有检索的汇聚点（chat pipeline、Agent 工具、搜索 API 共用）：
 
 1. **授权与校验**：批量加载 KB（含跨租户 Organization 共享库），逐库 `authorizeKBAccess`；`validateSameEmbeddingModel` 拒绝跨 embedding 空间的多库检索（wiki/graph 无向量库有豁免）。
-2. **过召回**：`matchCount = max(MatchCount*5, 50) * len(KBs)`，上限 500。
+2. **入参归一化 + 过召回**：`MatchCount <= 0`（调用方未传时 JSON 反序列化即为 0）先经 `normalizedMatchCount` 归一化为 `defaultMatchCount`（50），使过召回下限、FAQ 迭代触发条件、末尾截断三处读到同一个值——否则截断会把结果集切成 `[:0]`，负数还会越界 panic；随后 `matchCount = max(MatchCount*5, 50) * len(KBs)`，上限 `maxRetrievalPoolSize`（500）。
 3. **查询向量只算一次**，随 `params.QueryEmbedding` 传播到所有 store 组。
 4. **storeGroup 分组**（`knowledgebase_search_storegroup.go`）：按 `(VectorStoreID, 属主租户)` 分组；每组经 `retriever.CreateRetrieveEngineForKB` 解析出 `CompositeRetrieveEngine`。`buildRetrievalParams` 按组内每个 KB 的类型路由：FAQ 库走 FAQ 向量索引（`KnowledgeType=faq`，无关键词索引），文档库走默认向量索引 + 关键词索引。
 5. **fan-out**（`knowledgebase_search_fanout.go`）：单组直查零开销；多组用 `errgroup` 并发（上限 4），每组超时 `MULTI_STORE_RETRIEVE_TIMEOUT_SEC`（默认 30s），all-or-nothing 失败策略；结果跨引擎类型时用 `EngineAwareNormalizer` 把向量分归一化到 [0,1]（详见检索引擎文档）。
@@ -484,7 +484,7 @@ sequenceDiagram
    - 仅向量或仅关键词 → `deduplicateByScore`（按 chunk 保留最高分）；
    - 混合 → **加权 RRF**：`score = vectorWeight/(k+vectorRank) + keywordWeight/(k+keywordRank)`，`k` 与权重来自租户 `RetrievalConfig`（有缺省值），rank 基于各自检索器返回顺序（1-indexed），对分数尺度免疫。
 7. **FAQ 命中策略**（`knowledgebase_search_faq.go`，仅 FAQ 类型 KB）：
-   - **迭代检索**：去重后不足 `MatchCount` 且首轮已打满 → 从 `TopK*3` 起最多 5 轮翻倍扩大 TopK 重检索，跨 store 组统一生效，chunk 数据缓存避免重复回表；
+   - **迭代检索**：去重后不足 `MatchCount` 且首轮已打满 → 从 `TopK*3` 起最多 5 轮翻倍扩大 TopK 重检索，跨 store 组统一生效，chunk 数据缓存避免重复回表；种子与每轮增长均封顶 `maxRetrievalPoolSize`，触顶即停（再迭代只会重发同一个查询）；
    - **负例问题过滤**：查询与 FAQ 的 `NegativeQuestions` 精确匹配（小写去空格）即剔除该条——支持"这个问题不要用这条 FAQ 答"的运营配置。
 8. 截断到 `MatchCount` 后 `processSearchResults` 补全 chunk 元数据（管线场景 `SkipContextEnrichment=true`，上下文组装留给 merge 阶段）。
 

--- a/website-docs/02-architecture/04-rag-pipeline.md
+++ b/website-docs/02-architecture/04-rag-pipeline.md
@@ -476,7 +476,7 @@ sequenceDiagram
 `internal/application/service/knowledgebase_search.go` 是所有检索的汇聚点（chat pipeline、Agent 工具、搜索 API 共用）：
 
 1. **授权与校验**：批量加载 KB（含跨租户 Organization 共享库），逐库 `authorizeKBAccess`；`validateSameEmbeddingModel` 拒绝跨 embedding 空间的多库检索（wiki/graph 无向量库有豁免）。
-2. **入参归一化 + 过召回**：`MatchCount <= 0`（调用方未传时 JSON 反序列化即为 0）先经 `normalizedMatchCount` 归一化为 `defaultMatchCount`（50），使过召回下限、FAQ 迭代触发条件、末尾截断三处读到同一个值——否则截断会把结果集切成 `[:0]`，负数还会越界 panic；随后 `matchCount = max(MatchCount*5, 50) * len(KBs)`，上限 `maxRetrievalPoolSize`（500）。
+2. **入参归一化 + 过召回**：`MatchCount <= 0`（调用方未传时 JSON 反序列化即为 0）先经 `normalizedMatchCount` 归一化为 `types.DefaultRetrievalTopK`（50），使过召回下限、FAQ 迭代触发条件、末尾截断三处读到同一个值——否则截断会把结果集切成 `[:0]`，负数还会越界 panic；随后 `matchCount = max(MatchCount*5, 50) * len(KBs)`，上限 `maxRetrievalPoolSize`（500）。
 3. **查询向量只算一次**，随 `params.QueryEmbedding` 传播到所有 store 组。
 4. **storeGroup 分组**（`knowledgebase_search_storegroup.go`）：按 `(VectorStoreID, 属主租户)` 分组；每组经 `retriever.CreateRetrieveEngineForKB` 解析出 `CompositeRetrieveEngine`。`buildRetrievalParams` 按组内每个 KB 的类型路由：FAQ 库走 FAQ 向量索引（`KnowledgeType=faq`，无关键词索引），文档库走默认向量索引 + 关键词索引。
 5. **fan-out**（`knowledgebase_search_fanout.go`）：单组直查零开销；多组用 `errgroup` 并发（上限 4），每组超时 `MULTI_STORE_RETRIEVE_TIMEOUT_SEC`（默认 30s），all-or-nothing 失败策略；结果跨引擎类型时用 `EngineAwareNormalizer` 把向量分归一化到 [0,1]（详见检索引擎文档）。

--- a/website-docs/03-features/17-faq.md
+++ b/website-docs/03-features/17-faq.md
@@ -187,7 +187,7 @@ type FAQSearchRequest struct {
 1. **混合召回**：查询文本归一化后做向量检索 + BM25 关键词检索，融合去重；
 2. **两级标签优先**：`FirstPriorityTagIDs` 命中的条目排最前，其次 `SecondPriorityTagIDs`；
 3. **负例过滤**（`filterByNegativeQuestions`）：查询文本与某条目的任一反例问完全匹配（小写比较）→ 该条目从结果中剔除。典型场景：用户问"不支持 X 吗"，避免返回"支持 X"的条目；
-4. **迭代召回**（`applyFAQPostProcessing`）：当过滤后的唯一条目数不足 `match_count` 且向量结果打满时触发 `iterativeRetrieveWithDeduplication`——最多迭代 5 次、每次 TopK 翻倍，带去重与负例过滤缓存，无新结果提前终止；
+4. **迭代召回**（`applyFAQPostProcessing`）：当过滤后的唯一条目数不足 `match_count` 且向量结果打满时触发 `iterativeRetrieveWithDeduplication`——最多迭代 5 次、每次 TopK 翻倍（种子 `MatchCount*3` 与每轮增长均封顶 500，触顶即停），带去重与负例过滤缓存，无新结果提前终止；
 5. 结果附带 `score`、`match_type`、`matched_question`（实际命中的是标准问还是哪个相似问），答案按 `answer_strategy`（all / random）返回。
 
 非 FAQ 类型 KB 直接跳过该后处理（`if kb.Type != types.KnowledgeBaseTypeFAQ { return chunks, nil }`），普通混合检索不受影响；agent 检索链在 FAQ 库上同样经过这条后处理路径。


### PR DESCRIPTION
## Description
这是 #1156 的后续，主要目的是让这块逻辑更整洁：把同一件事收敛到一处处理，顺手补上两个当时没覆盖到的地方。#1156 已经把线上问题止住了，这个 PR 不改变它的结论。
**背景**：`match_count` 是搜索接口的可选字段。调用方不传时，代码里拿到的是 0——请求体里没有这个字段，和明确传了个 0，在解析后是同一个结果，区分不出来。
`HybridSearch` 里有三个地方要用这个值：
1. 决定向量和关键词各自要多捞多少候选（`max(MatchCount*5, 50)`）
2. 判断 FAQ 库要不要再多捞一轮（`len(chunks) < params.MatchCount`）
3. 最后截断，决定返回多少条（`deduplicatedChunks[:params.MatchCount]`）

#1156 在第 3 处加了兜底。第 1 处因为自带下限，本来就不受影响。但第 2 处仍然读到原始的 0，而 `len(chunks) < 0` 永远不成立——也就是说 FAQ 库那个"结果不够就扩大范围再捞一轮"的逻辑，在这条路径上一直不会触发。
这个 PR 把取值改到函数入口做一次，三处读到同一个数，不再各自解释。参数是值传递，改动只在这次调用内生效。

**顺带修掉的两件事**：

一是负数。原来传 `match_count: -1` 时，截断那一行会越界，请求以 500 收场（有 recover 兜着，不会影响进程）。入口这次用的是"小于等于 0"，负数一并覆盖。
二是 FAQ 那段再捞一轮的深度。它以传入值的 3 倍起步、之后每轮翻倍最多 5 轮，而 `match_count` 从接口进来是没有上限的，极端情况下一次请求会向向量库要几十万条。现在起步值和每轮增长都封顶在 500（和已有的候选池上限同一个数），到顶就停止，不再重复发同一个查询。这件事和上面的取值改动是配套的：正是因为取值统一了，FAQ 那条路径才会被真正走到，所以上限必须同时补上。
**第二个 commit 是纯整理**，没有任何行为变化：`50` 这个数字原来在三个地方各写了一遍——候选池下限、#1156 加的兜底、以及租户检索配置里的默认值——但没有任何地方记录这三者本该一致。现在提成一个共用常量。

### 不包含的部分
搜索接口本身"不传 `match_count` 时应该返回几条"这个默认值，这个 PR 没有定。目前会落到服务层的兜底值 50。这个 50 是按内部调用方的需要定的——对话链路和 Agent 工具拿到结果后还要走重排、之后再裁剪，候选多一些是合理的；而一个纯搜索接口可能更应该像 FAQ 搜索接口那样默认给 10 条。这属于产品决定，单独拿出来讨论，不放进来卡住这次修复。
在此期间没有安全问题：上面那个上限已经把实际检索深度框住了，不管调用方传什么。

### 影响范围
显式传了正数的调用方不受影响，包括对话链路、MCP 的 `search_chunks`、命令行的 `search chunks`、FAQ 搜索和 Agent 工具。
传进来是 0 的调用方，原来拿到空结果，现在会拿到结果。除了 HTTP 接口，还有一种情况：配置里 `conversation.embedding_top_k` 被设成 0 时，对话链路和 Agent 工具也会走到这里——配置校验只要求这个值大于等于 0，所以 0 是合法的。默认配置是 30，属于边缘情况，但确实意味着这类租户的召回量会有变化，万一有人反馈"升级后回答不一样了"，可以对上号。

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [x] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
#1156 的后续，没有单独开 issue。

## Testing
新增回归测试在 `internal/application/service/knowledgebase_search_matchcount_test.go`：
- 不传（0）和负数（-1）都会取到默认值，显式传的正数原样保留；
- 传入 100000 时，FAQ 那段的起步深度是 500 而不是 300000。
本地执行过的检查：
```
git diff --check origin/main...HEAD            # 无空白字符问题
gofmt -l internal/                             # 无待格式化文件
go build ./internal/...                        # 通过
go vet ./internal/handler/ ./internal/application/service/ ./internal/types/
go test ./internal/application/service/... ./internal/handler/ ./internal/types/
go test ./...                                  # 全仓，全部通过
GOTOOLCHAIN=go1.26.0 golangci-lint run --new-from-rev=origin/main ./internal/...
                                               # 0 issues
```
关于格式化工具的一点说明：`gofumpt` 会提示 `knowledgebase_search_faq.go` 需要调整，但差异只是文件里原有的 `"slices"` 这一行 import 的位置，本 PR 没有动它，为了不扩大改动范围就没顺手改。CI 用的是 `only-new-issues: true`，不会把它算作新增问题。

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above
## Screenshots / Recordings
无，不涉及界面改动。