### PR TITLE
ci(dsh-weknora): cache pinned dsh install to speed up e2e

### DIFF
--- a/.github/workflows/dsh-plugin.yml
+++ b/.github/workflows/dsh-plugin.yml
@@ -65,6 +65,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
+          cache: npm
+          cache-dependency-path: packages/dsh-weknora/package-lock.json
 
       - name: Install dependencies
         run: npm ci || npm install
@@ -111,7 +113,7 @@ jobs:
   e2e:
     name: End-to-end inside dsh (pinned)
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: packages/dsh-weknora
@@ -121,10 +123,20 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
+          cache: npm
+          cache-dependency-path: packages/dsh-weknora/package-lock.json
 
       - uses: pnpm/action-setup@v4
         with:
           version: ${{ env.PNPM_VERSION }}
+
+      # The e2e script installs @deepseek-ai/dsh on first run (~15 min uncached).
+      # Reuse the install across workflow runs; bump DSH_PINNED_SPEC to refresh.
+      - name: Cache pinned dsh install
+        uses: actions/cache@v4
+        with:
+          path: .cache/dsh-e2e-install
+          key: dsh-e2e-${{ env.DSH_PINNED_SPEC }}
 
       - name: Install dependencies
         run: npm ci || npm install
@@ -135,6 +147,7 @@ jobs:
       - name: Run the plugin inside a real dsh profile
         env:
           DSH_PACKAGE_SPEC: ${{ env.DSH_PINNED_SPEC }}
+          DSH_INSTALL_DIR: ${{ github.workspace }}/.cache/dsh-e2e-install
           DSH_E2E_LOG: ${{ runner.temp }}/dsh-weknora-e2e.log
         run: node test/e2e/run-in-dsh.mjs
 
@@ -161,10 +174,23 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
+          cache: npm
+          cache-dependency-path: packages/dsh-weknora/package-lock.json
 
       - uses: pnpm/action-setup@v4
         with:
           version: ${{ env.PNPM_VERSION }}
+
+      - name: Week id for dsh@latest cache
+        id: week
+        run: echo "id=$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
+
+      # dsh@latest moves; refresh the cache weekly.
+      - name: Cache latest dsh install
+        uses: actions/cache@v4
+        with:
+          path: .cache/dsh-e2e-install-latest
+          key: dsh-e2e-latest-${{ steps.week.outputs.id }}
 
       - name: Install dependencies
         run: npm ci || npm install
@@ -175,6 +201,7 @@ jobs:
       - name: Run against the latest harness release
         env:
           DSH_PACKAGE_SPEC: "@deepseek-ai/dsh@latest"
+          DSH_INSTALL_DIR: ${{ github.workspace }}/.cache/dsh-e2e-install-latest
         run: node test/e2e/run-in-dsh.mjs
 
   publish:
@@ -199,6 +226,8 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          cache: npm
+          cache-dependency-path: packages/dsh-weknora/package-lock.json
 
       - name: Install dependencies
         run: npm ci || npm install


### PR DESCRIPTION
## Summary

- Cache the pinned `@deepseek-ai/dsh` install used by the e2e job (keyed by `DSH_PINNED_SPEC`) so CI does not spend ~15 minutes downloading it on every run.
- Enable npm dependency caching for the dsh-weknora workflow jobs.
- Refresh the advisory `dsh@latest` drift cache weekly; reduce the pinned e2e timeout from 25 to 10 minutes.

The actual harness scenarios finish in a few seconds; the bottleneck is cold `npm install @deepseek-ai/dsh@…`. After the first cache warm-up, the workflow should drop from ~16 minutes to ~3–4 minutes.

## Test plan

- [ ] Merge and confirm the first run still passes (cache miss, may take ~15 min for e2e)
- [ ] Re-run workflow or push a noop change and confirm e2e completes in a few minutes with log line `# reusing the dsh install at …`
- [ ] Tag publish path still runs e2e + publish successfully