### PR TITLE
fix(organization): clarify tenant-scoped member roster

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -4900,12 +4900,12 @@ export default {
     manageMembers: 'Manage Members',
     noMembers: 'No members',
     members: {
-      listTitle: 'Shared space members',
-      searchPlaceholder: 'Search members…',
-      loading: 'Loading members…',
-      emptySearch: 'No members matching "{q}"',
+      listTitle: 'Member workspaces',
+      searchPlaceholder: 'Search workspaces or representative accounts…',
+      loading: 'Loading member workspaces…',
+      emptySearch: 'No member workspaces matching "{q}"',
       columns: {
-        member: 'Member',
+        member: 'Workspace',
         role: 'Role',
         joinedAt: 'Joined',
         operations: 'Actions'
@@ -4963,7 +4963,7 @@ export default {
     },
     settings: {
       editTitle: 'Shared Space Settings',
-      membersDesc: 'View and manage shared space members and their roles. Each member represents a workspace — all users in the same workspace share access to this shared space.',
+      membersDesc: 'The member list shows one row per workspace. All users in a workspace share access; the account below the workspace name only identifies who first joined.',
       permissionsIconHint: 'View role permissions',
       sharedDesc: 'View all knowledge bases shared to this shared space',
       noSharedKB: 'No shared knowledge bases yet',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1691,7 +1691,7 @@ export default {
     },
     settings: {
       editTitle: '共享空间设置',
-      membersDesc: '查看和管理共享空间成员、调整成员角色。成员的最小单位是空间——加入后该空间下的所有用户都将获得访问权限。',
+      membersDesc: '成员列表按空间展示，每个空间只显示一行。空间下的所有用户共享访问权限，空间名下方的账号仅用于标识最初加入者。',
       permissionsIconHint: '查看各角色权限说明',
       sharedDesc: '查看共享到此共享空间的所有知识库',
       noSharedKB: '暂无共享的知识库',
@@ -1782,12 +1782,12 @@ export default {
       }
     },
     members: {
-      listTitle: '共享空间成员',
-      searchPlaceholder: '搜索成员…',
-      loading: '加载成员中…',
-      emptySearch: '未找到匹配「{q}」的成员',
+      listTitle: '成员空间',
+      searchPlaceholder: '搜索空间或代表账号…',
+      loading: '加载成员空间中…',
+      emptySearch: '未找到匹配「{q}」的成员空间',
       columns: {
-        member: '成员',
+        member: '空间',
         role: '角色',
         joinedAt: '加入时间',
         operations: '操作'

--- a/frontend/src/views/organization/OrganizationSettingsModal.test.mjs
+++ b/frontend/src/views/organization/OrganizationSettingsModal.test.mjs
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs'
 import test from 'node:test'
 
 const source = readFileSync(new URL('./OrganizationSettingsModal.vue', import.meta.url), 'utf8')
+const zhCN = readFileSync(new URL('../../i18n/locales/zh-CN.ts', import.meta.url), 'utf8')
+const enUS = readFileSync(new URL('../../i18n/locales/en-US.ts', import.meta.url), 'utf8')
 
 test('reviewing join requests goes through the store and refreshes modal data', () => {
   assert.match(
@@ -32,4 +34,18 @@ test('organization settings lock and restore background scrolling', () => {
   assert.match(source, /onBeforeUnmount\(\(\) => \{\s*unlockBackgroundScroll\(\)/)
   assert.match(source, /\.settings-overlay\s*\{[\s\S]*?overscroll-behavior: none;/)
   assert.match(source, /\.content-wrapper\s*\{[\s\S]*?overscroll-behavior: contain;/)
+})
+
+test('member roster presents workspace identity instead of representative user identity', () => {
+  assert.match(source, /row\.tenant_id === authStore\.currentTenantId/)
+  assert.doesNotMatch(source, /row\.user_id === authStore\.currentUserId/)
+  assert.match(
+    source,
+    /return m\.tenant_name \|\| `\$\{t\('organization\.members\.columns\.member'\)\} #\$\{m\.tenant_id\}`/
+  )
+  assert.match(source, /return m\.username \|\| ''/)
+  assert.match(zhCN, /listTitle: '成员空间'/)
+  assert.match(zhCN, /成员列表按空间展示，每个空间只显示一行/)
+  assert.match(enUS, /listTitle: 'Member workspaces'/)
+  assert.match(enUS, /The member list shows one row per workspace/)
 })

--- a/frontend/src/views/organization/OrganizationSettingsModal.vue
+++ b/frontend/src/views/organization/OrganizationSettingsModal.vue
@@ -464,7 +464,7 @@
                             <span class="member-name">
                               {{ memberPrimaryLabel(row) }}
                               <span v-if="isOwnerMember(row)" class="owner-tag">{{ $t('organization.owner') }}</span>
-                              <span v-if="row.user_id === authStore.currentUserId" class="me-tag">{{ $t('common.me')
+                              <span v-if="row.tenant_id === authStore.currentTenantId" class="me-tag">{{ $t('common.me')
                               }}</span>
                             </span>
                             <span v-if="memberSecondaryLabel(row)" class="member-email">{{ memberSecondaryLabel(row)
@@ -1240,21 +1240,15 @@ function joinRequestApplicantSecondary(req: JoinRequestResponse): string {
   return ''
 }
 
-// 成员行的主标题：优先展示「空间名」，回退到代表用户名 / 空间 ID。Plan 3
-// 之后每一行成员都对应一个空间，UI 必须先于代表用户呈现空间身份，
-// 否则用户会误以为这是按"人"加进来的。
+// 成员行始终以空间为主身份。代表用户只用于辅助展示，不能在空间名
+// 缺失时取代空间身份，否则同一空间的其他用户会误以为自己不在列表中。
 const memberPrimaryLabel = (m: OrganizationMember): string => {
-  return m.tenant_name || m.username || `tenant#${m.tenant_id}`
+  return m.tenant_name || `${t('organization.members.columns.member')} #${m.tenant_id}`
 }
 
-// 副标题：主标题展示的是空间名时，副标题展示代表用户名；如果主标题已经
-// 是用户名（无 tenant_name 时的回退），副标题留空，避免重复信息。
-// 邮箱在空间成员列表里没什么用（不是邀请人需要联系的对象），不展示。
+// 副标题展示代表用户名，仅作为展示和审计信息。
 const memberSecondaryLabel = (m: OrganizationMember): string => {
-  if (m.tenant_name && m.username) {
-    return m.username
-  }
-  return ''
+  return m.username || ''
 }
 
 // Owner identification is tenant-keyed after Plan 3 (#1303): the org's

--- a/internal/application/repository/organization_sqlite_test.go
+++ b/internal/application/repository/organization_sqlite_test.go
@@ -1,0 +1,47 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestListTenantMembersPreservesDistinctTenants(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.User{}, &types.OrganizationTenantMember{}))
+
+	repo := NewOrganizationRepository(db)
+	ctx := context.Background()
+	const orgID = "org-1"
+
+	for i, tenantID := range []uint64{101, 102, 103} {
+		require.NoError(t, repo.AddTenantMember(ctx, &types.OrganizationTenantMember{
+			ID:                   fmt.Sprintf("member-%d", tenantID),
+			OrganizationID:       orgID,
+			TenantID:             tenantID,
+			Role:                 types.OrgRoleViewer,
+			RepresentativeUserID: fmt.Sprintf("user-%d", i+1),
+		}))
+	}
+	require.NoError(t, repo.AddTenantMember(ctx, &types.OrganizationTenantMember{
+		ID:             "other-org-member",
+		OrganizationID: "org-2",
+		TenantID:       104,
+		Role:           types.OrgRoleViewer,
+	}))
+
+	members, err := repo.ListTenantMembers(ctx, orgID)
+	require.NoError(t, err)
+	require.Len(t, members, 3)
+	require.Equal(t, []uint64{101, 102, 103}, []uint64{
+		members[0].TenantID,
+		members[1].TenantID,
+		members[2].TenantID,
+	})
+}

--- a/internal/handler/organization_members_test.go
+++ b/internal/handler/organization_members_test.go
@@ -1,0 +1,83 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type organizationMemberServiceStub struct {
+	interfaces.OrganizationService
+	members []*types.OrganizationTenantMember
+}
+
+func (s *organizationMemberServiceStub) GetTenantMember(_ context.Context, _ string, tenantID uint64) (*types.OrganizationTenantMember, error) {
+	return &types.OrganizationTenantMember{TenantID: tenantID}, nil
+}
+
+func (s *organizationMemberServiceStub) ListTenantMembers(context.Context, string) ([]*types.OrganizationTenantMember, error) {
+	return s.members, nil
+}
+
+type organizationMemberTenantServiceStub struct {
+	interfaces.TenantService
+	tenants map[uint64]*types.Tenant
+}
+
+func (s *organizationMemberTenantServiceStub) GetTenantsByIDs(context.Context, []uint64) (map[uint64]*types.Tenant, error) {
+	return s.tenants, nil
+}
+
+func TestListMembersReturnsAllTenantMemberships(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	joinedAt := time.Date(2026, time.August, 30, 12, 0, 0, 0, time.UTC)
+	members := []*types.OrganizationTenantMember{
+		{ID: "member-101", TenantID: 101, RepresentativeUserID: "user-1", Role: types.OrgRoleAdmin, CreatedAt: joinedAt},
+		{ID: "member-102", TenantID: 102, RepresentativeUserID: "user-2", Role: types.OrgRoleEditor, CreatedAt: joinedAt},
+		{ID: "member-103", TenantID: 103, RepresentativeUserID: "user-3", Role: types.OrgRoleViewer, CreatedAt: joinedAt},
+	}
+	handler := &OrganizationHandler{
+		orgService: &organizationMemberServiceStub{members: members},
+		tenantService: &organizationMemberTenantServiceStub{tenants: map[uint64]*types.Tenant{
+			101: {ID: 101, Name: "Workspace A"},
+			102: {ID: 102, Name: "Workspace B"},
+			103: {ID: 103, Name: "Workspace C"},
+		}},
+	}
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/organizations/org-1/members", nil)
+	c.Params = gin.Params{{Key: "id", Value: "org-1"}}
+	c.Set(types.TenantIDContextKey.String(), uint64(101))
+
+	handler.ListMembers(c)
+
+	require.Empty(t, c.Errors)
+	require.Equal(t, http.StatusOK, recorder.Code)
+	var response struct {
+		Success bool                      `json:"success"`
+		Data    types.ListMembersResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	require.True(t, response.Success)
+	require.Equal(t, int64(3), response.Data.Total)
+	require.Equal(t, []uint64{101, 102, 103}, []uint64{
+		response.Data.Members[0].TenantID,
+		response.Data.Members[1].TenantID,
+		response.Data.Members[2].TenantID,
+	})
+	require.Equal(t, []string{"Workspace A", "Workspace B", "Workspace C"}, []string{
+		response.Data.Members[0].TenantName,
+		response.Data.Members[1].TenantName,
+		response.Data.Members[2].TenantName,
+	})
+}


### PR DESCRIPTION
## Description

- Clarifies that the organization member roster contains one row per workspace, not one row per user account.
- Uses the active workspace ID for the current membership marker instead of the informational representative user ID.
- Keeps the workspace as the primary row identity even when its name is unavailable.
- Adds repository and handler regressions proving distinct workspace memberships are preserved and all rows are returned.

## Type of Change

- [x] Bug fix
- [x] Test

## Related Issue

Fixes #2874

## Testing

- `go test ./internal/application/repository ./internal/handler -run TestListTenantMembersPreservesDistinctTenants|TestListMembersReturnsAllTenantMemberships -count=1`
- `go vet ./internal/application/repository ./internal/handler`
- `go test ./internal/application/repository -count=1`
- `go test ./internal/handler -skip TestDeploymentCapabilityKeysMatchFrontend -count=1`
- `npm test`, 528 tests passed
- `npm run type-check`
- `npm run check-i18n`
- `npm run build`

The full Go workflow was also attempted locally. The Windows build cannot compile the existing sqlite-vec dependency because sqlite3.h is unavailable. The existing TestDeploymentCapabilityKeysMatchFrontend test also fails on CRLF checkout parsing; all other handler tests pass. GitHub CI runs on Ubuntu and remains the authoritative full workflow check.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages and component pass
- [ ] Diff-scoped golangci-lint was not available locally; scoped go vet passes
- [x] Full-repository checks were attempted and environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added tests covering the change
- [x] No documentation update is required
- [x] No breaking changes

## Screenshots / Recordings

Not included. This is a text and identity-marker correction with no layout change; the production build and component regression test verify the affected UI path.