### PR TITLE
fix(docreader): apply PDF image SMask so embedded figures are not all-black

### DIFF
--- a/docreader/parser/pdf_parser.py
+++ b/docreader/parser/pdf_parser.py
@@ -1185,6 +1185,31 @@ def _select_embedded_images(
     return kept
 
 
+def _decode_embedded_image_pil(obj):
+    """Decode an embedded image the way a PDF viewer displays it.
+
+    ``get_bitmap()`` returns the raw image plane and ignores any /SMask (soft
+    transparency mask). Figures exported from plotting tools often store a
+    black base plane with the visible content in the mask, so the raw plane
+    decodes to an all-black rectangle. ``get_bitmap(render=True)`` renders the
+    object through pdfium's imaging pipeline and carries the mask as an alpha
+    channel; compositing over white then yields what the page looks like
+    (JPEG cannot keep alpha, and pages render on white).
+    """
+    from PIL import Image
+
+    try:
+        pil = obj.get_bitmap(render=True).to_pil()
+    except Exception:
+        pil = obj.get_bitmap().to_pil()
+    if pil.mode in ("RGBA", "LA", "PA"):
+        pil = pil.convert("RGBA")
+        if pil.getchannel("A").getextrema()[0] < 255:
+            background = Image.new("RGBA", pil.size, (255, 255, 255, 255))
+            pil = Image.alpha_composite(background, pil)
+    return pil.convert("RGB")
+
+
 def _extract_embedded_images(pdf, classes, raw, base_name: str, quality: int) -> dict:
     """Extract filtered embedded figures from native text pages.
 
@@ -1217,7 +1242,7 @@ def _extract_embedded_images(pdf, classes, raw, base_name: str, quality: int) ->
                 if area_ratio < EMBED_MIN_AREA_RATIO:
                     continue  # cheap skip before decoding (logos/decorations)
                 try:
-                    pil = obj.get_bitmap().to_pil()
+                    pil = _decode_embedded_image_pil(obj)
                 except Exception:
                     continue
                 content_hash = hashlib.md5(pil.tobytes()).hexdigest()

--- a/docreader/parser/pdf_parser.py
+++ b/docreader/parser/pdf_parser.py
@@ -1195,19 +1195,40 @@ def _decode_embedded_image_pil(obj):
     object through pdfium's imaging pipeline and carries the mask as an alpha
     channel; compositing over white then yields what the page looks like
     (JPEG cannot keep alpha, and pages render on white).
+
+    The ``PdfBitmap`` is kept alive until pixels are copied: ``to_pil()``
+    shares the pdfium buffer for RGBA/RGBX/L, and releasing the handle first
+    would use-after-free. Opaque RGB/L images keep their mode so grayscale
+    hashes and JPEGs stay single-channel.
     """
     from PIL import Image
 
+    bitmap = None
     try:
-        pil = obj.get_bitmap(render=True).to_pil()
-    except Exception:
-        pil = obj.get_bitmap().to_pil()
-    if pil.mode in ("RGBA", "LA", "PA"):
-        pil = pil.convert("RGBA")
-        if pil.getchannel("A").getextrema()[0] < 255:
-            background = Image.new("RGBA", pil.size, (255, 255, 255, 255))
-            pil = Image.alpha_composite(background, pil)
-    return pil.convert("RGB")
+        try:
+            bitmap = obj.get_bitmap(render=True)
+        except Exception:
+            logger.warning(
+                "get_bitmap(render=True) failed; falling back to raw decode",
+                exc_info=True,
+            )
+            _close_pdfium_resource(bitmap)
+            bitmap = obj.get_bitmap()
+        pil = bitmap.to_pil()
+        if pil.mode in ("RGBA", "LA", "PA"):
+            src_mode = pil.mode
+            rgba = pil.convert("RGBA")
+            if rgba.getchannel("A").getextrema()[0] < 255:
+                background = Image.new("RGBA", rgba.size, (255, 255, 255, 255))
+                return Image.alpha_composite(background, rgba).convert("RGB")
+            if src_mode == "LA":
+                return rgba.convert("L")
+            return rgba.convert("RGB")
+        if pil.mode in ("RGB", "L"):
+            return pil.copy()
+        return pil.convert("RGB")
+    finally:
+        _close_pdfium_resource(bitmap)
 
 
 def _extract_embedded_images(pdf, classes, raw, base_name: str, quality: int) -> dict:

--- a/docreader/tests/test_pdf_embedded_images.py
+++ b/docreader/tests/test_pdf_embedded_images.py
@@ -8,8 +8,10 @@ from a production PDF exported by a plotting tool.
 """
 
 import base64
+import gc
 import io
 import unittest
+from unittest.mock import patch
 
 import pypdfium2 as pdfium
 import pypdfium2.raw as pdfium_raw
@@ -24,46 +26,7 @@ PAGE_W, PAGE_H = 612, 792
 IMG_W, IMG_H = 120, 90
 
 
-def _build_smask_pdf() -> bytes:
-    """Hand-built PDF: one black RGB image shaped by an SMask circle.
-
-    The base plane is entirely black; the SMask is opaque (255) inside a
-    filled circle and transparent (0) elsewhere, so a viewer shows a black
-    circle on the white page — and a decoder that drops the mask shows pure
-    black.
-    """
-    base = b"\x00\x00\x00" * (IMG_W * IMG_H)
-    cx, cy, radius = IMG_W // 2, IMG_H // 2, 30
-    mask = bytearray(IMG_W * IMG_H)
-    for y in range(IMG_H):
-        for x in range(IMG_W):
-            if (x - cx) ** 2 + (y - cy) ** 2 <= radius * radius:
-                mask[y * IMG_W + x] = 255
-    contents = b"q 480 0 0 360 66 216 cm /Im0 Do Q\n"
-    objects = [
-        b"<< /Type /Catalog /Pages 2 0 R >>",
-        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
-        (
-            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 %d %d] "
-            b"/Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>"
-            % (PAGE_W, PAGE_H)
-        ),
-        b"<< /Length %d >>\nstream\n" % len(contents) + contents + b"endstream",
-        (
-            b"<< /Type /XObject /Subtype /Image /Width %d /Height %d "
-            b"/ColorSpace /DeviceRGB /BitsPerComponent 8 /SMask 6 0 R "
-            b"/Length %d >>\nstream\n" % (IMG_W, IMG_H, len(base))
-            + base
-            + b"\nendstream"
-        ),
-        (
-            b"<< /Type /XObject /Subtype /Image /Width %d /Height %d "
-            b"/ColorSpace /DeviceGray /BitsPerComponent 8 /Length %d >>\nstream\n"
-            % (IMG_W, IMG_H, len(mask))
-            + bytes(mask)
-            + b"\nendstream"
-        ),
-    ]
+def _pdf_from_objects(objects: list) -> bytes:
     out = bytearray(b"%PDF-1.7\n")
     offsets = []
     for i, body in enumerate(objects, start=1):
@@ -81,12 +44,89 @@ def _build_smask_pdf() -> bytes:
     return bytes(out)
 
 
+def _page_objects(image_obj: bytes, extra_objs: list | None = None) -> list:
+    contents = b"q 480 0 0 360 66 216 cm /Im0 Do Q\n"
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        (
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 %d %d] "
+            b"/Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>"
+            % (PAGE_W, PAGE_H)
+        ),
+        b"<< /Length %d >>\nstream\n" % len(contents) + contents + b"endstream",
+        image_obj,
+    ]
+    if extra_objs:
+        objects.extend(extra_objs)
+    return objects
+
+
+def _circle_mask() -> bytes:
+    cx, cy, radius = IMG_W // 2, IMG_H // 2, 30
+    mask = bytearray(IMG_W * IMG_H)
+    for y in range(IMG_H):
+        for x in range(IMG_W):
+            if (x - cx) ** 2 + (y - cy) ** 2 <= radius * radius:
+                mask[y * IMG_W + x] = 255
+    return bytes(mask)
+
+
+def _build_smask_pdf(base_rgb=(0, 0, 0)) -> bytes:
+    """Hand-built PDF: one RGB image shaped by an SMask circle.
+
+    The SMask is opaque (255) inside a filled circle and transparent (0)
+    elsewhere. A decoder that drops the mask shows the raw base plane only.
+    """
+    r, g, b = base_rgb
+    base = bytes((r, g, b)) * (IMG_W * IMG_H)
+    mask = _circle_mask()
+    image = (
+        b"<< /Type /XObject /Subtype /Image /Width %d /Height %d "
+        b"/ColorSpace /DeviceRGB /BitsPerComponent 8 /SMask 6 0 R "
+        b"/Length %d >>\nstream\n" % (IMG_W, IMG_H, len(base))
+        + base
+        + b"\nendstream"
+    )
+    mask_obj = (
+        b"<< /Type /XObject /Subtype /Image /Width %d /Height %d "
+        b"/ColorSpace /DeviceGray /BitsPerComponent 8 /Length %d >>\nstream\n"
+        % (IMG_W, IMG_H, len(mask))
+        + mask
+        + b"\nendstream"
+    )
+    return _pdf_from_objects(_page_objects(image, [mask_obj]))
+
+
+def _build_opaque_gray_pdf(level: int = 128) -> bytes:
+    data = bytes((level,)) * (IMG_W * IMG_H)
+    image = (
+        b"<< /Type /XObject /Subtype /Image /Width %d /Height %d "
+        b"/ColorSpace /DeviceGray /BitsPerComponent 8 /Length %d >>\nstream\n"
+        % (IMG_W, IMG_H, len(data))
+        + data
+        + b"\nendstream"
+    )
+    return _pdf_from_objects(_page_objects(image))
+
+
 def _first_image_object(pdf):
     for page in pdf:
         for obj in page.get_objects():
             if obj.type == pdfium_raw.FPDF_PAGEOBJ_IMAGE:
                 return obj
     raise AssertionError("test PDF has no image object")
+
+
+def _raw_decode(obj):
+    bitmap = obj.get_bitmap()
+    try:
+        pil = bitmap.to_pil()
+        if pil.mode in ("RGB", "L"):
+            return pil.copy()
+        return pil.convert("RGB")
+    finally:
+        bitmap.close()
 
 
 class DecodeEmbeddedImageTest(unittest.TestCase):
@@ -103,7 +143,58 @@ class DecodeEmbeddedImageTest(unittest.TestCase):
         # Opaque circle center keeps the base-plane colour (black).
         self.assertLess(pil.getpixel((IMG_W // 2, IMG_H // 2))[0], 40)
 
-    def test_opaque_image_without_mask_unchanged(self):
+    def test_colored_smask_keeps_base_color(self):
+        pdf = pdfium.PdfDocument(_build_smask_pdf(base_rgb=(200, 30, 40)))
+        try:
+            pil = _decode_embedded_image_pil(_first_image_object(pdf))
+        finally:
+            pdf.close()
+        self.assertEqual(pil.mode, "RGB")
+        self.assertGreater(pil.getpixel((2, 2))[0], 200)
+        center = pil.getpixel((IMG_W // 2, IMG_H // 2))
+        self.assertGreater(center[0], 150)
+        self.assertLess(center[1], 80)
+        self.assertLess(center[2], 80)
+
+    def test_opaque_image_matches_raw_pixels(self):
+        buf = io.BytesIO()
+        Image.new("RGB", (100, 80), (10, 200, 30)).save(buf, format="PDF")
+        pdf = pdfium.PdfDocument(buf.getvalue())
+        try:
+            obj = _first_image_object(pdf)
+            raw = _raw_decode(obj)
+            pil = _decode_embedded_image_pil(obj)
+        finally:
+            pdf.close()
+        self.assertEqual(pil.size, raw.size)
+        self.assertEqual(pil.mode, raw.mode)
+        self.assertEqual(pil.tobytes(), raw.tobytes())
+
+    def test_opaque_gray_fallback_keeps_l_mode(self):
+        # render=True typically returns BGRA even for DeviceGray; the raw
+        # fallback must keep L so grayscale hashes/JPEGs stay single-channel.
+        pdf = pdfium.PdfDocument(_build_opaque_gray_pdf(128))
+        try:
+            obj = _first_image_object(pdf)
+            raw = _raw_decode(obj)
+            self.assertEqual(raw.mode, "L")
+            original = obj.get_bitmap
+
+            def _boom(render=False, **kwargs):
+                if render:
+                    raise RuntimeError("render unavailable")
+                return original(render=render, **kwargs)
+
+            with patch.object(obj, "get_bitmap", side_effect=_boom):
+                with self.assertLogs("docreader.parser.pdf_parser", level="WARNING"):
+                    pil = _decode_embedded_image_pil(obj)
+        finally:
+            pdf.close()
+        self.assertEqual(pil.mode, "L")
+        self.assertEqual(pil.getpixel((IMG_W // 2, IMG_H // 2)), 128)
+        self.assertEqual(pil.tobytes(), raw.tobytes())
+
+    def test_decoded_image_survives_bitmap_gc(self):
         buf = io.BytesIO()
         Image.new("RGB", (100, 80), (10, 200, 30)).save(buf, format="PDF")
         pdf = pdfium.PdfDocument(buf.getvalue())
@@ -111,8 +202,33 @@ class DecodeEmbeddedImageTest(unittest.TestCase):
             pil = _decode_embedded_image_pil(_first_image_object(pdf))
         finally:
             pdf.close()
-        self.assertEqual(pil.mode, "RGB")
-        self.assertEqual(pil.getpixel((50, 40))[1], 200)
+        gc.collect()
+        self.assertEqual(pil.getpixel((50, 40)), (10, 200, 30))
+
+    def test_render_failure_falls_back_to_raw(self):
+        buf = io.BytesIO()
+        Image.new("RGB", (100, 80), (10, 200, 30)).save(buf, format="PDF")
+        pdf = pdfium.PdfDocument(buf.getvalue())
+        try:
+            obj = _first_image_object(pdf)
+            raw = _raw_decode(obj)
+            original = obj.get_bitmap
+
+            def _boom(render=False, **kwargs):
+                if render:
+                    raise RuntimeError("render unavailable")
+                return original(render=render, **kwargs)
+
+            with patch.object(obj, "get_bitmap", side_effect=_boom):
+                with self.assertLogs(
+                    "docreader.parser.pdf_parser", level="WARNING"
+                ) as logs:
+                    pil = _decode_embedded_image_pil(obj)
+        finally:
+            pdf.close()
+        self.assertTrue(any("falling back to raw decode" in m for m in logs.output))
+        self.assertEqual(pil.mode, raw.mode)
+        self.assertEqual(pil.tobytes(), raw.tobytes())
 
 
 class ExtractEmbeddedImagesTest(unittest.TestCase):

--- a/docreader/tests/test_pdf_embedded_images.py
+++ b/docreader/tests/test_pdf_embedded_images.py
@@ -1,0 +1,142 @@
+"""Embedded-figure extraction from native PDF pages.
+
+Focus: images whose visible content lives in a /SMask (soft transparency
+mask) while the base RGB plane is black. ``get_bitmap()`` alone decodes only
+the base plane, producing an all-black JPEG; the decode path must render the
+mask in and composite over white. Reproduces the all-black figures extracted
+from a production PDF exported by a plotting tool.
+"""
+
+import base64
+import io
+import unittest
+
+import pypdfium2 as pdfium
+import pypdfium2.raw as pdfium_raw
+from PIL import Image
+
+from docreader.parser.pdf_parser import (
+    _decode_embedded_image_pil,
+    _extract_embedded_images,
+)
+
+PAGE_W, PAGE_H = 612, 792
+IMG_W, IMG_H = 120, 90
+
+
+def _build_smask_pdf() -> bytes:
+    """Hand-built PDF: one black RGB image shaped by an SMask circle.
+
+    The base plane is entirely black; the SMask is opaque (255) inside a
+    filled circle and transparent (0) elsewhere, so a viewer shows a black
+    circle on the white page — and a decoder that drops the mask shows pure
+    black.
+    """
+    base = b"\x00\x00\x00" * (IMG_W * IMG_H)
+    cx, cy, radius = IMG_W // 2, IMG_H // 2, 30
+    mask = bytearray(IMG_W * IMG_H)
+    for y in range(IMG_H):
+        for x in range(IMG_W):
+            if (x - cx) ** 2 + (y - cy) ** 2 <= radius * radius:
+                mask[y * IMG_W + x] = 255
+    contents = b"q 480 0 0 360 66 216 cm /Im0 Do Q\n"
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        (
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 %d %d] "
+            b"/Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>"
+            % (PAGE_W, PAGE_H)
+        ),
+        b"<< /Length %d >>\nstream\n" % len(contents) + contents + b"endstream",
+        (
+            b"<< /Type /XObject /Subtype /Image /Width %d /Height %d "
+            b"/ColorSpace /DeviceRGB /BitsPerComponent 8 /SMask 6 0 R "
+            b"/Length %d >>\nstream\n" % (IMG_W, IMG_H, len(base))
+            + base
+            + b"\nendstream"
+        ),
+        (
+            b"<< /Type /XObject /Subtype /Image /Width %d /Height %d "
+            b"/ColorSpace /DeviceGray /BitsPerComponent 8 /Length %d >>\nstream\n"
+            % (IMG_W, IMG_H, len(mask))
+            + bytes(mask)
+            + b"\nendstream"
+        ),
+    ]
+    out = bytearray(b"%PDF-1.7\n")
+    offsets = []
+    for i, body in enumerate(objects, start=1):
+        offsets.append(len(out))
+        out += b"%d 0 obj\n" % i + body + b"\nendobj\n"
+    xref_pos = len(out)
+    out += b"xref\n0 %d\n" % (len(objects) + 1)
+    out += b"0000000000 65535 f \n"
+    for off in offsets:
+        out += b"%010d 00000 n \n" % off
+    out += b"trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n" % (
+        len(objects) + 1,
+        xref_pos,
+    )
+    return bytes(out)
+
+
+def _first_image_object(pdf):
+    for page in pdf:
+        for obj in page.get_objects():
+            if obj.type == pdfium_raw.FPDF_PAGEOBJ_IMAGE:
+                return obj
+    raise AssertionError("test PDF has no image object")
+
+
+class DecodeEmbeddedImageTest(unittest.TestCase):
+    def test_smask_image_composites_over_white(self):
+        pdf = pdfium.PdfDocument(_build_smask_pdf())
+        try:
+            pil = _decode_embedded_image_pil(_first_image_object(pdf))
+        finally:
+            pdf.close()
+        self.assertEqual(pil.mode, "RGB")
+        # Transparent corners become white page background, not black.
+        self.assertGreater(pil.getpixel((2, 2))[0], 200)
+        self.assertGreater(pil.getpixel((IMG_W - 3, IMG_H - 3))[0], 200)
+        # Opaque circle center keeps the base-plane colour (black).
+        self.assertLess(pil.getpixel((IMG_W // 2, IMG_H // 2))[0], 40)
+
+    def test_opaque_image_without_mask_unchanged(self):
+        buf = io.BytesIO()
+        Image.new("RGB", (100, 80), (10, 200, 30)).save(buf, format="PDF")
+        pdf = pdfium.PdfDocument(buf.getvalue())
+        try:
+            pil = _decode_embedded_image_pil(_first_image_object(pdf))
+        finally:
+            pdf.close()
+        self.assertEqual(pil.mode, "RGB")
+        self.assertEqual(pil.getpixel((50, 40))[1], 200)
+
+
+class ExtractEmbeddedImagesTest(unittest.TestCase):
+    def test_smask_figure_is_not_all_black(self):
+        pdf = pdfium.PdfDocument(_build_smask_pdf())
+        try:
+            result = _extract_embedded_images(
+                pdf, ["text"], pdfium_raw, "smask_doc", 85
+            )
+        finally:
+            pdf.close()
+        self.assertIn(0, result)
+        ref_path, b64_jpeg, _y_top = result[0][0]
+        self.assertTrue(ref_path.startswith("images/smask_doc_p1_img1"))
+        pil = Image.open(io.BytesIO(base64.b64decode(b64_jpeg))).convert("RGB")
+        total = bright = 0
+        for x in range(0, pil.width, 4):
+            for y in range(0, pil.height, 4):
+                total += 1
+                if max(pil.getpixel((x, y))) >= 200:
+                    bright += 1
+        # Dropping the mask would make this ~0: the whole figure is black.
+        self.assertGreater(bright / total, 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

PDFs that embed figures with a soft transparency mask (/\SMask) — a common export format from plotting tools — get their embedded figures extracted as **all-black JPEGs**. The figure content becomes unreadable in the document chunks, and downstream VLM captions / OCR run on a black rectangle (e.g. captions come back as *"black background with three white triangular shapes"*).

## Root cause

`_extract_embedded_images` decoded each embedded image with `PdfObject.get_bitmap()`, which returns the **raw base image plane and ignores the /\SMask**. For masked figures the visible content lives in the mask while the base RGB plane is black, so the raw plane decodes to a solid black rectangle, which is then saved as JPEG as-is.

Verified on a production PDF: 7 of 23 embedded images carried an /\SMask; each decoded to ~100% dark pixels via `get_bitmap()` while the same object rendered normally in any PDF viewer.

## Fix

New helper `_decode_embedded_image_pil()`:

1. Decode with `get_bitmap(render=True)` (`FPDFImageObj_GetRenderedBitmap`), which renders through pdfium's imaging pipeline and carries the mask as an alpha channel.
2. If the result has real transparency, composite over **white** — JPEG cannot keep alpha and PDF pages render on white, so this matches what a viewer displays.
3. Fall back to the previous raw decode if rendering raises.

Opaque images are byte-for-byte unaffected.

## Testing

- New `docreader/tests/test_pdf_embedded_images.py` with a hand-built PDF that reproduces the exact pattern (black RGB base plane + /\SMask circle): asserts corners become white, the opaque circle keeps its color, and the extracted JPEG is no longer all-black. Also asserts a plain opaque image is unchanged.
- Full docreader suite: 161 tests pass (13 skipped), no behavior change for the other 158.
- End-to-end on the production PDF that triggered the bug: all 7 masked figures' dark-pixel ratio drops from ~100% to 0.7%–4.5% and are fully readable.