### PR TITLE
fix(frontend): sync settings nav with a single section query

### DIFF
--- a/frontend/src/config/settingsRoute.test.ts
+++ b/frontend/src/config/settingsRoute.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildSettingsRouteQuery,
+  integrationSectionKey,
+  isIntegrationSection,
+  normalizeSettingsSection,
+  settingsQueryUnchanged,
+} from './settingsRoute'
+
+test('every settings nav item writes only section', () => {
+  assert.deepEqual(
+    buildSettingsRouteQuery('models', {
+      section: 'system-global',
+      tab: 'im',
+      agentId: 'agt_1',
+    }),
+    { section: 'models' },
+  )
+  assert.deepEqual(
+    buildSettingsRouteQuery('general', { section: 'system-global' }),
+    { section: 'general' },
+  )
+  assert.deepEqual(
+    buildSettingsRouteQuery('runtime-queues', { section: 'system-global' }),
+    { section: 'runtime-queues' },
+  )
+  assert.deepEqual(
+    buildSettingsRouteQuery(integrationSectionKey('claw'), {
+      section: 'integrations',
+      tab: 'im',
+    }),
+    { section: 'integration-claw' },
+  )
+  assert.deepEqual(
+    buildSettingsRouteQuery(integrationSectionKey('api'), {
+      section: 'integrations',
+      tab: 'im',
+      agentId: 'agt_1',
+    }),
+    { section: 'integration-api', agentId: 'agt_1' },
+  )
+})
+
+test('legacy api / integrations / bare-tab query strings normalize to nav keys', () => {
+  assert.equal(normalizeSettingsSection('api'), 'integration-api')
+  assert.equal(normalizeSettingsSection('claw'), 'integration-claw')
+  assert.equal(normalizeSettingsSection('integrations', 'embed'), 'integration-embed')
+  assert.equal(normalizeSettingsSection('integrations'), 'integration-im')
+  assert.equal(normalizeSettingsSection('integration-chrome'), 'integration-chrome')
+  assert.equal(normalizeSettingsSection('system-global'), 'system-global')
+  assert.equal(isIntegrationSection('integration-chrome'), true)
+  assert.equal(isIntegrationSection('models'), false)
+  assert.equal(isIntegrationSection('integration-unknown'), false)
+})
+
+test('canonical settings query skips a redundant replace', () => {
+  assert.equal(
+    settingsQueryUnchanged(
+      { section: 'integration-claw' },
+      { section: 'integration-claw' },
+    ),
+    true,
+  )
+  assert.equal(
+    settingsQueryUnchanged(
+      { section: 'integrations', tab: 'claw' },
+      { section: 'integration-claw' },
+    ),
+    false,
+  )
+})

--- a/frontend/src/config/settingsRoute.ts
+++ b/frontend/src/config/settingsRoute.ts
@@ -1,0 +1,73 @@
+import { INTEGRATION_TABS, type IntegrationTab } from './integrations'
+
+export const INTEGRATION_SECTION_PREFIX = 'integration-'
+
+type QueryValue = string | number | boolean | null | undefined | Array<string | number | boolean | null>
+export type SettingsRouteQuery = Record<string, QueryValue>
+
+export function integrationSectionKey(tab: IntegrationTab): string {
+  return `${INTEGRATION_SECTION_PREFIX}${tab}`
+}
+
+export function integrationTabFromSection(section: string): IntegrationTab {
+  const raw = section.startsWith(INTEGRATION_SECTION_PREFIX)
+    ? section.slice(INTEGRATION_SECTION_PREFIX.length)
+    : section
+  if (INTEGRATION_TABS.includes(raw as IntegrationTab)) {
+    return raw as IntegrationTab
+  }
+  return 'im'
+}
+
+export function isIntegrationSection(section: string): boolean {
+  if (!section.startsWith(INTEGRATION_SECTION_PREFIX)) return false
+  const raw = section.slice(INTEGRATION_SECTION_PREFIX.length)
+  return (INTEGRATION_TABS as readonly string[]).includes(raw)
+}
+
+function isBareIntegrationTab(section: string): section is IntegrationTab {
+  return (INTEGRATION_TABS as readonly string[]).includes(section)
+}
+
+/**
+ * Map URL `section` (and a leftover `tab` from old bookmarks) onto the
+ * settings nav key. Canonical form is `integration-<tab>`; `integrations`,
+ * `api`, and bare tab names remain aliases.
+ */
+export function normalizeSettingsSection(section: string, tab?: string | null): string {
+  if (section === 'integrations') {
+    return integrationSectionKey(integrationTabFromSection(tab || 'im'))
+  }
+  if (isBareIntegrationTab(section)) {
+    return integrationSectionKey(section)
+  }
+  return section
+}
+
+/**
+ * Settings left-nav → URL. Every page, including integrations, is
+ * `?section=<navKey>` (e.g. `integration-claw`). `tab` is dropped.
+ */
+export function buildSettingsRouteQuery(
+  sectionKey: string,
+  currentQuery: object = {},
+): SettingsRouteQuery {
+  const query: SettingsRouteQuery = { ...(currentQuery as SettingsRouteQuery) }
+  delete query.tab
+  if (!isIntegrationSection(sectionKey)) {
+    delete query.agentId
+  }
+  query.section = sectionKey
+  return query
+}
+
+export function settingsQueryUnchanged(
+  currentQuery: object,
+  nextQuery: SettingsRouteQuery,
+): boolean {
+  const current = currentQuery as SettingsRouteQuery
+  return String(current.section ?? '') === String(nextQuery.section ?? '')
+    && current.tab == null
+    && nextQuery.tab == null
+    && String(current.agentId ?? '') === String(nextQuery.agentId ?? '')
+}

--- a/frontend/src/config/settingsRoute.ts
+++ b/frontend/src/config/settingsRoute.ts
@@ -2,7 +2,7 @@ import { INTEGRATION_TABS, type IntegrationTab } from './integrations'
 
 export const INTEGRATION_SECTION_PREFIX = 'integration-'
 
-type QueryValue = string | number | boolean | null | undefined | Array<string | number | boolean | null>
+type QueryValue = string | number | null | undefined | Array<string | number | null>
 export type SettingsRouteQuery = Record<string, QueryValue>
 
 export function integrationSectionKey(tab: IntegrationTab): string {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -6,6 +6,7 @@ import { autoSetup, getCurrentUser, userInfoFromApi } from '@/api/auth'
 import type { DeploymentCapabilityKey } from '@/config/deploymentCapabilities'
 import { MessagePlugin } from 'tdesign-vue-next'
 import i18n from '@/i18n'
+import { normalizeSettingsSection } from '@/config/settingsRoute'
 
 /** Lite /桌面 WebView 硬刷新时可能只打开 `/`，用 session 记住上次页面以便恢复 */
 const LITE_LAST_PATH_KEY = 'weknora_lite_last_path'
@@ -140,13 +141,19 @@ const router = createRouter({
         },
         {
           path: "integrations",
-          redirect: (to) => ({
-            path: "/platform/settings",
-            query: {
-              ...to.query,
-              section: "integrations",
-            },
-          }),
+          redirect: (to) => {
+            const tab = typeof to.query.tab === 'string' ? to.query.tab : undefined
+            const incoming = typeof to.query.section === 'string' ? to.query.section : 'integrations'
+            const rest = { ...to.query }
+            delete rest.tab
+            return {
+              path: '/platform/settings',
+              query: {
+                ...rest,
+                section: normalizeSettingsSection(incoming, tab),
+              },
+            }
+          },
           meta: { requiresInit: true, requiresAuth: true }
         },
         {

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -1757,6 +1757,7 @@ import KBParserSettings, { type ParserEngineRule } from '@/views/knowledge/setti
 import AgentShareSettings from '@/components/AgentShareSettings.vue';
 import { listEmbedChannels } from '@/api/embed';
 import { getRootZoom, rectToCssPx } from '@/utils/zoom';
+import { integrationSectionKey } from '@/config/settingsRoute';
 import {
   evaluateToolRequirement,
   deriveKbFilterFromTools,
@@ -2636,7 +2637,7 @@ function gotoIntegrations(tab: 'im' | 'embed') {
   const agentId = editorAgent.value?.id;
   if (!agentId) return;
   handleClose();
-  router.push({ path: '/platform/settings', query: { section: 'integrations', agentId, tab } });
+  router.push({ path: '/platform/settings', query: { section: integrationSectionKey(tab), agentId } });
 }
 
 const filteredIntentPlaceholders = computed(() => {

--- a/frontend/src/views/agent/AgentList.vue
+++ b/frontend/src/views/agent/AgentList.vue
@@ -838,6 +838,7 @@ import { shouldShowResourceOriginBadge } from '@/utils/card-list-badge'
 import { useAuthStore } from '@/stores/auth'
 import { useListUrlState } from '@/composables/useListUrlState'
 import { useResourcePins } from '@/composables/useResourcePins'
+import { integrationSectionKey } from '@/config/settingsRoute'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -1141,11 +1142,11 @@ const checkAndOpenEditModal = () => {
   const editId = route.query.edit as string
   const section = route.query.section as string
   const sourceTenantId = route.query.sourceTenantId as string | undefined
-  if (editId && (section === 'im' || section === 'embed' || section === 'integrations')) {
-    const tab = section === 'embed' ? 'embed' : 'im'
+  if (editId && (section === 'im' || section === 'embed' || section === 'integrations' || section === 'integration-im' || section === 'integration-embed')) {
+    const tab = section === 'embed' || section === 'integration-embed' ? 'embed' : 'im'
     router.replace({
       path: '/platform/settings',
-      query: { section: 'integrations', tab, agentId: editId },
+      query: { section: integrationSectionKey(tab), agentId: editId },
     })
     return
   }

--- a/frontend/src/views/integrations/ChromeExtensionLanding.vue
+++ b/frontend/src/views/integrations/ChromeExtensionLanding.vue
@@ -117,7 +117,7 @@ const openChromeStore = () => {
 }
 
 const openApiSettings = () => {
-  router.push({ path: '/platform/settings', query: { section: 'integrations', tab: 'api' } })
+  router.push({ path: '/platform/settings', query: { section: 'integration-api' } })
   uiStore.openSettings('integration-api')
 }
 

--- a/frontend/src/views/integrations/ClawSkillLanding.vue
+++ b/frontend/src/views/integrations/ClawSkillLanding.vue
@@ -139,7 +139,7 @@ const openClawHub = () => {
 }
 
 const openApiSettings = () => {
-  router.push({ path: '/platform/settings', query: { section: 'integrations', tab: 'api' } })
+  router.push({ path: '/platform/settings', query: { section: 'integration-api' } })
   uiStore.openSettings('integration-api')
 }
 

--- a/frontend/src/views/settings/Settings.vue
+++ b/frontend/src/views/settings/Settings.vue
@@ -245,14 +245,20 @@ import {
   INTEGRATION_PREVIEW_ITEMS,
   INTEGRATION_TAB_CAPABILITY,
   INTEGRATION_TAB_MIN_ROLE,
-  INTEGRATION_TABS,
-  type IntegrationTab,
 } from '@/config/integrations'
 import {
   SETTINGS_SECTION_MIN_ROLE,
   SYSTEM_ADMIN_SETTINGS_SECTIONS,
 } from '@/config/settingsAccess'
 import { SETTINGS_SECTION_CAPABILITY } from '@/config/deploymentCapabilities'
+import {
+  buildSettingsRouteQuery,
+  integrationSectionKey,
+  integrationTabFromSection,
+  isIntegrationSection,
+  normalizeSettingsSection as normalizeSettingsSectionFromQuery,
+  settingsQueryUnchanged,
+} from '@/config/settingsRoute'
 
 const route = useRoute()
 const router = useRouter()
@@ -295,33 +301,19 @@ type NavGroup = {
 //   ModelSettings.vue 里另用 hasRole('admin') 自己 gate，所以入口保留
 //   viewer 是合理的（contributor 也能浏览模型列表）。
 const SYSTEM_ADMIN_SECTIONS = SYSTEM_ADMIN_SETTINGS_SECTIONS
-const INTEGRATION_SECTION_PREFIX = 'integration-'
-
-const integrationSectionKey = (tab: IntegrationTab) => `${INTEGRATION_SECTION_PREFIX}${tab}`
-
-const integrationTabFromSection = (section: string): IntegrationTab => {
-  const raw = section.startsWith(INTEGRATION_SECTION_PREFIX)
-    ? section.slice(INTEGRATION_SECTION_PREFIX.length)
-    : section
-  if (INTEGRATION_TABS.includes(raw as IntegrationTab)) {
-    return raw as IntegrationTab
-  }
-  return 'im'
-}
-
-const isIntegrationSection = (section: string) => {
-  return section.startsWith(INTEGRATION_SECTION_PREFIX) &&
-    INTEGRATION_TABS.includes(integrationTabFromSection(section))
-}
 
 const normalizeSettingsSection = (section: string) => {
-  if (section === 'api') {
-    return integrationSectionKey('api')
-  }
-  if (section === 'integrations') {
-    return integrationSectionKey(integrationTabFromSection((route.query.tab as string) || 'im'))
-  }
-  return section
+  return normalizeSettingsSectionFromQuery(section, route.query.tab as string | undefined)
+}
+
+const syncSettingsRoute = (sectionKey: string) => {
+  if (route.path !== '/platform/settings') return
+  const query = buildSettingsRouteQuery(sectionKey, route.query)
+  if (settingsQueryUnchanged(route.query, query)) return
+  void router.replace({
+    path: '/platform/settings',
+    query,
+  })
 }
 
 const isSectionSupported = (key: string): boolean => {
@@ -467,25 +459,10 @@ const handleNavClick = (item: any) => {
     currentSubSection.value = ''
   }
 
-  // 切换到对应页面
+  // 切换到对应页面，并同步 URL 为 ?section=<navKey>（含 integration-claw）。
+  // 否则从其它 section 点进来时 query 不变，路由监听会把内容拉回去。
   currentSection.value = item.key
-  if (route.path === '/platform/settings' && isIntegrationSection(item.key)) {
-    router.replace({
-      path: '/platform/settings',
-      query: {
-        ...route.query,
-        section: 'integrations',
-        tab: integrationTabFromSection(item.key),
-      },
-    })
-  } else if (route.path === '/platform/settings' && SYSTEM_ADMIN_SECTIONS.has(item.key)) {
-    const query = { ...route.query }
-    delete query.tab
-    router.replace({
-      path: '/platform/settings',
-      query: { ...query, section: item.key },
-    })
-  }
+  syncSettingsRoute(item.key)
 }
 
 // 子菜单点击处理
@@ -536,6 +513,7 @@ watch(() => uiStore.settingsInitialSection, (section) => {
       return
     }
     currentSection.value = normalizedSection
+    syncSettingsRoute(normalizedSection)
     const navItem = (navItems.value as any[]).find((item) => item.key === normalizedSection)
     if (navItem && navItem.children && navItem.children.length > 0) {
       if (!expandedMenus.value.includes(section)) {
@@ -557,24 +535,28 @@ watch(() => uiStore.settingsInitialSection, (section) => {
 }, { immediate: true })
 
 watch(
-  () => [visible.value, route.query.section, deploymentCapabilities.loaded] as const,
-  ([isVisible, section, capabilitiesLoaded]) => {
-    if (!isVisible || typeof section !== 'string') return
-    const normalizedSection = normalizeSettingsSection(section)
+  () => [visible.value, route.path, route.query.section, deploymentCapabilities.loaded] as const,
+  ([isVisible, path, section, capabilitiesLoaded]) => {
+    if (!isVisible || path !== '/platform/settings') return
+    if (typeof section !== 'string') {
+      syncSettingsRoute(currentSection.value || 'general')
+      return
+    }
+    const normalizedSection = normalizeSettingsSectionFromQuery(
+      section,
+      typeof route.query.tab === 'string' ? route.query.tab : undefined,
+    )
     if (capabilitiesLoaded && !isSectionSupported(normalizedSection)) {
       MessagePlugin.warning(t('settings.capabilityUnavailable'))
-      currentSection.value = navItems.value[0]?.key || 'general'
+      const fallback = navItems.value[0]?.key || 'general'
+      currentSection.value = fallback
       currentSubSection.value = ''
-      if (route.path === '/platform/settings') {
-        const query = { ...route.query }
-        delete query.section
-        delete query.tab
-        void router.replace({ path: route.path, query })
-      }
+      syncSettingsRoute(fallback)
       return
     }
     currentSection.value = normalizedSection
     currentSubSection.value = ''
+    syncSettingsRoute(normalizedSection)
   },
   { immediate: true },
 )
@@ -583,8 +565,10 @@ watch(
 // 如果 currentSection 落到了不再显示的 key 上，就回退到第一个可见项。
 watch(navItems, (items) => {
   if (!items.some((item) => item.key === currentSection.value)) {
-    currentSection.value = items[0]?.key || 'general'
+    const fallback = items[0]?.key || 'general'
+    currentSection.value = fallback
     currentSubSection.value = ''
+    syncSettingsRoute(fallback)
   }
 })
 
@@ -607,6 +591,7 @@ const handleSettingsNav = (e: CustomEvent) => {
       return
     }
     currentSection.value = normalizedSection
+    syncSettingsRoute(normalizedSection)
     // 如果有子菜单，自动展开
     const navItem = (navItems.value as any[]).find((item: any) => item.key === normalizedSection)
     if (navItem && navItem.children && navItem.children.length > 0) {

--- a/frontend/src/views/settings/Settings.vue
+++ b/frontend/src/views/settings/Settings.vue
@@ -214,6 +214,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import type { LocationQueryRaw } from 'vue-router'
 import { useUIStore } from '@/stores/ui'
 import { useAuthStore } from '@/stores/auth'
 import { useDeploymentCapabilitiesStore } from '@/stores/deploymentCapabilities'
@@ -312,7 +313,7 @@ const syncSettingsRoute = (sectionKey: string) => {
   if (settingsQueryUnchanged(route.query, query)) return
   void router.replace({
     path: '/platform/settings',
-    query,
+    query: query as LocationQueryRaw,
   })
 }
 

--- a/website-docs/05-clients/01-frontend.md
+++ b/website-docs/05-clients/01-frontend.md
@@ -127,7 +127,7 @@ flowchart TB
 | `/platform/settings` | `settings` | `src/views/settings/Settings.vue` | 设置中心（全屏模态形态），分区见下方「设置中心的分区与可见性」 |
 | `/platform/tenant` | — | 重定向 | 兼容旧路径 → `/platform/settings` |
 | `/platform/knowledge-search` | — | 重定向 | 旧全局搜索路径 → 知识库列表并通过 `?cmdk=` 打开全局命令面板（⌘K） |
-| `/platform/integrations` | — | 重定向 | → `/platform/settings?section=integrations`（API / Chrome 扩展 / Claw Skill 集成，视图在 `src/views/integrations/`） |
+| `/platform/integrations` | — | 重定向 | → `/platform/settings?section=integration-im`（旧 `?tab=` 会归一成 `integration-<tab>`；视图在 `src/views/integrations/`） |
 | `/platform/system`、`/platform/system/settings`、`/platform/system/admins` | `systemSettings` / `systemAdmins` | 重定向 | 系统管理旧路径 → `/platform/settings?section=system-global`，要求 `requiresSystemAdmin`（视图在 `src/views/system/`：`SystemSettings.vue`、`SystemAuditLog.vue`、`PlatformAPIKeys.vue` 等） |
 | `/platform/system/queues` | `systemQueues` | 重定向 | → `/platform/settings?section=runtime-queues`（运行时任务队列 `src/views/system/RuntimeQueues.vue`） |
 
@@ -144,7 +144,7 @@ flowchart TB
 | 账户 | `general`（个人偏好）、`userprofile` |
 | 空间 | `tenant`（空间信息）、`members`（成员）、`chathistory` |
 | 模型与运行 | `models`、`ollama`、`weknoracloud` |
-| 发布与集成 | IM 集成、网页嵌入、API、Chrome 扩展、Claw Skill |
+| 发布与集成 | `integration-im`、`integration-embed`、`integration-api`、`integration-chrome`、`integration-claw` |
 | 数据与扩展 | `vectorstore`、`parser`、`storage`、`websearch`、`mcp` |
 | 系统管理 | `system-global`、`runtime-queues`、`platform-api-keys`、`system-audit-log` |
 | 平台 | `system`（版本信息） |


### PR DESCRIPTION
## Summary
- Settings left nav now writes `?section=<navKey>`, so clicking Models / Storage / etc. no longer stays on `?section=system-global` and gets snapped back by the route watcher.
- Integration pages use the same shape (`?section=integration-claw`, `integration-api`, …). Old `?section=integrations&tab=` bookmarks still open and rewrite to the canonical URL.

## Test plan
- [ ] Open settings from system administration, then click several left-nav items; the URL and panel should follow the clicked section.
- [ ] Open `/platform/settings?section=integrations&tab=claw` and confirm it rewrites to `?section=integration-claw`.
- [ ] Click IM / API / Chrome / Claw in settings and confirm each lands on `?section=integration-<tab>`.
- [ ] From an agent editor, jump to IM/embed integration and confirm `agentId` is kept on the query.