### PR TITLE
fix(sandbox): accept npipe docker hosts so Windows can use the Docker backend

### DIFF
--- a/internal/sandbox/docker_engine.go
+++ b/internal/sandbox/docker_engine.go
@@ -264,12 +264,28 @@ func ValidateDockerHost(host string, allowPrivate bool) error {
 	scheme, address, found := strings.Cut(trimmed, "://")
 	if !found {
 		return fmt.Errorf(
-			"sandbox: docker host %q must include a scheme (unix:// or tcp://)", host)
+			"sandbox: docker host %q must include a scheme (unix://, npipe:// or tcp://)", host)
 	}
 	switch strings.ToLower(scheme) {
 	case "unix":
 		if !strings.HasPrefix(address, "/") {
 			return fmt.Errorf("sandbox: docker unix socket path %q must be absolute", address)
+		}
+		return nil
+	case "npipe":
+		// Windows' local daemon endpoint, the named-pipe counterpart of the
+		// unix socket: npipe:////./pipe/docker_engine. It is local to this
+		// machine and carries no address to check, so it needs no outbound
+		// guard — the same reasoning as "unix" above.
+		//
+		// Without this case a Windows host cannot use the Docker backend at
+		// all: leaving the host blank makes DetectLocalDockerHost read the
+		// docker CLI context, which returns npipe://, and the config is then
+		// refused with "unsupported docker host scheme". The moby client this
+		// package builds already dials npipe (client.go handles the scheme),
+		// so validation was the only thing in the way.
+		if address == "" {
+			return fmt.Errorf("sandbox: docker npipe host %q has no pipe path", host)
 		}
 		return nil
 	case "tcp", "http", "https":

--- a/internal/sandbox/docker_remote_client_test.go
+++ b/internal/sandbox/docker_remote_client_test.go
@@ -1091,11 +1091,20 @@ func TestValidateDockerHost(t *testing.T) {
 	require.Error(t, ValidateDockerHost("tcp://10.0.0.5:2376", false),
 		"a private daemon address needs the explicit private-endpoint opt-in")
 	require.NoError(t, ValidateDockerHost("tcp://10.0.0.5:2376", true))
+
+	// Windows' local daemon. Without this the Docker backend is unusable on
+	// Windows: a blank host resolves through the docker CLI context to
+	// npipe://, and the config is refused before it can be saved.
+	require.NoError(t, ValidateDockerHost("npipe:////./pipe/docker_engine", false))
+	require.Error(t, ValidateDockerHost("npipe://", false),
+		"a scheme with no pipe path is not an endpoint")
 }
 
 func TestValidateDockerRemoteTLS(t *testing.T) {
 	require.NoError(t, ValidateDockerRemoteTLS("", ""))
 	require.NoError(t, ValidateDockerRemoteTLS("unix:///var/run/docker.sock", ""))
+	require.NoError(t, ValidateDockerRemoteTLS("npipe:////./pipe/docker_engine", ""),
+		"a named pipe is local to this host, same as a unix socket")
 	require.Error(t, ValidateDockerRemoteTLS("tcp://10.0.0.5:2376", ""),
 		"a remote daemon without TLS is a plaintext root socket")
 	require.NoError(t, ValidateDockerRemoteTLS("tcp://10.0.0.5:2376", "/etc/weknora/docker-certs"))


### PR DESCRIPTION
## Problem

On Windows the Docker sandbox backend cannot be configured at all. Leaving the daemon address blank makes `DetectLocalDockerHost` read the docker CLI context, which returns `npipe:////./pipe/docker_engine` — and `ValidateDockerHost` only knows `unix` / `tcp` / `http` / `https`, so the config is refused before it can be saved:

```
sandbox: unsupported docker host scheme "npipe"
```

The UI just shows a failed check, with no hint that it is a platform issue rather than a typo.

## Fix

Validation is the only thing in the way: the moby client this package builds already dials npipe (`client.go` handles the scheme), the outbound dial guard only concerns network endpoints, and the TLS check only applies to `tcp`/`http`/`https`. A named pipe is local to the machine, the same as a unix socket, so neither guard should touch it. Allowing the scheme is the whole fix — no transport code needed.

Also mentions `npipe://` in the missing-scheme error, which previously suggested only `unix://` or `tcp://` and left Windows users with no correct option.

## Verification

- `TestValidateDockerHost` / `TestValidateDockerRemoteTLS` cover the new scheme (valid pipe path accepted, bare `npipe://` rejected, no TLS requirement).
- Negative-verified: removing the npipe case turns `TestValidateDockerHost` red.
- Verified end-to-end on Windows 11 + Docker Desktop: with this change the Docker backend detects the local daemon, saves, and runs sandboxes.