### PR TITLE
fix(graph): increase entity extraction output budget

### DIFF
--- a/internal/application/service/chat_pipeline/extract_entity.go
+++ b/internal/application/service/chat_pipeline/extract_entity.go
@@ -151,6 +151,9 @@ func (p *PluginExtractEntity) OnEvent(ctx context.Context,
 	return next()
 }
 
+// Graph extraction can return many nodes and relations; 4096 tokens can truncate the JSON payload.
+const entityExtractionMaxTokens = 8192
+
 // Extractor is a struct for extracting entities
 type Extractor struct {
 	chat     chat.Chat
@@ -171,7 +174,7 @@ func NewExtractor(
 		template: template,
 		chatOpt: &chat.ChatOptions{
 			Temperature: 0.3,
-			MaxTokens:   4096,
+			MaxTokens:   entityExtractionMaxTokens,
 			Thinking:    &think,
 		},
 	}

--- a/internal/application/service/chat_pipeline/extract_entity_test.go
+++ b/internal/application/service/chat_pipeline/extract_entity_test.go
@@ -259,3 +259,10 @@ func TestIsLikelyLanguageTag(t *testing.T) {
 		})
 	}
 }
+
+func TestNewExtractorUsesGraphOutputBudget(t *testing.T) {
+	extractor := NewExtractor(nil, nil)
+	if got := extractor.chatOpt.MaxTokens; got != 8192 {
+		t.Fatalf("MaxTokens = %d, want 8192", got)
+	}
+}


### PR DESCRIPTION
## Description

Entity/relationship extraction can produce JSON responses containing many nodes and relations. The previous 4096-token output budget can truncate otherwise valid graph payloads before the closing JSON structure, causing parsing failures during both document graph extraction and query entity extraction because both paths use `NewExtractor`.

This change raises that shared output budget to 8192 tokens and adds a regression test for the configured extractor options.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🧪 Test

## Related Issue

N/A

## Testing
- `go test ./internal/application/service/chat_pipeline -count=1`
- `go vet ./internal/application/service/chat_pipeline`
- `git diff --check origin/main...HEAD`

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A
