### PR TITLE
test(sandbox): drop TEST-NET DNS fixture from Cube tests

### DIFF
--- a/internal/application/service/tenant_sandbox_config_test.go
+++ b/internal/application/service/tenant_sandbox_config_test.go
@@ -118,7 +118,7 @@ func TestSandboxIdentityChanged(t *testing.T) {
 			old:  cubeCfg("key-a", "https://cube.example.com", "https://proxy.example.com", "cube.app"),
 			new: func() *types.TenantSandboxConfig {
 				cfg := cubeCfg("key-a", "https://cube.example.com", "https://proxy.example.com", "cube.app")
-				cfg.Cube.DNSServers = []string{"192.0.2.53"}
+				cfg.Cube.DNSServers = []string{"8.8.8.8"}
 				return cfg
 			}(),
 			want: false,

--- a/internal/sandbox/cube_template_catalog_test.go
+++ b/internal/sandbox/cube_template_catalog_test.go
@@ -424,7 +424,7 @@ func TestCubeRemoteClientReplaceStandardTemplateRebuildsInPlace(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	})
-	client.config.CubeDNSServers = []string{"192.0.2.53"}
+	client.config.CubeDNSServers = []string{"8.8.8.8"}
 
 	template, err := client.ReplaceStandardTemplate(context.Background())
 	require.NoError(t, err)
@@ -432,7 +432,7 @@ func TestCubeRemoteClientReplaceStandardTemplateRebuildsInPlace(t *testing.T) {
 	require.Equal(t, "building", template.Status)
 	require.Equal(t, int32(0), deleted.Load(), "in-place rebuild must keep the stored template ID")
 	require.Equal(t, int32(0), created.Load())
-	require.Equal(t, []any{"192.0.2.53"}, payload["dns"])
+	require.Equal(t, []any{"8.8.8.8"}, payload["dns"])
 	require.Equal(t, true, payload["allowInternetAccess"])
 }
 


### PR DESCRIPTION
## Summary
- Replace RFC 5737 TEST-NET (`192.0.2.53`) Cube DNS fixtures with `8.8.8.8`, matching the other Cube DNS tests.
- Identity and in-place rebuild coverage is unchanged; only the dummy nameserver address is aligned.

## Test plan
- [x] `go test ./internal/application/service/ -run TestSandboxIdentityChanged`
- [x] `go test ./internal/sandbox/ -run TestCubeRemoteClientReplaceStandardTemplateRebuildsInPlace`
- [ ] CI sandbox packages pass