### PR TITLE
fix(frontend): extend multipart upload timeouts

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -17,6 +17,9 @@ server {
     server_name localhost;
     # Default 50M, configured via MAX_FILE_SIZE_MB env var
     client_max_body_size ${MAX_FILE_SIZE};
+    # Large uploads over slower links may pause while nginx is still reading
+    # the multipart body. Keep this aligned with the API proxy timeouts.
+    client_body_timeout 3600s;
 
     # 启用 gzip 压缩静态资源 (前端 index.js 单文件 ~1MB, 不压实测 20s+,
     # 压缩后约 200-300KB, 大陆同地域低带宽机器加载从 25s 降到 3-5s)

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -264,6 +264,9 @@ export function postUpload(
   config: any = {},
 ): Promise<any> {
   return instance.post(url, data, {
+    // Large uploads can take longer than the 30-second API default before
+    // nginx has buffered the request body and the backend can respond.
+    timeout: 60 * 60 * 1000,
     ...config,
     headers: {
       "Content-Type": "multipart/form-data",


### PR DESCRIPTION
## Description

Large multipart uploads inherit the shared Axios 30-second timeout. On slower links, nginx may still be receiving or buffering the request body when the browser aborts, which surfaces as a generic network error even though the configured size limit allows the file.

This change:
- gives multipart uploads a one-hour Axios timeout while preserving per-call overrides;
- aligns nginx `client_body_timeout` with the existing one-hour API proxy timeouts.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing
- `npm run type-check`
- `npm run build`
- rendered `frontend/nginx.conf` with the production entrypoint variables and ran `nginx -t`
- `git diff --check origin/main...HEAD`

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A
