### PR TITLE
Fix/document list pagination

### DIFF
--- a/frontend/src/hooks/useKnowledgeBase.ts
+++ b/frontend/src/hooks/useKnowledgeBase.ts
@@ -57,17 +57,17 @@ export default function (knowledgeBaseId?: string) {
       folder_recursive?: boolean;
     } = { page: 1, page_size: 35 },
     kbId?: string,
-  ): Promise<void> => {
+  ): Promise<boolean> => {
     const targetKbId = kbId || knowledgeBaseId;
-    if (!targetKbId) return Promise.resolve();
+    if (!targetKbId) return Promise.resolve(false);
     const requestGeneration = query.page === 1 ? ++knowledgeListGeneration : knowledgeListGeneration;
 
     return listKnowledgeFiles(targetKbId, query)
       .then((result: any) => {
-        if (requestGeneration !== knowledgeListGeneration) return;
+        if (requestGeneration !== knowledgeListGeneration) return false;
 
         const currentRouteKbId = (route.params as any)?.kbId as string | undefined;
-        if (currentRouteKbId && currentRouteKbId !== targetKbId) return;
+        if (currentRouteKbId && currentRouteKbId !== targetKbId) return false;
 
         const { data, total: totalResult } = result;
     const cardList_ = data.map((item: any) => {
@@ -93,8 +93,9 @@ export default function (knowledgeBaseId?: string) {
           cardList.value.push(...cardList_);
         }
         total.value = totalResult;
+        return true;
       })
-      .catch(() => {});
+      .catch(() => false);
   };
   const delKnowledge = (index: number, item: any, onSuccess?: () => void) => {
     cardList.value[index].isMore = false;

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -63,6 +63,12 @@ import {
 import { listMoveTargets, moveKnowledge, getKnowledgeMoveProgress } from '@/api/knowledge-base';
 import { resolveKnowledgeDownloadFileName } from './knowledgeDownloadFileName';
 import {
+  beginDocumentPageRequest,
+  createDocumentPaginationState,
+  resetDocumentPagination,
+  settleDocumentPageRequest,
+} from './documentPagination';
+import {
   buildUploadFileName,
   canMoveFolderTo,
   childFolders,
@@ -402,11 +408,17 @@ const onCardMoreVisibleChange = (visible: boolean, item: KnowledgeCard) => {
 };
 let isCardDetails = ref(false);
 let timeout: ReturnType<typeof setTimeout> | null = null;
-let knowledgeScroll = ref()
-let page = 1;
+const knowledgeScroll = ref<HTMLElement | null>(null);
 let pageSize = 35;
-let scrollLoading = false;
-const resetPage = () => { page = 1; scrollLoading = false; };
+const documentLoadSentinel = ref<HTMLElement | null>(null);
+const documentPagination = createDocumentPaginationState();
+const documentPaginationLoadFailed = ref(false);
+let documentPaginationObserver: IntersectionObserver | null = null;
+const DOCUMENT_PAGE_PREFETCH_PX = 120;
+const resetPage = () => {
+  resetDocumentPagination(documentPagination);
+  documentPaginationLoadFailed.value = false;
+};
 
 // Move state — inline in card menu
 const moveMenuMode = ref<'normal' | 'targets' | 'confirm'>('normal');
@@ -756,23 +768,28 @@ const getTagName = (tagId?: string | number) => {
   return tagMap.value[key]?.name || '';
 };
 
-const loadKnowledgeFiles = (kbIdValue: string): Promise<void> => {
-  if (!kbIdValue) return Promise.resolve();
+const loadKnowledgeFiles = async (kbIdValue: string): Promise<void> => {
+  if (!kbIdValue) return;
+  resetPage();
   if (!isFAQ.value) {
     docListLoading.value = true;
   }
-  return getKnowled(
-    {
+  let loaded = false;
+  try {
+    loaded = await getKnowled({
       page: 1,
       page_size: pageSize,
       ...filterParams.value,
-    },
-    kbIdValue,
-  ).finally(() => {
+    }, kbIdValue);
+  } finally {
     if (isCurrentKb(kbIdValue) && !isFAQ.value) {
       docListLoading.value = false;
     }
-  });
+  }
+  if (loaded && isCurrentKb(kbIdValue) && !isFAQ.value) {
+    await nextTick();
+    void loadNextDocumentPageIfNeeded();
+  }
 };
 
 const isCurrentKb = (targetKbId: string) => targetKbId === kbId.value;
@@ -1117,6 +1134,10 @@ watch(() => kbId.value, (newKbId, oldKbId) => {
   loadKnowledgeBaseInfo(newKbId);
 }, { immediate: true });
 
+watch([kbId, isFAQ], () => {
+  void nextTick(setupDocumentPaginationObserver);
+});
+
 watch(selectedTagIds, (newVal, oldVal) => {
   if (oldVal === undefined) return;
   if (kbId.value) {
@@ -1281,6 +1302,7 @@ const handleOpenKnowledgeEvent = (e: Event) => {
 onMounted(() => {
   loadKnowledgeList();
   editorResources.ensureParserEngines();
+  void nextTick(setupDocumentPaginationObserver);
 
   window.addEventListener('knowledgeFileUploaded', handleFileUploaded as EventListener);
   window.addEventListener('openURLImportDialog', handleOpenURLImportDialog as EventListener);
@@ -1289,6 +1311,8 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
+  documentPaginationObserver?.disconnect();
+  documentPaginationObserver = null;
   window.removeEventListener('knowledgeFileUploaded', handleFileUploaded as EventListener);
   window.removeEventListener('openURLImportDialog', handleOpenURLImportDialog as EventListener);
   window.removeEventListener('weknora:knowledge-file-drop', handleKnowledgeFileDrop as EventListener);
@@ -1958,28 +1982,71 @@ const submitReparse = async (id: string, processConfig?: KnowledgeProcessOverrid
   }
 };
 
-const handleScroll = () => {
-  if (isFAQ.value) return;
-  if (docListLoading.value) return;
-  if (scrollLoading) return;
+function documentPaginationViewport() {
+  const element = knowledgeScroll.value as HTMLElement | undefined;
+  if (!element) return null;
+  return {
+    loadedCount: cardList.value.length,
+    totalCount: total.value,
+    pageSize,
+    scrollTop: element.scrollTop,
+    scrollHeight: element.scrollHeight,
+    clientHeight: element.clientHeight,
+    threshold: DOCUMENT_PAGE_PREFETCH_PX,
+  };
+}
+
+async function loadNextDocumentPageIfNeeded(force = false) {
+  if (isFAQ.value || docListLoading.value) return;
   const currentKbId = kbId.value;
   if (!currentKbId) return;
-  const element = knowledgeScroll.value;
-  if (element) {
-    let pageNum = Math.ceil(total.value / pageSize)
-    const { scrollTop, scrollHeight, clientHeight } = element;
-    if (scrollTop + clientHeight >= scrollHeight - 10) {
-      if (cardList.value.length < total.value && page < pageNum) {
-        page++;
-        scrollLoading = true;
-        getKnowled({ page, page_size: pageSize, ...filterParams.value }, currentKbId).finally(() => {
-          if (isCurrentKb(currentKbId)) {
-            scrollLoading = false;
-          }
-        });
-      }
-    }
+
+  const viewport = documentPaginationViewport();
+  if (!viewport) return;
+  const request = beginDocumentPageRequest(documentPagination, viewport, force);
+  if (!request) return;
+
+  documentPaginationLoadFailed.value = false;
+  const loaded = await getKnowled(
+    { page: request.page, page_size: pageSize, ...filterParams.value },
+    currentKbId,
+  );
+  const result = settleDocumentPageRequest(documentPagination, request, loaded && isCurrentKb(currentKbId));
+  if (result === 'stale') return;
+  if (result === 'failed') {
+    documentPaginationLoadFailed.value = true;
+    return;
   }
+
+  // 宽屏下新增一页后仍可能没有滚动条；继续检查，直到内容可滚动或全部加载完。
+  await nextTick();
+  if (isCurrentKb(currentKbId)) {
+    void loadNextDocumentPageIfNeeded();
+  }
+}
+
+function setupDocumentPaginationObserver() {
+  documentPaginationObserver?.disconnect();
+  documentPaginationObserver = null;
+  if (typeof IntersectionObserver === 'undefined') return;
+
+  const root = knowledgeScroll.value as HTMLElement | undefined;
+  const sentinel = documentLoadSentinel.value;
+  if (!root || !sentinel) return;
+
+  documentPaginationObserver = new IntersectionObserver((entries) => {
+    if (entries.some((entry) => entry.isIntersecting)) {
+      void loadNextDocumentPageIfNeeded(true);
+    }
+  }, {
+    root,
+    rootMargin: `0px 0px ${DOCUMENT_PAGE_PREFETCH_PX}px 0px`,
+  });
+  documentPaginationObserver.observe(sentinel);
+}
+
+const handleScroll = () => {
+  void loadNextDocumentPageIfNeeded();
 };
 const getDoc = (page: number) => {
   getfDetails(details.id, page)
@@ -2671,6 +2738,12 @@ async function createNewSession(value: string): Promise<void> {
                     <EmptyKnowledge v-else />
                   </div>
                 </template>
+                <div ref="documentLoadSentinel" class="doc-pagination-sentinel" aria-live="polite">
+                  <t-button v-if="documentPaginationLoadFailed && cardList.length < total" variant="text" size="small"
+                    @click="loadNextDocumentPageIfNeeded(true)">
+                    {{ $t('common.retry') }}
+                  </t-button>
+                </div>
               </div>
               <div class="doc-batch-bar-anchor" v-show="batchMode || selectedIds.size > 0">
                 <DocumentBatchBar :count="selectedIds.size" :delete-loading="batchDeleting"
@@ -3419,6 +3492,14 @@ async function createNewSession(value: string): Promise<void> {
   &.is-marquee-active {
     cursor: crosshair;
   }
+}
+
+.doc-pagination-sentinel {
+  display: flex;
+  min-height: 1px;
+  align-items: center;
+  justify-content: center;
+  padding-top: 8px;
 }
 
 .doc-marquee-box {

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -62,12 +62,7 @@ import {
 } from './wikiStatusRefresh';
 import { listMoveTargets, moveKnowledge, getKnowledgeMoveProgress } from '@/api/knowledge-base';
 import { resolveKnowledgeDownloadFileName } from './knowledgeDownloadFileName';
-import {
-  beginDocumentPageRequest,
-  createDocumentPaginationState,
-  resetDocumentPagination,
-  settleDocumentPageRequest,
-} from './documentPagination';
+import { getNextDocumentPage } from './documentPagination';
 import {
   buildUploadFileName,
   canMoveFolderTo,
@@ -409,15 +404,10 @@ const onCardMoreVisibleChange = (visible: boolean, item: KnowledgeCard) => {
 let isCardDetails = ref(false);
 let timeout: ReturnType<typeof setTimeout> | null = null;
 const knowledgeScroll = ref<HTMLElement | null>(null);
-let pageSize = 35;
-const documentLoadSentinel = ref<HTMLElement | null>(null);
-const documentPagination = createDocumentPaginationState();
-const documentPaginationLoadFailed = ref(false);
-let documentPaginationObserver: IntersectionObserver | null = null;
-const DOCUMENT_PAGE_PREFETCH_PX = 120;
+const pageSize = 35;
+let documentLoadGeneration = 0;
 const resetPage = () => {
-  resetDocumentPagination(documentPagination);
-  documentPaginationLoadFailed.value = false;
+  documentLoadGeneration += 1;
 };
 
 // Move state — inline in card menu
@@ -754,13 +744,6 @@ function onTagEditConfirm(tagIds: string[]) {
     handleKnowledgeTagChange(tagEditTarget.value.id, tagIds);
   }
 }
-const getPageSize = () => {
-  const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
-  const itemHeight = 148;
-  let itemsInView = Math.floor(viewportHeight / itemHeight) * 5;
-  pageSize = Math.max(35, itemsInView);
-}
-getPageSize()
 // 直接调用 API 获取知识库文件列表
 const getTagName = (tagId?: string | number) => {
   if (!tagId && tagId !== 0) return '';
@@ -771,13 +754,15 @@ const getTagName = (tagId?: string | number) => {
 const loadKnowledgeFiles = async (kbIdValue: string): Promise<void> => {
   if (!kbIdValue) return;
   resetPage();
+  const loadGeneration = documentLoadGeneration;
   if (!isFAQ.value) {
     docListLoading.value = true;
   }
+  let page = 1;
   let loaded = false;
   try {
     loaded = await getKnowled({
-      page: 1,
+      page,
       page_size: pageSize,
       ...filterParams.value,
     }, kbIdValue);
@@ -786,9 +771,18 @@ const loadKnowledgeFiles = async (kbIdValue: string): Promise<void> => {
       docListLoading.value = false;
     }
   }
-  if (loaded && isCurrentKb(kbIdValue) && !isFAQ.value) {
-    await nextTick();
-    void loadNextDocumentPageIfNeeded();
+
+  // 每批固定加载 35 个文件，成功后继续下一批，直到当前筛选结果全部加载完毕。
+  while (loaded && loadGeneration === documentLoadGeneration && isCurrentKb(kbIdValue) && !isFAQ.value) {
+    const nextPage = getNextDocumentPage(cardList.value.length, total.value, page, pageSize);
+    if (!nextPage) return;
+
+    loaded = await getKnowled({
+      page: nextPage,
+      page_size: pageSize,
+      ...filterParams.value,
+    }, kbIdValue);
+    if (loaded) page = nextPage;
   }
 };
 
@@ -1134,10 +1128,6 @@ watch(() => kbId.value, (newKbId, oldKbId) => {
   loadKnowledgeBaseInfo(newKbId);
 }, { immediate: true });
 
-watch([kbId, isFAQ], () => {
-  void nextTick(setupDocumentPaginationObserver);
-});
-
 watch(selectedTagIds, (newVal, oldVal) => {
   if (oldVal === undefined) return;
   if (kbId.value) {
@@ -1302,7 +1292,6 @@ const handleOpenKnowledgeEvent = (e: Event) => {
 onMounted(() => {
   loadKnowledgeList();
   editorResources.ensureParserEngines();
-  void nextTick(setupDocumentPaginationObserver);
 
   window.addEventListener('knowledgeFileUploaded', handleFileUploaded as EventListener);
   window.addEventListener('openURLImportDialog', handleOpenURLImportDialog as EventListener);
@@ -1311,8 +1300,6 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-  documentPaginationObserver?.disconnect();
-  documentPaginationObserver = null;
   window.removeEventListener('knowledgeFileUploaded', handleFileUploaded as EventListener);
   window.removeEventListener('openURLImportDialog', handleOpenURLImportDialog as EventListener);
   window.removeEventListener('weknora:knowledge-file-drop', handleKnowledgeFileDrop as EventListener);
@@ -1982,72 +1969,6 @@ const submitReparse = async (id: string, processConfig?: KnowledgeProcessOverrid
   }
 };
 
-function documentPaginationViewport() {
-  const element = knowledgeScroll.value as HTMLElement | undefined;
-  if (!element) return null;
-  return {
-    loadedCount: cardList.value.length,
-    totalCount: total.value,
-    pageSize,
-    scrollTop: element.scrollTop,
-    scrollHeight: element.scrollHeight,
-    clientHeight: element.clientHeight,
-    threshold: DOCUMENT_PAGE_PREFETCH_PX,
-  };
-}
-
-async function loadNextDocumentPageIfNeeded(force = false) {
-  if (isFAQ.value || docListLoading.value) return;
-  const currentKbId = kbId.value;
-  if (!currentKbId) return;
-
-  const viewport = documentPaginationViewport();
-  if (!viewport) return;
-  const request = beginDocumentPageRequest(documentPagination, viewport, force);
-  if (!request) return;
-
-  documentPaginationLoadFailed.value = false;
-  const loaded = await getKnowled(
-    { page: request.page, page_size: pageSize, ...filterParams.value },
-    currentKbId,
-  );
-  const result = settleDocumentPageRequest(documentPagination, request, loaded && isCurrentKb(currentKbId));
-  if (result === 'stale') return;
-  if (result === 'failed') {
-    documentPaginationLoadFailed.value = true;
-    return;
-  }
-
-  // 宽屏下新增一页后仍可能没有滚动条；继续检查，直到内容可滚动或全部加载完。
-  await nextTick();
-  if (isCurrentKb(currentKbId)) {
-    void loadNextDocumentPageIfNeeded();
-  }
-}
-
-function setupDocumentPaginationObserver() {
-  documentPaginationObserver?.disconnect();
-  documentPaginationObserver = null;
-  if (typeof IntersectionObserver === 'undefined') return;
-
-  const root = knowledgeScroll.value as HTMLElement | undefined;
-  const sentinel = documentLoadSentinel.value;
-  if (!root || !sentinel) return;
-
-  documentPaginationObserver = new IntersectionObserver((entries) => {
-    if (entries.some((entry) => entry.isIntersecting)) {
-      void loadNextDocumentPageIfNeeded(true);
-    }
-  }, {
-    root,
-    rootMargin: `0px 0px ${DOCUMENT_PAGE_PREFETCH_PX}px 0px`,
-  });
-  documentPaginationObserver.observe(sentinel);
-}
-
-const handleScroll = () => {
-  void loadNextDocumentPageIfNeeded();
-};
 const getDoc = (page: number) => {
   getfDetails(details.id, page)
 };
@@ -2653,7 +2574,7 @@ async function createNewSession(value: string): Promise<void> {
                   'is-empty': !cardList.length && !currentChildFolders.length && !docListLoading,
                   'is-marquee-active': docMarqueeVisible,
                 }"
-                ref="knowledgeScroll" @scroll="handleScroll" @mousedown="onDocMarqueeMouseDown">
+                ref="knowledgeScroll" @mousedown="onDocMarqueeMouseDown">
                 <div v-if="docMarqueeVisible" class="doc-marquee-box"
                   :class="{ 'is-add': docMarqueeMode === 'add', 'is-subtract': docMarqueeMode === 'subtract' }"
                   :style="docMarqueeBoxStyle" aria-hidden="true" />
@@ -2738,12 +2659,6 @@ async function createNewSession(value: string): Promise<void> {
                     <EmptyKnowledge v-else />
                   </div>
                 </template>
-                <div ref="documentLoadSentinel" class="doc-pagination-sentinel" aria-live="polite">
-                  <t-button v-if="documentPaginationLoadFailed && cardList.length < total" variant="text" size="small"
-                    @click="loadNextDocumentPageIfNeeded(true)">
-                    {{ $t('common.retry') }}
-                  </t-button>
-                </div>
               </div>
               <div class="doc-batch-bar-anchor" v-show="batchMode || selectedIds.size > 0">
                 <DocumentBatchBar :count="selectedIds.size" :delete-loading="batchDeleting"
@@ -3492,14 +3407,6 @@ async function createNewSession(value: string): Promise<void> {
   &.is-marquee-active {
     cursor: crosshair;
   }
-}
-
-.doc-pagination-sentinel {
-  display: flex;
-  min-height: 1px;
-  align-items: center;
-  justify-content: center;
-  padding-top: 8px;
 }
 
 .doc-marquee-box {

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -404,7 +404,7 @@ const onCardMoreVisibleChange = (visible: boolean, item: KnowledgeCard) => {
 let isCardDetails = ref(false);
 let timeout: ReturnType<typeof setTimeout> | null = null;
 const knowledgeScroll = ref<HTMLElement | null>(null);
-const pageSize = 35;
+let pageSize = 35;
 let documentLoadGeneration = 0;
 const resetPage = () => {
   documentLoadGeneration += 1;
@@ -744,6 +744,13 @@ function onTagEditConfirm(tagIds: string[]) {
     handleKnowledgeTagChange(tagEditTarget.value.id, tagIds);
   }
 }
+const getPageSize = () => {
+  const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+  const itemHeight = 148;
+  let itemsInView = Math.floor(viewportHeight / itemHeight) * 5;
+  pageSize = Math.max(35, itemsInView);
+}
+getPageSize()
 // 直接调用 API 获取知识库文件列表
 const getTagName = (tagId?: string | number) => {
   if (!tagId && tagId !== 0) return '';
@@ -772,7 +779,7 @@ const loadKnowledgeFiles = async (kbIdValue: string): Promise<void> => {
     }
   }
 
-  // 每批固定加载 35 个文件，成功后继续下一批，直到当前筛选结果全部加载完毕。
+  // 每批加载完成后检查后端总数，仍有文件时继续请求下一页。
   while (loaded && loadGeneration === documentLoadGeneration && isCurrentKb(kbIdValue) && !isFAQ.value) {
     const nextPage = getNextDocumentPage(cardList.value.length, total.value, page, pageSize);
     if (!nextPage) return;

--- a/frontend/src/views/knowledge/documentPagination.test.ts
+++ b/frontend/src/views/knowledge/documentPagination.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  beginDocumentPageRequest,
+  createDocumentPaginationState,
+  resetDocumentPagination,
+  settleDocumentPageRequest,
+  shouldLoadNextDocumentPage,
+} from './documentPagination.ts'
+
+const viewport = {
+  loadedCount: 35,
+  totalCount: 90,
+  pageSize: 35,
+  scrollTop: 0,
+  scrollHeight: 600,
+  clientHeight: 600,
+}
+
+test('首批内容没有撑出滚动条时仍应继续加载下一页', () => {
+  assert.equal(shouldLoadNextDocumentPage(viewport), true)
+})
+
+test('尚未接近列表底部时不应提前翻页', () => {
+  assert.equal(
+    shouldLoadNextDocumentPage({
+      ...viewport,
+      scrollHeight: 1200,
+      clientHeight: 600,
+      threshold: 120,
+    }),
+    false,
+  )
+})
+
+test('翻页失败后不推进页码并允许重试同一页', () => {
+  const state = createDocumentPaginationState()
+  const firstRequest = beginDocumentPageRequest(state, viewport)
+
+  assert.deepEqual(firstRequest, { page: 2, generation: 0 })
+  assert.equal(settleDocumentPageRequest(state, firstRequest!, false), 'failed')
+  assert.equal(state.page, 1)
+
+  const retryRequest = beginDocumentPageRequest(state, viewport)
+  assert.deepEqual(retryRequest, { page: 2, generation: 0 })
+  assert.equal(settleDocumentPageRequest(state, retryRequest!, true), 'loaded')
+  assert.equal(state.page, 2)
+})
+
+test('重置列表后忽略旧筛选条件下完成的请求', () => {
+  const state = createDocumentPaginationState()
+  const request = beginDocumentPageRequest(state, viewport)
+
+  resetDocumentPagination(state)
+
+  assert.equal(settleDocumentPageRequest(state, request!, true), 'stale')
+  assert.deepEqual(state, { page: 1, loading: false, generation: 1 })
+})
+
+test('全部文档已加载时不再创建翻页请求', () => {
+  const state = createDocumentPaginationState()
+  const completeViewport = { ...viewport, loadedCount: 90 }
+
+  assert.equal(beginDocumentPageRequest(state, completeViewport, true), null)
+})

--- a/frontend/src/views/knowledge/documentPagination.test.ts
+++ b/frontend/src/views/knowledge/documentPagination.test.ts
@@ -1,66 +1,28 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import {
-  beginDocumentPageRequest,
-  createDocumentPaginationState,
-  resetDocumentPagination,
-  settleDocumentPageRequest,
-  shouldLoadNextDocumentPage,
-} from './documentPagination.ts'
+import { getNextDocumentPage } from './documentPagination.ts'
 
-const viewport = {
-  loadedCount: 35,
-  totalCount: 90,
-  pageSize: 35,
-  scrollTop: 0,
-  scrollHeight: 600,
-  clientHeight: 600,
-}
+test('每批加载 35 个文件，直到全部加载完毕', () => {
+  const pages: number[] = []
+  let loadedCount = 35
+  let currentPage = 1
 
-test('首批内容没有撑出滚动条时仍应继续加载下一页', () => {
-  assert.equal(shouldLoadNextDocumentPage(viewport), true)
-})
+  while (true) {
+    const nextPage = getNextDocumentPage(loadedCount, 90, currentPage, 35)
+    if (!nextPage) break
+    pages.push(nextPage)
+    currentPage = nextPage
+    loadedCount = Math.min(loadedCount + 35, 90)
+  }
 
-test('尚未接近列表底部时不应提前翻页', () => {
-  assert.equal(
-    shouldLoadNextDocumentPage({
-      ...viewport,
-      scrollHeight: 1200,
-      clientHeight: 600,
-      threshold: 120,
-    }),
-    false,
-  )
-})
-
-test('翻页失败后不推进页码并允许重试同一页', () => {
-  const state = createDocumentPaginationState()
-  const firstRequest = beginDocumentPageRequest(state, viewport)
-
-  assert.deepEqual(firstRequest, { page: 2, generation: 0 })
-  assert.equal(settleDocumentPageRequest(state, firstRequest!, false), 'failed')
-  assert.equal(state.page, 1)
-
-  const retryRequest = beginDocumentPageRequest(state, viewport)
-  assert.deepEqual(retryRequest, { page: 2, generation: 0 })
-  assert.equal(settleDocumentPageRequest(state, retryRequest!, true), 'loaded')
-  assert.equal(state.page, 2)
-})
-
-test('重置列表后忽略旧筛选条件下完成的请求', () => {
-  const state = createDocumentPaginationState()
-  const request = beginDocumentPageRequest(state, viewport)
-
-  resetDocumentPagination(state)
-
-  assert.equal(settleDocumentPageRequest(state, request!, true), 'stale')
-  assert.deepEqual(state, { page: 1, loading: false, generation: 1 })
+  assert.deepEqual(pages, [2, 3])
 })
 
 test('全部文档已加载时不再创建翻页请求', () => {
-  const state = createDocumentPaginationState()
-  const completeViewport = { ...viewport, loadedCount: 90 }
+  assert.equal(getNextDocumentPage(90, 90, 3, 35), null)
+})
 
-  assert.equal(beginDocumentPageRequest(state, completeViewport, true), null)
+test('异常总数不会导致请求超过计算出的总页数', () => {
+  assert.equal(getNextDocumentPage(70, 90, 3, 35), null)
 })

--- a/frontend/src/views/knowledge/documentPagination.test.ts
+++ b/frontend/src/views/knowledge/documentPagination.test.ts
@@ -3,17 +3,18 @@ import test from 'node:test'
 
 import { getNextDocumentPage } from './documentPagination.ts'
 
-test('每批加载 35 个文件，直到全部加载完毕', () => {
+test('按当前批量继续分页，直到全部加载完毕', () => {
   const pages: number[] = []
-  let loadedCount = 35
+  const pageSize = 45
+  let loadedCount = pageSize
   let currentPage = 1
 
   while (true) {
-    const nextPage = getNextDocumentPage(loadedCount, 90, currentPage, 35)
+    const nextPage = getNextDocumentPage(loadedCount, 100, currentPage, pageSize)
     if (!nextPage) break
     pages.push(nextPage)
     currentPage = nextPage
-    loadedCount = Math.min(loadedCount + 35, 90)
+    loadedCount = Math.min(loadedCount + pageSize, 100)
   }
 
   assert.deepEqual(pages, [2, 3])

--- a/frontend/src/views/knowledge/documentPagination.ts
+++ b/frontend/src/views/knowledge/documentPagination.ts
@@ -1,0 +1,72 @@
+export type DocumentPaginationViewport = {
+  loadedCount: number
+  totalCount: number
+  pageSize: number
+  scrollTop: number
+  scrollHeight: number
+  clientHeight: number
+  threshold?: number
+}
+
+export type DocumentPaginationState = {
+  page: number
+  loading: boolean
+  generation: number
+}
+
+export type DocumentPageRequest = {
+  page: number
+  generation: number
+}
+
+export type DocumentPageRequestResult = 'loaded' | 'failed' | 'stale'
+
+export function createDocumentPaginationState(): DocumentPaginationState {
+  return { page: 1, loading: false, generation: 0 }
+}
+
+// 重置时递增代次，使旧筛选条件下尚未完成的翻页请求无法推进新列表的页码。
+export function resetDocumentPagination(state: DocumentPaginationState): void {
+  state.page = 1
+  state.loading = false
+  state.generation += 1
+}
+
+export function shouldLoadNextDocumentPage(viewport: DocumentPaginationViewport): boolean {
+  if (viewport.pageSize <= 0 || viewport.loadedCount >= viewport.totalCount) return false
+
+  const threshold = Math.max(0, viewport.threshold ?? 0)
+  return viewport.scrollTop + viewport.clientHeight >= viewport.scrollHeight - threshold
+}
+
+// 只有确实需要下一页时才占用加载锁；force 用于底部观察点和手动重试。
+export function beginDocumentPageRequest(
+  state: DocumentPaginationState,
+  viewport: DocumentPaginationViewport,
+  force = false,
+): DocumentPageRequest | null {
+  if (state.loading) return null
+
+  const hasMore = viewport.pageSize > 0 &&
+    viewport.loadedCount < viewport.totalCount &&
+    state.page < Math.ceil(viewport.totalCount / viewport.pageSize)
+  if (!hasMore || (!force && !shouldLoadNextDocumentPage(viewport))) return null
+
+  state.loading = true
+  return { page: state.page + 1, generation: state.generation }
+}
+
+// 请求失败时保持原页码，下一次仍请求同一页；过期请求不得修改当前分页状态。
+export function settleDocumentPageRequest(
+  state: DocumentPaginationState,
+  request: DocumentPageRequest,
+  succeeded: boolean,
+): DocumentPageRequestResult {
+  if (request.generation !== state.generation) return 'stale'
+
+  state.loading = false
+  if (!succeeded) return 'failed'
+
+  state.page = request.page
+  return 'loaded'
+}

--- a/frontend/src/views/knowledge/documentPagination.ts
+++ b/frontend/src/views/knowledge/documentPagination.ts
@@ -1,72 +1,12 @@
-export type DocumentPaginationViewport = {
-  loadedCount: number
-  totalCount: number
-  pageSize: number
-  scrollTop: number
-  scrollHeight: number
-  clientHeight: number
-  threshold?: number
-}
+// 已加载数量小于总数时按页继续请求；总页数限制可以避免异常数据造成无限请求。
+export function getNextDocumentPage(
+  loadedCount: number,
+  totalCount: number,
+  currentPage: number,
+  pageSize: number,
+): number | null {
+  if (pageSize <= 0 || loadedCount >= totalCount) return null
 
-export type DocumentPaginationState = {
-  page: number
-  loading: boolean
-  generation: number
-}
-
-export type DocumentPageRequest = {
-  page: number
-  generation: number
-}
-
-export type DocumentPageRequestResult = 'loaded' | 'failed' | 'stale'
-
-export function createDocumentPaginationState(): DocumentPaginationState {
-  return { page: 1, loading: false, generation: 0 }
-}
-
-// 重置时递增代次，使旧筛选条件下尚未完成的翻页请求无法推进新列表的页码。
-export function resetDocumentPagination(state: DocumentPaginationState): void {
-  state.page = 1
-  state.loading = false
-  state.generation += 1
-}
-
-export function shouldLoadNextDocumentPage(viewport: DocumentPaginationViewport): boolean {
-  if (viewport.pageSize <= 0 || viewport.loadedCount >= viewport.totalCount) return false
-
-  const threshold = Math.max(0, viewport.threshold ?? 0)
-  return viewport.scrollTop + viewport.clientHeight >= viewport.scrollHeight - threshold
-}
-
-// 只有确实需要下一页时才占用加载锁；force 用于底部观察点和手动重试。
-export function beginDocumentPageRequest(
-  state: DocumentPaginationState,
-  viewport: DocumentPaginationViewport,
-  force = false,
-): DocumentPageRequest | null {
-  if (state.loading) return null
-
-  const hasMore = viewport.pageSize > 0 &&
-    viewport.loadedCount < viewport.totalCount &&
-    state.page < Math.ceil(viewport.totalCount / viewport.pageSize)
-  if (!hasMore || (!force && !shouldLoadNextDocumentPage(viewport))) return null
-
-  state.loading = true
-  return { page: state.page + 1, generation: state.generation }
-}
-
-// 请求失败时保持原页码，下一次仍请求同一页；过期请求不得修改当前分页状态。
-export function settleDocumentPageRequest(
-  state: DocumentPaginationState,
-  request: DocumentPageRequest,
-  succeeded: boolean,
-): DocumentPageRequestResult {
-  if (request.generation !== state.generation) return 'stale'
-
-  state.loading = false
-  if (!succeeded) return 'failed'
-
-  state.page = request.page
-  return 'loaded'
+  const nextPage = currentPage + 1
+  return nextPage <= Math.ceil(totalCount / pageSize) ? nextPage : null
 }


### PR DESCRIPTION
## Description

修复知识库文件列表有时无法加载全部文档，并且刷新页面后仍然缺少相同文档的问题。

### 原有逻辑

知识库文件列表使用分页接口加载数据。

每批请求数量根据浏览器窗口高度动态计算：

```text
pageSize = max(35, floor(窗口高度 / 148) × 5)
```

后端返回的数据中包含：

```text
data：当前分页的文档
total：当前筛选条件下的文档总数
```

问题举例：知识库有 90 个文档，第一页请求 35 个时，后端会返回：

```text
data.length = 35
total = 90
```

此时前端已经知道还有 55 个文档没有加载，但原逻辑不会立即请求下一页，而是等待用户滚动到列表底部；
原来的第二页及后续分页完全依赖文件列表的滚动事件。

只有同时满足下面条件时，前端才会请求下一页：

1. 文件列表已经产生可滚动区域。
2. 用户实际滚动了文件列表。
3. 滚动位置到达列表底部。
4. 当前没有其他分页请求。
5. 前端判断当前页码小于总页数。

问题在于，每批数量是根据整个浏览器窗口高度和固定 5 列计算的，但实际文件列表是响应式布局：

- 文件列表的实际高度不等于整个浏览器窗口高度。
- 页面顶部还有导航栏、筛选栏和标签区域。
- 不同窗口宽度下，每行实际显示的文件数量不一定是 5 个。
- 浏览器缩放比例也会改变每行数量和卡片高度。
- 网格视图和列表视图需要的垂直空间也不相同。

因此，在部分窗口尺寸、屏幕分辨率或缩放比例下，第一页文件可能没有让文件列表形成有效的滚动区域。

即使后端返回的 `total` 明确表示还有更多文档，前端也不会主动请求下一页。

例如：

```text
知识库文档总数：90
第一页加载数量：35
前端已显示数量：35
后端返回总数：90
```

原逻辑只是保存 `total = 90`，但不会立即比较：

```text
35 < 90
```

第二页请求必须等待滚动事件。如果页面没有产生滚动条，或者滚动事件没有达到底部判断条件，第二页就永远不会触发。

所以文档并没有被后端删除或过滤掉，只是前端始终停留在第一页。

### 为什么刷新页面仍然无效

刷新页面只会重新执行同一套加载流程，并不等于加载全部分页。

### 分页请求失败的影响

原来的滚动分页还会在请求成功前增加页码。

如果第二页请求失败：

1. 页码已经从第一页增加到第二页。
2. 请求异常被静默处理。
3. 页码不会恢复。
4. 下一次滚动可能直接请求第三页。

这样第二页可能被跳过，进一步造成文档列表不完整。

### 修改方式

本次修改不改变原来的每批数量计算公式，也不改变任何前端页面。只补充每批加载完成后的检查：

```text
如果 已加载数量 < 后端总数
    继续请求下一页
否则
    停止加载
```

例如总数为 90、当前 `pageSize` 为 35 时：

```text
第 1 页：加载 35 个，35 < 90，继续
第 2 页：加载 35 个，70 < 90，继续
第 3 页：加载 20 个，90 = 90，结束
```

如果当前窗口计算出的 `pageSize` 为 45：

```text
第 1 页：加载 45 个，45 < 90，继续
第 2 页：加载 45 个，90 = 90，结束
```

用户不需要滚动到底部来触发下一页。滚轮只负责浏览已经加载出来的长列表。

切换知识库、标签或状态筛选时，旧筛选条件下尚未完成的分页流程会停止，避免旧请求覆盖新列表。

### UI Changes

无。

本次修改不新增按钮、提示、加载区域或样式，只让现有文档列表的分页检查更加完整和稳定。