### PR TITLE
docs: clarify Docker image release tags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@
 # #####################################################################
 
 # ========== A1. 镜像版本与构建 ==========
-# WeKnora 镜像版本标签：latest（稳定版）/ main（最新开发版）。升级时请将版本改为目标 release（如 0.7.0），并执行 docker compose pull 拉取对应镜像。
+# WeKnora 镜像版本标签：latest（稳定版）/ main（最新开发版）。升级到固定版本时，请填写目标 release 的 git tag（如 v0.7.0，注意 v 前缀），并执行 docker compose pull 拉取对应镜像。
 WEKNORA_VERSION=latest
 # Alpine apk 镜像源（构建 app 镜像用，留空用默认源；国内可设 mirrors.tencent.com 加速）。
 APK_MIRROR_ARG=mirrors.tencent.com

--- a/scripts/cloud-image/prepare.sh
+++ b/scripts/cloud-image/prepare.sh
@@ -163,8 +163,10 @@ sed -i 's/^GIN_MODE=.*/GIN_MODE=release/' .env || true
 
 # 把 WEKNORA_VERSION 与 WEKNORA_REF 对齐, 让 docker compose 拉取与 ref 一致的
 # 镜像 tag。无条件覆盖, 避免 .env 残留上一次 prepare 留下的旧版本号。
-# Docker Hub 上 wechatopenai/weknora-* 的 tag 实际值就是 git ref 原样
-# (`main` / `v0.5.2`), 因此这里不剥 v、也不映射到 latest。
+# Docker Hub 上 wechatopenai/weknora-* 的 tag 命名约定：
+#   - 浮动 tag：main（持续指向最新构建）
+#   - 固定 release tag：v 前缀 + semver（如 v0.7.2、v0.5.2）
+# 因此这里不剥 v、也不映射到 latest。
 WEKNORA_VERSION_VAL="${WEKNORA_REF}"
 if grep -qE '^WEKNORA_VERSION=' .env; then
   sed -i "s|^WEKNORA_VERSION=.*|WEKNORA_VERSION=${WEKNORA_VERSION_VAL}|" .env


### PR DESCRIPTION
## Description

Clarify that fixed WeKnora Docker image versions must use the release git tag with the `v` prefix (for example, `v0.7.0`), preventing failed pulls for non-existent tags such as `0.7.0`.

Also document the Docker Hub tag convention in the cloud image preparation script.

## Type of Change

- [x] 📚 Documentation update

## Related Issue

Fixes #2782

## Testing

- Ran `git diff --check origin/main...HEAD`

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Self-reviewed the code
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)