### PR TITLE
ci(dsh-weknora): restore e2e timeout for cold dsh cache

### DIFF
--- a/.github/workflows/dsh-plugin.yml
+++ b/.github/workflows/dsh-plugin.yml
@@ -113,7 +113,8 @@ jobs:
   e2e:
     name: End-to-end inside dsh (pinned)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Cold cache: npm install @deepseek-ai/dsh takes ~15 min; keep headroom.
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: packages/dsh-weknora


### PR DESCRIPTION
## Summary

- Restore the pinned e2e job timeout from 10 to 25 minutes.
- #2760 merged the dsh install cache but left the shorter timeout; the first cache miss still spends ~15 minutes in `npm install @deepseek-ai/dsh`, so the job was cancelled before the cache could warm up.

## Test plan

- [ ] Merge and re-run **Build & Publish (dsh-weknora)** on main
- [ ] Confirm the e2e job completes (~15 min on first run, log shows `# installing @deepseek-ai/dsh@…`)
- [ ] Re-run workflow and confirm cache hit (`# reusing the dsh install at …`) finishes in a few minutes