### PR TITLE
fix(agent): clamp LLMCallTimeout into a sane 10s-3600s range

### DIFF
--- a/internal/agent/const.go
+++ b/internal/agent/const.go
@@ -21,6 +21,15 @@ const (
 	// Can be overridden via AgentConfig.LLMCallTimeout.
 	defaultLLMCallTimeout = 120 * time.Second
 
+	// minLLMCallTimeout / maxLLMCallTimeout bound the effective per-call timeout
+	// when AgentConfig.LLMCallTimeout is set explicitly. Values below min can never
+	// survive network + first-token latency and almost always indicate operator
+	// error; values above max defeat the purpose of the per-call guard (a hung
+	// provider connection would pin a worker for hours). The max matches the
+	// frontend editor's upper bound (AgentEditorModal.vue, :max="3600").
+	minLLMCallTimeout = 10 * time.Second
+	maxLLMCallTimeout = 3600 * time.Second
+
 	// defaultToolExecTimeout is the default maximum time for a single tool execution.
 	// Prevents long-running tools (web_fetch, database_query) from hanging indefinitely.
 	defaultToolExecTimeout = 60 * time.Second
@@ -75,12 +84,24 @@ func isTransientError(err error) bool {
 	return false
 }
 
-// getLLMCallTimeout returns the configured LLM call timeout, falling back to default.
+// getLLMCallTimeout returns the configured LLM call timeout, falling back to
+// default. Explicitly configured values are clamped into
+// [minLLMCallTimeout, maxLLMCallTimeout] so a misconfiguration can neither
+// break every call (too short) nor silently disable the guard (too long);
+// values <= 0 keep the "use default" semantics. The comparison happens in
+// the seconds domain to avoid time.Duration overflow on absurd inputs.
 func (e *AgentEngine) getLLMCallTimeout() time.Duration {
-	if e.config.LLMCallTimeout > 0 {
-		return time.Duration(e.config.LLMCallTimeout) * time.Second
+	if e.config == nil || e.config.LLMCallTimeout <= 0 {
+		return defaultLLMCallTimeout
 	}
-	return defaultLLMCallTimeout
+	sec := e.config.LLMCallTimeout
+	if sec < int(minLLMCallTimeout/time.Second) {
+		return minLLMCallTimeout
+	}
+	if sec > int(maxLLMCallTimeout/time.Second) {
+		return maxLLMCallTimeout
+	}
+	return time.Duration(sec) * time.Second
 }
 
 // generateEventID generates a unique event ID with type suffix for better traceability

--- a/internal/agent/const_test.go
+++ b/internal/agent/const_test.go
@@ -4,10 +4,34 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestToolExecutionTimeout(t *testing.T) {
 	assert.Equal(t, 10*time.Minute+5*time.Second, toolExecutionTimeout("shell_exec"))
 	assert.Equal(t, 60*time.Second, toolExecutionTimeout("web_fetch"))
+}
+
+func TestGetLLMCallTimeout(t *testing.T) {
+	cases := []struct {
+		name     string
+		config   *types.AgentConfig
+		expected time.Duration
+	}{
+		{"nil config falls back to default", nil, defaultLLMCallTimeout},
+		{"zero falls back to default", &types.AgentConfig{LLMCallTimeout: 0}, defaultLLMCallTimeout},
+		{"negative falls back to default", &types.AgentConfig{LLMCallTimeout: -5}, defaultLLMCallTimeout},
+		{"below minimum clamps up", &types.AgentConfig{LLMCallTimeout: 1}, minLLMCallTimeout},
+		{"at minimum passes through", &types.AgentConfig{LLMCallTimeout: 10}, minLLMCallTimeout},
+		{"in range passes through", &types.AgentConfig{LLMCallTimeout: 120}, 120 * time.Second},
+		{"at maximum passes through", &types.AgentConfig{LLMCallTimeout: 3600}, maxLLMCallTimeout},
+		{"above maximum clamps down", &types.AgentConfig{LLMCallTimeout: 99999}, maxLLMCallTimeout},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &AgentEngine{config: tc.config}
+			assert.Equal(t, tc.expected, e.getLLMCallTimeout())
+		})
+	}
 }

--- a/internal/models/chat/transport.go
+++ b/internal/models/chat/transport.go
@@ -14,8 +14,8 @@ import (
 // LLM 调用超时配置。仅作为"上层未设置 deadline 时"的兜底，避免 hung 请求
 // 永久阻塞 worker。如果上层 ctx 已经设置了 deadline（无论比默认更短还是更长），
 // 都会原样尊重，不再叠加默认超时。可通过环境变量覆盖：
-//   - WEKNORA_LLM_CHAT_TIMEOUT_SECONDS    非流式调用兜底超时（默认 600s）
-//   - WEKNORA_LLM_STREAM_TIMEOUT_SECONDS  流式调用兜底超时（默认 1800s）
+//   - WEKNORA_LLM_CHAT_TIMEOUT_SECONDS    非流式调用兜底超时（默认 300s）
+//   - WEKNORA_LLM_STREAM_TIMEOUT_SECONDS  流式调用兜底超时（默认 600s）
 var (
 	defaultChatTimeout   = envDurationSeconds("WEKNORA_LLM_CHAT_TIMEOUT_SECONDS", 300*time.Second)
 	defaultStreamTimeout = envDurationSeconds("WEKNORA_LLM_STREAM_TIMEOUT_SECONDS", 600*time.Second)


### PR DESCRIPTION
## Description

`AgentEngine.getLLMCallTimeout()` (`internal/agent/const.go`) previously passed any positive `AgentConfig.LLMCallTimeout` straight through to `context.WithTimeout` in `internal/agent/think.go`. Misconfigured values caused two failure modes:

- **Too small** (e.g. `1`): every LLM call times out after ~1s, before network + first-token latency can possibly complete, so the agent can never produce an answer.
- **Too large** (e.g. `86400`): the per-call guard that prevents a hung provider connection from pinning a worker for the whole pipeline is silently disabled.

This PR clamps the effective per-call timeout into `[10s, 3600s]` at the single consumption point (`getLLMCallTimeout`), so every configuration source — the agent API, custom-agent YAML, the global `WEKNORA_AGENT_LLM_TIMEOUT` env override, and the frontend form — inherits the protection regardless of where the value was written. The max matches the frontend editor's existing upper bound (`AgentEditorModal.vue`, `:max="3600"`); values `<= 0` keep the existing "use default (120s)" semantics. The comparison runs in the seconds domain to avoid `time.Duration` overflow on absurd inputs, and a nil-config guard is added as drive-by defense.

Also fixes a stale doc comment in `internal/models/chat/transport.go`: the chat/stream fallback defaults are 300s/600s (as implemented), not 600s/1800s (as documented).

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

- Refs #916 — introduced the customizable per-agent LLM call timeout this PR hardens.
- Related: #1801 — that issue asked for a configurable LLM stream timeout (implemented in main as `WEKNORA_LLM_STREAM_TIMEOUT_SECONDS`, default 600s); the doc-comment fix in this PR corrects the documented defaults for exactly those env vars. This PR does not implement #1801's remaining asks (descriptive SSE error on timeout, near-threshold warning logs).

## Testing

Added `TestGetLLMCallTimeout` in `internal/agent/const_test.go` — table-driven, 8 cases: nil config, zero, negative, below-minimum clamp, at-minimum, in-range pass-through, at-maximum, above-maximum clamp.

- [x] `git diff --check upstream/main...HEAD` passes
- No local Go toolchain was available on the authoring machine (`go: command not found`), so the following are deferred to CI on this PR:
  - `go test ./internal/agent/ -run TestGetLLMCallTimeout -count=1`
  - `golangci-lint run --new-from-rev=origin/main ./...`
  - `gofmt` verification (edits follow existing tab-indented style)

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted (verified visually; CI gate remains)
- [ ] Targeted tests for the changed packages/components pass — deferred to CI (see Testing)
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`) — deferred to CI (see Testing)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (inline doc comments corrected)
- [ ] Breaking changes are clearly called out in the description above — N/A, no breaking changes
