### PR TITLE
fix: return all chunk types in chunk list by default

### DIFF
--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -199,8 +199,11 @@ func (r *chunkRepository) ListPagedChunksByKnowledgeID(
 	keyword = strings.TrimSpace(keyword)
 
 	baseFilter := func(db *gorm.DB) *gorm.DB {
-		db = db.Where("tenant_id = ? AND knowledge_id = ? AND chunk_type IN (?) AND status in (?)",
-			tenantID, knowledgeID, chunkType, []int{int(types.ChunkStatusIndexed), int(types.ChunkStatusDefault)})
+		db = db.Where("tenant_id = ? AND knowledge_id = ? AND status in (?)",
+			tenantID, knowledgeID, []int{int(types.ChunkStatusIndexed), int(types.ChunkStatusDefault)})
+		if len(chunkType) > 0 {
+			db = db.Where("chunk_type IN (?)", chunkType)
+		}
 		if len(tagIDs) > 0 {
 			db = db.Where("tag_id IN ?", tagIDs)
 		}

--- a/internal/application/repository/chunk_sqlite_test.go
+++ b/internal/application/repository/chunk_sqlite_test.go
@@ -267,6 +267,55 @@ func TestListPagedChunksByKnowledgeID_FiltersEnabledState(t *testing.T) {
 	assert.Len(t, allChunks, 2)
 }
 
+func TestListPagedChunksByKnowledgeID_WithoutChunkTypeReturnsAllTypes(t *testing.T) {
+	db := setupChunkTestDB(t)
+	repo := NewChunkRepository(db)
+	ctx := context.Background()
+
+	chunks := []*types.Chunk{
+		makeChunk("kb-1", "doc-1", types.ChunkTypeText),
+		makeChunk("kb-1", "doc-1", types.ChunkTypeImageOCR),
+		makeChunk("kb-1", "doc-1", types.ChunkTypeImageCaption),
+		makeChunk("kb-1", "doc-2", types.ChunkTypeText),
+		makeChunk("kb-1", "doc-1", types.ChunkTypeText),
+	}
+	chunks[4].TenantID = 2
+	require.NoError(t, repo.CreateChunks(ctx, chunks))
+
+	got, total, err := repo.ListPagedChunksByKnowledgeID(
+		ctx, 1, "doc-1", &types.Pagination{Page: 1, PageSize: 20},
+		nil, nil, "", "", "", "", nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), total)
+	require.Len(t, got, 3)
+	assert.ElementsMatch(t,
+		[]string{types.ChunkTypeText, types.ChunkTypeImageOCR, types.ChunkTypeImageCaption},
+		[]string{got[0].ChunkType, got[1].ChunkType, got[2].ChunkType},
+	)
+}
+
+func TestListPagedChunksByKnowledgeID_WithChunkTypePreservesFilter(t *testing.T) {
+	db := setupChunkTestDB(t)
+	repo := NewChunkRepository(db)
+	ctx := context.Background()
+
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{
+		makeChunk("kb-1", "doc-1", types.ChunkTypeText),
+		makeChunk("kb-1", "doc-1", types.ChunkTypeImageOCR),
+		makeChunk("kb-1", "doc-1", types.ChunkTypeImageCaption),
+	}))
+
+	got, total, err := repo.ListPagedChunksByKnowledgeID(
+		ctx, 1, "doc-1", &types.Pagination{Page: 1, PageSize: 20},
+		[]types.ChunkType{types.ChunkTypeImageOCR}, nil, "", "", "", "", nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, got, 1)
+	assert.Equal(t, types.ChunkTypeImageOCR, got[0].ChunkType)
+}
+
 func makeSuggestedFAQChunk(t *testing.T, kbID, knowledgeID, tagID, question string) *types.Chunk {
 	t.Helper()
 	chunk := makeChunk(kbID, knowledgeID, types.ChunkTypeFAQ)

--- a/internal/handler/chunk.go
+++ b/internal/handler/chunk.go
@@ -124,8 +124,8 @@ func (h *ChunkHandler) ListKnowledgeChunks(c *gin.Context) {
 		pagination.PageSize = 100
 	}
 
-	// Default to text chunks; callers may override via ?chunk_type=image_caption etc.
-	chunkType := []types.ChunkType{types.ChunkTypeText}
+	// Filter by chunk type only when explicitly requested.
+	var chunkType []types.ChunkType
 	if queryTypes := c.QueryArray("chunk_type"); len(queryTypes) > 0 {
 		chunkType = make([]types.ChunkType, 0, len(queryTypes))
 		for _, qt := range queryTypes {


### PR DESCRIPTION
## Description

Fix the knowledge chunk listing behavior so requests without an explicit `chunk_type` filter return all chunk types instead of defaulting to `text` only.

This change:

- Removes the implicit `text` default from `ListKnowledgeChunks`
- Treats an empty chunk type list as no chunk type restriction in the repository query
- Preserves explicit `chunk_type` filtering
- Adds regression coverage for unfiltered and explicitly filtered queries

As a result, multimodal chunks such as `image_ocr` and `image_caption` are included in the default chunk list and total count.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test
- [ ] Configuration / Build / CI

## Related Issue

Fixes #2857

## Testing

Passed:

```bash
gofmt -l internal/handler/chunk.go internal/application/repository/chunk.go internal/application/repository/chunk_sqlite_test.go
go test ./internal/application/repository -count=1
go test ./internal/handler -run '^$' -count=1
golangci-lint run --new-from-rev=origin/main ./internal/application/repository ./internal/handler
git diff --check origin/main...HEAD
```

The repository regression tests cover:

- No chunk type filter returns `text`, `image_ocr`, and `image_caption` for the requested knowledge
- Tenant and knowledge boundaries remain enforced
- An explicit `image_ocr` filter still returns only that type

Additional repository-wide checks were attempted:

- `go test ./internal/handler -count=1` is blocked by the existing `TestDeploymentCapabilityKeysMatchFrontend` frontend key parsing mismatch
- `go test ./... -count=1` is blocked on this Windows environment by a missing `sqlite3.h`, DuckDB and MinGW linker incompatibilities, and an existing Windows path separator assertion
- `golangci-lint run --new-from-rev=origin/main ./...` reported 0 issues before type checking stopped at the same missing `sqlite3.h` dependency

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages pass
- [x] Diff-scoped lint passes for the changed packages
- [x] Full-repository checks were run and environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added tests covering the change
- [x] Documentation and Swagger updates are not required because the existing endpoint description already states that it lists all chunks
- [x] This change introduces no breaking API or schema changes

## Screenshots / Recordings

Not applicable. This is a backend query behavior fix with no UI change.
