### PR TITLE
feat(deploy): add isolated Neo4j compose override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -324,6 +324,15 @@ RETRIEVE_DRIVER=postgres
 # NEO4J_URI=bolt://neo4j:7687
 # NEO4J_USERNAME=neo4j
 # NEO4J_PASSWORD=password
+# Optional settings used by docker-compose.neo4j-isolated.yml. The override
+# binds Neo4j to localhost and gives it a predictable memory ceiling.
+# NEO4J_BIND_IP=127.0.0.1
+# NEO4J_HTTP_PORT=7474
+# NEO4J_BOLT_PORT=7687
+# NEO4J_HEAP_INITIAL_SIZE=256m
+# NEO4J_HEAP_MAX_SIZE=1g
+# NEO4J_PAGECACHE_SIZE=512m
+# NEO4J_MEMORY_LIMIT=2g
 
 
 # #####################################################################

--- a/docker-compose.neo4j-isolated.yml
+++ b/docker-compose.neo4j-isolated.yml
@@ -1,0 +1,16 @@
+# Optional Neo4j override for self-hosted deployments that should not expose
+# Neo4j beyond the host and need a predictable memory ceiling.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.neo4j-isolated.yml \
+#     --profile neo4j up -d
+services:
+  neo4j:
+    ports: !override
+      - "${NEO4J_BIND_IP:-127.0.0.1}:${NEO4J_HTTP_PORT:-7474}:7474"
+      - "${NEO4J_BIND_IP:-127.0.0.1}:${NEO4J_BOLT_PORT:-7687}:7687"
+    environment:
+      NEO4J_server_memory_heap_initial__size: ${NEO4J_HEAP_INITIAL_SIZE:-256m}
+      NEO4J_server_memory_heap_max__size: ${NEO4J_HEAP_MAX_SIZE:-1g}
+      NEO4J_server_memory_pagecache_size: ${NEO4J_PAGECACHE_SIZE:-512m}
+    mem_limit: ${NEO4J_MEMORY_LIMIT:-2g}

--- a/docs/KnowledgeGraph.md
+++ b/docs/KnowledgeGraph.md
@@ -10,8 +10,19 @@
 
 - 启动 Neo4j
 ```bash
-docker-compose --profile neo4j up -d
+docker compose --profile neo4j up -d
 ```
+
+### 可选：仅本机访问并限制内存
+
+需要避免 Neo4j 端口对外暴露，或希望在资源有限的自托管主机上限制其内存时，可叠加仓库提供的独立配置：
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.neo4j-isolated.yml \
+  --profile neo4j up -d
+```
+
+该配置默认只监听 `127.0.0.1:7474` 和 `127.0.0.1:7687`，并将容器内存限制为 2 GiB。端口、监听地址、堆内存和 page cache 均可通过 `.env.example` 中的 `NEO4J_*` 变量调整。`!override` 需要 Docker Compose 2.24.4 或更高版本。
 
 - 在知识库设置页面启用实体和关系提取，并根据提示配置相关内容
 


### PR DESCRIPTION
## Description

The default Neo4j profile exposes Browser and Bolt ports on every host interface and leaves resource sizing to the container runtime. Self-hosted installations on shared or memory-constrained machines currently have to edit the main Compose file to bind Neo4j locally and cap its memory.

This change adds an opt-in `docker-compose.neo4j-isolated.yml` override that:
- binds Browser and Bolt to `127.0.0.1` by default;
- applies a predictable 2 GiB container limit with configurable heap and page cache;
- keeps every value configurable through documented `NEO4J_*` variables;
- leaves the default `docker-compose.yml` behavior unchanged.

The knowledge graph documentation includes the compose command and the Docker Compose version required by the `!override` merge tag.

## Type of Change
- [x] ✨ New feature
- [x] 📚 Documentation update
- [x] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing
- rendered the default override with `docker compose ... config` and verified localhost bindings, memory limit, heap, and page cache;
- rendered a second configuration with custom bind address, ports, heap, and memory limit and verified all overrides;
- `git diff --check origin/main...HEAD`.

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [x] Updated related documentation
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A
