### PR TITLE
feat(provider): add Synthorai as an OpenAI-compatible provider

### DIFF
--- a/client/model.go
+++ b/client/model.go
@@ -49,6 +49,7 @@ const (
 	ModelSourceJina        ModelSource = "jina"         // Jina AI model
 	ModelSourceOpenRouter  ModelSource = "openrouter"   // OpenRouter model
 	ModelSourceLiteLLM     ModelSource = "litellm"      // LiteLLM proxy model
+	ModelSourceSynthorai   ModelSource = "synthorai"    // Synthorai model
 	ModelSourceRequesty    ModelSource = "requesty"     // Requesty model
 	ModelSourceNvidia      ModelSource = "nvidia"       // NVIDIA model
 	ModelSourceNovita      ModelSource = "novita"       // Novita AI model

--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -35,6 +35,7 @@ WeKnora 支持多种主流 AI 模型服务商，在创建模型时可通过 `par
 | `openrouter`   | OpenRouter                   | Chat, VLLM                      |
 | `litellm`      | LiteLLM (self-hosted proxy)  | Chat, Embedding, VLLM           |
 | `requesty`     | Requesty                     | Chat, Embedding, VLLM           |
+| `synthorai`    | Synthorai                    | Chat, VLLM                      |
 | `gemini`       | Google Gemini                | Chat                            |
 | `modelscope`   | 魔搭 ModelScope              | Chat, Embedding, VLLM           |
 | `moonshot`     | 月之暗面 Moonshot            | Chat, VLLM                      |

--- a/docs/wiki/核心功能/内置模型管理.md
+++ b/docs/wiki/核心功能/内置模型管理.md
@@ -30,7 +30,7 @@ source: BUILTIN_MODELS.md
 - 模型参数（parameters）：包括 base_url、api_key、provider 等
 - 空间ID（tenant_id）：建议使用小于10000的空间ID
 
-**支持的服务商（provider）**：`generic`、`openai`、`aliyun`、`zhipu`、`volcengine`、`hunyuan`、`deepseek`、`minimax`、`mimo`、`siliconflow`、`jina`、`openrouter`、`litellm`、`requesty`、`gemini`、`modelscope`、`moonshot`、`qianfan`、`qiniu`、`longcat`、`gpustack`
+**支持的服务商（provider）**：`generic`、`openai`、`aliyun`、`zhipu`、`volcengine`、`hunyuan`、`deepseek`、`minimax`、`mimo`、`siliconflow`、`jina`、`openrouter`、`litellm`、`requesty`、`synthorai`、`gemini`、`modelscope`、`moonshot`、`qianfan`、`qiniu`、`longcat`、`gpustack`
 
 ### 2. 执行 SQL 插入语句
 

--- a/frontend/src/components/ModelEditorDialog.vue
+++ b/frontend/src/components/ModelEditorDialog.vue
@@ -573,6 +573,15 @@ const fallbackProviderOptions = computed(() => [
     modelTypes: ['chat', 'embedding', 'vllm']
   },
   {
+    value: 'synthorai',
+    label: t('model.editor.providers.synthorai.label'),
+    defaultUrls: {
+      chat: 'https://synthorai.io/v1'
+    },
+    description: t('model.editor.providers.synthorai.description'),
+    modelTypes: ['chat']
+  },
+  {
     value: 'requesty',
     label: t('model.editor.providers.requesty.label'),
     defaultUrls: {

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -4319,6 +4319,10 @@ export default {
           label: 'LiteLLM',
           description: 'Self-hosted proxy to 100+ providers (OpenAI, Anthropic, Gemini, Bedrock, etc.). Replace the placeholder URL; loopback hosts need SSRF_WHITELIST.'
         },
+        synthorai: {
+          label: 'Synthorai',
+          description: 'OpenAI-compatible gateway serving Claude, GPT, Gemini, DeepSeek, Qwen and GLM behind one key.'
+        },
         requesty: {
           label: 'Requesty',
           description: 'openai/gpt-4o-mini, anthropic/claude-sonnet-4-5, etc.'

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -2473,6 +2473,10 @@ export default {
           label: '사용자 정의 (OpenAI 호환)',
           description: 'Generic API endpoint'
         },
+        synthorai: {
+          label: 'Synthorai',
+          description: 'Claude, GPT, Gemini, DeepSeek, Qwen, GLM을 하나의 키로 제공하는 OpenAI 호환 게이트웨이.'
+        },
         requesty: {
           label: 'Requesty',
           description: 'openai/gpt-4o-mini, anthropic/claude-sonnet-4-5 등'

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -2473,6 +2473,10 @@ export default {
           label: 'Пользовательский (OpenAI-совместимый)',
           description: 'Generic API endpoint'
         },
+        synthorai: {
+          label: 'Synthorai',
+          description: 'OpenAI-совместимый шлюз: Claude, GPT, Gemini, DeepSeek, Qwen и GLM по одному ключу.'
+        },
         requesty: {
           label: 'Requesty',
           description: 'openai/gpt-4o-mini, anthropic/claude-sonnet-4-5, etc.'

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2475,6 +2475,10 @@ export default {
           label: '自定义 (OpenAI兼容接口)',
           description: 'Generic API endpoint (OpenAI-compatible)'
         },
+        synthorai: {
+          label: 'Synthorai',
+          description: 'OpenAI 兼容网关,一个 key 直连 Claude、GPT、Gemini、DeepSeek、Qwen、GLM 等模型。'
+        },
         requesty: {
           label: 'Requesty',
           description: 'openai/gpt-4o-mini, anthropic/claude-sonnet-4-5, etc.'

--- a/internal/models/provider/provider.go
+++ b/internal/models/provider/provider.go
@@ -25,6 +25,8 @@ const (
 	ProviderOpenRouter ProviderName = "openrouter"
 	// ProviderLiteLLM is the LiteLLM self-hosted proxy (OpenAI-compatible gateway to 100+ providers).
 	ProviderLiteLLM ProviderName = "litellm"
+	// Synthorai
+	ProviderSynthorai ProviderName = "synthorai"
 	// Requesty
 	ProviderRequesty ProviderName = "requesty"
 	// 硅基流动
@@ -88,6 +90,7 @@ func AllProviders() []ProviderName {
 		ProviderGemini,
 		ProviderOpenRouter,
 		ProviderLiteLLM,
+		ProviderSynthorai,
 		ProviderRequesty,
 		ProviderJina,
 		ProviderMimo,
@@ -235,6 +238,8 @@ func DetectProvider(baseURL string) ProviderName {
 	// because they are SSRF-blocked unless explicitly whitelisted.
 	case containsAny(baseURL, "litellm"):
 		return ProviderLiteLLM
+	case containsAny(baseURL, "synthorai.io"):
+		return ProviderSynthorai
 	case containsAny(baseURL, "router.requesty.ai", "requesty.ai"):
 		return ProviderRequesty
 	case containsAny(baseURL, "siliconflow.cn"):

--- a/internal/models/provider/provider_test.go
+++ b/internal/models/provider/provider_test.go
@@ -379,3 +379,33 @@ func TestLiteLLMProviderValidation(t *testing.T) {
 		assert.True(t, foundEmbed, "LiteLLM should appear for embedding models")
 	})
 }
+
+func TestSynthoraiProviderValidation(t *testing.T) {
+	p := &SynthoraiProvider{}
+
+	t.Run("valid config", func(t *testing.T) {
+		config := &Config{
+			APIKey:    "test-key",
+			ModelName: "claude-opus-5",
+		}
+		err := p.ValidateConfig(config)
+		assert.NoError(t, err)
+	})
+
+	t.Run("missing API key", func(t *testing.T) {
+		config := &Config{
+			ModelName: "claude-opus-5",
+		}
+		err := p.ValidateConfig(config)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "API key")
+	})
+
+	t.Run("info", func(t *testing.T) {
+		info := p.Info()
+		assert.Equal(t, ProviderSynthorai, info.Name)
+		assert.Equal(t, "Synthorai", info.DisplayName)
+		assert.True(t, info.RequiresAuth)
+		assert.Equal(t, SynthoraiBaseURL, info.DefaultURLs[types.ModelTypeKnowledgeQA])
+	})
+}

--- a/internal/models/provider/synthorai.go
+++ b/internal/models/provider/synthorai.go
@@ -1,0 +1,44 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+const (
+	SynthoraiBaseURL = "https://synthorai.io/v1"
+)
+
+// SynthoraiProvider 实现 Synthorai 的 Provider 接口
+type SynthoraiProvider struct{}
+
+func init() {
+	Register(&SynthoraiProvider{})
+}
+
+// Info 返回 Synthorai provider 的元数据
+func (p *SynthoraiProvider) Info() ProviderInfo {
+	return ProviderInfo{
+		Name:        ProviderSynthorai,
+		DisplayName: "Synthorai",
+		Description: "claude-opus-5, gpt-5.6-sol, deepseek-v4-pro, glm-5.2, etc.",
+		DefaultURLs: map[types.ModelType]string{
+			types.ModelTypeKnowledgeQA: SynthoraiBaseURL,
+			types.ModelTypeVLLM:        SynthoraiBaseURL,
+		},
+		ModelTypes: []types.ModelType{
+			types.ModelTypeKnowledgeQA,
+			types.ModelTypeVLLM,
+		},
+		RequiresAuth: true,
+	}
+}
+
+// ValidateConfig 验证 Synthorai provider 配置
+func (p *SynthoraiProvider) ValidateConfig(config *Config) error {
+	if config.APIKey == "" {
+		return fmt.Errorf("API key is required for Synthorai provider")
+	}
+	return nil
+}

--- a/internal/types/model.go
+++ b/internal/types/model.go
@@ -107,6 +107,7 @@ const (
 	ModelSourceJina        ModelSource = "jina"         // Jina AI model
 	ModelSourceOpenRouter  ModelSource = "openrouter"   // OpenRouter model
 	ModelSourceLiteLLM     ModelSource = "litellm"      // LiteLLM proxy model
+	ModelSourceSynthorai   ModelSource = "synthorai"    // Synthorai model
 	ModelSourceRequesty    ModelSource = "requesty"     // Requesty model
 	ModelSourceNvidia      ModelSource = "nvidia"       // NVIDIA model
 	ModelSourceNovita      ModelSource = "novita"       // Novita AI model


### PR DESCRIPTION
### Summary

Adds Synthorai as an OpenAI-compatible model provider, mirroring **#2013 (Requesty, merged 2026-07-13)** file for file.

**Disclosure: I'm affiliated with Synthorai**, so this is a vendor adding its own provider rather than a user request. Flagging it up front so it's weighed with that in mind.

### Related Issue

Closes #2822 — I opened that issue asking whether this would be welcome. Looking at how #2013 actually landed (straight to a PR, no preceding issue), asking first was the wrong read of how this repo works, so here is the code.

### What's included

| | |
|---|---|
| `internal/models/provider/synthorai.go` | new, mirrors `requesty.go` |
| `internal/models/provider/provider.go` | the same three points #2013 touched — const, `AllProviders()`, `DetectProvider()` |
| `internal/types/model.go` + `client/model.go` | both hand-synced `ModelSource` enums, kept together |
| `frontend/src/components/ModelEditorDialog.vue` | dropdown entry |
| 4 × `frontend/src/i18n/locales/*.ts` | all four locales the repo ships |
| `docs/api/model.md`, `docs/wiki/核心功能/内置模型管理.md` | the two rows a maintainer had to add afterwards in **#2036** — folded in here so no follow-up is needed |
| `internal/models/provider/provider_test.go` | `TestSynthoraiProviderValidation` (valid / missing-key / info) + a `DetectProvider` case |

### One deliberate difference from Requesty

`requesty.go` declares `KnowledgeQA`, `Embedding` and `VLLM`. **This declares only `KnowledgeQA` and `VLLM`.** Our public catalog has no embedding models at all — I checked before writing it — so declaring `Embedding` would advertise something that doesn't exist.

Model ids are also bare rather than vendor-prefixed (`claude-opus-5`, not `anthropic/claude-opus-5`), which is why the `Description` and tests use that form.

### Checks

- `go build ./...` — clean
- `go test ./internal/models/provider/...` — `ok`
- `gofmt` — the five Go files touched are clean. (`client/chunk.go`, `client/faq.go` and `client/web_search.go` are also unformatted on `main`; I left them alone rather than mixing an unrelated cleanup into this PR.)

### What I have not done

**I have not run WeKnora end to end against this provider.** It is a shape-for-shape mirror of a merged provider and the unit tests pass, but that is not a live inference run and I don't want to imply it is. If you'd like that before merging, say so and I'll do it and post the output.

I'm also not claiming demand — nobody else has asked for this as far as I know.
