### PR TITLE
fix(qdrant): add tag_id payload index

### DIFF
--- a/internal/application/repository/retriever/qdrant/repository.go
+++ b/internal/application/repository/retriever/qdrant/repository.go
@@ -60,6 +60,17 @@ func (q *qdrantRepository) ensureCollection(ctx context.Context, dimension int) 
 		return nil
 	}
 
+	// Collection setup is a read/create/index sequence. Serialize it per
+	// repository so concurrent first writes do not both observe a missing
+	// collection and race to create it or its payload indexes.
+	q.collectionMu.Lock()
+	defer q.collectionMu.Unlock()
+
+	// A second cache check is required after waiting for the initializer.
+	if _, ok := q.initializedCollections.Load(dimension); ok {
+		return nil
+	}
+
 	log := logger.GetLogger(ctx)
 
 	// Check if collection exists
@@ -82,59 +93,123 @@ func (q *qdrantRepository) ensureCollection(ctx context.Context, dimension int) 
 			ReplicationFactor: types.OptionalUint32(q.replicationFactor),
 		})
 		if err != nil {
-			log.Errorf("[Qdrant] Failed to create collection: %v", err)
-			return fmt.Errorf("failed to create collection: %w", err)
+			// Another process may have created the collection after the
+			// existence check. Continue with index reconciliation in that
+			// case; all other creation errors remain fatal.
+			if !isCollectionAlreadyExistsError(err) {
+				log.Errorf("[Qdrant] Failed to create collection: %v", err)
+				return fmt.Errorf("failed to create collection: %w", err)
+			}
+			log.Infof("[Qdrant] Collection %s was created concurrently, reconciling indexes", collectionName)
 		}
 
-		// Create payload indexes for filtering
-		indexFields := []string{fieldChunkID, fieldKnowledgeID, fieldKnowledgeBaseID, fieldSourceID}
-		for _, field := range indexFields {
+		if err == nil {
+			// Create payload indexes for filtering
+			indexFields := []string{fieldChunkID, fieldKnowledgeID, fieldKnowledgeBaseID, fieldSourceID, fieldTagID}
+			for _, field := range indexFields {
+				_, err = q.client.CreateFieldIndex(ctx, &qdrant.CreateFieldIndexCollection{
+					CollectionName: collectionName,
+					FieldName:      field,
+					FieldType:      qdrant.FieldType_FieldTypeKeyword.Enum(),
+				})
+				if err != nil {
+					log.Warnf("[Qdrant] Failed to create index for field %s: %v", field, err)
+				}
+			}
+
+			// Create bool index for is_enabled
 			_, err = q.client.CreateFieldIndex(ctx, &qdrant.CreateFieldIndexCollection{
 				CollectionName: collectionName,
-				FieldName:      field,
-				FieldType:      qdrant.FieldType_FieldTypeKeyword.Enum(),
+				FieldName:      fieldIsEnabled,
+				FieldType:      qdrant.FieldType_FieldTypeBool.Enum(),
 			})
 			if err != nil {
-				log.Warnf("[Qdrant] Failed to create index for field %s: %v", field, err)
+				log.Warnf("[Qdrant] Failed to create index for field %s: %v", fieldIsEnabled, err)
 			}
-		}
 
-		// Create bool index for is_enabled
-		_, err = q.client.CreateFieldIndex(ctx, &qdrant.CreateFieldIndexCollection{
-			CollectionName: collectionName,
-			FieldName:      fieldIsEnabled,
-			FieldType:      qdrant.FieldType_FieldTypeBool.Enum(),
-		})
-		if err != nil {
-			log.Warnf("[Qdrant] Failed to create index for field %s: %v", fieldIsEnabled, err)
-		}
-
-		// Create text index for content (for keyword search) with multilingual tokenizer
-		// This supports Chinese, Japanese, Korean and other languages
-		lowercase := true
-		_, err = q.client.CreateFieldIndex(ctx, &qdrant.CreateFieldIndexCollection{
-			CollectionName: collectionName,
-			FieldName:      fieldContent,
-			FieldType:      qdrant.FieldType_FieldTypeText.Enum(),
-			FieldIndexParams: &qdrant.PayloadIndexParams{
-				IndexParams: &qdrant.PayloadIndexParams_TextIndexParams{
-					TextIndexParams: &qdrant.TextIndexParams{
-						Tokenizer: qdrant.TokenizerType_Multilingual,
-						Lowercase: &lowercase,
+			// Create text index for content (for keyword search) with multilingual tokenizer
+			// This supports Chinese, Japanese, Korean and other languages
+			lowercase := true
+			_, err = q.client.CreateFieldIndex(ctx, &qdrant.CreateFieldIndexCollection{
+				CollectionName: collectionName,
+				FieldName:      fieldContent,
+				FieldType:      qdrant.FieldType_FieldTypeText.Enum(),
+				FieldIndexParams: &qdrant.PayloadIndexParams{
+					IndexParams: &qdrant.PayloadIndexParams_TextIndexParams{
+						TextIndexParams: &qdrant.TextIndexParams{
+							Tokenizer: qdrant.TokenizerType_Multilingual,
+							Lowercase: &lowercase,
+						},
 					},
 				},
-			},
-		})
-		if err != nil {
-			log.Warnf("[Qdrant] Failed to create text index for content: %v", err)
-		}
+			})
+			if err != nil {
+				log.Warnf("[Qdrant] Failed to create text index for content: %v", err)
+			}
 
-		log.Infof("[Qdrant] Successfully created collection %s", collectionName)
+			log.Infof("[Qdrant] Successfully created collection %s", collectionName)
+		}
+	}
+
+	// Older collections were created before tag_id was part of the schema.
+	// Reconcile that field for both existing collections and collections that
+	// won a cross-process create race. Qdrant reports indexed payload fields in
+	// PayloadSchema, so this remains idempotent across restarts.
+	if err := q.ensureTagIDIndex(ctx, collectionName); err != nil {
+		log.Warnf("[Qdrant] Failed to reconcile index for field %s: %v", fieldTagID, err)
+		// Do not cache a partially initialized collection. The next write can
+		// retry after a transient Qdrant/API failure instead of silently
+		// leaving tag filtering unavailable for the lifetime of the process.
+		return nil
 	}
 
 	// Mark as initialized
 	q.initializedCollections.Store(dimension, true)
 	return nil
+}
+
+func (q *qdrantRepository) ensureTagIDIndex(ctx context.Context, collectionName string) error {
+	info, err := q.client.GetCollectionInfo(ctx, collectionName)
+	if err != nil {
+		return fmt.Errorf("failed to get collection info: %w", err)
+	}
+	if !needsPayloadIndex(info, fieldTagID) {
+		return nil
+	}
+
+	_, err = q.client.CreateFieldIndex(ctx, &qdrant.CreateFieldIndexCollection{
+		CollectionName: collectionName,
+		FieldName:      fieldTagID,
+		FieldType:      qdrant.FieldType_FieldTypeKeyword.Enum(),
+	})
+	if err != nil && !isPayloadIndexAlreadyExistsError(err) {
+		return fmt.Errorf("failed to create keyword index: %w", err)
+	}
+	return nil
+}
+
+func needsPayloadIndex(info *qdrant.CollectionInfo, fieldName string) bool {
+	if info == nil {
+		return true
+	}
+	_, ok := info.GetPayloadSchema()[fieldName]
+	return !ok
+}
+
+func isCollectionAlreadyExistsError(err error) bool {
+	return containsQdrantAlreadyExistsMessage(err)
+}
+
+func isPayloadIndexAlreadyExistsError(err error) bool {
+	return containsQdrantAlreadyExistsMessage(err)
+}
+
+func containsQdrantAlreadyExistsMessage(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(strings.ReplaceAll(err.Error(), "_", " "))
+	return strings.Contains(message, "already exists") || strings.Contains(message, "already exist")
 }
 
 func (q *qdrantRepository) EngineType() types.RetrieverEngineType {

--- a/internal/application/repository/retriever/qdrant/repository_test.go
+++ b/internal/application/repository/retriever/qdrant/repository_test.go
@@ -1,0 +1,57 @@
+package qdrant
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/qdrant/go-client/qdrant"
+)
+
+func TestNeedsPayloadIndex(t *testing.T) {
+	tests := []struct {
+		name string
+		info *qdrant.CollectionInfo
+		want bool
+	}{
+		{name: "nil collection info", want: true},
+		{name: "missing field", info: &qdrant.CollectionInfo{}, want: true},
+		{
+			name: "indexed field",
+			info: &qdrant.CollectionInfo{
+				PayloadSchema: map[string]*qdrant.PayloadSchemaInfo{
+					fieldTagID: {DataType: qdrant.PayloadSchemaType_Keyword},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := needsPayloadIndex(tt.info, fieldTagID); got != tt.want {
+				t.Fatalf("needsPayloadIndex() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainsQdrantAlreadyExistsMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "qdrant conflict", err: errors.New("collection already exists"), want: true},
+		{name: "snake case conflict", err: errors.New("resource_already_exists_exception"), want: true},
+		{name: "unrelated error", err: errors.New("permission denied"), want: false},
+		{name: "nil", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsQdrantAlreadyExistsMessage(tt.err); got != tt.want {
+				t.Fatalf("containsQdrantAlreadyExistsMessage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/application/repository/retriever/qdrant/structs.go
+++ b/internal/application/repository/retriever/qdrant/structs.go
@@ -11,6 +11,7 @@ type qdrantRepository struct {
 	collectionBaseName string
 	shardNumber        int // 0 = use Qdrant server default
 	replicationFactor  int // 0 = use Qdrant server default
+	collectionMu       sync.Mutex
 	// Cache for initialized collections (dimension -> true)
 	initializedCollections sync.Map
 }


### PR DESCRIPTION
## 说明

为 Qdrant 集合初始化补充 tag_id 的 keyword payload index，并对旧集合做幂等补偿；同时串行化首次初始化，避免并发创建竞态。

## 类型
- [x] 🐛 Bug fix
- [ ] ✨ New feature

## 关联 Issue
Fixes #2855

## 测试
- gofmt 检查通过
- git diff --check origin/main...HEAD 通过
- go test ./internal/application/repository/retriever/qdrant：未通过，当前 Windows 环境编译 internal/utils 时缺少 pg_query.Parse/Deparse 符号（本机 CGO/依赖环境问题）

## Checklist
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Full Go test suite（同上环境限制）