### PR TITLE
fix(anydoc): rebuild truncated patched crate instead of failing cargo

### DIFF
--- a/.github/workflows/anydoc.yml
+++ b/.github/workflows/anydoc.yml
@@ -57,6 +57,13 @@ jobs:
         if: steps.cargo-audit-cache.outputs.cache-hit != 'true'
         run: cargo install cargo-audit --locked
 
+      # The archive is a build artifact, not a committed blob, so CI is what
+      # keeps the vendored bindings in third_party/anydoc-go compiling.
+      # This also materializes patched-anydoc/ (gitignored); cargo audit below
+      # cannot load the crates-io patch until that tree exists.
+      - name: Build the anydoc static archive
+        run: ./scripts/build-anydoc-lib.sh
+
       # The vendored bindings pull anydoc and its PDF stack from crates.io, and
       # WeKnora parses untrusted uploads in-process. A Rust advisory there (as
       # in RUSTSEC-2026-0187, an uncatchable abort on a hostile PDF) has to
@@ -66,11 +73,6 @@ jobs:
       - name: Audit the vendored dependency tree
         working-directory: third_party/anydoc-go
         run: cargo audit
-
-      # The archive is a build artifact, not a committed blob, so CI is what
-      # keeps the vendored bindings in third_party/anydoc-go compiling.
-      - name: Build the anydoc static archive
-        run: ./scripts/build-anydoc-lib.sh
 
       - name: Vet, test, and build with the engine linked in
         run: |

--- a/scripts/build-anydoc-lib.sh
+++ b/scripts/build-anydoc-lib.sh
@@ -55,8 +55,10 @@ prepare_patched_anydoc() {
   local dest="$crate_dir/patched-anydoc"
   # The marker records which version was patched: after a version bump the
   # copy left by the previous build is the wrong crate, and reusing it would
-  # fail deep inside cargo's patch resolution instead of here.
-  if [ -f "$dest/.weknora-patched" ] && [ "$(cat "$dest/.weknora-patched")" = "$anydoc_version" ]; then
+  # fail deep inside cargo's patch resolution instead of here. Cargo.toml is
+  # required too: a truncated leftover with only the marker would otherwise
+  # skip the copy and fail with "failed to read .../Cargo.toml".
+  if [ -f "$dest/.weknora-patched" ] && [ "$(cat "$dest/.weknora-patched")" = "$anydoc_version" ] && [ -f "$dest/Cargo.toml" ]; then
     return
   fi
 


### PR DESCRIPTION
## Summary
- `prepare_patched_anydoc` treated a leftover `.weknora-patched` marker as enough, so a truncated `patched-anydoc/` (no `Cargo.toml`) skipped the recopy and `cargo` failed with a missing manifest.
- Run the archive build before `cargo audit` so CI materializes the gitignored patch path first.

## Test plan
- [x] `make anydoc-lib` on `aarch64-apple-darwin` after a truncated `patched-anydoc` leftover
- [ ] Anydoc workflow on this PR (build archive, then `cargo audit`, then `go test -tags anydoc`)