### PR TITLE
fix(s3): disable optional checksums for compatible endpoints

### DIFF
--- a/internal/application/service/file/s3.go
+++ b/internal/application/service/file/s3.go
@@ -65,6 +65,12 @@ func newS3Client(endpoint, accessKey, secretKey, bucketName, region, pathPrefix 
 		client = s3.NewFromConfig(cfg, func(o *s3.Options) {
 			o.BaseEndpoint = aws.String(endpoint)
 			o.UsePathStyle = usePathStyle
+			if !strings.Contains(endpoint, "amazonaws.com") {
+				// S3-compatible services commonly reject the SDK's default
+				// trailing checksum negotiation. Only relax this for explicit
+				// non-AWS endpoints; standard AWS S3 keeps its default behavior.
+				o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+			}
 			o.HTTPClient = httpClient
 		})
 	} else {

--- a/internal/application/service/file/s3_test.go
+++ b/internal/application/service/file/s3_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/Tencent/WeKnora/internal/utils"
+	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 func TestNewS3Client_Credentials(t *testing.T) {
@@ -89,6 +92,61 @@ func TestNewS3Client_EmptyEndpoint(t *testing.T) {
 	endpoint := ""
 	if endpoint != "" {
 		t.Fatal("expected empty endpoint to skip custom configuration")
+	}
+}
+
+func TestNewS3Client_RequestChecksumCalculation(t *testing.T) {
+	const (
+		compatibleEndpoint = "https://s3-compatible.example.com"
+		awsEndpoint        = "https://s3.us-east-1.amazonaws.com"
+	)
+
+	// Keep the test independent of the developer's AWS profile while checking
+	// that a standard AWS endpoint still honors the SDK-resolved default.
+	t.Setenv("AWS_REQUEST_CHECKSUM_CALCULATION", "when_supported")
+	t.Setenv("SSRF_WHITELIST", "s3-compatible.example.com,s3.us-east-1.amazonaws.com")
+	utils.ResetSSRFWhitelistForTest()
+	t.Cleanup(utils.ResetSSRFWhitelistForTest)
+
+	standard, err := newS3Client("", "ak", "sk", "bucket", "us-east-1", "", false)
+	if err != nil {
+		t.Fatalf("newS3Client() with empty endpoint error = %v", err)
+	}
+	wantStandard := standard.client.Options().RequestChecksumCalculation
+
+	tests := []struct {
+		name     string
+		endpoint string
+		want     aws.RequestChecksumCalculation
+	}{
+		{
+			name:     "empty endpoint preserves standard AWS setting",
+			endpoint: "",
+			want:     wantStandard,
+		},
+		{
+			name:     "AWS endpoint preserves standard AWS setting",
+			endpoint: awsEndpoint,
+			want:     wantStandard,
+		},
+		{
+			name:     "S3-compatible endpoint calculates checksum only when required",
+			endpoint: compatibleEndpoint,
+			want:     aws.RequestChecksumCalculationWhenRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, err := newS3Client(tt.endpoint, "ak", "sk", "bucket", "us-east-1", "", false)
+			if err != nil {
+				t.Fatalf("newS3Client() error = %v", err)
+			}
+			got := svc.client.Options().RequestChecksumCalculation
+			if got != tt.want {
+				t.Errorf("RequestChecksumCalculation = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 说明

修复使用 S3-compatible 存储时 PutObject 因 SDK 默认请求 checksum 生成 trailing checksum、导致服务端拒绝 x-amz-content-sha256 的问题。仅对显式配置的非 AWS endpoint 设置 RequestChecksumCalculationWhenRequired，标准 AWS endpoint 保留默认行为，并补充配置回归测试。

## 类型
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change

## 关联 Issue
Fixes #2208

## 测试
- gofmt 检查通过
- git diff --check origin/main...HEAD 通过
- go test ./internal/application/service/file -run TestNewS3Client_RequestChecksumCalculation -count=1：未通过，当前 Windows 环境编译 internal/utils 时缺少 pg_query.Parse/Deparse 符号（本机 CGO/依赖环境问题）
- 独立 AWS SDK PutObject 探针确认 WhenRequired 不再发送默认 checksum header/trailer

## Checklist
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Full Go test suite（本机环境限制）