### PR TITLE
fix(wiki): skip ambiguous single-Han auto-links

### DIFF
--- a/internal/application/service/wiki_linkify.go
+++ b/internal/application/service/wiki_linkify.go
@@ -47,6 +47,14 @@ func linkifyContent(content string, refs []linkRef, selfSlug string) (string, bo
 		if r.slug == selfSlug {
 			continue
 		}
+		// A single Han character has no reliable token boundary in unsegmented
+		// Chinese prose. Substring-linking it would turn words such as 风沙、
+		// 栏目 and 核心 into broken links. Keep one-character Wiki pages and
+		// any explicit [[...]] links authored by the generator, but never
+		// inject a new cross-link for such a surface form.
+		if isSingleHanRune(r.matchText) {
+			continue
+		}
 		sorted = append(sorted, r)
 	}
 	sort.SliceStable(sorted, func(i, j int) bool {
@@ -123,6 +131,15 @@ func hasASCIILetterEdge(s string) bool {
 	first, _ := utf8.DecodeRuneInString(s)
 	last, _ := utf8.DecodeLastRuneInString(s)
 	return isASCIIWordRune(first) || isASCIIWordRune(last)
+}
+
+// isSingleHanRune reports whether s consists of exactly one Han character.
+func isSingleHanRune(s string) bool {
+	if s == "" {
+		return false
+	}
+	r, size := utf8.DecodeRuneInString(s)
+	return size == len(s) && unicode.Is(unicode.Han, r)
 }
 
 func isASCIIWordRune(r rune) bool {

--- a/internal/application/service/wiki_linkify_test.go
+++ b/internal/application/service/wiki_linkify_test.go
@@ -37,6 +37,34 @@ func TestLinkifyContent_LongerNameWinsOverSubstring(t *testing.T) {
 	}
 }
 
+func TestLinkifyContent_SkipsSingleHanRuneAutoLink(t *testing.T) {
+	refs := []linkRef{
+		{slug: "entity/feng", matchText: "风"},
+	}
+	in := "穿越河西走廊体验大漠风沙。"
+	got, changed := linkifyContent(in, refs, "")
+	if changed {
+		t.Fatalf("single Han rune must not be auto-linked: %q", got)
+	}
+	if got != in {
+		t.Fatalf("content changed: got %q, want %q", got, in)
+	}
+}
+
+func TestLinkifyContent_PreservesExplicitSingleHanRuneLink(t *testing.T) {
+	refs := []linkRef{
+		{slug: "entity/feng", matchText: "风"},
+	}
+	in := "寓言中，[[entity/feng|风]]羡慕目。"
+	got, changed := linkifyContent(in, refs, "")
+	if changed {
+		t.Fatalf("explicit single-character link must be preserved without reinjection: %q", got)
+	}
+	if got != in {
+		t.Fatalf("content changed: got %q, want %q", got, in)
+	}
+}
+
 func TestLinkifyContent_ASCIIWordBoundary(t *testing.T) {
 	refs := []linkRef{
 		{slug: "ai", matchText: "AI"},


### PR DESCRIPTION
## Description

Wiki auto-linking currently treats a one-character Han page title as a safe substring match. Chinese prose has no whitespace token boundary, so a page such as `风` can be injected inside `风沙`, and `目` inside `栏目`, splitting normal words into incorrect links.

This change skips automatic cross-link injection when the surface form is exactly one Han character. It does not remove one-character Wiki pages and it preserves explicit `[[slug|label]]` links produced by the generator or author.

Regression tests cover both the false-positive substring and explicit-link preservation.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🧪 Test

## Related Issue

N/A

## Testing
- `go test ./internal/application/service -run 'TestLinkifyContent|TestFindFirstSafeMatch|TestComputeForbiddenSpans' -count=1`
- `go vet ./internal/application/service`
- `git diff --check origin/main...HEAD`

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A
