### PR TITLE
fix(agent): reject leaked tool-call markup as final answers

### DIFF
--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -381,6 +381,7 @@ func (e *AgentEngine) executeLoop(
 	defer emitCompletion()
 
 	emptyRetries := 0
+	leakedToolMarkupRetries := 0
 	consecutiveSameContent := 0
 	lastResponseContent := ""
 loop:
@@ -406,7 +407,8 @@ loop:
 		// every exit path (break/continue/next) without having to sprinkle
 		// manual finish calls throughout the many branches below.
 		outcome, iterErr := e.runReActIteration(ctx, state, &messages, tools,
-			sessionID, messageID, query, &emptyRetries, &consecutiveSameContent, &lastResponseContent)
+			sessionID, messageID, query, &emptyRetries, &leakedToolMarkupRetries,
+			&consecutiveSameContent, &lastResponseContent)
 		if iterErr != nil {
 			return state, iterErr
 		}
@@ -442,7 +444,7 @@ const (
 	// iterOutcomeNext advances state.CurrentRound and loops again.
 	iterOutcomeNext iterOutcome = iota
 	// iterOutcomeContinue re-runs the loop without advancing the round
-	// counter. Used by the empty-content retry path.
+	// counter. Used by invalid-response retry paths.
 	iterOutcomeContinue
 	// iterOutcomeBreak exits the loop (final answer, stuck loop, or end).
 	iterOutcomeBreak
@@ -461,7 +463,7 @@ func (e *AgentEngine) runReActIteration(
 	messagesPtr *[]chat.Message,
 	tools []chat.Tool,
 	sessionID, assistantMessageID, query string,
-	emptyRetries, consecutiveSameContent *int,
+	emptyRetries, leakedToolMarkupRetries, consecutiveSameContent *int,
 	lastResponseContent *string,
 ) (outcome iterOutcome, retErr error) {
 	roundStart := time.Now()
@@ -554,27 +556,6 @@ func (e *AgentEngine) runReActIteration(
 			response.Usage.CompletionTokens, response.Usage.TotalTokens)
 	}
 
-	// Detect stuck loops: if the LLM keeps returning the same content
-	// without tool calls (e.g., an unhandled finish reason), break early.
-	if len(response.ToolCalls) == 0 && response.Content != "" {
-		if response.Content == *lastResponseContent {
-			*consecutiveSameContent++
-		} else {
-			*consecutiveSameContent = 0
-		}
-		*lastResponseContent = response.Content
-		if *consecutiveSameContent >= maxRepeatedResponseRounds {
-			logger.Warnf(ctx, "[Agent][Round-%d] Detected stuck loop: same content repeated %d times (finish=%s), stopping",
-				round, *consecutiveSameContent+1, response.FinishReason)
-			state.FinalAnswer = response.Content
-			state.IsComplete = true
-			return iterOutcomeBreak, nil
-		}
-	} else {
-		*consecutiveSameContent = 0
-		*lastResponseContent = ""
-	}
-
 	// Create agent step
 	step := types.AgentStep{
 		Iteration:        state.CurrentRound,
@@ -606,6 +587,27 @@ func (e *AgentEngine) runReActIteration(
 	// 2. Analyze: Check for stop conditions (natural stop with no tool calls)
 	verdict := e.analyzeResponse(ctx, response, step, state.CurrentRound, sessionID, roundStart)
 	if verdict.isDone {
+		// A provider may emit its internal tool-call envelope as plain content
+		// with finish=stop. The stream guard kept it out of the UI; retry without
+		// persisting the bogus assistant turn or adding it to AgentSteps.
+		if verdict.leakedToolMarkup {
+			*leakedToolMarkupRetries++
+			if *leakedToolMarkupRetries <= maxEmptyResponseRetries {
+				logger.Warnf(ctx, "[Agent][Round-%d] Leaked tool-call markup - retrying (%d/%d)",
+					round, *leakedToolMarkupRetries, maxEmptyResponseRetries)
+				*messagesPtr = append(*messagesPtr, chat.Message{
+					Role: "user",
+					Content: "Your previous reply contained an internal tool-call envelope as plain text and was discarded. " +
+						"If you still need a tool, issue a proper function call; otherwise provide the complete final answer as plain text.",
+				})
+				return iterOutcomeContinue, nil
+			}
+			logger.Warnf(ctx, "[Agent][Round-%d] Leaked tool-call markup after %d retries - using fallback",
+				round, maxEmptyResponseRetries)
+			state.FinalAnswer = "I'm sorry, I was unable to generate a response. Please try again."
+			state.IsComplete = true
+			return iterOutcomeBreak, nil
+		}
 		// Guard against empty content: when the LLM stops naturally with no
 		// content and no tool calls (e.g., thinking-only loop without KB),
 		// retry with a nudge message instead of accepting an empty answer.
@@ -632,6 +634,28 @@ func (e *AgentEngine) runReActIteration(
 		state.IsComplete = true
 		state.RoundSteps = append(state.RoundSteps, verdict.step)
 		return iterOutcomeBreak, nil
+	}
+
+	// Detect stuck loops only after terminal-response validation. Otherwise a
+	// repeatedly leaked protocol envelope could bypass the guard on its third
+	// occurrence and be accepted as the final answer.
+	if len(response.ToolCalls) == 0 && response.Content != "" {
+		if response.Content == *lastResponseContent {
+			*consecutiveSameContent++
+		} else {
+			*consecutiveSameContent = 0
+		}
+		*lastResponseContent = response.Content
+		if *consecutiveSameContent >= maxRepeatedResponseRounds {
+			logger.Warnf(ctx, "[Agent][Round-%d] Detected stuck loop: same content repeated %d times (finish=%s), stopping",
+				round, *consecutiveSameContent+1, response.FinishReason)
+			state.FinalAnswer = response.Content
+			state.IsComplete = true
+			return iterOutcomeBreak, nil
+		}
+	} else {
+		*consecutiveSameContent = 0
+		*lastResponseContent = ""
 	}
 
 	// This round is non-terminal (it will execute tools and loop again). Any

--- a/internal/agent/finalize.go
+++ b/internal/agent/finalize.go
@@ -96,6 +96,7 @@ Now generate the final answer:`, query, imageRequirement)
 	answerID := generateEventID("answer")
 	logger.Debugf(ctx, "[Agent][FinalAnswer] AnswerID: %s", answerID)
 	answerDoneEmitted := false
+	answerGuard := &toolMarkupStreamGuard{}
 
 	llmResult, err := e.streamLLMToEventBus(
 		ctx,
@@ -106,14 +107,15 @@ Now generate the final answer:`, query, imageRequirement)
 			if chunk.ResponseType == types.ResponseTypeThinking {
 				return
 			}
-			if chunk.Content != "" {
-				logger.Debugf(ctx, "[Agent][FinalAnswer] Emitting answer chunk: %d chars", len(chunk.Content))
+			safeContent := answerGuard.Feed(chunk.Content, chunk.Done)
+			if safeContent != "" {
+				logger.Debugf(ctx, "[Agent][FinalAnswer] Emitting answer chunk: %d chars", len(safeContent))
 				e.eventBus.Emit(ctx, event.Event{
 					ID:        answerID,
 					Type:      event.EventAgentFinalAnswer,
 					SessionID: sessionID,
 					Data: event.AgentFinalAnswerData{
-						Content: chunk.Content,
+						Content: safeContent,
 						Done:    chunk.Done,
 					},
 				})
@@ -130,6 +132,15 @@ Now generate the final answer:`, query, imageRequirement)
 			"error":      err.Error(),
 		})
 		return err
+	}
+	if answerGuard.Rejected() || looksLikeLeakedToolMarkup(llmResult.Content) {
+		logger.Warnf(ctx, "[Agent][FinalAnswer] Rejecting leaked tool-call markup (%d chars)",
+			len(llmResult.Content))
+		common.PipelineWarn(ctx, "Agent", "final_answer_tool_markup_rejected", map[string]interface{}{
+			"session_id":  sessionID,
+			"content_len": len(llmResult.Content),
+		})
+		return errLeakedToolMarkup
 	}
 
 	if !answerDoneEmitted {

--- a/internal/agent/observe.go
+++ b/internal/agent/observe.go
@@ -183,10 +183,11 @@ func compactToolMessage(msg chat.Message, maxTokens int, estimator *agenttoken.E
 // responseVerdict captures the result of analyzing an LLM response to determine
 // whether the agent loop should stop and what the final answer is (if any).
 type responseVerdict struct {
-	isDone       bool
-	finalAnswer  string
-	emptyContent bool // LLM returned stop with no tool calls and empty content
-	step         types.AgentStep
+	isDone           bool
+	finalAnswer      string
+	emptyContent     bool // LLM returned stop with no tool calls and empty content
+	leakedToolMarkup bool // provider tool-call envelope arrived as plain content
+	step             types.AgentStep
 }
 
 // isNaturalStopFinishReason reports whether a provider finish reason means the
@@ -261,6 +262,20 @@ func (e *AgentEngine) analyzeResponse(
 		// Strip <think>…</think> blocks that some models embed in content
 		// (DeepSeek, Qwen, etc.) before processing or displaying.
 		response.Content = agenttools.StripThinkBlocks(response.Content)
+		if looksLikeLeakedToolMarkup(response.Content) {
+			logger.Warnf(ctx, "[Agent][Round-%d] Rejecting leaked tool-call markup as final answer (%d chars)",
+				iteration+1, len(response.Content))
+			common.PipelineWarn(ctx, "Agent", "leaked_tool_markup_rejected", map[string]interface{}{
+				"iteration":   iteration,
+				"round":       iteration + 1,
+				"content_len": len(response.Content),
+			})
+			return responseVerdict{
+				isDone:           true,
+				leakedToolMarkup: true,
+				step:             step,
+			}
+		}
 		logger.Infof(ctx, "[Agent][Round-%d] Agent finished naturally: answer=%d chars, duration=%dms",
 			iteration+1, len(response.Content), time.Since(roundStart).Milliseconds())
 		common.PipelineInfo(ctx, "Agent", "round_final_answer", map[string]interface{}{

--- a/internal/agent/think.go
+++ b/internal/agent/think.go
@@ -193,6 +193,7 @@ func (e *AgentEngine) streamThinkingToEventBus(
 	//   - answerStreamed records that user-facing answer text was sent live to
 	//     the final-answer area, so the natural-stop branch only emits Done.
 	splitter := agenttools.NewThinkStreamSplitter()
+	answerGuard := &toolMarkupStreamGuard{}
 	thinkingOpen := false
 	answerStreamed := false
 
@@ -221,7 +222,8 @@ func (e *AgentEngine) streamThinkingToEventBus(
 			thinkingOpen = false
 		}
 	}
-	emitAnswer := func(content string) {
+	emitAnswer := func(content string, done bool) {
+		content = answerGuard.Feed(content, done)
 		if content == "" {
 			return
 		}
@@ -323,7 +325,7 @@ func (e *AgentEngine) streamThinkingToEventBus(
 					thinkingOpen = true
 					emitThought(thinkPart, false)
 				}
-				emitAnswer(answerPart)
+				emitAnswer(answerPart, false)
 			}
 			if chunk.Done {
 				thinkPart, answerPart := splitter.Flush()
@@ -331,7 +333,7 @@ func (e *AgentEngine) streamThinkingToEventBus(
 					thinkingOpen = true
 					emitThought(thinkPart, false)
 				}
-				emitAnswer(answerPart)
+				emitAnswer(answerPart, true)
 				closeThinking()
 			}
 		},
@@ -340,6 +342,8 @@ func (e *AgentEngine) streamThinkingToEventBus(
 		logger.Errorf(ctx, "[Agent][Thinking] Iteration-%d failed: %v", iteration+1, err)
 		return nil, err
 	}
+	emitAnswer("", true)
+	closeThinking()
 
 	// Emit diagnostics: helps identify when answer content went to "thought" vs "final_answer" events
 	logger.Infof(ctx, "[Agent][Thinking] Iteration-%d completed: content=%d chars, tool_calls=%d, emitted_events=%v",

--- a/internal/agent/tool_markup_guard.go
+++ b/internal/agent/tool_markup_guard.go
@@ -1,0 +1,91 @@
+package agent
+
+import (
+	"errors"
+	"strings"
+	"unicode"
+)
+
+var errLeakedToolMarkup = errors.New("LLM returned tool-call markup as plain text")
+
+var leakedToolMarkupPrefixes = []string{
+	"<||dsml||tool_calls",
+	"<|dsml|tool_calls",
+	"<||dsml||invoke",
+	"<|dsml|invoke",
+}
+
+// normalizeToolMarkupPrefix only normalizes characters used by known DSML
+// envelopes. It deliberately does not search arbitrary prose: an assistant may
+// legitimately explain or quote the protocol without that answer being a
+// failed tool call.
+func normalizeToolMarkupPrefix(content string) string {
+	content = strings.TrimLeftFunc(content, unicode.IsSpace)
+	content = strings.ReplaceAll(content, "｜", "|")
+	return strings.ToLower(content)
+}
+
+// looksLikeLeakedToolMarkup reports whether the assistant started its answer
+// with a provider-internal DSML tool-call envelope. Some OpenAI-compatible
+// providers occasionally return this envelope in content with finish=stop
+// instead of exposing structured tool_calls.
+func looksLikeLeakedToolMarkup(content string) bool {
+	normalized := normalizeToolMarkupPrefix(content)
+	for _, prefix := range leakedToolMarkupPrefixes {
+		if strings.HasPrefix(normalized, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func couldStartLeakedToolMarkup(content string) bool {
+	normalized := normalizeToolMarkupPrefix(content)
+	if normalized == "" {
+		return true
+	}
+	for _, prefix := range leakedToolMarkupPrefixes {
+		if strings.HasPrefix(prefix, normalized) {
+			return true
+		}
+	}
+	return false
+}
+
+// toolMarkupStreamGuard holds only the short, ambiguous beginning of an answer
+// until it can rule out a leaked tool-call envelope. Normal prose is released
+// as soon as its first non-space characters differ from every known prefix, so
+// regular answer streaming is unaffected.
+type toolMarkupStreamGuard struct {
+	pending  string
+	decided  bool
+	rejected bool
+}
+
+func (g *toolMarkupStreamGuard) Feed(content string, done bool) string {
+	if g.rejected {
+		return ""
+	}
+	if g.decided {
+		return content
+	}
+
+	g.pending += content
+	if looksLikeLeakedToolMarkup(g.pending) {
+		g.pending = ""
+		g.rejected = true
+		return ""
+	}
+	if !done && couldStartLeakedToolMarkup(g.pending) {
+		return ""
+	}
+
+	out := g.pending
+	g.pending = ""
+	g.decided = true
+	return out
+}
+
+func (g *toolMarkupStreamGuard) Rejected() bool {
+	return g.rejected
+}

--- a/internal/agent/tool_markup_guard_test.go
+++ b/internal/agent/tool_markup_guard_test.go
@@ -1,0 +1,156 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/event"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLooksLikeLeakedToolMarkup(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "fullwidth", content: "<｜｜DSML｜｜tool_calls>\n<｜｜DSML｜｜invoke name=\"knowledge_search\">", want: true},
+		{name: "ascii", content: "  \n<||DSML||tool_calls>", want: true},
+		{name: "single bars", content: "<|DSML|invoke name=\"knowledge_search\">", want: true},
+		{name: "protocol discussion", content: "DSML is a tool-call protocol.", want: false},
+		{name: "quoted example", content: "For example: <||DSML||tool_calls>", want: false},
+		{name: "ordinary answer", content: "Here is the answer.", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, looksLikeLeakedToolMarkup(tt.content))
+		})
+	}
+}
+
+func TestToolMarkupStreamGuardBuffersOnlyAmbiguousPrefix(t *testing.T) {
+	t.Run("split leaked envelope is rejected", func(t *testing.T) {
+		guard := &toolMarkupStreamGuard{}
+		assert.Empty(t, guard.Feed("\n<｜", false))
+		assert.Empty(t, guard.Feed("｜DSML｜", false))
+		assert.Empty(t, guard.Feed("｜tool_calls>payload", true))
+		assert.True(t, guard.Rejected())
+	})
+
+	t.Run("ordinary text streams immediately", func(t *testing.T) {
+		guard := &toolMarkupStreamGuard{}
+		assert.Equal(t, "Hello ", guard.Feed("Hello ", false))
+		assert.Equal(t, "world", guard.Feed("world", true))
+		assert.False(t, guard.Rejected())
+	})
+}
+
+func TestAnalyzeResponseRejectsLeakedToolMarkup(t *testing.T) {
+	engine := newTestEngine(t, &mockChat{})
+	response := &types.ChatResponse{
+		FinishReason: "stop",
+		Content:      "<｜｜DSML｜｜tool_calls>\n<｜｜DSML｜｜invoke name=\"knowledge_search\">",
+	}
+
+	verdict := engine.analyzeResponse(
+		context.Background(), response, types.AgentStep{}, 0, "sess-1", time.Now(),
+	)
+
+	assert.True(t, verdict.isDone)
+	assert.True(t, verdict.leakedToolMarkup)
+	assert.Empty(t, verdict.finalAnswer)
+}
+
+func TestExecuteLoopRetriesLeakedToolMarkupWithoutEmittingOrPersistingIt(t *testing.T) {
+	leaked := "<｜｜DSML｜｜tool_calls>\n<｜｜DSML｜｜invoke name=\"knowledge_search\">"
+	model := &mockChat{responses: []mockResponse{
+		{chunks: []types.StreamResponse{
+			{ResponseType: types.ResponseTypeAnswer, Content: "<｜"},
+			{ResponseType: types.ResponseTypeAnswer, Content: "｜DSML｜｜tool_calls>\n"},
+			{ResponseType: types.ResponseTypeAnswer, Content: "<｜｜DSML｜｜invoke name=\"knowledge_search\">", Done: true, FinishReason: "stop"},
+		}},
+		{chunks: []types.StreamResponse{
+			{ResponseType: types.ResponseTypeAnswer, Content: "Safe answer.", Done: true, FinishReason: "stop"},
+		}},
+	}}
+	engine := newTestEngine(t, model)
+	var emitted string
+	engine.eventBus.On(event.EventAgentFinalAnswer, func(_ context.Context, evt event.Event) error {
+		if data, ok := evt.Data.(event.AgentFinalAnswerData); ok {
+			emitted += data.Content
+		}
+		return nil
+	})
+
+	state := &types.AgentState{}
+	_, err := engine.executeLoop(context.Background(), state, "test query",
+		emptyMessages(), emptyTools(), "sess-1", "msg-1")
+
+	require.NoError(t, err)
+	assert.True(t, state.IsComplete)
+	assert.Equal(t, "Safe answer.", state.FinalAnswer)
+	assert.Equal(t, "Safe answer.", emitted)
+	assert.Equal(t, 2, model.callCount)
+	for _, step := range state.RoundSteps {
+		assert.NotContains(t, step.Thought, "DSML")
+	}
+	require.Len(t, model.calls, 2)
+	for _, message := range model.calls[1] {
+		assert.NotContains(t, message.Content, leaked)
+	}
+	assert.Contains(t, model.calls[1][len(model.calls[1])-1].Content, "proper function call")
+}
+
+func TestStreamFinalAnswerRejectsLeakedToolMarkupBeforeEmission(t *testing.T) {
+	model := &mockChat{responses: []mockResponse{{chunks: []types.StreamResponse{
+		{ResponseType: types.ResponseTypeAnswer, Content: "<||DSML||tool_"},
+		{ResponseType: types.ResponseTypeAnswer, Content: "calls>payload", Done: true, FinishReason: "stop"},
+	}}}}
+	engine := newTestEngine(t, model)
+	var emitted string
+	engine.eventBus.On(event.EventAgentFinalAnswer, func(_ context.Context, evt event.Event) error {
+		if data, ok := evt.Data.(event.AgentFinalAnswerData); ok {
+			emitted += data.Content
+		}
+		return nil
+	})
+
+	state := &types.AgentState{}
+	err := engine.streamFinalAnswerToEventBus(context.Background(), "test query", state, "sess-1")
+
+	require.ErrorIs(t, err, errLeakedToolMarkup)
+	assert.Empty(t, emitted)
+	assert.Empty(t, state.FinalAnswer)
+}
+
+func TestRepeatedLeakedToolMarkupFallsBackInsteadOfTriggeringStuckLoop(t *testing.T) {
+	leakedChunks := func() []types.StreamResponse {
+		return []types.StreamResponse{{
+			ResponseType: types.ResponseTypeAnswer,
+			Content:      "<||DSML||tool_calls>payload",
+			Done:         true,
+			FinishReason: "stop",
+		}}
+	}
+	model := &mockChat{responses: []mockResponse{
+		{chunks: leakedChunks()},
+		{chunks: leakedChunks()},
+		{chunks: leakedChunks()},
+	}}
+	engine := newTestEngine(t, model)
+
+	state := &types.AgentState{}
+	_, err := engine.executeLoop(context.Background(), state, "test query",
+		emptyMessages(), emptyTools(), "sess-1", "msg-1")
+
+	require.NoError(t, err)
+	assert.True(t, state.IsComplete)
+	assert.NotContains(t, state.FinalAnswer, "DSML")
+	assert.True(t, strings.HasPrefix(state.FinalAnswer, "I'm sorry"))
+	assert.Empty(t, state.RoundSteps)
+}


### PR DESCRIPTION
## Description

Some OpenAI-compatible providers can occasionally return their internal DSML tool-call envelope in plain `content` with `finish_reason=stop`, instead of returning structured `tool_calls`. The agent currently treats that response as a final answer, so raw protocol markup can be streamed to the UI and persisted in the conversation.

This PR:

- recognizes known DSML tool-call prefixes at the start of an answer (ASCII and full-width bar variants)
- buffers only the short ambiguous stream prefix, preventing split protocol markers from briefly reaching the UI
- retries the ReAct turn with a corrective instruction without persisting the rejected assistant content
- falls back safely after bounded retries and keeps the raw envelope out of agent steps
- applies the same guard to final-answer synthesis
- validates terminal responses before the existing repeated-response detector, so repeated leaked envelopes cannot bypass the guard

Detection is deliberately prefix-only: normal answers that discuss or quote DSML later in the text are not rejected.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

- `go test ./internal/agent`
- new markup guard and retry tests repeated with `-count=20`
- `go vet ./internal/agent`
- `go test ./...` (all packages passed except the pre-existing `internal/handler TestDeploymentCapabilityKeysMatchFrontend` failure; the identical failure was reproduced on an untouched `01ec6c05` checkout)
- `git diff --check upstream/main...HEAD`
- GitHub CI: format/vet/test/build, `golangci-lint`, and open-source scan all passed

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (not applicable; no user-facing behavior or API changes)
- [x] Breaking changes are clearly called out in the description above (none)

## Screenshots / Recordings

N/A (backend-only guard)
