### PR TITLE
feat(chat): display message timestamps

### DIFF
--- a/frontend/src/components/chat/MessageTimestamp.vue
+++ b/frontend/src/components/chat/MessageTimestamp.vue
@@ -1,0 +1,37 @@
+<template>
+  <time v-if="label" class="message-time" :class="alignClass" :datetime="datetime">{{ label }}</time>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { formatMessageTimestamp, normalizeMessageCreatedAt } from '@/utils/messageTimestamp'
+
+const props = defineProps<{
+  value?: unknown
+  align?: 'start' | 'end'
+}>()
+
+const datetime = computed(() => normalizeMessageCreatedAt(props.value))
+const label = computed(() => formatMessageTimestamp(props.value))
+const alignClass = computed(() =>
+  props.align === 'end' ? 'message-time--end' : 'message-time--start',
+)
+</script>
+
+<style scoped lang="less">
+.message-time {
+  margin-top: 4px;
+  color: var(--td-text-color-secondary);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  line-height: 20px;
+}
+
+.message-time--start {
+  align-self: flex-start;
+}
+
+.message-time--end {
+  align-self: flex-end;
+}
+</style>

--- a/frontend/src/composables/useChatStreamHandler.ts
+++ b/frontend/src/composables/useChatStreamHandler.ts
@@ -1,6 +1,7 @@
 import { markRaw, nextTick, type Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ensureRagPipelineHistoryStream } from '@/utils/rag-pipeline-history'
+import { applyMessageCreatedAt, bindServerTurnTimestamps, ensureMessageCreatedAt } from '@/utils/messageTimestamp'
 
 export type ChatMessage = Record<string, unknown>
 
@@ -56,6 +57,16 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
     onAgentChunkBound,
     debug = false,
   } = options
+
+  const emitMessageCreated = (message: ChatMessage) => {
+    ensureMessageCreatedAt(message)
+    onMessageCreated?.(message)
+  }
+
+  const emitMessageUpdated = (message: ChatMessage, payload?: ChatMessage) => {
+    if (payload) applyMessageCreatedAt(message, payload.created_at)
+    onMessageUpdated?.(message, payload)
+  }
 
   const log = (...args: unknown[]) => {
     if (debug) console.log(...args)
@@ -166,7 +177,7 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
       }
       ensureAgentMessageShell(message, data.id as string | undefined)
       messagesList.push(message)
-      onMessageCreated?.(message)
+      emitMessageCreated(message)
       loading.value = false
     } else {
       ensureAgentMessageShell(message, data.id as string | undefined)
@@ -174,7 +185,7 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
 
     message.knowledge_references = refs.slice()
     if (created) onAgentChunkBound?.(message, true)
-    onMessageUpdated?.(message, data)
+    emitMessageUpdated(message, data)
     log('[References] Saved to message, count:', refs.length)
     return message
   }
@@ -194,7 +205,7 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
       return undefined
     }
     message.used_memories = memories.slice()
-    onMessageUpdated?.(message, data)
+    emitMessageUpdated(message, data)
     log('[Memory] Saved to message, count:', memories.length)
     return message
   }
@@ -473,13 +484,13 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
       }
       if (payload.is_fallback) message.is_fallback = true
       if (payload.is_completed) message.is_completed = true
-      onMessageUpdated?.(message, payload)
+      emitMessageUpdated(message, payload)
     } else {
       const entry = { ...payload }
       if (entry.id && !entry.request_id) entry.request_id = entry.id
       messagesList.push(entry)
-      onMessageCreated?.(entry)
-      onMessageUpdated?.(entry, payload)
+      emitMessageCreated(entry)
+      emitMessageUpdated(entry, payload)
     }
     scrollToBottom()
   }
@@ -510,7 +521,7 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
         knowledge_references: [],
       }
       messagesList.push(newMsg)
-      onMessageCreated?.(newMsg)
+      emitMessageCreated(newMsg)
       loading.value = false
       scrollToBottom(true)
       message = newMsg
@@ -524,6 +535,7 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
     }
 
     ensureAgentMessageShell(message, dataId)
+    applyMessageCreatedAt(message, data.created_at)
 
     if (
       loading.value &&
@@ -921,7 +933,7 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
           knowledge_references: [],
         }
         messagesList.push(existingMessage)
-        onMessageCreated?.(existingMessage)
+        emitMessageCreated(existingMessage)
         loading.value = false
         scrollToBottom(true)
         log('[Agent Query] Created agent placeholder message')
@@ -933,6 +945,11 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
         }
         log('[Agent Query] Continuing stream for existing message')
       }
+      bindServerTurnTimestamps(
+        messagesList,
+        (data.data as Record<string, unknown> | undefined) || data,
+        existingMessage,
+      )
       onAgentQuery?.(data, existingMessage, created)
       return
     }

--- a/frontend/src/composables/useEmbedChatSession.ts
+++ b/frontend/src/composables/useEmbedChatSession.ts
@@ -286,6 +286,7 @@ export function useEmbedChatSession(options: {
       images: displayImages,
       attachments: displayAttachments,
       channel: 'embed',
+      created_at: new Date().toISOString(),
     })
     postEmbedMessageSent(options.channelId, options.sessionId.value, value)
     relayEmbedWebhookEvent(

--- a/frontend/src/utils/messageTimestamp.test.ts
+++ b/frontend/src/utils/messageTimestamp.test.ts
@@ -84,7 +84,10 @@ test('formatMessageTimestamp converts a UTC string into local wall time', () => 
 })
 
 test('bindServerTurnTimestamps replaces local fallbacks with persisted server times', () => {
-  const user = { role: 'user', created_at: '2026-01-02T03:04:05.000Z' }
+  const user: { role: string; created_at: string; id?: string } = {
+    role: 'user',
+    created_at: '2026-01-02T03:04:05.000Z',
+  }
   const assistant = { role: 'assistant', created_at: '2026-01-02T03:04:06.000Z' }
 
   bindServerTurnTimestamps(

--- a/frontend/src/utils/messageTimestamp.test.ts
+++ b/frontend/src/utils/messageTimestamp.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { ensureMessageCreatedAt, formatMessageTimestamp } from './messageTimestamp'
+
+test('ensureMessageCreatedAt fills a missing timestamp with the provided fallback', () => {
+  const message: Record<string, unknown> = { role: 'assistant' }
+  const result = ensureMessageCreatedAt(message, '2026-01-02T03:04:05.000Z')
+
+  assert.equal(result, message)
+  assert.equal(message.created_at, '2026-01-02T03:04:05.000Z')
+})
+
+test('ensureMessageCreatedAt preserves a server timestamp', () => {
+  const message = { created_at: '2026-02-03T04:05:06.000Z' }
+
+  ensureMessageCreatedAt(message, '2026-01-02T03:04:05.000Z')
+
+  assert.equal(message.created_at, '2026-02-03T04:05:06.000Z')
+})
+
+test('formatMessageTimestamp renders local time to minute precision', () => {
+  const localTime = new Date(2026, 0, 2, 3, 4, 5)
+
+  assert.equal(formatMessageTimestamp(localTime.toISOString()), '2026-01-02 03:04')
+})
+
+test('formatMessageTimestamp hides empty and invalid timestamps', () => {
+  assert.equal(formatMessageTimestamp(''), '')
+  assert.equal(formatMessageTimestamp('not-a-date'), '')
+  assert.equal(formatMessageTimestamp(undefined), '')
+})

--- a/frontend/src/utils/messageTimestamp.test.ts
+++ b/frontend/src/utils/messageTimestamp.test.ts
@@ -1,6 +1,22 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { ensureMessageCreatedAt, formatMessageTimestamp } from './messageTimestamp'
+import {
+  applyMessageCreatedAt,
+  bindServerTurnTimestamps,
+  ensureMessageCreatedAt,
+  formatMessageTimestamp,
+  normalizeMessageCreatedAt,
+} from './messageTimestamp'
+
+test('normalizeMessageCreatedAt accepts parseable timestamps and rejects junk', () => {
+  assert.equal(normalizeMessageCreatedAt('2026-01-02T03:04:05.000Z'), '2026-01-02T03:04:05.000Z')
+  assert.equal(normalizeMessageCreatedAt('  2026-01-02T03:04:05.000Z  '), '2026-01-02T03:04:05.000Z')
+  assert.equal(normalizeMessageCreatedAt(''), '')
+  assert.equal(normalizeMessageCreatedAt('   '), '')
+  assert.equal(normalizeMessageCreatedAt('not-a-date'), '')
+  assert.equal(normalizeMessageCreatedAt(undefined), '')
+  assert.equal(normalizeMessageCreatedAt(1735787045000), '')
+})
 
 test('ensureMessageCreatedAt fills a missing timestamp with the provided fallback', () => {
   const message: Record<string, unknown> = { role: 'assistant' }
@@ -8,6 +24,20 @@ test('ensureMessageCreatedAt fills a missing timestamp with the provided fallbac
 
   assert.equal(result, message)
   assert.equal(message.created_at, '2026-01-02T03:04:05.000Z')
+})
+
+test('ensureMessageCreatedAt replaces empty and invalid local timestamps', () => {
+  const empty = { created_at: '' }
+  const blank = { created_at: '   ' }
+  const invalid = { created_at: 'not-a-date' }
+
+  ensureMessageCreatedAt(empty, '2026-01-02T03:04:05.000Z')
+  ensureMessageCreatedAt(blank, '2026-01-02T03:04:05.000Z')
+  ensureMessageCreatedAt(invalid, '2026-01-02T03:04:05.000Z')
+
+  assert.equal(empty.created_at, '2026-01-02T03:04:05.000Z')
+  assert.equal(blank.created_at, '2026-01-02T03:04:05.000Z')
+  assert.equal(invalid.created_at, '2026-01-02T03:04:05.000Z')
 })
 
 test('ensureMessageCreatedAt preserves a server timestamp', () => {
@@ -18,14 +48,82 @@ test('ensureMessageCreatedAt preserves a server timestamp', () => {
   assert.equal(message.created_at, '2026-02-03T04:05:06.000Z')
 })
 
+test('applyMessageCreatedAt overwrites a local fallback with a server timestamp', () => {
+  const message = { created_at: '2026-01-02T03:04:05.000Z' }
+
+  applyMessageCreatedAt(message, '2026-02-03T04:05:06.000Z')
+
+  assert.equal(message.created_at, '2026-02-03T04:05:06.000Z')
+})
+
+test('applyMessageCreatedAt ignores empty or invalid server candidates', () => {
+  const message = { created_at: '2026-01-02T03:04:05.000Z' }
+
+  applyMessageCreatedAt(message, '')
+  applyMessageCreatedAt(message, '   ')
+  applyMessageCreatedAt(message, 'not-a-date')
+  applyMessageCreatedAt(message, undefined)
+
+  assert.equal(message.created_at, '2026-01-02T03:04:05.000Z')
+})
+
 test('formatMessageTimestamp renders local time to minute precision', () => {
   const localTime = new Date(2026, 0, 2, 3, 4, 5)
 
   assert.equal(formatMessageTimestamp(localTime.toISOString()), '2026-01-02 03:04')
 })
 
+test('formatMessageTimestamp converts a UTC string into local wall time', () => {
+  const utc = '2026-01-02T00:00:00.000Z'
+  const local = new Date(utc)
+  const pad = (part: number) => String(part).padStart(2, '0')
+  const expected = `${local.getFullYear()}-${pad(local.getMonth() + 1)}-${pad(local.getDate())} ${pad(local.getHours())}:${pad(local.getMinutes())}`
+
+  assert.equal(formatMessageTimestamp(utc), expected)
+  assert.notEqual(expected, '')
+})
+
+test('bindServerTurnTimestamps replaces local fallbacks with persisted server times', () => {
+  const user = { role: 'user', created_at: '2026-01-02T03:04:05.000Z' }
+  const assistant = { role: 'assistant', created_at: '2026-01-02T03:04:06.000Z' }
+
+  bindServerTurnTimestamps(
+    [user, assistant],
+    {
+      user_message_id: 'user-1',
+      user_created_at: '2026-01-02T03:05:00.000Z',
+      assistant_created_at: '2026-01-02T03:05:01.000Z',
+    },
+    assistant,
+  )
+
+  assert.equal(user.id, 'user-1')
+  assert.equal(user.created_at, '2026-01-02T03:05:00.000Z')
+  assert.equal(assistant.created_at, '2026-01-02T03:05:01.000Z')
+})
+
+test('bindServerTurnTimestamps ignores junk and keeps existing user ids', () => {
+  const user = { id: 'existing-user', role: 'user', created_at: '2026-01-02T03:04:05.000Z' }
+  const assistant = { role: 'assistant', created_at: '2026-01-02T03:04:06.000Z' }
+
+  bindServerTurnTimestamps(
+    [user, assistant],
+    {
+      user_message_id: 'user-1',
+      user_created_at: 'not-a-date',
+      assistant_created_at: '',
+    },
+    assistant,
+  )
+
+  assert.equal(user.id, 'existing-user')
+  assert.equal(user.created_at, '2026-01-02T03:04:05.000Z')
+  assert.equal(assistant.created_at, '2026-01-02T03:04:06.000Z')
+})
+
 test('formatMessageTimestamp hides empty and invalid timestamps', () => {
   assert.equal(formatMessageTimestamp(''), '')
+  assert.equal(formatMessageTimestamp('   '), '')
   assert.equal(formatMessageTimestamp('not-a-date'), '')
   assert.equal(formatMessageTimestamp(undefined), '')
 })

--- a/frontend/src/utils/messageTimestamp.ts
+++ b/frontend/src/utils/messageTimestamp.ts
@@ -1,21 +1,64 @@
 type MessageWithTimestamp = Record<string, unknown> & { created_at?: unknown }
 
+export function normalizeMessageCreatedAt(value: unknown): string {
+  if (typeof value !== 'string' || !value.trim()) return ''
+
+  const trimmed = value.trim()
+  const date = new Date(trimmed)
+  if (Number.isNaN(date.getTime())) return ''
+  return trimmed
+}
+
+export function applyMessageCreatedAt<T extends MessageWithTimestamp>(
+  message: T,
+  candidate: unknown,
+): T {
+  const next = normalizeMessageCreatedAt(candidate)
+  if (next) message.created_at = next
+  return message
+}
+
 export function ensureMessageCreatedAt<T extends MessageWithTimestamp>(
   message: T,
   fallback = new Date().toISOString(),
 ): T {
-  if (typeof message.created_at !== 'string' || !message.created_at.trim()) {
+  if (!normalizeMessageCreatedAt(message.created_at)) {
     message.created_at = fallback
   }
   return message
 }
 
+export function bindServerTurnTimestamps(
+  messages: MessageWithTimestamp[],
+  payload: Record<string, unknown> | undefined,
+  assistant?: MessageWithTimestamp,
+): void {
+  if (!payload) return
+
+  if (assistant) {
+    applyMessageCreatedAt(assistant, payload.assistant_created_at ?? payload.created_at)
+  }
+
+  const userCreatedAt = payload.user_created_at
+  const userMessageId = typeof payload.user_message_id === 'string' ? payload.user_message_id : ''
+  if (!normalizeMessageCreatedAt(userCreatedAt) && !userMessageId) return
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (message.role !== 'user') continue
+    applyMessageCreatedAt(message, userCreatedAt)
+    if (userMessageId && (typeof message.id !== 'string' || !message.id)) {
+      message.id = userMessageId
+    }
+    break
+  }
+}
+
 export function formatMessageTimestamp(value: unknown): string {
-  if (typeof value !== 'string' || !value.trim()) return ''
+  const normalized = normalizeMessageCreatedAt(value)
+  if (!normalized) return ''
 
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return ''
-
+  const date = new Date(normalized)
   const pad = (part: number) => String(part).padStart(2, '0')
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`
 }

--- a/frontend/src/utils/messageTimestamp.ts
+++ b/frontend/src/utils/messageTimestamp.ts
@@ -1,0 +1,21 @@
+type MessageWithTimestamp = Record<string, unknown> & { created_at?: unknown }
+
+export function ensureMessageCreatedAt<T extends MessageWithTimestamp>(
+  message: T,
+  fallback = new Date().toISOString(),
+): T {
+  if (typeof message.created_at !== 'string' || !message.created_at.trim()) {
+    message.created_at = fallback
+  }
+  return message
+}
+
+export function formatMessageTimestamp(value: unknown): string {
+  if (typeof value !== 'string' || !value.trim()) return ''
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+
+  const pad = (part: number) => String(part).padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`
+}

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -76,19 +76,28 @@
                 <div v-for="(session, index) in messagesList"
                     :key="session.id || `${session.role}-${session.created_at}-${index}`" class="msg-item-wrapper">
 
-                    <div v-if="session.role == 'user'">
+                    <div v-if="session.role == 'user'" class="message-row message-row--user">
                         <usermsg :content="session.content" :mentioned_items="session.mentioned_items"
                             :images="session.images" :attachments="session.attachments" :embeddedMode="embeddedMode"
                             :session-id="session_id">
                         </usermsg>
+                        <time v-if="formatMessageTimestamp(session.created_at)" class="message-time"
+                            :datetime="session.created_at">
+                            {{ formatMessageTimestamp(session.created_at) }}
+                        </time>
                     </div>
-                    <div v-if="session.role == 'assistant' && shouldRenderAssistantMessage(session)">
+                    <div v-if="session.role == 'assistant' && shouldRenderAssistantMessage(session)"
+                        class="message-row message-row--assistant">
                         <botmsg :content="session.content" :session="session" :session-id="session_id"
                             :user-query="getUserQuery(index)" @scroll-bottom="scrollToBottom"
                             :isFirstEnter="isFirstEnter" :embeddedMode="embeddedMode"
                             :follow-up-loading="Boolean(session.suggestionLoading && !session.suggestionSet?.questions?.length)"
                             @render-complete-change="(ready) => handleAnswerRenderComplete(session, ready)">
                         </botmsg>
+                        <time v-if="formatMessageTimestamp(session.created_at)" class="message-time"
+                            :datetime="session.created_at">
+                            {{ formatMessageTimestamp(session.created_at) }}
+                        </time>
                         <FollowUpSuggestions v-if="session.answerFullyRendered && !session.suggestionsDismissed"
                             :suggestion-set="session.suggestionSet"
                             :loading="session.suggestionLoading"
@@ -159,6 +168,7 @@ import {
 } from '@/api/message-suggestion';
 import { provideChatReferencesDrawer } from '@/composables/useChatReferencesDrawer';
 import { provideChatAttachmentPreviewDrawer } from '@/composables/useChatAttachmentPreviewDrawer';
+import { ensureMessageCreatedAt, formatMessageTimestamp } from '@/utils/messageTimestamp';
 
 const referencesDrawer = provideChatReferencesDrawer();
 provideChatAttachmentPreviewDrawer();
@@ -584,7 +594,10 @@ const {
         pendingStreamDebug.value = buildStreamDebugPayload();
         if (existingMessage) attachStreamDebugToMessage(existingMessage);
     },
-    onMessageCreated: (message) => attachStreamDebugToMessage(message),
+    onMessageCreated: (message) => {
+        ensureMessageCreatedAt(message);
+        attachStreamDebugToMessage(message);
+    },
     onMessageUpdated: (message, payload) => {
         attachStreamDebugToMessage(message);
         if (payload?.is_completed) pendingStreamDebug.value = null;
@@ -659,6 +672,7 @@ const handleStopGeneration = () => {
 };
 
 const sendMsg = async (value, modelId = '', mentionedItems = [], imageFiles = [], attachmentFiles = []) => {
+    const outgoingMessageCreatedAt = new Date().toISOString();
     stopStream();
     prepareForNewOutgoingMessage();
     isReplying.value = true;
@@ -774,7 +788,7 @@ const sendMsg = async (value, modelId = '', mentionedItems = [], imageFiles = []
     }
 
     // 将@提及的知识库和文件信息存入用户消息
-    messagesList.push({ content: value, role: 'user', mentioned_items: mentionedItems, images: userImages, attachments: attachmentFiles.map(a => ({ id: a.documentId, file_name: a.name, file_size: a.size, file_type: '.' + a.name.split('.').pop()?.toLowerCase() })), channel: 'web' });
+    messagesList.push({ content: value, role: 'user', mentioned_items: mentionedItems, images: userImages, attachments: attachmentFiles.map(a => ({ id: a.documentId, file_name: a.name, file_size: a.size, file_type: '.' + a.name.split('.').pop()?.toLowerCase() })), channel: 'web', created_at: outgoingMessageCreatedAt });
     userHasScrolledUp.value = false;
     scrollToBottom(true);
 
@@ -1247,6 +1261,28 @@ onBeforeRouteUpdate((to, from, next) => {
     */
     .msg-item-wrapper {
         contain: layout style;
+    }
+
+    .message-row {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+    }
+
+    .message-row--user {
+        align-items: flex-end;
+    }
+
+    .message-time {
+        margin-top: 4px;
+        color: var(--td-text-color-secondary);
+        font-size: 12px;
+        font-variant-numeric: tabular-nums;
+        line-height: 20px;
+    }
+
+    .message-row--assistant .message-time {
+        align-self: flex-start;
     }
 
     .botanswer_laoding_gif {

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -76,28 +76,22 @@
                 <div v-for="(session, index) in messagesList"
                     :key="session.id || `${session.role}-${session.created_at}-${index}`" class="msg-item-wrapper">
 
-                    <div v-if="session.role == 'user'" class="message-row message-row--user">
+                    <div v-if="session.role == 'user'" class="message-row">
                         <usermsg :content="session.content" :mentioned_items="session.mentioned_items"
                             :images="session.images" :attachments="session.attachments" :embeddedMode="embeddedMode"
                             :session-id="session_id">
                         </usermsg>
-                        <time v-if="formatMessageTimestamp(session.created_at)" class="message-time"
-                            :datetime="session.created_at">
-                            {{ formatMessageTimestamp(session.created_at) }}
-                        </time>
+                        <MessageTimestamp :value="session.created_at" align="end" />
                     </div>
                     <div v-if="session.role == 'assistant' && shouldRenderAssistantMessage(session)"
-                        class="message-row message-row--assistant">
+                        class="message-row">
                         <botmsg :content="session.content" :session="session" :session-id="session_id"
                             :user-query="getUserQuery(index)" @scroll-bottom="scrollToBottom"
                             :isFirstEnter="isFirstEnter" :embeddedMode="embeddedMode"
                             :follow-up-loading="Boolean(session.suggestionLoading && !session.suggestionSet?.questions?.length)"
                             @render-complete-change="(ready) => handleAnswerRenderComplete(session, ready)">
                         </botmsg>
-                        <time v-if="formatMessageTimestamp(session.created_at)" class="message-time"
-                            :datetime="session.created_at">
-                            {{ formatMessageTimestamp(session.created_at) }}
-                        </time>
+                        <MessageTimestamp :value="session.created_at" align="start" />
                         <FollowUpSuggestions v-if="session.answerFullyRendered && !session.suggestionsDismissed"
                             :suggestion-set="session.suggestionSet"
                             :loading="session.suggestionLoading"
@@ -156,6 +150,7 @@ import { clearCitationChunkCache } from '@/utils/citationChunkCache';
 import ChatReferencesDrawer from '@/components/ChatReferencesDrawer.vue';
 import ChatAttachmentPreviewDrawer from '@/components/ChatAttachmentPreviewDrawer.vue';
 import FollowUpSuggestions from '@/components/chat/FollowUpSuggestions.vue';
+import MessageTimestamp from '@/components/chat/MessageTimestamp.vue';
 import ChatHeader from '@/components/ChatHeader.vue';
 import {
     notifySessionMutation,
@@ -168,8 +163,6 @@ import {
 } from '@/api/message-suggestion';
 import { provideChatReferencesDrawer } from '@/composables/useChatReferencesDrawer';
 import { provideChatAttachmentPreviewDrawer } from '@/composables/useChatAttachmentPreviewDrawer';
-import { ensureMessageCreatedAt, formatMessageTimestamp } from '@/utils/messageTimestamp';
-
 const referencesDrawer = provideChatReferencesDrawer();
 provideChatAttachmentPreviewDrawer();
 const { visible: referencesDrawerVisible } = referencesDrawer;
@@ -594,10 +587,7 @@ const {
         pendingStreamDebug.value = buildStreamDebugPayload();
         if (existingMessage) attachStreamDebugToMessage(existingMessage);
     },
-    onMessageCreated: (message) => {
-        ensureMessageCreatedAt(message);
-        attachStreamDebugToMessage(message);
-    },
+    onMessageCreated: (message) => attachStreamDebugToMessage(message),
     onMessageUpdated: (message, payload) => {
         attachStreamDebugToMessage(message);
         if (payload?.is_completed) pendingStreamDebug.value = null;
@@ -672,7 +662,6 @@ const handleStopGeneration = () => {
 };
 
 const sendMsg = async (value, modelId = '', mentionedItems = [], imageFiles = [], attachmentFiles = []) => {
-    const outgoingMessageCreatedAt = new Date().toISOString();
     stopStream();
     prepareForNewOutgoingMessage();
     isReplying.value = true;
@@ -788,7 +777,7 @@ const sendMsg = async (value, modelId = '', mentionedItems = [], imageFiles = []
     }
 
     // 将@提及的知识库和文件信息存入用户消息
-    messagesList.push({ content: value, role: 'user', mentioned_items: mentionedItems, images: userImages, attachments: attachmentFiles.map(a => ({ id: a.documentId, file_name: a.name, file_size: a.size, file_type: '.' + a.name.split('.').pop()?.toLowerCase() })), channel: 'web', created_at: outgoingMessageCreatedAt });
+    messagesList.push({ content: value, role: 'user', mentioned_items: mentionedItems, images: userImages, attachments: attachmentFiles.map(a => ({ id: a.documentId, file_name: a.name, file_size: a.size, file_type: '.' + a.name.split('.').pop()?.toLowerCase() })), channel: 'web', created_at: new Date().toISOString() });
     userHasScrolledUp.value = false;
     scrollToBottom(true);
 
@@ -1267,22 +1256,6 @@ onBeforeRouteUpdate((to, from, next) => {
         display: flex;
         flex-direction: column;
         width: 100%;
-    }
-
-    .message-row--user {
-        align-items: flex-end;
-    }
-
-    .message-time {
-        margin-top: 4px;
-        color: var(--td-text-color-secondary);
-        font-size: 12px;
-        font-variant-numeric: tabular-nums;
-        line-height: 20px;
-    }
-
-    .message-row--assistant .message-time {
-        align-self: flex-start;
     }
 
     .botanswer_laoding_gif {

--- a/frontend/src/views/embed/EmbedChatCore.vue
+++ b/frontend/src/views/embed/EmbedChatCore.vue
@@ -46,7 +46,7 @@
           :key="(session.id as string) || `${session.role}-${session.created_at}-${index}`"
           class="msg-item-wrapper"
         >
-          <div v-if="session.role === 'user'">
+          <div v-if="session.role === 'user'" class="message-row">
             <EmbedUserMessage
               :content="String(session.content || '')"
               :mentioned_items="asUnknownArray(session.mentioned_items)"
@@ -56,8 +56,9 @@
               :embed-channel-id="channelId"
               :embed-token="token"
             />
+            <MessageTimestamp :value="session.created_at" align="end" />
           </div>
-          <div v-if="session.role === 'assistant' && shouldRenderAssistantMessage(session)">
+          <div v-if="session.role === 'assistant' && shouldRenderAssistantMessage(session)" class="message-row">
             <EmbedBotMessage
               :content="String(session.content || '')"
               :session="session"
@@ -69,6 +70,7 @@
               :embed-session-sig="sessionSig"
               :embed-visitor-id="visitorId"
             />
+            <MessageTimestamp :value="session.created_at" align="start" />
             <FollowUpSuggestions v-if="!session.suggestionsDismissed"
               :suggestion-set="session.suggestionSet as any"
               :loading="Boolean(session.suggestionLoading)"
@@ -127,6 +129,7 @@ import ChatReferencesDrawer from '@/components/ChatReferencesDrawer.vue'
 import { provideChatReferencesDrawer } from '@/composables/useChatReferencesDrawer'
 import { useEmbedChatSession } from '@/composables/useEmbedChatSession'
 import FollowUpSuggestions from '@/components/chat/FollowUpSuggestions.vue'
+import MessageTimestamp from '@/components/chat/MessageTimestamp.vue'
 import type { MessageSuggestionItem, MessageSuggestionSet } from '@/api/message-suggestion'
 
 provideChatReferencesDrawer()
@@ -416,6 +419,12 @@ watch(
   width: 100%;
   padding: 12px 16px 0;
   box-sizing: border-box;
+}
+
+.message-row {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
 }
 
 .embed-suggested {

--- a/internal/handler/session/helpers.go
+++ b/internal/handler/session/helpers.go
@@ -243,18 +243,33 @@ func sendCompletionEvent(c *gin.Context, requestID string) {
 	// which is already sent before this function is called
 }
 
-// createAgentQueryEvent creates a standard agent query event
-func createAgentQueryEvent(sessionID, assistantMessageID string) interfaces.StreamEvent {
+// createAgentQueryEvent creates a standard agent query event.
+// It carries the persisted user/assistant timestamps so the live UI can
+// display the same created_at that history reload will return.
+func createAgentQueryEvent(
+	sessionID, assistantMessageID, userMessageID string,
+	userCreatedAt, assistantCreatedAt time.Time,
+) interfaces.StreamEvent {
+	data := map[string]interface{}{
+		"session_id":           sessionID,
+		"assistant_message_id": assistantMessageID,
+	}
+	if userMessageID != "" {
+		data["user_message_id"] = userMessageID
+	}
+	if !userCreatedAt.IsZero() {
+		data["user_created_at"] = userCreatedAt.UTC().Format(time.RFC3339Nano)
+	}
+	if !assistantCreatedAt.IsZero() {
+		data["assistant_created_at"] = assistantCreatedAt.UTC().Format(time.RFC3339Nano)
+	}
 	return interfaces.StreamEvent{
 		ID:        fmt.Sprintf("query-%d", time.Now().UnixNano()),
 		Type:      types.ResponseTypeAgentQuery,
 		Content:   "",
 		Done:      true,
 		Timestamp: time.Now(),
-		Data: map[string]interface{}{
-			"session_id":           sessionID,
-			"assistant_message_id": assistantMessageID,
-		},
+		Data:      data,
 	}
 }
 
@@ -399,8 +414,21 @@ func (h *Handler) startStopWatcher(
 }
 
 // writeAgentQueryEvent writes an agent query event to the stream manager
-func (h *Handler) writeAgentQueryEvent(ctx context.Context, sessionID, assistantMessageID string) {
-	agentQueryEvent := createAgentQueryEvent(sessionID, assistantMessageID)
+func (h *Handler) writeAgentQueryEvent(
+	ctx context.Context,
+	sessionID, userMessageID string,
+	userCreatedAt time.Time,
+	assistantMessage *types.Message,
+) {
+	assistantMessageID := ""
+	var assistantCreatedAt time.Time
+	if assistantMessage != nil {
+		assistantMessageID = assistantMessage.ID
+		assistantCreatedAt = assistantMessage.CreatedAt
+	}
+	agentQueryEvent := createAgentQueryEvent(
+		sessionID, assistantMessageID, userMessageID, userCreatedAt, assistantCreatedAt,
+	)
 	if err := h.streamManager.AppendEvent(ctx, sessionID, assistantMessageID, agentQueryEvent); err != nil {
 		logger.ErrorWithFields(ctx, err, map[string]interface{}{
 			"session_id": sessionID,

--- a/internal/handler/session/helpers_test.go
+++ b/internal/handler/session/helpers_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/stretchr/testify/assert"
@@ -104,4 +105,29 @@ func TestSearchResultFromMap_RoundTrip(t *testing.T) {
 	assert.Equal(t, original.KnowledgeDescription, got.KnowledgeDescription)
 	assert.Equal(t, original.KnowledgeBaseID, got.KnowledgeBaseID)
 	assert.Equal(t, original.Metadata, got.Metadata)
+}
+
+func TestCreateAgentQueryEventIncludesPersistedTimestamps(t *testing.T) {
+	userAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	assistantAt := time.Date(2026, 1, 2, 3, 4, 6, 0, time.UTC)
+
+	evt := createAgentQueryEvent("sess-1", "asst-1", "user-1", userAt, assistantAt)
+
+	assert.Equal(t, types.ResponseTypeAgentQuery, evt.Type)
+	assert.Equal(t, "sess-1", evt.Data["session_id"])
+	assert.Equal(t, "asst-1", evt.Data["assistant_message_id"])
+	assert.Equal(t, "user-1", evt.Data["user_message_id"])
+	assert.Equal(t, userAt.Format(time.RFC3339Nano), evt.Data["user_created_at"])
+	assert.Equal(t, assistantAt.Format(time.RFC3339Nano), evt.Data["assistant_created_at"])
+}
+
+func TestCreateAgentQueryEventOmitsZeroTimestamps(t *testing.T) {
+	evt := createAgentQueryEvent("sess-1", "asst-1", "", time.Time{}, time.Time{})
+
+	_, hasUserID := evt.Data["user_message_id"]
+	_, hasUserAt := evt.Data["user_created_at"]
+	_, hasAssistantAt := evt.Data["assistant_created_at"]
+	assert.False(t, hasUserID)
+	assert.False(t, hasUserAt)
+	assert.False(t, hasAssistantAt)
 }

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -53,6 +53,7 @@ type qaRequestContext struct {
 	sharedAgentReadOnly   bool                     // access was granted by a read-only agent share
 	images                []ImageAttachment        // Uploaded images with analysis text
 	userMessageID         string                   // Created user message ID (populated after createUserMessage)
+	userCreatedAt         time.Time                // Persisted user message timestamp, echoed on agent_query
 	channel               string                   // Source channel: "web", "api", "im", etc.
 	attachments           types.MessageAttachments // Processed base64 file attachments (legacy inline uploads)
 	attachmentIDs         []string                 // Pre-uploaded session-scoped document IDs, resolved after SSE starts
@@ -616,7 +617,13 @@ func (h *Handler) setupSSEStream(reqCtx *qaRequestContext, generateTitle bool) *
 	setSSEHeaders(reqCtx.c)
 
 	// Write initial agent_query event
-	h.writeAgentQueryEvent(reqCtx.ctx, reqCtx.sessionID, reqCtx.assistantMessage.ID)
+	h.writeAgentQueryEvent(
+		reqCtx.ctx,
+		reqCtx.sessionID,
+		reqCtx.userMessageID,
+		reqCtx.userCreatedAt,
+		reqCtx.assistantMessage,
+	)
 
 	// Base context for async work: when using shared agent, use source tenant for model/KB/MCP resolution
 	baseCtx := reqCtx.ctx
@@ -920,6 +927,7 @@ func (h *Handler) executeQA(reqCtx *qaRequestContext, mode qaMode, generateTitle
 		return
 	}
 	reqCtx.userMessageID = userMsg.ID
+	reqCtx.userCreatedAt = userMsg.CreatedAt
 
 	// Create assistant message
 	assistantMessagePtr, err := h.createAssistantMessage(ctx, reqCtx.assistantMessage)


### PR DESCRIPTION
## Description

Chat messages currently expose `created_at` data but do not display it in the main conversation view. This change renders a compact local timestamp below user and assistant messages.

It also:

- assigns a stable timestamp to optimistic user messages at send time;
- assigns timestamps to every locally created streamed assistant message path;
- preserves timestamps returned by the server;
- renders semantic `<time>` elements using local `YYYY-MM-DD HH:mm` formatting;
- hides empty or invalid timestamps.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #1859

## Testing

```text
npm test
npm run type-check
npm run build
```

Results:

- 401/401 frontend tests pass;
- Vue/TypeScript type checking passes;
- the production Vite build passes.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted and full frontend tests pass
- [x] Type checking and production build pass
- [x] Self-reviewed the code
- [x] Added tests covering timestamp creation and formatting
- [x] Documentation is not affected; no public API or configuration changed
- [x] No breaking changes

## Screenshots / Recordings

Static visual preview of timestamp placement below user and assistant messages:

<img width="1280" height="720" alt="Message timestamps displayed below user and assistant chat messages" src="https://github.com/user-attachments/assets/aac85053-25ce-46f1-a9f4-5f8f126d184c" />
