### PR TITLE
fix(sandbox): hide Cube skill snapshots from the template catalog

### DIFF
--- a/internal/sandbox/cube_remote_client.go
+++ b/internal/sandbox/cube_remote_client.go
@@ -149,8 +149,16 @@ func (c *CubeRemoteClient) ListTemplates(ctx context.Context) ([]RemoteTemplate,
 	if err != nil {
 		return nil, normalizeCubeError("ListTemplates", err)
 	}
+	// Cube stores snapshots in the same template store that GET /templates
+	// returns, so skill-image snapshots would otherwise show up in the
+	// settings "pick a base template" step. Subtract them; E2B's catalog
+	// already keeps the two lists apart.
+	snapshotIDs := c.cubeSnapshotIDsForCatalog(ctx)
 	result := make([]RemoteTemplate, 0, len(items))
 	for _, item := range items {
+		if cubeTemplateIsSnapshot(item.TemplateID, snapshotIDs) {
+			continue
+		}
 		name := strings.TrimSpace(item.Name)
 		// Cube only reports a name when the template carries an alias, so fall
 		// back to the image before falling back to the opaque ID: recognising
@@ -175,6 +183,36 @@ func (c *CubeRemoteClient) ListTemplates(ctx context.Context) ([]RemoteTemplate,
 		})
 	}
 	return result, nil
+}
+
+// cubeSnapshotIDsForCatalog lists snapshot IDs so ListTemplates can hide them.
+// A listing failure must not fail the catalog: the settings UI still needs
+// real templates, and cubeTemplateIsSnapshot still drops the snap- prefix.
+func (c *CubeRemoteClient) cubeSnapshotIDsForCatalog(ctx context.Context) map[string]struct{} {
+	refs, err := c.ListSnapshots(ctx, "")
+	if err != nil {
+		logger.Warnf(ctx, "cube ListTemplates: listing snapshots to exclude them failed: %v", err)
+		return nil
+	}
+	out := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		if id := strings.TrimSpace(ref.ID); id != "" {
+			out[id] = struct{}{}
+		}
+	}
+	return out
+}
+
+func cubeTemplateIsSnapshot(templateID string, snapshotIDs map[string]struct{}) bool {
+	id := strings.TrimSpace(templateID)
+	if id == "" {
+		return false
+	}
+	if strings.HasPrefix(strings.ToLower(id), "snap-") {
+		return true
+	}
+	_, ok := snapshotIDs[id]
+	return ok
 }
 
 // EnsureStandardTemplate makes the cluster hold exactly one WeKnora template.

--- a/internal/sandbox/cube_template_catalog_test.go
+++ b/internal/sandbox/cube_template_catalog_test.go
@@ -12,9 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newCubeTemplateClient points a CubeRemoteClient at a bare template-API stub.
-// The full cubeMockServer models sandboxes rather than the template catalog,
-// and these tests only need the three /templates routes.
+// newCubeTemplateClient points a CubeRemoteClient at a bare catalog-API stub.
+// The full cubeMockServer models sandboxes rather than the template catalog.
 func newCubeTemplateClient(t *testing.T, handler http.HandlerFunc) *CubeRemoteClient {
 	t.Helper()
 	server := httptest.NewServer(handler)
@@ -34,6 +33,10 @@ func newCubeTemplateClient(t *testing.T, handler http.HandlerFunc) *CubeRemoteCl
 // our own template unrecognisable and every catalog refresh build another one.
 func TestCubeRemoteClientListTemplatesRecognisesStandardByImage(t *testing.T) {
 	client := newCubeTemplateClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/snapshots" {
+			writeJSON(w, http.StatusOK, []map[string]any{})
+			return
+		}
 		require.Equal(t, "/templates", r.URL.Path)
 		writeJSON(w, http.StatusOK, []map[string]any{
 			{
@@ -61,19 +64,118 @@ func TestCubeRemoteClientListTemplatesRecognisesStandardByImage(t *testing.T) {
 }
 
 func TestCubeRemoteClientListTemplatesSurfacesLastError(t *testing.T) {
-	client := newCubeTemplateClient(t, func(w http.ResponseWriter, _ *http.Request) {
-		writeJSON(w, http.StatusOK, []map[string]any{{
+	client := newCubeTemplateClient(t, cubeCatalogHandler(
+		[]map[string]any{{
 			"templateID": "tpl-broken",
 			"status":     "FAILED",
 			"imageInfo":  DefaultDockerImage,
 			"lastError":  "pull access denied for wechatopenai/weknora-sandbox",
-		}})
-	})
+		}},
+		nil,
+	))
 
 	templates, err := client.ListTemplates(context.Background())
 	require.NoError(t, err)
 	require.Len(t, templates, 1)
 	require.Equal(t, "pull access denied for wechatopenai/weknora-sandbox", templates[0].Error)
+}
+
+// Cube stores snapshots in the template store. The settings step is for
+// picking a base template, so snap- IDs must not appear even if GET
+// /snapshots is empty or missing.
+func TestCubeRemoteClientListTemplatesHidesSnapPrefixedIDs(t *testing.T) {
+	client := newCubeTemplateClient(t, cubeCatalogHandler(
+		[]map[string]any{
+			{
+				"templateID": "tpl-weknora",
+				"name":       "weknora",
+				"status":     "READY",
+			},
+			{
+				"templateID": "snap-1546901f7e5e40bdb8794c78",
+				"aliases":    []string{"weknora-sk-c838ac20-g2"},
+				"status":     "READY",
+			},
+			{
+				"templateID": "SNAP-uppercase",
+				"status":     "READY",
+			},
+		},
+		nil,
+	))
+
+	templates, err := client.ListTemplates(context.Background())
+	require.NoError(t, err)
+	require.Len(t, templates, 1)
+	require.Equal(t, "tpl-weknora", templates[0].ID)
+}
+
+// Snapshot IDs that do not use the snap- prefix still belong to GET
+// /snapshots, and must not be offered as a base template.
+func TestCubeRemoteClientListTemplatesHidesListedSnapshots(t *testing.T) {
+	client := newCubeTemplateClient(t, cubeCatalogHandler(
+		[]map[string]any{
+			{"templateID": "tpl-weknora", "name": "weknora", "status": "READY"},
+			{"templateID": "abc123unprefixed", "aliases": []string{"weknora-sk-cfg-g1"}, "status": "READY"},
+		},
+		[]map[string]any{
+			{"snapshotID": "abc123unprefixed", "names": []string{"weknora-sk-cfg-g1"}},
+		},
+	))
+
+	templates, err := client.ListTemplates(context.Background())
+	require.NoError(t, err)
+	require.Len(t, templates, 1)
+	require.Equal(t, "tpl-weknora", templates[0].ID)
+}
+
+func TestCubeRemoteClientListTemplatesKeepsTemplatesWhenSnapshotListFails(t *testing.T) {
+	client := newCubeTemplateClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/templates":
+			writeJSON(w, http.StatusOK, []map[string]any{
+				{"templateID": "tpl-weknora", "status": "READY"},
+				{"templateID": "snap-orphan", "status": "READY"},
+			})
+		case "/snapshots":
+			http.Error(w, "unavailable", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	templates, err := client.ListTemplates(context.Background())
+	require.NoError(t, err)
+	require.Len(t, templates, 1)
+	require.Equal(t, "tpl-weknora", templates[0].ID)
+}
+
+func TestCubeTemplateIsSnapshot(t *testing.T) {
+	listed := map[string]struct{}{"listed-id": {}}
+	require.True(t, cubeTemplateIsSnapshot("snap-1", nil))
+	require.True(t, cubeTemplateIsSnapshot("SNAP-1", nil))
+	require.True(t, cubeTemplateIsSnapshot("listed-id", listed))
+	require.False(t, cubeTemplateIsSnapshot("tpl-weknora", listed))
+	require.False(t, cubeTemplateIsSnapshot("", listed))
+}
+
+func cubeCatalogHandler(templates, snapshots []map[string]any) http.HandlerFunc {
+	if templates == nil {
+		templates = []map[string]any{}
+	}
+	if snapshots == nil {
+		snapshots = []map[string]any{}
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/templates" && r.Method == http.MethodGet:
+			writeJSON(w, http.StatusOK, templates)
+		case r.URL.Path == "/snapshots" && r.Method == http.MethodGet:
+			writeJSON(w, http.StatusOK, snapshots)
+		default:
+			http.NotFound(w, r)
+		}
+	}
 }
 
 // The bug this guards: an unnamed WeKnora template was invisible to the


### PR DESCRIPTION
## Summary
- Cube stores skill snapshots in the same template store that `GET /templates` returns, so generations like `weknora-sk-…-g2` (`snap-*`) showed up in the sandbox settings template picker.
- `ListTemplates` now subtracts `GET /snapshots` (and still drops `snap-` IDs if that listing fails) so the step only offers real base templates. E2B is unchanged.

## Test plan
- [x] `go test ./internal/sandbox/ -run TestCube`
- [ ] Open a Cube sandbox config → template step: only `tpl-*` entries (e.g. recommended `weknora`); no `weknora-sk-…` / `snap-*` rows
- [ ] Confirm an E2B config's template step is unchanged
- [ ] After installing a skill on Cube, refresh the template step: the new snapshot still does not appear