### PR TITLE
fix(datasource): honor conflict_strategy "skip" during sync ingest

### DIFF
--- a/internal/application/service/datasource_service.go
+++ b/internal/application/service/datasource_service.go
@@ -936,6 +936,12 @@ func (s *DataSourceService) applyFetchedItem(
 	if err != nil {
 		var dupErr *types.DuplicateKnowledgeError
 		switch {
+		case errors.Is(err, errSkipExisting):
+			// "Skip existing" conflict strategy: the KB already holds this
+			// item, keep it untouched (no re-download, no re-parse).
+			logger.Infof(ctx, "item %q (external_id=%s) already exists and conflict strategy is skip; keeping existing version",
+				item.Title, item.ExternalID)
+			result.Skipped++
 		case errors.As(err, &dupErr):
 			// Duplicate file/URL is not a failure — count as skipped.
 			logger.Infof(ctx, "item %q (external_id=%s) already exists, skipping", item.Title, item.ExternalID)
@@ -1225,8 +1231,17 @@ func (s *DataSourceService) validateDataSourceConfig(ctx context.Context, ds *ty
 	return connector.Validate(ctx, config)
 }
 
+// errSkipExisting signals that an item with the same external_id is already
+// in the knowledge base and the data source's conflict strategy is "skip":
+// the existing knowledge is kept untouched (no re-ingest). Counted as a
+// skipped item, not a failure.
+var errSkipExisting = errors.New("item already exists; conflict strategy is skip")
+
 // ingestItem writes a single FetchedItem into the knowledge base.
-// If a knowledge item with the same external_id already exists, it is deleted first (update = delete + re-create).
+// If a knowledge item with the same external_id already exists, the data
+// source's conflict strategy decides: "overwrite" (default) deletes it first
+// (update = delete + re-create); "skip" keeps it untouched and returns
+// errSkipExisting.
 //
 // Routing logic:
 //   - Has Content bytes → CreateKnowledgeFromFile (走完整的文档解析 pipeline)
@@ -1267,6 +1282,12 @@ func (s *DataSourceService) ingestItem(ctx context.Context, ds *types.DataSource
 			logger.Warnf(ctx, "failed to check existing knowledge for external_id=%s: %v", item.ExternalID, err)
 			// Non-fatal: proceed with creation (may produce duplicate)
 		} else if existing != nil {
+			if ds.ConflictStrategy == types.ConflictStrategySkip {
+				// "Skip existing" strategy: keep the current KB version.
+				// Note this also skips genuine source-side updates — switch
+				// the strategy to overwrite to propagate changed content.
+				return false, errSkipExisting
+			}
 			logger.Infof(ctx, "found existing knowledge %s for external_id=%s, deleting for update", existing.ID, item.ExternalID)
 			if err := s.knowledgeService.DeleteKnowledge(ctx, existing.ID); err != nil {
 				logger.Warnf(ctx, "failed to delete existing knowledge %s: %v", existing.ID, err)

--- a/internal/application/service/datasource_service_test.go
+++ b/internal/application/service/datasource_service_test.go
@@ -501,6 +501,83 @@ func TestIngestItem_URLCreationAttachesDataSourceMetadata(t *testing.T) {
 	assert.Equal(t, "url:1", repo.metadataUpdates[0]["external_id"])
 }
 
+// TestIngestItem_ConflictStrategySkipKeepsExisting verifies the "skip"
+// conflict strategy: when an item with the same external_id already exists
+// in the KB, it is kept untouched — no deletion, no re-ingest.
+func TestIngestItem_ConflictStrategySkipKeepsExisting(t *testing.T) {
+	ds := &types.DataSource{
+		ID: "ds-1", TenantID: 1, KnowledgeBaseID: "kb-1",
+		ConflictStrategy: types.ConflictStrategySkip,
+	}
+	repo := &deletionLookupKnowledgeRepo{knowledge: &types.Knowledge{ID: "existing-1"}}
+	ks := &sweepFakeKS{repo: repo}
+	svc := &DataSourceService{knowledgeService: ks}
+
+	isUpdate, err := svc.ingestItem(context.Background(), ds, &types.FetchedItem{
+		ExternalID: "ext-1",
+		Title:      "doc.pdf",
+		Content:    []byte("body"),
+		FileName:   "doc.pdf",
+	}, nil)
+
+	assert.ErrorIs(t, err, errSkipExisting)
+	assert.False(t, isUpdate)
+	assert.Empty(t, ks.deleted, "skip must keep the existing knowledge untouched")
+	assert.Empty(t, repo.hardDeleted, "skip must not hard-delete the existing knowledge")
+}
+
+// TestIngestItem_ConflictStrategyOverwriteReplacesExisting verifies the
+// default "overwrite" strategy: an existing item is deleted and re-ingested
+// (counted as an update).
+func TestIngestItem_ConflictStrategyOverwriteReplacesExisting(t *testing.T) {
+	ds := &types.DataSource{
+		ID: "ds-1", TenantID: 1, KnowledgeBaseID: "kb-1",
+		ConflictStrategy: types.ConflictStrategyOverwrite,
+	}
+	repo := &deletionLookupKnowledgeRepo{knowledge: &types.Knowledge{ID: "existing-1"}}
+	ks := &sweepFakeKS{repo: repo}
+	svc := &DataSourceService{knowledgeService: ks}
+
+	isUpdate, err := svc.ingestItem(context.Background(), ds, &types.FetchedItem{
+		ExternalID: "ext-1",
+		Title:      "doc.pdf",
+		Content:    []byte("body"),
+		FileName:   "doc.pdf",
+	}, nil)
+
+	require.NoError(t, err)
+	assert.True(t, isUpdate)
+	assert.Equal(t, []string{"existing-1"}, ks.deleted)
+	assert.Equal(t, []string{"existing-1"}, repo.hardDeleted)
+}
+
+// TestApplyFetchedItem_ConflictStrategySkipCountsSkipped verifies the sync
+// counters: a skip-strategy item already present in the KB is counted as
+// Skipped, never as Failed or Created.
+func TestApplyFetchedItem_ConflictStrategySkipCountsSkipped(t *testing.T) {
+	ds := &types.DataSource{
+		ID: "ds-1", TenantID: 1, KnowledgeBaseID: "kb-1",
+		ConflictStrategy: types.ConflictStrategySkip,
+	}
+	repo := &deletionLookupKnowledgeRepo{knowledge: &types.Knowledge{ID: "existing-1"}}
+	ks := &sweepFakeKS{repo: repo}
+	svc := &DataSourceService{knowledgeService: ks}
+
+	result := &types.SyncResult{}
+	svc.applyFetchedItem(context.Background(), ds, &types.FetchedItem{
+		ExternalID: "ext-1",
+		Title:      "doc.pdf",
+		Content:    []byte("body"),
+		FileName:   "doc.pdf",
+	}, nil, result)
+
+	assert.Equal(t, 1, result.Skipped)
+	assert.Equal(t, 0, result.Failed)
+	assert.Equal(t, 0, result.Created)
+	assert.Equal(t, 0, result.Updated)
+	assert.Empty(t, result.Errors)
+}
+
 func TestProcessSync_SyncDeletionsDeletesMatchingKnowledge(t *testing.T) {
 	h := newSyncDeletionHarness(t, true, "ds-delete-characterization", "log-delete-characterization", nil, nil)
 	updated, err := h.run(t)


### PR DESCRIPTION
The data source editor exposes a conflict strategy (overwrite / skip existing) and the value is persisted on the data source, but the sync ingest path never read it: items whose external_id already exists in the knowledge base were always deleted and re-ingested, even when the strategy was set to "skip existing". A full sync therefore re-parsed every document regardless of the chosen strategy.

- ingestItem returns errSkipExisting when the strategy is "skip" and a knowledge item with the same external_id (scoped to the data source) already exists; the existing item is kept untouched
- applyFetchedItem counts such items as Skipped (not Failed/Created)
- note: "skip" also skips genuine source-side updates — switch to overwrite to propagate changed content

<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

## Type of Change
<!-- Check applicable items -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->

## Checklist
- [ ] `git diff --check origin/main...HEAD` passes
- [ ] Changed source files are formatted
- [ ] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [ ] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
