### PR TITLE
fix(knowledge): use current parser rules for batch reparse

### DIFF
--- a/internal/application/service/knowledge_batch_reparse_test.go
+++ b/internal/application/service/knowledge_batch_reparse_test.go
@@ -47,6 +47,40 @@ type reparseFailureKBService struct {
 	kb *types.KnowledgeBase
 }
 
+type parserRulesKnowledgeRepo struct {
+	interfaces.KnowledgeRepository
+	knowledge       *types.Knowledge
+	getErr          error
+	updateErr       error
+	requestedTenant uint64
+	updateCalls     int
+	updatedID       string
+	updatedColumn   string
+	updatedValue    interface{}
+}
+
+func (r *parserRulesKnowledgeRepo) GetKnowledgeByID(
+	_ context.Context,
+	tenantID uint64,
+	_ string,
+) (*types.Knowledge, error) {
+	r.requestedTenant = tenantID
+	return r.knowledge, r.getErr
+}
+
+func (r *parserRulesKnowledgeRepo) UpdateKnowledgeColumn(
+	_ context.Context,
+	id string,
+	column string,
+	value interface{},
+) error {
+	r.updateCalls++
+	r.updatedID = id
+	r.updatedColumn = column
+	r.updatedValue = value
+	return r.updateErr
+}
+
 func (s *reparseFailureKBService) GetKnowledgeBaseByID(
 	_ context.Context,
 	_ string,
@@ -133,4 +167,105 @@ func TestRunKnowledgeListReparseSubmissionsSucceeds(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, knowledgeListReparseOutcome{Submitted: 2}, outcome)
+}
+
+func TestClearStoredParserEngineRulesUsesCurrentKnowledgeBaseRules(t *testing.T) {
+	enableMultimodel := true
+	knowledge := &types.Knowledge{
+		ID:       "knowledge-1",
+		TenantID: 7,
+		Metadata: types.JSON(`{
+			"source_id":"keep-me",
+			"process_overrides":{
+				"parser_engine_rules":[{"file_types":["pdf"],"engine":"old-top-level"}],
+				"chunking_config":{
+					"chunk_size":1024,
+					"chunk_overlap":128,
+					"enable_parent_child":true,
+					"parser_engine_rules":[{"file_types":["docx"],"engine":"old-nested"}]
+				},
+				"enable_multimodel":true,
+				"parser_engine_overrides":{"pdf_force_scanned":"true"}
+			}
+		}`),
+	}
+	repo := &parserRulesKnowledgeRepo{knowledge: knowledge}
+	svc := &knowledgeService{repo: repo}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(7))
+
+	err := svc.clearStoredParserEngineRules(ctx, knowledge.ID)
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), repo.requestedTenant)
+	require.Equal(t, 1, repo.updateCalls)
+	require.Equal(t, knowledge.ID, repo.updatedID)
+	require.Equal(t, "metadata", repo.updatedColumn)
+	require.Equal(t, knowledge.Metadata, repo.updatedValue)
+
+	overrides, err := knowledge.ProcessOverrides()
+	require.NoError(t, err)
+	require.NotNil(t, overrides)
+	require.Empty(t, overrides.ParserEngineRules)
+	require.NotNil(t, overrides.ChunkingConfig)
+	require.Empty(t, overrides.ChunkingConfig.ParserEngineRules)
+	require.Equal(t, 1024, overrides.ChunkingConfig.ChunkSize)
+	require.Equal(t, 128, overrides.ChunkingConfig.ChunkOverlap)
+	require.True(t, overrides.ChunkingConfig.EnableParentChild)
+	require.Equal(t, &enableMultimodel, overrides.EnableMultimodel)
+	require.Equal(t, map[string]string{"pdf_force_scanned": "true"}, overrides.ParserEngineOverrides)
+
+	metadata, err := knowledge.Metadata.Map()
+	require.NoError(t, err)
+	require.Equal(t, "keep-me", metadata["source_id"])
+
+	currentRules := []types.ParserEngineRule{{FileTypes: []string{"pdf", "docx"}, Engine: "current"}}
+	effective := ResolveProcessConfig(&types.KnowledgeBase{
+		ChunkingConfig: types.ChunkingConfig{ParserEngineRules: currentRules},
+	}, overrides)
+	require.Equal(t, currentRules, effective.ChunkingConfig.ParserEngineRules)
+}
+
+func TestClearStoredParserEngineRulesWithoutSnapshotsIsNoOp(t *testing.T) {
+	knowledge := &types.Knowledge{
+		ID:       "knowledge-2",
+		TenantID: 7,
+		Metadata: types.JSON(`{
+			"source_id":"keep-me",
+			"process_overrides":{
+				"chunking_config":{"chunk_size":2048},
+				"parser_engine_overrides":{"xlsx_first_row_as_header":"true"}
+			}
+		}`),
+	}
+	originalMetadata := append(types.JSON(nil), knowledge.Metadata...)
+	repo := &parserRulesKnowledgeRepo{knowledge: knowledge}
+	svc := &knowledgeService{repo: repo}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(7))
+
+	err := svc.clearStoredParserEngineRules(ctx, knowledge.ID)
+
+	require.NoError(t, err)
+	require.Zero(t, repo.updateCalls)
+	require.Equal(t, originalMetadata, knowledge.Metadata)
+}
+
+func TestClearStoredParserEngineRulesPropagatesUpdateFailure(t *testing.T) {
+	updateErr := errors.New("metadata update failed")
+	knowledge := &types.Knowledge{
+		ID:       "knowledge-3",
+		TenantID: 7,
+		Metadata: types.JSON(`{
+			"process_overrides":{
+				"parser_engine_rules":[{"file_types":["pdf"],"engine":"old"}]
+			}
+		}`),
+	}
+	repo := &parserRulesKnowledgeRepo{knowledge: knowledge, updateErr: updateErr}
+	svc := &knowledgeService{repo: repo}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(7))
+
+	err := svc.clearStoredParserEngineRules(ctx, knowledge.ID)
+
+	require.ErrorIs(t, err, updateErr)
+	require.Equal(t, 1, repo.updateCalls)
 }

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -3870,6 +3870,44 @@ func (s *knowledgeService) enqueueImageMultimodalTasks(
 	}
 }
 
+// clearStoredParserEngineRules drops only the upload-time parser selection from
+// a knowledge's process overrides. Batch reparse can then resolve parser rules
+// from the current knowledge-base config while retaining document-specific
+// chunking and parser options.
+func (s *knowledgeService) clearStoredParserEngineRules(ctx context.Context, knowledgeID string) error {
+	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
+	knowledge, err := s.repo.GetKnowledgeByID(ctx, tenantID, knowledgeID)
+	if err != nil {
+		return err
+	}
+	if knowledge == nil {
+		return fmt.Errorf("knowledge %s not found", secutils.SanitizeForLog(knowledgeID))
+	}
+
+	overrides, err := knowledge.ProcessOverrides()
+	if err != nil {
+		return err
+	}
+	if overrides == nil {
+		return nil
+	}
+
+	changed := len(overrides.ParserEngineRules) > 0
+	overrides.ParserEngineRules = nil
+	if overrides.ChunkingConfig != nil && len(overrides.ChunkingConfig.ParserEngineRules) > 0 {
+		overrides.ChunkingConfig.ParserEngineRules = nil
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+
+	if err := knowledge.SetProcessOverrides(overrides); err != nil {
+		return err
+	}
+	return s.repo.UpdateKnowledgeColumn(ctx, knowledge.ID, "metadata", knowledge.Metadata)
+}
+
 // ProcessKnowledgeListReparse handles Asynq knowledge list reparse tasks.
 func (s *knowledgeService) ProcessKnowledgeListReparse(ctx context.Context, t *asynq.Task) error {
 	var payload types.KnowledgeListReparsePayload
@@ -3893,6 +3931,11 @@ func (s *knowledgeService) ProcessKnowledgeListReparse(ctx context.Context, t *a
 	ctx = context.WithValue(ctx, types.TenantInfoContextKey, tenant)
 
 	outcome, err := runKnowledgeListReparseSubmissions(payload.KnowledgeIDs, func(id string) error {
+		if payload.ProcessConfig == nil {
+			if err := s.clearStoredParserEngineRules(ctx, id); err != nil {
+				return err
+			}
+		}
 		_, err := s.ReparseKnowledge(ctx, id, payload.ProcessConfig)
 		return err
 	})


### PR DESCRIPTION
## Description

Batch reparse tasks without an explicit `process_config` reload each document's stored process overrides. Upload-time parser-engine snapshots then take precedence over the knowledge base's current parser rules, so changing the parser engine does not affect failed documents selected for batch reparse.

This change clears only the stored parser-engine rule snapshots before a nil-config batch reparse:

- both top-level and nested `chunking_config` parser rules are removed;
- document-specific chunking, multimodal, and parser options are preserved;
- explicit batch `process_config` and single-document reparse behavior are unchanged;
- metadata is updated only when a parser snapshot exists, and update errors flow through the existing batch outcome aggregation.

This is a focused implementation against the current `main`. It follows the backend direction discussed in the closed, unmerged #1901 and accounts for the nested snapshot identified there; #2094 explored a broader frontend-driven alternative.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #1892

## Testing

```text
go test ./internal/application/service -run 'TestClearStoredParserEngineRules|TestRunKnowledgeListReparseSubmissions|TestReparseKnowledgeManualEnqueueFailureIsVisible' -count=1
go vet ./internal/application/service
golangci-lint run --new-from-rev=origin/main ./internal/application/service
```

All focused commands pass; golangci-lint reports `0 issues`.

`go test ./internal/application/service -count=1` was also run. On Windows it fails only while removing SQLite temporary files in these existing tests:

- `TestDataSourceServiceDeleteSQLiteCleansUpAfterSoftDelete`
- `TestDataSourceServiceDeleteKeepsCleanupStateWhenSoftDeleteFails`
- `TestDeleteKnowledgeBaseCleansUpSQLiteDataSources`

The same `weknora.db` file-lock cleanup failures reproduce on an unchanged `main` worktree.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed package pass
- [x] Diff-scoped lint passes for the changed package
- [x] Unrelated full-package Windows failures are documented above and reproduced on `main`
- [x] Self-reviewed the code
- [x] Added tests covering top-level and nested snapshots, no-op behavior, preserved overrides, and update failures
- [x] Documentation is not affected; no public API or configuration changed
- [x] No breaking changes

## Screenshots / Recordings

Not applicable; this is a backend batch-processing fix.
