### PR TITLE
fix(datasource): 修复同步删除关闭状态无法保存的问题

### DIFF
--- a/internal/application/repository/datasource_repo.go
+++ b/internal/application/repository/datasource_repo.go
@@ -25,10 +25,17 @@ func (r *DataSourceRepository) Create(ctx context.Context, ds *types.DataSource)
 	if ds == nil {
 		return errors.New("data source is nil")
 	}
-	if err := r.db.WithContext(ctx).Create(ds).Error; err != nil {
-		return err
-	}
-	return nil
+	// GORM may omit a false value for a field with a database default. Preserve
+	// the caller's choice before Create potentially hydrates that default.
+	syncDeletions := ds.SyncDeletions
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(ds).Error; err != nil {
+			return err
+		}
+		return tx.Model(&types.DataSource{}).
+			Where("id = ?", ds.ID).
+			UpdateColumn("sync_deletions", syncDeletions).Error
+	})
 }
 
 // FindByID retrieves a data source by ID
@@ -73,12 +80,16 @@ func (r *DataSourceRepository) Update(ctx context.Context, ds *types.DataSource)
 	if ds.ID == "" {
 		return errors.New("data source id is empty")
 	}
-	if err := r.db.WithContext(ctx).
-		Model(ds).
-		Updates(ds).Error; err != nil {
-		return err
-	}
-	return nil
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(ds).Updates(ds).Error; err != nil {
+			return err
+		}
+		// GORM Updates(struct) deliberately skips zero values, which would make
+		// a user-selected sync_deletions=false impossible to persist.
+		return tx.Model(&types.DataSource{}).
+			Where("id = ?", ds.ID).
+			UpdateColumn("sync_deletions", ds.SyncDeletions).Error
+	})
 }
 
 // UpdateSyncState updates only fields managed by sync execution. GORM's

--- a/internal/application/repository/datasource_repo.go
+++ b/internal/application/repository/datasource_repo.go
@@ -25,10 +25,13 @@ func (r *DataSourceRepository) Create(ctx context.Context, ds *types.DataSource)
 	if ds == nil {
 		return errors.New("data source is nil")
 	}
-	// GORM may omit a false value for a field with a database default. Preserve
-	// the caller's choice before Create potentially hydrates that default.
+	// GORM treats false as the zero value of bool. For a field tagged
+	// default:true it replaces both the INSERT value and the in-memory field
+	// with true, so a caller-selected false would be lost. Capture it, force
+	// the column write, then restore the struct so Create's return value (and
+	// the HTTP 201 body) match the database.
 	syncDeletions := ds.SyncDeletions
-	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(ds).Error; err != nil {
 			return err
 		}
@@ -36,6 +39,8 @@ func (r *DataSourceRepository) Create(ctx context.Context, ds *types.DataSource)
 			Where("id = ?", ds.ID).
 			UpdateColumn("sync_deletions", syncDeletions).Error
 	})
+	ds.SyncDeletions = syncDeletions
+	return err
 }
 
 // FindByID retrieves a data source by ID

--- a/internal/application/repository/datasource_repo_test.go
+++ b/internal/application/repository/datasource_repo_test.go
@@ -51,6 +51,49 @@ func TestDataSourceRepositoryUpdateSyncStateClearsErrorMessage(t *testing.T) {
 	require.NotNil(t, stored.LastSyncAt)
 }
 
+func TestDataSourceRepositoryUpdatePersistsDisabledSyncDeletions(t *testing.T) {
+	db := setupDataSourceRepoTestDB(t)
+	repo := NewDataSourceRepository(db)
+	ctx := context.Background()
+
+	ds := &types.DataSource{
+		ID:              "ds-sync-deletions",
+		TenantID:        1,
+		KnowledgeBaseID: "kb-1",
+		Name:            "Feishu",
+		Type:            types.ConnectorTypeFeishu,
+		SyncDeletions:   true,
+	}
+	require.NoError(t, repo.Create(ctx, ds))
+
+	ds.SyncDeletions = false
+	require.NoError(t, repo.Update(ctx, ds))
+
+	var stored types.DataSource
+	require.NoError(t, db.First(&stored, "id = ?", ds.ID).Error)
+	assert.False(t, stored.SyncDeletions)
+}
+
+func TestDataSourceRepositoryCreatePersistsDisabledSyncDeletions(t *testing.T) {
+	db := setupDataSourceRepoTestDB(t)
+	repo := NewDataSourceRepository(db)
+	ctx := context.Background()
+
+	ds := &types.DataSource{
+		ID:              "ds-create-sync-deletions",
+		TenantID:        1,
+		KnowledgeBaseID: "kb-1",
+		Name:            "Feishu",
+		Type:            types.ConnectorTypeFeishu,
+		SyncDeletions:   false,
+	}
+	require.NoError(t, repo.Create(ctx, ds))
+
+	var stored types.DataSource
+	require.NoError(t, db.First(&stored, "id = ?", ds.ID).Error)
+	assert.False(t, stored.SyncDeletions)
+}
+
 func TestDataSourceRepositoryDeleteSoftDeletesOnSQLite(t *testing.T) {
 	db := setupDataSourceRepoTestDB(t)
 	repo := NewDataSourceRepository(db)

--- a/internal/application/repository/datasource_repo_test.go
+++ b/internal/application/repository/datasource_repo_test.go
@@ -68,10 +68,17 @@ func TestDataSourceRepositoryUpdatePersistsDisabledSyncDeletions(t *testing.T) {
 
 	ds.SyncDeletions = false
 	require.NoError(t, repo.Update(ctx, ds))
+	assert.False(t, ds.SyncDeletions)
 
 	var stored types.DataSource
 	require.NoError(t, db.First(&stored, "id = ?", ds.ID).Error)
 	assert.False(t, stored.SyncDeletions)
+
+	ds.SyncDeletions = true
+	require.NoError(t, repo.Update(ctx, ds))
+	assert.True(t, ds.SyncDeletions)
+	require.NoError(t, db.First(&stored, "id = ?", ds.ID).Error)
+	assert.True(t, stored.SyncDeletions)
 }
 
 func TestDataSourceRepositoryCreatePersistsDisabledSyncDeletions(t *testing.T) {
@@ -88,10 +95,39 @@ func TestDataSourceRepositoryCreatePersistsDisabledSyncDeletions(t *testing.T) {
 		SyncDeletions:   false,
 	}
 	require.NoError(t, repo.Create(ctx, ds))
+	assert.False(t, ds.SyncDeletions, "Create must not leave the in-memory field hydrated to the GORM default")
 
 	var stored types.DataSource
 	require.NoError(t, db.First(&stored, "id = ?", ds.ID).Error)
 	assert.False(t, stored.SyncDeletions)
+
+	// A later Updates() on the same pointer must not persist the hydrated default.
+	ds.Name = "Renamed"
+	require.NoError(t, repo.Update(ctx, ds))
+	require.NoError(t, db.First(&stored, "id = ?", ds.ID).Error)
+	assert.False(t, stored.SyncDeletions)
+	assert.Equal(t, "Renamed", stored.Name)
+}
+
+func TestDataSourceRepositoryCreatePersistsEnabledSyncDeletions(t *testing.T) {
+	db := setupDataSourceRepoTestDB(t)
+	repo := NewDataSourceRepository(db)
+	ctx := context.Background()
+
+	ds := &types.DataSource{
+		ID:              "ds-create-sync-deletions-enabled",
+		TenantID:        1,
+		KnowledgeBaseID: "kb-1",
+		Name:            "Feishu",
+		Type:            types.ConnectorTypeFeishu,
+		SyncDeletions:   true,
+	}
+	require.NoError(t, repo.Create(ctx, ds))
+	assert.True(t, ds.SyncDeletions)
+
+	var stored types.DataSource
+	require.NoError(t, db.First(&stored, "id = ?", ds.ID).Error)
+	assert.True(t, stored.SyncDeletions)
 }
 
 func TestDataSourceRepositoryDeleteSoftDeletesOnSQLite(t *testing.T) {


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description

修复数据源创建和编辑时，`sync_deletions=false` 无法可靠持久化的问题。

GORM 的结构体 `Create` 和 `Updates` 操作会对带有 `default:true` 的布尔字段应用默认值，或跳过 `false` 零值更新。因此用户取消“同步删
除”后，数据库中的值可能仍然是 `true`。

本次在同一事务中完成常规创建/更新后，显式写入 `sync_deletions` 字段，确保用户设置的 `true` 或 `false` 都能正确保存。

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->


## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->

- `go test ./internal/application/repository`

## Checklist
- [ ] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->

无