### PR TITLE
fix(im): handle WeCom 32-byte PKCS7 padding

### DIFF
--- a/internal/im/wecom/webhook_adapter.go
+++ b/internal/im/wecom/webhook_adapter.go
@@ -42,7 +42,10 @@ var httpClient = secutils.NewSSRFSafeHTTPClient(secutils.SSRFSafeHTTPClientConfi
 	MaxRedirects: 5,
 })
 
-const defaultAPIBaseURL = "https://qyapi.weixin.qq.com"
+const (
+	defaultAPIBaseURL   = "https://qyapi.weixin.qq.com"
+	wecomPKCS7BlockSize = 32
+)
 
 // extraHostFromEndpoint returns the lowercased hostname from endpoint if it
 // differs from defaultEndpoint; otherwise returns "". Used to extend the SSRF
@@ -463,7 +466,7 @@ func (a *WebhookAdapter) decrypt(encrypted string) ([]byte, error) {
 
 	// Remove and verify PKCS#7 padding
 	padLen := int(ciphertext[len(ciphertext)-1])
-	if padLen > aes.BlockSize || padLen == 0 || padLen > len(ciphertext) {
+	if padLen > wecomPKCS7BlockSize || padLen == 0 || padLen > len(ciphertext) {
 		return nil, fmt.Errorf("invalid padding")
 	}
 	for i := 0; i < padLen; i++ {

--- a/internal/im/wecom/webhook_adapter.go
+++ b/internal/im/wecom/webhook_adapter.go
@@ -459,6 +459,9 @@ func (a *WebhookAdapter) decrypt(encrypted string) ([]byte, error) {
 	if len(ciphertext) < aes.BlockSize {
 		return nil, fmt.Errorf("ciphertext too short")
 	}
+	if len(ciphertext)%aes.BlockSize != 0 {
+		return nil, fmt.Errorf("ciphertext length is not a multiple of AES block size")
+	}
 
 	iv := a.aesKey[:aes.BlockSize]
 	mode := cipher.NewCBCDecrypter(block, iv)

--- a/internal/im/wecom/webhook_adapter_test.go
+++ b/internal/im/wecom/webhook_adapter_test.go
@@ -1,0 +1,75 @@
+package wecom
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/binary"
+	"testing"
+)
+
+const wecomTestPKCS7BlockSize = 32
+
+func TestWebhookAdapterDecryptPadding(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+	corpID := "ww_corp_id"
+	adapter := &WebhookAdapter{aesKey: key, corpID: corpID}
+
+	tests := []struct {
+		name       string
+		message    string
+		wantPadLen int
+	}{
+		{
+			name:       "padding below AES block size",
+			message:    "message with seven-byte pad",
+			wantPadLen: 7,
+		},
+		{
+			name:       "padding above AES block size",
+			message:    "message with 19",
+			wantPadLen: 19,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encrypted, padLen := encryptWeComTestPayload(t, key, corpID, []byte(tt.message))
+			if padLen != tt.wantPadLen {
+				t.Fatalf("test fixture padding = %d, want %d", padLen, tt.wantPadLen)
+			}
+
+			got, err := adapter.decrypt(encrypted)
+			if err != nil {
+				t.Fatalf("decrypt() error = %v", err)
+			}
+			if !bytes.Equal(got, []byte(tt.message)) {
+				t.Fatalf("decrypt() = %q, want %q", got, tt.message)
+			}
+		})
+	}
+}
+
+func encryptWeComTestPayload(t *testing.T, key []byte, corpID string, message []byte) (string, int) {
+	t.Helper()
+
+	plaintext := make([]byte, 16)
+	messageLength := make([]byte, 4)
+	binary.BigEndian.PutUint32(messageLength, uint32(len(message)))
+	plaintext = append(plaintext, messageLength...)
+	plaintext = append(plaintext, message...)
+	plaintext = append(plaintext, []byte(corpID)...)
+
+	padLen := wecomTestPKCS7BlockSize - len(plaintext)%wecomTestPKCS7BlockSize
+	plaintext = append(plaintext, bytes.Repeat([]byte{byte(padLen)}, padLen)...)
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+
+	ciphertext := make([]byte, len(plaintext))
+	cipher.NewCBCEncrypter(block, key[:aes.BlockSize]).CryptBlocks(ciphertext, plaintext)
+	return base64.StdEncoding.EncodeToString(ciphertext), padLen
+}

--- a/internal/im/wecom/webhook_adapter_test.go
+++ b/internal/im/wecom/webhook_adapter_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 )
 
-const wecomTestPKCS7BlockSize = 32
-
 func TestWebhookAdapterDecryptPadding(t *testing.T) {
 	key := []byte("0123456789abcdef0123456789abcdef")
 	corpID := "ww_corp_id"
@@ -51,6 +49,18 @@ func TestWebhookAdapterDecryptPadding(t *testing.T) {
 	}
 }
 
+func TestWebhookAdapterDecryptRejectsNonBlockAlignedCiphertext(t *testing.T) {
+	adapter := &WebhookAdapter{
+		aesKey: []byte("0123456789abcdef0123456789abcdef"),
+		corpID: "ww_corp_id",
+	}
+	encrypted := base64.StdEncoding.EncodeToString(make([]byte, aes.BlockSize+1))
+
+	if _, err := adapter.decrypt(encrypted); err == nil {
+		t.Fatal("decrypt() succeeded for ciphertext with a non-block-aligned length")
+	}
+}
+
 func encryptWeComTestPayload(t *testing.T, key []byte, corpID string, message []byte) (string, int) {
 	t.Helper()
 
@@ -61,7 +71,7 @@ func encryptWeComTestPayload(t *testing.T, key []byte, corpID string, message []
 	plaintext = append(plaintext, message...)
 	plaintext = append(plaintext, []byte(corpID)...)
 
-	padLen := wecomTestPKCS7BlockSize - len(plaintext)%wecomTestPKCS7BlockSize
+	padLen := wecomPKCS7BlockSize - len(plaintext)%wecomPKCS7BlockSize
 	plaintext = append(plaintext, bytes.Repeat([]byte{byte(padLen)}, padLen)...)
 
 	block, err := aes.NewCipher(key)


### PR DESCRIPTION
## Description

`WebhookAdapter.decrypt()` validated the PKCS#7 padding length against AES's 16-byte block size. WeCom callback encryption uses a 32-byte PKCS#7 padding block size, so valid payloads with padding lengths greater than 16, including the 19-byte case from #2832, were rejected.

This PR:

- Adds a WeCom-specific 32-byte PKCS#7 block size for padding validation.
- Keeps AES-CBC's 16-byte block size and IV handling unchanged.
- Adds regression coverage for valid 7-byte and 19-byte padding.
- Introduces no breaking changes.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2832

## Testing

- `gofmt` passed for changed Go files.
- `git diff --check origin/main...HEAD` passed.
- `go test ./internal/im/wecom -count=1` passed.
- `go test -race ./internal/im/wecom -count=1` passed.
- `go vet ./internal/im/wecom` passed.
- `golangci-lint run --new-from-rev=origin/main ./...` passed with 0 issues. It emitted one pre-existing warning about an unknown `staticcheck` nolint directive.
- The full `make fmt`, `make lint`, and `make test` gate was not run; all focused checks required for this package passed.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed package pass
- [x] Diff-scoped lint passes
- [x] Full-repository check status is documented above
- [x] Self-reviewed the code
- [x] Added regression tests covering the change
- [ ] Updated related documentation (not needed for this internal implementation fix)
- [x] Breaking changes are clearly called out above

## Screenshots / Recordings

Not applicable; this is a backend-only change.