### PR TITLE
fix(wiki): remove stale chunk refs before knowledge reparse

### DIFF
--- a/internal/application/service/knowledge_delete.go
+++ b/internal/application/service/knowledge_delete.go
@@ -449,9 +449,8 @@ func (s *knowledgeService) scrubWikiPendingIngest(ctx context.Context, kbID, kno
 }
 
 // prepareWikiForReparse is the reparse counterpart to
-// cleanupWikiOnKnowledgeDelete. It aligns reparse with the same "pending
-// queue hygiene" the delete path already enforces, without taking any
-// destructive action against existing pages.
+// cleanupWikiOnKnowledgeDelete. It aligns reparse with the same pending queue
+// hygiene the delete path already enforces.
 //
 // Why no retract / tombstone here: reparse is not a "K is gone" event, it's
 // a "K's contribution is about to be swapped for a new version" event. The
@@ -460,10 +459,10 @@ func (s *knowledgeService) scrubWikiPendingIngest(ctx context.Context, kbID, kno
 // the freshly extracted candidate slugs, which is exactly the information
 // the WikiPageModifyUserPrompt needs to do a correct replace-not-append.
 //
-// So the only thing worth doing synchronously at reparse time is keeping
-// the Redis pending list clean so the re-ingest enqueued by
-// KnowledgePostProcess doesn't race with a stale ingest op that would
-// fire mid-flight against zero chunks.
+// Reparse also replaces the knowledge's chunks with newly generated IDs.
+// Strip the old IDs from page metadata while the chunks are still queryable;
+// the normal reduce step will append the new citations. SourceRefs stay intact
+// because the knowledge remains a source throughout the reparse.
 func (s *knowledgeService) prepareWikiForReparse(ctx context.Context, knowledge *types.Knowledge) {
 	if knowledge == nil {
 		return
@@ -474,6 +473,37 @@ func (s *knowledgeService) prepareWikiForReparse(ctx context.Context, knowledge 
 		return
 	}
 	s.scrubWikiPendingIngest(ctx, kbID, knowledgeID, "reparse")
+	if s.wikiRepo == nil || s.wikiService == nil || s.chunkRepo == nil {
+		return
+	}
+
+	oldChunkRefs := s.wikiChunkRefsForKnowledge(ctx, knowledge)
+	if len(oldChunkRefs) == 0 {
+		return
+	}
+	pages, err := s.wikiRepo.ListBySourceRef(ctx, kbID, knowledgeID)
+	if err != nil {
+		logger.Warnf(ctx, "wiki reparse: failed to list pages for knowledge %s: %v", knowledgeID, err)
+		return
+	}
+
+	updated := 0
+	for _, page := range pages {
+		if page == nil {
+			continue
+		}
+		chunkRefs := removeChunkRefs(page.ChunkRefs, oldChunkRefs)
+		if len(chunkRefs) == len(page.ChunkRefs) {
+			continue
+		}
+		page.ChunkRefs = chunkRefs
+		if err := s.wikiService.UpdatePageMeta(ctx, page); err != nil {
+			logger.Warnf(ctx, "wiki reparse: failed to remove old chunk refs from page %s: %v", page.Slug, err)
+			continue
+		}
+		updated++
+	}
+	logger.Infof(ctx, "wiki reparse: removed old chunk refs from %d pages for knowledge %s", updated, knowledgeID)
 }
 
 // removeSourceRef removes entries from source_refs that match a knowledge ID.

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -2444,12 +2444,11 @@ func (s *knowledgeService) ReparseKnowledge(
 	processOverrides, _ = existing.ProcessOverrides()
 	reparseEff := ResolveProcessConfig(kb, processOverrides)
 
-	// Keep wiki's pending queue consistent across both manual and non-manual
-	// paths. The destructive work (swapping old wiki contributions for new)
-	// happens asynchronously inside mapOneDocument — see its oldPageSlugs
-	// handling — once post-process re-enqueues wiki ingest. All we need to
-	// do here is stop any stale pending ingest op from firing against the
-	// pre-reparse chunk set.
+	// Keep wiki metadata and its pending queue consistent across both manual
+	// and non-manual paths. Remove old chunk refs while the chunks are still
+	// queryable, and stop any stale ingest op from firing against the
+	// pre-reparse chunk set. The new refs are added asynchronously when
+	// post-process re-enqueues wiki ingest.
 	if kb != nil && kb.IsWikiEnabled() {
 		s.prepareWikiForReparse(ctx, existing)
 	}

--- a/internal/application/service/wiki_ingest_chunk_refs_reparse_test.go
+++ b/internal/application/service/wiki_ingest_chunk_refs_reparse_test.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+type reparseChunkRepo struct {
+	interfaces.ChunkRepository
+	chunks []*types.Chunk
+}
+
+func (r *reparseChunkRepo) ListChunksByKnowledgeID(
+	context.Context, uint64, string,
+) ([]*types.Chunk, error) {
+	return r.chunks, nil
+}
+
+type reparseWikiRepo struct {
+	interfaces.WikiPageRepository
+	pages []*types.WikiPage
+}
+
+func (r *reparseWikiRepo) ListBySourceRef(
+	context.Context, string, string,
+) ([]*types.WikiPage, error) {
+	return r.pages, nil
+}
+
+type reparseWikiService struct {
+	interfaces.WikiPageService
+	updated []*types.WikiPage
+}
+
+func (s *reparseWikiService) UpdatePageMeta(_ context.Context, page *types.WikiPage) error {
+	snapshot := *page
+	snapshot.SourceRefs = append(types.StringArray(nil), page.SourceRefs...)
+	snapshot.ChunkRefs = append(types.StringArray(nil), page.ChunkRefs...)
+	s.updated = append(s.updated, &snapshot)
+	return nil
+}
+
+func TestPrepareWikiForReparse_RemovesOnlyReparsedKnowledgeChunkRefs(t *testing.T) {
+	page := &types.WikiPage{
+		Slug:       "entity/example",
+		SourceRefs: types.StringArray{"knowledge-1", "knowledge-2"},
+		ChunkRefs:  types.StringArray{"chunk-old-1", "chunk-other-source"},
+	}
+	wikiService := &reparseWikiService{}
+	svc := &knowledgeService{
+		chunkRepo: &reparseChunkRepo{chunks: []*types.Chunk{
+			{ID: "chunk-old-1", KnowledgeID: "knowledge-1"},
+		}},
+		wikiRepo:    &reparseWikiRepo{pages: []*types.WikiPage{page}},
+		wikiService: wikiService,
+	}
+
+	svc.prepareWikiForReparse(context.Background(), &types.Knowledge{
+		ID:              "knowledge-1",
+		TenantID:        1,
+		KnowledgeBaseID: "kb-1",
+	})
+
+	if len(wikiService.updated) != 1 {
+		t.Fatalf("expected one wiki page metadata update, got %d", len(wikiService.updated))
+	}
+	got := wikiService.updated[0]
+	wantChunkRefs := types.StringArray{"chunk-other-source"}
+	if !reflect.DeepEqual(got.ChunkRefs, wantChunkRefs) {
+		t.Fatalf("unexpected chunk refs: got %v, want %v", got.ChunkRefs, wantChunkRefs)
+	}
+	wantSourceRefs := types.StringArray{"knowledge-1", "knowledge-2"}
+	if !reflect.DeepEqual(got.SourceRefs, wantSourceRefs) {
+		t.Fatalf("source refs changed during reparse: got %v, want %v", got.SourceRefs, wantSourceRefs)
+	}
+}


### PR DESCRIPTION
## Description

Knowledge reparse deletes and recreates chunk rows before Wiki reduce. For overlapping slugs, `mapOneDocument` emits both the replacement content and a retract update, but reduce eventually unions the page's existing `chunk_refs` with the new citations. When reparse generates new chunk IDs, deleted IDs therefore remain in `wiki_pages.chunk_refs`.

This change extends `prepareWikiForReparse` to:

- collect the knowledge's old chunk IDs while they are still queryable;
- remove only those IDs from Wiki pages that reference the knowledge;
- preserve `source_refs` and chunk refs contributed by other knowledge sources;
- let the normal post-process Wiki ingest append the newly generated citations.

The implementation reuses the existing knowledge-deletion reconciliation helpers. The regression test covers a multi-source page so cleanup of one reparsed knowledge cannot remove another source's citations.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Related to #1679

Issue #1679 describes the broader need for stable chunk IDs during reparse. This PR fixes the Wiki metadata consequence when chunk IDs do change; it does not close the caching issue.

## Testing

Validation used the repository's original `go.mod` and `go.sum` in a Linux/amd64 environment with Go 1.26.3, `CGO_ENABLED=1`, GCC 14.2.0, and the real `pg_query`, `gojieba`, `go-sqlite3`, and `sqlite-vec` dependencies. No dependency replacements or test skips were used.

- Baseline red test: the regression test against `origin/main` production code failed deterministically 10/10 times with `expected one wiki page metadata update, got 0`.
- Fixed green test: `go test ./internal/application/service -run '^TestPrepareWikiForReparse_RemovesOnlyReparsedKnowledgeChunkRefs$' -count=10` passed 10/10.
- Related Wiki tests passed, including chunk-ref removal, citation merge, and pending-op language persistence.
- `go vet` and `go test` passed for all 91 packages selected by the repository's `App` workflow (all root-module packages except `/docreader/`).
- `go build ./cmd/server` passed.
- `golangci-lint v2.12.2 run --new-from-rev=origin/main ./...` passed with 0 issues.
- `gofmt` and `git diff --check origin/main...HEAD` passed.

The local Docker DNS proxy resolves public test fixture domains to the reserved `198.18.0.0/15` range. For the full suite, those fixture hostnames were mapped to a public address so the existing SSRF allow-public-host tests ran instead of being skipped.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

Not applicable; this change has no user-interface impact.
