### PR TITLE
fix(im): handle unresolved Feishu resource images

### DIFF
--- a/internal/im/feishu/adapter.go
+++ b/internal/im/feishu/adapter.go
@@ -1008,8 +1008,10 @@ func (a *Adapter) cardkitUpdateElement(ctx context.Context, accessToken, cardID,
 // reaches the card we must download each referenced image and re-upload it to
 // Feishu to obtain a usable image_key.
 
-// feishuMarkdownImageRe matches a markdown image whose target is an http(s) URL.
-var feishuMarkdownImageRe = regexp.MustCompile(`!\[([^\]]*)\]\((https?://[^)\s]+)\)`)
+// feishuMarkdownImageRe matches markdown images backed by a URL that WeKnora may
+// send to a card. An unresolved resource:// handle is not a valid Feishu
+// image_key, so resolveMarkdownImages degrades it to a link instead.
+var feishuMarkdownImageRe = regexp.MustCompile(`!\[([^\]]*)\]\(((?:https?://|resource://)[^)\s]+)\)`)
 
 // feishuMaxImageBytes caps the download size of an image before uploading to
 // Feishu (Feishu's limit is 10MB; keep a small margin).
@@ -1035,23 +1037,29 @@ func imageCacheKey(rawURL string) string {
 }
 
 // resolveMarkdownImages replaces the URL inside every ![alt](httpURL) with a
-// Feishu image_key. On failure it degrades the image to a plain text link so the
-// rest of the card still renders instead of failing the whole update.
+// Feishu image_key. On failure, or when the storage resolver left a resource://
+// handle unresolved, it degrades the image to a plain text link so the rest of
+// the card still renders instead of failing the whole update.
 func (a *Adapter) resolveMarkdownImages(ctx context.Context, accessToken, content string) string {
 	if !strings.Contains(content, "![") {
 		return content
 	}
+	fallback := func(alt, rawURL string) string {
+		if alt == "" {
+			alt = a.region.ImageFallbackLabel
+		}
+		return fmt.Sprintf("[%s](%s)", alt, rawURL)
+	}
 	return feishuMarkdownImageRe.ReplaceAllStringFunc(content, func(match string) string {
 		sub := feishuMarkdownImageRe.FindStringSubmatch(match)
 		alt, rawURL := sub[1], sub[2]
+		if strings.HasPrefix(rawURL, "resource://") {
+			return fallback(alt, rawURL)
+		}
 		imgKey, err := a.imageKeyForURL(ctx, accessToken, rawURL)
 		if err != nil || imgKey == "" {
 			logger.Warnf(ctx, "[%s] image upload failed, degrading to link: url=%s err=%v", a.region.Label, rawURL, err)
-			label := alt
-			if label == "" {
-				label = a.region.ImageFallbackLabel
-			}
-			return fmt.Sprintf("[%s](%s)", label, rawURL)
+			return fallback(alt, rawURL)
 		}
 		return fmt.Sprintf("![%s](%s)", alt, imgKey)
 	})

--- a/internal/im/feishu/adapter_test.go
+++ b/internal/im/feishu/adapter_test.go
@@ -90,6 +90,15 @@ func TestResolveMarkdownImages_FallbackToLinkOnFailure(t *testing.T) {
 	}
 }
 
+func TestResolveMarkdownImages_ResourceHandleFallsBackToLink(t *testing.T) {
+	a := &Adapter{region: RegionFeishu}
+	in := "see ![diagram](resource://Zb2IrqfTdlCFkbUqFtmS5A) here"
+	want := "see [diagram](resource://Zb2IrqfTdlCFkbUqFtmS5A) here"
+	if got := a.resolveMarkdownImages(context.Background(), "tok", in); got != want {
+		t.Errorf("resource image fallback = %q, want %q", got, want)
+	}
+}
+
 // An image with no alt text falls back to the region's own label, so Lark users
 // do not get a Chinese link label.
 func TestResolveMarkdownImages_FallbackLabelFollowsRegion(t *testing.T) {


### PR DESCRIPTION
## Description

Feishu interactive cards reject unresolved `resource://` Markdown images as invalid image keys. The adapter's image matcher only handled HTTP(S), so unresolved resource handles passed through unchanged and could make the entire card update fail.

This change:

- recognizes `resource://` image targets in `resolveMarkdownImages`;
- degrades unresolved resource images to ordinary Markdown links using the existing regional fallback label;
- keeps the existing HTTP(S) upload-to-`image_key` path unchanged.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2726

## Testing

```text
go test ./internal/im/feishu -count=1
go test ./internal/im/... -count=1
go vet ./internal/im/feishu
golangci-lint run --new-from-rev=origin/main ./internal/im/feishu
```

All commands pass; golangci-lint reports `0 issues`.

The full repository suite was not run because the change is isolated to the Feishu adapter; the complete `internal/im/...` package tree was tested.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent limitations are documented above
- [x] Self-reviewed the code
- [x] Added tests covering the change
- [x] Documentation is not affected; no public API or configuration changed
- [x] No breaking changes

## Screenshots / Recordings

Not applicable; this is an IM adapter behavior fix.
