### PR TITLE
fix(sandbox): advertise only image skills and unstick installs

### DIFF
--- a/frontend/src/components/SandboxSkillsPanel.vue
+++ b/frontend/src/components/SandboxSkillsPanel.vue
@@ -125,7 +125,13 @@
         </p>
 
         <ul class="skill-list">
-          <li v-for="skill in skills" :key="skill.id" class="skill-item">
+          <li
+            v-for="skill in skills"
+            :key="skill.id"
+            :ref="(el) => bindSkillItem(skill.id, el)"
+            class="skill-item"
+            :class="{ 'skill-item--focused': focusedSkillId === skill.id }"
+          >
             <div class="skill-status-ring" :title="statusLabel(skill)">
               <t-progress
                 v-if="isBusy(skill)"
@@ -154,6 +160,7 @@
                     <span v-if="skill.version">{{ skill.version }} · </span>
                     <span>{{ statusLabel(skill) }}</span>
                     <span v-if="isBusy(skill)"> · {{ progressOf(skill) }}%</span>
+                    <span v-if="isBusy(skill) && progressLog(skill)"> · {{ progressLog(skill) }}</span>
                   </p>
                 </div>
                 <div class="skill-item__actions">
@@ -275,7 +282,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { useI18n } from 'vue-i18n'
 import { fetchEventSource } from '@microsoft/fetch-event-source'
@@ -330,6 +337,9 @@ const deletingId = ref('')
 const expandedSkillId = ref('')
 const expandedCopyIds = ref<Set<string>>(new Set())
 const transcriptEpoch = ref(0)
+const focusedSkillId = ref('')
+const skillItemEls = new Map<string, HTMLElement>()
+let focusTimer: number | null = null
 const fileInputRef = ref<HTMLInputElement | null>(null)
 const progressById = ref<Record<string, ConfigSkillInstallEvent>>({})
 
@@ -406,6 +416,26 @@ function isBusy(skill: ConfigSkill): boolean {
 function hasTranscript(skill: ConfigSkill): boolean {
   if (skill.status === 'installing') return true
   return Boolean(skill.install_session_id && skill.install_message_id)
+}
+
+function bindSkillItem(id: string, el: unknown) {
+  if (el instanceof HTMLElement) {
+    skillItemEls.set(id, el)
+    return
+  }
+  skillItemEls.delete(id)
+}
+
+function revealSkill(skillId: string) {
+  focusedSkillId.value = skillId
+  void nextTick(() => {
+    skillItemEls.get(skillId)?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  })
+  if (focusTimer != null) window.clearTimeout(focusTimer)
+  focusTimer = window.setTimeout(() => {
+    if (focusedSkillId.value === skillId) focusedSkillId.value = ''
+    focusTimer = null
+  }, 2400)
 }
 
 function onTranscriptVisible(skill: ConfigSkill, visible: boolean) {
@@ -671,7 +701,10 @@ async function uploadFile(file: File) {
     const skillId = res?.data?.skill_id
     await loadSkills()
     await refreshImage()
-    if (skillId) followProgress(skillId)
+    if (skillId) {
+      followProgress(skillId)
+      revealSkill(skillId)
+    }
   } catch (e: any) {
     MessagePlugin.error(e?.message || t('settings.sandbox.skillUploadFailed'))
   } finally {
@@ -698,7 +731,10 @@ async function installFromSource() {
     const skillId = res?.data?.skill_id
     await loadSkills()
     await refreshImage()
-    if (skillId) followProgress(skillId)
+    if (skillId) {
+      followProgress(skillId)
+      revealSkill(skillId)
+    }
   } catch (e: any) {
     MessagePlugin.error(e?.message || t('settings.sandbox.skillSourceFailed'))
   } finally {
@@ -773,6 +809,7 @@ watch(
 onUnmounted(() => {
   stopAllFollows()
   stopPoll()
+  if (focusTimer != null) window.clearTimeout(focusTimer)
 })
 </script>
 
@@ -976,6 +1013,12 @@ onUnmounted(() => {
   border: 1px solid var(--td-component-stroke);
   border-radius: 8px;
   background: var(--td-bg-color-container);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.skill-item--focused {
+  border-color: var(--td-brand-color);
+  box-shadow: 0 0 0 2px var(--td-brand-color-focus, rgba(0, 168, 112, 0.18));
 }
 
 .skill-transcript-toggle--on {

--- a/frontend/src/components/SkillInstallTimeline.vue
+++ b/frontend/src/components/SkillInstallTimeline.vue
@@ -38,9 +38,9 @@ const props = defineProps<{
   // The durable rows behind the run, used when the event log has aged out.
   sessionId: string
   messageId: string
-  // True while this skill is still installing. The locators are written only
-  // after the installer sandbox is up, so a 404 here means "not yet" rather
-  // than "gone" and the stream is retried.
+  // True while this skill is still installing. Locators are written after the
+  // sandbox is up; until then this component shows the waiting copy and does
+  // not hit /transcript.
   live?: boolean
   compact?: boolean
 }>()
@@ -168,22 +168,30 @@ async function open() {
   const run = ++openRun
   closed = false
   messages.splice(0, messages.length)
-  loading.value = true
   const stale = () => run !== openRun || closed
   try {
     // A finished install already has durable rows. Replaying the event log
     // through processStreamChunk would animate every tool call again, which
     // is what "view the run" must not do.
     if (!props.live) {
+      loading.value = true
       if (props.sessionId) {
         await loadPersisted(run)
       }
       return
     }
 
-    // Locators land after the installer sandbox is up. Keep asking until the
-    // stream answers; falling through to the empty state on the first 404
-    // would flash "no record" during setup.
+    // Locators land after the installer sandbox is up. Hitting /transcript
+    // before that 404s every second (WARNING in the access log) and leaves
+    // the spinner up for the entire file seed, which can take minutes.
+    // The parent already polls the skill list; this watch re-opens when
+    // sessionId arrives.
+    if (!props.sessionId || !props.messageId) {
+      loading.value = false
+      return
+    }
+
+    loading.value = true
     for (;;) {
       if (stale() || !props.live) return
       const served = await follow(run).catch(() => false)
@@ -204,7 +212,7 @@ async function open() {
 }
 
 watch(
-  () => [props.configId, props.skillId, props.sessionId, props.live] as const,
+  () => [props.configId, props.skillId, props.sessionId, props.messageId, props.live] as const,
   () => {
     stop()
     if (props.configId && props.skillId) void open()

--- a/internal/agent/skills/manager.go
+++ b/internal/agent/skills/manager.go
@@ -77,8 +77,9 @@ type Manager struct {
 	sandboxMgr sandbox.Manager
 
 	// tenantSource holds the skills installed into this run's sandbox image.
-	// It is nil for every run whose workspace has none, which is why the
-	// preloaded path below is untouched by its existence.
+	// When set it is the only source the model is told about: the host
+	// skills/preloaded directory is not what execute_skill_script would find
+	// inside the sandbox.
 	tenantSource SkillSource
 
 	// Configuration
@@ -129,70 +130,25 @@ func (m *Manager) WithTenantSource(source SkillSource) *Manager {
 	return m
 }
 
-// resolveSource decides which source owns one skill name. An installed skill
-// shadows a preloaded one of the same name, because the sandbox boots the
-// image the install produced and that is the copy a script would run.
+// resolveSource decides which source owns one skill name. An installed image
+// is the only copy the sandbox can run: falling back to a host preloaded
+// skill would advertise files that are not in the image.
 func (m *Manager) resolveSource(skillName string) SkillSource {
 	if m.tenantSource != nil {
-		if _, err := m.tenantSource.GetSkillBasePath(skillName); err == nil {
-			return m.tenantSource
-		}
+		return m.tenantSource
 	}
 	return m.loader
 }
 
-// discoverAllSkills merges the two sources into the set the model is told
-// about.
+// discoverAllSkills returns the set the model is told about. When skills are
+// installed into the sandbox image, that image is the source of truth; the
+// deployment's skills/preloaded directory is not what execute_skill_script
+// would find inside the sandbox.
 func (m *Manager) discoverAllSkills() ([]*SkillMetadata, error) {
-	preloaded, err := m.loader.DiscoverSkills()
-	if err != nil {
-		return nil, err
+	if m.tenantSource != nil {
+		return m.tenantSource.DiscoverSkills()
 	}
-	return m.mergeWithTenantSkills(preloaded)
-}
-
-// mergeWithTenantSkills overlays the installed skills on a freshly discovered
-// preloaded set.
-func (m *Manager) mergeWithTenantSkills(preloaded []*SkillMetadata) ([]*SkillMetadata, error) {
-	if m.tenantSource == nil {
-		return preloaded, nil
-	}
-	tenant, err := m.tenantSource.DiscoverSkills()
-	if err != nil {
-		return nil, err
-	}
-	return mergeSkillMetadata(preloaded, tenant), nil
-}
-
-// mergeSkillMetadata overlays the installed skills on the preloaded ones,
-// keeping the preloaded ordering for the names both sources carry so the
-// system prompt does not reshuffle when a skill is installed.
-func mergeSkillMetadata(preloaded, tenant []*SkillMetadata) []*SkillMetadata {
-	byName := make(map[string]*SkillMetadata, len(tenant))
-	for _, meta := range tenant {
-		if meta != nil {
-			byName[meta.Name] = meta
-		}
-	}
-	merged := make([]*SkillMetadata, 0, len(preloaded)+len(tenant))
-	overridden := make(map[string]bool, len(tenant))
-	for _, meta := range preloaded {
-		if meta == nil {
-			continue
-		}
-		if installed, ok := byName[meta.Name]; ok {
-			merged = append(merged, installed)
-			overridden[meta.Name] = true
-			continue
-		}
-		merged = append(merged, meta)
-	}
-	for _, meta := range tenant {
-		if meta != nil && !overridden[meta.Name] {
-			merged = append(merged, meta)
-		}
-	}
-	return merged
+	return m.loader.Reload()
 }
 
 // Initialize discovers all skills and caches their metadata
@@ -491,11 +447,7 @@ func (m *Manager) Reload(ctx context.Context) error {
 		return nil
 	}
 
-	preloaded, err := m.loader.Reload()
-	if err != nil {
-		return err
-	}
-	metadata, err := m.mergeWithTenantSkills(preloaded)
+	metadata, err := m.discoverAllSkills()
 	if err != nil {
 		return err
 	}

--- a/internal/agent/skills/tenant_source_test.go
+++ b/internal/agent/skills/tenant_source_test.go
@@ -188,8 +188,8 @@ func TestTenantSkillSourceReportsAMissingBundleWithoutBlockingExecution(t *testi
 	require.Equal(t, "/opt/weknora/tenant/skills/pdf/scripts/extract.py", remote)
 }
 
-func TestManagerPrefersTheTenantSkillOverASameNamedPreloadedOne(t *testing.T) {
-	dir := preloadedSkillDir(t, "pdf", "preloaded description")
+func TestManagerIgnoresPreloadedSkillsWhenTenantSourceIsAttached(t *testing.T) {
+	dir := preloadedSkillDir(t, "document-analyzer", "preloaded description")
 	mgr := NewManager(&ManagerConfig{SkillDirs: []string{dir}, Enabled: true}, nil)
 	mgr.WithTenantSource(NewTenantSkillSource([]*types.TenantSkillEntity{
 		{
@@ -209,13 +209,17 @@ func TestManagerPrefersTheTenantSkillOverASameNamedPreloadedOne(t *testing.T) {
 		byName[meta.Name] = meta
 	}
 	require.Len(t, byName, 2)
-	require.Equal(t, "tenant description", byName["pdf"].Description,
-		"the tenant's own install is what the sandbox image actually carries")
+	require.NotContains(t, byName, "document-analyzer",
+		"host preloaded skills are not in the sandbox image")
+	require.Equal(t, "tenant description", byName["pdf"].Description)
 	require.Equal(t, "tenant only", byName["csv"].Description)
 
 	skill, err := mgr.LoadSkill(context.Background(), "pdf")
 	require.NoError(t, err)
 	require.Equal(t, "tenant body", skill.Instructions)
+
+	_, err = mgr.LoadSkill(context.Background(), "document-analyzer")
+	require.Error(t, err, "a host-only skill must not be readable once the image is the source")
 }
 
 func TestManagerRunsATenantSkillFromTheImageWithoutUploading(t *testing.T) {
@@ -246,13 +250,10 @@ func TestManagerRunsATenantSkillFromTheImageWithoutUploading(t *testing.T) {
 
 // Preloaded skills keep uploading from the host and keep running in their own
 // directory; the tenant source must not change that path at all.
-func TestManagerKeepsPreloadedSkillExecutionUnchanged(t *testing.T) {
+func TestManagerKeepsPreloadedSkillExecutionWhenNoTenantSource(t *testing.T) {
 	dir := preloadedSkillDir(t, "pdf", "preloaded description")
 	sandboxMgr := &recordingSandboxManager{}
 	mgr := NewManager(&ManagerConfig{SkillDirs: []string{dir}, Enabled: true}, sandboxMgr)
-	mgr.WithTenantSource(NewTenantSkillSource([]*types.TenantSkillEntity{{
-		ID: "sk-1", Name: "csv", Status: types.SkillStatusReady, Enabled: true,
-	}}, nil))
 	require.NoError(t, mgr.Initialize(context.Background()))
 
 	_, err := mgr.ExecuteScript(context.Background(), "pdf", "scripts/run.py", nil, "")

--- a/internal/application/service/agent_service.go
+++ b/internal/application/service/agent_service.go
@@ -237,20 +237,18 @@ func (s *agentService) CreateAgentEngine(
 		}
 	}
 
-	skillsEnabledWithDirs := config.SkillsEnabled && len(config.SkillDirs) > 0
-	// Initialize the skills/sandbox manager when skills are configured, or for
-	// the skill installer, which keeps skills off yet needs the sandbox shell.
-	// The second disjunct is deliberately NOT "the config lists a sandbox
-	// tool": shell_exec is a user-selectable entry in the tool picker, so that
-	// rule would hand a live sandbox shell to every stored agent record that
-	// already lists it. Install mode is settable only through
-	// EnableSkillInstallMode, so only the built-in installer passes here and
-	// every other agent keeps exactly its previous behaviour.
-	if skillsEnabledWithDirs || config.SkillInstallMode() {
+	// TenantSkills is the sandbox image. SkillDirs is the host
+	// skills/preloaded tree and is no longer filled on the QA path; it
+	// remains so tests (and any caller that still points at a host
+	// directory) can construct a manager. Install mode initializes for
+	// the shell without hanging a skills manager on the engine.
+	offerSkills := config.SkillsEnabled &&
+		(len(config.SkillDirs) > 0 || len(config.TenantSkills) > 0)
+	if offerSkills || config.SkillInstallMode() {
 		skillsManager, err := s.initializeSkillsManager(ctx, sessionID, config, toolRegistry)
 		if err != nil {
 			logger.Warnf(ctx, "Failed to initialize skills manager: %v", err)
-		} else if skillsEnabledWithDirs && skillsManager != nil {
+		} else if offerSkills && skillsManager != nil {
 			engine.SetSkillsManager(skillsManager)
 			logger.Infof(ctx, "Skills manager initialized with %d skills",
 				len(skillsManager.GetAllMetadata()))
@@ -838,6 +836,14 @@ func (s *agentService) registerTools(
 		case tools.ToolWikiDeletePage:
 			toolToRegister = tools.NewWikiDeletePageTool(s.wikiPageService, wikiKBIDs, wikiRoutes)
 
+		case tools.ToolShellExec, tools.ToolReadSkill, tools.ToolExecuteSkillScript,
+			tools.ToolListSandboxFiles, tools.ToolReadSandboxFile:
+			// Bound to the resolved sandbox manager in initializeSkillsManager
+			// / registerSandboxShellTool. Listing them here would warn
+			// "Unknown tool: shell_exec" on every skill install, then register
+			// the real tool a few lines later.
+			continue
+
 		default:
 			logger.Warnf(ctx, "Unknown tool: %s", toolName)
 		}
@@ -1176,6 +1182,11 @@ func (s *agentService) resolvePinnedSkillInfos(config *types.AgentConfig) []*age
 					descByName[meta.Name] = meta.Description
 				}
 			}
+		}
+	}
+	for _, row := range config.TenantSkills {
+		if row != nil && row.Name != "" {
+			descByName[row.Name] = row.Description
 		}
 	}
 

--- a/internal/application/service/agent_service_test.go
+++ b/internal/application/service/agent_service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -253,6 +254,42 @@ func TestCreateAgentEngineOpensSandboxToolsOnlyForInstallMode(t *testing.T) {
 		require.True(t, toolOffered(chatModel.lastToolNames, tools.ToolExecuteSkillScript))
 		require.NotNil(t, engine.(*agent.AgentEngine).GetSkillsManager())
 	})
+
+	t.Run("skills enabled with tenant skills and no host dirs still offers skill tools", func(t *testing.T) {
+		chatModel := &fakeAgentChatModel{}
+		svc := &agentService{
+			sandboxResolver: stubSandboxResolver{
+				mgr: &capableManager{
+					typ:   sandbox.SandboxTypeCube,
+					shell: &stubShellExecutor{},
+					files: stubSessionFileStore{},
+				},
+			},
+		}
+
+		engine, err := svc.CreateAgentEngine(ctx, &types.AgentConfig{
+			SandboxConfigID: "cfg-remote",
+			SkillsEnabled:   true,
+			TenantSkills: []*types.TenantSkillEntity{{
+				ID: "sk-1", TenantID: 7, SandboxConfigID: "cfg-remote",
+				Name: "pdf-tools", Description: "PDF helpers",
+				Status: types.SkillStatusReady, Enabled: true,
+			}},
+		}, chatModel, nil, nil, "sess-1", "msg-1")
+
+		require.NoError(t, err)
+		_, err = engine.Execute(ctx, "sess-1", "msg-1", "hello", nil)
+		require.NoError(t, err)
+		require.True(t, toolOffered(chatModel.lastToolNames, tools.ToolReadSkill))
+		require.True(t, toolOffered(chatModel.lastToolNames, tools.ToolExecuteSkillScript))
+		mgr := engine.(*agent.AgentEngine).GetSkillsManager()
+		require.NotNil(t, mgr)
+		var names []string
+		for _, meta := range mgr.GetAllMetadata() {
+			names = append(names, meta.Name)
+		}
+		require.Equal(t, []string{"pdf-tools"}, names)
+	})
 }
 
 func TestSkillToolsFollowSkillsEnabled(t *testing.T) {
@@ -320,6 +357,47 @@ func TestSkillsManagerOffersTheInjectedInstalledSkills(t *testing.T) {
 		}
 		return names
 	}
+
+	t.Run("injected rows are offered without a host skill directory", func(t *testing.T) {
+		mgr, err := newSvc().initializeSkillsManager(ctx, "sess-1", &types.AgentConfig{
+			SandboxConfigID: "cfg-remote",
+			SkillsEnabled:   true,
+			TenantSkills: []*types.TenantSkillEntity{{
+				ID: "sk-1", TenantID: 7, SandboxConfigID: "cfg-remote",
+				Name: "pdf-tools", Description: "PDF helpers",
+				Status: types.SkillStatusReady, Enabled: true,
+			}},
+		}, tools.NewToolRegistry())
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"pdf-tools"}, skillNamesOf(mgr))
+	})
+
+	t.Run("host preloaded skills are not offered beside the sandbox image", func(t *testing.T) {
+		dir := t.TempDir()
+		skillDir := filepath.Join(dir, "document-analyzer")
+		require.NoError(t, os.MkdirAll(skillDir, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(skillDir, "SKILL.md"),
+			[]byte("---\nname: document-analyzer\ndescription: old host copy\n---\n"),
+			0o644,
+		))
+
+		mgr, err := newSvc().initializeSkillsManager(ctx, "sess-1", &types.AgentConfig{
+			SandboxConfigID: "cfg-remote",
+			SkillsEnabled:   true,
+			SkillDirs:       []string{dir},
+			TenantSkills: []*types.TenantSkillEntity{{
+				ID: "sk-1", TenantID: 7, SandboxConfigID: "cfg-remote",
+				Name: "pdf-tools", Description: "PDF helpers",
+				Status: types.SkillStatusReady, Enabled: true,
+			}},
+		}, tools.NewToolRegistry())
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"pdf-tools"}, skillNamesOf(mgr),
+			"the host skills/preloaded tree is not what the sandbox image carries")
+	})
 
 	t.Run("injected rows are offered", func(t *testing.T) {
 		mgr, err := newSvc().initializeSkillsManager(ctx, "sess-1", &types.AgentConfig{

--- a/internal/application/service/session_agent_qa.go
+++ b/internal/application/service/session_agent_qa.go
@@ -566,11 +566,10 @@ func dedupPreservingOrder(values []string) []string {
 	return result
 }
 
-// configureSkillsFromAgent configures skills settings in AgentConfig based on CustomAgentConfig
-// Returns the skill directories and allowed skills based on the selection mode:
-//   - "all": uses all preloaded skills
-//   - "selected": uses the explicitly selected skills
-//   - "none" or "": skills are disabled
+// configureSkillsFromAgent turns the agent's skill picker into runtime flags.
+// The skills themselves come from the sandbox image (TenantSkills), not from
+// the deployment's skills/preloaded directory — that host copy is not what
+// execute_skill_script would find inside the sandbox.
 func (s *sessionService) configureSkillsFromAgent(
 	ctx context.Context,
 	agentConfig *types.AgentConfig,
@@ -580,19 +579,14 @@ func (s *sessionService) configureSkillsFromAgent(
 		return
 	}
 	agentConfig.SandboxConfigID = customAgent.Config.SandboxConfigID
-	dir := getPreloadedSkillsDir()
 	switch customAgent.Config.SkillsSelectionMode {
 	case "all":
-		// Enable all preloaded skills
 		agentConfig.SkillsEnabled = true
-		agentConfig.SkillDirs = []string{dir}
-		agentConfig.AllowedSkills = nil // Empty means all skills allowed
-		logger.Infof(ctx, "SkillsSelectionMode=all: enabled all preloaded skills")
+		agentConfig.AllowedSkills = nil
+		logger.Infof(ctx, "SkillsSelectionMode=all: using installed sandbox skills")
 	case "selected":
-		// Enable only selected skills
 		if len(customAgent.Config.SelectedSkills) > 0 {
 			agentConfig.SkillsEnabled = true
-			agentConfig.SkillDirs = []string{dir}
 			agentConfig.AllowedSkills = customAgent.Config.SelectedSkills
 			logger.Infof(ctx, "SkillsSelectionMode=selected: enabled %d selected skills: %v",
 				len(customAgent.Config.SelectedSkills), customAgent.Config.SelectedSkills)
@@ -601,11 +595,9 @@ func (s *sessionService) configureSkillsFromAgent(
 			logger.Infof(ctx, "SkillsSelectionMode=selected but no skills selected: skills disabled")
 		}
 	case "none", "":
-		// Skills disabled
 		agentConfig.SkillsEnabled = false
 		logger.Infof(ctx, "SkillsSelectionMode=%s: skills disabled", customAgent.Config.SkillsSelectionMode)
 	default:
-		// Unknown mode, disable skills
 		agentConfig.SkillsEnabled = false
 		logger.Warnf(ctx, "Unknown SkillsSelectionMode=%s: skills disabled", customAgent.Config.SkillsSelectionMode)
 	}

--- a/internal/application/service/session_agent_qa_scope_test.go
+++ b/internal/application/service/session_agent_qa_scope_test.go
@@ -98,3 +98,18 @@ func TestApplyPerRequestSkillScope_NoneIgnores(t *testing.T) {
 	applyPerRequestSkillScope(context.Background(), cfg, "none", []string{"a"})
 	assert.Empty(t, cfg.PinnedSkillNames)
 }
+
+func TestConfigureSkillsFromAgentDoesNotLoadHostPreloadedDir(t *testing.T) {
+	svc := &sessionService{}
+	cfg := &types.AgentConfig{}
+	svc.configureSkillsFromAgent(context.Background(), cfg, &types.CustomAgent{
+		Config: types.CustomAgentConfig{
+			SandboxConfigID:     "cfg-1",
+			SkillsSelectionMode: "all",
+		},
+	})
+	assert.True(t, cfg.SkillsEnabled)
+	assert.Equal(t, "cfg-1", cfg.SandboxConfigID)
+	assert.Empty(t, cfg.SkillDirs,
+		"the host skills/preloaded tree is not what the sandbox image carries")
+}

--- a/internal/application/service/tenant_skill_install.go
+++ b/internal/application/service/tenant_skill_install.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -36,6 +38,11 @@ const (
 	// still missing is the row that says so.
 	readySkillWriteAttempts = 3
 	readySkillWriteDelay    = 100 * time.Millisecond
+
+	// skillSeedArchivePath is the single remote write used to land a skill's
+	// files. Writing each file with MakeDir+WriteFile is two round trips per
+	// entry, which is why a 50-file skill crawled through "seeding 12/56".
+	skillSeedArchivePath = sandbox.SkillsImageRoot + "/.weknora-seed.tar"
 )
 
 // InstallSkill validates an uploaded archive, records it, and kicks off the
@@ -270,13 +277,30 @@ func (s *TenantSkillService) runInstall(
 	if err := s.resetSkillDir(ctx, mgr, sess.ID, skillDir); err != nil {
 		return err
 	}
+
+	// Locators must land before the file seed. A large skill is copied file by
+	// file over the sandbox API and can take minutes; the console attaches to
+	// the transcript as soon as the directory is ready, not after that copy.
+	transcript, prompt := s.beginInstallTranscript(ctx, tenantID, skillID, sess, mgr, skillDir, bundle)
+
+	fileCount := 0
+	if bundle != nil {
+		fileCount = len(bundle.Files)
+	}
+	if fileCount > 0 {
+		logger.Infof(ctx, "[skill] seeding %d files for %s as one archive", fileCount, skillID)
+		s.publishProgress(ctx, tenantID, configID, skillID, SkillProgress{
+			Percent: 28, Stage: "seeding",
+			Log: fmt.Sprintf("seeding %d files", fileCount),
+		})
+	}
 	if err := s.seedSkillFiles(ctx, mgr, sess.ID, skillDir, bundle); err != nil {
 		return err
 	}
 	s.publishProgress(ctx, tenantID, configID, skillID, SkillProgress{Percent: 35, Stage: "seeded"})
 
 	// 3. Let the installer agent install dependencies.
-	if err := s.driveInstallerAgent(ctx, tenantID, skillID, sess, mgr, skillDir, bundle); err != nil {
+	if err := s.driveInstallerAgent(ctx, tenantID, skillID, sess, transcript, prompt); err != nil {
 		return err
 	}
 	s.publishProgress(ctx, tenantID, configID, skillID, SkillProgress{Percent: 80, Stage: "agent_done"})
@@ -495,20 +519,96 @@ func guardSkillDir(skillDir string) error {
 // server-side rather than asking the agent to unpack keeps the source of truth
 // byte-identical to what was uploaded. Provisioning the directory is
 // runInstall's step 2, not this function's job.
+//
+// The files travel as one tar: each remote WriteFile is a MakeDir plus an
+// upload, and a skill with dozens of files was spending minutes on that
+// round-trip tax. Extracting inside the sandbox is one local untar.
 func (s *TenantSkillService) seedSkillFiles(
 	ctx context.Context, mgr sandbox.Manager, sessionID, skillDir string, bundle *SkillBundle,
 ) error {
+	if bundle == nil || len(bundle.Files) == 0 {
+		return nil
+	}
 	store, err := installFileStore(mgr)
 	if err != nil {
 		return err
 	}
-	for rel, content := range bundle.Files {
-		target := path.Join(skillDir, rel)
-		if err := store.WriteSessionFile(ctx, sessionID, target, content); err != nil {
-			return fmt.Errorf("seed %s: %w", target, err)
-		}
+	archive, err := packSkillTar(bundle)
+	if err != nil {
+		return err
+	}
+	if err := store.WriteSessionFile(ctx, sessionID, skillSeedArchivePath, archive); err != nil {
+		return fmt.Errorf("seed skill archive: %w", err)
+	}
+	if _, err := s.execInstall(ctx, mgr, sessionID, seedExtractCommand(skillDir)); err != nil {
+		return fmt.Errorf("extract skill archive: %w", err)
 	}
 	return nil
+}
+
+func seedExtractCommand(skillDir string) string {
+	tarPath := sandbox.ShellQuote(skillSeedArchivePath)
+	dir := sandbox.ShellQuote(skillDir)
+	return fmt.Sprintf("tar -xf %s -C %s && rm -f %s", tarPath, dir, tarPath)
+}
+
+func packSkillTar(bundle *SkillBundle) ([]byte, error) {
+	if bundle == nil {
+		return nil, nil
+	}
+	names := make([]string, 0, len(bundle.Files))
+	for rel := range bundle.Files {
+		names = append(names, rel)
+	}
+	sort.Strings(names)
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, rel := range names {
+		name := path.Clean(rel)
+		if name == "." || name == ".." || strings.HasPrefix(name, "../") || path.IsAbs(name) {
+			return nil, fmt.Errorf("skill file %q escapes the archive root", rel)
+		}
+		content := bundle.Files[rel]
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0o644,
+			Size: int64(len(content)),
+		}); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write(content); err != nil {
+			return nil, err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// beginInstallTranscript writes the locators and opening prompt after the
+// skill directory is reset, so a console that opens during the file seed
+// finds something to follow instead of 404-polling for minutes.
+func (s *TenantSkillService) beginInstallTranscript(
+	ctx context.Context, tenantID uint64, skillID string,
+	sess *types.Session, mgr sandbox.Manager, skillDir string, bundle *SkillBundle,
+) (*installTranscript, string) {
+	assistantMessageID := uuid.NewString()
+	prompt := buildInstallPrompt(skillDir, bundle, s.probeUv(ctx, mgr, sess.ID))
+	transcript := newInstallTranscript(ctx, event.NewEventBus(), s.streams, s.messages, sess.ID, assistantMessageID)
+	if err := transcript.Create(ctx, prompt); err != nil {
+		logger.Warnf(ctx, "[skill] seed install transcript for %s failed: %v", skillID, err)
+	}
+	transcript.Subscribe()
+	if err := s.updateSkillFields(ctx, tenantID, sess.SandboxConfigID, skillID,
+		func(e *types.TenantSkillEntity) {
+			e.InstallSessionID = sess.ID
+			e.InstallMessageID = assistantMessageID
+		}); err != nil {
+		logger.Warnf(ctx, "[skill] record transcript locators for %s failed: %v", skillID, err)
+	}
+	return transcript, prompt
 }
 
 // driveInstallerAgent runs one installer conversation. It calls the engine
@@ -517,10 +617,13 @@ func (s *TenantSkillService) seedSkillFiles(
 // need a reliable signal before switching the image.
 func (s *TenantSkillService) driveInstallerAgent(
 	ctx context.Context, tenantID uint64, skillID string, sess *types.Session,
-	mgr sandbox.Manager, skillDir string, bundle *SkillBundle,
+	transcript *installTranscript, prompt string,
 ) error {
 	if s.installerAgents == nil {
 		return errors.New("custom agent service is not configured")
+	}
+	if transcript == nil {
+		return errors.New("install transcript was not seeded")
 	}
 	// The record is tenant-writable: updateBuiltinAgent lets a tenant persist a
 	// Config for any built-in ID, this one included. It is therefore read for
@@ -537,30 +640,8 @@ func (s *TenantSkillService) driveInstallerAgent(
 		return err
 	}
 
-	bus := event.NewEventBus()
-	assistantMessageID := uuid.NewString()
-	prompt := buildInstallPrompt(skillDir, bundle, s.probeUv(ctx, mgr, sess.ID))
-
-	// The transcript is set up before the engine so a console that attaches
-	// while the install is still running finds a message to stream into. Its
-	// failures are logged rather than returned: an unreadable transcript is a
-	// worse outcome than no transcript, but neither is a reason to refuse an
-	// otherwise good install.
-	transcript := newInstallTranscript(ctx, bus, s.streams, s.messages, sess.ID, assistantMessageID)
-	if err := transcript.Create(ctx, prompt); err != nil {
-		logger.Warnf(ctx, "[skill] seed install transcript for %s failed: %v", skillID, err)
-	}
-	transcript.Subscribe()
-	if err := s.updateSkillFields(ctx, tenantID, sess.SandboxConfigID, skillID,
-		func(e *types.TenantSkillEntity) {
-			e.InstallSessionID = sess.ID
-			e.InstallMessageID = assistantMessageID
-		}); err != nil {
-		logger.Warnf(ctx, "[skill] record transcript locators for %s failed: %v", skillID, err)
-	}
-
 	engine, err := s.agents.CreateAgentEngine(
-		ctx, agentConfig, chatModel, nil, bus, sess.ID, assistantMessageID,
+		ctx, agentConfig, chatModel, nil, transcript.bus, sess.ID, transcript.assistantMessageID,
 	)
 	if err != nil {
 		runErr := fmt.Errorf("create installer engine: %w", err)
@@ -568,7 +649,7 @@ func (s *TenantSkillService) driveInstallerAgent(
 		return runErr
 	}
 
-	state, err := engine.Execute(ctx, sess.ID, assistantMessageID, prompt, nil)
+	state, err := engine.Execute(ctx, sess.ID, transcript.assistantMessageID, prompt, nil)
 	runErr := err
 	if runErr == nil && (state == nil || !state.IsComplete) {
 		runErr = errors.New("installer agent stopped without completing")

--- a/internal/application/service/tenant_skill_install_test.go
+++ b/internal/application/service/tenant_skill_install_test.go
@@ -1,12 +1,15 @@
 package service
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -79,6 +82,7 @@ func TestRunInstallIssuesExactlyTheseCommands(t *testing.T) {
 	require.Equal(t, []string{
 		installPrepareCommand,
 		"uv --version",
+		seedExtractCommand(installSkillDir),
 		"chmod -R 555 " + installSkillDir,
 		"chown -R root:root " + installSkillDir,
 		"test -f " + installSkillDir + "/SKILL.md",
@@ -1024,6 +1028,54 @@ func TestRunInstallPublishesTranscriptLocatorsBeforeTheAgentRuns(t *testing.T) {
 	require.NotEmpty(t, atExecute.InstallMessageID)
 }
 
+func TestRunInstallPublishesTranscriptLocatorsBeforeSeedingFiles(t *testing.T) {
+	fx := newInstallFixture(t)
+
+	var atSeed *types.TenantSkillEntity
+	fx.beforeSeed = func() {
+		skill, err := fx.skillRepo.GetSkill(context.Background(), 7, "cfg-1", "sk-1")
+		require.NoError(t, err)
+		copied := *skill
+		atSeed = &copied
+	}
+
+	require.NoError(t, fx.svc.runInstall(ctxWithTenant(7), 7, "cfg-1", "sk-1", fx.bundle))
+
+	require.NotNil(t, atSeed, "files were seeded without a hook")
+	require.NotEmpty(t, atSeed.InstallSessionID)
+	require.NotEmpty(t, atSeed.InstallMessageID)
+}
+
+func TestPackSkillTarRoundTrip(t *testing.T) {
+	bundle := &SkillBundle{Files: map[string][]byte{
+		"SKILL.md":           []byte("name: x"),
+		"scripts/extract.py": []byte("print(1)\n"),
+	}}
+	raw, err := packSkillTar(bundle)
+	require.NoError(t, err)
+
+	got := map[string][]byte{}
+	tr := tar.NewReader(bytes.NewReader(raw))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		content, err := io.ReadAll(tr)
+		require.NoError(t, err)
+		got[hdr.Name] = content
+	}
+	require.Equal(t, bundle.Files, got)
+}
+
+func TestPackSkillTarRejectsEscapingNames(t *testing.T) {
+	_, err := packSkillTar(&SkillBundle{Files: map[string][]byte{
+		"../etc/passwd": []byte("x"),
+	}})
+	require.Error(t, err)
+}
+
 // Maintenance sessions are excluded from the console by their description, and
 // scoped to the admin who started the install by their owner. Both are written
 // at creation time; neither has a backfill.
@@ -1107,6 +1159,9 @@ type installFixture struct {
 	// beforeExecute runs at the moment the engine would start, so a test can
 	// observe the state an attaching console would see mid-install.
 	beforeExecute func()
+	// beforeSeed runs on the first image file write, so a test can prove the
+	// transcript locators landed before the minutes-long copy begins.
+	beforeSeed func()
 	// staleMarks records every InvalidateConfigSandboxes call, so a test can
 	// state which config was marked rather than only that something was.
 	staleMarks []staleMark
@@ -1661,9 +1716,57 @@ func (m *installSandboxManager) WriteSessionFile(
 		return nil
 	}
 	if !containsEvent(m.fx.events, "seed-files") {
+		if m.fx.beforeSeed != nil {
+			m.fx.beforeSeed()
+		}
 		m.fx.record("seed-files")
 	}
 	return nil
+}
+
+func (m *installSandboxManager) extractSeedArchive(command string) {
+	archive, ok := m.writeContents[skillSeedArchivePath]
+	if !ok {
+		return
+	}
+	skillDir := installSkillDir
+	if _, after, found := strings.Cut(command, " -C "); found {
+		dir, _, _ := strings.Cut(strings.TrimSpace(after), " ")
+		if dir != "" {
+			skillDir = dir
+		}
+	}
+	tr := tar.NewReader(bytes.NewReader(archive))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return
+		}
+		if hdr.Typeflag != tar.TypeReg && hdr.Typeflag != 0 {
+			continue
+		}
+		content, err := io.ReadAll(tr)
+		if err != nil {
+			return
+		}
+		dest := path.Join(skillDir, hdr.Name)
+		m.writes = append(m.writes, dest)
+		if m.writeContents == nil {
+			m.writeContents = map[string][]byte{}
+		}
+		m.writeContents[dest] = content
+	}
+	delete(m.writeContents, skillSeedArchivePath)
+	kept := m.writes[:0]
+	for _, w := range m.writes {
+		if w != skillSeedArchivePath {
+			kept = append(kept, w)
+		}
+	}
+	m.writes = kept
 }
 
 func (m *installSandboxManager) RemoveSessionInputPath(context.Context, string, string) error {
@@ -1696,6 +1799,8 @@ func (m *installSandboxManager) ExecShellCommandWithOptions(
 	switch {
 	case command == installPrepareCommand:
 		m.fx.record("prepare-skill-dir")
+	case strings.HasPrefix(command, "tar -xf "):
+		m.extractSeedArchive(command)
 	case strings.HasPrefix(command, "test -f "):
 		if !m.structureSeen {
 			m.fx.record("verify-structure")

--- a/internal/handler/sandbox_skill.go
+++ b/internal/handler/sandbox_skill.go
@@ -567,6 +567,7 @@ func (h *SandboxSkillHandler) InstallEvents(c *gin.Context) {
 // @Param        id       path      string  true  "Sandbox config ID"
 // @Param        skillId  path      string  true  "Skill ID"
 // @Success      200      {string}  string  "SSE stream of transcript events"
+// @Success      204      {string}  string  "Install is still preparing; retry once locators exist"
 // @Failure      401      {object}  map[string]interface{}  "Unauthorized"
 // @Failure      404      {object}  apperrors.AppError      "Skill or transcript not found"
 // @Security     Bearer
@@ -589,6 +590,13 @@ func (h *SandboxSkillHandler) InstallTranscript(c *gin.Context) {
 	}
 	sessionID, messageID := skill.InstallSessionID, skill.InstallMessageID
 	if sessionID == "" || messageID == "" {
+		// The skill row exists the moment the upload is accepted; locators
+		// are written only after the installer sandbox is up. A 404 here is
+		// "not yet", not "gone", and the access log would WARN on every poll.
+		if skill.Status == types.SkillStatusInstalling {
+			c.Status(http.StatusNoContent)
+			return
+		}
 		_ = c.Error(apperrors.NewNotFoundError("this skill has no install transcript"))
 		return
 	}

--- a/internal/handler/sandbox_skill_test.go
+++ b/internal/handler/sandbox_skill_test.go
@@ -887,6 +887,19 @@ func TestSandboxSkillTranscriptWithoutLocatorsReturns404(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
 }
 
+func TestSandboxSkillTranscriptWhileInstallIsPreparingReturns204(t *testing.T) {
+	svc := &fakeSandboxSkillService{skills: map[string]*types.TenantSkillEntity{
+		"skill-1": {ID: "skill-1", SandboxConfigID: "cfg-a", Status: types.SkillStatusInstalling},
+	}}
+	router := newSkillTestRouter(NewSandboxSkillHandler(svc, &transcriptStreamManager{}))
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, transcriptRequest("cfg-a", "skill-1"))
+
+	require.Equal(t, http.StatusNoContent, w.Code, "body=%s", w.Body.String())
+	require.NotContains(t, w.Header().Get("Content-Type"), "event-stream")
+}
+
 // The skill lookup is this endpoint's authorization: an install transcript can
 // hold command output from another workspace's image build.
 func TestSandboxSkillTranscriptOfAnotherConfigReturns404(t *testing.T) {


### PR DESCRIPTION
## Summary
- Agent runs now advertise only skills installed in the sandbox image. The host `skills/preloaded` tree is no longer merged into the system prompt, so models stop listing skills (document analyzer, citation generator, etc.) that `execute_skill_script` cannot find in the image.
- Skill install copies files with one tar upload instead of per-file MakeDir/WriteFile, writes transcript locators before the seed, and returns 204 until those locators exist so the timeline does not 404-poll during setup.
- After install starts, the skills list scrolls to the new row. The timeline waits for locators instead of spinning on `/transcript`.

## Test plan
- [ ] Ask an agent with `skills_selection_mode=all` “我现在有哪些 Skill”; the reply should match the sandbox Skills menu, not host preloaded names like 文档分析器 / 引用生成器.
- [ ] Install a multi-file skill (e.g. `tencent-docs`); progress should move past seeding without minutes of `12/56`, and the install timeline should show a waiting state rather than a 404 spinner.
- [ ] After clicking install, the new skill row should scroll into view and briefly highlight.
- [ ] Server logs should not WARN on `GET .../skills/{id}/transcript` every second while files are still seeding, and should not log `Unknown tool: shell_exec` during install-mode tool registration.