### PR TITLE
feat(dsh): render image references in harness

### DIFF
--- a/internal/handler/chunk.go
+++ b/internal/handler/chunk.go
@@ -1,12 +1,15 @@
 package handler
 
 import (
+	"context"
 	stderrors "errors"
 	"net/http"
 
 	"github.com/Tencent/WeKnora/internal/application/service"
 	"github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/searchutil"
+	"github.com/Tencent/WeKnora/internal/storageurl"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
@@ -28,13 +31,41 @@ import (
 // access — that lookup answers "is the caller the creator of THIS
 // resource", not "does the caller's tenant have access").
 type ChunkHandler struct {
-	service   interfaces.ChunkService
-	kgService interfaces.KnowledgeService
+	service         interfaces.ChunkService
+	kgService       interfaces.KnowledgeService
+	fileService     interfaces.FileService
+	storageResolver interfaces.StorageBackendResolver
 }
 
 // NewChunkHandler creates a new chunk handler.
-func NewChunkHandler(service interfaces.ChunkService, kgService interfaces.KnowledgeService) *ChunkHandler {
-	return &ChunkHandler{service: service, kgService: kgService}
+func NewChunkHandler(
+	service interfaces.ChunkService,
+	kgService interfaces.KnowledgeService,
+	fileService interfaces.FileService,
+	storageResolver interfaces.StorageBackendResolver,
+) *ChunkHandler {
+	return &ChunkHandler{
+		service:         service,
+		kgService:       kgService,
+		fileService:     fileService,
+		storageResolver: storageResolver,
+	}
+}
+
+// resolveResourceRewriter builds the storage-reference rewriter for one
+// response. The default handle mode keeps the existing resource:// contract;
+// public mode returns directly loadable URLs for clients such as DSH that
+// cannot attach WeKnora credentials to an image request.
+func (h *ChunkHandler) resolveResourceRewriter(c *gin.Context) (*storageurl.Rewriter, error) {
+	ctx := c.Request.Context()
+	mode, err := storageurl.ResolveMode(ctx, c.Query(storageurl.QueryParam))
+	if err != nil {
+		if stderrors.Is(err, storageurl.ErrPublicModeForbidden) {
+			return nil, errors.NewForbiddenError(err.Error())
+		}
+		return nil, errors.NewBadRequestError(err.Error())
+	}
+	return storageurl.NewRequestRewriter(ctx, mode, h.fileService, h.storageResolver), nil
 }
 
 // GetChunkByIDOnly godoc
@@ -91,6 +122,7 @@ func (h *ChunkHandler) GetChunkByIDOnly(c *gin.Context) {
 // @Param        knowledge_id  path      string  true   "知识ID"
 // @Param        page          query     int     false  "页码"  default(1)
 // @Param        page_size     query     int     false  "每页数量"  default(10)
+// @Param        resource_urls query     string  false  "文件引用形式，public 返回可加载直链"  Enums(handle, public)  default(handle)
 // @Success      200           {object}  map[string]interface{}  "分块列表"
 // @Failure      400           {object}  errors.AppError         "请求参数错误"
 // @Security     Bearer
@@ -104,6 +136,13 @@ func (h *ChunkHandler) ListKnowledgeChunks(c *gin.Context) {
 	if knowledgeID == "" {
 		logger.Error(ctx, "Knowledge ID is empty")
 		c.Error(errors.NewBadRequestError("Knowledge ID cannot be empty"))
+		return
+	}
+
+	rewriter, err := h.resolveResourceRewriter(c)
+	if err != nil {
+		logger.Warnf(ctx, "Rejected resource URL mode: %v", err)
+		_ = c.Error(err)
 		return
 	}
 
@@ -142,6 +181,13 @@ func (h *ChunkHandler) ListKnowledgeChunks(c *gin.Context) {
 		return
 	}
 
+	// Image OCR/caption rows are stored as children of the returned text rows.
+	// Enrich them here, at the API boundary, so document readers receive the
+	// same image metadata as the internal list_knowledge_chunks tool without
+	// widening the service method (and every existing caller) to extra queries.
+	h.enrichImageInfo(ctx, result.Data)
+	h.rewriteChunkResources(ctx, rewriter, result.Data)
+
 	c.JSON(http.StatusOK, gin.H{
 		"success":   true,
 		"data":      result.Data,
@@ -149,6 +195,58 @@ func (h *ChunkHandler) ListKnowledgeChunks(c *gin.Context) {
 		"page":      result.Page,
 		"page_size": result.PageSize,
 	})
+}
+
+// enrichImageInfo lazily merges image metadata from image child chunks into
+// the text chunks returned by the public endpoint.
+func (h *ChunkHandler) enrichImageInfo(ctx context.Context, data interface{}) {
+	chunks, ok := data.([]*types.Chunk)
+	if !ok || len(chunks) == 0 || h.service == nil || h.service.GetRepository() == nil {
+		return
+	}
+	tenantID, ok := types.TenantIDFromContext(ctx)
+	if !ok {
+		return
+	}
+	chunkIDs := make([]string, 0, len(chunks))
+	for _, chunk := range chunks {
+		if chunk != nil && chunk.ImageInfo == "" {
+			chunkIDs = append(chunkIDs, chunk.ID)
+		}
+	}
+	if len(chunkIDs) == 0 {
+		return
+	}
+	infoMap := searchutil.CollectImageInfoByChunkIDs(ctx, h.service.GetRepository(), tenantID, chunkIDs)
+	for _, chunk := range chunks {
+		if chunk != nil && chunk.ImageInfo == "" {
+			if imageInfo, exists := infoMap[chunk.ID]; exists {
+				chunk.ImageInfo = imageInfo
+			}
+		}
+	}
+}
+
+// rewriteChunkResources rewrites both Markdown content and the JSON-encoded
+// image_info payload. Rewriter.String handles provider:// and resource://
+// references inside either representation and is a no-op in handle mode.
+func (h *ChunkHandler) rewriteChunkResources(
+	ctx context.Context, rewriter *storageurl.Rewriter, data interface{},
+) {
+	if rewriter == nil || !rewriter.Enabled() {
+		return
+	}
+	chunks, ok := data.([]*types.Chunk)
+	if !ok {
+		return
+	}
+	for _, chunk := range chunks {
+		if chunk == nil {
+			continue
+		}
+		chunk.Content = rewriter.String(ctx, chunk.Content)
+		chunk.ImageInfo = rewriter.String(ctx, chunk.ImageInfo)
+	}
 }
 
 // UpdateChunkRequest defines the request structure for updating a chunk

--- a/internal/handler/chunk_resource_urls_test.go
+++ b/internal/handler/chunk_resource_urls_test.go
@@ -63,7 +63,9 @@ func newChunkListTestContext(t *testing.T, query string) (*gin.Context, *httptes
 }
 
 func TestListKnowledgeChunksEnrichesAndRewritesImageInfo(t *testing.T) {
-	const resourceHandle = "resource://image-1"
+	// Use a valid 22-character resource handle so the resolver exercises the
+	// resource:// branch instead of treating the fixture as an unknown scheme.
+	const resourceHandle = "resource://image-0000000000000000"
 	textChunk := &types.Chunk{
 		ID:        "text-1",
 		Content:   "流程图：![diagram](" + resourceHandle + ")",

--- a/internal/handler/chunk_resource_urls_test.go
+++ b/internal/handler/chunk_resource_urls_test.go
@@ -1,0 +1,106 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type chunkListTestRepository struct {
+	interfaces.ChunkRepository
+	children []*types.Chunk
+}
+
+func (r *chunkListTestRepository) ListChunksByParentIDs(
+	context.Context, uint64, []string,
+) ([]*types.Chunk, error) {
+	return r.children, nil
+}
+
+type chunkListTestService struct {
+	interfaces.ChunkService
+	result *types.PageResult
+	repo   interfaces.ChunkRepository
+}
+
+func (s *chunkListTestService) ListPagedChunksByKnowledgeID(
+	context.Context, string, *types.Pagination, []types.ChunkType,
+) (*types.PageResult, error) {
+	return s.result, nil
+}
+
+func (s *chunkListTestService) GetRepository() interfaces.ChunkRepository {
+	return s.repo
+}
+
+type chunkResourceFileService struct {
+	interfaces.FileService
+	url string
+}
+
+func (s *chunkResourceFileService) GetFileURL(context.Context, string) (string, error) {
+	return s.url, nil
+}
+
+func newChunkListTestContext(t *testing.T, query string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	response := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(response)
+	request := httptest.NewRequest(http.MethodGet, "/chunks/knowledge-1"+query, nil)
+	request = request.WithContext(context.WithValue(request.Context(), types.TenantIDContextKey, uint64(1)))
+	c.Request = request
+	c.Params = gin.Params{{Key: "knowledge_id", Value: "knowledge-1"}}
+	return c, response
+}
+
+func TestListKnowledgeChunksEnrichesAndRewritesImageInfo(t *testing.T) {
+	const resourceHandle = "resource://image-1"
+	textChunk := &types.Chunk{
+		ID:        "text-1",
+		Content:   "流程图：![diagram](" + resourceHandle + ")",
+		ImageInfo: "",
+	}
+	imageChunk := &types.Chunk{
+		ID:            "image-1",
+		ParentChunkID: "text-1",
+		ChunkType:     types.ChunkTypeImageCaption,
+		IsEnabled:     true,
+		ImageInfo:     `[{"url":"` + resourceHandle + `","caption":"流程图"}]`,
+	}
+	service := &chunkListTestService{
+		result: types.NewPageResult(1, &types.Pagination{Page: 1, PageSize: 10}, []*types.Chunk{textChunk}),
+		repo: &chunkListTestRepository{
+			children: []*types.Chunk{imageChunk},
+		},
+	}
+	h := &ChunkHandler{
+		service:     service,
+		fileService: &chunkResourceFileService{url: "https://cdn.example.com/image.png"},
+	}
+	c, response := newChunkListTestContext(t, "?resource_urls=public")
+
+	h.ListKnowledgeChunks(c)
+
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	assert.NotContains(t, textChunk.Content, resourceHandle)
+	assert.Contains(t, textChunk.Content, "https://cdn.example.com/image.png")
+	assert.NotContains(t, textChunk.ImageInfo, resourceHandle)
+	assert.Contains(t, textChunk.ImageInfo, "https://cdn.example.com/image.png")
+
+	var body struct {
+		Data []types.Chunk `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+	require.Len(t, body.Data, 1)
+	assert.Equal(t, textChunk.Content, body.Data[0].Content)
+	assert.Equal(t, textChunk.ImageInfo, body.Data[0].ImageInfo)
+}

--- a/packages/dsh-weknora/contract/contract_test.go
+++ b/packages/dsh-weknora/contract/contract_test.go
@@ -166,6 +166,7 @@ func TestResponseFieldsThePluginReadsStillExist(t *testing.T) {
 			ChunkIndex:        3,
 			KnowledgeTitle:    "检索流程.md",
 			KnowledgeFilename: "检索流程.md",
+			ImageInfo:         `[{"url":"https://cdn.example.com/diagram.png","caption":"检索流程图"}]`,
 			Score:             0.83,
 		},
 		"types.Knowledge": types.Knowledge{
@@ -181,6 +182,7 @@ func TestResponseFieldsThePluginReadsStillExist(t *testing.T) {
 			Content:     "默认的 vector_threshold 是 0.5",
 			ChunkIndex:  3,
 			KnowledgeID: "doc-1",
+			ImageInfo:   `[{"url":"https://cdn.example.com/diagram.png","caption":"检索流程图"}]`,
 		},
 		"types.StreamResponse": types.StreamResponse{
 			ID:                  "event-1",

--- a/packages/dsh-weknora/src/client.ts
+++ b/packages/dsh-weknora/src/client.ts
@@ -10,6 +10,8 @@ export interface SearchResult {
   chunk_index?: number
   knowledge_title?: string
   knowledge_filename?: string
+  /** JSON-encoded image metadata returned with a retrieved chunk. */
+  image_info?: string
   score?: number
   match_type?: number | string
   [key: string]: unknown
@@ -29,6 +31,8 @@ export interface ChunkRecord {
   content?: string
   chunk_index?: number
   knowledge_id?: string
+  /** JSON-encoded image metadata returned with a stored chunk. */
+  image_info?: string
   [key: string]: unknown
 }
 

--- a/packages/dsh-weknora/src/tools.ts
+++ b/packages/dsh-weknora/src/tools.ts
@@ -15,6 +15,14 @@ interface SearchHit {
   score: number
   content: string
   truncated: boolean
+  images: ImageReference[]
+}
+
+/** One image the model can preserve as Markdown in its answer. */
+interface ImageReference {
+  url: string
+  caption: string
+  ocr_text: string
 }
 
 /** A document whose name matched, which passage retrieval alone would miss. */
@@ -49,6 +57,7 @@ interface DocumentValue {
   has_more: boolean
   truncated: boolean
   content: string
+  images: ImageReference[]
 }
 
 interface AskValue {
@@ -56,12 +65,32 @@ interface AskValue {
   session_id: string
   pipeline: 'rag' | 'agent'
   tool_calls: string[]
-  references: { knowledge_id: string, document: string, chunk_index: number, content: string }[]
+  references: {
+    knowledge_id: string
+    document: string
+    chunk_index: number
+    content: string
+    images: ImageReference[]
+  }[]
 }
 
 const text = (value: string): TextContentBlock[] => [{ type: 'text', text: value }]
 
 const STRING_ARRAY: JsonSchemaNode = { type: 'array', items: { type: 'string' } }
+
+const IMAGE_ARRAY: JsonSchemaNode = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      url: { type: 'string' },
+      caption: { type: 'string' },
+      ocr_text: { type: 'string' },
+    },
+    required: ['url', 'caption', 'ocr_text'],
+    additionalProperties: false,
+  },
+}
 
 /** Read an argument the harness passes as `unknown` without trusting its shape. */
 function argRecord(args: unknown): Record<string, unknown> {
@@ -102,6 +131,71 @@ function documentLabel(result: SearchResult): string {
   return typeof result.knowledge_id === 'string' && result.knowledge_id !== '' ? result.knowledge_id : '(untitled)'
 }
 
+/**
+ * Decode the JSON string used by WeKnora's `image_info` field. Invalid or
+ * incomplete metadata is ignored so one malformed image cannot hide a passage.
+ */
+function projectImages(raw: unknown): ImageReference[] {
+  let value: unknown = raw
+  if (typeof raw === 'string') {
+    if (raw.trim() === '') return []
+    try {
+      value = JSON.parse(raw) as unknown
+    } catch {
+      return []
+    }
+  }
+  if (!Array.isArray(value)) return []
+
+  const seen = new Set<string>()
+  const images: ImageReference[] = []
+  for (const item of value) {
+    if (typeof item !== 'object' || item === null || Array.isArray(item)) continue
+    const record = item as Record<string, unknown>
+    const url = typeof record.url === 'string' && record.url.trim() !== ''
+      ? record.url.trim()
+      : typeof record.original_url === 'string' ? record.original_url.trim() : ''
+    if (url === '' || seen.has(url)) continue
+    seen.add(url)
+    images.push({
+      url,
+      caption: typeof record.caption === 'string' ? record.caption.trim() : '',
+      ocr_text: typeof record.ocr_text === 'string' ? record.ocr_text.trim() : '',
+    })
+  }
+  return images
+}
+
+/** Keep captions safe inside the alt-text part of a Markdown image. */
+function markdownAltText(value: string): string {
+  const normalized = value.replace(/[\r\n]+/g, ' ').replace(/[\\[\]]/g, ' ').trim()
+  return normalized === '' ? 'WeKnora image' : normalized
+}
+
+/** Render image metadata as answer-ready Markdown for the DSH model. */
+function renderImages(images: ImageReference[] | undefined): string {
+  return (images ?? []).map(image => `![${markdownAltText(image.caption)}](${image.url})`).join('\n')
+}
+
+/** Collect page images once, preserving the first occurrence's order. */
+function projectDocumentImages(chunks: ChunkRecord[]): ImageReference[] {
+  const byUrl = new Map<string, ImageReference>()
+  for (const chunk of chunks) {
+    for (const image of projectImages(chunk.image_info)) {
+      const existing = byUrl.get(image.url)
+      if (existing === undefined) {
+        byUrl.set(image.url, image)
+        continue
+      }
+      // A caption and OCR result can be stored on separate child chunks;
+      // retain whichever copy has the richer metadata.
+      if (existing.caption === '' && image.caption !== '') existing.caption = image.caption
+      if (existing.ocr_text === '' && image.ocr_text !== '') existing.ocr_text = image.ocr_text
+    }
+  }
+  return [...byUrl.values()]
+}
+
 function projectHit(result: SearchResult, rank: number, maxChunkChars: number): SearchHit {
   const clipped = clip(typeof result.content === 'string' ? result.content : '', maxChunkChars)
   return {
@@ -114,6 +208,7 @@ function projectHit(result: SearchResult, rank: number, maxChunkChars: number): 
     score: typeof result.score === 'number' && Number.isFinite(result.score) ? result.score : 0,
     content: clipped.text,
     truncated: clipped.truncated,
+    images: projectImages(result.image_info),
   }
 }
 
@@ -281,8 +376,11 @@ export function createTools(client: WeknoraClient, config: ResolvedConfig): Tool
                   score: { type: 'number' },
                   content: { type: 'string' },
                   truncated: { type: 'boolean' },
+                  images: IMAGE_ARRAY,
                 },
-                required: ['rank', 'chunk_id', 'knowledge_id', 'document', 'chunk_index', 'score', 'content', 'truncated'],
+                required: [
+                  'rank', 'chunk_id', 'knowledge_id', 'document', 'chunk_index', 'score', 'content', 'truncated', 'images',
+                ],
                 additionalProperties: false,
               },
             },
@@ -319,9 +417,12 @@ export function createTools(client: WeknoraClient, config: ResolvedConfig): Tool
             }
             return text(`No passage matched "${result.query}", but its name matches document(s).${named}`)
           }
-          const blocks = result.results.map(hit =>
-            `[${hit.rank}] ${hit.document} · score ${formatScore(hit.score)} · chunk ${hit.chunk_index} `
-            + `· knowledge_id: ${hit.knowledge_id}\n${hit.content}${hit.truncated ? '\n(passage truncated)' : ''}`)
+          const blocks = result.results.map(hit => {
+            const images = renderImages(hit.images)
+            return `[${hit.rank}] ${hit.document} · score ${formatScore(hit.score)} · chunk ${hit.chunk_index} `
+              + `· knowledge_id: ${hit.knowledge_id}\n${hit.content}${hit.truncated ? '\n(passage truncated)' : ''}`
+              + (images === '' ? '' : `\n${images}`)
+          })
           return text(`${result.count} passage(s) for "${result.query}" `
             + `(searched: ${describeScope(result.knowledge_base_ids)}):\n\n${blocks.join('\n\n')}${named}`)
         },
@@ -391,10 +492,11 @@ export function createTools(client: WeknoraClient, config: ResolvedConfig): Tool
             has_more: { type: 'boolean' },
             truncated: { type: 'boolean' },
             content: { type: 'string' },
+            images: IMAGE_ARRAY,
           },
           required: [
             'knowledge_id', 'title', 'summary', 'page', 'page_size',
-            'total_chunks', 'returned_chunks', 'has_more', 'truncated', 'content',
+            'total_chunks', 'returned_chunks', 'has_more', 'truncated', 'content', 'images',
           ],
           additionalProperties: false,
         },
@@ -410,8 +512,10 @@ export function createTools(client: WeknoraClient, config: ResolvedConfig): Tool
           const summary = result.summary === '' ? '' : `\n\nSummary: ${result.summary}`
           const more = result.has_more ? `\n\n(more passages available: request page ${result.page + 1})` : ''
           const cut = result.truncated ? '\n(content truncated)' : ''
+          const images = renderImages(result.images)
+          const imageBlock = images === '' ? '' : `\n\nImages:\n${images}`
           return text(`Document ${label}, passages ${result.returned_chunks} of ${result.total_chunks} `
-            + `(page ${result.page}):${summary}\n\n${result.content}${cut}${more}`)
+            + `(page ${result.page}):${summary}\n\n${result.content}${cut}${imageBlock}${more}`)
         },
       },
       async execute(args, exec): Promise<DocumentValue> {
@@ -446,6 +550,7 @@ export function createTools(client: WeknoraClient, config: ResolvedConfig): Tool
           has_more: result.page * result.pageSize < result.total,
           truncated: clipped.truncated,
           content: clipped.text,
+          images: projectDocumentImages(ordered),
         }
       },
     })
@@ -490,8 +595,9 @@ export function createTools(client: WeknoraClient, config: ResolvedConfig): Tool
                   document: { type: 'string' },
                   chunk_index: { type: 'integer' },
                   content: { type: 'string' },
+                  images: IMAGE_ARRAY,
                 },
-                required: ['knowledge_id', 'document', 'chunk_index', 'content'],
+                required: ['knowledge_id', 'document', 'chunk_index', 'content', 'images'],
                 additionalProperties: false,
               },
             },
@@ -506,8 +612,11 @@ export function createTools(client: WeknoraClient, config: ResolvedConfig): Tool
             ? 'WeKnora returned an empty answer. Retry with a more specific question, or retrieve passages instead.'
             : result.answer)
           if (result.references.length > 0) {
-            const cited = result.references.map((reference, index) =>
-              `[${index + 1}] ${reference.document} · chunk ${reference.chunk_index} · knowledge_id: ${reference.knowledge_id}`)
+            const cited = result.references.map((reference, index) => {
+              const images = renderImages(reference.images)
+              return `[${index + 1}] ${reference.document} · chunk ${reference.chunk_index} · knowledge_id: ${reference.knowledge_id}`
+                + (images === '' ? '' : `\n${images}`)
+            })
             parts.push(`Citations:\n${cited.join('\n')}`)
           }
           if (result.tool_calls.length > 0) parts.push(`WeKnora tools used: ${result.tool_calls.join(', ')}`)
@@ -545,6 +654,7 @@ export function createTools(client: WeknoraClient, config: ResolvedConfig): Tool
             document: documentLabel(reference),
             chunk_index: typeof reference.chunk_index === 'number' ? reference.chunk_index : -1,
             content: clip(typeof reference.content === 'string' ? reference.content : '', config.maxChunkChars).text,
+            images: projectImages(reference.image_info),
           })),
         }
       },

--- a/packages/dsh-weknora/test/contract.test.mjs
+++ b/packages/dsh-weknora/test/contract.test.mjs
@@ -128,6 +128,7 @@ test('the plugin only reads response fields the fixture declares', async () => {
       score: result.score ?? 0,
       content: result.content ?? '',
       truncated: false,
+      images: [],
     })),
     documents: [],
   })

--- a/packages/dsh-weknora/test/fixtures/api-contract.json
+++ b/packages/dsh-weknora/test/fixtures/api-contract.json
@@ -94,9 +94,10 @@
       "chunk_index",
       "knowledge_title",
       "knowledge_filename",
+      "image_info",
       "score"
     ],
-    "types.Chunk": ["id", "content", "chunk_index", "knowledge_id"],
+    "types.Chunk": ["id", "content", "chunk_index", "knowledge_id", "image_info"],
     "types.Knowledge": [
       "id",
       "title",

--- a/packages/dsh-weknora/test/helpers/mock-weknora.mjs
+++ b/packages/dsh-weknora/test/helpers/mock-weknora.mjs
@@ -90,6 +90,13 @@ function searchResults(query, knowledgeBaseIds, knowledgeIds) {
       start_at: 0,
       end_at: content.length,
       metadata: {},
+      image_info: document.knowledge_id === 'doc-retrieval-pipeline' && index === 0
+        ? JSON.stringify([{
+          url: 'https://cdn.example.com/retrieval-diagram.png',
+          caption: '检索流程图',
+          ocr_text: '向量召回 → 关键词召回 → rerank',
+        }])
+        : '',
     })))
     .filter(result => result.score > 0.4)
     .sort((left, right) => right.score - left.score)
@@ -244,10 +251,17 @@ export async function startMockWeknora(options = {}) {
             id: `${knowledgeId}-chunk-${start + index}`,
             knowledge_id: knowledgeId,
             knowledge_base_id: 'kb-product',
-            content,
-            chunk_index: start + index,
-            is_enabled: true,
-          })),
+          content,
+          chunk_index: start + index,
+          is_enabled: true,
+          image_info: knowledgeId === 'doc-retrieval-pipeline' && start + index === 0
+            ? JSON.stringify([{
+              url: 'https://cdn.example.com/retrieval-diagram.png',
+              caption: '检索流程图',
+              ocr_text: '向量召回 → 关键词召回 → rerank',
+            }])
+            : '',
+        })),
           total: document.chunks.length,
           page,
           page_size: pageSize,

--- a/packages/dsh-weknora/test/tools.test.mjs
+++ b/packages/dsh-weknora/test/tools.test.mjs
@@ -68,6 +68,22 @@ test('search returns ranked passages carrying their knowledge_id', async () => {
   assert.match(text, /knowledge_id: doc-retrieval-pipeline/)
 })
 
+test('search projects image_info as answer-ready Markdown', async () => {
+  const { byName } = await toolset({
+    knowledgeBaseIds: ['kb-product'],
+    resourceUrls: 'public',
+  })
+  const { value, text } = await call(byName.get('weknora_search'), { query: 'WeKnora 的混合检索' })
+  const imageHit = value.results.find(hit => hit.images.length > 0)
+  assert.ok(imageHit)
+  assert.deepEqual(imageHit.images, [{
+    url: 'https://cdn.example.com/retrieval-diagram.png',
+    caption: '检索流程图',
+    ocr_text: '向量召回 → 关键词召回 → rerank',
+  }])
+  assert.match(text, /!\[检索流程图\]\(https:\/\/cdn\.example\.com\/retrieval-diagram\.png\)/)
+})
+
 test('search respects max_results and the configured ceiling', async () => {
   const { byName } = await toolset({ maxResults: 2, knowledgeBaseIds: ['kb-product'] })
   const wide = await call(byName.get('weknora_search'), { query: '检索 部署 向量 阈值' })
@@ -193,6 +209,24 @@ test('read_document reassembles passages in order and reports paging', async () 
   assert.equal(second.value.has_more, false)
 })
 
+test('read_document preserves page images as answer-ready Markdown', async () => {
+  const { byName } = await toolset({
+    maxChunkChars: 4000,
+    resourceUrls: 'public',
+  })
+  const { value, text } = await call(byName.get('weknora_read_document'), {
+    knowledge_id: 'doc-retrieval-pipeline',
+    page: 1,
+    page_size: 2,
+  })
+  assert.deepEqual(value.images, [{
+    url: 'https://cdn.example.com/retrieval-diagram.png',
+    caption: '检索流程图',
+    ocr_text: '向量召回 → 关键词召回 → rerank',
+  }])
+  assert.match(text, /Images:\n!\[检索流程图\]\(https:\/\/cdn\.example\.com\/retrieval-diagram\.png\)/)
+})
+
 // A long document costs many pages to identify from its passages alone, so
 // page 1 carries the title and WeKnora's generated summary.
 test('read_document leads with the document title and summary', async () => {
@@ -260,6 +294,17 @@ test('ask returns the composed answer, citations and a resumable session', async
   assert.match(text, /Citations:/)
   assert.match(text, /pass session_id to ask a follow-up/)
   assert.equal(mock.requests.some(request => request.path === '/api/v1/sessions'), true)
+})
+
+test('ask preserves citation images for the harness renderer', async () => {
+  const { byName } = await toolset({
+    knowledgeBaseIds: ['kb-product'],
+    resourceUrls: 'public',
+  })
+  const { value, text } = await call(byName.get('weknora_ask'), { query: 'WeKnora 的混合检索' })
+  const imageReference = value.references.find(reference => reference.images.length > 0)
+  assert.ok(imageReference)
+  assert.match(text, /!\[检索流程图\]\(https:\/\/cdn\.example\.com\/retrieval-diagram\.png\)/)
 })
 
 test('ask reuses a given session instead of creating one', async () => {


### PR DESCRIPTION
## 说明

修复 DeepSeek Harness 回答中无法显示知识库图片的问题：透传并解析 image_info，在搜索结果、文档读取和引用中保留图片元数据，并输出 Markdown 图片；Chunk 接口支持 resource_urls=public，将资源引用转换为可直接加载的 URL。

## 类型
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change

## 关联 Issue
Fixes #2829

## 测试
- npm run typecheck：通过
- npm test：通过，54/54
- git diff --check origin/main...HEAD：通过
- Go 端聚焦测试受当前 Windows 环境缺少 pg_query.Parse/Deparse 符号影响，未能编译执行

## Checklist
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Full Go test suite（本机环境限制）