### PR TITLE
fix(im): handle DingTalk rich text messages

### DIFF
--- a/internal/im/dingtalk/adapter.go
+++ b/internal/im/dingtalk/adapter.go
@@ -397,7 +397,12 @@ func parseCallbackMessage(msg *callbackMessage) *im.IncomingMessage {
 	return incoming
 }
 
-func applyRichText(incoming *im.IncomingMessage, extra map[string]string, rich parsedRichText, msgID, robotCode string) {
+func applyRichText(
+	incoming *im.IncomingMessage,
+	extra map[string]string,
+	rich parsedRichText,
+	msgID, robotCode string,
+) {
 	incoming.Content = rich.Text
 	if rich.DownloadCode != "" {
 		incoming.MessageType = im.MessageTypeImage

--- a/internal/im/dingtalk/adapter.go
+++ b/internal/im/dingtalk/adapter.go
@@ -174,6 +174,60 @@ type fileMessageContent struct {
 	FileName            string `json:"fileName"`
 }
 
+// richTextMessageContent is the payload DingTalk sends for msgtype=richText.
+// Text and pictures are interleaved in their original display order. The
+// unified IM message currently carries one downloadable file, so we retain the
+// first picture while preserving all text fragments for the QA query.
+type richTextMessageContent struct {
+	RichText []richTextElement `json:"richText"`
+}
+
+type richTextElement struct {
+	Text                string `json:"text"`
+	Type                string `json:"type"`
+	DownloadCode        string `json:"downloadCode"`
+	PictureDownloadCode string `json:"pictureDownloadCode"`
+}
+
+type parsedRichText struct {
+	Text         string
+	DownloadCode string
+	PictureCount int
+}
+
+func parseRichTextContent(msgtype string, content json.RawMessage) (parsedRichText, bool) {
+	if !strings.EqualFold(strings.TrimSpace(msgtype), "richText") {
+		return parsedRichText{}, false
+	}
+
+	var payload richTextMessageContent
+	if len(content) == 0 || json.Unmarshal(content, &payload) != nil {
+		return parsedRichText{}, false
+	}
+
+	textParts := make([]string, 0, len(payload.RichText))
+	result := parsedRichText{}
+	for _, item := range payload.RichText {
+		if text := strings.TrimSpace(item.Text); text != "" {
+			textParts = append(textParts, text)
+		}
+
+		if !strings.EqualFold(strings.TrimSpace(item.Type), "picture") &&
+			item.DownloadCode == "" && item.PictureDownloadCode == "" {
+			continue
+		}
+		result.PictureCount++
+		if result.DownloadCode == "" {
+			result.DownloadCode = item.DownloadCode
+			if result.DownloadCode == "" {
+				result.DownloadCode = item.PictureDownloadCode
+			}
+		}
+	}
+	result.Text = strings.Join(textParts, "\n")
+	return result, true
+}
+
 // parseFileContent maps a DingTalk msgtype + content object to WeKnora's file
 // message fields. Returns ok=false for non-file/picture message types so the
 // caller keeps its text handling. Picture messages have no fileName; the IM
@@ -286,6 +340,7 @@ func parseCallbackMessage(msg *callbackMessage) *im.IncomingMessage {
 
 	extra := map[string]string{
 		"session_webhook": msg.SessionWebhook,
+		"raw_msgtype":     msg.Msgtype,
 	}
 	incoming := &im.IncomingMessage{
 		Platform:  im.PlatformDingtalk,
@@ -297,7 +352,9 @@ func parseCallbackMessage(msg *callbackMessage) *im.IncomingMessage {
 		Extra:     extra,
 	}
 
-	if msgType, fileName, downloadCode, ok := parseFileContent(msg.Msgtype, msg.Content); ok {
+	if rich, ok := parseRichTextContent(msg.Msgtype, msg.Content); ok {
+		applyRichText(incoming, extra, rich, msg.MsgID, msg.RobotCode)
+	} else if msgType, fileName, downloadCode, ok := parseFileContent(msg.Msgtype, msg.Content); ok {
 		incoming.MessageType = msgType
 		incoming.FileName = defaultFileName(msgType, fileName, msg.MsgID)
 		incoming.FileKey = downloadCode
@@ -309,6 +366,26 @@ func parseCallbackMessage(msg *callbackMessage) *im.IncomingMessage {
 		}
 	}
 	return incoming
+}
+
+func applyRichText(incoming *im.IncomingMessage, extra map[string]string, rich parsedRichText, msgID, robotCode string) {
+	incoming.Content = rich.Text
+	if rich.DownloadCode != "" {
+		incoming.MessageType = im.MessageTypeImage
+	} else {
+		incoming.MessageType = im.MessageTypeText
+	}
+
+	if rich.PictureCount == 0 {
+		return
+	}
+	extra["rich_text_picture_count"] = strconv.Itoa(rich.PictureCount)
+	if rich.DownloadCode == "" {
+		return
+	}
+	incoming.FileKey = rich.DownloadCode
+	incoming.FileName = defaultFileName(im.MessageTypeImage, "", msgID)
+	extra["robot_code"] = robotCode
 }
 
 // defaultFileName gives picture messages (which carry no fileName) a name with a
@@ -374,6 +451,7 @@ func streamToIncoming(data *chatbot.BotCallbackDataModel, fallbackRobotCode stri
 
 	extra := map[string]string{
 		"session_webhook": data.SessionWebhook,
+		"raw_msgtype":     data.Msgtype,
 	}
 	incoming := &im.IncomingMessage{
 		Platform:  im.PlatformDingtalk,
@@ -394,7 +472,9 @@ func streamToIncoming(data *chatbot.BotCallbackDataModel, fallbackRobotCode stri
 		}
 	}
 
-	if msgType, fileName, downloadCode, ok := parseFileContent(data.Msgtype, contentRaw); ok {
+	if rich, ok := parseRichTextContent(data.Msgtype, contentRaw); ok {
+		applyRichText(incoming, extra, rich, data.MsgId, fallbackRobotCode)
+	} else if msgType, fileName, downloadCode, ok := parseFileContent(data.Msgtype, contentRaw); ok {
 		incoming.MessageType = msgType
 		incoming.FileName = defaultFileName(msgType, fileName, data.MsgId)
 		incoming.FileKey = downloadCode

--- a/internal/im/dingtalk/adapter.go
+++ b/internal/im/dingtalk/adapter.go
@@ -212,20 +212,46 @@ func parseRichTextContent(msgtype string, content json.RawMessage) (parsedRichTe
 			textParts = append(textParts, text)
 		}
 
-		if !strings.EqualFold(strings.TrimSpace(item.Type), "picture") &&
-			item.DownloadCode == "" && item.PictureDownloadCode == "" {
+		code := pictureDownloadCode(item)
+		if code == "" {
 			continue
 		}
 		result.PictureCount++
 		if result.DownloadCode == "" {
-			result.DownloadCode = item.DownloadCode
-			if result.DownloadCode == "" {
-				result.DownloadCode = item.PictureDownloadCode
-			}
+			result.DownloadCode = code
 		}
 	}
 	result.Text = strings.Join(textParts, "\n")
 	return result, true
+}
+
+func pictureDownloadCode(item richTextElement) string {
+	if !strings.EqualFold(strings.TrimSpace(item.Type), "picture") {
+		return ""
+	}
+	if item.DownloadCode != "" {
+		return item.DownloadCode
+	}
+	return item.PictureDownloadCode
+}
+
+type audioMessageContent struct {
+	Recognition string `json:"recognition"`
+}
+
+func parseAudioContent(msgtype string, content json.RawMessage) (string, bool) {
+	if !strings.EqualFold(strings.TrimSpace(msgtype), "audio") {
+		return "", false
+	}
+	var payload audioMessageContent
+	if len(content) == 0 || json.Unmarshal(content, &payload) != nil {
+		return "", false
+	}
+	text := strings.TrimSpace(payload.Recognition)
+	if text == "" {
+		return "", false
+	}
+	return text, true
 }
 
 // parseFileContent maps a DingTalk msgtype + content object to WeKnora's file
@@ -359,6 +385,9 @@ func parseCallbackMessage(msg *callbackMessage) *im.IncomingMessage {
 		incoming.FileName = defaultFileName(msgType, fileName, msg.MsgID)
 		incoming.FileKey = downloadCode
 		extra["robot_code"] = msg.RobotCode
+	} else if text, ok := parseAudioContent(msg.Msgtype, msg.Content); ok {
+		incoming.MessageType = im.MessageTypeText
+		incoming.Content = text
 	} else {
 		incoming.MessageType = im.MessageTypeText
 		if msg.Text != nil {
@@ -386,6 +415,17 @@ func applyRichText(incoming *im.IncomingMessage, extra map[string]string, rich p
 	incoming.FileKey = rich.DownloadCode
 	incoming.FileName = defaultFileName(im.MessageTypeImage, "", msgID)
 	extra["robot_code"] = robotCode
+	if rich.PictureCount > 1 {
+		incoming.Content = appendDroppedPictureHint(incoming.Content, rich.PictureCount)
+	}
+}
+
+func appendDroppedPictureHint(text string, pictureCount int) string {
+	hint := fmt.Sprintf("（该消息共 %d 张图片，当前仅处理第一张）", pictureCount)
+	if strings.TrimSpace(text) == "" {
+		return hint
+	}
+	return text + "\n" + hint
 }
 
 // defaultFileName gives picture messages (which carry no fileName) a name with a
@@ -479,6 +519,9 @@ func streamToIncoming(data *chatbot.BotCallbackDataModel, fallbackRobotCode stri
 		incoming.FileName = defaultFileName(msgType, fileName, data.MsgId)
 		incoming.FileKey = downloadCode
 		extra["robot_code"] = fallbackRobotCode
+	} else if text, ok := parseAudioContent(data.Msgtype, contentRaw); ok {
+		incoming.MessageType = im.MessageTypeText
+		incoming.Content = text
 	} else {
 		incoming.MessageType = im.MessageTypeText
 		incoming.Content = strings.TrimSpace(data.Text.Content)

--- a/internal/im/dingtalk/adapter_test.go
+++ b/internal/im/dingtalk/adapter_test.go
@@ -180,6 +180,65 @@ func TestParseCallbackMessage_TextStillWorks(t *testing.T) {
 	}
 }
 
+func TestParseCallbackMessage_RichTextPreservesTextAndPictureMetadata(t *testing.T) {
+	msg := &callbackMessage{
+		MsgID:     "rich-1",
+		Msgtype:   "richText",
+		RobotCode: "robot-123",
+		Content: json.RawMessage(`{
+			"richText":[
+				{"text":"  这个问题示例图如下：  "},
+				{"pictureDownloadCode":"PIC-FALLBACK","downloadCode":"PIC-CODE","type":"picture"},
+				{"text":"通过以上示意图可以明白完整的交互流程"}
+			]
+		}`),
+	}
+
+	got := parseCallbackMessage(msg)
+	if got.MessageType != im.MessageTypeImage {
+		t.Fatalf("MessageType = %q, want %q", got.MessageType, im.MessageTypeImage)
+	}
+	if got.Content != "这个问题示例图如下：\n通过以上示意图可以明白完整的交互流程" {
+		t.Errorf("Content = %q", got.Content)
+	}
+	if got.FileKey != "PIC-CODE" {
+		t.Errorf("FileKey = %q, want PIC-CODE", got.FileKey)
+	}
+	if got.FileName != "rich-1.png" {
+		t.Errorf("FileName = %q, want rich-1.png", got.FileName)
+	}
+	if got.Extra["raw_msgtype"] != "richText" {
+		t.Errorf("raw_msgtype = %q, want richText", got.Extra["raw_msgtype"])
+	}
+	if got.Extra["rich_text_picture_count"] != "1" {
+		t.Errorf("rich_text_picture_count = %q, want 1", got.Extra["rich_text_picture_count"])
+	}
+	if got.Extra["robot_code"] != "robot-123" {
+		t.Errorf("robot_code = %q, want robot-123", got.Extra["robot_code"])
+	}
+}
+
+func TestParseCallbackMessage_RichTextPictureOnlyUsesImagePath(t *testing.T) {
+	msg := &callbackMessage{
+		MsgID:   "rich-picture",
+		Msgtype: "richText",
+		Content: json.RawMessage(`{
+			"richText":[{"pictureDownloadCode":"PIC-CODE","type":"picture"}]
+		}`),
+	}
+
+	got := parseCallbackMessage(msg)
+	if got.MessageType != im.MessageTypeImage {
+		t.Fatalf("MessageType = %q, want %q", got.MessageType, im.MessageTypeImage)
+	}
+	if got.Content != "" {
+		t.Errorf("Content = %q, want empty", got.Content)
+	}
+	if got.FileKey != "PIC-CODE" {
+		t.Errorf("FileKey = %q, want PIC-CODE", got.FileKey)
+	}
+}
+
 func TestStreamToIncoming_File(t *testing.T) {
 	data := &chatbot.BotCallbackDataModel{
 		MsgId:            "m3",
@@ -239,5 +298,35 @@ func TestStreamToIncoming_TextStillWorks(t *testing.T) {
 	}
 	if got.Content != "hi" {
 		t.Errorf("Content = %q, want %q", got.Content, "hi")
+	}
+}
+
+func TestStreamToIncoming_RichTextPreservesTextAndPictureMetadata(t *testing.T) {
+	data := &chatbot.BotCallbackDataModel{
+		MsgId:   "stream-rich",
+		Msgtype: "richText",
+		Content: map[string]interface{}{
+			"richText": []interface{}{
+				map[string]interface{}{"text": "这种场景下，AI 去纹身去不干净"},
+				map[string]interface{}{"downloadCode": "STREAM-PIC", "type": "picture"},
+			},
+		},
+	}
+
+	got := streamToIncoming(data, "client-app-key")
+	if got.MessageType != im.MessageTypeImage {
+		t.Fatalf("MessageType = %q, want %q", got.MessageType, im.MessageTypeImage)
+	}
+	if got.Content != "这种场景下，AI 去纹身去不干净" {
+		t.Errorf("Content = %q", got.Content)
+	}
+	if got.FileKey != "STREAM-PIC" {
+		t.Errorf("FileKey = %q, want STREAM-PIC", got.FileKey)
+	}
+	if got.Extra["raw_msgtype"] != "richText" {
+		t.Errorf("raw_msgtype = %q, want richText", got.Extra["raw_msgtype"])
+	}
+	if got.Extra["robot_code"] != "client-app-key" {
+		t.Errorf("robot_code = %q, want client-app-key", got.Extra["robot_code"])
 	}
 }

--- a/internal/im/dingtalk/adapter_test.go
+++ b/internal/im/dingtalk/adapter_test.go
@@ -2,6 +2,7 @@ package dingtalk
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/open-dingtalk/dingtalk-stream-sdk-go/chatbot"
@@ -239,6 +240,142 @@ func TestParseCallbackMessage_RichTextPictureOnlyUsesImagePath(t *testing.T) {
 	}
 }
 
+func TestParseCallbackMessage_RichTextTextOnly(t *testing.T) {
+	msg := &callbackMessage{
+		MsgID:   "rich-text",
+		Msgtype: "richText",
+		Content: json.RawMessage(`{"richText":[{"text":"  只发文字  "}]}`),
+	}
+
+	got := parseCallbackMessage(msg)
+	if got.MessageType != im.MessageTypeText {
+		t.Fatalf("MessageType = %q, want %q", got.MessageType, im.MessageTypeText)
+	}
+	if got.Content != "只发文字" {
+		t.Errorf("Content = %q, want 只发文字", got.Content)
+	}
+	if got.FileKey != "" {
+		t.Errorf("FileKey = %q, want empty", got.FileKey)
+	}
+}
+
+func TestParseCallbackMessage_RichTextOfficialPictureSample(t *testing.T) {
+	msg := &callbackMessage{
+		MsgID:     "official-rich",
+		Msgtype:   "richText",
+		RobotCode: "robot-123",
+		Content: json.RawMessage(`{
+			"richText":[
+				{"text":"你好"},
+				{"downloadCode":"OFFICIAL-PIC","type":"picture"}
+			]
+		}`),
+	}
+
+	got := parseCallbackMessage(msg)
+	if got.MessageType != im.MessageTypeImage {
+		t.Fatalf("MessageType = %q, want %q", got.MessageType, im.MessageTypeImage)
+	}
+	if got.Content != "你好" {
+		t.Errorf("Content = %q, want 你好", got.Content)
+	}
+	if got.FileKey != "OFFICIAL-PIC" {
+		t.Errorf("FileKey = %q, want OFFICIAL-PIC", got.FileKey)
+	}
+}
+
+func TestParseCallbackMessage_RichTextKeepsFirstPictureAndHints(t *testing.T) {
+	msg := &callbackMessage{
+		MsgID:   "rich-multi",
+		Msgtype: "richText",
+		Content: json.RawMessage(`{
+			"richText":[
+				{"text":"对比这几张图"},
+				{"downloadCode":"PIC-1","type":"picture"},
+				{"downloadCode":"PIC-2","type":"picture"},
+				{"downloadCode":"PIC-3","type":"picture"}
+			]
+		}`),
+	}
+
+	got := parseCallbackMessage(msg)
+	if got.FileKey != "PIC-1" {
+		t.Errorf("FileKey = %q, want PIC-1", got.FileKey)
+	}
+	if got.Extra["rich_text_picture_count"] != "3" {
+		t.Errorf("rich_text_picture_count = %q, want 3", got.Extra["rich_text_picture_count"])
+	}
+	if !strings.Contains(got.Content, "对比这几张图") || !strings.Contains(got.Content, "共 3 张图片") {
+		t.Errorf("Content = %q, want text plus dropped-picture hint", got.Content)
+	}
+}
+
+func TestParseCallbackMessage_RichTextIgnoresDownloadCodeWithoutPictureType(t *testing.T) {
+	msg := &callbackMessage{
+		MsgID:   "rich-notype",
+		Msgtype: "richText",
+		Content: json.RawMessage(`{"richText":[{"text":"hello","downloadCode":"NOT-A-PIC"}]}`),
+	}
+
+	got := parseCallbackMessage(msg)
+	if got.MessageType != im.MessageTypeText {
+		t.Fatalf("MessageType = %q, want %q", got.MessageType, im.MessageTypeText)
+	}
+	if got.FileKey != "" {
+		t.Errorf("FileKey = %q, want empty", got.FileKey)
+	}
+}
+
+func TestParseCallbackMessage_RichTextEmptyOrInvalidFallsBackToEmptyText(t *testing.T) {
+	empty := parseCallbackMessage(&callbackMessage{
+		MsgID:   "rich-empty",
+		Msgtype: "richText",
+		Content: json.RawMessage(`{"richText":[]}`),
+	})
+	if empty.MessageType != im.MessageTypeText || empty.Content != "" {
+		t.Errorf("empty richText: type=%q content=%q", empty.MessageType, empty.Content)
+	}
+
+	invalid := parseCallbackMessage(&callbackMessage{
+		MsgID:   "rich-bad",
+		Msgtype: "richText",
+		Content: json.RawMessage(`not-json`),
+	})
+	if invalid.MessageType != im.MessageTypeText || invalid.Content != "" {
+		t.Errorf("invalid richText: type=%q content=%q", invalid.MessageType, invalid.Content)
+	}
+}
+
+func TestParseCallbackMessage_AudioUsesRecognition(t *testing.T) {
+	msg := &callbackMessage{
+		MsgID:   "audio-1",
+		Msgtype: "audio",
+		Content: json.RawMessage(`{"duration":4000,"downloadCode":"AUD-CODE","recognition":"  钉钉，让进步发生  "}`),
+	}
+
+	got := parseCallbackMessage(msg)
+	if got.MessageType != im.MessageTypeText {
+		t.Fatalf("MessageType = %q, want %q", got.MessageType, im.MessageTypeText)
+	}
+	if got.Content != "钉钉，让进步发生" {
+		t.Errorf("Content = %q, want recognition text", got.Content)
+	}
+	if got.Extra["raw_msgtype"] != "audio" {
+		t.Errorf("raw_msgtype = %q, want audio", got.Extra["raw_msgtype"])
+	}
+}
+
+func TestParseCallbackMessage_AudioWithoutRecognitionStaysEmpty(t *testing.T) {
+	got := parseCallbackMessage(&callbackMessage{
+		MsgID:   "audio-empty",
+		Msgtype: "audio",
+		Content: json.RawMessage(`{"duration":1000,"downloadCode":"AUD-CODE"}`),
+	})
+	if got.MessageType != im.MessageTypeText || got.Content != "" {
+		t.Errorf("audio without recognition: type=%q content=%q", got.MessageType, got.Content)
+	}
+}
+
 func TestStreamToIncoming_File(t *testing.T) {
 	data := &chatbot.BotCallbackDataModel{
 		MsgId:            "m3",
@@ -328,5 +465,24 @@ func TestStreamToIncoming_RichTextPreservesTextAndPictureMetadata(t *testing.T) 
 	}
 	if got.Extra["robot_code"] != "client-app-key" {
 		t.Errorf("robot_code = %q, want client-app-key", got.Extra["robot_code"])
+	}
+}
+
+func TestStreamToIncoming_AudioUsesRecognition(t *testing.T) {
+	data := &chatbot.BotCallbackDataModel{
+		MsgId:   "stream-audio",
+		Msgtype: "audio",
+		Content: map[string]interface{}{
+			"recognition":  "语音转写结果",
+			"downloadCode": "STREAM-AUD",
+		},
+	}
+
+	got := streamToIncoming(data, "client-app-key")
+	if got.MessageType != im.MessageTypeText {
+		t.Fatalf("MessageType = %q, want %q", got.MessageType, im.MessageTypeText)
+	}
+	if got.Content != "语音转写结果" {
+		t.Errorf("Content = %q, want recognition text", got.Content)
 	}
 }

--- a/internal/im/file_message_test.go
+++ b/internal/im/file_message_test.go
@@ -53,6 +53,80 @@ func TestFileMessageQAContent(t *testing.T) {
 	}
 }
 
+func TestEmptyIncomingMessageReply(t *testing.T) {
+	tests := []struct {
+		name      string
+		msg       *IncomingMessage
+		wantEmpty bool
+		wantHint  string
+	}{
+		{
+			name:      "text content is accepted",
+			msg:       &IncomingMessage{MessageType: MessageTypeText, Content: " hello "},
+			wantEmpty: false,
+		},
+		{
+			name:      "blank text is rejected",
+			msg:       &IncomingMessage{MessageType: MessageTypeText, Content: " \n\t "},
+			wantEmpty: true,
+			wantHint:  "未能识别这条消息中的文字内容。请改用纯文本发送；图片或文件请单独发送。",
+		},
+		{
+			name:      "image without caption is accepted before QA content fill",
+			msg:       &IncomingMessage{MessageType: MessageTypeImage, FileKey: "pic-1", FileName: "pic-1.png"},
+			wantEmpty: false,
+		},
+		{
+			name:      "file without caption is accepted before QA content fill",
+			msg:       &IncomingMessage{MessageType: MessageTypeFile, FileKey: "file-1", FileName: "spec.pdf"},
+			wantEmpty: false,
+		},
+		{
+			name:      "file key is treated as an attachment even if type stays text",
+			msg:       &IncomingMessage{MessageType: MessageTypeText, FileKey: "pic-1"},
+			wantEmpty: false,
+		},
+		{
+			name: "audio without recognition uses a voice-specific hint",
+			msg: &IncomingMessage{
+				MessageType: MessageTypeText,
+				Extra:       map[string]string{"raw_msgtype": "audio"},
+			},
+			wantEmpty: true,
+			wantHint:  "未能识别这条语音中的文字内容。请改用纯文本发送，或再说一遍。",
+		},
+		{
+			name: "video uses an unsupported-type hint",
+			msg: &IncomingMessage{
+				MessageType: MessageTypeText,
+				Extra:       map[string]string{"raw_msgtype": "video"},
+			},
+			wantEmpty: true,
+			wantHint:  "暂不支持视频消息。请改用纯文本发送；图片或文件请单独发送。",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotHint, gotEmpty := emptyIncomingMessageReply(tt.msg)
+			if gotEmpty != tt.wantEmpty {
+				t.Fatalf("empty = %v, want %v", gotEmpty, tt.wantEmpty)
+			}
+			if gotHint != tt.wantHint {
+				t.Fatalf("hint = %q, want %q", gotHint, tt.wantHint)
+			}
+		})
+	}
+}
+
+func TestEmptyIncomingMessageReplyAfterFileQAContent(t *testing.T) {
+	msg := &IncomingMessage{MessageType: MessageTypeImage, FileName: "shot.png"}
+	msg.Content = fileMessageQAContent(msg)
+	if hint, empty := emptyIncomingMessageReply(msg); empty {
+		t.Fatalf("image after fileMessageQAContent was rejected: hint=%q", hint)
+	}
+}
+
 func TestApplyIMAttachmentTruncationByLineCount(t *testing.T) {
 	lines := make([]string, maxIMAttachmentLines+1)
 	for i := range lines {

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -1849,7 +1849,27 @@ func emptyIncomingMessageReply(msg *IncomingMessage) (string, bool) {
 	if msg == nil || strings.TrimSpace(msg.Content) != "" {
 		return "", false
 	}
-	return "未能识别这条消息中的文字内容。请改用纯文本发送；图片或文件请单独发送。", true
+	// Image/file events are allowed to arrive without a caption. Do not depend
+	// on fileMessageQAContent having already filled Content — a later reorder
+	// of HandleMessage must not reject attachments.
+	hasAttachment := msg.MessageType == MessageTypeFile ||
+		msg.MessageType == MessageTypeImage ||
+		strings.TrimSpace(msg.FileKey) != ""
+	if hasAttachment {
+		return "", false
+	}
+	rawType := ""
+	if msg.Extra != nil {
+		rawType = strings.ToLower(strings.TrimSpace(msg.Extra["raw_msgtype"]))
+	}
+	switch rawType {
+	case "audio":
+		return "未能识别这条语音中的文字内容。请改用纯文本发送，或再说一遍。", true
+	case "video":
+		return "暂不支持视频消息。请改用纯文本发送；图片或文件请单独发送。", true
+	default:
+		return "未能识别这条消息中的文字内容。请改用纯文本发送；图片或文件请单独发送。", true
+	}
 }
 
 func (s *Service) persistIMLastRequestState(ctx context.Context, sessionID, agentID string, customAgent *types.CustomAgent, kbIDs []string) {

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -1687,8 +1687,8 @@ func (s *Service) HandleMessage(ctx context.Context, msg *IncomingMessage, chann
 
 	logger.Infof(ctx, "[IM] HandleMessage: channel=%s platform=%s user=%s chat=%s msgtype=%s content_len=%d",
 		channelID, msg.Platform, msg.UserID, msg.ChatID, msg.MessageType, len(msg.Content))
-	logger.Debugf(ctx, "[IM] HandleMessage detail: msgid=%s filekey=%s filename=%s",
-		msg.MessageID, msg.FileKey, msg.FileName)
+	logger.Debugf(ctx, "[IM] HandleMessage detail: msgid=%s raw_msgtype=%s filekey=%s filename=%s",
+		msg.MessageID, msg.Extra["raw_msgtype"], msg.FileKey, msg.FileName)
 
 	// ── File/Image message handling ──
 	// File messages use the normal QA path as well.  A configured knowledge base
@@ -1697,6 +1697,22 @@ func (s *Service) HandleMessage(ctx context.Context, msg *IncomingMessage, chann
 	// the save rather than rejecting the message.
 	if msg.MessageType == MessageTypeFile || msg.MessageType == MessageTypeImage {
 		msg.Content = fileMessageQAContent(msg)
+	}
+
+	// Never send an empty query into rewrite/intent classification. Some IM
+	// platforms deliver unsupported rich message shapes with no normalized text;
+	// allowing those through makes the model infer an unrelated intent from an
+	// empty query (for example, rewriting it as a greeting).
+	if hint, empty := emptyIncomingMessageReply(msg); empty {
+		logger.Infof(ctx, "[IM] Skipping QA for message without content: type=%s raw_type=%s",
+			msg.MessageType, msg.Extra["raw_msgtype"])
+		if err := adapter.SendReply(ctx, msg, &ReplyMessage{
+			Content: hint,
+			IsFinal: true,
+		}); err != nil {
+			logger.Warnf(ctx, "[IM] Failed to send empty-message hint reply: %v", err)
+		}
+		return nil
 	}
 
 	// 1. Get tenant
@@ -1827,6 +1843,13 @@ func (s *Service) HandleMessage(ctx context.Context, msg *IncomingMessage, chann
 	}
 
 	return nil
+}
+
+func emptyIncomingMessageReply(msg *IncomingMessage) (string, bool) {
+	if msg == nil || strings.TrimSpace(msg.Content) != "" {
+		return "", false
+	}
+	return "未能识别这条消息中的文字内容。请改用纯文本发送；图片或文件请单独发送。", true
 }
 
 func (s *Service) persistIMLastRequestState(ctx context.Context, sessionID, agentID string, customAgent *types.CustomAgent, kbIDs []string) {

--- a/internal/im/session_test.go
+++ b/internal/im/session_test.go
@@ -151,39 +151,6 @@ func TestIncomingMessageThreadID(t *testing.T) {
 	}
 }
 
-func TestEmptyIncomingMessageReply(t *testing.T) {
-	tests := []struct {
-		name      string
-		msg       *IncomingMessage
-		wantEmpty bool
-		wantHint  string
-	}{
-		{
-			name:      "text content is accepted",
-			msg:       &IncomingMessage{MessageType: MessageTypeText, Content: " hello "},
-			wantEmpty: false,
-		},
-		{
-			name:      "blank text is rejected",
-			msg:       &IncomingMessage{MessageType: MessageTypeText, Content: " \n\t "},
-			wantEmpty: true,
-			wantHint:  "未能识别这条消息中的文字内容。请改用纯文本发送；图片或文件请单独发送。",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotHint, gotEmpty := emptyIncomingMessageReply(tt.msg)
-			if gotEmpty != tt.wantEmpty {
-				t.Fatalf("empty = %v, want %v", gotEmpty, tt.wantEmpty)
-			}
-			if gotHint != tt.wantHint {
-				t.Fatalf("hint = %q, want %q", gotHint, tt.wantHint)
-			}
-		})
-	}
-}
-
 func TestBuildIMLastRequestStateFromAgent(t *testing.T) {
 	agent := &types.CustomAgent{
 		ID: "agent-1",

--- a/internal/im/session_test.go
+++ b/internal/im/session_test.go
@@ -151,6 +151,39 @@ func TestIncomingMessageThreadID(t *testing.T) {
 	}
 }
 
+func TestEmptyIncomingMessageReply(t *testing.T) {
+	tests := []struct {
+		name      string
+		msg       *IncomingMessage
+		wantEmpty bool
+		wantHint  string
+	}{
+		{
+			name:      "text content is accepted",
+			msg:       &IncomingMessage{MessageType: MessageTypeText, Content: " hello "},
+			wantEmpty: false,
+		},
+		{
+			name:      "blank text is rejected",
+			msg:       &IncomingMessage{MessageType: MessageTypeText, Content: " \n\t "},
+			wantEmpty: true,
+			wantHint:  "未能识别这条消息中的文字内容。请改用纯文本发送；图片或文件请单独发送。",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotHint, gotEmpty := emptyIncomingMessageReply(tt.msg)
+			if gotEmpty != tt.wantEmpty {
+				t.Fatalf("empty = %v, want %v", gotEmpty, tt.wantEmpty)
+			}
+			if gotHint != tt.wantHint {
+				t.Fatalf("hint = %q, want %q", gotHint, tt.wantHint)
+			}
+		})
+	}
+}
+
 func TestBuildIMLastRequestStateFromAgent(t *testing.T) {
 	agent := &types.CustomAgent{
 		ID: "agent-1",


### PR DESCRIPTION
## Summary

- parse DingTalk `richText` callbacks in both webhook and Stream modes
- preserve all text fragments and route the first embedded picture through the existing IM image/VLM pipeline
- reject empty normalized IM messages before query rewriting so unsupported payloads cannot become unrelated greetings
- include the raw DingTalk message type in debug logs for future protocol diagnosis

## Root cause

DingTalk sends combined image-and-text messages as `msgtype=richText`, with content in `content.richText[]`. The adapter only handled `text`, `file`, and `picture`, so rich-text messages were normalized to `MessageTypeText` with empty content. That empty query then reached intent classification and could be rewritten as a greeting.

Reference payload: https://open-dingtalk.github.io/developerpedia/docs/learn/bot/message/#各类型消息体描述

## Tests

- `go test ./internal/im/dingtalk ./internal/im`
- `go test ./...`
