### PR TITLE
fix: reconcile direct invites after share-link join

### DIFF
--- a/internal/application/service/tenant_invitation.go
+++ b/internal/application/service/tenant_invitation.go
@@ -287,6 +287,23 @@ func (s *tenantInvitationService) MarkPendingAcceptedIfExists(
 	return s.repo.MarkStatusIfPending(ctx, inv.ID, types.TenantInvitationStatusAccepted, s.now())
 }
 
+// reconcilePendingInvitation closes a per-user invitation after another
+// successful join path (for example a multi-use share link) has already
+// established the membership. This keeps the invitation inbox consistent
+// without turning a bookkeeping failure into a failed join after the member
+// row has already been committed.
+func (s *tenantInvitationService) reconcilePendingInvitation(
+	ctx context.Context,
+	tenantID uint64,
+	inviteeUserID string,
+) {
+	if err := s.MarkPendingAcceptedIfExists(ctx, tenantID, inviteeUserID); err != nil {
+		logger.Warnf(ctx,
+			"failed to reconcile pending invitation for tenant %d user %s: %v",
+			tenantID, inviteeUserID, err)
+	}
+}
+
 // emitInvitationAccepted writes the rbac.invitation_accepted audit row.
 // Actor is the invitee (acting on their own inbox); target is the same
 // user since the action is self-directed.
@@ -578,6 +595,7 @@ func (s *tenantInvitationService) AcceptByToken(
 		if errors.Is(err, ErrMembershipAlreadyExists) {
 			existing, getErr := s.memberSvc.GetMembership(ctx, newUserID, inv.TenantID)
 			if getErr == nil && existing != nil {
+				s.reconcilePendingInvitation(ctx, inv.TenantID, newUserID)
 				return existing, nil
 			}
 		}
@@ -595,6 +613,10 @@ func (s *tenantInvitationService) AcceptByToken(
 			"share-link %d accepted_count bump failed (membership still created): %v",
 			inv.ID, incErr)
 	}
+	// A user may have received a direct invitation and then joined through
+	// a share link first. Close that direct invitation now so its notification
+	// cannot be accepted a second time and produce a misleading audit event.
+	s.reconcilePendingInvitation(ctx, inv.TenantID, newUserID)
 	s.emitAudit(ctx, &types.AuditLog{
 		TenantID:     inv.TenantID,
 		ActorUserID:  auditActor(ctx),

--- a/internal/application/service/tenant_invitation_test.go
+++ b/internal/application/service/tenant_invitation_test.go
@@ -558,6 +558,66 @@ func TestInvitationService_AcceptByToken_AllowsMultipleUsers(t *testing.T) {
 	}
 }
 
+func TestInvitationService_AcceptByToken_ReconcilesDirectInvitation(t *testing.T) {
+	svc, repo, _ := newInvitationSvc()
+	ctx := context.Background()
+	direct, err := svc.Create(ctx, 1, "u-alice", types.TenantRoleViewer, nil, "")
+	if err != nil {
+		t.Fatalf("create direct invitation: %v", err)
+	}
+	_, plain, err := svc.CreateShareLink(ctx, 1, types.TenantRoleViewer, nil, "")
+	if err != nil {
+		t.Fatalf("create share link: %v", err)
+	}
+
+	if _, err := svc.AcceptByToken(ctx, plain, "u-alice"); err != nil {
+		t.Fatalf("accept by token: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, direct.ID)
+	if err != nil {
+		t.Fatalf("get direct invitation: %v", err)
+	}
+	if got.Status != types.TenantInvitationStatusAccepted {
+		t.Fatalf("direct invitation must be reconciled as accepted, got %s", got.Status)
+	}
+	pending, err := svc.CountPendingByInvitee(ctx, "u-alice")
+	if err != nil {
+		t.Fatalf("count pending: %v", err)
+	}
+	if pending != 0 {
+		t.Fatalf("joined user must not retain an actionable invitation, got %d", pending)
+	}
+}
+
+func TestInvitationService_AcceptByToken_ReconcilesDirectInvitationForExistingMember(t *testing.T) {
+	svc, repo, memberSvc := newInvitationSvc()
+	ctx := context.Background()
+	direct, err := svc.Create(ctx, 1, "u-alice", types.TenantRoleViewer, nil, "")
+	if err != nil {
+		t.Fatalf("create direct invitation: %v", err)
+	}
+	_, plain, err := svc.CreateShareLink(ctx, 1, types.TenantRoleViewer, nil, "")
+	if err != nil {
+		t.Fatalf("create share link: %v", err)
+	}
+	if _, err := memberSvc.AddMember(ctx, "u-alice", 1, types.TenantRoleViewer, nil); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+
+	if _, err := svc.AcceptByToken(ctx, plain, "u-alice"); err != nil {
+		t.Fatalf("idempotent accept by token: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, direct.ID)
+	if err != nil {
+		t.Fatalf("get direct invitation: %v", err)
+	}
+	if got.Status != types.TenantInvitationStatusAccepted {
+		t.Fatalf("direct invitation must be reconciled for an existing member, got %s", got.Status)
+	}
+}
+
 func TestInvitationService_AcceptByToken_RevokedTokenRejected(t *testing.T) {
 	svc, _, _ := newInvitationSvc()
 	ctx := context.Background()

--- a/internal/types/interfaces/tenant_invitation_service.go
+++ b/internal/types/interfaces/tenant_invitation_service.go
@@ -92,7 +92,9 @@ type TenantInvitationService interface {
 	// the invitation row into a terminal state — share-link rows stay
 	// pending so subsequent invitees can also register through the
 	// same link. Idempotent: if the user already has membership, the
-	// existing row is returned.
+	// existing row is returned. If the same user also has a pending direct
+	// invitation for the tenant, it is reconciled to accepted so the inbox
+	// cannot offer a second acceptance after membership already exists.
 	AcceptByToken(ctx context.Context, plainToken string, newUserID string) (*types.TenantMember, error)
 
 	// MarkPendingAcceptedIfExists transitions a per-user pending invitation


### PR DESCRIPTION
## Description

修复同一用户同时收到定向邀请和共享链接时的重复邀请问题。

此前，用户通过共享链接成功加入空间后，同一空间中的定向邀请仍保持 `pending` 状态，导致：

- 邀请通知仍然显示并可再次接受
- 用户可以重复执行接受邀请操作
- 审计日志产生误导性的重复接受记录

本次修改在共享链接成功建立成员关系后，将该用户在同一空间中的待处理定向邀请同步标记为 `accepted`。

同时覆盖以下场景：

- 用户首次通过共享链接加入空间
- 用户已经是空间成员，再次幂等访问共享链接
- 共享链接本身继续保持可供其他用户使用的多次邀请语义
- 邀请状态同步失败不会回滚已经成功创建的成员关系

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Testing

已通过邀请服务的定向测试：

```shell
go test ./internal/application/service -run 'TestInvitationService_(AcceptByToken|MarkPendingAcceptedIfExists)' -count=1
```

新增回归测试：

- `TestInvitationService_AcceptByToken_ReconcilesDirectInvitation`
- `TestInvitationService_AcceptByToken_ReconcilesDirectInvitationForExistingMember`

同时执行了以下完整包测试：

```shell
go test ./internal/application/service ./internal/handler
```


## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.) — not required; no public API behavior or configuration changed
- [x] Breaking changes are clearly called out in the description above — no breaking changes

## Screenshots / Recordings

问题复现：



https://github.com/user-attachments/assets/c3f1ada4-49b3-4341-a447-a28c1bdc5cfa

