### PR TITLE
feat: support editing document summaries

### DIFF
--- a/client/initialization.go
+++ b/client/initialization.go
@@ -26,11 +26,11 @@ type InitializationConfig struct {
 // CLI. Field tags are snake_case (the CLI envelope convention), remapped from
 // the server's camelCase.
 type KBModelConfigView struct {
-	RetrievalReady bool                  `json:"retrieval_ready"` // embedding model bound → KB can embed/retrieve
-	Embedding      ModelSlotView         `json:"embedding"`
-	LLM            ModelSlotView         `json:"llm"`
-	Rerank         RerankSlotView        `json:"rerank"`
-	Multimodal     MultimodalSlotView    `json:"multimodal"`
+	RetrievalReady bool               `json:"retrieval_ready"` // embedding model bound → KB can embed/retrieve
+	Embedding      ModelSlotView      `json:"embedding"`
+	LLM            ModelSlotView      `json:"llm"`
+	Rerank         RerankSlotView     `json:"rerank"`
+	Multimodal     MultimodalSlotView `json:"multimodal"`
 }
 
 // ModelSlotView is one non-secret model slot (embedding / llm).

--- a/docs/api/knowledge.md
+++ b/docs/api/knowledge.md
@@ -548,7 +548,9 @@ curl --location 'http://localhost:8080/api/v1/knowledge/4c4e7c1a-09cf-485b-a7b5-
 
 ## PUT `/knowledge/:id` - 更新知识
 
-更新知识条目的元信息（标题/描述/标签等）。请求体为 `Knowledge` 结构，仅服务侧白名单字段会被实际更新。
+部分更新知识条目的元信息。请求体字段均可选；**未传字段保持不变**。显式传入 `"description": ""` 可清空摘要。
+
+可更新字段：`title`、`description`、`custom_metadata`。
 
 **请求**:
 
@@ -558,9 +560,18 @@ curl --location --request PUT 'http://localhost:8080/api/v1/knowledge/4c4e7c1a-0
 --header 'Content-Type: application/json' \
 --data '{
     "title": "彗星 - 天文百科",
-    "description": "彗星条目，已校对",
-    "tag_id": "tag-00000001",
-    "enable_status": "enabled"
+    "description": "彗星条目，已校对"
+}'
+```
+
+清空摘要示例：
+
+```curl
+curl --location --request PUT 'http://localhost:8080/api/v1/knowledge/4c4e7c1a-09cf-485b-a7b5-24b8cdc5acf5' \
+--header 'X-API-Key: sk-xxxxx' \
+--header 'Content-Type: application/json' \
+--data '{
+    "description": ""
 }'
 ```
 
@@ -569,7 +580,8 @@ curl --location --request PUT 'http://localhost:8080/api/v1/knowledge/4c4e7c1a-0
 ```json
 {
     "success": true,
-    "message": "Knowledge chunk updated successfully"
+    "message": "Knowledge updated successfully",
+    "data": {}
 }
 ```
 

--- a/frontend/src/api/knowledge-base/index.ts
+++ b/frontend/src/api/knowledge-base/index.ts
@@ -422,6 +422,10 @@ export function updateKnowledgeMetadata(knowledgeId: string, customMetadata: Rec
   return put(`/api/v1/knowledge/${knowledgeId}`, { custom_metadata: customMetadata });
 }
 
+export function updateKnowledgeSummary(knowledgeId: string, description: string) {
+  return put(`/api/v1/knowledge/${knowledgeId}`, { description });
+}
+
 export function regenerateKnowledgeSummary(knowledgeId: string) {
   return post(`/api/v1/knowledge/${knowledgeId}/regenerate-summary`, {});
 }

--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -11,7 +11,7 @@ import { onMounted, ref, nextTick, onUnmounted, watch, computed } from "vue";
 import {
   downKnowledgeDetails, deleteGeneratedQuestion, getChunkByIdOnly, previewKnowledgeFile,
   updateDocumentChunk, listChunkRevisions, revertDocumentChunk, updateKnowledgeMetadata,
-  regenerateKnowledgeSummary, upsertGeneratedQuestion, regenerateGeneratedQuestions, getKnowledgeDetails,
+  updateKnowledgeSummary, regenerateKnowledgeSummary, upsertGeneratedQuestion, regenerateGeneratedQuestions, getKnowledgeDetails,
   KNOWLEDGE_CHUNK_PAGE_SIZE,
 } from "@/api/knowledge-base/index";
 import { MessagePlugin } from "tdesign-vue-next";
@@ -52,6 +52,34 @@ const metadataEditing = ref(false);
 const metadataDraft = ref<MetadataDraftRow[]>([]);
 const metadataSaving = ref(false);
 const summaryRefreshing = ref(false);
+const summaryEditing = ref(false);
+const summaryDraft = ref('');
+const summarySaving = ref(false);
+
+const startSummaryEdit = () => {
+  summaryDraft.value = props.details?.description || '';
+  summaryEditing.value = true;
+};
+
+const cancelSummaryEdit = () => {
+  summaryEditing.value = false;
+  summaryDraft.value = '';
+};
+
+const saveSummary = async () => {
+  summarySaving.value = true;
+  try {
+    const description = summaryDraft.value.trim();
+    const result: any = await updateKnowledgeSummary(props.details.id, description);
+    applySummaryState(result?.data?.summary_status, result?.data?.description ?? description);
+    summaryEditing.value = false;
+    MessagePlugin.success(t('common.saveSuccess'));
+  } catch (error: any) {
+    MessagePlugin.error(error?.message || t('common.saveFailed'));
+  } finally {
+    summarySaving.value = false;
+  }
+};
 
 const metadataTypeOptions = computed(() => [
   { label: t('knowledgeBase.metadataTypeText'), value: 'text' },
@@ -603,6 +631,7 @@ onMounted(() => {
 });
 
 watch(() => props.details?.id, () => {
+  cancelSummaryEdit();
   chunkPage.value = 1;
   loadedChunkPage.value = 1;
   pendingChunkPage = null;
@@ -1724,14 +1753,34 @@ const handleChunkPageChange = (pageInfo: { current: number }) => {
                 <span>{{ $t('knowledgeBase.generatingSummary') }}</span>
               </span>
             </div>
-            <t-tooltip v-if="canEditContent" :content="$t('knowledgeBase.regenerateSummary')" placement="top">
-              <t-button class="icon-action-btn" size="small" variant="text" shape="square"
-                :loading="summaryRefreshing" @click="refreshSummary">
-                <template #icon><t-icon name="refresh" size="15px" /></template>
-              </t-button>
-            </t-tooltip>
+            <div v-if="canEditContent && !summaryEditing" class="summary-title-actions">
+              <t-tooltip :content="$t('common.edit')" placement="top">
+                <t-button class="icon-action-btn" size="small" variant="text" shape="square"
+                  @click="startSummaryEdit">
+                  <template #icon><t-icon name="edit" size="15px" /></template>
+                </t-button>
+              </t-tooltip>
+              <t-tooltip :content="$t('knowledgeBase.regenerateSummary')" placement="top">
+                <t-button class="icon-action-btn" size="small" variant="text" shape="square"
+                  :loading="summaryRefreshing" @click="refreshSummary">
+                  <template #icon><t-icon name="refresh" size="15px" /></template>
+                </t-button>
+              </t-tooltip>
+            </div>
           </div>
-          <div v-if="details.description" class="summary_wrapper"
+          <div v-if="summaryEditing" class="summary_editor">
+            <t-textarea v-model="summaryDraft" :autosize="{ minRows: 4, maxRows: 10 }"
+              :placeholder="$t('knowledgeBase.noDocumentSummary')" />
+            <div class="summary_editor_actions">
+              <t-button size="small" variant="outline" :disabled="summarySaving" @click="cancelSummaryEdit">
+                {{ $t('common.cancel') }}
+              </t-button>
+              <t-button size="small" theme="primary" :loading="summarySaving" @click="saveSummary">
+                {{ $t('common.save') }}
+              </t-button>
+            </div>
+          </div>
+          <div v-else-if="details.description" class="summary_wrapper"
             :class="{ 'summary_clickable': summaryOverflow || summaryExpanded }"
             @click="(summaryOverflow || summaryExpanded) && (summaryExpanded = !summaryExpanded)">
             <div ref="summaryRef" :class="['summary_content', { 'summary_collapsed': !summaryExpanded }]">{{
@@ -2543,6 +2592,23 @@ const handleChunkPageChange = (pageInfo: { current: number }) => {
   &.summary_clickable {
     cursor: pointer;
   }
+}
+
+.summary-title-actions,
+.summary_editor_actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.summary_editor {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.summary_editor_actions {
+  justify-content: flex-end;
 }
 
 .summary_content {

--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -261,6 +261,7 @@ const applySummaryState = (summaryStatus?: string, description?: string) => {
 
 const isSummaryStatusInFlight = (status?: string) => status === 'pending' || status === 'processing';
 const summaryStatusRefreshing = computed(() => isSummaryStatusInFlight(props.details?.summary_status));
+const canEditSummary = computed(() => canEditContent.value && !summaryStatusRefreshing.value);
 let summaryStatusPollTimer: ReturnType<typeof setTimeout> | null = null;
 let summaryStatusPollGeneration = 0;
 
@@ -840,10 +841,18 @@ watch(() => viewMode.value, (mode) => {
 }, { flush: 'post' });
 
 watch(() => props.visible, (visible) => {
-  if (visible && (viewMode.value === 'chunks' || viewMode.value === 'merged')) {
+  if (!visible) {
+    cancelSummaryEdit();
+  } else if (viewMode.value === 'chunks' || viewMode.value === 'merged') {
     runMarkdownPostRenderPipeline();
   }
 }, { flush: 'post' });
+
+watch(summaryStatusRefreshing, (refreshing) => {
+  if (refreshing) {
+    cancelSummaryEdit();
+  }
+});
 
 // 渲染 Mermaid 图表的函数
 const renderMermaidDiagrams = async () => {
@@ -1754,7 +1763,7 @@ const handleChunkPageChange = (pageInfo: { current: number }) => {
               </span>
             </div>
             <div v-if="canEditContent && !summaryEditing" class="summary-title-actions">
-              <t-tooltip :content="$t('common.edit')" placement="top">
+              <t-tooltip v-if="canEditSummary" :content="$t('common.edit')" placement="top">
                 <t-button class="icon-action-btn" size="small" variant="text" shape="square"
                   @click="startSummaryEdit">
                   <template #icon><t-icon name="edit" size="15px" /></template>

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -698,7 +698,7 @@ func (s *knowledgeService) UpdateKnowledge(ctx context.Context, knowledge *types
 	if knowledge.Title != "" {
 		record.Title = knowledge.Title
 	}
-	if knowledge.Description != "" {
+	if knowledge.DescriptionSpecified || knowledge.Description != "" {
 		record.Description = knowledge.Description
 	}
 	metadataChanged := false

--- a/internal/application/service/knowledge.go
+++ b/internal/application/service/knowledge.go
@@ -698,7 +698,14 @@ func (s *knowledgeService) UpdateKnowledge(ctx context.Context, knowledge *types
 	if knowledge.Title != "" {
 		record.Title = knowledge.Title
 	}
-	if knowledge.DescriptionSpecified || knowledge.Description != "" {
+	if knowledge.DescriptionSpecified {
+		record.Description = knowledge.Description
+		if record.Description != "" {
+			record.SummaryStatus = types.SummaryStatusCompleted
+		} else {
+			record.SummaryStatus = types.SummaryStatusNone
+		}
+	} else if knowledge.Description != "" {
 		record.Description = knowledge.Description
 	}
 	metadataChanged := false

--- a/internal/application/service/knowledge_update_test.go
+++ b/internal/application/service/knowledge_update_test.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateKnowledgeExplicitEmptyDescriptionClearsSummary(t *testing.T) {
+	t.Parallel()
+	repo := &metadataUpdateKnowledgeRepo{knowledge: &types.Knowledge{
+		ID:              "knowledge-1",
+		TenantID:        7,
+		KnowledgeBaseID: "kb-1",
+		Description:     "old summary",
+		SummaryStatus:   types.SummaryStatusCompleted,
+	}}
+	service := &knowledgeService{
+		repo: repo, kbService: metadataUpdateKBService{},
+	}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(7))
+
+	err := service.UpdateKnowledge(ctx, &types.Knowledge{
+		ID:                   "knowledge-1",
+		DescriptionSpecified: true,
+		Description:          "",
+	})
+	require.NoError(t, err)
+	require.Empty(t, repo.knowledge.Description)
+	require.Equal(t, types.SummaryStatusNone, repo.knowledge.SummaryStatus)
+}
+
+func TestUpdateKnowledgeOmittedDescriptionPreservesExisting(t *testing.T) {
+	t.Parallel()
+	repo := &metadataUpdateKnowledgeRepo{knowledge: &types.Knowledge{
+		ID:              "knowledge-1",
+		TenantID:        7,
+		KnowledgeBaseID: "kb-1",
+		Description:     "keep me",
+		SummaryStatus:   types.SummaryStatusCompleted,
+	}}
+	service := &knowledgeService{
+		repo: repo, kbService: metadataUpdateKBService{},
+	}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(7))
+
+	err := service.UpdateKnowledge(ctx, &types.Knowledge{
+		ID:    "knowledge-1",
+		Title: "new title",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "new title", repo.knowledge.Title)
+	require.Equal(t, "keep me", repo.knowledge.Description)
+	require.Equal(t, types.SummaryStatusCompleted, repo.knowledge.SummaryStatus)
+}
+
+func TestUpdateKnowledgeManualDescriptionSetsCompletedStatus(t *testing.T) {
+	t.Parallel()
+	repo := &metadataUpdateKnowledgeRepo{knowledge: &types.Knowledge{
+		ID:              "knowledge-1",
+		TenantID:        7,
+		KnowledgeBaseID: "kb-1",
+		SummaryStatus:   types.SummaryStatusFailed,
+	}}
+	service := &knowledgeService{
+		repo: repo, kbService: metadataUpdateKBService{},
+	}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(7))
+
+	err := service.UpdateKnowledge(ctx, &types.Knowledge{
+		ID:                   "knowledge-1",
+		DescriptionSpecified: true,
+		Description:          "manual summary",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "manual summary", repo.knowledge.Description)
+	require.Equal(t, types.SummaryStatusCompleted, repo.knowledge.SummaryStatus)
+}
+
+func TestUpdateKnowledgeDescriptionOnlyDoesNotTouchMetadata(t *testing.T) {
+	t.Parallel()
+	repo := &metadataUpdateKnowledgeRepo{knowledge: &types.Knowledge{
+		ID:              "knowledge-1",
+		TenantID:        7,
+		KnowledgeBaseID: "kb-1",
+		Description:     "old summary",
+		SummaryStatus:   types.SummaryStatusCompleted,
+		CustomMetadata:  types.JSON(`{"region":"Beijing"}`),
+	}}
+	service := &knowledgeService{
+		repo: repo, kbService: metadataUpdateKBService{},
+	}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(7))
+
+	err := service.UpdateKnowledge(ctx, &types.Knowledge{
+		ID:                   "knowledge-1",
+		DescriptionSpecified: true,
+		Description:          "updated summary",
+	})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"region":"Beijing"}`, string(repo.knowledge.CustomMetadata))
+}

--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -1778,14 +1778,22 @@ func (h *KnowledgeHandler) GetKnowledgeBatch(c *gin.Context) {
 	})
 }
 
+// UpdateKnowledgeRequest defines the partial-update body for PUT /knowledge/:id.
+// Omitted fields are left unchanged; an explicit empty description clears the summary.
+type UpdateKnowledgeRequest struct {
+	Title          *string         `json:"title"`
+	Description    *string         `json:"description"`
+	CustomMetadata json.RawMessage `json:"custom_metadata"`
+}
+
 // UpdateKnowledge godoc
 // @Summary      更新知识
-// @Description  更新知识条目信息
+// @Description  部分更新知识条目（标题/描述/自定义元数据）；未传字段保持不变，显式传空 description 可清空摘要
 // @Tags         知识管理
 // @Accept       json
 // @Produce      json
-// @Param        id       path      string          true  "知识ID"
-// @Param        request  body      types.Knowledge true  "知识信息"
+// @Param        id       path      string                   true  "知识ID"
+// @Param        request  body      UpdateKnowledgeRequest   true  "更新字段（均可选）"
 // @Success      200      {object}  map[string]interface{}  "更新成功"
 // @Failure      400      {object}  errors.AppError         "请求参数错误"
 // @Security     Bearer
@@ -1807,11 +1815,7 @@ func (h *KnowledgeHandler) UpdateKnowledge(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Title          *string         `json:"title"`
-		Description    *string         `json:"description"`
-		CustomMetadata json.RawMessage `json:"custom_metadata"`
-	}
+	var req UpdateKnowledgeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		logger.Error(ctx, "Failed to parse request parameters", err)
 		c.Error(errors.NewBadRequestError(err.Error()))

--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -1807,13 +1807,24 @@ func (h *KnowledgeHandler) UpdateKnowledge(c *gin.Context) {
 		return
 	}
 
-	var knowledge types.Knowledge
-	if err := c.ShouldBindJSON(&knowledge); err != nil {
+	var req struct {
+		Title          *string         `json:"title"`
+		Description    *string         `json:"description"`
+		CustomMetadata json.RawMessage `json:"custom_metadata"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
 		logger.Error(ctx, "Failed to parse request parameters", err)
 		c.Error(errors.NewBadRequestError(err.Error()))
 		return
 	}
-	knowledge.ID = id
+	knowledge := types.Knowledge{ID: id, CustomMetadata: types.JSON(req.CustomMetadata)}
+	if req.Title != nil {
+		knowledge.Title = *req.Title
+	}
+	if req.Description != nil {
+		knowledge.Description = *req.Description
+		knowledge.DescriptionSpecified = true
+	}
 
 	if err := h.kgService.UpdateKnowledge(effCtx, &knowledge); err != nil {
 		logger.ErrorWithFields(ctx, err, nil)

--- a/internal/types/knowledge.go
+++ b/internal/types/knowledge.go
@@ -136,6 +136,9 @@ type Knowledge struct {
 	Title string `json:"title"`
 	// Description of the knowledge
 	Description string `json:"description"`
+	// DescriptionSpecified distinguishes an explicitly supplied empty description
+	// from an omitted field in partial update requests.
+	DescriptionSpecified bool `json:"-" gorm:"-"`
 	// Source of the knowledge (e.g. URL address for url type, "manual" for manual type)
 	Source string `json:"source"             gorm:"type:varchar(2048)"`
 	// Channel indicates through which channel the knowledge was ingested (web, api, browser_extension, wechat, etc.)


### PR DESCRIPTION
## Description

为知识库文档详情抽屉中的“摘要”增加手动编辑能力。

主要变更：

- 在文档摘要标题旁增加编辑按钮，仅对具有编辑权限的用户显示
- 支持通过多行文本框编辑摘要，并提供保存、取消操作
- 支持清空已有摘要
- 保存后同步更新详情抽屉及文档列表中的摘要内容
- 保留原有的“重新生成摘要”功能
- 调整 `PUT /api/v1/knowledge/:id` 的部分更新逻辑，区分“未传入摘要字段”和“显式传入空摘要”，避免清空操作失效

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2744 

## Testing

已执行以下检查：

```bash
cd frontend
npm run type-check
```

结果：通过。

```bash
go test ./internal/application/service -run 'TestUpdateKnowledge' -count=1
go test ./internal/handler -run '^TestNonExistent$' -count=1
```

结果：通过，确认相关 Service 和 Handler 可以正常编译，已有知识更新测试通过。

```bash
git diff --check
```

结果：通过。

同时执行了：

```bash
go test ./internal/handler ./internal/application/service
```


本次改动涉及的代码已成功编译，针对性测试均通过。

手动验证步骤：

1. 进入 `/platform/knowledge-bases/:kbId`
2. 打开一个文档的详情抽屉
3. 在“摘要”标题右侧点击编辑按钮
4. 修改摘要并点击保存
5. 确认抽屉及文档列表中的摘要同步更新
6. 再次编辑并清空摘要，确认可以正常保存为空
7. 使用只读权限访问，确认不显示编辑按钮
8. 确认“重新生成摘要”功能仍可正常使用

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings



https://github.com/user-attachments/assets/f72f5495-6b91-4966-8474-22ac9b001366

