### PR TITLE
fix(skills): map ClawHub @owner/slug to slug plus ownerHandle

### DIFF
--- a/internal/application/service/tenant_skill_source.go
+++ b/internal/application/service/tenant_skill_source.go
@@ -53,7 +53,7 @@ type parsedSkillSource struct {
 	Registry  string // origin, e.g. https://clawhub.ai or a SkillHub host
 	Slug      string
 	Version   string
-	Owner     string
+	Owner     string // GitHub/GitLab owner, or ClawHub ownerHandle
 	Repo      string
 	Ref       string
 	Subdir    string
@@ -123,11 +123,12 @@ func fetchSkillArchive(ctx context.Context, source string, client *http.Client) 
 }
 
 // parseSkillSource maps one paste onto exactly one kind. It does not probe
-// the network to guess: owner/slug is both a ClawHub id and a GitHub repo,
-// so a slash without a URL or a leading @ is refused rather than fetched
-// twice.
+// the network to guess: owner/slug is both a ClawHub locator and a GitHub
+// repo, so a slash without a URL or a leading @ is refused rather than
+// fetched twice.
 //
-//	@owner/slug          ClawHub (default registry)
+//	@owner/slug          ClawHub (default registry). The API slug is the
+//	                     last segment; owner becomes ownerHandle.
 //	my-skill             ClawHub slug (no slash)
 //	my-skill@1.2.0       ClawHub slug + version
 //	https://…            host decides (GitHub / GitLab / ClawHub / SkillHub /
@@ -264,12 +265,16 @@ func parseRegistryURL(u *url.URL) (parsedSkillSource, error) {
 	if qVersion := strings.TrimSpace(u.Query().Get("version")); qVersion != "" {
 		version = qVersion
 	}
-	return parsedSkillSource{
+	src := parsedSkillSource{
 		Kind:     skillSourceRegistry,
 		Registry: origin,
 		Slug:     slug,
 		Version:  version,
-	}, nil
+	}
+	if isClawHubHost(u.Hostname()) {
+		src.Owner, src.Slug = splitClawHubOwnerSlug(slug)
+	}
+	return src, nil
 }
 
 func parseRegistrySlug(origin, spec string) (parsedSkillSource, error) {
@@ -281,12 +286,41 @@ func parseRegistrySlug(origin, spec string) (parsedSkillSource, error) {
 	if slug == "" {
 		return parsedSkillSource{}, fmt.Errorf("%w: skill slug is required", ErrSkillSourceInvalid)
 	}
-	return parsedSkillSource{
+	src := parsedSkillSource{
 		Kind:     skillSourceRegistry,
 		Registry: origin,
 		Slug:     slug,
 		Version:  version,
-	}, nil
+	}
+	if isClawHubOrigin(origin) {
+		src.Owner, src.Slug = splitClawHubOwnerSlug(slug)
+	}
+	return src, nil
+}
+
+func isClawHubOrigin(origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil || u.Hostname() == "" {
+		return false
+	}
+	return isClawHubHost(u.Hostname())
+}
+
+// splitClawHubOwnerSlug turns a ClawHub locator into the API slug.
+// ClawHub pages and CLI refs look like owner/slug, but GET /api/v1/download
+// keys by the skill slug alone and takes the publisher as ownerHandle.
+func splitClawHubOwnerSlug(spec string) (owner, slug string) {
+	parts := splitPath(spec)
+	switch len(parts) {
+	case 0:
+		return "", spec
+	case 1:
+		return "", parts[0]
+	case 2:
+		return parts[0], parts[1]
+	default:
+		return "", spec
+	}
 }
 
 func slugAndVersionFromPath(trimmed, fragment string) (string, string, error) {
@@ -461,6 +495,9 @@ func (s parsedSkillSource) fetchURL() (string, error) {
 		}
 		q := u.Query()
 		q.Set("slug", s.Slug)
+		if s.Owner != "" {
+			q.Set("ownerHandle", s.Owner)
+		}
 		if s.Version != "" && !strings.EqualFold(s.Version, "latest") {
 			if semverLike.MatchString(s.Version) {
 				q.Set("version", s.Version)

--- a/internal/application/service/tenant_skill_source_test.go
+++ b/internal/application/service/tenant_skill_source_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -23,7 +24,7 @@ func TestParseSkillSource(t *testing.T) {
 			in:   "@lyingbug/weknora",
 			want: parsedSkillSource{
 				Kind: skillSourceRegistry, Registry: defaultSkillRegistryOrigin,
-				Slug: "lyingbug/weknora",
+				Owner: "lyingbug", Slug: "weknora",
 			},
 		},
 		{
@@ -31,7 +32,7 @@ func TestParseSkillSource(t *testing.T) {
 			in:   "https://clawhub.ai/lyingbug/weknora",
 			want: parsedSkillSource{
 				Kind: skillSourceRegistry, Registry: "https://clawhub.ai",
-				Slug: "lyingbug/weknora",
+				Owner: "lyingbug", Slug: "weknora",
 			},
 		},
 		{
@@ -39,7 +40,15 @@ func TestParseSkillSource(t *testing.T) {
 			in:   "https://clawhub.ai/steipete/skills/github",
 			want: parsedSkillSource{
 				Kind: skillSourceRegistry, Registry: "https://clawhub.ai",
-				Slug: "steipete/github",
+				Owner: "steipete", Slug: "github",
+			},
+		},
+		{
+			name: "clawhub owner skills path",
+			in:   "https://clawhub.ai/jixinyi546-maker/skills/emar-ppt-skill",
+			want: parsedSkillSource{
+				Kind: skillSourceRegistry, Registry: "https://clawhub.ai",
+				Owner: "jixinyi546-maker", Slug: "emar-ppt-skill",
 			},
 		},
 		{
@@ -161,13 +170,33 @@ func TestParseSkillSourceAtSlugIsRegistryNotGitHub(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, skillSourceRegistry, got.Kind)
 	require.Equal(t, defaultSkillRegistryOrigin, got.Registry)
-	require.Equal(t, "clawhub_pskoett/self-improving-agent", got.Slug)
+	require.Equal(t, "clawhub_pskoett", got.Owner)
+	require.Equal(t, "self-improving-agent", got.Slug)
 }
 
 func TestFetchSkillArchiveRejectsAmbiguousShorthandWithoutFetching(t *testing.T) {
 	_, err := fetchSkillArchive(t.Context(), "owner/demo", http.DefaultClient)
 	require.ErrorIs(t, err, ErrSkillSourceInvalid)
 	require.ErrorContains(t, err, "ambiguous")
+}
+
+func TestClawHubOwnerSlugMapsToDownloadAPI(t *testing.T) {
+	cases := []string{
+		"@jixinyi546-maker/emar-ppt-skill",
+		"https://clawhub.ai/jixinyi546-maker/emar-ppt-skill",
+		"https://clawhub.ai/jixinyi546-maker/skills/emar-ppt-skill",
+	}
+	for _, in := range cases {
+		got, err := parseSkillSource(in)
+		require.NoError(t, err, in)
+		u, err := got.fetchURL()
+		require.NoError(t, err, in)
+		parsed, err := url.Parse(u)
+		require.NoError(t, err, in)
+		require.Equal(t, "https://clawhub.ai/api/v1/download", parsed.Scheme+"://"+parsed.Host+parsed.Path, in)
+		require.Equal(t, "emar-ppt-skill", parsed.Query().Get("slug"), in)
+		require.Equal(t, "jixinyi546-maker", parsed.Query().Get("ownerHandle"), in)
+	}
 }
 
 func TestSkillHubCNMapsToDownloadAPI(t *testing.T) {


### PR DESCRIPTION
## Summary
- ClawHub listings and CLI refs look like `@owner/slug`, but `GET /api/v1/download` keys by the skill slug alone and takes the publisher as `ownerHandle`.
- We were sending `slug=jixinyi546-maker/emar-ppt-skill`, which the registry answers with `404 Skill not found` even though the page exists. The same bug also 404s `@lyingbug/weknora`.
- Parse `@owner/slug` and `https://clawhub.ai/{owner}/skills/{slug}` into `slug` + `ownerHandle`. SkillHub and other registries are unchanged.

## Test plan
- [ ] Register `@jixinyi546-maker/emar-ppt-skill` from the catalog — should download instead of 404.
- [ ] Register `https://clawhub.ai/jixinyi546-maker/skills/emar-ppt-skill` — same result.
- [ ] Register `@lyingbug/weknora` — should download.
- [ ] Register a SkillHub.cn URL such as `https://skillhub.cn/skills/clawhub_pskoett/self-improving-agent` — still uses `slug=<skill-name>` only.
- [ ] `go test ./internal/application/service/ -run 'TestParseSkillSource|TestClawHub|TestSkillHub|TestFetchSkillArchive'`