### PR TITLE
fix(handler): validate knowledge search pagination

### DIFF
--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -2206,8 +2206,8 @@ func (h *KnowledgeHandler) UpdateImageInfo(c *gin.Context) {
 // @Accept       json
 // @Produce      json
 // @Param        keyword    query     string  false "Keyword to search"
-// @Param        offset     query     int     false "Offset for pagination"
-// @Param        limit      query     int     false "Limit for pagination (default 20)"
+// @Param        offset     query     int     false "Offset for pagination (minimum 0)" minimum(0)
+// @Param        limit      query     int     false "Limit for pagination (default 20, maximum 100)" minimum(1) maximum(100)
 // @Param        file_types query     string  false "Comma-separated file extensions to filter (e.g., csv,xlsx)"
 // @Param        agent_id   query     string  false "Shared agent ID (search within agent's KB scope)"
 // @Param        recent     query     bool    false "Return recent files when keyword is empty"
@@ -2235,8 +2235,10 @@ func (h *KnowledgeHandler) SearchKnowledge(c *gin.Context) {
 		return
 	}
 	keyword = strings.TrimSpace(keyword)
-	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
+	offset, limit, ok := parseOffsetPagination(c)
+	if !ok {
+		return
+	}
 
 	var fileTypes []string
 	if fileTypesStr := c.Query("file_types"); fileTypesStr != "" {

--- a/internal/handler/list_pagination.go
+++ b/internal/handler/list_pagination.go
@@ -13,6 +13,8 @@ import (
 const (
 	defaultListPageSize = 20
 	maxListPageSize     = 100
+	defaultSearchLimit  = 20
+	maxSearchLimit      = 100
 )
 
 // parseListPagination parses ?page and ?page_size for tenant-scoped list
@@ -39,4 +41,28 @@ func parseListPagination(c *gin.Context) (page, pageSize int, ok bool) {
 		pageSize = ps
 	}
 	return page, pageSize, true
+}
+
+// parseOffsetPagination parses ?offset and ?limit for offset-based search
+// endpoints. Omitted keys default to offset=0 and limit=20.
+func parseOffsetPagination(c *gin.Context) (offset, limit int, ok bool) {
+	limit = defaultSearchLimit
+
+	if s := strings.TrimSpace(c.Query("offset")); s != "" {
+		parsedOffset, err := strconv.Atoi(s)
+		if err != nil || parsedOffset < 0 {
+			c.Error(apperrors.NewValidationError("offset must be a non-negative integer"))
+			return 0, 0, false
+		}
+		offset = parsedOffset
+	}
+	if s := strings.TrimSpace(c.Query("limit")); s != "" {
+		parsedLimit, err := strconv.Atoi(s)
+		if err != nil || parsedLimit < 1 || parsedLimit > maxSearchLimit {
+			c.Error(apperrors.NewValidationError(fmt.Sprintf("limit must be between 1 and %d", maxSearchLimit)))
+			return 0, 0, false
+		}
+		limit = parsedLimit
+	}
+	return offset, limit, true
 }

--- a/internal/handler/list_pagination_test.go
+++ b/internal/handler/list_pagination_test.go
@@ -1,0 +1,77 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestParseOffsetPagination(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name        string
+		query       string
+		wantOffset  int
+		wantLimit   int
+		wantOK      bool
+		wantMessage string
+	}{
+		{name: "defaults", wantOffset: 0, wantLimit: 20, wantOK: true},
+		{name: "valid", query: "?offset=40&limit=50", wantOffset: 40, wantLimit: 50, wantOK: true},
+		{name: "invalid offset", query: "?offset=not-a-number", wantMessage: "offset must be a non-negative integer"},
+		{name: "negative offset", query: "?offset=-1", wantMessage: "offset must be a non-negative integer"},
+		{name: "invalid limit", query: "?limit=not-a-number", wantMessage: "limit must be between 1 and 100"},
+		{name: "zero limit", query: "?limit=0", wantMessage: "limit must be between 1 and 100"},
+		{name: "limit too large", query: "?limit=101", wantMessage: "limit must be between 1 and 100"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest("GET", "/knowledge/search"+tt.query, nil)
+
+			offset, limit, ok := parseOffsetPagination(c)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if offset != tt.wantOffset || limit != tt.wantLimit {
+				t.Fatalf("got offset=%d limit=%d, want offset=%d limit=%d", offset, limit, tt.wantOffset, tt.wantLimit)
+			}
+			if tt.wantOK {
+				if len(c.Errors) != 0 {
+					t.Fatalf("unexpected errors: %v", c.Errors)
+				}
+				return
+			}
+			if len(c.Errors) != 1 {
+				t.Fatalf("got %d errors, want 1", len(c.Errors))
+			}
+			if !strings.Contains(c.Errors[0].Error(), tt.wantMessage) {
+				t.Fatalf("error = %q, want message containing %q", c.Errors[0].Error(), tt.wantMessage)
+			}
+		})
+	}
+}
+
+func TestSearchKnowledgeRejectsInvalidPagination(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, query := range []string{
+		"?keyword=test&offset=-1",
+		"?keyword=test&limit=101",
+	} {
+		t.Run(query, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest("GET", "/knowledge/search"+query, nil)
+
+			(&KnowledgeHandler{}).SearchKnowledge(c)
+
+			if len(c.Errors) != 1 {
+				t.Fatalf("got %d errors, want 1", len(c.Errors))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

`GET /api/v1/knowledge/search` previously ignored `strconv.Atoi` errors for `offset` and `limit` and passed the resulting values directly through the service layer to GORM. This meant malformed values were silently treated as zero, negative values were accepted, and arbitrarily large limits could reach `LIMIT(limit + 1)`.

This PR:
- adds a shared parser for offset-based pagination;
- requires `offset >= 0` and `1 <= limit <= 100`;
- preserves the existing defaults (`offset=0`, `limit=20`);
- stops invalid requests before they reach the service/repository layer;
- documents the bounds in the Swagger annotations.

The change is limited to request-boundary validation; search semantics, service interfaces, and repository queries are unchanged.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

No linked issue.

## Testing

Passed:

```bash
go test ./internal/handler -run "TestParseOffsetPagination|TestSearchKnowledgeRejectsInvalidPagination" -count=1
```

`go test ./internal/handler -count=1` was also run. It reaches an unrelated existing failure:

```text
TestPutTenantParserConfigAdminPreservesRedactedSecrets
expected: 200
actual:   400
```

The same test fails identically on an untouched `upstream/main` worktree at `412dcc41`, confirming it is not introduced by this PR.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

Not applicable; no UI changes.