### PR TITLE
docs: fix URL-encoded slash in Trendshift badge alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 <p align="center">
   <h4 align="center">
 
-  [概述](#-overview) • [Architecture](#-architecture) • [Key Features](#-key-features) • [Getting Started](#-getting-started) • [API Reference](#-api-reference) • [Developer Guide](#-developer-guide)
+  [Overview](#-overview) • [Architecture](#-architecture) • [Key Features](#-key-features) • [Getting Started](#-getting-started) • [API Reference](#-api-reference) • [Developer Guide](#-developer-guide)
   
   </h4>
 </p>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <picture>
     <a href="https://trendshift.io/repositories/15289" target="_blank">
-      <img src="https://trendshift.io/api/badge/repositories/15289" alt="Tencent%2FWeKnora | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
+      <img src="https://trendshift.io/api/badge/repositories/15289" alt="Tencent/WeKnora | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
     </a>
   </picture>
 </p>
@@ -39,7 +39,7 @@
 <p align="center">
   <h4 align="center">
 
-  [Overview](#-overview) • [Architecture](#-architecture) • [Key Features](#-key-features) • [Getting Started](#-getting-started) • [API Reference](#-api-reference) • [Developer Guide](#-developer-guide)
+  [概述](#-overview) • [Architecture](#-architecture) • [Key Features](#-key-features) • [Getting Started](#-getting-started) • [API Reference](#-api-reference) • [Developer Guide](#-developer-guide)
   
   </h4>
 </p>

--- a/README_CN.md
+++ b/README_CN.md
@@ -7,7 +7,7 @@
 <p align="center">
   <picture>
     <a href="https://trendshift.io/repositories/15289" target="_blank">
-      <img src="https://trendshift.io/api/badge/repositories/15289" alt="Tencent%2FWeKnora | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
+      <img src="https://trendshift.io/api/badge/repositories/15289" alt="Tencent/WeKnora | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
     </a>
   </picture>
 </p>

--- a/README_JA.md
+++ b/README_JA.md
@@ -6,7 +6,7 @@
 <p align="center">
   <picture>
     <a href="https://trendshift.io/repositories/15289" target="_blank">
-      <img src="https://trendshift.io/api/badge/repositories/15289" alt="Tencent%2FWeKnora | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
+      <img src="https://trendshift.io/api/badge/repositories/15289" alt="Tencent/WeKnora | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
     </a>
   </picture>
 </p>

--- a/README_KO.md
+++ b/README_KO.md
@@ -7,7 +7,7 @@
 <p align="center">
   <picture>
     <a href="https://trendshift.io/repositories/15289" target="_blank">
-      <img src="https://trendshift.io/api/badge/repositories/15289" alt="Tencent%2FWeKnora | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
+      <img src="https://trendshift.io/api/badge/repositories/15289" alt="Tencent/WeKnora | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
     </a>
   </picture>
 </p>


### PR DESCRIPTION
## Description

The Trendshift badge on the README (and the zh-CN / ja / ko variants)
uses `alt="Tencent%2FWeKnora | Trendshift"`. `%2F` is the URL-encoded
form of `/` and should not appear in a visible alt attribute.

This changes it to `Tencent/WeKnora` across README.md, README_CN.md,
README_JA.md and README_KO.md.

## Type of Change

- [√] 📚 Documentation update

## Related Issue

N/A

## Testing

Verified via `git diff --check` (passes) and confirmed the URL-encoded
`%2F` no longer appears in any of the four README files. This is a
documentation-only change; no Go code or tests are touched.

## Checklist

- [√] `git diff --check origin/main...HEAD` passes
- [√] Self-reviewed the code
- [√] Updated related documentation (README, `docs/`, Swagger annotations, etc.)

## Screenshots / Recordings

N/A