### PR TITLE
fix(wiki): fall back to a knowledge QA model

### DIFF
--- a/internal/application/service/session_knowledge_qa_test.go
+++ b/internal/application/service/session_knowledge_qa_test.go
@@ -48,8 +48,9 @@ func (m *captureChatModel) GetModelName() string { return "capture" }
 func (m *captureChatModel) GetModelID() string   { return "capture" }
 
 type stubModelService struct {
-	chatModel  chat.Chat
-	modelsByID map[string]*types.Model
+	chatModel       chat.Chat
+	modelsByID      map[string]*types.Model
+	availableModels []*types.Model
 }
 
 func TestEmitKnowledgeReferencesEventIgnoresCitationOutputSetting(t *testing.T) {
@@ -89,7 +90,7 @@ func (s *stubModelService) GetModelByID(_ context.Context, id string) (*types.Mo
 }
 
 func (s *stubModelService) ListModels(context.Context) ([]*types.Model, error) {
-	return nil, nil
+	return s.availableModels, nil
 }
 
 func (s *stubModelService) UpdateModel(context.Context, *types.Model) error {

--- a/internal/application/service/session_model_requirement_test.go
+++ b/internal/application/service/session_model_requirement_test.go
@@ -147,3 +147,57 @@ func TestResolveChatModelIDUsesValidSummaryModelOverride(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "override-chat", modelID)
 }
+
+func TestResolveChatModelIDWikiFixerFallsBackToKnowledgeBaseModel(t *testing.T) {
+	svc := &sessionService{
+		modelService: &stubModelService{
+			modelsByID: map[string]*types.Model{
+				"wiki-chat": {
+					ID:   "wiki-chat",
+					Type: types.ModelTypeKnowledgeQA,
+				},
+			},
+		},
+		knowledgeBaseService: &fakeAgentKnowledgeBaseService{
+			kb: &types.KnowledgeBase{
+				ID:             "wiki-kb",
+				SummaryModelID: "wiki-chat",
+			},
+		},
+	}
+	req := &types.QARequest{
+		Session: &types.Session{},
+		CustomAgent: &types.CustomAgent{
+			ID: types.BuiltinWikiFixerID,
+		},
+	}
+
+	modelID, err := svc.resolveChatModelID(context.Background(), req, []string{"wiki-kb"}, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "wiki-chat", modelID)
+}
+
+func TestResolveChatModelIDWikiFixerFallsBackToAvailableModel(t *testing.T) {
+	svc := &sessionService{
+		modelService: &stubModelService{
+			availableModels: []*types.Model{
+				{
+					ID:   "system-chat",
+					Type: types.ModelTypeKnowledgeQA,
+				},
+			},
+		},
+	}
+	req := &types.QARequest{
+		Session: &types.Session{},
+		CustomAgent: &types.CustomAgent{
+			ID: types.BuiltinWikiFixerID,
+		},
+	}
+
+	modelID, err := svc.resolveChatModelID(context.Background(), req, nil, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "system-chat", modelID)
+}

--- a/internal/application/service/session_qa_helpers.go
+++ b/internal/application/service/session_qa_helpers.go
@@ -86,8 +86,10 @@ func (s *sessionService) restrictTagScopesToAgentScope(
 
 // resolveChatModelID resolves the effective chat model ID for a QA request.
 //
-// When an agent is selected, its model configuration must be complete and
-// valid. A request-level override may choose another valid model for this
+// When a user-configured agent is selected, its model configuration must be
+// complete and valid. The internal wiki fixer is the one exception: it is not
+// exposed in the agent UI, so an empty model_id falls back to KB/system model
+// selection. A request-level override may choose another valid model for this
 // request, but it must not make an unconfigured or stale agent appear usable.
 //
 // Without an agent, the legacy KB / session / system fallback remains
@@ -101,15 +103,24 @@ func (s *sessionService) resolveChatModelID(
 	summaryModelID := req.SummaryModelID
 	customAgent := req.CustomAgent
 	session := req.Session
+	configuredAgentModelID := ""
 
 	if customAgent != nil {
-		configuredModelID := strings.TrimSpace(customAgent.Config.ModelID)
-		if configuredModelID == "" {
+		configuredAgentModelID = strings.TrimSpace(customAgent.Config.ModelID)
+		if configuredAgentModelID == "" && customAgent.ID != types.BuiltinWikiFixerID {
 			return "", fmt.Errorf("chat model is not configured: please set model_id on agent %s", customAgent.ID)
 		}
-		model, err := s.modelService.GetModelByID(ctx, configuredModelID)
-		if err != nil || model == nil || model.Type != types.ModelTypeKnowledgeQA {
-			return "", fmt.Errorf("configured chat model %s is unavailable for agent %s", configuredModelID, customAgent.ID)
+		if configuredAgentModelID != "" {
+			model, err := s.modelService.GetModelByID(ctx, configuredAgentModelID)
+			if err != nil || model == nil || model.Type != types.ModelTypeKnowledgeQA {
+				return "", fmt.Errorf("configured chat model %s is unavailable for agent %s", configuredAgentModelID, customAgent.ID)
+			}
+		} else {
+			// The wiki fixer is an internal agent and is intentionally omitted
+			// from the agent-management list. It therefore cannot receive a
+			// user-configured model_id; resolve it from the current Wiki KB or
+			// the normal system KnowledgeQA fallback below instead.
+			logger.Infof(ctx, "No model_id configured for internal wiki fixer %s, using KB/system fallback", customAgent.ID)
 		}
 	}
 
@@ -122,9 +133,9 @@ func (s *sessionService) resolveChatModelID(
 		}
 		logger.Warnf(ctx, "Request provided invalid summary model ID %s, falling back", summaryModelID)
 	}
-	if customAgent != nil && strings.TrimSpace(customAgent.Config.ModelID) != "" {
-		logger.Infof(ctx, "Using custom agent's model_id: %s", strings.TrimSpace(customAgent.Config.ModelID))
-		return strings.TrimSpace(customAgent.Config.ModelID), nil
+	if configuredAgentModelID != "" {
+		logger.Infof(ctx, "Using custom agent's model_id: %s", configuredAgentModelID)
+		return configuredAgentModelID, nil
 	}
 	return s.selectChatModelID(ctx, session, knowledgeBaseIDs, knowledgeIDs)
 }


### PR DESCRIPTION
## 说明

修复内置 Wiki fixer 因未配置 model_id 而无法使用的问题。显式配置的 agent 模型仍按原逻辑校验；仅对内置 Wiki fixer 在缺少 model_id 时回退到当前知识库模型或系统 KnowledgeQA 模型，并补充知识库模型与系统模型两条回归测试。

说明：已有 PR #2173 已关闭且未合并；本 PR 是基于当前 main 的聚焦实现，发布前未发现开放的重复 PR。

## 类型
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change

## 关联 Issue
Fixes #2110

## 测试
- gofmt 检查通过
- git diff --check origin/main...HEAD 通过
- go test ./internal/application/service -run TestResolveChatModelID -count=1：未通过，当前 Windows 环境编译 internal/utils 时缺少 pg_query.Parse/Deparse 符号（本机 CGO/依赖环境问题）

## Checklist
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Full Go test suite（本机环境限制）