### PR TITLE
fix(agent): keep skill-script stdout on failure for the model and UI

### DIFF
--- a/frontend/src/composables/useChatStreamHandler.test.mjs
+++ b/frontend/src/composables/useChatStreamHandler.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const source = readFileSync(new URL('./useChatStreamHandler.ts', import.meta.url), 'utf8')
+
+test('failed tool results keep stdout/output instead of replacing it with the short error', () => {
+  assert.match(source, /toolCallEvent\.output = dataPayload\.output \|\| data\.content/)
+  assert.doesNotMatch(
+    source,
+    /toolCallEvent\.output = success\s*\?[\s\S]*dataPayload\.error/,
+  )
+})

--- a/frontend/src/composables/useChatStreamHandler.ts
+++ b/frontend/src/composables/useChatStreamHandler.ts
@@ -760,9 +760,10 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
           if (toolCallEvent) {
             toolCallEvent.pending = false
             toolCallEvent.success = success
-            toolCallEvent.output = success
-              ? dataPayload.output || data.content
-              : dataPayload.error || data.content
+            // Keep stdout/markdown on failure. The error field is often just
+            // "exited with code 1" plus a retry hint; the streams live on
+            // output / tool_data and are what the terminal card should show.
+            toolCallEvent.output = dataPayload.output || data.content
             toolCallEvent.error = !success ? dataPayload.error || data.content : undefined
             const duration =
               dataPayload.duration_ms !== undefined ? dataPayload.duration_ms : dataPayload.duration

--- a/frontend/src/utils/shellExecResult.test.ts
+++ b/frontend/src/utils/shellExecResult.test.ts
@@ -48,3 +48,31 @@ test('previewShellCommand collapses whitespace and truncates', () => {
   assert.equal(previewShellCommand('ls   -la'), 'ls -la')
   assert.equal(previewShellCommand('abcdefghij', 8), 'abcdefg…')
 })
+
+test('buildShellExecView parses skill-script markdown and command fallback', () => {
+  const view = buildShellExecView(
+    {
+      skill_name: 'smart-charts',
+      script_path: 'scripts/cli.py',
+      args: ['--x-axis', '工作项目'],
+      exit_code: 1,
+    },
+    null,
+    [
+      '=== Script Execution: smart-charts/scripts/cli.py ===',
+      '',
+      '**Arguments**: [--x-axis 工作项目]',
+      '**Exit Code**: 1',
+      '',
+      '## Standard Output',
+      '',
+      '```',
+      '{"chart":{"success":false,"error":{"error":"X轴字段不存在：工作项目"}}}',
+      '```',
+      '',
+    ].join('\n'),
+  )
+  assert.equal(view.command, 'smart-charts/scripts/cli.py --x-axis 工作项目')
+  assert.equal(view.exitCode, 1)
+  assert.match(view.stdout, /X轴字段不存在：工作项目/)
+})

--- a/frontend/src/utils/shellExecResult.ts
+++ b/frontend/src/utils/shellExecResult.ts
@@ -64,7 +64,9 @@ function extractFencedSection(output: string, heading: string): string {
 function stripLegacyShellHeader(output: string): string {
   return output
     .replace(/^=== Shell Exec[\s\S]*?\n\n/, '')
+    .replace(/^=== Script Execution[\s\S]*?\n\n/, '')
     .replace(/\*\*Command\*\*:[\s\S]*?(?:\n(?!\*\*)|$)/, '')
+    .replace(/\*\*Arguments\*\*:.*\n/, '')
     .replace(/\*\*Work Dir\*\*:.*\n/, '')
     .replace(/\*\*Exit Code\*\*:.*\n/, '')
     .replace(/\*\*Duration\*\*:.*\n/, '')
@@ -72,6 +74,21 @@ function stripLegacyShellHeader(output: string): string {
     .replace(/\*\*Truncated\*\*:.*\n/, '')
     .replace(/\*\*Binary Output Suppressed\*\*:.*\n/, '')
     .trim()
+}
+
+function skillScriptCommand(
+  data: Record<string, unknown>,
+  args: Record<string, unknown>,
+): string {
+  const skill = asString(data.skill_name) || asString(args.skill_name)
+  const script = asString(data.script_path) || asString(args.script_path)
+  if (!skill && !script) return ''
+  const path = [skill, script].filter(Boolean).join('/')
+  const extra = data.args ?? args.args
+  if (Array.isArray(extra) && extra.length) {
+    return [path, ...extra.map((item) => asString(item))].join(' ')
+  }
+  return path
 }
 
 export function buildShellExecView(
@@ -84,8 +101,12 @@ export function buildShellExecView(
   const rawOutput = asString(output)
   const stdoutFromData = asString(record.stdout)
   const stderrFromData = asString(record.stderr)
-  const parsedStdout = stdoutFromData ? '' : extractFencedSection(rawOutput, 'Stdout')
-  const parsedStderr = stderrFromData ? '' : extractFencedSection(rawOutput, 'Stderr')
+  const parsedStdout = stdoutFromData
+    ? ''
+    : extractFencedSection(rawOutput, 'Stdout') || extractFencedSection(rawOutput, 'Standard Output')
+  const parsedStderr = stderrFromData
+    ? ''
+    : extractFencedSection(rawOutput, 'Stderr') || extractFencedSection(rawOutput, 'Standard Error')
 
   let stdout = stdoutFromData || parsedStdout
   let stderr = stderrFromData || parsedStderr
@@ -94,7 +115,7 @@ export function buildShellExecView(
   }
 
   return {
-    command: asString(record.command) || asString(argumentsRecord.command),
+    command: asString(record.command) || asString(argumentsRecord.command) || skillScriptCommand(record, argumentsRecord),
     workDir: asString(record.work_dir) || asString(argumentsRecord.work_dir),
     exitCode: asNumber(record.exit_code),
     durationMs: asNumber(record.duration_ms),

--- a/frontend/src/views/chat/components/AgentStreamDisplay.vue
+++ b/frontend/src/views/chat/components/AgentStreamDisplay.vue
@@ -1071,7 +1071,9 @@ const isMcpTool = (toolName?: string | null): boolean => String(toolName || '').
 
 const resolveToolDisplayType = (event: any): DisplayType | undefined => {
   if (event?.display_type) return event.display_type as DisplayType
-  if (event?.tool_name === 'shell_exec') return 'shell_exec'
+  if (event?.tool_name === 'shell_exec' || event?.tool_name === 'execute_skill_script') {
+    return 'shell_exec'
+  }
   return undefined
 };
 
@@ -2676,7 +2678,7 @@ const getToolTitle = (event: any): string => {
     if (event.tool_name === 'wiki_search' || event.tool_name === 'wiki_read_page') {
       return `${getLocalizedToolName(event.tool_name)}...`;
     }
-    if (event.tool_name === 'shell_exec') {
+    if (event.tool_name === 'shell_exec' || event.tool_name === 'execute_skill_script') {
       return t('agentStream.toolStatus.shellExecRunning');
     }
     const localizedName = getLocalizedToolName(event.tool_name);
@@ -2774,10 +2776,8 @@ const getToolTitle = (event: any): string => {
     return pageLabel ? `${baseTitle}：「${sanitizeForDisplay(pageLabel)}」` : baseTitle;
   }
 
-  if (toolName === 'shell_exec') {
-    const command = previewShellCommand(
-      String(event.tool_data?.command || event.arguments?.command || ''),
-    )
+  if (toolName === 'shell_exec' || toolName === 'execute_skill_script') {
+    const command = previewShellCommand(skillScriptCommandLabel(event))
     const baseTitle = getToolDescription(event)
     return command ? `${baseTitle}：${command}` : baseTitle
   }
@@ -2786,6 +2786,19 @@ const getToolTitle = (event: any): string => {
   const summary = getToolSummary(event);
   return summary || getToolDescription(event);
 };
+
+const skillScriptCommandLabel = (event: any): string => {
+  const fromData = String(event?.tool_data?.command || event?.arguments?.command || '').trim()
+  if (fromData) return fromData
+  const skill = String(event?.tool_data?.skill_name || event?.arguments?.skill_name || '').trim()
+  const script = String(event?.tool_data?.script_path || event?.arguments?.script_path || '').trim()
+  const path = [skill, script].filter(Boolean).join('/')
+  const args = event?.tool_data?.args || event?.arguments?.args
+  if (Array.isArray(args) && args.length) {
+    return [path, ...args.map((arg: unknown) => String(arg))].filter(Boolean).join(' ')
+  }
+  return path
+}
 
 // Tool description
 const getToolDescription = (event: any): string => {
@@ -2799,7 +2812,7 @@ const getToolDescription = (event: any): string => {
     if (event.tool_name === 'query_understand') {
       return t('agentStream.toolStatus.queryUnderstanding');
     }
-    if (event.tool_name === 'shell_exec') {
+    if (event.tool_name === 'shell_exec' || event.tool_name === 'execute_skill_script') {
       return t('agentStream.toolStatus.shellExecRunning');
     }
     const localizedName = getLocalizedToolName(event.tool_name);
@@ -2832,7 +2845,7 @@ const getToolDescription = (event: any): string => {
     return success ? t('agentStream.toolStatus.attachmentParsingDone') : t('agentStream.toolStatus.attachmentParsingFailed');
   } else if (toolName === 'query_understand') {
     return success ? t('agentStream.toolStatus.queryUnderstandDone') : t('agentStream.toolStatus.calledFailed', { name: getLocalizedToolName(toolName) });
-  } else if (toolName === 'shell_exec') {
+  } else if (toolName === 'shell_exec' || toolName === 'execute_skill_script') {
     const localizedName = getLocalizedToolName(toolName);
     return success ? localizedName : t('agentStream.toolStatus.calledFailed', { name: localizedName });
   } else {

--- a/internal/agent/tools/persist.go
+++ b/internal/agent/tools/persist.go
@@ -144,16 +144,16 @@ func CompactToolOutputForHistory(toolName string, result *types.ToolResult) stri
 	if result == nil {
 		return ""
 	}
-	if !result.Success {
-		if result.Error != "" {
-			return "Error: " + result.Error
-		}
-		return "Error: tool call failed"
-	}
 	if isSandboxContentTool(toolName) {
 		if rebuilt := compactSandboxHistory(result); rebuilt != "" {
-			return rebuilt
+			if result.Success {
+				return rebuilt
+			}
+			return failedToolVisibleContent(rebuilt, result.Error)
 		}
+	}
+	if !result.Success {
+		return failedToolVisibleContent(result.Output, result.Error)
 	}
 	if result.Output != "" && !ShouldOmitRawToolOutput(toolName, result.Data) {
 		return result.Output
@@ -162,7 +162,25 @@ func CompactToolOutputForHistory(toolName string, result *types.ToolResult) stri
 }
 
 func isSandboxContentTool(toolName string) bool {
-	return toolName == ToolShellExec || toolName == ToolReadSandboxFile
+	return toolName == ToolShellExec || toolName == ToolReadSandboxFile || toolName == ToolExecuteSkillScript
+}
+
+// failedToolVisibleContent keeps stdout/stderr (in Output) when a tool fails.
+// Error is often a one-line exit status plus a retry hint; the streams are
+// what the model needs to change arguments instead of guessing.
+func failedToolVisibleContent(output, errMsg string) string {
+	output = strings.TrimSpace(output)
+	errMsg = strings.TrimSpace(errMsg)
+	switch {
+	case output == "" && errMsg == "":
+		return "Error: tool call failed"
+	case output == "":
+		return "Error: " + errMsg
+	case errMsg == "" || strings.Contains(output, errMsg):
+		return output
+	default:
+		return output + "\n\nError: " + errMsg
+	}
 }
 
 func compactHistoricalSandboxOutput(output string) string {

--- a/internal/agent/tools/persist_test.go
+++ b/internal/agent/tools/persist_test.go
@@ -230,3 +230,57 @@ func TestCompactToolOutputForHistory_recoversStreamsFromPlaceholder(t *testing.T
 		t.Fatalf("rebuilt history should keep the command, got %q", history)
 	}
 }
+
+func TestCompactToolOutputForHistory_failedSkillScriptKeepsStdout(t *testing.T) {
+	stdout := `{"chart":{"success":false,"error":{"error":"X轴字段不存在：工作项目","available":["name","value"]}}}`
+	output := "=== Script Execution: smart-charts/scripts/cli.py ===\n\n**Exit Code**: 1\n\n## Standard Output\n\n```\n" + stdout + "\n```\n"
+	errMsg := "Script exited with code 1\n\n[Analyze the error above and try a different approach.]"
+	history := CompactToolOutputForHistory(ToolExecuteSkillScript, &types.ToolResult{
+		Success: false,
+		Output:  output,
+		Error:   errMsg,
+		Data: map[string]interface{}{
+			"display_type": "shell_exec",
+			"command":      "smart-charts/scripts/cli.py --x-axis 工作项目",
+			"exit_code":    1,
+			"stdout":       stdout,
+		},
+	})
+	if !strings.Contains(history, "X轴字段不存在：工作项目") {
+		t.Fatalf("failed skill script history must keep stdout, got %q", history)
+	}
+	if !strings.Contains(history, "Error: Script exited with code 1") {
+		t.Fatalf("failed skill script history must still surface the error, got %q", history)
+	}
+}
+
+func TestSanitizeAgentStepsForStorage_skillScriptKeepsStreamsOnFailure(t *testing.T) {
+	stdout := `{"chart":{"success":false,"error":{"error":"X轴字段不存在：工作项目"}}}`
+	output := "=== Script Execution: smart-charts/scripts/cli.py ===\n\n" + stdout
+	steps := []types.AgentStep{{
+		ToolCalls: []types.ToolCall{{
+			Name: ToolExecuteSkillScript,
+			Result: &types.ToolResult{
+				Success: false,
+				Output:  output,
+				Error:   "Script exited with code 1",
+				Data: map[string]interface{}{
+					"display_type": "shell_exec",
+					"command":      "smart-charts/scripts/cli.py",
+					"exit_code":    1,
+					"stdout":       stdout,
+					"stderr":       "",
+				},
+			},
+		}},
+	}}
+
+	sanitized := SanitizeAgentStepsForStorage(steps)
+	result := sanitized[0].ToolCalls[0].Result
+	if strings.Contains(result.Output, "omitted from history") {
+		t.Fatalf("failed skill script must not collapse to an omit line, got %q", result.Output)
+	}
+	if got, _ := result.Data["stdout"].(string); !strings.Contains(got, "X轴字段不存在") {
+		t.Fatalf("persisted stdout should remain for the UI card, got %#v", result.Data["stdout"])
+	}
+}

--- a/internal/agent/tools/skill_execute.go
+++ b/internal/agent/tools/skill_execute.go
@@ -206,14 +206,16 @@ func (t *ExecuteSkillScriptTool) Execute(ctx context.Context, args json.RawMessa
 	success := result.IsSuccess()
 
 	resultData := map[string]interface{}{
-		"skill_name":  input.SkillName,
-		"script_path": input.ScriptPath,
-		"args":        input.Args,
-		"exit_code":   result.ExitCode,
-		"stdout":      result.Stdout,
-		"stderr":      result.Stderr,
-		"duration_ms": result.Duration.Milliseconds(),
-		"killed":      result.Killed,
+		"display_type": "shell_exec",
+		"command":      skillScriptCommand(input),
+		"skill_name":   input.SkillName,
+		"script_path":  input.ScriptPath,
+		"args":         input.Args,
+		"exit_code":    result.ExitCode,
+		"stdout":       result.Stdout,
+		"stderr":       result.Stderr,
+		"duration_ms":  result.Duration.Milliseconds(),
+		"killed":       result.Killed,
 	}
 
 	logger.Infof(ctx, "[Tool][ExecuteSkillScript] Script completed with exit code: %d", result.ExitCode)
@@ -232,6 +234,18 @@ func (t *ExecuteSkillScriptTool) Execute(ctx context.Context, args json.RawMessa
 			return ""
 		}(),
 	}, nil
+}
+
+func skillScriptCommand(input ExecuteSkillScriptInput) string {
+	parts := make([]string, 0, 1+len(input.Args))
+	switch {
+	case input.SkillName != "" && input.ScriptPath != "":
+		parts = append(parts, input.SkillName+"/"+input.ScriptPath)
+	case input.ScriptPath != "":
+		parts = append(parts, input.ScriptPath)
+	}
+	parts = append(parts, input.Args...)
+	return strings.Join(parts, " ")
 }
 
 // Cleanup releases any resources

--- a/internal/application/service/agent_history.go
+++ b/internal/application/service/agent_history.go
@@ -210,17 +210,11 @@ func filterNonTerminalToolCalls(calls []types.ToolCall) []types.ToolCall {
 }
 
 // toolCallOutput returns the textual content to use for a historical tool
-// message: the recorded Output on success, or an "Error: …" line otherwise so
-// the model can tell that an earlier tool call failed.
+// message. Failures still go through CompactToolOutputForHistory so stdout
+// from a crashed skill script is not dropped in favor of a one-line exit code.
 func toolCallOutput(tc types.ToolCall) string {
 	if tc.Result == nil {
 		return ""
-	}
-	if !tc.Result.Success {
-		if tc.Result.Error != "" {
-			return "Error: " + tc.Result.Error
-		}
-		return "Error: tool call failed"
 	}
 	return agenttools.CompactToolOutputForHistory(tc.Name, tc.Result)
 }

--- a/internal/application/service/agent_history_test.go
+++ b/internal/application/service/agent_history_test.go
@@ -250,6 +250,42 @@ func TestBuildAssistantHistoryMessages_ToolFailureSurfacesAsError(t *testing.T) 
 	}, got[1])
 }
 
+func TestBuildAssistantHistoryMessages_SkillScriptFailureKeepsStdout(t *testing.T) {
+	stdout := `{"chart":{"success":false,"error":{"error":"X轴字段不存在：工作项目"}}}`
+	msg := &types.Message{
+		Role:    "assistant",
+		Content: "I will retry with a different axis.",
+		AgentSteps: types.AgentSteps{
+			{
+				Iteration: 0,
+				Thought:   "Plot the chart.",
+				ToolCalls: []types.ToolCall{
+					{
+						ID:   "call_skill",
+						Name: agenttools.ToolExecuteSkillScript,
+						Args: map[string]interface{}{"skill_name": "smart-charts", "script_path": "scripts/cli.py"},
+						Result: &types.ToolResult{
+							Success: false,
+							Output:  "=== Script Execution ===\n" + stdout,
+							Error:   "Script exited with code 1",
+							Data: map[string]interface{}{
+								"display_type": "shell_exec",
+								"stdout":       stdout,
+								"exit_code":    1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	got := buildAssistantHistoryMessages(msg)
+	require.Len(t, got, 3)
+	assert.Equal(t, "tool", got[1].Role)
+	assert.Contains(t, got[1].Content, "X轴字段不存在：工作项目")
+	assert.Contains(t, got[1].Content, "Error: Script exited with code 1")
+}
+
 // TestFilterNonTerminalToolCalls confirms a legacy final_answer entry is
 // dropped — every other tool (KB search, web search, MCP tools…) must survive.
 func TestFilterNonTerminalToolCalls(t *testing.T) {

--- a/internal/modelcontext/model_output.go
+++ b/internal/modelcontext/model_output.go
@@ -27,10 +27,7 @@ func (r *sourceRegistry) ModelOutput(result *types.ToolResult) string {
 		return r.modelWebFetchOutput(mapsValue(result.Data["results"]), result.Output)
 	}
 	if !result.Success {
-		if result.Error != "" {
-			return "Error: " + r.CompactKnownText(result.Error)
-		}
-		return "Error: tool call failed"
+		return failedToolModelText(result.Output, result.Error)
 	}
 	switch displayType {
 	case "grep_results":
@@ -476,6 +473,26 @@ func truncateModelEvidence(value string, maxRunes int) (string, bool) {
 		return "", true
 	}
 	return string(runes[:maxRunes]), true
+}
+
+// failedToolModelText is what the model should see for a failed tool call.
+// Script and shell failures put the useful diagnostics in Output (stdout /
+// stderr); Error is often just "exited with code 1" plus a retry hint.
+// Putting Output first makes "[Analyze the error above ...]" refer to the
+// actual streams.
+func failedToolModelText(output, errMsg string) string {
+	output = strings.TrimSpace(output)
+	errMsg = strings.TrimSpace(errMsg)
+	switch {
+	case output == "" && errMsg == "":
+		return "Error: tool call failed"
+	case output == "":
+		return "Error: " + errMsg
+	case errMsg == "" || strings.Contains(output, errMsg):
+		return output
+	default:
+		return output + "\n\nError: " + errMsg
+	}
 }
 
 func mapsValue(value interface{}) []map[string]interface{} {

--- a/internal/modelcontext/registry.go
+++ b/internal/modelcontext/registry.go
@@ -250,7 +250,7 @@ func (r *Registry) ModelToolResultForTool(toolName string, result *types.ToolRes
 		if result.Success {
 			return result.Output
 		}
-		return result.Error
+		return failedToolModelText(result.Output, result.Error)
 	}
 	// Protect durable resources and UUID-bearing summary slugs before the
 	// source codec sees any embedded document IDs. Encode once more afterwards
@@ -266,10 +266,8 @@ func (r *Registry) ModelToolResultForTool(toolName string, result *types.ToolRes
 		modelOutput = r.sources.ModelOutput(&copyResult)
 	} else if copyResult.Success {
 		modelOutput = copyResult.Output
-	} else if copyResult.Error != "" {
-		modelOutput = "Error: " + copyResult.Error
 	} else {
-		modelOutput = "Error: tool call failed"
+		modelOutput = failedToolModelText(copyResult.Output, copyResult.Error)
 	}
 	// Even tools without structured source results can surface a known durable
 	// ID in validation errors or status text. Compact only explicitly declared

--- a/internal/modelcontext/registry_test.go
+++ b/internal/modelcontext/registry_test.go
@@ -272,6 +272,19 @@ func TestRegistryCompactsKnownIDsInBuiltInValidationErrors(t *testing.T) {
 	require.Equal(t, "Error: document d1 belongs to knowledge base b1", got)
 }
 
+func TestModelToolResultForTool_failedSkillScriptKeepsStdout(t *testing.T) {
+	registry := NewRegistry(true)
+	stdout := `{"chart":{"success":false,"error":{"error":"X轴字段不存在：工作项目","available":["name","value"]}}}`
+	got := registry.ModelToolResultForTool("execute_skill_script", &types.ToolResult{
+		Success: false,
+		Output:  "=== Script Execution: smart-charts/scripts/cli.py ===\n\n## Standard Output\n\n```\n" + stdout + "\n```\n",
+		Error:   "Script exited with code 1\n\n[Analyze the error above and try a different approach.]",
+	})
+	require.Contains(t, got, "X轴字段不存在：工作项目")
+	require.Contains(t, got, "available")
+	require.Contains(t, got, "Error: Script exited with code 1")
+}
+
 func TestRegistryCompactsDatabaseQueryIDColumnsForBuiltInFollowUps(t *testing.T) {
 	registry := NewRegistry(true)
 	modelOutput := registry.ModelToolResultForTool("database_query", &types.ToolResult{


### PR DESCRIPTION
## Summary
- Failed `execute_skill_script` calls were reduced to `Script exited with code 1` plus a retry hint, so the chat card hid the real stdout/stderr and the next model round could not see errors like a missing chart axis.
- Keep stdout/stderr on the failure path for the current-round tool message, historical replay, and the terminal card (`display_type: shell_exec`).

## Test plan
- [ ] Run a skill script that exits non-zero with a structured stdout error (e.g. invalid `--x-axis`) and confirm the chat card shows the JSON/error body, not only `exited with code 1`.
- [ ] Confirm the next agent round uses that stdout (e.g. switches to an available field instead of changing chart type blindly).
- [ ] Reload the conversation and confirm the failed card still shows stdout.
- [ ] `go test ./internal/agent/tools ./internal/modelcontext ./internal/application/service`
- [ ] `npx tsx --test src/utils/shellExecResult.test.ts src/composables/useChatStreamHandler.test.mjs` (from `frontend/`)